### PR TITLE
sm70/V100: fail loudly when torch<2.10 skips _C_stable_libtorch; tolerate UUID-form CUDA_VISIBLE_DEVICES; add sm_70 build guide

### DIFF
--- a/BUILD_SM70.md
+++ b/BUILD_SM70.md
@@ -1,0 +1,75 @@
+# Building and serving 1Cat-vLLM on NVIDIA V100 (sm_70)
+
+Validated recipe for building this fork from source for Volta (V100-32GB) and
+serving with the compiled `FLASH_ATTN_V100` backend. All numbers below were
+measured on a single V100-SXM2-32GB.
+
+## Build environment
+
+| requirement | value | why |
+|---|---|---|
+| Python | 3.12 | tested combination |
+| torch | **2.10.0+cu128** | the fork pins `torch==2.10.0` (`requirements/cuda.txt`); the stable-ABI op library `vllm._C_stable_libtorch` requires torch >= 2.10. The cu126 wheel index tops out at torch 2.9.1, so cu128 is the correct CUDA variant. torch 2.10.0+cu128 still ships sm_70 kernels — verify with `python -c "import torch; print(torch._C._cuda_getArchFlags())"` (must include `sm_70`). Do **not** use a CUDA 13 (cu130) torch: sm_70 is dropped there. |
+| CUDA toolkit (nvcc) | 12.6+ works | minor-version mismatch vs. torch's cu128 runtime is fine for compilation |
+| `TORCH_CUDA_ARCH_LIST` | `7.0` | compile only sm_70; keeps the build to ~13 min on a 24-core host |
+
+Do **not** set `VLLM_SKIP_FLASH_ATTN_V100_BUNDLE` — the bundled
+`flash-attention-v100` extension is what provides the Volta attention kernels
+(XQA decode, bhmd, paged prefill bhmd/bfla/splitkv, wmma decode, turboquant
+decode). A wheel built without the bundle, or installed next to a stale
+`flash_attn_v100` package, makes the strict `FLASH_ATTN_V100` backend refuse
+to run ("required Flash op is unavailable").
+
+```bash
+export TORCH_CUDA_ARCH_LIST=7.0
+export FLASH_ATTN_V100_CUDA_ARCH_LIST=7.0
+export MAX_JOBS=<cores>
+pip wheel --no-build-isolation --no-deps -w dist .
+pip install dist/1cat_vllm-*.whl
+```
+
+If the build environment has torch < 2.10, `setup.py` now fails loudly instead
+of producing a wheel whose `_C` namespace is missing every generic op
+(`silu_and_mul`, `rms_norm`, `rotary_embedding`, all of `_C_cache_ops`, ...) —
+such a wheel imports cleanly but cannot load any model.
+
+## Serving on V100
+
+```bash
+PYTHONNOUSERSITE=1 \
+CUDA_DEVICE_ORDER=PCI_BUS_ID CUDA_VISIBLE_DEVICES=<numeric index> \
+python -m vllm.entrypoints.openai.api_server \
+  --model <model> --dtype float16 \
+  --max-model-len 8192 --gpu-memory-utilization 0.85
+```
+
+- `--dtype float16` always — Volta has no bf16.
+- `PYTHONNOUSERSITE=1` if your user site-packages contains a different torch:
+  a shadowing torch causes `vllm/_C.abi3.so: undefined symbol ...` at import.
+- Prefer numeric `CUDA_VISIBLE_DEVICES` under `CUDA_DEVICE_ORDER=PCI_BUS_ID`.
+  UUID-form entries (`GPU-<uuid>`) are supported as of this branch (they used
+  to crash device resolution with
+  `ValueError: invalid literal for int() ...`); map UUID to index per boot
+  with:
+  `nvidia-smi --query-gpu=pci.bus_id,uuid --format=csv,noheader | sort | cat -n`
+- Do **not** pass `--enforce-eager` in production. CUDA graph capture works on
+  sm_70 (the fork auto-selects `mode=VLLM_COMPILE`,
+  `cudagraph_mode=FULL_AND_PIECEWISE`) and is the single biggest win:
+
+| mode | decode t/s (greedy, 128 tok, single stream) | prefill t/s (~5.3k tok) |
+|---|---|---|
+| eager (`--enforce-eager`) | 51.6 | 3836 |
+| CUDA graphs (default) | **132.8 (2.56x)** | 3796 |
+
+Model: Qwen/Qwen3-4B-AWQ, single V100-SXM2-32GB, `float16`, 8192 context.
+Greedy output is bit-identical between eager and graphs.
+
+- XQA decode gating: for `q_per_kv == 4` models (e.g. Qwen3-4B: 32 Q / 8 KV
+  heads) the XQA route engages only when the decode sequence-length hint is
+  >= 32768 (`VLLM_FLASH_V100_DECODE_XQA_Q4_MIN_SEQ_LEN`); shorter contexts use
+  the scalar paged flash route. XQA is unconditional for `q_per_kv` 6 or 8.
+- First requests warm up JIT/compiled kernels — warm before benchmarking.
+- `VLLM_FLASH_V100_ROUTE_SUMMARY=1` prints per-route counters at exit.
+
+---
+Findings from PLI Labs V100 serving research (proprietarylegal.ai).

--- a/setup.py
+++ b/setup.py
@@ -1211,6 +1211,24 @@ if _is_cpu():
 if _build_custom_ops():
     ext_modules.append(CMakeExtension(name="vllm._C"))
     if _is_cuda() or _is_hip():
+        # vllm._C_stable_libtorch owns ALL generic ops (activations,
+        # rms_norm, rotary_embedding, the whole _C_cache_ops namespace,
+        # CUTLASS scaled_mm/MoE helpers, ...). It builds against the
+        # torch stable ABI introduced for this target in torch 2.10.
+        # Do NOT silently skip it on older torch: a wheel built without
+        # it imports fine but cannot load ANY model (the first symptom
+        # is `'_OpNamespace' '_C' object has no attribute
+        # 'silu_and_mul'` at model init).
+        torch_base_version = Version(torch.__version__.split("+", 1)[0])
+        if torch_base_version < Version("2.10.0"):
+            raise RuntimeError(
+                "1Cat-vLLM requires torch>=2.10 to build the stable-ABI "
+                f"op library (vllm._C_stable_libtorch); found torch "
+                f"{torch.__version__}. Building without it produces a "
+                "wheel that cannot load any model. Upgrade the build "
+                "environment's torch (e.g. torch 2.10.0+cu128 still "
+                "ships sm_70 kernels for V100) and rebuild."
+            )
         ext_modules.append(CMakeExtension(name="vllm._C_stable_libtorch"))
 
 package_data = {

--- a/vllm/platforms/cuda.py
+++ b/vllm/platforms/cuda.py
@@ -625,12 +625,26 @@ class CudaPlatformBase(Platform):
 # the major benefit of using NVML is that it will not initialize CUDA
 class NvmlCudaPlatform(CudaPlatformBase):
     @classmethod
+    def _get_nvml_handle(cls, physical_device_id: int | str):
+        """Return an NVML handle for a physical device index or a
+        "GPU-<uuid>" / "MIG-<uuid>" entry from CUDA_VISIBLE_DEVICES.
+
+        NVML is not affected by CUDA_VISIBLE_DEVICES, so UUID-form
+        entries (which device_id_to_physical_device_id passes through
+        unchanged) must be resolved via nvmlDeviceGetHandleByUUID
+        instead of being fed to int()/index-based lookup.
+        """
+        if isinstance(physical_device_id, str):
+            return pynvml.nvmlDeviceGetHandleByUUID(physical_device_id)
+        return pynvml.nvmlDeviceGetHandleByIndex(physical_device_id)
+
+    @classmethod
     @cache
     @with_nvml_context
     def get_device_capability(cls, device_id: int = 0) -> DeviceCapability | None:
         try:
             physical_device_id = cls.device_id_to_physical_device_id(device_id)
-            handle = pynvml.nvmlDeviceGetHandleByIndex(physical_device_id)
+            handle = cls._get_nvml_handle(physical_device_id)
             major, minor = pynvml.nvmlDeviceGetCudaComputeCapability(handle)
             return DeviceCapability(major=major, minor=minor)
         except RuntimeError:
@@ -658,23 +672,23 @@ class NvmlCudaPlatform(CudaPlatformBase):
     @with_nvml_context
     def get_device_uuid(cls, device_id: int = 0) -> str:
         physical_device_id = cls.device_id_to_physical_device_id(device_id)
-        handle = pynvml.nvmlDeviceGetHandleByIndex(physical_device_id)
+        handle = cls._get_nvml_handle(physical_device_id)
         return pynvml.nvmlDeviceGetUUID(handle)
 
     @classmethod
     @with_nvml_context
     def get_device_total_memory(cls, device_id: int = 0) -> int:
         physical_device_id = cls.device_id_to_physical_device_id(device_id)
-        handle = pynvml.nvmlDeviceGetHandleByIndex(physical_device_id)
+        handle = cls._get_nvml_handle(physical_device_id)
         return int(pynvml.nvmlDeviceGetMemoryInfo(handle).total)
 
     @classmethod
     @with_nvml_context
-    def is_fully_connected(cls, physical_device_ids: list[int]) -> bool:
+    def is_fully_connected(cls, physical_device_ids: list[int | str]) -> bool:
         """
         query if the set of gpus are fully connected by nvlink (1 hop)
         """
-        handles = [pynvml.nvmlDeviceGetHandleByIndex(i) for i in physical_device_ids]
+        handles = [cls._get_nvml_handle(i) for i in physical_device_ids]
         for i, handle in enumerate(handles):
             for j, peer_handle in enumerate(handles):
                 if i < j:
@@ -695,8 +709,8 @@ class NvmlCudaPlatform(CudaPlatformBase):
         return True
 
     @classmethod
-    def _get_physical_device_name(cls, device_id: int = 0) -> str:
-        handle = pynvml.nvmlDeviceGetHandleByIndex(device_id)
+    def _get_physical_device_name(cls, device_id: int | str = 0) -> str:
+        handle = cls._get_nvml_handle(device_id)
         return pynvml.nvmlDeviceGetName(handle)
 
     @classmethod
@@ -704,7 +718,7 @@ class NvmlCudaPlatform(CudaPlatformBase):
     def get_device_numa_node(cls, device_id: int = 0) -> int | None:
         """Get the NUMA node ID for a GPU device."""
         physical_device_id = cls.device_id_to_physical_device_id(device_id)
-        handle = pynvml.nvmlDeviceGetHandleByIndex(physical_device_id)
+        handle = cls._get_nvml_handle(physical_device_id)
 
         try:
             numa_node = pynvml.nvmlDeviceGetNumaNodeId(handle)

--- a/vllm/platforms/interface.py
+++ b/vllm/platforms/interface.py
@@ -224,7 +224,7 @@ class Platform:
         import vllm.kernels  # noqa: F401
 
     @classmethod
-    def device_id_to_physical_device_id(cls, device_id: int):
+    def device_id_to_physical_device_id(cls, device_id: int) -> int | str:
         # Treat empty device control env var as unset. This is a valid
         # configuration in Ray setups where the engine is launched in
         # a CPU-only placement group located on a GPU node.
@@ -234,7 +234,25 @@ class Platform:
         ):
             device_ids = os.environ[cls.device_control_env_var].split(",")
             physical_device_id = device_ids[device_id]
-            return int(physical_device_id)
+            try:
+                return int(physical_device_id)
+            except ValueError:
+                # The CUDA runtime also accepts device UUIDs
+                # ("GPU-<uuid>" / "MIG-<uuid>") in CUDA_VISIBLE_DEVICES.
+                # Those cannot be converted to a physical index here, so
+                # return the raw entry. Consumers that only rebuild a
+                # visibility env var for child processes can use it
+                # as-is; platform code that needs a physical handle must
+                # resolve it (e.g. NvmlCudaPlatform resolves UUIDs via
+                # nvmlDeviceGetHandleByUUID).
+                if physical_device_id.startswith(("GPU-", "MIG-")):
+                    return physical_device_id
+                raise ValueError(
+                    f"Invalid entry {physical_device_id!r} in "
+                    f"{cls.device_control_env_var}: expected a numeric "
+                    "device index or a device UUID of the form "
+                    "'GPU-<uuid>' / 'MIG-<uuid>'."
+                ) from None
         else:
             return device_id
 


### PR DESCRIPTION
## Summary

**1. `setup.py`: fail loudly when torch < 2.10 would skip `vllm._C_stable_libtorch`** (90b1cb5)
The stable-ABI extension owns every generic op — activations (`silu_and_mul`, `gelu*`, …), `rms_norm`/`fused_add_rms_norm`, `rotary_embedding`, the entire `_C_cache_ops` namespace, and the CUTLASS scaled_mm/MoE helpers — and only builds against torch >= 2.10. Nothing enforced that at build time (the pin lives in `requirements/cuda.txt`, which `--no-build-isolation` workflows bypass). A wheel produced under older torch is maximally misleading: it installs, imports, and registers all fork-specific kernels, then the first model load dies far from the root cause. This commit turns that into a hard, actionable `RuntimeError` at setup time.

**2. `vllm/platforms`: tolerate UUID-form `CUDA_VISIBLE_DEVICES`** (bf5e135)
The CUDA runtime accepts `GPU-<uuid>` / `MIG-<uuid>` entries in `CUDA_VISIBLE_DEVICES` (the reliable way to pin devices on multi-GPU hosts where indices shift across boots), but `device_id_to_physical_device_id()` ran `int()` on the raw entry. The fix passes UUID entries through unchanged (consumers that rebuild visibility env vars for child processes can use them as-is), raises a clear `ValueError` for anything that is neither an index nor a UUID, and teaches `NvmlCudaPlatform` to resolve UUID entries via `nvmlDeviceGetHandleByUUID` (NVML is unaffected by `CUDA_VISIBLE_DEVICES`, so index-based lookup is wrong for them).

**3. `BUILD_SM70.md`: V100 / sm_70 build and serving guide** (0202f83)
Validated build recipe (torch 2.10.0+cu128 — the cu126 wheel index tops out at 2.9.1, and cu130/CUDA-13 torch drops sm_70; `TORCH_CUDA_ARCH_LIST=7.0`; keep the flash-attention-v100 bundle enabled) plus a serving recipe (float16, device pinning, no `--enforce-eager`) with measured single-V100 numbers.

## Reproduction of the defects

**Defect 1 — silent stable-ABI skip.** Building the wheel in an environment with torch 2.9.1+cu128 (via `pip wheel --no-build-isolation`) succeeded and produced a 100+ MB wheel. `import vllm` worked; all 62 fork-specific sm70 kernels (`awq_*_sm70`, `fp8_*_sm70`, `sm70_f16_*`, marlin, machete) registered in `torch.ops._C`. Serving any model then failed at engine init with:

```
AttributeError: '_OpNamespace' '_C' object has no attribute 'silu_and_mul'
```

Dispatcher inspection showed the `_C` namespace had 62 ops instead of 138 and the `_C_cache_ops` namespace was missing entirely — every generic op (`rms_norm`, `rotary_embedding`, `reshape_and_cache_flash`, …) lives in the never-built `vllm._C_stable_libtorch`. Because import succeeds and the error surfaces at model-load time deep in layer construction, this took real effort to trace back to a build-environment torch version.

**Defect 2 — UUID `CUDA_VISIBLE_DEVICES`.** Launching with `CUDA_DEVICE_ORDER=PCI_BUS_ID CUDA_VISIBLE_DEVICES=GPU-<uuid>` crashed during engine config inside the model-registry inspection subprocess:

```
ValueError: invalid literal for int() with base 10: 'GPU-<uuid>'
```

surfacing to the user as an opaque `Model architectures ['Qwen3ForCausalLM'] failed to be inspected` pydantic ValidationError. Root frame: `vllm/platforms/interface.py`, `device_id_to_physical_device_id()`.

## Validation

- Rebuilt the wheel from this branch's parent (4e9fdbc) with torch 2.10.0+cu128, nvcc 12.6, `TORCH_CUDA_ARCH_LIST=7.0` (~13 min wall on 24 cores): `_C` registers **138 ops** (all 62 sm70 kernels intact + the generic set), `_C_cache_ops` registers 13, and the bundled `flash_attn_v100` exposes all **17** Volta attention features (XQA decode, bhmd, paged prefill bhmd/bfla/splitkv, wmma decode, turboquant decode).
- Runtime-validated on a single V100-SXM2-32GB with Qwen/Qwen3-4B-AWQ (`--dtype float16`, 8192 ctx): `FLASH_ATTN_V100` backend engaged; CUDA graph capture (`mode=VLLM_COMPILE`, `cudagraph_mode=FULL_AND_PIECEWISE`) captured cleanly in 14 s / 0.75 GiB; greedy single-stream decode went from **51.6 t/s (eager) to 132.8 t/s (graphs), a 2.56x lift**, prefill ~3.8k t/s, with **bit-identical greedy output** between eager and graphs.
- Fix 1 verified: `setup.py` under torch 2.9.1 now aborts immediately with the actionable message instead of building a broken wheel.
- Fix 2 verified: with `CUDA_VISIBLE_DEVICES=GPU-<uuid>`, `device_id_to_physical_device_id(0)` passes the UUID through, `NvmlCudaPlatform.get_device_capability(0)` resolves `DeviceCapability(major=7, minor=0)` via NVML, and the previously-crashing model-module import path completes.

Measurements come from PLI Labs V100 serving research (proprietarylegal.ai).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
