### PR TITLE
[Doc] Add SM70 worktree PR workflow

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/sm70-performance.md
+++ b/.github/PULL_REQUEST_TEMPLATE/sm70-performance.md
@@ -1,0 +1,43 @@
+<!-- Use this template for 1Cat SM70/V100 performance work. -->
+
+## Scope
+
+- Integration base: `main`
+- Base SHA:
+- Task branch and worktree:
+- Related issues/PRs checked:
+- Human submitter review:
+- AI assistance:
+
+## Implementation And Dispatch
+
+- Changed path and intended workload:
+- Relevant backend/graph/MTP/cache environment gates:
+- Compatibility and rollback behavior:
+
+## Correctness And Quality
+
+- Focused tests:
+- Numerical oracle or exactness result:
+- Output-quality result:
+- Unrun gates and reason:
+
+## Performance Evidence
+
+| Metric | Baseline | Candidate | Delta | Contract |
+| --- | ---: | ---: | ---: | --- |
+| Microbenchmark | | | | |
+| Prefill | | | | |
+| TTFT | | | | |
+| Steady decode | | | | |
+
+- Model, quantization, TP/GPU topology, input/output/context lengths:
+- Sampling/MTP state, attention backend, CUDA Graph state, KV cache:
+- Commands and raw artifact paths:
+- Profiler results, if used, clearly separated from unprofiled wall time:
+
+## Risks And Follow-up
+
+- Rejected variants or negative results:
+- Remaining risks and rollback switch:
+- Follow-up work or merge dependencies:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -127,3 +127,7 @@ change and explain why**.
 - **Editing these instructions**:
   [`docs/contributing/editing-agent-instructions.md`](docs/contributing/editing-agent-instructions.md)
   — Rules for modifying AGENTS.md or any domain-specific guide it references.
+- **SM70/V100 performance engineering**:
+  [`docs/contributing/sm70-worktree-pr-workflow.md`](docs/contributing/sm70-worktree-pr-workflow.md)
+  — Mandatory isolated-worktree, evidence, and Draft-PR workflow for 1Cat
+  performance changes.

--- a/docs/contributing/sm70-worktree-pr-workflow.md
+++ b/docs/contributing/sm70-worktree-pr-workflow.md
@@ -1,0 +1,138 @@
+# SM70 Worktree And PR Workflow
+
+Use this workflow for every 1Cat SM70/V100 performance investigation, kernel
+change, model-path change, benchmark, or release fix. Its purpose is to keep
+one auditable integration line while allowing independent experiments to run
+without overwriting source, compiler caches, or measurements.
+
+## Integration Contract
+
+`onecat/main` is the default integration branch. A campaign may declare a
+different integration branch, but the owner must record it in the campaign
+handoff before work starts. Do not commit or push directly to the integration
+branch except for an explicitly authorized emergency fix.
+
+Treat the canonical checkout as read-only coordination state. It can be dirty;
+that is not permission to clean, stage, reformat, or reuse its changes. A task
+is shared only after its owned branch is pushed and has a Draft PR against the
+declared integration branch.
+
+## Start A Task
+
+Run preflight from the canonical checkout before editing:
+
+```bash
+git status --short --branch
+git remote -v
+git worktree list --porcelain
+git fetch onecat --prune
+git rev-parse onecat/main
+gh auth status
+```
+
+Record the final `onecat/main` SHA as `BASE_SHA`. Check for a related open PR
+before creating a duplicate path:
+
+```bash
+gh pr list --repo 1CatAI/1Cat-vLLM --state open --search "<area keywords>"
+```
+
+Create one branch and one worktree per scope. The helper resolves the canonical
+checkout even when it is invoked from an existing task worktree. It defaults to
+`onecat/main`; environment variables permit a declared campaign base.
+
+```bash
+tools/create-sm70-worktree.sh <short-scope>
+```
+
+The helper prints `BASE_SHA`, branch, and worktree path. Do not share any of
+those three values with another active task. Use a separate worktree for
+documentation-only and release work when it has a distinct review or rollback
+boundary.
+
+## Isolate Runtime State
+
+Git isolation alone is not enough for GPU work. Pin task-owned mutable paths
+before any build, benchmark, or server launch:
+
+```bash
+export TORCH_EXTENSIONS_DIR="$PWD/.cache/torch_extensions"
+export TORCHINDUCTOR_CACHE_DIR="$PWD/.cache/torchinductor"
+export TRITON_CACHE_DIR="$PWD/.cache/triton"
+export PROFILE_DIR="$PWD/.cache/profiles"
+mkdir -p "$PROFILE_DIR"
+```
+
+Use a task-specific tmux session, API port, benchmark-result directory, and
+compiler cache. Do not share a FlashQLA JIT cache, a build directory, a
+profiler output directory, or a persistent server between worktrees. Pass
+`$PROFILE_DIR` explicitly to each benchmark's output option. Capture the full
+command and all non-default environment variables with each result.
+
+Before GPU work, inspect GPU and Python processes. Use idle GPUs; never stop,
+reset, or preempt a process unless it is proven to belong to the task. Stop
+task-owned services when testing ends unless the user asked to keep them live.
+
+## Evidence Before Promotion
+
+Every performance PR must contain the following from the same source SHA and
+workload contract:
+
+- baseline and candidate commands, model, quantization, TP size, GPU set,
+  context/input/output lengths, sampling/MTP state, backend, graph mode, and
+  relevant cache settings;
+- numerical and output-quality evidence appropriate to the changed path;
+- focused test results and exact raw-artifact locations;
+- a before/after table that separates microbenchmark projections from measured
+  end-to-end prefill, TTFT, and steady decode results;
+- rejected variants and known risks, including profiler perturbation or
+  unavailable validation.
+
+Do not turn a profiler percentage, a kernel-only win, or a different workload
+into an endpoint speedup claim. Keep failed experiments in the worklog with a
+short cause so later work does not repeat them.
+
+## Commit, Synchronize, And Review
+
+Make small, owned commits. Stage explicit files or hunks only; do not use
+`git add -A` or stage generated build artifacts. Use signed commits:
+
+```bash
+git status --short --branch
+git diff --check
+git diff --stat
+git add <owned paths>
+git diff --cached --check
+git commit -s -m "[Kernel] Describe one SM70 change"
+```
+
+Before publishing, fetch the integration branch and compare it with the task
+branch. Rebase only an unpublished branch. Once published, merge the current
+integration branch into the task branch; do not force-push a PR branch without
+explicit coordination.
+
+```bash
+git fetch onecat --prune
+git log --oneline --left-right onecat/main...HEAD
+git push -u onecat <task-branch>
+```
+
+Open one Draft PR per scope using
+`.github/PULL_REQUEST_TEMPLATE/sm70-performance.md`. Its base must be the
+declared integration branch, normally `main`, and never `origin/main`.
+The human submitter reviews every changed line and records AI assistance in the
+PR. Promote it to Ready only after its documented quality and performance gates
+pass. Merge accepted PRs one at a time and validate the integration branch
+after hot-path changes.
+
+## Handoff And Cleanup
+
+Every handoff records the canonical repo, integration branch, `BASE_SHA`,
+owned branch, worktree, head SHA, PR URL/state, changed files, test results,
+raw artifacts, active tmux sessions, ports, GPU processes, and the next
+concrete action.
+
+After merge, verify the merge commit on `onecat/main`, stop only task-owned
+processes, preserve required artifacts, and remove the worktree only after all
+work is pushed and merged. For interrupted work, make and push an explicit WIP
+commit; never use a shared stash as handoff.

--- a/tools/create-sm70-worktree.sh
+++ b/tools/create-sm70-worktree.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# Create an isolated SM70 task worktree from the declared 1Cat integration ref.
+
+set -euo pipefail
+
+usage() {
+    cat <<'EOF'
+Usage: tools/create-sm70-worktree.sh <scope> [--base <remote/branch>] [--dry-run]
+
+Create a unique agent/sm70-* branch and sibling worktree. By default the base
+is onecat/main. Override the remote and branch with VLLM_PUSH_REMOTE and
+VLLM_INTEGRATION_BRANCH, or pass --base for a declared campaign branch.
+
+Optional environment variables:
+  VLLM_WORKTREE_ROOT    Directory for new worktrees.
+  VLLM_WORKTREE_OWNER   Branch owner prefix (default: agent).
+  VLLM_PUSH_REMOTE      Push remote (default: onecat).
+  VLLM_INTEGRATION_BRANCH  Integration branch (default: main).
+EOF
+}
+
+scope=""
+base=""
+dry_run=0
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --base)
+            [[ $# -ge 2 ]] || { usage >&2; exit 2; }
+            base="$2"
+            shift 2
+            ;;
+        --dry-run)
+            dry_run=1
+            shift
+            ;;
+        --help|-h)
+            usage
+            exit 0
+            ;;
+        -*)
+            usage >&2
+            exit 2
+            ;;
+        *)
+            [[ -z "$scope" ]] || { usage >&2; exit 2; }
+            scope="$1"
+            shift
+            ;;
+    esac
+done
+
+[[ -n "$scope" ]] || { usage >&2; exit 2; }
+[[ "$scope" =~ ^[a-z0-9][a-z0-9._-]*$ ]] || {
+    echo "scope must use lowercase letters, digits, dots, underscores, or hyphens" >&2
+    exit 2
+}
+
+repo_root="$(git rev-parse --show-toplevel)"
+common_git_dir="$(git rev-parse --git-common-dir)"
+if [[ "$common_git_dir" != /* ]]; then
+    common_git_dir="${repo_root}/${common_git_dir}"
+fi
+common_git_dir="$(cd "$common_git_dir" && pwd)"
+if [[ "$(basename "$common_git_dir")" == ".git" ]]; then
+    canonical_root="$(dirname "$common_git_dir")"
+else
+    canonical_root="$repo_root"
+fi
+push_remote="${VLLM_PUSH_REMOTE:-onecat}"
+integration_branch="${VLLM_INTEGRATION_BRANCH:-main}"
+owner="${VLLM_WORKTREE_OWNER:-agent}"
+[[ "$owner" =~ ^[a-z0-9][a-z0-9._-]*$ ]] || {
+    echo "VLLM_WORKTREE_OWNER must be a valid branch component" >&2
+    exit 2
+}
+
+if [[ -z "$base" ]]; then
+    base="${push_remote}/${integration_branch}"
+fi
+
+timestamp="$(date -u +%Y%m%d-%H%M%S)"
+branch="${owner}/sm70-${scope}-${timestamp}"
+worktree_root="${VLLM_WORKTREE_ROOT:-$(dirname "$canonical_root")/worktrees}"
+worktree="${worktree_root}/sm70-${scope}-${timestamp}"
+
+if [[ "$dry_run" -eq 1 ]]; then
+    printf 'CANONICAL=%s\nBASE=%s\nBRANCH=%s\nWORKTREE=%s\n' \
+        "$canonical_root" "$base" "$branch" "$worktree"
+    exit 0
+fi
+
+git -C "$canonical_root" remote get-url "$push_remote" >/dev/null
+git -C "$canonical_root" status --short --branch
+git -C "$canonical_root" fetch "$push_remote" --prune
+git -C "$canonical_root" rev-parse --verify "${base}^{commit}" >/dev/null
+git -C "$canonical_root" check-ref-format --branch "$branch" >/dev/null
+
+mkdir -p "$worktree_root"
+git -C "$canonical_root" worktree add -b "$branch" "$worktree" "$base"
+
+base_sha="$(git -C "$worktree" rev-parse HEAD)"
+printf 'BASE_SHA=%s\nBRANCH=%s\nWORKTREE=%s\n' \
+    "$base_sha" "$branch" "$worktree"
+git -C "$worktree" status --short --branch


### PR DESCRIPTION
## Purpose

Add the mandatory 1Cat SM70/V100 isolated-worktree and Draft-PR workflow, plus a safe worktree creation helper and a performance PR template. No related open PR was found.

## Test Plan

- `bash -n tools/create-sm70-worktree.sh`
- `tools/create-sm70-worktree.sh sm70-workflow-check --dry-run`
- `git diff --check`

## Test Result

All checks passed. The dry run correctly resolves the canonical checkout when invoked from a child worktree and proposes a sibling task worktree from `onecat/main`.

## AI Assistance

Created with Codex; human submitter review is required before promotion to Ready.