### PR TITLE
[Bugfix] Resolve 1Cat CLI distribution version (#81)

### DIFF
--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -16,6 +16,38 @@ def test_version_tuple():
     assert len(version.__version_tuple__) in (3, 4, 5)
 
 
+def test_distribution_version_prefers_1cat_package(monkeypatch):
+    def distribution_version(distribution_name):
+        assert distribution_name == "1cat-vllm"
+        return "1.2.2"
+
+    monkeypatch.setattr(version.importlib.metadata, "version", distribution_version)
+
+    assert version.get_vllm_distribution_version() == "1.2.2"
+
+
+def test_distribution_version_falls_back_to_upstream_package(monkeypatch):
+    def distribution_version(distribution_name):
+        if distribution_name == "1cat-vllm":
+            raise version.importlib.metadata.PackageNotFoundError
+        assert distribution_name == "vllm"
+        return "0.13.0"
+
+    monkeypatch.setattr(version.importlib.metadata, "version", distribution_version)
+
+    assert version.get_vllm_distribution_version() == "0.13.0"
+
+
+def test_distribution_version_falls_back_to_source_version(monkeypatch):
+    def distribution_version(distribution_name):
+        raise version.importlib.metadata.PackageNotFoundError(distribution_name)
+
+    monkeypatch.setattr(version.importlib.metadata, "version", distribution_version)
+    monkeypatch.setattr(version, "__version__", "source")
+
+    assert version.get_vllm_distribution_version() == "source"
+
+
 @pytest.mark.parametrize(
     "version_tuple, version_str, expected",
     [

--- a/vllm/entrypoints/cli/main.py
+++ b/vllm/entrypoints/cli/main.py
@@ -5,11 +5,11 @@
 Note that all future modules must be lazily loaded within main
 to avoid certain eager import breakage."""
 
-import importlib.metadata
 import sys
 from importlib.util import find_spec
 
 from vllm.logger import init_logger
+from vllm.version import get_vllm_distribution_version
 
 logger = init_logger(__name__)
 
@@ -75,7 +75,7 @@ def main():
             "-v",
             "--version",
             action="version",
-            version=importlib.metadata.version("vllm"),
+            version=get_vllm_distribution_version(),
         )
         subparsers = parser.add_subparsers(required=False, dest="subparser")
         cmds = {}

--- a/vllm/entrypoints/cli/run_batch.py
+++ b/vllm/entrypoints/cli/run_batch.py
@@ -3,12 +3,12 @@
 
 import argparse
 import asyncio
-import importlib.metadata
 import typing
 
 from vllm.entrypoints.cli.types import CLISubcommand
 from vllm.entrypoints.utils import VLLM_SUBCMD_PARSER_EPILOG
 from vllm.logger import init_logger
+from vllm.version import get_vllm_distribution_version
 
 if typing.TYPE_CHECKING:
     from vllm.utils.argparse_utils import FlexibleArgumentParser
@@ -28,7 +28,7 @@ class RunBatchSubcommand(CLISubcommand):
         from vllm.entrypoints.openai.run_batch import main as run_batch_main
 
         logger.info(
-            "vLLM batch processing API version %s", importlib.metadata.version("vllm")
+            "vLLM batch processing API version %s", get_vllm_distribution_version()
         )
         logger.info("args: %s", args)
 

--- a/vllm/version.py
+++ b/vllm/version.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import importlib.metadata
+
 try:
     from ._version import __version__, __version_tuple__
 except Exception as e:
@@ -10,6 +12,16 @@ except Exception as e:
 
     __version__ = "dev"
     __version_tuple__ = (0, 0, __version__)
+
+
+def get_vllm_distribution_version() -> str:
+    """Return the installed distribution version for vLLM CLI entrypoints."""
+    for distribution_name in ("1cat-vllm", "vllm"):
+        try:
+            return importlib.metadata.version(distribution_name)
+        except importlib.metadata.PackageNotFoundError:
+            continue
+    return __version__
 
 
 def _prev_minor_version_was(version_str):


### PR DESCRIPTION
Fixes #81.

## Root cause
The project distribution is named `1cat-vllm`, while the CLI queried only `importlib.metadata.version("vllm")`. The parser creates that version action for every CLI invocation, so `vllm bench serve` could fail before command parsing when only the 1Cat distribution is installed. The same lookup existed in `vllm run-batch`.

## Change
- Add one lightweight distribution-version resolver that prefers `1cat-vllm`, falls back to upstream `vllm`, then to the embedded source version.
- Use it in the main CLI and run-batch logger.

## Validation
- `python -m ruff check vllm/version.py vllm/entrypoints/cli/main.py vllm/entrypoints/cli/run_batch.py tests/test_version.py`
- `python -m ruff format --check vllm/version.py vllm/entrypoints/cli/main.py vllm/entrypoints/cli/run_batch.py tests/test_version.py`
- `python -m pytest -q tests/test_version.py -k distribution` (3 passed)
- Direct resolver smoke returned the installed 1Cat distribution version.

## Known local test limitation
The existing six 1.x cases in `tests/test_version.py::test_prev_minor_version_was` fail before and after this change because the old helper asserts major version 0. This is a separate current defect and is intentionally not mixed into this installation-fix PR.

A direct CLI smoke is blocked locally by an unrelated installed `mistral_common` API mismatch (`NamedToolChoice`) during eager subcommand imports.