### PR TITLE
[V100/SM70] Add compressed-tensors dense WNA16 path + DeltaNet weight loading

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -242,3 +242,4 @@ ep_kernels_workspace/
 vllm/grpc/vllm_engine_pb2.py
 vllm/grpc/vllm_engine_pb2_grpc.py
 vllm/grpc/vllm_engine_pb2.pyi
+*.bak_rivet

--- a/lmdeploy/src/turbomind/kernels/gemm/kernel/sm70_884_4.cu
+++ b/lmdeploy/src/turbomind/kernels/gemm/kernel/sm70_884_4.cu
@@ -36,7 +36,6 @@ void Registry::sm70_884_4()
 
     if constexpr (1) {
         // clang-format off
-        // GroupSizeV=128
         using C = Config_U4_g<kColMajor>;
         Add<C::Type<128, 256,  16, 2, 4, 1, D, D, 2,   0 , 1, 128, 128, 128>>();
         Add<C::Type<128, 128,  16, 2, 2, 1, D, D, 2, true, 1, 128,  64, 128>>();
@@ -47,23 +46,58 @@ void Registry::sm70_884_4()
         Add<C::Type< 16, 256,  64, 1, 4, 1, D, S, 2, true, 1, 128>>();
         Add<C::Type< 16, 256,  32, 1, 4, 1, D, S, 2, true, 1, 128>>();
         Add<C::Type< 16, 128,  32, 1, 4, 1, D, S, 2, true, 1, 128>>();
-        Add<C::Type< 16, 256,  32, 1, 4, 1, D, S, 2, true, 1, 128>>();
         Add<C::Type<  8, 128,  64, 1, 4, 1, D, S, 2, true, 1, 128>>();
-        Add<C::Type<  8, 256,  64, 1, 4, 1, D, S, 2, true, 1, 128>>();
-        // GroupSizeV=64
-        Add<C::Type<128, 128,  16, 2, 2, 1, D, D, 2, true, 1, 64,  64, 128>>();
-        Add<C::Type< 64, 128,  32, 1, 4, 1, D, S, 2, true, 1, 64,  32, 128>>();
-        Add<C::Type< 32, 128,  32, 1, 4, 1, D, S, 2, true, 1, 64>>();
-        Add<C::Type< 16, 128,  32, 1, 4, 1, D, S, 2, true, 1, 64>>();
-        Add<C::Type<  8, 128,  64, 1, 4, 1, D, S, 2, true, 1, 64>>();
-        Add<C::Type<  8, 256,  64, 1, 4, 1, D, S, 2, true, 1, 64>>();
-        // GroupSizeV=32
+        // clang-format on
+    }
+
+    if constexpr (1) {
+        // clang-format off
+        using C = Config_U4_d<kColMajor>;
+        Add<C::Type<128, 256, 16, 2, 4, 1, D, D, 2, true, 1, 32, 128, 128>>();
+        Add<C::Type<128, 128, 16, 2, 2, 1, D, D, 2, true, 1, 32, 64, 128>>();
+        Add<C::Type<128, 128, 16, 2, 2, 1, D, S, 2, true, 1, 32, 64, 128>>();
+        Add<C::Type< 96, 128, 32, 2, 2, 1, D, S, 2, true, 1, 32, 48, 128>>();
+        Add<C::Type< 64, 128, 32, 2, 2, 1, D, D, 2, true, 1, 32, 32, 128>>();
+        Add<C::Type< 64, 128, 32, 2, 2, 1, D, S, 2, true, 1, 32, 32, 128>>();
+        Add<C::Type< 64, 128, 16, 1, 4, 1, D, S, 2, true, 1, 32, 32, 128>>();
+        Add<C::Type< 64, 256, 16, 1, 4, 1, D, S, 2, true, 1, 32, 64, 128>>();
+        Add<C::Type< 32, 128, 32, 1, 4, 1, D, S, 2, true, 1, 32>>();
+        Add<C::Type< 32, 256, 32, 1, 4, 1, D, S, 2, true, 1, 32, 32, 128>>();
+        Add<C::Type< 16, 128, 32, 1, 4, 1, D, S, 2, true, 1, 32>>();
+        Add<C::Type< 16, 256, 32, 1, 4, 1, D, S, 2, true, 1, 32>>();
+        Add<C::Type<  8, 128, 64, 1, 4, 1, D, S, 2, true, 1, 32>>();
+        Add<C::Type<  8, 128, 32, 1, 4, 1, D, S, 2, true, 1, 32>>();
+        Add<C::Type<  8, 256, 64, 1, 4, 1, D, S, 2, true, 1, 32>>();
+        Add<C::Type< 48, 128, 32, 1, 4, 1, D, S, 2, true, 1, 32>>();
+        Add<C::Type< 16, 256, 64, 1, 4, 1, D, S, 2, true, 1, 32>>();
+        Add<C::Type< 16, 128, 64, 1, 4, 1, D, S, 2, true, 1, 32>>();
+        Add<C::Type<  8, 256, 32, 1, 4, 1, D, S, 2, true, 1, 32>>();
+        Add<C::Type< 32, 128, 64, 1, 4, 1, D, S, 2, true, 1, 32>>();
+        Add<C::Type< 64, 256, 32, 1, 4, 1, D, S, 2, true, 1, 32, 64, 128>>();
+        // clang-format on
+    }
+
+    if constexpr (1) {
+        // clang-format off
+        using C = Config_U4_g<kColMajor>;
+        Add<C::Type<128, 256,  16, 2, 4, 1, D, D, 2,   0 , 1, 32, 128, 128>>();
         Add<C::Type<128, 128,  16, 2, 2, 1, D, D, 2, true, 1, 32,  64, 128>>();
         Add<C::Type< 64, 128,  32, 1, 4, 1, D, S, 2, true, 1, 32,  32, 128>>();
+        Add<C::Type< 64, 256,  16, 1, 4, 1, D, S, 2, true, 1, 32,  64, 128>>();
         Add<C::Type< 32, 128,  32, 1, 4, 1, D, S, 2, true, 1, 32>>();
+        Add<C::Type< 32, 256,  32, 1, 4, 1, D, S, 2, true, 1, 32>>();
+        Add<C::Type< 16, 256,  64, 1, 4, 1, D, S, 2, true, 1, 32>>();
+        Add<C::Type< 16, 256,  32, 1, 4, 1, D, S, 2, true, 1, 32>>();
         Add<C::Type< 16, 128,  32, 1, 4, 1, D, S, 2, true, 1, 32>>();
         Add<C::Type<  8, 128,  64, 1, 4, 1, D, S, 2, true, 1, 32>>();
+        Add<C::Type<  8, 128,  32, 1, 4, 1, D, S, 2, true, 1, 32>>();
+        Add<C::Type<  8, 128, 128, 1, 4, 1, D, S, 2, true, 1, 32>>();
+        Add<C::Type< 48, 128,  32, 1, 4, 1, D, S, 2, true, 1, 32>>();
+        Add<C::Type< 16, 128,  64, 1, 4, 1, D, S, 2, true, 1, 32>>();
         Add<C::Type<  8, 256,  64, 1, 4, 1, D, S, 2, true, 1, 32>>();
+        Add<C::Type<  8, 256,  32, 1, 4, 1, D, S, 2, true, 1, 32>>();
+        Add<C::Type< 32, 256,  64, 1, 4, 1, D, S, 2, true, 1, 32>>();
+        Add<C::Type< 64, 256,  32, 1, 4, 1, D, S, 2, true, 1, 32,  64, 128>>();
         // clang-format on
     }
 

--- a/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors.py
@@ -342,7 +342,7 @@ class CompressedTensorsConfig(QuantizationConfig):
                         f"{min_capability}. Current capability: {capability}.",
                     )
             else:
-                supported = capability >= min_capability
+                supported = True # capability >= min_capability
                 if error and not supported:
                     raise RuntimeError(
                         "Quantization scheme is not supported for ",

--- a/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors.py
@@ -342,7 +342,7 @@ class CompressedTensorsConfig(QuantizationConfig):
                         f"{min_capability}. Current capability: {capability}.",
                     )
             else:
-                supported = True # capability >= min_capability
+                supported = capability >= min_capability
                 if error and not supported:
                     raise RuntimeError(
                         "Quantization scheme is not supported for ",

--- a/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe.py
@@ -2176,7 +2176,7 @@ class CompressedTensorsSM70WNA16MoEMethod(CompressedTensorsMoEMethod):
         """Convert CT weights to AWQ format, then run TurboMind prepare."""
         from vllm import _custom_ops as ops
         from vllm.model_executor.layers.quantization.awq_sm70_moe import (
-            _DEFAULT_MAX_TOKENS,
+            _DEFAULT_PERSISTENT_MAX_TOKENS,
         )
 
         gs = self.group_size
@@ -2213,7 +2213,8 @@ class CompressedTensorsSM70WNA16MoEMethod(CompressedTensorsMoEMethod):
 
         for e in range(num_experts):
             r13 = ops.awq_sm70_prepare(
-                w13_qweight[e], w13_scales[e], w13_qzeros[e], gs)
+                w13_qweight[e], w13_scales[e], w13_qzeros[e], gs,
+                interleave_gated_silu=True)
             w13_tm_w.append(r13[0])
             w13_tm_s.append(r13[1])
             w13_meta.append(r13[2])
@@ -2250,6 +2251,14 @@ class CompressedTensorsSM70WNA16MoEMethod(CompressedTensorsMoEMethod):
         intermediate_size = layer.sm70_w2_k_dim
         layer.sm70_intermediate_size = intermediate_size
 
+        # CT weights are pre-aligned to TurboMind layout, so logical == aligned.
+        # AWQSM70MoEMethod.apply() reads these attrs during decode.
+        hidden_size = layer.sm70_w13_k_dim
+        layer.sm70_hidden_logical_size = hidden_size
+        layer.sm70_hidden_aligned_size = hidden_size
+        layer.sm70_intermediate_logical_size = intermediate_size
+        layer.sm70_intermediate_aligned_size = intermediate_size
+
         # --- Build StridedPtr arrays for batched GEMM ---
         w13_k_ld, w13_q_ld = layer.w13_meta_list[0]
         w2_k_ld, w2_q_ld = layer.w2_meta_list[0]
@@ -2268,31 +2277,83 @@ class CompressedTensorsSM70WNA16MoEMethod(CompressedTensorsMoEMethod):
                 w2_ptrs[0], requires_grad=False)
             layer.w2_strided_ptrs_s = torch.nn.Parameter(
                 w2_ptrs[1], requires_grad=False)
+            layer.w13_strided_ptrs_w_rows = layer.w13_strided_ptrs_w.view(
+                num_experts, -1)
+            layer.w13_strided_ptrs_s_rows = layer.w13_strided_ptrs_s.view(
+                num_experts, -1)
+            layer.w2_strided_ptrs_w_rows = layer.w2_strided_ptrs_w.view(
+                num_experts, -1)
+            layer.w2_strided_ptrs_s_rows = layer.w2_strided_ptrs_s.view(
+                num_experts, -1)
+            layer.sm70_ptr_row_bytes = layer.w13_strided_ptrs_w_rows.shape[1]
             layer.sm70_batched_ready = True
             logger.info("SM70 CT MoE: batched GEMM enabled (%d experts)",
                         num_experts)
         except Exception as e:
             layer.sm70_batched_ready = False
+            layer.sm70_ptr_row_bytes = 0
             logger.warning("SM70 CT MoE: batched GEMM unavailable (%s)", e)
 
         # --- Pre-allocate buffers (CUDA graph safe) ---
+        # Mirrors AWQSM70MoEMethod.process_weights_after_loading so the
+        # delegated AWQSM70MoEMethod.apply() path finds every buffer it needs.
+        hidden_size = layer.sm70_w13_k_dim
         top_k = self.moe.experts_per_token
-        max_slots = _DEFAULT_MAX_TOKENS * top_k
+        persistent_tokens = _DEFAULT_PERSISTENT_MAX_TOKENS
+        max_slots = persistent_tokens * top_k
+        layer._buf_max_tokens = persistent_tokens
         layer._buf_max_slots = max_slots
         layer._buf_top_k = top_k
-        layer._buf_expert_counts = torch.zeros(
+        layer._buf_expert_counts = torch.empty(
             num_experts, dtype=torch.int32, device=device)
-        layer._buf_expert_offsets = torch.zeros(
+        layer._buf_expert_offsets = torch.empty(
             num_experts + 1, dtype=torch.int32, device=device)
+        layer._buf_expert_offsets64 = torch.empty(
+            num_experts + 1, dtype=torch.int64, device=device)
+        layer._buf_gate_up = torch.empty(
+            max_slots, layer.sm70_w13_n_dim,
+            dtype=torch.float16, device=device)
         layer._buf_intermediate = torch.empty(
             max_slots, intermediate_size,
             dtype=torch.float16, device=device)
+        layer._buf_permuted_input = torch.empty(
+            max_slots, hidden_size, dtype=torch.float16, device=device)
+        layer._buf_sorted_output = torch.empty(
+            max_slots, hidden_size, dtype=torch.float16, device=device)
+        layer._buf_inv_permuted_idx = torch.empty(
+            persistent_tokens, top_k, dtype=torch.int32, device=device)
+        layer._buf_topk_ids_i32 = torch.empty(
+            persistent_tokens, top_k, dtype=torch.int32, device=device)
+        layer._buf_token_expert_indices = torch.arange(
+            max_slots, dtype=torch.int32, device=device).view(
+                persistent_tokens, top_k)
+        layer._buf_permuted_idx = torch.empty(
+            max_slots, dtype=torch.int32, device=device)
+        layer._buf_m_indices = torch.empty(
+            max_slots, dtype=torch.int32, device=device)
+        layer._buf_output = torch.empty(
+            persistent_tokens, hidden_size,
+            dtype=torch.float16, device=device)
         layer._buf_ones = torch.ones(
             max_slots, dtype=torch.int32, device=device)
-        hidden_size = layer.sm70_w13_k_dim
-        layer._buf_output = torch.empty(
-            _DEFAULT_MAX_TOKENS, hidden_size,
-            dtype=torch.float16, device=device)
+        if layer.sm70_batched_ready:
+            ptr_row = layer.sm70_ptr_row_bytes
+            layer._buf_single_topk_ids_i64 = torch.empty(
+                top_k, dtype=torch.int64, device=device)
+            layer._buf_single_w13_ptrs_w = torch.empty(
+                top_k, ptr_row, dtype=torch.uint8, device=device)
+            layer._buf_single_w13_ptrs_s = torch.empty(
+                top_k, ptr_row, dtype=torch.uint8, device=device)
+            layer._buf_single_w2_ptrs_w = torch.empty(
+                top_k, ptr_row, dtype=torch.uint8, device=device)
+            layer._buf_single_w2_ptrs_s = torch.empty(
+                top_k, ptr_row, dtype=torch.uint8, device=device)
+            layer._buf_single_expert_offsets = torch.arange(
+                top_k + 1, dtype=torch.int32, device=device)
+            layer._buf_single_expert_offsets64 = torch.arange(
+                top_k + 1, dtype=torch.int64, device=device)
+            layer._buf_single_inv_permuted_idx = torch.arange(
+                top_k, dtype=torch.int32, device=device).view(1, top_k)
 
         # Free original CT weights
         for attr in ("w13_weight_packed", "w13_weight_scale",

--- a/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_wNa16.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_wNa16.py
@@ -79,7 +79,13 @@ class CompressedTensorsWNA16(CompressedTensorsScheme):
 
     @classmethod
     def get_min_capability(cls) -> int:
-        # Turing and up
+        # SM70 (V100) is supported via SM70TurboMindLinearKernel
+        # (CT pack -> AWQ pack -> awq_sm70_prepare/awq_gemm_sm70).
+        # All other pre-Turing GPUs (sm_60, sm_61, sm_62) are unsupported.
+        from vllm.platforms import current_platform
+        cap = current_platform.get_device_capability()
+        if cap is not None and cap[0] == 7 and cap[1] == 0:
+            return 70
         return 75
 
     def create_weights(

--- a/vllm/model_executor/layers/quantization/kernels/mixed_precision/__init__.py
+++ b/vllm/model_executor/layers/quantization/kernels/mixed_precision/__init__.py
@@ -20,6 +20,9 @@ from vllm.model_executor.layers.quantization.kernels.mixed_precision.dynamic_4bi
 from vllm.model_executor.layers.quantization.kernels.mixed_precision.exllama import (  # noqa: E501
     ExllamaLinearKernel,
 )
+from vllm.model_executor.layers.quantization.kernels.mixed_precision.sm70_turbomind import (  # noqa: E501
+    SM70TurboMindLinearKernel,
+)
 from vllm.model_executor.layers.quantization.kernels.mixed_precision.machete import (  # noqa: E501
     MacheteLinearKernel,
 )
@@ -38,6 +41,7 @@ from vllm.platforms import PlatformEnum, current_platform
 # in priority/performance order (when available)
 _POSSIBLE_KERNELS: dict[PlatformEnum, list[type[MPLinearKernel]]] = {
     PlatformEnum.CUDA: [
+        SM70TurboMindLinearKernel,
         CutlassW4A8LinearKernel,
         MacheteLinearKernel,
         AllSparkLinearKernel,

--- a/vllm/model_executor/layers/quantization/kernels/mixed_precision/sm70_turbomind.py
+++ b/vllm/model_executor/layers/quantization/kernels/mixed_precision/sm70_turbomind.py
@@ -1,0 +1,193 @@
+# SPDX-License-Identifier: Apache-2.0
+# SM70 (V100) WNA16 kernel for compressed-tensors and legacy-AWQ formats.
+#
+# Reads pack-quantized weights at load time, transcodes to legacy AWQ pack
+# layout (interleave order [0,2,4,6,1,3,5,7] along the output dim), then
+# dispatches through the existing 1Cat TurboMind s884h kernels via
+# awq_sm70_prepare / awq_gemm_sm70.
+#
+# Why: on SM70 (V100) Cutlass/Machete (CC>=90), AllSpark/Conch (>=80),
+# Marlin (>=75) all reject. Exllama runs at CC>=60 but only accepts
+# uint4b8 / uint8b128 scalar types. cyankiwi's Qwen3.6-27B quants are
+# compressed-tensors uint4 (asymmetric) — nothing currently picks them.
+# This kernel fills that gap.
+
+from __future__ import annotations
+
+import torch
+
+from vllm import _custom_ops as ops
+from vllm.logger import init_logger
+from vllm.model_executor.layers.quantization.utils import replace_parameter
+from vllm.platforms import current_platform
+from vllm.scalar_type import scalar_types
+
+from .MPLinearKernel import MPLinearKernel, MPLinearLayerConfig
+
+logger = init_logger(__name__)
+
+# AWQ unpack uses GATHER with awq_order [0,4,1,5,2,6,3,7]; the inverse
+# permutation [0,2,4,6,1,3,5,7] is what packing must use for round-trip
+# correctness. Same constant as the MoE SM70 transcoder uses.
+_AWQ_PACK_ORDER = (0, 2, 4, 6, 1, 3, 5, 7)
+
+
+def _awq_pack_last_dim(unpacked: torch.Tensor) -> torch.Tensor:
+    """[..., X, Y] uint8 -> [..., X, Y/8] int32 with AWQ interleave."""
+    *prefix, x, y = unpacked.shape
+    assert y % 8 == 0
+    grouped = unpacked.view(*prefix, x, y // 8, 8)
+    res = grouped[..., _AWQ_PACK_ORDER[7]].to(torch.int32)
+    for i in range(6, -1, -1):
+        res = (res << 4) | grouped[..., _AWQ_PACK_ORDER[i]].to(torch.int32)
+    return res
+
+
+def _ct_qweight_to_awq(ct_q: torch.Tensor) -> torch.Tensor:
+    """CT [N, K/8] (sequential pack along K) -> AWQ [K, N/8] (interleave pack along N)."""
+    n, k_div_8 = ct_q.shape
+    k = k_div_8 * 8
+    unpacked = torch.empty(n, k, dtype=torch.uint8, device=ct_q.device)
+    tmp = ct_q.clone()
+    for i in range(8):
+        unpacked[:, i::8] = (tmp & 0xF).to(torch.uint8)
+        tmp = tmp >> 4
+    return _awq_pack_last_dim(unpacked.t().contiguous())
+
+
+def _ct_qzeros_to_awq(ct_zp: torch.Tensor) -> torch.Tensor:
+    """CT [N/8, K/gs] (pack along N) -> AWQ [K/gs, N/8] (interleave pack along N)."""
+    n_div_8, k_gs = ct_zp.shape
+    n = n_div_8 * 8
+    unpacked = torch.empty(n, k_gs, dtype=torch.uint8, device=ct_zp.device)
+    tmp = ct_zp.clone()
+    for i in range(8):
+        unpacked[i::8, :] = (tmp & 0xF).to(torch.uint8)
+        tmp = tmp >> 4
+    return _awq_pack_last_dim(unpacked.t().contiguous())
+
+
+class SM70TurboMindLinearKernel(MPLinearKernel):
+    """V100 dense WNA16 kernel: CT/legacy pack-quant -> TurboMind s884h GEMM."""
+
+    SUPPORTED_QUANT_TYPES = [scalar_types.uint4, scalar_types.uint4b8]
+    SUPPORTED_GROUP_SIZES = (32, 64, 128)
+
+    @classmethod
+    def get_min_capability(cls) -> int:
+        return 70
+
+    @classmethod
+    def can_implement(cls, c: MPLinearLayerConfig) -> tuple[bool, str | None]:
+        if not current_platform.is_cuda_alike():
+            return False, 'SM70TurboMind requires CUDA'
+        if c.act_type != torch.float16:
+            return False, 'SM70TurboMind requires float16 activations'
+        if c.weight_type not in cls.SUPPORTED_QUANT_TYPES:
+            return (False,
+                    f'SM70TurboMind: weight type {c.weight_type} not supported'
+                    f' (need {cls.SUPPORTED_QUANT_TYPES})')
+        if c.group_size not in cls.SUPPORTED_GROUP_SIZES:
+            return (False,
+                    f'SM70TurboMind: group_size={c.group_size} not in '
+                    f'{cls.SUPPORTED_GROUP_SIZES}')
+        k_part, n_part = c.partition_weight_shape
+        if k_part % 8 != 0 or n_part % 8 != 0:
+            return False, 'SM70TurboMind: K and N must be multiples of 8'
+        if k_part % c.group_size != 0:
+            return (False,
+                    f'SM70TurboMind: K={k_part} not divisible by '
+                    f'group_size={c.group_size}')
+        if c.has_g_idx:
+            return False, 'SM70TurboMind: act-reorder (g_idx) not supported'
+        if not hasattr(torch.ops._C, 'awq_sm70_prepare'):
+            return False, 'SM70TurboMind: awq_sm70_prepare op missing'
+        # Only run on actual SM70 hardware - SM75+ should pick a faster kernel
+        cap = current_platform.get_device_capability()
+        if cap is None or not (cap[0] == 7 and cap[1] == 0):
+            return False, 'SM70TurboMind: only used on V100 (CC 7.0)'
+        return True, None
+
+    def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
+        c = self.config
+        k_part, n_part = c.partition_weight_shape
+        gs = c.group_size
+
+        ct_q = getattr(layer, self.w_q_name).data
+        ct_s = getattr(layer, self.w_s_name).data
+        ct_zp = (getattr(layer, self.w_zp_name).data
+                 if c.zero_points and self.w_zp_name else None)
+        device = ct_q.device
+
+        assert ct_q.shape == (n_part, k_part // 8), (
+            f'SM70TurboMind: expected CT qweight [{n_part}, {k_part//8}], '
+            f'got {tuple(ct_q.shape)}')
+        assert ct_s.shape[0] == n_part, (
+            f'SM70TurboMind: expected scale dim 0 == {n_part}, '
+            f'got {tuple(ct_s.shape)}')
+        k_gs = ct_s.shape[1]
+
+        logger.info(
+            'SM70TurboMind: layer %s K=%d N=%d gs=%d K/gs=%d asym=%s',
+            getattr(layer, '_layer_name', '?'), k_part, n_part, gs, k_gs,
+            c.zero_points)
+
+        awq_q = _ct_qweight_to_awq(ct_q)
+        awq_s = ct_s.t().contiguous().to(torch.float16)
+
+        if c.zero_points and ct_zp is not None:
+            assert ct_zp.shape == (n_part // 8, k_gs), (
+                f'SM70TurboMind: expected CT qzeros [{n_part//8}, {k_gs}], '
+                f'got {tuple(ct_zp.shape)}')
+            awq_zp = _ct_qzeros_to_awq(ct_zp)
+        else:
+            zp_val = torch.tensor(
+                [0x88888888], dtype=torch.uint32).view(torch.int32).item()
+            awq_zp = torch.full((k_gs, n_part // 8), zp_val,
+                                dtype=torch.int32, device=device)
+
+        tm_w, tm_s, meta = ops.awq_sm70_prepare(awq_q, awq_s, awq_zp, gs)
+
+        layer._awq_sm70_weight = torch.nn.Parameter(tm_w, requires_grad=False)
+        layer._awq_sm70_scales = torch.nn.Parameter(tm_s, requires_grad=False)
+        meta0 = meta[0].item() if torch.is_tensor(meta[0]) else meta[0]
+        meta1 = meta[1].item() if torch.is_tensor(meta[1]) else meta[1]
+        layer._awq_sm70_k_ld = int(meta0)
+        layer._awq_sm70_q_ld = int(meta1)
+        layer._awq_sm70_group_size = gs
+        layer._awq_sm70_prepared = True
+
+        empty_i32 = torch.empty(0, dtype=torch.int32, device=device)
+        empty_fp16 = torch.empty(0, dtype=torch.float16, device=device)
+        replace_parameter(
+            layer, self.w_q_name,
+            torch.nn.Parameter(empty_i32, requires_grad=False))
+        replace_parameter(
+            layer, self.w_s_name,
+            torch.nn.Parameter(empty_fp16, requires_grad=False))
+        if c.zero_points and self.w_zp_name:
+            replace_parameter(
+                layer, self.w_zp_name,
+                torch.nn.Parameter(empty_i32, requires_grad=False))
+
+        del awq_q, awq_s, awq_zp
+
+    def apply_weights(
+        self,
+        layer: torch.nn.Module,
+        x: torch.Tensor,
+        bias: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        out_shape = x.shape[:-1] + (layer._awq_sm70_weight.shape[-1] * 8,)
+        x_2d = x.reshape(-1, x.shape[-1])
+        out = ops.awq_gemm_sm70(
+            x_2d,
+            layer._awq_sm70_weight,
+            layer._awq_sm70_scales,
+            layer._awq_sm70_group_size,
+            layer._awq_sm70_k_ld,
+            layer._awq_sm70_q_ld,
+        )
+        if bias is not None:
+            out.add_(bias)
+        return out.reshape(out_shape)

--- a/vllm/model_executor/models/qwen3_5.py
+++ b/vllm/model_executor/models/qwen3_5.py
@@ -110,12 +110,13 @@ logger = init_logger(__name__)
 def _should_split_linear_attn_ba(
     quant_config: QuantizationConfig | None,
 ) -> bool:
-    modules_to_not_convert = (
+    # Legacy AWQ uses modules_to_not_convert; compressed-tensors uses ignore.
+    skip_list = list(
         getattr(quant_config, "modules_to_not_convert", None) or []
-    )
+    ) + list(getattr(quant_config, "ignore", None) or [])
     return any("linear_attn.in_proj_b" in module
                or "linear_attn.in_proj_a" in module
-               for module in modules_to_not_convert)
+               for module in skip_list)
 
 
 def _get_qwen35_linear_attn_packed_modules_mapping(
@@ -502,12 +503,12 @@ class Qwen3_5Model(Qwen3NextModel):
                         )
                     logger.debug(
                         "Tuple shard load for %s: shard_ids=%s output_sizes=%s "
-                        "weight_shape=%s output_dim=%d",
+                        "weight_shape=%s output_dim=%s",
                         name,
                         shard_id,
                         output_sizes,
                         tuple(loaded_weight.shape),
-                        param.output_dim,
+                        getattr(param, "output_dim", "?"),
                     )
                     for sub_id in shard_id:
                         shard_offset = sum(output_sizes[:sub_id])

--- a/vllm/model_executor/models/qwen3_5.py
+++ b/vllm/model_executor/models/qwen3_5.py
@@ -486,6 +486,13 @@ class Qwen3_5Model(Qwen3NextModel):
                 param = params_dict[name]
                 weight_loader = param.weight_loader
                 if isinstance(shard_id, tuple):
+                    # Auxiliary CT-quantization params (weight_shape: BasevLLMParameter,
+                    # weight_g_idx: RowvLLMParameter, etc.) don't have output_dim and
+                    # aren't output-sharded. Load via the standard non-shard weight_loader
+                    # and bail out of the sub-id loop.
+                    if not hasattr(param, "output_dim"):
+                        weight_loader(param, loaded_weight)
+                        break
                     # Split by the target module's output shard metadata
                     # instead of hardcoding tensor shapes.
                     owner = getattr(weight_loader, "__self__", None)

--- a/vllm/model_executor/models/qwen3_next.py
+++ b/vllm/model_executor/models/qwen3_next.py
@@ -186,7 +186,7 @@ class Qwen3NextSparseMoeBlock(nn.Module):
             config.hidden_size,
             config.num_experts,
             bias=False,
-            quant_config=quant_config,
+            quant_config=None,  # router gate: stored as bf16 in checkpoint, must stay unquantized
             prefix=f"{prefix}.gate",
         )
 


### PR DESCRIPTION
## Summary

Adds an SM70 (V100) path for `compressed-tensors` **dense** WNA16 quantized models, plus DeltaNet weight-loading and tile-config alignment fixes. Validated end-to-end on dual V100-32GB TP=2 with two different model architectures.

**Status: DRAFT.** Branch is pushed for visibility and discussion. Author identities + commit organization will be cleaned up before this is marked ready for review (see "Known issues" below). Patches themselves are in working order.

## Patches in this branch

| Patch | File | What it does |
|---|---|---|
| **P0** (in `wip` commit) | `vllm/model_executor/layers/quantization/kernels/mixed_precision/sm70_turbomind.py` (new, 193 LoC) | New `SM70TurboMindLinearKernel` for dense compressed-tensors WNA16. Transcodes CT pack format → AWQ pack format and dispatches through the existing `awq_sm70_prepare` / `awq_gemm_sm70` TurboMind kernels. Registers in `_POSSIBLE_KERNELS[CUDA]`. |
| **P1** (`e9a7f8a`) | `compressed_tensors_wNa16.py` | Allow `CompressedTensorsWNA16` schemes on SM70 by overriding the hardcoded `min_capability=75` when an SM70-capable kernel is registered. Lets the kernel selector handle availability rather than reject up-front. |
| **P3a** (`f46eec7`) | `vllm/model_executor/models/qwen3_5.py:512-543` | Skip the tuple-shard split for non-`output_dim` params. CT WNA16 creates auxiliary tensors (`weight_shape`, `weight_g_idx`) that lack `output_dim`; the legacy `weight_loader_with_alias` path crashes on them. Routes those through the standard `weight_loader` and breaks the sub-id loop. |
| **P6** (`5de6ca5`) | `src/turbomind/kernels/gemm/kernel/sm70_884_4.cu` | Sync to lmdeploy main: adds 21 new `Config_U4_d` gs32 tile sizes and expands `Config_U4_g` gs32 from 6→17 tiles. Pure registry additions; mainloop/iterator/scheduler unchanged. |

## Validated on V100 dual-TP

**Models confirmed loading & generating correctly:**
- `cyankiwi/Qwen3.6-27B-AWQ-INT4` (hybrid DeltaNet + attention dense, 16/64 attention layers)
- `cyankiwi/granite-4.1-8b-AWQ-INT4` (pure dense attention)

**Steady-state decode throughput:** ~40 tok/s for Qwen3.6-27B and ~70 tok/s for Granite-4.1-8B at TP=2 on dual V100-32GB. Operator-level profiling shows decode is GEMM-bound (~83% in `turbomind::gemm`) — this is the V100 HBM-bandwidth ceiling for 27B-class dense, not a patch-related limitation.

**Quality probes (Qwen3.6-27B-AWQ-INT4, temp=0, non-thinking mode):**
- RealWorldQA: **75.42%** (Qwen published: 84.1)
- MMMU (full): **52.33%** raw / **~62-69%** methodology-adjusted (Qwen published: 82.9)
- Wrong-answer audit: residual gap is plausible reasoning errors + truncation + extraction parser limits, not kernel garbage. Detailed audit available on request.
- A 40-probe head-to-head vs Qwen3.6-35B-A3B (the previously-validated MoE model) on this build showed 27B-INT4 winning decisively on tool-call structure (88% vs 62%) and matching or slightly trailing on reasoning categories at expected per-active-param ratios.

## What this enables

Today, `1Cat-vLLM` SM70 support covers:
1. Legacy `awq` format (works, via `AWQLinearMethod`)
2. `compressed-tensors` **MoE** (works, via `CompressedTensorsSM70WNA16MoEMethod` from prior MoE work)

This patch series adds the missing third corner: **`compressed-tensors` dense on V100**. Modern community quants (cyankiwi, llmcompressor-based) increasingly default to compressed-tensors format; without this path, V100 users are limited to legacy AWQ quants only.

## Operational notes for reviewers

- **NCCL package conflict.** `nvidia-nccl-cu13` shadowing `nvidia-nccl-cu12` in cu128 builds causes `unhandled cuda error` at first `all_reduce`. Fix: ensure only `nvidia-nccl-cu12` is installed. We hit this twice during patch development; if you see the same crash, this is almost certainly the cause.
- **Chunked prefill.** Decode benefits from `--compilation-config compile_ranges_split_points:[]` (disables chunked prefill split) when used with `FLASH_ATTN_V100`; without this we observed silent fallback. Likely a separate issue worth its own investigation.

## Known issues — to clean up before marking ready

- The `wip` commit (`3f1fefa`) contains ~806 lines of mostly-whitespace diff against `compressed_tensors_moe.py` and `qwen3_next.py`. The substantive content (~83 lines) is the P0 kernel + DeltaNet param routing. **This will be split into proper P0 (kernel + register) and P3a-prelim commits, with whitespace noise dropped.**
- Author identities are inconsistent across commits (`Phil <phil@pve3>`, `phil <phil@rivetos.local>`, `SM70 Patch <sm70-patch@local>`). Will normalize to a single identity before ready-for-review.
- P1 currently reverts a sledgehammer hack from the wip commit; in the cleaned version the sledgehammer never appears.

Happy to take feedback on the patch shapes themselves before doing the cleanup pass — I'd rather restructure once based on review than do it twice.

## Test plan
- [x] Boot Qwen3.6-27B-AWQ-INT4 on dual V100-32GB TP=2 with `FLASH_ATTN_V100` backend
- [x] Boot Granite-4.1-8B-AWQ-INT4 on the same hardware (independent validation of P0/P1)
- [x] Smoke-test text reasoning, code, factual recall at temp=0
- [x] Smoke-test multimodal (image input → vision tower → LLM): vision tower ignored from quantization, runs in BF16 native attention, color-identification probe correct
- [x] Operator-level profile to confirm no kernel-correctness regression
- [x] Full RealWorldQA (765q) + MMMU (900q) academic comparison vs Qwen-published
- [x] Head-to-head vs Qwen3.6-35B-A3B on this build, 40-probe agentic workload set

