### PR TITLE
[CI/Build] Clear Python Ruff format baseline (#126)

### DIFF
--- a/benchmarks/benchmark_sm70_custom_all_reduce.py
+++ b/benchmarks/benchmark_sm70_custom_all_reduce.py
@@ -51,9 +51,7 @@ def _make_input(
     elif pattern == "random_small":
         generator = torch.Generator(device="cuda")
         generator.manual_seed(seed + rank)
-        tensor = (torch.rand(size, device="cuda", generator=generator) - 0.5).to(
-            dtype
-        )
+        tensor = (torch.rand(size, device="cuda", generator=generator) - 0.5).to(dtype)
     elif pattern == "model_like":
         generator = torch.Generator(device="cuda")
         generator.manual_seed(seed + rank)
@@ -292,12 +290,15 @@ def _make_gemma_rms_norm_inputs(
 
     shared_generator = torch.Generator(device="cuda")
     shared_generator.manual_seed(seed + 1009)
-    residual = torch.randn(
-        (tokens, _GEMMA_RMS_NORM_HIDDEN_SIZE),
-        device="cuda",
-        dtype=torch.float32,
-        generator=shared_generator,
-    ) * 0.03
+    residual = (
+        torch.randn(
+            (tokens, _GEMMA_RMS_NORM_HIDDEN_SIZE),
+            device="cuda",
+            dtype=torch.float32,
+            generator=shared_generator,
+        )
+        * 0.03
+    )
     residual = residual.to(residual_dtype)
     weight = (
         torch.randn(
@@ -857,9 +858,7 @@ def main() -> None:
             "custom_allreduce_disabled": False,
             "fully_connected": ca.fully_connected,
             "max_size_bytes": ca.max_size,
-            "sm70_tp4_m5_ar_threads": os.environ.get(
-                "VLLM_SM70_TP4_M5_AR_THREADS"
-            ),
+            "sm70_tp4_m5_ar_threads": os.environ.get("VLLM_SM70_TP4_M5_AR_THREADS"),
             "required_exact_patterns": sorted(require_exact_patterns),
             "required_exact_passed": not required_failures,
             "required_failures": required_failures[:16],

--- a/benchmarks/benchmark_sm70_flashinfer_fixed_entry.py
+++ b/benchmarks/benchmark_sm70_flashinfer_fixed_entry.py
@@ -262,9 +262,7 @@ def _active_ctas_per_sm(
     threads_per_cta: int,
     shared_bytes_per_cta: int,
 ) -> int:
-    register_limited = SM70_REGISTERS_PER_SM // (
-        registers_per_thread * threads_per_cta
-    )
+    register_limited = SM70_REGISTERS_PER_SM // (registers_per_thread * threads_per_cta)
     shared_limited = SM70_SHARED_BYTES_PER_SM // shared_bytes_per_cta
     thread_limited = SM70_THREADS_PER_SM // threads_per_cta
     return min(register_limited, shared_limited, thread_limited, SM70_MAX_CTA_PER_SM)
@@ -349,9 +347,7 @@ def _paged_resource_gate(kernel: Mapping[str, Any]) -> dict[str, Any]:
             f"requires <= {PAGED_MAX_SHARED_BYTES}"
         )
     if kernel["active_ctas_per_sm"] != 2:
-        reasons.append(
-            f"active_ctas_per_sm={kernel['active_ctas_per_sm']}, requires 2"
-        )
+        reasons.append(f"active_ctas_per_sm={kernel['active_ctas_per_sm']}, requires 2")
     instructions = kernel["instructions"]
     if instructions["hmma"] == 0:
         reasons.append("paged target has no HMMA")
@@ -616,15 +612,9 @@ def _pairwise_stats(
     return {
         "right_minus_left_mean_ms": float(statistics.mean(deltas)),
         "right_minus_left_p50_ms": float(statistics.median(deltas)),
-        "right_faster_wins": sum(
-            right_ms < left_ms for left_ms, right_ms in paired
-        ),
-        "left_faster_wins": sum(
-            left_ms < right_ms for left_ms, right_ms in paired
-        ),
-        "ties": sum(
-            left_ms == right_ms for left_ms, right_ms in paired
-        ),
+        "right_faster_wins": sum(right_ms < left_ms for left_ms, right_ms in paired),
+        "left_faster_wins": sum(left_ms < right_ms for left_ms, right_ms in paired),
+        "ties": sum(left_ms == right_ms for left_ms, right_ms in paired),
         "right_vs_left_mean_pct": (
             (right_stats["mean_ms"] / left_stats["mean_ms"] - 1.0) * 100.0
         ),

--- a/benchmarks/benchmark_sm70_flashqla_indexed_state_cache.py
+++ b/benchmarks/benchmark_sm70_flashqla_indexed_state_cache.py
@@ -71,27 +71,38 @@ def main() -> None:
     dtype = torch.float16
     scale = args.dim**-0.5
 
-    q = (torch.randn(1, args.tokens, args.q_heads, args.dim,
-                     device=device, dtype=dtype) * 0.05).contiguous()
+    q = (
+        torch.randn(1, args.tokens, args.q_heads, args.dim, device=device, dtype=dtype)
+        * 0.05
+    ).contiguous()
     k = (torch.randn_like(q) * 0.05).contiguous()
-    v = (torch.randn(1, args.tokens, args.v_heads, args.dim,
-                     device=device, dtype=dtype) * 0.1).contiguous()
-    g = (torch.randn(1, args.tokens, args.v_heads,
-                     device=device, dtype=torch.float32) * 0.02 - 0.04).contiguous()
-    beta = torch.rand(1, args.tokens, args.v_heads,
-                      device=device, dtype=torch.float32).contiguous()
+    v = (
+        torch.randn(1, args.tokens, args.v_heads, args.dim, device=device, dtype=dtype)
+        * 0.1
+    ).contiguous()
+    g = (
+        torch.randn(1, args.tokens, args.v_heads, device=device, dtype=torch.float32)
+        * 0.02
+        - 0.04
+    ).contiguous()
+    beta = torch.rand(
+        1, args.tokens, args.v_heads, device=device, dtype=torch.float32
+    ).contiguous()
     cu_seqlens = torch.tensor([0, args.tokens], device=device, dtype=torch.int32)
     state_indices = torch.tensor([args.state_index], device=device, dtype=torch.long)
     has_initial_state = torch.ones(1, device=device, dtype=torch.bool)
 
-    base_state_cache = (torch.randn(
-        args.state_slots,
-        args.v_heads,
-        args.dim,
-        args.dim,
-        device=device,
-        dtype=torch.float32,
-    ) * 0.01).contiguous()
+    base_state_cache = (
+        torch.randn(
+            args.state_slots,
+            args.v_heads,
+            args.dim,
+            args.dim,
+            device=device,
+            dtype=torch.float32,
+        )
+        * 0.01
+    ).contiguous()
     gather_cache = base_state_cache.clone()
     indexed_cache = base_state_cache.clone()
     gather_out = torch.empty_like(v)
@@ -150,8 +161,9 @@ def main() -> None:
 
     correctness = {
         "out": _diff(gather_result, indexed_result),
-        "state_slot": _diff(gather_cache[args.state_index],
-                            indexed_cache[args.state_index]),
+        "state_slot": _diff(
+            gather_cache[args.state_index], indexed_cache[args.state_index]
+        ),
     }
     if args.state_slots > 1:
         untouched_index = 0 if args.state_index != 0 else args.state_slots - 1

--- a/benchmarks/benchmark_sm70_fp8_fixed_vs_dynamic.py
+++ b/benchmarks/benchmark_sm70_fp8_fixed_vs_dynamic.py
@@ -64,8 +64,9 @@ def _candidate_layers(model_path: Path) -> tuple[dict[str, str], list[str]]:
     return weight_map, layers
 
 
-def _select_layers(layers: list[str], layer_ids: set[int],
-                   max_layers: int) -> list[str]:
+def _select_layers(
+    layers: list[str], layer_ids: set[int], max_layers: int
+) -> list[str]:
     selected: list[str] = []
     seen_kind: set[str] = set()
     for prefix in layers:
@@ -99,8 +100,7 @@ def _run_case(
             "skip": "shape_not_multiple_128",
         }
 
-    tm_weight, tm_scales, meta = sm70_ops.fp8_sm70_prepare(
-        qweight, scales, group_size)
+    tm_weight, tm_scales, meta = sm70_ops.fp8_sm70_prepare(qweight, scales, group_size)
     x = torch.randn((m, k), device=qweight.device, dtype=torch.float16)
 
     fixed = torch.empty((m, n), device=qweight.device, dtype=torch.float16)
@@ -119,8 +119,7 @@ def _run_case(
 
     os.environ["VLLM_SM70_FP8_TUNE_SMALL_SHAPES"] = "0"
     fixed_after = torch.empty((m, n), device=qweight.device, dtype=torch.float16)
-    sm70_ops.fp8_gemm_sm70_out_meta(
-        fixed_after, x, tm_weight, tm_scales, meta)
+    sm70_ops.fp8_gemm_sm70_out_meta(fixed_after, x, tm_weight, tm_scales, meta)
     torch.cuda.synchronize(qweight.device)
 
     diff_dynamic = (fixed.float() - dynamic.float()).abs()
@@ -178,8 +177,7 @@ def main() -> int:
     results: list[dict[str, Any]] = []
     try:
         for prefix in selected:
-            qweight, scales = _load_fp8_layer(
-                args.model, weight_map, prefix, device)
+            qweight, scales = _load_fp8_layer(args.model, weight_map, prefix, device)
             for m in args.m:
                 results.append(_run_case(prefix, qweight, scales, m))
     finally:
@@ -189,7 +187,8 @@ def main() -> int:
             os.environ["VLLM_SM70_FP8_TUNE_SMALL_SHAPES"] = original_env
 
     failures = [
-        item for item in results
+        item
+        for item in results
         if item.get("fixed_vs_dynamic_max_diff", 0.0) != 0.0
         or not item.get("fixed_vs_dynamic_equal", True)
     ]

--- a/benchmarks/benchmark_sm70_gdn_exactness.py
+++ b/benchmarks/benchmark_sm70_gdn_exactness.py
@@ -164,12 +164,15 @@ def _make_inputs(args: argparse.Namespace) -> dict[str, torch.Tensor]:
         )
         * args.input_scale
     ).to(dtype)
-    g = -torch.rand(
-        (args.batch, args.seqlen, args.v_heads),
-        device=device,
-        dtype=torch.float32,
-        generator=generator,
-    ) * args.gate_scale
+    g = (
+        -torch.rand(
+            (args.batch, args.seqlen, args.v_heads),
+            device=device,
+            dtype=torch.float32,
+            generator=generator,
+        )
+        * args.gate_scale
+    )
     beta = torch.sigmoid(
         torch.randn(
             (args.batch, args.seqlen, args.v_heads),
@@ -210,9 +213,7 @@ def _make_inputs(args: argparse.Namespace) -> dict[str, torch.Tensor]:
         "initial_state": initial_state.cpu(),
     }
     if args.cu_seqlens:
-        result["cu_seqlens"] = torch.tensor(
-            [0, args.seqlen], dtype=torch.int32
-        )
+        result["cu_seqlens"] = torch.tensor([0, args.seqlen], dtype=torch.int32)
     return result
 
 
@@ -564,25 +565,17 @@ def _make_spec_decode_cudagraph_inputs(
     max_query_len = args.num_spec + 1
     graph_rows = args.graph_rows or max_query_len
     if graph_rows < max_query_len:
-        raise ValueError(
-            f"--graph-rows must be >= num_spec + 1 ({max_query_len})"
-        )
+        raise ValueError(f"--graph-rows must be >= num_spec + 1 ({max_query_len})")
     if args.state_slots < max_query_len:
-        raise ValueError(
-            f"--state-slots must be >= num_spec + 1 ({max_query_len})"
-        )
+        raise ValueError(f"--state-slots must be >= num_spec + 1 ({max_query_len})")
     if args.fixed_query_len is not None and not (
         1 <= args.fixed_query_len <= max_query_len
     ):
-        raise ValueError(
-            f"--fixed-query-len must be in [1, {max_query_len}]"
-        )
+        raise ValueError(f"--fixed-query-len must be in [1, {max_query_len}]")
     if args.fixed_accepted is not None and not (
         1 <= args.fixed_accepted <= max_query_len
     ):
-        raise ValueError(
-            f"--fixed-accepted must be in [1, {max_query_len}]"
-        )
+        raise ValueError(f"--fixed-accepted must be in [1, {max_query_len}]")
 
     q_dim = args.k_heads * args.head_k_dim
     k_dim = args.k_heads * args.head_k_dim
@@ -905,12 +898,14 @@ def _make_sigmoid_gating_inputs(args: argparse.Namespace) -> dict[str, torch.Ten
         )
         * args.gate_scale
     )
-    inputs.update({
-        "a": a.cpu(),
-        "b": b.cpu(),
-        "A_log": a_log.cpu(),
-        "dt_bias": dt_bias.cpu(),
-    })
+    inputs.update(
+        {
+            "a": a.cpu(),
+            "b": b.cpu(),
+            "A_log": a_log.cpu(),
+            "dt_bias": dt_bias.cpu(),
+        }
+    )
     if getattr(args, "decode_segments", False):
         if args.batch != 1:
             raise ValueError("decode-segments fixture requires --batch 1")
@@ -936,9 +931,7 @@ def _make_sigmoid_gating_inputs(args: argparse.Namespace) -> dict[str, torch.Ten
                 dtype=state_dtype,
             )
         inputs["initial_state"] = initial_state.cpu()
-        inputs["cu_seqlens"] = torch.arange(
-            0, args.seqlen + 1, dtype=torch.int32
-        )
+        inputs["cu_seqlens"] = torch.arange(0, args.seqlen + 1, dtype=torch.int32)
         inputs["ssm_state_indices"] = torch.arange(
             1, args.seqlen + 1, dtype=torch.int32
         )
@@ -1104,9 +1097,7 @@ def run_case(args: argparse.Namespace) -> int:
 
     outputs: dict[str, torch.Tensor | None] = {
         "out": out.detach().cpu(),
-        "final_state": final_state.detach().cpu()
-        if final_state is not None
-        else None,
+        "final_state": final_state.detach().cpu() if final_state is not None else None,
     }
     if args.save_intermediates:
         pipeline_outputs = _run_chunk_pipeline(cuda_inputs, cu_seqlens, scale)
@@ -1160,12 +1151,17 @@ def run_case(args: argparse.Namespace) -> int:
     out_path = Path(args.out)
     out_path.parent.mkdir(parents=True, exist_ok=True)
     torch.save(payload, out_path)
-    print(json.dumps({
-        "out": str(out_path),
-        "elapsed_s": elapsed_s,
-        "timing_summary": payload["timing_summary"],
-        "output_summaries": payload["output_summaries"],
-    }, indent=2))
+    print(
+        json.dumps(
+            {
+                "out": str(out_path),
+                "elapsed_s": elapsed_s,
+                "timing_summary": payload["timing_summary"],
+                "output_summaries": payload["output_summaries"],
+            },
+            indent=2,
+        )
+    )
     return 0
 
 
@@ -1268,12 +1264,17 @@ def run_recurrent_case(args: argparse.Namespace) -> int:
     out_path = Path(args.out)
     out_path.parent.mkdir(parents=True, exist_ok=True)
     torch.save(payload, out_path)
-    print(json.dumps({
-        "out": str(out_path),
-        "elapsed_s": elapsed_s,
-        "timing_summary": payload["timing_summary"],
-        "output_summaries": payload["output_summaries"],
-    }, indent=2))
+    print(
+        json.dumps(
+            {
+                "out": str(out_path),
+                "elapsed_s": elapsed_s,
+                "timing_summary": payload["timing_summary"],
+                "output_summaries": payload["output_summaries"],
+            },
+            indent=2,
+        )
+    )
     return 0
 
 
@@ -1384,12 +1385,17 @@ def run_sigmoid_gating_case(args: argparse.Namespace) -> int:
     out_path = Path(args.out)
     out_path.parent.mkdir(parents=True, exist_ok=True)
     torch.save(payload, out_path)
-    print(json.dumps({
-        "out": str(out_path),
-        "elapsed_s": elapsed_s,
-        "timing_summary": payload["timing_summary"],
-        "output_summaries": payload["output_summaries"],
-    }, indent=2))
+    print(
+        json.dumps(
+            {
+                "out": str(out_path),
+                "elapsed_s": elapsed_s,
+                "timing_summary": payload["timing_summary"],
+                "output_summaries": payload["output_summaries"],
+            },
+            indent=2,
+        )
+    )
     return 0
 
 
@@ -1511,12 +1517,17 @@ def run_sigmoid_gating_mixed_qkv_case(args: argparse.Namespace) -> int:
     out_path = Path(args.out)
     out_path.parent.mkdir(parents=True, exist_ok=True)
     torch.save(payload, out_path)
-    print(json.dumps({
-        "out": str(out_path),
-        "elapsed_s": elapsed_s,
-        "timing_summary": payload["timing_summary"],
-        "output_summaries": payload["output_summaries"],
-    }, indent=2))
+    print(
+        json.dumps(
+            {
+                "out": str(out_path),
+                "elapsed_s": elapsed_s,
+                "timing_summary": payload["timing_summary"],
+                "output_summaries": payload["output_summaries"],
+            },
+            indent=2,
+        )
+    )
     return 0
 
 
@@ -1850,12 +1861,17 @@ def run_packed_recurrent_case(args: argparse.Namespace) -> int:
     out_path = Path(args.out)
     out_path.parent.mkdir(parents=True, exist_ok=True)
     torch.save(payload, out_path)
-    print(json.dumps({
-        "out": str(out_path),
-        "elapsed_s": elapsed_s,
-        "timing_summary": payload["timing_summary"],
-        "output_summaries": payload["output_summaries"],
-    }, indent=2))
+    print(
+        json.dumps(
+            {
+                "out": str(out_path),
+                "elapsed_s": elapsed_s,
+                "timing_summary": payload["timing_summary"],
+                "output_summaries": payload["output_summaries"],
+            },
+            indent=2,
+        )
+    )
     return 0
 
 
@@ -1946,9 +1962,7 @@ def run_flashqla_decode_case(args: argparse.Namespace) -> int:
         "metadata": _metadata(args),
         "config": {
             "op": "flashqla_sm70_gdn_decode_full_route",
-            "route_components": (
-                "fused_mixed_qkv+gating+l2norm+global_state_update"
-            ),
+            "route_components": ("fused_mixed_qkv+gating+l2norm+global_state_update"),
             "batch": args.batch,
             "k_heads": args.k_heads,
             "v_heads": args.v_heads,
@@ -1983,12 +1997,17 @@ def run_flashqla_decode_case(args: argparse.Namespace) -> int:
     out_path = Path(args.out)
     out_path.parent.mkdir(parents=True, exist_ok=True)
     torch.save(payload, out_path)
-    print(json.dumps({
-        "out": str(out_path),
-        "elapsed_s": elapsed_s,
-        "timing_summary": payload["timing_summary"],
-        "output_summaries": payload["output_summaries"],
-    }, indent=2))
+    print(
+        json.dumps(
+            {
+                "out": str(out_path),
+                "elapsed_s": elapsed_s,
+                "timing_summary": payload["timing_summary"],
+                "output_summaries": payload["output_summaries"],
+            },
+            indent=2,
+        )
+    )
     return 0
 
 
@@ -2115,13 +2134,10 @@ def run_packed_recurrent_cudagraph_case(args: argparse.Namespace) -> int:
     }
     comparisons = {
         "out": _compare_tensor(outputs["eager_out"], outputs["graph_out"]),
-        "final_state": _compare_tensor(
-            outputs["eager_state"], outputs["graph_state"]
-        ),
+        "final_state": _compare_tensor(outputs["eager_state"], outputs["graph_state"]),
     }
     strict_ok = all(
-        item["torch_equal"] and item["max_diff"] == 0.0
-        for item in comparisons.values()
+        item["torch_equal"] and item["max_diff"] == 0.0 for item in comparisons.values()
     )
     saved_inputs = {name: tensor.cpu() for name, tensor in inputs.items()}
     payload = {
@@ -2159,12 +2175,17 @@ def run_packed_recurrent_cudagraph_case(args: argparse.Namespace) -> int:
     out_path = Path(args.out)
     out_path.parent.mkdir(parents=True, exist_ok=True)
     torch.save(payload, out_path)
-    print(json.dumps({
-        "out": str(out_path),
-        "strict_ok": strict_ok,
-        "elapsed_s": elapsed_s,
-        "comparisons": comparisons,
-    }, indent=2))
+    print(
+        json.dumps(
+            {
+                "out": str(out_path),
+                "strict_ok": strict_ok,
+                "elapsed_s": elapsed_s,
+                "comparisons": comparisons,
+            },
+            indent=2,
+        )
+    )
     return 0 if strict_ok else 1
 
 
@@ -2246,13 +2267,10 @@ def run_conv_update_cudagraph_case(args: argparse.Namespace) -> int:
     }
     comparisons = {
         "out": _compare_tensor(outputs["eager_out"], outputs["graph_out"]),
-        "final_state": _compare_tensor(
-            outputs["eager_state"], outputs["graph_state"]
-        ),
+        "final_state": _compare_tensor(outputs["eager_state"], outputs["graph_state"]),
     }
     strict_ok = all(
-        item["torch_equal"] and item["max_diff"] == 0.0
-        for item in comparisons.values()
+        item["torch_equal"] and item["max_diff"] == 0.0 for item in comparisons.values()
     )
     saved_inputs = {name: tensor.cpu() for name, tensor in inputs.items()}
     payload = {
@@ -2287,12 +2305,17 @@ def run_conv_update_cudagraph_case(args: argparse.Namespace) -> int:
     out_path = Path(args.out)
     out_path.parent.mkdir(parents=True, exist_ok=True)
     torch.save(payload, out_path)
-    print(json.dumps({
-        "out": str(out_path),
-        "strict_ok": strict_ok,
-        "elapsed_s": elapsed_s,
-        "comparisons": comparisons,
-    }, indent=2))
+    print(
+        json.dumps(
+            {
+                "out": str(out_path),
+                "strict_ok": strict_ok,
+                "elapsed_s": elapsed_s,
+                "comparisons": comparisons,
+            },
+            indent=2,
+        )
+    )
     return 0 if strict_ok else 1
 
 
@@ -2470,8 +2493,7 @@ def run_spec_decode_cudagraph_case(args: argparse.Namespace) -> int:
 
     query_lens = inputs["query_lens"].to(torch.int64)
     live_token_mask = (
-        torch.arange(max_query_len, dtype=torch.int64)[None, :]
-        < query_lens[:, None]
+        torch.arange(max_query_len, dtype=torch.int64)[None, :] < query_lens[:, None]
     )
     outputs: dict[str, torch.Tensor | None] = {
         "eager_live_out": eager_out.detach().cpu()[live_token_mask],
@@ -2556,13 +2578,18 @@ def run_spec_decode_cudagraph_case(args: argparse.Namespace) -> int:
     out_path = Path(args.out)
     out_path.parent.mkdir(parents=True, exist_ok=True)
     torch.save(payload, out_path)
-    print(json.dumps({
-        "out": str(out_path),
-        "strict_ok": strict_ok,
-        "elapsed_s": elapsed_s,
-        "config": payload["config"],
-        "comparisons": comparisons,
-    }, indent=2))
+    print(
+        json.dumps(
+            {
+                "out": str(out_path),
+                "strict_ok": strict_ok,
+                "elapsed_s": elapsed_s,
+                "config": payload["config"],
+                "comparisons": comparisons,
+            },
+            indent=2,
+        )
+    )
     return 0 if strict_ok else 1
 
 
@@ -2703,7 +2730,9 @@ def run_spec_mixed_qkv_candidate_case(args: argparse.Namespace) -> int:
         )
         out.copy_(core_out.squeeze(0))
 
-    def run_eager_sequence(launch_fn: Any) -> tuple[
+    def run_eager_sequence(
+        launch_fn: Any,
+    ) -> tuple[
         torch.Tensor,
         torch.Tensor,
         torch.Tensor,
@@ -2803,8 +2832,7 @@ def run_spec_mixed_qkv_candidate_case(args: argparse.Namespace) -> int:
 
     query_lens = inputs["query_lens"].to(torch.int64)
     live_token_mask = (
-        torch.arange(max_query_len, dtype=torch.int64)[None, :]
-        < query_lens[:, None]
+        torch.arange(max_query_len, dtype=torch.int64)[None, :] < query_lens[:, None]
     )
     outputs: dict[str, torch.Tensor] = {
         "split_live_out": split_out.detach().cpu()[live_token_mask],
@@ -2897,13 +2925,18 @@ def run_spec_mixed_qkv_candidate_case(args: argparse.Namespace) -> int:
     out_path = Path(args.out)
     out_path.parent.mkdir(parents=True, exist_ok=True)
     torch.save(payload, out_path)
-    print(json.dumps({
-        "out": str(out_path),
-        "strict_ok": strict_ok,
-        "timing": timing,
-        "config": payload["config"],
-        "comparisons": comparisons,
-    }, indent=2))
+    print(
+        json.dumps(
+            {
+                "out": str(out_path),
+                "strict_ok": strict_ok,
+                "timing": timing,
+                "config": payload["config"],
+                "comparisons": comparisons,
+            },
+            indent=2,
+        )
+    )
     return 0 if strict_ok else 1
 
 
@@ -3168,8 +3201,7 @@ def run_spec_commit_vs_standard_case(args: argparse.Namespace) -> int:
 
     query_lens = inputs["query_lens"].to(torch.int64)
     live_token_mask = (
-        torch.arange(max_query_len, dtype=torch.int64)[None, :]
-        < query_lens[:, None]
+        torch.arange(max_query_len, dtype=torch.int64)[None, :] < query_lens[:, None]
     )
     outputs: dict[str, torch.Tensor | None] = {
         "standard_live_out": standard_out.detach().cpu()[live_token_mask],
@@ -3285,13 +3317,18 @@ def run_spec_commit_vs_standard_case(args: argparse.Namespace) -> int:
     out_path = Path(args.out)
     out_path.parent.mkdir(parents=True, exist_ok=True)
     torch.save(payload, out_path)
-    print(json.dumps({
-        "out": str(out_path),
-        "strict_ok": strict_ok,
-        "elapsed_s": elapsed_s,
-        "config": payload["config"],
-        "comparisons": comparisons,
-    }, indent=2))
+    print(
+        json.dumps(
+            {
+                "out": str(out_path),
+                "strict_ok": strict_ok,
+                "elapsed_s": elapsed_s,
+                "config": payload["config"],
+                "comparisons": comparisons,
+            },
+            indent=2,
+        )
+    )
     return 0 if strict_ok else 1
 
 
@@ -3795,8 +3832,7 @@ def run_spec_commit_projection_case(args: argparse.Namespace) -> int:
 
     query_lens = inputs["query_lens"].to(torch.int64)
     live_token_mask = (
-        torch.arange(max_query_len, dtype=torch.int64)[None, :]
-        < query_lens[:, None]
+        torch.arange(max_query_len, dtype=torch.int64)[None, :] < query_lens[:, None]
     )
     outputs: dict[str, torch.Tensor | None] = {
         "standard_live_output": standard_output.detach().cpu()[live_token_mask],
@@ -3985,12 +4021,15 @@ def run_spec_commit_projection_case(args: argparse.Namespace) -> int:
                 "direct_compile_ssm_state",
             ]
         )
-    strict_ok = all(
-        comparisons[name] is not None
-        and comparisons[name]["torch_equal"]
-        and comparisons[name]["max_diff"] == 0.0
-        for name in strict_keys
-    ) and compile_step_error is None
+    strict_ok = (
+        all(
+            comparisons[name] is not None
+            and comparisons[name]["torch_equal"]
+            and comparisons[name]["max_diff"] == 0.0
+            for name in strict_keys
+        )
+        and compile_step_error is None
+    )
     accepted_hist = torch.bincount(
         inputs["num_accepted_tokens_seq"][:, 0].to(torch.int64),
         minlength=max_query_len + 1,
@@ -4049,13 +4088,18 @@ def run_spec_commit_projection_case(args: argparse.Namespace) -> int:
     out_path = Path(args.out)
     out_path.parent.mkdir(parents=True, exist_ok=True)
     torch.save(payload, out_path)
-    print(json.dumps({
-        "out": str(out_path),
-        "strict_ok": strict_ok,
-        "elapsed_s": elapsed_s,
-        "config": payload["config"],
-        "comparisons": comparisons,
-    }, indent=2))
+    print(
+        json.dumps(
+            {
+                "out": str(out_path),
+                "strict_ok": strict_ok,
+                "elapsed_s": elapsed_s,
+                "config": payload["config"],
+                "comparisons": comparisons,
+            },
+            indent=2,
+        )
+    )
     return 0 if strict_ok else 1
 
 
@@ -4230,9 +4274,7 @@ def make_parser() -> argparse.ArgumentParser:
     sigmoid.add_argument("--v-heads", type=int, default=8)
     sigmoid.add_argument("--head-k-dim", type=int, default=128)
     sigmoid.add_argument("--head-v-dim", type=int, default=128)
-    sigmoid.add_argument(
-        "--dtype", choices=("float16", "bfloat16"), default="float16"
-    )
+    sigmoid.add_argument("--dtype", choices=("float16", "bfloat16"), default="float16")
     sigmoid.add_argument(
         "--state-dtype",
         choices=("same", "float16", "bfloat16", "float32"),
@@ -4293,9 +4335,7 @@ def make_parser() -> argparse.ArgumentParser:
     model_mixed = subparsers.add_parser("run-model-mixed-qkv-route")
     model_mixed.add_argument("--out", required=True)
     model_mixed.add_argument("--input-file")
-    model_mixed.add_argument(
-        "--case-name", default="gdn_model_mixed_qkv_route_smoke"
-    )
+    model_mixed.add_argument("--case-name", default="gdn_model_mixed_qkv_route_smoke")
     model_mixed.add_argument("--batch", type=int, default=1)
     model_mixed.add_argument("--seqlen", type=int, default=16)
     model_mixed.add_argument("--k-heads", type=int, default=4)
@@ -4413,16 +4453,12 @@ def make_parser() -> argparse.ArgumentParser:
     )
     packed_cg.add_argument("--random-initial-state", action="store_true")
     packed_cg.add_argument("--capture-null-indices", action="store_true")
-    packed_cg.set_defaults(
-        func=run_packed_recurrent_cudagraph_case, l2norm_inputs=True
-    )
+    packed_cg.set_defaults(func=run_packed_recurrent_cudagraph_case, l2norm_inputs=True)
 
     conv_cg = subparsers.add_parser("run-conv-update-cudagraph")
     conv_cg.add_argument("--out", required=True)
     conv_cg.add_argument("--input-file")
-    conv_cg.add_argument(
-        "--case-name", default="gdn_conv_update_cudagraph_exactness"
-    )
+    conv_cg.add_argument("--case-name", default="gdn_conv_update_cudagraph_exactness")
     conv_cg.add_argument("--batch", type=int, default=2)
     conv_cg.add_argument("--seqlen", type=int, default=1024)
     conv_cg.add_argument("--k-heads", type=int, default=4)
@@ -4447,9 +4483,7 @@ def make_parser() -> argparse.ArgumentParser:
     spec_cg = subparsers.add_parser("run-spec-decode-cudagraph")
     spec_cg.add_argument("--out", required=True)
     spec_cg.add_argument("--input-file")
-    spec_cg.add_argument(
-        "--case-name", default="gdn_spec_decode_cudagraph_exactness"
-    )
+    spec_cg.add_argument("--case-name", default="gdn_spec_decode_cudagraph_exactness")
     spec_cg.add_argument("--steps", type=int, default=512)
     spec_cg.add_argument("--num-spec", type=int, default=4)
     spec_cg.add_argument("--graph-rows", type=int)
@@ -4488,9 +4522,7 @@ def make_parser() -> argparse.ArgumentParser:
     spec_mixed = subparsers.add_parser("run-spec-mixed-qkv-candidate")
     spec_mixed.add_argument("--out", required=True)
     spec_mixed.add_argument("--input-file")
-    spec_mixed.add_argument(
-        "--case-name", default="gdn_spec_mixed_qkv_candidate"
-    )
+    spec_mixed.add_argument("--case-name", default="gdn_spec_mixed_qkv_candidate")
     spec_mixed.add_argument("--steps", type=int, default=512)
     spec_mixed.add_argument("--num-spec", type=int, default=4)
     spec_mixed.add_argument("--graph-rows", type=int)
@@ -4531,9 +4563,7 @@ def make_parser() -> argparse.ArgumentParser:
     spec_op = subparsers.add_parser("run-spec-commit-vs-standard")
     spec_op.add_argument("--out", required=True)
     spec_op.add_argument("--input-file")
-    spec_op.add_argument(
-        "--case-name", default="gdn_spec_commit_vs_standard_exactness"
-    )
+    spec_op.add_argument("--case-name", default="gdn_spec_commit_vs_standard_exactness")
     spec_op.add_argument("--steps", type=int, default=512)
     spec_op.add_argument("--num-spec", type=int, default=4)
     spec_op.add_argument("--graph-rows", type=int)

--- a/benchmarks/benchmark_sm70_lm_head_top1.py
+++ b/benchmarks/benchmark_sm70_lm_head_top1.py
@@ -111,9 +111,7 @@ def main() -> int:
 
     x = torch.randn((args.m, args.k), device=device, dtype=torch.float16)
     weight = torch.randn((args.n, args.k), device=device, dtype=torch.float16)
-    torch_logits_out = torch.empty(
-        (args.m, args.n), device=device, dtype=torch.float16
-    )
+    torch_logits_out = torch.empty((args.m, args.n), device=device, dtype=torch.float16)
     prepared = sm70_ops.sm70_f16_prepare(weight)
     tm_weight = prepared[0]
     k_ld = int(prepared[1][0].item())
@@ -121,7 +119,7 @@ def main() -> int:
     def torch_mm_max() -> tuple[torch.Tensor, torch.Tensor]:
         logits = torch.mm(x, weight.t())
         if args.pad:
-            logits[:, -args.pad:] = -float("inf")
+            logits[:, -args.pad :] = -float("inf")
         values, indices = logits.max(dim=-1)
         return values, indices.to(torch.int64) + args.vocab_start
 
@@ -189,15 +187,21 @@ def main() -> int:
     def sm70_gemm_max() -> tuple[torch.Tensor, torch.Tensor]:
         sm70_ops.sm70_f16_gemm_out(logits_out, x, tm_weight, k_ld, False)
         if args.pad:
-            logits_out[:, -args.pad:] = -float("inf")
+            logits_out[:, -args.pad :] = -float("inf")
         values, indices = logits_out.max(dim=-1)
         return values, indices.to(torch.int64) + args.vocab_start
 
     sm70_values, sm70_indices = sm70_gemm_max()
     sm70_ms = _bench_cuda_ms(lambda: sm70_gemm_max(), args.warmup, args.iters)
     results.append(
-        _stats("sm70_gemm_then_max", sm70_values, sm70_indices, ref_values,
-               ref_indices, sm70_ms)
+        _stats(
+            "sm70_gemm_then_max",
+            sm70_values,
+            sm70_indices,
+            ref_values,
+            ref_indices,
+            sm70_ms,
+        )
     )
 
     torch_mm_ms = _bench_cuda_ms(lambda: torch_mm_max(), args.warmup, args.iters)

--- a/benchmarks/benchmark_sm70_long_quality_suffix.py
+++ b/benchmarks/benchmark_sm70_long_quality_suffix.py
@@ -220,9 +220,9 @@ def main() -> None:
                     "im_end_count": result["im_end_count"],
                     "unique_tokens": result["unique_tokens"],
                     "top_token_count_id": result["top_token_count_id"],
-                    "steady_decode_tps": (
-                        result["request_metrics"] or {}
-                    ).get("steady_decode_tps"),
+                    "steady_decode_tps": (result["request_metrics"] or {}).get(
+                        "steady_decode_tps"
+                    ),
                     "prefix": text[:160],
                 },
                 ensure_ascii=False,

--- a/benchmarks/benchmark_sm70_native_bm32_allp_crossblock_micro.py
+++ b/benchmarks/benchmark_sm70_native_bm32_allp_crossblock_micro.py
@@ -102,8 +102,7 @@ def _require_environment(args: argparse.Namespace) -> None:
         raise ValueError(f"formal runs require exactly {K_DEFAULT_ROUNDS} rounds.")
     if args.launches_per_sample != K_DEFAULT_LAUNCHES:
         raise ValueError(
-            "formal runs require exactly "
-            f"{K_DEFAULT_LAUNCHES} launches per sample."
+            f"formal runs require exactly {K_DEFAULT_LAUNCHES} launches per sample."
         )
 
 
@@ -260,12 +259,8 @@ def _inspect_sass(binary: Path) -> dict[str, Any]:
         "kernels": kernels,
         "static_instruction_delta": {
             mnemonic: (
-                kernels.get("candidate", {})
-                .get("instructions", {})
-                .get(mnemonic, 0)
-                - kernels.get("baseline", {})
-                .get("instructions", {})
-                .get(mnemonic, 0)
+                kernels.get("candidate", {}).get("instructions", {}).get(mnemonic, 0)
+                - kernels.get("baseline", {}).get("instructions", {}).get(mnemonic, 0)
             )
             for mnemonic in ("hmma", "ldg", "lds", "sts", "ldl", "stl", "bar")
         },
@@ -301,13 +296,11 @@ def _resource_gate(
             )
         if resource.get("registers_per_thread", 65) > 64:
             reasons.append(
-                f"{path} REG={resource.get('registers_per_thread')}, "
-                "requires <=64"
+                f"{path} REG={resource.get('registers_per_thread')}, requires <=64"
             )
         if resource.get("local_bytes_per_thread") != 0:
             reasons.append(
-                f"{path} LOCAL={resource.get('local_bytes_per_thread')}, "
-                "requires 0"
+                f"{path} LOCAL={resource.get('local_bytes_per_thread')}, requires 0"
             )
         if resource.get("static_shared_bytes") != K_ALLP_SHARED_BYTES:
             reasons.append(
@@ -332,8 +325,7 @@ def _resource_gate(
             continue
         if ptxas["registers_per_thread"] > 64:
             reasons.append(
-                f"PTXAS {path} REG={ptxas['registers_per_thread']}, "
-                "requires <=64"
+                f"PTXAS {path} REG={ptxas['registers_per_thread']}, requires <=64"
             )
         for key in ("stack_frame_bytes", "spill_store_bytes", "spill_load_bytes"):
             if ptxas[key] != 0:
@@ -355,9 +347,7 @@ def _resource_gate(
             instructions = path_sass.get("instructions", {})
             for mnemonic in ("hmma", "ldg", "lds", "sts"):
                 if instructions.get(mnemonic, 0) == 0:
-                    reasons.append(
-                        f"{path} SASS has no {mnemonic.upper()} instruction"
-                    )
+                    reasons.append(f"{path} SASS has no {mnemonic.upper()} instruction")
             if instructions.get("ldl", 0) or instructions.get("stl", 0):
                 reasons.append(
                     f"{path} SASS has local instructions "
@@ -396,40 +386,31 @@ def _resource_gate(
     return not reasons, reasons
 
 
-def _correctness_gate(
-    payload: dict[str, Any], groups: int
-) -> tuple[bool, list[str]]:
+def _correctness_gate(payload: dict[str, Any], groups: int) -> tuple[bool, list[str]]:
     reasons: list[str] = []
     exactness = payload.get("exactness") or {}
     expected_words = groups * K_M * K_D // 2
     if exactness.get("word_dtype") != "uint32 packed fp16":
         reasons.append(
-            "word_dtype="
-            f"{exactness.get('word_dtype')}, requires uint32 packed fp16"
+            f"word_dtype={exactness.get('word_dtype')}, requires uint32 packed fp16"
         )
     if exactness.get("word_count") != expected_words:
         reasons.append(
-            "word_count="
-            f"{exactness.get('word_count')}, requires {expected_words}"
+            f"word_count={exactness.get('word_count')}, requires {expected_words}"
         )
     if exactness.get("full_output") is not True:
         reasons.append("C++ probe did not compare the full output")
     if exactness.get("bitwise_equal") is not True:
         reasons.append("candidate output is not bitwise equal to baseline")
     if exactness.get("mismatch_words") != 0:
-        reasons.append(
-            "mismatch_words="
-            f"{exactness.get('mismatch_words')}, requires 0"
-        )
+        reasons.append(f"mismatch_words={exactness.get('mismatch_words')}, requires 0")
     xor = exactness.get("xor", {})
     if xor.get("max_word") != 0 or xor.get("reduction") != 0:
         reasons.append("packed uint32 XOR result is nonzero")
     return not reasons, reasons
 
 
-def _performance_gate(
-    payload: dict[str, Any], rounds: int
-) -> tuple[bool, list[str]]:
+def _performance_gate(payload: dict[str, Any], rounds: int) -> tuple[bool, list[str]]:
     reasons: list[str] = []
     pairs = payload.get("pairs") or {}
     if pairs.get("count") != rounds:
@@ -440,13 +421,10 @@ def _performance_gate(
             f"candidate_faster={pairs.get('candidate_faster')}, "
             f"requires >= {required_wins}/{rounds}"
         )
-    speedup_pct = (payload.get("timing") or {}).get(
-        "candidate_speedup_vs_baseline_pct"
-    )
+    speedup_pct = (payload.get("timing") or {}).get("candidate_speedup_vs_baseline_pct")
     if speedup_pct is None or speedup_pct < K_REQUIRED_SPEEDUP_PCT:
         reasons.append(
-            f"median speedup={speedup_pct}, requires "
-            f">= {K_REQUIRED_SPEEDUP_PCT}%"
+            f"median speedup={speedup_pct}, requires >= {K_REQUIRED_SPEEDUP_PCT}%"
         )
     return not reasons, reasons
 
@@ -665,14 +643,11 @@ def _run_ncu_kernel(
             "mio_throttle_per_warp_active": metrics.get(
                 "smsp__warp_issue_stalled_mio_throttle_per_warp_active"
             ),
-            "tensor_instructions": metrics.get(
-                "smsp__inst_executed_pipe_tensor.sum"
-            ),
+            "tensor_instructions": metrics.get("smsp__inst_executed_pipe_tensor.sum"),
         },
         "stdout_tail": completed.stdout[-3000:],
         "stderr_tail": completed.stderr[-3000:],
-        "permission_error": "ERR_NVGPUCTRPERM"
-        in (completed.stdout + completed.stderr),
+        "permission_error": "ERR_NVGPUCTRPERM" in (completed.stdout + completed.stderr),
     }
 
 
@@ -829,8 +804,7 @@ def _main() -> int:
         "benchmark": "sm70_native_bm32_allp_crossblock_micro",
         "target": "sm_70",
         "matrix": [
-            {"pattern": pattern, "nblocks": nblocks}
-            for pattern, nblocks in K_CASES
+            {"pattern": pattern, "nblocks": nblocks} for pattern, nblocks in K_CASES
         ],
         "configuration": {
             "groups": args.groups,

--- a/benchmarks/benchmark_sm70_native_bm32_allp_scratch_micro.py
+++ b/benchmarks/benchmark_sm70_native_bm32_allp_scratch_micro.py
@@ -93,10 +93,7 @@ def _require_environment(args: argparse.Namespace) -> None:
     if args.rounds < K_DEFAULT_ROUNDS:
         raise ValueError(f"rounds must be at least {K_DEFAULT_ROUNDS}.")
     if args.launches_per_sample < K_DEFAULT_LAUNCHES:
-        raise ValueError(
-            "launches-per-sample must be at least "
-            f"{K_DEFAULT_LAUNCHES}."
-        )
+        raise ValueError(f"launches-per-sample must be at least {K_DEFAULT_LAUNCHES}.")
 
 
 def _graphics_clock_mhz(physical_gpu: int) -> int:
@@ -247,8 +244,7 @@ def _inspect_sass(binary: Path) -> dict[str, Any]:
             "ctas_per_group": ctas_per_group,
             "instructions": instructions,
             "instructions_per_group": {
-                name: count * ctas_per_group
-                for name, count in instructions.items()
+                name: count * ctas_per_group for name, count in instructions.items()
             },
         }
     baseline_instructions = kernels.get("baseline", {}).get("instructions", {})
@@ -292,13 +288,11 @@ def _resource_gate(
             )
         if resource.get("registers_per_thread", 65) > 64:
             reasons.append(
-                f"{path} REG={resource.get('registers_per_thread')}, "
-                "requires <=64"
+                f"{path} REG={resource.get('registers_per_thread')}, requires <=64"
             )
         if resource.get("local_bytes_per_thread") != 0:
             reasons.append(
-                f"{path} LOCAL={resource.get('local_bytes_per_thread')}, "
-                "requires 0"
+                f"{path} LOCAL={resource.get('local_bytes_per_thread')}, requires 0"
             )
         if resource.get("static_shared_bytes") != K_ALLP_SHARED_BYTES:
             reasons.append(
@@ -325,8 +319,7 @@ def _resource_gate(
             continue
         if ptxas["registers_per_thread"] > 64:
             reasons.append(
-                f"PTXAS {path} REG={ptxas['registers_per_thread']}, "
-                "requires <=64"
+                f"PTXAS {path} REG={ptxas['registers_per_thread']}, requires <=64"
             )
         for key in ("stack_frame_bytes", "spill_store_bytes", "spill_load_bytes"):
             if ptxas[key] != 0:
@@ -347,9 +340,7 @@ def _resource_gate(
             instructions = path_sass.get("instructions", {})
             for mnemonic in ("hmma", "ldg", "lds"):
                 if instructions.get(mnemonic, 0) == 0:
-                    reasons.append(
-                        f"{path} SASS has no {mnemonic.upper()} instruction"
-                    )
+                    reasons.append(f"{path} SASS has no {mnemonic.upper()} instruction")
             if instructions.get("ldl", 0) or instructions.get("stl", 0):
                 reasons.append(
                     f"{path} SASS has local instructions "
@@ -379,46 +370,35 @@ def _resource_gate(
     }
     for key, expected in expected_scratch.items():
         if scratch.get(key) != expected:
-            reasons.append(
-                f"scratch {key}={scratch.get(key)}, requires {expected}"
-            )
+            reasons.append(f"scratch {key}={scratch.get(key)}, requires {expected}")
     return not reasons, reasons
 
 
-def _correctness_gate(
-    payload: dict[str, Any], groups: int
-) -> tuple[bool, list[str]]:
+def _correctness_gate(payload: dict[str, Any], groups: int) -> tuple[bool, list[str]]:
     reasons: list[str] = []
     exactness = payload.get("exactness", {})
     expected_words = groups * K_M * K_D // 2
     if exactness.get("word_dtype") != "uint32 packed fp16":
         reasons.append(
-            "word_dtype="
-            f"{exactness.get('word_dtype')}, requires uint32 packed fp16"
+            f"word_dtype={exactness.get('word_dtype')}, requires uint32 packed fp16"
         )
     if exactness.get("word_count") != expected_words:
         reasons.append(
-            "word_count="
-            f"{exactness.get('word_count')}, requires {expected_words}"
+            f"word_count={exactness.get('word_count')}, requires {expected_words}"
         )
     if exactness.get("full_output") is not True:
         reasons.append("C++ probe did not compare the full output")
     if exactness.get("bitwise_equal") is not True:
         reasons.append("candidate output is not bitwise equal to baseline")
     if exactness.get("mismatch_words") != 0:
-        reasons.append(
-            "mismatch_words="
-            f"{exactness.get('mismatch_words')}, requires 0"
-        )
+        reasons.append(f"mismatch_words={exactness.get('mismatch_words')}, requires 0")
     xor = exactness.get("xor", {})
     if xor.get("max_word") != 0 or xor.get("reduction") != 0:
         reasons.append("packed uint32 XOR result is nonzero")
     return not reasons, reasons
 
 
-def _performance_gate(
-    payload: dict[str, Any], rounds: int
-) -> tuple[bool, list[str]]:
+def _performance_gate(payload: dict[str, Any], rounds: int) -> tuple[bool, list[str]]:
     reasons: list[str] = []
     pairs = payload.get("pairs", {})
     if pairs.get("count") != rounds:
@@ -429,13 +409,10 @@ def _performance_gate(
             f"candidate_faster={pairs.get('candidate_faster')}, "
             f"requires >= {required_wins}/{rounds}"
         )
-    speedup_pct = payload.get("timing", {}).get(
-        "candidate_speedup_vs_baseline_pct"
-    )
+    speedup_pct = payload.get("timing", {}).get("candidate_speedup_vs_baseline_pct")
     if speedup_pct is None or speedup_pct < K_REQUIRED_SPEEDUP_PCT:
         reasons.append(
-            f"median speedup={speedup_pct}, requires "
-            f">= {K_REQUIRED_SPEEDUP_PCT}%"
+            f"median speedup={speedup_pct}, requires >= {K_REQUIRED_SPEEDUP_PCT}%"
         )
     return not reasons, reasons
 
@@ -501,9 +478,7 @@ def _run_case(
     resource_passed, resource_reasons = _resource_gate(
         payload, sass, ptxas_baseline, ptxas_candidate, build_command
     )
-    performance_passed, performance_reasons = _performance_gate(
-        payload, args.rounds
-    )
+    performance_passed, performance_reasons = _performance_gate(payload, args.rounds)
     reasons = [
         *([] if completed.returncode == 0 else ["C++ benchmark returned nonzero"]),
         *correctness_reasons,
@@ -624,14 +599,11 @@ def _run_ncu_kernel(
                 "l1tex__data_bank_conflicts_pipe_lsu_mem_shared.sum"
             ),
             "duration_ns": metrics.get("gpu__time_duration.sum"),
-            "tensor_instructions": metrics.get(
-                "smsp__inst_executed_pipe_tensor.sum"
-            ),
+            "tensor_instructions": metrics.get("smsp__inst_executed_pipe_tensor.sum"),
         },
         "stdout_tail": completed.stdout[-3000:],
         "stderr_tail": completed.stderr[-3000:],
-        "permission_error": "ERR_NVGPUCTRPERM"
-        in (completed.stdout + completed.stderr),
+        "permission_error": "ERR_NVGPUCTRPERM" in (completed.stdout + completed.stderr),
     }
 
 
@@ -658,17 +630,13 @@ def _ncu_payload(
 
 
 def _aggregate_gates(cases: list[dict[str, Any]]) -> dict[str, Any]:
-    correctness_all_cases = all(
-        case["gates"]["correctness_passed"] for case in cases
-    )
+    correctness_all_cases = all(case["gates"]["correctness_passed"] for case in cases)
     resource_all_cases = all(case["gates"]["resource_passed"] for case in cases)
     all_case_performance_passed = all(
         case["gates"]["performance_passed"] for case in cases
     )
     aggregate_passed = (
-        correctness_all_cases
-        and resource_all_cases
-        and all_case_performance_passed
+        correctness_all_cases and resource_all_cases and all_case_performance_passed
     )
     reasons: list[str] = []
     if not correctness_all_cases:
@@ -734,8 +702,7 @@ def main() -> int:
         "benchmark": "sm70_native_bm32_allp_scratch_micro",
         "target": "sm_70",
         "matrix": [
-            {"pattern": pattern, "nblocks": nblocks}
-            for pattern, nblocks in K_CASES
+            {"pattern": pattern, "nblocks": nblocks} for pattern, nblocks in K_CASES
         ],
         "configuration": {
             "groups": args.groups,

--- a/benchmarks/benchmark_sm70_native_bm32_full_phase_allp_micro.py
+++ b/benchmarks/benchmark_sm70_native_bm32_full_phase_allp_micro.py
@@ -86,10 +86,7 @@ def _require_environment(args: argparse.Namespace) -> None:
     if args.rounds < K_DEFAULT_ROUNDS:
         raise ValueError(f"rounds must be at least {K_DEFAULT_ROUNDS}.")
     if args.launches_per_sample < K_DEFAULT_LAUNCHES:
-        raise ValueError(
-            "launches-per-sample must be at least "
-            f"{K_DEFAULT_LAUNCHES}."
-        )
+        raise ValueError(f"launches-per-sample must be at least {K_DEFAULT_LAUNCHES}.")
 
 
 def _graphics_clock_mhz(physical_gpu: int) -> int:
@@ -238,8 +235,7 @@ def _inspect_sass(binary: Path) -> dict[str, Any]:
             "ctas_per_group": ctas_per_group,
             "instructions": instructions,
             "instructions_per_group": {
-                name: count * ctas_per_group
-                for name, count in instructions.items()
+                name: count * ctas_per_group for name, count in instructions.items()
             },
         }
     return {"available": True, "binary": str(binary), "kernels": kernels}
@@ -265,8 +261,7 @@ def _resource_gate(
         reasons.append("C++ runtime resource gate did not pass")
     if baseline.get("threads_per_cta") != 512:
         reasons.append(
-            "baseline threads_per_cta="
-            f"{baseline.get('threads_per_cta')}, requires 512"
+            f"baseline threads_per_cta={baseline.get('threads_per_cta')}, requires 512"
         )
     if baseline.get("active_ctas_per_sm", 0) < 2:
         reasons.append(
@@ -280,18 +275,15 @@ def _resource_gate(
         )
     if candidate.get("registers_per_thread", 65) > 64:
         reasons.append(
-            "candidate REG="
-            f"{candidate.get('registers_per_thread')}, requires <=64"
+            f"candidate REG={candidate.get('registers_per_thread')}, requires <=64"
         )
     if candidate.get("local_bytes_per_thread") != 0:
         reasons.append(
-            "candidate LOCAL="
-            f"{candidate.get('local_bytes_per_thread')}, requires 0"
+            f"candidate LOCAL={candidate.get('local_bytes_per_thread')}, requires 0"
         )
     if candidate.get("static_shared_bytes", 48 * 1024 + 1) > 48 * 1024:
         reasons.append(
-            "candidate shared="
-            f"{candidate.get('static_shared_bytes')}, requires <=49152"
+            f"candidate shared={candidate.get('static_shared_bytes')}, requires <=49152"
         )
     if candidate.get("active_ctas_per_sm", 0) < 2:
         reasons.append(
@@ -347,40 +339,31 @@ def _resource_gate(
     return not reasons, reasons
 
 
-def _correctness_gate(
-    payload: dict[str, Any], groups: int
-) -> tuple[bool, list[str]]:
+def _correctness_gate(payload: dict[str, Any], groups: int) -> tuple[bool, list[str]]:
     reasons: list[str] = []
     exactness = payload.get("exactness", {})
     expected_words = groups * K_M * K_D // 2
     if exactness.get("word_dtype") != "uint32 packed fp16":
         reasons.append(
-            "word_dtype="
-            f"{exactness.get('word_dtype')}, requires uint32 packed fp16"
+            f"word_dtype={exactness.get('word_dtype')}, requires uint32 packed fp16"
         )
     if exactness.get("word_count") != expected_words:
         reasons.append(
-            "word_count="
-            f"{exactness.get('word_count')}, requires {expected_words}"
+            f"word_count={exactness.get('word_count')}, requires {expected_words}"
         )
     if exactness.get("full_output") is not True:
         reasons.append("C++ probe did not compare the full output")
     if exactness.get("bitwise_equal") is not True:
         reasons.append("candidate output is not bitwise equal to baseline")
     if exactness.get("mismatch_words") != 0:
-        reasons.append(
-            "mismatch_words="
-            f"{exactness.get('mismatch_words')}, requires 0"
-        )
+        reasons.append(f"mismatch_words={exactness.get('mismatch_words')}, requires 0")
     xor = exactness.get("xor", {})
     if xor.get("max_word") != 0 or xor.get("reduction") != 0:
         reasons.append("packed uint32 XOR result is nonzero")
     return not reasons, reasons
 
 
-def _performance_gate(
-    payload: dict[str, Any], rounds: int
-) -> tuple[bool, list[str]]:
+def _performance_gate(payload: dict[str, Any], rounds: int) -> tuple[bool, list[str]]:
     reasons: list[str] = []
     timing = payload.get("timing", {})
     pairs = payload.get("pairs", {})
@@ -389,8 +372,7 @@ def _performance_gate(
         reasons.append("candidate speedup was not reported")
     elif speedup < K_REQUIRED_SPEEDUP_PCT:
         reasons.append(
-            f"candidate speedup {speedup:.3f}% is below "
-            f"{K_REQUIRED_SPEEDUP_PCT:.3f}%"
+            f"candidate speedup {speedup:.3f}% is below {K_REQUIRED_SPEEDUP_PCT:.3f}%"
         )
     if pairs.get("count") != rounds:
         reasons.append(f"pair count={pairs.get('count')}, requires {rounds}")
@@ -467,9 +449,7 @@ def _run_case(
     resource_passed, resource_reasons = _resource_gate(
         payload, sass, ptxas_candidate, build_command
     )
-    performance_passed, performance_reasons = _performance_gate(
-        payload, args.rounds
-    )
+    performance_passed, performance_reasons = _performance_gate(payload, args.rounds)
     reasons = [
         *([] if completed.returncode == 0 else ["C++ benchmark returned nonzero"]),
         *correctness_reasons,
@@ -583,14 +563,11 @@ def _run_ncu_kernel(
             "long_scoreboard_per_warp_active": metrics.get(
                 "smsp__warp_issue_stalled_long_scoreboard_per_warp_active"
             ),
-            "tensor_instructions": metrics.get(
-                "smsp__inst_executed_pipe_tensor.sum"
-            ),
+            "tensor_instructions": metrics.get("smsp__inst_executed_pipe_tensor.sum"),
         },
         "stdout_tail": completed.stdout[-3000:],
         "stderr_tail": completed.stderr[-3000:],
-        "permission_error": "ERR_NVGPUCTRPERM"
-        in (completed.stdout + completed.stderr),
+        "permission_error": "ERR_NVGPUCTRPERM" in (completed.stdout + completed.stderr),
     }
 
 
@@ -619,9 +596,7 @@ def _ncu_payload(
 def _aggregate_gates(cases: list[dict[str, Any]]) -> dict[str, Any]:
     primary_cases = [case for case in cases if case["nblocks"] == 4]
     short_cases = [case for case in cases if case["nblocks"] != 4]
-    correctness_all_cases = all(
-        case["gates"]["correctness_passed"] for case in cases
-    )
+    correctness_all_cases = all(case["gates"]["correctness_passed"] for case in cases)
     resource_all_cases = all(case["gates"]["resource_passed"] for case in cases)
     primary_performance_passed = all(
         case["gates"]["performance_passed"] for case in primary_cases
@@ -630,9 +605,7 @@ def _aggregate_gates(cases: list[dict[str, Any]]) -> dict[str, Any]:
         case["gates"]["performance_passed"] for case in cases
     )
     short_case_performance_failures = [
-        case["name"]
-        for case in short_cases
-        if not case["gates"]["performance_passed"]
+        case["name"] for case in short_cases if not case["gates"]["performance_passed"]
     ]
     aggregate_passed = (
         correctness_all_cases and resource_all_cases and primary_performance_passed
@@ -701,8 +674,7 @@ def main() -> int:
         "benchmark": "sm70_native_bm32_full_phase_allp_micro",
         "target": "sm_70",
         "matrix": [
-            {"pattern": pattern, "nblocks": nblocks}
-            for pattern, nblocks in K_CASES
+            {"pattern": pattern, "nblocks": nblocks} for pattern, nblocks in K_CASES
         ],
         "configuration": {
             "groups": args.groups,

--- a/benchmarks/benchmark_sm70_native_bm32_full_phase_micro.py
+++ b/benchmarks/benchmark_sm70_native_bm32_full_phase_micro.py
@@ -86,10 +86,7 @@ def _require_environment(args: argparse.Namespace) -> None:
     if args.rounds < K_DEFAULT_ROUNDS:
         raise ValueError(f"rounds must be at least {K_DEFAULT_ROUNDS}.")
     if args.launches_per_sample < K_DEFAULT_LAUNCHES:
-        raise ValueError(
-            "launches-per-sample must be at least "
-            f"{K_DEFAULT_LAUNCHES}."
-        )
+        raise ValueError(f"launches-per-sample must be at least {K_DEFAULT_LAUNCHES}.")
 
 
 def _graphics_clock_mhz(physical_gpu: int) -> int:
@@ -238,8 +235,7 @@ def _inspect_sass(binary: Path) -> dict[str, Any]:
             "ctas_per_group": ctas_per_group,
             "instructions": instructions,
             "instructions_per_group": {
-                name: count * ctas_per_group
-                for name, count in instructions.items()
+                name: count * ctas_per_group for name, count in instructions.items()
             },
         }
     return {"available": True, "binary": str(binary), "kernels": kernels}
@@ -265,8 +261,7 @@ def _resource_gate(
         reasons.append("C++ runtime resource gate did not pass")
     if baseline.get("threads_per_cta") != 512:
         reasons.append(
-            "baseline threads_per_cta="
-            f"{baseline.get('threads_per_cta')}, requires 512"
+            f"baseline threads_per_cta={baseline.get('threads_per_cta')}, requires 512"
         )
     if baseline.get("active_ctas_per_sm", 0) < 2:
         reasons.append(
@@ -280,18 +275,15 @@ def _resource_gate(
         )
     if candidate.get("registers_per_thread", 65) > 64:
         reasons.append(
-            "candidate REG="
-            f"{candidate.get('registers_per_thread')}, requires <=64"
+            f"candidate REG={candidate.get('registers_per_thread')}, requires <=64"
         )
     if candidate.get("local_bytes_per_thread") != 0:
         reasons.append(
-            "candidate LOCAL="
-            f"{candidate.get('local_bytes_per_thread')}, requires 0"
+            f"candidate LOCAL={candidate.get('local_bytes_per_thread')}, requires 0"
         )
     if candidate.get("static_shared_bytes", 48 * 1024 + 1) > 48 * 1024:
         reasons.append(
-            "candidate shared="
-            f"{candidate.get('static_shared_bytes')}, requires <=49152"
+            f"candidate shared={candidate.get('static_shared_bytes')}, requires <=49152"
         )
     if candidate.get("active_ctas_per_sm", 0) < 2:
         reasons.append(
@@ -347,40 +339,31 @@ def _resource_gate(
     return not reasons, reasons
 
 
-def _correctness_gate(
-    payload: dict[str, Any], groups: int
-) -> tuple[bool, list[str]]:
+def _correctness_gate(payload: dict[str, Any], groups: int) -> tuple[bool, list[str]]:
     reasons: list[str] = []
     exactness = payload.get("exactness", {})
     expected_words = groups * K_M * K_D // 2
     if exactness.get("word_dtype") != "uint32 packed fp16":
         reasons.append(
-            "word_dtype="
-            f"{exactness.get('word_dtype')}, requires uint32 packed fp16"
+            f"word_dtype={exactness.get('word_dtype')}, requires uint32 packed fp16"
         )
     if exactness.get("word_count") != expected_words:
         reasons.append(
-            "word_count="
-            f"{exactness.get('word_count')}, requires {expected_words}"
+            f"word_count={exactness.get('word_count')}, requires {expected_words}"
         )
     if exactness.get("full_output") is not True:
         reasons.append("C++ probe did not compare the full output")
     if exactness.get("bitwise_equal") is not True:
         reasons.append("candidate output is not bitwise equal to baseline")
     if exactness.get("mismatch_words") != 0:
-        reasons.append(
-            "mismatch_words="
-            f"{exactness.get('mismatch_words')}, requires 0"
-        )
+        reasons.append(f"mismatch_words={exactness.get('mismatch_words')}, requires 0")
     xor = exactness.get("xor", {})
     if xor.get("max_word") != 0 or xor.get("reduction") != 0:
         reasons.append("packed uint32 XOR result is nonzero")
     return not reasons, reasons
 
 
-def _performance_gate(
-    payload: dict[str, Any], rounds: int
-) -> tuple[bool, list[str]]:
+def _performance_gate(payload: dict[str, Any], rounds: int) -> tuple[bool, list[str]]:
     reasons: list[str] = []
     timing = payload.get("timing", {})
     pairs = payload.get("pairs", {})
@@ -389,8 +372,7 @@ def _performance_gate(
         reasons.append("candidate speedup was not reported")
     elif speedup < K_REQUIRED_SPEEDUP_PCT:
         reasons.append(
-            f"candidate speedup {speedup:.3f}% is below "
-            f"{K_REQUIRED_SPEEDUP_PCT:.3f}%"
+            f"candidate speedup {speedup:.3f}% is below {K_REQUIRED_SPEEDUP_PCT:.3f}%"
         )
     if pairs.get("count") != rounds:
         reasons.append(f"pair count={pairs.get('count')}, requires {rounds}")
@@ -467,9 +449,7 @@ def _run_case(
     resource_passed, resource_reasons = _resource_gate(
         payload, sass, ptxas_candidate, build_command
     )
-    performance_passed, performance_reasons = _performance_gate(
-        payload, args.rounds
-    )
+    performance_passed, performance_reasons = _performance_gate(payload, args.rounds)
     reasons = [
         *([] if completed.returncode == 0 else ["C++ benchmark returned nonzero"]),
         *correctness_reasons,
@@ -583,14 +563,11 @@ def _run_ncu_kernel(
             "long_scoreboard_per_warp_active": metrics.get(
                 "smsp__warp_issue_stalled_long_scoreboard_per_warp_active"
             ),
-            "tensor_instructions": metrics.get(
-                "smsp__inst_executed_pipe_tensor.sum"
-            ),
+            "tensor_instructions": metrics.get("smsp__inst_executed_pipe_tensor.sum"),
         },
         "stdout_tail": completed.stdout[-3000:],
         "stderr_tail": completed.stderr[-3000:],
-        "permission_error": "ERR_NVGPUCTRPERM"
-        in (completed.stdout + completed.stderr),
+        "permission_error": "ERR_NVGPUCTRPERM" in (completed.stdout + completed.stderr),
     }
 
 
@@ -619,9 +596,7 @@ def _ncu_payload(
 def _aggregate_gates(cases: list[dict[str, Any]]) -> dict[str, Any]:
     primary_cases = [case for case in cases if case["nblocks"] == 4]
     short_cases = [case for case in cases if case["nblocks"] != 4]
-    correctness_all_cases = all(
-        case["gates"]["correctness_passed"] for case in cases
-    )
+    correctness_all_cases = all(case["gates"]["correctness_passed"] for case in cases)
     resource_all_cases = all(case["gates"]["resource_passed"] for case in cases)
     primary_performance_passed = all(
         case["gates"]["performance_passed"] for case in primary_cases
@@ -630,9 +605,7 @@ def _aggregate_gates(cases: list[dict[str, Any]]) -> dict[str, Any]:
         case["gates"]["performance_passed"] for case in cases
     )
     short_case_performance_failures = [
-        case["name"]
-        for case in short_cases
-        if not case["gates"]["performance_passed"]
+        case["name"] for case in short_cases if not case["gates"]["performance_passed"]
     ]
     aggregate_passed = (
         correctness_all_cases and resource_all_cases and primary_performance_passed
@@ -701,8 +674,7 @@ def main() -> int:
         "benchmark": "sm70_native_bm32_full_phase_micro",
         "target": "sm_70",
         "matrix": [
-            {"pattern": pattern, "nblocks": nblocks}
-            for pattern, nblocks in K_CASES
+            {"pattern": pattern, "nblocks": nblocks} for pattern, nblocks in K_CASES
         ],
         "configuration": {
             "groups": args.groups,

--- a/benchmarks/benchmark_sm70_native_bm32_pv_panel_micro.py
+++ b/benchmarks/benchmark_sm70_native_bm32_pv_panel_micro.py
@@ -107,9 +107,7 @@ def _build_binary(verbose: bool) -> tuple[Path, list[str], str]:
     if nvcc is None:
         raise RuntimeError("nvcc is required to build the SM70 BM32 PV microbenchmark.")
     source = (
-        Path(__file__).resolve().parent
-        / "csrc"
-        / "sm70_native_bm32_pv_panel_micro.cu"
+        Path(__file__).resolve().parent / "csrc" / "sm70_native_bm32_pv_panel_micro.cu"
     )
     build_dir = (
         Path(tempfile.gettempdir())
@@ -227,8 +225,7 @@ def _resource_gate(
         )
     if baseline.get("threads_per_cta") != 512:
         reasons.append(
-            "baseline threads_per_cta="
-            f"{baseline.get('threads_per_cta')}, requires 512"
+            f"baseline threads_per_cta={baseline.get('threads_per_cta')}, requires 512"
         )
     if baseline.get("resident_active_warps") != 32:
         reasons.append(
@@ -257,13 +254,11 @@ def _resource_gate(
         )
     if candidate.get("registers_per_thread", 65) > 64:
         reasons.append(
-            "candidate REG="
-            f"{candidate.get('registers_per_thread')}, requires <=64"
+            f"candidate REG={candidate.get('registers_per_thread')}, requires <=64"
         )
     if candidate.get("local_bytes_per_thread") != 0:
         reasons.append(
-            "candidate LOCAL="
-            f"{candidate.get('local_bytes_per_thread')}, requires 0"
+            f"candidate LOCAL={candidate.get('local_bytes_per_thread')}, requires 0"
         )
     if candidate_topology.get("ctas_per_group") != 1:
         reasons.append(
@@ -387,9 +382,7 @@ def _run_ncu_kernel(
             "long_scoreboard_per_warp_active": metrics.get(
                 "smsp__warp_issue_stalled_long_scoreboard_per_warp_active"
             ),
-            "tensor_instructions": metrics.get(
-                "smsp__inst_executed_pipe_tensor.sum"
-            ),
+            "tensor_instructions": metrics.get("smsp__inst_executed_pipe_tensor.sum"),
         },
         "stdout_tail": result.stdout[-3000:],
         "stderr_tail": result.stderr[-3000:],

--- a/benchmarks/benchmark_sm70_raw_hmma_probe.py
+++ b/benchmarks/benchmark_sm70_raw_hmma_probe.py
@@ -32,10 +32,7 @@ def _build_binary(source: Path, verbose: bool) -> tuple[Path, list[str]]:
     if nvcc is None:
         raise RuntimeError("nvcc is required to build the SM70 raw HMMA probe.")
 
-    build_dir = (
-        Path(tempfile.gettempdir())
-        / f"vllm-sm70-raw-hmma-probe-{os.getuid()}"
-    )
+    build_dir = Path(tempfile.gettempdir()) / f"vllm-sm70-raw-hmma-probe-{os.getuid()}"
     build_dir.mkdir(parents=True, exist_ok=True)
     binary = build_dir / "sm70_raw_hmma_probe_sm70"
     command = [

--- a/benchmarks/benchmark_sm70_rejection_sampler_micro.py
+++ b/benchmarks/benchmark_sm70_rejection_sampler_micro.py
@@ -173,9 +173,7 @@ def _sparse_target_topk_topp_rejection_prototype(
     target_logits = sampled_logits[:num_tokens].float()
     bonus_logits = sampled_logits[num_tokens:].float()
 
-    target_topk_values, target_topk_ids = torch.topk(
-        target_logits, k=top_k, dim=-1
-    )
+    target_topk_values, target_topk_ids = torch.topk(target_logits, k=top_k, dim=-1)
     target_topk_probs = target_topk_values.softmax(dim=-1, dtype=torch.float32)
     target_remove_mask = target_topk_probs.cumsum(dim=-1) > top_p
     target_remove_mask[:, 1:] = target_remove_mask[:, :-1].clone()
@@ -190,9 +188,7 @@ def _sparse_target_topk_topp_rejection_prototype(
     bonus_remove_mask = bonus_topk_probs.cumsum(dim=-1) > top_p
     bonus_remove_mask[:, 1:] = bonus_remove_mask[:, :-1].clone()
     bonus_remove_mask[:, 0] = False
-    bonus_topk_values = bonus_topk_values.masked_fill(
-        bonus_remove_mask, -float("inf")
-    )
+    bonus_topk_values = bonus_topk_values.masked_fill(bonus_remove_mask, -float("inf"))
     bonus_topk_probs = bonus_topk_values.softmax(dim=-1, dtype=torch.float32)
 
     draft_ids_i64 = draft_token_ids.to(torch.int64).view(-1, 1)
@@ -209,9 +205,9 @@ def _sparse_target_topk_topp_rejection_prototype(
     ).clamp_max(1.0)
     accepted_prefix = (torch.rand_like(accept_ratio) <= accept_ratio).cumprod(0)
 
-    residual = (
-        target_topk_probs - draft_probs.gather(1, target_topk_ids)
-    ).clamp_min_(0.0)
+    residual = (target_topk_probs - draft_probs.gather(1, target_topk_ids)).clamp_min_(
+        0.0
+    )
     residual_q = torch.empty_like(residual).exponential_()
     recovered_offsets = (residual / residual_q).argmax(dim=-1, keepdim=True)
     recovered_token_ids = target_topk_ids.gather(1, recovered_offsets).view(-1)
@@ -246,9 +242,9 @@ def _full_vocab_topk_topp_probability_reference(
         k=min(top_k, probs.shape[-1]),
         dim=-1,
     )
-    residual = (
-        target_top_probs - draft_probs.gather(1, target_top_ids)
-    ).clamp_min_(0.0)
+    residual = (target_top_probs - draft_probs.gather(1, target_top_ids)).clamp_min_(
+        0.0
+    )
     return target_draft_probs, target_top_ids, residual
 
 
@@ -291,9 +287,7 @@ def _compact_tp2_topk_topp_probability_prototype(
         target_probs,
         torch.zeros_like(target_probs),
     ).sum(dim=-1)
-    residual = (
-        target_probs - draft_probs.gather(1, target_ids)
-    ).clamp_min_(0.0)
+    residual = (target_probs - draft_probs.gather(1, target_ids)).clamp_min_(0.0)
     return target_draft_probs, target_ids, residual
 
 
@@ -393,9 +387,7 @@ def main() -> None:
         bonus_logits_indices=torch.tensor(
             [num_tokens], dtype=torch.int32, device=device
         ),
-        logits_indices=torch.arange(
-            num_tokens + 1, dtype=torch.int32, device=device
-        ),
+        logits_indices=torch.arange(num_tokens + 1, dtype=torch.int32, device=device),
     )
 
     target_logits_constrained = apply_sampling_constraints(
@@ -494,9 +486,9 @@ def main() -> None:
             args.iters,
         ),
         "target_prepare_with_clone": _time_cuda(
-            lambda: target_prepare_base[target_prepare_indices].to(
-                torch.float32
-            ).clone(),
+            lambda: target_prepare_base[target_prepare_indices]
+            .to(torch.float32)
+            .clone(),
             args.warmup,
             args.iters,
         ),

--- a/benchmarks/benchmark_sm70_serving_quality.py
+++ b/benchmarks/benchmark_sm70_serving_quality.py
@@ -51,10 +51,12 @@ def _load_prompts(args: argparse.Namespace) -> list[dict[str, str]]:
             )
         for index, item in enumerate(loaded):
             if isinstance(item, str):
-                prompts.append({
-                    "id": f"external_{index + 1:02d}",
-                    "content": item,
-                })
+                prompts.append(
+                    {
+                        "id": f"external_{index + 1:02d}",
+                        "content": item,
+                    }
+                )
             elif isinstance(item, dict):
                 raw_content = item.get("content", item.get("prompt"))
                 if not isinstance(raw_content, str):
@@ -62,10 +64,12 @@ def _load_prompts(args: argparse.Namespace) -> list[dict[str, str]]:
                         "--prompts-json dict entries require string "
                         "'content' or 'prompt'"
                     )
-                prompts.append({
-                    "id": str(item.get("id", f"external_{index + 1:02d}")),
-                    "content": raw_content,
-                })
+                prompts.append(
+                    {
+                        "id": str(item.get("id", f"external_{index + 1:02d}")),
+                        "content": raw_content,
+                    }
+                )
             else:
                 raise TypeError("--prompts-json entries must be strings or objects")
     if not prompts:
@@ -147,27 +151,24 @@ def _collect_serving_counters(metrics_text: str) -> dict[str, float]:
     return counters
 
 
-def _metrics_snapshot(metrics_url: str | None,
-                      timeout: float) -> dict[str, float] | None:
+def _metrics_snapshot(
+    metrics_url: str | None, timeout: float
+) -> dict[str, float] | None:
     if metrics_url is None:
         return None
     return _collect_serving_counters(_get_text(metrics_url, timeout))
 
 
-def _counter_delta(before: dict[str, float] | None,
-                   after: dict[str, float] | None) -> dict[str, Any] | None:
+def _counter_delta(
+    before: dict[str, float] | None, after: dict[str, float] | None
+) -> dict[str, Any] | None:
     if before is None or after is None:
         return None
     keys = sorted(set(before) | set(after))
-    delta = {
-        key: after.get(key, 0.0) - before.get(key, 0.0)
-        for key in keys
-    }
+    delta = {key: after.get(key, 0.0) - before.get(key, 0.0) for key in keys}
     drafts = delta.get("vllm:spec_decode_num_drafts_total", 0.0)
     draft_tokens = delta.get("vllm:spec_decode_num_draft_tokens_total", 0.0)
-    accepted_tokens = delta.get(
-        "vllm:spec_decode_num_accepted_tokens_total", 0.0
-    )
+    accepted_tokens = delta.get("vllm:spec_decode_num_accepted_tokens_total", 0.0)
     generation_tokens = delta.get("vllm:generation_tokens_total", 0.0)
     prompt_tokens = delta.get("vllm:prompt_tokens_total", 0.0)
     per_position = [
@@ -275,7 +276,7 @@ def _max_repeated_window(text: str, width: int) -> int:
         return 0
     counts: dict[str, int] = {}
     for idx in range(0, len(normalized) - width + 1):
-        window = normalized[idx:idx + width]
+        window = normalized[idx : idx + width]
         if len(window.strip()) < width // 2:
             continue
         counts[window] = counts.get(window, 0) + 1
@@ -299,9 +300,9 @@ def _max_same_line_run(text: str) -> int:
     return best
 
 
-def _quality_metrics(text: str | None,
-                     raw_token_ids: Any,
-                     completion_tokens: Any = None) -> dict[str, Any]:
+def _quality_metrics(
+    text: str | None, raw_token_ids: Any, completion_tokens: Any = None
+) -> dict[str, Any]:
     text = text or ""
     token_ids = [int(token_id) for token_id in (raw_token_ids or [])]
     if token_ids:
@@ -361,8 +362,9 @@ def _quality_metrics(text: str | None,
     return metrics
 
 
-def _summarize_tps(records: list[dict[str, Any]],
-                   elapsed_seconds: float) -> dict[str, Any]:
+def _summarize_tps(
+    records: list[dict[str, Any]], elapsed_seconds: float
+) -> dict[str, Any]:
     completion_tokens = [
         int(record["timing"]["completion_tokens"]) for record in records
     ]
@@ -381,27 +383,28 @@ def _summarize_tps(records: list[dict[str, Any]],
     if request_tps:
         sorted_tps = sorted(request_tps)
         p90_index = min(len(sorted_tps) - 1, math.ceil(0.9 * len(sorted_tps)) - 1)
-        summary.update({
-            "request_tps_min": min(request_tps),
-            "request_tps_mean": statistics.fmean(request_tps),
-            "request_tps_median": statistics.median(request_tps),
-            "request_tps_p90": sorted_tps[p90_index],
-            "request_tps_max": max(request_tps),
-        })
+        summary.update(
+            {
+                "request_tps_min": min(request_tps),
+                "request_tps_mean": statistics.fmean(request_tps),
+                "request_tps_median": statistics.median(request_tps),
+                "request_tps_p90": sorted_tps[p90_index],
+                "request_tps_max": max(request_tps),
+            }
+        )
     return summary
 
 
 def _summarize_spec_metrics(records: list[dict[str, Any]]) -> dict[str, Any] | None:
     per_request = [
-        record.get("serving_metrics_delta") for record in records
+        record.get("serving_metrics_delta")
+        for record in records
         if record.get("serving_metrics_delta") is not None
     ]
     if not per_request:
         return None
     total_drafts = sum(float(item["num_drafts"]) for item in per_request)
-    total_draft_tokens = sum(
-        float(item["num_draft_tokens"]) for item in per_request
-    )
+    total_draft_tokens = sum(float(item["num_draft_tokens"]) for item in per_request)
     total_accepted_tokens = sum(
         float(item["num_accepted_tokens"]) for item in per_request
     )
@@ -417,17 +420,16 @@ def _summarize_spec_metrics(records: list[dict[str, Any]]) -> dict[str, Any] | N
             total_accepted_tokens / total_drafts if total_drafts > 0 else None
         ),
         "mean_acceptance_length": (
-            1.0 + total_accepted_tokens / total_drafts
-            if total_drafts > 0 else None
+            1.0 + total_accepted_tokens / total_drafts if total_drafts > 0 else None
         ),
         "draft_acceptance_rate": (
             total_accepted_tokens / total_draft_tokens
-            if total_draft_tokens > 0 else None
+            if total_draft_tokens > 0
+            else None
         ),
         "accepted_tokens_per_pos": per_position,
         "per_position_acceptance_rate": [
-            value / total_drafts if total_drafts > 0 else None
-            for value in per_position
+            value / total_drafts if total_drafts > 0 else None for value in per_position
         ],
     }
 
@@ -456,18 +458,22 @@ def _dump(args: argparse.Namespace) -> int:
             "stream": False,
         }
         if args.endpoint == "chat":
-            payload["messages"] = [{
-                "role": "user",
-                "content": prompt["content"],
-            }]
+            payload["messages"] = [
+                {
+                    "role": "user",
+                    "content": prompt["content"],
+                }
+            ]
         else:
-            payload.update({
-                "prompt": prompt["content"],
-                "logprobs": args.logprobs,
-                "return_token_ids": True,
-                "return_tokens_as_token_ids": True,
-                "prompt_logprobs": args.prompt_logprobs,
-            })
+            payload.update(
+                {
+                    "prompt": prompt["content"],
+                    "logprobs": args.logprobs,
+                    "return_token_ids": True,
+                    "return_tokens_as_token_ids": True,
+                    "prompt_logprobs": args.prompt_logprobs,
+                }
+            )
         if args.seed is not None:
             payload["seed"] = args.seed
         if args.top_k is not None:
@@ -482,35 +488,36 @@ def _dump(args: argparse.Namespace) -> int:
         choice = _extract_choice(response)
         usage = response.get("usage") or {}
         completion_tokens = int(
-            usage.get("completion_tokens")
-            or len(choice.get("token_ids") or [])
+            usage.get("completion_tokens") or len(choice.get("token_ids") or [])
         )
         prompt_tokens = usage.get("prompt_tokens")
         total_tokens = usage.get("total_tokens")
         completion_tps = (
             completion_tokens / request_elapsed if request_elapsed > 0 else None
         )
-        records.append({
-            "index": index,
-            "id": prompt["id"],
-            "prompt": prompt["content"],
-            "request": payload,
-            "response": response,
-            "choice": choice,
-            "timing": {
-                "elapsed_seconds": request_elapsed,
-                "completion_tokens": completion_tokens,
-                "prompt_tokens": prompt_tokens,
-                "total_tokens": total_tokens,
-                "completion_tokens_per_second": completion_tps,
-            },
-            "serving_metrics_delta": _counter_delta(metrics_before, metrics_after),
-            "metrics": _quality_metrics(
-                choice.get("text"),
-                choice.get("token_ids"),
-                completion_tokens,
-            ),
-        })
+        records.append(
+            {
+                "index": index,
+                "id": prompt["id"],
+                "prompt": prompt["content"],
+                "request": payload,
+                "response": response,
+                "choice": choice,
+                "timing": {
+                    "elapsed_seconds": request_elapsed,
+                    "completion_tokens": completion_tokens,
+                    "prompt_tokens": prompt_tokens,
+                    "total_tokens": total_tokens,
+                    "completion_tokens_per_second": completion_tps,
+                },
+                "serving_metrics_delta": _counter_delta(metrics_before, metrics_after),
+                "metrics": _quality_metrics(
+                    choice.get("text"),
+                    choice.get("token_ids"),
+                    completion_tokens,
+                ),
+            }
+        )
     elapsed = time.perf_counter() - start
     quality_passed = all(record["metrics"]["passed"] for record in records)
     throughput_summary = _summarize_tps(records, elapsed)
@@ -561,9 +568,13 @@ def _dump(args: argparse.Namespace) -> int:
         "records": records,
     }
     args.out.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
-    print(json.dumps({k: v for k, v in payload.items() if k != "records"},
-                     indent=2,
-                     sort_keys=True))
+    print(
+        json.dumps(
+            {k: v for k, v in payload.items() if k != "records"},
+            indent=2,
+            sort_keys=True,
+        )
+    )
     return 0 if quality_passed or not args.require_quality_gate else 2
 
 
@@ -626,7 +637,7 @@ def _token_logprobs(choice: dict[str, Any]) -> list[float | None]:
 def _normal_logprob_key(key: Any) -> str:
     text = str(key)
     if text.startswith("token_id:"):
-        return text[len("token_id:"):]
+        return text[len("token_id:") :]
     return text
 
 
@@ -678,8 +689,7 @@ def _diff_top_logprob_maps(
     }
 
 
-def _diff_values(left: list[float | None],
-                 right: list[float | None]) -> dict[str, Any]:
+def _diff_values(left: list[float | None], right: list[float | None]) -> dict[str, Any]:
     diffs: list[float] = []
     same_count = len(left) == len(right)
     for left_value, right_value in zip(left, right, strict=False):
@@ -695,8 +705,9 @@ def _diff_values(left: list[float | None],
     }
 
 
-def _first_mismatch(left: list[int] | None,
-                    right: list[int] | None) -> dict[str, Any] | None:
+def _first_mismatch(
+    left: list[int] | None, right: list[int] | None
+) -> dict[str, Any] | None:
     if left is None or right is None:
         return None if left == right else {"index": 0, "left": left, "right": right}
     for index, (left_id, right_id) in enumerate(zip(left, right, strict=False)):
@@ -719,22 +730,26 @@ def _load_logits_dumps(path: Path) -> list[dict[str, Any]]:
     for file_path in sorted(path.glob("sampler_logits_*.pt")):
         payload = torch.load(file_path, map_location="cpu", weights_only=False)
         logits = payload["logits"].float()
-        entries.append({
-            "path": str(file_path),
-            "step": int(payload["step"]),
-            "pid": payload.get("pid"),
-            "stage": payload.get("stage"),
-            "shape": list(payload.get("shape", tuple(logits.shape))),
-            "dtype": payload.get("dtype"),
-            "all_greedy": bool(payload.get("all_greedy")),
-            "output_token_ids": payload.get("output_token_ids"),
-            "logits": logits,
-        })
-    entries.sort(key=lambda item: (
-        int(item["step"]),
-        str(item.get("stage")),
-        str(item["path"]),
-    ))
+        entries.append(
+            {
+                "path": str(file_path),
+                "step": int(payload["step"]),
+                "pid": payload.get("pid"),
+                "stage": payload.get("stage"),
+                "shape": list(payload.get("shape", tuple(logits.shape))),
+                "dtype": payload.get("dtype"),
+                "all_greedy": bool(payload.get("all_greedy")),
+                "output_token_ids": payload.get("output_token_ids"),
+                "logits": logits,
+            }
+        )
+    entries.sort(
+        key=lambda item: (
+            int(item["step"]),
+            str(item.get("stage")),
+            str(item["path"]),
+        )
+    )
     return entries
 
 
@@ -753,7 +768,8 @@ def _compare_logits_dirs(left_dir: Path, right_dir: Path) -> dict[str, Any]:
     num_argmax_mismatch = 0
     first_argmax_mismatch = None
     for index, (left, right) in enumerate(
-            zip(left_entries, right_entries, strict=False)):
+        zip(left_entries, right_entries, strict=False)
+    ):
         shape_equal = tuple(left["logits"].shape) == tuple(right["logits"].shape)
         all_shape_equal = all_shape_equal and shape_equal
         payload = {
@@ -787,15 +803,17 @@ def _compare_logits_dirs(left_dir: Path, right_dir: Path) -> dict[str, Any]:
             global_max = max(global_max, max_diff)
             total_sum += float(diff.sum().item())
             total_count += int(diff.numel())
-            payload.update({
-                "max_abs_diff": max_diff,
-                "mean_abs_diff": mean_diff,
-                "argmax_equal": argmax_equal,
-                "argmax_first_mismatch": _first_mismatch(
-                    left_argmax.reshape(-1).tolist(),
-                    right_argmax.reshape(-1).tolist(),
-                ),
-            })
+            payload.update(
+                {
+                    "max_abs_diff": max_diff,
+                    "mean_abs_diff": mean_diff,
+                    "argmax_equal": argmax_equal,
+                    "argmax_first_mismatch": _first_mismatch(
+                        left_argmax.reshape(-1).tolist(),
+                        right_argmax.reshape(-1).tolist(),
+                    ),
+                }
+            )
         else:
             all_argmax_equal = False
         comparisons.append(payload)
@@ -831,11 +849,12 @@ def _compare(args: argparse.Namespace) -> int:
     output_top_logprob_diffs: list[float] = []
     prompt_perplexity_diffs: list[float] = []
     for index, (left_record, right_record) in enumerate(
-            zip(left["records"], right["records"], strict=False)):
+        zip(left["records"], right["records"], strict=False)
+    ):
         left_choice = left_record["choice"]
         right_choice = right_record["choice"]
-        prompt_equal = (
-            left_choice.get("prompt_token_ids") == right_choice.get("prompt_token_ids")
+        prompt_equal = left_choice.get("prompt_token_ids") == right_choice.get(
+            "prompt_token_ids"
         )
         output_equal = left_choice.get("token_ids") == right_choice.get("token_ids")
         text_equal = left_choice.get("text") == right_choice.get("text")
@@ -870,32 +889,35 @@ def _compare(args: argparse.Namespace) -> int:
         left_ppl_value = left_ppl["perplexity"]
         right_ppl_value = right_ppl["perplexity"]
         prompt_perplexity_abs_diff = (
-            None if left_ppl_value is None or right_ppl_value is None else
-            abs(float(left_ppl_value) - float(right_ppl_value))
+            None
+            if left_ppl_value is None or right_ppl_value is None
+            else abs(float(left_ppl_value) - float(right_ppl_value))
         )
         if prompt_perplexity_abs_diff is not None:
             prompt_perplexity_diffs.append(prompt_perplexity_abs_diff)
-        pairs.append({
-            "index": index,
-            "prompt_equal": prompt_equal,
-            "output_equal": output_equal,
-            "text_equal": text_equal,
-            "prompt_first_mismatch": _first_mismatch(
-                left_choice.get("prompt_token_ids"),
-                right_choice.get("prompt_token_ids"),
-            ),
-            "output_first_mismatch": _first_mismatch(
-                left_choice.get("token_ids"),
-                right_choice.get("token_ids"),
-            ),
-            "prompt_logprob_diff": prompt_diff,
-            "output_logprob_diff": output_diff,
-            "prompt_top_logprob_diff": prompt_top_diff,
-            "output_top_logprob_diff": output_top_diff,
-            "left_prompt_perplexity": left_ppl,
-            "right_prompt_perplexity": right_ppl,
-            "prompt_perplexity_abs_diff": prompt_perplexity_abs_diff,
-        })
+        pairs.append(
+            {
+                "index": index,
+                "prompt_equal": prompt_equal,
+                "output_equal": output_equal,
+                "text_equal": text_equal,
+                "prompt_first_mismatch": _first_mismatch(
+                    left_choice.get("prompt_token_ids"),
+                    right_choice.get("prompt_token_ids"),
+                ),
+                "output_first_mismatch": _first_mismatch(
+                    left_choice.get("token_ids"),
+                    right_choice.get("token_ids"),
+                ),
+                "prompt_logprob_diff": prompt_diff,
+                "output_logprob_diff": output_diff,
+                "prompt_top_logprob_diff": prompt_top_diff,
+                "output_top_logprob_diff": output_top_diff,
+                "left_prompt_perplexity": left_ppl,
+                "right_prompt_perplexity": right_ppl,
+                "prompt_perplexity_abs_diff": prompt_perplexity_abs_diff,
+            }
+        )
 
     sampler_logits_diff = (
         _compare_logits_dirs(args.left_logits_dir, args.right_logits_dir)
@@ -962,15 +984,9 @@ def _model_quality_gate(
         "token_equal": token_equal,
         "prompt_logprob_max_abs_diff": result.get("max_prompt_logprob_diff"),
         "output_logprob_max_abs_diff": result.get("max_output_logprob_diff"),
-        "prompt_top_logprob_max_abs_diff": result.get(
-            "max_prompt_top_logprob_diff"
-        ),
-        "output_top_logprob_max_abs_diff": result.get(
-            "max_output_top_logprob_diff"
-        ),
-        "prompt_perplexity_max_abs_diff": result.get(
-            "max_prompt_perplexity_abs_diff"
-        ),
+        "prompt_top_logprob_max_abs_diff": result.get("max_prompt_top_logprob_diff"),
+        "output_top_logprob_max_abs_diff": result.get("max_output_top_logprob_diff"),
+        "prompt_perplexity_max_abs_diff": result.get("max_prompt_perplexity_abs_diff"),
         "sampler_logits_max_abs_diff": None
         if sampler_logits_diff is None
         else sampler_logits_diff.get("max_abs_diff"),

--- a/benchmarks/benchmark_sm70_source_inventory.py
+++ b/benchmarks/benchmark_sm70_source_inventory.py
@@ -501,19 +501,14 @@ def _scan_tree(root: Path) -> dict[str, Any]:
         "file_count": file_count,
         "scanned_bytes": scanned_bytes,
         "env_vars": {
-            name: sorted(files)
-            for name, files in sorted(env_to_files.items())
+            name: sorted(files) for name, files in sorted(env_to_files.items())
         },
         "runtime_env_vars": {
-            name: sorted(files)
-            for name, files in sorted(runtime_env_to_files.items())
+            name: sorted(files) for name, files in sorted(runtime_env_to_files.items())
         },
         "env_file_counts": dict(sorted(env_counts.items())),
         "keyword_files": dict(sorted(keyword_files.items())),
-        "torch_ops": {
-            name: sorted(files)
-            for name, files in sorted(torch_ops.items())
-        },
+        "torch_ops": {name: sorted(files) for name, files in sorted(torch_ops.items())},
     }
 
 
@@ -596,11 +591,11 @@ def _compact_diff(old: dict[str, Any], latest: dict[str, Any]) -> dict[str, Any]
     diff["old_only_torch_op_classification"] = _classify_old_only_torch_ops(
         diff["torch_ops"]["old_only"]
     )
-    diff["old_only_runtime_env_classification"] = (
-        _classify_old_only_runtime_envs(diff["runtime_env_vars"]["old_only"])
+    diff["old_only_runtime_env_classification"] = _classify_old_only_runtime_envs(
+        diff["runtime_env_vars"]["old_only"]
     )
-    diff["old_only_keyword_file_classification"] = (
-        _classify_old_only_keyword_files(diff["keyword_files"]["old_only"])
+    diff["old_only_keyword_file_classification"] = _classify_old_only_keyword_files(
+        diff["keyword_files"]["old_only"]
     )
     return diff
 
@@ -616,15 +611,9 @@ def _classification_counts(section: dict[str, Any]) -> dict[str, Any]:
 
 
 def _inventory_gate(diff: dict[str, Any]) -> dict[str, Any]:
-    runtime_env = _classification_counts(
-        diff["old_only_runtime_env_classification"]
-    )
-    keyword_files = _classification_counts(
-        diff["old_only_keyword_file_classification"]
-    )
-    torch_ops = _classification_counts(
-        diff["old_only_torch_op_classification"]
-    )
+    runtime_env = _classification_counts(diff["old_only_runtime_env_classification"])
+    keyword_files = _classification_counts(diff["old_only_keyword_file_classification"])
+    torch_ops = _classification_counts(diff["old_only_torch_op_classification"])
     old_only_env_vars = diff["env_vars"]["old_only"]
     complete = (
         not old_only_env_vars
@@ -674,32 +663,37 @@ def main() -> int:
         json.dumps(payload, indent=args.indent, sort_keys=True) + "\n",
         encoding="utf-8",
     )
-    print(json.dumps({
-        "out": str(args.out),
-        "old_files": payload["old"]["file_count"],
-        "latest_files": payload["latest"]["file_count"],
-        "old_env_vars": len(payload["old"]["env_vars"]),
-        "latest_env_vars": len(payload["latest"]["env_vars"]),
-        "old_runtime_env_vars": len(payload["old"]["runtime_env_vars"]),
-        "latest_runtime_env_vars": len(payload["latest"]["runtime_env_vars"]),
-            "old_keyword_files": len(payload["old"]["keyword_files"]),
-            "latest_keyword_files": len(payload["latest"]["keyword_files"]),
-            "old_torch_ops": len(payload["old"]["torch_ops"]),
-            "latest_torch_ops": len(payload["latest"]["torch_ops"]),
-            "inventory_complete": payload["inventory_gate"]["complete"],
-            "old_only_env_vars": payload["inventory_gate"][
-                "old_only_env_vars_count"
-            ],
-            "old_only_runtime_env_unclassified": payload["inventory_gate"][
-                "old_only_runtime_env"
-            ]["unclassified_count"],
-            "old_only_keyword_files_unclassified": payload["inventory_gate"][
-                "old_only_keyword_files"
-            ]["unclassified_count"],
-            "old_only_torch_ops_unclassified": payload["inventory_gate"][
-                "old_only_torch_ops"
-            ]["unclassified_count"],
-        }, sort_keys=True))
+    print(
+        json.dumps(
+            {
+                "out": str(args.out),
+                "old_files": payload["old"]["file_count"],
+                "latest_files": payload["latest"]["file_count"],
+                "old_env_vars": len(payload["old"]["env_vars"]),
+                "latest_env_vars": len(payload["latest"]["env_vars"]),
+                "old_runtime_env_vars": len(payload["old"]["runtime_env_vars"]),
+                "latest_runtime_env_vars": len(payload["latest"]["runtime_env_vars"]),
+                "old_keyword_files": len(payload["old"]["keyword_files"]),
+                "latest_keyword_files": len(payload["latest"]["keyword_files"]),
+                "old_torch_ops": len(payload["old"]["torch_ops"]),
+                "latest_torch_ops": len(payload["latest"]["torch_ops"]),
+                "inventory_complete": payload["inventory_gate"]["complete"],
+                "old_only_env_vars": payload["inventory_gate"][
+                    "old_only_env_vars_count"
+                ],
+                "old_only_runtime_env_unclassified": payload["inventory_gate"][
+                    "old_only_runtime_env"
+                ]["unclassified_count"],
+                "old_only_keyword_files_unclassified": payload["inventory_gate"][
+                    "old_only_keyword_files"
+                ]["unclassified_count"],
+                "old_only_torch_ops_unclassified": payload["inventory_gate"][
+                    "old_only_torch_ops"
+                ]["unclassified_count"],
+            },
+            sort_keys=True,
+        )
+    )
     return 0
 
 

--- a/benchmarks/benchmark_sm70_turbomind_parity.py
+++ b/benchmarks/benchmark_sm70_turbomind_parity.py
@@ -94,8 +94,9 @@ def _load_awq(
     device: torch.device,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     weight_map = _weight_map(model_path)
-    with safe_open(model_path / weight_map[f"{layer}.qweight"],
-                   framework="pt", device="cpu") as f:
+    with safe_open(
+        model_path / weight_map[f"{layer}.qweight"], framework="pt", device="cpu"
+    ) as f:
         qweight = f.get_tensor(f"{layer}.qweight").to(device).contiguous()
         scales = f.get_tensor(f"{layer}.scales").to(device).contiguous()
         qzeros = f.get_tensor(f"{layer}.qzeros").to(device).contiguous()
@@ -108,8 +109,9 @@ def _load_fp8(
     device: torch.device,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     weight_map = _weight_map(model_path)
-    with safe_open(model_path / weight_map[f"{layer}.weight"],
-                   framework="pt", device="cpu") as f:
+    with safe_open(
+        model_path / weight_map[f"{layer}.weight"], framework="pt", device="cpu"
+    ) as f:
         weight = f.get_tensor(f"{layer}.weight").to(device).contiguous()
         scales = (
             f.get_tensor(f"{layer}.weight_scale_inv")
@@ -158,9 +160,7 @@ def _dump_fp8(
     ops = _import_sm70_ops()
     weight, scales = _load_fp8(args.model, args.layer, device)
     x = _make_input(args.m, weight.shape[1], device)
-    tm_weight, tm_scales, meta = ops.fp8_sm70_prepare(
-        weight, scales, args.group_size
-    )
+    tm_weight, tm_scales, meta = ops.fp8_sm70_prepare(weight, scales, args.group_size)
     out = torch.empty((args.m, weight.shape[0]), device=device, dtype=torch.float16)
     ops.fp8_gemm_sm70_out_meta(out, x, tm_weight, tm_scales, meta)
     details = {
@@ -205,8 +205,13 @@ def _dump(args: argparse.Namespace) -> int:
         "output": out.detach().cpu(),
     }
     torch.save(payload, args.out)
-    print(json.dumps({k: v for k, v in payload.items() if k != "output"},
-                     indent=2, sort_keys=True))
+    print(
+        json.dumps(
+            {k: v for k, v in payload.items() if k != "output"},
+            indent=2,
+            sort_keys=True,
+        )
+    )
     return 0
 
 
@@ -270,9 +275,9 @@ def _bench_awq(
     tm_weight, tm_scales, meta = ops.awq_sm70_prepare(
         qweight, scales, qzeros, args.group_size
     )
-    out = torch.empty((args.m, qweight.shape[1] * 8),
-                      device=device,
-                      dtype=torch.float16)
+    out = torch.empty(
+        (args.m, qweight.shape[1] * 8), device=device, dtype=torch.float16
+    )
     k_ld = int(meta[0].item())
     q_ld = int(meta[1].item())
 
@@ -300,9 +305,7 @@ def _bench_fp8(
     ops = _import_sm70_ops()
     weight, scales = _load_fp8(args.model, args.layer, device)
     x = _make_input(args.m, weight.shape[1], device)
-    tm_weight, tm_scales, meta = ops.fp8_sm70_prepare(
-        weight, scales, args.group_size
-    )
+    tm_weight, tm_scales, meta = ops.fp8_sm70_prepare(weight, scales, args.group_size)
     out = torch.empty((args.m, weight.shape[0]), device=device, dtype=torch.float16)
 
     def run() -> None:

--- a/benchmarks/benchmark_sm70_wmma_fragment_probe.py
+++ b/benchmarks/benchmark_sm70_wmma_fragment_probe.py
@@ -15,11 +15,7 @@ from torch.utils.cpp_extension import load
 
 
 def _load_extension() -> object:
-    source = (
-        Path(__file__).resolve().parent
-        / "csrc"
-        / "sm70_wmma_fragment_probe.cu"
-    )
+    source = Path(__file__).resolve().parent / "csrc" / "sm70_wmma_fragment_probe.cu"
     os.environ.setdefault("TORCH_CUDA_ARCH_LIST", "7.0")
     return load(
         name="sm70_wmma_fragment_probe_v3",
@@ -41,17 +37,16 @@ def _parse_args() -> argparse.Namespace:
 def main() -> int:
     args = _parse_args()
     device = torch.device(args.device)
-    if not torch.cuda.is_available() or torch.cuda.get_device_capability(
-        device
-    ) != (7, 0):
+    if not torch.cuda.is_available() or torch.cuda.get_device_capability(device) != (
+        7,
+        0,
+    ):
         raise RuntimeError("This probe requires an SM70 CUDA device.")
 
     extension = _load_extension()
     tile = torch.arange(256, device=device, dtype=torch.float16).reshape(16, 16)
     words = extension.dump_matrix_a_fragment(tile, args.stride)
-    reference_words, swizzled_words = (
-        extension.compare_swizzled_matrix_a_fragment(tile)
-    )
+    reference_words, swizzled_words = extension.compare_swizzled_matrix_a_fragment(tile)
     matrix_b_row_words = extension.dump_matrix_b_fragment(tile, False)
     matrix_b_col_storage = tile.t().contiguous()
     matrix_b_col_words = extension.dump_matrix_b_fragment(
@@ -59,9 +54,7 @@ def main() -> int:
         True,
     )
     matrix_b_reference_words, matrix_b_compact_words = (
-        extension.compare_compact_matrix_b_col_fragment(
-            matrix_b_col_storage
-        )
+        extension.compare_compact_matrix_b_col_fragment(matrix_b_col_storage)
     )
     torch.cuda.synchronize(device)
     elements = words.cpu().view(torch.float16).to(torch.int32).reshape(32, 16)
@@ -69,15 +62,10 @@ def main() -> int:
     counts = Counter(value for lane in mapping for value in lane)
     multiplicities = Counter(counts.values())
     matrix_b_elements = (
-        matrix_b_col_words.cpu()
-        .view(torch.float16)
-        .to(torch.int32)
-        .reshape(32, 16)
+        matrix_b_col_words.cpu().view(torch.float16).to(torch.int32).reshape(32, 16)
     )
     matrix_b_mapping = matrix_b_elements.tolist()
-    matrix_b_counts = Counter(
-        value for lane in matrix_b_mapping for value in lane
-    )
+    matrix_b_counts = Counter(value for lane in matrix_b_mapping for value in lane)
     matrix_b_multiplicities = Counter(matrix_b_counts.values())
     payload = {
         "device": str(device),
@@ -94,10 +82,7 @@ def main() -> int:
             torch.equal(reference_words, swizzled_words)
         ),
         "swizzled_fragment_max_word_xor": int(
-            torch.bitwise_xor(reference_words, swizzled_words)
-            .abs()
-            .max()
-            .item()
+            torch.bitwise_xor(reference_words, swizzled_words).abs().max().item()
         ),
         "matrix_b": {
             "lane_elements": matrix_b_mapping,
@@ -106,8 +91,7 @@ def main() -> int:
                 str(key): value
                 for key, value in sorted(matrix_b_multiplicities.items())
             },
-            "all_elements_covered": sorted(matrix_b_counts)
-            == list(range(256)),
+            "all_elements_covered": sorted(matrix_b_counts) == list(range(256)),
             "row_col_fragment_words_equal": bool(
                 torch.equal(matrix_b_row_words, matrix_b_col_words)
             ),

--- a/benchmarks/compare_sm70_tensor_dumps.py
+++ b/benchmarks/compare_sm70_tensor_dumps.py
@@ -79,11 +79,13 @@ def _load_records(root: Path) -> dict[tuple[Any, ...], list[dict[str, Any]]]:
         source = payload.get("source", payload.get("layer_type", "unknown"))
         shape = tuple(payload.get("shape", tuple(tensor.shape)))
         key = (step, layer_idx, source, label, shape)
-        records.setdefault(key, []).append({
-            "path": str(path),
-            "pid": payload.get("pid"),
-            "tensor": tensor,
-        })
+        records.setdefault(key, []).append(
+            {
+                "path": str(path),
+                "pid": payload.get("pid"),
+                "tensor": tensor,
+            }
+        )
     return records
 
 
@@ -134,33 +136,37 @@ def compare_dirs(left: Path, right: Path, top: int) -> dict[str, Any]:
         right_items = right_records.get(key, [])
         step, layer_idx, source, label, shape = key
         if not left_items or not right_items:
-            missing.append({
-                "step": step,
-                "layer_idx": layer_idx,
-                "source": source,
-                "label": label,
-                "shape": shape,
-                "left_count": len(left_items),
-                "right_count": len(right_items),
-            })
+            missing.append(
+                {
+                    "step": step,
+                    "layer_idx": layer_idx,
+                    "source": source,
+                    "label": label,
+                    "shape": shape,
+                    "left_count": len(left_items),
+                    "right_count": len(right_items),
+                }
+            )
             continue
         _, pairs = _best_pairing(left_items, right_items)
         for left_idx, right_idx, stats in pairs:
             left_tensor = left_items[left_idx]["tensor"]
             right_tensor = right_items[right_idx]["tensor"]
-            summaries.append({
-                "step": step,
-                "layer_idx": layer_idx,
-                "source": source,
-                "label": label,
-                "shape": shape,
-                "left_pid": left_items[left_idx]["pid"],
-                "right_pid": right_items[right_idx]["pid"],
-                "left_path": left_items[left_idx]["path"],
-                "right_path": right_items[right_idx]["path"],
-                **stats,
-                "rows": _row_stats(left_tensor, right_tensor),
-            })
+            summaries.append(
+                {
+                    "step": step,
+                    "layer_idx": layer_idx,
+                    "source": source,
+                    "label": label,
+                    "shape": shape,
+                    "left_pid": left_items[left_idx]["pid"],
+                    "right_pid": right_items[right_idx]["pid"],
+                    "left_path": left_items[left_idx]["path"],
+                    "right_path": right_items[right_idx]["path"],
+                    **stats,
+                    "rows": _row_stats(left_tensor, right_tensor),
+                }
+            )
 
     by_worst = sorted(
         summaries,
@@ -262,10 +268,12 @@ def _numeric_gate(
 
     if missing and not allow_missing:
         for item in missing[:20]:
-            violations.append({
-                "reason": "missing_tensor_dump",
-                **item,
-            })
+            violations.append(
+                {
+                    "reason": "missing_tensor_dump",
+                    **item,
+                }
+            )
 
     for item in compared:
         max_abs = float(item.get("max_abs", math.inf))
@@ -280,21 +288,25 @@ def _numeric_gate(
             )
 
         if item.get("shape_mismatch"):
-            violations.append({
-                "reason": "shape_mismatch",
-                **_record_ref(item),
-                "left_shape": item.get("left_shape"),
-                "right_shape": item.get("right_shape"),
-            })
+            violations.append(
+                {
+                    "reason": "shape_mismatch",
+                    **_record_ref(item),
+                    "left_shape": item.get("left_shape"),
+                    "right_shape": item.get("right_shape"),
+                }
+            )
             continue
 
         if not math.isfinite(max_abs) or not math.isfinite(mean_abs):
-            violations.append({
-                "reason": "non_finite_diff",
-                **_record_ref(item),
-                "max_abs": item.get("max_abs"),
-                "mean_abs": item.get("mean_abs"),
-            })
+            violations.append(
+                {
+                    "reason": "non_finite_diff",
+                    **_record_ref(item),
+                    "max_abs": item.get("max_abs"),
+                    "mean_abs": item.get("mean_abs"),
+                }
+            )
             continue
 
         item_max_abs_bound, max_abs_rule = _bound_for_item(
@@ -304,21 +316,25 @@ def _numeric_gate(
         )
         if item_max_abs_bound is None:
             if max_abs != 0.0:
-                pending.append({
-                    "reason": "nonzero_max_abs_without_bound",
-                    **_record_ref(item),
-                    "max_abs": max_abs,
-                })
+                pending.append(
+                    {
+                        "reason": "nonzero_max_abs_without_bound",
+                        **_record_ref(item),
+                        "max_abs": max_abs,
+                    }
+                )
         else:
             checked_max_abs += 1
             if max_abs > item_max_abs_bound:
-                violations.append({
-                    "reason": "max_abs_exceeds_bound",
-                    **_record_ref(item),
-                    "max_abs": max_abs,
-                    "bound": item_max_abs_bound,
-                    "bound_rule": max_abs_rule,
-                })
+                violations.append(
+                    {
+                        "reason": "max_abs_exceeds_bound",
+                        **_record_ref(item),
+                        "max_abs": max_abs,
+                        "bound": item_max_abs_bound,
+                        "bound_rule": max_abs_rule,
+                    }
+                )
 
         item_mean_abs_bound, mean_abs_rule = _bound_for_item(
             item,
@@ -328,23 +344,27 @@ def _numeric_gate(
         if item_mean_abs_bound is not None:
             checked_mean_abs += 1
             if mean_abs > item_mean_abs_bound:
-                violations.append({
-                    "reason": "mean_abs_exceeds_bound",
-                    **_record_ref(item),
-                    "mean_abs": mean_abs,
-                    "bound": item_mean_abs_bound,
-                    "bound_rule": mean_abs_rule,
-                })
+                violations.append(
+                    {
+                        "reason": "mean_abs_exceeds_bound",
+                        **_record_ref(item),
+                        "mean_abs": mean_abs,
+                        "bound": item_mean_abs_bound,
+                        "bound_rule": mean_abs_rule,
+                    }
+                )
 
         if min_cosine is not None and cosine is not None:
             checked_cosine += 1
             if cosine < min_cosine:
-                violations.append({
-                    "reason": "cosine_below_bound",
-                    **_record_ref(item),
-                    "cosine": cosine,
-                    "bound": min_cosine,
-                })
+                violations.append(
+                    {
+                        "reason": "cosine_below_bound",
+                        **_record_ref(item),
+                        "cosine": cosine,
+                        "bound": min_cosine,
+                    }
+                )
 
     if checked_max_abs == 0 and (max_abs_bound is not None or max_abs_rules):
         pending.append("no tensors matched any max_abs bound")

--- a/benchmarks/verify_sm70_artifact.py
+++ b/benchmarks/verify_sm70_artifact.py
@@ -74,18 +74,14 @@ AWQ_TURBOMIND_DENSE_JSON_EXPECTATIONS = (
     ("sm70_turbomind_policy.awq_turbomind_effective", True),
 )
 
-AWQ_TURBOMIND_DENSE_REQUIRED_LOGS = (
-    "SM70 AWQ TurboMind dense path enabled",
-)
+AWQ_TURBOMIND_DENSE_REQUIRED_LOGS = ("SM70 AWQ TurboMind dense path enabled",)
 
 FP8_TURBOMIND_DENSE_JSON_EXPECTATIONS = (
     ("sm70_turbomind_policy.fp8_turbomind_effective", True),
     ("sm70_turbomind_policy.fp8_dequant_fallback_effective", True),
 )
 
-FP8_TURBOMIND_DENSE_REQUIRED_LOGS = (
-    "SM70 FP8 TurboMind W8A16 dense path enabled",
-)
+FP8_TURBOMIND_DENSE_REQUIRED_LOGS = ("SM70 FP8 TurboMind W8A16 dense path enabled",)
 
 FP8_0DOT3_DENSE_DEQUANT_JSON_EXPECTATIONS = (
     ("sm70_turbomind_policy.fp8_turbomind_effective", False),
@@ -104,8 +100,7 @@ AWQ_MOE_SAFE_ROUTE_JSON_EXPECTATIONS = (
     ("sm70_turbomind_policy.accepted_awq_moe_default_policy", True),
     ("sm70_turbomind_policy.awq_moe_disable_effective", False),
     ("sm70_turbomind_policy.awq_moe_batched_gemm_effective", False),
-    ("sm70_turbomind_policy.awq_moe_legacy_single_token_compact_effective",
-     False),
+    ("sm70_turbomind_policy.awq_moe_legacy_single_token_compact_effective", False),
     ("sm70_moe_policy.single_token_unpermute_fastpath_effective", True),
 )
 
@@ -120,8 +115,7 @@ AWQ_MOE_BATCHED_SAFE_ROUTE_JSON_EXPECTATIONS = (
     ("sm70_turbomind_policy.accepted_awq_moe_default_policy", True),
     ("sm70_turbomind_policy.awq_moe_disable_effective", False),
     ("sm70_turbomind_policy.awq_moe_batched_gemm_effective", True),
-    ("sm70_turbomind_policy.awq_moe_legacy_single_token_compact_effective",
-     False),
+    ("sm70_turbomind_policy.awq_moe_legacy_single_token_compact_effective", False),
 )
 
 AWQ_MOE_BATCHED_SAFE_ROUTE_REQUIRED_LOGS = (
@@ -137,8 +131,7 @@ AWQ_MOE_0DOT3_BASELINE_ROUTE_JSON_EXPECTATIONS = (
     ("sm70_turbomind_policy.awq_moe_0dot3_baseline_policy", True),
     ("sm70_turbomind_policy.awq_moe_disable_effective", False),
     ("sm70_turbomind_policy.awq_moe_batched_gemm_effective", True),
-    ("sm70_turbomind_policy.awq_moe_legacy_single_token_compact_effective",
-     True),
+    ("sm70_turbomind_policy.awq_moe_legacy_single_token_compact_effective", True),
 )
 
 AWQ_MOE_0DOT3_BASELINE_ROUTE_REQUIRED_LOGS = (
@@ -152,9 +145,7 @@ FP8_MOE_SAFE_ROUTE_JSON_EXPECTATIONS = (
     ("sm70_turbomind_policy.fp8_moe_batched_gemm_effective", True),
 )
 
-FP8_MOE_SAFE_ROUTE_REQUIRED_LOGS = (
-    "SM70 FP8 MoE TurboMind batched path enabled",
-)
+FP8_MOE_SAFE_ROUTE_REQUIRED_LOGS = ("SM70 FP8 MoE TurboMind batched path enabled",)
 
 FP8_MOE_0DOT3_FALLBACK_ROUTE_JSON_EXPECTATIONS = (
     ("sm70_turbomind_policy.fp8_moe_0dot3_dequant_fallback_policy", True),
@@ -280,9 +271,7 @@ def _get_json_path(payload: Any, path: str) -> Any:
 
 def _parse_expectation(raw: str) -> tuple[str, Any]:
     if "=" not in raw:
-        raise ValueError(
-            f"Expected PATH=VALUE for --expect-json, got {raw!r}"
-        )
+        raise ValueError(f"Expected PATH=VALUE for --expect-json, got {raw!r}")
     path, expected = raw.split("=", 1)
     if not path:
         raise ValueError(f"Expected non-empty PATH in {raw!r}")
@@ -338,17 +327,13 @@ def _awq_moe_safe_tune_gate_for_meta(meta: Any) -> dict[str, Any]:
         }
 
     raw = tune_policy.get("VLLM_SM70_AWQ_TUNE_SMALL_SHAPES")
-    tune_safe_default = tune_policy.get(
-        "awq_moe_safe_default_selector_effective"
-    )
+    tune_safe_default = tune_policy.get("awq_moe_safe_default_selector_effective")
     turbomind_safe_default = turbomind_policy.get(
         "awq_moe_safe_default_selector_effective"
     )
     pinned = raw == "0"
     source_safe_unset = (
-        raw is None
-        and tune_safe_default is True
-        and turbomind_safe_default is True
+        raw is None and tune_safe_default is True and turbomind_safe_default is True
     )
     return {
         "passed": pinned or source_safe_unset,
@@ -408,10 +393,12 @@ def _awq_moe_safe_tune_gate(payload: Any) -> dict[str, Any]:
     return {
         "passed": False,
         "location": None,
-        "checks": [{
-            "passed": False,
-            "reason": "no top-level or compare metadata policies found",
-        }],
+        "checks": [
+            {
+                "passed": False,
+                "reason": "no top-level or compare metadata policies found",
+            }
+        ],
     }
 
 
@@ -528,8 +515,7 @@ def _model_quality_failures(payload: Any) -> list[str]:
     failures = []
     if gate.get("label") != "model-pass":
         failures.append(
-            "model_quality_gate.label is not model-pass "
-            f"({gate.get('label')!r})"
+            f"model_quality_gate.label is not model-pass ({gate.get('label')!r})"
         )
     if gate.get("default_acceptance") != "model-level gate passed":
         failures.append(
@@ -585,8 +571,7 @@ def _inventory_complete_failures(payload: Any) -> list[str]:
     failures = []
     if gate.get("label") != "inventory-complete":
         failures.append(
-            "inventory_gate.label is not inventory-complete "
-            f"({gate.get('label')!r})"
+            f"inventory_gate.label is not inventory-complete ({gate.get('label')!r})"
         )
     if gate.get("complete") is not True:
         failures.append("inventory_gate.complete is not true")
@@ -594,8 +579,7 @@ def _inventory_complete_failures(payload: Any) -> list[str]:
     old_only_env_vars = gate.get("old_only_env_vars")
     if old_only_env_vars:
         failures.append(
-            "inventory_gate.old_only_env_vars is not empty: "
-            f"{old_only_env_vars!r}"
+            f"inventory_gate.old_only_env_vars is not empty: {old_only_env_vars!r}"
         )
     if gate.get("old_only_env_vars_count") != 0:
         failures.append(
@@ -646,11 +630,13 @@ def _verify(
         present = location is not None
         if not present:
             missing_policies.append(policy)
-        policy_results.append({
-            "policy": policy,
-            "present": present,
-            "location": location,
-        })
+        policy_results.append(
+            {
+                "policy": policy,
+                "present": present,
+                "location": location,
+            }
+        )
 
     json_results = []
     failed_json_expectations = []
@@ -677,10 +663,12 @@ def _verify(
         present = text in logs
         if not present:
             missing_log_texts.append(text)
-        log_results.append({
-            "text": text,
-            "present": present,
-        })
+        log_results.append(
+            {
+                "text": text,
+                "present": present,
+            }
+        )
 
     log_regex_results = []
     missing_log_regexes = []
@@ -688,10 +676,12 @@ def _verify(
         present = re.search(pattern, logs) is not None
         if not present:
             missing_log_regexes.append(pattern)
-        log_regex_results.append({
-            "pattern": pattern,
-            "present": present,
-        })
+        log_regex_results.append(
+            {
+                "pattern": pattern,
+                "present": present,
+            }
+        )
 
     rejected_log_results = []
     rejected_log_texts = []
@@ -699,10 +689,12 @@ def _verify(
         present = text in logs
         if present:
             rejected_log_texts.append(text)
-        rejected_log_results.append({
-            "text": text,
-            "present": present,
-        })
+        rejected_log_results.append(
+            {
+                "text": text,
+                "present": present,
+            }
+        )
 
     rejected_log_regex_results = []
     rejected_log_regexes = []
@@ -710,10 +702,12 @@ def _verify(
         present = re.search(pattern, logs) is not None
         if present:
             rejected_log_regexes.append(pattern)
-        rejected_log_regex_results.append({
-            "pattern": pattern,
-            "present": present,
-        })
+        rejected_log_regex_results.append(
+            {
+                "pattern": pattern,
+                "present": present,
+            }
+        )
 
     decode_timing_failures = (
         _decode_timing_failures(payload) if require_decode_timing else []
@@ -722,8 +716,7 @@ def _verify(
         _model_quality_failures(payload) if require_model_quality_pass else []
     )
     inventory_complete_failures = (
-        _inventory_complete_failures(payload)
-        if require_inventory_complete else []
+        _inventory_complete_failures(payload) if require_inventory_complete else []
     )
 
     passed = not (
@@ -887,9 +880,7 @@ def _build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--require-awq-turbomind-dense",
         action="store_true",
-        help=(
-            "Require SM70 AWQ TurboMind dense policy and its runtime route log."
-        ),
+        help=("Require SM70 AWQ TurboMind dense policy and its runtime route log."),
     )
     parser.add_argument(
         "--require-fp8-turbomind-dense",
@@ -1016,9 +1007,7 @@ def main() -> int:
 
     try:
         payload = _read_json(args.json)
-        expectations = [
-            _parse_expectation(raw) for raw in args.expect_json
-        ]
+        expectations = [_parse_expectation(raw) for raw in args.expect_json]
         log_expectations = list(args.expect_log)
         log_regex_expectations = list(args.expect_log_regex)
         rejected_log_expectations = list(args.reject_log)
@@ -1033,9 +1022,7 @@ def main() -> int:
             log_expectations.extend(FULL_FLASH_V100_REQUIRED_LOGS)
             log_expectations.extend(SM70_FP8_KV_CACHE_ROUTE_REQUIRED_LOGS)
             rejected_log_expectations.extend(FULL_FLASH_V100_REJECTED_LOGS)
-            rejected_log_expectations.extend(
-                SM70_FP8_KV_CACHE_ROUTE_REJECTED_LOGS
-            )
+            rejected_log_expectations.extend(SM70_FP8_KV_CACHE_ROUTE_REJECTED_LOGS)
         if args.require_turbomind_default_policy:
             expectations.extend(TURBOMIND_DEFAULT_JSON_EXPECTATIONS)
         if args.require_awq_turbomind_dense:
@@ -1056,27 +1043,17 @@ def main() -> int:
         if args.require_awq_moe_batched_safe_route:
             expectations.extend(AWQ_MOE_BATCHED_SAFE_ROUTE_JSON_EXPECTATIONS)
             log_expectations.extend(AWQ_MOE_BATCHED_SAFE_ROUTE_REQUIRED_LOGS)
-            rejected_log_expectations.extend(
-                AWQ_MOE_BATCHED_SAFE_ROUTE_REJECTED_LOGS
-            )
+            rejected_log_expectations.extend(AWQ_MOE_BATCHED_SAFE_ROUTE_REJECTED_LOGS)
         if args.require_awq_moe_0dot3_baseline_route:
             expectations.extend(AWQ_MOE_0DOT3_BASELINE_ROUTE_JSON_EXPECTATIONS)
-            log_expectations.extend(
-                AWQ_MOE_0DOT3_BASELINE_ROUTE_REQUIRED_LOGS
-            )
+            log_expectations.extend(AWQ_MOE_0DOT3_BASELINE_ROUTE_REQUIRED_LOGS)
         if args.require_fp8_moe_safe_route:
             expectations.extend(FP8_MOE_SAFE_ROUTE_JSON_EXPECTATIONS)
             log_expectations.extend(FP8_MOE_SAFE_ROUTE_REQUIRED_LOGS)
         if args.require_fp8_moe_0dot3_fallback_route:
-            expectations.extend(
-                FP8_MOE_0DOT3_FALLBACK_ROUTE_JSON_EXPECTATIONS
-            )
-            log_expectations.extend(
-                FP8_MOE_0DOT3_FALLBACK_ROUTE_REQUIRED_LOGS
-            )
-            rejected_log_expectations.extend(
-                FP8_MOE_0DOT3_FALLBACK_ROUTE_REJECTED_LOGS
-            )
+            expectations.extend(FP8_MOE_0DOT3_FALLBACK_ROUTE_JSON_EXPECTATIONS)
+            log_expectations.extend(FP8_MOE_0DOT3_FALLBACK_ROUTE_REQUIRED_LOGS)
+            rejected_log_expectations.extend(FP8_MOE_0DOT3_FALLBACK_ROUTE_REJECTED_LOGS)
         extra_required_policies = list(args.require_policy)
         if args.require_sm70_breakable_graph_route:
             extra_required_policies.append("sm70_graph_policy")
@@ -1084,12 +1061,8 @@ def main() -> int:
             log_expectations.extend(SM70_BREAKABLE_GRAPH_ROUTE_REQUIRED_LOGS)
         if args.require_sm70_flash_v100_0dot3_compile_graph:
             extra_required_policies.append("sm70_graph_policy")
-            expectations.extend(
-                SM70_FLASH_V100_0DOT3_COMPILE_GRAPH_JSON_EXPECTATIONS
-            )
-            log_expectations.extend(
-                SM70_FLASH_V100_0DOT3_COMPILE_GRAPH_REQUIRED_LOGS
-            )
+            expectations.extend(SM70_FLASH_V100_0DOT3_COMPILE_GRAPH_JSON_EXPECTATIONS)
+            log_expectations.extend(SM70_FLASH_V100_0DOT3_COMPILE_GRAPH_REQUIRED_LOGS)
             rejected_log_expectations.extend(
                 SM70_FLASH_V100_0DOT3_COMPILE_GRAPH_REJECTED_LOGS
             )
@@ -1097,19 +1070,17 @@ def main() -> int:
             extra_required_policies.append("sm70_comm_policy")
             expectations.extend(SM70_CUSTOM_ALLREDUCE_ROUTE_JSON_EXPECTATIONS)
             log_expectations.extend(SM70_CUSTOM_ALLREDUCE_ROUTE_REQUIRED_LOGS)
-            rejected_log_expectations.extend(
-                SM70_CUSTOM_ALLREDUCE_ROUTE_REJECTED_LOGS
-            )
+            rejected_log_expectations.extend(SM70_CUSTOM_ALLREDUCE_ROUTE_REJECTED_LOGS)
         if args.require_sm70_all_reduce_sum2_route:
             extra_required_policies.append("sm70_comm_policy")
             expectations.extend(SM70_ALL_REDUCE_SUM2_ROUTE_JSON_EXPECTATIONS)
             log_expectations.extend(SM70_ALL_REDUCE_SUM2_ROUTE_REQUIRED_LOGS)
-            log_regex_expectations.extend(
-                SM70_ALL_REDUCE_SUM2_ROUTE_REQUIRED_REGEXES
-            )
-        required_policies = [] if args.require_inventory_complete else list(
-            dict.fromkeys(
-                list(DEFAULT_REQUIRED_POLICIES) + extra_required_policies
+            log_regex_expectations.extend(SM70_ALL_REDUCE_SUM2_ROUTE_REQUIRED_REGEXES)
+        required_policies = (
+            []
+            if args.require_inventory_complete
+            else list(
+                dict.fromkeys(list(DEFAULT_REQUIRED_POLICIES) + extra_required_policies)
             )
         )
         result = _verify(
@@ -1126,10 +1097,7 @@ def main() -> int:
             require_model_quality_pass=args.require_model_quality_pass,
             require_inventory_complete=args.require_inventory_complete,
         )
-        if (
-            args.require_awq_moe_safe_route
-            or args.require_awq_moe_batched_safe_route
-        ):
+        if args.require_awq_moe_safe_route or args.require_awq_moe_batched_safe_route:
             awq_moe_safe_tune_gate = _awq_moe_safe_tune_gate(payload)
             result["awq_moe_safe_tune_gate"] = awq_moe_safe_tune_gate
             if not awq_moe_safe_tune_gate["passed"]:

--- a/tests/kernels/attention/test_sm70_flash_v100_splitkv3.py
+++ b/tests/kernels/attention/test_sm70_flash_v100_splitkv3.py
@@ -37,18 +37,14 @@ def _run_case(
         dtype=torch.float16,
     )
     value_cache = torch.randn_like(key_cache)
-    block_table = torch.tensor(
-        [page_ids], device="cuda", dtype=torch.int32
-    )
+    block_table = torch.tensor([page_ids], device="cuda", dtype=torch.int32)
     sequence_lengths = torch.full(
         (batch_size,), sequence_len, device="cuda", dtype=torch.int32
     )
     softmax_scale = head_dim**-0.5
 
     unsplit_out = torch.empty_like(query)
-    unsplit_lse = torch.empty(
-        query.shape[:-1], device="cuda", dtype=torch.float32
-    )
+    unsplit_lse = torch.empty(query.shape[:-1], device="cuda", dtype=torch.float32)
     split_out = torch.empty_like(query)
     split_lse = torch.empty_like(unsplit_lse)
     split_tmp_out = torch.empty(
@@ -202,6 +198,4 @@ def test_splitkv3_python_wrapper_reuses_stream_workspace() -> None:
         rtol=0.0,
         atol=0.001953125,
     )
-    torch.testing.assert_close(
-        second_lse, result["unsplit_lse"], rtol=0.0, atol=0.001
-    )
+    torch.testing.assert_close(second_lse, result["unsplit_lse"], rtol=0.0, atol=0.001)

--- a/tests/kernels/moe/test_moe_permute_unpermute.py
+++ b/tests/kernels/moe/test_moe_permute_unpermute.py
@@ -473,9 +473,7 @@ def test_sm70_single_token_weighted_reduce_matches_moe_unpermute():
         )
         topk_weights = torch.randn((1, topk), device=device, dtype=torch.float32)
         dummy_hidden = torch.randn((1, hidden), device=device, dtype=torch.float16)
-        _, _, offsets, inv, _ = moe_permute(
-            dummy_hidden, None, topk_ids, n_expert
-        )
+        _, _, offsets, inv, _ = moe_permute(dummy_hidden, None, topk_ids, n_expert)
         sorted_output_storage = torch.randn(
             (topk, hidden + pad), device=device, dtype=torch.float16
         )
@@ -483,12 +481,8 @@ def test_sm70_single_token_weighted_reduce_matches_moe_unpermute():
 
         expected = torch.empty((1, hidden), device=device, dtype=torch.float16)
         actual = torch.empty_like(expected)
-        reference_sorted_output = (
-            sorted_output.contiguous() if pad else sorted_output
-        )
-        moe_unpermute(
-            expected, reference_sorted_output, topk_weights, inv, offsets
-        )
+        reference_sorted_output = sorted_output.contiguous() if pad else sorted_output
+        moe_unpermute(expected, reference_sorted_output, topk_weights, inv, offsets)
         torch.ops._C.awq_moe_single_token_weighted_reduce_out(
             sorted_output,
             topk_weights,

--- a/tests/kernels/test_fused_recurrent_packed_decode.py
+++ b/tests/kernels/test_fused_recurrent_packed_decode.py
@@ -151,9 +151,7 @@ def test_fused_recurrent_packed_decode_cuda_graph_replay_uses_runtime_indices():
     mixed_qkv_static = torch.empty((B, qkv_dim), device=device, dtype=dtype)
     a_static = torch.empty((B, HV), device=device, dtype=dtype)
     b_static = torch.empty((B, HV), device=device, dtype=dtype)
-    state_static = torch.empty(
-        (num_state_slots, HV, V, K), device=device, dtype=dtype
-    )
+    state_static = torch.empty((num_state_slots, HV, V, K), device=device, dtype=dtype)
     indices_static = torch.empty((B,), device=device, dtype=torch.int32)
     out_static = torch.empty((B, 1, HV, V), device=device, dtype=dtype)
 
@@ -161,9 +159,7 @@ def test_fused_recurrent_packed_decode_cuda_graph_replay_uses_runtime_indices():
     warm_mixed_qkv = torch.randn((B, qkv_dim), device=device, dtype=dtype)
     warm_a = torch.randn((B, HV), device=device, dtype=dtype)
     warm_b = torch.randn((B, HV), device=device, dtype=dtype)
-    warm_state = torch.randn(
-        (num_state_slots, HV, V, K), device=device, dtype=dtype
-    )
+    warm_state = torch.randn((num_state_slots, HV, V, K), device=device, dtype=dtype)
     warm_indices = torch.tensor([0, 1, -1, -1], device=device, dtype=torch.int32)
     warm_out = torch.empty_like(out_static)
     fused_recurrent_gated_delta_rule_packed_decode(
@@ -183,9 +179,7 @@ def test_fused_recurrent_packed_decode_cuda_graph_replay_uses_runtime_indices():
     capture_mixed_qkv = torch.randn((B, qkv_dim), device=device, dtype=dtype)
     capture_a = torch.randn((B, HV), device=device, dtype=dtype)
     capture_b = torch.randn((B, HV), device=device, dtype=dtype)
-    capture_state = torch.randn(
-        (num_state_slots, HV, V, K), device=device, dtype=dtype
-    )
+    capture_state = torch.randn((num_state_slots, HV, V, K), device=device, dtype=dtype)
     capture_indices = torch.tensor([6, -1, 7, -1], device=device, dtype=torch.int32)
     mixed_qkv_static.copy_(capture_mixed_qkv)
     a_static.copy_(capture_a)

--- a/tests/tool_parsers/test_qwen3coder_tool_parser.py
+++ b/tests/tool_parsers/test_qwen3coder_tool_parser.py
@@ -1384,7 +1384,7 @@ def test_streaming_multi_param_single_chunk(qwen3_tool_parser, qwen3_tokenizer):
 @pytest.mark.parametrize(
     "deltas, expected_content",
     [
-        (["<", "meta charset=\"UTF-8\">"], '<meta charset="UTF-8">'),
+        (["<", 'meta charset="UTF-8">'], '<meta charset="UTF-8">'),
         (["<t", "itle>macOS</title>"], "<title>macOS</title>"),
         (["<", "<", "span>text</span>"], "<<span>text</span>"),
     ],

--- a/tests/v1/attention/test_gdn_metadata_builder.py
+++ b/tests/v1/attention/test_gdn_metadata_builder.py
@@ -468,9 +468,7 @@ def test_spec_state_slot_selector_can_differ_from_accepted_count(local_gdn_model
         common_prefix_len=0,
         common_attn_metadata=common,
         num_accepted_tokens=torch.tensor([2], dtype=torch.int32, device=DEVICE),
-        spec_state_slot_selectors=torch.tensor(
-            [4], dtype=torch.int32, device=DEVICE
-        ),
+        spec_state_slot_selectors=torch.tensor([4], dtype=torch.int32, device=DEVICE),
         num_decode_draft_tokens_cpu=torch.tensor([4], dtype=torch.int32, device="cpu"),
     )
 
@@ -749,9 +747,7 @@ def test_gdn_state_contract_debug_assert_rejects_pad_accepted_slot(
             spec_sequence_masks_cpu=torch.tensor(
                 [True], dtype=torch.bool, device="cpu"
             ),
-            num_accepted_tokens=torch.tensor(
-                [5], dtype=torch.int32, device=DEVICE
-            ),
+            num_accepted_tokens=torch.tensor([5], dtype=torch.int32, device=DEVICE),
             current_state_block_ids=None,
             is_mamba_cache_all=False,
         )
@@ -778,9 +774,7 @@ def test_spec_commit_pure_decode_consumes_padded_graph_rows_without_metadata_pat
         num_spec_decodes=2,
         num_spec_decode_tokens=10,
         num_actual_tokens=10,
-        spec_query_start_loc=torch.tensor(
-            [0, 5, 10], dtype=torch.int32, device=DEVICE
-        ),
+        spec_query_start_loc=torch.tensor([0, 5, 10], dtype=torch.int32, device=DEVICE),
         spec_state_indices_tensor=torch.tensor(
             [[10, 11, 12, 13, 14], [20, 21, 22, 23, 24]],
             dtype=torch.int32,
@@ -821,7 +815,6 @@ def test_spec_commit_pure_decode_consumes_padded_graph_rows_without_metadata_pat
     seen: dict[str, object] = {}
 
     class FakeLayer:
-
         def __init__(self) -> None:
             self.conv1d = torch.nn.Identity()
             self.conv1d.weight = torch.empty((8, 1, 1), device=DEVICE)
@@ -1023,9 +1016,7 @@ def test_sm70_qwen_gdn_blocks_003_spec_core_only_for_deep_native_mtp(
     expected,
 ):
     monkeypatch.setenv("VLLM_SM70_QWEN_GDN_003_SPEC_CORE_OP", "1")
-    monkeypatch.delenv(
-        "VLLM_SM70_QWEN_GDN_003_SPEC_ALLOW_DEEP_MTP", raising=False
-    )
+    monkeypatch.delenv("VLLM_SM70_QWEN_GDN_003_SPEC_ALLOW_DEEP_MTP", raising=False)
     _clear_envs_cache()
 
     vllm_config = SimpleNamespace(
@@ -1036,9 +1027,7 @@ def test_sm70_qwen_gdn_blocks_003_spec_core_only_for_deep_native_mtp(
     )
 
     assert (
-        qwen_gdn._sm70_qwen_gdn_block_003_spec_for_deep_native_mtp(
-            vllm_config
-        )
+        qwen_gdn._sm70_qwen_gdn_block_003_spec_for_deep_native_mtp(vllm_config)
         is expected
     )
 
@@ -1057,9 +1046,7 @@ def test_sm70_qwen_gdn_003_spec_core_deep_mtp_override_is_diagnostic(
         )
     )
 
-    assert not qwen_gdn._sm70_qwen_gdn_block_003_spec_for_deep_native_mtp(
-        vllm_config
-    )
+    assert not qwen_gdn._sm70_qwen_gdn_block_003_spec_for_deep_native_mtp(vllm_config)
 
 
 def test_sm70_qwen_gdn_003_spec_core_route_has_priority(

--- a/tests/v1/spec_decode/test_ddtree_flex_attention.py
+++ b/tests/v1/spec_decode/test_ddtree_flex_attention.py
@@ -29,11 +29,11 @@ def test_ddtree_logical_mask_hides_siblings() -> None:
     )
 
     assert mask.tolist() == [
-        True,   # history
-        True,   # history
-        True,   # root
-        True,   # parent node 1
-        True,   # self node 2
+        True,  # history
+        True,  # history
+        True,  # root
+        True,  # parent node 1
+        True,  # self node 2
         False,  # sibling node 3
         False,  # beyond tree
     ]

--- a/tests/v1/spec_decode/test_ddtree_gpu_runner_positions.py
+++ b/tests/v1/spec_decode/test_ddtree_gpu_runner_positions.py
@@ -304,9 +304,7 @@ def test_mamba_postprocess_ddtree_state_slot_bias_uses_compact_node_index(
         forward_context=forward_context,
         mamba_state_copy_funcs=(copy_func,),
         copy_bufs=copy_bufs,
-        ddtree_accepted_node_indices=torch.tensor(
-            [[0, 2, 5, 9]], dtype=torch.int32
-        ),
+        ddtree_accepted_node_indices=torch.tensor([[0, 2, 5, 9]], dtype=torch.int32),
     )
 
     assert calls == [(9, 1)]
@@ -317,9 +315,7 @@ def test_update_states_after_model_execute_keeps_compact_state_selector() -> Non
     runner.speculative_config = object()
     runner.model_config = SimpleNamespace(is_hybrid=True)
     runner.cache_config = SimpleNamespace(mamba_cache_mode="none")
-    runner.num_accepted_tokens = SimpleNamespace(
-        gpu=torch.ones(1, dtype=torch.int32)
-    )
+    runner.num_accepted_tokens = SimpleNamespace(gpu=torch.ones(1, dtype=torch.int32))
     runner.spec_state_slot_selectors = SimpleNamespace(
         gpu=torch.ones(1, dtype=torch.int32)
     )
@@ -389,9 +385,7 @@ def test_compact_ddtree_drafter_context_moves_branch_to_prefix() -> None:
     scheduler_output = _scheduler_output(payload)
     scheduler_output.num_scheduled_tokens = {"r0": 6}
     scheduler_output.total_num_scheduled_tokens = 6
-    scheduler_output.scheduled_spec_decode_tokens = {
-        "r0": list(payload.tree_token_ids)
-    }
+    scheduler_output.scheduled_spec_decode_tokens = {"r0": list(payload.tree_token_ids)}
 
     runner._compact_ddtree_drafter_context(
         hidden_states,

--- a/tests/v1/spec_decode/test_ddtree_metadata.py
+++ b/tests/v1/spec_decode/test_ddtree_metadata.py
@@ -34,7 +34,8 @@ def test_single_request_metadata_indices() -> None:
     assert metadata.compact_logits_indices[0] == 6
     assert metadata.compact_logits_indices[1] == 7
     assert metadata.node_compact_indices == tuple(
-        range(1, tree.non_root_nodes[-1].index + 1))
+        range(1, tree.non_root_nodes[-1].index + 1)
+    )
     assert metadata.edge_parent_compact_indices[0] == 0
     assert metadata.edge_parent_compact_indices[1] == 1
     assert metadata.tree_position_ids[:3] == (7, 8, 9)

--- a/tests/v1/worker/test_mamba_utils.py
+++ b/tests/v1/worker/test_mamba_utils.py
@@ -689,9 +689,7 @@ class TestPostprocessMambaFusedKernel:
         torch.manual_seed(20260617)
 
         accepted = [1, 2, 3, 4, 5]
-        req_ids = [f"same_{i}" for i in accepted] + [
-            f"cross_{i}" for i in accepted
-        ]
+        req_ids = [f"same_{i}" for i in accepted] + [f"cross_{i}" for i in accepted]
         num_accepted_tokens = accepted + accepted
         # scheduled=5 and draft=4 gives running_state = computed + 1.
         num_scheduled_tokens = {req_id: 5 for req_id in req_ids}
@@ -742,9 +740,7 @@ class TestPostprocessMambaFusedKernel:
         torch.accelerator.synchronize()
 
         gpu_ctx = _make_gpu_ctx(cfg, kv_cache_config, device)
-        block_table_gpu = torch.zeros(
-            len(req_ids), 8, dtype=torch.int32, device=device
-        )
+        block_table_gpu = torch.zeros(len(req_ids), 8, dtype=torch.int32, device=device)
         for i, block_ids in enumerate(block_ids_per_req):
             block_table_gpu[i, : len(block_ids)] = torch.tensor(
                 block_ids, dtype=torch.int32, device=device

--- a/vllm/compilation/cuda_graph.py
+++ b/vllm/compilation/cuda_graph.py
@@ -192,8 +192,7 @@ class CUDAGraphWrapper:
         self.first_run_finished = False
         self.is_debugging_mode = envs.VLLM_LOGGING_LEVEL == "DEBUG"
         self.check_input_addresses = (
-            self.is_debugging_mode
-            or envs.VLLM_CUDAGRAPH_INPUT_ADDR_DEBUG
+            self.is_debugging_mode or envs.VLLM_CUDAGRAPH_INPUT_ADDR_DEBUG
         )
         self._runnable_str = str(runnable) if self.is_debugging_mode else None
 

--- a/vllm/compilation/passes/fusion/matcher_utils.py
+++ b/vllm/compilation/passes/fusion/matcher_utils.py
@@ -44,8 +44,7 @@ def get_op_overload(
 
 
 ROTARY_OP = get_op_overload(torch.ops._C, "rotary_embedding")
-FLASHINFER_ROTARY_OP = get_op_overload(torch.ops.vllm,
-                                       "flashinfer_rotary_embedding")
+FLASHINFER_ROTARY_OP = get_op_overload(torch.ops.vllm, "flashinfer_rotary_embedding")
 
 QUANT_OPS: dict[QuantKey, OpOverload] = {}
 

--- a/vllm/compilation/passes/fusion/qk_norm_rope_fusion.py
+++ b/vllm/compilation/passes/fusion/qk_norm_rope_fusion.py
@@ -198,8 +198,7 @@ class QKNormRoPEFusionPass(VllmPatternMatcherPass):
         dtype = config.model_config.dtype
         if FUSED_QK_ROPE_OP is None:
             logger.warning_once(
-                "QK Norm+RoPE fusion not enabled: fused_qk_norm_rope is "
-                "unavailable."
+                "QK Norm+RoPE fusion not enabled: fused_qk_norm_rope is unavailable."
             )
             return
 

--- a/vllm/compilation/passes/fusion/rms_quant_fusion.py
+++ b/vllm/compilation/passes/fusion/rms_quant_fusion.py
@@ -124,12 +124,9 @@ def _register_fused_op(
 
 
 _register_fused_op(kFp8StaticTensorSym, False, "rms_norm_static_fp8_quant")
-_register_fused_op(kFp8StaticTensorSym, True,
-                   "fused_add_rms_norm_static_fp8_quant")
-_register_fused_op(kFp8DynamicTokenSym, False,
-                   "rms_norm_dynamic_per_token_quant")
-_register_fused_op(kFp8DynamicTokenSym, True,
-                   "rms_norm_dynamic_per_token_quant")
+_register_fused_op(kFp8StaticTensorSym, True, "fused_add_rms_norm_static_fp8_quant")
+_register_fused_op(kFp8DynamicTokenSym, False, "rms_norm_dynamic_per_token_quant")
+_register_fused_op(kFp8DynamicTokenSym, True, "rms_norm_dynamic_per_token_quant")
 _register_fused_op(kFp8Dynamic128Sym, False, "rms_norm_per_block_quant")
 _register_fused_op(kFp8Dynamic128Sym, True, "rms_norm_per_block_quant")
 _register_fused_op(kFp8Dynamic64Sym, False, "rms_norm_per_block_quant")

--- a/vllm/compilation/passes/utility/fix_functionalization.py
+++ b/vllm/compilation/passes/utility/fix_functionalization.py
@@ -78,9 +78,7 @@ class FixFunctionalizationPass(VllmInductorPass):
         fused_add_rms_norm_static_fp8_quant = _get_c_op(
             "fused_add_rms_norm_static_fp8_quant"
         )
-        rms_norm_dynamic_per_token_quant = _get_c_op(
-            "rms_norm_dynamic_per_token_quant"
-        )
+        rms_norm_dynamic_per_token_quant = _get_c_op("rms_norm_dynamic_per_token_quant")
         rms_norm_targets = [
             op
             for op in (

--- a/vllm/config/speculative.py
+++ b/vllm/config/speculative.py
@@ -295,10 +295,14 @@ class SpeculativeConfig:
         factors: list[Any] = []
         # Eagle3 and extract_hidden_states affect the computation graph because
         # they return intermediate hidden states in addition to the final hidden state.
-        uses_aux_hidden_states = self.method in (
-            "eagle3",
-            "extract_hidden_states",
-        ) or self.use_dflash()
+        uses_aux_hidden_states = (
+            self.method
+            in (
+                "eagle3",
+                "extract_hidden_states",
+            )
+            or self.use_dflash()
+        )
         factors.append(uses_aux_hidden_states)
 
         # The specific layers used also affect the computation graph

--- a/vllm/distributed/device_communicators/cuda_communicator.py
+++ b/vllm/distributed/device_communicators/cuda_communicator.py
@@ -21,9 +21,9 @@ from ..utils import StatelessProcessGroup
 from .base_device_communicator import DeviceCommunicatorBase
 
 logger = init_logger(__name__)
-_SEEN_TP_ALLREDUCE_PATHS: set[
-    tuple[str, str, tuple[int, ...], torch.dtype, int]
-] = set()
+_SEEN_TP_ALLREDUCE_PATHS: set[tuple[str, str, tuple[int, ...], torch.dtype, int]] = (
+    set()
+)
 
 
 def _trace_all_reduce_path(
@@ -99,9 +99,7 @@ class CudaCommunicator(DeviceCommunicatorBase):
         self.use_custom_allreduce = use_custom_allreduce
         self.use_top1_custom_ar = use_top1_custom_ar
         self.use_sm70_awq_mlp_down_tile_ar = use_sm70_awq_mlp_down_tile_ar
-        self.use_sm70_awq_mlp_down_tile_overlap = (
-            use_sm70_awq_mlp_down_tile_overlap
-        )
+        self.use_sm70_awq_mlp_down_tile_overlap = use_sm70_awq_mlp_down_tile_overlap
         self.use_torch_symm_mem = use_torch_symm_mem
         self.use_flashinfer_allreduce = use_flashinfer_allreduce
 
@@ -468,18 +466,14 @@ class CudaCommunicator(DeviceCommunicatorBase):
             k_ld,
             q_ld,
             tile_numel=envs.VLLM_SM70_AWQ_MLP_DOWN_TILE_OVERLAP_TILE_NUMEL,
-            reducer_blocks=(
-                envs.VLLM_SM70_AWQ_MLP_DOWN_TILE_OVERLAP_REDUCER_BLOCKS
-            ),
+            reducer_blocks=(envs.VLLM_SM70_AWQ_MLP_DOWN_TILE_OVERLAP_REDUCER_BLOCKS),
             kernel_reducer_blocks=(
                 envs.VLLM_SM70_AWQ_MLP_DOWN_TILE_OVERLAP_KERNEL_REDUCER_BLOCKS
             ),
             overlap=envs.VLLM_SM70_AWQ_MLP_DOWN_TILE_OVERLAP_SIDE_STREAM,
         )
         if out is not None:
-            _trace_all_reduce_path(
-                self, "sm70_awq_mlp_down_tile_overlap", input_
-            )
+            _trace_all_reduce_path(self, "sm70_awq_mlp_down_tile_overlap", input_)
         return out
 
     def reduce_scatter(self, input_: torch.Tensor, dim: int = -1):

--- a/vllm/distributed/device_communicators/custom_all_reduce.py
+++ b/vllm/distributed/device_communicators/custom_all_reduce.py
@@ -282,9 +282,7 @@ class CustomAllreduce:
         weight: torch.Tensor,
         epsilon: float,
     ) -> tuple[torch.Tensor, torch.Tensor]:
-        if not self.can_sm70_tp2_all_reduce_gemma_rms_norm(
-            inp, residual, weight
-        ):
+        if not self.can_sm70_tp2_all_reduce_gemma_rms_norm(inp, residual, weight):
             raise RuntimeError("SM70 TP2 fused all-reduce RMSNorm is unavailable")
         normalized_out = torch.empty_like(inp)
         residual_out = torch.empty_like(residual, dtype=torch.float32)

--- a/vllm/distributed/parallel_state.py
+++ b/vllm/distributed/parallel_state.py
@@ -695,9 +695,7 @@ class GroupCoordinator:
             raise RuntimeError("Device communicator lacks SM70 fused AR RMSNorm")
         return fused_op(input_, residual, weight, epsilon)
 
-    def sm70_awq_mlp_down_tile_all_reduce(
-        self, input_: torch.Tensor
-    ) -> torch.Tensor:
+    def sm70_awq_mlp_down_tile_all_reduce(self, input_: torch.Tensor) -> torch.Tensor:
         if self.world_size == 1:
             return input_
 

--- a/vllm/model_executor/layers/fla/ops/chunk_scaled_dot_kkt.py
+++ b/vllm/model_executor/layers/fla/ops/chunk_scaled_dot_kkt.py
@@ -45,7 +45,9 @@ def _parse_int_list(env_name: str, default_vals: list[int]) -> list[int]:
     return out or default_vals
 
 
-_use_sm70_kkt_schedule = os.getenv("VLLM_SM70_GDN_KKT_SCHEDULE", "1") == "1" and _is_sm70()
+_use_sm70_kkt_schedule = (
+    os.getenv("VLLM_SM70_GDN_KKT_SCHEDULE", "1") == "1" and _is_sm70()
+)
 _kkt_configs = (
     [
         triton.Config({"BK": BK}, num_warps=num_warps, num_stages=num_stages)

--- a/vllm/model_executor/layers/fla/ops/fused_gdn_prefill_post_conv.py
+++ b/vllm/model_executor/layers/fla/ops/fused_gdn_prefill_post_conv.py
@@ -76,8 +76,7 @@ def _fused_post_conv_kernel(
 
         # Load Q features: mixed_qkv[t, i_h*K + k]
         q_offsets = (
-            offs_t[:, None] * stride_x_tok
-            + (i_h * K + offs_k[None, :]) * stride_x_feat
+            offs_t[:, None] * stride_x_tok + (i_h * K + offs_k[None, :]) * stride_x_feat
         )
         q_f32 = tl.load(mixed_qkv_ptr + q_offsets, mask=qk_mask_2d, other=0).to(
             tl.float32

--- a/vllm/model_executor/layers/fla/ops/fused_recurrent.py
+++ b/vllm/model_executor/layers/fla/ops/fused_recurrent.py
@@ -56,9 +56,7 @@ def _round_num_warps(value: int) -> int:
     return 8
 
 
-_SM70_FLA_RECURRENT_SCHEDULE = (
-    os.getenv("VLLM_SM70_FLA_RECURRENT_SCHEDULE", "1") == "1"
-)
+_SM70_FLA_RECURRENT_SCHEDULE = os.getenv("VLLM_SM70_FLA_RECURRENT_SCHEDULE", "1") == "1"
 _SM70_FLA_BV_OVERRIDE = _parse_positive_int_env("VLLM_SM70_FLA_BV")
 _SM70_FLA_WARPS_OVERRIDE = _parse_positive_int_env("VLLM_SM70_FLA_WARPS")
 _SM70_FLA_STAGES_OVERRIDE = _parse_positive_int_env("VLLM_SM70_FLA_STAGES")

--- a/vllm/model_executor/layers/fused_moe/fused_moe.py
+++ b/vllm/model_executor/layers/fused_moe/fused_moe.py
@@ -1278,9 +1278,7 @@ def get_default_config(
                 "GROUP_SIZE_M": 8,
                 "SPLIT_K": 1,
             }
-        logger.info_once(
-            f"Using SM70 0.0.3 unquantized MoE default config: {config}"
-        )
+        logger.info_once(f"Using SM70 0.0.3 unquantized MoE default config: {config}")
     else:
         # General defaults for bf16/fp16 and fp8 per-tensor.
         # Tile sizes scale with batch: small batches are memory-bound

--- a/vllm/model_executor/layers/layernorm.py
+++ b/vllm/model_executor/layers/layernorm.py
@@ -62,11 +62,7 @@ def _sm70_gemma_fused_add_rms_norm_eager(
 ) -> tuple[torch.Tensor, torch.Tensor]:
     orig_dtype = x.dtype
     gemma_weight = weight.float() + 1.0
-    x = (
-        x.float() + residual.float()
-        if orig_dtype == torch.float16
-        else x + residual
-    )
+    x = x.float() + residual.float() if orig_dtype == torch.float16 else x + residual
     residual_out = x
     out = ir.ops.rms_norm(x, gemma_weight, variance_epsilon)
     return out.to(orig_dtype), residual_out

--- a/vllm/model_executor/layers/linear.py
+++ b/vllm/model_executor/layers/linear.py
@@ -1793,14 +1793,10 @@ class RowParallelLinear(LinearBase):
         if output is None:
             output_parallel = _maybe_sm70_dense_forward(self, input_parallel, bias_)
             if output_parallel is None:
-                output_parallel = self.quant_method.apply(
-                    self, input_parallel, bias_
-                )
+                output_parallel = self.quant_method.apply(self, input_parallel, bias_)
 
             if self.reduce_results and self.tp_size > 1:
-                output = _maybe_sm70_awq_mlp_down_tile_all_reduce(
-                    self, output_parallel
-                )
+                output = _maybe_sm70_awq_mlp_down_tile_all_reduce(self, output_parallel)
                 if output is None:
                     output = tensor_model_parallel_all_reduce(output_parallel)
             else:

--- a/vllm/model_executor/layers/logits_processor.py
+++ b/vllm/model_executor/layers/logits_processor.py
@@ -149,8 +149,9 @@ def _cuda_graph_capture_active() -> bool:
         return False
 
 
-def _maybe_sync_top1_all_gather(module: torch.nn.Module,
-                                local_pair: torch.Tensor) -> None:
+def _maybe_sync_top1_all_gather(
+    module: torch.nn.Module, local_pair: torch.Tensor
+) -> None:
     raw_steps = envs.VLLM_SM70_SYNC_TOP1_ALLGATHER_STEPS
     if not raw_steps or not local_pair.is_cuda:
         return
@@ -254,8 +255,8 @@ class LogitsProcessor(PluggableLayer):
         pre_stream_sync_ms = 0.0
         pre_device_extra_sync_ms = 0.0
         if profile_enabled:
-            pre_stream_sync_ms, pre_device_extra_sync_ms = (
-                _cuda_sync_breakdown_ms(hidden_states)
+            pre_stream_sync_ms, pre_device_extra_sync_ms = _cuda_sync_breakdown_ms(
+                hidden_states
             )
         pre_sync_ms = pre_stream_sync_ms + pre_device_extra_sync_ms
 
@@ -313,9 +314,7 @@ class LogitsProcessor(PluggableLayer):
             )
         tp_size = get_tensor_model_parallel_world_size()
 
-        local_top1 = lm_head.maybe_get_sm70_lm_head_top1(
-            hidden_states, embedding_bias
-        )
+        local_top1 = lm_head.maybe_get_sm70_lm_head_top1(hidden_states, embedding_bias)
         if local_top1 is None:
             logits = lm_head.quant_method.apply(
                 lm_head, hidden_states, bias=embedding_bias
@@ -394,14 +393,12 @@ class LogitsProcessor(PluggableLayer):
         pre_stream_sync_ms = 0.0
         pre_device_extra_sync_ms = 0.0
         if profile_enabled:
-            pre_stream_sync_ms, pre_device_extra_sync_ms = (
-                _cuda_sync_breakdown_ms(hidden_states)
+            pre_stream_sync_ms, pre_device_extra_sync_ms = _cuda_sync_breakdown_ms(
+                hidden_states
             )
         pre_sync_ms = pre_stream_sync_ms + pre_device_extra_sync_ms
         stage_start = _cuda_stage_start(profile_enabled)
-        logits = lm_head.quant_method.apply(
-            lm_head, hidden_states, bias=embedding_bias
-        )
+        logits = lm_head.quant_method.apply(lm_head, hidden_states, bias=embedding_bias)
         local_lm_head_ms = _cuda_stage_ms(profile_enabled, stage_start)
 
         stage_start = _cuda_stage_start(profile_enabled)
@@ -528,15 +525,13 @@ class LogitsProcessor(PluggableLayer):
         pre_stream_sync_ms = 0.0
         pre_device_extra_sync_ms = 0.0
         if profile_enabled:
-            pre_stream_sync_ms, pre_device_extra_sync_ms = (
-                _cuda_sync_breakdown_ms(hidden_states)
+            pre_stream_sync_ms, pre_device_extra_sync_ms = _cuda_sync_breakdown_ms(
+                hidden_states
             )
         pre_sync_ms = pre_stream_sync_ms + pre_device_extra_sync_ms
 
         stage_start = _cuda_stage_start(profile_enabled)
-        logits = lm_head.quant_method.apply(
-            lm_head, hidden_states, bias=embedding_bias
-        )
+        logits = lm_head.quant_method.apply(lm_head, hidden_states, bias=embedding_bias)
         local_lm_head_ms = _cuda_stage_ms(profile_enabled, stage_start)
 
         stage_start = _cuda_stage_start(profile_enabled)

--- a/vllm/model_executor/layers/quantization/auto_gptq.py
+++ b/vllm/model_executor/layers/quantization/auto_gptq.py
@@ -480,15 +480,11 @@ class AutoGPTQLinearMethod(LinearMethodBase):
                     group_size=self.quant_config.group_size,
                 )
                 layer.qweight = torch.nn.Parameter(
-                    torch.empty(
-                        0, dtype=torch.int32, device=layer.qweight.device
-                    ),
+                    torch.empty(0, dtype=torch.int32, device=layer.qweight.device),
                     requires_grad=False,
                 )
                 layer.qzeros = torch.nn.Parameter(
-                    torch.empty(
-                        0, dtype=torch.int32, device=layer.scales.device
-                    ),
+                    torch.empty(0, dtype=torch.int32, device=layer.scales.device),
                     requires_grad=False,
                 )
                 layer.scales = torch.nn.Parameter(
@@ -498,9 +494,7 @@ class AutoGPTQLinearMethod(LinearMethodBase):
                     requires_grad=False,
                 )
                 layer.g_idx = torch.nn.Parameter(
-                    torch.empty(
-                        0, dtype=torch.int32, device=layer.scales.device
-                    ),
+                    torch.empty(0, dtype=torch.int32, device=layer.scales.device),
                     requires_grad=False,
                 )
                 logger.info_once("SM70 GPTQ TurboMind dense path enabled.")

--- a/vllm/model_executor/layers/quantization/awq_marlin.py
+++ b/vllm/model_executor/layers/quantization/awq_marlin.py
@@ -610,9 +610,7 @@ class AWQMarlinLinearMethod(LinearMethodBase):
                 torch.empty(0, dtype=tm_scales.dtype, device=tm_weight.device),
                 requires_grad=False,
             )
-            logger.info_once(
-                "SM70 AWQ TurboMind dense path enabled under AWQ Marlin."
-            )
+            logger.info_once("SM70 AWQ TurboMind dense path enabled under AWQ Marlin.")
             return
 
         # AWQ checkpoints use a non-standard packing order and pack qweight

--- a/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_w4a16_nvfp4.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_w4a16_nvfp4.py
@@ -97,8 +97,7 @@ class CompressedTensorsW4A16Fp4(CompressedTensorsScheme):
             layer.weight, envs.VLLM_SM70_NVFP4_TURBOMIND
         ):
             logger.info_once(
-                "SM70 compressed-tensors NVFP4 TurboMind W4A16 dense path "
-                "enabled."
+                "SM70 compressed-tensors NVFP4 TurboMind W4A16 dense path enabled."
             )
             sm70_tm.prepare_nvfp4_linear(layer)
             layer.weight = Parameter(

--- a/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_w4a4_mxfp4.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_w4a4_mxfp4.py
@@ -108,15 +108,11 @@ class CompressedTensorsW4A4Mxfp4(CompressedTensorsScheme):
             )
             sm70_tm.prepare_mxfp4_linear(layer)
             layer.weight_packed = Parameter(
-                torch.empty(
-                    0, dtype=torch.uint8, device=layer.weight_packed.device
-                ),
+                torch.empty(0, dtype=torch.uint8, device=layer.weight_packed.device),
                 requires_grad=False,
             )
             layer.weight_scale = Parameter(
-                torch.empty(
-                    0, dtype=torch.uint8, device=layer.weight_scale.device
-                ),
+                torch.empty(0, dtype=torch.uint8, device=layer.weight_scale.device),
                 requires_grad=False,
             )
             return

--- a/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_w4a4_nvfp4.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_w4a4_nvfp4.py
@@ -25,10 +25,7 @@ __all__ = ["CompressedTensorsW4A4Fp4"]
 
 
 def _explicit_nvfp4_emulation_requested() -> bool:
-    if (
-        envs.VLLM_USE_NVFP4_CT_EMULATIONS
-        or envs.VLLM_NVFP4_GEMM_BACKEND == "emulation"
-    ):
+    if envs.VLLM_USE_NVFP4_CT_EMULATIONS or envs.VLLM_NVFP4_GEMM_BACKEND == "emulation":
         return True
 
     from vllm.config import get_current_vllm_config_or_none

--- a/vllm/model_executor/layers/quantization/input_quant_fp8.py
+++ b/vllm/model_executor/layers/quantization/input_quant_fp8.py
@@ -227,9 +227,7 @@ class QuantFP8(CustomOp):
             else:
                 x_max = x.abs().max().unsqueeze(-1).to(torch.float32)
 
-            scale = (x_max / self.fp8_max).clamp(
-                min=self.fp8_min_scaling_factor
-            )
+            scale = (x_max / self.fp8_max).clamp(min=self.fp8_min_scaling_factor)
         else:
             scale = prep_scale_for_group_broadcast(scale, x, self.group_shape)
 

--- a/vllm/model_executor/layers/quantization/sm70_turbomind.py
+++ b/vllm/model_executor/layers/quantization/sm70_turbomind.py
@@ -57,9 +57,7 @@ def should_prepare_turbomind_or_marlin(
     tensor: torch.Tensor,
     default_enabled: bool,
 ) -> bool:
-    return is_exact_sm70_cuda(
-        tensor, use_turbomind(default_enabled) or forces_marlin()
-    )
+    return is_exact_sm70_cuda(tensor, use_turbomind(default_enabled) or forces_marlin())
 
 
 def _get_u4_slices(x: torch.Tensor, dtype: torch.dtype) -> list[torch.Tensor]:
@@ -146,8 +144,7 @@ def prepare_gptq_linear(
 ) -> None:
     if group_size not in GPTQ_GROUP_SIZES:
         raise RuntimeError(
-            "SM70 TurboMind GPTQ supports group_size 128, "
-            f"but got {group_size}."
+            f"SM70 TurboMind GPTQ supports group_size 128, but got {group_size}."
         )
     if not hasattr(torch.ops._C, "uint4_sm70_prepare"):
         raise RuntimeError(
@@ -251,9 +248,13 @@ def prepare_nvfp4_linear(
 
     qweight = unpack_mxfp4_weight(layer.weight.data)
     scales = (
-        layer.weight_scale.data.t().to(torch.float32)
-        * layer.weight_global_scale.to(torch.float32)
-    ).to(torch.float16).contiguous()
+        (
+            layer.weight_scale.data.t().to(torch.float32)
+            * layer.weight_global_scale.to(torch.float32)
+        )
+        .to(torch.float16)
+        .contiguous()
+    )
     tm_weight, tm_scales, meta = sm70_ops.nvfp4_sm70_prepare(
         qweight, scales, NVFP4_GROUP_SIZE, interleave_gated_silu
     )

--- a/vllm/model_executor/layers/quantization/utils/marlin_utils_fp4.py
+++ b/vllm/model_executor/layers/quantization/utils/marlin_utils_fp4.py
@@ -28,10 +28,7 @@ def is_fp4_marlin_supported():
         return False
     if current_platform.has_device_capability(75):
         return True
-    return (
-        current_platform.is_device_capability((7, 0))
-        and ops.sm70_marlin_available()
-    )
+    return current_platform.is_device_capability((7, 0)) and ops.sm70_marlin_available()
 
 
 def _nvfp4_compute_scale_factor(

--- a/vllm/model_executor/layers/quantization/utils/w8a8_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/w8a8_utils.py
@@ -22,8 +22,7 @@ def cutlass_fp8_supported() -> bool:
     capability_tuple = current_platform.get_device_capability()
     capability = -1 if capability_tuple is None else capability_tuple.to_int()
 
-    return _cutlass_capability_probe("cutlass_scaled_mm_supports_fp8",
-                                     capability)
+    return _cutlass_capability_probe("cutlass_scaled_mm_supports_fp8", capability)
 
 
 def cutlass_block_fp8_supported() -> bool:
@@ -33,8 +32,7 @@ def cutlass_block_fp8_supported() -> bool:
     capability_tuple = current_platform.get_device_capability()
     capability = -1 if capability_tuple is None else capability_tuple.to_int()
 
-    return _cutlass_capability_probe("cutlass_scaled_mm_supports_block_fp8",
-                                     capability)
+    return _cutlass_capability_probe("cutlass_scaled_mm_supports_block_fp8", capability)
 
 
 def cutlass_group_gemm_supported() -> bool:
@@ -44,8 +42,7 @@ def cutlass_group_gemm_supported() -> bool:
     capability_tuple = current_platform.get_device_capability()
     capability = -1 if capability_tuple is None else capability_tuple.to_int()
 
-    return _cutlass_capability_probe("cutlass_group_gemm_supported",
-                                     capability)
+    return _cutlass_capability_probe("cutlass_group_gemm_supported", capability)
 
 
 CUTLASS_FP8_SUPPORTED = cutlass_fp8_supported()

--- a/vllm/model_executor/layers/vocab_parallel_embedding.py
+++ b/vllm/model_executor/layers/vocab_parallel_embedding.py
@@ -44,9 +44,7 @@ def _sm70_env_bool(name: str, default: bool) -> bool:
 
 
 def _sm70_lm_head_top1_default() -> bool:
-    return not _sm70_env_bool(
-        "VLLM_SM70_FLASH_V100_0DOT3_COMPILE_GRAPH", False
-    )
+    return not _sm70_env_bool("VLLM_SM70_FLASH_V100_0DOT3_COMPILE_GRAPH", False)
 
 
 def _trace_sm70_lm_head_skip(reason: str) -> None:
@@ -164,8 +162,7 @@ def _maybe_sm70_lm_head_top1(
         or hasattr(torch.ops._C, "sm70_f16_lm_head_top1_tc_out")
     ):
         logger.warning_once(
-            "SM70 LM head top1 requested, but no top1 op is available; "
-            "falling back."
+            "SM70 LM head top1 requested, but no top1 op is available; falling back."
         )
         return None
     if x.dtype != torch.float16 or not x.is_cuda:
@@ -193,9 +190,7 @@ def _maybe_sm70_lm_head_top1(
 
     values = torch.empty((x_2d.size(0),), dtype=torch.float32, device=x_2d.device)
     indices = torch.empty((x_2d.size(0),), dtype=torch.int64, device=x_2d.device)
-    if lm_head_top1_tc and hasattr(
-        torch.ops._C, "sm70_f16_lm_head_top1_tc_out"
-    ):
+    if lm_head_top1_tc and hasattr(torch.ops._C, "sm70_f16_lm_head_top1_tc_out"):
         tm_weight = getattr(layer, "_sm70_f16_tm_weight", None)
         k_ld = getattr(layer, "_sm70_f16_k_ld", None)
         if tm_weight is not None and k_ld is not None:
@@ -216,9 +211,7 @@ def _maybe_sm70_lm_head_top1(
     if num_rows != 1:
         return None
 
-    if not lm_head_top1 or not hasattr(
-        torch.ops._C, "sm70_f16_lm_head_top1_out"
-    ):
+    if not lm_head_top1 or not hasattr(torch.ops._C, "sm70_f16_lm_head_top1_out"):
         return None
 
     sm70_ops.sm70_f16_lm_head_top1_out(

--- a/vllm/model_executor/models/config.py
+++ b/vllm/model_executor/models/config.py
@@ -361,9 +361,7 @@ class MambaModelConfig(VerifyAndUpdateConfig):
                     )
                 else:
                     cache_config.mamba_cache_mode = (
-                        "all"
-                        if model_config.supports_mamba_prefix_caching
-                        else "align"
+                        "all" if model_config.supports_mamba_prefix_caching else "align"
                     )
                     logger.warning(
                         "Mamba cache mode is set to '%s' for %s by default "

--- a/vllm/model_executor/models/qwen2_moe.py
+++ b/vllm/model_executor/models/qwen2_moe.py
@@ -149,9 +149,7 @@ class Qwen2MoeMLP(nn.Module):
         out = fused_act(x) if fused_act is not None else None
         if out is None:
             gate_up, _ = self.gate_up_proj(x)
-            gate_up = _sm70_dump_qwen_mlp_tensor(
-                "mlp_gate_up", self.layer_idx, gate_up
-            )
+            gate_up = _sm70_dump_qwen_mlp_tensor("mlp_gate_up", self.layer_idx, gate_up)
             out = self.act_fn(gate_up)
         out = _sm70_dump_qwen_mlp_tensor("mlp_silu_out", self.layer_idx, out)
         out, _ = self.down_proj(out)

--- a/vllm/model_executor/models/qwen3_5.py
+++ b/vllm/model_executor/models/qwen3_5.py
@@ -116,6 +116,7 @@ from .utils import (
 
 logger = init_logger(__name__)
 
+
 def _parse_sm70_moe_dense_allowlist() -> set[str] | None:
     raw = envs.VLLM_SM70_MOE_DENSE_ALLOWLIST
     if raw is None:
@@ -281,15 +282,9 @@ class Qwen3_5GatedDeltaNet(QwenGatedDeltaNetAttention):
             ba_start = z_start + z_size
             a_start = ba_start + ba_size
             mixed_qkv = mixed_qkvzba[..., :qkv_size]
-            z = _sm70_compile_graph_slice_dim(
-                mixed_qkvzba, -1, z_start, z_size
-            )
-            b = _sm70_compile_graph_slice_dim(
-                mixed_qkvzba, -1, ba_start, ba_size
-            )
-            a = _sm70_compile_graph_slice_dim(
-                mixed_qkvzba, -1, a_start, ba_size
-            )
+            z = _sm70_compile_graph_slice_dim(mixed_qkvzba, -1, z_start, z_size)
+            b = _sm70_compile_graph_slice_dim(mixed_qkvzba, -1, ba_start, ba_size)
+            a = _sm70_compile_graph_slice_dim(mixed_qkvzba, -1, a_start, ba_size)
 
         mixed_qkv = _sm70_dump_gdn_projection_tensor(
             "split_mixed_qkv", layer_name, mixed_qkv

--- a/vllm/model_executor/models/qwen3_5_mtp.py
+++ b/vllm/model_executor/models/qwen3_5_mtp.py
@@ -462,8 +462,7 @@ class Qwen3_5MTP(nn.Module, SupportsMultiModal):
                 )
 
             if modules_to_not_convert and any(
-                str(module) in ("mtp", "model.mtp")
-                for module in modules_to_not_convert
+                str(module) in ("mtp", "model.mtp") for module in modules_to_not_convert
             ):
                 return True
 

--- a/vllm/tool_parsers/qwen3coder_tool_parser.py
+++ b/vllm/tool_parsers/qwen3coder_tool_parser.py
@@ -358,10 +358,7 @@ class Qwen3CoderToolParser(ToolParser):
                 if pos != -1
             ]
             tool_start = min(tool_start_candidates) if tool_start_candidates else -1
-            if (
-                self.tool_call_start_token_id in delta_token_ids
-                or tool_start != -1
-            ):
+            if self.tool_call_start_token_id in delta_token_ids or tool_start != -1:
                 self.is_tool_call_started = True
                 # Return any content before the tool call
                 if tool_start > len(previous_text):

--- a/vllm/utils/torch_utils.py
+++ b/vllm/utils/torch_utils.py
@@ -592,9 +592,7 @@ def create_kv_caches_with_random(
         if cache_dtype in ["auto", "half", "bfloat16", "float"]:
             key_cache.uniform_(-scale, scale)
         elif cache_dtype in fp8_cache_dtypes:
-            _generate_random_fp8(
-                key_cache, -scale, scale, kv_dtype=str(cache_dtype)
-            )
+            _generate_random_fp8(key_cache, -scale, scale, kv_dtype=str(cache_dtype))
         else:
             raise ValueError(f"Does not support key cache of type {cache_dtype}")
         key_caches.append(key_cache)
@@ -606,9 +604,7 @@ def create_kv_caches_with_random(
         if cache_dtype in ["auto", "half", "bfloat16", "float"]:
             value_cache.uniform_(-scale, scale)
         elif cache_dtype in fp8_cache_dtypes:
-            _generate_random_fp8(
-                value_cache, -scale, scale, kv_dtype=str(cache_dtype)
-            )
+            _generate_random_fp8(value_cache, -scale, scale, kv_dtype=str(cache_dtype))
         else:
             raise ValueError(f"Does not support value cache of type {cache_dtype}")
         value_caches.append(value_cache)

--- a/vllm/v1/attention/backends/ddtree_branch_triton.py
+++ b/vllm/v1/attention/backends/ddtree_branch_triton.py
@@ -77,10 +77,7 @@ def _ddtree_paged_attention_kernel(
     offs_d = tl.arange(0, BLOCK_D)
     d_mask = offs_d < head_size
     q_ptrs = (
-        query
-        + (q_start + row) * q_stride_t
-        + q_head * q_stride_h
-        + offs_d * q_stride_d
+        query + (q_start + row) * q_stride_t + q_head * q_stride_h + offs_d * q_stride_d
     )
     q_vec = tl.load(q_ptrs, mask=d_mask & active, other=0.0).to(tl.float32)
 
@@ -101,18 +98,10 @@ def _ddtree_paged_attention_kernel(
         for _ in range(max_q_len):
             cur_valid = active & (cur >= 0) & (cur < max_q_len) & (cur < q_len)
             visible = visible | (
-                (local == cur)
-                & (local >= 0)
-                & (local < q_len)
-                & n_mask
-                & cur_valid
+                (local == cur) & (local >= 0) & (local < q_len) & n_mask & cur_valid
             )
             safe_cur = tl.maximum(tl.minimum(cur, max_q_len - 1), 0)
-            parent_ptr = (
-                parent_ids
-                + req_i * parent_stride0
-                + safe_cur * parent_stride1
-            )
+            parent_ptr = parent_ids + req_i * parent_stride0 + safe_cur * parent_stride1
             parent = tl.load(parent_ptr, mask=cur_valid, other=0).to(tl.int32)
             # In vLLM DDTree metadata, -1 means "root child". The verifier has
             # a synthetic prefix/root row at local slot 0, so root children must
@@ -126,9 +115,7 @@ def _ddtree_paged_attention_kernel(
 
         block_offsets = offs_n - (offs_n // block_size) * block_size
         block_ptrs = (
-            block_table
-            + req_i * block_stride0
-            + (offs_n // block_size) * block_stride1
+            block_table + req_i * block_stride0 + (offs_n // block_size) * block_stride1
         )
         block_ids = tl.load(block_ptrs, mask=n_mask, other=0).to(tl.int64)
 

--- a/vllm/v1/attention/backends/fa_utils.py
+++ b/vllm/v1/attention/backends/fa_utils.py
@@ -17,6 +17,7 @@ _ROCM_FLASH_ATTN_AVAILABLE = False
 
 if current_platform.is_cuda():
     from vllm._custom_ops import reshape_and_cache_flash
+
     try:
         from vllm.vllm_flash_attn import (  # type: ignore[attr-defined]
             flash_attn_varlen_func,

--- a/vllm/v1/attention/backends/registry.py
+++ b/vllm/v1/attention/backends/registry.py
@@ -42,12 +42,8 @@ class AttentionBackendEnum(Enum, metaclass=_AttentionBackendEnumMeta):
     """
 
     FLASH_ATTN = "vllm.v1.attention.backends.flash_attn.FlashAttentionBackend"
-    FLASH_ATTN_V100 = (
-        "vllm.v1.attention.backends.flash_attn_v100.FlashAttnV100Backend"
-    )
-    FLASHINFER_SM70 = (
-        "vllm.v1.attention.backends.flashinfer_sm70.FlashInferSM70Backend"
-    )
+    FLASH_ATTN_V100 = "vllm.v1.attention.backends.flash_attn_v100.FlashAttnV100Backend"
+    FLASHINFER_SM70 = "vllm.v1.attention.backends.flashinfer_sm70.FlashInferSM70Backend"
     FLASH_ATTN_DIFFKV = (
         "vllm.v1.attention.backends.flash_attn_diffkv.FlashAttentionDiffKVBackend"
     )

--- a/vllm/v1/attention/ops/triton_prefill_attention.py
+++ b/vllm/v1/attention/ops/triton_prefill_attention.py
@@ -184,11 +184,7 @@ def get_block_size(dtype: torch.dtype, head_dim: int | None = None) -> int:
         80
     ):
         return 128
-    elif (
-        current_platform.is_cuda_alike()
-        and head_dim is not None
-        and head_dim >= 256
-    ):
+    elif current_platform.is_cuda_alike() and head_dim is not None and head_dim >= 256:
         # SM70/SM75 only expose 96KB shared memory per block. With head_dim=256,
         # BLOCK=64 requires 128KB in this Triton kernel.
         return 32

--- a/vllm/v1/attention/ops/triton_unified_attention.py
+++ b/vllm/v1/attention/ops/triton_unified_attention.py
@@ -558,9 +558,7 @@ def kernel_unified_attention(
             if PV_INPUT_PRECISION == "":
                 acc += tl.dot(P.to(V.dtype), V)
             else:
-                acc += tl.dot(
-                    P.to(V.dtype), V, input_precision=PV_INPUT_PRECISION
-                )
+                acc += tl.dot(P.to(V.dtype), V, input_precision=PV_INPUT_PRECISION)
 
     # ---- Epilogue ---------------------------------------------------------
     if IS_3D:
@@ -920,12 +918,8 @@ def unified_attention(
         sm70_prefill_tile_size = envs.VLLM_SM70_TRITON_ATTN_PREFILL_TILE_SIZE
         sm70_decode_tile_size = envs.VLLM_SM70_TRITON_ATTN_DECODE_TILE_SIZE
         sm70_num_warps = envs.VLLM_SM70_TRITON_ATTN_NUM_WARPS
-        sm70_prefill_num_warps = (
-            envs.VLLM_SM70_TRITON_ATTN_PREFILL_NUM_WARPS
-        )
-        sm70_decode_num_warps = (
-            envs.VLLM_SM70_TRITON_ATTN_DECODE_NUM_WARPS
-        )
+        sm70_prefill_num_warps = envs.VLLM_SM70_TRITON_ATTN_PREFILL_NUM_WARPS
+        sm70_decode_num_warps = envs.VLLM_SM70_TRITON_ATTN_DECODE_NUM_WARPS
         sm70_safe_defaults = envs.VLLM_SM70_TRITON_ATTN_SAFE_DEFAULTS
         sm70_qk_input_precision = _validate_sm70_triton_attn_input_precision(
             envs.VLLM_SM70_TRITON_ATTN_QK_INPUT_PRECISION,

--- a/vllm/v1/cudagraph_dispatcher.py
+++ b/vllm/v1/cudagraph_dispatcher.py
@@ -306,11 +306,7 @@ class CudagraphDispatcher:
                 for x in self.compilation_config.cudagraph_capture_sizes
                 if x <= max_num_tokens
                 and x >= uniform_decode_query_len
-                and (
-                    self._bs_to_padded_graph_size[x]
-                    % uniform_decode_query_len
-                    == 0
-                )
+                and (self._bs_to_padded_graph_size[x] % uniform_decode_query_len == 0)
             ]
             for bs, num_active_loras in product(
                 cudagraph_capture_sizes_for_decode, lora_cases

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -461,9 +461,7 @@ class EngineCore:
         profile_sample_ms = 0.0
         profile_update_ms = 0.0
         if profile_ddtree_engine:
-            profile_step = getattr(
-                self, "_dflash_ddtree_engine_profile_step", 0
-            ) + 1
+            profile_step = getattr(self, "_dflash_ddtree_engine_profile_step", 0) + 1
             self._dflash_ddtree_engine_profile_step = profile_step
             profile_t0 = time.perf_counter()
 
@@ -478,9 +476,7 @@ class EngineCore:
             profile_part_t0 = time.perf_counter()
         future = self.model_executor.execute_model(scheduler_output, non_block=True)
         if profile_ddtree_engine:
-            profile_execute_submit_ms = (
-                time.perf_counter() - profile_part_t0
-            ) * 1000.0
+            profile_execute_submit_ms = (time.perf_counter() - profile_part_t0) * 1000.0
             profile_part_t0 = time.perf_counter()
         grammar_output = self.scheduler.get_grammar_bitmask(scheduler_output)
         if profile_ddtree_engine:
@@ -497,9 +493,7 @@ class EngineCore:
                 profile_part_t0 = time.perf_counter() if profile_ddtree_engine else 0.0
                 model_output = self.model_executor.sample_tokens(grammar_output)
                 if profile_ddtree_engine:
-                    profile_sample_ms = (
-                        time.perf_counter() - profile_part_t0
-                    ) * 1000.0
+                    profile_sample_ms = (time.perf_counter() - profile_part_t0) * 1000.0
 
         # Before processing the model output, process any aborts that happened
         # during the model execution.
@@ -611,9 +605,7 @@ class EngineCore:
             trace_schedule_t0 = time.perf_counter() if trace_log else 0.0
             scheduler_output = self.scheduler.schedule()
             if trace_log:
-                trace_schedule_ms = (
-                    time.perf_counter() - trace_schedule_t0
-                ) * 1000.0
+                trace_schedule_ms = (time.perf_counter() - trace_schedule_t0) * 1000.0
                 trace_scheduled_tokens = scheduler_output.total_num_scheduled_tokens
             with self.log_error_detail(scheduler_output):
                 trace_execute_t0 = time.perf_counter() if trace_log else 0.0

--- a/vllm/v1/sample/sampler.py
+++ b/vllm/v1/sample/sampler.py
@@ -77,10 +77,7 @@ def _maybe_dump_sm70_sampler_logits(
             ],
         },
         path
-        / (
-            f"sampler_logits_pid{os.getpid()}"
-            f"_step{_SM70_LOGITS_DUMP_COUNTER:04d}.pt"
-        ),
+        / (f"sampler_logits_pid{os.getpid()}_step{_SM70_LOGITS_DUMP_COUNTER:04d}.pt"),
     )
 
 

--- a/vllm/v1/sample/thinking_budget_state.py
+++ b/vllm/v1/sample/thinking_budget_state.py
@@ -153,9 +153,7 @@ class ThinkingBudgetStateHolder:
                 # the suffix that is present; stripping the full spec length in
                 # the repeated layout drops one real output token.
                 spec_suffix_len = (
-                    max(0, spec_len - 1)
-                    if last_row_for_req is not None
-                    else spec_len
+                    max(0, spec_len - 1) if last_row_for_req is not None else spec_len
                 )
                 # Only strip draft suffix when there are spec tokens; ``[:-0]`` would
                 # clear the whole list (Python treats stop index 0 as "up to empty").
@@ -163,9 +161,7 @@ class ThinkingBudgetStateHolder:
                     spec_suffix_len > 0
                     and len(state["output_tok_ids"]) >= spec_suffix_len
                 ):
-                    state["output_tok_ids"] = state["output_tok_ids"][
-                        :-spec_suffix_len
-                    ]
+                    state["output_tok_ids"] = state["output_tok_ids"][:-spec_suffix_len]
             self._update_think_state(state)
 
     def apply_to_logits(

--- a/vllm/v1/spec_decode/ddtree_metadata.py
+++ b/vllm/v1/spec_decode/ddtree_metadata.py
@@ -52,10 +52,10 @@ class DDTreeVerifierMetadata:
         tree_token_ids = tree.token_ids_for_verifier()
         parent_indices = tree.parent_indices_for_verifier()
         node_depths = tree.node_depths_for_verifier()
-        tree_position_ids = tuple(prompt_len + depth - 1
-                                  for depth in node_depths)
+        tree_position_ids = tuple(prompt_len + depth - 1 for depth in node_depths)
         compact_logits_indices = (prompt_len - 1,) + tuple(
-            prompt_len + offset for offset in range(len(tree_token_ids)))
+            prompt_len + offset for offset in range(len(tree_token_ids))
+        )
 
         edge_parent_compact_indices: list[int] = []
         node_compact_indices: list[int] = []
@@ -98,8 +98,7 @@ def _offset_parent_indices(
     parent_indices: tuple[int, ...],
     tree_start: int,
 ) -> list[int]:
-    return [parent if parent < 0 else parent + tree_start
-            for parent in parent_indices]
+    return [parent if parent < 0 else parent + tree_start for parent in parent_indices]
 
 
 def make_prefill_tree_attention_mask(
@@ -115,7 +114,7 @@ def make_prefill_tree_attention_mask(
     visible = torch.zeros((total_len, total_len), device=device, dtype=torch.bool)
 
     for row in range(prompt_len):
-        visible[row, :row + 1] = True
+        visible[row, : row + 1] = True
 
     for node in tree.non_root_nodes:
         row = prompt_len + node.index - 1
@@ -126,10 +125,9 @@ def make_prefill_tree_attention_mask(
             col = prompt_len + ancestor_index - 1
             visible[row, col] = True
 
-    mask = torch.full((total_len, total_len),
-                      torch.finfo(dtype).min,
-                      device=device,
-                      dtype=dtype)
+    mask = torch.full(
+        (total_len, total_len), torch.finfo(dtype).min, device=device, dtype=dtype
+    )
     mask.masked_fill_(visible, 0)
     return mask.unsqueeze(0).unsqueeze(0)
 
@@ -157,7 +155,8 @@ def make_batched_metadata(
 
     max_total_len = max(
         prompt_len + len(tree.non_root_nodes)
-        for prompt_len, tree in zip(prompt_lens, trees, strict=True))
+        for prompt_len, tree in zip(prompt_lens, trees, strict=True)
+    )
     tree_token_ids: list[int] = []
     parent_indices: list[int] = []
     node_depths: list[int] = []
@@ -172,15 +171,18 @@ def make_batched_metadata(
     for metadata in per_request:
         tree_token_ids.extend(metadata.tree_token_ids)
         parent_indices.extend(
-            _offset_parent_indices(metadata.parent_indices, tree_start))
+            _offset_parent_indices(metadata.parent_indices, tree_start)
+        )
         node_depths.extend(metadata.node_depths)
         compact_logits_indices.extend(
-            seq_start + index for index in metadata.compact_logits_indices)
+            seq_start + index for index in metadata.compact_logits_indices
+        )
         edge_parent_compact_indices.extend(
-            compact_start + index
-            for index in metadata.edge_parent_compact_indices)
+            compact_start + index for index in metadata.edge_parent_compact_indices
+        )
         node_compact_indices.extend(
-            compact_start + index for index in metadata.node_compact_indices)
+            compact_start + index for index in metadata.node_compact_indices
+        )
 
         row = list(metadata.all_position_ids())
         row.extend([0] * (max_total_len - len(row)))
@@ -192,24 +194,20 @@ def make_batched_metadata(
 
     return BatchedDDTreeVerifierMetadata(
         prompt_lens=tuple(prompt_lens),
-        tree_token_ids=torch.tensor(tree_token_ids, device=device,
-                                    dtype=torch.int32),
-        parent_indices=torch.tensor(parent_indices, device=device,
-                                    dtype=torch.int32),
+        tree_token_ids=torch.tensor(tree_token_ids, device=device, dtype=torch.int32),
+        parent_indices=torch.tensor(parent_indices, device=device, dtype=torch.int32),
         node_depths=torch.tensor(node_depths, device=device, dtype=torch.int32),
-        position_ids=torch.tensor(position_rows, device=device,
-                                  dtype=torch.long),
-        cu_num_tree_nodes=torch.tensor(cu_nodes, device=device,
-                                       dtype=torch.int32),
-        compact_logits_indices=torch.tensor(compact_logits_indices,
-                                            device=device,
-                                            dtype=torch.int32),
-        edge_parent_compact_indices=torch.tensor(edge_parent_compact_indices,
-                                                 device=device,
-                                                 dtype=torch.int32),
-        node_compact_indices=torch.tensor(node_compact_indices,
-                                          device=device,
-                                          dtype=torch.int32),
+        position_ids=torch.tensor(position_rows, device=device, dtype=torch.long),
+        cu_num_tree_nodes=torch.tensor(cu_nodes, device=device, dtype=torch.int32),
+        compact_logits_indices=torch.tensor(
+            compact_logits_indices, device=device, dtype=torch.int32
+        ),
+        edge_parent_compact_indices=torch.tensor(
+            edge_parent_compact_indices, device=device, dtype=torch.int32
+        ),
+        node_compact_indices=torch.tensor(
+            node_compact_indices, device=device, dtype=torch.int32
+        ),
     )
 
 
@@ -226,7 +224,8 @@ def greedy_sample_from_compact_logits(
     if compact_logits.shape[0] != expected_rows:
         raise ValueError(
             f"compact_logits row mismatch: expected {expected_rows}, "
-            f"got {compact_logits.shape[0]}")
+            f"got {compact_logits.shape[0]}"
+        )
 
     target_argmax = compact_logits.argmax(dim=-1)
     path_to_compact_index: dict[tuple[int, ...], int] = {(): 0}
@@ -252,7 +251,8 @@ def greedy_sample_from_compact_top_tokens(
     if compact_top_tokens.shape[0] != expected_rows:
         raise ValueError(
             f"compact_top_tokens row mismatch: expected {expected_rows}, "
-            f"got {compact_top_tokens.shape[0]}")
+            f"got {compact_top_tokens.shape[0]}"
+        )
 
     target_tokens = compact_top_tokens.detach().cpu().tolist()
     path_to_compact_index: dict[tuple[int, ...], int] = {(): 0}

--- a/vllm/v1/worker/block_table.py
+++ b/vllm/v1/worker/block_table.py
@@ -104,9 +104,7 @@ class BlockTable:
         self.cp_kv_cache_interleave_size = cp_kv_cache_interleave_size
 
     def _mark_dirty(self, row_idx: int) -> None:
-        self._block_table_dirty_until = max(
-            self._block_table_dirty_until, row_idx + 1
-        )
+        self._block_table_dirty_until = max(self._block_table_dirty_until, row_idx + 1)
 
     def append_row(
         self,

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -220,9 +220,9 @@ class Worker(WorkerBase):
             yield
             return
 
-        set_allocator_settings = getattr(torch._C,
-                                         "_accelerator_setAllocatorSettings",
-                                         None)
+        set_allocator_settings = getattr(
+            torch._C, "_accelerator_setAllocatorSettings", None
+        )
         if set_allocator_settings is None:
             yield
             return

--- a/vllm/v1/worker/utils.py
+++ b/vllm/v1/worker/utils.py
@@ -155,8 +155,7 @@ class KVBlockZeroer:
                         page_size_el = cur_page_el
                     else:
                         assert page_size_el == cur_page_el, (
-                            f"Non-uniform page sizes: {page_size_el} vs "
-                            f"{cur_page_el}"
+                            f"Non-uniform page sizes: {page_size_el} vs {cur_page_el}"
                         )
 
                     block_stride_bytes = cur_bytes
@@ -187,8 +186,7 @@ class KVBlockZeroer:
                         page_size_el = cur_page_el
                     else:
                         assert page_size_el == cur_page_el, (
-                            f"Non-uniform page sizes: {page_size_el} vs "
-                            f"{cur_page_el}"
+                            f"Non-uniform page sizes: {page_size_el} vs {cur_page_el}"
                         )
                     seg_addrs.append(dp)
 


### PR DESCRIPTION
## Purpose
Clear only the existing Python Ruff format baseline debt tracked by #126.

## Scope
- Applied the repository-pinned Ruff 0.14.0 formatter to 74 tracked Python files.
- Excluded all 15 files in the concurrent mypy worker write scope.
- No manual or semantic edits; no docs, requirements, C/CUDA, or Markdown changes.

## Duplicate Check
No open PR was found for Ruff format baseline cleanup. This is a bounded mechanical child of #126.

## Validation
- Ruff 0.14.0 format check passed for all 3,421 eligible Python targets.
- The repository ruff-format pre-commit hook passed for all 74 changed files.
- Python AST equivalence against HEAD passed for all 74 changed files.
- Git diff check passed; scope assertions confirmed no excluded or non-Python files changed.

## Runtime Validation
No physical GPU is available. This formatter-only PR makes no GPU or performance claim.

## Remaining Risk
Full pre-commit remains tracked by #126; other formatter, lint, type, and dependency baseline items are intentionally outside this PR.

## AI Assistance
Prepared with OpenAI Codex; human review is required before merge.