### PR TITLE
[V100/SM70] fp8_e5m2 KV on W4A16 (P7) + fast fp8 prefill gather + serving docs

### DIFF
--- a/docs/v100-sm70-serving.md
+++ b/docs/v100-sm70-serving.md
@@ -1,0 +1,57 @@
+# Serving Qwen3.5/3.6 on V100 (SM70) with 1Cat-vLLM 1.2.1
+
+Field notes for running W4A16 (+ MTP speculative decoding) Qwen3.6-27B-class checkpoints on
+2x Tesla V100-PCIE-32GB (compute capability 7.0) with 1Cat-vLLM 1.2.1. As of 1.2.1 the Volta
+serving stack is in-release; only the fp8-KV prefill gather (this PR) is an add-on.
+
+## What 1.2.1 already handles (no patch needed)
+- **W4A16 on Volta**: `CompressedTensorsWNA16` admits CC 7.0 and binds the SM70 TurboMind kernel.
+- **fp8_e5m2 KV on W4A16**: `CompressedTensorsKVCacheMethod.validate_kv_cache_scheme(None)` returns
+  cleanly, so `--kv-cache-dtype fp8_e5m2` works on a no-KV-scale W4A16 checkpoint.
+- **SM70 rotary**: pure-PyTorch `forward_native` fallback when `_vllm_fa2_C` is unavailable.
+- **Reasoning**: `--reasoning-parser qwen3` populates the reasoning field and keeps partial content
+  when truncated by `max_tokens`.
+
+## This PR: fast fp8-KV prefill gather
+`_extract_contiguous_kv_from_paged_cache` skips the native `paged_kv_to_contiguous` kernel for
+`uint8` (the kernel is fp16-typed), so fp8 KV falls to a per-block Python loop -- the dominant
+chunked-prefill cost on long prompts for fp8-KV models. The patch views the uint8 bytes as fp16
+(a gather is a bitwise copy) to run the fast kernel. Correctness-equivalent to the fallback;
+only prefill speed changes. Decode (incl. MTP) is unaffected.
+
+## MTP (speculative decoding) packed-head recipe
+To enable `--speculative-config '{"method":"mtp","num_speculative_tokens":2}'` on a W4A16 checkpoint:
+
+- The MTP head must be **quantized (packed W4A16)** to match the body. A bf16 head on a W4A16 body
+  crashes SM70 spec-decode (mixed-precision GDN spec forward).
+- **But `mtp.fc` must stay fp16** and be listed in `quantization_config.ignore` (and excluded from any
+  quant `config_group` target). If `mtp.fc` is marked for quantization while stored plain fp16, the
+  loader logs `Parameter fc.weight not found in params_dict, skip loading`, the drafter's fusion
+  projection is left uninitialized, and **MTP accept rate is 0%** -- silently, since the target model
+  still emits coherent text. With `mtp.fc` in `ignore`, accept is ~76-80%.
+- This matches the base Qwen3.6 packed-head layout: 36 mtp tensors, each `mtp.layers.0.*_proj` with
+  `weight_packed/weight_scale/weight_shape/weight_zero_point`; `mtp.fc` + norms fp16.
+
+## Recommended serving config (measured, 2x V100-PCIE-32GB)
+```
+VLLM_SM70_QUANT_BACKEND=turbomind \
+NCCL_P2P_DISABLE=1 NCCL_SHM_DISABLE=0 \
+VLLM_WORKER_MULTIPROC_METHOD=spawn \
+PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True \
+python -m vllm.entrypoints.openai.api_server \
+  --model <qwen3.6-27b W4A16 + packed MTP head> \
+  --trust-remote-code --dtype half --attention-backend FLASH_ATTN_V100 \
+  --tensor-parallel-size 2 --gpu-memory-utilization 0.58 \
+  --max-model-len 262144 --max-num-seqs 6 --max-num-batched-tokens 8192 \
+  --kv-cache-dtype fp8_e5m2 \
+  --speculative-config '{"method":"mtp","num_speculative_tokens":2,"attention_backend":"FLASH_ATTN_V100"}' \
+  --compilation-config '{"cudagraph_mode":"full_and_piecewise","cudagraph_capture_sizes":[1,2,4,8]}' \
+  --enable-prefix-caching --reasoning-parser qwen3 \
+  --enable-auto-tool-choice --tool-call-parser qwen3_coder
+```
+
+- **fp8_e5m2 KV** roughly doubles the KV pool vs fp16, enabling the full 262144 context; this PR keeps
+  its prefill fast. (fp16 KV also works and is simpler if you only need ~130k context.)
+- **MTP K=2** is the sweet spot for stock Qwen MTP on V100 (~76-80% accept, ~1.5x single-stream decode);
+  K=4 lowers accept without a purpose-built head.
+- `--attention-backend FLASH_ATTN_V100` and `VLLM_SM70_QUANT_BACKEND=turbomind` are required on Volta.

--- a/docs/v100-sm70-serving.md
+++ b/docs/v100-sm70-serving.md
@@ -1,23 +1,50 @@
 # Serving Qwen3.5/3.6 on V100 (SM70) with 1Cat-vLLM 1.2.1
 
-Field notes for running W4A16 (+ MTP speculative decoding) Qwen3.6-27B-class checkpoints on
-2x Tesla V100-PCIE-32GB (compute capability 7.0) with 1Cat-vLLM 1.2.1. As of 1.2.1 the Volta
-serving stack is in-release; only the fp8-KV prefill gather (this PR) is an add-on.
+Field notes for running W4A16 (+ MTP speculative decoding, + `fp8_e5m2` KV) Qwen3.6-27B-class
+checkpoints on 2× Tesla V100-PCIE-32GB (compute capability 7.0) with 1Cat-vLLM 1.2.1. As of 1.2.1
+most of the Volta stack is in-release; this PR adds the **two** remaining pieces needed to run the
+full W4A16 + `fp8_e5m2` + MTP config.
 
-## What 1.2.1 already handles (no patch needed)
+## What 1.2.1 already handles (no patch)
 - **W4A16 on Volta**: `CompressedTensorsWNA16` admits CC 7.0 and binds the SM70 TurboMind kernel.
-- **fp8_e5m2 KV on W4A16**: `CompressedTensorsKVCacheMethod.validate_kv_cache_scheme(None)` returns
-  cleanly, so `--kv-cache-dtype fp8_e5m2` works on a no-KV-scale W4A16 checkpoint.
-- **SM70 rotary**: pure-PyTorch `forward_native` fallback when `_vllm_fa2_C` is unavailable.
+- **SM70 rotary**: pure-PyTorch `forward_native` fallback when `_vllm_fa2_C` is unavailable (vision/MM).
 - **Reasoning**: `--reasoning-parser qwen3` populates the reasoning field and keeps partial content
   when truncated by `max_tokens`.
+- **An SM70 `fp8_e5m2` unit-scale override path exists** (`attention.py`, `_force_unit_fp8_e5m2_kv_scales`)
+  — but it is gated on the layer using `BaseKVCacheMethod.process_weights_after_loading`. See P7 below.
 
-## This PR: fast fp8-KV prefill gather
-`_extract_contiguous_kv_from_paged_cache` skips the native `paged_kv_to_contiguous` kernel for
-`uint8` (the kernel is fp16-typed), so fp8 KV falls to a per-block Python loop -- the dominant
-chunked-prefill cost on long prompts for fp8-KV models. The patch views the uint8 bytes as fp16
-(a gather is a bitwise copy) to run the fast kernel. Correctness-equivalent to the fallback;
-only prefill speed changes. Decode (incl. MTP) is unaffected.
+## This PR — two patches
+
+### 1. P7: `fp8_e5m2` KV on compressed-tensors W4A16 (SM70)
+A W4A16 checkpoint ships **no KV scales** (`kv_cache_scheme=None`), yet `get_quant_method` still returns
+`CompressedTensorsKVCacheMethod` for the attention layer. That class **overrides**
+`process_weights_after_loading`, so 1.2.1's SM70 unit-scale override (which requires the *base* method's
+`process_weights_after_loading`) does **not** apply, and `attention.py` raises:
+
+```
+ValueError: fp8_e5m2 kv-cache is not supported with fp8 checkpoints
+outside the SM70 Flash-V100 unit-scale override path.
+```
+
+Fix: when no KV scheme ships, skip the CT KV method entirely so the layer takes the plain
+`fp8_e5m2` unit-scale path:
+
+```python
+if isinstance(layer, Attention):
+    if self.kv_cache_scheme is None:
+        return None
+    return CompressedTensorsKVCacheMethod(self)
+```
+
+Without this, `--kv-cache-dtype fp8_e5m2` cannot be used with a W4A16 checkpoint on V100 — which means
+no `fp8_e5m2` KV, which means you cannot fit the full 262144 context (fp16 KV ~halves the pool).
+
+### 2. Fast `fp8`-KV prefill gather
+`_extract_contiguous_kv_from_paged_cache` skips the native `paged_kv_to_contiguous` kernel for `uint8`
+(the kernel is fp16-typed), so `fp8` KV falls to a per-block Python loop — the dominant chunked-prefill
+cost on long prompts for fp8-KV models. A gather is a bitwise copy, so view two `uint8` bytes as one
+`float16`, run the fast kernel, view back. Correctness-equivalent to the fallback; decode (incl. MTP)
+unaffected. (This pairs with P7: once `fp8_e5m2` KV is usable on W4A16, this keeps its prefill fast.)
 
 ## MTP (speculative decoding) packed-head recipe
 To enable `--speculative-config '{"method":"mtp","num_speculative_tokens":2}'` on a W4A16 checkpoint:
@@ -27,12 +54,12 @@ To enable `--speculative-config '{"method":"mtp","num_speculative_tokens":2}'` o
 - **But `mtp.fc` must stay fp16** and be listed in `quantization_config.ignore` (and excluded from any
   quant `config_group` target). If `mtp.fc` is marked for quantization while stored plain fp16, the
   loader logs `Parameter fc.weight not found in params_dict, skip loading`, the drafter's fusion
-  projection is left uninitialized, and **MTP accept rate is 0%** -- silently, since the target model
-  still emits coherent text. With `mtp.fc` in `ignore`, accept is ~76-80%.
+  projection is left uninitialized, and **MTP accept rate is 0%** — silently, since the target model
+  still emits coherent text. With `mtp.fc` in `ignore`, accept is ~76–84%.
 - This matches the base Qwen3.6 packed-head layout: 36 mtp tensors, each `mtp.layers.0.*_proj` with
   `weight_packed/weight_scale/weight_shape/weight_zero_point`; `mtp.fc` + norms fp16.
 
-## Recommended serving config (measured, 2x V100-PCIE-32GB)
+## Recommended serving config (measured, 2× V100-PCIE-32GB, 1.2.1 + this PR)
 ```
 VLLM_SM70_QUANT_BACKEND=turbomind \
 NCCL_P2P_DISABLE=1 NCCL_SHM_DISABLE=0 \
@@ -50,8 +77,10 @@ python -m vllm.entrypoints.openai.api_server \
   --enable-auto-tool-choice --tool-call-parser qwen3_coder
 ```
 
-- **fp8_e5m2 KV** roughly doubles the KV pool vs fp16, enabling the full 262144 context; this PR keeps
-  its prefill fast. (fp16 KV also works and is simpler if you only need ~130k context.)
-- **MTP K=2** is the sweet spot for stock Qwen MTP on V100 (~76-80% accept, ~1.5x single-stream decode);
-  K=4 lowers accept without a purpose-built head.
+Measured (Qwen3.6-27B-Uncensored W4A16-AWQ g128 + packed MTP head):
+- **MTP K=2 accept ~84%**, **~57 tok/s** single-stream decode (≈1.5× vs no-MTP).
+- **fp8_e5m2 KV** → **427k-token KV pool** at `util 0.58` (1.63× concurrency at 262144) while coexisting
+  with an ASR+TTS stack on the same 2 GPUs. fp16 KV also works (~213k pool, ~192k usable context) and
+  needs neither patch if you don't need the full 262k context.
+- `num_speculative_tokens=2` is the sweet spot for stock Qwen MTP on V100; K=4 lowers accept.
 - `--attention-backend FLASH_ATTN_V100` and `VLLM_SM70_QUANT_BACKEND=turbomind` are required on Volta.

--- a/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors.py
@@ -180,6 +180,13 @@ class CompressedTensorsConfig(QuantizationConfig):
                 return CompressedTensorsLinearMethod(self)
 
         if isinstance(layer, Attention):
+            # P7: compressed-tensors W4A16 ships no KV scales (kv_cache_scheme=None).
+            # 1.2.1's SM70 fp8_e5m2 unit-scale override requires the base KV method's
+            # process_weights_after_loading, but CompressedTensorsKVCacheMethod overrides it,
+            # so attention.py rejects --kv-cache-dtype fp8_e5m2. When no KV scheme ships,
+            # skip the CT KV method so e5m2 takes the unit-scale path.
+            if self.kv_cache_scheme is None:
+                return None
             return CompressedTensorsKVCacheMethod(self)
         if isinstance(layer, RoutedExperts):
             return CompressedTensorsMoEMethod.get_moe_method(

--- a/vllm/v1/attention/backends/flash_attn_v100.py
+++ b/vllm/v1/attention/backends/flash_attn_v100.py
@@ -816,6 +816,25 @@ def _extract_contiguous_kv_from_paged_cache(
 
     key_cache, value_cache = _split_paged_kv_cache(kv_cache)
 
+    # [1Cat SM70] fp8 (uint8) caches: the native paged_kv_to_contiguous gather kernel
+    # is typed for fp16 and is skipped for uint8 below, so fp8 KV falls to the slow
+    # per-block Python loop -- the dominant chunked-prefill cost for fp8-KV models on
+    # Volta (e.g. W4A16 + fp8_e5m2). A gather is a bitwise copy, so view two uint8
+    # bytes as one fp16, run the fast kernel, view back. Correctness-equivalent to the
+    # Python fallback; only the prefill speed differs.
+    if (paged_kv_utils is not None and key_cache.dtype == torch.uint8
+            and head_dim % 2 == 0
+            and hasattr(paged_kv_utils, "paged_kv_to_contiguous")):
+        kc_h = key_cache.contiguous().view(torch.float16)
+        vc_h = value_cache.contiguous().view(torch.float16)
+        k_h, v_h = paged_kv_utils.paged_kv_to_contiguous(
+            kc_h, vc_h, block_table, seq_lens)
+        if total_tokens is None:
+            total_tokens = int(seq_lens.sum().item())
+        k_cont = k_h.view(torch.uint8).view(-1, num_kv_heads, head_dim)
+        v_cont = v_h.view(torch.uint8).view(-1, num_kv_heads, head_dim)
+        return k_cont[:total_tokens], v_cont[:total_tokens]
+
     if paged_kv_utils is not None and key_cache.dtype != torch.uint8:
         if hasattr(paged_kv_utils, "paged_kv_to_contiguous"):
             k_cont, v_cont = paged_kv_utils.paged_kv_to_contiguous(


### PR DESCRIPTION
### Summary

The two remaining changes needed to run the **full W4A16 + `fp8_e5m2` KV + MTP** stack on 2×V100 (SM70) with 1Cat-vLLM 1.2.1. Everything else in our old rollup (#55) is now in-release; these two are what's left. Both are V100/SM70-only paths and no-ops elsewhere. Includes `docs/v100-sm70-serving.md` with the complete validated serving config.

### Patch 1 — P7: `fp8_e5m2` KV on compressed-tensors W4A16

A W4A16 checkpoint ships **no KV scales** (`kv_cache_scheme=None`), but `get_quant_method` still returns `CompressedTensorsKVCacheMethod`, which **overrides** `process_weights_after_loading`. 1.2.1's SM70 unit-scale override (`attention.py`, `_force_unit_fp8_e5m2_kv_scales`) only engages for the *base* method, so it doesn't apply and boot fails:

```
ValueError: fp8_e5m2 kv-cache is not supported with fp8 checkpoints
outside the SM70 Flash-V100 unit-scale override path.
```

Fix — when no KV scheme ships, skip the CT KV method so the layer takes the plain unit-scale `fp8_e5m2` path:

```python
if isinstance(layer, Attention):
    if self.kv_cache_scheme is None:
        return None
    return CompressedTensorsKVCacheMethod(self)
```

Without this, `--kv-cache-dtype fp8_e5m2` is unusable on W4A16/V100 → no fp8 KV → can't fit the full 262144 context (fp16 KV ~halves the pool).

### Patch 2 — fast `fp8`-KV prefill gather

`_extract_contiguous_kv_from_paged_cache` gates the native `paged_kv_to_contiguous` kernel behind `key_cache.dtype != torch.uint8` (it's fp16-typed), so `fp8` KV falls to a per-block Python loop — the dominant chunked-prefill cost on long prompts. A gather is a bitwise copy, so view two `uint8` bytes as one `float16`, run the fast kernel, view back. **Correctness-equivalent** to the fallback (verified element-wise); decode (incl. MTP) unaffected. Pairs with P7: once e5m2 KV works on W4A16, this keeps its prefill fast.

### Docs

`docs/v100-sm70-serving.md`: what 1.2.1 handles out of the box, both patches above, the **MTP packed-head recipe** (incl. the non-obvious `mtp.fc`-must-stay-fp16 gotcha — a quantized `mtp.fc` silently drops MTP accept to 0%), and the complete recommended serving config.

### Serving config

The full validated config (also in `docs/v100-sm70-serving.md`). Every env var and flag below is required on Volta; `<model>` is any Qwen3.6-27B-class W4A16 checkpoint with a packed (W4A16) MTP head whose `mtp.fc` stays fp16:

```
VLLM_SM70_QUANT_BACKEND=turbomind \
NCCL_P2P_DISABLE=1 NCCL_SHM_DISABLE=0 \
VLLM_WORKER_MULTIPROC_METHOD=spawn \
PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True \
python -m vllm.entrypoints.openai.api_server \
  --model <qwen3.6-27b W4A16 + packed MTP head> \
  --trust-remote-code --dtype half --attention-backend FLASH_ATTN_V100 \
  --tensor-parallel-size 2 --gpu-memory-utilization 0.58 \
  --max-model-len 262144 --max-num-seqs 6 --max-num-batched-tokens 8192 \
  --kv-cache-dtype fp8_e5m2 \
  --speculative-config '{"method":"mtp","num_speculative_tokens":2,"attention_backend":"FLASH_ATTN_V100"}' \
  --compilation-config '{"cudagraph_mode":"full_and_piecewise","cudagraph_capture_sizes":[1,2,4,8]}' \
  --enable-prefix-caching --reasoning-parser qwen3 \
  --enable-auto-tool-choice --tool-call-parser qwen3_coder
```

Notes: `num_speculative_tokens=2` is the sweet spot for stock Qwen MTP on V100 (K=4 lowers accept); `full_and_piecewise` cudagraphs are required so the MTP draft all-reduce is amortized on no-NVLink V100; drop `--kv-cache-dtype fp8_e5m2` (and you no longer need either patch) if you don't need the full 262k context — fp16 KV gives ~192k usable.

### Validation (running in prod, 2×V100-PCIE-32GB, 1.2.1 + both patches)

Qwen3.6-27B-Uncensored W4A16-AWQ g128 + packed MTP head, `fp8_e5m2` KV, **262144** context, MTP K=2:
- **MTP accept ~84%**, **~57 tok/s** single-stream decode (≈1.5× vs no-MTP)
- **427k-token KV pool** at `util 0.58` (1.63× concurrency at 262144), coexisting with an ASR+TTS stack on the same 2 GPUs
- correct outputs at e5m2 unit-scale; long-prompt prefill stays on the fast gather path
