### PR TITLE
[Doc] Fix static documentation baseline

### DIFF
--- a/SM70_MTP_OUTPUT_QUALITY_AUDIT_20260616.md
+++ b/SM70_MTP_OUTPUT_QUALITY_AUDIT_20260616.md
@@ -251,7 +251,7 @@ generic MTP, Flash attention, or sampling parameters.
     `num_accepted_tokens`, `num_computed_tokens`, and block rollover behavior
     around the first corrupted-token region.
 
-## Do Not Repeat
+## Do Not Repeat: Rejected Latest Paths
 
 - Do not rerun the exact-CPU `seq_lens_cpu_upper_bound` A/B unless the related
   code changes. It failed and is not sufficient root.

--- a/docs/design/qwen36_27b_awq_mtp_target_verifier_fastpaths.md
+++ b/docs/design/qwen36_27b_awq_mtp_target_verifier_fastpaths.md
@@ -351,11 +351,11 @@ Required experiment:
 
 Primary source paths:
 
-- https://github.com/NVIDIA/TensorRT-LLM/blob/main/cpp/tensorrt_llm/kernels/weightOnlyBatchedGemv/kernelDispatcher.h
-- https://github.com/NVIDIA/TensorRT-LLM/blob/main/cpp/tensorrt_llm/kernels/weightOnlyBatchedGemv/kernelLauncher.h
-- https://github.com/NVIDIA/TensorRT-LLM/blob/main/cpp/tensorrt_llm/kernels/weightOnlyBatchedGemv/kernel.h
-- https://github.com/NVIDIA/TensorRT-LLM/blob/main/cpp/tensorrt_llm/kernels/weightOnlyBatchedGemv/utility.h
-- https://github.com/NVIDIA/TensorRT-LLM/blob/main/cpp/tensorrt_llm/plugins/weightOnlyGroupwiseQuantMatmulPlugin/weightOnlyGroupwiseQuantMatmulPlugin.cpp
+- <https://github.com/NVIDIA/TensorRT-LLM/blob/main/cpp/tensorrt_llm/kernels/weightOnlyBatchedGemv/kernelDispatcher.h>
+- <https://github.com/NVIDIA/TensorRT-LLM/blob/main/cpp/tensorrt_llm/kernels/weightOnlyBatchedGemv/kernelLauncher.h>
+- <https://github.com/NVIDIA/TensorRT-LLM/blob/main/cpp/tensorrt_llm/kernels/weightOnlyBatchedGemv/kernel.h>
+- <https://github.com/NVIDIA/TensorRT-LLM/blob/main/cpp/tensorrt_llm/kernels/weightOnlyBatchedGemv/utility.h>
+- <https://github.com/NVIDIA/TensorRT-LLM/blob/main/cpp/tensorrt_llm/plugins/weightOnlyGroupwiseQuantMatmulPlugin/weightOnlyGroupwiseQuantMatmulPlugin.cpp>
 
 ### P1: SM90 Machete-style mixed-input WGMMA
 
@@ -401,7 +401,7 @@ must profile 1-SM, 2-SM, Stream-K, and exact-M GEMV tactics for each of the
 four real shapes.
 
 Source:
-https://github.com/NVIDIA/cutlass/blob/main/examples/86_blackwell_mixed_dtype_gemm/86_blackwell_mixed_dtype.cu
+<https://github.com/NVIDIA/cutlass/blob/main/examples/86_blackwell_mixed_dtype_gemm/86_blackwell_mixed_dtype.cu>
 
 **Native NVFP4/MXFP4.** Blackwell's `tcgen05.mma.blockscaled` consumes native
 block-scaled FP4 and accumulates through TMEM. CUTLASS documents 2x instruction
@@ -415,9 +415,9 @@ valid conversion.
 
 Sources:
 
-- https://github.com/NVIDIA/cutlass/blob/main/examples/72_blackwell_narrow_precision_gemm/72a_blackwell_nvfp4_bf16_gemm.cu
-- https://github.com/NVIDIA/cutlass/blob/main/examples/91_fp4_gemv/91_fp4_gemv.cu
-- https://github.com/NVIDIA/Model-Optimizer/blob/main/examples/llm_ptq/README.md
+- <https://github.com/NVIDIA/cutlass/blob/main/examples/72_blackwell_narrow_precision_gemm/72a_blackwell_nvfp4_bf16_gemm.cu>
+- <https://github.com/NVIDIA/cutlass/blob/main/examples/91_fp4_gemv/91_fp4_gemv.cu>
+- <https://github.com/NVIDIA/Model-Optimizer/blob/main/examples/llm_ptq/README.md>
 
 ### TurboMind SM90 ceiling
 
@@ -429,7 +429,7 @@ mainloop. Therefore, "enable TurboMind SM90" and "exploit Hopper's full mixed
 input path" are separate milestones.
 
 Source:
-https://github.com/InternLM/lmdeploy/blob/main/src/turbomind/kernels/gemm/kernel/sm90_16816_4.cu
+<https://github.com/InternLM/lmdeploy/blob/main/src/turbomind/kernels/gemm/kernel/sm90_16816_4.cu>
 
 ### Ranked benchmark order
 
@@ -538,11 +538,11 @@ or H100 target-forward baseline.
 
 ## Primary References
 
-- NVIDIA Ampere tuning guide: https://docs.nvidia.com/cuda/ampere-tuning-guide/index.html
-- NVIDIA Hopper tuning guide: https://docs.nvidia.com/cuda/archive/12.8.0/hopper-tuning-guide/index.html
-- CUTLASS changelog and mixed-input GEMM support: https://github.com/NVIDIA/cutlass/blob/main/CHANGELOG.md
-- Upstream TurboMind architecture-specific GEMM registry: https://github.com/InternLM/lmdeploy/tree/main/src/turbomind/kernels/gemm/kernel
-- FlashInfer GDN decode/MTP API: https://docs.flashinfer.ai/api/gdn_decode.html
-- FlashInfer GDN SM90 implementation contract: https://github.com/flashinfer-ai/flashinfer/blob/main/flashinfer/gdn_decode.py
-- FlashInfer/TensorRT-LLM MTP attention API: https://docs.flashinfer.ai/generated/flashinfer.decode.trtllm_batch_decode_with_kv_cache.html
-- TensorRT-LLM quantization hardware matrix: https://nvidia.github.io/TensorRT-LLM/latest/features/quantization.html
+- NVIDIA Ampere tuning guide: <https://docs.nvidia.com/cuda/ampere-tuning-guide/index.html>
+- NVIDIA Hopper tuning guide: <https://docs.nvidia.com/cuda/archive/12.8.0/hopper-tuning-guide/index.html>
+- CUTLASS changelog and mixed-input GEMM support: <https://github.com/NVIDIA/cutlass/blob/main/CHANGELOG.md>
+- Upstream TurboMind architecture-specific GEMM registry: <https://github.com/InternLM/lmdeploy/tree/main/src/turbomind/kernels/gemm/kernel>
+- FlashInfer GDN decode/MTP API: <https://docs.flashinfer.ai/api/gdn_decode.html>
+- FlashInfer GDN SM90 implementation contract: <https://github.com/flashinfer-ai/flashinfer/blob/main/flashinfer/gdn_decode.py>
+- FlashInfer/TensorRT-LLM MTP attention API: <https://docs.flashinfer.ai/generated/flashinfer.decode.trtllm_batch_decode_with_kv_cache.html>
+- TensorRT-LLM quantization hardware matrix: <https://nvidia.github.io/TensorRT-LLM/latest/features/quantization.html>

--- a/docs/design/sm70_nvfp4_turbomind_operator_optimization.md
+++ b/docs/design/sm70_nvfp4_turbomind_operator_optimization.md
@@ -640,11 +640,11 @@ Required run shape unless a note says otherwise:
 - CUDA device: one V100/SM70 rank
 - verifier shape: `m=17`, matching `budget=16` plus root
 - weighted verifier suite:
-  - `63` MLP gate/up calls
-  - `63` MLP down calls
-  - `47` linear-attention qkv calls
-  - `47` linear-attention z calls
-  - `16` full-attention o-proj calls
+    - `63` MLP gate/up calls
+    - `63` MLP down calls
+    - `47` linear-attention qkv calls
+    - `47` linear-attention z calls
+    - `16` full-attention o-proj calls
 - time only `awq_gemm_sm70_out` after `awq_sm70_prepare` and warmup
 - record exact env, JSON artifact, selected kernel when tracing is enabled, and
   whether the candidate is default behavior or env-forced only

--- a/docs/design/sm70_tile_runtime_exploration.md
+++ b/docs/design/sm70_tile_runtime_exploration.md
@@ -19,12 +19,12 @@ decode path:
 
 Relevant public references:
 
-- TileRT README: https://github.com/tile-ai/TileRT
-- TileRT execution-model blog: https://www.tilert.ai/blog/speed-as-the-next-scaling-law.html
-- TileRT 1000 TPS blog: https://www.tilert.ai/blog/breaking-1000-tps.html
-- DistFuse tile-wise GEMM/all-reduce paper: https://mcanini.github.io/papers/distfuse.hotinfra24.pdf
-- TokenWeave paper: https://arxiv.org/html/2505.11329v2
-- CUTLASS-native Distributed GEMM write-up: https://blog.shi-labs.com/distributed-gemm-88be6a481e2b
+- TileRT README: <https://github.com/tile-ai/TileRT>
+- TileRT execution-model blog: <https://www.tilert.ai/blog/speed-as-the-next-scaling-law.html>
+- TileRT 1000 TPS blog: <https://www.tilert.ai/blog/breaking-1000-tps.html>
+- DistFuse tile-wise GEMM/all-reduce paper: <https://mcanini.github.io/papers/distfuse.hotinfra24.pdf>
+- TokenWeave paper: <https://arxiv.org/html/2505.11329v2>
+- CUTLASS-native Distributed GEMM write-up: <https://blog.shi-labs.com/distributed-gemm-88be6a481e2b>
 
 The TileRT repository currently ships Python wrappers and binary backends, not
 the core engine source. The actionable implementation detail therefore comes
@@ -314,8 +314,8 @@ Correctness:
   `gated_silu` epilogue produced `max_abs=0`; interleaved normal output
   restored to the original order also produced `max_abs=0`.
 - End-to-end Qwen3.6-27B-AWQ TP2 token hashes matched baseline:
-  - 16-token smoke: `3d326cfe4c2bcd0aae49b11ed684dc2baff445be00e7eff6472cb014eb269cdb`.
-  - 128-token repeat-3: `25acc1257b65019cd7398d36105134378675d9de82bc7d30c6b49d78b1f7b755`.
+    - 16-token smoke: `3d326cfe4c2bcd0aae49b11ed684dc2baff445be00e7eff6472cb014eb269cdb`.
+    - 128-token repeat-3: `25acc1257b65019cd7398d36105134378675d9de82bc7d30c6b49d78b1f7b755`.
 
 Performance, 27B-AWQ TP2 on GPU0/1, `input_len=512`, `output_len=128`,
 `repeat=3`, Flash-V100 compile graph:
@@ -390,10 +390,10 @@ Correctness:
   both repeats produced token hash
   `1ccba72c62311edee3c604b4d41cdeddad72adb96fd6666a1af609c59708fd68`.
 - Tail-worker reduce also matches the normal path:
-  - short smoke, `output_len=4`: token hash
-    `e3b3ebc930b09ed8921c4e20f0c8dd6fb93f0bd51c382cdc33a485050ef60939`;
-  - stable comparison, `output_len=32`: both repeats produced token hash
-    `1ccba72c62311edee3c604b4d41cdeddad72adb96fd6666a1af609c59708fd68`.
+    - short smoke, `output_len=4`: token hash
+      `e3b3ebc930b09ed8921c4e20f0c8dd6fb93f0bd51c382cdc33a485050ef60939`;
+    - stable comparison, `output_len=32`: both repeats produced token hash
+      `1ccba72c62311edee3c604b4d41cdeddad72adb96fd6666a1af609c59708fd68`.
 
 Performance, 27B-AWQ TP2 on GPU0/1, `input_len=512`, `output_len=32`,
 `warmup=1`, `repeat=2`, Flash-V100 compile graph:

--- a/docs/design/sm70_tp4_nomtp_long_context_decode.md
+++ b/docs/design/sm70_tp4_nomtp_long_context_decode.md
@@ -863,7 +863,7 @@ tail improved `0.38862 -> 0.37598 ms` (`-3.25%`) but was not bitwise equal:
 The two expressions are algebraically equivalent, but Volta does not promise
 that different WMMA shapes have the same internal floating-point association or
 rounding. There is a second exactness risk: this padded route uses Q/K leading
-dimensions `264/136` halfs (`528/272 B`), which are only `16 mod 32` bytes and
+dimensions `264/136` halves (`528/272 B`), which are only `16 mod 32` bytes and
 therefore do not provide a clean WMMA fragment-alignment proof. The accepted
 `m8n32` route already uses those strides, but the `m32n8` mapping can expose a
 different sensitivity to that contract. This experiment did not export the


### PR DESCRIPTION
## Purpose

Tracking issue: #126.

Fix only non-Python, non-CUDA static baseline debt. This PR contains mechanical documentation corrections only.

## Base

- Integration base: onecat/main
- Base SHA: 3ec0c68c6596d6ab31fbdee9fa676254a52c2b7d
- Head SHA: 437f0ca93e950833f148a8561f921961be6a07a6

## Changes

- Convert bare documentation URLs to Markdown autolinks.
- Correct nested-list indentation and one duplicate heading.
- Correct the documentation spelling halves.
- Do not modify Python, C/CUDA, Flash-V100 kernel source, requirements, or pre-commit configuration.

## Validation

- PASS: pre-commit markdownlint-cli2 --all-files.
- PASS: markdownlint-cli2 0.21.0 scanned 296 Markdown files with 0 errors.
- PASS: pre-commit typos on the five changed Markdown files.
- PASS: git diff --check.
- EXPECTED SKIP: check-spdx-header on Markdown files. The hook applies only to Python files.
- OUT OF SCOPE: a read-only SPDX scan finds 26 Python header failures among 3460 Python files; no Python files are changed by this PR.

## Explicit C/CUDA Typos Handoff

The full-tree typos hook still reports these 18 scope-excluded C/CUDA matches. They are intentionally not modified here:

- flash-attention-v100/kernel/flash_v100_traits.cuh:122,132: halfs
- csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/arch/config_sm80_s16816.h:63,84: Prefecth
- csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/gemm_universal_sm90_v3.h:156: dyanmic
- csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/gemm_universal_sm90_v5.h:164: dyanmic
- csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/context.cu:194: lastest
- flash-attention-v100/kernel/fused_mha_forward_paged.cu:1175,1180,1322,1327: halfs
- csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/scheduler.cuh:166: dyanmic
- csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/dispatch_cache.cu:116: faild
- csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/gpu_metric.h:13: proble
- csrc/sm70_turbomind/lmdeploy/src/turbomind/core/allocator.h:188,189,193,194: excpected

## Risk

Documentation-only change. No GPU validation is applicable or claimed.