### PR TITLE
Fix GPTQ/compressed-tensors WNA16 on sm_70 (V100): auto-detect Volta Marlin, actionable errors (#87, #94)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -467,7 +467,11 @@ if(VLLM_GPU_LANG STREQUAL "CUDA")
       COMPILE_DEFINITIONS ENABLE_SM70_MARLIN=1)
     message(STATUS "Building SM70 Marlin kernels for archs: ${MARLIN_SM70_ARCHS}")
   elseif(MARLIN_SM70_ARCHS)
-    message(STATUS "Skipping SM70 Marlin kernels in mixed Marlin arch build")
+    message(WARNING
+      "Skipping SM70 Marlin kernels: they register the same torch ops as the "
+      "sm_75+ Marlin kernels and can only be built in a dedicated sm_70 build "
+      "(TORCH_CUDA_ARCH_LIST=7.0). This wheel will NOT support Marlin-format "
+      "quantization (GPTQ/AWQ/compressed-tensors WNA16 repack+gemm) on V100.")
   endif()
 
   if (MARLIN_OTHER_ARCHS)

--- a/csrc/quantization/marlin/awq_marlin_repack.cu
+++ b/csrc/quantization/marlin/awq_marlin_repack.cu
@@ -260,6 +260,20 @@ torch::Tensor awq_marlin_repack(torch::Tensor& b_q_weight, int64_t size_k,
 
   // Get dev info
   int dev = b_q_weight.get_device();
+
+  // This translation unit is only compiled for sm_75 and newer (see
+  // MARLIN_OTHER_ARCHS in CMakeLists.txt). Volta (sm_70) Marlin kernels are
+  // provided by the dedicated sm_70 build (TORCH_CUDA_ARCH_LIST=7.0), which
+  // replaces this implementation. Fail with an actionable error instead of a
+  // cryptic "no kernel image is available" at kernel-launch time (issue #87).
+  int cc_major = 0, cc_minor = 0;
+  cudaDeviceGetAttribute(&cc_major, cudaDevAttrComputeCapabilityMajor, dev);
+  cudaDeviceGetAttribute(&cc_minor, cudaDevAttrComputeCapabilityMinor, dev);
+  TORCH_CHECK(cc_major * 10 + cc_minor >= 75,
+              "awq_marlin_repack: this build has no sm_70 (Volta) Marlin kernels. "
+              "They are only included in a dedicated sm_70 build; rebuild "
+              "with TORCH_CUDA_ARCH_LIST=7.0 to serve on V100. Current "
+              "device compute capability: ", cc_major, ".", cc_minor);
   cudaStream_t stream = at::cuda::getCurrentCUDAStream(dev);
   int blocks;
   cudaDeviceGetAttribute(&blocks, cudaDevAttrMultiProcessorCount, dev);

--- a/csrc/quantization/marlin/gptq_marlin_repack.cu
+++ b/csrc/quantization/marlin/gptq_marlin_repack.cu
@@ -325,6 +325,20 @@ torch::Tensor gptq_marlin_repack(torch::Tensor& b_q_weight, torch::Tensor& perm,
 
   // Get dev info
   int dev = b_q_weight.get_device();
+
+  // This translation unit is only compiled for sm_75 and newer (see
+  // MARLIN_OTHER_ARCHS in CMakeLists.txt). Volta (sm_70) Marlin kernels are
+  // provided by the dedicated sm_70 build (TORCH_CUDA_ARCH_LIST=7.0), which
+  // replaces this implementation. Fail with an actionable error instead of a
+  // cryptic "no kernel image is available" at kernel-launch time (issue #87).
+  int cc_major = 0, cc_minor = 0;
+  cudaDeviceGetAttribute(&cc_major, cudaDevAttrComputeCapabilityMajor, dev);
+  cudaDeviceGetAttribute(&cc_minor, cudaDevAttrComputeCapabilityMinor, dev);
+  TORCH_CHECK(cc_major * 10 + cc_minor >= 75,
+              "gptq_marlin_repack: this build has no sm_70 (Volta) Marlin kernels. "
+              "They are only included in a dedicated sm_70 build; rebuild "
+              "with TORCH_CUDA_ARCH_LIST=7.0 to serve on V100. Current "
+              "device compute capability: ", cc_major, ".", cc_minor);
   cudaStream_t stream = at::cuda::getCurrentCUDAStream(dev);
   int blocks;
   cudaDeviceGetAttribute(&blocks, cudaDevAttrMultiProcessorCount, dev);

--- a/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_wNa16.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_wNa16.py
@@ -6,6 +6,7 @@ from collections.abc import Callable
 import torch
 from compressed_tensors.quantization import ActivationOrdering
 
+from vllm import _custom_ops as ops
 from vllm import envs
 from vllm.logger import init_logger
 from vllm.model_executor.kernels.linear import (
@@ -82,6 +83,10 @@ class CompressedTensorsWNA16(CompressedTensorsScheme):
         if (
             sm70_tm.use_turbomind(envs.VLLM_SM70_COMPRESSED_TENSORS_TURBOMIND)
             or sm70_tm.forces_marlin()
+            # Dedicated sm_70 builds (TORCH_CUDA_ARCH_LIST=7.0) ship Volta
+            # Marlin kernels for all WNA16 types (u4, u4b8, u8, u8b128), so
+            # capability 7.0 is supported out of the box -- no env flag needed.
+            or ops.sm70_marlin_available()
         ):
             return 70
         # Turing and up


### PR DESCRIPTION
## Summary

Fixes GPTQ / compressed-tensors WNA16 on Tesla V100 (sm_70). Closes #94, de-mystifies #87.

The Volta Marlin kernels (incl. `sm70_gptq_marlin_repack.cu` with act-order variants and the u4b8/u8b128 GEMMs) already exist in this tree, but (a) they are only compiled in a dedicated `TORCH_CUDA_ARCH_LIST=7.0` build because they register the same torch ops as the sm_75+ set, and (b) `CompressedTensorsWNA16.get_min_capability()` returned 75 unless `VLLM_SM70_COMPRESSED_TENSORS_TURBOMIND=1` / `VLLM_SM70_QUANT_BACKEND=marlin` was set — so even correct sm_70 builds rejected compressed-tensors GPTQ/AWQ checkpoints out of the box, while the AWQ path (whose turbomind env defaults True) worked.

## Changes

1. `CompressedTensorsWNA16.get_min_capability()` additionally returns 70 when `torch.ops._C.sm70_marlin_available()` is true (the existing `ENABLE_SM70_MARLIN` binding, already used by `marlin_utils_fp4.py`). No env flags needed on sm_70 builds; behavior unchanged on builds without the Volta kernels.
2. The sm_75+ `gptq_marlin_repack` / `awq_marlin_repack` host functions `TORCH_CHECK` compute capability >= 7.5 with a message naming the remedy, instead of failing at kernel launch with `no kernel image is available` (the #87 symptom). The CMake "Skipping SM70 Marlin kernels" message is upgraded to `WARNING`.

## Test

- Dedicated sm_70 build (CUDA 12.6, torch 2.10.0+cu128, py3.12, `TORCH_CUDA_ARCH_LIST=7.0`): builds clean; `cuobjdump` confirms `marlin::gptq_marlin_repack_kernel` (incl. `has_perm=true`), u4b8/u8b128 GEMM and MoE Marlin sm_70 cubins in `_C`/`_moe_C`; `sm70_marlin_available()` True at import.
- Runtime on Tesla V100-SXM2-32GB (2026-07-10, TP1, `--dtype float16`, torch 2.10.0+cu128, py3.12, dedicated sm_70 wheel from this branch):
  - `TheBloke/Llama-2-7B-Chat-GPTQ` (4-bit g128, desc_act=false): engine starts, `gptq_marlin_repack` executes (no kernel-image error), `Using MarlinLinearKernel for AutoGPTQLinearMethod`, coherent greedy generation, finite/sane logprobs.
  - `nm-testing/Meta-Llama-3-8B-Instruct-W4A16-compressed-tensors-test`: loads and generates coherently with **zero `VLLM_SM70_*` env vars** (the commit-1 behavior); `Using MarlinLinearKernel for CompressedTensorsWNA16`.
  - Pre-existing sm_70 kernel limitations confirmed orthogonal to this patch (clean `TORCH_CHECK` rejections, unchanged by it): act-order (`desc_act=true`) and bias epilogue are not supported by the sm_70 Marlin dispatch — so scope is desc_act=false, bias-free checkpoints (Llama/Mistral-family OK, Qwen-family QKV-bias not).

AI assistance was used for this change; every line has been reviewed by the submitter. Not duplicating any open PR (checked `gh pr list` for marlin/sm70/gptq).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
