### PR TITLE
[Bugfix] Protect non-MTP SM70 GDN graph decode (#93)

### DIFF
--- a/tests/v1/attention/test_gdn_metadata_builder.py
+++ b/tests/v1/attention/test_gdn_metadata_builder.py
@@ -1025,9 +1025,7 @@ def test_sm70_qwen_gdn_full_forward_auto_protects_non_mtp(
 ):
     monkeypatch.setenv("VLLM_SM70_FLASH_V100_0DOT3_COMPILE_GRAPH", "1")
     monkeypatch.setenv("VLLM_SM70_QWEN_GDN_SPEC_CORE_OP", str(int(spec_core)))
-    monkeypatch.setenv(
-        "VLLM_SM70_QWEN_GDN_003_SPEC_CORE_OP", str(int(spec_core_003))
-    )
+    monkeypatch.setenv("VLLM_SM70_QWEN_GDN_003_SPEC_CORE_OP", str(int(spec_core_003)))
     _clear_envs_cache()
 
     assert (

--- a/tests/v1/attention/test_gdn_metadata_builder.py
+++ b/tests/v1/attention/test_gdn_metadata_builder.py
@@ -928,7 +928,7 @@ def test_spec_commit_pure_decode_consumes_padded_graph_rows_without_metadata_pat
     assert live_meta.num_accepted_tokens is not padded_accepted
 
 
-def test_sm70_qwen_gdn_full_forward_auto_is_mtp_engine_scoped(
+def test_sm70_qwen_gdn_full_forward_guard_honors_auto_flag(
     monkeypatch,
     local_gdn_model,
 ):
@@ -1005,6 +1005,37 @@ def test_sm70_qwen_gdn_full_forward_auto_is_mtp_engine_scoped(
             disabled=False,
             auto_enabled=False,
         )
+
+
+@pytest.mark.parametrize(
+    ("spec_core", "spec_core_003", "block_003_deep_mtp", "expected"),
+    [
+        (False, False, False, True),
+        (True, False, False, False),
+        (False, True, False, False),
+        (False, True, True, True),
+    ],
+)
+def test_sm70_qwen_gdn_full_forward_auto_protects_non_mtp(
+    monkeypatch,
+    spec_core,
+    spec_core_003,
+    block_003_deep_mtp,
+    expected,
+):
+    monkeypatch.setenv("VLLM_SM70_FLASH_V100_0DOT3_COMPILE_GRAPH", "1")
+    monkeypatch.setenv("VLLM_SM70_QWEN_GDN_SPEC_CORE_OP", str(int(spec_core)))
+    monkeypatch.setenv(
+        "VLLM_SM70_QWEN_GDN_003_SPEC_CORE_OP", str(int(spec_core_003))
+    )
+    _clear_envs_cache()
+
+    assert (
+        qwen_gdn._sm70_qwen_gdn_auto_full_forward_enabled(
+            block_003_deep_mtp=block_003_deep_mtp
+        )
+        is expected
+    )
 
 
 @pytest.mark.parametrize(

--- a/vllm/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py
+++ b/vllm/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py
@@ -580,6 +580,18 @@ def _sm70_qwen_gdn_block_003_spec_for_deep_native_mtp(vllm_config: object) -> bo
     )
 
 
+def _sm70_qwen_gdn_auto_full_forward_enabled(
+    *,
+    block_003_deep_mtp: bool,
+) -> bool:
+    """Enable the safe full-forward boundary for all SM70 graph engines."""
+    return (
+        envs.VLLM_SM70_FLASH_V100_0DOT3_COMPILE_GRAPH
+        and not envs.VLLM_SM70_QWEN_GDN_SPEC_CORE_OP
+        and (not envs.VLLM_SM70_QWEN_GDN_003_SPEC_CORE_OP or block_003_deep_mtp)
+    )
+
+
 def _sm70_qwen_gdn_num_speculative_tokens(vllm_config: object) -> int:
     spec_config = getattr(vllm_config, "speculative_config", None)
     return int(getattr(spec_config, "num_speculative_tokens", 0) or 0)
@@ -607,8 +619,8 @@ def _sm70_qwen_gdn_full_forward_enabled(
     # trace commonly comes from a profile/prefill batch without active spec
     # metadata.  If we re-check per-batch active metadata here, the quality
     # guard is captured as disabled and active verifier replays fall through to
-    # the split path.  The caller only sets auto_enabled for MTP engines, so
-    # no-MTP decode still keeps the lightweight standard path.
+    # the split path. The caller enables this for every SM70 graph engine, so
+    # non-MTP decode is protected from the same recurrent-state ordering bug.
     return auto_enabled
 
 
@@ -2224,11 +2236,8 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
         self.disable_sm70_qwen_gdn_full_forward = (
             envs.VLLM_SM70_QWEN_GDN_DISABLE_FULL_FORWARD and not block_003_deep_mtp
         )
-        self.auto_sm70_qwen_gdn_full_forward = (
-            envs.VLLM_SM70_FLASH_V100_0DOT3_COMPILE_GRAPH
-            and vllm_config.speculative_config is not None
-            and not envs.VLLM_SM70_QWEN_GDN_SPEC_CORE_OP
-            and (not envs.VLLM_SM70_QWEN_GDN_003_SPEC_CORE_OP or block_003_deep_mtp)
+        self.auto_sm70_qwen_gdn_full_forward = _sm70_qwen_gdn_auto_full_forward_enabled(
+            block_003_deep_mtp=block_003_deep_mtp
         )
         self.auto_sm70_qwen_gdn_spec_core = (
             envs.VLLM_SM70_FLASH_V100_0DOT3_COMPILE_GRAPH


### PR DESCRIPTION
Fixes #93.

## Purpose
Arm the existing SM70 Qwen GDN full-forward safety boundary for CUDA-graph decode regardless of whether speculative decoding is enabled. The old automatic condition required MTP, leaving non-MTP FULL graph replay on a known unsafe split recurrent-state path.

## Scope
- Preserve explicit full-forward disable and force overrides.
- Preserve speculative-core and 0.0.3 speculative-core exclusions.
- Keep the deep native MTP 0.0.3 safety fallback armed.

## Validation
- `python -m ruff check vllm/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py tests/v1/attention/test_gdn_metadata_builder.py`
- `python -m ruff format --check vllm/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py`
- `python -m pytest -q tests/v1/attention/test_gdn_metadata_builder.py -k "full_forward_auto_protects_non_mtp or blocks_003_spec_core_only_for_deep_native_mtp"` (8 passed)

## Hardware gate
The local host has an NVML/driver mismatch, so full V100 graph replay and text-quality validation remain required before this Draft PR is promoted.