### PR TITLE
[V100/SM70] Gemma4 complete adaptation: FA head_dim=512 + MTP speculative decoding + vision encoding OOM fix + compile priming

### DIFF
--- a/flash-attention-v100/flash_attn_v100/__init__.py
+++ b/flash-attention-v100/flash_attn_v100/__init__.py
@@ -3,6 +3,8 @@ __version__ = "1.2.0"
 from flash_attn_v100.flash_attn_interface import (
     flash_attn_decode_qk_scores,
     flash_attn_decode_paged,
+    flash_attn_decode_paged_mq,
+    flash_attn_decode_paged_mq_available,
     flash_attn_decode_paged_xqa,
     flash_attn_decode_paged_xqa_available,
     flash_attn_decode_paged_wmma,
@@ -21,6 +23,8 @@ from flash_attn_v100.flash_attn_interface import (
 __all__ = [
     "flash_attn_decode_qk_scores",
     "flash_attn_decode_paged",
+    "flash_attn_decode_paged_mq",
+    "flash_attn_decode_paged_mq_available",
     "flash_attn_decode_paged_xqa",
     "flash_attn_decode_paged_xqa_available",
     "flash_attn_decode_paged_wmma",

--- a/flash-attention-v100/flash_attn_v100/flash_attn_interface.py
+++ b/flash-attention-v100/flash_attn_v100/flash_attn_interface.py
@@ -15,8 +15,10 @@ except ImportError:
 
 DEFAULT_DECODE_PARTITION_SIZE = 256
 VALID_DECODE_PARTITION_SIZES = (256, 512, 1024)
+DECODE_MQ_Q_MAX = 8
 _decode_plan_cache = {}
 _decode_workspace_cache = {}
+_decode_mq_workspace_cache = {}
 _turboquant_decode_workspace_cache = {}
 logger = logging.getLogger(__name__)
 
@@ -134,6 +136,7 @@ def _get_decode_plan(
     batch_size_hint: Optional[int] = None,
     workspace_seq_capacity_hint: Optional[int] = None,
     active_num_partitions: Optional[torch.Tensor] = None,
+    default_partition_size: Optional[int] = None,
 ) -> _DecodePlan:
     batch_capacity = batch_size_hint or block_table.shape[0]
     num_heads = q.shape[1]
@@ -169,6 +172,7 @@ def _get_decode_plan(
         num_kv_heads=k_cache.shape[2],
         max_seq_len_hint=effective_max_seq_len,
         batch_size_hint=batch_capacity,
+        default_partition_size=default_partition_size,
     )
     runtime_num_partitions = max(
         1,
@@ -256,6 +260,102 @@ def _get_decode_workspace_for_plan(
     )
 
 
+@dataclass
+class _DecodeWorkspaceMq:
+    tmp_out: torch.Tensor
+    max_logits: torch.Tensor
+    exp_sums: torch.Tensor
+    active_num_partitions: torch.Tensor
+    max_num_partitions: int
+
+
+def _allocate_decode_workspace_mq(
+    q: torch.Tensor,
+    *,
+    batch_capacity: int,
+    num_heads: int,
+    head_dim: int,
+    q_max: int,
+    max_num_partitions: int,
+) -> _DecodeWorkspaceMq:
+    return _DecodeWorkspaceMq(
+        tmp_out=torch.empty(
+            (batch_capacity, num_heads, q_max, max_num_partitions, head_dim),
+            dtype=torch.float16,
+            device=q.device,
+        ),
+        max_logits=torch.empty(
+            (batch_capacity, num_heads, q_max, max_num_partitions),
+            dtype=torch.float32,
+            device=q.device,
+        ),
+        exp_sums=torch.empty(
+            (batch_capacity, num_heads, q_max, max_num_partitions),
+            dtype=torch.float32,
+            device=q.device,
+        ),
+        active_num_partitions=torch.empty(
+            (1,),
+            dtype=torch.int32,
+            device=q.device,
+        ),
+        max_num_partitions=max_num_partitions,
+    )
+
+
+def _get_decode_workspace_mq_for_plan(
+    q: torch.Tensor,
+    *,
+    batch_capacity: int,
+    num_heads: int,
+    head_dim: int,
+    plan: _DecodePlan,
+    active_num_partitions: Optional[torch.Tensor] = None,
+):
+    device_index = q.device.index if q.device.index is not None else -1
+    stream_id = _workspace_stream_id(q.device)
+    key = (
+        "mq",
+        device_index,
+        stream_id,
+        batch_capacity,
+        num_heads,
+        head_dim,
+        DECODE_MQ_Q_MAX,
+        plan.partition_size,
+    )
+
+    workspace = (
+        _decode_mq_workspace_cache.get(key) if _can_cache_workspace(q) else None
+    )
+    if (
+        workspace is None
+        or workspace.max_num_partitions < plan.workspace_num_partitions
+    ):
+        workspace = _allocate_decode_workspace_mq(
+            q,
+            batch_capacity=batch_capacity,
+            num_heads=num_heads,
+            head_dim=head_dim,
+            q_max=DECODE_MQ_Q_MAX,
+            max_num_partitions=_round_decode_partition_capacity(
+                plan.workspace_num_partitions
+            ),
+        )
+        if _can_cache_workspace(q):
+            _decode_mq_workspace_cache[key] = workspace
+
+    if active_num_partitions is None:
+        workspace.active_num_partitions.fill_(plan.actual_num_partitions)
+        active_num_partitions = workspace.active_num_partitions
+    return (
+        workspace.tmp_out[:, :, :, :workspace.max_num_partitions, :],
+        workspace.max_logits[:, :, :, :workspace.max_num_partitions],
+        workspace.exp_sums[:, :, :, :workspace.max_num_partitions],
+        active_num_partitions,
+    )
+
+
 def _get_turboquant_decode_workspace(
     q_rot: torch.Tensor,
     kv_cache: torch.Tensor,
@@ -321,9 +421,15 @@ def _get_decode_partition_size(
     num_kv_heads: int,
     max_seq_len_hint: Optional[int] = None,
     batch_size_hint: Optional[int] = None,
+    default_partition_size: Optional[int] = None,
 ) -> int:
     raw = os.getenv("VLLM_FLASH_V100_DECODE_PARTITION_SIZE")
     if raw is None:
+        if default_partition_size is not None:
+            return _validate_decode_partition_size(
+                default_partition_size,
+                "default_partition_size",
+            )
         return _select_default_decode_partition_size(max_seq_len_hint)
     try:
         value = int(raw)
@@ -812,6 +918,131 @@ def flash_attn_decode_paged_xqa(
         softmax_scale,
         plan.partition_size,
         plan.launch_num_partitions,
+        kv_cache_dtype,
+        float(k_scale),
+        float(v_scale),
+        int(window_size_left),
+        int(window_size_right),
+    )
+
+
+def flash_attn_decode_paged_mq_available() -> bool:
+    return hasattr(flash_attn_v100_cuda, "decode_paged_mq_fwd")
+
+
+def _mq_default_partition_size() -> Optional[int]:
+    raw = os.getenv("VLLM_FLASH_V100_MQ_PARTITION_SIZE")
+    if raw is not None:
+        try:
+            value = int(raw)
+        except ValueError as exc:
+            raise ValueError(
+                "VLLM_FLASH_V100_MQ_PARTITION_SIZE must be one of "
+                f"{VALID_DECODE_PARTITION_SIZES}, got {raw!r}"
+            ) from exc
+        return _validate_decode_partition_size(
+            value,
+            "VLLM_FLASH_V100_MQ_PARTITION_SIZE",
+        )
+    # Default: match the legacy single-query partition sizing so multi-query
+    # outputs stay bit-identical to the folded path (the partition merge
+    # order is the only numeric difference between the two). Set
+    # VLLM_FLASH_V100_MQ_PARTITION_SIZE=512 for ~10-15% more kernel speed at
+    # 128k at the cost of ~1e-4 output drift vs the folded path.
+    return None
+
+
+def flash_attn_decode_paged_mq(
+    q: torch.Tensor,
+    k_cache: torch.Tensor,
+    v_cache: torch.Tensor,
+    block_table: torch.Tensor,
+    seq_lens: torch.Tensor,
+    query_start_loc: torch.Tensor,
+    softmax_scale: Optional[float] = None,
+    out: Optional[torch.Tensor] = None,
+    kv_cache_dtype: str = "auto",
+    k_scale: float = 1.0,
+    v_scale: float = 1.0,
+    window_size: tuple = (-1, -1),
+    max_seq_len_hint: Optional[int] = None,
+    workspace_seq_capacity_hint: Optional[int] = None,
+    active_num_partitions: Optional[torch.Tensor] = None,
+    q_len_max: Optional[int] = None,
+):
+    """Multi-query paged decode: each request contributes q_len query tokens.
+
+    ``q``/``out`` have shape [total_tokens, H, D]; ``query_start_loc`` has
+    shape [num_reqs + 1] and gives per-request token offsets; ``seq_lens``
+    holds per-request total lengths (including the new tokens). Query token j
+    of a request attends to KV positions [0, seq_len - q_len + j] inclusive.
+    Per-request q_len must be <= q_len_max <= DECODE_MQ_Q_MAX. Requests with
+    q_len == 0 or seq_len == 0 are skipped (their rows are left untouched /
+    zeroed). ``q_len_max`` should be the batch max query length (host-side);
+    it selects the kernel instantiation and defaults to DECODE_MQ_Q_MAX.
+    """
+    if not flash_attn_decode_paged_mq_available():
+        raise RuntimeError(
+            "flash_attn_v100 CUDA extension lacks multi-query decode"
+        )
+    if softmax_scale is None:
+        softmax_scale = q.shape[-1] ** -0.5
+    if q_len_max is None:
+        q_len_max = DECODE_MQ_Q_MAX
+    q_len_max = max(1, min(int(q_len_max), DECODE_MQ_Q_MAX))
+
+    q = maybe_contiguous(q)
+    block_table = maybe_contiguous(block_table)
+    seq_lens = maybe_contiguous(seq_lens)
+    query_start_loc = maybe_contiguous(query_start_loc)
+    out = maybe_contiguous(out)
+    window_size_left, window_size_right = window_size
+    if window_size_left < -1 or window_size_right < -1:
+        raise ValueError(f"Invalid window_size={window_size}; values must be >= -1")
+    num_reqs = query_start_loc.shape[0] - 1
+    num_heads = q.shape[1]
+    head_dim = q.shape[2]
+    if not _decode_dynamic_partitions_enabled():
+        max_seq_len_hint = None
+        workspace_seq_capacity_hint = None
+        active_num_partitions = None
+    plan = _get_decode_plan(
+        q,
+        k_cache,
+        block_table,
+        max_seq_len_hint=max_seq_len_hint,
+        batch_size_hint=num_reqs,
+        workspace_seq_capacity_hint=workspace_seq_capacity_hint,
+        active_num_partitions=active_num_partitions,
+        default_partition_size=_mq_default_partition_size(),
+    )
+    tmp_out, max_logits, exp_sums, active_num_partitions = (
+        _get_decode_workspace_mq_for_plan(
+            q,
+            batch_capacity=num_reqs,
+            num_heads=num_heads,
+            head_dim=head_dim,
+            plan=plan,
+            active_num_partitions=active_num_partitions,
+        )
+    )
+
+    return flash_attn_v100_cuda.decode_paged_mq_fwd(
+        q,
+        k_cache,
+        v_cache,
+        out,
+        block_table,
+        seq_lens,
+        query_start_loc,
+        tmp_out,
+        max_logits,
+        exp_sums,
+        active_num_partitions,
+        softmax_scale,
+        plan.partition_size,
+        plan.launch_num_partitions,
+        q_len_max,
         kv_cache_dtype,
         float(k_scale),
         float(v_scale),

--- a/flash-attention-v100/include/fused_mha.h
+++ b/flash-attention-v100/include/fused_mha.h
@@ -51,6 +51,29 @@ at::Tensor flash_attention_decode_paged(
     const int window_size_right
 );
 
+at::Tensor flash_attention_decode_paged_mq(
+    const at::Tensor& q,
+    const at::Tensor& k_cache,
+    const at::Tensor& v_cache,
+    std::optional<at::Tensor>& out_,
+    const at::Tensor& block_table,
+    const at::Tensor& seq_lens,
+    const at::Tensor& query_start_loc,
+    at::Tensor& tmp_out,
+    at::Tensor& max_logits,
+    at::Tensor& exp_sums,
+    const at::Tensor& active_num_partitions,
+    const float softmax_scale,
+    const int partition_size,
+    const int launch_num_partitions,
+    const int q_len_max,
+    const std::string& kv_cache_dtype,
+    const float k_scale,
+    const float v_scale,
+    const int window_size_left,
+    const int window_size_right
+);
+
 at::Tensor flash_attention_decode_paged_xqa(
     const at::Tensor& q,
     const at::Tensor& k_cache,

--- a/flash-attention-v100/kernel/flash_decode_paged.cu
+++ b/flash-attention-v100/kernel/flash_decode_paged.cu
@@ -1256,6 +1256,9 @@ at::Tensor flash_attention_decode_paged(
     case 256:
       LAUNCH_BY_PARTITION(256);
       break;
+    case 512:
+      LAUNCH_BY_PARTITION(512);
+      break;
     default:
       TORCH_CHECK(false, "Unsupported head_dim for paged decode: ", head_dim);
   }

--- a/flash-attention-v100/kernel/flash_decode_paged.cu
+++ b/flash-attention-v100/kernel/flash_decode_paged.cu
@@ -174,6 +174,417 @@ __device__ __forceinline__ float dot_qk_cache(
   }
 }
 
+// ---------------------------------------------------------------------------
+// Multi-query (small-q) paged decode: one CTA processes all q_len query
+// tokens of a request against each K/V tile, so the KV cache is read once per
+// request instead of once per query token. query_start_loc gives per-request
+// token offsets into q/out; seq_lens holds per-request total lengths
+// (including the new tokens). Query token j of a request attends to KV
+// positions [0, seq_len - q_len + j] inclusive (causal within the verify
+// block); the sliding window applies relative to each query token's own
+// position. The partition kernel is instantiated for MQ_QLEN in {1,2,4,8}
+// (MTP1..MTP7 verify shapes); callers pick the smallest MQ_QLEN covering the
+// batch's max q_len, and requests with smaller q_len take zero-filled tail
+// rows. kDecodeMqQMax caps q_len_max at 8 (smem budget at head_dim=256).
+// ---------------------------------------------------------------------------
+
+constexpr int kDecodeMqQMax = 8;
+
+__device__ __forceinline__ int decode_mq_query_limit(
+    const int seq_len, const int q_len, const int j) {
+  return max(0, min(seq_len, seq_len - q_len + j + 1));
+}
+
+template<int D, int KV_DTYPE, int MQ_QLEN>
+__device__ __forceinline__ void dot_qk_cache_mq(
+    const __half* __restrict__ q_shared,
+    const void* __restrict__ k_cache,
+    const int64_t k_index_base,
+    const int lane,
+    float* __restrict__ acc) {
+  if constexpr (KV_DTYPE == flash_v100::KV_CACHE_DTYPE_FP16) {
+    static_assert(D % 2 == 0, "Head dim must be even for half2 dot");
+    const __half2* q_ptr2 = reinterpret_cast<const __half2*>(q_shared);
+    const __half2* k_ptr2 = reinterpret_cast<const __half2*>(
+        reinterpret_cast<const __half*>(k_cache) + k_index_base);
+    #pragma unroll
+    for (int i = lane; i < D / 2; i += kWarpSize) {
+      const float2 kv = __half22float2(k_ptr2[i]);
+      #pragma unroll
+      for (int j = 0; j < MQ_QLEN; ++j) {
+        const float2 qv = __half22float2(q_ptr2[j * (D / 2) + i]);
+        acc[j] = fmaf(qv.x, kv.x, acc[j]);
+        acc[j] = fmaf(qv.y, kv.y, acc[j]);
+      }
+    }
+  } else if constexpr (KV_DTYPE == flash_v100::KV_CACHE_DTYPE_FP8_E5M2) {
+    static_assert(D % 2 == 0, "Head dim must be even for e5m2 half2 dot");
+    const __half2* q_ptr2 = reinterpret_cast<const __half2*>(q_shared);
+    #pragma unroll
+    for (int i = lane; i < D / 2; i += kWarpSize) {
+      const __half2 k_h2 = flash_v100::load_fp8_e5m2_half2_unscaled(
+          k_cache, k_index_base + static_cast<int64_t>(i) * 2);
+      const float2 kv = __half22float2(k_h2);
+      #pragma unroll
+      for (int j = 0; j < MQ_QLEN; ++j) {
+        const float2 qv = __half22float2(q_ptr2[j * (D / 2) + i]);
+        acc[j] = fmaf(qv.x, kv.x, acc[j]);
+        acc[j] = fmaf(qv.y, kv.y, acc[j]);
+      }
+    }
+  } else {
+    #pragma unroll
+    for (int d = lane; d < D; d += kWarpSize) {
+      const float kv = flash_v100::load_kv_cache_float_unscaled<KV_DTYPE>(
+          k_cache, k_index_base + d);
+      #pragma unroll
+      for (int j = 0; j < MQ_QLEN; ++j) {
+        const float qv = __half2float(q_shared[j * D + d]);
+        acc[j] = fmaf(qv, kv, acc[j]);
+      }
+    }
+  }
+}
+
+template<int NUM_WARPS, int COUNT>
+__device__ __forceinline__ void block_reduce_max_mq(
+    float* __restrict__ vals) {
+  __shared__ float shared[NUM_WARPS][COUNT];
+  __shared__ float result[COUNT];
+  const int lane = threadIdx.x % kWarpSize;
+  const int warp = threadIdx.x / kWarpSize;
+
+  #pragma unroll
+  for (int j = 0; j < COUNT; ++j) {
+    vals[j] = warp_reduce_max(vals[j]);
+  }
+  if (lane == 0) {
+    #pragma unroll
+    for (int j = 0; j < COUNT; ++j) {
+      shared[warp][j] = vals[j];
+    }
+  }
+  __syncthreads();
+
+  if (warp == 0) {
+    #pragma unroll
+    for (int j = 0; j < COUNT; ++j) {
+      float val = lane < NUM_WARPS ? shared[lane][j] : -1.0e20f;
+      val = warp_reduce_max(val);
+      if (lane == 0) {
+        result[j] = val;
+      }
+    }
+  }
+  __syncthreads();
+  #pragma unroll
+  for (int j = 0; j < COUNT; ++j) {
+    vals[j] = result[j];
+  }
+  __syncthreads();
+}
+
+template<int NUM_WARPS, int COUNT>
+__device__ __forceinline__ void block_reduce_sum_mq(
+    float* __restrict__ vals) {
+  __shared__ float shared[NUM_WARPS][COUNT];
+  __shared__ float result[COUNT];
+  const int lane = threadIdx.x % kWarpSize;
+  const int warp = threadIdx.x / kWarpSize;
+
+  #pragma unroll
+  for (int j = 0; j < COUNT; ++j) {
+    vals[j] = warp_reduce_sum(vals[j]);
+  }
+  if (lane == 0) {
+    #pragma unroll
+    for (int j = 0; j < COUNT; ++j) {
+      shared[warp][j] = vals[j];
+    }
+  }
+  __syncthreads();
+
+  if (warp == 0) {
+    #pragma unroll
+    for (int j = 0; j < COUNT; ++j) {
+      float val = lane < NUM_WARPS ? shared[lane][j] : 0.f;
+      val = warp_reduce_sum(val);
+      if (lane == 0) {
+        result[j] = val;
+      }
+    }
+  }
+  __syncthreads();
+  #pragma unroll
+  for (int j = 0; j < COUNT; ++j) {
+    vals[j] = result[j];
+  }
+  __syncthreads();
+}
+
+template<int D, int PARTITION_SIZE, int KV_DTYPE, int MQ_QLEN>
+__global__ void flash_attention_decode_partition_mq_kernel(
+    const __half* __restrict__ q,
+    const void* __restrict__ k_cache,
+    const void* __restrict__ v_cache,
+    __half* __restrict__ tmp_out,
+    float* __restrict__ max_logits,
+    float* __restrict__ exp_sums,
+    const int* __restrict__ block_table,
+    const int* __restrict__ seq_lens,
+    const int* __restrict__ query_start_loc,
+    const int* __restrict__ active_num_partitions,
+    const int num_reqs,
+    const int max_num_blocks,
+    const int max_num_partitions,
+    const int num_heads_q,
+    const int num_heads_kv,
+    const int block_size,
+    const int64_t q_stride0,
+    const int64_t q_stride1,
+    const int64_t tmp_out_stride0,
+    const int64_t tmp_out_stride1,
+    const int64_t tmp_out_stride2,
+    const int64_t tmp_out_stride3,
+    const int64_t stats_stride0,
+    const int64_t stats_stride1,
+    const int64_t stats_stride2,
+    const int64_t k_block_stride,
+    const int64_t k_token_stride,
+    const int64_t k_head_stride,
+    const int64_t v_block_stride,
+    const int64_t v_token_stride,
+    const int64_t v_head_stride,
+    const float softmax_scale,
+    const float k_scale,
+    const float v_scale,
+    const int window_size_left,
+    const int window_size_right) {
+  const int req_idx = blockIdx.x;
+  const int head_idx = blockIdx.y;
+  const int partition_idx = blockIdx.z;
+
+  if (req_idx >= num_reqs || head_idx >= num_heads_q ||
+      partition_idx >= max_num_partitions) {
+    return;
+  }
+
+  const int seq_len = seq_lens[req_idx];
+  const int q_start = query_start_loc[req_idx];
+  const int q_len = min(query_start_loc[req_idx + 1] - q_start, MQ_QLEN);
+  const int start_token_idx = partition_idx * PARTITION_SIZE;
+  if (seq_len <= 0 || q_len <= 0 || start_token_idx >= seq_len) {
+    return;
+  }
+  const int runtime_num_partitions = active_num_partitions[0];
+  const int seq_num_partitions =
+      (seq_len + PARTITION_SIZE - 1) / PARTITION_SIZE;
+  const int effective_num_partitions =
+      min(max_num_partitions, max(runtime_num_partitions, seq_num_partitions));
+  if (partition_idx >= effective_num_partitions) {
+    return;
+  }
+
+  // Token range shared by all queries of this request: the first query owns
+  // the leftmost window edge, the last query the rightmost causal edge.
+  const int query_pos_first = seq_len - q_len;
+  const int query_pos_last = seq_len - 1;
+  const int min_token_idx = window_size_left >= 0
+                                ? max(0, query_pos_first - window_size_left)
+                                : 0;
+  const int max_token_idx = window_size_right >= 0
+                                ? min(seq_len - 1,
+                                      query_pos_last + window_size_right)
+                                : seq_len - 1;
+  const int part_start = max(start_token_idx, min_token_idx);
+  const int part_end = min(start_token_idx + PARTITION_SIZE, max_token_idx + 1);
+  const int q_per_kv = num_heads_q / num_heads_kv;
+  const int kv_head_idx = head_idx / q_per_kv;
+  const int lane = threadIdx.x % kWarpSize;
+  const int warp_idx = threadIdx.x / kWarpSize;
+  const float score_scale =
+      KV_DTYPE == flash_v100::KV_CACHE_DTYPE_FP16 ? softmax_scale
+                                                  : softmax_scale * k_scale;
+
+  const int64_t tmp_out_base =
+      static_cast<int64_t>(req_idx) * tmp_out_stride0 +
+      static_cast<int64_t>(head_idx) * tmp_out_stride1 +
+      static_cast<int64_t>(partition_idx) * tmp_out_stride3;
+  const int64_t stats_base =
+      static_cast<int64_t>(req_idx) * stats_stride0 +
+      static_cast<int64_t>(head_idx) * stats_stride1;
+  if (part_start >= part_end) {
+    for (int j = 0; j < q_len; ++j) {
+      for (int d = threadIdx.x; d < D; d += blockDim.x) {
+        tmp_out[tmp_out_base + static_cast<int64_t>(j) * tmp_out_stride2 + d] =
+            __float2half(0.f);
+      }
+      if (threadIdx.x == 0) {
+        const int64_t stats_index =
+            stats_base + static_cast<int64_t>(j) * stats_stride2 +
+            partition_idx;
+        max_logits[stats_index] = -1.0e20f;
+        exp_sums[stats_index] = 0.f;
+      }
+    }
+    return;
+  }
+
+  const int part_tokens = part_end - part_start;
+
+  __shared__ __half q_shared[MQ_QLEN * D];
+  __shared__ float scores_shared[MQ_QLEN * PARTITION_SIZE];
+  // Per-token KV slot in units of tokens: physical_block * tokens_per_block
+  // (block_stride / token_stride) + block_offset. Works both for contiguous
+  // [block, token, head, dim] caches (tokens_per_block == block_size) and the
+  // interleaved [block, 2, token, head, dim] vLLM layout (== 2 * block_size);
+  // the launcher requires K and V to share the same ratio, so the flat K/V
+  // index is slot * token_stride + head * head_stride (+ d).
+  __shared__ int slot_shared[PARTITION_SIZE];
+  const int64_t tokens_per_block = k_block_stride / k_token_stride;
+
+  const __half* q_ptr = q + static_cast<int64_t>(q_start) * q_stride0 +
+                        static_cast<int64_t>(head_idx) * q_stride1;
+  for (int j = 0; j < q_len; ++j) {
+    for (int d = threadIdx.x; d < D; d += blockDim.x) {
+      q_shared[j * D + d] = q_ptr[static_cast<int64_t>(j) * q_stride0 + d];
+    }
+  }
+  // Queries beyond this request's q_len get zeroed Q rows and empty windows
+  // so their dots/scores are defined values that never become valid.
+  #pragma unroll
+  for (int j = q_len; j < MQ_QLEN; ++j) {
+    for (int d = threadIdx.x; d < D; d += blockDim.x) {
+      q_shared[j * D + d] = __float2half(0.f);
+    }
+  }
+  for (int i = threadIdx.x; i < part_tokens; i += blockDim.x) {
+    const int token_idx = part_start + i;
+    const int logical_block = token_idx / block_size;
+    slot_shared[i] =
+        block_table[req_idx * max_num_blocks + logical_block] *
+            tokens_per_block +
+        (token_idx - logical_block * block_size);
+  }
+  __syncthreads();
+
+  int qlimit[MQ_QLEN];
+  int qmin[MQ_QLEN];
+  int qmax[MQ_QLEN];
+  #pragma unroll
+  for (int j = 0; j < MQ_QLEN; ++j) {
+    if (j < q_len) {
+      qlimit[j] = decode_mq_query_limit(seq_len, q_len, j);
+      const int query_pos_j = qlimit[j] - 1;
+      qmin[j] = window_size_left >= 0
+                    ? max(0, query_pos_j - window_size_left)
+                    : 0;
+      qmax[j] = window_size_right >= 0
+                    ? min(seq_len - 1, query_pos_j + window_size_right)
+                    : seq_len - 1;
+    } else {
+      qlimit[j] = 0;
+      qmin[j] = 0;
+      qmax[j] = -1;
+    }
+  }
+
+  float part_max[MQ_QLEN];
+  #pragma unroll
+  for (int j = 0; j < MQ_QLEN; ++j) {
+    part_max[j] = -1.0e20f;
+  }
+  for (int token_local = warp_idx; token_local < part_tokens;
+       token_local += kWarpsPerBlock) {
+    const int token_abs = part_start + token_local;
+    const int64_t k_index =
+        static_cast<int64_t>(slot_shared[token_local]) * k_token_stride +
+        static_cast<int64_t>(kv_head_idx) * k_head_stride;
+
+    float acc[MQ_QLEN];
+    #pragma unroll
+    for (int j = 0; j < MQ_QLEN; ++j) {
+      acc[j] = 0.f;
+    }
+    dot_qk_cache_mq<D, KV_DTYPE, MQ_QLEN>(q_shared, k_cache, k_index, lane,
+                                          acc);
+    #pragma unroll
+    for (int j = 0; j < MQ_QLEN; ++j) {
+      acc[j] = warp_reduce_sum(acc[j]);
+      if (lane == 0) {
+        const float score = acc[j] * score_scale;
+        scores_shared[j * PARTITION_SIZE + token_local] = score;
+        if (token_abs < qlimit[j] && token_abs >= qmin[j] &&
+            token_abs <= qmax[j]) {
+          part_max[j] = fmaxf(part_max[j], score);
+        }
+      }
+    }
+  }
+  block_reduce_max_mq<kWarpsPerBlock, MQ_QLEN>(part_max);
+
+  float part_sum[MQ_QLEN];
+  #pragma unroll
+  for (int j = 0; j < MQ_QLEN; ++j) {
+    part_sum[j] = 0.f;
+  }
+  for (int i = threadIdx.x; i < part_tokens; i += blockDim.x) {
+    const int token_abs = part_start + i;
+    #pragma unroll
+    for (int j = 0; j < MQ_QLEN; ++j) {
+      const bool valid =
+          token_abs < qlimit[j] && token_abs >= qmin[j] &&
+          token_abs <= qmax[j];
+      const float p =
+          valid ? __expf(scores_shared[j * PARTITION_SIZE + i] - part_max[j])
+                : 0.f;
+      scores_shared[j * PARTITION_SIZE + i] = p;
+      part_sum[j] += p;
+    }
+  }
+  block_reduce_sum_mq<kWarpsPerBlock, MQ_QLEN>(part_sum);
+
+  for (int d = threadIdx.x; d < D; d += blockDim.x) {
+    float out_acc[MQ_QLEN];
+    #pragma unroll
+    for (int j = 0; j < MQ_QLEN; ++j) {
+      out_acc[j] = 0.f;
+    }
+    for (int i = 0; i < part_tokens; ++i) {
+      const int64_t v_index =
+          static_cast<int64_t>(slot_shared[i]) * v_token_stride +
+          static_cast<int64_t>(kv_head_idx) * v_head_stride + d;
+      const float vv = flash_v100::load_kv_cache_float_unscaled<KV_DTYPE>(
+          v_cache, v_index);
+      #pragma unroll
+      for (int j = 0; j < MQ_QLEN; ++j) {
+        out_acc[j] =
+            fmaf(scores_shared[j * PARTITION_SIZE + i], vv, out_acc[j]);
+      }
+    }
+    #pragma unroll
+    for (int j = 0; j < MQ_QLEN; ++j) {
+      const float inv_part_sum = part_sum[j] > 0.f ? 1.f / part_sum[j] : 0.f;
+      const float out_scale =
+          KV_DTYPE == flash_v100::KV_CACHE_DTYPE_FP16
+              ? inv_part_sum
+              : inv_part_sum * v_scale;
+      tmp_out[tmp_out_base + static_cast<int64_t>(j) * tmp_out_stride2 + d] =
+          __float2half(out_acc[j] * out_scale);
+    }
+  }
+
+  if (threadIdx.x == 0) {
+    #pragma unroll
+    for (int j = 0; j < MQ_QLEN; ++j) {
+      const int64_t stats_index =
+          stats_base + static_cast<int64_t>(j) * stats_stride2 + partition_idx;
+      max_logits[stats_index] = part_max[j];
+      exp_sums[stats_index] = part_sum[j];
+    }
+  }
+}
+
 template<int D, int PARTITION_SIZE, int KV_DTYPE>
 __global__ void flash_attention_decode_partition_kernel(
     const __half* __restrict__ q,
@@ -792,6 +1203,109 @@ __global__ void flash_attention_decode_reduce_kernel(
   }
 }
 
+template<int D, int PARTITION_SIZE>
+__global__ void flash_attention_decode_reduce_mq_kernel(
+    const __half* __restrict__ tmp_out,
+    const float* __restrict__ max_logits,
+    const float* __restrict__ exp_sums,
+    const int* __restrict__ seq_lens,
+    const int* __restrict__ query_start_loc,
+    const int* __restrict__ active_num_partitions,
+    __half* __restrict__ out,
+    const int num_reqs,
+    const int max_num_partitions,
+    const int num_heads_q,
+    const int64_t tmp_out_stride0,
+    const int64_t tmp_out_stride1,
+    const int64_t tmp_out_stride2,
+    const int64_t tmp_out_stride3,
+    const int64_t stats_stride0,
+    const int64_t stats_stride1,
+    const int64_t stats_stride2,
+    const int64_t out_stride0,
+    const int64_t out_stride1) {
+  const int req_idx = blockIdx.x;
+  const int head_idx = blockIdx.y;
+
+  if (req_idx >= num_reqs || head_idx >= num_heads_q) {
+    return;
+  }
+
+  const int seq_len = seq_lens[req_idx];
+  const int q_start = query_start_loc[req_idx];
+  const int q_len =
+      min(query_start_loc[req_idx + 1] - q_start, kDecodeMqQMax);
+  if (q_len <= 0) {
+    return;
+  }
+  __half* out_ptr = out + static_cast<int64_t>(q_start) * out_stride0 +
+                    static_cast<int64_t>(head_idx) * out_stride1;
+  if (seq_len <= 0) {
+    for (int j = 0; j < q_len; ++j) {
+      for (int d = threadIdx.x; d < D; d += blockDim.x) {
+        out_ptr[static_cast<int64_t>(j) * out_stride0 + d] =
+            __float2half(0.f);
+      }
+    }
+    return;
+  }
+  const int num_partitions =
+      min(max_num_partitions,
+          (seq_len + PARTITION_SIZE - 1) / PARTITION_SIZE);
+  (void)active_num_partitions;
+
+  extern __shared__ float shared_mem[];
+  float* max_shared = shared_mem;
+  float* weight_shared = shared_mem + max_num_partitions;
+
+  const int64_t tmp_base_bh =
+      static_cast<int64_t>(req_idx) * tmp_out_stride0 +
+      static_cast<int64_t>(head_idx) * tmp_out_stride1;
+  const int64_t stats_base_bh =
+      static_cast<int64_t>(req_idx) * stats_stride0 +
+      static_cast<int64_t>(head_idx) * stats_stride1;
+
+  for (int j = 0; j < q_len; ++j) {
+    const int64_t stats_base =
+        stats_base_bh + static_cast<int64_t>(j) * stats_stride2;
+    float local_max = -1.0e20f;
+    for (int i = threadIdx.x; i < num_partitions; i += blockDim.x) {
+      const float m = max_logits[stats_base + i];
+      max_shared[i] = m;
+      local_max = fmaxf(local_max, m);
+    }
+    const float global_max = block_reduce_max<kWarpsPerBlock>(local_max);
+
+    float local_sum = 0.f;
+    for (int i = threadIdx.x; i < num_partitions; i += blockDim.x) {
+      const float weight =
+          exp_sums[stats_base + i] * __expf(max_shared[i] - global_max);
+      weight_shared[i] = weight;
+      local_sum += weight;
+    }
+    const float global_sum = block_reduce_sum<kWarpsPerBlock>(local_sum);
+    const float inv_global_sum = global_sum > 0.f ? 1.f / global_sum : 0.f;
+    __syncthreads();
+
+    const int64_t tmp_base =
+        tmp_base_bh + static_cast<int64_t>(j) * tmp_out_stride2;
+    for (int d = threadIdx.x; d < D; d += blockDim.x) {
+      float acc = 0.f;
+      for (int i = 0; i < num_partitions; ++i) {
+        acc = fmaf(
+            weight_shared[i],
+            __half2float(tmp_out[tmp_base +
+                                 static_cast<int64_t>(i) * tmp_out_stride3 +
+                                 d]),
+            acc);
+      }
+      out_ptr[static_cast<int64_t>(j) * out_stride0 + d] =
+          __float2half(acc * inv_global_sum);
+    }
+    __syncthreads();
+  }
+}
+
 template<int D, int PARTITION_SIZE, int KV_DTYPE>
 __global__ void flash_attention_decode_qk_scores_kernel(
     const __half* __restrict__ q,
@@ -961,6 +1475,102 @@ void launch_flash_attention_decode_paged(
       tmp_out.stride(2),
       max_logits.stride(0),
       max_logits.stride(1),
+      out.stride(0),
+      out.stride(1));
+}
+
+template<int D, int PARTITION_SIZE, int KV_DTYPE, int MQ_QLEN>
+void launch_flash_attention_decode_paged_mq(
+    const at::Tensor& q,
+    const at::Tensor& k_cache,
+    const at::Tensor& v_cache,
+    at::Tensor& out,
+    const at::Tensor& block_table,
+    const at::Tensor& seq_lens,
+    const at::Tensor& query_start_loc,
+    at::Tensor& tmp_out,
+    at::Tensor& max_logits,
+    at::Tensor& exp_sums,
+    const at::Tensor& active_num_partitions,
+    const float softmax_scale,
+    const int launch_num_partitions,
+    const float k_scale,
+    const float v_scale,
+    const int window_size_left,
+    const int window_size_right,
+    cudaStream_t stream) {
+  const int num_reqs = query_start_loc.size(0) - 1;
+  const int num_heads_q = q.size(1);
+  const int num_heads_kv = k_cache.size(2);
+  const int block_size = k_cache.size(1);
+  const int max_num_blocks = block_table.size(1);
+  const int max_num_partitions = launch_num_partitions;
+
+  const dim3 partition_grid(num_reqs, num_heads_q, max_num_partitions);
+  const dim3 reduce_grid(num_reqs, num_heads_q, 1);
+  const dim3 block(kThreadsPerBlock);
+  const size_t reduce_shared_mem =
+      static_cast<size_t>(2 * max_num_partitions) * sizeof(float);
+
+  flash_attention_decode_partition_mq_kernel<D, PARTITION_SIZE, KV_DTYPE,
+                                             MQ_QLEN>
+      <<<partition_grid, block, 0, stream>>>(
+      reinterpret_cast<const __half*>(q.data_ptr<at::Half>()),
+      k_cache.data_ptr(),
+      v_cache.data_ptr(),
+      reinterpret_cast<__half*>(tmp_out.data_ptr<at::Half>()),
+      max_logits.data_ptr<float>(),
+      exp_sums.data_ptr<float>(),
+      block_table.data_ptr<int>(),
+      seq_lens.data_ptr<int>(),
+      query_start_loc.data_ptr<int>(),
+      active_num_partitions.data_ptr<int>(),
+      num_reqs,
+      max_num_blocks,
+      max_num_partitions,
+      num_heads_q,
+      num_heads_kv,
+      block_size,
+      q.stride(0),
+      q.stride(1),
+      tmp_out.stride(0),
+      tmp_out.stride(1),
+      tmp_out.stride(2),
+      tmp_out.stride(3),
+      max_logits.stride(0),
+      max_logits.stride(1),
+      max_logits.stride(2),
+      k_cache.stride(0),
+      k_cache.stride(1),
+      k_cache.stride(2),
+      v_cache.stride(0),
+      v_cache.stride(1),
+      v_cache.stride(2),
+      softmax_scale,
+      k_scale,
+      v_scale,
+      window_size_left,
+      window_size_right);
+
+  flash_attention_decode_reduce_mq_kernel<D, PARTITION_SIZE>
+      <<<reduce_grid, block, reduce_shared_mem, stream>>>(
+      reinterpret_cast<const __half*>(tmp_out.data_ptr<at::Half>()),
+      max_logits.data_ptr<float>(),
+      exp_sums.data_ptr<float>(),
+      seq_lens.data_ptr<int>(),
+      query_start_loc.data_ptr<int>(),
+      active_num_partitions.data_ptr<int>(),
+      reinterpret_cast<__half*>(out.data_ptr<at::Half>()),
+      num_reqs,
+      max_num_partitions,
+      num_heads_q,
+      tmp_out.stride(0),
+      tmp_out.stride(1),
+      tmp_out.stride(2),
+      tmp_out.stride(3),
+      max_logits.stride(0),
+      max_logits.stride(1),
+      max_logits.stride(2),
       out.stride(0),
       out.stride(1));
 }
@@ -1266,6 +1876,239 @@ at::Tensor flash_attention_decode_paged(
   #undef LAUNCH_BY_PARTITION
   #undef LAUNCH_BY_KV_DTYPE
   #undef LAUNCH_TYPED
+
+  C10_CUDA_KERNEL_LAUNCH_CHECK();
+  return out;
+}
+
+at::Tensor flash_attention_decode_paged_mq(
+    const at::Tensor& q,
+    const at::Tensor& k_cache,
+    const at::Tensor& v_cache,
+    std::optional<at::Tensor>& out_,
+    const at::Tensor& block_table,
+    const at::Tensor& seq_lens,
+    const at::Tensor& query_start_loc,
+    at::Tensor& tmp_out,
+    at::Tensor& max_logits,
+    at::Tensor& exp_sums,
+    const at::Tensor& active_num_partitions,
+    const float softmax_scale,
+    const int partition_size,
+    const int launch_num_partitions,
+    const int q_len_max,
+    const std::string& kv_cache_dtype,
+    const float k_scale,
+    const float v_scale,
+    const int window_size_left,
+    const int window_size_right) {
+  TORCH_CHECK(q.is_cuda(), "q must be on CUDA");
+  TORCH_CHECK(k_cache.is_cuda() && v_cache.is_cuda(), "k/v cache must be on CUDA");
+  TORCH_CHECK(block_table.is_cuda() && seq_lens.is_cuda(),
+              "block_table and seq_lens must be on CUDA");
+  TORCH_CHECK(query_start_loc.is_cuda(), "query_start_loc must be on CUDA");
+  TORCH_CHECK(tmp_out.is_cuda() && max_logits.is_cuda() && exp_sums.is_cuda(),
+              "workspace tensors must be on CUDA");
+  TORCH_CHECK(active_num_partitions.is_cuda(),
+              "active_num_partitions must be on CUDA");
+  TORCH_CHECK(q.dtype() == torch::kFloat16, "q must be fp16");
+  const int kv_dtype_code = kv_cache_dtype_code_from_string(kv_cache_dtype);
+  TORCH_CHECK(kv_dtype_code >= 0, "Unsupported kv_cache_dtype: ", kv_cache_dtype);
+  if (kv_dtype_code == flash_v100::KV_CACHE_DTYPE_FP16) {
+    TORCH_CHECK(k_cache.dtype() == torch::kFloat16, "k_cache must be fp16");
+    TORCH_CHECK(v_cache.dtype() == torch::kFloat16, "v_cache must be fp16");
+  } else {
+    TORCH_CHECK(k_cache.dtype() == torch::kUInt8,
+                "fp8 k_cache must be stored as uint8");
+    TORCH_CHECK(v_cache.dtype() == torch::kUInt8,
+                "fp8 v_cache must be stored as uint8");
+    TORCH_CHECK(k_scale > 0.f && v_scale > 0.f,
+                "fp8 k/v scales must be positive");
+  }
+  TORCH_CHECK(tmp_out.dtype() == torch::kFloat16, "tmp_out must be fp16");
+  TORCH_CHECK(max_logits.dtype() == torch::kFloat32, "max_logits must be fp32");
+  TORCH_CHECK(exp_sums.dtype() == torch::kFloat32, "exp_sums must be fp32");
+  TORCH_CHECK(block_table.dtype() == torch::kInt32, "block_table must be int32");
+  TORCH_CHECK(seq_lens.dtype() == torch::kInt32, "seq_lens must be int32");
+  TORCH_CHECK(query_start_loc.dtype() == torch::kInt32,
+              "query_start_loc must be int32");
+  TORCH_CHECK(active_num_partitions.dtype() == torch::kInt32,
+              "active_num_partitions must be int32");
+  TORCH_CHECK(q.dim() == 3, "q must have shape [total_tokens, H, D]");
+  TORCH_CHECK(k_cache.dim() == 4, "k_cache must have shape [num_blocks, block_size, H_kv, D]");
+  TORCH_CHECK(v_cache.dim() == 4, "v_cache must have shape [num_blocks, block_size, H_kv, D]");
+  TORCH_CHECK(block_table.dim() == 2, "block_table must have shape [B, max_num_blocks]");
+  TORCH_CHECK(seq_lens.dim() == 1, "seq_lens must have shape [B]");
+  TORCH_CHECK(query_start_loc.dim() == 1 && query_start_loc.size(0) >= 2,
+              "query_start_loc must have shape [B+1]");
+  TORCH_CHECK(tmp_out.dim() == 5,
+              "tmp_out must have shape [B, H, q_len_max, P, D]");
+  TORCH_CHECK(max_logits.dim() == 4,
+              "max_logits must have shape [B, H, q_len_max, P]");
+  TORCH_CHECK(exp_sums.dim() == 4,
+              "exp_sums must have shape [B, H, q_len_max, P]");
+  TORCH_CHECK(active_num_partitions.dim() == 1 &&
+                  active_num_partitions.numel() == 1,
+              "active_num_partitions must have shape [1]");
+  TORCH_CHECK(q.stride(-1) == 1, "q last dim must be contiguous");
+  TORCH_CHECK(k_cache.stride(-1) == 1, "k_cache last dim must be contiguous");
+  TORCH_CHECK(v_cache.stride(-1) == 1, "v_cache last dim must be contiguous");
+  TORCH_CHECK(tmp_out.stride(-1) == 1, "tmp_out last dim must be contiguous");
+  TORCH_CHECK(k_cache.stride(1) > 0 &&
+                  k_cache.stride(0) % k_cache.stride(1) == 0,
+              "multi-query decode requires the K block stride to be a "
+              "multiple of the token stride");
+  TORCH_CHECK(v_cache.stride(1) > 0 &&
+                  v_cache.stride(0) % v_cache.stride(1) == 0,
+              "multi-query decode requires the V block stride to be a "
+              "multiple of the token stride");
+  TORCH_CHECK(k_cache.stride(0) / k_cache.stride(1) ==
+                  v_cache.stride(0) / v_cache.stride(1),
+              "multi-query decode requires matching K/V block-to-token "
+              "stride ratios");
+  TORCH_CHECK(
+      k_cache.size(0) * (k_cache.stride(0) / k_cache.stride(1)) < (1LL << 31),
+      "multi-query decode KV slot overflow");
+
+  const int num_reqs = query_start_loc.size(0) - 1;
+  const int num_heads_q = q.size(1);
+  const int head_dim = q.size(2);
+  const int num_heads_kv = k_cache.size(2);
+
+  TORCH_CHECK(num_reqs <= block_table.size(0),
+              "block_table batch size must cover num_reqs");
+  TORCH_CHECK(num_reqs <= seq_lens.size(0),
+              "seq_lens batch size must cover num_reqs");
+  TORCH_CHECK(num_reqs <= tmp_out.size(0),
+              "tmp_out batch size must cover num_reqs");
+  TORCH_CHECK(num_heads_q == tmp_out.size(1), "tmp_out head dimension mismatch");
+  TORCH_CHECK(q_len_max >= 1 && q_len_max <= kDecodeMqQMax,
+              "q_len_max must be in [1, ", kDecodeMqQMax, "], got ", q_len_max);
+  TORCH_CHECK(tmp_out.size(2) >= q_len_max,
+              "tmp_out q_len dimension must cover q_len_max");
+  TORCH_CHECK(head_dim == tmp_out.size(4), "tmp_out head_dim mismatch");
+  TORCH_CHECK(max_logits.size(0) == tmp_out.size(0) &&
+                  max_logits.size(1) == tmp_out.size(1) &&
+                  max_logits.size(2) == tmp_out.size(2) &&
+                  max_logits.size(3) == tmp_out.size(3),
+              "max_logits shape mismatch");
+  TORCH_CHECK(exp_sums.sizes() == max_logits.sizes(),
+              "exp_sums shape mismatch");
+  TORCH_CHECK(num_heads_q % num_heads_kv == 0,
+              "num_heads_q must be divisible by num_heads_kv");
+  TORCH_CHECK(k_cache.size(3) == head_dim, "k_cache head_dim mismatch");
+  TORCH_CHECK(v_cache.size(3) == head_dim, "v_cache head_dim mismatch");
+  TORCH_CHECK(partition_size == 256 || partition_size == 512 || partition_size == 1024,
+              "Unsupported decode partition_size: ", partition_size);
+  TORCH_CHECK(launch_num_partitions > 0 &&
+                  launch_num_partitions <= tmp_out.size(3),
+              "launch_num_partitions must be in (0, tmp_out.size(3)]");
+  TORCH_CHECK(window_size_left >= -1 && window_size_right >= -1,
+              "window sizes must be >= -1");
+
+  at::Tensor out = out_.has_value() ? out_.value() : torch::empty_like(q);
+  TORCH_CHECK(out.is_cuda(), "out must be on CUDA");
+  TORCH_CHECK(out.dtype() == torch::kFloat16, "out must be fp16");
+  TORCH_CHECK(out.sizes() == q.sizes(), "out must have same shape as q");
+  TORCH_CHECK(out.stride(-1) == 1, "out last dim must be contiguous");
+
+  auto stream = at::cuda::getCurrentCUDAStream().stream();
+  c10::cuda::CUDAGuard device_guard(q.device());
+
+  #define LAUNCH_MQ_TYPED(HDIM, PARTITION, KV_DTYPE_CODE, QLEN)                 \
+    launch_flash_attention_decode_paged_mq<HDIM, PARTITION, KV_DTYPE_CODE,      \
+                                           QLEN>(                               \
+        q, k_cache, v_cache, out, block_table, seq_lens, query_start_loc,       \
+        tmp_out, max_logits, exp_sums, active_num_partitions, softmax_scale,    \
+        launch_num_partitions, k_scale, v_scale, window_size_left,              \
+        window_size_right, stream)
+
+  #define LAUNCH_MQ_BY_KV_DTYPE(HDIM, PARTITION, QLEN)                          \
+    do {                                                                        \
+      switch (kv_dtype_code) {                                                  \
+        case flash_v100::KV_CACHE_DTYPE_FP16:                                   \
+          LAUNCH_MQ_TYPED(HDIM, PARTITION, flash_v100::KV_CACHE_DTYPE_FP16,     \
+                          QLEN);                                                \
+          break;                                                                \
+        case flash_v100::KV_CACHE_DTYPE_FP8_E4M3:                               \
+          LAUNCH_MQ_TYPED(HDIM, PARTITION, flash_v100::KV_CACHE_DTYPE_FP8_E4M3, \
+                          QLEN);                                                \
+          break;                                                                \
+        case flash_v100::KV_CACHE_DTYPE_FP8_E5M2:                               \
+          LAUNCH_MQ_TYPED(HDIM, PARTITION, flash_v100::KV_CACHE_DTYPE_FP8_E5M2, \
+                          QLEN);                                                \
+          break;                                                                \
+        default:                                                                \
+          TORCH_CHECK(false, "Unsupported kv_cache_dtype: ", kv_cache_dtype);  \
+      }                                                                         \
+    } while (0)
+
+  #define LAUNCH_MQ_BY_PARTITION(HDIM, QLEN)                                    \
+    do {                                                                        \
+      switch (partition_size) {                                                 \
+        case 256:                                                               \
+          LAUNCH_MQ_BY_KV_DTYPE(HDIM, 256, QLEN);                               \
+          break;                                                                \
+        case 512:                                                               \
+          LAUNCH_MQ_BY_KV_DTYPE(HDIM, 512, QLEN);                               \
+          break;                                                                \
+        case 1024:                                                              \
+          LAUNCH_MQ_BY_KV_DTYPE(HDIM, 1024, QLEN);                              \
+          break;                                                                \
+        default:                                                                \
+          TORCH_CHECK(false, "Unsupported decode partition_size: ",             \
+                      partition_size);                                          \
+      }                                                                         \
+    } while (0)
+
+  #define LAUNCH_MQ_BY_PARTITION_FP16_ONLY(HDIM, QLEN)                          \
+    do {                                                                        \
+      switch (partition_size) {                                                 \
+        case 256:                                                               \
+          LAUNCH_MQ_TYPED(HDIM, 256, flash_v100::KV_CACHE_DTYPE_FP16, QLEN);   \
+          break;                                                                \
+        case 512:                                                               \
+          LAUNCH_MQ_TYPED(HDIM, 512, flash_v100::KV_CACHE_DTYPE_FP16, QLEN);   \
+          break;                                                                \
+        case 1024:                                                              \
+          LAUNCH_MQ_TYPED(HDIM, 1024, flash_v100::KV_CACHE_DTYPE_FP16, QLEN);  \
+          break;                                                                \
+        default:                                                                \
+          TORCH_CHECK(false, "Unsupported decode partition_size: ",             \
+                      partition_size);                                          \
+      }                                                                         \
+    } while (0)
+
+  TORCH_CHECK(head_dim == 256 || head_dim == 512,
+              "multi-query paged decode supports head_dim in {256, 512}, got ",
+              head_dim);
+  if (head_dim == 512) {
+    TORCH_CHECK(kv_dtype_code == flash_v100::KV_CACHE_DTYPE_FP16,
+                "multi-query paged decode supports fp16 KV only at "
+                "head_dim=512");
+    if (q_len_max <= 1) {
+      LAUNCH_MQ_BY_PARTITION_FP16_ONLY(512, 1);
+    } else if (q_len_max <= 2) {
+      LAUNCH_MQ_BY_PARTITION_FP16_ONLY(512, 2);
+    } else if (q_len_max <= 4) {
+      LAUNCH_MQ_BY_PARTITION_FP16_ONLY(512, 4);
+    } else {
+      LAUNCH_MQ_BY_PARTITION_FP16_ONLY(512, 8);
+    }
+  } else if (q_len_max <= 1) {
+    LAUNCH_MQ_BY_PARTITION(256, 1);
+  } else if (q_len_max <= 2) {
+    LAUNCH_MQ_BY_PARTITION(256, 2);
+  } else if (q_len_max <= 4) {
+    LAUNCH_MQ_BY_PARTITION(256, 4);
+  } else {
+    LAUNCH_MQ_BY_PARTITION(256, 8);
+  }
+
+  #undef LAUNCH_MQ_BY_PARTITION_FP16_ONLY
+  #undef LAUNCH_MQ_BY_PARTITION
+  #undef LAUNCH_MQ_BY_KV_DTYPE
+  #undef LAUNCH_MQ_TYPED
 
   C10_CUDA_KERNEL_LAUNCH_CHECK();
   return out;

--- a/flash-attention-v100/kernel/fused_mha_api.cpp
+++ b/flash-attention-v100/kernel/fused_mha_api.cpp
@@ -25,6 +25,10 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
         &flash_attention_decode_paged_xqa,
         "FlashAttention XQA decode over paged KV cache (Volta)");
     m.def(
+        "decode_paged_mq_fwd",
+        &flash_attention_decode_paged_mq,
+        "FlashAttention multi-query decode over paged KV cache (Volta)");
+    m.def(
         "decode_paged_wmma_fwd",
         &flash_attention_decode_paged_wmma,
         "FlashAttention single-query decode through paged-prefill WMMA order (Volta)");

--- a/flash-attention-v100/kernel/fused_mha_forward.cu
+++ b/flash-attention-v100/kernel/fused_mha_forward.cu
@@ -51,6 +51,10 @@ using namespace nvcuda::wmma;
 #define BLOCK_N_256 64
 #define WARPS_256   16
 
+#define BLOCK_M_512 16
+#define BLOCK_N_512 32
+#define WARPS_512   16
+
 #define BLOCK_M_256_LOW_SMEM 16
 #define BLOCK_N_256_LOW_SMEM 32
 #define WARPS_256_LOW_SMEM   16
@@ -67,9 +71,9 @@ inline bool env_flag_enabled_default_on(const char* name) {
 
 template<int D, bool LOW_SMEM = false>
 struct KernelConfig {
-    static constexpr int BLOCK_M = (D == 16) ? BLOCK_M_16 : (D == 32) ? BLOCK_M_32 : (D == 64) ? BLOCK_M_64 : (D == 128) ? BLOCK_M_128 : (LOW_SMEM ? BLOCK_M_256_LOW_SMEM : BLOCK_M_256);
-    static constexpr int BLOCK_N = (D == 16) ? BLOCK_N_16 : (D == 32) ? BLOCK_N_32 : (D == 64) ? BLOCK_N_64 : (D == 128) ? BLOCK_N_128 : (LOW_SMEM ? BLOCK_N_256_LOW_SMEM : BLOCK_N_256);
-    static constexpr int WARPS_PER_BLOCK = (D == 16) ? WARPS_16 : (D == 32) ? WARPS_32 : (D == 64) ? WARPS_64 : (D == 128) ? WARPS_128 : (LOW_SMEM ? WARPS_256_LOW_SMEM : WARPS_256);
+    static constexpr int BLOCK_M = (D == 16) ? BLOCK_M_16 : (D == 32) ? BLOCK_M_32 : (D == 64) ? BLOCK_M_64 : (D == 128) ? BLOCK_M_128 : (D == 512) ? BLOCK_M_512 : (LOW_SMEM ? BLOCK_M_256_LOW_SMEM : BLOCK_M_256);
+    static constexpr int BLOCK_N = (D == 16) ? BLOCK_N_16 : (D == 32) ? BLOCK_N_32 : (D == 64) ? BLOCK_N_64 : (D == 128) ? BLOCK_N_128 : (D == 512) ? BLOCK_N_512 : (LOW_SMEM ? BLOCK_N_256_LOW_SMEM : BLOCK_N_256);
+    static constexpr int WARPS_PER_BLOCK = (D == 16) ? WARPS_16 : (D == 32) ? WARPS_32 : (D == 64) ? WARPS_64 : (D == 128) ? WARPS_128 : (D == 512) ? WARPS_512 : (LOW_SMEM ? WARPS_256_LOW_SMEM : WARPS_256);
 
     static constexpr int THREADS_PER_BLOCK = WARPS_PER_BLOCK * MAX_THREADS_PER_WARP;
     static constexpr int THREADS_PER_ROW   = THREADS_PER_BLOCK / BLOCK_M;
@@ -1112,7 +1116,7 @@ std::vector<at::Tensor> flash_attention_forward(
     const int B = sizes[0], H = sizes[1], M = sizes[2], D = sizes[3];
     const int H_KV = k.size(1);
     const int N = k.size(2);
-    TORCH_CHECK(D <= 256 && D % 8 == 0 && D % 2 == 0, "D must be even, <=256, multiple of 8");
+    TORCH_CHECK(D <= 512 && D % 8 == 0 && D % 2 == 0, "D must be even, <=512, multiple of 8");
     TORCH_CHECK(H_KV > 0, "num_kv_heads must be positive");
     TORCH_CHECK(H % H_KV == 0, "num_attention_heads must be divisible by num_kv_heads");
     TORCH_CHECK(k.size(0) == B && v.size(0) == B, "K/V batch size must match Q");
@@ -1139,6 +1143,7 @@ std::vector<at::Tensor> flash_attention_forward(
         case 64:  launcher_flash_attention_forward<64>(q, k, v, out_fp16, softmax_lse, softmax_scale, is_causal, scalar_pv, window_size_left, window_size_right, stream); break;
         case 128: launcher_flash_attention_forward<128>(q, k, v, out_fp16, softmax_lse, softmax_scale, is_causal, scalar_pv, window_size_left, window_size_right, stream); break;
         case 256: launcher_flash_attention_forward<256>(q, k, v, out_fp16, softmax_lse, softmax_scale, is_causal, scalar_pv, window_size_left, window_size_right, stream); break;
+        case 512: launcher_flash_attention_forward<512>(q, k, v, out_fp16, softmax_lse, softmax_scale, is_causal, scalar_pv, window_size_left, window_size_right, stream); break;
         default: TORCH_CHECK(false, "Unsupported D: ", D);
     }
 

--- a/flash-attention-v100/kernel/fused_mha_forward_paged.cu
+++ b/flash-attention-v100/kernel/fused_mha_forward_paged.cu
@@ -68,6 +68,10 @@ int kv_cache_dtype_code_from_string(const std::string& kv_cache_dtype) {
 #define BLOCK_N_256 64
 #define WARPS_256   16
 
+#define BLOCK_M_512 16
+#define BLOCK_N_512 32
+#define WARPS_512   16
+
 #define BLOCK_M_256_LOW_SMEM 16
 #define BLOCK_N_256_LOW_SMEM 128
 #define KV_STAGE_N_256_LOW_SMEM 1
@@ -79,9 +83,9 @@ int kv_cache_dtype_code_from_string(const std::string& kv_cache_dtype) {
 template<int D, bool LOW_SMEM = false, bool LOW_SMEM_SCALAR_QK = false,
          bool LOW_SMEM_BM32 = false>
 struct KernelConfig {
-    static constexpr int BLOCK_M = (D == 16) ? BLOCK_M_16 : (D == 32) ? BLOCK_M_32 : (D == 64) ? BLOCK_M_64 : (D == 128) ? BLOCK_M_128 : (LOW_SMEM ? (LOW_SMEM_BM32 ? BLOCK_M_256 : BLOCK_M_256_LOW_SMEM) : BLOCK_M_256);
-    static constexpr int BLOCK_N = (D == 16) ? BLOCK_N_16 : (D == 32) ? BLOCK_N_32 : (D == 64) ? BLOCK_N_64 : (D == 128) ? BLOCK_N_128 : (LOW_SMEM ? (LOW_SMEM_SCALAR_QK ? BLOCK_N_256_LOW_SMEM_SCALAR_QK : BLOCK_N_256_LOW_SMEM) : BLOCK_N_256);
-    static constexpr int WARPS_PER_BLOCK = (D == 16) ? WARPS_16 : (D == 32) ? WARPS_32 : (D == 64) ? WARPS_64 : (D == 128) ? WARPS_128 : (LOW_SMEM ? WARPS_256_LOW_SMEM : WARPS_256);
+    static constexpr int BLOCK_M = (D == 16) ? BLOCK_M_16 : (D == 32) ? BLOCK_M_32 : (D == 64) ? BLOCK_M_64 : (D == 128) ? BLOCK_M_128 : (D == 512) ? BLOCK_M_512 : (LOW_SMEM ? (LOW_SMEM_BM32 ? BLOCK_M_256 : BLOCK_M_256_LOW_SMEM) : BLOCK_M_256);
+    static constexpr int BLOCK_N = (D == 16) ? BLOCK_N_16 : (D == 32) ? BLOCK_N_32 : (D == 64) ? BLOCK_N_64 : (D == 128) ? BLOCK_N_128 : (D == 512) ? BLOCK_N_512 : (LOW_SMEM ? (LOW_SMEM_SCALAR_QK ? BLOCK_N_256_LOW_SMEM_SCALAR_QK : BLOCK_N_256_LOW_SMEM) : BLOCK_N_256);
+    static constexpr int WARPS_PER_BLOCK = (D == 16) ? WARPS_16 : (D == 32) ? WARPS_32 : (D == 64) ? WARPS_64 : (D == 128) ? WARPS_128 : (D == 512) ? WARPS_512 : (LOW_SMEM ? WARPS_256_LOW_SMEM : WARPS_256);
 
     static constexpr int THREADS_PER_BLOCK = WARPS_PER_BLOCK * MAX_THREADS_PER_WARP;
     static constexpr int THREADS_PER_ROW   = THREADS_PER_BLOCK / BLOCK_M;
@@ -1874,8 +1878,8 @@ at::Tensor flash_attention_prefill_paged(
     const int D = q.size(3);
     const int num_kv_heads = k_cache.size(2);
 
-    TORCH_CHECK(D <= 256 && D % 8 == 0 && D % 2 == 0,
-                "D must be even, <=256, multiple of 8");
+    TORCH_CHECK(D <= 512 && D % 8 == 0 && D % 2 == 0,
+                "D must be even, <=512, multiple of 8");
     TORCH_CHECK(H % num_kv_heads == 0,
                 "num_heads must be divisible by num_kv_heads");
     TORCH_CHECK(window_size_left >= -1 && window_size_right >= -1,
@@ -1928,6 +1932,9 @@ at::Tensor flash_attention_prefill_paged(
             break;
         case 256:
             LAUNCH_PAGED_BY_KV(256);
+            break;
+        case 512:
+            LAUNCH_PAGED_BY_KV(512);
             break;
         default:
             TORCH_CHECK(false, "Unsupported D: ", D);

--- a/flash-attention-v100/test_fa512.py
+++ b/flash-attention-v100/test_fa512.py
@@ -1,0 +1,278 @@
+#!/usr/bin/env python3
+"""Parity test for flash-attention-v100 head_dim=512 kernels (prefill + decode).
+
+Data source: by default, real token vectors are harvested from a gemma-4
+checkpoint's embed_tokens (--model-dir), sliced per head and RMS-normalized
+to approximate the post-q_norm/k_norm/v_norm distribution seen in the model.
+If no checkpoint is available, falls back to seeded random data (deterministic,
+but with a less realistic distribution).
+
+Usage:
+    python test_fa512.py                            # all cases, random data
+    python test_fa512.py --model-dir /path/to/gemma-4-31B-it-qat-w4a16-ct
+    python test_fa512.py --bench                    # with perf measurement
+"""
+
+import argparse
+import os
+
+import torch
+import torch.nn.functional as F
+
+from flash_attn_v100 import (
+    flash_attn_decode_paged,
+    flash_attn_func,
+    flash_attn_prefill_paged,
+)
+
+EMB_KEY = "model.language_model.embed_tokens.weight"
+EMB_DIM = 5376
+BLOCK_SIZE = 16
+ATOL = 2e-2
+RTOL = 2e-2
+
+_MODEL_DIR = None
+_EMB_CACHE = None
+
+
+def harvest_embeddings(n_rows: int) -> torch.Tensor:
+    """Harvest real embedding rows (bf16->fp16, CPU).
+
+    Consecutive rows of embed_tokens are trained vectors whose heavy-tailed
+    distribution with outliers is far more representative than gaussian noise;
+    per-head slices stand in for post-norm Q/K/V. Falls back to seeded randn.
+    """
+    global _EMB_CACHE
+    if _EMB_CACHE is not None and _EMB_CACHE.shape[0] >= n_rows:
+        return _EMB_CACHE
+    safetensors = None
+    if _MODEL_DIR:
+        candidate = os.path.join(_MODEL_DIR, "model.safetensors")
+        if os.path.exists(candidate):
+            safetensors = candidate
+    if safetensors is not None:
+        from safetensors import safe_open
+
+        with safe_open(safetensors, framework="pt", device="cpu") as f:
+            rows = f.get_slice(EMB_KEY)[:n_rows, :]  # [n_rows, 5376]
+        _EMB_CACHE = rows.to(torch.float16)
+        src = f"real embeddings from {safetensors}"
+    else:
+        g = torch.Generator().manual_seed(20260718)
+        _EMB_CACHE = torch.randn(n_rows, EMB_DIM, generator=g).to(torch.float16)
+        src = "seeded random data (--model-dir not given)"
+    print(f"[harvest] {n_rows} rows, {src}, std={_EMB_CACHE.std().item():.4f}")
+    return _EMB_CACHE
+
+
+def rms_norm(x: torch.Tensor, eps: float = 1e-6) -> torch.Tensor:
+    return x / x.pow(2).mean(-1, keepdim=True).add(eps).sqrt()
+
+
+def make_real_qkv(B, H, H_kv, M, S, D, device="cuda"):
+    """Build q and paged k/v cache from harvested embeddings.
+
+    Head h takes the D-dim slice starting at (h*D)%EMB_DIM; every (b,h,m/s)
+    uses a different token row; finally RMS-normalized per head.
+
+    Note: the prefill kernel's q layout is [B, M, H, D] (seq-major, see
+    fused_mha_forward_paged.cu: q_ptr = Q + q_head_linear*M*D; the vLLM
+    backend passes query[start:end].unsqueeze(0), same layout).
+    """
+    n_q = B * H * M
+    n_kv = B * H_kv * S
+    emb = harvest_embeddings(n_q + n_kv)
+    q_rows, kv_rows = emb[:n_q], emb[n_q:n_q + n_kv]
+
+    q = torch.empty(B, M, H, D, dtype=torch.float16)  # [B,M,H,D]
+    kc = torch.empty(B, H_kv, S, D, dtype=torch.float16)
+    vc = torch.empty(B, H_kv, S, D, dtype=torch.float16)
+    for b in range(B):
+        for h in range(H):
+            base = (b * H + h) * M
+            off = (h * D) % EMB_DIM
+            seg = q_rows[base:base + M]
+            if off + D <= EMB_DIM:
+                q[b, :, h, :] = seg[:, off:off + D]
+            else:
+                q[b, :, h, :] = torch.cat(
+                    [seg[:, off:], seg[:, :D - (EMB_DIM - off)]], dim=-1)
+        for h in range(H_kv):
+            base = (b * H_kv + h) * S
+            off = (h * D) % EMB_DIM
+            off_v = ((H_kv - 1 - h) * D) % EMB_DIM
+            seg = kv_rows[base:base + S]
+            if off + D <= EMB_DIM:
+                kc[b, h] = seg[:, off:off + D]
+                vc[b, h] = seg[:, off_v:off_v + D]
+            else:
+                kc[b, h] = torch.cat(
+                    [seg[:, off:], seg[:, :D - (EMB_DIM - off)]], dim=-1)
+                vc[b, h] = torch.cat(
+                    [seg[:, off_v:], seg[:, :D - (EMB_DIM - off_v)]], dim=-1)
+    q = rms_norm(q.float()).to(torch.float16)
+    kc = rms_norm(kc.float()).to(torch.float16)
+    vc = rms_norm(vc.float()).to(torch.float16)
+    return q.to(device), kc.to(device), vc.to(device)
+
+
+def pack_paged_kv(k, v, block=BLOCK_SIZE):
+    """[B,H_kv,S,D] -> paged cache [nblocks, block, H_kv, D] + block_table."""
+    B, H_kv, S, D = k.shape
+    nblk = (S + block - 1) // block
+    total = B * nblk
+    kc = torch.zeros(total, block, H_kv, D, dtype=k.dtype, device=k.device)
+    vc = torch.zeros_like(kc)
+    table = torch.arange(total, dtype=torch.int32, device=k.device).view(B, nblk)
+    for b in range(B):
+        for i in range(S):
+            blk, off = i // block, i % block
+            kc[table[b, blk], off, :] = k[b, :, i, :]
+            vc[table[b, blk], off, :] = v[b, :, i, :]
+    return kc, vc, table
+
+
+def ref_attention(q, k, v, causal=True):
+    """fp32 reference. q [B,M,H,D] (seq-major), k/v [B,H_kv,S,D].
+
+    When chunked, q holds the last M positions of the sequence.
+    """
+    q = q.transpose(1, 2)  # -> [B,H,M,D]
+    B, H, M, D = q.shape
+    H_kv, S = k.shape[1], k.shape[2]
+    rep = H // H_kv
+    k = k.float().repeat_interleave(rep, dim=1)
+    v = v.float().repeat_interleave(rep, dim=1)
+    scores = torch.einsum("bhmd,bhsd->bhms", q.float(), k) * (D ** -0.5)
+    if causal:
+        qi = torch.arange(S - M, S, device=q.device).view(M, 1)
+        kj = torch.arange(S, device=q.device).view(1, S)
+        mask = kj > qi
+        scores = scores.masked_fill(mask, float("-inf"))
+    p = scores.softmax(dim=-1)
+    out = torch.einsum("bhms,bhsd->bhmd", p, v)  # [B,H,M,D]
+    return out.transpose(1, 2).to(torch.float16)  # -> [B,M,H,D]
+
+
+def compare(name, got, ref):
+    got, ref = got.float().cpu(), ref.float().cpu()
+    if got.shape != ref.shape:
+        got = got.reshape(ref.shape)
+    diff = (got - ref).abs()
+    rel = diff / ref.abs().clamp_min(1e-3)
+    ok = torch.allclose(got, ref, atol=ATOL, rtol=RTOL)
+    print(f"  {name}: max_abs={diff.max().item():.5f} "
+          f"mean_abs={diff.mean().item():.6f} "
+          f"max_rel={rel.max().item():.4f} -> {'PASS' if ok else 'FAIL'}")
+    return ok
+
+
+def case_prefill(D, B, H, H_kv, M, S, expect_fail=False, bench=False):
+    print(f"[prefill] D={D} B={B} H={H} H_kv={H_kv} M={M} S={S}")
+    q, k, v = make_real_qkv(B, H, H_kv, M, S, D)
+    kc, vc, table = pack_paged_kv(k, v)
+    seq_lens = torch.full((B,), S, dtype=torch.int32, device=q.device)
+    try:
+        if bench:
+            torch.cuda.synchronize()
+            ev0, ev1 = torch.cuda.Event(True), torch.cuda.Event(True)
+            ev0.record()
+            for _ in range(5):
+                out = flash_attn_prefill_paged(
+                    q, kc, vc, table, seq_lens, causal=True)
+            ev1.record()
+            torch.cuda.synchronize()
+            ms = ev0.elapsed_time(ev1) / 5
+            print(f"  bench: {ms:.2f} ms/iter, {B * M / (ms / 1000):.1f} tok/s")
+        else:
+            out = flash_attn_prefill_paged(
+                q, kc, vc, table, seq_lens, causal=True)
+    except RuntimeError as e:
+        print(f"  call failed: {str(e).splitlines()[0][:150]}")
+        return "EXPECTED_FAIL" if expect_fail else False
+    if expect_fail:
+        print("  expected to fail but succeeded (kernel already adapted?)")
+    ref = ref_attention(q, k, v, causal=True)
+    return compare("prefill", out, ref)
+
+
+def case_dense_prefill(D, B, H, H_kv, M, S, expect_fail=False):
+    """Dense prefill path (flash_attn_func, fused_mha_forward.cu).
+
+    The vLLM backend's no-prefix prefill goes here (flash_v100_dense_prefill),
+    q layout [B, T, H, D], M==S.
+    """
+    print(f"[dense  ] D={D} B={B} H={H} H_kv={H_kv} M={M} S={S}")
+    q, k, v = make_real_qkv(B, H, H_kv, M, S, D)  # q [B,M,H,D]; k/v [B,H_kv,S,D]
+    kd = k.transpose(1, 2).contiguous()  # [B,S,H_kv,D]
+    vd = v.transpose(1, 2).contiguous()
+    try:
+        out = flash_attn_func(q, kd, vd, causal=True)
+    except RuntimeError as e:
+        print(f"  call failed: {str(e).splitlines()[0][:150]}")
+        return "EXPECTED_FAIL" if expect_fail else False
+    ref = ref_attention(q, k, v, causal=True)
+    return compare("dense", out, ref)
+
+
+def case_decode(D, B, H, H_kv, S, expect_fail=False):
+    print(f"[decode ] D={D} B={B} H={H} H_kv={H_kv} S={S}")
+    q_full, k, v = make_real_qkv(B, H, H_kv, 1, S, D)  # [B,1,H,D]
+    q = q_full[:, 0]  # [B, H, D]
+    kc, vc, table = pack_paged_kv(k, v)
+    seq_lens = torch.full((B,), S, dtype=torch.int32, device=q.device)
+    try:
+        out = flash_attn_decode_paged(q, kc, vc, table, seq_lens)
+    except RuntimeError as e:
+        print(f"  call failed: {str(e).splitlines()[0][:150]}")
+        return "EXPECTED_FAIL" if expect_fail else False
+    ref = ref_attention(q_full, k, v, causal=False)[:, 0]
+    return compare("decode", out, ref)
+
+
+def main():
+    global _MODEL_DIR
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--bench", action="store_true")
+    ap.add_argument(
+        "--model-dir",
+        default=os.environ.get("FA512_MODEL_DIR"),
+        help="gemma-4 checkpoint dir for real-embedding harvest "
+             "(falls back to seeded random data when absent)",
+    )
+    args = ap.parse_args()
+    _MODEL_DIR = args.model_dir
+
+    assert torch.cuda.is_available()
+    results = {}
+
+    # A. Regression on the in-service paths (harness self-check, must PASS)
+    results["prefill_D256"] = case_prefill(256, 2, 32, 16, 256, 256)
+    results["decode_D256"] = case_decode(256, 2, 32, 16, 373)
+    results["dense_D256"] = case_dense_prefill(256, 2, 32, 16, 256, 256)
+
+    # B. Target: D=512 (must all PASS after the kernel adaptation)
+    results["prefill_D512"] = case_prefill(512, 2, 32, 4, 256, 256)
+    results["prefill_D512_chunked"] = case_prefill(512, 1, 32, 4, 64, 1024)
+    results["decode_D512"] = case_decode(512, 2, 32, 4, 373)
+    results["dense_D512"] = case_dense_prefill(512, 2, 32, 4, 256, 256)
+
+    if args.bench:
+        print("\n[perf] baseline record only (re-run to compare after changes)")
+        case_prefill(256, 2, 32, 16, 512, 512, bench=True)
+
+    print("\n===== summary =====")
+    bad = 0
+    for k, r in results.items():
+        if r == "EXPECTED_FAIL":
+            print(f"  {k}: EXPECTED_FAIL (kernel not adapted yet)")
+        elif r is True:
+            print(f"  {k}: PASS")
+        else:
+            print(f"  {k}: FAIL  <-- unexpected")
+            bad += 1
+    raise SystemExit(1 if bad else 0)
+
+
+if __name__ == "__main__":
+    main()

--- a/vllm/model_executor/models/gemma4_mm.py
+++ b/vllm/model_executor/models/gemma4_mm.py
@@ -1194,9 +1194,30 @@ class Gemma4ForConditionalGeneration(
                 pad_tensor = (pp_tensor == -1).all(dim=-1)
 
                 inputs_embeds = vt.patch_embedder(pv_tensor, pp_tensor, pad_tensor)
+
+                # HF expands a 2D bool mask into a full (B, 1, N, N) bool
+                # mask, which makes torch SDPA fall back to the math backend
+                # and materialize N x N fp16 scores per head (a ~6 GiB single
+                # allocation for 2 images at 10080 patches — OOMs the worker
+                # on memory-tight SM70 cards). Build the additive key-padding
+                # mask ourselves in the query dtype (the tower runs bf16 on
+                # this checkpoint): broadcastable (B, 1, 1, N), keeps SDPA on
+                # the memory-efficient backend, and produces bit-identical
+                # outputs (verified offline). With no padding at all, pass
+                # None.
+                if pad_tensor.any():
+                    batch_size, num_patches = pad_tensor.shape
+                    attn_mask = torch.zeros(
+                        (batch_size, 1, 1, num_patches),
+                        dtype=inputs_embeds.dtype,
+                        device=pad_tensor.device,
+                    ).masked_fill_(pad_tensor.unsqueeze(1).unsqueeze(1), float("-inf"))
+                else:
+                    attn_mask = None
+
                 encoder_outputs = vt.encoder(
                     inputs_embeds=inputs_embeds,
-                    attention_mask=~pad_tensor,
+                    attention_mask=attn_mask,
                     pixel_position_ids=pp_tensor,
                 )
                 hidden_states = encoder_outputs.last_hidden_state
@@ -1570,7 +1591,21 @@ class Gemma4ForConditionalGeneration(
             self,
             ignore_unexpected_prefixes=ignore_prefixes,
         )
-        return loader.load_weights(weights, mapper=self.hf_to_vllm_mapper)
+        loaded = loader.load_weights(weights, mapper=self.hf_to_vllm_mapper)
+
+        # The HF vision/audio towers stay in the checkpoint's bf16 dtype
+        # (the fp16 cast applied to the vLLM language stack does not cover
+        # them). torch's memory-efficient SDPA kernel rejects bf16 on SM70
+        # (fp16/fp32 only), so a bf16 tower always falls back to the math
+        # backend and materializes N x N attention scores — several GiB per
+        # encoder pass at high patch counts, OOMing memory-tight workers.
+        # Cast the towers to the language model's dtype so SDPA can take
+        # the memory-efficient path.
+        model_dtype = self.language_model.model.embed_tokens.weight.dtype
+        for tower in (self.vision_tower, self.embed_vision, self.audio_tower, self.embed_audio):
+            if tower is not None:
+                tower.to(model_dtype)
+        return loaded
 
     # ------------------------------------------------------------------ #
     # LoRA / multimodal mapping

--- a/vllm/v1/attention/backends/flash_attn_v100.py
+++ b/vllm/v1/attention/backends/flash_attn_v100.py
@@ -62,6 +62,8 @@ _logged_prefill_prefix_bfla = False
 _logged_prefill_prefix_splitkv = False
 _logged_prefill_paged_cache = False
 _logged_prefill_smallq_decode = False
+_logged_smallq_mq = False
+_logged_smallq_mq_fallback = False
 _logged_prefill_triton_safe = False
 _logged_decode_flash = False
 _logged_decode_dense_reference = False
@@ -498,6 +500,7 @@ def _get_flash_ops():
     global _flash_attn_prefill_paged
     global _flash_attn_decode_paged_wmma, _flash_attn_prefill_paged_bhmd
     global _flash_attn_prefill_paged_bfla, _flash_attn_prefill_paged_splitkv
+    global _flash_attn_decode_paged_mq
     if (
         _flash_attn_func is None
         or _flash_attn_decode_paged is None
@@ -521,6 +524,12 @@ def _get_flash_ops():
                 _flash_attn_decode_paged_xqa = flash_attn_decode_paged_xqa
             except ImportError:
                 _flash_attn_decode_paged_xqa = None
+            try:
+                from flash_attn_v100 import flash_attn_decode_paged_mq
+
+                _flash_attn_decode_paged_mq = flash_attn_decode_paged_mq
+            except ImportError:
+                _flash_attn_decode_paged_mq = None
             try:
                 from flash_attn_v100 import flash_attn_decode_paged_wmma
 
@@ -550,6 +559,7 @@ def _get_flash_ops():
             _flash_attn_bhmd_func = None
             _flash_attn_decode_paged = None
             _flash_attn_decode_paged_xqa = None
+            _flash_attn_decode_paged_mq = None
             _flash_attn_decode_paged_wmma = None
             _flash_attn_prefill_paged = None
             _flash_attn_prefill_paged_bhmd = None
@@ -565,11 +575,12 @@ def _get_flash_ops():
         _flash_attn_prefill_paged_bhmd,
         _flash_attn_prefill_paged_bfla,
         _flash_attn_prefill_paged_splitkv,
+        _flash_attn_decode_paged_mq,
     )
 
 
 def flash_v100_dense_prefill_available() -> bool:
-    flash_attn_func, _, _, _, _, _, _, _, _ = _get_flash_ops()
+    flash_attn_func, _, _, _, _, _, _, _, _, _ = _get_flash_ops()
     return flash_attn_func is not None
 
 
@@ -585,7 +596,7 @@ def flash_v100_dense_prefill(
     window_size: tuple[int, int] = (-1, -1),
 ) -> torch.Tensor:
     """Run Flash-V100 dense raw-QKV prefill without backend metadata coupling."""
-    flash_attn_func, _, _, _, _, _, _, _, _ = _get_flash_ops()
+    flash_attn_func, _, _, _, _, _, _, _, _, _ = _get_flash_ops()
     if flash_attn_func is None:
         raise RuntimeError("flash_attn_v100 dense prefill op is unavailable")
 
@@ -1386,6 +1397,8 @@ class FlashAttnV100MetadataBuilder(TritonAttentionMetadataBuilder):
         self._smallq_query_start_loc: torch.Tensor | None = None
         self._smallq_token_indices: torch.Tensor | None = None
         self._smallq_buffer_shape: tuple[int, int, int] | None = None
+        self._smallq_mq_block_table: torch.Tensor | None = None
+        self._smallq_mq_seq_lens: torch.Tensor | None = None
         self._decode_active_num_partitions: torch.Tensor | None = None
 
     def _attach_common_flash_metadata(
@@ -1695,6 +1708,12 @@ class FlashAttnV100MetadataBuilder(TritonAttentionMetadataBuilder):
     def _configured_smallq_max_model_len(self) -> int:
         return int(os.getenv("VLLM_FLASH_V100_SMALLQ_DECODE_MAX_MODEL_LEN", "0"))
 
+    def _configured_smallq_mq_enabled(self) -> bool:
+        return os.getenv("VLLM_FLASH_V100_SMALLQ_FOLD", "0") != "1"
+
+    def _configured_smallq_mq_max_query_len(self) -> int:
+        return int(os.getenv("VLLM_FLASH_V100_SMALLQ_MQ_MAX_Q", "8"))
+
     def _smallq_buffer_token_capacity(self, required_tokens: int) -> int:
         compilation_config = self.vllm_config.compilation_config
         graph_tokens = compilation_config.max_cudagraph_capture_size
@@ -1762,6 +1781,16 @@ class FlashAttnV100MetadataBuilder(TritonAttentionMetadataBuilder):
             dtype=torch.int32,
             device=self.device,
         )
+        self._smallq_mq_block_table = torch.empty(
+            (req_capacity, block_cols),
+            dtype=torch.int32,
+            device=self.device,
+        )
+        self._smallq_mq_seq_lens = torch.empty(
+            (req_capacity,),
+            dtype=torch.int32,
+            device=self.device,
+        )
         self._smallq_token_indices = torch.arange(
             token_capacity,
             dtype=torch.int32,
@@ -1779,6 +1808,9 @@ class FlashAttnV100MetadataBuilder(TritonAttentionMetadataBuilder):
         attn_metadata.smallq_query_start_loc = None
         attn_metadata.smallq_decode_max_seq_len_hint = None
         attn_metadata.smallq_decode_workspace_seq_capacity_hint = None
+        attn_metadata.smallq_mq_block_table = None
+        attn_metadata.smallq_mq_seq_lens = None
+        attn_metadata.smallq_mq_query_start_loc = None
 
     def _update_smallq_decode_metadata(
         self,
@@ -1923,6 +1955,59 @@ class FlashAttnV100MetadataBuilder(TritonAttentionMetadataBuilder):
         attn_metadata.smallq_query_start_loc = (
             self._smallq_query_start_loc[: num_reqs + 1]
         )
+
+        # Multi-query (unfolded) metadata: one batch row per request so the
+        # decode kernel reads each KV tile once per request instead of once
+        # per query token. The decode grid is baked into the CUDA graph as
+        # (num_reqs, heads, partitions); capture has no padding, so at replay
+        # the launch width must be num_query_tokens // max_query_len (uniform
+        # verify shapes), with tail requests padded as empty (q_len=0).
+        num_reqs_launch = num_reqs
+        mq_eligible = (
+            self._configured_smallq_mq_enabled()
+            and max_query_len <= self._configured_smallq_mq_max_query_len()
+        )
+        if mq_eligible and padding_tokens > 0:
+            if max_query_len <= 0 or num_query_tokens % max_query_len != 0:
+                mq_eligible = False
+            else:
+                num_reqs_launch = num_query_tokens // max_query_len
+        if num_reqs_launch < num_reqs:
+            # Defensive: mixed query lengths under graph replay would leave
+            # some requests uncovered by the launch grid; keep the folded
+            # path for those (uniform verify shapes never hit this).
+            mq_eligible = False
+        if mq_eligible:
+            assert self._smallq_buffer_shape is not None
+            _, req_capacity, _ = self._smallq_buffer_shape
+            if num_reqs_launch > req_capacity:
+                mq_eligible = False
+        if mq_eligible:
+            assert self._smallq_mq_block_table is not None
+            assert self._smallq_mq_seq_lens is not None
+            self._smallq_mq_block_table[:num_reqs].copy_(
+                block_table,
+                non_blocking=True,
+            )
+            self._smallq_mq_seq_lens[:num_reqs].copy_(
+                effective_seq_lens,
+                non_blocking=True,
+            )
+            if num_reqs_launch > num_reqs:
+                self._smallq_mq_seq_lens[num_reqs:num_reqs_launch].zero_()
+                self._smallq_query_start_loc[
+                    num_reqs + 1 : num_reqs_launch + 1
+                ].fill_(real_num_query_tokens)
+            attn_metadata.smallq_mq_block_table = (
+                self._smallq_mq_block_table[:num_reqs_launch]
+            )
+            attn_metadata.smallq_mq_seq_lens = (
+                self._smallq_mq_seq_lens[:num_reqs_launch]
+            )
+            attn_metadata.smallq_mq_query_start_loc = (
+                self._smallq_query_start_loc[: num_reqs_launch + 1]
+            )
+
         raw_seq_capacity = int(block_table.shape[1]) * int(self.block_size)
         max_seq_len_hint = int(seq_lens_cpu.max().item())
         if max_seq_len_hint > 0 and raw_seq_capacity > 0:
@@ -2085,6 +2170,7 @@ class FlashAttnV100Impl(TritonAttentionImpl):
             self.flash_attn_prefill_paged_bhmd,
             self.flash_attn_prefill_paged_bfla,
             self.flash_attn_prefill_paged_splitkv,
+            self.flash_attn_decode_paged_mq,
         ) = _get_flash_ops()
         # V100 FA2 kernels consume fp16 Q. FP8 KV cache support is implemented
         # as storage compression only, with K/V dequantized inside FA2 kernels.
@@ -2159,6 +2245,16 @@ class FlashAttnV100Impl(TritonAttentionImpl):
         )
         self.smallq_decode_max_model_len = int(
             os.getenv("VLLM_FLASH_V100_SMALLQ_DECODE_MAX_MODEL_LEN", "0")
+        )
+        # Multi-query smallq decode: the decode kernel reads KV once per
+        # request for the whole verify block instead of once per query token.
+        # VLLM_FLASH_V100_SMALLQ_FOLD=1 forces the legacy folded path.
+        self.use_smallq_mq = (
+            self.flash_attn_decode_paged_mq is not None
+            and os.getenv("VLLM_FLASH_V100_SMALLQ_FOLD", "0") != "1"
+        )
+        self.smallq_mq_max_query_len = int(
+            os.getenv("VLLM_FLASH_V100_SMALLQ_MQ_MAX_Q", "8")
         )
         self.use_decode_dense_reference = (
             os.getenv("VLLM_FLASH_V100_DECODE_DENSE_REFERENCE", "0") == "1"
@@ -4204,6 +4300,89 @@ class FlashAttnV100Impl(TritonAttentionImpl):
                     ),
                     _format_tensor_debug(persistent_query_start_loc, "smallq_qsl"),
                 )
+            mq_block_table = getattr(
+                attn_metadata,
+                "smallq_mq_block_table",
+                None,
+            )
+            mq_seq_lens = getattr(
+                attn_metadata,
+                "smallq_mq_seq_lens",
+                None,
+            )
+            mq_query_start_loc = getattr(
+                attn_metadata,
+                "smallq_mq_query_start_loc",
+                None,
+            )
+            if (
+                self.use_smallq_mq
+                and query.shape[2] in (256, 512)
+                and self._flash_v100_window_size(causal=True) == (-1, -1)
+                and mq_block_table is not None
+                and mq_seq_lens is not None
+                and mq_query_start_loc is not None
+                and int(mq_query_start_loc.shape[0]) >= 2
+            ):
+                # Multi-query decode: one kernel batch row per request reads
+                # each KV tile once for the whole verify block.
+                global _logged_smallq_mq, _logged_smallq_mq_fallback
+                if not _logged_smallq_mq:
+                    logger.info(
+                        "FLASH_ATTN_V100 smallq multi-query decode ACTIVE "
+                        "(num_reqs_launch=%d q_len_max=%d)",
+                        int(mq_query_start_loc.shape[0]) - 1,
+                        min(
+                            int(getattr(attn_metadata, "max_query_len", 1)),
+                            self.smallq_mq_max_query_len,
+                        ),
+                    )
+                    _logged_smallq_mq = True
+                self.flash_attn_decode_paged_mq(
+                    query,
+                    key_cache,
+                    value_cache,
+                    mq_block_table,
+                    mq_seq_lens,
+                    mq_query_start_loc,
+                    softmax_scale=self.scale,
+                    out=out_view,
+                    kv_cache_dtype=self.kv_cache_dtype,
+                    k_scale=float(layer._k_scale_float),
+                    v_scale=float(layer._v_scale_float),
+                    window_size=self._flash_v100_window_size(causal=True),
+                    max_seq_len_hint=getattr(
+                        attn_metadata,
+                        "smallq_decode_max_seq_len_hint",
+                        None,
+                    ),
+                    workspace_seq_capacity_hint=getattr(
+                        attn_metadata,
+                        "smallq_decode_workspace_seq_capacity_hint",
+                        None,
+                    ),
+                    q_len_max=min(
+                        int(getattr(attn_metadata, "max_query_len", 1)),
+                        self.smallq_mq_max_query_len,
+                    ),
+                )
+                _record_route("decode_scalar_paged_mq")
+                return output
+            if not _logged_smallq_mq_fallback:
+                logger.info(
+                    "FLASH_ATTN_V100 smallq multi-query decode INACTIVE, "
+                    "folded path: use_smallq_mq=%s query_shape=%s "
+                    "mq_meta=(bt=%s sl=%s qsl=%s) mq_qsl_len=%s",
+                    self.use_smallq_mq,
+                    tuple(query.shape),
+                    mq_block_table is not None,
+                    mq_seq_lens is not None,
+                    mq_query_start_loc is not None,
+                    int(mq_query_start_loc.shape[0])
+                    if mq_query_start_loc is not None
+                    else -1,
+                )
+                _logged_smallq_mq_fallback = True
             self._call_flash_attn_decode_paged(
                 query,
                 key_cache,
@@ -4274,6 +4453,41 @@ class FlashAttnV100Impl(TritonAttentionImpl):
             real_query_lens_gpu.to(dtype=attn_metadata.seq_lens.dtype),
         )
         block_table = attn_metadata.block_table[:num_seqs].clamp_min(0)
+        if (
+            self.use_smallq_mq
+            and query.shape[2] in (256, 512)
+            and self._flash_v100_window_size(causal=True) == (-1, -1)
+            and num_seqs > 0
+            and int(getattr(attn_metadata, "max_query_len", 1))
+            <= self.smallq_mq_max_query_len
+        ):
+            # Multi-query decode: one kernel batch row per request reads each
+            # KV tile once for the whole verify block. Padding tokens (beyond
+            # query_start_loc[-1]) belong to no request and are ignored.
+            self.flash_attn_decode_paged_mq(
+                query,
+                key_cache,
+                value_cache,
+                block_table,
+                effective_seq_lens.to(dtype=torch.int32),
+                query_start_loc_gpu.to(dtype=torch.int32),
+                softmax_scale=self.scale,
+                out=out_view,
+                kv_cache_dtype=self.kv_cache_dtype,
+                k_scale=float(layer._k_scale_float),
+                v_scale=float(layer._v_scale_float),
+                window_size=self._flash_v100_window_size(causal=True),
+                max_seq_len_hint=int(seq_lens.max().item()),
+                workspace_seq_capacity_hint=(
+                    int(block_table.shape[1]) * int(key_cache.shape[1])
+                ),
+                q_len_max=min(
+                    int(getattr(attn_metadata, "max_query_len", 1)),
+                    self.smallq_mq_max_query_len,
+                ),
+            )
+            _record_route("decode_scalar_paged_mq")
+            return output
         decode_block_table = torch.repeat_interleave(
             block_table,
             query_lens_gpu,

--- a/vllm/v1/attention/backends/flash_attn_v100.py
+++ b/vllm/v1/attention/backends/flash_attn_v100.py
@@ -1395,11 +1395,18 @@ class FlashAttnV100MetadataBuilder(TritonAttentionMetadataBuilder):
     ) -> None:
         attn_metadata.query_start_loc_cpu = common_attn_metadata.query_start_loc_cpu
         seq_lens_cpu = getattr(common_attn_metadata, "_seq_lens_cpu", None)
-        attn_metadata.seq_lens_cpu = (
-            seq_lens_cpu
-            if seq_lens_cpu is not None
-            else common_attn_metadata.seq_lens_cpu
-        )
+        if seq_lens_cpu is None:
+            # The deprecated seq_lens_cpu property performs a blocking D2H
+            # copy when the shadow is unset (the spec-decode draft loop
+            # invalidates it every step). That stalls the CPU behind the
+            # in-flight target forward (~12ms per draft step). The optimistic
+            # upper bound is maintained on CPU by the runner and is
+            # sufficient for every consumer on the draft decode path
+            # (decode shape hints and prefix-context detection only).
+            seq_lens_cpu = common_attn_metadata.seq_lens_cpu_upper_bound
+        if seq_lens_cpu is None:
+            seq_lens_cpu = common_attn_metadata.seq_lens_cpu
+        attn_metadata.seq_lens_cpu = seq_lens_cpu
         attn_metadata.causal = common_attn_metadata.causal
         attn_metadata.max_model_len = self.vllm_config.model_config.max_model_len
 

--- a/vllm/v1/spec_decode/gemma4.py
+++ b/vllm/v1/spec_decode/gemma4.py
@@ -46,6 +46,9 @@ class Gemma4Proposer(SpecDecodeBaseProposer):
         # advance between steps.
         self.constant_draft_positions = True
 
+        # Gemma4MTP.get_top_tokens does not accept spec_step_idx.
+        self.use_local_argmax_reduction = False
+
         # Per-group block tables for multi-group KV cache models.
         # Populated by gpu_model_runner during _prepare_inputs.
         self._per_group_block_tables: dict[int, torch.Tensor] = {}
@@ -96,7 +99,9 @@ class Gemma4Proposer(SpecDecodeBaseProposer):
                 per_layer_attn_metadata[layer_name] = attn_metadata
         return per_group_attn_metadata, per_layer_attn_metadata
 
-    def _greedy_sample(self, hidden_states: torch.Tensor) -> torch.Tensor:
+    def _greedy_sample(
+        self, hidden_states: torch.Tensor, spec_step_idx: int = 0
+    ) -> torch.Tensor:
         if self._centroids_sizes:
             T = hidden_states.shape[0]
             for size in self._centroids_sizes:
@@ -105,7 +110,7 @@ class Gemma4Proposer(SpecDecodeBaseProposer):
                     self._centroids_graphs[size].replay()
                     return self._centroids_outputs[size][:T].clone()
             return self.model.get_top_tokens(hidden_states)
-        return super()._greedy_sample(hidden_states)
+        return super()._greedy_sample(hidden_states, spec_step_idx)
 
     def _setup_centroids_cuda_graphs(self) -> None:
         """Capture CUDA graphs for centroids get_top_tokens at key sizes."""

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -604,6 +604,27 @@ class Worker(WorkerBase):
                 if not any(x in compile_range for x in all_sizes):
                     warmup_sizes.append(compile_range.end)
 
+            # torch's BACKED dynamic shapes (the default) specialize a
+            # symbol whose first-seen value is 0 or 1: if the first compiled
+            # forward runs with num_tokens == 1, batch=1 is baked into the
+            # compiled artifact, and every later guard-free call returns
+            # batch-1 outputs (e.g. hidden_states shaped [1, H] for a
+            # 4-token warmup run, tripping device-side asserts downstream).
+            # CUDA graph capture compiles largest-first, but a config whose
+            # compiled sizes are all 1 (e.g. cudagraph_capture_sizes=[1])
+            # still poisons the artifact. Prime compilation at num_tokens=2
+            # so the batch symbol stays dynamic. When max_num_batched_tokens
+            # is 1 no real batch can exceed 1, so priming is unnecessary.
+            compiled_sizes = set(cg_capture_sizes)
+            compiled_sizes.update(x for x in warmup_sizes if isinstance(x, int))
+            if (
+                compiled_sizes
+                and max(compiled_sizes) < 2
+                and (self.vllm_config.scheduler_config.max_num_batched_tokens or 0)
+                > 1
+            ):
+                warmup_sizes.append(2)
+
         # We skip EPLB here since we don't want to record dummy metrics
         for size in sorted(warmup_sizes, reverse=True):
             logger.info("Compile and warming up model for size %d", size)


### PR DESCRIPTION
## Purpose

Complete **gemma-4-31B** adaptation for V100/SM70 with the **FLASH_ATTN_V100** backend:

1. **Kernel**: the hybrid attention model (50× sliding-window layers at head_dim 256 + 10× global layers at **head_dim 512**, unified K/V) aborted at startup with `Unsupported head_dim for paged decode: 512`.
2. **Compile**: a startup crash that the SM70 0.0.3 compile graph policy exposed for any model whose first compiled batch is 1.
3. **MTP speculative decoding**: the Gemma4 MTP proposer crashed on every draft step beyond the first, and the draft metadata build stalled the CPU on a blocking D2H copy every step.
4. **Multimodal**: high-soft-token vision encoding OOMed the worker on SM70.

### 1. Kernel: head_dim=512 instantiation (24 lines across 3 files)

Previously the backend aborted at startup with `Unsupported head_dim for paged decode: 512`.

- `flash-attention-v100/kernel/flash_decode_paged.cu` — dispatch `case 512` for paged decode
- `flash-attention-v100/kernel/fused_mha_forward_paged.cu` — `Config<512>` (BLOCK_M=16, BLOCK_N=32, 16 warps) for paged prefill
- `flash-attention-v100/kernel/fused_mha_forward.cu` — same tile config for dense prefill
- Adds `flash-attention-v100/test_fa512.py` (parity harness, see Test Plan)

### 2. Compile: prime torch.compile above batch 1 (`vllm/v1/worker/gpu_worker.py`)

With the kernel adapted, startup still crashed once the 0.0.3 policy was auto-enabled: the compiled model returned `hidden_states` shaped `[1, H]` for num_tokens>1 warmup dummy runs, tripping a device-side assert in `gpu_model_runner._dummy_run`'s `hidden_states[logit_indices]` gather.

**Root cause (reproduced in a standalone torch experiment):** with BACKED dynamic shapes (the default), torch.compile specializes a symbol whose first-seen value is 0 or 1. CUDA-graph capture compiles largest-first, so configs with a capture size ≥ 2 are safe — but with `cudagraph_capture_sizes=[1]` (what our SM70 serve configs use) the *first* compiled forward runs at num_tokens=1 and batch=1 is baked into the artifact. Since vLLM drops dynamo guards by design (and the 0.0.3 policy's AOT path cannot recompile on a guard miss), every later call reuses the poisoned artifact. The defect is model-agnostic; Gemma4 was simply the first model deployed here with an all-1 compile config.

**Fix:** in `compile_or_warm_up_model`, when all compiled sizes are 1 while the scheduler can batch beyond one token, append a priming warmup at num_tokens=2 so the first trace keeps the batch dimension dynamic. Size-1 capture/replay and larger non-captured runs then both behave. This replaces the interim Gemma4-only policy guard (693a295f6, dropped from this branch); the policy now auto-enables for Gemma4 as intended.

*Residual note:* a config with no startup-time compilation at all (no capture/compile sizes) could still first-compile on a real batch-1 request — that upstream-wide hazard is out of scope here.

### 3. MTP speculative decoding fixes (`vllm/v1/spec_decode/gemma4.py`, `vllm/v1/attention/backends/flash_attn_v100.py`)

**Crash fixes:** `Gemma4Proposer._greedy_sample` did not accept the `spec_step_idx` argument passed by the base proposer loop, crashing every draft step beyond the first. `Gemma4MTP.get_top_tokens` also does not take `spec_step_idx`, so `use_local_argmax_reduction` is disabled to route through the compatible `super()._greedy_sample` path.

**D2H sync stall:** `_attach_common_flash_metadata` fell back to the deprecated `seq_lens_cpu` property whenever the `_seq_lens_cpu` shadow was unset. The spec-decode draft loop invalidates that shadow every step (`llm_base_proposer.py`), so each draft iteration issued a **blocking `seq_lens.to("cpu")` copy** that stalled the CPU behind the in-flight target forward (~12.6 ms per propose call at batch 1). The fix uses the runner-maintained `seq_lens_cpu_upper_bound` instead — kept on CPU, no sync, and sufficient for every consumer on the draft decode path (decode shape hints and prefix-context detection); the decode kernels themselves read exact lengths from device tensors. SM70 MTP proposer profile (batch=1): **loop_metadata_cpu 12.6 ms → 0.24 ms**, proposer wall 17.2 ms → 4.8 ms.

**Deployment note:** `cudagraph_capture_sizes` must be multiples of `num_speculative_tokens + 1`. With MTP and `[1,2,3,4]`, sizes round up to just `{4}` (single-request verify only) — concurrency ≥2 silently falls off the FULL cudagraph path and aggregate throughput collapses. Working config:

```
--compilation-config '{"cudagraph_mode":"full_and_piecewise","cudagraph_capture_sizes":[4,8,12,16]}' \
--speculative-config '{"method":"mtp","model":"<assistant>","num_speculative_tokens":3}'
```

Decode throughput (tok/s, greedy, 512 output tokens, TP=8, W4A16), greedy output **byte-identical** to non-MTP (lossless verified):

| Concurrency | Non-MTP | MTP=3 | Speedup |
|---|---|---|---|
| 1 | 60.1 | 120.8 | **2.0×** |
| 2 | 118.3 | 236.2 | **2.0×** |
| 4 | 232.1 | 417.1 | **1.8×** |

### 4. Multimodal: high-soft-token vision encoding memory-safe on SM70 (`vllm/model_executor/models/gemma4_mm.py`)

Two compounding defects OOMed the worker (crashing the engine) when encoding images at high max_soft_tokens (e.g. 1120, i.e. 10080 patches):

1. The HF vision/audio towers stay in the checkpoint's bf16 dtype — the fp16 cast applied to the vLLM language stack does not cover them. torch's memory-efficient SDPA kernel rejects bf16 on SM70 (fp16/fp32 only), so tower attention always fell back to the math backend and materialized N×N fp16 scores per head: a ~6 GiB single allocation for 2 images at 10080 patches, exceeding the ~1-2 GiB free outside the vLLM memory pool. Cast the towers (and embedders) to the language model's dtype in `load_weights`.
2. The 2D bool padding mask passed to the HF encoder is expanded internally to a full `(B, 1, N, N)` bool mask, which likewise forces the math SDPA backend. Build the additive key-padding mask directly in the query dtype with broadcastable shape `(B, 1, 1, N)`, keeping SDPA on the memory-efficient backend; outputs are bit-identical to the bool-mask path (verified offline), and `None` is passed when a bucket has no padding.

### Relationship to prior work (duplicate-work check)

- Checked open PRs/issues for "head_dim", "Gemma4/gemma-4", "512": only #77 (fp8 KV gather) is open — unrelated.
- **#59** ([V100/SM70] gemma-4 support, fully-FA hybrid attention) covered D=512 inside a much larger model+MTP enablement PR and was **closed unmerged** (2026-06-14). The sliding-window FA support from that line of work has since landed in the tree; the D=512 instantiation never did. This PR now carries the complete Gemma4 adaptation: kernel, compile, MTP, and multimodal.

## Test Plan

- **Kernel parity**: `flash-attention-v100/test_fa512.py` — 7 cases vs fp32 reference: dense prefill / paged prefill / paged prefill-chunked / paged decode at D=512, plus D=256 regression on all three paths. Inputs harvested from real gemma-4 `embed_tokens` rows (`--model-dir`, with seeded-random fallback).
- **Compile fix**: standalone torch repro of the 0/1 specialization (mark_dynamic + size-1 first compile + guard-free replay ⇒ size-1 outputs); then end-to-end: serve `gemma-4-31B-it-qat-w4a16-ct` (compressed-tensors W4A16, SM70 TurboMind path) with FLASH_ATTN_V100, `cudagraph_capture_sizes=[1]`, 0.0.3 policy auto-enabled — startup and chat-template generation at TP4/TP8.
- **MTP**: serve with `--speculative-config '{"method":"mtp","num_speculative_tokens":3}'`; verify no proposer crashes across long generations; greedy output compared byte-for-byte against the non-MTP baseline (identical ⇒ lossless); acceptance rate from `/metrics` (pos0 86%, pos1 74%, pos2 66%, ~3.2 tokens/step).
- **Vision**: `max_soft_tokens=1120` with 1/2/4 images per prompt — all encode and answer correctly where 2 images previously OOMed with a 6 GiB allocation. Combined with `gpu-memory-utilization=0.80` for encoder headroom.

## Test Result

Parity: **7/7 PASS** (max_abs ≤ 0.016 vs fp32 ref; D=256 paths unchanged).

Compile fix: policy auto-enables for Gemma4, priming warmup at size 2 fires, startup clean, greedy chat answers correct (`2+2` → `4`) at TP4; TP8 service verification in the comments below.

TP8, single request, prefill/decode tok/s — FLASH_ATTN_V100 vs TRITON_ATTN baseline (identical serving config):

| ctx | Triton prefill | FA prefill | speedup | Triton decode | FA decode | speedup |
|----:|----:|----:|----:|----:|----:|----:|
| 1024 | 1544.69 | 3209.64 | **2.1×** | 59.67 | 60.55 | 1.01× |
| 2048 | 1575.29 | 4828.49 | **3.1×** | 51.42 | 60.37 | 1.17× |
| 4096 | 995.07 | 4653.80 | **4.7×** | 40.46 | 59.95 | 1.48× |
| 8192 | 593.58 | 3818.40 | **6.4×** | 28.36 | 59.29 | **2.1×** |
| 16384 | 330.37 | 2905.40 | **8.8×** | 21.67 | 57.15 | **2.6×** |
| 32700 | 178.03 | 2120.39 | **11.9×** | 13.60 | 51.80 | **3.8×** |

TP4: FA completes all context lengths (32700 at 1359 t/s prefill / 46.0 t/s decode) where the Triton TP4 baseline timed out (>900 s); FA decode barely degrades with context length (60.6 → 51.8 from 1k → 32k) vs Triton (59.7 → 13.6).

---

**AI-assistance disclosure**: this change was developed and tested with AI assistance (Kimi Code). The submitting human has reviewed the diff and reproduced the key results before marking ready for review.

