### PR TITLE
[Bugfix][SM70] Fast gather for fp8 KV cache (uint8 view-as-half trick)

### DIFF
--- a/vllm/v1/attention/backends/flash_attn_v100.py
+++ b/vllm/v1/attention/backends/flash_attn_v100.py
@@ -816,6 +816,26 @@ def _extract_contiguous_kv_from_paged_cache(
 
     key_cache, value_cache = _split_paged_kv_cache(kv_cache)
 
+    # fp8 (uint8) caches: the gather kernel is typed for fp16, but a gather is
+    # a bitwise copy, so we can view 2 uint8 bytes as one fake half, run the
+    # fast kernel, and view the result back. This avoids the very slow
+    # per-block Python loop below, which is the dominant chunked-prefill cost
+    # for fp8-KV models (e.g. fp8 checkpoints + --kv-cache-dtype fp8_e5m2 on
+    # SM70/Volta).
+    if (paged_kv_utils is not None
+            and key_cache.dtype == torch.uint8
+            and head_dim % 2 == 0
+            and hasattr(paged_kv_utils, "paged_kv_to_contiguous")):
+        kc_h = key_cache.view(torch.float16)
+        vc_h = value_cache.view(torch.float16)
+        k_h, v_h = paged_kv_utils.paged_kv_to_contiguous(
+            kc_h, vc_h, block_table, seq_lens)
+        if total_tokens is None:
+            total_tokens = int(seq_lens.sum().item())
+        k_cont = k_h.view(torch.uint8).view(-1, num_kv_heads, head_dim)
+        v_cont = v_h.view(torch.uint8).view(-1, num_kv_heads, head_dim)
+        return k_cont[:total_tokens], v_cont[:total_tokens]
+
     if paged_kv_utils is not None and key_cache.dtype != torch.uint8:
         if hasattr(paged_kv_utils, "paged_kv_to_contiguous"):
             k_cont, v_cont = paged_kv_utils.paged_kv_to_contiguous(


### PR DESCRIPTION
## Summary

`_extract_contiguous_kv_from_paged_cache` currently excludes `uint8` KV cache from the fast CUDA gather path (`key_cache.dtype != torch.uint8`), falling through to the per-block Python loop. That's the dominant chunked-prefill cost on V100/SM70 whenever `--kv-cache-dtype fp8_e5m2` (or `fp8` / `fp8_e4m3`) is in use — either an fp8 checkpoint, or a non-fp8 checkpoint configured for fp8 KV.

A gather is a bitwise copy, so it's safe to view two `uint8` bytes as one fake `float16`, run the typed-for-fp16 `paged_kv_to_contiguous` kernel, then view the result back to `uint8`. The kernel doesn't inspect values; same bytes in, same bytes out.

## Workload context — Qwen3.6-27B-AWQ-int4 + MTP

Validated end-to-end on the community-standard config used to characterize this fork on V100: **Qwen3.6-27B-AWQ-int4, TP=2, MTP k=2**, warmed ShareGPT, 2× Tesla V100-PCIE-32GB. Without this patch we hit **c=1=53 / c=4=71 / c=8=119 agg tok/s** at default fp16 KV — that's the baseline the patch builds on. With fp8 KV the patch activates the fast gather and lifts the chunked-prefill phase that otherwise dominates wall-clock at concurrency.

## Measured A/B — fp8_e5m2 KV (where the patch actually fires)

Same hardware, same backend, same engine version (1.2.0). Model: Deckard-40B-W4A16-AWQ ([`philbert440/Qwen3.6-40B-DeckardUncensored-OpusDistilled-HermesCalibrated-W4A16-AWQ`](https://huggingface.co/philbert440/Qwen3.6-40B-DeckardUncensored-OpusDistilled-HermesCalibrated-W4A16-AWQ)) with `--kv-cache-dtype fp8_e5m2`, MTP k=4. Warmed ShareGPT, consumers paused.

| concurrency | pre-patch agg tok/s | post-patch agg tok/s | mean TTFT |
|---|---|---|---|
| c=1 | 41.7 | 42.0 | 468 → 435 ms |
| c=4 | 52.9 | **59.5** (+12.5%) | 1517 → 913 ms (-40%) |

c=1 is neutral as expected (one short prompt → minimal chunked-prefill share of wall time). At concurrency the gather fast path fires throughout the prefill phase and the cost shows up. No quality change observed; the same byte-for-byte data flows through the typed-fp16 kernel — verified against the fidelity benchmark (corruption catalog empty pre- and post-patch).

## Compatibility

- Only triggers when `key_cache.dtype == torch.uint8` AND `head_dim % 2 == 0` AND the CUDA extension exposes `paged_kv_to_contiguous`. Falls through to the existing fp16 path / Python fallback otherwise.
- No new dependencies, no kernel changes, no API changes. Pure Python edit in the dispatch wrapper.
- Backward-compatible: non-fp8 KV behavior is unchanged.
- Sits on top of the 1.2.1-prep rotary fallback fix (#9342ab09b3); applies cleanly to current main.

## Credit

Thanks to @temptationOne for helping hunt this down.