### PR TITLE
[Bugfix] Stabilize SM70 FlashQLA JIT bootstrap (#108)

### DIFF
--- a/flash_qla/ops/gated_delta_rule/chunk/sm70/fused_fwd.py
+++ b/flash_qla/ops/gated_delta_rule/chunk/sm70/fused_fwd.py
@@ -10,24 +10,47 @@ import torch
 from torch.utils.cpp_extension import load
 
 _EXT = None
+_EXT_LOAD_ERROR: Exception | None = None
+
+# Passing these directly avoids PyTorch's CUDA-device auto-detection during a
+# worker's first JIT build. That detection can report no visible accelerator
+# while distributed workers are still initializing, even though the SM70
+# extension has a fixed target architecture.
+_SM70_GENCODE_FLAGS = [
+    "-gencode=arch=compute_70,code=sm_70",
+    "-gencode=arch=compute_75,code=sm_75",
+]
 
 
 def _load_ext():
-    global _EXT
+    global _EXT, _EXT_LOAD_ERROR
     if _EXT is not None:
         return _EXT
+    if _EXT_LOAD_ERROR is not None:
+        raise RuntimeError(
+            "SM70 FlashQLA JIT extension initialization previously failed. "
+            "The original compiler or loader error is chained below. "
+            "Set FLASH_QLA_SM70_VERBOSE_BUILD=1 to log the full build command."
+        ) from _EXT_LOAD_ERROR
     if not torch.cuda.is_available():
         raise RuntimeError("SM70 FlashQLA backend requires CUDA.")
 
-    os.environ.setdefault("TORCH_CUDA_ARCH_LIST", "7.0;7.5")
     src = Path(__file__).with_name("csrc") / "gdn_forward.cu"
-    _EXT = load(
-        name="flash_qla_sm70_gdn_strided",
-        sources=[str(src)],
-        extra_cuda_cflags=["-O3"],
-        extra_cflags=["-O3"],
-        verbose=bool(int(os.environ.get("FLASH_QLA_SM70_VERBOSE_BUILD", "0"))),
-    )
+    try:
+        _EXT = load(
+            name="flash_qla_sm70_gdn_strided",
+            sources=[str(src)],
+            extra_cuda_cflags=["-O3", *_SM70_GENCODE_FLAGS],
+            extra_cflags=["-O3"],
+            verbose=bool(int(os.environ.get("FLASH_QLA_SM70_VERBOSE_BUILD", "0"))),
+        )
+    except Exception as exc:
+        # ``torch.utils.cpp_extension`` marks a failed build as current in its
+        # process-local versioner. A later load then skips compilation and
+        # reports only a missing .so. Retain the first error so users see the
+        # actionable compiler failure instead.
+        _EXT_LOAD_ERROR = exc
+        raise
     return _EXT
 
 

--- a/tests/kernels/mamba/test_sm70_flashqla_extension.py
+++ b/tests/kernels/mamba/test_sm70_flashqla_extension.py
@@ -1,0 +1,67 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Unit tests for SM70 FlashQLA's JIT extension bootstrap."""
+
+from __future__ import annotations
+
+from types import ModuleType
+
+import pytest
+
+from flash_qla.ops.gated_delta_rule.chunk.sm70 import fused_fwd
+
+
+@pytest.fixture(autouse=True)
+def reset_extension_load_state(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(fused_fwd, "_EXT", None)
+    monkeypatch.setattr(fused_fwd, "_EXT_LOAD_ERROR", None)
+
+
+def test_sm70_flashqla_jit_passes_explicit_gencode_flags(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    loaded_extension = ModuleType("flash_qla_sm70_gdn_strided")
+    load_kwargs = {}
+
+    def fake_load(**kwargs):
+        load_kwargs.update(kwargs)
+        return loaded_extension
+
+    monkeypatch.setenv("TORCH_CUDA_ARCH_LIST", "")
+    monkeypatch.setattr(fused_fwd.torch.cuda, "is_available", lambda: True)
+    monkeypatch.setattr(fused_fwd, "load", fake_load)
+
+    assert fused_fwd._load_ext() is loaded_extension
+    assert load_kwargs["extra_cuda_cflags"] == [
+        "-O3",
+        "-gencode=arch=compute_70,code=sm_70",
+        "-gencode=arch=compute_75,code=sm_75",
+    ]
+    assert fused_fwd.os.environ["TORCH_CUDA_ARCH_LIST"] == ""
+
+
+def test_sm70_flashqla_jit_retains_initial_build_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    initial_error = RuntimeError("nvcc failed")
+    load_calls = 0
+
+    def failing_load(**kwargs):
+        nonlocal load_calls
+        load_calls += 1
+        raise initial_error
+
+    monkeypatch.setattr(fused_fwd.torch.cuda, "is_available", lambda: True)
+    monkeypatch.setattr(fused_fwd, "load", failing_load)
+
+    with pytest.raises(RuntimeError, match="nvcc failed"):
+        fused_fwd._load_ext()
+
+    with pytest.raises(
+        RuntimeError,
+        match="initialization previously failed",
+    ) as retry_error:
+        fused_fwd._load_ext()
+
+    assert retry_error.value.__cause__ is initial_error
+    assert load_calls == 1


### PR DESCRIPTION
Fixes #108.

## Root cause
The SM70 FlashQLA loader used `TORCH_CUDA_ARCH_LIST` only through `setdefault`, so an empty or unavailable-device state made PyTorch infer the architecture from worker-visible GPUs during JIT startup. A failed build is then cached by PyTorch's process-local extension versioner; the next load skips rebuilding and reports only a missing `.so`.

## Change
- Pass explicit SM70 and SM75 `-gencode` flags to the JIT build, independent of GPU auto-detection and the caller's `TORCH_CUDA_ARCH_LIST`.
- Retain the initial compiler/loader exception and chain it on repeated loads instead of replacing it with a misleading missing-DSO error.

## Validation
- `python -m ruff check flash_qla/ops/gated_delta_rule/chunk/sm70/fused_fwd.py tests/kernels/mamba/test_sm70_flashqla_extension.py`
- `python -m ruff format --check flash_qla/ops/gated_delta_rule/chunk/sm70/fused_fwd.py tests/kernels/mamba/test_sm70_flashqla_extension.py`
- `python -m pytest -q tests/kernels/mamba/test_sm70_flashqla_extension.py` (2 passed)
- Real offline JIT build and fresh-process load with `TORCH_CUDA_ARCH_LIST=''`, task-local `TORCH_EXTENSIONS_DIR`, CUDA 12.8, and no discoverable GPU. Generated and loaded `flash_qla_sm70_gdn_strided.so` successfully.

## Hardware gate
The local host has an NVML/driver mismatch. A real TP worker startup on V100 remains required before promoting this Draft PR.