### PR TITLE
[Bugfix] Extend SM70 non-MTP CUDA graph coverage (#89)

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -32,6 +32,7 @@ from vllm.config.utils import get_field
 from vllm.config.vllm import (
     OPTIMIZATION_LEVEL_TO_CONFIG,
     OptimizationLevel,
+    _sm70_non_spec_cudagraph_capture_sizes,
 )
 from vllm.platforms import current_platform
 
@@ -65,6 +66,32 @@ def test_v2_model_runner_env_tri_state(monkeypatch, env_value, expected):
         monkeypatch.setenv("VLLM_USE_V2_MODEL_RUNNER", env_value)
 
     assert envs.VLLM_USE_V2_MODEL_RUNNER is expected
+
+
+@pytest.mark.parametrize(
+    ("max_num_seqs", "dense_capture", "expected"),
+    [
+        (1, False, [1]),
+        (2, False, [1, 2]),
+        (3, False, [1, 2, 4]),
+        (5, False, [1, 2, 4, 8]),
+        (64, False, [1, 2, 4, 8]),
+        (5, True, [1, 2, 3, 4, 5]),
+        (80, True, list(range(1, 65))),
+    ],
+)
+def test_sm70_non_spec_cudagraph_capture_sizes(
+    max_num_seqs,
+    dense_capture,
+    expected,
+):
+    assert (
+        _sm70_non_spec_cudagraph_capture_sizes(
+            max_num_seqs=max_num_seqs,
+            dense_capture=dense_capture,
+        )
+        == expected
+    )
 
 
 @pytest.mark.parametrize(

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -206,6 +206,28 @@ def enable_mla_dual_rms_norm_fusion(cfg: "VllmConfig") -> bool:
     return rocm_aiter_ops.is_enabled() and check_aiter_fused_qk_rmsnorm()
 
 
+def _sm70_non_spec_cudagraph_capture_sizes(
+    *,
+    max_num_seqs: int,
+    dense_capture: bool,
+) -> list[int]:
+    """Return bounded SM70 decode graph sizes for a non-speculative engine.
+
+    The SM70 compile-graph policy needs a graph above batch size two for even
+    modest serving concurrency. Keep the default bounded at eight to preserve
+    the low startup and graph-memory cost of the single-request policy. The
+    existing opt-in dense mode remains available for larger services.
+    """
+    max_live_batch = max(int(max_num_seqs), 1)
+    if dense_capture:
+        return list(range(1, min(max_live_batch, 64) + 1))
+
+    capture_sizes = [1]
+    while capture_sizes[-1] < min(max_live_batch, 8):
+        capture_sizes.append(capture_sizes[-1] * 2)
+    return capture_sizes
+
+
 OPTIMIZATION_LEVEL_00 = {
     "compilation_config": {
         "pass_config": {
@@ -1324,7 +1346,10 @@ class VllmConfig:
                     CUDAGraphMode.FULL_AND_PIECEWISE
                 )
                 if self.compilation_config.cudagraph_capture_sizes is None:
-                    cudagraph_capture_sizes = [1, 2]
+                    cudagraph_capture_sizes = _sm70_non_spec_cudagraph_capture_sizes(
+                        max_num_seqs=self.scheduler_config.max_num_seqs,
+                        dense_capture=envs.VLLM_SM70_DENSE_CUDAGRAPH_CAPTURE,
+                    )
                     if (
                         self.speculative_config is not None
                         and self.speculative_config.num_speculative_tokens


### PR DESCRIPTION
Fixes #89.

## Root cause
The SM70 Flash-V100 compile-graph policy hard-coded non-MTP capture sizes to `[1, 2]`. Any decode batch of three or more requests missed CUDA graphs and fell onto a much slower fallback. This branch also bypassed the existing `VLLM_SM70_DENSE_CUDAGRAPH_CAPTURE` control, making the documented opt-in ineffective for this route.

## Change
- Default non-MTP SM70 graph capture now grows by powers of two only through batch 8, preserving single-request startup and graph-memory behavior while covering modest serving concurrency.
- `VLLM_SM70_DENSE_CUDAGRAPH_CAPTURE=1` now takes effect for this compile-graph policy and captures `1..min(max_num_seqs, 64)`.
- Explicit user `cudagraph_capture_sizes` remain untouched. MTP-specific shape logic is unchanged.

## Validation
- `python -m ruff check vllm/config/vllm.py tests/test_config.py`
- `python -m ruff format --check vllm/config/vllm.py tests/test_config.py`
- `python -m pytest -q tests/test_config.py -k sm70_non_spec_cudagraph_capture_sizes` (7 passed)

## Hardware gate
Needs a V100 non-MTP concurrency sweep to record actual graph route hits, capture startup cost, and TPOT for batch 3-8 before promotion.