### PR TITLE
[Bugfix] Default Qwen3 reasoning parser to prompt-has-open-think

### DIFF
--- a/vllm/reasoning/qwen3_reasoning_parser.py
+++ b/vllm/reasoning/qwen3_reasoning_parser.py
@@ -27,9 +27,11 @@ class Qwen3ReasoningParser(BaseThinkingReasoningParser):
     def __init__(self, tokenizer, *args, **kwargs):
         super().__init__(tokenizer, *args, **kwargs)
         chat_kwargs = kwargs.get("chat_template_kwargs", {}) or {}
-        # Qwen3.5 chat templates open the <think> block in the prompt when
-        # thinking is enabled, so completion tokens may only contain </think>.
-        self.prompt_has_open_think = bool(chat_kwargs.get("enable_thinking", False))
+        # The standard Qwen3 chat template injects <think>\n into the prompt
+        # whenever enable_thinking is not explicitly False, so completion tokens
+        # may only contain </think>. Default to True and only honor an explicit
+        # enable_thinking=False to opt out.
+        self.prompt_has_open_think = bool(chat_kwargs.get("enable_thinking", True))
 
     @property
     def start_token(self) -> str:


### PR DESCRIPTION
## Summary

The standard Qwen3 chat template injects `<think>\n` into the assistant turn opener whenever `enable_thinking` is not explicitly `False`. That means completion tokens only contain `</think>` followed by the answer — never an opening `<think>`.

The current parser default (`prompt_has_open_think=False`) forces every client to pass `chat_template_kwargs={"enable_thinking": True}` on each request. When they don't (the common case for OpenAI-compatible clients), the parser sees no opening `<think>`, falls through to the both-tags-required branch, and dumps the entire completion — reasoning prose, the close tag, and the answer — into `content` with `reasoning` left `null`.

Flip the default to `True` so the parser matches the chat template's actual behavior out of the box. An explicit `enable_thinking=False` still works correctly: in that case the template emits a closed `<think></think>` pair into the prompt, so neither tag appears in the completion and the existing no-prompt-open-think branch is the right code path.

## Reproduction

Live on V100 TP=2 with a Qwen3-derived model (`deckard-40b-w4a16-hermes`), serving config:

```
--reasoning-parser qwen3 --tool-call-parser qwen3_coder --enable-auto-tool-choice
```

**Before** (no `chat_template_kwargs`):
```
reasoning: null
content: "\n\n # Train Meeting Problem\n## Step 1: ...\n## Final Answer\nThey meet ..."
```
The CoT framing leaks into `content` because the parser couldn't find an opening `<think>`.

**With explicit `chat_template_kwargs={"enable_thinking": true}`** (workaround):
```
reasoning: "This is a classic relative speed problem. Let me work through it..."
content: "\n\n # Train Meeting Problem\n..."
```

**After this patch** (no `chat_template_kwargs`):
```
reasoning: "This is a classic relative speed problem. Let me work through it..."  (1377 chars)
content: "\n\n # Train Meeting Problem\n..."  (clean)
```

## Test plan

- [x] Live A/B on V100 TP=2, deckard-40b-w4a16-hermes, before/with-kwargs/after — see reproduction above
- [x] `enable_thinking=False` path: still hits the no-prompt-open-think branch (template emits closed `<think></think>`, neither tag in completion)
- [ ] Streaming path verification (uses same flag)

Co-Authored-By: RivetOS Claude <noreply@rivetos.dev>
