### PR TITLE
[CI/Build] Normalize C/CUDA static baseline

### DIFF
--- a/csrc/custom_all_reduce.cu
+++ b/csrc/custom_all_reduce.cu
@@ -161,12 +161,12 @@ void sm70_all_reduce_gemma_rms_norm_impl(
                 "SM70 TP4 Gemma RMSNorm prototype residual must be float32.");
   } else {
     TORCH_CHECK(residual.scalar_type() == at::ScalarType::Half ||
-                residual.scalar_type() == at::ScalarType::Float,
+                    residual.scalar_type() == at::ScalarType::Float,
                 "SM70 Gemma RMSNorm prototype residual must be float16 or "
                 "float32.");
   }
   TORCH_CHECK(weight.scalar_type() == at::ScalarType::Half ||
-              weight.scalar_type() == at::ScalarType::Float,
+                  weight.scalar_type() == at::ScalarType::Float,
               "SM70 Gemma RMSNorm prototype weight must be float16 or "
               "float32.");
   TORCH_CHECK_EQ(inp.dim(), 2);
@@ -176,8 +176,9 @@ void sm70_all_reduce_gemma_rms_norm_impl(
   TORCH_CHECK(normalized_out.sizes() == inp.sizes(),
               "SM70 Gemma RMSNorm prototype normalized_out shape must match "
               "inp.");
-  TORCH_CHECK(residual_out.sizes() == inp.sizes(),
-              "SM70 Gemma RMSNorm prototype residual_out shape must match inp.");
+  TORCH_CHECK(
+      residual_out.sizes() == inp.sizes(),
+      "SM70 Gemma RMSNorm prototype residual_out shape must match inp.");
   TORCH_CHECK_EQ(weight.dim(), 1);
   TORCH_CHECK_EQ(weight.numel(), kHiddenSize);
   TORCH_CHECK_EQ(residual.get_device(), inp.get_device());
@@ -307,17 +308,17 @@ void all_reduce_sum2(fptr_t _fa, torch::Tensor& inp_a, torch::Tensor& inp_b,
 
   switch (out.scalar_type()) {
     case at::ScalarType::Float: {
-      fa->allreduce_sum2<float>(stream, reinterpret_cast<float*>(inp_a.data_ptr()),
-                                reinterpret_cast<float*>(inp_b.data_ptr()),
-                                reinterpret_cast<float*>(out.data_ptr()),
-                                out.numel());
+      fa->allreduce_sum2<float>(
+          stream, reinterpret_cast<float*>(inp_a.data_ptr()),
+          reinterpret_cast<float*>(inp_b.data_ptr()),
+          reinterpret_cast<float*>(out.data_ptr()), out.numel());
       break;
     }
     case at::ScalarType::Half: {
-      fa->allreduce_sum2<half>(stream, reinterpret_cast<half*>(inp_a.data_ptr()),
-                               reinterpret_cast<half*>(inp_b.data_ptr()),
-                               reinterpret_cast<half*>(out.data_ptr()),
-                               out.numel());
+      fa->allreduce_sum2<half>(
+          stream, reinterpret_cast<half*>(inp_a.data_ptr()),
+          reinterpret_cast<half*>(inp_b.data_ptr()),
+          reinterpret_cast<half*>(out.data_ptr()), out.numel());
       break;
     }
 #if (__CUDA_ARCH__ >= 800 || !defined(__CUDA_ARCH__))
@@ -363,8 +364,7 @@ void top1_argmax(fptr_t _fa, torch::Tensor& input_pair, torch::Tensor& output,
 }
 
 void tile_runtime_all_reduce(fptr_t _fa, torch::Tensor& inp, torch::Tensor& out,
-                             fptr_t _reg_buffer,
-                             int64_t reg_buffer_sz_bytes,
+                             fptr_t _reg_buffer, int64_t reg_buffer_sz_bytes,
                              int64_t tile_numel, int64_t engine_blocks,
                              int64_t compute_iters) {
   auto fa = reinterpret_cast<vllm::CustomAllreduce*>(_fa);
@@ -412,8 +412,7 @@ void tile_runtime_all_reduce(fptr_t _fa, torch::Tensor& inp, torch::Tensor& out,
 void tile_runtime_all_reduce_engine(fptr_t _fa, torch::Tensor& inp,
                                     torch::Tensor& out, fptr_t _reg_buffer,
                                     int64_t reg_buffer_sz_bytes,
-                                    int64_t tile_numel,
-                                    int64_t producer_blocks,
+                                    int64_t tile_numel, int64_t producer_blocks,
                                     int64_t reducer_blocks,
                                     int64_t compute_iters) {
   auto fa = reinterpret_cast<vllm::CustomAllreduce*>(_fa);

--- a/csrc/custom_all_reduce.cuh
+++ b/csrc/custom_all_reduce.cuh
@@ -83,8 +83,7 @@ inline bool custom_allreduce_current_device_is_sm70() {
 #endif
 }
 
-inline int custom_allreduce_block_limit(int default_limit,
-                                        int world_size,
+inline int custom_allreduce_block_limit(int default_limit, int world_size,
                                         size_t bytes) {
   const char* raw = std::getenv("VLLM_CUSTOM_ALLREDUCE_BLOCK_LIMIT");
   if (raw == nullptr || raw[0] == '\0') {
@@ -104,8 +103,7 @@ inline int custom_allreduce_block_limit(int default_limit,
   return static_cast<int>(parsed);
 }
 
-inline int sm70_tp4_m5_allreduce_threads(int world_size,
-                                         bool fully_connected,
+inline int sm70_tp4_m5_allreduce_threads(int world_size, bool fully_connected,
                                          size_t bytes) {
   const char* raw = std::getenv("VLLM_SM70_TP4_M5_AR_THREADS");
   if (raw == nullptr || raw[0] == '\0') return 512;
@@ -264,8 +262,7 @@ static DINLINE FlagType ld_flag_volatile(FlagType* flag_addr) {
 }
 
 static DINLINE void st_flag_sys_visible(FlagType* flag_addr, FlagType flag) {
-  asm volatile("membar.sys; st.volatile.global.u32 [%1], %0;"
-               ::"r"(flag),
+  asm volatile("membar.sys; st.volatile.global.u32 [%1], %0;" ::"r"(flag),
                "l"(flag_addr)
                : "memory");
 }
@@ -421,11 +418,13 @@ __global__ void __launch_bounds__(512, 1)
 // residual after the peer reduction.
 template <int Threads, int ngpus, typename ResidualT, typename WeightT>
 __global__ void __launch_bounds__(Threads, 1)
-    sm70_peer_reduce_gemma_rms_norm(
-        RankData* _dp, RankSignals sg, Signal* self_sg,
-        const ResidualT* __restrict__ residual,
-        const WeightT* __restrict__ weight, half* __restrict__ normalized_out,
-        float* __restrict__ residual_out, int rank, float epsilon) {
+    sm70_peer_reduce_gemma_rms_norm(RankData* _dp, RankSignals sg,
+                                    Signal* self_sg,
+                                    const ResidualT* __restrict__ residual,
+                                    const WeightT* __restrict__ weight,
+                                    half* __restrict__ normalized_out,
+                                    float* __restrict__ residual_out, int rank,
+                                    float epsilon) {
   using P = typename packed_t<half>::P;
   using A = typename packed_t<half>::A;
   constexpr int kPackedWidth = P::size;
@@ -446,15 +445,14 @@ __global__ void __launch_bounds__(Threads, 1)
 
   for (int packed_idx = tid; packed_idx < packed_per_row;
        packed_idx += blockDim.x) {
-    const P reduced =
-        packed_reduce<P, ngpus, A>((const P**)&dp.ptrs[0],
-                                    row * packed_per_row + packed_idx);
+    const P reduced = packed_reduce<P, ngpus, A>(
+        (const P**)&dp.ptrs[0], row * packed_per_row + packed_idx);
     const int element_offset = row_offset + packed_idx * kPackedWidth;
 #pragma unroll
     for (int i = 0; i < kPackedWidth; ++i) {
-      const float value = __half2float(reduced.data[i]) +
-                          sm70_gemma_rms_norm_to_float(
-                              residual[element_offset + i]);
+      const float value =
+          __half2float(reduced.data[i]) +
+          sm70_gemma_rms_norm_to_float(residual[element_offset + i]);
       residual_values[packed_idx * kPackedWidth + i] = value;
       residual_out[element_offset + i] = value;
     }
@@ -490,8 +488,8 @@ __global__ void __launch_bounds__(Threads, 1)
       const int column = element_offset + i;
       const float gemma_weight =
           sm70_gemma_rms_norm_to_float(weight[column]) + 1.0f;
-      normalized_out[row_offset + column] = __float2half_rn(
-          residual_values[column] * inverse_rms * gemma_weight);
+      normalized_out[row_offset + column] =
+          __float2half_rn(residual_values[column] * inverse_rms * gemma_weight);
     }
   }
 
@@ -500,10 +498,9 @@ __global__ void __launch_bounds__(Threads, 1)
 
 template <typename T, int ngpus>
 __global__ void __launch_bounds__(256, 1) sm70_tile_runtime_reduce_kernel(
-    RankData* _dp, RankSignals sg, Signal* self_sg,
-    const T* __restrict__ input, T* __restrict__ staging,
-    T* __restrict__ result, int rank, int packed_size, int tile_packed_size,
-    int tile_count, int compute_iters) {
+    RankData* _dp, RankSignals sg, Signal* self_sg, const T* __restrict__ input,
+    T* __restrict__ staging, T* __restrict__ result, int rank, int packed_size,
+    int tile_packed_size, int tile_count, int compute_iters) {
   using P = typename packed_t<T>::P;
   using A = typename packed_t<T>::A;
 
@@ -554,11 +551,10 @@ __global__ void __launch_bounds__(256, 1) sm70_tile_runtime_reduce_kernel(
 
 template <typename T, int ngpus>
 __global__ void __launch_bounds__(256, 1) sm70_tile_runtime_engine_kernel(
-    RankData* _dp, RankSignals sg, Signal* self_sg,
-    const T* __restrict__ input, T* __restrict__ staging,
-    T* __restrict__ result, int rank, int packed_size, int tile_packed_size,
-    int tile_count, int producer_blocks, int reducer_blocks,
-    int compute_iters) {
+    RankData* _dp, RankSignals sg, Signal* self_sg, const T* __restrict__ input,
+    T* __restrict__ staging, T* __restrict__ result, int rank, int packed_size,
+    int tile_packed_size, int tile_count, int producer_blocks,
+    int reducer_blocks, int compute_iters) {
   using P = typename packed_t<T>::P;
   using A = typename packed_t<T>::A;
 
@@ -621,10 +617,11 @@ __global__ void __launch_bounds__(256, 1) sm70_tile_runtime_engine_kernel(
 
 template <typename T, int ngpus>
 __global__ void __launch_bounds__(256, 1)
-    sm70_tile_runtime_wait_reduce_kernel(
-        RankData* _dp, RankSignals sg, Signal* self_sg,
-        T* __restrict__ result, int rank, int packed_size,
-        int tile_packed_size, int tile_count) {
+    sm70_tile_runtime_wait_reduce_kernel(RankData* _dp, RankSignals sg,
+                                         Signal* self_sg,
+                                         T* __restrict__ result, int rank,
+                                         int packed_size, int tile_packed_size,
+                                         int tile_count) {
   using P = typename packed_t<T>::P;
   using A = typename packed_t<T>::A;
 
@@ -656,9 +653,11 @@ __global__ void __launch_bounds__(256, 1)
 }
 
 template <typename T, int ngpus>
-__global__ void __launch_bounds__(512, 1) cross_device_reduce_sum2_1stage(
-    RankData* _dp_a, RankData* _dp_b, RankSignals sg, Signal* self_sg,
-    T* __restrict__ result, int rank, int size) {
+__global__ void __launch_bounds__(512, 1)
+    cross_device_reduce_sum2_1stage(RankData* _dp_a, RankData* _dp_b,
+                                    RankSignals sg, Signal* self_sg,
+                                    T* __restrict__ result, int rank,
+                                    int size) {
   using P = typename packed_t<T>::P;
   using A = typename packed_t<T>::A;
   auto dp_a = *_dp_a;
@@ -666,9 +665,8 @@ __global__ void __launch_bounds__(512, 1) cross_device_reduce_sum2_1stage(
   barrier_at_start<ngpus>(sg, self_sg, rank);
   for (int idx = blockIdx.x * blockDim.x + threadIdx.x; idx < size;
        idx += gridDim.x * blockDim.x) {
-    ((P*)result)[idx] =
-        packed_reduce_sum2<P, ngpus, A>((const P**)&dp_a.ptrs[0],
-                                        (const P**)&dp_b.ptrs[0], idx);
+    ((P*)result)[idx] = packed_reduce_sum2<P, ngpus, A>(
+        (const P**)&dp_a.ptrs[0], (const P**)&dp_b.ptrs[0], idx);
   }
   barrier_at_end<ngpus, true>(sg, self_sg, rank);
 }
@@ -726,9 +724,11 @@ __global__ void __launch_bounds__(512, 1)
 }
 
 template <typename T, int ngpus>
-__global__ void __launch_bounds__(512, 1) cross_device_reduce_sum2_2stage(
-    RankData* _dp_a, RankData* _dp_b, RankSignals sg, Signal* self_sg,
-    T* __restrict__ result, int rank, int size) {
+__global__ void __launch_bounds__(512, 1)
+    cross_device_reduce_sum2_2stage(RankData* _dp_a, RankData* _dp_b,
+                                    RankSignals sg, Signal* self_sg,
+                                    T* __restrict__ result, int rank,
+                                    int size) {
   int tid = blockIdx.x * blockDim.x + threadIdx.x;
   int stride = gridDim.x * blockDim.x;
   using P = typename packed_t<T>::P;
@@ -753,8 +753,7 @@ __global__ void __launch_bounds__(512, 1) cross_device_reduce_sum2_2stage(
   // Stage 1 mirrors cross_device_reduce_2stage, but each rank first forms
   // its local input_a + input_b value before the cross-rank reduction.
   for (int idx = start + tid; idx < end; idx += stride) {
-    tmp_out[idx - start] =
-        packed_reduce_sum2<P, ngpus, A>(ptrs_a, ptrs_b, idx);
+    tmp_out[idx - start] = packed_reduce_sum2<P, ngpus, A>(ptrs_a, ptrs_b, idx);
   }
   barrier_at_end<ngpus>(sg, self_sg, rank);
 
@@ -925,11 +924,10 @@ class CustomAllreduce {
     } else {
       auto it = buffers_.find(buffer);
       if (it == buffers_.end()) {
-        throw std::runtime_error(std::string(op_name) +
-                                 " buffer address " +
-                                 std::to_string(
-                                     reinterpret_cast<uint64_t>(buffer)) +
-                                 " is not registered!");
+        throw std::runtime_error(
+            std::string(op_name) + " buffer address " +
+            std::to_string(reinterpret_cast<uint64_t>(buffer)) +
+            " is not registered!");
       }
       ptrs = it->second;
     }
@@ -1013,8 +1011,8 @@ class CustomAllreduce {
 
     size /= d;
     auto bytes = size * sizeof(typename packed_t<T>::P);
-    threads = sm70_tp4_m5_allreduce_threads(world_size_, fully_connected_,
-                                            bytes);
+    threads =
+        sm70_tp4_m5_allreduce_threads(world_size_, fully_connected_, bytes);
     int blocks = std::min(block_limit, (size + threads - 1) / threads);
 
     // Check environment variable once
@@ -1077,11 +1075,11 @@ class CustomAllreduce {
 
   template <int ngpus, typename ResidualT, typename WeightT>
   void sm70_allreduce_gemma_rms_norm(cudaStream_t stream, half* input,
-                                      const ResidualT* residual,
-                                      const WeightT* weight,
-                                      half* normalized_out,
-                                      float* residual_out, int num_tokens,
-                                      int hidden_size, float epsilon) {
+                                     const ResidualT* residual,
+                                     const WeightT* weight,
+                                     half* normalized_out, float* residual_out,
+                                     int num_tokens, int hidden_size,
+                                     float epsilon) {
     if (world_size_ != ngpus || !custom_allreduce_current_device_is_sm70()) {
       throw std::runtime_error("SM70 Gemma RMSNorm prototype requires TP" +
                                std::to_string(ngpus) + " on an SM70 device.");
@@ -1095,18 +1093,18 @@ class CustomAllreduce {
     if (num_tokens <= 0 || num_tokens > kMaxTokens) {
       throw std::runtime_error(
           "SM70 Gemma RMSNorm prototype supports tokens in [1, " +
-          std::to_string(kMaxTokens) + "]. Got " +
-          std::to_string(num_tokens) + ".");
+          std::to_string(kMaxTokens) + "]. Got " + std::to_string(num_tokens) +
+          ".");
     }
 
-    RankData* ptrs = rank_data_for_buffer(
-        stream, input, "SM70 Gemma RMSNorm prototype input");
+    RankData* ptrs = rank_data_for_buffer(stream, input,
+                                          "SM70 Gemma RMSNorm prototype input");
     if constexpr (ngpus == 4) {
       // Keep the same 1024-thread CUB reduction topology as vLLM rms_norm.
       // packed_reduce preserves the cross_device_reduce_1stage<half, 4>
       // rank order before the FP32 residual add.
       sm70_peer_reduce_gemma_rms_norm<kSm70GemmaRmsNormThreads, ngpus,
-                                       ResidualT, WeightT>
+                                      ResidualT, WeightT>
           <<<num_tokens, kSm70GemmaRmsNormThreads, 0, stream>>>(
               ptrs, sg_, self_sg_, residual, weight, normalized_out,
               residual_out, rank_, epsilon);
@@ -1114,11 +1112,11 @@ class CustomAllreduce {
     }
 
     const int threads = sm70_gemma_rms_norm_threads();
-#define VLLM_LAUNCH_SM70_GEMMA_RMS_NORM(THREADS)                         \
+#define VLLM_LAUNCH_SM70_GEMMA_RMS_NORM(THREADS)                          \
   sm70_peer_reduce_gemma_rms_norm<THREADS, ngpus, ResidualT, WeightT>     \
-      <<<num_tokens, THREADS, 0, stream>>>(                               \
-          ptrs, sg_, self_sg_, residual, weight, normalized_out,          \
-          residual_out, rank_, epsilon)
+      <<<num_tokens, THREADS, 0, stream>>>(ptrs, sg_, self_sg_, residual, \
+                                           weight, normalized_out,        \
+                                           residual_out, rank_, epsilon)
     switch (threads) {
       case 256:
         VLLM_LAUNCH_SM70_GEMMA_RMS_NORM(256);
@@ -1190,29 +1188,28 @@ class CustomAllreduce {
       }
     }
 
-#define SUM2_KL(ngpus, name)                                                  \
-  name<T, ngpus><<<blocks, threads, 0, stream>>>(ptrs_a, ptrs_b, sg_,         \
-                                                 self_sg_, output, rank_,     \
-                                                 size);
-#define SUM2_CASE(ngpus)                              \
-  case ngpus: {                                      \
-    if (force_1stage) {                              \
-      SUM2_KL(ngpus, cross_device_reduce_sum2_1stage); \
-    } else if (force_2stage) {                       \
-      SUM2_KL(ngpus, cross_device_reduce_sum2_2stage); \
-    } else {                                         \
-      if (world_size_ == 2) {                        \
-        SUM2_KL(ngpus, cross_device_reduce_sum2_1stage); \
-      } else if (fully_connected_) {                 \
-        if ((world_size_ <= 4 && bytes < 512 * 1024) || \
-            (world_size_ <= 8 && bytes < 256 * 1024)) { \
+#define SUM2_KL(ngpus, name)                      \
+  name<T, ngpus><<<blocks, threads, 0, stream>>>( \
+      ptrs_a, ptrs_b, sg_, self_sg_, output, rank_, size);
+#define SUM2_CASE(ngpus)                                   \
+  case ngpus: {                                            \
+    if (force_1stage) {                                    \
+      SUM2_KL(ngpus, cross_device_reduce_sum2_1stage);     \
+    } else if (force_2stage) {                             \
+      SUM2_KL(ngpus, cross_device_reduce_sum2_2stage);     \
+    } else {                                               \
+      if (world_size_ == 2) {                              \
+        SUM2_KL(ngpus, cross_device_reduce_sum2_1stage);   \
+      } else if (fully_connected_) {                       \
+        if ((world_size_ <= 4 && bytes < 512 * 1024) ||    \
+            (world_size_ <= 8 && bytes < 256 * 1024)) {    \
           SUM2_KL(ngpus, cross_device_reduce_sum2_1stage); \
-        } else {                                     \
+        } else {                                           \
           SUM2_KL(ngpus, cross_device_reduce_sum2_2stage); \
-        }                                            \
-      }                                              \
-    }                                                \
-    break;                                           \
+        }                                                  \
+      }                                                    \
+    }                                                      \
+    break;                                                 \
   }
 
     switch (world_size_) {
@@ -1252,12 +1249,12 @@ class CustomAllreduce {
 
     const int packed_size = size / pack;
     const int tile_packed_size = tile_numel / pack;
-    const int tile_count = (packed_size + tile_packed_size - 1) / tile_packed_size;
+    const int tile_count =
+        (packed_size + tile_packed_size - 1) / tile_packed_size;
     if (tile_count <= 0 || tile_count > kMaxBlocks) {
       throw std::runtime_error(
           "SM70 tile runtime prototype supports tile_count in [1, " +
-          std::to_string(kMaxBlocks) + "]. Got " +
-          std::to_string(tile_count));
+          std::to_string(kMaxBlocks) + "]. Got " + std::to_string(tile_count));
     }
 
     auto it = buffers_.find(staging);
@@ -1274,14 +1271,12 @@ class CustomAllreduce {
     blocks = std::max(1, std::min(blocks, tile_count));
     compute_iters = std::max(0, compute_iters);
 
-#define TILE_RUNTIME_CASE(ngpus)                                             \
-  case ngpus: {                                                              \
-    sm70_tile_runtime_reduce_kernel<T, ngpus>                                \
-        <<<blocks, threads, 0, stream>>>(ptrs, sg_, self_sg_, input, staging, \
-                                         output, rank_, packed_size,          \
-                                         tile_packed_size, tile_count,        \
-                                         compute_iters);                     \
-    break;                                                                   \
+#define TILE_RUNTIME_CASE(ngpus)                                               \
+  case ngpus: {                                                                \
+    sm70_tile_runtime_reduce_kernel<T, ngpus><<<blocks, threads, 0, stream>>>( \
+        ptrs, sg_, self_sg_, input, staging, output, rank_, packed_size,       \
+        tile_packed_size, tile_count, compute_iters);                          \
+    break;                                                                     \
   }
 
     switch (world_size_) {
@@ -1321,8 +1316,7 @@ class CustomAllreduce {
     if (tile_count <= 0 || tile_count > kMaxBlocks) {
       throw std::runtime_error(
           "SM70 tile runtime engine supports tile_count in [1, " +
-          std::to_string(kMaxBlocks) + "]. Got " +
-          std::to_string(tile_count));
+          std::to_string(kMaxBlocks) + "]. Got " + std::to_string(tile_count));
     }
 
     auto it = buffers_.find(staging);
@@ -1344,15 +1338,13 @@ class CustomAllreduce {
     const int threads = 256;
     const int blocks = producer_blocks + reducer_blocks;
 
-#define TILE_RUNTIME_ENGINE_CASE(ngpus)                                      \
-  case ngpus: {                                                              \
-    sm70_tile_runtime_engine_kernel<T, ngpus>                                \
-        <<<blocks, threads, 0, stream>>>(ptrs, sg_, self_sg_, input, staging, \
-                                         output, rank_, packed_size,          \
-                                         tile_packed_size, tile_count,        \
-                                         producer_blocks, reducer_blocks,     \
-                                         compute_iters);                     \
-    break;                                                                   \
+#define TILE_RUNTIME_ENGINE_CASE(ngpus)                                        \
+  case ngpus: {                                                                \
+    sm70_tile_runtime_engine_kernel<T, ngpus><<<blocks, threads, 0, stream>>>( \
+        ptrs, sg_, self_sg_, input, staging, output, rank_, packed_size,       \
+        tile_packed_size, tile_count, producer_blocks, reducer_blocks,         \
+        compute_iters);                                                        \
+    break;                                                                     \
   }
 
     switch (world_size_) {
@@ -1366,8 +1358,7 @@ class CustomAllreduce {
 
   template <typename T>
   void tile_runtime_wait_reduce(cudaStream_t stream, T* staging, T* output,
-                                int size, int tile_numel,
-                                int reducer_blocks) {
+                                int size, int tile_numel, int reducer_blocks) {
     if (world_size_ != 2) {
       throw std::runtime_error(
           "SM70 tile runtime wait-reduce currently supports only TP2.");
@@ -1391,8 +1382,7 @@ class CustomAllreduce {
     if (tile_count <= 0 || tile_count > kMaxBlocks) {
       throw std::runtime_error(
           "SM70 tile runtime wait-reduce supports tile_count in [1, " +
-          std::to_string(kMaxBlocks) + "]. Got " +
-          std::to_string(tile_count));
+          std::to_string(kMaxBlocks) + "]. Got " + std::to_string(tile_count));
     }
 
     RankData* ptrs;
@@ -1418,13 +1408,13 @@ class CustomAllreduce {
 
     constexpr int threads = 256;
 
-#define TILE_RUNTIME_WAIT_REDUCE_CASE(ngpus)                                 \
-  case ngpus: {                                                              \
-    sm70_tile_runtime_wait_reduce_kernel<T, ngpus>                           \
-        <<<reducer_blocks, threads, 0, stream>>>(                            \
-            ptrs, sg_, self_sg_, output, rank_, packed_size,                 \
-            tile_packed_size, tile_count);                                   \
-    break;                                                                   \
+#define TILE_RUNTIME_WAIT_REDUCE_CASE(ngpus)                                   \
+  case ngpus: {                                                                \
+    sm70_tile_runtime_wait_reduce_kernel<T, ngpus>                             \
+        <<<reducer_blocks, threads, 0, stream>>>(                              \
+            ptrs, sg_, self_sg_, output, rank_, packed_size, tile_packed_size, \
+            tile_count);                                                       \
+    break;                                                                     \
   }
 
     switch (world_size_) {
@@ -1453,11 +1443,11 @@ class CustomAllreduce {
       ptrs = it->second;
     }
 
-#define TOP1_CASE(ngpus)                                   \
-  case ngpus: {                                            \
-    cross_device_top1_argmax<ngpus><<<1, 32, 0, stream>>>( \
-        ptrs, sg_, self_sg_, output, rank_);               \
-    break;                                                 \
+#define TOP1_CASE(ngpus)                                            \
+  case ngpus: {                                                     \
+    cross_device_top1_argmax<ngpus>                                 \
+        <<<1, 32, 0, stream>>>(ptrs, sg_, self_sg_, output, rank_); \
+    break;                                                          \
   }
 
     switch (world_size_) {

--- a/csrc/moe/marlin_moe_wna16/sm70_marlin_fp8_gemm.cu
+++ b/csrc/moe/marlin_moe_wna16/sm70_marlin_fp8_gemm.cu
@@ -35,22 +35,25 @@ class Sm70MoeFp8IteratorB {
   static int const kPackedMacroN = PackedMacroN_;
   static constexpr bool kUseMetadataVectorWords = UseMetadataVectorWords_;
   using Element = cutlass::half_t;
-  using Fragment = cutlass::Array<
-      Element, ThreadMap::Iterations::kCount * ThreadMap::kElementsPerAccess>;
-    static_assert(Shape::kN == 64 || Shape::kN == 128 || Shape::kN == 256,
-                "SM70 Marlin MoE FP8 IteratorB expects CTA_N in {64, 128, 256}.");
-  static_assert(ThreadMap::Iterations::kContiguous ==
-                    Shape::kN / kQuantTileN,
-                "SM70 Marlin MoE FP8 IteratorB expects one contiguous iteration per "
-                "64-column quant tile.");
+  using Fragment = cutlass::Array<Element, ThreadMap::Iterations::kCount *
+                                               ThreadMap::kElementsPerAccess>;
+  static_assert(
+      Shape::kN == 64 || Shape::kN == 128 || Shape::kN == 256,
+      "SM70 Marlin MoE FP8 IteratorB expects CTA_N in {64, 128, 256}.");
+  static_assert(
+      ThreadMap::Iterations::kContiguous == Shape::kN / kQuantTileN,
+      "SM70 Marlin MoE FP8 IteratorB expects one contiguous iteration per "
+      "64-column quant tile.");
   static_assert(ThreadMap::Delta::kContiguous == kQuantTileN,
                 "SM70 Marlin MoE FP8 IteratorB expects 64-column deltas.");
-  static_assert(ThreadMap::kElementsPerAccess == kFp8ValuesPerAccess,
-                "SM70 Marlin MoE FP8 IteratorB expects two packed FP8 words per "
-                "access.");
-  static_assert(ThreadMap::Iterations::kStrided >= 1,
-                "SM70 Marlin MoE U8-family IteratorB expects one or more strided "
-                "iterations.");
+  static_assert(
+      ThreadMap::kElementsPerAccess == kFp8ValuesPerAccess,
+      "SM70 Marlin MoE FP8 IteratorB expects two packed FP8 words per "
+      "access.");
+  static_assert(
+      ThreadMap::Iterations::kStrided >= 1,
+      "SM70 Marlin MoE U8-family IteratorB expects one or more strided "
+      "iterations.");
   static constexpr int kQweightWordStrideWords = kPackedMacroN / kQuantTileN;
 
   struct Params {
@@ -83,12 +86,11 @@ class Sm70MoeFp8IteratorB {
  public:
   CUTLASS_DEVICE
   Sm70MoeFp8IteratorB(Params const& params, uint32_t const* qweight,
-                       half const* scales, half const*, int thread_id,
-                       int expert, int k_offset, int n_offset)
+                      half const* scales, half const*, int thread_id,
+                      int expert, int k_offset, int n_offset)
       : qweight_(qweight),
-        scales_expert_base_(scales +
-                            (expert >= 0 ? expert : 0) *
-                                params.num_groups * params.size_n),
+        scales_expert_base_(scales + (expert >= 0 ? expert : 0) *
+                                         params.num_groups * params.size_n),
         params_(params),
         thread_offset_(ThreadMap::initial_offset(thread_id)),
         expert_(expert),
@@ -130,9 +132,7 @@ class Sm70MoeFp8IteratorB {
   }
 
   CUTLASS_DEVICE
-  int metadata_group_offset(int group) const {
-    return group * params_.size_n;
-  }
+  int metadata_group_offset(int group) const { return group * params_.size_n; }
 
   CUTLASS_DEVICE
   int scale_group(int logical_k) const {
@@ -155,8 +155,8 @@ class Sm70MoeFp8IteratorB {
   CUTLASS_DEVICE
   void cache_metadata_lane_vectors(int c, int group, int cache_n) const {
     int const metadata_offset = metadata_group_offset(group) + cache_n;
-    half2 const* scale_vec = reinterpret_cast<half2 const*>(
-        scales_expert_base_ + metadata_offset);
+    half2 const* scale_vec =
+        reinterpret_cast<half2 const*>(scales_expert_base_ + metadata_offset);
     half2* scale_cache = cached_scales_ + c * 4;
     scale_cache[0] = scale_vec[0];
     scale_cache[1] = scale_vec[1];
@@ -167,8 +167,8 @@ class Sm70MoeFp8IteratorB {
   CUTLASS_DEVICE
   void cache_metadata_vector_words(int c, int group, int cache_n) const {
     int const metadata_offset = metadata_group_offset(group) + cache_n;
-    uint4 const scale_words = *reinterpret_cast<uint4 const*>(
-        scales_expert_base_ + metadata_offset);
+    uint4 const scale_words =
+        *reinterpret_cast<uint4 const*>(scales_expert_base_ + metadata_offset);
     half2 const* scale_vec = reinterpret_cast<half2 const*>(&scale_words);
     half2* scale_cache = cached_scales_ + c * 4;
     scale_cache[0] = scale_vec[0];
@@ -181,9 +181,8 @@ class Sm70MoeFp8IteratorB {
   void cache_current_group_metadata(int group) const {
     CUTLASS_PRAGMA_UNROLL
     for (int c = 0; c < ThreadMap::Iterations::kContiguous; ++c) {
-      int const cache_n =
-          n_offset_ + thread_offset_.contiguous() +
-          c * ThreadMap::Delta::kContiguous;
+      int const cache_n = n_offset_ + thread_offset_.contiguous() +
+                          c * ThreadMap::Delta::kContiguous;
       if constexpr (kUseMetadataVectorWords) {
         cache_metadata_vector_words(c, group, cache_n);
       } else {
@@ -244,8 +243,9 @@ class Sm70MoeFp8IteratorB {
           frag_vec[3] = __hmul2(deq[1], scale_vec[3]);
         }
       } else {
-        static_assert(ThreadMap::Iterations::kContiguous == 1,
-                      "Unsupported SM70 Marlin MoE FP8 contiguous iteration count.");
+        static_assert(
+            ThreadMap::Iterations::kContiguous == 1,
+            "Unsupported SM70 Marlin MoE FP8 contiguous iteration count.");
         uint32_t const qword0 =
             load_qword_vector<1>(qweight_ + qweight_base_offset_);
         uint32_t const qword1 = load_qword_vector<1>(
@@ -267,9 +267,8 @@ class Sm70MoeFp8IteratorB {
       int const logical_n_base = n_offset_ + thread_offset_.contiguous();
       CUTLASS_PRAGMA_UNROLL
       for (int s = 0; s < ThreadMap::Iterations::kStrided; ++s) {
-        int const logical_k_s =
-            k_offset_ + thread_offset_.strided() +
-            s * ThreadMap::Delta::kStrided;
+        int const logical_k_s = k_offset_ + thread_offset_.strided() +
+                                s * ThreadMap::Delta::kStrided;
         if constexpr (kGroupSize != -1) {
           cache_current_group_metadata(scale_group(logical_k_s));
         }
@@ -277,10 +276,9 @@ class Sm70MoeFp8IteratorB {
             expert_qweight_base_offset() +
             qweight_offset_from_logical(params_, logical_k_s, logical_n_base);
         if constexpr (ThreadMap::Iterations::kContiguous == 4) {
-          uint4 const qwords0 =
-              load_qword_vector<4>(qweight_ + qweight_base_s);
-          uint4 const qwords1 = load_qword_vector<4>(
-              qweight_ + qweight_base_s + kQweightWordStrideWords);
+          uint4 const qwords0 = load_qword_vector<4>(qweight_ + qweight_base_s);
+          uint4 const qwords1 = load_qword_vector<4>(qweight_ + qweight_base_s +
+                                                     kQweightWordStrideWords);
           CUTLASS_PRAGMA_UNROLL
           for (int c = 0; c < ThreadMap::Iterations::kContiguous; ++c) {
             constexpr int kAccess = ThreadMap::kElementsPerAccess;
@@ -294,22 +292,17 @@ class Sm70MoeFp8IteratorB {
             half2* frag_vec = reinterpret_cast<half2*>(frag.data() + frag_base);
             marlin::dequant<half2, vllm::kFE4M3fn.id(), true>(
                 static_cast<int>(qword0), deq);
-            frag_vec[0] =
-                __hmul2(deq[0], scale_vec[0]);
-            frag_vec[1] =
-                __hmul2(deq[1], scale_vec[1]);
+            frag_vec[0] = __hmul2(deq[0], scale_vec[0]);
+            frag_vec[1] = __hmul2(deq[1], scale_vec[1]);
             marlin::dequant<half2, vllm::kFE4M3fn.id(), true>(
                 static_cast<int>(qword1), deq);
-            frag_vec[2] =
-                __hmul2(deq[0], scale_vec[2]);
-            frag_vec[3] =
-                __hmul2(deq[1], scale_vec[3]);
+            frag_vec[2] = __hmul2(deq[0], scale_vec[2]);
+            frag_vec[3] = __hmul2(deq[1], scale_vec[3]);
           }
         } else if constexpr (ThreadMap::Iterations::kContiguous == 2) {
-          uint2 const qwords0 =
-              load_qword_vector<2>(qweight_ + qweight_base_s);
-          uint2 const qwords1 = load_qword_vector<2>(
-              qweight_ + qweight_base_s + kQweightWordStrideWords);
+          uint2 const qwords0 = load_qword_vector<2>(qweight_ + qweight_base_s);
+          uint2 const qwords1 = load_qword_vector<2>(qweight_ + qweight_base_s +
+                                                     kQweightWordStrideWords);
           CUTLASS_PRAGMA_UNROLL
           for (int c = 0; c < ThreadMap::Iterations::kContiguous; ++c) {
             constexpr int kAccess = ThreadMap::kElementsPerAccess;
@@ -323,20 +316,17 @@ class Sm70MoeFp8IteratorB {
             half2* frag_vec = reinterpret_cast<half2*>(frag.data() + frag_base);
             marlin::dequant<half2, vllm::kFE4M3fn.id(), true>(
                 static_cast<int>(qword0), deq);
-            frag_vec[0] =
-                __hmul2(deq[0], scale_vec[0]);
-            frag_vec[1] =
-                __hmul2(deq[1], scale_vec[1]);
+            frag_vec[0] = __hmul2(deq[0], scale_vec[0]);
+            frag_vec[1] = __hmul2(deq[1], scale_vec[1]);
             marlin::dequant<half2, vllm::kFE4M3fn.id(), true>(
                 static_cast<int>(qword1), deq);
-            frag_vec[2] =
-                __hmul2(deq[0], scale_vec[2]);
-            frag_vec[3] =
-                __hmul2(deq[1], scale_vec[3]);
+            frag_vec[2] = __hmul2(deq[0], scale_vec[2]);
+            frag_vec[3] = __hmul2(deq[1], scale_vec[3]);
           }
         } else {
-          static_assert(ThreadMap::Iterations::kContiguous == 1,
-                        "Unsupported SM70 Marlin MoE FP8 contiguous iteration count.");
+          static_assert(
+              ThreadMap::Iterations::kContiguous == 1,
+              "Unsupported SM70 Marlin MoE FP8 contiguous iteration count.");
           uint32_t const qword0 =
               load_qword_vector<1>(qweight_ + qweight_base_s);
           uint32_t const qword1 = load_qword_vector<1>(
@@ -366,8 +356,7 @@ class Sm70MoeFp8IteratorB {
       return;
     }
 
-    if constexpr (kGroupSize != -1 &&
-                  ThreadMap::Iterations::kStrided == 1) {
+    if constexpr (kGroupSize != -1 && ThreadMap::Iterations::kStrided == 1) {
       int const first_logical_k = k_offset_ + thread_offset_.strided();
       cache_current_group_metadata(scale_group(first_logical_k));
     }
@@ -386,18 +375,17 @@ struct Sm70MoeFp8GemmSpec {
   using IteratorA = Sm70MoeGatherIteratorA<Shape, ThreadMap>;
 
   template <typename Shape, typename ThreadMap, int GroupSize, int PackedMacroN>
-  using IteratorB =
-      Sm70MoeFp8IteratorB<Shape, ThreadMap, GroupSize, PackedMacroN,
-                          UseMetadataVectorWords>;
+  using IteratorB = Sm70MoeFp8IteratorB<Shape, ThreadMap, GroupSize,
+                                        PackedMacroN, UseMetadataVectorWords>;
 };
 
-template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM,
-          int WarpN, int WarpK, int GroupSize, int PackedMacroN,
+template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM, int WarpN,
+          int WarpK, int GroupSize, int PackedMacroN,
           bool UseMetadataVectorWords = true>
 using Sm70MoeFp8GemmTraits =
-    Sm70MarlinMoeGemmTraits<
-        Sm70MoeFp8GemmSpec<UseMetadataVectorWords>, CtaM, CtaN, CtaK,
-        Warps, WarpM, WarpN, WarpK, GroupSize, PackedMacroN>;
+    Sm70MarlinMoeGemmTraits<Sm70MoeFp8GemmSpec<UseMetadataVectorWords>, CtaM,
+                            CtaN, CtaK, Warps, WarpM, WarpN, WarpK, GroupSize,
+                            PackedMacroN>;
 
 template <bool UseMetadataVectorWords = true>
 struct Sm70MoeFp8Launcher {
@@ -419,16 +407,16 @@ struct Sm70MoeFp8Launcher {
   int64_t size_k;
   int requested_split_k;
 
-  template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM,
-          int WarpN, int WarpK, int GroupSize, int PackedMacroN>
+  template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM, int WarpN,
+            int WarpK, int GroupSize, int PackedMacroN>
   torch::Tensor operator()() const {
-    using Traits = Sm70MoeFp8GemmTraits<CtaM, CtaN, CtaK, Warps, WarpM,
-                                        WarpN, WarpK, GroupSize, PackedMacroN,
-                                        UseMetadataVectorWords>;
+    using Traits =
+        Sm70MoeFp8GemmTraits<CtaM, CtaN, CtaK, Warps, WarpM, WarpN, WarpK,
+                             GroupSize, PackedMacroN, UseMetadataVectorWords>;
     return launch_sm70_marlin_moe_gemm<Traits>(
         a, c, b_q_weight, b_scales, b_zeros, global_scale, sorted_token_ids,
-        expert_ids, num_tokens_past_padded, topk_weights, moe_block_size,
-        top_k, mul_topk_weights, size_m, size_n, size_k, requested_split_k);
+        expert_ids, num_tokens_past_padded, topk_weights, moe_block_size, top_k,
+        mul_topk_weights, size_m, size_n, size_k, requested_split_k);
   }
 };
 
@@ -446,9 +434,10 @@ torch::Tensor sm70_marlin_fp8_gemm(
   auto const params = sm70_marlin_moe_auto_stage_params(
       "fp8_e4m3", group_size, moe_block_size, top_k, size_m, size_n, size_k);
   Sm70CtaGeometry const geometry = params.geometry;
-  validate_sm70_marlin_moe_stage_cta_geometry_supported("SM70 Marlin MoE fp8_e4m3", geometry);
-  validate_sm70_marlin_moe_stage_cta_n_alignment("SM70 Marlin MoE fp8_e4m3", geometry,
-                                        size_n);
+  validate_sm70_marlin_moe_stage_cta_geometry_supported(
+      "SM70 Marlin MoE fp8_e4m3", geometry);
+  validate_sm70_marlin_moe_stage_cta_n_alignment("SM70 Marlin MoE fp8_e4m3",
+                                                 geometry, size_n);
   TORCH_CHECK(size_k % geometry.cta_k == 0,
               "SM70 Marlin MoE fp8_e4m3 requires K divisible by CTA_K=",
               geometry.cta_k, ". Got K=", size_k, ".");
@@ -457,17 +446,45 @@ torch::Tensor sm70_marlin_fp8_gemm(
   auto empty_float = torch::empty(
       {0}, torch::TensorOptions().dtype(at::kFloat).device(a.device()));
   if (params.use_metadata_vector_words) {
-    Sm70MoeFp8Launcher<true> const launcher{
-        a, c, b_q_weight, b_scales, empty_half, empty_float, sorted_token_ids,
-        expert_ids, num_tokens_past_padded, topk_weights, moe_block_size, top_k,
-        mul_topk_weights, size_m, size_n, size_k, params.requested_split_k};
-    return dispatch_sm70_marlin_moe_fp8_geometry(launcher, geometry, params.packed_macro_n, group_size);
+    Sm70MoeFp8Launcher<true> const launcher{a,
+                                            c,
+                                            b_q_weight,
+                                            b_scales,
+                                            empty_half,
+                                            empty_float,
+                                            sorted_token_ids,
+                                            expert_ids,
+                                            num_tokens_past_padded,
+                                            topk_weights,
+                                            moe_block_size,
+                                            top_k,
+                                            mul_topk_weights,
+                                            size_m,
+                                            size_n,
+                                            size_k,
+                                            params.requested_split_k};
+    return dispatch_sm70_marlin_moe_fp8_geometry(
+        launcher, geometry, params.packed_macro_n, group_size);
   }
-  Sm70MoeFp8Launcher<false> const launcher{
-      a, c, b_q_weight, b_scales, empty_half, empty_float, sorted_token_ids,
-      expert_ids, num_tokens_past_padded, topk_weights, moe_block_size, top_k,
-      mul_topk_weights, size_m, size_n, size_k, params.requested_split_k};
-  return dispatch_sm70_marlin_moe_fp8_geometry(launcher, geometry, params.packed_macro_n, group_size);
+  Sm70MoeFp8Launcher<false> const launcher{a,
+                                           c,
+                                           b_q_weight,
+                                           b_scales,
+                                           empty_half,
+                                           empty_float,
+                                           sorted_token_ids,
+                                           expert_ids,
+                                           num_tokens_past_padded,
+                                           topk_weights,
+                                           moe_block_size,
+                                           top_k,
+                                           mul_topk_weights,
+                                           size_m,
+                                           size_n,
+                                           size_k,
+                                           params.requested_split_k};
+  return dispatch_sm70_marlin_moe_fp8_geometry(
+      launcher, geometry, params.packed_macro_n, group_size);
 }
 
 }  // namespace marlin_moe_wna16

--- a/csrc/moe/marlin_moe_wna16/sm70_marlin_gemm.cuh
+++ b/csrc/moe/marlin_moe_wna16/sm70_marlin_gemm.cuh
@@ -27,22 +27,22 @@
 
 namespace marlin_moe_wna16 {
 
-using marlin::sm70::Sm70CtaGeometry;
-using marlin::sm70::Sm70MarlinAutoParams;
-using marlin::sm70::Sm70MarlinMoeAutoParamsContext;
-using marlin::sm70::Sm70SplitKPartition;
-using marlin::sm70::Sm70MarlinMmaPipelined;
-using marlin::sm70::Sm70WarpShape;
 using marlin::sm70::configure_sm70_dynamic_smem;
 using marlin::sm70::kQuantTileK;
 using marlin::sm70::kQuantTileN;
+using marlin::sm70::sm70_active_split_k;
 using marlin::sm70::sm70_marlin_any_auto_env_is_set;
 using marlin::sm70::sm70_marlin_auto_packed_macro_n;
 using marlin::sm70::sm70_marlin_auto_params_from_env;
 using marlin::sm70::sm70_marlin_cta_geometry_is_supported;
 using marlin::sm70::sm70_marlin_default_auto_params;
-using marlin::sm70::sm70_active_split_k;
 using marlin::sm70::sm70_splitk_partition;
+using marlin::sm70::Sm70CtaGeometry;
+using marlin::sm70::Sm70MarlinAutoParams;
+using marlin::sm70::Sm70MarlinMmaPipelined;
+using marlin::sm70::Sm70MarlinMoeAutoParamsContext;
+using marlin::sm70::Sm70SplitKPartition;
+using marlin::sm70::Sm70WarpShape;
 using marlin::sm70::validate_sm70_marlin_auto_params;
 
 inline constexpr char const* kSupportedSm70MarlinMoeCtaGeometries =
@@ -55,9 +55,9 @@ inline constexpr char const* kSupportedSm70MarlinMoeCtaGeometries =
     "geometries are dense-only.";
 
 inline bool sm70_marlin_moe_auto_env_is_set() {
-  return sm70_marlin_any_auto_env_is_set(
-      "SM70_MARLIN_MOE_CTA_GEOMETRY", "SM70_MARLIN_MOE_SPLIT_K",
-      "SM70_MARLIN_MOE_METADATA_CACHE");
+  return sm70_marlin_any_auto_env_is_set("SM70_MARLIN_MOE_CTA_GEOMETRY",
+                                         "SM70_MARLIN_MOE_SPLIT_K",
+                                         "SM70_MARLIN_MOE_METADATA_CACHE");
 }
 
 inline Sm70MarlinAutoParams sm70_marlin_moe_auto_params_from_env(
@@ -68,16 +68,14 @@ inline Sm70MarlinAutoParams sm70_marlin_moe_auto_params_from_env(
 }
 
 inline bool sm70_marlin_moe_try_select_quanttrio_qwen3_6_35b_a3b_awq_params(
-    Sm70MarlinMoeAutoParamsContext const& ctx,
-    Sm70MarlinAutoParams& params) {
+    Sm70MarlinMoeAutoParamsContext const& ctx, Sm70MarlinAutoParams& params) {
   if (ctx.quant_format == nullptr ||
-      std::strcmp(ctx.quant_format, "uint4") != 0 ||
-      ctx.group_size != 128 || ctx.size_m <= 0) {
+      std::strcmp(ctx.quant_format, "uint4") != 0 || ctx.group_size != 128 ||
+      ctx.size_m <= 0) {
     return false;
   }
 
-  auto const set_params = [&](Sm70CtaGeometry geometry,
-                              int requested_split_k,
+  auto const set_params = [&](Sm70CtaGeometry geometry, int requested_split_k,
                               bool use_metadata_vector_words) {
     params = {geometry, requested_split_k, use_metadata_vector_words,
               ctx.packed_macro_n};
@@ -152,8 +150,7 @@ inline bool sm70_marlin_moe_try_select_quanttrio_qwen3_6_35b_a3b_awq_params(
       }
       return set_params({64, 128, 32, 8, 32, 32, 32}, 1, false);
     }
-    if (ctx.moe_block_size == 64 &&
-        (ctx.size_n == 256 || ctx.size_n == 1024)) {
+    if (ctx.moe_block_size == 64 && (ctx.size_n == 256 || ctx.size_n == 1024)) {
       return set_params({64, 256, 32, 4, 64, 64, 32}, 1, false);
     }
   }
@@ -162,16 +159,14 @@ inline bool sm70_marlin_moe_try_select_quanttrio_qwen3_6_35b_a3b_awq_params(
 }
 
 inline bool sm70_marlin_moe_try_select_quanttrio_qwen3_5_122b_a10b_awq_params(
-    Sm70MarlinMoeAutoParamsContext const& ctx,
-    Sm70MarlinAutoParams& params) {
+    Sm70MarlinMoeAutoParamsContext const& ctx, Sm70MarlinAutoParams& params) {
   if (ctx.quant_format == nullptr ||
-      std::strcmp(ctx.quant_format, "uint4") != 0 ||
-      ctx.group_size != 128 || ctx.size_m <= 0) {
+      std::strcmp(ctx.quant_format, "uint4") != 0 || ctx.group_size != 128 ||
+      ctx.size_m <= 0) {
     return false;
   }
 
-  auto const set_params = [&](Sm70CtaGeometry geometry,
-                              int requested_split_k,
+  auto const set_params = [&](Sm70CtaGeometry geometry, int requested_split_k,
                               bool use_metadata_vector_words) {
     params = {geometry, requested_split_k, use_metadata_vector_words,
               ctx.packed_macro_n};
@@ -278,16 +273,14 @@ inline bool sm70_marlin_moe_try_select_quanttrio_qwen3_5_122b_a10b_awq_params(
 }
 
 inline bool sm70_marlin_moe_try_select_quanttrio_minimax_m2_7_awq_params(
-    Sm70MarlinMoeAutoParamsContext const& ctx,
-    Sm70MarlinAutoParams& params) {
+    Sm70MarlinMoeAutoParamsContext const& ctx, Sm70MarlinAutoParams& params) {
   if (ctx.quant_format == nullptr ||
-      std::strcmp(ctx.quant_format, "uint4") != 0 ||
-      ctx.group_size != 128 || ctx.size_m <= 0) {
+      std::strcmp(ctx.quant_format, "uint4") != 0 || ctx.group_size != 128 ||
+      ctx.size_m <= 0) {
     return false;
   }
 
-  auto const set_params = [&](Sm70CtaGeometry geometry,
-                              int requested_split_k,
+  auto const set_params = [&](Sm70CtaGeometry geometry, int requested_split_k,
                               bool use_metadata_vector_words) {
     params = {geometry, requested_split_k, use_metadata_vector_words,
               ctx.packed_macro_n};
@@ -378,17 +371,16 @@ inline bool sm70_marlin_moe_try_select_quanttrio_minimax_m2_7_awq_params(
   return false;
 }
 
-inline bool sm70_marlin_moe_try_select_cyankiwi_qwen3_5_122b_a10b_awq_8bit_params(
-    Sm70MarlinMoeAutoParamsContext const& ctx,
-    Sm70MarlinAutoParams& params) {
+inline bool
+sm70_marlin_moe_try_select_cyankiwi_qwen3_5_122b_a10b_awq_8bit_params(
+    Sm70MarlinMoeAutoParamsContext const& ctx, Sm70MarlinAutoParams& params) {
   if (ctx.quant_format == nullptr ||
-      std::strcmp(ctx.quant_format, "uint8b128") != 0 ||
-      ctx.group_size != 32 || ctx.size_m <= 0) {
+      std::strcmp(ctx.quant_format, "uint8b128") != 0 || ctx.group_size != 32 ||
+      ctx.size_m <= 0) {
     return false;
   }
 
-  auto const set_params = [&](Sm70CtaGeometry geometry,
-                              int requested_split_k,
+  auto const set_params = [&](Sm70CtaGeometry geometry, int requested_split_k,
                               bool use_metadata_vector_words) {
     params = {geometry, requested_split_k, use_metadata_vector_words,
               ctx.packed_macro_n};
@@ -400,57 +392,57 @@ inline bool sm70_marlin_moe_try_select_cyankiwi_qwen3_5_122b_a10b_awq_8bit_param
     // top_k=1
     if (ctx.top_k == 1 && ctx.size_n == 3072) {
       if (ctx.size_k == 128) {
-          if (ctx.size_m <= 8) {
-            return set_params({32,128,32,4,32,32,32}, 1, true);
-          }
-          if (ctx.size_m <= 256) {
-            return set_params({32,256,32,4,32,64,32}, 1, true);
-          }
-          return set_params({32,256,32,4,32,64,32}, 1, true);
+        if (ctx.size_m <= 8) {
+          return set_params({32, 128, 32, 4, 32, 32, 32}, 1, true);
+        }
+        if (ctx.size_m <= 256) {
+          return set_params({32, 256, 32, 4, 32, 64, 32}, 1, true);
+        }
+        return set_params({32, 256, 32, 4, 32, 64, 32}, 1, true);
       }
     }
     if (ctx.top_k == 1 && ctx.size_n == 3072) {
       if (ctx.size_k == 256) {
-        return set_params({32,256,32,4,32,64,32}, 1, true);
+        return set_params({32, 256, 32, 4, 32, 64, 32}, 1, true);
       }
     }
     if (ctx.top_k == 1 && ctx.size_n == 3072) {
       if (ctx.size_k == 1024) {
-          if (ctx.size_m <= 8) {
-            return set_params({32,128,32,4,32,32,32}, 1, true);
-          }
-          return set_params({32,256,32,4,32,64,32}, 1, true);
+        if (ctx.size_m <= 8) {
+          return set_params({32, 128, 32, 4, 32, 32, 32}, 1, true);
+        }
+        return set_params({32, 256, 32, 4, 32, 64, 32}, 1, true);
       }
     }
     // top_k=8
     if (ctx.top_k == 8 && ctx.size_k == 3072) {
       if (ctx.size_n == 256) {
-          if (ctx.size_m <= 1) {
-            return set_params({32,128,32,4,32,32,32}, 8, true);
-          }
-          if (ctx.size_m <= 32) {
-            return set_params({32,128,128,8,32,64,32}, 1, true);
-          }
-          return set_params({32,128,64,8,32,32,32}, 1, true);
+        if (ctx.size_m <= 1) {
+          return set_params({32, 128, 32, 4, 32, 32, 32}, 8, true);
+        }
+        if (ctx.size_m <= 32) {
+          return set_params({32, 128, 128, 8, 32, 64, 32}, 1, true);
+        }
+        return set_params({32, 128, 64, 8, 32, 32, 32}, 1, true);
       }
     }
     if (ctx.top_k == 8 && ctx.size_k == 3072) {
       if (ctx.size_n == 512) {
-          if (ctx.size_m <= 1) {
-            return set_params({32,256,32,4,32,64,32}, 8, true);
-          }
-          if (ctx.size_m <= 32) {
-            return set_params({32,256,64,8,32,64,32}, 1, true);
-          }
-          return set_params({32,256,32,4,32,64,32}, 1, true);
+        if (ctx.size_m <= 1) {
+          return set_params({32, 256, 32, 4, 32, 64, 32}, 8, true);
+        }
+        if (ctx.size_m <= 32) {
+          return set_params({32, 256, 64, 8, 32, 64, 32}, 1, true);
+        }
+        return set_params({32, 256, 32, 4, 32, 64, 32}, 1, true);
       }
     }
     if (ctx.top_k == 8 && ctx.size_k == 3072) {
       if (ctx.size_n == 2048) {
-          if (ctx.size_m <= 1) {
-            return set_params({32,256,32,4,32,64,32}, 2, true);
-          }
-          return set_params({32,256,32,4,32,64,32}, 1, true);
+        if (ctx.size_m <= 1) {
+          return set_params({32, 256, 32, 4, 32, 64, 32}, 2, true);
+        }
+        return set_params({32, 256, 32, 4, 32, 64, 32}, 1, true);
       }
     }
   }
@@ -460,13 +452,13 @@ inline bool sm70_marlin_moe_try_select_cyankiwi_qwen3_5_122b_a10b_awq_8bit_param
     // top_k=1
     if (ctx.top_k == 1 && ctx.size_n == 3072) {
       if (ctx.size_k == 1024) {
-        return set_params({32,256,32,4,32,64,32}, 1, true);
+        return set_params({32, 256, 32, 4, 32, 64, 32}, 1, true);
       }
     }
     // top_k=8
     if (ctx.top_k == 8 && ctx.size_k == 3072) {
       if (ctx.size_n == 2048) {
-        return set_params({32,256,32,4,32,64,32}, 1, true);
+        return set_params({32, 256, 32, 4, 32, 64, 32}, 1, true);
       }
     }
   }
@@ -476,13 +468,13 @@ inline bool sm70_marlin_moe_try_select_cyankiwi_qwen3_5_122b_a10b_awq_8bit_param
     // top_k=1
     if (ctx.top_k == 1 && ctx.size_n == 3072) {
       if (ctx.size_k == 1024) {
-        return set_params({32,256,32,4,32,64,32}, 1, true);
+        return set_params({32, 256, 32, 4, 32, 64, 32}, 1, true);
       }
     }
     // top_k=8
     if (ctx.top_k == 8 && ctx.size_k == 3072) {
       if (ctx.size_n == 2048) {
-        return set_params({32,256,32,4,32,64,32}, 1, true);
+        return set_params({32, 256, 32, 4, 32, 64, 32}, 1, true);
       }
     }
   }
@@ -492,33 +484,33 @@ inline bool sm70_marlin_moe_try_select_cyankiwi_qwen3_5_122b_a10b_awq_8bit_param
     // top_k=1
     if (ctx.top_k == 1 && ctx.size_n == 3072) {
       if (ctx.size_k == 128) {
-        return set_params({64,256,32,4,64,64,32}, 1, false);
+        return set_params({64, 256, 32, 4, 64, 64, 32}, 1, false);
       }
     }
     if (ctx.top_k == 1 && ctx.size_n == 3072) {
       if (ctx.size_k == 256) {
-        return set_params({64,256,32,4,64,64,32}, 1, false);
+        return set_params({64, 256, 32, 4, 64, 64, 32}, 1, false);
       }
     }
     if (ctx.top_k == 1 && ctx.size_n == 3072) {
       if (ctx.size_k == 1024) {
-        return set_params({64,256,32,4,64,64,32}, 1, false);
+        return set_params({64, 256, 32, 4, 64, 64, 32}, 1, false);
       }
     }
     // top_k=8
     if (ctx.top_k == 8 && ctx.size_k == 3072) {
       if (ctx.size_n == 256) {
-        return set_params({64,256,32,4,64,64,32}, 1, false);
+        return set_params({64, 256, 32, 4, 64, 64, 32}, 1, false);
       }
     }
     if (ctx.top_k == 8 && ctx.size_k == 3072) {
       if (ctx.size_n == 512) {
-        return set_params({64,256,32,4,64,64,32}, 1, false);
+        return set_params({64, 256, 32, 4, 64, 64, 32}, 1, false);
       }
     }
     if (ctx.top_k == 8 && ctx.size_k == 3072) {
       if (ctx.size_n == 2048) {
-        return set_params({64,256,32,4,64,64,32}, 1, false);
+        return set_params({64, 256, 32, 4, 64, 64, 32}, 1, false);
       }
     }
   }
@@ -527,16 +519,14 @@ inline bool sm70_marlin_moe_try_select_cyankiwi_qwen3_5_122b_a10b_awq_8bit_param
 }
 
 inline bool sm70_marlin_moe_try_select_cyankiwi_qwen3_6_35b_a3b_awq_4bit_params(
-    Sm70MarlinMoeAutoParamsContext const& ctx,
-    Sm70MarlinAutoParams& params) {
+    Sm70MarlinMoeAutoParamsContext const& ctx, Sm70MarlinAutoParams& params) {
   if (ctx.quant_format == nullptr ||
-      std::strcmp(ctx.quant_format, "uint4") != 0 ||
-      ctx.group_size != 32 || ctx.size_m <= 0) {
+      std::strcmp(ctx.quant_format, "uint4") != 0 || ctx.group_size != 32 ||
+      ctx.size_m <= 0) {
     return false;
   }
 
-  auto const set_params = [&](Sm70CtaGeometry geometry,
-                              int requested_split_k,
+  auto const set_params = [&](Sm70CtaGeometry geometry, int requested_split_k,
                               bool use_metadata_vector_words) {
     params = {geometry, requested_split_k, use_metadata_vector_words,
               ctx.packed_macro_n};
@@ -548,63 +538,63 @@ inline bool sm70_marlin_moe_try_select_cyankiwi_qwen3_6_35b_a3b_awq_4bit_params(
     // top_k=1
     if (ctx.top_k == 1 && ctx.size_n == 2048) {
       if (ctx.size_k == 64) {
-          if (ctx.size_m <= 8) {
-            return set_params({32,64,32,4,32,32,16}, 1, false);
-          }
-          if (ctx.size_m <= 256) {
-            return set_params({32,256,32,4,32,64,32}, 1, true);
-          }
-          return set_params({32,256,32,4,32,64,32}, 1, true);
+        if (ctx.size_m <= 8) {
+          return set_params({32, 64, 32, 4, 32, 32, 16}, 1, false);
+        }
+        if (ctx.size_m <= 256) {
+          return set_params({32, 256, 32, 4, 32, 64, 32}, 1, true);
+        }
+        return set_params({32, 256, 32, 4, 32, 64, 32}, 1, true);
       }
     }
     if (ctx.top_k == 1 && ctx.size_n == 2048) {
       if (ctx.size_k == 128) {
-          if (ctx.size_m <= 8) {
-            return set_params({32,64,32,4,32,32,16}, 1, true);
-          }
-          if (ctx.size_m <= 256) {
-            return set_params({32,256,32,4,32,64,32}, 1, true);
-          }
-          return set_params({32,256,32,4,32,64,32}, 1, true);
+        if (ctx.size_m <= 8) {
+          return set_params({32, 64, 32, 4, 32, 32, 16}, 1, true);
+        }
+        if (ctx.size_m <= 256) {
+          return set_params({32, 256, 32, 4, 32, 64, 32}, 1, true);
+        }
+        return set_params({32, 256, 32, 4, 32, 64, 32}, 1, true);
       }
     }
     if (ctx.top_k == 1 && ctx.size_n == 2048) {
       if (ctx.size_k == 512) {
-          if (ctx.size_m <= 8) {
-            return set_params({32,128,32,4,32,64,16}, 1, true);
-          }
-          return set_params({32,256,32,4,32,64,32}, 1, true);
+        if (ctx.size_m <= 8) {
+          return set_params({32, 128, 32, 4, 32, 64, 16}, 1, true);
+        }
+        return set_params({32, 256, 32, 4, 32, 64, 32}, 1, true);
       }
     }
     // top_k=8
     if (ctx.top_k == 8 && ctx.size_k == 2048) {
       if (ctx.size_n == 128) {
-          if (ctx.size_m <= 1) {
-            return set_params({32,128,32,4,32,32,32}, 8, false);
-          }
-          if (ctx.size_m <= 32) {
-            return set_params({32,128,64,8,32,64,16}, 2, false);
-          }
-          return set_params({32,128,128,8,32,64,32}, 1, true);
+        if (ctx.size_m <= 1) {
+          return set_params({32, 128, 32, 4, 32, 32, 32}, 8, false);
+        }
+        if (ctx.size_m <= 32) {
+          return set_params({32, 128, 64, 8, 32, 64, 16}, 2, false);
+        }
+        return set_params({32, 128, 128, 8, 32, 64, 32}, 1, true);
       }
     }
     if (ctx.top_k == 8 && ctx.size_k == 2048) {
       if (ctx.size_n == 256) {
-          if (ctx.size_m <= 1) {
-            return set_params({32,128,32,4,32,32,32}, 8, true);
-          }
-          if (ctx.size_m <= 32) {
-            return set_params({32,128,128,8,32,64,32}, 1, true);
-          }
-          return set_params({32,256,64,8,32,64,32}, 1, false);
+        if (ctx.size_m <= 1) {
+          return set_params({32, 128, 32, 4, 32, 32, 32}, 8, true);
+        }
+        if (ctx.size_m <= 32) {
+          return set_params({32, 128, 128, 8, 32, 64, 32}, 1, true);
+        }
+        return set_params({32, 256, 64, 8, 32, 64, 32}, 1, false);
       }
     }
     if (ctx.top_k == 8 && ctx.size_k == 2048) {
       if (ctx.size_n == 1024) {
-          if (ctx.size_m <= 1) {
-            return set_params({32,256,32,4,32,64,32}, 4, true);
-          }
-          return set_params({32,256,32,4,32,64,32}, 1, true);
+        if (ctx.size_m <= 1) {
+          return set_params({32, 256, 32, 4, 32, 64, 32}, 4, true);
+        }
+        return set_params({32, 256, 32, 4, 32, 64, 32}, 1, true);
       }
     }
   }
@@ -614,16 +604,16 @@ inline bool sm70_marlin_moe_try_select_cyankiwi_qwen3_6_35b_a3b_awq_4bit_params(
     // top_k=1
     if (ctx.top_k == 1 && ctx.size_n == 2048) {
       if (ctx.size_k == 512) {
-        return set_params({32,256,32,4,32,64,32}, 1, true);
+        return set_params({32, 256, 32, 4, 32, 64, 32}, 1, true);
       }
     }
     // top_k=8
     if (ctx.top_k == 8 && ctx.size_k == 2048) {
       if (ctx.size_n == 1024) {
-          if (ctx.size_m <= 32) {
-            return set_params({32,256,64,8,32,64,32}, 1, false);
-          }
-          return set_params({32,256,32,4,32,64,32}, 1, true);
+        if (ctx.size_m <= 32) {
+          return set_params({32, 256, 64, 8, 32, 64, 32}, 1, false);
+        }
+        return set_params({32, 256, 32, 4, 32, 64, 32}, 1, true);
       }
     }
   }
@@ -633,13 +623,13 @@ inline bool sm70_marlin_moe_try_select_cyankiwi_qwen3_6_35b_a3b_awq_4bit_params(
     // top_k=1
     if (ctx.top_k == 1 && ctx.size_n == 2048) {
       if (ctx.size_k == 512) {
-        return set_params({32,256,32,4,32,64,32}, 1, true);
+        return set_params({32, 256, 32, 4, 32, 64, 32}, 1, true);
       }
     }
     // top_k=8
     if (ctx.top_k == 8 && ctx.size_k == 2048) {
       if (ctx.size_n == 1024) {
-        return set_params({32,256,64,8,32,64,32}, 1, true);
+        return set_params({32, 256, 64, 8, 32, 64, 32}, 1, true);
       }
     }
   }
@@ -649,36 +639,36 @@ inline bool sm70_marlin_moe_try_select_cyankiwi_qwen3_6_35b_a3b_awq_4bit_params(
     // top_k=1
     if (ctx.top_k == 1 && ctx.size_n == 2048) {
       if (ctx.size_k == 64) {
-        return set_params({64,256,32,4,64,64,32}, 1, false);
+        return set_params({64, 256, 32, 4, 64, 64, 32}, 1, false);
       }
     }
     if (ctx.top_k == 1 && ctx.size_n == 2048) {
       if (ctx.size_k == 128) {
-        return set_params({64,256,32,4,64,64,32}, 1, false);
+        return set_params({64, 256, 32, 4, 64, 64, 32}, 1, false);
       }
     }
     if (ctx.top_k == 1 && ctx.size_n == 2048) {
       if (ctx.size_k == 512) {
-        return set_params({64,256,32,4,64,64,32}, 1, false);
+        return set_params({64, 256, 32, 4, 64, 64, 32}, 1, false);
       }
     }
     // top_k=8
     if (ctx.top_k == 8 && ctx.size_k == 2048) {
       if (ctx.size_n == 128) {
-          if (ctx.size_m <= 2048) {
-            return set_params({64,128,32,4,64,64,16}, 1, false);
-          }
-          return set_params({64,128,32,8,32,32,32}, 1, true);
+        if (ctx.size_m <= 2048) {
+          return set_params({64, 128, 32, 4, 64, 64, 16}, 1, false);
+        }
+        return set_params({64, 128, 32, 8, 32, 32, 32}, 1, true);
       }
     }
     if (ctx.top_k == 8 && ctx.size_k == 2048) {
       if (ctx.size_n == 256) {
-        return set_params({64,256,32,4,64,64,32}, 1, false);
+        return set_params({64, 256, 32, 4, 64, 64, 32}, 1, false);
       }
     }
     if (ctx.top_k == 8 && ctx.size_k == 2048) {
       if (ctx.size_n == 1024) {
-        return set_params({64,256,32,4,64,64,32}, 1, false);
+        return set_params({64, 256, 32, 4, 64, 64, 32}, 1, false);
       }
     }
   }
@@ -686,17 +676,16 @@ inline bool sm70_marlin_moe_try_select_cyankiwi_qwen3_6_35b_a3b_awq_4bit_params(
   return false;
 }
 
-inline bool sm70_marlin_moe_try_select_cyankiwi_qwen3_6_35b_a3b_awq_nvfp4_params(
-    Sm70MarlinMoeAutoParamsContext const& ctx,
-    Sm70MarlinAutoParams& params) {
+inline bool
+sm70_marlin_moe_try_select_cyankiwi_qwen3_6_35b_a3b_awq_nvfp4_params(
+    Sm70MarlinMoeAutoParamsContext const& ctx, Sm70MarlinAutoParams& params) {
   if (ctx.quant_format == nullptr ||
-      std::strcmp(ctx.quant_format, "nvfp4") != 0 ||
-      ctx.group_size != 16 || ctx.size_m <= 0) {
+      std::strcmp(ctx.quant_format, "nvfp4") != 0 || ctx.group_size != 16 ||
+      ctx.size_m <= 0) {
     return false;
   }
 
-  auto const set_params = [&](Sm70CtaGeometry geometry,
-                              int requested_split_k,
+  auto const set_params = [&](Sm70CtaGeometry geometry, int requested_split_k,
                               bool use_metadata_vector_words) {
     params = {geometry, requested_split_k, use_metadata_vector_words,
               ctx.packed_macro_n};
@@ -708,63 +697,63 @@ inline bool sm70_marlin_moe_try_select_cyankiwi_qwen3_6_35b_a3b_awq_nvfp4_params
     // top_k=1
     if (ctx.top_k == 1 && ctx.size_n == 2048) {
       if (ctx.size_k == 64) {
-          if (ctx.size_m <= 8) {
-            return set_params({32,128,64,4,32,64,32}, 1, true);
-          }
-          if (ctx.size_m <= 256) {
-            return set_params({32,128,32,4,32,32,32}, 1, true);
-          }
-          return set_params({32,128,32,4,32,32,32}, 1, true);
+        if (ctx.size_m <= 8) {
+          return set_params({32, 128, 64, 4, 32, 64, 32}, 1, true);
+        }
+        if (ctx.size_m <= 256) {
+          return set_params({32, 128, 32, 4, 32, 32, 32}, 1, true);
+        }
+        return set_params({32, 128, 32, 4, 32, 32, 32}, 1, true);
       }
     }
     if (ctx.top_k == 1 && ctx.size_n == 2048) {
       if (ctx.size_k == 128) {
-          if (ctx.size_m <= 8) {
-            return set_params({32,128,32,4,32,32,32}, 1, false);
-          }
-          if (ctx.size_m <= 256) {
-            return set_params({32,128,32,4,32,32,32}, 1, true);
-          }
-          return set_params({32,128,32,4,32,32,32}, 1, false);
+        if (ctx.size_m <= 8) {
+          return set_params({32, 128, 32, 4, 32, 32, 32}, 1, false);
+        }
+        if (ctx.size_m <= 256) {
+          return set_params({32, 128, 32, 4, 32, 32, 32}, 1, true);
+        }
+        return set_params({32, 128, 32, 4, 32, 32, 32}, 1, false);
       }
     }
     if (ctx.top_k == 1 && ctx.size_n == 2048) {
       if (ctx.size_k == 512) {
-          if (ctx.size_m <= 8) {
-            return set_params({32,128,64,4,32,64,32}, 1, true);
-          }
-          return set_params({32,128,32,4,32,32,32}, 1, true);
+        if (ctx.size_m <= 8) {
+          return set_params({32, 128, 64, 4, 32, 64, 32}, 1, true);
+        }
+        return set_params({32, 128, 32, 4, 32, 32, 32}, 1, true);
       }
     }
     // top_k=8
     if (ctx.top_k == 8 && ctx.size_k == 2048) {
       if (ctx.size_n == 128) {
-          if (ctx.size_m <= 1) {
-            return set_params({32,64,32,4,32,32,16}, 8, true);
-          }
-          if (ctx.size_m <= 32) {
-            return set_params({32,128,64,8,32,32,32}, 4, true);
-          }
-          return set_params({32,128,128,8,32,64,32}, 1, true);
+        if (ctx.size_m <= 1) {
+          return set_params({32, 64, 32, 4, 32, 32, 16}, 8, true);
+        }
+        if (ctx.size_m <= 32) {
+          return set_params({32, 128, 64, 8, 32, 32, 32}, 4, true);
+        }
+        return set_params({32, 128, 128, 8, 32, 64, 32}, 1, true);
       }
     }
     if (ctx.top_k == 8 && ctx.size_k == 2048) {
       if (ctx.size_n == 256) {
-          if (ctx.size_m <= 1) {
-            return set_params({32,128,32,4,32,32,32}, 8, true);
-          }
-          if (ctx.size_m <= 32) {
-            return set_params({32,128,128,8,32,64,32}, 1, true);
-          }
-          return set_params({32,256,64,8,32,64,32}, 1, true);
+        if (ctx.size_m <= 1) {
+          return set_params({32, 128, 32, 4, 32, 32, 32}, 8, true);
+        }
+        if (ctx.size_m <= 32) {
+          return set_params({32, 128, 128, 8, 32, 64, 32}, 1, true);
+        }
+        return set_params({32, 256, 64, 8, 32, 64, 32}, 1, true);
       }
     }
     if (ctx.top_k == 8 && ctx.size_k == 2048) {
       if (ctx.size_n == 1024) {
-          if (ctx.size_m <= 1) {
-            return set_params({32,128,32,4,32,32,32}, 4, false);
-          }
-          return set_params({32,128,32,4,32,32,32}, 1, true);
+        if (ctx.size_m <= 1) {
+          return set_params({32, 128, 32, 4, 32, 32, 32}, 4, false);
+        }
+        return set_params({32, 128, 32, 4, 32, 32, 32}, 1, true);
       }
     }
   }
@@ -774,16 +763,16 @@ inline bool sm70_marlin_moe_try_select_cyankiwi_qwen3_6_35b_a3b_awq_nvfp4_params
     // top_k=1
     if (ctx.top_k == 1 && ctx.size_n == 2048) {
       if (ctx.size_k == 512) {
-        return set_params({32,128,32,4,32,32,32}, 1, false);
+        return set_params({32, 128, 32, 4, 32, 32, 32}, 1, false);
       }
     }
     // top_k=8
     if (ctx.top_k == 8 && ctx.size_k == 2048) {
       if (ctx.size_n == 1024) {
-          if (ctx.size_m <= 32) {
-            return set_params({32,256,64,8,32,64,32}, 1, true);
-          }
-          return set_params({32,128,32,4,32,32,32}, 1, true);
+        if (ctx.size_m <= 32) {
+          return set_params({32, 256, 64, 8, 32, 64, 32}, 1, true);
+        }
+        return set_params({32, 128, 32, 4, 32, 32, 32}, 1, true);
       }
     }
   }
@@ -793,13 +782,13 @@ inline bool sm70_marlin_moe_try_select_cyankiwi_qwen3_6_35b_a3b_awq_nvfp4_params
     // top_k=1
     if (ctx.top_k == 1 && ctx.size_n == 2048) {
       if (ctx.size_k == 512) {
-        return set_params({32,128,32,4,32,32,32}, 1, true);
+        return set_params({32, 128, 32, 4, 32, 32, 32}, 1, true);
       }
     }
     // top_k=8
     if (ctx.top_k == 8 && ctx.size_k == 2048) {
       if (ctx.size_n == 1024) {
-        return set_params({32,256,64,8,32,64,32}, 1, false);
+        return set_params({32, 256, 64, 8, 32, 64, 32}, 1, false);
       }
     }
   }
@@ -809,45 +798,45 @@ inline bool sm70_marlin_moe_try_select_cyankiwi_qwen3_6_35b_a3b_awq_nvfp4_params
     // top_k=1
     if (ctx.top_k == 1 && ctx.size_n == 2048) {
       if (ctx.size_k == 64) {
-          if (ctx.size_m <= 16384) {
-            return set_params({64,64,32,4,32,32,32}, 1, true);
-          }
-          return set_params({64,256,32,4,64,64,32}, 1, false);
+        if (ctx.size_m <= 16384) {
+          return set_params({64, 64, 32, 4, 32, 32, 32}, 1, true);
+        }
+        return set_params({64, 256, 32, 4, 64, 64, 32}, 1, false);
       }
     }
     if (ctx.top_k == 1 && ctx.size_n == 2048) {
       if (ctx.size_k == 128) {
-        return set_params({64,256,32,4,64,64,32}, 1, true);
+        return set_params({64, 256, 32, 4, 64, 64, 32}, 1, true);
       }
     }
     if (ctx.top_k == 1 && ctx.size_n == 2048) {
       if (ctx.size_k == 512) {
-          if (ctx.size_m <= 16384) {
-            return set_params({64,256,32,4,64,64,32}, 1, false);
-          }
-          return set_params({64,256,32,4,64,64,32}, 1, true);
+        if (ctx.size_m <= 16384) {
+          return set_params({64, 256, 32, 4, 64, 64, 32}, 1, false);
+        }
+        return set_params({64, 256, 32, 4, 64, 64, 32}, 1, true);
       }
     }
     // top_k=8
     if (ctx.top_k == 8 && ctx.size_k == 2048) {
       if (ctx.size_n == 128) {
-          if (ctx.size_m <= 2048) {
-            return set_params({32,128,32,4,32,32,32}, 1, true);
-          }
-          return set_params({64,128,32,8,32,32,32}, 1, true);
+        if (ctx.size_m <= 2048) {
+          return set_params({32, 128, 32, 4, 32, 32, 32}, 1, true);
+        }
+        return set_params({64, 128, 32, 8, 32, 32, 32}, 1, true);
       }
     }
     if (ctx.top_k == 8 && ctx.size_k == 2048) {
       if (ctx.size_n == 256) {
-          if (ctx.size_m <= 2048) {
-            return set_params({64,256,32,4,64,64,32}, 1, true);
-          }
-          return set_params({64,256,64,8,64,64,32}, 1, false);
+        if (ctx.size_m <= 2048) {
+          return set_params({64, 256, 32, 4, 64, 64, 32}, 1, true);
+        }
+        return set_params({64, 256, 64, 8, 64, 64, 32}, 1, false);
       }
     }
     if (ctx.top_k == 8 && ctx.size_k == 2048) {
       if (ctx.size_n == 1024) {
-        return set_params({64,256,32,4,64,64,32}, 1, true);
+        return set_params({64, 256, 32, 4, 64, 64, 32}, 1, true);
       }
     }
   }
@@ -855,17 +844,16 @@ inline bool sm70_marlin_moe_try_select_cyankiwi_qwen3_6_35b_a3b_awq_nvfp4_params
   return false;
 }
 
-inline bool sm70_marlin_moe_try_select_cyankiwi_qwen3_coder_next_awq_4bit_params(
-    Sm70MarlinMoeAutoParamsContext const& ctx,
-    Sm70MarlinAutoParams& params) {
+inline bool
+sm70_marlin_moe_try_select_cyankiwi_qwen3_coder_next_awq_4bit_params(
+    Sm70MarlinMoeAutoParamsContext const& ctx, Sm70MarlinAutoParams& params) {
   if (ctx.quant_format == nullptr ||
-      std::strcmp(ctx.quant_format, "uint4b8") != 0 ||
-      ctx.group_size != 32 || ctx.size_m <= 0) {
+      std::strcmp(ctx.quant_format, "uint4b8") != 0 || ctx.group_size != 32 ||
+      ctx.size_m <= 0) {
     return false;
   }
 
-  auto const set_params = [&](Sm70CtaGeometry geometry,
-                              int requested_split_k,
+  auto const set_params = [&](Sm70CtaGeometry geometry, int requested_split_k,
                               bool use_metadata_vector_words) {
     params = {geometry, requested_split_k, use_metadata_vector_words,
               ctx.packed_macro_n};
@@ -877,63 +865,63 @@ inline bool sm70_marlin_moe_try_select_cyankiwi_qwen3_coder_next_awq_4bit_params
     // top_k=1
     if (ctx.top_k == 1 && ctx.size_n == 2048) {
       if (ctx.size_k == 64) {
-          if (ctx.size_m <= 10) {
-            return set_params({32,128,32,4,32,32,32}, 1, true);
-          }
-          if (ctx.size_m <= 320) {
-            return set_params({32,256,32,4,32,64,32}, 1, true);
-          }
-          return set_params({32,256,32,4,32,64,32}, 1, true);
+        if (ctx.size_m <= 10) {
+          return set_params({32, 128, 32, 4, 32, 32, 32}, 1, true);
+        }
+        if (ctx.size_m <= 320) {
+          return set_params({32, 256, 32, 4, 32, 64, 32}, 1, true);
+        }
+        return set_params({32, 256, 32, 4, 32, 64, 32}, 1, true);
       }
     }
     if (ctx.top_k == 1 && ctx.size_n == 2048) {
       if (ctx.size_k == 128) {
-        return set_params({32,256,32,4,32,64,32}, 1, true);
+        return set_params({32, 256, 32, 4, 32, 64, 32}, 1, true);
       }
     }
     if (ctx.top_k == 1 && ctx.size_n == 2048) {
       if (ctx.size_k == 512) {
-          if (ctx.size_m <= 10) {
-            return set_params({32,128,64,4,32,64,32}, 1, true);
-          }
-          if (ctx.size_m <= 320) {
-            return set_params({32,256,32,4,32,64,32}, 1, true);
-          }
-          return set_params({32,256,32,4,32,64,32}, 1, true);
+        if (ctx.size_m <= 10) {
+          return set_params({32, 128, 64, 4, 32, 64, 32}, 1, true);
+        }
+        if (ctx.size_m <= 320) {
+          return set_params({32, 256, 32, 4, 32, 64, 32}, 1, true);
+        }
+        return set_params({32, 256, 32, 4, 32, 64, 32}, 1, true);
       }
     }
     // top_k=10
     if (ctx.top_k == 10 && ctx.size_k == 2048) {
       if (ctx.size_n == 128) {
-          if (ctx.size_m <= 1) {
-            return set_params({32,64,32,4,32,32,16}, 8, true);
-          }
-          if (ctx.size_m <= 32) {
-            return set_params({32,128,64,8,32,64,16}, 2, true);
-          }
-          return set_params({32,128,128,8,32,64,32}, 1, true);
+        if (ctx.size_m <= 1) {
+          return set_params({32, 64, 32, 4, 32, 32, 16}, 8, true);
+        }
+        if (ctx.size_m <= 32) {
+          return set_params({32, 128, 64, 8, 32, 64, 16}, 2, true);
+        }
+        return set_params({32, 128, 128, 8, 32, 64, 32}, 1, true);
       }
     }
     if (ctx.top_k == 10 && ctx.size_k == 2048) {
       if (ctx.size_n == 256) {
-          if (ctx.size_m <= 1) {
-            return set_params({32,128,32,4,32,32,32}, 8, true);
-          }
-          if (ctx.size_m <= 32) {
-            return set_params({32,128,128,8,32,64,32}, 1, true);
-          }
-          return set_params({32,256,64,8,32,64,32}, 1, true);
+        if (ctx.size_m <= 1) {
+          return set_params({32, 128, 32, 4, 32, 32, 32}, 8, true);
+        }
+        if (ctx.size_m <= 32) {
+          return set_params({32, 128, 128, 8, 32, 64, 32}, 1, true);
+        }
+        return set_params({32, 256, 64, 8, 32, 64, 32}, 1, true);
       }
     }
     if (ctx.top_k == 10 && ctx.size_k == 2048) {
       if (ctx.size_n == 1024) {
-          if (ctx.size_m <= 1) {
-            return set_params({32,256,32,4,32,64,32}, 4, true);
-          }
-          if (ctx.size_m <= 32) {
-            return set_params({32,256,32,4,32,64,32}, 1, true);
-          }
-          return set_params({32,256,32,4,32,64,32}, 1, true);
+        if (ctx.size_m <= 1) {
+          return set_params({32, 256, 32, 4, 32, 64, 32}, 4, true);
+        }
+        if (ctx.size_m <= 32) {
+          return set_params({32, 256, 32, 4, 32, 64, 32}, 1, true);
+        }
+        return set_params({32, 256, 32, 4, 32, 64, 32}, 1, true);
       }
     }
   }
@@ -943,13 +931,13 @@ inline bool sm70_marlin_moe_try_select_cyankiwi_qwen3_coder_next_awq_4bit_params
     // top_k=1
     if (ctx.top_k == 1 && ctx.size_n == 2048) {
       if (ctx.size_k == 512) {
-        return set_params({32,256,32,4,32,64,32}, 1, true);
+        return set_params({32, 256, 32, 4, 32, 64, 32}, 1, true);
       }
     }
     // top_k=10
     if (ctx.top_k == 10 && ctx.size_k == 2048) {
       if (ctx.size_n == 1024) {
-        return set_params({32,256,32,4,32,64,32}, 1, true);
+        return set_params({32, 256, 32, 4, 32, 64, 32}, 1, true);
       }
     }
   }
@@ -959,23 +947,23 @@ inline bool sm70_marlin_moe_try_select_cyankiwi_qwen3_coder_next_awq_4bit_params
     // top_k=1
     if (ctx.top_k == 1 && ctx.size_n == 2048) {
       if (ctx.size_k == 64) {
-        return set_params({64,256,32,4,64,64,32}, 1, false);
+        return set_params({64, 256, 32, 4, 64, 64, 32}, 1, false);
       }
     }
     if (ctx.top_k == 1 && ctx.size_n == 2048) {
       if (ctx.size_k == 128) {
-        return set_params({64,256,32,4,64,64,32}, 1, false);
+        return set_params({64, 256, 32, 4, 64, 64, 32}, 1, false);
       }
     }
     // top_k=10
     if (ctx.top_k == 10 && ctx.size_k == 2048) {
       if (ctx.size_n == 128) {
-        return set_params({64,128,32,8,32,32,32}, 1, false);
+        return set_params({64, 128, 32, 8, 32, 32, 32}, 1, false);
       }
     }
     if (ctx.top_k == 10 && ctx.size_k == 2048) {
       if (ctx.size_n == 256) {
-        return set_params({64,256,32,4,64,64,32}, 1, false);
+        return set_params({64, 256, 32, 4, 64, 64, 32}, 1, false);
       }
     }
   }
@@ -985,33 +973,33 @@ inline bool sm70_marlin_moe_try_select_cyankiwi_qwen3_coder_next_awq_4bit_params
     // top_k=1
     if (ctx.top_k == 1 && ctx.size_n == 2048) {
       if (ctx.size_k == 64) {
-        return set_params({64,256,32,4,64,64,32}, 1, false);
+        return set_params({64, 256, 32, 4, 64, 64, 32}, 1, false);
       }
     }
     if (ctx.top_k == 1 && ctx.size_n == 2048) {
       if (ctx.size_k == 128) {
-        return set_params({64,256,32,4,64,64,32}, 1, false);
+        return set_params({64, 256, 32, 4, 64, 64, 32}, 1, false);
       }
     }
     if (ctx.top_k == 1 && ctx.size_n == 2048) {
       if (ctx.size_k == 512) {
-        return set_params({64,256,32,4,64,64,32}, 1, false);
+        return set_params({64, 256, 32, 4, 64, 64, 32}, 1, false);
       }
     }
     // top_k=10
     if (ctx.top_k == 10 && ctx.size_k == 2048) {
       if (ctx.size_n == 128) {
-        return set_params({64,128,32,4,32,64,32}, 1, true);
+        return set_params({64, 128, 32, 4, 32, 64, 32}, 1, true);
       }
     }
     if (ctx.top_k == 10 && ctx.size_k == 2048) {
       if (ctx.size_n == 256) {
-        return set_params({64,256,32,4,64,64,32}, 1, false);
+        return set_params({64, 256, 32, 4, 64, 64, 32}, 1, false);
       }
     }
     if (ctx.top_k == 10 && ctx.size_k == 2048) {
       if (ctx.size_n == 1024) {
-        return set_params({64,256,32,4,64,64,32}, 1, false);
+        return set_params({64, 256, 32, 4, 64, 64, 32}, 1, false);
       }
     }
   }
@@ -1019,17 +1007,16 @@ inline bool sm70_marlin_moe_try_select_cyankiwi_qwen3_coder_next_awq_4bit_params
   return false;
 }
 
-inline bool sm70_marlin_moe_try_select_cyankiwi_qwen3_coder_next_awq_8bit_params(
-    Sm70MarlinMoeAutoParamsContext const& ctx,
-    Sm70MarlinAutoParams& params) {
+inline bool
+sm70_marlin_moe_try_select_cyankiwi_qwen3_coder_next_awq_8bit_params(
+    Sm70MarlinMoeAutoParamsContext const& ctx, Sm70MarlinAutoParams& params) {
   if (ctx.quant_format == nullptr ||
-      std::strcmp(ctx.quant_format, "uint8b128") != 0 ||
-      ctx.group_size != 32 || ctx.size_m <= 0) {
+      std::strcmp(ctx.quant_format, "uint8b128") != 0 || ctx.group_size != 32 ||
+      ctx.size_m <= 0) {
     return false;
   }
 
-  auto const set_params = [&](Sm70CtaGeometry geometry,
-                              int requested_split_k,
+  auto const set_params = [&](Sm70CtaGeometry geometry, int requested_split_k,
                               bool use_metadata_vector_words) {
     params = {geometry, requested_split_k, use_metadata_vector_words,
               ctx.packed_macro_n};
@@ -1041,63 +1028,63 @@ inline bool sm70_marlin_moe_try_select_cyankiwi_qwen3_coder_next_awq_8bit_params
     // top_k=1
     if (ctx.top_k == 1 && ctx.size_n == 2048) {
       if (ctx.size_k == 64) {
-        return set_params({32,256,32,4,32,64,32}, 1, true);
+        return set_params({32, 256, 32, 4, 32, 64, 32}, 1, true);
       }
     }
     if (ctx.top_k == 1 && ctx.size_n == 2048) {
       if (ctx.size_k == 128) {
-          if (ctx.size_m <= 10) {
-            return set_params({32,128,32,4,32,32,32}, 1, true);
-          }
-          if (ctx.size_m <= 320) {
-            return set_params({32,256,32,4,32,64,32}, 1, true);
-          }
-          return set_params({32,256,32,4,32,64,32}, 1, true);
+        if (ctx.size_m <= 10) {
+          return set_params({32, 128, 32, 4, 32, 32, 32}, 1, true);
+        }
+        if (ctx.size_m <= 320) {
+          return set_params({32, 256, 32, 4, 32, 64, 32}, 1, true);
+        }
+        return set_params({32, 256, 32, 4, 32, 64, 32}, 1, true);
       }
     }
     if (ctx.top_k == 1 && ctx.size_n == 2048) {
       if (ctx.size_k == 512) {
-          if (ctx.size_m <= 10) {
-            return set_params({32,256,64,8,32,64,32}, 1, true);
-          }
-          if (ctx.size_m <= 320) {
-            return set_params({32,256,32,4,32,64,32}, 1, true);
-          }
-          return set_params({32,256,32,4,32,64,32}, 1, true);
+        if (ctx.size_m <= 10) {
+          return set_params({32, 256, 64, 8, 32, 64, 32}, 1, true);
+        }
+        if (ctx.size_m <= 320) {
+          return set_params({32, 256, 32, 4, 32, 64, 32}, 1, true);
+        }
+        return set_params({32, 256, 32, 4, 32, 64, 32}, 1, true);
       }
     }
     // top_k=10
     if (ctx.top_k == 10 && ctx.size_k == 2048) {
       if (ctx.size_n == 128) {
-          if (ctx.size_m <= 1) {
-            return set_params({32,64,32,4,32,32,16}, 8, true);
-          }
-          if (ctx.size_m <= 32) {
-            return set_params({32,128,64,8,32,64,16}, 2, true);
-          }
-          return set_params({32,128,128,8,32,64,32}, 1, true);
+        if (ctx.size_m <= 1) {
+          return set_params({32, 64, 32, 4, 32, 32, 16}, 8, true);
+        }
+        if (ctx.size_m <= 32) {
+          return set_params({32, 128, 64, 8, 32, 64, 16}, 2, true);
+        }
+        return set_params({32, 128, 128, 8, 32, 64, 32}, 1, true);
       }
     }
     if (ctx.top_k == 10 && ctx.size_k == 2048) {
       if (ctx.size_n == 256) {
-          if (ctx.size_m <= 1) {
-            return set_params({32,256,32,4,32,64,32}, 8, true);
-          }
-          if (ctx.size_m <= 32) {
-            return set_params({32,128,128,8,32,64,32}, 1, true);
-          }
-          return set_params({32,256,64,8,32,64,32}, 1, true);
+        if (ctx.size_m <= 1) {
+          return set_params({32, 256, 32, 4, 32, 64, 32}, 8, true);
+        }
+        if (ctx.size_m <= 32) {
+          return set_params({32, 128, 128, 8, 32, 64, 32}, 1, true);
+        }
+        return set_params({32, 256, 64, 8, 32, 64, 32}, 1, true);
       }
     }
     if (ctx.top_k == 10 && ctx.size_k == 2048) {
       if (ctx.size_n == 1024) {
-          if (ctx.size_m <= 1) {
-            return set_params({32,128,128,8,32,64,32}, 1, true);
-          }
-          if (ctx.size_m <= 32) {
-            return set_params({32,256,32,4,32,64,32}, 1, true);
-          }
-          return set_params({32,256,32,4,32,64,32}, 1, true);
+        if (ctx.size_m <= 1) {
+          return set_params({32, 128, 128, 8, 32, 64, 32}, 1, true);
+        }
+        if (ctx.size_m <= 32) {
+          return set_params({32, 256, 32, 4, 32, 64, 32}, 1, true);
+        }
+        return set_params({32, 256, 32, 4, 32, 64, 32}, 1, true);
       }
     }
   }
@@ -1107,13 +1094,13 @@ inline bool sm70_marlin_moe_try_select_cyankiwi_qwen3_coder_next_awq_8bit_params
     // top_k=1
     if (ctx.top_k == 1 && ctx.size_n == 2048) {
       if (ctx.size_k == 512) {
-        return set_params({32,256,32,4,32,64,32}, 1, true);
+        return set_params({32, 256, 32, 4, 32, 64, 32}, 1, true);
       }
     }
     // top_k=10
     if (ctx.top_k == 10 && ctx.size_k == 2048) {
       if (ctx.size_n == 1024) {
-        return set_params({32,256,32,4,32,64,32}, 1, true);
+        return set_params({32, 256, 32, 4, 32, 64, 32}, 1, true);
       }
     }
   }
@@ -1123,23 +1110,23 @@ inline bool sm70_marlin_moe_try_select_cyankiwi_qwen3_coder_next_awq_8bit_params
     // top_k=1
     if (ctx.top_k == 1 && ctx.size_n == 2048) {
       if (ctx.size_k == 64) {
-        return set_params({64,256,32,4,64,64,32}, 1, false);
+        return set_params({64, 256, 32, 4, 64, 64, 32}, 1, false);
       }
     }
     if (ctx.top_k == 1 && ctx.size_n == 2048) {
       if (ctx.size_k == 128) {
-        return set_params({64,256,32,4,64,64,32}, 1, false);
+        return set_params({64, 256, 32, 4, 64, 64, 32}, 1, false);
       }
     }
     // top_k=10
     if (ctx.top_k == 10 && ctx.size_k == 2048) {
       if (ctx.size_n == 128) {
-        return set_params({64,128,32,8,32,32,32}, 1, false);
+        return set_params({64, 128, 32, 8, 32, 32, 32}, 1, false);
       }
     }
     if (ctx.top_k == 10 && ctx.size_k == 2048) {
       if (ctx.size_n == 256) {
-        return set_params({64,256,32,4,64,64,32}, 1, false);
+        return set_params({64, 256, 32, 4, 64, 64, 32}, 1, false);
       }
     }
   }
@@ -1149,33 +1136,33 @@ inline bool sm70_marlin_moe_try_select_cyankiwi_qwen3_coder_next_awq_8bit_params
     // top_k=1
     if (ctx.top_k == 1 && ctx.size_n == 2048) {
       if (ctx.size_k == 64) {
-        return set_params({64,256,32,4,64,64,32}, 1, false);
+        return set_params({64, 256, 32, 4, 64, 64, 32}, 1, false);
       }
     }
     if (ctx.top_k == 1 && ctx.size_n == 2048) {
       if (ctx.size_k == 128) {
-        return set_params({64,256,32,4,64,64,32}, 1, false);
+        return set_params({64, 256, 32, 4, 64, 64, 32}, 1, false);
       }
     }
     if (ctx.top_k == 1 && ctx.size_n == 2048) {
       if (ctx.size_k == 512) {
-        return set_params({64,256,32,4,64,64,32}, 1, false);
+        return set_params({64, 256, 32, 4, 64, 64, 32}, 1, false);
       }
     }
     // top_k=10
     if (ctx.top_k == 10 && ctx.size_k == 2048) {
       if (ctx.size_n == 128) {
-        return set_params({64,128,32,8,32,32,32}, 1, false);
+        return set_params({64, 128, 32, 8, 32, 32, 32}, 1, false);
       }
     }
     if (ctx.top_k == 10 && ctx.size_k == 2048) {
       if (ctx.size_n == 256) {
-        return set_params({64,256,32,4,64,64,32}, 1, false);
+        return set_params({64, 256, 32, 4, 64, 64, 32}, 1, false);
       }
     }
     if (ctx.top_k == 10 && ctx.size_k == 2048) {
       if (ctx.size_n == 1024) {
-        return set_params({64,256,32,4,64,64,32}, 1, false);
+        return set_params({64, 256, 32, 4, 64, 64, 32}, 1, false);
       }
     }
   }
@@ -1184,16 +1171,14 @@ inline bool sm70_marlin_moe_try_select_cyankiwi_qwen3_coder_next_awq_8bit_params
 }
 
 inline bool sm70_marlin_moe_try_select_nvidia_glm_4_7_nvfp4_params(
-    Sm70MarlinMoeAutoParamsContext const& ctx,
-    Sm70MarlinAutoParams& params) {
+    Sm70MarlinMoeAutoParamsContext const& ctx, Sm70MarlinAutoParams& params) {
   if (ctx.quant_format == nullptr ||
-      std::strcmp(ctx.quant_format, "nvfp4") != 0 ||
-      ctx.group_size != 16 || ctx.size_m <= 0) {
+      std::strcmp(ctx.quant_format, "nvfp4") != 0 || ctx.group_size != 16 ||
+      ctx.size_m <= 0) {
     return false;
   }
 
-  auto const set_params = [&](Sm70CtaGeometry geometry,
-                              int requested_split_k,
+  auto const set_params = [&](Sm70CtaGeometry geometry, int requested_split_k,
                               bool use_metadata_vector_words) {
     params = {geometry, requested_split_k, use_metadata_vector_words,
               ctx.packed_macro_n};
@@ -1205,63 +1190,63 @@ inline bool sm70_marlin_moe_try_select_nvidia_glm_4_7_nvfp4_params(
     // top_k=1
     if (ctx.top_k == 1 && ctx.size_n == 5120) {
       if (ctx.size_k == 192) {
-          if (ctx.size_m <= 8) {
-            return set_params({32,128,32,4,32,32,32}, 1, false);
-          }
-          if (ctx.size_m <= 256) {
-            return set_params({32,128,32,4,32,32,32}, 1, false);
-          }
-          return set_params({32,128,32,4,32,32,32}, 1, true);
+        if (ctx.size_m <= 8) {
+          return set_params({32, 128, 32, 4, 32, 32, 32}, 1, false);
+        }
+        if (ctx.size_m <= 256) {
+          return set_params({32, 128, 32, 4, 32, 32, 32}, 1, false);
+        }
+        return set_params({32, 128, 32, 4, 32, 32, 32}, 1, true);
       }
     }
     if (ctx.top_k == 1 && ctx.size_n == 5120) {
       if (ctx.size_k == 384) {
-          if (ctx.size_m <= 8) {
-            return set_params({32,256,32,4,32,64,32}, 1, true);
-          }
-          if (ctx.size_m <= 256) {
-            return set_params({32,128,32,4,32,32,32}, 1, true);
-          }
-          return set_params({32,128,32,4,32,32,32}, 1, true);
+        if (ctx.size_m <= 8) {
+          return set_params({32, 256, 32, 4, 32, 64, 32}, 1, true);
+        }
+        if (ctx.size_m <= 256) {
+          return set_params({32, 128, 32, 4, 32, 32, 32}, 1, true);
+        }
+        return set_params({32, 128, 32, 4, 32, 32, 32}, 1, true);
       }
     }
     if (ctx.top_k == 1 && ctx.size_n == 5120) {
       if (ctx.size_k == 1536) {
-          if (ctx.size_m <= 8) {
-            return set_params({32,128,32,4,32,32,32}, 1, true);
-          }
-          return set_params({32,128,32,4,32,32,32}, 1, false);
+        if (ctx.size_m <= 8) {
+          return set_params({32, 128, 32, 4, 32, 32, 32}, 1, true);
+        }
+        return set_params({32, 128, 32, 4, 32, 32, 32}, 1, false);
       }
     }
     // top_k=8
     if (ctx.top_k == 8 && ctx.size_k == 5120) {
       if (ctx.size_n == 384) {
-          if (ctx.size_m <= 1) {
-            return set_params({32,128,32,4,32,32,32}, 8, true);
-          }
-          if (ctx.size_m <= 32) {
-            return set_params({32,128,32,4,32,64,16}, 2, true);
-          }
-          return set_params({32,128,32,4,32,64,16}, 1, true);
+        if (ctx.size_m <= 1) {
+          return set_params({32, 128, 32, 4, 32, 32, 32}, 8, true);
+        }
+        if (ctx.size_m <= 32) {
+          return set_params({32, 128, 32, 4, 32, 64, 16}, 2, true);
+        }
+        return set_params({32, 128, 32, 4, 32, 64, 16}, 1, true);
       }
     }
     if (ctx.top_k == 8 && ctx.size_k == 5120) {
       if (ctx.size_n == 768) {
-          if (ctx.size_m <= 1) {
-            return set_params({32,128,32,4,32,64,16}, 4, true);
-          }
-          if (ctx.size_m <= 32) {
-            return set_params({32,128,32,4,32,64,16}, 1, true);
-          }
-          return set_params({32,128,32,4,32,32,32}, 4, true);
+        if (ctx.size_m <= 1) {
+          return set_params({32, 128, 32, 4, 32, 64, 16}, 4, true);
+        }
+        if (ctx.size_m <= 32) {
+          return set_params({32, 128, 32, 4, 32, 64, 16}, 1, true);
+        }
+        return set_params({32, 128, 32, 4, 32, 32, 32}, 4, true);
       }
     }
     if (ctx.top_k == 8 && ctx.size_k == 5120) {
       if (ctx.size_n == 3072) {
-          if (ctx.size_m <= 1) {
-            return set_params({32,128,32,4,32,32,32}, 8, true);
-          }
-          return set_params({32,128,32,4,32,32,32}, 2, true);
+        if (ctx.size_m <= 1) {
+          return set_params({32, 128, 32, 4, 32, 32, 32}, 8, true);
+        }
+        return set_params({32, 128, 32, 4, 32, 32, 32}, 2, true);
       }
     }
   }
@@ -1271,19 +1256,19 @@ inline bool sm70_marlin_moe_try_select_nvidia_glm_4_7_nvfp4_params(
     // top_k=1
     if (ctx.top_k == 1 && ctx.size_n == 5120) {
       if (ctx.size_k == 1536) {
-          if (ctx.size_m <= 256) {
-            return set_params({32,256,64,8,32,64,32}, 1, true);
-          }
-          return set_params({32,128,32,4,32,32,32}, 1, true);
+        if (ctx.size_m <= 256) {
+          return set_params({32, 256, 64, 8, 32, 64, 32}, 1, true);
+        }
+        return set_params({32, 128, 32, 4, 32, 32, 32}, 1, true);
       }
     }
     // top_k=8
     if (ctx.top_k == 8 && ctx.size_k == 5120) {
       if (ctx.size_n == 3072) {
-          if (ctx.size_m <= 32) {
-            return set_params({32,128,32,4,32,32,32}, 4, true);
-          }
-          return set_params({32,256,64,8,32,64,32}, 1, true);
+        if (ctx.size_m <= 32) {
+          return set_params({32, 128, 32, 4, 32, 32, 32}, 4, true);
+        }
+        return set_params({32, 256, 64, 8, 32, 64, 32}, 1, true);
       }
     }
   }
@@ -1293,13 +1278,13 @@ inline bool sm70_marlin_moe_try_select_nvidia_glm_4_7_nvfp4_params(
     // top_k=1
     if (ctx.top_k == 1 && ctx.size_n == 5120) {
       if (ctx.size_k == 1536) {
-        return set_params({32,256,64,8,32,64,32}, 1, true);
+        return set_params({32, 256, 64, 8, 32, 64, 32}, 1, true);
       }
     }
     // top_k=8
     if (ctx.top_k == 8 && ctx.size_k == 5120) {
       if (ctx.size_n == 3072) {
-        return set_params({32,256,64,8,32,64,32}, 1, true);
+        return set_params({32, 256, 64, 8, 32, 64, 32}, 1, true);
       }
     }
   }
@@ -1309,42 +1294,42 @@ inline bool sm70_marlin_moe_try_select_nvidia_glm_4_7_nvfp4_params(
     // top_k=1
     if (ctx.top_k == 1 && ctx.size_n == 5120) {
       if (ctx.size_k == 192) {
-          if (ctx.size_m <= 16384) {
-            return set_params({64,256,32,4,64,64,32}, 1, true);
-          }
-          return set_params({64,256,32,4,64,64,32}, 1, false);
+        if (ctx.size_m <= 16384) {
+          return set_params({64, 256, 32, 4, 64, 64, 32}, 1, true);
+        }
+        return set_params({64, 256, 32, 4, 64, 64, 32}, 1, false);
       }
     }
     if (ctx.top_k == 1 && ctx.size_n == 5120) {
       if (ctx.size_k == 384) {
-          if (ctx.size_m <= 16384) {
-            return set_params({64,256,32,4,64,64,32}, 1, false);
-          }
-          return set_params({64,256,32,4,64,64,32}, 1, true);
+        if (ctx.size_m <= 16384) {
+          return set_params({64, 256, 32, 4, 64, 64, 32}, 1, false);
+        }
+        return set_params({64, 256, 32, 4, 64, 64, 32}, 1, true);
       }
     }
     if (ctx.top_k == 1 && ctx.size_n == 5120) {
       if (ctx.size_k == 1536) {
-        return set_params({64,256,32,4,64,64,32}, 1, true);
+        return set_params({64, 256, 32, 4, 64, 64, 32}, 1, true);
       }
     }
     // top_k=8
     if (ctx.top_k == 8 && ctx.size_k == 5120) {
       if (ctx.size_n == 384) {
-          if (ctx.size_m <= 2048) {
-            return set_params({64,128,32,8,32,32,32}, 1, false);
-          }
-          return set_params({64,128,32,8,32,32,32}, 1, true);
+        if (ctx.size_m <= 2048) {
+          return set_params({64, 128, 32, 8, 32, 32, 32}, 1, false);
+        }
+        return set_params({64, 128, 32, 8, 32, 32, 32}, 1, true);
       }
     }
     if (ctx.top_k == 8 && ctx.size_k == 5120) {
       if (ctx.size_n == 768) {
-        return set_params({64,256,32,4,64,64,32}, 1, true);
+        return set_params({64, 256, 32, 4, 64, 64, 32}, 1, true);
       }
     }
     if (ctx.top_k == 8 && ctx.size_k == 5120) {
       if (ctx.size_n == 3072) {
-        return set_params({64,256,32,4,64,64,32}, 1, true);
+        return set_params({64, 256, 32, 4, 64, 64, 32}, 1, true);
       }
     }
   }
@@ -1353,16 +1338,14 @@ inline bool sm70_marlin_moe_try_select_nvidia_glm_4_7_nvfp4_params(
 }
 
 inline bool sm70_marlin_moe_try_select_nvidia_minimax_m2_7_nvfp4_params(
-    Sm70MarlinMoeAutoParamsContext const& ctx,
-    Sm70MarlinAutoParams& params) {
+    Sm70MarlinMoeAutoParamsContext const& ctx, Sm70MarlinAutoParams& params) {
   if (ctx.quant_format == nullptr ||
-      std::strcmp(ctx.quant_format, "nvfp4") != 0 ||
-      ctx.group_size != 16 || ctx.size_m <= 0) {
+      std::strcmp(ctx.quant_format, "nvfp4") != 0 || ctx.group_size != 16 ||
+      ctx.size_m <= 0) {
     return false;
   }
 
-  auto const set_params = [&](Sm70CtaGeometry geometry,
-                              int requested_split_k,
+  auto const set_params = [&](Sm70CtaGeometry geometry, int requested_split_k,
                               bool use_metadata_vector_words) {
     params = {geometry, requested_split_k, use_metadata_vector_words,
               ctx.packed_macro_n};
@@ -1374,63 +1357,63 @@ inline bool sm70_marlin_moe_try_select_nvidia_minimax_m2_7_nvfp4_params(
     // top_k=1
     if (ctx.top_k == 1 && ctx.size_n == 3072) {
       if (ctx.size_k == 192) {
-          if (ctx.size_m <= 8) {
-            return set_params({32,128,32,4,32,32,32}, 1, true);
-          }
-          if (ctx.size_m <= 256) {
-            return set_params({32,128,32,4,32,32,32}, 1, true);
-          }
-          return set_params({32,256,32,4,32,64,32}, 1, true);
+        if (ctx.size_m <= 8) {
+          return set_params({32, 128, 32, 4, 32, 32, 32}, 1, true);
+        }
+        if (ctx.size_m <= 256) {
+          return set_params({32, 128, 32, 4, 32, 32, 32}, 1, true);
+        }
+        return set_params({32, 256, 32, 4, 32, 64, 32}, 1, true);
       }
     }
     if (ctx.top_k == 1 && ctx.size_n == 3072) {
       if (ctx.size_k == 384) {
-          if (ctx.size_m <= 8) {
-            return set_params({32,256,32,4,32,64,32}, 1, true);
-          }
-          if (ctx.size_m <= 256) {
-            return set_params({32,256,32,4,32,64,32}, 1, false);
-          }
-          return set_params({32,256,32,4,32,64,32}, 1, true);
+        if (ctx.size_m <= 8) {
+          return set_params({32, 256, 32, 4, 32, 64, 32}, 1, true);
+        }
+        if (ctx.size_m <= 256) {
+          return set_params({32, 256, 32, 4, 32, 64, 32}, 1, false);
+        }
+        return set_params({32, 256, 32, 4, 32, 64, 32}, 1, true);
       }
     }
     if (ctx.top_k == 1 && ctx.size_n == 3072) {
       if (ctx.size_k == 1536) {
-          if (ctx.size_m <= 8) {
-            return set_params({32,128,32,4,32,64,16}, 1, true);
-          }
-          return set_params({32,128,32,4,32,32,32}, 1, true);
+        if (ctx.size_m <= 8) {
+          return set_params({32, 128, 32, 4, 32, 64, 16}, 1, true);
+        }
+        return set_params({32, 128, 32, 4, 32, 32, 32}, 1, true);
       }
     }
     // top_k=8
     if (ctx.top_k == 8 && ctx.size_k == 3072) {
       if (ctx.size_n == 384) {
-          if (ctx.size_m <= 1) {
-            return set_params({32,128,32,4,32,32,32}, 8, false);
-          }
-          if (ctx.size_m <= 32) {
-            return set_params({32,128,32,4,32,64,16}, 2, true);
-          }
-          return set_params({32,128,32,4,32,64,16}, 1, true);
+        if (ctx.size_m <= 1) {
+          return set_params({32, 128, 32, 4, 32, 32, 32}, 8, false);
+        }
+        if (ctx.size_m <= 32) {
+          return set_params({32, 128, 32, 4, 32, 64, 16}, 2, true);
+        }
+        return set_params({32, 128, 32, 4, 32, 64, 16}, 1, true);
       }
     }
     if (ctx.top_k == 8 && ctx.size_k == 3072) {
       if (ctx.size_n == 768) {
-          if (ctx.size_m <= 1) {
-            return set_params({32,128,32,4,32,32,32}, 4, true);
-          }
-          if (ctx.size_m <= 32) {
-            return set_params({32,128,32,4,32,64,16}, 1, true);
-          }
-          return set_params({32,128,32,4,32,64,16}, 1, true);
+        if (ctx.size_m <= 1) {
+          return set_params({32, 128, 32, 4, 32, 32, 32}, 4, true);
+        }
+        if (ctx.size_m <= 32) {
+          return set_params({32, 128, 32, 4, 32, 64, 16}, 1, true);
+        }
+        return set_params({32, 128, 32, 4, 32, 64, 16}, 1, true);
       }
     }
     if (ctx.top_k == 8 && ctx.size_k == 3072) {
       if (ctx.size_n == 3072) {
-          if (ctx.size_m <= 1) {
-            return set_params({32,128,32,4,32,32,32}, 4, true);
-          }
-          return set_params({32,256,64,8,32,64,32}, 1, true);
+        if (ctx.size_m <= 1) {
+          return set_params({32, 128, 32, 4, 32, 32, 32}, 4, true);
+        }
+        return set_params({32, 256, 64, 8, 32, 64, 32}, 1, true);
       }
     }
   }
@@ -1440,19 +1423,19 @@ inline bool sm70_marlin_moe_try_select_nvidia_minimax_m2_7_nvfp4_params(
     // top_k=1
     if (ctx.top_k == 1 && ctx.size_n == 3072) {
       if (ctx.size_k == 1536) {
-          if (ctx.size_m <= 256) {
-            return set_params({32,256,64,8,32,64,32}, 1, true);
-          }
-          return set_params({32,128,32,4,32,32,32}, 1, true);
+        if (ctx.size_m <= 256) {
+          return set_params({32, 256, 64, 8, 32, 64, 32}, 1, true);
+        }
+        return set_params({32, 128, 32, 4, 32, 32, 32}, 1, true);
       }
     }
     // top_k=8
     if (ctx.top_k == 8 && ctx.size_k == 3072) {
       if (ctx.size_n == 3072) {
-          if (ctx.size_m <= 32) {
-            return set_params({32,256,64,8,32,64,32}, 1, true);
-          }
-          return set_params({32,128,32,4,32,32,32}, 1, true);
+        if (ctx.size_m <= 32) {
+          return set_params({32, 256, 64, 8, 32, 64, 32}, 1, true);
+        }
+        return set_params({32, 128, 32, 4, 32, 32, 32}, 1, true);
       }
     }
   }
@@ -1462,13 +1445,13 @@ inline bool sm70_marlin_moe_try_select_nvidia_minimax_m2_7_nvfp4_params(
     // top_k=1
     if (ctx.top_k == 1 && ctx.size_n == 3072) {
       if (ctx.size_k == 1536) {
-        return set_params({32,256,64,8,32,64,32}, 1, true);
+        return set_params({32, 256, 64, 8, 32, 64, 32}, 1, true);
       }
     }
     // top_k=8
     if (ctx.top_k == 8 && ctx.size_k == 3072) {
       if (ctx.size_n == 3072) {
-        return set_params({32,256,64,8,32,64,32}, 1, false);
+        return set_params({32, 256, 64, 8, 32, 64, 32}, 1, false);
       }
     }
   }
@@ -1478,45 +1461,45 @@ inline bool sm70_marlin_moe_try_select_nvidia_minimax_m2_7_nvfp4_params(
     // top_k=1
     if (ctx.top_k == 1 && ctx.size_n == 3072) {
       if (ctx.size_k == 192) {
-          if (ctx.size_m <= 16384) {
-            return set_params({64,256,32,4,64,64,32}, 1, true);
-          }
-          return set_params({64,256,32,4,64,64,32}, 1, false);
+        if (ctx.size_m <= 16384) {
+          return set_params({64, 256, 32, 4, 64, 64, 32}, 1, true);
+        }
+        return set_params({64, 256, 32, 4, 64, 64, 32}, 1, false);
       }
     }
     if (ctx.top_k == 1 && ctx.size_n == 3072) {
       if (ctx.size_k == 384) {
-          if (ctx.size_m <= 16384) {
-            return set_params({64,256,32,4,64,64,32}, 1, false);
-          }
-          return set_params({64,256,32,4,64,64,32}, 1, true);
+        if (ctx.size_m <= 16384) {
+          return set_params({64, 256, 32, 4, 64, 64, 32}, 1, false);
+        }
+        return set_params({64, 256, 32, 4, 64, 64, 32}, 1, true);
       }
     }
     if (ctx.top_k == 1 && ctx.size_n == 3072) {
       if (ctx.size_k == 1536) {
-          if (ctx.size_m <= 16384) {
-            return set_params({64,256,32,4,64,64,32}, 1, true);
-          }
-          return set_params({64,256,32,4,64,64,32}, 1, false);
+        if (ctx.size_m <= 16384) {
+          return set_params({64, 256, 32, 4, 64, 64, 32}, 1, true);
+        }
+        return set_params({64, 256, 32, 4, 64, 64, 32}, 1, false);
       }
     }
     // top_k=8
     if (ctx.top_k == 8 && ctx.size_k == 3072) {
       if (ctx.size_n == 384) {
-          if (ctx.size_m <= 2048) {
-            return set_params({64,128,32,8,32,32,32}, 1, true);
-          }
-          return set_params({64,128,32,8,32,32,32}, 1, false);
+        if (ctx.size_m <= 2048) {
+          return set_params({64, 128, 32, 8, 32, 32, 32}, 1, true);
+        }
+        return set_params({64, 128, 32, 8, 32, 32, 32}, 1, false);
       }
     }
     if (ctx.top_k == 8 && ctx.size_k == 3072) {
       if (ctx.size_n == 768) {
-        return set_params({64,256,32,4,64,64,32}, 1, true);
+        return set_params({64, 256, 32, 4, 64, 64, 32}, 1, true);
       }
     }
     if (ctx.top_k == 8 && ctx.size_k == 3072) {
       if (ctx.size_n == 3072) {
-        return set_params({64,256,32,4,64,64,32}, 1, true);
+        return set_params({64, 256, 32, 4, 64, 64, 32}, 1, true);
       }
     }
   }
@@ -1525,16 +1508,14 @@ inline bool sm70_marlin_moe_try_select_nvidia_minimax_m2_7_nvfp4_params(
 }
 
 inline bool sm70_marlin_moe_try_select_nvidia_qwen3_6_35b_a3b_nvfp4_params(
-    Sm70MarlinMoeAutoParamsContext const& ctx,
-    Sm70MarlinAutoParams& params) {
+    Sm70MarlinMoeAutoParamsContext const& ctx, Sm70MarlinAutoParams& params) {
   if (ctx.quant_format == nullptr ||
-      std::strcmp(ctx.quant_format, "nvfp4") != 0 ||
-      ctx.group_size != 16 || ctx.size_m <= 0) {
+      std::strcmp(ctx.quant_format, "nvfp4") != 0 || ctx.group_size != 16 ||
+      ctx.size_m <= 0) {
     return false;
   }
 
-  auto const set_params = [&](Sm70CtaGeometry geometry,
-                              int requested_split_k,
+  auto const set_params = [&](Sm70CtaGeometry geometry, int requested_split_k,
                               bool use_metadata_vector_words) {
     params = {geometry, requested_split_k, use_metadata_vector_words,
               ctx.packed_macro_n};
@@ -1546,63 +1527,63 @@ inline bool sm70_marlin_moe_try_select_nvidia_qwen3_6_35b_a3b_nvfp4_params(
     // top_k=1
     if (ctx.top_k == 1 && ctx.size_n == 2048) {
       if (ctx.size_k == 64) {
-          if (ctx.size_m <= 8) {
-            return set_params({32,64,64,4,32,32,32}, 1, true);
-          }
-          if (ctx.size_m <= 256) {
-            return set_params({32,128,32,4,32,32,32}, 1, true);
-          }
-          return set_params({32,128,32,4,32,32,32}, 1, true);
+        if (ctx.size_m <= 8) {
+          return set_params({32, 64, 64, 4, 32, 32, 32}, 1, true);
+        }
+        if (ctx.size_m <= 256) {
+          return set_params({32, 128, 32, 4, 32, 32, 32}, 1, true);
+        }
+        return set_params({32, 128, 32, 4, 32, 32, 32}, 1, true);
       }
     }
     if (ctx.top_k == 1 && ctx.size_n == 2048) {
       if (ctx.size_k == 128) {
-          if (ctx.size_m <= 8) {
-            return set_params({32,64,64,4,32,32,32}, 1, true);
-          }
-          if (ctx.size_m <= 256) {
-            return set_params({32,128,32,4,32,32,32}, 1, true);
-          }
-          return set_params({32,128,32,4,32,32,32}, 1, true);
+        if (ctx.size_m <= 8) {
+          return set_params({32, 64, 64, 4, 32, 32, 32}, 1, true);
+        }
+        if (ctx.size_m <= 256) {
+          return set_params({32, 128, 32, 4, 32, 32, 32}, 1, true);
+        }
+        return set_params({32, 128, 32, 4, 32, 32, 32}, 1, true);
       }
     }
     if (ctx.top_k == 1 && ctx.size_n == 2048) {
       if (ctx.size_k == 512) {
-          if (ctx.size_m <= 8) {
-            return set_params({32,128,64,4,32,64,32}, 1, true);
-          }
-          return set_params({32,128,32,4,32,32,32}, 1, true);
+        if (ctx.size_m <= 8) {
+          return set_params({32, 128, 64, 4, 32, 64, 32}, 1, true);
+        }
+        return set_params({32, 128, 32, 4, 32, 32, 32}, 1, true);
       }
     }
     // top_k=8
     if (ctx.top_k == 8 && ctx.size_k == 2048) {
       if (ctx.size_n == 128) {
-          if (ctx.size_m <= 1) {
-            return set_params({32,64,32,4,32,32,16}, 8, true);
-          }
-          if (ctx.size_m <= 32) {
-            return set_params({32,128,64,8,32,32,32}, 4, true);
-          }
-          return set_params({32,128,128,8,32,64,32}, 1, true);
+        if (ctx.size_m <= 1) {
+          return set_params({32, 64, 32, 4, 32, 32, 16}, 8, true);
+        }
+        if (ctx.size_m <= 32) {
+          return set_params({32, 128, 64, 8, 32, 32, 32}, 4, true);
+        }
+        return set_params({32, 128, 128, 8, 32, 64, 32}, 1, true);
       }
     }
     if (ctx.top_k == 8 && ctx.size_k == 2048) {
       if (ctx.size_n == 256) {
-          if (ctx.size_m <= 1) {
-            return set_params({32,128,32,4,32,32,32}, 8, true);
-          }
-          if (ctx.size_m <= 32) {
-            return set_params({32,128,128,8,32,64,32}, 1, true);
-          }
-          return set_params({32,256,64,8,32,64,32}, 1, true);
+        if (ctx.size_m <= 1) {
+          return set_params({32, 128, 32, 4, 32, 32, 32}, 8, true);
+        }
+        if (ctx.size_m <= 32) {
+          return set_params({32, 128, 128, 8, 32, 64, 32}, 1, true);
+        }
+        return set_params({32, 256, 64, 8, 32, 64, 32}, 1, true);
       }
     }
     if (ctx.top_k == 8 && ctx.size_k == 2048) {
       if (ctx.size_n == 1024) {
-          if (ctx.size_m <= 1) {
-            return set_params({32,128,32,4,32,32,32}, 4, true);
-          }
-          return set_params({32,128,32,4,32,32,32}, 1, true);
+        if (ctx.size_m <= 1) {
+          return set_params({32, 128, 32, 4, 32, 32, 32}, 4, true);
+        }
+        return set_params({32, 128, 32, 4, 32, 32, 32}, 1, true);
       }
     }
   }
@@ -1612,16 +1593,16 @@ inline bool sm70_marlin_moe_try_select_nvidia_qwen3_6_35b_a3b_nvfp4_params(
     // top_k=1
     if (ctx.top_k == 1 && ctx.size_n == 2048) {
       if (ctx.size_k == 512) {
-        return set_params({32,128,32,4,32,32,32}, 1, true);
+        return set_params({32, 128, 32, 4, 32, 32, 32}, 1, true);
       }
     }
     // top_k=8
     if (ctx.top_k == 8 && ctx.size_k == 2048) {
       if (ctx.size_n == 1024) {
-          if (ctx.size_m <= 32) {
-            return set_params({32,256,64,8,32,64,32}, 1, true);
-          }
-          return set_params({32,128,32,4,32,32,32}, 1, true);
+        if (ctx.size_m <= 32) {
+          return set_params({32, 256, 64, 8, 32, 64, 32}, 1, true);
+        }
+        return set_params({32, 128, 32, 4, 32, 32, 32}, 1, true);
       }
     }
   }
@@ -1631,13 +1612,13 @@ inline bool sm70_marlin_moe_try_select_nvidia_qwen3_6_35b_a3b_nvfp4_params(
     // top_k=1
     if (ctx.top_k == 1 && ctx.size_n == 2048) {
       if (ctx.size_k == 512) {
-        return set_params({32,128,32,4,32,32,32}, 1, true);
+        return set_params({32, 128, 32, 4, 32, 32, 32}, 1, true);
       }
     }
     // top_k=8
     if (ctx.top_k == 8 && ctx.size_k == 2048) {
       if (ctx.size_n == 1024) {
-        return set_params({32,256,64,8,32,64,32}, 1, true);
+        return set_params({32, 256, 64, 8, 32, 64, 32}, 1, true);
       }
     }
   }
@@ -1647,48 +1628,48 @@ inline bool sm70_marlin_moe_try_select_nvidia_qwen3_6_35b_a3b_nvfp4_params(
     // top_k=1
     if (ctx.top_k == 1 && ctx.size_n == 2048) {
       if (ctx.size_k == 64) {
-          if (ctx.size_m <= 16384) {
-            return set_params({64,64,32,4,32,32,32}, 1, false);
-          }
-          return set_params({64,256,32,4,64,64,32}, 1, false);
+        if (ctx.size_m <= 16384) {
+          return set_params({64, 64, 32, 4, 32, 32, 32}, 1, false);
+        }
+        return set_params({64, 256, 32, 4, 64, 64, 32}, 1, false);
       }
     }
     if (ctx.top_k == 1 && ctx.size_n == 2048) {
       if (ctx.size_k == 128) {
-        return set_params({64,256,32,4,64,64,32}, 1, true);
+        return set_params({64, 256, 32, 4, 64, 64, 32}, 1, true);
       }
     }
     if (ctx.top_k == 1 && ctx.size_n == 2048) {
       if (ctx.size_k == 512) {
-          if (ctx.size_m <= 16384) {
-            return set_params({64,256,32,4,64,64,32}, 1, false);
-          }
-          return set_params({64,256,32,4,64,64,32}, 1, true);
+        if (ctx.size_m <= 16384) {
+          return set_params({64, 256, 32, 4, 64, 64, 32}, 1, false);
+        }
+        return set_params({64, 256, 32, 4, 64, 64, 32}, 1, true);
       }
     }
     // top_k=8
     if (ctx.top_k == 8 && ctx.size_k == 2048) {
       if (ctx.size_n == 128) {
-          if (ctx.size_m <= 2048) {
-            return set_params({32,128,32,4,32,32,32}, 1, true);
-          }
-          return set_params({64,128,32,8,32,32,32}, 1, true);
+        if (ctx.size_m <= 2048) {
+          return set_params({32, 128, 32, 4, 32, 32, 32}, 1, true);
+        }
+        return set_params({64, 128, 32, 8, 32, 32, 32}, 1, true);
       }
     }
     if (ctx.top_k == 8 && ctx.size_k == 2048) {
       if (ctx.size_n == 256) {
-          if (ctx.size_m <= 2048) {
-            return set_params({64,256,32,4,64,64,32}, 1, true);
-          }
-          return set_params({64,256,64,8,64,64,32}, 1, false);
+        if (ctx.size_m <= 2048) {
+          return set_params({64, 256, 32, 4, 64, 64, 32}, 1, true);
+        }
+        return set_params({64, 256, 64, 8, 64, 64, 32}, 1, false);
       }
     }
     if (ctx.top_k == 8 && ctx.size_k == 2048) {
       if (ctx.size_n == 1024) {
-          if (ctx.size_m <= 2048) {
-            return set_params({64,256,32,4,64,64,32}, 1, false);
-          }
-          return set_params({64,256,32,4,64,64,32}, 1, true);
+        if (ctx.size_m <= 2048) {
+          return set_params({64, 256, 32, 4, 64, 64, 32}, 1, false);
+        }
+        return set_params({64, 256, 32, 4, 64, 64, 32}, 1, true);
       }
     }
   }
@@ -1696,17 +1677,16 @@ inline bool sm70_marlin_moe_try_select_nvidia_qwen3_6_35b_a3b_nvfp4_params(
   return false;
 }
 
-inline bool sm70_marlin_moe_try_select_nvidia_qwen3_next_80b_a3b_thinking_nvfp4_params(
-    Sm70MarlinMoeAutoParamsContext const& ctx,
-    Sm70MarlinAutoParams& params) {
+inline bool
+sm70_marlin_moe_try_select_nvidia_qwen3_next_80b_a3b_thinking_nvfp4_params(
+    Sm70MarlinMoeAutoParamsContext const& ctx, Sm70MarlinAutoParams& params) {
   if (ctx.quant_format == nullptr ||
-      std::strcmp(ctx.quant_format, "nvfp4") != 0 ||
-      ctx.group_size != 16 || ctx.size_m <= 0) {
+      std::strcmp(ctx.quant_format, "nvfp4") != 0 || ctx.group_size != 16 ||
+      ctx.size_m <= 0) {
     return false;
   }
 
-  auto const set_params = [&](Sm70CtaGeometry geometry,
-                              int requested_split_k,
+  auto const set_params = [&](Sm70CtaGeometry geometry, int requested_split_k,
                               bool use_metadata_vector_words) {
     params = {geometry, requested_split_k, use_metadata_vector_words,
               ctx.packed_macro_n};
@@ -1718,69 +1698,69 @@ inline bool sm70_marlin_moe_try_select_nvidia_qwen3_next_80b_a3b_thinking_nvfp4_
     // top_k=1
     if (ctx.top_k == 1 && ctx.size_n == 2048) {
       if (ctx.size_k == 64) {
-          if (ctx.size_m <= 10) {
-            return set_params({32,128,32,4,32,32,32}, 1, false);
-          }
-          if (ctx.size_m <= 320) {
-            return set_params({32,128,32,4,32,32,32}, 1, true);
-          }
-          return set_params({32,256,32,4,32,64,32}, 1, true);
+        if (ctx.size_m <= 10) {
+          return set_params({32, 128, 32, 4, 32, 32, 32}, 1, false);
+        }
+        if (ctx.size_m <= 320) {
+          return set_params({32, 128, 32, 4, 32, 32, 32}, 1, true);
+        }
+        return set_params({32, 256, 32, 4, 32, 64, 32}, 1, true);
       }
     }
     if (ctx.top_k == 1 && ctx.size_n == 2048) {
       if (ctx.size_k == 128) {
-          if (ctx.size_m <= 10) {
-            return set_params({32,128,32,4,32,32,32}, 1, true);
-          }
-          if (ctx.size_m <= 320) {
-            return set_params({32,128,32,4,32,32,32}, 1, true);
-          }
-          return set_params({32,256,32,4,32,64,32}, 1, true);
+        if (ctx.size_m <= 10) {
+          return set_params({32, 128, 32, 4, 32, 32, 32}, 1, true);
+        }
+        if (ctx.size_m <= 320) {
+          return set_params({32, 128, 32, 4, 32, 32, 32}, 1, true);
+        }
+        return set_params({32, 256, 32, 4, 32, 64, 32}, 1, true);
       }
     }
     if (ctx.top_k == 1 && ctx.size_n == 2048) {
       if (ctx.size_k == 512) {
-          if (ctx.size_m <= 10) {
-            return set_params({32,256,64,8,32,64,32}, 1, true);
-          }
-          if (ctx.size_m <= 320) {
-            return set_params({32,128,32,4,32,32,32}, 1, true);
-          }
-          return set_params({32,128,32,4,32,32,32}, 1, false);
+        if (ctx.size_m <= 10) {
+          return set_params({32, 256, 64, 8, 32, 64, 32}, 1, true);
+        }
+        if (ctx.size_m <= 320) {
+          return set_params({32, 128, 32, 4, 32, 32, 32}, 1, true);
+        }
+        return set_params({32, 128, 32, 4, 32, 32, 32}, 1, false);
       }
     }
     // top_k=10
     if (ctx.top_k == 10 && ctx.size_k == 2048) {
       if (ctx.size_n == 128) {
-          if (ctx.size_m <= 1) {
-            return set_params({32,64,32,4,32,32,16}, 8, false);
-          }
-          if (ctx.size_m <= 32) {
-            return set_params({32,128,64,8,32,64,16}, 2, true);
-          }
-          return set_params({32,128,128,8,32,64,32}, 1, true);
+        if (ctx.size_m <= 1) {
+          return set_params({32, 64, 32, 4, 32, 32, 16}, 8, false);
+        }
+        if (ctx.size_m <= 32) {
+          return set_params({32, 128, 64, 8, 32, 64, 16}, 2, true);
+        }
+        return set_params({32, 128, 128, 8, 32, 64, 32}, 1, true);
       }
     }
     if (ctx.top_k == 10 && ctx.size_k == 2048) {
       if (ctx.size_n == 256) {
-          if (ctx.size_m <= 1) {
-            return set_params({32,128,32,4,32,32,32}, 8, true);
-          }
-          if (ctx.size_m <= 32) {
-            return set_params({32,128,128,8,32,64,32}, 1, true);
-          }
-          return set_params({32,256,64,8,32,64,32}, 1, true);
+        if (ctx.size_m <= 1) {
+          return set_params({32, 128, 32, 4, 32, 32, 32}, 8, true);
+        }
+        if (ctx.size_m <= 32) {
+          return set_params({32, 128, 128, 8, 32, 64, 32}, 1, true);
+        }
+        return set_params({32, 256, 64, 8, 32, 64, 32}, 1, true);
       }
     }
     if (ctx.top_k == 10 && ctx.size_k == 2048) {
       if (ctx.size_n == 1024) {
-          if (ctx.size_m <= 1) {
-            return set_params({32,128,128,8,32,64,32}, 1, true);
-          }
-          if (ctx.size_m <= 32) {
-            return set_params({32,256,32,4,32,64,32}, 1, false);
-          }
-          return set_params({32,128,32,4,32,32,32}, 1, true);
+        if (ctx.size_m <= 1) {
+          return set_params({32, 128, 128, 8, 32, 64, 32}, 1, true);
+        }
+        if (ctx.size_m <= 32) {
+          return set_params({32, 256, 32, 4, 32, 64, 32}, 1, false);
+        }
+        return set_params({32, 128, 32, 4, 32, 32, 32}, 1, true);
       }
     }
   }
@@ -1790,13 +1770,13 @@ inline bool sm70_marlin_moe_try_select_nvidia_qwen3_next_80b_a3b_thinking_nvfp4_
     // top_k=1
     if (ctx.top_k == 1 && ctx.size_n == 2048) {
       if (ctx.size_k == 512) {
-        return set_params({32,128,32,4,32,32,32}, 1, true);
+        return set_params({32, 128, 32, 4, 32, 32, 32}, 1, true);
       }
     }
     // top_k=10
     if (ctx.top_k == 10 && ctx.size_k == 2048) {
       if (ctx.size_n == 1024) {
-        return set_params({32,128,32,4,32,32,32}, 1, true);
+        return set_params({32, 128, 32, 4, 32, 32, 32}, 1, true);
       }
     }
   }
@@ -1806,23 +1786,23 @@ inline bool sm70_marlin_moe_try_select_nvidia_qwen3_next_80b_a3b_thinking_nvfp4_
     // top_k=1
     if (ctx.top_k == 1 && ctx.size_n == 2048) {
       if (ctx.size_k == 64) {
-        return set_params({64,256,32,4,64,64,32}, 1, true);
+        return set_params({64, 256, 32, 4, 64, 64, 32}, 1, true);
       }
     }
     if (ctx.top_k == 1 && ctx.size_n == 2048) {
       if (ctx.size_k == 128) {
-        return set_params({64,256,32,4,64,64,32}, 1, true);
+        return set_params({64, 256, 32, 4, 64, 64, 32}, 1, true);
       }
     }
     // top_k=10
     if (ctx.top_k == 10 && ctx.size_k == 2048) {
       if (ctx.size_n == 128) {
-        return set_params({64,128,32,8,32,32,32}, 1, false);
+        return set_params({64, 128, 32, 8, 32, 32, 32}, 1, false);
       }
     }
     if (ctx.top_k == 10 && ctx.size_k == 2048) {
       if (ctx.size_n == 256) {
-        return set_params({64,256,32,4,64,64,32}, 1, false);
+        return set_params({64, 256, 32, 4, 64, 64, 32}, 1, false);
       }
     }
   }
@@ -1832,36 +1812,36 @@ inline bool sm70_marlin_moe_try_select_nvidia_qwen3_next_80b_a3b_thinking_nvfp4_
     // top_k=1
     if (ctx.top_k == 1 && ctx.size_n == 2048) {
       if (ctx.size_k == 64) {
-        return set_params({64,256,32,4,64,64,32}, 1, true);
+        return set_params({64, 256, 32, 4, 64, 64, 32}, 1, true);
       }
     }
     if (ctx.top_k == 1 && ctx.size_n == 2048) {
       if (ctx.size_k == 128) {
-        return set_params({64,256,32,4,64,64,32}, 1, true);
+        return set_params({64, 256, 32, 4, 64, 64, 32}, 1, true);
       }
     }
     if (ctx.top_k == 1 && ctx.size_n == 2048) {
       if (ctx.size_k == 512) {
-          if (ctx.size_m <= 20480) {
-            return set_params({64,256,32,4,64,64,32}, 1, false);
-          }
-          return set_params({64,256,32,4,64,64,32}, 1, true);
+        if (ctx.size_m <= 20480) {
+          return set_params({64, 256, 32, 4, 64, 64, 32}, 1, false);
+        }
+        return set_params({64, 256, 32, 4, 64, 64, 32}, 1, true);
       }
     }
     // top_k=10
     if (ctx.top_k == 10 && ctx.size_k == 2048) {
       if (ctx.size_n == 128) {
-        return set_params({64,128,32,8,32,32,32}, 1, true);
+        return set_params({64, 128, 32, 8, 32, 32, 32}, 1, true);
       }
     }
     if (ctx.top_k == 10 && ctx.size_k == 2048) {
       if (ctx.size_n == 256) {
-        return set_params({64,256,32,4,64,64,32}, 1, true);
+        return set_params({64, 256, 32, 4, 64, 64, 32}, 1, true);
       }
     }
     if (ctx.top_k == 10 && ctx.size_k == 2048) {
       if (ctx.size_n == 1024) {
-        return set_params({64,256,32,4,64,64,32}, 1, true);
+        return set_params({64, 256, 32, 4, 64, 64, 32}, 1, true);
       }
     }
   }
@@ -1870,16 +1850,14 @@ inline bool sm70_marlin_moe_try_select_nvidia_qwen3_next_80b_a3b_thinking_nvfp4_
 }
 
 inline bool sm70_marlin_moe_try_select_cyankiwi_minimax_m2_7_awq_4bit_params(
-    Sm70MarlinMoeAutoParamsContext const& ctx,
-    Sm70MarlinAutoParams& params) {
+    Sm70MarlinMoeAutoParamsContext const& ctx, Sm70MarlinAutoParams& params) {
   if (ctx.quant_format == nullptr ||
-      std::strcmp(ctx.quant_format, "uint4b8") != 0 ||
-      ctx.group_size != 32 || ctx.size_m <= 0) {
+      std::strcmp(ctx.quant_format, "uint4b8") != 0 || ctx.group_size != 32 ||
+      ctx.size_m <= 0) {
     return false;
   }
 
-  auto const set_params = [&](Sm70CtaGeometry geometry,
-                              int requested_split_k,
+  auto const set_params = [&](Sm70CtaGeometry geometry, int requested_split_k,
                               bool use_metadata_vector_words) {
     params = {geometry, requested_split_k, use_metadata_vector_words,
               ctx.packed_macro_n};
@@ -1995,16 +1973,14 @@ inline bool sm70_marlin_moe_try_select_cyankiwi_minimax_m2_7_awq_4bit_params(
 }
 
 inline bool sm70_marlin_moe_try_select_cyankiwi_glm_4_7_awq_4bit_params(
-    Sm70MarlinMoeAutoParamsContext const& ctx,
-    Sm70MarlinAutoParams& params) {
+    Sm70MarlinMoeAutoParamsContext const& ctx, Sm70MarlinAutoParams& params) {
   if (ctx.quant_format == nullptr ||
-      std::strcmp(ctx.quant_format, "uint4b8") != 0 ||
-      ctx.group_size != 32 || ctx.size_m <= 0) {
+      std::strcmp(ctx.quant_format, "uint4b8") != 0 || ctx.group_size != 32 ||
+      ctx.size_m <= 0) {
     return false;
   }
 
-  auto const set_params = [&](Sm70CtaGeometry geometry,
-                              int requested_split_k,
+  auto const set_params = [&](Sm70CtaGeometry geometry, int requested_split_k,
                               bool use_metadata_vector_words) {
     params = {geometry, requested_split_k, use_metadata_vector_words,
               ctx.packed_macro_n};
@@ -2108,16 +2084,14 @@ inline bool sm70_marlin_moe_try_select_cyankiwi_glm_4_7_awq_4bit_params(
 }
 
 inline bool sm70_marlin_moe_try_select_quanttrio_glm_4_7_awq_params(
-    Sm70MarlinMoeAutoParamsContext const& ctx,
-    Sm70MarlinAutoParams& params) {
+    Sm70MarlinMoeAutoParamsContext const& ctx, Sm70MarlinAutoParams& params) {
   if (ctx.quant_format == nullptr ||
-      std::strcmp(ctx.quant_format, "uint4") != 0 ||
-      ctx.group_size != 128 || ctx.size_m <= 0) {
+      std::strcmp(ctx.quant_format, "uint4") != 0 || ctx.group_size != 128 ||
+      ctx.size_m <= 0) {
     return false;
   }
 
-  auto const set_params = [&](Sm70CtaGeometry geometry,
-                              int requested_split_k,
+  auto const set_params = [&](Sm70CtaGeometry geometry, int requested_split_k,
                               bool use_metadata_vector_words) {
     params = {geometry, requested_split_k, use_metadata_vector_words,
               ctx.packed_macro_n};
@@ -2206,20 +2180,21 @@ inline bool sm70_marlin_moe_try_select_quanttrio_glm_4_7_awq_params(
 }
 
 inline Sm70MarlinAutoParams sm70_marlin_moe_auto_stage_params(
-    char const* quant_format, int64_t group_size,
-    int64_t moe_block_size, int64_t top_k, int64_t size_m,
-    int64_t size_n, int64_t size_k) {
+    char const* quant_format, int64_t group_size, int64_t moe_block_size,
+    int64_t top_k, int64_t size_m, int64_t size_n, int64_t size_k) {
   Sm70MarlinMoeAutoParamsContext const ctx{
-      quant_format, group_size, moe_block_size, top_k, size_m, size_n, size_k,
-      sm70_marlin_auto_packed_macro_n(size_n)};
+      quant_format,   group_size,
+      moe_block_size, top_k,
+      size_m,         size_n,
+      size_k,         sm70_marlin_auto_packed_macro_n(size_n)};
 
   if (sm70_marlin_moe_auto_env_is_set()) {
     return sm70_marlin_moe_auto_params_from_env(ctx);
   }
 
   Sm70MarlinAutoParams params{};
-  if (sm70_marlin_moe_try_select_quanttrio_qwen3_6_35b_a3b_awq_params(
-          ctx, params)) {
+  if (sm70_marlin_moe_try_select_quanttrio_qwen3_6_35b_a3b_awq_params(ctx,
+                                                                      params)) {
     validate_sm70_marlin_auto_params("MoE", params);
     return params;
   }
@@ -2228,8 +2203,8 @@ inline Sm70MarlinAutoParams sm70_marlin_moe_auto_stage_params(
     validate_sm70_marlin_auto_params("MoE", params);
     return params;
   }
-  if (sm70_marlin_moe_try_select_quanttrio_minimax_m2_7_awq_params(
-          ctx, params)) {
+  if (sm70_marlin_moe_try_select_quanttrio_minimax_m2_7_awq_params(ctx,
+                                                                   params)) {
     validate_sm70_marlin_auto_params("MoE", params);
     return params;
   }
@@ -2258,18 +2233,17 @@ inline Sm70MarlinAutoParams sm70_marlin_moe_auto_stage_params(
     validate_sm70_marlin_auto_params("MoE", params);
     return params;
   }
-  if (sm70_marlin_moe_try_select_nvidia_glm_4_7_nvfp4_params(
-          ctx, params)) {
+  if (sm70_marlin_moe_try_select_nvidia_glm_4_7_nvfp4_params(ctx, params)) {
     validate_sm70_marlin_auto_params("MoE", params);
     return params;
   }
-  if (sm70_marlin_moe_try_select_nvidia_minimax_m2_7_nvfp4_params(
-          ctx, params)) {
+  if (sm70_marlin_moe_try_select_nvidia_minimax_m2_7_nvfp4_params(ctx,
+                                                                  params)) {
     validate_sm70_marlin_auto_params("MoE", params);
     return params;
   }
-  if (sm70_marlin_moe_try_select_nvidia_qwen3_6_35b_a3b_nvfp4_params(
-          ctx, params)) {
+  if (sm70_marlin_moe_try_select_nvidia_qwen3_6_35b_a3b_nvfp4_params(ctx,
+                                                                     params)) {
     validate_sm70_marlin_auto_params("MoE", params);
     return params;
   }
@@ -2283,13 +2257,12 @@ inline Sm70MarlinAutoParams sm70_marlin_moe_auto_stage_params(
     validate_sm70_marlin_auto_params("MoE", params);
     return params;
   }
-  if (sm70_marlin_moe_try_select_cyankiwi_glm_4_7_awq_4bit_params(
-          ctx, params)) {
+  if (sm70_marlin_moe_try_select_cyankiwi_glm_4_7_awq_4bit_params(ctx,
+                                                                  params)) {
     validate_sm70_marlin_auto_params("MoE", params);
     return params;
   }
-  if (sm70_marlin_moe_try_select_quanttrio_glm_4_7_awq_params(
-          ctx, params)) {
+  if (sm70_marlin_moe_try_select_quanttrio_glm_4_7_awq_params(ctx, params)) {
     validate_sm70_marlin_auto_params("MoE", params);
     return params;
   }
@@ -2303,46 +2276,44 @@ inline bool sm70_marlin_moe_cta_geometry_is_supported(
          sm70_marlin_cta_geometry_is_supported(geometry);
 }
 
-inline void validate_sm70_marlin_moe_stage_cta_geometry_supported(char const* op_name,
-                                                                  Sm70CtaGeometry geometry) {
+inline void validate_sm70_marlin_moe_stage_cta_geometry_supported(
+    char const* op_name, Sm70CtaGeometry geometry) {
   TORCH_CHECK(sm70_marlin_moe_cta_geometry_is_supported(geometry),
               "Unsupported SM70 Marlin MoE CTA geometry for ", op_name, ": ",
-              geometry.cta_m, "x", geometry.cta_n, "x", geometry.cta_k,
-              "x", geometry.warps, "x", geometry.warp_m, "x",
-              geometry.warp_n, "x", geometry.warp_k,
-              ". Supported geometries are ",
+              geometry.cta_m, "x", geometry.cta_n, "x", geometry.cta_k, "x",
+              geometry.warps, "x", geometry.warp_m, "x", geometry.warp_n, "x",
+              geometry.warp_k, ". Supported geometries are ",
               kSupportedSm70MarlinMoeCtaGeometries, ".");
 }
 
-inline void validate_sm70_marlin_moe_stage_cta_n_alignment(char const* op_name,
-                                                           Sm70CtaGeometry geometry,
-                                                           int64_t size_n) {
+inline void validate_sm70_marlin_moe_stage_cta_n_alignment(
+    char const* op_name, Sm70CtaGeometry geometry, int64_t size_n) {
   TORCH_CHECK(
       size_n % geometry.cta_n == 0 && size_n % kQuantTileN == 0,
       "SM70 Marlin MoE requires size_n divisible by both CTA_N and 64 for ",
-      op_name, " with CTA geometry ", geometry.cta_m, "x", geometry.cta_n,
-      "x", geometry.cta_k, "x", geometry.warps, "x", geometry.warp_m,
-      "x", geometry.warp_n, "x", geometry.warp_k, ". Got size_n = ",
-      size_n, ".");
+      op_name, " with CTA geometry ", geometry.cta_m, "x", geometry.cta_n, "x",
+      geometry.cta_k, "x", geometry.warps, "x", geometry.warp_m, "x",
+      geometry.warp_n, "x", geometry.warp_k, ". Got size_n = ", size_n, ".");
 }
 
 template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM, int WarpN,
           int WarpK, int PackedMacroN, typename Launcher>
-torch::Tensor dispatch_sm70_marlin_moe_group_size(
-    Launcher const& launcher, int64_t group_size, char const* quant_name) {
+torch::Tensor dispatch_sm70_marlin_moe_group_size(Launcher const& launcher,
+                                                  int64_t group_size,
+                                                  char const* quant_name) {
   switch (group_size) {
     case -1:
-      return launcher.template operator()<CtaM, CtaN, CtaK, Warps, WarpM,
-                                          WarpN, WarpK, -1, PackedMacroN>();
+      return launcher.template operator()<CtaM, CtaN, CtaK, Warps, WarpM, WarpN,
+                                          WarpK, -1, PackedMacroN>();
     case 32:
-      return launcher.template operator()<CtaM, CtaN, CtaK, Warps, WarpM,
-                                          WarpN, WarpK, 32, PackedMacroN>();
+      return launcher.template operator()<CtaM, CtaN, CtaK, Warps, WarpM, WarpN,
+                                          WarpK, 32, PackedMacroN>();
     case 64:
-      return launcher.template operator()<CtaM, CtaN, CtaK, Warps, WarpM,
-                                          WarpN, WarpK, 64, PackedMacroN>();
+      return launcher.template operator()<CtaM, CtaN, CtaK, Warps, WarpM, WarpN,
+                                          WarpK, 64, PackedMacroN>();
     case 128:
-      return launcher.template operator()<CtaM, CtaN, CtaK, Warps, WarpM,
-                                          WarpN, WarpK, 128, PackedMacroN>();
+      return launcher.template operator()<CtaM, CtaN, CtaK, Warps, WarpM, WarpN,
+                                          WarpK, 128, PackedMacroN>();
     default:
       TORCH_CHECK(false, "SM70 Marlin MoE ", quant_name,
                   " supports only group_size -1, 32, 64, or 128. Got ",
@@ -2357,17 +2328,17 @@ torch::Tensor dispatch_sm70_marlin_moe_group_size_with_group32(
     Launcher const& launcher, int64_t group_size, char const* quant_name) {
   switch (group_size) {
     case -1:
-      return launcher.template operator()<CtaM, CtaN, CtaK, Warps, WarpM,
-                                          WarpN, WarpK, -1, PackedMacroN>();
+      return launcher.template operator()<CtaM, CtaN, CtaK, Warps, WarpM, WarpN,
+                                          WarpK, -1, PackedMacroN>();
     case 32:
-      return launcher.template operator()<CtaM, CtaN, CtaK, Warps, WarpM,
-                                          WarpN, WarpK, 32, PackedMacroN>();
+      return launcher.template operator()<CtaM, CtaN, CtaK, Warps, WarpM, WarpN,
+                                          WarpK, 32, PackedMacroN>();
     case 64:
-      return launcher.template operator()<CtaM, CtaN, CtaK, Warps, WarpM,
-                                          WarpN, WarpK, 64, PackedMacroN>();
+      return launcher.template operator()<CtaM, CtaN, CtaK, Warps, WarpM, WarpN,
+                                          WarpK, 64, PackedMacroN>();
     case 128:
-      return launcher.template operator()<CtaM, CtaN, CtaK, Warps, WarpM,
-                                          WarpN, WarpK, 128, PackedMacroN>();
+      return launcher.template operator()<CtaM, CtaN, CtaK, Warps, WarpM, WarpN,
+                                          WarpK, 128, PackedMacroN>();
     default:
       TORCH_CHECK(false, "SM70 Marlin MoE ", quant_name,
                   " supports only group_size -1, 32, 64, or 128. Got ",
@@ -2378,15 +2349,15 @@ torch::Tensor dispatch_sm70_marlin_moe_group_size_with_group32(
 
 template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM, int WarpN,
           int WarpK, int PackedMacroN, typename Launcher>
-torch::Tensor dispatch_sm70_marlin_moe_fp8_group_size(
-    Launcher const& launcher, int64_t group_size) {
+torch::Tensor dispatch_sm70_marlin_moe_fp8_group_size(Launcher const& launcher,
+                                                      int64_t group_size) {
   switch (group_size) {
     case -1:
-      return launcher.template operator()<CtaM, CtaN, CtaK, Warps, WarpM,
-                                          WarpN, WarpK, -1, PackedMacroN>();
+      return launcher.template operator()<CtaM, CtaN, CtaK, Warps, WarpM, WarpN,
+                                          WarpK, -1, PackedMacroN>();
     case 128:
-      return launcher.template operator()<CtaM, CtaN, CtaK, Warps, WarpM,
-                                          WarpN, WarpK, 128, PackedMacroN>();
+      return launcher.template operator()<CtaM, CtaN, CtaK, Warps, WarpM, WarpN,
+                                          WarpK, 128, PackedMacroN>();
     default:
       TORCH_CHECK(false,
                   "SM70 Marlin MoE fp8_e4m3 supports only group_size -1 "
@@ -2448,10 +2419,9 @@ struct Sm70MarlinMoeFp8GroupSizeDispatchLauncher {
   template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM, int WarpN,
             int WarpK, int PackedMacroN>
   torch::Tensor operator()() const {
-    return dispatch_sm70_marlin_moe_fp8_group_size<CtaM, CtaN, CtaK, Warps,
-                                                   WarpM, WarpN, WarpK,
-                                                   PackedMacroN>(
-        inner, group_size);
+    return dispatch_sm70_marlin_moe_fp8_group_size<
+        CtaM, CtaN, CtaK, Warps, WarpM, WarpN, WarpK, PackedMacroN>(inner,
+                                                                    group_size);
   }
 };
 
@@ -2465,59 +2435,59 @@ struct Sm70MarlinMoeFixedGroupSizeDispatchLauncher {
             int WarpK, int PackedMacroN>
   torch::Tensor operator()() const {
     return dispatch_sm70_marlin_moe_fixed_group_size<
-        CtaM, CtaN, CtaK, Warps, WarpM, WarpN, WarpK, GroupSize,
-        PackedMacroN>(inner, group_size, quant_name);
+        CtaM, CtaN, CtaK, Warps, WarpM, WarpN, WarpK, GroupSize, PackedMacroN>(
+        inner, group_size, quant_name);
   }
 };
 
 template <typename Launcher>
-torch::Tensor dispatch_sm70_marlin_moe_cta_geometry(
-    Launcher const& launcher, Sm70CtaGeometry geometry, int packed_macro_n,
-    char const* quant_name) {
-#define DISPATCH_SM70_MOE_PACKED_MACRO_N(CM, CN, CK, W, WM, WN, WK, PMN)  \
+torch::Tensor dispatch_sm70_marlin_moe_cta_geometry(Launcher const& launcher,
+                                                    Sm70CtaGeometry geometry,
+                                                    int packed_macro_n,
+                                                    char const* quant_name) {
+#define DISPATCH_SM70_MOE_PACKED_MACRO_N(CM, CN, CK, W, WM, WN, WK, PMN)   \
   if (packed_macro_n == PMN) {                                             \
     return launcher.template operator()<CM, CN, CK, W, WM, WN, WK, PMN>(); \
   }
 
-#define DISPATCH_SM70_MOE_GEOMETRY(CM, CN, CK, W, WM, WN, WK, PMN)         \
-  if (geometry.cta_m == CM && geometry.cta_n == CN &&                      \
-      geometry.cta_k == CK && geometry.warps == W &&                       \
-      geometry.warp_m == WM && geometry.warp_n == WN &&                    \
-      geometry.warp_k == WK) {                                             \
-    DISPATCH_SM70_MOE_PACKED_MACRO_N(CM, CN, CK, W, WM, WN, WK, PMN)       \
+#define DISPATCH_SM70_MOE_GEOMETRY(CM, CN, CK, W, WM, WN, WK, PMN)             \
+  if (geometry.cta_m == CM && geometry.cta_n == CN && geometry.cta_k == CK &&  \
+      geometry.warps == W && geometry.warp_m == WM && geometry.warp_n == WN && \
+      geometry.warp_k == WK) {                                                 \
+    DISPATCH_SM70_MOE_PACKED_MACRO_N(CM, CN, CK, W, WM, WN, WK, PMN)           \
   }
 
-#define FOR_EACH_SM70_MOE_GEOMETRY(M)                                     \
-  M(32, 64, 32, 4, 32, 32, 16, 128)                                       \
-  M(32, 64, 32, 4, 32, 32, 16, 256)                                       \
-  M(32, 64, 64, 4, 32, 32, 32, 128)                                       \
-  M(32, 64, 64, 4, 32, 32, 32, 256)                                       \
-  M(32, 128, 32, 4, 32, 32, 32, 128)                                      \
-  M(32, 128, 32, 4, 32, 32, 32, 256)                                      \
-  M(32, 128, 32, 4, 32, 64, 16, 128)                                      \
-  M(32, 128, 32, 4, 32, 64, 16, 256)                                      \
-  M(32, 128, 64, 4, 32, 64, 32, 128)                                      \
-  M(32, 128, 64, 4, 32, 64, 32, 256)                                      \
-  M(32, 128, 64, 8, 32, 32, 32, 128)                                      \
-  M(32, 128, 64, 8, 32, 32, 32, 256)                                      \
-  M(32, 128, 64, 8, 32, 64, 16, 128)                                      \
-  M(32, 128, 64, 8, 32, 64, 16, 256)                                      \
-  M(32, 128, 128, 8, 32, 64, 32, 128)                                     \
-  M(32, 128, 128, 8, 32, 64, 32, 256)                                     \
-  M(32, 256, 32, 4, 32, 64, 32, 256)                                      \
-  M(32, 256, 64, 8, 32, 64, 32, 256)                                      \
-  M(64, 64, 32, 4, 32, 32, 32, 64)                                        \
-  M(64, 64, 32, 4, 32, 32, 32, 128)                                       \
-  M(64, 64, 32, 4, 32, 32, 32, 256)                                       \
-  M(64, 128, 32, 4, 32, 64, 32, 128)                                      \
-  M(64, 128, 32, 4, 32, 64, 32, 256)                                      \
-  M(64, 128, 32, 4, 64, 64, 16, 128)                                      \
-  M(64, 128, 32, 4, 64, 64, 16, 256)                                      \
-  M(64, 128, 32, 8, 32, 32, 32, 128)                                      \
-  M(64, 128, 32, 8, 32, 32, 32, 256)                                      \
-  M(64, 128, 64, 4, 64, 64, 32, 128)                                      \
-  M(64, 128, 64, 4, 64, 64, 32, 256)                                      \
-  M(64, 256, 32, 4, 64, 64, 32, 256)                                      \
+#define FOR_EACH_SM70_MOE_GEOMETRY(M) \
+  M(32, 64, 32, 4, 32, 32, 16, 128)   \
+  M(32, 64, 32, 4, 32, 32, 16, 256)   \
+  M(32, 64, 64, 4, 32, 32, 32, 128)   \
+  M(32, 64, 64, 4, 32, 32, 32, 256)   \
+  M(32, 128, 32, 4, 32, 32, 32, 128)  \
+  M(32, 128, 32, 4, 32, 32, 32, 256)  \
+  M(32, 128, 32, 4, 32, 64, 16, 128)  \
+  M(32, 128, 32, 4, 32, 64, 16, 256)  \
+  M(32, 128, 64, 4, 32, 64, 32, 128)  \
+  M(32, 128, 64, 4, 32, 64, 32, 256)  \
+  M(32, 128, 64, 8, 32, 32, 32, 128)  \
+  M(32, 128, 64, 8, 32, 32, 32, 256)  \
+  M(32, 128, 64, 8, 32, 64, 16, 128)  \
+  M(32, 128, 64, 8, 32, 64, 16, 256)  \
+  M(32, 128, 128, 8, 32, 64, 32, 128) \
+  M(32, 128, 128, 8, 32, 64, 32, 256) \
+  M(32, 256, 32, 4, 32, 64, 32, 256)  \
+  M(32, 256, 64, 8, 32, 64, 32, 256)  \
+  M(64, 64, 32, 4, 32, 32, 32, 64)    \
+  M(64, 64, 32, 4, 32, 32, 32, 128)   \
+  M(64, 64, 32, 4, 32, 32, 32, 256)   \
+  M(64, 128, 32, 4, 32, 64, 32, 128)  \
+  M(64, 128, 32, 4, 32, 64, 32, 256)  \
+  M(64, 128, 32, 4, 64, 64, 16, 128)  \
+  M(64, 128, 32, 4, 64, 64, 16, 256)  \
+  M(64, 128, 32, 8, 32, 32, 32, 128)  \
+  M(64, 128, 32, 8, 32, 32, 32, 256)  \
+  M(64, 128, 64, 4, 64, 64, 32, 128)  \
+  M(64, 128, 64, 4, 64, 64, 32, 256)  \
+  M(64, 256, 32, 4, 64, 64, 32, 256)  \
   M(64, 256, 64, 8, 64, 64, 32, 256)
 
   FOR_EACH_SM70_MOE_GEOMETRY(DISPATCH_SM70_MOE_GEOMETRY)
@@ -2537,8 +2507,8 @@ torch::Tensor dispatch_sm70_marlin_moe_geometry(Launcher const& launcher,
                                                 int64_t group_size,
                                                 char const* quant_name) {
   return dispatch_sm70_marlin_moe_cta_geometry(
-      Sm70MarlinMoeGroupSizeDispatchLauncher<Launcher>{
-          launcher, group_size, quant_name},
+      Sm70MarlinMoeGroupSizeDispatchLauncher<Launcher>{launcher, group_size,
+                                                       quant_name},
       geometry, packed_macro_n, quant_name);
 }
 
@@ -2547,18 +2517,18 @@ torch::Tensor dispatch_sm70_marlin_moe_geometry_with_group32(
     Launcher const& launcher, Sm70CtaGeometry geometry, int packed_macro_n,
     int64_t group_size, char const* quant_name) {
   return dispatch_sm70_marlin_moe_cta_geometry(
-      Sm70MarlinMoeGroupSize32DispatchLauncher<Launcher>{
-          launcher, group_size, quant_name},
+      Sm70MarlinMoeGroupSize32DispatchLauncher<Launcher>{launcher, group_size,
+                                                         quant_name},
       geometry, packed_macro_n, quant_name);
 }
 
 template <typename Launcher>
-torch::Tensor dispatch_sm70_marlin_moe_fp8_geometry(
-    Launcher const& launcher, Sm70CtaGeometry geometry, int packed_macro_n,
-    int64_t group_size) {
+torch::Tensor dispatch_sm70_marlin_moe_fp8_geometry(Launcher const& launcher,
+                                                    Sm70CtaGeometry geometry,
+                                                    int packed_macro_n,
+                                                    int64_t group_size) {
   return dispatch_sm70_marlin_moe_cta_geometry(
-      Sm70MarlinMoeFp8GroupSizeDispatchLauncher<Launcher>{launcher,
-                                                          group_size},
+      Sm70MarlinMoeFp8GroupSizeDispatchLauncher<Launcher>{launcher, group_size},
       geometry, packed_macro_n, "fp8_e4m3");
 }
 
@@ -2603,8 +2573,8 @@ class Sm70MoeGatherIteratorA {
   using Element = cutlass::half_t;
   using Layout = cutlass::layout::RowMajor;
   using TensorCoord = cutlass::MatrixCoord;
-  using Fragment = cutlass::Array<
-      Element, ThreadMap::Iterations::kCount * ThreadMap::kElementsPerAccess>;
+  using Fragment = cutlass::Array<Element, ThreadMap::Iterations::kCount *
+                                               ThreadMap::kElementsPerAccess>;
   struct Params {
     int lda;
     int moe_block_size;
@@ -2689,9 +2659,8 @@ class Sm70MoeGatherIteratorA {
 
     CUTLASS_PRAGMA_UNROLL
     for (int s = 0; s < ThreadMap::Iterations::kStrided; ++s) {
-      int const local_row =
-          local_m_offset_ + thread_offset_.strided() +
-          s * ThreadMap::Delta::kStrided;
+      int const local_row = local_m_offset_ + thread_offset_.strided() +
+                            s * ThreadMap::Delta::kStrided;
       int const route_row = moe_block_ * params_.moe_block_size + local_row;
 
       int sorted_id = -1;
@@ -2699,20 +2668,17 @@ class Sm70MoeGatherIteratorA {
                        route_row < params_.padded_tokens;
       if (valid_row) {
         sorted_id = sorted_token_ids_[route_row];
-        valid_row =
-            sorted_id >= 0 && sorted_id < params_.expanded_token_count;
+        valid_row = sorted_id >= 0 && sorted_id < params_.expanded_token_count;
       }
 
       int const token_row = valid_row ? (sorted_id / params_.top_k) : 0;
 
       CUTLASS_PRAGMA_UNROLL
       for (int c = 0; c < ThreadMap::Iterations::kContiguous; ++c) {
-        int const logical_k =
-            k_offset_ + thread_offset_.contiguous() +
-            c * ThreadMap::Delta::kContiguous;
-        int const frag_base =
-            (c + s * ThreadMap::Iterations::kContiguous) *
-            ThreadMap::kElementsPerAccess;
+        int const logical_k = k_offset_ + thread_offset_.contiguous() +
+                              c * ThreadMap::Delta::kContiguous;
+        int const frag_base = (c + s * ThreadMap::Iterations::kContiguous) *
+                              ThreadMap::kElementsPerAccess;
         bool const valid = valid_row && logical_k < params_.lda;
 
         CUTLASS_PRAGMA_UNROLL
@@ -2754,8 +2720,8 @@ struct Sm70MarlinMoeGemmTraits {
   using LayoutB = cutlass::layout::RowMajor;
   using LayoutC = cutlass::layout::RowMajor;
   using ThreadblockShape = cutlass::gemm::GemmShape<CtaM, CtaN, CtaK>;
-  using WarpShape =
-      typename Sm70WarpShape<CtaM, CtaN, CtaK, Warps, WarpM, WarpN, WarpK>::Type;
+  using WarpShape = typename Sm70WarpShape<CtaM, CtaN, CtaK, Warps, WarpM,
+                                           WarpN, WarpK>::Type;
   static_assert(WarpShape::kM <= 64 && WarpShape::kN <= 64,
                 "SM70 Marlin MoE keeps per-warp M/N no larger than 64.");
   using InstructionShape = cutlass::gemm::GemmShape<8, 8, 4>;
@@ -2763,13 +2729,16 @@ struct Sm70MarlinMoeGemmTraits {
       ThreadblockShape, WarpShape, InstructionShape, ElementA, LayoutA,
       ElementB, LayoutB, ElementAccumulator, LayoutC,
       cutlass::arch::OpClassTensorOp, 2, cutlass::arch::OpMultiplyAdd>;
-  static_assert(MmaCore::kThreads == Warps * 32,
-                "SM70 Marlin MoE launch threads must match CUTLASS warp count.");
-  using IteratorA = typename Spec::template IteratorA<
-      ThreadblockShape, typename MmaCore::IteratorThreadMapA>;
-  using IteratorB = typename Spec::template IteratorB<
-      ThreadblockShape, typename MmaCore::IteratorThreadMapB, GroupSize,
-      PackedMacroN>;
+  static_assert(
+      MmaCore::kThreads == Warps * 32,
+      "SM70 Marlin MoE launch threads must match CUTLASS warp count.");
+  using IteratorA =
+      typename Spec::template IteratorA<ThreadblockShape,
+                                        typename MmaCore::IteratorThreadMapA>;
+  using IteratorB =
+      typename Spec::template IteratorB<ThreadblockShape,
+                                        typename MmaCore::IteratorThreadMapB,
+                                        GroupSize, PackedMacroN>;
   using Mma = Sm70MarlinMmaPipelined<
       ThreadblockShape, IteratorA, typename MmaCore::SmemIteratorA, IteratorB,
       typename MmaCore::SmemIteratorB, ElementAccumulator, LayoutC,
@@ -2818,11 +2787,11 @@ class Sm70MoeScatterEpilogue {
                       typename SharedLoadIterator::Fragment const& frag,
                       int32_t const* __restrict__ sorted_token_ids,
                       float const* __restrict__ topk_weights,
-                      cutlass::half_t* __restrict__ c,
-                      int n, int moe_block, int local_m_offset,
-                      int moe_block_size, int expanded_token_count,
-                      int padded_tokens, bool mul_topk_weights,
-                      bool atomic_store, float output_scale) const {
+                      cutlass::half_t* __restrict__ c, int n, int moe_block,
+                      int local_m_offset, int moe_block_size,
+                      int expanded_token_count, int padded_tokens,
+                      bool mul_topk_weights, bool atomic_store,
+                      float output_scale) const {
     float const* frag_ptr = reinterpret_cast<float const*>(&frag);
     half* c_half = reinterpret_cast<half*>(c);
     int const thread_start_row = destination_iterator.thread_start_row();
@@ -2838,20 +2807,17 @@ class Sm70MoeScatterEpilogue {
           int const frag_row_idx =
               row + ThreadMap::Iterations::kRow *
                         (group + ThreadMap::Iterations::kGroup * cluster);
-          int const row_offset =
-              row * ThreadMap::Delta::kRow +
-              group * ThreadMap::Delta::kGroup +
-              cluster * ThreadMap::Delta::kCluster;
-          int const local_row =
-              local_m_offset + thread_start_row + row_offset;
+          int const row_offset = row * ThreadMap::Delta::kRow +
+                                 group * ThreadMap::Delta::kGroup +
+                                 cluster * ThreadMap::Delta::kCluster;
+          int const local_row = local_m_offset + thread_start_row + row_offset;
           int const route_row = moe_block * moe_block_size + local_row;
           bool valid_row =
               local_row < moe_block_size && route_row < padded_tokens;
           int sorted_id = -1;
           if (valid_row) {
             sorted_id = sorted_token_ids[route_row];
-            valid_row =
-                sorted_id >= 0 && sorted_id < expanded_token_count;
+            valid_row = sorted_id >= 0 && sorted_id < expanded_token_count;
           }
           float const route_scale =
               (valid_row && mul_topk_weights) ? topk_weights[sorted_id] : 1.0f;
@@ -2896,8 +2862,7 @@ class Sm70MoeScatterEpilogue {
     int const warp_mn = warp_idx % (WarpCount::kM * WarpCount::kN);
     int const warp_m = warp_mn % WarpCount::kM;
     int const warp_n = warp_mn / WarpCount::kM;
-    cutlass::MatrixCoord warp_offset{warp_k * WarpCount::kM + warp_m,
-                                     warp_n};
+    cutlass::MatrixCoord warp_offset{warp_k * WarpCount::kM + warp_m, warp_n};
     warp_tile_iterator_.add_tile_offset(warp_offset);
   }
 
@@ -2906,11 +2871,11 @@ class Sm70MoeScatterEpilogue {
                   AccumulatorTile const& accumulators,
                   int32_t const* __restrict__ sorted_token_ids,
                   float const* __restrict__ topk_weights,
-                  cutlass::half_t* __restrict__ c,
-                  int n, int moe_block, int local_m_offset,
-                  int moe_block_size, int expanded_token_count,
-                  int padded_tokens, bool mul_topk_weights,
-                  bool atomic_store, float output_scale = 1.0f) {
+                  cutlass::half_t* __restrict__ c, int n, int moe_block,
+                  int local_m_offset, int moe_block_size,
+                  int expanded_token_count, int padded_tokens,
+                  bool mul_topk_weights, bool atomic_store,
+                  float output_scale = 1.0f) {
     AccumulatorFragmentIterator accum_fragment_iterator(accumulators);
 
     CUTLASS_PRAGMA_UNROLL
@@ -2956,19 +2921,19 @@ class Sm70MoeScatterEpilogue {
 };
 
 template <typename Traits, bool SplitK>
-__global__ __launch_bounds__(Traits::MmaCore::kThreads, 1)
-void sm70_marlin_moe_gemm_kernel(
+__global__
+__launch_bounds__(Traits::MmaCore::kThreads, 1) void sm70_marlin_moe_gemm_kernel(
     cutlass::half_t const* __restrict__ a,
     uint32_t const* __restrict__ b_q_weight,
     typename Traits::GemmSpec::ScaleElement const* __restrict__ b_scales,
     typename Traits::GemmSpec::ZeroElement const* __restrict__ b_zeros,
-    float const* __restrict__ global_scale,
-    cutlass::half_t* __restrict__ c,
+    float const* __restrict__ global_scale, cutlass::half_t* __restrict__ c,
     int32_t const* __restrict__ sorted_token_ids,
     int32_t const* __restrict__ expert_ids,
     int32_t const* __restrict__ num_tokens_past_padded,
     float const* __restrict__ topk_weights, int moe_block_size, int top_k,
-    bool mul_topk_weights, int m, int n, int k, int lda, int requested_split_k) {
+    bool mul_topk_weights, int m, int n, int k, int lda,
+    int requested_split_k) {
   using Mma = typename Traits::Mma;
   using Epilogue = Sm70MoeScatterEpilogue<Traits>;
   constexpr int CtaM = Traits::ThreadblockShape::kM;
@@ -3002,8 +2967,8 @@ void sm70_marlin_moe_gemm_kernel(
   int partition_k = k;
   if constexpr (SplitK) {
     Sm70SplitKPartition const partition =
-        sm70_splitk_partition<Traits::kGroupSize, CtaK>(
-            k, requested_split_k, int(blockIdx.z));
+        sm70_splitk_partition<Traits::kGroupSize, CtaK>(k, requested_split_k,
+                                                        int(blockIdx.z));
     if (partition.partition_k == 0) {
       return;
     }
@@ -3014,8 +2979,8 @@ void sm70_marlin_moe_gemm_kernel(
   int const n_offset = int(blockIdx.y) * CtaN;
 
   typename Mma::IteratorA iterator_A(
-      typename Mma::IteratorA::Params(lda, moe_block_size, top_k, m,
-                                      m * top_k, padded_tokens),
+      typename Mma::IteratorA::Params(lda, moe_block_size, top_k, m, m * top_k,
+                                      padded_tokens),
       a, sorted_token_ids, thread_idx, moe_block, local_m_offset, k_begin);
   typename Mma::IteratorB iterator_B(
       typename Mma::IteratorB::Params(k, n),
@@ -3042,8 +3007,8 @@ void sm70_marlin_moe_gemm_kernel(
   }
   Epilogue epilogue(shared_storage.epilogue, thread_idx, warp_idx, lane_idx);
   epilogue(iterator_D, accumulators, sorted_token_ids, topk_weights, c, n,
-           moe_block, local_m_offset, moe_block_size, m * top_k,
-           padded_tokens, mul_topk_weights, SplitK, output_scale);
+           moe_block, local_m_offset, moe_block_size, m * top_k, padded_tokens,
+           mul_topk_weights, SplitK, output_scale);
 }
 
 template <typename Traits>
@@ -3103,9 +3068,9 @@ torch::Tensor launch_sm70_marlin_moe_gemm(
   smem_bytes = configure_sm70_dynamic_smem<SharedStorage>(split_kernel);
 
   int64_t const numel = size_m * top_k * size_n;
-  C10_CUDA_CHECK(cudaMemsetAsync(
-      c.data_ptr<at::Half>(), 0,
-      static_cast<size_t>(numel) * sizeof(at::Half), stream));
+  C10_CUDA_CHECK(cudaMemsetAsync(c.data_ptr<at::Half>(), 0,
+                                 static_cast<size_t>(numel) * sizeof(at::Half),
+                                 stream));
 
   int const active_split_k =
       sm70_active_split_k(static_cast<int>(size_k), requested_split_k, CtaK);
@@ -3115,11 +3080,11 @@ torch::Tensor launch_sm70_marlin_moe_gemm(
       reinterpret_cast<uint32_t const*>(b_q_weight.data_ptr<int32_t>()),
       b_scales_ptr, b_zeros_ptr, global_scale_ptr,
       reinterpret_cast<cutlass::half_t*>(c.data_ptr<at::Half>()),
-      sorted_token_ids.data_ptr<int32_t>(),
-      expert_ids.data_ptr<int32_t>(), num_tokens_past_padded.data_ptr<int32_t>(),
+      sorted_token_ids.data_ptr<int32_t>(), expert_ids.data_ptr<int32_t>(),
+      num_tokens_past_padded.data_ptr<int32_t>(),
       topk_weights.data_ptr<float>(), int(moe_block_size), int(top_k),
-      mul_topk_weights, int(size_m), int(size_n), int(size_k),
-      int(a.stride(0)), requested_split_k);
+      mul_topk_weights, int(size_m), int(size_n), int(size_k), int(a.stride(0)),
+      requested_split_k);
   C10_CUDA_KERNEL_LAUNCH_CHECK();
   return c;
 }

--- a/csrc/moe/marlin_moe_wna16/sm70_marlin_moe_dispatch.cu
+++ b/csrc/moe/marlin_moe_wna16/sm70_marlin_moe_dispatch.cu
@@ -43,15 +43,13 @@ __device__ __forceinline__ int sm70_inverse_zp_interleave(int idx,
   return inv[idx];
 }
 
-__device__ __forceinline__ int sm70_inverse_scale_perm(int idx,
-                                                       int perm_len) {
+__device__ __forceinline__ int sm70_inverse_scale_perm(int idx, int perm_len) {
   if (perm_len == 64) {
     return (idx % 8) * 8 + idx / 8;
   }
-  constexpr int inv[32] = {0,  1,  8,  9,  16, 17, 24, 25,
-                           2,  3,  10, 11, 18, 19, 26, 27,
-                           4,  5,  12, 13, 20, 21, 28, 29,
-                           6,  7,  14, 15, 22, 23, 30, 31};
+  constexpr int inv[32] = {0,  1,  8,  9,  16, 17, 24, 25, 2,  3,  10,
+                           11, 18, 19, 26, 27, 4,  5,  12, 13, 20, 21,
+                           28, 29, 6,  7,  14, 15, 22, 23, 30, 31};
   return inv[idx];
 }
 
@@ -66,10 +64,9 @@ __global__ void sm70_unpermute_half_metadata_kernel(
 }
 
 __global__ void sm70_unpack_moe_zp_to_half_kernel(
-    const int32_t* __restrict__ packed_zp,
-    const half* __restrict__ scales, half* __restrict__ out,
-    int64_t total, int64_t num_groups, int64_t size_n, int64_t packed_n,
-    int num_bits, bool is_a_8bit) {
+    const int32_t* __restrict__ packed_zp, const half* __restrict__ scales,
+    half* __restrict__ out, int64_t total, int64_t num_groups, int64_t size_n,
+    int64_t packed_n, int num_bits, bool is_a_8bit) {
   const int64_t idx = blockIdx.x * blockDim.x + threadIdx.x;
   if (idx >= total) return;
 
@@ -83,15 +80,14 @@ __global__ void sm70_unpack_moe_zp_to_half_kernel(
   if (!is_a_8bit) {
     packed_col_in_block =
         (packed_col_in_block / pack_factor) * pack_factor +
-        sm70_inverse_zp_interleave(packed_col_in_block % pack_factor,
-                                   num_bits);
+        sm70_inverse_zp_interleave(packed_col_in_block % pack_factor, num_bits);
   }
   const int64_t packed_col = block64 * 64 + packed_col_in_block;
-  const uint32_t word = reinterpret_cast<const uint32_t*>(packed_zp)
-      [(expert * num_groups + group) * packed_n + packed_col / pack_factor];
-  const uint32_t zp =
-      (word >> ((packed_col % pack_factor) * num_bits)) &
-      ((1u << num_bits) - 1u);
+  const uint32_t word = reinterpret_cast<const uint32_t*>(
+      packed_zp)[(expert * num_groups + group) * packed_n +
+                 packed_col / pack_factor];
+  const uint32_t zp = (word >> ((packed_col % pack_factor) * num_bits)) &
+                      ((1u << num_bits) - 1u);
   out[idx] = __float2half(static_cast<float>(zp) * __half2float(scales[idx]));
 }
 
@@ -111,8 +107,8 @@ torch::Tensor sm70_moe_scales_as_logical(torch::Tensor const& b_scales,
   const int64_t total = out.numel();
   constexpr int threads = 256;
   const int blocks = static_cast<int>((total + threads - 1) / threads);
-  sm70_unpermute_half_metadata_kernel<<<
-      blocks, threads, 0, at::cuda::getCurrentCUDAStream()>>>(
+  sm70_unpermute_half_metadata_kernel<<<blocks, threads, 0,
+                                        at::cuda::getCurrentCUDAStream()>>>(
       reinterpret_cast<const half*>(b_scales.data_ptr<at::Half>()),
       reinterpret_cast<half*>(out.data_ptr<at::Half>()), total, perm_len);
   C10_CUDA_KERNEL_LAUNCH_CHECK();
@@ -120,9 +116,8 @@ torch::Tensor sm70_moe_scales_as_logical(torch::Tensor const& b_scales,
 }
 
 torch::Tensor sm70_moe_zp_as_half(torch::Tensor const& b_zeros,
-                                  torch::Tensor const& b_scales,
-                                  int64_t size_n, int num_bits,
-                                  bool is_a_8bit) {
+                                  torch::Tensor const& b_scales, int64_t size_n,
+                                  int num_bits, bool is_a_8bit) {
   if (b_zeros.scalar_type() == at::ScalarType::Half) {
     return b_zeros;
   }
@@ -143,14 +138,13 @@ torch::Tensor sm70_moe_zp_as_half(torch::Tensor const& b_zeros,
   TORCH_CHECK(b_scales.scalar_type() == at::ScalarType::Half,
               "SM70 Marlin MoE packed zero-point adapter expects fp16 scales.");
 
-  auto out =
-      torch::empty({b_scales.size(0), b_scales.size(1), size_n},
-                   b_scales.options());
+  auto out = torch::empty({b_scales.size(0), b_scales.size(1), size_n},
+                          b_scales.options());
   const int64_t total = out.numel();
   constexpr int threads = 256;
   const int blocks = static_cast<int>((total + threads - 1) / threads);
-  sm70_unpack_moe_zp_to_half_kernel<<<
-      blocks, threads, 0, at::cuda::getCurrentCUDAStream()>>>(
+  sm70_unpack_moe_zp_to_half_kernel<<<blocks, threads, 0,
+                                      at::cuda::getCurrentCUDAStream()>>>(
       b_zeros.data_ptr<int32_t>(),
       reinterpret_cast<const half*>(b_scales.data_ptr<at::Half>()),
       reinterpret_cast<half*>(out.data_ptr<at::Half>()), total,
@@ -229,8 +223,7 @@ torch::Tensor moe_wna16_marlin_gemm(
     std::optional<torch::Tensor> const& global_scale_or_none,
     std::optional<torch::Tensor> const& b_zeros_or_none,
     std::optional<torch::Tensor> const& g_idx_or_none,
-    std::optional<torch::Tensor> const& perm_or_none,
-    torch::Tensor& workspace,
+    std::optional<torch::Tensor> const& perm_or_none, torch::Tensor& workspace,
     torch::Tensor& sorted_token_ids, torch::Tensor& expert_ids,
     torch::Tensor& num_tokens_past_padded, torch::Tensor& topk_weights,
     int64_t moe_block_size, int64_t top_k, bool mul_topk_weights,
@@ -308,8 +301,7 @@ torch::Tensor moe_wna16_marlin_gemm(
               "SM70 Marlin MoE supports only float16 outputs.");
   TORCH_CHECK(s_type == vllm::kFloat16 ||
                   (b_type == vllm::kFE2M1f &&
-                   (s_type == vllm::kFE4M3fn ||
-                    s_type == vllm::kFE8M0fnu)),
+                   (s_type == vllm::kFE4M3fn || s_type == vllm::kFE8M0fnu)),
               "SM70 Marlin MoE supports only float16 scales, "
               "except FP4 uses float8_e4m3fn scales for NVFP4 or "
               "float8_e8m0fnu scales for MXFP4.");
@@ -364,10 +356,8 @@ torch::Tensor moe_wna16_marlin_gemm(
   TORCH_CHECK(b_scales.is_contiguous(), "b_scales is not contiguous");
   TORCH_CHECK(b_scales.scalar_type() == at::ScalarType::Half ||
                   (b_type == vllm::kFE2M1f &&
-                   (b_scales.scalar_type() ==
-                        at::ScalarType::Float8_e4m3fn ||
-                    b_scales.scalar_type() ==
-                        at::ScalarType::Float8_e8m0fnu)),
+                   (b_scales.scalar_type() == at::ScalarType::Float8_e4m3fn ||
+                    b_scales.scalar_type() == at::ScalarType::Float8_e8m0fnu)),
               "SM70 Marlin MoE supports float16 scales, except FP4 uses "
               "float8_e4m3fn scales for NVFP4 or float8_e8m0fnu scales for "
               "MXFP4.");
@@ -457,17 +447,15 @@ torch::Tensor moe_wna16_marlin_gemm(
 
   torch::Tensor b_scales_kernel = b_scales;
   if (b_scales.scalar_type() == at::ScalarType::Half) {
-    b_scales_kernel =
-        sm70_moe_scales_as_logical(b_scales, size_k, group_size,
-                                   a_type.size_bits() == 8);
+    b_scales_kernel = sm70_moe_scales_as_logical(b_scales, size_k, group_size,
+                                                 a_type.size_bits() == 8);
   }
 
   torch::Tensor global_scale;
   if (global_scale_or_none.has_value()) {
     global_scale = global_scale_or_none.value();
-    TORCH_CHECK(
-        b_type == vllm::kFE2M1f && s_type == vllm::kFE4M3fn,
-        "SM70 Marlin MoE supports global_scale only for nvfp4 format.");
+    TORCH_CHECK(b_type == vllm::kFE2M1f && s_type == vllm::kFE4M3fn,
+                "SM70 Marlin MoE supports global_scale only for nvfp4 format.");
     TORCH_CHECK(global_scale.device().is_cuda(), "global_scale is not on GPU");
     TORCH_CHECK(global_scale.is_contiguous(), "global_scale is not contiguous");
     TORCH_CHECK(global_scale.scalar_type() == at::ScalarType::Float,
@@ -510,9 +498,9 @@ torch::Tensor moe_wna16_marlin_gemm(
                 "weights when zero-points are enabled. Got = ",
                 b_type.str());
     if (!is_zp_float && b_zeros.scalar_type() == at::ScalarType::Int) {
-      b_zeros = sm70_moe_zp_as_half(
-          b_zeros, b_scales_kernel, size_n, b_type == vllm::kU4 ? 4 : 8,
-          a_type.size_bits() == 8);
+      b_zeros = sm70_moe_zp_as_half(b_zeros, b_scales_kernel, size_n,
+                                    b_type == vllm::kU4 ? 4 : 8,
+                                    a_type.size_bits() == 8);
       zp_is_float = true;
     }
   } else {
@@ -535,8 +523,7 @@ torch::Tensor moe_wna16_marlin_gemm(
     TORCH_CHECK(num_groups == b_zeros.size(1),
                 "b_zeros dim 1 = ", b_zeros.size(1),
                 " is not num_groups = ", num_groups);
-    TORCH_CHECK(b_zeros.size(2) == size_n,
-                "b_zeros dim 2 = ", b_zeros.size(2),
+    TORCH_CHECK(b_zeros.size(2) == size_n, "b_zeros dim 2 = ", b_zeros.size(2),
                 " is not size_n = ", size_n);
   } else {
     TORCH_CHECK(!zp_is_float,
@@ -559,20 +546,18 @@ torch::Tensor moe_wna16_marlin_gemm(
 
   TORCH_CHECK(!has_act_order,
               "act_order is not supported for the SM70 Marlin MoE path.");
-  TORCH_CHECK(!has_bias,
-              "SM70 Marlin MoE does not support bias.");
+  TORCH_CHECK(!has_bias, "SM70 Marlin MoE does not support bias.");
   TORCH_CHECK(!use_atomic_add,
               "SM70 Marlin MoE does not support atomic-add "
               "output.");
-  TORCH_CHECK(is_k_full,
-              "SM70 Marlin MoE requires full-K inputs.");
+  TORCH_CHECK(is_k_full, "SM70 Marlin MoE requires full-K inputs.");
 
   if (b_type == vllm::kU4) {
     TORCH_CHECK(has_zp && zp_is_float,
                 "SM70 Marlin MoE uint4 path requires fp16 zero points.");
     return MARLIN_NAMESPACE_NAME::sm70_marlin_u4_gemm(
-        a, c, b_q_weight, b_scales_kernel, b_zeros, sorted_token_ids, expert_ids,
-        num_tokens_past_padded, topk_weights, moe_block_size, top_k,
+        a, c, b_q_weight, b_scales_kernel, b_zeros, sorted_token_ids,
+        expert_ids, num_tokens_past_padded, topk_weights, moe_block_size, top_k,
         mul_topk_weights, size_m, size_n, size_k, group_size);
   }
 
@@ -580,8 +565,8 @@ torch::Tensor moe_wna16_marlin_gemm(
     TORCH_CHECK(has_zp && zp_is_float,
                 "SM70 Marlin MoE uint8 path requires fp16 zero points.");
     return MARLIN_NAMESPACE_NAME::sm70_marlin_u8_gemm(
-        a, c, b_q_weight, b_scales_kernel, b_zeros, sorted_token_ids, expert_ids,
-        num_tokens_past_padded, topk_weights, moe_block_size, top_k,
+        a, c, b_q_weight, b_scales_kernel, b_zeros, sorted_token_ids,
+        expert_ids, num_tokens_past_padded, topk_weights, moe_block_size, top_k,
         mul_topk_weights, size_m, size_n, size_k, group_size);
   }
 
@@ -622,8 +607,9 @@ torch::Tensor moe_wna16_marlin_gemm(
     TORCH_CHECK(!has_zp && !is_zp_float,
                 "SM70 Marlin MoE fp4 does not support zero-point metadata.");
     if (s_type == vllm::kFE4M3fn) {
-      TORCH_CHECK(global_scale.numel() == num_experts,
-                  "the global_scale parameter must be passed for nvfp4 format.");
+      TORCH_CHECK(
+          global_scale.numel() == num_experts,
+          "the global_scale parameter must be passed for nvfp4 format.");
       TORCH_CHECK(group_size == 16,
                   "SM70 Marlin MoE NVFP4 supports only group_size 16. "
                   "Got ",

--- a/csrc/moe/marlin_moe_wna16/sm70_marlin_mxfp4_gemm.cu
+++ b/csrc/moe/marlin_moe_wna16/sm70_marlin_mxfp4_gemm.cu
@@ -56,7 +56,8 @@ void dequant_e8m0_scales_to_half2(int q, half2* scale_cache) {
   *reinterpret_cast<uint2*>(scale_cache) = vec_res;
 }
 
-template <typename Shape_, typename ThreadMap_, int GroupSize_, int PackedMacroN_>
+template <typename Shape_, typename ThreadMap_, int GroupSize_,
+          int PackedMacroN_>
 class Sm70MoeMxfp4IteratorB {
  public:
   using Shape = Shape_;
@@ -64,22 +65,25 @@ class Sm70MoeMxfp4IteratorB {
   static int const kGroupSize = GroupSize_;
   static int const kPackedMacroN = PackedMacroN_;
   using Element = cutlass::half_t;
-  using Fragment = cutlass::Array<
-      Element, ThreadMap::Iterations::kCount * ThreadMap::kElementsPerAccess>;
-    static_assert(Shape::kN == 64 || Shape::kN == 128 || Shape::kN == 256,
-                "SM70 Marlin MoE MXFP4 IteratorB expects CTA_N in {64, 128, 256}.");
-  static_assert(ThreadMap::Iterations::kContiguous ==
-                    Shape::kN / kQuantTileN,
-                "SM70 Marlin MoE MXFP4 IteratorB expects one contiguous iteration "
-                "per 64-column quant tile.");
+  using Fragment = cutlass::Array<Element, ThreadMap::Iterations::kCount *
+                                               ThreadMap::kElementsPerAccess>;
+  static_assert(
+      Shape::kN == 64 || Shape::kN == 128 || Shape::kN == 256,
+      "SM70 Marlin MoE MXFP4 IteratorB expects CTA_N in {64, 128, 256}.");
+  static_assert(
+      ThreadMap::Iterations::kContiguous == Shape::kN / kQuantTileN,
+      "SM70 Marlin MoE MXFP4 IteratorB expects one contiguous iteration "
+      "per 64-column quant tile.");
   static_assert(ThreadMap::Delta::kContiguous == kQuantTileN,
                 "SM70 Marlin MoE MXFP4 IteratorB expects 64-column deltas.");
-  static_assert(ThreadMap::kElementsPerAccess == kMxfp4ValuesPerWord,
-                "SM70 Marlin MoE MXFP4 IteratorB expects one packed FP4 word per "
-                "access.");
-  static_assert(ThreadMap::Iterations::kStrided >= 1,
-                "SM70 Marlin MoE U4-family IteratorB expects one or more strided "
-                "iterations.");
+  static_assert(
+      ThreadMap::kElementsPerAccess == kMxfp4ValuesPerWord,
+      "SM70 Marlin MoE MXFP4 IteratorB expects one packed FP4 word per "
+      "access.");
+  static_assert(
+      ThreadMap::Iterations::kStrided >= 1,
+      "SM70 Marlin MoE U4-family IteratorB expects one or more strided "
+      "iterations.");
   struct Params {
     int size_k;
     int size_n;
@@ -90,9 +94,7 @@ class Sm70MoeMxfp4IteratorB {
 
     CUTLASS_HOST_DEVICE
     Params(int size_k_, int size_n_)
-        : size_k(size_k_),
-          size_n(size_n_),
-          num_groups(size_k_ / GroupSize_) {}
+        : size_k(size_k_), size_n(size_n_), num_groups(size_k_ / GroupSize_) {}
   };
 
  private:
@@ -113,9 +115,8 @@ class Sm70MoeMxfp4IteratorB {
                         uint8_t const* scales, half const*, int thread_id,
                         int expert, int k_offset, int n_offset)
       : qweight_(qweight),
-        scales_expert_base_(scales +
-                            (expert >= 0 ? expert : 0) *
-                                params.num_groups * params.size_n),
+        scales_expert_base_(scales + (expert >= 0 ? expert : 0) *
+                                         params.num_groups * params.size_n),
         params_(params),
         thread_offset_(ThreadMap::initial_offset(thread_id)),
         expert_(expert),
@@ -154,9 +155,7 @@ class Sm70MoeMxfp4IteratorB {
   }
 
   CUTLASS_DEVICE
-  int metadata_group_offset(int group) const {
-    return group * params_.size_n;
-  }
+  int metadata_group_offset(int group) const { return group * params_.size_n; }
 
   CUTLASS_DEVICE
   int scale_group(int logical_k) const {
@@ -189,14 +188,12 @@ class Sm70MoeMxfp4IteratorB {
     CUTLASS_PRAGMA_UNROLL
     for (int s = 0; s < ThreadMap::Iterations::kStrided; ++s) {
       int const logical_k =
-          k_offset_ + thread_offset_.strided() +
-          s * ThreadMap::Delta::kStrided;
+          k_offset_ + thread_offset_.strided() + s * ThreadMap::Delta::kStrided;
       int const group = scale_group(logical_k);
       CUTLASS_PRAGMA_UNROLL
       for (int c = 0; c < ThreadMap::Iterations::kContiguous; ++c) {
-        int const cache_n =
-            n_offset_ + thread_offset_.contiguous() +
-            c * ThreadMap::Delta::kContiguous;
+        int const cache_n = n_offset_ + thread_offset_.contiguous() +
+                            c * ThreadMap::Delta::kContiguous;
         int const cache_index = c + s * ThreadMap::Iterations::kContiguous;
         cache_metadata_e8m0_scales(cache_index, group, cache_n);
       }
@@ -249,8 +246,9 @@ class Sm70MoeMxfp4IteratorB {
           frag_vec[3] = __hmul2(deq[1], scale_vec[3]);
         }
       } else {
-        static_assert(ThreadMap::Iterations::kContiguous == 1,
-                      "Unsupported SM70 Marlin MoE MXFP4 contiguous iteration count.");
+        static_assert(
+            ThreadMap::Iterations::kContiguous == 1,
+            "Unsupported SM70 Marlin MoE MXFP4 contiguous iteration count.");
         uint32_t const qword =
             load_qword_vector<1>(qweight_ + qweight_base_offset_);
         half2 const* scale_vec = cached_scales_;
@@ -270,15 +268,13 @@ class Sm70MoeMxfp4IteratorB {
       int const logical_n_base = n_offset_ + thread_offset_.contiguous();
       CUTLASS_PRAGMA_UNROLL
       for (int s = 0; s < ThreadMap::Iterations::kStrided; ++s) {
-        int const logical_k_s =
-            k_offset_ + thread_offset_.strided() +
-            s * ThreadMap::Delta::kStrided;
+        int const logical_k_s = k_offset_ + thread_offset_.strided() +
+                                s * ThreadMap::Delta::kStrided;
         int const qweight_base_s =
             expert_qweight_base_offset() +
             qweight_offset_from_logical(params_, logical_k_s, logical_n_base);
         if constexpr (ThreadMap::Iterations::kContiguous == 4) {
-          auto const qwords =
-              load_qword_vector<4>(qweight_ + qweight_base_s);
+          auto const qwords = load_qword_vector<4>(qweight_ + qweight_base_s);
           CUTLASS_PRAGMA_UNROLL
           for (int c = 0; c < ThreadMap::Iterations::kContiguous; ++c) {
             constexpr int kAccess = ThreadMap::kElementsPerAccess;
@@ -301,8 +297,7 @@ class Sm70MoeMxfp4IteratorB {
             frag_vec[3] = __hmul2(deq[1], scale_vec[3]);
           }
         } else if constexpr (ThreadMap::Iterations::kContiguous == 2) {
-          auto const qwords =
-              load_qword_vector<2>(qweight_ + qweight_base_s);
+          auto const qwords = load_qword_vector<2>(qweight_ + qweight_base_s);
           CUTLASS_PRAGMA_UNROLL
           for (int c = 0; c < ThreadMap::Iterations::kContiguous; ++c) {
             constexpr int kAccess = ThreadMap::kElementsPerAccess;
@@ -325,8 +320,9 @@ class Sm70MoeMxfp4IteratorB {
             frag_vec[3] = __hmul2(deq[1], scale_vec[3]);
           }
         } else {
-          static_assert(ThreadMap::Iterations::kContiguous == 1,
-                        "Unsupported SM70 Marlin MoE MXFP4 contiguous iteration count.");
+          static_assert(
+              ThreadMap::Iterations::kContiguous == 1,
+              "Unsupported SM70 Marlin MoE MXFP4 contiguous iteration count.");
           uint32_t const qword =
               load_qword_vector<1>(qweight_ + qweight_base_s);
           constexpr int kAccess = ThreadMap::kElementsPerAccess;
@@ -369,15 +365,15 @@ struct Sm70MoeMxfp4GemmSpec {
   using IteratorA = Sm70MoeGatherIteratorA<Shape, ThreadMap>;
 
   template <typename Shape, typename ThreadMap, int GroupSize, int PackedMacroN>
-  using IteratorB = Sm70MoeMxfp4IteratorB<Shape, ThreadMap, GroupSize, PackedMacroN>;
+  using IteratorB =
+      Sm70MoeMxfp4IteratorB<Shape, ThreadMap, GroupSize, PackedMacroN>;
 };
 
-template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM,
-          int WarpN, int WarpK, int GroupSize, int PackedMacroN>
+template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM, int WarpN,
+          int WarpK, int GroupSize, int PackedMacroN>
 using Sm70MoeMxfp4GemmTraits =
-    Sm70MarlinMoeGemmTraits<Sm70MoeMxfp4GemmSpec, CtaM, CtaN, CtaK,
-                            Warps, WarpM, WarpN, WarpK, GroupSize,
-                            PackedMacroN>;
+    Sm70MarlinMoeGemmTraits<Sm70MoeMxfp4GemmSpec, CtaM, CtaN, CtaK, Warps,
+                            WarpM, WarpN, WarpK, GroupSize, PackedMacroN>;
 
 struct Sm70MoeMxfp4Launcher {
   torch::Tensor& a;
@@ -398,15 +394,15 @@ struct Sm70MoeMxfp4Launcher {
   int64_t size_k;
   int requested_split_k;
 
-  template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM,
-          int WarpN, int WarpK, int GroupSize, int PackedMacroN>
+  template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM, int WarpN,
+            int WarpK, int GroupSize, int PackedMacroN>
   torch::Tensor operator()() const {
-    using Traits = Sm70MoeMxfp4GemmTraits<CtaM, CtaN, CtaK, Warps, WarpM,
-                                    WarpN, WarpK, GroupSize, PackedMacroN>;
+    using Traits = Sm70MoeMxfp4GemmTraits<CtaM, CtaN, CtaK, Warps, WarpM, WarpN,
+                                          WarpK, GroupSize, PackedMacroN>;
     return launch_sm70_marlin_moe_gemm<Traits>(
         a, c, b_q_weight, b_scales, b_zeros, global_scale, sorted_token_ids,
-        expert_ids, num_tokens_past_padded, topk_weights, moe_block_size,
-        top_k, mul_topk_weights, size_m, size_n, size_k, requested_split_k);
+        expert_ids, num_tokens_past_padded, topk_weights, moe_block_size, top_k,
+        mul_topk_weights, size_m, size_n, size_k, requested_split_k);
   }
 };
 
@@ -424,9 +420,10 @@ torch::Tensor sm70_marlin_mxfp4_gemm(
   auto const params = sm70_marlin_moe_auto_stage_params(
       "mxfp4", group_size, moe_block_size, top_k, size_m, size_n, size_k);
   Sm70CtaGeometry const geometry = params.geometry;
-  validate_sm70_marlin_moe_stage_cta_geometry_supported("SM70 Marlin MoE mxfp4", geometry);
-  validate_sm70_marlin_moe_stage_cta_n_alignment("SM70 Marlin MoE mxfp4", geometry,
-                                        size_n);
+  validate_sm70_marlin_moe_stage_cta_geometry_supported("SM70 Marlin MoE mxfp4",
+                                                        geometry);
+  validate_sm70_marlin_moe_stage_cta_n_alignment("SM70 Marlin MoE mxfp4",
+                                                 geometry, size_n);
   TORCH_CHECK(size_k % geometry.cta_k == 0,
               "SM70 Marlin MoE mxfp4 requires K divisible by CTA_K=",
               geometry.cta_k, ". Got K=", size_k, ".");
@@ -434,10 +431,23 @@ torch::Tensor sm70_marlin_mxfp4_gemm(
   auto empty_half = torch::empty({0}, b_scales.options().dtype(at::kHalf));
   auto empty_float = torch::empty(
       {0}, torch::TensorOptions().dtype(at::kFloat).device(a.device()));
-  Sm70MoeMxfp4Launcher const launcher{
-      a, c, b_q_weight, b_scales, empty_half, empty_float, sorted_token_ids,
-      expert_ids, num_tokens_past_padded, topk_weights, moe_block_size, top_k,
-      mul_topk_weights, size_m, size_n, size_k, params.requested_split_k};
+  Sm70MoeMxfp4Launcher const launcher{a,
+                                      c,
+                                      b_q_weight,
+                                      b_scales,
+                                      empty_half,
+                                      empty_float,
+                                      sorted_token_ids,
+                                      expert_ids,
+                                      num_tokens_past_padded,
+                                      topk_weights,
+                                      moe_block_size,
+                                      top_k,
+                                      mul_topk_weights,
+                                      size_m,
+                                      size_n,
+                                      size_k,
+                                      params.requested_split_k};
   return dispatch_sm70_marlin_moe_fixed_group_geometry<32>(
       launcher, geometry, params.packed_macro_n, group_size, "mxfp4");
 }

--- a/csrc/moe/marlin_moe_wna16/sm70_marlin_nvfp4_gemm.cu
+++ b/csrc/moe/marlin_moe_wna16/sm70_marlin_nvfp4_gemm.cu
@@ -26,7 +26,8 @@ namespace {
 
 constexpr int kNvfp4ValuesPerWord = 8;
 
-template <typename Shape_, typename ThreadMap_, int GroupSize_, int PackedMacroN_>
+template <typename Shape_, typename ThreadMap_, int GroupSize_,
+          int PackedMacroN_>
 class Sm70MoeNvfp4IteratorB {
  public:
   using Shape = Shape_;
@@ -34,22 +35,25 @@ class Sm70MoeNvfp4IteratorB {
   static int const kGroupSize = GroupSize_;
   static int const kPackedMacroN = PackedMacroN_;
   using Element = cutlass::half_t;
-  using Fragment = cutlass::Array<
-      Element, ThreadMap::Iterations::kCount * ThreadMap::kElementsPerAccess>;
-    static_assert(Shape::kN == 64 || Shape::kN == 128 || Shape::kN == 256,
-                "SM70 Marlin MoE NVFP4 IteratorB expects CTA_N in {64, 128, 256}.");
-  static_assert(ThreadMap::Iterations::kContiguous ==
-                    Shape::kN / kQuantTileN,
-                "SM70 Marlin MoE NVFP4 IteratorB expects one contiguous iteration "
-                "per 64-column quant tile.");
+  using Fragment = cutlass::Array<Element, ThreadMap::Iterations::kCount *
+                                               ThreadMap::kElementsPerAccess>;
+  static_assert(
+      Shape::kN == 64 || Shape::kN == 128 || Shape::kN == 256,
+      "SM70 Marlin MoE NVFP4 IteratorB expects CTA_N in {64, 128, 256}.");
+  static_assert(
+      ThreadMap::Iterations::kContiguous == Shape::kN / kQuantTileN,
+      "SM70 Marlin MoE NVFP4 IteratorB expects one contiguous iteration "
+      "per 64-column quant tile.");
   static_assert(ThreadMap::Delta::kContiguous == kQuantTileN,
                 "SM70 Marlin MoE NVFP4 IteratorB expects 64-column deltas.");
-  static_assert(ThreadMap::kElementsPerAccess == kNvfp4ValuesPerWord,
-                "SM70 Marlin MoE NVFP4 IteratorB expects one packed FP4 word per "
-                "access.");
-  static_assert(ThreadMap::Iterations::kStrided >= 1,
-                "SM70 Marlin MoE U4-family IteratorB expects one or more strided "
-                "iterations.");
+  static_assert(
+      ThreadMap::kElementsPerAccess == kNvfp4ValuesPerWord,
+      "SM70 Marlin MoE NVFP4 IteratorB expects one packed FP4 word per "
+      "access.");
+  static_assert(
+      ThreadMap::Iterations::kStrided >= 1,
+      "SM70 Marlin MoE U4-family IteratorB expects one or more strided "
+      "iterations.");
   struct Params {
     int size_k;
     int size_n;
@@ -60,9 +64,7 @@ class Sm70MoeNvfp4IteratorB {
 
     CUTLASS_HOST_DEVICE
     Params(int size_k_, int size_n_)
-        : size_k(size_k_),
-          size_n(size_n_),
-          num_groups(size_k_ / GroupSize_) {}
+        : size_k(size_k_), size_n(size_n_), num_groups(size_k_ / GroupSize_) {}
   };
 
  private:
@@ -83,9 +85,8 @@ class Sm70MoeNvfp4IteratorB {
                         uint8_t const* scales, half const*, int thread_id,
                         int expert, int k_offset, int n_offset)
       : qweight_(qweight),
-        scales_expert_base_(scales +
-                            (expert >= 0 ? expert : 0) *
-                                params.num_groups * params.size_n),
+        scales_expert_base_(scales + (expert >= 0 ? expert : 0) *
+                                         params.num_groups * params.size_n),
         params_(params),
         thread_offset_(ThreadMap::initial_offset(thread_id)),
         expert_(expert),
@@ -124,9 +125,7 @@ class Sm70MoeNvfp4IteratorB {
   }
 
   CUTLASS_DEVICE
-  int metadata_group_offset(int group) const {
-    return group * params_.size_n;
-  }
+  int metadata_group_offset(int group) const { return group * params_.size_n; }
 
   CUTLASS_DEVICE
   int scale_group(int logical_k) const {
@@ -159,14 +158,12 @@ class Sm70MoeNvfp4IteratorB {
     CUTLASS_PRAGMA_UNROLL
     for (int s = 0; s < ThreadMap::Iterations::kStrided; ++s) {
       int const logical_k =
-          k_offset_ + thread_offset_.strided() +
-          s * ThreadMap::Delta::kStrided;
+          k_offset_ + thread_offset_.strided() + s * ThreadMap::Delta::kStrided;
       int const group = scale_group(logical_k);
       CUTLASS_PRAGMA_UNROLL
       for (int c = 0; c < ThreadMap::Iterations::kContiguous; ++c) {
-        int const cache_n =
-            n_offset_ + thread_offset_.contiguous() +
-            c * ThreadMap::Delta::kContiguous;
+        int const cache_n = n_offset_ + thread_offset_.contiguous() +
+                            c * ThreadMap::Delta::kContiguous;
         int const cache_index = c + s * ThreadMap::Iterations::kContiguous;
         cache_metadata_fp8_scales(cache_index, group, cache_n);
       }
@@ -219,8 +216,9 @@ class Sm70MoeNvfp4IteratorB {
           frag_vec[3] = __hmul2(deq[1], scale_vec[3]);
         }
       } else {
-        static_assert(ThreadMap::Iterations::kContiguous == 1,
-                      "Unsupported SM70 Marlin MoE NVFP4 contiguous iteration count.");
+        static_assert(
+            ThreadMap::Iterations::kContiguous == 1,
+            "Unsupported SM70 Marlin MoE NVFP4 contiguous iteration count.");
         uint32_t const qword =
             load_qword_vector<1>(qweight_ + qweight_base_offset_);
         half2 const* scale_vec = cached_scales_;
@@ -240,15 +238,13 @@ class Sm70MoeNvfp4IteratorB {
       int const logical_n_base = n_offset_ + thread_offset_.contiguous();
       CUTLASS_PRAGMA_UNROLL
       for (int s = 0; s < ThreadMap::Iterations::kStrided; ++s) {
-        int const logical_k_s =
-            k_offset_ + thread_offset_.strided() +
-            s * ThreadMap::Delta::kStrided;
+        int const logical_k_s = k_offset_ + thread_offset_.strided() +
+                                s * ThreadMap::Delta::kStrided;
         int const qweight_base_s =
             expert_qweight_base_offset() +
             qweight_offset_from_logical(params_, logical_k_s, logical_n_base);
         if constexpr (ThreadMap::Iterations::kContiguous == 4) {
-          auto const qwords =
-              load_qword_vector<4>(qweight_ + qweight_base_s);
+          auto const qwords = load_qword_vector<4>(qweight_ + qweight_base_s);
           CUTLASS_PRAGMA_UNROLL
           for (int c = 0; c < ThreadMap::Iterations::kContiguous; ++c) {
             constexpr int kAccess = ThreadMap::kElementsPerAccess;
@@ -271,8 +267,7 @@ class Sm70MoeNvfp4IteratorB {
             frag_vec[3] = __hmul2(deq[1], scale_vec[3]);
           }
         } else if constexpr (ThreadMap::Iterations::kContiguous == 2) {
-          auto const qwords =
-              load_qword_vector<2>(qweight_ + qweight_base_s);
+          auto const qwords = load_qword_vector<2>(qweight_ + qweight_base_s);
           CUTLASS_PRAGMA_UNROLL
           for (int c = 0; c < ThreadMap::Iterations::kContiguous; ++c) {
             constexpr int kAccess = ThreadMap::kElementsPerAccess;
@@ -295,8 +290,9 @@ class Sm70MoeNvfp4IteratorB {
             frag_vec[3] = __hmul2(deq[1], scale_vec[3]);
           }
         } else {
-          static_assert(ThreadMap::Iterations::kContiguous == 1,
-                        "Unsupported SM70 Marlin MoE NVFP4 contiguous iteration count.");
+          static_assert(
+              ThreadMap::Iterations::kContiguous == 1,
+              "Unsupported SM70 Marlin MoE NVFP4 contiguous iteration count.");
           uint32_t const qword =
               load_qword_vector<1>(qweight_ + qweight_base_s);
           constexpr int kAccess = ThreadMap::kElementsPerAccess;
@@ -339,15 +335,15 @@ struct Sm70MoeNvfp4GemmSpec {
   using IteratorA = Sm70MoeGatherIteratorA<Shape, ThreadMap>;
 
   template <typename Shape, typename ThreadMap, int GroupSize, int PackedMacroN>
-  using IteratorB = Sm70MoeNvfp4IteratorB<Shape, ThreadMap, GroupSize, PackedMacroN>;
+  using IteratorB =
+      Sm70MoeNvfp4IteratorB<Shape, ThreadMap, GroupSize, PackedMacroN>;
 };
 
-template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM,
-          int WarpN, int WarpK, int GroupSize, int PackedMacroN>
+template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM, int WarpN,
+          int WarpK, int GroupSize, int PackedMacroN>
 using Sm70MoeNvfp4GemmTraits =
-    Sm70MarlinMoeGemmTraits<Sm70MoeNvfp4GemmSpec, CtaM, CtaN, CtaK,
-                            Warps, WarpM, WarpN, WarpK, GroupSize,
-                            PackedMacroN>;
+    Sm70MarlinMoeGemmTraits<Sm70MoeNvfp4GemmSpec, CtaM, CtaN, CtaK, Warps,
+                            WarpM, WarpN, WarpK, GroupSize, PackedMacroN>;
 
 struct Sm70MoeNvfp4Launcher {
   torch::Tensor& a;
@@ -368,15 +364,15 @@ struct Sm70MoeNvfp4Launcher {
   int64_t size_k;
   int requested_split_k;
 
-  template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM,
-          int WarpN, int WarpK, int GroupSize, int PackedMacroN>
+  template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM, int WarpN,
+            int WarpK, int GroupSize, int PackedMacroN>
   torch::Tensor operator()() const {
-    using Traits = Sm70MoeNvfp4GemmTraits<CtaM, CtaN, CtaK, Warps, WarpM,
-                                    WarpN, WarpK, GroupSize, PackedMacroN>;
+    using Traits = Sm70MoeNvfp4GemmTraits<CtaM, CtaN, CtaK, Warps, WarpM, WarpN,
+                                          WarpK, GroupSize, PackedMacroN>;
     return launch_sm70_marlin_moe_gemm<Traits>(
         a, c, b_q_weight, b_scales, b_zeros, global_scale, sorted_token_ids,
-        expert_ids, num_tokens_past_padded, topk_weights, moe_block_size,
-        top_k, mul_topk_weights, size_m, size_n, size_k, requested_split_k);
+        expert_ids, num_tokens_past_padded, topk_weights, moe_block_size, top_k,
+        mul_topk_weights, size_m, size_n, size_k, requested_split_k);
   }
 };
 
@@ -394,18 +390,32 @@ torch::Tensor sm70_marlin_nvfp4_gemm(
   auto const params = sm70_marlin_moe_auto_stage_params(
       "nvfp4", group_size, moe_block_size, top_k, size_m, size_n, size_k);
   Sm70CtaGeometry const geometry = params.geometry;
-  validate_sm70_marlin_moe_stage_cta_geometry_supported("SM70 Marlin MoE nvfp4", geometry);
-  validate_sm70_marlin_moe_stage_cta_n_alignment("SM70 Marlin MoE nvfp4", geometry,
-                                        size_n);
+  validate_sm70_marlin_moe_stage_cta_geometry_supported("SM70 Marlin MoE nvfp4",
+                                                        geometry);
+  validate_sm70_marlin_moe_stage_cta_n_alignment("SM70 Marlin MoE nvfp4",
+                                                 geometry, size_n);
   TORCH_CHECK(size_k % geometry.cta_k == 0,
               "SM70 Marlin MoE nvfp4 requires K divisible by CTA_K=",
               geometry.cta_k, ". Got K=", size_k, ".");
 
   auto empty_half = torch::empty({0}, b_scales.options().dtype(at::kHalf));
-  Sm70MoeNvfp4Launcher const launcher{
-      a, c, b_q_weight, b_scales, empty_half, global_scale, sorted_token_ids,
-      expert_ids, num_tokens_past_padded, topk_weights, moe_block_size, top_k,
-      mul_topk_weights, size_m, size_n, size_k, params.requested_split_k};
+  Sm70MoeNvfp4Launcher const launcher{a,
+                                      c,
+                                      b_q_weight,
+                                      b_scales,
+                                      empty_half,
+                                      global_scale,
+                                      sorted_token_ids,
+                                      expert_ids,
+                                      num_tokens_past_padded,
+                                      topk_weights,
+                                      moe_block_size,
+                                      top_k,
+                                      mul_topk_weights,
+                                      size_m,
+                                      size_n,
+                                      size_k,
+                                      params.requested_split_k};
   return dispatch_sm70_marlin_moe_fixed_group_geometry<16>(
       launcher, geometry, params.packed_macro_n, group_size, "nvfp4");
 }

--- a/csrc/moe/marlin_moe_wna16/sm70_marlin_u4_gemm.cu
+++ b/csrc/moe/marlin_moe_wna16/sm70_marlin_u4_gemm.cu
@@ -35,21 +35,23 @@ class Sm70MoeU4ZpIteratorB {
   static int const kPackedMacroN = PackedMacroN_;
   static constexpr bool kUseMetadataVectorWords = UseMetadataVectorWords_;
   using Element = cutlass::half_t;
-  using Fragment = cutlass::Array<
-      Element, ThreadMap::Iterations::kCount * ThreadMap::kElementsPerAccess>;
-  static_assert(Shape::kN == 64 || Shape::kN == 128 || Shape::kN == 256,
-                "SM70 Marlin MoE U4 IteratorB expects CTA_N in {64, 128, 256}.");
-  static_assert(ThreadMap::Iterations::kContiguous ==
-                    Shape::kN / kQuantTileN,
-                "SM70 Marlin MoE U4 IteratorB expects one contiguous iteration per "
-                "64-column quant tile.");
+  using Fragment = cutlass::Array<Element, ThreadMap::Iterations::kCount *
+                                               ThreadMap::kElementsPerAccess>;
+  static_assert(
+      Shape::kN == 64 || Shape::kN == 128 || Shape::kN == 256,
+      "SM70 Marlin MoE U4 IteratorB expects CTA_N in {64, 128, 256}.");
+  static_assert(
+      ThreadMap::Iterations::kContiguous == Shape::kN / kQuantTileN,
+      "SM70 Marlin MoE U4 IteratorB expects one contiguous iteration per "
+      "64-column quant tile.");
   static_assert(ThreadMap::Delta::kContiguous == kQuantTileN,
                 "SM70 Marlin MoE U4 IteratorB expects 64-column deltas.");
   static_assert(ThreadMap::kElementsPerAccess == kU4ValuesPerWord,
                 "SM70 Marlin MoE U4 IteratorB expects one packed int4 word per "
                 "access.");
   static_assert(ThreadMap::Iterations::kStrided >= 1,
-                "SM70 Marlin MoE U4-family IteratorB expects one or more strided iterations.");
+                "SM70 Marlin MoE U4-family IteratorB expects one or more "
+                "strided iterations.");
   struct Params {
     int size_k;
     int size_n;
@@ -85,11 +87,10 @@ class Sm70MoeU4ZpIteratorB {
                        half const* scales, half const* zp, int thread_id,
                        int expert, int k_offset, int n_offset)
       : qweight_(qweight),
-        scales_expert_base_(scales +
-                            (expert >= 0 ? expert : 0) *
-                                params.num_groups * params.size_n),
-        zp_expert_base_(zp + (expert >= 0 ? expert : 0) *
-                                 params.num_groups * params.size_n),
+        scales_expert_base_(scales + (expert >= 0 ? expert : 0) *
+                                         params.num_groups * params.size_n),
+        zp_expert_base_(zp + (expert >= 0 ? expert : 0) * params.num_groups *
+                                 params.size_n),
         params_(params),
         thread_offset_(ThreadMap::initial_offset(thread_id)),
         expert_(expert),
@@ -131,17 +132,14 @@ class Sm70MoeU4ZpIteratorB {
   }
 
   CUTLASS_DEVICE
-  int metadata_group_offset(int group) const {
-    return group * params_.size_n;
-  }
+  int metadata_group_offset(int group) const { return group * params_.size_n; }
 
   CUTLASS_DEVICE
   int scale_group(int logical_k) const {
     if constexpr (kGroupSize == -1) {
       return 0;
     } else {
-      static_assert(kGroupSize == 32 || kGroupSize == 64 ||
-                        kGroupSize == 128,
+      static_assert(kGroupSize == 32 || kGroupSize == 64 || kGroupSize == 128,
                     "SM70 Marlin MoE U4 supports only group sizes -1, 32, 64, "
                     "and 128.");
       return logical_k / kGroupSize;
@@ -158,16 +156,16 @@ class Sm70MoeU4ZpIteratorB {
   CUTLASS_DEVICE
   void cache_metadata_lane_vectors(int c, int group, int cache_n) const {
     int const metadata_offset = metadata_group_offset(group) + cache_n;
-    half2 const* scale_vec = reinterpret_cast<half2 const*>(
-        scales_expert_base_ + metadata_offset);
+    half2 const* scale_vec =
+        reinterpret_cast<half2 const*>(scales_expert_base_ + metadata_offset);
     half2* scale_cache = cached_scales_ + c * 4;
     scale_cache[0] = scale_vec[0];
     scale_cache[1] = scale_vec[1];
     scale_cache[2] = scale_vec[2];
     scale_cache[3] = scale_vec[3];
 
-    half2 const* zp_vec = reinterpret_cast<half2 const*>(
-        zp_expert_base_ + metadata_offset);
+    half2 const* zp_vec =
+        reinterpret_cast<half2 const*>(zp_expert_base_ + metadata_offset);
     half2* zp_cache = cached_zp_ + c * 4;
     zp_cache[0] = zp_vec[0];
     zp_cache[1] = zp_vec[1];
@@ -178,8 +176,8 @@ class Sm70MoeU4ZpIteratorB {
   CUTLASS_DEVICE
   void cache_metadata_vector_words(int c, int group, int cache_n) const {
     int const metadata_offset = metadata_group_offset(group) + cache_n;
-    uint4 const scale_words = *reinterpret_cast<uint4 const*>(
-        scales_expert_base_ + metadata_offset);
+    uint4 const scale_words =
+        *reinterpret_cast<uint4 const*>(scales_expert_base_ + metadata_offset);
     half2 const* scale_vec = reinterpret_cast<half2 const*>(&scale_words);
     half2* scale_cache = cached_scales_ + c * 4;
     scale_cache[0] = scale_vec[0];
@@ -187,8 +185,8 @@ class Sm70MoeU4ZpIteratorB {
     scale_cache[2] = scale_vec[2];
     scale_cache[3] = scale_vec[3];
 
-    uint4 const zp_words = *reinterpret_cast<uint4 const*>(
-        zp_expert_base_ + metadata_offset);
+    uint4 const zp_words =
+        *reinterpret_cast<uint4 const*>(zp_expert_base_ + metadata_offset);
     half2 const* zp_vec = reinterpret_cast<half2 const*>(&zp_words);
     half2* zp_cache = cached_zp_ + c * 4;
     zp_cache[0] = zp_vec[0];
@@ -201,9 +199,8 @@ class Sm70MoeU4ZpIteratorB {
   void cache_current_group_metadata(int group) const {
     CUTLASS_PRAGMA_UNROLL
     for (int c = 0; c < ThreadMap::Iterations::kContiguous; ++c) {
-      int const cache_n =
-          n_offset_ + thread_offset_.contiguous() +
-          c * ThreadMap::Delta::kContiguous;
+      int const cache_n = n_offset_ + thread_offset_.contiguous() +
+                          c * ThreadMap::Delta::kContiguous;
       if constexpr (kUseMetadataVectorWords) {
         cache_metadata_vector_words(c, group, cache_n);
       } else {
@@ -228,8 +225,8 @@ class Sm70MoeU4ZpIteratorB {
 
           half2 deq[2];
           half2* frag_vec = reinterpret_cast<half2*>(frag.data() + frag_base);
-          marlin::dequant<half2, vllm::kU4.id(), false>(
-              static_cast<int>(qword), deq);
+          marlin::dequant<half2, vllm::kU4.id(), false>(static_cast<int>(qword),
+                                                        deq);
           frag_vec[0] = __hfma2(deq[0], scale_vec[0], __hneg2(zp_vec[0]));
           frag_vec[1] = __hfma2(deq[1], scale_vec[1], __hneg2(zp_vec[1]));
           marlin::dequant<half2, vllm::kU4.id(), false>(
@@ -250,8 +247,8 @@ class Sm70MoeU4ZpIteratorB {
 
           half2 deq[2];
           half2* frag_vec = reinterpret_cast<half2*>(frag.data() + frag_base);
-          marlin::dequant<half2, vllm::kU4.id(), false>(
-              static_cast<int>(qword), deq);
+          marlin::dequant<half2, vllm::kU4.id(), false>(static_cast<int>(qword),
+                                                        deq);
           frag_vec[0] = __hfma2(deq[0], scale_vec[0], __hneg2(zp_vec[0]));
           frag_vec[1] = __hfma2(deq[1], scale_vec[1], __hneg2(zp_vec[1]));
           marlin::dequant<half2, vllm::kU4.id(), false>(
@@ -260,16 +257,18 @@ class Sm70MoeU4ZpIteratorB {
           frag_vec[3] = __hfma2(deq[1], scale_vec[3], __hneg2(zp_vec[3]));
         }
       } else {
-        static_assert(ThreadMap::Iterations::kContiguous == 1,
-                      "Unsupported SM70 Marlin MoE U4 contiguous iteration count.");
-        uint32_t const qword = load_qword_vector<1>(qweight_ + qweight_base_offset_);
+        static_assert(
+            ThreadMap::Iterations::kContiguous == 1,
+            "Unsupported SM70 Marlin MoE U4 contiguous iteration count.");
+        uint32_t const qword =
+            load_qword_vector<1>(qweight_ + qweight_base_offset_);
         half2 const* scale_vec = cached_scales_;
         half2 const* zp_vec = cached_zp_;
 
         half2 deq[2];
         half2* frag_vec = reinterpret_cast<half2*>(frag.data());
-        marlin::dequant<half2, vllm::kU4.id(), false>(
-            static_cast<int>(qword), deq);
+        marlin::dequant<half2, vllm::kU4.id(), false>(static_cast<int>(qword),
+                                                      deq);
         frag_vec[0] = __hfma2(deq[0], scale_vec[0], __hneg2(zp_vec[0]));
         frag_vec[1] = __hfma2(deq[1], scale_vec[1], __hneg2(zp_vec[1]));
         marlin::dequant<half2, vllm::kU4.id(), false>(
@@ -281,9 +280,8 @@ class Sm70MoeU4ZpIteratorB {
       int const logical_n_base = n_offset_ + thread_offset_.contiguous();
       CUTLASS_PRAGMA_UNROLL
       for (int s = 0; s < ThreadMap::Iterations::kStrided; ++s) {
-        int const logical_k_s =
-            k_offset_ + thread_offset_.strided() +
-            s * ThreadMap::Delta::kStrided;
+        int const logical_k_s = k_offset_ + thread_offset_.strided() +
+                                s * ThreadMap::Delta::kStrided;
         if constexpr (kGroupSize != -1) {
           cache_current_group_metadata(scale_group(logical_k_s));
         }
@@ -291,8 +289,7 @@ class Sm70MoeU4ZpIteratorB {
             expert_qweight_base_offset() +
             qweight_offset_from_logical(params_, logical_k_s, logical_n_base);
         if constexpr (ThreadMap::Iterations::kContiguous == 4) {
-          auto const qwords =
-              load_qword_vector<4>(qweight_ + qweight_base_s);
+          auto const qwords = load_qword_vector<4>(qweight_ + qweight_base_s);
           CUTLASS_PRAGMA_UNROLL
           for (int c = 0; c < ThreadMap::Iterations::kContiguous; ++c) {
             constexpr int kAccess = ThreadMap::kElementsPerAccess;
@@ -314,8 +311,7 @@ class Sm70MoeU4ZpIteratorB {
             frag_vec[3] = __hfma2(deq[1], scale_vec[3], __hneg2(zp_vec[3]));
           }
         } else if constexpr (ThreadMap::Iterations::kContiguous == 2) {
-          auto const qwords =
-              load_qword_vector<2>(qweight_ + qweight_base_s);
+          auto const qwords = load_qword_vector<2>(qweight_ + qweight_base_s);
           CUTLASS_PRAGMA_UNROLL
           for (int c = 0; c < ThreadMap::Iterations::kContiguous; ++c) {
             constexpr int kAccess = ThreadMap::kElementsPerAccess;
@@ -337,9 +333,11 @@ class Sm70MoeU4ZpIteratorB {
             frag_vec[3] = __hfma2(deq[1], scale_vec[3], __hneg2(zp_vec[3]));
           }
         } else {
-          static_assert(ThreadMap::Iterations::kContiguous == 1,
-                        "Unsupported SM70 Marlin MoE U4 contiguous iteration count.");
-          uint32_t const qword = load_qword_vector<1>(qweight_ + qweight_base_s);
+          static_assert(
+              ThreadMap::Iterations::kContiguous == 1,
+              "Unsupported SM70 Marlin MoE U4 contiguous iteration count.");
+          uint32_t const qword =
+              load_qword_vector<1>(qweight_ + qweight_base_s);
           constexpr int kAccess = ThreadMap::kElementsPerAccess;
           int const frag_base = s * kAccess;
           half2 const* scale_vec = cached_scales_;
@@ -347,8 +345,8 @@ class Sm70MoeU4ZpIteratorB {
 
           half2 deq[2];
           half2* frag_vec = reinterpret_cast<half2*>(frag.data() + frag_base);
-          marlin::dequant<half2, vllm::kU4.id(), false>(
-              static_cast<int>(qword), deq);
+          marlin::dequant<half2, vllm::kU4.id(), false>(static_cast<int>(qword),
+                                                        deq);
           frag_vec[0] = __hfma2(deq[0], scale_vec[0], __hneg2(zp_vec[0]));
           frag_vec[1] = __hfma2(deq[1], scale_vec[1], __hneg2(zp_vec[1]));
           marlin::dequant<half2, vllm::kU4.id(), false>(
@@ -366,8 +364,7 @@ class Sm70MoeU4ZpIteratorB {
       return;
     }
 
-    if constexpr (kGroupSize != -1 &&
-                  ThreadMap::Iterations::kStrided == 1) {
+    if constexpr (kGroupSize != -1 && ThreadMap::Iterations::kStrided == 1) {
       int const first_logical_k = k_offset_ + thread_offset_.strided();
       cache_current_group_metadata(scale_group(first_logical_k));
     }
@@ -386,18 +383,17 @@ struct Sm70MoeU4ZpGemmSpec {
   using IteratorA = Sm70MoeGatherIteratorA<Shape, ThreadMap>;
 
   template <typename Shape, typename ThreadMap, int GroupSize, int PackedMacroN>
-  using IteratorB =
-      Sm70MoeU4ZpIteratorB<Shape, ThreadMap, GroupSize, PackedMacroN,
-                           UseMetadataVectorWords>;
+  using IteratorB = Sm70MoeU4ZpIteratorB<Shape, ThreadMap, GroupSize,
+                                         PackedMacroN, UseMetadataVectorWords>;
 };
 
-template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM,
-          int WarpN, int WarpK, int GroupSize, int PackedMacroN,
+template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM, int WarpN,
+          int WarpK, int GroupSize, int PackedMacroN,
           bool UseMetadataVectorWords = true>
 using Sm70MoeU4ZpGemmTraits =
-    Sm70MarlinMoeGemmTraits<
-        Sm70MoeU4ZpGemmSpec<UseMetadataVectorWords>, CtaM, CtaN, CtaK,
-        Warps, WarpM, WarpN, WarpK, GroupSize, PackedMacroN>;
+    Sm70MarlinMoeGemmTraits<Sm70MoeU4ZpGemmSpec<UseMetadataVectorWords>, CtaM,
+                            CtaN, CtaK, Warps, WarpM, WarpN, WarpK, GroupSize,
+                            PackedMacroN>;
 
 template <bool UseMetadataVectorWords = true>
 struct Sm70MoeU4Launcher {
@@ -419,16 +415,16 @@ struct Sm70MoeU4Launcher {
   int64_t size_k;
   int requested_split_k;
 
-  template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM,
-          int WarpN, int WarpK, int GroupSize, int PackedMacroN>
+  template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM, int WarpN,
+            int WarpK, int GroupSize, int PackedMacroN>
   torch::Tensor operator()() const {
-    using Traits = Sm70MoeU4ZpGemmTraits<CtaM, CtaN, CtaK, Warps, WarpM,
-                                         WarpN, WarpK, GroupSize, PackedMacroN,
-                                         UseMetadataVectorWords>;
+    using Traits =
+        Sm70MoeU4ZpGemmTraits<CtaM, CtaN, CtaK, Warps, WarpM, WarpN, WarpK,
+                              GroupSize, PackedMacroN, UseMetadataVectorWords>;
     return launch_sm70_marlin_moe_gemm<Traits>(
         a, c, b_q_weight, b_scales, b_zeros, global_scale, sorted_token_ids,
-        expert_ids, num_tokens_past_padded, topk_weights, moe_block_size,
-        top_k, mul_topk_weights, size_m, size_n, size_k, requested_split_k);
+        expert_ids, num_tokens_past_padded, topk_weights, moe_block_size, top_k,
+        mul_topk_weights, size_m, size_n, size_k, requested_split_k);
   }
 };
 
@@ -446,9 +442,10 @@ torch::Tensor sm70_marlin_u4_gemm(
   auto const params = sm70_marlin_moe_auto_stage_params(
       "uint4", group_size, moe_block_size, top_k, size_m, size_n, size_k);
   Sm70CtaGeometry const geometry = params.geometry;
-  validate_sm70_marlin_moe_stage_cta_geometry_supported("SM70 Marlin MoE uint4", geometry);
-  validate_sm70_marlin_moe_stage_cta_n_alignment("SM70 Marlin MoE uint4", geometry,
-                                        size_n);
+  validate_sm70_marlin_moe_stage_cta_geometry_supported("SM70 Marlin MoE uint4",
+                                                        geometry);
+  validate_sm70_marlin_moe_stage_cta_n_alignment("SM70 Marlin MoE uint4",
+                                                 geometry, size_n);
   TORCH_CHECK(size_k % geometry.cta_k == 0,
               "SM70 Marlin MoE uint4 requires K divisible by CTA_K=",
               geometry.cta_k, ". Got K=", size_k, ".");
@@ -456,19 +453,45 @@ torch::Tensor sm70_marlin_u4_gemm(
   auto empty_float = torch::empty(
       {0}, torch::TensorOptions().dtype(at::kFloat).device(a.device()));
   if (params.use_metadata_vector_words) {
-    Sm70MoeU4Launcher<true> const launcher{
-        a, c, b_q_weight, b_scales, b_zeros, empty_float, sorted_token_ids,
-        expert_ids, num_tokens_past_padded, topk_weights, moe_block_size, top_k,
-        mul_topk_weights, size_m, size_n, size_k, params.requested_split_k};
-    return dispatch_sm70_marlin_moe_geometry(launcher, geometry, params.packed_macro_n, group_size,
-        "uint4");
+    Sm70MoeU4Launcher<true> const launcher{a,
+                                           c,
+                                           b_q_weight,
+                                           b_scales,
+                                           b_zeros,
+                                           empty_float,
+                                           sorted_token_ids,
+                                           expert_ids,
+                                           num_tokens_past_padded,
+                                           topk_weights,
+                                           moe_block_size,
+                                           top_k,
+                                           mul_topk_weights,
+                                           size_m,
+                                           size_n,
+                                           size_k,
+                                           params.requested_split_k};
+    return dispatch_sm70_marlin_moe_geometry(
+        launcher, geometry, params.packed_macro_n, group_size, "uint4");
   }
-  Sm70MoeU4Launcher<false> const launcher{
-      a, c, b_q_weight, b_scales, b_zeros, empty_float, sorted_token_ids,
-      expert_ids, num_tokens_past_padded, topk_weights, moe_block_size, top_k,
-      mul_topk_weights, size_m, size_n, size_k, params.requested_split_k};
-  return dispatch_sm70_marlin_moe_geometry(launcher, geometry, params.packed_macro_n, group_size,
-      "uint4");
+  Sm70MoeU4Launcher<false> const launcher{a,
+                                          c,
+                                          b_q_weight,
+                                          b_scales,
+                                          b_zeros,
+                                          empty_float,
+                                          sorted_token_ids,
+                                          expert_ids,
+                                          num_tokens_past_padded,
+                                          topk_weights,
+                                          moe_block_size,
+                                          top_k,
+                                          mul_topk_weights,
+                                          size_m,
+                                          size_n,
+                                          size_k,
+                                          params.requested_split_k};
+  return dispatch_sm70_marlin_moe_geometry(
+      launcher, geometry, params.packed_macro_n, group_size, "uint4");
 }
 
 }  // namespace marlin_moe_wna16

--- a/csrc/moe/marlin_moe_wna16/sm70_marlin_u4b8_gemm.cu
+++ b/csrc/moe/marlin_moe_wna16/sm70_marlin_u4b8_gemm.cu
@@ -35,22 +35,25 @@ class Sm70MoeU4B8IteratorB {
   static int const kPackedMacroN = PackedMacroN_;
   static constexpr bool kUseMetadataVectorWords = UseMetadataVectorWords_;
   using Element = cutlass::half_t;
-  using Fragment = cutlass::Array<
-      Element, ThreadMap::Iterations::kCount * ThreadMap::kElementsPerAccess>;
-    static_assert(Shape::kN == 64 || Shape::kN == 128 || Shape::kN == 256,
-                "SM70 Marlin MoE U4B8 IteratorB expects CTA_N in {64, 128, 256}.");
-  static_assert(ThreadMap::Iterations::kContiguous ==
-                    Shape::kN / kQuantTileN,
-                "SM70 Marlin MoE U4B8 IteratorB expects one contiguous iteration per "
-                "64-column quant tile.");
+  using Fragment = cutlass::Array<Element, ThreadMap::Iterations::kCount *
+                                               ThreadMap::kElementsPerAccess>;
+  static_assert(
+      Shape::kN == 64 || Shape::kN == 128 || Shape::kN == 256,
+      "SM70 Marlin MoE U4B8 IteratorB expects CTA_N in {64, 128, 256}.");
+  static_assert(
+      ThreadMap::Iterations::kContiguous == Shape::kN / kQuantTileN,
+      "SM70 Marlin MoE U4B8 IteratorB expects one contiguous iteration per "
+      "64-column quant tile.");
   static_assert(ThreadMap::Delta::kContiguous == kQuantTileN,
                 "SM70 Marlin MoE U4B8 IteratorB expects 64-column deltas.");
-  static_assert(ThreadMap::kElementsPerAccess == kU4ValuesPerWord,
-                "SM70 Marlin MoE U4B8 IteratorB expects one packed int4 word per "
-                "access.");
-  static_assert(ThreadMap::Iterations::kStrided >= 1,
-                "SM70 Marlin MoE U4-family IteratorB expects one or more strided "
-                "iterations.");
+  static_assert(
+      ThreadMap::kElementsPerAccess == kU4ValuesPerWord,
+      "SM70 Marlin MoE U4B8 IteratorB expects one packed int4 word per "
+      "access.");
+  static_assert(
+      ThreadMap::Iterations::kStrided >= 1,
+      "SM70 Marlin MoE U4-family IteratorB expects one or more strided "
+      "iterations.");
   struct Params {
     int size_k;
     int size_n;
@@ -84,9 +87,8 @@ class Sm70MoeU4B8IteratorB {
                        half const* scales, half const*, int thread_id,
                        int expert, int k_offset, int n_offset)
       : qweight_(qweight),
-        scales_expert_base_(scales +
-                            (expert >= 0 ? expert : 0) *
-                                params.num_groups * params.size_n),
+        scales_expert_base_(scales + (expert >= 0 ? expert : 0) *
+                                         params.num_groups * params.size_n),
         params_(params),
         thread_offset_(ThreadMap::initial_offset(thread_id)),
         expert_(expert),
@@ -128,19 +130,17 @@ class Sm70MoeU4B8IteratorB {
   }
 
   CUTLASS_DEVICE
-  int metadata_group_offset(int group) const {
-    return group * params_.size_n;
-  }
+  int metadata_group_offset(int group) const { return group * params_.size_n; }
 
   CUTLASS_DEVICE
   int scale_group(int logical_k) const {
     if constexpr (kGroupSize == -1) {
       return 0;
     } else {
-      static_assert(kGroupSize == 32 || kGroupSize == 64 ||
-                        kGroupSize == 128,
-                    "SM70 Marlin MoE U4B8 supports only group sizes -1, 32, 64, "
-                    "and 128.");
+      static_assert(
+          kGroupSize == 32 || kGroupSize == 64 || kGroupSize == 128,
+          "SM70 Marlin MoE U4B8 supports only group sizes -1, 32, 64, "
+          "and 128.");
       return logical_k / kGroupSize;
     }
   }
@@ -155,8 +155,8 @@ class Sm70MoeU4B8IteratorB {
   CUTLASS_DEVICE
   void cache_metadata_lane_vectors(int c, int group, int cache_n) const {
     int const metadata_offset = metadata_group_offset(group) + cache_n;
-    half2 const* scale_vec = reinterpret_cast<half2 const*>(
-        scales_expert_base_ + metadata_offset);
+    half2 const* scale_vec =
+        reinterpret_cast<half2 const*>(scales_expert_base_ + metadata_offset);
     half2* scale_cache = cached_scales_ + c * 4;
     scale_cache[0] = scale_vec[0];
     scale_cache[1] = scale_vec[1];
@@ -167,8 +167,8 @@ class Sm70MoeU4B8IteratorB {
   CUTLASS_DEVICE
   void cache_metadata_vector_words(int c, int group, int cache_n) const {
     int const metadata_offset = metadata_group_offset(group) + cache_n;
-    uint4 const scale_words = *reinterpret_cast<uint4 const*>(
-        scales_expert_base_ + metadata_offset);
+    uint4 const scale_words =
+        *reinterpret_cast<uint4 const*>(scales_expert_base_ + metadata_offset);
     half2 const* scale_vec = reinterpret_cast<half2 const*>(&scale_words);
     half2* scale_cache = cached_scales_ + c * 4;
     scale_cache[0] = scale_vec[0];
@@ -181,9 +181,8 @@ class Sm70MoeU4B8IteratorB {
   void cache_current_group_metadata(int group) const {
     CUTLASS_PRAGMA_UNROLL
     for (int c = 0; c < ThreadMap::Iterations::kContiguous; ++c) {
-      int const cache_n =
-          n_offset_ + thread_offset_.contiguous() +
-          c * ThreadMap::Delta::kContiguous;
+      int const cache_n = n_offset_ + thread_offset_.contiguous() +
+                          c * ThreadMap::Delta::kContiguous;
       if constexpr (kUseMetadataVectorWords) {
         cache_metadata_vector_words(c, group, cache_n);
       } else {
@@ -238,16 +237,17 @@ class Sm70MoeU4B8IteratorB {
           frag_vec[3] = __hmul2(deq[1], scale_vec[3]);
         }
       } else {
-        static_assert(ThreadMap::Iterations::kContiguous == 1,
-                      "Unsupported SM70 Marlin MoE U4B8 contiguous iteration count.");
+        static_assert(
+            ThreadMap::Iterations::kContiguous == 1,
+            "Unsupported SM70 Marlin MoE U4B8 contiguous iteration count.");
         uint32_t const qword =
             load_qword_vector<1>(qweight_ + qweight_base_offset_);
         half2 const* scale_vec = cached_scales_;
 
         half2 deq[2];
         half2* frag_vec = reinterpret_cast<half2*>(frag.data());
-        marlin::dequant<half2, vllm::kU4B8.id(), false>(
-            static_cast<int>(qword), deq);
+        marlin::dequant<half2, vllm::kU4B8.id(), false>(static_cast<int>(qword),
+                                                        deq);
         frag_vec[0] = __hmul2(deq[0], scale_vec[0]);
         frag_vec[1] = __hmul2(deq[1], scale_vec[1]);
         marlin::dequant<half2, vllm::kU4B8.id(), false>(
@@ -259,9 +259,8 @@ class Sm70MoeU4B8IteratorB {
       int const logical_n_base = n_offset_ + thread_offset_.contiguous();
       CUTLASS_PRAGMA_UNROLL
       for (int s = 0; s < ThreadMap::Iterations::kStrided; ++s) {
-        int const logical_k_s =
-            k_offset_ + thread_offset_.strided() +
-            s * ThreadMap::Delta::kStrided;
+        int const logical_k_s = k_offset_ + thread_offset_.strided() +
+                                s * ThreadMap::Delta::kStrided;
         if constexpr (kGroupSize != -1) {
           cache_current_group_metadata(scale_group(logical_k_s));
         }
@@ -269,8 +268,7 @@ class Sm70MoeU4B8IteratorB {
             expert_qweight_base_offset() +
             qweight_offset_from_logical(params_, logical_k_s, logical_n_base);
         if constexpr (ThreadMap::Iterations::kContiguous == 4) {
-          auto const qwords =
-              load_qword_vector<4>(qweight_ + qweight_base_s);
+          auto const qwords = load_qword_vector<4>(qweight_ + qweight_base_s);
           CUTLASS_PRAGMA_UNROLL
           for (int c = 0; c < ThreadMap::Iterations::kContiguous; ++c) {
             constexpr int kAccess = ThreadMap::kElementsPerAccess;
@@ -291,8 +289,7 @@ class Sm70MoeU4B8IteratorB {
             frag_vec[3] = __hmul2(deq[1], scale_vec[3]);
           }
         } else if constexpr (ThreadMap::Iterations::kContiguous == 2) {
-          auto const qwords =
-              load_qword_vector<2>(qweight_ + qweight_base_s);
+          auto const qwords = load_qword_vector<2>(qweight_ + qweight_base_s);
           CUTLASS_PRAGMA_UNROLL
           for (int c = 0; c < ThreadMap::Iterations::kContiguous; ++c) {
             constexpr int kAccess = ThreadMap::kElementsPerAccess;
@@ -313,8 +310,9 @@ class Sm70MoeU4B8IteratorB {
             frag_vec[3] = __hmul2(deq[1], scale_vec[3]);
           }
         } else {
-          static_assert(ThreadMap::Iterations::kContiguous == 1,
-                        "Unsupported SM70 Marlin MoE U4B8 contiguous iteration count.");
+          static_assert(
+              ThreadMap::Iterations::kContiguous == 1,
+              "Unsupported SM70 Marlin MoE U4B8 contiguous iteration count.");
           uint32_t const qword =
               load_qword_vector<1>(qweight_ + qweight_base_s);
           constexpr int kAccess = ThreadMap::kElementsPerAccess;
@@ -342,8 +340,7 @@ class Sm70MoeU4B8IteratorB {
       return;
     }
 
-    if constexpr (kGroupSize != -1 &&
-                  ThreadMap::Iterations::kStrided == 1) {
+    if constexpr (kGroupSize != -1 && ThreadMap::Iterations::kStrided == 1) {
       int const first_logical_k = k_offset_ + thread_offset_.strided();
       cache_current_group_metadata(scale_group(first_logical_k));
     }
@@ -362,18 +359,17 @@ struct Sm70MoeU4B8GemmSpec {
   using IteratorA = Sm70MoeGatherIteratorA<Shape, ThreadMap>;
 
   template <typename Shape, typename ThreadMap, int GroupSize, int PackedMacroN>
-  using IteratorB =
-      Sm70MoeU4B8IteratorB<Shape, ThreadMap, GroupSize, PackedMacroN,
-                           UseMetadataVectorWords>;
+  using IteratorB = Sm70MoeU4B8IteratorB<Shape, ThreadMap, GroupSize,
+                                         PackedMacroN, UseMetadataVectorWords>;
 };
 
-template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM,
-          int WarpN, int WarpK, int GroupSize, int PackedMacroN,
+template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM, int WarpN,
+          int WarpK, int GroupSize, int PackedMacroN,
           bool UseMetadataVectorWords = true>
 using Sm70MoeU4B8GemmTraits =
-    Sm70MarlinMoeGemmTraits<
-        Sm70MoeU4B8GemmSpec<UseMetadataVectorWords>, CtaM, CtaN, CtaK,
-        Warps, WarpM, WarpN, WarpK, GroupSize, PackedMacroN>;
+    Sm70MarlinMoeGemmTraits<Sm70MoeU4B8GemmSpec<UseMetadataVectorWords>, CtaM,
+                            CtaN, CtaK, Warps, WarpM, WarpN, WarpK, GroupSize,
+                            PackedMacroN>;
 
 template <bool UseMetadataVectorWords = true>
 struct Sm70MoeU4B8Launcher {
@@ -395,16 +391,16 @@ struct Sm70MoeU4B8Launcher {
   int64_t size_k;
   int requested_split_k;
 
-  template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM,
-          int WarpN, int WarpK, int GroupSize, int PackedMacroN>
+  template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM, int WarpN,
+            int WarpK, int GroupSize, int PackedMacroN>
   torch::Tensor operator()() const {
-    using Traits = Sm70MoeU4B8GemmTraits<CtaM, CtaN, CtaK, Warps, WarpM,
-                                         WarpN, WarpK, GroupSize, PackedMacroN,
-                                         UseMetadataVectorWords>;
+    using Traits =
+        Sm70MoeU4B8GemmTraits<CtaM, CtaN, CtaK, Warps, WarpM, WarpN, WarpK,
+                              GroupSize, PackedMacroN, UseMetadataVectorWords>;
     return launch_sm70_marlin_moe_gemm<Traits>(
         a, c, b_q_weight, b_scales, b_zeros, global_scale, sorted_token_ids,
-        expert_ids, num_tokens_past_padded, topk_weights, moe_block_size,
-        top_k, mul_topk_weights, size_m, size_n, size_k, requested_split_k);
+        expert_ids, num_tokens_past_padded, topk_weights, moe_block_size, top_k,
+        mul_topk_weights, size_m, size_n, size_k, requested_split_k);
   }
 };
 
@@ -422,9 +418,10 @@ torch::Tensor sm70_marlin_u4b8_gemm(
   auto const params = sm70_marlin_moe_auto_stage_params(
       "uint4b8", group_size, moe_block_size, top_k, size_m, size_n, size_k);
   Sm70CtaGeometry const geometry = params.geometry;
-  validate_sm70_marlin_moe_stage_cta_geometry_supported("SM70 Marlin MoE uint4b8", geometry);
-  validate_sm70_marlin_moe_stage_cta_n_alignment("SM70 Marlin MoE uint4b8", geometry,
-                                        size_n);
+  validate_sm70_marlin_moe_stage_cta_geometry_supported(
+      "SM70 Marlin MoE uint4b8", geometry);
+  validate_sm70_marlin_moe_stage_cta_n_alignment("SM70 Marlin MoE uint4b8",
+                                                 geometry, size_n);
   TORCH_CHECK(size_k % geometry.cta_k == 0,
               "SM70 Marlin MoE uint4b8 requires K divisible by CTA_K=",
               geometry.cta_k, ". Got K=", size_k, ".");
@@ -433,17 +430,43 @@ torch::Tensor sm70_marlin_u4b8_gemm(
   auto empty_float = torch::empty(
       {0}, torch::TensorOptions().dtype(at::kFloat).device(a.device()));
   if (params.use_metadata_vector_words) {
-    Sm70MoeU4B8Launcher<true> const launcher{
-        a, c, b_q_weight, b_scales, empty_half, empty_float, sorted_token_ids,
-        expert_ids, num_tokens_past_padded, topk_weights, moe_block_size, top_k,
-        mul_topk_weights, size_m, size_n, size_k, params.requested_split_k};
+    Sm70MoeU4B8Launcher<true> const launcher{a,
+                                             c,
+                                             b_q_weight,
+                                             b_scales,
+                                             empty_half,
+                                             empty_float,
+                                             sorted_token_ids,
+                                             expert_ids,
+                                             num_tokens_past_padded,
+                                             topk_weights,
+                                             moe_block_size,
+                                             top_k,
+                                             mul_topk_weights,
+                                             size_m,
+                                             size_n,
+                                             size_k,
+                                             params.requested_split_k};
     return dispatch_sm70_marlin_moe_geometry(
         launcher, geometry, params.packed_macro_n, group_size, "uint4b8");
   }
-  Sm70MoeU4B8Launcher<false> const launcher{
-      a, c, b_q_weight, b_scales, empty_half, empty_float, sorted_token_ids,
-      expert_ids, num_tokens_past_padded, topk_weights, moe_block_size, top_k,
-      mul_topk_weights, size_m, size_n, size_k, params.requested_split_k};
+  Sm70MoeU4B8Launcher<false> const launcher{a,
+                                            c,
+                                            b_q_weight,
+                                            b_scales,
+                                            empty_half,
+                                            empty_float,
+                                            sorted_token_ids,
+                                            expert_ids,
+                                            num_tokens_past_padded,
+                                            topk_weights,
+                                            moe_block_size,
+                                            top_k,
+                                            mul_topk_weights,
+                                            size_m,
+                                            size_n,
+                                            size_k,
+                                            params.requested_split_k};
   return dispatch_sm70_marlin_moe_geometry(
       launcher, geometry, params.packed_macro_n, group_size, "uint4b8");
 }

--- a/csrc/moe/marlin_moe_wna16/sm70_marlin_u8_gemm.cu
+++ b/csrc/moe/marlin_moe_wna16/sm70_marlin_u8_gemm.cu
@@ -35,22 +35,24 @@ class Sm70MoeU8ZpIteratorB {
   static int const kPackedMacroN = PackedMacroN_;
   static constexpr bool kUseMetadataVectorWords = UseMetadataVectorWords_;
   using Element = cutlass::half_t;
-  using Fragment = cutlass::Array<
-      Element, ThreadMap::Iterations::kCount * ThreadMap::kElementsPerAccess>;
-    static_assert(Shape::kN == 64 || Shape::kN == 128 || Shape::kN == 256,
-                "SM70 Marlin MoE U8 IteratorB expects CTA_N in {64, 128, 256}.");
-  static_assert(ThreadMap::Iterations::kContiguous ==
-                    Shape::kN / kQuantTileN,
-                "SM70 Marlin MoE U8 IteratorB expects one contiguous iteration per "
-                "64-column quant tile.");
+  using Fragment = cutlass::Array<Element, ThreadMap::Iterations::kCount *
+                                               ThreadMap::kElementsPerAccess>;
+  static_assert(
+      Shape::kN == 64 || Shape::kN == 128 || Shape::kN == 256,
+      "SM70 Marlin MoE U8 IteratorB expects CTA_N in {64, 128, 256}.");
+  static_assert(
+      ThreadMap::Iterations::kContiguous == Shape::kN / kQuantTileN,
+      "SM70 Marlin MoE U8 IteratorB expects one contiguous iteration per "
+      "64-column quant tile.");
   static_assert(ThreadMap::Delta::kContiguous == kQuantTileN,
                 "SM70 Marlin MoE U8 IteratorB expects 64-column deltas.");
   static_assert(ThreadMap::kElementsPerAccess == kU8ValuesPerAccess,
                 "SM70 Marlin MoE U8 IteratorB expects two packed U8 words per "
                 "access.");
-  static_assert(ThreadMap::Iterations::kStrided >= 1,
-                "SM70 Marlin MoE U8-family IteratorB expects one or more strided "
-                "iterations.");
+  static_assert(
+      ThreadMap::Iterations::kStrided >= 1,
+      "SM70 Marlin MoE U8-family IteratorB expects one or more strided "
+      "iterations.");
   static constexpr int kQweightWordStrideWords = kPackedMacroN / kQuantTileN;
 
   struct Params {
@@ -88,11 +90,10 @@ class Sm70MoeU8ZpIteratorB {
                        half const* scales, half const* zp, int thread_id,
                        int expert, int k_offset, int n_offset)
       : qweight_(qweight),
-        scales_expert_base_(scales +
-                            (expert >= 0 ? expert : 0) *
-                                params.num_groups * params.size_n),
-        zp_expert_base_(zp + (expert >= 0 ? expert : 0) *
-                                 params.num_groups * params.size_n),
+        scales_expert_base_(scales + (expert >= 0 ? expert : 0) *
+                                         params.num_groups * params.size_n),
+        zp_expert_base_(zp + (expert >= 0 ? expert : 0) * params.num_groups *
+                                 params.size_n),
         params_(params),
         thread_offset_(ThreadMap::initial_offset(thread_id)),
         expert_(expert),
@@ -134,17 +135,14 @@ class Sm70MoeU8ZpIteratorB {
   }
 
   CUTLASS_DEVICE
-  int metadata_group_offset(int group) const {
-    return group * params_.size_n;
-  }
+  int metadata_group_offset(int group) const { return group * params_.size_n; }
 
   CUTLASS_DEVICE
   int scale_group(int logical_k) const {
     if constexpr (kGroupSize == -1) {
       return 0;
     } else {
-      static_assert(kGroupSize == 32 || kGroupSize == 64 ||
-                        kGroupSize == 128,
+      static_assert(kGroupSize == 32 || kGroupSize == 64 || kGroupSize == 128,
                     "SM70 Marlin MoE U8 supports only group sizes -1, 32, 64, "
                     "and 128.");
       return logical_k / kGroupSize;
@@ -161,16 +159,16 @@ class Sm70MoeU8ZpIteratorB {
   CUTLASS_DEVICE
   void cache_metadata_lane_vectors(int c, int group, int cache_n) const {
     int const metadata_offset = metadata_group_offset(group) + cache_n;
-    half2 const* scale_vec = reinterpret_cast<half2 const*>(
-        scales_expert_base_ + metadata_offset);
+    half2 const* scale_vec =
+        reinterpret_cast<half2 const*>(scales_expert_base_ + metadata_offset);
     half2* scale_cache = cached_scales_ + c * 4;
     scale_cache[0] = scale_vec[0];
     scale_cache[1] = scale_vec[1];
     scale_cache[2] = scale_vec[2];
     scale_cache[3] = scale_vec[3];
 
-    half2 const* zp_vec = reinterpret_cast<half2 const*>(
-        zp_expert_base_ + metadata_offset);
+    half2 const* zp_vec =
+        reinterpret_cast<half2 const*>(zp_expert_base_ + metadata_offset);
     half2* zp_cache = cached_zp_ + c * 4;
     zp_cache[0] = zp_vec[0];
     zp_cache[1] = zp_vec[1];
@@ -181,8 +179,8 @@ class Sm70MoeU8ZpIteratorB {
   CUTLASS_DEVICE
   void cache_metadata_vector_words(int c, int group, int cache_n) const {
     int const metadata_offset = metadata_group_offset(group) + cache_n;
-    uint4 const scale_words = *reinterpret_cast<uint4 const*>(
-        scales_expert_base_ + metadata_offset);
+    uint4 const scale_words =
+        *reinterpret_cast<uint4 const*>(scales_expert_base_ + metadata_offset);
     half2 const* scale_vec = reinterpret_cast<half2 const*>(&scale_words);
     half2* scale_cache = cached_scales_ + c * 4;
     scale_cache[0] = scale_vec[0];
@@ -190,8 +188,8 @@ class Sm70MoeU8ZpIteratorB {
     scale_cache[2] = scale_vec[2];
     scale_cache[3] = scale_vec[3];
 
-    uint4 const zp_words = *reinterpret_cast<uint4 const*>(
-        zp_expert_base_ + metadata_offset);
+    uint4 const zp_words =
+        *reinterpret_cast<uint4 const*>(zp_expert_base_ + metadata_offset);
     half2 const* zp_vec = reinterpret_cast<half2 const*>(&zp_words);
     half2* zp_cache = cached_zp_ + c * 4;
     zp_cache[0] = zp_vec[0];
@@ -204,9 +202,8 @@ class Sm70MoeU8ZpIteratorB {
   void cache_current_group_metadata(int group) const {
     CUTLASS_PRAGMA_UNROLL
     for (int c = 0; c < ThreadMap::Iterations::kContiguous; ++c) {
-      int const cache_n =
-          n_offset_ + thread_offset_.contiguous() +
-          c * ThreadMap::Delta::kContiguous;
+      int const cache_n = n_offset_ + thread_offset_.contiguous() +
+                          c * ThreadMap::Delta::kContiguous;
       if constexpr (kUseMetadataVectorWords) {
         cache_metadata_vector_words(c, group, cache_n);
       } else {
@@ -269,8 +266,9 @@ class Sm70MoeU8ZpIteratorB {
           frag_vec[3] = __hfma2(deq[1], scale_vec[3], __hneg2(zp_vec[3]));
         }
       } else {
-        static_assert(ThreadMap::Iterations::kContiguous == 1,
-                      "Unsupported SM70 Marlin MoE U8 contiguous iteration count.");
+        static_assert(
+            ThreadMap::Iterations::kContiguous == 1,
+            "Unsupported SM70 Marlin MoE U8 contiguous iteration count.");
         uint32_t const qword0 =
             load_qword_vector<1>(qweight_ + qweight_base_offset_);
         uint32_t const qword1 = load_qword_vector<1>(
@@ -280,12 +278,12 @@ class Sm70MoeU8ZpIteratorB {
 
         half2 deq[2];
         half2* frag_vec = reinterpret_cast<half2*>(frag.data());
-        marlin::dequant<half2, vllm::kU8.id(), false>(
-            static_cast<int>(qword0), deq);
+        marlin::dequant<half2, vllm::kU8.id(), false>(static_cast<int>(qword0),
+                                                      deq);
         frag_vec[0] = __hfma2(deq[0], scale_vec[0], __hneg2(zp_vec[0]));
         frag_vec[1] = __hfma2(deq[1], scale_vec[1], __hneg2(zp_vec[1]));
-        marlin::dequant<half2, vllm::kU8.id(), false>(
-            static_cast<int>(qword1), deq);
+        marlin::dequant<half2, vllm::kU8.id(), false>(static_cast<int>(qword1),
+                                                      deq);
         frag_vec[2] = __hfma2(deq[0], scale_vec[2], __hneg2(zp_vec[2]));
         frag_vec[3] = __hfma2(deq[1], scale_vec[3], __hneg2(zp_vec[3]));
       }
@@ -293,9 +291,8 @@ class Sm70MoeU8ZpIteratorB {
       int const logical_n_base = n_offset_ + thread_offset_.contiguous();
       CUTLASS_PRAGMA_UNROLL
       for (int s = 0; s < ThreadMap::Iterations::kStrided; ++s) {
-        int const logical_k_s =
-            k_offset_ + thread_offset_.strided() +
-            s * ThreadMap::Delta::kStrided;
+        int const logical_k_s = k_offset_ + thread_offset_.strided() +
+                                s * ThreadMap::Delta::kStrided;
         if constexpr (kGroupSize != -1) {
           cache_current_group_metadata(scale_group(logical_k_s));
         }
@@ -303,10 +300,9 @@ class Sm70MoeU8ZpIteratorB {
             expert_qweight_base_offset() +
             qweight_offset_from_logical(params_, logical_k_s, logical_n_base);
         if constexpr (ThreadMap::Iterations::kContiguous == 4) {
-          uint4 const qwords0 =
-              load_qword_vector<4>(qweight_ + qweight_base_s);
-          uint4 const qwords1 = load_qword_vector<4>(
-              qweight_ + qweight_base_s + kQweightWordStrideWords);
+          uint4 const qwords0 = load_qword_vector<4>(qweight_ + qweight_base_s);
+          uint4 const qwords1 = load_qword_vector<4>(qweight_ + qweight_base_s +
+                                                     kQweightWordStrideWords);
           CUTLASS_PRAGMA_UNROLL
           for (int c = 0; c < ThreadMap::Iterations::kContiguous; ++c) {
             constexpr int kAccess = ThreadMap::kElementsPerAccess;
@@ -321,22 +317,17 @@ class Sm70MoeU8ZpIteratorB {
             half2* frag_vec = reinterpret_cast<half2*>(frag.data() + frag_base);
             marlin::dequant<half2, vllm::kU8.id(), false>(
                 static_cast<int>(qword0), deq);
-            frag_vec[0] =
-                __hfma2(deq[0], scale_vec[0], __hneg2(zp_vec[0]));
-            frag_vec[1] =
-                __hfma2(deq[1], scale_vec[1], __hneg2(zp_vec[1]));
+            frag_vec[0] = __hfma2(deq[0], scale_vec[0], __hneg2(zp_vec[0]));
+            frag_vec[1] = __hfma2(deq[1], scale_vec[1], __hneg2(zp_vec[1]));
             marlin::dequant<half2, vllm::kU8.id(), false>(
                 static_cast<int>(qword1), deq);
-            frag_vec[2] =
-                __hfma2(deq[0], scale_vec[2], __hneg2(zp_vec[2]));
-            frag_vec[3] =
-                __hfma2(deq[1], scale_vec[3], __hneg2(zp_vec[3]));
+            frag_vec[2] = __hfma2(deq[0], scale_vec[2], __hneg2(zp_vec[2]));
+            frag_vec[3] = __hfma2(deq[1], scale_vec[3], __hneg2(zp_vec[3]));
           }
         } else if constexpr (ThreadMap::Iterations::kContiguous == 2) {
-          uint2 const qwords0 =
-              load_qword_vector<2>(qweight_ + qweight_base_s);
-          uint2 const qwords1 = load_qword_vector<2>(
-              qweight_ + qweight_base_s + kQweightWordStrideWords);
+          uint2 const qwords0 = load_qword_vector<2>(qweight_ + qweight_base_s);
+          uint2 const qwords1 = load_qword_vector<2>(qweight_ + qweight_base_s +
+                                                     kQweightWordStrideWords);
           CUTLASS_PRAGMA_UNROLL
           for (int c = 0; c < ThreadMap::Iterations::kContiguous; ++c) {
             constexpr int kAccess = ThreadMap::kElementsPerAccess;
@@ -351,20 +342,17 @@ class Sm70MoeU8ZpIteratorB {
             half2* frag_vec = reinterpret_cast<half2*>(frag.data() + frag_base);
             marlin::dequant<half2, vllm::kU8.id(), false>(
                 static_cast<int>(qword0), deq);
-            frag_vec[0] =
-                __hfma2(deq[0], scale_vec[0], __hneg2(zp_vec[0]));
-            frag_vec[1] =
-                __hfma2(deq[1], scale_vec[1], __hneg2(zp_vec[1]));
+            frag_vec[0] = __hfma2(deq[0], scale_vec[0], __hneg2(zp_vec[0]));
+            frag_vec[1] = __hfma2(deq[1], scale_vec[1], __hneg2(zp_vec[1]));
             marlin::dequant<half2, vllm::kU8.id(), false>(
                 static_cast<int>(qword1), deq);
-            frag_vec[2] =
-                __hfma2(deq[0], scale_vec[2], __hneg2(zp_vec[2]));
-            frag_vec[3] =
-                __hfma2(deq[1], scale_vec[3], __hneg2(zp_vec[3]));
+            frag_vec[2] = __hfma2(deq[0], scale_vec[2], __hneg2(zp_vec[2]));
+            frag_vec[3] = __hfma2(deq[1], scale_vec[3], __hneg2(zp_vec[3]));
           }
         } else {
-          static_assert(ThreadMap::Iterations::kContiguous == 1,
-                        "Unsupported SM70 Marlin MoE U8 contiguous iteration count.");
+          static_assert(
+              ThreadMap::Iterations::kContiguous == 1,
+              "Unsupported SM70 Marlin MoE U8 contiguous iteration count.");
           uint32_t const qword0 =
               load_qword_vector<1>(qweight_ + qweight_base_s);
           uint32_t const qword1 = load_qword_vector<1>(
@@ -395,8 +383,7 @@ class Sm70MoeU8ZpIteratorB {
       return;
     }
 
-    if constexpr (kGroupSize != -1 &&
-                  ThreadMap::Iterations::kStrided == 1) {
+    if constexpr (kGroupSize != -1 && ThreadMap::Iterations::kStrided == 1) {
       int const first_logical_k = k_offset_ + thread_offset_.strided();
       cache_current_group_metadata(scale_group(first_logical_k));
     }
@@ -415,18 +402,17 @@ struct Sm70MoeU8ZpGemmSpec {
   using IteratorA = Sm70MoeGatherIteratorA<Shape, ThreadMap>;
 
   template <typename Shape, typename ThreadMap, int GroupSize, int PackedMacroN>
-  using IteratorB =
-      Sm70MoeU8ZpIteratorB<Shape, ThreadMap, GroupSize, PackedMacroN,
-                           UseMetadataVectorWords>;
+  using IteratorB = Sm70MoeU8ZpIteratorB<Shape, ThreadMap, GroupSize,
+                                         PackedMacroN, UseMetadataVectorWords>;
 };
 
-template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM,
-          int WarpN, int WarpK, int GroupSize, int PackedMacroN,
+template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM, int WarpN,
+          int WarpK, int GroupSize, int PackedMacroN,
           bool UseMetadataVectorWords = true>
 using Sm70MoeU8ZpGemmTraits =
-    Sm70MarlinMoeGemmTraits<
-        Sm70MoeU8ZpGemmSpec<UseMetadataVectorWords>, CtaM, CtaN, CtaK,
-        Warps, WarpM, WarpN, WarpK, GroupSize, PackedMacroN>;
+    Sm70MarlinMoeGemmTraits<Sm70MoeU8ZpGemmSpec<UseMetadataVectorWords>, CtaM,
+                            CtaN, CtaK, Warps, WarpM, WarpN, WarpK, GroupSize,
+                            PackedMacroN>;
 
 template <bool UseMetadataVectorWords = true>
 struct Sm70MoeU8Launcher {
@@ -448,16 +434,16 @@ struct Sm70MoeU8Launcher {
   int64_t size_k;
   int requested_split_k;
 
-  template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM,
-          int WarpN, int WarpK, int GroupSize, int PackedMacroN>
+  template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM, int WarpN,
+            int WarpK, int GroupSize, int PackedMacroN>
   torch::Tensor operator()() const {
-    using Traits = Sm70MoeU8ZpGemmTraits<CtaM, CtaN, CtaK, Warps, WarpM,
-                                         WarpN, WarpK, GroupSize, PackedMacroN,
-                                         UseMetadataVectorWords>;
+    using Traits =
+        Sm70MoeU8ZpGemmTraits<CtaM, CtaN, CtaK, Warps, WarpM, WarpN, WarpK,
+                              GroupSize, PackedMacroN, UseMetadataVectorWords>;
     return launch_sm70_marlin_moe_gemm<Traits>(
         a, c, b_q_weight, b_scales, b_zeros, global_scale, sorted_token_ids,
-        expert_ids, num_tokens_past_padded, topk_weights, moe_block_size,
-        top_k, mul_topk_weights, size_m, size_n, size_k, requested_split_k);
+        expert_ids, num_tokens_past_padded, topk_weights, moe_block_size, top_k,
+        mul_topk_weights, size_m, size_n, size_k, requested_split_k);
   }
 };
 
@@ -475,9 +461,10 @@ torch::Tensor sm70_marlin_u8_gemm(
   auto const params = sm70_marlin_moe_auto_stage_params(
       "uint8", group_size, moe_block_size, top_k, size_m, size_n, size_k);
   Sm70CtaGeometry const geometry = params.geometry;
-  validate_sm70_marlin_moe_stage_cta_geometry_supported("SM70 Marlin MoE uint8", geometry);
-  validate_sm70_marlin_moe_stage_cta_n_alignment("SM70 Marlin MoE uint8", geometry,
-                                        size_n);
+  validate_sm70_marlin_moe_stage_cta_geometry_supported("SM70 Marlin MoE uint8",
+                                                        geometry);
+  validate_sm70_marlin_moe_stage_cta_n_alignment("SM70 Marlin MoE uint8",
+                                                 geometry, size_n);
   TORCH_CHECK(size_k % geometry.cta_k == 0,
               "SM70 Marlin MoE uint8 requires K divisible by CTA_K=",
               geometry.cta_k, ". Got K=", size_k, ".");
@@ -485,19 +472,45 @@ torch::Tensor sm70_marlin_u8_gemm(
   auto empty_float = torch::empty(
       {0}, torch::TensorOptions().dtype(at::kFloat).device(a.device()));
   if (params.use_metadata_vector_words) {
-    Sm70MoeU8Launcher<true> const launcher{
-        a, c, b_q_weight, b_scales, b_zeros, empty_float, sorted_token_ids,
-        expert_ids, num_tokens_past_padded, topk_weights, moe_block_size, top_k,
-        mul_topk_weights, size_m, size_n, size_k, params.requested_split_k};
-    return dispatch_sm70_marlin_moe_geometry_with_group32(launcher, geometry, params.packed_macro_n, group_size,
-        "uint8");
+    Sm70MoeU8Launcher<true> const launcher{a,
+                                           c,
+                                           b_q_weight,
+                                           b_scales,
+                                           b_zeros,
+                                           empty_float,
+                                           sorted_token_ids,
+                                           expert_ids,
+                                           num_tokens_past_padded,
+                                           topk_weights,
+                                           moe_block_size,
+                                           top_k,
+                                           mul_topk_weights,
+                                           size_m,
+                                           size_n,
+                                           size_k,
+                                           params.requested_split_k};
+    return dispatch_sm70_marlin_moe_geometry_with_group32(
+        launcher, geometry, params.packed_macro_n, group_size, "uint8");
   }
-  Sm70MoeU8Launcher<false> const launcher{
-      a, c, b_q_weight, b_scales, b_zeros, empty_float, sorted_token_ids,
-      expert_ids, num_tokens_past_padded, topk_weights, moe_block_size, top_k,
-      mul_topk_weights, size_m, size_n, size_k, params.requested_split_k};
-  return dispatch_sm70_marlin_moe_geometry_with_group32(launcher, geometry, params.packed_macro_n, group_size,
-      "uint8");
+  Sm70MoeU8Launcher<false> const launcher{a,
+                                          c,
+                                          b_q_weight,
+                                          b_scales,
+                                          b_zeros,
+                                          empty_float,
+                                          sorted_token_ids,
+                                          expert_ids,
+                                          num_tokens_past_padded,
+                                          topk_weights,
+                                          moe_block_size,
+                                          top_k,
+                                          mul_topk_weights,
+                                          size_m,
+                                          size_n,
+                                          size_k,
+                                          params.requested_split_k};
+  return dispatch_sm70_marlin_moe_geometry_with_group32(
+      launcher, geometry, params.packed_macro_n, group_size, "uint8");
 }
 
 }  // namespace marlin_moe_wna16

--- a/csrc/moe/marlin_moe_wna16/sm70_marlin_u8b128_gemm.cu
+++ b/csrc/moe/marlin_moe_wna16/sm70_marlin_u8b128_gemm.cu
@@ -35,22 +35,25 @@ class Sm70MoeU8B128IteratorB {
   static int const kPackedMacroN = PackedMacroN_;
   static constexpr bool kUseMetadataVectorWords = UseMetadataVectorWords_;
   using Element = cutlass::half_t;
-  using Fragment = cutlass::Array<
-      Element, ThreadMap::Iterations::kCount * ThreadMap::kElementsPerAccess>;
-    static_assert(Shape::kN == 64 || Shape::kN == 128 || Shape::kN == 256,
-                "SM70 Marlin MoE U8B128 IteratorB expects CTA_N in {64, 128, 256}.");
-  static_assert(ThreadMap::Iterations::kContiguous ==
-                    Shape::kN / kQuantTileN,
-                "SM70 Marlin MoE U8B128 IteratorB expects one contiguous iteration per "
-                "64-column quant tile.");
+  using Fragment = cutlass::Array<Element, ThreadMap::Iterations::kCount *
+                                               ThreadMap::kElementsPerAccess>;
+  static_assert(
+      Shape::kN == 64 || Shape::kN == 128 || Shape::kN == 256,
+      "SM70 Marlin MoE U8B128 IteratorB expects CTA_N in {64, 128, 256}.");
+  static_assert(
+      ThreadMap::Iterations::kContiguous == Shape::kN / kQuantTileN,
+      "SM70 Marlin MoE U8B128 IteratorB expects one contiguous iteration per "
+      "64-column quant tile.");
   static_assert(ThreadMap::Delta::kContiguous == kQuantTileN,
                 "SM70 Marlin MoE U8B128 IteratorB expects 64-column deltas.");
-  static_assert(ThreadMap::kElementsPerAccess == kU8B128ValuesPerAccess,
-                "SM70 Marlin MoE U8B128 IteratorB expects two packed U8B128 words "
-                "per access.");
-  static_assert(ThreadMap::Iterations::kStrided >= 1,
-                "SM70 Marlin MoE U8-family IteratorB expects one or more strided "
-                "iterations.");
+  static_assert(
+      ThreadMap::kElementsPerAccess == kU8B128ValuesPerAccess,
+      "SM70 Marlin MoE U8B128 IteratorB expects two packed U8B128 words "
+      "per access.");
+  static_assert(
+      ThreadMap::Iterations::kStrided >= 1,
+      "SM70 Marlin MoE U8-family IteratorB expects one or more strided "
+      "iterations.");
   static constexpr int kQweightWordStrideWords = kPackedMacroN / kQuantTileN;
 
   struct Params {
@@ -86,9 +89,8 @@ class Sm70MoeU8B128IteratorB {
                          half const* scales, half const*, int thread_id,
                          int expert, int k_offset, int n_offset)
       : qweight_(qweight),
-        scales_expert_base_(scales +
-                            (expert >= 0 ? expert : 0) *
-                                params.num_groups * params.size_n),
+        scales_expert_base_(scales + (expert >= 0 ? expert : 0) *
+                                         params.num_groups * params.size_n),
         params_(params),
         thread_offset_(ThreadMap::initial_offset(thread_id)),
         expert_(expert),
@@ -130,19 +132,17 @@ class Sm70MoeU8B128IteratorB {
   }
 
   CUTLASS_DEVICE
-  int metadata_group_offset(int group) const {
-    return group * params_.size_n;
-  }
+  int metadata_group_offset(int group) const { return group * params_.size_n; }
 
   CUTLASS_DEVICE
   int scale_group(int logical_k) const {
     if constexpr (kGroupSize == -1) {
       return 0;
     } else {
-      static_assert(kGroupSize == 32 || kGroupSize == 64 ||
-                        kGroupSize == 128,
-                    "SM70 Marlin MoE U8B128 supports only group sizes -1, 32, 64, "
-                    "and 128.");
+      static_assert(
+          kGroupSize == 32 || kGroupSize == 64 || kGroupSize == 128,
+          "SM70 Marlin MoE U8B128 supports only group sizes -1, 32, 64, "
+          "and 128.");
       return logical_k / kGroupSize;
     }
   }
@@ -157,8 +157,8 @@ class Sm70MoeU8B128IteratorB {
   CUTLASS_DEVICE
   void cache_metadata_lane_vectors(int c, int group, int cache_n) const {
     int const metadata_offset = metadata_group_offset(group) + cache_n;
-    half2 const* scale_vec = reinterpret_cast<half2 const*>(
-        scales_expert_base_ + metadata_offset);
+    half2 const* scale_vec =
+        reinterpret_cast<half2 const*>(scales_expert_base_ + metadata_offset);
     half2* scale_cache = cached_scales_ + c * 4;
     scale_cache[0] = scale_vec[0];
     scale_cache[1] = scale_vec[1];
@@ -169,8 +169,8 @@ class Sm70MoeU8B128IteratorB {
   CUTLASS_DEVICE
   void cache_metadata_vector_words(int c, int group, int cache_n) const {
     int const metadata_offset = metadata_group_offset(group) + cache_n;
-    uint4 const scale_words = *reinterpret_cast<uint4 const*>(
-        scales_expert_base_ + metadata_offset);
+    uint4 const scale_words =
+        *reinterpret_cast<uint4 const*>(scales_expert_base_ + metadata_offset);
     half2 const* scale_vec = reinterpret_cast<half2 const*>(&scale_words);
     half2* scale_cache = cached_scales_ + c * 4;
     scale_cache[0] = scale_vec[0];
@@ -183,9 +183,8 @@ class Sm70MoeU8B128IteratorB {
   void cache_current_group_metadata(int group) const {
     CUTLASS_PRAGMA_UNROLL
     for (int c = 0; c < ThreadMap::Iterations::kContiguous; ++c) {
-      int const cache_n =
-          n_offset_ + thread_offset_.contiguous() +
-          c * ThreadMap::Delta::kContiguous;
+      int const cache_n = n_offset_ + thread_offset_.contiguous() +
+                          c * ThreadMap::Delta::kContiguous;
       if constexpr (kUseMetadataVectorWords) {
         cache_metadata_vector_words(c, group, cache_n);
       } else {
@@ -246,8 +245,9 @@ class Sm70MoeU8B128IteratorB {
           frag_vec[3] = __hmul2(deq[1], scale_vec[3]);
         }
       } else {
-        static_assert(ThreadMap::Iterations::kContiguous == 1,
-                      "Unsupported SM70 Marlin MoE U8B128 contiguous iteration count.");
+        static_assert(
+            ThreadMap::Iterations::kContiguous == 1,
+            "Unsupported SM70 Marlin MoE U8B128 contiguous iteration count.");
         uint32_t const qword0 =
             load_qword_vector<1>(qweight_ + qweight_base_offset_);
         uint32_t const qword1 = load_qword_vector<1>(
@@ -269,9 +269,8 @@ class Sm70MoeU8B128IteratorB {
       int const logical_n_base = n_offset_ + thread_offset_.contiguous();
       CUTLASS_PRAGMA_UNROLL
       for (int s = 0; s < ThreadMap::Iterations::kStrided; ++s) {
-        int const logical_k_s =
-            k_offset_ + thread_offset_.strided() +
-            s * ThreadMap::Delta::kStrided;
+        int const logical_k_s = k_offset_ + thread_offset_.strided() +
+                                s * ThreadMap::Delta::kStrided;
         if constexpr (kGroupSize != -1) {
           cache_current_group_metadata(scale_group(logical_k_s));
         }
@@ -279,10 +278,9 @@ class Sm70MoeU8B128IteratorB {
             expert_qweight_base_offset() +
             qweight_offset_from_logical(params_, logical_k_s, logical_n_base);
         if constexpr (ThreadMap::Iterations::kContiguous == 4) {
-          uint4 const qwords0 =
-              load_qword_vector<4>(qweight_ + qweight_base_s);
-          uint4 const qwords1 = load_qword_vector<4>(
-              qweight_ + qweight_base_s + kQweightWordStrideWords);
+          uint4 const qwords0 = load_qword_vector<4>(qweight_ + qweight_base_s);
+          uint4 const qwords1 = load_qword_vector<4>(qweight_ + qweight_base_s +
+                                                     kQweightWordStrideWords);
           CUTLASS_PRAGMA_UNROLL
           for (int c = 0; c < ThreadMap::Iterations::kContiguous; ++c) {
             constexpr int kAccess = ThreadMap::kElementsPerAccess;
@@ -296,22 +294,17 @@ class Sm70MoeU8B128IteratorB {
             half2* frag_vec = reinterpret_cast<half2*>(frag.data() + frag_base);
             marlin::dequant<half2, vllm::kU8B128.id(), false>(
                 static_cast<int>(qword0), deq);
-            frag_vec[0] =
-                __hmul2(deq[0], scale_vec[0]);
-            frag_vec[1] =
-                __hmul2(deq[1], scale_vec[1]);
+            frag_vec[0] = __hmul2(deq[0], scale_vec[0]);
+            frag_vec[1] = __hmul2(deq[1], scale_vec[1]);
             marlin::dequant<half2, vllm::kU8B128.id(), false>(
                 static_cast<int>(qword1), deq);
-            frag_vec[2] =
-                __hmul2(deq[0], scale_vec[2]);
-            frag_vec[3] =
-                __hmul2(deq[1], scale_vec[3]);
+            frag_vec[2] = __hmul2(deq[0], scale_vec[2]);
+            frag_vec[3] = __hmul2(deq[1], scale_vec[3]);
           }
         } else if constexpr (ThreadMap::Iterations::kContiguous == 2) {
-          uint2 const qwords0 =
-              load_qword_vector<2>(qweight_ + qweight_base_s);
-          uint2 const qwords1 = load_qword_vector<2>(
-              qweight_ + qweight_base_s + kQweightWordStrideWords);
+          uint2 const qwords0 = load_qword_vector<2>(qweight_ + qweight_base_s);
+          uint2 const qwords1 = load_qword_vector<2>(qweight_ + qweight_base_s +
+                                                     kQweightWordStrideWords);
           CUTLASS_PRAGMA_UNROLL
           for (int c = 0; c < ThreadMap::Iterations::kContiguous; ++c) {
             constexpr int kAccess = ThreadMap::kElementsPerAccess;
@@ -325,20 +318,17 @@ class Sm70MoeU8B128IteratorB {
             half2* frag_vec = reinterpret_cast<half2*>(frag.data() + frag_base);
             marlin::dequant<half2, vllm::kU8B128.id(), false>(
                 static_cast<int>(qword0), deq);
-            frag_vec[0] =
-                __hmul2(deq[0], scale_vec[0]);
-            frag_vec[1] =
-                __hmul2(deq[1], scale_vec[1]);
+            frag_vec[0] = __hmul2(deq[0], scale_vec[0]);
+            frag_vec[1] = __hmul2(deq[1], scale_vec[1]);
             marlin::dequant<half2, vllm::kU8B128.id(), false>(
                 static_cast<int>(qword1), deq);
-            frag_vec[2] =
-                __hmul2(deq[0], scale_vec[2]);
-            frag_vec[3] =
-                __hmul2(deq[1], scale_vec[3]);
+            frag_vec[2] = __hmul2(deq[0], scale_vec[2]);
+            frag_vec[3] = __hmul2(deq[1], scale_vec[3]);
           }
         } else {
-          static_assert(ThreadMap::Iterations::kContiguous == 1,
-                        "Unsupported SM70 Marlin MoE U8B128 contiguous iteration count.");
+          static_assert(
+              ThreadMap::Iterations::kContiguous == 1,
+              "Unsupported SM70 Marlin MoE U8B128 contiguous iteration count.");
           uint32_t const qword0 =
               load_qword_vector<1>(qweight_ + qweight_base_s);
           uint32_t const qword1 = load_qword_vector<1>(
@@ -368,8 +358,7 @@ class Sm70MoeU8B128IteratorB {
       return;
     }
 
-    if constexpr (kGroupSize != -1 &&
-                  ThreadMap::Iterations::kStrided == 1) {
+    if constexpr (kGroupSize != -1 && ThreadMap::Iterations::kStrided == 1) {
       int const first_logical_k = k_offset_ + thread_offset_.strided();
       cache_current_group_metadata(scale_group(first_logical_k));
     }
@@ -393,13 +382,13 @@ struct Sm70MoeU8B128GemmSpec {
                              UseMetadataVectorWords>;
 };
 
-template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM,
-          int WarpN, int WarpK, int GroupSize, int PackedMacroN,
+template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM, int WarpN,
+          int WarpK, int GroupSize, int PackedMacroN,
           bool UseMetadataVectorWords = true>
 using Sm70MoeU8B128GemmTraits =
-    Sm70MarlinMoeGemmTraits<
-        Sm70MoeU8B128GemmSpec<UseMetadataVectorWords>, CtaM, CtaN, CtaK,
-        Warps, WarpM, WarpN, WarpK, GroupSize, PackedMacroN>;
+    Sm70MarlinMoeGemmTraits<Sm70MoeU8B128GemmSpec<UseMetadataVectorWords>, CtaM,
+                            CtaN, CtaK, Warps, WarpM, WarpN, WarpK, GroupSize,
+                            PackedMacroN>;
 
 template <bool UseMetadataVectorWords = true>
 struct Sm70MoeU8B128Launcher {
@@ -421,16 +410,17 @@ struct Sm70MoeU8B128Launcher {
   int64_t size_k;
   int requested_split_k;
 
-  template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM,
-          int WarpN, int WarpK, int GroupSize, int PackedMacroN>
+  template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM, int WarpN,
+            int WarpK, int GroupSize, int PackedMacroN>
   torch::Tensor operator()() const {
-    using Traits = Sm70MoeU8B128GemmTraits<CtaM, CtaN, CtaK, Warps, WarpM,
-                                           WarpN, WarpK, GroupSize, PackedMacroN,
-                                           UseMetadataVectorWords>;
+    using Traits =
+        Sm70MoeU8B128GemmTraits<CtaM, CtaN, CtaK, Warps, WarpM, WarpN, WarpK,
+                                GroupSize, PackedMacroN,
+                                UseMetadataVectorWords>;
     return launch_sm70_marlin_moe_gemm<Traits>(
         a, c, b_q_weight, b_scales, b_zeros, global_scale, sorted_token_ids,
-        expert_ids, num_tokens_past_padded, topk_weights, moe_block_size,
-        top_k, mul_topk_weights, size_m, size_n, size_k, requested_split_k);
+        expert_ids, num_tokens_past_padded, topk_weights, moe_block_size, top_k,
+        mul_topk_weights, size_m, size_n, size_k, requested_split_k);
   }
 };
 
@@ -448,9 +438,10 @@ torch::Tensor sm70_marlin_u8b128_gemm(
   auto const params = sm70_marlin_moe_auto_stage_params(
       "uint8b128", group_size, moe_block_size, top_k, size_m, size_n, size_k);
   Sm70CtaGeometry const geometry = params.geometry;
-  validate_sm70_marlin_moe_stage_cta_geometry_supported("SM70 Marlin MoE uint8b128", geometry);
-  validate_sm70_marlin_moe_stage_cta_n_alignment("SM70 Marlin MoE uint8b128", geometry,
-                                        size_n);
+  validate_sm70_marlin_moe_stage_cta_geometry_supported(
+      "SM70 Marlin MoE uint8b128", geometry);
+  validate_sm70_marlin_moe_stage_cta_n_alignment("SM70 Marlin MoE uint8b128",
+                                                 geometry, size_n);
   TORCH_CHECK(size_k % geometry.cta_k == 0,
               "SM70 Marlin MoE uint8b128 requires K divisible by CTA_K=",
               geometry.cta_k, ". Got K=", size_k, ".");
@@ -459,17 +450,43 @@ torch::Tensor sm70_marlin_u8b128_gemm(
   auto empty_float = torch::empty(
       {0}, torch::TensorOptions().dtype(at::kFloat).device(a.device()));
   if (params.use_metadata_vector_words) {
-    Sm70MoeU8B128Launcher<true> const launcher{
-        a, c, b_q_weight, b_scales, empty_half, empty_float, sorted_token_ids,
-        expert_ids, num_tokens_past_padded, topk_weights, moe_block_size, top_k,
-        mul_topk_weights, size_m, size_n, size_k, params.requested_split_k};
+    Sm70MoeU8B128Launcher<true> const launcher{a,
+                                               c,
+                                               b_q_weight,
+                                               b_scales,
+                                               empty_half,
+                                               empty_float,
+                                               sorted_token_ids,
+                                               expert_ids,
+                                               num_tokens_past_padded,
+                                               topk_weights,
+                                               moe_block_size,
+                                               top_k,
+                                               mul_topk_weights,
+                                               size_m,
+                                               size_n,
+                                               size_k,
+                                               params.requested_split_k};
     return dispatch_sm70_marlin_moe_geometry_with_group32(
         launcher, geometry, params.packed_macro_n, group_size, "uint8b128");
   }
-  Sm70MoeU8B128Launcher<false> const launcher{
-      a, c, b_q_weight, b_scales, empty_half, empty_float, sorted_token_ids,
-      expert_ids, num_tokens_past_padded, topk_weights, moe_block_size, top_k,
-      mul_topk_weights, size_m, size_n, size_k, params.requested_split_k};
+  Sm70MoeU8B128Launcher<false> const launcher{a,
+                                              c,
+                                              b_q_weight,
+                                              b_scales,
+                                              empty_half,
+                                              empty_float,
+                                              sorted_token_ids,
+                                              expert_ids,
+                                              num_tokens_past_padded,
+                                              topk_weights,
+                                              moe_block_size,
+                                              top_k,
+                                              mul_topk_weights,
+                                              size_m,
+                                              size_n,
+                                              size_k,
+                                              params.requested_split_k};
   return dispatch_sm70_marlin_moe_geometry_with_group32(
       launcher, geometry, params.packed_macro_n, group_size, "uint8b128");
 }

--- a/csrc/moe/moe_permute_unpermute_op.cu
+++ b/csrc/moe/moe_permute_unpermute_op.cu
@@ -28,9 +28,7 @@ torch::Tensor maybe_allocate_tensor(
   return torch::empty(expected_sizes, torch::dtype(dtype).device(device));
 }
 
-int64_t pad_to_multiple_of_16(int64_t value) {
-  return (value + 15) / 16 * 16;
-}
+int64_t pad_to_multiple_of_16(int64_t value) { return (value + 15) / 16 * 16; }
 
 }  // namespace
 
@@ -72,16 +70,15 @@ void moe_permute_impl(
   auto expanded_rows = n_token * topk;
   auto stream = at::cuda::getCurrentCUDAStream().stream();
 
-  if (canUseSingleTokenMoePermuteFastPath(
-          n_token, topk, expert_map.has_value(), n_expert, n_local_expert)) {
+  if (canUseSingleTokenMoePermuteFastPath(n_token, topk, expert_map.has_value(),
+                                          n_expert, n_local_expert)) {
     if (input.scalar_type() == at::ScalarType::Half) {
       singleTokenMoePermuteLauncher<half>(
           get_ptr<half>(input), get_ptr<int>(topk_ids),
           get_ptr<half>(permuted_input),
           get_ptr<int64_t>(expert_first_token_offset),
           get_ptr<int>(inv_permuted_idx), get_ptr<int>(permuted_idx),
-          static_cast<int>(n_expert), static_cast<int>(topk), n_hidden,
-          stream);
+          static_cast<int>(n_expert), static_cast<int>(topk), n_hidden, stream);
       return;
     }
     if (input.scalar_type() == at::ScalarType::BFloat16) {
@@ -90,8 +87,7 @@ void moe_permute_impl(
           get_ptr<__nv_bfloat16>(permuted_input),
           get_ptr<int64_t>(expert_first_token_offset),
           get_ptr<int>(inv_permuted_idx), get_ptr<int>(permuted_idx),
-          static_cast<int>(n_expert), static_cast<int>(topk), n_hidden,
-          stream);
+          static_cast<int>(n_expert), static_cast<int>(topk), n_hidden, stream);
       return;
     }
     if (input.scalar_type() == at::ScalarType::Float) {
@@ -100,8 +96,7 @@ void moe_permute_impl(
           get_ptr<float>(permuted_input),
           get_ptr<int64_t>(expert_first_token_offset),
           get_ptr<int>(inv_permuted_idx), get_ptr<int>(permuted_idx),
-          static_cast<int>(n_expert), static_cast<int>(topk), n_hidden,
-          stream);
+          static_cast<int>(n_expert), static_cast<int>(topk), n_hidden, stream);
       return;
     }
   }

--- a/csrc/moe/permute_unpermute_kernels/moe_permute_unpermute_kernel.cu
+++ b/csrc/moe/permute_unpermute_kernels/moe_permute_unpermute_kernel.cu
@@ -93,10 +93,12 @@ bool singleTokenUnpermuteFastPathEnabled() {
 }
 
 template <typename T>
-__global__ void singleTokenMoePermuteKernel(
-    T const* input, int const* topk_ids, T* permuted_output,
-    int64_t* expert_first_token_offset, int* inv_permuted_idx,
-    int* permuted_idx, int num_experts, int topk, int64_t cols) {
+__global__ void singleTokenMoePermuteKernel(T const* input, int const* topk_ids,
+                                            T* permuted_output,
+                                            int64_t* expert_first_token_offset,
+                                            int* inv_permuted_idx,
+                                            int* permuted_idx, int num_experts,
+                                            int topk, int64_t cols) {
   __shared__ int sorted_ids[kSingleTokenFastPathMaxTopK];
   __shared__ int sorted_src[kSingleTokenFastPathMaxTopK];
 
@@ -177,8 +179,8 @@ __global__ void singleTokenMoeUnpermuteKernel(
 
   auto const* expanded_rows_v =
       reinterpret_cast<InputElem const*>(expanded_permuted_rows);
-  auto* reduced_row_ptr_v = reinterpret_cast<OutputElem*>(
-      reduced_unpermuted_output);
+  auto* reduced_row_ptr_v =
+      reinterpret_cast<OutputElem*>(reduced_unpermuted_output);
   int64_t const num_elems_in_col = cols / FINALIZE_ELEM_PER_THREAD;
 
   for (int64_t elem_index = threadIdx.x; elem_index < num_elems_in_col;
@@ -186,7 +188,7 @@ __global__ void singleTokenMoeUnpermuteKernel(
     ComputeElem thread_output;
     thread_output.fill(0);
 
-#pragma unroll
+  #pragma unroll
     for (int k_idx = 0; k_idx < kSingleTokenFastPathMaxTopK; ++k_idx) {
       if (k_idx >= topk) {
         break;
@@ -222,11 +224,12 @@ bool canUseSingleTokenMoePermuteFastPath(int64_t n_token, int64_t topk,
 }
 
 template <typename T>
-void singleTokenMoePermuteLauncher(
-    T const* input, int const* topk_ids, T* permuted_output,
-    int64_t* expert_first_token_offset, int* inv_permuted_idx,
-    int* permuted_idx, int num_experts, int topk, int64_t cols,
-    cudaStream_t stream) {
+void singleTokenMoePermuteLauncher(T const* input, int const* topk_ids,
+                                   T* permuted_output,
+                                   int64_t* expert_first_token_offset,
+                                   int* inv_permuted_idx, int* permuted_idx,
+                                   int num_experts, int topk, int64_t cols,
+                                   cudaStream_t stream) {
   constexpr int threads = 256;
   singleTokenMoePermuteKernel<T><<<1, threads, 0, stream>>>(
       input, topk_ids, permuted_output, expert_first_token_offset,

--- a/csrc/moe/permute_unpermute_kernels/moe_permute_unpermute_kernel.h
+++ b/csrc/moe/permute_unpermute_kernels/moe_permute_unpermute_kernel.h
@@ -80,11 +80,12 @@ bool canUseSingleTokenMoePermuteFastPath(int64_t n_token, int64_t topk,
                                          int64_t n_local_expert);
 
 template <typename T>
-void singleTokenMoePermuteLauncher(
-    T const* input, int const* topk_ids, T* permuted_output,
-    int64_t* expert_first_token_offset, int* inv_permuted_idx,
-    int* permuted_idx, int num_experts, int topk, int64_t cols,
-    cudaStream_t stream);
+void singleTokenMoePermuteLauncher(T const* input, int const* topk_ids,
+                                   T* permuted_output,
+                                   int64_t* expert_first_token_offset,
+                                   int* inv_permuted_idx, int* permuted_idx,
+                                   int num_experts, int topk, int64_t cols,
+                                   cudaStream_t stream);
 
 bool canUseSingleTokenMoeUnpermuteFastPath(int64_t n_token, int64_t topk);
 

--- a/csrc/ops.h
+++ b/csrc/ops.h
@@ -124,126 +124,84 @@ std::vector<torch::Tensor> nvfp4_sm70_prepare(torch::Tensor _kernel,
 
 std::vector<torch::Tensor> sm70_f16_prepare(torch::Tensor _kernel);
 
-torch::Tensor awq_gemm_sm70(torch::Tensor _in_feats,
-                            torch::Tensor _kernel,
-                            torch::Tensor _scaling_factors,
-                            int64_t group_size,
-                            int64_t k_ld,
-                            int64_t q_ld);
+torch::Tensor awq_gemm_sm70(torch::Tensor _in_feats, torch::Tensor _kernel,
+                            torch::Tensor _scaling_factors, int64_t group_size,
+                            int64_t k_ld, int64_t q_ld);
 
 torch::Tensor sm70_f16_gemm(torch::Tensor _in_feats, torch::Tensor _kernel);
 
-void awq_gemm_sm70_out(torch::Tensor out,
-                       torch::Tensor _in_feats,
-                       torch::Tensor _kernel,
-                       torch::Tensor _scaling_factors,
-                       int64_t group_size,
-                       int64_t k_ld,
-                       int64_t q_ld,
+void awq_gemm_sm70_out(torch::Tensor out, torch::Tensor _in_feats,
+                       torch::Tensor _kernel, torch::Tensor _scaling_factors,
+                       int64_t group_size, int64_t k_ld, int64_t q_ld,
                        bool gated_silu);
 
-void awq_gemm_sm70_out_tile_reduce(torch::Tensor out,
-                                   torch::Tensor staging,
-                                   torch::Tensor _in_feats,
-                                   torch::Tensor _kernel,
-                                   torch::Tensor _scaling_factors,
-                                   int64_t group_size,
-                                   int64_t k_ld,
-                                   int64_t q_ld,
-                                   int64_t fa_ptr,
-                                   int64_t tile_numel,
-                                   int64_t reducer_blocks,
-                                   int64_t kernel_reducer_blocks,
-                                   bool overlap);
+void awq_gemm_sm70_out_tile_reduce(
+    torch::Tensor out, torch::Tensor staging, torch::Tensor _in_feats,
+    torch::Tensor _kernel, torch::Tensor _scaling_factors, int64_t group_size,
+    int64_t k_ld, int64_t q_ld, int64_t fa_ptr, int64_t tile_numel,
+    int64_t reducer_blocks, int64_t kernel_reducer_blocks, bool overlap);
 
-void fp8_gemm_sm70_out(torch::Tensor out,
-                       torch::Tensor _in_feats,
-                       torch::Tensor _kernel,
-                       torch::Tensor _scaling_factors,
-                       int64_t group_size,
-                       int64_t k_ld,
-                       int64_t q_ld,
+void fp8_gemm_sm70_out(torch::Tensor out, torch::Tensor _in_feats,
+                       torch::Tensor _kernel, torch::Tensor _scaling_factors,
+                       int64_t group_size, int64_t k_ld, int64_t q_ld,
                        bool gated_silu);
 
-void mxfp4_gemm_sm70_out(torch::Tensor out,
-                         torch::Tensor _in_feats,
-                         torch::Tensor _kernel,
-                         torch::Tensor _scaling_factors,
-                         int64_t group_size,
-                         int64_t k_ld,
-                         int64_t q_ld,
+void mxfp4_gemm_sm70_out(torch::Tensor out, torch::Tensor _in_feats,
+                         torch::Tensor _kernel, torch::Tensor _scaling_factors,
+                         int64_t group_size, int64_t k_ld, int64_t q_ld,
                          bool gated_silu);
 
-void nvfp4_gemm_sm70_out(torch::Tensor out,
-                         torch::Tensor _in_feats,
-                         torch::Tensor _kernel,
-                         torch::Tensor _scaling_factors,
-                         int64_t group_size,
-                         int64_t k_ld,
-                         int64_t q_ld,
+void nvfp4_gemm_sm70_out(torch::Tensor out, torch::Tensor _in_feats,
+                         torch::Tensor _kernel, torch::Tensor _scaling_factors,
+                         int64_t group_size, int64_t k_ld, int64_t q_ld,
                          bool gated_silu);
 
-void nvfp4_gemv_sm70_raw_out(torch::Tensor out,
-                             torch::Tensor _in_feats,
+void nvfp4_gemv_sm70_raw_out(torch::Tensor out, torch::Tensor _in_feats,
                              torch::Tensor _kernel,
                              torch::Tensor _scaling_factors,
-                             torch::Tensor partials,
-                             int64_t group_size,
+                             torch::Tensor partials, int64_t group_size,
                              int64_t split_k);
 
-void nvfp4_gemv_sm70_warp_out(torch::Tensor out,
-                              torch::Tensor _in_feats,
+void nvfp4_gemv_sm70_warp_out(torch::Tensor out, torch::Tensor _in_feats,
                               torch::Tensor _kernel,
                               torch::Tensor _scaling_factors,
                               int64_t group_size);
 
-void nvfp4_gemv_sm70_h2_out(torch::Tensor out,
-                            torch::Tensor _in_feats,
+void nvfp4_gemv_sm70_h2_out(torch::Tensor out, torch::Tensor _in_feats,
                             torch::Tensor _kernel,
                             torch::Tensor _scaling_factors,
-                            torch::Tensor partials,
-                            int64_t group_size,
+                            torch::Tensor partials, int64_t group_size,
                             int64_t split_k);
 
-void fp8_gemm_sm70_out_auto(torch::Tensor out,
-                            torch::Tensor _in_feats,
+void fp8_gemm_sm70_out_auto(torch::Tensor out, torch::Tensor _in_feats,
                             torch::Tensor _kernel,
                             torch::Tensor _scaling_factors);
 
-void fp8_gemm_sm70_out_meta(torch::Tensor out,
-                            torch::Tensor _in_feats,
+void fp8_gemm_sm70_out_meta(torch::Tensor out, torch::Tensor _in_feats,
                             torch::Tensor _kernel,
-                            torch::Tensor _scaling_factors,
-                            torch::Tensor _meta,
+                            torch::Tensor _scaling_factors, torch::Tensor _meta,
                             bool gated_silu);
 
-void sm70_f16_gemm_out(torch::Tensor out,
-                       torch::Tensor _in_feats,
-                       torch::Tensor _kernel,
-                       int64_t k_ld,
-                       bool gated_silu);
+void sm70_f16_gemm_out(torch::Tensor out, torch::Tensor _in_feats,
+                       torch::Tensor _kernel, int64_t k_ld, bool gated_silu);
 
 void sm70_f16_lm_head_top1_out(torch::Tensor values_out,
                                torch::Tensor indices_out,
-                               torch::Tensor _in_feats,
-                               torch::Tensor _kernel,
-                               int64_t k_ld,
-                               int64_t vocab_start_index,
+                               torch::Tensor _in_feats, torch::Tensor _kernel,
+                               int64_t k_ld, int64_t vocab_start_index,
                                int64_t num_vocab_padding);
 
 void sm70_f16_lm_head_top1_tc_out(torch::Tensor values_out,
                                   torch::Tensor indices_out,
                                   torch::Tensor _in_feats,
-                                  torch::Tensor _kernel,
-                                  int64_t k_ld,
+                                  torch::Tensor _kernel, int64_t k_ld,
                                   int64_t vocab_start_index,
                                   int64_t num_vocab_padding);
 
 void sm70_f16_lm_head_top20_tc_out(torch::Tensor values_out,
                                    torch::Tensor indices_out,
                                    torch::Tensor _in_feats,
-                                   torch::Tensor _kernel,
-                                   int64_t k_ld,
+                                   torch::Tensor _kernel, int64_t k_ld,
                                    int64_t vocab_start_index,
                                    int64_t num_vocab_padding);
 
@@ -259,27 +217,20 @@ void sm70_sample_packed_top20_out(torch::Tensor sampled_token_out,
                                   torch::Tensor sparse_ids_out,
                                   torch::Tensor sparse_probs_out,
                                   torch::Tensor gathered_pairs,
-                                  torch::Tensor exponential,
-                                  double top_p);
+                                  torch::Tensor exponential, double top_p);
 
 void sm70_dynamic_draft_vocab_update_tail_out(
-    torch::Tensor lru_token_ids,
-    torch::Tensor local_tail_token_ids,
-    torch::Tensor source_row_indices,
-    torch::Tensor observed_output_ids,
-    torch::Tensor target_candidate_ids,
-    torch::Tensor base_token_mask,
-    int64_t full_vocab_size,
-    int64_t local_shard_start,
+    torch::Tensor lru_token_ids, torch::Tensor local_tail_token_ids,
+    torch::Tensor source_row_indices, torch::Tensor observed_output_ids,
+    torch::Tensor target_candidate_ids, torch::Tensor base_token_mask,
+    int64_t full_vocab_size, int64_t local_shard_start,
     int64_t local_shard_end);
 
 void sm70_dynamic_draft_vocab_refresh_tail_weight_out(
-    torch::Tensor local_tail_weight,
-    torch::Tensor source_weight,
+    torch::Tensor local_tail_weight, torch::Tensor source_weight,
     torch::Tensor source_row_indices);
 
-void sm70_f16_gate_mul_out(torch::Tensor out,
-                           torch::Tensor _in_feats,
+void sm70_f16_gate_mul_out(torch::Tensor out, torch::Tensor _in_feats,
                            torch::Tensor _gate_weight);
 
 int64_t sm70_gemm_import_cache(torch::Tensor device_hint,
@@ -288,317 +239,167 @@ int64_t sm70_gemm_import_cache(torch::Tensor device_hint,
 int64_t sm70_gemm_export_cache(torch::Tensor device_hint,
                                const std::string& path);
 
-std::vector<torch::Tensor> awq_moe_build_strided_ptrs(
-    torch::Tensor tm_weights,
-    torch::Tensor tm_scales,
-    int64_t k_ld,
-    int64_t q_ld,
-    int64_t num_experts);
+std::vector<torch::Tensor> awq_moe_build_strided_ptrs(torch::Tensor tm_weights,
+                                                      torch::Tensor tm_scales,
+                                                      int64_t k_ld,
+                                                      int64_t q_ld,
+                                                      int64_t num_experts);
 
-void awq_moe_gemm_sm70_out(torch::Tensor out,
-                           torch::Tensor sorted_input,
+void awq_moe_gemm_sm70_out(torch::Tensor out, torch::Tensor sorted_input,
                            torch::Tensor expert_offsets,
                            torch::Tensor strided_ptrs_w,
-                           torch::Tensor strided_ptrs_s,
-                           int64_t num_experts,
-                           int64_t k,
-                           int64_t n,
-                           int64_t group_size,
+                           torch::Tensor strided_ptrs_s, int64_t num_experts,
+                           int64_t k, int64_t n, int64_t group_size,
                            bool gated_silu);
 
-void awq_moe_gemm_sm70_per_expert_dispatch_out(torch::Tensor out,
-                                               torch::Tensor sorted_input,
-                                               torch::Tensor expert_offsets,
-                                               torch::Tensor strided_ptrs_w,
-                                               torch::Tensor strided_ptrs_s,
-                                               int64_t num_experts,
-                                               int64_t k,
-                                               int64_t n,
-                                               int64_t group_size,
-                                               bool gated_silu);
+void awq_moe_gemm_sm70_per_expert_dispatch_out(
+    torch::Tensor out, torch::Tensor sorted_input, torch::Tensor expert_offsets,
+    torch::Tensor strided_ptrs_w, torch::Tensor strided_ptrs_s,
+    int64_t num_experts, int64_t k, int64_t n, int64_t group_size,
+    bool gated_silu);
 
-void awq_moe_dense_stage_sm70_out(torch::Tensor out,
-                                  torch::Tensor input,
+void awq_moe_dense_stage_sm70_out(torch::Tensor out, torch::Tensor input,
                                   torch::Tensor expert_offsets,
                                   torch::Tensor dense_expert_ids,
-                                  torch::Tensor ptrs_w,
-                                  torch::Tensor ptrs_s,
-                                  int64_t num_experts,
-                                  int64_t k,
-                                  int64_t n,
+                                  torch::Tensor ptrs_w, torch::Tensor ptrs_s,
+                                  int64_t num_experts, int64_t k, int64_t n,
                                   int64_t group_size);
 
 void awq_moe_active_dense_stage_sm70_out(
-    torch::Tensor out,
-    torch::Tensor input,
-    torch::Tensor permuted_experts_id,
-    torch::Tensor active_expert_offsets,
-    torch::Tensor active_expert_ids,
-    torch::Tensor ptrs_w,
-    torch::Tensor ptrs_s,
-    int64_t total_slots,
-    int64_t k,
-    int64_t n,
-    int64_t group_size);
+    torch::Tensor out, torch::Tensor input, torch::Tensor permuted_experts_id,
+    torch::Tensor active_expert_offsets, torch::Tensor active_expert_ids,
+    torch::Tensor ptrs_w, torch::Tensor ptrs_s, int64_t total_slots, int64_t k,
+    int64_t n, int64_t group_size);
 
 void awq_moe_single_token_dense_stage_sm70_out(
-    torch::Tensor out,
-    torch::Tensor input,
-    torch::Tensor expert_offsets,
-    torch::Tensor sorted_expert_ids,
-    torch::Tensor ptrs_w,
-    torch::Tensor ptrs_s,
-    int64_t top_k,
-    int64_t k,
-    int64_t n,
-    int64_t group_size);
+    torch::Tensor out, torch::Tensor input, torch::Tensor expert_offsets,
+    torch::Tensor sorted_expert_ids, torch::Tensor ptrs_w, torch::Tensor ptrs_s,
+    int64_t top_k, int64_t k, int64_t n, int64_t group_size);
 
 void awq_moe_single_token_indexed_dense_stage_sm70_out(
-    torch::Tensor out,
-    torch::Tensor input,
-    torch::Tensor expert_offsets,
-    torch::Tensor sorted_expert_ids,
-    torch::Tensor ptrs_w,
-    torch::Tensor ptrs_s,
-    int64_t top_k,
-    int64_t k,
-    int64_t n,
-    int64_t group_size);
+    torch::Tensor out, torch::Tensor input, torch::Tensor expert_offsets,
+    torch::Tensor sorted_expert_ids, torch::Tensor ptrs_w, torch::Tensor ptrs_s,
+    int64_t top_k, int64_t k, int64_t n, int64_t group_size);
 
 void awq_moe_single_token_dense_w13_sm70_out(
-    torch::Tensor gate_up,
-    torch::Tensor compact_input,
-    torch::Tensor x,
-    torch::Tensor topk_ids,
-    torch::Tensor w13_ptrs_w,
-    torch::Tensor w13_ptrs_s,
-    torch::Tensor expert_offsets,
-    torch::Tensor expert_offsets64,
-    torch::Tensor inv_permuted_idx,
-    torch::Tensor sorted_expert_ids,
-    int64_t w13_k,
-    int64_t w13_n,
-    int64_t group_size,
+    torch::Tensor gate_up, torch::Tensor compact_input, torch::Tensor x,
+    torch::Tensor topk_ids, torch::Tensor w13_ptrs_w, torch::Tensor w13_ptrs_s,
+    torch::Tensor expert_offsets, torch::Tensor expert_offsets64,
+    torch::Tensor inv_permuted_idx, torch::Tensor sorted_expert_ids,
+    int64_t w13_k, int64_t w13_n, int64_t group_size,
     int64_t hidden_logical_size);
 
 void awq_moe_single_token_indexed_dense_w13_sm70_out(
-    torch::Tensor gate_up,
-    torch::Tensor compact_input,
-    torch::Tensor x,
-    torch::Tensor topk_ids,
-    torch::Tensor w13_ptrs_w,
-    torch::Tensor w13_ptrs_s,
-    torch::Tensor expert_offsets,
-    torch::Tensor expert_offsets64,
-    torch::Tensor inv_permuted_idx,
-    torch::Tensor sorted_expert_ids,
-    int64_t w13_k,
-    int64_t w13_n,
-    int64_t group_size,
+    torch::Tensor gate_up, torch::Tensor compact_input, torch::Tensor x,
+    torch::Tensor topk_ids, torch::Tensor w13_ptrs_w, torch::Tensor w13_ptrs_s,
+    torch::Tensor expert_offsets, torch::Tensor expert_offsets64,
+    torch::Tensor inv_permuted_idx, torch::Tensor sorted_expert_ids,
+    int64_t w13_k, int64_t w13_n, int64_t group_size,
     int64_t hidden_logical_size);
 
 void awq_moe_single_token_compact_dense_w13_sm70_out(
-    torch::Tensor gate_up,
-    torch::Tensor compact_input,
-    torch::Tensor x,
-    torch::Tensor topk_ids,
-    torch::Tensor w13_ptrs_w,
-    torch::Tensor w13_ptrs_s,
-    torch::Tensor compact_w13_ptrs_w,
-    torch::Tensor compact_w13_ptrs_s,
-    torch::Tensor expert_offsets,
-    torch::Tensor expert_offsets64,
-    torch::Tensor inv_permuted_idx,
-    torch::Tensor sorted_expert_ids,
-    int64_t w13_k,
-    int64_t w13_n,
-    int64_t group_size,
+    torch::Tensor gate_up, torch::Tensor compact_input, torch::Tensor x,
+    torch::Tensor topk_ids, torch::Tensor w13_ptrs_w, torch::Tensor w13_ptrs_s,
+    torch::Tensor compact_w13_ptrs_w, torch::Tensor compact_w13_ptrs_s,
+    torch::Tensor expert_offsets, torch::Tensor expert_offsets64,
+    torch::Tensor inv_permuted_idx, torch::Tensor sorted_expert_ids,
+    int64_t w13_k, int64_t w13_n, int64_t group_size,
     int64_t hidden_logical_size);
 
-void awq_moe_single_token_exact_layout_prepare(torch::Tensor topk_ids,
-                                               torch::Tensor x,
-                                               torch::Tensor compact_input,
-                                               torch::Tensor expert_offsets,
-                                               torch::Tensor expert_offsets64,
-                                               torch::Tensor inv_permuted_idx,
-                                               int64_t num_experts);
+void awq_moe_single_token_exact_layout_prepare(
+    torch::Tensor topk_ids, torch::Tensor x, torch::Tensor compact_input,
+    torch::Tensor expert_offsets, torch::Tensor expert_offsets64,
+    torch::Tensor inv_permuted_idx, int64_t num_experts);
 
 void awq_moe_single_token_weighted_reduce_out(torch::Tensor sorted_output,
                                               torch::Tensor topk_weights,
                                               torch::Tensor inv_permuted_idx,
-                                              torch::Tensor out,
-                                              int64_t top_k,
+                                              torch::Tensor out, int64_t top_k,
                                               int64_t hidden_logical_size);
 
 void awq_moe_single_token_sm70_out(
-    torch::Tensor out,
-    torch::Tensor x,
-    torch::Tensor topk_weights,
-    torch::Tensor topk_ids,
-    torch::Tensor src_w13_ptrs_w_rows,
-    torch::Tensor src_w13_ptrs_s_rows,
-    torch::Tensor src_w2_ptrs_w_rows,
-    torch::Tensor src_w2_ptrs_s_rows,
-    torch::Tensor compact_input,
-    torch::Tensor intermediate,
-    torch::Tensor sorted_output,
-    torch::Tensor sorted_weights,
-    torch::Tensor dst_w13_ptrs_w_rows,
-    torch::Tensor dst_w13_ptrs_s_rows,
-    torch::Tensor dst_w2_ptrs_w_rows,
-    torch::Tensor dst_w2_ptrs_s_rows,
-    torch::Tensor expert_offsets,
-    torch::Tensor inv_permuted_idx,
-    int64_t w13_k,
-    int64_t w13_n,
-    int64_t w2_k,
-    int64_t w2_n,
-    int64_t group_size,
-    int64_t hidden_logical_size);
+    torch::Tensor out, torch::Tensor x, torch::Tensor topk_weights,
+    torch::Tensor topk_ids, torch::Tensor src_w13_ptrs_w_rows,
+    torch::Tensor src_w13_ptrs_s_rows, torch::Tensor src_w2_ptrs_w_rows,
+    torch::Tensor src_w2_ptrs_s_rows, torch::Tensor compact_input,
+    torch::Tensor intermediate, torch::Tensor sorted_output,
+    torch::Tensor sorted_weights, torch::Tensor dst_w13_ptrs_w_rows,
+    torch::Tensor dst_w13_ptrs_s_rows, torch::Tensor dst_w2_ptrs_w_rows,
+    torch::Tensor dst_w2_ptrs_s_rows, torch::Tensor expert_offsets,
+    torch::Tensor inv_permuted_idx, int64_t w13_k, int64_t w13_n, int64_t w2_k,
+    int64_t w2_n, int64_t group_size, int64_t hidden_logical_size);
 
-void fp8_moe_gemm_sm70_out(torch::Tensor out,
-                           torch::Tensor sorted_input,
+void fp8_moe_gemm_sm70_out(torch::Tensor out, torch::Tensor sorted_input,
                            torch::Tensor expert_offsets,
                            torch::Tensor strided_ptrs_w,
-                           torch::Tensor strided_ptrs_s,
-                           int64_t num_experts,
-                           int64_t k,
-                           int64_t n,
-                           int64_t group_size,
+                           torch::Tensor strided_ptrs_s, int64_t num_experts,
+                           int64_t k, int64_t n, int64_t group_size,
                            bool gated_silu);
 
-void fp8_moe_gemm_sm70_per_expert_dispatch_out(torch::Tensor out,
-                                               torch::Tensor sorted_input,
-                                               torch::Tensor expert_offsets,
-                                               torch::Tensor strided_ptrs_w,
-                                               torch::Tensor strided_ptrs_s,
-                                               int64_t num_experts,
-                                               int64_t k,
-                                               int64_t n,
-                                               int64_t group_size,
-                                               bool gated_silu);
+void fp8_moe_gemm_sm70_per_expert_dispatch_out(
+    torch::Tensor out, torch::Tensor sorted_input, torch::Tensor expert_offsets,
+    torch::Tensor strided_ptrs_w, torch::Tensor strided_ptrs_s,
+    int64_t num_experts, int64_t k, int64_t n, int64_t group_size,
+    bool gated_silu);
 
-void fp8_moe_dense_stage_sm70_out(torch::Tensor out,
-                                  torch::Tensor input,
+void fp8_moe_dense_stage_sm70_out(torch::Tensor out, torch::Tensor input,
                                   torch::Tensor expert_offsets,
                                   torch::Tensor dense_expert_ids,
-                                  torch::Tensor ptrs_w,
-                                  torch::Tensor ptrs_s,
-                                  int64_t num_experts,
-                                  int64_t k,
-                                  int64_t n,
+                                  torch::Tensor ptrs_w, torch::Tensor ptrs_s,
+                                  int64_t num_experts, int64_t k, int64_t n,
                                   int64_t group_size);
 
 void fp8_moe_single_token_dense_stage_sm70_out(
-    torch::Tensor out,
-    torch::Tensor input,
-    torch::Tensor expert_offsets,
-    torch::Tensor sorted_expert_ids,
-    torch::Tensor ptrs_w,
-    torch::Tensor ptrs_s,
-    int64_t top_k,
-    int64_t k,
-    int64_t n,
-    int64_t group_size);
+    torch::Tensor out, torch::Tensor input, torch::Tensor expert_offsets,
+    torch::Tensor sorted_expert_ids, torch::Tensor ptrs_w, torch::Tensor ptrs_s,
+    int64_t top_k, int64_t k, int64_t n, int64_t group_size);
 
 void fp8_moe_single_token_indexed_dense_stage_sm70_out(
-    torch::Tensor out,
-    torch::Tensor input,
-    torch::Tensor expert_offsets,
-    torch::Tensor sorted_expert_ids,
-    torch::Tensor ptrs_w,
-    torch::Tensor ptrs_s,
-    int64_t top_k,
-    int64_t k,
-    int64_t n,
-    int64_t group_size);
+    torch::Tensor out, torch::Tensor input, torch::Tensor expert_offsets,
+    torch::Tensor sorted_expert_ids, torch::Tensor ptrs_w, torch::Tensor ptrs_s,
+    int64_t top_k, int64_t k, int64_t n, int64_t group_size);
 
 void fp8_moe_single_token_dense_w13_sm70_out(
-    torch::Tensor gate_up,
-    torch::Tensor compact_input,
-    torch::Tensor x,
-    torch::Tensor topk_ids,
-    torch::Tensor w13_ptrs_w,
-    torch::Tensor w13_ptrs_s,
-    torch::Tensor expert_offsets,
-    torch::Tensor expert_offsets64,
-    torch::Tensor inv_permuted_idx,
-    torch::Tensor sorted_expert_ids,
-    int64_t w13_k,
-    int64_t w13_n,
-    int64_t group_size,
+    torch::Tensor gate_up, torch::Tensor compact_input, torch::Tensor x,
+    torch::Tensor topk_ids, torch::Tensor w13_ptrs_w, torch::Tensor w13_ptrs_s,
+    torch::Tensor expert_offsets, torch::Tensor expert_offsets64,
+    torch::Tensor inv_permuted_idx, torch::Tensor sorted_expert_ids,
+    int64_t w13_k, int64_t w13_n, int64_t group_size,
     int64_t hidden_logical_size);
 
 void fp8_moe_single_token_indexed_dense_w13_sm70_out(
-    torch::Tensor gate_up,
-    torch::Tensor compact_input,
-    torch::Tensor x,
-    torch::Tensor topk_ids,
-    torch::Tensor w13_ptrs_w,
-    torch::Tensor w13_ptrs_s,
-    torch::Tensor expert_offsets,
-    torch::Tensor expert_offsets64,
-    torch::Tensor inv_permuted_idx,
-    torch::Tensor sorted_expert_ids,
-    int64_t w13_k,
-    int64_t w13_n,
-    int64_t group_size,
+    torch::Tensor gate_up, torch::Tensor compact_input, torch::Tensor x,
+    torch::Tensor topk_ids, torch::Tensor w13_ptrs_w, torch::Tensor w13_ptrs_s,
+    torch::Tensor expert_offsets, torch::Tensor expert_offsets64,
+    torch::Tensor inv_permuted_idx, torch::Tensor sorted_expert_ids,
+    int64_t w13_k, int64_t w13_n, int64_t group_size,
     int64_t hidden_logical_size);
 
 void fp8_moe_single_token_compact_dense_w13_sm70_out(
-    torch::Tensor gate_up,
-    torch::Tensor compact_input,
-    torch::Tensor x,
-    torch::Tensor topk_ids,
-    torch::Tensor w13_ptrs_w,
-    torch::Tensor w13_ptrs_s,
-    torch::Tensor compact_w13_ptrs_w,
-    torch::Tensor compact_w13_ptrs_s,
-    torch::Tensor expert_offsets,
-    torch::Tensor expert_offsets64,
-    torch::Tensor inv_permuted_idx,
-    torch::Tensor sorted_expert_ids,
-    int64_t w13_k,
-    int64_t w13_n,
-    int64_t group_size,
+    torch::Tensor gate_up, torch::Tensor compact_input, torch::Tensor x,
+    torch::Tensor topk_ids, torch::Tensor w13_ptrs_w, torch::Tensor w13_ptrs_s,
+    torch::Tensor compact_w13_ptrs_w, torch::Tensor compact_w13_ptrs_s,
+    torch::Tensor expert_offsets, torch::Tensor expert_offsets64,
+    torch::Tensor inv_permuted_idx, torch::Tensor sorted_expert_ids,
+    int64_t w13_k, int64_t w13_n, int64_t group_size,
     int64_t hidden_logical_size);
 
 void fp8_moe_single_token_sm70_out(
-    torch::Tensor out,
-    torch::Tensor x,
-    torch::Tensor topk_weights,
-    torch::Tensor topk_ids,
-    torch::Tensor src_w13_ptrs_w_rows,
-    torch::Tensor src_w13_ptrs_s_rows,
-    torch::Tensor src_w2_ptrs_w_rows,
-    torch::Tensor src_w2_ptrs_s_rows,
-    torch::Tensor compact_input,
-    torch::Tensor gate_up,
-    torch::Tensor intermediate,
-    torch::Tensor sorted_output,
-    torch::Tensor sorted_weights,
-    torch::Tensor dst_w13_ptrs_w_rows,
-    torch::Tensor dst_w13_ptrs_s_rows,
-    torch::Tensor dst_w2_ptrs_w_rows,
-    torch::Tensor dst_w2_ptrs_s_rows,
-    torch::Tensor expert_offsets,
-    torch::Tensor inv_permuted_idx,
-    torch::Tensor sorted_expert_ids,
-    torch::Tensor broadcast_input_indices,
-    torch::Tensor w2_raw_weight,
-    torch::Tensor w2_raw_scale_inv,
-    int64_t w13_k,
-    int64_t w13_n,
-    int64_t w2_k,
-    int64_t w2_n,
-    int64_t group_size,
-    int64_t hidden_logical_size,
-    bool fused_gated_silu,
-    bool fused_weighted_reduce,
-    bool broadcast_input,
-    bool w2_direct_reduce,
-    bool indexed_expert_ptrs,
-    bool exact_per_route);
+    torch::Tensor out, torch::Tensor x, torch::Tensor topk_weights,
+    torch::Tensor topk_ids, torch::Tensor src_w13_ptrs_w_rows,
+    torch::Tensor src_w13_ptrs_s_rows, torch::Tensor src_w2_ptrs_w_rows,
+    torch::Tensor src_w2_ptrs_s_rows, torch::Tensor compact_input,
+    torch::Tensor gate_up, torch::Tensor intermediate,
+    torch::Tensor sorted_output, torch::Tensor sorted_weights,
+    torch::Tensor dst_w13_ptrs_w_rows, torch::Tensor dst_w13_ptrs_s_rows,
+    torch::Tensor dst_w2_ptrs_w_rows, torch::Tensor dst_w2_ptrs_s_rows,
+    torch::Tensor expert_offsets, torch::Tensor inv_permuted_idx,
+    torch::Tensor sorted_expert_ids, torch::Tensor broadcast_input_indices,
+    torch::Tensor w2_raw_weight, torch::Tensor w2_raw_scale_inv, int64_t w13_k,
+    int64_t w13_n, int64_t w2_k, int64_t w2_n, int64_t group_size,
+    int64_t hidden_logical_size, bool fused_gated_silu,
+    bool fused_weighted_reduce, bool broadcast_input, bool w2_direct_reduce,
+    bool indexed_expert_ptrs, bool exact_per_route);
 #endif
 
 void static_scaled_int8_quant(torch::Tensor& out, torch::Tensor const& input,
@@ -624,27 +425,25 @@ void all_reduce(fptr_t _fa, torch::Tensor& inp, torch::Tensor& out,
 void sm70_tp2_all_reduce_gemma_rms_norm(
     fptr_t _fa, torch::Tensor& inp, torch::Tensor& residual,
     torch::Tensor& weight, torch::Tensor& normalized_out,
-    torch::Tensor& residual_out, fptr_t reg_buffer,
-    int64_t reg_buffer_sz_bytes, double epsilon);
+    torch::Tensor& residual_out, fptr_t reg_buffer, int64_t reg_buffer_sz_bytes,
+    double epsilon);
 void sm70_tp4_all_reduce_gemma_rms_norm(
     fptr_t _fa, torch::Tensor& inp, torch::Tensor& residual,
     torch::Tensor& weight, torch::Tensor& normalized_out,
-    torch::Tensor& residual_out, fptr_t reg_buffer,
-    int64_t reg_buffer_sz_bytes, double epsilon);
+    torch::Tensor& residual_out, fptr_t reg_buffer, int64_t reg_buffer_sz_bytes,
+    double epsilon);
 void all_reduce_sum2(fptr_t _fa, torch::Tensor& inp_a, torch::Tensor& inp_b,
                      torch::Tensor& out);
 void top1_argmax(fptr_t _fa, torch::Tensor& input_pair, torch::Tensor& output,
                  fptr_t reg_buffer, int64_t reg_buffer_sz_bytes);
 void tile_runtime_all_reduce(fptr_t _fa, torch::Tensor& inp, torch::Tensor& out,
-                             fptr_t reg_buffer,
-                             int64_t reg_buffer_sz_bytes,
+                             fptr_t reg_buffer, int64_t reg_buffer_sz_bytes,
                              int64_t tile_numel, int64_t engine_blocks,
                              int64_t compute_iters);
 void tile_runtime_all_reduce_engine(fptr_t _fa, torch::Tensor& inp,
                                     torch::Tensor& out, fptr_t reg_buffer,
                                     int64_t reg_buffer_sz_bytes,
-                                    int64_t tile_numel,
-                                    int64_t producer_blocks,
+                                    int64_t tile_numel, int64_t producer_blocks,
                                     int64_t reducer_blocks,
                                     int64_t compute_iters);
 void tile_runtime_wait_reduce(fptr_t _fa, torch::Tensor& staging,

--- a/csrc/quantization/marlin/sm70_awq_marlin_repack.cu
+++ b/csrc/quantization/marlin/sm70_awq_marlin_repack.cu
@@ -92,8 +92,7 @@ __global__ void awq_marlin_repack_kernel(
       constexpr int sh_stride = tile_n_ints;
       int4* sh_stage_ptr = sh + stage_size * pipe;
       uint32_t* sh_stage_int_ptr = reinterpret_cast<uint32_t*>(sh_stage_ptr);
-      uint32_t packed_src =
-          sh_stage_int_ptr[local_k * sh_stride + local_n_vec];
+      uint32_t packed_src = sh_stage_int_ptr[local_k * sh_stride + local_n_vec];
 
       constexpr int undo_pack[8] = {0, 4, 1, 5, 2, 6, 3, 7};
       constexpr int pack_idx[8] = {0, 2, 4, 6, 1, 3, 5, 7};
@@ -114,9 +113,8 @@ __global__ void awq_marlin_repack_kernel(
       int const cta_first_n_tile = cta_n_tile * cta_n_tiles;
       int const subtile = n_tile_id - cta_first_n_tile;
       int const local_word = local_k * 8 + local_n_vec;
-      int const cta_n_offset =
-          cta_n_tile * cta_n_tiles * tile_size +
-          local_word * cta_n_tiles + subtile;
+      int const cta_n_offset = cta_n_tile * cta_n_tiles * tile_size +
+                               local_word * cta_n_tiles + subtile;
       out_ptr[k_tile_id * n_tiles * tile_size + cta_n_offset] = res;
       return;
     }
@@ -155,9 +153,8 @@ __global__ void awq_marlin_repack_kernel(
       int const cta_first_n_tile = cta_n_tile * cta_n_tiles;
       int const subtile = n_tile_id - cta_first_n_tile;
       int const local_word = local_k * 16 + local_n_word;
-      int const cta_n_offset =
-          cta_n_tile * cta_n_tiles * tile_size +
-          local_word * cta_n_tiles + subtile;
+      int const cta_n_offset = cta_n_tile * cta_n_tiles * tile_size +
+                               local_word * cta_n_tiles + subtile;
       out_ptr[k_tile_id * n_tiles * tile_size + cta_n_offset] = res;
       return;
     }
@@ -304,16 +301,15 @@ __global__ void awq_marlin_repack_kernel(
             b_q_weight_ptr, out_ptr, size_k, size_n);                      \
   } else
 
-#define CALL_FOR_CTA(CTA_N)                                                \
-  do {                                                                     \
-    CALL_IF(4, false, CTA_N)                                               \
-    CALL_IF(8, false, CTA_N)                                               \
-    CALL_IF(4, true, CTA_N)                                                \
-    CALL_IF(8, true, CTA_N)                                                \
-    {                                                                      \
-      TORCH_CHECK(false, "Unsupported repack config: num_bits = ",         \
-                  num_bits, ", is_a_8bit = ", is_a_8bit);                 \
-    }                                                                      \
+#define CALL_FOR_CTA(CTA_N)                                                  \
+  do {                                                                       \
+    CALL_IF(4, false, CTA_N)                                                 \
+    CALL_IF(8, false, CTA_N)                                                 \
+    CALL_IF(4, true, CTA_N)                                                  \
+    CALL_IF(8, true, CTA_N) {                                                \
+      TORCH_CHECK(false, "Unsupported repack config: num_bits = ", num_bits, \
+                  ", is_a_8bit = ", is_a_8bit);                              \
+    }                                                                        \
   } while (false)
 
 torch::Tensor awq_marlin_repack(torch::Tensor& b_q_weight, int64_t size_k,

--- a/csrc/quantization/marlin/sm70_gptq_marlin_repack.cu
+++ b/csrc/quantization/marlin/sm70_gptq_marlin_repack.cu
@@ -164,9 +164,8 @@ __global__ void gptq_marlin_repack_kernel(
       int const cta_first_n_tile = cta_n_tile * cta_n_tiles;
       int const subtile = n_tile_id - cta_first_n_tile;
       int const local_word = local_k * 8 + local_n_vec;
-      int const cta_n_offset =
-          cta_n_tile * cta_n_tiles * tile_size +
-          local_word * cta_n_tiles + subtile;
+      int const cta_n_offset = cta_n_tile * cta_n_tiles * tile_size +
+                               local_word * cta_n_tiles + subtile;
       out_ptr[k_tile_id * n_tiles * tile_size + cta_n_offset] = res;
       return;
     }
@@ -215,9 +214,8 @@ __global__ void gptq_marlin_repack_kernel(
       int const cta_first_n_tile = cta_n_tile * cta_n_tiles;
       int const subtile = n_tile_id - cta_first_n_tile;
       int const local_word = local_k * 16 + local_n_word;
-      int const cta_n_offset =
-          cta_n_tile * cta_n_tiles * tile_size +
-          local_word * cta_n_tiles + subtile;
+      int const cta_n_offset = cta_n_tile * cta_n_tiles * tile_size +
+                               local_word * cta_n_tiles + subtile;
       out_ptr[k_tile_id * n_tiles * tile_size + cta_n_offset] = res;
       return;
     }
@@ -381,19 +379,17 @@ __global__ void gptq_marlin_repack_kernel(
             b_q_weight_ptr, perm_ptr, out_ptr, size_k, size_n);             \
   } else
 
-#define CALL_FOR_CTA(CTA_N)                                                 \
-  do {                                                                      \
-    CALL_IF(4, false, false, CTA_N)                                         \
-    CALL_IF(4, true, false, CTA_N)                                          \
-    CALL_IF(8, false, false, CTA_N)                                         \
-    CALL_IF(8, true, false, CTA_N)                                          \
-    CALL_IF(4, false, true, CTA_N)                                          \
-    CALL_IF(8, false, true, CTA_N)                                          \
-    {                                                                       \
-      TORCH_CHECK(false, "Unsupported repack config: num_bits = ",          \
-                  num_bits, ", has_perm = ", has_perm,                     \
-                  ", is_a_8bit = ", is_a_8bit);                            \
-    }                                                                       \
+#define CALL_FOR_CTA(CTA_N)                                                  \
+  do {                                                                       \
+    CALL_IF(4, false, false, CTA_N)                                          \
+    CALL_IF(4, true, false, CTA_N)                                           \
+    CALL_IF(8, false, false, CTA_N)                                          \
+    CALL_IF(8, true, false, CTA_N)                                           \
+    CALL_IF(4, false, true, CTA_N)                                           \
+    CALL_IF(8, false, true, CTA_N) {                                         \
+      TORCH_CHECK(false, "Unsupported repack config: num_bits = ", num_bits, \
+                  ", has_perm = ", has_perm, ", is_a_8bit = ", is_a_8bit);   \
+    }                                                                        \
   } while (false)
 
 torch::Tensor gptq_marlin_repack(torch::Tensor& b_q_weight, torch::Tensor& perm,

--- a/csrc/quantization/marlin/sm70_marlin_common.cuh
+++ b/csrc/quantization/marlin/sm70_marlin_common.cuh
@@ -28,31 +28,29 @@ inline size_t configure_sm70_dynamic_smem(Kernel kernel) {
   return smem_bytes;
 }
 
-constexpr int sm70_const_min(int lhs, int rhs) {
-  return lhs < rhs ? lhs : rhs;
-}
+constexpr int sm70_const_min(int lhs, int rhs) { return lhs < rhs ? lhs : rhs; }
 
-constexpr bool sm70_marlin_basic_geometry_values_supported(
-    int cta_m, int cta_n, int cta_k, int warps, int warp_m, int warp_n,
-    int warp_k) {
+constexpr bool sm70_marlin_basic_geometry_values_supported(int cta_m, int cta_n,
+                                                           int cta_k, int warps,
+                                                           int warp_m,
+                                                           int warp_n,
+                                                           int warp_k) {
   return (cta_m == 32 || cta_m == 64 || cta_m == 128 || cta_m == 256) &&
          (cta_n == 64 || cta_n == 128 || cta_n == 256) &&
          (cta_k == 16 || cta_k == 32 || cta_k == 64 || cta_k == 128) &&
-         (warps == 4 || warps == 8) &&
-         (warp_m == 32 || warp_m == 64) &&
-         (warp_n == 32 || warp_n == 64) &&
-         (warp_k == 16 || warp_k == 32);
+         (warps == 4 || warps == 8) && (warp_m == 32 || warp_m == 64) &&
+         (warp_n == 32 || warp_n == 64) && (warp_k == 16 || warp_k == 32);
 }
 
-constexpr bool sm70_marlin_warp_decomposition_supported(
-    int cta_m, int cta_n, int cta_k, int warps, int warp_m, int warp_n,
-    int warp_k) {
-  if (!sm70_marlin_basic_geometry_values_supported(
-          cta_m, cta_n, cta_k, warps, warp_m, warp_n, warp_k)) {
+constexpr bool sm70_marlin_warp_decomposition_supported(int cta_m, int cta_n,
+                                                        int cta_k, int warps,
+                                                        int warp_m, int warp_n,
+                                                        int warp_k) {
+  if (!sm70_marlin_basic_geometry_values_supported(cta_m, cta_n, cta_k, warps,
+                                                   warp_m, warp_n, warp_k)) {
     return false;
   }
-  if (cta_m % warp_m != 0 || cta_n % warp_n != 0 ||
-      cta_k % warp_k != 0) {
+  if (cta_m % warp_m != 0 || cta_n % warp_n != 0 || cta_k % warp_k != 0) {
     return false;
   }
   return (cta_m / warp_m) * (cta_n / warp_n) * (cta_k / warp_k) == warps;
@@ -65,8 +63,7 @@ constexpr bool sm70_marlin_pitchlinear_threadmap_supported(
   if (shape_contiguous % elements_per_access != 0) {
     return false;
   }
-  int const shape_access_contiguous =
-      shape_contiguous / elements_per_access;
+  int const shape_access_contiguous = shape_contiguous / elements_per_access;
   int const shape_access_strided = shape_strided;
   if (shape_access_contiguous % warp_thread_contiguous != 0 ||
       shape_access_strided % warp_thread_strided != 0) {
@@ -74,8 +71,7 @@ constexpr bool sm70_marlin_pitchlinear_threadmap_supported(
   }
   int const warp_access_contiguous =
       shape_access_contiguous / warp_thread_contiguous;
-  int const warp_access_strided =
-      shape_access_strided / warp_thread_strided;
+  int const warp_access_strided = shape_access_strided / warp_thread_strided;
   int const warp_count = threads / 32;
   if (warp_access_strided <= 0 || warp_count <= 0) {
     return false;
@@ -90,43 +86,40 @@ constexpr bool sm70_marlin_pitchlinear_threadmap_supported(
   if (warps_contiguous <= 0) {
     return false;
   }
-  int const iterations_contiguous =
-      warp_access_contiguous / warps_contiguous;
+  int const iterations_contiguous = warp_access_contiguous / warps_contiguous;
   int const iterations_strided = warp_access_strided / warps_strided;
   return iterations_contiguous > 0 && iterations_strided > 0;
 }
 
-constexpr bool sm70_marlin_b_threadmap_matches_quant_iterator(
-    int cta_n, int cta_k, int threads) {
+constexpr bool sm70_marlin_b_threadmap_matches_quant_iterator(int cta_n,
+                                                              int cta_k,
+                                                              int threads) {
   constexpr int kElementsPerAccess = 8;
   constexpr int kWarpThreadContiguous = 8;
   constexpr int kWarpThreadStrided = 4;
   if (!sm70_marlin_pitchlinear_threadmap_supported(
-          cta_n, cta_k, threads, kWarpThreadContiguous,
-          kWarpThreadStrided, kElementsPerAccess)) {
+          cta_n, cta_k, threads, kWarpThreadContiguous, kWarpThreadStrided,
+          kElementsPerAccess)) {
     return false;
   }
   int const shape_access_contiguous = cta_n / kElementsPerAccess;
   int const shape_access_strided = cta_k;
   int const warp_access_contiguous =
       shape_access_contiguous / kWarpThreadContiguous;
-  int const warp_access_strided =
-      shape_access_strided / kWarpThreadStrided;
+  int const warp_access_strided = shape_access_strided / kWarpThreadStrided;
   int const warp_count = threads / 32;
   int const warps_strided =
       warp_access_strided >= warp_count ? warp_count : warp_access_strided;
   int const warps_contiguous =
       warp_count > warp_access_strided ? warp_count / warps_strided : 1;
-  int const iterations_contiguous =
-      warp_access_contiguous / warps_contiguous;
-  int const delta_contiguous =
-      kWarpThreadContiguous * kElementsPerAccess;
+  int const iterations_contiguous = warp_access_contiguous / warps_contiguous;
+  int const delta_contiguous = kWarpThreadContiguous * kElementsPerAccess;
   return iterations_contiguous == cta_n / kQuantTileN &&
          delta_contiguous == kQuantTileN;
 }
 
-constexpr bool sm70_marlin_volta_epilogue_supported(
-    int cta_m, int cta_n, int warps, int warp_m) {
+constexpr bool sm70_marlin_volta_epilogue_supported(int cta_m, int cta_n,
+                                                    int warps, int warp_m) {
   constexpr int kShapeRow = 4;
   constexpr int kShapeGroup = 4;
   constexpr int kElementsPerAccess = 8;
@@ -183,8 +176,8 @@ constexpr bool sm70_marlin_volta_epilogue_supported(
 constexpr bool sm70_marlin_cta_geometry_is_supported_constexpr(
     int cta_m, int cta_n, int cta_k, int warps, int warp_m, int warp_n,
     int warp_k) {
-  if (!sm70_marlin_warp_decomposition_supported(
-          cta_m, cta_n, cta_k, warps, warp_m, warp_n, warp_k)) {
+  if (!sm70_marlin_warp_decomposition_supported(cta_m, cta_n, cta_k, warps,
+                                                warp_m, warp_n, warp_k)) {
     return false;
   }
   int const threads = warps * 32;
@@ -192,12 +185,11 @@ constexpr bool sm70_marlin_cta_geometry_is_supported_constexpr(
   // DefaultMmaCore. Its A/B thread maps are fixed to 128-bit half loads.
   // CTA_K=16 is a mathematical GEMM shape but does not provide enough
   // contiguous A accesses for that thread map.
-  if (!sm70_marlin_pitchlinear_threadmap_supported(
-          cta_k, cta_m, threads, 4, 8, 8)) {
+  if (!sm70_marlin_pitchlinear_threadmap_supported(cta_k, cta_m, threads, 4, 8,
+                                                   8)) {
     return false;
   }
-  if (!sm70_marlin_b_threadmap_matches_quant_iterator(cta_n, cta_k,
-                                                      threads)) {
+  if (!sm70_marlin_b_threadmap_matches_quant_iterator(cta_n, cta_k, threads)) {
     return false;
   }
   return sm70_marlin_volta_epilogue_supported(cta_m, cta_n, warps, warp_m);
@@ -212,8 +204,7 @@ struct Sm70WarpShape {
                 "SM70 Marlin supports CTA_N in {64, 128, 256}.");
   static_assert(CtaK == 16 || CtaK == 32 || CtaK == 64 || CtaK == 128,
                 "SM70 Marlin supports CTA_K in {16, 32, 64, 128}.");
-  static_assert(Warps == 4 || Warps == 8,
-                "SM70 Marlin supports 4 or 8 warps.");
+  static_assert(Warps == 4 || Warps == 8, "SM70 Marlin supports 4 or 8 warps.");
   static_assert(WarpM == 32 || WarpM == 64,
                 "SM70 Marlin supports Warp_M in {32, 64}.");
   static_assert(WarpN == 32 || WarpN == 64,
@@ -283,8 +274,7 @@ inline constexpr char const* kSupportedSm70MarlinCtaGeometries =
     "decomposition, current CUTLASS Volta thread-map support, and "
     "phase-aware SM70 Marlin warp-K offset support.";
 
-inline bool sm70_marlin_cta_geometry_is_supported(
-    Sm70CtaGeometry geometry) {
+inline bool sm70_marlin_cta_geometry_is_supported(Sm70CtaGeometry geometry) {
   return sm70_marlin_cta_geometry_is_supported_constexpr(
       geometry.cta_m, geometry.cta_n, geometry.cta_k, geometry.warps,
       geometry.warp_m, geometry.warp_n, geometry.warp_k);
@@ -300,8 +290,10 @@ inline int sm70_marlin_auto_packed_macro_n(int64_t size_n) {
   if (size_n % 64 == 0) {
     return 64;
   }
-  TORCH_CHECK(false, "SM70 Marlin requires size_n divisible "
-                     "by 64. Got size_n = ", size_n, ".");
+  TORCH_CHECK(false,
+              "SM70 Marlin requires size_n divisible "
+              "by 64. Got size_n = ",
+              size_n, ".");
   return 0;
 }
 
@@ -309,14 +301,12 @@ inline bool sm70_marlin_packed_macro_n_is_supported(int packed_macro_n) {
   return packed_macro_n == 64 || packed_macro_n == 128 || packed_macro_n == 256;
 }
 
-inline bool sm70_marlin_requested_split_k_is_supported(
-    int requested_split_k) {
+inline bool sm70_marlin_requested_split_k_is_supported(int requested_split_k) {
   return requested_split_k == 1 || requested_split_k == 2 ||
          requested_split_k == 4 || requested_split_k == 8;
 }
 
-inline Sm70MarlinAutoParams sm70_marlin_default_auto_params(
-    int packed_macro_n);
+inline Sm70MarlinAutoParams sm70_marlin_default_auto_params(int packed_macro_n);
 
 inline Sm70CtaGeometry sm70_marlin_default_geometry_from_packed_macro_n(
     int packed_macro_n) {
@@ -328,8 +318,8 @@ inline Sm70CtaGeometry sm70_marlin_default_geometry_from_packed_macro_n(
     case 256:
       return {32, 256, 32, 4, 32, 64, 32};
     default:
-      TORCH_CHECK(false, "Unsupported SM70 Marlin packed macro-N=",
-                  packed_macro_n,
+      TORCH_CHECK(false,
+                  "Unsupported SM70 Marlin packed macro-N=", packed_macro_n,
                   ".");
   }
   return {0, 0, 0, 0, 0, 0, 0};
@@ -337,10 +327,8 @@ inline Sm70CtaGeometry sm70_marlin_default_geometry_from_packed_macro_n(
 
 inline Sm70MarlinAutoParams sm70_marlin_default_auto_params(
     int packed_macro_n) {
-  return {sm70_marlin_default_geometry_from_packed_macro_n(packed_macro_n),
-          1,
-          true,
-          packed_macro_n};
+  return {sm70_marlin_default_geometry_from_packed_macro_n(packed_macro_n), 1,
+          true, packed_macro_n};
 }
 
 inline bool sm70_marlin_parse_int_component(char const*& cursor, int& value) {
@@ -386,9 +374,10 @@ inline bool sm70_marlin_try_get_geometry_env(char const* env_name,
   if (value == nullptr || value[0] == '\0') {
     return false;
   }
-  TORCH_CHECK(sm70_marlin_parse_geometry_env_value(value, geometry),
-              "Invalid ", env_name, " value '", value,
-              "'. Expected {CTA_M}x{CTA_N}x{CTA_K}x{Warps}x{WarpM}x{WarpN}x{WarpK}.");
+  TORCH_CHECK(
+      sm70_marlin_parse_geometry_env_value(value, geometry), "Invalid ",
+      env_name, " value '", value,
+      "'. Expected {CTA_M}x{CTA_N}x{CTA_K}x{Warps}x{WarpM}x{WarpN}x{WarpK}.");
   return true;
 }
 
@@ -409,8 +398,8 @@ inline bool sm70_marlin_try_get_split_k_env(char const* env_name,
   return true;
 }
 
-inline bool sm70_marlin_try_get_metadata_env(
-    char const* env_name, bool& use_metadata_vector_words) {
+inline bool sm70_marlin_try_get_metadata_env(char const* env_name,
+                                             bool& use_metadata_vector_words) {
   char const* value = std::getenv(env_name);
   if (value == nullptr || value[0] == '\0') {
     return false;
@@ -433,9 +422,9 @@ inline bool sm70_marlin_env_is_set(char const* env_name) {
   return value != nullptr && value[0] != '\0';
 }
 
-inline bool sm70_marlin_any_auto_env_is_set(
-    char const* geometry_env_name, char const* split_k_env_name,
-    char const* metadata_env_name) {
+inline bool sm70_marlin_any_auto_env_is_set(char const* geometry_env_name,
+                                            char const* split_k_env_name,
+                                            char const* metadata_env_name) {
   return sm70_marlin_env_is_set(geometry_env_name) ||
          sm70_marlin_env_is_set(split_k_env_name) ||
          sm70_marlin_env_is_set(metadata_env_name);
@@ -447,14 +436,13 @@ inline void validate_sm70_marlin_packed_macro_n(char const* op_name,
   TORCH_CHECK(sm70_marlin_packed_macro_n_is_supported(packed_macro_n),
               "Unsupported SM70 Marlin packed macro-N for ", op_name, ": ",
               packed_macro_n, ".");
-  TORCH_CHECK(packed_macro_n % geometry.cta_n == 0,
-              "SM70 Marlin ", op_name,
+  TORCH_CHECK(packed_macro_n % geometry.cta_n == 0, "SM70 Marlin ", op_name,
               " requires PackedMacroN divisible by CTA_N. Got PackedMacroN=",
               packed_macro_n, ", CTA_N=", geometry.cta_n, ".");
 }
 
-inline void validate_sm70_marlin_auto_params(
-    char const* op_name, Sm70MarlinAutoParams params) {
+inline void validate_sm70_marlin_auto_params(char const* op_name,
+                                             Sm70MarlinAutoParams params) {
   TORCH_CHECK(sm70_marlin_cta_geometry_is_supported(params.geometry),
               "Unsupported SM70 Marlin CTA geometry for ", op_name, ": ",
               params.geometry.cta_m, "x", params.geometry.cta_n, "x",
@@ -474,8 +462,7 @@ inline Sm70MarlinAutoParams sm70_marlin_auto_params_from_env(
     char const* op_name, char const* geometry_env_name,
     char const* split_k_env_name, char const* metadata_env_name,
     int packed_macro_n) {
-  Sm70MarlinAutoParams params =
-      sm70_marlin_default_auto_params(packed_macro_n);
+  Sm70MarlinAutoParams params = sm70_marlin_default_auto_params(packed_macro_n);
   sm70_marlin_try_get_geometry_env(geometry_env_name, params.geometry);
   sm70_marlin_try_get_split_k_env(split_k_env_name, params.requested_split_k);
   sm70_marlin_try_get_metadata_env(metadata_env_name,
@@ -485,31 +472,27 @@ inline Sm70MarlinAutoParams sm70_marlin_auto_params_from_env(
 }
 
 inline bool sm70_marlin_dense_auto_env_is_set() {
-  return sm70_marlin_any_auto_env_is_set(
-      "SM70_MARLIN_DENSE_CTA_GEOMETRY", "SM70_MARLIN_DENSE_SPLIT_K",
-      "SM70_MARLIN_DENSE_METADATA_CACHE");
+  return sm70_marlin_any_auto_env_is_set("SM70_MARLIN_DENSE_CTA_GEOMETRY",
+                                         "SM70_MARLIN_DENSE_SPLIT_K",
+                                         "SM70_MARLIN_DENSE_METADATA_CACHE");
 }
 
 inline Sm70MarlinAutoParams sm70_marlin_dense_auto_params_from_env(
     Sm70MarlinDenseAutoParamsContext const& ctx) {
   return sm70_marlin_auto_params_from_env(
-      "Dense", "SM70_MARLIN_DENSE_CTA_GEOMETRY",
-      "SM70_MARLIN_DENSE_SPLIT_K", "SM70_MARLIN_DENSE_METADATA_CACHE",
-      ctx.packed_macro_n);
+      "Dense", "SM70_MARLIN_DENSE_CTA_GEOMETRY", "SM70_MARLIN_DENSE_SPLIT_K",
+      "SM70_MARLIN_DENSE_METADATA_CACHE", ctx.packed_macro_n);
 }
 
-inline bool
-sm70_marlin_dense_try_select_quanttrio_qwen3_6_27b_awq_params(
-    Sm70MarlinDenseAutoParamsContext const& ctx,
-    Sm70MarlinAutoParams& params) {
+inline bool sm70_marlin_dense_try_select_quanttrio_qwen3_6_27b_awq_params(
+    Sm70MarlinDenseAutoParamsContext const& ctx, Sm70MarlinAutoParams& params) {
   if (ctx.quant_format == nullptr ||
-      std::strcmp(ctx.quant_format, "uint4") != 0 ||
-      ctx.group_size != 128 || ctx.size_m <= 0) {
+      std::strcmp(ctx.quant_format, "uint4") != 0 || ctx.group_size != 128 ||
+      ctx.size_m <= 0) {
     return false;
   }
 
-  auto const set_params = [&](Sm70CtaGeometry geometry,
-                              int requested_split_k,
+  auto const set_params = [&](Sm70CtaGeometry geometry, int requested_split_k,
                               bool use_metadata_vector_words) {
     params = {geometry, requested_split_k, use_metadata_vector_words,
               ctx.packed_macro_n};
@@ -596,16 +579,14 @@ sm70_marlin_dense_try_select_quanttrio_qwen3_6_27b_awq_params(
 
 inline bool
 sm70_marlin_dense_try_select_cyankiwi_qwen3_6_27b_awq_bf16_nvfp4_params(
-    Sm70MarlinDenseAutoParamsContext const& ctx,
-    Sm70MarlinAutoParams& params) {
+    Sm70MarlinDenseAutoParamsContext const& ctx, Sm70MarlinAutoParams& params) {
   if (ctx.quant_format == nullptr ||
-      std::strcmp(ctx.quant_format, "nvfp4") != 0 ||
-      ctx.group_size != 16 || ctx.size_m <= 0) {
+      std::strcmp(ctx.quant_format, "nvfp4") != 0 || ctx.group_size != 16 ||
+      ctx.size_m <= 0) {
     return false;
   }
 
-  auto const set_params = [&](Sm70CtaGeometry geometry,
-                              int requested_split_k,
+  auto const set_params = [&](Sm70CtaGeometry geometry, int requested_split_k,
                               bool use_metadata_vector_words) {
     params = {geometry, requested_split_k, use_metadata_vector_words,
               ctx.packed_macro_n};
@@ -614,147 +595,144 @@ sm70_marlin_dense_try_select_cyankiwi_qwen3_6_27b_awq_bf16_nvfp4_params(
 
   if (ctx.size_n == 2048 && ctx.size_k == 5120) {
     if (ctx.size_m <= 1) {
-      return set_params({32,128,32,4,32,32,32}, 8, true);
+      return set_params({32, 128, 32, 4, 32, 32, 32}, 8, true);
     }
     if (ctx.size_m <= 32) {
-      return set_params({32,64,64,4,32,64,16}, 4, true);
+      return set_params({32, 64, 64, 4, 32, 64, 16}, 4, true);
     }
     if (ctx.size_m <= 64) {
-      return set_params({64,64,64,4,32,64,32}, 4, true);
+      return set_params({64, 64, 64, 4, 32, 64, 32}, 4, true);
     }
     if (ctx.size_m <= 2048) {
-      return set_params({128,256,32,8,64,64,32}, 1, true);
+      return set_params({128, 256, 32, 8, 64, 64, 32}, 1, true);
     }
-    return set_params({128,256,32,8,64,64,32}, 1, false);
+    return set_params({128, 256, 32, 8, 64, 64, 32}, 1, false);
   }
 
   if (ctx.size_n == 3584 && ctx.size_k == 5120) {
     if (ctx.size_m <= 1) {
-      return set_params({32,128,32,4,32,32,32}, 8, true);
+      return set_params({32, 128, 32, 4, 32, 32, 32}, 8, true);
     }
     if (ctx.size_m <= 32) {
-      return set_params({32,64,64,4,32,64,16}, 4, true);
+      return set_params({32, 64, 64, 4, 32, 64, 16}, 4, true);
     }
     if (ctx.size_m <= 64) {
-      return set_params({64,64,32,4,32,32,32}, 4, true);
+      return set_params({64, 64, 32, 4, 32, 32, 32}, 4, true);
     }
     if (ctx.size_m <= 2048) {
-      return set_params({128,256,32,8,64,64,32}, 1, true);
+      return set_params({128, 256, 32, 8, 64, 64, 32}, 1, true);
     }
-    return set_params({128,256,32,8,64,64,32}, 1, true);
+    return set_params({128, 256, 32, 8, 64, 64, 32}, 1, true);
   }
 
   if (ctx.size_n == 4352 && ctx.size_k == 5120) {
     if (ctx.size_m <= 1) {
-      return set_params({32,128,32,4,32,32,32}, 8, true);
+      return set_params({32, 128, 32, 4, 32, 32, 32}, 8, true);
     }
     if (ctx.size_m <= 32) {
-      return set_params({32,64,64,4,32,32,32}, 4, true);
+      return set_params({32, 64, 64, 4, 32, 32, 32}, 4, true);
     }
     if (ctx.size_m <= 64) {
-      return set_params({64,64,32,4,32,32,32}, 4, false);
+      return set_params({64, 64, 32, 4, 32, 32, 32}, 4, false);
     }
     if (ctx.size_m <= 2048) {
-      return set_params({128,256,32,8,64,64,32}, 1, false);
+      return set_params({128, 256, 32, 8, 64, 64, 32}, 1, false);
     }
-    return set_params({128,256,32,8,64,64,32}, 1, true);
+    return set_params({128, 256, 32, 8, 64, 64, 32}, 1, true);
   }
 
   if (ctx.size_n == 5120 && ctx.size_k == 768) {
     if (ctx.size_m <= 1) {
-      return set_params({64,64,64,4,32,64,32}, 1, false);
+      return set_params({64, 64, 64, 4, 32, 64, 32}, 1, false);
     }
     if (ctx.size_m <= 32) {
-      return set_params({32,64,64,4,32,64,16}, 1, false);
+      return set_params({32, 64, 64, 4, 32, 64, 16}, 1, false);
     }
     if (ctx.size_m <= 64) {
-      return set_params({32,64,32,4,32,32,16}, 1, true);
+      return set_params({32, 64, 32, 4, 32, 32, 16}, 1, true);
     }
     if (ctx.size_m <= 2048) {
-      return set_params({128,256,32,8,64,64,32}, 1, true);
+      return set_params({128, 256, 32, 8, 64, 64, 32}, 1, true);
     }
-    return set_params({128,256,32,8,64,64,32}, 1, false);
+    return set_params({128, 256, 32, 8, 64, 64, 32}, 1, false);
   }
 
   if (ctx.size_n == 5120 && ctx.size_k == 1536) {
     if (ctx.size_m <= 1) {
-      return set_params({32,64,64,4,32,64,16}, 1, true);
+      return set_params({32, 64, 64, 4, 32, 64, 16}, 1, true);
     }
     if (ctx.size_m <= 32) {
-      return set_params({64,64,32,4,32,32,32}, 1, true);
+      return set_params({64, 64, 32, 4, 32, 32, 32}, 1, true);
     }
     if (ctx.size_m <= 64) {
-      return set_params({64,64,32,4,32,32,32}, 1, false);
+      return set_params({64, 64, 32, 4, 32, 32, 32}, 1, false);
     }
     if (ctx.size_m <= 2048) {
-      return set_params({128,256,32,8,64,64,32}, 1, true);
+      return set_params({128, 256, 32, 8, 64, 64, 32}, 1, true);
     }
-    return set_params({128,256,32,8,64,64,32}, 1, true);
+    return set_params({128, 256, 32, 8, 64, 64, 32}, 1, true);
   }
 
   if (ctx.size_n == 5120 && ctx.size_k == 2176) {
     if (ctx.size_m <= 1) {
-      return set_params({32,128,32,4,32,32,32}, 8, true);
+      return set_params({32, 128, 32, 4, 32, 32, 32}, 8, true);
     }
     if (ctx.size_m <= 32) {
-      return set_params({32,64,128,4,32,64,32}, 1, true);
+      return set_params({32, 64, 128, 4, 32, 64, 32}, 1, true);
     }
     if (ctx.size_m <= 64) {
-      return set_params({32,128,128,8,32,64,32}, 1, true);
+      return set_params({32, 128, 128, 8, 32, 64, 32}, 1, true);
     }
     if (ctx.size_m <= 2048) {
-      return set_params({128,256,32,8,64,64,32}, 1, true);
+      return set_params({128, 256, 32, 8, 64, 64, 32}, 1, true);
     }
-    return set_params({128,256,32,8,64,64,32}, 1, true);
+    return set_params({128, 256, 32, 8, 64, 64, 32}, 1, true);
   }
 
   if (ctx.size_n == 5120 && ctx.size_k == 4352) {
     if (ctx.size_m <= 1) {
-      return set_params({32,128,32,4,32,32,32}, 8, true);
+      return set_params({32, 128, 32, 4, 32, 32, 32}, 8, true);
     }
     if (ctx.size_m <= 32) {
-      return set_params({32,128,64,8,32,32,32}, 2, true);
+      return set_params({32, 128, 64, 8, 32, 32, 32}, 2, true);
     }
     if (ctx.size_m <= 64) {
-      return set_params({32,128,128,8,32,64,32}, 1, true);
+      return set_params({32, 128, 128, 8, 32, 64, 32}, 1, true);
     }
     if (ctx.size_m <= 2048) {
-      return set_params({128,256,32,8,64,64,32}, 1, true);
+      return set_params({128, 256, 32, 8, 64, 64, 32}, 1, true);
     }
-    return set_params({128,256,32,8,64,64,32}, 1, true);
+    return set_params({128, 256, 32, 8, 64, 64, 32}, 1, true);
   }
 
   if (ctx.size_n == 8704 && ctx.size_k == 5120) {
     if (ctx.size_m <= 1) {
-      return set_params({32,128,32,4,32,32,32}, 4, true);
+      return set_params({32, 128, 32, 4, 32, 32, 32}, 4, true);
     }
     if (ctx.size_m <= 32) {
-      return set_params({32,128,32,4,32,32,32}, 4, false);
+      return set_params({32, 128, 32, 4, 32, 32, 32}, 4, false);
     }
     if (ctx.size_m <= 64) {
-      return set_params({64,128,128,8,64,64,32}, 1, true);
+      return set_params({64, 128, 128, 8, 64, 64, 32}, 1, true);
     }
     if (ctx.size_m <= 2048) {
-      return set_params({128,256,32,8,64,64,32}, 1, true);
+      return set_params({128, 256, 32, 8, 64, 64, 32}, 1, true);
     }
-    return set_params({128,256,32,8,64,64,32}, 1, true);
+    return set_params({128, 256, 32, 8, 64, 64, 32}, 1, true);
   }
 
   return false;
 }
 
-inline bool
-sm70_marlin_dense_try_select_nvidia_glm_4_7_nvfp4_params(
-    Sm70MarlinDenseAutoParamsContext const& ctx,
-    Sm70MarlinAutoParams& params) {
+inline bool sm70_marlin_dense_try_select_nvidia_glm_4_7_nvfp4_params(
+    Sm70MarlinDenseAutoParamsContext const& ctx, Sm70MarlinAutoParams& params) {
   if (ctx.quant_format == nullptr ||
-      std::strcmp(ctx.quant_format, "nvfp4") != 0 ||
-      ctx.group_size != 16 || ctx.size_m <= 0) {
+      std::strcmp(ctx.quant_format, "nvfp4") != 0 || ctx.group_size != 16 ||
+      ctx.size_m <= 0) {
     return false;
   }
 
-  auto const set_params = [&](Sm70CtaGeometry geometry,
-                              int requested_split_k,
+  auto const set_params = [&](Sm70CtaGeometry geometry, int requested_split_k,
                               bool use_metadata_vector_words) {
     params = {geometry, requested_split_k, use_metadata_vector_words,
               ctx.packed_macro_n};
@@ -763,293 +741,282 @@ sm70_marlin_dense_try_select_nvidia_glm_4_7_nvfp4_params(
 
   if (ctx.size_n == 384 && ctx.size_k == 5120) {
     if (ctx.size_m <= 1) {
-      return set_params({32,64,64,4,32,64,16}, 8, true);
+      return set_params({32, 64, 64, 4, 32, 64, 16}, 8, true);
     }
     if (ctx.size_m <= 32) {
-      return set_params({32,64,64,4,32,32,32}, 8, true);
+      return set_params({32, 64, 64, 4, 32, 32, 32}, 8, true);
     }
     if (ctx.size_m <= 64) {
-      return set_params({32,64,64,4,32,64,16}, 8, true);
+      return set_params({32, 64, 64, 4, 32, 64, 16}, 8, true);
     }
     if (ctx.size_m <= 2048) {
-      return set_params({64,64,64,4,64,32,32}, 1, true);
+      return set_params({64, 64, 64, 4, 64, 32, 32}, 1, true);
     }
-    return set_params({64,128,32,4,32,64,32}, 1, true);
+    return set_params({64, 128, 32, 4, 32, 64, 32}, 1, true);
   }
 
   if (ctx.size_n == 768 && ctx.size_k == 5120) {
     if (ctx.size_m <= 1) {
-      return set_params({32,64,64,4,32,32,32}, 8, true);
+      return set_params({32, 64, 64, 4, 32, 32, 32}, 8, true);
     }
     if (ctx.size_m <= 32) {
-      return set_params({32,64,64,4,32,64,16}, 8, false);
+      return set_params({32, 64, 64, 4, 32, 64, 16}, 8, false);
     }
     if (ctx.size_m <= 64) {
-      return set_params({32,64,64,4,32,32,32}, 4, true);
+      return set_params({32, 64, 64, 4, 32, 32, 32}, 4, true);
     }
     if (ctx.size_m <= 2048) {
-      return set_params({128,64,32,4,32,64,32}, 1, true);
+      return set_params({128, 64, 32, 4, 32, 64, 32}, 1, true);
     }
-    return set_params({64,128,32,4,32,64,32}, 1, true);
+    return set_params({64, 128, 32, 4, 32, 64, 32}, 1, true);
   }
 
   if (ctx.size_n == 3072 && ctx.size_k == 5120) {
     if (ctx.size_m <= 1) {
-      return set_params({32,128,32,4,32,32,32}, 8, true);
+      return set_params({32, 128, 32, 4, 32, 32, 32}, 8, true);
     }
     if (ctx.size_m <= 32) {
-      return set_params({32,64,64,4,32,64,16}, 4, true);
+      return set_params({32, 64, 64, 4, 32, 64, 16}, 4, true);
     }
     if (ctx.size_m <= 64) {
-      return set_params({64,64,32,4,32,32,32}, 4, true);
+      return set_params({64, 64, 32, 4, 32, 32, 32}, 4, true);
     }
     if (ctx.size_m <= 2048) {
-      return set_params({128,128,64,8,64,64,32}, 1, true);
+      return set_params({128, 128, 64, 8, 64, 64, 32}, 1, true);
     }
-    return set_params({128,256,32,8,64,64,32}, 1, true);
+    return set_params({128, 256, 32, 8, 64, 64, 32}, 1, true);
   }
 
   if (ctx.size_n == 5120 && ctx.size_k == 192) {
     if (ctx.size_m <= 1) {
-      return set_params({32,64,64,4,32,32,32}, 1, true);
+      return set_params({32, 64, 64, 4, 32, 32, 32}, 1, true);
     }
     if (ctx.size_m <= 32) {
-      return set_params({32,64,32,4,32,32,16}, 1, true);
+      return set_params({32, 64, 32, 4, 32, 32, 16}, 1, true);
     }
     if (ctx.size_m <= 64) {
-      return set_params({32,64,32,4,32,32,16}, 1, true);
+      return set_params({32, 64, 32, 4, 32, 32, 16}, 1, true);
     }
     if (ctx.size_m <= 2048) {
-      return set_params({128,128,32,4,64,64,32}, 1, true);
+      return set_params({128, 128, 32, 4, 64, 64, 32}, 1, true);
     }
-    return set_params({128,128,32,4,64,64,32}, 1, true);
+    return set_params({128, 128, 32, 4, 64, 64, 32}, 1, true);
   }
 
   if (ctx.size_n == 5120 && ctx.size_k == 384) {
     if (ctx.size_m <= 1) {
-      return set_params({32,64,32,4,32,32,16}, 1, true);
+      return set_params({32, 64, 32, 4, 32, 32, 16}, 1, true);
     }
     if (ctx.size_m <= 32) {
-      return set_params({32,64,32,4,32,32,16}, 1, true);
+      return set_params({32, 64, 32, 4, 32, 32, 16}, 1, true);
     }
     if (ctx.size_m <= 64) {
-      return set_params({32,64,32,4,32,32,16}, 1, true);
+      return set_params({32, 64, 32, 4, 32, 32, 16}, 1, true);
     }
     if (ctx.size_m <= 2048) {
-      return set_params({128,256,32,8,64,64,32}, 1, true);
+      return set_params({128, 256, 32, 8, 64, 64, 32}, 1, true);
     }
-    return set_params({128,256,32,8,64,64,32}, 1, true);
+    return set_params({128, 256, 32, 8, 64, 64, 32}, 1, true);
   }
 
   if (ctx.size_n == 5120 && ctx.size_k == 1536) {
     if (ctx.size_m <= 1) {
-      return set_params({32,64,64,4,32,32,32}, 4, true);
+      return set_params({32, 64, 64, 4, 32, 32, 32}, 4, true);
     }
     if (ctx.size_m <= 32) {
-      return set_params({32,64,64,4,32,32,32}, 1, true);
+      return set_params({32, 64, 64, 4, 32, 32, 32}, 1, true);
     }
     if (ctx.size_m <= 64) {
-      return set_params({32,128,32,4,32,32,32}, 1, true);
+      return set_params({32, 128, 32, 4, 32, 32, 32}, 1, true);
     }
     if (ctx.size_m <= 2048) {
-      return set_params({128,256,32,8,64,64,32}, 1, true);
+      return set_params({128, 256, 32, 8, 64, 64, 32}, 1, true);
     }
-    return set_params({128,256,32,8,64,64,32}, 1, true);
+    return set_params({128, 256, 32, 8, 64, 64, 32}, 1, true);
   }
 
   if (ctx.size_n == 5120 && ctx.size_k == 3072) {
     if (ctx.size_m <= 1) {
-      return set_params({32,128,32,4,32,32,32}, 8, true);
+      return set_params({32, 128, 32, 4, 32, 32, 32}, 8, true);
     }
     if (ctx.size_m <= 32) {
-      return set_params({32,64,64,4,32,64,16}, 2, false);
+      return set_params({32, 64, 64, 4, 32, 64, 16}, 2, false);
     }
     if (ctx.size_m <= 64) {
-      return set_params({32,128,128,8,32,64,32}, 1, true);
+      return set_params({32, 128, 128, 8, 32, 64, 32}, 1, true);
     }
     if (ctx.size_m <= 2048) {
-      return set_params({128,256,32,8,64,64,32}, 1, true);
+      return set_params({128, 256, 32, 8, 64, 64, 32}, 1, true);
     }
-    return set_params({128,256,32,8,64,64,32}, 1, true);
+    return set_params({128, 256, 32, 8, 64, 64, 32}, 1, true);
   }
 
   if (ctx.size_n == 6144 && ctx.size_k == 5120) {
     if (ctx.size_m <= 1) {
-      return set_params({32,128,32,4,32,32,32}, 4, true);
+      return set_params({32, 128, 32, 4, 32, 32, 32}, 4, true);
     }
     if (ctx.size_m <= 32) {
-      return set_params({32,128,32,4,32,32,32}, 4, true);
+      return set_params({32, 128, 32, 4, 32, 32, 32}, 4, true);
     }
     if (ctx.size_m <= 64) {
-      return set_params({64,128,32,4,32,64,32}, 4, false);
+      return set_params({64, 128, 32, 4, 32, 64, 32}, 4, false);
     }
     if (ctx.size_m <= 2048) {
-      return set_params({128,256,32,8,64,64,32}, 1, true);
+      return set_params({128, 256, 32, 8, 64, 64, 32}, 1, true);
     }
-    return set_params({128,256,32,8,64,64,32}, 1, true);
+    return set_params({128, 256, 32, 8, 64, 64, 32}, 1, true);
   }
 
   return false;
 }
 
-inline bool
-sm70_marlin_dense_try_select_nvidia_qwen3_6_35b_a3b_nvfp4_params(
-    Sm70MarlinDenseAutoParamsContext const& ctx,
-    Sm70MarlinAutoParams& params) {
+inline bool sm70_marlin_dense_try_select_nvidia_qwen3_6_35b_a3b_nvfp4_params(
+    Sm70MarlinDenseAutoParamsContext const& ctx, Sm70MarlinAutoParams& params) {
   if (ctx.quant_format == nullptr || ctx.size_m <= 0) {
     return false;
   }
 
-  auto const set_params = [&](Sm70CtaGeometry geometry,
-                              int requested_split_k,
+  auto const set_params = [&](Sm70CtaGeometry geometry, int requested_split_k,
                               bool use_metadata_vector_words) {
     params = {geometry, requested_split_k, use_metadata_vector_words,
               ctx.packed_macro_n};
     return true;
   };
 
-  if (std::strcmp(ctx.quant_format, "fp8_e4m3") == 0 &&
-      ctx.group_size == 512 &&
+  if (std::strcmp(ctx.quant_format, "fp8_e4m3") == 0 && ctx.group_size == 512 &&
       ctx.size_n == 2048 && ctx.size_k == 512) {
     if (ctx.size_m <= 1) {
-      return set_params({32,64,32,4,32,32,16}, 1, true);
+      return set_params({32, 64, 32, 4, 32, 32, 16}, 1, true);
     }
     if (ctx.size_m <= 32) {
-      return set_params({32,64,32,4,32,32,16}, 1, false);
+      return set_params({32, 64, 32, 4, 32, 32, 16}, 1, false);
     }
     if (ctx.size_m <= 64) {
-      return set_params({32,64,32,4,32,32,16}, 1, true);
+      return set_params({32, 64, 32, 4, 32, 32, 16}, 1, true);
     }
     if (ctx.size_m <= 2048) {
-      return set_params({128,256,32,8,64,64,32}, 1, true);
+      return set_params({128, 256, 32, 8, 64, 64, 32}, 1, true);
     }
-    return set_params({128,256,32,8,64,64,32}, 1, true);
+    return set_params({128, 256, 32, 8, 64, 64, 32}, 1, true);
   }
 
   if (std::strcmp(ctx.quant_format, "fp8_e4m3") == 0 &&
-      ctx.group_size == 1024 &&
-      ctx.size_n == 2048 && ctx.size_k == 1024) {
+      ctx.group_size == 1024 && ctx.size_n == 2048 && ctx.size_k == 1024) {
     if (ctx.size_m <= 1) {
-      return set_params({32,64,64,4,32,32,32}, 1, true);
+      return set_params({32, 64, 64, 4, 32, 32, 32}, 1, true);
     }
     if (ctx.size_m <= 32) {
-      return set_params({32,64,64,4,32,32,32}, 1, true);
+      return set_params({32, 64, 64, 4, 32, 32, 32}, 1, true);
     }
     if (ctx.size_m <= 64) {
-      return set_params({32,64,64,4,32,32,32}, 1, true);
+      return set_params({32, 64, 64, 4, 32, 32, 32}, 1, true);
     }
     if (ctx.size_m <= 2048) {
-      return set_params({128,256,32,8,64,64,32}, 1, true);
+      return set_params({128, 256, 32, 8, 64, 64, 32}, 1, true);
     }
-    return set_params({128,256,32,8,64,64,32}, 1, true);
+    return set_params({128, 256, 32, 8, 64, 64, 32}, 1, true);
   }
 
   if (std::strcmp(ctx.quant_format, "fp8_e4m3") == 0 &&
-      ctx.group_size == 2048 &&
-      ctx.size_n == 1536 && ctx.size_k == 2048) {
+      ctx.group_size == 2048 && ctx.size_n == 1536 && ctx.size_k == 2048) {
     if (ctx.size_m <= 1) {
-      return set_params({32,64,32,4,32,32,16}, 4, true);
+      return set_params({32, 64, 32, 4, 32, 32, 16}, 4, true);
     }
     if (ctx.size_m <= 32) {
-      return set_params({32,64,64,4,32,32,32}, 4, true);
+      return set_params({32, 64, 64, 4, 32, 32, 32}, 4, true);
     }
     if (ctx.size_m <= 64) {
-      return set_params({32,64,64,4,32,32,32}, 4, true);
+      return set_params({32, 64, 64, 4, 32, 32, 32}, 4, true);
     }
     if (ctx.size_m <= 2048) {
-      return set_params({64,128,32,4,32,64,32}, 1, false);
+      return set_params({64, 128, 32, 4, 32, 64, 32}, 1, false);
     }
-    return set_params({128,256,32,8,64,64,32}, 1, true);
+    return set_params({128, 256, 32, 8, 64, 64, 32}, 1, true);
   }
 
   if (std::strcmp(ctx.quant_format, "fp8_e4m3") == 0 &&
-      ctx.group_size == 2048 &&
-      ctx.size_n == 2560 && ctx.size_k == 2048) {
+      ctx.group_size == 2048 && ctx.size_n == 2560 && ctx.size_k == 2048) {
     if (ctx.size_m <= 1) {
-      return set_params({32,64,32,4,32,32,16}, 8, true);
+      return set_params({32, 64, 32, 4, 32, 32, 16}, 8, true);
     }
     if (ctx.size_m <= 32) {
-      return set_params({32,64,64,4,32,32,32}, 2, true);
+      return set_params({32, 64, 64, 4, 32, 32, 32}, 2, true);
     }
     if (ctx.size_m <= 64) {
-      return set_params({32,64,64,4,32,64,16}, 1, true);
+      return set_params({32, 64, 64, 4, 32, 64, 16}, 1, true);
     }
     if (ctx.size_m <= 2048) {
-      return set_params({128,256,32,8,64,64,32}, 1, true);
+      return set_params({128, 256, 32, 8, 64, 64, 32}, 1, true);
     }
-    return set_params({128,256,32,8,64,64,32}, 1, true);
+    return set_params({128, 256, 32, 8, 64, 64, 32}, 1, true);
   }
 
-  if (std::strcmp(ctx.quant_format, "nvfp4") == 0 &&
-      ctx.group_size == 16 &&
+  if (std::strcmp(ctx.quant_format, "nvfp4") == 0 && ctx.group_size == 16 &&
       ctx.size_n == 128 && ctx.size_k == 2048) {
     if (ctx.size_m <= 1) {
-      return set_params({32,64,32,4,32,32,16}, 4, true);
+      return set_params({32, 64, 32, 4, 32, 32, 16}, 4, true);
     }
     if (ctx.size_m <= 32) {
-      return set_params({32,64,64,4,32,32,32}, 4, true);
+      return set_params({32, 64, 64, 4, 32, 32, 32}, 4, true);
     }
     if (ctx.size_m <= 64) {
-      return set_params({32,64,64,4,32,32,32}, 4, true);
+      return set_params({32, 64, 64, 4, 32, 32, 32}, 4, true);
     }
     if (ctx.size_m <= 2048) {
-      return set_params({64,64,64,4,32,64,32}, 1, true);
+      return set_params({64, 64, 64, 4, 32, 64, 32}, 1, true);
     }
-    return set_params({128,64,128,8,64,64,32}, 1, true);
+    return set_params({128, 64, 128, 8, 64, 64, 32}, 1, true);
   }
 
-  if (std::strcmp(ctx.quant_format, "nvfp4") == 0 &&
-      ctx.group_size == 16 &&
+  if (std::strcmp(ctx.quant_format, "nvfp4") == 0 && ctx.group_size == 16 &&
       ctx.size_n == 256 && ctx.size_k == 2048) {
     if (ctx.size_m <= 1) {
-      return set_params({32,64,32,4,32,32,16}, 4, true);
+      return set_params({32, 64, 32, 4, 32, 32, 16}, 4, true);
     }
     if (ctx.size_m <= 32) {
-      return set_params({32,64,64,4,32,32,32}, 4, true);
+      return set_params({32, 64, 64, 4, 32, 32, 32}, 4, true);
     }
     if (ctx.size_m <= 64) {
-      return set_params({32,64,64,4,32,32,32}, 4, true);
+      return set_params({32, 64, 64, 4, 32, 32, 32}, 4, true);
     }
     if (ctx.size_m <= 2048) {
-      return set_params({128,64,128,8,64,64,32}, 1, false);
+      return set_params({128, 64, 128, 8, 64, 64, 32}, 1, false);
     }
-    return set_params({128,64,32,4,32,64,32}, 1, false);
+    return set_params({128, 64, 32, 4, 32, 64, 32}, 1, false);
   }
 
-  if (std::strcmp(ctx.quant_format, "nvfp4") == 0 &&
-      ctx.group_size == 16 &&
+  if (std::strcmp(ctx.quant_format, "nvfp4") == 0 && ctx.group_size == 16 &&
       ctx.size_n == 2048 && ctx.size_k == 64) {
     if (ctx.size_m <= 1) {
-      return set_params({32,64,64,4,32,64,16}, 1, false);
+      return set_params({32, 64, 64, 4, 32, 64, 16}, 1, false);
     }
     if (ctx.size_m <= 32) {
-      return set_params({32,64,64,4,32,32,32}, 1, true);
+      return set_params({32, 64, 64, 4, 32, 32, 32}, 1, true);
     }
     if (ctx.size_m <= 64) {
-      return set_params({32,64,64,4,32,64,16}, 1, false);
+      return set_params({32, 64, 64, 4, 32, 64, 16}, 1, false);
     }
     if (ctx.size_m <= 2048) {
-      return set_params({32,128,32,4,32,32,32}, 1, true);
+      return set_params({32, 128, 32, 4, 32, 32, 32}, 1, true);
     }
-    return set_params({128,64,32,4,32,64,32}, 1, false);
+    return set_params({128, 64, 32, 4, 32, 64, 32}, 1, false);
   }
 
-  if (std::strcmp(ctx.quant_format, "nvfp4") == 0 &&
-      ctx.group_size == 16 &&
+  if (std::strcmp(ctx.quant_format, "nvfp4") == 0 && ctx.group_size == 16 &&
       ctx.size_n == 2048 && ctx.size_k == 128) {
     if (ctx.size_m <= 1) {
-      return set_params({32,64,64,4,32,32,32}, 1, false);
+      return set_params({32, 64, 64, 4, 32, 32, 32}, 1, false);
     }
     if (ctx.size_m <= 32) {
-      return set_params({32,64,64,4,32,32,32}, 1, true);
+      return set_params({32, 64, 64, 4, 32, 32, 32}, 1, true);
     }
     if (ctx.size_m <= 64) {
-      return set_params({32,64,64,4,32,64,16}, 1, false);
+      return set_params({32, 64, 64, 4, 32, 64, 16}, 1, false);
     }
     if (ctx.size_m <= 2048) {
-      return set_params({128,64,32,4,32,64,32}, 1, true);
+      return set_params({128, 64, 32, 4, 32, 64, 32}, 1, true);
     }
-    return set_params({128,64,32,4,32,64,32}, 1, true);
+    return set_params({128, 64, 32, 4, 32, 64, 32}, 1, true);
   }
 
   return false;
@@ -1057,16 +1024,14 @@ sm70_marlin_dense_try_select_nvidia_qwen3_6_35b_a3b_nvfp4_params(
 
 inline bool
 sm70_marlin_dense_try_select_nvidia_qwen3_next_80b_a3b_thinking_nvfp4_params(
-    Sm70MarlinDenseAutoParamsContext const& ctx,
-    Sm70MarlinAutoParams& params) {
+    Sm70MarlinDenseAutoParamsContext const& ctx, Sm70MarlinAutoParams& params) {
   if (ctx.quant_format == nullptr ||
-      std::strcmp(ctx.quant_format, "nvfp4") != 0 ||
-      ctx.group_size != 16 || ctx.size_m <= 0) {
+      std::strcmp(ctx.quant_format, "nvfp4") != 0 || ctx.group_size != 16 ||
+      ctx.size_m <= 0) {
     return false;
   }
 
-  auto const set_params = [&](Sm70CtaGeometry geometry,
-                              int requested_split_k,
+  auto const set_params = [&](Sm70CtaGeometry geometry, int requested_split_k,
                               bool use_metadata_vector_words) {
     params = {geometry, requested_split_k, use_metadata_vector_words,
               ctx.packed_macro_n};
@@ -1075,115 +1040,112 @@ sm70_marlin_dense_try_select_nvidia_qwen3_next_80b_a3b_thinking_nvfp4_params(
 
   if (ctx.size_n == 128 && ctx.size_k == 2048) {
     if (ctx.size_m <= 1) {
-      return set_params({32,64,32,4,32,32,16}, 4, true);
+      return set_params({32, 64, 32, 4, 32, 32, 16}, 4, true);
     }
     if (ctx.size_m <= 32) {
-      return set_params({32,64,32,4,32,32,16}, 4, true);
+      return set_params({32, 64, 32, 4, 32, 32, 16}, 4, true);
     }
     if (ctx.size_m <= 64) {
-      return set_params({32,64,64,4,32,32,32}, 4, true);
+      return set_params({32, 64, 64, 4, 32, 32, 32}, 4, true);
     }
     if (ctx.size_m <= 2048) {
-      return set_params({64,64,64,4,32,64,32}, 1, true);
+      return set_params({64, 64, 64, 4, 32, 64, 32}, 1, true);
     }
-    return set_params({128,64,128,8,64,64,32}, 1, true);
+    return set_params({128, 64, 128, 8, 64, 64, 32}, 1, true);
   }
 
   if (ctx.size_n == 256 && ctx.size_k == 2048) {
     if (ctx.size_m <= 1) {
-      return set_params({32,64,32,4,32,32,16}, 4, true);
+      return set_params({32, 64, 32, 4, 32, 32, 16}, 4, true);
     }
     if (ctx.size_m <= 32) {
-      return set_params({32,64,64,4,32,32,32}, 4, true);
+      return set_params({32, 64, 64, 4, 32, 32, 32}, 4, true);
     }
     if (ctx.size_m <= 64) {
-      return set_params({32,64,64,4,32,32,32}, 4, true);
+      return set_params({32, 64, 64, 4, 32, 32, 32}, 4, true);
     }
     if (ctx.size_m <= 2048) {
-      return set_params({128,64,128,8,64,64,32}, 1, true);
+      return set_params({128, 64, 128, 8, 64, 64, 32}, 1, true);
     }
-    return set_params({128,64,32,4,32,64,32}, 1, true);
+    return set_params({128, 64, 32, 4, 32, 64, 32}, 1, true);
   }
 
   if (ctx.size_n == 2048 && ctx.size_k == 64) {
     if (ctx.size_m <= 1) {
-      return set_params({32,64,64,4,32,64,16}, 1, true);
+      return set_params({32, 64, 64, 4, 32, 64, 16}, 1, true);
     }
     if (ctx.size_m <= 32) {
-      return set_params({32,64,64,4,32,32,32}, 1, true);
+      return set_params({32, 64, 64, 4, 32, 32, 32}, 1, true);
     }
     if (ctx.size_m <= 64) {
-      return set_params({32,64,64,4,32,32,32}, 1, false);
+      return set_params({32, 64, 64, 4, 32, 32, 32}, 1, false);
     }
     if (ctx.size_m <= 2048) {
-      return set_params({64,64,32,4,32,32,32}, 1, true);
+      return set_params({64, 64, 32, 4, 32, 32, 32}, 1, true);
     }
-    return set_params({128,64,32,4,32,64,32}, 1, true);
+    return set_params({128, 64, 32, 4, 32, 64, 32}, 1, true);
   }
 
   if (ctx.size_n == 2048 && ctx.size_k == 128) {
     if (ctx.size_m <= 1) {
-      return set_params({32,128,32,4,32,32,32}, 1, true);
+      return set_params({32, 128, 32, 4, 32, 32, 32}, 1, true);
     }
     if (ctx.size_m <= 32) {
-      return set_params({32,64,64,4,32,64,16}, 1, true);
+      return set_params({32, 64, 64, 4, 32, 64, 16}, 1, true);
     }
     if (ctx.size_m <= 64) {
-      return set_params({32,64,64,4,32,32,32}, 1, true);
+      return set_params({32, 64, 64, 4, 32, 32, 32}, 1, true);
     }
     if (ctx.size_m <= 2048) {
-      return set_params({128,64,32,4,32,64,32}, 1, true);
+      return set_params({128, 64, 32, 4, 32, 64, 32}, 1, true);
     }
-    return set_params({128,64,32,4,32,64,32}, 1, false);
+    return set_params({128, 64, 32, 4, 32, 64, 32}, 1, false);
   }
 
   if (ctx.size_n == 2048 && ctx.size_k == 512) {
     if (ctx.size_m <= 1) {
-      return set_params({32,64,64,4,32,32,32}, 1, true);
+      return set_params({32, 64, 64, 4, 32, 32, 32}, 1, true);
     }
     if (ctx.size_m <= 32) {
-      return set_params({32,64,64,4,32,32,32}, 1, false);
+      return set_params({32, 64, 64, 4, 32, 32, 32}, 1, false);
     }
     if (ctx.size_m <= 64) {
-      return set_params({32,64,32,4,32,32,16}, 1, false);
+      return set_params({32, 64, 32, 4, 32, 32, 16}, 1, false);
     }
     if (ctx.size_m <= 2048) {
-      return set_params({128,128,32,4,64,64,32}, 1, true);
+      return set_params({128, 128, 32, 4, 64, 64, 32}, 1, true);
     }
-    return set_params({128,256,32,8,64,64,32}, 1, true);
+    return set_params({128, 256, 32, 8, 64, 64, 32}, 1, true);
   }
 
   if (ctx.size_n == 2048 && ctx.size_k == 1024) {
     if (ctx.size_m <= 1) {
-      return set_params({64,64,32,4,32,32,32}, 1, true);
+      return set_params({64, 64, 32, 4, 32, 32, 32}, 1, true);
     }
     if (ctx.size_m <= 32) {
-      return set_params({32,64,64,4,32,32,32}, 1, false);
+      return set_params({32, 64, 64, 4, 32, 32, 32}, 1, false);
     }
     if (ctx.size_m <= 64) {
-      return set_params({32,64,64,4,32,32,32}, 1, true);
+      return set_params({32, 64, 64, 4, 32, 32, 32}, 1, true);
     }
     if (ctx.size_m <= 2048) {
-      return set_params({128,256,32,8,64,64,32}, 1, true);
+      return set_params({128, 256, 32, 8, 64, 64, 32}, 1, true);
     }
-    return set_params({128,256,32,8,64,64,32}, 1, true);
+    return set_params({128, 256, 32, 8, 64, 64, 32}, 1, true);
   }
 
   return false;
 }
 
-inline bool
-sm70_marlin_dense_try_select_cyankiwi_minimax_m2_7_awq_4bit_params(
-    Sm70MarlinDenseAutoParamsContext const& ctx,
-    Sm70MarlinAutoParams& params) {
+inline bool sm70_marlin_dense_try_select_cyankiwi_minimax_m2_7_awq_4bit_params(
+    Sm70MarlinDenseAutoParamsContext const& ctx, Sm70MarlinAutoParams& params) {
   if (ctx.quant_format == nullptr ||
-      std::strcmp(ctx.quant_format, "uint4b8") != 0 ||
-      ctx.group_size != 32 || ctx.size_m <= 0) {
+      std::strcmp(ctx.quant_format, "uint4b8") != 0 || ctx.group_size != 32 ||
+      ctx.size_m <= 0) {
     return false;
   }
 
-  auto const set_params = [&](Sm70CtaGeometry geometry,
-                              int requested_split_k,
+  auto const set_params = [&](Sm70CtaGeometry geometry, int requested_split_k,
                               bool use_metadata_vector_words) {
     params = {geometry, requested_split_k, use_metadata_vector_words,
               ctx.packed_macro_n};
@@ -1246,18 +1208,15 @@ sm70_marlin_dense_try_select_cyankiwi_minimax_m2_7_awq_4bit_params(
   return false;
 }
 
-inline bool
-sm70_marlin_dense_try_select_cyankiwi_glm_4_7_awq_4bit_params(
-    Sm70MarlinDenseAutoParamsContext const& ctx,
-    Sm70MarlinAutoParams& params) {
+inline bool sm70_marlin_dense_try_select_cyankiwi_glm_4_7_awq_4bit_params(
+    Sm70MarlinDenseAutoParamsContext const& ctx, Sm70MarlinAutoParams& params) {
   if (ctx.quant_format == nullptr ||
-      std::strcmp(ctx.quant_format, "uint4b8") != 0 ||
-      ctx.group_size != 32 || ctx.size_m <= 0) {
+      std::strcmp(ctx.quant_format, "uint4b8") != 0 || ctx.group_size != 32 ||
+      ctx.size_m <= 0) {
     return false;
   }
 
-  auto const set_params = [&](Sm70CtaGeometry geometry,
-                              int requested_split_k,
+  auto const set_params = [&](Sm70CtaGeometry geometry, int requested_split_k,
                               bool use_metadata_vector_words) {
     params = {geometry, requested_split_k, use_metadata_vector_words,
               ctx.packed_macro_n};
@@ -1323,18 +1282,15 @@ sm70_marlin_dense_try_select_cyankiwi_glm_4_7_awq_4bit_params(
   return false;
 }
 
-inline bool
-sm70_marlin_dense_try_select_quanttrio_glm_4_7_awq_params(
-    Sm70MarlinDenseAutoParamsContext const& ctx,
-    Sm70MarlinAutoParams& params) {
+inline bool sm70_marlin_dense_try_select_quanttrio_glm_4_7_awq_params(
+    Sm70MarlinDenseAutoParamsContext const& ctx, Sm70MarlinAutoParams& params) {
   if (ctx.quant_format == nullptr ||
-      std::strcmp(ctx.quant_format, "uint4") != 0 ||
-      ctx.group_size != 128 || ctx.size_m <= 0) {
+      std::strcmp(ctx.quant_format, "uint4") != 0 || ctx.group_size != 128 ||
+      ctx.size_m <= 0) {
     return false;
   }
 
-  auto const set_params = [&](Sm70CtaGeometry geometry,
-                              int requested_split_k,
+  auto const set_params = [&](Sm70CtaGeometry geometry, int requested_split_k,
                               bool use_metadata_vector_words) {
     params = {geometry, requested_split_k, use_metadata_vector_words,
               ctx.packed_macro_n};
@@ -1426,16 +1382,16 @@ inline Sm70MarlinAutoParams sm70_marlin_dense_auto_params(
     char const* quant_format, int64_t group_size, int64_t size_m,
     int64_t size_n, int64_t size_k) {
   Sm70MarlinDenseAutoParamsContext const ctx{
-      quant_format, group_size, size_m, size_n, size_k,
-      sm70_marlin_auto_packed_macro_n(size_n)};
+      quant_format, group_size, size_m,
+      size_n,       size_k,     sm70_marlin_auto_packed_macro_n(size_n)};
 
   if (sm70_marlin_dense_auto_env_is_set()) {
     return sm70_marlin_dense_auto_params_from_env(ctx);
   }
 
   Sm70MarlinAutoParams params{};
-  if (sm70_marlin_dense_try_select_quanttrio_qwen3_6_27b_awq_params(
-          ctx, params)) {
+  if (sm70_marlin_dense_try_select_quanttrio_qwen3_6_27b_awq_params(ctx,
+                                                                    params)) {
     validate_sm70_marlin_auto_params("Dense", params);
     return params;
   }
@@ -1444,8 +1400,7 @@ inline Sm70MarlinAutoParams sm70_marlin_dense_auto_params(
     validate_sm70_marlin_auto_params("Dense", params);
     return params;
   }
-  if (sm70_marlin_dense_try_select_nvidia_glm_4_7_nvfp4_params(
-          ctx, params)) {
+  if (sm70_marlin_dense_try_select_nvidia_glm_4_7_nvfp4_params(ctx, params)) {
     validate_sm70_marlin_auto_params("Dense", params);
     return params;
   }
@@ -1464,13 +1419,12 @@ inline Sm70MarlinAutoParams sm70_marlin_dense_auto_params(
     validate_sm70_marlin_auto_params("Dense", params);
     return params;
   }
-  if (sm70_marlin_dense_try_select_cyankiwi_glm_4_7_awq_4bit_params(
-          ctx, params)) {
+  if (sm70_marlin_dense_try_select_cyankiwi_glm_4_7_awq_4bit_params(ctx,
+                                                                    params)) {
     validate_sm70_marlin_auto_params("Dense", params);
     return params;
   }
-  if (sm70_marlin_dense_try_select_quanttrio_glm_4_7_awq_params(
-          ctx, params)) {
+  if (sm70_marlin_dense_try_select_quanttrio_glm_4_7_awq_params(ctx, params)) {
     validate_sm70_marlin_auto_params("Dense", params);
     return params;
   }
@@ -1478,27 +1432,25 @@ inline Sm70MarlinAutoParams sm70_marlin_dense_auto_params(
   return sm70_marlin_default_auto_params(ctx.packed_macro_n);
 }
 
-inline void validate_sm70_marlin_dense_cta_geometry_supported(char const* op_name,
-                                                              Sm70CtaGeometry geometry) {
+inline void validate_sm70_marlin_dense_cta_geometry_supported(
+    char const* op_name, Sm70CtaGeometry geometry) {
   TORCH_CHECK(sm70_marlin_cta_geometry_is_supported(geometry),
               "Unsupported SM70 Marlin CTA geometry for ", op_name, ": ",
-              geometry.cta_m, "x", geometry.cta_n, "x", geometry.cta_k,
-              "x", geometry.warps, "x", geometry.warp_m, "x",
-              geometry.warp_n, "x", geometry.warp_k,
-              ". Supported geometries are ",
+              geometry.cta_m, "x", geometry.cta_n, "x", geometry.cta_k, "x",
+              geometry.warps, "x", geometry.warp_m, "x", geometry.warp_n, "x",
+              geometry.warp_k, ". Supported geometries are ",
               kSupportedSm70MarlinCtaGeometries, ".");
 }
 
 inline void validate_sm70_marlin_dense_cta_n_alignment(char const* op_name,
                                                        Sm70CtaGeometry geometry,
                                                        int64_t size_n) {
-  TORCH_CHECK(
-      size_n % geometry.cta_n == 0 && size_n % kQuantTileN == 0,
-      "SM70 Marlin requires size_n divisible by both CTA_N and 64 for ",
-      op_name, " with CTA geometry ", geometry.cta_m, "x", geometry.cta_n,
-      "x", geometry.cta_k, "x", geometry.warps, "x", geometry.warp_m,
-      "x", geometry.warp_n, "x", geometry.warp_k, ". Got size_n = ",
-      size_n, ".");
+  TORCH_CHECK(size_n % geometry.cta_n == 0 && size_n % kQuantTileN == 0,
+              "SM70 Marlin requires size_n divisible by both CTA_N and 64 for ",
+              op_name, " with CTA geometry ", geometry.cta_m, "x",
+              geometry.cta_n, "x", geometry.cta_k, "x", geometry.warps, "x",
+              geometry.warp_m, "x", geometry.warp_n, "x", geometry.warp_k,
+              ". Got size_n = ", size_n, ".");
 }
 
 }  // namespace marlin::sm70

--- a/csrc/quantization/marlin/sm70_marlin_dispatch.cu
+++ b/csrc/quantization/marlin/sm70_marlin_dispatch.cu
@@ -43,15 +43,13 @@ __device__ __forceinline__ int sm70_inverse_zp_interleave(int idx,
   return inv[idx];
 }
 
-__device__ __forceinline__ int sm70_inverse_scale_perm(int idx,
-                                                       int perm_len) {
+__device__ __forceinline__ int sm70_inverse_scale_perm(int idx, int perm_len) {
   if (perm_len == 64) {
     return (idx % 8) * 8 + idx / 8;
   }
-  constexpr int inv[32] = {0,  1,  8,  9,  16, 17, 24, 25,
-                           2,  3,  10, 11, 18, 19, 26, 27,
-                           4,  5,  12, 13, 20, 21, 28, 29,
-                           6,  7,  14, 15, 22, 23, 30, 31};
+  constexpr int inv[32] = {0,  1,  8,  9,  16, 17, 24, 25, 2,  3,  10,
+                           11, 18, 19, 26, 27, 4,  5,  12, 13, 20, 21,
+                           28, 29, 6,  7,  14, 15, 22, 23, 30, 31};
   return inv[idx];
 }
 
@@ -66,10 +64,9 @@ __global__ void sm70_unpermute_half_metadata_kernel(
 }
 
 __global__ void sm70_unpack_dense_zp_to_half_kernel(
-    const int32_t* __restrict__ packed_zp,
-    const half* __restrict__ scales, half* __restrict__ out,
-    int64_t total, int64_t size_n, int64_t packed_n, int num_bits,
-    bool is_a_8bit) {
+    const int32_t* __restrict__ packed_zp, const half* __restrict__ scales,
+    half* __restrict__ out, int64_t total, int64_t size_n, int64_t packed_n,
+    int num_bits, bool is_a_8bit) {
   const int64_t idx = blockIdx.x * blockDim.x + threadIdx.x;
   if (idx >= total) return;
 
@@ -81,21 +78,18 @@ __global__ void sm70_unpack_dense_zp_to_half_kernel(
   if (!is_a_8bit) {
     packed_col_in_block =
         (packed_col_in_block / pack_factor) * pack_factor +
-        sm70_inverse_zp_interleave(packed_col_in_block % pack_factor,
-                                   num_bits);
+        sm70_inverse_zp_interleave(packed_col_in_block % pack_factor, num_bits);
   }
   const int64_t packed_col = block64 * 64 + packed_col_in_block;
-  const uint32_t word = reinterpret_cast<const uint32_t*>(packed_zp)
-      [(idx / size_n) * packed_n + packed_col / pack_factor];
-  const uint32_t zp =
-      (word >> ((packed_col % pack_factor) * num_bits)) &
-      ((1u << num_bits) - 1u);
+  const uint32_t word = reinterpret_cast<const uint32_t*>(
+      packed_zp)[(idx / size_n) * packed_n + packed_col / pack_factor];
+  const uint32_t zp = (word >> ((packed_col % pack_factor) * num_bits)) &
+                      ((1u << num_bits) - 1u);
   out[idx] = __float2half(static_cast<float>(zp) * __half2float(scales[idx]));
 }
 
 torch::Tensor sm70_dense_scales_as_logical(torch::Tensor const& b_scales,
-                                           int64_t size_k,
-                                           int64_t group_size,
+                                           int64_t size_k, int64_t group_size,
                                            bool is_a_8bit) {
   TORCH_CHECK(b_scales.scalar_type() == at::ScalarType::Half,
               "SM70 Marlin adapter expects fp16 scales.");
@@ -103,15 +97,14 @@ torch::Tensor sm70_dense_scales_as_logical(torch::Tensor const& b_scales,
       group_size < size_k && group_size != -1 && !is_a_8bit;
   const int perm_len = uses_group_perm ? 64 : 32;
   TORCH_CHECK(b_scales.numel() % perm_len == 0,
-              "SM70 Marlin scale metadata size is not divisible by ",
-              perm_len);
+              "SM70 Marlin scale metadata size is not divisible by ", perm_len);
 
   auto out = torch::empty_like(b_scales);
   const int64_t total = out.numel();
   constexpr int threads = 256;
   const int blocks = static_cast<int>((total + threads - 1) / threads);
-  sm70_unpermute_half_metadata_kernel<<<
-      blocks, threads, 0, at::cuda::getCurrentCUDAStream()>>>(
+  sm70_unpermute_half_metadata_kernel<<<blocks, threads, 0,
+                                        at::cuda::getCurrentCUDAStream()>>>(
       reinterpret_cast<const half*>(b_scales.data_ptr<at::Half>()),
       reinterpret_cast<half*>(out.data_ptr<at::Half>()), total, perm_len);
   C10_CUDA_KERNEL_LAUNCH_CHECK();
@@ -143,8 +136,8 @@ torch::Tensor sm70_dense_zp_as_half(torch::Tensor const& b_zeros,
   const int64_t total = out.numel();
   constexpr int threads = 256;
   const int blocks = static_cast<int>((total + threads - 1) / threads);
-  sm70_unpack_dense_zp_to_half_kernel<<<
-      blocks, threads, 0, at::cuda::getCurrentCUDAStream()>>>(
+  sm70_unpack_dense_zp_to_half_kernel<<<blocks, threads, 0,
+                                        at::cuda::getCurrentCUDAStream()>>>(
       b_zeros.data_ptr<int32_t>(),
       reinterpret_cast<const half*>(b_scales.data_ptr<at::Half>()),
       reinterpret_cast<half*>(out.data_ptr<at::Half>()), total, size_n,
@@ -202,8 +195,7 @@ torch::Tensor marlin_gemm(
     std::optional<torch::Tensor> const& global_scale_or_none,
     std::optional<torch::Tensor> const& b_zeros_or_none,
     std::optional<torch::Tensor> const& g_idx_or_none,
-    std::optional<torch::Tensor> const& perm_or_none,
-    torch::Tensor& workspace,
+    std::optional<torch::Tensor> const& perm_or_none, torch::Tensor& workspace,
     vllm::ScalarTypeId const& b_type_id, int64_t size_m, int64_t size_n,
     int64_t size_k, bool is_k_full, bool use_atomic_add, bool use_fp32_reduce,
     bool is_zp_float) {
@@ -273,8 +265,7 @@ torch::Tensor marlin_gemm(
               "SM70 build only supports float16 outputs.");
   TORCH_CHECK(s_type == vllm::kFloat16 ||
                   (b_type == vllm::kFE2M1f &&
-                   (s_type == vllm::kFE4M3fn ||
-                    s_type == vllm::kFE8M0fnu)),
+                   (s_type == vllm::kFE4M3fn || s_type == vllm::kFE8M0fnu)),
               "SM70 build only supports float16 scales, except FP4 uses "
               "float8_e4m3fn scales for NVFP4 or float8_e8m0fnu scales for "
               "MXFP4.");
@@ -325,10 +316,8 @@ torch::Tensor marlin_gemm(
   TORCH_CHECK(b_scales.is_contiguous(), "b_scales is not contiguous");
   TORCH_CHECK(b_scales.scalar_type() == at::ScalarType::Half ||
                   (b_type == vllm::kFE2M1f &&
-                   (b_scales.scalar_type() ==
-                        at::ScalarType::Float8_e4m3fn ||
-                    b_scales.scalar_type() ==
-                        at::ScalarType::Float8_e8m0fnu)),
+                   (b_scales.scalar_type() == at::ScalarType::Float8_e4m3fn ||
+                    b_scales.scalar_type() == at::ScalarType::Float8_e8m0fnu)),
               "SM70 build only supports float16 scales, except FP4 uses "
               "float8_e4m3fn scales for NVFP4 or float8_e8m0fnu scales for "
               "MXFP4.");
@@ -421,21 +410,18 @@ torch::Tensor marlin_gemm(
 
   torch::Tensor b_scales_kernel = b_scales;
   if (b_scales.scalar_type() == at::ScalarType::Half) {
-    b_scales_kernel =
-        sm70_dense_scales_as_logical(b_scales, size_k, group_size,
-                                     a_type.size_bits() == 8);
+    b_scales_kernel = sm70_dense_scales_as_logical(b_scales, size_k, group_size,
+                                                   a_type.size_bits() == 8);
   }
 
   torch::Tensor global_scale;
   if (global_scale_or_none.has_value()) {
     global_scale = global_scale_or_none.value();
-    TORCH_CHECK(
-        b_type == vllm::kFE2M1f && s_type == vllm::kFE4M3fn,
-        "SM70 Marlin supports global_scale only for "
-        "nvfp4 format.");
+    TORCH_CHECK(b_type == vllm::kFE2M1f && s_type == vllm::kFE4M3fn,
+                "SM70 Marlin supports global_scale only for "
+                "nvfp4 format.");
     TORCH_CHECK(global_scale.device().is_cuda(), "global_scale is not on GPU");
-    TORCH_CHECK(global_scale.is_contiguous(),
-                "global_scale is not contiguous");
+    TORCH_CHECK(global_scale.is_contiguous(), "global_scale is not contiguous");
     TORCH_CHECK(global_scale.scalar_type() == at::ScalarType::Float,
                 "SM70 Marlin NVFP4 expects fp32 global_scale.");
     TORCH_CHECK(global_scale.numel() == 1,
@@ -463,8 +449,7 @@ torch::Tensor marlin_gemm(
   if (b_zeros_or_none.has_value()) {
     b_zeros = b_zeros_or_none.value();
     TORCH_CHECK(b_zeros.device().is_cuda(), "b_zeros is not on GPU");
-    TORCH_CHECK(b_zeros.is_contiguous(),
-                "b_zeros is not contiguous");
+    TORCH_CHECK(b_zeros.is_contiguous(), "b_zeros is not contiguous");
   } else {
     b_zeros = torch::empty({0}, options);
   }
@@ -477,9 +462,9 @@ torch::Tensor marlin_gemm(
 
   if (has_zp) {
     if (!is_zp_float && b_zeros.scalar_type() == at::ScalarType::Int) {
-      b_zeros = sm70_dense_zp_as_half(
-          b_zeros, b_scales_kernel, size_n, b_type == vllm::kU4 ? 4 : 8,
-          a_type.size_bits() == 8);
+      b_zeros = sm70_dense_zp_as_half(b_zeros, b_scales_kernel, size_n,
+                                      b_type == vllm::kU4 ? 4 : 8,
+                                      a_type.size_bits() == 8);
       zp_is_float = true;
     }
   }
@@ -493,8 +478,7 @@ torch::Tensor marlin_gemm(
     TORCH_CHECK(b_zeros.scalar_type() == at::ScalarType::Half,
                 "SM70 Marlin uint4/uint8 dense path expects fp16 "
                 "zero points.");
-    TORCH_CHECK(b_zeros.size(1) == size_n,
-                "b_zeros dim 1 = ", b_zeros.size(1),
+    TORCH_CHECK(b_zeros.size(1) == size_n, "b_zeros dim 1 = ", b_zeros.size(1),
                 " is not size_n = ", size_n);
     TORCH_CHECK(num_groups == b_zeros.size(0),
                 "b_zeros dim 0 = ", b_zeros.size(0),
@@ -523,30 +507,26 @@ torch::Tensor marlin_gemm(
               "SM70 Marlin expects int32 packed weights.");
   TORCH_CHECK(!has_act_order,
               "act_order is not supported for the SM70 Marlin path.");
-  TORCH_CHECK(!has_bias,
-              "SM70 Marlin does not support bias. TODO: add epilogue bias fusion.");
+  TORCH_CHECK(
+      !has_bias,
+      "SM70 Marlin does not support bias. TODO: add epilogue bias fusion.");
   TORCH_CHECK((b_type == vllm::kFE2M1f && s_type == vllm::kFE4M3fn) ||
                   global_scale.numel() == 0,
               "SM70 Marlin supports global_scale only for "
               "nvfp4 format.");
   TORCH_CHECK(!use_atomic_add,
               "SM70 Marlin does not support atomic-add output.");
-  TORCH_CHECK(is_k_full,
-              "SM70 Marlin requires full-K non act-order inputs.");
-  TORCH_CHECK(size_k % 32 == 0,
-              "SM70 Marlin requires size_k % 32 == 0.");
-  TORCH_CHECK(size_n % 64 == 0,
-              "SM70 Marlin requires size_n % 64 == 0.");
+  TORCH_CHECK(is_k_full, "SM70 Marlin requires full-K non act-order inputs.");
+  TORCH_CHECK(size_k % 32 == 0, "SM70 Marlin requires size_k % 32 == 0.");
+  TORCH_CHECK(size_n % 64 == 0, "SM70 Marlin requires size_n % 64 == 0.");
   TORCH_CHECK(group_size == -1 || group_size > 0,
-              "SM70 Marlin received invalid group_size = ",
-              group_size);
+              "SM70 Marlin received invalid group_size = ", group_size);
 
   if (b_type == vllm::kU4) {
     TORCH_CHECK(size_k % 32 == 0,
                 "SM70 Marlin uint4 dense path requires size_k % 32 == 0.");
-    TORCH_CHECK(
-        has_zp && zp_is_float,
-        "SM70 Marlin uint4 dense path requires fp16 zero points.");
+    TORCH_CHECK(has_zp && zp_is_float,
+                "SM70 Marlin uint4 dense path requires fp16 zero points.");
     return sm70_marlin_u4_gemm(a, c, b_q_weight, b_scales_kernel, b_zeros,
                                size_m, size_n, size_k, group_size);
   }
@@ -554,17 +534,15 @@ torch::Tensor marlin_gemm(
   if (b_type == vllm::kU8) {
     TORCH_CHECK(size_k % 32 == 0,
                 "SM70 Marlin uint8 dense path requires size_k % 32 == 0.");
-    TORCH_CHECK(
-        has_zp && zp_is_float,
-        "SM70 Marlin uint8 dense path requires fp16 zero points.");
+    TORCH_CHECK(has_zp && zp_is_float,
+                "SM70 Marlin uint8 dense path requires fp16 zero points.");
     return sm70_marlin_u8_gemm(a, c, b_q_weight, b_scales_kernel, b_zeros,
                                size_m, size_n, size_k, group_size);
   }
 
   if (b_type == vllm::kU8B128) {
-    TORCH_CHECK(
-        size_k % 32 == 0,
-        "SM70 Marlin uint8b128 dense path requires size_k % 32 == 0.");
+    TORCH_CHECK(size_k % 32 == 0,
+                "SM70 Marlin uint8b128 dense path requires size_k % 32 == 0.");
     TORCH_CHECK(!has_zp && !is_zp_float,
                 "SM70 Marlin uint8b128 does not support "
                 "zero-point metadata.");
@@ -573,9 +551,8 @@ torch::Tensor marlin_gemm(
   }
 
   if (b_type == vllm::kFE4M3fn) {
-    TORCH_CHECK(
-        size_k % 32 == 0,
-        "SM70 Marlin FP8 dense path requires size_k % 32 == 0.");
+    TORCH_CHECK(size_k % 32 == 0,
+                "SM70 Marlin FP8 dense path requires size_k % 32 == 0.");
     TORCH_CHECK(group_size == -1 || group_size == 128,
                 "SM70 Marlin FP8 supports only group_size -1 or "
                 "128. Got ",
@@ -588,15 +565,15 @@ torch::Tensor marlin_gemm(
   }
 
   if (b_type == vllm::kFE2M1f) {
-    TORCH_CHECK(
-        size_k % 32 == 0,
-        "SM70 Marlin FP4 dense path requires size_k % 32 == 0.");
+    TORCH_CHECK(size_k % 32 == 0,
+                "SM70 Marlin FP4 dense path requires size_k % 32 == 0.");
     TORCH_CHECK(!has_zp && !is_zp_float,
                 "SM70 Marlin FP4 does not support zero-point "
                 "metadata.");
     if (s_type == vllm::kFE4M3fn) {
-      TORCH_CHECK(global_scale.numel() == 1,
-                  "the global_scale parameter must be passed for nvfp4 format.");
+      TORCH_CHECK(
+          global_scale.numel() == 1,
+          "the global_scale parameter must be passed for nvfp4 format.");
       TORCH_CHECK(group_size == 16,
                   "SM70 Marlin NVFP4 supports only group_size 16. "
                   "Got ",

--- a/csrc/quantization/marlin/sm70_marlin_fp8_gemm.cu
+++ b/csrc/quantization/marlin/sm70_marlin_fp8_gemm.cu
@@ -20,24 +20,24 @@
 #include "cutlass/layout/tensor_op_multiplicand_sm70.h"
 #include "cutlass/transform/threadblock/predicated_tile_iterator.h"
 
-using marlin::sm70::Sm70CtaGeometry;
-using marlin::sm70::Sm70AtomicFp16Epilogue;
-using marlin::sm70::Sm70MarlinGemmTraits;
-using marlin::sm70::Sm70SplitKPartition;
-using marlin::sm70::validate_sm70_marlin_dense_cta_geometry_supported;
-using marlin::sm70::validate_sm70_marlin_dense_cta_n_alignment;
 using marlin::sm70::configure_sm70_dynamic_smem;
 using marlin::sm70::dispatch_sm70_marlin_fp8_geometry;
 using marlin::sm70::kQuantTileK;
 using marlin::sm70::kQuantTileN;
-using marlin::sm70::sm70_marlin_dense_auto_params;
 using marlin::sm70::load_qword_vector;
 using marlin::sm70::qword_from_vector;
-using marlin::sm70::sm70_marlin_cta_grid;
 using marlin::sm70::sm70_active_split_k;
+using marlin::sm70::sm70_marlin_cta_grid;
+using marlin::sm70::sm70_marlin_dense_auto_params;
 using marlin::sm70::sm70_splitk_partition;
+using marlin::sm70::Sm70AtomicFp16Epilogue;
+using marlin::sm70::Sm70CtaGeometry;
+using marlin::sm70::Sm70MarlinGemmTraits;
+using marlin::sm70::Sm70SplitKPartition;
 using marlin::sm70::u8_packed_macro_n_qweight_offset_from_logical;
 using marlin::sm70::u8_packed_macro_n_qweight_word_stride;
+using marlin::sm70::validate_sm70_marlin_dense_cta_geometry_supported;
+using marlin::sm70::validate_sm70_marlin_dense_cta_n_alignment;
 
 namespace {
 
@@ -53,12 +53,11 @@ class Sm70Fp8IteratorB {
   static int const kPackedMacroN = PackedMacroN_;
   static constexpr bool kUseMetadataVectorWords = UseMetadataVectorWords_;
   using Element = cutlass::half_t;
-  using Fragment = cutlass::Array<
-      Element, ThreadMap::Iterations::kCount * ThreadMap::kElementsPerAccess>;
+  using Fragment = cutlass::Array<Element, ThreadMap::Iterations::kCount *
+                                               ThreadMap::kElementsPerAccess>;
   static_assert(Shape::kN == 64 || Shape::kN == 128 || Shape::kN == 256,
                 "SM70 Marlin FP8 IteratorB expects CTA_N in {64, 128, 256}.");
-  static_assert(ThreadMap::Iterations::kContiguous ==
-                    Shape::kN / kQuantTileN,
+  static_assert(ThreadMap::Iterations::kContiguous == Shape::kN / kQuantTileN,
                 "SM70 Marlin FP8 IteratorB expects one contiguous iteration "
                 "per 64-column quant tile.");
   static_assert(ThreadMap::Delta::kContiguous == kQuantTileN,
@@ -159,13 +158,12 @@ class Sm70Fp8IteratorB {
   CUTLASS_DEVICE
   static int qweight_offset_from_logical(Params const& params, int logical_k,
                                          int logical_n) {
-    return u8_packed_macro_n_qweight_offset_from_logical<kPackedMacroN>(params.size_n, logical_k,
-                                                     logical_n);
+    return u8_packed_macro_n_qweight_offset_from_logical<kPackedMacroN>(
+        params.size_n, logical_k, logical_n);
   }
 
   CUTLASS_DEVICE
-  static int qweight_word_stride_from_logical(Params const&,
-                                              int logical_n) {
+  static int qweight_word_stride_from_logical(Params const&, int logical_n) {
     return u8_packed_macro_n_qweight_word_stride<kPackedMacroN>();
   }
 
@@ -196,9 +194,8 @@ class Sm70Fp8IteratorB {
   void cache_current_group_metadata(int group) const {
     CUTLASS_PRAGMA_UNROLL
     for (int c = 0; c < ThreadMap::Iterations::kContiguous; ++c) {
-      int const cache_n =
-          n_offset_ + thread_offset_.contiguous() +
-          c * ThreadMap::Delta::kContiguous;
+      int const cache_n = n_offset_ + thread_offset_.contiguous() +
+                          c * ThreadMap::Delta::kContiguous;
       if constexpr (kUseMetadataVectorWords) {
         cache_metadata_vector_words(c, group, cache_n);
       } else {
@@ -259,8 +256,9 @@ class Sm70Fp8IteratorB {
           frag_vec[3] = __hmul2(deq[1], scale_vec[3]);
         }
       } else {
-        static_assert(ThreadMap::Iterations::kContiguous == 1,
-                      "Unsupported SM70 Marlin FP8 contiguous iteration count.");
+        static_assert(
+            ThreadMap::Iterations::kContiguous == 1,
+            "Unsupported SM70 Marlin FP8 contiguous iteration count.");
         uint32_t const qword0 =
             load_qword_vector<1>(qweight_ + qweight_base_offset_);
         uint32_t const qword1 = load_qword_vector<1>(
@@ -282,19 +280,17 @@ class Sm70Fp8IteratorB {
       int const logical_n_base = n_offset_ + thread_offset_.contiguous();
       CUTLASS_PRAGMA_UNROLL
       for (int s = 0; s < ThreadMap::Iterations::kStrided; ++s) {
-        int const logical_k_s =
-            k_offset_ + thread_offset_.strided() +
-            s * ThreadMap::Delta::kStrided;
+        int const logical_k_s = k_offset_ + thread_offset_.strided() +
+                                s * ThreadMap::Delta::kStrided;
         if constexpr (kGroupSize != -1) {
           cache_current_group_metadata(scale_group(logical_k_s));
         }
         int const qweight_base_s =
             qweight_offset_from_logical(params_, logical_k_s, logical_n_base);
         if constexpr (ThreadMap::Iterations::kContiguous == 4) {
-          uint4 const qwords0 =
-              load_qword_vector<4>(qweight_ + qweight_base_s);
-          uint4 const qwords1 = load_qword_vector<4>(
-              qweight_ + qweight_base_s + kQweightWordStrideWords);
+          uint4 const qwords0 = load_qword_vector<4>(qweight_ + qweight_base_s);
+          uint4 const qwords1 = load_qword_vector<4>(qweight_ + qweight_base_s +
+                                                     kQweightWordStrideWords);
           CUTLASS_PRAGMA_UNROLL
           for (int c = 0; c < ThreadMap::Iterations::kContiguous; ++c) {
             constexpr int kAccess = ThreadMap::kElementsPerAccess;
@@ -316,10 +312,9 @@ class Sm70Fp8IteratorB {
             frag_vec[3] = __hmul2(deq[1], scale_vec[3]);
           }
         } else if constexpr (ThreadMap::Iterations::kContiguous == 2) {
-          uint2 const qwords0 =
-              load_qword_vector<2>(qweight_ + qweight_base_s);
-          uint2 const qwords1 = load_qword_vector<2>(
-              qweight_ + qweight_base_s + kQweightWordStrideWords);
+          uint2 const qwords0 = load_qword_vector<2>(qweight_ + qweight_base_s);
+          uint2 const qwords1 = load_qword_vector<2>(qweight_ + qweight_base_s +
+                                                     kQweightWordStrideWords);
           CUTLASS_PRAGMA_UNROLL
           for (int c = 0; c < ThreadMap::Iterations::kContiguous; ++c) {
             constexpr int kAccess = ThreadMap::kElementsPerAccess;
@@ -341,8 +336,9 @@ class Sm70Fp8IteratorB {
             frag_vec[3] = __hmul2(deq[1], scale_vec[3]);
           }
         } else {
-          static_assert(ThreadMap::Iterations::kContiguous == 1,
-                        "Unsupported SM70 Marlin FP8 contiguous iteration count.");
+          static_assert(
+              ThreadMap::Iterations::kContiguous == 1,
+              "Unsupported SM70 Marlin FP8 contiguous iteration count.");
           uint32_t const qword0 =
               load_qword_vector<1>(qweight_ + qweight_base_s);
           uint32_t const qword1 = load_qword_vector<1>(
@@ -372,8 +368,7 @@ class Sm70Fp8IteratorB {
       return;
     }
 
-    if constexpr (kGroupSize != -1 &&
-                  ThreadMap::Iterations::kStrided == 1) {
+    if constexpr (kGroupSize != -1 && ThreadMap::Iterations::kStrided == 1) {
       int const first_logical_k = k_offset_ + thread_offset_.strided();
       cache_current_group_metadata(scale_group(first_logical_k));
     }
@@ -385,32 +380,29 @@ class Sm70Fp8IteratorB {
 template <bool UseMetadataVectorWords = true>
 struct Sm70Fp8GemmSpec {
   template <typename Shape, typename ThreadMap, int GroupSize, int PackedMacroN>
-  using IteratorB =
-      Sm70Fp8IteratorB<Shape, ThreadMap, GroupSize, PackedMacroN,
-                       UseMetadataVectorWords>;
+  using IteratorB = Sm70Fp8IteratorB<Shape, ThreadMap, GroupSize, PackedMacroN,
+                                     UseMetadataVectorWords>;
 };
 
-template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM,
-          int WarpN, int WarpK, int GroupSize, int PackedMacroN,
+template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM, int WarpN,
+          int WarpK, int GroupSize, int PackedMacroN,
           bool UseMetadataVectorWords = true>
 using Sm70Fp8GemmTraits =
-    Sm70MarlinGemmTraits<Sm70Fp8GemmSpec<UseMetadataVectorWords>, CtaM,
-                         CtaN, CtaK, Warps, WarpM, WarpN, WarpK,
-                         GroupSize, PackedMacroN>;
+    Sm70MarlinGemmTraits<Sm70Fp8GemmSpec<UseMetadataVectorWords>, CtaM, CtaN,
+                         CtaK, Warps, WarpM, WarpN, WarpK, GroupSize,
+                         PackedMacroN>;
 
-template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM,
-          int WarpN, int WarpK, int GroupSize, int PackedMacroN,
+template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM, int WarpN,
+          int WarpK, int GroupSize, int PackedMacroN,
           bool UseMetadataVectorWords = true>
-__global__ __launch_bounds__(Warps * 32, 1)
-void sm70_marlin_fp8_gemm_kernel(
+__global__ __launch_bounds__(Warps * 32, 1) void sm70_marlin_fp8_gemm_kernel(
     cutlass::half_t const* __restrict__ a,
     uint32_t const* __restrict__ b_q_weight,
     cutlass::half_t const* __restrict__ b_scales,
     cutlass::half_t* __restrict__ c, int m, int n, int k, int lda) {
   using Traits =
-      Sm70Fp8GemmTraits<CtaM, CtaN, CtaK, Warps, WarpM, WarpN, WarpK,
-                        GroupSize, PackedMacroN,
-                        UseMetadataVectorWords>;
+      Sm70Fp8GemmTraits<CtaM, CtaN, CtaK, Warps, WarpM, WarpN, WarpK, GroupSize,
+                        PackedMacroN, UseMetadataVectorWords>;
   using Mma = typename Traits::Mma;
   using Epilogue = typename Traits::Epilogue;
 
@@ -430,10 +422,10 @@ void sm70_marlin_fp8_gemm_kernel(
   typename Traits::LayoutA layout_a(lda);
   typename Traits::LayoutC layout_c(n);
 
-  typename Mma::IteratorA iterator_A(
-      typename Mma::IteratorA::Params(layout_a),
-      const_cast<cutlass::half_t*>(a), cutlass::MatrixCoord(m, k), thread_idx,
-      tb_offset_A);
+  typename Mma::IteratorA iterator_A(typename Mma::IteratorA::Params(layout_a),
+                                     const_cast<cutlass::half_t*>(a),
+                                     cutlass::MatrixCoord(m, k), thread_idx,
+                                     tb_offset_A);
   typename Mma::IteratorB iterator_B(
       typename Mma::IteratorB::Params(k, n),
       reinterpret_cast<uint32_t const*>(b_q_weight),
@@ -458,18 +450,19 @@ void sm70_marlin_fp8_gemm_kernel(
   epilogue(output_op, iterator_D, accumulators, iterator_C);
 }
 
-template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM,
-          int WarpN, int WarpK, int GroupSize, int PackedMacroN,
+template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM, int WarpN,
+          int WarpK, int GroupSize, int PackedMacroN,
           bool UseMetadataVectorWords = true>
-__global__ __launch_bounds__(Warps * 32, 1)
-void sm70_marlin_fp8_gemm_splitk_kernel(
+__global__
+__launch_bounds__(Warps * 32, 1) void sm70_marlin_fp8_gemm_splitk_kernel(
     cutlass::half_t const* __restrict__ a,
     uint32_t const* __restrict__ b_q_weight,
     cutlass::half_t const* __restrict__ b_scales,
-    cutlass::half_t* __restrict__ c, int m, int n, int k, int lda, int requested_split_k) {
-  using Traits = Sm70Fp8GemmTraits<CtaM, CtaN, CtaK, Warps, WarpM, WarpN,
-                                   WarpK, GroupSize, PackedMacroN,
-                                   UseMetadataVectorWords>;
+    cutlass::half_t* __restrict__ c, int m, int n, int k, int lda,
+    int requested_split_k) {
+  using Traits =
+      Sm70Fp8GemmTraits<CtaM, CtaN, CtaK, Warps, WarpM, WarpN, WarpK, GroupSize,
+                        PackedMacroN, UseMetadataVectorWords>;
   using Mma = typename Traits::Mma;
   using AtomicEpilogue = Sm70AtomicFp16Epilogue<Traits>;
 
@@ -480,14 +473,13 @@ void sm70_marlin_fp8_gemm_splitk_kernel(
   int const thread_idx = threadIdx.x;
   int const warp_idx = cutlass::canonical_warp_idx_sync();
   int const lane_idx = threadIdx.x % 32;
-  Sm70SplitKPartition const partition =
-      sm70_splitk_partition<GroupSize, CtaK>(k, requested_split_k, int(blockIdx.z));
+  Sm70SplitKPartition const partition = sm70_splitk_partition<GroupSize, CtaK>(
+      k, requested_split_k, int(blockIdx.z));
   if (partition.partition_k == 0) {
     return;
   }
 
-  cutlass::MatrixCoord tb_offset_A{int(blockIdx.x) * CtaM,
-                                   partition.k_begin};
+  cutlass::MatrixCoord tb_offset_A{int(blockIdx.x) * CtaM, partition.k_begin};
   cutlass::MatrixCoord tb_offset_B{partition.k_begin, int(blockIdx.y) * CtaN};
   cutlass::MatrixCoord tb_offset_C{int(blockIdx.x) * CtaM,
                                    int(blockIdx.y) * CtaN};
@@ -495,10 +487,10 @@ void sm70_marlin_fp8_gemm_splitk_kernel(
   typename Traits::LayoutA layout_a(lda);
   typename Traits::LayoutC layout_c(n);
 
-  typename Mma::IteratorA iterator_A(
-      typename Mma::IteratorA::Params(layout_a),
-      const_cast<cutlass::half_t*>(a), cutlass::MatrixCoord(m, k), thread_idx,
-      tb_offset_A);
+  typename Mma::IteratorA iterator_A(typename Mma::IteratorA::Params(layout_a),
+                                     const_cast<cutlass::half_t*>(a),
+                                     cutlass::MatrixCoord(m, k), thread_idx,
+                                     tb_offset_A);
   typename Mma::IteratorB iterator_B(
       typename Mma::IteratorB::Params(k, n),
       reinterpret_cast<uint32_t const*>(b_q_weight),
@@ -512,9 +504,8 @@ void sm70_marlin_fp8_gemm_splitk_kernel(
   mma(gemm_k_iterations, accumulators, iterator_A, iterator_B, accumulators);
 
   typename AtomicEpilogue::OutputTileIterator iterator_D(
-      typename AtomicEpilogue::OutputTileIterator::Params(layout_c),
-      c, cutlass::MatrixCoord(m, n),
-      thread_idx, tb_offset_C);
+      typename AtomicEpilogue::OutputTileIterator::Params(layout_c), c,
+      cutlass::MatrixCoord(m, n), thread_idx, tb_offset_C);
 
   AtomicEpilogue epilogue(shared_storage.epilogue, thread_idx, warp_idx,
                           lane_idx);
@@ -523,20 +514,23 @@ void sm70_marlin_fp8_gemm_splitk_kernel(
 
 }  // namespace
 
-template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM,
-          int WarpN, int WarpK, int GroupSize, int PackedMacroN,
+template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM, int WarpN,
+          int WarpK, int GroupSize, int PackedMacroN,
           bool UseMetadataVectorWords = true>
-torch::Tensor launch_sm70_marlin_fp8_gemm(
-    torch::Tensor& a, torch::Tensor& c, torch::Tensor& b_q_weight,
-    torch::Tensor& b_scales, int64_t size_m, int64_t size_n, int64_t size_k,
-    int requested_split_k) {
+torch::Tensor launch_sm70_marlin_fp8_gemm(torch::Tensor& a, torch::Tensor& c,
+                                          torch::Tensor& b_q_weight,
+                                          torch::Tensor& b_scales,
+                                          int64_t size_m, int64_t size_n,
+                                          int64_t size_k,
+                                          int requested_split_k) {
   auto kernel =
-      sm70_marlin_fp8_gemm_kernel<CtaM, CtaN, CtaK, Warps, WarpM, WarpN,
-                                  WarpK, GroupSize, PackedMacroN,
+      sm70_marlin_fp8_gemm_kernel<CtaM, CtaN, CtaK, Warps, WarpM, WarpN, WarpK,
+                                  GroupSize, PackedMacroN,
                                   UseMetadataVectorWords>;
-  using SharedStorage = typename Sm70Fp8GemmTraits<
-      CtaM, CtaN, CtaK, Warps, WarpM, WarpN, WarpK, GroupSize,
-      PackedMacroN, UseMetadataVectorWords>::SharedStorage;
+  using SharedStorage =
+      typename Sm70Fp8GemmTraits<CtaM, CtaN, CtaK, Warps, WarpM, WarpN, WarpK,
+                                 GroupSize, PackedMacroN,
+                                 UseMetadataVectorWords>::SharedStorage;
   size_t smem_bytes = configure_sm70_dynamic_smem<SharedStorage>(kernel);
 
   dim3 block(Warps * 32);
@@ -556,21 +550,20 @@ torch::Tensor launch_sm70_marlin_fp8_gemm(
   }
 
   TORCH_CHECK(size_k % int64_t(CtaK) == 0,
-              "SM70 Marlin fp8_e4m3 requires K divisible by CTA_K=",
-              CtaK, " for requested_split_k > 1. Got K=", size_k,
+              "SM70 Marlin fp8_e4m3 requires K divisible by CTA_K=", CtaK,
+              " for requested_split_k > 1. Got K=", size_k,
               ", requested_split_k=", requested_split_k, ".");
 
   auto split_kernel =
-      sm70_marlin_fp8_gemm_splitk_kernel<CtaM, CtaN, CtaK, Warps, WarpM,
-                                         WarpN, WarpK, GroupSize,
-                                         PackedMacroN,
+      sm70_marlin_fp8_gemm_splitk_kernel<CtaM, CtaN, CtaK, Warps, WarpM, WarpN,
+                                         WarpK, GroupSize, PackedMacroN,
                                          UseMetadataVectorWords>;
   smem_bytes = configure_sm70_dynamic_smem<SharedStorage>(split_kernel);
 
   int64_t const numel = size_m * size_n;
-  C10_CUDA_CHECK(cudaMemsetAsync(
-      c.data_ptr<at::Half>(), 0,
-      static_cast<size_t>(numel) * sizeof(at::Half), stream));
+  C10_CUDA_CHECK(cudaMemsetAsync(c.data_ptr<at::Half>(), 0,
+                                 static_cast<size_t>(numel) * sizeof(at::Half),
+                                 stream));
 
   dim3 grid = sm70_marlin_cta_grid(size_m, size_n, CtaM, CtaN);
   int const active_split_k =
@@ -582,7 +575,8 @@ torch::Tensor launch_sm70_marlin_fp8_gemm(
       reinterpret_cast<cutlass::half_t const*>(b_scales.data_ptr<at::Half>()),
       reinterpret_cast<cutlass::half_t*>(c.data_ptr<at::Half>()),
       static_cast<int>(size_m), static_cast<int>(size_n),
-      static_cast<int>(size_k), static_cast<int>(a.stride(0)), requested_split_k);
+      static_cast<int>(size_k), static_cast<int>(a.stride(0)),
+      requested_split_k);
   C10_CUDA_KERNEL_LAUNCH_CHECK();
 
   return c;
@@ -599,8 +593,8 @@ struct Sm70Fp8Launcher {
   int64_t size_k;
   int requested_split_k;
 
-  template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM,
-            int WarpN, int WarpK, int GroupSize, int PackedMacroN>
+  template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM, int WarpN,
+            int WarpK, int GroupSize, int PackedMacroN>
   torch::Tensor operator()() const {
     return launch_sm70_marlin_fp8_gemm<CtaM, CtaN, CtaK, Warps, WarpM, WarpN,
                                        WarpK, GroupSize, PackedMacroN,
@@ -616,21 +610,23 @@ torch::Tensor sm70_marlin_fp8_gemm(torch::Tensor& a, torch::Tensor& c,
                                    int64_t group_size) {
   c10::cuda::CUDAGuard device_guard(a.device());
 
-  auto const params = sm70_marlin_dense_auto_params(
-      "fp8_e4m3", group_size, size_m, size_n, size_k);
+  auto const params = sm70_marlin_dense_auto_params("fp8_e4m3", group_size,
+                                                    size_m, size_n, size_k);
   Sm70CtaGeometry const geometry = params.geometry;
-  validate_sm70_marlin_dense_cta_geometry_supported("SM70 Marlin fp8_e4m3", geometry);
-  validate_sm70_marlin_dense_cta_n_alignment("SM70 Marlin fp8_e4m3", geometry, size_n);
+  validate_sm70_marlin_dense_cta_geometry_supported("SM70 Marlin fp8_e4m3",
+                                                    geometry);
+  validate_sm70_marlin_dense_cta_n_alignment("SM70 Marlin fp8_e4m3", geometry,
+                                             size_n);
   if (params.use_metadata_vector_words) {
     Sm70Fp8Launcher<true> const launcher{
-        a, c, b_q_weight, b_scales, size_m, size_n, size_k,
-        params.requested_split_k};
-    return dispatch_sm70_marlin_fp8_geometry(
-        launcher, geometry, params.packed_macro_n, group_size);
+        a,      c,      b_q_weight, b_scales,
+        size_m, size_n, size_k,     params.requested_split_k};
+    return dispatch_sm70_marlin_fp8_geometry(launcher, geometry,
+                                             params.packed_macro_n, group_size);
   }
   Sm70Fp8Launcher<false> const launcher{
-      a, c, b_q_weight, b_scales, size_m, size_n, size_k,
-      params.requested_split_k};
-  return dispatch_sm70_marlin_fp8_geometry(
-      launcher, geometry, params.packed_macro_n, group_size);
+      a,      c,      b_q_weight, b_scales,
+      size_m, size_n, size_k,     params.requested_split_k};
+  return dispatch_sm70_marlin_fp8_geometry(launcher, geometry,
+                                           params.packed_macro_n, group_size);
 }

--- a/csrc/quantization/marlin/sm70_marlin_gemm.cuh
+++ b/csrc/quantization/marlin/sm70_marlin_gemm.cuh
@@ -30,8 +30,7 @@ struct Sm70MarlinGemmTraits {
                 "SM70 Marlin supports CTA_N in {64, 128, 256}.");
   static_assert(CtaK == 16 || CtaK == 32 || CtaK == 64 || CtaK == 128,
                 "SM70 Marlin supports CTA_K in {16, 32, 64, 128}.");
-  static_assert(Warps == 4 || Warps == 8,
-                "SM70 Marlin supports 4 or 8 warps.");
+  static_assert(Warps == 4 || Warps == 8, "SM70 Marlin supports 4 or 8 warps.");
   static_assert(PackedMacroN == 64 || PackedMacroN == 128 ||
                     PackedMacroN == 256,
                 "SM70 Marlin packed macro-N must be 64, 128, or 256.");
@@ -45,8 +44,8 @@ struct Sm70MarlinGemmTraits {
   using LayoutB = cutlass::layout::RowMajor;
   using LayoutC = cutlass::layout::RowMajor;
   using ThreadblockShape = cutlass::gemm::GemmShape<CtaM, CtaN, CtaK>;
-  using WarpShape =
-      typename Sm70WarpShape<CtaM, CtaN, CtaK, Warps, WarpM, WarpN, WarpK>::Type;
+  using WarpShape = typename Sm70WarpShape<CtaM, CtaN, CtaK, Warps, WarpM,
+                                           WarpN, WarpK>::Type;
   static_assert(WarpShape::kM <= 64 && WarpShape::kN <= 64,
                 "SM70 Marlin keeps per-warp M/N no larger than 64.");
   using InstructionShape = cutlass::gemm::GemmShape<8, 8, 4>;
@@ -60,9 +59,10 @@ struct Sm70MarlinGemmTraits {
       cutlass::MatrixShape<ThreadblockShape::kM, ThreadblockShape::kK>,
       ElementA, LayoutA, 1, typename MmaCore::IteratorThreadMapA,
       128 / cutlass::sizeof_bits<ElementA>::value>;
-  using IteratorB = typename Spec::template IteratorB<
-      ThreadblockShape, typename MmaCore::IteratorThreadMapB, GroupSize,
-      PackedMacroN>;
+  using IteratorB =
+      typename Spec::template IteratorB<ThreadblockShape,
+                                        typename MmaCore::IteratorThreadMapB,
+                                        GroupSize, PackedMacroN>;
   using Mma = Sm70MarlinMmaPipelined<
       ThreadblockShape, IteratorA, typename MmaCore::SmemIteratorA, IteratorB,
       typename MmaCore::SmemIteratorB, ElementAccumulator, LayoutC,
@@ -102,17 +102,17 @@ torch::Tensor dispatch_sm70_marlin_group_size(Launcher const& launcher,
                                               char const* quant_name) {
   switch (group_size) {
     case -1:
-      return launcher.template operator()<CtaM, CtaN, CtaK, Warps, WarpM,
-                                          WarpN, WarpK, -1, PackedMacroN>();
+      return launcher.template operator()<CtaM, CtaN, CtaK, Warps, WarpM, WarpN,
+                                          WarpK, -1, PackedMacroN>();
     case 32:
-      return launcher.template operator()<CtaM, CtaN, CtaK, Warps, WarpM,
-                                          WarpN, WarpK, 32, PackedMacroN>();
+      return launcher.template operator()<CtaM, CtaN, CtaK, Warps, WarpM, WarpN,
+                                          WarpK, 32, PackedMacroN>();
     case 64:
-      return launcher.template operator()<CtaM, CtaN, CtaK, Warps, WarpM,
-                                          WarpN, WarpK, 64, PackedMacroN>();
+      return launcher.template operator()<CtaM, CtaN, CtaK, Warps, WarpM, WarpN,
+                                          WarpK, 64, PackedMacroN>();
     case 128:
-      return launcher.template operator()<CtaM, CtaN, CtaK, Warps, WarpM,
-                                          WarpN, WarpK, 128, PackedMacroN>();
+      return launcher.template operator()<CtaM, CtaN, CtaK, Warps, WarpM, WarpN,
+                                          WarpK, 128, PackedMacroN>();
     default:
       TORCH_CHECK(false, "SM70 Marlin ", quant_name,
                   " supports only group_size -1, 32, 64, or 128. Got ",
@@ -127,17 +127,17 @@ torch::Tensor dispatch_sm70_marlin_group_size_with_group32(
     Launcher const& launcher, int64_t group_size, char const* quant_name) {
   switch (group_size) {
     case -1:
-      return launcher.template operator()<CtaM, CtaN, CtaK, Warps, WarpM,
-                                          WarpN, WarpK, -1, PackedMacroN>();
+      return launcher.template operator()<CtaM, CtaN, CtaK, Warps, WarpM, WarpN,
+                                          WarpK, -1, PackedMacroN>();
     case 32:
-      return launcher.template operator()<CtaM, CtaN, CtaK, Warps, WarpM,
-                                          WarpN, WarpK, 32, PackedMacroN>();
+      return launcher.template operator()<CtaM, CtaN, CtaK, Warps, WarpM, WarpN,
+                                          WarpK, 32, PackedMacroN>();
     case 64:
-      return launcher.template operator()<CtaM, CtaN, CtaK, Warps, WarpM,
-                                          WarpN, WarpK, 64, PackedMacroN>();
+      return launcher.template operator()<CtaM, CtaN, CtaK, Warps, WarpM, WarpN,
+                                          WarpK, 64, PackedMacroN>();
     case 128:
-      return launcher.template operator()<CtaM, CtaN, CtaK, Warps, WarpM,
-                                          WarpN, WarpK, 128, PackedMacroN>();
+      return launcher.template operator()<CtaM, CtaN, CtaK, Warps, WarpM, WarpN,
+                                          WarpK, 128, PackedMacroN>();
     default:
       TORCH_CHECK(false, "SM70 Marlin ", quant_name,
                   " supports only group_size -1, 32, 64, or 128. Got ",
@@ -152,15 +152,16 @@ torch::Tensor dispatch_sm70_marlin_fp8_group_size(Launcher const& launcher,
                                                   int64_t group_size) {
   switch (group_size) {
     case -1:
-      return launcher.template operator()<CtaM, CtaN, CtaK, Warps, WarpM,
-                                          WarpN, WarpK, -1, PackedMacroN>();
+      return launcher.template operator()<CtaM, CtaN, CtaK, Warps, WarpM, WarpN,
+                                          WarpK, -1, PackedMacroN>();
     case 128:
-      return launcher.template operator()<CtaM, CtaN, CtaK, Warps, WarpM,
-                                          WarpN, WarpK, 128, PackedMacroN>();
+      return launcher.template operator()<CtaM, CtaN, CtaK, Warps, WarpM, WarpN,
+                                          WarpK, 128, PackedMacroN>();
     default:
-      TORCH_CHECK(false,
-                  "SM70 Marlin fp8_e4m3 supports only group_size -1 or 128. Got ",
-                  group_size, ".");
+      TORCH_CHECK(
+          false,
+          "SM70 Marlin fp8_e4m3 supports only group_size -1 or 128. Got ",
+          group_size, ".");
   }
   return torch::Tensor();
 }
@@ -175,58 +176,57 @@ torch::Tensor dispatch_sm70_marlin_cta_geometry(Launcher const& launcher,
     return launcher.template operator()<CM, CN, CK, W, WM, WN, WK, PMN>(); \
   }
 
-#define DISPATCH_SM70_GEOMETRY(CM, CN, CK, W, WM, WN, WK, PMN)             \
-  if (geometry.cta_m == CM && geometry.cta_n == CN &&                      \
-      geometry.cta_k == CK && geometry.warps == W &&                       \
-      geometry.warp_m == WM && geometry.warp_n == WN &&                    \
-      geometry.warp_k == WK) {                                             \
-    DISPATCH_SM70_PACKED_MACRO_N(CM, CN, CK, W, WM, WN, WK, PMN)           \
+#define DISPATCH_SM70_GEOMETRY(CM, CN, CK, W, WM, WN, WK, PMN)                 \
+  if (geometry.cta_m == CM && geometry.cta_n == CN && geometry.cta_k == CK &&  \
+      geometry.warps == W && geometry.warp_m == WM && geometry.warp_n == WN && \
+      geometry.warp_k == WK) {                                                 \
+    DISPATCH_SM70_PACKED_MACRO_N(CM, CN, CK, W, WM, WN, WK, PMN)               \
   }
 
-#define FOR_EACH_SM70_GEOMETRY(M)                                         \
-  M(32, 64, 32, 4, 32, 32, 16, 128)                                       \
-  M(32, 64, 32, 4, 32, 32, 16, 256)                                       \
-  M(32, 64, 64, 4, 32, 32, 32, 128)                                       \
-  M(32, 64, 64, 4, 32, 32, 32, 256)                                       \
-  M(32, 64, 64, 4, 32, 64, 16, 128)                                       \
-  M(32, 64, 64, 4, 32, 64, 16, 256)                                       \
-  M(32, 64, 128, 4, 32, 64, 32, 128)                                      \
-  M(32, 64, 128, 4, 32, 64, 32, 256)                                      \
-  M(32, 128, 32, 4, 32, 32, 32, 128)                                      \
-  M(32, 128, 32, 4, 32, 32, 32, 256)                                      \
-  M(32, 128, 64, 4, 32, 64, 32, 128)                                      \
-  M(32, 128, 64, 4, 32, 64, 32, 256)                                      \
-  M(32, 128, 64, 8, 32, 32, 32, 128)                                      \
-  M(32, 128, 64, 8, 32, 32, 32, 256)                                      \
-  M(32, 128, 128, 8, 32, 64, 32, 128)                                     \
-  M(32, 128, 128, 8, 32, 64, 32, 256)                                     \
-  M(32, 256, 32, 4, 32, 64, 32, 256)                                      \
-  M(32, 256, 64, 8, 32, 64, 32, 256)                                      \
-  M(64, 64, 32, 4, 32, 32, 32, 64)                                        \
-  M(64, 64, 32, 4, 32, 32, 32, 128)                                       \
-  M(64, 64, 32, 4, 32, 32, 32, 256)                                       \
-  M(64, 64, 32, 4, 64, 32, 16, 128)                                       \
-  M(64, 64, 32, 4, 64, 32, 16, 256)                                       \
-  M(64, 64, 64, 4, 32, 64, 32, 128)                                       \
-  M(64, 64, 64, 4, 32, 64, 32, 256)                                       \
-  M(64, 64, 64, 4, 64, 32, 32, 128)                                       \
-  M(64, 64, 64, 4, 64, 32, 32, 256)                                       \
-  M(64, 64, 64, 4, 64, 64, 16, 128)                                       \
-  M(64, 64, 64, 4, 64, 64, 16, 256)                                       \
-  M(64, 128, 32, 4, 32, 64, 32, 128)                                      \
-  M(64, 128, 32, 4, 32, 64, 32, 256)                                      \
-  M(64, 128, 32, 4, 64, 32, 32, 128)                                      \
-  M(64, 128, 32, 4, 64, 32, 32, 256)                                      \
-  M(64, 128, 128, 8, 64, 64, 32, 128)                                     \
-  M(64, 128, 128, 8, 64, 64, 32, 256)                                     \
-  M(128, 64, 32, 4, 32, 64, 32, 128)                                      \
-  M(128, 64, 32, 4, 32, 64, 32, 256)                                      \
-  M(128, 64, 128, 8, 64, 64, 32, 128)                                     \
-  M(128, 64, 128, 8, 64, 64, 32, 256)                                     \
-  M(128, 128, 32, 4, 64, 64, 32, 128)                                     \
-  M(128, 128, 32, 4, 64, 64, 32, 256)                                     \
-  M(128, 128, 64, 8, 64, 64, 32, 128)                                     \
-  M(128, 128, 64, 8, 64, 64, 32, 256)                                     \
+#define FOR_EACH_SM70_GEOMETRY(M)     \
+  M(32, 64, 32, 4, 32, 32, 16, 128)   \
+  M(32, 64, 32, 4, 32, 32, 16, 256)   \
+  M(32, 64, 64, 4, 32, 32, 32, 128)   \
+  M(32, 64, 64, 4, 32, 32, 32, 256)   \
+  M(32, 64, 64, 4, 32, 64, 16, 128)   \
+  M(32, 64, 64, 4, 32, 64, 16, 256)   \
+  M(32, 64, 128, 4, 32, 64, 32, 128)  \
+  M(32, 64, 128, 4, 32, 64, 32, 256)  \
+  M(32, 128, 32, 4, 32, 32, 32, 128)  \
+  M(32, 128, 32, 4, 32, 32, 32, 256)  \
+  M(32, 128, 64, 4, 32, 64, 32, 128)  \
+  M(32, 128, 64, 4, 32, 64, 32, 256)  \
+  M(32, 128, 64, 8, 32, 32, 32, 128)  \
+  M(32, 128, 64, 8, 32, 32, 32, 256)  \
+  M(32, 128, 128, 8, 32, 64, 32, 128) \
+  M(32, 128, 128, 8, 32, 64, 32, 256) \
+  M(32, 256, 32, 4, 32, 64, 32, 256)  \
+  M(32, 256, 64, 8, 32, 64, 32, 256)  \
+  M(64, 64, 32, 4, 32, 32, 32, 64)    \
+  M(64, 64, 32, 4, 32, 32, 32, 128)   \
+  M(64, 64, 32, 4, 32, 32, 32, 256)   \
+  M(64, 64, 32, 4, 64, 32, 16, 128)   \
+  M(64, 64, 32, 4, 64, 32, 16, 256)   \
+  M(64, 64, 64, 4, 32, 64, 32, 128)   \
+  M(64, 64, 64, 4, 32, 64, 32, 256)   \
+  M(64, 64, 64, 4, 64, 32, 32, 128)   \
+  M(64, 64, 64, 4, 64, 32, 32, 256)   \
+  M(64, 64, 64, 4, 64, 64, 16, 128)   \
+  M(64, 64, 64, 4, 64, 64, 16, 256)   \
+  M(64, 128, 32, 4, 32, 64, 32, 128)  \
+  M(64, 128, 32, 4, 32, 64, 32, 256)  \
+  M(64, 128, 32, 4, 64, 32, 32, 128)  \
+  M(64, 128, 32, 4, 64, 32, 32, 256)  \
+  M(64, 128, 128, 8, 64, 64, 32, 128) \
+  M(64, 128, 128, 8, 64, 64, 32, 256) \
+  M(128, 64, 32, 4, 32, 64, 32, 128)  \
+  M(128, 64, 32, 4, 32, 64, 32, 256)  \
+  M(128, 64, 128, 8, 64, 64, 32, 128) \
+  M(128, 64, 128, 8, 64, 64, 32, 256) \
+  M(128, 128, 32, 4, 64, 64, 32, 128) \
+  M(128, 128, 32, 4, 64, 64, 32, 256) \
+  M(128, 128, 64, 8, 64, 64, 32, 128) \
+  M(128, 128, 64, 8, 64, 64, 32, 256) \
   M(128, 256, 32, 8, 64, 64, 32, 256)
 
   FOR_EACH_SM70_GEOMETRY(DISPATCH_SM70_GEOMETRY)
@@ -261,8 +261,8 @@ torch::Tensor dispatch_sm70_marlin_geometry(Launcher const& launcher,
                                             int64_t group_size,
                                             char const* quant_name) {
   return dispatch_sm70_marlin_cta_geometry(
-      Sm70MarlinGroupSizeDispatchLauncher<Launcher>{
-          launcher, group_size, quant_name},
+      Sm70MarlinGroupSizeDispatchLauncher<Launcher>{launcher, group_size,
+                                                    quant_name},
       geometry, packed_macro_n, quant_name);
 }
 
@@ -300,8 +300,8 @@ torch::Tensor dispatch_sm70_marlin_geometry_with_group32(
     Launcher const& launcher, Sm70CtaGeometry geometry, int packed_macro_n,
     int64_t group_size, char const* quant_name) {
   return dispatch_sm70_marlin_cta_geometry(
-      Sm70MarlinGroupSize32DispatchLauncher<Launcher>{
-          launcher, group_size, quant_name},
+      Sm70MarlinGroupSize32DispatchLauncher<Launcher>{launcher, group_size,
+                                                      quant_name},
       geometry, packed_macro_n, quant_name);
 }
 
@@ -339,8 +339,8 @@ struct Sm70MarlinFixedGroupDispatchLauncher {
             int WarpK, int PackedMacroN>
   torch::Tensor operator()() const {
     return dispatch_sm70_marlin_fixed_group_size<
-        CtaM, CtaN, CtaK, Warps, WarpM, WarpN, WarpK, GroupSize,
-        PackedMacroN>(inner, group_size, quant_name);
+        CtaM, CtaN, CtaK, Warps, WarpM, WarpN, WarpK, GroupSize, PackedMacroN>(
+        inner, group_size, quant_name);
   }
 };
 

--- a/csrc/quantization/marlin/sm70_marlin_iterator_utils.cuh
+++ b/csrc/quantization/marlin/sm70_marlin_iterator_utils.cuh
@@ -30,23 +30,23 @@ struct QwordVector<4> {
 template <int ContiguousWords>
 CUTLASS_DEVICE typename QwordVector<ContiguousWords>::Type load_qword_vector(
     uint32_t const* ptr) {
-  static_assert(ContiguousWords == 1 || ContiguousWords == 2 ||
-                    ContiguousWords == 4,
-                "SM70 qword vector load supports 1, 2, or 4 words.");
+  static_assert(
+      ContiguousWords == 1 || ContiguousWords == 2 || ContiguousWords == 4,
+      "SM70 qword vector load supports 1, 2, or 4 words.");
   if constexpr (ContiguousWords == 1) {
     return *ptr;
   } else {
-    return *reinterpret_cast<typename QwordVector<ContiguousWords>::Type const*>(
-        ptr);
+    return *reinterpret_cast<
+        typename QwordVector<ContiguousWords>::Type const*>(ptr);
   }
 }
 
 template <int ContiguousWords>
 CUTLASS_DEVICE uint32_t qword_from_vector(
     typename QwordVector<ContiguousWords>::Type const& words, int c) {
-  static_assert(ContiguousWords == 1 || ContiguousWords == 2 ||
-                    ContiguousWords == 4,
-                "SM70 qword vector access supports 1, 2, or 4 words.");
+  static_assert(
+      ContiguousWords == 1 || ContiguousWords == 2 || ContiguousWords == 4,
+      "SM70 qword vector access supports 1, 2, or 4 words.");
   if constexpr (ContiguousWords == 1) {
     return words;
   } else {
@@ -68,9 +68,9 @@ CUTLASS_DEVICE uint32_t qword_from_vector(uint2 const& words, int c) {
 template <int PackedMacroN>
 CUTLASS_DEVICE int u4_packed_macro_n_qweight_offset_from_logical(
     int size_n, int logical_k, int logical_n) {
-  static_assert(PackedMacroN == 64 || PackedMacroN == 128 ||
-                    PackedMacroN == 256,
-                "SM70 Marlin packed macro-N must be 64, 128, or 256.");
+  static_assert(
+      PackedMacroN == 64 || PackedMacroN == 128 || PackedMacroN == 256,
+      "SM70 Marlin packed macro-N must be 64, 128, or 256.");
   constexpr int kGroupTiles = PackedMacroN / kQuantTileN;
   int const k_tile = logical_k / kQuantTileK;
   int const local_k = logical_k - k_tile * kQuantTileK;
@@ -89,9 +89,9 @@ CUTLASS_DEVICE int u4_packed_macro_n_qweight_offset_from_logical(
 template <int PackedMacroN>
 CUTLASS_DEVICE int u8_packed_macro_n_qweight_offset_from_logical(
     int size_n, int logical_k, int logical_n) {
-  static_assert(PackedMacroN == 64 || PackedMacroN == 128 ||
-                    PackedMacroN == 256,
-                "SM70 Marlin packed macro-N must be 64, 128, or 256.");
+  static_assert(
+      PackedMacroN == 64 || PackedMacroN == 128 || PackedMacroN == 256,
+      "SM70 Marlin packed macro-N must be 64, 128, or 256.");
   constexpr int kGroupTiles = PackedMacroN / kQuantTileN;
   int const k_tile = logical_k / kQuantTileK;
   int const local_k = logical_k - k_tile * kQuantTileK;
@@ -109,9 +109,9 @@ CUTLASS_DEVICE int u8_packed_macro_n_qweight_offset_from_logical(
 
 template <int PackedMacroN>
 CUTLASS_DEVICE int u8_packed_macro_n_qweight_word_stride() {
-  static_assert(PackedMacroN == 64 || PackedMacroN == 128 ||
-                    PackedMacroN == 256,
-                "SM70 Marlin packed macro-N must be 64, 128, or 256.");
+  static_assert(
+      PackedMacroN == 64 || PackedMacroN == 128 || PackedMacroN == 256,
+      "SM70 Marlin packed macro-N must be 64, 128, or 256.");
   return PackedMacroN / kQuantTileN;
 }
 

--- a/csrc/quantization/marlin/sm70_marlin_mma.cuh
+++ b/csrc/quantization/marlin/sm70_marlin_mma.cuh
@@ -7,17 +7,16 @@
 
 namespace marlin::sm70 {
 
-template <
-    typename Shape_, typename IteratorA_, typename SmemIteratorA_,
-    typename IteratorB_, typename SmemIteratorB_, typename ElementC_,
-    typename LayoutC_, typename Policy_,
-    typename TransformA_ = cutlass::NumericArrayConverter<
-        typename SmemIteratorA_::Element, typename IteratorA_::Element,
-        IteratorA_::Fragment::kElements>,
-    typename TransformB_ = cutlass::NumericArrayConverter<
-        typename SmemIteratorB_::Element, typename IteratorB_::Element,
-        IteratorB_::Fragment::kElements>,
-    typename Enable = bool>
+template <typename Shape_, typename IteratorA_, typename SmemIteratorA_,
+          typename IteratorB_, typename SmemIteratorB_, typename ElementC_,
+          typename LayoutC_, typename Policy_,
+          typename TransformA_ = cutlass::NumericArrayConverter<
+              typename SmemIteratorA_::Element, typename IteratorA_::Element,
+              IteratorA_::Fragment::kElements>,
+          typename TransformB_ = cutlass::NumericArrayConverter<
+              typename SmemIteratorB_::Element, typename IteratorB_::Element,
+              IteratorB_::Fragment::kElements>,
+          typename Enable = bool>
 class Sm70MarlinMmaPipelined
     : public cutlass::gemm::threadblock::MmaBase<Shape_, Policy_, 2> {
  public:
@@ -106,10 +105,10 @@ class Sm70MarlinMmaPipelined
 
  public:
   CUTLASS_DEVICE
-  Sm70MarlinMmaPipelined(
-      typename Base::SharedStorage& shared_storage, int thread_idx,
-      int warp_idx, int lane_idx, TransformA transform_A = TransformA(),
-      TransformB transform_B = TransformB())
+  Sm70MarlinMmaPipelined(typename Base::SharedStorage& shared_storage,
+                         int thread_idx, int warp_idx, int lane_idx,
+                         TransformA transform_A = TransformA(),
+                         TransformB transform_B = TransformB())
       : Base(shared_storage, thread_idx, warp_idx, lane_idx),
         smem_iterator_A_(shared_storage.operand_A_ref(), thread_idx),
         smem_iterator_B_(shared_storage.operand_B_ref(), thread_idx),
@@ -154,12 +153,12 @@ class Sm70MarlinMmaPipelined
       this->smem_iterator_B_.add_tile_offset({-Base::kStages, 0});
 
       if constexpr (Policy::kPartitionsK > 1) {
-        add_warp_tile_k_group_offset(
-            (Policy::kPartitionsK - 1) * Base::kWarpGemmIterations);
+        add_warp_tile_k_group_offset((Policy::kPartitionsK - 1) *
+                                     Base::kWarpGemmIterations);
       }
     } else {
-      add_warp_tile_k_group_offset(
-          -(Policy::kPartitionsK + 1) * Base::kWarpGemmIterations);
+      add_warp_tile_k_group_offset(-(Policy::kPartitionsK + 1) *
+                                   Base::kWarpGemmIterations);
     }
 
     smem_write_stage_idx ^= 1;
@@ -222,10 +221,10 @@ class Sm70MarlinMmaPipelined
           advance_smem_stages();
         }
 
-        this->warp_tile_iterator_A_.set_kgroup_index(
-            (warp_mma_k + 1) % Base::kWarpGemmIterations);
-        this->warp_tile_iterator_B_.set_kgroup_index(
-            (warp_mma_k + 1) % Base::kWarpGemmIterations);
+        this->warp_tile_iterator_A_.set_kgroup_index((warp_mma_k + 1) %
+                                                     Base::kWarpGemmIterations);
+        this->warp_tile_iterator_B_.set_kgroup_index((warp_mma_k + 1) %
+                                                     Base::kWarpGemmIterations);
 
         this->warp_tile_iterator_A_.load(warp_frag_A[(warp_mma_k + 1) % 2]);
         this->warp_tile_iterator_B_.load(warp_frag_B[(warp_mma_k + 1) % 2]);

--- a/csrc/quantization/marlin/sm70_marlin_mxfp4_gemm.cu
+++ b/csrc/quantization/marlin/sm70_marlin_mxfp4_gemm.cu
@@ -21,23 +21,23 @@
 #include "cutlass/layout/tensor_op_multiplicand_sm70.h"
 #include "cutlass/transform/threadblock/predicated_tile_iterator.h"
 
-using marlin::sm70::Sm70CtaGeometry;
-using marlin::sm70::Sm70AtomicFp16Epilogue;
-using marlin::sm70::Sm70MarlinGemmTraits;
-using marlin::sm70::Sm70SplitKPartition;
-using marlin::sm70::validate_sm70_marlin_dense_cta_geometry_supported;
-using marlin::sm70::validate_sm70_marlin_dense_cta_n_alignment;
 using marlin::sm70::configure_sm70_dynamic_smem;
 using marlin::sm70::dispatch_sm70_marlin_fixed_group_geometry;
 using marlin::sm70::kQuantTileK;
 using marlin::sm70::kQuantTileN;
-using marlin::sm70::sm70_marlin_dense_auto_params;
 using marlin::sm70::load_qword_vector;
 using marlin::sm70::qword_from_vector;
-using marlin::sm70::sm70_marlin_cta_grid;
 using marlin::sm70::sm70_active_split_k;
+using marlin::sm70::sm70_marlin_cta_grid;
+using marlin::sm70::sm70_marlin_dense_auto_params;
 using marlin::sm70::sm70_splitk_partition;
+using marlin::sm70::Sm70AtomicFp16Epilogue;
+using marlin::sm70::Sm70CtaGeometry;
+using marlin::sm70::Sm70MarlinGemmTraits;
+using marlin::sm70::Sm70SplitKPartition;
 using marlin::sm70::u4_packed_macro_n_qweight_offset_from_logical;
+using marlin::sm70::validate_sm70_marlin_dense_cta_geometry_supported;
+using marlin::sm70::validate_sm70_marlin_dense_cta_n_alignment;
 
 namespace {
 
@@ -76,7 +76,8 @@ void dequant_e8m0_scales_to_half2(int q, half2* scale_cache) {
   *reinterpret_cast<uint2*>(scale_cache) = vec_res;
 }
 
-template <typename Shape_, typename ThreadMap_, int GroupSize_, int PackedMacroN_>
+template <typename Shape_, typename ThreadMap_, int GroupSize_,
+          int PackedMacroN_>
 class Sm70Mxfp4IteratorB {
  public:
   using Shape = Shape_;
@@ -84,12 +85,11 @@ class Sm70Mxfp4IteratorB {
   static int const kGroupSize = GroupSize_;
   static int const kPackedMacroN = PackedMacroN_;
   using Element = cutlass::half_t;
-  using Fragment = cutlass::Array<
-      Element, ThreadMap::Iterations::kCount * ThreadMap::kElementsPerAccess>;
+  using Fragment = cutlass::Array<Element, ThreadMap::Iterations::kCount *
+                                               ThreadMap::kElementsPerAccess>;
   static_assert(Shape::kN == 64 || Shape::kN == 128 || Shape::kN == 256,
                 "SM70 Marlin MXFP4 IteratorB expects CTA_N in {64, 128, 256}.");
-  static_assert(ThreadMap::Iterations::kContiguous ==
-                    Shape::kN / kQuantTileN,
+  static_assert(ThreadMap::Iterations::kContiguous == Shape::kN / kQuantTileN,
                 "SM70 Marlin MXFP4 IteratorB expects one contiguous iteration "
                 "per 64-column quant tile.");
   static_assert(ThreadMap::Delta::kContiguous == kQuantTileN,
@@ -98,7 +98,8 @@ class Sm70Mxfp4IteratorB {
                 "SM70 Marlin MXFP4 IteratorB expects one packed FP4 word per "
                 "access.");
   static_assert(ThreadMap::Iterations::kStrided >= 1,
-                "SM70 Marlin U4-family IteratorB expects one or more strided iterations.");
+                "SM70 Marlin U4-family IteratorB expects one or more strided "
+                "iterations.");
   struct Params {
     int size_n;
     int aligned_initial_k_step;
@@ -180,8 +181,8 @@ class Sm70Mxfp4IteratorB {
   CUTLASS_DEVICE
   static int qweight_offset_from_logical(Params const& params, int logical_k,
                                          int logical_n) {
-    return u4_packed_macro_n_qweight_offset_from_logical<kPackedMacroN>(params.size_n, logical_k,
-                                                     logical_n);
+    return u4_packed_macro_n_qweight_offset_from_logical<kPackedMacroN>(
+        params.size_n, logical_k, logical_n);
   }
 
   CUTLASS_DEVICE
@@ -200,14 +201,12 @@ class Sm70Mxfp4IteratorB {
     CUTLASS_PRAGMA_UNROLL
     for (int s = 0; s < ThreadMap::Iterations::kStrided; ++s) {
       int const logical_k =
-          k_offset_ + thread_offset_.strided() +
-          s * ThreadMap::Delta::kStrided;
+          k_offset_ + thread_offset_.strided() + s * ThreadMap::Delta::kStrided;
       int const group = scale_group(logical_k);
       CUTLASS_PRAGMA_UNROLL
       for (int c = 0; c < ThreadMap::Iterations::kContiguous; ++c) {
-        int const cache_n =
-            n_offset_ + thread_offset_.contiguous() +
-            c * ThreadMap::Delta::kContiguous;
+        int const cache_n = n_offset_ + thread_offset_.contiguous() +
+                            c * ThreadMap::Delta::kContiguous;
         int const cache_index = c + s * ThreadMap::Iterations::kContiguous;
         cache_metadata_e8m0_scales(cache_index, group, cache_n);
       }
@@ -260,9 +259,11 @@ class Sm70Mxfp4IteratorB {
           frag_vec[3] = __hmul2(deq[1], scale_vec[3]);
         }
       } else {
-        static_assert(ThreadMap::Iterations::kContiguous == 1,
-                      "Unsupported SM70 Marlin MXFP4 contiguous iteration count.");
-        uint32_t const qword = load_qword_vector<1>(qweight_ + qweight_base_offset_);
+        static_assert(
+            ThreadMap::Iterations::kContiguous == 1,
+            "Unsupported SM70 Marlin MXFP4 contiguous iteration count.");
+        uint32_t const qword =
+            load_qword_vector<1>(qweight_ + qweight_base_offset_);
         half2 const* scale_vec = cached_scales_;
 
         half2 deq[2];
@@ -280,14 +281,12 @@ class Sm70Mxfp4IteratorB {
       int const logical_n_base = n_offset_ + thread_offset_.contiguous();
       CUTLASS_PRAGMA_UNROLL
       for (int s = 0; s < ThreadMap::Iterations::kStrided; ++s) {
-        int const logical_k_s =
-            k_offset_ + thread_offset_.strided() +
-            s * ThreadMap::Delta::kStrided;
+        int const logical_k_s = k_offset_ + thread_offset_.strided() +
+                                s * ThreadMap::Delta::kStrided;
         int const qweight_base_s =
             qweight_offset_from_logical(params_, logical_k_s, logical_n_base);
         if constexpr (ThreadMap::Iterations::kContiguous == 4) {
-          auto const qwords =
-              load_qword_vector<4>(qweight_ + qweight_base_s);
+          auto const qwords = load_qword_vector<4>(qweight_ + qweight_base_s);
           CUTLASS_PRAGMA_UNROLL
           for (int c = 0; c < ThreadMap::Iterations::kContiguous; ++c) {
             constexpr int kAccess = ThreadMap::kElementsPerAccess;
@@ -308,8 +307,7 @@ class Sm70Mxfp4IteratorB {
             frag_vec[3] = __hmul2(deq[1], scale_vec[3]);
           }
         } else if constexpr (ThreadMap::Iterations::kContiguous == 2) {
-          auto const qwords =
-              load_qword_vector<2>(qweight_ + qweight_base_s);
+          auto const qwords = load_qword_vector<2>(qweight_ + qweight_base_s);
           CUTLASS_PRAGMA_UNROLL
           for (int c = 0; c < ThreadMap::Iterations::kContiguous; ++c) {
             constexpr int kAccess = ThreadMap::kElementsPerAccess;
@@ -330,9 +328,11 @@ class Sm70Mxfp4IteratorB {
             frag_vec[3] = __hmul2(deq[1], scale_vec[3]);
           }
         } else {
-          static_assert(ThreadMap::Iterations::kContiguous == 1,
-                        "Unsupported SM70 Marlin MXFP4 contiguous iteration count.");
-          uint32_t const qword = load_qword_vector<1>(qweight_ + qweight_base_s);
+          static_assert(
+              ThreadMap::Iterations::kContiguous == 1,
+              "Unsupported SM70 Marlin MXFP4 contiguous iteration count.");
+          uint32_t const qword =
+              load_qword_vector<1>(qweight_ + qweight_base_s);
           constexpr int kAccess = ThreadMap::kElementsPerAccess;
           int const frag_base = s * kAccess;
           half2 const* scale_vec = cached_scales_;
@@ -365,26 +365,25 @@ class Sm70Mxfp4IteratorB {
 
 struct Sm70Mxfp4GemmSpec {
   template <typename Shape, typename ThreadMap, int GroupSize, int PackedMacroN>
-  using IteratorB = Sm70Mxfp4IteratorB<Shape, ThreadMap, GroupSize, PackedMacroN>;
+  using IteratorB =
+      Sm70Mxfp4IteratorB<Shape, ThreadMap, GroupSize, PackedMacroN>;
 };
 
-template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM,
-          int WarpN, int WarpK, int GroupSize, int PackedMacroN>
+template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM, int WarpN,
+          int WarpK, int GroupSize, int PackedMacroN>
 using Sm70Mxfp4GemmTraits =
-    Sm70MarlinGemmTraits<Sm70Mxfp4GemmSpec, CtaM, CtaN, CtaK,
-                         Warps, WarpM, WarpN, WarpK, GroupSize, PackedMacroN>;
+    Sm70MarlinGemmTraits<Sm70Mxfp4GemmSpec, CtaM, CtaN, CtaK, Warps, WarpM,
+                         WarpN, WarpK, GroupSize, PackedMacroN>;
 
-template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM,
-          int WarpN, int WarpK, int GroupSize, int PackedMacroN>
-__global__ __launch_bounds__(Warps * 32, 1)
-void sm70_marlin_mxfp4_gemm_kernel(
+template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM, int WarpN,
+          int WarpK, int GroupSize, int PackedMacroN>
+__global__ __launch_bounds__(Warps * 32, 1) void sm70_marlin_mxfp4_gemm_kernel(
     cutlass::half_t const* __restrict__ a,
     uint32_t const* __restrict__ b_q_weight,
-    uint8_t const* __restrict__ b_scales,
-    cutlass::half_t* __restrict__ c, int m, int n, int k, int lda) {
-  using Traits =
-      Sm70Mxfp4GemmTraits<CtaM, CtaN, CtaK, Warps, WarpM,
-                                  WarpN, WarpK, GroupSize, PackedMacroN>;
+    uint8_t const* __restrict__ b_scales, cutlass::half_t* __restrict__ c,
+    int m, int n, int k, int lda) {
+  using Traits = Sm70Mxfp4GemmTraits<CtaM, CtaN, CtaK, Warps, WarpM, WarpN,
+                                     WarpK, GroupSize, PackedMacroN>;
   using Mma = typename Traits::Mma;
   using Epilogue = typename Traits::Epilogue;
 
@@ -404,10 +403,10 @@ void sm70_marlin_mxfp4_gemm_kernel(
   typename Traits::LayoutA layout_a(lda);
   typename Traits::LayoutC layout_c(n);
 
-  typename Mma::IteratorA iterator_A(
-      typename Mma::IteratorA::Params(layout_a),
-      const_cast<cutlass::half_t*>(a), cutlass::MatrixCoord(m, k), thread_idx,
-      tb_offset_A);
+  typename Mma::IteratorA iterator_A(typename Mma::IteratorA::Params(layout_a),
+                                     const_cast<cutlass::half_t*>(a),
+                                     cutlass::MatrixCoord(m, k), thread_idx,
+                                     tb_offset_A);
   typename Mma::IteratorB iterator_B(
       typename Mma::IteratorB::Params(k, n),
       reinterpret_cast<uint32_t const*>(b_q_weight),
@@ -432,16 +431,16 @@ void sm70_marlin_mxfp4_gemm_kernel(
   epilogue(output_op, iterator_D, accumulators, iterator_C);
 }
 
-template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM,
-          int WarpN, int WarpK, int GroupSize, int PackedMacroN>
-__global__ __launch_bounds__(Warps * 32, 1)
-void sm70_marlin_mxfp4_gemm_splitk_kernel(
+template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM, int WarpN,
+          int WarpK, int GroupSize, int PackedMacroN>
+__global__
+__launch_bounds__(Warps * 32, 1) void sm70_marlin_mxfp4_gemm_splitk_kernel(
     cutlass::half_t const* __restrict__ a,
     uint32_t const* __restrict__ b_q_weight,
-    uint8_t const* __restrict__ b_scales,
-    cutlass::half_t* __restrict__ c, int m, int n, int k, int lda, int requested_split_k) {
-  using Traits = Sm70Mxfp4GemmTraits<CtaM, CtaN, CtaK, Warps, WarpM,
-                                  WarpN, WarpK, GroupSize, PackedMacroN>;
+    uint8_t const* __restrict__ b_scales, cutlass::half_t* __restrict__ c,
+    int m, int n, int k, int lda, int requested_split_k) {
+  using Traits = Sm70Mxfp4GemmTraits<CtaM, CtaN, CtaK, Warps, WarpM, WarpN,
+                                     WarpK, GroupSize, PackedMacroN>;
   using Mma = typename Traits::Mma;
   using AtomicEpilogue = Sm70AtomicFp16Epilogue<Traits>;
 
@@ -452,14 +451,13 @@ void sm70_marlin_mxfp4_gemm_splitk_kernel(
   int const thread_idx = threadIdx.x;
   int const warp_idx = cutlass::canonical_warp_idx_sync();
   int const lane_idx = threadIdx.x % 32;
-  Sm70SplitKPartition const partition =
-      sm70_splitk_partition<GroupSize, CtaK>(k, requested_split_k, int(blockIdx.z));
+  Sm70SplitKPartition const partition = sm70_splitk_partition<GroupSize, CtaK>(
+      k, requested_split_k, int(blockIdx.z));
   if (partition.partition_k == 0) {
     return;
   }
 
-  cutlass::MatrixCoord tb_offset_A{int(blockIdx.x) * CtaM,
-                                   partition.k_begin};
+  cutlass::MatrixCoord tb_offset_A{int(blockIdx.x) * CtaM, partition.k_begin};
   cutlass::MatrixCoord tb_offset_B{partition.k_begin, int(blockIdx.y) * CtaN};
   cutlass::MatrixCoord tb_offset_C{int(blockIdx.x) * CtaM,
                                    int(blockIdx.y) * CtaN};
@@ -467,10 +465,10 @@ void sm70_marlin_mxfp4_gemm_splitk_kernel(
   typename Traits::LayoutA layout_a(lda);
   typename Traits::LayoutC layout_c(n);
 
-  typename Mma::IteratorA iterator_A(
-      typename Mma::IteratorA::Params(layout_a),
-      const_cast<cutlass::half_t*>(a), cutlass::MatrixCoord(m, k), thread_idx,
-      tb_offset_A);
+  typename Mma::IteratorA iterator_A(typename Mma::IteratorA::Params(layout_a),
+                                     const_cast<cutlass::half_t*>(a),
+                                     cutlass::MatrixCoord(m, k), thread_idx,
+                                     tb_offset_A);
   typename Mma::IteratorB iterator_B(
       typename Mma::IteratorB::Params(k, n),
       reinterpret_cast<uint32_t const*>(b_q_weight),
@@ -484,9 +482,8 @@ void sm70_marlin_mxfp4_gemm_splitk_kernel(
   mma(gemm_k_iterations, accumulators, iterator_A, iterator_B, accumulators);
 
   typename AtomicEpilogue::OutputTileIterator iterator_D(
-      typename AtomicEpilogue::OutputTileIterator::Params(layout_c),
-      c, cutlass::MatrixCoord(m, n),
-      thread_idx, tb_offset_C);
+      typename AtomicEpilogue::OutputTileIterator::Params(layout_c), c,
+      cutlass::MatrixCoord(m, n), thread_idx, tb_offset_C);
 
   AtomicEpilogue epilogue(shared_storage.epilogue, thread_idx, warp_idx,
                           lane_idx);
@@ -495,18 +492,20 @@ void sm70_marlin_mxfp4_gemm_splitk_kernel(
 
 }  // namespace
 
-template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM,
-          int WarpN, int WarpK, int GroupSize, int PackedMacroN>
-torch::Tensor launch_sm70_marlin_mxfp4_gemm(
-    torch::Tensor& a, torch::Tensor& c, torch::Tensor& b_q_weight,
-    torch::Tensor& b_scales, int64_t size_m, int64_t size_n, int64_t size_k,
-    int requested_split_k) {
+template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM, int WarpN,
+          int WarpK, int GroupSize, int PackedMacroN>
+torch::Tensor launch_sm70_marlin_mxfp4_gemm(torch::Tensor& a, torch::Tensor& c,
+                                            torch::Tensor& b_q_weight,
+                                            torch::Tensor& b_scales,
+                                            int64_t size_m, int64_t size_n,
+                                            int64_t size_k,
+                                            int requested_split_k) {
   auto kernel =
-      sm70_marlin_mxfp4_gemm_kernel<CtaM, CtaN, CtaK, Warps, WarpM, WarpN, WarpK,
-                  GroupSize, PackedMacroN>;
-  using SharedStorage = typename Sm70Mxfp4GemmTraits<
-      CtaM, CtaN, CtaK, Warps, WarpM, WarpN, WarpK, GroupSize,
-      PackedMacroN>::SharedStorage;
+      sm70_marlin_mxfp4_gemm_kernel<CtaM, CtaN, CtaK, Warps, WarpM, WarpN,
+                                    WarpK, GroupSize, PackedMacroN>;
+  using SharedStorage =
+      typename Sm70Mxfp4GemmTraits<CtaM, CtaN, CtaK, Warps, WarpM, WarpN, WarpK,
+                                   GroupSize, PackedMacroN>::SharedStorage;
   size_t smem_bytes = configure_sm70_dynamic_smem<SharedStorage>(kernel);
 
   dim3 block(Warps * 32);
@@ -526,19 +525,18 @@ torch::Tensor launch_sm70_marlin_mxfp4_gemm(
   }
 
   TORCH_CHECK(size_k % int64_t(CtaK) == 0,
-              "SM70 Marlin mxfp4 requires K divisible by CTA_K=",
-              CtaK, " for requested_split_k > 1. Got K=", size_k,
+              "SM70 Marlin mxfp4 requires K divisible by CTA_K=", CtaK,
+              " for requested_split_k > 1. Got K=", size_k,
               ", requested_split_k=", requested_split_k, ".");
 
-  auto split_kernel =
-      sm70_marlin_mxfp4_gemm_splitk_kernel<CtaM, CtaN, CtaK, Warps, WarpM, WarpN,
-                  WarpK, GroupSize, PackedMacroN>;
+  auto split_kernel = sm70_marlin_mxfp4_gemm_splitk_kernel<
+      CtaM, CtaN, CtaK, Warps, WarpM, WarpN, WarpK, GroupSize, PackedMacroN>;
   smem_bytes = configure_sm70_dynamic_smem<SharedStorage>(split_kernel);
 
   int64_t const numel = size_m * size_n;
-  C10_CUDA_CHECK(cudaMemsetAsync(
-      c.data_ptr<at::Half>(), 0,
-      static_cast<size_t>(numel) * sizeof(at::Half), stream));
+  C10_CUDA_CHECK(cudaMemsetAsync(c.data_ptr<at::Half>(), 0,
+                                 static_cast<size_t>(numel) * sizeof(at::Half),
+                                 stream));
 
   dim3 grid = sm70_marlin_cta_grid(size_m, size_n, CtaM, CtaN);
   int const active_split_k =
@@ -550,7 +548,8 @@ torch::Tensor launch_sm70_marlin_mxfp4_gemm(
       reinterpret_cast<uint8_t const*>(b_scales.data_ptr()),
       reinterpret_cast<cutlass::half_t*>(c.data_ptr<at::Half>()),
       static_cast<int>(size_m), static_cast<int>(size_n),
-      static_cast<int>(size_k), static_cast<int>(a.stride(0)), requested_split_k);
+      static_cast<int>(size_k), static_cast<int>(a.stride(0)),
+      requested_split_k);
   C10_CUDA_KERNEL_LAUNCH_CHECK();
 
   return c;
@@ -566,11 +565,11 @@ struct Sm70Mxfp4Launcher {
   int64_t size_k;
   int requested_split_k;
 
-  template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM,
-            int WarpN, int WarpK, int GroupSize, int PackedMacroN>
+  template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM, int WarpN,
+            int WarpK, int GroupSize, int PackedMacroN>
   torch::Tensor operator()() const {
-    return launch_sm70_marlin_mxfp4_gemm<CtaM, CtaN, CtaK, Warps, WarpM, WarpN, WarpK,
-                  GroupSize, PackedMacroN>(
+    return launch_sm70_marlin_mxfp4_gemm<CtaM, CtaN, CtaK, Warps, WarpM, WarpN,
+                                         WarpK, GroupSize, PackedMacroN>(
         a, c, b_q_weight, b_scales, size_m, size_n, size_k, requested_split_k);
   }
 };
@@ -582,14 +581,16 @@ torch::Tensor sm70_marlin_mxfp4_gemm(torch::Tensor& a, torch::Tensor& c,
                                      int64_t group_size) {
   c10::cuda::CUDAGuard device_guard(a.device());
 
-  auto const params = sm70_marlin_dense_auto_params(
-      "mxfp4", group_size, size_m, size_n, size_k);
+  auto const params = sm70_marlin_dense_auto_params("mxfp4", group_size, size_m,
+                                                    size_n, size_k);
   Sm70CtaGeometry const geometry = params.geometry;
-  validate_sm70_marlin_dense_cta_geometry_supported("SM70 Marlin mxfp4", geometry);
-  validate_sm70_marlin_dense_cta_n_alignment("SM70 Marlin mxfp4", geometry, size_n);
+  validate_sm70_marlin_dense_cta_geometry_supported("SM70 Marlin mxfp4",
+                                                    geometry);
+  validate_sm70_marlin_dense_cta_n_alignment("SM70 Marlin mxfp4", geometry,
+                                             size_n);
   Sm70Mxfp4Launcher const launcher{
-      a, c, b_q_weight, b_scales, size_m, size_n, size_k,
-      params.requested_split_k};
+      a,      c,      b_q_weight, b_scales,
+      size_m, size_n, size_k,     params.requested_split_k};
   return dispatch_sm70_marlin_fixed_group_geometry<32>(
       launcher, geometry, params.packed_macro_n, group_size, "mxfp4");
 }

--- a/csrc/quantization/marlin/sm70_marlin_nvfp4_gemm.cu
+++ b/csrc/quantization/marlin/sm70_marlin_nvfp4_gemm.cu
@@ -21,29 +21,30 @@
 #include "cutlass/layout/tensor_op_multiplicand_sm70.h"
 #include "cutlass/transform/threadblock/predicated_tile_iterator.h"
 
-using marlin::sm70::Sm70CtaGeometry;
-using marlin::sm70::Sm70AtomicFp16Epilogue;
-using marlin::sm70::Sm70MarlinGemmTraits;
-using marlin::sm70::Sm70SplitKPartition;
-using marlin::sm70::validate_sm70_marlin_dense_cta_geometry_supported;
-using marlin::sm70::validate_sm70_marlin_dense_cta_n_alignment;
 using marlin::sm70::configure_sm70_dynamic_smem;
 using marlin::sm70::dispatch_sm70_marlin_fixed_group_geometry;
 using marlin::sm70::kQuantTileK;
 using marlin::sm70::kQuantTileN;
-using marlin::sm70::sm70_marlin_dense_auto_params;
 using marlin::sm70::load_qword_vector;
 using marlin::sm70::qword_from_vector;
-using marlin::sm70::sm70_marlin_cta_grid;
 using marlin::sm70::sm70_active_split_k;
+using marlin::sm70::sm70_marlin_cta_grid;
+using marlin::sm70::sm70_marlin_dense_auto_params;
 using marlin::sm70::sm70_splitk_partition;
+using marlin::sm70::Sm70AtomicFp16Epilogue;
+using marlin::sm70::Sm70CtaGeometry;
+using marlin::sm70::Sm70MarlinGemmTraits;
+using marlin::sm70::Sm70SplitKPartition;
 using marlin::sm70::u4_packed_macro_n_qweight_offset_from_logical;
+using marlin::sm70::validate_sm70_marlin_dense_cta_geometry_supported;
+using marlin::sm70::validate_sm70_marlin_dense_cta_n_alignment;
 
 namespace {
 
 constexpr int kNvfp4ValuesPerWord = 8;
 
-template <typename Shape_, typename ThreadMap_, int GroupSize_, int PackedMacroN_>
+template <typename Shape_, typename ThreadMap_, int GroupSize_,
+          int PackedMacroN_>
 class Sm70Nvfp4IteratorB {
  public:
   using Shape = Shape_;
@@ -51,12 +52,11 @@ class Sm70Nvfp4IteratorB {
   static int const kGroupSize = GroupSize_;
   static int const kPackedMacroN = PackedMacroN_;
   using Element = cutlass::half_t;
-  using Fragment = cutlass::Array<
-      Element, ThreadMap::Iterations::kCount * ThreadMap::kElementsPerAccess>;
+  using Fragment = cutlass::Array<Element, ThreadMap::Iterations::kCount *
+                                               ThreadMap::kElementsPerAccess>;
   static_assert(Shape::kN == 64 || Shape::kN == 128 || Shape::kN == 256,
                 "SM70 Marlin NVFP4 IteratorB expects CTA_N in {64, 128, 256}.");
-  static_assert(ThreadMap::Iterations::kContiguous ==
-                    Shape::kN / kQuantTileN,
+  static_assert(ThreadMap::Iterations::kContiguous == Shape::kN / kQuantTileN,
                 "SM70 Marlin NVFP4 IteratorB expects one contiguous iteration "
                 "per 64-column quant tile.");
   static_assert(ThreadMap::Delta::kContiguous == kQuantTileN,
@@ -65,7 +65,8 @@ class Sm70Nvfp4IteratorB {
                 "SM70 Marlin NVFP4 IteratorB expects one packed FP4 word per "
                 "access.");
   static_assert(ThreadMap::Iterations::kStrided >= 1,
-                "SM70 Marlin U4-family IteratorB expects one or more strided iterations.");
+                "SM70 Marlin U4-family IteratorB expects one or more strided "
+                "iterations.");
   struct Params {
     int size_n;
     int aligned_initial_k_step;
@@ -147,8 +148,8 @@ class Sm70Nvfp4IteratorB {
   CUTLASS_DEVICE
   static int qweight_offset_from_logical(Params const& params, int logical_k,
                                          int logical_n) {
-    return u4_packed_macro_n_qweight_offset_from_logical<kPackedMacroN>(params.size_n, logical_k,
-                                                     logical_n);
+    return u4_packed_macro_n_qweight_offset_from_logical<kPackedMacroN>(
+        params.size_n, logical_k, logical_n);
   }
 
   CUTLASS_DEVICE
@@ -168,14 +169,12 @@ class Sm70Nvfp4IteratorB {
     CUTLASS_PRAGMA_UNROLL
     for (int s = 0; s < ThreadMap::Iterations::kStrided; ++s) {
       int const logical_k =
-          k_offset_ + thread_offset_.strided() +
-          s * ThreadMap::Delta::kStrided;
+          k_offset_ + thread_offset_.strided() + s * ThreadMap::Delta::kStrided;
       int const group = scale_group(logical_k);
       CUTLASS_PRAGMA_UNROLL
       for (int c = 0; c < ThreadMap::Iterations::kContiguous; ++c) {
-        int const cache_n =
-            n_offset_ + thread_offset_.contiguous() +
-            c * ThreadMap::Delta::kContiguous;
+        int const cache_n = n_offset_ + thread_offset_.contiguous() +
+                            c * ThreadMap::Delta::kContiguous;
         int const cache_index = c + s * ThreadMap::Iterations::kContiguous;
         cache_metadata_fp8_scales(cache_index, group, cache_n);
       }
@@ -228,9 +227,11 @@ class Sm70Nvfp4IteratorB {
           frag_vec[3] = __hmul2(deq[1], scale_vec[3]);
         }
       } else {
-        static_assert(ThreadMap::Iterations::kContiguous == 1,
-                      "Unsupported SM70 Marlin NVFP4 contiguous iteration count.");
-        uint32_t const qword = load_qword_vector<1>(qweight_ + qweight_base_offset_);
+        static_assert(
+            ThreadMap::Iterations::kContiguous == 1,
+            "Unsupported SM70 Marlin NVFP4 contiguous iteration count.");
+        uint32_t const qword =
+            load_qword_vector<1>(qweight_ + qweight_base_offset_);
         half2 const* scale_vec = cached_scales_;
 
         half2 deq[2];
@@ -248,14 +249,12 @@ class Sm70Nvfp4IteratorB {
       int const logical_n_base = n_offset_ + thread_offset_.contiguous();
       CUTLASS_PRAGMA_UNROLL
       for (int s = 0; s < ThreadMap::Iterations::kStrided; ++s) {
-        int const logical_k_s =
-            k_offset_ + thread_offset_.strided() +
-            s * ThreadMap::Delta::kStrided;
+        int const logical_k_s = k_offset_ + thread_offset_.strided() +
+                                s * ThreadMap::Delta::kStrided;
         int const qweight_base_s =
             qweight_offset_from_logical(params_, logical_k_s, logical_n_base);
         if constexpr (ThreadMap::Iterations::kContiguous == 4) {
-          auto const qwords =
-              load_qword_vector<4>(qweight_ + qweight_base_s);
+          auto const qwords = load_qword_vector<4>(qweight_ + qweight_base_s);
           CUTLASS_PRAGMA_UNROLL
           for (int c = 0; c < ThreadMap::Iterations::kContiguous; ++c) {
             constexpr int kAccess = ThreadMap::kElementsPerAccess;
@@ -278,8 +277,7 @@ class Sm70Nvfp4IteratorB {
             frag_vec[3] = __hmul2(deq[1], scale_vec[3]);
           }
         } else if constexpr (ThreadMap::Iterations::kContiguous == 2) {
-          auto const qwords =
-              load_qword_vector<2>(qweight_ + qweight_base_s);
+          auto const qwords = load_qword_vector<2>(qweight_ + qweight_base_s);
           CUTLASS_PRAGMA_UNROLL
           for (int c = 0; c < ThreadMap::Iterations::kContiguous; ++c) {
             constexpr int kAccess = ThreadMap::kElementsPerAccess;
@@ -302,9 +300,11 @@ class Sm70Nvfp4IteratorB {
             frag_vec[3] = __hmul2(deq[1], scale_vec[3]);
           }
         } else {
-          static_assert(ThreadMap::Iterations::kContiguous == 1,
-                        "Unsupported SM70 Marlin NVFP4 contiguous iteration count.");
-          uint32_t const qword = load_qword_vector<1>(qweight_ + qweight_base_s);
+          static_assert(
+              ThreadMap::Iterations::kContiguous == 1,
+              "Unsupported SM70 Marlin NVFP4 contiguous iteration count.");
+          uint32_t const qword =
+              load_qword_vector<1>(qweight_ + qweight_base_s);
           constexpr int kAccess = ThreadMap::kElementsPerAccess;
           int const frag_base = s * kAccess;
           half2 const* scale_vec =
@@ -338,27 +338,26 @@ class Sm70Nvfp4IteratorB {
 
 struct Sm70Nvfp4GemmSpec {
   template <typename Shape, typename ThreadMap, int GroupSize, int PackedMacroN>
-  using IteratorB = Sm70Nvfp4IteratorB<Shape, ThreadMap, GroupSize, PackedMacroN>;
+  using IteratorB =
+      Sm70Nvfp4IteratorB<Shape, ThreadMap, GroupSize, PackedMacroN>;
 };
 
-template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM,
-          int WarpN, int WarpK, int GroupSize, int PackedMacroN>
+template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM, int WarpN,
+          int WarpK, int GroupSize, int PackedMacroN>
 using Sm70Nvfp4GemmTraits =
-    Sm70MarlinGemmTraits<Sm70Nvfp4GemmSpec, CtaM, CtaN, CtaK,
-                         Warps, WarpM, WarpN, WarpK, GroupSize, PackedMacroN>;
+    Sm70MarlinGemmTraits<Sm70Nvfp4GemmSpec, CtaM, CtaN, CtaK, Warps, WarpM,
+                         WarpN, WarpK, GroupSize, PackedMacroN>;
 
-template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM,
-          int WarpN, int WarpK, int GroupSize, int PackedMacroN>
-__global__ __launch_bounds__(Warps * 32, 1)
-void sm70_marlin_nvfp4_gemm_kernel(
+template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM, int WarpN,
+          int WarpK, int GroupSize, int PackedMacroN>
+__global__ __launch_bounds__(Warps * 32, 1) void sm70_marlin_nvfp4_gemm_kernel(
     cutlass::half_t const* __restrict__ a,
     uint32_t const* __restrict__ b_q_weight,
     uint8_t const* __restrict__ b_scales,
-    float const* __restrict__ global_scale,
-    cutlass::half_t* __restrict__ c, int m, int n, int k, int lda) {
-  using Traits =
-      Sm70Nvfp4GemmTraits<CtaM, CtaN, CtaK, Warps, WarpM,
-                                  WarpN, WarpK, GroupSize, PackedMacroN>;
+    float const* __restrict__ global_scale, cutlass::half_t* __restrict__ c,
+    int m, int n, int k, int lda) {
+  using Traits = Sm70Nvfp4GemmTraits<CtaM, CtaN, CtaK, Warps, WarpM, WarpN,
+                                     WarpK, GroupSize, PackedMacroN>;
   using Mma = typename Traits::Mma;
   using Epilogue = typename Traits::Epilogue;
 
@@ -378,10 +377,10 @@ void sm70_marlin_nvfp4_gemm_kernel(
   typename Traits::LayoutA layout_a(lda);
   typename Traits::LayoutC layout_c(n);
 
-  typename Mma::IteratorA iterator_A(
-      typename Mma::IteratorA::Params(layout_a),
-      const_cast<cutlass::half_t*>(a), cutlass::MatrixCoord(m, k), thread_idx,
-      tb_offset_A);
+  typename Mma::IteratorA iterator_A(typename Mma::IteratorA::Params(layout_a),
+                                     const_cast<cutlass::half_t*>(a),
+                                     cutlass::MatrixCoord(m, k), thread_idx,
+                                     tb_offset_A);
   typename Mma::IteratorB iterator_B(
       typename Mma::IteratorB::Params(k, n),
       reinterpret_cast<uint32_t const*>(b_q_weight),
@@ -406,17 +405,17 @@ void sm70_marlin_nvfp4_gemm_kernel(
   epilogue(output_op, iterator_D, accumulators, iterator_C);
 }
 
-template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM,
-          int WarpN, int WarpK, int GroupSize, int PackedMacroN>
-__global__ __launch_bounds__(Warps * 32, 1)
-void sm70_marlin_nvfp4_gemm_splitk_kernel(
+template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM, int WarpN,
+          int WarpK, int GroupSize, int PackedMacroN>
+__global__
+__launch_bounds__(Warps * 32, 1) void sm70_marlin_nvfp4_gemm_splitk_kernel(
     cutlass::half_t const* __restrict__ a,
     uint32_t const* __restrict__ b_q_weight,
     uint8_t const* __restrict__ b_scales,
-    float const* __restrict__ global_scale,
-    cutlass::half_t* __restrict__ c, int m, int n, int k, int lda, int requested_split_k) {
-  using Traits = Sm70Nvfp4GemmTraits<CtaM, CtaN, CtaK, Warps, WarpM,
-                                  WarpN, WarpK, GroupSize, PackedMacroN>;
+    float const* __restrict__ global_scale, cutlass::half_t* __restrict__ c,
+    int m, int n, int k, int lda, int requested_split_k) {
+  using Traits = Sm70Nvfp4GemmTraits<CtaM, CtaN, CtaK, Warps, WarpM, WarpN,
+                                     WarpK, GroupSize, PackedMacroN>;
   using Mma = typename Traits::Mma;
   using AtomicEpilogue = Sm70AtomicFp16Epilogue<Traits>;
 
@@ -427,14 +426,13 @@ void sm70_marlin_nvfp4_gemm_splitk_kernel(
   int const thread_idx = threadIdx.x;
   int const warp_idx = cutlass::canonical_warp_idx_sync();
   int const lane_idx = threadIdx.x % 32;
-  Sm70SplitKPartition const partition =
-      sm70_splitk_partition<GroupSize, CtaK>(k, requested_split_k, int(blockIdx.z));
+  Sm70SplitKPartition const partition = sm70_splitk_partition<GroupSize, CtaK>(
+      k, requested_split_k, int(blockIdx.z));
   if (partition.partition_k == 0) {
     return;
   }
 
-  cutlass::MatrixCoord tb_offset_A{int(blockIdx.x) * CtaM,
-                                   partition.k_begin};
+  cutlass::MatrixCoord tb_offset_A{int(blockIdx.x) * CtaM, partition.k_begin};
   cutlass::MatrixCoord tb_offset_B{partition.k_begin, int(blockIdx.y) * CtaN};
   cutlass::MatrixCoord tb_offset_C{int(blockIdx.x) * CtaM,
                                    int(blockIdx.y) * CtaN};
@@ -442,10 +440,10 @@ void sm70_marlin_nvfp4_gemm_splitk_kernel(
   typename Traits::LayoutA layout_a(lda);
   typename Traits::LayoutC layout_c(n);
 
-  typename Mma::IteratorA iterator_A(
-      typename Mma::IteratorA::Params(layout_a),
-      const_cast<cutlass::half_t*>(a), cutlass::MatrixCoord(m, k), thread_idx,
-      tb_offset_A);
+  typename Mma::IteratorA iterator_A(typename Mma::IteratorA::Params(layout_a),
+                                     const_cast<cutlass::half_t*>(a),
+                                     cutlass::MatrixCoord(m, k), thread_idx,
+                                     tb_offset_A);
   typename Mma::IteratorB iterator_B(
       typename Mma::IteratorB::Params(k, n),
       reinterpret_cast<uint32_t const*>(b_q_weight),
@@ -461,9 +459,8 @@ void sm70_marlin_nvfp4_gemm_splitk_kernel(
   accumulators = scale_accumulators(accumulators, global_scale[0]);
 
   typename AtomicEpilogue::OutputTileIterator iterator_D(
-      typename AtomicEpilogue::OutputTileIterator::Params(layout_c),
-      c, cutlass::MatrixCoord(m, n),
-      thread_idx, tb_offset_C);
+      typename AtomicEpilogue::OutputTileIterator::Params(layout_c), c,
+      cutlass::MatrixCoord(m, n), thread_idx, tb_offset_C);
 
   AtomicEpilogue epilogue(shared_storage.epilogue, thread_idx, warp_idx,
                           lane_idx);
@@ -472,18 +469,18 @@ void sm70_marlin_nvfp4_gemm_splitk_kernel(
 
 }  // namespace
 
-template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM,
-          int WarpN, int WarpK, int GroupSize, int PackedMacroN>
+template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM, int WarpN,
+          int WarpK, int GroupSize, int PackedMacroN>
 torch::Tensor launch_sm70_marlin_nvfp4_gemm(
     torch::Tensor& a, torch::Tensor& c, torch::Tensor& b_q_weight,
     torch::Tensor& b_scales, torch::Tensor& global_scale, int64_t size_m,
     int64_t size_n, int64_t size_k, int requested_split_k) {
   auto kernel =
-      sm70_marlin_nvfp4_gemm_kernel<CtaM, CtaN, CtaK, Warps, WarpM, WarpN, WarpK,
-                  GroupSize, PackedMacroN>;
-  using SharedStorage = typename Sm70Nvfp4GemmTraits<
-      CtaM, CtaN, CtaK, Warps, WarpM, WarpN, WarpK, GroupSize,
-      PackedMacroN>::SharedStorage;
+      sm70_marlin_nvfp4_gemm_kernel<CtaM, CtaN, CtaK, Warps, WarpM, WarpN,
+                                    WarpK, GroupSize, PackedMacroN>;
+  using SharedStorage =
+      typename Sm70Nvfp4GemmTraits<CtaM, CtaN, CtaK, Warps, WarpM, WarpN, WarpK,
+                                   GroupSize, PackedMacroN>::SharedStorage;
   size_t smem_bytes = configure_sm70_dynamic_smem<SharedStorage>(kernel);
 
   dim3 block(Warps * 32);
@@ -504,19 +501,18 @@ torch::Tensor launch_sm70_marlin_nvfp4_gemm(
   }
 
   TORCH_CHECK(size_k % int64_t(CtaK) == 0,
-              "SM70 Marlin nvfp4 requires K divisible by CTA_K=",
-              CtaK, " for requested_split_k > 1. Got K=", size_k,
+              "SM70 Marlin nvfp4 requires K divisible by CTA_K=", CtaK,
+              " for requested_split_k > 1. Got K=", size_k,
               ", requested_split_k=", requested_split_k, ".");
 
-  auto split_kernel =
-      sm70_marlin_nvfp4_gemm_splitk_kernel<CtaM, CtaN, CtaK, Warps, WarpM, WarpN,
-                  WarpK, GroupSize, PackedMacroN>;
+  auto split_kernel = sm70_marlin_nvfp4_gemm_splitk_kernel<
+      CtaM, CtaN, CtaK, Warps, WarpM, WarpN, WarpK, GroupSize, PackedMacroN>;
   smem_bytes = configure_sm70_dynamic_smem<SharedStorage>(split_kernel);
 
   int64_t const numel = size_m * size_n;
-  C10_CUDA_CHECK(cudaMemsetAsync(
-      c.data_ptr<at::Half>(), 0,
-      static_cast<size_t>(numel) * sizeof(at::Half), stream));
+  C10_CUDA_CHECK(cudaMemsetAsync(c.data_ptr<at::Half>(), 0,
+                                 static_cast<size_t>(numel) * sizeof(at::Half),
+                                 stream));
 
   dim3 grid = sm70_marlin_cta_grid(size_m, size_n, CtaM, CtaN);
   int const active_split_k =
@@ -529,7 +525,8 @@ torch::Tensor launch_sm70_marlin_nvfp4_gemm(
       reinterpret_cast<float const*>(global_scale.data_ptr<float>()),
       reinterpret_cast<cutlass::half_t*>(c.data_ptr<at::Half>()),
       static_cast<int>(size_m), static_cast<int>(size_n),
-      static_cast<int>(size_k), static_cast<int>(a.stride(0)), requested_split_k);
+      static_cast<int>(size_k), static_cast<int>(a.stride(0)),
+      requested_split_k);
   C10_CUDA_KERNEL_LAUNCH_CHECK();
 
   return c;
@@ -546,11 +543,11 @@ struct Sm70Nvfp4Launcher {
   int64_t size_k;
   int requested_split_k;
 
-  template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM,
-            int WarpN, int WarpK, int GroupSize, int PackedMacroN>
+  template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM, int WarpN,
+            int WarpK, int GroupSize, int PackedMacroN>
   torch::Tensor operator()() const {
-    return launch_sm70_marlin_nvfp4_gemm<CtaM, CtaN, CtaK, Warps, WarpM, WarpN, WarpK,
-                  GroupSize, PackedMacroN>(
+    return launch_sm70_marlin_nvfp4_gemm<CtaM, CtaN, CtaK, Warps, WarpM, WarpN,
+                                         WarpK, GroupSize, PackedMacroN>(
         a, c, b_q_weight, b_scales, global_scale, size_m, size_n, size_k,
         requested_split_k);
   }
@@ -564,14 +561,22 @@ torch::Tensor sm70_marlin_nvfp4_gemm(torch::Tensor& a, torch::Tensor& c,
                                      int64_t size_k, int64_t group_size) {
   c10::cuda::CUDAGuard device_guard(a.device());
 
-  auto const params = sm70_marlin_dense_auto_params(
-      "nvfp4", group_size, size_m, size_n, size_k);
+  auto const params = sm70_marlin_dense_auto_params("nvfp4", group_size, size_m,
+                                                    size_n, size_k);
   Sm70CtaGeometry const geometry = params.geometry;
-  validate_sm70_marlin_dense_cta_geometry_supported("SM70 Marlin nvfp4", geometry);
-  validate_sm70_marlin_dense_cta_n_alignment("SM70 Marlin nvfp4", geometry, size_n);
-  Sm70Nvfp4Launcher const launcher{
-      a, c, b_q_weight, b_scales, global_scale, size_m, size_n, size_k,
-      params.requested_split_k};
+  validate_sm70_marlin_dense_cta_geometry_supported("SM70 Marlin nvfp4",
+                                                    geometry);
+  validate_sm70_marlin_dense_cta_n_alignment("SM70 Marlin nvfp4", geometry,
+                                             size_n);
+  Sm70Nvfp4Launcher const launcher{a,
+                                   c,
+                                   b_q_weight,
+                                   b_scales,
+                                   global_scale,
+                                   size_m,
+                                   size_n,
+                                   size_k,
+                                   params.requested_split_k};
   return dispatch_sm70_marlin_fixed_group_geometry<16>(
       launcher, geometry, params.packed_macro_n, group_size, "nvfp4");
 }

--- a/csrc/quantization/marlin/sm70_marlin_splitk.cuh
+++ b/csrc/quantization/marlin/sm70_marlin_splitk.cuh
@@ -22,9 +22,7 @@ int sm70_splitk_ceil_div_int(int numerator, int denominator) {
 }
 
 CUTLASS_HOST_DEVICE
-int sm70_splitk_min_int(int lhs, int rhs) {
-  return lhs < rhs ? lhs : rhs;
-}
+int sm70_splitk_min_int(int lhs, int rhs) { return lhs < rhs ? lhs : rhs; }
 
 template <int GroupSize, int CtaK = kCtaK>
 CUTLASS_HOST_DEVICE int sm70_splitk_group_tiles() {
@@ -76,8 +74,8 @@ int sm70_splitk_partition_tile_count(int remaining_tiles,
 }
 
 template <int GroupSize, int CtaK = kCtaK>
-CUTLASS_HOST_DEVICE Sm70SplitKPartition sm70_splitk_partition(
-    int k, int requested_split_k, int partition_idx) {
+CUTLASS_HOST_DEVICE Sm70SplitKPartition
+sm70_splitk_partition(int k, int requested_split_k, int partition_idx) {
   int const active_split_k = sm70_active_split_k(k, requested_split_k, CtaK);
   if (partition_idx >= active_split_k) {
     return {0, 0};
@@ -135,10 +133,9 @@ class Sm70AtomicFp16Epilogue {
           int const frag_row_idx =
               row + ThreadMap::Iterations::kRow *
                         (group + ThreadMap::Iterations::kGroup * cluster);
-          int const row_offset =
-              row * ThreadMap::Delta::kRow +
-              group * ThreadMap::Delta::kGroup +
-              cluster * ThreadMap::Delta::kCluster;
+          int const row_offset = row * ThreadMap::Delta::kRow +
+                                 group * ThreadMap::Delta::kGroup +
+                                 cluster * ThreadMap::Delta::kCluster;
           int const logical_row = thread_start_row + row_offset;
 
           CUTLASS_PRAGMA_UNROLL
@@ -168,7 +165,7 @@ class Sm70AtomicFp16Epilogue {
  public:
   CUTLASS_DEVICE
   Sm70AtomicFp16Epilogue(SharedStorage& shared_storage, int thread_idx,
-                              int warp_idx, int lane_idx)
+                         int warp_idx, int lane_idx)
       : warp_tile_iterator_(shared_storage.reference(), lane_idx),
         shared_load_iterator_(shared_storage.reference(), thread_idx) {
     using WarpCount = typename CutlassEpilogue::WarpCount;
@@ -177,8 +174,7 @@ class Sm70AtomicFp16Epilogue {
     int const warp_m = warp_mn % WarpCount::kM;
     int const warp_n = warp_mn / WarpCount::kM;
 
-    cutlass::MatrixCoord warp_offset{warp_k * WarpCount::kM + warp_m,
-                                     warp_n};
+    cutlass::MatrixCoord warp_offset{warp_k * WarpCount::kM + warp_m, warp_n};
     warp_tile_iterator_.add_tile_offset(warp_offset);
   }
 
@@ -220,8 +216,7 @@ class Sm70AtomicFp16Epilogue {
             CutlassEpilogue::kSmemPointerOffset);
       }
 
-      atomic_store_fragment(destination_iterator, aligned_accum_fragment, c,
-                            n);
+      atomic_store_fragment(destination_iterator, aligned_accum_fragment, c, n);
       ++destination_iterator;
     }
   }

--- a/csrc/quantization/marlin/sm70_marlin_u4_gemm.cu
+++ b/csrc/quantization/marlin/sm70_marlin_u4_gemm.cu
@@ -20,23 +20,23 @@
 #include "cutlass/layout/tensor_op_multiplicand_sm70.h"
 #include "cutlass/transform/threadblock/predicated_tile_iterator.h"
 
-using marlin::sm70::Sm70CtaGeometry;
-using marlin::sm70::Sm70AtomicFp16Epilogue;
-using marlin::sm70::Sm70MarlinGemmTraits;
-using marlin::sm70::Sm70SplitKPartition;
-using marlin::sm70::validate_sm70_marlin_dense_cta_geometry_supported;
-using marlin::sm70::validate_sm70_marlin_dense_cta_n_alignment;
 using marlin::sm70::configure_sm70_dynamic_smem;
 using marlin::sm70::dispatch_sm70_marlin_geometry;
 using marlin::sm70::kQuantTileK;
 using marlin::sm70::kQuantTileN;
-using marlin::sm70::sm70_marlin_dense_auto_params;
 using marlin::sm70::load_qword_vector;
 using marlin::sm70::qword_from_vector;
-using marlin::sm70::sm70_marlin_cta_grid;
 using marlin::sm70::sm70_active_split_k;
+using marlin::sm70::sm70_marlin_cta_grid;
+using marlin::sm70::sm70_marlin_dense_auto_params;
 using marlin::sm70::sm70_splitk_partition;
+using marlin::sm70::Sm70AtomicFp16Epilogue;
+using marlin::sm70::Sm70CtaGeometry;
+using marlin::sm70::Sm70MarlinGemmTraits;
+using marlin::sm70::Sm70SplitKPartition;
 using marlin::sm70::u4_packed_macro_n_qweight_offset_from_logical;
+using marlin::sm70::validate_sm70_marlin_dense_cta_geometry_supported;
+using marlin::sm70::validate_sm70_marlin_dense_cta_n_alignment;
 
 namespace {
 
@@ -52,12 +52,11 @@ class Sm70U4ZpIteratorB {
   static int const kPackedMacroN = PackedMacroN_;
   static constexpr bool kUseMetadataVectorWords = UseMetadataVectorWords_;
   using Element = cutlass::half_t;
-  using Fragment = cutlass::Array<
-      Element, ThreadMap::Iterations::kCount * ThreadMap::kElementsPerAccess>;
+  using Fragment = cutlass::Array<Element, ThreadMap::Iterations::kCount *
+                                               ThreadMap::kElementsPerAccess>;
   static_assert(Shape::kN == 64 || Shape::kN == 128 || Shape::kN == 256,
                 "SM70 Marlin U4 IteratorB expects CTA_N in {64, 128, 256}.");
-  static_assert(ThreadMap::Iterations::kContiguous ==
-                    Shape::kN / kQuantTileN,
+  static_assert(ThreadMap::Iterations::kContiguous == Shape::kN / kQuantTileN,
                 "SM70 Marlin U4 IteratorB expects one contiguous iteration per "
                 "64-column quant tile.");
   static_assert(ThreadMap::Delta::kContiguous == kQuantTileN,
@@ -66,7 +65,8 @@ class Sm70U4ZpIteratorB {
                 "SM70 Marlin U4 IteratorB expects one packed int4 word per "
                 "access.");
   static_assert(ThreadMap::Iterations::kStrided >= 1,
-                "SM70 Marlin U4-family IteratorB expects one or more strided iterations.");
+                "SM70 Marlin U4-family IteratorB expects one or more strided "
+                "iterations.");
   struct Params {
     int size_n;
     int aligned_initial_k_step;
@@ -113,7 +113,7 @@ class Sm70U4ZpIteratorB {
     qweight_base_offset_ =
         qweight_offset_from_logical(params_, logical_k, logical_n);
     if constexpr (kGroupSize == -1) {
-        cache_current_group_metadata(0);
+      cache_current_group_metadata(0);
     }
   }
 
@@ -149,8 +149,7 @@ class Sm70U4ZpIteratorB {
     if constexpr (kGroupSize == -1) {
       return 0;
     } else {
-      static_assert(kGroupSize == 32 || kGroupSize == 64 ||
-                        kGroupSize == 128,
+      static_assert(kGroupSize == 32 || kGroupSize == 64 || kGroupSize == 128,
                     "SM70 Marlin U4 supports only group sizes "
                     "-1, 32, 64, and 128.");
       return logical_k / kGroupSize;
@@ -160,8 +159,8 @@ class Sm70U4ZpIteratorB {
   CUTLASS_DEVICE
   static int qweight_offset_from_logical(Params const& params, int logical_k,
                                          int logical_n) {
-    return u4_packed_macro_n_qweight_offset_from_logical<kPackedMacroN>(params.size_n, logical_k,
-                                                  logical_n);
+    return u4_packed_macro_n_qweight_offset_from_logical<kPackedMacroN>(
+        params.size_n, logical_k, logical_n);
   }
 
   CUTLASS_DEVICE
@@ -174,8 +173,8 @@ class Sm70U4ZpIteratorB {
     scale_cache[2] = scale_vec[2];
     scale_cache[3] = scale_vec[3];
 
-    half2 const* zp_vec = reinterpret_cast<half2 const*>(
-        zp_ + group * params_.size_n + cache_n);
+    half2 const* zp_vec =
+        reinterpret_cast<half2 const*>(zp_ + group * params_.size_n + cache_n);
     half2* zp_cache = cached_zp_ + c * 4;
     zp_cache[0] = zp_vec[0];
     zp_cache[1] = zp_vec[1];
@@ -194,8 +193,8 @@ class Sm70U4ZpIteratorB {
     scale_cache[2] = scale_vec[2];
     scale_cache[3] = scale_vec[3];
 
-    uint4 const zp_words = *reinterpret_cast<uint4 const*>(
-        zp_ + group * params_.size_n + cache_n);
+    uint4 const zp_words =
+        *reinterpret_cast<uint4 const*>(zp_ + group * params_.size_n + cache_n);
     half2 const* zp_vec = reinterpret_cast<half2 const*>(&zp_words);
     half2* zp_cache = cached_zp_ + c * 4;
     zp_cache[0] = zp_vec[0];
@@ -208,9 +207,8 @@ class Sm70U4ZpIteratorB {
   void cache_current_group_metadata(int group) const {
     CUTLASS_PRAGMA_UNROLL
     for (int c = 0; c < ThreadMap::Iterations::kContiguous; ++c) {
-      int const cache_n =
-          n_offset_ + thread_offset_.contiguous() +
-          c * ThreadMap::Delta::kContiguous;
+      int const cache_n = n_offset_ + thread_offset_.contiguous() +
+                          c * ThreadMap::Delta::kContiguous;
       if constexpr (kUseMetadataVectorWords) {
         cache_metadata_vector_words(c, group, cache_n);
       } else {
@@ -235,8 +233,8 @@ class Sm70U4ZpIteratorB {
 
           half2 deq[2];
           half2* frag_vec = reinterpret_cast<half2*>(frag.data() + frag_base);
-          marlin::dequant<half2, vllm::kU4.id(), false>(
-              static_cast<int>(qword), deq);
+          marlin::dequant<half2, vllm::kU4.id(), false>(static_cast<int>(qword),
+                                                        deq);
           frag_vec[0] = __hfma2(deq[0], scale_vec[0], __hneg2(zp_vec[0]));
           frag_vec[1] = __hfma2(deq[1], scale_vec[1], __hneg2(zp_vec[1]));
           marlin::dequant<half2, vllm::kU4.id(), false>(
@@ -257,8 +255,8 @@ class Sm70U4ZpIteratorB {
 
           half2 deq[2];
           half2* frag_vec = reinterpret_cast<half2*>(frag.data() + frag_base);
-          marlin::dequant<half2, vllm::kU4.id(), false>(
-              static_cast<int>(qword), deq);
+          marlin::dequant<half2, vllm::kU4.id(), false>(static_cast<int>(qword),
+                                                        deq);
           frag_vec[0] = __hfma2(deq[0], scale_vec[0], __hneg2(zp_vec[0]));
           frag_vec[1] = __hfma2(deq[1], scale_vec[1], __hneg2(zp_vec[1]));
           marlin::dequant<half2, vllm::kU4.id(), false>(
@@ -269,14 +267,15 @@ class Sm70U4ZpIteratorB {
       } else {
         static_assert(ThreadMap::Iterations::kContiguous == 1,
                       "Unsupported SM70 Marlin U4 contiguous iteration count.");
-        uint32_t const qword = load_qword_vector<1>(qweight_ + qweight_base_offset_);
+        uint32_t const qword =
+            load_qword_vector<1>(qweight_ + qweight_base_offset_);
         half2 const* scale_vec = cached_scales_;
         half2 const* zp_vec = cached_zp_;
 
         half2 deq[2];
         half2* frag_vec = reinterpret_cast<half2*>(frag.data());
-        marlin::dequant<half2, vllm::kU4.id(), false>(
-            static_cast<int>(qword), deq);
+        marlin::dequant<half2, vllm::kU4.id(), false>(static_cast<int>(qword),
+                                                      deq);
         frag_vec[0] = __hfma2(deq[0], scale_vec[0], __hneg2(zp_vec[0]));
         frag_vec[1] = __hfma2(deq[1], scale_vec[1], __hneg2(zp_vec[1]));
         marlin::dequant<half2, vllm::kU4.id(), false>(
@@ -288,17 +287,15 @@ class Sm70U4ZpIteratorB {
       int const logical_n_base = n_offset_ + thread_offset_.contiguous();
       CUTLASS_PRAGMA_UNROLL
       for (int s = 0; s < ThreadMap::Iterations::kStrided; ++s) {
-        int const logical_k_s =
-            k_offset_ + thread_offset_.strided() +
-            s * ThreadMap::Delta::kStrided;
+        int const logical_k_s = k_offset_ + thread_offset_.strided() +
+                                s * ThreadMap::Delta::kStrided;
         if constexpr (kGroupSize != -1) {
           cache_current_group_metadata(scale_group(logical_k_s));
         }
         int const qweight_base_s =
             qweight_offset_from_logical(params_, logical_k_s, logical_n_base);
         if constexpr (ThreadMap::Iterations::kContiguous == 4) {
-          auto const qwords =
-              load_qword_vector<4>(qweight_ + qweight_base_s);
+          auto const qwords = load_qword_vector<4>(qweight_ + qweight_base_s);
           CUTLASS_PRAGMA_UNROLL
           for (int c = 0; c < ThreadMap::Iterations::kContiguous; ++c) {
             constexpr int kAccess = ThreadMap::kElementsPerAccess;
@@ -312,20 +309,15 @@ class Sm70U4ZpIteratorB {
             half2* frag_vec = reinterpret_cast<half2*>(frag.data() + frag_base);
             marlin::dequant<half2, vllm::kU4.id(), false>(
                 static_cast<int>(qword), deq);
-            frag_vec[0] =
-                __hfma2(deq[0], scale_vec[0], __hneg2(zp_vec[0]));
-            frag_vec[1] =
-                __hfma2(deq[1], scale_vec[1], __hneg2(zp_vec[1]));
+            frag_vec[0] = __hfma2(deq[0], scale_vec[0], __hneg2(zp_vec[0]));
+            frag_vec[1] = __hfma2(deq[1], scale_vec[1], __hneg2(zp_vec[1]));
             marlin::dequant<half2, vllm::kU4.id(), false>(
                 static_cast<int>(qword >> 8), deq);
-            frag_vec[2] =
-                __hfma2(deq[0], scale_vec[2], __hneg2(zp_vec[2]));
-            frag_vec[3] =
-                __hfma2(deq[1], scale_vec[3], __hneg2(zp_vec[3]));
+            frag_vec[2] = __hfma2(deq[0], scale_vec[2], __hneg2(zp_vec[2]));
+            frag_vec[3] = __hfma2(deq[1], scale_vec[3], __hneg2(zp_vec[3]));
           }
         } else if constexpr (ThreadMap::Iterations::kContiguous == 2) {
-          auto const qwords =
-              load_qword_vector<2>(qweight_ + qweight_base_s);
+          auto const qwords = load_qword_vector<2>(qweight_ + qweight_base_s);
           CUTLASS_PRAGMA_UNROLL
           for (int c = 0; c < ThreadMap::Iterations::kContiguous; ++c) {
             constexpr int kAccess = ThreadMap::kElementsPerAccess;
@@ -339,21 +331,19 @@ class Sm70U4ZpIteratorB {
             half2* frag_vec = reinterpret_cast<half2*>(frag.data() + frag_base);
             marlin::dequant<half2, vllm::kU4.id(), false>(
                 static_cast<int>(qword), deq);
-            frag_vec[0] =
-                __hfma2(deq[0], scale_vec[0], __hneg2(zp_vec[0]));
-            frag_vec[1] =
-                __hfma2(deq[1], scale_vec[1], __hneg2(zp_vec[1]));
+            frag_vec[0] = __hfma2(deq[0], scale_vec[0], __hneg2(zp_vec[0]));
+            frag_vec[1] = __hfma2(deq[1], scale_vec[1], __hneg2(zp_vec[1]));
             marlin::dequant<half2, vllm::kU4.id(), false>(
                 static_cast<int>(qword >> 8), deq);
-            frag_vec[2] =
-                __hfma2(deq[0], scale_vec[2], __hneg2(zp_vec[2]));
-            frag_vec[3] =
-                __hfma2(deq[1], scale_vec[3], __hneg2(zp_vec[3]));
+            frag_vec[2] = __hfma2(deq[0], scale_vec[2], __hneg2(zp_vec[2]));
+            frag_vec[3] = __hfma2(deq[1], scale_vec[3], __hneg2(zp_vec[3]));
           }
         } else {
-          static_assert(ThreadMap::Iterations::kContiguous == 1,
-                        "Unsupported SM70 Marlin U4 contiguous iteration count.");
-          uint32_t const qword = load_qword_vector<1>(qweight_ + qweight_base_s);
+          static_assert(
+              ThreadMap::Iterations::kContiguous == 1,
+              "Unsupported SM70 Marlin U4 contiguous iteration count.");
+          uint32_t const qword =
+              load_qword_vector<1>(qweight_ + qweight_base_s);
           constexpr int kAccess = ThreadMap::kElementsPerAccess;
           int const frag_base = s * kAccess;
           half2 const* scale_vec = cached_scales_;
@@ -361,8 +351,8 @@ class Sm70U4ZpIteratorB {
 
           half2 deq[2];
           half2* frag_vec = reinterpret_cast<half2*>(frag.data() + frag_base);
-          marlin::dequant<half2, vllm::kU4.id(), false>(
-              static_cast<int>(qword), deq);
+          marlin::dequant<half2, vllm::kU4.id(), false>(static_cast<int>(qword),
+                                                        deq);
           frag_vec[0] = __hfma2(deq[0], scale_vec[0], __hneg2(zp_vec[0]));
           frag_vec[1] = __hfma2(deq[1], scale_vec[1], __hneg2(zp_vec[1]));
           marlin::dequant<half2, vllm::kU4.id(), false>(
@@ -380,8 +370,7 @@ class Sm70U4ZpIteratorB {
       return;
     }
 
-    if constexpr (kGroupSize != -1 &&
-                  ThreadMap::Iterations::kStrided == 1) {
+    if constexpr (kGroupSize != -1 && ThreadMap::Iterations::kStrided == 1) {
       int const first_logical_k = k_offset_ + thread_offset_.strided();
       cache_current_group_metadata(scale_group(first_logical_k));
     }
@@ -393,32 +382,30 @@ class Sm70U4ZpIteratorB {
 template <bool UseMetadataVectorWords = true>
 struct Sm70U4ZpGemmSpec {
   template <typename Shape, typename ThreadMap, int GroupSize, int PackedMacroN>
-  using IteratorB =
-      Sm70U4ZpIteratorB<Shape, ThreadMap, GroupSize, PackedMacroN,
-                        UseMetadataVectorWords>;
+  using IteratorB = Sm70U4ZpIteratorB<Shape, ThreadMap, GroupSize, PackedMacroN,
+                                      UseMetadataVectorWords>;
 };
 
-template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM,
-          int WarpN, int WarpK, int GroupSize, int PackedMacroN,
+template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM, int WarpN,
+          int WarpK, int GroupSize, int PackedMacroN,
           bool UseMetadataVectorWords = true>
 using Sm70U4ZpGemmTraits =
-    Sm70MarlinGemmTraits<Sm70U4ZpGemmSpec<UseMetadataVectorWords>, CtaM,
-                         CtaN, CtaK, Warps, WarpM, WarpN, WarpK,
-                         GroupSize, PackedMacroN>;
+    Sm70MarlinGemmTraits<Sm70U4ZpGemmSpec<UseMetadataVectorWords>, CtaM, CtaN,
+                         CtaK, Warps, WarpM, WarpN, WarpK, GroupSize,
+                         PackedMacroN>;
 
-template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM,
-          int WarpN, int WarpK, int GroupSize, int PackedMacroN,
+template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM, int WarpN,
+          int WarpK, int GroupSize, int PackedMacroN,
           bool UseMetadataVectorWords = true>
-__global__ __launch_bounds__(Warps * 32, 1)
-void sm70_marlin_u4_gemm_kernel(
+__global__ __launch_bounds__(Warps * 32, 1) void sm70_marlin_u4_gemm_kernel(
     cutlass::half_t const* __restrict__ a,
     uint32_t const* __restrict__ b_q_weight,
     cutlass::half_t const* __restrict__ b_scales,
     cutlass::half_t const* __restrict__ b_zeros,
     cutlass::half_t* __restrict__ c, int m, int n, int k, int lda) {
-  using Traits = Sm70U4ZpGemmTraits<CtaM, CtaN, CtaK, Warps, WarpM,
-                                    WarpN, WarpK, GroupSize, PackedMacroN,
-                                    UseMetadataVectorWords>;
+  using Traits =
+      Sm70U4ZpGemmTraits<CtaM, CtaN, CtaK, Warps, WarpM, WarpN, WarpK,
+                         GroupSize, PackedMacroN, UseMetadataVectorWords>;
   using Mma = typename Traits::Mma;
   using Epilogue = typename Traits::Epilogue;
 
@@ -438,10 +425,10 @@ void sm70_marlin_u4_gemm_kernel(
   typename Traits::LayoutA layout_a(lda);
   typename Traits::LayoutC layout_c(n);
 
-  typename Mma::IteratorA iterator_A(
-      typename Mma::IteratorA::Params(layout_a),
-      const_cast<cutlass::half_t*>(a), cutlass::MatrixCoord(m, k), thread_idx,
-      tb_offset_A);
+  typename Mma::IteratorA iterator_A(typename Mma::IteratorA::Params(layout_a),
+                                     const_cast<cutlass::half_t*>(a),
+                                     cutlass::MatrixCoord(m, k), thread_idx,
+                                     tb_offset_A);
   typename Mma::IteratorB iterator_B(
       typename Mma::IteratorB::Params(k, n),
       reinterpret_cast<uint32_t const*>(b_q_weight),
@@ -467,19 +454,20 @@ void sm70_marlin_u4_gemm_kernel(
   epilogue(output_op, iterator_D, accumulators, iterator_C);
 }
 
-template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM,
-          int WarpN, int WarpK, int GroupSize, int PackedMacroN,
+template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM, int WarpN,
+          int WarpK, int GroupSize, int PackedMacroN,
           bool UseMetadataVectorWords = true>
-__global__ __launch_bounds__(Warps * 32, 1)
-void sm70_marlin_u4_gemm_splitk_kernel(
+__global__
+__launch_bounds__(Warps * 32, 1) void sm70_marlin_u4_gemm_splitk_kernel(
     cutlass::half_t const* __restrict__ a,
     uint32_t const* __restrict__ b_q_weight,
     cutlass::half_t const* __restrict__ b_scales,
     cutlass::half_t const* __restrict__ b_zeros,
-    cutlass::half_t* __restrict__ c, int m, int n, int k, int lda, int requested_split_k) {
-  using Traits = Sm70U4ZpGemmTraits<CtaM, CtaN, CtaK, Warps, WarpM,
-                                    WarpN, WarpK, GroupSize, PackedMacroN,
-                                    UseMetadataVectorWords>;
+    cutlass::half_t* __restrict__ c, int m, int n, int k, int lda,
+    int requested_split_k) {
+  using Traits =
+      Sm70U4ZpGemmTraits<CtaM, CtaN, CtaK, Warps, WarpM, WarpN, WarpK,
+                         GroupSize, PackedMacroN, UseMetadataVectorWords>;
   using Mma = typename Traits::Mma;
   using AtomicEpilogue = Sm70AtomicFp16Epilogue<Traits>;
 
@@ -490,14 +478,13 @@ void sm70_marlin_u4_gemm_splitk_kernel(
   int const thread_idx = threadIdx.x;
   int const warp_idx = cutlass::canonical_warp_idx_sync();
   int const lane_idx = threadIdx.x % 32;
-  Sm70SplitKPartition const partition =
-      sm70_splitk_partition<GroupSize, CtaK>(k, requested_split_k, int(blockIdx.z));
+  Sm70SplitKPartition const partition = sm70_splitk_partition<GroupSize, CtaK>(
+      k, requested_split_k, int(blockIdx.z));
   if (partition.partition_k == 0) {
     return;
   }
 
-  cutlass::MatrixCoord tb_offset_A{int(blockIdx.x) * CtaM,
-                                   partition.k_begin};
+  cutlass::MatrixCoord tb_offset_A{int(blockIdx.x) * CtaM, partition.k_begin};
   cutlass::MatrixCoord tb_offset_B{partition.k_begin, int(blockIdx.y) * CtaN};
   cutlass::MatrixCoord tb_offset_C{int(blockIdx.x) * CtaM,
                                    int(blockIdx.y) * CtaN};
@@ -505,10 +492,10 @@ void sm70_marlin_u4_gemm_splitk_kernel(
   typename Traits::LayoutA layout_a(lda);
   typename Traits::LayoutC layout_c(n);
 
-  typename Mma::IteratorA iterator_A(
-      typename Mma::IteratorA::Params(layout_a),
-      const_cast<cutlass::half_t*>(a), cutlass::MatrixCoord(m, k), thread_idx,
-      tb_offset_A);
+  typename Mma::IteratorA iterator_A(typename Mma::IteratorA::Params(layout_a),
+                                     const_cast<cutlass::half_t*>(a),
+                                     cutlass::MatrixCoord(m, k), thread_idx,
+                                     tb_offset_A);
   typename Mma::IteratorB iterator_B(
       typename Mma::IteratorB::Params(k, n),
       reinterpret_cast<uint32_t const*>(b_q_weight),
@@ -523,9 +510,8 @@ void sm70_marlin_u4_gemm_splitk_kernel(
   mma(gemm_k_iterations, accumulators, iterator_A, iterator_B, accumulators);
 
   typename AtomicEpilogue::OutputTileIterator iterator_D(
-      typename AtomicEpilogue::OutputTileIterator::Params(layout_c),
-      c, cutlass::MatrixCoord(m, n),
-      thread_idx, tb_offset_C);
+      typename AtomicEpilogue::OutputTileIterator::Params(layout_c), c,
+      cutlass::MatrixCoord(m, n), thread_idx, tb_offset_C);
 
   AtomicEpilogue epilogue(shared_storage.epilogue, thread_idx, warp_idx,
                           lane_idx);
@@ -534,19 +520,23 @@ void sm70_marlin_u4_gemm_splitk_kernel(
 
 }  // namespace
 
-template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM,
-          int WarpN, int WarpK, int GroupSize, int PackedMacroN,
+template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM, int WarpN,
+          int WarpK, int GroupSize, int PackedMacroN,
           bool UseMetadataVectorWords = true>
-torch::Tensor launch_sm70_marlin_u4_gemm(
-    torch::Tensor& a, torch::Tensor& c, torch::Tensor& b_q_weight,
-    torch::Tensor& b_scales, torch::Tensor& b_zeros, int64_t size_m,
-    int64_t size_n, int64_t size_k, int requested_split_k) {
-  auto kernel = sm70_marlin_u4_gemm_kernel<CtaM, CtaN, CtaK, Warps, WarpM, WarpN, WarpK,
-                                           GroupSize, PackedMacroN,
-                                           UseMetadataVectorWords>;
-  using SharedStorage = typename Sm70U4ZpGemmTraits<
-      CtaM, CtaN, CtaK, Warps, WarpM, WarpN, WarpK, GroupSize,
-      PackedMacroN, UseMetadataVectorWords>::SharedStorage;
+torch::Tensor launch_sm70_marlin_u4_gemm(torch::Tensor& a, torch::Tensor& c,
+                                         torch::Tensor& b_q_weight,
+                                         torch::Tensor& b_scales,
+                                         torch::Tensor& b_zeros, int64_t size_m,
+                                         int64_t size_n, int64_t size_k,
+                                         int requested_split_k) {
+  auto kernel =
+      sm70_marlin_u4_gemm_kernel<CtaM, CtaN, CtaK, Warps, WarpM, WarpN, WarpK,
+                                 GroupSize, PackedMacroN,
+                                 UseMetadataVectorWords>;
+  using SharedStorage =
+      typename Sm70U4ZpGemmTraits<CtaM, CtaN, CtaK, Warps, WarpM, WarpN, WarpK,
+                                  GroupSize, PackedMacroN,
+                                  UseMetadataVectorWords>::SharedStorage;
   size_t smem_bytes = configure_sm70_dynamic_smem<SharedStorage>(kernel);
   dim3 block(Warps * 32);
   cudaStream_t stream = at::cuda::getCurrentCUDAStream(a.get_device()).stream();
@@ -556,8 +546,7 @@ torch::Tensor launch_sm70_marlin_u4_gemm(
     kernel<<<grid, block, smem_bytes, stream>>>(
         reinterpret_cast<cutlass::half_t const*>(a.data_ptr<at::Half>()),
         reinterpret_cast<uint32_t const*>(b_q_weight.data_ptr<int32_t>()),
-        reinterpret_cast<cutlass::half_t const*>(
-            b_scales.data_ptr<at::Half>()),
+        reinterpret_cast<cutlass::half_t const*>(b_scales.data_ptr<at::Half>()),
         reinterpret_cast<cutlass::half_t const*>(b_zeros.data_ptr<at::Half>()),
         reinterpret_cast<cutlass::half_t*>(c.data_ptr<at::Half>()),
         static_cast<int>(size_m), static_cast<int>(size_n),
@@ -567,8 +556,8 @@ torch::Tensor launch_sm70_marlin_u4_gemm(
   }
 
   TORCH_CHECK(size_k % int64_t(CtaK) == 0,
-              "SM70 Marlin uint4 requires K divisible by CTA_K=",
-              CtaK, " for requested_split_k > 1. Got K=", size_k,
+              "SM70 Marlin uint4 requires K divisible by CTA_K=", CtaK,
+              " for requested_split_k > 1. Got K=", size_k,
               ", requested_split_k=", requested_split_k, ".");
 
   auto split_kernel =
@@ -578,9 +567,9 @@ torch::Tensor launch_sm70_marlin_u4_gemm(
   smem_bytes = configure_sm70_dynamic_smem<SharedStorage>(split_kernel);
 
   int64_t const numel = size_m * size_n;
-  C10_CUDA_CHECK(cudaMemsetAsync(
-      c.data_ptr<at::Half>(), 0,
-      static_cast<size_t>(numel) * sizeof(at::Half), stream));
+  C10_CUDA_CHECK(cudaMemsetAsync(c.data_ptr<at::Half>(), 0,
+                                 static_cast<size_t>(numel) * sizeof(at::Half),
+                                 stream));
 
   dim3 grid = sm70_marlin_cta_grid(size_m, size_n, CtaM, CtaN);
   int const active_split_k =
@@ -593,7 +582,8 @@ torch::Tensor launch_sm70_marlin_u4_gemm(
       reinterpret_cast<cutlass::half_t const*>(b_zeros.data_ptr<at::Half>()),
       reinterpret_cast<cutlass::half_t*>(c.data_ptr<at::Half>()),
       static_cast<int>(size_m), static_cast<int>(size_n),
-      static_cast<int>(size_k), static_cast<int>(a.stride(0)), requested_split_k);
+      static_cast<int>(size_k), static_cast<int>(a.stride(0)),
+      requested_split_k);
   C10_CUDA_KERNEL_LAUNCH_CHECK();
 
   return c;
@@ -611,38 +601,44 @@ struct Sm70U4Launcher {
   int64_t size_k;
   int requested_split_k;
 
-  template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM,
-            int WarpN, int WarpK, int GroupSize, int PackedMacroN>
+  template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM, int WarpN,
+            int WarpK, int GroupSize, int PackedMacroN>
   torch::Tensor operator()() const {
-    return launch_sm70_marlin_u4_gemm<CtaM, CtaN, CtaK, Warps, WarpM, WarpN, WarpK,
-                                      GroupSize, PackedMacroN,
+    return launch_sm70_marlin_u4_gemm<CtaM, CtaN, CtaK, Warps, WarpM, WarpN,
+                                      WarpK, GroupSize, PackedMacroN,
                                       UseMetadataVectorWords>(
-        a, c, b_q_weight, b_scales, b_zeros, size_m, size_n, size_k, requested_split_k);
+        a, c, b_q_weight, b_scales, b_zeros, size_m, size_n, size_k,
+        requested_split_k);
   }
 };
 
-torch::Tensor sm70_marlin_u4_gemm(
-    torch::Tensor& a, torch::Tensor& c, torch::Tensor& b_q_weight,
-    torch::Tensor& b_scales, torch::Tensor& b_zeros, int64_t size_m,
-    int64_t size_n, int64_t size_k, int64_t group_size) {
+torch::Tensor sm70_marlin_u4_gemm(torch::Tensor& a, torch::Tensor& c,
+                                  torch::Tensor& b_q_weight,
+                                  torch::Tensor& b_scales,
+                                  torch::Tensor& b_zeros, int64_t size_m,
+                                  int64_t size_n, int64_t size_k,
+                                  int64_t group_size) {
   c10::cuda::CUDAGuard device_guard(a.device());
 
-  auto const params =
-      sm70_marlin_dense_auto_params("uint4", group_size, size_m, size_n,
-                                    size_k);
+  auto const params = sm70_marlin_dense_auto_params("uint4", group_size, size_m,
+                                                    size_n, size_k);
   Sm70CtaGeometry const geometry = params.geometry;
-  validate_sm70_marlin_dense_cta_geometry_supported("SM70 Marlin uint4", geometry);
-  validate_sm70_marlin_dense_cta_n_alignment("SM70 Marlin uint4", geometry, size_n);
+  validate_sm70_marlin_dense_cta_geometry_supported("SM70 Marlin uint4",
+                                                    geometry);
+  validate_sm70_marlin_dense_cta_n_alignment("SM70 Marlin uint4", geometry,
+                                             size_n);
   if (params.use_metadata_vector_words) {
     Sm70U4Launcher<true> const launcher{
-        a, c, b_q_weight, b_scales, b_zeros, size_m, size_n,
-        size_k, params.requested_split_k};
+        a,        c,       b_q_weight,
+        b_scales, b_zeros, size_m,
+        size_n,   size_k,  params.requested_split_k};
     return dispatch_sm70_marlin_geometry(
         launcher, geometry, params.packed_macro_n, group_size, "uint4");
   }
   Sm70U4Launcher<false> const launcher{
-      a, c, b_q_weight, b_scales, b_zeros, size_m, size_n,
-      size_k, params.requested_split_k};
+      a,        c,       b_q_weight,
+      b_scales, b_zeros, size_m,
+      size_n,   size_k,  params.requested_split_k};
   return dispatch_sm70_marlin_geometry(
       launcher, geometry, params.packed_macro_n, group_size, "uint4");
 }

--- a/csrc/quantization/marlin/sm70_marlin_u4b8_gemm.cu
+++ b/csrc/quantization/marlin/sm70_marlin_u4b8_gemm.cu
@@ -20,23 +20,23 @@
 #include "cutlass/layout/tensor_op_multiplicand_sm70.h"
 #include "cutlass/transform/threadblock/predicated_tile_iterator.h"
 
-using marlin::sm70::Sm70CtaGeometry;
-using marlin::sm70::Sm70AtomicFp16Epilogue;
-using marlin::sm70::Sm70MarlinGemmTraits;
-using marlin::sm70::Sm70SplitKPartition;
-using marlin::sm70::validate_sm70_marlin_dense_cta_geometry_supported;
-using marlin::sm70::validate_sm70_marlin_dense_cta_n_alignment;
 using marlin::sm70::configure_sm70_dynamic_smem;
 using marlin::sm70::dispatch_sm70_marlin_geometry;
 using marlin::sm70::kQuantTileK;
 using marlin::sm70::kQuantTileN;
-using marlin::sm70::sm70_marlin_dense_auto_params;
 using marlin::sm70::load_qword_vector;
 using marlin::sm70::qword_from_vector;
-using marlin::sm70::sm70_marlin_cta_grid;
 using marlin::sm70::sm70_active_split_k;
+using marlin::sm70::sm70_marlin_cta_grid;
+using marlin::sm70::sm70_marlin_dense_auto_params;
 using marlin::sm70::sm70_splitk_partition;
+using marlin::sm70::Sm70AtomicFp16Epilogue;
+using marlin::sm70::Sm70CtaGeometry;
+using marlin::sm70::Sm70MarlinGemmTraits;
+using marlin::sm70::Sm70SplitKPartition;
 using marlin::sm70::u4_packed_macro_n_qweight_offset_from_logical;
+using marlin::sm70::validate_sm70_marlin_dense_cta_geometry_supported;
+using marlin::sm70::validate_sm70_marlin_dense_cta_n_alignment;
 
 namespace {
 
@@ -52,12 +52,11 @@ class Sm70U4B8IteratorB {
   static int const kPackedMacroN = PackedMacroN_;
   static constexpr bool kUseMetadataVectorWords = UseMetadataVectorWords_;
   using Element = cutlass::half_t;
-  using Fragment = cutlass::Array<
-      Element, ThreadMap::Iterations::kCount * ThreadMap::kElementsPerAccess>;
+  using Fragment = cutlass::Array<Element, ThreadMap::Iterations::kCount *
+                                               ThreadMap::kElementsPerAccess>;
   static_assert(Shape::kN == 64 || Shape::kN == 128 || Shape::kN == 256,
                 "SM70 Marlin U4B8 IteratorB expects CTA_N in {64, 128, 256}.");
-  static_assert(ThreadMap::Iterations::kContiguous ==
-                    Shape::kN / kQuantTileN,
+  static_assert(ThreadMap::Iterations::kContiguous == Shape::kN / kQuantTileN,
                 "SM70 Marlin U4B8 IteratorB expects one contiguous iteration "
                 "per 64-column quant tile.");
   static_assert(ThreadMap::Delta::kContiguous == kQuantTileN,
@@ -66,7 +65,8 @@ class Sm70U4B8IteratorB {
                 "SM70 Marlin U4B8 IteratorB expects one packed int4 word per "
                 "access.");
   static_assert(ThreadMap::Iterations::kStrided >= 1,
-                "SM70 Marlin U4-family IteratorB expects one or more strided iterations.");
+                "SM70 Marlin U4-family IteratorB expects one or more strided "
+                "iterations.");
   struct Params {
     int size_n;
     int aligned_initial_k_step;
@@ -146,8 +146,7 @@ class Sm70U4B8IteratorB {
     if constexpr (kGroupSize == -1) {
       return 0;
     } else {
-      static_assert(kGroupSize == 32 || kGroupSize == 64 ||
-                        kGroupSize == 128,
+      static_assert(kGroupSize == 32 || kGroupSize == 64 || kGroupSize == 128,
                     "SM70 Marlin U4B8 supports only group sizes "
                     "-1, 32, 64, and 128.");
       return logical_k / kGroupSize;
@@ -157,8 +156,8 @@ class Sm70U4B8IteratorB {
   CUTLASS_DEVICE
   static int qweight_offset_from_logical(Params const& params, int logical_k,
                                          int logical_n) {
-    return u4_packed_macro_n_qweight_offset_from_logical<kPackedMacroN>(params.size_n, logical_k,
-                                                  logical_n);
+    return u4_packed_macro_n_qweight_offset_from_logical<kPackedMacroN>(
+        params.size_n, logical_k, logical_n);
   }
 
   CUTLASS_DEVICE
@@ -188,9 +187,8 @@ class Sm70U4B8IteratorB {
   void cache_current_group_metadata(int group) const {
     CUTLASS_PRAGMA_UNROLL
     for (int c = 0; c < ThreadMap::Iterations::kContiguous; ++c) {
-      int const cache_n =
-          n_offset_ + thread_offset_.contiguous() +
-          c * ThreadMap::Delta::kContiguous;
+      int const cache_n = n_offset_ + thread_offset_.contiguous() +
+                          c * ThreadMap::Delta::kContiguous;
       if constexpr (kUseMetadataVectorWords) {
         cache_metadata_vector_words(c, group, cache_n);
       } else {
@@ -245,15 +243,17 @@ class Sm70U4B8IteratorB {
           frag_vec[3] = __hmul2(deq[1], scale_vec[3]);
         }
       } else {
-        static_assert(ThreadMap::Iterations::kContiguous == 1,
-                      "Unsupported SM70 Marlin U4B8 contiguous iteration count.");
-        uint32_t const qword = load_qword_vector<1>(qweight_ + qweight_base_offset_);
+        static_assert(
+            ThreadMap::Iterations::kContiguous == 1,
+            "Unsupported SM70 Marlin U4B8 contiguous iteration count.");
+        uint32_t const qword =
+            load_qword_vector<1>(qweight_ + qweight_base_offset_);
         half2 const* scale_vec = cached_scales_;
 
         half2 deq[2];
         half2* frag_vec = reinterpret_cast<half2*>(frag.data());
-        marlin::dequant<half2, vllm::kU4B8.id(), false>(
-            static_cast<int>(qword), deq);
+        marlin::dequant<half2, vllm::kU4B8.id(), false>(static_cast<int>(qword),
+                                                        deq);
         frag_vec[0] = __hmul2(deq[0], scale_vec[0]);
         frag_vec[1] = __hmul2(deq[1], scale_vec[1]);
         marlin::dequant<half2, vllm::kU4B8.id(), false>(
@@ -265,17 +265,15 @@ class Sm70U4B8IteratorB {
       int const logical_n_base = n_offset_ + thread_offset_.contiguous();
       CUTLASS_PRAGMA_UNROLL
       for (int s = 0; s < ThreadMap::Iterations::kStrided; ++s) {
-        int const logical_k_s =
-            k_offset_ + thread_offset_.strided() +
-            s * ThreadMap::Delta::kStrided;
+        int const logical_k_s = k_offset_ + thread_offset_.strided() +
+                                s * ThreadMap::Delta::kStrided;
         if constexpr (kGroupSize != -1) {
           cache_current_group_metadata(scale_group(logical_k_s));
         }
         int const qweight_base_s =
             qweight_offset_from_logical(params_, logical_k_s, logical_n_base);
         if constexpr (ThreadMap::Iterations::kContiguous == 4) {
-          auto const qwords =
-              load_qword_vector<4>(qweight_ + qweight_base_s);
+          auto const qwords = load_qword_vector<4>(qweight_ + qweight_base_s);
           CUTLASS_PRAGMA_UNROLL
           for (int c = 0; c < ThreadMap::Iterations::kContiguous; ++c) {
             constexpr int kAccess = ThreadMap::kElementsPerAccess;
@@ -296,8 +294,7 @@ class Sm70U4B8IteratorB {
             frag_vec[3] = __hmul2(deq[1], scale_vec[3]);
           }
         } else if constexpr (ThreadMap::Iterations::kContiguous == 2) {
-          auto const qwords =
-              load_qword_vector<2>(qweight_ + qweight_base_s);
+          auto const qwords = load_qword_vector<2>(qweight_ + qweight_base_s);
           CUTLASS_PRAGMA_UNROLL
           for (int c = 0; c < ThreadMap::Iterations::kContiguous; ++c) {
             constexpr int kAccess = ThreadMap::kElementsPerAccess;
@@ -318,9 +315,11 @@ class Sm70U4B8IteratorB {
             frag_vec[3] = __hmul2(deq[1], scale_vec[3]);
           }
         } else {
-          static_assert(ThreadMap::Iterations::kContiguous == 1,
-                        "Unsupported SM70 Marlin U4B8 contiguous iteration count.");
-          uint32_t const qword = load_qword_vector<1>(qweight_ + qweight_base_s);
+          static_assert(
+              ThreadMap::Iterations::kContiguous == 1,
+              "Unsupported SM70 Marlin U4B8 contiguous iteration count.");
+          uint32_t const qword =
+              load_qword_vector<1>(qweight_ + qweight_base_s);
           constexpr int kAccess = ThreadMap::kElementsPerAccess;
           int const frag_base = s * kAccess;
           half2 const* scale_vec = cached_scales_;
@@ -346,8 +345,7 @@ class Sm70U4B8IteratorB {
       return;
     }
 
-    if constexpr (kGroupSize != -1 &&
-                  ThreadMap::Iterations::kStrided == 1) {
+    if constexpr (kGroupSize != -1 && ThreadMap::Iterations::kStrided == 1) {
       int const first_logical_k = k_offset_ + thread_offset_.strided();
       cache_current_group_metadata(scale_group(first_logical_k));
     }
@@ -359,31 +357,29 @@ class Sm70U4B8IteratorB {
 template <bool UseMetadataVectorWords = true>
 struct Sm70U4B8GemmSpec {
   template <typename Shape, typename ThreadMap, int GroupSize, int PackedMacroN>
-  using IteratorB =
-      Sm70U4B8IteratorB<Shape, ThreadMap, GroupSize, PackedMacroN,
-                        UseMetadataVectorWords>;
+  using IteratorB = Sm70U4B8IteratorB<Shape, ThreadMap, GroupSize, PackedMacroN,
+                                      UseMetadataVectorWords>;
 };
 
-template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM,
-          int WarpN, int WarpK, int GroupSize, int PackedMacroN,
+template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM, int WarpN,
+          int WarpK, int GroupSize, int PackedMacroN,
           bool UseMetadataVectorWords = true>
 using Sm70U4B8GemmTraits =
-    Sm70MarlinGemmTraits<Sm70U4B8GemmSpec<UseMetadataVectorWords>, CtaM,
-                         CtaN, CtaK, Warps, WarpM, WarpN, WarpK,
-                         GroupSize, PackedMacroN>;
+    Sm70MarlinGemmTraits<Sm70U4B8GemmSpec<UseMetadataVectorWords>, CtaM, CtaN,
+                         CtaK, Warps, WarpM, WarpN, WarpK, GroupSize,
+                         PackedMacroN>;
 
-template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM,
-          int WarpN, int WarpK, int GroupSize, int PackedMacroN,
+template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM, int WarpN,
+          int WarpK, int GroupSize, int PackedMacroN,
           bool UseMetadataVectorWords = true>
-__global__ __launch_bounds__(Warps * 32, 1)
-void sm70_marlin_u4b8_gemm_kernel(
+__global__ __launch_bounds__(Warps * 32, 1) void sm70_marlin_u4b8_gemm_kernel(
     cutlass::half_t const* __restrict__ a,
     uint32_t const* __restrict__ b_q_weight,
     cutlass::half_t const* __restrict__ b_scales,
     cutlass::half_t* __restrict__ c, int m, int n, int k, int lda) {
-  using Traits = Sm70U4B8GemmTraits<CtaM, CtaN, CtaK, Warps, WarpM,
-                                    WarpN, WarpK, GroupSize, PackedMacroN,
-                                    UseMetadataVectorWords>;
+  using Traits =
+      Sm70U4B8GemmTraits<CtaM, CtaN, CtaK, Warps, WarpM, WarpN, WarpK,
+                         GroupSize, PackedMacroN, UseMetadataVectorWords>;
   using Mma = typename Traits::Mma;
   using Epilogue = typename Traits::Epilogue;
 
@@ -403,10 +399,10 @@ void sm70_marlin_u4b8_gemm_kernel(
   typename Traits::LayoutA layout_a(lda);
   typename Traits::LayoutC layout_c(n);
 
-  typename Mma::IteratorA iterator_A(
-      typename Mma::IteratorA::Params(layout_a),
-      const_cast<cutlass::half_t*>(a), cutlass::MatrixCoord(m, k), thread_idx,
-      tb_offset_A);
+  typename Mma::IteratorA iterator_A(typename Mma::IteratorA::Params(layout_a),
+                                     const_cast<cutlass::half_t*>(a),
+                                     cutlass::MatrixCoord(m, k), thread_idx,
+                                     tb_offset_A);
   typename Mma::IteratorB iterator_B(
       typename Mma::IteratorB::Params(k, n),
       reinterpret_cast<uint32_t const*>(b_q_weight),
@@ -431,18 +427,19 @@ void sm70_marlin_u4b8_gemm_kernel(
   epilogue(output_op, iterator_D, accumulators, iterator_C);
 }
 
-template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM,
-          int WarpN, int WarpK, int GroupSize, int PackedMacroN,
+template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM, int WarpN,
+          int WarpK, int GroupSize, int PackedMacroN,
           bool UseMetadataVectorWords = true>
-__global__ __launch_bounds__(Warps * 32, 1)
-void sm70_marlin_u4b8_gemm_splitk_kernel(
+__global__
+__launch_bounds__(Warps * 32, 1) void sm70_marlin_u4b8_gemm_splitk_kernel(
     cutlass::half_t const* __restrict__ a,
     uint32_t const* __restrict__ b_q_weight,
     cutlass::half_t const* __restrict__ b_scales,
-    cutlass::half_t* __restrict__ c, int m, int n, int k, int lda, int requested_split_k) {
-  using Traits = Sm70U4B8GemmTraits<CtaM, CtaN, CtaK, Warps, WarpM,
-                                    WarpN, WarpK, GroupSize, PackedMacroN,
-                                    UseMetadataVectorWords>;
+    cutlass::half_t* __restrict__ c, int m, int n, int k, int lda,
+    int requested_split_k) {
+  using Traits =
+      Sm70U4B8GemmTraits<CtaM, CtaN, CtaK, Warps, WarpM, WarpN, WarpK,
+                         GroupSize, PackedMacroN, UseMetadataVectorWords>;
   using Mma = typename Traits::Mma;
   using AtomicEpilogue = Sm70AtomicFp16Epilogue<Traits>;
 
@@ -453,14 +450,13 @@ void sm70_marlin_u4b8_gemm_splitk_kernel(
   int const thread_idx = threadIdx.x;
   int const warp_idx = cutlass::canonical_warp_idx_sync();
   int const lane_idx = threadIdx.x % 32;
-  Sm70SplitKPartition const partition =
-      sm70_splitk_partition<GroupSize, CtaK>(k, requested_split_k, int(blockIdx.z));
+  Sm70SplitKPartition const partition = sm70_splitk_partition<GroupSize, CtaK>(
+      k, requested_split_k, int(blockIdx.z));
   if (partition.partition_k == 0) {
     return;
   }
 
-  cutlass::MatrixCoord tb_offset_A{int(blockIdx.x) * CtaM,
-                                   partition.k_begin};
+  cutlass::MatrixCoord tb_offset_A{int(blockIdx.x) * CtaM, partition.k_begin};
   cutlass::MatrixCoord tb_offset_B{partition.k_begin, int(blockIdx.y) * CtaN};
   cutlass::MatrixCoord tb_offset_C{int(blockIdx.x) * CtaM,
                                    int(blockIdx.y) * CtaN};
@@ -468,10 +464,10 @@ void sm70_marlin_u4b8_gemm_splitk_kernel(
   typename Traits::LayoutA layout_a(lda);
   typename Traits::LayoutC layout_c(n);
 
-  typename Mma::IteratorA iterator_A(
-      typename Mma::IteratorA::Params(layout_a),
-      const_cast<cutlass::half_t*>(a), cutlass::MatrixCoord(m, k), thread_idx,
-      tb_offset_A);
+  typename Mma::IteratorA iterator_A(typename Mma::IteratorA::Params(layout_a),
+                                     const_cast<cutlass::half_t*>(a),
+                                     cutlass::MatrixCoord(m, k), thread_idx,
+                                     tb_offset_A);
   typename Mma::IteratorB iterator_B(
       typename Mma::IteratorB::Params(k, n),
       reinterpret_cast<uint32_t const*>(b_q_weight),
@@ -485,9 +481,8 @@ void sm70_marlin_u4b8_gemm_splitk_kernel(
   mma(gemm_k_iterations, accumulators, iterator_A, iterator_B, accumulators);
 
   typename AtomicEpilogue::OutputTileIterator iterator_D(
-      typename AtomicEpilogue::OutputTileIterator::Params(layout_c),
-      c, cutlass::MatrixCoord(m, n),
-      thread_idx, tb_offset_C);
+      typename AtomicEpilogue::OutputTileIterator::Params(layout_c), c,
+      cutlass::MatrixCoord(m, n), thread_idx, tb_offset_C);
 
   AtomicEpilogue epilogue(shared_storage.epilogue, thread_idx, warp_idx,
                           lane_idx);
@@ -496,20 +491,23 @@ void sm70_marlin_u4b8_gemm_splitk_kernel(
 
 }  // namespace
 
-template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM,
-          int WarpN, int WarpK, int GroupSize, int PackedMacroN,
+template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM, int WarpN,
+          int WarpK, int GroupSize, int PackedMacroN,
           bool UseMetadataVectorWords = true>
-torch::Tensor launch_sm70_marlin_u4b8_gemm(
-    torch::Tensor& a, torch::Tensor& c, torch::Tensor& b_q_weight,
-    torch::Tensor& b_scales, int64_t size_m, int64_t size_n, int64_t size_k,
-    int requested_split_k) {
+torch::Tensor launch_sm70_marlin_u4b8_gemm(torch::Tensor& a, torch::Tensor& c,
+                                           torch::Tensor& b_q_weight,
+                                           torch::Tensor& b_scales,
+                                           int64_t size_m, int64_t size_n,
+                                           int64_t size_k,
+                                           int requested_split_k) {
   auto kernel =
-      sm70_marlin_u4b8_gemm_kernel<CtaM, CtaN, CtaK, Warps, WarpM, WarpN,
-                                   WarpK, GroupSize, PackedMacroN,
+      sm70_marlin_u4b8_gemm_kernel<CtaM, CtaN, CtaK, Warps, WarpM, WarpN, WarpK,
+                                   GroupSize, PackedMacroN,
                                    UseMetadataVectorWords>;
-  using SharedStorage = typename Sm70U4B8GemmTraits<
-      CtaM, CtaN, CtaK, Warps, WarpM, WarpN, WarpK, GroupSize,
-      PackedMacroN, UseMetadataVectorWords>::SharedStorage;
+  using SharedStorage =
+      typename Sm70U4B8GemmTraits<CtaM, CtaN, CtaK, Warps, WarpM, WarpN, WarpK,
+                                  GroupSize, PackedMacroN,
+                                  UseMetadataVectorWords>::SharedStorage;
   size_t smem_bytes = configure_sm70_dynamic_smem<SharedStorage>(kernel);
 
   dim3 block(Warps * 32);
@@ -529,21 +527,20 @@ torch::Tensor launch_sm70_marlin_u4b8_gemm(
   }
 
   TORCH_CHECK(size_k % int64_t(CtaK) == 0,
-              "SM70 Marlin uint4b8 requires K divisible by CTA_K=",
-              CtaK, " for requested_split_k > 1. Got K=", size_k,
+              "SM70 Marlin uint4b8 requires K divisible by CTA_K=", CtaK,
+              " for requested_split_k > 1. Got K=", size_k,
               ", requested_split_k=", requested_split_k, ".");
 
   auto split_kernel =
-      sm70_marlin_u4b8_gemm_splitk_kernel<CtaM, CtaN, CtaK, Warps, WarpM,
-                                          WarpN, WarpK, GroupSize,
-                                          PackedMacroN,
+      sm70_marlin_u4b8_gemm_splitk_kernel<CtaM, CtaN, CtaK, Warps, WarpM, WarpN,
+                                          WarpK, GroupSize, PackedMacroN,
                                           UseMetadataVectorWords>;
   smem_bytes = configure_sm70_dynamic_smem<SharedStorage>(split_kernel);
 
   int64_t const numel = size_m * size_n;
-  C10_CUDA_CHECK(cudaMemsetAsync(
-      c.data_ptr<at::Half>(), 0,
-      static_cast<size_t>(numel) * sizeof(at::Half), stream));
+  C10_CUDA_CHECK(cudaMemsetAsync(c.data_ptr<at::Half>(), 0,
+                                 static_cast<size_t>(numel) * sizeof(at::Half),
+                                 stream));
 
   dim3 grid = sm70_marlin_cta_grid(size_m, size_n, CtaM, CtaN);
   int const active_split_k =
@@ -555,7 +552,8 @@ torch::Tensor launch_sm70_marlin_u4b8_gemm(
       reinterpret_cast<cutlass::half_t const*>(b_scales.data_ptr<at::Half>()),
       reinterpret_cast<cutlass::half_t*>(c.data_ptr<at::Half>()),
       static_cast<int>(size_m), static_cast<int>(size_n),
-      static_cast<int>(size_k), static_cast<int>(a.stride(0)), requested_split_k);
+      static_cast<int>(size_k), static_cast<int>(a.stride(0)),
+      requested_split_k);
   C10_CUDA_KERNEL_LAUNCH_CHECK();
 
   return c;
@@ -572,8 +570,8 @@ struct Sm70U4B8Launcher {
   int64_t size_k;
   int requested_split_k;
 
-  template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM,
-            int WarpN, int WarpK, int GroupSize, int PackedMacroN>
+  template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM, int WarpN,
+            int WarpK, int GroupSize, int PackedMacroN>
   torch::Tensor operator()() const {
     return launch_sm70_marlin_u4b8_gemm<CtaM, CtaN, CtaK, Warps, WarpM, WarpN,
                                         WarpK, GroupSize, PackedMacroN,
@@ -589,21 +587,23 @@ torch::Tensor sm70_marlin_u4b8_gemm(torch::Tensor& a, torch::Tensor& c,
                                     int64_t group_size) {
   c10::cuda::CUDAGuard device_guard(a.device());
 
-  auto const params = sm70_marlin_dense_auto_params(
-      "uint4b8", group_size, size_m, size_n, size_k);
+  auto const params = sm70_marlin_dense_auto_params("uint4b8", group_size,
+                                                    size_m, size_n, size_k);
   Sm70CtaGeometry const geometry = params.geometry;
-  validate_sm70_marlin_dense_cta_geometry_supported("SM70 Marlin uint4b8", geometry);
-  validate_sm70_marlin_dense_cta_n_alignment("SM70 Marlin uint4b8", geometry, size_n);
+  validate_sm70_marlin_dense_cta_geometry_supported("SM70 Marlin uint4b8",
+                                                    geometry);
+  validate_sm70_marlin_dense_cta_n_alignment("SM70 Marlin uint4b8", geometry,
+                                             size_n);
   if (params.use_metadata_vector_words) {
     Sm70U4B8Launcher<true> const launcher{
-        a, c, b_q_weight, b_scales, size_m, size_n, size_k,
-        params.requested_split_k};
+        a,      c,      b_q_weight, b_scales,
+        size_m, size_n, size_k,     params.requested_split_k};
     return dispatch_sm70_marlin_geometry(
         launcher, geometry, params.packed_macro_n, group_size, "uint4b8");
   }
   Sm70U4B8Launcher<false> const launcher{
-      a, c, b_q_weight, b_scales, size_m, size_n, size_k,
-      params.requested_split_k};
+      a,      c,      b_q_weight, b_scales,
+      size_m, size_n, size_k,     params.requested_split_k};
   return dispatch_sm70_marlin_geometry(
       launcher, geometry, params.packed_macro_n, group_size, "uint4b8");
 }

--- a/csrc/quantization/marlin/sm70_marlin_u8_gemm.cu
+++ b/csrc/quantization/marlin/sm70_marlin_u8_gemm.cu
@@ -20,24 +20,24 @@
 #include "cutlass/layout/tensor_op_multiplicand_sm70.h"
 #include "cutlass/transform/threadblock/predicated_tile_iterator.h"
 
-using marlin::sm70::Sm70CtaGeometry;
-using marlin::sm70::Sm70AtomicFp16Epilogue;
-using marlin::sm70::Sm70MarlinGemmTraits;
-using marlin::sm70::Sm70SplitKPartition;
-using marlin::sm70::validate_sm70_marlin_dense_cta_geometry_supported;
-using marlin::sm70::validate_sm70_marlin_dense_cta_n_alignment;
 using marlin::sm70::configure_sm70_dynamic_smem;
 using marlin::sm70::dispatch_sm70_marlin_geometry_with_group32;
 using marlin::sm70::kQuantTileK;
 using marlin::sm70::kQuantTileN;
-using marlin::sm70::sm70_marlin_dense_auto_params;
 using marlin::sm70::load_qword_vector;
 using marlin::sm70::qword_from_vector;
-using marlin::sm70::sm70_marlin_cta_grid;
 using marlin::sm70::sm70_active_split_k;
+using marlin::sm70::sm70_marlin_cta_grid;
+using marlin::sm70::sm70_marlin_dense_auto_params;
 using marlin::sm70::sm70_splitk_partition;
+using marlin::sm70::Sm70AtomicFp16Epilogue;
+using marlin::sm70::Sm70CtaGeometry;
+using marlin::sm70::Sm70MarlinGemmTraits;
+using marlin::sm70::Sm70SplitKPartition;
 using marlin::sm70::u8_packed_macro_n_qweight_offset_from_logical;
 using marlin::sm70::u8_packed_macro_n_qweight_word_stride;
+using marlin::sm70::validate_sm70_marlin_dense_cta_geometry_supported;
+using marlin::sm70::validate_sm70_marlin_dense_cta_n_alignment;
 
 namespace {
 
@@ -53,12 +53,11 @@ class Sm70U8ZpIteratorB {
   static int const kPackedMacroN = PackedMacroN_;
   static constexpr bool kUseMetadataVectorWords = UseMetadataVectorWords_;
   using Element = cutlass::half_t;
-  using Fragment = cutlass::Array<
-      Element, ThreadMap::Iterations::kCount * ThreadMap::kElementsPerAccess>;
+  using Fragment = cutlass::Array<Element, ThreadMap::Iterations::kCount *
+                                               ThreadMap::kElementsPerAccess>;
   static_assert(Shape::kN == 64 || Shape::kN == 128 || Shape::kN == 256,
                 "SM70 Marlin U8 IteratorB expects CTA_N in {64, 128, 256}.");
-  static_assert(ThreadMap::Iterations::kContiguous ==
-                    Shape::kN / kQuantTileN,
+  static_assert(ThreadMap::Iterations::kContiguous == Shape::kN / kQuantTileN,
                 "SM70 Marlin U8 IteratorB expects one contiguous iteration per "
                 "64-column quant tile.");
   static_assert(ThreadMap::Delta::kContiguous == kQuantTileN,
@@ -117,7 +116,7 @@ class Sm70U8ZpIteratorB {
     qweight_base_offset_ =
         qweight_offset_from_logical(params_, logical_k, logical_n);
     if constexpr (kGroupSize == -1) {
-        cache_current_group_metadata(0);
+      cache_current_group_metadata(0);
     }
   }
 
@@ -153,8 +152,7 @@ class Sm70U8ZpIteratorB {
     if constexpr (kGroupSize == -1) {
       return 0;
     } else {
-      static_assert(kGroupSize == 32 || kGroupSize == 64 ||
-                        kGroupSize == 128,
+      static_assert(kGroupSize == 32 || kGroupSize == 64 || kGroupSize == 128,
                     "SM70 Marlin U8 supports only group sizes "
                     "-1, 32, 64, and 128.");
       return logical_k / kGroupSize;
@@ -164,8 +162,8 @@ class Sm70U8ZpIteratorB {
   CUTLASS_DEVICE
   static int qweight_offset_from_logical(Params const& params, int logical_k,
                                          int logical_n) {
-    return u8_packed_macro_n_qweight_offset_from_logical<kPackedMacroN>(params.size_n, logical_k,
-                                                  logical_n);
+    return u8_packed_macro_n_qweight_offset_from_logical<kPackedMacroN>(
+        params.size_n, logical_k, logical_n);
   }
 
   CUTLASS_DEVICE
@@ -183,8 +181,8 @@ class Sm70U8ZpIteratorB {
     scale_cache[2] = scale_vec[2];
     scale_cache[3] = scale_vec[3];
 
-    half2 const* zp_vec = reinterpret_cast<half2 const*>(
-        zp_ + group * params_.size_n + cache_n);
+    half2 const* zp_vec =
+        reinterpret_cast<half2 const*>(zp_ + group * params_.size_n + cache_n);
     half2* zp_cache = cached_zp_ + c * 4;
     zp_cache[0] = zp_vec[0];
     zp_cache[1] = zp_vec[1];
@@ -203,8 +201,8 @@ class Sm70U8ZpIteratorB {
     scale_cache[2] = scale_vec[2];
     scale_cache[3] = scale_vec[3];
 
-    uint4 const zp_words = *reinterpret_cast<uint4 const*>(
-        zp_ + group * params_.size_n + cache_n);
+    uint4 const zp_words =
+        *reinterpret_cast<uint4 const*>(zp_ + group * params_.size_n + cache_n);
     half2 const* zp_vec = reinterpret_cast<half2 const*>(&zp_words);
     half2* zp_cache = cached_zp_ + c * 4;
     zp_cache[0] = zp_vec[0];
@@ -217,9 +215,8 @@ class Sm70U8ZpIteratorB {
   void cache_current_group_metadata(int group) const {
     CUTLASS_PRAGMA_UNROLL
     for (int c = 0; c < ThreadMap::Iterations::kContiguous; ++c) {
-      int const cache_n =
-          n_offset_ + thread_offset_.contiguous() +
-          c * ThreadMap::Delta::kContiguous;
+      int const cache_n = n_offset_ + thread_offset_.contiguous() +
+                          c * ThreadMap::Delta::kContiguous;
       if constexpr (kUseMetadataVectorWords) {
         cache_metadata_vector_words(c, group, cache_n);
       } else {
@@ -293,12 +290,12 @@ class Sm70U8ZpIteratorB {
 
         half2 deq[2];
         half2* frag_vec = reinterpret_cast<half2*>(frag.data());
-        marlin::dequant<half2, vllm::kU8.id(), false>(
-            static_cast<int>(qword0), deq);
+        marlin::dequant<half2, vllm::kU8.id(), false>(static_cast<int>(qword0),
+                                                      deq);
         frag_vec[0] = __hfma2(deq[0], scale_vec[0], __hneg2(zp_vec[0]));
         frag_vec[1] = __hfma2(deq[1], scale_vec[1], __hneg2(zp_vec[1]));
-        marlin::dequant<half2, vllm::kU8.id(), false>(
-            static_cast<int>(qword1), deq);
+        marlin::dequant<half2, vllm::kU8.id(), false>(static_cast<int>(qword1),
+                                                      deq);
         frag_vec[2] = __hfma2(deq[0], scale_vec[2], __hneg2(zp_vec[2]));
         frag_vec[3] = __hfma2(deq[1], scale_vec[3], __hneg2(zp_vec[3]));
       }
@@ -306,19 +303,17 @@ class Sm70U8ZpIteratorB {
       int const logical_n_base = n_offset_ + thread_offset_.contiguous();
       CUTLASS_PRAGMA_UNROLL
       for (int s = 0; s < ThreadMap::Iterations::kStrided; ++s) {
-        int const logical_k_s =
-            k_offset_ + thread_offset_.strided() +
-            s * ThreadMap::Delta::kStrided;
+        int const logical_k_s = k_offset_ + thread_offset_.strided() +
+                                s * ThreadMap::Delta::kStrided;
         if constexpr (kGroupSize != -1) {
           cache_current_group_metadata(scale_group(logical_k_s));
         }
         int const qweight_base_s =
             qweight_offset_from_logical(params_, logical_k_s, logical_n_base);
         if constexpr (ThreadMap::Iterations::kContiguous == 4) {
-          uint4 const qwords0 =
-              load_qword_vector<4>(qweight_ + qweight_base_s);
-          uint4 const qwords1 = load_qword_vector<4>(
-              qweight_ + qweight_base_s + kQweightWordStrideWords);
+          uint4 const qwords0 = load_qword_vector<4>(qweight_ + qweight_base_s);
+          uint4 const qwords1 = load_qword_vector<4>(qweight_ + qweight_base_s +
+                                                     kQweightWordStrideWords);
           CUTLASS_PRAGMA_UNROLL
           for (int c = 0; c < ThreadMap::Iterations::kContiguous; ++c) {
             constexpr int kAccess = ThreadMap::kElementsPerAccess;
@@ -333,22 +328,17 @@ class Sm70U8ZpIteratorB {
             half2* frag_vec = reinterpret_cast<half2*>(frag.data() + frag_base);
             marlin::dequant<half2, vllm::kU8.id(), false>(
                 static_cast<int>(qword0), deq);
-            frag_vec[0] =
-                __hfma2(deq[0], scale_vec[0], __hneg2(zp_vec[0]));
-            frag_vec[1] =
-                __hfma2(deq[1], scale_vec[1], __hneg2(zp_vec[1]));
+            frag_vec[0] = __hfma2(deq[0], scale_vec[0], __hneg2(zp_vec[0]));
+            frag_vec[1] = __hfma2(deq[1], scale_vec[1], __hneg2(zp_vec[1]));
             marlin::dequant<half2, vllm::kU8.id(), false>(
                 static_cast<int>(qword1), deq);
-            frag_vec[2] =
-                __hfma2(deq[0], scale_vec[2], __hneg2(zp_vec[2]));
-            frag_vec[3] =
-                __hfma2(deq[1], scale_vec[3], __hneg2(zp_vec[3]));
+            frag_vec[2] = __hfma2(deq[0], scale_vec[2], __hneg2(zp_vec[2]));
+            frag_vec[3] = __hfma2(deq[1], scale_vec[3], __hneg2(zp_vec[3]));
           }
         } else if constexpr (ThreadMap::Iterations::kContiguous == 2) {
-          uint2 const qwords0 =
-              load_qword_vector<2>(qweight_ + qweight_base_s);
-          uint2 const qwords1 = load_qword_vector<2>(
-              qweight_ + qweight_base_s + kQweightWordStrideWords);
+          uint2 const qwords0 = load_qword_vector<2>(qweight_ + qweight_base_s);
+          uint2 const qwords1 = load_qword_vector<2>(qweight_ + qweight_base_s +
+                                                     kQweightWordStrideWords);
           CUTLASS_PRAGMA_UNROLL
           for (int c = 0; c < ThreadMap::Iterations::kContiguous; ++c) {
             constexpr int kAccess = ThreadMap::kElementsPerAccess;
@@ -363,20 +353,17 @@ class Sm70U8ZpIteratorB {
             half2* frag_vec = reinterpret_cast<half2*>(frag.data() + frag_base);
             marlin::dequant<half2, vllm::kU8.id(), false>(
                 static_cast<int>(qword0), deq);
-            frag_vec[0] =
-                __hfma2(deq[0], scale_vec[0], __hneg2(zp_vec[0]));
-            frag_vec[1] =
-                __hfma2(deq[1], scale_vec[1], __hneg2(zp_vec[1]));
+            frag_vec[0] = __hfma2(deq[0], scale_vec[0], __hneg2(zp_vec[0]));
+            frag_vec[1] = __hfma2(deq[1], scale_vec[1], __hneg2(zp_vec[1]));
             marlin::dequant<half2, vllm::kU8.id(), false>(
                 static_cast<int>(qword1), deq);
-            frag_vec[2] =
-                __hfma2(deq[0], scale_vec[2], __hneg2(zp_vec[2]));
-            frag_vec[3] =
-                __hfma2(deq[1], scale_vec[3], __hneg2(zp_vec[3]));
+            frag_vec[2] = __hfma2(deq[0], scale_vec[2], __hneg2(zp_vec[2]));
+            frag_vec[3] = __hfma2(deq[1], scale_vec[3], __hneg2(zp_vec[3]));
           }
         } else {
-          static_assert(ThreadMap::Iterations::kContiguous == 1,
-                        "Unsupported SM70 Marlin U8 contiguous iteration count.");
+          static_assert(
+              ThreadMap::Iterations::kContiguous == 1,
+              "Unsupported SM70 Marlin U8 contiguous iteration count.");
           uint32_t const qword0 =
               load_qword_vector<1>(qweight_ + qweight_base_s);
           uint32_t const qword1 = load_qword_vector<1>(
@@ -407,8 +394,7 @@ class Sm70U8ZpIteratorB {
       return;
     }
 
-    if constexpr (kGroupSize != -1 &&
-                  ThreadMap::Iterations::kStrided == 1) {
+    if constexpr (kGroupSize != -1 && ThreadMap::Iterations::kStrided == 1) {
       int const first_logical_k = k_offset_ + thread_offset_.strided();
       cache_current_group_metadata(scale_group(first_logical_k));
     }
@@ -420,32 +406,30 @@ class Sm70U8ZpIteratorB {
 template <bool UseMetadataVectorWords = true>
 struct Sm70U8ZpGemmSpec {
   template <typename Shape, typename ThreadMap, int GroupSize, int PackedMacroN>
-  using IteratorB =
-      Sm70U8ZpIteratorB<Shape, ThreadMap, GroupSize, PackedMacroN,
-                        UseMetadataVectorWords>;
+  using IteratorB = Sm70U8ZpIteratorB<Shape, ThreadMap, GroupSize, PackedMacroN,
+                                      UseMetadataVectorWords>;
 };
 
-template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM,
-          int WarpN, int WarpK, int GroupSize, int PackedMacroN,
+template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM, int WarpN,
+          int WarpK, int GroupSize, int PackedMacroN,
           bool UseMetadataVectorWords = true>
 using Sm70U8ZpGemmTraits =
-    Sm70MarlinGemmTraits<Sm70U8ZpGemmSpec<UseMetadataVectorWords>, CtaM,
-                         CtaN, CtaK, Warps, WarpM, WarpN, WarpK,
-                         GroupSize, PackedMacroN>;
+    Sm70MarlinGemmTraits<Sm70U8ZpGemmSpec<UseMetadataVectorWords>, CtaM, CtaN,
+                         CtaK, Warps, WarpM, WarpN, WarpK, GroupSize,
+                         PackedMacroN>;
 
-template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM,
-          int WarpN, int WarpK, int GroupSize, int PackedMacroN,
+template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM, int WarpN,
+          int WarpK, int GroupSize, int PackedMacroN,
           bool UseMetadataVectorWords = true>
-__global__ __launch_bounds__(Warps * 32, 1)
-void sm70_marlin_u8_gemm_kernel(
+__global__ __launch_bounds__(Warps * 32, 1) void sm70_marlin_u8_gemm_kernel(
     cutlass::half_t const* __restrict__ a,
     uint32_t const* __restrict__ b_q_weight,
     cutlass::half_t const* __restrict__ b_scales,
     cutlass::half_t const* __restrict__ b_zeros,
     cutlass::half_t* __restrict__ c, int m, int n, int k, int lda) {
-  using Traits = Sm70U8ZpGemmTraits<CtaM, CtaN, CtaK, Warps, WarpM,
-                                    WarpN, WarpK, GroupSize, PackedMacroN,
-                                    UseMetadataVectorWords>;
+  using Traits =
+      Sm70U8ZpGemmTraits<CtaM, CtaN, CtaK, Warps, WarpM, WarpN, WarpK,
+                         GroupSize, PackedMacroN, UseMetadataVectorWords>;
   using Mma = typename Traits::Mma;
   using Epilogue = typename Traits::Epilogue;
 
@@ -465,10 +449,10 @@ void sm70_marlin_u8_gemm_kernel(
   typename Traits::LayoutA layout_a(lda);
   typename Traits::LayoutC layout_c(n);
 
-  typename Mma::IteratorA iterator_A(
-      typename Mma::IteratorA::Params(layout_a),
-      const_cast<cutlass::half_t*>(a), cutlass::MatrixCoord(m, k), thread_idx,
-      tb_offset_A);
+  typename Mma::IteratorA iterator_A(typename Mma::IteratorA::Params(layout_a),
+                                     const_cast<cutlass::half_t*>(a),
+                                     cutlass::MatrixCoord(m, k), thread_idx,
+                                     tb_offset_A);
   typename Mma::IteratorB iterator_B(
       typename Mma::IteratorB::Params(k, n),
       reinterpret_cast<uint32_t const*>(b_q_weight),
@@ -494,19 +478,20 @@ void sm70_marlin_u8_gemm_kernel(
   epilogue(output_op, iterator_D, accumulators, iterator_C);
 }
 
-template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM,
-          int WarpN, int WarpK, int GroupSize, int PackedMacroN,
+template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM, int WarpN,
+          int WarpK, int GroupSize, int PackedMacroN,
           bool UseMetadataVectorWords = true>
-__global__ __launch_bounds__(Warps * 32, 1)
-void sm70_marlin_u8_gemm_splitk_kernel(
+__global__
+__launch_bounds__(Warps * 32, 1) void sm70_marlin_u8_gemm_splitk_kernel(
     cutlass::half_t const* __restrict__ a,
     uint32_t const* __restrict__ b_q_weight,
     cutlass::half_t const* __restrict__ b_scales,
     cutlass::half_t const* __restrict__ b_zeros,
-    cutlass::half_t* __restrict__ c, int m, int n, int k, int lda, int requested_split_k) {
-  using Traits = Sm70U8ZpGemmTraits<CtaM, CtaN, CtaK, Warps, WarpM,
-                                    WarpN, WarpK, GroupSize, PackedMacroN,
-                                    UseMetadataVectorWords>;
+    cutlass::half_t* __restrict__ c, int m, int n, int k, int lda,
+    int requested_split_k) {
+  using Traits =
+      Sm70U8ZpGemmTraits<CtaM, CtaN, CtaK, Warps, WarpM, WarpN, WarpK,
+                         GroupSize, PackedMacroN, UseMetadataVectorWords>;
   using Mma = typename Traits::Mma;
   using AtomicEpilogue = Sm70AtomicFp16Epilogue<Traits>;
 
@@ -517,14 +502,13 @@ void sm70_marlin_u8_gemm_splitk_kernel(
   int const thread_idx = threadIdx.x;
   int const warp_idx = cutlass::canonical_warp_idx_sync();
   int const lane_idx = threadIdx.x % 32;
-  Sm70SplitKPartition const partition =
-      sm70_splitk_partition<GroupSize, CtaK>(k, requested_split_k, int(blockIdx.z));
+  Sm70SplitKPartition const partition = sm70_splitk_partition<GroupSize, CtaK>(
+      k, requested_split_k, int(blockIdx.z));
   if (partition.partition_k == 0) {
     return;
   }
 
-  cutlass::MatrixCoord tb_offset_A{int(blockIdx.x) * CtaM,
-                                   partition.k_begin};
+  cutlass::MatrixCoord tb_offset_A{int(blockIdx.x) * CtaM, partition.k_begin};
   cutlass::MatrixCoord tb_offset_B{partition.k_begin, int(blockIdx.y) * CtaN};
   cutlass::MatrixCoord tb_offset_C{int(blockIdx.x) * CtaM,
                                    int(blockIdx.y) * CtaN};
@@ -532,10 +516,10 @@ void sm70_marlin_u8_gemm_splitk_kernel(
   typename Traits::LayoutA layout_a(lda);
   typename Traits::LayoutC layout_c(n);
 
-  typename Mma::IteratorA iterator_A(
-      typename Mma::IteratorA::Params(layout_a),
-      const_cast<cutlass::half_t*>(a), cutlass::MatrixCoord(m, k), thread_idx,
-      tb_offset_A);
+  typename Mma::IteratorA iterator_A(typename Mma::IteratorA::Params(layout_a),
+                                     const_cast<cutlass::half_t*>(a),
+                                     cutlass::MatrixCoord(m, k), thread_idx,
+                                     tb_offset_A);
   typename Mma::IteratorB iterator_B(
       typename Mma::IteratorB::Params(k, n),
       reinterpret_cast<uint32_t const*>(b_q_weight),
@@ -550,9 +534,8 @@ void sm70_marlin_u8_gemm_splitk_kernel(
   mma(gemm_k_iterations, accumulators, iterator_A, iterator_B, accumulators);
 
   typename AtomicEpilogue::OutputTileIterator iterator_D(
-      typename AtomicEpilogue::OutputTileIterator::Params(layout_c),
-      c, cutlass::MatrixCoord(m, n),
-      thread_idx, tb_offset_C);
+      typename AtomicEpilogue::OutputTileIterator::Params(layout_c), c,
+      cutlass::MatrixCoord(m, n), thread_idx, tb_offset_C);
 
   AtomicEpilogue epilogue(shared_storage.epilogue, thread_idx, warp_idx,
                           lane_idx);
@@ -561,20 +544,23 @@ void sm70_marlin_u8_gemm_splitk_kernel(
 
 }  // namespace
 
-template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM,
-          int WarpN, int WarpK, int GroupSize, int PackedMacroN,
+template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM, int WarpN,
+          int WarpK, int GroupSize, int PackedMacroN,
           bool UseMetadataVectorWords = true>
-torch::Tensor launch_sm70_marlin_u8_gemm(
-    torch::Tensor& a, torch::Tensor& c, torch::Tensor& b_q_weight,
-    torch::Tensor& b_scales, torch::Tensor& b_zeros, int64_t size_m,
-    int64_t size_n, int64_t size_k, int requested_split_k) {
+torch::Tensor launch_sm70_marlin_u8_gemm(torch::Tensor& a, torch::Tensor& c,
+                                         torch::Tensor& b_q_weight,
+                                         torch::Tensor& b_scales,
+                                         torch::Tensor& b_zeros, int64_t size_m,
+                                         int64_t size_n, int64_t size_k,
+                                         int requested_split_k) {
   auto kernel =
       sm70_marlin_u8_gemm_kernel<CtaM, CtaN, CtaK, Warps, WarpM, WarpN, WarpK,
                                  GroupSize, PackedMacroN,
                                  UseMetadataVectorWords>;
-  using SharedStorage = typename Sm70U8ZpGemmTraits<
-      CtaM, CtaN, CtaK, Warps, WarpM, WarpN, WarpK, GroupSize,
-      PackedMacroN, UseMetadataVectorWords>::SharedStorage;
+  using SharedStorage =
+      typename Sm70U8ZpGemmTraits<CtaM, CtaN, CtaK, Warps, WarpM, WarpN, WarpK,
+                                  GroupSize, PackedMacroN,
+                                  UseMetadataVectorWords>::SharedStorage;
   size_t smem_bytes = configure_sm70_dynamic_smem<SharedStorage>(kernel);
 
   dim3 block(Warps * 32);
@@ -595,8 +581,8 @@ torch::Tensor launch_sm70_marlin_u8_gemm(
   }
 
   TORCH_CHECK(size_k % int64_t(CtaK) == 0,
-              "SM70 Marlin uint8 requires K divisible by CTA_K=",
-              CtaK, " for requested_split_k > 1. Got K=", size_k,
+              "SM70 Marlin uint8 requires K divisible by CTA_K=", CtaK,
+              " for requested_split_k > 1. Got K=", size_k,
               ", requested_split_k=", requested_split_k, ".");
 
   auto split_kernel =
@@ -606,9 +592,9 @@ torch::Tensor launch_sm70_marlin_u8_gemm(
   smem_bytes = configure_sm70_dynamic_smem<SharedStorage>(split_kernel);
 
   int64_t const numel = size_m * size_n;
-  C10_CUDA_CHECK(cudaMemsetAsync(
-      c.data_ptr<at::Half>(), 0,
-      static_cast<size_t>(numel) * sizeof(at::Half), stream));
+  C10_CUDA_CHECK(cudaMemsetAsync(c.data_ptr<at::Half>(), 0,
+                                 static_cast<size_t>(numel) * sizeof(at::Half),
+                                 stream));
 
   dim3 grid = sm70_marlin_cta_grid(size_m, size_n, CtaM, CtaN);
   int const active_split_k =
@@ -621,7 +607,8 @@ torch::Tensor launch_sm70_marlin_u8_gemm(
       reinterpret_cast<cutlass::half_t const*>(b_zeros.data_ptr<at::Half>()),
       reinterpret_cast<cutlass::half_t*>(c.data_ptr<at::Half>()),
       static_cast<int>(size_m), static_cast<int>(size_n),
-      static_cast<int>(size_k), static_cast<int>(a.stride(0)), requested_split_k);
+      static_cast<int>(size_k), static_cast<int>(a.stride(0)),
+      requested_split_k);
   C10_CUDA_KERNEL_LAUNCH_CHECK();
 
   return c;
@@ -639,13 +626,14 @@ struct Sm70U8Launcher {
   int64_t size_k;
   int requested_split_k;
 
-  template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM,
-            int WarpN, int WarpK, int GroupSize, int PackedMacroN>
+  template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM, int WarpN,
+            int WarpK, int GroupSize, int PackedMacroN>
   torch::Tensor operator()() const {
-    return launch_sm70_marlin_u8_gemm<CtaM, CtaN, CtaK, Warps, WarpM, WarpN, WarpK,
-                                      GroupSize, PackedMacroN,
+    return launch_sm70_marlin_u8_gemm<CtaM, CtaN, CtaK, Warps, WarpM, WarpN,
+                                      WarpK, GroupSize, PackedMacroN,
                                       UseMetadataVectorWords>(
-        a, c, b_q_weight, b_scales, b_zeros, size_m, size_n, size_k, requested_split_k);
+        a, c, b_q_weight, b_scales, b_zeros, size_m, size_n, size_k,
+        requested_split_k);
   }
 };
 
@@ -657,22 +645,25 @@ torch::Tensor sm70_marlin_u8_gemm(torch::Tensor& a, torch::Tensor& c,
                                   int64_t group_size) {
   c10::cuda::CUDAGuard device_guard(a.device());
 
-  auto const params =
-      sm70_marlin_dense_auto_params("uint8", group_size, size_m, size_n,
-                                    size_k);
+  auto const params = sm70_marlin_dense_auto_params("uint8", group_size, size_m,
+                                                    size_n, size_k);
   Sm70CtaGeometry const geometry = params.geometry;
-  validate_sm70_marlin_dense_cta_geometry_supported("SM70 Marlin uint8", geometry);
-  validate_sm70_marlin_dense_cta_n_alignment("SM70 Marlin uint8", geometry, size_n);
+  validate_sm70_marlin_dense_cta_geometry_supported("SM70 Marlin uint8",
+                                                    geometry);
+  validate_sm70_marlin_dense_cta_n_alignment("SM70 Marlin uint8", geometry,
+                                             size_n);
   if (params.use_metadata_vector_words) {
     Sm70U8Launcher<true> const launcher{
-        a, c, b_q_weight, b_scales, b_zeros, size_m, size_n, size_k,
-        params.requested_split_k};
+        a,        c,       b_q_weight,
+        b_scales, b_zeros, size_m,
+        size_n,   size_k,  params.requested_split_k};
     return dispatch_sm70_marlin_geometry_with_group32(
         launcher, geometry, params.packed_macro_n, group_size, "uint8");
   }
   Sm70U8Launcher<false> const launcher{
-      a, c, b_q_weight, b_scales, b_zeros, size_m, size_n, size_k,
-      params.requested_split_k};
+      a,        c,       b_q_weight,
+      b_scales, b_zeros, size_m,
+      size_n,   size_k,  params.requested_split_k};
   return dispatch_sm70_marlin_geometry_with_group32(
       launcher, geometry, params.packed_macro_n, group_size, "uint8");
 }

--- a/csrc/quantization/marlin/sm70_marlin_u8b128_gemm.cu
+++ b/csrc/quantization/marlin/sm70_marlin_u8b128_gemm.cu
@@ -20,24 +20,24 @@
 #include "cutlass/layout/tensor_op_multiplicand_sm70.h"
 #include "cutlass/transform/threadblock/predicated_tile_iterator.h"
 
-using marlin::sm70::Sm70CtaGeometry;
-using marlin::sm70::Sm70AtomicFp16Epilogue;
-using marlin::sm70::Sm70MarlinGemmTraits;
-using marlin::sm70::Sm70SplitKPartition;
-using marlin::sm70::validate_sm70_marlin_dense_cta_geometry_supported;
-using marlin::sm70::validate_sm70_marlin_dense_cta_n_alignment;
 using marlin::sm70::configure_sm70_dynamic_smem;
 using marlin::sm70::dispatch_sm70_marlin_geometry_with_group32;
 using marlin::sm70::kQuantTileK;
 using marlin::sm70::kQuantTileN;
-using marlin::sm70::sm70_marlin_dense_auto_params;
 using marlin::sm70::load_qword_vector;
 using marlin::sm70::qword_from_vector;
-using marlin::sm70::sm70_marlin_cta_grid;
 using marlin::sm70::sm70_active_split_k;
+using marlin::sm70::sm70_marlin_cta_grid;
+using marlin::sm70::sm70_marlin_dense_auto_params;
 using marlin::sm70::sm70_splitk_partition;
+using marlin::sm70::Sm70AtomicFp16Epilogue;
+using marlin::sm70::Sm70CtaGeometry;
+using marlin::sm70::Sm70MarlinGemmTraits;
+using marlin::sm70::Sm70SplitKPartition;
 using marlin::sm70::u8_packed_macro_n_qweight_offset_from_logical;
 using marlin::sm70::u8_packed_macro_n_qweight_word_stride;
+using marlin::sm70::validate_sm70_marlin_dense_cta_geometry_supported;
+using marlin::sm70::validate_sm70_marlin_dense_cta_n_alignment;
 
 namespace {
 
@@ -53,12 +53,12 @@ class Sm70U8B128IteratorB {
   static int const kPackedMacroN = PackedMacroN_;
   static constexpr bool kUseMetadataVectorWords = UseMetadataVectorWords_;
   using Element = cutlass::half_t;
-  using Fragment = cutlass::Array<
-      Element, ThreadMap::Iterations::kCount * ThreadMap::kElementsPerAccess>;
-  static_assert(Shape::kN == 64 || Shape::kN == 128 || Shape::kN == 256,
-                "SM70 Marlin U8B128 IteratorB expects CTA_N in {64, 128, 256}.");
-  static_assert(ThreadMap::Iterations::kContiguous ==
-                    Shape::kN / kQuantTileN,
+  using Fragment = cutlass::Array<Element, ThreadMap::Iterations::kCount *
+                                               ThreadMap::kElementsPerAccess>;
+  static_assert(
+      Shape::kN == 64 || Shape::kN == 128 || Shape::kN == 256,
+      "SM70 Marlin U8B128 IteratorB expects CTA_N in {64, 128, 256}.");
+  static_assert(ThreadMap::Iterations::kContiguous == Shape::kN / kQuantTileN,
                 "SM70 Marlin U8B128 IteratorB expects one contiguous iteration "
                 "per 64-column quant tile.");
   static_assert(ThreadMap::Delta::kContiguous == kQuantTileN,
@@ -150,8 +150,7 @@ class Sm70U8B128IteratorB {
     if constexpr (kGroupSize == -1) {
       return 0;
     } else {
-      static_assert(kGroupSize == 32 || kGroupSize == 64 ||
-                        kGroupSize == 128,
+      static_assert(kGroupSize == 32 || kGroupSize == 64 || kGroupSize == 128,
                     "SM70 Marlin U8B128 supports only group sizes "
                     "-1, 32, 64, and 128.");
       return logical_k / kGroupSize;
@@ -161,13 +160,12 @@ class Sm70U8B128IteratorB {
   CUTLASS_DEVICE
   static int qweight_offset_from_logical(Params const& params, int logical_k,
                                          int logical_n) {
-    return u8_packed_macro_n_qweight_offset_from_logical<kPackedMacroN>(params.size_n, logical_k,
-                                                     logical_n);
+    return u8_packed_macro_n_qweight_offset_from_logical<kPackedMacroN>(
+        params.size_n, logical_k, logical_n);
   }
 
   CUTLASS_DEVICE
-  static int qweight_word_stride_from_logical(Params const&,
-                                              int logical_n) {
+  static int qweight_word_stride_from_logical(Params const&, int logical_n) {
     return u8_packed_macro_n_qweight_word_stride<kPackedMacroN>();
   }
 
@@ -198,9 +196,8 @@ class Sm70U8B128IteratorB {
   void cache_current_group_metadata(int group) const {
     CUTLASS_PRAGMA_UNROLL
     for (int c = 0; c < ThreadMap::Iterations::kContiguous; ++c) {
-      int const cache_n =
-          n_offset_ + thread_offset_.contiguous() +
-          c * ThreadMap::Delta::kContiguous;
+      int const cache_n = n_offset_ + thread_offset_.contiguous() +
+                          c * ThreadMap::Delta::kContiguous;
       if constexpr (kUseMetadataVectorWords) {
         cache_metadata_vector_words(c, group, cache_n);
       } else {
@@ -261,8 +258,9 @@ class Sm70U8B128IteratorB {
           frag_vec[3] = __hmul2(deq[1], scale_vec[3]);
         }
       } else {
-        static_assert(ThreadMap::Iterations::kContiguous == 1,
-                      "Unsupported SM70 Marlin U8B128 contiguous iteration count.");
+        static_assert(
+            ThreadMap::Iterations::kContiguous == 1,
+            "Unsupported SM70 Marlin U8B128 contiguous iteration count.");
         uint32_t const qword0 =
             load_qword_vector<1>(qweight_ + qweight_base_offset_);
         uint32_t const qword1 = load_qword_vector<1>(
@@ -284,19 +282,17 @@ class Sm70U8B128IteratorB {
       int const logical_n_base = n_offset_ + thread_offset_.contiguous();
       CUTLASS_PRAGMA_UNROLL
       for (int s = 0; s < ThreadMap::Iterations::kStrided; ++s) {
-        int const logical_k_s =
-            k_offset_ + thread_offset_.strided() +
-            s * ThreadMap::Delta::kStrided;
+        int const logical_k_s = k_offset_ + thread_offset_.strided() +
+                                s * ThreadMap::Delta::kStrided;
         if constexpr (kGroupSize != -1) {
           cache_current_group_metadata(scale_group(logical_k_s));
         }
         int const qweight_base_s =
             qweight_offset_from_logical(params_, logical_k_s, logical_n_base);
         if constexpr (ThreadMap::Iterations::kContiguous == 4) {
-          uint4 const qwords0 =
-              load_qword_vector<4>(qweight_ + qweight_base_s);
-          uint4 const qwords1 = load_qword_vector<4>(
-              qweight_ + qweight_base_s + kQweightWordStrideWords);
+          uint4 const qwords0 = load_qword_vector<4>(qweight_ + qweight_base_s);
+          uint4 const qwords1 = load_qword_vector<4>(qweight_ + qweight_base_s +
+                                                     kQweightWordStrideWords);
           CUTLASS_PRAGMA_UNROLL
           for (int c = 0; c < ThreadMap::Iterations::kContiguous; ++c) {
             constexpr int kAccess = ThreadMap::kElementsPerAccess;
@@ -318,10 +314,9 @@ class Sm70U8B128IteratorB {
             frag_vec[3] = __hmul2(deq[1], scale_vec[3]);
           }
         } else if constexpr (ThreadMap::Iterations::kContiguous == 2) {
-          uint2 const qwords0 =
-              load_qword_vector<2>(qweight_ + qweight_base_s);
-          uint2 const qwords1 = load_qword_vector<2>(
-              qweight_ + qweight_base_s + kQweightWordStrideWords);
+          uint2 const qwords0 = load_qword_vector<2>(qweight_ + qweight_base_s);
+          uint2 const qwords1 = load_qword_vector<2>(qweight_ + qweight_base_s +
+                                                     kQweightWordStrideWords);
           CUTLASS_PRAGMA_UNROLL
           for (int c = 0; c < ThreadMap::Iterations::kContiguous; ++c) {
             constexpr int kAccess = ThreadMap::kElementsPerAccess;
@@ -343,8 +338,9 @@ class Sm70U8B128IteratorB {
             frag_vec[3] = __hmul2(deq[1], scale_vec[3]);
           }
         } else {
-          static_assert(ThreadMap::Iterations::kContiguous == 1,
-                        "Unsupported SM70 Marlin U8B128 contiguous iteration count.");
+          static_assert(
+              ThreadMap::Iterations::kContiguous == 1,
+              "Unsupported SM70 Marlin U8B128 contiguous iteration count.");
           uint32_t const qword0 =
               load_qword_vector<1>(qweight_ + qweight_base_s);
           uint32_t const qword1 = load_qword_vector<1>(
@@ -374,8 +370,7 @@ class Sm70U8B128IteratorB {
       return;
     }
 
-    if constexpr (kGroupSize != -1 &&
-                  ThreadMap::Iterations::kStrided == 1) {
+    if constexpr (kGroupSize != -1 && ThreadMap::Iterations::kStrided == 1) {
       int const first_logical_k = k_offset_ + thread_offset_.strided();
       cache_current_group_metadata(scale_group(first_logical_k));
     }
@@ -387,32 +382,29 @@ class Sm70U8B128IteratorB {
 template <bool UseMetadataVectorWords = true>
 struct Sm70U8B128GemmSpec {
   template <typename Shape, typename ThreadMap, int GroupSize, int PackedMacroN>
-  using IteratorB =
-      Sm70U8B128IteratorB<Shape, ThreadMap, GroupSize, PackedMacroN,
-                          UseMetadataVectorWords>;
+  using IteratorB = Sm70U8B128IteratorB<Shape, ThreadMap, GroupSize,
+                                        PackedMacroN, UseMetadataVectorWords>;
 };
 
-template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM,
-          int WarpN, int WarpK, int GroupSize, int PackedMacroN,
+template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM, int WarpN,
+          int WarpK, int GroupSize, int PackedMacroN,
           bool UseMetadataVectorWords = true>
 using Sm70U8B128GemmTraits =
-    Sm70MarlinGemmTraits<Sm70U8B128GemmSpec<UseMetadataVectorWords>, CtaM,
-                         CtaN, CtaK, Warps, WarpM, WarpN, WarpK,
-                         GroupSize, PackedMacroN>;
+    Sm70MarlinGemmTraits<Sm70U8B128GemmSpec<UseMetadataVectorWords>, CtaM, CtaN,
+                         CtaK, Warps, WarpM, WarpN, WarpK, GroupSize,
+                         PackedMacroN>;
 
-template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM,
-          int WarpN, int WarpK, int GroupSize, int PackedMacroN,
+template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM, int WarpN,
+          int WarpK, int GroupSize, int PackedMacroN,
           bool UseMetadataVectorWords = true>
-__global__ __launch_bounds__(Warps * 32, 1)
-void sm70_marlin_u8b128_gemm_kernel(
+__global__ __launch_bounds__(Warps * 32, 1) void sm70_marlin_u8b128_gemm_kernel(
     cutlass::half_t const* __restrict__ a,
     uint32_t const* __restrict__ b_q_weight,
     cutlass::half_t const* __restrict__ b_scales,
     cutlass::half_t* __restrict__ c, int m, int n, int k, int lda) {
   using Traits =
       Sm70U8B128GemmTraits<CtaM, CtaN, CtaK, Warps, WarpM, WarpN, WarpK,
-                           GroupSize, PackedMacroN,
-                           UseMetadataVectorWords>;
+                           GroupSize, PackedMacroN, UseMetadataVectorWords>;
   using Mma = typename Traits::Mma;
   using Epilogue = typename Traits::Epilogue;
 
@@ -432,10 +424,10 @@ void sm70_marlin_u8b128_gemm_kernel(
   typename Traits::LayoutA layout_a(lda);
   typename Traits::LayoutC layout_c(n);
 
-  typename Mma::IteratorA iterator_A(
-      typename Mma::IteratorA::Params(layout_a),
-      const_cast<cutlass::half_t*>(a), cutlass::MatrixCoord(m, k), thread_idx,
-      tb_offset_A);
+  typename Mma::IteratorA iterator_A(typename Mma::IteratorA::Params(layout_a),
+                                     const_cast<cutlass::half_t*>(a),
+                                     cutlass::MatrixCoord(m, k), thread_idx,
+                                     tb_offset_A);
   typename Mma::IteratorB iterator_B(
       typename Mma::IteratorB::Params(k, n),
       reinterpret_cast<uint32_t const*>(b_q_weight),
@@ -460,18 +452,19 @@ void sm70_marlin_u8b128_gemm_kernel(
   epilogue(output_op, iterator_D, accumulators, iterator_C);
 }
 
-template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM,
-          int WarpN, int WarpK, int GroupSize, int PackedMacroN,
+template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM, int WarpN,
+          int WarpK, int GroupSize, int PackedMacroN,
           bool UseMetadataVectorWords = true>
-__global__ __launch_bounds__(Warps * 32, 1)
-void sm70_marlin_u8b128_gemm_splitk_kernel(
+__global__
+__launch_bounds__(Warps * 32, 1) void sm70_marlin_u8b128_gemm_splitk_kernel(
     cutlass::half_t const* __restrict__ a,
     uint32_t const* __restrict__ b_q_weight,
     cutlass::half_t const* __restrict__ b_scales,
-    cutlass::half_t* __restrict__ c, int m, int n, int k, int lda, int requested_split_k) {
-  using Traits = Sm70U8B128GemmTraits<CtaM, CtaN, CtaK, Warps, WarpM,
-                                      WarpN, WarpK, GroupSize, PackedMacroN,
-                                      UseMetadataVectorWords>;
+    cutlass::half_t* __restrict__ c, int m, int n, int k, int lda,
+    int requested_split_k) {
+  using Traits =
+      Sm70U8B128GemmTraits<CtaM, CtaN, CtaK, Warps, WarpM, WarpN, WarpK,
+                           GroupSize, PackedMacroN, UseMetadataVectorWords>;
   using Mma = typename Traits::Mma;
   using AtomicEpilogue = Sm70AtomicFp16Epilogue<Traits>;
 
@@ -482,14 +475,13 @@ void sm70_marlin_u8b128_gemm_splitk_kernel(
   int const thread_idx = threadIdx.x;
   int const warp_idx = cutlass::canonical_warp_idx_sync();
   int const lane_idx = threadIdx.x % 32;
-  Sm70SplitKPartition const partition =
-      sm70_splitk_partition<GroupSize, CtaK>(k, requested_split_k, int(blockIdx.z));
+  Sm70SplitKPartition const partition = sm70_splitk_partition<GroupSize, CtaK>(
+      k, requested_split_k, int(blockIdx.z));
   if (partition.partition_k == 0) {
     return;
   }
 
-  cutlass::MatrixCoord tb_offset_A{int(blockIdx.x) * CtaM,
-                                   partition.k_begin};
+  cutlass::MatrixCoord tb_offset_A{int(blockIdx.x) * CtaM, partition.k_begin};
   cutlass::MatrixCoord tb_offset_B{partition.k_begin, int(blockIdx.y) * CtaN};
   cutlass::MatrixCoord tb_offset_C{int(blockIdx.x) * CtaM,
                                    int(blockIdx.y) * CtaN};
@@ -497,10 +489,10 @@ void sm70_marlin_u8b128_gemm_splitk_kernel(
   typename Traits::LayoutA layout_a(lda);
   typename Traits::LayoutC layout_c(n);
 
-  typename Mma::IteratorA iterator_A(
-      typename Mma::IteratorA::Params(layout_a),
-      const_cast<cutlass::half_t*>(a), cutlass::MatrixCoord(m, k), thread_idx,
-      tb_offset_A);
+  typename Mma::IteratorA iterator_A(typename Mma::IteratorA::Params(layout_a),
+                                     const_cast<cutlass::half_t*>(a),
+                                     cutlass::MatrixCoord(m, k), thread_idx,
+                                     tb_offset_A);
   typename Mma::IteratorB iterator_B(
       typename Mma::IteratorB::Params(k, n),
       reinterpret_cast<uint32_t const*>(b_q_weight),
@@ -514,9 +506,8 @@ void sm70_marlin_u8b128_gemm_splitk_kernel(
   mma(gemm_k_iterations, accumulators, iterator_A, iterator_B, accumulators);
 
   typename AtomicEpilogue::OutputTileIterator iterator_D(
-      typename AtomicEpilogue::OutputTileIterator::Params(layout_c),
-      c, cutlass::MatrixCoord(m, n),
-      thread_idx, tb_offset_C);
+      typename AtomicEpilogue::OutputTileIterator::Params(layout_c), c,
+      cutlass::MatrixCoord(m, n), thread_idx, tb_offset_C);
 
   AtomicEpilogue epilogue(shared_storage.epilogue, thread_idx, warp_idx,
                           lane_idx);
@@ -525,20 +516,23 @@ void sm70_marlin_u8b128_gemm_splitk_kernel(
 
 }  // namespace
 
-template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM,
-          int WarpN, int WarpK, int GroupSize, int PackedMacroN,
+template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM, int WarpN,
+          int WarpK, int GroupSize, int PackedMacroN,
           bool UseMetadataVectorWords = true>
-torch::Tensor launch_sm70_marlin_u8b128_gemm(
-    torch::Tensor& a, torch::Tensor& c, torch::Tensor& b_q_weight,
-    torch::Tensor& b_scales, int64_t size_m, int64_t size_n, int64_t size_k,
-    int requested_split_k) {
+torch::Tensor launch_sm70_marlin_u8b128_gemm(torch::Tensor& a, torch::Tensor& c,
+                                             torch::Tensor& b_q_weight,
+                                             torch::Tensor& b_scales,
+                                             int64_t size_m, int64_t size_n,
+                                             int64_t size_k,
+                                             int requested_split_k) {
   auto kernel =
       sm70_marlin_u8b128_gemm_kernel<CtaM, CtaN, CtaK, Warps, WarpM, WarpN,
                                      WarpK, GroupSize, PackedMacroN,
                                      UseMetadataVectorWords>;
-  using SharedStorage = typename Sm70U8B128GemmTraits<
-      CtaM, CtaN, CtaK, Warps, WarpM, WarpN, WarpK, GroupSize,
-      PackedMacroN, UseMetadataVectorWords>::SharedStorage;
+  using SharedStorage =
+      typename Sm70U8B128GemmTraits<CtaM, CtaN, CtaK, Warps, WarpM, WarpN,
+                                    WarpK, GroupSize, PackedMacroN,
+                                    UseMetadataVectorWords>::SharedStorage;
   size_t smem_bytes = configure_sm70_dynamic_smem<SharedStorage>(kernel);
 
   dim3 block(Warps * 32);
@@ -558,21 +552,19 @@ torch::Tensor launch_sm70_marlin_u8b128_gemm(
   }
 
   TORCH_CHECK(size_k % int64_t(CtaK) == 0,
-              "SM70 Marlin uint8b128 requires K divisible by CTA_K=",
-              CtaK, " for requested_split_k > 1. Got K=", size_k,
+              "SM70 Marlin uint8b128 requires K divisible by CTA_K=", CtaK,
+              " for requested_split_k > 1. Got K=", size_k,
               ", requested_split_k=", requested_split_k, ".");
 
-  auto split_kernel =
-      sm70_marlin_u8b128_gemm_splitk_kernel<CtaM, CtaN, CtaK, Warps, WarpM,
-                                            WarpN, WarpK, GroupSize,
-                                            PackedMacroN,
-                                            UseMetadataVectorWords>;
+  auto split_kernel = sm70_marlin_u8b128_gemm_splitk_kernel<
+      CtaM, CtaN, CtaK, Warps, WarpM, WarpN, WarpK, GroupSize, PackedMacroN,
+      UseMetadataVectorWords>;
   smem_bytes = configure_sm70_dynamic_smem<SharedStorage>(split_kernel);
 
   int64_t const numel = size_m * size_n;
-  C10_CUDA_CHECK(cudaMemsetAsync(
-      c.data_ptr<at::Half>(), 0,
-      static_cast<size_t>(numel) * sizeof(at::Half), stream));
+  C10_CUDA_CHECK(cudaMemsetAsync(c.data_ptr<at::Half>(), 0,
+                                 static_cast<size_t>(numel) * sizeof(at::Half),
+                                 stream));
 
   dim3 grid = sm70_marlin_cta_grid(size_m, size_n, CtaM, CtaN);
   int const active_split_k =
@@ -584,7 +576,8 @@ torch::Tensor launch_sm70_marlin_u8b128_gemm(
       reinterpret_cast<cutlass::half_t const*>(b_scales.data_ptr<at::Half>()),
       reinterpret_cast<cutlass::half_t*>(c.data_ptr<at::Half>()),
       static_cast<int>(size_m), static_cast<int>(size_n),
-      static_cast<int>(size_k), static_cast<int>(a.stride(0)), requested_split_k);
+      static_cast<int>(size_k), static_cast<int>(a.stride(0)),
+      requested_split_k);
   C10_CUDA_KERNEL_LAUNCH_CHECK();
 
   return c;
@@ -601,12 +594,11 @@ struct Sm70U8B128Launcher {
   int64_t size_k;
   int requested_split_k;
 
-  template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM,
-            int WarpN, int WarpK, int GroupSize, int PackedMacroN>
+  template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM, int WarpN,
+            int WarpK, int GroupSize, int PackedMacroN>
   torch::Tensor operator()() const {
-    return launch_sm70_marlin_u8b128_gemm<CtaM, CtaN, CtaK, Warps, WarpM,
-                                          WarpN, WarpK, GroupSize,
-                                          PackedMacroN,
+    return launch_sm70_marlin_u8b128_gemm<CtaM, CtaN, CtaK, Warps, WarpM, WarpN,
+                                          WarpK, GroupSize, PackedMacroN,
                                           UseMetadataVectorWords>(
         a, c, b_q_weight, b_scales, size_m, size_n, size_k, requested_split_k);
   }
@@ -619,21 +611,23 @@ torch::Tensor sm70_marlin_u8b128_gemm(torch::Tensor& a, torch::Tensor& c,
                                       int64_t group_size) {
   c10::cuda::CUDAGuard device_guard(a.device());
 
-  auto const params = sm70_marlin_dense_auto_params(
-      "uint8b128", group_size, size_m, size_n, size_k);
+  auto const params = sm70_marlin_dense_auto_params("uint8b128", group_size,
+                                                    size_m, size_n, size_k);
   Sm70CtaGeometry const geometry = params.geometry;
-  validate_sm70_marlin_dense_cta_geometry_supported("SM70 Marlin uint8b128", geometry);
-  validate_sm70_marlin_dense_cta_n_alignment("SM70 Marlin uint8b128", geometry, size_n);
+  validate_sm70_marlin_dense_cta_geometry_supported("SM70 Marlin uint8b128",
+                                                    geometry);
+  validate_sm70_marlin_dense_cta_n_alignment("SM70 Marlin uint8b128", geometry,
+                                             size_n);
   if (params.use_metadata_vector_words) {
     Sm70U8B128Launcher<true> const launcher{
-        a, c, b_q_weight, b_scales, size_m, size_n, size_k,
-        params.requested_split_k};
+        a,      c,      b_q_weight, b_scales,
+        size_m, size_n, size_k,     params.requested_split_k};
     return dispatch_sm70_marlin_geometry_with_group32(
         launcher, geometry, params.packed_macro_n, group_size, "uint8b128");
   }
   Sm70U8B128Launcher<false> const launcher{
-      a, c, b_q_weight, b_scales, size_m, size_n, size_k,
-      params.requested_split_k};
+      a,      c,      b_q_weight, b_scales,
+      size_m, size_n, size_k,     params.requested_split_k};
   return dispatch_sm70_marlin_geometry_with_group32(
       launcher, geometry, params.packed_macro_n, group_size, "uint8b128");
 }

--- a/csrc/sm70_tile_runtime_signal.cuh
+++ b/csrc/sm70_tile_runtime_signal.cuh
@@ -28,14 +28,13 @@ struct __align__(16) RankSignals {
 #if !defined(USE_ROCM)
 static __device__ __forceinline__ void store_flag_sys_visible(
     FlagType* flag_addr, FlagType flag) {
-  asm volatile("membar.sys; st.volatile.global.u32 [%1], %0;"
-               ::"r"(flag),
+  asm volatile("membar.sys; st.volatile.global.u32 [%1], %0;" ::"r"(flag),
                "l"(flag_addr)
                : "memory");
 }
 
-static __device__ __forceinline__ FlagType load_flag_sys_visible(
-    FlagType* flag_addr) {
+static __device__ __forceinline__ FlagType
+load_flag_sys_visible(FlagType* flag_addr) {
   FlagType flag;
   asm volatile("ld.volatile.global.u32 %0, [%1]; membar.sys;"
                : "=r"(flag)

--- a/csrc/sm70_turbomind/lmdeploy/src/turbomind/core/allocator.cc
+++ b/csrc/sm70_turbomind/lmdeploy/src/turbomind/core/allocator.cc
@@ -9,151 +9,119 @@ namespace turbomind::core {
 
 AllocatorImpl::~AllocatorImpl() = default;
 
-Stream AllocatorImpl::stream() const noexcept
-{
-    return Stream{};
+Stream AllocatorImpl::stream() const noexcept { return Stream{}; }
+
+class CudaMemPoolAllocator : public AllocatorImpl {
+ public:
+  CudaMemPoolAllocator(Stream stream, bool use_default_pool)
+      : pool_{},
+        stream_{stream},
+        device_{kDEVICE},
+        use_default_pool_{use_default_pool} {
+    check_cuda_error(cudaGetDevice(&device_.id));
+    if (use_default_pool_) {
+      check_cuda_error(cudaDeviceGetDefaultMemPool(&pool_, device_.id));
+    } else {
+      cudaMemPoolProps props{};
+      props.allocType = cudaMemAllocationTypePinned;
+      props.handleTypes = cudaMemHandleTypeNone;
+      props.location.type = cudaMemLocationTypeDevice;
+      props.location.id = device_.id;
+      check_cuda_error(cudaMemPoolCreate(&pool_, &props));
+      cuuint64_t thres = (cuuint64_t)-1;
+      check_cuda_error(cudaMemPoolSetAttribute(
+          pool_, cudaMemPoolAttrReleaseThreshold, &thres));
+    }
+  }
+
+  ~CudaMemPoolAllocator() override {
+    if (!use_default_pool_) {
+      check_cuda_error(cudaMemPoolDestroy(pool_));
+    }
+    pool_ = {};
+  }
+
+  void* allocate(ssize_t size) override {
+    void* ptr{};
+    check_cuda_error(
+        cudaMallocFromPoolAsync(&ptr, size, pool_, stream_.handle()));
+    return ptr;
+  }
+
+  void deallocate(void* p, ssize_t) override {
+    check_cuda_error(cudaFreeAsync(p, stream_.handle()));
+  }
+
+  Device device() const noexcept override { return device_; }
+
+  Stream stream() const noexcept override { return stream_; }
+
+  void trim(size_t bytes_to_keep) {
+    check_cuda_error(cudaMemPoolTrimTo(pool_, bytes_to_keep));
+  }
+
+ private:
+  cudaMemPool_t pool_;
+  Stream stream_;
+  Device device_;
+  bool use_default_pool_;
+};
+
+class CudaAllocator : public AllocatorImpl {
+ public:
+  void* allocate(ssize_t size) override {
+    void* ptr{};
+    check_cuda_error(cudaMalloc(&ptr, size));
+    return ptr;
+  }
+
+  void deallocate(void* p, ssize_t) override { check_cuda_error(cudaFree(p)); }
+
+  Device device() const noexcept override { return kDEVICE; }
+};
+
+class CudaHostAllocator : public AllocatorImpl {
+ public:
+  void* allocate(ssize_t size) override {
+    void* ptr{};
+    check_cuda_error(cudaHostAlloc(&ptr, size, cudaHostAllocDefault));
+    return ptr;
+  }
+
+  void deallocate(void* p, ssize_t) override {
+    check_cuda_error(cudaFreeHost(p));
+  }
+
+  Device device() const noexcept override { return kCPUpinned; }
+};
+
+class HostAllocator : public AllocatorImpl {
+ public:
+  void* allocate(ssize_t size) override { return ::operator new(size); }
+
+  void deallocate(void* p, ssize_t) override { ::operator delete(p); }
+
+  Device device() const noexcept override { return kCPU; }
+};
+
+Allocator::Allocator(DeviceType type) {
+  impl_ = [&]() -> shared_ptr<AllocatorImpl> {
+    switch (type) {
+      case kCPU:
+        return std::make_shared<HostAllocator>();
+      case kDEVICE:
+        return std::make_shared<CudaAllocator>();
+      case kCPUpinned:
+        return std::make_shared<CudaHostAllocator>();
+    }
+    return {};
+  }();
+  TM_CHECK_NOTNULL(impl_);
 }
 
-class CudaMemPoolAllocator: public AllocatorImpl {
-public:
-    CudaMemPoolAllocator(Stream stream, bool use_default_pool):
-        pool_{}, stream_{stream}, device_{kDEVICE}, use_default_pool_{use_default_pool}
-    {
-        check_cuda_error(cudaGetDevice(&device_.id));
-        if (use_default_pool_) {
-            check_cuda_error(cudaDeviceGetDefaultMemPool(&pool_, device_.id));
-        }
-        else {
-            cudaMemPoolProps props{};
-            props.allocType     = cudaMemAllocationTypePinned;
-            props.handleTypes   = cudaMemHandleTypeNone;
-            props.location.type = cudaMemLocationTypeDevice;
-            props.location.id   = device_.id;
-            check_cuda_error(cudaMemPoolCreate(&pool_, &props));
-            cuuint64_t thres = (cuuint64_t)-1;
-            check_cuda_error(cudaMemPoolSetAttribute(pool_, cudaMemPoolAttrReleaseThreshold, &thres));
-        }
-    }
-
-    ~CudaMemPoolAllocator() override
-    {
-        if (!use_default_pool_) {
-            check_cuda_error(cudaMemPoolDestroy(pool_));
-        }
-        pool_ = {};
-    }
-
-    void* allocate(ssize_t size) override
-    {
-        void* ptr{};
-        check_cuda_error(cudaMallocFromPoolAsync(&ptr, size, pool_, stream_.handle()));
-        return ptr;
-    }
-
-    void deallocate(void* p, ssize_t) override
-    {
-        check_cuda_error(cudaFreeAsync(p, stream_.handle()));
-    }
-
-    Device device() const noexcept override
-    {
-        return device_;
-    }
-
-    Stream stream() const noexcept override
-    {
-        return stream_;
-    }
-
-    void trim(size_t bytes_to_keep)
-    {
-        check_cuda_error(cudaMemPoolTrimTo(pool_, bytes_to_keep));
-    }
-
-private:
-    cudaMemPool_t pool_;
-    Stream        stream_;
-    Device        device_;
-    bool          use_default_pool_;
-};
-
-class CudaAllocator: public AllocatorImpl {
-public:
-    void* allocate(ssize_t size) override
-    {
-        void* ptr{};
-        check_cuda_error(cudaMalloc(&ptr, size));
-        return ptr;
-    }
-
-    void deallocate(void* p, ssize_t) override
-    {
-        check_cuda_error(cudaFree(p));
-    }
-
-    Device device() const noexcept override
-    {
-        return kDEVICE;
-    }
-};
-
-class CudaHostAllocator: public AllocatorImpl {
-public:
-    void* allocate(ssize_t size) override
-    {
-        void* ptr{};
-        check_cuda_error(cudaHostAlloc(&ptr, size, cudaHostAllocDefault));
-        return ptr;
-    }
-
-    void deallocate(void* p, ssize_t) override
-    {
-        check_cuda_error(cudaFreeHost(p));
-    }
-
-    Device device() const noexcept override
-    {
-        return kCPUpinned;
-    }
-};
-
-class HostAllocator: public AllocatorImpl {
-public:
-    void* allocate(ssize_t size) override
-    {
-        return ::operator new(size);
-    }
-
-    void deallocate(void* p, ssize_t) override
-    {
-        ::operator delete(p);
-    }
-
-    Device device() const noexcept override
-    {
-        return kCPU;
-    }
-};
-
-Allocator::Allocator(DeviceType type)
-{
-    impl_ = [&]() -> shared_ptr<AllocatorImpl> {
-        switch (type) {
-            case kCPU:
-                return std::make_shared<HostAllocator>();
-            case kDEVICE:
-                return std::make_shared<CudaAllocator>();
-            case kCPUpinned:
-                return std::make_shared<CudaHostAllocator>();
-        }
-        return {};
-    }();
-    TM_CHECK_NOTNULL(impl_);
-}
-
-Allocator::Allocator(Stream stream, bool use_default_pool)
-{
-    impl_ = std::make_shared<CudaMemPoolAllocator>(std::move(stream), use_default_pool);
+Allocator::Allocator(Stream stream, bool use_default_pool) {
+  impl_ = std::make_shared<CudaMemPoolAllocator>(std::move(stream),
+                                                 use_default_pool);
 }
 
 }  // namespace turbomind::core

--- a/csrc/sm70_turbomind/lmdeploy/src/turbomind/core/allocator.h
+++ b/csrc/sm70_turbomind/lmdeploy/src/turbomind/core/allocator.h
@@ -11,33 +11,26 @@
 
 namespace turbomind {
 
-enum class DeviceType : int
-{
-    kCPU,
-    kCPUpinned,
-    kDEVICE
-};
+enum class DeviceType : int { kCPU, kCPUpinned, kDEVICE };
 
-inline constexpr DeviceType kCPU       = DeviceType::kCPU;
+inline constexpr DeviceType kCPU = DeviceType::kCPU;
 inline constexpr DeviceType kCPUpinned = DeviceType::kCPUpinned;
-inline constexpr DeviceType kDEVICE    = DeviceType::kDEVICE;
+inline constexpr DeviceType kDEVICE = DeviceType::kDEVICE;
 
-constexpr const char* to_string(DeviceType device)
-{
-    switch (device) {
-        case kCPU:
-            return "cpu";
-        case kCPUpinned:
-            return "cpu_pinned";
-        case kDEVICE:
-            return "device";
-    }
-    return "";
+constexpr const char* to_string(DeviceType device) {
+  switch (device) {
+    case kCPU:
+      return "cpu";
+    case kCPUpinned:
+      return "cpu_pinned";
+    case kDEVICE:
+      return "device";
+  }
+  return "";
 }
 
-inline std::ostream& operator<<(std::ostream& os, DeviceType device)
-{
-    return os << to_string(device);
+inline std::ostream& operator<<(std::ostream& os, DeviceType device) {
+  return os << to_string(device);
 }
 
 }  // namespace turbomind
@@ -45,203 +38,170 @@ inline std::ostream& operator<<(std::ostream& os, DeviceType device)
 namespace turbomind::core {
 
 struct Device {
-    DeviceType type;
-    int        id;
-    Device(): Device{kCPU} {}
-    Device(DeviceType type_): type{type_}, id{-1} {}
-    Device(DeviceType type_, int device_): type{type_}, id{device_} {}
-    friend bool operator==(const Device& a, const Device& b)
-    {
-        return a.type == b.type && a.id == b.id;
-    }
-    friend bool operator!=(const Device& a, const Device& b)
-    {
-        return !(a == b);
-    }
+  DeviceType type;
+  int id;
+  Device() : Device{kCPU} {}
+  Device(DeviceType type_) : type{type_}, id{-1} {}
+  Device(DeviceType type_, int device_) : type{type_}, id{device_} {}
+  friend bool operator==(const Device& a, const Device& b) {
+    return a.type == b.type && a.id == b.id;
+  }
+  friend bool operator!=(const Device& a, const Device& b) { return !(a == b); }
 };
 
 class AllocatorImpl {
-public:
-    virtual ~AllocatorImpl();
+ public:
+  virtual ~AllocatorImpl();
 
-    virtual void* allocate(ssize_t size) = 0;
+  virtual void* allocate(ssize_t size) = 0;
 
-    virtual void deallocate(void* p, ssize_t size) = 0;
+  virtual void deallocate(void* p, ssize_t size) = 0;
 
-    // Returns invalid stream by default
-    virtual Stream stream() const noexcept;
+  // Returns invalid stream by default
+  virtual Stream stream() const noexcept;
 
-    virtual Device device() const noexcept = 0;
+  virtual Device device() const noexcept = 0;
 
-    virtual void trim(size_t bytes_to_keep){};
+  virtual void trim(size_t bytes_to_keep) {};
 };
 
 class Allocator {
-public:
-    Allocator() = default;
+ public:
+  Allocator() = default;
 
-    explicit Allocator(DeviceType type);
+  explicit Allocator(DeviceType type);
 
-    Allocator(Stream stream, bool use_default_pool);
+  Allocator(Stream stream, bool use_default_pool);
 
-    Allocator(shared_ptr<AllocatorImpl> impl): impl_{std::move(impl)} {};
+  Allocator(shared_ptr<AllocatorImpl> impl) : impl_{std::move(impl)} {};
 
-    AllocatorImpl* operator->() const
-    {
-        TM_CHECK_NOTNULL(impl_);
-        return impl_.get();
-    }
+  AllocatorImpl* operator->() const {
+    TM_CHECK_NOTNULL(impl_);
+    return impl_.get();
+  }
 
-    explicit operator bool() const noexcept
-    {
-        return static_cast<bool>(impl_);
-    }
+  explicit operator bool() const noexcept { return static_cast<bool>(impl_); }
 
-    friend bool operator==(const Allocator& a, const Allocator& b)
-    {
-        return a.impl_ == b.impl_;
-    }
+  friend bool operator==(const Allocator& a, const Allocator& b) {
+    return a.impl_ == b.impl_;
+  }
 
-    friend bool operator!=(const Allocator& a, const Allocator& b)
-    {
-        return !(a == b);
-    }
+  friend bool operator!=(const Allocator& a, const Allocator& b) {
+    return !(a == b);
+  }
 
-    template<class T, class... Args>
-    shared_ptr<T> adapt(Args&&... args) const
-    {
-        return {std::make_shared<T>(impl_, ((Args &&) args)...)};
-    }
+  template <class T, class... Args>
+  shared_ptr<T> adapt(Args&&... args) const {
+    return {std::make_shared<T>(impl_, ((Args&&)args)...)};
+  }
 
-private:
-    shared_ptr<AllocatorImpl> impl_;
+ private:
+  shared_ptr<AllocatorImpl> impl_;
 };
 
-class StackAllocatorImpl: public AllocatorImpl {
-public:
-    static constexpr ssize_t kAlignment = 256;
+class StackAllocatorImpl : public AllocatorImpl {
+ public:
+  static constexpr ssize_t kAlignment = 256;
 
-    explicit StackAllocatorImpl(shared_ptr<AllocatorImpl> underlying_impl): underlying_impl_{std::move(underlying_impl)}
-    {
+  explicit StackAllocatorImpl(shared_ptr<AllocatorImpl> underlying_impl)
+      : underlying_impl_{std::move(underlying_impl)} {}
+
+  ~StackAllocatorImpl() override {
+    if (cached_beg_) {
+      underlying_impl_->deallocate(cached_beg_, cached_end_ - cached_beg_);
+    }
+  }
+
+  void* allocate(ssize_t size) override {
+    size = round_up(size, kAlignment);
+
+    void* p{};
+    if (cached_ptr_ + size <= cached_end_) {
+      p = cached_ptr_;
+      cached_ptr_ += size;
+    } else {
+      TM_CHECK(!cached_beg_);
+      p = underlying_impl_->allocate(size);
     }
 
-    ~StackAllocatorImpl() override
-    {
-        if (cached_beg_) {
-            underlying_impl_->deallocate(cached_beg_, cached_end_ - cached_beg_);
-        }
+    // TM_LOG_ERROR("allocate %p, %ld", p, size);
+
+    size_ += size;
+    ++num_;
+    max_size_ = std::max(size_, max_size_);
+    num_ = std::max(num_, max_num_);
+    return p;
+  }
+
+  void deallocate(void* p, ssize_t size) override {
+    size = round_up(size, kAlignment);
+
+    // TM_LOG_ERROR("deallocate %p, %p, %ld", p, cached_ptr_, size);
+
+    if ((char*)p + size == cached_ptr_) {
+      cached_ptr_ -= size;
+    } else {
+      TM_CHECK(!cached_beg_);
+      underlying_impl_->deallocate(p, size);
     }
+    size_ -= size;
+    --num_;
+  }
 
-    void* allocate(ssize_t size) override
-    {
-        size = round_up(size, kAlignment);
+  Stream stream() const noexcept override { return underlying_impl_->stream(); }
 
-        void* p{};
-        if (cached_ptr_ + size <= cached_end_) {
-            p = cached_ptr_;
-            cached_ptr_ += size;
-        }
-        else {
-            TM_CHECK(!cached_beg_);
-            p = underlying_impl_->allocate(size);
-        }
+  Device device() const noexcept override { return underlying_impl_->device(); }
 
-        // TM_LOG_ERROR("allocate %p, %ld", p, size);
-
-        size_ += size;
-        ++num_;
-        max_size_ = std::max(size_, max_size_);
-        num_      = std::max(num_, max_num_);
-        return p;
+  void iter() {
+    TM_CHECK_EQ((void*)cached_beg_, (void*)cached_ptr_);
+    auto expected = max_size_ + kAlignment * max_num_;
+    if (cached_end_ - cached_beg_ < expected) {
+      if (cached_beg_) {
+        underlying_impl_->deallocate(cached_beg_, cached_end_ - cached_beg_);
+      }
+      cached_ptr_ = cached_beg_ = (char*)underlying_impl_->allocate(expected);
+      cached_end_ = cached_beg_ + expected;
     }
+    size_ = num_ = max_size_ = max_num_ = 0;
+  }
 
-    void deallocate(void* p, ssize_t size) override
-    {
-        size = round_up(size, kAlignment);
+ private:
+  ssize_t size_{};
+  ssize_t num_{};
+  ssize_t max_size_{};
+  ssize_t max_num_{};
 
-        // TM_LOG_ERROR("deallocate %p, %p, %ld", p, cached_ptr_, size);
+  char* cached_beg_{};
+  char* cached_end_{};
+  char* cached_ptr_{};
 
-        if ((char*)p + size == cached_ptr_) {
-            cached_ptr_ -= size;
-        }
-        else {
-            TM_CHECK(!cached_beg_);
-            underlying_impl_->deallocate(p, size);
-        }
-        size_ -= size;
-        --num_;
-    }
-
-    Stream stream() const noexcept override
-    {
-        return underlying_impl_->stream();
-    }
-
-    Device device() const noexcept override
-    {
-        return underlying_impl_->device();
-    }
-
-    void iter()
-    {
-        TM_CHECK_EQ((void*)cached_beg_, (void*)cached_ptr_);
-        auto excpected = max_size_ + kAlignment * max_num_;
-        if (cached_end_ - cached_beg_ < excpected) {
-            if (cached_beg_) {
-                underlying_impl_->deallocate(cached_beg_, cached_end_ - cached_beg_);
-            }
-            cached_ptr_ = cached_beg_ = (char*)underlying_impl_->allocate(excpected);
-            cached_end_               = cached_beg_ + excpected;
-        }
-        size_ = num_ = max_size_ = max_num_ = 0;
-    }
-
-private:
-    ssize_t size_{};
-    ssize_t num_{};
-    ssize_t max_size_{};
-    ssize_t max_num_{};
-
-    char* cached_beg_{};
-    char* cached_end_{};
-    char* cached_ptr_{};
-
-    std::shared_ptr<AllocatorImpl> underlying_impl_;
+  std::shared_ptr<AllocatorImpl> underlying_impl_;
 };
 
-class SimpleAllocator: public AllocatorImpl {
-public:
-    template<class Alloc, class Dealloc>
-    static Allocator Create(Alloc&& alloc, Dealloc&& dealloc, Device device)
-    {
-        return Allocator{std::make_shared<SimpleAllocator>((Alloc &&) alloc, (Dealloc &&) dealloc, device)};
-    }
+class SimpleAllocator : public AllocatorImpl {
+ public:
+  template <class Alloc, class Dealloc>
+  static Allocator Create(Alloc&& alloc, Dealloc&& dealloc, Device device) {
+    return Allocator{std::make_shared<SimpleAllocator>(
+        (Alloc&&)alloc, (Dealloc&&)dealloc, device)};
+  }
 
-    template<class Alloc, class Dealloc>
-    SimpleAllocator(Alloc&& alloc, Dealloc&& dealloc, Device device):
-        alloc_{std::move(alloc)}, dealloc_{std ::move(dealloc)}, device_{device}
-    {
-    }
+  template <class Alloc, class Dealloc>
+  SimpleAllocator(Alloc&& alloc, Dealloc&& dealloc, Device device)
+      : alloc_{std::move(alloc)},
+        dealloc_{std ::move(dealloc)},
+        device_{device} {}
 
-    void* allocate(ssize_t size) override
-    {
-        return alloc_(size);
-    };
+  void* allocate(ssize_t size) override { return alloc_(size); };
 
-    void deallocate(void* p, ssize_t size) override
-    {
-        return dealloc_(p, size);
-    }
+  void deallocate(void* p, ssize_t size) override { return dealloc_(p, size); }
 
-    Device device() const noexcept override
-    {
-        return device_;
-    }
+  Device device() const noexcept override { return device_; }
 
-private:
-    std::function<void*(ssize_t)>       alloc_;
-    std::function<void(void*, ssize_t)> dealloc_;
-    Device                              device_;
+ private:
+  std::function<void*(ssize_t)> alloc_;
+  std::function<void(void*, ssize_t)> dealloc_;
+  Device device_;
 };
 
 }  // namespace turbomind::core

--- a/csrc/sm70_turbomind/lmdeploy/src/turbomind/core/buffer.cc
+++ b/csrc/sm70_turbomind/lmdeploy/src/turbomind/core/buffer.cc
@@ -6,93 +6,81 @@
 #include "src/turbomind/core/stream.h"
 namespace turbomind::core {
 
-Buffer Buffer::view(DataType dtype) const
-{
-    auto b = *this;
-    if (dtype == dtype_) {
-        return b;
-    }
-    b.dtype_ = dtype;
-    b.size_  = numel(dtype, byte_size());
-    if (base_) {
-        b.base_ = numel(dtype, turbomind::byte_size(dtype_, base_));
-    }
+Buffer Buffer::view(DataType dtype) const {
+  auto b = *this;
+  if (dtype == dtype_) {
     return b;
+  }
+  b.dtype_ = dtype;
+  b.size_ = numel(dtype, byte_size());
+  if (base_) {
+    b.base_ = numel(dtype, turbomind::byte_size(dtype_, base_));
+  }
+  return b;
 }
 
-Buffer Buffer::slice(ssize_t base, ssize_t size) const
-{
-    TM_CHECK_LE(base + size, size_);
-    auto b = *this;
-    b.base_ += base;
-    if (size == -1) {
-        b.size_ -= base;
-    }
-    else {
-        b.size_ = size;
-    }
-    return b;
+Buffer Buffer::slice(ssize_t base, ssize_t size) const {
+  TM_CHECK_LE(base + size, size_);
+  auto b = *this;
+  b.base_ += base;
+  if (size == -1) {
+    b.size_ -= base;
+  } else {
+    b.size_ = size;
+  }
+  return b;
 }
 
-std::ostream& operator<<(std::ostream& os, const Buffer& b)
-{
-    os << b.dtype() << "[" << b.size() << "]@" << b.data_;
-    if (b.base_) {
-        os << "+" << b.base_;
-    }
-    return os;
+std::ostream& operator<<(std::ostream& os, const Buffer& b) {
+  os << b.dtype() << "[" << b.size() << "]@" << b.data_;
+  if (b.base_) {
+    os << "+" << b.base_;
+  }
+  return os;
 }
 
-void Copy(const Buffer& a, ssize_t n, Ref<Buffer> b_, const Stream& stream)
-{
-    auto& b = b_.get();
-    TM_CHECK_EQ(a.dtype(), b.dtype());
-    TM_CHECK_LE(n, a.size());
-    TM_CHECK_LE(n, b.size());
-    if (auto size = byte_size(a.dtype(), n)) {
-        check_cuda_error(cudaMemcpyAsync(b.raw_data(), a.raw_data(), size, cudaMemcpyDefault, stream.handle()));
-    }
+void Copy(const Buffer& a, ssize_t n, Ref<Buffer> b_, const Stream& stream) {
+  auto& b = b_.get();
+  TM_CHECK_EQ(a.dtype(), b.dtype());
+  TM_CHECK_LE(n, a.size());
+  TM_CHECK_LE(n, b.size());
+  if (auto size = byte_size(a.dtype(), n)) {
+    check_cuda_error(cudaMemcpyAsync(b.raw_data(), a.raw_data(), size,
+                                     cudaMemcpyDefault, stream.handle()));
+  }
 }
 
-void Copy(const Buffer& a, ssize_t n, Ref<Buffer> b_)
-{
-    Copy(a, n, b_, Context::stream());
+void Copy(const Buffer& a, ssize_t n, Ref<Buffer> b_) {
+  Copy(a, n, b_, Context::stream());
 }
 
-void Copy(const Buffer& a, Ref<Buffer> b_, const Stream& stream)
-{
-    TM_CHECK_EQ(a.size(), b_.get().size());
-    Copy(a, a.size(), b_, stream);
+void Copy(const Buffer& a, Ref<Buffer> b_, const Stream& stream) {
+  TM_CHECK_EQ(a.size(), b_.get().size());
+  Copy(a, a.size(), b_, stream);
 }
 
-void Copy(const Buffer& a, Ref<Buffer> b_)
-{
-    Copy(a, b_, Context::stream());
-}
+void Copy(const Buffer& a, Ref<Buffer> b_) { Copy(a, b_, Context::stream()); }
 
 namespace detail {
 
-void* Copy(const void* a, ssize_t n, void* b, const Stream& stream)
-{
-    if (n) {
-        check_cuda_error(cudaMemcpyAsync(b, a, n, cudaMemcpyDefault, stream.handle()));
-    }
-    return (uint8_t*)b + n;
+void* Copy(const void* a, ssize_t n, void* b, const Stream& stream) {
+  if (n) {
+    check_cuda_error(
+        cudaMemcpyAsync(b, a, n, cudaMemcpyDefault, stream.handle()));
+  }
+  return (uint8_t*)b + n;
 }
 
 }  // namespace detail
 
-void Clear(Ref<Buffer> b_, const Stream& stream)
-{
-    auto& b = b_.get();
-    if (auto size = b.byte_size()) {
-        check_cuda_error(cudaMemsetAsync(b.raw_data(), 0, b.byte_size(), stream.handle()));
-    }
+void Clear(Ref<Buffer> b_, const Stream& stream) {
+  auto& b = b_.get();
+  if (auto size = b.byte_size()) {
+    check_cuda_error(
+        cudaMemsetAsync(b.raw_data(), 0, b.byte_size(), stream.handle()));
+  }
 }
 
-void Clear(Ref<Buffer> b_)
-{
-    Clear(b_, Context::stream());
-}
+void Clear(Ref<Buffer> b_) { Clear(b_, Context::stream()); }
 
 }  // namespace turbomind::core

--- a/csrc/sm70_turbomind/lmdeploy/src/turbomind/core/buffer.h
+++ b/csrc/sm70_turbomind/lmdeploy/src/turbomind/core/buffer.h
@@ -15,301 +15,227 @@
 namespace turbomind::core {
 
 class Buffer {
-public:
-    Buffer(): data_{}, base_{}, size_{}, device_{}, dtype_{} {}
+ public:
+  Buffer() : data_{}, base_{}, size_{}, device_{}, dtype_{} {}
 
-    // Typed empty buffer
-    explicit Buffer(DataType dtype): Buffer()
-    {
-        dtype_ = dtype;
+  // Typed empty buffer
+  explicit Buffer(DataType dtype) : Buffer() { dtype_ = dtype; }
+
+  // Reference into `data` buffer
+  template <class T>
+  Buffer(T* data, ssize_t size, Device device)
+      : data_{data, [](auto) {}},
+        base_{},
+        size_{size},
+        device_{device},
+        dtype_{data_type_v<T>} {}
+
+  Buffer(void* data, ssize_t size, DataType dtype, Device device)
+      : data_{data, [](auto) {}},
+        base_{},
+        size_{size},
+        device_{device},
+        dtype_{dtype} {}
+
+  // Share ownership of `data`
+  Buffer(shared_ptr<void> data, ssize_t size, DataType dtype, Device device)
+      : data_{std::move(data)},
+        base_{},
+        size_{size},
+        device_{device},
+        dtype_{dtype} {}
+
+  // Create from the allocator
+  Buffer(ssize_t size, DataType dtype, Allocator& alloc)
+      : base_{}, size_{size}, device_{alloc->device()}, dtype_{dtype} {
+    auto bytes = turbomind::byte_size(dtype, size);
+    data_ = {alloc->allocate(bytes),
+             [=](auto p) { alloc->deallocate(p, bytes); }};
+  }
+
+  Buffer(ssize_t size, DataType dtype, Device device)
+      : Buffer{size, dtype, Context::alloc(device)} {}
+
+  template <class T>
+  T* data() {
+    TM_CHECK_EQ(data_type_v<T>, dtype_);
+    return (T*)((char*)TM_CHECK_NOTNULL(data_).get() +
+                turbomind::byte_size<T>(base_));
+  }
+
+  template <class T>
+  const T* data() const {
+    return const_cast<Buffer*>(this)->data<T>();
+  }
+
+  void* raw_data(ssize_t offset = 0) {
+    return (char*)TM_CHECK_NOTNULL(data_).get() +
+           turbomind::byte_size(dtype_, base_ + offset);
+  }
+
+  const void* raw_data(ssize_t offset = 0) const {
+    return const_cast<Buffer*>(this)->raw_data(offset);
+  }
+
+  template <class T>
+  T* data_or(T* other) noexcept {
+    if constexpr (std::is_void_v<T>) {
+      return data_ ? (T*)raw_data() : other;
+    } else {
+      return data_ ? data<T>() : other;
     }
+  }
 
-    // Reference into `data` buffer
-    template<class T>
-    Buffer(T* data, ssize_t size, Device device):
-        data_{data, [](auto) {}}, base_{}, size_{size}, device_{device}, dtype_{data_type_v<T>}
-    {
-    }
+  template <class T>
+  const T* data_or(const T* other) const noexcept {
+    return const_cast<Buffer*>(this)->data_or(other);
+  }
 
-    Buffer(void* data, ssize_t size, DataType dtype, Device device):
-        data_{data, [](auto) {}}, base_{}, size_{size}, device_{device}, dtype_{dtype}
-    {
-    }
+  DataType dtype() const { return dtype_; }
 
-    // Share ownership of `data`
-    Buffer(shared_ptr<void> data, ssize_t size, DataType dtype, Device device):
-        data_{std::move(data)}, base_{}, size_{size}, device_{device}, dtype_{dtype}
-    {
-    }
+  Device device() const { return device_; }
 
-    // Create from the allocator
-    Buffer(ssize_t size, DataType dtype, Allocator& alloc):
-        base_{}, size_{size}, device_{alloc->device()}, dtype_{dtype}
-    {
-        auto bytes = turbomind::byte_size(dtype, size);
-        data_      = {alloc->allocate(bytes), [=](auto p) { alloc->deallocate(p, bytes); }};
-    }
+  ssize_t size() const { return size_; }
 
-    Buffer(ssize_t size, DataType dtype, Device device): Buffer{size, dtype, Context::alloc(device)} {}
+  ssize_t byte_size() const { return turbomind::byte_size(dtype_, size_); }
 
-    template<class T>
-    T* data()
-    {
-        TM_CHECK_EQ(data_type_v<T>, dtype_);
-        return (T*)((char*)TM_CHECK_NOTNULL(data_).get() + turbomind::byte_size<T>(base_));
-    }
+  explicit operator bool() const noexcept { return static_cast<bool>(data_); }
 
-    template<class T>
-    const T* data() const
-    {
-        return const_cast<Buffer*>(this)->data<T>();
-    }
+  Buffer view(DataType dtype) const;
 
-    void* raw_data(ssize_t offset = 0)
-    {
-        return (char*)TM_CHECK_NOTNULL(data_).get() + turbomind::byte_size(dtype_, base_ + offset);
-    }
+  template <class T>
+  Buffer view() const {
+    return view(data_type_v<T>);
+  }
 
-    const void* raw_data(ssize_t offset = 0) const
-    {
-        return const_cast<Buffer*>(this)->raw_data(offset);
-    }
+  Buffer slice(ssize_t base, ssize_t size) const;
 
-    template<class T>
-    T* data_or(T* other) noexcept
-    {
-        if constexpr (std::is_void_v<T>) {
-            return data_ ? (T*)raw_data() : other;
-        }
-        else {
-            return data_ ? data<T>() : other;
-        }
-    }
+  Buffer borrow() const {
+    return Buffer{const_cast<void*>(raw_data()), size_, dtype_, device_};
+  }
 
-    template<class T>
-    const T* data_or(const T* other) const noexcept
-    {
-        return const_cast<Buffer*>(this)->data_or(other);
-    }
+  friend bool operator==(const Buffer& a, const Buffer& b);
 
-    DataType dtype() const
-    {
-        return dtype_;
-    }
+  friend bool operator!=(const Buffer& a, const Buffer& b);
 
-    Device device() const
-    {
-        return device_;
-    }
+  friend std::ostream& operator<<(std::ostream& os, const Buffer& b);
 
-    ssize_t size() const
-    {
-        return size_;
-    }
+ protected:
+  auto as_tuple() const {
+    return std::tie(data_, base_, size_, dtype_, device_);
+  }
 
-    ssize_t byte_size() const
-    {
-        return turbomind::byte_size(dtype_, size_);
-    }
-
-    explicit operator bool() const noexcept
-    {
-        return static_cast<bool>(data_);
-    }
-
-    Buffer view(DataType dtype) const;
-
-    template<class T>
-    Buffer view() const
-    {
-        return view(data_type_v<T>);
-    }
-
-    Buffer slice(ssize_t base, ssize_t size) const;
-
-    Buffer borrow() const
-    {
-        return Buffer{const_cast<void*>(raw_data()), size_, dtype_, device_};
-    }
-
-    friend bool operator==(const Buffer& a, const Buffer& b);
-
-    friend bool operator!=(const Buffer& a, const Buffer& b);
-
-    friend std::ostream& operator<<(std::ostream& os, const Buffer& b);
-
-protected:
-    auto as_tuple() const
-    {
-        return std::tie(data_, base_, size_, dtype_, device_);
-    }
-
-    shared_ptr<void> data_;
-    ssize_t          base_;
-    ssize_t          size_;
-    Device           device_;
-    DataType         dtype_;
+  shared_ptr<void> data_;
+  ssize_t base_;
+  ssize_t size_;
+  Device device_;
+  DataType dtype_;
 };
 
-inline bool operator==(const Buffer& a, const Buffer& b)
-{
-    return a.as_tuple() == b.as_tuple();
+inline bool operator==(const Buffer& a, const Buffer& b) {
+  return a.as_tuple() == b.as_tuple();
 }
 
-inline bool operator!=(const Buffer& a, const Buffer& b)
-{
-    return !(a == b);
+inline bool operator!=(const Buffer& a, const Buffer& b) { return !(a == b); }
+
+inline Buffer empty_like(const Buffer& buffer) {
+  return Buffer{buffer.size(), buffer.dtype(), buffer.device()};
 }
 
-inline Buffer empty_like(const Buffer& buffer)
-{
-    return Buffer{buffer.size(), buffer.dtype(), buffer.device()};
+inline Buffer empty_like(const Buffer& buffer, Device device) {
+  return Buffer{buffer.size(), buffer.dtype(), device};
 }
 
-inline Buffer empty_like(const Buffer& buffer, Device device)
-{
-    return Buffer{buffer.size(), buffer.dtype(), device};
+inline Buffer empty_like(const Buffer& buffer, DataType dtype) {
+  return Buffer{buffer.size(), dtype, buffer.device()};
 }
 
-inline Buffer empty_like(const Buffer& buffer, DataType dtype)
-{
-    return Buffer{buffer.size(), dtype, buffer.device()};
-}
+template <class T>
+struct Buffer_ : public Buffer {
+  Buffer_() : Buffer{data_type_v<T>} {}
 
-template<class T>
-struct Buffer_: public Buffer {
+  Buffer_(T* data, ssize_t size, Device device) : Buffer{data, size, device} {}
 
-    Buffer_(): Buffer{data_type_v<T>} {}
+  Buffer_(shared_ptr<void> data, ssize_t size, Device device)
+      : Buffer{std::move(data), size, data_type_v<T>, device} {}
 
-    Buffer_(T* data, ssize_t size, Device device): Buffer{data, size, device} {}
+  Buffer_(ssize_t size, Allocator& alloc)
+      : Buffer{size, data_type_v<T>, alloc} {}
 
-    Buffer_(shared_ptr<void> data, ssize_t size, Device device): Buffer{std::move(data), size, data_type_v<T>, device}
-    {
-    }
+  Buffer_(ssize_t size, Device device) : Buffer{size, data_type_v<T>, device} {}
 
-    Buffer_(ssize_t size, Allocator& alloc): Buffer{size, data_type_v<T>, alloc} {}
+  Buffer_(const Buffer_&) = default;
+  Buffer_& operator=(const Buffer_&) = default;
 
-    Buffer_(ssize_t size, Device device): Buffer{size, data_type_v<T>, device} {}
+  Buffer_(Buffer_&&) noexcept = default;
+  Buffer_& operator=(Buffer_&&) noexcept = default;
 
-    Buffer_(const Buffer_&) = default;
-    Buffer_& operator=(const Buffer_&) = default;
+  Buffer_(const Buffer& b) { *static_cast<Buffer*>(this) = ensure_dtype(b); }
+  Buffer_(Buffer&& b) noexcept {
+    *static_cast<Buffer*>(this) = ensure_dtype(std::move(b));
+  }
 
-    Buffer_(Buffer_&&) noexcept = default;
-    Buffer_& operator=(Buffer_&&) noexcept = default;
+  T* data_or(T* other) { return data_ ? data() : other; }
 
-    Buffer_(const Buffer& b)
-    {
-        *static_cast<Buffer*>(this) = ensure_dtype(b);
-    }
-    Buffer_(Buffer&& b) noexcept
-    {
-        *static_cast<Buffer*>(this) = ensure_dtype(std::move(b));
-    }
+  const T* data_or(const T* other) const { return data_ ? data() : other; }
 
-    T* data_or(T* other)
-    {
-        return data_ ? data() : other;
-    }
+  void* raw_data(ssize_t offset = 0) {
+    return (char*)TM_CHECK_NOTNULL(data_).get() +
+           turbomind::byte_size<T>(base_ + offset);
+  }
 
-    const T* data_or(const T* other) const
-    {
-        return data_ ? data() : other;
-    }
+  const void* raw_data(ssize_t offset = 0) const {
+    return const_cast<Buffer_*>(this)->raw_data(offset);
+  }
 
-    void* raw_data(ssize_t offset = 0)
-    {
-        return (char*)TM_CHECK_NOTNULL(data_).get() + turbomind::byte_size<T>(base_ + offset);
-    }
+  T* data() { return static_cast<T*>(raw_data()); }
 
-    const void* raw_data(ssize_t offset = 0) const
-    {
-        return const_cast<Buffer_*>(this)->raw_data(offset);
-    }
+  const T* data() const { return static_cast<const T*>(raw_data()); }
 
-    T* data()
-    {
-        return static_cast<T*>(raw_data());
-    }
+  T* begin() { return data(); }
 
-    const T* data() const
-    {
-        return static_cast<const T*>(raw_data());
-    }
+  const T* begin() const { return data(); }
 
-    T* begin()
-    {
-        return data();
-    }
+  T* end() { return begin() + size(); }
 
-    const T* begin() const
-    {
-        return data();
-    }
+  const T* end() const { return begin() + size(); }
 
-    T* end()
-    {
-        return begin() + size();
-    }
+  T& operator[](ssize_t i) { return data()[i]; }
 
-    const T* end() const
-    {
-        return begin() + size();
-    }
+  const T& operator[](ssize_t i) const { return data()[i]; }
 
-    T& operator[](ssize_t i)
-    {
-        return data()[i];
-    }
+  T& at(ssize_t i) {
+    TM_CHECK_LT(i, size());
+    return data()[i];
+  }
 
-    const T& operator[](ssize_t i) const
-    {
-        return data()[i];
-    }
+  T& at(ssize_t i) const {
+    TM_CHECK_LT(i, size());
+    return data()[i];
+  }
 
-    T& at(ssize_t i)
-    {
-        TM_CHECK_LT(i, size());
-        return data()[i];
-    }
+  constexpr DataType dtype() const noexcept { return data_type_v<T>; }
 
-    T& at(ssize_t i) const
-    {
-        TM_CHECK_LT(i, size());
-        return data()[i];
-    }
-
-    constexpr DataType dtype() const noexcept
-    {
-        return data_type_v<T>;
-    }
-
-private:
-    template<class U>
-    static decltype(auto) ensure_dtype(U&& u) noexcept
-    {
-        TM_CHECK_EQ(u.dtype(), data_type_v<T>);
-        return (U &&) u;
-    }
+ private:
+  template <class U>
+  static decltype(auto) ensure_dtype(U&& u) noexcept {
+    TM_CHECK_EQ(u.dtype(), data_type_v<T>);
+    return (U&&)u;
+  }
 };
 
-template<class T>
+template <class T>
 class Ref {
-public:
-    Ref(T& x): ref_{x} {}
-    Ref(T&& x): ref_{x} {}
+ public:
+  Ref(T& x) : ref_{x} {}
+  Ref(T&& x) : ref_{x} {}
 
-    operator T&()
-    {
-        return ref_;
-    }
+  operator T&() { return ref_; }
 
-    T& get()
-    {
-        return ref_;
-    }
+  T& get() { return ref_; }
 
-private:
-    T& ref_;
+ private:
+  T& ref_;
 };
 
 void Copy(const Buffer& a, ssize_t n, Ref<Buffer> b_, const Stream& stream);
@@ -321,10 +247,9 @@ void Copy(const Buffer& a, Ref<Buffer> b_, const Stream& stream);
 void Copy(const Buffer& a, Ref<Buffer> b_);
 
 // Static type checking
-template<class T>
-inline void Copy_(const Buffer_<T>& a, ssize_t n, Buffer_<T>& b_)
-{
-    Copy((const Buffer&)a, n, (Buffer&)b_);
+template <class T>
+inline void Copy_(const Buffer_<T>& a, ssize_t n, Buffer_<T>& b_) {
+  Copy((const Buffer&)a, n, (Buffer&)b_);
 }
 
 namespace detail {
@@ -333,35 +258,32 @@ void* Copy(const void* a, ssize_t n, void* b, const Stream& stream);
 
 }  // namespace detail
 
-template<class T>
-inline T* Copy(const T* a, ssize_t n, T* b, const Stream& stream)
-{
-    return (T*)detail::Copy((const void*)a, sizeof(T) * n, (void*)b, stream);
+template <class T>
+inline T* Copy(const T* a, ssize_t n, T* b, const Stream& stream) {
+  return (T*)detail::Copy((const void*)a, sizeof(T) * n, (void*)b, stream);
 }
 
-template<class T>
-inline T* Copy(const T* a, ssize_t n, T* b)
-{
-    return (T*)detail::Copy((const void*)a, sizeof(T) * n, (void*)b, Context::stream());
+template <class T>
+inline T* Copy(const T* a, ssize_t n, T* b) {
+  return (T*)detail::Copy((const void*)a, sizeof(T) * n, (void*)b,
+                          Context::stream());
 }
 
 struct CopyT {
-    template<class... Args>
-    auto operator()(Args&&... args) const
-    {
-        return Copy(((Args &&) args)...);
-    }
+  template <class... Args>
+  auto operator()(Args&&... args) const {
+    return Copy(((Args&&)args)...);
+  }
 };
 
 void Clear(Ref<Buffer> b_, const Stream& stream);
 
 void Clear(Ref<Buffer> b_);
 
-template<class T>
-std::vector<T> to_vector(const Buffer_<T>& b)
-{
-    TM_CHECK(b.device().type == kCPU || b.device().type == kCPUpinned);
-    return std::vector<T>(b.begin(), b.end());
+template <class T>
+std::vector<T> to_vector(const Buffer_<T>& b) {
+  TM_CHECK(b.device().type == kCPU || b.device().type == kCPUpinned);
+  return std::vector<T>(b.begin(), b.end());
 }
 
 // clang-format off

--- a/csrc/sm70_turbomind/lmdeploy/src/turbomind/core/check.cc
+++ b/csrc/sm70_turbomind/lmdeploy/src/turbomind/core/check.cc
@@ -11,80 +11,73 @@ namespace turbomind::core {
 
 namespace {
 
-std::string StripSrcPrefix(const char* file)
-{
-    static const char* flag = std::getenv("TM_SRC_FULL_PATH");
-    if (flag) {
-        return file;
+std::string StripSrcPrefix(const char* file) {
+  static const char* flag = std::getenv("TM_SRC_FULL_PATH");
+  if (flag) {
+    return file;
+  }
+
+  std::filesystem::path path{file};
+  std::filesystem::path ret{
+      path};  // return the original path if anchor is not found
+
+  constexpr auto anchor = "turbomind";
+
+  bool found = false;
+
+  for (const auto& x : path) {
+    if (x == anchor) {
+      found = true;
+      ret.clear();
+    } else if (found) {
+      ret /= x;
     }
+  }
 
-    std::filesystem::path path{file};
-    std::filesystem::path ret{path};  // return the original path if anchor is not found
-
-    constexpr auto anchor = "turbomind";
-
-    bool found = false;
-
-    for (const auto& x : path) {
-        if (x == anchor) {
-            found = true;
-            ret.clear();
-        }
-        else if (found) {
-            ret /= x;
-        }
-    }
-
-    return ret.string();
+  return ret.string();
 }
 
 }  // namespace
 
-CheckOpStringBuilder::CheckOpStringBuilder()
-{
-    oss_ = new std::ostringstream;
+CheckOpStringBuilder::CheckOpStringBuilder() { oss_ = new std::ostringstream; }
+
+std::ostream* CheckOpStringBuilder::ForVal1() {
+  (*oss_) << "(";
+  return oss_;
+}
+std::ostream* CheckOpStringBuilder::ForVal2() {
+  (*oss_) << " vs. ";
+  return oss_;
+}
+std::string* CheckOpStringBuilder::NewString() {
+  (*oss_) << ")";
+  return new std::string{oss_->str()};
 }
 
-std::ostream* CheckOpStringBuilder::ForVal1()
-{
-    (*oss_) << "(";
-    return oss_;
-}
-std::ostream* CheckOpStringBuilder::ForVal2()
-{
-    (*oss_) << " vs. ";
-    return oss_;
-}
-std::string* CheckOpStringBuilder::NewString()
-{
-    (*oss_) << ")";
-    return new std::string{oss_->str()};
+CheckErrorStream::CheckErrorStream(const char* file, int line,
+                                   const char* expr) {
+  oss_ = new std::ostringstream{};
+  *oss_ << StripSrcPrefix(file) << "(" << line << "): Check failed: " << expr
+        << " ";
 }
 
-CheckErrorStream::CheckErrorStream(const char* file, int line, const char* expr)
-{
-    oss_ = new std::ostringstream{};
-    *oss_ << StripSrcPrefix(file) << "(" << line << "): Check failed: " << expr << " ";
+CheckErrorStream::CheckErrorStream(const char* file, int line, const char* expr,
+                                   std::string* str)
+    : CheckErrorStream{file, line, expr} {
+  *oss_ << *str << " ";
 }
 
-CheckErrorStream::CheckErrorStream(const char* file, int line, const char* expr, std::string* str):
-    CheckErrorStream{file, line, expr}
-{
-    *oss_ << *str << " ";
+void CheckErrorStream::Report() {
+  // ! Be aware of `%` in expr
+  std::cerr << "[TM][FATAL] " << oss_->str() << "\n";
+  std::abort();
 }
 
-void CheckErrorStream::Report()
-{
-    // ! Be aware of `%` in expr
-    std::cerr << "[TM][FATAL] " << oss_->str() << "\n";
-    std::abort();
-}
-
-void ReportNullError(const char* file, int line, const char* expr)
-{
-    // ! Be aware of `%` in expr
-    std::cerr << "[TM][FATAL] " << StripSrcPrefix(file) << "(" << line << "): '" << expr << "' Must be non NULL\n";
-    std::abort();
+void ReportNullError(const char* file, int line, const char* expr) {
+  // ! Be aware of `%` in expr
+  std::cerr << "[TM][FATAL] " << StripSrcPrefix(file) << "(" << line << "): '"
+            << expr << "' Must be non NULL\n";
+  std::abort();
 }
 
 }  // namespace turbomind::core

--- a/csrc/sm70_turbomind/lmdeploy/src/turbomind/core/check.h
+++ b/csrc/sm70_turbomind/lmdeploy/src/turbomind/core/check.h
@@ -8,86 +8,82 @@
 namespace turbomind::core {
 
 #if defined(_MSC_VER) && !defined(__clang__)
-#define TM_LIKELY(expr) (expr)
-#define TM_UNLIKELY(expr) (expr)
-#define TM_NOINLINE
-#define TM_UNREACHABLE __assume(0)
+  #define TM_LIKELY(expr) (expr)
+  #define TM_UNLIKELY(expr) (expr)
+  #define TM_NOINLINE
+  #define TM_UNREACHABLE __assume(0)
 #else
-#define TM_LIKELY(expr) (__builtin_expect(bool(expr), 1))
-#define TM_UNLIKELY(expr) (__builtin_expect(bool(expr), 0))
-#define TM_NOINLINE __attribute__((noinline))
-#define TM_UNREACHABLE __builtin_unreachable()
+  #define TM_LIKELY(expr) (__builtin_expect(bool(expr), 1))
+  #define TM_UNLIKELY(expr) (__builtin_expect(bool(expr), 0))
+  #define TM_NOINLINE __attribute__((noinline))
+  #define TM_UNREACHABLE __builtin_unreachable()
 #endif
 
 #define TM_DISABLE_CHECK_STREAM 0
 #define TM_DISABLE_CHECK_OP 0
 
 class CheckErrorStream {
-public:
-    CheckErrorStream(const char* file, int line, const char* expr);
+ public:
+  CheckErrorStream(const char* file, int line, const char* expr);
 
-    CheckErrorStream(const char* file, int line, const char* expr, std::string* str);
+  CheckErrorStream(const char* file, int line, const char* expr,
+                   std::string* str);
 
 #if defined(_MSC_VER) && !defined(__clang__)
-#pragma warning(push)
-#pragma warning(disable : 4722)  // MSVC warns dtor never return
+  #pragma warning(push)
+  #pragma warning(disable : 4722)  // MSVC warns dtor never return
 #endif
-    ~CheckErrorStream()
-    {
-        Report();
-    }
+  ~CheckErrorStream() { Report(); }
 #if defined(_MSC_VER) && !defined(__clang__)
-#pragma warning(pop)
+  #pragma warning(pop)
 #endif
 
-    template<class T>
-    CheckErrorStream& operator<<(const T& msg)
-    {
+  template <class T>
+  CheckErrorStream& operator<<(const T& msg) {
 #if TM_DISABLE_CHECK_STREAM
 #else
-        *oss_ << msg;
+    *oss_ << msg;
 #endif
-        return *this;
-    }
+    return *this;
+  }
 
-private:
-    [[noreturn]] void Report();
+ private:
+  [[noreturn]] void Report();
 
-    std::ostringstream* oss_;
+  std::ostringstream* oss_;
 };
 
 class CheckOpStringBuilder {
-public:
-    CheckOpStringBuilder();
-    std::ostream* ForVal1();
-    std::ostream* ForVal2();
-    std::string*  NewString();
+ public:
+  CheckOpStringBuilder();
+  std::ostream* ForVal1();
+  std::ostream* ForVal2();
+  std::string* NewString();
 
-private:
-    std::ostringstream* oss_;
+ private:
+  std::ostringstream* oss_;
 };
 
-template<class T1, class T2>
+template <class T1, class T2>
 std::string* MakeCheckOpString(const T1& v1, const T2& v2) TM_NOINLINE;
 
-template<class T1, class T2>
-std::string* MakeCheckOpString(const T1& v1, const T2& v2)
-{
-    CheckOpStringBuilder builder;
-    *builder.ForVal1() << v1;
-    *builder.ForVal2() << v2;
-    return builder.NewString();
+template <class T1, class T2>
+std::string* MakeCheckOpString(const T1& v1, const T2& v2) {
+  CheckOpStringBuilder builder;
+  *builder.ForVal1() << v1;
+  *builder.ForVal2() << v2;
+  return builder.NewString();
 }
 
-#define DEFINE_CHECK_OP_IMPL(name, op)                                                                                 \
-    template<class T1, class T2>                                                                                       \
-    inline std::pair<bool, std::string*> name##Impl(const T1& v1, const T2& v2)                                        \
-    {                                                                                                                  \
-        if (TM_LIKELY(v1 op v2))                                                                                       \
-            return {false, nullptr};                                                                                   \
-        else                                                                                                           \
-            return {true, MakeCheckOpString(v1, v2)};                                                                  \
-    }
+#define DEFINE_CHECK_OP_IMPL(name, op)                            \
+  template <class T1, class T2>                                   \
+  inline std::pair<bool, std::string*> name##Impl(const T1& v1,   \
+                                                  const T2& v2) { \
+    if (TM_LIKELY(v1 op v2))                                      \
+      return {false, nullptr};                                    \
+    else                                                          \
+      return {true, MakeCheckOpString(v1, v2)};                   \
+  }
 
 DEFINE_CHECK_OP_IMPL(Check_EQ, ==);
 DEFINE_CHECK_OP_IMPL(Check_NE, !=);
@@ -109,35 +105,36 @@ DEFINE_CHECK_OP_IMPL(Check_GT, >);
 
 #if TM_DISABLE_CHECK_OP
 
-#define TM_CHECK_EQ(a, b) TM_CHECK(a == b)
-#define TM_CHECK_NE(a, b) TM_CHECK(a != b)
-#define TM_CHECK_LE(a, b) TM_CHECK(a <= b)
-#define TM_CHECK_LT(a, b) TM_CHECK(a < b)
-#define TM_CHECK_GE(a, b) TM_CHECK(a >= b)
-#define TM_CHECK_GT(a, b) TM_CHECK(a > b)
+  #define TM_CHECK_EQ(a, b) TM_CHECK(a == b)
+  #define TM_CHECK_NE(a, b) TM_CHECK(a != b)
+  #define TM_CHECK_LE(a, b) TM_CHECK(a <= b)
+  #define TM_CHECK_LT(a, b) TM_CHECK(a < b)
+  #define TM_CHECK_GE(a, b) TM_CHECK(a >= b)
+  #define TM_CHECK_GT(a, b) TM_CHECK(a > b)
 
 #else
 
-#define TM_CHECK_EQ(a, b) TM_CHECK_OP(_EQ, ==, a, b)
-#define TM_CHECK_NE(a, b) TM_CHECK_OP(_NE, !=, a, b)
-#define TM_CHECK_LE(a, b) TM_CHECK_OP(_LE, <=, a, b)
-#define TM_CHECK_LT(a, b) TM_CHECK_OP(_LT, <, a, b)
-#define TM_CHECK_GE(a, b) TM_CHECK_OP(_GE, >=, a, b)
-#define TM_CHECK_GT(a, b) TM_CHECK_OP(_GT, >, a, b)
+  #define TM_CHECK_EQ(a, b) TM_CHECK_OP(_EQ, ==, a, b)
+  #define TM_CHECK_NE(a, b) TM_CHECK_OP(_NE, !=, a, b)
+  #define TM_CHECK_LE(a, b) TM_CHECK_OP(_LE, <=, a, b)
+  #define TM_CHECK_LT(a, b) TM_CHECK_OP(_LT, <, a, b)
+  #define TM_CHECK_GE(a, b) TM_CHECK_OP(_GE, >=, a, b)
+  #define TM_CHECK_GT(a, b) TM_CHECK_OP(_GT, >, a, b)
 
 #endif
 
 [[noreturn]] void ReportNullError(const char* file, int line, const char* expr);
 
-template<class T>
-decltype(auto) EnsureNotNull(const char* file, int line, const char* expr, T&& p)
-{
-    if (TM_UNLIKELY(p == nullptr)) {
-        ReportNullError(file, line, expr);
-    }
-    return (T &&) p;
+template <class T>
+decltype(auto) EnsureNotNull(const char* file, int line, const char* expr,
+                             T&& p) {
+  if (TM_UNLIKELY(p == nullptr)) {
+    ReportNullError(file, line, expr);
+  }
+  return (T&&)p;
 }
 
-#define TM_CHECK_NOTNULL(p) ::turbomind::core::EnsureNotNull(__FILE__, __LINE__, #p, (p))
+#define TM_CHECK_NOTNULL(p) \
+  ::turbomind::core::EnsureNotNull(__FILE__, __LINE__, #p, (p))
 
 }  // namespace turbomind::core

--- a/csrc/sm70_turbomind/lmdeploy/src/turbomind/core/context.cc
+++ b/csrc/sm70_turbomind/lmdeploy/src/turbomind/core/context.cc
@@ -9,136 +9,119 @@ namespace turbomind::core {
 namespace {
 
 struct ContextStorage {
-    enum
-    {
-        stream_bit       = 1,
-        host_alloc_bit   = 2,
-        device_alloc_bit = 4,
-        pinned_alloc_bit = 8,
-    };
+  enum {
+    stream_bit = 1,
+    host_alloc_bit = 2,
+    device_alloc_bit = 4,
+    pinned_alloc_bit = 8,
+  };
 
-    std::stack<Stream>    stream_;
-    std::stack<Allocator> host_alloc_;
-    std::stack<Allocator> device_alloc_;
-    std::stack<Allocator> pinned_alloc_;
-    std::stack<int>       mask_;
+  std::stack<Stream> stream_;
+  std::stack<Allocator> host_alloc_;
+  std::stack<Allocator> device_alloc_;
+  std::stack<Allocator> pinned_alloc_;
+  std::stack<int> mask_;
 
-    ContextStorage()
-    {
-        push(Allocator{kCPU});
+  ContextStorage() { push(Allocator{kCPU}); }
+
+  void push(const Stream& stream) {
+    int mask{};
+    if (stream) {
+      stream_.push(stream);
+      mask = stream_bit;
     }
+    mask_.push(mask);
+  }
 
-    void push(const Stream& stream)
-    {
-        int mask{};
-        if (stream) {
-            stream_.push(stream);
-            mask = stream_bit;
-        }
-        mask_.push(mask);
+  void push(const Allocator& alloc) {
+    int mask{};
+    if (alloc) {
+      const auto type = alloc->device().type;
+      if (type == kCPU) {
+        mask = host_alloc_bit;
+        host_alloc_.push(alloc);
+      } else if (type == kDEVICE) {
+        mask = device_alloc_bit;
+        device_alloc_.push(alloc);
+      } else if (type == kCPUpinned) {
+        mask = pinned_alloc_bit;
+        pinned_alloc_.push(alloc);
+      }
     }
+    mask_.push(mask);
+  }
 
-    void push(const Allocator& alloc)
-    {
-        int mask{};
-        if (alloc) {
-            const auto type = alloc->device().type;
-            if (type == kCPU) {
-                mask = host_alloc_bit;
-                host_alloc_.push(alloc);
-            }
-            else if (type == kDEVICE) {
-                mask = device_alloc_bit;
-                device_alloc_.push(alloc);
-            }
-            else if (type == kCPUpinned) {
-                mask = pinned_alloc_bit;
-                pinned_alloc_.push(alloc);
-            }
-        }
-        mask_.push(mask);
+  void pop() {
+    if (mask_.top() & stream_bit) {
+      stream_.pop();
     }
+    if (mask_.top() & host_alloc_bit) {
+      host_alloc_.pop();
+    }
+    if (mask_.top() & device_alloc_bit) {
+      device_alloc_.pop();
+    }
+    if (mask_.top() & pinned_alloc_bit) {
+      pinned_alloc_.pop();
+    }
+    mask_.pop();
+  }
 
-    void pop()
-    {
-        if (mask_.top() & stream_bit) {
-            stream_.pop();
-        }
-        if (mask_.top() & host_alloc_bit) {
-            host_alloc_.pop();
-        }
-        if (mask_.top() & device_alloc_bit) {
-            device_alloc_.pop();
-        }
-        if (mask_.top() & pinned_alloc_bit) {
-            pinned_alloc_.pop();
-        }
-        mask_.pop();
-    }
-
-    static ContextStorage& instance()
-    {
-        thread_local ContextStorage inst{};
-        return inst;
-    }
+  static ContextStorage& instance() {
+    thread_local ContextStorage inst{};
+    return inst;
+  }
 };
 
 }  // namespace
 
-void Context::push(const Stream& stream)
-{
-    ContextStorage::instance().push(stream);
+void Context::push(const Stream& stream) {
+  ContextStorage::instance().push(stream);
 }
 
-void Context::push(const Allocator& alloc)
-{
-    ContextStorage::instance().push(alloc);
+void Context::push(const Allocator& alloc) {
+  ContextStorage::instance().push(alloc);
 }
 
-void Context::pop()
-{
-    ContextStorage::instance().pop();
+void Context::pop() { ContextStorage::instance().pop(); }
+
+Stream& Context::stream() {
+  auto& stream_ = ContextStorage::instance().stream_;
+  TM_CHECK(!stream_.empty()) << "No STREAM available in current context";
+  return stream_.top();
 }
 
-Stream& Context::stream()
-{
-    auto& stream_ = ContextStorage::instance().stream_;
-    TM_CHECK(!stream_.empty()) << "No STREAM available in current context";
-    return stream_.top();
+Allocator& Context::host_alloc() {
+  auto& host_alloc_ = ContextStorage::instance().host_alloc_;
+  TM_CHECK(!host_alloc_.empty())
+      << "No HOST memory allocator available in current context";
+  return host_alloc_.top();
 }
 
-Allocator& Context::host_alloc()
-{
-    auto& host_alloc_ = ContextStorage::instance().host_alloc_;
-    TM_CHECK(!host_alloc_.empty()) << "No HOST memory allocator available in current context";
-    return host_alloc_.top();
+Allocator& Context::device_alloc() {
+  auto& device_alloc_ = ContextStorage::instance().device_alloc_;
+  TM_CHECK(!device_alloc_.empty())
+      << "No DEVICE memory allocator available in current context";
+  return device_alloc_.top();
 }
 
-Allocator& Context::device_alloc()
-{
-    auto& device_alloc_ = ContextStorage::instance().device_alloc_;
-    TM_CHECK(!device_alloc_.empty()) << "No DEVICE memory allocator available in current context";
-    return device_alloc_.top();
+Allocator& Context::pinned_alloc() {
+  auto& pinned_alloc_ = ContextStorage::instance().pinned_alloc_;
+  TM_CHECK(!pinned_alloc_.empty())
+      << "No PINNED memory allocator available in current context";
+  return pinned_alloc_.top();
 }
 
-Allocator& Context::pinned_alloc()
-{
-    auto& pinned_alloc_ = ContextStorage::instance().pinned_alloc_;
-    TM_CHECK(!pinned_alloc_.empty()) << "No PINNED memory allocator available in current context";
-    return pinned_alloc_.top();
-}
-
-Allocator& Context::alloc(Device device)
-{
-    switch (device.type) {
-        case kDEVICE:
-            return device_alloc();
-        case kCPU:
-            return host_alloc();
-        case kCPUpinned:
-            return pinned_alloc();
-    }
-    TM_UNREACHABLE;
+Allocator& Context::alloc(Device device) {
+  switch (device.type) {
+    case kDEVICE:
+      return device_alloc();
+    case kCPU:
+      return host_alloc();
+    case kCPUpinned:
+      return pinned_alloc();
+  }
+  TM_UNREACHABLE;
 }
 
 }  // namespace turbomind::core

--- a/csrc/sm70_turbomind/lmdeploy/src/turbomind/core/context.h
+++ b/csrc/sm70_turbomind/lmdeploy/src/turbomind/core/context.h
@@ -7,37 +7,35 @@
 namespace turbomind::core {
 
 class Context {
-public:
-    static Stream&    stream();
-    static Allocator& host_alloc();
-    static Allocator& device_alloc();
-    static Allocator& pinned_alloc();
-    static Allocator& alloc(Device device);
+ public:
+  static Stream& stream();
+  static Allocator& host_alloc();
+  static Allocator& device_alloc();
+  static Allocator& pinned_alloc();
+  static Allocator& alloc(Device device);
 
-private:
-    friend class ContextGuard;
-    static void push(const Stream& stream);
-    static void push(const Allocator& alloc);
-    static void pop();
+ private:
+  friend class ContextGuard;
+  static void push(const Stream& stream);
+  static void push(const Allocator& alloc);
+  static void pop();
 };
 
 class ContextGuard {
-public:
-    template<class... Args>
-    explicit ContextGuard(Args&&... args): n_{}
-    {
-        (Context::push((Args &&) args), ...);
-        n_ = sizeof...(Args);
+ public:
+  template <class... Args>
+  explicit ContextGuard(Args&&... args) : n_{} {
+    (Context::push((Args&&)args), ...);
+    n_ = sizeof...(Args);
+  }
+  ~ContextGuard() {
+    for (int i = 0; i < n_; ++i) {
+      Context::pop();
     }
-    ~ContextGuard()
-    {
-        for (int i = 0; i < n_; ++i) {
-            Context::pop();
-        }
-    }
+  }
 
-private:
-    int n_;
+ private:
+  int n_;
 };
 
 }  // namespace turbomind::core

--- a/csrc/sm70_turbomind/lmdeploy/src/turbomind/core/copy.h
+++ b/csrc/sm70_turbomind/lmdeploy/src/turbomind/core/copy.h
@@ -8,17 +8,17 @@
 namespace turbomind::core {
 
 class BatchCopy {
-public:
-    ~BatchCopy();
+ public:
+  ~BatchCopy();
 
-    BatchCopy();
+  BatchCopy();
 
-    BatchCopy(const BatchCopy&) = delete;
-    BatchCopy& operator=(const BatchCopy&) = delete;
-    BatchCopy(BatchCopy&&) noexcept        = delete;
-    BatchCopy& operator=(BatchCopy&&) noexcept = delete;
+  BatchCopy(const BatchCopy&) = delete;
+  BatchCopy& operator=(const BatchCopy&) = delete;
+  BatchCopy(BatchCopy&&) noexcept = delete;
+  BatchCopy& operator=(BatchCopy&&) noexcept = delete;
 
-    // clang-format off
+  // clang-format off
     class Group {
     public:
         ~Group() { parent_.group_end(); }
@@ -27,114 +27,100 @@ public:
     private:
         BatchCopy& parent_;
     };
-    // clang-format on
+  // clang-format on
 
-    friend Group;
+  friend Group;
 
-    Group group()
-    {
-        return {*this};
+  Group group() { return {*this}; }
+
+  template <class T>
+  T* operator()(const T* src, ssize_t size, T* dst) {
+    // return core::Copy(src, size, dst);
+
+    /// TODO: verify this is actually a fast path in a loop (without extra jump)
+    if (TM_LIKELY(group_ && src == (const T*)src_ptr_ && dst == (T*)dst_ptr_)) {
+      src_ptr_ += sizeof(T) * size;
+      dst_ptr_ += sizeof(T) * size;
+      gsize_ += sizeof(T) * size;
+      count_ += 1;
+      return dst + size;
+    } else if (group_) {
+      group_commit();
+      gsize_ = sizeof(T) * size;
+      src_ptr_ = reinterpret_cast<const char*>(src + size);
+      dst_ptr_ = reinterpret_cast<char*>(dst + size);
+      count_ += 1;
+      return dst + size;
+    } else {
+      gsize_ = sizeof(T) * size;
+      src_ptr_ = reinterpret_cast<const char*>(src + size);
+      dst_ptr_ = reinterpret_cast<char*>(dst + size);
+      count_ = 1;
+      group_commit();
+      return dst + size;
     }
+  }
 
-    template<class T>
-    T* operator()(const T* src, ssize_t size, T* dst)
-    {
-        // return core::Copy(src, size, dst);
+  void operator()(const Buffer& src, ssize_t size, Ref<Buffer> dst_) {
+    auto& dst = dst_.get();
+    TM_CHECK_EQ(src.dtype(), dst.dtype());
+    TM_CHECK_LE(size, src.size());
+    TM_CHECK_LE(size, dst.size());
+    (*this)((const char*)src.raw_data(), byte_size(src.dtype(), size),
+            (char*)dst.raw_data());
+  }
 
-        /// TODO: verify this is actually a fast path in a loop (without extra jump)
-        if (TM_LIKELY(group_ && src == (const T*)src_ptr_ && dst == (T*)dst_ptr_)) {
-            src_ptr_ += sizeof(T) * size;
-            dst_ptr_ += sizeof(T) * size;
-            gsize_ += sizeof(T) * size;
-            count_ += 1;
-            return dst + size;
-        }
-        else if (group_) {
-            group_commit();
-            gsize_   = sizeof(T) * size;
-            src_ptr_ = reinterpret_cast<const char*>(src + size);
-            dst_ptr_ = reinterpret_cast<char*>(dst + size);
-            count_ += 1;
-            return dst + size;
-        }
-        else {
-            gsize_   = sizeof(T) * size;
-            src_ptr_ = reinterpret_cast<const char*>(src + size);
-            dst_ptr_ = reinterpret_cast<char*>(dst + size);
-            count_   = 1;
-            group_commit();
-            return dst + size;
-        }
+  void Run();
+
+  Buffer_<BatchCopy*> buf() { return {&self_, 1, kCPU}; }
+
+  friend std::ostream& operator<<(std::ostream& os, const BatchCopy& a) {
+    os << "(" << a.count_ << ", " << a.src_.size() << ")";
+    return os;
+  }
+
+ private:
+  void Reset() {
+    src_.clear();
+    dst_.clear();
+    size_.clear();
+    count_ = 0;
+  }
+
+  void group_begin() {
+    TM_CHECK(!group_) << "Nested group is not supported";
+    group_ = true;
+  }
+
+  void group_end() {
+    TM_CHECK(group_) << "Mismatched group end";
+    group_commit();
+    group_ = false;
+  }
+
+  void group_commit() {
+    if (gsize_) {
+      src_.push_back(src_ptr_ - gsize_);
+      dst_.push_back(dst_ptr_ - gsize_);
+      size_.push_back(gsize_);
     }
+    src_ptr_ = dst_ptr_ = {};
+    gsize_ = {};
+  }
 
-    void operator()(const Buffer& src, ssize_t size, Ref<Buffer> dst_)
-    {
-        auto& dst = dst_.get();
-        TM_CHECK_EQ(src.dtype(), dst.dtype());
-        TM_CHECK_LE(size, src.size());
-        TM_CHECK_LE(size, dst.size());
-        (*this)((const char*)src.raw_data(), byte_size(src.dtype(), size), (char*)dst.raw_data());
-    }
+ private:
+  std::vector<const char*> src_;
+  std::vector<char*> dst_;
+  std::vector<size_t> size_;
 
-    void Run();
+  int group_ = 0;
+  size_t gsize_ = 0;
+  const char* src_ptr_ = {};
+  char* dst_ptr_ = {};
 
-    Buffer_<BatchCopy*> buf()
-    {
-        return {&self_, 1, kCPU};
-    }
+  size_t count_;
 
-    friend std::ostream& operator<<(std::ostream& os, const BatchCopy& a)
-    {
-        os << "(" << a.count_ << ", " << a.src_.size() << ")";
-        return os;
-    }
-
-private:
-    void Reset()
-    {
-        src_.clear();
-        dst_.clear();
-        size_.clear();
-        count_ = 0;
-    }
-
-    void group_begin()
-    {
-        TM_CHECK(!group_) << "Nested group is not supported";
-        group_ = true;
-    }
-
-    void group_end()
-    {
-        TM_CHECK(group_) << "Mismatched group end";
-        group_commit();
-        group_ = false;
-    }
-
-    void group_commit()
-    {
-        if (gsize_) {
-            src_.push_back(src_ptr_ - gsize_);
-            dst_.push_back(dst_ptr_ - gsize_);
-            size_.push_back(gsize_);
-        }
-        src_ptr_ = dst_ptr_ = {};
-        gsize_              = {};
-    }
-
-private:
-    std::vector<const char*> src_;
-    std::vector<char*>       dst_;
-    std::vector<size_t>      size_;
-
-    int         group_   = 0;
-    size_t      gsize_   = 0;
-    const char* src_ptr_ = {};
-    char*       dst_ptr_ = {};
-
-    size_t count_;
-
-    BatchCopy* self_;
+  BatchCopy* self_;
 };
 
 }  // namespace turbomind::core

--- a/csrc/sm70_turbomind/lmdeploy/src/turbomind/core/core.h
+++ b/csrc/sm70_turbomind/lmdeploy/src/turbomind/core/core.h
@@ -13,18 +13,18 @@
 
 namespace turbomind {
 
-using core::ssize_t;
+using core::Allocator;
+using core::BatchCopy;
 using core::Buffer;
 using core::Buffer_;
+using core::Event;
+using core::Layout;
+using core::Ref;
+using core::ssize_t;
+using core::Stream;
 using core::Tensor;
 using core::Tensor_;
 using core::TensorMap;
-using core::Ref;
-using core::Layout;
-using core::Allocator;
-using core::Stream;
-using core::Event;
-using core::BatchCopy;
 
 using core::subrange;
 

--- a/csrc/sm70_turbomind/lmdeploy/src/turbomind/core/data_type.h
+++ b/csrc/sm70_turbomind/lmdeploy/src/turbomind/core/data_type.h
@@ -270,47 +270,49 @@ inline std::ostream& operator<<(std::ostream& os, DataType type) {
 
 // clang-format on
 
-#define TM_PP_NARGS(...) TM_PP_NARGS_IMPL(__VA_ARGS__, 8, 7, 6, 5, 4, 3, 2, 1, 0)
+#define TM_PP_NARGS(...) \
+  TM_PP_NARGS_IMPL(__VA_ARGS__, 8, 7, 6, 5, 4, 3, 2, 1, 0)
 #define TM_PP_NARGS_IMPL(_0, _1, _2, _3, _4, _5, _6, _7, N, ...) N
 
 #define TM_PP_CAT(a, b) a##b
 #define TM_PP_STR(x) #x
 
-#define TM_PP_DISPATCH_N(macro, ...) TM_PP_DISPATCH_N_IMPL(macro, TM_PP_NARGS(__VA_ARGS__))
+#define TM_PP_DISPATCH_N(macro, ...) \
+  TM_PP_DISPATCH_N_IMPL(macro, TM_PP_NARGS(__VA_ARGS__))
 #define TM_PP_DISPATCH_N_IMPL(macro, x) TM_PP_CAT(macro, x)
 
 #define TM_PP_INVOKE_1(macro, f, _0) macro(f, _0)
 
-#define TM_PP_INVOKE_2(macro, f, _0, _1)                                                                               \
-    macro(f, _0);                                                                                                      \
-    macro(f, _1)
+#define TM_PP_INVOKE_2(macro, f, _0, _1) \
+  macro(f, _0);                          \
+  macro(f, _1)
 
-#define TM_PP_INVOKE_3(macro, f, _0, _1, _2)                                                                           \
-    macro(f, _0);                                                                                                      \
-    macro(f, _1);                                                                                                      \
-    macro(f, _2)
+#define TM_PP_INVOKE_3(macro, f, _0, _1, _2) \
+  macro(f, _0);                              \
+  macro(f, _1);                              \
+  macro(f, _2)
 
-#define TM_PP_INVOKE_4(macro, f, _0, _1, _2, _3)                                                                       \
-    macro(f, _0);                                                                                                      \
-    macro(f, _1);                                                                                                      \
-    macro(f, _2);                                                                                                      \
-    macro(f, _3)
+#define TM_PP_INVOKE_4(macro, f, _0, _1, _2, _3) \
+  macro(f, _0);                                  \
+  macro(f, _1);                                  \
+  macro(f, _2);                                  \
+  macro(f, _3)
 
-#define TM_PP_INVOKE_5(macro, f, _0, _1, _2, _3, _4)                                                                   \
-    macro(f, _0);                                                                                                      \
-    macro(f, _1);                                                                                                      \
-    macro(f, _2);                                                                                                      \
-    macro(f, _3);                                                                                                      \
-    macro(f, _4)
+#define TM_PP_INVOKE_5(macro, f, _0, _1, _2, _3, _4) \
+  macro(f, _0);                                      \
+  macro(f, _1);                                      \
+  macro(f, _2);                                      \
+  macro(f, _3);                                      \
+  macro(f, _4)
 
-#define TM_DISPATCH_DTYPE_RET_CASE(f, t)                                                                               \
-    case ::turbomind::data_type_v<t>:                                                                                  \
-        return f(t{});
+#define TM_DISPATCH_DTYPE_RET_CASE(f, t) \
+  case ::turbomind::data_type_v<t>:      \
+    return f(t{});
 
-#define TM_DISPATCH_DTYPE_CASE(f, t)                                                                                   \
-    case ::turbomind::data_type_v<t>:                                                                                  \
-        f(t{});                                                                                                        \
-        break
+#define TM_DISPATCH_DTYPE_CASE(f, t) \
+  case ::turbomind::data_type_v<t>:  \
+    f(t{});                          \
+    break
 
 // clang-format off
 #define TM_DISPATCH_DTYPES_RET(var, f, ...)                                                                            \
@@ -332,19 +334,21 @@ inline std::ostream& operator<<(std::ostream& os, DataType type) {
 #define TM_PRIMARY_DTYPES_0 ::turbomind::half_t
 
 #if ENABLE_BF16
-#define TM_PRIMARY_DTYPES_1 TM_PRIMARY_DTYPES_0, ::turbomind::bfloat16_t
+  #define TM_PRIMARY_DTYPES_1 TM_PRIMARY_DTYPES_0, ::turbomind::bfloat16_t
 #else
-#define TM_PRIMARY_DTYPES_1 TM_PRIMARY_DTYPES_0
+  #define TM_PRIMARY_DTYPES_1 TM_PRIMARY_DTYPES_0
 #endif
 
 #if ENABLE_FP32
-#define TM_PRIMARY_DTYPES TM_PRIMARY_DTYPES_1, float
+  #define TM_PRIMARY_DTYPES TM_PRIMARY_DTYPES_1, float
 #else
-#define TM_PRIMARY_DTYPES TM_PRIMARY_DTYPES_1
+  #define TM_PRIMARY_DTYPES TM_PRIMARY_DTYPES_1
 #endif
 
-#define TM_DISPATCH_PRIMARY_DTYPES(var, func) TM_DISPATCH_DTYPES(var, func, TM_PRIMARY_DTYPES)
+#define TM_DISPATCH_PRIMARY_DTYPES(var, func) \
+  TM_DISPATCH_DTYPES(var, func, TM_PRIMARY_DTYPES)
 
-#define TM_DISPATCH_PRIMARY_DTYPES_RET(var, func) TM_DISPATCH_DTYPES_RET(var, func, TM_PRIMARY_DTYPES)
+#define TM_DISPATCH_PRIMARY_DTYPES_RET(var, func) \
+  TM_DISPATCH_DTYPES_RET(var, func, TM_PRIMARY_DTYPES)
 
 }  // namespace turbomind

--- a/csrc/sm70_turbomind/lmdeploy/src/turbomind/core/interval.h
+++ b/csrc/sm70_turbomind/lmdeploy/src/turbomind/core/interval.h
@@ -9,87 +9,60 @@
 namespace turbomind {
 
 class Interval {
-public:
-    struct Size {
-        int      x;
-        explicit operator int() const noexcept
-        {
-            return x;
-        }
-        friend bool operator<(const Size& a, const Size& b)
-        {
-            return a.x < b.x;
-        }
-    };
+ public:
+  struct Size {
+    int x;
+    explicit operator int() const noexcept { return x; }
+    friend bool operator<(const Size& a, const Size& b) { return a.x < b.x; }
+  };
 
-    Interval(): first_{0}, last_{0} {}
+  Interval() : first_{0}, last_{0} {}
 
-    explicit Interval(int first): first_{first}, last_{INT_MAX} {};
+  explicit Interval(int first) : first_{first}, last_{INT_MAX} {};
 
-    Interval(int first, int last): first_{first}, last_{last} {}
+  Interval(int first, int last) : first_{first}, last_{last} {}
 
-    Interval(int first, Size size): first_{first}, last_{first + (int)size} {}
+  Interval(int first, Size size) : first_{first}, last_{first + (int)size} {}
 
-    bool empty() const noexcept
-    {
-        return first_ >= last_;
-    }
+  bool empty() const noexcept { return first_ >= last_; }
 
-    explicit operator bool() const noexcept
-    {
-        return !empty();
-    }
+  explicit operator bool() const noexcept { return !empty(); }
 
-    Size size() const noexcept
-    {
-        return Size{std::max(0, last_ - first_)};
-    }
+  Size size() const noexcept { return Size{std::max(0, last_ - first_)}; }
 
-    int begin() const noexcept
-    {
-        return first_;
-    }
+  int begin() const noexcept { return first_; }
 
-    int end() const noexcept
-    {
-        return last_;
-    }
+  int end() const noexcept { return last_; }
 
-    friend Interval operator&(const Interval& a, const Interval& b)
-    {
-        return {std::max(a.first_, b.first_), std::min(a.last_, b.last_)};
-    }
+  friend Interval operator&(const Interval& a, const Interval& b) {
+    return {std::max(a.first_, b.first_), std::min(a.last_, b.last_)};
+  }
 
-    friend Interval operator|(const Interval& a, const Interval& b)
-    {
-        return {std::min(a.first_, b.first_), std::max(a.last_, b.last_)};
-    }
+  friend Interval operator|(const Interval& a, const Interval& b) {
+    return {std::min(a.first_, b.first_), std::max(a.last_, b.last_)};
+  }
 
-    // dilate / erode left
-    friend Interval operator|(int x, const Interval& a)
-    {
-        return {a.begin() - x, a.end()};
-    }
+  // dilate / erode left
+  friend Interval operator|(int x, const Interval& a) {
+    return {a.begin() - x, a.end()};
+  }
 
-    // dilate / erode right
-    friend Interval operator|(const Interval& a, int x)
-    {
-        return {a.begin(), a.end() + x};
-    }
+  // dilate / erode right
+  friend Interval operator|(const Interval& a, int x) {
+    return {a.begin(), a.end() + x};
+  }
 
-    friend std::ostream& operator<<(std::ostream& os, const Interval& a)
-    {
-        return os << "[" << a.first_ << ", " << a.last_ << ")";
-    }
+  friend std::ostream& operator<<(std::ostream& os, const Interval& a) {
+    return os << "[" << a.first_ << ", " << a.last_ << ")";
+  }
 
-    friend std::ostream& operator<<(std::ostream& os, const Interval* a)
-    {
-        return os << *a;
-    }
+  friend std::ostream& operator<<(std::ostream& os, const Interval* a) {
+    return os << *a;
+  }
 
-private:
-    int first_;
-    int last_;
+ private:
+  int first_;
+  int last_;
 };
 
 }  // namespace turbomind

--- a/csrc/sm70_turbomind/lmdeploy/src/turbomind/core/layout.cc
+++ b/csrc/sm70_turbomind/lmdeploy/src/turbomind/core/layout.cc
@@ -6,148 +6,140 @@
 
 namespace turbomind::core {
 
-Layout::Layout(std::vector<ssize_t> shape): shape_{std::move(shape)}
-{
-    TM_CHECK(shape_.size());
-    stride_.resize(shape_.size());
-    size_ = 1;
-    for (int i = shape_.size() - 1; i >= 0; --i) {
-        stride_[i] = size_;
-        size_ *= shape_[i];
-    }
+Layout::Layout(std::vector<ssize_t> shape) : shape_{std::move(shape)} {
+  TM_CHECK(shape_.size());
+  stride_.resize(shape_.size());
+  size_ = 1;
+  for (int i = shape_.size() - 1; i >= 0; --i) {
+    stride_[i] = size_;
+    size_ *= shape_[i];
+  }
 }
 
-Layout::Layout(vector<ssize_t> shape, vector<ssize_t> stride): shape_{std::move(shape)}, stride_{std::move(stride)}
-{
-    TM_CHECK(shape_.size());
-    TM_CHECK_EQ(shape_.size(), stride_.size());
+Layout::Layout(vector<ssize_t> shape, vector<ssize_t> stride)
+    : shape_{std::move(shape)}, stride_{std::move(stride)} {
+  TM_CHECK(shape_.size());
+  TM_CHECK_EQ(shape_.size(), stride_.size());
 
-    size_ = std::accumulate(shape_.begin(), shape_.end(), ssize_t{1}, std::multiplies<>{});
+  size_ = std::accumulate(shape_.begin(), shape_.end(), ssize_t{1},
+                          std::multiplies<>{});
 
-    TM_CHECK_GE(size_, 0);
+  TM_CHECK_GE(size_, 0);
 }
 
-ssize_t Layout::cosize() const noexcept
-{
-    if (rank() == 0) {
-        return 0;
-    }
-    ssize_t value{1};
-    for (size_t i = 0; i < shape_.size(); ++i) {
-        value += (shape_[i] - 1) * stride_[i];
-    }
-    return value;
+ssize_t Layout::cosize() const noexcept {
+  if (rank() == 0) {
+    return 0;
+  }
+  ssize_t value{1};
+  for (size_t i = 0; i < shape_.size(); ++i) {
+    value += (shape_[i] - 1) * stride_[i];
+  }
+  return value;
 }
 
-Layout Layout::coalesce() const noexcept
-{
-    vector<ssize_t> shape{shape_.front()};
-    vector<ssize_t> stride{stride_.front()};
+Layout Layout::coalesce() const noexcept {
+  vector<ssize_t> shape{shape_.front()};
+  vector<ssize_t> stride{stride_.front()};
 
-    for (size_t i = 1; i < shape_.size(); ++i) {
-        if (shape_[i] == 1) {
-            continue;
-        }
-        else if (shape.back() == 1) {
-            shape.back()  = shape_[i];
-            stride.back() = stride_[i];
-        }
-        else if (stride.back() == shape_[i] * stride_[i]) {
-            stride.back() = stride_[i];
-            shape.back() *= shape_[i];
-        }
-        else {
-            shape.push_back(shape_[i]);
-            stride.push_back(stride_[i]);
-        }
+  for (size_t i = 1; i < shape_.size(); ++i) {
+    if (shape_[i] == 1) {
+      continue;
+    } else if (shape.back() == 1) {
+      shape.back() = shape_[i];
+      stride.back() = stride_[i];
+    } else if (stride.back() == shape_[i] * stride_[i]) {
+      stride.back() = stride_[i];
+      shape.back() *= shape_[i];
+    } else {
+      shape.push_back(shape_[i]);
+      stride.push_back(stride_[i]);
     }
+  }
 
-    return Layout{shape, stride};
+  return Layout{shape, stride};
 }
 
-Layout Layout::view(vector<ssize_t> shape) const
-{
-    if (shape == shape_) {
-        return *this;
+Layout Layout::view(vector<ssize_t> shape) const {
+  if (shape == shape_) {
+    return *this;
+  }
+
+  TM_CHECK(!shape.empty());
+
+  // size check & wildcard resolution
+  auto wildcard = std::find(shape.begin(), shape.end(), -1);
+  if (wildcard != shape.end()) {
+    TM_CHECK(std::find(wildcard + 1, shape.end(), -1) == shape.end());
+    *wildcard = 1;
+  }
+  auto new_size = std::accumulate(shape.begin(), shape.end(), ssize_t{1},
+                                  std::multiplies<>{});
+  if (wildcard != shape.end()) {
+    TM_CHECK(size_ % new_size == 0) << size_ << " % " << new_size;
+    *wildcard = size_ / new_size;
+  } else {
+    TM_CHECK_EQ(size_, new_size);
+  }
+
+  if (is_contiguous()) {
+    return Layout{shape};
+  }
+
+  const Layout c = coalesce();  // merge contiguous dimensions
+
+  ssize_t p = c.rank();
+  ssize_t s = 1;
+  ssize_t d = 0;
+
+  vector<ssize_t> stride(shape.size());
+
+  for (int i = shape.size() - 1; i >= 0; --i) {
+    if (shape[i] == 1) {
+      stride[i] = 0;
+    } else {
+      if (s == 1) {
+        --p;
+        s = c.shape().at(p);
+        d = c.stride().at(p);
+      }
+      TM_CHECK_EQ(s % shape[i], 0);  // crossing non-contiguous dimensions
+      stride[i] = d;
+      d *= shape[i];
+      s /= shape[i];
     }
-
-    TM_CHECK(!shape.empty());
-
-    // size check & wildcard resolution
-    auto wildcard = std::find(shape.begin(), shape.end(), -1);
-    if (wildcard != shape.end()) {
-        TM_CHECK(std::find(wildcard + 1, shape.end(), -1) == shape.end());
-        *wildcard = 1;
-    }
-    auto new_size = std::accumulate(shape.begin(), shape.end(), ssize_t{1}, std::multiplies<>{});
-    if (wildcard != shape.end()) {
-        TM_CHECK(size_ % new_size == 0) << size_ << " % " << new_size;
-        *wildcard = size_ / new_size;
-    }
-    else {
-        TM_CHECK_EQ(size_, new_size);
-    }
-
-    if (is_contiguous()) {
-        return Layout{shape};
-    }
-
-    const Layout c = coalesce();  // merge contiguous dimensions
-
-    ssize_t p = c.rank();
-    ssize_t s = 1;
-    ssize_t d = 0;
-
-    vector<ssize_t> stride(shape.size());
-
-    for (int i = shape.size() - 1; i >= 0; --i) {
-        if (shape[i] == 1) {
-            stride[i] = 0;
-        }
-        else {
-            if (s == 1) {
-                --p;
-                s = c.shape().at(p);
-                d = c.stride().at(p);
-            }
-            TM_CHECK_EQ(s % shape[i], 0);  // crossing non-contiguous dimensions
-            stride[i] = d;
-            d *= shape[i];
-            s /= shape[i];
-        }
-    }
-    return Layout{std::move(shape), std::move(stride)};
+  }
+  return Layout{std::move(shape), std::move(stride)};
 }
 
-std::pair<Layout, ssize_t> Layout::slice(const vector<ssize_t>& base, vector<ssize_t> shape) const
-{
-    TM_CHECK_EQ(base.size(), shape.size());
-    TM_CHECK_EQ(shape_.size(), shape.size());
-    ssize_t offset = 0;
-    for (size_t i = 0; i < shape.size(); ++i) {
-        const auto space = shape_[i] - base[i];
-        TM_CHECK_GE(space, 0);
-        if (shape[i] == -1) {
-            shape[i] = space;
-        }
-        TM_CHECK_LE(shape[i], space);
-        offset += base[i] * stride_[i];
+std::pair<Layout, ssize_t> Layout::slice(const vector<ssize_t>& base,
+                                         vector<ssize_t> shape) const {
+  TM_CHECK_EQ(base.size(), shape.size());
+  TM_CHECK_EQ(shape_.size(), shape.size());
+  ssize_t offset = 0;
+  for (size_t i = 0; i < shape.size(); ++i) {
+    const auto space = shape_[i] - base[i];
+    TM_CHECK_GE(space, 0);
+    if (shape[i] == -1) {
+      shape[i] = space;
     }
-    return {Layout{std::move(shape), stride_}, offset};
+    TM_CHECK_LE(shape[i], space);
+    offset += base[i] * stride_[i];
+  }
+  return {Layout{std::move(shape), stride_}, offset};
 }
 
-std::ostream& operator<<(std::ostream& os, const Layout& x)
-{
-    os << "(";
-    for (int i = 0; i < x.rank(); ++i) {
-        os << (i ? "," : "") << x.shape_[i];
-    }
-    os << "):(";
-    for (int i = 0; i < x.rank(); ++i) {
-        os << (i ? "," : "") << x.stride_[i];
-    }
-    os << ")";
-    return os;
+std::ostream& operator<<(std::ostream& os, const Layout& x) {
+  os << "(";
+  for (int i = 0; i < x.rank(); ++i) {
+    os << (i ? "," : "") << x.shape_[i];
+  }
+  os << "):(";
+  for (int i = 0; i < x.rank(); ++i) {
+    os << (i ? "," : "") << x.stride_[i];
+  }
+  os << ")";
+  return os;
 }
 
 }  // namespace turbomind::core

--- a/csrc/sm70_turbomind/lmdeploy/src/turbomind/core/layout.h
+++ b/csrc/sm70_turbomind/lmdeploy/src/turbomind/core/layout.h
@@ -9,168 +9,138 @@
 namespace turbomind::core {
 
 class Layout {
-public:
-    Layout(): size_{0} {}
+ public:
+  Layout() : size_{0} {}
 
-    /* implicit */ Layout(vector<ssize_t> shape);
+  /* implicit */ Layout(vector<ssize_t> shape);
 
-    /* implicit */ Layout(std::initializer_list<ssize_t> shape): Layout(vector(shape)) {}
+  /* implicit */ Layout(std::initializer_list<ssize_t> shape)
+      : Layout(vector(shape)) {}
 
-    Layout(vector<ssize_t> shape, vector<ssize_t> stride);
+  Layout(vector<ssize_t> shape, vector<ssize_t> stride);
 
-    ssize_t size() const noexcept
-    {
-        return size_;
+  ssize_t size() const noexcept { return size_; }
+
+  ssize_t cosize() const noexcept;
+
+  ssize_t rank() const noexcept { return shape_.size(); }
+
+  auto& shape() const noexcept { return shape_; }
+
+  auto shape(int i) const { return shape_.at(wrap(i)); }
+
+  template <class... Is>
+  auto shapes(Is... is) const {
+    return std::make_tuple(shape(is)...);
+  }
+
+  auto& stride() const noexcept { return stride_; }
+
+  auto stride(int i) const { return stride_.at(wrap(i)); }
+
+  template <class... Is>
+  auto strides(Is... is) const {
+    return std::make_tuple(stride(is)...);
+  }
+
+  bool is_contiguous() const noexcept {
+    if (stride_.back() != 1) {
+      return false;
     }
-
-    ssize_t cosize() const noexcept;
-
-    ssize_t rank() const noexcept
-    {
-        return shape_.size();
+    if (size() != cosize()) {
+      return false;
     }
-
-    auto& shape() const noexcept
-    {
-        return shape_;
+    for (int i = 0; i < rank() - 1; ++i) {
+      // TODO: skip when shape == 1
+      if (stride_[i] < stride_[i + 1]) {
+        return false;
+      }
     }
+    return true;
+  }
 
-    auto shape(int i) const
-    {
-        return shape_.at(wrap(i));
+  Layout permute(const vector<int>& dims) const {
+    TM_CHECK((int)dims.size() == rank());
+    auto a = *this;
+    for (int i = 0; i < rank(); ++i) {
+      a.shape_[i] = shape_[dims[i]];
+      a.stride_[i] = stride_[dims[i]];
     }
+    return a;
+  }
 
-    template<class... Is>
-    auto shapes(Is... is) const
-    {
-        return std::make_tuple(shape(is)...);
+  Layout transpose(int a, int b) const {
+    TM_CHECK_LT(a, rank());
+    TM_CHECK_LT(b, rank());
+    auto x = *this;
+    std::swap(x.shape_[a], x.shape_[b]);
+    std::swap(x.stride_[a], x.stride_[b]);
+    return x;
+  }
+
+  ssize_t offset(const vector<ssize_t>& idxs) const {
+    TM_CHECK((int)idxs.size() < rank());
+    ssize_t val = 0;
+    for (size_t i = 0; i < idxs.size(); ++i) {
+      TM_CHECK_LT(idxs[i], shape_[i]);
+      val += idxs[i] * stride_[i];
     }
+    return val;
+  }
 
-    auto& stride() const noexcept
-    {
-        return stride_;
+  ssize_t offset(ssize_t idx0) const {
+    TM_CHECK(rank());
+    TM_CHECK_LT(idx0, shape_[0]);
+    return stride_[0] * idx0;
+  }
+
+  Layout coalesce() const noexcept;
+
+  Layout view(vector<ssize_t> shape) const;
+
+  std::pair<Layout, ssize_t> slice(const vector<ssize_t>& base,
+                                   vector<ssize_t> shape) const;
+
+  Layout squeeze(int dim) const {
+    if (rank() == 1 || shape(dim) != 1) {
+      return *this;
     }
-
-    auto stride(int i) const
-    {
-        return stride_.at(wrap(i));
+    Layout a;
+    a.shape_.reserve(rank() - 1);
+    a.stride_.reserve(rank() - 1);
+    for (int i = 0; i < rank(); ++i) {
+      if (i != dim) {
+        a.shape_.push_back(shape_[i]);
+        a.stride_.push_back(stride_[i]);
+      }
     }
+    a.size_ = size_;
+    return a;
+  }
 
-    template<class... Is>
-    auto strides(Is... is) const
-    {
-        return std::make_tuple(stride(is)...);
-    }
+  friend std::ostream& operator<<(std::ostream& os, const Layout& x);
 
-    bool is_contiguous() const noexcept
-    {
-        if (stride_.back() != 1) {
-            return false;
-        }
-        if (size() != cosize()) {
-            return false;
-        }
-        for (int i = 0; i < rank() - 1; ++i) {
-            // TODO: skip when shape == 1
-            if (stride_[i] < stride_[i + 1]) {
-                return false;
-            }
-        }
-        return true;
-    }
+  friend bool operator==(const Layout& a, const Layout& b) {
+    return a.shape_ == b.shape_ && a.stride_ == b.stride_;
+  }
 
-    Layout permute(const vector<int>& dims) const
-    {
-        TM_CHECK((int)dims.size() == rank());
-        auto a = *this;
-        for (int i = 0; i < rank(); ++i) {
-            a.shape_[i]  = shape_[dims[i]];
-            a.stride_[i] = stride_[dims[i]];
-        }
-        return a;
-    }
+  friend bool operator!=(const Layout& a, const Layout& b) { return !(a == b); }
 
-    Layout transpose(int a, int b) const
-    {
-        TM_CHECK_LT(a, rank());
-        TM_CHECK_LT(b, rank());
-        auto x = *this;
-        std::swap(x.shape_[a], x.shape_[b]);
-        std::swap(x.stride_[a], x.stride_[b]);
-        return x;
-    }
+ private:
+  int wrap(int dim) const noexcept {
+    return dim < 0 ? dim + shape_.size() : dim;
+  }
 
-    ssize_t offset(const vector<ssize_t>& idxs) const
-    {
-        TM_CHECK((int)idxs.size() < rank());
-        ssize_t val = 0;
-        for (size_t i = 0; i < idxs.size(); ++i) {
-            TM_CHECK_LT(idxs[i], shape_[i]);
-            val += idxs[i] * stride_[i];
-        }
-        return val;
-    }
-
-    ssize_t offset(ssize_t idx0) const
-    {
-        TM_CHECK(rank());
-        TM_CHECK_LT(idx0, shape_[0]);
-        return stride_[0] * idx0;
-    }
-
-    Layout coalesce() const noexcept;
-
-    Layout view(vector<ssize_t> shape) const;
-
-    std::pair<Layout, ssize_t> slice(const vector<ssize_t>& base, vector<ssize_t> shape) const;
-
-    Layout squeeze(int dim) const
-    {
-        if (rank() == 1 || shape(dim) != 1) {
-            return *this;
-        }
-        Layout a;
-        a.shape_.reserve(rank() - 1);
-        a.stride_.reserve(rank() - 1);
-        for (int i = 0; i < rank(); ++i) {
-            if (i != dim) {
-                a.shape_.push_back(shape_[i]);
-                a.stride_.push_back(stride_[i]);
-            }
-        }
-        a.size_ = size_;
-        return a;
-    }
-
-    friend std::ostream& operator<<(std::ostream& os, const Layout& x);
-
-    friend bool operator==(const Layout& a, const Layout& b)
-    {
-        return a.shape_ == b.shape_ && a.stride_ == b.stride_;
-    }
-
-    friend bool operator!=(const Layout& a, const Layout& b)
-    {
-        return !(a == b);
-    }
-
-private:
-    int wrap(int dim) const noexcept
-    {
-        return dim < 0 ? dim + shape_.size() : dim;
-    }
-
-private:
-    vector<ssize_t> shape_;
-    vector<ssize_t> stride_;
-    ssize_t         size_;
+ private:
+  vector<ssize_t> shape_;
+  vector<ssize_t> stride_;
+  ssize_t size_;
 };
 
-inline std::string to_string(const Layout& x)
-{
-    std::stringstream ss;
-    ss << x;
-    return ss.str();
+inline std::string to_string(const Layout& x) {
+  std::stringstream ss;
+  ss << x;
+  return ss.str();
 }
 
 // clang-format off

--- a/csrc/sm70_turbomind/lmdeploy/src/turbomind/core/module.h
+++ b/csrc/sm70_turbomind/lmdeploy/src/turbomind/core/module.h
@@ -4,33 +4,35 @@
 namespace turbomind::core {
 
 class Module {
-public:
-    virtual ~Module();
+ public:
+  virtual ~Module();
 
-    Module();
+  Module();
 
-    Module(const Module&) = delete;
-    Module& operator=(const Module&) = delete;
+  Module(const Module&) = delete;
+  Module& operator=(const Module&) = delete;
 
-    Module(Module&&) noexcept = delete;
-    Module& operator=(Module&&) noexcept = delete;
+  Module(Module&&) noexcept = delete;
+  Module& operator=(Module&&) noexcept = delete;
 
-    void register_module(std::string name, Module& module, std::optional<int> index = {});
-    void register_parameter(std::string name, Tensor& param);
+  void register_module(std::string name, Module& module,
+                       std::optional<int> index = {});
+  void register_parameter(std::string name, Tensor& param);
 
-    void remove_module(Module& module);
-    void remove_parameter(Tensor& param);
+  void remove_module(Module& module);
+  void remove_parameter(Tensor& param);
 
-    std::unordered_map<std::string, Tensor*> get_parameters() const;
+  std::unordered_map<std::string, Tensor*> get_parameters() const;
 
-private:
-    void get_parameters_impl(std::string prefix, std::unordered_map<std::string, Tensor*>& m) const;
+ private:
+  void get_parameters_impl(std::string prefix,
+                           std::unordered_map<std::string, Tensor*>& m) const;
 
-protected:
-    Module* parent_;
+ protected:
+  Module* parent_;
 
-    std::vector<std::pair<std::string, Module*>> modules_;
-    std::vector<std::pair<std::string, Tensor*>> params_;
+  std::vector<std::pair<std::string, Module*>> modules_;
+  std::vector<std::pair<std::string, Tensor*>> params_;
 };
 
 }  // namespace turbomind::core

--- a/csrc/sm70_turbomind/lmdeploy/src/turbomind/core/ranges.h
+++ b/csrc/sm70_turbomind/lmdeploy/src/turbomind/core/ranges.h
@@ -2,34 +2,22 @@
 
 namespace turbomind::core {
 
-template<class Iterator>
+template <class Iterator>
 class subrange {
-public:
-    subrange(Iterator first, Iterator last): first_{first}, last_{last} {}
+ public:
+  subrange(Iterator first, Iterator last) : first_{first}, last_{last} {}
 
-    Iterator begin()
-    {
-        return first_;
-    }
+  Iterator begin() { return first_; }
 
-    Iterator end()
-    {
-        return last_;
-    }
+  Iterator end() { return last_; }
 
-    auto empty() const
-    {
-        return first_ == last_;
-    }
+  auto empty() const { return first_ == last_; }
 
-    auto size() const
-    {
-        return last_ - first_;
-    }
+  auto size() const { return last_ - first_; }
 
-private:
-    Iterator first_;
-    Iterator last_;
+ private:
+  Iterator first_;
+  Iterator last_;
 };
 
 }  // namespace turbomind::core

--- a/csrc/sm70_turbomind/lmdeploy/src/turbomind/core/serdes.h
+++ b/csrc/sm70_turbomind/lmdeploy/src/turbomind/core/serdes.h
@@ -8,179 +8,157 @@
 
 namespace turbomind::core {
 
-template<template<class...> typename F, class SFINAE, class... Args>
-struct is_detected: std::false_type {
-};
+template <template <class...> typename F, class SFINAE, class... Args>
+struct is_detected : std::false_type {};
 
-template<template<class... Args> typename F, class... Args>
-struct is_detected<F, std::void_t<F<Args...>>, Args...>: std::true_type {
-};
+template <template <class... Args> typename F, class... Args>
+struct is_detected<F, std::void_t<F<Args...>>, Args...> : std::true_type {};
 
-template<class Archive, class T>
+template <class Archive, class T>
 using save_t = decltype(save(std::declval<Archive&>(), std::declval<T>()));
 
-template<class Archive, class T>
+template <class Archive, class T>
 inline constexpr bool has_save_v = is_detected<save_t, void, Archive, T>::value;
 
-template<class Archive, class T>
+template <class Archive, class T>
 using load_t = decltype(load(std::declval<Archive&>(), std::declval<T>()));
 
-template<class Archive, class T>
+template <class Archive, class T>
 inline constexpr bool has_load_v = is_detected<load_t, void, Archive, T>::value;
 
-template<class Archive, class T>
+template <class Archive, class T>
 using serdes_t = decltype(serdes(std::declval<Archive&>(), std::declval<T>()));
 
-template<class Archive, class T>
-inline constexpr bool has_serdes_v = is_detected<serdes_t, void, Archive, T>::value;
+template <class Archive, class T>
+inline constexpr bool has_serdes_v =
+    is_detected<serdes_t, void, Archive, T>::value;
 
-template<typename T>
+template <typename T>
 class ArrayWrapper {
-public:
-    ArrayWrapper(T* t, std::size_t size): t_{t}, size_{size}
-    {
-        static_assert(std::is_trivially_copyable_v<T>, "ArrayWrapper requires trivially copyable type");
-    }
+ public:
+  ArrayWrapper(T* t, std::size_t size) : t_{t}, size_{size} {
+    static_assert(std::is_trivially_copyable_v<T>,
+                  "ArrayWrapper requires trivially copyable type");
+  }
 
-    T* data() const
-    {
-        return t_;
-    }
+  T* data() const { return t_; }
 
-    std::size_t count() const
-    {
-        return size_;
-    }
+  std::size_t count() const { return size_; }
 
-    T* const          t_;
-    const std::size_t size_;
+  T* const t_;
+  const std::size_t size_;
 };
 
-template<typename T>
+template <typename T>
 inline constexpr bool is_array_wrapper_v = std::false_type{};
 
-template<typename T>
+template <typename T>
 inline constexpr bool is_array_wrapper_v<ArrayWrapper<T>> = std::true_type{};
 
-template<class Derived>
+template <class Derived>
 struct OutputArchive {
-    static constexpr bool is_loading = false;
+  static constexpr bool is_loading = false;
 
-    template<class T>
-    void operator&(T&& x)
-    {
-        if constexpr (has_save_v<Derived, T>) {
-            save(*this, (T &&) x);
-        }
-        else if constexpr (has_serdes_v<Derived, T>) {
-            serdes(*this, (T &&) x);
-        }
-        else {
-            reinterpret_cast<Derived*>(this)->write((T &&) x);
-        }
+  template <class T>
+  void operator&(T&& x) {
+    if constexpr (has_save_v<Derived, T>) {
+      save(*this, (T&&)x);
+    } else if constexpr (has_serdes_v<Derived, T>) {
+      serdes(*this, (T&&)x);
+    } else {
+      reinterpret_cast<Derived*>(this)->write((T&&)x);
     }
+  }
 };
 
-template<class Derived>
+template <class Derived>
 struct InputArchive {
-    static constexpr bool is_loading = true;
+  static constexpr bool is_loading = true;
 
-    template<class T>
-    void operator&(T&& x)
-    {
-        if constexpr (has_load_v<Derived, T>) {
-            load(*this, (T &&) x);
-        }
-        else if constexpr (has_serdes_v<Derived, T>) {
-            serdes(*this, (T &&) x);
-        }
-        else {
-            reinterpret_cast<Derived*>(this)->read((T &&) x);
-        }
+  template <class T>
+  void operator&(T&& x) {
+    if constexpr (has_load_v<Derived, T>) {
+      load(*this, (T&&)x);
+    } else if constexpr (has_serdes_v<Derived, T>) {
+      serdes(*this, (T&&)x);
+    } else {
+      reinterpret_cast<Derived*>(this)->read((T&&)x);
     }
+  }
 };
 
-struct BinarySizeArchive: OutputArchive<BinarySizeArchive> {
-    size_t size_{};
+struct BinarySizeArchive : OutputArchive<BinarySizeArchive> {
+  size_t size_{};
 
-    size_t size()
-    {
-        return size_;
-    }
+  size_t size() { return size_; }
 
-    template<class T>
-    void write(const T& x)
-    {
-        static_assert(std::is_trivially_copyable_v<T>);
-        size_ += sizeof(x);
-    }
+  template <class T>
+  void write(const T& x) {
+    static_assert(std::is_trivially_copyable_v<T>);
+    size_ += sizeof(x);
+  }
 
-    template<class T>
-    void write(const ArrayWrapper<T>& arr)
-    {
-        static_assert(std::is_trivially_copyable_v<T>);
-        size_ += sizeof(T) * arr.count();
-    }
+  template <class T>
+  void write(const ArrayWrapper<T>& arr) {
+    static_assert(std::is_trivially_copyable_v<T>);
+    size_ += sizeof(T) * arr.count();
+  }
 };
 
-struct BinaryOutputArchive: OutputArchive<BinaryOutputArchive> {
+struct BinaryOutputArchive : OutputArchive<BinaryOutputArchive> {
+  ArrayWrapper<std::byte> external_;
+  size_t ptr_;
 
-    ArrayWrapper<std::byte> external_;
-    size_t                  ptr_;
+  BinaryOutputArchive(ArrayWrapper<std::byte> external)
+      : external_{external}, ptr_{} {}
 
-    BinaryOutputArchive(ArrayWrapper<std::byte> external): external_{external}, ptr_{} {}
+  template <class T>
+  void write(const T& x) {
+    static_assert(std::is_trivially_copyable_v<T>);
+    auto data = (const std::byte*)&x;
+    TM_CHECK_LE(ptr_ + sizeof(T), external_.count());
+    std::copy_n(data, sizeof(T), external_.data() + ptr_);
+    ptr_ += sizeof(T);
+  }
 
-    template<class T>
-    void write(const T& x)
-    {
-        static_assert(std::is_trivially_copyable_v<T>);
-        auto data = (const std::byte*)&x;
-        TM_CHECK_LE(ptr_ + sizeof(T), external_.count());
-        std::copy_n(data, sizeof(T), external_.data() + ptr_);
-        ptr_ += sizeof(T);
-    }
-
-    template<class T>
-    void write(const ArrayWrapper<T>& arr)
-    {
-        static_assert(std::is_trivially_copyable_v<T>);
-        auto data = (const std::byte*)arr.data();
-        TM_CHECK_LE(ptr_ + sizeof(T) * arr.count(), external_.count());
-        std::copy_n(data, sizeof(T) * arr.count(), external_.data() + ptr_);
-        ptr_ += sizeof(T) * arr.count();
-    }
+  template <class T>
+  void write(const ArrayWrapper<T>& arr) {
+    static_assert(std::is_trivially_copyable_v<T>);
+    auto data = (const std::byte*)arr.data();
+    TM_CHECK_LE(ptr_ + sizeof(T) * arr.count(), external_.count());
+    std::copy_n(data, sizeof(T) * arr.count(), external_.data() + ptr_);
+    ptr_ += sizeof(T) * arr.count();
+  }
 };
 
-struct BinaryInputArchive: InputArchive<BinaryInputArchive> {
+struct BinaryInputArchive : InputArchive<BinaryInputArchive> {
+  ArrayWrapper<std::byte> external_;
+  size_t ptr_;
 
-    ArrayWrapper<std::byte> external_;
-    size_t                  ptr_;
+  BinaryInputArchive(ArrayWrapper<std::byte> external)
+      : external_{external}, ptr_{} {}
 
-    BinaryInputArchive(ArrayWrapper<std::byte> external): external_{external}, ptr_{} {}
+  template <class T>
+  void read(T& x) {
+    static_assert(std::is_trivially_copyable_v<T>);
+    TM_CHECK_LE(ptr_ + sizeof(T), external_.count());
+    std::copy_n(external_.data() + ptr_, sizeof(T), (std::byte*)&x);
+    ptr_ += sizeof(T);
+  }
 
-    template<class T>
-    void read(T& x)
-    {
-        static_assert(std::is_trivially_copyable_v<T>);
-        TM_CHECK_LE(ptr_ + sizeof(T), external_.count());
-        std::copy_n(external_.data() + ptr_, sizeof(T), (std::byte*)&x);
-        ptr_ += sizeof(T);
-    }
-
-    template<class T>
-    void read(ArrayWrapper<T>&& arr)
-    {
-        static_assert(std::is_trivially_copyable_v<T>);
-        TM_CHECK_LE(ptr_ + sizeof(T) * arr.count(), external_.count());
-        std::copy_n(external_.data() + ptr_, sizeof(T) * arr.count(), (std::byte*)arr.data());
-        ptr_ += sizeof(T) * arr.count();
-    }
+  template <class T>
+  void read(ArrayWrapper<T>&& arr) {
+    static_assert(std::is_trivially_copyable_v<T>);
+    TM_CHECK_LE(ptr_ + sizeof(T) * arr.count(), external_.count());
+    std::copy_n(external_.data() + ptr_, sizeof(T) * arr.count(),
+                (std::byte*)arr.data());
+    ptr_ += sizeof(T) * arr.count();
+  }
 };
 
-template<class Archive, class T>
-void save(Archive& ar, const std::vector<T>& xs)
-{
-    // clang-format off
+template <class Archive, class T>
+void save(Archive& ar, const std::vector<T>& xs) {
+  // clang-format off
     ar & xs.size();
     if constexpr (std::is_trivially_copyable_v<T>) {
         ar & ArrayWrapper(xs.data(), xs.size());
@@ -190,13 +168,12 @@ void save(Archive& ar, const std::vector<T>& xs)
             ar & x;
         }
     }
-    // clang-format on
+  // clang-format on
 }
 
-template<class Archive, class T>
-void load(Archive& ar, std::vector<T>& xs)
-{
-    // clang-format off
+template <class Archive, class T>
+void load(Archive& ar, std::vector<T>& xs) {
+  // clang-format off
     decltype(xs.size()) size;
     ar & size;
     xs.resize(size);
@@ -208,44 +185,40 @@ void load(Archive& ar, std::vector<T>& xs)
             ar & xs[i];
         }
     }
-    // clang-format on
+  // clang-format on
 }
 
-template<class Archive>
-void save(Archive& ar, const std::string& s)
-{
-    // clang-format off
+template <class Archive>
+void save(Archive& ar, const std::string& s) {
+  // clang-format off
     ar & s.size();
     ar & ArrayWrapper(s.data(), s.size());
-    // clang-format on
+  // clang-format on
 }
 
-template<class Archive>
-void load(Archive& ar, std::string& s)
-{
-    // clang-format off
+template <class Archive>
+void load(Archive& ar, std::string& s) {
+  // clang-format off
     decltype(s.size()) size;
     ar & size;
     s.resize(size);
     ar & ArrayWrapper(s.data(), size);
-    // clang-format on
+  // clang-format on
 }
 
-template<class Archive, class T>
-void save(Archive& ar, const std::shared_ptr<T>& p)
-{
-    // clang-format off
+template <class Archive, class T>
+void save(Archive& ar, const std::shared_ptr<T>& p) {
+  // clang-format off
     ar & (bool)p;
     if (p) {
         ar & (*p);
     }
-    // clang-format on
+  // clang-format on
 }
 
-template<class Archive, class T>
-void load(Archive& ar, std::shared_ptr<T>& p)
-{
-    // clang-format off
+template <class Archive, class T>
+void load(Archive& ar, std::shared_ptr<T>& p) {
+  // clang-format off
     bool pred;
     ar & pred;
     if (pred) {
@@ -266,13 +239,12 @@ void serdes(Archive& ar, std::array<T, N>& xs)
             ar & xs[i];
         }
     }
-    // clang-format on
+  // clang-format on
 }
 
-template<class Archive, class... Ts>
-void serdes(Archive& ar, std::tuple<Ts...>& tpl)
-{
-    std::apply([&](auto&... elems) { ((ar & elems), ...); }, tpl);
+template <class Archive, class... Ts>
+void serdes(Archive& ar, std::tuple<Ts...>& tpl) {
+  std::apply([&](auto&... elems) { ((ar & elems), ...); }, tpl);
 }
 
 }  // namespace turbomind::core

--- a/csrc/sm70_turbomind/lmdeploy/src/turbomind/core/state.h
+++ b/csrc/sm70_turbomind/lmdeploy/src/turbomind/core/state.h
@@ -14,97 +14,81 @@ namespace turbomind {
 // 2. single stream synchronization / iteration
 
 struct State {
+  Tensor data_[2];
 
-    Tensor data_[2];
+  State() = default;
 
-    State() = default;
+  State(const Layout& layout, DataType dtype, const core::Device& device) {
+    data_[0] = {layout, dtype, device};
+    data_[1] = {layout, dtype, device};
+  }
 
-    State(const Layout& layout, DataType dtype, const core::Device& device)
-    {
-        data_[0] = {layout, dtype, device};
-        data_[1] = {layout, dtype, device};
-    }
+  Tensor& front() { return data_[0]; }
 
-    Tensor& front()
-    {
-        return data_[0];
-    }
+  Tensor& back() { return data_[1]; }
 
-    Tensor& back()
-    {
-        return data_[1];
-    }
-
-    void Swap()
-    {
-        std::swap(data_[0], data_[1]);
-    }
+  void Swap() { std::swap(data_[0], data_[1]); }
 };
 
-template<class Copy>
-void Warp(const Tensor& a0, int size0, const Buffer_<int>& perm, Tensor b1, Copy& copy)
-{
-    auto a0_ptr = (const uint8_t*)a0.raw_data();
-    auto b1_ptr = (uint8_t*)b1.raw_data();
+template <class Copy>
+void Warp(const Tensor& a0, int size0, const Buffer_<int>& perm, Tensor b1,
+          Copy& copy) {
+  auto a0_ptr = (const uint8_t*)a0.raw_data();
+  auto b1_ptr = (uint8_t*)b1.raw_data();
 
-    const auto vec_size = byte_size(a0.dtype(), a0.stride(0));
+  const auto vec_size = byte_size(a0.dtype(), a0.stride(0));
 
-    for (int i = 0; i < perm.size(); ++i) {
-        if (const int j = perm[i]; TM_LIKELY(j < size0)) {
-            copy(a0_ptr + j * vec_size, vec_size, b1_ptr + i * vec_size);
-        }
+  for (int i = 0; i < perm.size(); ++i) {
+    if (const int j = perm[i]; TM_LIKELY(j < size0)) {
+      copy(a0_ptr + j * vec_size, vec_size, b1_ptr + i * vec_size);
     }
+  }
 }
 
-template<class Copy>
-void Warp(const Tensor& a0, const Tensor& b1, int size0, const Buffer_<int>& perm, Tensor c1, Copy& copy)
-{
-    auto a0_ptr = (const uint8_t*)a0.raw_data();
-    auto b1_ptr = (const uint8_t*)b1.raw_data();
-    auto c1_ptr = (uint8_t*)c1.raw_data();
+template <class Copy>
+void Warp(const Tensor& a0, const Tensor& b1, int size0,
+          const Buffer_<int>& perm, Tensor c1, Copy& copy) {
+  auto a0_ptr = (const uint8_t*)a0.raw_data();
+  auto b1_ptr = (const uint8_t*)b1.raw_data();
+  auto c1_ptr = (uint8_t*)c1.raw_data();
 
-    const auto vec_size = byte_size(a0.dtype(), a0.stride(0));
+  const auto vec_size = byte_size(a0.dtype(), a0.stride(0));
 
-    for (int i = 0; i < perm.size(); ++i) {
-        const uint8_t* src_ptr = TM_LIKELY(perm[i] < size0) ? a0_ptr + perm[i] * vec_size : b1_ptr + i * vec_size;
-        copy(src_ptr, vec_size, c1_ptr + i * vec_size);
-    }
+  for (int i = 0; i < perm.size(); ++i) {
+    const uint8_t* src_ptr = TM_LIKELY(perm[i] < size0)
+                                 ? a0_ptr + perm[i] * vec_size
+                                 : b1_ptr + i * vec_size;
+    copy(src_ptr, vec_size, c1_ptr + i * vec_size);
+  }
 }
 
-template<class Copy>
-void Warp(const Tensor&       src0,
-          const Buffer_<int>& offset0,
-          int                 size0,
-          const Tensor&       src1,
-          const Buffer_<int>& offset1,
-          const Buffer_<int>& perm0,
-          Tensor              dst,
-          Buffer_<int>        offsetd,
-          Copy&               copy)
-{
-    auto p_src0 = (const uint8_t*)src0.raw_data();
-    auto p_src1 = (const uint8_t*)src1.raw_data();
+template <class Copy>
+void Warp(const Tensor& src0, const Buffer_<int>& offset0, int size0,
+          const Tensor& src1, const Buffer_<int>& offset1,
+          const Buffer_<int>& perm0, Tensor dst, Buffer_<int> offsetd,
+          Copy& copy) {
+  auto p_src0 = (const uint8_t*)src0.raw_data();
+  auto p_src1 = (const uint8_t*)src1.raw_data();
 
-    const ssize_t vec_size = byte_size(src0.dtype(), src0.stride(0));
+  const ssize_t vec_size = byte_size(src0.dtype(), src0.stride(0));
 
-    auto p_dst = (uint8_t*)dst.raw_data();
+  auto p_dst = (uint8_t*)dst.raw_data();
 
-    offsetd[0] = 0;
+  offsetd[0] = 0;
 
-    for (int i = 0; i < perm0.size(); ++i) {
-        const uint8_t* p_src;
-        ssize_t        n;
-        if (const int j = perm0[i]; TM_LIKELY(j < size0)) {
-            p_src = p_src0 + offset0[j] * vec_size;
-            n     = offset0[j + 1] - offset0[j];
-        }
-        else {
-            p_src = p_src1 + offset1[i] * vec_size;
-            n     = offset1[i + 1] - offset1[i];
-        }
-        offsetd[i + 1] = offsetd[i] + n;
-        copy(p_src, n * vec_size, p_dst + offsetd[i] * vec_size);
+  for (int i = 0; i < perm0.size(); ++i) {
+    const uint8_t* p_src;
+    ssize_t n;
+    if (const int j = perm0[i]; TM_LIKELY(j < size0)) {
+      p_src = p_src0 + offset0[j] * vec_size;
+      n = offset0[j + 1] - offset0[j];
+    } else {
+      p_src = p_src1 + offset1[i] * vec_size;
+      n = offset1[i + 1] - offset1[i];
     }
+    offsetd[i + 1] = offsetd[i] + n;
+    copy(p_src, n * vec_size, p_dst + offsetd[i] * vec_size);
+  }
 }
 
 // d1[i] = a0[perm[i]]:b0[perm[i]] if perm[i] < size0 else c1[i]
@@ -112,41 +96,34 @@ void Warp(const Tensor&       src0,
 //       `b0` has fixed size (1)
 //       `a1` has variable size
 //       `c1` has variable size with fixed stride
-template<class Copy>
-void Append(const Tensor&       a0,
-            const Buffer_<int>& a0_size,
-            const Tensor&       b0,
-            const Tensor&       c1,
-            const Buffer_<int>& c1_offset,
-            const Buffer_<int>& perm,
-            int                 size0,
-            Tensor              d1,
-            Buffer_<int>        d1_size,
-            Copy&               copy)
-{
-    auto a0_ptr = (const uint8_t*)a0.raw_data();
-    auto b0_ptr = (const uint8_t*)b0.raw_data();
-    auto c1_ptr = (const uint8_t*)c1.raw_data();
+template <class Copy>
+void Append(const Tensor& a0, const Buffer_<int>& a0_size, const Tensor& b0,
+            const Tensor& c1, const Buffer_<int>& c1_offset,
+            const Buffer_<int>& perm, int size0, Tensor d1,
+            Buffer_<int> d1_size, Copy& copy) {
+  auto a0_ptr = (const uint8_t*)a0.raw_data();
+  auto b0_ptr = (const uint8_t*)b0.raw_data();
+  auto c1_ptr = (const uint8_t*)c1.raw_data();
 
-    auto d1_ptr = (uint8_t*)d1.raw_data();
+  auto d1_ptr = (uint8_t*)d1.raw_data();
 
-    TM_CHECK_EQ(a0.stride(0), d1.stride(0));
+  TM_CHECK_EQ(a0.stride(0), d1.stride(0));
 
-    const auto stride   = byte_size(a0.dtype(), a0.stride(0));
-    const auto vec_size = byte_size(a0.dtype(), a0.stride(1));
+  const auto stride = byte_size(a0.dtype(), a0.stride(0));
+  const auto vec_size = byte_size(a0.dtype(), a0.stride(1));
 
-    for (int i = 0; i < perm.size(); ++i) {
-        if (const int j = perm[i]; TM_LIKELY(j < size0)) {
-            uint8_t* out = copy(a0_ptr + j * stride, vec_size * a0_size[j], d1_ptr + i * stride);
-            copy(b0_ptr + j * vec_size, vec_size, out);
-            d1_size[i] = a0_size[j] + 1;
-        }
-        else {
-            const auto n = c1_offset[i + 1] - c1_offset[i];
-            copy(c1_ptr + c1_offset[i] * vec_size, n * vec_size, d1_ptr + i * stride);
-            d1_size[i] = n;
-        }
+  for (int i = 0; i < perm.size(); ++i) {
+    if (const int j = perm[i]; TM_LIKELY(j < size0)) {
+      uint8_t* out =
+          copy(a0_ptr + j * stride, vec_size * a0_size[j], d1_ptr + i * stride);
+      copy(b0_ptr + j * vec_size, vec_size, out);
+      d1_size[i] = a0_size[j] + 1;
+    } else {
+      const auto n = c1_offset[i + 1] - c1_offset[i];
+      copy(c1_ptr + c1_offset[i] * vec_size, n * vec_size, d1_ptr + i * stride);
+      d1_size[i] = n;
     }
+  }
 }
 
 }  // namespace turbomind

--- a/csrc/sm70_turbomind/lmdeploy/src/turbomind/core/stream.cc
+++ b/csrc/sm70_turbomind/lmdeploy/src/turbomind/core/stream.cc
@@ -4,16 +4,14 @@
 
 namespace turbomind::core {
 
-Stream Stream::create(int priority)
-{
-    Stream stream;
-    stream.impl_ = std::make_shared<StreamImpl>(priority);
-    return stream;
+Stream Stream::create(int priority) {
+  Stream stream;
+  stream.impl_ = std::make_shared<StreamImpl>(priority);
+  return stream;
 }
 
-void StreamImpl::Wait(const Event& event)
-{
-    check_cuda_error(cudaStreamWaitEvent(stream_, event));
+void StreamImpl::Wait(const Event& event) {
+  check_cuda_error(cudaStreamWaitEvent(stream_, event));
 }
 
 }  // namespace turbomind::core

--- a/csrc/sm70_turbomind/lmdeploy/src/turbomind/core/stream.h
+++ b/csrc/sm70_turbomind/lmdeploy/src/turbomind/core/stream.h
@@ -8,153 +8,104 @@
 namespace turbomind::core {
 
 class StreamImpl {
-public:
-    StreamImpl(int priority): stream_{}
-    {
-        check_cuda_error(cudaStreamCreateWithPriority(&stream_, cudaStreamNonBlocking, priority));
+ public:
+  StreamImpl(int priority) : stream_{} {
+    check_cuda_error(cudaStreamCreateWithPriority(
+        &stream_, cudaStreamNonBlocking, priority));
+  }
+
+  ~StreamImpl() {
+    if (auto ec = cudaStreamDestroy(stream_); ec != cudaSuccess) {
+      TM_LOG_ERROR(cudaGetErrorString(ec));
     }
+    stream_ = {};
+  }
 
-    ~StreamImpl()
-    {
-        if (auto ec = cudaStreamDestroy(stream_); ec != cudaSuccess) {
-            TM_LOG_ERROR(cudaGetErrorString(ec));
-        }
-        stream_ = {};
-    }
+  void Sync() { check_cuda_error(cudaStreamSynchronize(stream_)); }
 
-    void Sync()
-    {
-        check_cuda_error(cudaStreamSynchronize(stream_));
-    }
+  void Wait(const Event& event);
 
-    void Wait(const Event& event);
+  cudaStream_t handle() const { return stream_; }
 
-    cudaStream_t handle() const
-    {
-        return stream_;
-    }
-
-public:
-    cudaStream_t stream_;
+ public:
+  cudaStream_t stream_;
 };
 
 class Stream {
-public:
-    Stream() = default;
+ public:
+  Stream() = default;
 
-    static Stream create(int priority = 0);
+  static Stream create(int priority = 0);
 
-    void Sync()
-    {
-        impl_->Sync();
-    }
+  void Sync() { impl_->Sync(); }
 
-    void Wait(const Event& event)
-    {
-        impl_->Wait(event);
-    }
+  void Wait(const Event& event) { impl_->Wait(event); }
 
-    cudaStream_t handle() const
-    {
-        return TM_CHECK_NOTNULL(impl_)->handle();
-    }
+  cudaStream_t handle() const { return TM_CHECK_NOTNULL(impl_)->handle(); }
 
-    explicit operator cudaStream_t() const
-    {
-        return handle();
-    }
+  explicit operator cudaStream_t() const { return handle(); }
 
-    explicit operator bool() const noexcept
-    {
-        return static_cast<bool>(impl_);
-    }
+  explicit operator bool() const noexcept { return static_cast<bool>(impl_); }
 
-    friend bool operator==(const Stream& a, const Stream& b)
-    {
-        return a.impl_ == b.impl_;
-    }
+  friend bool operator==(const Stream& a, const Stream& b) {
+    return a.impl_ == b.impl_;
+  }
 
-    friend bool operator!=(const Stream& a, const Stream& b)
-    {
-        return !(a == b);
-    }
+  friend bool operator!=(const Stream& a, const Stream& b) { return !(a == b); }
 
-    friend std::ostream& operator<<(std::ostream& os, const Stream& s)
-    {
-        os << s.impl_;
-        return os;
-    }
+  friend std::ostream& operator<<(std::ostream& os, const Stream& s) {
+    os << s.impl_;
+    return os;
+  }
 
-private:
-    shared_ptr<StreamImpl> impl_;
+ private:
+  shared_ptr<StreamImpl> impl_;
 };
 
 class EventImpl {
-public:
-    explicit EventImpl(unsigned flags)
-    {
-        check_cuda_error(cudaEventCreateWithFlags(&event_, flags));
-    }
+ public:
+  explicit EventImpl(unsigned flags) {
+    check_cuda_error(cudaEventCreateWithFlags(&event_, flags));
+  }
 
-    ~EventImpl()
-    {
-        if (auto ec = cudaEventDestroy(event_); ec != cudaSuccess) {
-            TM_LOG_ERROR(cudaGetErrorString(ec));
-        }
+  ~EventImpl() {
+    if (auto ec = cudaEventDestroy(event_); ec != cudaSuccess) {
+      TM_LOG_ERROR(cudaGetErrorString(ec));
     }
+  }
 
-    void Record(const Stream& stream)
-    {
-        check_cuda_error(cudaEventRecord(event_, stream.handle()));
-    }
+  void Record(const Stream& stream) {
+    check_cuda_error(cudaEventRecord(event_, stream.handle()));
+  }
 
-    void Sync() const
-    {
-        check_cuda_error(cudaEventSynchronize(event_));
-    }
+  void Sync() const { check_cuda_error(cudaEventSynchronize(event_)); }
 
-    cudaEvent_t handle() const
-    {
-        return event_;
-    }
+  cudaEvent_t handle() const { return event_; }
 
-private:
-    cudaEvent_t event_;
+ private:
+  cudaEvent_t event_;
 };
 
 class Event {
-public:
-    Event() = default;
+ public:
+  Event() = default;
 
-    static Event create(bool timing = false)
-    {
-        Event e{};
-        e.impl_ = std::make_shared<EventImpl>(timing ? 0 : cudaEventDisableTiming);
-        return e;
-    }
+  static Event create(bool timing = false) {
+    Event e{};
+    e.impl_ = std::make_shared<EventImpl>(timing ? 0 : cudaEventDisableTiming);
+    return e;
+  }
 
-    void Record(const Stream& stream)
-    {
-        TM_CHECK_NOTNULL(impl_)->Record(stream);
-    }
+  void Record(const Stream& stream) { TM_CHECK_NOTNULL(impl_)->Record(stream); }
 
-    void Sync() const
-    {
-        TM_CHECK_NOTNULL(impl_)->Sync();
-    }
+  void Sync() const { TM_CHECK_NOTNULL(impl_)->Sync(); }
 
-    operator cudaEvent_t() const
-    {
-        return TM_CHECK_NOTNULL(impl_)->handle();
-    }
+  operator cudaEvent_t() const { return TM_CHECK_NOTNULL(impl_)->handle(); }
 
-    explicit operator bool() const noexcept
-    {
-        return static_cast<bool>(impl_);
-    }
+  explicit operator bool() const noexcept { return static_cast<bool>(impl_); }
 
-private:
-    shared_ptr<EventImpl> impl_;
+ private:
+  shared_ptr<EventImpl> impl_;
 };
 
 }  // namespace turbomind::core

--- a/csrc/sm70_turbomind/lmdeploy/src/turbomind/core/tensor.h
+++ b/csrc/sm70_turbomind/lmdeploy/src/turbomind/core/tensor.h
@@ -12,214 +12,149 @@
 namespace turbomind::core {
 
 class Tensor {
-public:
-    Tensor() = default;
+ public:
+  Tensor() = default;
 
-    Tensor(Layout layout, DataType dtype, Device device): Tensor{layout, dtype, Context::alloc(device)} {}
+  Tensor(Layout layout, DataType dtype, Device device)
+      : Tensor{layout, dtype, Context::alloc(device)} {}
 
-    Tensor(Layout layout, DataType dtype, Allocator& alloc): layout_{std::move(layout)}
-    {
-        buffer_ = Buffer(layout_.cosize(), dtype, alloc);
-    }
+  Tensor(Layout layout, DataType dtype, Allocator& alloc)
+      : layout_{std::move(layout)} {
+    buffer_ = Buffer(layout_.cosize(), dtype, alloc);
+  }
 
-    Tensor(Buffer buffer, Layout layout): layout_{std::move(layout)}, buffer_{buffer.slice(0, layout_.cosize())} {}
+  Tensor(Buffer buffer, Layout layout)
+      : layout_{std::move(layout)},
+        buffer_{buffer.slice(0, layout_.cosize())} {}
 
-    Tensor(Buffer buffer): layout_{buffer.size()}, buffer_{buffer} {}
+  Tensor(Buffer buffer) : layout_{buffer.size()}, buffer_{buffer} {}
 
-    Tensor(void* data, Layout layout, DataType dtype, Device device):
-        Tensor{Buffer{data, layout.cosize(), dtype, device}, layout}
-    {
-    }
+  Tensor(void* data, Layout layout, DataType dtype, Device device)
+      : Tensor{Buffer{data, layout.cosize(), dtype, device}, layout} {}
 
-    Tensor(std::shared_ptr<void> data, Layout layout, DataType dtype, Device device):
-        Tensor{Buffer{data, layout.cosize(), dtype, device}, layout}
-    {
-    }
+  Tensor(std::shared_ptr<void> data, Layout layout, DataType dtype,
+         Device device)
+      : Tensor{Buffer{data, layout.cosize(), dtype, device}, layout} {}
 
-    template<class T>
-    Tensor(T* data, Layout layout, Device device): Tensor{Buffer{data, layout.cosize(), device}, layout}
-    {
-    }
+  template <class T>
+  Tensor(T* data, Layout layout, Device device)
+      : Tensor{Buffer{data, layout.cosize(), device}, layout} {}
 
-    Buffer& buffer() noexcept
-    {
-        return buffer_;
-    }
+  Buffer& buffer() noexcept { return buffer_; }
 
-    const Buffer& buffer() const noexcept
-    {
-        return buffer_;
-    }
+  const Buffer& buffer() const noexcept { return buffer_; }
 
-    DataType dtype() const
-    {
-        return buffer_.dtype();
-    }
+  DataType dtype() const { return buffer_.dtype(); }
 
-    Device device() const
-    {
-        return buffer_.device();
-    }
+  Device device() const { return buffer_.device(); }
 
-    ssize_t size() const noexcept
-    {
-        return layout_.size();
-    }
+  ssize_t size() const noexcept { return layout_.size(); }
 
-    ssize_t byte_size() const noexcept
-    {
-        return turbomind::byte_size(dtype(), size());
-    }
+  ssize_t byte_size() const noexcept {
+    return turbomind::byte_size(dtype(), size());
+  }
 
-    explicit operator bool() const noexcept
-    {
-        return static_cast<bool>(buffer_);
-    }
+  explicit operator bool() const noexcept { return static_cast<bool>(buffer_); }
 
-    template<class T>
-    T* data()
-    {
-        return buffer_.data<T>();
-    }
+  template <class T>
+  T* data() {
+    return buffer_.data<T>();
+  }
 
-    template<class T>
-    const T* data() const
-    {
-        return const_cast<Tensor*>(this)->data<T>();
-    }
+  template <class T>
+  const T* data() const {
+    return const_cast<Tensor*>(this)->data<T>();
+  }
 
-    void* raw_data()
-    {
-        return buffer_.raw_data();
-    }
+  void* raw_data() { return buffer_.raw_data(); }
 
-    const void* raw_data() const
-    {
-        return const_cast<Tensor*>(this)->raw_data();
-    }
+  const void* raw_data() const { return const_cast<Tensor*>(this)->raw_data(); }
 
-    template<class T>
-    T* data_or(T* other)
-    {
-        return buffer_.data_or(other);
-    }
+  template <class T>
+  T* data_or(T* other) {
+    return buffer_.data_or(other);
+  }
 
-    template<class T>
-    const T* data_or(T* other) const
-    {
-        return buffer_.data_or(other);
-    }
+  template <class T>
+  const T* data_or(T* other) const {
+    return buffer_.data_or(other);
+  }
 
-    Tensor view(std::vector<ssize_t> shape) const
-    {
-        return Tensor{buffer_, layout_.view(std::move(shape))};
-    }
+  Tensor view(std::vector<ssize_t> shape) const {
+    return Tensor{buffer_, layout_.view(std::move(shape))};
+  }
 
-    auto& layout() const noexcept
-    {
-        return layout_;
-    }
+  auto& layout() const noexcept { return layout_; }
 
-    auto& shape() const noexcept
-    {
-        return layout_.shape();
-    }
+  auto& shape() const noexcept { return layout_.shape(); }
 
-    auto shape(int i) const
-    {
-        return layout_.shape(i);
-    }
+  auto shape(int i) const { return layout_.shape(i); }
 
-    template<class... Is>
-    auto shapes(Is&&... is) const
-    {
-        return layout_.shapes(((Is &&) is)...);
-    }
+  template <class... Is>
+  auto shapes(Is&&... is) const {
+    return layout_.shapes(((Is&&)is)...);
+  }
 
-    auto& stride() const noexcept
-    {
-        return layout_.stride();
-    }
+  auto& stride() const noexcept { return layout_.stride(); }
 
-    auto stride(int i) const
-    {
-        return layout_.stride(i);
-    }
+  auto stride(int i) const { return layout_.stride(i); }
 
-    template<class... Is>
-    auto strides(Is&&... is) const
-    {
-        return layout_.strides(((Is &&) is)...);
-    }
+  template <class... Is>
+  auto strides(Is&&... is) const {
+    return layout_.strides(((Is&&)is)...);
+  }
 
-    bool is_contiguous() const noexcept
-    {
-        return layout().is_contiguous();
-    }
+  bool is_contiguous() const noexcept { return layout().is_contiguous(); }
 
-    Tensor slice(std::vector<ssize_t> base, std::vector<ssize_t> shape) const
-    {
-        auto&& [layout, offset] = layout_.slice(base, std::move(shape));
-        const auto cosize       = layout.cosize();
-        return Tensor{buffer_.slice(offset, cosize), std::move(layout)};
-    }
+  Tensor slice(std::vector<ssize_t> base, std::vector<ssize_t> shape) const {
+    auto&& [layout, offset] = layout_.slice(base, std::move(shape));
+    const auto cosize = layout.cosize();
+    return Tensor{buffer_.slice(offset, cosize), std::move(layout)};
+  }
 
-    // The outermost dimension
-    Tensor slice(ssize_t base, ssize_t size = 1) const
-    {
-        vector<ssize_t> bases(shape().size());
-        bases.front() = base;
-        vector<ssize_t> sizes{this->shape()};
-        sizes.front() = size;
-        return slice(bases, sizes);
-    }
+  // The outermost dimension
+  Tensor slice(ssize_t base, ssize_t size = 1) const {
+    vector<ssize_t> bases(shape().size());
+    bases.front() = base;
+    vector<ssize_t> sizes{this->shape()};
+    sizes.front() = size;
+    return slice(bases, sizes);
+  }
 
-    Tensor borrow() const
-    {
-        return Tensor{buffer_.borrow(), layout_};
-    }
+  Tensor borrow() const { return Tensor{buffer_.borrow(), layout_}; }
 
-    Tensor squeeze(int dim) const
-    {
-        return Tensor{buffer_, layout_.squeeze(dim)};
-    }
+  Tensor squeeze(int dim) const {
+    return Tensor{buffer_, layout_.squeeze(dim)};
+  }
 
-    Tensor transpose(int a, int b) const
-    {
-        return Tensor{buffer_, layout_.transpose(a, b)};
-    }
+  Tensor transpose(int a, int b) const {
+    return Tensor{buffer_, layout_.transpose(a, b)};
+  }
 
-    Tensor t() const
-    {
-        TM_CHECK_EQ(ndim(), 2);
-        return transpose(0, 1);
-    }
+  Tensor t() const {
+    TM_CHECK_EQ(ndim(), 2);
+    return transpose(0, 1);
+  }
 
-    int ndim() const noexcept
-    {
-        return layout_.rank();
-    }
+  int ndim() const noexcept { return layout_.rank(); }
 
-    friend std::ostream& operator<<(std::ostream& os, const Tensor& t);
+  friend std::ostream& operator<<(std::ostream& os, const Tensor& t);
 
-private:
-    Layout layout_;
-    Buffer buffer_;
+ private:
+  Layout layout_;
+  Buffer buffer_;
 };
 
-inline Tensor empty_like(const Tensor& tensor)
-{
-    return Tensor{tensor.layout(), tensor.dtype(), tensor.device()};
+inline Tensor empty_like(const Tensor& tensor) {
+  return Tensor{tensor.layout(), tensor.dtype(), tensor.device()};
 }
 
-inline Tensor empty_like(const Tensor& tensor, Device device)
-{
-    return Tensor{tensor.layout(), tensor.dtype(), device};
+inline Tensor empty_like(const Tensor& tensor, Device device) {
+  return Tensor{tensor.layout(), tensor.dtype(), device};
 }
 
-inline Tensor empty_like(const Tensor& tensor, DataType dtype)
-{
-    return Tensor{tensor.layout(), dtype, tensor.device()};
+inline Tensor empty_like(const Tensor& tensor, DataType dtype) {
+  return Tensor{tensor.layout(), dtype, tensor.device()};
 }
 
 void Copy(const Tensor& src, Ref<Tensor> dst_, const Stream& stream);
@@ -246,124 +181,98 @@ Tensor Permute(const Tensor& t, vector<int> dims);
 Tensor Contiguous(const Tensor& t);
 #endif
 
-template<class T>
-struct Tensor_: public Tensor {
-    Tensor_() = default;
+template <class T>
+struct Tensor_ : public Tensor {
+  Tensor_() = default;
 
-    Tensor_(Layout layout, Device device): Tensor{std::move(layout), data_type_v<T>, device} {}
+  Tensor_(Layout layout, Device device)
+      : Tensor{std::move(layout), data_type_v<T>, device} {}
 
-    Tensor_(Layout layout, Allocator& alloc): Tensor{std::move(layout), data_type_v<T>, alloc} {}
+  Tensor_(Layout layout, Allocator& alloc)
+      : Tensor{std::move(layout), data_type_v<T>, alloc} {}
 
-    Tensor_(Buffer buffer, Layout layout): Tensor{ensure_dtype(std::move(buffer)), std::move(layout)} {}
+  Tensor_(Buffer buffer, Layout layout)
+      : Tensor{ensure_dtype(std::move(buffer)), std::move(layout)} {}
 
-    Tensor_(T* data, Layout layout, Device device): Tensor{data, std::move(layout), device} {}
+  Tensor_(T* data, Layout layout, Device device)
+      : Tensor{data, std::move(layout), device} {}
 
-    Tensor_(shared_ptr<void> data, Layout layout, Device device):
-        Tensor{Buffer{std::move(data), layout.cosize(), data_type_v<T>, device}, layout}
-    {
-    }
+  Tensor_(shared_ptr<void> data, Layout layout, Device device)
+      : Tensor{Buffer{std::move(data), layout.cosize(), data_type_v<T>, device},
+               layout} {}
 
-    Tensor_(const Tensor_&) = default;
-    Tensor_& operator=(const Tensor_&) = default;
+  Tensor_(const Tensor_&) = default;
+  Tensor_& operator=(const Tensor_&) = default;
 
-    Tensor_(Tensor_&&) noexcept = default;
-    Tensor_& operator=(Tensor_&&) noexcept = default;
+  Tensor_(Tensor_&&) noexcept = default;
+  Tensor_& operator=(Tensor_&&) noexcept = default;
 
-    Tensor_(const Tensor& other)
-    {
-        *static_cast<Tensor*>(this) = ensure_dtype(other);
-    }
-    Tensor_(Tensor&& other) noexcept
-    {
-        *static_cast<Tensor*>(this) = ensure_dtype(std::move(other));
-    }
+  Tensor_(const Tensor& other) {
+    *static_cast<Tensor*>(this) = ensure_dtype(other);
+  }
+  Tensor_(Tensor&& other) noexcept {
+    *static_cast<Tensor*>(this) = ensure_dtype(std::move(other));
+  }
 
-    ssize_t offset(const vector<ssize_t>& idxs)
-    {
-        return layout().offset(idxs);
-    }
+  ssize_t offset(const vector<ssize_t>& idxs) { return layout().offset(idxs); }
 
-    T* data() noexcept
-    {
-        return Tensor::data<T>();
-    }
+  T* data() noexcept { return Tensor::data<T>(); }
 
-    const T* data() const noexcept
-    {
-        return Tensor::data<T>();
-    }
+  const T* data() const noexcept { return Tensor::data<T>(); }
 
-    T* data_or(T* other)
-    {
-        return Tensor::data_or<T>(other);
-    }
+  T* data_or(T* other) { return Tensor::data_or<T>(other); }
 
-    const T* data_or(T* other) const
-    {
-        return Tensor::data_or<T>(other);
-    }
+  const T* data_or(T* other) const { return Tensor::data_or<T>(other); }
 
-    constexpr DataType dtype() const noexcept
-    {
-        return data_type_v<T>;
-    }
+  constexpr DataType dtype() const noexcept { return data_type_v<T>; }
 
-private:
-    template<class U>
-    static decltype(auto) ensure_dtype(U&& u)
-    {
-        TM_CHECK_EQ(u.dtype(), data_type_v<T>);
-        return (U &&) u;
-    }
+ private:
+  template <class U>
+  static decltype(auto) ensure_dtype(U&& u) {
+    TM_CHECK_EQ(u.dtype(), data_type_v<T>);
+    return (U&&)u;
+  }
 };
 
-class TensorMap: public std::unordered_map<std::string, Tensor> {
-public:
-    using std::unordered_map<std::string, Tensor>::unordered_map;
+class TensorMap : public std::unordered_map<std::string, Tensor> {
+ public:
+  using std::unordered_map<std::string, Tensor>::unordered_map;
 
-    Tensor& at(const std::string& key);
+  Tensor& at(const std::string& key);
 
-    const Tensor& at(const std::string& key) const
-    {
-        return const_cast<TensorMap*>(this)->at(key);
+  const Tensor& at(const std::string& key) const {
+    return const_cast<TensorMap*>(this)->at(key);
+  }
+
+  Tensor* try_(const std::string& key);
+
+  const Tensor* try_(const std::string& key) const {
+    return const_cast<TensorMap*>(this)->try_(key);
+  }
+
+  bool contains(const std::string& key) const { return find(key) != end(); }
+
+  void produce(const std::string& key, Tensor value) {
+    TM_CHECK(emplace(key, std::move(value)).second);
+  }
+
+  Tensor try_consume(const std::string& key) {
+    if (auto it = find(key); it != end()) {
+      auto value = std::move(it->second);
+      erase(it);
+      return value;
     }
+    return Tensor{};
+  }
 
-    Tensor* try_(const std::string& key);
+  Tensor consume(const std::string& key) {
+    auto value = try_consume(key);
+    TM_CHECK(value) << get_out_of_range_msg(key);
+    return value;
+  }
 
-    const Tensor* try_(const std::string& key) const
-    {
-        return const_cast<TensorMap*>(this)->try_(key);
-    }
-
-    bool contains(const std::string& key) const
-    {
-        return find(key) != end();
-    }
-
-    void produce(const std::string& key, Tensor value)
-    {
-        TM_CHECK(emplace(key, std::move(value)).second);
-    }
-
-    Tensor try_consume(const std::string& key)
-    {
-        if (auto it = find(key); it != end()) {
-            auto value = std::move(it->second);
-            erase(it);
-            return value;
-        }
-        return Tensor{};
-    }
-
-    Tensor consume(const std::string& key)
-    {
-        auto value = try_consume(key);
-        TM_CHECK(value) << get_out_of_range_msg(key);
-        return value;
-    }
-
-private:
-    std::string get_out_of_range_msg(const std::string& key) const;
+ private:
+  std::string get_out_of_range_msg(const std::string& key) const;
 };
 
 // clang-format off

--- a/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/attention/quantization.h
+++ b/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/attention/quantization.h
@@ -14,875 +14,855 @@ namespace turbomind {
 
 #define TM_ROUND_USE_CVT_RNI 1
 
-inline constexpr bool kFuseU4F16Dequant  = false;
+inline constexpr bool kFuseU4F16Dequant = false;
 inline constexpr bool kForceIntZeroPoint = false;
 
-template<class T>
-__device__ T Infinity()
-{
-    if constexpr (std::is_same_v<T, half>) {
-        return __ushort_as_half((unsigned short)0x7C00U);
-    }
+template <class T>
+__device__ T Infinity() {
+  if constexpr (std::is_same_v<T, half>) {
+    return __ushort_as_half((unsigned short)0x7C00U);
+  }
 
 #if __CUDA_ARCH__ >= 800
-    if constexpr (std::is_same_v<T, nv_bfloat16>) {
-        return __ushort_as_bfloat16((unsigned short)0x7F80U);
-    }
+  if constexpr (std::is_same_v<T, nv_bfloat16>) {
+    return __ushort_as_bfloat16((unsigned short)0x7F80U);
+  }
 #endif
 
-    if constexpr (std::is_same_v<T, float>) {
-        return __int_as_float(0x7f800000U);
-    }
+  if constexpr (std::is_same_v<T, float>) {
+    return __int_as_float(0x7f800000U);
+  }
 
-    return T{};
+  return T{};
 }
 
-template<class T>
-__device__ constexpr T Max(T a, T b)
-{
-    if constexpr (std::is_same_v<T, half>) {
-        return __hmax(a, b);
-    }
+template <class T>
+__device__ constexpr T Max(T a, T b) {
+  if constexpr (std::is_same_v<T, half>) {
+    return __hmax(a, b);
+  }
 
 #if __CUDA_ARCH__ >= 800
-    if constexpr (std::is_same_v<T, nv_bfloat16>) {
-        return __hmax(a, b);
-    }
+  if constexpr (std::is_same_v<T, nv_bfloat16>) {
+    return __hmax(a, b);
+  }
 #endif
 
-    if constexpr (std::is_same_v<T, float>) {
-        return fmaxf(a, b);
-    }
+  if constexpr (std::is_same_v<T, float>) {
+    return fmaxf(a, b);
+  }
 
-    if constexpr (std::is_same_v<T, int>) {
-        return max(a, b);
-    }
+  if constexpr (std::is_same_v<T, int>) {
+    return max(a, b);
+  }
 
-    return T{};
+  return T{};
 }
 
-template<class T>
-__device__ constexpr T Min(T a, T b)
-{
-    if constexpr (std::is_same_v<T, half>) {
-        return __hmin(a, b);
-    }
+template <class T>
+__device__ constexpr T Min(T a, T b) {
+  if constexpr (std::is_same_v<T, half>) {
+    return __hmin(a, b);
+  }
 
 #if __CUDA_ARCH__ >= 800
-    if constexpr (std::is_same_v<T, nv_bfloat16>) {
-        return __hmin(a, b);
-    }
+  if constexpr (std::is_same_v<T, nv_bfloat16>) {
+    return __hmin(a, b);
+  }
 #endif
 
-    if constexpr (std::is_same_v<T, float>) {
-        return fminf(a, b);
-    }
+  if constexpr (std::is_same_v<T, float>) {
+    return fminf(a, b);
+  }
 
-    if constexpr (std::is_same_v<T, int>) {
-        return min(a, b);
-    }
+  if constexpr (std::is_same_v<T, int>) {
+    return min(a, b);
+  }
 
-    return T{};
+  return T{};
 }
 
-template<bool norm = true>
-inline __device__ Array<half, 4> cvt_f16x4_u8(const Array<uint8_t, 4>& src)
-{
-    static constexpr uint32_t f16_magic = 0x64000000;
-    // 01234567 01234567
-    // SEEEEEMM MMMMMMMM
-    //      1MM XXXXXXXX
-    // (1 + x/2^10) * 2^(e-15) -> e-15=10 -> e=25=16+8+1 -> 01100100b -> 0x64
-    Array<uint32_t, 2> dst;
-    dst[0] = __byte_perm((uint32_t&)src, f16_magic, 0x7170);
-    dst[1] = __byte_perm((uint32_t&)src, f16_magic, 0x7372);
-    if constexpr (norm) {
-        for (int i = 0; i < 4; ++i) {
-            ((Array<half, 4>&)dst)[i] -= __ushort_as_half(0x6400U);
-        }
-    }
-    return (Array<half, 4>&)dst;
-}
-
-template<bool norm = true>
-inline __device__ Array<half, 4> cvt_f16x2x2_u8_trans(const Array<uint8_t, 4>& src)
-{
-    static constexpr uint32_t f16_magic = 0x64000000;
-    // 01234567 01234567
-    // SEEEEEMM MMMMMMMM
-    //      1MM XXXXXXXX
-    // (1 + x/2^10) * 2^(e-15) -> e-15=10 -> e=25=16+8+1 -> 01100100b -> 0x64
-    Array<uint32_t, 2> dst;
-    dst[0] = __byte_perm((uint32_t&)src, f16_magic, 0x7270);
-    dst[1] = __byte_perm((uint32_t&)src, f16_magic, 0x7371);
-    if constexpr (norm) {
-        for (int i = 0; i < 4; ++i) {
-            ((Array<half, 4>&)dst)[i] -= __ushort_as_half(0x6400U);
-        }
-    }
-    return (Array<half, 4>&)dst;
-}
-
-inline __device__ Array<nv_bfloat16, 4> cvt_bf16x4_u8(const Array<uint8_t, 4>& src)
-{
-    // 01234567 01234567 01234567 01234567
-    // SEEEEEEE EMMMMMMM MMMMMMMM MMMMMMMM
-    //          1MM...   XXXXXXXX
-    // (1 + x/2^15) * 2^(e-127) -> e-127=15 -> e=142 -> 01000111 -> 0x47
-    static constexpr uint32_t f32_magic = 0x47000000;  // 32768
-
-    Array<uint32_t, 4> tmp;
-    tmp[0] = __byte_perm((uint32_t&)src, f32_magic, 0x7604);
-    tmp[1] = __byte_perm((uint32_t&)src, f32_magic, 0x7614);
-    tmp[2] = __byte_perm((uint32_t&)src, f32_magic, 0x7624);
-    tmp[3] = __byte_perm((uint32_t&)src, f32_magic, 0x7634);
-
-    auto& vec = (Array<float, 4>&)tmp;
-
-    Array<nv_bfloat16, 4> dst;
-    PRAGMA_UNROLL
+template <bool norm = true>
+inline __device__ Array<half, 4> cvt_f16x4_u8(const Array<uint8_t, 4>& src) {
+  static constexpr uint32_t f16_magic = 0x64000000;
+  // 01234567 01234567
+  // SEEEEEMM MMMMMMMM
+  //      1MM XXXXXXXX
+  // (1 + x/2^10) * 2^(e-15) -> e-15=10 -> e=25=16+8+1 -> 01100100b -> 0x64
+  Array<uint32_t, 2> dst;
+  dst[0] = __byte_perm((uint32_t&)src, f16_magic, 0x7170);
+  dst[1] = __byte_perm((uint32_t&)src, f16_magic, 0x7372);
+  if constexpr (norm) {
     for (int i = 0; i < 4; ++i) {
-        dst[i] = __float2bfloat16(vec[i] - 32768.f);
+      ((Array<half, 4>&)dst)[i] -= __ushort_as_half(0x6400U);
     }
-    return dst;
+  }
+  return (Array<half, 4>&)dst;
 }
 
-inline __device__ Array<float, 4> cvt_f32x4_u8(const Array<uint8_t, 4>& src)
-{
-    // 01234567 01234567 01234567 01234567
-    // SEEEEEEE EMMMMMMM MMMMMMMM MMMMMMMM
-    //          1MM...   XXXXXXXX
-    // (1 + x/2^15) * 2^(e-127) -> e-127=15 -> e=142 -> 01000111 -> 0x47
-    static constexpr uint32_t f32_magic = 0x47000000;  // 32768
-
-    Array<uint32_t, 4> tmp;
-    tmp[0] = __byte_perm((uint32_t&)src, f32_magic, 0x7604);
-    tmp[1] = __byte_perm((uint32_t&)src, f32_magic, 0x7614);
-    tmp[2] = __byte_perm((uint32_t&)src, f32_magic, 0x7624);
-    tmp[3] = __byte_perm((uint32_t&)src, f32_magic, 0x7634);
-
-    auto& vec = (Array<float, 4>&)tmp;
-    PRAGMA_UNROLL
+template <bool norm = true>
+inline __device__ Array<half, 4> cvt_f16x2x2_u8_trans(
+    const Array<uint8_t, 4>& src) {
+  static constexpr uint32_t f16_magic = 0x64000000;
+  // 01234567 01234567
+  // SEEEEEMM MMMMMMMM
+  //      1MM XXXXXXXX
+  // (1 + x/2^10) * 2^(e-15) -> e-15=10 -> e=25=16+8+1 -> 01100100b -> 0x64
+  Array<uint32_t, 2> dst;
+  dst[0] = __byte_perm((uint32_t&)src, f16_magic, 0x7270);
+  dst[1] = __byte_perm((uint32_t&)src, f16_magic, 0x7371);
+  if constexpr (norm) {
     for (int i = 0; i < 4; ++i) {
-        vec[i] -= 32768.f;
+      ((Array<half, 4>&)dst)[i] -= __ushort_as_half(0x6400U);
     }
-    return vec;
+  }
+  return (Array<half, 4>&)dst;
 }
 
-template<bool norm = true>
-inline __device__ Array<nv_bfloat16, 8> cvt_bf16x8_u4(const Array<uint4_t, 8>& src)
-{
+inline __device__ Array<nv_bfloat16, 4> cvt_bf16x4_u8(
+    const Array<uint8_t, 4>& src) {
+  // 01234567 01234567 01234567 01234567
+  // SEEEEEEE EMMMMMMM MMMMMMMM MMMMMMMM
+  //          1MM...   XXXXXXXX
+  // (1 + x/2^15) * 2^(e-127) -> e-127=15 -> e=142 -> 01000111 -> 0x47
+  static constexpr uint32_t f32_magic = 0x47000000;  // 32768
+
+  Array<uint32_t, 4> tmp;
+  tmp[0] = __byte_perm((uint32_t&)src, f32_magic, 0x7604);
+  tmp[1] = __byte_perm((uint32_t&)src, f32_magic, 0x7614);
+  tmp[2] = __byte_perm((uint32_t&)src, f32_magic, 0x7624);
+  tmp[3] = __byte_perm((uint32_t&)src, f32_magic, 0x7634);
+
+  auto& vec = (Array<float, 4>&)tmp;
+
+  Array<nv_bfloat16, 4> dst;
+  PRAGMA_UNROLL
+  for (int i = 0; i < 4; ++i) {
+    dst[i] = __float2bfloat16(vec[i] - 32768.f);
+  }
+  return dst;
+}
+
+inline __device__ Array<float, 4> cvt_f32x4_u8(const Array<uint8_t, 4>& src) {
+  // 01234567 01234567 01234567 01234567
+  // SEEEEEEE EMMMMMMM MMMMMMMM MMMMMMMM
+  //          1MM...   XXXXXXXX
+  // (1 + x/2^15) * 2^(e-127) -> e-127=15 -> e=142 -> 01000111 -> 0x47
+  static constexpr uint32_t f32_magic = 0x47000000;  // 32768
+
+  Array<uint32_t, 4> tmp;
+  tmp[0] = __byte_perm((uint32_t&)src, f32_magic, 0x7604);
+  tmp[1] = __byte_perm((uint32_t&)src, f32_magic, 0x7614);
+  tmp[2] = __byte_perm((uint32_t&)src, f32_magic, 0x7624);
+  tmp[3] = __byte_perm((uint32_t&)src, f32_magic, 0x7634);
+
+  auto& vec = (Array<float, 4>&)tmp;
+  PRAGMA_UNROLL
+  for (int i = 0; i < 4; ++i) {
+    vec[i] -= 32768.f;
+  }
+  return vec;
+}
+
+template <bool norm = true>
+inline __device__ Array<nv_bfloat16, 8> cvt_bf16x8_u4(
+    const Array<uint4_t, 8>& src) {
 #if __CUDA_ARCH__ >= 800
-    // 01234567 01234567
-    // SEEEEEEE EMMMMMMM
-    //          1...XXXX
-    // (1 + x/2^7) * 2^(e-127) -> e-127=7 -> e=134 -> 0100 0011 -> 0x43
-    static constexpr uint32_t TEMPLATE = 0x43004300;  // nv_bfloat162(128, 128)
-    static constexpr uint32_t MASK     = 0x000f000f;
-    static constexpr uint32_t immLut   = (0xf0 & 0xcc) | 0xaa;
+  // 01234567 01234567
+  // SEEEEEEE EMMMMMMM
+  //          1...XXXX
+  // (1 + x/2^7) * 2^(e-127) -> e-127=7 -> e=134 -> 0100 0011 -> 0x43
+  static constexpr uint32_t TEMPLATE = 0x43004300;  // nv_bfloat162(128, 128)
+  static constexpr uint32_t MASK = 0x000f000f;
+  static constexpr uint32_t immLut = (0xf0 & 0xcc) | 0xaa;
 
-    Array<uint32_t, 4> h;
+  Array<uint32_t, 4> h;
 
-    static_assert(sizeof(Array<nv_bfloat16, 8>) == sizeof(Array<uint32_t, 4>));
+  static_assert(sizeof(Array<nv_bfloat16, 8>) == sizeof(Array<uint32_t, 4>));
 
-    uint32_t const& i4s    = reinterpret_cast<uint32_t const&>(src);
-    const uint32_t  i4s_4  = i4s >> 4;
-    const uint32_t  i4s_8  = i4s >> 8;
-    const uint32_t  i4s_12 = i4s >> 12;
+  uint32_t const& i4s = reinterpret_cast<uint32_t const&>(src);
+  const uint32_t i4s_4 = i4s >> 4;
+  const uint32_t i4s_8 = i4s >> 8;
+  const uint32_t i4s_12 = i4s >> 12;
 
-    asm volatile("lop3.b32 %0, %1, %2, %3, %4;\n" : "=r"(h[0]) : "r"(i4s), "n"(MASK), "n"(TEMPLATE), "n"(immLut));
-    asm volatile("lop3.b32 %0, %1, %2, %3, %4;\n" : "=r"(h[1]) : "r"(i4s_4), "n"(MASK), "n"(TEMPLATE), "n"(immLut));
-    asm volatile("lop3.b32 %0, %1, %2, %3, %4;\n" : "=r"(h[2]) : "r"(i4s_8), "n"(MASK), "n"(TEMPLATE), "n"(immLut));
-    asm volatile("lop3.b32 %0, %1, %2, %3, %4;\n" : "=r"(h[3]) : "r"(i4s_12), "n"(MASK), "n"(TEMPLATE), "n"(immLut));
+  asm volatile("lop3.b32 %0, %1, %2, %3, %4;\n"
+               : "=r"(h[0])
+               : "r"(i4s), "n"(MASK), "n"(TEMPLATE), "n"(immLut));
+  asm volatile("lop3.b32 %0, %1, %2, %3, %4;\n"
+               : "=r"(h[1])
+               : "r"(i4s_4), "n"(MASK), "n"(TEMPLATE), "n"(immLut));
+  asm volatile("lop3.b32 %0, %1, %2, %3, %4;\n"
+               : "=r"(h[2])
+               : "r"(i4s_8), "n"(MASK), "n"(TEMPLATE), "n"(immLut));
+  asm volatile("lop3.b32 %0, %1, %2, %3, %4;\n"
+               : "=r"(h[3])
+               : "r"(i4s_12), "n"(MASK), "n"(TEMPLATE), "n"(immLut));
 
-    if constexpr (norm) {
-        auto result = reinterpret_cast<nv_bfloat16*>(h.data());
-        PRAGMA_UNROLL
-        for (int i = 0; i < 8; ++i) {
-            result[i] -= nv_bfloat16(128.f);
-        }
+  if constexpr (norm) {
+    auto result = reinterpret_cast<nv_bfloat16*>(h.data());
+    PRAGMA_UNROLL
+    for (int i = 0; i < 8; ++i) {
+      result[i] -= nv_bfloat16(128.f);
     }
-    return (Array<nv_bfloat16, 8>&)h;
+  }
+  return (Array<nv_bfloat16, 8>&)h;
 #else
-    return {};
+  return {};
 #endif
 }
 
 #if TM_ROUND_USE_CVT_RNI
 
-template<class T>
-inline __device__ T round(float x)
-{
-    uint32_t y{};
-    if constexpr (std::is_same_v<T, uint8_t>) {
-        asm("cvt.rni.sat.u8.f32 %0, %1;\n" : "=r"(y) : "f"(x));
-    }
-    else if constexpr (std::is_same_v<T, uint16_t>) {
-        asm("cvt.rni.sat.u16.f32 %0, %1;\n" : "=r"(y) : "f"(x));
-    }
-    else if constexpr (std::is_same_v<T, uint32_t>) {
-        asm("cvt.rni.sat.u32.f32 %0, %1;\n" : "=r"(y) : "f"(x));
-    }
-    else if constexpr (std::is_same_v<T, int32_t>) {
-        asm("cvt.rni.sat.s32.f32 %0, %1;\n" : "=r"(y) : "f"(x));
-    }
-    else {
-        static_assert(!std::is_same_v<T, T>, "not implemented");
-    }
-    return y;
+template <class T>
+inline __device__ T round(float x) {
+  uint32_t y{};
+  if constexpr (std::is_same_v<T, uint8_t>) {
+    asm("cvt.rni.sat.u8.f32 %0, %1;\n" : "=r"(y) : "f"(x));
+  } else if constexpr (std::is_same_v<T, uint16_t>) {
+    asm("cvt.rni.sat.u16.f32 %0, %1;\n" : "=r"(y) : "f"(x));
+  } else if constexpr (std::is_same_v<T, uint32_t>) {
+    asm("cvt.rni.sat.u32.f32 %0, %1;\n" : "=r"(y) : "f"(x));
+  } else if constexpr (std::is_same_v<T, int32_t>) {
+    asm("cvt.rni.sat.s32.f32 %0, %1;\n" : "=r"(y) : "f"(x));
+  } else {
+    static_assert(!std::is_same_v<T, T>, "not implemented");
+  }
+  return y;
 }
 
-template<class T>
-inline __device__ T round(half x)
-{
-    uint32_t y{};
-    if constexpr (std::is_same_v<T, uint8_t>) {
-        asm("cvt.rni.sat.u8.f16 %0, %1;\n" : "=r"(y) : "h"((uint16_t&)x));
-    }
-    else if constexpr (std::is_same_v<T, uint16_t>) {
-        asm("cvt.rni.sat.u16.f16 %0, %1;\n" : "=r"(y) : "h"((uint16_t&)x));
-    }
-    else if constexpr (std::is_same_v<T, uint32_t>) {
-        asm("cvt.rni.sat.u32.f16 %0, %1;\n" : "=r"(y) : "h"((uint16_t&)x));
-    }
-    else if constexpr (std::is_same_v<T, int32_t>) {
-        asm("cvt.rni.sat.s32.f16 %0, %1;\n" : "=r"(y) : "h"((uint16_t&)x));
-    }
-    else {
-        static_assert(!std::is_same_v<T, T>, "not implemented");
-    }
-    return y;
+template <class T>
+inline __device__ T round(half x) {
+  uint32_t y{};
+  if constexpr (std::is_same_v<T, uint8_t>) {
+    asm("cvt.rni.sat.u8.f16 %0, %1;\n" : "=r"(y) : "h"((uint16_t&)x));
+  } else if constexpr (std::is_same_v<T, uint16_t>) {
+    asm("cvt.rni.sat.u16.f16 %0, %1;\n" : "=r"(y) : "h"((uint16_t&)x));
+  } else if constexpr (std::is_same_v<T, uint32_t>) {
+    asm("cvt.rni.sat.u32.f16 %0, %1;\n" : "=r"(y) : "h"((uint16_t&)x));
+  } else if constexpr (std::is_same_v<T, int32_t>) {
+    asm("cvt.rni.sat.s32.f16 %0, %1;\n" : "=r"(y) : "h"((uint16_t&)x));
+  } else {
+    static_assert(!std::is_same_v<T, T>, "not implemented");
+  }
+  return y;
 }
 
 #else
 
-template<class T>
-inline __device__ T round(float x)
-{
-    x += .5f;
+template <class T>
+inline __device__ T round(float x) {
+  x += .5f;
 
-    uint32_t y{};
-    if constexpr (std::is_same_v<T, uint8_t>) {
-        asm("cvt.rzi.sat.u8.f32 %0, %1;\n" : "=r"(y) : "f"(x));
-    }
-    else if constexpr (std::is_same_v<T, uint16_t>) {
-        asm("cvt.rzi.sat.u16.f32 %0, %1;\n" : "=r"(y) : "f"(x));
-    }
-    else if constexpr (std::is_same_v<T, uint32_t>) {
-        asm("cvt.rzi.sat.u32.f32 %0, %1;\n" : "=r"(y) : "f"(x));
-    }
-    else {
-        static_assert(!std::is_same_v<T, T>, "not implemented");
-    }
-    return y;
+  uint32_t y{};
+  if constexpr (std::is_same_v<T, uint8_t>) {
+    asm("cvt.rzi.sat.u8.f32 %0, %1;\n" : "=r"(y) : "f"(x));
+  } else if constexpr (std::is_same_v<T, uint16_t>) {
+    asm("cvt.rzi.sat.u16.f32 %0, %1;\n" : "=r"(y) : "f"(x));
+  } else if constexpr (std::is_same_v<T, uint32_t>) {
+    asm("cvt.rzi.sat.u32.f32 %0, %1;\n" : "=r"(y) : "f"(x));
+  } else {
+    static_assert(!std::is_same_v<T, T>, "not implemented");
+  }
+  return y;
 }
 
-template<class T>
-inline __device__ T round(half x)
-{
-    x += half(.5f);
+template <class T>
+inline __device__ T round(half x) {
+  x += half(.5f);
 
-    uint32_t y{};
-    if constexpr (std::is_same_v<T, uint8_t>) {
-        asm("cvt.rzi.sat.u8.f16 %0, %1;\n" : "=r"(y) : "h"((uint16_t&)x));
-    }
-    else if constexpr (std::is_same_v<T, uint16_t>) {
-        asm("cvt.rzi.sat.u16.f16 %0, %1;\n" : "=r"(y) : "h"((uint16_t&)x));
-    }
-    else if constexpr (std::is_same_v<T, uint32_t>) {
-        asm("cvt.rzi.sat.u32.f16 %0, %1;\n" : "=r"(y) : "h"((uint16_t&)x));
-    }
-    else {
-        static_assert(!std::is_same_v<T, T>, "not implemented");
-    }
-    return y;
+  uint32_t y{};
+  if constexpr (std::is_same_v<T, uint8_t>) {
+    asm("cvt.rzi.sat.u8.f16 %0, %1;\n" : "=r"(y) : "h"((uint16_t&)x));
+  } else if constexpr (std::is_same_v<T, uint16_t>) {
+    asm("cvt.rzi.sat.u16.f16 %0, %1;\n" : "=r"(y) : "h"((uint16_t&)x));
+  } else if constexpr (std::is_same_v<T, uint32_t>) {
+    asm("cvt.rzi.sat.u32.f16 %0, %1;\n" : "=r"(y) : "h"((uint16_t&)x));
+  } else {
+    static_assert(!std::is_same_v<T, T>, "not implemented");
+  }
+  return y;
 }
 
 #endif
 
-template<class To, class Ti, class B>
-inline __device__ To quant(Ti x, B n_bits)
-{
-    auto y = round<To>(x);
-    if constexpr (n_bits < sizeof(To) * 8) {  // saturate operation for sub-byte type
-        return min(y, To((1 << n_bits) - 1));
-    }
-    else {
-        return y;
-    }
+template <class To, class Ti, class B>
+inline __device__ To quant(Ti x, B n_bits) {
+  auto y = round<To>(x);
+  if constexpr (n_bits <
+                sizeof(To) * 8) {  // saturate operation for sub-byte type
+    return min(y, To((1 << n_bits) - 1));
+  } else {
+    return y;
+  }
 }
 
-template<int WarpThreadC, class T, int C>
-__device__ inline void warp_minmax(Array<T, 2>& stats, const Array<T, C>& x)
-{
+template <int WarpThreadC, class T, int C>
+__device__ inline void warp_minmax(Array<T, 2>& stats, const Array<T, C>& x) {
+  PRAGMA_UNROLL
+  for (int i = 0; i < C; ++i) {
+    stats[0] = Min(stats[0], x[i]);
+    stats[1] = Max(stats[1], x[i]);
+  }
+  if constexpr (sizeof(T) == 2) {
     PRAGMA_UNROLL
-    for (int i = 0; i < C; ++i) {
-        stats[0] = Min(stats[0], x[i]);
-        stats[1] = Max(stats[1], x[i]);
+    for (int mask = WarpThreadC / 2; mask > 0; mask /= 2) {
+      Array<T, 2> tmp;
+      (uint32_t&)tmp = __shfl_xor_sync(uint32_t(-1), (uint32_t&)stats, mask);
+      stats[0] = Min(stats[0], tmp[0]);
+      stats[1] = Max(stats[1], tmp[1]);
     }
-    if constexpr (sizeof(T) == 2) {
-        PRAGMA_UNROLL
-        for (int mask = WarpThreadC / 2; mask > 0; mask /= 2) {
-            Array<T, 2> tmp;
-            (uint32_t&)tmp = __shfl_xor_sync(uint32_t(-1), (uint32_t&)stats, mask);
-            stats[0]       = Min(stats[0], tmp[0]);
-            stats[1]       = Max(stats[1], tmp[1]);
-        }
+  } else {
+    PRAGMA_UNROLL
+    for (int mask = WarpThreadC / 2; mask > 0; mask /= 2) {
+      stats[0] = Min(stats[0], __shfl_xor_sync(uint32_t(-1), stats[0], mask));
+      stats[1] = Max(stats[1], __shfl_xor_sync(uint32_t(-1), stats[1], mask));
     }
-    else {
-        PRAGMA_UNROLL
-        for (int mask = WarpThreadC / 2; mask > 0; mask /= 2) {
-            stats[0] = Min(stats[0], __shfl_xor_sync(uint32_t(-1), stats[0], mask));
-            stats[1] = Max(stats[1], __shfl_xor_sync(uint32_t(-1), stats[1], mask));
-        }
-    }
+  }
 }
 
-template<int WarpThreadC, class P, class T, class B, int N, int C, int S>
-__device__ void warp_stats(Array<P, 2> (&param)[S], const Array<T, N> (&x)[S][C], B n_bits)
-{
+template <int WarpThreadC, class P, class T, class B, int N, int C, int S>
+__device__ void warp_stats(Array<P, 2> (&param)[S],
+                           const Array<T, N> (&x)[S][C], B n_bits) {
+  PRAGMA_UNROLL
+  for (int s = 0; s < S; ++s) {
+    Array<T, 2> stats{Infinity<T>(), -Infinity<T>()};
     PRAGMA_UNROLL
-    for (int s = 0; s < S; ++s) {
-        Array<T, 2> stats{Infinity<T>(), -Infinity<T>()};
-        PRAGMA_UNROLL
-        for (int c = 0; c < C; ++c) {
-            warp_minmax<WarpThreadC>(stats, x[s][c]);
-        }
-        const float inv_q_max = fdividef(1.f, float((1 << n_bits) - 1));
-        const float scale     = ((float)stats[1] - (float)stats[0]) * inv_q_max;
-        param[s][0]           = (P)scale;
-        param[s][1]           = (P)stats[0];
+    for (int c = 0; c < C; ++c) {
+      warp_minmax<WarpThreadC>(stats, x[s][c]);
+    }
+    const float inv_q_max = fdividef(1.f, float((1 << n_bits) - 1));
+    const float scale = ((float)stats[1] - (float)stats[0]) * inv_q_max;
+    param[s][0] = (P)scale;
+    param[s][1] = (P)stats[0];
 
-        if constexpr (kForceIntZeroPoint) {
+    if constexpr (kForceIntZeroPoint) {
 #if TM_ROUND_USE_CVT_RNI
-            // rintf -> cvt.rni.f32.f32
-            param[s][1] = (P)(rintf((float)stats[0] / scale) * scale);
+      // rintf -> cvt.rni.f32.f32
+      param[s][1] = (P)(rintf((float)stats[0] / scale) * scale);
 #else
-            // roundf -> cvt.rzi.f32.f32(x + 0.5)
-            param[s][1] = (P)(roundf((float)stats[0] / scale) * scale);
+      // roundf -> cvt.rzi.f32.f32(x + 0.5)
+      param[s][1] = (P)(roundf((float)stats[0] / scale) * scale);
 #endif
-        }
     }
+  }
 }
 
-template<class Q, class T, class P, class B, int N, int C, int S>
-__device__ void
-quantize(Array<Q, N> (&dst)[S][C], const Array<T, N> (&src)[S][C], const Array<P, 2> (&params)[S], B n_bits)
-{
+template <class Q, class T, class P, class B, int N, int C, int S>
+__device__ void quantize(Array<Q, N> (&dst)[S][C],
+                         const Array<T, N> (&src)[S][C],
+                         const Array<P, 2> (&params)[S], B n_bits) {
+  PRAGMA_UNROLL
+  for (int s = 0; s < S; ++s) {
+    P inv_scale = (P)fdividef(1.f, (float)params[s][0]);
+    P zero = params[s][1];
     PRAGMA_UNROLL
-    for (int s = 0; s < S; ++s) {
-        P inv_scale = (P)fdividef(1.f, (float)params[s][0]);
-        P zero      = params[s][1];
-        PRAGMA_UNROLL
-        for (int c = 0; c < C; ++c) {
-            PRAGMA_UNROLL
-            for (int i = 0; i < N; ++i) {
-                const auto v = ((P)src[s][c][i] - zero) * inv_scale;
-                dst[s][c][i] = quant<Q>(v, n_bits);
-            }
-        }
+    for (int c = 0; c < C; ++c) {
+      PRAGMA_UNROLL
+      for (int i = 0; i < N; ++i) {
+        const auto v = ((P)src[s][c][i] - zero) * inv_scale;
+        dst[s][c][i] = quant<Q>(v, n_bits);
+      }
     }
+  }
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////////
 
-// generic case for floating point -> floating point / integer -> integer conversion
-template<typename Ti, typename To, typename = void>
+// generic case for floating point -> floating point / integer -> integer
+// conversion
+template <typename Ti, typename To, typename = void>
 struct ConvertKvCache {
-    __device__ __host__ ConvertKvCache(float, float) {}
-    template<int N>
-    __device__ static auto convert(const Array<Ti, N>& vi)
-    {
-        Array<To, N> vo;
-        PRAGMA_UNROLL
-        for (int i = 0; i < N; ++i) {
-            vo[i] = (To)vi[i];
-        }
-        return vo;
+  __device__ __host__ ConvertKvCache(float, float) {}
+  template <int N>
+  __device__ static auto convert(const Array<Ti, N>& vi) {
+    Array<To, N> vo;
+    PRAGMA_UNROLL
+    for (int i = 0; i < N; ++i) {
+      vo[i] = (To)vi[i];
     }
-    template<int N>
-    inline __device__ auto operator()(const Array<Ti, N>& vi) const -> Array<To, N>
-    {
-        return convert(vi);
-    }
+    return vo;
+  }
+  template <int N>
+  inline __device__ auto operator()(const Array<Ti, N>& vi) const
+      -> Array<To, N> {
+    return convert(vi);
+  }
 };
 
 // generic case for converting to same type, bypass
-template<typename T>
+template <typename T>
 struct ConvertKvCache<T, T> {
-    __device__ __host__ ConvertKvCache(float, float) {}
-    template<int N>
-    __device__ static auto convert(const Array<T, N>& v)
-    {
-        return v;
-    }
-    template<int N>
-    inline __device__ auto operator()(const Array<T, N>& v) const -> Array<T, N>
-    {
-        return convert(v);
-    }
+  __device__ __host__ ConvertKvCache(float, float) {}
+  template <int N>
+  __device__ static auto convert(const Array<T, N>& v) {
+    return v;
+  }
+  template <int N>
+  inline __device__ auto operator()(const Array<T, N>& v) const -> Array<T, N> {
+    return convert(v);
+  }
 };
 
 //  floating point -> u8
-template<class T>
+template <class T>
 struct ConvertKvCache<T, uint8_t> {
-    T          inv_scale_;
-    T          zero_;
-    __device__ ConvertKvCache(T scale, T zero): zero_{zero}
-    {
-        // NVCC complains if we put this in the member init list
-        inv_scale_ = (T)fdividef(1.f, (float)scale);
-    }
+  T inv_scale_;
+  T zero_;
+  __device__ ConvertKvCache(T scale, T zero) : zero_{zero} {
+    // NVCC complains if we put this in the member init list
+    inv_scale_ = (T)fdividef(1.f, (float)scale);
+  }
 
-    template<int N>
-    __device__ auto operator()(const Array<T, N>& vi) const
-    {
-        Array<uint8_t, N> vo;
-        PRAGMA_UNROLL
-        for (int i = 0; i < N; ++i) {
-            vo[i] = quant<uint8_t>((vi[i] - zero_) * inv_scale_, std::integral_constant<int, 8>{});
-        }
-        return vo;
+  template <int N>
+  __device__ auto operator()(const Array<T, N>& vi) const {
+    Array<uint8_t, N> vo;
+    PRAGMA_UNROLL
+    for (int i = 0; i < N; ++i) {
+      vo[i] = quant<uint8_t>((vi[i] - zero_) * inv_scale_,
+                             std::integral_constant<int, 8>{});
     }
+    return vo;
+  }
 };
 
-template<class T>
+template <class T>
 struct ConvertKvCache<T, uint4_t> {
-    T          inv_scale_;
-    T          zero_;
-    __device__ ConvertKvCache(T scale, T zero): zero_{zero}
-    {
-        // NVCC complains if we put this in the member init list
-        inv_scale_ = (T)fdividef(1.f, (float)scale);
+  T inv_scale_;
+  T zero_;
+  __device__ ConvertKvCache(T scale, T zero) : zero_{zero} {
+    // NVCC complains if we put this in the member init list
+    inv_scale_ = (T)fdividef(1.f, (float)scale);
+  }
+
+  static __device__ Array<uint4_t, 8> pack(const Array<uint8_t, 8>& vi) {
+    Array<uint32_t, 2> ui = (Array<uint32_t, 2>&)vi;
+
+    ui[0] |= (ui[0] >> 12);
+    ui[1] |= (ui[1] >> 12);
+
+    //  7 6 5 4 3 2 1 0
+    // _7_67564_3_23120
+    uint32_t uo = __byte_perm(ui[0], ui[1], 0x5140);
+
+    return (Array<uint4_t, 8>&)uo;
+  }
+
+  /// TODO: try cvt.pack.sat.u4
+  template <int N>
+  __device__ auto operator()(const Array<T, N>& vi) const {
+    static_assert(N % 8 == 0);
+    Array<uint8_t, N> tmp;
+    PRAGMA_UNROLL
+    for (int i = 0; i < N; ++i) {
+      tmp[i] = quant<uint8_t>((vi[i] - zero_) * inv_scale_,
+                              std::integral_constant<int, 4>{});
     }
-
-    static __device__ Array<uint4_t, 8> pack(const Array<uint8_t, 8>& vi)
-    {
-        Array<uint32_t, 2> ui = (Array<uint32_t, 2>&)vi;
-
-        ui[0] |= (ui[0] >> 12);
-        ui[1] |= (ui[1] >> 12);
-
-        //  7 6 5 4 3 2 1 0
-        // _7_67564_3_23120
-        uint32_t uo = __byte_perm(ui[0], ui[1], 0x5140);
-
-        return (Array<uint4_t, 8>&)uo;
+    Array<uint4_t, N> vo;
+    PRAGMA_UNROLL
+    for (int i = 0; i < N; i += 8) {
+      (Array<uint4_t, 8>&)vo[i] = pack((Array<uint8_t, 8>&)tmp[i]);
     }
-
-    /// TODO: try cvt.pack.sat.u4
-    template<int N>
-    __device__ auto operator()(const Array<T, N>& vi) const
-    {
-        static_assert(N % 8 == 0);
-        Array<uint8_t, N> tmp;
-        PRAGMA_UNROLL
-        for (int i = 0; i < N; ++i) {
-            tmp[i] = quant<uint8_t>((vi[i] - zero_) * inv_scale_, std::integral_constant<int, 4>{});
-        }
-        Array<uint4_t, N> vo;
-        PRAGMA_UNROLL
-        for (int i = 0; i < N; i += 8) {
-            (Array<uint4_t, 8>&)vo[i] = pack((Array<uint8_t, 8>&)tmp[i]);
-        }
-        return vo;
-    }
+    return vo;
+  }
 };
-template<>
+template <>
 struct ConvertKvCache<uint4_t, half> {
+  half scale_;
+  half zero_;
 
-    half scale_;
-    half zero_;
+  __device__ ConvertKvCache(half scale, half zero) {
+    scale_ = scale;
+    zero_ = zero;
+  }
 
-    __device__ ConvertKvCache(half scale, half zero)
-    {
-        scale_ = scale;
-        zero_  = zero;
+  static __device__ Array<half, 8> cvt_f16x8_u4(const Array<uint4_t, 8>& vi) {
+    Array<half, 8> result;
+    uint32_t* h = reinterpret_cast<uint32_t*>(&result);
+    uint32_t const& i4s = reinterpret_cast<uint32_t const&>(vi);
+    static constexpr uint32_t immLut = (0xf0 & 0xcc) | 0xaa;
+    static constexpr uint32_t BOT_MASK = 0x000f000f;
+    static constexpr uint32_t TOP_MASK = 0x00f000f0;
+    static constexpr uint32_t MAGIC_NUM_0 = 0x64006400;  // `1024`
+    static constexpr uint32_t MAGIC_NUM_1 = 0x54005400;  // `64`
+    // const uint32_t            top_i4s     = i4s >> 8;
+    uint32_t top_i4s = __byte_perm(i4s, 0, 0x4321);
+    asm("lop3.b32 %0, %1, %2, %3, %4;\n"
+        : "=r"(h[0])
+        : "r"(i4s), "n"(BOT_MASK), "n"(MAGIC_NUM_0), "n"(immLut));
+    asm("lop3.b32 %0, %1, %2, %3, %4;\n"
+        : "=r"(h[1])
+        : "r"(i4s), "n"(TOP_MASK), "n"(MAGIC_NUM_1), "n"(immLut));
+    asm("lop3.b32 %0, %1, %2, %3, %4;\n"
+        : "=r"(h[2])
+        : "r"(top_i4s), "n"(BOT_MASK), "n"(MAGIC_NUM_0), "n"(immLut));
+    asm("lop3.b32 %0, %1, %2, %3, %4;\n"
+        : "=r"(h[3])
+        : "r"(top_i4s), "n"(TOP_MASK), "n"(MAGIC_NUM_1), "n"(immLut));
+    asm("sub.f16x2 %0, %1, %2;\n" : "=r"(h[0]) : "r"(h[0]), "r"(MAGIC_NUM_0));
+    asm("sub.f16x2 %0, %1, %2;\n" : "=r"(h[1]) : "r"(h[1]), "r"(MAGIC_NUM_1));
+    asm("sub.f16x2 %0, %1, %2;\n" : "=r"(h[2]) : "r"(h[2]), "r"(MAGIC_NUM_0));
+    asm("sub.f16x2 %0, %1, %2;\n" : "=r"(h[3]) : "r"(h[3]), "r"(MAGIC_NUM_1));
+    return result;
+  }
+
+  static __device__ Array<half, 8> cvt_f16x8_u4_biased(
+      const Array<uint4_t, 8>& vi) {
+    Array<half, 8> result;
+    uint32_t* h = reinterpret_cast<uint32_t*>(&result);
+    uint32_t const& i4s = reinterpret_cast<uint32_t const&>(vi);
+    static constexpr uint32_t immLut = (0xf0 & 0xcc) | 0xaa;
+    static constexpr uint32_t BOT_MASK = 0x000f000f;
+    static constexpr uint32_t TOP_MASK = 0x00f000f0;
+    static constexpr uint32_t MAGIC_NUM_1 = 0x54005400;        // `64`
+    static constexpr uint32_t MAGIC_NUM_2 = MAGIC_NUM_1 >> 4;  // `64` >> 4
+    const uint32_t top_i4s = i4s >> 8;
+    // uint32_t top_i4s = __byte_perm(i4s, 0, 0x4321);
+    asm("lop3.b32 %0, %1, %2, %3, %4;\n"
+        : "=r"(h[0])
+        : "r"(i4s), "n"(BOT_MASK), "n"(MAGIC_NUM_2), "n"(immLut));
+    asm("lop3.b32 %0, %1, %2, %3, %4;\n"
+        : "=r"(h[1])
+        : "r"(i4s), "n"(TOP_MASK), "n"(MAGIC_NUM_1), "n"(immLut));
+    asm("lop3.b32 %0, %1, %2, %3, %4;\n"
+        : "=r"(h[2])
+        : "r"(top_i4s), "n"(BOT_MASK), "n"(MAGIC_NUM_2), "n"(immLut));
+    asm("lop3.b32 %0, %1, %2, %3, %4;\n"
+        : "=r"(h[3])
+        : "r"(top_i4s), "n"(TOP_MASK), "n"(MAGIC_NUM_1), "n"(immLut));
+    h[0] <<= 4;
+    h[2] <<= 4;
+    return result;
+  }
+
+  template <int N>
+  __device__ static auto convert(const Array<uint4_t, N>& vi) {
+    Array<half, N> vo;
+    PRAGMA_UNROLL
+    for (int i = 0; i < N; i += 8) {
+      auto& v = (Array<half, 8>&)vo[i];
+      if constexpr (kFuseU4F16Dequant) {
+        v = cvt_f16x8_u4_biased((Array<uint4_t, 8>&)vi[i]);
+      } else {
+        v = cvt_f16x8_u4((Array<uint4_t, 8>&)vi[i]);
+      }
     }
+    return vo;
+  }
 
-    static __device__ Array<half, 8> cvt_f16x8_u4(const Array<uint4_t, 8>& vi)
-    {
-        Array<half, 8>            result;
-        uint32_t*                 h           = reinterpret_cast<uint32_t*>(&result);
-        uint32_t const&           i4s         = reinterpret_cast<uint32_t const&>(vi);
-        static constexpr uint32_t immLut      = (0xf0 & 0xcc) | 0xaa;
-        static constexpr uint32_t BOT_MASK    = 0x000f000f;
-        static constexpr uint32_t TOP_MASK    = 0x00f000f0;
-        static constexpr uint32_t MAGIC_NUM_0 = 0x64006400;  // `1024`
-        static constexpr uint32_t MAGIC_NUM_1 = 0x54005400;  // `64`
-        // const uint32_t            top_i4s     = i4s >> 8;
-        uint32_t top_i4s = __byte_perm(i4s, 0, 0x4321);
-        asm("lop3.b32 %0, %1, %2, %3, %4;\n" : "=r"(h[0]) : "r"(i4s), "n"(BOT_MASK), "n"(MAGIC_NUM_0), "n"(immLut));
-        asm("lop3.b32 %0, %1, %2, %3, %4;\n" : "=r"(h[1]) : "r"(i4s), "n"(TOP_MASK), "n"(MAGIC_NUM_1), "n"(immLut));
-        asm("lop3.b32 %0, %1, %2, %3, %4;\n" : "=r"(h[2]) : "r"(top_i4s), "n"(BOT_MASK), "n"(MAGIC_NUM_0), "n"(immLut));
-        asm("lop3.b32 %0, %1, %2, %3, %4;\n" : "=r"(h[3]) : "r"(top_i4s), "n"(TOP_MASK), "n"(MAGIC_NUM_1), "n"(immLut));
-        asm("sub.f16x2 %0, %1, %2;\n" : "=r"(h[0]) : "r"(h[0]), "r"(MAGIC_NUM_0));
-        asm("sub.f16x2 %0, %1, %2;\n" : "=r"(h[1]) : "r"(h[1]), "r"(MAGIC_NUM_1));
-        asm("sub.f16x2 %0, %1, %2;\n" : "=r"(h[2]) : "r"(h[2]), "r"(MAGIC_NUM_0));
-        asm("sub.f16x2 %0, %1, %2;\n" : "=r"(h[3]) : "r"(h[3]), "r"(MAGIC_NUM_1));
-        return result;
+  template <int N>
+  __device__ auto operator()(const Array<uint4_t, N>& vi) const {
+    auto vo = convert(vi);
+    PRAGMA_UNROLL
+    for (int i = 0; i < N; ++i) {
+      vo[i] = vo[i] * scale_ + zero_;
     }
-
-    static __device__ Array<half, 8> cvt_f16x8_u4_biased(const Array<uint4_t, 8>& vi)
-    {
-        Array<half, 8>            result;
-        uint32_t*                 h           = reinterpret_cast<uint32_t*>(&result);
-        uint32_t const&           i4s         = reinterpret_cast<uint32_t const&>(vi);
-        static constexpr uint32_t immLut      = (0xf0 & 0xcc) | 0xaa;
-        static constexpr uint32_t BOT_MASK    = 0x000f000f;
-        static constexpr uint32_t TOP_MASK    = 0x00f000f0;
-        static constexpr uint32_t MAGIC_NUM_1 = 0x54005400;        // `64`
-        static constexpr uint32_t MAGIC_NUM_2 = MAGIC_NUM_1 >> 4;  // `64` >> 4
-        const uint32_t            top_i4s     = i4s >> 8;
-        // uint32_t top_i4s = __byte_perm(i4s, 0, 0x4321);
-        asm("lop3.b32 %0, %1, %2, %3, %4;\n" : "=r"(h[0]) : "r"(i4s), "n"(BOT_MASK), "n"(MAGIC_NUM_2), "n"(immLut));
-        asm("lop3.b32 %0, %1, %2, %3, %4;\n" : "=r"(h[1]) : "r"(i4s), "n"(TOP_MASK), "n"(MAGIC_NUM_1), "n"(immLut));
-        asm("lop3.b32 %0, %1, %2, %3, %4;\n" : "=r"(h[2]) : "r"(top_i4s), "n"(BOT_MASK), "n"(MAGIC_NUM_2), "n"(immLut));
-        asm("lop3.b32 %0, %1, %2, %3, %4;\n" : "=r"(h[3]) : "r"(top_i4s), "n"(TOP_MASK), "n"(MAGIC_NUM_1), "n"(immLut));
-        h[0] <<= 4;
-        h[2] <<= 4;
-        return result;
-    }
-
-    template<int N>
-    __device__ static auto convert(const Array<uint4_t, N>& vi)
-    {
-        Array<half, N> vo;
-        PRAGMA_UNROLL
-        for (int i = 0; i < N; i += 8) {
-            auto& v = (Array<half, 8>&)vo[i];
-            if constexpr (kFuseU4F16Dequant) {
-                v = cvt_f16x8_u4_biased((Array<uint4_t, 8>&)vi[i]);
-            }
-            else {
-                v = cvt_f16x8_u4((Array<uint4_t, 8>&)vi[i]);
-            }
-        }
-        return vo;
-    }
-
-    template<int N>
-    __device__ auto operator()(const Array<uint4_t, N>& vi) const
-    {
-        auto vo = convert(vi);
-        PRAGMA_UNROLL
-        for (int i = 0; i < N; ++i) {
-            vo[i] = vo[i] * scale_ + zero_;
-        }
-        return vo;
-    }
+    return vo;
+  }
 };
 
-template<>
+template <>
 struct ConvertKvCache<uint4_t, nv_bfloat16> {
+  nv_bfloat16 scale_;
+  nv_bfloat16 zero_;
 
-    nv_bfloat16 scale_;
-    nv_bfloat16 zero_;
+  __device__ ConvertKvCache(nv_bfloat16 scale, nv_bfloat16 zero) {
+    scale_ = scale;
+    zero_ = zero;
+  }
 
-    __device__ ConvertKvCache(nv_bfloat16 scale, nv_bfloat16 zero)
-    {
-        scale_ = scale;
-        zero_  = zero;
+  template <int N>
+  __device__ static Array<nv_bfloat16, N> convert(const Array<uint4_t, N>& vi) {
+    Array<nv_bfloat16, N> vo{};
+    PRAGMA_UNROLL
+    for (int i = 0; i < N; i += 8) {
+      auto& v = (Array<short, 8>&)vo[i];
+      auto u = cvt_bf16x8_u4((Array<uint4_t, 8>&)vi[i]);
+      v = (Array<short, 8>&)u;
     }
+    return vo;
+  }
 
-    template<int N>
-    __device__ static Array<nv_bfloat16, N> convert(const Array<uint4_t, N>& vi)
-    {
-        Array<nv_bfloat16, N> vo{};
-        PRAGMA_UNROLL
-        for (int i = 0; i < N; i += 8) {
-            auto& v = (Array<short, 8>&)vo[i];
-            auto  u = cvt_bf16x8_u4((Array<uint4_t, 8>&)vi[i]);
-            v       = (Array<short, 8>&)u;
-        }
-        return vo;
+  template <int N>
+  __device__ Array<nv_bfloat16, N> operator()(
+      const Array<uint4_t, N>& vi) const {
+    auto vo = convert(vi);
+    PRAGMA_UNROLL
+    for (int i = 0; i < N; ++i) {
+      vo[i] = vo[i] * scale_ + zero_;
     }
-
-    template<int N>
-    __device__ Array<nv_bfloat16, N> operator()(const Array<uint4_t, N>& vi) const
-    {
-        auto vo = convert(vi);
-        PRAGMA_UNROLL
-        for (int i = 0; i < N; ++i) {
-            vo[i] = vo[i] * scale_ + zero_;
-        }
-        return (Array<nv_bfloat16, N>&)vo;
-    }
+    return (Array<nv_bfloat16, N>&)vo;
+  }
 };
 
-template<>
+template <>
 struct ConvertKvCache<uint4_t, float> {
-
 #if 1
-    ConvertKvCache<uint4_t, half> impl_;
+  ConvertKvCache<uint4_t, half> impl_;
 
-    __device__ ConvertKvCache(float scale, float zero): impl_{scale, zero} {}
+  __device__ ConvertKvCache(float scale, float zero) : impl_{scale, zero} {}
 
-    template<int N>
-    __device__ auto operator()(const Array<uint4_t, N>& vi) const
-    {
-        return cast<float>(impl_(vi));
-    }
+  template <int N>
+  __device__ auto operator()(const Array<uint4_t, N>& vi) const {
+    return cast<float>(impl_(vi));
+  }
 #else
-    static __device__ Array<half, 8> cvt_f16x8_u4_biased(const Array<uint4_t, 8>& vi)
-    {
-        Array<half, 8> result;
-        uint32_t* h = reinterpret_cast<uint32_t*>(&result);
-        uint32_t const& i4s = reinterpret_cast<uint32_t const&>(vi);
-        static constexpr uint32_t immLut = (0xf0 & 0xcc) | 0xaa;
-        static constexpr uint32_t BOT_MASK = 0x000f000f;
-        static constexpr uint32_t TOP_MASK = 0x00f000f0;
-        static constexpr uint32_t MAGIC_NUM_1 = 0x54005400;        // `64`
-        static constexpr uint32_t MAGIC_NUM_2 = MAGIC_NUM_1 >> 4;  // `64` >> 4
-        const uint32_t top_i4s = i4s >> 8;
-        asm("lop3.b32 %0, %1, %2, %3, %4;\n" : "=r"(h[0]) : "r"(i4s), "n"(BOT_MASK), "n"(MAGIC_NUM_2), "n"(immLut));
-        asm("lop3.b32 %0, %1, %2, %3, %4;\n" : "=r"(h[1]) : "r"(i4s), "n"(TOP_MASK), "n"(MAGIC_NUM_1), "n"(immLut));
-        asm("lop3.b32 %0, %1, %2, %3, %4;\n" : "=r"(h[2]) : "r"(top_i4s), "n"(BOT_MASK), "n"(MAGIC_NUM_2), "n"(immLut));
-        asm("lop3.b32 %0, %1, %2, %3, %4;\n" : "=r"(h[3]) : "r"(top_i4s), "n"(TOP_MASK), "n"(MAGIC_NUM_1), "n"(immLut));
-        h[0] <<= 4;
-        h[2] <<= 4;
-        return result;
-    }
-    float scale_;
-    float zero_;
-    __device__ ConvertKvCache(float scale, float zero)
-    {
-        scale_ = scale;
-        zero_ = zero - scale * 64.f;
-    }
-    template<int N>
-    __device__ auto operator()(const Array<uint4_t, N>& vi) const
-    {
-        auto vo = cast<float>(cvt_f16x8_u4_biased(vi));
-        using namespace ops;
-        return vo * scale_ + zero_;
-    }
+  static __device__ Array<half, 8> cvt_f16x8_u4_biased(
+      const Array<uint4_t, 8>& vi) {
+    Array<half, 8> result;
+    uint32_t* h = reinterpret_cast<uint32_t*>(&result);
+    uint32_t const& i4s = reinterpret_cast<uint32_t const&>(vi);
+    static constexpr uint32_t immLut = (0xf0 & 0xcc) | 0xaa;
+    static constexpr uint32_t BOT_MASK = 0x000f000f;
+    static constexpr uint32_t TOP_MASK = 0x00f000f0;
+    static constexpr uint32_t MAGIC_NUM_1 = 0x54005400;        // `64`
+    static constexpr uint32_t MAGIC_NUM_2 = MAGIC_NUM_1 >> 4;  // `64` >> 4
+    const uint32_t top_i4s = i4s >> 8;
+    asm("lop3.b32 %0, %1, %2, %3, %4;\n"
+        : "=r"(h[0])
+        : "r"(i4s), "n"(BOT_MASK), "n"(MAGIC_NUM_2), "n"(immLut));
+    asm("lop3.b32 %0, %1, %2, %3, %4;\n"
+        : "=r"(h[1])
+        : "r"(i4s), "n"(TOP_MASK), "n"(MAGIC_NUM_1), "n"(immLut));
+    asm("lop3.b32 %0, %1, %2, %3, %4;\n"
+        : "=r"(h[2])
+        : "r"(top_i4s), "n"(BOT_MASK), "n"(MAGIC_NUM_2), "n"(immLut));
+    asm("lop3.b32 %0, %1, %2, %3, %4;\n"
+        : "=r"(h[3])
+        : "r"(top_i4s), "n"(TOP_MASK), "n"(MAGIC_NUM_1), "n"(immLut));
+    h[0] <<= 4;
+    h[2] <<= 4;
+    return result;
+  }
+  float scale_;
+  float zero_;
+  __device__ ConvertKvCache(float scale, float zero) {
+    scale_ = scale;
+    zero_ = zero - scale * 64.f;
+  }
+  template <int N>
+  __device__ auto operator()(const Array<uint4_t, N>& vi) const {
+    auto vo = cast<float>(cvt_f16x8_u4_biased(vi));
+    using namespace ops;
+    return vo * scale_ + zero_;
+  }
 #endif
 };
 
 // u8 -> f32/f16/bf16
-template<class T>
+template <class T>
 struct ConvertKvCache<uint8_t, T> {
-    T          scale_;
-    T          zero_;
-    __device__ ConvertKvCache(T scale, T zero): scale_{scale}, zero_{zero} {}
+  T scale_;
+  T zero_;
+  __device__ ConvertKvCache(T scale, T zero) : scale_{scale}, zero_{zero} {}
 
-    template<int N>
-    __device__ static auto convert(const Array<uint8_t, N>& vi)
-    {
-        Array<T, N> vo;
-        PRAGMA_UNROLL
-        for (int n = 0; n < N; n += 4) {
-            auto& ui = (const Array<uint8_t, 4>&)vi[n];
-            auto& uo = (Array<T, 4>&)vo[n];
+  template <int N>
+  __device__ static auto convert(const Array<uint8_t, N>& vi) {
+    Array<T, N> vo;
+    PRAGMA_UNROLL
+    for (int n = 0; n < N; n += 4) {
+      auto& ui = (const Array<uint8_t, 4>&)vi[n];
+      auto& uo = (Array<T, 4>&)vo[n];
 
-            if constexpr (std::is_same_v<T, half>) {
-                uo = cvt_f16x4_u8<true>(ui);
-            }
-            else if constexpr (std::is_same_v<T, float>) {
-                uo = cvt_f32x4_u8(ui);
-            }
+      if constexpr (std::is_same_v<T, half>) {
+        uo = cvt_f16x4_u8<true>(ui);
+      } else if constexpr (std::is_same_v<T, float>) {
+        uo = cvt_f32x4_u8(ui);
+      }
 #if __CUDA_ARCH__ >= 800
-            else if constexpr (std::is_same_v<T, nv_bfloat16>) {
-                uo = cvt_bf16x4_u8(ui);
-            }
+      else if constexpr (std::is_same_v<T, nv_bfloat16>) {
+        uo = cvt_bf16x4_u8(ui);
+      }
 #endif
-        }
-        return vo;
     }
+    return vo;
+  }
 
-    template<int N>
-    __device__ auto operator()(const Array<uint8_t, N>& vi) const
-    {
-        auto vo = convert(vi);
-        PRAGMA_UNROLL
-        for (int i = 0; i < N; ++i) {
-            vo[i] = vo[i] * scale_ + zero_;
-        }
-        return vo;
+  template <int N>
+  __device__ auto operator()(const Array<uint8_t, N>& vi) const {
+    auto vo = convert(vi);
+    PRAGMA_UNROLL
+    for (int i = 0; i < N; ++i) {
+      vo[i] = vo[i] * scale_ + zero_;
     }
+    return vo;
+  }
 };
 
-template<class T>
+template <class T>
 struct ConvertKvCache<fp4_e2m1_t, T> {
+  __device__ static Array<bfloat16_t, 8> cvt_bf16x8_e2m1(
+      const Array<fp4_e2m1_t, 8>& vi) {
+    const uint32_t& x = (const uint32_t&)vi;
 
-    __device__ static Array<bfloat16_t, 8> cvt_bf16x8_e2m1(const Array<fp4_e2m1_t, 8>& vi)
-    {
-        const uint32_t& x = (const uint32_t&)vi;
+    constexpr uint32_t S = 0x80008000U;
+    constexpr uint32_t EM = 0x01C001C0U;
 
-        constexpr uint32_t S  = 0x80008000U;
-        constexpr uint32_t EM = 0x01C001C0U;
+    Array<uint32_t, 4> vo;
 
-        Array<uint32_t, 4> vo;
-
-        // clang-format off
+    // clang-format off
         vo[0] = (x << 12 & S) | (x << 6 & EM);
         vo[1] = (x <<  8 & S) | (x << 2 & EM);
         vo[2] = (x <<  4 & S) | (x >> 2 & EM);
         vo[3] = (x <<  0 & S) | (x >> 6 & EM);
-        // clang-format on
+    // clang-format on
 
-        constexpr uint32_t e  = (127U - 1U + 127U) << 7U;
-        constexpr uint32_t ee = e << 16U | e;
+    constexpr uint32_t e = (127U - 1U + 127U) << 7U;
+    constexpr uint32_t ee = e << 16U | e;
 
-        PRAGMA_UNROLL
-        for (int i = 0; i < 4; ++i) {
+    PRAGMA_UNROLL
+    for (int i = 0; i < 4; ++i) {
 #if TURBOMIND_ARCH_SM90
-            asm("mul.rn.bf16x2 %0, %1, %2;" : "=r"(vo[i]) : "r"(vo[i]), "r"(ee));
+      asm("mul.rn.bf16x2 %0, %1, %2;" : "=r"(vo[i]) : "r"(vo[i]), "r"(ee));
 #else
-            asm("fma.rn.bf16x2 %0, %1, %2, %3;" : "=r"(vo[i]) : "r"(vo[i]), "r"(ee), "r"(0));
+      asm("fma.rn.bf16x2 %0, %1, %2, %3;"
+          : "=r"(vo[i])
+          : "r"(vo[i]), "r"(ee), "r"(0));
 #endif
-        }
-
-        return (Array<bfloat16_t, 8>&)vo;
     }
 
-    __device__ static Array<half, 8> cvt_f16x8_e2m1(const Array<fp4_e2m1_t, 8>& vi)
-    {
-        const uint32_t& x = (const uint32_t&)vi;
+    return (Array<bfloat16_t, 8>&)vo;
+  }
 
-        constexpr uint32_t S  = 0x80008000U;
-        constexpr uint32_t EM = 0x0E000E00U;
+  __device__ static Array<half, 8> cvt_f16x8_e2m1(
+      const Array<fp4_e2m1_t, 8>& vi) {
+    const uint32_t& x = (const uint32_t&)vi;
 
-        Array<uint32_t, 4> vo;
+    constexpr uint32_t S = 0x80008000U;
+    constexpr uint32_t EM = 0x0E000E00U;
 
-        // clang-format off
+    Array<uint32_t, 4> vo;
+
+    // clang-format off
         vo[0] = (x << 12 & S) | (x << 9 & EM);
         vo[1] = (x <<  8 & S) | (x << 5 & EM);
         vo[2] = (x <<  4 & S) | (x << 1 & EM);
         vo[3] = (x <<  0 & S) | (x >> 3 & EM);
-        // clang-format on
+    // clang-format on
 
-        constexpr uint32_t e  = (15U - 1U + 15U) << 10U;
-        constexpr uint32_t ee = e << 16U | e;
-
-        PRAGMA_UNROLL
-        for (int i = 0; i < 4; ++i) {
-            asm volatile("mul.f16x2 %0, %1, %2;" : "=r"(vo[i]) : "r"(vo[i]), "r"(ee));
-        }
-
-        return (Array<half, 8>&)vo;
-    }
-
-    template<int N>
-    __device__ static auto convert(const Array<fp4_e2m1_t, N>& vi)
-    {
-        Array<T, N> vo;
-        PRAGMA_UNROLL
-        for (int i = 0; i < N; i += 8) {
-            auto& v = (Array<T, 8>&)vo[i];
-            if constexpr (std::is_same_v<T, bfloat16_t>) {
-                v = cvt_bf16x8_e2m1((Array<fp4_e2m1_t, 8>&)vi[i]);
-            }
-            else if constexpr (std::is_same_v<T, half_t>) {
-                v = cvt_f16x8_e2m1((Array<fp4_e2m1_t, 8>&)vi[i]);
-            }
-            else {
-                static_assert(N != N, "not implemented");
-            }
-        }
-        return vo;
-    }
-};
-
-__device__ inline Array<bfloat16_t, 4> cvt_bf16x4_e4m3(const Array<fp8_e4m3_t, 4>& vi)
-{
-    const uint32_t& x = (const uint32_t&)vi;
-
-    //    0   7   C   0
-    // SEEEEEEEEMMMMMMMSEEEEEEEEMMMMMMM
-    // SEEEEMMM        SEEEEMMM
-    //         SEEEEMMM        SEEEEMMM
-
-    constexpr uint32_t S  = 0x80008000U;
-    constexpr uint32_t EM = 0x07F007F0U;
-
-    Array<uint32_t, 2> vo;
-
-    vo[0] = (x << 8 & S) | (x << 4 & EM);
-    vo[1] = (x << 0 & S) | (x >> 4 & EM);
-
-    constexpr uint32_t e  = (127U - 7U + 127U) << 7U;
+    constexpr uint32_t e = (15U - 1U + 15U) << 10U;
     constexpr uint32_t ee = e << 16U | e;
 
     PRAGMA_UNROLL
-    for (int i = 0; i < 2; ++i) {
+    for (int i = 0; i < 4; ++i) {
+      asm volatile("mul.f16x2 %0, %1, %2;" : "=r"(vo[i]) : "r"(vo[i]), "r"(ee));
+    }
+
+    return (Array<half, 8>&)vo;
+  }
+
+  template <int N>
+  __device__ static auto convert(const Array<fp4_e2m1_t, N>& vi) {
+    Array<T, N> vo;
+    PRAGMA_UNROLL
+    for (int i = 0; i < N; i += 8) {
+      auto& v = (Array<T, 8>&)vo[i];
+      if constexpr (std::is_same_v<T, bfloat16_t>) {
+        v = cvt_bf16x8_e2m1((Array<fp4_e2m1_t, 8>&)vi[i]);
+      } else if constexpr (std::is_same_v<T, half_t>) {
+        v = cvt_f16x8_e2m1((Array<fp4_e2m1_t, 8>&)vi[i]);
+      } else {
+        static_assert(N != N, "not implemented");
+      }
+    }
+    return vo;
+  }
+};
+
+__device__ inline Array<bfloat16_t, 4> cvt_bf16x4_e4m3(
+    const Array<fp8_e4m3_t, 4>& vi) {
+  const uint32_t& x = (const uint32_t&)vi;
+
+  //    0   7   C   0
+  // SEEEEEEEEMMMMMMMSEEEEEEEEMMMMMMM
+  // SEEEEMMM        SEEEEMMM
+  //         SEEEEMMM        SEEEEMMM
+
+  constexpr uint32_t S = 0x80008000U;
+  constexpr uint32_t EM = 0x07F007F0U;
+
+  Array<uint32_t, 2> vo;
+
+  vo[0] = (x << 8 & S) | (x << 4 & EM);
+  vo[1] = (x << 0 & S) | (x >> 4 & EM);
+
+  constexpr uint32_t e = (127U - 7U + 127U) << 7U;
+  constexpr uint32_t ee = e << 16U | e;
+
+  PRAGMA_UNROLL
+  for (int i = 0; i < 2; ++i) {
 #if TURBOMIND_ARCH_SM90
-        asm("mul.rn.bf16x2 %0, %1, %2;" : "=r"(vo[i]) : "r"(vo[i]), "r"(ee));
+    asm("mul.rn.bf16x2 %0, %1, %2;" : "=r"(vo[i]) : "r"(vo[i]), "r"(ee));
 #else
-        asm("fma.rn.bf16x2 %0, %1, %2, %3;" : "=r"(vo[i]) : "r"(vo[i]), "r"(ee), "r"(0));
+    asm("fma.rn.bf16x2 %0, %1, %2, %3;"
+        : "=r"(vo[i])
+        : "r"(vo[i]), "r"(ee), "r"(0));
 #endif
-    }
+  }
 
-    return (Array<bfloat16_t, 4>&)vo;
+  return (Array<bfloat16_t, 4>&)vo;
 }
 
-__device__ inline Array<half, 4> cvt_f16x4_e4m3(const Array<fp8_e4m3_t, 4>& vi)
-{
-    const uint32_t& x = (const uint32_t&)vi;
+__device__ inline Array<half, 4> cvt_f16x4_e4m3(
+    const Array<fp8_e4m3_t, 4>& vi) {
+  const uint32_t& x = (const uint32_t&)vi;
 
-    //    3   F   8   0
-    // SEEEEEMMMMMMMMMMSEEEEEMMMMMMMMMM
-    // SEEEEMMM        SEEEEMMM
-    //         SEEEEMMM        SEEEEMMM
+  //    3   F   8   0
+  // SEEEEEMMMMMMMMMMSEEEEEMMMMMMMMMM
+  // SEEEEMMM        SEEEEMMM
+  //         SEEEEMMM        SEEEEMMM
 
-    constexpr uint32_t S  = 0x80008000U;
-    constexpr uint32_t EM = 0x3F803F80U;
+  constexpr uint32_t S = 0x80008000U;
+  constexpr uint32_t EM = 0x3F803F80U;
 
-    Array<uint32_t, 2> vo;
+  Array<uint32_t, 2> vo;
 
-    vo[0] = (x << 8 & S) | (x << 7 & EM);
-    vo[1] = (x << 0 & S) | (x >> 1 & EM);
+  vo[0] = (x << 8 & S) | (x << 7 & EM);
+  vo[1] = (x << 0 & S) | (x >> 1 & EM);
 
-    constexpr uint32_t e  = (15U - 7U + 15U) << 10U;
-    constexpr uint32_t ee = e << 16U | e;
+  constexpr uint32_t e = (15U - 7U + 15U) << 10U;
+  constexpr uint32_t ee = e << 16U | e;
 
-    PRAGMA_UNROLL
-    for (int i = 0; i < 2; ++i) {
-        asm("mul.rn.f16x2 %0, %1, %2;" : "=r"(vo[i]) : "r"(vo[i]), "r"(ee));
-    }
+  PRAGMA_UNROLL
+  for (int i = 0; i < 2; ++i) {
+    asm("mul.rn.f16x2 %0, %1, %2;" : "=r"(vo[i]) : "r"(vo[i]), "r"(ee));
+  }
 
-    return (Array<half, 4>&)vo;
+  return (Array<half, 4>&)vo;
 }
 
-template<class T>
+template <class T>
 struct ConvertKvCache<fp8_e4m3_t, T> {
-
-    template<int N>
-    __device__ static auto convert(const Array<fp8_e4m3_t, N>& vi)
-    {
-        static_assert(N % 4 == 0);
-        Array<T, N> vo;
-        PRAGMA_UNROLL
-        for (int i = 0; i < N; i += 4) {
-            auto& v = (Array<T, 4>&)vo[i];
-            if constexpr (std::is_same_v<T, bfloat16_t>) {
-                v = cvt_bf16x4_e4m3((Array<fp8_e4m3_t, 4>&)vi[i]);
-            }
-            else if constexpr (std::is_same_v<T, half_t>) {
-                v = cvt_f16x4_e4m3((Array<fp8_e4m3_t, 4>&)vi[i]);
-            }
-            else {
-                static_assert(N != N, "not implemented");
-            }
-        }
-        return vo;
+  template <int N>
+  __device__ static auto convert(const Array<fp8_e4m3_t, N>& vi) {
+    static_assert(N % 4 == 0);
+    Array<T, N> vo;
+    PRAGMA_UNROLL
+    for (int i = 0; i < N; i += 4) {
+      auto& v = (Array<T, 4>&)vo[i];
+      if constexpr (std::is_same_v<T, bfloat16_t>) {
+        v = cvt_bf16x4_e4m3((Array<fp8_e4m3_t, 4>&)vi[i]);
+      } else if constexpr (std::is_same_v<T, half_t>) {
+        v = cvt_f16x4_e4m3((Array<fp8_e4m3_t, 4>&)vi[i]);
+      } else {
+        static_assert(N != N, "not implemented");
+      }
     }
+    return vo;
+  }
 };
 
-template<class Q, class T>
-inline __device__ void StoreQuantParam(T* dst, Array<T, 2> src)
-{
-    Store(dst, src);
+template <class Q, class T>
+inline __device__ void StoreQuantParam(T* dst, Array<T, 2> src) {
+  Store(dst, src);
 }
 
-template<>
-inline __device__ void StoreQuantParam<uint4_t, half>(half* dst, Array<half, 2> src)
-{
-    if constexpr (kFuseU4F16Dequant) {
-        src[1] = src[1] - src[0] * __ushort_as_half(0x5400);
-    }
-    Store(dst, src);
+template <>
+inline __device__ void StoreQuantParam<uint4_t, half>(half* dst,
+                                                      Array<half, 2> src) {
+  if constexpr (kFuseU4F16Dequant) {
+    src[1] = src[1] - src[0] * __ushort_as_half(0x5400);
+  }
+  Store(dst, src);
 }
 
 }  // namespace turbomind

--- a/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/core/array.h
+++ b/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/core/array.h
@@ -10,131 +10,104 @@
 
 namespace turbomind {
 
-template<typename T, int N>
+template <typename T, int N>
 struct Array {
-    using value_type      = T;
-    using size_type       = int;
-    using difference_type = int;
-    using reference       = value_type&;
-    using const_reference = const value_type&;
-    using pointer         = value_type*;
-    using const_pointer   = const value_type*;
-    using iterator        = pointer;
-    using const_iterator  = const_pointer;
+  using value_type = T;
+  using size_type = int;
+  using difference_type = int;
+  using reference = value_type&;
+  using const_reference = const value_type&;
+  using pointer = value_type*;
+  using const_pointer = const value_type*;
+  using iterator = pointer;
+  using const_iterator = const_pointer;
 
-    static_assert(N > 0);
+  static_assert(N > 0);
 
-    T __a[N];
+  T __a[N];
 
-    TM_HOST_DEVICE constexpr reference operator[](size_type i) noexcept
-    {
-        return __a[i];
-    }
+  TM_HOST_DEVICE constexpr reference operator[](size_type i) noexcept {
+    return __a[i];
+  }
 
-    TM_HOST_DEVICE constexpr const_reference operator[](size_type i) const noexcept
-    {
-        return __a[i];
-    }
+  TM_HOST_DEVICE constexpr const_reference operator[](
+      size_type i) const noexcept {
+    return __a[i];
+  }
 
-    TM_HOST_DEVICE constexpr reference front() noexcept
-    {
-        return *begin();
-    }
+  TM_HOST_DEVICE constexpr reference front() noexcept { return *begin(); }
 
-    TM_HOST_DEVICE constexpr const_reference front() const noexcept
-    {
-        return *begin();
-    }
+  TM_HOST_DEVICE constexpr const_reference front() const noexcept {
+    return *begin();
+  }
 
-    TM_HOST_DEVICE constexpr reference back() noexcept
-    {
-        return *(end() - 1);
-    }
+  TM_HOST_DEVICE constexpr reference back() noexcept { return *(end() - 1); }
 
-    TM_HOST_DEVICE constexpr const_reference back() const noexcept
-    {
-        return *(end() - 1);
-    }
+  TM_HOST_DEVICE constexpr const_reference back() const noexcept {
+    return *(end() - 1);
+  }
 
-    TM_HOST_DEVICE constexpr pointer data() noexcept
-    {
-        return &__a[0];
-    }
+  TM_HOST_DEVICE constexpr pointer data() noexcept { return &__a[0]; }
 
-    TM_HOST_DEVICE constexpr const_pointer data() const noexcept
-    {
-        return &__a[0];
-    }
+  TM_HOST_DEVICE constexpr const_pointer data() const noexcept {
+    return &__a[0];
+  }
 
-    TM_HOST_DEVICE constexpr iterator begin() noexcept
-    {
-        return data();
-    }
+  TM_HOST_DEVICE constexpr iterator begin() noexcept { return data(); }
 
-    TM_HOST_DEVICE constexpr const_iterator begin() const noexcept
-    {
-        return data();
-    }
+  TM_HOST_DEVICE constexpr const_iterator begin() const noexcept {
+    return data();
+  }
 
-    TM_HOST_DEVICE constexpr iterator end() noexcept
-    {
-        return data() + N;
-    }
+  TM_HOST_DEVICE constexpr iterator end() noexcept { return data() + N; }
 
-    TM_HOST_DEVICE constexpr const_iterator end() const noexcept
-    {
-        return data() + N;
-    }
+  TM_HOST_DEVICE constexpr const_iterator end() const noexcept {
+    return data() + N;
+  }
 
-    TM_HOST_DEVICE static constexpr std::integral_constant<int, N> size() noexcept
-    {
-        return {};
-    }
+  TM_HOST_DEVICE static constexpr std::integral_constant<int, N>
+  size() noexcept {
+    return {};
+  }
 
-    TM_HOST_DEVICE static constexpr std::false_type empty() noexcept
-    {
-        return {};
-    }
+  TM_HOST_DEVICE static constexpr std::false_type empty() noexcept {
+    return {};
+  }
 };
 
-template<int N>
+template <int N>
 struct Array<uint4_t, N> {
-    using value_type      = detail::__uint4_t;
-    using size_type       = int;
-    using difference_type = int;
-    using reference       = value_type&;
-    using const_reference = const value_type&;
-    using pointer         = SubBytePtr<uint4_t>;
-    using const_pointer   = SubBytePtr<const uint4_t>;
+  using value_type = detail::__uint4_t;
+  using size_type = int;
+  using difference_type = int;
+  using reference = value_type&;
+  using const_reference = const value_type&;
+  using pointer = SubBytePtr<uint4_t>;
+  using const_pointer = SubBytePtr<const uint4_t>;
 
-    // static_assert(N % 8 == 0);
+  // static_assert(N % 8 == 0);
 
-    detail::__uint4_t __a[N / 8];
+  detail::__uint4_t __a[N / 8];
 
-    TM_HOST_DEVICE constexpr reference operator[](size_type i) noexcept
-    {
-        return __a[i / 8];
-    }
+  TM_HOST_DEVICE constexpr reference operator[](size_type i) noexcept {
+    return __a[i / 8];
+  }
 
-    TM_HOST_DEVICE constexpr const_reference operator[](size_type i) const noexcept
-    {
-        return __a[i / 8];
-    }
+  TM_HOST_DEVICE constexpr const_reference operator[](
+      size_type i) const noexcept {
+    return __a[i / 8];
+  }
 
-    TM_HOST_DEVICE static constexpr std::integral_constant<int, N> size() noexcept
-    {
-        return {};
-    }
+  TM_HOST_DEVICE static constexpr std::integral_constant<int, N>
+  size() noexcept {
+    return {};
+  }
 
-    TM_HOST_DEVICE static constexpr std::false_type empty() noexcept
-    {
-        return {};
-    }
+  TM_HOST_DEVICE static constexpr std::false_type empty() noexcept {
+    return {};
+  }
 
-    TM_HOST_DEVICE constexpr pointer data() noexcept
-    {
-        return {(char*)&__a[0]};
-    }
+  TM_HOST_DEVICE constexpr pointer data() noexcept { return {(char*)&__a[0]}; }
 };
 
 static_assert(sizeof(Array<uint4_t, 8>) == 4);
@@ -142,44 +115,39 @@ static_assert(sizeof(Array<uint4_t, 16>) == 8);
 static_assert(sizeof(Array<uint4_t, 24>) == 12);
 static_assert(sizeof(Array<uint4_t, 32>) == 16);
 
-template<int N>
+template <int N>
 struct Array<fp4_e2m1_t, N> {
-    using value_type      = detail::__uint4_t;
-    using size_type       = int;
-    using difference_type = int;
-    using reference       = value_type&;
-    using const_reference = const value_type&;
-    using pointer         = SubBytePtr<fp4_e2m1_t>;
-    using const_pointer   = SubBytePtr<const fp4_e2m1_t>;
+  using value_type = detail::__uint4_t;
+  using size_type = int;
+  using difference_type = int;
+  using reference = value_type&;
+  using const_reference = const value_type&;
+  using pointer = SubBytePtr<fp4_e2m1_t>;
+  using const_pointer = SubBytePtr<const fp4_e2m1_t>;
 
-    // static_assert(N % 8 == 0);
+  // static_assert(N % 8 == 0);
 
-    detail::__uint4_t __a[N / 8];
+  detail::__uint4_t __a[N / 8];
 
-    TM_HOST_DEVICE constexpr reference operator[](size_type i) noexcept
-    {
-        return __a[i / 8];
-    }
+  TM_HOST_DEVICE constexpr reference operator[](size_type i) noexcept {
+    return __a[i / 8];
+  }
 
-    TM_HOST_DEVICE constexpr const_reference operator[](size_type i) const noexcept
-    {
-        return __a[i / 8];
-    }
+  TM_HOST_DEVICE constexpr const_reference operator[](
+      size_type i) const noexcept {
+    return __a[i / 8];
+  }
 
-    TM_HOST_DEVICE static constexpr std::integral_constant<int, N> size() noexcept
-    {
-        return {};
-    }
+  TM_HOST_DEVICE static constexpr std::integral_constant<int, N>
+  size() noexcept {
+    return {};
+  }
 
-    TM_HOST_DEVICE static constexpr std::false_type empty() noexcept
-    {
-        return {};
-    }
+  TM_HOST_DEVICE static constexpr std::false_type empty() noexcept {
+    return {};
+  }
 
-    TM_HOST_DEVICE constexpr pointer data() noexcept
-    {
-        return {(char*)&__a[0]};
-    }
+  TM_HOST_DEVICE constexpr pointer data() noexcept { return {(char*)&__a[0]}; }
 };
 
 }  // namespace turbomind

--- a/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/core/array_ops.h
+++ b/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/core/array_ops.h
@@ -11,501 +11,435 @@ namespace turbomind {
 
 namespace ops {
 
-template<typename T>
+template <typename T>
 struct plus {
-    __device__ T operator()(T a, T b)
-    {
-        return a + b;
-    }
+  __device__ T operator()(T a, T b) { return a + b; }
 };
 
-template<typename T>
+template <typename T>
 struct minus {
-    __device__ T operator()(T a, T b)
-    {
-        return a - b;
-    }
+  __device__ T operator()(T a, T b) { return a - b; }
 };
 
-template<typename T>
+template <typename T>
 struct multiplies {
-    __device__ T operator()(T a, T b)
-    {
-        return a * b;
-    }
+  __device__ T operator()(T a, T b) { return a * b; }
 };
 
-template<typename T, int N, typename Op>
-inline __device__ Array<T, N> binary_op_vv(const Array<T, N>& a, const Array<T, N>& b, Op op)
-{
-    Array<T, N> c;
-    PRAGMA_UNROLL
-    for (int i = 0; i < N; ++i) {
-        c[i] = op(a[i], b[i]);
-    }
-    return c;
+template <typename T, int N, typename Op>
+inline __device__ Array<T, N> binary_op_vv(const Array<T, N>& a,
+                                           const Array<T, N>& b, Op op) {
+  Array<T, N> c;
+  PRAGMA_UNROLL
+  for (int i = 0; i < N; ++i) {
+    c[i] = op(a[i], b[i]);
+  }
+  return c;
 }
 
-template<typename T, int N, typename Op>
-inline __device__ Array<T, N> binary_op_sv(const T& a, const Array<T, N>& b, Op op)
-{
-    Array<T, N> c;
-    PRAGMA_UNROLL
-    for (int i = 0; i < N; ++i) {
-        c[i] = op(a, b[i]);
-    }
-    return c;
+template <typename T, int N, typename Op>
+inline __device__ Array<T, N> binary_op_sv(const T& a, const Array<T, N>& b,
+                                           Op op) {
+  Array<T, N> c;
+  PRAGMA_UNROLL
+  for (int i = 0; i < N; ++i) {
+    c[i] = op(a, b[i]);
+  }
+  return c;
 }
 
-template<typename T, int N, typename Op>
-inline __device__ Array<T, N> binary_op_vs(const Array<T, N>& a, const T& b, Op op)
-{
-    Array<T, N> c;
-    PRAGMA_UNROLL
-    for (int i = 0; i < N; ++i) {
-        c[i] = op(a[i], b);
-    }
-    return c;
+template <typename T, int N, typename Op>
+inline __device__ Array<T, N> binary_op_vs(const Array<T, N>& a, const T& b,
+                                           Op op) {
+  Array<T, N> c;
+  PRAGMA_UNROLL
+  for (int i = 0; i < N; ++i) {
+    c[i] = op(a[i], b);
+  }
+  return c;
 }
 
-template<typename T, int N>
-inline __device__ Array<T, N> operator+(const Array<T, N>& a, const Array<T, N>& b)
-{
-    return binary_op_vv(a, b, plus<T>{});
+template <typename T, int N>
+inline __device__ Array<T, N> operator+(const Array<T, N>& a,
+                                        const Array<T, N>& b) {
+  return binary_op_vv(a, b, plus<T>{});
 }
 
-template<typename T, int N>
-inline __device__ Array<T, N> operator*(const Array<T, N>& a, const Array<T, N>& b)
-{
-    return binary_op_vv(a, b, multiplies<T>{});
+template <typename T, int N>
+inline __device__ Array<T, N> operator*(const Array<T, N>& a,
+                                        const Array<T, N>& b) {
+  return binary_op_vv(a, b, multiplies<T>{});
 }
 
-template<typename T, int N>
-inline __device__ Array<T, N> operator*(const Array<T, N>& a, const T& b)
-{
-    return binary_op_vs(a, b, multiplies<T>{});
+template <typename T, int N>
+inline __device__ Array<T, N> operator*(const Array<T, N>& a, const T& b) {
+  return binary_op_vs(a, b, multiplies<T>{});
 }
 
-template<typename T, int N>
-inline __device__ Array<T, N> operator+(const Array<T, N>& a, const T& b)
-{
-    return binary_op_vs(a, b, plus<T>{});
+template <typename T, int N>
+inline __device__ Array<T, N> operator+(const Array<T, N>& a, const T& b) {
+  return binary_op_vs(a, b, plus<T>{});
 }
 
-template<typename T, int N>
-inline __device__ Array<T, N> operator-(const Array<T, N>& a, const T& b)
-{
-    return binary_op_vs(a, b, minus<T>{});
+template <typename T, int N>
+inline __device__ Array<T, N> operator-(const Array<T, N>& a, const T& b) {
+  return binary_op_vs(a, b, minus<T>{});
 }
 
 }  // namespace ops
 
-template<typename To, typename From, int N>
-inline __device__ Array<To, N> cast(const Array<From, N>& src)
-{
-    Array<To, N> dst;
-    PRAGMA_UNROLL
-    for (int i = 0; i < N; ++i) {
-        dst[i] = (To)src[i];
-    }
-    return dst;
+template <typename To, typename From, int N>
+inline __device__ Array<To, N> cast(const Array<From, N>& src) {
+  Array<To, N> dst;
+  PRAGMA_UNROLL
+  for (int i = 0; i < N; ++i) {
+    dst[i] = (To)src[i];
+  }
+  return dst;
 }
 
-template<class T, int N>
-inline __device__ void fill(Array<T, N>& x, T val)
-{
-    PRAGMA_UNROLL
-    for (int i = 0; i < N; ++i) {
-        x[i] = val;
-    }
+template <class T, int N>
+inline __device__ void fill(Array<T, N>& x, T val) {
+  PRAGMA_UNROLL
+  for (int i = 0; i < N; ++i) {
+    x[i] = val;
+  }
 }
 
-template<class T, int M, int N>
-inline __device__ void fill(Array<T, N> (&x)[M], T val)
-{
+template <class T, int M, int N>
+inline __device__ void fill(Array<T, N> (&x)[M], T val) {
+  PRAGMA_UNROLL
+  for (int i = 0; i < M; ++i) {
+    fill(x[i], val);
+  }
+}
+
+template <class T, int N>
+inline __device__ void clear(Array<T, N>& x) {
+  fill(x, T(0));
+}
+
+template <class T, int M, int N>
+inline __device__ void clear(Array<T, N> (&x)[M]) {
+  PRAGMA_UNROLL
+  for (int i = 0; i < M; ++i) {
+    clear(x[i]);
+  }
+}
+
+template <class T, int M1, int M0, int N>
+inline __device__ void clear(Array<T, N> (&x)[M1][M0]) {
+  PRAGMA_UNROLL
+  for (int m1 = 0; m1 < M1; ++m1) {
+    PRAGMA_UNROLL
+    for (int m0 = 0; m0 < M0; ++m0) {
+      clear(x[m1][m0]);
+    }
+  }
+}
+
+template <class T, int N>
+inline __device__ void copy(const Array<T, N>& src, Array<T, N>& dst) {
+  dst = src;
+}
+
+template <class T, int M, int N>
+inline __device__ void copy(const Array<T, N> (&src)[M],
+                            Array<T, N> (&dst)[M]) {
+  PRAGMA_UNROLL
+  for (int m = 0; m < M; ++m) {
+    dst[m] = src[m];
+  }
+}
+
+template <typename T, int N>
+inline __device__ void Store(T* dst, const Array<T, N>& src) {
+  if constexpr (sizeof(Array<T, N>) == sizeof(uint4)) {
+    *(uint4*)dst = (const uint4&)src;
+  } else if constexpr (sizeof(Array<T, N>) == sizeof(uint2)) {
+    *(uint2*)dst = (const uint2&)src;
+  } else if constexpr (sizeof(Array<T, N>) == sizeof(uint1)) {
+    *(uint1*)dst = (const uint1&)src;
+  } else if constexpr (sizeof(Array<T, N>) == sizeof(ushort)) {
+    *(ushort*)dst = (const ushort&)src;
+  } else if constexpr (sizeof(Array<T, N>) == sizeof(char)) {
+    *(char*)dst = (const char&)src;
+  } else if constexpr (sizeof(Array<T, N>) % sizeof(uint4) ==
+                       0) {  //  uncoalesced
+    static_assert(bitsof<T> % 8 == 0,
+                  "raw pointer arithmetic of sub-byte types");
+    constexpr int M = sizeof(Array<T, N>) / sizeof(uint4);
     PRAGMA_UNROLL
     for (int i = 0; i < M; ++i) {
-        fill(x[i], val);
+      *((uint4*)dst + i) = *((uint4*)&src + i);
     }
+  } else {
+    static_assert(!std::is_same_v<T, T>);
+  }
 }
 
-template<class T, int N>
-inline __device__ void clear(Array<T, N>& x)
-{
-    fill(x, T(0));
+template <typename T, int N>
+inline __device__ void Stcs(T* __restrict__ dst, const Array<T, N>& src) {
+  static_assert(sizeof(Array<T, N>) <= sizeof(uint4));
+
+  if constexpr (sizeof(Array<T, N>) == sizeof(uint4)) {
+    __stcs((uint4*)dst, (const uint4&)src);
+  } else if constexpr (sizeof(Array<T, N>) == sizeof(uint2)) {
+    __stcs((uint2*)dst, (const uint2&)src);
+  } else if constexpr (sizeof(Array<T, N>) == sizeof(uint1)) {
+    __stcs((uint*)dst, (const uint&)src);
+  } else if constexpr (sizeof(Array<T, N>) == sizeof(uint16_t)) {
+    __stcs((uint16_t*)dst, (const uint16_t&)src);
+  } else if constexpr (sizeof(Array<T, N>) == sizeof(uint8_t)) {
+    __stcs((uint8_t*)dst, (const uint8_t&)src);
+  } else {
+    static_assert(!std::is_same_v<T, T>);
+  }
 }
 
-template<class T, int M, int N>
-inline __device__ void clear(Array<T, N> (&x)[M])
-{
+template <typename T, int N>
+inline __device__ void Stcg(T* __restrict__ dst, const Array<T, N>& src) {
+  static_assert(sizeof(Array<T, N>) <= sizeof(uint4));
+
+  if constexpr (sizeof(Array<T, N>) == sizeof(uint4)) {
+    __stcg((uint4*)dst, (const uint4&)src);
+  } else if constexpr (sizeof(Array<T, N>) == sizeof(uint2)) {
+    __stcg((uint2*)dst, (const uint2&)src);
+  } else if constexpr (sizeof(Array<T, N>) == sizeof(uint1)) {
+    __stcg((uint*)dst, (const uint&)src);
+  } else if constexpr (sizeof(Array<T, N>) == sizeof(uint16_t)) {
+    __stcg((uint16_t*)dst, (const uint16_t&)src);
+  } else if constexpr (sizeof(Array<T, N>) == sizeof(uint8_t)) {
+    __stcg((uint8_t*)dst, (const uint8_t&)src);
+  } else {
+    static_assert(!std::is_same_v<T, T>);
+  }
+}
+
+template <typename T, int N>
+inline __device__ void Ldg(Array<T, N>& dst, const T* src) {
+  static_assert(sizeof(Array<T, N>) <= sizeof(uint4));
+
+  if constexpr (sizeof(Array<T, N>) == sizeof(uint4)) {
+    (uint4&)dst = __ldg((const uint4*)src);
+  } else if constexpr (sizeof(Array<T, N>) == sizeof(uint2)) {
+    (uint2&)dst = __ldg((const uint2*)src);
+  } else if constexpr (sizeof(Array<T, N>) == sizeof(uint)) {
+    (uint&)dst = __ldg((const uint*)src);
+  } else if constexpr (sizeof(Array<T, N>) == sizeof(uint16_t)) {
+    (uint16_t&)dst = __ldg((const uint16_t*)src);
+  } else if constexpr (sizeof(Array<T, N>) == sizeof(uint8_t)) {
+    (uint8_t&)dst = __ldg((const uint8_t*)src);
+  } else {
+    static_assert(!std::is_same_v<T, T>);
+  }
+}
+
+template <typename T, int N>
+inline __device__ void Ldcs(Array<T, N>& dst, const T* src) {
+  static_assert(sizeof(Array<T, N>) <= sizeof(uint4));
+
+  if constexpr (sizeof(Array<T, N>) == sizeof(uint4)) {
+    (uint4&)dst = __ldcs((const uint4*)src);
+  } else if constexpr (sizeof(Array<T, N>) == sizeof(uint2)) {
+    (uint2&)dst = __ldcs((const uint2*)src);
+  } else if constexpr (sizeof(Array<T, N>) == sizeof(uint)) {
+    (uint&)dst = __ldcs((const uint*)src);
+  } else if constexpr (sizeof(Array<T, N>) == sizeof(uint16_t)) {
+    (uint16_t&)dst = __ldcs((const uint16_t*)src);
+  } else if constexpr (sizeof(Array<T, N>) == sizeof(uint8_t)) {
+    (uint8_t&)dst = __ldcs((const uint8_t*)src);
+  } else {
+    static_assert(!std::is_same_v<T, T>);
+  }
+}
+
+template <typename T, int N>
+inline __device__ void Ldcg(Array<T, N>& dst, const T* src) {
+  static_assert(sizeof(Array<T, N>) <= sizeof(uint4));
+
+  if constexpr (sizeof(Array<T, N>) == sizeof(uint4)) {
+    (uint4&)dst = __ldcg((const uint4*)src);
+  } else if constexpr (sizeof(Array<T, N>) == sizeof(uint2)) {
+    (uint2&)dst = __ldcg((const uint2*)src);
+  } else if constexpr (sizeof(Array<T, N>) == sizeof(uint)) {
+    (uint&)dst = __ldcg((const uint*)src);
+  } else if constexpr (sizeof(Array<T, N>) == sizeof(uint16_t)) {
+    (uint16_t&)dst = __ldcg((const uint16_t*)src);
+  } else if constexpr (sizeof(Array<T, N>) == sizeof(uint8_t)) {
+    (uint8_t&)dst = __ldcg((const uint8_t*)src);
+  } else {
+    static_assert(!std::is_same_v<T, T>);
+  }
+}
+
+template <typename T, int N>
+inline __device__ void Load(Array<T, N>& dst, const T* src) {
+  if constexpr (sizeof(Array<T, N>) == sizeof(uint4)) {
+    (uint4&)dst = *(const uint4*)src;
+  } else if constexpr (sizeof(Array<T, N>) == sizeof(uint2)) {
+    (uint2&)dst = *(const uint2*)src;
+  } else if constexpr (sizeof(Array<T, N>) == sizeof(uint)) {
+    (uint1&)dst = *(const uint1*)src;
+  } else if constexpr (sizeof(Array<T, N>) == sizeof(uint16_t)) {
+    (uint16_t&)dst = *(const uint16_t*)src;
+  } else if constexpr (sizeof(Array<T, N>) == sizeof(uint8_t)) {
+    (uint8_t&)dst = *(const uint8_t*)src;
+  } else if constexpr (sizeof(Array<T, N>) % sizeof(uint4) ==
+                       0) {  //  uncoalesced
+    static_assert(bitsof<T> % 8 == 0,
+                  "raw pointer arithmetic of sub-byte types");
+    constexpr int M = sizeof(Array<T, N>) / sizeof(uint4);
     PRAGMA_UNROLL
     for (int i = 0; i < M; ++i) {
-        clear(x[i]);
+      *((uint4*)&dst + i) = *((uint4*)src + i);
     }
+  } else {
+    static_assert(!std::is_same_v<T, T>);
+  }
 }
 
-template<class T, int M1, int M0, int N>
-inline __device__ void clear(Array<T, N> (&x)[M1][M0])
-{
-    PRAGMA_UNROLL
-    for (int m1 = 0; m1 < M1; ++m1) {
-        PRAGMA_UNROLL
-        for (int m0 = 0; m0 < M0; ++m0) {
-            clear(x[m1][m0]);
-        }
-    }
+template <typename T, int N>
+inline __device__ void Lds(Array<T, N>& dst, const T* src) {
+  Load(dst, src);
 }
 
-template<class T, int N>
-inline __device__ void copy(const Array<T, N>& src, Array<T, N>& dst)
-{
-    dst = src;
-}
-
-template<class T, int M, int N>
-inline __device__ void copy(const Array<T, N> (&src)[M], Array<T, N> (&dst)[M])
-{
-    PRAGMA_UNROLL
-    for (int m = 0; m < M; ++m) {
-        dst[m] = src[m];
-    }
-}
-
-template<typename T, int N>
-inline __device__ void Store(T* dst, const Array<T, N>& src)
-{
-    if constexpr (sizeof(Array<T, N>) == sizeof(uint4)) {
-        *(uint4*)dst = (const uint4&)src;
-    }
-    else if constexpr (sizeof(Array<T, N>) == sizeof(uint2)) {
-        *(uint2*)dst = (const uint2&)src;
-    }
-    else if constexpr (sizeof(Array<T, N>) == sizeof(uint1)) {
-        *(uint1*)dst = (const uint1&)src;
-    }
-    else if constexpr (sizeof(Array<T, N>) == sizeof(ushort)) {
-        *(ushort*)dst = (const ushort&)src;
-    }
-    else if constexpr (sizeof(Array<T, N>) == sizeof(char)) {
-        *(char*)dst = (const char&)src;
-    }
-    else if constexpr (sizeof(Array<T, N>) % sizeof(uint4) == 0) {  //  uncoalesced
-        static_assert(bitsof<T> % 8 == 0, "raw pointer arithmetic of sub-byte types");
-        constexpr int M = sizeof(Array<T, N>) / sizeof(uint4);
-        PRAGMA_UNROLL
-        for (int i = 0; i < M; ++i) {
-            *((uint4*)dst + i) = *((uint4*)&src + i);
-        }
-    }
-    else {
-        static_assert(!std::is_same_v<T, T>);
-    }
-}
-
-template<typename T, int N>
-inline __device__ void Stcs(T* __restrict__ dst, const Array<T, N>& src)
-{
-    static_assert(sizeof(Array<T, N>) <= sizeof(uint4));
-
-    if constexpr (sizeof(Array<T, N>) == sizeof(uint4)) {
-        __stcs((uint4*)dst, (const uint4&)src);
-    }
-    else if constexpr (sizeof(Array<T, N>) == sizeof(uint2)) {
-        __stcs((uint2*)dst, (const uint2&)src);
-    }
-    else if constexpr (sizeof(Array<T, N>) == sizeof(uint1)) {
-        __stcs((uint*)dst, (const uint&)src);
-    }
-    else if constexpr (sizeof(Array<T, N>) == sizeof(uint16_t)) {
-        __stcs((uint16_t*)dst, (const uint16_t&)src);
-    }
-    else if constexpr (sizeof(Array<T, N>) == sizeof(uint8_t)) {
-        __stcs((uint8_t*)dst, (const uint8_t&)src);
-    }
-    else {
-        static_assert(!std::is_same_v<T, T>);
-    }
-}
-
-template<typename T, int N>
-inline __device__ void Stcg(T* __restrict__ dst, const Array<T, N>& src)
-{
-    static_assert(sizeof(Array<T, N>) <= sizeof(uint4));
-
-    if constexpr (sizeof(Array<T, N>) == sizeof(uint4)) {
-        __stcg((uint4*)dst, (const uint4&)src);
-    }
-    else if constexpr (sizeof(Array<T, N>) == sizeof(uint2)) {
-        __stcg((uint2*)dst, (const uint2&)src);
-    }
-    else if constexpr (sizeof(Array<T, N>) == sizeof(uint1)) {
-        __stcg((uint*)dst, (const uint&)src);
-    }
-    else if constexpr (sizeof(Array<T, N>) == sizeof(uint16_t)) {
-        __stcg((uint16_t*)dst, (const uint16_t&)src);
-    }
-    else if constexpr (sizeof(Array<T, N>) == sizeof(uint8_t)) {
-        __stcg((uint8_t*)dst, (const uint8_t&)src);
-    }
-    else {
-        static_assert(!std::is_same_v<T, T>);
-    }
-}
-
-template<typename T, int N>
-inline __device__ void Ldg(Array<T, N>& dst, const T* src)
-{
-    static_assert(sizeof(Array<T, N>) <= sizeof(uint4));
-
-    if constexpr (sizeof(Array<T, N>) == sizeof(uint4)) {
-        (uint4&)dst = __ldg((const uint4*)src);
-    }
-    else if constexpr (sizeof(Array<T, N>) == sizeof(uint2)) {
-        (uint2&)dst = __ldg((const uint2*)src);
-    }
-    else if constexpr (sizeof(Array<T, N>) == sizeof(uint)) {
-        (uint&)dst = __ldg((const uint*)src);
-    }
-    else if constexpr (sizeof(Array<T, N>) == sizeof(uint16_t)) {
-        (uint16_t&)dst = __ldg((const uint16_t*)src);
-    }
-    else if constexpr (sizeof(Array<T, N>) == sizeof(uint8_t)) {
-        (uint8_t&)dst = __ldg((const uint8_t*)src);
-    }
-    else {
-        static_assert(!std::is_same_v<T, T>);
-    }
-}
-
-template<typename T, int N>
-inline __device__ void Ldcs(Array<T, N>& dst, const T* src)
-{
-    static_assert(sizeof(Array<T, N>) <= sizeof(uint4));
-
-    if constexpr (sizeof(Array<T, N>) == sizeof(uint4)) {
-        (uint4&)dst = __ldcs((const uint4*)src);
-    }
-    else if constexpr (sizeof(Array<T, N>) == sizeof(uint2)) {
-        (uint2&)dst = __ldcs((const uint2*)src);
-    }
-    else if constexpr (sizeof(Array<T, N>) == sizeof(uint)) {
-        (uint&)dst = __ldcs((const uint*)src);
-    }
-    else if constexpr (sizeof(Array<T, N>) == sizeof(uint16_t)) {
-        (uint16_t&)dst = __ldcs((const uint16_t*)src);
-    }
-    else if constexpr (sizeof(Array<T, N>) == sizeof(uint8_t)) {
-        (uint8_t&)dst = __ldcs((const uint8_t*)src);
-    }
-    else {
-        static_assert(!std::is_same_v<T, T>);
-    }
-}
-
-template<typename T, int N>
-inline __device__ void Ldcg(Array<T, N>& dst, const T* src)
-{
-    static_assert(sizeof(Array<T, N>) <= sizeof(uint4));
-
-    if constexpr (sizeof(Array<T, N>) == sizeof(uint4)) {
-        (uint4&)dst = __ldcg((const uint4*)src);
-    }
-    else if constexpr (sizeof(Array<T, N>) == sizeof(uint2)) {
-        (uint2&)dst = __ldcg((const uint2*)src);
-    }
-    else if constexpr (sizeof(Array<T, N>) == sizeof(uint)) {
-        (uint&)dst = __ldcg((const uint*)src);
-    }
-    else if constexpr (sizeof(Array<T, N>) == sizeof(uint16_t)) {
-        (uint16_t&)dst = __ldcg((const uint16_t*)src);
-    }
-    else if constexpr (sizeof(Array<T, N>) == sizeof(uint8_t)) {
-        (uint8_t&)dst = __ldcg((const uint8_t*)src);
-    }
-    else {
-        static_assert(!std::is_same_v<T, T>);
-    }
-}
-
-template<typename T, int N>
-inline __device__ void Load(Array<T, N>& dst, const T* src)
-{
-    if constexpr (sizeof(Array<T, N>) == sizeof(uint4)) {
-        (uint4&)dst = *(const uint4*)src;
-    }
-    else if constexpr (sizeof(Array<T, N>) == sizeof(uint2)) {
-        (uint2&)dst = *(const uint2*)src;
-    }
-    else if constexpr (sizeof(Array<T, N>) == sizeof(uint)) {
-        (uint1&)dst = *(const uint1*)src;
-    }
-    else if constexpr (sizeof(Array<T, N>) == sizeof(uint16_t)) {
-        (uint16_t&)dst = *(const uint16_t*)src;
-    }
-    else if constexpr (sizeof(Array<T, N>) == sizeof(uint8_t)) {
-        (uint8_t&)dst = *(const uint8_t*)src;
-    }
-    else if constexpr (sizeof(Array<T, N>) % sizeof(uint4) == 0) {  //  uncoalesced
-        static_assert(bitsof<T> % 8 == 0, "raw pointer arithmetic of sub-byte types");
-        constexpr int M = sizeof(Array<T, N>) / sizeof(uint4);
-        PRAGMA_UNROLL
-        for (int i = 0; i < M; ++i) {
-            *((uint4*)&dst + i) = *((uint4*)src + i);
-        }
-    }
-    else {
-        static_assert(!std::is_same_v<T, T>);
-    }
-}
-
-template<typename T, int N>
-inline __device__ void Lds(Array<T, N>& dst, const T* src)
-{
-    Load(dst, src);
-}
-
-template<typename T, int N>
-inline __device__ void LdShared(Array<T, N>& dst, uint32_t uintptr)
-{
-    static_assert(sizeof(Array<T, N>) <= sizeof(uint4));
-    if constexpr (sizeof(Array<T, N>) == sizeof(uint4)) {
-        uint4& p = (uint4&)dst;
-        // clang-format off
+template <typename T, int N>
+inline __device__ void LdShared(Array<T, N>& dst, uint32_t uintptr) {
+  static_assert(sizeof(Array<T, N>) <= sizeof(uint4));
+  if constexpr (sizeof(Array<T, N>) == sizeof(uint4)) {
+    uint4& p = (uint4&)dst;
+    // clang-format off
         asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];\n" : "=r"(p.x), "=r"(p.y), "=r"(p.z), "=r"(p.w) : "r"(uintptr));
-        // clang-format on
-    }
-    else if constexpr (sizeof(Array<T, N>) == sizeof(uint2)) {
-        uint2& p = (uint2&)dst;
-        asm volatile("ld.shared.v2.b32 {%0,%1}, [%2];\n" : "=r"(p.x), "=r"(p.y) : "r"(uintptr));
-    }
-    else if constexpr (sizeof(Array<T, N>) == sizeof(uint)) {
-        uint& p = (uint&)dst;
-        asm volatile("ld.shared.b32 %0, [%1];\n" : "=r"(p) : "r"(uintptr));
-    }
-    else {
-        static_assert(!std::is_same_v<T, T>);
-    }
+    // clang-format on
+  } else if constexpr (sizeof(Array<T, N>) == sizeof(uint2)) {
+    uint2& p = (uint2&)dst;
+    asm volatile("ld.shared.v2.b32 {%0,%1}, [%2];\n"
+                 : "=r"(p.x), "=r"(p.y)
+                 : "r"(uintptr));
+  } else if constexpr (sizeof(Array<T, N>) == sizeof(uint)) {
+    uint& p = (uint&)dst;
+    asm volatile("ld.shared.b32 %0, [%1];\n" : "=r"(p) : "r"(uintptr));
+  } else {
+    static_assert(!std::is_same_v<T, T>);
+  }
 }
 
-template<typename T, int N>
-inline __device__ void StShared(uint32_t uintptr, Array<T, N>& src)
-{
-    static_assert(sizeof(Array<T, N>) <= sizeof(uint4));
-    if constexpr (sizeof(Array<T, N>) == sizeof(uint4)) {
-        uint4& p = (uint4&)src;
-        // clang-format off
+template <typename T, int N>
+inline __device__ void StShared(uint32_t uintptr, Array<T, N>& src) {
+  static_assert(sizeof(Array<T, N>) <= sizeof(uint4));
+  if constexpr (sizeof(Array<T, N>) == sizeof(uint4)) {
+    uint4& p = (uint4&)src;
+    // clang-format off
         asm volatile("st.shared.v4.b32 [%0], {%1,%2,%3,%4};\n" :: "r"(uintptr), "r"(p.x), "r"(p.y), "r"(p.z), "r"(p.w) );
-        // clang-format on
-    }
-    else if constexpr (sizeof(Array<T, N>) == sizeof(uint2)) {
-        uint2& p = (uint2&)src;
-        asm volatile("st.shared.v2.b32 [%0], {%1,%2};\n" ::"r"(uintptr), "r"(p.x), "r"(p.y));
-    }
-    else if constexpr (sizeof(Array<T, N>) == sizeof(uint)) {
-        uint& p = (uint&)src;
-        asm volatile("st.shared.b32  [%0], %1;\n" ::"r"(uintptr), "r"(p));
-    }
-    else {
-        static_assert(!std::is_same_v<T, T>);
-    }
+    // clang-format on
+  } else if constexpr (sizeof(Array<T, N>) == sizeof(uint2)) {
+    uint2& p = (uint2&)src;
+    asm volatile("st.shared.v2.b32 [%0], {%1,%2};\n" ::"r"(uintptr), "r"(p.x),
+                 "r"(p.y));
+  } else if constexpr (sizeof(Array<T, N>) == sizeof(uint)) {
+    uint& p = (uint&)src;
+    asm volatile("st.shared.b32  [%0], %1;\n" ::"r"(uintptr), "r"(p));
+  } else {
+    static_assert(!std::is_same_v<T, T>);
+  }
 }
 
-template<int kWarpCount, typename T, int N>
-inline __device__ Array<T, N> blockSum(Array<T, N> val, T* smem_red, int warp_id, int lane_id)
-{
+template <int kWarpCount, typename T, int N>
+inline __device__ Array<T, N> blockSum(Array<T, N> val, T* smem_red,
+                                       int warp_id, int lane_id) {
+  PRAGMA_UNROLL
+  for (int i = 0; i < N; ++i) {
     PRAGMA_UNROLL
-    for (int i = 0; i < N; ++i) {
-        PRAGMA_UNROLL
-        for (int mask = WARP_SIZE >> 1; mask >= 1; mask >>= 1) {
-            val[i] += __shfl_xor_sync((uint32_t)-1, val[i], mask);
-        }
-        if (lane_id == 0) {
-            smem_red[i * kWarpCount + warp_id] = val[i];
-        }
+    for (int mask = WARP_SIZE >> 1; mask >= 1; mask >>= 1) {
+      val[i] += __shfl_xor_sync((uint32_t)-1, val[i], mask);
     }
+    if (lane_id == 0) {
+      smem_red[i * kWarpCount + warp_id] = val[i];
+    }
+  }
 
-    __syncthreads();
+  __syncthreads();
 
+  PRAGMA_UNROLL
+  for (int i = 0; i < N; ++i) {
+    val[i] = lane_id < kWarpCount ? smem_red[i * kWarpCount + lane_id] : T{};
     PRAGMA_UNROLL
-    for (int i = 0; i < N; ++i) {
-        val[i] = lane_id < kWarpCount ? smem_red[i * kWarpCount + lane_id] : T{};
-        PRAGMA_UNROLL
-        for (int mask = kWarpCount >> 1; mask >= 1; mask >>= 1) {
-            val[i] += __shfl_xor_sync((uint32_t)-1, val[i], mask);
-        }
-        val[i] = __shfl_sync((uint32_t)-1, val[i], 0);
+    for (int mask = kWarpCount >> 1; mask >= 1; mask >>= 1) {
+      val[i] += __shfl_xor_sync((uint32_t)-1, val[i], mask);
     }
+    val[i] = __shfl_sync((uint32_t)-1, val[i], 0);
+  }
 
-    return val;
+  return val;
 }
 
-template<class T, int N>
-__device__ void CpAsync(T* dst, const Array<T, N>* __restrict__ src)
-{
-    const int     smem_int_ptr = cast_smem_ptr_to_uint(dst);
-    constexpr int cp_size      = sizeof(Array<T, N>);
+template <class T, int N>
+__device__ void CpAsync(T* dst, const Array<T, N>* __restrict__ src) {
+  const int smem_int_ptr = cast_smem_ptr_to_uint(dst);
+  constexpr int cp_size = sizeof(Array<T, N>);
 #if TURBOMIND_ARCH_SM80
-    asm volatile("cp.async.ca.shared.global [%0], [%1], %2;\n" ::"r"(smem_int_ptr), "l"(src), "n"(cp_size));
+  asm volatile(
+      "cp.async.ca.shared.global [%0], [%1], %2;\n" ::"r"(smem_int_ptr),
+      "l"(src), "n"(cp_size));
 #else
-    assert(TURBOMIND_ARCH_SM80);
+  assert(TURBOMIND_ARCH_SM80);
 #endif
 }
 
-__inline__ __device__ uint transpose_m8n8_b16_warp_shuffle(uint value)
-{
-    const int lane_id  = threadIdx.x % WARP_SIZE;
-    int       src_lane = lane_id / 8 + lane_id % 4 * 8;
-    uint      u0       = __shfl_sync(0xffffffff, value, src_lane);
-    uint      u1       = __shfl_sync(0xffffffff, value, src_lane + 4);
-    short2    r;
+__inline__ __device__ uint transpose_m8n8_b16_warp_shuffle(uint value) {
+  const int lane_id = threadIdx.x % WARP_SIZE;
+  int src_lane = lane_id / 8 + lane_id % 4 * 8;
+  uint u0 = __shfl_sync(0xffffffff, value, src_lane);
+  uint u1 = __shfl_sync(0xffffffff, value, src_lane + 4);
+  short2 r;
 
-    if (lane_id % 8 < 4) {
-        r.x = ((short2&)u0).x;
-        r.y = ((short2&)u1).x;
-    }
-    else {
-        r.x = ((short2&)u0).y;
-        r.y = ((short2&)u1).y;
-    }
-    return (uint&)r;
+  if (lane_id % 8 < 4) {
+    r.x = ((short2&)u0).x;
+    r.y = ((short2&)u1).x;
+  } else {
+    r.x = ((short2&)u0).y;
+    r.y = ((short2&)u1).y;
+  }
+  return (uint&)r;
 }
 
 #if (__CUDACC_VER_MAJOR__ >= 11) && (__CUDACC_VER_MINOR__ >= 8)
-__inline__ __device__ uint transpose_m8n8_b16_movmatrix(uint a)
-{
-#if TURBOMIND_ARCH_SM75
-    uint d;
-    asm volatile("movmatrix.sync.aligned.m8n8.trans.b16 %0, %1;\n" : "=r"(d) : "r"(a));
-    return d;
-#else
-    assert(TURBOMIND_ARCH_SM75);
-    return 0;
-#endif
+__inline__ __device__ uint transpose_m8n8_b16_movmatrix(uint a) {
+  #if TURBOMIND_ARCH_SM75
+  uint d;
+  asm volatile("movmatrix.sync.aligned.m8n8.trans.b16 %0, %1;\n"
+               : "=r"(d)
+               : "r"(a));
+  return d;
+  #else
+  assert(TURBOMIND_ARCH_SM75);
+  return 0;
+  #endif
 }
 #endif
 
-__inline__ __device__ uint32_t transpose_m8n8_b16(uint32_t a)
-{
+__inline__ __device__ uint32_t transpose_m8n8_b16(uint32_t a) {
 #if (__CUDACC_VER_MAJOR__ >= 11) && (__CUDACC_VER_MINOR__ >= 8)
-    return transpose_m8n8_b16_movmatrix(a);
+  return transpose_m8n8_b16_movmatrix(a);
 #else
-    return transpose_m8n8_b16_warp_shuffle(a);
+  return transpose_m8n8_b16_warp_shuffle(a);
 #endif
 }
 
-__inline__ __device__ Array<uint32_t, 2> transpose_m8n8_b32(const Array<uint32_t, 2>& x)
-{
-    uint32_t lo = __byte_perm(x[0], x[1], 0x5410);
-    uint32_t hi = __byte_perm(x[0], x[1], 0x7632);
+__inline__ __device__ Array<uint32_t, 2> transpose_m8n8_b32(
+    const Array<uint32_t, 2>& x) {
+  uint32_t lo = __byte_perm(x[0], x[1], 0x5410);
+  uint32_t hi = __byte_perm(x[0], x[1], 0x7632);
 
-    lo = transpose_m8n8_b16(lo);
-    hi = transpose_m8n8_b16(hi);
+  lo = transpose_m8n8_b16(lo);
+  hi = transpose_m8n8_b16(hi);
 
-    Array<uint32_t, 2> y;
-    y[0] = __byte_perm(lo, hi, 0x5410);
-    y[1] = __byte_perm(lo, hi, 0x7632);
+  Array<uint32_t, 2> y;
+  y[0] = __byte_perm(lo, hi, 0x5410);
+  y[1] = __byte_perm(lo, hi, 0x7632);
 
-    return y;
+  return y;
 }
 
 }  // namespace turbomind

--- a/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/core/common.h
+++ b/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/core/common.h
@@ -3,66 +3,69 @@
 #pragma once
 
 #if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 700))
-#define TURBOMIND_ARCH_SM70 1
+  #define TURBOMIND_ARCH_SM70 1
 #else
-#define TURBOMIND_ARCH_SM70 0
+  #define TURBOMIND_ARCH_SM70 0
 #endif
 
 #if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 750))
-#define TURBOMIND_ARCH_SM75 1
+  #define TURBOMIND_ARCH_SM75 1
 #else
-#define TURBOMIND_ARCH_SM75 0
+  #define TURBOMIND_ARCH_SM75 0
 #endif
 
 #if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 800))
-#define TURBOMIND_ARCH_SM80 1
+  #define TURBOMIND_ARCH_SM80 1
 #else
-#define TURBOMIND_ARCH_SM80 0
+  #define TURBOMIND_ARCH_SM80 0
 #endif
 
 #if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
-#define TURBOMIND_ARCH_SM90 1
+  #define TURBOMIND_ARCH_SM90 1
 #else
-#define TURBOMIND_ARCH_SM90 0
+  #define TURBOMIND_ARCH_SM90 0
 #endif
 
 #define TURBOMIND_ARCH_HAS_BF16 TURBOMIND_ARCH_SM80
 
 #define TURBOMIND_ARCH_HAS_FP8 TURBOMIND_ARCH_SM90
 
-#define TURBOMIND_ARCH_BF16_GUARD(type) (TURBOMIND_ARCH_HAS_BF16 || type != ::turbomind::kBfloat16)
+#define TURBOMIND_ARCH_BF16_GUARD(type) \
+  (TURBOMIND_ARCH_HAS_BF16 || type != ::turbomind::kBfloat16)
 
-#define TURBOMIND_ARCH_FP8_GUARD(type)                                                                                 \
-    (TURBOMIND_ARCH_HAS_FP8 || (type != ::turbomind::kFloat8_e4m3 && type != ::turbomind::kFloat8_e5m2))
+#define TURBOMIND_ARCH_FP8_GUARD(type) \
+  (TURBOMIND_ARCH_HAS_FP8 ||           \
+   (type != ::turbomind::kFloat8_e4m3 && type != ::turbomind::kFloat8_e5m2))
 
-#define TURBOMIND_ARCH_DTYPE_GUARD(type) (TURBOMIND_ARCH_BF16_GUARD(type) && TURBOMIND_ARCH_FP8_GUARD(type))
+#define TURBOMIND_ARCH_DTYPE_GUARD(type) \
+  (TURBOMIND_ARCH_BF16_GUARD(type) && TURBOMIND_ARCH_FP8_GUARD(type))
 
 #if defined(__CUDA_ARCH__) && !defined(__INTELLISENSE__)
-#if defined(__CUDACC_RTC__) || (defined(__clang__) && defined(__CUDA__))
-#define PRAGMA_UNROLL _Pragma("unroll")
-#define PRAGMA_UNROLL_4 _Pragma("unroll 4")
-#define PRAGMA_NO_UNROLL _Pragma("unroll 1")
+  #if defined(__CUDACC_RTC__) || (defined(__clang__) && defined(__CUDA__))
+    #define PRAGMA_UNROLL _Pragma("unroll")
+    #define PRAGMA_UNROLL_4 _Pragma("unroll 4")
+    #define PRAGMA_NO_UNROLL _Pragma("unroll 1")
 
-#else
-#define PRAGMA_UNROLL #pragma unroll
-#define PRAGMA_UNROLL_4 #pragma unroll 4
-#define PRAGMA_NO_UNROLL #pragma unroll 1
+  #else
+    #define PRAGMA_UNROLL #pragma unroll
+    #define PRAGMA_UNROLL_4 #pragma unroll 4
+    #define PRAGMA_NO_UNROLL #pragma unroll 1
 
-#endif
+  #endif
 #else
-#define PRAGMA_UNROLL
-#define PRAGMA_UNROLL_4
-#define PRAGMA_NO_UNROLL
+  #define PRAGMA_UNROLL
+  #define PRAGMA_UNROLL_4
+  #define PRAGMA_NO_UNROLL
 #endif
 
 #if defined(__CUDACC__)
-#define TM_HOST_DEVICE __forceinline__ __host__ __device__
-#define TM_DEVICE __forceinline__ __device__
-#define TM_HOST __forceinline__ __host__
+  #define TM_HOST_DEVICE __forceinline__ __host__ __device__
+  #define TM_DEVICE __forceinline__ __device__
+  #define TM_HOST __forceinline__ __host__
 #else
-#define TM_HOST_DEVICE inline
-#define TM_DEVICE inline
-#define TM_HOST inline
+  #define TM_HOST_DEVICE inline
+  #define TM_DEVICE inline
+  #define TM_HOST inline
 #endif
 
 constexpr int WARP_SIZE = 32;

--- a/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/core/data_type.h
+++ b/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/core/data_type.h
@@ -4,7 +4,7 @@
 
 #include <cuda_fp16.h>
 #if ENABLE_BF16
-#include <cuda_bf16.h>
+  #include <cuda_bf16.h>
 #endif
 
 #include <cstdint>
@@ -16,17 +16,17 @@ namespace turbomind {
 namespace detail {
 
 struct __uint4_t {
-    uint32_t x;
+  uint32_t x;
 };
 
 }  // namespace detail
 
-template<class T, class SFINAE = void>
+template <class T, class SFINAE = void>
 struct get_pointer_type_t {
-    using type = T*;
+  using type = T*;
 };
 
-template<class T>
+template <class T>
 using get_pointer_type = typename get_pointer_type_t<T>::type;
 
 }  // namespace turbomind

--- a/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/core/floating_point.h
+++ b/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/core/floating_point.h
@@ -6,114 +6,111 @@
 
 namespace turbomind {
 
-template<int E, int M>
+template <int E, int M>
 struct FloatingPoint {
-    static constexpr unsigned exponent_bits = E;
-    static constexpr unsigned mantissa_bits = M;
-    static constexpr unsigned exponent_bias = ((1 << exponent_bits) - 1) / 2;
+  static constexpr unsigned exponent_bits = E;
+  static constexpr unsigned mantissa_bits = M;
+  static constexpr unsigned exponent_bias = ((1 << exponent_bits) - 1) / 2;
 
-    static constexpr unsigned bits = 1 + exponent_bits + mantissa_bits;
+  static constexpr unsigned bits = 1 + exponent_bits + mantissa_bits;
 
-    static constexpr unsigned exponent_mask = (1 << exponent_bits) - 1;
-    static constexpr unsigned mantissa_mask = (1 << mantissa_bits) - 1;
+  static constexpr unsigned exponent_mask = (1 << exponent_bits) - 1;
+  static constexpr unsigned mantissa_mask = (1 << mantissa_bits) - 1;
 
-    // clang-format off
+  // clang-format off
     // For `reinterpret_cast` is not constexpr yet
     static constexpr float exp2(unsigned e) { float x = 1; for (; e > 0; --e) { x *= 2; } return x; }
-    // clang-format on
+  // clang-format on
 
-    static constexpr float max_normal =
-        ((1U << (mantissa_bits + 1U)) - 1U) * exp2(exponent_bias + 1) / exp2(mantissa_bits);
-    static constexpr float min_normal   = 1 / exp2(exponent_bias - 1);
-    static constexpr float max_denormal = mantissa_mask / exp2(exponent_bias - 1 + mantissa_bits);
-    static constexpr float min_denormal = 1 / exp2(exponent_bias - 1 + mantissa_bits);
+  static constexpr float max_normal = ((1U << (mantissa_bits + 1U)) - 1U) *
+                                      exp2(exponent_bias + 1) /
+                                      exp2(mantissa_bits);
+  static constexpr float min_normal = 1 / exp2(exponent_bias - 1);
+  static constexpr float max_denormal =
+      mantissa_mask / exp2(exponent_bias - 1 + mantissa_bits);
+  static constexpr float min_denormal =
+      1 / exp2(exponent_bias - 1 + mantissa_bits);
 
-    // Modified from `__nv_cvt_double_to_fp8` in <cuda_fp8.hpp>
-    template<class R>
-    __device__ static unsigned from_f32(float x, R rbits)
-    {
-        constexpr bool stochastic = std::is_same_v<R, unsigned>;
+  // Modified from `__nv_cvt_double_to_fp8` in <cuda_fp8.hpp>
+  template <class R>
+  __device__ static unsigned from_f32(float x, R rbits) {
+    constexpr bool stochastic = std::is_same_v<R, unsigned>;
 
-        // 1/2 LSB of the target format, positioned in single precision mantissa
-        constexpr int half_ulp = 1U << (23U - mantissa_bits - 1U);
+    // 1/2 LSB of the target format, positioned in single precision mantissa
+    constexpr int half_ulp = 1U << (23U - mantissa_bits - 1U);
 
-        auto absx = fabsf(x);
+    auto absx = fabsf(x);
 
-        unsigned xbits = __float_as_uint(x);
+    unsigned xbits = __float_as_uint(x);
 
-        unsigned sign     = (xbits >> 31U) << (bits - 1);
-        unsigned exp      = ((xbits >> 23U) & 0xFFU) - 127U + exponent_bias;
-        unsigned mantissa = (xbits >> (23U - mantissa_bits)) & mantissa_mask;
+    unsigned sign = (xbits >> 31U) << (bits - 1);
+    unsigned exp = ((xbits >> 23U) & 0xFFU) - 127U + exponent_bias;
+    unsigned mantissa = (xbits >> (23U - mantissa_bits)) & mantissa_mask;
 
-        unsigned res;
+    unsigned res;
 
-        if (absx <= min_denormal / 2.) {  // underflow
-            res = 0;
+    if (absx <= min_denormal / 2.) {  // underflow
+      res = 0;
+    } else if (absx > max_normal) {  // overflow
+      res = (exponent_mask << mantissa_bits) | mantissa_mask;
+    } else if (absx >= min_normal) {  // normal
+      res = (exp << mantissa_bits) | mantissa;
+
+      unsigned round_mask = (half_ulp << 1U) - 1U;
+      // rounded-off bits
+      unsigned round = xbits & round_mask;
+      if constexpr (stochastic) {
+        // stochastic rounding (.rs) adjustment
+        if (round + (rbits & round_mask) > round_mask) {
+          res += 1U;
         }
-        else if (absx > max_normal) {  // overflow
-            res = (exponent_mask << mantissa_bits) | mantissa_mask;
+      } else {
+        // round-to-nearest-even (.rn) adjustment
+        if ((round > half_ulp) || ((round == half_ulp) && (mantissa & 1U))) {
+          res += 1U;
         }
-        else if (absx >= min_normal) {  // normal
-            res = (exp << mantissa_bits) | mantissa;
+      }
+    } else {  // denormal
+      unsigned shift = 1U - exp;
+      // add implicit leading bit
+      mantissa |= 1U << mantissa_bits;
+      // additional round-off due to denormalization
+      res = mantissa >> shift;
 
-            unsigned round_mask = (half_ulp << 1U) - 1U;
-            // rounded-off bits
-            unsigned round = xbits & round_mask;
-            if constexpr (stochastic) {
-                // stochastic rounding (.rs) adjustment
-                if (round + (rbits & round_mask) > round_mask) {
-                    res += 1U;
-                }
-            }
-            else {
-                // round-to-nearest-even (.rn) adjustment
-                if ((round > half_ulp) || ((round == half_ulp) && (mantissa & 1U))) {
-                    res += 1U;
-                }
-            }
+      unsigned round_mask = (half_ulp << (shift + 1U)) - 1U;
+      // rounded-off bits, including implicit leading bit
+      unsigned round = (xbits | (1U << 23U)) & round_mask;
+      if constexpr (stochastic) {
+        // stochastic rounding (.rs) adjustment
+        if (round + (rbits & round_mask) > round_mask) {
+          res += 1U;
         }
-        else {  // denormal
-            unsigned shift = 1U - exp;
-            // add implicit leading bit
-            mantissa |= 1U << mantissa_bits;
-            // additional round-off due to denormalization
-            res = mantissa >> shift;
-
-            unsigned round_mask = (half_ulp << (shift + 1U)) - 1U;
-            // rounded-off bits, including implicit leading bit
-            unsigned round = (xbits | (1U << 23U)) & round_mask;
-            if constexpr (stochastic) {
-                // stochastic rounding (.rs) adjustment
-                if (round + (rbits & round_mask) > round_mask) {
-                    res += 1U;
-                }
-            }
-            else {
-                // round-to-nearest-even (.rn) adjustment
-                if ((round > (half_ulp << shift)) || ((round == (half_ulp << shift)) && (res & 1U))) {
-                    res += 1U;
-                }
-            }
+      } else {
+        // round-to-nearest-even (.rn) adjustment
+        if ((round > (half_ulp << shift)) ||
+            ((round == (half_ulp << shift)) && (res & 1U))) {
+          res += 1U;
         }
-
-        res |= sign;  // preserve sign
-
-        return res;
+      }
     }
 
-    __device__ static float to_f32(unsigned x)
-    {
-        unsigned u = (x >> (bits - 1U)) << 31U;
-        u |= (x & ((1U << (bits - 1U)) - 1U)) << (23U - mantissa_bits);
+    res |= sign;  // preserve sign
 
-        unsigned e = (127U - exponent_bias + 127U) << 23U;
+    return res;
+  }
 
-        float res;
-        /// ! force non-FTZ multiplication
-        asm("mul.f32 %0, %1, %2;" : "=f"(res) : "r"(u), "r"(e));
+  __device__ static float to_f32(unsigned x) {
+    unsigned u = (x >> (bits - 1U)) << 31U;
+    u |= (x & ((1U << (bits - 1U)) - 1U)) << (23U - mantissa_bits);
 
-        return res;
-    }
+    unsigned e = (127U - exponent_bias + 127U) << 23U;
+
+    float res;
+    /// ! force non-FTZ multiplication
+    asm("mul.f32 %0, %1, %2;" : "=f"(res) : "r"(u), "r"(e));
+
+    return res;
+  }
 };
 
 static_assert(FloatingPoint<2, 1>::max_normal == 6);

--- a/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/core/layout.h
+++ b/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/core/layout.h
@@ -5,144 +5,121 @@
 #include "src/turbomind/kernels/core/data_type.h"
 namespace turbomind {
 
-template<int Bits, int Base, int Shift>
+template <int Bits, int Base, int Shift>
 struct Swizzle {
+  using bit_mask = std::integral_constant<int, (1 << Bits) - 1>;
+  using yyy_mask = std::integral_constant<int, bit_mask{} << (Base + Shift)>;
+  using shift = std::integral_constant<int, Shift>;
 
-    using bit_mask = std::integral_constant<int, (1 << Bits) - 1>;
-    using yyy_mask = std::integral_constant<int, bit_mask{} << (Base + Shift)>;
-    using shift    = std::integral_constant<int, Shift>;
+  template <class Offset>
+  __host__ __device__ constexpr static auto apply(Offset offset) {
+    return offset ^ ((offset & yyy_mask{}) >> shift{});
+  }
 
-    template<class Offset>
-    __host__ __device__ constexpr static auto apply(Offset offset)
-    {
-        return offset ^ ((offset & yyy_mask{}) >> shift{});
-    }
-
-    template<class Offset>
-    __host__ __device__ constexpr auto operator()(Offset offset)
-    {
-        return apply(offset);
-    }
+  template <class Offset>
+  __host__ __device__ constexpr auto operator()(Offset offset) {
+    return apply(offset);
+  }
 };
 
 struct Identity {
+  template <class Offset>
+  __device__ constexpr static auto apply(Offset offset) {
+    return offset;
+  }
 
-    template<class Offset>
-    __device__ constexpr static auto apply(Offset offset)
-    {
-        return offset;
-    }
+  template <class Offset>
+  __device__ Offset operator()(Offset offset) {
+    return apply(offset);
+  }
 
-    template<class Offset>
-    __device__ Offset operator()(Offset offset)
-    {
-        return apply(offset);
-    }
-
-    template<int D>
-    __device__ int AdvanceS(int offset, int s0, int s1)
-    {
-        return offset;
-    }
+  template <int D>
+  __device__ int AdvanceS(int offset, int s0, int s1) {
+    return offset;
+  }
 };
 
-template<int S_, int C_, int S0_ = -1, int C0_ = -1, class Swizzle_ = Identity>
+template <int S_, int C_, int S0_ = -1, int C0_ = -1, class Swizzle_ = Identity>
 struct SmemLayoutV2 {
+  // (C0,S0),(   C1,       S1)
+  // ( 1,C0),(C0*S0, C0*S0*C1)
 
-    // (C0,S0),(   C1,       S1)
-    // ( 1,C0),(C0*S0, C0*S0*C1)
+  static constexpr int S = S_;
+  static constexpr int C = C_;
 
-    static constexpr int S = S_;
-    static constexpr int C = C_;
+  static constexpr int S0 = S0_ < 0 ? S : S0_;
+  static constexpr int C0 = C0_ < 0 ? C : C0_;
 
-    static constexpr int S0 = S0_ < 0 ? S : S0_;
-    static constexpr int C0 = C0_ < 0 ? C : C0_;
+  static_assert(S % S0 == 0);
+  static_assert(C % C0 == 0);
 
-    static_assert(S % S0 == 0);
-    static_assert(C % C0 == 0);
+  static constexpr int S1 = S / S0;
+  static constexpr int C1 = C / C0;
 
-    static constexpr int S1 = S / S0;
-    static constexpr int C1 = C / C0;
+  static constexpr int kSize = S * C;
 
-    static constexpr int kSize = S * C;
+  static constexpr int kSize0 = S0 * C0;
+  static constexpr int kSize1 = S1 * C1;
 
-    static constexpr int kSize0 = S0 * C0;
-    static constexpr int kSize1 = S1 * C1;
+  using Swizzle = Swizzle_;
 
-    using Swizzle = Swizzle_;
+  static constexpr int kIsTrivial =
+      S == S0 && C == C0 && std::is_same_v<Swizzle, Identity>;
 
-    static constexpr int kIsTrivial = S == S0 && C == C0 && std::is_same_v<Swizzle, Identity>;
+  __forceinline__ __device__ static int apply(int s, int c, int offset = 0) {
+    int s1 = s / S0;
+    int s0 = s % S0;
+    int c1 = c / C0;
+    int c0 = c % C0;
+    //            variable             | uniform |         constant
+    // return Swizzle::apply(s0 * C0 + c0) + offset + (s1 * C1 + c1) * kSize0;
 
-    __forceinline__ __device__ static int apply(int s, int c, int offset = 0)
-    {
-        int s1 = s / S0;
-        int s0 = s % S0;
-        int c1 = c / C0;
-        int c0 = c % C0;
-        //            variable             | uniform |         constant
-        // return Swizzle::apply(s0 * C0 + c0) + offset + (s1 * C1 + c1) * kSize0;
+    // return offset + Swizzle::apply(s0 * C0 + c0) + (s1 * C1 + c1) * kSize0;
 
-        // return offset + Swizzle::apply(s0 * C0 + c0) + (s1 * C1 + c1) * kSize0;
+    return Swizzle::apply(s0 * C0 + c0) + (s1 * C1 + c1) * kSize0 + offset;
+  }
 
-        return Swizzle::apply(s0 * C0 + c0) + (s1 * C1 + c1) * kSize0 + offset;
-    }
-
-    __forceinline__ __device__ int operator()(int s, int c, int offset = 0)
-    {
-        return apply(s, c, offset);
-    }
+  __forceinline__ __device__ int operator()(int s, int c, int offset = 0) {
+    return apply(s, c, offset);
+  }
 };
 
 struct Offset {
-    __device__ explicit Offset(int value): value_{value} {};
-    __device__ int& operator()()
-    {
-        return value_;
-    }
-    __device__ const int& operator()() const
-    {
-        return value_;
-    }
-    int value_;
+  __device__ explicit Offset(int value) : value_{value} {};
+  __device__ int& operator()() { return value_; }
+  __device__ const int& operator()() const { return value_; }
+  int value_;
 };
 
-template<class T, class Layout>
+template <class T, class Layout>
 struct SmemAccessor {
-    using Pointer = get_pointer_type<T>;
-    Pointer ptr_;
-    Layout  layout_;
+  using Pointer = get_pointer_type<T>;
+  Pointer ptr_;
+  Layout layout_;
 
-    __device__ SmemAccessor(Pointer ptr): ptr_{ptr} {}
+  __device__ SmemAccessor(Pointer ptr) : ptr_{ptr} {}
 
-    __device__ T& operator()(int s, int c)
-    {
-        return ptr_[layout_(s, c)];
-    }
+  __device__ T& operator()(int s, int c) { return ptr_[layout_(s, c)]; }
 
-    __device__ T& operator()(int s, int c, int offset)
-    {
-        return ptr_[layout_(s, c, offset)];
-    }
+  __device__ T& operator()(int s, int c, int offset) {
+    return ptr_[layout_(s, c, offset)];
+  }
 
-    __device__ T& operator()(int idx)
-    {
-        return ptr_[idx];
-    }
+  __device__ T& operator()(int idx) { return ptr_[idx]; }
 };
 
-template<class T0, class T1>
+template <class T0, class T1>
 struct Stride {
-    T0 v0;
-    T1 v1;
+  T0 v0;
+  T1 v1;
 
-    // CTAD
-    __host__ __device__ Stride(T0 v0, T1 v1): v0{v0}, v1{v1} {}
+  // CTAD
+  __host__ __device__ Stride(T0 v0, T1 v1) : v0{v0}, v1{v1} {}
 
-    template<class I0, class I1>
-    __host__ __device__ constexpr auto operator()(I0 i0, I1 i1) const
-    {
-        return v0 * i0 + v1 * i1;
-    }
+  template <class I0, class I1>
+  __host__ __device__ constexpr auto operator()(I0 i0, I1 i1) const {
+    return v0 * i0 + v1 * i1;
+  }
 };
 
 }  // namespace turbomind

--- a/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/core/math.h
+++ b/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/core/math.h
@@ -9,75 +9,65 @@
 
 namespace turbomind {
 
-template<class T>
-TM_HOST_DEVICE constexpr T ceil_div(T a, T b)
-{
-    return (a + b - 1) / b;
+template <class T>
+TM_HOST_DEVICE constexpr T ceil_div(T a, T b) {
+  return (a + b - 1) / b;
 }
 
-template<class T>
-TM_HOST_DEVICE constexpr T cdiv(T a, T b)
-{
-    return (a + b - 1) / b;
+template <class T>
+TM_HOST_DEVICE constexpr T cdiv(T a, T b) {
+  return (a + b - 1) / b;
 }
 
-template<class T>
-TM_HOST_DEVICE constexpr T round_up(T a, T b)
-{
-    return (a + b - 1) / b * b;
+template <class T>
+TM_HOST_DEVICE constexpr T round_up(T a, T b) {
+  return (a + b - 1) / b * b;
 }
 
-template<class T>
-TM_HOST_DEVICE constexpr T log2(T x)
-{
-    T n = 0;
-    while (x != 1) {
-        x /= 2;
-        ++n;
-    }
-    return n;
+template <class T>
+TM_HOST_DEVICE constexpr T log2(T x) {
+  T n = 0;
+  while (x != 1) {
+    x /= 2;
+    ++n;
+  }
+  return n;
 }
 
 // static_assert(log2(65536) == 16);
 // static_assert(log2(32) == 5);
 // static_assert(log2(1) == 0);
 
-template<class T>
-TM_HOST_DEVICE constexpr T lowbit(T x)
-{
-    const std::make_signed_t<T> s = x;
-    return static_cast<T>(s & -s);
+template <class T>
+TM_HOST_DEVICE constexpr T lowbit(T x) {
+  const std::make_signed_t<T> s = x;
+  return static_cast<T>(s & -s);
 }
 
 // https://arxiv.org/abs/1902.01961
-template<class T>
-struct FastDivMod {
-};
+template <class T>
+struct FastDivMod {};
 
-template<>
+template <>
 struct FastDivMod<uint16_t> {
-    uint32_t c_;  // cdiv(2^32,d) = (2^32+d-1)/d = (2^32-1)/d+1
-    uint32_t d_;
+  uint32_t c_;  // cdiv(2^32,d) = (2^32+d-1)/d = (2^32-1)/d+1
+  uint32_t d_;
 
-    TM_HOST_DEVICE constexpr FastDivMod(uint16_t d): c_{0xFFFFFFFF / d + 1}, d_{d} {}
+  TM_HOST_DEVICE constexpr FastDivMod(uint16_t d)
+      : c_{0xFFFFFFFF / d + 1}, d_{d} {}
 
-    template<class T>
-    TM_HOST_DEVICE friend constexpr uint16_t operator/(T a, FastDivMod b)
-    {
-        return (a * (uint64_t)b.c_) >> 32;
-    }
+  template <class T>
+  TM_HOST_DEVICE friend constexpr uint16_t operator/(T a, FastDivMod b) {
+    return (a * (uint64_t)b.c_) >> 32;
+  }
 
-    template<class T>
-    TM_HOST_DEVICE friend constexpr uint16_t operator%(T a, FastDivMod b)
-    {
-        uint64_t lowbits = (a * (uint64_t)b.c_) & 0xFFFFFFFF;
-        return (lowbits * b.d_) >> 32;
-    }
+  template <class T>
+  TM_HOST_DEVICE friend constexpr uint16_t operator%(T a, FastDivMod b) {
+    uint64_t lowbits = (a * (uint64_t)b.c_) & 0xFFFFFFFF;
+    return (lowbits * b.d_) >> 32;
+  }
 
-    TM_HOST_DEVICE constexpr operator uint16_t() const noexcept
-    {
-        return d_;
-    }
+  TM_HOST_DEVICE constexpr operator uint16_t() const noexcept { return d_; }
 };
 
 static_assert(32 / FastDivMod<uint16_t>{5} == 6);

--- a/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/core/meta.h
+++ b/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/core/meta.h
@@ -4,49 +4,39 @@
 
 namespace turbomind {
 
-template<class T>
+template <class T>
 struct basic_type {
-    using type = T;
+  using type = T;
 };
 
-template<class T>
+template <class T>
 constexpr basic_type<T> type_c{};
 
-template<auto v>
+template <auto v>
 struct constant {
-    using type       = constant;
-    using value_type = decltype(v);
+  using type = constant;
+  using value_type = decltype(v);
 
-    static constexpr value_type value = v;
+  static constexpr value_type value = v;
 
-    constexpr value_type operator()() const noexcept
-    {
-        return v;
-    }
-    constexpr operator value_type() const noexcept
-    {
-        return v;
-    }
+  constexpr value_type operator()() const noexcept { return v; }
+  constexpr operator value_type() const noexcept { return v; }
 };
 
-template<auto u, auto v>
-struct pair {
-};
+template <auto u, auto v>
+struct pair {};
 
-template<auto u, auto v>
-constexpr auto first(pair<u, v>)
-{
-    return u;
+template <auto u, auto v>
+constexpr auto first(pair<u, v>) {
+  return u;
 }
 
-template<auto u, auto v>
-constexpr auto second(pair<u, v>)
-{
-    return v;
+template <auto u, auto v>
+constexpr auto second(pair<u, v>) {
+  return v;
 }
 
-template<auto u, auto v, auto w>
-struct triplet {
-};
+template <auto u, auto v, auto w>
+struct triplet {};
 
 }  // namespace turbomind

--- a/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/core/mma.h
+++ b/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/core/mma.h
@@ -9,13 +9,14 @@
 
 namespace turbomind {
 
-__inline__ __device__ void
-mma_m8n8k4_row_col(Array<float, 8>& d, const Array<half, 4>& a, const Array<half, 4>& b, Array<float, 8>& c)
-{
+__inline__ __device__ void mma_m8n8k4_row_col(Array<float, 8>& d,
+                                              const Array<half, 4>& a,
+                                              const Array<half, 4>& b,
+                                              Array<float, 8>& c) {
 #if TURBOMIND_ARCH_SM70
-    uint32_t const* A = reinterpret_cast<uint32_t const*>(&a);
-    uint32_t const* B = reinterpret_cast<uint32_t const*>(&b);
-    // clang-format off
+  uint32_t const* A = reinterpret_cast<uint32_t const*>(&a);
+  uint32_t const* B = reinterpret_cast<uint32_t const*>(&b);
+  // clang-format off
     asm volatile(
         "mma.sync.aligned.m8n8k4.row.col.f32.f16.f16.f32"
         "{%0,  %1,  %2,  %3,  %4,  %5,  %6,  %7},"
@@ -30,13 +31,14 @@ mma_m8n8k4_row_col(Array<float, 8>& d, const Array<half, 4>& a, const Array<half
 #endif
 }
 
-__inline__ __device__ void
-mma_m8n8k4_row_row(Array<float, 8>& d, const Array<half, 4>& a, const Array<half, 4>& b, Array<float, 8>& c)
-{
+__inline__ __device__ void mma_m8n8k4_row_row(Array<float, 8>& d,
+                                              const Array<half, 4>& a,
+                                              const Array<half, 4>& b,
+                                              Array<float, 8>& c) {
 #if TURBOMIND_ARCH_SM70
-    uint32_t const* A = reinterpret_cast<uint32_t const*>(&a);
-    uint32_t const* B = reinterpret_cast<uint32_t const*>(&b);
-    // clang-format off
+  uint32_t const* A = reinterpret_cast<uint32_t const*>(&a);
+  uint32_t const* B = reinterpret_cast<uint32_t const*>(&b);
+  // clang-format off
     asm volatile(
         "mma.sync.aligned.m8n8k4.row.row.f32.f16.f16.f32"
         "{%0,  %1,  %2,  %3,  %4,  %5,  %6,  %7},"
@@ -51,161 +53,173 @@ mma_m8n8k4_row_row(Array<float, 8>& d, const Array<half, 4>& a, const Array<half
 #endif
 }
 
-__inline__ __device__ void
-mma_m16n8k8_row_col(Array<float, 4>& d, const Array<half, 4>& a, const Array<half, 2>& b, Array<float, 4>& c)
-{
+__inline__ __device__ void mma_m16n8k8_row_col(Array<float, 4>& d,
+                                               const Array<half, 4>& a,
+                                               const Array<half, 2>& b,
+                                               Array<float, 4>& c) {
 #if TURBOMIND_ARCH_SM75
-    uint32_t const* A = reinterpret_cast<uint32_t const*>(&a);
-    uint32_t const* B = reinterpret_cast<uint32_t const*>(&b);
-    float const*    C = reinterpret_cast<float const*>(&c);
-    float*          D = reinterpret_cast<float*>(&d);
-    asm volatile("mma.sync.aligned.m16n8k8.row.col.f32.f16.f16.f32  {%0,%1,%2,%3}, "
-                 "{%4,%5}, {%6}, {%7,%8,%9,%10};\n"
-                 : "=f"(D[0]), "=f"(D[1]), "=f"(D[2]), "=f"(D[3])
-                 : "r"(A[0]), "r"(A[1]), "r"(B[0]), "f"(C[0]), "f"(C[1]), "f"(C[2]), "f"(C[3]));
+  uint32_t const* A = reinterpret_cast<uint32_t const*>(&a);
+  uint32_t const* B = reinterpret_cast<uint32_t const*>(&b);
+  float const* C = reinterpret_cast<float const*>(&c);
+  float* D = reinterpret_cast<float*>(&d);
+  asm volatile(
+      "mma.sync.aligned.m16n8k8.row.col.f32.f16.f16.f32  {%0,%1,%2,%3}, "
+      "{%4,%5}, {%6}, {%7,%8,%9,%10};\n"
+      : "=f"(D[0]), "=f"(D[1]), "=f"(D[2]), "=f"(D[3])
+      : "r"(A[0]), "r"(A[1]), "r"(B[0]), "f"(C[0]), "f"(C[1]), "f"(C[2]),
+        "f"(C[3]));
 #else
-    assert(TURBOMIND_ARCH_SM75);
+  assert(TURBOMIND_ARCH_SM75);
 #endif
 }
 
-__inline__ __device__ void
-mma_m16n8k8_row_col(Array<half, 4>& d, const Array<half, 4>& a, const Array<half, 2>& b, Array<half, 4>& c)
-{
+__inline__ __device__ void mma_m16n8k8_row_col(Array<half, 4>& d,
+                                               const Array<half, 4>& a,
+                                               const Array<half, 2>& b,
+                                               Array<half, 4>& c) {
 #if TURBOMIND_ARCH_SM75
-    uint32_t const* A = reinterpret_cast<uint32_t const*>(&a);
-    uint32_t const* B = reinterpret_cast<uint32_t const*>(&b);
-    uint32_t const* C = reinterpret_cast<uint32_t const*>(&c);
-    uint32_t*       D = reinterpret_cast<uint32_t*>(&d);
-    asm volatile("mma.sync.aligned.m16n8k8.row.col.f16.f16.f16.f16  {%0,%1}, "
-                 "{%2,%3}, {%4}, {%5,%6};\n"
-                 : "=r"(D[0]), "=r"(D[1])
-                 : "r"(A[0]), "r"(A[1]), "r"(B[0]), "r"(C[0]), "r"(C[1]));
+  uint32_t const* A = reinterpret_cast<uint32_t const*>(&a);
+  uint32_t const* B = reinterpret_cast<uint32_t const*>(&b);
+  uint32_t const* C = reinterpret_cast<uint32_t const*>(&c);
+  uint32_t* D = reinterpret_cast<uint32_t*>(&d);
+  asm volatile(
+      "mma.sync.aligned.m16n8k8.row.col.f16.f16.f16.f16  {%0,%1}, "
+      "{%2,%3}, {%4}, {%5,%6};\n"
+      : "=r"(D[0]), "=r"(D[1])
+      : "r"(A[0]), "r"(A[1]), "r"(B[0]), "r"(C[0]), "r"(C[1]));
 #else
-    assert(TURBOMIND_ARCH_SM75);
+  assert(TURBOMIND_ARCH_SM75);
 #endif
 }
 
-__inline__ __device__ void mma_m16n8k8_row_col(Array<float, 4>&             d,
+__inline__ __device__ void mma_m16n8k8_row_col(Array<float, 4>& d,
                                                const Array<nv_bfloat16, 4>& a,
                                                const Array<nv_bfloat16, 2>& b,
-                                               Array<float, 4>&             c)
-{
+                                               Array<float, 4>& c) {
 #if TURBOMIND_ARCH_SM80
-    uint32_t const* A = reinterpret_cast<uint32_t const*>(&a);
-    uint32_t const* B = reinterpret_cast<uint32_t const*>(&b);
-    float const*    C = reinterpret_cast<float const*>(&c);
-    float*          D = reinterpret_cast<float*>(&d);
-    asm volatile("mma.sync.aligned.m16n8k8.row.col.f32.bf16.bf16.f32  {%0,%1,%2,%3}, "
-                 "{%4,%5}, {%6}, {%7,%8,%9,%10};\n"
-                 : "=f"(D[0]), "=f"(D[1]), "=f"(D[2]), "=f"(D[3])
-                 : "r"(A[0]), "r"(A[1]), "r"(B[0]), "f"(C[0]), "f"(C[1]), "f"(C[2]), "f"(C[3]));
+  uint32_t const* A = reinterpret_cast<uint32_t const*>(&a);
+  uint32_t const* B = reinterpret_cast<uint32_t const*>(&b);
+  float const* C = reinterpret_cast<float const*>(&c);
+  float* D = reinterpret_cast<float*>(&d);
+  asm volatile(
+      "mma.sync.aligned.m16n8k8.row.col.f32.bf16.bf16.f32  {%0,%1,%2,%3}, "
+      "{%4,%5}, {%6}, {%7,%8,%9,%10};\n"
+      : "=f"(D[0]), "=f"(D[1]), "=f"(D[2]), "=f"(D[3])
+      : "r"(A[0]), "r"(A[1]), "r"(B[0]), "f"(C[0]), "f"(C[1]), "f"(C[2]),
+        "f"(C[3]));
 #else
-    assert(TURBOMIND_ARCH_SM80);
+  assert(TURBOMIND_ARCH_SM80);
 #endif
 }
 
-__inline__ __device__ void mma_m16n8k8_row_col(Array<nv_bfloat16, 4>&       d,
+__inline__ __device__ void mma_m16n8k8_row_col(Array<nv_bfloat16, 4>& d,
                                                const Array<nv_bfloat16, 4>& a,
                                                const Array<nv_bfloat16, 2>& b,
-                                               Array<nv_bfloat16, 4>&       c)
-{
+                                               Array<nv_bfloat16, 4>& c) {
 #if TURBOMIND_ARCH_SM80
-    uint32_t const* A = reinterpret_cast<uint32_t const*>(&a);
-    uint32_t const* B = reinterpret_cast<uint32_t const*>(&b);
-    uint32_t const* C = reinterpret_cast<uint32_t const*>(&c);
-    uint32_t*       D = reinterpret_cast<uint32_t*>(&d);
-    asm volatile("mma.sync.aligned.m16n8k8.row.col.bf16.bf16.bf16.bf16  {%0,%1}, "
-                 "{%2,%3}, {%4}, {%5,%6};\n"
-                 : "=r"(D[0]), "=r"(D[1])
-                 : "r"(A[0]), "r"(A[1]), "r"(B[0]), "r"(C[0]), "r"(C[1]));
+  uint32_t const* A = reinterpret_cast<uint32_t const*>(&a);
+  uint32_t const* B = reinterpret_cast<uint32_t const*>(&b);
+  uint32_t const* C = reinterpret_cast<uint32_t const*>(&c);
+  uint32_t* D = reinterpret_cast<uint32_t*>(&d);
+  asm volatile(
+      "mma.sync.aligned.m16n8k8.row.col.bf16.bf16.bf16.bf16  {%0,%1}, "
+      "{%2,%3}, {%4}, {%5,%6};\n"
+      : "=r"(D[0]), "=r"(D[1])
+      : "r"(A[0]), "r"(A[1]), "r"(B[0]), "r"(C[0]), "r"(C[1]));
 #else
-    assert(TURBOMIND_ARCH_SM80);
+  assert(TURBOMIND_ARCH_SM80);
 #endif
 }
 
-__inline__ __device__ void
-mma_m16n8k16_row_col(Array<float, 4>& d, const Array<half, 8>& a, const Array<half, 4>& b, Array<float, 4>& c)
-{
+__inline__ __device__ void mma_m16n8k16_row_col(Array<float, 4>& d,
+                                                const Array<half, 8>& a,
+                                                const Array<half, 4>& b,
+                                                Array<float, 4>& c) {
 #if TURBOMIND_ARCH_SM80
-    uint32_t const* A = reinterpret_cast<uint32_t const*>(&a);
-    uint32_t const* B = reinterpret_cast<uint32_t const*>(&b);
-    float const*    C = reinterpret_cast<float const*>(&c);
-    float*          D = reinterpret_cast<float*>(&d);
-    asm volatile(
-        "mma.sync.aligned.m16n8k16.row.col.f32.f16.f16.f32  {%0,%1,%2,%3}, "
-        "{%4,%5,%6,%7}, {%8,%9}, {%10,%11,%12,%13};\n"
-        : "=f"(D[0]), "=f"(D[1]), "=f"(D[2]), "=f"(D[3])
-        : "r"(A[0]), "r"(A[1]), "r"(A[2]), "r"(A[3]), "r"(B[0]), "r"(B[1]), "f"(C[0]), "f"(C[1]), "f"(C[2]), "f"(C[3]));
+  uint32_t const* A = reinterpret_cast<uint32_t const*>(&a);
+  uint32_t const* B = reinterpret_cast<uint32_t const*>(&b);
+  float const* C = reinterpret_cast<float const*>(&c);
+  float* D = reinterpret_cast<float*>(&d);
+  asm volatile(
+      "mma.sync.aligned.m16n8k16.row.col.f32.f16.f16.f32  {%0,%1,%2,%3}, "
+      "{%4,%5,%6,%7}, {%8,%9}, {%10,%11,%12,%13};\n"
+      : "=f"(D[0]), "=f"(D[1]), "=f"(D[2]), "=f"(D[3])
+      : "r"(A[0]), "r"(A[1]), "r"(A[2]), "r"(A[3]), "r"(B[0]), "r"(B[1]),
+        "f"(C[0]), "f"(C[1]), "f"(C[2]), "f"(C[3]));
 #else
-    const Array<half, 4>* _a = (const Array<half, 4>*)&a;
-    const Array<half, 2>* _b = (const Array<half, 2>*)&b;
-    mma_m16n8k8_row_col(d, _a[0], _b[0], c);
-    mma_m16n8k8_row_col(d, _a[1], _b[1], d);
+  const Array<half, 4>* _a = (const Array<half, 4>*)&a;
+  const Array<half, 2>* _b = (const Array<half, 2>*)&b;
+  mma_m16n8k8_row_col(d, _a[0], _b[0], c);
+  mma_m16n8k8_row_col(d, _a[1], _b[1], d);
 #endif
 }
 
-__inline__ __device__ void
-mma_m16n8k16_row_col(Array<half, 4>& d, const Array<half, 8>& a, const Array<half, 4>& b, Array<half, 4>& c)
-{
+__inline__ __device__ void mma_m16n8k16_row_col(Array<half, 4>& d,
+                                                const Array<half, 8>& a,
+                                                const Array<half, 4>& b,
+                                                Array<half, 4>& c) {
 #if TURBOMIND_ARCH_SM80
-    uint32_t const* A = reinterpret_cast<uint32_t const*>(&a);
-    uint32_t const* B = reinterpret_cast<uint32_t const*>(&b);
-    uint32_t const* C = reinterpret_cast<uint32_t const*>(&c);
-    uint32_t*       D = reinterpret_cast<uint32_t*>(&d);
-    asm volatile("mma.sync.aligned.m16n8k16.row.col.f16.f16.f16.f16  {%0,%1}, "
-                 "{%2,%3,%4,%5}, {%6,%7}, {%8,%9};\n"
-                 : "=r"(D[0]), "=r"(D[1])
-                 : "r"(A[0]), "r"(A[1]), "r"(A[2]), "r"(A[3]), "r"(B[0]), "r"(B[1]), "r"(C[0]), "r"(C[1]));
+  uint32_t const* A = reinterpret_cast<uint32_t const*>(&a);
+  uint32_t const* B = reinterpret_cast<uint32_t const*>(&b);
+  uint32_t const* C = reinterpret_cast<uint32_t const*>(&c);
+  uint32_t* D = reinterpret_cast<uint32_t*>(&d);
+  asm volatile(
+      "mma.sync.aligned.m16n8k16.row.col.f16.f16.f16.f16  {%0,%1}, "
+      "{%2,%3,%4,%5}, {%6,%7}, {%8,%9};\n"
+      : "=r"(D[0]), "=r"(D[1])
+      : "r"(A[0]), "r"(A[1]), "r"(A[2]), "r"(A[3]), "r"(B[0]), "r"(B[1]),
+        "r"(C[0]), "r"(C[1]));
 #else
-    const Array<half, 4>* _a = (const Array<half, 4>*)&a;
-    const Array<half, 2>* _b = (const Array<half, 2>*)&b;
-    mma_m16n8k8_row_col(d, _a[0], _b[0], c);
-    mma_m16n8k8_row_col(d, _a[1], _b[1], d);
+  const Array<half, 4>* _a = (const Array<half, 4>*)&a;
+  const Array<half, 2>* _b = (const Array<half, 2>*)&b;
+  mma_m16n8k8_row_col(d, _a[0], _b[0], c);
+  mma_m16n8k8_row_col(d, _a[1], _b[1], d);
 #endif
 }
 
-__inline__ __device__ void mma_m16n8k16_row_col(Array<float, 4>&             d,
+__inline__ __device__ void mma_m16n8k16_row_col(Array<float, 4>& d,
                                                 const Array<nv_bfloat16, 8>& a,
                                                 const Array<nv_bfloat16, 4>& b,
-                                                Array<float, 4>&             c)
-{
+                                                Array<float, 4>& c) {
 #if TURBOMIND_ARCH_SM80
-    uint32_t const* A = reinterpret_cast<uint32_t const*>(&a);
-    uint32_t const* B = reinterpret_cast<uint32_t const*>(&b);
-    float const*    C = reinterpret_cast<float const*>(&c);
-    float*          D = reinterpret_cast<float*>(&d);
-    asm volatile(
-        "mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32  {%0,%1,%2,%3}, "
-        "{%4,%5,%6,%7}, {%8,%9}, {%10,%11,%12,%13};\n"
-        : "=f"(D[0]), "=f"(D[1]), "=f"(D[2]), "=f"(D[3])
-        : "r"(A[0]), "r"(A[1]), "r"(A[2]), "r"(A[3]), "r"(B[0]), "r"(B[1]), "f"(C[0]), "f"(C[1]), "f"(C[2]), "f"(C[3]));
+  uint32_t const* A = reinterpret_cast<uint32_t const*>(&a);
+  uint32_t const* B = reinterpret_cast<uint32_t const*>(&b);
+  float const* C = reinterpret_cast<float const*>(&c);
+  float* D = reinterpret_cast<float*>(&d);
+  asm volatile(
+      "mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32  {%0,%1,%2,%3}, "
+      "{%4,%5,%6,%7}, {%8,%9}, {%10,%11,%12,%13};\n"
+      : "=f"(D[0]), "=f"(D[1]), "=f"(D[2]), "=f"(D[3])
+      : "r"(A[0]), "r"(A[1]), "r"(A[2]), "r"(A[3]), "r"(B[0]), "r"(B[1]),
+        "f"(C[0]), "f"(C[1]), "f"(C[2]), "f"(C[3]));
 #else
-    const Array<nv_bfloat16, 4>* _a = (const Array<nv_bfloat16, 4>*)&a;
-    const Array<nv_bfloat16, 2>* _b = (const Array<nv_bfloat16, 2>*)&b;
-    mma_m16n8k8_row_col(d, _a[0], _b[0], c);
-    mma_m16n8k8_row_col(d, _a[1], _b[1], d);
+  const Array<nv_bfloat16, 4>* _a = (const Array<nv_bfloat16, 4>*)&a;
+  const Array<nv_bfloat16, 2>* _b = (const Array<nv_bfloat16, 2>*)&b;
+  mma_m16n8k8_row_col(d, _a[0], _b[0], c);
+  mma_m16n8k8_row_col(d, _a[1], _b[1], d);
 #endif
 }
 
-__inline__ __device__ void mma_m16n8k16_row_col(Array<nv_bfloat16, 4>&       d,
+__inline__ __device__ void mma_m16n8k16_row_col(Array<nv_bfloat16, 4>& d,
                                                 const Array<nv_bfloat16, 8>& a,
                                                 const Array<nv_bfloat16, 4>& b,
-                                                Array<nv_bfloat16, 4>&       c)
-{
+                                                Array<nv_bfloat16, 4>& c) {
 #if TURBOMIND_ARCH_SM80
-    uint32_t const* A = reinterpret_cast<uint32_t const*>(&a);
-    uint32_t const* B = reinterpret_cast<uint32_t const*>(&b);
-    uint32_t const* C = reinterpret_cast<uint32_t const*>(&c);
-    uint32_t*       D = reinterpret_cast<uint32_t*>(&d);
-    asm volatile("mma.sync.aligned.m16n8k16.row.col.bf16.bf16.bf16.bf16  {%0,%1}, "
-                 "{%2,%3,%4,%5}, {%6,%7}, {%8,%9};\n"
-                 : "=r"(D[0]), "=r"(D[1])
-                 : "r"(A[0]), "r"(A[1]), "r"(A[2]), "r"(A[3]), "r"(B[0]), "r"(B[1]), "r"(C[0]), "r"(C[1]));
+  uint32_t const* A = reinterpret_cast<uint32_t const*>(&a);
+  uint32_t const* B = reinterpret_cast<uint32_t const*>(&b);
+  uint32_t const* C = reinterpret_cast<uint32_t const*>(&c);
+  uint32_t* D = reinterpret_cast<uint32_t*>(&d);
+  asm volatile(
+      "mma.sync.aligned.m16n8k16.row.col.bf16.bf16.bf16.bf16  {%0,%1}, "
+      "{%2,%3,%4,%5}, {%6,%7}, {%8,%9};\n"
+      : "=r"(D[0]), "=r"(D[1])
+      : "r"(A[0]), "r"(A[1]), "r"(A[2]), "r"(A[3]), "r"(B[0]), "r"(B[1]),
+        "r"(C[0]), "r"(C[1]));
 #else
-    const Array<nv_bfloat16, 4>* _a = (const Array<nv_bfloat16, 4>*)&a;
-    const Array<nv_bfloat16, 2>* _b = (const Array<nv_bfloat16, 2>*)&b;
-    mma_m16n8k8_row_col(d, _a[0], _b[0], c);
-    mma_m16n8k8_row_col(d, _a[1], _b[1], d);
+  const Array<nv_bfloat16, 4>* _a = (const Array<nv_bfloat16, 4>*)&a;
+  const Array<nv_bfloat16, 2>* _b = (const Array<nv_bfloat16, 2>*)&b;
+  mma_m16n8k8_row_col(d, _a[0], _b[0], c);
+  mma_m16n8k8_row_col(d, _a[1], _b[1], d);
 #endif
 }
 

--- a/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/core/pipe_iter.h
+++ b/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/core/pipe_iter.h
@@ -4,22 +4,21 @@
 
 namespace turbomind {
 
-template<int Stages, int Step = 1>
+template <int Stages, int Step = 1>
 struct PipeIter {
-    static constexpr int kMaxStep = Stages * Step;
+  static constexpr int kMaxStep = Stages * Step;
 
-    int r = 0;
-    int w = kMaxStep - Step;
+  int r = 0;
+  int w = kMaxStep - Step;
 
-    __inline__ __device__ PipeIter& operator++()
-    {
-        w = r;
-        r += Step;
-        if (r == kMaxStep) {
-            r -= kMaxStep;
-        }
-        return *this;
+  __inline__ __device__ PipeIter& operator++() {
+    w = r;
+    r += Step;
+    if (r == kMaxStep) {
+      r -= kMaxStep;
     }
+    return *this;
+  }
 };
 
 }  // namespace turbomind

--- a/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/core/smem.h
+++ b/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/core/smem.h
@@ -8,99 +8,105 @@
 
 namespace turbomind {
 
-__inline__ __device__ uint32_t cast_smem_ptr_to_uint(void const* const ptr)
-{
-    return (uint32_t)__cvta_generic_to_shared(ptr);
+__inline__ __device__ uint32_t cast_smem_ptr_to_uint(void const* const ptr) {
+  return (uint32_t)__cvta_generic_to_shared(ptr);
 }
 
-__inline__ __device__ void ldmatrix_m8n8_x4_b16(uint& d0, uint& d1, uint& d2, uint& d3, uint32_t smem_int_ptr)
-{
+__inline__ __device__ void ldmatrix_m8n8_x4_b16(uint& d0, uint& d1, uint& d2,
+                                                uint& d3,
+                                                uint32_t smem_int_ptr) {
 #if TURBOMIND_ARCH_SM75
-    asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0,%1,%2,%3}, [%4];\n"
-                 : "=r"(d0), "=r"(d1), "=r"(d2), "=r"(d3)
-                 : "r"(smem_int_ptr));
+  asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0,%1,%2,%3}, [%4];\n"
+               : "=r"(d0), "=r"(d1), "=r"(d2), "=r"(d3)
+               : "r"(smem_int_ptr));
 #else
-    assert(TURBOMIND_ARCH_SM75);
+  assert(TURBOMIND_ARCH_SM75);
 #endif
 }
 
-__inline__ __device__ void ldsm_x4_trans(uint& d0, uint& d1, uint& d2, uint& d3, uint32_t smem_int_ptr)
-{
+__inline__ __device__ void ldsm_x4_trans(uint& d0, uint& d1, uint& d2, uint& d3,
+                                         uint32_t smem_int_ptr) {
 #if TURBOMIND_ARCH_SM75
-    asm volatile("ldmatrix.sync.aligned.m8n8.x4.trans.shared.b16 {%0,%1,%2,%3}, [%4];\n"
-                 : "=r"(d0), "=r"(d1), "=r"(d2), "=r"(d3)
-                 : "r"(smem_int_ptr));
+  asm volatile(
+      "ldmatrix.sync.aligned.m8n8.x4.trans.shared.b16 {%0,%1,%2,%3}, [%4];\n"
+      : "=r"(d0), "=r"(d1), "=r"(d2), "=r"(d3)
+      : "r"(smem_int_ptr));
 #else
-    assert(TURBOMIND_ARCH_SM75);
+  assert(TURBOMIND_ARCH_SM75);
 #endif
 }
 
-__inline__ __device__ void ldmatrix_m8n8_x2_b16(uint& d0, uint& d1, uint32_t smem_int_ptr)
-{
+__inline__ __device__ void ldmatrix_m8n8_x2_b16(uint& d0, uint& d1,
+                                                uint32_t smem_int_ptr) {
 #if TURBOMIND_ARCH_SM75
-    asm volatile("ldmatrix.sync.aligned.m8n8.x2.shared.b16 {%0,%1}, [%2];\n" : "=r"(d0), "=r"(d1) : "r"(smem_int_ptr));
+  asm volatile("ldmatrix.sync.aligned.m8n8.x2.shared.b16 {%0,%1}, [%2];\n"
+               : "=r"(d0), "=r"(d1)
+               : "r"(smem_int_ptr));
 #else
-    assert(TURBOMIND_ARCH_SM75);
+  assert(TURBOMIND_ARCH_SM75);
 #endif
 }
 
-__inline__ __device__ void ldsm_x2_trans(uint& d0, uint& d1, uint32_t smem_int_ptr)
-{
+__inline__ __device__ void ldsm_x2_trans(uint& d0, uint& d1,
+                                         uint32_t smem_int_ptr) {
 #if TURBOMIND_ARCH_SM75
-    asm volatile("ldmatrix.sync.aligned.m8n8.x2.trans.shared.b16 {%0,%1}, [%2];\n"
-                 : "=r"(d0), "=r"(d1)
-                 : "r"(smem_int_ptr));
+  asm volatile("ldmatrix.sync.aligned.m8n8.x2.trans.shared.b16 {%0,%1}, [%2];\n"
+               : "=r"(d0), "=r"(d1)
+               : "r"(smem_int_ptr));
 #else
-    assert(TURBOMIND_ARCH_SM75);
+  assert(TURBOMIND_ARCH_SM75);
 #endif
 }
 
-__inline__ __device__ void ldmatrix_m8n8_x1_b16(uint& d0, uint32_t smem_int_ptr)
-{
+__inline__ __device__ void ldmatrix_m8n8_x1_b16(uint& d0,
+                                                uint32_t smem_int_ptr) {
 #if TURBOMIND_ARCH_SM75
-    asm volatile("ldmatrix.sync.aligned.m8n8.x1.shared.b16 %0, [%1];\n" : "=r"(d0) : "r"(smem_int_ptr));
+  asm volatile("ldmatrix.sync.aligned.m8n8.x1.shared.b16 %0, [%1];\n"
+               : "=r"(d0)
+               : "r"(smem_int_ptr));
 #else
-    assert(TURBOMIND_ARCH_SM75);
+  assert(TURBOMIND_ARCH_SM75);
 #endif
 }
 
-__inline__ __device__ void ldsm_x1_trans(uint& d0, uint32_t smem_int_ptr)
-{
+__inline__ __device__ void ldsm_x1_trans(uint& d0, uint32_t smem_int_ptr) {
 #if TURBOMIND_ARCH_SM75
-    asm volatile("ldmatrix.sync.aligned.m8n8.x1.trans.shared.b16 %0, [%1];\n" : "=r"(d0) : "r"(smem_int_ptr));
+  asm volatile("ldmatrix.sync.aligned.m8n8.x1.trans.shared.b16 %0, [%1];\n"
+               : "=r"(d0)
+               : "r"(smem_int_ptr));
 #else
-    assert(TURBOMIND_ARCH_SM75);
+  assert(TURBOMIND_ARCH_SM75);
 #endif
 }
 
-__inline__ __device__ void ldsm_x4(Array<uint32_t, 4>& d, uint32_t smem_int_ptr)
-{
-    ldmatrix_m8n8_x4_b16(d[0], d[1], d[2], d[3], smem_int_ptr);
+__inline__ __device__ void ldsm_x4(Array<uint32_t, 4>& d,
+                                   uint32_t smem_int_ptr) {
+  ldmatrix_m8n8_x4_b16(d[0], d[1], d[2], d[3], smem_int_ptr);
 }
 
-__inline__ __device__ void ldsm_x2(Array<uint32_t, 2>& d, uint32_t smem_int_ptr)
-{
-    ldmatrix_m8n8_x2_b16(d[0], d[1], smem_int_ptr);
+__inline__ __device__ void ldsm_x2(Array<uint32_t, 2>& d,
+                                   uint32_t smem_int_ptr) {
+  ldmatrix_m8n8_x2_b16(d[0], d[1], smem_int_ptr);
 }
 
-__inline__ __device__ void ldsm_x1(Array<uint32_t, 1>& d, uint32_t smem_int_ptr)
-{
-    ldmatrix_m8n8_x1_b16(d[0], smem_int_ptr);
+__inline__ __device__ void ldsm_x1(Array<uint32_t, 1>& d,
+                                   uint32_t smem_int_ptr) {
+  ldmatrix_m8n8_x1_b16(d[0], smem_int_ptr);
 }
 
-__inline__ __device__ void ldsm_x4_trans(Array<uint32_t, 4>& d, uint32_t smem_int_ptr)
-{
-    ldsm_x4_trans(d[0], d[1], d[2], d[3], smem_int_ptr);
+__inline__ __device__ void ldsm_x4_trans(Array<uint32_t, 4>& d,
+                                         uint32_t smem_int_ptr) {
+  ldsm_x4_trans(d[0], d[1], d[2], d[3], smem_int_ptr);
 }
 
-__inline__ __device__ void ldsm_x2_trans(Array<uint32_t, 2>& d, uint32_t smem_int_ptr)
-{
-    ldsm_x2_trans(d[0], d[1], smem_int_ptr);
+__inline__ __device__ void ldsm_x2_trans(Array<uint32_t, 2>& d,
+                                         uint32_t smem_int_ptr) {
+  ldsm_x2_trans(d[0], d[1], smem_int_ptr);
 }
 
-__inline__ __device__ void ldsm_x1_trans(Array<uint32_t, 1>& d, uint32_t smem_int_ptr)
-{
-    ldsm_x1_trans(d[0], smem_int_ptr);
+__inline__ __device__ void ldsm_x1_trans(Array<uint32_t, 1>& d,
+                                         uint32_t smem_int_ptr) {
+  ldsm_x1_trans(d[0], smem_int_ptr);
 }
 
 }  // namespace turbomind

--- a/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/core/sub_byte_ptr.h
+++ b/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/core/sub_byte_ptr.h
@@ -6,46 +6,40 @@
 
 namespace turbomind {
 
-template<class T>
+template <class T>
 struct SubBytePtr {
+  constexpr SubBytePtr() = default;
 
-    constexpr SubBytePtr() = default;
+  constexpr __host__ __device__ explicit SubBytePtr(T* ptr)
+      : ptr_((char*)ptr) {}
 
-    constexpr __host__ __device__ explicit SubBytePtr(T* ptr): ptr_((char*)ptr) {}
+  constexpr __host__ __device__ SubBytePtr(char* ptr) : ptr_(ptr) {}
 
-    constexpr __host__ __device__ SubBytePtr(char* ptr): ptr_(ptr) {}
+  __host__ __device__ T& operator[](int i) {
+    return *reinterpret_cast<T*>(ptr_ + i * bitsof<T> / bitsof<char>);
+  }
 
-    __host__ __device__ T& operator[](int i)
-    {
-        return *reinterpret_cast<T*>(ptr_ + i * bitsof<T> / bitsof<char>);
-    }
+  friend __host__ __device__ SubBytePtr operator+(const SubBytePtr a, int n) {
+    return SubBytePtr{a.ptr_ + n * bitsof<T> / bitsof<char>};
+  }
 
-    friend __host__ __device__ SubBytePtr operator+(const SubBytePtr a, int n)
-    {
-        return SubBytePtr{a.ptr_ + n * bitsof<T> / bitsof<char>};
-    }
+  friend __host__ __device__ SubBytePtr operator+(int n, const SubBytePtr a) {
+    return a + n;
+  }
 
-    friend __host__ __device__ SubBytePtr operator+(int n, const SubBytePtr a)
-    {
-        return a + n;
-    }
+  friend __host__ __device__ bool operator==(const SubBytePtr& a,
+                                             const SubBytePtr& b) {
+    return a.ptr_ == b.ptr_;
+  }
 
-    friend __host__ __device__ bool operator==(const SubBytePtr& a, const SubBytePtr& b)
-    {
-        return a.ptr_ == b.ptr_;
-    }
+  __host__ __device__ explicit operator T*() const { return (T*)ptr_; }
 
-    __host__ __device__ explicit operator T*() const
-    {
-        return (T*)ptr_;
-    }
-
-    char* ptr_;
+  char* ptr_;
 };
 
-template<class T>
+template <class T>
 struct get_pointer_type_t<T, std::enable_if_t<bitsof<T> % 8 != 0>> {
-    using type = SubBytePtr<T>;
+  using type = SubBytePtr<T>;
 };
 
 }  // namespace turbomind

--- a/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/core/sync.h
+++ b/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/core/sync.h
@@ -4,62 +4,61 @@
 
 namespace turbomind {
 
-__inline__ __device__ int sem_fetch(int* lock, bool pred)
-{
-    int state{};
-    if (pred) {
+__inline__ __device__ int sem_fetch(int* lock, bool pred) {
+  int state{};
+  if (pred) {
 #if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 700
-        asm volatile("ld.global.acquire.gpu.b32 %0, [%1];\n" : "=r"(state) : "l"(lock));
+    asm volatile("ld.global.acquire.gpu.b32 %0, [%1];\n"
+                 : "=r"(state)
+                 : "l"(lock));
 #else
-        asm volatile("ld.global.cg.b32 %0, [%1];\n" : "=r"(state) : "l"(lock));
+    asm volatile("ld.global.cg.b32 %0, [%1];\n" : "=r"(state) : "l"(lock));
 #endif
-    }
-    return state;
+  }
+  return state;
 }
 
-__inline__ __device__ void sem_wait(int* lock, int status, bool pred)
-{
-    int state = 0;
-    while (__syncthreads_and(state != status)) {
-        state = sem_fetch(lock, pred);
-    }
+__inline__ __device__ void sem_wait(int* lock, int status, bool pred) {
+  int state = 0;
+  while (__syncthreads_and(state != status)) {
+    state = sem_fetch(lock, pred);
+  }
 
-    __syncthreads();  // memory fence
+  __syncthreads();  // memory fence
 }
 
-__inline__ __device__ void sem_wait_lane0(int* lock, int status)
-{
-    // The first split has no predecessor, matching sem_wait's initial
-    // state==status fast path without issuing an unnecessary acquire load.
-    if (threadIdx.x == 0 && status != 0) {
-        while (sem_fetch(lock, true) != status) {
-        }
+__inline__ __device__ void sem_wait_lane0(int* lock, int status) {
+  // The first split has no predecessor, matching sem_wait's initial
+  // state==status fast path without issuing an unnecessary acquire load.
+  if (threadIdx.x == 0 && status != 0) {
+    while (sem_fetch(lock, true) != status) {
     }
+  }
 
-    __syncthreads();  // CTA memory fence after lane 0's acquire load
+  __syncthreads();  // CTA memory fence after lane 0's acquire load
 }
 
-__inline__ __device__ void sem_wait_many(int* lock, int count, bool pred)
-{
-    int state = 0;
-    while (__syncthreads_count(state) != count) {
-        state = sem_fetch(lock, pred);
-    }
+__inline__ __device__ void sem_wait_many(int* lock, int count, bool pred) {
+  int state = 0;
+  while (__syncthreads_count(state) != count) {
+    state = sem_fetch(lock, pred);
+  }
 
-    __syncthreads();  // memory fence
+  __syncthreads();  // memory fence
 }
 
-__inline__ __device__ void sem_post(int* lock, int status, bool pred)
-{
-    __syncthreads();  // memory fence
+__inline__ __device__ void sem_post(int* lock, int status, bool pred) {
+  __syncthreads();  // memory fence
 
-    if (pred) {
+  if (pred) {
 #if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 700
-        asm volatile("st.global.release.gpu.b32 [%0], %1;\n" : : "l"(lock), "r"(status));
+    asm volatile("st.global.release.gpu.b32 [%0], %1;\n"
+                 :
+                 : "l"(lock), "r"(status));
 #else
-        asm volatile("st.global.cg.b32 [%0], %1;\n" : : "l"(lock), "r"(status));
+    asm volatile("st.global.cg.b32 [%0], %1;\n" : : "l"(lock), "r"(status));
 #endif
-    }
+  }
 }
 
 }  // namespace turbomind

--- a/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/core/thread_map.h
+++ b/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/core/thread_map.h
@@ -9,125 +9,133 @@
 
 namespace turbomind {
 
-template<int C, int S, int AccessC, int WarpCount>
+template <int C, int S, int AccessC, int WarpCount>
 struct ThreadMapQ {
-    static constexpr int kWarpCount = WarpCount;
-    static constexpr int kAccessC   = AccessC;
+  static constexpr int kWarpCount = WarpCount;
+  static constexpr int kAccessC = AccessC;
 
-    static constexpr int kWarpThreadC = C / kAccessC;
-    static constexpr int kWarpThreadS = WARP_SIZE / kWarpThreadC;
+  static constexpr int kWarpThreadC = C / kAccessC;
+  static constexpr int kWarpThreadS = WARP_SIZE / kWarpThreadC;
 
-    static_assert(kWarpThreadC <= WARP_SIZE);
+  static_assert(kWarpThreadC <= WARP_SIZE);
 
-    static constexpr int kWarpAccessC = kWarpThreadC * kAccessC;  // C
-    static constexpr int kWarpAccessS = kWarpThreadS;
+  static constexpr int kWarpAccessC = kWarpThreadC * kAccessC;  // C
+  static constexpr int kWarpAccessS = kWarpThreadS;
 
-    static constexpr int kWarpIterC = C / kWarpAccessC;  // 1
-    static constexpr int kWarpIterS = S / kWarpAccessS;
+  static constexpr int kWarpIterC = C / kWarpAccessC;  // 1
+  static constexpr int kWarpIterS = S / kWarpAccessS;
 
-    static constexpr int kWarpC = 1;
-    static constexpr int kWarpS = kWarpCount;
+  static constexpr int kWarpC = 1;
+  static constexpr int kWarpS = kWarpCount;
 
-    static constexpr int kIterC = kWarpIterC / kWarpC;  // 1
-    static constexpr int kIterS = std::max(kWarpIterS / kWarpS, 1);
+  static constexpr int kIterC = kWarpIterC / kWarpC;  // 1
+  static constexpr int kIterS = std::max(kWarpIterS / kWarpS, 1);
 
-    static constexpr int kFootprintC = kWarpAccessC * kIterC;  // C
-    static constexpr int kFootprintS = kWarpAccessS * kIterS;
+  static constexpr int kFootprintC = kWarpAccessC * kIterC;  // C
+  static constexpr int kFootprintS = kWarpAccessS * kIterS;
 
-    static constexpr int kDeltaC = kWarpAccessC;
-    static constexpr int kDeltaS = kWarpAccessS;
+  static constexpr int kDeltaC = kWarpAccessC;
+  static constexpr int kDeltaS = kWarpAccessS;
 
-    __device__ static int2 get_offset(int warp_id, int lane_id)
-    {
-        int warp_offset_c = warp_id % kWarpC;
-        int warp_offset_s = warp_id / kWarpC;
+  __device__ static int2 get_offset(int warp_id, int lane_id) {
+    int warp_offset_c = warp_id % kWarpC;
+    int warp_offset_s = warp_id / kWarpC;
 
-        int warp_thread_offset_c = lane_id % kWarpThreadC;
-        int warp_thread_offset_s = lane_id / kWarpThreadC;
+    int warp_thread_offset_c = lane_id % kWarpThreadC;
+    int warp_thread_offset_s = lane_id / kWarpThreadC;
 
-        int cta_thread_offset_c = kFootprintC * warp_offset_c + warp_thread_offset_c * kAccessC;
-        int cta_thread_offset_s = kFootprintS * warp_offset_s + warp_thread_offset_s;
+    int cta_thread_offset_c =
+        kFootprintC * warp_offset_c + warp_thread_offset_c * kAccessC;
+    int cta_thread_offset_s =
+        kFootprintS * warp_offset_s + warp_thread_offset_s;
 
-        return {cta_thread_offset_c, cta_thread_offset_s};
-    }
+    return {cta_thread_offset_c, cta_thread_offset_s};
+  }
 };
 
-template<int DimC, int DimS, int AccessC, int WarpCount, int WarpThreadC = lowbit(DimC) / AccessC>
+template <int DimC, int DimS, int AccessC, int WarpCount,
+          int WarpThreadC = lowbit(DimC) / AccessC>
 struct RakedThreadMap {
-    static constexpr int kDimC = DimC;
-    static constexpr int kDimS = DimS;
+  static constexpr int kDimC = DimC;
+  static constexpr int kDimS = DimS;
 
-    static constexpr int kWarpCount = WarpCount;
-    static constexpr int kAccessC   = AccessC;
+  static constexpr int kWarpCount = WarpCount;
+  static constexpr int kAccessC = AccessC;
 
-    static constexpr int kWarpThreadC = WarpThreadC;
-    static constexpr int kWarpThreadS = WARP_SIZE / kWarpThreadC;
+  static constexpr int kWarpThreadC = WarpThreadC;
+  static constexpr int kWarpThreadS = WARP_SIZE / kWarpThreadC;
 
-    static_assert(kWarpThreadC <= WARP_SIZE);
+  static_assert(kWarpThreadC <= WARP_SIZE);
 
-    static constexpr int kWarpAccessC = kWarpThreadC * kAccessC;
-    static constexpr int kWarpAccessS = kWarpThreadS;
+  static constexpr int kWarpAccessC = kWarpThreadC * kAccessC;
+  static constexpr int kWarpAccessS = kWarpThreadS;
 
-    static constexpr int kWarpIterC = (kDimC + kWarpAccessC - 1) / kWarpAccessC;
-    static constexpr int kWarpIterS = kDimS / kWarpAccessS;
+  static constexpr int kWarpIterC = (kDimC + kWarpAccessC - 1) / kWarpAccessC;
+  static constexpr int kWarpIterS = kDimS / kWarpAccessS;
 
-    static constexpr int kWarpC = 1;
-    static constexpr int kWarpS = kWarpCount;
+  static constexpr int kWarpC = 1;
+  static constexpr int kWarpS = kWarpCount;
 
-    static constexpr int kIterC = kWarpIterC / kWarpC;
-    static constexpr int kIterS = std::max(kWarpIterS / kWarpS, 1);
+  static constexpr int kIterC = kWarpIterC / kWarpC;
+  static constexpr int kIterS = std::max(kWarpIterS / kWarpS, 1);
 
-    // Allow partial tile when there is ONLY 1 iteration
-    static_assert(kDimC % kWarpAccessC == 0 || kIterC == 1);
+  // Allow partial tile when there is ONLY 1 iteration
+  static_assert(kDimC % kWarpAccessC == 0 || kIterC == 1);
 
-    static_assert(kIterC > 0);
-    static_assert(kIterS > 0);
+  static_assert(kIterC > 0);
+  static_assert(kIterS > 0);
 
-    static constexpr bool kPartialC = kDimC % kWarpAccessC != 0;
+  static constexpr bool kPartialC = kDimC % kWarpAccessC != 0;
 
-    static constexpr int kFootprintC = kWarpAccessC * kIterC;
-    static constexpr int kFootprintS = kWarpAccessS * kIterS;
+  static constexpr int kFootprintC = kWarpAccessC * kIterC;
+  static constexpr int kFootprintS = kWarpAccessS * kIterS;
 
-    static constexpr int kDeltaC = kWarpAccessC;
-    static constexpr int kDeltaS = kWarpAccessS;
+  static constexpr int kDeltaC = kWarpAccessC;
+  static constexpr int kDeltaS = kWarpAccessS;
 
-    // static constexpr int kDeltaC = kWarpAccessC * kWarpC;
-    // static constexpr int kDeltaS = kWarpAccessS * kWarpS;
+  // static constexpr int kDeltaC = kWarpAccessC * kWarpC;
+  // static constexpr int kDeltaS = kWarpAccessS * kWarpS;
 
-    __device__ static int2 get_offset(int warp_id, int lane_id)
-    {
-        int warp_offset_c = warp_id % kWarpC;
-        int warp_offset_s = warp_id / kWarpC;
+  __device__ static int2 get_offset(int warp_id, int lane_id) {
+    int warp_offset_c = warp_id % kWarpC;
+    int warp_offset_s = warp_id / kWarpC;
 
-        int warp_thread_offset_c = lane_id % kWarpThreadC;
-        int warp_thread_offset_s = lane_id / kWarpThreadC;
+    int warp_thread_offset_c = lane_id % kWarpThreadC;
+    int warp_thread_offset_s = lane_id / kWarpThreadC;
 
-        int cta_thread_offset_c = kFootprintC * warp_offset_c + warp_thread_offset_c * kAccessC;
-        int cta_thread_offset_s = kFootprintS * warp_offset_s + warp_thread_offset_s;
+    int cta_thread_offset_c =
+        kFootprintC * warp_offset_c + warp_thread_offset_c * kAccessC;
+    int cta_thread_offset_s =
+        kFootprintS * warp_offset_s + warp_thread_offset_s;
 
-        // int cta_thread_offset_c = kWarpAccessC * warp_offset_c + warp_thread_offset_c * kAccessC;
-        // int cta_thread_offset_s = kWarpAccessS * warp_offset_s + warp_thread_offset_s;
+    // int cta_thread_offset_c = kWarpAccessC * warp_offset_c +
+    // warp_thread_offset_c * kAccessC; int cta_thread_offset_s = kWarpAccessS *
+    // warp_offset_s + warp_thread_offset_s;
 
-        return {cta_thread_offset_c, cta_thread_offset_s};
-    }
+    return {cta_thread_offset_c, cta_thread_offset_s};
+  }
 };
 
 namespace {
 
-template<class TMap>
-void Print(TMap)
-{
-    std::cout << "     warps: " << TMap::kWarpCount << "\n";
-    std::cout << "     shape: (" << TMap::kDimC << ", " << TMap::kDimS << ")\n";
-    std::cout << "    access: (" << TMap::kAccessC << ", " << 1 << ")\n";
-    std::cout << "warpThread: (" << TMap::kWarpThreadC << ", " << TMap::kWarpThreadS << ")\n";
-    std::cout << "warpAccess: (" << TMap::kWarpAccessC << ", " << TMap::kWarpAccessS << ")\n";
-    std::cout << "  warpIter: (" << TMap::kWarpIterC << ", " << TMap::kWarpIterS << ")\n";
-    std::cout << "      warp: (" << TMap::kWarpC << ", " << TMap::kWarpS << ")\n";
-    std::cout << "      iter: (" << TMap::kIterC << ", " << TMap::kIterS << ")\n";
-    std::cout << " footprint: (" << TMap::kFootprintC << ", " << TMap::kFootprintS << ")\n";
-    std::cout << "     delta: (" << TMap::kDeltaC << ", " << TMap::kDeltaS << ")\n";
-    std::cout << "  partialC: " << TMap::kPartialC << "\n";
+template <class TMap>
+void Print(TMap) {
+  std::cout << "     warps: " << TMap::kWarpCount << "\n";
+  std::cout << "     shape: (" << TMap::kDimC << ", " << TMap::kDimS << ")\n";
+  std::cout << "    access: (" << TMap::kAccessC << ", " << 1 << ")\n";
+  std::cout << "warpThread: (" << TMap::kWarpThreadC << ", "
+            << TMap::kWarpThreadS << ")\n";
+  std::cout << "warpAccess: (" << TMap::kWarpAccessC << ", "
+            << TMap::kWarpAccessS << ")\n";
+  std::cout << "  warpIter: (" << TMap::kWarpIterC << ", " << TMap::kWarpIterS
+            << ")\n";
+  std::cout << "      warp: (" << TMap::kWarpC << ", " << TMap::kWarpS << ")\n";
+  std::cout << "      iter: (" << TMap::kIterC << ", " << TMap::kIterS << ")\n";
+  std::cout << " footprint: (" << TMap::kFootprintC << ", " << TMap::kFootprintS
+            << ")\n";
+  std::cout << "     delta: (" << TMap::kDeltaC << ", " << TMap::kDeltaS
+            << ")\n";
+  std::cout << "  partialC: " << TMap::kPartialC << "\n";
 }
 
 }  // namespace

--- a/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/arch.h
+++ b/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/arch.h
@@ -6,46 +6,44 @@ namespace turbomind::gemm {
 
 // tags for dispatching & conditional codegen
 
-template<int Begin, int End = -1>
+template <int Begin, int End = -1>
 struct Arch {
-    static constexpr bool is_compatible(int arch)
-    {
-        return Begin <= arch && (End == -1 || arch < End);
-    }
+  static constexpr bool is_compatible(int arch) {
+    return Begin <= arch && (End == -1 || arch < End);
+  }
 };
 
-struct Sm70: Arch<700, 750> {
-    static constexpr int value = 700;
+struct Sm70 : Arch<700, 750> {
+  static constexpr int value = 700;
 };
 
-struct Sm75: Arch<750, 800> {
-    static constexpr int value = 750;
+struct Sm75 : Arch<750, 800> {
+  static constexpr int value = 750;
 };
 
-struct Sm80: Arch<800, 900> {
-    static constexpr int value = 800;
+struct Sm80 : Arch<800, 900> {
+  static constexpr int value = 800;
 };
 
-struct Sm90: Arch<900> {
-    static constexpr int value = 900;
+struct Sm90 : Arch<900> {
+  static constexpr int value = 900;
 };
 
-inline bool is_arch_compatible(int karch, int darch)
-{
-    switch (karch) {
-        case 0:
-            return true;
-        case 700:
-            return Sm70::is_compatible(darch);
-        case 750:
-            return Sm75::is_compatible(darch);
-        case 800:
-            return Sm80::is_compatible(darch);
-        case 900:
-            return Sm90::is_compatible(darch);
-        default:
-            return false;
-    }
+inline bool is_arch_compatible(int karch, int darch) {
+  switch (karch) {
+    case 0:
+      return true;
+    case 700:
+      return Sm70::is_compatible(darch);
+    case 750:
+      return Sm75::is_compatible(darch);
+    case 800:
+      return Sm80::is_compatible(darch);
+    case 900:
+      return Sm90::is_compatible(darch);
+    default:
+      return false;
+  }
 }
 
 }  // namespace turbomind::gemm

--- a/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/arch/config_simt.h
+++ b/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/arch/config_simt.h
@@ -17,86 +17,51 @@ namespace turbomind::gemm {
 
 namespace simt {
 
-template<class A,
-         class TransformA,
-         class U,
-         class B,
-         class TransformB,
-         class V,
-         Order order_C,
-         class Tc,
-         Striding mode_A,
-         Striding mode_B,
-         Striding mode_C,
-         class CtaMap_>
+template <class A, class TransformA, class U, class B, class TransformB,
+          class V, Order order_C, class Tc, Striding mode_A, Striding mode_B,
+          Striding mode_C, class CtaMap_>
 struct Sm75_Simt {
+  static_assert(A::SmemCopyAtom::K == B::SmemCopyAtom::K);
 
-    static_assert(A::SmemCopyAtom::K == B::SmemCopyAtom::K);
+  static constexpr int SMEM_M = A::SmemCopyAtom::M / A::SmemCopyAtom::kFragNum;
+  static constexpr int SMEM_N = B::SmemCopyAtom::M / B::SmemCopyAtom::kFragNum;
+  static constexpr int SMEM_K = A::SmemCopyAtom::K;
 
-    static constexpr int SMEM_M = A::SmemCopyAtom::M / A::SmemCopyAtom::kFragNum;
-    static constexpr int SMEM_N = B::SmemCopyAtom::M / B::SmemCopyAtom::kFragNum;
-    static constexpr int SMEM_K = A::SmemCopyAtom::K;
+  template <int CTA_M, int CTA_N, int CTA_K, int TG_M, int TG_N, int TG_K,
+            class PolicyA, class PolicyB, int Stages, bool SplitK,
+            int GroupSizeU = 1, int GroupSizeV = 1, int TILE_C_M_ = -1,
+            int TILE_C_N_ = -1>
+  struct Type {
+    // (TM, TN, TK) = R(MMA_Atom, SmemCopy_Atom)
+    using MMA_Atom = MMA_SIMT<half>;
 
-    template<int CTA_M,
-             int CTA_N,
-             int CTA_K,
-             int TG_M,
-             int TG_N,
-             int TG_K,
-             class PolicyA,
-             class PolicyB,
-             int  Stages,
-             bool SplitK,
-             int  GroupSizeU = 1,
-             int  GroupSizeV = 1,
-             int  TILE_C_M_  = -1,
-             int  TILE_C_N_  = -1>
-    struct Type {
+    static constexpr int TM = MMA_Atom::M;
+    static constexpr int TN = MMA_Atom::N;
+    static constexpr int TK = MMA_Atom::K;
 
-        // (TM, TN, TK) = R(MMA_Atom, SmemCopy_Atom)
-        using MMA_Atom = MMA_SIMT<half>;
+    using Partition = Blocked<TG_M, TG_N, kColMajor>;
 
-        static constexpr int TM = MMA_Atom::M;
-        static constexpr int TN = MMA_Atom::N;
-        static constexpr int TK = MMA_Atom::K;
+    using MMA_Map =
+        MMA_Map<CTA_M, CTA_N, CTA_K, SMEM_M, SMEM_N, SMEM_K, Partition, TG_K>;
+    using MMA = Tiled_MMA_v2<MMA_Atom, MMA_Map>;
 
-        using Partition = Blocked<TG_M, TG_N, kColMajor>;
+    // using MMA_Map = RakedThreadGroupMap<CTA_M, CTA_N, CTA_K, TM, TN, TK,
+    // WARP_CNT_M, WARP_CNT_N, WARP_CNT_K>;
 
-        using MMA_Map = MMA_Map<CTA_M, CTA_N, CTA_K, SMEM_M, SMEM_N, SMEM_K, Partition, TG_K>;
-        using MMA     = Tiled_MMA_v2<MMA_Atom, MMA_Map>;
+    using Mainloop =
+        MainloopSm70<MMA, A, IteratorSm70<mode_A, PolicyA>, TransformA, U,
+                     GroupSizeU, B, IteratorSm70<mode_B, PolicyB>, TransformB,
+                     V, GroupSizeV, Stages, true>;
 
-        // using MMA_Map = RakedThreadGroupMap<CTA_M, CTA_N, CTA_K, TM, TN, TK, WARP_CNT_M, WARP_CNT_N, WARP_CNT_K>;
+    static constexpr int TILE_C_M = TILE_C_M_ == -1 ? CTA_M : TILE_C_M_;
+    static constexpr int TILE_C_N = TILE_C_N_ == -1 ? CTA_N : TILE_C_N_;
 
-        using Mainloop = MainloopSm70<MMA,
-                                      A,
-                                      IteratorSm70<mode_A, PolicyA>,
-                                      TransformA,
-                                      U,
-                                      GroupSizeU,
-                                      B,
-                                      IteratorSm70<mode_B, PolicyB>,
-                                      TransformB,
-                                      V,
-                                      GroupSizeV,
-                                      Stages,
-                                      true>;
+    using Epilogue = gemm::Epilogue_<Tc, CTA_M, CTA_N, TILE_C_M, TILE_C_N,
+                                     MMA::kThreadCount, Rearrange<MMA>,
+                                     Operand_C<float, order_C>, mode_C, SplitK>;
 
-        static constexpr int TILE_C_M = TILE_C_M_ == -1 ? CTA_M : TILE_C_M_;
-        static constexpr int TILE_C_N = TILE_C_N_ == -1 ? CTA_N : TILE_C_N_;
-
-        using Epilogue = gemm::Epilogue_<Tc,
-                                         CTA_M,
-                                         CTA_N,
-                                         TILE_C_M,
-                                         TILE_C_N,
-                                         MMA::kThreadCount,
-                                         Rearrange<MMA>,
-                                         Operand_C<float, order_C>,
-                                         mode_C,
-                                         SplitK>;
-
-        using Kernel = GemmUniversal<Sm75, Mainloop, Epilogue, CtaMap_>;
-    };
+    using Kernel = GemmUniversal<Sm75, Mainloop, Epilogue, CtaMap_>;
+  };
 };
 
 }  // namespace simt

--- a/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/arch/config_sm70_s884.h
+++ b/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/arch/config_sm70_s884.h
@@ -19,117 +19,79 @@
 
 namespace turbomind::gemm::sm70_s884 {
 
-template<class A,
-         class TransformA,
-         class U,
-         class B,
-         class TransformB,
-         class V,
-         Order order_C,
-         class Tc,
-         Order raster_order,
-         int   group_axis>
+template <class A, class TransformA, class U, class B, class TransformB,
+          class V, Order order_C, class Tc, Order raster_order, int group_axis>
 struct Sm70_s884 {
+  static_assert(A::SmemCopyAtom::K == B::SmemCopyAtom::K);
 
-    static_assert(A::SmemCopyAtom::K == B::SmemCopyAtom::K);
+  static constexpr int SMEM_M = A::SmemCopyAtom::M / A::SmemCopyAtom::kFragNum;
+  static constexpr int SMEM_N = B::SmemCopyAtom::M / B::SmemCopyAtom::kFragNum;
+  static constexpr int SMEM_K = A::SmemCopyAtom::K;
 
-    static constexpr int SMEM_M = A::SmemCopyAtom::M / A::SmemCopyAtom::kFragNum;
-    static constexpr int SMEM_N = B::SmemCopyAtom::M / B::SmemCopyAtom::kFragNum;
-    static constexpr int SMEM_K = A::SmemCopyAtom::K;
+  static constexpr auto MODE_ =
+      group_axis >= 0 ? Striding::kBlocked : Striding::kFlat;
 
-    static constexpr auto MODE_ = group_axis >= 0 ? Striding::kBlocked : Striding::kFlat;
+  static constexpr auto MODE_A = group_axis == 0 ? Striding::kIndexed : MODE_;
+  static constexpr auto MODE_B = group_axis == 1 ? Striding::kIndexed : MODE_;
+  static constexpr auto MODE_C = MODE_;
 
-    static constexpr auto MODE_A = group_axis == 0 ? Striding::kIndexed : MODE_;
-    static constexpr auto MODE_B = group_axis == 1 ? Striding::kIndexed : MODE_;
-    static constexpr auto MODE_C = MODE_;
+  template <int CTA_M, int CTA_N, int CTA_K, int TG_M, int TG_N, int TG_K,
+            class PolicyA, class PolicyB, int Stages, bool SplitK,
+            int GroupSizeU = 1, int GroupSizeV = 1, int TILE_C_M_ = -1,
+            int TILE_C_N_ = -1, int GmemLookahead = 1>
+  struct Type {
+    // (TM, TN, TK) = R(MMA_Atom, SmemCopy_Atom)
+    using MMA_Atom = SM70_MMA_884;
 
-    template<int CTA_M,
-             int CTA_N,
-             int CTA_K,
-             int TG_M,
-             int TG_N,
-             int TG_K,
-             class PolicyA,
-             class PolicyB,
-             int  Stages,
-             bool SplitK,
-             int  GroupSizeU = 1,
-             int  GroupSizeV = 1,
-             int  TILE_C_M_  = -1,
-             int  TILE_C_N_  = -1,
-             int  GmemLookahead = 1>
-    struct Type {
+    using Partition = Blocked<TG_M, TG_N, kColMajor>;
+    using MMA_Map =
+        MMA_Map<CTA_M, CTA_N, CTA_K, SMEM_M, SMEM_N, SMEM_K, Partition, TG_K>;
 
-        // (TM, TN, TK) = R(MMA_Atom, SmemCopy_Atom)
-        using MMA_Atom = SM70_MMA_884;
+    using MMA = Tiled_MMA_v2<MMA_Atom, MMA_Map>;
 
-        using Partition = Blocked<TG_M, TG_N, kColMajor>;
-        using MMA_Map   = MMA_Map<CTA_M, CTA_N, CTA_K, SMEM_M, SMEM_N, SMEM_K, Partition, TG_K>;
+    using Mainloop =
+        MainloopSm70<MMA, A, IteratorSm70<MODE_A, PolicyA>, TransformA, U,
+                     GroupSizeU, B, IteratorSm70<MODE_B, PolicyB>, TransformB,
+                     V, GroupSizeV, Stages, true,
+                     GmemLookahead>;  // FusePrefetch_
 
-        using MMA = Tiled_MMA_v2<MMA_Atom, MMA_Map>;
+    static constexpr int CHUNK_K =
+        std::lcm(std::lcm(GroupSizeU, GroupSizeV), CTA_K);
 
-        using Mainloop = MainloopSm70<MMA,
-                                      A,
-                                      IteratorSm70<MODE_A, PolicyA>,
-                                      TransformA,
-                                      U,
-                                      GroupSizeU,
-                                      B,
-                                      IteratorSm70<MODE_B, PolicyB>,
-                                      TransformB,
-                                      V,
-                                      GroupSizeV,
-                                      Stages,
-                                      true,
-                                      GmemLookahead>;  // FusePrefetch_
+    using Scheduler = SchedulerSm70<raster_order, CTA_M, CTA_N, CTA_K, CHUNK_K,
+                                    SplitK, group_axis>;
 
-        static constexpr int CHUNK_K = std::lcm(std::lcm(GroupSizeU, GroupSizeV), CTA_K);
+    static constexpr int TILE_C_M = TILE_C_M_ == -1 ? CTA_M : TILE_C_M_;
+    static constexpr int TILE_C_N = TILE_C_N_ == -1 ? CTA_N : TILE_C_N_;
 
-        using Scheduler = SchedulerSm70<raster_order, CTA_M, CTA_N, CTA_K, CHUNK_K, SplitK, group_axis>;
+    using Epilogue = gemm::Epilogue_<Tc, CTA_M, CTA_N, TILE_C_M, TILE_C_N,
+                                     MMA::kThreadCount, Rearrange<MMA>,
+                                     Operand_C<float, order_C>, MODE_C, SplitK>;
 
-        static constexpr int TILE_C_M = TILE_C_M_ == -1 ? CTA_M : TILE_C_M_;
-        static constexpr int TILE_C_N = TILE_C_N_ == -1 ? CTA_N : TILE_C_N_;
-
-        using Epilogue = gemm::Epilogue_<Tc,
-                                         CTA_M,
-                                         CTA_N,
-                                         TILE_C_M,
-                                         TILE_C_N,
-                                         MMA::kThreadCount,
-                                         Rearrange<MMA>,
-                                         Operand_C<float, order_C>,
-                                         MODE_C,
-                                         SplitK>;
-
-        using Kernel = GemmUniversal<Sm70, Mainloop, Epilogue, Scheduler>;
-    };
+    using Kernel = GemmUniversal<Sm70, Mainloop, Epilogue, Scheduler>;
+  };
 };
 
-template<Order raster_order>
-using Config_U4_d = Sm70_s884<typename GetOperand<HMMA_884, OPERAND_A, half, kRowMajor, false>::Operand,
-                              Transform_Default,
-                              VoidOperand,
-                              typename GetOperand<HMMA_884, OPERAND_B, uint4_t, kRowMajor, true>::Operand,
-                              Transform_HMMA_SIMT_B,
-                              typename GetOperand<HMMA_884, OPERAND_V, uint32_t, kColMajor, true>::Operand,
-                              kRowMajor,
-                              half,
-                              raster_order,
-                              -1>;
+template <Order raster_order>
+using Config_U4_d = Sm70_s884<
+    typename GetOperand<HMMA_884, OPERAND_A, half, kRowMajor, false>::Operand,
+    Transform_Default, VoidOperand,
+    typename GetOperand<HMMA_884, OPERAND_B, uint4_t, kRowMajor, true>::Operand,
+    Transform_HMMA_SIMT_B,
+    typename GetOperand<HMMA_884, OPERAND_V, uint32_t, kColMajor,
+                        true>::Operand,
+    kRowMajor, half, raster_order, -1>;
 
-template<Order raster_order>
-using Config_U4_d_A8x64Swizzle = Sm70_s884<Operand_A_Swizzle_8x64<half>,
-                                           Transform_Default,
-                                           VoidOperand,
-                                           typename GetOperand<HMMA_884, OPERAND_B, uint4_t, kRowMajor, true>::Operand,
-                                           Transform_HMMA_SIMT_B,
-                                           typename GetOperand<HMMA_884, OPERAND_V, uint32_t, kColMajor, true>::Operand,
-                                           kRowMajor,
-                                           half,
-                                           raster_order,
-                                           -1>;
+template <Order raster_order>
+using Config_U4_d_A8x64Swizzle = Sm70_s884<
+    Operand_A_Swizzle_8x64<half>, Transform_Default, VoidOperand,
+    typename GetOperand<HMMA_884, OPERAND_B, uint4_t, kRowMajor, true>::Operand,
+    Transform_HMMA_SIMT_B,
+    typename GetOperand<HMMA_884, OPERAND_V, uint32_t, kColMajor,
+                        true>::Operand,
+    kRowMajor, half, raster_order, -1>;
 
-template<Order raster_order>
+template <Order raster_order>
 using Config_U4_g = Sm70_s884<Operand_A<half>,           // A
                               Transform_Default,         // tarnsform A
                               VoidOperand,               // U
@@ -138,10 +100,9 @@ using Config_U4_g = Sm70_s884<Operand_A<half>,           // A
                               Operand_V_Pack<uint32_t>,  // V
                               kRowMajor,                 // order_C
                               half,                      // Tc
-                              raster_order,
-                              0>;
+                              raster_order, 0>;
 
-template<Order raster_order, int group_axis = -1>
+template <Order raster_order, int group_axis = -1>
 using Config_MXF4 = Sm70_s884<Operand_A<half>,             // A
                               Transform_Default,           // tarnsform A
                               VoidOperand,                 // U
@@ -150,10 +111,9 @@ using Config_MXF4 = Sm70_s884<Operand_A<half>,             // A
                               Operand_V_Pack<uint8_t>,     // V
                               kRowMajor,                   // order_C
                               half,                        // Tc
-                              raster_order,
-                              group_axis>;
+                              raster_order, group_axis>;
 
-template<Order raster_order, int group_axis = -1>
+template <Order raster_order, int group_axis = -1>
 using Config_NVF4 = Sm70_s884<Operand_A<half>,             // A
                               Transform_Default,           // tarnsform A
                               VoidOperand,                 // U
@@ -162,10 +122,9 @@ using Config_NVF4 = Sm70_s884<Operand_A<half>,             // A
                               Operand_V_Pack<uint16_t>,    // V
                               kRowMajor,                   // order_C
                               half,                        // Tc
-                              raster_order,
-                              group_axis>;
+                              raster_order, group_axis>;
 
-template<Order raster_order, int group_axis = -1>
+template <Order raster_order, int group_axis = -1>
 using Config_E4M3 = Sm70_s884<Operand_A<half>,             // A
                               Transform_Default,           // tarnsform A
                               VoidOperand,                 // U
@@ -174,10 +133,9 @@ using Config_E4M3 = Sm70_s884<Operand_A<half>,             // A
                               Operand_V_Pack<uint16_t>,    // V
                               kRowMajor,                   // order_C
                               half,                        // Tc
-                              raster_order,
-                              group_axis>;
+                              raster_order, group_axis>;
 
-template<Order raster_order, int group_axis = -1>
+template <Order raster_order, int group_axis = -1>
 using Config_F16 = Sm70_s884<Operand_A<half>,       // A
                              Transform_Default,     // tarnsform A
                              VoidOperand,           // U
@@ -186,7 +144,6 @@ using Config_F16 = Sm70_s884<Operand_A<half>,       // A
                              VoidOperand,           // V
                              kRowMajor,             // order_C
                              half,                  // Tc
-                             raster_order,
-                             group_axis>;
+                             raster_order, group_axis>;
 
 }  // namespace turbomind::gemm::sm70_s884

--- a/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/arch/config_sm75_s16816.h
+++ b/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/arch/config_sm75_s16816.h
@@ -21,153 +21,112 @@ namespace sm75_s16816 {
 
 using namespace sm80_s16816;
 
-template<Order mma_iter_order,
-         class A,
-         class TransformA,
-         class U,
-         class B,
-         class TransformB,
-         class V,
-         Order order_C,
-         class Tc,
-         Order raster_order,
-         int   group_axis>
+template <Order mma_iter_order, class A, class TransformA, class U, class B,
+          class TransformB, class V, Order order_C, class Tc,
+          Order raster_order, int group_axis>
 struct Sm75_s16816 {
+  static_assert(A::SmemCopyAtom::K == B::SmemCopyAtom::K);
 
-    static_assert(A::SmemCopyAtom::K == B::SmemCopyAtom::K);
+  static constexpr int SMEM_M = A::SmemCopyAtom::M / A::SmemCopyAtom::kFragNum;
+  static constexpr int SMEM_N = B::SmemCopyAtom::M / B::SmemCopyAtom::kFragNum;
+  static constexpr int SMEM_K = A::SmemCopyAtom::K;
 
-    static constexpr int SMEM_M = A::SmemCopyAtom::M / A::SmemCopyAtom::kFragNum;
-    static constexpr int SMEM_N = B::SmemCopyAtom::M / B::SmemCopyAtom::kFragNum;
-    static constexpr int SMEM_K = A::SmemCopyAtom::K;
+  static constexpr auto MODE_ =
+      group_axis >= 0 ? Striding::kBlocked : Striding::kFlat;
 
-    static constexpr auto MODE_ = group_axis >= 0 ? Striding::kBlocked : Striding::kFlat;
+  static constexpr auto MODE_A = group_axis == 0 ? Striding::kIndexed : MODE_;
+  static constexpr auto MODE_B = group_axis == 1 ? Striding::kIndexed : MODE_;
+  static constexpr auto MODE_C = MODE_;
 
-    static constexpr auto MODE_A = group_axis == 0 ? Striding::kIndexed : MODE_;
-    static constexpr auto MODE_B = group_axis == 1 ? Striding::kIndexed : MODE_;
-    static constexpr auto MODE_C = MODE_;
+  template <int CTA_M, int CTA_N, int CTA_K, int TG_M, int TG_N, int TG_K,
+            class PolicyA, class PolicyB, int Stages, bool SplitK,
+            int GroupSizeU = 1, int GroupSizeV = 1, int TILE_C_M_ = -1,
+            int TILE_C_N_ = -1>
+  struct Type {
+    // Raked partition dont support `Pack_M > 1`
+    using Partition = Blocked<TG_M, TG_N, kColMajor>;
+    using MMA_Map =
+        MMA_Map<CTA_M, CTA_N, CTA_K, SMEM_M, SMEM_N, SMEM_K, Partition, TG_K>;
+    using MMA = Tiled_MMA_v2<SM80_MMA_16x8x16_F32_F16_F16_F32_TN<half>, MMA_Map,
+                             mma_iter_order>;
 
-    template<int CTA_M,
-             int CTA_N,
-             int CTA_K,
-             int TG_M,
-             int TG_N,
-             int TG_K,
-             class PolicyA,
-             class PolicyB,
-             int  Stages,
-             bool SplitK,
-             int  GroupSizeU = 1,
-             int  GroupSizeV = 1,
-             int  TILE_C_M_  = -1,
-             int  TILE_C_N_  = -1>
-    struct Type {
-        // Raked partition dont support `Pack_M > 1`
-        using Partition = Blocked<TG_M, TG_N, kColMajor>;
-        using MMA_Map   = MMA_Map<CTA_M, CTA_N, CTA_K, SMEM_M, SMEM_N, SMEM_K, Partition, TG_K>;
-        using MMA       = Tiled_MMA_v2<SM80_MMA_16x8x16_F32_F16_F16_F32_TN<half>, MMA_Map, mma_iter_order>;
+    using Mainloop =
+        MainloopSm70<MMA, A, IteratorSm70<MODE_A, PolicyA>, TransformA, U,
+                     GroupSizeU, B, IteratorSm70<MODE_B, PolicyB>, TransformB,
+                     V, GroupSizeV, Stages,
+                     true>;  // FusePrefetch_
 
-        using Mainloop = MainloopSm70<MMA,
-                                      A,
-                                      IteratorSm70<MODE_A, PolicyA>,
-                                      TransformA,
-                                      U,
-                                      GroupSizeU,
-                                      B,
-                                      IteratorSm70<MODE_B, PolicyB>,
-                                      TransformB,
-                                      V,
-                                      GroupSizeV,
-                                      Stages,
-                                      true>;  // FusePrefetch_
+    static constexpr int CHUNK_K =
+        std::lcm(std::lcm(GroupSizeU, GroupSizeV), CTA_K);
 
-        static constexpr int CHUNK_K = std::lcm(std::lcm(GroupSizeU, GroupSizeV), CTA_K);
+    using Scheduler = SchedulerSm70<raster_order, CTA_M, CTA_N, CTA_K, CHUNK_K,
+                                    SplitK, group_axis>;
 
-        using Scheduler = SchedulerSm70<raster_order, CTA_M, CTA_N, CTA_K, CHUNK_K, SplitK, group_axis>;
+    static constexpr int TILE_C_M = TILE_C_M_ == -1 ? CTA_M : TILE_C_M_;
+    static constexpr int TILE_C_N = TILE_C_N_ == -1 ? CTA_N : TILE_C_N_;
 
-        static constexpr int TILE_C_M = TILE_C_M_ == -1 ? CTA_M : TILE_C_M_;
-        static constexpr int TILE_C_N = TILE_C_N_ == -1 ? CTA_N : TILE_C_N_;
+    using Epilogue = gemm::Epilogue_<Tc, CTA_M, CTA_N, TILE_C_M, TILE_C_N,
+                                     MMA::kThreadCount, Rearrange<MMA>,
+                                     Operand_C<float, order_C>, MODE_C, SplitK>;
 
-        using Epilogue = gemm::Epilogue_<Tc,
-                                         CTA_M,
-                                         CTA_N,
-                                         TILE_C_M,
-                                         TILE_C_N,
-                                         MMA::kThreadCount,
-                                         Rearrange<MMA>,
-                                         Operand_C<float, order_C>,
-                                         MODE_C,
-                                         SplitK>;
-
-        using Kernel = GemmUniversal<Sm75, Mainloop, Epilogue, Scheduler>;
-    };
+    using Kernel = GemmUniversal<Sm75, Mainloop, Epilogue, Scheduler>;
+  };
 };
 
 // mma_iter_order has no effect yet
 
-template<Order raster_order>  // kColMajor
-using Config_U4_d = Sm75_s16816<kColMajor,
-                                Operand_A<half, kRowMajor>,
-                                Transform_Default,
-                                VoidOperand,
-                                Operand_B_Pack<uint4_t, kColMajor, 2>,
-                                Transform_HMMA_16816<1, 0>,
-                                Operand_UV_Pack<uint32_t, true>,
-                                kRowMajor,
-                                half,
-                                raster_order,
-                                -1>;
+template <Order raster_order>  // kColMajor
+using Config_U4_d =
+    Sm75_s16816<kColMajor, Operand_A<half, kRowMajor>, Transform_Default,
+                VoidOperand, Operand_B_Pack<uint4_t, kColMajor, 2>,
+                Transform_HMMA_16816<1, 0>, Operand_UV_Pack<uint32_t, true>,
+                kRowMajor, half, raster_order, -1>;
 
-template<Order raster_order>  // kColMajor
-using Config_U4_g = Sm75_s16816<kColMajor,
-                                Operand_A<half, kRowMajor>,             // A
-                                Transform_Default,                      // tarnsform A
-                                VoidOperand,                            // U
+template <Order raster_order>  // kColMajor
+using Config_U4_g = Sm75_s16816<kColMajor, Operand_A<half, kRowMajor>,  // A
+                                Transform_Default,  // tarnsform A
+                                VoidOperand,        // U
                                 Operand_B_Pack<uint4_t, kRowMajor, 2>,  // B
-                                Transform_HMMA_16816<1, 0>,             // transform B,
-                                Operand_UV_Pack<uint32_t, true>,        // V
-                                kRowMajor,                              // order_C
-                                half,                                   // Tc
-                                raster_order,
-                                0>;
+                                Transform_HMMA_16816<1, 0>,  // transform B,
+                                Operand_UV_Pack<uint32_t, true>,  // V
+                                kRowMajor,                        // order_C
+                                half,                             // Tc
+                                raster_order, 0>;
 
-template<Order raster_order, int group_axis = -1>
-using Config_MXF4 = Sm75_s16816<kColMajor,
-                                Operand_A_Pack<fp4_e2m1_t, kColMajor, 1>,  // A
-                                Transform_HMMA_16816<0, 1>,                // tarnsform A
-                                Operand_UV_Pack<uint8_t, false>,           // U
-                                Operand_B<half_t, kRowMajor>,              // B
-                                Transform_Default,                         // transform B
-                                VoidOperand,                               // V
-                                kColMajor,                                 // order_C
-                                half_t,                                    // Tc
-                                raster_order,
-                                group_axis>;
+template <Order raster_order, int group_axis = -1>
+using Config_MXF4 =
+    Sm75_s16816<kColMajor, Operand_A_Pack<fp4_e2m1_t, kColMajor, 1>,  // A
+                Transform_HMMA_16816<0, 1>,       // tarnsform A
+                Operand_UV_Pack<uint8_t, false>,  // U
+                Operand_B<half_t, kRowMajor>,     // B
+                Transform_Default,                // transform B
+                VoidOperand,                      // V
+                kColMajor,                        // order_C
+                half_t,                           // Tc
+                raster_order, group_axis>;
 
-template<Order raster_order, int group_axis = -1>
-using Config_E4M3 = Sm75_s16816<kColMajor,
-                                Operand_A_Pack<fp8_e4m3_t, kColMajor, 1>,  // A
-                                Transform_HMMA_16816<0, 1>,                // tarnsform A
-                                Operand_UV_Pack<uint16_t, false>,          // U
-                                Operand_B<half_t, kRowMajor>,              // B
-                                Transform_Default,                         // transform B
-                                VoidOperand,                               // V
-                                kColMajor,                                 // order_C
-                                half_t,                                    // Tc
-                                raster_order,
-                                group_axis>;
+template <Order raster_order, int group_axis = -1>
+using Config_E4M3 =
+    Sm75_s16816<kColMajor, Operand_A_Pack<fp8_e4m3_t, kColMajor, 1>,  // A
+                Transform_HMMA_16816<0, 1>,        // tarnsform A
+                Operand_UV_Pack<uint16_t, false>,  // U
+                Operand_B<half_t, kRowMajor>,      // B
+                Transform_Default,                 // transform B
+                VoidOperand,                       // V
+                kColMajor,                         // order_C
+                half_t,                            // Tc
+                raster_order, group_axis>;
 
-template<Order raster_order, int group_axis = -1>
-using Config_F16 = Sm75_s16816<kColMajor,
-                               Operand_A<half, kRowMajor>,          // A
-                               Transform_Default,                   // tarnsform A
-                               VoidOperand,                         // U
+template <Order raster_order, int group_axis = -1>
+using Config_F16 = Sm75_s16816<kColMajor, Operand_A<half, kRowMajor>,  // A
+                               Transform_Default,  // tarnsform A
+                               VoidOperand,        // U
                                Operand_B_Pack<half, kRowMajor, 1>,  // B
-                               Transform_Default,                   // transform B
-                               VoidOperand,                         // V
-                               kRowMajor,                           // order_C
-                               half,                                // Tc
-                               raster_order,
-                               group_axis>;
+                               Transform_Default,  // transform B
+                               VoidOperand,        // V
+                               kRowMajor,          // order_C
+                               half,               // Tc
+                               raster_order, group_axis>;
 
 }  // namespace sm75_s16816
 

--- a/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/arch/config_sm80_s16816.h
+++ b/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/arch/config_sm80_s16816.h
@@ -19,165 +19,131 @@
 
 namespace turbomind::gemm::sm80_s16816 {
 
-template<class Arch,
-         class Dtype,
-         Order mma_iter_order,
-         class A,
-         class TransformA,
-         class U,
-         class B,
-         class TransformB,
-         class V,
-         Order order_C,
-         class Tc,
-         Order raster_order,
-         int   group_axis>
+template <class Arch, class Dtype, Order mma_iter_order, class A,
+          class TransformA, class U, class B, class TransformB, class V,
+          Order order_C, class Tc, Order raster_order, int group_axis>
 struct Sm80_s16816 {
+  static_assert(A::SmemCopyAtom::K == B::SmemCopyAtom::K);
 
-    static_assert(A::SmemCopyAtom::K == B::SmemCopyAtom::K);
+  static constexpr int SMEM_M = A::SmemCopyAtom::M / A::SmemCopyAtom::kFragNum;
+  static constexpr int SMEM_N = B::SmemCopyAtom::M / B::SmemCopyAtom::kFragNum;
+  static constexpr int SMEM_K = A::SmemCopyAtom::K;
 
-    static constexpr int SMEM_M = A::SmemCopyAtom::M / A::SmemCopyAtom::kFragNum;
-    static constexpr int SMEM_N = B::SmemCopyAtom::M / B::SmemCopyAtom::kFragNum;
-    static constexpr int SMEM_K = A::SmemCopyAtom::K;
+  static constexpr auto MODE_ =
+      group_axis >= 0 ? Striding::kBlocked : Striding::kFlat;
 
-    static constexpr auto MODE_ = group_axis >= 0 ? Striding::kBlocked : Striding::kFlat;
+  static constexpr auto MODE_A = group_axis == 0 ? Striding::kIndexed : MODE_;
+  static constexpr auto MODE_B = group_axis == 1 ? Striding::kIndexed : MODE_;
+  static constexpr auto MODE_C = MODE_;
 
-    static constexpr auto MODE_A = group_axis == 0 ? Striding::kIndexed : MODE_;
-    static constexpr auto MODE_B = group_axis == 1 ? Striding::kIndexed : MODE_;
-    static constexpr auto MODE_C = MODE_;
+  template <int CTA_M, int CTA_N, int CTA_K, int TG_M, int TG_N, int TG_K,
+            class PolicyA, class PolicyB, int Stages, bool SplitK,
+            int GroupSizeU = 1, int GroupSizeV = 1, int TILE_C_M_ = -1,
+            int TILE_C_N_ = -1, bool FusePrefetch = true>
 
-    template<int CTA_M,
-             int CTA_N,
-             int CTA_K,
-             int TG_M,
-             int TG_N,
-             int TG_K,
-             class PolicyA,
-             class PolicyB,
-             int  Stages,
-             bool SplitK,
-             int  GroupSizeU   = 1,
-             int  GroupSizeV   = 1,
-             int  TILE_C_M_    = -1,
-             int  TILE_C_N_    = -1,
-             bool FusePrefecth = true>
+  struct Type {
+    // Raked partition dont support `Pack_M > 1`
+    using Partition = Blocked<TG_M, TG_N, kColMajor>;
+    using MMA_Map =
+        MMA_Map<CTA_M, CTA_N, CTA_K, SMEM_M, SMEM_N, SMEM_K, Partition, TG_K>;
+    using MMA = Tiled_MMA_v2<SM80_MMA_16x8x16_F32_F16_F16_F32_TN<Dtype>,
+                             MMA_Map, mma_iter_order>;
 
-    struct Type {
+    using Mainloop =
+        MainloopSm80_v2<MMA, A, IteratorSm80<MODE_A, PolicyA>, TransformA, U,
+                        GroupSizeU, B, IteratorSm80<MODE_B, PolicyB>,
+                        TransformB, V, GroupSizeV, Stages, FusePrefetch>;
 
-        // Raked partition dont support `Pack_M > 1`
-        using Partition = Blocked<TG_M, TG_N, kColMajor>;
-        using MMA_Map   = MMA_Map<CTA_M, CTA_N, CTA_K, SMEM_M, SMEM_N, SMEM_K, Partition, TG_K>;
-        using MMA       = Tiled_MMA_v2<SM80_MMA_16x8x16_F32_F16_F16_F32_TN<Dtype>, MMA_Map, mma_iter_order>;
+    static constexpr int CHUNK_K =
+        std::lcm(std::lcm(GroupSizeU, GroupSizeV), CTA_K);
 
-        using Mainloop = MainloopSm80_v2<MMA,
-                                         A,
-                                         IteratorSm80<MODE_A, PolicyA>,
-                                         TransformA,
-                                         U,
-                                         GroupSizeU,
-                                         B,
-                                         IteratorSm80<MODE_B, PolicyB>,
-                                         TransformB,
-                                         V,
-                                         GroupSizeV,
-                                         Stages,
-                                         FusePrefecth>;
+    using Scheduler = SchedulerSm70<raster_order, CTA_M, CTA_N, CTA_K, CHUNK_K,
+                                    SplitK, group_axis>;
 
-        static constexpr int CHUNK_K = std::lcm(std::lcm(GroupSizeU, GroupSizeV), CTA_K);
+    static constexpr int TILE_C_M = TILE_C_M_ == -1 ? CTA_M : TILE_C_M_;
+    static constexpr int TILE_C_N = TILE_C_N_ == -1 ? CTA_N : TILE_C_N_;
 
-        using Scheduler = SchedulerSm70<raster_order, CTA_M, CTA_N, CTA_K, CHUNK_K, SplitK, group_axis>;
+    using Epilogue = gemm::Epilogue_<Tc, CTA_M, CTA_N, TILE_C_M, TILE_C_N,
+                                     MMA::kThreadCount, Rearrange<MMA>,
+                                     Operand_C<float, order_C>, MODE_C, SplitK>;
 
-        static constexpr int TILE_C_M = TILE_C_M_ == -1 ? CTA_M : TILE_C_M_;
-        static constexpr int TILE_C_N = TILE_C_N_ == -1 ? CTA_N : TILE_C_N_;
-
-        using Epilogue = gemm::Epilogue_<Tc,
-                                         CTA_M,
-                                         CTA_N,
-                                         TILE_C_M,
-                                         TILE_C_N,
-                                         MMA::kThreadCount,
-                                         Rearrange<MMA>,
-                                         Operand_C<float, order_C>,
-                                         MODE_C,
-                                         SplitK>;
-
-        using Kernel = GemmUniversal<Arch, Mainloop, Epilogue, Scheduler>;
-    };
+    using Kernel = GemmUniversal<Arch, Mainloop, Epilogue, Scheduler>;
+  };
 };
 
-template<class Arch, class T, Order raster_order>  // kColMajor
+template <class Arch, class T, Order raster_order>  // kColMajor
 using Config_U4_d = Sm80_s16816<Arch,
-                                T,                                      // mma dtype
-                                kColMajor,                              // mma iter order
-                                Operand_A<half, kRowMajor>,             // A
-                                Transform_Default,                      // tarnsform A
-                                VoidOperand,                            // U
+                                T,                           // mma dtype
+                                kColMajor,                   // mma iter order
+                                Operand_A<half, kRowMajor>,  // A
+                                Transform_Default,           // tarnsform A
+                                VoidOperand,                 // U
                                 Operand_B_Pack<uint4_t, kColMajor, 2>,  // B
-                                Transform_HMMA_16816<1, 0>,             // transform B
-                                Operand_UV_Pack<uint32_t, true>,        // V
-                                kRowMajor,                              // order_C
-                                half,                                   // Tc
-                                raster_order,                           // raster order
-                                -1>;                                    // group axis
+                                Transform_HMMA_16816<1, 0>,       // transform B
+                                Operand_UV_Pack<uint32_t, true>,  // V
+                                kRowMajor,                        // order_C
+                                half,                             // Tc
+                                raster_order,  // raster order
+                                -1>;           // group axis
 
-template<class Arch, class T, Order raster_order>  // kColMajor
+template <class Arch, class T, Order raster_order>  // kColMajor
 using Config_U4_g = Sm80_s16816<Arch,
-                                T,                                      // mma dtype
-                                kColMajor,                              // mma iter order
-                                Operand_A<T, kRowMajor>,                // A
-                                Transform_Default,                      // tarnsform A
-                                VoidOperand,                            // U
+                                T,                        // mma dtype
+                                kColMajor,                // mma iter order
+                                Operand_A<T, kRowMajor>,  // A
+                                Transform_Default,        // tarnsform A
+                                VoidOperand,              // U
                                 Operand_B_Pack<uint4_t, kRowMajor, 2>,  // B
-                                Transform_HMMA_16816<1, 0>,             // transform B,
-                                Operand_UV_Pack<uint32_t, true>,        // V
-                                kRowMajor,                              // order_C
-                                T,                                      // Tc
-                                raster_order,                           // raster order
-                                0>;                                     // group axis
+                                Transform_HMMA_16816<1, 0>,  // transform B,
+                                Operand_UV_Pack<uint32_t, true>,  // V
+                                kRowMajor,                        // order_C
+                                T,                                // Tc
+                                raster_order,  // raster order
+                                0>;            // group axis
 
-template<class Arch, class T, int N, Order raster_order, int group_axis = -1>
+template <class Arch, class T, int N, Order raster_order, int group_axis = -1>
 using Config_MXF4 = Sm80_s16816<Arch,
-                                T,                                         // mma dtype
-                                kRowMajor,                                 // mma iter order
+                                T,          // mma dtype
+                                kRowMajor,  // mma iter order
                                 Operand_A_Pack<fp4_e2m1_t, kColMajor, 1>,  // A
-                                Transform_HMMA_16816<0, 1>,                // tarnsform A
-                                Operand_UV_Pack<uint8_t, false>,           // U
-                                Operand_B<T, kRowMajor, N>,                // B
-                                Transform_Default,                         // transform B
-                                VoidOperand,                               // V
-                                kColMajor,                                 // order_C
-                                T,                                         // Tc
-                                raster_order,                              // raster order
-                                group_axis>;                               // group axis
+                                Transform_HMMA_16816<0, 1>,       // tarnsform A
+                                Operand_UV_Pack<uint8_t, false>,  // U
+                                Operand_B<T, kRowMajor, N>,       // B
+                                Transform_Default,                // transform B
+                                VoidOperand,                      // V
+                                kColMajor,                        // order_C
+                                T,                                // Tc
+                                raster_order,  // raster order
+                                group_axis>;   // group axis
 
-template<class Arch, class T, int N, Order raster_order, int group_axis = -1>
+template <class Arch, class T, int N, Order raster_order, int group_axis = -1>
 using Config_E4M3 = Sm80_s16816<Arch,
-                                T,                                         // mma dtype
-                                kRowMajor,                                 // mma iter order
+                                T,          // mma dtype
+                                kRowMajor,  // mma iter order
                                 Operand_A_Pack<fp8_e4m3_t, kColMajor, 1>,  // A
-                                Transform_HMMA_16816<0, 1>,                // tarnsform A
-                                Operand_UV_Pack<uint16_t, false>,          // U
-                                Operand_B<T, kRowMajor, N>,                // B
-                                Transform_Default,                         // transform B
-                                VoidOperand,                               // V
-                                kColMajor,                                 // order_C
-                                T,                                         // Tc
-                                raster_order,                              // raster order
-                                group_axis>;                               // group axis
+                                Transform_HMMA_16816<0, 1>,  // tarnsform A
+                                Operand_UV_Pack<uint16_t, false>,  // U
+                                Operand_B<T, kRowMajor, N>,        // B
+                                Transform_Default,  // transform B
+                                VoidOperand,        // V
+                                kColMajor,          // order_C
+                                T,                  // Tc
+                                raster_order,       // raster order
+                                group_axis>;        // group axis
 
-template<class Arch, class T, Order raster_order>
+template <class Arch, class T, Order raster_order>
 using Config_F16_g = Sm80_s16816<Arch,
-                                 T,                                // mma dtype
-                                 kColMajor,                        // mma iter order
-                                 Operand_A<T, kRowMajor>,          // A
-                                 Transform_Default,                // tarnsform A
-                                 VoidOperand,                      // U
+                                 T,                        // mma dtype
+                                 kColMajor,                // mma iter order
+                                 Operand_A<T, kRowMajor>,  // A
+                                 Transform_Default,        // tarnsform A
+                                 VoidOperand,              // U
                                  Operand_B_Pack<T, kRowMajor, 1>,  // B
-                                 Transform_Default,                // transform B
-                                 VoidOperand,                      // V
-                                 kRowMajor,                        // order_C
-                                 T,                                // Tc
-                                 raster_order,                     // raster order
-                                 0>;                               // group axis
+                                 Transform_Default,  // transform B
+                                 VoidOperand,        // V
+                                 kRowMajor,          // order_C
+                                 T,                  // Tc
+                                 raster_order,       // raster order
+                                 0>;                 // group axis
 
 }  // namespace turbomind::gemm::sm80_s16816

--- a/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/arch/mma_simt.h
+++ b/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/arch/mma_simt.h
@@ -9,63 +9,56 @@
 
 namespace turbomind::gemm {
 
-template<class T>
+template <class T>
 struct MMA_SIMT {
-    static constexpr int M = simt::OP_M;
-    static constexpr int N = simt::OP_N;
-    static constexpr int K = simt::OP_K;
+  static constexpr int M = simt::OP_M;
+  static constexpr int N = simt::OP_N;
+  static constexpr int K = simt::OP_K;
 
-    static constexpr int kThreadCount = 32;
+  static constexpr int kThreadCount = 32;
 
-    static constexpr auto kOpClass = OpClass::kSIMT;
+  static constexpr auto kOpClass = OpClass::kSIMT;
 
-    using FragA = Array<T, K>;
-    using FragB = Array<T, K>;
-    using FragC = Array<float, 1>;
+  using FragA = Array<T, K>;
+  using FragB = Array<T, K>;
+  using FragC = Array<float, 1>;
 
-    using OffsetC = Array<int2, 1>;
-    using FragC_  = FragC[1];
+  using OffsetC = Array<int2, 1>;
+  using FragC_ = FragC[1];
 
-    __device__ static void fma(FragC& d, const FragA& a, const FragB& b, const FragC& c)
-    {
-        PRAGMA_UNROLL
-        for (int k = 0; k < K; ++k) {
-            d[0] = c[0] + float(a[k]) * float(b[k]);
-        }
-
-        // PRAGMA_UNROLL
-        // for (int k = 0; k < K; ++k) {
-        //     d[0] = c[0] + float(a[k] * b[k]);
-        // }
-
-        // T acc{};
-        // PRAGMA_UNROLL
-        // for (int k = 0; k < K; ++k) {
-        //     acc += a[k] * b[k];
-        // }
-        // d[0] = c[0] + float(acc);
+  __device__ static void fma(FragC& d, const FragA& a, const FragB& b,
+                             const FragC& c) {
+    PRAGMA_UNROLL
+    for (int k = 0; k < K; ++k) {
+      d[0] = c[0] + float(a[k]) * float(b[k]);
     }
 
-    __device__ static constexpr OffsetC static_offset_C()
-    {
-        return {};
-    }
+    // PRAGMA_UNROLL
+    // for (int k = 0; k < K; ++k) {
+    //     d[0] = c[0] + float(a[k] * b[k]);
+    // }
 
-    __device__ static int2 thread_offset_C()  // -> (m,n)
-    {
-        const int lane_id = threadIdx.x % WARP_SIZE;
-        return {lane_id / N, lane_id % N};
-    }
+    // T acc{};
+    // PRAGMA_UNROLL
+    // for (int k = 0; k < K; ++k) {
+    //     acc += a[k] * b[k];
+    // }
+    // d[0] = c[0] + float(acc);
+  }
 
-    __device__ static void ReshapeC(const FragC& c, FragC_& c_)
-    {
-        c_[0] = c;
-    }
+  __device__ static constexpr OffsetC static_offset_C() { return {}; }
 
-    __device__ static int get_group_id(int thread_idx)
-    {
-        return thread_idx / WARP_SIZE;
-    }
+  __device__ static int2 thread_offset_C()  // -> (m,n)
+  {
+    const int lane_id = threadIdx.x % WARP_SIZE;
+    return {lane_id / N, lane_id % N};
+  }
+
+  __device__ static void ReshapeC(const FragC& c, FragC_& c_) { c_[0] = c; }
+
+  __device__ static int get_group_id(int thread_idx) {
+    return thread_idx / WARP_SIZE;
+  }
 };
 
 }  // namespace turbomind::gemm

--- a/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/arch/mma_sm70.h
+++ b/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/arch/mma_sm70.h
@@ -10,67 +10,66 @@
 namespace turbomind::gemm {
 
 struct SM70_MMA_884 {
-    // static constexpr int M = 16;
-    // static constexpr int N = 16;
-    static constexpr int M = 8;
-    static constexpr int N = 32;
-    static constexpr int K = 8;
+  // static constexpr int M = 16;
+  // static constexpr int N = 16;
+  static constexpr int M = 8;
+  static constexpr int N = 32;
+  static constexpr int K = 8;
 
-    static constexpr int kThreadCount = 32;
+  static constexpr int kThreadCount = 32;
 
-    static constexpr auto kOpClass = OpClass::kMMA_s884;
+  static constexpr auto kOpClass = OpClass::kMMA_s884;
 
-    using FragA = Array<half, K>;
-    using FragB = Array<half, K>;
-    using FragC = Array<float, 8>;
+  using FragA = Array<half, K>;
+  using FragB = Array<half, K>;
+  using FragC = Array<float, 8>;
 
-    using OffsetC = Array<int2, 4>;
-    using FragC_  = Array<float, 2>[4];
+  using OffsetC = Array<int2, 4>;
+  using FragC_ = Array<float, 2>[4];
 
-    __device__ static void fma(FragC& d, const FragA& a, const FragB& b, const FragC& c)
-    {
-        mma_m8n8k4_row_col(d, (const Array<half, 4>&)a[0], (const Array<half, 4>&)b[0], (FragC&)c);
-        if constexpr (K == 8) {
-            mma_m8n8k4_row_col(d, (const Array<half, 4>&)a[4], (const Array<half, 4>&)b[4], (FragC&)d);
-        }
+  __device__ static void fma(FragC& d, const FragA& a, const FragB& b,
+                             const FragC& c) {
+    mma_m8n8k4_row_col(d, (const Array<half, 4>&)a[0],
+                       (const Array<half, 4>&)b[0], (FragC&)c);
+    if constexpr (K == 8) {
+      mma_m8n8k4_row_col(d, (const Array<half, 4>&)a[4],
+                         (const Array<half, 4>&)b[4], (FragC&)d);
     }
+  }
 
-    __device__ static constexpr OffsetC static_offset_C()
-    {
-        OffsetC r{};
-        PRAGMA_UNROLL
-        for (int n = 0; n < 2; ++n) {
-            PRAGMA_UNROLL
-            for (int m = 0; m < 2; ++m) {
-                r[n * 2 + m] = int2{m * 2, n * 4};
-            }
-        }
-        return r;
+  __device__ static constexpr OffsetC static_offset_C() {
+    OffsetC r{};
+    PRAGMA_UNROLL
+    for (int n = 0; n < 2; ++n) {
+      PRAGMA_UNROLL
+      for (int m = 0; m < 2; ++m) {
+        r[n * 2 + m] = int2{m * 2, n * 4};
+      }
     }
+    return r;
+  }
 
-    __device__ static int2 thread_offset_C()  // -> (m,n)
-    {
-        const int lane_id = threadIdx.x % WARP_SIZE;
-        // return {
-        //     (lane_id & 8) * 1 + (lane_id & 1) + lane_id / 16 * 4,
-        //     (lane_id & 4) * 2 + (lane_id & 2),
-        // };
-        return {(lane_id & 1) + (lane_id / 16) * 4,  //
-                (lane_id & 2) + (lane_id & 12) * 2};
-    }
+  __device__ static int2 thread_offset_C()  // -> (m,n)
+  {
+    const int lane_id = threadIdx.x % WARP_SIZE;
+    // return {
+    //     (lane_id & 8) * 1 + (lane_id & 1) + lane_id / 16 * 4,
+    //     (lane_id & 4) * 2 + (lane_id & 2),
+    // };
+    return {(lane_id & 1) + (lane_id / 16) * 4,  //
+            (lane_id & 2) + (lane_id & 12) * 2};
+  }
 
-    __device__ static void ReshapeC(const FragC& c, FragC_& c_)
-    {
-        PRAGMA_UNROLL
-        for (int m = 0; m < 4; ++m) {
-            c_[m] = (Array<float, 2>&)c[m * 2];
-        }
+  __device__ static void ReshapeC(const FragC& c, FragC_& c_) {
+    PRAGMA_UNROLL
+    for (int m = 0; m < 4; ++m) {
+      c_[m] = (Array<float, 2>&)c[m * 2];
     }
+  }
 
-    __device__ static int get_group_id(int thread_idx)
-    {
-        return thread_idx / WARP_SIZE;
-    }
+  __device__ static int get_group_id(int thread_idx) {
+    return thread_idx / WARP_SIZE;
+  }
 };
 
 }  // namespace turbomind::gemm

--- a/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/arch/mma_sm80.h
+++ b/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/arch/mma_sm80.h
@@ -9,68 +9,66 @@
 
 namespace turbomind::gemm {
 
-template<class T>
+template <class T>
 struct SM80_MMA_16x8x16_F32_F16_F16_F32_TN {
-    static constexpr int M = 16;
-    static constexpr int N = 8;
-    static constexpr int K = 16;
+  static constexpr int M = 16;
+  static constexpr int N = 8;
+  static constexpr int K = 16;
 
-    static constexpr int kThreadCount = 32;
+  static constexpr int kThreadCount = 32;
 
-    static constexpr auto kOpClass = OpClass::kMMA_s16816;
+  static constexpr auto kOpClass = OpClass::kMMA_s16816;
 
-    using FragA = Array<T, 8>;
-    using FragB = Array<T, 4>;
-    using FragC = Array<float, 4>;
+  using FragA = Array<T, 8>;
+  using FragB = Array<T, 4>;
+  using FragC = Array<float, 4>;
 
-    using OffsetC = Array<int2, 2>;  // (m, n)
-    using FragC_  = Array<float, 2>[2];
+  using OffsetC = Array<int2, 2>;  // (m, n)
+  using FragC_ = Array<float, 2>[2];
 
-    __device__ static void fma(FragC& d, const FragA& a, const FragB& b, const FragC& c)
-    {
-        mma_m16n8k16_row_col(d, a, b, (FragC&)c);
+  __device__ static void fma(FragC& d, const FragA& a, const FragB& b,
+                             const FragC& c) {
+    mma_m16n8k16_row_col(d, a, b, (FragC&)c);
+  }
+
+  __device__ static constexpr OffsetC static_offset_C() {
+    return {int2{0, 0}, int2{8, 0}};
+  }
+
+  __device__ static int2 thread_offset_C()  // -> (m,n)
+  {
+    const int lane_id = threadIdx.x % WARP_SIZE;
+    return {lane_id / 4, lane_id % 4 * 2};
+  }
+
+  __device__ static void ReshapeC(const FragC& c, FragC_& c_) {
+    PRAGMA_UNROLL
+    for (int m = 0; m < 2; ++m) {
+      c_[m] = (Array<float, 2>&)c[m * 2];
     }
+  }
 
-    __device__ static constexpr OffsetC static_offset_C()
-    {
-        return {int2{0, 0}, int2{8, 0}};
-    }
-
-    __device__ static int2 thread_offset_C()  // -> (m,n)
-    {
-        const int lane_id = threadIdx.x % WARP_SIZE;
-        return {lane_id / 4, lane_id % 4 * 2};
-    }
-
-    __device__ static void ReshapeC(const FragC& c, FragC_& c_)
-    {
-        PRAGMA_UNROLL
-        for (int m = 0; m < 2; ++m) {
-            c_[m] = (Array<float, 2>&)c[m * 2];
-        }
-    }
-
-    __device__ static int get_group_id(int thread_idx)
-    {
-        return thread_idx / WARP_SIZE;
-    }
+  __device__ static int get_group_id(int thread_idx) {
+    return thread_idx / WARP_SIZE;
+  }
 };
 
 // This is not used yet
-template<class T>
-struct SM75_MMA_16x8x8_F32_F16_F16_F32_TN: SM80_MMA_16x8x16_F32_F16_F16_F32_TN<T> {
-    static constexpr int M = 16;
-    static constexpr int N = 8;
-    static constexpr int K = 8;
+template <class T>
+struct SM75_MMA_16x8x8_F32_F16_F16_F32_TN
+    : SM80_MMA_16x8x16_F32_F16_F16_F32_TN<T> {
+  static constexpr int M = 16;
+  static constexpr int N = 8;
+  static constexpr int K = 8;
 
-    using FragA = Array<T, 4>;
-    using FragB = Array<T, 2>;
-    using FragC = Array<float, 4>;
+  using FragA = Array<T, 4>;
+  using FragB = Array<T, 2>;
+  using FragC = Array<float, 4>;
 
-    __device__ static void fma(FragC& d, const FragA& a, const FragB& b, const FragC& c)
-    {
-        mma_m16n8k8_row_col(d, a, b, (FragC&)c);
-    }
+  __device__ static void fma(FragC& d, const FragA& a, const FragB& b,
+                             const FragC& c) {
+    mma_m16n8k8_row_col(d, a, b, (FragC&)c);
+  }
 };
 
 }  // namespace turbomind::gemm

--- a/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/arch/operand_simt.h
+++ b/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/arch/operand_simt.h
@@ -16,160 +16,157 @@ namespace turbomind::gemm {
 namespace simt {
 
 struct GetSmemLayout {
-    template<int M, int K>
-    static constexpr auto apply(pair<M, K>)
-    {
-        return SmemLayoutV2<M, K>{};
-    }
+  template <int M, int K>
+  static constexpr auto apply(pair<M, K>) {
+    return SmemLayoutV2<M, K>{};
+  }
 };
 
-template<class T, int K>
+template <class T, int K>
 struct Operand_A {
-    using Dtype = T;
+  using Dtype = T;
 
-    static constexpr Pack  kPack  = 0;
-    static constexpr Order kOrder = kRowMajor;
+  static constexpr Pack kPack = 0;
+  static constexpr Order kOrder = kRowMajor;
 
-    using SmemCopyAtom = SmemCopy_MMA_SIMT_A<T, K>;
+  using SmemCopyAtom = SmemCopy_MMA_SIMT_A<T, K>;
 
-    using GetSmemLayout = GetSmemLayout;
-    using GetGmemIter   = GetGmemIter;
+  using GetSmemLayout = GetSmemLayout;
+  using GetGmemIter = GetGmemIter;
 };
 
-template<class T, int K>
+template <class T, int K>
 struct Operand_B {
-    using Dtype = T;
+  using Dtype = T;
 
-    static constexpr Pack  kPack  = 0;
-    static constexpr Order kOrder = kRowMajor;
+  static constexpr Pack kPack = 0;
+  static constexpr Order kOrder = kRowMajor;
 
-    using SmemCopyAtom = SmemCopy_MMA_SIMT_B<T, K>;
+  using SmemCopyAtom = SmemCopy_MMA_SIMT_B<T, K>;
 
-    using GetSmemLayout = GetSmemLayout;
-    using GetGmemIter   = GetGmemIter;
+  using GetSmemLayout = GetSmemLayout;
+  using GetGmemIter = GetGmemIter;
 };
 
-template<Order order>
+template <Order order>
 struct _GetSmemLayoutC {
-    template<int M, int N>
-    static constexpr auto apply(pair<M, N>)
-    {
-        constexpr auto cs = mk2cs<order>(M, N);
-        return SmemLayoutV2<cs.y, cs.x, 1, 1>{};
-    }
+  template <int M, int N>
+  static constexpr auto apply(pair<M, N>) {
+    constexpr auto cs = mk2cs<order>(M, N);
+    return SmemLayoutV2<cs.y, cs.x, 1, 1>{};
+  }
 };
 
-template<Order order>
+template <Order order>
 struct _GetThreadMapC {
-    template<int M, int N, int THREADS>
-    static constexpr auto apply(pair<M, N>, constant<THREADS>)
-    {
-        constexpr auto cs    = mk2cs<order>(M, N);
-        constexpr int  WARPS = THREADS / WARP_SIZE;
+  template <int M, int N, int THREADS>
+  static constexpr auto apply(pair<M, N>, constant<THREADS>) {
+    constexpr auto cs = mk2cs<order>(M, N);
+    constexpr int WARPS = THREADS / WARP_SIZE;
 
-        return ThreadMap_V2<cs.x, cs.y, 4, Raked, WARPS>{};
-    }
+    return ThreadMap_V2<cs.x, cs.y, 4, Raked, WARPS>{};
+  }
 };
 
-template<class T, Order order>
+template <class T, Order order>
 struct Operand_C {
-    using Dtype = T;
+  using Dtype = T;
 
-    static constexpr Order kOrder = order;
+  static constexpr Order kOrder = order;
 
-    using GetSmemLayout = _GetSmemLayoutC<order>;
-    using GetThreadMap  = _GetThreadMapC<order>;
+  using GetSmemLayout = _GetSmemLayoutC<order>;
+  using GetThreadMap = _GetThreadMapC<order>;
 };
 
-template<class T>
+template <class T>
 struct Operand_V {
-    using Dtype = T;
+  using Dtype = T;
 
-    static constexpr Pack  kPack  = 0;
-    static constexpr Order kOrder = kColMajor;
+  static constexpr Pack kPack = 0;
+  static constexpr Order kOrder = kColMajor;
 
-    using SmemCopyAtom = SmemCopy_MMA_SIMT_V<T, 1>;
+  using SmemCopyAtom = SmemCopy_MMA_SIMT_V<T, 1>;
 
-    struct GetSmemLayout {  // m-major
-        template<int M, int K>
-        static constexpr auto apply(pair<M, K>)
-        {
-            return SmemLayoutV2<K, M>{};
-        }
-    };
+  struct GetSmemLayout {  // m-major
+    template <int M, int K>
+    static constexpr auto apply(pair<M, K>) {
+      return SmemLayoutV2<K, M>{};
+    }
+  };
 
-    using GetGmemIter = GetGmemIter;
+  using GetGmemIter = GetGmemIter;
 };
 
 struct GetSmemLayout_Pack {
-    template<int M, int K>
-    static constexpr auto apply(pair<M, K>)
-    {
-        return SmemLayoutV2<M, K>{};
-    }
+  template <int M, int K>
+  static constexpr auto apply(pair<M, K>) {
+    return SmemLayoutV2<M, K>{};
+  }
 };
 
-template<class T, int K>
+template <class T, int K>
 struct Operand_B_Pack {
-    using Dtype = T;
+  using Dtype = T;
 
-    static constexpr int Pack_M = 1;
+  static constexpr int Pack_M = 1;
 
-    static constexpr Pack  kPack  = HMMA_SIMT | OPERAND_B | Pack_M;
-    static constexpr Order kOrder = kRowMajor;
+  static constexpr Pack kPack = HMMA_SIMT | OPERAND_B | Pack_M;
+  static constexpr Order kOrder = kRowMajor;
 
-    using SmemCopyAtom  = SmemCopyAtom_Pack_v3<T, typename Operand_B<T, K>::SmemCopyAtom, kRowMajor, Pack_M>;
-    using GetSmemLayout = GetSmemLayout_Pack;
-    using GetGmemIter   = GetGmemIter;
+  using SmemCopyAtom =
+      SmemCopyAtom_Pack_v3<T, typename Operand_B<T, K>::SmemCopyAtom, kRowMajor,
+                           Pack_M>;
+  using GetSmemLayout = GetSmemLayout_Pack;
+  using GetGmemIter = GetGmemIter;
 };
 
-template<class T>
+template <class T>
 struct Operand_V_Pack {
-    using Dtype = T;
+  using Dtype = T;
 
-    static constexpr int Pack_M = 1;
+  static constexpr int Pack_M = 1;
 
-    static constexpr Pack  kPack  = HMMA_SIMT | OPERAND_V | Pack_M;
-    static constexpr Order kOrder = kColMajor;
+  static constexpr Pack kPack = HMMA_SIMT | OPERAND_V | Pack_M;
+  static constexpr Order kOrder = kColMajor;
 
-    using SmemCopyAtom = SmemCopyAtom_Pack_v3<T, SmemCopy_MMA_SIMT_V<T, OP_K>, kColMajor, Pack_M>;
+  using SmemCopyAtom =
+      SmemCopyAtom_Pack_v3<T, SmemCopy_MMA_SIMT_V<T, OP_K>, kColMajor, Pack_M>;
 
-    struct GetSmemLayout {  // m-major
-        template<int M, int K>
-        static constexpr auto apply(pair<M, K>)
-        {
-            return SmemLayoutV2<K, M>{};
-        }
-    };
+  struct GetSmemLayout {  // m-major
+    template <int M, int K>
+    static constexpr auto apply(pair<M, K>) {
+      return SmemLayoutV2<K, M>{};
+    }
+  };
 
-    using GetGmemIter = GetGmemIter;
+  using GetGmemIter = GetGmemIter;
 };
 
 }  // namespace simt
 
-template<class T>
-struct GetOperand<HMMA_SIMT, OPERAND_A, T, kRowMajor, false>: std::true_type {
-    using Operand = simt::Operand_A<T, simt::OP_K>;
+template <class T>
+struct GetOperand<HMMA_SIMT, OPERAND_A, T, kRowMajor, false> : std::true_type {
+  using Operand = simt::Operand_A<T, simt::OP_K>;
 };
 
-template<class T>
-struct GetOperand<HMMA_SIMT, OPERAND_B, T, kRowMajor, false>: std::true_type {
-    using Operand = simt::Operand_B<T, simt::OP_K>;
+template <class T>
+struct GetOperand<HMMA_SIMT, OPERAND_B, T, kRowMajor, false> : std::true_type {
+  using Operand = simt::Operand_B<T, simt::OP_K>;
 };
 
-template<class T>
-struct GetOperand<HMMA_SIMT, OPERAND_V, T, kColMajor, false>: std::true_type {
-    using Operand = simt::Operand_V<T>;
+template <class T>
+struct GetOperand<HMMA_SIMT, OPERAND_V, T, kColMajor, false> : std::true_type {
+  using Operand = simt::Operand_V<T>;
 };
 
-template<class T>
-struct GetOperand<HMMA_SIMT, OPERAND_B, T, kRowMajor, true>: std::true_type {
-    using Operand = simt::Operand_B_Pack<T, simt::OP_K>;
+template <class T>
+struct GetOperand<HMMA_SIMT, OPERAND_B, T, kRowMajor, true> : std::true_type {
+  using Operand = simt::Operand_B_Pack<T, simt::OP_K>;
 };
 
-template<class T>
-struct GetOperand<HMMA_SIMT, OPERAND_V, T, kColMajor, true>: std::true_type {
-    using Operand = simt::Operand_V_Pack<T>;
+template <class T>
+struct GetOperand<HMMA_SIMT, OPERAND_V, T, kColMajor, true> : std::true_type {
+  using Operand = simt::Operand_V_Pack<T>;
 };
 
 }  // namespace turbomind::gemm

--- a/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/arch/operand_sm70_s884.h
+++ b/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/arch/operand_sm70_s884.h
@@ -14,168 +14,164 @@ namespace turbomind::gemm {
 
 namespace sm70_s884 {
 
-template<Order order>
+template <Order order>
 struct GetSmemLayout {
-    template<int M, int K>
-    static constexpr auto apply(pair<M, K>)
-    {
-        constexpr int2 cs = mk2cs<order>(M, K);
-        return SmemLayoutV2<cs.y, cs.x, 1, 1>{};
-    }
+  template <int M, int K>
+  static constexpr auto apply(pair<M, K>) {
+    constexpr int2 cs = mk2cs<order>(M, K);
+    return SmemLayoutV2<cs.y, cs.x, 1, 1>{};
+  }
 };
 
-template<class T>
+template <class T>
 struct Operand_A {
-    using Dtype = T;
+  using Dtype = T;
 
-    static constexpr Pack  kPack  = 0;
-    static constexpr Order kOrder = kRowMajor;
+  static constexpr Pack kPack = 0;
+  static constexpr Order kOrder = kRowMajor;
 
-    using SmemCopyAtom = SmemCopy_MMA_884_A<T>;
+  using SmemCopyAtom = SmemCopy_MMA_884_A<T>;
 
-    using GetSmemLayout = GetSmemLayout<kOrder>;
-    using GetGmemIter   = GetGmemIter;
+  using GetSmemLayout = GetSmemLayout<kOrder>;
+  using GetGmemIter = GetGmemIter;
 };
 
-template<class T>
-struct Operand_A_Swizzle_8x64: Operand_A<T> {
-    struct GetSmemLayout {
-        template<int M, int K>
-        static constexpr auto apply(pair<M, K>)
-        {
-            static_assert(M == 8 && K == 64);
-            return SmemLayoutV2<M, K, M, K, Swizzle<3, 3, 3>>{};
-        }
-    };
+template <class T>
+struct Operand_A_Swizzle_8x64 : Operand_A<T> {
+  struct GetSmemLayout {
+    template <int M, int K>
+    static constexpr auto apply(pair<M, K>) {
+      static_assert(M == 8 && K == 64);
+      return SmemLayoutV2<M, K, M, K, Swizzle<3, 3, 3>>{};
+    }
+  };
 };
 
-template<class T>
+template <class T>
 struct Operand_B {
-    using Dtype = T;
+  using Dtype = T;
 
-    static constexpr Pack  kPack  = 0;
-    static constexpr Order kOrder = kRowMajor;  // (n,k)
+  static constexpr Pack kPack = 0;
+  static constexpr Order kOrder = kRowMajor;  // (n,k)
 
-    using SmemCopyAtom = SmemCopy_MMA_884_B<T>;
+  using SmemCopyAtom = SmemCopy_MMA_884_B<T>;
 
-    using GetSmemLayout = GetSmemLayout<kOrder>;
-    using GetGmemIter   = GetGmemIter;
+  using GetSmemLayout = GetSmemLayout<kOrder>;
+  using GetGmemIter = GetGmemIter;
 };
 
-template<class T>
+template <class T>
 struct Operand_V {
-    using Dtype = T;
+  using Dtype = T;
 
-    static constexpr Pack  kPack  = 0;
-    static constexpr Order kOrder = kColMajor;  // (n,k)
+  static constexpr Pack kPack = 0;
+  static constexpr Order kOrder = kColMajor;  // (n,k)
 
-    using SmemCopyAtom = SmemCopy_MMA_884_V<T, 1>;
+  using SmemCopyAtom = SmemCopy_MMA_884_V<T, 1>;
 
-    struct GetSmemLayout {  // m-major
-        template<int M, int K>
-        static constexpr auto apply(pair<M, K>)
-        {
-            return SmemLayoutV2<K, M>{};
-        }
-    };
+  struct GetSmemLayout {  // m-major
+    template <int M, int K>
+    static constexpr auto apply(pair<M, K>) {
+      return SmemLayoutV2<K, M>{};
+    }
+  };
 
-    using GetGmemIter = GetGmemIter;
+  using GetGmemIter = GetGmemIter;
 };
 
-template<Order order>
+template <Order order>
 struct _GetSmemLayoutC {
-    template<int M, int N>
-    static constexpr auto apply(pair<M, N>)
-    {
-        constexpr auto cs = mk2cs<order>(M, N);
-        return SmemLayoutV2<cs.y, cs.x, 1, 1>{};
-    }
+  template <int M, int N>
+  static constexpr auto apply(pair<M, N>) {
+    constexpr auto cs = mk2cs<order>(M, N);
+    return SmemLayoutV2<cs.y, cs.x, 1, 1>{};
+  }
 };
 
-template<Order order>
+template <Order order>
 struct _GetThreadMapC {
-    template<int M, int N, int THREADS>
-    static constexpr auto apply(pair<M, N>, constant<THREADS>)
-    {
-        constexpr auto cs    = mk2cs<order>(M, N);
-        constexpr int  WARPS = THREADS / WARP_SIZE;
+  template <int M, int N, int THREADS>
+  static constexpr auto apply(pair<M, N>, constant<THREADS>) {
+    constexpr auto cs = mk2cs<order>(M, N);
+    constexpr int WARPS = THREADS / WARP_SIZE;
 
-        return ThreadMap_V2<cs.x, cs.y, 4, Raked, WARPS>{};
-    }
+    return ThreadMap_V2<cs.x, cs.y, 4, Raked, WARPS>{};
+  }
 };
 
-template<class T, Order order>
+template <class T, Order order>
 struct Operand_C {
-    using Dtype = T;
+  using Dtype = T;
 
-    static constexpr Order kOrder = order;
+  static constexpr Order kOrder = order;
 
-    using GetSmemLayout = _GetSmemLayoutC<order>;
-    using GetThreadMap  = _GetThreadMapC<order>;
+  using GetSmemLayout = _GetSmemLayoutC<order>;
+  using GetThreadMap = _GetThreadMapC<order>;
 };
 
-template<class T>
+template <class T>
 struct Operand_B_Pack {
-    using Dtype = T;
+  using Dtype = T;
 
-    static constexpr int Pack_M = 1;
+  static constexpr int Pack_M = 1;
 
-    static constexpr Pack  kPack  = HMMA_884 | OPERAND_B | Pack_M;
-    static constexpr Order kOrder = kRowMajor;
+  static constexpr Pack kPack = HMMA_884 | OPERAND_B | Pack_M;
+  static constexpr Order kOrder = kRowMajor;
 
-    using SmemCopyAtom = SmemCopyAtom_Pack_v3<T, SmemCopy_MMA_884_B<T>, kOrder, Pack_M>;
+  using SmemCopyAtom =
+      SmemCopyAtom_Pack_v3<T, SmemCopy_MMA_884_B<T>, kOrder, Pack_M>;
 
-    using GetSmemLayout = GetSmemLayout<kOrder>;
-    using GetGmemIter   = GetGmemIter;
+  using GetSmemLayout = GetSmemLayout<kOrder>;
+  using GetGmemIter = GetGmemIter;
 };
 
-template<class T>
+template <class T>
 struct Operand_V_Pack {
-    using Dtype = T;
+  using Dtype = T;
 
-    static constexpr int Pack_M = 1;
+  static constexpr int Pack_M = 1;
 
-    static constexpr Pack  kPack  = HMMA_884 | OPERAND_V | Pack_M;
-    static constexpr Order kOrder = kColMajor;
+  static constexpr Pack kPack = HMMA_884 | OPERAND_V | Pack_M;
+  static constexpr Order kOrder = kColMajor;
 
-    using SmemCopyAtom = SmemCopyAtom_Pack_v3<T, SmemCopy_MMA_884_V<T, 8>, kColMajor, Pack_M>;
+  using SmemCopyAtom =
+      SmemCopyAtom_Pack_v3<T, SmemCopy_MMA_884_V<T, 8>, kColMajor, Pack_M>;
 
-    struct GetSmemLayout {  // m-major
-        template<int M, int K>
-        static constexpr auto apply(pair<M, K>)
-        {
-            return SmemLayoutV2<K, M>{};
-        }
-    };
+  struct GetSmemLayout {  // m-major
+    template <int M, int K>
+    static constexpr auto apply(pair<M, K>) {
+      return SmemLayoutV2<K, M>{};
+    }
+  };
 
-    using GetGmemIter = GetGmemIter;
+  using GetGmemIter = GetGmemIter;
 };
 
 }  // namespace sm70_s884
 
-template<class T>
-struct GetOperand<HMMA_884, OPERAND_A, T, kRowMajor, false>: std::true_type {
-    using Operand = sm70_s884::Operand_A<T>;
+template <class T>
+struct GetOperand<HMMA_884, OPERAND_A, T, kRowMajor, false> : std::true_type {
+  using Operand = sm70_s884::Operand_A<T>;
 };
 
-template<class T>
-struct GetOperand<HMMA_884, OPERAND_B, T, kRowMajor, false>: std::true_type {
-    using Operand = sm70_s884::Operand_B<T>;
+template <class T>
+struct GetOperand<HMMA_884, OPERAND_B, T, kRowMajor, false> : std::true_type {
+  using Operand = sm70_s884::Operand_B<T>;
 };
 
-template<class T>
-struct GetOperand<HMMA_884, OPERAND_V, T, kColMajor, false>: std::true_type {
-    using Operand = sm70_s884::Operand_V<T>;
+template <class T>
+struct GetOperand<HMMA_884, OPERAND_V, T, kColMajor, false> : std::true_type {
+  using Operand = sm70_s884::Operand_V<T>;
 };
 
-template<class T>
-struct GetOperand<HMMA_884, OPERAND_B, T, kRowMajor, true>: std::true_type {
-    using Operand = sm70_s884::Operand_B_Pack<T>;
+template <class T>
+struct GetOperand<HMMA_884, OPERAND_B, T, kRowMajor, true> : std::true_type {
+  using Operand = sm70_s884::Operand_B_Pack<T>;
 };
 
-template<class T>
-struct GetOperand<HMMA_884, OPERAND_V, T, kColMajor, true>: std::true_type {
-    using Operand = sm70_s884::Operand_V_Pack<T>;
+template <class T>
+struct GetOperand<HMMA_884, OPERAND_V, T, kColMajor, true> : std::true_type {
+  using Operand = sm70_s884::Operand_V_Pack<T>;
 };
 
 }  // namespace turbomind::gemm

--- a/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/arch/operand_sm80_s16816.h
+++ b/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/arch/operand_sm80_s16816.h
@@ -19,230 +19,235 @@ namespace sm80_s16816 {
 namespace detail {
 
 struct GetSmemLayout {
-    template<int S, int C>
-    static constexpr auto apply(pair<S, C>)
-    {
-        // constexpr int S0 = S >= 16 ? 16 : 8;
-        constexpr int S0 = 8;
-        constexpr int C0 = C >= 64 ? 64 : (C >= 32 ? 32 : 16);
-        using _Small     = std::conditional_t<C0 == 32, Swizzle<2, 3, 3>, Swizzle<1, 3, 3>>;
-        using Swizzle    = std::conditional_t<C0 == 64, Swizzle<3, 3, 3>, _Small>;
-        return SmemLayoutV2<S, C, S0, C0, Swizzle>{};
-    }
+  template <int S, int C>
+  static constexpr auto apply(pair<S, C>) {
+    // constexpr int S0 = S >= 16 ? 16 : 8;
+    constexpr int S0 = 8;
+    constexpr int C0 = C >= 64 ? 64 : (C >= 32 ? 32 : 16);
+    using _Small =
+        std::conditional_t<C0 == 32, Swizzle<2, 3, 3>, Swizzle<1, 3, 3>>;
+    using Swizzle = std::conditional_t<C0 == 64, Swizzle<3, 3, 3>, _Small>;
+    return SmemLayoutV2<S, C, S0, C0, Swizzle>{};
+  }
 };
 
 }  // namespace detail
 
-template<Order order>
+template <Order order>
 struct GetSmemLayoutV2 {
-    template<int M, int K>
-    static constexpr auto apply(pair<M, K>)
-    {
-        constexpr int2 cs = mk2cs<order>(M, K);
-        return detail::GetSmemLayout::apply(pair<cs.y, cs.x>{});
-    }
+  template <int M, int K>
+  static constexpr auto apply(pair<M, K>) {
+    constexpr int2 cs = mk2cs<order>(M, K);
+    return detail::GetSmemLayout::apply(pair<cs.y, cs.x>{});
+  }
 };
 
 // (m, k)
-template<class T, Order order>
+template <class T, Order order>
 struct Operand_A {
-    using Dtype = T;
+  using Dtype = T;
 
-    static constexpr Pack  kPack  = 0;
-    static constexpr Order kOrder = order;
+  static constexpr Pack kPack = 0;
+  static constexpr Order kOrder = order;
 
-    // using SmemCopyAtom =
-    //     std::conditional_t<order == kRowMajor, SmemCopy_MMA_16816_A<T, false>, SmemCopy_MMA_16816_B<T, true>>;
+  // using SmemCopyAtom =
+  //     std::conditional_t<order == kRowMajor, SmemCopy_MMA_16816_A<T, false>,
+  //     SmemCopy_MMA_16816_B<T, true>>;
 
-    // using SmemCopyAtom = std::conditional_t<order == kRowMajor,
-    //                                         LDSM_SM75_8x8<T, 16, 16, kColMajor, kRowMajor>,
-    //                                         LDSM_SM75_8x8<T, 16, 16, kRowMajor, kColMajor>>;
+  // using SmemCopyAtom = std::conditional_t<order == kRowMajor,
+  //                                         LDSM_SM75_8x8<T, 16, 16, kColMajor,
+  //                                         kRowMajor>, LDSM_SM75_8x8<T, 16,
+  //                                         16, kRowMajor, kColMajor>>;
 
-    using SmemCopyAtom = LDSM_SM75_8x8<T, 16, 16, ~order, order>;
+  using SmemCopyAtom = LDSM_SM75_8x8<T, 16, 16, ~order, order>;
 
-    using GetSmemLayout = GetSmemLayoutV2<kOrder>;
-    using GetGmemIter   = GetGmemIter;
+  using GetSmemLayout = GetSmemLayoutV2<kOrder>;
+  using GetGmemIter = GetGmemIter;
 };
 
 // (n, k)
-template<class T, Order order, int N = 16>
+template <class T, Order order, int N = 16>
 struct Operand_B {
-    using Dtype = T;
+  using Dtype = T;
 
-    static constexpr Pack  kPack  = 0;
-    static constexpr Order kOrder = order;
+  static constexpr Pack kPack = 0;
+  static constexpr Order kOrder = order;
 
-    // using SmemCopyAtom =
-    //     std::conditional_t<order == kRowMajor, SmemCopy_MMA_16816_B<T, false>, SmemCopy_MMA_16816_A<T, true>>;
-    // using SmemCopyAtom = std::conditional_t<order == kRowMajor,  //
-    //                                         LDSM_SM75_8x8<T, 16, 16, kRowMajor, kRowMajor>,
-    //                                         LDSM_SM75_8x8<T, 16, 16, kColMajor, kColMajor>>;
+  // using SmemCopyAtom =
+  //     std::conditional_t<order == kRowMajor, SmemCopy_MMA_16816_B<T, false>,
+  //     SmemCopy_MMA_16816_A<T, true>>;
+  // using SmemCopyAtom = std::conditional_t<order == kRowMajor,  //
+  //                                         LDSM_SM75_8x8<T, 16, 16, kRowMajor,
+  //                                         kRowMajor>, LDSM_SM75_8x8<T, 16,
+  //                                         16, kColMajor, kColMajor>>;
 
-    using SmemCopyAtom = LDSM_SM75_8x8<T, N, 16, order, order>;
+  using SmemCopyAtom = LDSM_SM75_8x8<T, N, 16, order, order>;
 
-    using GetSmemLayout = GetSmemLayoutV2<kOrder>;
-    using GetGmemIter   = GetGmemIter;
+  using GetSmemLayout = GetSmemLayoutV2<kOrder>;
+  using GetGmemIter = GetGmemIter;
 };
 
-template<Order order>
+template <Order order>
 struct _GetSmemLayoutC {
-    template<int M, int N>
-    static constexpr auto apply(pair<M, N>)
-    {
-        if constexpr (order == kRowMajor) {
-            // x01  23
-            // cccccss
-            //                                    bits base shift
-            return SmemLayoutV2<M, N, 8, 32, Swizzle<2, 3, 2>>{};
-        }
-        else {
-            // 234  x01
-            // 23401x
-            // cccccsss
-            // so that x is not part of swizzling
-            return SmemLayoutV2<N, M, 8, 32, Swizzle<2, 3, 3>>{};
-        }
+  template <int M, int N>
+  static constexpr auto apply(pair<M, N>) {
+    if constexpr (order == kRowMajor) {
+      // x01  23
+      // cccccss
+      //                                    bits base shift
+      return SmemLayoutV2<M, N, 8, 32, Swizzle<2, 3, 2>>{};
+    } else {
+      // 234  x01
+      // 23401x
+      // cccccsss
+      // so that x is not part of swizzling
+      return SmemLayoutV2<N, M, 8, 32, Swizzle<2, 3, 3>>{};
     }
+  }
 };
 
-template<Order order>
+template <Order order>
 struct _GetThreadMapC {
-    template<int M, int N, int THREADS>
-    static constexpr auto apply(pair<M, N>, constant<THREADS>)
-    {
-        constexpr auto cs    = mk2cs<order>(M, N);
-        constexpr int  WARPS = THREADS / WARP_SIZE;
+  template <int M, int N, int THREADS>
+  static constexpr auto apply(pair<M, N>, constant<THREADS>) {
+    constexpr auto cs = mk2cs<order>(M, N);
+    constexpr int WARPS = THREADS / WARP_SIZE;
 
-        return ThreadMap_V2<cs.x, cs.y, 4, Raked, WARPS>{};
-    }
+    return ThreadMap_V2<cs.x, cs.y, 4, Raked, WARPS>{};
+  }
 };
 
-template<class T, Order order>
+template <class T, Order order>
 struct Operand_C {
-    using Dtype = T;
+  using Dtype = T;
 
-    static constexpr Order kOrder = order;
+  static constexpr Order kOrder = order;
 
-    using GetSmemLayout = _GetSmemLayoutC<order>;
-    using GetThreadMap  = _GetThreadMapC<order>;
+  using GetSmemLayout = _GetSmemLayoutC<order>;
+  using GetThreadMap = _GetThreadMapC<order>;
 };
 
-template<class T>
+template <class T>
 struct Operand_UV {
-    using Dtype = T;
+  using Dtype = T;
 
-    static constexpr Pack  kPack  = 0;
-    static constexpr Order kOrder = kColMajor;
+  static constexpr Pack kPack = 0;
+  static constexpr Order kOrder = kColMajor;
 
-    using SmemCopyAtom = SmemCopy_MMA_16816_U<T>;
+  using SmemCopyAtom = SmemCopy_MMA_16816_U<T>;
 
-    struct GetSmemLayout {
-        template<int M, int K>
-        static constexpr auto apply(pair<M, K>)
-        {
-            return SmemLayoutV2<K, M>{};
-        }
-    };
-    using GetGmemIter = GetGmemIter;
-};
-
-template<Order order>
-struct GetSmemLayout_Pack {
-    template<int M, int K>
-    static constexpr auto apply(pair<M, K>)
-    {
-        constexpr int2 CS = mk2cs<order>(M, K);
-        return SmemLayoutV2<CS.y, CS.x, 1, 1>{};
+  struct GetSmemLayout {
+    template <int M, int K>
+    static constexpr auto apply(pair<M, K>) {
+      return SmemLayoutV2<K, M>{};
     }
+  };
+  using GetGmemIter = GetGmemIter;
 };
 
-template<class T, Order order, int Pack_M_>
+template <Order order>
+struct GetSmemLayout_Pack {
+  template <int M, int K>
+  static constexpr auto apply(pair<M, K>) {
+    constexpr int2 CS = mk2cs<order>(M, K);
+    return SmemLayoutV2<CS.y, CS.x, 1, 1>{};
+  }
+};
+
+template <class T, Order order, int Pack_M_>
 struct Operand_A_Pack {
-    using Dtype = T;
+  using Dtype = T;
 
-    static constexpr int Pack_M = Pack_M_;
+  static constexpr int Pack_M = Pack_M_;
 
-    static constexpr Pack  kPack  = HMMA_16816 | OPERAND_A | Pack_M;
-    static constexpr Order kOrder = order;
+  static constexpr Pack kPack = HMMA_16816 | OPERAND_A | Pack_M;
+  static constexpr Order kOrder = order;
 
-    // using SmemCopyAtom = SmemCopyAtom_Pack_v2<T, kOrder, 16 * Pack_M, 16, 8, Pack_M>;
-    using _SCp         = typename Operand_A<T, order>::SmemCopyAtom;
-    using SmemCopyAtom = SmemCopyAtom_Pack_v3<T, _SCp, order, Pack_M>;
+  // using SmemCopyAtom = SmemCopyAtom_Pack_v2<T, kOrder, 16 * Pack_M, 16, 8,
+  // Pack_M>;
+  using _SCp = typename Operand_A<T, order>::SmemCopyAtom;
+  using SmemCopyAtom = SmemCopyAtom_Pack_v3<T, _SCp, order, Pack_M>;
 
-    using GetSmemLayout = GetSmemLayout_Pack<kOrder>;
-    using GetGmemIter   = GetGmemIter;
+  using GetSmemLayout = GetSmemLayout_Pack<kOrder>;
+  using GetGmemIter = GetGmemIter;
 };
 
-template<class T, Order order, int Pack_M_>
+template <class T, Order order, int Pack_M_>
 struct Operand_B_Pack {
-    using Dtype = T;
+  using Dtype = T;
 
-    static constexpr int Pack_M = Pack_M_;
+  static constexpr int Pack_M = Pack_M_;
 
-    static constexpr Pack  kPack  = HMMA_16816 | OPERAND_B | Pack_M;
-    static constexpr Order kOrder = order;
+  static constexpr Pack kPack = HMMA_16816 | OPERAND_B | Pack_M;
+  static constexpr Order kOrder = order;
 
-    using SmemCopyAtom = SmemCopyAtom_Pack_v2<T, kOrder, 16 * Pack_M, 16, 8, Pack_M>;
+  using SmemCopyAtom =
+      SmemCopyAtom_Pack_v2<T, kOrder, 16 * Pack_M, 16, 8, Pack_M>;
 
-    using GetSmemLayout = GetSmemLayout_Pack<kOrder>;
-    using GetGmemIter   = GetGmemIter;
+  using GetSmemLayout = GetSmemLayout_Pack<kOrder>;
+  using GetGmemIter = GetGmemIter;
 };
 
-template<class T, bool is_V>
+template <class T, bool is_V>
 struct Operand_UV_Pack {
-    using Dtype = T;
+  using Dtype = T;
 
-    static constexpr int Pack_M = 1;
+  static constexpr int Pack_M = 1;
 
-    static constexpr Pack  kPack  = HMMA_16816 | (is_V ? OPERAND_V : OPERAND_U) | Pack_M;
-    static constexpr Order kOrder = Order::kColMajor;
+  static constexpr Pack kPack =
+      HMMA_16816 | (is_V ? OPERAND_V : OPERAND_U) | Pack_M;
+  static constexpr Order kOrder = Order::kColMajor;
 
-    using _SCp         = typename Operand_UV<T>::SmemCopyAtom;
-    using SmemCopyAtom = SmemCopyAtom_Pack_v3<T, _SCp, kOrder, Pack_M>;
+  using _SCp = typename Operand_UV<T>::SmemCopyAtom;
+  using SmemCopyAtom = SmemCopyAtom_Pack_v3<T, _SCp, kOrder, Pack_M>;
 
-    using GetSmemLayout = GetSmemLayout_Pack<kOrder>;
-    using GetGmemIter   = GetGmemIter;
+  using GetSmemLayout = GetSmemLayout_Pack<kOrder>;
+  using GetGmemIter = GetGmemIter;
 };
 
 }  // namespace sm80_s16816
 
-template<class T, Order order>
-struct GetOperand<HMMA_16816, OPERAND_A, T, order, false>: std::true_type {
-    using Operand = sm80_s16816::Operand_A<T, order>;
+template <class T, Order order>
+struct GetOperand<HMMA_16816, OPERAND_A, T, order, false> : std::true_type {
+  using Operand = sm80_s16816::Operand_A<T, order>;
 };
 
-template<class T, Order order>
-struct GetOperand<HMMA_16816, OPERAND_B, T, order, false>: std::true_type {
-    using Operand = sm80_s16816::Operand_B<T, order, 16>;
+template <class T, Order order>
+struct GetOperand<HMMA_16816, OPERAND_B, T, order, false> : std::true_type {
+  using Operand = sm80_s16816::Operand_B<T, order, 16>;
 };
 
-template<class T>
-struct GetOperand<HMMA_16816, OPERAND_U, T, kColMajor, false>: std::true_type {
-    using Operand = sm80_s16816::Operand_UV<T>;
+template <class T>
+struct GetOperand<HMMA_16816, OPERAND_U, T, kColMajor, false> : std::true_type {
+  using Operand = sm80_s16816::Operand_UV<T>;
 };
 
-template<class T>
-struct GetOperand<HMMA_16816, OPERAND_V, T, kColMajor, false>: std::true_type {
-    using Operand = sm80_s16816::Operand_UV<T>;
+template <class T>
+struct GetOperand<HMMA_16816, OPERAND_V, T, kColMajor, false> : std::true_type {
+  using Operand = sm80_s16816::Operand_UV<T>;
 };
 
 // template<class T>
-// struct GetOperand<HMMA_16816, OPERAND_A, T, kColMajor, true>: std::true_type {
+// struct GetOperand<HMMA_16816, OPERAND_A, T, kColMajor, true>: std::true_type
+// {
 //     using Operand = sm80_s16816::Operand_A_Pack<T, kColMajor>;
 // };
 
 // template<class T>
-// struct GetOperand<HMMA_16816, OPERAND_B, T, kColMajor, true>: std::true_type {
+// struct GetOperand<HMMA_16816, OPERAND_B, T, kColMajor, true>: std::true_type
+// {
 //     using Operand = sm80_s16816::Operand_B_Pack<T, kColMajor>;
 // };
 
 // template<>
-// struct GetOperand<HMMA_16816, OPERAND_U, uint32_t, kColMajor, true>: std::true_type {
+// struct GetOperand<HMMA_16816, OPERAND_U, uint32_t, kColMajor, true>:
+// std::true_type {
 //     using Operand = sm80_s16816::Operand_U_Pack<uint32_t>;
 // };
 
 // template<>
-// struct GetOperand<HMMA_16816, OPERAND_V, uint32_t, kColMajor, true>: std::true_type {
+// struct GetOperand<HMMA_16816, OPERAND_V, uint32_t, kColMajor, true>:
+// std::true_type {
 //     using Operand = sm80_s16816::Operand_U_Pack<uint32_t>;
 // };
 

--- a/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/arch/smem_copy_simt.h
+++ b/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/arch/smem_copy_simt.h
@@ -10,93 +10,91 @@
 
 namespace turbomind::gemm {
 
-template<class T, int K_>
+template <class T, int K_>
 struct SmemCopy_MMA_SIMT_A {
-    static constexpr int M = simt::OP_M;
-    static constexpr int K = simt::OP_K;
+  static constexpr int M = simt::OP_M;
+  static constexpr int K = simt::OP_K;
 
-    static constexpr int OP_N = simt::OP_N;
+  static constexpr int OP_N = simt::OP_N;
 
-    static constexpr int kFragNum = 1;
+  static constexpr int kFragNum = 1;
 
-    using Frag = Array<T, K>;
+  using Frag = Array<T, K>;
 
-    __device__ static int2 get_offset(int thread_idx)
-    {
-        const int lane_id = thread_idx % WARP_SIZE;
-        return {lane_id / OP_N, 0};
-    }
+  __device__ static int2 get_offset(int thread_idx) {
+    const int lane_id = thread_idx % WARP_SIZE;
+    return {lane_id / OP_N, 0};
+  }
 
-    template<class S, class D>
-    __device__ static void copy(S&& src_ptr, D&& dst_ptr, bool)  // -> (m, k)
-    {
-        Lds(*(Frag*)dst_ptr, (S &&) src_ptr);
-    }
+  template <class S, class D>
+  __device__ static void copy(S&& src_ptr, D&& dst_ptr, bool)  // -> (m, k)
+  {
+    Lds(*(Frag*)dst_ptr, (S&&)src_ptr);
+  }
 
-    __device__ static int2 unique(int thread_idx, int pack_idx)  // -> (unique id, repeat id)
-    {
-        const int lane_id = thread_idx % WARP_SIZE;
-        return {pack_idx * M + lane_id / OP_N, lane_id % OP_N};
-    }
+  __device__ static int2 unique(int thread_idx,
+                                int pack_idx)  // -> (unique id, repeat id)
+  {
+    const int lane_id = thread_idx % WARP_SIZE;
+    return {pack_idx * M + lane_id / OP_N, lane_id % OP_N};
+  }
 };
 
-template<class T, int K_>
+template <class T, int K_>
 struct SmemCopy_MMA_SIMT_B {
-    static constexpr int M = simt::OP_N;
-    static constexpr int K = simt::OP_K;
+  static constexpr int M = simt::OP_N;
+  static constexpr int K = simt::OP_K;
 
-    static constexpr int OP_N = simt::OP_N;
+  static constexpr int OP_N = simt::OP_N;
 
-    static constexpr int kFragNum = 1;
+  static constexpr int kFragNum = 1;
 
-    using Frag = Array<T, K>;
+  using Frag = Array<T, K>;
 
-    __device__ static int2 get_offset(int thread_idx)  // -> (m, k)
-    {
-        const int lane_id = thread_idx % WARP_SIZE;
-        return {lane_id % OP_N, 0};
-    }
+  __device__ static int2 get_offset(int thread_idx)  // -> (m, k)
+  {
+    const int lane_id = thread_idx % WARP_SIZE;
+    return {lane_id % OP_N, 0};
+  }
 
-    template<class S, class D>
-    __device__ static void copy(S&& src_ptr, D&& dst_ptr, bool)
-    {
-        Lds(*(Frag*)dst_ptr, (S &&) src_ptr);
-    }
+  template <class S, class D>
+  __device__ static void copy(S&& src_ptr, D&& dst_ptr, bool) {
+    Lds(*(Frag*)dst_ptr, (S&&)src_ptr);
+  }
 
-    __device__ static int2 unique(int thread_idx, int pack_idx)  // -> (unique id, repeat id)
-    {
-        const int lane_id = thread_idx % WARP_SIZE;
-        return {pack_idx * OP_N + lane_id % OP_N, lane_id / OP_N};
-    }
+  __device__ static int2 unique(int thread_idx,
+                                int pack_idx)  // -> (unique id, repeat id)
+  {
+    const int lane_id = thread_idx % WARP_SIZE;
+    return {pack_idx * OP_N + lane_id % OP_N, lane_id / OP_N};
+  }
 };
 
-template<class T, int K_>
+template <class T, int K_>
 struct SmemCopy_MMA_SIMT_V {
-    static constexpr int M = simt::OP_N;
-    static constexpr int K = K_;
+  static constexpr int M = simt::OP_N;
+  static constexpr int K = K_;
 
-    static constexpr int OP_N = simt::OP_N;
+  static constexpr int OP_N = simt::OP_N;
 
-    static constexpr int kFragNum = 1;
+  static constexpr int kFragNum = 1;
 
-    using Frag = Array<T, 1>;
+  using Frag = Array<T, 1>;
 
-    __device__ static int2 unique(int thread_idx, int pack_idx)
-    {
-        const int lane_id = thread_idx % WARP_SIZE;
-        return {pack_idx * OP_N + lane_id % OP_N, lane_id / OP_N};
-    }
+  __device__ static int2 unique(int thread_idx, int pack_idx) {
+    const int lane_id = thread_idx % WARP_SIZE;
+    return {pack_idx * OP_N + lane_id % OP_N, lane_id / OP_N};
+  }
 
-    __device__ static int2 get_offset(int thread_idx)  // -> (m, k)
-    {
-        return {unique(thread_idx, 0).x, 0};
-    }
+  __device__ static int2 get_offset(int thread_idx)  // -> (m, k)
+  {
+    return {unique(thread_idx, 0).x, 0};
+  }
 
-    template<class S, class D>
-    __device__ static void copy(S&& src_ptr, D&& dst_ptr, bool mask)
-    {
-        Lds(*(Frag*)dst_ptr, src_ptr);
-    }
+  template <class S, class D>
+  __device__ static void copy(S&& src_ptr, D&& dst_ptr, bool mask) {
+    Lds(*(Frag*)dst_ptr, src_ptr);
+  }
 };
 
 }  // namespace turbomind::gemm

--- a/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/arch/smem_copy_sm70.h
+++ b/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/arch/smem_copy_sm70.h
@@ -7,107 +7,98 @@
 
 namespace turbomind::gemm {
 
-template<class T>
+template <class T>
 struct SmemCopy_MMA_884_A {
-    // static constexpr int M = 16;
-    // static constexpr int K = 8;
-    static constexpr int M = 8;
-    static constexpr int K = 8;
+  // static constexpr int M = 16;
+  // static constexpr int K = 8;
+  static constexpr int M = 8;
+  static constexpr int K = 8;
 
-    static constexpr int kFragNum = 1;
+  static constexpr int kFragNum = 1;
 
-    using Frag = Array<T, K>;
+  using Frag = Array<T, K>;
 
-    __device__ static int2 unique(int thread_idx, int pack_idx)
-    {
-        const int lane_id = thread_idx % WARP_SIZE;
-        //                   4                3               01
-        // const int m = lane_id / 16 * 4 + (lane_id & 8) + lane_id % 4;
-        // return {pack_idx * M + m, (lane_id & 4) >> 2};
+  __device__ static int2 unique(int thread_idx, int pack_idx) {
+    const int lane_id = thread_idx % WARP_SIZE;
+    //                   4                3               01
+    // const int m = lane_id / 16 * 4 + (lane_id & 8) + lane_id % 4;
+    // return {pack_idx * M + m, (lane_id & 4) >> 2};
 
-        //                   4                01
-        const int m = lane_id / 16 * 4 + lane_id % 4;
-        return {pack_idx * M + m, (lane_id & 12) >> 2};
-    }
+    //                   4                01
+    const int m = lane_id / 16 * 4 + lane_id % 4;
+    return {pack_idx * M + m, (lane_id & 12) >> 2};
+  }
 
-    __device__ static int2 get_offset(int thread_idx)
-    {
-        return int2{unique(thread_idx, 0).x, 0};
-    }
+  __device__ static int2 get_offset(int thread_idx) {
+    return int2{unique(thread_idx, 0).x, 0};
+  }
 
-    template<class S, class D>
-    __device__ static void copy(S&& src_ptr, D&& dst_ptr, bool)
-    {
-        Lds(*(Frag*)dst_ptr, src_ptr);
-    }
+  template <class S, class D>
+  __device__ static void copy(S&& src_ptr, D&& dst_ptr, bool) {
+    Lds(*(Frag*)dst_ptr, src_ptr);
+  }
 };
 
-template<class T>
+template <class T>
 struct SmemCopy_MMA_884_B {
-    // static constexpr int M = 16;
-    // static constexpr int K = 8;
-    static constexpr int M = 32;
-    static constexpr int K = 8;
+  // static constexpr int M = 16;
+  // static constexpr int K = 8;
+  static constexpr int M = 32;
+  static constexpr int K = 8;
 
-    static constexpr int kFragNum = 1;
+  static constexpr int kFragNum = 1;
 
-    using Frag = Array<T, K>;
+  using Frag = Array<T, K>;
 
-    __device__ static int2 unique(int thread_idx, int pack_idx)
-    {
-        const int lane_id = thread_idx % WARP_SIZE;
-        //                4                     2                 01
-        // const int m = lane_id / 16 * 4 + (lane_id & 4) * 2 + lane_id % 4;
-        // return {pack_idx * M + m, (lane_id & 8) >> 3};
+  __device__ static int2 unique(int thread_idx, int pack_idx) {
+    const int lane_id = thread_idx % WARP_SIZE;
+    //                4                     2                 01
+    // const int m = lane_id / 16 * 4 + (lane_id & 4) * 2 + lane_id % 4;
+    // return {pack_idx * M + m, (lane_id & 8) >> 3};
 
-        //                  4                  23                  01
-        const int m = lane_id / 16 * 4 + (lane_id & 12) * 2 + lane_id % 4;
-        return {pack_idx * M + m, 0};
-    }
+    //                  4                  23                  01
+    const int m = lane_id / 16 * 4 + (lane_id & 12) * 2 + lane_id % 4;
+    return {pack_idx * M + m, 0};
+  }
 
-    __device__ static int2 get_offset(int thread_idx)
-    {
-        return int2{unique(thread_idx, 0).x, 0};
-    }
+  __device__ static int2 get_offset(int thread_idx) {
+    return int2{unique(thread_idx, 0).x, 0};
+  }
 
-    template<class S, class D>
-    __device__ static void copy(S&& src_ptr, D&& dst_ptr, bool)
-    {
-        Lds(*(Frag*)dst_ptr, src_ptr);
-    }
+  template <class S, class D>
+  __device__ static void copy(S&& src_ptr, D&& dst_ptr, bool) {
+    Lds(*(Frag*)dst_ptr, src_ptr);
+  }
 };
 
-template<class T, int K_>
+template <class T, int K_>
 struct SmemCopy_MMA_884_V {
-    // static constexpr int M = 16;
-    static constexpr int M = 32;
-    static constexpr int K = K_;
+  // static constexpr int M = 16;
+  static constexpr int M = 32;
+  static constexpr int K = K_;
 
-    static constexpr int kFragNum = 1;
+  static constexpr int kFragNum = 1;
 
-    using Frag = Array<T, 1>;
+  using Frag = Array<T, 1>;
 
-    __device__ static int2 unique(int thread_idx, int pack_idx)
-    {
-        const int lane_id = thread_idx % WARP_SIZE;
-        //                4                     2                 01
-        // const int m = lane_id / 16 * 4 + (lane_id & 4) * 2 + lane_id % 4;
-        // return {pack_idx * 16 + m, (lane_id & 8) >> 3};
+  __device__ static int2 unique(int thread_idx, int pack_idx) {
+    const int lane_id = thread_idx % WARP_SIZE;
+    //                4                     2                 01
+    // const int m = lane_id / 16 * 4 + (lane_id & 4) * 2 + lane_id % 4;
+    // return {pack_idx * 16 + m, (lane_id & 8) >> 3};
 
-        const int m = lane_id / 16 * 4 + (lane_id & 12) * 2 + lane_id % 4;
-        return {pack_idx * M + m, 0};
-    }
+    const int m = lane_id / 16 * 4 + (lane_id & 12) * 2 + lane_id % 4;
+    return {pack_idx * M + m, 0};
+  }
 
-    __device__ static int2 get_offset(int thread_idx)
-    {
-        return int2{unique(thread_idx, 0).x, 0};
-    }
+  __device__ static int2 get_offset(int thread_idx) {
+    return int2{unique(thread_idx, 0).x, 0};
+  }
 
-    template<class S, class D>
-    __device__ static void copy(S&& src_ptr, D&& dst_ptr, bool)
-    {
-        Lds(*(Frag*)dst_ptr, src_ptr);
-    }
+  template <class S, class D>
+  __device__ static void copy(S&& src_ptr, D&& dst_ptr, bool) {
+    Lds(*(Frag*)dst_ptr, src_ptr);
+  }
 };
 
 }  // namespace turbomind::gemm

--- a/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/arch/smem_copy_sm80.h
+++ b/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/arch/smem_copy_sm80.h
@@ -9,199 +9,178 @@
 
 namespace turbomind::gemm {
 
-template<bool trans>
+template <bool trans>
 struct LDSM_x4 {
-    template<class S, class D>
-    __device__ static void apply(S src_ptr, D dst_ptr)
-    {
-        const uint32_t uint_ptr = cast_smem_ptr_to_uint(src_ptr);
-        if constexpr (trans) {
-            ldsm_x4_trans(*(Array<uint32_t, 4>*)dst_ptr, uint_ptr);
-        }
-        else {
-            ldsm_x4(*(Array<uint32_t, 4>*)dst_ptr, uint_ptr);
-        }
+  template <class S, class D>
+  __device__ static void apply(S src_ptr, D dst_ptr) {
+    const uint32_t uint_ptr = cast_smem_ptr_to_uint(src_ptr);
+    if constexpr (trans) {
+      ldsm_x4_trans(*(Array<uint32_t, 4>*)dst_ptr, uint_ptr);
+    } else {
+      ldsm_x4(*(Array<uint32_t, 4>*)dst_ptr, uint_ptr);
     }
+  }
 };
 
-template<bool trans>
+template <bool trans>
 struct LDSM_x2 {
-    template<class S, class D>
-    __device__ static void apply(S src_ptr, D dst_ptr)
-    {
-        const uint32_t uint_ptr = cast_smem_ptr_to_uint(src_ptr);
-        if constexpr (trans) {
-            ldsm_x2_trans(*(Array<uint32_t, 2>*)dst_ptr, uint_ptr);
-        }
-        else {
-            ldsm_x2(*(Array<uint32_t, 2>*)dst_ptr, uint_ptr);
-        }
+  template <class S, class D>
+  __device__ static void apply(S src_ptr, D dst_ptr) {
+    const uint32_t uint_ptr = cast_smem_ptr_to_uint(src_ptr);
+    if constexpr (trans) {
+      ldsm_x2_trans(*(Array<uint32_t, 2>*)dst_ptr, uint_ptr);
+    } else {
+      ldsm_x2(*(Array<uint32_t, 2>*)dst_ptr, uint_ptr);
     }
+  }
 };
 
-template<bool trans>
+template <bool trans>
 struct LDSM_x1 {
-    template<class S, class D>
-    __device__ static void apply(S src_ptr, D dst_ptr)
-    {
-        const uint32_t uint_ptr = cast_smem_ptr_to_uint(src_ptr);
-        if constexpr (trans) {
-            ldsm_x1_trans(*(Array<uint32_t, 1>*)dst_ptr, uint_ptr);
-        }
-        else {
-            ldsm_x1(*(Array<uint32_t, 1>*)dst_ptr, uint_ptr);
-        }
+  template <class S, class D>
+  __device__ static void apply(S src_ptr, D dst_ptr) {
+    const uint32_t uint_ptr = cast_smem_ptr_to_uint(src_ptr);
+    if constexpr (trans) {
+      ldsm_x1_trans(*(Array<uint32_t, 1>*)dst_ptr, uint_ptr);
+    } else {
+      ldsm_x1(*(Array<uint32_t, 1>*)dst_ptr, uint_ptr);
     }
+  }
 };
 
-template<class T, bool trans>
+template <class T, bool trans>
 struct SmemCopy_MMA_16816_A {
-    static constexpr int M = 16;
-    static constexpr int K = 16;
+  static constexpr int M = 16;
+  static constexpr int K = 16;
 
-    static constexpr int kFragNum = 1;
+  static constexpr int kFragNum = 1;
 
-    using Frag = Array<T, 8>;
+  using Frag = Array<T, 8>;
 
-    __device__ static int2 get_offset(int thread_idx)  // -> (m, k)
-    {
-        const int lane_id = thread_idx % WARP_SIZE;
+  __device__ static int2 get_offset(int thread_idx)  // -> (m, k)
+  {
+    const int lane_id = thread_idx % WARP_SIZE;
 
-        const int c = lane_id / 16 * 8;
-        const int s = lane_id % 16;
+    const int c = lane_id / 16 * 8;
+    const int s = lane_id % 16;
 
-        return trans ? int2{c, s} : int2{s, c};
-    }
+    return trans ? int2{c, s} : int2{s, c};
+  }
 
-    template<class S, class D>
-    __device__ static void copy(S&& src_ptr, D&& dst_ptr, bool)
-    {
-        LDSM_x4<trans>::apply((S &&) src_ptr, (D &&) dst_ptr);
-    }
+  template <class S, class D>
+  __device__ static void copy(S&& src_ptr, D&& dst_ptr, bool) {
+    LDSM_x4<trans>::apply((S&&)src_ptr, (D&&)dst_ptr);
+  }
 
-    __device__ static int2 unique(int thread_idx, int pack_idx)
-    {
-        return {pack_idx * WARP_SIZE + thread_idx % WARP_SIZE, 0};
-    }
+  __device__ static int2 unique(int thread_idx, int pack_idx) {
+    return {pack_idx * WARP_SIZE + thread_idx % WARP_SIZE, 0};
+  }
 };
 
-template<class T, bool trans>
+template <class T, bool trans>
 struct SmemCopy_MMA_16816_B {
-    static constexpr int M = 16;
-    static constexpr int K = 16;
+  static constexpr int M = 16;
+  static constexpr int K = 16;
 
-    static constexpr int kFragNum = 1;
+  static constexpr int kFragNum = 1;
 
-    using Frag = Array<T, 8>;
+  using Frag = Array<T, 8>;
 
-    __device__ static int2 get_offset(int thread_idx)
-    {
-        const int lane_id = thread_idx % WARP_SIZE;
+  __device__ static int2 get_offset(int thread_idx) {
+    const int lane_id = thread_idx % WARP_SIZE;
 
-        const int c = lane_id / 8 * 8 % 16;
-        const int s = lane_id % 8 + lane_id / 16 * 8;
+    const int c = lane_id / 8 * 8 % 16;
+    const int s = lane_id % 8 + lane_id / 16 * 8;
 
-        return trans ? int2{c, s} : int2{s, c};
-    }
+    return trans ? int2{c, s} : int2{s, c};
+  }
 
-    template<class S, class D>
-    __device__ static void copy(S&& src_ptr, D&& dst_ptr, bool)
-    {
-        LDSM_x4<trans>::apply((S &&) src_ptr, (D &&) dst_ptr);
-    }
+  template <class S, class D>
+  __device__ static void copy(S&& src_ptr, D&& dst_ptr, bool) {
+    LDSM_x4<trans>::apply((S&&)src_ptr, (D&&)dst_ptr);
+  }
 
-    __device__ static int2 unique(int thread_idx, int pack_idx)
-    {
-        return {pack_idx * WARP_SIZE + thread_idx % WARP_SIZE, 0};
-    }
+  __device__ static int2 unique(int thread_idx, int pack_idx) {
+    return {pack_idx * WARP_SIZE + thread_idx % WARP_SIZE, 0};
+  }
 };
 
-template<class T, int M_, int K_, Order mat_order, Order thr_order>
+template <class T, int M_, int K_, Order mat_order, Order thr_order>
 struct LDSM_SM75_8x8 {
-    static constexpr int M = M_;
-    static constexpr int K = K_;
+  static constexpr int M = M_;
+  static constexpr int K = K_;
 
-    static constexpr int iM = M / 8;
-    static constexpr int iK = K / 8;
+  static constexpr int iM = M / 8;
+  static constexpr int iK = K / 8;
 
-    static constexpr int kFragNum = 1;
+  static constexpr int kFragNum = 1;
 
-    using Frag = Array<T, 2 * iM * iK>;
+  using Frag = Array<T, 2 * iM * iK>;
 
-    __device__ static int2 get_offset(int thread_idx)
-    {
-        const int lane_id = thread_idx % WARP_SIZE;
-        int       c, s;
-        if constexpr (mat_order == kColMajor) {
-            s = lane_id % 16;
-            c = lane_id / 16 * 8;
-        }
-        else {
-            s = lane_id / 16 * 8 + lane_id % 8;
-            c = lane_id & 8;
-        }
-        int2 mk = cs2mk<thr_order>(c, s);
+  __device__ static int2 get_offset(int thread_idx) {
+    const int lane_id = thread_idx % WARP_SIZE;
+    int c, s;
+    if constexpr (mat_order == kColMajor) {
+      s = lane_id % 16;
+      c = lane_id / 16 * 8;
+    } else {
+      s = lane_id / 16 * 8 + lane_id % 8;
+      c = lane_id & 8;
+    }
+    int2 mk = cs2mk<thr_order>(c, s);
 #if __CUDA_ARCH__ <= 750  // wrap ptrs around for sm_75
-        mk.x %= M;
-        mk.y %= K;
+    mk.x %= M;
+    mk.y %= K;
 #endif
-        return mk;
-    }
+    return mk;
+  }
 
-    template<class S, class D>
-    __device__ static void copy(S&& src_ptr, D&& dst_ptr, bool)
-    {
-        constexpr bool trans = thr_order != kRowMajor;
-        if constexpr (sizeof(Frag) == 16) {
-            LDSM_x4<trans>::apply((S &&) src_ptr, (D &&) dst_ptr);
-        }
-        else if constexpr (sizeof(Frag) == 8) {
-            LDSM_x2<trans>::apply((S &&) src_ptr, (D &&) dst_ptr);
-        }
-        else if constexpr (sizeof(Frag) == 4) {
-            LDSM_x1<trans>::apply((S &&) src_ptr, (D &&) dst_ptr);
-        }
-        else {
-            static_assert(sizeof(S) != sizeof(S), "not implemented");
-        }
+  template <class S, class D>
+  __device__ static void copy(S&& src_ptr, D&& dst_ptr, bool) {
+    constexpr bool trans = thr_order != kRowMajor;
+    if constexpr (sizeof(Frag) == 16) {
+      LDSM_x4<trans>::apply((S&&)src_ptr, (D&&)dst_ptr);
+    } else if constexpr (sizeof(Frag) == 8) {
+      LDSM_x2<trans>::apply((S&&)src_ptr, (D&&)dst_ptr);
+    } else if constexpr (sizeof(Frag) == 4) {
+      LDSM_x1<trans>::apply((S&&)src_ptr, (D&&)dst_ptr);
+    } else {
+      static_assert(sizeof(S) != sizeof(S), "not implemented");
     }
+  }
 
-    __device__ static int2 unique(int thread_idx, int pack_idx)
-    {
-        return {pack_idx * WARP_SIZE + thread_idx % WARP_SIZE, 0};
-    }
+  __device__ static int2 unique(int thread_idx, int pack_idx) {
+    return {pack_idx * WARP_SIZE + thread_idx % WARP_SIZE, 0};
+  }
 };
 
-template<class T>
+template <class T>
 struct SmemCopy_MMA_16816_U {  // (M, K)
-    static constexpr int M = 16;
-    static constexpr int K = 1;
+  static constexpr int M = 16;
+  static constexpr int K = 1;
 
-    static constexpr int kFragNum = 1;
+  static constexpr int kFragNum = 1;
 
-    using Frag = Array<T, 2>;
+  using Frag = Array<T, 2>;
 
-    __device__ static int2 get_offset(int thread_idx)
-    {
-        const int lane_id = thread_idx % WARP_SIZE;
-        // Note: this forbids sub-tile group sizes
-        return {lane_id / 4, 0};
+  __device__ static int2 get_offset(int thread_idx) {
+    const int lane_id = thread_idx % WARP_SIZE;
+    // Note: this forbids sub-tile group sizes
+    return {lane_id / 4, 0};
+  }
+
+  template <class S, class D>
+  __device__ static void copy(S&& src_ptr, D&& dst_ptr, bool mask) {
+    PRAGMA_UNROLL
+    for (int i = 0; i < 2; ++i) {
+      Lds(*((Array<T, 1>*)dst_ptr + i), src_ptr + i * 8);
     }
+  }
 
-    template<class S, class D>
-    __device__ static void copy(S&& src_ptr, D&& dst_ptr, bool mask)
-    {
-        PRAGMA_UNROLL
-        for (int i = 0; i < 2; ++i) {
-            Lds(*((Array<T, 1>*)dst_ptr + i), src_ptr + i * 8);
-        }
-    }
-
-    __device__ static int2 unique(int thread_idx, int pack_idx)
-    {
-        const int lane_id = thread_idx % WARP_SIZE;
-        return {pack_idx * 8 + lane_id / 4, lane_id % 4};
-    }
+  __device__ static int2 unique(int thread_idx, int pack_idx) {
+    const int lane_id = thread_idx % WARP_SIZE;
+    return {pack_idx * 8 + lane_id / 4, lane_id % 4};
+  }
 };
 
 }  // namespace turbomind::gemm

--- a/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/cast.cu
+++ b/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/cast.cu
@@ -9,251 +9,250 @@
 
 namespace turbomind {
 
-template<class Ti, class To>
+template <class Ti, class To>
 struct Cast {
-    template<int N>
-    __device__ static Array<To, N> apply(const Array<Ti, N>& vi)
-    {
-        Array<To, N> vo;
-        PRAGMA_UNROLL
-        for (int i = 0; i < N; ++i) {
-            vo[i] = static_cast<To>(vi[i]);
-        }
-        return vo;
+  template <int N>
+  __device__ static Array<To, N> apply(const Array<Ti, N>& vi) {
+    Array<To, N> vo;
+    PRAGMA_UNROLL
+    for (int i = 0; i < N; ++i) {
+      vo[i] = static_cast<To>(vi[i]);
     }
+    return vo;
+  }
 };
 
-template<class Ti>
+template <class Ti>
 struct Cast<Ti, uint4_t> {
-    template<int N>
-    __device__ static Array<uint4_t, N> apply(const Array<Ti, N>& vi)
-    {
-        static_assert(N % 8 == 0);
-        Array<uint4_t, N> vo;
-        PRAGMA_UNROLL
-        for (int i = 0; i < N; i += 8) {
-            uint32_t& v = (uint32_t&)vo[i];
-            v           = 0;
-            PRAGMA_UNROLL
-            for (int j = 7; j >= 0; --j) {
-                v = (v << 4) | vi[i + j];
-            }
-        }
-        return vo;
+  template <int N>
+  __device__ static Array<uint4_t, N> apply(const Array<Ti, N>& vi) {
+    static_assert(N % 8 == 0);
+    Array<uint4_t, N> vo;
+    PRAGMA_UNROLL
+    for (int i = 0; i < N; i += 8) {
+      uint32_t& v = (uint32_t&)vo[i];
+      v = 0;
+      PRAGMA_UNROLL
+      for (int j = 7; j >= 0; --j) {
+        v = (v << 4) | vi[i + j];
+      }
     }
+    return vo;
+  }
 };
 
-template<class To>
+template <class To>
 struct Cast<uint4_t, To> {
-    template<int N>
-    __device__ static Array<To, N> apply(const Array<uint4_t, N>& vi)
-    {
-        static_assert(N % 8 == 0);
-        Array<To, N> vo;
-        PRAGMA_UNROLL
-        for (int i = 0; i < N; i += 8) {
-            uint32_t v = (const uint32_t&)vi[i];
-            PRAGMA_UNROLL
-            for (int j = 0; j < 8; ++j) {
-                vo[i + j] = (v & 0xf);
-                v >>= 4;
-            }
-        }
-        return vo;
+  template <int N>
+  __device__ static Array<To, N> apply(const Array<uint4_t, N>& vi) {
+    static_assert(N % 8 == 0);
+    Array<To, N> vo;
+    PRAGMA_UNROLL
+    for (int i = 0; i < N; i += 8) {
+      uint32_t v = (const uint32_t&)vi[i];
+      PRAGMA_UNROLL
+      for (int j = 0; j < 8; ++j) {
+        vo[i + j] = (v & 0xf);
+        v >>= 4;
+      }
     }
+    return vo;
+  }
 };
 
-template<>
+template <>
 struct Cast<uint4_t, uint4_t> {
-    template<int N>
-    __device__ static Array<uint4_t, N> apply(const Array<uint4_t, N>& vi)
-    {
-        return vi;
-    }
+  template <int N>
+  __device__ static Array<uint4_t, N> apply(const Array<uint4_t, N>& vi) {
+    return vi;
+  }
 };
 
-template<int VecSize, class Ti, class To>
-__global__ void cast_kernel(To* dst, const Ti* src, size_t n)
-{
-    n /= VecSize;
+template <int VecSize, class Ti, class To>
+__global__ void cast_kernel(To* dst, const Ti* src, size_t n) {
+  n /= VecSize;
 
-    auto p_src = (const Array<Ti, VecSize>*)src;
-    auto p_dst = (Array<To, VecSize>*)dst;
+  auto p_src = (const Array<Ti, VecSize>*)src;
+  auto p_dst = (Array<To, VecSize>*)dst;
 
-    for (size_t p = threadIdx.x + blockDim.x * blockIdx.x; p < n; p += blockDim.x * gridDim.x) {
-        Array<Ti, VecSize> vi;
-        Ldg(vi, (const Ti*)&p_src[p]);
+  for (size_t p = threadIdx.x + blockDim.x * blockIdx.x; p < n;
+       p += blockDim.x * gridDim.x) {
+    Array<Ti, VecSize> vi;
+    Ldg(vi, (const Ti*)&p_src[p]);
 
-        Array<To, VecSize> vo = Cast<Ti, To>::apply(vi);
+    Array<To, VecSize> vo = Cast<Ti, To>::apply(vi);
 
-        Store((To*)&p_dst[p], vo);
-    }
+    Store((To*)&p_dst[p], vo);
+  }
 }
 
-template<int VecSize, class Ti, class To>
-void invokeCast(To* dst, const Ti* src, size_t n, cudaStream_t st)
-{
-    cast_kernel<VecSize><<<256, 256, 0, st>>>(dst, src, n);
+template <int VecSize, class Ti, class To>
+void invokeCast(To* dst, const Ti* src, size_t n, cudaStream_t st) {
+  cast_kernel<VecSize><<<256, 256, 0, st>>>(dst, src, n);
 }
 
-void extend_to_u8(uint8_t* dst, const uint4_t* src, size_t n, cudaStream_t st)
-{
-    invokeCast<8>(dst, src, n, st);
+void extend_to_u8(uint8_t* dst, const uint4_t* src, size_t n, cudaStream_t st) {
+  invokeCast<8>(dst, src, n, st);
 }
 
-void compact_to_u4(uint4_t* dst, const uint8_t* src, size_t n, cudaStream_t st)
-{
-    invokeCast<8>(dst, src, n, st);
+void compact_to_u4(uint4_t* dst, const uint8_t* src, size_t n,
+                   cudaStream_t st) {
+  invokeCast<8>(dst, src, n, st);
 }
 
-void extend_to_u16(uint16_t* dst, const uint4_t* src, size_t n, cudaStream_t st)
-{
-    invokeCast<8>(dst, src, n, st);
+void extend_to_u16(uint16_t* dst, const uint4_t* src, size_t n,
+                   cudaStream_t st) {
+  invokeCast<8>(dst, src, n, st);
 }
 
 namespace {
 
-__global__ void extend_u16_u8(uint16_t* dst, const uint8_t* src, size_t n)
-{
-    int64_t idx = threadIdx.x + (int64_t)blockDim.x * blockIdx.x;
-    if (idx < n) {
-        dst[idx] = src[idx];
-    }
+__global__ void extend_u16_u8(uint16_t* dst, const uint8_t* src, size_t n) {
+  int64_t idx = threadIdx.x + (int64_t)blockDim.x * blockIdx.x;
+  if (idx < n) {
+    dst[idx] = src[idx];
+  }
 }
 
 }  // namespace
 
-void extend_to_u16(uint16_t* dst, const uint8_t* src, size_t n, cudaStream_t st)
-{
-    extend_u16_u8<<<(n + 511) / 512, 512, 0, st>>>(dst, src, n);
+void extend_to_u16(uint16_t* dst, const uint8_t* src, size_t n,
+                   cudaStream_t st) {
+  extend_u16_u8<<<(n + 511) / 512, 512, 0, st>>>(dst, src, n);
 }
 
-template<int VecSize, class T>
-__global__ void fuse_scales_and_zeros_kernel(T* fused, const T* scales, T* zeros, size_t n)
-{
-    n /= VecSize;
+template <int VecSize, class T>
+__global__ void fuse_scales_and_zeros_kernel(T* fused, const T* scales,
+                                             T* zeros, size_t n) {
+  n /= VecSize;
 
-    auto p_scales = (const Array<T, VecSize>*)scales;
-    auto p_zeros  = (const Array<T, VecSize>*)zeros;
+  auto p_scales = (const Array<T, VecSize>*)scales;
+  auto p_zeros = (const Array<T, VecSize>*)zeros;
 
-    auto p_fused = (Array<T, VecSize * 2>*)fused;
+  auto p_fused = (Array<T, VecSize * 2>*)fused;
 
-    for (size_t p = threadIdx.x + blockDim.x * blockIdx.x; p < n; p += blockDim.x * gridDim.x) {
-        Array<T, VecSize> vs;
-        Ldg(vs, (const T*)&p_scales[p]);
-        Array<T, VecSize> vz{};
-        if (zeros) {
-            Ldg(vz, (const T*)&p_zeros[p]);
-        }
-        Array<T, VecSize * 2> vf;
-        PRAGMA_UNROLL
-        for (int i = 0; i < VecSize; ++i) {
-            vf[i * 2]     = vs[i];
-            vf[i * 2 + 1] = -vz[i] * vs[i];
-        }
-        Store((T*)&p_fused[p], vf);
+  for (size_t p = threadIdx.x + blockDim.x * blockIdx.x; p < n;
+       p += blockDim.x * gridDim.x) {
+    Array<T, VecSize> vs;
+    Ldg(vs, (const T*)&p_scales[p]);
+    Array<T, VecSize> vz{};
+    if (zeros) {
+      Ldg(vz, (const T*)&p_zeros[p]);
     }
-}
-
-void fuse_scales_and_zeros(half* fused, const half* scales, half* zeros, size_t n, cudaStream_t st)
-{
-    fuse_scales_and_zeros_kernel<4><<<256, 256, 0, st>>>(fused, scales, zeros, n);
-}
-
-template<int VecSize, class T>
-__global__ void
-interleave_output_dims_kernel(T* __restrict__ fused, const T* __restrict__ a, const T* __restrict__ b, int m, int k)
-{
-    using Vec1 = Array<T, VecSize>;
-
-    const int ki = blockIdx.y;
-
-    auto p_a = reinterpret_cast<const Vec1*>(a + ki * m);
-    auto p_b = reinterpret_cast<const Vec1*>(b + ki * m);
-
-    using Vec2 = Array<T, VecSize * 2>;
-
-    auto p_f = reinterpret_cast<Vec2*>(fused + ki * m * 2);
-
-    m /= VecSize;
-
-    const int tidx = threadIdx.x + blockIdx.x * blockDim.x;
-
-    for (int64_t mi = tidx; mi < m; mi += blockDim.x * gridDim.x) {
-        Vec1 va;
-        Vec1 vb;
-        Ldg(va, (const T*)&p_a[mi]);
-        Ldg(vb, (const T*)&p_b[mi]);
-        Vec2 vc;
-        PRAGMA_UNROLL
-        for (int i = 0; i < VecSize; ++i) {
-            vc[i * 2]     = va[i];
-            vc[i * 2 + 1] = vb[i];
-        }
-        Store((T*)&p_f[mi], vc);
+    Array<T, VecSize * 2> vf;
+    PRAGMA_UNROLL
+    for (int i = 0; i < VecSize; ++i) {
+      vf[i * 2] = vs[i];
+      vf[i * 2 + 1] = -vz[i] * vs[i];
     }
+    Store((T*)&p_fused[p], vf);
+  }
 }
 
-template<class T>
-void interleave_output_dims_impl(T* fused, const T* a, const T* b, int m, int k, cudaStream_t st)
-{
-    constexpr int kVecSize = std::min(8, 128 / (bitsof<T> * 2));
-
-    constexpr int block = 256;
-    const dim3    grid(1, k);  // x is a grid stride loop
-
-    interleave_output_dims_kernel<kVecSize><<<grid, block, 0, st>>>(fused, a, b, m, k);
+void fuse_scales_and_zeros(half* fused, const half* scales, half* zeros,
+                           size_t n, cudaStream_t st) {
+  fuse_scales_and_zeros_kernel<4><<<256, 256, 0, st>>>(fused, scales, zeros, n);
 }
 
-template void
-interleave_output_dims_impl(uint8_t* fused, const uint8_t* a, const uint8_t* b, int m, int k, cudaStream_t st);
-template void
-interleave_output_dims_impl(uint16_t* fused, const uint16_t* a, const uint16_t* b, int m, int k, cudaStream_t st);
-template void
-interleave_output_dims_impl(uint32_t* fused, const uint32_t* a, const uint32_t* b, int m, int k, cudaStream_t st);
+template <int VecSize, class T>
+__global__ void interleave_output_dims_kernel(T* __restrict__ fused,
+                                              const T* __restrict__ a,
+                                              const T* __restrict__ b, int m,
+                                              int k) {
+  using Vec1 = Array<T, VecSize>;
 
-__global__ void adjust_ue8m0_scale_for_half_kernel(uint8_t* data, int n)
-{
-    int64_t idx = threadIdx.x + (int64_t)blockDim.x * blockIdx.x;
-    if (idx < n) {
-        /// TODO: saturate the quantized values accordingly
-        data[idx] = max(0, min(30, (int)data[idx] + 15 - 127));  // exponent 31 is INF in half
+  const int ki = blockIdx.y;
+
+  auto p_a = reinterpret_cast<const Vec1*>(a + ki * m);
+  auto p_b = reinterpret_cast<const Vec1*>(b + ki * m);
+
+  using Vec2 = Array<T, VecSize * 2>;
+
+  auto p_f = reinterpret_cast<Vec2*>(fused + ki * m * 2);
+
+  m /= VecSize;
+
+  const int tidx = threadIdx.x + blockIdx.x * blockDim.x;
+
+  for (int64_t mi = tidx; mi < m; mi += blockDim.x * gridDim.x) {
+    Vec1 va;
+    Vec1 vb;
+    Ldg(va, (const T*)&p_a[mi]);
+    Ldg(vb, (const T*)&p_b[mi]);
+    Vec2 vc;
+    PRAGMA_UNROLL
+    for (int i = 0; i < VecSize; ++i) {
+      vc[i * 2] = va[i];
+      vc[i * 2 + 1] = vb[i];
     }
+    Store((T*)&p_f[mi], vc);
+  }
 }
 
-void AdjustUe8m0ScaleForHalf(uint8_t* data, int n, cudaStream_t st)
-{
-    constexpr int block = 512;
-    const int     grid  = cdiv(n, block);
-    adjust_ue8m0_scale_for_half_kernel<<<grid, block, 0, st>>>(data, n);
+template <class T>
+void interleave_output_dims_impl(T* fused, const T* a, const T* b, int m, int k,
+                                 cudaStream_t st) {
+  constexpr int kVecSize = std::min(8, 128 / (bitsof<T> * 2));
+
+  constexpr int block = 256;
+  const dim3 grid(1, k);  // x is a grid stride loop
+
+  interleave_output_dims_kernel<kVecSize>
+      <<<grid, block, 0, st>>>(fused, a, b, m, k);
 }
 
-template<class T0, class T1>
-__global__ void BlockscaleToGroupscale_Kernel(T1* dst, const T0* src, int64_t n, int block_size)
-{
-    int64_t idx = threadIdx.x + (int64_t)blockIdx.x * blockDim.x;
-    if (idx < n) {
-        dst[idx] = (T1)src[idx / block_size];
-    }
+template void interleave_output_dims_impl(uint8_t* fused, const uint8_t* a,
+                                          const uint8_t* b, int m, int k,
+                                          cudaStream_t st);
+template void interleave_output_dims_impl(uint16_t* fused, const uint16_t* a,
+                                          const uint16_t* b, int m, int k,
+                                          cudaStream_t st);
+template void interleave_output_dims_impl(uint32_t* fused, const uint32_t* a,
+                                          const uint32_t* b, int m, int k,
+                                          cudaStream_t st);
+
+__global__ void adjust_ue8m0_scale_for_half_kernel(uint8_t* data, int n) {
+  int64_t idx = threadIdx.x + (int64_t)blockDim.x * blockIdx.x;
+  if (idx < n) {
+    /// TODO: saturate the quantized values accordingly
+    data[idx] = max(
+        0, min(30, (int)data[idx] + 15 - 127));  // exponent 31 is INF in half
+  }
 }
 
-Tensor BlockscaleToGroupscale(const Tensor& scales, DataType data_type, int block_size)
-{
-    TM_CHECK_EQ(scales.dtype(), kFloat32);
+void AdjustUe8m0ScaleForHalf(uint8_t* data, int n, cudaStream_t st) {
+  constexpr int block = 512;
+  const int grid = cdiv(n, block);
+  adjust_ue8m0_scale_for_half_kernel<<<grid, block, 0, st>>>(data, n);
+}
 
-    Tensor ret{{scales.shape(0), scales.shape(1) * block_size}, data_type, kDEVICE};
+template <class T0, class T1>
+__global__ void BlockscaleToGroupscale_Kernel(T1* dst, const T0* src, int64_t n,
+                                              int block_size) {
+  int64_t idx = threadIdx.x + (int64_t)blockIdx.x * blockDim.x;
+  if (idx < n) {
+    dst[idx] = (T1)src[idx / block_size];
+  }
+}
 
-    auto stream = core::Context::stream().handle();
+Tensor BlockscaleToGroupscale(const Tensor& scales, DataType data_type,
+                              int block_size) {
+  TM_CHECK_EQ(scales.dtype(), kFloat32);
 
-    auto invoke = [&](auto t) {
-        using T = decltype(t);
-        BlockscaleToGroupscale_Kernel<<<(ret.size() + 511) / 512, 512, 0, stream>>>(
-            ret.data<T>(), scales.data<float>(), ret.size(), block_size);
-    };
+  Tensor ret{
+      {scales.shape(0), scales.shape(1) * block_size}, data_type, kDEVICE};
 
-    TM_DISPATCH_DTYPES(data_type, invoke, half_t, bfloat16_t);
+  auto stream = core::Context::stream().handle();
 
-    return ret;
+  auto invoke = [&](auto t) {
+    using T = decltype(t);
+    BlockscaleToGroupscale_Kernel<<<(ret.size() + 511) / 512, 512, 0, stream>>>(
+        ret.data<T>(), scales.data<float>(), ret.size(), block_size);
+  };
+
+  TM_DISPATCH_DTYPES(data_type, invoke, half_t, bfloat16_t);
+
+  return ret;
 }
 
 }  // namespace turbomind

--- a/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/cast.h
+++ b/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/cast.h
@@ -7,41 +7,48 @@
 
 namespace turbomind {
 
-void extend_to_u8(uint8_t* dst, const uint4_t* src, size_t n, cudaStream_t st = {});
+void extend_to_u8(uint8_t* dst, const uint4_t* src, size_t n,
+                  cudaStream_t st = {});
 
-void extend_to_u16(uint16_t* dst, const uint4_t* src, size_t n, cudaStream_t st = {});
+void extend_to_u16(uint16_t* dst, const uint4_t* src, size_t n,
+                   cudaStream_t st = {});
 
-void extend_to_u16(uint16_t* dst, const uint8_t* src, size_t n, cudaStream_t st);
+void extend_to_u16(uint16_t* dst, const uint8_t* src, size_t n,
+                   cudaStream_t st);
 
-void compact_to_u4(uint4_t* dst, const uint8_t* src, size_t n, cudaStream_t st = {});
+void compact_to_u4(uint4_t* dst, const uint8_t* src, size_t n,
+                   cudaStream_t st = {});
 
-void transpose_u4(uint4_t* dst, const uint4_t* src, int s, int c, cudaStream_t st = {});
+void transpose_u4(uint4_t* dst, const uint4_t* src, int s, int c,
+                  cudaStream_t st = {});
 
-void fuse_scales_and_zeros(half* fused, const half* scales, half* zeros, size_t n, cudaStream_t st = {});
+void fuse_scales_and_zeros(half* fused, const half* scales, half* zeros,
+                           size_t n, cudaStream_t st = {});
 
-template<class T>
-void interleave_output_dims_impl(T* fused, const T* a, const T* b, int m, int k, cudaStream_t st);
+template <class T>
+void interleave_output_dims_impl(T* fused, const T* a, const T* b, int m, int k,
+                                 cudaStream_t st);
 
-template<class T>
-inline void interleave_output_dims(T* fused, const T* a, const T* b, int m, int k, cudaStream_t st)
-{
-    auto dispatch = [&](auto u) {
-        using U = decltype(u);
-        return interleave_output_dims_impl((U*)fused, (const U*)a, (const U*)b, m, k, st);
-    };
-    if constexpr (bitsof<T> == 8) {
-        return dispatch(uint8_t{});
-    }
-    else if constexpr (bitsof<T> == 16) {
-        return dispatch(uint16_t{});
-    }
-    else if constexpr (bitsof<T> == 32) {
-        return dispatch(uint32_t{});
-    }
+template <class T>
+inline void interleave_output_dims(T* fused, const T* a, const T* b, int m,
+                                   int k, cudaStream_t st) {
+  auto dispatch = [&](auto u) {
+    using U = decltype(u);
+    return interleave_output_dims_impl((U*)fused, (const U*)a, (const U*)b, m,
+                                       k, st);
+  };
+  if constexpr (bitsof<T> == 8) {
+    return dispatch(uint8_t{});
+  } else if constexpr (bitsof<T> == 16) {
+    return dispatch(uint16_t{});
+  } else if constexpr (bitsof<T> == 32) {
+    return dispatch(uint32_t{});
+  }
 }
 
 void AdjustUe8m0ScaleForHalf(uint8_t* data, int n, cudaStream_t st);
 
-Tensor BlockscaleToGroupscale(const Tensor& scales, DataType data_type, int block_size);
+Tensor BlockscaleToGroupscale(const Tensor& scales, DataType data_type,
+                              int block_size);
 
 }  // namespace turbomind

--- a/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/context.cu
+++ b/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/context.cu
@@ -16,234 +16,241 @@
 
 namespace turbomind::gemm {
 
-static std::optional<GemmDesc> get_gemm_desc(const Operation&    operation,
-                                             const MatrixLayout& Adesc,
-                                             const MatrixLayout& Udesc,
-                                             const MatrixLayout& Bdesc,
-                                             const MatrixLayout& Vdesc,
-                                             const MatrixLayout& Cdesc,
-                                             const MatrixLayout& Ddesc,
-                                             int                 arch)
-{
+static std::optional<GemmDesc> get_gemm_desc(
+    const Operation& operation, const MatrixLayout& Adesc,
+    const MatrixLayout& Udesc, const MatrixLayout& Bdesc,
+    const MatrixLayout& Vdesc, const MatrixLayout& Cdesc,
+    const MatrixLayout& Ddesc, int arch) {
+  // Constant dimensions are set to the exact value
+  // Variable dimensions are set to sum of the values
 
-    // Constant dimensions are set to the exact value
-    // Variable dimensions are set to sum of the values
+  const int m0 = Adesc.rows, k0 = Adesc.cols;
+  const int k1 = Bdesc.rows, n0 = Bdesc.cols;
+  const int m1 = Ddesc.rows, n1 = Ddesc.cols;
 
-    const int m0 = Adesc.rows, k0 = Adesc.cols;
-    const int k1 = Bdesc.rows, n0 = Bdesc.cols;
-    const int m1 = Ddesc.rows, n1 = Ddesc.cols;
+  const int l0 = Adesc.num, l1 = Bdesc.num, l2 = Ddesc.num;
 
-    const int l0 = Adesc.num, l1 = Bdesc.num, l2 = Ddesc.num;
+  if (m0 != m1 || n0 != n1 || k0 != k1 || l0 != l1 || l0 != l2) {
+    fprintf(stderr, "%d %d %d %d %d %d %d %d %d\n", m0, m1, n0, n1, k0, k1, l0,
+            l1, l2);
+    return {};
+  }
 
-    if (m0 != m1 || n0 != n1 || k0 != k1 || l0 != l1 || l0 != l2) {
-        fprintf(stderr, "%d %d %d %d %d %d %d %d %d\n", m0, m1, n0, n1, k0, k1, l0, l1, l2);
-        return {};
-    }
+  GemmDesc desc{arch,
+                Adesc.type,
+                Bdesc.type,
+                Ddesc.type,
+                Adesc.order,
+                Bdesc.order,
+                Ddesc.order,
+                get_mode(Adesc),
+                get_mode(Bdesc),
+                get_mode(Ddesc),
+                Adesc.pack,
+                Bdesc.pack,
+                Udesc.pack,
+                Vdesc.pack,
+                operation.quant_a,
+                operation.quant_b,
+                operation.epilogue,
+                operation.batch_dim,
+                -1};
 
-    GemmDesc desc{arch,
-                  Adesc.type,
-                  Bdesc.type,
-                  Ddesc.type,
-                  Adesc.order,
-                  Bdesc.order,
-                  Ddesc.order,
-                  get_mode(Adesc),
-                  get_mode(Bdesc),
-                  get_mode(Ddesc),
-                  Adesc.pack,
-                  Bdesc.pack,
-                  Udesc.pack,
-                  Vdesc.pack,
-                  operation.quant_a,
-                  operation.quant_b,
-                  operation.epilogue,
-                  operation.batch_dim,
-                  -1};
+  desc.m = m0;
+  desc.n = n0;
+  desc.k = k0;
+  desc.num = std::max(l0, 1);
 
-    desc.m   = m0;
-    desc.n   = n0;
-    desc.k   = k0;
-    desc.num = std::max(l0, 1);
+  if (desc.num > 1) {
+    desc.group_axis = operation.batch_dim;
+  }
 
-    if (desc.num > 1) {
-        desc.group_axis = operation.batch_dim;
-    }
-
-    return desc;
+  return desc;
 }
 
-std::vector<LaunchSpec> get_swizzle(const int4& shape, const LaunchSpec& spec, const std::vector<int>& swizzle)
-{
-    std::vector<int> vec;
-    const int        max_swizzle = spec.kernel->GetMaxSwizzle(shape);
-    for (const auto& s : swizzle) {
-        if (s <= max_swizzle && std::find(vec.begin(), vec.end(), s) == vec.end()) {
-            vec.push_back(s);
-        }
+std::vector<LaunchSpec> get_swizzle(const int4& shape, const LaunchSpec& spec,
+                                    const std::vector<int>& swizzle) {
+  std::vector<int> vec;
+  const int max_swizzle = spec.kernel->GetMaxSwizzle(shape);
+  for (const auto& s : swizzle) {
+    if (s <= max_swizzle && std::find(vec.begin(), vec.end(), s) == vec.end()) {
+      vec.push_back(s);
     }
-    std::vector<LaunchSpec> ret;
-    for (const auto& s : vec) {
-        auto tmp    = spec;
-        tmp.swizzle = s;
-        ret.push_back(tmp);
-    }
-    return ret;
+  }
+  std::vector<LaunchSpec> ret;
+  for (const auto& s : vec) {
+    auto tmp = spec;
+    tmp.swizzle = s;
+    ret.push_back(tmp);
+  }
+  return ret;
 }
 
-Context::Context(const cudaDeviceProp& prop)
-{
-    arch_     = prop.major * 100 + prop.minor * 10;
-    sm_count_ = prop.multiProcessorCount;
+Context::Context(const cudaDeviceProp& prop) {
+  arch_ = prop.major * 100 + prop.minor * 10;
+  sm_count_ = prop.multiProcessorCount;
 }
 
-bool Context::Init(const Operation&    operation,
-                   const MatrixLayout& Adesc,
-                   const MatrixLayout& Udesc,
-                   const MatrixLayout& Bdesc,
-                   const MatrixLayout& Vdesc,
-                   const MatrixLayout& Cdesc,
-                   const MatrixLayout& Ddesc)
-{
-    auto desc = get_gemm_desc(operation, Adesc, Udesc, Bdesc, Vdesc, Cdesc, Ddesc, arch_);
-    if (!desc) {
-        return false;
-    }
+bool Context::Init(const Operation& operation, const MatrixLayout& Adesc,
+                   const MatrixLayout& Udesc, const MatrixLayout& Bdesc,
+                   const MatrixLayout& Vdesc, const MatrixLayout& Cdesc,
+                   const MatrixLayout& Ddesc) {
+  auto desc =
+      get_gemm_desc(operation, Adesc, Udesc, Bdesc, Vdesc, Cdesc, Ddesc, arch_);
+  if (!desc) {
+    return false;
+  }
 
-    desc_       = *desc;
-    desc_trans_ = transpose(desc_);
+  desc_ = *desc;
+  desc_trans_ = transpose(desc_);
 
-    return true;
+  return true;
 }
 
-std::vector<Kernel*> Context::Filter(const std::vector<Kernel*>& kernels) const
-{
-    std::vector<std::pair<Kernel*, int>> feasible;
-    auto get_batch_dim  = [](auto k, auto& g) { return g.batch_dim ? k->desc().cta_tile.y : k->desc().cta_tile.x; };
-    int  max_batch_size = 0;  // max batch size of single CTA tile
+std::vector<Kernel*> Context::Filter(
+    const std::vector<Kernel*>& kernels) const {
+  std::vector<std::pair<Kernel*, int>> feasible;
+  auto get_batch_dim = [](auto k, auto& g) {
+    return g.batch_dim ? k->desc().cta_tile.y : k->desc().cta_tile.x;
+  };
+  int max_batch_size = 0;  // max batch size of single CTA tile
 
-    for (auto& k : kernels) {
-        auto& g = get_desc(*k);
-        if (k->is_feasible(g)) {
-            auto bsz = get_batch_dim(k, g);
-            feasible.emplace_back(k, bsz);
-            max_batch_size = std::max(bsz, max_batch_size);
-        }
+  for (auto& k : kernels) {
+    auto& g = get_desc(*k);
+    if (k->is_feasible(g)) {
+      auto bsz = get_batch_dim(k, g);
+      feasible.emplace_back(k, bsz);
+      max_batch_size = std::max(bsz, max_batch_size);
     }
+  }
 
-    // Batch size of the GEMM problem
-    const int batch_size = desc_.batch_dim ? desc_.n : desc_.m;
-    // std::cout << "BATCH SIZE: " << batch_size << "\n";
+  // Batch size of the GEMM problem
+  const int batch_size = desc_.batch_dim ? desc_.n : desc_.m;
+  // std::cout << "BATCH SIZE: " << batch_size << "\n";
 
-    // Find smallest kernel the problem can fit into (may not exist)
-    for (const auto& [k, bsz] : feasible) {
-        if (bsz >= batch_size) {
-            max_batch_size = std::min(max_batch_size, bsz);
-        }
+  // Find smallest kernel the problem can fit into (may not exist)
+  for (const auto& [k, bsz] : feasible) {
+    if (bsz >= batch_size) {
+      max_batch_size = std::min(max_batch_size, bsz);
     }
+  }
 
-    const auto pred = [&](auto k) {  //
-        return k.second > max_batch_size;
-    };
-    feasible.erase(std::remove_if(feasible.begin(), feasible.end(), pred), feasible.end());
+  const auto pred = [&](auto k) {  //
+    return k.second > max_batch_size;
+  };
+  feasible.erase(std::remove_if(feasible.begin(), feasible.end(), pred),
+                 feasible.end());
 
-    std::vector<Kernel*> ret;
-    for (auto& [k, bsz] : feasible) {
-        // std::cout << "KERNEL: " << k->name() << ", BSZ: " << bsz << std::endl;
-        ret.push_back(k);
-    }
+  std::vector<Kernel*> ret;
+  for (auto& [k, bsz] : feasible) {
+    // std::cout << "KERNEL: " << k->name() << ", BSZ: " << bsz << std::endl;
+    ret.push_back(k);
+  }
 
-    return ret;
+  return ret;
 }
 
-std::vector<LaunchSpec> Context::Populate(const Kernel& kernel, const PopulateParam& param) const
-{
-    // early exit for cuBLAS backend
-    if (kernel.desc().backend) {
-        return {LaunchSpec{const_cast<Kernel*>(&kernel), 0, 1}};
+std::vector<LaunchSpec> Context::Populate(const Kernel& kernel,
+                                          const PopulateParam& param) const {
+  // early exit for cuBLAS backend
+  if (kernel.desc().backend) {
+    return {LaunchSpec{const_cast<Kernel*>(&kernel), 0, 1}};
+  }
+
+  const auto& gemm = get_desc(kernel);
+
+  const int m = gemm.m, n = gemm.n, k = gemm.k, num = std::max(1, gemm.num);
+
+  const auto& desc = kernel.desc();
+  const auto& info = kernel.info();
+
+  const int64_t tiled_shape_m =
+      cdiv(m, desc.cta_tile.x * (desc.group_axis == 0 ? num : 1));
+  const int64_t tiled_shape_n =
+      cdiv(n, desc.cta_tile.y * (desc.group_axis == 1 ? num : 1));
+  const int chunk_cnt_k = cdiv(k, kernel.chunk_size_k());
+
+  // Despite we only have sm_count * constant tensor cores, this is the
+  // granularity for scheduling
+  const int concurrency = sm_count_ * kernel.info().max_active_ctas;
+  const float waves_per_split =
+      float(tiled_shape_m * tiled_shape_n) / concurrency;
+  const float splits_per_wave = 1.f / waves_per_split;
+
+  // Tile quantization
+  const int64_t ceil_m = tiled_shape_m * desc.cta_tile.x;
+  const int64_t ceil_n = tiled_shape_n * desc.cta_tile.y;
+
+  // int max_splits = kernel.GetMaxSplits(m, n, k, param.barriers_size,
+  // param.partials_size);
+  int max_splits = kernel.GetMaxSplits({m, n, k, num}, 0, param.barriers_size,
+                                       param.partials_size);
+
+  // std::cout << "max_splits: " << max_splits << std::endl;
+
+  max_splits = std::min(param.max_splits, max_splits);
+
+  std::vector<LaunchSpec> specs;
+
+  /// TODO: revise this according to the latest scheduler
+  for (int splits = 1; splits <= max_splits; ++splits) {
+    // Split quantization, penalize uneven splits
+    const int64_t split_ceil_k =
+        cdiv(chunk_cnt_k, splits) * kernel.chunk_size_k();
+    // Footprint for single split
+    const int64_t split_mma_cost = ceil_m * ceil_n * split_ceil_k;
+    // Footprint for single wave
+    const int64_t wave_mma_cost = split_mma_cost * splits_per_wave;
+
+    // Wave quantization
+    // const int waves = (int)std::ceil(wave_per_split * splits);
+
+    // Bold simulation of thread block scheduling
+    const int grid_size = tiled_shape_m * tiled_shape_n * splits * num;
+    const int full_waves = grid_size / concurrency;
+    const int residue = grid_size % concurrency;
+    const float partial_wave =
+        (float)cdiv(residue, sm_count_) / info.max_active_ctas;
+    const float waves = full_waves + partial_wave;
+
+    if (splits > 1 && waves > param.max_waves) {
+      break;
     }
+    // ceil(tiled_mn / C * splits) * C / tiled_mn * ceil_m * ceil_n *
+    // split_ceil_k
+    const int64_t mma_cost = wave_mma_cost * waves;
 
-    const auto& gemm = get_desc(kernel);
+    // IO has less severe quantization effect
+    const int64_t mio_cost_a =
+        byte_size(desc.type_a, tiled_shape_n * m * split_ceil_k) * splits * num;
+    const int64_t mio_cost_b =
+        byte_size(desc.type_b, tiled_shape_m * n * split_ceil_k) * splits * num;
+    /// TODO: read type from `desc_.accum` when added
+    const int64_t mio_cost_c =
+        byte_size(desc.type_c, (int64_t)m * n) * (splits - 1) * 2 * num;
+    const int64_t mio_cost = mio_cost_a + mio_cost_b + mio_cost_c;
 
-    const int m = gemm.m, n = gemm.n, k = gemm.k, num = std::max(1, gemm.num);
+    // std::cout << kernel.name() << " " << splits << " " << waves << " " <<
+    // (float)mio_cost << " " << (float)mma_cost
+    //           << "\n";
 
-    const auto& desc = kernel.desc();
-    const auto& info = kernel.info();
+    // metrics.emplace_back(splits, KernelMetric{mio_cost, mma_cost});
 
-    const int64_t tiled_shape_m = cdiv(m, desc.cta_tile.x * (desc.group_axis == 0 ? num : 1));
-    const int64_t tiled_shape_n = cdiv(n, desc.cta_tile.y * (desc.group_axis == 1 ? num : 1));
-    const int     chunk_cnt_k   = cdiv(k, kernel.chunk_size_k());
+    LaunchSpec spec{};
+    spec.kernel = const_cast<Kernel*>(&kernel);
+    spec.splits = splits;
+    spec.swizzle = param.swizzle;
+    spec.estimated = {mio_cost, mma_cost};
+    specs.push_back(spec);
+  }
 
-    // Despite we only have sm_count * constant tensor cores, this is the granularity for scheduling
-    const int   concurrency     = sm_count_ * kernel.info().max_active_ctas;
-    const float waves_per_split = float(tiled_shape_m * tiled_shape_n) / concurrency;
-    const float splits_per_wave = 1.f / waves_per_split;
-
-    // Tile quantization
-    const int64_t ceil_m = tiled_shape_m * desc.cta_tile.x;
-    const int64_t ceil_n = tiled_shape_n * desc.cta_tile.y;
-
-    // int max_splits = kernel.GetMaxSplits(m, n, k, param.barriers_size, param.partials_size);
-    int max_splits = kernel.GetMaxSplits({m, n, k, num}, 0, param.barriers_size, param.partials_size);
-
-    // std::cout << "max_splits: " << max_splits << std::endl;
-
-    max_splits = std::min(param.max_splits, max_splits);
-
-    std::vector<LaunchSpec> specs;
-
-    /// TODO: revise this according to the lastest scheduler
-    for (int splits = 1; splits <= max_splits; ++splits) {
-        // Split quantization, penalize uneven splits
-        const int64_t split_ceil_k = cdiv(chunk_cnt_k, splits) * kernel.chunk_size_k();
-        // Footprint for single split
-        const int64_t split_mma_cost = ceil_m * ceil_n * split_ceil_k;
-        // Footprint for single wave
-        const int64_t wave_mma_cost = split_mma_cost * splits_per_wave;
-
-        // Wave quantization
-        // const int waves = (int)std::ceil(wave_per_split * splits);
-
-        // Bold simulation of thread block scheduling
-        const int   grid_size    = tiled_shape_m * tiled_shape_n * splits * num;
-        const int   full_waves   = grid_size / concurrency;
-        const int   residue      = grid_size % concurrency;
-        const float partial_wave = (float)cdiv(residue, sm_count_) / info.max_active_ctas;
-        const float waves        = full_waves + partial_wave;
-
-        if (splits > 1 && waves > param.max_waves) {
-            break;
-        }
-        // ceil(tiled_mn / C * splits) * C / tiled_mn * ceil_m * ceil_n * split_ceil_k
-        const int64_t mma_cost = wave_mma_cost * waves;
-
-        // IO has less severe quantization effect
-        const int64_t mio_cost_a = byte_size(desc.type_a, tiled_shape_n * m * split_ceil_k) * splits * num;
-        const int64_t mio_cost_b = byte_size(desc.type_b, tiled_shape_m * n * split_ceil_k) * splits * num;
-        /// TODO: read type from `desc_.accum` when added
-        const int64_t mio_cost_c = byte_size(desc.type_c, (int64_t)m * n) * (splits - 1) * 2 * num;
-        const int64_t mio_cost   = mio_cost_a + mio_cost_b + mio_cost_c;
-
-        // std::cout << kernel.name() << " " << splits << " " << waves << " " << (float)mio_cost << " " <<
-        // (float)mma_cost
-        //           << "\n";
-
-        // metrics.emplace_back(splits, KernelMetric{mio_cost, mma_cost});
-
-        LaunchSpec spec{};
-        spec.kernel    = const_cast<Kernel*>(&kernel);
-        spec.splits    = splits;
-        spec.swizzle   = param.swizzle;
-        spec.estimated = {mio_cost, mma_cost};
-        specs.push_back(spec);
-    }
-
-    return specs;
+  return specs;
 }
 
-std::vector<LaunchSpec> Context::Swizzle(const LaunchSpec& spec, const std::vector<int>& swizzle) const
-{
-    auto& desc = get_desc(*spec.kernel);
-    return get_swizzle({desc.m, desc.n, desc.k, desc.num}, spec, swizzle);
+std::vector<LaunchSpec> Context::Swizzle(
+    const LaunchSpec& spec, const std::vector<int>& swizzle) const {
+  auto& desc = get_desc(*spec.kernel);
+  return get_swizzle({desc.m, desc.n, desc.k, desc.num}, spec, swizzle);
 }
 
 }  // namespace turbomind::gemm

--- a/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/context.h
+++ b/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/context.h
@@ -8,61 +8,56 @@
 namespace turbomind::gemm {
 
 struct PopulateParam {
-    int    max_splits;
-    int    max_waves;
-    int    swizzle;
-    size_t barriers_size;
-    size_t partials_size;
+  int max_splits;
+  int max_waves;
+  int swizzle;
+  size_t barriers_size;
+  size_t partials_size;
 };
 
 class Context {
-public:
-    explicit Context(const cudaDeviceProp& prop);
+ public:
+  explicit Context(const cudaDeviceProp& prop);
 
-    bool Init(const Operation&    operation,
-              const MatrixLayout& Adesc,
-              const MatrixLayout& Udesc,
-              const MatrixLayout& Bdesc,
-              const MatrixLayout& Vdesc,
-              const MatrixLayout& Cdesc,
-              const MatrixLayout& Ddesc);
+  bool Init(const Operation& operation, const MatrixLayout& Adesc,
+            const MatrixLayout& Udesc, const MatrixLayout& Bdesc,
+            const MatrixLayout& Vdesc, const MatrixLayout& Cdesc,
+            const MatrixLayout& Ddesc);
 
-    std::vector<Kernel*> Filter(const std::vector<Kernel*>& kernels) const;
+  std::vector<Kernel*> Filter(const std::vector<Kernel*>& kernels) const;
 
-    std::vector<LaunchSpec> Populate(const Kernel& kernel, const PopulateParam& param) const;
+  std::vector<LaunchSpec> Populate(const Kernel& kernel,
+                                   const PopulateParam& param) const;
 
-    std::vector<LaunchSpec> Swizzle(const LaunchSpec& spec, const std::vector<int>& swizzle) const;
+  std::vector<LaunchSpec> Swizzle(const LaunchSpec& spec,
+                                  const std::vector<int>& swizzle) const;
 
-    const GemmDesc& desc() const
-    {
-        return desc_;
-    }
+  const GemmDesc& desc() const { return desc_; }
 
-    const GemmDesc& get_desc(const Kernel& kernel) const
-    {
-        return kernel.desc().transpose ? desc_trans_ : desc_;
-    }
+  const GemmDesc& get_desc(const Kernel& kernel) const {
+    return kernel.desc().transpose ? desc_trans_ : desc_;
+  }
 
-    // Alignment
-    // (align_m, align_n, align_k) -> is_aligned
-    //  gcd_mnk need to be part of gemm desc
+  // Alignment
+  // (align_m, align_n, align_k) -> is_aligned
+  //  gcd_mnk need to be part of gemm desc
 
-    // Max splits
-    // (max_mn_tiles, max_k_tiles) -> max_splits
+  // Max splits
+  // (max_mn_tiles, max_k_tiles) -> max_splits
 
-    // CTA Swizzling
-    // - GemmScheduler: return get_log_tile
-    // - DynamicScheduler: bypass
+  // CTA Swizzling
+  // - GemmScheduler: return get_log_tile
+  // - DynamicScheduler: bypass
 
-    // Cost estimation
-    //
+  // Cost estimation
+  //
 
-protected:
-    int arch_{};
-    int sm_count_{};
+ protected:
+  int arch_{};
+  int sm_count_{};
 
-    GemmDesc desc_{};
-    GemmDesc desc_trans_{};
+  GemmDesc desc_{};
+  GemmDesc desc_trans_{};
 };
 
 }  // namespace turbomind::gemm

--- a/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/convert.cuh
+++ b/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/convert.cuh
@@ -18,232 +18,223 @@
 #include "src/turbomind/kernels/gemm/types.h"
 #include "src/turbomind/kernels/gemm/utils.h"
 
-template<class T>
-__device__ void print_type(T)
-{
-    if (threadIdx.x == 0) {
-        printf("%s\n", __PRETTY_FUNCTION__);
-    }
+template <class T>
+__device__ void print_type(T) {
+  if (threadIdx.x == 0) {
+    printf("%s\n", __PRETTY_FUNCTION__);
+  }
 }
 
 namespace turbomind::gemm {
 
-template<int M_, int K_, int Pack_M, class Operand_, class Td, class Converter>
+template <int M_, int K_, int Pack_M, class Operand_, class Td, class Converter>
 struct ConvertOperand {
+  static constexpr int M = M_;
+  static constexpr int K = K_;
 
-    static constexpr int M = M_;
-    static constexpr int K = K_;
+  using Operand =
+      MakeOperand<Operand_,
+                  IteratorSm70<Striding::kFlat, cache_policy::Default>, M_, K_,
+                  1>;
 
-    using Operand = MakeOperand<Operand_, IteratorSm70<Striding::kFlat, cache_policy::Default>, M_, K_, 1>;
+  using Ts = typename Operand::Dtype;
+  using SmemLayout = typename Operand::SmemLayout;
+  using GmemIter = typename Operand::GmemIter;
 
-    using Ts         = typename Operand::Dtype;
-    using SmemLayout = typename Operand::SmemLayout;
-    using GmemIter   = typename Operand::GmemIter;
+  using Atom = typename Operand::SmemCopyAtom;
 
-    using Atom = typename Operand::SmemCopyAtom;
+  using SmemCopy =
+      SmemCopy<Operand, M_ / Atom::M, K_ / Atom::K, Atom::M, Atom::K>;
 
-    using SmemCopy = SmemCopy<Operand, M_ / Atom::M, K_ / Atom::K, Atom::M, Atom::K>;
+  using Accessor = SmemAccessor<Ts, SmemLayout>;
 
-    using Accessor = SmemAccessor<Ts, SmemLayout>;
+  static constexpr auto kOrderS = Operand::kOrder;
 
-    static constexpr auto kOrderS = Operand::kOrder;
+  static constexpr int ITER_K = ceil_div(K, Atom::K);
 
-    static constexpr int ITER_K = ceil_div(K, Atom::K);
+  /// TODO: generailize this
+  static constexpr int WARP_CNT = 1;
 
-    /// TODO: generailize this
-    static constexpr int WARP_CNT = 1;
+  using PtrD = get_pointer_type<Td>;
 
-    using PtrD = get_pointer_type<Td>;
+  struct Param {
+    int m;
+    int k;
+    MatrixParam src;
+    MatrixParam dst;
+  };
 
-    struct Param {
-        int         m;
-        int         k;
-        MatrixParam src;
-        MatrixParam dst;
-    };
+  using SharedStorage = Array<Ts, SmemLayout::kSize>;
 
-    using SharedStorage = Array<Ts, SmemLayout::kSize>;
+  template <class T, int N, int M>
+  static constexpr int get_fragment_size(Array<T, N> (&)[M]) {
+    return N;
+  }
 
-    template<class T, int N, int M>
-    static constexpr int get_fragment_size(Array<T, N> (&)[M])
-    {
-        return N;
+  template <class T, int N, int M>
+  static constexpr int get_fragment_num(Array<T, N> (&)[M]) {
+    return M;
+  }
+
+  __device__ constexpr int2 _mk2cs(int m, int k) {
+    return mk2cs<kOrderS>(m, k);
+  }
+
+  __device__ void operator()(const Param& param, char* smem_buf) {
+    Ts* smem = (Ts*)smem_buf;
+
+    const int cta_cnt_m = ceil_div(param.m, M);
+    const int cta_cnt_k = ceil_div(param.k, K);
+
+    const int cta_idx_m = blockIdx.x;
+
+    const int cta_offset_m = cta_idx_m * M;
+    const int residue_m = min(M, param.m - cta_offset_m);
+
+    const int warp_id = threadIdx.x / WARP_SIZE;
+
+    const int warp_offset_m = 0;
+
+    Converter converter{};
+
+    typename SmemCopy::Frag data;
+
+    constexpr int kFragSize = get_fragment_size(data);
+    constexpr int kFragNum = get_fragment_num(data);
+    constexpr int kPackSize = kFragSize * Pack_M;
+
+    const int pack_cnt_k = ceil_div(param.k, Atom::K);
+    const int pack_cnt_m = ceil_div(param.m, Atom::M * Pack_M);
+
+    if (threadIdx.x == 0 && blockIdx.x == 0 && blockIdx.y == 0) {
+      // printf("m=%d, k=%d, lds = %d\n", param.m, param.k, param.lds);
+      // printf(
+      //     "CTA_M=%d, CTA_K=%d, cta_cnt_m=%d, cta_cnt_k=%d, cta_idx_m=%d,
+      //     ITER_K=%d, pack_cnt_m=%d, pack_cnt_k=%d\n", M_, K_, cta_cnt_m,
+      //     cta_cnt_k, cta_idx_m, ITER_K, pack_cnt_m, pack_cnt_k);
+      // printf("frag_size=%d, frag_num=%d, pack_size=%d\n", kFragSize,
+      // kFragNum, kPackSize);
     }
 
-    template<class T, int N, int M>
-    static constexpr int get_fragment_num(Array<T, N> (&)[M])
-    {
-        return M;
-    }
+    const int cta_offset_k = (cta_cnt_k - 1) * K;
+    const int residue_k = min(K, param.k - cta_offset_k);
 
-    __device__ constexpr int2 _mk2cs(int m, int k)
-    {
-        return mk2cs<kOrderS>(m, k);
-    }
+    const auto mat_S = resolve<Ts, Striding::kFlat>(param.src, 0);
+    const auto mat_D = resolve<Td, Striding::kFlat>(param.dst, 0);
 
-    __device__ void operator()(const Param& param, char* smem_buf)
-    {
-        Ts* smem = (Ts*)smem_buf;
+    // Handle residue k first
+    GmemIter gmem{mat_S, {cta_offset_m, cta_offset_k}, {residue_m, residue_k}};
 
-        const int cta_cnt_m = ceil_div(param.m, M);
-        const int cta_cnt_k = ceil_div(param.k, K);
+    gmem.smem_data_ = smem;
+    gmem.ClearSmem();
 
-        const int cta_idx_m = blockIdx.x;
+    __syncthreads();
 
-        const int cta_offset_m = cta_idx_m * M;
-        const int residue_m    = min(M, param.m - cta_offset_m);
+    // gmem.Prefetch(true);
 
-        const int warp_id = threadIdx.x / WARP_SIZE;
+    typename GmemIter::Fragments fragments{};
+    gmem.Fetch(fragments, true);
+    gmem.Store(fragments);
 
-        const int warp_offset_m = 0;
+    // Rest full k tiles
+    gmem = GmemIter{mat_S, {cta_offset_m, 0}, {residue_m, K}};
+    gmem.smem_data_ = smem;
 
-        Converter converter{};
+    SmemCopy smem_copy({warp_offset_m, 0});
 
-        typename SmemCopy::Frag data;
+    // last, 0, 1, 2, 3, ..., last - 1
+    int cta_idx_k = cta_cnt_k - 1;
 
-        constexpr int kFragSize = get_fragment_size(data);
-        constexpr int kFragNum  = get_fragment_num(data);
-        constexpr int kPackSize = kFragSize * Pack_M;
+    get_pointer_type<Td> mat_D_ptr{(Td*)mat_D.ptr.ptr};
 
-        const int pack_cnt_k = ceil_div(param.k, Atom::K);
-        const int pack_cnt_m = ceil_div(param.m, Atom::M * Pack_M);
+    for (int k_stage = 0; k_stage < cta_cnt_k; ++k_stage) {
+      __syncthreads();
 
-        if (threadIdx.x == 0 && blockIdx.x == 0 && blockIdx.y == 0) {
-            // printf("m=%d, k=%d, lds = %d\n", param.m, param.k, param.lds);
-            // printf(
-            //     "CTA_M=%d, CTA_K=%d, cta_cnt_m=%d, cta_cnt_k=%d, cta_idx_m=%d, ITER_K=%d, pack_cnt_m=%d,
-            //     pack_cnt_k=%d\n", M_, K_, cta_cnt_m, cta_cnt_k, cta_idx_m, ITER_K, pack_cnt_m, pack_cnt_k);
-            // printf("frag_size=%d, frag_num=%d, pack_size=%d\n", kFragSize, kFragNum, kPackSize);
+      PRAGMA_UNROLL
+      for (int k = 0; k < ITER_K; ++k) {
+        // Assuming `SmemCopy` is a warp-level operation
+        // Load from smem as we are doing GEMMs
+        // SmemCopy::copy(smem, data, int2{warp_offset_m, 0}, k);
+        smem_copy(smem, data, k);
+
+        PRAGMA_UNROLL
+        for (int m = 0; m < kFragNum; m += Pack_M) {
+          // Convert and pack rmem data
+          Array<Td, kPackSize> packed =
+              converter((Array<Ts, kPackSize>&)data[m]);
+
+          // Logical pack coords
+          const int pack_idx_k = cta_idx_k * ITER_K + k;
+          const int pack_idx_m =
+              ((cta_idx_m * WARP_CNT + warp_id) * kFragNum + m) / Pack_M;
+
+          // Linear pack index
+          const int pack_index = cs2idx(_mk2cs(pack_idx_m, pack_idx_k),  //
+                                        _mk2cs(pack_cnt_m, pack_cnt_k).x);
+
+          auto [unique_id, repeat_id] = Atom::unique(threadIdx.x, pack_index);
+
+          // Store in [pack_id, lane_id], static cast is needed to decay
+          // SubBytePtr<T> to T*
+          auto dst_ptr = static_cast<Td*>(mat_D_ptr + unique_id * kPackSize);
+
+          if (pack_idx_m < pack_cnt_m && pack_idx_k < pack_cnt_k &&
+              repeat_id == 0) {
+            Store(dst_ptr, packed);
+          }
         }
+      }
 
-        const int cta_offset_k = (cta_cnt_k - 1) * K;
-        const int residue_k    = min(K, param.k - cta_offset_k);
+      __syncthreads();
 
-        const auto mat_S = resolve<Ts, Striding::kFlat>(param.src, 0);
-        const auto mat_D = resolve<Td, Striding::kFlat>(param.dst, 0);
+      if (k_stage == cta_cnt_k - 1) {
+        break;
+      }
 
-        // Handle residue k first
-        GmemIter gmem{mat_S, {cta_offset_m, cta_offset_k}, {residue_m, residue_k}};
+      // gmem.Prefetch(true);
+      gmem.Fetch(fragments, true);
+      gmem.Store(fragments);
+      gmem.Advance();
 
-        gmem.smem_data_ = smem;
-        gmem.ClearSmem();
-
-        __syncthreads();
-
-        // gmem.Prefetch(true);
-
-        typename GmemIter::Fragments fragments{};
-        gmem.Fetch(fragments, true);
-        gmem.Store(fragments);
-
-        // Rest full k tiles
-        gmem            = GmemIter{mat_S, {cta_offset_m, 0}, {residue_m, K}};
-        gmem.smem_data_ = smem;
-
-        SmemCopy smem_copy({warp_offset_m, 0});
-
-        // last, 0, 1, 2, 3, ..., last - 1
-        int cta_idx_k = cta_cnt_k - 1;
-
-        get_pointer_type<Td> mat_D_ptr{(Td*)mat_D.ptr.ptr};
-
-        for (int k_stage = 0; k_stage < cta_cnt_k; ++k_stage) {
-            __syncthreads();
-
-            PRAGMA_UNROLL
-            for (int k = 0; k < ITER_K; ++k) {
-                // Assuming `SmemCopy` is a warp-level operation
-                // Load from smem as we are doing GEMMs
-                // SmemCopy::copy(smem, data, int2{warp_offset_m, 0}, k);
-                smem_copy(smem, data, k);
-
-                PRAGMA_UNROLL
-                for (int m = 0; m < kFragNum; m += Pack_M) {
-                    // Convert and pack rmem data
-                    Array<Td, kPackSize> packed = converter((Array<Ts, kPackSize>&)data[m]);
-
-                    // Logical pack coords
-                    const int pack_idx_k = cta_idx_k * ITER_K + k;
-                    const int pack_idx_m = ((cta_idx_m * WARP_CNT + warp_id) * kFragNum + m) / Pack_M;
-
-                    // Linear pack index
-                    const int pack_index = cs2idx(_mk2cs(pack_idx_m, pack_idx_k),  //
-                                                  _mk2cs(pack_cnt_m, pack_cnt_k).x);
-
-                    auto [unique_id, repeat_id] = Atom::unique(threadIdx.x, pack_index);
-
-                    // Store in [pack_id, lane_id], static cast is needed to decay SubBytePtr<T> to T*
-                    auto dst_ptr = static_cast<Td*>(mat_D_ptr + unique_id * kPackSize);
-
-                    if (pack_idx_m < pack_cnt_m && pack_idx_k < pack_cnt_k && repeat_id == 0) {
-                        Store(dst_ptr, packed);
-                    }
-                }
-            }
-
-            __syncthreads();
-
-            if (k_stage == cta_cnt_k - 1) {
-                break;
-            }
-
-            // gmem.Prefetch(true);
-            gmem.Fetch(fragments, true);
-            gmem.Store(fragments);
-            gmem.Advance();
-
-            cta_idx_k = k_stage;
-        }
+      cta_idx_k = k_stage;
     }
+  }
 
-    __device__ void print(...) {}
+  __device__ void print(...) {}
 
-    __device__ void print(Array<uint32_t, 2> _x)
-    {
-        auto& x = (const Array<half, 4>&)_x;
-        printf("tidx=%d, %f %f %f %f\n", (int)threadIdx.x, (float)x[0], (float)x[1], (float)x[2], (float)x[3]);
-    }
+  __device__ void print(Array<uint32_t, 2> _x) {
+    auto& x = (const Array<half, 4>&)_x;
+    printf("tidx=%d, %f %f %f %f\n", (int)threadIdx.x, (float)x[0], (float)x[1],
+           (float)x[2], (float)x[3]);
+  }
 };
 
 extern __shared__ char smem_buf[];
 
-template<class Kernel>
-__global__ void convert_kernel(typename Kernel::Param param)
-{
-    Kernel kernel;
-    kernel(param, smem_buf);
+template <class Kernel>
+__global__ void convert_kernel(typename Kernel::Param param) {
+  Kernel kernel;
+  kernel(param, smem_buf);
 }
 
-constexpr bool is_AB(Op_Tag op)
-{
-    if (op == OPERAND_A || op == OPERAND_B) {
-        return true;
-    }
-    else {
-        return false;
-    }
+constexpr bool is_AB(Op_Tag op) {
+  if (op == OPERAND_A || op == OPERAND_B) {
+    return true;
+  } else {
+    return false;
+  }
 }
 
-constexpr bool is_UV(Op_Tag op)
-{
-    return !is_AB(op);
+constexpr bool is_UV(Op_Tag op) { return !is_AB(op); }
+
+template <class Dtype>
+constexpr int unit_size(basic_type<Dtype>) {
+  return 1;
 }
 
-template<class Dtype>
-constexpr int unit_size(basic_type<Dtype>)
-{
-    return 1;
-}
+constexpr int unit_size(basic_type<uint8_t>) { return 4; }
 
-constexpr int unit_size(basic_type<uint8_t>)
-{
-    return 4;
-}
-
-constexpr int unit_size(basic_type<uint4_t>)
-{
-    return 8;
-}
+constexpr int unit_size(basic_type<uint4_t>) { return 8; }
 
 // MMA     : H_16816, H_1688, H_884, H_SIMT
 // Operand : A, B, U, V
@@ -251,44 +242,49 @@ constexpr int unit_size(basic_type<uint4_t>)
 // Dtype   : u16, u8, u4 (u6, u3)
 // PackNum : 1, 2, 4
 
-template<class Operand, class Dtype_, int PackNum>
+template <class Operand, class Dtype_, int PackNum>
 struct Config {
-    static constexpr int CTA_M = 64;
-    static constexpr int CTA_K = 32;
+  static constexpr int CTA_M = 64;
+  static constexpr int CTA_K = 32;
 
-    static constexpr int BLOCK_SIZE = 32;
+  static constexpr int BLOCK_SIZE = 32;
 
-    using Stype = typename Operand::Dtype;
-    using Dtype = Dtype_;
+  using Stype = typename Operand::Dtype;
+  using Dtype = Dtype_;
 
-    using Kernel = ConvertOperand<CTA_M, CTA_K, PackNum, Operand, Dtype, Converter<Stype, Dtype>>;
+  using Kernel = ConvertOperand<CTA_M, CTA_K, PackNum, Operand, Dtype,
+                                Converter<Stype, Dtype>>;
 };
 
-template<class Config>
-void Convert_v2_Impl(const void* S, const MatrixLayout& Sdesc, void* D, const MatrixLayout& Ddesc, cudaStream_t stream)
-{
-    using Kernel = typename Config::Kernel;
-    using Stype  = typename Config::Stype;
-    using Dtype  = typename Config::Dtype;
+template <class Config>
+void Convert_v2_Impl(const void* S, const MatrixLayout& Sdesc, void* D,
+                     const MatrixLayout& Ddesc, cudaStream_t stream) {
+  using Kernel = typename Config::Kernel;
+  using Stype = typename Config::Stype;
+  using Dtype = typename Config::Dtype;
 
-    constexpr int CTA_M = Config::CTA_M;
+  constexpr int CTA_M = Config::CTA_M;
 
-    static constexpr int kSmemSize = sizeof(typename Kernel::SharedStorage);
+  static constexpr int kSmemSize = sizeof(typename Kernel::SharedStorage);
 
-    if (kSmemSize > (48 << 10)) {
-        cudaFuncSetAttribute(convert_kernel<Kernel>, cudaFuncAttributeMaxDynamicSharedMemorySize, kSmemSize);
-    }
+  if (kSmemSize > (48 << 10)) {
+    cudaFuncSetAttribute(convert_kernel<Kernel>,
+                         cudaFuncAttributeMaxDynamicSharedMemorySize,
+                         kSmemSize);
+  }
 
-    typename Kernel::Param param{Sdesc.rows, Sdesc.cols, to_param((void*)S, Sdesc), to_param((void*)D, Ddesc)};
+  typename Kernel::Param param{Sdesc.rows, Sdesc.cols,
+                               to_param((void*)S, Sdesc),
+                               to_param((void*)D, Ddesc)};
 
-    constexpr int threads = Config::BLOCK_SIZE;
-    const int     blocks  = ceil_div(Sdesc.rows, CTA_M);
+  constexpr int threads = Config::BLOCK_SIZE;
+  const int blocks = ceil_div(Sdesc.rows, CTA_M);
 
-    // std::cout << __PRETTY_FUNCTION__ << std::endl;
-    // std::cout << __PRETTY_FUNCTION__ << "\nThreadMap:\n";
-    // Print(typename Kernel::GmemIter::ThreadMap{});
+  // std::cout << __PRETTY_FUNCTION__ << std::endl;
+  // std::cout << __PRETTY_FUNCTION__ << "\nThreadMap:\n";
+  // Print(typename Kernel::GmemIter::ThreadMap{});
 
-    convert_kernel<Kernel><<<blocks, threads, kSmemSize, stream>>>(param);
+  convert_kernel<Kernel><<<blocks, threads, kSmemSize, stream>>>(param);
 }
 
 }  // namespace turbomind::gemm

--- a/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/convert.h
+++ b/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/convert.h
@@ -8,26 +8,24 @@
 namespace turbomind::gemm {
 
 struct LayoutConverter {
+  Order order;
+  Pack pack;
 
-    Order order;
-    Pack  pack;
-
-    virtual int Convert(const void*         S,  //
-                        const MatrixLayout& Sdesc,
-                        void*               D,
-                        MatrixLayout&       Ddesc,
-                        cudaStream_t        stream) const = 0;
+  virtual int Convert(const void* S,  //
+                      const MatrixLayout& Sdesc, void* D, MatrixLayout& Ddesc,
+                      cudaStream_t stream) const = 0;
 };
 
 // Pointers to singletons
 std::array<const LayoutConverter*, 2> GetConverters(DataType data_type,
                                                     DataType weight_type,  //
                                                     DataType input_type,
-                                                    bool     grouped,
-                                                    int      sm);
+                                                    bool grouped, int sm);
 
 // Free with `cudaFree`
-void* MakeStridedPtrs(const std::vector<std::pair<void*, int>>& ptrs, cudaStream_t stream);
-void* MakeBlockedPtrs(const std::vector<std::pair<void*, int>>& ptrs, cudaStream_t stream);
+void* MakeStridedPtrs(const std::vector<std::pair<void*, int>>& ptrs,
+                      cudaStream_t stream);
+void* MakeBlockedPtrs(const std::vector<std::pair<void*, int>>& ptrs,
+                      cudaStream_t stream);
 
 }  // namespace turbomind::gemm

--- a/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/convert_v3.cu
+++ b/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/convert_v3.cu
@@ -13,226 +13,221 @@
 
 namespace turbomind::gemm {
 
-template<class Arch, Order order_, MMA_Tag mma_tag, Op_Tag op_tag, int pack_num, class Stype, class Dtype>
-struct LayoutConverterImpl: public LayoutConverter {
+template <class Arch, Order order_, MMA_Tag mma_tag, Op_Tag op_tag,
+          int pack_num, class Stype, class Dtype>
+struct LayoutConverterImpl : public LayoutConverter {
+  LayoutConverterImpl() : LayoutConverter{} {
+    this->order = order_;
+    this->pack = mma_tag | op_tag | pack_num;
+  }
 
-    LayoutConverterImpl(): LayoutConverter{}
-    {
-        this->order = order_;
-        this->pack  = mma_tag | op_tag | pack_num;
-    }
+  int Convert(const void* S,
+              const MatrixLayout& Sdesc_,  // (m,k) / (n,k)
+              void* D,
+              MatrixLayout& Ddesc,  // (m,k) / (n,k)
+              cudaStream_t stream) const override {
+    // TM_CHECK_EQ(Sdesc.pack, 0U) << "Source must be non-packed format";
 
-    int Convert(const void*         S,
-                const MatrixLayout& Sdesc_,  // (m,k) / (n,k)
-                void*               D,
-                MatrixLayout&       Ddesc,  // (m,k) / (n,k)
-                cudaStream_t        stream) const override
-    {
-        // TM_CHECK_EQ(Sdesc.pack, 0U) << "Source must be non-packed format";
+    const bool trans = op_tag == OPERAND_B || op_tag == OPERAND_V;
+    // (k, n) -> (n, k)
+    MatrixLayout Sdesc = trans ? transpose(Sdesc_) : Sdesc_;
+    // MatrixLayout Ddesc = trans ? transpose(Ddesc_) : Ddesc_;
 
-        const bool trans = op_tag == OPERAND_B || op_tag == OPERAND_V;
-        // (k, n) -> (n, k)
-        MatrixLayout Sdesc = trans ? transpose(Sdesc_) : Sdesc_;
-        // MatrixLayout Ddesc = trans ? transpose(Ddesc_) : Ddesc_;
+    TM_CHECK_NOTNULL(S);
+    TM_CHECK_NOTNULL(D);
 
-        TM_CHECK_NOTNULL(S);
-        TM_CHECK_NOTNULL(D);
+    using Operand =
+        typename GetOperand<mma_tag, op_tag, Stype, order_, false>::Operand;
 
-        using Operand = typename GetOperand<mma_tag, op_tag, Stype, order_, false>::Operand;
+    Convert_v2_Impl<Config<Operand, Dtype, pack_num>>(S, Sdesc, D, Ddesc,
+                                                      stream);
 
-        Convert_v2_Impl<Config<Operand, Dtype, pack_num>>(S, Sdesc, D, Ddesc, stream);
+    constexpr Pack pack = mma_tag | op_tag | pack_num;
 
-        constexpr Pack pack = mma_tag | op_tag | pack_num;
+    // Update leading dimension
+    Ddesc.ld =
+        mk2cs<order_>(Packing_v2<pack, order_>::apply({Sdesc.rows, Sdesc.cols}))
+            .x;
 
-        // Update leading dimension
-        Ddesc.ld = mk2cs<order_>(Packing_v2<pack, order_>::apply({Sdesc.rows, Sdesc.cols})).x;
-
-        return 0;
-    }
+    return 0;
+  }
 };
 
-template<class Arch, Order order, uint32_t pack, class Stype, class Dtype>
-static LayoutConverter* GetImpl()
-{
-    constexpr auto mma      = get_mma_tag(pack);
-    constexpr auto operand  = get_operand_tag(pack);
-    constexpr auto pack_num = get_pack_num(pack);
+template <class Arch, Order order, uint32_t pack, class Stype, class Dtype>
+static LayoutConverter* GetImpl() {
+  constexpr auto mma = get_mma_tag(pack);
+  constexpr auto operand = get_operand_tag(pack);
+  constexpr auto pack_num = get_pack_num(pack);
 
-    static LayoutConverterImpl<Arch, order, mma, operand, pack_num, Stype, Dtype> impl{};
+  static LayoutConverterImpl<Arch, order, mma, operand, pack_num, Stype, Dtype>
+      impl{};
 
-    return &impl;
+  return &impl;
 }
 
-template<class Stype, class Dtype>
+template <class Stype, class Dtype>
 struct Cvt {
-    template<class Arch, Order order, Pack pack>
-    LayoutConverter* operator()(Arch, constant<order>, constant<pack>) const
-    {
-        return GetImpl<Arch, order, pack, Stype, Dtype>();
-    }
+  template <class Arch, Order order, Pack pack>
+  LayoutConverter* operator()(Arch, constant<order>, constant<pack>) const {
+    return GetImpl<Arch, order, pack, Stype, Dtype>();
+  }
 };
 
 constexpr constant<(Pack)HMMA_16816> s16816h{};
-constexpr constant<(Pack)HMMA_884>   s884h{};
+constexpr constant<(Pack)HMMA_884> s884h{};
 
-template<auto a, auto b>
-constexpr auto operator|(constant<a>, constant<b>)
-{
-    return constant<a | b>{};
+template <auto a, auto b>
+constexpr auto operator|(constant<a>, constant<b>) {
+  return constant<a | b>{};
 }
 
 std::array<const LayoutConverter*, 2> GetConverters(DataType data_type,
                                                     DataType weight_type,  //
                                                     DataType input_type,
-                                                    bool     grouped,
-                                                    int      sm)
-{
-    constexpr constant<kRowMajor> kRow{};
-    constexpr constant<kColMajor> kCol{};
+                                                    bool grouped, int sm) {
+  constexpr constant<kRowMajor> kRow{};
+  constexpr constant<kColMajor> kCol{};
 
-    constexpr constant<OPERAND_A> A{};
-    constexpr constant<OPERAND_B> B{};
-    constexpr constant<OPERAND_U> U{};
-    constexpr constant<OPERAND_V> V{};
+  constexpr constant<OPERAND_A> A{};
+  constexpr constant<OPERAND_B> B{};
+  constexpr constant<OPERAND_U> U{};
+  constexpr constant<OPERAND_V> V{};
 
-    constexpr constant<1> _1{};
-    constexpr constant<2> _2{};
+  constexpr constant<1> _1{};
+  constexpr constant<2> _2{};
 
-    constexpr Arch<80> sm8_{};
-    constexpr Sm75     sm75{};
-    constexpr Sm70     sm70{};
+  constexpr Arch<80> sm8_{};
+  constexpr Sm75 sm75{};
+  constexpr Sm70 sm70{};
 
-    if (weight_type == kHalf || weight_type == kBfloat16) {
-        constexpr Cvt<uint16_t, uint16_t> W;
-        if (grouped) {
-            // clang-format off
+  if (weight_type == kHalf || weight_type == kBfloat16) {
+    constexpr Cvt<uint16_t, uint16_t> W;
+    if (grouped) {
+      // clang-format off
             if (sm >= 80) return {W(sm8_, kRow, s16816h | B | _1), {}};
             if (sm == 75) return {W(sm75, kRow, s16816h | B | _1), {}};
             if (sm >= 70) return {W(sm70, kRow,   s884h | B | _1), {}};
-            // clang-format on
-        }
-        else {
-            return {};  //  trivial case: dense floating point
-        }
+      // clang-format on
+    } else {
+      return {};  //  trivial case: dense floating point
     }
+  }
 
-    // For performance reasons, u4 use different layouts for grouped/non-grouped GEMM
-    if (weight_type == kUint4) {
-        constexpr Cvt<uint16_t, uint4_t>  W;  // e4m3     weight
-        constexpr Cvt<uint32_t, uint32_t> S;  // f16/bf16 scales&zeros
-        if (grouped) {
-            // clang-format off
+  // For performance reasons, u4 use different layouts for grouped/non-grouped
+  // GEMM
+  if (weight_type == kUint4) {
+    constexpr Cvt<uint16_t, uint4_t> W;   // e4m3     weight
+    constexpr Cvt<uint32_t, uint32_t> S;  // f16/bf16 scales&zeros
+    if (grouped) {
+      // clang-format off
             if (sm >= 80) return {W(sm8_, kRow, s16816h | B | _2), S(sm8_, kCol, s16816h | V | _1)};
             if (sm == 75) return {W(sm75, kRow, s16816h | B | _2), S(sm75, kCol, s16816h | V | _1)};
             if (sm >= 70) return {W(sm70, kRow,   s884h | B | _1), S(sm70, kCol,   s884h | V | _1)};
-            // clang-format on
-        }
-        else {
-            // clang-format off
+      // clang-format on
+    } else {
+      // clang-format off
             if (sm >= 80) return {W(sm8_, kCol, s16816h | B | _2), S(sm8_, kCol, s16816h | V | _1)};
             if (sm == 75) return {W(sm75, kCol, s16816h | B | _2), S(sm75, kCol, s16816h | V | _1)};
             if (sm >= 70) return {W(sm70, kRow,   s884h | B | _1), S(sm70, kCol,   s884h | V | _1)};
-            // clang-format on
-        }
+      // clang-format on
     }
+  }
 
-    if (weight_type == kFloat4_e2m1) {
-        constexpr Cvt<uint16_t, uint4_t> W;  // e2m1  weight
-        constexpr Cvt<uint8_t, uint8_t>  S;  // ue8m0 scales
-        // clang-format off
+  if (weight_type == kFloat4_e2m1) {
+    constexpr Cvt<uint16_t, uint4_t> W;  // e2m1  weight
+    constexpr Cvt<uint8_t, uint8_t> S;   // ue8m0 scales
+                                         // clang-format off
         if (sm >= 80) return {W(sm8_, kCol, s16816h | A | _1), S(sm8_, kCol, s16816h | U | _1)};
         if (sm == 75) return {W(sm75, kCol, s16816h | A | _1), S(sm75, kCol, s16816h | U | _1)};
         if (sm >= 70) return {W(sm70, kRow,   s884h | B | _1), S(sm70, kCol,   s884h | V | _1)};
-        // clang-format on
-    }
+                                         // clang-format on
+  }
 
-    if (weight_type == kFloat8_e4m3) {
-        constexpr Cvt<uint16_t, uint8_t>  W;  // e4m3     weight
-        constexpr Cvt<uint16_t, uint16_t> S;  // f16/bf16 scales
-        // clang-format off
+  if (weight_type == kFloat8_e4m3) {
+    constexpr Cvt<uint16_t, uint8_t> W;   // e4m3     weight
+    constexpr Cvt<uint16_t, uint16_t> S;  // f16/bf16 scales
+                                          // clang-format off
         if (sm >= 80) return {W(sm8_, kCol, s16816h | A | _1), S(sm8_, kCol, s16816h | U | _1)};
         if (sm == 75) return {W(sm75, kCol, s16816h | A | _1), S(sm75, kCol, s16816h | U | _1)};
         if (sm >= 70) return {W(sm70, kRow,   s884h | B | _1), S(sm70, kCol,   s884h | V | _1)};
-        // clang-format on
-    }
+                                          // clang-format on
+  }
 
-    TM_CHECK(0) << "Invalid combination: " << sm << " " << data_type << " " << weight_type << " " << input_type << " "
-                << grouped;
+  TM_CHECK(0) << "Invalid combination: " << sm << " " << data_type << " "
+              << weight_type << " " << input_type << " " << grouped;
 
-    return {};
+  return {};
 }
 
 namespace {
 
-template<int N>
+template <int N>
 struct Param {
-    StridedPtr  data[N];
-    StridedPtr* ptr;
-    int         n;
+  StridedPtr data[N];
+  StridedPtr* ptr;
+  int n;
 };
 
-template<int N>
-__global__ void fill_strided_ptrs(Param<N> param)
-{
-    const int idx = threadIdx.x + blockIdx.x * blockDim.x;
-    if (idx < param.n) {
-        param.ptr[idx] = param.data[idx];
-    }
+template <int N>
+__global__ void fill_strided_ptrs(Param<N> param) {
+  const int idx = threadIdx.x + blockIdx.x * blockDim.x;
+  if (idx < param.n) {
+    param.ptr[idx] = param.data[idx];
+  }
 }
 
 }  // namespace
 
-void* MakeStridedPtrs(const std::vector<std::pair<void*, int>>& ptrs, cudaStream_t stream)
-{
-    constexpr int N = 64;
-    Param<N>      param{};
-    static_assert(sizeof(param) <= 4096);  // max parameter size for cuda11
-    StridedPtr* ptr{};
-    cudaMallocAsync(&ptr, sizeof(StridedPtr) * ptrs.size(), stream);
-    param.ptr = ptr;
-    for (int i = 0; i < (int)ptrs.size(); i += N) {
-        const int n = std::min<int>(ptrs.size() - i, N);
-        for (int j = 0; j < n; ++j) {
-            auto& [p, s]  = ptrs[i + j];
-            param.data[j] = StridedPtr{p, s};
-        }
-        param.n = n;
-        fill_strided_ptrs<<<1, N, 0, stream>>>(param);
-        param.ptr += N;
+void* MakeStridedPtrs(const std::vector<std::pair<void*, int>>& ptrs,
+                      cudaStream_t stream) {
+  constexpr int N = 64;
+  Param<N> param{};
+  static_assert(sizeof(param) <= 4096);  // max parameter size for cuda11
+  StridedPtr* ptr{};
+  cudaMallocAsync(&ptr, sizeof(StridedPtr) * ptrs.size(), stream);
+  param.ptr = ptr;
+  for (int i = 0; i < (int)ptrs.size(); i += N) {
+    const int n = std::min<int>(ptrs.size() - i, N);
+    for (int j = 0; j < n; ++j) {
+      auto& [p, s] = ptrs[i + j];
+      param.data[j] = StridedPtr{p, s};
     }
-    return ptr;
+    param.n = n;
+    fill_strided_ptrs<<<1, N, 0, stream>>>(param);
+    param.ptr += N;
+  }
+  return ptr;
 }
 
 namespace {
 
-template<int N>
-__global__ void fill_blocked_ptrs(Array<void*, N> src, void** dst, int n)
-{
-    const int idx = threadIdx.x + blockIdx.x * blockDim.x;
-    if (idx < n) {
-        dst[idx] = src[idx];
-    }
+template <int N>
+__global__ void fill_blocked_ptrs(Array<void*, N> src, void** dst, int n) {
+  const int idx = threadIdx.x + blockIdx.x * blockDim.x;
+  if (idx < n) {
+    dst[idx] = src[idx];
+  }
 }
 
 }  // namespace
 
-void* MakeBlockedPtrs(const std::vector<std::pair<void*, int>>& ptrs, cudaStream_t stream)
-{
-    constexpr int   N = 64;
-    Array<void*, N> src{};
-    static_assert(sizeof(src) <= 4096);  // max parameter size for cuda11
-    void** dst{};
-    cudaMallocAsync(&dst, sizeof(void*) * ptrs.size(), stream);
-    for (int i = 0; i < (int)ptrs.size(); i += N) {
-        const int n = std::min<int>(ptrs.size() - i, N);
-        for (int j = 0; j < n; ++j) {
-            auto& [p, s] = ptrs[i + j];
-            src[j]       = p;
-        }
-        fill_blocked_ptrs<<<1, N, 0, stream>>>(src, dst, n);
-        dst += n;
+void* MakeBlockedPtrs(const std::vector<std::pair<void*, int>>& ptrs,
+                      cudaStream_t stream) {
+  constexpr int N = 64;
+  Array<void*, N> src{};
+  static_assert(sizeof(src) <= 4096);  // max parameter size for cuda11
+  void** dst{};
+  cudaMallocAsync(&dst, sizeof(void*) * ptrs.size(), stream);
+  for (int i = 0; i < (int)ptrs.size(); i += N) {
+    const int n = std::min<int>(ptrs.size() - i, N);
+    for (int j = 0; j < n; ++j) {
+      auto& [p, s] = ptrs[i + j];
+      src[j] = p;
     }
-    return dst - ptrs.size();
+    fill_blocked_ptrs<<<1, N, 0, stream>>>(src, dst, n);
+    dst += n;
+  }
+  return dst - ptrs.size();
 }
 
 }  // namespace turbomind::gemm

--- a/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/cp_async.h
+++ b/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/cp_async.h
@@ -5,68 +5,65 @@
 #include <type_traits>
 
 #if (__CUDACC_VER_MAJOR__ >= 11) && (__CUDACC_VER_MINOR__ >= 4)
-#define L2_CACHEHINT(size) ".L2::" #size "B"
+  #define L2_CACHEHINT(size) ".L2::" #size "B"
 #else
-#define L2_CACHEHINT(size)
+  #define L2_CACHEHINT(size)
 #endif
 
 namespace turbomind {
 
-enum class CacheOp
-{
-    kDefault,  // use global when possible
-    kAlways,
-    kGlobal,
+enum class CacheOp {
+  kDefault,  // use global when possible
+  kAlways,
+  kGlobal,
 };
 
-template<CacheOp cache_op, int size>
+template <CacheOp cache_op, int size>
 struct GetCacheOp {
-    static constexpr auto value = cache_op;
+  static constexpr auto value = cache_op;
 };
 
-template<>
+template <>
 struct GetCacheOp<CacheOp::kDefault, 16> {
-    static constexpr auto value = CacheOp::kGlobal;
+  static constexpr auto value = CacheOp::kGlobal;
 };
 
-template<int size>
+template <int size>
 struct GetCacheOp<CacheOp::kDefault, size> {
-    static constexpr auto value = CacheOp::kAlways;
+  static constexpr auto value = CacheOp::kAlways;
 };
 
-enum class EvictPolicy
-{
-    kEvictNormal,
-    kEvictFirst,
-    kEvictLast,
+enum class EvictPolicy {
+  kEvictNormal,
+  kEvictFirst,
+  kEvictLast,
 };
 
 namespace cache_policy {
 
 struct Default {
-    static constexpr auto kCacheOp     = CacheOp::kDefault;
-    static constexpr auto kEvictPolicy = EvictPolicy::kEvictNormal;
+  static constexpr auto kCacheOp = CacheOp::kDefault;
+  static constexpr auto kEvictPolicy = EvictPolicy::kEvictNormal;
 };
 
 struct Stream {
-    static constexpr auto kCacheOp     = CacheOp::kDefault;
-    static constexpr auto kEvictPolicy = EvictPolicy::kEvictFirst;
+  static constexpr auto kCacheOp = CacheOp::kDefault;
+  static constexpr auto kEvictPolicy = EvictPolicy::kEvictFirst;
 };
 
 struct Reuse {
-    static constexpr auto kCacheOp     = CacheOp::kAlways;
-    static constexpr auto kEvictPolicy = EvictPolicy::kEvictNormal;
+  static constexpr auto kCacheOp = CacheOp::kAlways;
+  static constexpr auto kEvictPolicy = EvictPolicy::kEvictNormal;
 };
 
 };  // namespace cache_policy
 
-template<CacheOp, int size, int prefetch_size>
-struct CP_ASYNC {
-};
+template <CacheOp, int size, int prefetch_size>
+struct CP_ASYNC {};
 
-template<int prefetch_size>
+template <int prefetch_size>
 struct CP_ASYNC<CacheOp::kGlobal, 16, prefetch_size> {
-    // clang-format off
+  // clang-format off
     __device__ static void apply(int smem_ptr, const void* __restrict__ src, bool mask)
     {
         asm volatile("{\n  .reg .pred p;\n  setp.ne.b32 p, %0, 0;\n"
@@ -79,12 +76,12 @@ struct CP_ASYNC<CacheOp::kGlobal, 16, prefetch_size> {
                      "  @p cp.async.cg.shared.global.L2::cache_hint [%1], [%2], 16, %3;\n"
                      "}\n" ::"r"((int)mask), "r"(smem_ptr), "l"(src), "l"(cache_policy));
     }
-    // clang-format on
+  // clang-format on
 };
 
-template<>
+template <>
 struct CP_ASYNC<CacheOp::kGlobal, 16, 64> {
-    // clang-format off
+  // clang-format off
     __device__ static void apply(int smem_ptr, const void* __restrict__ src, bool mask)
     {
         asm volatile("{\n  .reg .pred p;\n  setp.ne.b32 p, %0, 0;\n"
@@ -97,12 +94,12 @@ struct CP_ASYNC<CacheOp::kGlobal, 16, 64> {
                      "  @p cp.async.cg.shared.global.L2::cache_hint" L2_CACHEHINT(64) " [%1], [%2], 16, %3;\n"
                      "}\n" ::"r"((int)mask), "r"(smem_ptr), "l"(src), "l"(cache_policy));
     }
-    // clang-format on
+  // clang-format on
 };
 
-template<>
+template <>
 struct CP_ASYNC<CacheOp::kGlobal, 16, 128> {
-    // clang-format off
+  // clang-format off
     __device__ static void apply(int smem_ptr, const void* __restrict__ src, bool mask)
     {
         asm volatile("{\n  .reg .pred p;\n  setp.ne.b32 p, %0, 0;\n"
@@ -115,12 +112,12 @@ struct CP_ASYNC<CacheOp::kGlobal, 16, 128> {
                      "  @p cp.async.cg.shared.global.L2::cache_hint" L2_CACHEHINT(128) " [%1], [%2], 16, %3;\n"
                      "}\n" ::"r"((int)mask), "r"(smem_ptr), "l"(src), "l"(cache_policy));
     }
-    // clang-format on
+  // clang-format on
 };
 
-template<>
+template <>
 struct CP_ASYNC<CacheOp::kGlobal, 16, 256> {
-    // clang-format off
+  // clang-format off
     __device__ static void apply(int smem_ptr, const void* __restrict__ src, bool mask)
     {
         asm volatile("{\n  .reg .pred p;\n  setp.ne.b32 p, %0, 0;\n"
@@ -133,12 +130,12 @@ struct CP_ASYNC<CacheOp::kGlobal, 16, 256> {
                      "  @p cp.async.cg.shared.global.L2::cache_hint" L2_CACHEHINT(256) " [%1], [%2], 16, %3;\n"
                      "}\n" ::"r"((int)mask), "r"(smem_ptr), "l"(src), "l"(cache_policy));
     }
-    // clang-format on
+  // clang-format on
 };
 
-template<int size, int prefetch_size>
+template <int size, int prefetch_size>
 struct CP_ASYNC<CacheOp::kAlways, size, prefetch_size> {
-    // clang-format off
+  // clang-format off
     __device__ static void apply(int smem_ptr, const void* __restrict__ src, bool mask)
     {
         asm volatile("{\n  .reg .pred p;\n  setp.ne.b32 p, %0, 0;\n"
@@ -151,12 +148,12 @@ struct CP_ASYNC<CacheOp::kAlways, size, prefetch_size> {
                      "  @p cp.async.ca.shared.global.L2::cache_hint [%1], [%2], %3, %4;\n"
                      "}\n" ::"r"((int)mask), "r"(smem_ptr), "l"(src), "n"(size), "l"(cache_policy));
     }
-    // clang-format on
+  // clang-format on
 };
 
-template<int size>
+template <int size>
 struct CP_ASYNC<CacheOp::kAlways, size, 64> {
-    // clang-format off
+  // clang-format off
     __device__ static void apply(int smem_ptr, const void* __restrict__ src, bool mask)
     {
         asm volatile("{\n  .reg .pred p;\n  setp.ne.b32 p, %0, 0;\n"
@@ -169,12 +166,12 @@ struct CP_ASYNC<CacheOp::kAlways, size, 64> {
                      "  @p cp.async.ca.shared.global.L2::cache_hint" L2_CACHEHINT(64) " [%1], [%2], %3, %4;\n"
                      "}\n" ::"r"((int)mask), "r"(smem_ptr), "l"(src), "n"(size), "l"(cache_policy));
     }
-    // clang-format on
+  // clang-format on
 };
 
-template<int size>
+template <int size>
 struct CP_ASYNC<CacheOp::kAlways, size, 128> {
-    // clang-format off
+  // clang-format off
     __device__ static void apply(int smem_ptr, const void* __restrict__ src, bool mask)
     {
         asm volatile("{\n  .reg .pred p;\n  setp.ne.b32 p, %0, 0;\n"
@@ -187,12 +184,12 @@ struct CP_ASYNC<CacheOp::kAlways, size, 128> {
                      "  @p cp.async.ca.shared.global.L2::cache_hint" L2_CACHEHINT(128) " [%1], [%2], %3, %4;\n"
                      "}\n" ::"r"((int)mask), "r"(smem_ptr), "l"(src), "n"(size), "l"(cache_policy));
     }
-    // clang-format on
+  // clang-format on
 };
 
-template<int size>
+template <int size>
 struct CP_ASYNC<CacheOp::kAlways, size, 256> {
-    // clang-format off
+  // clang-format off
     __device__ static void apply(int smem_ptr, const void* __restrict__ src, bool mask)
     {
         asm volatile("{\n  .reg .pred p;\n  setp.ne.b32 p, %0, 0;\n"
@@ -205,7 +202,7 @@ struct CP_ASYNC<CacheOp::kAlways, size, 256> {
                      "  @p cp.async.ca.shared.global.L2::cache_hint" L2_CACHEHINT(256) " [%1], [%2], %3, %4;\n"
                      "}\n" ::"r"((int)mask), "r"(smem_ptr), "l"(src), "n"(size), "l"(cache_policy));
     }
-    // clang-format on
+  // clang-format on
 };
 
 }  // namespace turbomind

--- a/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/cta_map.h
+++ b/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/cta_map.h
@@ -8,252 +8,208 @@
 
 namespace turbomind::gemm {
 
-TM_HOST_DEVICE constexpr int get_log_tile(int size, int tile_size)
-{
-    if (tile_size >= 32 && size >= 24)
-        return 5;
-    if (tile_size >= 16 && size >= 12)
-        return 4;
-    if (tile_size >= 8 && size >= 6)
-        return 3;
-    if (tile_size >= 4 && size >= 3)
-        return 2;
-    if (tile_size >= 2 && size >= 2)
-        return 1;
-    return 0;
+TM_HOST_DEVICE constexpr int get_log_tile(int size, int tile_size) {
+  if (tile_size >= 32 && size >= 24) return 5;
+  if (tile_size >= 16 && size >= 12) return 4;
+  if (tile_size >= 8 && size >= 6) return 3;
+  if (tile_size >= 4 && size >= 3) return 2;
+  if (tile_size >= 2 && size >= 2) return 1;
+  return 0;
 }
 
-TM_HOST_DEVICE constexpr int2 get_tiled_shape(int m, int n, int cta_m, int cta_n)
-{
-    return {ceil_div(m, cta_m), ceil_div(n, cta_n)};
+TM_HOST_DEVICE constexpr int2 get_tiled_shape(int m, int n, int cta_m,
+                                              int cta_n) {
+  return {ceil_div(m, cta_m), ceil_div(n, cta_n)};
 }
 
 struct CtaMap_ {
+  TM_HOST_DEVICE static int3 get_tiled_shape(int m, int n, int k, int cta_m,
+                                             int cta_n, int split_cnt) {
+    return {(m + cta_m - 1) / cta_m, (n + cta_n - 1) / cta_n, split_cnt};
+  }
 
-    TM_HOST_DEVICE static int3 get_tiled_shape(int m, int n, int k, int cta_m, int cta_n, int split_cnt)
-    {
-        return {(m + cta_m - 1) / cta_m, (n + cta_n - 1) / cta_n, split_cnt};
-    }
+  TM_HOST_DEVICE static int get_log_tile(int2 tiled_mn, int N) {
+    return gemm::get_log_tile(tiled_mn.y, N);
+  }
 
-    TM_HOST_DEVICE static int get_log_tile(int2 tiled_mn, int N)
-    {
-        return gemm::get_log_tile(tiled_mn.y, N);
-    }
+  TM_HOST_DEVICE static dim3 get_grid_shape(int3 tiled_shape, int log_tile) {
+    int tile = 1 << log_tile;
+    return {static_cast<unsigned>(tiled_shape.x * tile),
+            static_cast<unsigned>((tiled_shape.y + tile - 1) / tile),
+            static_cast<unsigned>(tiled_shape.z)};
+  }
 
-    TM_HOST_DEVICE static dim3 get_grid_shape(int3 tiled_shape, int log_tile)
-    {
-        int tile = 1 << log_tile;
-        return {static_cast<unsigned>(tiled_shape.x * tile),
-                static_cast<unsigned>((tiled_shape.y + tile - 1) / tile),
-                static_cast<unsigned>(tiled_shape.z)};
-    }
-
-    TM_DEVICE static int3 get_tile_offset(int log_tile)
-    {
-        int block_idx_x = blockIdx.x;
-        int block_idx_y = blockIdx.y;
-        int block_idx_z = blockIdx.z;
-        return {(block_idx_x >> log_tile),  //
-                (block_idx_y << log_tile) + (block_idx_x & ((1 << log_tile) - 1)),
-                block_idx_z};
-    }
+  TM_DEVICE static int3 get_tile_offset(int log_tile) {
+    int block_idx_x = blockIdx.x;
+    int block_idx_y = blockIdx.y;
+    int block_idx_z = blockIdx.z;
+    return {(block_idx_x >> log_tile),  //
+            (block_idx_y << log_tile) + (block_idx_x & ((1 << log_tile) - 1)),
+            block_idx_z};
+  }
 };
 
-template<Order order_>
+template <Order order_>
 class GemmScheduler {
+  static constexpr auto order = order_;
 
-    static constexpr auto order = order_;
+  int4 gemm_shape_;
+  int4 tiled_shape_;
+  int log_tile_;
 
-    int4 gemm_shape_;
-    int4 tiled_shape_;
-    int  log_tile_;
+  int chunk_offset_;
+  int chunks_per_split_;
+  int iter_k_per_chunk_;
 
-    int chunk_offset_;
-    int chunks_per_split_;
-    int iter_k_per_chunk_;
+  int4 tile_offset_;
+  int2 iter_k_range_;
 
-    int4 tile_offset_;
-    int2 iter_k_range_;
+ public:
+  TM_HOST_DEVICE
+  GemmScheduler(int4 gemm_shape, int2 tiled_mn, int splits, int log_tile,
+                int cta_k, int chunk_size)
+      : gemm_shape_{gemm_shape},
+        tiled_shape_{tiled_mn.x, tiled_mn.y, splits},
+        log_tile_{log_tile} {
+    const int chunk_cnt = cdiv(gemm_shape_.z, chunk_size);
 
-public:
-    TM_HOST_DEVICE
-    GemmScheduler(int4 gemm_shape, int2 tiled_mn, int splits, int log_tile, int cta_k, int chunk_size):
-        gemm_shape_{gemm_shape}, tiled_shape_{tiled_mn.x, tiled_mn.y, splits}, log_tile_{log_tile}
-    {
-        const int chunk_cnt = cdiv(gemm_shape_.z, chunk_size);
+    iter_k_per_chunk_ = chunk_size / cta_k;
+    chunks_per_split_ = chunk_cnt / splits;
+    chunk_offset_ = splits - chunk_cnt % splits;
+  }
 
-        iter_k_per_chunk_ = chunk_size / cta_k;
-        chunks_per_split_ = chunk_cnt / splits;
-        chunk_offset_     = splits - chunk_cnt % splits;
+  TM_HOST_DEVICE static int get_log_tile(int2 tiled_mn, int tile_size) {
+    return gemm::get_log_tile(order == kColMajor ? tiled_mn.y : tiled_mn.x,
+                              tile_size);
+  }
+
+  TM_HOST_DEVICE static dim3 get_grid_shape(int4 tiled_shape, int log_tile) {
+    const int tile = 1 << log_tile;
+    if constexpr (order == kColMajor) {
+      return {(unsigned)(tiled_shape.x * tile),
+              (unsigned)(cdiv(tiled_shape.y, tile)), (unsigned)(tiled_shape.z)};
+    } else {
+      return {(unsigned)(tiled_shape.y * tile),
+              (unsigned)(cdiv(tiled_shape.x, tile)), (unsigned)(tiled_shape.z)};
     }
+  }
 
-    TM_HOST_DEVICE static int get_log_tile(int2 tiled_mn, int tile_size)
-    {
-        return gemm::get_log_tile(order == kColMajor ? tiled_mn.y : tiled_mn.x, tile_size);
+  TM_HOST_DEVICE dim3 get_grid_shape() const {
+    return get_grid_shape(tiled_shape_, log_tile_);
+  }
+
+  TM_HOST_DEVICE std::true_type init(int block_idx_x, int block_idx_y,
+                                     int block_idx_z) {
+    if constexpr (order == kColMajor) {
+      tile_offset_ = {
+          (block_idx_x >> log_tile_),
+          (block_idx_y << log_tile_) + (block_idx_x & ((1 << log_tile_) - 1)),
+          (block_idx_z)};
+    } else {
+      tile_offset_ = {
+          (block_idx_y << log_tile_) + (block_idx_x & ((1 << log_tile_) - 1)),
+          (block_idx_x >> log_tile_), (block_idx_z)};
     }
+    tile_offset_.w = 0;
+    const int chunk_id = tile_offset_.z * chunks_per_split_ +
+                         max(tile_offset_.z - chunk_offset_, 0);
+    const int iter_k_beg = chunk_id * iter_k_per_chunk_;
+    const int iter_k_cnt =
+        (chunks_per_split_ + int(tile_offset_.z >= chunk_offset_)) *
+        iter_k_per_chunk_;
+    iter_k_range_ = {iter_k_beg, iter_k_beg + iter_k_cnt};
 
-    TM_HOST_DEVICE static dim3 get_grid_shape(int4 tiled_shape, int log_tile)
-    {
-        const int tile = 1 << log_tile;
-        if constexpr (order == kColMajor) {
-            return {(unsigned)(tiled_shape.x * tile), (unsigned)(cdiv(tiled_shape.y, tile)), (unsigned)(tiled_shape.z)};
-        }
-        else {
-            return {(unsigned)(tiled_shape.y * tile), (unsigned)(cdiv(tiled_shape.x, tile)), (unsigned)(tiled_shape.z)};
-        }
-    }
+    return {};
+  }
 
-    TM_HOST_DEVICE dim3 get_grid_shape() const
-    {
-        return get_grid_shape(tiled_shape_, log_tile_);
-    }
+  TM_DEVICE std::true_type init() {
+    return init(blockIdx.x, blockIdx.y, blockIdx.z);
+  }
 
-    TM_HOST_DEVICE std::true_type init(int block_idx_x, int block_idx_y, int block_idx_z)
-    {
-        if constexpr (order == kColMajor) {
-            tile_offset_ = {(block_idx_x >> log_tile_),
-                            (block_idx_y << log_tile_) + (block_idx_x & ((1 << log_tile_) - 1)),
-                            (block_idx_z)};
-        }
-        else {
-            tile_offset_ = {(block_idx_y << log_tile_) + (block_idx_x & ((1 << log_tile_) - 1)),
-                            (block_idx_x >> log_tile_),
-                            (block_idx_z)};
-        }
-        tile_offset_.w       = 0;
-        const int chunk_id   = tile_offset_.z * chunks_per_split_ + max(tile_offset_.z - chunk_offset_, 0);
-        const int iter_k_beg = chunk_id * iter_k_per_chunk_;
-        const int iter_k_cnt = (chunks_per_split_ + int(tile_offset_.z >= chunk_offset_)) * iter_k_per_chunk_;
-        iter_k_range_        = {iter_k_beg, iter_k_beg + iter_k_cnt};
+  TM_DEVICE int4 gemm_shape() const { return gemm_shape_; }
 
-        return {};
-    }
+  TM_DEVICE int4 tiled_shape() const { return tiled_shape_; }
 
-    TM_DEVICE std::true_type init()
-    {
-        return init(blockIdx.x, blockIdx.y, blockIdx.z);
-    }
+  TM_DEVICE int4 tile_offset() const { return tile_offset_; }
 
-    TM_DEVICE int4 gemm_shape() const
-    {
-        return gemm_shape_;
-    }
+  TM_DEVICE int2 iter_k_range() const { return iter_k_range_; }
 
-    TM_DEVICE int4 tiled_shape() const
-    {
-        return tiled_shape_;
-    }
-
-    TM_DEVICE int4 tile_offset() const
-    {
-        return tile_offset_;
-    }
-
-    TM_DEVICE int2 iter_k_range() const
-    {
-        return iter_k_range_;
-    }
-
-    TM_DEVICE int tile_id() const
-    {
-        return tile_offset_.x * tiled_shape_.y + tile_offset_.y;
-    }
+  TM_DEVICE int tile_id() const {
+    return tile_offset_.x * tiled_shape_.y + tile_offset_.y;
+  }
 };
 
-template<Order order_>
+template <Order order_>
 class DynamicScheduler {
+  static constexpr auto order = order_;
 
-    static constexpr auto order = order_;
+  int ctas_;
 
-    int ctas_;
+  const int4* __restrict__ gemm_shapes_;    // [group_num]
+  const int4* __restrict__ tiled_shapes_;   // [group_num]
+  const int2* __restrict__ offsets_mn_;     // [group_num]
+  const int4* __restrict__ tile_offsets_;   // [ctas]
+  const int2* __restrict__ iter_k_ranges_;  // [ctas]
+  const int* __restrict__ tile_ids_;        // [ctas]
 
-    const int4* __restrict__ gemm_shapes_;    // [group_num]
-    const int4* __restrict__ tiled_shapes_;   // [group_num]
-    const int2* __restrict__ offsets_mn_;     // [group_num]
-    const int4* __restrict__ tile_offsets_;   // [ctas]
-    const int2* __restrict__ iter_k_ranges_;  // [ctas]
-    const int* __restrict__ tile_ids_;        // [ctas]
+  int4 gemm_shape_;
+  int4 tiled_shape_;
+  int4 tile_offset_;
+  int2 iter_k_range_;
+  int2 base_mn_;
 
-    int4 gemm_shape_;
-    int4 tiled_shape_;
-    int4 tile_offset_;
-    int2 iter_k_range_;
-    int2 base_mn_;
-
-public:
-    DynamicScheduler(const Tape& tape):
-        ctas_{tape.ctas},
+ public:
+  DynamicScheduler(const Tape& tape)
+      : ctas_{tape.ctas},
         gemm_shapes_{tape.gemm_shapes},
         tiled_shapes_{tape.tiled_shapes},
         tile_offsets_{tape.tile_offsets},
         iter_k_ranges_{tape.iter_k_ranges},
-        tile_ids_{tape.tile_ids}
-    {
+        tile_ids_{tape.tile_ids} {}
+
+  TM_HOST_DEVICE static int get_log_tile(int2 tiled_mn, int tile_size) {
+    return gemm::get_log_tile(order == kColMajor ? tiled_mn.y : tiled_mn.x,
+                              tile_size);
+  }
+
+  TM_HOST_DEVICE dim3 get_grid_shape() { return {(unsigned)ctas_, 1, 1}; }
+
+  TM_DEVICE bool init() {
+    const int block_idx = blockIdx.x;
+
+    const auto [cta_m_id, cta_n_id, cta_k_id, group_id] =
+        __ldg(tile_offsets_ + block_idx);
+
+    if (group_id < 0) {
+      return false;
     }
 
-    TM_HOST_DEVICE static int get_log_tile(int2 tiled_mn, int tile_size)
-    {
-        return gemm::get_log_tile(order == kColMajor ? tiled_mn.y : tiled_mn.x, tile_size);
-    }
+    gemm_shape_ = __ldg(gemm_shapes_ + group_id);
+    tiled_shape_ = __ldg(tiled_shapes_ + group_id);
+    base_mn_ = __ldg(offsets_mn_ + group_id);
 
-    TM_HOST_DEVICE dim3 get_grid_shape()
-    {
-        return {(unsigned)ctas_, 1, 1};
-    }
+    tile_offset_ = {cta_m_id, cta_n_id, cta_k_id, group_id};
 
-    TM_DEVICE bool init()
-    {
-        const int block_idx = blockIdx.x;
+    iter_k_range_ = __ldg(iter_k_ranges_ + block_idx);
 
-        const auto [cta_m_id, cta_n_id, cta_k_id, group_id] = __ldg(tile_offsets_ + block_idx);
+    return true;
+  }
 
-        if (group_id < 0) {
-            return false;
-        }
+  TM_DEVICE int4 gemm_shape() const { return gemm_shape_; }
 
-        gemm_shape_  = __ldg(gemm_shapes_ + group_id);
-        tiled_shape_ = __ldg(tiled_shapes_ + group_id);
-        base_mn_     = __ldg(offsets_mn_ + group_id);
+  TM_DEVICE int4 tiled_shape() const { return tiled_shape_; }
 
-        tile_offset_ = {cta_m_id, cta_n_id, cta_k_id, group_id};
+  TM_DEVICE int4 tile_offset() const { return tile_offset_; }
 
-        iter_k_range_ = __ldg(iter_k_ranges_ + block_idx);
+  TM_DEVICE int2 iter_k_range() const { return iter_k_range_; }
 
-        return true;
-    }
-
-    TM_DEVICE int4 gemm_shape() const
-    {
-        return gemm_shape_;
-    }
-
-    TM_DEVICE int4 tiled_shape() const
-    {
-        return tiled_shape_;
-    }
-
-    TM_DEVICE int4 tile_offset() const
-    {
-        return tile_offset_;
-    }
-
-    TM_DEVICE int2 iter_k_range() const
-    {
-        return iter_k_range_;
-    }
-
-    TM_DEVICE int tile_id() const
-    {
-        return tile_ids_[blockIdx.x];
-    }
+  TM_DEVICE int tile_id() const { return tile_ids_[blockIdx.x]; }
 };
 
-template<class S>
-struct is_dynamic_scheduler: std::false_type {
-};
+template <class S>
+struct is_dynamic_scheduler : std::false_type {};
 
-template<Order order>
-struct is_dynamic_scheduler<DynamicScheduler<order>>: std::true_type {
-};
+template <Order order>
+struct is_dynamic_scheduler<DynamicScheduler<order>> : std::true_type {};
 
 }  // namespace turbomind::gemm

--- a/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/desc.h
+++ b/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/desc.h
@@ -13,192 +13,182 @@ namespace turbomind::gemm {
 
 // aggregate that uniquely identifies a GEMM problem
 struct GemmDesc {
-    int       arch;
-    DataType  type_a;
-    DataType  type_b;
-    DataType  type_c;
-    Order     order_a;
-    Order     order_b;
-    Order     order_c;
-    Striding  striding_a;
-    Striding  striding_b;
-    Striding  striding_c;
-    Pack      pack_a;
-    Pack      pack_b;
-    Pack      pack_u;
-    Pack      pack_v;
-    QuantDesc quant_a;
-    QuantDesc quant_b;
-    Epilogue  epilogue;
-    int       batch_dim;
-    int       group_axis;
-    int       m;
-    int       n;
-    int       k;
-    int       num;
+  int arch;
+  DataType type_a;
+  DataType type_b;
+  DataType type_c;
+  Order order_a;
+  Order order_b;
+  Order order_c;
+  Striding striding_a;
+  Striding striding_b;
+  Striding striding_c;
+  Pack pack_a;
+  Pack pack_b;
+  Pack pack_u;
+  Pack pack_v;
+  QuantDesc quant_a;
+  QuantDesc quant_b;
+  Epilogue epilogue;
+  int batch_dim;
+  int group_axis;
+  int m;
+  int n;
+  int k;
+  int num;
 };
 
 static_assert(std::is_trivially_copyable_v<GemmDesc>);
 
-inline GemmDesc transpose(GemmDesc d)
-{
-    std::swap(d.type_a, d.type_b);
-    std::swap(d.order_a, d.order_b);
-    d.order_a = ~d.order_a;
-    d.order_b = ~d.order_b;
-    d.order_c = ~d.order_c;
-    std::swap(d.striding_a, d.striding_b);
-    std::swap(d.pack_a, d.pack_b);
-    std::swap(d.pack_u, d.pack_v);
-    std::swap(d.quant_a, d.quant_b);
-    std::swap(d.m, d.n);
-    d.batch_dim = 1 - d.batch_dim;
-    if (d.group_axis >= 0) {
-        d.group_axis = 1 - d.group_axis;
-    }
-    return d;
+inline GemmDesc transpose(GemmDesc d) {
+  std::swap(d.type_a, d.type_b);
+  std::swap(d.order_a, d.order_b);
+  d.order_a = ~d.order_a;
+  d.order_b = ~d.order_b;
+  d.order_c = ~d.order_c;
+  std::swap(d.striding_a, d.striding_b);
+  std::swap(d.pack_a, d.pack_b);
+  std::swap(d.pack_u, d.pack_v);
+  std::swap(d.quant_a, d.quant_b);
+  std::swap(d.m, d.n);
+  d.batch_dim = 1 - d.batch_dim;
+  if (d.group_axis >= 0) {
+    d.group_axis = 1 - d.group_axis;
+  }
+  return d;
 }
 
-inline std::string to_string(const GemmDesc& d)
-{
-    std::stringstream ss;
-    ss << "sm" << d.arch / 10;
-    ss << "_" << to_string(d.type_a);  //
-    if (d.quant_a) {
-        ss << to_string(d.quant_a);
-    }
-    ss << "_" << to_string(d.type_b);  //
-    if (d.quant_b) {
-        ss << to_string(d.quant_b);
-    }
-    ss << "_" << to_string(d.type_c);
-    ss << "_"                                    //
-       << (d.order_a == kColMajor ? 'n' : 't')   //
-       << (d.order_b == kColMajor ? 'n' : 't')   //
-       << (d.order_c == kColMajor ? 'n' : 't');  //
-    ss << "_"                                    //
-       << to_string(d.striding_a)                //
-       << to_string(d.striding_b)                //
-       << to_string(d.striding_c);
-    ss << "_" << d.m << "x" << d.n << "x" << d.k;
-    ss << "_" << d.num;
-    return ss.str();
+inline std::string to_string(const GemmDesc& d) {
+  std::stringstream ss;
+  ss << "sm" << d.arch / 10;
+  ss << "_" << to_string(d.type_a);  //
+  if (d.quant_a) {
+    ss << to_string(d.quant_a);
+  }
+  ss << "_" << to_string(d.type_b);  //
+  if (d.quant_b) {
+    ss << to_string(d.quant_b);
+  }
+  ss << "_" << to_string(d.type_c);
+  ss << "_"                                    //
+     << (d.order_a == kColMajor ? 'n' : 't')   //
+     << (d.order_b == kColMajor ? 'n' : 't')   //
+     << (d.order_c == kColMajor ? 'n' : 't');  //
+  ss << "_"                                    //
+     << to_string(d.striding_a)                //
+     << to_string(d.striding_b)                //
+     << to_string(d.striding_c);
+  ss << "_" << d.m << "x" << d.n << "x" << d.k;
+  ss << "_" << d.num;
+  return ss.str();
 }
 
-enum class OpClass
-{
-    kSIMT,
-    kMMA_s884,
-    kMMA_s16816,
-    kGMMA_s64n16
-};
+enum class OpClass { kSIMT, kMMA_s884, kMMA_s16816, kGMMA_s64n16 };
 
-inline const char* to_string(OpClass op)
-{
-    switch (op) {
-        case OpClass::kSIMT:
-            return "simt";
-        case OpClass::kMMA_s884:
-            return "s884";
-        case OpClass::kMMA_s16816:
-            return "s16816";
-        default:
-            return "unknown_op_cls";
-    }
+inline const char* to_string(OpClass op) {
+  switch (op) {
+    case OpClass::kSIMT:
+      return "simt";
+    case OpClass::kMMA_s884:
+      return "s884";
+    case OpClass::kMMA_s16816:
+      return "s16816";
+    default:
+      return "unknown_op_cls";
+  }
 }
 
 // aggregate that uniquely identifies a kernel
 struct KernelDesc {
-    int       arch;
-    OpClass   op_class;
-    DataType  type_a;
-    DataType  type_b;
-    DataType  type_c;
-    Order     order_a;
-    Order     order_b;
-    Order     order_c;
-    Striding  striding_a;
-    Striding  striding_b;
-    Striding  striding_c;
-    Pack      pack_a;
-    Pack      pack_b;
-    Pack      pack_u;
-    Pack      pack_v;
-    QuantDesc quant_a;
-    QuantDesc quant_b;
-    int       policy_a;
-    int       policy_b;
-    int3      cta_tile;
-    int3      mma_tile;
-    int2      cluster_shape;
-    int3      align;
-    int2      c_tile;
-    int       stages;
-    bool      split_k;
-    int       group_axis;
-    int       backend;
-    bool      transpose;
+  int arch;
+  OpClass op_class;
+  DataType type_a;
+  DataType type_b;
+  DataType type_c;
+  Order order_a;
+  Order order_b;
+  Order order_c;
+  Striding striding_a;
+  Striding striding_b;
+  Striding striding_c;
+  Pack pack_a;
+  Pack pack_b;
+  Pack pack_u;
+  Pack pack_v;
+  QuantDesc quant_a;
+  QuantDesc quant_b;
+  int policy_a;
+  int policy_b;
+  int3 cta_tile;
+  int3 mma_tile;
+  int2 cluster_shape;
+  int3 align;
+  int2 c_tile;
+  int stages;
+  bool split_k;
+  int group_axis;
+  int backend;
+  bool transpose;
 };
 
 static_assert(std::is_trivially_copyable_v<KernelDesc>);
 
 struct KernelInfo {
-    int dynamic_smem_size;
-    int max_active_ctas;
-    int chunk_size_k;
+  int dynamic_smem_size;
+  int max_active_ctas;
+  int chunk_size_k;
 
-    std::string name;
+  std::string name;
 
-    cudaFuncAttributes attr;
+  cudaFuncAttributes attr;
 };
 
-inline KernelDesc transpose(const KernelDesc& d)
-{
-    KernelDesc k{d};
+inline KernelDesc transpose(const KernelDesc& d) {
+  KernelDesc k{d};
 
-    k.arch     = d.arch;
-    k.op_class = d.op_class;
+  k.arch = d.arch;
+  k.op_class = d.op_class;
 
-    k.order_a = ~d.order_b;
-    k.order_b = ~d.order_a;
-    k.order_c = ~d.order_c;
+  k.order_a = ~d.order_b;
+  k.order_b = ~d.order_a;
+  k.order_c = ~d.order_c;
 
-    k.type_a = d.type_b;
-    k.type_b = d.type_a;
+  k.type_a = d.type_b;
+  k.type_b = d.type_a;
 
-    k.striding_a = d.striding_b;
-    k.striding_b = d.striding_a;
+  k.striding_a = d.striding_b;
+  k.striding_b = d.striding_a;
 
-    k.pack_a = d.pack_b;
-    k.pack_b = d.pack_a;
-    k.pack_u = d.pack_v;
-    k.pack_v = d.pack_u;
+  k.pack_a = d.pack_b;
+  k.pack_b = d.pack_a;
+  k.pack_u = d.pack_v;
+  k.pack_v = d.pack_u;
 
-    k.quant_a = d.quant_b;
-    k.quant_b = d.quant_a;
+  k.quant_a = d.quant_b;
+  k.quant_b = d.quant_a;
 
-    k.policy_a = d.policy_b;
-    k.policy_b = d.policy_a;
+  k.policy_a = d.policy_b;
+  k.policy_b = d.policy_a;
 
-    auto swap = [](auto& v) { std::swap(v.x, v.y); };
+  auto swap = [](auto& v) { std::swap(v.x, v.y); };
 
-    swap(k.cta_tile);
-    swap(k.mma_tile);
-    swap(k.cluster_shape);
-    swap(k.align);
-    swap(k.c_tile);
+  swap(k.cta_tile);
+  swap(k.mma_tile);
+  swap(k.cluster_shape);
+  swap(k.align);
+  swap(k.c_tile);
 
-    return k;
+  return k;
 }
 
 class Kernel;
 struct LaunchSpec {
-    Kernel* kernel;
-    int     swizzle;
-    int     splits;
-    float   measured;
+  Kernel* kernel;
+  int swizzle;
+  int splits;
+  float measured;
 
-    std::array<int64_t, 2> estimated;
+  std::array<int64_t, 2> estimated;
 };
 
 }  // namespace turbomind::gemm

--- a/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/dispatch_cache.cu
+++ b/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/dispatch_cache.cu
@@ -13,342 +13,282 @@
 #include <sstream>
 #include <vector>
 
-static inline bool operator==(const int3& a, const int3& b)
-{
-    return a.x == b.x && a.y == b.y && a.z == b.z;
+static inline bool operator==(const int3& a, const int3& b) {
+  return a.x == b.x && a.y == b.y && a.z == b.z;
 }
 
-static inline bool operator==(const int2& a, const int2& b)
-{
-    return a.x == b.x && a.y == b.y;
+static inline bool operator==(const int2& a, const int2& b) {
+  return a.x == b.x && a.y == b.y;
 }
 
 namespace turbomind::gemm {
 
 namespace {
 
-bool dispatch_cache_summary_enabled()
-{
-    const char* raw = std::getenv("TM_GEMM_CACHE_SUMMARY");
-    return raw != nullptr && std::atoi(raw) != 0;
+bool dispatch_cache_summary_enabled() {
+  const char* raw = std::getenv("TM_GEMM_CACHE_SUMMARY");
+  return raw != nullptr && std::atoi(raw) != 0;
 }
 
 }  // namespace
 
-static inline decltype(auto) as_tuple(const KernelDesc& d)
-{
-    return std::tie(d.arch,
-                    d.op_class,
-                    d.type_a,
-                    d.type_b,
-                    d.type_c,
-                    d.order_a,
-                    d.order_b,
-                    d.order_c,
-                    d.striding_a,
-                    d.striding_b,
-                    d.striding_c,
-                    d.pack_a,
-                    d.pack_b,
-                    d.pack_u,
-                    d.pack_v,
-                    d.quant_a,
-                    d.quant_b,
-                    d.policy_a,
-                    d.policy_b,
-                    d.cta_tile,
-                    d.mma_tile,
-                    d.cluster_shape,
-                    d.align,
-                    d.c_tile,
-                    d.stages,
-                    d.split_k,
-                    d.backend,
-                    d.transpose,
-                    d.group_axis);
+static inline decltype(auto) as_tuple(const KernelDesc& d) {
+  return std::tie(d.arch, d.op_class, d.type_a, d.type_b, d.type_c, d.order_a,
+                  d.order_b, d.order_c, d.striding_a, d.striding_b,
+                  d.striding_c, d.pack_a, d.pack_b, d.pack_u, d.pack_v,
+                  d.quant_a, d.quant_b, d.policy_a, d.policy_b, d.cta_tile,
+                  d.mma_tile, d.cluster_shape, d.align, d.c_tile, d.stages,
+                  d.split_k, d.backend, d.transpose, d.group_axis);
 }
 
-static inline bool operator==(const QuantDesc& a, const QuantDesc& b)
-{
-    return a.type == b.type && a.group_size == b.group_size;
+static inline bool operator==(const QuantDesc& a, const QuantDesc& b) {
+  return a.type == b.type && a.group_size == b.group_size;
 }
 
-static inline bool operator==(const KernelDesc& a, const KernelDesc& b)
-{
-    return as_tuple(a) == as_tuple(b);
+static inline bool operator==(const KernelDesc& a, const KernelDesc& b) {
+  return as_tuple(a) == as_tuple(b);
 }
 
 namespace {
 
 struct Record {
-    GemmDesc   gemm;
-    KernelDesc kernel;
+  GemmDesc gemm;
+  KernelDesc kernel;
 
-    int swizzle;
-    int splits;
+  int swizzle;
+  int splits;
 };
 
 }  // namespace
 
-void ExportDispatchCache(std::ostream& os, const std::vector<std::pair<GemmDesc, LaunchSpec>>& entries)
-{
+void ExportDispatchCache(
+    std::ostream& os,
+    const std::vector<std::pair<GemmDesc, LaunchSpec>>& entries) {
+  for (const auto& [g, spec] : entries) {
+    Record record{};
+    record.gemm = g;
+    record.kernel = spec.kernel->desc();
+    record.splits = spec.splits;
+    record.swizzle = spec.swizzle;
 
-    for (const auto& [g, spec] : entries) {
-        Record record{};
-        record.gemm    = g;
-        record.kernel  = spec.kernel->desc();
-        record.splits  = spec.splits;
-        record.swizzle = spec.swizzle;
-
-        os.write((const char*)&record, sizeof(record));
-    }
+    os.write((const char*)&record, sizeof(record));
+  }
 }
 
-void ImportDispatchCache(std::istream&                                 is,
+void ImportDispatchCache(std::istream& is,
                          std::vector<std::pair<GemmDesc, LaunchSpec>>& entries,
-                         const std::vector<Kernel*>&                   kernels)
-{
-    is.seekg(0, is.end);
-    const auto size_in_bytes = is.tellg();
-    is.seekg(0, is.beg);
+                         const std::vector<Kernel*>& kernels) {
+  is.seekg(0, is.end);
+  const auto size_in_bytes = is.tellg();
+  is.seekg(0, is.beg);
 
-    if (size_in_bytes % sizeof(Record)) {
-        std::cerr << "File size is not a multiple of record size, faild to import records.\n";
+  if (size_in_bytes % sizeof(Record)) {
+    std::cerr << "File size is not a multiple of record size, failed to import "
+                 "records.\n";
+  }
+
+  const int n = size_in_bytes / sizeof(Record);
+
+  for (int i = 0; i < n; ++i) {
+    Record record;
+    is.read((char*)&record, sizeof(Record));
+
+    LaunchSpec spec{};
+    spec.splits = record.splits;
+    spec.swizzle = record.swizzle;
+
+    for (const auto& p : kernels) {
+      if (p->desc() == record.kernel) {
+        spec.kernel = p;
+        break;
+      }
     }
-
-    const int n = size_in_bytes / sizeof(Record);
-
-    for (int i = 0; i < n; ++i) {
-        Record record;
-        is.read((char*)&record, sizeof(Record));
-
-        LaunchSpec spec{};
-        spec.splits  = record.splits;
-        spec.swizzle = record.swizzle;
-
-        for (const auto& p : kernels) {
-            if (p->desc() == record.kernel) {
-                spec.kernel = p;
-                break;
-            }
-        }
-        if (spec.kernel) {
-            entries.emplace_back(record.gemm, spec);
-        }
-        else {
-            std::cerr << "No kernel found for entry " << i << "\n";
-        }
+    if (spec.kernel) {
+      entries.emplace_back(record.gemm, spec);
+    } else {
+      std::cerr << "No kernel found for entry " << i << "\n";
     }
+  }
 }
 
 namespace {
 
-inline decltype(auto) as_tuple(const GemmDesc& d)
-{
-    return std::tie(d.arch,
-                    d.type_a,
-                    d.type_b,
-                    d.type_c,
-                    d.order_a,
-                    d.order_b,
-                    d.order_c,
-                    d.striding_a,
-                    d.striding_b,
-                    d.striding_c,
-                    d.pack_a,
-                    d.pack_b,
-                    d.pack_u,
-                    d.pack_v,
-                    d.quant_a.type,
-                    d.quant_a.group_size,
-                    d.quant_b.type,
-                    d.quant_b.group_size,
-                    d.batch_dim,
-                    d.group_axis,
-                    d.m,
-                    d.n,
-                    d.k,
-                    d.num);
-    // Note: `d.epilogue` is not used yet
+inline decltype(auto) as_tuple(const GemmDesc& d) {
+  return std::tie(d.arch, d.type_a, d.type_b, d.type_c, d.order_a, d.order_b,
+                  d.order_c, d.striding_a, d.striding_b, d.striding_c, d.pack_a,
+                  d.pack_b, d.pack_u, d.pack_v, d.quant_a.type,
+                  d.quant_a.group_size, d.quant_b.type, d.quant_b.group_size,
+                  d.batch_dim, d.group_axis, d.m, d.n, d.k, d.num);
+  // Note: `d.epilogue` is not used yet
 }
 
 }  // namespace
 
-inline bool operator<(const GemmDesc& a, const GemmDesc& b)
-{
-    return as_tuple(a) < as_tuple(b);
+inline bool operator<(const GemmDesc& a, const GemmDesc& b) {
+  return as_tuple(a) < as_tuple(b);
 }
 
-int extract_batch_size(GemmDesc& desc)
-{
-    return std::exchange(desc.batch_dim == 0 ? desc.m : desc.n, 0);
+int extract_batch_size(GemmDesc& desc) {
+  return std::exchange(desc.batch_dim == 0 ? desc.m : desc.n, 0);
 }
 
-void set_batch_size(GemmDesc& desc, int batch_size)
-{
-    (desc.batch_dim == 0 ? desc.m : desc.n) = batch_size;
+void set_batch_size(GemmDesc& desc, int batch_size) {
+  (desc.batch_dim == 0 ? desc.m : desc.n) = batch_size;
 }
 
 struct DispatchCache::Impl {
+  struct Flat {
+    std::vector<std::pair<int, int>> idxs;
+    std::vector<LaunchSpec> specs;
+  };
 
-    struct Flat {
-        std::vector<std::pair<int, int>> idxs;
-        std::vector<LaunchSpec>          specs;
-    };
+  const std::vector<Kernel*> kernels_;
+  std::map<GemmDesc, Flat> cache_;
 
-    const std::vector<Kernel*> kernels_;
-    std::map<GemmDesc, Flat>   cache_;
+  Impl(std::vector<Kernel*> kernels) : kernels_(std::move(kernels)) {}
 
-    Impl(std::vector<Kernel*> kernels): kernels_(std::move(kernels)) {}
-
-    std::optional<LaunchSpec> Find(GemmDesc desc, bool exact) const
-    {
-        const int batch_size = extract_batch_size(desc);
-        // std::cerr << batch_size << " " << desc.m << " " << desc.n << " " << desc.k << " " << std::boolalpha << exact
-        //           << "\n";
-        const auto it = cache_.find(desc);
-        if (it != cache_.end()) {
-            const auto& [idxs, specs] = it->second;
-            // Find index via key
-            const auto p =
-                std::lower_bound(idxs.begin(), idxs.end(), std::make_pair(batch_size, 0), [](auto& a, auto& b) {  //
-                    return a.first < b.first;
-                });
-            // std::cout << it->second.specs.size() << std::endl;
-            if (p != idxs.end() && (!exact || p->first == batch_size)) {
-                // std::cerr << p->first << " " << p->second << "\n";
-                return specs[p->second];
-            }
-        }
-        return {};
+  std::optional<LaunchSpec> Find(GemmDesc desc, bool exact) const {
+    const int batch_size = extract_batch_size(desc);
+    // std::cerr << batch_size << " " << desc.m << " " << desc.n << " " <<
+    // desc.k << " " << std::boolalpha << exact
+    //           << "\n";
+    const auto it = cache_.find(desc);
+    if (it != cache_.end()) {
+      const auto& [idxs, specs] = it->second;
+      // Find index via key
+      const auto p = std::lower_bound(idxs.begin(), idxs.end(),
+                                      std::make_pair(batch_size, 0),
+                                      [](auto& a, auto& b) {  //
+                                        return a.first < b.first;
+                                      });
+      // std::cout << it->second.specs.size() << std::endl;
+      if (p != idxs.end() && (!exact || p->first == batch_size)) {
+        // std::cerr << p->first << " " << p->second << "\n";
+        return specs[p->second];
+      }
     }
+    return {};
+  }
 
-    bool Insert(GemmDesc desc, const LaunchSpec& spec)
-    {
-        const int batch_size = extract_batch_size(desc);
+  bool Insert(GemmDesc desc, const LaunchSpec& spec) {
+    const int batch_size = extract_batch_size(desc);
 
-        auto it = cache_.find(desc);
-        if (it == cache_.end()) {
-            it = cache_.emplace_hint(it, desc, Flat{});
-        }
-        auto& [idxs, specs] = it->second;
-        // Find index via key
-        const auto p =
-            std::lower_bound(idxs.begin(), idxs.end(), std::make_pair(batch_size, 0), [](auto& a, auto& b) {  //
-                return a.first < b.first;
-            });
-        // Exact match, skip
-        if (p != idxs.end() && p->first == batch_size) {
-            return false;
-        }
-        // Insert
-        idxs.insert(p, {batch_size, (int)specs.size()});
-        specs.push_back(spec);
-        return true;
+    auto it = cache_.find(desc);
+    if (it == cache_.end()) {
+      it = cache_.emplace_hint(it, desc, Flat{});
     }
-
-    int Export(std::ostream& os) const
-    {
-        std::vector<std::pair<GemmDesc, LaunchSpec>> entries;
-        for (const auto& [desc, flat] : cache_) {
-            auto tmp = desc;
-            for (const auto& [batch_size, index] : flat.idxs) {
-                set_batch_size(tmp, batch_size);
-                entries.emplace_back(tmp, flat.specs[index]);
-            }
-        }
-        Summary(entries);
-        ExportDispatchCache(os, entries);
-        return entries.size();
+    auto& [idxs, specs] = it->second;
+    // Find index via key
+    const auto p = std::lower_bound(idxs.begin(), idxs.end(),
+                                    std::make_pair(batch_size, 0),
+                                    [](auto& a, auto& b) {  //
+                                      return a.first < b.first;
+                                    });
+    // Exact match, skip
+    if (p != idxs.end() && p->first == batch_size) {
+      return false;
     }
+    // Insert
+    idxs.insert(p, {batch_size, (int)specs.size()});
+    specs.push_back(spec);
+    return true;
+  }
 
-    int Import(std::istream& is)
-    {
-        std::vector<std::pair<GemmDesc, LaunchSpec>> entries;
-        ImportDispatchCache(is, entries, kernels_);
-        Summary(entries);
-        for (auto [desc, spec] : entries) {
-            const int batch_size = extract_batch_size(desc);
-            auto      it         = cache_.find(desc);
-            if (it == cache_.end()) {
-                it = cache_.emplace_hint(it, desc, Flat{});
-            }
-            auto& [idxs, specs] = it->second;
-            // Order is not maintained at this point
-            idxs.emplace_back(batch_size, (int)specs.size());
-            specs.push_back(spec);
-        }
-        // Sort indices and deduplicate
-        for (auto& [desc, flat] : cache_) {
-            auto& [idxs, specs] = flat;
-            std::stable_sort(idxs.begin(), idxs.end(), [](auto a, auto b) { return a.first < b.first; });
-            idxs.erase(std::unique(idxs.begin(), idxs.end(), [](auto a, auto b) { return a.first == b.first; }),
-                       idxs.end());
-            // Remove unreferenced specs and update spec indices
-            std::vector<LaunchSpec> tmp;
-            for (auto& [key, val] : idxs) {
-                int old = std::exchange(val, tmp.size());
-                tmp.push_back(specs[old]);
-            }
-            specs = std::move(tmp);
-        }
-        return entries.size();
+  int Export(std::ostream& os) const {
+    std::vector<std::pair<GemmDesc, LaunchSpec>> entries;
+    for (const auto& [desc, flat] : cache_) {
+      auto tmp = desc;
+      for (const auto& [batch_size, index] : flat.idxs) {
+        set_batch_size(tmp, batch_size);
+        entries.emplace_back(tmp, flat.specs[index]);
+      }
     }
+    Summary(entries);
+    ExportDispatchCache(os, entries);
+    return entries.size();
+  }
 
-    // Print a summary of how many cases a kernel is used
-    void Summary(const std::vector<std::pair<GemmDesc, LaunchSpec>>& entries) const
-    {
-        if (!dispatch_cache_summary_enabled()) {
-            return;
-        }
-        std::vector<Kernel*> uses{nullptr};
-        std::copy(kernels_.begin(), kernels_.end(), std::back_inserter(uses));
-
-        for (const auto& [_, s] : entries) {
-            uses.push_back(s.kernel);
-        }
-        std::sort(uses.begin(), uses.end());
-        std::vector<std::pair<int, Kernel*>> count;
-        for (size_t i = 1; i < uses.size(); ++i) {
-            if (uses[i] != uses[i - 1]) {
-                count.emplace_back(-1, uses[i]);
-            }
-            ++count.back().first;
-        }
-        std::sort(count.begin(), count.end(), std::greater<>{});
-        for (const auto& [n, k] : count) {
-            std::cout << k->name() << ": " << n << "\n";
-        }
+  int Import(std::istream& is) {
+    std::vector<std::pair<GemmDesc, LaunchSpec>> entries;
+    ImportDispatchCache(is, entries, kernels_);
+    Summary(entries);
+    for (auto [desc, spec] : entries) {
+      const int batch_size = extract_batch_size(desc);
+      auto it = cache_.find(desc);
+      if (it == cache_.end()) {
+        it = cache_.emplace_hint(it, desc, Flat{});
+      }
+      auto& [idxs, specs] = it->second;
+      // Order is not maintained at this point
+      idxs.emplace_back(batch_size, (int)specs.size());
+      specs.push_back(spec);
     }
+    // Sort indices and deduplicate
+    for (auto& [desc, flat] : cache_) {
+      auto& [idxs, specs] = flat;
+      std::stable_sort(idxs.begin(), idxs.end(),
+                       [](auto a, auto b) { return a.first < b.first; });
+      idxs.erase(std::unique(idxs.begin(), idxs.end(),
+                             [](auto a, auto b) { return a.first == b.first; }),
+                 idxs.end());
+      // Remove unreferenced specs and update spec indices
+      std::vector<LaunchSpec> tmp;
+      for (auto& [key, val] : idxs) {
+        int old = std::exchange(val, tmp.size());
+        tmp.push_back(specs[old]);
+      }
+      specs = std::move(tmp);
+    }
+    return entries.size();
+  }
+
+  // Print a summary of how many cases a kernel is used
+  void Summary(
+      const std::vector<std::pair<GemmDesc, LaunchSpec>>& entries) const {
+    if (!dispatch_cache_summary_enabled()) {
+      return;
+    }
+    std::vector<Kernel*> uses{nullptr};
+    std::copy(kernels_.begin(), kernels_.end(), std::back_inserter(uses));
+
+    for (const auto& [_, s] : entries) {
+      uses.push_back(s.kernel);
+    }
+    std::sort(uses.begin(), uses.end());
+    std::vector<std::pair<int, Kernel*>> count;
+    for (size_t i = 1; i < uses.size(); ++i) {
+      if (uses[i] != uses[i - 1]) {
+        count.emplace_back(-1, uses[i]);
+      }
+      ++count.back().first;
+    }
+    std::sort(count.begin(), count.end(), std::greater<>{});
+    for (const auto& [n, k] : count) {
+      std::cout << k->name() << ": " << n << "\n";
+    }
+  }
 };
 
-DispatchCache::DispatchCache(std::vector<Kernel*> kernels): impl_(std::make_unique<Impl>(std::move(kernels))) {}
+DispatchCache::DispatchCache(std::vector<Kernel*> kernels)
+    : impl_(std::make_unique<Impl>(std::move(kernels))) {}
 
 DispatchCache::~DispatchCache() = default;
 
-std::optional<LaunchSpec> DispatchCache::Find(const GemmDesc& desc) const
-{
-    return impl_->Find(desc, true);
+std::optional<LaunchSpec> DispatchCache::Find(const GemmDesc& desc) const {
+  return impl_->Find(desc, true);
 }
 
-std::optional<LaunchSpec> DispatchCache::LowerBound(const GemmDesc& desc) const
-{
-    return impl_->Find(desc, false);
+std::optional<LaunchSpec> DispatchCache::LowerBound(
+    const GemmDesc& desc) const {
+  return impl_->Find(desc, false);
 }
 
-bool DispatchCache::Insert(const GemmDesc& desc, const LaunchSpec& spec)
-{
-    return impl_->Insert(desc, spec);
+bool DispatchCache::Insert(const GemmDesc& desc, const LaunchSpec& spec) {
+  return impl_->Insert(desc, spec);
 }
 
-int DispatchCache::Export(std::ostream& os) const
-{
-    return impl_->Export(os);
-}
+int DispatchCache::Export(std::ostream& os) const { return impl_->Export(os); }
 
-int DispatchCache::Import(std::istream& is)
-{
-    return impl_->Import(is);
-}
+int DispatchCache::Import(std::istream& is) { return impl_->Import(is); }
 
 }  // namespace turbomind::gemm

--- a/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/dispatch_cache.h
+++ b/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/dispatch_cache.h
@@ -9,24 +9,24 @@
 namespace turbomind::gemm {
 
 class DispatchCache {
-public:
-    DispatchCache(std::vector<Kernel*> kernels);
+ public:
+  DispatchCache(std::vector<Kernel*> kernels);
 
-    ~DispatchCache();
+  ~DispatchCache();
 
-    std::optional<LaunchSpec> LowerBound(const GemmDesc& desc) const;
+  std::optional<LaunchSpec> LowerBound(const GemmDesc& desc) const;
 
-    std::optional<LaunchSpec> Find(const GemmDesc& desc) const;
+  std::optional<LaunchSpec> Find(const GemmDesc& desc) const;
 
-    bool Insert(const GemmDesc& desc, const LaunchSpec& spec);
+  bool Insert(const GemmDesc& desc, const LaunchSpec& spec);
 
-    int Export(std::ostream& os) const;
+  int Export(std::ostream& os) const;
 
-    int Import(std::istream& is);
+  int Import(std::istream& is);
 
-private:
-    struct Impl;
-    std::unique_ptr<Impl> impl_;
+ private:
+  struct Impl;
+  std::unique_ptr<Impl> impl_;
 };
 
 }  // namespace turbomind::gemm

--- a/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/epilogue.h
+++ b/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/epilogue.h
@@ -16,559 +16,516 @@
 
 namespace turbomind::gemm {
 
-template<class Tc>
+template <class Tc>
 struct ChannelCombination_v3 {
-    const Tc* __restrict__ scale_bias_ptr;
+  const Tc* __restrict__ scale_bias_ptr;
 
-    template<class T, int V, int S, int C, int delta_c, int delta_s, class Pred>
-    __device__ void operator()(Array<T, V> (&x)[S][C], int2 cs0, pair<delta_c, delta_s>, Pred& pred) const
-    {
-        __align__(16) Array<Tc, 2> scale_bias[S];
+  template <class T, int V, int S, int C, int delta_c, int delta_s, class Pred>
+  __device__ void operator()(Array<T, V> (&x)[S][C], int2 cs0,
+                             pair<delta_c, delta_s>, Pred& pred) const {
+    __align__(16) Array<Tc, 2> scale_bias[S];
 
-        if (scale_bias_ptr) {
-            constexpr int ds  = sizeof(Tc) * delta_s;
-            auto          ptr = reinterpret_cast<const char*>(scale_bias_ptr + cs0.y);
-            PRAGMA_UNROLL
-            for (int s = 0; s < S; ++s) {
-                if (pred(s, 0)) {
-                    Ldg(scale_bias[s], reinterpret_cast<const Tc*>(ptr));
-                }
-                ptr += ds;
-            }
-            PRAGMA_UNROLL
-            for (int s = 0; s < S; ++s) {
-                auto tmp = cast<T>(scale_bias[s]);
-                PRAGMA_UNROLL
-                for (int c = 0; c < C; ++c) {
-                    using namespace ops;
-                    x[s][c] = x[s][c] * tmp[0] + tmp[1];
-                }
-            }
+    if (scale_bias_ptr) {
+      constexpr int ds = sizeof(Tc) * delta_s;
+      auto ptr = reinterpret_cast<const char*>(scale_bias_ptr + cs0.y);
+      PRAGMA_UNROLL
+      for (int s = 0; s < S; ++s) {
+        if (pred(s, 0)) {
+          Ldg(scale_bias[s], reinterpret_cast<const Tc*>(ptr));
         }
-    }
-};
-
-template<bool     scale_S,
-         bool     scale_C,
-         Striding mode_S,
-         Striding mode_C,
-         class T,
-         int N,
-         int S,
-         int C,
-         int delta_C,
-         int delta_S,
-         class Pred>
-__device__ void Scale(pair<scale_S, scale_C>,
-                      pair<mode_S, mode_C>,
-                      pair<delta_C, delta_S>,
-                      Array<T, N> (&x)[S][C],
-                      const MatrixParam& param_S,
-                      const MatrixParam& param_C,
-                      int                gemm_id,
-                      int2               cs0,
-                      Pred&              pred)
-{
-    if (scale_S && param_S.ptr) {
-        const auto mat = resolve<T, mode_S>(param_S, gemm_id);
-        const T*   ptr = (const T*)mat.ptr.ptr;
-        T          param[S];
-        PRAGMA_UNROLL
-        for (int s = 0; s < S; ++s) {
-            const int ss  = cs0.y + s * delta_S;
-            const int idx = mat.idxs ? __ldg(mat.idxs + ss) : ss;
-            if (pred(s, 0)) {
-                param[s] = __ldg((const T*)(ptr + idx));
-            }
-            PRAGMA_UNROLL
-            for (int c = 0; c < C; ++c) {
-                using namespace ops;
-                x[s][c] = x[s][c] * param[s];
-            }
-        }
-    }
-
-    if (scale_C && param_C.ptr) {
-        const T*      ptr = (const T*)resolve<T, mode_C>(param_C, gemm_id).ptr.ptr + cs0.x;
-        constexpr int dc  = sizeof(Array<T, N>) * delta_C;
-        Array<T, N>   param[C];
+        ptr += ds;
+      }
+      PRAGMA_UNROLL
+      for (int s = 0; s < S; ++s) {
+        auto tmp = cast<T>(scale_bias[s]);
         PRAGMA_UNROLL
         for (int c = 0; c < C; ++c) {
-            if (pred(0, c)) {
-                Ldg(param[c], (const T*)(ptr + dc * c));
-            }
-            PRAGMA_UNROLL
-            for (int s = 0; s < S; ++s) {
-                using namespace ops;
-                x[s][c] = x[s][c] * param[c];
-            }
+          using namespace ops;
+          x[s][c] = x[s][c] * tmp[0] + tmp[1];
         }
+      }
     }
+  }
+};
+
+template <bool scale_S, bool scale_C, Striding mode_S, Striding mode_C, class T,
+          int N, int S, int C, int delta_C, int delta_S, class Pred>
+__device__ void Scale(pair<scale_S, scale_C>, pair<mode_S, mode_C>,
+                      pair<delta_C, delta_S>, Array<T, N> (&x)[S][C],
+                      const MatrixParam& param_S, const MatrixParam& param_C,
+                      int gemm_id, int2 cs0, Pred& pred) {
+  if (scale_S && param_S.ptr) {
+    const auto mat = resolve<T, mode_S>(param_S, gemm_id);
+    const T* ptr = (const T*)mat.ptr.ptr;
+    T param[S];
+    PRAGMA_UNROLL
+    for (int s = 0; s < S; ++s) {
+      const int ss = cs0.y + s * delta_S;
+      const int idx = mat.idxs ? __ldg(mat.idxs + ss) : ss;
+      if (pred(s, 0)) {
+        param[s] = __ldg((const T*)(ptr + idx));
+      }
+      PRAGMA_UNROLL
+      for (int c = 0; c < C; ++c) {
+        using namespace ops;
+        x[s][c] = x[s][c] * param[s];
+      }
+    }
+  }
+
+  if (scale_C && param_C.ptr) {
+    const T* ptr =
+        (const T*)resolve<T, mode_C>(param_C, gemm_id).ptr.ptr + cs0.x;
+    constexpr int dc = sizeof(Array<T, N>) * delta_C;
+    Array<T, N> param[C];
+    PRAGMA_UNROLL
+    for (int c = 0; c < C; ++c) {
+      if (pred(0, c)) {
+        Ldg(param[c], (const T*)(ptr + dc * c));
+      }
+      PRAGMA_UNROLL
+      for (int s = 0; s < S; ++s) {
+        using namespace ops;
+        x[s][c] = x[s][c] * param[c];
+      }
+    }
+  }
 }
 
 struct MatrixCombination_v3 {
+  MatrixParam param_c;
+  float alpha;
+  float beta;
 
-    MatrixParam param_c;
-    float       alpha;
-    float       beta;
+  template <class Tc, Striding mode, class T, int N, int S, int C, int delta_c,
+            int delta_s, class Pred>
+  __device__ void operator()(Tc*,  //
+                             constant<mode>, Array<T, N> (&x)[S][C], int2 cs0,
+                             int gemm_id, pair<delta_c, delta_s>,
+                             Pred& pred) const {
+    if (beta) {
+      const auto c = resolve<Tc, mode>(param_c, gemm_id);
 
-    template<class Tc, Striding mode, class T, int N, int S, int C, int delta_c, int delta_s, class Pred>
-    __device__ void operator()(Tc*,  //
-                               constant<mode>,
-                               Array<T, N> (&x)[S][C],
-                               int2 cs0,
-                               int  gemm_id,
-                               pair<delta_c, delta_s>,
-                               Pred& pred) const
-    {
-        if (beta) {
-            const auto c = resolve<Tc, mode>(param_c, gemm_id);
-
-            Array<Tc, N>  frag[S][C];
-            constexpr int dc  = sizeof(Tc) * delta_c;
-            const int     ds  = sizeof(Tc) * delta_s * c.ptr.stride;
-            const char*   ptr = (const char*)c.ptr.ptr + sizeof(Tc) * dot(cs0, long2{1, c.ptr.stride});
-            PRAGMA_UNROLL
-            for (int s = 0; s < S; ++s) {
-                PRAGMA_UNROLL
-                for (int c = 0; c < C; ++c) {
-                    if (pred(s, c)) {
-                        Load(frag[s][c], reinterpret_cast<const Tc*>(ptr));
-                        using namespace ops;
-                        x[s][c] = x[s][c] * alpha + cast<T>(frag[s][c]) * beta;
-                    }
-                    ptr += dc;
-                }
-                ptr -= dc * C;
-                ptr += ds;
-            }
+      Array<Tc, N> frag[S][C];
+      constexpr int dc = sizeof(Tc) * delta_c;
+      const int ds = sizeof(Tc) * delta_s * c.ptr.stride;
+      const char* ptr = (const char*)c.ptr.ptr +
+                        sizeof(Tc) * dot(cs0, long2{1, c.ptr.stride});
+      PRAGMA_UNROLL
+      for (int s = 0; s < S; ++s) {
+        PRAGMA_UNROLL
+        for (int c = 0; c < C; ++c) {
+          if (pred(s, c)) {
+            Load(frag[s][c], reinterpret_cast<const Tc*>(ptr));
+            using namespace ops;
+            x[s][c] = x[s][c] * alpha + cast<T>(frag[s][c]) * beta;
+          }
+          ptr += dc;
         }
-        else if (alpha != 1.f) {
-            PRAGMA_UNROLL
-            for (int s = 0; s < S; ++s) {
-                PRAGMA_UNROLL
-                for (int c = 0; c < C; ++c) {
-                    using namespace ops;
-                    x[s][c] = x[s][c] * alpha;
-                }
-            }
+        ptr -= dc * C;
+        ptr += ds;
+      }
+    } else if (alpha != 1.f) {
+      PRAGMA_UNROLL
+      for (int s = 0; s < S; ++s) {
+        PRAGMA_UNROLL
+        for (int c = 0; c < C; ++c) {
+          using namespace ops;
+          x[s][c] = x[s][c] * alpha;
         }
+      }
     }
+  }
 };
 
-template<class Act>
+template <class Act>
 struct GatedActivation {
-    template<class OutT, class T, int N>
-    __device__ static void apply(Array<T, N>& x)
-    {
-        static_assert(N % 2 == 0);
-        PRAGMA_UNROLL
-        for (int i = 0; i < N; i += 2) {
-            const OutT gate = static_cast<OutT>(x[i]);
-            const OutT up   = static_cast<OutT>(x[i + 1]);
-            x[i / 2]        = static_cast<T>(Act::apply(gate) * up);
-        }
+  template <class OutT, class T, int N>
+  __device__ static void apply(Array<T, N>& x) {
+    static_assert(N % 2 == 0);
+    PRAGMA_UNROLL
+    for (int i = 0; i < N; i += 2) {
+      const OutT gate = static_cast<OutT>(x[i]);
+      const OutT up = static_cast<OutT>(x[i + 1]);
+      x[i / 2] = static_cast<T>(Act::apply(gate) * up);
     }
+  }
 };
 
 struct Silu {
-    template<class T>
-    __device__ static T apply(T x)
-    {
-        const float xf = static_cast<float>(x);
-        return static_cast<T>(fdividef(xf, 1.f + expf(-xf)));
-    }
+  template <class T>
+  __device__ static T apply(T x) {
+    const float xf = static_cast<float>(x);
+    return static_cast<T>(fdividef(xf, 1.f + expf(-xf)));
+  }
 };
 
 struct EpilogueParam {
-    MatrixParam c;
-    MatrixParam partials;
-    int*        locks;
+  MatrixParam c;
+  MatrixParam partials;
+  int* locks;
 
-    // MatrixParam scale_S;
-    // MatrixParam scale_C;
+  // MatrixParam scale_S;
+  // MatrixParam scale_C;
 
-    MatrixCombination_v3 combine_mat;
+  MatrixCombination_v3 combine_mat;
 
-    bool         silu_act;
-    bool         moe_weighted_reduce;
-    void*        moe_reduce_out;
-    const float* moe_sorted_weights;
-    const int*   moe_offsets;
+  bool silu_act;
+  bool moe_weighted_reduce;
+  void* moe_reduce_out;
+  const float* moe_sorted_weights;
+  const int* moe_offsets;
 
-    bool tile_allreduce;
-    TileAllReduceParam tile_allreduce_param;
+  bool tile_allreduce;
+  TileAllReduceParam tile_allreduce_param;
 };
 
-template<class Tc_,
-         int M,
-         int N,
-         int TM_,
-         int TN_,
-         int THREADS,
-         class RearrangeC,
-         class OperandC,
-         Striding mode_C,
-         bool     SplitK_>
+template <class Tc_, int M, int N, int TM_, int TN_, int THREADS,
+          class RearrangeC, class OperandC, Striding mode_C, bool SplitK_>
 struct Epilogue_ {
+  using Dtype = typename OperandC::Dtype;
 
-    using Dtype = typename OperandC::Dtype;
+  static constexpr auto kOrder = OperandC::kOrder;
+  static constexpr auto kMode = mode_C;
+  static constexpr bool SplitK = SplitK_;
+  using Tc = Tc_;
 
-    static constexpr auto kOrder = OperandC::kOrder;
-    static constexpr auto kMode  = mode_C;
-    static constexpr bool SplitK = SplitK_;
-    using Tc = Tc_;
+  static constexpr int TM = TM_;
+  static constexpr int TN = TN_;
 
-    static constexpr int TM = TM_;
-    static constexpr int TN = TN_;
+  using SmemLayout = decltype(OperandC::GetSmemLayout::apply(pair<TM, TN>{}));
 
-    using SmemLayout = decltype(OperandC::GetSmemLayout::apply(pair<TM, TN>{}));
+  using SmemAccessorV2 = SmemAccessorV2<Dtype, SmemLayout, kOrder>;
 
-    using SmemAccessorV2 = SmemAccessorV2<Dtype, SmemLayout, kOrder>;
+  using SharedStorage = Array<Dtype, SmemLayout::kSize>;
 
-    using SharedStorage = Array<Dtype, SmemLayout::kSize>;
+  using Map = decltype(OperandC::GetThreadMap::apply(pair<M, N>{},
+                                                     constant<THREADS>{}));
 
-    using Map = decltype(OperandC::GetThreadMap::apply(pair<M, N>{}, constant<THREADS>{}));
+  static constexpr int S = Map::kIterS;
+  static constexpr int C = Map::kIterC;
+  static constexpr int kAccess = Map::kAccessC;
 
-    static constexpr int S       = Map::kIterS;
-    static constexpr int C       = Map::kIterC;
-    static constexpr int kAccess = Map::kAccessC;
+  template <class T>
+  using OutputC = Array<T, kAccess>;
 
-    template<class T>
-    using OutputC = Array<T, kAccess>;
+  template <class FragC>
+  __device__ void Rearrange(FragC& frag_C, SharedStorage& storage,
+                            OutputC<Dtype> (&out)[S][C]) {
+    SmemAccessorV2 smem_C{storage.data()};
 
-    template<class FragC>
-    __device__ void Rearrange(FragC& frag_C, SharedStorage& storage, OutputC<Dtype> (&out)[S][C])
-    {
-        SmemAccessorV2 smem_C{storage.data()};
+    const int2 thr_cs =
+        Map::get_offset(threadIdx.x / WARP_SIZE, threadIdx.x % WARP_SIZE);
 
-        const int2 thr_cs = Map::get_offset(threadIdx.x / WARP_SIZE, threadIdx.x % WARP_SIZE);
+    constexpr int kPeriodC = ceil_div(SmemLayout::C0, Map::kDeltaC);
+    constexpr int kPeriodS = ceil_div(SmemLayout::S0, Map::kDeltaS);
 
-        constexpr int kPeriodC = ceil_div(SmemLayout::C0, Map::kDeltaC);
-        constexpr int kPeriodS = ceil_div(SmemLayout::S0, Map::kDeltaS);
-
-        int phases[kPeriodS][kPeriodC];
-        PRAGMA_UNROLL
-        for (int s = 0; s < kPeriodS; ++s) {
-            PRAGMA_UNROLL
-            for (int c = 0; c < kPeriodC; ++c) {
-                phases[s][c] = SmemLayout::apply(s * Map::kDeltaS + thr_cs.y, c * Map::kDeltaC + thr_cs.x);
-            }
-        }
-
-        constexpr bool kRaked = true;
-
-        PRAGMA_UNROLL
-        for (int m = 0; m < M; m += TM) {
-            PRAGMA_UNROLL
-            for (int n = 0; n < N; n += TN) {
-                // Store to shared memory
-                RearrangeC::apply(frag_C, smem_C, {m, n}, pair<TM, TN>{});
-
-                // Load from shared memory
-                PRAGMA_UNROLL
-                for (int s = 0; s < S; ++s) {
-                    PRAGMA_UNROLL
-                    for (int c = 0; c < C; ++c) {
-                        const int cc = c * Map::kDeltaC + thr_cs.x;
-                        const int ss = s * Map::kDeltaS + thr_cs.y;
-
-                        const int2 mn =
-                            kRaked ? cs2mk<kOrder>(c * Map::kDeltaC, s * Map::kDeltaS) : cs2mk<kOrder>(cc, ss);
-                        const int  mm   = mn.x - m;
-                        const int  nn   = mn.y - n;
-                        const bool mask = (M <= TM || (0 <= mm && mm < TM)) && ((N <= TN) || (0 <= nn && nn < TN));
-
-                        const int2 _cs      = mk2cs<kOrder>(m, n);
-                        const int  offset_0 = SmemLayout::apply(  //
-                            s / kPeriodS * kPeriodS * Map::kDeltaS - _cs.y,
-                            c / kPeriodC * kPeriodC * Map::kDeltaC - _cs.x);
-                        const int  offset_p = phases[s % kPeriodS][c % kPeriodC];
-
-                        if (mask) {
-                            Load(out[s][c], &storage[offset_0 + offset_p]);
-                        }
-                    }
-                }
-                __syncthreads();
-            }
-        }
+    int phases[kPeriodS][kPeriodC];
+    PRAGMA_UNROLL
+    for (int s = 0; s < kPeriodS; ++s) {
+      PRAGMA_UNROLL
+      for (int c = 0; c < kPeriodC; ++c) {
+        phases[s][c] = SmemLayout::apply(s * Map::kDeltaS + thr_cs.y,
+                                         c * Map::kDeltaC + thr_cs.x);
+      }
     }
 
-    template<class T, class VecC, class Pred>
-    __device__ void StoreC(const VecC& vec_C, const MatrixData& c, int2 cs0, Pred& pred)
-    {
-        constexpr int dc  = sizeof(T) * Map::kDeltaC;
-        const int     ds  = sizeof(T) * Map::kDeltaS * c.ptr.stride;
-        char*         ptr = (char*)c.ptr.ptr + sizeof(T) * dot(cs0, long2{1, c.ptr.stride});
+    constexpr bool kRaked = true;
+
+    PRAGMA_UNROLL
+    for (int m = 0; m < M; m += TM) {
+      PRAGMA_UNROLL
+      for (int n = 0; n < N; n += TN) {
+        // Store to shared memory
+        RearrangeC::apply(frag_C, smem_C, {m, n}, pair<TM, TN>{});
+
+        // Load from shared memory
         PRAGMA_UNROLL
         for (int s = 0; s < S; ++s) {
-            PRAGMA_UNROLL
-            for (int c = 0; c < C; ++c) {
-                const auto tmp = cast<T>(vec_C[s][c]);
-                if (pred(s, c)) {
-                    Store(reinterpret_cast<T*>(ptr), tmp);
-                }
-                ptr += dc;
+          PRAGMA_UNROLL
+          for (int c = 0; c < C; ++c) {
+            const int cc = c * Map::kDeltaC + thr_cs.x;
+            const int ss = s * Map::kDeltaS + thr_cs.y;
+
+            const int2 mn =
+                kRaked ? cs2mk<kOrder>(c * Map::kDeltaC, s * Map::kDeltaS)
+                       : cs2mk<kOrder>(cc, ss);
+            const int mm = mn.x - m;
+            const int nn = mn.y - n;
+            const bool mask = (M <= TM || (0 <= mm && mm < TM)) &&
+                              ((N <= TN) || (0 <= nn && nn < TN));
+
+            const int2 _cs = mk2cs<kOrder>(m, n);
+            const int offset_0 = SmemLayout::apply(  //
+                s / kPeriodS * kPeriodS * Map::kDeltaS - _cs.y,
+                c / kPeriodC * kPeriodC * Map::kDeltaC - _cs.x);
+            const int offset_p = phases[s % kPeriodS][c % kPeriodC];
+
+            if (mask) {
+              Load(out[s][c], &storage[offset_0 + offset_p]);
             }
-            ptr -= dc * C;
-            ptr += ds;
-        }
-    }
-
-    template<class VecC, class Pred>
-    __device__ void StoreMoeWeightedReduce(const VecC& vec_C,
-                                           int2 cs0,
-                                           int group_id,
-                                           Pred& pred,
-                                           const EpilogueParam& param)
-    {
-        static_assert(std::is_same_v<Tc, half_t>);
-        __half* out = reinterpret_cast<__half*>(param.moe_reduce_out);
-        const int base_row = param.moe_offsets ? __ldg(param.moe_offsets + group_id) : 0;
-        PRAGMA_UNROLL
-        for (int s = 0; s < S; ++s) {
-            const int   row    = base_row + cs0.y + s * Map::kDeltaS;
-            const float weight = __ldg(param.moe_sorted_weights + row);
-            PRAGMA_UNROLL
-            for (int c = 0; c < C; ++c) {
-                if (pred(s, c)) {
-                    const auto tmp = cast<float>(vec_C[s][c]);
-                    PRAGMA_UNROLL
-                    for (int i = 0; i < kAccess; ++i) {
-                        const int col = cs0.x + c * Map::kDeltaC + i;
-                        atomicAdd(out + col, __float2half_rn(tmp[i] * weight));
-                    }
-                }
-            }
-        }
-    }
-
-    __device__ void PublishTileAllReduceFlag(const int4&          tile_offset,
-                                             int                  tile_id,
-                                             bool                 is_last,
-                                             const EpilogueParam& param)
-    {
-        if (!param.tile_allreduce || !is_last) {
-            return;
-        }
-        const auto& tile_ar = param.tile_allreduce_param;
-        if (tile_ar.world_size != 2 || tile_ar.tile_numel <= 0) {
-            return;
-        }
-        // The first model path is intentionally M=1 and row-major N tiles.
-        if (tile_offset.x != 0 || tile_offset.w != 0) {
-            return;
-        }
-        const int col_begin = tile_offset.y * N;
-        if (col_begin >= tile_ar.output_numel) {
-            return;
-        }
-        const int col_end = min(col_begin + N, tile_ar.output_numel);
-
-        // Make all CTA stores visible before any peer-visible flag is set.
-        __threadfence_system();
-        __syncthreads();
-
-        const int first_signal = col_begin / tile_ar.tile_numel;
-        const int last_signal  = (col_end - 1) / tile_ar.tile_numel;
-        for (int signal_id = first_signal; signal_id <= last_signal; ++signal_id) {
-            if (signal_id < 0 || signal_id >= vllm::sm70_tile_runtime::kMaxBlocks) {
-                continue;
-            }
-            const int signal_begin = signal_id * tile_ar.tile_numel;
-            const int signal_end   = min(signal_begin + tile_ar.tile_numel,
-                                         tile_ar.output_numel);
-            if (signal_begin < col_begin || signal_end > col_end) {
-                continue;
-            }
-
-            const auto flag =
-                reinterpret_cast<vllm::sm70_tile_runtime::Signal*>(
-                    tile_ar.self_signal)->_flag[signal_id] +
-                1;
-            if (threadIdx.x < tile_ar.world_size) {
-                auto* peer_signal =
-                    reinterpret_cast<vllm::sm70_tile_runtime::Signal*>(
-                        tile_ar.signals[threadIdx.x]);
-                auto* peer_flag = &peer_signal->start[signal_id][tile_ar.rank];
-                vllm::sm70_tile_runtime::store_flag_sys_visible(peer_flag, flag);
-            }
-        }
-    }
-
-    template<class VecC, class Pred>
-    __device__ void StoreTileAllReduceC(const VecC&           vec_C,
-                                        const MatrixData&     c,
-                                        int2                  cs0,
-                                        const int4&           tile_offset,
-                                        bool                  is_last,
-                                        Pred&                 pred,
-                                        const EpilogueParam&  param)
-    {
-        if (!param.tile_allreduce || !is_last) {
-            return;
-        }
-        const auto& tile_ar = param.tile_allreduce_param;
-        if (tile_ar.world_size != 2 || tile_ar.tile_numel <= 0 ||
-            tile_ar.rank_data == nullptr || tile_ar.output == nullptr) {
-            return;
-        }
-        if (tile_offset.x != 0 || tile_offset.w != 0) {
-            return;
-        }
-
-        const int col_begin = tile_offset.y * N;
-        if (col_begin >= tile_ar.output_numel) {
-            return;
-        }
-        const int col_end = min(col_begin + N, tile_ar.output_numel);
-        const int first_signal = col_begin / tile_ar.tile_numel;
-        const int last_signal  = (col_end - 1) / tile_ar.tile_numel;
-        auto* self_signal =
-            reinterpret_cast<vllm::sm70_tile_runtime::Signal*>(
-                tile_ar.self_signal);
-
-        for (int signal_id = first_signal; signal_id <= last_signal; ++signal_id) {
-            if (signal_id < 0 ||
-                signal_id >= vllm::sm70_tile_runtime::kMaxBlocks) {
-                return;
-            }
-            const int signal_begin = signal_id * tile_ar.tile_numel;
-            const int signal_end   = min(signal_begin + tile_ar.tile_numel,
-                                         tile_ar.output_numel);
-            if (signal_begin < col_begin || signal_end > col_end) {
-                return;
-            }
-
-            const auto flag = self_signal->_flag[signal_id] + 1;
-            if (threadIdx.x < tile_ar.world_size) {
-                auto* self_flag = &self_signal->start[signal_id][threadIdx.x];
-                while (vllm::sm70_tile_runtime::load_flag_sys_visible(
-                           self_flag) != flag) {
-                }
-            }
-            __syncthreads();
-        }
-
-        const auto rank_data =
-            *reinterpret_cast<const vllm::sm70_tile_runtime::RankData*>(
-                tile_ar.rank_data);
-        const int peer_rank = 1 - tile_ar.rank;
-        const auto* peer_base =
-            reinterpret_cast<const char*>(rank_data.ptrs[peer_rank]);
-        auto* output_base = reinterpret_cast<char*>(tile_ar.output);
-
-        constexpr int dc = sizeof(Tc) * Map::kDeltaC;
-        const int ds = sizeof(Tc) * Map::kDeltaS * c.ptr.stride;
-        const auto offset =
-            sizeof(Tc) * dot(cs0, long2{1, c.ptr.stride});
-        const char* peer_ptr = peer_base + offset;
-        char* output_ptr = output_base + offset;
-
-        PRAGMA_UNROLL
-        for (int s = 0; s < S; ++s) {
-            PRAGMA_UNROLL
-            for (int c = 0; c < C; ++c) {
-                if (pred(s, c)) {
-                    OutputC<Tc> peer;
-                    Load(peer, reinterpret_cast<const Tc*>(peer_ptr));
-                    using namespace ops;
-                    const auto self = cast<Tc>(vec_C[s][c]);
-                    const auto reduced =
-                        cast<Tc>(cast<float>(self) + cast<float>(peer));
-                    Store(reinterpret_cast<Tc*>(output_ptr), reduced);
-                }
-                peer_ptr += dc;
-                output_ptr += dc;
-            }
-            peer_ptr -= dc * C;
-            output_ptr -= dc * C;
-            peer_ptr += ds;
-            output_ptr += ds;
-        }
-
-        __syncthreads();
-        if (threadIdx.x == 0) {
-            for (int signal_id = first_signal; signal_id <= last_signal; ++signal_id) {
-                self_signal->_flag[signal_id] = self_signal->_flag[signal_id] + 1;
-            }
-        }
-    }
-
-    __device__ bool StoreTailAllReduceC(const int4&          tile_offset,
-                                        bool                 is_last,
-                                        const EpilogueParam& param)
-    {
-        if (!param.tile_allreduce || !is_last) {
-            return false;
-        }
-        const auto& tile_ar = param.tile_allreduce_param;
-        if (tile_ar.world_size != 2 || tile_ar.rank_data == nullptr ||
-            tile_ar.output == nullptr || tile_ar.output_numel <= 0 ||
-            (tile_ar.output_numel & 1)) {
-            return false;
-        }
-        // Narrow first model path: M=1, row-major dense down_proj output.
-        if (tile_offset.x != 0 || tile_offset.w != 0) {
-            return false;
-        }
-        const int cta_count = (tile_ar.output_numel + N - 1) / N;
-        if (cta_count <= 0) {
-            return false;
-        }
-
-        constexpr int signal_id = vllm::sm70_tile_runtime::kMaxBlocks - 1;
-        auto* self_signal =
-            reinterpret_cast<vllm::sm70_tile_runtime::Signal*>(
-                tile_ar.self_signal);
-        const auto epoch = self_signal->_flag[signal_id];
-        const auto target = (epoch + 1) * cta_count;
-
-        // Every producer CTA releases its staging stores before contributing to
-        // the completion counter. Only one completed CTA stays alive as the
-        // reduce worker; the rest exit the GEMM kernel normally.
-        __syncthreads();
-        __threadfence_system();
-        if (threadIdx.x == 0) {
-            atomicAdd(&self_signal->start[signal_id][tile_ar.rank],
-                      static_cast<vllm::sm70_tile_runtime::FlagType>(1));
-        }
-
-        if (tile_offset.y != 0) {
-            return true;
-        }
-
-        if (threadIdx.x < tile_ar.world_size) {
-            auto* rank_signal =
-                reinterpret_cast<vllm::sm70_tile_runtime::Signal*>(
-                    tile_ar.signals[threadIdx.x]);
-            auto* counter = &rank_signal->start[signal_id][threadIdx.x];
-            while (vllm::sm70_tile_runtime::load_flag_sys_visible(counter) <
-                   target) {
-            }
+          }
         }
         __syncthreads();
-
-        const auto rank_data =
-            *reinterpret_cast<const vllm::sm70_tile_runtime::RankData*>(
-                tile_ar.rank_data);
-        const auto* rank0 =
-            reinterpret_cast<const half2*>(rank_data.ptrs[0]);
-        const auto* rank1 =
-            reinterpret_cast<const half2*>(rank_data.ptrs[1]);
-        auto* output = reinterpret_cast<half2*>(tile_ar.output);
-        const int half2_count = tile_ar.output_numel / 2;
-        for (int idx = threadIdx.x; idx < half2_count; idx += blockDim.x) {
-            output[idx] = __hadd2(rank0[idx], rank1[idx]);
-        }
-
-        __syncthreads();
-        if (threadIdx.x == 0) {
-            self_signal->_flag[signal_id] = epoch + 1;
-        }
-        return true;
+      }
     }
+  }
+
+  template <class T, class VecC, class Pred>
+  __device__ void StoreC(const VecC& vec_C, const MatrixData& c, int2 cs0,
+                         Pred& pred) {
+    constexpr int dc = sizeof(T) * Map::kDeltaC;
+    const int ds = sizeof(T) * Map::kDeltaS * c.ptr.stride;
+    char* ptr = (char*)c.ptr.ptr + sizeof(T) * dot(cs0, long2{1, c.ptr.stride});
+    PRAGMA_UNROLL
+    for (int s = 0; s < S; ++s) {
+      PRAGMA_UNROLL
+      for (int c = 0; c < C; ++c) {
+        const auto tmp = cast<T>(vec_C[s][c]);
+        if (pred(s, c)) {
+          Store(reinterpret_cast<T*>(ptr), tmp);
+        }
+        ptr += dc;
+      }
+      ptr -= dc * C;
+      ptr += ds;
+    }
+  }
+
+  template <class VecC, class Pred>
+  __device__ void StoreMoeWeightedReduce(const VecC& vec_C, int2 cs0,
+                                         int group_id, Pred& pred,
+                                         const EpilogueParam& param) {
+    static_assert(std::is_same_v<Tc, half_t>);
+    __half* out = reinterpret_cast<__half*>(param.moe_reduce_out);
+    const int base_row =
+        param.moe_offsets ? __ldg(param.moe_offsets + group_id) : 0;
+    PRAGMA_UNROLL
+    for (int s = 0; s < S; ++s) {
+      const int row = base_row + cs0.y + s * Map::kDeltaS;
+      const float weight = __ldg(param.moe_sorted_weights + row);
+      PRAGMA_UNROLL
+      for (int c = 0; c < C; ++c) {
+        if (pred(s, c)) {
+          const auto tmp = cast<float>(vec_C[s][c]);
+          PRAGMA_UNROLL
+          for (int i = 0; i < kAccess; ++i) {
+            const int col = cs0.x + c * Map::kDeltaC + i;
+            atomicAdd(out + col, __float2half_rn(tmp[i] * weight));
+          }
+        }
+      }
+    }
+  }
+
+  __device__ void PublishTileAllReduceFlag(const int4& tile_offset, int tile_id,
+                                           bool is_last,
+                                           const EpilogueParam& param) {
+    if (!param.tile_allreduce || !is_last) {
+      return;
+    }
+    const auto& tile_ar = param.tile_allreduce_param;
+    if (tile_ar.world_size != 2 || tile_ar.tile_numel <= 0) {
+      return;
+    }
+    // The first model path is intentionally M=1 and row-major N tiles.
+    if (tile_offset.x != 0 || tile_offset.w != 0) {
+      return;
+    }
+    const int col_begin = tile_offset.y * N;
+    if (col_begin >= tile_ar.output_numel) {
+      return;
+    }
+    const int col_end = min(col_begin + N, tile_ar.output_numel);
+
+    // Make all CTA stores visible before any peer-visible flag is set.
+    __threadfence_system();
+    __syncthreads();
+
+    const int first_signal = col_begin / tile_ar.tile_numel;
+    const int last_signal = (col_end - 1) / tile_ar.tile_numel;
+    for (int signal_id = first_signal; signal_id <= last_signal; ++signal_id) {
+      if (signal_id < 0 || signal_id >= vllm::sm70_tile_runtime::kMaxBlocks) {
+        continue;
+      }
+      const int signal_begin = signal_id * tile_ar.tile_numel;
+      const int signal_end =
+          min(signal_begin + tile_ar.tile_numel, tile_ar.output_numel);
+      if (signal_begin < col_begin || signal_end > col_end) {
+        continue;
+      }
+
+      const auto flag = reinterpret_cast<vllm::sm70_tile_runtime::Signal*>(
+                            tile_ar.self_signal)
+                            ->_flag[signal_id] +
+                        1;
+      if (threadIdx.x < tile_ar.world_size) {
+        auto* peer_signal = reinterpret_cast<vllm::sm70_tile_runtime::Signal*>(
+            tile_ar.signals[threadIdx.x]);
+        auto* peer_flag = &peer_signal->start[signal_id][tile_ar.rank];
+        vllm::sm70_tile_runtime::store_flag_sys_visible(peer_flag, flag);
+      }
+    }
+  }
+
+  template <class VecC, class Pred>
+  __device__ void StoreTileAllReduceC(const VecC& vec_C, const MatrixData& c,
+                                      int2 cs0, const int4& tile_offset,
+                                      bool is_last, Pred& pred,
+                                      const EpilogueParam& param) {
+    if (!param.tile_allreduce || !is_last) {
+      return;
+    }
+    const auto& tile_ar = param.tile_allreduce_param;
+    if (tile_ar.world_size != 2 || tile_ar.tile_numel <= 0 ||
+        tile_ar.rank_data == nullptr || tile_ar.output == nullptr) {
+      return;
+    }
+    if (tile_offset.x != 0 || tile_offset.w != 0) {
+      return;
+    }
+
+    const int col_begin = tile_offset.y * N;
+    if (col_begin >= tile_ar.output_numel) {
+      return;
+    }
+    const int col_end = min(col_begin + N, tile_ar.output_numel);
+    const int first_signal = col_begin / tile_ar.tile_numel;
+    const int last_signal = (col_end - 1) / tile_ar.tile_numel;
+    auto* self_signal =
+        reinterpret_cast<vllm::sm70_tile_runtime::Signal*>(tile_ar.self_signal);
+
+    for (int signal_id = first_signal; signal_id <= last_signal; ++signal_id) {
+      if (signal_id < 0 || signal_id >= vllm::sm70_tile_runtime::kMaxBlocks) {
+        return;
+      }
+      const int signal_begin = signal_id * tile_ar.tile_numel;
+      const int signal_end =
+          min(signal_begin + tile_ar.tile_numel, tile_ar.output_numel);
+      if (signal_begin < col_begin || signal_end > col_end) {
+        return;
+      }
+
+      const auto flag = self_signal->_flag[signal_id] + 1;
+      if (threadIdx.x < tile_ar.world_size) {
+        auto* self_flag = &self_signal->start[signal_id][threadIdx.x];
+        while (vllm::sm70_tile_runtime::load_flag_sys_visible(self_flag) !=
+               flag) {
+        }
+      }
+      __syncthreads();
+    }
+
+    const auto rank_data =
+        *reinterpret_cast<const vllm::sm70_tile_runtime::RankData*>(
+            tile_ar.rank_data);
+    const int peer_rank = 1 - tile_ar.rank;
+    const auto* peer_base =
+        reinterpret_cast<const char*>(rank_data.ptrs[peer_rank]);
+    auto* output_base = reinterpret_cast<char*>(tile_ar.output);
+
+    constexpr int dc = sizeof(Tc) * Map::kDeltaC;
+    const int ds = sizeof(Tc) * Map::kDeltaS * c.ptr.stride;
+    const auto offset = sizeof(Tc) * dot(cs0, long2{1, c.ptr.stride});
+    const char* peer_ptr = peer_base + offset;
+    char* output_ptr = output_base + offset;
+
+    PRAGMA_UNROLL
+    for (int s = 0; s < S; ++s) {
+      PRAGMA_UNROLL
+      for (int c = 0; c < C; ++c) {
+        if (pred(s, c)) {
+          OutputC<Tc> peer;
+          Load(peer, reinterpret_cast<const Tc*>(peer_ptr));
+          using namespace ops;
+          const auto self = cast<Tc>(vec_C[s][c]);
+          const auto reduced = cast<Tc>(cast<float>(self) + cast<float>(peer));
+          Store(reinterpret_cast<Tc*>(output_ptr), reduced);
+        }
+        peer_ptr += dc;
+        output_ptr += dc;
+      }
+      peer_ptr -= dc * C;
+      output_ptr -= dc * C;
+      peer_ptr += ds;
+      output_ptr += ds;
+    }
+
+    __syncthreads();
+    if (threadIdx.x == 0) {
+      for (int signal_id = first_signal; signal_id <= last_signal;
+           ++signal_id) {
+        self_signal->_flag[signal_id] = self_signal->_flag[signal_id] + 1;
+      }
+    }
+  }
+
+  __device__ bool StoreTailAllReduceC(const int4& tile_offset, bool is_last,
+                                      const EpilogueParam& param) {
+    if (!param.tile_allreduce || !is_last) {
+      return false;
+    }
+    const auto& tile_ar = param.tile_allreduce_param;
+    if (tile_ar.world_size != 2 || tile_ar.rank_data == nullptr ||
+        tile_ar.output == nullptr || tile_ar.output_numel <= 0 ||
+        (tile_ar.output_numel & 1)) {
+      return false;
+    }
+    // Narrow first model path: M=1, row-major dense down_proj output.
+    if (tile_offset.x != 0 || tile_offset.w != 0) {
+      return false;
+    }
+    const int cta_count = (tile_ar.output_numel + N - 1) / N;
+    if (cta_count <= 0) {
+      return false;
+    }
+
+    constexpr int signal_id = vllm::sm70_tile_runtime::kMaxBlocks - 1;
+    auto* self_signal =
+        reinterpret_cast<vllm::sm70_tile_runtime::Signal*>(tile_ar.self_signal);
+    const auto epoch = self_signal->_flag[signal_id];
+    const auto target = (epoch + 1) * cta_count;
+
+    // Every producer CTA releases its staging stores before contributing to
+    // the completion counter. Only one completed CTA stays alive as the
+    // reduce worker; the rest exit the GEMM kernel normally.
+    __syncthreads();
+    __threadfence_system();
+    if (threadIdx.x == 0) {
+      atomicAdd(&self_signal->start[signal_id][tile_ar.rank],
+                static_cast<vllm::sm70_tile_runtime::FlagType>(1));
+    }
+
+    if (tile_offset.y != 0) {
+      return true;
+    }
+
+    if (threadIdx.x < tile_ar.world_size) {
+      auto* rank_signal = reinterpret_cast<vllm::sm70_tile_runtime::Signal*>(
+          tile_ar.signals[threadIdx.x]);
+      auto* counter = &rank_signal->start[signal_id][threadIdx.x];
+      while (vllm::sm70_tile_runtime::load_flag_sys_visible(counter) < target) {
+      }
+    }
+    __syncthreads();
+
+    const auto rank_data =
+        *reinterpret_cast<const vllm::sm70_tile_runtime::RankData*>(
+            tile_ar.rank_data);
+    const auto* rank0 = reinterpret_cast<const half2*>(rank_data.ptrs[0]);
+    const auto* rank1 = reinterpret_cast<const half2*>(rank_data.ptrs[1]);
+    auto* output = reinterpret_cast<half2*>(tile_ar.output);
+    const int half2_count = tile_ar.output_numel / 2;
+    for (int idx = threadIdx.x; idx < half2_count; idx += blockDim.x) {
+      output[idx] = __hadd2(rank0[idx], rank1[idx]);
+    }
+
+    __syncthreads();
+    if (threadIdx.x == 0) {
+      self_signal->_flag[signal_id] = epoch + 1;
+    }
+    return true;
+  }
 
 #if 0
     template<class FragC, class Pred>
@@ -597,261 +554,257 @@ struct Epilogue_ {
     }
 #endif
 
-    template<class FragC, class Pred>
-    __device__ void Reduce(FragC& frag_C, const MatrixData& p, bool is_first, bool is_last, int2 cs0, Pred& pred)
-    {
-        constexpr int dc = sizeof(Dtype) * Map::kDeltaC;
-        const int     ds = sizeof(Dtype) * Map::kDeltaS * p.ptr.stride;
+  template <class FragC, class Pred>
+  __device__ void Reduce(FragC& frag_C, const MatrixData& p, bool is_first,
+                         bool is_last, int2 cs0, Pred& pred) {
+    constexpr int dc = sizeof(Dtype) * Map::kDeltaC;
+    const int ds = sizeof(Dtype) * Map::kDeltaS * p.ptr.stride;
 
-        char* ptr = (char*)p.ptr.ptr + sizeof(Dtype) * dot(cs0, long2{1, p.ptr.stride});
+    char* ptr =
+        (char*)p.ptr.ptr + sizeof(Dtype) * dot(cs0, long2{1, p.ptr.stride});
 
-        Pred ld_mask = is_first ? Pred{} : pred;
-        Pred st_mask = is_last ? Pred{} : pred;
+    Pred ld_mask = is_first ? Pred{} : pred;
+    Pred st_mask = is_last ? Pred{} : pred;
 
-        PRAGMA_UNROLL
-        for (int s = 0; s < S; ++s) {
-            PRAGMA_UNROLL
-            for (int c = 0; c < C; ++c) {
-                OutputC<Dtype> tmp{};  // ! ZERO-filled
-                if (ld_mask(s, c)) {
-                    Load(tmp, reinterpret_cast<Dtype*>(ptr));
-                }
-                if (1) {
-                    using namespace ops;
-                    frag_C[s][c] = frag_C[s][c] + tmp;
-                }
-                if (st_mask(s, c)) {
-                    Store(reinterpret_cast<Dtype*>(ptr), frag_C[s][c]);
-                }
-                ptr += dc;
-            }
-            ptr -= dc * C;
-            ptr += ds;
+    PRAGMA_UNROLL
+    for (int s = 0; s < S; ++s) {
+      PRAGMA_UNROLL
+      for (int c = 0; c < C; ++c) {
+        OutputC<Dtype> tmp{};  // ! ZERO-filled
+        if (ld_mask(s, c)) {
+          Load(tmp, reinterpret_cast<Dtype*>(ptr));
         }
+        if (1) {
+          using namespace ops;
+          frag_C[s][c] = frag_C[s][c] + tmp;
+        }
+        if (st_mask(s, c)) {
+          Store(reinterpret_cast<Dtype*>(ptr), frag_C[s][c]);
+        }
+        ptr += dc;
+      }
+      ptr -= dc * C;
+      ptr += ds;
+    }
+  }
+
+  template <class FragC>
+  __device__ void operator()(FragC& frag_C, const int4& tile_offset,
+                             const int2& extents, int splits, int tile_id,
+                             bool is_last, const EpilogueParam& param,
+                             SharedStorage& storage) {
+    const int2 cta_cs = mk2cs<kOrder>(tile_offset.x * M, tile_offset.y * N);
+    const int2 end_cs = mk2cs<kOrder>(extents);
+
+    OutputC<Dtype> tmp_C[S][C];
+
+    Rearrange(frag_C, storage, tmp_C);
+
+    Predicate<S, C, false, false> pred{};  //  1 regs
+
+    const int2 thr_cs =
+        Map::get_offset(threadIdx.x / WARP_SIZE, threadIdx.x % WARP_SIZE);
+    const int2 cs0 = {cta_cs.x + thr_cs.x, cta_cs.y + thr_cs.y};
+
+    PRAGMA_UNROLL
+    for (int s = 0; s < S; ++s) {
+      PRAGMA_UNROLL
+      for (int c = 0; c < C; ++c) {
+        const int ss = thr_cs.y + s * Map::kDeltaS;
+        const int cc = thr_cs.x + c * Map::kDeltaC;
+        if (ss < end_cs.y && cc < end_cs.x) {
+          pred.set(s, c);
+        }
+      }
     }
 
-    template<class FragC>
-    __device__ void operator()(FragC&               frag_C,
-                               const int4&          tile_offset,
-                               const int2&          extents,
-                               int                  splits,
-                               int                  tile_id,
-                               bool                 is_last,
-                               const EpilogueParam& param,
-                               SharedStorage&       storage)
-    {
-        const int2 cta_cs = mk2cs<kOrder>(tile_offset.x * M, tile_offset.y * N);
-        const int2 end_cs = mk2cs<kOrder>(extents);
+    if (SplitK_ && splits > 1) {
+      int* barrier = &param.locks[tile_id];
 
-        OutputC<Dtype> tmp_C[S][C];
+      sem_wait(barrier, tile_offset.z, threadIdx.x == 0);
 
-        Rearrange(frag_C, storage, tmp_C);
+      const MatrixData p = resolve<Dtype, kMode>(param.partials, tile_offset.w);
 
-        Predicate<S, C, false, false> pred{};  //  1 regs
+      Reduce(tmp_C, p, tile_offset.z == 0, is_last, cs0, pred);
 
-        const int2 thr_cs = Map::get_offset(threadIdx.x / WARP_SIZE, threadIdx.x % WARP_SIZE);
-        const int2 cs0    = {cta_cs.x + thr_cs.x, cta_cs.y + thr_cs.y};
+      const int post_id = is_last ? 0 : tile_offset.z + 1;
+      sem_post(barrier, post_id, threadIdx.x == 0);
 
-        PRAGMA_UNROLL
-        for (int s = 0; s < S; ++s) {
-            PRAGMA_UNROLL
-            for (int c = 0; c < C; ++c) {
-                const int ss = thr_cs.y + s * Map::kDeltaS;
-                const int cc = thr_cs.x + c * Map::kDeltaC;
-                if (ss < end_cs.y && cc < end_cs.x) {
-                    pred.set(s, c);
-                }
-            }
-        }
-
-        if (SplitK_ && splits > 1) {
-            int* barrier = &param.locks[tile_id];
-
-            sem_wait(barrier, tile_offset.z, threadIdx.x == 0);
-
-            const MatrixData p = resolve<Dtype, kMode>(param.partials, tile_offset.w);
-
-            Reduce(tmp_C, p, tile_offset.z == 0, is_last, cs0, pred);
-
-            const int post_id = is_last ? 0 : tile_offset.z + 1;
-            sem_post(barrier, post_id, threadIdx.x == 0);
-
-            if (!is_last) {
-                return;
-            }
-        }
-
-        constexpr pair<Map::kDeltaC, Map::kDeltaS> delta_cs{};
-
-        // opt-in scaling
-        // Scale(scale_SC{}, mode_SC{}, delta_cs, tmp_C, param.scale_S, param.scale_C, tile_offset.w, cs0, pred);
-
-        param.combine_mat((Tc*)0, constant<kMode>{}, tmp_C, cs0, tile_offset.w, delta_cs, pred);
-
-        const MatrixData c = resolve<Tc, kMode>(param.c, tile_offset.w);
-
-        bool publish_tile_allreduce = false;
-        if (param.moe_weighted_reduce) {
-            if constexpr (std::is_same_v<Tc, half_t>) {
-                StoreMoeWeightedReduce(tmp_C, cs0, tile_offset.w, pred, param);
-            }
-        }
-        else if (param.silu_act) {
-            constexpr int dc  = sizeof(Tc) * Map::kDeltaC / 2;
-            const int     ds  = sizeof(Tc) * Map::kDeltaS * c.ptr.stride;
-            auto          ptr = (char*)c.ptr.ptr + sizeof(Tc) * dot({cs0.x / 2, cs0.y}, long2{1, c.ptr.stride});
-            PRAGMA_UNROLL
-            for (int s = 0; s < S; ++s) {
-                PRAGMA_UNROLL
-                for (int c = 0; c < C; ++c) {
-                    GatedActivation<Silu>::template apply<Tc>(tmp_C[s][c]);
-                    if (pred(s, c)) {
-                        const auto tmp = cast<Tc>((Array<Dtype, kAccess / 2>&)tmp_C[s][c]);
-                        Store(reinterpret_cast<Tc*>(ptr), tmp);
-                    }
-                    ptr += dc;
-                }
-                ptr -= dc * C;
-                ptr += ds;
-            }
-        }
-        else {
-            StoreC<Tc>(tmp_C, c, cs0, pred);
-            publish_tile_allreduce = true;
-        }
-
-        if (publish_tile_allreduce) {
-            if (param.tile_allreduce && param.tile_allreduce_param.kernel_reducer_blocks > 0) {
-                PublishTileAllReduceFlag(tile_offset, tile_id, is_last, param);
-            }
-            else if (!StoreTailAllReduceC(tile_offset, is_last, param)) {
-                PublishTileAllReduceFlag(tile_offset, tile_id, is_last, param);
-                StoreTileAllReduceC(tmp_C, c, cs0, tile_offset, is_last, pred, param);
-            }
-        }
+      if (!is_last) {
+        return;
+      }
     }
+
+    constexpr pair<Map::kDeltaC, Map::kDeltaS> delta_cs{};
+
+    // opt-in scaling
+    // Scale(scale_SC{}, mode_SC{}, delta_cs, tmp_C, param.scale_S,
+    // param.scale_C, tile_offset.w, cs0, pred);
+
+    param.combine_mat((Tc*)0, constant<kMode>{}, tmp_C, cs0, tile_offset.w,
+                      delta_cs, pred);
+
+    const MatrixData c = resolve<Tc, kMode>(param.c, tile_offset.w);
+
+    bool publish_tile_allreduce = false;
+    if (param.moe_weighted_reduce) {
+      if constexpr (std::is_same_v<Tc, half_t>) {
+        StoreMoeWeightedReduce(tmp_C, cs0, tile_offset.w, pred, param);
+      }
+    } else if (param.silu_act) {
+      constexpr int dc = sizeof(Tc) * Map::kDeltaC / 2;
+      const int ds = sizeof(Tc) * Map::kDeltaS * c.ptr.stride;
+      auto ptr = (char*)c.ptr.ptr +
+                 sizeof(Tc) * dot({cs0.x / 2, cs0.y}, long2{1, c.ptr.stride});
+      PRAGMA_UNROLL
+      for (int s = 0; s < S; ++s) {
+        PRAGMA_UNROLL
+        for (int c = 0; c < C; ++c) {
+          GatedActivation<Silu>::template apply<Tc>(tmp_C[s][c]);
+          if (pred(s, c)) {
+            const auto tmp = cast<Tc>((Array<Dtype, kAccess / 2>&)tmp_C[s][c]);
+            Store(reinterpret_cast<Tc*>(ptr), tmp);
+          }
+          ptr += dc;
+        }
+        ptr -= dc * C;
+        ptr += ds;
+      }
+    } else {
+      StoreC<Tc>(tmp_C, c, cs0, pred);
+      publish_tile_allreduce = true;
+    }
+
+    if (publish_tile_allreduce) {
+      if (param.tile_allreduce &&
+          param.tile_allreduce_param.kernel_reducer_blocks > 0) {
+        PublishTileAllReduceFlag(tile_offset, tile_id, is_last, param);
+      } else if (!StoreTailAllReduceC(tile_offset, is_last, param)) {
+        PublishTileAllReduceFlag(tile_offset, tile_id, is_last, param);
+        StoreTileAllReduceC(tmp_C, c, cs0, tile_offset, is_last, pred, param);
+      }
+    }
+  }
 };
 
 // Opt-in wrapper that changes only the serial split-K wait policy.
-template<class Base>
+template <class Base>
 struct EpilogueLane0Wait : Base {
-    using Base::Base;
+  using Base::Base;
 
-    using Dtype = typename Base::Dtype;
-    using Tc    = typename Base::Tc;
+  using Dtype = typename Base::Dtype;
+  using Tc = typename Base::Tc;
 
-    static constexpr auto kOrder = Base::kOrder;
-    static constexpr auto kMode  = Base::kMode;
-    static constexpr bool SplitK = Base::SplitK;
+  static constexpr auto kOrder = Base::kOrder;
+  static constexpr auto kMode = Base::kMode;
+  static constexpr bool SplitK = Base::SplitK;
 
-    using SharedStorage = typename Base::SharedStorage;
-    using Map           = typename Base::Map;
+  using SharedStorage = typename Base::SharedStorage;
+  using Map = typename Base::Map;
 
-    static constexpr int S       = Base::S;
-    static constexpr int C       = Base::C;
-    static constexpr int kAccess = Base::kAccess;
-    static constexpr int2 kMN    = cs2mk<kOrder>(Map::kDimC, Map::kDimS);
+  static constexpr int S = Base::S;
+  static constexpr int C = Base::C;
+  static constexpr int kAccess = Base::kAccess;
+  static constexpr int2 kMN = cs2mk<kOrder>(Map::kDimC, Map::kDimS);
 
-    template<class T>
-    using OutputC = typename Base::template OutputC<T>;
+  template <class T>
+  using OutputC = typename Base::template OutputC<T>;
 
-    template<class FragC>
-    __device__ void operator()(FragC&               frag_C,
-                               const int4&          tile_offset,
-                               const int2&          extents,
-                               int                  splits,
-                               int                  tile_id,
-                               bool                 is_last,
-                               const EpilogueParam& param,
-                               SharedStorage&       storage)
-    {
-        const int2 cta_cs = mk2cs<kOrder>(tile_offset.x * kMN.x, tile_offset.y * kMN.y);
-        const int2 end_cs = mk2cs<kOrder>(extents);
+  template <class FragC>
+  __device__ void operator()(FragC& frag_C, const int4& tile_offset,
+                             const int2& extents, int splits, int tile_id,
+                             bool is_last, const EpilogueParam& param,
+                             SharedStorage& storage) {
+    const int2 cta_cs =
+        mk2cs<kOrder>(tile_offset.x * kMN.x, tile_offset.y * kMN.y);
+    const int2 end_cs = mk2cs<kOrder>(extents);
 
-        OutputC<Dtype> tmp_C[S][C];
+    OutputC<Dtype> tmp_C[S][C];
 
-        this->Rearrange(frag_C, storage, tmp_C);
+    this->Rearrange(frag_C, storage, tmp_C);
 
-        Predicate<S, C, false, false> pred{};
+    Predicate<S, C, false, false> pred{};
 
-        const int2 thr_cs = Map::get_offset(threadIdx.x / WARP_SIZE, threadIdx.x % WARP_SIZE);
-        const int2 cs0    = {cta_cs.x + thr_cs.x, cta_cs.y + thr_cs.y};
+    const int2 thr_cs =
+        Map::get_offset(threadIdx.x / WARP_SIZE, threadIdx.x % WARP_SIZE);
+    const int2 cs0 = {cta_cs.x + thr_cs.x, cta_cs.y + thr_cs.y};
 
-        PRAGMA_UNROLL
-        for (int s = 0; s < S; ++s) {
-            PRAGMA_UNROLL
-            for (int c = 0; c < C; ++c) {
-                const int ss = thr_cs.y + s * Map::kDeltaS;
-                const int cc = thr_cs.x + c * Map::kDeltaC;
-                if (ss < end_cs.y && cc < end_cs.x) {
-                    pred.set(s, c);
-                }
-            }
+    PRAGMA_UNROLL
+    for (int s = 0; s < S; ++s) {
+      PRAGMA_UNROLL
+      for (int c = 0; c < C; ++c) {
+        const int ss = thr_cs.y + s * Map::kDeltaS;
+        const int cc = thr_cs.x + c * Map::kDeltaC;
+        if (ss < end_cs.y && cc < end_cs.x) {
+          pred.set(s, c);
         }
-
-        if (SplitK && splits > 1) {
-            int* barrier = &param.locks[tile_id];
-
-            sem_wait_lane0(barrier, tile_offset.z);
-
-            const MatrixData p = resolve<Dtype, kMode>(param.partials, tile_offset.w);
-
-            this->Reduce(tmp_C, p, tile_offset.z == 0, is_last, cs0, pred);
-
-            const int post_id = is_last ? 0 : tile_offset.z + 1;
-            sem_post(barrier, post_id, threadIdx.x == 0);
-
-            if (!is_last) {
-                return;
-            }
-        }
-
-        constexpr pair<Map::kDeltaC, Map::kDeltaS> delta_cs{};
-
-        param.combine_mat((Tc*)0, constant<kMode>{}, tmp_C, cs0, tile_offset.w, delta_cs, pred);
-
-        const MatrixData c = resolve<Tc, kMode>(param.c, tile_offset.w);
-
-        bool publish_tile_allreduce = false;
-        if (param.moe_weighted_reduce) {
-            if constexpr (std::is_same_v<Tc, half_t>) {
-                this->StoreMoeWeightedReduce(tmp_C, cs0, tile_offset.w, pred, param);
-            }
-        }
-        else if (param.silu_act) {
-            constexpr int dc  = sizeof(Tc) * Map::kDeltaC / 2;
-            const int     ds  = sizeof(Tc) * Map::kDeltaS * c.ptr.stride;
-            auto          ptr = (char*)c.ptr.ptr + sizeof(Tc) * dot({cs0.x / 2, cs0.y}, long2{1, c.ptr.stride});
-            PRAGMA_UNROLL
-            for (int s = 0; s < S; ++s) {
-                PRAGMA_UNROLL
-                for (int c = 0; c < C; ++c) {
-                    GatedActivation<Silu>::template apply<Tc>(tmp_C[s][c]);
-                    if (pred(s, c)) {
-                        const auto tmp = cast<Tc>((Array<Dtype, kAccess / 2>&)tmp_C[s][c]);
-                        Store(reinterpret_cast<Tc*>(ptr), tmp);
-                    }
-                    ptr += dc;
-                }
-                ptr -= dc * C;
-                ptr += ds;
-            }
-        }
-        else {
-            this->template StoreC<Tc>(tmp_C, c, cs0, pred);
-            publish_tile_allreduce = true;
-        }
-
-        if (publish_tile_allreduce) {
-            if (param.tile_allreduce && param.tile_allreduce_param.kernel_reducer_blocks > 0) {
-                this->PublishTileAllReduceFlag(tile_offset, tile_id, is_last, param);
-            }
-            else if (!this->StoreTailAllReduceC(tile_offset, is_last, param)) {
-                this->PublishTileAllReduceFlag(tile_offset, tile_id, is_last, param);
-                this->StoreTileAllReduceC(tmp_C, c, cs0, tile_offset, is_last, pred, param);
-            }
-        }
+      }
     }
+
+    if (SplitK && splits > 1) {
+      int* barrier = &param.locks[tile_id];
+
+      sem_wait_lane0(barrier, tile_offset.z);
+
+      const MatrixData p = resolve<Dtype, kMode>(param.partials, tile_offset.w);
+
+      this->Reduce(tmp_C, p, tile_offset.z == 0, is_last, cs0, pred);
+
+      const int post_id = is_last ? 0 : tile_offset.z + 1;
+      sem_post(barrier, post_id, threadIdx.x == 0);
+
+      if (!is_last) {
+        return;
+      }
+    }
+
+    constexpr pair<Map::kDeltaC, Map::kDeltaS> delta_cs{};
+
+    param.combine_mat((Tc*)0, constant<kMode>{}, tmp_C, cs0, tile_offset.w,
+                      delta_cs, pred);
+
+    const MatrixData c = resolve<Tc, kMode>(param.c, tile_offset.w);
+
+    bool publish_tile_allreduce = false;
+    if (param.moe_weighted_reduce) {
+      if constexpr (std::is_same_v<Tc, half_t>) {
+        this->StoreMoeWeightedReduce(tmp_C, cs0, tile_offset.w, pred, param);
+      }
+    } else if (param.silu_act) {
+      constexpr int dc = sizeof(Tc) * Map::kDeltaC / 2;
+      const int ds = sizeof(Tc) * Map::kDeltaS * c.ptr.stride;
+      auto ptr = (char*)c.ptr.ptr +
+                 sizeof(Tc) * dot({cs0.x / 2, cs0.y}, long2{1, c.ptr.stride});
+      PRAGMA_UNROLL
+      for (int s = 0; s < S; ++s) {
+        PRAGMA_UNROLL
+        for (int c = 0; c < C; ++c) {
+          GatedActivation<Silu>::template apply<Tc>(tmp_C[s][c]);
+          if (pred(s, c)) {
+            const auto tmp = cast<Tc>((Array<Dtype, kAccess / 2>&)tmp_C[s][c]);
+            Store(reinterpret_cast<Tc*>(ptr), tmp);
+          }
+          ptr += dc;
+        }
+        ptr -= dc * C;
+        ptr += ds;
+      }
+    } else {
+      this->template StoreC<Tc>(tmp_C, c, cs0, pred);
+      publish_tile_allreduce = true;
+    }
+
+    if (publish_tile_allreduce) {
+      if (param.tile_allreduce &&
+          param.tile_allreduce_param.kernel_reducer_blocks > 0) {
+        this->PublishTileAllReduceFlag(tile_offset, tile_id, is_last, param);
+      } else if (!this->StoreTailAllReduceC(tile_offset, is_last, param)) {
+        this->PublishTileAllReduceFlag(tile_offset, tile_id, is_last, param);
+        this->StoreTileAllReduceC(tmp_C, c, cs0, tile_offset, is_last, pred,
+                                  param);
+      }
+    }
+  }
 };
 
 }  // namespace turbomind::gemm

--- a/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/format.h
+++ b/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/format.h
@@ -6,72 +6,66 @@
 
 namespace turbomind::gemm {
 
-template<class Tin, class Tout>
-struct Converter {
-};
+template <class Tin, class Tout>
+struct Converter {};
 
-template<class T>
+template <class T>
 struct Converter<T, T> {
-    template<int N>
-    __device__ Array<T, N> operator()(Array<T, N> x)
-    {
-        return x;
-    }
+  template <int N>
+  __device__ Array<T, N> operator()(Array<T, N> x) {
+    return x;
+  }
 };
 
-template<>
+template <>
 struct Converter<uint16_t, uint4_t> {
+  static __device__ Array<uint4_t, 8> pack(const Array<uint8_t, 8>& vi) {
+    Array<uint32_t, 2> ui = (Array<uint32_t, 2>&)vi;
 
-    static __device__ Array<uint4_t, 8> pack(const Array<uint8_t, 8>& vi)
-    {
-        Array<uint32_t, 2> ui = (Array<uint32_t, 2>&)vi;
+    ui[0] |= (ui[0] >> 12);
+    ui[1] |= (ui[1] >> 12);
 
-        ui[0] |= (ui[0] >> 12);
-        ui[1] |= (ui[1] >> 12);
+    //  7 6 5 4 3 2 1 0
+    // _7_67564_3_23120
+    uint32_t uo = __byte_perm(ui[0], ui[1], 0x5140);
 
-        //  7 6 5 4 3 2 1 0
-        // _7_67564_3_23120
-        uint32_t uo = __byte_perm(ui[0], ui[1], 0x5140);
+    return (Array<uint4_t, 8>&)uo;
+  }
 
-        return (Array<uint4_t, 8>&)uo;
+  template <class U, int N>
+  __device__ Array<uint4_t, N> operator()(const Array<U, N>& x) {
+    static_assert(sizeof(U) == 2);
+    auto& vi = (const Array<uint16_t, N>&)x;
+    Array<uint8_t, N> tmp;
+    PRAGMA_UNROLL
+    for (int i = 0; i < N; ++i) {
+      tmp[i] = static_cast<uint8_t>(vi[i]);
     }
-
-    template<class U, int N>
-    __device__ Array<uint4_t, N> operator()(const Array<U, N>& x)
-    {
-        static_assert(sizeof(U) == 2);
-        auto&             vi = (const Array<uint16_t, N>&)x;
-        Array<uint8_t, N> tmp;
-        PRAGMA_UNROLL
-        for (int i = 0; i < N; ++i) {
-            tmp[i] = static_cast<uint8_t>(vi[i]);
-        }
-        Array<uint4_t, N> vo;
-        PRAGMA_UNROLL
-        for (int i = 0; i < N; i += 8) {
-            (Array<uint4_t, 8>&)vo[i] = pack((Array<uint8_t, 8>&)tmp[i]);
-        }
-        return vo;
+    Array<uint4_t, N> vo;
+    PRAGMA_UNROLL
+    for (int i = 0; i < N; i += 8) {
+      (Array<uint4_t, 8>&)vo[i] = pack((Array<uint8_t, 8>&)tmp[i]);
     }
+    return vo;
+  }
 };
 
-template<>
+template <>
 struct Converter<uint16_t, uint8_t> {
-    template<int N>
-    __device__ Array<uint8_t, N> operator()(const Array<uint16_t, N>& x)
-    {
-        static_assert(N % 4 == 0);
-        Array<uint8_t, N> vo;
-        PRAGMA_UNROLL
-        for (int i = 0; i < N; i += 4) {
-            // 3120
-            vo[i + 0] = (uint8_t)x[i + 0];
-            vo[i + 1] = (uint8_t)x[i + 2];
-            vo[i + 2] = (uint8_t)x[i + 1];
-            vo[i + 3] = (uint8_t)x[i + 3];
-        }
-        return vo;
+  template <int N>
+  __device__ Array<uint8_t, N> operator()(const Array<uint16_t, N>& x) {
+    static_assert(N % 4 == 0);
+    Array<uint8_t, N> vo;
+    PRAGMA_UNROLL
+    for (int i = 0; i < N; i += 4) {
+      // 3120
+      vo[i + 0] = (uint8_t)x[i + 0];
+      vo[i + 1] = (uint8_t)x[i + 2];
+      vo[i + 2] = (uint8_t)x[i + 1];
+      vo[i + 3] = (uint8_t)x[i + 3];
     }
+    return vo;
+  }
 };
 
 }  // namespace turbomind::gemm

--- a/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/gemm.cu
+++ b/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/gemm.cu
@@ -25,608 +25,578 @@
 
 namespace turbomind::gemm {
 
-void ExportDispatchCache(std::ostream& os, const std::vector<std::pair<GemmDesc, LaunchSpec>>& entries);
+void ExportDispatchCache(
+    std::ostream& os,
+    const std::vector<std::pair<GemmDesc, LaunchSpec>>& entries);
 
-void ImportDispatchCache(std::istream&                                 is,
+void ImportDispatchCache(std::istream& is,
                          std::vector<std::pair<GemmDesc, LaunchSpec>>& entries,
-                         const std::vector<std::unique_ptr<Kernel>>&   kernels);
+                         const std::vector<std::unique_ptr<Kernel>>& kernels);
 
 namespace {
 
-template<class Cmp>
-std::vector<int> ArgSort(size_t size, const Cmp& cmp)
-{
-    std::vector<int> idxs(size);
-    std::iota(idxs.begin(), idxs.end(), 0);
-    std::stable_sort(idxs.begin(), idxs.end(), cmp);
-    return idxs;
+template <class Cmp>
+std::vector<int> ArgSort(size_t size, const Cmp& cmp) {
+  std::vector<int> idxs(size);
+  std::iota(idxs.begin(), idxs.end(), 0);
+  std::stable_sort(idxs.begin(), idxs.end(), cmp);
+  return idxs;
 }
 
-bool GemmTraceEnabled()
-{
-    const char* raw = std::getenv("TM_GEMM_TRACE");
-    return raw && std::atoi(raw) != 0;
+bool GemmTraceEnabled() {
+  const char* raw = std::getenv("TM_GEMM_TRACE");
+  return raw && std::atoi(raw) != 0;
 }
 
-int GemmTraceLimit()
-{
-    const char* raw = std::getenv("TM_GEMM_TRACE_LIMIT");
-    return raw ? std::max(std::atoi(raw), 0) : 256;
+int GemmTraceLimit() {
+  const char* raw = std::getenv("TM_GEMM_TRACE_LIMIT");
+  return raw ? std::max(std::atoi(raw), 0) : 256;
 }
 
-bool GemmTraceFilterAllows(const std::string& desc)
-{
-    const char* raw = std::getenv("TM_GEMM_TRACE_FILTER");
-    return !raw || !*raw || desc.find(raw) != std::string::npos;
+bool GemmTraceFilterAllows(const std::string& desc) {
+  const char* raw = std::getenv("TM_GEMM_TRACE_FILTER");
+  return !raw || !*raw || desc.find(raw) != std::string::npos;
 }
 
-bool Sm70AwqTp2FastSelectorEnabled()
-{
-    const char* raw = std::getenv("VLLM_SM70_AWQ_TP2_FAST_SELECTOR");
-    return !raw || std::atoi(raw) != 0;
+bool Sm70AwqTp2FastSelectorEnabled() {
+  const char* raw = std::getenv("VLLM_SM70_AWQ_TP2_FAST_SELECTOR");
+  return !raw || std::atoi(raw) != 0;
 }
 
 // Keep the accepted QKVZ route enabled by default, while allowing an isolated
 // end-to-end A/B comparison without disabling the other exact small-M routes.
-bool Sm70AwqTp4QkvCta64Enabled()
-{
-    const char* raw = std::getenv("VLLM_SM70_AWQ_TP4_QKV_CTA64");
-    return !raw || std::atoi(raw) != 0;
+bool Sm70AwqTp4QkvCta64Enabled() {
+  const char* raw = std::getenv("VLLM_SM70_AWQ_TP4_QKV_CTA64");
+  return !raw || std::atoi(raw) != 0;
 }
 
 // Default-on A/B gate for the exact TP4 MTP verifier M=5 routes.
-bool Sm70AwqMtpM5FastSelectorEnabled()
-{
-    const char* raw = std::getenv("VLLM_SM70_AWQ_MTP_M5_FAST_SELECTOR");
-    return !raw || std::atoi(raw) != 0;
+bool Sm70AwqMtpM5FastSelectorEnabled() {
+  const char* raw = std::getenv("VLLM_SM70_AWQ_MTP_M5_FAST_SELECTOR");
+  return !raw || std::atoi(raw) != 0;
 }
 
 struct Sm70AwqTp2FastTarget {
-    int  n;
-    int  k;
-    int  cta_m;
-    int  cta_n;
-    int  cta_k;
-    int  splits;
-    int  swizzle;
-    bool require_mgroup;
-    std::string name_contains;
+  int n;
+  int k;
+  int cta_m;
+  int cta_n;
+  int cta_k;
+  int splits;
+  int swizzle;
+  bool require_mgroup;
+  std::string name_contains;
 };
 
-std::optional<Sm70AwqTp2FastTarget> GetSm70AwqTp2EnvFastTarget(const GemmDesc&         desc,
-                                                               const std::string_view desc_str)
-{
-    const char* raw = std::getenv("VLLM_SM70_AWQ_TP2_FAST_TARGETS");
-    if (!raw || !*raw) {
-        return std::nullopt;
-    }
-    const std::string targets(raw);
-    size_t            begin = 0;
-    while (begin <= targets.size()) {
-        const size_t end   = targets.find(';', begin);
-        const auto   entry = targets.substr(begin, end == std::string::npos ? std::string::npos : end - begin);
-        const size_t sep   = entry.find('|');
-        if (sep != std::string::npos && entry.substr(0, sep) == desc_str) {
-            std::string spec = entry.substr(sep + 1);
-            std::string name_contains;
-            if (const size_t name_sep = spec.find('@'); name_sep != std::string::npos) {
-                name_contains = spec.substr(name_sep + 1);
-                spec.resize(name_sep);
-            }
-            std::replace(spec.begin(), spec.end(), 'x', ',');
-            std::replace(spec.begin(), spec.end(), ':', ',');
-            for (char& ch : spec) {
-                if (ch == ',') {
-                    ch = ' ';
-                }
-            }
-            std::istringstream is(spec);
-            int                cta_m{};
-            int                cta_n{};
-            int                cta_k{};
-            int                splits{};
-            int                swizzle{};
-            int                require_mgroup{};
-            if (is >> cta_m >> cta_n >> cta_k >> splits >> swizzle >> require_mgroup) {
-                if (name_contains.empty()) {
-                    is >> name_contains;
-                }
-                return Sm70AwqTp2FastTarget{desc.n,
-                                            desc.k,
-                                            cta_m,
-                                            cta_n,
-                                            cta_k,
-                                            splits,
-                                            swizzle,
-                                            require_mgroup != 0,
-                                            name_contains};
-            }
-            if (GemmTraceEnabled() && GemmTraceFilterAllows(std::string(desc_str))) {
-                std::cerr << "[TM_GEMM_FAST_SELECTOR] desc=" << desc_str
-                          << " stage=invalid_env_target entry=" << entry << std::endl;
-            }
-            return std::nullopt;
-        }
-        if (end == std::string::npos) {
-            break;
-        }
-        begin = end + 1;
-    }
+std::optional<Sm70AwqTp2FastTarget> GetSm70AwqTp2EnvFastTarget(
+    const GemmDesc& desc, const std::string_view desc_str) {
+  const char* raw = std::getenv("VLLM_SM70_AWQ_TP2_FAST_TARGETS");
+  if (!raw || !*raw) {
     return std::nullopt;
+  }
+  const std::string targets(raw);
+  size_t begin = 0;
+  while (begin <= targets.size()) {
+    const size_t end = targets.find(';', begin);
+    const auto entry = targets.substr(
+        begin, end == std::string::npos ? std::string::npos : end - begin);
+    const size_t sep = entry.find('|');
+    if (sep != std::string::npos && entry.substr(0, sep) == desc_str) {
+      std::string spec = entry.substr(sep + 1);
+      std::string name_contains;
+      if (const size_t name_sep = spec.find('@');
+          name_sep != std::string::npos) {
+        name_contains = spec.substr(name_sep + 1);
+        spec.resize(name_sep);
+      }
+      std::replace(spec.begin(), spec.end(), 'x', ',');
+      std::replace(spec.begin(), spec.end(), ':', ',');
+      for (char& ch : spec) {
+        if (ch == ',') {
+          ch = ' ';
+        }
+      }
+      std::istringstream is(spec);
+      int cta_m{};
+      int cta_n{};
+      int cta_k{};
+      int splits{};
+      int swizzle{};
+      int require_mgroup{};
+      if (is >> cta_m >> cta_n >> cta_k >> splits >> swizzle >>
+          require_mgroup) {
+        if (name_contains.empty()) {
+          is >> name_contains;
+        }
+        return Sm70AwqTp2FastTarget{
+            desc.n,       desc.k, cta_m,   cta_n,
+            cta_k,        splits, swizzle, require_mgroup != 0,
+            name_contains};
+      }
+      if (GemmTraceEnabled() && GemmTraceFilterAllows(std::string(desc_str))) {
+        std::cerr << "[TM_GEMM_FAST_SELECTOR] desc=" << desc_str
+                  << " stage=invalid_env_target entry=" << entry << std::endl;
+      }
+      return std::nullopt;
+    }
+    if (end == std::string::npos) {
+      break;
+    }
+    begin = end + 1;
+  }
+  return std::nullopt;
 }
 
-std::optional<Sm70AwqTp2FastTarget> GetSm70AwqTp2FastTarget(const GemmDesc& desc)
-{
-    if (!Sm70AwqTp2FastSelectorEnabled()) {
-        return std::nullopt;
-    }
-    const std::string desc_str = to_string(desc);
-    if (auto target = GetSm70AwqTp2EnvFastTarget(desc, desc_str)) {
-        return target;
-    }
-    if (desc_str == "sm70_f16_u4k128_f16_tnt_fff_5x17408x5120_1") {
-        return Sm70AwqTp2FastTarget{desc.n, desc.k, 8, 64, 64, 1, 0, false, ""};
-    }
-    if (desc_str == "sm70_f16_u4k128_f16_tnt_fff_5x8192x5120_1") {
-        return Sm70AwqTp2FastTarget{desc.n, desc.k, 8, 64, 64, 2, 0, false, ""};
-    }
-    if (desc_str == "sm70_f16_u4k128_f16_tnt_fff_5x5120x3072_1") {
-        return Sm70AwqTp2FastTarget{desc.n, desc.k, 8, 64, 64, 3, 0, false, ""};
-    }
-    if (Sm70AwqMtpM5FastSelectorEnabled()) {
-        // TP4 MTP verifier, M=5. Both routes are bitwise exact on all TP shards.
-        if (desc_str == "sm70_f16_u4k128_f16_tnt_fff_5x8704x5120_1") {
-            return Sm70AwqTp2FastTarget{desc.n, desc.k, 8, 64, 64, 2, 4, false, ""};
-        }
-        if (desc_str == "sm70_f16_u4k128_f16_tnt_fff_5x4096x5120_1") {
-            return Sm70AwqTp2FastTarget{desc.n, desc.k, 8, 64, 64, 4, 4, false, ""};
-        }
-    }
-    if (desc_str == "sm70_f16_u4k128_f16_tnt_fff_1x17408x5120_1") {
-        return Sm70AwqTp2FastTarget{desc.n, desc.k, 8, 256, 64, 3, 3, false, ""};
-    }
-    if (desc_str == "sm70_f16_u4k128_f16_tnt_fff_1x8704x5120_1") {
-        return Sm70AwqTp2FastTarget{desc.n, desc.k, 8, 64, 64, 2, 4, false, ""};
-    }
-    if (Sm70AwqTp4QkvCta64Enabled()
-        && desc_str == "sm70_f16_u4k128_f16_tnt_fff_1x4096x5120_1") {
-        return Sm70AwqTp2FastTarget{desc.n, desc.k, 8, 64, 64, 4, 4, false, ""};
-    }
-    if (desc_str == "sm70_f16_u4k128_f16_tnt_fff_1x5120x1536_1") {
-        return Sm70AwqTp2FastTarget{desc.n, desc.k, 8, 256, 64, 12, 4, false, "s884_1x4x1"};
-    }
-    if (desc_str == "sm70_f16_u4k128_f16_tnt_fff_1x5120x3072_1") {
-        return Sm70AwqTp2FastTarget{desc.n, desc.k, 8, 256, 64, 7, 0, false, ""};
-    }
+std::optional<Sm70AwqTp2FastTarget> GetSm70AwqTp2FastTarget(
+    const GemmDesc& desc) {
+  if (!Sm70AwqTp2FastSelectorEnabled()) {
     return std::nullopt;
+  }
+  const std::string desc_str = to_string(desc);
+  if (auto target = GetSm70AwqTp2EnvFastTarget(desc, desc_str)) {
+    return target;
+  }
+  if (desc_str == "sm70_f16_u4k128_f16_tnt_fff_5x17408x5120_1") {
+    return Sm70AwqTp2FastTarget{desc.n, desc.k, 8, 64, 64, 1, 0, false, ""};
+  }
+  if (desc_str == "sm70_f16_u4k128_f16_tnt_fff_5x8192x5120_1") {
+    return Sm70AwqTp2FastTarget{desc.n, desc.k, 8, 64, 64, 2, 0, false, ""};
+  }
+  if (desc_str == "sm70_f16_u4k128_f16_tnt_fff_5x5120x3072_1") {
+    return Sm70AwqTp2FastTarget{desc.n, desc.k, 8, 64, 64, 3, 0, false, ""};
+  }
+  if (Sm70AwqMtpM5FastSelectorEnabled()) {
+    // TP4 MTP verifier, M=5. Both routes are bitwise exact on all TP shards.
+    if (desc_str == "sm70_f16_u4k128_f16_tnt_fff_5x8704x5120_1") {
+      return Sm70AwqTp2FastTarget{desc.n, desc.k, 8, 64, 64, 2, 4, false, ""};
+    }
+    if (desc_str == "sm70_f16_u4k128_f16_tnt_fff_5x4096x5120_1") {
+      return Sm70AwqTp2FastTarget{desc.n, desc.k, 8, 64, 64, 4, 4, false, ""};
+    }
+  }
+  if (desc_str == "sm70_f16_u4k128_f16_tnt_fff_1x17408x5120_1") {
+    return Sm70AwqTp2FastTarget{desc.n, desc.k, 8, 256, 64, 3, 3, false, ""};
+  }
+  if (desc_str == "sm70_f16_u4k128_f16_tnt_fff_1x8704x5120_1") {
+    return Sm70AwqTp2FastTarget{desc.n, desc.k, 8, 64, 64, 2, 4, false, ""};
+  }
+  if (Sm70AwqTp4QkvCta64Enabled() &&
+      desc_str == "sm70_f16_u4k128_f16_tnt_fff_1x4096x5120_1") {
+    return Sm70AwqTp2FastTarget{desc.n, desc.k, 8, 64, 64, 4, 4, false, ""};
+  }
+  if (desc_str == "sm70_f16_u4k128_f16_tnt_fff_1x5120x1536_1") {
+    return Sm70AwqTp2FastTarget{desc.n, desc.k, 8,     256,         64,
+                                12,     4,      false, "s884_1x4x1"};
+  }
+  if (desc_str == "sm70_f16_u4k128_f16_tnt_fff_1x5120x3072_1") {
+    return Sm70AwqTp2FastTarget{desc.n, desc.k, 8, 256, 64, 7, 0, false, ""};
+  }
+  return std::nullopt;
 }
 
-bool MatchesSm70AwqTp2FastKernel(const Kernel& kernel, const Sm70AwqTp2FastTarget& target)
-{
-    const int3 cta = kernel.cta_tile_size();
-    if (cta.x != target.cta_m || cta.y != target.cta_n || cta.z != target.cta_k) {
-        return false;
-    }
-    const std::string name = kernel.name();
-    const bool        is_mgroup = name.find("mgroup") != std::string::npos;
-    if (is_mgroup != target.require_mgroup) {
-        return false;
-    }
-    return target.name_contains.empty() || name.find(target.name_contains) != std::string::npos;
+bool MatchesSm70AwqTp2FastKernel(const Kernel& kernel,
+                                 const Sm70AwqTp2FastTarget& target) {
+  const int3 cta = kernel.cta_tile_size();
+  if (cta.x != target.cta_m || cta.y != target.cta_n || cta.z != target.cta_k) {
+    return false;
+  }
+  const std::string name = kernel.name();
+  const bool is_mgroup = name.find("mgroup") != std::string::npos;
+  if (is_mgroup != target.require_mgroup) {
+    return false;
+  }
+  return target.name_contains.empty() ||
+         name.find(target.name_contains) != std::string::npos;
 }
 
-void MaybeTraceSm70AwqTp2FastSelector(const GemmDesc& desc, const char* stage, const LaunchSpec* spec = nullptr)
-{
-    if (!GemmTraceEnabled()) {
-        return;
-    }
-    const std::string desc_str = to_string(desc);
-    if (!GemmTraceFilterAllows(desc_str)) {
-        return;
-    }
-    std::cerr << "[TM_GEMM_FAST_SELECTOR] desc=" << desc_str << " stage=" << stage;
-    if (spec && spec->kernel) {
-        std::cerr << " kernel=" << spec->kernel->name() << " splits=" << spec->splits
-                  << " swizzle=" << spec->swizzle;
-    }
-    std::cerr << std::endl;
+void MaybeTraceSm70AwqTp2FastSelector(const GemmDesc& desc, const char* stage,
+                                      const LaunchSpec* spec = nullptr) {
+  if (!GemmTraceEnabled()) {
+    return;
+  }
+  const std::string desc_str = to_string(desc);
+  if (!GemmTraceFilterAllows(desc_str)) {
+    return;
+  }
+  std::cerr << "[TM_GEMM_FAST_SELECTOR] desc=" << desc_str
+            << " stage=" << stage;
+  if (spec && spec->kernel) {
+    std::cerr << " kernel=" << spec->kernel->name()
+              << " splits=" << spec->splits << " swizzle=" << spec->swizzle;
+  }
+  std::cerr << std::endl;
 }
 
-std::optional<LaunchSpec> SelectSm70AwqTp2FastSpec(Context&                              ctx,
-                                                   const std::vector<LaunchSpec>&        specs,
-                                                   const Sm70AwqTp2FastTarget&           target,
-                                                   size_t                                barriers_size,
-                                                   size_t                                partials_size)
-{
-    for (const auto& spec : specs) {
-        if (!spec.kernel || !MatchesSm70AwqTp2FastKernel(*spec.kernel, target)) {
-            continue;
-        }
-        if (spec.splits != target.splits) {
-            continue;
-        }
-        auto selected = spec;
-        const auto& actual_desc = ctx.get_desc(*selected.kernel);
-        const int4  shape{actual_desc.m, actual_desc.n, actual_desc.k, actual_desc.num};
-        if (target.swizzle > selected.kernel->GetMaxSwizzle(shape)) {
-            continue;
-        }
-        (void)barriers_size;
-        (void)partials_size;
-        selected.splits  = target.splits;
-        selected.swizzle = target.swizzle;
-        MaybeTraceSm70AwqTp2FastSelector(ctx.desc(), "selected", &selected);
-        return selected;
+std::optional<LaunchSpec> SelectSm70AwqTp2FastSpec(
+    Context& ctx, const std::vector<LaunchSpec>& specs,
+    const Sm70AwqTp2FastTarget& target, size_t barriers_size,
+    size_t partials_size) {
+  for (const auto& spec : specs) {
+    if (!spec.kernel || !MatchesSm70AwqTp2FastKernel(*spec.kernel, target)) {
+      continue;
     }
-    MaybeTraceSm70AwqTp2FastSelector(ctx.desc(), "no_match");
-    return std::nullopt;
+    if (spec.splits != target.splits) {
+      continue;
+    }
+    auto selected = spec;
+    const auto& actual_desc = ctx.get_desc(*selected.kernel);
+    const int4 shape{actual_desc.m, actual_desc.n, actual_desc.k,
+                     actual_desc.num};
+    if (target.swizzle > selected.kernel->GetMaxSwizzle(shape)) {
+      continue;
+    }
+    (void)barriers_size;
+    (void)partials_size;
+    selected.splits = target.splits;
+    selected.swizzle = target.swizzle;
+    MaybeTraceSm70AwqTp2FastSelector(ctx.desc(), "selected", &selected);
+    return selected;
+  }
+  MaybeTraceSm70AwqTp2FastSelector(ctx.desc(), "no_match");
+  return std::nullopt;
 }
 
-const char* ToString(DispatchPolicy policy)
-{
-    if ((policy & DispatchPolicy::kPreserveDefaultSplits)
-        || (policy & DispatchPolicy::kPreserveDefaultSplitCount)) {
-        static thread_local std::string text;
-        auto base =
-            static_cast<DispatchPolicy>((int)policy & ~(int)DispatchPolicy::kPreserveDefaultSplits
-                                        & ~(int)DispatchPolicy::kPreserveDefaultSplitCount);
-        text = std::string(ToString(base));
-        if (policy & DispatchPolicy::kPreserveDefaultSplits) {
-            text += "|preserve_default_splits";
-        }
-        if (policy & DispatchPolicy::kPreserveDefaultSplitCount) {
-            text += "|preserve_default_split_count";
-        }
-        return text.c_str();
+const char* ToString(DispatchPolicy policy) {
+  if ((policy & DispatchPolicy::kPreserveDefaultSplits) ||
+      (policy & DispatchPolicy::kPreserveDefaultSplitCount)) {
+    static thread_local std::string text;
+    auto base = static_cast<DispatchPolicy>(
+        (int)policy & ~(int)DispatchPolicy::kPreserveDefaultSplits &
+        ~(int)DispatchPolicy::kPreserveDefaultSplitCount);
+    text = std::string(ToString(base));
+    if (policy & DispatchPolicy::kPreserveDefaultSplits) {
+      text += "|preserve_default_splits";
     }
-    switch (policy) {
-        case DispatchPolicy::kDefault:
-            return "default";
-        case DispatchPolicy::kMeasure:
-            return "measure";
-        case DispatchPolicy::kReuse:
-            return "reuse";
-        case DispatchPolicy::kAppend:
-            return "append";
-        default:
-            return "unknown";
+    if (policy & DispatchPolicy::kPreserveDefaultSplitCount) {
+      text += "|preserve_default_split_count";
     }
+    return text.c_str();
+  }
+  switch (policy) {
+    case DispatchPolicy::kDefault:
+      return "default";
+    case DispatchPolicy::kMeasure:
+      return "measure";
+    case DispatchPolicy::kReuse:
+      return "reuse";
+    case DispatchPolicy::kAppend:
+      return "append";
+    default:
+      return "unknown";
+  }
 }
 
-void MaybeTraceGemmDispatch(const GemmDesc& desc, DispatchPolicy policy, const LaunchSpec& spec, bool measured)
-{
-    if (!GemmTraceEnabled()) {
-        return;
-    }
-    const std::string desc_str = to_string(desc);
-    if (!GemmTraceFilterAllows(desc_str)) {
-        return;
-    }
-    static std::atomic<int> logged{0};
-    const int limit = GemmTraceLimit();
-    if (limit > 0 && logged.fetch_add(1, std::memory_order_relaxed) >= limit) {
-        return;
-    }
+void MaybeTraceGemmDispatch(const GemmDesc& desc, DispatchPolicy policy,
+                            const LaunchSpec& spec, bool measured) {
+  if (!GemmTraceEnabled()) {
+    return;
+  }
+  const std::string desc_str = to_string(desc);
+  if (!GemmTraceFilterAllows(desc_str)) {
+    return;
+  }
+  static std::atomic<int> logged{0};
+  const int limit = GemmTraceLimit();
+  if (limit > 0 && logged.fetch_add(1, std::memory_order_relaxed) >= limit) {
+    return;
+  }
 
-    std::cerr << "[TM_GEMM_TRACE] desc=" << desc_str << " policy=" << ToString(policy) << " measured="
-              << (measured ? 1 : 0);
-    if (spec.kernel) {
-        const int3 cta = spec.kernel->cta_tile_size();
-        const int3 mma = spec.kernel->warp_tile_size();
-        std::cerr << " kernel=" << spec.kernel->name() << " splits=" << spec.splits << " swizzle=" << spec.swizzle
-                  << " cta=" << cta.x << "x" << cta.y << "x" << cta.z << " mma=" << mma.x << "x" << mma.y
-                  << "x" << mma.z << " stages=" << spec.kernel->stages() << " smem=" << spec.kernel->smem_size();
-    }
-    else {
-        std::cerr << " kernel=<none>";
-    }
-    std::cerr << std::endl;
+  std::cerr << "[TM_GEMM_TRACE] desc=" << desc_str
+            << " policy=" << ToString(policy)
+            << " measured=" << (measured ? 1 : 0);
+  if (spec.kernel) {
+    const int3 cta = spec.kernel->cta_tile_size();
+    const int3 mma = spec.kernel->warp_tile_size();
+    std::cerr << " kernel=" << spec.kernel->name() << " splits=" << spec.splits
+              << " swizzle=" << spec.swizzle << " cta=" << cta.x << "x" << cta.y
+              << "x" << cta.z << " mma=" << mma.x << "x" << mma.y << "x"
+              << mma.z << " stages=" << spec.kernel->stages()
+              << " smem=" << spec.kernel->smem_size();
+  } else {
+    std::cerr << " kernel=<none>";
+  }
+  std::cerr << std::endl;
 }
 
 }  // namespace
 
 struct Gemm::Impl {
-
-    Impl():
-        props_{GetCudaDeviceProps()},
+  Impl()
+      : props_{GetCudaDeviceProps()},
         arch_{props_->major * 100 + props_->minor * 10},
         registry_{props_},
-        cache_{registry_.kernels()}
-    {
-        if (arch_ == 700) {
-            // V100 decode is dominated by many tiny GEMM/GEMV problems. A
-            // broader search space consistently finds better launch specs than
-            // the generic defaults for these SM70 workloads.
-            tuning_.max_splits = 16;
-            tuning_.max_waves  = 32;
-            tuning_.swizzle    = {0, 1, 2, 3, 4};
-            tuning_.top_k      = 0;
-            tuning_.clusters   = 0;
-            tuning_.min_iter   = 2;
-            tuning_.max_iter   = 20;
-            tuning_.max_time   = 2.f;
-        }
-        if (auto str = std::getenv("TM_GEMM_TUNE")) {
-            try {
-                ParseTuningParams(tuning_, str);
-            }
-            catch (...) {
-                std::cerr << "[Gemm2] Failed to parse `TM_GEMM_TUNE`, default value will be used.\n";
-                tuning_ = {};
-            }
-        }
-        if (std::getenv("TM_GEMM_WARN_CACHE_MISS")) {
-            warn_cache_miss_ = true;
-        }
-        measurer_.emplace(CreateStoppingCriterion(tuning_.min_iter, tuning_.max_iter, tuning_.max_time));
+        cache_{registry_.kernels()} {
+    if (arch_ == 700) {
+      // V100 decode is dominated by many tiny GEMM/GEMV problems. A
+      // broader search space consistently finds better launch specs than
+      // the generic defaults for these SM70 workloads.
+      tuning_.max_splits = 16;
+      tuning_.max_waves = 32;
+      tuning_.swizzle = {0, 1, 2, 3, 4};
+      tuning_.top_k = 0;
+      tuning_.clusters = 0;
+      tuning_.min_iter = 2;
+      tuning_.max_iter = 20;
+      tuning_.max_time = 2.f;
+    }
+    if (auto str = std::getenv("TM_GEMM_TUNE")) {
+      try {
+        ParseTuningParams(tuning_, str);
+      } catch (...) {
+        std::cerr << "[Gemm2] Failed to parse `TM_GEMM_TUNE`, default value "
+                     "will be used.\n";
+        tuning_ = {};
+      }
+    }
+    if (std::getenv("TM_GEMM_WARN_CACHE_MISS")) {
+      warn_cache_miss_ = true;
+    }
+    measurer_.emplace(CreateStoppingCriterion(
+        tuning_.min_iter, tuning_.max_iter, tuning_.max_time));
+  }
+
+  // find launch spec in dispatch cache, dispatch by heuristic on cache miss
+  LaunchSpec Dispatch(Context& ctx, DispatchPolicy policy, size_t barriers_size,
+                      size_t partials_size) {
+    const auto& desc = ctx.desc();
+    const auto is_feasible = [&](const LaunchSpec& spec) {
+      return spec.kernel &&
+             spec.kernel->is_feasible(ctx.get_desc(*spec.kernel));
+    };
+    if (policy & DispatchPolicy::kReuse) {
+      if (auto spec = cache_.LowerBound(desc); spec && is_feasible(*spec)) {
+        return *spec;
+      }
+      if (warn_cache_miss_) {
+        std::cerr << "Failed to find a feasible kernel in the cache, will "
+                     "dispatch by heuristic: "
+                  << to_string(ctx.desc()) << std::endl;
+      }
     }
 
-    // find launch spec in dispatch cache, dispatch by heuristic on cache miss
-    LaunchSpec Dispatch(Context& ctx, DispatchPolicy policy, size_t barriers_size, size_t partials_size)
-    {
-        const auto& desc = ctx.desc();
-        const auto is_feasible = [&](const LaunchSpec& spec) {
-            return spec.kernel && spec.kernel->is_feasible(ctx.get_desc(*spec.kernel));
-        };
-        if (policy & DispatchPolicy::kReuse) {
-            if (auto spec = cache_.LowerBound(desc); spec && is_feasible(*spec)) {
-                return *spec;
-            }
-            if (warn_cache_miss_) {
-                std::cerr << "Failed to find a feasible kernel in the cache, will dispatch by heuristic: "
-                          << to_string(ctx.desc()) << std::endl;
-            }
-        }
-
-        if (auto spec = cache_.Find(desc); spec && is_feasible(*spec)) {
-            return *spec;
-        }
-
-        const auto fast_target = GetSm70AwqTp2FastTarget(desc);
-        auto specs = Find(ctx, barriers_size, partials_size, fast_target ? 0 : 1);
-        if (!specs.empty()) {
-            auto selected = specs.front();
-            if (fast_target) {
-                if (auto fast_spec =
-                        SelectSm70AwqTp2FastSpec(ctx, specs, *fast_target, barriers_size, partials_size)) {
-                    selected = *fast_spec;
-                }
-            }
-            cache_.Insert(desc, selected);
-            return selected;
-        }
-        return {};
+    if (auto spec = cache_.Find(desc); spec && is_feasible(*spec)) {
+      return *spec;
     }
 
-    std::vector<LaunchSpec> Find(Context& ctx, size_t barrier_size, size_t partials_size, int top_k)
+    const auto fast_target = GetSm70AwqTp2FastTarget(desc);
+    auto specs = Find(ctx, barriers_size, partials_size, fast_target ? 0 : 1);
+    if (!specs.empty()) {
+      auto selected = specs.front();
+      if (fast_target) {
+        if (auto fast_spec = SelectSm70AwqTp2FastSpec(
+                ctx, specs, *fast_target, barriers_size, partials_size)) {
+          selected = *fast_spec;
+        }
+      }
+      cache_.Insert(desc, selected);
+      return selected;
+    }
+    return {};
+  }
+
+  std::vector<LaunchSpec> Find(Context& ctx, size_t barrier_size,
+                               size_t partials_size, int top_k) {
+    std::vector<Kernel*> feasible = ctx.Filter(registry_.kernels());
+
+    std::vector<std::vector<LaunchSpec>> clusters;
     {
-        std::vector<Kernel*> feasible = ctx.Filter(registry_.kernels());
+      std::vector<LaunchSpec> tmp;
+      tmp.reserve(feasible.size());
+      for (const auto& k : feasible) {
+        LaunchSpec spec{k};
+        tmp.push_back(spec);
+      }
+      clusters = Cluster(tmp, ClusteringParam{false, true});
+    }
+    std::vector<Kernel*> proxies;
+    proxies.reserve(clusters.size());
 
-        std::vector<std::vector<LaunchSpec>> clusters;
-        {
-            std::vector<LaunchSpec> tmp;
-            tmp.reserve(feasible.size());
-            for (const auto& k : feasible) {
-                LaunchSpec spec{k};
-                tmp.push_back(spec);
-            }
-            clusters = Cluster(tmp, ClusteringParam{false, true});
-        }
-        std::vector<Kernel*> proxies;
-        proxies.reserve(clusters.size());
-
-        for (const auto& c : clusters) {
-            proxies.push_back(c.front().kernel);
-        }
-
-        std::vector<std::pair<int, LaunchSpec>> specs;
-
-        PopulateParam param{};
-        param.max_splits    = tuning_.max_splits;
-        param.max_waves     = tuning_.max_waves;
-        param.swizzle       = tuning_.swizzle.at(0);
-        param.barriers_size = barrier_size;
-        param.partials_size = partials_size;
-
-        for (int cluster_id = 0; cluster_id < (int)proxies.size(); ++cluster_id) {
-            auto& kernel = *proxies[cluster_id];
-
-            auto tmp = ctx.Populate(kernel, param);
-            for (const auto& s : tmp) {
-                specs.emplace_back(cluster_id, s);
-            }
-        }
-
-        // std::cerr << "#kernel: " << kernels.size() << ", #cluster: " << clusters.size()
-        //           << ", #metric: " << metrics.size() << "\n";
-
-        int64_t mio_max = 0;
-        int64_t mma_max = 0;
-        for (const auto& [_, s] : specs) {
-            auto& [mio, mma] = s.estimated;
-            mio_max          = std::max(mio_max, mio);
-            mma_max          = std::max(mma_max, mma);
-        }
-        std::vector<float> mio_ratio;
-        std::vector<float> mma_ratio;
-        std::vector<float> avg_ratio;
-        for (const auto& [_, s] : specs) {
-            auto& [mio, mma] = s.estimated;
-            mio_ratio.push_back((float)mio / mio_max);
-            mma_ratio.push_back((float)mma / mma_max);
-            avg_ratio.push_back(.5 * (mio_ratio.back() + mma_ratio.back()));
-        }
-        auto idxs = ArgSort(specs.size(), [&](int i, int j) {  //
-            return avg_ratio[i] < avg_ratio[j];
-        });
-
-        // for (const auto& i : idxs) {
-        //     auto [cid, s, m] = metrics[i];
-        //     std::cout << clusters[cid].front().kernel->name() << " s" << s << " " << avg_ratio[i] << " " <<
-        //     mio_ratio[i]
-        //               << " " << mma_ratio[i] << " " << m.mio_cost << " " << m.mma_cost << "\n";
-        // }
-
-        top_k = top_k > 0 ? std::min<int>(idxs.size(), top_k) : (int)idxs.size();
-        std::vector<LaunchSpec> ret;
-        ret.reserve(top_k);
-        for (int i = 0; i < top_k; ++i) {
-            const auto& [cluster_id, spec] = specs[idxs[i]];
-            // Apply `splits` to all kernels in the cluster
-            for (const auto& s : clusters[cluster_id]) {
-                auto tmp   = spec;
-                tmp.kernel = s.kernel;
-                ret.push_back(tmp);
-            }
-        }
-
-        return ret;
+    for (const auto& c : clusters) {
+      proxies.push_back(c.front().kernel);
     }
 
-    template<class LaunchFunc>
-    int Measure(
-        Context& ctx, size_t barriers_size, size_t partials_size, int top_k, LaunchFunc launch_func, cudaStream_t st)
-    {
-        // Early exit on exact match
-        if (cache_.Find(ctx.desc())) {
-            return 0;
-        }
-        // std::cerr << "GEMM: " << desc.m << "x" << desc.n << "x" << desc.k << "\n";
+    std::vector<std::pair<int, LaunchSpec>> specs;
 
-        const auto tmp = Find(ctx, barriers_size, partials_size, tuning_.top_k);
+    PopulateParam param{};
+    param.max_splits = tuning_.max_splits;
+    param.max_waves = tuning_.max_waves;
+    param.swizzle = tuning_.swizzle.at(0);
+    param.barriers_size = barrier_size;
+    param.partials_size = partials_size;
 
-        std::vector<LaunchSpec> specs;
-        for (const auto& spec : tmp) {
-            // populate swizzle parameters
-            const auto swis = ctx.Swizzle(spec, tuning_.swizzle);
-            specs.insert(specs.end(), swis.begin(), swis.end());
-        }
+    for (int cluster_id = 0; cluster_id < (int)proxies.size(); ++cluster_id) {
+      auto& kernel = *proxies[cluster_id];
 
-        specs = Sampler{*measurer_, tuning_.clusters}.Run(specs, launch_func, st);
-
-        // for (const auto& s : specs) {
-        //     std::cout << s.kernel->name()          //
-        //               << " swizzle=" << s.swizzle  //
-        //               << ", splits=" << s.splits   //
-        //               << ", measured=" << s.measured << "ms\n";
-        //     break;
-        // }
-
-        if (!specs.empty()) {
-            cache_.Insert(ctx.desc(), specs.front());
-        }
-        else {
-            std::cerr << "No valid kernel found for the problem\n";
-            return -1;
-        }
-
-        return 0;
+      auto tmp = ctx.Populate(kernel, param);
+      for (const auto& s : tmp) {
+        specs.emplace_back(cluster_id, s);
+      }
     }
 
-    /// TODO: move to cuda utils
-    static std::unique_ptr<cudaDeviceProp> GetCudaDeviceProps()
-    {
-        auto props     = std::make_unique<cudaDeviceProp>();
-        int  device_id = -1;
-        cudaGetDevice(&device_id);
-        cudaGetDeviceProperties(props.get(), device_id);
-        return props;
+    // std::cerr << "#kernel: " << kernels.size() << ", #cluster: " <<
+    // clusters.size()
+    //           << ", #metric: " << metrics.size() << "\n";
+
+    int64_t mio_max = 0;
+    int64_t mma_max = 0;
+    for (const auto& [_, s] : specs) {
+      auto& [mio, mma] = s.estimated;
+      mio_max = std::max(mio_max, mio);
+      mma_max = std::max(mma_max, mma);
+    }
+    std::vector<float> mio_ratio;
+    std::vector<float> mma_ratio;
+    std::vector<float> avg_ratio;
+    for (const auto& [_, s] : specs) {
+      auto& [mio, mma] = s.estimated;
+      mio_ratio.push_back((float)mio / mio_max);
+      mma_ratio.push_back((float)mma / mma_max);
+      avg_ratio.push_back(.5 * (mio_ratio.back() + mma_ratio.back()));
+    }
+    auto idxs = ArgSort(specs.size(), [&](int i, int j) {  //
+      return avg_ratio[i] < avg_ratio[j];
+    });
+
+    // for (const auto& i : idxs) {
+    //     auto [cid, s, m] = metrics[i];
+    //     std::cout << clusters[cid].front().kernel->name() << " s" << s << " "
+    //     << avg_ratio[i] << " " << mio_ratio[i]
+    //               << " " << mma_ratio[i] << " " << m.mio_cost << " " <<
+    //               m.mma_cost << "\n";
+    // }
+
+    top_k = top_k > 0 ? std::min<int>(idxs.size(), top_k) : (int)idxs.size();
+    std::vector<LaunchSpec> ret;
+    ret.reserve(top_k);
+    for (int i = 0; i < top_k; ++i) {
+      const auto& [cluster_id, spec] = specs[idxs[i]];
+      // Apply `splits` to all kernels in the cluster
+      for (const auto& s : clusters[cluster_id]) {
+        auto tmp = spec;
+        tmp.kernel = s.kernel;
+        ret.push_back(tmp);
+      }
     }
 
-    std::shared_ptr<cudaDeviceProp> props_;
+    return ret;
+  }
 
-    int arch_;
+  template <class LaunchFunc>
+  int Measure(Context& ctx, size_t barriers_size, size_t partials_size,
+              int top_k, LaunchFunc launch_func, cudaStream_t st) {
+    // Early exit on exact match
+    if (cache_.Find(ctx.desc())) {
+      return 0;
+    }
+    // std::cerr << "GEMM: " << desc.m << "x" << desc.n << "x" << desc.k <<
+    // "\n";
 
-    Registry registry_;
+    const auto tmp = Find(ctx, barriers_size, partials_size, tuning_.top_k);
 
-    TuningParams tuning_;
+    std::vector<LaunchSpec> specs;
+    for (const auto& spec : tmp) {
+      // populate swizzle parameters
+      const auto swis = ctx.Swizzle(spec, tuning_.swizzle);
+      specs.insert(specs.end(), swis.begin(), swis.end());
+    }
 
-    bool warn_cache_miss_{};
+    specs = Sampler{*measurer_, tuning_.clusters}.Run(specs, launch_func, st);
 
-    std::optional<Measurer> measurer_;
+    // for (const auto& s : specs) {
+    //     std::cout << s.kernel->name()          //
+    //               << " swizzle=" << s.swizzle  //
+    //               << ", splits=" << s.splits   //
+    //               << ", measured=" << s.measured << "ms\n";
+    //     break;
+    // }
 
-    DispatchCache cache_;
+    if (!specs.empty()) {
+      cache_.Insert(ctx.desc(), specs.front());
+    } else {
+      std::cerr << "No valid kernel found for the problem\n";
+      return -1;
+    }
 
-    std::mutex dispatch_mutex_;
+    return 0;
+  }
+
+  /// TODO: move to cuda utils
+  static std::unique_ptr<cudaDeviceProp> GetCudaDeviceProps() {
+    auto props = std::make_unique<cudaDeviceProp>();
+    int device_id = -1;
+    cudaGetDevice(&device_id);
+    cudaGetDeviceProperties(props.get(), device_id);
+    return props;
+  }
+
+  std::shared_ptr<cudaDeviceProp> props_;
+
+  int arch_;
+
+  Registry registry_;
+
+  TuningParams tuning_;
+
+  bool warn_cache_miss_{};
+
+  std::optional<Measurer> measurer_;
+
+  DispatchCache cache_;
+
+  std::mutex dispatch_mutex_;
 };
 
 // implementation of GEMM interfaces
 
-Gemm::Gemm(): impl_{new Impl{}} {}
+Gemm::Gemm() : impl_{new Impl{}} {}
 
 Gemm::~Gemm() = default;
 
-int Gemm::Run(const Operation&    operation,
-              float               alpha,
-              const void*         A,
-              const MatrixLayout& Adesc,
-              const void*         U,
-              const MatrixLayout& Udesc,
-              const void*         B,
-              const MatrixLayout& Bdesc,
-              const void*         V,
-              const MatrixLayout& Vdesc,
-              float               beta,
-              const void*         C,
-              const MatrixLayout& Cdesc,
-              void*               D,
-              const MatrixLayout& Ddesc,
-              const Workspace&    workspace,
-              cudaStream_t        stream)
-{
+int Gemm::Run(const Operation& operation, float alpha, const void* A,
+              const MatrixLayout& Adesc, const void* U,
+              const MatrixLayout& Udesc, const void* B,
+              const MatrixLayout& Bdesc, const void* V,
+              const MatrixLayout& Vdesc, float beta, const void* C,
+              const MatrixLayout& Cdesc, void* D, const MatrixLayout& Ddesc,
+              const Workspace& workspace, cudaStream_t stream) {
+  Context context{*impl_->props_};
 
-    Context context{*impl_->props_};
+  const auto desc =
+      context.Init(operation, Adesc, Udesc, Bdesc, Vdesc, Cdesc, Ddesc);
 
-    const auto desc = context.Init(operation, Adesc, Udesc, Bdesc, Vdesc, Cdesc, Ddesc);
+  if (!desc) {
+    fprintf(stderr, "invalid argument.\n");
+    TM_CHECK(0);
+    return -1;
+  }
 
-    if (!desc) {
-        fprintf(stderr, "invalid argument.\n");
-        TM_CHECK(0);
-        return -1;
+  const auto launch = [=](LaunchSpec spec, cudaStream_t st) {
+    auto _workspace = workspace;
+    return spec.kernel->Launch(operation, alpha, A, Adesc, U, Udesc, B, Bdesc,
+                               V, Vdesc, beta, C, Cdesc, D, Ddesc, spec.swizzle,
+                               spec.splits, _workspace, st);
+  };
+
+  std::optional<Context> dispatch_context_storage;
+  Context* dispatch_context = &context;
+  if (operation.dispatch_num_override > 0 &&
+      operation.dispatch_num_override != context.desc().num) {
+    MatrixLayout dispatch_Adesc = Adesc;
+    MatrixLayout dispatch_Bdesc = Bdesc;
+    MatrixLayout dispatch_Ddesc = Ddesc;
+    dispatch_Adesc.num = operation.dispatch_num_override;
+    dispatch_Bdesc.num = operation.dispatch_num_override;
+    dispatch_Ddesc.num = operation.dispatch_num_override;
+    dispatch_context_storage.emplace(*impl_->props_);
+    if (dispatch_context_storage->Init(operation, dispatch_Adesc, Udesc,
+                                       dispatch_Bdesc, Vdesc, Cdesc,
+                                       dispatch_Ddesc)) {
+      dispatch_context = &*dispatch_context_storage;
+    } else {
+      dispatch_context_storage.reset();
+      dispatch_context = &context;
     }
-
-    const auto launch = [=](LaunchSpec spec, cudaStream_t st) {
-        auto _workspace = workspace;
-        return spec.kernel->Launch(operation,
-                                   alpha,
-                                   A,
-                                   Adesc,
-                                   U,
-                                   Udesc,
-                                   B,
-                                   Bdesc,
-                                   V,
-                                   Vdesc,
-                                   beta,
-                                   C,
-                                   Cdesc,
-                                   D,
-                                   Ddesc,
-                                   spec.swizzle,
-                                   spec.splits,
-                                   _workspace,
-                                   st);
-    };
-
-    std::optional<Context> dispatch_context_storage;
-    Context*               dispatch_context = &context;
-    if (operation.dispatch_num_override > 0 && operation.dispatch_num_override != context.desc().num) {
-        MatrixLayout dispatch_Adesc = Adesc;
-        MatrixLayout dispatch_Bdesc = Bdesc;
-        MatrixLayout dispatch_Ddesc = Ddesc;
-        dispatch_Adesc.num          = operation.dispatch_num_override;
-        dispatch_Bdesc.num          = operation.dispatch_num_override;
-        dispatch_Ddesc.num          = operation.dispatch_num_override;
-        dispatch_context_storage.emplace(*impl_->props_);
-        if (dispatch_context_storage->Init(
-                operation, dispatch_Adesc, Udesc, dispatch_Bdesc, Vdesc, Cdesc, dispatch_Ddesc)) {
-            dispatch_context = &*dispatch_context_storage;
-        }
-        else {
-            dispatch_context_storage.reset();
-            dispatch_context = &context;
-        }
-    }
+  }
 
 #if 0
     if (operation.reserved) {
@@ -642,70 +612,70 @@ int Gemm::Run(const Operation&    operation,
     }
 #endif
 
-    LaunchSpec spec{};
+  LaunchSpec spec{};
 
-    const bool measured = operation.dispatch & DispatchPolicy::kMeasure;
-    {
-        std::lock_guard<std::mutex> lock(impl_->dispatch_mutex_);
-        if (measured) {
-            impl_->Measure(*dispatch_context, workspace.barriers_size, workspace.partials_size, 1, launch, stream);
+  const bool measured = operation.dispatch & DispatchPolicy::kMeasure;
+  {
+    std::lock_guard<std::mutex> lock(impl_->dispatch_mutex_);
+    if (measured) {
+      impl_->Measure(*dispatch_context, workspace.barriers_size,
+                     workspace.partials_size, 1, launch, stream);
+    }
+
+    spec = impl_->Dispatch(*dispatch_context, operation.dispatch,
+                           workspace.barriers_size, workspace.partials_size);
+    const bool preserve_default_kernel =
+        operation.dispatch & DispatchPolicy::kPreserveDefaultSplits;
+    const bool preserve_default_split_count =
+        operation.dispatch & DispatchPolicy::kPreserveDefaultSplitCount;
+    if (spec.kernel &&
+        (preserve_default_kernel || preserve_default_split_count)) {
+      auto default_specs =
+          impl_->Find(*dispatch_context, workspace.barriers_size,
+                      workspace.partials_size, 1);
+      if (!default_specs.empty()) {
+        const auto default_spec = default_specs.front();
+        if (preserve_default_kernel) {
+          spec.kernel = default_spec.kernel;
         }
-
-        spec = impl_->Dispatch(*dispatch_context, operation.dispatch, workspace.barriers_size, workspace.partials_size);
-        const bool preserve_default_kernel = operation.dispatch & DispatchPolicy::kPreserveDefaultSplits;
-        const bool preserve_default_split_count = operation.dispatch & DispatchPolicy::kPreserveDefaultSplitCount;
-        if (spec.kernel && (preserve_default_kernel || preserve_default_split_count)) {
-            auto default_specs = impl_->Find(*dispatch_context, workspace.barriers_size, workspace.partials_size, 1);
-            if (!default_specs.empty()) {
-                const auto default_spec = default_specs.front();
-                if (preserve_default_kernel) {
-                    spec.kernel = default_spec.kernel;
-                }
-                spec.splits = default_spec.splits;
-                const auto& default_desc = dispatch_context->get_desc(*spec.kernel);
-                spec.swizzle = std::min(
-                    spec.swizzle,
-                    spec.kernel->GetMaxSwizzle({
-                        default_desc.m,
-                        default_desc.n,
-                        default_desc.k,
-                        default_desc.num,
-                    }));
-            }
-        }
+        spec.splits = default_spec.splits;
+        const auto& default_desc = dispatch_context->get_desc(*spec.kernel);
+        spec.swizzle = std::min(spec.swizzle, spec.kernel->GetMaxSwizzle({
+                                                  default_desc.m,
+                                                  default_desc.n,
+                                                  default_desc.k,
+                                                  default_desc.num,
+                                              }));
+      }
     }
-    if (spec.kernel && dispatch_context != &context) {
-        const auto& actual_desc = context.get_desc(*spec.kernel);
-        spec.swizzle =
-            std::min(spec.swizzle, spec.kernel->GetMaxSwizzle({actual_desc.m, actual_desc.n, actual_desc.k, actual_desc.num}));
-    }
-    MaybeTraceGemmDispatch(dispatch_context->desc(), operation.dispatch, spec, measured);
+  }
+  if (spec.kernel && dispatch_context != &context) {
+    const auto& actual_desc = context.get_desc(*spec.kernel);
+    spec.swizzle =
+        std::min(spec.swizzle,
+                 spec.kernel->GetMaxSwizzle({actual_desc.m, actual_desc.n,
+                                             actual_desc.k, actual_desc.num}));
+  }
+  MaybeTraceGemmDispatch(dispatch_context->desc(), operation.dispatch, spec,
+                         measured);
 
-    if (spec.kernel) {
-        // std::cout << "[Gemm] dispatch: " << spec.kernel->name()  //
-        //           << " split_k=" << spec.splits                  //
-        //           << " swizzle=" << spec.swizzle << std::endl;
-        return launch(spec, stream);
-    }
+  if (spec.kernel) {
+    // std::cout << "[Gemm] dispatch: " << spec.kernel->name()  //
+    //           << " split_k=" << spec.splits                  //
+    //           << " swizzle=" << spec.swizzle << std::endl;
+    return launch(spec, stream);
+  }
 
-    TM_CHECK(0) << "No feasible kernel found for the problem: " << to_string(context.desc());
+  TM_CHECK(0) << "No feasible kernel found for the problem: "
+              << to_string(context.desc());
 
-    return -1;
+  return -1;
 }
 
-int Gemm::Export(std::ostream& os)
-{
-    return impl_->cache_.Export(os);
-}
+int Gemm::Export(std::ostream& os) { return impl_->cache_.Export(os); }
 
-int Gemm::Import(std::istream& is)
-{
-    return impl_->cache_.Import(is);
-}
+int Gemm::Import(std::istream& is) { return impl_->cache_.Import(is); }
 
-std::vector<int> Gemm::GetTuningSeq() const
-{
-    return impl_->tuning_.seq;
-}
+std::vector<int> Gemm::GetTuningSeq() const { return impl_->tuning_.seq; }
 
 }  // namespace turbomind::gemm

--- a/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/gemm.h
+++ b/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/gemm.h
@@ -12,41 +12,32 @@
 namespace turbomind::gemm {
 
 class Gemm {
-public:
-    static constexpr size_t kBarriersSize = 1 << 20;
-    static constexpr size_t kPartialsSize = 32 << 20;
+ public:
+  static constexpr size_t kBarriersSize = 1 << 20;
+  static constexpr size_t kPartialsSize = 32 << 20;
 
-    Gemm();
+  Gemm();
 
-    ~Gemm();
+  ~Gemm();
 
-    [[nodiscard]] int Run(const Operation&    operation,
-                          float               alpha,
-                          const void*         A,
-                          const MatrixLayout& Adesc,
-                          const void*         U,
-                          const MatrixLayout& Udesc,
-                          const void*         B,
-                          const MatrixLayout& Bdesc,
-                          const void*         V,
-                          const MatrixLayout& Vdesc,
-                          float               beta,
-                          const void*         C,
-                          const MatrixLayout& Cdesc,
-                          void*               D,
-                          const MatrixLayout& Ddesc,
-                          const Workspace&    workspace,
-                          cudaStream_t        stream);
+  [[nodiscard]] int Run(const Operation& operation, float alpha, const void* A,
+                        const MatrixLayout& Adesc, const void* U,
+                        const MatrixLayout& Udesc, const void* B,
+                        const MatrixLayout& Bdesc, const void* V,
+                        const MatrixLayout& Vdesc, float beta, const void* C,
+                        const MatrixLayout& Cdesc, void* D,
+                        const MatrixLayout& Ddesc, const Workspace& workspace,
+                        cudaStream_t stream);
 
-    [[maybe_unused]] int Export(std::ostream& os);
+  [[maybe_unused]] int Export(std::ostream& os);
 
-    [[maybe_unused]] int Import(std::istream& is);
+  [[maybe_unused]] int Import(std::istream& is);
 
-    [[nodiscard]] std::vector<int> GetTuningSeq() const;
+  [[nodiscard]] std::vector<int> GetTuningSeq() const;
 
-private:
-    struct Impl;
-    std::unique_ptr<Impl> impl_;
+ private:
+  struct Impl;
+  std::unique_ptr<Impl> impl_;
 };
 
 }  // namespace turbomind::gemm

--- a/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/gemm_universal.h
+++ b/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/gemm_universal.h
@@ -20,232 +20,242 @@
 namespace turbomind::gemm {
 
 struct GemmParam {
-    MatrixParam a;
-    MatrixParam b;
-    MatrixParam u;
-    MatrixParam v;
+  MatrixParam a;
+  MatrixParam b;
+  MatrixParam u;
+  MatrixParam v;
 };
 
-template<class Op>
-__inline__ __device__ MatrixData resolve_op(const MatrixParam& param, int gemm_id)
-{
-    return resolve<typename Op::Dtype, Op::GmemIter::kMode>(param, gemm_id);
+template <class Op>
+__inline__ __device__ MatrixData resolve_op(const MatrixParam& param,
+                                            int gemm_id) {
+  return resolve<typename Op::Dtype, Op::GmemIter::kMode>(param, gemm_id);
 }
 
-template<class Arch_, class Mainloop, class Epilogue_, class Scheduler_>
+template <class Arch_, class Mainloop, class Epilogue_, class Scheduler_>
 struct GemmUniversal {
+  // using Impl = typename Mainloop::Impl;
+  using Impl = Mainloop;
 
-    // using Impl = typename Mainloop::Impl;
-    using Impl = Mainloop;
+  using Ta = typename Impl::Ta;
+  using Tb = typename Impl::Tb;
+  using Tu = typename Impl::Tu;
+  using Tv = typename Impl::Tv;
 
-    using Ta = typename Impl::Ta;
-    using Tb = typename Impl::Tb;
-    using Tu = typename Impl::Tu;
-    using Tv = typename Impl::Tv;
+  using Arch = Arch_;
+  using Scheduler = Scheduler_;
+  using Epilogue = Epilogue_;
 
-    using Arch      = Arch_;
-    using Scheduler = Scheduler_;
-    using Epilogue  = Epilogue_;
+  using Tc = typename Epilogue::Tc;
 
-    using Tc = typename Epilogue::Tc;
+  // col major == M-major (A)
+  // row major == N-major (B)
+  static constexpr Order kOrderC = Epilogue::kOrder;
 
-    // col major == M-major (A)
-    // row major == N-major (B)
-    static constexpr Order kOrderC = Epilogue::kOrder;
+  static constexpr int CTA_M = Impl::CTA_M;
+  static constexpr int CTA_N = Impl::CTA_N;
+  static constexpr int CTA_K = Impl::CTA_K;
 
-    static constexpr int CTA_M = Impl::CTA_M;
-    static constexpr int CTA_N = Impl::CTA_N;
-    static constexpr int CTA_K = Impl::CTA_K;
+  static constexpr bool kDynamicSched = Scheduler::group_axis >= 0;
+  static constexpr bool kSplitK = Epilogue::SplitK;
 
-    static constexpr bool kDynamicSched = Scheduler::group_axis >= 0;
-    static constexpr bool kSplitK       = Epilogue::SplitK;
+  using FragC = typename Impl::FragC;
 
-    using FragC = typename Impl::FragC;
+  static constexpr int WARP_CNT = Impl::WARPS;
 
-    static constexpr int WARP_CNT = Impl::WARPS;
+  using OperandA = typename Mainloop::OperandA;
+  using OperandB = typename Mainloop::OperandB;
+  using OperandU = typename Mainloop::OperandU;
+  using OperandV = typename Mainloop::OperandV;
 
-    using OperandA = typename Mainloop::OperandA;
-    using OperandB = typename Mainloop::OperandB;
-    using OperandU = typename Mainloop::OperandU;
-    using OperandV = typename Mainloop::OperandV;
+  static constexpr int kChunkSizeK =
+      std::max(CTA_K, std::max(OperandU::kGroupSize, OperandV::kGroupSize));
 
-    static constexpr int kChunkSizeK = std::max(CTA_K, std::max(OperandU::kGroupSize, OperandV::kGroupSize));
+  static constexpr int kGSizeU = OperandU::kGroupSize;
+  static constexpr int kGSizeV = OperandV::kGroupSize;
 
-    static constexpr int kGSizeU = OperandU::kGroupSize;
-    static constexpr int kGSizeV = OperandV::kGroupSize;
-
-    struct SharedStorage {
-        union {
-            typename Mainloop::SharedStorage mainloop;
-            typename Epilogue::SharedStorage epilogue;
-        };
-        typename Scheduler::SharedStorage sched;
+  struct SharedStorage {
+    union {
+      typename Mainloop::SharedStorage mainloop;
+      typename Epilogue::SharedStorage epilogue;
     };
+    typename Scheduler::SharedStorage sched;
+  };
 
-    static constexpr Order kOrderA = OperandA::kOrder;
-    static constexpr Order kOrderB = OperandB::kOrder;
-    static constexpr Order kOrderU = OperandU::kOrder;
-    static constexpr Order kOrderV = OperandV::kOrder;
+  static constexpr Order kOrderA = OperandA::kOrder;
+  static constexpr Order kOrderB = OperandB::kOrder;
+  static constexpr Order kOrderU = OperandU::kOrder;
+  static constexpr Order kOrderV = OperandV::kOrder;
 
-    static constexpr Pack kPackA = OperandA::kPack;
-    static constexpr Pack kPackB = OperandB::kPack;
+  static constexpr Pack kPackA = OperandA::kPack;
+  static constexpr Pack kPackB = OperandB::kPack;
 
-    using Param = GemmParam;
+  using Param = GemmParam;
 
-    __device__ void operator()(const Param& param, const EpilogueParam& epi_param, Scheduler& sched, char* smem_buf)
-    {
-        SharedStorage& storage = *reinterpret_cast<SharedStorage*>(smem_buf);
+  __device__ void operator()(const Param& param, const EpilogueParam& epi_param,
+                             Scheduler& sched, char* smem_buf) {
+    SharedStorage& storage = *reinterpret_cast<SharedStorage*>(smem_buf);
 
-        typename Scheduler::Tile tile;
+    typename Scheduler::Tile tile;
 
-        if (!sched.init(tile, storage.sched, std::false_type{})) {
-            return;
-        }
-
-        const auto& [M, N, K] = tile.shape.__a;
-
-        const auto tile_id = tile.tile_id;
-
-        const int offset_m = tile_id[0] * CTA_M;
-        const int offset_n = tile_id[1] * CTA_N;
-
-        const int offset_k = tile.k_iters[0] * CTA_K;
-
-        if (offset_m >= M || offset_n >= N || offset_k >= K) {  // empty tile
-            return;
-        }
-
-        const int extent_m = min(CTA_M, M - offset_m);
-        const int extent_n = min(CTA_N, N - offset_n);
-
-        // Is 8 enough?
-        __align__(8) FragC frag_C{};
-
-        int tile_iter = tile.k_iters[1];
-
-        const int g = tile.group_id;
-
-        const auto mat_A = resolve_op<OperandA>(param.a, g);
-        const auto mat_B = resolve_op<OperandB>(param.b, g);
-        const auto mat_U = resolve_op<OperandU>(param.u, g);
-        const auto mat_V = resolve_op<OperandV>(param.v, g);
-
-        typename OperandA::GmemIter gmem_A{mat_A, {offset_m, offset_k}, {extent_m, CTA_K}};
-        typename OperandB::GmemIter gmem_B{mat_B, {offset_n, offset_k}, {extent_n, CTA_K}};
-
-        const int2 offset_U{offset_m, cdiv(offset_k, kGSizeU)}, extent_U{extent_m, cdiv(CTA_K, kGSizeU)};
-        typename OperandU::GmemIter gmem_U{mat_U, offset_U, extent_U};
-
-        const int2 offset_V{offset_n, cdiv(offset_k, kGSizeV)}, extent_V{extent_n, cdiv(CTA_K, kGSizeV)};
-        typename OperandV::GmemIter gmem_V{mat_V, offset_V, extent_V};
-
-        Mainloop mainloop{};
-        mainloop(gmem_A, gmem_B, gmem_U, gmem_V, frag_C, tile_iter, storage.mainloop);
-
-        {
-            sched.init(tile, storage.sched, std::true_type{});
-
-            const auto [M, N, K] = tile.shape.__a;
-
-            int4 tile_offset{tile.tile_id[0], tile.tile_id[1], tile.tile_id[2], tile.group_id};
-
-            const int2 extents = {min(CTA_M, M - tile_offset.x * CTA_M), min(CTA_N, N - tile_offset.y * CTA_N)};
-
-            const bool is_last = (tile.k_iters[0] + tile.k_iters[1]) * CTA_K == K;
-
-            Epilogue epilogue{};
-            epilogue(frag_C,  //
-                     tile_offset,
-                     extents,
-                     sched.tiles_[2],
-                     tile.linear_tile_id,
-                     is_last,
-                     epi_param,
-                     storage.epilogue);
-        }
+    if (!sched.init(tile, storage.sched, std::false_type{})) {
+      return;
     }
+
+    const auto& [M, N, K] = tile.shape.__a;
+
+    const auto tile_id = tile.tile_id;
+
+    const int offset_m = tile_id[0] * CTA_M;
+    const int offset_n = tile_id[1] * CTA_N;
+
+    const int offset_k = tile.k_iters[0] * CTA_K;
+
+    if (offset_m >= M || offset_n >= N || offset_k >= K) {  // empty tile
+      return;
+    }
+
+    const int extent_m = min(CTA_M, M - offset_m);
+    const int extent_n = min(CTA_N, N - offset_n);
+
+    // Is 8 enough?
+    __align__(8) FragC frag_C{};
+
+    int tile_iter = tile.k_iters[1];
+
+    const int g = tile.group_id;
+
+    const auto mat_A = resolve_op<OperandA>(param.a, g);
+    const auto mat_B = resolve_op<OperandB>(param.b, g);
+    const auto mat_U = resolve_op<OperandU>(param.u, g);
+    const auto mat_V = resolve_op<OperandV>(param.v, g);
+
+    typename OperandA::GmemIter gmem_A{
+        mat_A, {offset_m, offset_k}, {extent_m, CTA_K}};
+    typename OperandB::GmemIter gmem_B{
+        mat_B, {offset_n, offset_k}, {extent_n, CTA_K}};
+
+    const int2 offset_U{offset_m, cdiv(offset_k, kGSizeU)},
+        extent_U{extent_m, cdiv(CTA_K, kGSizeU)};
+    typename OperandU::GmemIter gmem_U{mat_U, offset_U, extent_U};
+
+    const int2 offset_V{offset_n, cdiv(offset_k, kGSizeV)},
+        extent_V{extent_n, cdiv(CTA_K, kGSizeV)};
+    typename OperandV::GmemIter gmem_V{mat_V, offset_V, extent_V};
+
+    Mainloop mainloop{};
+    mainloop(gmem_A, gmem_B, gmem_U, gmem_V, frag_C, tile_iter,
+             storage.mainloop);
+
+    {
+      sched.init(tile, storage.sched, std::true_type{});
+
+      const auto [M, N, K] = tile.shape.__a;
+
+      int4 tile_offset{tile.tile_id[0], tile.tile_id[1], tile.tile_id[2],
+                       tile.group_id};
+
+      const int2 extents = {min(CTA_M, M - tile_offset.x * CTA_M),
+                            min(CTA_N, N - tile_offset.y * CTA_N)};
+
+      const bool is_last = (tile.k_iters[0] + tile.k_iters[1]) * CTA_K == K;
+
+      Epilogue epilogue{};
+      epilogue(frag_C,  //
+               tile_offset, extents, sched.tiles_[2], tile.linear_tile_id,
+               is_last, epi_param, storage.epilogue);
+    }
+  }
 };
 
 extern __shared__ char smem_buf[];
 
-__device__ __forceinline__ bool TryRunTileAllReduceReducerCta(const EpilogueParam& epi_param)
-{
-    if (!epi_param.tile_allreduce) {
-        return false;
-    }
+__device__ __forceinline__ bool TryRunTileAllReduceReducerCta(
+    const EpilogueParam& epi_param) {
+  if (!epi_param.tile_allreduce) {
+    return false;
+  }
 
-    const auto& tile_ar = epi_param.tile_allreduce_param;
-    if (tile_ar.kernel_reducer_blocks <= 0) {
-        return false;
-    }
-    if ((int)blockIdx.z != tile_ar.producer_grid_z) {
-        return false;
-    }
+  const auto& tile_ar = epi_param.tile_allreduce_param;
+  if (tile_ar.kernel_reducer_blocks <= 0) {
+    return false;
+  }
+  if ((int)blockIdx.z != tile_ar.producer_grid_z) {
+    return false;
+  }
 
-    if (tile_ar.world_size != 2 || tile_ar.rank_data == nullptr || tile_ar.output == nullptr ||
-        tile_ar.self_signal == nullptr || tile_ar.tile_numel <= 0 || tile_ar.output_numel <= 0 ||
-        (tile_ar.tile_numel & 1) || (tile_ar.output_numel & 1) || tile_ar.producer_grid_x <= 0 ||
-        tile_ar.producer_grid_y <= 0) {
-        return true;
-    }
-
-    const int reducer_id = (int)blockIdx.y * tile_ar.producer_grid_x + (int)blockIdx.x;
-    if (reducer_id >= tile_ar.kernel_reducer_blocks) {
-        return true;
-    }
-
-    const int tile_count = (tile_ar.output_numel + tile_ar.tile_numel - 1) / tile_ar.tile_numel;
-    if (tile_count <= 0 || tile_count > vllm::sm70_tile_runtime::kMaxBlocks) {
-        return true;
-    }
-
-    const int tid = threadIdx.x;
-    auto* self_signal = reinterpret_cast<vllm::sm70_tile_runtime::Signal*>(tile_ar.self_signal);
-    const auto rank_data =
-        *reinterpret_cast<const vllm::sm70_tile_runtime::RankData*>(tile_ar.rank_data);
-    const auto* rank0 = reinterpret_cast<const half2*>(rank_data.ptrs[0]);
-    const auto* rank1 = reinterpret_cast<const half2*>(rank_data.ptrs[1]);
-    auto* output      = reinterpret_cast<half2*>(tile_ar.output);
-
-    for (int tile_id = reducer_id; tile_id < tile_count; tile_id += tile_ar.kernel_reducer_blocks) {
-        const int elem_begin = tile_id * tile_ar.tile_numel;
-        const int elem_end   = min(elem_begin + tile_ar.tile_numel, tile_ar.output_numel);
-        const int h2_begin   = elem_begin / 2;
-        const int h2_end     = elem_end / 2;
-        const auto flag      = self_signal->_flag[tile_id] + 1;
-
-        if (tid < tile_ar.world_size) {
-            auto* self_flag = &self_signal->start[tile_id][tid];
-            while (vllm::sm70_tile_runtime::load_flag_sys_visible(self_flag) != flag) {
-            }
-        }
-
-        __syncthreads();
-
-        for (int idx = h2_begin + tid; idx < h2_end; idx += blockDim.x) {
-            output[idx] = __hadd2(rank0[idx], rank1[idx]);
-        }
-
-        __syncthreads();
-        if (tid == 0) {
-            self_signal->_flag[tile_id] = flag;
-        }
-    }
-
+  if (tile_ar.world_size != 2 || tile_ar.rank_data == nullptr ||
+      tile_ar.output == nullptr || tile_ar.self_signal == nullptr ||
+      tile_ar.tile_numel <= 0 || tile_ar.output_numel <= 0 ||
+      (tile_ar.tile_numel & 1) || (tile_ar.output_numel & 1) ||
+      tile_ar.producer_grid_x <= 0 || tile_ar.producer_grid_y <= 0) {
     return true;
+  }
+
+  const int reducer_id =
+      (int)blockIdx.y * tile_ar.producer_grid_x + (int)blockIdx.x;
+  if (reducer_id >= tile_ar.kernel_reducer_blocks) {
+    return true;
+  }
+
+  const int tile_count =
+      (tile_ar.output_numel + tile_ar.tile_numel - 1) / tile_ar.tile_numel;
+  if (tile_count <= 0 || tile_count > vllm::sm70_tile_runtime::kMaxBlocks) {
+    return true;
+  }
+
+  const int tid = threadIdx.x;
+  auto* self_signal =
+      reinterpret_cast<vllm::sm70_tile_runtime::Signal*>(tile_ar.self_signal);
+  const auto rank_data =
+      *reinterpret_cast<const vllm::sm70_tile_runtime::RankData*>(
+          tile_ar.rank_data);
+  const auto* rank0 = reinterpret_cast<const half2*>(rank_data.ptrs[0]);
+  const auto* rank1 = reinterpret_cast<const half2*>(rank_data.ptrs[1]);
+  auto* output = reinterpret_cast<half2*>(tile_ar.output);
+
+  for (int tile_id = reducer_id; tile_id < tile_count;
+       tile_id += tile_ar.kernel_reducer_blocks) {
+    const int elem_begin = tile_id * tile_ar.tile_numel;
+    const int elem_end =
+        min(elem_begin + tile_ar.tile_numel, tile_ar.output_numel);
+    const int h2_begin = elem_begin / 2;
+    const int h2_end = elem_end / 2;
+    const auto flag = self_signal->_flag[tile_id] + 1;
+
+    if (tid < tile_ar.world_size) {
+      auto* self_flag = &self_signal->start[tile_id][tid];
+      while (vllm::sm70_tile_runtime::load_flag_sys_visible(self_flag) !=
+             flag) {
+      }
+    }
+
+    __syncthreads();
+
+    for (int idx = h2_begin + tid; idx < h2_end; idx += blockDim.x) {
+      output[idx] = __hadd2(rank0[idx], rank1[idx]);
+    }
+
+    __syncthreads();
+    if (tid == 0) {
+      self_signal->_flag[tile_id] = flag;
+    }
+  }
+
+  return true;
 }
 
-template<class Kernel, class Param, class EpilogueParam, class Scheduler>
-__global__ void gemm_kernel(Param param, EpilogueParam epi_param, Scheduler sched)
-{
+template <class Kernel, class Param, class EpilogueParam, class Scheduler>
+__global__ void gemm_kernel(Param param, EpilogueParam epi_param,
+                            Scheduler sched) {
 #if __CUDA_ARCH__
-    if constexpr (Kernel::Arch::is_compatible(__CUDA_ARCH__)) {
-        if (TryRunTileAllReduceReducerCta(epi_param)) {
-            return;
-        }
-        Kernel kernel;
-        kernel(param, epi_param, sched, smem_buf);
+  if constexpr (Kernel::Arch::is_compatible(__CUDA_ARCH__)) {
+    if (TryRunTileAllReduceReducerCta(epi_param)) {
+      return;
     }
+    Kernel kernel;
+    kernel(param, epi_param, sched, smem_buf);
+  }
 #endif
 }
 

--- a/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/gemm_universal_sm90.h
+++ b/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/gemm_universal_sm90.h
@@ -29,504 +29,509 @@ namespace turbomind::gemm {
 
 namespace GMMA = cute::SM90::GMMA;
 
-inline __device__ cute::GmmaDescriptor make_smem_desc(void* smem_ptr, int layout_type)
-{
-    auto uint_ptr = cast_smem_ptr_to_uint(smem_ptr);
+inline __device__ cute::GmmaDescriptor make_smem_desc(void* smem_ptr,
+                                                      int layout_type) {
+  auto uint_ptr = cast_smem_ptr_to_uint(smem_ptr);
 
-    cute::GmmaDescriptor desc{};
-    desc.bitfield.start_address_       = uint_ptr >> 4;
-    desc.bitfield.layout_type_         = layout_type;
-    desc.bitfield.leading_byte_offset_ = 0;
-    desc.bitfield.stride_byte_offset_  = 1024 >> 4;
-    desc.bitfield.base_offset_         = 0;
+  cute::GmmaDescriptor desc{};
+  desc.bitfield.start_address_ = uint_ptr >> 4;
+  desc.bitfield.layout_type_ = layout_type;
+  desc.bitfield.leading_byte_offset_ = 0;
+  desc.bitfield.stride_byte_offset_ = 1024 >> 4;
+  desc.bitfield.base_offset_ = 0;
 
-    return desc;
+  return desc;
 }
 
-template<int Stages, int Step>
+template <int Stages, int Step>
 struct SmemDescIterV2 {
-    union {
-        uint32_t u32_[2];
-        uint64_t u64_;
-    };
+  union {
+    uint32_t u32_[2];
+    uint64_t u64_;
+  };
 
-    uint32_t base_;
+  uint32_t base_;
 
-    __device__ SmemDescIterV2(uint64_t desc): u64_{desc}, base_{u32_[0]} {}
+  __device__ SmemDescIterV2(uint64_t desc) : u64_{desc}, base_{u32_[0]} {}
 
-    __device__ void Advance(int stage)
-    {
-        u32_[0] += Step;
-        if (stage == Stages - 1) {
-            u32_[0] = base_;
-        }
+  __device__ void Advance(int stage) {
+    u32_[0] += Step;
+    if (stage == Stages - 1) {
+      u32_[0] = base_;
     }
+  }
 
-    __device__ SmemDescIterV2& operator+=(int offset)
-    {
-        u32_[0] += offset;
-        return *this;
-    }
+  __device__ SmemDescIterV2& operator+=(int offset) {
+    u32_[0] += offset;
+    return *this;
+  }
 
-    __device__ SmemDescIterV2& operator-=(int offset)
-    {
-        u32_[0] -= offset;
-        return *this;
-    }
+  __device__ SmemDescIterV2& operator-=(int offset) {
+    u32_[0] -= offset;
+    return *this;
+  }
 
-    __device__ operator uint64_t()
-    {
-        return u64_;
-    }
+  __device__ operator uint64_t() { return u64_; }
 };
 
-template<class MMA_Atom, size_t... Is>
-inline __device__ void
-wgmma_impl(uint64_t desc_a, uint64_t desc_b, float* frag_C, bool clear, std::index_sequence<Is...>)
-{
-    return MMA_Atom::fma(desc_a, desc_b, frag_C[Is]..., clear ? GMMA::ScaleOut::Zero : GMMA::ScaleOut::One);
+template <class MMA_Atom, size_t... Is>
+inline __device__ void wgmma_impl(uint64_t desc_a, uint64_t desc_b,
+                                  float* frag_C, bool clear,
+                                  std::index_sequence<Is...>) {
+  return MMA_Atom::fma(desc_a, desc_b, frag_C[Is]...,
+                       clear ? GMMA::ScaleOut::Zero : GMMA::ScaleOut::One);
 }
 
-template<class MMA_Atom, int N>
-inline __device__ void wgmma(uint64_t desc_a, uint64_t desc_b, float (&frag_C)[N], bool clear)
-{
-    return wgmma_impl<MMA_Atom>(desc_a, desc_b, frag_C, clear, std::make_index_sequence<N>{});
+template <class MMA_Atom, int N>
+inline __device__ void wgmma(uint64_t desc_a, uint64_t desc_b,
+                             float (&frag_C)[N], bool clear) {
+  return wgmma_impl<MMA_Atom>(desc_a, desc_b, frag_C, clear,
+                              std::make_index_sequence<N>{});
 }
 
-inline __device__ void warpgroup_fence_operand(float& reg)
-{
-    asm volatile("" : "+f"(reg)::"memory");
+inline __device__ void warpgroup_fence_operand(float& reg) {
+  asm volatile("" : "+f"(reg)::"memory");
 }
 
-template<int M, int N, int K>
-inline __device__ void warpgroup_fence_operand(float (&x)[M][N][K])
-{
+template <int M, int N, int K>
+inline __device__ void warpgroup_fence_operand(float (&x)[M][N][K]) {
+  PRAGMA_UNROLL
+  for (int m = 0; m < M; ++m) {
     PRAGMA_UNROLL
-    for (int m = 0; m < M; ++m) {
-        PRAGMA_UNROLL
-        for (int n = 0; n < N; ++n) {
-            PRAGMA_UNROLL
-            for (int k = 0; k < K; ++k) {
-                warpgroup_fence_operand(x[m][n][k]);
-            }
-        }
+    for (int n = 0; n < N; ++n) {
+      PRAGMA_UNROLL
+      for (int k = 0; k < K; ++k) {
+        warpgroup_fence_operand(x[m][n][k]);
+      }
     }
+  }
 }
 
-template<class Arch_>
+template <class Arch_>
 struct GemmUniversalSm90 {
+  // using MMA_Atom = GMMA::MMA_64x128x16_F32BF16BF16_SS<GMMA::Major::K,
+  // GMMA::Major::K>;
+  using MMA_Atom = GMMA::MMA_64x112x32_F32E4M3E4M3_SS_TN<>;
+  static constexpr typename cute::MMA_Traits<MMA_Atom>::Shape_MNK MMA_Shape{};
 
-    // using MMA_Atom = GMMA::MMA_64x128x16_F32BF16BF16_SS<GMMA::Major::K, GMMA::Major::K>;
-    using MMA_Atom = GMMA::MMA_64x112x32_F32E4M3E4M3_SS_TN<>;
-    static constexpr typename cute::MMA_Traits<MMA_Atom>::Shape_MNK MMA_Shape{};
+  static constexpr int MMA_ATOM_M = cute::get<0>(MMA_Shape);
+  static constexpr int MMA_ATOM_N = cute::get<1>(MMA_Shape);
+  static constexpr int MMA_ATOM_K = cute::get<2>(MMA_Shape);
 
-    static constexpr int MMA_ATOM_M = cute::get<0>(MMA_Shape);
-    static constexpr int MMA_ATOM_N = cute::get<1>(MMA_Shape);
-    static constexpr int MMA_ATOM_K = cute::get<2>(MMA_Shape);
+  static constexpr int kWorkGroupM = 1;
+  static constexpr int kWorkGroupN = 2;
 
-    static constexpr int kWorkGroupM = 1;
-    static constexpr int kWorkGroupN = 2;
+  static constexpr int CTA_M = 128;
+  static constexpr int CTA_N = MMA_ATOM_N * kWorkGroupN;
+  static constexpr int CTA_K = 128;
 
-    static constexpr int CTA_M = 128;
-    static constexpr int CTA_N = MMA_ATOM_N * kWorkGroupN;
-    static constexpr int CTA_K = 128;
+  static constexpr int WARPGORUPS = kWorkGroupM * kWorkGroupN;
 
-    static constexpr int WARPGORUPS = kWorkGroupM * kWorkGroupN;
+  static constexpr int MMA_M = MMA_ATOM_M * kWorkGroupM;
+  static constexpr int MMA_N = MMA_ATOM_N * kWorkGroupN;
+  static constexpr int MMA_K = MMA_ATOM_K;
 
-    static constexpr int MMA_M = MMA_ATOM_M * kWorkGroupM;
-    static constexpr int MMA_N = MMA_ATOM_N * kWorkGroupN;
-    static constexpr int MMA_K = MMA_ATOM_K;
+  static constexpr int MMA_ITER_M = CTA_M / MMA_M;  // 2
+  static constexpr int MMA_ITER_N = CTA_N / MMA_N;  // 1
+  static constexpr int MMA_ITER_K = CTA_K / MMA_K;  // 4
 
-    static constexpr int MMA_ITER_M = CTA_M / MMA_M;  // 2
-    static constexpr int MMA_ITER_N = CTA_N / MMA_N;  // 1
-    static constexpr int MMA_ITER_K = CTA_K / MMA_K;  // 4
+  static constexpr int kMulticastA = 1;
+  static constexpr int kMulticastB = 2;
 
-    static constexpr int kMulticastA = 1;
-    static constexpr int kMulticastB = 2;
+  static constexpr int kClusterSize = kMulticastA * kMulticastB;
 
-    static constexpr int kClusterSize = kMulticastA * kMulticastB;
+  static constexpr int Stages = 3;
 
-    static constexpr int Stages = 3;
+  static constexpr bool kSplitK = false;
+  static constexpr int kChunkSizeK = CTA_K;
 
-    static constexpr bool kSplitK     = false;
-    static constexpr int  kChunkSizeK = CTA_K;
+  static constexpr int WARPGROUP_SIZE = 128;
 
-    static constexpr int WARPGROUP_SIZE = 128;
+  static constexpr int CTA_SIZE = WARPGROUP_SIZE * (WARPGORUPS + 1);
 
-    static constexpr int CTA_SIZE = WARPGROUP_SIZE * (WARPGORUPS + 1);
+  using Ta = __nv_fp8_e4m3;
+  using Tb = __nv_fp8_e4m3;
+  using Tc = nv_bfloat16;
 
-    using Ta = __nv_fp8_e4m3;
-    using Tb = __nv_fp8_e4m3;
-    using Tc = nv_bfloat16;
+  using Tu = float;
+  using Tv = float;
 
-    using Tu = float;
-    using Tv = float;
+  using Arch = Arch_;
+  using Scheduler = TileScheduler<kRowMajor, kMulticastB, kMulticastA>;
 
-    using Arch      = Arch_;
-    using Scheduler = TileScheduler<kRowMajor, kMulticastB, kMulticastA>;
+  using ProducerBar = cutlass::arch::ClusterTransactionBarrier;
+  using ConsumerBar = cutlass::arch::ClusterBarrier;
 
-    using ProducerBar = cutlass::arch::ClusterTransactionBarrier;
-    using ConsumerBar = cutlass::arch::ClusterBarrier;
+  static constexpr int CTA_M_U = cdiv(CTA_M, 128);
+  static constexpr int CTA_K_U = cdiv(CTA_K, 128);
+  static constexpr int CTA_K_V = cdiv(CTA_K, 128);
+  static constexpr int CTA_N_V = cdiv(CTA_N, 1);
 
-    static constexpr int CTA_M_U = cdiv(CTA_M, 128);
-    static constexpr int CTA_K_U = cdiv(CTA_K, 128);
-    static constexpr int CTA_K_V = cdiv(CTA_K, 128);
-    static constexpr int CTA_N_V = cdiv(CTA_N, 1);
+  static constexpr int kTmaTxBytes = sizeof(Ta) * (CTA_M * CTA_K) +
+                                     sizeof(Tb) * (CTA_K * CTA_N) +
+                                     sizeof(Tv) * CTA_N_V * CTA_K_V;
 
-    static constexpr int kTmaTxBytes =
-        sizeof(Ta) * (CTA_M * CTA_K) + sizeof(Tb) * (CTA_K * CTA_N) + sizeof(Tv) * CTA_N_V * CTA_K_V;
-
-    struct SharedStorage {
-        struct Source {
-            __align__(128) Array<Ta, Stages * CTA_M * CTA_K> A;
-            __align__(128) Array<Tb, Stages * CTA_K * CTA_N> B;
-            __align__(128) Tu U[Stages][round_up(CTA_M_U * CTA_K_U, 32)];
-            __align__(128) Tv V[Stages][round_up(CTA_N_V * CTA_K_V, 32)];  // (k1,n256)
-        };
-        Source source;
-        __align__(128) Array<Tc, CTA_M * CTA_N> C;
-        __align__(128) float UV[WARPGORUPS][round_up(CTA_M_U * CTA_N_V, 32)];
-        __align__(128) uint64_t producer_bar[Stages];
-        __align__(128) uint64_t consumer_bar[Stages];
+  struct SharedStorage {
+    struct Source {
+      __align__(128) Array<Ta, Stages * CTA_M * CTA_K> A;
+      __align__(128) Array<Tb, Stages * CTA_K * CTA_N> B;
+      __align__(128) Tu U[Stages][round_up(CTA_M_U * CTA_K_U, 32)];
+      __align__(
+          128) Tv V[Stages][round_up(CTA_N_V * CTA_K_V, 32)];  // (k1,n256)
     };
+    Source source;
+    __align__(128) Array<Tc, CTA_M * CTA_N> C;
+    __align__(128) float UV[WARPGORUPS][round_up(CTA_M_U * CTA_N_V, 32)];
+    __align__(128) uint64_t producer_bar[Stages];
+    __align__(128) uint64_t consumer_bar[Stages];
+  };
 
-    __device__ void operator()(const CUtensorMap& tm_a,
-                               const CUtensorMap& tm_b,
-                               const CUtensorMap& tm_c,
-                               const CUtensorMap& tm_u,
-                               const CUtensorMap& tm_v,
-                               const void*        U_,
-                               int                ldU,
-                               const void*        V_,
-                               int                ldV,
-                               Scheduler          sched,
-                               char*              smem_buf)
-    {
-        sched.grid_init();
+  __device__ void operator()(const CUtensorMap& tm_a, const CUtensorMap& tm_b,
+                             const CUtensorMap& tm_c, const CUtensorMap& tm_u,
+                             const CUtensorMap& tm_v, const void* U_, int ldU,
+                             const void* V_, int ldV, Scheduler sched,
+                             char* smem_buf) {
+    sched.grid_init();
 
-        SharedStorage& storage = *reinterpret_cast<SharedStorage*>(smem_buf);
+    SharedStorage& storage = *reinterpret_cast<SharedStorage*>(smem_buf);
 
-        uint64_t* producer_bar = storage.producer_bar;
-        uint64_t* consumer_bar = storage.consumer_bar;
+    uint64_t* producer_bar = storage.producer_bar;
+    uint64_t* consumer_bar = storage.consumer_bar;
+
+    if (threadIdx.x == 0) {
+      PRAGMA_UNROLL
+      for (int s = 0; s < Stages; ++s) {
+        ProducerBar::init(&producer_bar[s], 1);
+        ConsumerBar::init(&consumer_bar[s], kClusterSize * WARPGORUPS);
+      }
+      cutlass::arch::fence_view_async_shared();
+      if constexpr (kClusterSize > 1) {
+        cutlass::arch::fence_barrier_init();
+      }
+    }
+
+    (kClusterSize > 1) ? cute::cluster_sync() : __syncthreads();
+
+    const int warpgroup_id = cutlass::canonical_warp_group_idx();
+
+    if (warpgroup_id == WARPGORUPS) {
+      cutlass::arch::warpgroup_reg_dealloc<32>();
+
+      static_assert(CTA_M % kMulticastA == 0);
+      static_assert(CTA_N % kMulticastB == 0);
+
+      const int cta_id = cute::block_id_in_cluster().x;
+
+      const int mc_offset_m =
+          kMulticastA > 1 ? cta_id * (CTA_M / kMulticastA) : 0;
+      const int mc_offset_n =
+          kMulticastB > 1 ? cta_id * (CTA_N / kMulticastB) : 0;
+
+      auto smem_A = storage.source.A.data() + mc_offset_m * CTA_K;
+      auto smem_B = storage.source.B.data() + mc_offset_n * CTA_K;
+      auto& smem_U = storage.source.U;
+      auto& smem_V = storage.source.V;
+
+      if (threadIdx.x == WARPGORUPS * WARPGROUP_SIZE) {
+        cutlass::PipelineState<Stages> write_state{0, 1, 0};
+        while (sched.next()) {
+          auto [valid_cta_tile_p, cluster_tile_p] = sched.is_valid_tile();
+
+          if (!cluster_tile_p) {
+            // OOB tile caused by swizzle pattern
+            continue;
+          }
+
+          const auto tile_offset = sched.tile_offset();
+          const auto [iter_k_beg, iter_k_end] = sched.iter_k_range();
+
+          const int offset_m = tile_offset.x * CTA_M;
+          const int offset_n = tile_offset.y * CTA_N;
+          const int offset_k = 0 * CTA_K;
+
+          int k_iter = iter_k_end - iter_k_beg;
+
+          GmemIteratorSm90<kMulticastA> gmem_A{
+              &tm_a, {offset_k, offset_m + mc_offset_m}, {CTA_K, 0}};
+          GmemIteratorSm90<kMulticastB> gmem_B{
+              &tm_b, {offset_k, offset_n + mc_offset_n}, {CTA_K, 0}};
+
+          // column-major
+          GmemIteratorSm90<false> gmem_V{
+              &tm_v, {offset_n, offset_k / 128}, {0, 1}};
+
+          // auto gmem_U = (const Tu*)U_ + (offset_m / 128) * ldU + (offset_k /
+          // 128); auto step_U = 1;
+
+          // auto gmem_V = (const Tv*)V_ + offset_n + (offset_k / 128) * ldV;
+          // auto step_V = ldV;
+
+          while (k_iter > 0) {
+            int pipe = write_state.index();
+            ConsumerBar::wait(&consumer_bar[pipe], write_state.phase());
+            ProducerBar::arrive_and_expect_tx(&producer_bar[pipe], kTmaTxBytes);
+            gmem_A.Load(&producer_bar[pipe], &smem_A[pipe * CTA_M * CTA_K]);
+            // {
+            //     // printf("%f\n", *gmem_U);
+            // smem_U[pipe][0] = *gmem_U;
+            // gmem_U += step_U;
+            // }
+            gmem_B.Load(&producer_bar[pipe], &smem_B[pipe * CTA_N * CTA_K]);
+            gmem_V.Load(&producer_bar[pipe], &smem_V[pipe][0]);
+
+            ++write_state;
+            --k_iter;
+          }
+        }
+      }
+    } else {
+      cutlass::arch::warpgroup_reg_alloc<232>();
+
+      auto& smem_A = storage.source.A;
+      auto& smem_B = storage.source.B;
+      auto& smem_U = storage.source.U;
+      auto& smem_V = storage.source.V;
+      auto& smem_UV = storage.UV[warpgroup_id];
+
+      const int warp_group_id_m = warpgroup_id % kWorkGroupM;
+      const int warp_group_id_n = warpgroup_id / kWorkGroupM;
+
+      auto smem_desc_A =
+          make_smem_desc(&smem_A[warp_group_id_m * MMA_ATOM_M * CTA_K], 1);
+      auto smem_desc_B =
+          make_smem_desc(&smem_B[warp_group_id_n * MMA_ATOM_N * CTA_K], 1);
+
+      SmemDescIterV2<Stages, ((sizeof(Ta) * CTA_M * CTA_K) >> 4)> smem_iter_A{
+          smem_desc_A};
+      SmemDescIterV2<Stages, ((sizeof(Tb) * CTA_N * CTA_K) >> 4)> smem_iter_B{
+          smem_desc_B};
+
+      constexpr int kStepMA = (sizeof(Ta) * MMA_M * CTA_K) >> 4;
+      constexpr int kStepNB = (sizeof(Tb) * MMA_N * CTA_K) >> 4;
+      constexpr int kStepKA = (sizeof(Ta) * MMA_K) >> 4;
+      constexpr int kStepKB = (sizeof(Tb) * MMA_K) >> 4;
+
+      cutlass::PipelineState<Stages> read_state{};
+      cutlass::PipelineState<Stages> release_state{};
+
+      while (sched.next()) {
+        auto [cta_tile_p, cluster_tile_p] = sched.is_valid_tile();
+
+        if (!cluster_tile_p) {
+          // OOB tile caused by swizzle pattern
+          continue;
+        }
+
+        MMA_Atom::CRegisters frag_C[MMA_ITER_M][MMA_ITER_N];
+        MMA_Atom::CRegisters
+            accum_C[MMA_ITER_M]
+                   [MMA_ITER_N]{};  /// TODO: check the z-fill is eliminated
+
+        const auto tile_offset = sched.tile_offset();
+        const auto [iter_k_beg, iter_k_end] = sched.iter_k_range();
+
+        const int offset_m = tile_offset.x * CTA_M;
+        const int offset_n = tile_offset.y * CTA_N;
+        const int offset_k = 0;
+
+        auto gmem_U = (const Tu*)U_ + (offset_m / 128) * ldU + (offset_k / 128);
+        auto step_U = 1;
+
+        int k_iter = iter_k_end - iter_k_beg;
+
+        auto tile_gemm = [&] {
+          PRAGMA_UNROLL
+          for (int k = 0; k < MMA_ITER_K; ++k) {
+            PRAGMA_UNROLL
+            for (int m = 0; m < MMA_ITER_M; ++m) {
+              PRAGMA_UNROLL
+              for (int n = 0; n < MMA_ITER_N; ++n) {
+                wgmma<MMA_Atom>(smem_iter_A, smem_iter_B, frag_C[m][n], k == 0);
+                smem_iter_B += kStepNB;
+              }
+              smem_iter_B -= MMA_ITER_N * kStepNB;
+              smem_iter_A += kStepMA;
+            }
+            smem_iter_A += kStepKA - MMA_ITER_M * kStepMA;
+            smem_iter_B += kStepKB;
+          }
+          smem_iter_A -= MMA_ITER_K * kStepKA;
+          smem_iter_B -= MMA_ITER_K * kStepKB;
+          cute::warpgroup_commit_batch();
+
+          smem_iter_A.Advance(read_state.index());
+          smem_iter_B.Advance(read_state.index());
+        };
+
+        auto consumer_arrive = [&] {
+          if constexpr (kClusterSize > 1) {
+            ConsumerBar::arrive(&consumer_bar[release_state.index()],
+                                threadIdx.x % WARPGROUP_SIZE,
+                                threadIdx.x % WARPGROUP_SIZE < kClusterSize);
+          } else {
+            if (threadIdx.x % WARPGROUP_SIZE == 0) {
+              ConsumerBar::arrive(&consumer_bar[release_state.index()]);
+            }
+          }
+        };
+
+        if constexpr (kClusterSize > 1) {
+          if (!cta_tile_p) {
+            // other CTAs in the cluster are still alive
+            for (; k_iter > 0; --k_iter) {
+              ProducerBar::wait(&producer_bar[read_state.index()],
+                                read_state.phase());
+              consumer_arrive();
+              smem_iter_A.Advance(read_state.index());
+              smem_iter_B.Advance(read_state.index());
+              ++read_state;
+              ++release_state;
+            }
+            continue;
+          }
+        }
+
+        float scale_U{};
+        auto Load_U = [&] {
+          scale_U = *gmem_U;
+          gmem_U += step_U;
+        };
+
+        auto scale_accum = [&]() {  // cta_n = mma_iter_n * wg_n * mma_atom_n
+          // auto scale_U = smem_U[read_state.index()][0];
+
+          PRAGMA_UNROLL
+          for (int i = threadIdx.x % WARPGROUP_SIZE; i < MMA_ATOM_N;
+               i += WARPGROUP_SIZE) {
+            smem_UV[i] =
+                scale_U *
+                smem_V[read_state.index()][i + warp_group_id_n * MMA_ATOM_N];
+          }
+          cute::warpgroup_wait<0>();
+
+          const int lane_id = threadIdx.x % WARP_SIZE;
+
+          cutlass::arch::NamedBarrier(WARPGROUP_SIZE, warpgroup_id + 1).sync();
+          PRAGMA_UNROLL
+          for (int n = 0; n < MMA_ITER_N; ++n) {
+            PRAGMA_UNROLL
+            for (int c = 0; c < MMA_ATOM_N; c += 8) {
+              Array<float, 2> scale_Vs;
+              int idx = n * MMA_N + c + (lane_id & 3) * 2;
+              Load(scale_Vs, &smem_UV[idx]);
+              PRAGMA_UNROLL
+              for (int m = 0; m < MMA_ITER_M; ++m) {
+                accum_C[m][n][c / 2 + 0] +=
+                    frag_C[m][n][c / 2 + 0] * scale_Vs[0];
+                accum_C[m][n][c / 2 + 1] +=
+                    frag_C[m][n][c / 2 + 1] * scale_Vs[1];
+                accum_C[m][n][c / 2 + 2] +=
+                    frag_C[m][n][c / 2 + 2] * scale_Vs[0];
+                accum_C[m][n][c / 2 + 3] +=
+                    frag_C[m][n][c / 2 + 3] * scale_Vs[1];
+              }
+            }
+          }
+        };
+
+        Load_U();
+        ProducerBar::wait(&producer_bar[read_state.index()],
+                          read_state.phase());
+        cute::warpgroup_arrive();
+        warpgroup_fence_operand(frag_C);
+        tile_gemm();
+        warpgroup_fence_operand(frag_C);
+        scale_accum();
+        consumer_arrive();
+        --k_iter;
+        ++read_state;
+        ++release_state;
+
+        while (k_iter > 0) {
+          Load_U();
+          ProducerBar::wait(&producer_bar[read_state.index()],
+                            read_state.phase());
+          cute::warpgroup_arrive();
+          warpgroup_fence_operand(frag_C);
+          tile_gemm();
+          warpgroup_fence_operand(frag_C);
+          scale_accum();
+          consumer_arrive();
+          --k_iter;
+          ++read_state;
+          ++release_state;
+        }
 
         if (threadIdx.x == 0) {
+          cute::tma_store_wait<0>();
+        }
+
+        cutlass::arch::NamedBarrier(WARPGORUPS * WARPGROUP_SIZE).sync();
+
+        // epilogue
+        const int warp_id = threadIdx.x / WARP_SIZE;
+        const int lane_id = threadIdx.x % WARP_SIZE;
+
+        auto& smem_C = storage.C;
+
+        // (M,N):(1,M)
+        PRAGMA_UNROLL
+        for (int m = 0; m < MMA_ITER_M; ++m) {
+          PRAGMA_UNROLL
+          for (int n = 0; n < MMA_ITER_N; ++n) {
             PRAGMA_UNROLL
-            for (int s = 0; s < Stages; ++s) {
-                ProducerBar::init(&producer_bar[s], 1);
-                ConsumerBar::init(&consumer_bar[s], kClusterSize * WARPGORUPS);
-            }
-            cutlass::arch::fence_view_async_shared();
-            if constexpr (kClusterSize > 1) {
-                cutlass::arch::fence_barrier_init();
-            }
-        }
-
-        (kClusterSize > 1) ? cute::cluster_sync() : __syncthreads();
-
-        const int warpgroup_id = cutlass::canonical_warp_group_idx();
-
-        if (warpgroup_id == WARPGORUPS) {
-            cutlass::arch::warpgroup_reg_dealloc<32>();
-
-            static_assert(CTA_M % kMulticastA == 0);
-            static_assert(CTA_N % kMulticastB == 0);
-
-            const int cta_id = cute::block_id_in_cluster().x;
-
-            const int mc_offset_m = kMulticastA > 1 ? cta_id * (CTA_M / kMulticastA) : 0;
-            const int mc_offset_n = kMulticastB > 1 ? cta_id * (CTA_N / kMulticastB) : 0;
-
-            auto  smem_A = storage.source.A.data() + mc_offset_m * CTA_K;
-            auto  smem_B = storage.source.B.data() + mc_offset_n * CTA_K;
-            auto& smem_U = storage.source.U;
-            auto& smem_V = storage.source.V;
-
-            if (threadIdx.x == WARPGORUPS * WARPGROUP_SIZE) {
-                cutlass::PipelineState<Stages> write_state{0, 1, 0};
-                while (sched.next()) {
-                    auto [valid_cta_tile_p, cluster_tile_p] = sched.is_valid_tile();
-
-                    if (!cluster_tile_p) {
-                        // OOB tile caused by swizzle pattern
-                        continue;
-                    }
-
-                    const auto tile_offset              = sched.tile_offset();
-                    const auto [iter_k_beg, iter_k_end] = sched.iter_k_range();
-
-                    const int offset_m = tile_offset.x * CTA_M;
-                    const int offset_n = tile_offset.y * CTA_N;
-                    const int offset_k = 0 * CTA_K;
-
-                    int k_iter = iter_k_end - iter_k_beg;
-
-                    GmemIteratorSm90<kMulticastA> gmem_A{&tm_a, {offset_k, offset_m + mc_offset_m}, {CTA_K, 0}};
-                    GmemIteratorSm90<kMulticastB> gmem_B{&tm_b, {offset_k, offset_n + mc_offset_n}, {CTA_K, 0}};
-
-                    // column-major
-                    GmemIteratorSm90<false> gmem_V{&tm_v, {offset_n, offset_k / 128}, {0, 1}};
-
-                    // auto gmem_U = (const Tu*)U_ + (offset_m / 128) * ldU + (offset_k / 128);
-                    // auto step_U = 1;
-
-                    // auto gmem_V = (const Tv*)V_ + offset_n + (offset_k / 128) * ldV;
-                    // auto step_V = ldV;
-
-                    while (k_iter > 0) {
-                        int pipe = write_state.index();
-                        ConsumerBar::wait(&consumer_bar[pipe], write_state.phase());
-                        ProducerBar::arrive_and_expect_tx(&producer_bar[pipe], kTmaTxBytes);
-                        gmem_A.Load(&producer_bar[pipe], &smem_A[pipe * CTA_M * CTA_K]);
-                        // {
-                        //     // printf("%f\n", *gmem_U);
-                        // smem_U[pipe][0] = *gmem_U;
-                        // gmem_U += step_U;
-                        // }
-                        gmem_B.Load(&producer_bar[pipe], &smem_B[pipe * CTA_N * CTA_K]);
-                        gmem_V.Load(&producer_bar[pipe], &smem_V[pipe][0]);
-
-                        ++write_state;
-                        --k_iter;
-                    }
-                }
-            }
-        }
-        else {
-            cutlass::arch::warpgroup_reg_alloc<232>();
-
-            auto& smem_A  = storage.source.A;
-            auto& smem_B  = storage.source.B;
-            auto& smem_U  = storage.source.U;
-            auto& smem_V  = storage.source.V;
-            auto& smem_UV = storage.UV[warpgroup_id];
-
-            const int warp_group_id_m = warpgroup_id % kWorkGroupM;
-            const int warp_group_id_n = warpgroup_id / kWorkGroupM;
-
-            auto smem_desc_A = make_smem_desc(&smem_A[warp_group_id_m * MMA_ATOM_M * CTA_K], 1);
-            auto smem_desc_B = make_smem_desc(&smem_B[warp_group_id_n * MMA_ATOM_N * CTA_K], 1);
-
-            SmemDescIterV2<Stages, ((sizeof(Ta) * CTA_M * CTA_K) >> 4)> smem_iter_A{smem_desc_A};
-            SmemDescIterV2<Stages, ((sizeof(Tb) * CTA_N * CTA_K) >> 4)> smem_iter_B{smem_desc_B};
-
-            constexpr int kStepMA = (sizeof(Ta) * MMA_M * CTA_K) >> 4;
-            constexpr int kStepNB = (sizeof(Tb) * MMA_N * CTA_K) >> 4;
-            constexpr int kStepKA = (sizeof(Ta) * MMA_K) >> 4;
-            constexpr int kStepKB = (sizeof(Tb) * MMA_K) >> 4;
-
-            cutlass::PipelineState<Stages> read_state{};
-            cutlass::PipelineState<Stages> release_state{};
-
-            while (sched.next()) {
-                auto [cta_tile_p, cluster_tile_p] = sched.is_valid_tile();
-
-                if (!cluster_tile_p) {
-                    // OOB tile caused by swizzle pattern
-                    continue;
-                }
-
-                MMA_Atom::CRegisters frag_C[MMA_ITER_M][MMA_ITER_N];
-                MMA_Atom::CRegisters accum_C[MMA_ITER_M][MMA_ITER_N]{};  /// TODO: check the z-fill is eliminated
-
-                const auto tile_offset              = sched.tile_offset();
-                const auto [iter_k_beg, iter_k_end] = sched.iter_k_range();
-
-                const int offset_m = tile_offset.x * CTA_M;
-                const int offset_n = tile_offset.y * CTA_N;
-                const int offset_k = 0;
-
-                auto gmem_U = (const Tu*)U_ + (offset_m / 128) * ldU + (offset_k / 128);
-                auto step_U = 1;
-
-                int k_iter = iter_k_end - iter_k_beg;
-
-                auto tile_gemm = [&] {
-                    PRAGMA_UNROLL
-                    for (int k = 0; k < MMA_ITER_K; ++k) {
-                        PRAGMA_UNROLL
-                        for (int m = 0; m < MMA_ITER_M; ++m) {
-                            PRAGMA_UNROLL
-                            for (int n = 0; n < MMA_ITER_N; ++n) {
-                                wgmma<MMA_Atom>(smem_iter_A, smem_iter_B, frag_C[m][n], k == 0);
-                                smem_iter_B += kStepNB;
-                            }
-                            smem_iter_B -= MMA_ITER_N * kStepNB;
-                            smem_iter_A += kStepMA;
-                        }
-                        smem_iter_A += kStepKA - MMA_ITER_M * kStepMA;
-                        smem_iter_B += kStepKB;
-                    }
-                    smem_iter_A -= MMA_ITER_K * kStepKA;
-                    smem_iter_B -= MMA_ITER_K * kStepKB;
-                    cute::warpgroup_commit_batch();
-
-                    smem_iter_A.Advance(read_state.index());
-                    smem_iter_B.Advance(read_state.index());
-                };
-
-                auto consumer_arrive = [&] {
-                    if constexpr (kClusterSize > 1) {
-                        ConsumerBar::arrive(&consumer_bar[release_state.index()],
-                                            threadIdx.x % WARPGROUP_SIZE,
-                                            threadIdx.x % WARPGROUP_SIZE < kClusterSize);
-                    }
-                    else {
-                        if (threadIdx.x % WARPGROUP_SIZE == 0) {
-                            ConsumerBar::arrive(&consumer_bar[release_state.index()]);
-                        }
-                    }
-                };
-
-                if constexpr (kClusterSize > 1) {
-                    if (!cta_tile_p) {
-                        // other CTAs in the cluster are still alive
-                        for (; k_iter > 0; --k_iter) {
-                            ProducerBar::wait(&producer_bar[read_state.index()], read_state.phase());
-                            consumer_arrive();
-                            smem_iter_A.Advance(read_state.index());
-                            smem_iter_B.Advance(read_state.index());
-                            ++read_state;
-                            ++release_state;
-                        }
-                        continue;
-                    }
-                }
-
-                float scale_U{};
-                auto  Load_U = [&] {
-                    scale_U = *gmem_U;
-                    gmem_U += step_U;
-                };
-
-                auto scale_accum = [&]() {  // cta_n = mma_iter_n * wg_n * mma_atom_n
-                    // auto scale_U = smem_U[read_state.index()][0];
-
-                    PRAGMA_UNROLL
-                    for (int i = threadIdx.x % WARPGROUP_SIZE; i < MMA_ATOM_N; i += WARPGROUP_SIZE) {
-                        smem_UV[i] = scale_U * smem_V[read_state.index()][i + warp_group_id_n * MMA_ATOM_N];
-                    }
-                    cute::warpgroup_wait<0>();
-
-                    const int lane_id = threadIdx.x % WARP_SIZE;
-
-                    cutlass::arch::NamedBarrier(WARPGROUP_SIZE, warpgroup_id + 1).sync();
-                    PRAGMA_UNROLL
-                    for (int n = 0; n < MMA_ITER_N; ++n) {
-                        PRAGMA_UNROLL
-                        for (int c = 0; c < MMA_ATOM_N; c += 8) {
-                            Array<float, 2> scale_Vs;
-                            int             idx = n * MMA_N + c + (lane_id & 3) * 2;
-                            Load(scale_Vs, &smem_UV[idx]);
-                            PRAGMA_UNROLL
-                            for (int m = 0; m < MMA_ITER_M; ++m) {
-                                accum_C[m][n][c / 2 + 0] += frag_C[m][n][c / 2 + 0] * scale_Vs[0];
-                                accum_C[m][n][c / 2 + 1] += frag_C[m][n][c / 2 + 1] * scale_Vs[1];
-                                accum_C[m][n][c / 2 + 2] += frag_C[m][n][c / 2 + 2] * scale_Vs[0];
-                                accum_C[m][n][c / 2 + 3] += frag_C[m][n][c / 2 + 3] * scale_Vs[1];
-                            }
-                        }
-                    }
-                };
-
-                Load_U();
-                ProducerBar::wait(&producer_bar[read_state.index()], read_state.phase());
-                cute::warpgroup_arrive();
-                warpgroup_fence_operand(frag_C);
-                tile_gemm();
-                warpgroup_fence_operand(frag_C);
-                scale_accum();
-                consumer_arrive();
-                --k_iter;
-                ++read_state;
-                ++release_state;
-
-                while (k_iter > 0) {
-                    Load_U();
-                    ProducerBar::wait(&producer_bar[read_state.index()], read_state.phase());
-                    cute::warpgroup_arrive();
-                    warpgroup_fence_operand(frag_C);
-                    tile_gemm();
-                    warpgroup_fence_operand(frag_C);
-                    scale_accum();
-                    consumer_arrive();
-                    --k_iter;
-                    ++read_state;
-                    ++release_state;
-                }
-
-                if (threadIdx.x == 0) {
-                    cute::tma_store_wait<0>();
-                }
-
-                cutlass::arch::NamedBarrier(WARPGORUPS * WARPGROUP_SIZE).sync();
-
-                // epilogue
-                const int warp_id = threadIdx.x / WARP_SIZE;
-                const int lane_id = threadIdx.x % WARP_SIZE;
-
-                auto& smem_C = storage.C;
-
-                // (M,N):(1,M)
-                PRAGMA_UNROLL
-                for (int m = 0; m < MMA_ITER_M; ++m) {
-                    PRAGMA_UNROLL
-                    for (int n = 0; n < MMA_ITER_N; ++n) {
-                        PRAGMA_UNROLL
-                        for (int i = 0; i < MMA_ATOM_N; i += 16) {
-                            // clang-format off
+            for (int i = 0; i < MMA_ATOM_N; i += 16) {
+              // clang-format off
                             // const int mm   = m * MMA_M + warp_id * 16 + (lane_id & 8);
                             // const int nn   = n * MMA_N +     i        + (lane_id & 7) + (lane_id & 16) / 2;
                             const int mm   = m * MMA_M + (warp_id & 3) * 16 + (lane_id & 8);
                             const int nn   = n * MMA_N + warp_group_id_n * MMA_ATOM_N + i + (lane_id & 7) + (lane_id & 16) / 2;
-                            // clang-format on
-                            __align__(16) Array<Tc, 8> tvec = cast<Tc>(*(Array<float, 8>*)&accum_C[m][n][i / 2]);
-                            cute::SM90_U16x8_STSM_T::copy((uint32_t&)tvec[0],
-                                                          (uint32_t&)tvec[2],
-                                                          (uint32_t&)tvec[4],
-                                                          (uint32_t&)tvec[6],
-                                                          (cutlass::uint128_t&)smem_C[nn * CTA_M + mm]);
-                        }
-                    }
-                }
-                cute::tma_store_fence();  // visibility: smem -> async proxy
-                cutlass::arch::NamedBarrier(WARPGORUPS * WARPGROUP_SIZE).sync();
-
-                if (threadIdx.x == 0) {
-                    cute::SM90_TMA_STORE_2D::copy(&tm_c, &smem_C, offset_m, offset_n);
-                    cute::tma_store_arrive();
-                }
-            }  // scheduler loop
-
-            if (threadIdx.x == 0) {
-                cute::tma_store_wait<0>();
+              // clang-format on
+              __align__(16) Array<Tc, 8> tvec =
+                  cast<Tc>(*(Array<float, 8>*)&accum_C[m][n][i / 2]);
+              cute::SM90_U16x8_STSM_T::copy(
+                  (uint32_t&)tvec[0], (uint32_t&)tvec[2], (uint32_t&)tvec[4],
+                  (uint32_t&)tvec[6],
+                  (cutlass::uint128_t&)smem_C[nn * CTA_M + mm]);
             }
+          }
         }
+        cute::tma_store_fence();  // visibility: smem -> async proxy
+        cutlass::arch::NamedBarrier(WARPGORUPS * WARPGROUP_SIZE).sync();
 
-        cute::cluster_arrive();
-        cute::cluster_wait();
+        if (threadIdx.x == 0) {
+          cute::SM90_TMA_STORE_2D::copy(&tm_c, &smem_C, offset_m, offset_n);
+          cute::tma_store_arrive();
+        }
+      }  // scheduler loop
 
-    }  // operator()
+      if (threadIdx.x == 0) {
+        cute::tma_store_wait<0>();
+      }
+    }
+
+    cute::cluster_arrive();
+    cute::cluster_wait();
+
+  }  // operator()
 };
 
 extern __shared__ char smem_buf[];
 
-template<class Kernel>
-__global__ void __launch_bounds__(Kernel::CTA_SIZE, 1) gemm_kernel_sm90(const __grid_constant__ CUtensorMap tm_a,
-                                                                        const __grid_constant__ CUtensorMap tm_b,
-                                                                        const __grid_constant__ CUtensorMap tm_c,
-                                                                        const __grid_constant__ CUtensorMap tm_u,
-                                                                        const __grid_constant__ CUtensorMap tm_v,
-                                                                        const void*                         U_,
-                                                                        int                                 ldU,
-                                                                        const void*                         V_,
-                                                                        int                                 ldV,
-                                                                        typename Kernel::Scheduler          sched)
-{
+template <class Kernel>
+__global__ void __launch_bounds__(Kernel::CTA_SIZE, 1)
+    gemm_kernel_sm90(const __grid_constant__ CUtensorMap tm_a,
+                     const __grid_constant__ CUtensorMap tm_b,
+                     const __grid_constant__ CUtensorMap tm_c,
+                     const __grid_constant__ CUtensorMap tm_u,
+                     const __grid_constant__ CUtensorMap tm_v, const void* U_,
+                     int ldU, const void* V_, int ldV,
+                     typename Kernel::Scheduler sched) {
 #if __CUDA_ARCH__
-    if constexpr (Kernel::Arch::is_compatible(__CUDA_ARCH__)) {
-        Kernel kernel;
-        kernel(tm_a, tm_b, tm_c, tm_u, tm_v, U_, ldU, V_, ldV, sched, smem_buf);
-    }
+  if constexpr (Kernel::Arch::is_compatible(__CUDA_ARCH__)) {
+    Kernel kernel;
+    kernel(tm_a, tm_b, tm_c, tm_u, tm_v, U_, ldU, V_, ldV, sched, smem_buf);
+  }
 #endif
 }
 

--- a/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/gemm_universal_sm90_v2.h
+++ b/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/gemm_universal_sm90_v2.h
@@ -36,710 +36,694 @@ namespace turbomind::gemm {
 
 namespace GMMA = cute::SM90::GMMA;
 
-inline __device__ cute::GmmaDescriptor make_smem_desc(void* smem_ptr, int layout_type)
-{
-    auto uint_ptr = cast_smem_ptr_to_uint(smem_ptr);
+inline __device__ cute::GmmaDescriptor make_smem_desc(void* smem_ptr,
+                                                      int layout_type) {
+  auto uint_ptr = cast_smem_ptr_to_uint(smem_ptr);
 
-    cute::GmmaDescriptor desc{};
-    desc.bitfield.start_address_       = uint_ptr >> 4;
-    desc.bitfield.layout_type_         = layout_type;
-    desc.bitfield.leading_byte_offset_ = 0;
-    desc.bitfield.stride_byte_offset_  = 1024 >> 4;
-    desc.bitfield.base_offset_         = 0;
+  cute::GmmaDescriptor desc{};
+  desc.bitfield.start_address_ = uint_ptr >> 4;
+  desc.bitfield.layout_type_ = layout_type;
+  desc.bitfield.leading_byte_offset_ = 0;
+  desc.bitfield.stride_byte_offset_ = 1024 >> 4;
+  desc.bitfield.base_offset_ = 0;
 
-    return desc;
+  return desc;
 }
 
-template<int Stages, int Step>
+template <int Stages, int Step>
 struct SmemDescIterV2 {
-    union {
-        uint32_t u32_[2];
-        uint64_t u64_;
-    };
+  union {
+    uint32_t u32_[2];
+    uint64_t u64_;
+  };
 
-    uint32_t base_;
+  uint32_t base_;
 
-    __device__ SmemDescIterV2(uint64_t desc): u64_{desc}, base_{u32_[0]} {}
+  __device__ SmemDescIterV2(uint64_t desc) : u64_{desc}, base_{u32_[0]} {}
 
-    __device__ void Advance(int stage)
-    {
-        u32_[0] += Step;
-        if (stage == Stages - 1) {
-            u32_[0] = base_;
-        }
+  __device__ void Advance(int stage) {
+    u32_[0] += Step;
+    if (stage == Stages - 1) {
+      u32_[0] = base_;
     }
+  }
 
-    __device__ void Reset(int stage)
-    {
-        u32_[0] = base_ + stage * Step;
-    }
+  __device__ void Reset(int stage) { u32_[0] = base_ + stage * Step; }
 
-    __device__ SmemDescIterV2& operator+=(int offset)
-    {
-        u32_[0] += offset;
-        return *this;
-    }
+  __device__ SmemDescIterV2& operator+=(int offset) {
+    u32_[0] += offset;
+    return *this;
+  }
 
-    __device__ SmemDescIterV2& operator-=(int offset)
-    {
-        u32_[0] -= offset;
-        return *this;
-    }
+  __device__ SmemDescIterV2& operator-=(int offset) {
+    u32_[0] -= offset;
+    return *this;
+  }
 
-    __device__ operator uint64_t()
-    {
-        return u64_;
-    }
+  __device__ operator uint64_t() { return u64_; }
 };
 
-template<class MMA_Atom, size_t... Is>
-inline __device__ void
-wgmma_impl(uint64_t desc_a, uint64_t desc_b, float* frag_C, bool clear, std::index_sequence<Is...>)
-{
-    return MMA_Atom::fma(desc_a, desc_b, frag_C[Is]..., clear ? GMMA::ScaleOut::Zero : GMMA::ScaleOut::One);
+template <class MMA_Atom, size_t... Is>
+inline __device__ void wgmma_impl(uint64_t desc_a, uint64_t desc_b,
+                                  float* frag_C, bool clear,
+                                  std::index_sequence<Is...>) {
+  return MMA_Atom::fma(desc_a, desc_b, frag_C[Is]...,
+                       clear ? GMMA::ScaleOut::Zero : GMMA::ScaleOut::One);
 }
 
-template<class MMA_Atom, int N>
-inline __device__ void wgmma(uint64_t desc_a, uint64_t desc_b, float (&frag_C)[N], bool clear)
-{
-    return wgmma_impl<MMA_Atom>(desc_a, desc_b, frag_C, clear, std::make_index_sequence<N>{});
+template <class MMA_Atom, int N>
+inline __device__ void wgmma(uint64_t desc_a, uint64_t desc_b,
+                             float (&frag_C)[N], bool clear) {
+  return wgmma_impl<MMA_Atom>(desc_a, desc_b, frag_C, clear,
+                              std::make_index_sequence<N>{});
 }
 
-inline __device__ void warpgroup_fence_operand(float& reg)
-{
-    asm volatile("" : "+f"(reg)::"memory");
+inline __device__ void warpgroup_fence_operand(float& reg) {
+  asm volatile("" : "+f"(reg)::"memory");
 }
 
-template<int M, int N, int K>
-inline __device__ void warpgroup_fence_operand(float (&x)[M][N][K])
-{
-    PRAGMA_UNROLL
-    for (int m = 0; m < M; ++m) {
-        PRAGMA_UNROLL
-        for (int n = 0; n < N; ++n) {
-            PRAGMA_UNROLL
-            for (int k = 0; k < K; ++k) {
-                warpgroup_fence_operand(x[m][n][k]);
-            }
-        }
-    }
-}
-
-template<int N, int K>
-inline __device__ void warpgroup_fence_operand(float (&x)[N][K])
-{
+template <int M, int N, int K>
+inline __device__ void warpgroup_fence_operand(float (&x)[M][N][K]) {
+  PRAGMA_UNROLL
+  for (int m = 0; m < M; ++m) {
     PRAGMA_UNROLL
     for (int n = 0; n < N; ++n) {
-        PRAGMA_UNROLL
-        for (int k = 0; k < K; ++k) {
-            warpgroup_fence_operand(x[n][k]);
-        }
+      PRAGMA_UNROLL
+      for (int k = 0; k < K; ++k) {
+        warpgroup_fence_operand(x[m][n][k]);
+      }
     }
+  }
 }
 
-template<class Func, size_t... Is>
-__device__ void for_(std::index_sequence<Is...>, Func func)
-{
-    return (func(constant<Is>{}), ...);
+template <int N, int K>
+inline __device__ void warpgroup_fence_operand(float (&x)[N][K]) {
+  PRAGMA_UNROLL
+  for (int n = 0; n < N; ++n) {
+    PRAGMA_UNROLL
+    for (int k = 0; k < K; ++k) {
+      warpgroup_fence_operand(x[n][k]);
+    }
+  }
+}
+
+template <class Func, size_t... Is>
+__device__ void for_(std::index_sequence<Is...>, Func func) {
+  return (func(constant<Is>{}), ...);
 }
 
 namespace arch {
 
-template<int M_, int N_, Order order>
+template <int M_, int N_, Order order>
 struct Cluster {
-    static constexpr int M = M_;
-    static constexpr int N = N_;
+  static constexpr int M = M_;
+  static constexpr int N = N_;
 
-    static constexpr int C = mk2cs<order>(M, N).x;
-    static constexpr int S = mk2cs<order>(M, N).y;
+  static constexpr int C = mk2cs<order>(M, N).x;
+  static constexpr int S = mk2cs<order>(M, N).y;
 
-    static constexpr int size = M * N;
+  static constexpr int size = M * N;
 
-    static constexpr uint16_t kMaskC = (1 << C) - 1;
-    static constexpr uint16_t kMaskS = ((1 << size) - 1) / kMaskC;
+  static constexpr uint16_t kMaskC = (1 << C) - 1;
+  static constexpr uint16_t kMaskS = ((1 << size) - 1) / kMaskC;
 
-    __device__ static ushort2 mask_cs(int cta_id)
-    {
-        const auto [c, s] = cta_cs(cta_id);
-        return make_ushort2(kMaskS << c, kMaskC << s * C);
-    }
+  __device__ static ushort2 mask_cs(int cta_id) {
+    const auto [c, s] = cta_cs(cta_id);
+    return make_ushort2(kMaskS << c, kMaskC << s * C);
+  }
 
-    __device__ static ushort2 mask_mn(int cta_id)
-    {
-        auto [c, s] = mask_cs(cta_id);
-        return order == kColMajor ? ushort2{c, s} : ushort2{s, c};
-    }
+  __device__ static ushort2 mask_mn(int cta_id) {
+    auto [c, s] = mask_cs(cta_id);
+    return order == kColMajor ? ushort2{c, s} : ushort2{s, c};
+  }
 
-    __device__ static int2 cta_cs(int cta_id)
-    {
-        return {C > 1 ? cta_id % C : 0, S > 1 ? cta_id / C : 0};
-    }
+  __device__ static int2 cta_cs(int cta_id) {
+    return {C > 1 ? cta_id % C : 0, S > 1 ? cta_id / C : 0};
+  }
 
-    __device__ static int2 cta_mn(int cta_id)
-    {
-        return cs2mk<order>(cta_cs(cta_id));
-    }
+  __device__ static int2 cta_mn(int cta_id) {
+    return cs2mk<order>(cta_cs(cta_id));
+  }
 
-    int2    cta_mn_;
-    ushort2 mask_mn_;
+  int2 cta_mn_;
+  ushort2 mask_mn_;
 
-    __device__ explicit Cluster(int cta_id): cta_mn_(cta_mn(cta_id)), mask_mn_(mask_mn(cta_id)) {}
+  __device__ explicit Cluster(int cta_id)
+      : cta_mn_(cta_mn(cta_id)), mask_mn_(mask_mn(cta_id)) {}
 
-    __device__ int cta_m()
-    {
-        return cta_mn_.x;
-    }
+  __device__ int cta_m() { return cta_mn_.x; }
 
-    __device__ int cta_n()
-    {
-        return cta_mn_.y;
-    }
+  __device__ int cta_n() { return cta_mn_.y; }
 
-    __device__ uint16_t mask_m()
-    {
-        return mask_mn_.x;
-    }
+  __device__ uint16_t mask_m() { return mask_mn_.x; }
 
-    __device__ uint16_t mask_n()
-    {
-        return mask_mn_.y;
-    }
+  __device__ uint16_t mask_n() { return mask_mn_.y; }
 };
 
 }  // namespace arch
 
 struct GemmUniversalSm90_v2 {
+  static constexpr bool kDebug = false;
 
-    static constexpr bool kDebug = false;
+  using Arch = Sm90;
 
-    using Arch = Sm90;
+  // using MMA_Atom = GMMA::MMA_64x128x16_F32BF16BF16_SS<GMMA::Major::K,
+  // GMMA::Major::K>;
+  using MMA_Atom = GMMA::MMA_64x96x32_F32E4M3E4M3_SS_TN<>;
+  static constexpr typename cute::MMA_Traits<MMA_Atom>::Shape_MNK MMA_Shape{};
 
-    // using MMA_Atom = GMMA::MMA_64x128x16_F32BF16BF16_SS<GMMA::Major::K, GMMA::Major::K>;
-    using MMA_Atom = GMMA::MMA_64x96x32_F32E4M3E4M3_SS_TN<>;
-    static constexpr typename cute::MMA_Traits<MMA_Atom>::Shape_MNK MMA_Shape{};
+  static constexpr int MMA_ATOM_M = cute::get<0>(MMA_Shape);
+  static constexpr int MMA_ATOM_N = cute::get<1>(MMA_Shape);
+  static constexpr int MMA_ATOM_K = cute::get<2>(MMA_Shape);
 
-    static constexpr int MMA_ATOM_M = cute::get<0>(MMA_Shape);
-    static constexpr int MMA_ATOM_N = cute::get<1>(MMA_Shape);
-    static constexpr int MMA_ATOM_K = cute::get<2>(MMA_Shape);
+  static constexpr int WARPGORUPS = 2;
 
-    static constexpr int WARPGORUPS = 2;
+  static constexpr int TILE_M = 128;
+  static constexpr int TILE_N = MMA_ATOM_N;
+  static constexpr int TILE_K = 128;
 
-    static constexpr int TILE_M = 128;
-    static constexpr int TILE_N = MMA_ATOM_N;
-    static constexpr int TILE_K = 128;
+  static constexpr int MMA_ITER_M = TILE_M / MMA_ATOM_M;
+  static constexpr int MMA_ITER_N = TILE_N / MMA_ATOM_N;
+  static constexpr int MMA_ITER_K = TILE_K / MMA_ATOM_K;
 
-    static constexpr int MMA_ITER_M = TILE_M / MMA_ATOM_M;
-    static constexpr int MMA_ITER_N = TILE_N / MMA_ATOM_N;
-    static constexpr int MMA_ITER_K = TILE_K / MMA_ATOM_K;
+  static constexpr int kMulticastA = 1;
+  static constexpr int kMulticastB = 2;
 
-    static constexpr int kMulticastA = 1;
-    static constexpr int kMulticastB = 2;
+  static constexpr int kClusterSize = kMulticastA * kMulticastB;
 
-    static constexpr int kClusterSize = kMulticastA * kMulticastB;
+  static constexpr int Stages = 4;
 
-    static constexpr int Stages = 4;
+  static constexpr bool kSplitK = false;
+  static constexpr int kChunkSizeK = TILE_K;
 
-    static constexpr bool kSplitK     = false;
-    static constexpr int  kChunkSizeK = TILE_K;
+  static constexpr int WARPGROUP_SIZE = 128;
 
-    static constexpr int WARPGROUP_SIZE = 128;
+  static constexpr int CTA_SIZE = WARPGROUP_SIZE * (WARPGORUPS + 1);
 
-    static constexpr int CTA_SIZE = WARPGROUP_SIZE * (WARPGORUPS + 1);
+  using Ta = __nv_fp8_e4m3;
+  using Tb = __nv_fp8_e4m3;
+  using Tc = nv_bfloat16;
 
-    using Ta = __nv_fp8_e4m3;
-    using Tb = __nv_fp8_e4m3;
-    using Tc = nv_bfloat16;
+  using Tu = float;
+  using Tv = float;
 
-    using Tu = float;
-    using Tv = float;
+  using Cluster = arch::Cluster<kMulticastB, kMulticastA, kRowMajor>;
 
-    using Cluster = arch::Cluster<kMulticastB, kMulticastA, kRowMajor>;
+  using Scheduler = TileScheduler<kRowMajor, Cluster, false, false>;
 
-    using Scheduler = TileScheduler<kRowMajor, Cluster, false, false>;
+  using ProducerBar = cutlass::arch::ClusterTransactionBarrier;
+  using ConsumerBar = cutlass::arch::ClusterBarrier;
 
-    using ProducerBar = cutlass::arch::ClusterTransactionBarrier;
-    using ConsumerBar = cutlass::arch::ClusterBarrier;
+  static constexpr int MAX_K = 32768;
 
-    static constexpr int MAX_K = 32768;
+  static constexpr int TILE_M_U = cdiv(TILE_M, 1);
+  static constexpr int CTA_K_U = cdiv(TILE_K, 128);
 
-    static constexpr int TILE_M_U = cdiv(TILE_M, 1);
-    static constexpr int CTA_K_U  = cdiv(TILE_K, 128);
+  static constexpr int kTmaTxBytes = sizeof(Ta) * (TILE_M * TILE_K) +
+                                     sizeof(Tb) * (TILE_N * TILE_K) +
+                                     sizeof(Tu) * TILE_M_U * CTA_K_U;
 
-    static constexpr int kTmaTxBytes =
-        sizeof(Ta) * (TILE_M * TILE_K) + sizeof(Tb) * (TILE_N * TILE_K) + sizeof(Tu) * TILE_M_U * CTA_K_U;
-
-    // ! Smem addr must be SBO aligned for TMA load/store
-    struct SharedStorage {
-        struct Source {
-            __align__(1024) Array<Ta, Stages * TILE_M * TILE_K> A;
-            __align__(1024) Array<Tb, Stages * TILE_N * TILE_K> B;
-            __align__(1024) Tu U[Stages][round_up(TILE_M_U * CTA_K_U, 32)];
-            __align__(1024) Tv V[2][WARPGORUPS][cdiv(MAX_K, 128)];
-        };
-        Source source;
-        __align__(1024) Array<Tc, TILE_M * TILE_N> C;
-        __align__(128) uint64_t producer_bar[Stages];
-        __align__(128) uint64_t consumer_bar[Stages];
-        int pipe_count[WARPGORUPS];
+  // ! Smem addr must be SBO aligned for TMA load/store
+  struct SharedStorage {
+    struct Source {
+      __align__(1024) Array<Ta, Stages * TILE_M * TILE_K> A;
+      __align__(1024) Array<Tb, Stages * TILE_N * TILE_K> B;
+      __align__(1024) Tu U[Stages][round_up(TILE_M_U * CTA_K_U, 32)];
+      __align__(1024) Tv V[2][WARPGORUPS][cdiv(MAX_K, 128)];
     };
+    Source source;
+    __align__(1024) Array<Tc, TILE_M * TILE_N> C;
+    __align__(128) uint64_t producer_bar[Stages];
+    __align__(128) uint64_t consumer_bar[Stages];
+    int pipe_count[WARPGORUPS];
+  };
 
-    static constexpr int kSmemSize = sizeof(SharedStorage);
+  static constexpr int kSmemSize = sizeof(SharedStorage);
 
-    static constexpr int kSwizzleC = 2 * std::gcd(TILE_N, 128 / sizeof(Tc));
+  static constexpr int kSwizzleC = 2 * std::gcd(TILE_N, 128 / sizeof(Tc));
 
-    using LayoutC = std::conditional_t<kSwizzleC >= 32,
-                                       SmemLayoutV2<TILE_M, TILE_N, -1, kSwizzleC / sizeof(Tc)>,
-                                       SmemLayoutV2<TILE_M, TILE_N>>;
+  using LayoutC = std::conditional_t<
+      kSwizzleC >= 32, SmemLayoutV2<TILE_M, TILE_N, -1, kSwizzleC / sizeof(Tc)>,
+      SmemLayoutV2<TILE_M, TILE_N>>;
 
-    __device__ void operator()(const CUtensorMap& tm_a,
-                               const CUtensorMap& tm_b,
-                               const CUtensorMap& tm_c,
-                               const CUtensorMap& tm_u,
-                               const CUtensorMap& tm_v,
-                               const void*        U_,
-                               int                ldU,
-                               const void*        V_,
-                               int                ldV,
-                               Scheduler          sched,
-                               char*              smem_buf)
-    {
-        SharedStorage& storage = *reinterpret_cast<SharedStorage*>(smem_buf);
+  __device__ void operator()(const CUtensorMap& tm_a, const CUtensorMap& tm_b,
+                             const CUtensorMap& tm_c, const CUtensorMap& tm_u,
+                             const CUtensorMap& tm_v, const void* U_, int ldU,
+                             const void* V_, int ldV, Scheduler sched,
+                             char* smem_buf) {
+    SharedStorage& storage = *reinterpret_cast<SharedStorage*>(smem_buf);
 
-        uint64_t* producer_bar = storage.producer_bar;
-        uint64_t* consumer_bar = storage.consumer_bar;
+    uint64_t* producer_bar = storage.producer_bar;
+    uint64_t* consumer_bar = storage.consumer_bar;
 
-        if (threadIdx.x == 0) {
-            PRAGMA_UNROLL
-            for (int s = 0; s < Stages; ++s) {
-                ProducerBar::init(&producer_bar[s], 1);
-                ConsumerBar::init(&consumer_bar[s], kClusterSize * 4);
-            }
-            cutlass::arch::fence_view_async_shared();
-            if constexpr (kClusterSize > 1) {
-                cutlass::arch::fence_barrier_init();
-            }
-            PRAGMA_UNROLL
-            for (int i = 0; i < WARPGORUPS; ++i) {
-                storage.pipe_count[i] = 0;
-            }
+    if (threadIdx.x == 0) {
+      PRAGMA_UNROLL
+      for (int s = 0; s < Stages; ++s) {
+        ProducerBar::init(&producer_bar[s], 1);
+        ConsumerBar::init(&consumer_bar[s], kClusterSize * 4);
+      }
+      cutlass::arch::fence_view_async_shared();
+      if constexpr (kClusterSize > 1) {
+        cutlass::arch::fence_barrier_init();
+      }
+      PRAGMA_UNROLL
+      for (int i = 0; i < WARPGORUPS; ++i) {
+        storage.pipe_count[i] = 0;
+      }
+    }
+
+    (kClusterSize > 1) ? cute::cluster_sync() : __syncthreads();
+
+    const int warpgroup_id = cutlass::canonical_warp_group_idx();
+
+    if (warpgroup_id == WARPGORUPS) {
+      cutlass::arch::warpgroup_reg_dealloc<40>();
+
+      static_assert(TILE_M % kMulticastA == 0);
+      static_assert(TILE_N % kMulticastB == 0);
+
+      if (threadIdx.x == WARPGORUPS * WARPGROUP_SIZE) {
+        Cluster cluster(cute::block_id_in_cluster().x);
+
+        const int mc_offset_m = cluster.cta_n() * (TILE_M / kMulticastA);
+        const int mc_offset_n = cluster.cta_m() * (TILE_N / kMulticastB);
+
+        auto smem_A = storage.source.A.data() + mc_offset_m * TILE_K;
+        auto smem_B = storage.source.B.data() + mc_offset_n * TILE_K;
+        auto& smem_U = storage.source.U;
+
+        sched.grid_init();
+
+        cutlass::PipelineState<Stages> write_state{0, 1, 0};
+
+        while (sched.next()) {
+          auto [valid_cta_tile_p, cluster_tile_p] = sched.is_valid_tile();
+
+          if (!cluster_tile_p) {
+            // OOB tile caused by swizzle pattern
+            continue;
+          }
+
+          const auto tile_offset = sched.tile_offset();
+          const auto [iter_k_beg, iter_k_end] = sched.iter_k_range();
+
+          const int offset_k = iter_k_beg * TILE_K;
+
+          const uint16_t mask_A = cluster.mask_m();
+          const uint16_t mask_B = cluster.mask_n();
+
+          const int offset_m = tile_offset.x * TILE_M;
+          const int offset_n = tile_offset.y * TILE_N;
+
+          int k_iter = iter_k_end - iter_k_beg;
+
+          GmemIteratorSm90<kMulticastA> gmem_A{
+              &tm_a, {offset_k, offset_m + mc_offset_m}, {TILE_K, 0}};
+          GmemIteratorSm90<kMulticastB> gmem_B{
+              &tm_b, {offset_k, offset_n + mc_offset_n}, {TILE_K, 0}};
+
+          // column-major
+          GmemIteratorSm90<kMulticastA> gmem_U{
+              &tm_u, {offset_m + mc_offset_m, offset_k / 128}, {0, 1}};
+
+          for (; k_iter > 0; --k_iter) {
+            int pipe = write_state.index();
+            ConsumerBar::wait(&consumer_bar[pipe], write_state.phase());
+            ProducerBar::arrive_and_expect_tx(&producer_bar[pipe], kTmaTxBytes);
+            gmem_A.Load(&producer_bar[pipe], &smem_A[pipe * TILE_M * TILE_K],
+                        mask_A);
+            gmem_B.Load(&producer_bar[pipe], &smem_B[pipe * TILE_N * TILE_K],
+                        mask_B);
+            gmem_U.Load(&producer_bar[pipe], &smem_U[pipe][0] + mc_offset_m,
+                        mask_A);
+            ++write_state;
+          }
+        }
+      }
+    } else {
+      cutlass::arch::warpgroup_reg_alloc<232>();
+
+      sched.grid_init(WARPGORUPS);
+
+      auto& smem_A = storage.source.A;
+      auto& smem_B = storage.source.B;
+      auto& smem_U = storage.source.U;
+
+      auto smem_desc_A = make_smem_desc(&smem_A, 1);
+      auto smem_desc_B = make_smem_desc(&smem_B, 1);
+
+      SmemDescIterV2<Stages, ((sizeof(Ta) * TILE_M * TILE_K) >> 4)> smem_iter_A{
+          smem_desc_A};
+      SmemDescIterV2<Stages, ((sizeof(Tb) * TILE_N * TILE_K) >> 4)> smem_iter_B{
+          smem_desc_B};
+
+      constexpr int kStepMA = (sizeof(Ta) * MMA_ATOM_M * TILE_K) >> 4;
+      constexpr int kStepNB = (sizeof(Tb) * MMA_ATOM_N * TILE_K) >> 4;
+      constexpr int kStepKA = (sizeof(Ta) * MMA_ATOM_K) >> 4;
+      constexpr int kStepKB = (sizeof(Tb) * MMA_ATOM_K) >> 4;
+
+      auto math_barrier_sync = [&](int phase, int alive = 1) {
+        constexpr int base =
+            (int)cutlass::arch::ReservedNamedBarriers::FirstUserBarrier;
+        constexpr int threads = WARPGORUPS * WARPGROUP_SIZE;
+        int res;
+        asm volatile(
+            "{\n"
+            "  .reg.pred p;\n"
+            "  setp.ne.b32 p, %3, 0;\n"
+            "  barrier.cta.red.or.pred p, %1, %2, p;\n"
+            "  selp.s32 %0, 1, 0, p;\n"
+            "}\n"
+            : "=r"(res)
+            : "r"(base + warpgroup_id ^ phase), "r"(threads), "r"(alive));
+        return res;
+      };
+
+      cutlass::arch::NamedBarrier wg_barrier(WARPGROUP_SIZE,
+                                             warpgroup_id + 2);  // 2,3
+
+      sched.next(warpgroup_id);
+
+      if (warpgroup_id == 1) {
+        math_barrier_sync(1);
+      }
+
+      while (sched.next(WARPGORUPS)) {
+        auto [cta_tile_p, cluster_tile_p] = sched.is_valid_tile();
+
+        if (!cluster_tile_p) {
+          // OOB tile caused by swizzle pattern
+          continue;
         }
 
-        (kClusterSize > 1) ? cute::cluster_sync() : __syncthreads();
+        MMA_Atom::CRegisters frag_C[MMA_ITER_M][MMA_ITER_N];
+        MMA_Atom::CRegisters accum_C[MMA_ITER_M][MMA_ITER_N]{};
 
-        const int warpgroup_id = cutlass::canonical_warp_group_idx();
+        const auto tile_offset = sched.tile_offset();
+        const auto [iter_k_beg, iter_k_end] = sched.iter_k_range();
 
-        if (warpgroup_id == WARPGORUPS) {
-            cutlass::arch::warpgroup_reg_dealloc<40>();
+        const auto [M, N, K, L] = sched.gemm_shape();
 
-            static_assert(TILE_M % kMulticastA == 0);
-            static_assert(TILE_N % kMulticastB == 0);
+        const int offset_m = tile_offset.x * TILE_M;
+        const int offset_n = tile_offset.y * TILE_N;
+        const int offset_k = 0;
 
-            if (threadIdx.x == WARPGORUPS * WARPGROUP_SIZE) {
+        int k_iter = iter_k_end - iter_k_beg;
 
-                Cluster cluster(cute::block_id_in_cluster().x);
+        const int warp_id = threadIdx.x / WARP_SIZE;
+        const int lane_id = threadIdx.x % WARP_SIZE;
 
-                const int mc_offset_m = cluster.cta_n() * (TILE_M / kMulticastA);
-                const int mc_offset_n = cluster.cta_m() * (TILE_N / kMulticastB);
+        const int wg_lane = threadIdx.x % WARPGROUP_SIZE;
 
-                auto  smem_A = storage.source.A.data() + mc_offset_m * TILE_K;
-                auto  smem_B = storage.source.B.data() + mc_offset_n * TILE_K;
-                auto& smem_U = storage.source.U;
+        cutlass::PipelineState<Stages> pipe_state{};
 
-                sched.grid_init();
-
-                cutlass::PipelineState<Stages> write_state{0, 1, 0};
-
-                while (sched.next()) {
-                    auto [valid_cta_tile_p, cluster_tile_p] = sched.is_valid_tile();
-
-                    if (!cluster_tile_p) {
-                        // OOB tile caused by swizzle pattern
-                        continue;
-                    }
-
-                    const auto tile_offset              = sched.tile_offset();
-                    const auto [iter_k_beg, iter_k_end] = sched.iter_k_range();
-
-                    const int offset_k = iter_k_beg * TILE_K;
-
-                    const uint16_t mask_A = cluster.mask_m();
-                    const uint16_t mask_B = cluster.mask_n();
-
-                    const int offset_m = tile_offset.x * TILE_M;
-                    const int offset_n = tile_offset.y * TILE_N;
-
-                    int k_iter = iter_k_end - iter_k_beg;
-
-                    GmemIteratorSm90<kMulticastA> gmem_A{&tm_a, {offset_k, offset_m + mc_offset_m}, {TILE_K, 0}};
-                    GmemIteratorSm90<kMulticastB> gmem_B{&tm_b, {offset_k, offset_n + mc_offset_n}, {TILE_K, 0}};
-
-                    // column-major
-                    GmemIteratorSm90<kMulticastA> gmem_U{&tm_u, {offset_m + mc_offset_m, offset_k / 128}, {0, 1}};
-
-                    for (; k_iter > 0; --k_iter) {
-                        int pipe = write_state.index();
-                        ConsumerBar::wait(&consumer_bar[pipe], write_state.phase());
-                        ProducerBar::arrive_and_expect_tx(&producer_bar[pipe], kTmaTxBytes);
-                        gmem_A.Load(&producer_bar[pipe], &smem_A[pipe * TILE_M * TILE_K], mask_A);
-                        gmem_B.Load(&producer_bar[pipe], &smem_B[pipe * TILE_N * TILE_K], mask_B);
-                        gmem_U.Load(&producer_bar[pipe], &smem_U[pipe][0] + mc_offset_m, mask_A);
-                        ++write_state;
-                    }
-                }
+        auto consumer_arrive = [&] {
+          __syncwarp();
+          if constexpr (kClusterSize > 1) {
+            ConsumerBar::arrive(&consumer_bar[pipe_state.index()], lane_id,
+                                lane_id < kClusterSize);
+          } else {
+            if (lane_id == 0) {
+              ConsumerBar::arrive(&consumer_bar[pipe_state.index()]);
             }
+          }
+        };
+
+        if constexpr (kClusterSize > 1) {
+          if (!cta_tile_p) {  // other CTAs in the cluster are still alive
+            math_barrier_sync(0);
+            pipe_state.advance(storage.pipe_count[warpgroup_id ^ 1]);
+            for (; k_iter > 0; --k_iter) {
+              ProducerBar::wait(&producer_bar[pipe_state.index()],
+                                pipe_state.phase());
+              consumer_arrive();
+              ++pipe_state;
+            }
+            if (wg_lane == 0) {
+              storage.pipe_count[warpgroup_id] = pipe_state.count();
+            }
+            math_barrier_sync(1);
+            continue;
+          }
         }
-        else {
-            cutlass::arch::warpgroup_reg_alloc<232>();
 
-            sched.grid_init(WARPGORUPS);
+        auto Copy = [k = cdiv(K, 128)](Tv* dst, const Tv* src) {
+          for (int i = threadIdx.x % WARPGROUP_SIZE; i < k;
+               i += WARPGROUP_SIZE) {
+            dst[i] = __ldg(&src[i]);
+          }
+        };
+        auto gmem_V = (const Tv*)V_ + (offset_n / 128) * ldV + (offset_k / 128);
+        Copy(storage.source.V[0][warpgroup_id], gmem_V);
 
-            auto& smem_A = storage.source.A;
-            auto& smem_B = storage.source.B;
-            auto& smem_U = storage.source.U;
+        uint32_t pred_V{};
+        int iter_V{};
 
-            auto smem_desc_A = make_smem_desc(&smem_A, 1);
-            auto smem_desc_B = make_smem_desc(&smem_B, 1);
+        constexpr int OUTER_N = std::gcd(MMA_ATOM_N, 128);
+        if constexpr (OUTER_N != 128) {
+          static_assert(MMA_ATOM_N <= 128 + OUTER_N,
+                        "MMA inst is crossing more than 2 scale blocks");
 
-            SmemDescIterV2<Stages, ((sizeof(Ta) * TILE_M * TILE_K) >> 4)> smem_iter_A{smem_desc_A};
-            SmemDescIterV2<Stages, ((sizeof(Tb) * TILE_N * TILE_K) >> 4)> smem_iter_B{smem_desc_B};
+          constexpr uint32_t mask = (1UL << (TILE_M / OUTER_N)) - 1;
 
-            constexpr int kStepMA = (sizeof(Ta) * MMA_ATOM_M * TILE_K) >> 4;
-            constexpr int kStepNB = (sizeof(Tb) * MMA_ATOM_N * TILE_K) >> 4;
-            constexpr int kStepKA = (sizeof(Ta) * MMA_ATOM_K) >> 4;
-            constexpr int kStepKB = (sizeof(Tb) * MMA_ATOM_K) >> 4;
+          int phase = 128 - offset_n % 128;
+          pred_V = (mask << (phase / OUTER_N)) & mask;
 
-            auto math_barrier_sync = [&](int phase, int alive = 1) {
-                constexpr int base    = (int)cutlass::arch::ReservedNamedBarriers::FirstUserBarrier;
-                constexpr int threads = WARPGORUPS * WARPGROUP_SIZE;
-                int           res;
-                asm volatile("{\n"
-                             "  .reg.pred p;\n"
-                             "  setp.ne.b32 p, %3, 0;\n"
-                             "  barrier.cta.red.or.pred p, %1, %2, p;\n"
-                             "  selp.s32 %0, 1, 0, p;\n"
-                             "}\n"
-                             : "=r"(res)
-                             : "r"(base + warpgroup_id ^ phase), "r"(threads), "r"(alive));
-                return res;
-            };
+          if (pred_V && offset_n / 128 + 1 < cdiv(N, 128)) {
+            Copy(storage.source.V[1][warpgroup_id], gmem_V + ldV);
+          }
 
-            cutlass::arch::NamedBarrier wg_barrier(WARPGROUP_SIZE, warpgroup_id + 2);  // 2,3
+          // if constexpr (kWorkGroupN > 1) {
+          //     constexpr int tiles = MMA_ATOM_N / OUTER_N;
+          //     pred_V              = (pred_V >> (warp_group_id_n * tiles)) &
+          //     ((1 << tiles) - 1);
+          // }
+        }
 
-            sched.next(warpgroup_id);
+        float scale_V[2];
+        auto Load_V = [&] {
+          scale_V[0] = storage.source.V[0][warpgroup_id][iter_V];
+          if (pred_V) {
+            scale_V[1] = storage.source.V[1][warpgroup_id][iter_V];
+          }
+          ++iter_V;
+        };
 
-            if (warpgroup_id == 1) {
-                math_barrier_sync(1);
-            }
+        float scale_U[MMA_ITER_M][2];
+        const int offset_U = warp_id % 4 * 16 + lane_id / 4;
+        auto Load_U = [&] {
+          for (int m = 0; m < MMA_ITER_M; ++m) {
+            scale_U[m][0] =
+                smem_U[pipe_state.index()][offset_U + m * MMA_ATOM_M];
+            scale_U[m][1] =
+                smem_U[pipe_state.index()][offset_U + m * MMA_ATOM_M + 8];
+          }
+        };
 
-            while (sched.next(WARPGORUPS)) {
-                auto [cta_tile_p, cluster_tile_p] = sched.is_valid_tile();
-
-                if (!cluster_tile_p) {
-                    // OOB tile caused by swizzle pattern
-                    continue;
-                }
-
-                MMA_Atom::CRegisters frag_C[MMA_ITER_M][MMA_ITER_N];
-                MMA_Atom::CRegisters accum_C[MMA_ITER_M][MMA_ITER_N]{};
-
-                const auto tile_offset              = sched.tile_offset();
-                const auto [iter_k_beg, iter_k_end] = sched.iter_k_range();
-
-                const auto [M, N, K, L] = sched.gemm_shape();
-
-                const int offset_m = tile_offset.x * TILE_M;
-                const int offset_n = tile_offset.y * TILE_N;
-                const int offset_k = 0;
-
-                int k_iter = iter_k_end - iter_k_beg;
-
-                const int warp_id = threadIdx.x / WARP_SIZE;
-                const int lane_id = threadIdx.x % WARP_SIZE;
-
-                const int wg_lane = threadIdx.x % WARPGROUP_SIZE;
-
-                cutlass::PipelineState<Stages> pipe_state{};
-
-                auto consumer_arrive = [&] {
-                    __syncwarp();
-                    if constexpr (kClusterSize > 1) {
-                        ConsumerBar::arrive(&consumer_bar[pipe_state.index()], lane_id, lane_id < kClusterSize);
-                    }
-                    else {
-                        if (lane_id == 0) {
-                            ConsumerBar::arrive(&consumer_bar[pipe_state.index()]);
-                        }
-                    }
-                };
-
-                if constexpr (kClusterSize > 1) {
-                    if (!cta_tile_p) {  // other CTAs in the cluster are still alive
-                        math_barrier_sync(0);
-                        pipe_state.advance(storage.pipe_count[warpgroup_id ^ 1]);
-                        for (; k_iter > 0; --k_iter) {
-                            ProducerBar::wait(&producer_bar[pipe_state.index()], pipe_state.phase());
-                            consumer_arrive();
-                            ++pipe_state;
-                        }
-                        if (wg_lane == 0) {
-                            storage.pipe_count[warpgroup_id] = pipe_state.count();
-                        }
-                        math_barrier_sync(1);
-                        continue;
-                    }
-                }
-
-                auto Copy = [k = cdiv(K, 128)](Tv* dst, const Tv* src) {
-                    for (int i = threadIdx.x % WARPGROUP_SIZE; i < k; i += WARPGROUP_SIZE) {
-                        dst[i] = __ldg(&src[i]);
-                    }
-                };
-                auto gmem_V = (const Tv*)V_ + (offset_n / 128) * ldV + (offset_k / 128);
-                Copy(storage.source.V[0][warpgroup_id], gmem_V);
-
-                uint32_t pred_V{};
-                int      iter_V{};
-
-                constexpr int OUTER_N = std::gcd(MMA_ATOM_N, 128);
-                if constexpr (OUTER_N != 128) {
-
-                    static_assert(MMA_ATOM_N <= 128 + OUTER_N, "MMA inst is crossing more than 2 scale blocks");
-
-                    constexpr uint32_t mask = (1UL << (TILE_M / OUTER_N)) - 1;
-
-                    int phase = 128 - offset_n % 128;
-                    pred_V    = (mask << (phase / OUTER_N)) & mask;
-
-                    if (pred_V && offset_n / 128 + 1 < cdiv(N, 128)) {
-                        Copy(storage.source.V[1][warpgroup_id], gmem_V + ldV);
-                    }
-
-                    // if constexpr (kWorkGroupN > 1) {
-                    //     constexpr int tiles = MMA_ATOM_N / OUTER_N;
-                    //     pred_V              = (pred_V >> (warp_group_id_n * tiles)) & ((1 << tiles) - 1);
-                    // }
-                }
-
-                float scale_V[2];
-                auto  Load_V = [&] {
-                    scale_V[0] = storage.source.V[0][warpgroup_id][iter_V];
-                    if (pred_V) {
-                        scale_V[1] = storage.source.V[1][warpgroup_id][iter_V];
-                    }
-                    ++iter_V;
-                };
-
-                float     scale_U[MMA_ITER_M][2];
-                const int offset_U = warp_id % 4 * 16 + lane_id / 4;
-                auto      Load_U   = [&] {
-                    for (int m = 0; m < MMA_ITER_M; ++m) {
-                        scale_U[m][0] = smem_U[pipe_state.index()][offset_U + m * MMA_ATOM_M];
-                        scale_U[m][1] = smem_U[pipe_state.index()][offset_U + m * MMA_ATOM_M + 8];
-                    }
-                };
-
-                auto scale_accum = [&](int m) {  // cta_n = mma_iter_n * wg_n * mma_atom_n
-                    float scales[2][2];
-                    scales[0][0] = scale_U[m][0] * scale_V[0];
-                    scales[1][0] = scale_U[m][1] * scale_V[0];
-                    scales[0][1] = scale_U[m][0] * scale_V[1];
-                    scales[1][1] = scale_U[m][1] * scale_V[1];
-                    PRAGMA_UNROLL
-                    for (int n = 0; n < MMA_ITER_N; ++n) {
-                        PRAGMA_UNROLL
-                        for (int c0 = 0; c0 < MMA_ATOM_N; c0 += OUTER_N) {
-                            bool pred = (pred_V & (1U << (c0 / OUTER_N)));
-                            PRAGMA_UNROLL
-                            for (int cc = 0; cc < OUTER_N; cc += 8) {
-                                int c = c0 + cc;
-                                // clang-format off
+        auto scale_accum =
+            [&](int m) {  // cta_n = mma_iter_n * wg_n * mma_atom_n
+              float scales[2][2];
+              scales[0][0] = scale_U[m][0] * scale_V[0];
+              scales[1][0] = scale_U[m][1] * scale_V[0];
+              scales[0][1] = scale_U[m][0] * scale_V[1];
+              scales[1][1] = scale_U[m][1] * scale_V[1];
+              PRAGMA_UNROLL
+              for (int n = 0; n < MMA_ITER_N; ++n) {
+                PRAGMA_UNROLL
+                for (int c0 = 0; c0 < MMA_ATOM_N; c0 += OUTER_N) {
+                  bool pred = (pred_V & (1U << (c0 / OUTER_N)));
+                  PRAGMA_UNROLL
+                  for (int cc = 0; cc < OUTER_N; cc += 8) {
+                    int c = c0 + cc;
+                    // clang-format off
                                 accum_C[m][n][c / 2 + 0] += (pred ? scales[0][1] : scales[0][0]) * frag_C[m][n][c / 2 + 0];
                                 accum_C[m][n][c / 2 + 1] += (pred ? scales[0][1] : scales[0][0]) * frag_C[m][n][c / 2 + 1];
                                 accum_C[m][n][c / 2 + 2] += (pred ? scales[1][1] : scales[1][0]) * frag_C[m][n][c / 2 + 2];
                                 accum_C[m][n][c / 2 + 3] += (pred ? scales[1][1] : scales[1][0]) * frag_C[m][n][c / 2 + 3];
-                                // clang-format on
-                            }
-                        }
-                    }
-
-                };
-
-                auto gmma = [&](int m) {
-                    PRAGMA_UNROLL
-                    for (int k = 0; k < MMA_ITER_K; ++k) {
-                        PRAGMA_UNROLL
-                        for (int n = 0; n < MMA_ITER_N; ++n) {
-                            wgmma<MMA_Atom>(smem_iter_A, smem_iter_B, frag_C[m][n], k == 0);
-                            smem_iter_B += kStepNB;
-                        }
-                        smem_iter_B -= MMA_ITER_N * kStepNB;
-                        smem_iter_A += kStepKA;
-                        smem_iter_B += kStepKB;
-                    }
-                    smem_iter_A -= MMA_ITER_K * kStepKA;
-                    smem_iter_B -= MMA_ITER_K * kStepKB;
-                    smem_iter_A += kStepMA;
-                    cute::warpgroup_commit_batch();
-                };
-
-                static_assert(MMA_ITER_N == 1);
-
-                math_barrier_sync(0);
-
-                pipe_state.advance(storage.pipe_count[warpgroup_id ^ 1]);
-
-                smem_iter_A.Reset(pipe_state.index());
-                smem_iter_B.Reset(pipe_state.index());
-                Load_V();
-                ProducerBar::wait(&producer_bar[pipe_state.index()], pipe_state.phase());
-                Load_U();
-                cute::warpgroup_arrive();
-                gmma(0);
-                gmma(1);
-                cute::warpgroup_wait<1>();
-                scale_accum(0);
-                cute::warpgroup_wait<0>();
-                scale_accum(1);
-                consumer_arrive();
-                ++pipe_state;
-                --k_iter;
-
-                Load_V();
-                ProducerBar::wait(&producer_bar[pipe_state.index()], pipe_state.phase());
-                Load_U();
-                smem_iter_A.Reset(pipe_state.index());
-                smem_iter_B.Reset(pipe_state.index());
-
-                for (; k_iter > 1; --k_iter) {
-                    cute::warpgroup_arrive();
-                    gmma(0);
-                    gmma(1);
-                    cute::warpgroup_wait<1>();
-                    scale_accum(0);
-                    cute::warpgroup_wait<0>();
-                    scale_accum(1);
-                    consumer_arrive();
-                    ++pipe_state;
-                    Load_V();
-                    ProducerBar::wait(&producer_bar[pipe_state.index()], pipe_state.phase());
-                    Load_U();
-                    smem_iter_A.Reset(pipe_state.index());
-                    smem_iter_B.Reset(pipe_state.index());
+                    // clang-format on
+                  }
                 }
+              }
 
-                cute::warpgroup_arrive();
-                gmma(0);
-                gmma(1);
-                cute::warpgroup_wait<1>();
-                scale_accum(0);
-                cute::warpgroup_wait<0>();
-                scale_accum(1);
-                consumer_arrive();
-                ++pipe_state;
+            };
 
-                if (wg_lane == 0) {
-                    storage.pipe_count[warpgroup_id] = pipe_state.count();
-                }
-
-                math_barrier_sync(1);
-
-                // epilogue
-                PRAGMA_UNROLL
-                for (int m = 0; m < MMA_ITER_M; ++m) {
-                    PRAGMA_UNROLL
-                    for (int n = 0; n < MMA_ITER_N; ++n) {
-
-                        constexpr int N       = LayoutC::C0;
-                        constexpr int SW_bits = log2(kSwizzleC / 16);
-
-                        static_assert(!SW_bits || MMA_ATOM_N % LayoutC::C0 == 0);
-
-                        const int m0 = m * MMA_ATOM_M;
-                        const int n0 = n * MMA_ATOM_N;
-
-                        PRAGMA_UNROLL
-                        for (int i = 0; i < MMA_ATOM_N; i += 16) {
-                            __align__(16) Array<Tc, 8> tvec = cast<Tc>(*(Array<float, 8>*)&accum_C[m][n][i / 2]);
-
-                            int mm = m0 + warp_id % 4 * 16 + (lane_id & 8);
-                            int nn = n0 + i / N * N;
-
-                            int addr = ((nn / N) * TILE_M * N) + (mm * N) + (nn % N);
-
-                            int s = lane_id % 8;
-                            int c = (lane_id & 16) / 2 + i % N;
-
-                            addr += Swizzle<SW_bits, 3, 3>::apply(s * N + c);
-
-                            auto& uvec = (Array<uint32_t, 4>&)tvec;
-                            cute::SM90_U32x4_STSM_N::copy(
-                                uvec[0], uvec[1], uvec[2], uvec[3], (cutlass::uint128_t&)storage.C[addr]);
-                        }
-                    }
-                }
-
-                cute::tma_store_fence();  // visibility: smem -> async proxy
-
-                wg_barrier.sync();
-
-                const int wg_thread_id = threadIdx.x % WARPGROUP_SIZE;
-
-                if (wg_thread_id < LayoutC::C1) {
-                    const int tma_n = wg_thread_id * LayoutC::C0;
-                    cute::SM90_TMA_STORE::copy(
-                        &tm_c, &storage.C[wg_thread_id * TILE_M * LayoutC::C0], offset_n + tma_n, offset_m);
-                    cute::tma_store_arrive();
-                    cute::tma_store_wait<0>();
-                }
-
-                wg_barrier.sync();
-
-            }  // scheduler loop
-
-            if (warpgroup_id == 0) {
-                math_barrier_sync(0, 0);
-                while (math_barrier_sync(1, 0)) {
-                    math_barrier_sync(0, 0);
-                }
+        auto gmma = [&](int m) {
+          PRAGMA_UNROLL
+          for (int k = 0; k < MMA_ITER_K; ++k) {
+            PRAGMA_UNROLL
+            for (int n = 0; n < MMA_ITER_N; ++n) {
+              wgmma<MMA_Atom>(smem_iter_A, smem_iter_B, frag_C[m][n], k == 0);
+              smem_iter_B += kStepNB;
             }
-            else {
-                while (math_barrier_sync(0, 0)) {
-                    math_barrier_sync(1, 0);
-                }
-            }
+            smem_iter_B -= MMA_ITER_N * kStepNB;
+            smem_iter_A += kStepKA;
+            smem_iter_B += kStepKB;
+          }
+          smem_iter_A -= MMA_ITER_K * kStepKA;
+          smem_iter_B -= MMA_ITER_K * kStepKB;
+          smem_iter_A += kStepMA;
+          cute::warpgroup_commit_batch();
+        };
 
-            if (threadIdx.x % WARPGROUP_SIZE < LayoutC::C1) {
-                cute::tma_store_wait<0>();
-            }
+        static_assert(MMA_ITER_N == 1);
+
+        math_barrier_sync(0);
+
+        pipe_state.advance(storage.pipe_count[warpgroup_id ^ 1]);
+
+        smem_iter_A.Reset(pipe_state.index());
+        smem_iter_B.Reset(pipe_state.index());
+        Load_V();
+        ProducerBar::wait(&producer_bar[pipe_state.index()],
+                          pipe_state.phase());
+        Load_U();
+        cute::warpgroup_arrive();
+        gmma(0);
+        gmma(1);
+        cute::warpgroup_wait<1>();
+        scale_accum(0);
+        cute::warpgroup_wait<0>();
+        scale_accum(1);
+        consumer_arrive();
+        ++pipe_state;
+        --k_iter;
+
+        Load_V();
+        ProducerBar::wait(&producer_bar[pipe_state.index()],
+                          pipe_state.phase());
+        Load_U();
+        smem_iter_A.Reset(pipe_state.index());
+        smem_iter_B.Reset(pipe_state.index());
+
+        for (; k_iter > 1; --k_iter) {
+          cute::warpgroup_arrive();
+          gmma(0);
+          gmma(1);
+          cute::warpgroup_wait<1>();
+          scale_accum(0);
+          cute::warpgroup_wait<0>();
+          scale_accum(1);
+          consumer_arrive();
+          ++pipe_state;
+          Load_V();
+          ProducerBar::wait(&producer_bar[pipe_state.index()],
+                            pipe_state.phase());
+          Load_U();
+          smem_iter_A.Reset(pipe_state.index());
+          smem_iter_B.Reset(pipe_state.index());
         }
 
-        if constexpr (kClusterSize > 1) {
-            cute::cluster_arrive();
-            cute::cluster_wait();
+        cute::warpgroup_arrive();
+        gmma(0);
+        gmma(1);
+        cute::warpgroup_wait<1>();
+        scale_accum(0);
+        cute::warpgroup_wait<0>();
+        scale_accum(1);
+        consumer_arrive();
+        ++pipe_state;
+
+        if (wg_lane == 0) {
+          storage.pipe_count[warpgroup_id] = pipe_state.count();
         }
 
-    }  // operator()
+        math_barrier_sync(1);
+
+        // epilogue
+        PRAGMA_UNROLL
+        for (int m = 0; m < MMA_ITER_M; ++m) {
+          PRAGMA_UNROLL
+          for (int n = 0; n < MMA_ITER_N; ++n) {
+            constexpr int N = LayoutC::C0;
+            constexpr int SW_bits = log2(kSwizzleC / 16);
+
+            static_assert(!SW_bits || MMA_ATOM_N % LayoutC::C0 == 0);
+
+            const int m0 = m * MMA_ATOM_M;
+            const int n0 = n * MMA_ATOM_N;
+
+            PRAGMA_UNROLL
+            for (int i = 0; i < MMA_ATOM_N; i += 16) {
+              __align__(16) Array<Tc, 8> tvec =
+                  cast<Tc>(*(Array<float, 8>*)&accum_C[m][n][i / 2]);
+
+              int mm = m0 + warp_id % 4 * 16 + (lane_id & 8);
+              int nn = n0 + i / N * N;
+
+              int addr = ((nn / N) * TILE_M * N) + (mm * N) + (nn % N);
+
+              int s = lane_id % 8;
+              int c = (lane_id & 16) / 2 + i % N;
+
+              addr += Swizzle<SW_bits, 3, 3>::apply(s * N + c);
+
+              auto& uvec = (Array<uint32_t, 4>&)tvec;
+              cute::SM90_U32x4_STSM_N::copy(
+                  uvec[0], uvec[1], uvec[2], uvec[3],
+                  (cutlass::uint128_t&)storage.C[addr]);
+            }
+          }
+        }
+
+        cute::tma_store_fence();  // visibility: smem -> async proxy
+
+        wg_barrier.sync();
+
+        const int wg_thread_id = threadIdx.x % WARPGROUP_SIZE;
+
+        if (wg_thread_id < LayoutC::C1) {
+          const int tma_n = wg_thread_id * LayoutC::C0;
+          cute::SM90_TMA_STORE::copy(
+              &tm_c, &storage.C[wg_thread_id * TILE_M * LayoutC::C0],
+              offset_n + tma_n, offset_m);
+          cute::tma_store_arrive();
+          cute::tma_store_wait<0>();
+        }
+
+        wg_barrier.sync();
+
+      }  // scheduler loop
+
+      if (warpgroup_id == 0) {
+        math_barrier_sync(0, 0);
+        while (math_barrier_sync(1, 0)) {
+          math_barrier_sync(0, 0);
+        }
+      } else {
+        while (math_barrier_sync(0, 0)) {
+          math_barrier_sync(1, 0);
+        }
+      }
+
+      if (threadIdx.x % WARPGROUP_SIZE < LayoutC::C1) {
+        cute::tma_store_wait<0>();
+      }
+    }
+
+    if constexpr (kClusterSize > 1) {
+      cute::cluster_arrive();
+      cute::cluster_wait();
+    }
+
+  }  // operator()
 };
 
 extern __shared__ char smem_buf[];
 
-template<class Kernel>
-__global__ void __launch_bounds__(Kernel::CTA_SIZE, 1) gemm_kernel_sm90(const __grid_constant__ CUtensorMap tm_a,
-                                                                        const __grid_constant__ CUtensorMap tm_b,
-                                                                        const __grid_constant__ CUtensorMap tm_c,
-                                                                        const __grid_constant__ CUtensorMap tm_u,
-                                                                        const __grid_constant__ CUtensorMap tm_v,
-                                                                        const void*                         U_,
-                                                                        int                                 ldU,
-                                                                        const void*                         V_,
-                                                                        int                                 ldV,
-                                                                        typename Kernel::Scheduler          sched)
-{
+template <class Kernel>
+__global__ void __launch_bounds__(Kernel::CTA_SIZE, 1)
+    gemm_kernel_sm90(const __grid_constant__ CUtensorMap tm_a,
+                     const __grid_constant__ CUtensorMap tm_b,
+                     const __grid_constant__ CUtensorMap tm_c,
+                     const __grid_constant__ CUtensorMap tm_u,
+                     const __grid_constant__ CUtensorMap tm_v, const void* U_,
+                     int ldU, const void* V_, int ldV,
+                     typename Kernel::Scheduler sched) {
 #if __CUDA_ARCH__
-    if constexpr (Kernel::Arch::is_compatible(__CUDA_ARCH__)) {
-        Kernel kernel;
-        kernel(tm_a, tm_b, tm_c, tm_u, tm_v, U_, ldU, V_, ldV, sched, smem_buf);
-    }
+  if constexpr (Kernel::Arch::is_compatible(__CUDA_ARCH__)) {
+    Kernel kernel;
+    kernel(tm_a, tm_b, tm_c, tm_u, tm_v, U_, ldU, V_, ldV, sched, smem_buf);
+  }
 #endif
 }
 

--- a/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/gemm_universal_sm90_v3.h
+++ b/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/gemm_universal_sm90_v3.h
@@ -38,577 +38,588 @@
 
 namespace turbomind::gemm {
 
-template<Order raster_order, int multicast_a, int multicast_b, bool is_grouped_gemm_>
+template <Order raster_order, int multicast_a, int multicast_b,
+          bool is_grouped_gemm_>
 struct GemmUniversalSm90_v3 {
+  static constexpr bool kDebug = false;
 
-    static constexpr bool kDebug = false;
+  using Arch = Sm90;
 
-    using Arch = Sm90;
+  static constexpr int TILE_M = 128;
+  static constexpr int TILE_N = 192;
+  static constexpr int TILE_K = 128;
 
-    static constexpr int TILE_M = 128;
-    static constexpr int TILE_N = 192;
-    static constexpr int TILE_K = 128;
+  static constexpr int WG_M = 2;
+  static constexpr int WG_N = 1;
 
-    static constexpr int WG_M = 2;
-    static constexpr int WG_N = 1;
+  static constexpr int WG_TILE_M = TILE_M / WG_M;
+  static constexpr int WG_TILE_N = TILE_N / WG_N;
 
-    static constexpr int WG_TILE_M = TILE_M / WG_M;
-    static constexpr int WG_TILE_N = TILE_N / WG_N;
+  static constexpr int kSchedWarpGroups = 1;
 
-    static constexpr int kSchedWarpGroups = 1;
+  static constexpr int WARPGORUPS = WG_M * WG_N;
 
-    static constexpr int WARPGORUPS = WG_M * WG_N;
+  using GMMA = ScaledGmmaFP8_TN<WG_TILE_M, WG_TILE_N, TILE_K, 1, 1, 1, 1>;
 
-    using GMMA = ScaledGmmaFP8_TN<WG_TILE_M, WG_TILE_N, TILE_K, 1, 1, 1, 1>;
+  static constexpr int kMulticastA = multicast_a;
+  static constexpr int kMulticastB = multicast_b;
 
-    static constexpr int kMulticastA = multicast_a;
-    static constexpr int kMulticastB = multicast_b;
+  static constexpr int kClusterSize = kMulticastA * kMulticastB;
 
-    static constexpr int kClusterSize = kMulticastA * kMulticastB;
+  static constexpr int Stages = 4;
 
-    static constexpr int Stages = 4;
+  static constexpr bool kSplitK = false;
+  static constexpr int kChunkSizeK = TILE_K;
 
-    static constexpr bool kSplitK     = false;
-    static constexpr int  kChunkSizeK = TILE_K;
+  static constexpr int WARPGROUP_SIZE = 128;
 
-    static constexpr int WARPGROUP_SIZE = 128;
+  static constexpr int kMathGroupSize = WARPGROUP_SIZE * WARPGORUPS;
 
-    static constexpr int kMathGroupSize = WARPGROUP_SIZE * WARPGORUPS;
+  static constexpr int CTA_SIZE = WARPGROUP_SIZE * (WARPGORUPS + 1);
 
-    static constexpr int CTA_SIZE = WARPGROUP_SIZE * (WARPGORUPS + 1);
+  using Ta = __nv_fp8_e4m3;
+  using Tb = __nv_fp8_e4m3;
+  using Tc = nv_bfloat16;
 
-    using Ta = __nv_fp8_e4m3;
-    using Tb = __nv_fp8_e4m3;
-    using Tc = nv_bfloat16;
+  using Tu = float;
+  using Tv = float;
 
-    using Tu = float;
-    using Tv = float;
+  using Cluster = arch::Cluster<kMulticastB, kMulticastA, kRowMajor>;
 
-    using Cluster = arch::Cluster<kMulticastB, kMulticastA, kRowMajor>;
+  static constexpr auto is_grouped_gemm = is_grouped_gemm_;
 
-    static constexpr auto is_grouped_gemm = is_grouped_gemm_;
+  using Scheduler = TileScheduler<raster_order, Cluster, true, true, TILE_M,
+                                  TILE_N, Stages, is_grouped_gemm>;
 
-    using Scheduler = TileScheduler<raster_order, Cluster, true, true, TILE_M, TILE_N, Stages, is_grouped_gemm>;
+  static constexpr int kMulticastU = is_grouped_gemm ? 1 : kMulticastA;
 
-    static constexpr int kMulticastU = is_grouped_gemm ? 1 : kMulticastA;
+  using ProducerBar = cutlass::arch::ClusterTransactionBarrier;
+  using ConsumerBar = cutlass::arch::ClusterBarrier;
 
-    using ProducerBar = cutlass::arch::ClusterTransactionBarrier;
-    using ConsumerBar = cutlass::arch::ClusterBarrier;
+  static constexpr int kAlignmentU = 16 / sizeof(Tu);
+  static constexpr int kBoxU = TILE_M + (is_grouped_gemm ? kAlignmentU : 0);
 
-    static constexpr int kAlignmentU = 16 / sizeof(Tu);
-    static constexpr int kBoxU       = TILE_M + (is_grouped_gemm ? kAlignmentU : 0);
+  // Alignment requirement for SMEM addr. This forbids multicast factor 8.
+  static_assert(kMulticastU == 1 ||
+                sizeof(Tu) * kBoxU / kMulticastU % 128 == 0);
 
-    // Alignment requirement for SMEM addr. This forbids multicast factor 8.
-    static_assert(kMulticastU == 1 || sizeof(Tu) * kBoxU / kMulticastU % 128 == 0);
+  static constexpr int kTmaTxBytes = sizeof(Ta) * (TILE_M * TILE_K) +
+                                     sizeof(Tb) * (TILE_N * TILE_K) +
+                                     sizeof(Tu) * kBoxU;
 
-    static constexpr int kTmaTxBytes =
-        sizeof(Ta) * (TILE_M * TILE_K) + sizeof(Tb) * (TILE_N * TILE_K) + sizeof(Tu) * kBoxU;
+  // ! SMEM addr must be SBO aligned for TMA load/store
+  struct SharedStorage {
+    __align__(1024) Array<Ta, Stages * TILE_M * TILE_K> A;
+    __align__(1024) Array<Tb, Stages * TILE_N * TILE_K> B;
+    __align__(1024) Array<Tc, TILE_M * TILE_N> C;
+    __align__(128)
+        Tu U[Stages][round_up<int>(kBoxU, 128)];  // at least 128 byte alignment
+    __align__(128) Tv V[Stages][2];
+    __align__(128) CUtensorMap tensor_map[5];
+    __align__(8) uint64_t producer_bar[Stages];
+    __align__(8) uint64_t consumer_bar[Stages];
+    typename Scheduler::Storage sched;
+  };
 
-    // ! SMEM addr must be SBO aligned for TMA load/store
-    struct SharedStorage {
-        __align__(1024) Array<Ta, Stages * TILE_M * TILE_K> A;
-        __align__(1024) Array<Tb, Stages * TILE_N * TILE_K> B;
-        __align__(1024) Array<Tc, TILE_M * TILE_N> C;
-        __align__(128) Tu U[Stages][round_up<int>(kBoxU, 128)];  // at least 128 byte alignment
-        __align__(128) Tv V[Stages][2];
-        __align__(128) CUtensorMap tensor_map[5];
-        __align__(8) uint64_t producer_bar[Stages];
-        __align__(8) uint64_t consumer_bar[Stages];
-        typename Scheduler::Storage sched;
-    };
+  static constexpr int kSmemSize = sizeof(SharedStorage);
 
-    static constexpr int kSmemSize = sizeof(SharedStorage);
+  static constexpr int kSwizzleC = 2 * std::gcd(WG_TILE_N, 128 / sizeof(Tc));
 
-    static constexpr int kSwizzleC = 2 * std::gcd(WG_TILE_N, 128 / sizeof(Tc));
+  using LayoutC = std::conditional_t<
+      kSwizzleC >= 32,
+      SmemLayoutV2<WG_TILE_M, WG_TILE_N, -1, kSwizzleC / sizeof(Tc)>,
+      SmemLayoutV2<WG_TILE_M, WG_TILE_N>>;
 
-    using LayoutC = std::conditional_t<kSwizzleC >= 32,
-                                       SmemLayoutV2<WG_TILE_M, WG_TILE_N, -1, kSwizzleC / sizeof(Tc)>,
-                                       SmemLayoutV2<WG_TILE_M, WG_TILE_N>>;
+  static constexpr int OUTER_N = GMMA::OUTER_N;
+  static constexpr int MMA_SUBTILE_N = GMMA::OP_N / OUTER_N;
 
-    static constexpr int OUTER_N       = GMMA::OUTER_N;
-    static constexpr int MMA_SUBTILE_N = GMMA::OP_N / OUTER_N;
-
-    __device__ void operator()(const CUtensorMap& tm_a,
-                               const CUtensorMap& tm_b,
-                               const CUtensorMap& tm_c,
-                               const CUtensorMap& tm_u,
-                               const CUtensorMap& tm_v,
-                               const MatrixParam& param_A,
-                               const MatrixParam& param_B,
-                               const MatrixParam& param_U,
-                               const MatrixParam& param_V,
-                               const MatrixParam& param_C,
-                               Scheduler          sched,
-                               CUtensorMap*       tensormap_buf,
-                               char*              smem_buf)
-    {
-        SharedStorage& storage = *reinterpret_cast<SharedStorage*>(smem_buf);
-
-        uint64_t* producer_bar = storage.producer_bar;
-        uint64_t* consumer_bar = storage.consumer_bar;
-
-        if (threadIdx.x == 0) {
-            PRAGMA_UNROLL
-            for (int s = 0; s < Stages; ++s) {
-                ProducerBar::init(&producer_bar[s], 1 + 1);
-                ConsumerBar::init(&consumer_bar[s], WARPGORUPS * kClusterSize * 4);
-            }
-            sched.init_dyanmic(storage.sched, kClusterSize * (WARPGORUPS * 4 + 1));
-            cutlass::arch::fence_view_async_shared();
-            if constexpr (kClusterSize > 1) {
-                cutlass::arch::fence_barrier_init();
-            }
-        }
-
-        (kClusterSize > 1) ? cute::cluster_sync() : __syncthreads();
-
-        const int wg_idx = cutlass::canonical_warp_group_idx();
-
-        if (wg_idx == WARPGORUPS) {
-            cutlass::arch::warpgroup_reg_dealloc<40>();
-
-            static_assert(TILE_M % kMulticastA == 0);
-            static_assert(TILE_N % kMulticastB == 0);
-
-            cutlass::arch::NamedBarrier producers_bar(WARP_SIZE * 2, 7);
-
-            const int  warp_id = cutlass::canonical_warp_idx_sync();
-            const bool cta_0   = cute::block_id_in_cluster().x == 0;
-
-            if (warp_id % 4 == 0) {
-
-                Cluster cluster(cute::block_id_in_cluster().x);
-
-                const int mc_offset_m = cluster.cta_n() * (TILE_M / kMulticastA);
-                const int mc_offset_n = cluster.cta_m() * (TILE_N / kMulticastB);
-
-                auto  smem_A = storage.A.data() + mc_offset_m * TILE_K;
-                auto  smem_B = storage.B.data() + mc_offset_n * TILE_K;
-                auto& smem_U = storage.U;
-                auto& smem_V = storage.V;
-
-                if constexpr (is_grouped_gemm) {
-                    init_tma_descs<3>({&tm_a, &tm_b, &tm_u}, storage.tensor_map);
-                }
-
-                cutlass::PipelineState<Stages> write_state{0, 1, 0};
-
-                auto sched_state = sched.init_consumer(storage.sched);
-
-                int lane_predicate = cute::elect_one_sync();
-
-                typename Scheduler::Tile* tile;
-
-                while (sched_state.acquire(tile)) {
-
-                    if (tile->is_valid_cluster) {
-
-                        const CUtensorMap* Adesc = &tm_a;
-                        const CUtensorMap* Bdesc = &tm_b;
-                        const CUtensorMap* Udesc = &tm_u;
-
-                        const Tv* gmem_V0 = (const Tv*)param_V.ptr;
-                        const Tv* gmem_V1;
-
-                        if constexpr (is_grouped_gemm) {
-                            const int g  = tile->group_idx;
-                            const int m0 = tile->m0;
-                            const int m1 = tile->m1;
-                            const int m  = m1 - m0;
-
-                            Array<void*, 3> global_addrs;
-                            global_addrs[0] = (Ta*)param_A.ptr + m0 * (int64_t)param_A.stride;
-                            global_addrs[1] = ((void**)param_B.ptr)[g];
-
-                            const int beg_u = m0 / kAlignmentU * kAlignmentU;
-                            const int end_u = round_up(m1, kAlignmentU);
-                            global_addrs[2] = (Tu*)param_U.ptr + beg_u;
-
-                            Array<int, 3> dims;
-                            dims[0] = m;
-                            dims[1] = sched.gemm_shape().y;
-                            dims[2] = end_u - beg_u;
-
-                            auto descs = update_tma_descs(tensormap_buf, storage.tensor_map, global_addrs, dims);
-                            Adesc      = &descs[0];
-                            Bdesc      = &descs[1];
-                            Udesc      = &descs[2];
-
-                            gmem_V0 = ((Tv**)gmem_V0)[g];
-
-                            PRAGMA_UNROLL
-                            for (int i = 0; i < 3; ++i) {
-                                cute::tma_descriptor_fence_acquire((cute::TmaDescriptor*)&descs[i]);
-                            }
-                        }
-
-                        if (lane_predicate) {
-                            const int offset_k = 0;
-
-                            const uint16_t mask_A = cluster.mask_m();
-                            const uint16_t mask_B = cluster.mask_n();
-
-                            const int offset_m = tile->offset_m;
-                            const int offset_n = tile->offset_n;
-
-                            int k_iter = sched.k_iters_;
-
-                            GmemIteratorSm90<kMulticastA> gmem_A{
-                                Adesc, {offset_k, offset_m + mc_offset_m}, {TILE_K, 0}};
-                            GmemIteratorSm90<kMulticastB> gmem_B{
-                                Bdesc, {offset_k, offset_n + mc_offset_n}, {TILE_K, 0}};
-
-                            const int mc_offset_u = kMulticastU > 1 ? mc_offset_m : 0;
-                            // column-major
-                            GmemIteratorSm90<kMulticastU> gmem_U{
-                                Udesc, {offset_m + mc_offset_u, offset_k / 128}, {0, 1}};
-
-                            gmem_V0 += (offset_n / 128) * param_V.stride + (offset_k / 128);
-                            gmem_V1 = gmem_V0;
-                            if (offset_n / 128 + 1 < cdiv(sched.gemm_shape().y, 128)) {
-                                gmem_V1 += param_V.stride;
-                            }
-
-                            for (; k_iter > 0; --k_iter) {
-                                int pipe = write_state.index();
-                                ConsumerBar::wait(&consumer_bar[pipe], write_state.phase());
-                                ProducerBar::arrive_and_expect_tx(&producer_bar[pipe], kTmaTxBytes);
-                                gmem_A.Step(&producer_bar[pipe], &smem_A[pipe * TILE_M * TILE_K], mask_A);
-                                gmem_B.Step(&producer_bar[pipe], &smem_B[pipe * TILE_N * TILE_K], mask_B);
-                                gmem_U.Step(&producer_bar[pipe], smem_U[pipe] + mc_offset_u, mask_A);
-                                uint32_t uint_ptr_V = cast_smem_ptr_to_uint(smem_V[pipe]);
-                                CP_ASYNC<CacheOp::kAlways, 4, 0>::apply(uint_ptr_V, gmem_V0, true);
-                                CP_ASYNC<CacheOp::kAlways, 4, 0>::apply(uint_ptr_V + sizeof(Tv), gmem_V1, true);
-                                ++gmem_V0;
-                                ++gmem_V1;
-                                cutlass::arch::cpasync_barrier_arrive_noinc(&producer_bar[pipe]);
-                                ++write_state;
-                            }
-                        }
-                    }
-
-                    if constexpr (Scheduler::is_dynamic) {
-                        if (cta_0) {
-                            producers_bar.arrive_unaligned();
-                        }
-                    }
-
-                    sched_state.release();
-
-                }  // scheduler loop
-
-                // release last tile
-                sched_state.release();
-
-                if constexpr (kClusterSize > 1) {
-                    if (lane_predicate) {
-                        for (int i = 0; i < Stages; ++i) {
-                            ConsumerBar::wait(&consumer_bar[write_state.index()], write_state.phase());
-                            ++write_state;
-                        }
-                    }
-                    __syncwarp();
-                }
-            }
-            else if (warp_id % 4 == 1 && cta_0) {
-                auto state = sched.init_producer(storage.sched);
-                while (state.next()) {
-                    if constexpr (Scheduler::is_dynamic) {
-                        producers_bar.arrive_and_wait_unaligned();
-                    }
-                }
-                sched.tail(state);
-            }
-        }
-        else {
-            cutlass::arch::warpgroup_reg_alloc<232>();
-
-            if constexpr (is_grouped_gemm) {
-                if (threadIdx.x % WARPGROUP_SIZE / WARP_SIZE == 0) {
-                    init_tma_descs<1>({&tm_c}, storage.tensor_map + 3 + wg_idx);
-                }
-            }
-
-            auto& smem_A = storage.A;
-            auto& smem_B = storage.B;
-            auto& smem_U = storage.U;
-            auto& smem_V = storage.V;
-
-            const int wg_idx_m = WG_M > 1 ? wg_idx % WG_M : 0;
-            const int wg_idx_n = WG_N > 1 ? wg_idx / WG_M : 0;
-
-            auto smem_desc_A = make_smem_desc(&smem_A[wg_idx_m * WG_TILE_M * TILE_K], 1);
-            auto smem_desc_B = make_smem_desc(&smem_B[wg_idx_n * WG_TILE_N * TILE_K], 1);
-
-            SmemDescIterV2<Stages, ((TILE_M * TILE_K) >> 4)> smem_iter_A{smem_desc_A};
-            SmemDescIterV2<Stages, ((TILE_N * TILE_K) >> 4)> smem_iter_B{smem_desc_B};
-
-            cutlass::arch::NamedBarrier barrier(WARPGROUP_SIZE, 2 + wg_idx);  // 0, 1
-
-            cutlass::PipelineState<Stages> pipe_state{};
-
-            const int warp_id = cutlass::canonical_warp_idx_sync();
-            const int lane_id = cutlass::canonical_lane_idx();
-
-            auto consumer_arrive = [&] {
-                auto bar = &consumer_bar[pipe_state.index()];
-                __syncwarp();
-                if constexpr (kClusterSize > 1) {
-                    ConsumerBar::arrive(bar, lane_id, lane_id < kClusterSize);
-                }
-                else {
-                    if (lane_id == 0) {
-                        ConsumerBar::arrive(bar);
-                    }
-                }
-            };
-
-            auto sched_state = sched.init_consumer(storage.sched);
-
-            typename Scheduler::Tile* tile;
-
-            sched_state.acquire(tile);
-
-            while (tile->alive) {
-
-                if (tile->is_valid_cta) {
-                    GMMA::AccumC accum_C{};
-                    GMMA::FragC  frag_C;
-
-                    auto pred_V = Fetch_V(tile, wg_idx_n);
-
-                    float scale_V[2];
-                    auto  Load_V = [&] {
-                        scale_V[0] = smem_V[pipe_state.index()][0];
-                        scale_V[1] = smem_V[pipe_state.index()][1];
-                    };
-
-                    int offset_U = wg_idx_m * WG_TILE_M + warp_id % 4 * 16 + lane_id / 4;
-                    if constexpr (is_grouped_gemm) {
-                        offset_U += tile->m0 % kAlignmentU;
-                    }
-                    GMMA::FragU frag_U;
-                    auto        Load_U = [&] {
-                        GMMA::foreach_m(frag_U, [&](auto& U, int m) {
-                            U[0] = smem_U[pipe_state.index()][offset_U + m * GMMA::OP_M];
-                            U[1] = smem_U[pipe_state.index()][offset_U + m * GMMA::OP_M + 8];
-                        });
-                    };
-
-                    auto gmma = [&] {  //
-                        GMMA::apply(smem_iter_A, smem_iter_B, frag_C, accum_C, frag_U, scale_V, pred_V);
-                    };
-
-                    if constexpr (is_grouped_gemm) {
-                        if (threadIdx.x % WARPGROUP_SIZE < LayoutC::C1) {
-                            cute::tma_store_wait<0>();
-                        }
-                        // No need to sync here as the update is warp synchronized
-                        if (warp_id % 4 == 0) {
-                            int  m0 = tile->m0, m1 = tile->m1;
-                            auto global_addr = (Tc*)param_C.ptr + m0 * (int64_t)param_C.stride;
-                            int  idx         = 3 + wg_idx;
-                            update_tma_descs<1>(
-                                tensormap_buf + idx, storage.tensor_map + idx, {global_addr}, {m1 - m0});
-                        }
-                        barrier.sync();
-                    }
-
-                    int k_iter = sched.k_iters_;
-
-                    ProducerBar::wait(&producer_bar[pipe_state.index()], pipe_state.phase());
-                    Load_V();
-                    Load_U();
-                    smem_iter_A.Reset(pipe_state.index());
-                    smem_iter_B.Reset(pipe_state.index());
-                    gmma();
-                    consumer_arrive();
-                    ++pipe_state;
-                    --k_iter;
-
-                    ProducerBar::wait(&producer_bar[pipe_state.index()], pipe_state.phase());
-                    Load_V();
-                    Load_U();
-                    smem_iter_A.Reset(pipe_state.index());
-                    smem_iter_B.Reset(pipe_state.index());
-
-                    PRAGMA_NO_UNROLL
-                    for (; k_iter > 1; --k_iter) {
-                        gmma();
-                        consumer_arrive();
-                        ++pipe_state;
-                        ProducerBar::wait(&producer_bar[pipe_state.index()], pipe_state.phase());
-                        Load_V();
-                        Load_U();
-                        smem_iter_A.Reset(pipe_state.index());
-                        smem_iter_B.Reset(pipe_state.index());
-                    }
-
-                    gmma();
-
-                    const int thread_idx = threadIdx.x % WARPGROUP_SIZE;
-                    if constexpr (!is_grouped_gemm) {
-                        if (thread_idx < LayoutC::C1) {
-                            cute::tma_store_wait<0>();
-                        }
-                        barrier.sync();
-                    }
-
-                    consumer_arrive();
-                    ++pipe_state;
-
-                    Tc* smem_C = &storage.C[wg_idx_m * WG_TILE_M * TILE_N + wg_idx_n * WG_TILE_N];
-
-                    // epilogue
-                    GMMA::foreach_C(accum_C, [&](const auto& C, int m, int n) {
-                        constexpr int N       = LayoutC::C0;
-                        constexpr int SW_bits = log2(kSwizzleC / 16);
-
-                        static_assert(!SW_bits || GMMA::OP_N % LayoutC::C0 == 0);
-                        static_assert(GMMA::OP_N % 16 == 0);
-
-                        const int m0 = m * GMMA::OP_M;
-                        const int n0 = n * GMMA::OP_N;
-
-                        PRAGMA_UNROLL
-                        for (int i = 0; i < GMMA::OP_N; i += 16) {
-                            __align__(16) Array<Tc, 8> tvec = cast<Tc>((Array<float, 8>&)C[i / 2]);
-
-                            // fill(tvec, Tc(255));
-
-                            int mm = m0 + warp_id % 4 * 16 + (lane_id & 8);
-                            int nn = n0 + i / N * N;
-
-                            int addr = ((nn / N) * WG_TILE_M * N) + (mm * N) + (nn % N);
-
-                            int s = lane_id % 8;
-                            int c = (lane_id & 16) / 2 + i % N;
-
-                            addr += Swizzle<SW_bits, 3, 3>::apply(s * N + c);
-
-                            auto& uvec = (Array<uint32_t, 4>&)tvec;
-                            cute::SM90_U32x4_STSM_N::copy(uvec[0],  //
-                                                          uvec[1],
-                                                          uvec[2],
-                                                          uvec[3],
-                                                          (cutlass::uint128_t&)smem_C[addr]);
-                        }
-                    });
-
-                    cute::tma_store_fence();  // visibility: smem -> async proxy
-
-                    barrier.sync();
-
-                    const int offset_m = tile->offset_m;
-                    const int offset_n = tile->offset_n;
-
-                    const void* Cdesc = &tm_c;
-
-                    if (thread_idx < LayoutC::C1) {
-                        const int tma_n = thread_idx * LayoutC::C0;
-                        if constexpr (is_grouped_gemm) {
-                            Cdesc = tensormap_buf + blockIdx.x * 5 + 3 + wg_idx;
-                            cute::tma_descriptor_fence_acquire((cute::TmaDescriptor*)Cdesc);
-                        }
-                        cute::SM90_TMA_STORE::copy(Cdesc,
-                                                   &smem_C[thread_idx * WG_TILE_M * LayoutC::C0],
-                                                   offset_n + wg_idx_n * WG_TILE_N + tma_n,
-                                                   offset_m + wg_idx_m * WG_TILE_M);
-                        cute::tma_store_arrive();
-                    }
-                }
-                else if (tile->is_valid_cluster) {
-                    int k_iter = sched.k_iters_;
-                    for (; k_iter > 0; --k_iter) {
-                        ProducerBar::wait(&producer_bar[pipe_state.index()], pipe_state.phase());
-                        consumer_arrive();
-                        ++pipe_state;
-                    }
-                }
-
-                sched_state.release();
-                sched_state.acquire(tile);
-
-            }  // scheduler loop
-
-            // release last tile
-            sched_state.release();
-
-            if (threadIdx.x % WARPGROUP_SIZE < LayoutC::C1) {
-                cute::tma_store_wait<0>();
-            }
-        }
-
-    }  // operator()
-
-    template<int N>
-    __device__ void init_tma_descs(Array<const CUtensorMap*, N> param_desc, CUtensorMap* smem_desc)
-    {
-        const int lane_id = threadIdx.x % WARP_SIZE;
-
-        if (lane_id < sizeof(CUtensorMap) / sizeof(uint2)) {
-            PRAGMA_UNROLL
-            for (int i = 0; i < N; ++i) {
-                ((uint2*)&smem_desc[i])[lane_id] = ((uint2*)param_desc[i])[lane_id];
-            }
-        }
-
-        __syncwarp();
+  __device__ void operator()(const CUtensorMap& tm_a, const CUtensorMap& tm_b,
+                             const CUtensorMap& tm_c, const CUtensorMap& tm_u,
+                             const CUtensorMap& tm_v,
+                             const MatrixParam& param_A,
+                             const MatrixParam& param_B,
+                             const MatrixParam& param_U,
+                             const MatrixParam& param_V,
+                             const MatrixParam& param_C, Scheduler sched,
+                             CUtensorMap* tensormap_buf, char* smem_buf) {
+    SharedStorage& storage = *reinterpret_cast<SharedStorage*>(smem_buf);
+
+    uint64_t* producer_bar = storage.producer_bar;
+    uint64_t* consumer_bar = storage.consumer_bar;
+
+    if (threadIdx.x == 0) {
+      PRAGMA_UNROLL
+      for (int s = 0; s < Stages; ++s) {
+        ProducerBar::init(&producer_bar[s], 1 + 1);
+        ConsumerBar::init(&consumer_bar[s], WARPGORUPS * kClusterSize * 4);
+      }
+      sched.init_dynamic(storage.sched, kClusterSize * (WARPGORUPS * 4 + 1));
+      cutlass::arch::fence_view_async_shared();
+      if constexpr (kClusterSize > 1) {
+        cutlass::arch::fence_barrier_init();
+      }
     }
 
-    template<int N>
-    __device__ CUtensorMap*
-    update_tma_descs(CUtensorMap* gmem_desc, CUtensorMap* smem_desc, Array<void*, N> global_addrs, Array<int, N> dims)
-    {
-        const int lane_id = threadIdx.x % WARP_SIZE;
-        if (lane_id == 0) {
+    (kClusterSize > 1) ? cute::cluster_sync() : __syncthreads();
+
+    const int wg_idx = cutlass::canonical_warp_group_idx();
+
+    if (wg_idx == WARPGORUPS) {
+      cutlass::arch::warpgroup_reg_dealloc<40>();
+
+      static_assert(TILE_M % kMulticastA == 0);
+      static_assert(TILE_N % kMulticastB == 0);
+
+      cutlass::arch::NamedBarrier producers_bar(WARP_SIZE * 2, 7);
+
+      const int warp_id = cutlass::canonical_warp_idx_sync();
+      const bool cta_0 = cute::block_id_in_cluster().x == 0;
+
+      if (warp_id % 4 == 0) {
+        Cluster cluster(cute::block_id_in_cluster().x);
+
+        const int mc_offset_m = cluster.cta_n() * (TILE_M / kMulticastA);
+        const int mc_offset_n = cluster.cta_m() * (TILE_N / kMulticastB);
+
+        auto smem_A = storage.A.data() + mc_offset_m * TILE_K;
+        auto smem_B = storage.B.data() + mc_offset_n * TILE_K;
+        auto& smem_U = storage.U;
+        auto& smem_V = storage.V;
+
+        if constexpr (is_grouped_gemm) {
+          init_tma_descs<3>({&tm_a, &tm_b, &tm_u}, storage.tensor_map);
+        }
+
+        cutlass::PipelineState<Stages> write_state{0, 1, 0};
+
+        auto sched_state = sched.init_consumer(storage.sched);
+
+        int lane_predicate = cute::elect_one_sync();
+
+        typename Scheduler::Tile* tile;
+
+        while (sched_state.acquire(tile)) {
+          if (tile->is_valid_cluster) {
+            const CUtensorMap* Adesc = &tm_a;
+            const CUtensorMap* Bdesc = &tm_b;
+            const CUtensorMap* Udesc = &tm_u;
+
+            const Tv* gmem_V0 = (const Tv*)param_V.ptr;
+            const Tv* gmem_V1;
+
+            if constexpr (is_grouped_gemm) {
+              const int g = tile->group_idx;
+              const int m0 = tile->m0;
+              const int m1 = tile->m1;
+              const int m = m1 - m0;
+
+              Array<void*, 3> global_addrs;
+              global_addrs[0] = (Ta*)param_A.ptr + m0 * (int64_t)param_A.stride;
+              global_addrs[1] = ((void**)param_B.ptr)[g];
+
+              const int beg_u = m0 / kAlignmentU * kAlignmentU;
+              const int end_u = round_up(m1, kAlignmentU);
+              global_addrs[2] = (Tu*)param_U.ptr + beg_u;
+
+              Array<int, 3> dims;
+              dims[0] = m;
+              dims[1] = sched.gemm_shape().y;
+              dims[2] = end_u - beg_u;
+
+              auto descs = update_tma_descs(tensormap_buf, storage.tensor_map,
+                                            global_addrs, dims);
+              Adesc = &descs[0];
+              Bdesc = &descs[1];
+              Udesc = &descs[2];
+
+              gmem_V0 = ((Tv**)gmem_V0)[g];
+
+              PRAGMA_UNROLL
+              for (int i = 0; i < 3; ++i) {
+                cute::tma_descriptor_fence_acquire(
+                    (cute::TmaDescriptor*)&descs[i]);
+              }
+            }
+
+            if (lane_predicate) {
+              const int offset_k = 0;
+
+              const uint16_t mask_A = cluster.mask_m();
+              const uint16_t mask_B = cluster.mask_n();
+
+              const int offset_m = tile->offset_m;
+              const int offset_n = tile->offset_n;
+
+              int k_iter = sched.k_iters_;
+
+              GmemIteratorSm90<kMulticastA> gmem_A{
+                  Adesc, {offset_k, offset_m + mc_offset_m}, {TILE_K, 0}};
+              GmemIteratorSm90<kMulticastB> gmem_B{
+                  Bdesc, {offset_k, offset_n + mc_offset_n}, {TILE_K, 0}};
+
+              const int mc_offset_u = kMulticastU > 1 ? mc_offset_m : 0;
+              // column-major
+              GmemIteratorSm90<kMulticastU> gmem_U{
+                  Udesc, {offset_m + mc_offset_u, offset_k / 128}, {0, 1}};
+
+              gmem_V0 += (offset_n / 128) * param_V.stride + (offset_k / 128);
+              gmem_V1 = gmem_V0;
+              if (offset_n / 128 + 1 < cdiv(sched.gemm_shape().y, 128)) {
+                gmem_V1 += param_V.stride;
+              }
+
+              for (; k_iter > 0; --k_iter) {
+                int pipe = write_state.index();
+                ConsumerBar::wait(&consumer_bar[pipe], write_state.phase());
+                ProducerBar::arrive_and_expect_tx(&producer_bar[pipe],
+                                                  kTmaTxBytes);
+                gmem_A.Step(&producer_bar[pipe],
+                            &smem_A[pipe * TILE_M * TILE_K], mask_A);
+                gmem_B.Step(&producer_bar[pipe],
+                            &smem_B[pipe * TILE_N * TILE_K], mask_B);
+                gmem_U.Step(&producer_bar[pipe], smem_U[pipe] + mc_offset_u,
+                            mask_A);
+                uint32_t uint_ptr_V = cast_smem_ptr_to_uint(smem_V[pipe]);
+                CP_ASYNC<CacheOp::kAlways, 4, 0>::apply(uint_ptr_V, gmem_V0,
+                                                        true);
+                CP_ASYNC<CacheOp::kAlways, 4, 0>::apply(uint_ptr_V + sizeof(Tv),
+                                                        gmem_V1, true);
+                ++gmem_V0;
+                ++gmem_V1;
+                cutlass::arch::cpasync_barrier_arrive_noinc(
+                    &producer_bar[pipe]);
+                ++write_state;
+              }
+            }
+          }
+
+          if constexpr (Scheduler::is_dynamic) {
+            if (cta_0) {
+              producers_bar.arrive_unaligned();
+            }
+          }
+
+          sched_state.release();
+
+        }  // scheduler loop
+
+        // release last tile
+        sched_state.release();
+
+        if constexpr (kClusterSize > 1) {
+          if (lane_predicate) {
+            for (int i = 0; i < Stages; ++i) {
+              ConsumerBar::wait(&consumer_bar[write_state.index()],
+                                write_state.phase());
+              ++write_state;
+            }
+          }
+          __syncwarp();
+        }
+      } else if (warp_id % 4 == 1 && cta_0) {
+        auto state = sched.init_producer(storage.sched);
+        while (state.next()) {
+          if constexpr (Scheduler::is_dynamic) {
+            producers_bar.arrive_and_wait_unaligned();
+          }
+        }
+        sched.tail(state);
+      }
+    } else {
+      cutlass::arch::warpgroup_reg_alloc<232>();
+
+      if constexpr (is_grouped_gemm) {
+        if (threadIdx.x % WARPGROUP_SIZE / WARP_SIZE == 0) {
+          init_tma_descs<1>({&tm_c}, storage.tensor_map + 3 + wg_idx);
+        }
+      }
+
+      auto& smem_A = storage.A;
+      auto& smem_B = storage.B;
+      auto& smem_U = storage.U;
+      auto& smem_V = storage.V;
+
+      const int wg_idx_m = WG_M > 1 ? wg_idx % WG_M : 0;
+      const int wg_idx_n = WG_N > 1 ? wg_idx / WG_M : 0;
+
+      auto smem_desc_A =
+          make_smem_desc(&smem_A[wg_idx_m * WG_TILE_M * TILE_K], 1);
+      auto smem_desc_B =
+          make_smem_desc(&smem_B[wg_idx_n * WG_TILE_N * TILE_K], 1);
+
+      SmemDescIterV2<Stages, ((TILE_M * TILE_K) >> 4)> smem_iter_A{smem_desc_A};
+      SmemDescIterV2<Stages, ((TILE_N * TILE_K) >> 4)> smem_iter_B{smem_desc_B};
+
+      cutlass::arch::NamedBarrier barrier(WARPGROUP_SIZE, 2 + wg_idx);  // 0, 1
+
+      cutlass::PipelineState<Stages> pipe_state{};
+
+      const int warp_id = cutlass::canonical_warp_idx_sync();
+      const int lane_id = cutlass::canonical_lane_idx();
+
+      auto consumer_arrive = [&] {
+        auto bar = &consumer_bar[pipe_state.index()];
+        __syncwarp();
+        if constexpr (kClusterSize > 1) {
+          ConsumerBar::arrive(bar, lane_id, lane_id < kClusterSize);
+        } else {
+          if (lane_id == 0) {
+            ConsumerBar::arrive(bar);
+          }
+        }
+      };
+
+      auto sched_state = sched.init_consumer(storage.sched);
+
+      typename Scheduler::Tile* tile;
+
+      sched_state.acquire(tile);
+
+      while (tile->alive) {
+        if (tile->is_valid_cta) {
+          GMMA::AccumC accum_C{};
+          GMMA::FragC frag_C;
+
+          auto pred_V = Fetch_V(tile, wg_idx_n);
+
+          float scale_V[2];
+          auto Load_V = [&] {
+            scale_V[0] = smem_V[pipe_state.index()][0];
+            scale_V[1] = smem_V[pipe_state.index()][1];
+          };
+
+          int offset_U = wg_idx_m * WG_TILE_M + warp_id % 4 * 16 + lane_id / 4;
+          if constexpr (is_grouped_gemm) {
+            offset_U += tile->m0 % kAlignmentU;
+          }
+          GMMA::FragU frag_U;
+          auto Load_U = [&] {
+            GMMA::foreach_m(frag_U, [&](auto& U, int m) {
+              U[0] = smem_U[pipe_state.index()][offset_U + m * GMMA::OP_M];
+              U[1] = smem_U[pipe_state.index()][offset_U + m * GMMA::OP_M + 8];
+            });
+          };
+
+          auto gmma = [&] {  //
+            GMMA::apply(smem_iter_A, smem_iter_B, frag_C, accum_C, frag_U,
+                        scale_V, pred_V);
+          };
+
+          if constexpr (is_grouped_gemm) {
+            if (threadIdx.x % WARPGROUP_SIZE < LayoutC::C1) {
+              cute::tma_store_wait<0>();
+            }
+            // No need to sync here as the update is warp synchronized
+            if (warp_id % 4 == 0) {
+              int m0 = tile->m0, m1 = tile->m1;
+              auto global_addr =
+                  (Tc*)param_C.ptr + m0 * (int64_t)param_C.stride;
+              int idx = 3 + wg_idx;
+              update_tma_descs<1>(tensormap_buf + idx, storage.tensor_map + idx,
+                                  {global_addr}, {m1 - m0});
+            }
+            barrier.sync();
+          }
+
+          int k_iter = sched.k_iters_;
+
+          ProducerBar::wait(&producer_bar[pipe_state.index()],
+                            pipe_state.phase());
+          Load_V();
+          Load_U();
+          smem_iter_A.Reset(pipe_state.index());
+          smem_iter_B.Reset(pipe_state.index());
+          gmma();
+          consumer_arrive();
+          ++pipe_state;
+          --k_iter;
+
+          ProducerBar::wait(&producer_bar[pipe_state.index()],
+                            pipe_state.phase());
+          Load_V();
+          Load_U();
+          smem_iter_A.Reset(pipe_state.index());
+          smem_iter_B.Reset(pipe_state.index());
+
+          PRAGMA_NO_UNROLL
+          for (; k_iter > 1; --k_iter) {
+            gmma();
+            consumer_arrive();
+            ++pipe_state;
+            ProducerBar::wait(&producer_bar[pipe_state.index()],
+                              pipe_state.phase());
+            Load_V();
+            Load_U();
+            smem_iter_A.Reset(pipe_state.index());
+            smem_iter_B.Reset(pipe_state.index());
+          }
+
+          gmma();
+
+          const int thread_idx = threadIdx.x % WARPGROUP_SIZE;
+          if constexpr (!is_grouped_gemm) {
+            if (thread_idx < LayoutC::C1) {
+              cute::tma_store_wait<0>();
+            }
+            barrier.sync();
+          }
+
+          consumer_arrive();
+          ++pipe_state;
+
+          Tc* smem_C =
+              &storage.C[wg_idx_m * WG_TILE_M * TILE_N + wg_idx_n * WG_TILE_N];
+
+          // epilogue
+          GMMA::foreach_C(accum_C, [&](const auto& C, int m, int n) {
+            constexpr int N = LayoutC::C0;
+            constexpr int SW_bits = log2(kSwizzleC / 16);
+
+            static_assert(!SW_bits || GMMA::OP_N % LayoutC::C0 == 0);
+            static_assert(GMMA::OP_N % 16 == 0);
+
+            const int m0 = m * GMMA::OP_M;
+            const int n0 = n * GMMA::OP_N;
+
             PRAGMA_UNROLL
-            for (int i = 0; i < N; ++i) {
-                uint32_t uint_ptr = cast_smem_ptr_to_uint(&smem_desc[i]);
-                // clang-format off
+            for (int i = 0; i < GMMA::OP_N; i += 16) {
+              __align__(16) Array<Tc, 8> tvec =
+                  cast<Tc>((Array<float, 8>&)C[i / 2]);
+
+              // fill(tvec, Tc(255));
+
+              int mm = m0 + warp_id % 4 * 16 + (lane_id & 8);
+              int nn = n0 + i / N * N;
+
+              int addr = ((nn / N) * WG_TILE_M * N) + (mm * N) + (nn % N);
+
+              int s = lane_id % 8;
+              int c = (lane_id & 16) / 2 + i % N;
+
+              addr += Swizzle<SW_bits, 3, 3>::apply(s * N + c);
+
+              auto& uvec = (Array<uint32_t, 4>&)tvec;
+              cute::SM90_U32x4_STSM_N::copy(uvec[0],  //
+                                            uvec[1], uvec[2], uvec[3],
+                                            (cutlass::uint128_t&)smem_C[addr]);
+            }
+          });
+
+          cute::tma_store_fence();  // visibility: smem -> async proxy
+
+          barrier.sync();
+
+          const int offset_m = tile->offset_m;
+          const int offset_n = tile->offset_n;
+
+          const void* Cdesc = &tm_c;
+
+          if (thread_idx < LayoutC::C1) {
+            const int tma_n = thread_idx * LayoutC::C0;
+            if constexpr (is_grouped_gemm) {
+              Cdesc = tensormap_buf + blockIdx.x * 5 + 3 + wg_idx;
+              cute::tma_descriptor_fence_acquire((cute::TmaDescriptor*)Cdesc);
+            }
+            cute::SM90_TMA_STORE::copy(
+                Cdesc, &smem_C[thread_idx * WG_TILE_M * LayoutC::C0],
+                offset_n + wg_idx_n * WG_TILE_N + tma_n,
+                offset_m + wg_idx_m * WG_TILE_M);
+            cute::tma_store_arrive();
+          }
+        } else if (tile->is_valid_cluster) {
+          int k_iter = sched.k_iters_;
+          for (; k_iter > 0; --k_iter) {
+            ProducerBar::wait(&producer_bar[pipe_state.index()],
+                              pipe_state.phase());
+            consumer_arrive();
+            ++pipe_state;
+          }
+        }
+
+        sched_state.release();
+        sched_state.acquire(tile);
+
+      }  // scheduler loop
+
+      // release last tile
+      sched_state.release();
+
+      if (threadIdx.x % WARPGROUP_SIZE < LayoutC::C1) {
+        cute::tma_store_wait<0>();
+      }
+    }
+
+  }  // operator()
+
+  template <int N>
+  __device__ void init_tma_descs(Array<const CUtensorMap*, N> param_desc,
+                                 CUtensorMap* smem_desc) {
+    const int lane_id = threadIdx.x % WARP_SIZE;
+
+    if (lane_id < sizeof(CUtensorMap) / sizeof(uint2)) {
+      PRAGMA_UNROLL
+      for (int i = 0; i < N; ++i) {
+        ((uint2*)&smem_desc[i])[lane_id] = ((uint2*)param_desc[i])[lane_id];
+      }
+    }
+
+    __syncwarp();
+  }
+
+  template <int N>
+  __device__ CUtensorMap* update_tma_descs(CUtensorMap* gmem_desc,
+                                           CUtensorMap* smem_desc,
+                                           Array<void*, N> global_addrs,
+                                           Array<int, N> dims) {
+    const int lane_id = threadIdx.x % WARP_SIZE;
+    if (lane_id == 0) {
+      PRAGMA_UNROLL
+      for (int i = 0; i < N; ++i) {
+        uint32_t uint_ptr = cast_smem_ptr_to_uint(&smem_desc[i]);
+        // clang-format off
                 asm volatile("tensormap.replace.tile.global_address.shared::cta.b1024.b64 [%0], %1;" ::"r"(uint_ptr), "l"(global_addrs[i]));
                 if (i != 2) {
                     asm volatile("tensormap.replace.tile.global_dim.shared::cta.b1024.b32 [%0], 1, %1;" ::"r"(uint_ptr), "r"(dims[i]));
                 } else { // special case for U
                     asm volatile("tensormap.replace.tile.global_dim.shared::cta.b1024.b32 [%0], 0, %1;" ::"r"(uint_ptr), "r"(dims[i]));
                 }
-                // clang-format on
-            }
-        }
+        // clang-format on
+      }
+    }
 
-        __syncwarp();
+    __syncwarp();
 
-        constexpr int kNumPerCta = 5;  // a,b,u,c0,c1
-        auto          gmem_ptr   = &gmem_desc[blockIdx.x * kNumPerCta];
-        PRAGMA_UNROLL
-        for (int i = 0; i < N; ++i) {
-            uint32_t uint_ptr = cast_smem_ptr_to_uint(&smem_desc[i]);
-            // clang-format off
+    constexpr int kNumPerCta = 5;  // a,b,u,c0,c1
+    auto gmem_ptr = &gmem_desc[blockIdx.x * kNumPerCta];
+    PRAGMA_UNROLL
+    for (int i = 0; i < N; ++i) {
+      uint32_t uint_ptr = cast_smem_ptr_to_uint(&smem_desc[i]);
+      // clang-format off
             asm volatile("tensormap.cp_fenceproxy.global.shared::cta.tensormap::generic.release.gpu.sync.aligned [%0], [%1], 128;" :: "l"(gmem_ptr + i), "r"(uint_ptr));
-            // clang-format on
-        }
-
-        return gmem_ptr;
+      // clang-format on
     }
 
-    __device__ auto Fetch_V(typename Scheduler::Tile* tile, int wg_idx_n)
-    {
-        constexpr int BLK_SUBTILE_N = 128 / OUTER_N;
-        static_assert(MMA_SUBTILE_N - 1 < BLK_SUBTILE_N + 1);  // n1 - 1 + n0 - 1 < 2 * n0
+    return gmem_ptr;
+  }
 
-        Array<bool, MMA_SUBTILE_N> pred_V{};
-        if constexpr (MMA_SUBTILE_N != 1) {
-            int offset = tile->offset_n % 128 + wg_idx_n * WG_TILE_N;
-            static_assert(WG_N == 1);
-            // Safely skip pred_V_0 when distributing WGs along M
-            PRAGMA_UNROLL
-            for (int i = 1; i < MMA_SUBTILE_N; ++i) {
-                pred_V[i] = (i * OUTER_N + offset) >= 128;
-            }
-        }
+  __device__ auto Fetch_V(typename Scheduler::Tile* tile, int wg_idx_n) {
+    constexpr int BLK_SUBTILE_N = 128 / OUTER_N;
+    static_assert(MMA_SUBTILE_N - 1 <
+                  BLK_SUBTILE_N + 1);  // n1 - 1 + n0 - 1 < 2 * n0
 
-        return pred_V;
+    Array<bool, MMA_SUBTILE_N> pred_V{};
+    if constexpr (MMA_SUBTILE_N != 1) {
+      int offset = tile->offset_n % 128 + wg_idx_n * WG_TILE_N;
+      static_assert(WG_N == 1);
+      // Safely skip pred_V_0 when distributing WGs along M
+      PRAGMA_UNROLL
+      for (int i = 1; i < MMA_SUBTILE_N; ++i) {
+        pred_V[i] = (i * OUTER_N + offset) >= 128;
+      }
     }
+
+    return pred_V;
+  }
 };
 
 }  // namespace turbomind::gemm

--- a/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/gemm_universal_sm90_v4.h
+++ b/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/gemm_universal_sm90_v4.h
@@ -38,751 +38,741 @@ namespace turbomind::gemm {
 
 namespace GMMA = cute::SM90::GMMA;
 
-inline __device__ cute::GmmaDescriptor make_smem_desc(void* smem_ptr, int layout_type)
-{
-    auto uint_ptr = cast_smem_ptr_to_uint(smem_ptr);
+inline __device__ cute::GmmaDescriptor make_smem_desc(void* smem_ptr,
+                                                      int layout_type) {
+  auto uint_ptr = cast_smem_ptr_to_uint(smem_ptr);
 
-    cute::GmmaDescriptor desc{};
-    desc.bitfield.start_address_       = uint_ptr >> 4;
-    desc.bitfield.layout_type_         = layout_type;
-    desc.bitfield.leading_byte_offset_ = 0;
-    desc.bitfield.stride_byte_offset_  = 1024 >> 4;
-    desc.bitfield.base_offset_         = 0;
+  cute::GmmaDescriptor desc{};
+  desc.bitfield.start_address_ = uint_ptr >> 4;
+  desc.bitfield.layout_type_ = layout_type;
+  desc.bitfield.leading_byte_offset_ = 0;
+  desc.bitfield.stride_byte_offset_ = 1024 >> 4;
+  desc.bitfield.base_offset_ = 0;
 
-    return desc;
+  return desc;
 }
 
-template<int Stages, int Step>
+template <int Stages, int Step>
 struct SmemDescIterV2 {
-    union {
-        uint32_t u32_[2];
-        uint64_t u64_;
-    };
+  union {
+    uint32_t u32_[2];
+    uint64_t u64_;
+  };
 
-    uint32_t base_;
+  uint32_t base_;
 
-    __device__ SmemDescIterV2(uint64_t desc): u64_{desc}, base_{u32_[0]} {}
+  __device__ SmemDescIterV2(uint64_t desc) : u64_{desc}, base_{u32_[0]} {}
 
-    __device__ void Advance(int stage)
-    {
-        u32_[0] += Step;
-        if (stage == Stages - 1) {
-            u32_[0] = base_;
-        }
+  __device__ void Advance(int stage) {
+    u32_[0] += Step;
+    if (stage == Stages - 1) {
+      u32_[0] = base_;
     }
+  }
 
-    __device__ void Reset(int stage)
-    {
-        u32_[0] = base_ + stage * Step;
-    }
+  __device__ void Reset(int stage) { u32_[0] = base_ + stage * Step; }
 
-    __device__ SmemDescIterV2& operator+=(int offset)
-    {
-        u32_[0] += offset;
-        return *this;
-    }
+  __device__ SmemDescIterV2& operator+=(int offset) {
+    u32_[0] += offset;
+    return *this;
+  }
 
-    __device__ SmemDescIterV2& operator-=(int offset)
-    {
-        u32_[0] -= offset;
-        return *this;
-    }
+  __device__ SmemDescIterV2& operator-=(int offset) {
+    u32_[0] -= offset;
+    return *this;
+  }
 
-    __device__ operator uint64_t()
-    {
-        return u64_;
-    }
+  __device__ operator uint64_t() { return u64_; }
 };
 
-template<class MMA_Atom, size_t... Is>
-inline __device__ void
-wgmma_impl(uint64_t desc_a, uint64_t desc_b, float* frag_C, bool clear, std::index_sequence<Is...>)
-{
-    return MMA_Atom::fma(desc_a, desc_b, frag_C[Is]..., clear ? GMMA::ScaleOut::Zero : GMMA::ScaleOut::One);
+template <class MMA_Atom, size_t... Is>
+inline __device__ void wgmma_impl(uint64_t desc_a, uint64_t desc_b,
+                                  float* frag_C, bool clear,
+                                  std::index_sequence<Is...>) {
+  return MMA_Atom::fma(desc_a, desc_b, frag_C[Is]...,
+                       clear ? GMMA::ScaleOut::Zero : GMMA::ScaleOut::One);
 }
 
-template<class MMA_Atom, int N>
-inline __device__ void wgmma(uint64_t desc_a, uint64_t desc_b, float (&frag_C)[N], bool clear)
-{
-    return wgmma_impl<MMA_Atom>(desc_a, desc_b, frag_C, clear, std::make_index_sequence<N>{});
+template <class MMA_Atom, int N>
+inline __device__ void wgmma(uint64_t desc_a, uint64_t desc_b,
+                             float (&frag_C)[N], bool clear) {
+  return wgmma_impl<MMA_Atom>(desc_a, desc_b, frag_C, clear,
+                              std::make_index_sequence<N>{});
 }
 
-inline __device__ void warpgroup_fence_operand(float& reg)
-{
-    asm volatile("" : "+f"(reg)::"memory");
+inline __device__ void warpgroup_fence_operand(float& reg) {
+  asm volatile("" : "+f"(reg)::"memory");
 }
 
-template<int M, int N, int K>
-inline __device__ void warpgroup_fence_operand(float (&x)[M][N][K])
-{
-    PRAGMA_UNROLL
-    for (int m = 0; m < M; ++m) {
-        PRAGMA_UNROLL
-        for (int n = 0; n < N; ++n) {
-            PRAGMA_UNROLL
-            for (int k = 0; k < K; ++k) {
-                warpgroup_fence_operand(x[m][n][k]);
-            }
-        }
-    }
-}
-
-template<int N, int K>
-inline __device__ void warpgroup_fence_operand(float (&x)[N][K])
-{
+template <int M, int N, int K>
+inline __device__ void warpgroup_fence_operand(float (&x)[M][N][K]) {
+  PRAGMA_UNROLL
+  for (int m = 0; m < M; ++m) {
     PRAGMA_UNROLL
     for (int n = 0; n < N; ++n) {
-        PRAGMA_UNROLL
-        for (int k = 0; k < K; ++k) {
-            warpgroup_fence_operand(x[n][k]);
-        }
+      PRAGMA_UNROLL
+      for (int k = 0; k < K; ++k) {
+        warpgroup_fence_operand(x[m][n][k]);
+      }
     }
+  }
 }
 
-template<class Func, size_t... Is>
-__device__ void for_(std::index_sequence<Is...>, Func func)
-{
-    return (func(constant<Is>{}), ...);
+template <int N, int K>
+inline __device__ void warpgroup_fence_operand(float (&x)[N][K]) {
+  PRAGMA_UNROLL
+  for (int n = 0; n < N; ++n) {
+    PRAGMA_UNROLL
+    for (int k = 0; k < K; ++k) {
+      warpgroup_fence_operand(x[n][k]);
+    }
+  }
+}
+
+template <class Func, size_t... Is>
+__device__ void for_(std::index_sequence<Is...>, Func func) {
+  return (func(constant<Is>{}), ...);
 }
 
 namespace arch {
 
-template<int M_, int N_, Order order>
+template <int M_, int N_, Order order>
 struct Cluster {
-    static constexpr int M = M_;
-    static constexpr int N = N_;
+  static constexpr int M = M_;
+  static constexpr int N = N_;
 
-    static constexpr int C = mk2cs<order>(M, N).x;
-    static constexpr int S = mk2cs<order>(M, N).y;
+  static constexpr int C = mk2cs<order>(M, N).x;
+  static constexpr int S = mk2cs<order>(M, N).y;
 
-    static constexpr int size = M * N;
+  static constexpr int size = M * N;
 
-    static constexpr uint16_t kMaskC = (1 << C) - 1;
-    static constexpr uint16_t kMaskS = ((1 << size) - 1) / kMaskC;
+  static constexpr uint16_t kMaskC = (1 << C) - 1;
+  static constexpr uint16_t kMaskS = ((1 << size) - 1) / kMaskC;
 
-    __device__ static ushort2 mask_cs(int cta_id)
-    {
-        const auto [c, s] = cta_cs(cta_id);
-        return make_ushort2(kMaskS << c, kMaskC << s * C);
-    }
+  __device__ static ushort2 mask_cs(int cta_id) {
+    const auto [c, s] = cta_cs(cta_id);
+    return make_ushort2(kMaskS << c, kMaskC << s * C);
+  }
 
-    __device__ static ushort2 mask_mn(int cta_id)
-    {
-        auto [c, s] = mask_cs(cta_id);
-        return order == kColMajor ? ushort2{c, s} : ushort2{s, c};
-    }
+  __device__ static ushort2 mask_mn(int cta_id) {
+    auto [c, s] = mask_cs(cta_id);
+    return order == kColMajor ? ushort2{c, s} : ushort2{s, c};
+  }
 
-    __device__ static int2 cta_cs(int cta_id)
-    {
-        return {C > 1 ? cta_id % C : 0, S > 1 ? cta_id / C : 0};
-    }
+  __device__ static int2 cta_cs(int cta_id) {
+    return {C > 1 ? cta_id % C : 0, S > 1 ? cta_id / C : 0};
+  }
 
-    __device__ static int2 cta_mn(int cta_id)
-    {
-        return cs2mk<order>(cta_cs(cta_id));
-    }
+  __device__ static int2 cta_mn(int cta_id) {
+    return cs2mk<order>(cta_cs(cta_id));
+  }
 
-    int2    cta_mn_;
-    ushort2 mask_mn_;
+  int2 cta_mn_;
+  ushort2 mask_mn_;
 
-    __device__ explicit Cluster(int cta_id): cta_mn_(cta_mn(cta_id)), mask_mn_(mask_mn(cta_id)) {}
+  __device__ explicit Cluster(int cta_id)
+      : cta_mn_(cta_mn(cta_id)), mask_mn_(mask_mn(cta_id)) {}
 
-    __device__ int cta_m()
-    {
-        return cta_mn_.x;
-    }
+  __device__ int cta_m() { return cta_mn_.x; }
 
-    __device__ int cta_n()
-    {
-        return cta_mn_.y;
-    }
+  __device__ int cta_n() { return cta_mn_.y; }
 
-    __device__ uint16_t mask_m()
-    {
-        return mask_mn_.x;
-    }
+  __device__ uint16_t mask_m() { return mask_mn_.x; }
 
-    __device__ uint16_t mask_n()
-    {
-        return mask_mn_.y;
-    }
+  __device__ uint16_t mask_n() { return mask_mn_.y; }
 };
 
 }  // namespace arch
 
 struct GemmUniversalSm90_v3 {
+  static constexpr bool kDebug = false;
 
-    static constexpr bool kDebug = false;
+  using Arch = Sm90;
 
-    using Arch = Sm90;
+  // using MMA_Atom = GMMA::MMA_64x128x16_F32BF16BF16_SS<GMMA::Major::K,
+  // GMMA::Major::K>;
+  using MMA_Atom = GMMA::MMA_64x192x32_F32E4M3E4M3_SS_TN<>;
+  static constexpr typename cute::MMA_Traits<MMA_Atom>::Shape_MNK MMA_Shape{};
 
-    // using MMA_Atom = GMMA::MMA_64x128x16_F32BF16BF16_SS<GMMA::Major::K, GMMA::Major::K>;
-    using MMA_Atom = GMMA::MMA_64x192x32_F32E4M3E4M3_SS_TN<>;
-    static constexpr typename cute::MMA_Traits<MMA_Atom>::Shape_MNK MMA_Shape{};
+  static constexpr int MMA_ATOM_M = cute::get<0>(MMA_Shape);
+  static constexpr int MMA_ATOM_N = cute::get<1>(MMA_Shape);
+  static constexpr int MMA_ATOM_K = cute::get<2>(MMA_Shape);
 
-    static constexpr int MMA_ATOM_M = cute::get<0>(MMA_Shape);
-    static constexpr int MMA_ATOM_N = cute::get<1>(MMA_Shape);
-    static constexpr int MMA_ATOM_K = cute::get<2>(MMA_Shape);
+  static constexpr int TILE_M = 128;
+  static constexpr int TILE_N = 192;
+  static constexpr int TILE_K = 128;
 
-    static constexpr int TILE_M = 128;
-    static constexpr int TILE_N = 192;
-    static constexpr int TILE_K = 128;
+  static constexpr int WG_M = 2;
+  static constexpr int WG_N = 1;
 
-    static constexpr int WG_M = 2;
-    static constexpr int WG_N = 1;
+  static constexpr int WG_TILE_M = TILE_M / WG_M;
+  static constexpr int WG_TILE_N = TILE_N / WG_N;
 
-    static constexpr int WG_TILE_M = TILE_M / WG_M;
-    static constexpr int WG_TILE_N = TILE_N / WG_N;
+  static constexpr int kSchedWarpGroups = 1;
 
-    static constexpr int kSchedWarpGroups = 1;
+  static constexpr int WARPGORUPS = WG_M * WG_N;
 
-    static constexpr int WARPGORUPS = WG_M * WG_N;
+  static constexpr int MMA_ITER_M = WG_TILE_M / MMA_ATOM_M;
+  static constexpr int MMA_ITER_N = WG_TILE_N / MMA_ATOM_N;
+  static constexpr int MMA_ITER_K = TILE_K / MMA_ATOM_K;
 
-    static constexpr int MMA_ITER_M = WG_TILE_M / MMA_ATOM_M;
-    static constexpr int MMA_ITER_N = WG_TILE_N / MMA_ATOM_N;
-    static constexpr int MMA_ITER_K = TILE_K / MMA_ATOM_K;
+  static constexpr int kMulticastA = 1;
+  static constexpr int kMulticastB = 2;
 
-    static constexpr int kMulticastA = 1;
-    static constexpr int kMulticastB = 2;
+  static constexpr int kClusterSize = kMulticastA * kMulticastB;
 
-    static constexpr int kClusterSize = kMulticastA * kMulticastB;
+  static constexpr int Stages = 4;
 
-    static constexpr int Stages = 4;
+  static constexpr bool kSplitK = false;
+  static constexpr int kChunkSizeK = TILE_K;
 
-    static constexpr bool kSplitK     = false;
-    static constexpr int  kChunkSizeK = TILE_K;
+  static constexpr int WARPGROUP_SIZE = 128;
 
-    static constexpr int WARPGROUP_SIZE = 128;
+  static constexpr int CTA_SIZE = WARPGROUP_SIZE * (WARPGORUPS + 1);
 
-    static constexpr int CTA_SIZE = WARPGROUP_SIZE * (WARPGORUPS + 1);
+  using Ta = __nv_fp8_e4m3;
+  using Tb = __nv_fp8_e4m3;
+  using Tc = nv_bfloat16;
 
-    using Ta = __nv_fp8_e4m3;
-    using Tb = __nv_fp8_e4m3;
-    using Tc = nv_bfloat16;
+  using Tu = float;
+  using Tv = float;
 
-    using Tu = float;
-    using Tv = float;
+  using Cluster = arch::Cluster<kMulticastB, kMulticastA, kRowMajor>;
 
-    using Cluster = arch::Cluster<kMulticastB, kMulticastA, kRowMajor>;
+  using Scheduler = TileScheduler<kRowMajor, Cluster, true, true, false>;
 
-    using Scheduler = TileScheduler<kRowMajor, Cluster, true, true, false>;
+  using ProducerBar = cutlass::arch::ClusterTransactionBarrier;
+  using ConsumerBar = cutlass::arch::ClusterBarrier;
 
-    using ProducerBar = cutlass::arch::ClusterTransactionBarrier;
-    using ConsumerBar = cutlass::arch::ClusterBarrier;
+  static constexpr int MAX_K = 32768;
 
-    static constexpr int MAX_K = 32768;
+  static constexpr int TILE_M_U = cdiv(TILE_M, 1);
+  static constexpr int CTA_K_U = cdiv(TILE_K, 128);
 
-    static constexpr int TILE_M_U = cdiv(TILE_M, 1);
-    static constexpr int CTA_K_U  = cdiv(TILE_K, 128);
+  static constexpr int kTmaTxBytes = sizeof(Ta) * (TILE_M * TILE_K) +
+                                     sizeof(Tb) * (TILE_N * TILE_K) +
+                                     sizeof(Tu) * TILE_M_U * CTA_K_U;
 
-    static constexpr int kTmaTxBytes =
-        sizeof(Ta) * (TILE_M * TILE_K) + sizeof(Tb) * (TILE_N * TILE_K) + sizeof(Tu) * TILE_M_U * CTA_K_U;
-
-    // ! Smem addr must be SBO aligned for TMA load/store
-    struct SharedStorage {
-        struct Source {
-            __align__(1024) Array<Ta, Stages * TILE_M * TILE_K> A;
-            __align__(1024) Array<Tb, Stages * TILE_N * TILE_K> B;
-            __align__(1024) Tu U[Stages][TILE_M_U * CTA_K_U];
-            // __align__(1024) Tv V[2][WARPGORUPS][cdiv(MAX_K, 128)];
-            __align__(1024) Tv V[Stages][2 * cdiv(MAX_K, 128)];
-        };
-        Source source;
-        __align__(1024) Array<Tc, TILE_M * TILE_N> C;
-        __align__(128) uint64_t producer_bar[Stages];
-        __align__(128) uint64_t consumer_bar[Stages];
-        __align__(128) CUtensorMap tma_desc_C[WARPGORUPS];
+  // ! Smem addr must be SBO aligned for TMA load/store
+  struct SharedStorage {
+    struct Source {
+      __align__(1024) Array<Ta, Stages * TILE_M * TILE_K> A;
+      __align__(1024) Array<Tb, Stages * TILE_N * TILE_K> B;
+      __align__(1024) Tu U[Stages][TILE_M_U * CTA_K_U];
+      // __align__(1024) Tv V[2][WARPGORUPS][cdiv(MAX_K, 128)];
+      __align__(1024) Tv V[Stages][2 * cdiv(MAX_K, 128)];
     };
+    Source source;
+    __align__(1024) Array<Tc, TILE_M * TILE_N> C;
+    __align__(128) uint64_t producer_bar[Stages];
+    __align__(128) uint64_t consumer_bar[Stages];
+    __align__(128) CUtensorMap tma_desc_C[WARPGORUPS];
+  };
 
-    static constexpr int kSmemSize = sizeof(SharedStorage);
+  static constexpr int kSmemSize = sizeof(SharedStorage);
 
-    static constexpr int kSwizzleC = 2 * std::gcd(WG_TILE_N, 128 / sizeof(Tc));
+  static constexpr int kSwizzleC = 2 * std::gcd(WG_TILE_N, 128 / sizeof(Tc));
 
-    using LayoutC = std::conditional_t<kSwizzleC >= 32,
-                                       SmemLayoutV2<WG_TILE_M, WG_TILE_N, -1, kSwizzleC / sizeof(Tc)>,
-                                       SmemLayoutV2<WG_TILE_M, WG_TILE_N>>;
+  using LayoutC = std::conditional_t<
+      kSwizzleC >= 32,
+      SmemLayoutV2<WG_TILE_M, WG_TILE_N, -1, kSwizzleC / sizeof(Tc)>,
+      SmemLayoutV2<WG_TILE_M, WG_TILE_N>>;
 
-    __device__ void operator()(const CUtensorMap& tm_a,
-                               const CUtensorMap& tm_b,
-                               const CUtensorMap& tm_c,
-                               const CUtensorMap& tm_u,
-                               const CUtensorMap& tm_v,
-                               const MatrixParam& param_A,
-                               const MatrixParam& param_B,
-                               const MatrixParam& param_U,
-                               const MatrixParam& param_V,
-                               const MatrixParam& param_C,
-                               uint2              box_V,
-                               Scheduler          sched,
-                               CUtensorMap*       tensormap_buf,
-                               char*              smem_buf)
-    {
-        SharedStorage& storage = *reinterpret_cast<SharedStorage*>(smem_buf);
+  __device__ void operator()(
+      const CUtensorMap& tm_a, const CUtensorMap& tm_b, const CUtensorMap& tm_c,
+      const CUtensorMap& tm_u, const CUtensorMap& tm_v,
+      const MatrixParam& param_A, const MatrixParam& param_B,
+      const MatrixParam& param_U, const MatrixParam& param_V,
+      const MatrixParam& param_C, uint2 box_V, Scheduler sched,
+      CUtensorMap* tensormap_buf, char* smem_buf) {
+    SharedStorage& storage = *reinterpret_cast<SharedStorage*>(smem_buf);
 
-        uint64_t* producer_bar = storage.producer_bar;
-        uint64_t* consumer_bar = storage.consumer_bar;
+    uint64_t* producer_bar = storage.producer_bar;
+    uint64_t* consumer_bar = storage.consumer_bar;
 
-        if (threadIdx.x == 0) {
-            PRAGMA_UNROLL
-            for (int s = 0; s < Stages; ++s) {
-                ProducerBar::init(&producer_bar[s], 1);
-                ConsumerBar::init(&consumer_bar[s], WARPGORUPS * kClusterSize * 4);
+    if (threadIdx.x == 0) {
+      PRAGMA_UNROLL
+      for (int s = 0; s < Stages; ++s) {
+        ProducerBar::init(&producer_bar[s], 1);
+        ConsumerBar::init(&consumer_bar[s], WARPGORUPS * kClusterSize * 4);
+      }
+      cutlass::arch::fence_view_async_shared();
+      if constexpr (kClusterSize > 1) {
+        cutlass::arch::fence_barrier_init();
+      }
+    }
+
+    (kClusterSize > 1) ? cute::cluster_sync() : __syncthreads();
+
+    const int wg_idx = cutlass::canonical_warp_group_idx();
+
+    if (wg_idx == WARPGORUPS) {
+      cutlass::arch::warpgroup_reg_dealloc<40>();
+
+      static_assert(TILE_M % kMulticastA == 0);
+      static_assert(TILE_N % kMulticastB == 0);
+
+      // if (threadIdx.x == WARPGORUPS * WARPGROUP_SIZE) {
+      if (threadIdx.x % WARPGROUP_SIZE / WARP_SIZE == 0) {
+        Cluster cluster(cute::block_id_in_cluster().x);
+
+        const int mc_offset_m = cluster.cta_n() * (TILE_M / kMulticastA);
+        const int mc_offset_n = cluster.cta_m() * (TILE_N / kMulticastB);
+
+        auto smem_A = storage.source.A.data() + mc_offset_m * TILE_K;
+        auto smem_B = storage.source.B.data() + mc_offset_n * TILE_K;
+        auto& smem_U = storage.source.U;
+        auto& smem_V = storage.source.V;
+
+        sched.grid_init();
+
+        cutlass::PipelineState<Stages> write_state{0, 1, 0};
+        cutlass::PipelineState<Stages> v_state{0, 1, 0};
+
+        while (sched.next()) {
+          if (cute::elect_one_sync()) {
+            auto [valid_cta_tile_p, cluster_tile_p] = sched.is_valid_tile();
+
+            if (!cluster_tile_p) {
+              // OOB tile caused by swizzle pattern
+              continue;
             }
-            cutlass::arch::fence_view_async_shared();
-            if constexpr (kClusterSize > 1) {
-                cutlass::arch::fence_barrier_init();
+
+            const auto tile_offset = sched.tile_offset();
+            const auto [iter_k_beg, iter_k_end] = sched.iter_k_range();
+
+            const int offset_k = iter_k_beg * TILE_K;
+
+            const uint16_t mask_A = cluster.mask_m();
+            const uint16_t mask_B = cluster.mask_n();
+
+            const int offset_m = tile_offset.x * TILE_M;
+            const int offset_n = tile_offset.y * TILE_N;
+
+            int k_iter = iter_k_end - iter_k_beg;
+
+            GmemIteratorSm90<kMulticastA> gmem_A{
+                &tm_a, {offset_k, offset_m + mc_offset_m}, {TILE_K, 0}};
+            GmemIteratorSm90<kMulticastB> gmem_B{
+                &tm_b, {offset_k, offset_n + mc_offset_n}, {TILE_K, 0}};
+            GmemIteratorSm90<kMulticastA> gmem_U{
+                &tm_u, {offset_m + mc_offset_m, offset_k / 128}, {0, 1}};
+            GmemIteratorSm90<1> gmem_V(&tm_v, {0, offset_n / 128}, {0, 0});
+
+            {
+              int pipe = write_state.index();
+              ConsumerBar::wait(&consumer_bar[pipe], write_state.phase());
+              const int v_bytes = sizeof(Tv) * box_V.x * box_V.y;
+              ProducerBar::arrive_and_expect_tx(&producer_bar[pipe],
+                                                kTmaTxBytes + v_bytes);
+              gmem_A.Step(&producer_bar[pipe], &smem_A[pipe * TILE_M * TILE_K],
+                          mask_A);
+              gmem_B.Step(&producer_bar[pipe], &smem_B[pipe * TILE_N * TILE_K],
+                          mask_B);
+              gmem_U.Step(&producer_bar[pipe], &smem_U[pipe][0] + mc_offset_m,
+                          mask_A);
+              gmem_V.Step(&producer_bar[pipe], &smem_V[v_state.index()], 0);
+              ++write_state;
+              --k_iter;
             }
+
+            for (; k_iter > 0; --k_iter) {
+              int pipe = write_state.index();
+              ConsumerBar::wait(&consumer_bar[pipe], write_state.phase());
+              ProducerBar::arrive_and_expect_tx(&producer_bar[pipe],
+                                                kTmaTxBytes);
+              gmem_A.Step(&producer_bar[pipe], &smem_A[pipe * TILE_M * TILE_K],
+                          mask_A);
+              gmem_B.Step(&producer_bar[pipe], &smem_B[pipe * TILE_N * TILE_K],
+                          mask_B);
+              gmem_U.Step(&producer_bar[pipe], &smem_U[pipe][0] + mc_offset_m,
+                          mask_A);
+              ++write_state;
+            }
+
+            ++v_state;
+          }
+        }
+      }
+    } else {
+      cutlass::arch::warpgroup_reg_alloc<232>();
+
+      sched.grid_init(kSchedWarpGroups);
+
+      auto& smem_A = storage.source.A;
+      auto& smem_B = storage.source.B;
+      auto& smem_U = storage.source.U;
+
+      const int wg_idx_m = WG_M > 1 ? wg_idx % WG_M : 0;
+      const int wg_idx_n = WG_N > 1 ? wg_idx / WG_M : 0;
+
+      auto smem_desc_A =
+          make_smem_desc(&smem_A[wg_idx_m * WG_TILE_M * TILE_K], 1);
+      auto smem_desc_B =
+          make_smem_desc(&smem_B[wg_idx_n * WG_TILE_N * TILE_K], 1);
+
+      SmemDescIterV2<Stages, ((sizeof(Ta) * TILE_M * TILE_K) >> 4)> smem_iter_A{
+          smem_desc_A};
+      SmemDescIterV2<Stages, ((sizeof(Tb) * TILE_N * TILE_K) >> 4)> smem_iter_B{
+          smem_desc_B};
+
+      constexpr int kStepMA = (sizeof(Ta) * MMA_ATOM_M * TILE_K) >> 4;
+      constexpr int kStepNB = (sizeof(Tb) * MMA_ATOM_N * TILE_K) >> 4;
+      constexpr int kStepKA = (sizeof(Ta) * MMA_ATOM_K) >> 4;
+      constexpr int kStepKB = (sizeof(Tb) * MMA_ATOM_K) >> 4;
+
+      cutlass::arch::NamedBarrier wg_barrier(WARPGROUP_SIZE,
+                                             wg_idx + 2);  // 2,3
+
+      auto epi_barrier = [&](int phase) {  // 0, 1
+        return EmptyBarrier{};
+        // return cutlass::arch::NamedBarrier(WARPGORUPS * WARPGROUP_SIZE,
+        // wg_idx ^ phase);
+      };
+
+      if (wg_idx == 1) {
+        epi_barrier(1).arrive_unaligned();
+      }
+
+      cutlass::PipelineState<Stages> pipe_state{};
+      cutlass::PipelineState<Stages> v_state{};
+
+      while (sched.next(kSchedWarpGroups)) {
+        auto [cta_tile_p, cluster_tile_p] = sched.is_valid_tile();
+
+        if (!cluster_tile_p) {
+          // OOB tile caused by swizzle pattern
+          continue;
         }
 
-        (kClusterSize > 1) ? cute::cluster_sync() : __syncthreads();
+        MMA_Atom::CRegisters frag_C[MMA_ITER_N];
+        MMA_Atom::CRegisters accum_C[MMA_ITER_M][MMA_ITER_N]{};
 
-        const int wg_idx = cutlass::canonical_warp_group_idx();
+        const auto tile_offset = sched.tile_offset();
+        const auto [iter_k_beg, iter_k_end] = sched.iter_k_range();
 
-        if (wg_idx == WARPGORUPS) {
-            cutlass::arch::warpgroup_reg_dealloc<40>();
+        // const auto [M, N, K, L] = sched.gemm_shape();
 
-            static_assert(TILE_M % kMulticastA == 0);
-            static_assert(TILE_N % kMulticastB == 0);
+        const int offset_m = tile_offset.x * TILE_M;
+        const int offset_n = tile_offset.y * TILE_N;
 
-            // if (threadIdx.x == WARPGORUPS * WARPGROUP_SIZE) {
-            if (threadIdx.x % WARPGROUP_SIZE / WARP_SIZE == 0) {
+        const int wg_offset_n = offset_n + wg_idx_n * WG_TILE_N;
 
-                Cluster cluster(cute::block_id_in_cluster().x);
+        int k_iter = iter_k_end - iter_k_beg;
 
-                const int mc_offset_m = cluster.cta_n() * (TILE_M / kMulticastA);
-                const int mc_offset_n = cluster.cta_m() * (TILE_N / kMulticastB);
+        const int warp_id = threadIdx.x / WARP_SIZE;
+        const int lane_id = threadIdx.x % WARP_SIZE;
 
-                auto  smem_A = storage.source.A.data() + mc_offset_m * TILE_K;
-                auto  smem_B = storage.source.B.data() + mc_offset_n * TILE_K;
-                auto& smem_U = storage.source.U;
-                auto& smem_V = storage.source.V;
-
-                sched.grid_init();
-
-                cutlass::PipelineState<Stages> write_state{0, 1, 0};
-                cutlass::PipelineState<Stages> v_state{0, 1, 0};
-
-                while (sched.next()) {
-                    if (cute::elect_one_sync()) {
-                        auto [valid_cta_tile_p, cluster_tile_p] = sched.is_valid_tile();
-
-                        if (!cluster_tile_p) {
-                            // OOB tile caused by swizzle pattern
-                            continue;
-                        }
-
-                        const auto tile_offset              = sched.tile_offset();
-                        const auto [iter_k_beg, iter_k_end] = sched.iter_k_range();
-
-                        const int offset_k = iter_k_beg * TILE_K;
-
-                        const uint16_t mask_A = cluster.mask_m();
-                        const uint16_t mask_B = cluster.mask_n();
-
-                        const int offset_m = tile_offset.x * TILE_M;
-                        const int offset_n = tile_offset.y * TILE_N;
-
-                        int k_iter = iter_k_end - iter_k_beg;
-
-                        GmemIteratorSm90<kMulticastA> gmem_A{&tm_a, {offset_k, offset_m + mc_offset_m}, {TILE_K, 0}};
-                        GmemIteratorSm90<kMulticastB> gmem_B{&tm_b, {offset_k, offset_n + mc_offset_n}, {TILE_K, 0}};
-                        GmemIteratorSm90<kMulticastA> gmem_U{&tm_u, {offset_m + mc_offset_m, offset_k / 128}, {0, 1}};
-                        GmemIteratorSm90<1>           gmem_V(&tm_v, {0, offset_n / 128}, {0, 0});
-
-                        {
-                            int pipe = write_state.index();
-                            ConsumerBar::wait(&consumer_bar[pipe], write_state.phase());
-                            const int v_bytes = sizeof(Tv) * box_V.x * box_V.y;
-                            ProducerBar::arrive_and_expect_tx(&producer_bar[pipe], kTmaTxBytes + v_bytes);
-                            gmem_A.Step(&producer_bar[pipe], &smem_A[pipe * TILE_M * TILE_K], mask_A);
-                            gmem_B.Step(&producer_bar[pipe], &smem_B[pipe * TILE_N * TILE_K], mask_B);
-                            gmem_U.Step(&producer_bar[pipe], &smem_U[pipe][0] + mc_offset_m, mask_A);
-                            gmem_V.Step(&producer_bar[pipe], &smem_V[v_state.index()], 0);
-                            ++write_state;
-                            --k_iter;
-                        }
-
-                        for (; k_iter > 0; --k_iter) {
-                            int pipe = write_state.index();
-                            ConsumerBar::wait(&consumer_bar[pipe], write_state.phase());
-                            ProducerBar::arrive_and_expect_tx(&producer_bar[pipe], kTmaTxBytes);
-                            gmem_A.Step(&producer_bar[pipe], &smem_A[pipe * TILE_M * TILE_K], mask_A);
-                            gmem_B.Step(&producer_bar[pipe], &smem_B[pipe * TILE_N * TILE_K], mask_B);
-                            gmem_U.Step(&producer_bar[pipe], &smem_U[pipe][0] + mc_offset_m, mask_A);
-                            ++write_state;
-                        }
-
-                        ++v_state;
-                    }
-                }
+        auto consumer_arrive = [&] {
+          __syncwarp();
+          if constexpr (kClusterSize > 1) {
+            ConsumerBar::arrive(&consumer_bar[pipe_state.index()], lane_id,
+                                lane_id < kClusterSize);
+          } else {
+            if (lane_id == 0) {
+              ConsumerBar::arrive(&consumer_bar[pipe_state.index()]);
             }
+          }
+          __syncwarp();
+        };
+
+        if constexpr (kClusterSize > 1) {
+          if (!cta_tile_p) {  // other CTAs in the cluster are still alive
+            for (; k_iter > 0; --k_iter) {
+              ProducerBar::wait(&producer_bar[pipe_state.index()],
+                                pipe_state.phase());
+              consumer_arrive();
+              ++pipe_state;
+            }
+            epi_barrier(0).arrive_and_wait_unaligned();
+            epi_barrier(1).arrive_unaligned();
+            continue;
+          }
         }
-        else {
-            cutlass::arch::warpgroup_reg_alloc<232>();
 
-            sched.grid_init(kSchedWarpGroups);
+        // auto Copy = [k = cdiv(K, 128)](Tv* dst, const Tv* src) {
+        //     PRAGMA_NO_UNROLL
+        //     for (int i = threadIdx.x % WARPGROUP_SIZE; i < k; i +=
+        //     WARPGROUP_SIZE) {
+        //         dst[i] = __ldg(&src[i]);
+        //     }
+        // };
+        // auto gmem_V = (const Tv*)param_V.ptr + (wg_offset_n / 128) *
+        // param_V.stride + (offset_k / 128); Copy(storage.source.V[0][wg_idx],
+        // gmem_V);
 
-            auto& smem_A = storage.source.A;
-            auto& smem_B = storage.source.B;
-            auto& smem_U = storage.source.U;
+        uint32_t pred_V{};
+        int iter_V{};
 
-            const int wg_idx_m = WG_M > 1 ? wg_idx % WG_M : 0;
-            const int wg_idx_n = WG_N > 1 ? wg_idx / WG_M : 0;
+        constexpr int OUTER_N = std::gcd(MMA_ATOM_N, 128);
+        if constexpr (OUTER_N != 128) {
+          static_assert(MMA_ATOM_N <= 128 + OUTER_N,
+                        "MMA inst is crossing more than 2 scale blocks");
 
-            auto smem_desc_A = make_smem_desc(&smem_A[wg_idx_m * WG_TILE_M * TILE_K], 1);
-            auto smem_desc_B = make_smem_desc(&smem_B[wg_idx_n * WG_TILE_N * TILE_K], 1);
+          constexpr uint32_t mask = (1UL << (WG_TILE_N / OUTER_N)) - 1;
 
-            SmemDescIterV2<Stages, ((sizeof(Ta) * TILE_M * TILE_K) >> 4)> smem_iter_A{smem_desc_A};
-            SmemDescIterV2<Stages, ((sizeof(Tb) * TILE_N * TILE_K) >> 4)> smem_iter_B{smem_desc_B};
+          int phase = 128 - wg_offset_n % 128;
+          pred_V = (mask << (phase / OUTER_N)) & mask;
 
-            constexpr int kStepMA = (sizeof(Ta) * MMA_ATOM_M * TILE_K) >> 4;
-            constexpr int kStepNB = (sizeof(Tb) * MMA_ATOM_N * TILE_K) >> 4;
-            constexpr int kStepKA = (sizeof(Ta) * MMA_ATOM_K) >> 4;
-            constexpr int kStepKB = (sizeof(Tb) * MMA_ATOM_K) >> 4;
+          // if (pred_V && wg_offset_n / 128 + 1 < cdiv(N, 128)) {
+          //     Copy(storage.source.V[1][wg_idx], gmem_V + param_V.stride);
+          // }
+          // if constexpr (WG_N > 1) {
+          //     constexpr int tiles = MMA_ATOM_N / OUTER_N;
+          //     pred_V              = (pred_V >> (wg_idx_n * tiles)) & ((1 <<
+          //     tiles) - 1);
+          // }
+        }
 
-            cutlass::arch::NamedBarrier wg_barrier(WARPGROUP_SIZE, wg_idx + 2);  // 2,3
+        __syncwarp();
 
-            auto epi_barrier = [&](int phase) {  // 0, 1
-                return EmptyBarrier{};
-                // return cutlass::arch::NamedBarrier(WARPGORUPS * WARPGROUP_SIZE, wg_idx ^ phase);
-            };
+        float scale_V[2];
+        // auto  Load_V = [&] {
+        //     scale_V[0] = storage.source.V[0][wg_idx][iter_V];
+        //     if (pred_V) {
+        //         scale_V[1] = storage.source.V[1][wg_idx][iter_V];
+        //     }
+        //     ++iter_V;
+        // };
+        auto Load_V = [&] {
+          // scale_V[0] = scale_V[1] = 1;
+          scale_V[0] = storage.source.V[v_state.index()][iter_V];
+          if (pred_V) {
+            scale_V[1] = storage.source.V[v_state.index()][box_V.x + iter_V];
+          }
+          ++iter_V;
+        };
 
-            if (wg_idx == 1) {
-                epi_barrier(1).arrive_unaligned();
-            }
+        float scale_U[MMA_ITER_M][2];
+        const int offset_U =
+            wg_idx_m * WG_TILE_M + warp_id % 4 * 16 + lane_id / 4;
+        auto Load_U = [&] {
+          for (int m = 0; m < MMA_ITER_M; ++m) {
+            scale_U[m][0] =
+                smem_U[pipe_state.index()][offset_U + m * MMA_ATOM_M];
+            scale_U[m][1] =
+                smem_U[pipe_state.index()][offset_U + m * MMA_ATOM_M + 8];
+          }
+        };
 
-            cutlass::PipelineState<Stages> pipe_state{};
-            cutlass::PipelineState<Stages> v_state{};
-
-            while (sched.next(kSchedWarpGroups)) {
-                auto [cta_tile_p, cluster_tile_p] = sched.is_valid_tile();
-
-                if (!cluster_tile_p) {
-                    // OOB tile caused by swizzle pattern
-                    continue;
-                }
-
-                MMA_Atom::CRegisters frag_C[MMA_ITER_N];
-                MMA_Atom::CRegisters accum_C[MMA_ITER_M][MMA_ITER_N]{};
-
-                const auto tile_offset              = sched.tile_offset();
-                const auto [iter_k_beg, iter_k_end] = sched.iter_k_range();
-
-                // const auto [M, N, K, L] = sched.gemm_shape();
-
-                const int offset_m = tile_offset.x * TILE_M;
-                const int offset_n = tile_offset.y * TILE_N;
-
-                const int wg_offset_n = offset_n + wg_idx_n * WG_TILE_N;
-
-                int k_iter = iter_k_end - iter_k_beg;
-
-                const int warp_id = threadIdx.x / WARP_SIZE;
-                const int lane_id = threadIdx.x % WARP_SIZE;
-
-                auto consumer_arrive = [&] {
-                    __syncwarp();
-                    if constexpr (kClusterSize > 1) {
-                        ConsumerBar::arrive(&consumer_bar[pipe_state.index()], lane_id, lane_id < kClusterSize);
-                    }
-                    else {
-                        if (lane_id == 0) {
-                            ConsumerBar::arrive(&consumer_bar[pipe_state.index()]);
-                        }
-                    }
-                    __syncwarp();
-                };
-
-                if constexpr (kClusterSize > 1) {
-                    if (!cta_tile_p) {  // other CTAs in the cluster are still alive
-                        for (; k_iter > 0; --k_iter) {
-                            ProducerBar::wait(&producer_bar[pipe_state.index()], pipe_state.phase());
-                            consumer_arrive();
-                            ++pipe_state;
-                        }
-                        epi_barrier(0).arrive_and_wait_unaligned();
-                        epi_barrier(1).arrive_unaligned();
-                        continue;
-                    }
-                }
-
-                // auto Copy = [k = cdiv(K, 128)](Tv* dst, const Tv* src) {
-                //     PRAGMA_NO_UNROLL
-                //     for (int i = threadIdx.x % WARPGROUP_SIZE; i < k; i += WARPGROUP_SIZE) {
-                //         dst[i] = __ldg(&src[i]);
-                //     }
-                // };
-                // auto gmem_V = (const Tv*)param_V.ptr + (wg_offset_n / 128) * param_V.stride + (offset_k / 128);
-                // Copy(storage.source.V[0][wg_idx], gmem_V);
-
-                uint32_t pred_V{};
-                int      iter_V{};
-
-                constexpr int OUTER_N = std::gcd(MMA_ATOM_N, 128);
-                if constexpr (OUTER_N != 128) {
-
-                    static_assert(MMA_ATOM_N <= 128 + OUTER_N, "MMA inst is crossing more than 2 scale blocks");
-
-                    constexpr uint32_t mask = (1UL << (WG_TILE_N / OUTER_N)) - 1;
-
-                    int phase = 128 - wg_offset_n % 128;
-                    pred_V    = (mask << (phase / OUTER_N)) & mask;
-
-                    // if (pred_V && wg_offset_n / 128 + 1 < cdiv(N, 128)) {
-                    //     Copy(storage.source.V[1][wg_idx], gmem_V + param_V.stride);
-                    // }
-                    // if constexpr (WG_N > 1) {
-                    //     constexpr int tiles = MMA_ATOM_N / OUTER_N;
-                    //     pred_V              = (pred_V >> (wg_idx_n * tiles)) & ((1 << tiles) - 1);
-                    // }
-                }
-
-                __syncwarp();
-
-                float scale_V[2];
-                // auto  Load_V = [&] {
-                //     scale_V[0] = storage.source.V[0][wg_idx][iter_V];
-                //     if (pred_V) {
-                //         scale_V[1] = storage.source.V[1][wg_idx][iter_V];
-                //     }
-                //     ++iter_V;
-                // };
-                auto Load_V = [&] {
-                    // scale_V[0] = scale_V[1] = 1;
-                    scale_V[0] = storage.source.V[v_state.index()][iter_V];
-                    if (pred_V) {
-                        scale_V[1] = storage.source.V[v_state.index()][box_V.x + iter_V];
-                    }
-                    ++iter_V;
-                };
-
-                float     scale_U[MMA_ITER_M][2];
-                const int offset_U = wg_idx_m * WG_TILE_M + warp_id % 4 * 16 + lane_id / 4;
-                auto      Load_U   = [&] {
-                    for (int m = 0; m < MMA_ITER_M; ++m) {
-                        scale_U[m][0] = smem_U[pipe_state.index()][offset_U + m * MMA_ATOM_M];
-                        scale_U[m][1] = smem_U[pipe_state.index()][offset_U + m * MMA_ATOM_M + 8];
-                    }
-                };
-
-                auto scale_accum = [&](int m) {  // cta_n = mma_iter_n * wg_n * mma_atom_n
-                    float scales[2][2];
-                    scales[0][0] = scale_U[m][0] * scale_V[0];
-                    scales[1][0] = scale_U[m][1] * scale_V[0];
-                    scales[0][1] = scale_U[m][0] * scale_V[1];
-                    scales[1][1] = scale_U[m][1] * scale_V[1];
-                    cute::warpgroup_wait<0>();
-                    PRAGMA_UNROLL
-                    for (int n = 0; n < MMA_ITER_N; ++n) {
-                        PRAGMA_UNROLL
-                        for (int c0 = 0; c0 < MMA_ATOM_N; c0 += OUTER_N) {
-                            bool pred = (pred_V & (1U << (c0 / OUTER_N)));
-                            PRAGMA_UNROLL
-                            for (int cc = 0; cc < OUTER_N; cc += 8) {
-                                int c = c0 + cc;
-                                // clang-format off
+        auto scale_accum =
+            [&](int m) {  // cta_n = mma_iter_n * wg_n * mma_atom_n
+              float scales[2][2];
+              scales[0][0] = scale_U[m][0] * scale_V[0];
+              scales[1][0] = scale_U[m][1] * scale_V[0];
+              scales[0][1] = scale_U[m][0] * scale_V[1];
+              scales[1][1] = scale_U[m][1] * scale_V[1];
+              cute::warpgroup_wait<0>();
+              PRAGMA_UNROLL
+              for (int n = 0; n < MMA_ITER_N; ++n) {
+                PRAGMA_UNROLL
+                for (int c0 = 0; c0 < MMA_ATOM_N; c0 += OUTER_N) {
+                  bool pred = (pred_V & (1U << (c0 / OUTER_N)));
+                  PRAGMA_UNROLL
+                  for (int cc = 0; cc < OUTER_N; cc += 8) {
+                    int c = c0 + cc;
+                    // clang-format off
                                 accum_C[m][n][c / 2 + 0] += (pred ? scales[0][1] : scales[0][0]) * frag_C[n][c / 2 + 0];
                                 accum_C[m][n][c / 2 + 1] += (pred ? scales[0][1] : scales[0][0]) * frag_C[n][c / 2 + 1];
                                 accum_C[m][n][c / 2 + 2] += (pred ? scales[1][1] : scales[1][0]) * frag_C[n][c / 2 + 2];
                                 accum_C[m][n][c / 2 + 3] += (pred ? scales[1][1] : scales[1][0]) * frag_C[n][c / 2 + 3];
-                                // clang-format on
-                            }
-                        }
-                    }
-                };
-
-                auto gmma = [&](int m) {
-                    PRAGMA_UNROLL
-                    for (int k = 0; k < MMA_ITER_K; ++k) {
-                        PRAGMA_UNROLL
-                        for (int n = 0; n < MMA_ITER_N; ++n) {
-                            wgmma<MMA_Atom>(smem_iter_A, smem_iter_B, frag_C[n], k == 0);
-                            smem_iter_B += kStepNB;
-                        }
-                        smem_iter_B -= MMA_ITER_N * kStepNB;
-                        smem_iter_A += kStepKA;
-                        smem_iter_B += kStepKB;
-                    }
-                    smem_iter_A -= MMA_ITER_K * kStepKA;
-                    smem_iter_B -= MMA_ITER_K * kStepKB;
-                    smem_iter_A += kStepMA;
-                    cute::warpgroup_commit_batch();
-                };
-
-                static_assert(MMA_ITER_N == 1);
-
-                wg_barrier.sync();
-
-                ProducerBar::wait(&producer_bar[pipe_state.index()], pipe_state.phase());
-                Load_V();
-                Load_U();
-                smem_iter_A.Reset(pipe_state.index());
-                smem_iter_B.Reset(pipe_state.index());
-                cute::warpgroup_arrive();
-                gmma(0);
-                scale_accum(0);
-                consumer_arrive();
-                ++pipe_state;
-                --k_iter;
-
-                Load_V();
-                ProducerBar::wait(&producer_bar[pipe_state.index()], pipe_state.phase());
-                Load_U();
-                smem_iter_A.Reset(pipe_state.index());
-                smem_iter_B.Reset(pipe_state.index());
-
-                for (; k_iter > 1; --k_iter) {
-                    cute::warpgroup_arrive();
-                    gmma(0);
-                    scale_accum(0);
-                    consumer_arrive();
-                    ++pipe_state;
-                    Load_V();
-                    ProducerBar::wait(&producer_bar[pipe_state.index()], pipe_state.phase());
-                    Load_U();
-                    smem_iter_A.Reset(pipe_state.index());
-                    smem_iter_B.Reset(pipe_state.index());
+                    // clang-format on
+                  }
                 }
+              }
+            };
 
-                cute::warpgroup_arrive();
-                gmma(0);
-                scale_accum(0);
-                consumer_arrive();
-                ++pipe_state;
-                ++v_state;
-
-                const int wg_lane = threadIdx.x % WARPGROUP_SIZE;
-
-                if (wg_lane < LayoutC::C1) {
-                    cute::tma_store_wait<0>();
-                }
-
-                epi_barrier(0).arrive_and_wait_unaligned();
-
-                wg_barrier.sync();
-
-                // void* Cdesc{};
-                // if (threadIdx.x % WARPGROUP_SIZE / WARP_SIZE == 0) {
-                //     Cdesc = update_tma_desc(tm_c, tensormap_buf, &storage.tma_desc_C[wg_idx], wg_idx, param_C.ptr,
-                //     M);
-                // }
-
-                Tc* smem_C = &storage.C[wg_idx_m * WG_TILE_M * TILE_N + wg_idx_n * WG_TILE_N];
-
-                // epilogue
-                PRAGMA_UNROLL
-                for (int m = 0; m < MMA_ITER_M; ++m) {
-                    PRAGMA_UNROLL
-                    for (int n = 0; n < MMA_ITER_N; ++n) {
-
-                        constexpr int N       = LayoutC::C0;
-                        constexpr int SW_bits = log2(kSwizzleC / 16);
-
-                        static_assert(!SW_bits || MMA_ATOM_N % LayoutC::C0 == 0);
-
-                        const int m0 = m * MMA_ATOM_M;
-                        const int n0 = n * MMA_ATOM_N;
-
-                        PRAGMA_UNROLL
-                        for (int i = 0; i < MMA_ATOM_N; i += 16) {
-                            __align__(16) Array<Tc, 8> tvec = cast<Tc>(*(Array<float, 8>*)&accum_C[m][n][i / 2]);
-
-                            int mm = m0 + warp_id % 4 * 16 + (lane_id & 8);
-                            int nn = n0 + i / N * N;
-
-                            int addr = ((nn / N) * WG_TILE_M * N) + (mm * N) + (nn % N);
-
-                            int s = lane_id % 8;
-                            int c = (lane_id & 16) / 2 + i % N;
-
-                            addr += Swizzle<SW_bits, 3, 3>::apply(s * N + c);
-
-                            auto& uvec = (Array<uint32_t, 4>&)tvec;
-                            cute::SM90_U32x4_STSM_N::copy(uvec[0],  //
-                                                          uvec[1],
-                                                          uvec[2],
-                                                          uvec[3],
-                                                          (cutlass::uint128_t&)smem_C[addr]);
-                        }
-                    }
-                }
-
-                cute::tma_store_fence();  // visibility: smem -> async proxy
-
-                wg_barrier.sync();
-
-                if (wg_lane < LayoutC::C1) {
-                    const int tma_n = wg_lane * LayoutC::C0;
-                    // cute::tma_descriptor_fence_acquire((cute::TmaDescriptor*)Cdesc);
-                    cute::SM90_TMA_STORE::copy(&tm_c,
-                                               &smem_C[wg_lane * WG_TILE_M * LayoutC::C0],
-                                               offset_n + wg_idx_n * WG_TILE_N + tma_n,
-                                               offset_m + wg_idx_m * WG_TILE_M);
-                    cute::tma_store_arrive();
-                }
-
-                epi_barrier(1).arrive_unaligned();
-
-            }  // scheduler loop
-
-            if (threadIdx.x % WARPGROUP_SIZE < LayoutC::C1) {
-                cute::tma_store_wait<0>();
+        auto gmma = [&](int m) {
+          PRAGMA_UNROLL
+          for (int k = 0; k < MMA_ITER_K; ++k) {
+            PRAGMA_UNROLL
+            for (int n = 0; n < MMA_ITER_N; ++n) {
+              wgmma<MMA_Atom>(smem_iter_A, smem_iter_B, frag_C[n], k == 0);
+              smem_iter_B += kStepNB;
             }
+            smem_iter_B -= MMA_ITER_N * kStepNB;
+            smem_iter_A += kStepKA;
+            smem_iter_B += kStepKB;
+          }
+          smem_iter_A -= MMA_ITER_K * kStepKA;
+          smem_iter_B -= MMA_ITER_K * kStepKB;
+          smem_iter_A += kStepMA;
+          cute::warpgroup_commit_batch();
+        };
 
-            if (wg_idx == 0) {
-                epi_barrier(0).arrive_and_wait_unaligned();
+        static_assert(MMA_ITER_N == 1);
+
+        wg_barrier.sync();
+
+        ProducerBar::wait(&producer_bar[pipe_state.index()],
+                          pipe_state.phase());
+        Load_V();
+        Load_U();
+        smem_iter_A.Reset(pipe_state.index());
+        smem_iter_B.Reset(pipe_state.index());
+        cute::warpgroup_arrive();
+        gmma(0);
+        scale_accum(0);
+        consumer_arrive();
+        ++pipe_state;
+        --k_iter;
+
+        Load_V();
+        ProducerBar::wait(&producer_bar[pipe_state.index()],
+                          pipe_state.phase());
+        Load_U();
+        smem_iter_A.Reset(pipe_state.index());
+        smem_iter_B.Reset(pipe_state.index());
+
+        for (; k_iter > 1; --k_iter) {
+          cute::warpgroup_arrive();
+          gmma(0);
+          scale_accum(0);
+          consumer_arrive();
+          ++pipe_state;
+          Load_V();
+          ProducerBar::wait(&producer_bar[pipe_state.index()],
+                            pipe_state.phase());
+          Load_U();
+          smem_iter_A.Reset(pipe_state.index());
+          smem_iter_B.Reset(pipe_state.index());
+        }
+
+        cute::warpgroup_arrive();
+        gmma(0);
+        scale_accum(0);
+        consumer_arrive();
+        ++pipe_state;
+        ++v_state;
+
+        const int wg_lane = threadIdx.x % WARPGROUP_SIZE;
+
+        if (wg_lane < LayoutC::C1) {
+          cute::tma_store_wait<0>();
+        }
+
+        epi_barrier(0).arrive_and_wait_unaligned();
+
+        wg_barrier.sync();
+
+        // void* Cdesc{};
+        // if (threadIdx.x % WARPGROUP_SIZE / WARP_SIZE == 0) {
+        //     Cdesc = update_tma_desc(tm_c, tensormap_buf,
+        //     &storage.tma_desc_C[wg_idx], wg_idx, param_C.ptr, M);
+        // }
+
+        Tc* smem_C =
+            &storage.C[wg_idx_m * WG_TILE_M * TILE_N + wg_idx_n * WG_TILE_N];
+
+        // epilogue
+        PRAGMA_UNROLL
+        for (int m = 0; m < MMA_ITER_M; ++m) {
+          PRAGMA_UNROLL
+          for (int n = 0; n < MMA_ITER_N; ++n) {
+            constexpr int N = LayoutC::C0;
+            constexpr int SW_bits = log2(kSwizzleC / 16);
+
+            static_assert(!SW_bits || MMA_ATOM_N % LayoutC::C0 == 0);
+
+            const int m0 = m * MMA_ATOM_M;
+            const int n0 = n * MMA_ATOM_N;
+
+            PRAGMA_UNROLL
+            for (int i = 0; i < MMA_ATOM_N; i += 16) {
+              __align__(16) Array<Tc, 8> tvec =
+                  cast<Tc>(*(Array<float, 8>*)&accum_C[m][n][i / 2]);
+
+              int mm = m0 + warp_id % 4 * 16 + (lane_id & 8);
+              int nn = n0 + i / N * N;
+
+              int addr = ((nn / N) * WG_TILE_M * N) + (mm * N) + (nn % N);
+
+              int s = lane_id % 8;
+              int c = (lane_id & 16) / 2 + i % N;
+
+              addr += Swizzle<SW_bits, 3, 3>::apply(s * N + c);
+
+              auto& uvec = (Array<uint32_t, 4>&)tvec;
+              cute::SM90_U32x4_STSM_N::copy(uvec[0],  //
+                                            uvec[1], uvec[2], uvec[3],
+                                            (cutlass::uint128_t&)smem_C[addr]);
             }
+          }
         }
 
-        if constexpr (kClusterSize > 1) {
-            cute::cluster_arrive();
-            cute::cluster_wait();
+        cute::tma_store_fence();  // visibility: smem -> async proxy
+
+        wg_barrier.sync();
+
+        if (wg_lane < LayoutC::C1) {
+          const int tma_n = wg_lane * LayoutC::C0;
+          // cute::tma_descriptor_fence_acquire((cute::TmaDescriptor*)Cdesc);
+          cute::SM90_TMA_STORE::copy(&tm_c,
+                                     &smem_C[wg_lane * WG_TILE_M * LayoutC::C0],
+                                     offset_n + wg_idx_n * WG_TILE_N + tma_n,
+                                     offset_m + wg_idx_m * WG_TILE_M);
+          cute::tma_store_arrive();
         }
 
-    }  // operator()
+        epi_barrier(1).arrive_unaligned();
 
-    struct EmptyBarrier {
-        __device__      EmptyBarrier(...) {}
-        __device__ void arrive_and_wait_unaligned() {}
-        __device__ void arrive_unaligned() {}
-    };
+      }  // scheduler loop
 
-    __device__ void* update_tma_desc(const CUtensorMap& param_desc,
-                                     CUtensorMap*       gmem_desc,
-                                     CUtensorMap*       smem_desc,
-                                     int                index,
-                                     void*              global_addr,
-                                     int                dim)
-    {
-        uint32_t uint_ptr = cast_smem_ptr_to_uint(smem_desc);
+      if (threadIdx.x % WARPGROUP_SIZE < LayoutC::C1) {
+        cute::tma_store_wait<0>();
+      }
 
-        const int lane_id = threadIdx.x % WARP_SIZE;
+      if (wg_idx == 0) {
+        epi_barrier(0).arrive_and_wait_unaligned();
+      }
+    }
 
-        if (lane_id < sizeof(CUtensorMap) / sizeof(uint2)) {
-            ((uint2*)smem_desc)[lane_id] = ((uint2*)&param_desc)[lane_id];
-        }
+    if constexpr (kClusterSize > 1) {
+      cute::cluster_arrive();
+      cute::cluster_wait();
+    }
 
-        __syncwarp();
+  }  // operator()
 
-        if (lane_id == 0) {
-            // clang-format off
+  struct EmptyBarrier {
+    __device__ EmptyBarrier(...) {}
+    __device__ void arrive_and_wait_unaligned() {}
+    __device__ void arrive_unaligned() {}
+  };
+
+  __device__ void* update_tma_desc(const CUtensorMap& param_desc,
+                                   CUtensorMap* gmem_desc,
+                                   CUtensorMap* smem_desc, int index,
+                                   void* global_addr, int dim) {
+    uint32_t uint_ptr = cast_smem_ptr_to_uint(smem_desc);
+
+    const int lane_id = threadIdx.x % WARP_SIZE;
+
+    if (lane_id < sizeof(CUtensorMap) / sizeof(uint2)) {
+      ((uint2*)smem_desc)[lane_id] = ((uint2*)&param_desc)[lane_id];
+    }
+
+    __syncwarp();
+
+    if (lane_id == 0) {
+      // clang-format off
             asm volatile("tensormap.replace.tile.global_address.shared::cta.b1024.b64 [%0], %1;" ::"r"(uint_ptr), "l"(global_addr));
             asm volatile("tensormap.replace.tile.global_dim.shared::cta.b1024.b32 [%0], 1, %1;" ::"r"(uint_ptr), "r"(dim));
-            // clang-format on
-        }
-
-        __syncwarp();
-
-        constexpr int kNumPerCta = 4;
-
-        auto gmem_ptr = (void*)&gmem_desc[blockIdx.x * kNumPerCta + index];
-
-        // clang-format off
-        asm volatile("tensormap.cp_fenceproxy.global.shared::cta.tensormap::generic.release.gpu.sync.aligned [%0], [%1], 128;" :: "l"(gmem_ptr), "r"(uint_ptr));
-        // clang-format on
-
-        return gmem_ptr;
+      // clang-format on
     }
+
+    __syncwarp();
+
+    constexpr int kNumPerCta = 4;
+
+    auto gmem_ptr = (void*)&gmem_desc[blockIdx.x * kNumPerCta + index];
+
+    // clang-format off
+        asm volatile("tensormap.cp_fenceproxy.global.shared::cta.tensormap::generic.release.gpu.sync.aligned [%0], [%1], 128;" :: "l"(gmem_ptr), "r"(uint_ptr));
+    // clang-format on
+
+    return gmem_ptr;
+  }
 };
 
 }  // namespace turbomind::gemm

--- a/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/gemm_universal_sm90_v5.h
+++ b/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/gemm_universal_sm90_v5.h
@@ -40,652 +40,664 @@
 
 namespace turbomind::gemm {
 
-template<Order raster_order, int multicast_a, int multicast_b, bool is_grouped_gemm_>
+template <Order raster_order, int multicast_a, int multicast_b,
+          bool is_grouped_gemm_>
 struct GemmUniversalSm90_v5 {
+  static constexpr bool kDebug = false;
 
-    static constexpr bool kDebug = false;
+  using Arch = Sm90;
 
-    using Arch = Sm90;
+  static constexpr int WARPGORUPS = 4;
 
-    static constexpr int WARPGORUPS = 4;
+  static constexpr int TILE_M = 128;
+  static constexpr int TILE_N = 96;
+  static constexpr int TILE_K = 128;
 
-    static constexpr int TILE_M = 128;
-    static constexpr int TILE_N = 96;
-    static constexpr int TILE_K = 128;
+  static constexpr int WG_M = 2;
+  static constexpr int WG_N = 1;
 
-    static constexpr int WG_M = 2;
-    static constexpr int WG_N = 1;
+  static constexpr int WG_TILE_M = TILE_M / WG_M;
+  static constexpr int WG_TILE_N = TILE_N / WG_N;
 
-    static constexpr int WG_TILE_M = TILE_M / WG_M;
-    static constexpr int WG_TILE_N = TILE_N / WG_N;
+  using GMMA = ScaledGmmaFP8_TN<WG_TILE_M, WG_TILE_N, TILE_K, 1, 1, 1, 1>;
 
-    using GMMA = ScaledGmmaFP8_TN<WG_TILE_M, WG_TILE_N, TILE_K, 1, 1, 1, 1>;
+  static constexpr int kMulticastA = multicast_a;
+  static constexpr int kMulticastB = multicast_b;
 
-    static constexpr int kMulticastA = multicast_a;
-    static constexpr int kMulticastB = multicast_b;
+  static constexpr int kClusterSize = kMulticastA * kMulticastB;
 
-    static constexpr int kClusterSize = kMulticastA * kMulticastB;
+  static constexpr int Stages = 5;
 
-    static constexpr int Stages = 5;
+  static constexpr bool kSplitK = false;
+  static constexpr int kChunkSizeK = TILE_K;
 
-    static constexpr bool kSplitK     = false;
-    static constexpr int  kChunkSizeK = TILE_K;
+  static constexpr int WARPGROUP_SIZE = 128;
+  static constexpr int kMathGroupSize = 256;
 
-    static constexpr int WARPGROUP_SIZE = 128;
-    static constexpr int kMathGroupSize = 256;
+  static constexpr int CTA_SIZE = WARPGROUP_SIZE * (WARPGORUPS + 1);
 
-    static constexpr int CTA_SIZE = WARPGROUP_SIZE * (WARPGORUPS + 1);
+  using Ta = __nv_fp8_e4m3;
+  using Tb = __nv_fp8_e4m3;
+  using Tc = nv_bfloat16;
 
-    using Ta = __nv_fp8_e4m3;
-    using Tb = __nv_fp8_e4m3;
-    using Tc = nv_bfloat16;
+  using Tu = float;
+  using Tv = float;
 
-    using Tu = float;
-    using Tv = float;
+  using Cluster = arch::Cluster<kMulticastB, kMulticastA, kRowMajor>;
 
-    using Cluster = arch::Cluster<kMulticastB, kMulticastA, kRowMajor>;
+  static constexpr auto is_grouped_gemm = is_grouped_gemm_;
 
-    static constexpr auto is_grouped_gemm = is_grouped_gemm_;
+  using Scheduler = TileScheduler<raster_order, Cluster, true, true, TILE_M,
+                                  TILE_N, Stages, is_grouped_gemm>;
 
-    using Scheduler = TileScheduler<raster_order, Cluster, true, true, TILE_M, TILE_N, Stages, is_grouped_gemm>;
+  static constexpr int kMulticastU = is_grouped_gemm ? 1 : kMulticastA;
 
-    static constexpr int kMulticastU = is_grouped_gemm ? 1 : kMulticastA;
+  using ProducerBar = cutlass::arch::ClusterTransactionBarrier;
+  using ConsumerBar = cutlass::arch::ClusterBarrier;
 
-    using ProducerBar = cutlass::arch::ClusterTransactionBarrier;
-    using ConsumerBar = cutlass::arch::ClusterBarrier;
+  static constexpr int MAX_K = 32768;
+  static constexpr int MAX_K_BLOCKS = cdiv(MAX_K, 128);
 
-    static constexpr int MAX_K        = 32768;
-    static constexpr int MAX_K_BLOCKS = cdiv(MAX_K, 128);
+  static constexpr int kAlignmentU = 16 / sizeof(Tu);
+  static constexpr int kBoxU = TILE_M + (is_grouped_gemm ? kAlignmentU : 0);
 
-    static constexpr int kAlignmentU = 16 / sizeof(Tu);
-    static constexpr int kBoxU       = TILE_M + (is_grouped_gemm ? kAlignmentU : 0);
+  // Alignment requirement for SMEM addr. This forbids multicast factor 8.
+  static_assert(kMulticastU == 1 ||
+                sizeof(Tu) * kBoxU / kMulticastU % 128 == 0);
 
-    // Alignment requirement for SMEM addr. This forbids multicast factor 8.
-    static_assert(kMulticastU == 1 || sizeof(Tu) * kBoxU / kMulticastU % 128 == 0);
+  static constexpr int kTmaTxBytes = sizeof(Ta) * (TILE_M * TILE_K) +
+                                     sizeof(Tb) * (TILE_N * TILE_K) +
+                                     sizeof(Tu) * kBoxU;
 
-    static constexpr int kTmaTxBytes =
-        sizeof(Ta) * (TILE_M * TILE_K) + sizeof(Tb) * (TILE_N * TILE_K) + sizeof(Tu) * kBoxU;
+  static constexpr int kTmaDescNum = 7;
 
-    static constexpr int kTmaDescNum = 7;
-
-    // ! Smem addr must be SBO aligned for TMA load/store
-    struct SharedStorage {
-        struct Source {
-            __align__(1024) Array<Ta, Stages * TILE_M * TILE_K> A;
-            __align__(1024) Array<Tb, Stages * TILE_N * TILE_K> B;
-            __align__(1024) Tu U[Stages][round_up<int>(kBoxU, 128)];
-            __align__(1024) Tv V[Stages][2];
-        };
-        Source source;
-        __align__(1024) Array<Tc, TILE_M * TILE_N> C;
-        __align__(128) uint64_t producer_bar[Stages];
-        __align__(128) uint64_t consumer_bar[Stages];
-        __align__(128) CUtensorMap tma_desc_buf[kTmaDescNum];  //
-        int                         pipe_count[2];
-        typename Scheduler::Storage sched;
+  // ! Smem addr must be SBO aligned for TMA load/store
+  struct SharedStorage {
+    struct Source {
+      __align__(1024) Array<Ta, Stages * TILE_M * TILE_K> A;
+      __align__(1024) Array<Tb, Stages * TILE_N * TILE_K> B;
+      __align__(1024) Tu U[Stages][round_up<int>(kBoxU, 128)];
+      __align__(1024) Tv V[Stages][2];
     };
-
-    static constexpr int kSmemSize = sizeof(SharedStorage);
-
-    static constexpr int kSwizzleC = 2 * std::gcd(WG_TILE_N, 128 / sizeof(Tc));
-
-    using LayoutC = std::conditional_t<kSwizzleC >= 32,
-                                       SmemLayoutV2<WG_TILE_M, WG_TILE_N, -1, kSwizzleC / sizeof(Tc)>,
-                                       SmemLayoutV2<WG_TILE_M, WG_TILE_N>>;
-
-    static constexpr int OUTER_N       = GMMA::OUTER_N;
-    static constexpr int MMA_SUBTILE_N = GMMA::OP_N / OUTER_N;
-
-    __device__ void operator()(const CUtensorMap& tm_a,
-                               const CUtensorMap& tm_b,
-                               const CUtensorMap& tm_c,
-                               const CUtensorMap& tm_u,
-                               const CUtensorMap& tm_v,
-                               const MatrixParam& param_A,
-                               const MatrixParam& param_B,
-                               const MatrixParam& param_U,
-                               const MatrixParam& param_V,
-                               const MatrixParam& param_C,
-                               Scheduler          sched,
-                               CUtensorMap*       tensormap_buf,
-                               char*              smem_buf)
-    {
-        SharedStorage& storage = *reinterpret_cast<SharedStorage*>(smem_buf);
-
-        uint64_t* producer_bar = storage.producer_bar;
-        uint64_t* consumer_bar = storage.consumer_bar;
-
-        if (threadIdx.x == 0) {
-            PRAGMA_UNROLL
-            for (int s = 0; s < Stages; ++s) {
-                ProducerBar::init(&producer_bar[s], 1 + 1);
-                ConsumerBar::init(&consumer_bar[s], kClusterSize * (kMathGroupSize / WARP_SIZE));
-            }
-            sched.init_dyanmic(storage.sched, kClusterSize * (kMathGroupSize / WARP_SIZE + 1));
-            cutlass::arch::fence_view_async_shared();
-            if constexpr (kClusterSize > 1) {
-                cutlass::arch::fence_barrier_init();
-            }
-            PRAGMA_UNROLL
-            for (int i = 0; i < 2; ++i) {
-                storage.pipe_count[i] = 0;
-            }
-        }
-
-        (kClusterSize > 1) ? cute::cluster_sync() : __syncthreads();
-
-        const int wg_idx = cutlass::canonical_warp_group_idx();
-
-        if (wg_idx == WARPGORUPS) {
-            cutlass::arch::warpgroup_reg_dealloc<32>();
-
-            static_assert(TILE_M % kMulticastA == 0);
-            static_assert(TILE_N % kMulticastB == 0);
-
-            cutlass::arch::NamedBarrier producers_bar(WARP_SIZE * 2, 6);
-
-            const int  warp_id = cutlass::canonical_warp_idx_sync();
-            const bool cta_0   = cute::block_id_in_cluster().x == 0;
-
-            if (warp_id % 4 == 0) {
-
-                Cluster cluster(cute::block_id_in_cluster().x);
-
-                const int mc_offset_m = cluster.cta_n() * (TILE_M / kMulticastA);
-                const int mc_offset_n = cluster.cta_m() * (TILE_N / kMulticastB);
-
-                auto  smem_A = storage.source.A.data() + mc_offset_m * TILE_K;
-                auto  smem_B = storage.source.B.data() + mc_offset_n * TILE_K;
-                auto& smem_U = storage.source.U;
-                auto& smem_V = storage.source.V;
-
-                if constexpr (is_grouped_gemm) {
-                    init_tma_descs<3>({&tm_a, &tm_b, &tm_u}, storage.tma_desc_buf);
-                }
-
-                cutlass::PipelineState<Stages> write_state{0, 1, 0};
-
-                auto sched_state = sched.init_consumer(storage.sched);
-
-                int lane_predicate = cute::elect_one_sync();
-
-                typename Scheduler::Tile* tile;
-
-                while (sched_state.acquire(tile)) {
-
-                    // if (cute::elect_one_sync()) {
-                    //     printf("READ m %d n %d g %d v %s\n",
-                    //            tile->offset_m,
-                    //            tile->offset_n,
-                    //            tile->group_idx,
-                    //            tile->is_valid_cluster ? "true" : "false");
-                    // }
-
-                    if constexpr (Scheduler::is_dynamic) {
-                        if (cta_0) {
-                            producers_bar.arrive_unaligned();
-                        }
-                    }
-
-                    if (tile->is_valid_cluster) {
-
-                        const CUtensorMap* Adesc = &tm_a;
-                        const CUtensorMap* Bdesc = &tm_b;
-                        const CUtensorMap* Udesc = &tm_u;
-
-                        const Tv* gmem_V0 = (const Tv*)param_V.ptr;
-                        const Tv* gmem_V1;
-
-                        if constexpr (is_grouped_gemm) {
-                            const int g  = tile->group_idx;
-                            const int m0 = tile->m0;
-                            const int m1 = tile->m1;
-                            const int m  = m1 - m0;
-
-                            Array<void*, 3> global_addrs;
-                            global_addrs[0] = (Ta*)param_A.ptr + m0 * (int64_t)param_A.stride;
-                            global_addrs[1] = ((void**)param_B.ptr)[g];
-
-                            const int beg_u = m0 / kAlignmentU * kAlignmentU;
-                            const int end_u = round_up(m1, kAlignmentU);
-                            global_addrs[2] = (Tu*)param_U.ptr + beg_u;
-
-                            Array<int, 3> dims;
-                            dims[0] = m;
-                            dims[1] = sched.gemm_shape().y;
-                            dims[2] = end_u - beg_u;
-
-                            auto descs = update_tma_descs(tensormap_buf, storage.tma_desc_buf, global_addrs, dims);
-                            Adesc      = &descs[0];
-                            Bdesc      = &descs[1];
-                            Udesc      = &descs[2];
-
-                            gmem_V0 = ((Tv**)gmem_V0)[g];
-
-                            PRAGMA_UNROLL
-                            for (int i = 0; i < 3; ++i) {
-                                cute::tma_descriptor_fence_acquire((cute::TmaDescriptor*)&descs[i]);
-                            }
-                        }
-
-                        if (lane_predicate) {
-
-                            const int offset_k = 0;
-
-                            const uint16_t mask_A = cluster.mask_m();
-                            const uint16_t mask_B = cluster.mask_n();
-
-                            const int offset_m = tile->offset_m;
-                            const int offset_n = tile->offset_n;
-
-                            int k_iter = sched.k_iters_;
-
-                            GmemIteratorSm90<kMulticastA> gmem_A{
-                                Adesc, {offset_k, offset_m + mc_offset_m}, {TILE_K, 0}};
-                            GmemIteratorSm90<kMulticastB> gmem_B{
-                                Bdesc, {offset_k, offset_n + mc_offset_n}, {TILE_K, 0}};
-
-                            const int mc_offset_u = kMulticastU > 1 ? mc_offset_m : 0;
-                            // column-major
-                            GmemIteratorSm90<kMulticastU> gmem_U{
-                                Udesc, {offset_m + mc_offset_u, offset_k / 128}, {0, 1}};
-
-                            gmem_V0 += (offset_n / 128) * param_V.stride + (offset_k / 128);
-                            gmem_V1 = gmem_V0;
-                            if (offset_n / 128 + 1 < cdiv(sched.gemm_shape().y, 128)) {
-                                gmem_V1 += param_V.stride;
-                            }
-
-                            for (; k_iter > 0; --k_iter) {
-                                int pipe = write_state.index();
-                                ConsumerBar::wait(&consumer_bar[pipe], write_state.phase());
-                                ProducerBar::arrive_and_expect_tx(&producer_bar[pipe], kTmaTxBytes);
-                                gmem_A.Step(&producer_bar[pipe], &smem_A[pipe * TILE_M * TILE_K], mask_A);
-                                gmem_B.Step(&producer_bar[pipe], &smem_B[pipe * TILE_N * TILE_K], mask_B);
-                                gmem_U.Step(&producer_bar[pipe], &smem_U[pipe][0] + mc_offset_u, mask_A);
-                                uint32_t uint_ptr_V = cast_smem_ptr_to_uint(smem_V[pipe]);
-                                CP_ASYNC<CacheOp::kAlways, 4, 0>::apply(uint_ptr_V, gmem_V0, true);
-                                CP_ASYNC<CacheOp::kAlways, 4, 0>::apply(uint_ptr_V + sizeof(Tv), gmem_V1, true);
-                                ++gmem_V0;
-                                ++gmem_V1;
-                                cutlass::arch::cpasync_barrier_arrive_noinc(&producer_bar[pipe]);
-                                ++write_state;
-                            }
-                        }
-                    }
-
-                    sched_state.release();
-
-                }  // scheduler loop
-
-                sched_state.release();
-
-                // pair with the EXTRA tile
-                sched_state.acquire(tile);
-                sched_state.release();
-
-                if constexpr (kClusterSize > 1) {
-                    if (lane_predicate) {
-                        for (int i = 0; i < Stages; ++i) {
-                            ConsumerBar::wait(&consumer_bar[write_state.index()], write_state.phase());
-                            ++write_state;
-                        }
-                    }
-                    __syncwarp();
-                }
-            }
-            else if (warp_id % 4 == 1 && cta_0) {
-                auto sched_state = sched.init_producer(storage.sched);
-                while (sched_state.next()) {
-                    if constexpr (Scheduler::is_dynamic) {
-                        producers_bar.arrive_and_wait_unaligned();
-                    }
-                }
-                // send EXTRA null tile (to math WGs)
-                sched_state.next();
-                sched.tail(sched_state);
-            }
-        }
-        else {
-            cutlass::arch::warpgroup_reg_alloc<112>();
-
-            const int math_group_idx = wg_idx / 2;
-
-            if constexpr (is_grouped_gemm) {
-                if (threadIdx.x % WARPGROUP_SIZE / WARP_SIZE == 0) {
-                    init_tma_descs<1>({&tm_c}, storage.tma_desc_buf + 3 + wg_idx);
-                }
-            }
-
-            auto& smem_A = storage.source.A;
-            auto& smem_B = storage.source.B;
-            auto& smem_U = storage.source.U;
-            auto& smem_V = storage.source.V;
-
-            const int wg_idx_m = WG_M > 1 ? wg_idx % 2 % WG_M : 0;
-            const int wg_idx_n = WG_N > 1 ? wg_idx % 2 / WG_M : 0;
-
-            auto smem_desc_A = make_smem_desc(&smem_A[wg_idx_m * WG_TILE_M * TILE_K], 1);
-            auto smem_desc_B = make_smem_desc(&smem_B[wg_idx_n * WG_TILE_N * TILE_K], 1);
-
-            SmemDescIterV2<Stages, ((TILE_M * TILE_K) >> 4)> smem_iter_A{smem_desc_A};
-            SmemDescIterV2<Stages, ((TILE_N * TILE_K) >> 4)> smem_iter_B{smem_desc_B};
-
-            const int  thread_idx    = threadIdx.x % WARPGROUP_SIZE;
-            const bool math_leader_p = threadIdx.x % kMathGroupSize == 0;
-
-            auto math_barrier_sync = [&](int phase, int alive = 1) {
-                constexpr int base       = (int)cutlass::arch::ReservedNamedBarriers::FirstUserBarrier;
-                const int     barrier_id = base + math_group_idx ^ phase;
-                constexpr int threads    = WARPGORUPS * WARPGROUP_SIZE;
-                int           res        = 0;
-                asm volatile("{\n"
-                             "  .reg.pred p;\n"
-                             "  setp.ne.b32 p, %3, 0;\n"
-                             "  barrier.cta.red.or.pred p, %1, %2, p;\n"
-                             "  selp.s32 %0, 1, 0, p;\n"
-                             "}\n"
-                             : "=r"(res)
-                             : "r"(barrier_id), "r"(threads), "r"(alive));
-                return res;
-            };
-
-            cutlass::arch::NamedBarrier barrier(WARPGROUP_SIZE, 2 + wg_idx);  // 2,3,4,5
-
-            cutlass::PipelineState<Stages> pipe_state{};
-
-            const int warp_id = cutlass::canonical_warp_idx_sync();
-            const int lane_id = cutlass::canonical_lane_idx();
-
-            auto consumer_arrive = [&] {
-                auto bar = &consumer_bar[pipe_state.index()];
-                __syncwarp();
-                if constexpr (kClusterSize > 1) {
-                    ConsumerBar::arrive(bar, lane_id, lane_id < kClusterSize);
-                }
-                else {
-                    if (lane_id == 0) {
-                        ConsumerBar::arrive(bar);
-                    }
-                }
-            };
-
-            auto sched_state = sched.init_consumer(storage.sched);
-
-            if (math_group_idx == 1) {
-                ++sched_state.pipe;
-                math_barrier_sync(1);
-            }
-
-            typename Scheduler::Tile* tile;
-
-            sched_state.acquire(tile);
-
-            while (tile->alive) {
-
-                if (tile->is_valid_cta) {
-
-                    GMMA::AccumC accum_C{};
-                    GMMA::FragC  frag_C;
-
-                    const auto [_, N, K, L] = sched.gemm_shape();
-
-                    const int offset_m = tile->offset_m;
-                    const int offset_n = tile->offset_n;
-
-                    int k_iter = sched.k_iters_;
-
-                    auto pred_V = Fetch_V(param_V, K, N, tile, math_group_idx, wg_idx_n, storage);
-
-                    float scale_V[2];
-                    auto  Load_V = [&] {
-                        scale_V[0] = smem_V[pipe_state.index()][0];
-                        scale_V[1] = smem_V[pipe_state.index()][1];
-                    };
-
-                    int offset_U = wg_idx_m * WG_TILE_M + warp_id % 4 * 16 + lane_id / 4;
-                    if constexpr (is_grouped_gemm) {
-                        offset_U += tile->m0 % kAlignmentU;
-                    }
-                    GMMA::FragU frag_U;
-                    auto        Load_U = [&] {
-                        GMMA::foreach_m(frag_U, [&](auto& U, int m) {
-                            U[0] = smem_U[pipe_state.index()][offset_U + m * GMMA::OP_M];
-                            U[1] = smem_U[pipe_state.index()][offset_U + m * GMMA::OP_M + 8];
-                        });
-                    };
-
-                    auto gmma = [&] {  //
-                        GMMA::apply(smem_iter_A, smem_iter_B, frag_C, accum_C, frag_U, scale_V, pred_V);
-                    };
-
-                    if constexpr (is_grouped_gemm) {
-                        if (warp_id % 4 == 0) {
-                            int  m0 = tile->m0, m1 = tile->m1;
-                            auto addr = (Tc*)param_C.ptr + m0 * (int64_t)param_C.stride;
-                            int  idx  = 3 + wg_idx;
-                            update_tma_descs<1>(tensormap_buf + idx, storage.tma_desc_buf + idx, {addr}, {m1 - m0});
-                        }
-                    }
-
-                    math_barrier_sync(0);
-
-                    pipe_state = {};
-                    pipe_state.advance(storage.pipe_count[math_group_idx ^ 1]);
-
-                    ProducerBar::wait(&producer_bar[pipe_state.index()], pipe_state.phase());
-                    Load_V();
-                    Load_U();
-                    smem_iter_A.Reset(pipe_state.index());
-                    smem_iter_B.Reset(pipe_state.index());
-                    gmma();
-                    consumer_arrive();
-                    ++pipe_state;
-                    --k_iter;
-
-                    ProducerBar::wait(&producer_bar[pipe_state.index()], pipe_state.phase());
-                    Load_V();
-                    Load_U();
-                    smem_iter_A.Reset(pipe_state.index());
-                    smem_iter_B.Reset(pipe_state.index());
-
-                    PRAGMA_NO_UNROLL
-                    for (; k_iter > 1; --k_iter) {
-                        gmma();
-                        consumer_arrive();
-                        ++pipe_state;
-                        ProducerBar::wait(&producer_bar[pipe_state.index()], pipe_state.phase());
-                        Load_V();
-                        Load_U();
-                        smem_iter_A.Reset(pipe_state.index());
-                        smem_iter_B.Reset(pipe_state.index());
-                    }
-
-                    if (math_leader_p) {
-                        storage.pipe_count[math_group_idx] = pipe_state.count() + 1;
-                    }
-                    math_barrier_sync(1);
-
-                    gmma();
-                    consumer_arrive();
-
-                    Tc* smem_C = &storage.C[wg_idx_m * WG_TILE_M * TILE_N + wg_idx_n * WG_TILE_N];
-
-                    GMMA::foreach_C(accum_C, [&](const auto& C, int m, int n) {
-                        constexpr int N       = LayoutC::C0;
-                        constexpr int SW_bits = log2(kSwizzleC / 16);
-
-                        static_assert(!SW_bits || GMMA::OP_N % LayoutC::C0 == 0);
-                        static_assert(GMMA::OP_N % 16 == 0);
-
-                        const int m0 = m * GMMA::OP_M;
-                        const int n0 = n * GMMA::OP_N;
-
-                        PRAGMA_UNROLL
-                        for (int i = 0; i < GMMA::OP_N; i += 16) {
-                            __align__(16) Array<Tc, 8> tvec = cast<Tc>(*(Array<float, 8>*)&C[i / 2]);
-                            // fill(tvec, Tc(255));
-                            int mm = m0 + warp_id % 4 * 16 + (lane_id & 8);
-                            int nn = n0 + i / N * N;
-
-                            int addr = ((nn / N) * WG_TILE_M * N) + (mm * N) + (nn % N);
-
-                            int s = lane_id % 8;
-                            int c = (lane_id & 16) / 2 + i % N;
-
-                            addr += Swizzle<SW_bits, 3, 3>::apply(s * N + c);
-
-                            auto& uvec = (Array<uint32_t, 4>&)tvec;
-                            cute::SM90_U32x4_STSM_N::copy(
-                                uvec[0], uvec[1], uvec[2], uvec[3], (cutlass::uint128_t&)smem_C[addr]);
-                        }
-                    });
-
-                    cute::tma_store_fence();  // visibility: smem -> async proxy
-
-                    barrier.sync();
-
-                    if (thread_idx < LayoutC::C1) {
-                        const void* Cdesc = &tm_c;
-                        const int   tma_n = thread_idx * LayoutC::C0;
-                        if constexpr (is_grouped_gemm) {
-                            Cdesc = &tensormap_buf[blockIdx.x * kTmaDescNum + 3 + wg_idx];
-                            cute::tma_descriptor_fence_acquire((cute::TmaDescriptor*)Cdesc);
-                        }
-                        cute::SM90_TMA_STORE::copy(Cdesc,
-                                                   &smem_C[thread_idx * WG_TILE_M * LayoutC::C0],
-                                                   offset_n + wg_idx_n * WG_TILE_N + tma_n,
-                                                   offset_m + wg_idx_m * WG_TILE_M);
-                        cute::tma_store_arrive();
-                        cute::tma_store_wait<0>();
-                    }
-
-                }  // valid cta tile
-                else {
-                    math_barrier_sync(0);
-
-                    pipe_state = {};
-                    pipe_state.advance(storage.pipe_count[math_group_idx ^ 1]);
-
-                    if (tile->is_valid_cluster) {
-                        // other CTAs in the cluster are still alive
-                        for (int k_iter = sched.k_iters_; k_iter > 0; --k_iter) {
-                            ProducerBar::wait(&producer_bar[pipe_state.index()], pipe_state.phase());
-                            consumer_arrive();
-                            ++pipe_state;
-                        }
-                    }
-
-                    if (math_leader_p) {
-                        storage.pipe_count[math_group_idx] = pipe_state.count();
-                    }
-
-                    math_barrier_sync(1);
-                }
-
-                sched_state.release(2);
-                sched_state.acquire(tile);
-            }  // scheduler loop
-
-            sched_state.release(2);  // release the last tile
-
-            if (math_group_idx == 0) {
-                math_barrier_sync(0, 0);
-                if (math_leader_p) {
-                    storage.pipe_count[0] = storage.pipe_count[1];
-                }
-                while (math_barrier_sync(1, 0)) {
-                    math_barrier_sync(0, 0);
-                    if (math_leader_p) {
-                        storage.pipe_count[0] = storage.pipe_count[1];
-                    }
-                }
-            }
-            else {
-                while (math_barrier_sync(0, 0)) {
-                    if (math_leader_p) {
-                        storage.pipe_count[1] = storage.pipe_count[0];
-                    }
-                    math_barrier_sync(1, 0);
-                }
-            }
-        }
-
-    }  // operator()
-
-    template<int N>
-    __device__ void init_tma_descs(Array<const CUtensorMap*, N> param_desc, CUtensorMap* smem_desc)
-    {
-        const int lane_id = threadIdx.x % WARP_SIZE;
-
-        if (lane_id < sizeof(CUtensorMap) / sizeof(uint2)) {
-            PRAGMA_UNROLL
-            for (int i = 0; i < N; ++i) {
-                ((uint2*)&smem_desc[i])[lane_id] = ((uint2*)param_desc[i])[lane_id];
-            }
-        }
-
-        __syncwarp();
+    Source source;
+    __align__(1024) Array<Tc, TILE_M * TILE_N> C;
+    __align__(128) uint64_t producer_bar[Stages];
+    __align__(128) uint64_t consumer_bar[Stages];
+    __align__(128) CUtensorMap tma_desc_buf[kTmaDescNum];  //
+    int pipe_count[2];
+    typename Scheduler::Storage sched;
+  };
+
+  static constexpr int kSmemSize = sizeof(SharedStorage);
+
+  static constexpr int kSwizzleC = 2 * std::gcd(WG_TILE_N, 128 / sizeof(Tc));
+
+  using LayoutC = std::conditional_t<
+      kSwizzleC >= 32,
+      SmemLayoutV2<WG_TILE_M, WG_TILE_N, -1, kSwizzleC / sizeof(Tc)>,
+      SmemLayoutV2<WG_TILE_M, WG_TILE_N>>;
+
+  static constexpr int OUTER_N = GMMA::OUTER_N;
+  static constexpr int MMA_SUBTILE_N = GMMA::OP_N / OUTER_N;
+
+  __device__ void operator()(const CUtensorMap& tm_a, const CUtensorMap& tm_b,
+                             const CUtensorMap& tm_c, const CUtensorMap& tm_u,
+                             const CUtensorMap& tm_v,
+                             const MatrixParam& param_A,
+                             const MatrixParam& param_B,
+                             const MatrixParam& param_U,
+                             const MatrixParam& param_V,
+                             const MatrixParam& param_C, Scheduler sched,
+                             CUtensorMap* tensormap_buf, char* smem_buf) {
+    SharedStorage& storage = *reinterpret_cast<SharedStorage*>(smem_buf);
+
+    uint64_t* producer_bar = storage.producer_bar;
+    uint64_t* consumer_bar = storage.consumer_bar;
+
+    if (threadIdx.x == 0) {
+      PRAGMA_UNROLL
+      for (int s = 0; s < Stages; ++s) {
+        ProducerBar::init(&producer_bar[s], 1 + 1);
+        ConsumerBar::init(&consumer_bar[s],
+                          kClusterSize * (kMathGroupSize / WARP_SIZE));
+      }
+      sched.init_dynamic(storage.sched,
+                         kClusterSize * (kMathGroupSize / WARP_SIZE + 1));
+      cutlass::arch::fence_view_async_shared();
+      if constexpr (kClusterSize > 1) {
+        cutlass::arch::fence_barrier_init();
+      }
+      PRAGMA_UNROLL
+      for (int i = 0; i < 2; ++i) {
+        storage.pipe_count[i] = 0;
+      }
     }
 
-    template<int N>
-    __device__ CUtensorMap*
-    update_tma_descs(CUtensorMap* gmem_desc, CUtensorMap* smem_desc, Array<void*, N> global_addrs, Array<int, N> dims)
-    {
-        const int lane_id = threadIdx.x % WARP_SIZE;
-        if (lane_id == 0) {
+    (kClusterSize > 1) ? cute::cluster_sync() : __syncthreads();
+
+    const int wg_idx = cutlass::canonical_warp_group_idx();
+
+    if (wg_idx == WARPGORUPS) {
+      cutlass::arch::warpgroup_reg_dealloc<32>();
+
+      static_assert(TILE_M % kMulticastA == 0);
+      static_assert(TILE_N % kMulticastB == 0);
+
+      cutlass::arch::NamedBarrier producers_bar(WARP_SIZE * 2, 6);
+
+      const int warp_id = cutlass::canonical_warp_idx_sync();
+      const bool cta_0 = cute::block_id_in_cluster().x == 0;
+
+      if (warp_id % 4 == 0) {
+        Cluster cluster(cute::block_id_in_cluster().x);
+
+        const int mc_offset_m = cluster.cta_n() * (TILE_M / kMulticastA);
+        const int mc_offset_n = cluster.cta_m() * (TILE_N / kMulticastB);
+
+        auto smem_A = storage.source.A.data() + mc_offset_m * TILE_K;
+        auto smem_B = storage.source.B.data() + mc_offset_n * TILE_K;
+        auto& smem_U = storage.source.U;
+        auto& smem_V = storage.source.V;
+
+        if constexpr (is_grouped_gemm) {
+          init_tma_descs<3>({&tm_a, &tm_b, &tm_u}, storage.tma_desc_buf);
+        }
+
+        cutlass::PipelineState<Stages> write_state{0, 1, 0};
+
+        auto sched_state = sched.init_consumer(storage.sched);
+
+        int lane_predicate = cute::elect_one_sync();
+
+        typename Scheduler::Tile* tile;
+
+        while (sched_state.acquire(tile)) {
+          // if (cute::elect_one_sync()) {
+          //     printf("READ m %d n %d g %d v %s\n",
+          //            tile->offset_m,
+          //            tile->offset_n,
+          //            tile->group_idx,
+          //            tile->is_valid_cluster ? "true" : "false");
+          // }
+
+          if constexpr (Scheduler::is_dynamic) {
+            if (cta_0) {
+              producers_bar.arrive_unaligned();
+            }
+          }
+
+          if (tile->is_valid_cluster) {
+            const CUtensorMap* Adesc = &tm_a;
+            const CUtensorMap* Bdesc = &tm_b;
+            const CUtensorMap* Udesc = &tm_u;
+
+            const Tv* gmem_V0 = (const Tv*)param_V.ptr;
+            const Tv* gmem_V1;
+
+            if constexpr (is_grouped_gemm) {
+              const int g = tile->group_idx;
+              const int m0 = tile->m0;
+              const int m1 = tile->m1;
+              const int m = m1 - m0;
+
+              Array<void*, 3> global_addrs;
+              global_addrs[0] = (Ta*)param_A.ptr + m0 * (int64_t)param_A.stride;
+              global_addrs[1] = ((void**)param_B.ptr)[g];
+
+              const int beg_u = m0 / kAlignmentU * kAlignmentU;
+              const int end_u = round_up(m1, kAlignmentU);
+              global_addrs[2] = (Tu*)param_U.ptr + beg_u;
+
+              Array<int, 3> dims;
+              dims[0] = m;
+              dims[1] = sched.gemm_shape().y;
+              dims[2] = end_u - beg_u;
+
+              auto descs = update_tma_descs(tensormap_buf, storage.tma_desc_buf,
+                                            global_addrs, dims);
+              Adesc = &descs[0];
+              Bdesc = &descs[1];
+              Udesc = &descs[2];
+
+              gmem_V0 = ((Tv**)gmem_V0)[g];
+
+              PRAGMA_UNROLL
+              for (int i = 0; i < 3; ++i) {
+                cute::tma_descriptor_fence_acquire(
+                    (cute::TmaDescriptor*)&descs[i]);
+              }
+            }
+
+            if (lane_predicate) {
+              const int offset_k = 0;
+
+              const uint16_t mask_A = cluster.mask_m();
+              const uint16_t mask_B = cluster.mask_n();
+
+              const int offset_m = tile->offset_m;
+              const int offset_n = tile->offset_n;
+
+              int k_iter = sched.k_iters_;
+
+              GmemIteratorSm90<kMulticastA> gmem_A{
+                  Adesc, {offset_k, offset_m + mc_offset_m}, {TILE_K, 0}};
+              GmemIteratorSm90<kMulticastB> gmem_B{
+                  Bdesc, {offset_k, offset_n + mc_offset_n}, {TILE_K, 0}};
+
+              const int mc_offset_u = kMulticastU > 1 ? mc_offset_m : 0;
+              // column-major
+              GmemIteratorSm90<kMulticastU> gmem_U{
+                  Udesc, {offset_m + mc_offset_u, offset_k / 128}, {0, 1}};
+
+              gmem_V0 += (offset_n / 128) * param_V.stride + (offset_k / 128);
+              gmem_V1 = gmem_V0;
+              if (offset_n / 128 + 1 < cdiv(sched.gemm_shape().y, 128)) {
+                gmem_V1 += param_V.stride;
+              }
+
+              for (; k_iter > 0; --k_iter) {
+                int pipe = write_state.index();
+                ConsumerBar::wait(&consumer_bar[pipe], write_state.phase());
+                ProducerBar::arrive_and_expect_tx(&producer_bar[pipe],
+                                                  kTmaTxBytes);
+                gmem_A.Step(&producer_bar[pipe],
+                            &smem_A[pipe * TILE_M * TILE_K], mask_A);
+                gmem_B.Step(&producer_bar[pipe],
+                            &smem_B[pipe * TILE_N * TILE_K], mask_B);
+                gmem_U.Step(&producer_bar[pipe], &smem_U[pipe][0] + mc_offset_u,
+                            mask_A);
+                uint32_t uint_ptr_V = cast_smem_ptr_to_uint(smem_V[pipe]);
+                CP_ASYNC<CacheOp::kAlways, 4, 0>::apply(uint_ptr_V, gmem_V0,
+                                                        true);
+                CP_ASYNC<CacheOp::kAlways, 4, 0>::apply(uint_ptr_V + sizeof(Tv),
+                                                        gmem_V1, true);
+                ++gmem_V0;
+                ++gmem_V1;
+                cutlass::arch::cpasync_barrier_arrive_noinc(
+                    &producer_bar[pipe]);
+                ++write_state;
+              }
+            }
+          }
+
+          sched_state.release();
+
+        }  // scheduler loop
+
+        sched_state.release();
+
+        // pair with the EXTRA tile
+        sched_state.acquire(tile);
+        sched_state.release();
+
+        if constexpr (kClusterSize > 1) {
+          if (lane_predicate) {
+            for (int i = 0; i < Stages; ++i) {
+              ConsumerBar::wait(&consumer_bar[write_state.index()],
+                                write_state.phase());
+              ++write_state;
+            }
+          }
+          __syncwarp();
+        }
+      } else if (warp_id % 4 == 1 && cta_0) {
+        auto sched_state = sched.init_producer(storage.sched);
+        while (sched_state.next()) {
+          if constexpr (Scheduler::is_dynamic) {
+            producers_bar.arrive_and_wait_unaligned();
+          }
+        }
+        // send EXTRA null tile (to math WGs)
+        sched_state.next();
+        sched.tail(sched_state);
+      }
+    } else {
+      cutlass::arch::warpgroup_reg_alloc<112>();
+
+      const int math_group_idx = wg_idx / 2;
+
+      if constexpr (is_grouped_gemm) {
+        if (threadIdx.x % WARPGROUP_SIZE / WARP_SIZE == 0) {
+          init_tma_descs<1>({&tm_c}, storage.tma_desc_buf + 3 + wg_idx);
+        }
+      }
+
+      auto& smem_A = storage.source.A;
+      auto& smem_B = storage.source.B;
+      auto& smem_U = storage.source.U;
+      auto& smem_V = storage.source.V;
+
+      const int wg_idx_m = WG_M > 1 ? wg_idx % 2 % WG_M : 0;
+      const int wg_idx_n = WG_N > 1 ? wg_idx % 2 / WG_M : 0;
+
+      auto smem_desc_A =
+          make_smem_desc(&smem_A[wg_idx_m * WG_TILE_M * TILE_K], 1);
+      auto smem_desc_B =
+          make_smem_desc(&smem_B[wg_idx_n * WG_TILE_N * TILE_K], 1);
+
+      SmemDescIterV2<Stages, ((TILE_M * TILE_K) >> 4)> smem_iter_A{smem_desc_A};
+      SmemDescIterV2<Stages, ((TILE_N * TILE_K) >> 4)> smem_iter_B{smem_desc_B};
+
+      const int thread_idx = threadIdx.x % WARPGROUP_SIZE;
+      const bool math_leader_p = threadIdx.x % kMathGroupSize == 0;
+
+      auto math_barrier_sync = [&](int phase, int alive = 1) {
+        constexpr int base =
+            (int)cutlass::arch::ReservedNamedBarriers::FirstUserBarrier;
+        const int barrier_id = base + math_group_idx ^ phase;
+        constexpr int threads = WARPGORUPS * WARPGROUP_SIZE;
+        int res = 0;
+        asm volatile(
+            "{\n"
+            "  .reg.pred p;\n"
+            "  setp.ne.b32 p, %3, 0;\n"
+            "  barrier.cta.red.or.pred p, %1, %2, p;\n"
+            "  selp.s32 %0, 1, 0, p;\n"
+            "}\n"
+            : "=r"(res)
+            : "r"(barrier_id), "r"(threads), "r"(alive));
+        return res;
+      };
+
+      cutlass::arch::NamedBarrier barrier(WARPGROUP_SIZE,
+                                          2 + wg_idx);  // 2,3,4,5
+
+      cutlass::PipelineState<Stages> pipe_state{};
+
+      const int warp_id = cutlass::canonical_warp_idx_sync();
+      const int lane_id = cutlass::canonical_lane_idx();
+
+      auto consumer_arrive = [&] {
+        auto bar = &consumer_bar[pipe_state.index()];
+        __syncwarp();
+        if constexpr (kClusterSize > 1) {
+          ConsumerBar::arrive(bar, lane_id, lane_id < kClusterSize);
+        } else {
+          if (lane_id == 0) {
+            ConsumerBar::arrive(bar);
+          }
+        }
+      };
+
+      auto sched_state = sched.init_consumer(storage.sched);
+
+      if (math_group_idx == 1) {
+        ++sched_state.pipe;
+        math_barrier_sync(1);
+      }
+
+      typename Scheduler::Tile* tile;
+
+      sched_state.acquire(tile);
+
+      while (tile->alive) {
+        if (tile->is_valid_cta) {
+          GMMA::AccumC accum_C{};
+          GMMA::FragC frag_C;
+
+          const auto [_, N, K, L] = sched.gemm_shape();
+
+          const int offset_m = tile->offset_m;
+          const int offset_n = tile->offset_n;
+
+          int k_iter = sched.k_iters_;
+
+          auto pred_V =
+              Fetch_V(param_V, K, N, tile, math_group_idx, wg_idx_n, storage);
+
+          float scale_V[2];
+          auto Load_V = [&] {
+            scale_V[0] = smem_V[pipe_state.index()][0];
+            scale_V[1] = smem_V[pipe_state.index()][1];
+          };
+
+          int offset_U = wg_idx_m * WG_TILE_M + warp_id % 4 * 16 + lane_id / 4;
+          if constexpr (is_grouped_gemm) {
+            offset_U += tile->m0 % kAlignmentU;
+          }
+          GMMA::FragU frag_U;
+          auto Load_U = [&] {
+            GMMA::foreach_m(frag_U, [&](auto& U, int m) {
+              U[0] = smem_U[pipe_state.index()][offset_U + m * GMMA::OP_M];
+              U[1] = smem_U[pipe_state.index()][offset_U + m * GMMA::OP_M + 8];
+            });
+          };
+
+          auto gmma = [&] {  //
+            GMMA::apply(smem_iter_A, smem_iter_B, frag_C, accum_C, frag_U,
+                        scale_V, pred_V);
+          };
+
+          if constexpr (is_grouped_gemm) {
+            if (warp_id % 4 == 0) {
+              int m0 = tile->m0, m1 = tile->m1;
+              auto addr = (Tc*)param_C.ptr + m0 * (int64_t)param_C.stride;
+              int idx = 3 + wg_idx;
+              update_tma_descs<1>(tensormap_buf + idx,
+                                  storage.tma_desc_buf + idx, {addr},
+                                  {m1 - m0});
+            }
+          }
+
+          math_barrier_sync(0);
+
+          pipe_state = {};
+          pipe_state.advance(storage.pipe_count[math_group_idx ^ 1]);
+
+          ProducerBar::wait(&producer_bar[pipe_state.index()],
+                            pipe_state.phase());
+          Load_V();
+          Load_U();
+          smem_iter_A.Reset(pipe_state.index());
+          smem_iter_B.Reset(pipe_state.index());
+          gmma();
+          consumer_arrive();
+          ++pipe_state;
+          --k_iter;
+
+          ProducerBar::wait(&producer_bar[pipe_state.index()],
+                            pipe_state.phase());
+          Load_V();
+          Load_U();
+          smem_iter_A.Reset(pipe_state.index());
+          smem_iter_B.Reset(pipe_state.index());
+
+          PRAGMA_NO_UNROLL
+          for (; k_iter > 1; --k_iter) {
+            gmma();
+            consumer_arrive();
+            ++pipe_state;
+            ProducerBar::wait(&producer_bar[pipe_state.index()],
+                              pipe_state.phase());
+            Load_V();
+            Load_U();
+            smem_iter_A.Reset(pipe_state.index());
+            smem_iter_B.Reset(pipe_state.index());
+          }
+
+          if (math_leader_p) {
+            storage.pipe_count[math_group_idx] = pipe_state.count() + 1;
+          }
+          math_barrier_sync(1);
+
+          gmma();
+          consumer_arrive();
+
+          Tc* smem_C =
+              &storage.C[wg_idx_m * WG_TILE_M * TILE_N + wg_idx_n * WG_TILE_N];
+
+          GMMA::foreach_C(accum_C, [&](const auto& C, int m, int n) {
+            constexpr int N = LayoutC::C0;
+            constexpr int SW_bits = log2(kSwizzleC / 16);
+
+            static_assert(!SW_bits || GMMA::OP_N % LayoutC::C0 == 0);
+            static_assert(GMMA::OP_N % 16 == 0);
+
+            const int m0 = m * GMMA::OP_M;
+            const int n0 = n * GMMA::OP_N;
+
             PRAGMA_UNROLL
-            for (int i = 0; i < N; ++i) {
-                uint32_t uint_ptr = cast_smem_ptr_to_uint(&smem_desc[i]);
-                // clang-format off
+            for (int i = 0; i < GMMA::OP_N; i += 16) {
+              __align__(16) Array<Tc, 8> tvec =
+                  cast<Tc>(*(Array<float, 8>*)&C[i / 2]);
+              // fill(tvec, Tc(255));
+              int mm = m0 + warp_id % 4 * 16 + (lane_id & 8);
+              int nn = n0 + i / N * N;
+
+              int addr = ((nn / N) * WG_TILE_M * N) + (mm * N) + (nn % N);
+
+              int s = lane_id % 8;
+              int c = (lane_id & 16) / 2 + i % N;
+
+              addr += Swizzle<SW_bits, 3, 3>::apply(s * N + c);
+
+              auto& uvec = (Array<uint32_t, 4>&)tvec;
+              cute::SM90_U32x4_STSM_N::copy(uvec[0], uvec[1], uvec[2], uvec[3],
+                                            (cutlass::uint128_t&)smem_C[addr]);
+            }
+          });
+
+          cute::tma_store_fence();  // visibility: smem -> async proxy
+
+          barrier.sync();
+
+          if (thread_idx < LayoutC::C1) {
+            const void* Cdesc = &tm_c;
+            const int tma_n = thread_idx * LayoutC::C0;
+            if constexpr (is_grouped_gemm) {
+              Cdesc = &tensormap_buf[blockIdx.x * kTmaDescNum + 3 + wg_idx];
+              cute::tma_descriptor_fence_acquire((cute::TmaDescriptor*)Cdesc);
+            }
+            cute::SM90_TMA_STORE::copy(
+                Cdesc, &smem_C[thread_idx * WG_TILE_M * LayoutC::C0],
+                offset_n + wg_idx_n * WG_TILE_N + tma_n,
+                offset_m + wg_idx_m * WG_TILE_M);
+            cute::tma_store_arrive();
+            cute::tma_store_wait<0>();
+          }
+
+        }  // valid cta tile
+        else {
+          math_barrier_sync(0);
+
+          pipe_state = {};
+          pipe_state.advance(storage.pipe_count[math_group_idx ^ 1]);
+
+          if (tile->is_valid_cluster) {
+            // other CTAs in the cluster are still alive
+            for (int k_iter = sched.k_iters_; k_iter > 0; --k_iter) {
+              ProducerBar::wait(&producer_bar[pipe_state.index()],
+                                pipe_state.phase());
+              consumer_arrive();
+              ++pipe_state;
+            }
+          }
+
+          if (math_leader_p) {
+            storage.pipe_count[math_group_idx] = pipe_state.count();
+          }
+
+          math_barrier_sync(1);
+        }
+
+        sched_state.release(2);
+        sched_state.acquire(tile);
+      }  // scheduler loop
+
+      sched_state.release(2);  // release the last tile
+
+      if (math_group_idx == 0) {
+        math_barrier_sync(0, 0);
+        if (math_leader_p) {
+          storage.pipe_count[0] = storage.pipe_count[1];
+        }
+        while (math_barrier_sync(1, 0)) {
+          math_barrier_sync(0, 0);
+          if (math_leader_p) {
+            storage.pipe_count[0] = storage.pipe_count[1];
+          }
+        }
+      } else {
+        while (math_barrier_sync(0, 0)) {
+          if (math_leader_p) {
+            storage.pipe_count[1] = storage.pipe_count[0];
+          }
+          math_barrier_sync(1, 0);
+        }
+      }
+    }
+
+  }  // operator()
+
+  template <int N>
+  __device__ void init_tma_descs(Array<const CUtensorMap*, N> param_desc,
+                                 CUtensorMap* smem_desc) {
+    const int lane_id = threadIdx.x % WARP_SIZE;
+
+    if (lane_id < sizeof(CUtensorMap) / sizeof(uint2)) {
+      PRAGMA_UNROLL
+      for (int i = 0; i < N; ++i) {
+        ((uint2*)&smem_desc[i])[lane_id] = ((uint2*)param_desc[i])[lane_id];
+      }
+    }
+
+    __syncwarp();
+  }
+
+  template <int N>
+  __device__ CUtensorMap* update_tma_descs(CUtensorMap* gmem_desc,
+                                           CUtensorMap* smem_desc,
+                                           Array<void*, N> global_addrs,
+                                           Array<int, N> dims) {
+    const int lane_id = threadIdx.x % WARP_SIZE;
+    if (lane_id == 0) {
+      PRAGMA_UNROLL
+      for (int i = 0; i < N; ++i) {
+        uint32_t uint_ptr = cast_smem_ptr_to_uint(&smem_desc[i]);
+        // clang-format off
                 asm volatile("tensormap.replace.tile.global_address.shared::cta.b1024.b64 [%0], %1;" ::"r"(uint_ptr), "l"(global_addrs[i]));
                 if (i != 2) {
                     asm volatile("tensormap.replace.tile.global_dim.shared::cta.b1024.b32 [%0], 1, %1;" ::"r"(uint_ptr), "r"(dims[i]));
                 } else { // special case for U
                     asm volatile("tensormap.replace.tile.global_dim.shared::cta.b1024.b32 [%0], 0, %1;" ::"r"(uint_ptr), "r"(dims[i]));
                 }
-                // clang-format on
-            }
-        }
+        // clang-format on
+      }
+    }
 
-        __syncwarp();
+    __syncwarp();
 
-        auto gmem_ptr = &gmem_desc[blockIdx.x * kTmaDescNum];
-        PRAGMA_UNROLL
-        for (int i = 0; i < N; ++i) {
-            uint32_t uint_ptr = cast_smem_ptr_to_uint(&smem_desc[i]);
-            // clang-format off
+    auto gmem_ptr = &gmem_desc[blockIdx.x * kTmaDescNum];
+    PRAGMA_UNROLL
+    for (int i = 0; i < N; ++i) {
+      uint32_t uint_ptr = cast_smem_ptr_to_uint(&smem_desc[i]);
+      // clang-format off
             asm volatile("tensormap.cp_fenceproxy.global.shared::cta.tensormap::generic.release.gpu.sync.aligned [%0], [%1], 128;" :: "l"(gmem_ptr + i), "r"(uint_ptr));
-            // clang-format on
-        }
-
-        return gmem_ptr;
+      // clang-format on
     }
 
-    __device__ auto Fetch_V(const MatrixParam&        param_V,
-                            int                       K,
-                            int                       N,
-                            typename Scheduler::Tile* tile,
-                            int                       math_group_idx,
-                            int                       wg_idx_n,
-                            SharedStorage&            storage)
-    {
-        const int offset_n = tile->offset_n;
+    return gmem_ptr;
+  }
 
-        Array<bool, MMA_SUBTILE_N> pred_V{};
+  __device__ auto Fetch_V(const MatrixParam& param_V, int K, int N,
+                          typename Scheduler::Tile* tile, int math_group_idx,
+                          int wg_idx_n, SharedStorage& storage) {
+    const int offset_n = tile->offset_n;
 
-        if constexpr (MMA_SUBTILE_N != 1) {
-            int offset = offset_n % 128 + wg_idx_n * WG_TILE_N;
-            static_assert(WG_N == 1);
-            // Safely skip pred_V_0 when distributing WGs along M
-            PRAGMA_UNROLL
-            for (int i = 1; i < MMA_SUBTILE_N; ++i) {
-                pred_V[i] = (i * OUTER_N + offset) >= 128;
-            }
-        }
+    Array<bool, MMA_SUBTILE_N> pred_V{};
 
-        return pred_V;
+    if constexpr (MMA_SUBTILE_N != 1) {
+      int offset = offset_n % 128 + wg_idx_n * WG_TILE_N;
+      static_assert(WG_N == 1);
+      // Safely skip pred_V_0 when distributing WGs along M
+      PRAGMA_UNROLL
+      for (int i = 1; i < MMA_SUBTILE_N; ++i) {
+        pred_V[i] = (i * OUTER_N + offset) >= 128;
+      }
     }
+
+    return pred_V;
+  }
 };
 
 }  // namespace turbomind::gemm

--- a/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/gpu_metric.h
+++ b/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/gpu_metric.h
@@ -10,6 +10,6 @@ namespace turbomind::gemm {
 float MeasureL2CacheThroughput();
 
 // fused multiply-add / second
-float MeasureMmaThroughput(int proble_size = 16384);
+float MeasureMmaThroughput(int problem_size = 16384);
 
 }  // namespace turbomind::gemm

--- a/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/iterator.h
+++ b/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/iterator.h
@@ -13,32 +13,34 @@
 namespace turbomind::gemm {
 
 struct VoidGmemIter {
-    static constexpr int  ITER_S = 0;
-    static constexpr auto kMode  = Striding::kFlat;
-    using Fragments              = int;
-    __device__      VoidGmemIter(...) {}
-    __device__ void ClearSmem() {}
-    __device__ void Prefetch(int, int, bool) {}
-    __device__ void Prefetch(bool) {}
-    __device__ void Fetch(Fragments&, bool) {}
-    __device__ void Store(const Fragments&) {}
-    __device__ void Advance() {}
-    int*            smem_data_;
-    bool            g_mask{false};
+  static constexpr int ITER_S = 0;
+  static constexpr auto kMode = Striding::kFlat;
+  using Fragments = int;
+  __device__ VoidGmemIter(...) {}
+  __device__ void ClearSmem() {}
+  __device__ void Prefetch(int, int, bool) {}
+  __device__ void Prefetch(bool) {}
+  __device__ void Fetch(Fragments&, bool) {}
+  __device__ void Store(const Fragments&) {}
+  __device__ void Advance() {}
+  int* smem_data_;
+  bool g_mask{false};
 };
 
 struct GetGmemIter {
-    template<class Operand, class Iterator, class SmemLayout, int M, int K, int WARPS>
-    static constexpr auto
-        apply(basic_type<Operand>, basic_type<Iterator>, basic_type<SmemLayout>, pair<M, K>, constant<WARPS>)
-    {
-        using Dtype = typename Operand::Dtype;
+  template <class Operand, class Iterator, class SmemLayout, int M, int K,
+            int WARPS>
+  static constexpr auto apply(basic_type<Operand>, basic_type<Iterator>,
+                              basic_type<SmemLayout>, pair<M, K>,
+                              constant<WARPS>) {
+    using Dtype = typename Operand::Dtype;
 
-        constexpr int kAccessSize =
-            std::min<int>(128 / bitsof<Dtype>, std::max<int>(32 / bitsof<Dtype>, M * K / (WARPS * WARP_SIZE)));
+    constexpr int kAccessSize = std::min<int>(
+        128 / bitsof<Dtype>,
+        std::max<int>(32 / bitsof<Dtype>, M * K / (WARPS * WARP_SIZE)));
 
-        constexpr int2 kAligned = mk2cs<Operand::kOrder>(0, 1);
-        constexpr int2 kCS      = mk2cs<Operand::kOrder>(M, K);
+    constexpr int2 kAligned = mk2cs<Operand::kOrder>(0, 1);
+    constexpr int2 kCS = mk2cs<Operand::kOrder>(M, K);
 
 #if 0
         constexpr int kMaxThrS = std::min(WARP_SIZE, ceil_div(kCS.y, WARPS));
@@ -48,15 +50,13 @@ struct GetGmemIter {
 
         constexpr int kWarpThrC = std::min(kMaxThrC, std::max(WARP_SIZE / kMaxThrS, kTgtThrC));
 #endif
-        using GmemIter = typename Iterator::template Type<Dtype,
-                                                          gemm::ThreadMap_V2<kCS.x, kCS.y, kAccessSize, Blocked, WARPS>,
-                                                          SmemLayout,
-                                                          Operand::kPack,
-                                                          Operand::kOrder,
-                                                          kAligned.x,   // aligned C
-                                                          kAligned.y>;  // aligned S
-        return type_c<GmemIter>;
-    }
+    using GmemIter = typename Iterator::template Type<
+        Dtype, gemm::ThreadMap_V2<kCS.x, kCS.y, kAccessSize, Blocked, WARPS>,
+        SmemLayout, Operand::kPack, Operand::kOrder,
+        kAligned.x,   // aligned C
+        kAligned.y>;  // aligned S
+    return type_c<GmemIter>;
+  }
 };
 
 }  // namespace turbomind::gemm

--- a/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/iterator_sm70.h
+++ b/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/iterator_sm70.h
@@ -16,262 +16,245 @@
 
 namespace turbomind::gemm {
 
-template<typename T, int N>
-inline __device__ void _Ld(Array<T, N>& dst, const T* src)
-{
-    static_assert(sizeof(Array<T, N>) <= sizeof(uint4));
+template <typename T, int N>
+inline __device__ void _Ld(Array<T, N>& dst, const T* src) {
+  static_assert(sizeof(Array<T, N>) <= sizeof(uint4));
 
-    if constexpr (sizeof(Array<T, N>) == sizeof(uint4)) {
-        (uint4&)dst = __ldcs((const uint4*)src);
-    }
-    else if constexpr (sizeof(Array<T, N>) == sizeof(uint2)) {
-        (uint2&)dst = __ldcs((const uint2*)src);
-    }
-    else if constexpr (sizeof(Array<T, N>) == sizeof(uint)) {
-        (uint&)dst = __ldcs((const uint*)src);
-    }
-    else {
-        static_assert(!std::is_same_v<T, T>);
-    }
+  if constexpr (sizeof(Array<T, N>) == sizeof(uint4)) {
+    (uint4&)dst = __ldcs((const uint4*)src);
+  } else if constexpr (sizeof(Array<T, N>) == sizeof(uint2)) {
+    (uint2&)dst = __ldcs((const uint2*)src);
+  } else if constexpr (sizeof(Array<T, N>) == sizeof(uint)) {
+    (uint&)dst = __ldcs((const uint*)src);
+  } else {
+    static_assert(!std::is_same_v<T, T>);
+  }
 }
 
-template<class T,
-         class Map,
-         class SmemLayout,
-         Pack     kPack,
-         Order    kOrder,
-         bool     AlignedC,
-         bool     AlignedS,
-         Striding mode,
-         class Policy_>
+template <class T, class Map, class SmemLayout, Pack kPack, Order kOrder,
+          bool AlignedC, bool AlignedS, Striding mode, class Policy_>
 struct GmemIteratorSm70 {
+  using ThreadMap = Map;
 
-    using ThreadMap = Map;
+  using AccessType = Array<T, Map::kAccessC>;
+  using Pointer = get_pointer_type<T>;
 
-    using AccessType = Array<T, Map::kAccessC>;
-    using Pointer    = get_pointer_type<T>;
+  using Policy = Policy_;
 
-    using Policy = Policy_;
+  static constexpr int ITER_S = Map::kIterS;
+  static constexpr int ITER_C = Map::kIterC;
 
-    static constexpr int ITER_S = Map::kIterS;
-    static constexpr int ITER_C = Map::kIterC;
+  static constexpr Striding kMode = mode;
+  static constexpr bool is_indexed = mode == Striding::kIndexed;
 
-    static constexpr Striding kMode      = mode;
-    static constexpr bool     is_indexed = mode == Striding::kIndexed;
+  const char* src_data_;
 
-    const char* src_data_;
+  int src_offset_;
+  int dst_offset_;
 
-    int src_offset_;
-    int dst_offset_;
+  int offset_c_;
+  int offset_s_;
 
-    int offset_c_;
-    int offset_s_;
+  int src_step_c_;
+  int src_step_s_;
 
-    int src_step_c_;
-    int src_step_s_;
+  int src_step_k_;
 
-    int src_step_k_;
+  Predicate<Map::kIterS, Map::kIterC, (AlignedC && Map::kAlignedC),
+            (AlignedS && Map::kAlignedS)>
+      pred_;
 
-    Predicate<Map::kIterS, Map::kIterC, (AlignedC && Map::kAlignedC), (AlignedS && Map::kAlignedS)> pred_;
+  bool g_mask{true};
 
-    bool g_mask{true};
+  SmemAccessor<T, SmemLayout> smem_data_;
 
-    SmemAccessor<T, SmemLayout> smem_data_;
+  static constexpr int2 kMK0 = cs2mk<kOrder>(SmemLayout::C0, SmemLayout::S0);
+  static constexpr int kPeriodC = ceil_div(SmemLayout::C0, Map::kDeltaC);
+  static constexpr int kPeriodS = ceil_div(SmemLayout::S0, Map::kDeltaS);
 
-    static constexpr int2 kMK0     = cs2mk<kOrder>(SmemLayout::C0, SmemLayout::S0);
-    static constexpr int  kPeriodC = ceil_div(SmemLayout::C0, Map::kDeltaC);
-    static constexpr int  kPeriodS = ceil_div(SmemLayout::S0, Map::kDeltaS);
+  int phases_[kPeriodS][kPeriodC];
 
-    int phases_[kPeriodS][kPeriodC];
+  const char* src_data_vec_[ITER_S];
 
-    const char* src_data_vec_[ITER_S];
+  using Fragments = AccessType[Map::kIterS][Map::kIterC];
 
-    using Fragments = AccessType[Map::kIterS][Map::kIterC];
+  __device__ static constexpr int2 pack(int2 mk) {
+    return Packing_v2<kPack, kOrder>::apply(mk);
+  }
 
-    __device__ static constexpr int2 pack(int2 mk)
-    {
-        return Packing_v2<kPack, kOrder>::apply(mk);
-    }
+  __device__ static constexpr int2 to_cs(int2 mk) {
+    return mk2cs<kOrder>(mk.x, mk.y);
+  }
 
-    __device__ static constexpr int2 to_cs(int2 mk)
-    {
-        return mk2cs<kOrder>(mk.x, mk.y);
-    }
+  __device__ GmemIteratorSm70() : smem_data_{Pointer{nullptr}} {};
 
-    __device__ GmemIteratorSm70(): smem_data_{Pointer{nullptr}} {};
+  __device__ GmemIteratorSm70(const MatrixData& mat, int2 offset, int2 extent)
+      : smem_data_{Pointer{(T*)nullptr}} {
+    const int warp_id = threadIdx.x / WARP_SIZE;
+    const int lane_id = threadIdx.x % WARP_SIZE;
 
-    __device__ GmemIteratorSm70(const MatrixData& mat, int2 offset, int2 extent): smem_data_{Pointer{(T*)nullptr}}
-    {
-        const int warp_id = threadIdx.x / WARP_SIZE;
-        const int lane_id = threadIdx.x % WARP_SIZE;
+    const Pointer data{(T*)mat.ptr.ptr};
+    const int ld = mat.ptr.stride;
 
-        const Pointer data{(T*)mat.ptr.ptr};
-        const int     ld = mat.ptr.stride;
+    const int2 offsets = Map::get_offset(warp_id, lane_id);
 
-        const int2 offsets = Map::get_offset(warp_id, lane_id);
+    offset_c_ = offsets.x;
+    offset_s_ = offsets.y;
 
-        offset_c_ = offsets.x;
-        offset_s_ = offsets.y;
+    // auto src_ptr = reinterpret_cast<const char*>((T*)data);
 
-        // auto src_ptr = reinterpret_cast<const char*>((T*)data);
-
-        if constexpr (pred_.is_active) {
-            extent = to_cs(pack(extent));
-            PRAGMA_UNROLL
-            for (int s = 0; s < Map::kIterS; ++s) {
-                PRAGMA_UNROLL
-                for (int c = 0; c < Map::kIterC; ++c) {
-                    int ss = offset_s_ + s * Map::kDeltaS;
-                    int cc = offset_c_ + c * Map::kDeltaC;
-                    if (ss < extent.y && cc < extent.x) {
-                        pred_.set(s, c);
-                    }
-                }
-            }
-        }
-
+    if constexpr (pred_.is_active) {
+      extent = to_cs(pack(extent));
+      PRAGMA_UNROLL
+      for (int s = 0; s < Map::kIterS; ++s) {
         PRAGMA_UNROLL
-        for (int s = 0; s < kPeriodS; ++s) {
-            PRAGMA_UNROLL
-            for (int c = 0; c < kPeriodC; ++c) {
-                phases_[s][c] = SmemLayout::apply(offset_s_ + s * Map::kDeltaS, offset_c_ + c * Map::kDeltaC);
-            }
+        for (int c = 0; c < Map::kIterC; ++c) {
+          int ss = offset_s_ + s * Map::kDeltaS;
+          int cc = offset_c_ + c * Map::kDeltaC;
+          if (ss < extent.y && cc < extent.x) {
+            pred_.set(s, c);
+          }
         }
-
-        const int src_offset = is_indexed ? offsets.x : offsets.x + offsets.y * ld;
-
-        src_offset_ = src_offset * bitsof<T> / bitsof<char>;
-
-        src_step_c_ = bitsof<T> * Map::kDeltaC / bitsof<char>;
-        src_step_s_ = bitsof<T> * Map::kDeltaS * ld / bitsof<char>;
-
-        src_step_k_ = bitsof<T> * cs2mk<kOrder>(Map::kDimC, Map::kDimS * ld).y / bitsof<char>;
-
-        // initialize for the first tile
-        if constexpr (is_indexed) {
-            const int2 cta_cs = to_cs(offset);
-            for (int s = 0; s < ITER_S; ++s) {
-                const int  ss    = cta_cs.y + offset_s_ + s * Map::kDeltaS;
-                const int  idx   = (mat.idxs && pred_(s, 0)) ? __ldg(mat.idxs + ss) : ss;
-                const auto tmp   = data + cs2idx({cta_cs.x, idx}, ld);
-                src_data_vec_[s] = reinterpret_cast<const char*>((T*)tmp) + src_offset_;
-            }
-        }
-        else {
-            auto src_data = data + cs2idx(to_cs(pack(offset)), ld);
-            src_data_     = reinterpret_cast<const char*>((T*)src_data) + src_offset_;
-        }
+      }
     }
 
-    __device__ constexpr int _src_step_k() const
-    {
-        return src_step_k_;
+    PRAGMA_UNROLL
+    for (int s = 0; s < kPeriodS; ++s) {
+      PRAGMA_UNROLL
+      for (int c = 0; c < kPeriodC; ++c) {
+        phases_[s][c] = SmemLayout::apply(offset_s_ + s * Map::kDeltaS,
+                                          offset_c_ + c * Map::kDeltaC);
+      }
     }
 
-    __device__ void ClearSmem(int pipe_iter = 0)
-    {
-        PRAGMA_UNROLL
-        for (int s = 0; s < Map::kIterS; ++s) {
-            PRAGMA_UNROLL
-            for (int c = 0; c < Map::kIterC; ++c) {
-                const int pred_s = offset_s_ + s * Map::kDeltaS < Map::kDimS;
-                const int pred_c = offset_c_ + c * Map::kDeltaC < Map::kDimC;
-                auto      ptr    = &smem_data_(offset_s_ + s * Map::kDeltaS, offset_c_ + c * Map::kDeltaC);
-                if ((Map::kAlignedC && Map::kAlignedS) || (pred_s && pred_c)) {
-                    turbomind::Store(ptr, Array<T, Map::kAccessC>{});
-                }
-            }
+    const int src_offset = is_indexed ? offsets.x : offsets.x + offsets.y * ld;
+
+    src_offset_ = src_offset * bitsof<T> / bitsof<char>;
+
+    src_step_c_ = bitsof<T> * Map::kDeltaC / bitsof<char>;
+    src_step_s_ = bitsof<T> * Map::kDeltaS * ld / bitsof<char>;
+
+    src_step_k_ =
+        bitsof<T> * cs2mk<kOrder>(Map::kDimC, Map::kDimS * ld).y / bitsof<char>;
+
+    // initialize for the first tile
+    if constexpr (is_indexed) {
+      const int2 cta_cs = to_cs(offset);
+      for (int s = 0; s < ITER_S; ++s) {
+        const int ss = cta_cs.y + offset_s_ + s * Map::kDeltaS;
+        const int idx = (mat.idxs && pred_(s, 0)) ? __ldg(mat.idxs + ss) : ss;
+        const auto tmp = data + cs2idx({cta_cs.x, idx}, ld);
+        src_data_vec_[s] = reinterpret_cast<const char*>((T*)tmp) + src_offset_;
+      }
+    } else {
+      auto src_data = data + cs2idx(to_cs(pack(offset)), ld);
+      src_data_ = reinterpret_cast<const char*>((T*)src_data) + src_offset_;
+    }
+  }
+
+  __device__ constexpr int _src_step_k() const { return src_step_k_; }
+
+  __device__ void ClearSmem(int pipe_iter = 0) {
+    PRAGMA_UNROLL
+    for (int s = 0; s < Map::kIterS; ++s) {
+      PRAGMA_UNROLL
+      for (int c = 0; c < Map::kIterC; ++c) {
+        const int pred_s = offset_s_ + s * Map::kDeltaS < Map::kDimS;
+        const int pred_c = offset_c_ + c * Map::kDeltaC < Map::kDimC;
+        auto ptr = &smem_data_(offset_s_ + s * Map::kDeltaS,
+                               offset_c_ + c * Map::kDeltaC);
+        if ((Map::kAlignedC && Map::kAlignedS) || (pred_s && pred_c)) {
+          turbomind::Store(ptr, Array<T, Map::kAccessC>{});
         }
+      }
     }
+  }
 
-    __device__ void Advance()
-    {
-        if constexpr (!is_indexed) {
-            if (!g_mask) {
-                src_data_ -= _src_step_k();
-            }
+  __device__ void Advance() {
+    if constexpr (!is_indexed) {
+      if (!g_mask) {
+        src_data_ -= _src_step_k();
+      }
+    }
+  }
+
+  __device__ void Copy(std::true_type, T* dst, const char* __restrict__ src,
+                       bool mask) {
+    if (mask) {
+      AccessType frag;
+      if constexpr (Policy_::kEvictPolicy != EvictPolicy::kEvictNormal) {
+        _Ld(frag, (const T*)src);
+      } else {
+        Ldg(frag, (const T*)src);
+      }
+      turbomind::Store(dst, frag);
+    }
+  }
+
+  __device__ void Fetch(Fragments& frags, bool tile_mask) {
+    PRAGMA_UNROLL
+    for (int s = 0; s < Map::kIterS; ++s) {
+      if constexpr (is_indexed) {
+        src_data_ = src_data_vec_[s];
+      }
+
+      PRAGMA_UNROLL
+      for (int c = 0; c < Map::kIterC; ++c) {
+        Copy2(frags[s][c], src_data_ + src_step_c_ * c,
+              tile_mask && g_mask && pred_(s, c));
+      }
+
+      if constexpr (is_indexed) {
+        src_data_vec_[s] += _src_step_k();
+      } else {
+        src_data_ += src_step_s_;
+        if (s == Map::kIterS - 1) {
+          src_data_ -= src_step_s_ * Map::kIterS;
+          src_data_ += _src_step_k();
         }
+      }
     }
+  }
 
-    __device__ void Copy(std::true_type, T* dst, const char* __restrict__ src, bool mask)
-    {
-        if (mask) {
-            AccessType frag;
-            if constexpr (Policy_::kEvictPolicy != EvictPolicy::kEvictNormal) {
-                _Ld(frag, (const T*)src);
-            }
-            else {
-                Ldg(frag, (const T*)src);
-            }
-            turbomind::Store(dst, frag);
+  __device__ void Store(Fragments& frags) {
+    PRAGMA_UNROLL
+    for (int s = 0; s < Map::kIterS; ++s) {
+      PRAGMA_UNROLL
+      for (int c = 0; c < Map::kIterC; ++c) {
+        // auto dst = &smem_data_(offset_s_ + s * Map::kDeltaS, offset_c_ + c *
+        // Map::kDeltaC);
+
+        const int i0 = SmemLayout::apply(  //
+            s / kPeriodS * kPeriodS * Map::kDeltaS,
+            c / kPeriodC * kPeriodC * Map::kDeltaC);
+        const int i1 = phases_[s % kPeriodS][c % kPeriodC];
+        auto dst = &smem_data_.ptr_[i0 + i1];
+
+        if (pred_(s, c)) {
+          turbomind::Store(dst, frags[s][c]);
         }
+      }
     }
+  }
 
-    __device__ void Fetch(Fragments& frags, bool tile_mask)
-    {
-        PRAGMA_UNROLL
-        for (int s = 0; s < Map::kIterS; ++s) {
-
-            if constexpr (is_indexed) {
-                src_data_ = src_data_vec_[s];
-            }
-
-            PRAGMA_UNROLL
-            for (int c = 0; c < Map::kIterC; ++c) {
-                Copy2(frags[s][c], src_data_ + src_step_c_ * c, tile_mask && g_mask && pred_(s, c));
-            }
-
-            if constexpr (is_indexed) {
-                src_data_vec_[s] += _src_step_k();
-            }
-            else {
-                src_data_ += src_step_s_;
-                if (s == Map::kIterS - 1) {
-                    src_data_ -= src_step_s_ * Map::kIterS;
-                    src_data_ += _src_step_k();
-                }
-            }
-        }
+  __device__ void Copy2(AccessType& frag, const char* __restrict__ src,
+                        bool mask) {
+    if (mask) {
+      if constexpr (Policy_::kEvictPolicy != EvictPolicy::kEvictNormal) {
+        _Ld(frag, (const T*)src);
+      } else {
+        Ldg(frag, (const T*)src);
+      }
     }
-
-    __device__ void Store(Fragments& frags)
-    {
-        PRAGMA_UNROLL
-        for (int s = 0; s < Map::kIterS; ++s) {
-            PRAGMA_UNROLL
-            for (int c = 0; c < Map::kIterC; ++c) {
-                // auto dst = &smem_data_(offset_s_ + s * Map::kDeltaS, offset_c_ + c * Map::kDeltaC);
-
-                const int i0  = SmemLayout::apply(  //
-                    s / kPeriodS * kPeriodS * Map::kDeltaS,
-                    c / kPeriodC * kPeriodC * Map::kDeltaC);
-                const int i1  = phases_[s % kPeriodS][c % kPeriodC];
-                auto      dst = &smem_data_.ptr_[i0 + i1];
-
-                if (pred_(s, c)) {
-                    turbomind::Store(dst, frags[s][c]);
-                }
-            }
-        }
-    }
-
-    __device__ void Copy2(AccessType& frag, const char* __restrict__ src, bool mask)
-    {
-        if (mask) {
-            if constexpr (Policy_::kEvictPolicy != EvictPolicy::kEvictNormal) {
-                _Ld(frag, (const T*)src);
-            }
-            else {
-                Ldg(frag, (const T*)src);
-            }
-        }
-    }
+  }
 };
 
-template<Striding mode, class Policy>
+template <Striding mode, class Policy>
 struct IteratorSm70 {
-    template<class T, class Map, class SmemLayout, Pack kPack, Order kOrder, bool AlignedC, bool AlignedS>
-    using Type = GmemIteratorSm70<T, Map, SmemLayout, kPack, kOrder, AlignedC, AlignedS, mode, Policy>;
+  template <class T, class Map, class SmemLayout, Pack kPack, Order kOrder,
+            bool AlignedC, bool AlignedS>
+  using Type = GmemIteratorSm70<T, Map, SmemLayout, kPack, kOrder, AlignedC,
+                                AlignedS, mode, Policy>;
 };
 
 }  // namespace turbomind::gemm

--- a/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/iterator_sm80.h
+++ b/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/iterator_sm80.h
@@ -17,236 +17,227 @@
 
 namespace turbomind::gemm {
 
-template<class T,
-         class Map,
-         class SmemLayout,
-         Pack     kPack,
-         Order    kOrder,
-         bool     AlignedC,
-         bool     AlignedS,
-         Striding mode,
-         class Policy_>
+template <class T, class Map, class SmemLayout, Pack kPack, Order kOrder,
+          bool AlignedC, bool AlignedS, Striding mode, class Policy_>
 struct GmemIteratorSm80 {
+  using ThreadMap = Map;
 
-    using ThreadMap = Map;
+  using AccessType = Array<T, Map::kAccessC>;
+  using Pointer = get_pointer_type<T>;
 
-    using AccessType = Array<T, Map::kAccessC>;
-    using Pointer    = get_pointer_type<T>;
+  using Policy = Policy_;
 
-    using Policy = Policy_;
+  static constexpr int ITER_S = Map::kIterS;
+  static constexpr int ITER_C = Map::kIterC;
 
-    static constexpr int ITER_S = Map::kIterS;
-    static constexpr int ITER_C = Map::kIterC;
+  static constexpr Striding kMode = mode;
+  static constexpr bool is_indexed = mode == Striding::kIndexed;
 
-    static constexpr Striding kMode      = mode;
-    static constexpr bool     is_indexed = mode == Striding::kIndexed;
+  const char* src_data_;
 
-    const char* src_data_;
+  int src_offset_;
+  int dst_offset_;
 
-    int src_offset_;
-    int dst_offset_;
+  int offset_c_;
+  int offset_s_;
 
-    int offset_c_;
-    int offset_s_;
+  int src_step_c_;
+  int src_step_s_;
 
-    int src_step_c_;
-    int src_step_s_;
+  int src_step_k_;
 
-    int src_step_k_;
+  Predicate<Map::kIterS, Map::kIterC, (AlignedC && Map::kAlignedC),
+            (AlignedS && Map::kAlignedS)>
+      pred_;
 
-    Predicate<Map::kIterS, Map::kIterC, (AlignedC && Map::kAlignedC), (AlignedS && Map::kAlignedS)> pred_;
+  bool g_mask{true};
 
-    bool g_mask{true};
+  SmemAccessor<T, SmemLayout> smem_data_;
 
-    SmemAccessor<T, SmemLayout> smem_data_;
+  static constexpr int2 kMK0 = cs2mk<kOrder>(SmemLayout::C0, SmemLayout::S0);
+  static constexpr int kPeriodC = ceil_div(SmemLayout::C0, Map::kDeltaC);
+  static constexpr int kPeriodS = ceil_div(SmemLayout::S0, Map::kDeltaS);
 
-    static constexpr int2 kMK0     = cs2mk<kOrder>(SmemLayout::C0, SmemLayout::S0);
-    static constexpr int  kPeriodC = ceil_div(SmemLayout::C0, Map::kDeltaC);
-    static constexpr int  kPeriodS = ceil_div(SmemLayout::S0, Map::kDeltaS);
+  int phases_[kPeriodS][kPeriodC];
 
-    int phases_[kPeriodS][kPeriodC];
+  const char* src_data_vec_[ITER_S];
 
-    const char* src_data_vec_[ITER_S];
+  uint64_t cache_policy_{};
 
-    uint64_t cache_policy_{};
+  __device__ static constexpr int2 pack(int2 mk) {
+    return Packing_v2<kPack, kOrder>::apply(mk);
+  }
 
-    __device__ static constexpr int2 pack(int2 mk)
-    {
-        return Packing_v2<kPack, kOrder>::apply(mk);
-    }
+  __device__ static constexpr int2 to_cs(int2 mk) {
+    return mk2cs<kOrder>(mk.x, mk.y);
+  }
 
-    __device__ static constexpr int2 to_cs(int2 mk)
-    {
-        return mk2cs<kOrder>(mk.x, mk.y);
-    }
+  __device__ GmemIteratorSm80() : smem_data_{Pointer{nullptr}} {};
 
-    __device__ GmemIteratorSm80(): smem_data_{Pointer{nullptr}} {};
+  __device__ GmemIteratorSm80(const MatrixData& mat, int2 offset, int2 extent)
+      : smem_data_{Pointer{(T*)nullptr}} {
+    const int warp_id = threadIdx.x / WARP_SIZE;
+    const int lane_id = threadIdx.x % WARP_SIZE;
 
-    __device__ GmemIteratorSm80(const MatrixData& mat, int2 offset, int2 extent): smem_data_{Pointer{(T*)nullptr}}
-    {
-        const int warp_id = threadIdx.x / WARP_SIZE;
-        const int lane_id = threadIdx.x % WARP_SIZE;
+    const Pointer data{(T*)mat.ptr.ptr};
+    const int ld = mat.ptr.stride;
 
-        const Pointer data{(T*)mat.ptr.ptr};
-        const int     ld = mat.ptr.stride;
+    const int2 offsets = Map::get_offset(warp_id, lane_id);
 
-        const int2 offsets = Map::get_offset(warp_id, lane_id);
+    offset_c_ = offsets.x;
+    offset_s_ = offsets.y;
 
-        offset_c_ = offsets.x;
-        offset_s_ = offsets.y;
-
-        if constexpr (pred_.is_active) {
-            extent = to_cs(pack(extent));
-            PRAGMA_UNROLL
-            for (int s = 0; s < Map::kIterS; ++s) {
-                PRAGMA_UNROLL
-                for (int c = 0; c < Map::kIterC; ++c) {
-                    int ss = offset_s_ + s * Map::kDeltaS;
-                    int cc = offset_c_ + c * Map::kDeltaC;
-                    if (ss < extent.y && cc < extent.x) {
-                        pred_.set(s, c);
-                    }
-                }
-            }
-        }
-
+    if constexpr (pred_.is_active) {
+      extent = to_cs(pack(extent));
+      PRAGMA_UNROLL
+      for (int s = 0; s < Map::kIterS; ++s) {
         PRAGMA_UNROLL
-        for (int s = 0; s < kPeriodS; ++s) {
-            PRAGMA_UNROLL
-            for (int c = 0; c < kPeriodC; ++c) {
-                phases_[s][c] = SmemLayout::apply(offset_s_ + s * Map::kDeltaS, offset_c_ + c * Map::kDeltaC);
-            }
+        for (int c = 0; c < Map::kIterC; ++c) {
+          int ss = offset_s_ + s * Map::kDeltaS;
+          int cc = offset_c_ + c * Map::kDeltaC;
+          if (ss < extent.y && cc < extent.x) {
+            pred_.set(s, c);
+          }
         }
+      }
+    }
 
-        const int src_offset = is_indexed ? offsets.x : offsets.x + offsets.y * ld;
+    PRAGMA_UNROLL
+    for (int s = 0; s < kPeriodS; ++s) {
+      PRAGMA_UNROLL
+      for (int c = 0; c < kPeriodC; ++c) {
+        phases_[s][c] = SmemLayout::apply(offset_s_ + s * Map::kDeltaS,
+                                          offset_c_ + c * Map::kDeltaC);
+      }
+    }
 
-        src_offset_ = src_offset * bitsof<T> / bitsof<char>;
+    const int src_offset = is_indexed ? offsets.x : offsets.x + offsets.y * ld;
 
-        src_step_c_ = bitsof<T> * Map::kDeltaC / bitsof<char>;
-        src_step_s_ = bitsof<T> * Map::kDeltaS * ld / bitsof<char>;
+    src_offset_ = src_offset * bitsof<T> / bitsof<char>;
 
-        src_step_k_ = bitsof<T> * cs2mk<kOrder>(Map::kDimC, Map::kDimS * ld).y / bitsof<char>;
+    src_step_c_ = bitsof<T> * Map::kDeltaC / bitsof<char>;
+    src_step_s_ = bitsof<T> * Map::kDeltaS * ld / bitsof<char>;
 
-        // Initialize for the first tile
-        if constexpr (is_indexed) {
-            const int2 cta_cs = to_cs(offset);
-            for (int s = 0; s < ITER_S; ++s) {
-                const int  ss    = cta_cs.y + offset_s_ + s * Map::kDeltaS;
-                const int  idx   = (mat.idxs && pred_(s, 0)) ? __ldg(mat.idxs + ss) : ss;
-                const auto tmp   = data + cs2idx({cta_cs.x, idx}, ld);
-                src_data_vec_[s] = reinterpret_cast<const char*>((T*)tmp) + src_offset_;
-            }
-        }
-        else {
-            auto src_data = data + cs2idx(to_cs(pack(offset)), ld);
-            src_data_     = reinterpret_cast<const char*>((T*)src_data) + src_offset_;
-        }
+    src_step_k_ =
+        bitsof<T> * cs2mk<kOrder>(Map::kDimC, Map::kDimS * ld).y / bitsof<char>;
+
+    // Initialize for the first tile
+    if constexpr (is_indexed) {
+      const int2 cta_cs = to_cs(offset);
+      for (int s = 0; s < ITER_S; ++s) {
+        const int ss = cta_cs.y + offset_s_ + s * Map::kDeltaS;
+        const int idx = (mat.idxs && pred_(s, 0)) ? __ldg(mat.idxs + ss) : ss;
+        const auto tmp = data + cs2idx({cta_cs.x, idx}, ld);
+        src_data_vec_[s] = reinterpret_cast<const char*>((T*)tmp) + src_offset_;
+      }
+    } else {
+      auto src_data = data + cs2idx(to_cs(pack(offset)), ld);
+      src_data_ = reinterpret_cast<const char*>((T*)src_data) + src_offset_;
+    }
 
 #if TURBOMIND_ARCH_SM80
-        if constexpr (Policy::kEvictPolicy != EvictPolicy::kEvictNormal) {
-            asm volatile("createpolicy.fractional.L2::evict_first.b64 %0;\n" : "=l"(cache_policy_) :);
-        }
+    if constexpr (Policy::kEvictPolicy != EvictPolicy::kEvictNormal) {
+      asm volatile("createpolicy.fractional.L2::evict_first.b64 %0;\n"
+                   : "=l"(cache_policy_)
+                   :);
+    }
 #endif
-    }
+  }
 
-    __device__ constexpr int _src_step_k() const
-    {
-        return src_step_k_;
-    }
+  __device__ constexpr int _src_step_k() const { return src_step_k_; }
 
-    __device__ void ClearSmem(int pipe_iter = 0)
-    {
-        PRAGMA_UNROLL
-        for (int s = 0; s < Map::kIterS; ++s) {
-            PRAGMA_UNROLL
-            for (int c = 0; c < Map::kIterC; ++c) {
-                const int pred_s = offset_s_ + s * Map::kDeltaS < Map::kDimS;
-                const int pred_c = offset_c_ + c * Map::kDeltaC < Map::kDimC;
-                auto      ptr    = &smem_data_(offset_s_ + s * Map::kDeltaS, offset_c_ + c * Map::kDeltaC);
-                if ((Map::kAlignedC && Map::kAlignedS) || (pred_s && pred_c)) {
-                    Store(ptr, Array<T, Map::kAccessC>{});
-                }
-            }
+  __device__ void ClearSmem(int pipe_iter = 0) {
+    PRAGMA_UNROLL
+    for (int s = 0; s < Map::kIterS; ++s) {
+      PRAGMA_UNROLL
+      for (int c = 0; c < Map::kIterC; ++c) {
+        const int pred_s = offset_s_ + s * Map::kDeltaS < Map::kDimS;
+        const int pred_c = offset_c_ + c * Map::kDeltaC < Map::kDimC;
+        auto ptr = &smem_data_(offset_s_ + s * Map::kDeltaS,
+                               offset_c_ + c * Map::kDeltaC);
+        if ((Map::kAlignedC && Map::kAlignedS) || (pred_s && pred_c)) {
+          Store(ptr, Array<T, Map::kAccessC>{});
         }
+      }
     }
+  }
 
-    __device__ void Prefetch(int begin, int count, bool tile_mask)
-    {
-        PRAGMA_UNROLL
-        for (int s = begin; s < begin + count && s < Map::kIterS; ++s) {
+  __device__ void Prefetch(int begin, int count, bool tile_mask) {
+    PRAGMA_UNROLL
+    for (int s = begin; s < begin + count && s < Map::kIterS; ++s) {
+      if constexpr (is_indexed) {
+        src_data_ = src_data_vec_[s];
+      }
 
-            if constexpr (is_indexed) {
-                src_data_ = src_data_vec_[s];
-            }
+      PRAGMA_UNROLL
+      for (int c = 0; c < Map::kIterC; ++c) {
+        // auto dst = &smem_data_(offset_s_ + s * Map::kDeltaS, offset_c_ + c *
+        // Map::kDeltaC);
 
-            PRAGMA_UNROLL
-            for (int c = 0; c < Map::kIterC; ++c) {
-                // auto dst = &smem_data_(offset_s_ + s * Map::kDeltaS, offset_c_ + c * Map::kDeltaC);
+        const int i0 = SmemLayout::apply(  //
+            s / kPeriodS * kPeriodS * Map::kDeltaS,
+            c / kPeriodC * kPeriodC * Map::kDeltaC);
+        const int i1 = phases_[s % kPeriodS][c % kPeriodC];
+        auto dst = &smem_data_.ptr_[i0 + i1];
 
-                const int i0  = SmemLayout::apply(  //
-                    s / kPeriodS * kPeriodS * Map::kDeltaS,
-                    c / kPeriodC * kPeriodC * Map::kDeltaC);
-                const int i1  = phases_[s % kPeriodS][c % kPeriodC];
-                auto      dst = &smem_data_.ptr_[i0 + i1];
+        CpAsync(std::true_type{}, dst, src_data_ + src_step_c_ * c,
+                tile_mask && g_mask && pred_(s, c));
+      }
 
-                CpAsync(std::true_type{}, dst, src_data_ + src_step_c_ * c, tile_mask && g_mask && pred_(s, c));
-            }
-
-            if constexpr (is_indexed) {
-                src_data_vec_[s] += _src_step_k();
-            }
-            else {
-                src_data_ += src_step_s_;
-                if (s == Map::kIterS - 1) {
-                    src_data_ -= src_step_s_ * Map::kIterS;
-                    src_data_ += _src_step_k();
-                }
-            }
+      if constexpr (is_indexed) {
+        src_data_vec_[s] += _src_step_k();
+      } else {
+        src_data_ += src_step_s_;
+        if (s == Map::kIterS - 1) {
+          src_data_ -= src_step_s_ * Map::kIterS;
+          src_data_ += _src_step_k();
         }
+      }
     }
+  }
 
-    __device__ void Prefetch(bool tile_mask)
-    {
-        Prefetch(0, Map::kIterS, tile_mask);
+  __device__ void Prefetch(bool tile_mask) {
+    Prefetch(0, Map::kIterS, tile_mask);
+  }
+
+  __device__ void Advance() {
+    if constexpr (!is_indexed) {
+      if (!g_mask) {
+        src_data_ -= _src_step_k();
+      }
     }
+  }
 
-    __device__ void Advance()
-    {
-        if constexpr (!is_indexed) {
-            if (!g_mask) {
-                src_data_ -= _src_step_k();
-            }
-        }
-    }
-
-    __device__ void CpAsync(std::true_type, T* dst, const char* __restrict__ src, bool mask)
-    {
+  __device__ void CpAsync(std::true_type, T* dst, const char* __restrict__ src,
+                          bool mask) {
 #if TURBOMIND_ARCH_SM80
-        constexpr int size = sizeof(AccessType);
-        static_assert(size <= 16);
+    constexpr int size = sizeof(AccessType);
+    static_assert(size <= 16);
 
-        constexpr int prefetch_size = std::min(256, size * Map::kWarpThreadC);
+    constexpr int prefetch_size = std::min(256, size * Map::kWarpThreadC);
 
-        auto ptr = cast_smem_ptr_to_uint(dst);
+    auto ptr = cast_smem_ptr_to_uint(dst);
 
-        static constexpr auto cache_op = GetCacheOp<Policy::kCacheOp, size>::value;
+    static constexpr auto cache_op = GetCacheOp<Policy::kCacheOp, size>::value;
 
-        if constexpr (Policy::kEvictPolicy != EvictPolicy::kEvictNormal) {
-            CP_ASYNC<cache_op, size, prefetch_size>::apply(ptr, src, cache_policy_, mask);
-        }
-        else {
-            CP_ASYNC<cache_op, size, prefetch_size>::apply(ptr, src, mask);
-        }
+    if constexpr (Policy::kEvictPolicy != EvictPolicy::kEvictNormal) {
+      CP_ASYNC<cache_op, size, prefetch_size>::apply(ptr, src, cache_policy_,
+                                                     mask);
+    } else {
+      CP_ASYNC<cache_op, size, prefetch_size>::apply(ptr, src, mask);
+    }
 #else
-        assert(TURBOMIND_ARCH_SM80);
+    assert(TURBOMIND_ARCH_SM80);
 #endif
-    }
+  }
 };
 
-template<Striding mode, class Policy>
+template <Striding mode, class Policy>
 struct IteratorSm80 {
-    template<class T, class Map, class SmemLayout, Pack kPack, Order kOrder, bool AlignedC, bool AlignedS>
-    using Type = GmemIteratorSm80<T, Map, SmemLayout, kPack, kOrder, AlignedC, AlignedS, mode, Policy>;
+  template <class T, class Map, class SmemLayout, Pack kPack, Order kOrder,
+            bool AlignedC, bool AlignedS>
+  using Type = GmemIteratorSm80<T, Map, SmemLayout, kPack, kOrder, AlignedC,
+                                AlignedS, mode, Policy>;
 };
 
 }  // namespace turbomind::gemm

--- a/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/iterator_sm90.h
+++ b/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/iterator_sm90.h
@@ -5,32 +5,32 @@
 
 namespace turbomind::gemm {
 
-template<int multicast>
+template <int multicast>
 struct GmemIteratorSm90 {
+  const CUtensorMap* desc_ptr_;
+  int2 offset_;
+  int2 step_;
 
-    const CUtensorMap* desc_ptr_;
-    int2               offset_;
-    int2               step_;
+  __device__ GmemIteratorSm90(const CUtensorMap* desc_ptr, int2 offset,
+                              int2 step) {
+    desc_ptr_ = desc_ptr;
+    offset_ = offset;
+    step_ = step;
+  }
 
-    __device__ GmemIteratorSm90(const CUtensorMap* desc_ptr, int2 offset, int2 step)
-    {
-        desc_ptr_ = desc_ptr;
-        offset_   = offset;
-        step_     = step;
+  __device__ void Step(uint64_t* mbar_ptr, void* smem_ptr, uint16_t mask,
+                       uint64_t cache_hint = 0) {
+    if constexpr (multicast > 1) {
+      cute::SM90_TMA_LOAD_MULTICAST_2D::copy(desc_ptr_, mbar_ptr, mask,
+                                             cache_hint, smem_ptr, offset_.x,
+                                             offset_.y);
+    } else {
+      cute::SM90_TMA_LOAD_2D::copy(desc_ptr_, mbar_ptr, cache_hint, smem_ptr,
+                                   offset_.x, offset_.y);
     }
-
-    __device__ void Step(uint64_t* mbar_ptr, void* smem_ptr, uint16_t mask, uint64_t cache_hint = 0)
-    {
-        if constexpr (multicast > 1) {
-            cute::SM90_TMA_LOAD_MULTICAST_2D::copy(
-                desc_ptr_, mbar_ptr, mask, cache_hint, smem_ptr, offset_.x, offset_.y);
-        }
-        else {
-            cute::SM90_TMA_LOAD_2D::copy(desc_ptr_, mbar_ptr, cache_hint, smem_ptr, offset_.x, offset_.y);
-        }
-        offset_.x += step_.x;
-        offset_.y += step_.y;
-    }
+    offset_.x += step_.x;
+    offset_.y += step_.y;
+  }
 };
 
 }  // namespace turbomind::gemm

--- a/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/kernel.cu
+++ b/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/kernel.cu
@@ -14,292 +14,259 @@
 
 namespace turbomind::gemm {
 
-bool accept(Striding a, Striding b)
-{
-    if (a == Striding::kBlocked) {
-        switch (b) {
-            case Striding::kBlocked:
-            case Striding::kFlat:
-                return true;
-            default:
-                return false;
-        }
+bool accept(Striding a, Striding b) {
+  if (a == Striding::kBlocked) {
+    switch (b) {
+      case Striding::kBlocked:
+      case Striding::kFlat:
+        return true;
+      default:
+        return false;
     }
-    else if (a == Striding::kIndexed) {
-        switch (b) {
-            case Striding::kFlat:
-            case Striding::kBlocked:
-            case Striding::kIndexed:
-                return true;
-            default:
-                return false;
-        }
+  } else if (a == Striding::kIndexed) {
+    switch (b) {
+      case Striding::kFlat:
+      case Striding::kBlocked:
+      case Striding::kIndexed:
+        return true;
+      default:
+        return false;
     }
-    else {
-        return a == b;
-    }
+  } else {
+    return a == b;
+  }
 }
 
-bool Kernel::is_feasible(const GemmDesc& desc) const noexcept
-{
-    constexpr bool debug = 0;
+bool Kernel::is_feasible(const GemmDesc& desc) const noexcept {
+  constexpr bool debug = 0;
 
-    if constexpr (debug)
-        printf("S\n");
+  if constexpr (debug) printf("S\n");
 
-    // printf("%d %d\n", desc.arch, desc_.arch);
+  // printf("%d %d\n", desc.arch, desc_.arch);
 
-    if (!is_arch_compatible(desc_.arch, desc.arch)) {
-        return false;
-    }
+  if (!is_arch_compatible(desc_.arch, desc.arch)) {
+    return false;
+  }
 
-    if constexpr (debug)
-        printf("S0\n");
+  if constexpr (debug) printf("S0\n");
 
-    if (std::tie(desc.order_a, desc.order_b, desc.order_c) != std::tie(desc_.order_a, desc_.order_b, desc_.order_c)) {
-        return false;
-    }
+  if (std::tie(desc.order_a, desc.order_b, desc.order_c) !=
+      std::tie(desc_.order_a, desc_.order_b, desc_.order_c)) {
+    return false;
+  }
 
-    if (desc.group_axis >= 0 && desc.group_axis != desc_.group_axis) {
-        return false;
-    }
+  if (desc.group_axis >= 0 && desc.group_axis != desc_.group_axis) {
+    return false;
+  }
 
-    if (!(accept(desc_.striding_a, desc.striding_a)     //
-          && accept(desc_.striding_b, desc.striding_b)  //
-          && accept(desc_.striding_c, desc.striding_c))) {
-        return false;
-    }
+  if (!(accept(desc_.striding_a, desc.striding_a)     //
+        && accept(desc_.striding_b, desc.striding_b)  //
+        && accept(desc_.striding_c, desc.striding_c))) {
+    return false;
+  }
 
-    if constexpr (debug)
-        printf("A\n");
+  if constexpr (debug) printf("A\n");
 
-    if (std::tie(desc.type_a, desc.type_b, desc.type_c) != std::tie(desc_.type_a, desc_.type_b, desc_.type_c)) {
-        return false;
-    }
+  if (std::tie(desc.type_a, desc.type_b, desc.type_c) !=
+      std::tie(desc_.type_a, desc_.type_b, desc_.type_c)) {
+    return false;
+  }
 
-    if constexpr (debug) {
-        printf("B\n");
-        printf("%X %X %X %X\n", desc.pack_a, desc_.pack_a, desc.pack_u, desc_.pack_u);
-    }
+  if constexpr (debug) {
+    printf("B\n");
+    printf("%X %X %X %X\n", desc.pack_a, desc_.pack_a, desc.pack_u,
+           desc_.pack_u);
+  }
 
-    if (std::tie(desc.pack_a, desc.pack_u) != std::tie(desc_.pack_a, desc_.pack_u)) {
-        return false;
-    }
+  if (std::tie(desc.pack_a, desc.pack_u) !=
+      std::tie(desc_.pack_a, desc_.pack_u)) {
+    return false;
+  }
 
-    if constexpr (debug) {
-        printf("C\n");
-        printf("%X %X %X %X\n", desc.pack_b, desc_.pack_b, desc.pack_v, desc_.pack_v);
-    }
+  if constexpr (debug) {
+    printf("C\n");
+    printf("%X %X %X %X\n", desc.pack_b, desc_.pack_b, desc.pack_v,
+           desc_.pack_v);
+  }
 
-    if (std::tie(desc.pack_b, desc.pack_v) != std::tie(desc_.pack_b, desc_.pack_v)) {
-        return false;
-    }
+  if (std::tie(desc.pack_b, desc.pack_v) !=
+      std::tie(desc_.pack_b, desc_.pack_v)) {
+    return false;
+  }
 
-    if constexpr (debug)
-        printf("D\n");
+  if constexpr (debug) printf("D\n");
 
-    if (desc.quant_a.type != desc_.quant_a.type || desc.quant_a.group_size != desc_.quant_a.group_size) {
-        return false;
-    }
+  if (desc.quant_a.type != desc_.quant_a.type ||
+      desc.quant_a.group_size != desc_.quant_a.group_size) {
+    return false;
+  }
 
-    if constexpr (debug)
-        printf("E\n");
+  if constexpr (debug) printf("E\n");
 
-    if (desc.quant_b.type != desc_.quant_b.type || desc.quant_b.group_size != desc_.quant_b.group_size) {
-        return false;
-    }
+  if (desc.quant_b.type != desc_.quant_b.type ||
+      desc.quant_b.group_size != desc_.quant_b.group_size) {
+    return false;
+  }
 
-    if constexpr (debug)
-        printf("F\n");
+  if constexpr (debug) printf("F\n");
 
-    if (desc.m % desc_.align.x || desc.n % desc_.align.y || desc.k % desc_.align.z) {
-        return false;
-    }
+  if (desc.m % desc_.align.x || desc.n % desc_.align.y ||
+      desc.k % desc_.align.z) {
+    return false;
+  }
 
-    if constexpr (debug)
-        printf("success\n");
+  if constexpr (debug) printf("success\n");
 
-    return true;
+  return true;
 }
 
 //  mm:     m * n * k,     m * k,     n * k,     m * n
 // Bmm: b * m * n * k, b * m * k, b * n * k, b * m * n
 // Gmm: S $ M * n * k, S $ M * k, S $ n * k, S $ M * n
 
-std::string Kernel::GetName() const
-{
-    std::stringstream ss;
+std::string Kernel::GetName() const {
+  std::stringstream ss;
 
-    ss << "sm" << desc_.arch / 10;
-    ss << "_" << to_string(desc_.type_a);  //
-    if (desc_.quant_a) {
-        ss << to_string(desc_.quant_a);
-    }
-    ss << "_" << to_string(desc_.type_b);  //
-    if (desc_.quant_b) {
-        ss << to_string(desc_.quant_b);
-    }
-    ss << "_" << to_string(desc_.type_c);
-    ss << "_"                                        //
-       << (desc_.order_a == kColMajor ? 'n' : 't')   //
-       << (desc_.order_b == kColMajor ? 'n' : 't')   //
-       << (desc_.order_c == kColMajor ? 'n' : 't');  //
-    ss << "_"                                        //
-       << to_string(desc_.striding_a)                //
-       << to_string(desc_.striding_b)                //
-       << to_string(desc_.striding_c);
-    ss << "_" << desc_.cta_tile.x << "x" << desc_.cta_tile.y << "x" << desc_.cta_tile.z  //
-       << "_" << desc_.stages                                                            //
-       << "_" << desc_.cluster_shape.x << "x" << desc_.cluster_shape.y                   //
-       << "_" << to_string(desc_.op_class)                                               //
-       << "_" << desc_.mma_tile.x << "x" << desc_.mma_tile.y << "x" << desc_.mma_tile.z;
-    if (desc_.group_axis >= 0) {
-        ss << "_"
-           << "mn"[desc_.group_axis] << "group";
-    }
-    ss << "_c" << desc_.c_tile.x << "x" << desc_.c_tile.y                        //
-       << "_a" << desc_.align.x << "x" << desc_.align.y << "x" << desc_.align.z  //
-       << "_" << desc_.policy_a << desc_.policy_b;
+  ss << "sm" << desc_.arch / 10;
+  ss << "_" << to_string(desc_.type_a);  //
+  if (desc_.quant_a) {
+    ss << to_string(desc_.quant_a);
+  }
+  ss << "_" << to_string(desc_.type_b);  //
+  if (desc_.quant_b) {
+    ss << to_string(desc_.quant_b);
+  }
+  ss << "_" << to_string(desc_.type_c);
+  ss << "_"                                        //
+     << (desc_.order_a == kColMajor ? 'n' : 't')   //
+     << (desc_.order_b == kColMajor ? 'n' : 't')   //
+     << (desc_.order_c == kColMajor ? 'n' : 't');  //
+  ss << "_"                                        //
+     << to_string(desc_.striding_a)                //
+     << to_string(desc_.striding_b)                //
+     << to_string(desc_.striding_c);
+  ss << "_" << desc_.cta_tile.x << "x" << desc_.cta_tile.y << "x"
+     << desc_.cta_tile.z                                              //
+     << "_" << desc_.stages                                           //
+     << "_" << desc_.cluster_shape.x << "x" << desc_.cluster_shape.y  //
+     << "_" << to_string(desc_.op_class)                              //
+     << "_" << desc_.mma_tile.x << "x" << desc_.mma_tile.y << "x"
+     << desc_.mma_tile.z;
+  if (desc_.group_axis >= 0) {
+    ss << "_"
+       << "mn"[desc_.group_axis] << "group";
+  }
+  ss << "_c" << desc_.c_tile.x << "x" << desc_.c_tile.y  //
+     << "_a" << desc_.align.x << "x" << desc_.align.y << "x"
+     << desc_.align.z  //
+     << "_" << desc_.policy_a << desc_.policy_b;
 
-    return ss.str();
+  return ss.str();
 }
 
-class TransposedKernel: public Kernel {
-public:
-    explicit TransposedKernel(Kernel& kernel): kernel_(&kernel)
-    {
-        desc_ = kernel.desc();
-        info_ = kernel.info();
+class TransposedKernel : public Kernel {
+ public:
+  explicit TransposedKernel(Kernel& kernel) : kernel_(&kernel) {
+    desc_ = kernel.desc();
+    info_ = kernel.info();
 
-        desc_.transpose = !desc_.transpose;
-    }
+    desc_.transpose = !desc_.transpose;
+  }
 
-    int Launch(const Operation&    operation,
-               float               alpha,
-               const void*         A,
-               const MatrixLayout& Adesc,
-               const void*         U,
-               const MatrixLayout& Udesc,
-               const void*         B,
-               const MatrixLayout& Bdesc,
-               const void*         V,
-               const MatrixLayout& Vdesc,
-               float               beta,
-               const void*         C,
-               const MatrixLayout& Cdesc,
-               void*               D,
-               const MatrixLayout& Ddesc,
-               int                 swizzle,
-               int                 splits,
-               Workspace&          workspace,
-               cudaStream_t        stream) override
-    {
-        return kernel_->Launch(transpose(operation),
-                               alpha,
-                               B,
-                               transpose(Bdesc),
-                               V,
-                               transpose(Vdesc),
-                               A,
-                               transpose(Adesc),
-                               U,
-                               transpose(Udesc),
-                               beta,
-                               C,
-                               transpose(Cdesc),
-                               D,
-                               transpose(Ddesc),
-                               swizzle,
-                               splits,
-                               workspace,
-                               stream);
-    }
+  int Launch(const Operation& operation, float alpha, const void* A,
+             const MatrixLayout& Adesc, const void* U,
+             const MatrixLayout& Udesc, const void* B,
+             const MatrixLayout& Bdesc, const void* V,
+             const MatrixLayout& Vdesc, float beta, const void* C,
+             const MatrixLayout& Cdesc, void* D, const MatrixLayout& Ddesc,
+             int swizzle, int splits, Workspace& workspace,
+             cudaStream_t stream) override {
+    return kernel_->Launch(
+        transpose(operation), alpha, B, transpose(Bdesc), V, transpose(Vdesc),
+        A, transpose(Adesc), U, transpose(Udesc), beta, C, transpose(Cdesc), D,
+        transpose(Ddesc), swizzle, splits, workspace, stream);
+  }
 
-    bool is_feasible(const GemmDesc& desc) const noexcept override
-    {
-        return kernel_->is_feasible(desc);
-    }
+  bool is_feasible(const GemmDesc& desc) const noexcept override {
+    return kernel_->is_feasible(desc);
+  }
 
-    int GetMaxSwizzle(const int4& shape) const override
-    {
-        return kernel_->GetMaxSwizzle(shape);
-    }
+  int GetMaxSwizzle(const int4& shape) const override {
+    return kernel_->GetMaxSwizzle(shape);
+  }
 
-    int GetMaxSplits(const int4& shape, int swizzle, size_t bsize, size_t psize) const override
-    {
-        return kernel_->GetMaxSplits(shape, swizzle, bsize, psize);
-    }
+  int GetMaxSplits(const int4& shape, int swizzle, size_t bsize,
+                   size_t psize) const override {
+    return kernel_->GetMaxSplits(shape, swizzle, bsize, psize);
+  }
 
-private:
-    Kernel* kernel_;
+ private:
+  Kernel* kernel_;
 };
 
-std::unique_ptr<Kernel> transpose(Kernel& kernel)
-{
-    return std::make_unique<TransposedKernel>(kernel);
+std::unique_ptr<Kernel> transpose(Kernel& kernel) {
+  return std::make_unique<TransposedKernel>(kernel);
 }
 
-template<class Op>
-inline static bool cmp(const int3& a, const int3& b, Op op)
-{
-    return op(std::tie(a.x, a.y, a.z), std::tie(b.x, b.y, b.z));
+template <class Op>
+inline static bool cmp(const int3& a, const int3& b, Op op) {
+  return op(std::tie(a.x, a.y, a.z), std::tie(b.x, b.y, b.z));
 }
 
-std::vector<std::vector<LaunchSpec>> Cluster(const std::vector<LaunchSpec>& specs, const ClusteringParam& param)
-{
-    std::vector<const LaunchSpec*> ptrs;  // pointer into `specs`
-    for (auto& s : specs) {
-        ptrs.push_back(&s);
+std::vector<std::vector<LaunchSpec>> Cluster(
+    const std::vector<LaunchSpec>& specs, const ClusteringParam& param) {
+  std::vector<const LaunchSpec*> ptrs;  // pointer into `specs`
+  for (auto& s : specs) {
+    ptrs.push_back(&s);
+  }
+
+  auto less = [&](const LaunchSpec* u, const LaunchSpec* v) {
+    const auto& a = u->kernel->desc();
+    const auto& b = v->kernel->desc();
+    if (!cmp(a.cta_tile, b.cta_tile, std::equal_to<>{})) {
+      return cmp(a.cta_tile, b.cta_tile, std::less<>{});
     }
-
-    auto less = [&](const LaunchSpec* u, const LaunchSpec* v) {
-        const auto& a = u->kernel->desc();
-        const auto& b = v->kernel->desc();
-        if (!cmp(a.cta_tile, b.cta_tile, std::equal_to<>{})) {
-            return cmp(a.cta_tile, b.cta_tile, std::less<>{});
-        }
-        if (!cmp(a.mma_tile, b.mma_tile, std::equal_to<>{})) {
-            return cmp(a.mma_tile, b.mma_tile, std::less<>{});
-        }
-        if (param.cache_policy) {
-            const auto pa = std::tie(a.policy_a, a.policy_b);
-            const auto pb = std::tie(b.policy_a, b.policy_b);
-            if (pa != pb) {
-                return pa < pb;
-            }
-        }
-        if (param.max_active_ctas) {
-            const auto& a = u->kernel->info();
-            const auto& b = v->kernel->info();
-            if (a.max_active_ctas != b.max_active_ctas) {
-                return a.max_active_ctas < b.max_active_ctas;
-            }
-        }
-        return u->splits < v->splits;
-    };
-
-    std::stable_sort(ptrs.begin(), ptrs.end(), less);
-
-    if (ptrs.empty()) {
-        return {};
+    if (!cmp(a.mma_tile, b.mma_tile, std::equal_to<>{})) {
+      return cmp(a.mma_tile, b.mma_tile, std::less<>{});
     }
-    std::vector<std::vector<LaunchSpec>> clusters{{*ptrs[0]}};
-
-    auto equal = [&](const LaunchSpec* u, const LaunchSpec* v) {  //
-        return !less(u, v) && !less(v, u);
-    };
-    int p = 0;
-    for (size_t i = 1; i < ptrs.size(); ++i) {
-        if (equal(ptrs[p], ptrs[i])) {
-            clusters.back().push_back(*ptrs[i]);
-        }
-        else {
-            clusters.push_back({*ptrs[i]});
-            p = i;
-        }
+    if (param.cache_policy) {
+      const auto pa = std::tie(a.policy_a, a.policy_b);
+      const auto pb = std::tie(b.policy_a, b.policy_b);
+      if (pa != pb) {
+        return pa < pb;
+      }
     }
+    if (param.max_active_ctas) {
+      const auto& a = u->kernel->info();
+      const auto& b = v->kernel->info();
+      if (a.max_active_ctas != b.max_active_ctas) {
+        return a.max_active_ctas < b.max_active_ctas;
+      }
+    }
+    return u->splits < v->splits;
+  };
 
-    return clusters;
+  std::stable_sort(ptrs.begin(), ptrs.end(), less);
+
+  if (ptrs.empty()) {
+    return {};
+  }
+  std::vector<std::vector<LaunchSpec>> clusters{{*ptrs[0]}};
+
+  auto equal = [&](const LaunchSpec* u, const LaunchSpec* v) {  //
+    return !less(u, v) && !less(v, u);
+  };
+  int p = 0;
+  for (size_t i = 1; i < ptrs.size(); ++i) {
+    if (equal(ptrs[p], ptrs[i])) {
+      clusters.back().push_back(*ptrs[i]);
+    } else {
+      clusters.push_back({*ptrs[i]});
+      p = i;
+    }
+  }
+
+  return clusters;
 }
 
 }  // namespace turbomind::gemm

--- a/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/kernel.h
+++ b/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/kernel.h
@@ -16,106 +16,69 @@
 namespace turbomind::gemm {
 
 struct KernelMetric {
-    int64_t mio_cost;
-    int64_t mma_cost;
+  int64_t mio_cost;
+  int64_t mma_cost;
 };
 
 class Kernel {
-public:
-    Kernel(): desc_{}, info_{} {}
+ public:
+  Kernel() : desc_{}, info_{} {}
 
-    virtual ~Kernel() = default;
+  virtual ~Kernel() = default;
 
-    virtual int Launch(const Operation&    operation,
-                       float               alpha,
-                       const void*         A,
-                       const MatrixLayout& Adesc,
-                       const void*         U,
-                       const MatrixLayout& Udesc,
-                       const void*         B,
-                       const MatrixLayout& Bdesc,
-                       const void*         V,
-                       const MatrixLayout& Vdesc,
-                       float               beta,
-                       const void*         C,
-                       const MatrixLayout& Cdesc,
-                       void*               D,
-                       const MatrixLayout& Ddesc,
-                       int                 swizzle,
-                       int                 splits,
-                       Workspace&          workspace,
-                       cudaStream_t        stream) = 0;
+  virtual int Launch(const Operation& operation, float alpha, const void* A,
+                     const MatrixLayout& Adesc, const void* U,
+                     const MatrixLayout& Udesc, const void* B,
+                     const MatrixLayout& Bdesc, const void* V,
+                     const MatrixLayout& Vdesc, float beta, const void* C,
+                     const MatrixLayout& Cdesc, void* D,
+                     const MatrixLayout& Ddesc, int swizzle, int splits,
+                     Workspace& workspace, cudaStream_t stream) = 0;
 
-    // true if this kernel can be used to compute the gemm
-    virtual bool is_feasible(const GemmDesc& desc) const noexcept;
+  // true if this kernel can be used to compute the gemm
+  virtual bool is_feasible(const GemmDesc& desc) const noexcept;
 
-    virtual int GetMaxSwizzle(const int4& shape) const = 0;
+  virtual int GetMaxSwizzle(const int4& shape) const = 0;
 
-    virtual int GetMaxSplits(const int4& shape, int swizzle, size_t bsize, size_t psize) const = 0;
+  virtual int GetMaxSplits(const int4& shape, int swizzle, size_t bsize,
+                           size_t psize) const = 0;
 
-    const KernelDesc& desc() const noexcept
-    {
-        return desc_;
-    }
+  const KernelDesc& desc() const noexcept { return desc_; }
 
-    const KernelInfo& info() const noexcept
-    {
-        return info_;
-    }
+  const KernelInfo& info() const noexcept { return info_; }
 
-    int3 cta_tile_size() const noexcept
-    {
-        return desc_.cta_tile;
-    }
+  int3 cta_tile_size() const noexcept { return desc_.cta_tile; }
 
-    int3 warp_tile_size() const noexcept
-    {
-        return desc_.mma_tile;
-    }
+  int3 warp_tile_size() const noexcept { return desc_.mma_tile; }
 
-    int chunk_size_k() const noexcept
-    {
-        return info_.chunk_size_k;
-    }
+  int chunk_size_k() const noexcept { return info_.chunk_size_k; }
 
-    int stages() const noexcept
-    {
-        return desc_.stages;
-    }
+  int stages() const noexcept { return desc_.stages; }
 
-    bool split_k() const noexcept
-    {
-        return desc_.split_k;
-    }
+  bool split_k() const noexcept { return desc_.split_k; }
 
-    int arch() const noexcept
-    {
-        return desc_.arch;
-    }
+  int arch() const noexcept { return desc_.arch; }
 
-    int smem_size() const noexcept
-    {
-        return info_.attr.sharedSizeBytes + info_.dynamic_smem_size;
-    }
+  int smem_size() const noexcept {
+    return info_.attr.sharedSizeBytes + info_.dynamic_smem_size;
+  }
 
-    std::string name() const
-    {
-        return info_.name;
-    }
+  std::string name() const { return info_.name; }
 
-protected:
-    std::string GetName() const;
+ protected:
+  std::string GetName() const;
 
-    KernelDesc desc_;
-    KernelInfo info_;
+  KernelDesc desc_;
+  KernelInfo info_;
 };
 
 struct ClusteringParam {
-    bool cache_policy;
-    bool max_active_ctas;
+  bool cache_policy;
+  bool max_active_ctas;
 };
 
-std::vector<std::vector<LaunchSpec>> Cluster(const std::vector<LaunchSpec>& specs, const ClusteringParam& param);
+std::vector<std::vector<LaunchSpec>> Cluster(
+    const std::vector<LaunchSpec>& specs, const ClusteringParam& param);
 
 std::unique_ptr<Kernel> transpose(Kernel& kernel);
 

--- a/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/kernel/sm70_884_16.cu
+++ b/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/kernel/sm70_884_16.cu
@@ -11,10 +11,9 @@ using namespace cache_policy;
 using S = cache_policy::Stream;
 using D = cache_policy::Default;
 
-void Registry::sm70_884_16()
-{
-    if constexpr (1) {
-        // clang-format off
+void Registry::sm70_884_16() {
+  if constexpr (1) {
+    // clang-format off
         using C = Config_F16<kColMajor, 0>;
         Add<C::Type<256, 128,  16, 4, 2, 1, D, D, 2,   0 , 1, 1, 128, 128>>();
         Add<C::Type<128, 256,  16, 2, 4, 1, D, D, 2,   0 , 1, 1, 128, 128>>();
@@ -28,8 +27,8 @@ void Registry::sm70_884_16()
         Add<C::Type< 16, 128,  32, 1, 4, 1, D, S, 2, true, 1, 1>>();
         Add<C::Type<  8, 128,  64, 1, 4, 1, D, S, 2, true, 1, 1>>();
         Add<C::Type<  8, 256,  64, 1, 4, 1, D, S, 2, true, 1, 1>>();
-        // clang-format on
-    }
+    // clang-format on
+  }
 }
 
 }  // namespace turbomind::gemm

--- a/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/kernel/sm70_884_4.cu
+++ b/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/kernel/sm70_884_4.cu
@@ -13,32 +13,30 @@ using D = cache_policy::Default;
 
 namespace {
 
-// Keep shape-specific small-N tactics out of prefill and unrelated CUDA graph shapes.
-template<class Gemm, int ExactM>
-class ExactMKernelImpl final: public KernelImpl<Gemm> {
-public:
-    bool is_feasible(const GemmDesc& desc) const noexcept override
-    {
-        return desc.m == ExactM && KernelImpl<Gemm>::is_feasible(desc);
-    }
+// Keep shape-specific small-N tactics out of prefill and unrelated CUDA graph
+// shapes.
+template <class Gemm, int ExactM>
+class ExactMKernelImpl final : public KernelImpl<Gemm> {
+ public:
+  bool is_feasible(const GemmDesc& desc) const noexcept override {
+    return desc.m == ExactM && KernelImpl<Gemm>::is_feasible(desc);
+  }
 };
 
-template<class Gemm, int ExactM, int ExactN, int ExactK>
-class ExactMnkKernelImpl final: public KernelImpl<Gemm> {
-public:
-    bool is_feasible(const GemmDesc& desc) const noexcept override
-    {
-        return desc.m == ExactM && desc.n == ExactN && desc.k == ExactK
-               && KernelImpl<Gemm>::is_feasible(desc);
-    }
+template <class Gemm, int ExactM, int ExactN, int ExactK>
+class ExactMnkKernelImpl final : public KernelImpl<Gemm> {
+ public:
+  bool is_feasible(const GemmDesc& desc) const noexcept override {
+    return desc.m == ExactM && desc.n == ExactN && desc.k == ExactK &&
+           KernelImpl<Gemm>::is_feasible(desc);
+  }
 };
 
 }  // namespace
 
-void Registry::sm70_884_4()
-{
-    if constexpr (1) {
-        // clang-format off
+void Registry::sm70_884_4() {
+  if constexpr (1) {
+    // clang-format off
         using C = Config_U4_d<kColMajor>;
         Add<C::Type<128, 256, 16, 2, 4, 1, D, D, 2, true, 1, 128, 128, 128>>();
         Add<C::Type<128, 128, 16, 2, 2, 1, D, D, 2, true, 1, 128, 64, 128>>();
@@ -65,11 +63,11 @@ void Registry::sm70_884_4()
         Add(std::make_unique<ExactMnkKernelImpl<typename C64::Kernel, 1, 8704, 5120>>());
         Add(std::make_unique<ExactMnkKernelImpl<typename C64::Kernel, 1, 4096, 5120>>());
 
-        // clang-format on
-    }
+    // clang-format on
+  }
 
-    if constexpr (1) {
-        // clang-format off
+  if constexpr (1) {
+    // clang-format off
         // GroupSizeV=128
         using C = Config_U4_g<kColMajor>;
         Add<C::Type<128, 256,  16, 2, 4, 1, D, D, 2,   0 , 1, 128, 128, 128>>();
@@ -98,30 +96,30 @@ void Registry::sm70_884_4()
         Add<C::Type< 16, 128,  32, 1, 4, 1, D, S, 2, true, 1, 32>>();
         Add<C::Type<  8, 128,  64, 1, 4, 1, D, S, 2, true, 1, 32>>();
         Add<C::Type<  8, 256,  64, 1, 4, 1, D, S, 2, true, 1, 32>>();
-        // clang-format on
-    }
+    // clang-format on
+  }
 
-    if constexpr (1) {
-        // clang-format off
+  if constexpr (1) {
+    // clang-format off
         using C = Config_MXF4<kColMajor, 0>;
         Add<C::Type<128, 128,  16, 2, 2, 1, D, D, 2, true, 1, 32,  64, 128>>();
         Add<C::Type< 64, 128,  32, 1, 4, 1, D, S, 2, true, 1, 32,  32, 128>>();
         Add<C::Type< 32, 128,  32, 1, 4, 1, D, S, 2, true, 1, 32>>();
         Add<C::Type< 16, 128,  32, 1, 4, 1, D, S, 2, true, 1, 32>>();
         Add<C::Type<  8, 128,  64, 1, 4, 1, D, S, 2, true, 1, 32>>();
-        // clang-format on
-    }
+    // clang-format on
+  }
 
-    if constexpr (1) {
-        // clang-format off
+  if constexpr (1) {
+    // clang-format off
         using C = Config_NVF4<kColMajor, 0>;
         Add<C::Type<128, 128,  16, 2, 2, 1, D, D, 2, true, 1, 16,  64, 128>>();
         Add<C::Type< 64, 128,  32, 1, 4, 1, D, S, 2, true, 1, 16,  32, 128>>();
         Add<C::Type< 32, 128,  32, 1, 4, 1, D, S, 2, true, 1, 16>>();
         Add<C::Type< 16, 128,  32, 1, 4, 1, D, S, 2, true, 1, 16>>();
         Add<C::Type<  8, 128,  64, 1, 4, 1, D, S, 2, true, 1, 16>>();
-        // clang-format on
-    }
+    // clang-format on
+  }
 }
 
 }  // namespace turbomind::gemm

--- a/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/kernel/sm70_884_8.cu
+++ b/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/kernel/sm70_884_8.cu
@@ -11,10 +11,9 @@ using namespace cache_policy;
 using S = cache_policy::Stream;
 using D = cache_policy::Default;
 
-void Registry::sm70_884_8()
-{
-    if constexpr (1) {
-        // clang-format off
+void Registry::sm70_884_8() {
+  if constexpr (1) {
+    // clang-format off
         using C = Config_E4M3<kColMajor, 0>;
         Add<C::Type<128, 256,  16, 2, 4, 1, D, D, 2, true, 1, 128, 128, 128>>();
         Add<C::Type<128, 128,  16, 2, 2, 1, D, D, 2, true, 1, 128,  64, 128>>();
@@ -29,8 +28,8 @@ void Registry::sm70_884_8()
         Add<C::Type<  8, 128,  32, 1, 4, 1, D, S, 2, true, 1, 128>>();
         Add<C::Type<  8, 256,  64, 1, 4, 1, D, S, 2, true, 1, 128>>();
         Add<C::Type<  8, 256,  32, 1, 4, 1, D, S, 2, true, 1, 128>>();
-        // clang-format on
-    }
+    // clang-format on
+  }
 }
 
 }  // namespace turbomind::gemm

--- a/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/kernel_impl.h
+++ b/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/kernel_impl.h
@@ -21,274 +21,268 @@
 
 namespace turbomind::gemm {
 
-template<class Gemm>
-class KernelImpl: public Kernel {
-public:
-    // import frequently used constants
-    static constexpr int CTA_M = Gemm::CTA_M;
-    static constexpr int CTA_N = Gemm::CTA_N;
-    static constexpr int CTA_K = Gemm::CTA_K;
+template <class Gemm>
+class KernelImpl : public Kernel {
+ public:
+  // import frequently used constants
+  static constexpr int CTA_M = Gemm::CTA_M;
+  static constexpr int CTA_N = Gemm::CTA_N;
+  static constexpr int CTA_K = Gemm::CTA_K;
 
-    using Impl  = typename Gemm::Impl;
-    using Sched = typename Gemm::Scheduler;
+  using Impl = typename Gemm::Impl;
+  using Sched = typename Gemm::Scheduler;
 
-    using OpA = typename Gemm::OperandA;
-    using OpB = typename Gemm::OperandB;
-    using OpU = typename Gemm::OperandU;
-    using OpV = typename Gemm::OperandV;
+  using OpA = typename Gemm::OperandA;
+  using OpB = typename Gemm::OperandB;
+  using OpU = typename Gemm::OperandU;
+  using OpV = typename Gemm::OperandV;
 
-    KernelImpl()
-    {
-        desc_.order_a = OpA::kOrder;
-        desc_.order_b = transpose(OpB::kOrder);
-        desc_.order_c = Gemm::kOrderC;
+  KernelImpl() {
+    desc_.order_a = OpA::kOrder;
+    desc_.order_b = transpose(OpB::kOrder);
+    desc_.order_c = Gemm::kOrderC;
 
-        desc_.type_a = data_type_v<typename Gemm::Ta>;
-        desc_.type_b = data_type_v<typename Gemm::Tb>;
-        desc_.type_c = data_type_v<typename Gemm::Tc>;
+    desc_.type_a = data_type_v<typename Gemm::Ta>;
+    desc_.type_b = data_type_v<typename Gemm::Tb>;
+    desc_.type_c = data_type_v<typename Gemm::Tc>;
 
-        using IterA = typename OpA::GmemIter;
-        using IterB = typename OpB::GmemIter;
+    using IterA = typename OpA::GmemIter;
+    using IterB = typename OpB::GmemIter;
 
-        desc_.striding_a = IterA::kMode;
-        desc_.striding_b = IterB::kMode;
-        desc_.striding_c = Gemm::Epilogue::kMode;
+    desc_.striding_a = IterA::kMode;
+    desc_.striding_b = IterB::kMode;
+    desc_.striding_c = Gemm::Epilogue::kMode;
 
-        desc_.pack_a = OpA::kPack;
-        desc_.pack_b = OpB::kPack;
-        desc_.pack_u = OpU::kPack;
-        desc_.pack_v = OpV::kPack;
+    desc_.pack_a = OpA::kPack;
+    desc_.pack_b = OpB::kPack;
+    desc_.pack_u = OpU::kPack;
+    desc_.pack_v = OpV::kPack;
 
-        desc_.quant_a = QuantDesc{};
-        desc_.quant_b = QuantDesc{};
+    desc_.quant_a = QuantDesc{};
+    desc_.quant_b = QuantDesc{};
 
-        if constexpr (OpU::SmemLayout::kSize > 1) {
-            desc_.quant_a = QuantDesc{QuantType::kDefault, OpU::kGroupSize};
-        }
-
-        if constexpr (OpV::SmemLayout::kSize > 1) {
-            desc_.quant_b = QuantDesc{QuantType::kDefault, OpV::kGroupSize};
-        }
-
-        desc_.cta_tile = {Gemm::CTA_M, Gemm::CTA_N, Gemm::CTA_K};
-        desc_.mma_tile = {Impl::MMA_Map::kGroupM, Impl::MMA_Map::kGroupN, Impl::MMA_Map::kGroupK};
-
-        info_.chunk_size_k = Gemm::kChunkSizeK;
-
-        desc_.align.x = OpA::kOrder == kColMajor ? IterA::ThreadMap::kAccessC : 1;
-        desc_.align.y = OpB::kOrder == kColMajor ? IterB::ThreadMap::kAccessC : 1;
-        desc_.align.z = Gemm::CTA_K;
-
-        desc_.policy_a = (int)IterA::Policy::kEvictPolicy;
-        desc_.policy_b = (int)IterB::Policy::kEvictPolicy;
-        desc_.c_tile   = {Gemm::Epilogue::TM, Gemm::Epilogue::TN};
-        desc_.op_class = Impl::kOpClass;
-
-        desc_.cluster_shape = {1, 1};
-
-        auto func = gemm_kernel<Gemm, GemmParam, EpilogueParam, Sched>;
-
-        cudaFuncGetAttributes(&info_.attr, func);
-
-        info_.dynamic_smem_size = sizeof(typename Gemm::SharedStorage);
-
-        if (info_.dynamic_smem_size > (48 << 10)) {
-            cudaFuncSetAttribute(func, cudaFuncAttributeMaxDynamicSharedMemorySize, info_.dynamic_smem_size);
-        }
-
-        cudaOccupancyMaxActiveBlocksPerMultiprocessor(
-            &info_.max_active_ctas, func, Impl::WARPS * WARP_SIZE, info_.dynamic_smem_size);
-
-        desc_.stages     = Impl::Stages;
-        desc_.split_k    = Gemm::kSplitK;
-        desc_.group_axis = Sched::group_axis;
-
-        desc_.arch = Gemm::Arch::value;
-
-        info_.name = GetName();
+    if constexpr (OpU::SmemLayout::kSize > 1) {
+      desc_.quant_a = QuantDesc{QuantType::kDefault, OpU::kGroupSize};
     }
 
-    int Launch(const Operation&    operation,
-               float               alpha,
-               const void*         A,
-               const MatrixLayout& _Adesc,
-               const void*         U,
-               const MatrixLayout& Udesc,
-               const void*         B,
-               const MatrixLayout& _Bdesc,
-               const void*         V,
-               const MatrixLayout& _Vdesc,
-               float               beta,
-               const void*         C,
-               const MatrixLayout& Cdesc,
-               void*               D,
-               const MatrixLayout& Ddesc,
-               int                 swizzle,
-               int                 splits,
-               Workspace&          workspace,
-               cudaStream_t        stream) override
-    {
-        MatrixLayout Adesc = _Adesc;
+    if constexpr (OpV::SmemLayout::kSize > 1) {
+      desc_.quant_b = QuantDesc{QuantType::kDefault, OpV::kGroupSize};
+    }
 
-        const int m = Ddesc.rows;
-        const int n = Ddesc.cols;
-        const int k = Adesc.cols;
-        const int l = std::max(1, Ddesc.num);
+    desc_.cta_tile = {Gemm::CTA_M, Gemm::CTA_N, Gemm::CTA_K};
+    desc_.mma_tile = {Impl::MMA_Map::kGroupM, Impl::MMA_Map::kGroupN,
+                      Impl::MMA_Map::kGroupK};
 
-        auto transpose = [](MatrixLayout x) {
-            std::swap(x.rows, x.cols);
-            x.order = gemm::transpose(x.order);
-            return x;
-        };
+    info_.chunk_size_k = Gemm::kChunkSizeK;
 
-        MatrixLayout Bdesc = transpose(_Bdesc);
-        MatrixLayout Vdesc = transpose(_Vdesc);
+    desc_.align.x = OpA::kOrder == kColMajor ? IterA::ThreadMap::kAccessC : 1;
+    desc_.align.y = OpB::kOrder == kColMajor ? IterB::ThreadMap::kAccessC : 1;
+    desc_.align.z = Gemm::CTA_K;
 
-        auto max_splits = GetMaxSplits({m, n, k, l}, swizzle, workspace.barriers_size, workspace.partials_size);
+    desc_.policy_a = (int)IterA::Policy::kEvictPolicy;
+    desc_.policy_b = (int)IterB::Policy::kEvictPolicy;
+    desc_.c_tile = {Gemm::Epilogue::TM, Gemm::Epilogue::TN};
+    desc_.op_class = Impl::kOpClass;
 
-        Sched sched{{m, n, k, l}, swizzle, std::min(splits, max_splits)};
-        sched.offsets_ = Ddesc.offsets;
-        sched.set_active_groups(Ddesc.group_idxs, operation.active_group_count);
+    desc_.cluster_shape = {1, 1};
 
-        using Ta = typename Gemm::Ta;
-        using Tb = typename Gemm::Tb;
-        using Tc = typename Gemm::Tc;
+    auto func = gemm_kernel<Gemm, GemmParam, EpilogueParam, Sched>;
 
-        if constexpr (0) {
-            [[maybe_unused]] static const int _ = [] {
-                std::cout << "A:\n";
-                Print(typename Gemm::OperandA::GmemIter::ThreadMap{});
-                std::cout << "\nB:\n";
-                Print(typename Gemm::OperandB::GmemIter::ThreadMap{});
-                if constexpr (!std::is_same_v<Ta, Tc>) {
-                    std::cout << "\nU:\n";
-                    Print(typename Gemm::OperandU::GmemIter::ThreadMap{});
-                }
-                if constexpr (!std::is_same_v<Tb, Tc>) {
-                    std::cout << "\nV:\n";
-                    Print(typename Gemm::OperandV::GmemIter::ThreadMap{});
-                }
-                printf("warp count: %d\n", Impl::WARPS);
-                Print_(typename Gemm::Impl::MMA_Map{});
+    cudaFuncGetAttributes(&info_.attr, func);
 
-                printf("C:\n");
-                Print(typename Gemm::Epilogue::Map{});
+    info_.dynamic_smem_size = sizeof(typename Gemm::SharedStorage);
 
-                std::cout << "Smem for mainloop: " << sizeof(Gemm::SharedStorage::mainloop) << "\n";
-                std::cout << "Smem for epilogue: " << sizeof(Gemm::SharedStorage::epilogue) << "\n";
+    if (info_.dynamic_smem_size > (48 << 10)) {
+      cudaFuncSetAttribute(func, cudaFuncAttributeMaxDynamicSharedMemorySize,
+                           info_.dynamic_smem_size);
+    }
 
-                return 0;
-            }();
+    cudaOccupancyMaxActiveBlocksPerMultiprocessor(&info_.max_active_ctas, func,
+                                                  Impl::WARPS * WARP_SIZE,
+                                                  info_.dynamic_smem_size);
+
+    desc_.stages = Impl::Stages;
+    desc_.split_k = Gemm::kSplitK;
+    desc_.group_axis = Sched::group_axis;
+
+    desc_.arch = Gemm::Arch::value;
+
+    info_.name = GetName();
+  }
+
+  int Launch(const Operation& operation, float alpha, const void* A,
+             const MatrixLayout& _Adesc, const void* U,
+             const MatrixLayout& Udesc, const void* B,
+             const MatrixLayout& _Bdesc, const void* V,
+             const MatrixLayout& _Vdesc, float beta, const void* C,
+             const MatrixLayout& Cdesc, void* D, const MatrixLayout& Ddesc,
+             int swizzle, int splits, Workspace& workspace,
+             cudaStream_t stream) override {
+    MatrixLayout Adesc = _Adesc;
+
+    const int m = Ddesc.rows;
+    const int n = Ddesc.cols;
+    const int k = Adesc.cols;
+    const int l = std::max(1, Ddesc.num);
+
+    auto transpose = [](MatrixLayout x) {
+      std::swap(x.rows, x.cols);
+      x.order = gemm::transpose(x.order);
+      return x;
+    };
+
+    MatrixLayout Bdesc = transpose(_Bdesc);
+    MatrixLayout Vdesc = transpose(_Vdesc);
+
+    auto max_splits =
+        GetMaxSplits({m, n, k, l}, swizzle, workspace.barriers_size,
+                     workspace.partials_size);
+
+    Sched sched{{m, n, k, l}, swizzle, std::min(splits, max_splits)};
+    sched.offsets_ = Ddesc.offsets;
+    sched.set_active_groups(Ddesc.group_idxs, operation.active_group_count);
+
+    using Ta = typename Gemm::Ta;
+    using Tb = typename Gemm::Tb;
+    using Tc = typename Gemm::Tc;
+
+    if constexpr (0) {
+      [[maybe_unused]] static const int _ = [] {
+        std::cout << "A:\n";
+        Print(typename Gemm::OperandA::GmemIter::ThreadMap{});
+        std::cout << "\nB:\n";
+        Print(typename Gemm::OperandB::GmemIter::ThreadMap{});
+        if constexpr (!std::is_same_v<Ta, Tc>) {
+          std::cout << "\nU:\n";
+          Print(typename Gemm::OperandU::GmemIter::ThreadMap{});
         }
-
-        const bool silu_act = ((int)operation.epilogue & (int)Epilogue::kGatedSilu);
-        const bool moe_weighted_reduce =
-            ((int)operation.epilogue & (int)Epilogue::kMoeWeightedReduce);
-        const bool tile_allreduce =
-            ((int)operation.epilogue & (int)Epilogue::kTileAllReduce);
-        const auto* moe_reduce =
-            static_cast<const MoeWeightedReduceParam*>(operation.reserved);
-        const auto* tile_reduce =
-            static_cast<const TileAllReduceParam*>(operation.tile_allreduce);
-
-        MatrixLayout Pdesc = Ddesc;
-        Pdesc.ld           = mk2cs<Gemm::kOrderC>(Pdesc.rows, Pdesc.cols).x;
-
-        MatrixCombination_v3 combin_mat{to_param((void*)C, Cdesc), alpha, beta};
-
-        EpilogueParam epilogue{to_param((void*)D, Ddesc),
-                               to_param((void*)workspace.partials, Pdesc),
-                               (int*)workspace.barriers,
-                               combin_mat,
-                               silu_act,
-                               moe_weighted_reduce,
-                               moe_reduce ? moe_reduce->out : nullptr,
-                               moe_reduce ? moe_reduce->sorted_weights : nullptr,
-                               moe_reduce ? moe_reduce->offsets : nullptr,
-                               tile_allreduce,
-                               tile_reduce ? *tile_reduce : TileAllReduceParam{}};
-
-        // std::cout << Adesc.offsets << " " << Adesc.idxs << "\n";
-
-        GemmParam param{
-            to_param((void*)A, Adesc),
-            to_param((void*)B, Bdesc),
-            to_param((void*)U, Udesc),
-            to_param((void*)V, Vdesc),
-        };
-
-        auto       grid  = sched.get_grid_shape();
-        const auto block = Gemm::Impl::WARPS * WARP_SIZE;
-
-        if (epilogue.tile_allreduce && epilogue.tile_allreduce_param.kernel_reducer_blocks > 0) {
-            auto& tile_ar = epilogue.tile_allreduce_param;
-            tile_ar.producer_grid_x = static_cast<int>(grid.x);
-            tile_ar.producer_grid_y = static_cast<int>(grid.y);
-            tile_ar.producer_grid_z = static_cast<int>(grid.z);
-            if (tile_ar.world_size == 2 && tile_ar.rank_data != nullptr && tile_ar.output != nullptr &&
-                tile_ar.output_numel > 0 && tile_ar.tile_numel > 0 && grid.z < 65535) {
-                grid.z += 1;
-            }
-            else {
-                tile_ar.kernel_reducer_blocks = 0;
-            }
+        if constexpr (!std::is_same_v<Tb, Tc>) {
+          std::cout << "\nV:\n";
+          Print(typename Gemm::OperandV::GmemIter::ThreadMap{});
         }
+        printf("warp count: %d\n", Impl::WARPS);
+        Print_(typename Gemm::Impl::MMA_Map{});
 
-        // std::cout << info_.name << " " << splits << " " << swizzle << " " << sched.tiles_[0] << " " <<
-        // sched.tiles_[1]
-        //           << std::endl;
-        // std::cout << grid.x << " " << grid.y << " " << grid.z << "\n";
+        printf("C:\n");
+        Print(typename Gemm::Epilogue::Map{});
 
-        gemm_kernel<Gemm><<<grid, block, info_.dynamic_smem_size, stream>>>(param, epilogue, sched);
+        std::cout << "Smem for mainloop: "
+                  << sizeof(Gemm::SharedStorage::mainloop) << "\n";
+        std::cout << "Smem for epilogue: "
+                  << sizeof(Gemm::SharedStorage::epilogue) << "\n";
 
         return 0;
+      }();
     }
 
-    std::array<size_t, 2> GetWorkspaceSize(int tiles, int splits) const
-    {
-        static constexpr bool kSerial = true;
+    const bool silu_act = ((int)operation.epilogue & (int)Epilogue::kGatedSilu);
+    const bool moe_weighted_reduce =
+        ((int)operation.epilogue & (int)Epilogue::kMoeWeightedReduce);
+    const bool tile_allreduce =
+        ((int)operation.epilogue & (int)Epilogue::kTileAllReduce);
+    const auto* moe_reduce =
+        static_cast<const MoeWeightedReduceParam*>(operation.reserved);
+    const auto* tile_reduce =
+        static_cast<const TileAllReduceParam*>(operation.tile_allreduce);
 
-        size_t barriers_size = sizeof(int) * tiles;
-        size_t partials_size = sizeof(float) * CTA_M * CTA_N * tiles;
+    MatrixLayout Pdesc = Ddesc;
+    Pdesc.ld = mk2cs<Gemm::kOrderC>(Pdesc.rows, Pdesc.cols).x;
 
-        if constexpr (!kSerial) {
-            barriers_size *= splits;
-            partials_size *= splits;
-        }
+    MatrixCombination_v3 combin_mat{to_param((void*)C, Cdesc), alpha, beta};
 
-        return {barriers_size, partials_size};
+    EpilogueParam epilogue{to_param((void*)D, Ddesc),
+                           to_param((void*)workspace.partials, Pdesc),
+                           (int*)workspace.barriers,
+                           combin_mat,
+                           silu_act,
+                           moe_weighted_reduce,
+                           moe_reduce ? moe_reduce->out : nullptr,
+                           moe_reduce ? moe_reduce->sorted_weights : nullptr,
+                           moe_reduce ? moe_reduce->offsets : nullptr,
+                           tile_allreduce,
+                           tile_reduce ? *tile_reduce : TileAllReduceParam{}};
+
+    // std::cout << Adesc.offsets << " " << Adesc.idxs << "\n";
+
+    GemmParam param{
+        to_param((void*)A, Adesc),
+        to_param((void*)B, Bdesc),
+        to_param((void*)U, Udesc),
+        to_param((void*)V, Vdesc),
+    };
+
+    auto grid = sched.get_grid_shape();
+    const auto block = Gemm::Impl::WARPS * WARP_SIZE;
+
+    if (epilogue.tile_allreduce &&
+        epilogue.tile_allreduce_param.kernel_reducer_blocks > 0) {
+      auto& tile_ar = epilogue.tile_allreduce_param;
+      tile_ar.producer_grid_x = static_cast<int>(grid.x);
+      tile_ar.producer_grid_y = static_cast<int>(grid.y);
+      tile_ar.producer_grid_z = static_cast<int>(grid.z);
+      if (tile_ar.world_size == 2 && tile_ar.rank_data != nullptr &&
+          tile_ar.output != nullptr && tile_ar.output_numel > 0 &&
+          tile_ar.tile_numel > 0 && grid.z < 65535) {
+        grid.z += 1;
+      } else {
+        tile_ar.kernel_reducer_blocks = 0;
+      }
     }
 
-    int GetMaxSplits(const int4& shape, int swizzle, size_t bsize, size_t psize) const override
-    {
-        if (!Gemm::kSplitK) {
-            return 1;
-        }
+    // std::cout << info_.name << " " << splits << " " << swizzle << " " <<
+    // sched.tiles_[0] << " " << sched.tiles_[1]
+    //           << std::endl;
+    // std::cout << grid.x << " " << grid.y << " " << grid.z << "\n";
 
-        const auto& [m, n, k, l] = shape;
+    gemm_kernel<Gemm><<<grid, block, info_.dynamic_smem_size, stream>>>(
+        param, epilogue, sched);
 
-        Sched sched{{m, n, k, l}, swizzle};  // for getting padded tiles
+    return 0;
+  }
 
-        const auto& [a, b] = GetWorkspaceSize(sched.tiles_[0] * sched.tiles_[1], 1);
+  std::array<size_t, 2> GetWorkspaceSize(int tiles, int splits) const {
+    static constexpr bool kSerial = true;
 
-        if (bsize >= a && psize >= b) {
-            // Serial split-k requires workspace for 1 split only
-            // But it can't exceed num of k chunks
-            return cdiv(k, Gemm::kChunkSizeK);
-        }
-        else {
-            return 1;
-        }
+    size_t barriers_size = sizeof(int) * tiles;
+    size_t partials_size = sizeof(float) * CTA_M * CTA_N * tiles;
+
+    if constexpr (!kSerial) {
+      barriers_size *= splits;
+      partials_size *= splits;
     }
 
-    int GetMaxSwizzle(const int4& shape) const override
-    {
-        const auto& [m, n, k, l] = shape;
+    return {barriers_size, partials_size};
+  }
 
-        auto swizzle = Sched{{m, n, k, l}}.get_max_swizzle();
-        // std::cout << m << " " << n << " " << k << " " << l << " " << swizzle << "\n";
-        return swizzle;
+  int GetMaxSplits(const int4& shape, int swizzle, size_t bsize,
+                   size_t psize) const override {
+    if (!Gemm::kSplitK) {
+      return 1;
     }
+
+    const auto& [m, n, k, l] = shape;
+
+    Sched sched{{m, n, k, l}, swizzle};  // for getting padded tiles
+
+    const auto& [a, b] = GetWorkspaceSize(sched.tiles_[0] * sched.tiles_[1], 1);
+
+    if (bsize >= a && psize >= b) {
+      // Serial split-k requires workspace for 1 split only
+      // But it can't exceed num of k chunks
+      return cdiv(k, Gemm::kChunkSizeK);
+    } else {
+      return 1;
+    }
+  }
+
+  int GetMaxSwizzle(const int4& shape) const override {
+    const auto& [m, n, k, l] = shape;
+
+    auto swizzle = Sched{{m, n, k, l}}.get_max_swizzle();
+    // std::cout << m << " " << n << " " << k << " " << l << " " << swizzle <<
+    // "\n";
+    return swizzle;
+  }
 };
 
 }  // namespace turbomind::gemm

--- a/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/kernel_impl_sm90.h
+++ b/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/kernel_impl_sm90.h
@@ -25,324 +25,299 @@
 #define TM_GEMM_CUTLASS_NAME 0
 
 #if TM_GEMM_CUTLASS_NAME
-#define gemm_kernel_name cutlass_gemm_kernel_sm90
+  #define gemm_kernel_name cutlass_gemm_kernel_sm90
 #else
-#define gemm_kernel_name gemm_kernel_sm90
+  #define gemm_kernel_name gemm_kernel_sm90
 #endif
 
 namespace turbomind::gemm {
 
 extern __shared__ char smem_buf[];
 
-template<class Kernel>
-__global__ void __launch_bounds__(Kernel::CTA_SIZE, 1) gemm_kernel_name(const __grid_constant__ CUtensorMap tm_a,
-                                                                        const __grid_constant__ CUtensorMap tm_b,
-                                                                        const __grid_constant__ CUtensorMap tm_c,
-                                                                        const __grid_constant__ CUtensorMap tm_u,
-                                                                        const __grid_constant__ CUtensorMap tm_v,
-                                                                        const MatrixParam                   param_A,
-                                                                        const MatrixParam                   param_B,
-                                                                        const MatrixParam                   param_U,
-                                                                        const MatrixParam                   param_V,
-                                                                        const MatrixParam                   param_C,
-                                                                        typename Kernel::Scheduler          sched,
-                                                                        void* tensormap_buf)
-{
-
+template <class Kernel>
+__global__ void __launch_bounds__(Kernel::CTA_SIZE, 1)
+    gemm_kernel_name(const __grid_constant__ CUtensorMap tm_a,
+                     const __grid_constant__ CUtensorMap tm_b,
+                     const __grid_constant__ CUtensorMap tm_c,
+                     const __grid_constant__ CUtensorMap tm_u,
+                     const __grid_constant__ CUtensorMap tm_v,
+                     const MatrixParam param_A, const MatrixParam param_B,
+                     const MatrixParam param_U, const MatrixParam param_V,
+                     const MatrixParam param_C,
+                     typename Kernel::Scheduler sched, void* tensormap_buf) {
 #if __CUDA_ARCH__
-    if constexpr (Kernel::Arch::is_compatible(__CUDA_ARCH__)) {
-        Kernel kernel;
-        kernel(tm_a,
-               tm_b,
-               tm_c,
-               tm_u,
-               tm_v,
-               param_A,
-               param_B,
-               param_U,
-               param_V,
-               param_C,
-               sched,
-               (CUtensorMap*)tensormap_buf,
-               smem_buf);
-    }
+  if constexpr (Kernel::Arch::is_compatible(__CUDA_ARCH__)) {
+    Kernel kernel;
+    kernel(tm_a, tm_b, tm_c, tm_u, tm_v, param_A, param_B, param_U, param_V,
+           param_C, sched, (CUtensorMap*)tensormap_buf, smem_buf);
+  }
 #endif
 }
 
-template<class Gemm>
-class KernelImplSm90: public Kernel {
-public:
-    // import frequently used constants
-    static constexpr int TILE_M = Gemm::TILE_M;
-    static constexpr int TILE_N = Gemm::TILE_N;
-    static constexpr int TILE_K = Gemm::TILE_K;
+template <class Gemm>
+class KernelImplSm90 : public Kernel {
+ public:
+  // import frequently used constants
+  static constexpr int TILE_M = Gemm::TILE_M;
+  static constexpr int TILE_N = Gemm::TILE_N;
+  static constexpr int TILE_K = Gemm::TILE_K;
 
-    static constexpr auto is_grouped_gemm = Gemm::is_grouped_gemm;
+  static constexpr auto is_grouped_gemm = Gemm::is_grouped_gemm;
 
-    KernelImplSm90()
-    {
-        desc_.order_a = kRowMajor;  // m, k
-        desc_.order_b = kColMajor;  // k, n
-        desc_.order_c = kRowMajor;
+  KernelImplSm90() {
+    desc_.order_a = kRowMajor;  // m, k
+    desc_.order_b = kColMajor;  // k, n
+    desc_.order_c = kRowMajor;
 
-        desc_.type_a = data_type_v<typename Gemm::Ta>;
-        desc_.type_b = data_type_v<typename Gemm::Tb>;
-        desc_.type_c = data_type_v<typename Gemm::Tc>;
+    desc_.type_a = data_type_v<typename Gemm::Ta>;
+    desc_.type_b = data_type_v<typename Gemm::Tb>;
+    desc_.type_c = data_type_v<typename Gemm::Tc>;
 
-        desc_.striding_a = {is_grouped_gemm ? Striding::kBlocked : Striding::kFlat};  // IterA::kMode;
-        desc_.striding_b = {is_grouped_gemm ? Striding::kBlocked : Striding::kFlat};  // IterB::kMode;
-        desc_.striding_c = {is_grouped_gemm ? Striding::kBlocked : Striding::kFlat};  // Gemm::Epilogue::kMode;
+    desc_.striding_a = {is_grouped_gemm ? Striding::kBlocked
+                                        : Striding::kFlat};  // IterA::kMode;
+    desc_.striding_b = {is_grouped_gemm ? Striding::kBlocked
+                                        : Striding::kFlat};  // IterB::kMode;
+    desc_.striding_c = {is_grouped_gemm
+                            ? Striding::kBlocked
+                            : Striding::kFlat};  // Gemm::Epilogue::kMode;
 
-        desc_.pack_a = {};  // OpA::kPack;
-        desc_.pack_b = {};  // OpB::kPack;
-        desc_.pack_u = {};  // OpU::kPack;
-        desc_.pack_v = {};  // OpV::kPack;
+    desc_.pack_a = {};  // OpA::kPack;
+    desc_.pack_b = {};  // OpB::kPack;
+    desc_.pack_u = {};  // OpU::kPack;
+    desc_.pack_v = {};  // OpV::kPack;
 
-        desc_.quant_a = QuantDesc{QuantType::kK, 128};
-        desc_.quant_b = QuantDesc{QuantType::kB, 128};
+    desc_.quant_a = QuantDesc{QuantType::kK, 128};
+    desc_.quant_b = QuantDesc{QuantType::kB, 128};
 
-        desc_.cta_tile = {TILE_M, TILE_N, TILE_K};
-        desc_.mma_tile = {1, 1, 1};
+    desc_.cta_tile = {TILE_M, TILE_N, TILE_K};
+    desc_.mma_tile = {1, 1, 1};
 
-        info_.chunk_size_k = Gemm::TILE_K;
+    info_.chunk_size_k = Gemm::TILE_K;
 
-        desc_.align.x = 1;  // OpA::kOrder == kColMajor ? IterA::ThreadMap::kAccessC : 1;
-        desc_.align.y = 1;  // OpB::kOrder == kColMajor ? IterB::ThreadMap::kAccessC : 1;
-        desc_.align.z = 1;  // Gemm::TILE_K;
+    desc_.align.x =
+        1;  // OpA::kOrder == kColMajor ? IterA::ThreadMap::kAccessC : 1;
+    desc_.align.y =
+        1;  // OpB::kOrder == kColMajor ? IterB::ThreadMap::kAccessC : 1;
+    desc_.align.z = 1;  // Gemm::TILE_K;
 
-        desc_.policy_a = 0;                 // (int)IterA::Policy::kEvictPolicy;
-        desc_.policy_b = 0;                 // (int)IterB::Policy::kEvictPolicy;
-        desc_.c_tile   = {TILE_M, TILE_N};  // {Gemm::Epilogue::TM, Gemm::Epilogue::TN};
-        desc_.op_class = OpClass::kGMMA_s64n16;
+    desc_.policy_a = 0;  // (int)IterA::Policy::kEvictPolicy;
+    desc_.policy_b = 0;  // (int)IterB::Policy::kEvictPolicy;
+    desc_.c_tile = {TILE_M,
+                    TILE_N};  // {Gemm::Epilogue::TM, Gemm::Epilogue::TN};
+    desc_.op_class = OpClass::kGMMA_s64n16;
 
-        desc_.cluster_shape = {Gemm::Cluster::M, Gemm::Cluster::N};
+    desc_.cluster_shape = {Gemm::Cluster::M, Gemm::Cluster::N};
 
-        info_.dynamic_smem_size = Gemm::kSmemSize;
+    info_.dynamic_smem_size = Gemm::kSmemSize;
 
-        desc_.stages     = Gemm::Stages;
-        desc_.split_k    = 1;  // Gemm::kSplitK;
-        desc_.group_axis = is_grouped_gemm ? 0 : -1;
+    desc_.stages = Gemm::Stages;
+    desc_.split_k = 1;  // Gemm::kSplitK;
+    desc_.group_axis = is_grouped_gemm ? 0 : -1;
 
-        desc_.arch = Gemm::Arch::value;
+    desc_.arch = Gemm::Arch::value;
 
-        auto func = gemm_kernel_name<Gemm>;
+    auto func = gemm_kernel_name<Gemm>;
 
-        cudaFuncGetAttributes(&info_.attr, func);
+    cudaFuncGetAttributes(&info_.attr, func);
 
-        if (info_.dynamic_smem_size > (48 << 10)) {
-            cudaFuncSetAttribute(func, cudaFuncAttributeMaxDynamicSharedMemorySize, info_.dynamic_smem_size);
-        }
-
-        if (1) {
-            cudaFuncSetAttribute(func, cudaFuncAttributeNonPortableClusterSizeAllowed, 16);
-        }
-
-        cudaOccupancyMaxActiveBlocksPerMultiprocessor(
-            &info_.max_active_ctas, func, Gemm::CTA_SIZE, info_.dynamic_smem_size);
-
-        sm_count_ = getSMCount();
-
-        info_.name = GetName();
+    if (info_.dynamic_smem_size > (48 << 10)) {
+      cudaFuncSetAttribute(func, cudaFuncAttributeMaxDynamicSharedMemorySize,
+                           info_.dynamic_smem_size);
     }
 
-    int Launch(const Operation&    operation,
-               float               alpha,
-               const void*         A,
-               const MatrixLayout& _Adesc,
-               const void*         U,
-               const MatrixLayout& Udesc,
-               const void*         B,
-               const MatrixLayout& _Bdesc,
-               const void*         V,
-               const MatrixLayout& _Vdesc,
-               float               beta,
-               const void*         C,
-               const MatrixLayout& Cdesc,
-               void*               D,
-               const MatrixLayout& Ddesc,
-               int                 swizzle,
-               int                 splits,
-               Workspace&          workspace,
-               cudaStream_t        stream) override
-    {
-        using Sched = typename Gemm::Scheduler;
-
-        MatrixLayout Adesc = _Adesc;
-
-        [[maybe_unused]] const int m = Ddesc.rows;
-        [[maybe_unused]] const int n = Ddesc.cols;
-        [[maybe_unused]] const int k = Adesc.cols;
-
-        // std::cout << "M: " << m << ", N: " << n << ", K: " << k << "\n";
-
-        auto transpose = [](MatrixLayout x) {
-            std::swap(x.rows, x.cols);
-            x.order = gemm::transpose(x.order);
-            return x;
-        };
-
-        // (K, N) -> (N, K)
-        MatrixLayout Bdesc = transpose(_Bdesc);
-        MatrixLayout Vdesc = transpose(_Vdesc);
-
-        auto sched = [&] {
-            const int2 tiles = get_tiled_shape(m, n, TILE_M, TILE_N);
-            const int4 shape{m, n, k, Adesc.num};
-
-            swizzle = Sched::get_log_tile(tiles, 1 << swizzle);
-
-            Sched sched{};
-            sched.init(shape, swizzle, {TILE_M, TILE_N, TILE_K});
-
-            sched.next_cluster_id_ = TM_CHECK_NOTNULL(workspace.flags);
-
-            sched.offsets_ = Adesc.offsets;
-
-            return sched;
-        }();
-
-        constexpr int kMulticastA = Gemm::kMulticastA;
-        constexpr int kMulticastB = Gemm::kMulticastB;
-        constexpr int kMulticastU = Gemm::kMulticastU;
-
-        constexpr int kTileM = Gemm::TILE_M;
-        constexpr int kTileN = Gemm::TILE_N;
-
-        if (Gemm::Scheduler::is_dynamic) {
-            check_cuda_error(cudaMemsetAsync(workspace.flags, 0, sizeof(int), stream));
-        }
-
-        // std::cout << "A: " << Adesc << "\n";
-        auto tm_a = make_2d_tma_desc((void*)A, Adesc, {kTileM / kMulticastA, TILE_K}, CU_TENSOR_MAP_SWIZZLE_128B);
-
-        // std::cout << "B: " << Bdesc << "\n";
-        auto tm_b = make_2d_tma_desc(Gemm::is_grouped_gemm ? nullptr : (void*)B,
-                                     Bdesc,
-                                     {kTileN / kMulticastB, TILE_K},
-                                     CU_TENSOR_MAP_SWIZZLE_128B);
-
-        // std::cout << "C: " << Cdesc << "\n";
-        using LayoutC = typename Gemm::LayoutC;
-        auto tm_c     = make_2d_tma_desc((void*)C, Cdesc, {LayoutC::S0, LayoutC::C0}, get_tma_swizzle(Gemm::kSwizzleC));
-
-        CUtensorMap tm_u{};
-        if (U) {
-            // std::cout << "U: " << Udesc << "\n";
-            tm_u = make_2d_tma_desc((void*)U, Udesc, {Gemm::kBoxU / kMulticastU, 1}, CU_TENSOR_MAP_SWIZZLE_NONE);
-        }
-
-        CUtensorMap            tm_v{};
-        [[maybe_unused]] uint2 box_v{};
-        if (V) {
-            // std::cout << "V: " << Vdesc << "\n";
-            // box_v = {(uint32_t)round_up(cdiv(k, 128), 4), 2};
-            // std::cout << "V: " << Vdesc << ", box: " << box_v.x << "," << box_v.y << "\n";
-            // tm_v = make_2d_tma_desc((void*)V, Vdesc, {box_v.y, box_v.x}, CU_TENSOR_MAP_SWIZZLE_NONE);
-        }
-
-        const int sm_count = sm_count_;
-
-        static constexpr int cluster_size = Gemm::kClusterSize;
-
-        auto       grid  = sm_count / cluster_size * cluster_size;
-        const auto block = Gemm::CTA_SIZE;
-
-        cudaLaunchConfig_t config{};
-        config.gridDim          = grid;
-        config.blockDim         = block;
-        config.dynamicSmemBytes = info_.dynamic_smem_size;
-        config.stream           = stream;
-
-        auto func = gemm_kernel_name<Gemm>;
-
-        [[maybe_unused]] static bool _ = [&] {
-            int max_cluster_size = 0;
-            cudaOccupancyMaxPotentialClusterSize(&max_cluster_size, func, &config);
-            // std::cout << "max cluster size: " << max_cluster_size << "\n";
-            return false;
-        }();
-
-        cudaLaunchAttribute attrs[1];
-
-        attrs[0].id               = cudaLaunchAttributeClusterDimension;
-        attrs[0].val.clusterDim.x = cluster_size;
-        attrs[0].val.clusterDim.y = 1;
-        attrs[0].val.clusterDim.z = 1;
-
-        config.attrs    = attrs;
-        config.numAttrs = std::size(attrs);
-
-        int max_active_cluster{};
-        cudaOccupancyMaxActiveClusters(&max_active_cluster, func, &config);
-        config.gridDim = std::min<int>(config.gridDim.x, max_active_cluster * cluster_size);
-
-        // std::cout << "max active cluster: " << max_active_cluster << "\n";
-
-        // std::cout << "swizzle: " << swizzle << ", split: " << splits << "\n";
-
-        auto ec = cudaLaunchKernelEx(&config,
-                                     func,
-                                     tm_a,
-                                     tm_b,
-                                     tm_c,
-                                     tm_u,
-                                     tm_v,
-                                     to_param((void*)A, Adesc),
-                                     to_param((void*)B, Bdesc),
-                                     to_param((void*)U, Udesc),
-                                     to_param((void*)V, Vdesc),
-                                     to_param((void*)D, Ddesc),
-                                     sched,
-                                     workspace.tensormaps);
-        TM_CHECK_EQ(ec, cudaSuccess) << cudaGetErrorString(ec);
-
-        return 0;
+    if (1) {
+      cudaFuncSetAttribute(func, cudaFuncAttributeNonPortableClusterSizeAllowed,
+                           16);
     }
 
-    std::array<size_t, 2> GetWorkspaceSize(int tiles, int splits) const
-    {
-        static constexpr bool kSerial = true;
+    cudaOccupancyMaxActiveBlocksPerMultiprocessor(
+        &info_.max_active_ctas, func, Gemm::CTA_SIZE, info_.dynamic_smem_size);
 
-        size_t barriers_size = sizeof(int) * tiles;
-        size_t partials_size = sizeof(float) * TILE_M * TILE_N * tiles;
+    sm_count_ = getSMCount();
 
-        if constexpr (!kSerial) {
-            barriers_size *= splits;
-            partials_size *= splits;
-        }
+    info_.name = GetName();
+  }
 
-        return {barriers_size, partials_size};
+  int Launch(const Operation& operation, float alpha, const void* A,
+             const MatrixLayout& _Adesc, const void* U,
+             const MatrixLayout& Udesc, const void* B,
+             const MatrixLayout& _Bdesc, const void* V,
+             const MatrixLayout& _Vdesc, float beta, const void* C,
+             const MatrixLayout& Cdesc, void* D, const MatrixLayout& Ddesc,
+             int swizzle, int splits, Workspace& workspace,
+             cudaStream_t stream) override {
+    using Sched = typename Gemm::Scheduler;
+
+    MatrixLayout Adesc = _Adesc;
+
+    [[maybe_unused]] const int m = Ddesc.rows;
+    [[maybe_unused]] const int n = Ddesc.cols;
+    [[maybe_unused]] const int k = Adesc.cols;
+
+    // std::cout << "M: " << m << ", N: " << n << ", K: " << k << "\n";
+
+    auto transpose = [](MatrixLayout x) {
+      std::swap(x.rows, x.cols);
+      x.order = gemm::transpose(x.order);
+      return x;
+    };
+
+    // (K, N) -> (N, K)
+    MatrixLayout Bdesc = transpose(_Bdesc);
+    MatrixLayout Vdesc = transpose(_Vdesc);
+
+    auto sched = [&] {
+      const int2 tiles = get_tiled_shape(m, n, TILE_M, TILE_N);
+      const int4 shape{m, n, k, Adesc.num};
+
+      swizzle = Sched::get_log_tile(tiles, 1 << swizzle);
+
+      Sched sched{};
+      sched.init(shape, swizzle, {TILE_M, TILE_N, TILE_K});
+
+      sched.next_cluster_id_ = TM_CHECK_NOTNULL(workspace.flags);
+
+      sched.offsets_ = Adesc.offsets;
+
+      return sched;
+    }();
+
+    constexpr int kMulticastA = Gemm::kMulticastA;
+    constexpr int kMulticastB = Gemm::kMulticastB;
+    constexpr int kMulticastU = Gemm::kMulticastU;
+
+    constexpr int kTileM = Gemm::TILE_M;
+    constexpr int kTileN = Gemm::TILE_N;
+
+    if (Gemm::Scheduler::is_dynamic) {
+      check_cuda_error(
+          cudaMemsetAsync(workspace.flags, 0, sizeof(int), stream));
     }
 
-    int GetMaxSplits(const int4& shape, int swizzle, size_t bsize, size_t psize) const override
-    {
-        return 1;
+    // std::cout << "A: " << Adesc << "\n";
+    auto tm_a =
+        make_2d_tma_desc((void*)A, Adesc, {kTileM / kMulticastA, TILE_K},
+                         CU_TENSOR_MAP_SWIZZLE_128B);
+
+    // std::cout << "B: " << Bdesc << "\n";
+    auto tm_b = make_2d_tma_desc(Gemm::is_grouped_gemm ? nullptr : (void*)B,
+                                 Bdesc, {kTileN / kMulticastB, TILE_K},
+                                 CU_TENSOR_MAP_SWIZZLE_128B);
+
+    // std::cout << "C: " << Cdesc << "\n";
+    using LayoutC = typename Gemm::LayoutC;
+    auto tm_c = make_2d_tma_desc((void*)C, Cdesc, {LayoutC::S0, LayoutC::C0},
+                                 get_tma_swizzle(Gemm::kSwizzleC));
+
+    CUtensorMap tm_u{};
+    if (U) {
+      // std::cout << "U: " << Udesc << "\n";
+      tm_u = make_2d_tma_desc((void*)U, Udesc, {Gemm::kBoxU / kMulticastU, 1},
+                              CU_TENSOR_MAP_SWIZZLE_NONE);
     }
 
-    int GetMaxSwizzle(const int4& shape) const override
-    {
-        using Map = typename Gemm::Scheduler;
-        // TODO: fix tiled shape
-        const auto tiles = get_tiled_shape(shape.x, shape.y, TILE_M, TILE_N);
-        return Map::get_log_tile(tiles, 1 << 10);
+    CUtensorMap tm_v{};
+    [[maybe_unused]] uint2 box_v{};
+    if (V) {
+      // std::cout << "V: " << Vdesc << "\n";
+      // box_v = {(uint32_t)round_up(cdiv(k, 128), 4), 2};
+      // std::cout << "V: " << Vdesc << ", box: " << box_v.x << "," << box_v.y
+      // << "\n"; tm_v = make_2d_tma_desc((void*)V, Vdesc, {box_v.y, box_v.x},
+      // CU_TENSOR_MAP_SWIZZLE_NONE);
     }
 
-    bool is_feasible(const GemmDesc& desc) const noexcept override
-    {
-        if (desc.striding_a != desc_.striding_a) {
-            return false;
-        }
-        if (desc.striding_b != desc_.striding_b) {
-            return false;
-        }
-        if (desc.striding_c != desc_.striding_c) {
-            return false;
-        }
-        return Kernel::is_feasible(desc);
+    const int sm_count = sm_count_;
+
+    static constexpr int cluster_size = Gemm::kClusterSize;
+
+    auto grid = sm_count / cluster_size * cluster_size;
+    const auto block = Gemm::CTA_SIZE;
+
+    cudaLaunchConfig_t config{};
+    config.gridDim = grid;
+    config.blockDim = block;
+    config.dynamicSmemBytes = info_.dynamic_smem_size;
+    config.stream = stream;
+
+    auto func = gemm_kernel_name<Gemm>;
+
+    [[maybe_unused]] static bool _ = [&] {
+      int max_cluster_size = 0;
+      cudaOccupancyMaxPotentialClusterSize(&max_cluster_size, func, &config);
+      // std::cout << "max cluster size: " << max_cluster_size << "\n";
+      return false;
+    }();
+
+    cudaLaunchAttribute attrs[1];
+
+    attrs[0].id = cudaLaunchAttributeClusterDimension;
+    attrs[0].val.clusterDim.x = cluster_size;
+    attrs[0].val.clusterDim.y = 1;
+    attrs[0].val.clusterDim.z = 1;
+
+    config.attrs = attrs;
+    config.numAttrs = std::size(attrs);
+
+    int max_active_cluster{};
+    cudaOccupancyMaxActiveClusters(&max_active_cluster, func, &config);
+    config.gridDim =
+        std::min<int>(config.gridDim.x, max_active_cluster * cluster_size);
+
+    // std::cout << "max active cluster: " << max_active_cluster << "\n";
+
+    // std::cout << "swizzle: " << swizzle << ", split: " << splits << "\n";
+
+    auto ec = cudaLaunchKernelEx(
+        &config, func, tm_a, tm_b, tm_c, tm_u, tm_v, to_param((void*)A, Adesc),
+        to_param((void*)B, Bdesc), to_param((void*)U, Udesc),
+        to_param((void*)V, Vdesc), to_param((void*)D, Ddesc), sched,
+        workspace.tensormaps);
+    TM_CHECK_EQ(ec, cudaSuccess) << cudaGetErrorString(ec);
+
+    return 0;
+  }
+
+  std::array<size_t, 2> GetWorkspaceSize(int tiles, int splits) const {
+    static constexpr bool kSerial = true;
+
+    size_t barriers_size = sizeof(int) * tiles;
+    size_t partials_size = sizeof(float) * TILE_M * TILE_N * tiles;
+
+    if constexpr (!kSerial) {
+      barriers_size *= splits;
+      partials_size *= splits;
     }
 
-private:
-    int sm_count_ = 0;
+    return {barriers_size, partials_size};
+  }
+
+  int GetMaxSplits(const int4& shape, int swizzle, size_t bsize,
+                   size_t psize) const override {
+    return 1;
+  }
+
+  int GetMaxSwizzle(const int4& shape) const override {
+    using Map = typename Gemm::Scheduler;
+    // TODO: fix tiled shape
+    const auto tiles = get_tiled_shape(shape.x, shape.y, TILE_M, TILE_N);
+    return Map::get_log_tile(tiles, 1 << 10);
+  }
+
+  bool is_feasible(const GemmDesc& desc) const noexcept override {
+    if (desc.striding_a != desc_.striding_a) {
+      return false;
+    }
+    if (desc.striding_b != desc_.striding_b) {
+      return false;
+    }
+    if (desc.striding_c != desc_.striding_c) {
+      return false;
+    }
+    return Kernel::is_feasible(desc);
+  }
+
+ private:
+  int sm_count_ = 0;
 };
 
 }  // namespace turbomind::gemm

--- a/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/mainloop_sm70.h
+++ b/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/mainloop_sm70.h
@@ -16,388 +16,370 @@
 
 namespace turbomind::gemm {
 
-template<int Stages>
+template <int Stages>
 struct GroupIter {
+  static_assert((Stages & (Stages - 1)) == 0);
 
-    static_assert((Stages & (Stages - 1)) == 0);
+  int iter_ = 0;
 
-    int iter_ = 0;
+  __device__ void Advance() { iter_ = (iter_ + 1) % Stages; }
 
-    __device__ void Advance()
-    {
-        iter_ = (iter_ + 1) % Stages;
-    }
-
-    __device__ constexpr explicit operator bool()
-    {
-        return iter_ == 0;
-    }
+  __device__ constexpr explicit operator bool() { return iter_ == 0; }
 };
 
-template<>
+template <>
 struct GroupIter<1> {
-    __device__ void               Advance() {}
-    __device__ constexpr explicit operator bool()
-    {
-        return true;
-    }
+  __device__ void Advance() {}
+  __device__ constexpr explicit operator bool() { return true; }
 };
 
-template<class Pointer, int Step, int Stages>
+template <class Pointer, int Step, int Stages>
 struct SmemIter {
-    Pointer pointer;
-    Pointer other_;
+  Pointer pointer;
+  Pointer other_;
 
-    __device__ SmemIter(Pointer base): pointer{base}, other_{base + Step} {}
+  __device__ SmemIter(Pointer base) : pointer{base}, other_{base + Step} {}
 
-    __device__ void Advance()
-    {
-        auto tmp = pointer;
-        pointer  = other_;
-        other_   = tmp;
-    }
+  __device__ void Advance() {
+    auto tmp = pointer;
+    pointer = other_;
+    other_ = tmp;
+  }
 };
 
-template<class A, class B, class U, class V>
+template <class A, class B, class U, class V>
 struct Binding {
-    A&         a;
-    B&         b;
-    U&         u;
-    V&         v;
-    __device__ Binding(A& a, B& b, U& u, V& v): a{a}, b{b}, u{u}, v{v} {}  // CTAD
+  A& a;
+  B& b;
+  U& u;
+  V& v;
+  __device__ Binding(A& a, B& b, U& u, V& v)
+      : a{a}, b{b}, u{u}, v{v} {}  // CTAD
 };
 
 // Inspired by
 // https://github.com/NVIDIA/cutlass/blob/f93a69134ec8259fd235f220209d6f8734a5cb06/include/cutlass/gemm/threadblock/mma_pipelined.h
-template<class MMA,
-         class OperandA_,
-         class IteratorA_,
-         class TransformA_,
-         class OperandU_,
-         int GroupSizeU_,
-         class OperandB_,
-         class IteratorB_,
-         class TransformB_,
-         class OperandV_,
-         int  GroupSizeV_,
-         int  Stages_,
-         bool FusePrefetch_,
-         int  GmemLookahead_ = 1>
+template <class MMA, class OperandA_, class IteratorA_, class TransformA_,
+          class OperandU_, int GroupSizeU_, class OperandB_, class IteratorB_,
+          class TransformB_, class OperandV_, int GroupSizeV_, int Stages_,
+          bool FusePrefetch_, int GmemLookahead_ = 1>
 struct MainloopSm70 {
+  using MMA_Atom = typename MMA::Atom;
+  using MMA_Map = typename MMA::Map;
 
-    using MMA_Atom = typename MMA::Atom;
-    using MMA_Map  = typename MMA::Map;
+  using FragC = typename MMA_Atom::FragC[MMA::kMmaIterM][MMA::kMmaIterN];
 
-    using FragC = typename MMA_Atom::FragC[MMA::kMmaIterM][MMA::kMmaIterN];
+  static constexpr int Stages = Stages_;
+  static constexpr int GmemLookahead = GmemLookahead_;
 
-    static constexpr int Stages       = Stages_;
-    static constexpr int GmemLookahead = GmemLookahead_;
+  static_assert(GmemLookahead >= 1 && GmemLookahead <= 2);
 
-    static_assert(GmemLookahead >= 1 && GmemLookahead <= 2);
+  static constexpr int CTA_M = MMA::M;
+  static constexpr int CTA_N = MMA::N;
+  static constexpr int CTA_K = MMA::K;
 
-    static constexpr int CTA_M = MMA::M;
-    static constexpr int CTA_N = MMA::N;
-    static constexpr int CTA_K = MMA::K;
+  static constexpr auto kOpClass = MMA_Atom::kOpClass;
 
-    static constexpr auto kOpClass = MMA_Atom::kOpClass;
+  static constexpr int WARPS = MMA::kThreadCount / WARP_SIZE;
 
-    static constexpr int WARPS = MMA::kThreadCount / WARP_SIZE;
+  using OperandA = MakeOperand<OperandA_, IteratorA_, CTA_M, CTA_K, WARPS>;
+  using OperandU =
+      MakeOperand<OperandU_, IteratorA_, CTA_M, CTA_K, WARPS, GroupSizeU_>;
 
-    using OperandA = MakeOperand<OperandA_, IteratorA_, CTA_M, CTA_K, WARPS>;
-    using OperandU = MakeOperand<OperandU_, IteratorA_, CTA_M, CTA_K, WARPS, GroupSizeU_>;
+  using OperandB = MakeOperand<OperandB_, IteratorB_, CTA_N, CTA_K, WARPS>;
+  using OperandV =
+      MakeOperand<OperandV_, IteratorB_, CTA_N, CTA_K, WARPS, GroupSizeV_>;
 
-    using OperandB = MakeOperand<OperandB_, IteratorB_, CTA_N, CTA_K, WARPS>;
-    using OperandV = MakeOperand<OperandV_, IteratorB_, CTA_N, CTA_K, WARPS, GroupSizeV_>;
+  using TransformA = TransformA_;
+  using TransformB = TransformB_;
 
-    using TransformA = TransformA_;
-    using TransformB = TransformB_;
+  using Ta = typename OperandA::Dtype;
+  using Tb = typename OperandB::Dtype;
+  using Tu = typename OperandU::Dtype;
+  using Tv = typename OperandV::Dtype;
 
-    using Ta = typename OperandA::Dtype;
-    using Tb = typename OperandB::Dtype;
-    using Tu = typename OperandU::Dtype;
-    using Tv = typename OperandV::Dtype;
+  using SmemLayoutA = typename OperandA::SmemLayout;
+  using SmemLayoutB = typename OperandB::SmemLayout;
+  using SmemLayoutU = typename OperandU::SmemLayout;
+  using SmemLayoutV = typename OperandV::SmemLayout;
 
-    using SmemLayoutA = typename OperandA::SmemLayout;
-    using SmemLayoutB = typename OperandB::SmemLayout;
-    using SmemLayoutU = typename OperandU::SmemLayout;
-    using SmemLayoutV = typename OperandV::SmemLayout;
+  using SmemCopyA = SmemCopy<OperandA, MMA_Map::kIterM, MMA_Map::kIterK,
+                             MMA_Map::kDeltaM, MMA_Map::kDeltaK>;
+  using SmemCopyU = SmemCopy<OperandU, MMA_Map::kIterM, MMA_Map::kIterK,
+                             MMA_Map::kDeltaM, MMA_Map::kDeltaK>;
+  using SmemCopyB = SmemCopy<OperandB, MMA_Map::kIterN, MMA_Map::kIterK,
+                             MMA_Map::kDeltaN, MMA_Map::kDeltaK>;
+  using SmemCopyV = SmemCopy<OperandV, MMA_Map::kIterN, MMA_Map::kIterK,
+                             MMA_Map::kDeltaN, MMA_Map::kDeltaK>;
 
-    using SmemCopyA = SmemCopy<OperandA, MMA_Map::kIterM, MMA_Map::kIterK, MMA_Map::kDeltaM, MMA_Map::kDeltaK>;
-    using SmemCopyU = SmemCopy<OperandU, MMA_Map::kIterM, MMA_Map::kIterK, MMA_Map::kDeltaM, MMA_Map::kDeltaK>;
-    using SmemCopyB = SmemCopy<OperandB, MMA_Map::kIterN, MMA_Map::kIterK, MMA_Map::kDeltaN, MMA_Map::kDeltaK>;
-    using SmemCopyV = SmemCopy<OperandV, MMA_Map::kIterN, MMA_Map::kIterK, MMA_Map::kDeltaN, MMA_Map::kDeltaK>;
+  using SmemAccessorA = SmemAccessor<Ta, SmemLayoutA>;
+  using SmemAccessorB = SmemAccessor<Tb, SmemLayoutB>;
+  using SmemAccessorU = SmemAccessor<Tu, SmemLayoutU>;
+  using SmemAccessorV = SmemAccessor<Tv, SmemLayoutV>;
 
-    using SmemAccessorA = SmemAccessor<Ta, SmemLayoutA>;
-    using SmemAccessorB = SmemAccessor<Tb, SmemLayoutB>;
-    using SmemAccessorU = SmemAccessor<Tu, SmemLayoutU>;
-    using SmemAccessorV = SmemAccessor<Tv, SmemLayoutV>;
+  using GmemIterA = typename OperandA::GmemIter;
+  using GmemIterB = typename OperandB::GmemIter;
+  using GmemIterU = typename OperandU::GmemIter;
+  using GmemIterV = typename OperandV::GmemIter;
 
-    using GmemIterA = typename OperandA::GmemIter;
-    using GmemIterB = typename OperandB::GmemIter;
-    using GmemIterU = typename OperandU::GmemIter;
-    using GmemIterV = typename OperandV::GmemIter;
+  struct SharedStorage {
+    __align__(16) Array<Ta, Stages * SmemLayoutA::kSize> A;
+    __align__(16) Array<Tb, Stages * SmemLayoutB::kSize> B;
+    __align__(16) Array<Tu, Stages * SmemLayoutU::kSize> U;
+    __align__(16) Array<Tv, Stages * SmemLayoutV::kSize> V;
+  };
 
-    struct SharedStorage {
-        __align__(16) Array<Ta, Stages * SmemLayoutA::kSize> A;
-        __align__(16) Array<Tb, Stages * SmemLayoutB::kSize> B;
-        __align__(16) Array<Tu, Stages * SmemLayoutU::kSize> U;
-        __align__(16) Array<Tv, Stages * SmemLayoutV::kSize> V;
+  template <class GmemIter, class SmemIter>
+  __device__ void _advance_smem(GmemIter& gmem_iter, SmemIter& smem_iter) {
+    gmem_iter.smem_data_ = smem_iter.pointer;
+    smem_iter.Advance();
+  }
+
+  // zip with
+  template <class BindingG, class BindingS>
+  __device__ void AdvanceSmemStage(BindingG& g, BindingS& s) {
+    _advance_smem(g.a, s.a);
+    _advance_smem(g.b, s.b);
+    _advance_smem(g.u, s.u);
+    _advance_smem(g.v, s.v);
+  }
+
+  template <class Binding>
+  __device__ void ClearSmem(Binding& g) {
+    g.a.ClearSmem();
+    g.b.ClearSmem();
+    g.u.ClearSmem();
+    g.v.ClearSmem();
+  }
+
+  template <class Binding, class Fragments>
+  __device__ void Fetch(Binding& g, Fragments& f, bool mask) {
+    g.a.Fetch(f.a, mask);
+    g.b.Fetch(f.b, mask);
+    g.u.Fetch(f.u, mask);
+    g.v.Fetch(f.v, mask);
+  }
+
+  template <class Binding, class Fragments>
+  __device__ void Store(Binding& g, Fragments& f) {
+    g.a.Store(f.a);
+    g.b.Store(f.b);
+    g.u.Store(f.u);
+    g.v.Store(f.v);
+  }
+
+  template <class Binding>
+  __device__ void AdvanceGmemStage(Binding& g) {
+    g.a.Advance();
+    g.b.Advance();
+    g.u.Advance();
+    g.v.Advance();
+  }
+
+  __device__ void operator()(GmemIterA& gmem_A, GmemIterB& gmem_B,
+                             GmemIterU& gmem_U, GmemIterV& gmem_V,
+                             FragC& frag_C, int tile_iter,
+                             SharedStorage& storage) {
+    static_assert(MMA::kAtomK == 1);
+
+    static constexpr int UU = 1;  // ceil_div(GroupSizeU_, MMA_Map::TileK);
+    static constexpr int VV = 1;  // ceil_div(GroupSizeV_, MMA_Map::TileK);
+
+    // mma_iter_x = tile_iter_x * atom_x
+    typename MMA_Atom::FragA frag_A[MMA::kTileIterK][MMA::kMmaIterM];
+    typename MMA_Atom::FragB frag_B[MMA::kTileIterK][MMA::kMmaIterN];
+
+    typename SmemCopyA::Frag data_A[MMA::kTileIterK];
+    typename SmemCopyB::Frag data_B[MMA::kTileIterK];
+    typename SmemCopyU::Frag data_U[ceil_div(MMA::kTileIterK, UU)];
+    typename SmemCopyV::Frag data_V[ceil_div(MMA::kTileIterK, VV)];
+
+    SmemIter<get_pointer_type<Ta>, SmemLayoutA::kSize, Stages> smem_A{
+        storage.A.data()};
+    SmemIter<get_pointer_type<Tb>, SmemLayoutB::kSize, Stages> smem_B{
+        storage.B.data()};
+    SmemIter<get_pointer_type<Tu>, SmemLayoutU::kSize, Stages> smem_U{
+        storage.U.data()};
+    SmemIter<get_pointer_type<Tv>, SmemLayoutV::kSize, Stages> smem_V{
+        storage.V.data()};
+
+    typename GmemIterA::Fragments rmem_A;
+    typename GmemIterB::Fragments rmem_B;
+    typename GmemIterU::Fragments rmem_U;
+    typename GmemIterV::Fragments rmem_V;
+
+    typename GmemIterA::Fragments rmem_A2;
+    typename GmemIterB::Fragments rmem_B2;
+    typename GmemIterU::Fragments rmem_U2;
+    typename GmemIterV::Fragments rmem_V2;
+
+    GroupIter<ceil_div(GroupSizeU_, CTA_K)> gmem_group_iter_U{};
+    GroupIter<ceil_div(GroupSizeV_, CTA_K)> gmem_group_iter_V{};
+
+    auto smem_group_iter_U = gmem_group_iter_U;
+    auto smem_group_iter_V = gmem_group_iter_V;
+
+    // a separate counter tends to generate better code
+    int gmem_iter = tile_iter;
+    int gmem_mask = true;
+
+    Binding gmem_iters{gmem_A, gmem_B, gmem_U, gmem_V};
+    Binding smem_iters{smem_A, smem_B, smem_U, smem_V};
+    Binding rmem{rmem_A, rmem_B, rmem_U, rmem_V};
+    Binding rmem2{rmem_A2, rmem_B2, rmem_U2, rmem_V2};
+
+    // r0,w_
+
+    PRAGMA_UNROLL
+    for (int i = 0; i < Stages; ++i) {
+      AdvanceSmemStage(gmem_iters, smem_iters);
+      ClearSmem(gmem_iters);
+    }
+
+    // r0,w1
+
+    __syncthreads();
+
+    auto fetch_stage = [&](auto& rmem) {
+      Fetch(gmem_iters, rmem, gmem_mask);
+      AdvanceGmemStage(gmem_iters);
+      gmem_group_iter_U.Advance();
+      gmem_group_iter_V.Advance();
+      gmem_U.g_mask = (bool)gmem_group_iter_U;
+      gmem_V.g_mask = (bool)gmem_group_iter_V;
+      if (--gmem_iter == 0) {
+        gmem_mask = false;
+      }
     };
 
-    template<class GmemIter, class SmemIter>
-    __device__ void _advance_smem(GmemIter& gmem_iter, SmemIter& smem_iter)
-    {
-        gmem_iter.smem_data_ = smem_iter.pointer;
-        smem_iter.Advance();
+    auto advance_and_wait_smem_stage = [&] {
+      __syncthreads();
+      AdvanceSmemStage(gmem_iters, smem_iters);
+    };
+
+    const int3 offset_mnk = MMA::get_offset(threadIdx.x);
+    const int offset_m = offset_mnk.x;
+    const int offset_n = offset_mnk.y;
+    const int offset_k = offset_mnk.z;
+
+    SmemCopyA smem_copy_A{{offset_m, offset_k}};
+    SmemCopyU smem_copy_U{{offset_m, offset_k}};
+    SmemCopyB smem_copy_B{{offset_n, offset_k}};
+    SmemCopyV smem_copy_V{{offset_n, offset_k}};
+
+    auto preload = [&](int k) {
+      smem_copy_A(smem_A.pointer, data_A[k], k);
+      smem_copy_U(smem_U.pointer, data_U[k / UU], k,
+                  k % UU == 0 && (bool)smem_group_iter_U);
+
+      smem_copy_B(smem_B.pointer, data_B[k], k);
+      smem_copy_V(smem_V.pointer, data_V[k / VV], k,
+                  k % VV == 0 && (bool)smem_group_iter_V);
+    };
+
+    AdvanceSmemStage(gmem_iters, smem_iters);
+    // r1,w0
+
+    fetch_stage(rmem);  // gmem -> rmem
+
+    Store(gmem_iters, rmem);  // rmem -> smem
+
+    if constexpr (GmemLookahead == 2) {
+      // Keep the next K tile in registers while the current tile is
+      // consumed from shared memory.
+      fetch_stage(rmem);
     }
 
-    // zip with
-    template<class BindingG, class BindingS>
-    __device__ void AdvanceSmemStage(BindingG& g, BindingS& s)
-    {
-        _advance_smem(g.a, s.a);
-        _advance_smem(g.b, s.b);
-        _advance_smem(g.u, s.u);
-        _advance_smem(g.v, s.v);
-    }
+    advance_and_wait_smem_stage();
+    // r0,w1
 
-    template<class Binding>
-    __device__ void ClearSmem(Binding& g)
-    {
-        g.a.ClearSmem();
-        g.b.ClearSmem();
-        g.u.ClearSmem();
-        g.v.ClearSmem();
-    }
+    preload(0);  // smem -> data_[A,B,U,V]
 
-    template<class Binding, class Fragments>
-    __device__ void Fetch(Binding& g, Fragments& f, bool mask)
-    {
-        g.a.Fetch(f.a, mask);
-        g.b.Fetch(f.b, mask);
-        g.u.Fetch(f.u, mask);
-        g.v.Fetch(f.v, mask);
-    }
+    TransformA::apply(frag_A, 0, data_A, data_U, UU);
+    TransformB::apply(frag_B, 0, data_B, data_V, VV);
 
-    template<class Binding, class Fragments>
-    __device__ void Store(Binding& g, Fragments& f)
-    {
-        g.a.Store(f.a);
-        g.b.Store(f.b);
-        g.u.Store(f.u);
-        g.v.Store(f.v);
-    }
+    constexpr int ITER_K = MMA::kTileIterK;
+    static_assert(ITER_K > 1);
 
-    template<class Binding>
-    __device__ void AdvanceGmemStage(Binding& g)
-    {
-        g.a.Advance();
-        g.b.Advance();
-        g.u.Advance();
-        g.v.Advance();
-    }
-
-    __device__ void operator()(GmemIterA&     gmem_A,
-                               GmemIterB&     gmem_B,
-                               GmemIterU&     gmem_U,
-                               GmemIterV&     gmem_V,
-                               FragC&         frag_C,
-                               int            tile_iter,
-                               SharedStorage& storage)
-    {
-        static_assert(MMA::kAtomK == 1);
-
-        static constexpr int UU = 1;  // ceil_div(GroupSizeU_, MMA_Map::TileK);
-        static constexpr int VV = 1;  // ceil_div(GroupSizeV_, MMA_Map::TileK);
-
-        // mma_iter_x = tile_iter_x * atom_x
-        typename MMA_Atom::FragA frag_A[MMA::kTileIterK][MMA::kMmaIterM];
-        typename MMA_Atom::FragB frag_B[MMA::kTileIterK][MMA::kMmaIterN];
-
-        typename SmemCopyA::Frag data_A[MMA::kTileIterK];
-        typename SmemCopyB::Frag data_B[MMA::kTileIterK];
-        typename SmemCopyU::Frag data_U[ceil_div(MMA::kTileIterK, UU)];
-        typename SmemCopyV::Frag data_V[ceil_div(MMA::kTileIterK, VV)];
-
-        SmemIter<get_pointer_type<Ta>, SmemLayoutA::kSize, Stages> smem_A{storage.A.data()};
-        SmemIter<get_pointer_type<Tb>, SmemLayoutB::kSize, Stages> smem_B{storage.B.data()};
-        SmemIter<get_pointer_type<Tu>, SmemLayoutU::kSize, Stages> smem_U{storage.U.data()};
-        SmemIter<get_pointer_type<Tv>, SmemLayoutV::kSize, Stages> smem_V{storage.V.data()};
-
-        typename GmemIterA::Fragments rmem_A;
-        typename GmemIterB::Fragments rmem_B;
-        typename GmemIterU::Fragments rmem_U;
-        typename GmemIterV::Fragments rmem_V;
-
-        typename GmemIterA::Fragments rmem_A2;
-        typename GmemIterB::Fragments rmem_B2;
-        typename GmemIterU::Fragments rmem_U2;
-        typename GmemIterV::Fragments rmem_V2;
-
-        GroupIter<ceil_div(GroupSizeU_, CTA_K)> gmem_group_iter_U{};
-        GroupIter<ceil_div(GroupSizeV_, CTA_K)> gmem_group_iter_V{};
-
-        auto smem_group_iter_U = gmem_group_iter_U;
-        auto smem_group_iter_V = gmem_group_iter_V;
-
-        // a separate counter tends to generate better code
-        int gmem_iter = tile_iter;
-        int gmem_mask = true;
-
-        Binding gmem_iters{gmem_A, gmem_B, gmem_U, gmem_V};
-        Binding smem_iters{smem_A, smem_B, smem_U, smem_V};
-        Binding rmem{rmem_A, rmem_B, rmem_U, rmem_V};
-        Binding rmem2{rmem_A2, rmem_B2, rmem_U2, rmem_V2};
-
-        // r0,w_
-
+    if constexpr (GmemLookahead == 1) {
+      PRAGMA_NO_UNROLL
+      for (; tile_iter > 0; --tile_iter) {
         PRAGMA_UNROLL
-        for (int i = 0; i < Stages; ++i) {
-            AdvanceSmemStage(gmem_iters, smem_iters);
-            ClearSmem(gmem_iters);
-        }
+        for (int k = 0; k < ITER_K; ++k) {
+          // The last iter, store prefetched fragments to smem
+          if (k == ITER_K - 1) {
+            Store(gmem_iters, rmem);
+            advance_and_wait_smem_stage();  // swap rw
+            smem_group_iter_U.Advance();
+            smem_group_iter_V.Advance();
+          }
 
-        // r0,w1
+          // Preload for next iter, smem -> data_[A,B,U,V]
+          preload((k + 1) % ITER_K);
 
-        __syncthreads();
-
-        auto fetch_stage = [&](auto& rmem) {
-            Fetch(gmem_iters, rmem, gmem_mask);
-            AdvanceGmemStage(gmem_iters);
-            gmem_group_iter_U.Advance();
-            gmem_group_iter_V.Advance();
-            gmem_U.g_mask = (bool)gmem_group_iter_U;
-            gmem_V.g_mask = (bool)gmem_group_iter_V;
-            if (--gmem_iter == 0) {
-                gmem_mask = false;
-            }
-        };
-
-        auto advance_and_wait_smem_stage = [&] {
-            __syncthreads();
-            AdvanceSmemStage(gmem_iters, smem_iters);
-        };
-
-        const int3 offset_mnk = MMA::get_offset(threadIdx.x);
-        const int  offset_m   = offset_mnk.x;
-        const int  offset_n   = offset_mnk.y;
-        const int  offset_k   = offset_mnk.z;
-
-        SmemCopyA smem_copy_A{{offset_m, offset_k}};
-        SmemCopyU smem_copy_U{{offset_m, offset_k}};
-        SmemCopyB smem_copy_B{{offset_n, offset_k}};
-        SmemCopyV smem_copy_V{{offset_n, offset_k}};
-
-        auto preload = [&](int k) {
-            smem_copy_A(smem_A.pointer, data_A[k], k);
-            smem_copy_U(smem_U.pointer, data_U[k / UU], k, k % UU == 0 && (bool)smem_group_iter_U);
-
-            smem_copy_B(smem_B.pointer, data_B[k], k);
-            smem_copy_V(smem_V.pointer, data_V[k / VV], k, k % VV == 0 && (bool)smem_group_iter_V);
-        };
-
-        AdvanceSmemStage(gmem_iters, smem_iters);
-        // r1,w0
-
-        fetch_stage(rmem);  // gmem -> rmem
-
-        Store(gmem_iters, rmem);  // rmem -> smem
-
-        if constexpr (GmemLookahead == 2) {
-            // Keep the next K tile in registers while the current tile is
-            // consumed from shared memory.
+          // The first iter, issue the prefetching of next stage
+          if (k == 0) {
             fetch_stage(rmem);
-        }
+          }
 
-        advance_and_wait_smem_stage();
-        // r0,w1
-
-        preload(0);  // smem -> data_[A,B,U,V]
-
-        TransformA::apply(frag_A, 0, data_A, data_U, UU);
-        TransformB::apply(frag_B, 0, data_B, data_V, VV);
-
-        constexpr int ITER_K = MMA::kTileIterK;
-        static_assert(ITER_K > 1);
-
-        if constexpr (GmemLookahead == 1) {
-            PRAGMA_NO_UNROLL
-            for (; tile_iter > 0; --tile_iter) {
-                PRAGMA_UNROLL
-                for (int k = 0; k < ITER_K; ++k) {
-                    // The last iter, store prefetched fragments to smem
-                    if (k == ITER_K - 1) {
-                        Store(gmem_iters, rmem);
-                        advance_and_wait_smem_stage();  // swap rw
-                        smem_group_iter_U.Advance();
-                        smem_group_iter_V.Advance();
-                    }
-
-                    // Preload for next iter, smem -> data_[A,B,U,V]
-                    preload((k + 1) % ITER_K);
-
-                    // The first iter, issue the prefetching of next stage
-                    if (k == 0) {
-                        fetch_stage(rmem);
-                    }
-
-                    PRAGMA_UNROLL
-                    for (int m = 0; m < MMA::kMmaIterM; ++m) {
-                        PRAGMA_UNROLL
-                        for (int n = 0; n < MMA::kMmaIterN; ++n) {
-                            int nn = m % 2 ? MMA::kMmaIterN - n - 1 : n;
-                            MMA_Atom::fma(frag_C[m][nn], frag_A[k][m], frag_B[k][nn], frag_C[m][nn]);
-                        }
-                    }
-
-                    TransformA::apply(frag_A, (k + 1) % ITER_K, data_A, data_U, UU);
-                    TransformB::apply(frag_B, (k + 1) % ITER_K, data_B, data_V, VV);
-                }
+          PRAGMA_UNROLL
+          for (int m = 0; m < MMA::kMmaIterM; ++m) {
+            PRAGMA_UNROLL
+            for (int n = 0; n < MMA::kMmaIterN; ++n) {
+              int nn = m % 2 ? MMA::kMmaIterN - n - 1 : n;
+              MMA_Atom::fma(frag_C[m][nn], frag_A[k][m], frag_B[k][nn],
+                            frag_C[m][nn]);
             }
+          }
+
+          TransformA::apply(frag_A, (k + 1) % ITER_K, data_A, data_U, UU);
+          TransformB::apply(frag_B, (k + 1) % ITER_K, data_B, data_V, VV);
         }
-        else if constexpr (GmemLookahead == 2) {
-            auto compute_stage = [&](auto& store_rmem, auto& fetch_rmem) {
-                PRAGMA_UNROLL
-                for (int k = 0; k < ITER_K; ++k) {
-                    if (k == 0) {
-                        fetch_stage(fetch_rmem);
-                    }
+      }
+    } else if constexpr (GmemLookahead == 2) {
+      auto compute_stage = [&](auto& store_rmem, auto& fetch_rmem) {
+        PRAGMA_UNROLL
+        for (int k = 0; k < ITER_K; ++k) {
+          if (k == 0) {
+            fetch_stage(fetch_rmem);
+          }
 
-                    // The last iter, store prefetched fragments to smem
-                    if (k == ITER_K - 1) {
-                        Store(gmem_iters, store_rmem);
-                        advance_and_wait_smem_stage();  // swap rw
-                        smem_group_iter_U.Advance();
-                        smem_group_iter_V.Advance();
-                    }
+          // The last iter, store prefetched fragments to smem
+          if (k == ITER_K - 1) {
+            Store(gmem_iters, store_rmem);
+            advance_and_wait_smem_stage();  // swap rw
+            smem_group_iter_U.Advance();
+            smem_group_iter_V.Advance();
+          }
 
-                    // Preload for next iter, smem -> data_[A,B,U,V]
-                    preload((k + 1) % ITER_K);
+          // Preload for next iter, smem -> data_[A,B,U,V]
+          preload((k + 1) % ITER_K);
 
-                    PRAGMA_UNROLL
-                    for (int m = 0; m < MMA::kMmaIterM; ++m) {
-                        PRAGMA_UNROLL
-                        for (int n = 0; n < MMA::kMmaIterN; ++n) {
-                            int nn = m % 2 ? MMA::kMmaIterN - n - 1 : n;
-                            MMA_Atom::fma(frag_C[m][nn], frag_A[k][m], frag_B[k][nn], frag_C[m][nn]);
-                        }
-                    }
-
-                    TransformA::apply(frag_A, (k + 1) % ITER_K, data_A, data_U, UU);
-                    TransformB::apply(frag_B, (k + 1) % ITER_K, data_B, data_V, VV);
-                }
-            };
-
-            PRAGMA_NO_UNROLL
-            for (; tile_iter > 0; tile_iter -= 2) {
-                compute_stage(rmem, rmem2);
-                if (tile_iter > 1) {
-                    compute_stage(rmem2, rmem);
-                }
+          PRAGMA_UNROLL
+          for (int m = 0; m < MMA::kMmaIterM; ++m) {
+            PRAGMA_UNROLL
+            for (int n = 0; n < MMA::kMmaIterN; ++n) {
+              int nn = m % 2 ? MMA::kMmaIterN - n - 1 : n;
+              MMA_Atom::fma(frag_C[m][nn], frag_A[k][m], frag_B[k][nn],
+                            frag_C[m][nn]);
             }
+          }
+
+          TransformA::apply(frag_A, (k + 1) % ITER_K, data_A, data_U, UU);
+          TransformB::apply(frag_B, (k + 1) % ITER_K, data_B, data_V, VV);
         }
-        __syncthreads();
+      };
+
+      PRAGMA_NO_UNROLL
+      for (; tile_iter > 0; tile_iter -= 2) {
+        compute_stage(rmem, rmem2);
+        if (tile_iter > 1) {
+          compute_stage(rmem2, rmem);
+        }
+      }
     }
+    __syncthreads();
+  }
 };
 
 }  // namespace turbomind::gemm

--- a/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/mainloop_sm80_v2.h
+++ b/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/mainloop_sm80_v2.h
@@ -16,363 +16,346 @@
 
 namespace turbomind::gemm {
 
-template<int Stages>
+template <int Stages>
 struct GroupIter {
+  static_assert((Stages & (Stages - 1)) == 0);
 
-    static_assert((Stages & (Stages - 1)) == 0);
+  int iter_ = 0;
 
-    int iter_ = 0;
+  __device__ void Advance() { iter_ = (iter_ + 1) % Stages; }
 
-    __device__ void Advance()
-    {
-        iter_ = (iter_ + 1) % Stages;
-    }
-
-    __device__ constexpr explicit operator bool()
-    {
-        return iter_ == 0;
-    }
+  __device__ constexpr explicit operator bool() { return iter_ == 0; }
 };
 
-template<>
+template <>
 struct GroupIter<1> {
-    __device__ void               Advance() {}
-    __device__ constexpr explicit operator bool()
-    {
-        return true;
-    }
+  __device__ void Advance() {}
+  __device__ constexpr explicit operator bool() { return true; }
 };
 
-template<class Pointer, int Step, int Stages>
+template <class Pointer, int Step, int Stages>
 struct SmemIter {
-    Pointer base_;
-    Pointer pointer;
-    int     pipe_iter_;
+  Pointer base_;
+  Pointer pointer;
+  int pipe_iter_;
 
-    __device__ SmemIter(Pointer base): base_{base}, pointer{base}, pipe_iter_{} {}
+  __device__ SmemIter(Pointer base)
+      : base_{base}, pointer{base}, pipe_iter_{} {}
 
-    __device__ void Advance()
-    {
-        pipe_iter_ += 1;
-        pointer = pointer + Step;
-        if (pipe_iter_ == Stages) {
-            pipe_iter_ = 0;
-            pointer    = base_;
-        }
+  __device__ void Advance() {
+    pipe_iter_ += 1;
+    pointer = pointer + Step;
+    if (pipe_iter_ == Stages) {
+      pipe_iter_ = 0;
+      pointer = base_;
     }
+  }
 };
 
-template<class A, class B, class U, class V>
+template <class A, class B, class U, class V>
 struct Binding {
-    A&         a;
-    B&         b;
-    U&         u;
-    V&         v;
-    __device__ Binding(A& a, B& b, U& u, V& v): a{a}, b{b}, u{u}, v{v} {}  // CTAD
+  A& a;
+  B& b;
+  U& u;
+  V& v;
+  __device__ Binding(A& a, B& b, U& u, V& v)
+      : a{a}, b{b}, u{u}, v{v} {}  // CTAD
 };
 
 // Inspired by
 // https://github.com/NVIDIA/cutlass/blob/f93a69134ec8259fd235f220209d6f8734a5cb06/include/cutlass/gemm/threadblock/mma_multistage.h
 // https://github.com/NVIDIA/cutlass/blob/f93a69134ec8259fd235f220209d6f8734a5cb06/include/cutlass/gemm/collective/sm80_mma_multistage.hpp
-template<class MMA,
-         class OperandA_,
-         class IteratorA_,
-         class TransformA_,
-         class OperandU_,
-         int GroupSizeU_,
-         class OperandB_,
-         class IteratorB_,
-         class TransformB_,
-         class OperandV_,
-         int  GroupSizeV_,
-         int  Stages_,
-         bool FusePrefetch_>
+template <class MMA, class OperandA_, class IteratorA_, class TransformA_,
+          class OperandU_, int GroupSizeU_, class OperandB_, class IteratorB_,
+          class TransformB_, class OperandV_, int GroupSizeV_, int Stages_,
+          bool FusePrefetch_>
 struct MainloopSm80_v2 {
+  using MMA_Atom = typename MMA::Atom;
+  using MMA_Map = typename MMA::Map;
 
-    using MMA_Atom = typename MMA::Atom;
-    using MMA_Map  = typename MMA::Map;
+  using FragC = typename MMA_Atom::FragC[MMA::kMmaIterM][MMA::kMmaIterN];
 
-    using FragC = typename MMA_Atom::FragC[MMA::kMmaIterM][MMA::kMmaIterN];
+  static constexpr int Stages = Stages_;
 
-    static constexpr int Stages = Stages_;
+  static constexpr int CTA_M = MMA::M;
+  static constexpr int CTA_N = MMA::N;
+  static constexpr int CTA_K = MMA::K;
 
-    static constexpr int CTA_M = MMA::M;
-    static constexpr int CTA_N = MMA::N;
-    static constexpr int CTA_K = MMA::K;
+  static constexpr auto kOpClass = MMA_Atom::kOpClass;
 
-    static constexpr auto kOpClass = MMA_Atom::kOpClass;
+  static constexpr int WARPS = MMA::kThreadCount / WARP_SIZE;
 
-    static constexpr int WARPS = MMA::kThreadCount / WARP_SIZE;
+  using OperandA = MakeOperand<OperandA_, IteratorA_, CTA_M, CTA_K, WARPS>;
+  using OperandU =
+      MakeOperand<OperandU_, IteratorA_, CTA_M, CTA_K, WARPS, GroupSizeU_>;
 
-    using OperandA = MakeOperand<OperandA_, IteratorA_, CTA_M, CTA_K, WARPS>;
-    using OperandU = MakeOperand<OperandU_, IteratorA_, CTA_M, CTA_K, WARPS, GroupSizeU_>;
+  using OperandB = MakeOperand<OperandB_, IteratorB_, CTA_N, CTA_K, WARPS>;
+  using OperandV =
+      MakeOperand<OperandV_, IteratorB_, CTA_N, CTA_K, WARPS, GroupSizeV_>;
 
-    using OperandB = MakeOperand<OperandB_, IteratorB_, CTA_N, CTA_K, WARPS>;
-    using OperandV = MakeOperand<OperandV_, IteratorB_, CTA_N, CTA_K, WARPS, GroupSizeV_>;
+  using TransformA = TransformA_;
+  using TransformB = TransformB_;
 
-    using TransformA = TransformA_;
-    using TransformB = TransformB_;
+  using Ta = typename OperandA::Dtype;
+  using Tb = typename OperandB::Dtype;
+  using Tu = typename OperandU::Dtype;
+  using Tv = typename OperandV::Dtype;
 
-    using Ta = typename OperandA::Dtype;
-    using Tb = typename OperandB::Dtype;
-    using Tu = typename OperandU::Dtype;
-    using Tv = typename OperandV::Dtype;
+  using SmemLayoutA = typename OperandA::SmemLayout;
+  using SmemLayoutB = typename OperandB::SmemLayout;
+  using SmemLayoutU = typename OperandU::SmemLayout;
+  using SmemLayoutV = typename OperandV::SmemLayout;
 
-    using SmemLayoutA = typename OperandA::SmemLayout;
-    using SmemLayoutB = typename OperandB::SmemLayout;
-    using SmemLayoutU = typename OperandU::SmemLayout;
-    using SmemLayoutV = typename OperandV::SmemLayout;
+  using SmemCopyA = SmemCopy<OperandA, MMA_Map::kIterM, MMA_Map::kIterK,
+                             MMA_Map::kDeltaM, MMA_Map::kDeltaK>;
+  using SmemCopyU = SmemCopy<OperandU, MMA_Map::kIterM, MMA_Map::kIterK,
+                             MMA_Map::kDeltaM, MMA_Map::kDeltaK>;
+  using SmemCopyB = SmemCopy<OperandB, MMA_Map::kIterN, MMA_Map::kIterK,
+                             MMA_Map::kDeltaN, MMA_Map::kDeltaK>;
+  using SmemCopyV = SmemCopy<OperandV, MMA_Map::kIterN, MMA_Map::kIterK,
+                             MMA_Map::kDeltaN, MMA_Map::kDeltaK>;
 
-    using SmemCopyA = SmemCopy<OperandA, MMA_Map::kIterM, MMA_Map::kIterK, MMA_Map::kDeltaM, MMA_Map::kDeltaK>;
-    using SmemCopyU = SmemCopy<OperandU, MMA_Map::kIterM, MMA_Map::kIterK, MMA_Map::kDeltaM, MMA_Map::kDeltaK>;
-    using SmemCopyB = SmemCopy<OperandB, MMA_Map::kIterN, MMA_Map::kIterK, MMA_Map::kDeltaN, MMA_Map::kDeltaK>;
-    using SmemCopyV = SmemCopy<OperandV, MMA_Map::kIterN, MMA_Map::kIterK, MMA_Map::kDeltaN, MMA_Map::kDeltaK>;
+  using SmemAccessorA = SmemAccessor<Ta, SmemLayoutA>;
+  using SmemAccessorB = SmemAccessor<Tb, SmemLayoutB>;
+  using SmemAccessorU = SmemAccessor<Tu, SmemLayoutU>;
+  using SmemAccessorV = SmemAccessor<Tv, SmemLayoutV>;
 
-    using SmemAccessorA = SmemAccessor<Ta, SmemLayoutA>;
-    using SmemAccessorB = SmemAccessor<Tb, SmemLayoutB>;
-    using SmemAccessorU = SmemAccessor<Tu, SmemLayoutU>;
-    using SmemAccessorV = SmemAccessor<Tv, SmemLayoutV>;
+  using GmemIterA = typename OperandA::GmemIter;
+  using GmemIterB = typename OperandB::GmemIter;
+  using GmemIterU = typename OperandU::GmemIter;
+  using GmemIterV = typename OperandV::GmemIter;
 
-    using GmemIterA = typename OperandA::GmemIter;
-    using GmemIterB = typename OperandB::GmemIter;
-    using GmemIterU = typename OperandU::GmemIter;
-    using GmemIterV = typename OperandV::GmemIter;
+  static constexpr int kFusePrefetch = FusePrefetch_;
 
-    static constexpr int kFusePrefetch = FusePrefetch_;
+  static constexpr int kMaxPrefetchIter = 1;
+  // std::min(ceil_div(std::max(GmemIterA::ITER_S, GmemIterB::ITER_S), 4),
+  // MMA::kTileIterK);
 
-    static constexpr int kMaxPrefetchIter = 1;
-    // std::min(ceil_div(std::max(GmemIterA::ITER_S, GmemIterB::ITER_S), 4), MMA::kTileIterK);
+  static constexpr int kBatchA = ceil_div(GmemIterA::ITER_S, kMaxPrefetchIter);
+  static constexpr int kBatchB = ceil_div(GmemIterB::ITER_S, kMaxPrefetchIter);
+  static constexpr int kBatchU = ceil_div(GmemIterU::ITER_S, kMaxPrefetchIter);
+  static constexpr int kBatchV = ceil_div(GmemIterV::ITER_S, kMaxPrefetchIter);
 
-    static constexpr int kBatchA = ceil_div(GmemIterA::ITER_S, kMaxPrefetchIter);
-    static constexpr int kBatchB = ceil_div(GmemIterB::ITER_S, kMaxPrefetchIter);
-    static constexpr int kBatchU = ceil_div(GmemIterU::ITER_S, kMaxPrefetchIter);
-    static constexpr int kBatchV = ceil_div(GmemIterV::ITER_S, kMaxPrefetchIter);
+  struct SharedStorage {
+    __align__(16) Array<Ta, Stages * SmemLayoutA::kSize> A;
+    __align__(16) Array<Tb, Stages * SmemLayoutB::kSize> B;
+    __align__(16) Array<Tu, Stages * SmemLayoutU::kSize> U;
+    __align__(16) Array<Tv, Stages * SmemLayoutV::kSize> V;
+  };
 
-    struct SharedStorage {
-        __align__(16) Array<Ta, Stages * SmemLayoutA::kSize> A;
-        __align__(16) Array<Tb, Stages * SmemLayoutB::kSize> B;
-        __align__(16) Array<Tu, Stages * SmemLayoutU::kSize> U;
-        __align__(16) Array<Tv, Stages * SmemLayoutV::kSize> V;
+  __device__ void Wait() {
+    __pipeline_wait_prior(Stages - 2);
+    __syncthreads();
+  }
+
+  template <class GmemIter, class SmemIter>
+  __device__ void _advance_smem(GmemIter& gmem_iter, SmemIter& smem_iter) {
+    gmem_iter.smem_data_ = smem_iter.pointer;
+    smem_iter.Advance();
+  }
+
+  // zip with
+  template <class BindingG, class BindingS>
+  __device__ void AdvanceSmemStage(BindingG& g, BindingS& s) {
+    _advance_smem(g.a, s.a);
+    _advance_smem(g.b, s.b);
+    _advance_smem(g.u, s.u);
+    _advance_smem(g.v, s.v);
+  }
+
+  template <class Binding>
+  __device__ void ClearSmem(Binding& g) {
+    g.a.ClearSmem();
+    g.b.ClearSmem();
+    g.u.ClearSmem();
+    g.v.ClearSmem();
+  }
+
+  template <class Binding>
+  __device__ void Prefetch(Binding& g, bool mask) {
+    g.a.Prefetch(mask);
+    g.b.Prefetch(mask);
+    g.u.Prefetch(mask);
+    g.v.Prefetch(mask);
+  }
+
+  template <class Binding>
+  __device__ void Prefetch(Binding& g, int k, bool mask) {
+    int batch_A = min((k + 1) * kBatchA, GmemIterA::ITER_S) - k * kBatchA;
+    int batch_B = min((k + 1) * kBatchB, GmemIterB::ITER_S) - k * kBatchB;
+    int batch_U = min((k + 1) * kBatchU, GmemIterU::ITER_S) - k * kBatchU;
+    int batch_V = min((k + 1) * kBatchV, GmemIterV::ITER_S) - k * kBatchV;
+    g.a.Prefetch(k * kBatchA, batch_A, mask);
+    g.b.Prefetch(k * kBatchB, batch_B, mask);
+    g.u.Prefetch(k * kBatchU, batch_U, mask);
+    g.v.Prefetch(k * kBatchV, batch_V, mask);
+  }
+
+  template <class Binding>
+  __device__ void AdvanceGmemStage(Binding& g) {
+    g.a.Advance();
+    g.b.Advance();
+    g.u.Advance();
+    g.v.Advance();
+  }
+
+  __device__ void operator()(GmemIterA& gmem_A, GmemIterB& gmem_B,
+                             GmemIterU& gmem_U, GmemIterV& gmem_V,
+                             FragC& frag_C, int tile_iter,
+                             SharedStorage& storage) {
+    static_assert(MMA::kAtomK == 1);
+
+    static constexpr int UU = ceil_div(GroupSizeU_, MMA_Map::TileK);
+    static constexpr int VV = ceil_div(GroupSizeV_, MMA_Map::TileK);
+
+    // mma_iter_x = tile_iter_x * atom_x
+    typename MMA_Atom::FragA frag_A[MMA::kTileIterK][MMA::kMmaIterM];
+    typename MMA_Atom::FragB frag_B[MMA::kTileIterK][MMA::kMmaIterN];
+
+    typename SmemCopyA::Frag data_A[MMA::kTileIterK];
+    typename SmemCopyB::Frag data_B[MMA::kTileIterK];
+    typename SmemCopyU::Frag data_U[ceil_div(MMA::kTileIterK, UU)];
+    typename SmemCopyV::Frag data_V[ceil_div(MMA::kTileIterK, VV)];
+
+    SmemIter<get_pointer_type<Ta>, SmemLayoutA::kSize, Stages> smem_A{
+        storage.A.data()};
+    SmemIter<get_pointer_type<Tb>, SmemLayoutB::kSize, Stages> smem_B{
+        storage.B.data()};
+    SmemIter<get_pointer_type<Tu>, SmemLayoutU::kSize, Stages> smem_U{
+        storage.U.data()};
+    SmemIter<get_pointer_type<Tv>, SmemLayoutV::kSize, Stages> smem_V{
+        storage.V.data()};
+
+    GroupIter<ceil_div(GroupSizeU_, CTA_K)> gmem_group_iter_U{};
+    GroupIter<ceil_div(GroupSizeV_, CTA_K)> gmem_group_iter_V{};
+
+    auto smem_group_iter_U = gmem_group_iter_U;
+    auto smem_group_iter_V = gmem_group_iter_V;
+
+    // a separate counter tends to generate better code
+    int gmem_iter = tile_iter;
+    int gmem_mask = true;
+
+    Binding gmem_iters{gmem_A, gmem_B, gmem_U, gmem_V};
+    Binding smem_iters{smem_A, smem_B, smem_U, smem_V};
+
+    PRAGMA_UNROLL
+    for (int i = 0; i < Stages; ++i) {
+      AdvanceSmemStage(gmem_iters, smem_iters);
+      ClearSmem(gmem_iters);
+    }
+
+    // r: 0, w:s-1
+
+    __syncthreads();
+
+    auto prefetch_stage = [&] {
+      Prefetch(gmem_iters, gmem_mask);
+      __pipeline_commit();
+      AdvanceGmemStage(gmem_iters);
+      gmem_group_iter_U.Advance();
+      gmem_group_iter_V.Advance();
+      gmem_U.g_mask = (bool)gmem_group_iter_U;
+      gmem_V.g_mask = (bool)gmem_group_iter_V;
+      if (--gmem_iter == 0) {
+        gmem_mask = false;
+      }
     };
 
-    __device__ void Wait()
-    {
-        __pipeline_wait_prior(Stages - 2);
-        __syncthreads();
-    }
-
-    template<class GmemIter, class SmemIter>
-    __device__ void _advance_smem(GmemIter& gmem_iter, SmemIter& smem_iter)
-    {
-        gmem_iter.smem_data_ = smem_iter.pointer;
-        smem_iter.Advance();
-    }
-
-    // zip with
-    template<class BindingG, class BindingS>
-    __device__ void AdvanceSmemStage(BindingG& g, BindingS& s)
-    {
-        _advance_smem(g.a, s.a);
-        _advance_smem(g.b, s.b);
-        _advance_smem(g.u, s.u);
-        _advance_smem(g.v, s.v);
-    }
-
-    template<class Binding>
-    __device__ void ClearSmem(Binding& g)
-    {
-        g.a.ClearSmem();
-        g.b.ClearSmem();
-        g.u.ClearSmem();
-        g.v.ClearSmem();
-    }
-
-    template<class Binding>
-    __device__ void Prefetch(Binding& g, bool mask)
-    {
-        g.a.Prefetch(mask);
-        g.b.Prefetch(mask);
-        g.u.Prefetch(mask);
-        g.v.Prefetch(mask);
-    }
-
-    template<class Binding>
-    __device__ void Prefetch(Binding& g, int k, bool mask)
-    {
-        int batch_A = min((k + 1) * kBatchA, GmemIterA::ITER_S) - k * kBatchA;
-        int batch_B = min((k + 1) * kBatchB, GmemIterB::ITER_S) - k * kBatchB;
-        int batch_U = min((k + 1) * kBatchU, GmemIterU::ITER_S) - k * kBatchU;
-        int batch_V = min((k + 1) * kBatchV, GmemIterV::ITER_S) - k * kBatchV;
-        g.a.Prefetch(k * kBatchA, batch_A, mask);
-        g.b.Prefetch(k * kBatchB, batch_B, mask);
-        g.u.Prefetch(k * kBatchU, batch_U, mask);
-        g.v.Prefetch(k * kBatchV, batch_V, mask);
-    }
-
-    template<class Binding>
-    __device__ void AdvanceGmemStage(Binding& g)
-    {
-        g.a.Advance();
-        g.b.Advance();
-        g.u.Advance();
-        g.v.Advance();
-    }
-
-    __device__ void operator()(GmemIterA&     gmem_A,
-                               GmemIterB&     gmem_B,
-                               GmemIterU&     gmem_U,
-                               GmemIterV&     gmem_V,
-                               FragC&         frag_C,
-                               int            tile_iter,
-                               SharedStorage& storage)
-    {
-        static_assert(MMA::kAtomK == 1);
-
-        static constexpr int UU = ceil_div(GroupSizeU_, MMA_Map::TileK);
-        static constexpr int VV = ceil_div(GroupSizeV_, MMA_Map::TileK);
-
-        // mma_iter_x = tile_iter_x * atom_x
-        typename MMA_Atom::FragA frag_A[MMA::kTileIterK][MMA::kMmaIterM];
-        typename MMA_Atom::FragB frag_B[MMA::kTileIterK][MMA::kMmaIterN];
-
-        typename SmemCopyA::Frag data_A[MMA::kTileIterK];
-        typename SmemCopyB::Frag data_B[MMA::kTileIterK];
-        typename SmemCopyU::Frag data_U[ceil_div(MMA::kTileIterK, UU)];
-        typename SmemCopyV::Frag data_V[ceil_div(MMA::kTileIterK, VV)];
-
-        SmemIter<get_pointer_type<Ta>, SmemLayoutA::kSize, Stages> smem_A{storage.A.data()};
-        SmemIter<get_pointer_type<Tb>, SmemLayoutB::kSize, Stages> smem_B{storage.B.data()};
-        SmemIter<get_pointer_type<Tu>, SmemLayoutU::kSize, Stages> smem_U{storage.U.data()};
-        SmemIter<get_pointer_type<Tv>, SmemLayoutV::kSize, Stages> smem_V{storage.V.data()};
-
-        GroupIter<ceil_div(GroupSizeU_, CTA_K)> gmem_group_iter_U{};
-        GroupIter<ceil_div(GroupSizeV_, CTA_K)> gmem_group_iter_V{};
-
-        auto smem_group_iter_U = gmem_group_iter_U;
-        auto smem_group_iter_V = gmem_group_iter_V;
-
-        // a separate counter tends to generate better code
-        int gmem_iter = tile_iter;
-        int gmem_mask = true;
-
-        Binding gmem_iters{gmem_A, gmem_B, gmem_U, gmem_V};
-        Binding smem_iters{smem_A, smem_B, smem_U, smem_V};
-
-        PRAGMA_UNROLL
-        for (int i = 0; i < Stages; ++i) {
-            AdvanceSmemStage(gmem_iters, smem_iters);
-            ClearSmem(gmem_iters);
+    [[maybe_unused]] auto prefetch_batch = [&](int k) {
+      Prefetch(gmem_iters, k, gmem_mask);
+      if (k == MMA::kTileIterK - 1) {
+        __pipeline_commit();
+        AdvanceGmemStage(gmem_iters);
+        gmem_group_iter_U.Advance();
+        gmem_group_iter_V.Advance();
+        gmem_U.g_mask = (bool)gmem_group_iter_U;
+        gmem_V.g_mask = (bool)gmem_group_iter_V;
+        if (--gmem_iter == 0) {
+          gmem_mask = false;
         }
+      }
+    };
 
-        // r: 0, w:s-1
+    auto advance_and_wait_smem_stage = [&] {
+      Wait();
+      AdvanceSmemStage(gmem_iters, smem_iters);
+    };
 
-        __syncthreads();
+    const int3 offset_mnk = MMA::get_offset(threadIdx.x);
+    const int offset_m = offset_mnk.x;
+    const int offset_n = offset_mnk.y;
+    const int offset_k = offset_mnk.z;
 
-        auto prefetch_stage = [&] {
-            Prefetch(gmem_iters, gmem_mask);
-            __pipeline_commit();
-            AdvanceGmemStage(gmem_iters);
-            gmem_group_iter_U.Advance();
-            gmem_group_iter_V.Advance();
-            gmem_U.g_mask = (bool)gmem_group_iter_U;
-            gmem_V.g_mask = (bool)gmem_group_iter_V;
-            if (--gmem_iter == 0) {
-                gmem_mask = false;
-            }
-        };
+    SmemCopyA smem_copy_A{{offset_m, offset_k}};
+    SmemCopyU smem_copy_U{{offset_m, offset_k}};
+    SmemCopyB smem_copy_B{{offset_n, offset_k}};
+    SmemCopyV smem_copy_V{{offset_n, offset_k}};
 
-        [[maybe_unused]] auto prefetch_batch = [&](int k) {
-            Prefetch(gmem_iters, k, gmem_mask);
-            if (k == MMA::kTileIterK - 1) {
-                __pipeline_commit();
-                AdvanceGmemStage(gmem_iters);
-                gmem_group_iter_U.Advance();
-                gmem_group_iter_V.Advance();
-                gmem_U.g_mask = (bool)gmem_group_iter_U;
-                gmem_V.g_mask = (bool)gmem_group_iter_V;
-                if (--gmem_iter == 0) {
-                    gmem_mask = false;
-                }
-            }
-        };
+    auto preload = [&](int k) {
+      smem_copy_A(smem_A.pointer, data_A[k], k);
+      smem_copy_U(smem_U.pointer, data_U[k / UU], k,
+                  k % UU == 0 && (bool)smem_group_iter_U);
 
-        auto advance_and_wait_smem_stage = [&] {
-            Wait();
-            AdvanceSmemStage(gmem_iters, smem_iters);
-        };
+      smem_copy_B(smem_B.pointer, data_B[k], k);
+      smem_copy_V(smem_V.pointer, data_V[k / VV], k,
+                  k % VV == 0 && (bool)smem_group_iter_V);
+    };
 
-        const int3 offset_mnk = MMA::get_offset(threadIdx.x);
-        const int  offset_m   = offset_mnk.x;
-        const int  offset_n   = offset_mnk.y;
-        const int  offset_k   = offset_mnk.z;
+    PRAGMA_UNROLL
+    for (int stage = 0; stage < Stages - 1; ++stage) {
+      AdvanceSmemStage(gmem_iters, smem_iters);
+      prefetch_stage();
+    }
+    // r:-1, w:-2
 
-        SmemCopyA smem_copy_A{{offset_m, offset_k}};
-        SmemCopyU smem_copy_U{{offset_m, offset_k}};
-        SmemCopyB smem_copy_B{{offset_n, offset_k}};
-        SmemCopyV smem_copy_V{{offset_n, offset_k}};
+    advance_and_wait_smem_stage();
+    // r: 0, w:-1
 
-        auto preload = [&](int k) {
-            smem_copy_A(smem_A.pointer, data_A[k], k);
-            smem_copy_U(smem_U.pointer, data_U[k / UU], k, k % UU == 0 && (bool)smem_group_iter_U);
+    preload(0);
 
-            smem_copy_B(smem_B.pointer, data_B[k], k);
-            smem_copy_V(smem_V.pointer, data_V[k / VV], k, k % VV == 0 && (bool)smem_group_iter_V);
-        };
+    TransformA::apply(frag_A, 0, data_A, data_U, UU);
+    TransformB::apply(frag_B, 0, data_B, data_V, VV);
 
-        PRAGMA_UNROLL
-        for (int stage = 0; stage < Stages - 1; ++stage) {
-            AdvanceSmemStage(gmem_iters, smem_iters);
-            prefetch_stage();
-        }
-        // r:-1, w:-2
+    if constexpr (kFusePrefetch) {
+      prefetch_batch(0);
+    }
 
-        advance_and_wait_smem_stage();
-        // r: 0, w:-1
+    PRAGMA_NO_UNROLL
+    for (; tile_iter > 0; --tile_iter) {
+      if constexpr (!kFusePrefetch) {
+        prefetch_stage();
+      }
+      constexpr int ITER_K = MMA::kTileIterK;
+      static_assert(ITER_K > 1);
 
-        preload(0);
+      PRAGMA_UNROLL
+      for (int k = 0; k < ITER_K; ++k) {
+        // preload for next iter
+        preload((k + 1) % ITER_K);
 
-        TransformA::apply(frag_A, 0, data_A, data_U, UU);
-        TransformB::apply(frag_B, 0, data_B, data_V, VV);
+        MMA::mma_k_iter(frag_C, frag_A[k], frag_B[k], frag_C);
 
         if constexpr (kFusePrefetch) {
-            prefetch_batch(0);
+          prefetch_batch((k + 1) % ITER_K);
         }
 
-        PRAGMA_NO_UNROLL
-        for (; tile_iter > 0; --tile_iter) {
-            if constexpr (!kFusePrefetch) {
-                prefetch_stage();
-            }
-            constexpr int ITER_K = MMA::kTileIterK;
-            static_assert(ITER_K > 1);
-
-            PRAGMA_UNROLL
-            for (int k = 0; k < ITER_K; ++k) {
-                // preload for next iter
-                preload((k + 1) % ITER_K);
-
-                MMA::mma_k_iter(frag_C, frag_A[k], frag_B[k], frag_C);
-
-                if constexpr (kFusePrefetch) {
-                    prefetch_batch((k + 1) % ITER_K);
-                }
-
-                if (k + 1 == ITER_K - 1) {
-                    advance_and_wait_smem_stage();
-                    smem_group_iter_U.Advance();
-                    smem_group_iter_V.Advance();
-                }
-
-                TransformA::apply(frag_A, (k + 1) % ITER_K, data_A, data_U, UU);
-                TransformB::apply(frag_B, (k + 1) % ITER_K, data_B, data_V, VV);
-            }
+        if (k + 1 == ITER_K - 1) {
+          advance_and_wait_smem_stage();
+          smem_group_iter_U.Advance();
+          smem_group_iter_V.Advance();
         }
 
-        __pipeline_commit();
-        __pipeline_wait_prior(0);
-
-        __syncthreads();
+        TransformA::apply(frag_A, (k + 1) % ITER_K, data_A, data_U, UU);
+        TransformB::apply(frag_B, (k + 1) % ITER_K, data_B, data_V, VV);
+      }
     }
+
+    __pipeline_commit();
+    __pipeline_wait_prior(0);
+
+    __syncthreads();
+  }
 };
 
 }  // namespace turbomind::gemm

--- a/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/matrix_ptr.h
+++ b/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/matrix_ptr.h
@@ -6,28 +6,26 @@
 
 namespace turbomind::gemm {
 
-struct __align__(16) StridedPtr
-{
-    void* ptr;
-    int   stride;
+struct __align__(16) StridedPtr {
+  void* ptr;
+  int stride;
 };
 
 struct MatrixParam {
-    void* ptr;
-    int   stride;
-    int*  offsets;
-    int*  idxs;
-    int*  group_idxs;
+  void* ptr;
+  int stride;
+  int* offsets;
+  int* idxs;
+  int* group_idxs;
 };
 
 struct MatrixData {
-    StridedPtr ptr;
-    const int* idxs;
+  StridedPtr ptr;
+  const int* idxs;
 };
 
-inline MatrixParam to_param(void* ptr, MatrixLayout layout)
-{
-    return {ptr, layout.ld, layout.offsets, layout.idxs, layout.group_idxs};
+inline MatrixParam to_param(void* ptr, MatrixLayout layout) {
+  return {ptr, layout.ld, layout.offsets, layout.idxs, layout.group_idxs};
 }
 
 #if 0
@@ -59,43 +57,40 @@ __inline__ __device__ MatrixData resolve(const MatrixParam& param, int gemm_id)
 }
 #endif
 
-template<class T, Striding mode>
-__inline__ __device__ MatrixData resolve(const MatrixParam& param, int g)
-{
-    StridedPtr ptr{param.ptr, param.stride};
-    const int* idxs{};
-    if constexpr (mode == Striding::kFlat) {
-        // pass
+template <class T, Striding mode>
+__inline__ __device__ MatrixData resolve(const MatrixParam& param, int g) {
+  StridedPtr ptr{param.ptr, param.stride};
+  const int* idxs{};
+  if constexpr (mode == Striding::kFlat) {
+    // pass
+  } else if constexpr (mode == Striding::kBlocked) {
+    const int ptr_group = param.group_idxs ? __ldg(param.group_idxs + g) : g;
+    if (ptr.stride == 0) {
+      (uint4&)ptr = __ldg((const uint4*)param.ptr + ptr_group);
+    }  // Post-condition: ptr.stride != 0
+    if (param.offsets) {
+      ptr.ptr = (char*)ptr.ptr + __ldg(param.offsets + g) * (size_t)ptr.stride *
+                                     bitsof<T> / bitsof<char>;
     }
-    else if constexpr (mode == Striding::kBlocked) {
-        const int ptr_group = param.group_idxs ? __ldg(param.group_idxs + g) : g;
-        if (ptr.stride == 0) {
-            (uint4&)ptr = __ldg((const uint4*)param.ptr + ptr_group);
-        }  // Post-condition: ptr.stride != 0
-        if (param.offsets) {
-            ptr.ptr = (char*)ptr.ptr + __ldg(param.offsets + g) * (size_t)ptr.stride * bitsof<T> / bitsof<char>;
-        }
+  } else if constexpr (mode == Striding::kIndexed) {
+    idxs = param.idxs;
+    if (ptr.stride == 0) {
+      (uint4&)ptr = __ldg((const uint4*)param.ptr + g);
+      idxs = idxs ? ((int**)idxs)[g] : nullptr;
+    }  // Post-condition: ptr.stride != 0
+    if (param.offsets) {
+      const int offset = __ldg(param.offsets + g);
+      if (idxs) {
+        idxs += offset;
+      } else {
+        ptr.ptr = (char*)ptr.ptr +
+                  offset * (size_t)ptr.stride * bitsof<T> / bitsof<char>;
+      }
     }
-    else if constexpr (mode == Striding::kIndexed) {
-        idxs = param.idxs;
-        if (ptr.stride == 0) {
-            (uint4&)ptr = __ldg((const uint4*)param.ptr + g);
-            idxs        = idxs ? ((int**)idxs)[g] : nullptr;
-        }  // Post-condition: ptr.stride != 0
-        if (param.offsets) {
-            const int offset = __ldg(param.offsets + g);
-            if (idxs) {
-                idxs += offset;
-            }
-            else {
-                ptr.ptr = (char*)ptr.ptr + offset * (size_t)ptr.stride * bitsof<T> / bitsof<char>;
-            }
-        }
-    }
-    else {
-        static_assert(mode != mode, "Not implemented.");
-    }
-    return {ptr, idxs};
+  } else {
+    static_assert(mode != mode, "Not implemented.");
+  }
+  return {ptr, idxs};
 }
 
 // p <- dat_ptrs[g]

--- a/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/moe_utils_v2.h
+++ b/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/moe_utils_v2.h
@@ -10,55 +10,36 @@
 namespace turbomind {
 
 constexpr int kMoeGateMaxTiles = 16;
-constexpr int kMoeGateVecSize  = 4;
+constexpr int kMoeGateVecSize = 4;
 
-void invokeMoeGate_V2(int*         f2n,
-                      int*         f2E,
-                      int*         en2f,
-                      int*         offsets,
-                      float*       scales,
-                      void*        masks,
-                      int*         accum,
-                      const float* logits,
-                      int          tokens,
-                      int          tokens_padded,
-                      int          experts,
-                      int          exp_per_tok,
-                      bool         softmax,
-                      bool         norm_topk,
-                      float        routed_scale,
-                      cudaStream_t st);
+void invokeMoeGate_V2(int* f2n, int* f2E, int* en2f, int* offsets,
+                      float* scales, void* masks, int* accum,
+                      const float* logits, int tokens, int tokens_padded,
+                      int experts, int exp_per_tok, bool softmax,
+                      bool norm_topk, float routed_scale, cudaStream_t st);
 
-void invokeMoeDispatch(Ref<Tensor>   out_,  //
-                       const Tensor& src,
-                       const int*    f2n,
-                       int           expert_per_token,
-                       cudaStream_t  st);
+void invokeMoeDispatch(Ref<Tensor> out_,  //
+                       const Tensor& src, const int* f2n, int expert_per_token,
+                       cudaStream_t st);
 
-void invokeMoeDispatchScales(Ref<Tensor>   out_,  //
-                             const Tensor& src,
-                             const int*    f2n,
-                             int           expert_per_token,
-                             cudaStream_t  st);
+void invokeMoeDispatchScales(Ref<Tensor> out_,  //
+                             const Tensor& src, const int* f2n,
+                             int expert_per_token, cudaStream_t st);
 
-void invokeMoeCombine(Ref<Tensor>   out_,
-                      const Tensor& src,
-                      const Tensor& bias,
-                      const float*  scales,
-                      const int*    en2f,
-                      const int*    f2E,
-                      const float*  dst_scales,
-                      int           experts_per_token,
-                      float         bscale,
-                      float         dst_scale,
-                      cudaStream_t  st);
+void invokeMoeCombine(Ref<Tensor> out_, const Tensor& src, const Tensor& bias,
+                      const float* scales, const int* en2f, const int* f2E,
+                      const float* dst_scales, int experts_per_token,
+                      float bscale, float dst_scale, cudaStream_t st);
 
-void invokeMoeSoftmaxMaskTopKGroups(
-    float* logits, int token_num, int expert_num, int group_size, int top_k, cudaStream_t st);
+void invokeMoeSoftmaxMaskTopKGroups(float* logits, int token_num,
+                                    int expert_num, int group_size, int top_k,
+                                    cudaStream_t st);
 
 // Sample `e` from `E` experts uniformly for every token
-std::vector<int> SampleUniform(int token_num, int expert_num, int exp_per_tok, std::mt19937& g);
+std::vector<int> SampleUniform(int token_num, int expert_num, int exp_per_tok,
+                               std::mt19937& g);
 
-std::vector<int> SampleBalanced(int token_num, int expert_num, int exp_per_tok, std::mt19937& g);
+std::vector<int> SampleBalanced(int token_num, int expert_num, int exp_per_tok,
+                                std::mt19937& g);
 
 }  // namespace turbomind

--- a/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/operand.h
+++ b/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/operand.h
@@ -12,55 +12,51 @@
 namespace turbomind::gemm {
 
 struct VoidOperand {
-    using Dtype = int;
+  using Dtype = int;
 
-    static constexpr Pack  kPack  = 0;
-    static constexpr Order kOrder = Order::kColMajor;
+  static constexpr Pack kPack = 0;
+  static constexpr Order kOrder = Order::kColMajor;
 
-    struct GetSmemLayout {
-        static constexpr SmemLayoutV2<1, 1> apply(...)
-        {
-            return {};
-        }
-    };
+  struct GetSmemLayout {
+    static constexpr SmemLayoutV2<1, 1> apply(...) { return {}; }
+  };
 
-    using SmemCopyAtom = VoidSmemCopyAtom;
+  using SmemCopyAtom = VoidSmemCopyAtom;
 
-    struct GetGmemIter {
-        static constexpr auto apply(...)
-        {
-            return type_c<VoidGmemIter>;
-        }
-    };
+  struct GetGmemIter {
+    static constexpr auto apply(...) { return type_c<VoidGmemIter>; }
+  };
 };
 
 /// TODO: fix AlignC, AlignS
 /// TODO: fix GroupSize
-template<class Operand, class Iterator, int M, int K, int WARPS, int GroupSize = 1>
+template <class Operand, class Iterator, int M, int K, int WARPS,
+          int GroupSize = 1>
 struct MakeOperand {
+  using Dtype = typename Operand::Dtype;
 
-    using Dtype = typename Operand::Dtype;
+  static constexpr Pack kPack = Operand::kPack;
+  static constexpr Order kOrder = Operand::kOrder;
+  static constexpr int kGroupSize = GroupSize;
 
-    static constexpr Pack  kPack      = Operand::kPack;
-    static constexpr Order kOrder     = Operand::kOrder;
-    static constexpr int   kGroupSize = GroupSize;
+  static constexpr int2 kPackMK =
+      Packing_v2<kPack, kOrder>::apply({M, ceil_div(K, kGroupSize)});
 
-    static constexpr int2 kPackMK = Packing_v2<kPack, kOrder>::apply({M, ceil_div(K, kGroupSize)});
+  static constexpr pair<kPackMK.x, kPackMK.y> kShapeMK{};
 
-    static constexpr pair<kPackMK.x, kPackMK.y> kShapeMK{};
+  using SmemLayout = decltype(Operand::GetSmemLayout::apply(kShapeMK));
+  using SmemAccessor = SmemAccessorV2<Dtype, SmemLayout, kOrder>;
 
-    using SmemLayout   = decltype(Operand::GetSmemLayout::apply(kShapeMK));
-    using SmemAccessor = SmemAccessorV2<Dtype, SmemLayout, kOrder>;
+  using GmemIter = typename decltype(Operand::GetGmemIter::apply(
+      type_c<Operand>, type_c<Iterator>, type_c<SmemLayout>, kShapeMK,
+      constant<WARPS>{}))::type;
 
-    using GmemIter = typename decltype(Operand::GetGmemIter::apply(
-        type_c<Operand>, type_c<Iterator>, type_c<SmemLayout>, kShapeMK, constant<WARPS>{}))::type;
-
-    using SmemCopyAtom = typename Operand::SmemCopyAtom;
+  using SmemCopyAtom = typename Operand::SmemCopyAtom;
 };
 
 // CPO for getting specific operand templates
-template<MMA_Tag mma, Op_Tag optag, class T, Order order, bool is_pack, class SFINAE = void>
-struct GetOperand: std::false_type {
-};
+template <MMA_Tag mma, Op_Tag optag, class T, Order order, bool is_pack,
+          class SFINAE = void>
+struct GetOperand : std::false_type {};
 
 }  // namespace turbomind::gemm

--- a/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/predicate.h
+++ b/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/predicate.h
@@ -7,49 +7,39 @@
 
 namespace turbomind::gemm {
 
-template<int S, int C, bool AlignedS, bool AlignedC>
+template <int S, int C, bool AlignedS, bool AlignedC>
 struct Predicate {
+  static constexpr int kSizeC = AlignedC ? 1 : C;
 
-    static constexpr int kSizeC = AlignedC ? 1 : C;
+  static_assert(S * kSizeC <= 32);
 
-    static_assert(S * kSizeC <= 32);
+  static constexpr bool is_active = true;
 
-    static constexpr bool is_active = true;
+  uint32_t pred_{};
 
-    uint32_t pred_{};
+  __device__ int operator()(int s, int c) const {
+    return (pred_ & (1 << (s * kSizeC + c))) != 0;
+  }
 
-    __device__ int operator()(int s, int c) const
-    {
-        return (pred_ & (1 << (s * kSizeC + c))) != 0;
-    }
+  __device__ void set(int s, int c) { pred_ |= (1 << (s * kSizeC + c)); }
 
-    __device__ void set(int s, int c)
-    {
-        pred_ |= (1 << (s * kSizeC + c));
-    }
-
-    __device__ void clear()
-    {
-        pred_ = 0;
-    }
+  __device__ void clear() { pred_ = 0; }
 };
 
-template<int S, int C>
+template <int S, int C>
 struct Predicate<S, C, true, true> {
+  static constexpr bool is_active = false;
 
-    static constexpr bool is_active = false;
+  __device__ constexpr std::integral_constant<int, 1> operator()(int,
+                                                                 int) const {
+    return {};
+  }
 
-    __device__ constexpr std::integral_constant<int, 1> operator()(int, int) const
-    {
-        return {};
-    }
+  __device__ void set(int, int) {}
 
-    __device__ void set(int, int) {}
-
-    __device__ void clear()
-    {
-        // pred_ = 0;
-    }
+  __device__ void clear() {
+    // pred_ = 0;
+  }
 };
 
 }  // namespace turbomind::gemm

--- a/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/registry.h
+++ b/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/registry.h
@@ -8,49 +8,45 @@
 namespace turbomind::gemm {
 
 class Registry {
-public:
-    explicit Registry(std::shared_ptr<cudaDeviceProp> device_prop);
+ public:
+  explicit Registry(std::shared_ptr<cudaDeviceProp> device_prop);
 
-    /// TODO: remove this
-    template<class Config>
-    [[maybe_unused]] bool Add()
-    {
-        return Add(std::make_unique<KernelImpl<typename Config::Kernel>>());
-    }
+  /// TODO: remove this
+  template <class Config>
+  [[maybe_unused]] bool Add() {
+    return Add(std::make_unique<KernelImpl<typename Config::Kernel>>());
+  }
 
-    [[nodiscard]] const std::vector<Kernel*>& kernels() const
-    {
-        return ptrs_;
-    }
+  [[nodiscard]] const std::vector<Kernel*>& kernels() const { return ptrs_; }
 
-private:
-    bool Add(std::unique_ptr<Kernel> kernel);
+ private:
+  bool Add(std::unique_ptr<Kernel> kernel);
 
-    void sm90_16816_4();
-    void sm90_16816_8();
-    void sm90_16816_16();
+  void sm90_16816_4();
+  void sm90_16816_8();
+  void sm90_16816_16();
 
-    void sm80_16816_4();
-    void sm80_16816_8();
-    void sm80_16816_16();
+  void sm80_16816_4();
+  void sm80_16816_8();
+  void sm80_16816_16();
 
-    void sm75_16816_4();
-    void sm75_16816_8();
-    void sm75_16816_16();
+  void sm75_16816_4();
+  void sm75_16816_8();
+  void sm75_16816_16();
 
-    void sm70_884_4();
-    void sm70_884_8();
-    void sm70_884_16();
+  void sm70_884_4();
+  void sm70_884_8();
+  void sm70_884_16();
 
-    void sm90_64n32_8();
+  void sm90_64n32_8();
 
-    void cublas_float();
+  void cublas_float();
 
-private:
-    std::shared_ptr<cudaDeviceProp>      device_prop_;
-    int                                  arch_;
-    std::vector<std::unique_ptr<Kernel>> kernels_;
-    std::vector<Kernel*>                 ptrs_;
+ private:
+  std::shared_ptr<cudaDeviceProp> device_prop_;
+  int arch_;
+  std::vector<std::unique_ptr<Kernel>> kernels_;
+  std::vector<Kernel*> ptrs_;
 };
 
 }  // namespace turbomind::gemm

--- a/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/scaled_gmma_fp8_sm90.h
+++ b/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/scaled_gmma_fp8_sm90.h
@@ -12,259 +12,237 @@
 
 namespace turbomind::gemm {
 
-template<int TILE_M, int TILE_N, int TILE_K, int BATCH_M, int BATCH_N, int PIPE_M, int PIPE_N>
+template <int TILE_M, int TILE_N, int TILE_K, int BATCH_M, int BATCH_N,
+          int PIPE_M, int PIPE_N>
 struct ScaledGmmaFP8_TN {
+  static constexpr auto select_gmma_operation() {
+    static_assert(TILE_M % (BATCH_M * PIPE_M) == 0);
+    static_assert(TILE_N % (BATCH_N * PIPE_N) == 0);
 
-    static constexpr auto select_gmma_operation()
-    {
-        static_assert(TILE_M % (BATCH_M * PIPE_M) == 0);
-        static_assert(TILE_N % (BATCH_N * PIPE_N) == 0);
+    constexpr int M = TILE_M / (BATCH_M * PIPE_M);
+    constexpr int N = TILE_N / (BATCH_N * PIPE_N);
 
-        constexpr int M = TILE_M / (BATCH_M * PIPE_M);
-        constexpr int N = TILE_N / (BATCH_N * PIPE_N);
+    static_assert(M % 64 == 0);
 
-        static_assert(M % 64 == 0);
+    using namespace cute::SM90::GMMA;
 
-        using namespace cute::SM90::GMMA;
-
-        if constexpr (N % 256 == 0) {
-            return type_c<MMA_64x256x32_F32E4M3E4M3_SS_TN<>>;
-        }
-        else if constexpr (N % 224 == 0) {
-            return type_c<MMA_64x224x32_F32E4M3E4M3_SS_TN<>>;
-        }
-        else if constexpr (N % 192 == 0) {
-            return type_c<MMA_64x192x32_F32E4M3E4M3_SS_TN<>>;
-        }
-        else if constexpr (N % 160 == 0) {
-            return type_c<MMA_64x160x32_F32E4M3E4M3_SS_TN<>>;
-        }
-        else if constexpr (N % 128 == 0) {
-            return type_c<MMA_64x128x32_F32E4M3E4M3_SS_TN<>>;
-        }
-        else if constexpr (N % 96 == 0) {
-            return type_c<MMA_64x96x32_F32E4M3E4M3_SS_TN<>>;
-        }
-        else if constexpr (N % 64 == 0) {
-            return type_c<MMA_64x64x32_F32E4M3E4M3_SS_TN<>>;
-        }
-        else {
-            static_assert(N == 0, "unsupported configuration");
-        }
+    if constexpr (N % 256 == 0) {
+      return type_c<MMA_64x256x32_F32E4M3E4M3_SS_TN<>>;
+    } else if constexpr (N % 224 == 0) {
+      return type_c<MMA_64x224x32_F32E4M3E4M3_SS_TN<>>;
+    } else if constexpr (N % 192 == 0) {
+      return type_c<MMA_64x192x32_F32E4M3E4M3_SS_TN<>>;
+    } else if constexpr (N % 160 == 0) {
+      return type_c<MMA_64x160x32_F32E4M3E4M3_SS_TN<>>;
+    } else if constexpr (N % 128 == 0) {
+      return type_c<MMA_64x128x32_F32E4M3E4M3_SS_TN<>>;
+    } else if constexpr (N % 96 == 0) {
+      return type_c<MMA_64x96x32_F32E4M3E4M3_SS_TN<>>;
+    } else if constexpr (N % 64 == 0) {
+      return type_c<MMA_64x64x32_F32E4M3E4M3_SS_TN<>>;
+    } else {
+      static_assert(N == 0, "unsupported configuration");
     }
+  }
 
-    using Operation = typename decltype(select_gmma_operation())::type;
+  using Operation = typename decltype(select_gmma_operation())::type;
 
-    static constexpr typename cute::MMA_Traits<Operation>::Shape_MNK OP_Shape{};
+  static constexpr typename cute::MMA_Traits<Operation>::Shape_MNK OP_Shape{};
 
-    static constexpr int OP_M = cute::get<0>(OP_Shape);
-    static constexpr int OP_N = cute::get<1>(OP_Shape);
-    static constexpr int OP_K = cute::get<2>(OP_Shape);
+  static constexpr int OP_M = cute::get<0>(OP_Shape);
+  static constexpr int OP_N = cute::get<1>(OP_Shape);
+  static constexpr int OP_K = cute::get<2>(OP_Shape);
 
-    static constexpr int ITER_M = TILE_M / OP_M / BATCH_M / PIPE_M;
-    static constexpr int ITER_N = TILE_N / OP_N / BATCH_N / PIPE_N;
+  static constexpr int ITER_M = TILE_M / OP_M / BATCH_M / PIPE_M;
+  static constexpr int ITER_N = TILE_N / OP_N / BATCH_N / PIPE_N;
 
-    using FragU = float[ITER_M][PIPE_M][BATCH_M][2];
-    using FragV = float[2];
+  using FragU = float[ITER_M][PIPE_M][BATCH_M][2];
+  using FragV = float[2];
 
-    using FragC = typename Operation::CRegisters[PIPE_M][PIPE_N][BATCH_M][BATCH_N];
+  using FragC =
+      typename Operation::CRegisters[PIPE_M][PIPE_N][BATCH_M][BATCH_N];
 
-    using AccumC = FragC[ITER_M][ITER_N];
+  using AccumC = FragC[ITER_M][ITER_N];
 
-    static constexpr int kStepMA = (OP_M * TILE_K) >> 4;
-    static constexpr int kStepNB = (OP_N * TILE_K) >> 4;
-    static constexpr int kStepKA = (OP_K) >> 4;
-    static constexpr int kStepKB = (OP_K) >> 4;
+  static constexpr int kStepMA = (OP_M * TILE_K) >> 4;
+  static constexpr int kStepNB = (OP_N * TILE_K) >> 4;
+  static constexpr int kStepKA = (OP_K) >> 4;
+  static constexpr int kStepKB = (OP_K) >> 4;
 
-    static constexpr int OUTER_N = std::gcd(TILE_N, 128);
+  static constexpr int OUTER_N = std::gcd(TILE_N, 128);
 
-    template<class FragC, class AccumC, class FragU, class FragV, class PredV>
-    __device__ static void scale_batch_to_accum(AccumC&      accum_C,
-                                                const FragC& frag_C,
-                                                const FragU& frag_U,
-                                                const FragV& frag_V,
-                                                const PredV& pred_V,
-                                                int          offset_V)
-    {
+  template <class FragC, class AccumC, class FragU, class FragV, class PredV>
+  __device__ static void scale_batch_to_accum(
+      AccumC& accum_C, const FragC& frag_C, const FragU& frag_U,
+      const FragV& frag_V, const PredV& pred_V, int offset_V) {
+    PRAGMA_UNROLL
+    for (int m = 0; m < BATCH_M; ++m) {
+      float scales[2][2];
+      // TODO: check the compiler's ability to avoid re-computing this
+      scales[0][0] = frag_U[m][0] * frag_V[0];
+      scales[1][0] = frag_U[m][1] * frag_V[0];
+      scales[0][1] = frag_U[m][0] * frag_V[1];
+      scales[1][1] = frag_U[m][1] * frag_V[1];
+      PRAGMA_UNROLL
+      for (int n = 0; n < BATCH_N; ++n) {
         PRAGMA_UNROLL
-        for (int m = 0; m < BATCH_M; ++m) {
-            float scales[2][2];
-            // TODO: check the compiler's ability to avoid re-computing this
-            scales[0][0] = frag_U[m][0] * frag_V[0];
-            scales[1][0] = frag_U[m][1] * frag_V[0];
-            scales[0][1] = frag_U[m][0] * frag_V[1];
-            scales[1][1] = frag_U[m][1] * frag_V[1];
-            PRAGMA_UNROLL
-            for (int n = 0; n < BATCH_N; ++n) {
-                PRAGMA_UNROLL
-                for (int c0 = 0; c0 < OP_N; c0 += OUTER_N) {
-                    int  i = (offset_V + c0) / OUTER_N;
-                    bool p = pred_V[i];
-                    PRAGMA_UNROLL
-                    for (int c1 = 0; c1 < OUTER_N; c1 += 8) {
-                        int c = c0 + c1;
-                        accum_C[m][n][c / 2 + 0] += (p ? scales[0][1] : scales[0][0]) * frag_C[m][n][c / 2 + 0];
-                        accum_C[m][n][c / 2 + 1] += (p ? scales[0][1] : scales[0][0]) * frag_C[m][n][c / 2 + 1];
-                        accum_C[m][n][c / 2 + 2] += (p ? scales[1][1] : scales[1][0]) * frag_C[m][n][c / 2 + 2];
-                        accum_C[m][n][c / 2 + 3] += (p ? scales[1][1] : scales[1][0]) * frag_C[m][n][c / 2 + 3];
-                    }
-                }
-            }
+        for (int c0 = 0; c0 < OP_N; c0 += OUTER_N) {
+          int i = (offset_V + c0) / OUTER_N;
+          bool p = pred_V[i];
+          PRAGMA_UNROLL
+          for (int c1 = 0; c1 < OUTER_N; c1 += 8) {
+            int c = c0 + c1;
+            accum_C[m][n][c / 2 + 0] +=
+                (p ? scales[0][1] : scales[0][0]) * frag_C[m][n][c / 2 + 0];
+            accum_C[m][n][c / 2 + 1] +=
+                (p ? scales[0][1] : scales[0][0]) * frag_C[m][n][c / 2 + 1];
+            accum_C[m][n][c / 2 + 2] +=
+                (p ? scales[1][1] : scales[1][0]) * frag_C[m][n][c / 2 + 2];
+            accum_C[m][n][c / 2 + 3] +=
+                (p ? scales[1][1] : scales[1][0]) * frag_C[m][n][c / 2 + 3];
+          }
         }
+      }
     }
+  }
 
-    __device__ static void warpgroup_wait(int n)
-    {
-        if (n == 0) {
-            cute::warpgroup_wait<0>();
-        }
-        else if (n == 1) {
-            cute::warpgroup_wait<1>();
-        }
-        else if (n == 2) {
-            cute::warpgroup_wait<2>();
-        }
-        else if (n == 3) {
-            cute::warpgroup_wait<3>();
-        }
-        else if (n == 4) {
-            cute::warpgroup_wait<4>();
-        }
-        else if (n == 5) {
-            cute::warpgroup_wait<5>();
-        }
-        else if (n == 6) {
-            cute::warpgroup_wait<6>();
-        }
-        else if (n == 7) {
-            cute::warpgroup_wait<7>();
-        }
+  __device__ static void warpgroup_wait(int n) {
+    if (n == 0) {
+      cute::warpgroup_wait<0>();
+    } else if (n == 1) {
+      cute::warpgroup_wait<1>();
+    } else if (n == 2) {
+      cute::warpgroup_wait<2>();
+    } else if (n == 3) {
+      cute::warpgroup_wait<3>();
+    } else if (n == 4) {
+      cute::warpgroup_wait<4>();
+    } else if (n == 5) {
+      cute::warpgroup_wait<5>();
+    } else if (n == 6) {
+      cute::warpgroup_wait<6>();
+    } else if (n == 7) {
+      cute::warpgroup_wait<7>();
     }
+  }
 
-    template<class SmemIterA, class SmemIterB, class FragC>
-    __device__ static void gmma_batch(SmemIterA& iter_A, SmemIterB& iter_B, FragC& frag_C)
-    {
-        constexpr int BATCH_K = TILE_K / OP_K;
+  template <class SmemIterA, class SmemIterB, class FragC>
+  __device__ static void gmma_batch(SmemIterA& iter_A, SmemIterB& iter_B,
+                                    FragC& frag_C) {
+    constexpr int BATCH_K = TILE_K / OP_K;
+    PRAGMA_UNROLL
+    for (int k = 0; k < BATCH_K; ++k) {
+      PRAGMA_UNROLL
+      for (int m = 0; m < BATCH_M; ++m) {
         PRAGMA_UNROLL
-        for (int k = 0; k < BATCH_K; ++k) {
-            PRAGMA_UNROLL
-            for (int m = 0; m < BATCH_M; ++m) {
-                PRAGMA_UNROLL
-                for (int n = 0; n < BATCH_N; ++n) {
-                    wgmma<Operation>(iter_A, iter_B, frag_C[m][n], k == 0);
-                    iter_B += kStepNB;
-                }
-                iter_B -= kStepNB * BATCH_N;
-                iter_A += kStepMA;
-            }
-            iter_A -= kStepMA * BATCH_M;
-            iter_A += kStepKA;
-            iter_B += kStepKB;
+        for (int n = 0; n < BATCH_N; ++n) {
+          wgmma<Operation>(iter_A, iter_B, frag_C[m][n], k == 0);
+          iter_B += kStepNB;
         }
-        iter_A -= kStepKA * BATCH_K;
-        iter_B -= kStepKB * BATCH_K;
-        cute::warpgroup_commit_batch();
+        iter_B -= kStepNB * BATCH_N;
+        iter_A += kStepMA;
+      }
+      iter_A -= kStepMA * BATCH_M;
+      iter_A += kStepKA;
+      iter_B += kStepKB;
     }
+    iter_A -= kStepKA * BATCH_K;
+    iter_B -= kStepKB * BATCH_K;
+    cute::warpgroup_commit_batch();
+  }
 
-    template<class SmemIterA, class SmemIterB, class FragC, class AccumC, class FragU, class FragV, class PredV>
-    __device__ static void gmma_pipe(AccumC&      accum_C,
-                                     SmemIterA&   iter_A,
-                                     SmemIterB&   iter_B,
-                                     FragC&       frag_C,
-                                     const FragU& frag_U,
-                                     const FragV& frag_V,
-                                     const PredV& pred_V,
-                                     int          offset_V)
-    {
-        cute::warpgroup_arrive();
+  template <class SmemIterA, class SmemIterB, class FragC, class AccumC,
+            class FragU, class FragV, class PredV>
+  __device__ static void gmma_pipe(AccumC& accum_C, SmemIterA& iter_A,
+                                   SmemIterB& iter_B, FragC& frag_C,
+                                   const FragU& frag_U, const FragV& frag_V,
+                                   const PredV& pred_V, int offset_V) {
+    cute::warpgroup_arrive();
+    PRAGMA_UNROLL
+    for (int m = 0; m < PIPE_M; ++m) {
+      PRAGMA_UNROLL
+      for (int n = 0; n < PIPE_N; ++n) {
+        gmma_batch(iter_A, iter_B, frag_C[m][n]);
+        iter_B += kStepNB * BATCH_N;
+      }
+      iter_B -= kStepNB * BATCH_N * PIPE_N;
+      iter_A += kStepMA * BATCH_M;
+    }
+    iter_A -= kStepMA * BATCH_M * PIPE_M;
+
+    int i = 0;
+    PRAGMA_UNROLL
+    for (int m = 0; m < PIPE_M; ++m) {
+      PRAGMA_UNROLL
+      for (int n = 0; n < PIPE_N; ++n, ++i) {
+        warpgroup_wait(PIPE_M * PIPE_N - i - 1);
+        int offset = offset_V + n * BATCH_N * OP_N;
+        scale_batch_to_accum(accum_C[m][n], frag_C[m][n], frag_U[m], frag_V,
+                             pred_V, offset);
+      }
+    }
+  }
+
+  template <class SmemIterA, class SmemIterB, class FragC, class AccumC,
+            class FragU, class FragV, class PredV>
+  __device__ static void apply(SmemIterA& iter_A, SmemIterB& iter_B,
+                               FragC& frag_C, AccumC& accum_C,
+                               const FragU& frag_U, const FragV& frag_V,
+                               const PredV& pred_V) {
+    PRAGMA_UNROLL
+    for (int m = 0; m < ITER_M; ++m) {
+      PRAGMA_UNROLL
+      for (int n = 0; n < ITER_N; ++n) {
+        int offset_V = n * PIPE_N * BATCH_N * OP_N;
+        gmma_pipe(accum_C[m][n], iter_A, iter_B, frag_C, frag_U[m], frag_V,
+                  pred_V, offset_V);
+        iter_B += kStepNB * BATCH_N * PIPE_N;
+      }
+      iter_B -= kStepNB * BATCH_N * PIPE_N * ITER_N;
+      iter_A += kStepMA * BATCH_M * PIPE_M;
+    }
+    iter_A -= kStepMA * BATCH_M * PIPE_M * ITER_M;
+  }
+
+  template <class Frag, class Func>
+  __device__ static void foreach_C(Frag& frag, Func&& func) {
+    PRAGMA_UNROLL
+    for (int i_m = 0; i_m < ITER_M; ++i_m) {
+      PRAGMA_UNROLL
+      for (int i_n = 0; i_n < ITER_N; ++i_n) {
         PRAGMA_UNROLL
-        for (int m = 0; m < PIPE_M; ++m) {
+        for (int p_m = 0; p_m < PIPE_M; ++p_m) {
+          PRAGMA_UNROLL
+          for (int p_n = 0; p_n < PIPE_N; ++p_n) {
             PRAGMA_UNROLL
-            for (int n = 0; n < PIPE_N; ++n) {
-                gmma_batch(iter_A, iter_B, frag_C[m][n]);
-                iter_B += kStepNB * BATCH_N;
-            }
-            iter_B -= kStepNB * BATCH_N * PIPE_N;
-            iter_A += kStepMA * BATCH_M;
+            for (int b_m = 0; b_m < BATCH_M; ++b_m) {
+              PRAGMA_UNROLL
+              for (int b_n = 0; b_n < BATCH_N; ++b_n) {
+                int m = ((i_m * PIPE_M) + p_m * BATCH_M) + b_m;
+                int n = ((i_n * PIPE_N) + p_n * BATCH_N) + b_n;
+                func(frag[i_m][i_n][p_m][p_n][b_m][b_n], m, n);
+              }  // BATCH_N
+            }  // BATCH_M
+          }  // PIPE_N
+        }  // PIPE_M
+      }  // ITER_N
+    }  // ITER_M
+  }
+
+  template <class Frag, class Func>
+  __device__ static void foreach_m(Frag& frag, Func&& func) {
+    PRAGMA_UNROLL
+    for (int i_m = 0; i_m < ITER_M; ++i_m) {
+      PRAGMA_UNROLL
+      for (int p_m = 0; p_m < PIPE_M; ++p_m) {
+        PRAGMA_UNROLL
+        for (int b_m = 0; b_m < BATCH_M; ++b_m) {
+          int m = ((i_m * PIPE_M) + p_m * BATCH_M) + b_m;
+          func(frag[i_m][p_m][b_m], m);
         }
-        iter_A -= kStepMA * BATCH_M * PIPE_M;
-
-        int i = 0;
-        PRAGMA_UNROLL
-        for (int m = 0; m < PIPE_M; ++m) {
-            PRAGMA_UNROLL
-            for (int n = 0; n < PIPE_N; ++n, ++i) {
-                warpgroup_wait(PIPE_M * PIPE_N - i - 1);
-                int offset = offset_V + n * BATCH_N * OP_N;
-                scale_batch_to_accum(accum_C[m][n], frag_C[m][n], frag_U[m], frag_V, pred_V, offset);
-            }
-        }
+      }
     }
-
-    template<class SmemIterA, class SmemIterB, class FragC, class AccumC, class FragU, class FragV, class PredV>
-    __device__ static void apply(SmemIterA&   iter_A,
-                                 SmemIterB&   iter_B,
-                                 FragC&       frag_C,
-                                 AccumC&      accum_C,
-                                 const FragU& frag_U,
-                                 const FragV& frag_V,
-                                 const PredV& pred_V)
-    {
-        PRAGMA_UNROLL
-        for (int m = 0; m < ITER_M; ++m) {
-            PRAGMA_UNROLL
-            for (int n = 0; n < ITER_N; ++n) {
-                int offset_V = n * PIPE_N * BATCH_N * OP_N;
-                gmma_pipe(accum_C[m][n], iter_A, iter_B, frag_C, frag_U[m], frag_V, pred_V, offset_V);
-                iter_B += kStepNB * BATCH_N * PIPE_N;
-            }
-            iter_B -= kStepNB * BATCH_N * PIPE_N * ITER_N;
-            iter_A += kStepMA * BATCH_M * PIPE_M;
-        }
-        iter_A -= kStepMA * BATCH_M * PIPE_M * ITER_M;
-    }
-
-    template<class Frag, class Func>
-    __device__ static void foreach_C(Frag& frag, Func&& func)
-    {
-        PRAGMA_UNROLL
-        for (int i_m = 0; i_m < ITER_M; ++i_m) {
-            PRAGMA_UNROLL
-            for (int i_n = 0; i_n < ITER_N; ++i_n) {
-                PRAGMA_UNROLL
-                for (int p_m = 0; p_m < PIPE_M; ++p_m) {
-                    PRAGMA_UNROLL
-                    for (int p_n = 0; p_n < PIPE_N; ++p_n) {
-                        PRAGMA_UNROLL
-                        for (int b_m = 0; b_m < BATCH_M; ++b_m) {
-                            PRAGMA_UNROLL
-                            for (int b_n = 0; b_n < BATCH_N; ++b_n) {
-                                int m = ((i_m * PIPE_M) + p_m * BATCH_M) + b_m;
-                                int n = ((i_n * PIPE_N) + p_n * BATCH_N) + b_n;
-                                func(frag[i_m][i_n][p_m][p_n][b_m][b_n], m, n);
-                            }  // BATCH_N
-                        }      // BATCH_M
-                    }          // PIPE_N
-                }              // PIPE_M
-            }                  // ITER_N
-        }                      // ITER_M
-    }
-
-    template<class Frag, class Func>
-    __device__ static void foreach_m(Frag& frag, Func&& func)
-    {
-        PRAGMA_UNROLL
-        for (int i_m = 0; i_m < ITER_M; ++i_m) {
-            PRAGMA_UNROLL
-            for (int p_m = 0; p_m < PIPE_M; ++p_m) {
-                PRAGMA_UNROLL
-                for (int b_m = 0; b_m < BATCH_M; ++b_m) {
-                    int m = ((i_m * PIPE_M) + p_m * BATCH_M) + b_m;
-                    func(frag[i_m][p_m][b_m], m);
-                }
-            }
-        }
-    }
+  }
 };
 
 }  // namespace turbomind::gemm

--- a/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/scheduler.cuh
+++ b/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/scheduler.cuh
@@ -16,491 +16,455 @@
 
 namespace turbomind::gemm {
 
-TM_DEVICE void mbarrier_arrive_cluster(uint64_t* mbar, int cta_id, int pred)
-{
-    uint32_t smem_addr = cast_smem_ptr_to_uint(mbar);
-    if (pred) {
-        asm volatile("{\n"
-                     ".reg .b32 remAddr32;\n"
-                     "mapa.shared::cluster.u32  remAddr32, %0, %1;\n"
-                     "mbarrier.arrive.release.cluster.shared::cluster.b64  _, [remAddr32];\n"
-                     "}"
-                     :
-                     : "r"(smem_addr), "r"(cta_id));
-    }
+TM_DEVICE void mbarrier_arrive_cluster(uint64_t* mbar, int cta_id, int pred) {
+  uint32_t smem_addr = cast_smem_ptr_to_uint(mbar);
+  if (pred) {
+    asm volatile(
+        "{\n"
+        ".reg .b32 remAddr32;\n"
+        "mapa.shared::cluster.u32  remAddr32, %0, %1;\n"
+        "mbarrier.arrive.release.cluster.shared::cluster.b64  _, [remAddr32];\n"
+        "}"
+        :
+        : "r"(smem_addr), "r"(cta_id));
+  }
 }
 
-TM_DEVICE void mbarrier_wait_cluster(uint64_t* mbar, uint32_t phase)
-{
-    uint32_t smem_addr = cast_smem_ptr_to_uint(mbar);
-    uint32_t ticks     = 0x989680;
-    asm volatile("{\n"
-                 ".reg .pred       P1; \n"
-                 "LAB_WAIT: \n"
-                 "mbarrier.try_wait.parity.acquire.cluster.shared::cta.b64 P1, [%0], %1, %2; \n"
-                 "@P1 bra DONE; \n"
-                 "bra     LAB_WAIT; \n"
-                 "DONE: \n"
-                 "}"
-                 :
-                 : "r"(smem_addr), "r"(phase), "r"(ticks));
+TM_DEVICE void mbarrier_wait_cluster(uint64_t* mbar, uint32_t phase) {
+  uint32_t smem_addr = cast_smem_ptr_to_uint(mbar);
+  uint32_t ticks = 0x989680;
+  asm volatile(
+      "{\n"
+      ".reg .pred       P1; \n"
+      "LAB_WAIT: \n"
+      "mbarrier.try_wait.parity.acquire.cluster.shared::cta.b64 P1, [%0], %1, "
+      "%2; \n"
+      "@P1 bra DONE; \n"
+      "bra     LAB_WAIT; \n"
+      "DONE: \n"
+      "}"
+      :
+      : "r"(smem_addr), "r"(phase), "r"(ticks));
 }
 
-TM_DEVICE void* map_to_cta(void* ptr, int cta_id)
-{
-    void* ret;
-    asm volatile("mapa.u64 %0, %1, %2;\n" : "=l"(ret) : "l"(ptr), "r"(cta_id));
-    return ret;
+TM_DEVICE void* map_to_cta(void* ptr, int cta_id) {
+  void* ret;
+  asm volatile("mapa.u64 %0, %1, %2;\n" : "=l"(ret) : "l"(ptr), "r"(cta_id));
+  return ret;
 }
 
-TM_DEVICE void st_shared_cluster(uint32_t ptr, int value)
-{
-    asm volatile("st.shared::cluster.s32 [%0], %1;\n" ::"r"(ptr), "r"(value));
+TM_DEVICE void st_shared_cluster(uint32_t ptr, int value) {
+  asm volatile("st.shared::cluster.s32 [%0], %1;\n" ::"r"(ptr), "r"(value));
 }
 
-template<class T, class M>
-constexpr int member_offset(M T::*member)
-{
-    return reinterpret_cast<std::size_t>(&(reinterpret_cast<T*>(0)->*member));
+template <class T, class M>
+constexpr int member_offset(M T::* member) {
+  return reinterpret_cast<std::size_t>(&(reinterpret_cast<T*>(0)->*member));
 }
 
-template<Order order,
-         class Cluster,
-         int  striped_m,
-         bool striped_n,
-         int  tile_m,
-         int  tile_n,
-         int  Stages_,
-         bool is_grouped_gemm>
+template <Order order, class Cluster, int striped_m, bool striped_n, int tile_m,
+          int tile_n, int Stages_, bool is_grouped_gemm>
 struct TileScheduler {
+  static constexpr bool is_dynamic = 1;  // is_grouped_gemm;
+  static constexpr int Stages = Stages_;
 
-    static constexpr bool is_dynamic = 1;  // is_grouped_gemm;
-    static constexpr int  Stages     = Stages_;
+  static constexpr int2 tile_{tile_m, tile_n};
+  static constexpr int2 cluster_tile_{tile_m * Cluster::M, tile_n* Cluster::N};
 
-    static constexpr int2 tile_{tile_m, tile_n};
-    static constexpr int2 cluster_tile_{tile_m * Cluster::M, tile_n* Cluster::N};
+  int4 gemm_shape_;
+  int2 tiled_shape_;
 
-    int4 gemm_shape_;
-    int2 tiled_shape_;
+  int log_tile_;
+  int k_iters_;
 
-    int log_tile_;
-    int k_iters_;
+  int2 tile_offset_;
+  int2 iter_k_range_;
 
-    int2 tile_offset_;
-    int2 iter_k_range_;
+  int clusters_;
 
-    int clusters_;
+  //////// v2 /////
+  int2 swizzle_unit_;
+  int2 cluster_tiles_;
+  int2 padded_cluster_tiles_;
+  int2 swizzled_cluster_tiles_;
 
-    //////// v2 /////
-    int2 swizzle_unit_;
-    int2 cluster_tiles_;
-    int2 padded_cluster_tiles_;
-    int2 swizzled_cluster_tiles_;
+  cutlass::FastDivmod swizzle_tile_x_;
+  /////////////
 
-    cutlass::FastDivmod swizzle_tile_x_;
-    /////////////
+  const int* offsets_;
 
-    const int* offsets_;
+  int* next_cluster_id_;
 
-    int* next_cluster_id_;
+  using PipelineState = cutlass::PipelineState<Stages>;
 
-    using PipelineState = cutlass::PipelineState<Stages>;
+  struct Tile0 {
+    int is_valid_cta;
+    int is_valid_cluster;
+    int offset_m;
+    int offset_n;
+    int alive;
+  };
 
-    struct Tile0 {
-        int is_valid_cta;
-        int is_valid_cluster;
-        int offset_m;
-        int offset_n;
-        int alive;
+  struct Tile1 {
+    int is_valid_cta;
+    int is_valid_cluster;
+    int offset_m;
+    int offset_n;
+    int alive;
+    int group_idx;
+    int m0;
+    int m1;
+  };
+
+  using Tile = std::conditional_t<is_grouped_gemm, Tile1, Tile0>;
+
+  struct Storage {
+    Tile tile[Stages];
+    __align__(8) uint64_t producer_bar[Stages];
+    __align__(8) uint64_t consumer_bar[Stages];
+  };
+
+  struct ConsumerState {
+    PipelineState pipe;
+    Storage& store;
+    TileScheduler& sched;
+
+    TM_DEVICE bool acquire(Tile*& tile) { return sched.acquire(*this, tile); }
+
+    TM_DEVICE void release(int step = 1) { return sched.release(*this, step); }
+  };
+
+  struct ProducerState {
+    PipelineState pipe;
+    int group_id_offset;
+    int cluster_idx;
+    Storage& store;
+    TileScheduler& sched;
+
+    TM_DEVICE bool next() { return sched.next(*this); }
+  };
+
+ public:
+  TM_DEVICE void init_dynamic(Storage& store, int consumer_num) {
+    for (int i = 0; i < Stages; ++i) {
+      cutlass::arch::ClusterBarrier::init(&store.producer_bar[i], 1);
+      cutlass::arch::ClusterBarrier::init(&store.consumer_bar[i], consumer_num);
+    }
+    // cutlass::arch::ClusterBarrier::init(&store.sync_bar, 1);
+  }
+
+  TM_HOST_DEVICE void init(int4 gemm_shape, int log_tile, int3 tile_shape) {
+    gemm_shape_ = gemm_shape;
+
+    // printf("gemm shape: %d %d %d\n", gemm_shape.x, gemm_shape.y,
+    // gemm_shape.z);
+
+    log_tile_ = log_tile;
+    k_iters_ = cdiv(gemm_shape_.z, tile_shape.z);
+
+    tiled_shape_.x = cdiv(gemm_shape.x, tile_.x);
+    tiled_shape_.y = cdiv(gemm_shape.y, tile_.y);
+
+    cluster_tiles_.x = cdiv(gemm_shape.x, cluster_tile_.x);  // useless
+    cluster_tiles_.y = cdiv(gemm_shape.y, cluster_tile_.y);
+
+    // printf("cluster tiles: %d %d\n", cluster_tiles_.x, cluster_tiles_.y);
+
+    if constexpr (is_grouped_gemm) {
+      {
+        int2 unit = get_swizzled_shape({1, 1}, log_tile);
+        swizzle_unit_ =
+            order == kColMajor ? int2{unit.y, unit.x} : int2{unit.x, unit.y};
+      }
+
+      // col {8, 1}, row {1, 8}
+      // printf("swizzle unit: %d %d\n", swizzle_unit_.x, swizzle_unit_.y);
+
+      swizzle_tile_x_ = cluster_tile_.x * swizzle_unit_.x;
+
+      int num = gemm_shape_.w;
+
+      // num of tiles won't change after swizzle
+      padded_cluster_tiles_.x =
+          (num + gemm_shape.x / (cluster_tile_.x * swizzle_unit_.x)) *
+          swizzle_unit_.x;
+      padded_cluster_tiles_.y =
+          cdiv(gemm_shape.y, cluster_tile_.y * swizzle_unit_.y) *
+          swizzle_unit_.y;
+
+      // printf("padded   cluster tiles: %d %d\n", padded_cluster_tiles_.x,
+      // padded_cluster_tiles_.y);
+
+      swizzled_cluster_tiles_ =
+          get_swizzled_shape(padded_cluster_tiles_, log_tile);
+
+      // printf("swizzled cluster tiles: %d %d\n", swizzled_cluster_tiles_.x,
+      // swizzled_cluster_tiles_.y);
+
+      clusters_ = padded_cluster_tiles_.x * padded_cluster_tiles_.y;
+
+      // printf("clusters = %d\n", clusters_);
+      // M is runtime value
+    } else {
+      tiled_shape_.x = cdiv(gemm_shape.x, tile_.x);
+      tiled_shape_.y = cdiv(gemm_shape.y, tile_.y);
+
+      cluster_tiles_.x = cdiv(gemm_shape.x, cluster_tile_.x);
+      cluster_tiles_.y = cdiv(gemm_shape.y, cluster_tile_.y);
+
+      swizzled_cluster_tiles_ = get_swizzled_shape(cluster_tiles_, log_tile);
+
+      swizzle_tile_x_ = swizzled_cluster_tiles_.x;
+
+      clusters_ = swizzled_cluster_tiles_.x * swizzled_cluster_tiles_.y;
+    }
+  }
+
+  TM_HOST_DEVICE static int get_log_tile(int2 tiled_mn, int tile_size) {
+    return gemm::get_log_tile(order == kColMajor ? tiled_mn.y : tiled_mn.x,
+                              tile_size);
+  }
+
+  TM_HOST_DEVICE static int2 get_swizzled_shape(int2 tiled_shape,
+                                                int log_tile) {
+    const int tile = 1 << log_tile;
+
+    if constexpr (order == kColMajor) {
+      return {tiled_shape.x * tile, (tiled_shape.y + tile - 1) >> log_tile};
+    } else {
+      return {tiled_shape.y * tile, (tiled_shape.x + tile - 1) >> log_tile};
+    }
+  }
+
+  TM_DEVICE ProducerState init_producer(Storage& store) {
+    int cluster_id = 0;
+    if constexpr (!is_dynamic) {
+      cluster_id = (int)cute::cluster_id_in_grid().x;
+    }
+    return {
+        PipelineState{0, 1, 0}, 0, cluster_id, store, *this,
     };
+  }
 
-    struct Tile1 {
-        int is_valid_cta;
-        int is_valid_cluster;
-        int offset_m;
-        int offset_n;
-        int alive;
-        int group_idx;
-        int m0;
-        int m1;
+  TM_DEVICE ConsumerState init_consumer(Storage& store) {
+    return {
+        PipelineState{},
+        store,
+        *this,
     };
+  }
 
-    using Tile = std::conditional_t<is_grouped_gemm, Tile1, Tile0>;
+  TM_DEVICE void unswizzle(Tile& tile, int cluster_idx, int cta_id,
+                           int2 cta_tiles, int2 cluster_tiles,
+                           int2 swizzle_tiles) const {
+    int cluster_idx_x, cluster_idx_y;
 
-    struct Storage {
-        Tile tile[Stages];
-        __align__(8) uint64_t producer_bar[Stages];
-        __align__(8) uint64_t consumer_bar[Stages];
-    };
-
-    struct ConsumerState {
-        PipelineState  pipe;
-        Storage&       store;
-        TileScheduler& sched;
-
-        TM_DEVICE bool acquire(Tile*& tile)
-        {
-            return sched.acquire(*this, tile);
-        }
-
-        TM_DEVICE void release(int step = 1)
-        {
-            return sched.release(*this, step);
-        }
-    };
-
-    struct ProducerState {
-        PipelineState  pipe;
-        int            group_id_offset;
-        int            cluster_idx;
-        Storage&       store;
-        TileScheduler& sched;
-
-        TM_DEVICE bool next()
-        {
-            return sched.next(*this);
-        }
-    };
-
-public:
-    TM_DEVICE void init_dyanmic(Storage& store, int consumer_num)
-    {
-        for (int i = 0; i < Stages; ++i) {
-            cutlass::arch::ClusterBarrier::init(&store.producer_bar[i], 1);
-            cutlass::arch::ClusterBarrier::init(&store.consumer_bar[i], consumer_num);
-        }
-        // cutlass::arch::ClusterBarrier::init(&store.sync_bar, 1);
+    if constexpr (is_grouped_gemm) {
+      cluster_idx_x = cluster_idx % swizzle_tiles.x;
+      cluster_idx_y = cluster_idx / swizzle_tiles.x;
+    } else {
+      swizzle_tile_x_(cluster_idx_y, cluster_idx_x, cluster_idx);
     }
 
-    TM_HOST_DEVICE void init(int4 gemm_shape, int log_tile, int3 tile_shape)
-    {
-        gemm_shape_ = gemm_shape;
+    auto [cluster_cta_m, cluster_cta_n] = Cluster::cta_mn(cta_id);
 
-        // printf("gemm shape: %d %d %d\n", gemm_shape.x, gemm_shape.y, gemm_shape.z);
+    const int offset_x = cluster_cta_m * (striped_m ? cluster_tiles.x : 1);
+    const int offset_y = cluster_cta_n * (striped_n ? cluster_tiles.y : 1);
 
-        log_tile_ = log_tile;
-        k_iters_  = cdiv(gemm_shape_.z, tile_shape.z);
+    int2 cluster_tile_offset;
 
-        tiled_shape_.x = cdiv(gemm_shape.x, tile_.x);
-        tiled_shape_.y = cdiv(gemm_shape.y, tile_.y);
+    if constexpr (order == kColMajor) {
+      cluster_tile_offset = {(cluster_idx_x >> log_tile_),
+                             (cluster_idx_y << log_tile_) +
+                                 (cluster_idx_x & ((1 << log_tile_) - 1))};
+    } else {
+      cluster_tile_offset = {(cluster_idx_y << log_tile_) +
+                                 (cluster_idx_x & ((1 << log_tile_) - 1)),
+                             (cluster_idx_x >> log_tile_)};
+    }
 
-        cluster_tiles_.x = cdiv(gemm_shape.x, cluster_tile_.x);  // useless
-        cluster_tiles_.y = cdiv(gemm_shape.y, cluster_tile_.y);
+    // `tile` may be on DSMEM
+    int tile_idx_x =
+        offset_x + cluster_tile_offset.x * (striped_m ? 1 : Cluster::M);
+    int tile_idx_y =
+        offset_y + cluster_tile_offset.y * (striped_n ? 1 : Cluster::N);
+    tile.offset_m = tile_idx_x * tile_.x;
+    tile.offset_n = tile_idx_y * tile_.y;
+    int valid_cluster_p = cluster_tile_offset.x < cluster_tiles.x &&
+                          cluster_tile_offset.y < cluster_tiles.y;
+    tile.is_valid_cta =
+        valid_cluster_p && tile_idx_x < cta_tiles.x && tile_idx_y < cta_tiles.y;
+    tile.is_valid_cluster = valid_cluster_p;
+  }
 
-        // printf("cluster tiles: %d %d\n", cluster_tiles_.x, cluster_tiles_.y);
+  TM_DEVICE int get_start_index(int g) const {
+    // return (__ldg(&offsets_[g]) / (cluster_tile_.x * swizzle_unit_.x) + g) *
+    // swizzle_unit_.x
+    //        * padded_cluster_tiles_.y;
+    return (swizzle_tile_x_.div(__ldg(&offsets_[g])) + g) * swizzle_unit_.x *
+           padded_cluster_tiles_.y;
+  }
 
+  TM_DEVICE bool update_sync(int cluster_idx, int& group_id_offset,
+                             int& group_idx, int& group_beg, int& group_m0,
+                             int& group_m1, int2& tiled_shape,
+                             int2& cluster_tiles, int2& swizzled_tiles) const {
+    const int lane_id = threadIdx.x % WARP_SIZE;
+
+    uint32_t mask;
+    while (true) {
+      int e = group_id_offset + lane_id;
+      int pred = e > gemm_shape_.w || cluster_idx < get_start_index(e);
+      mask = __ballot_sync((uint32_t)-1, pred);
+      if (mask) {
+        break;
+      }
+      group_id_offset += WARP_SIZE;
+    }
+
+    // 32 - clz(~mask) - 1
+    group_idx = group_id_offset + 31 - __clz(~mask);
+
+    group_m0 = __ldg(&offsets_[group_idx]);
+    group_m1 = __ldg(&offsets_[group_idx + 1]);
+    int m = group_m1 - group_m0;
+
+    group_beg = get_start_index(group_idx);
+
+    tiled_shape.x = cdiv(m, tile_.x);
+    cluster_tiles.x = cdiv(m, cluster_tile_.x);
+
+    swizzled_tiles = get_swizzled_shape(cluster_tiles, log_tile_);
+
+    return true;
+  }
+
+  TM_DEVICE bool next(ProducerState& state) {
+    const int lane_id = cutlass::canonical_lane_idx();
+
+    auto& store = state.store;
+    auto& pipe = state.pipe;
+
+    int cluster_idx{};
+
+    if constexpr (is_dynamic) {
+      if (lane_id == 0) {
+        cutlass::arch::ClusterBarrier::wait(&store.consumer_bar[pipe.index()],
+                                            pipe.phase());
+        cluster_idx = atomicAdd(next_cluster_id_, 1);
+      }
+      cluster_idx = __shfl_sync((uint32_t)-1, cluster_idx, 0);
+    } else {
+      cutlass::arch::ClusterBarrier::wait(&store.consumer_bar[pipe.index()],
+                                          pipe.phase());
+      cluster_idx = state.cluster_idx;
+      state.cluster_idx += (int)cute::cluster_grid_dims().x;
+    }
+
+    Tile* tile{};
+
+    if constexpr (Cluster::size == 1) {
+      tile = &store.tile[pipe.index()];
+    } else {
+      if (lane_id < Cluster::size) {
+        tile = (Tile*)map_to_cta(&store.tile[pipe.index()], lane_id);
+      }
+    }
+
+    const int alive = cluster_idx < clusters_;
+
+    if (alive) {
+      int group_id = 0;
+      int group_beg = 0;
+      int group_m0 = 0;
+      int group_m1 = 0;
+      auto cta_tiles = tiled_shape_;
+      auto cluster_tiles = cluster_tiles_;
+      auto swizzle_tiles = swizzled_cluster_tiles_;
+      if constexpr (is_grouped_gemm) {
+        update_sync(cluster_idx,  //
+                    state.group_id_offset, group_id, group_beg, group_m0,
+                    group_m1, cta_tiles, cluster_tiles, swizzle_tiles);
+      }
+      if (lane_id < Cluster::size) {
+        unswizzle(*tile,  //
+                  cluster_idx - group_beg, lane_id, cta_tiles, cluster_tiles,
+                  swizzle_tiles);
         if constexpr (is_grouped_gemm) {
-            {
-                int2 unit     = get_swizzled_shape({1, 1}, log_tile);
-                swizzle_unit_ = order == kColMajor ? int2{unit.y, unit.x} : int2{unit.x, unit.y};
-            }
-
-            // col {8, 1}, row {1, 8}
-            // printf("swizzle unit: %d %d\n", swizzle_unit_.x, swizzle_unit_.y);
-
-            swizzle_tile_x_ = cluster_tile_.x * swizzle_unit_.x;
-
-            int num = gemm_shape_.w;
-
-            // num of tiles won't change after swizzle
-            padded_cluster_tiles_.x = (num + gemm_shape.x / (cluster_tile_.x * swizzle_unit_.x)) * swizzle_unit_.x;
-            padded_cluster_tiles_.y = cdiv(gemm_shape.y, cluster_tile_.y * swizzle_unit_.y) * swizzle_unit_.y;
-
-            // printf("padded   cluster tiles: %d %d\n", padded_cluster_tiles_.x, padded_cluster_tiles_.y);
-
-            swizzled_cluster_tiles_ = get_swizzled_shape(padded_cluster_tiles_, log_tile);
-
-            // printf("swizzled cluster tiles: %d %d\n", swizzled_cluster_tiles_.x, swizzled_cluster_tiles_.y);
-
-            clusters_ = padded_cluster_tiles_.x * padded_cluster_tiles_.y;
-
-            // printf("clusters = %d\n", clusters_);
-            // M is runtime value
+          tile->group_idx = group_id;
+          tile->m0 = group_m0;
+          tile->m1 = group_m1;
         }
-        else {
-            tiled_shape_.x = cdiv(gemm_shape.x, tile_.x);
-            tiled_shape_.y = cdiv(gemm_shape.y, tile_.y);
-
-            cluster_tiles_.x = cdiv(gemm_shape.x, cluster_tile_.x);
-            cluster_tiles_.y = cdiv(gemm_shape.y, cluster_tile_.y);
-
-            swizzled_cluster_tiles_ = get_swizzled_shape(cluster_tiles_, log_tile);
-
-            swizzle_tile_x_ = swizzled_cluster_tiles_.x;
-
-            clusters_ = swizzled_cluster_tiles_.x * swizzled_cluster_tiles_.y;
-        }
+      }
     }
 
-    TM_HOST_DEVICE static int get_log_tile(int2 tiled_mn, int tile_size)
-    {
-        return gemm::get_log_tile(order == kColMajor ? tiled_mn.y : tiled_mn.x, tile_size);
+    if (lane_id < Cluster::size) {
+      tile->alive = alive;
     }
 
-    TM_HOST_DEVICE static int2 get_swizzled_shape(int2 tiled_shape, int log_tile)
-    {
-        const int tile = 1 << log_tile;
-
-        if constexpr (order == kColMajor) {
-            return {tiled_shape.x * tile, (tiled_shape.y + tile - 1) >> log_tile};
-        }
-        else {
-            return {tiled_shape.y * tile, (tiled_shape.x + tile - 1) >> log_tile};
-        }
+    if constexpr (Cluster::size == 1) {
+      if (lane_id == 0) {
+        cutlass::arch::ClusterBarrier::arrive(
+            &store.producer_bar[pipe.index()]);
+      }
+    } else {
+      mbarrier_arrive_cluster(&store.producer_bar[pipe.index()], lane_id,
+                              lane_id < Cluster::size);
     }
 
-    TM_DEVICE ProducerState init_producer(Storage& store)
-    {
-        int cluster_id = 0;
-        if constexpr (!is_dynamic) {
-            cluster_id = (int)cute::cluster_id_in_grid().x;
-        }
-        return {
-            PipelineState{0, 1, 0},
-            0,
-            cluster_id,
-            store,
-            *this,
-        };
+    ++pipe;
+
+    return alive;
+  }
+
+  TM_DEVICE void tail(ProducerState& state) {
+    if constexpr (Cluster::size > 1) {
+      for (int i = 0; i < Stages; ++i) {
+        cutlass::arch::ClusterBarrier::wait(
+            &state.store.consumer_bar[state.pipe.index()], state.pipe.phase());
+        ++state.pipe;
+      }
+    }
+  }
+
+  TM_DEVICE bool acquire(ConsumerState& state, Tile*& tile) {
+    auto& store = state.store;
+    auto& pipe = state.pipe;
+
+    if constexpr (Cluster::size == 1) {
+      cutlass::arch::ClusterBarrier::wait(&store.producer_bar[pipe.index()],
+                                          pipe.phase());
+    } else {
+      mbarrier_wait_cluster(&store.producer_bar[pipe.index()], pipe.phase());
     }
 
-    TM_DEVICE ConsumerState init_consumer(Storage& store)
-    {
-        return {
-            PipelineState{},
-            store,
-            *this,
-        };
+    tile = &store.tile[pipe.index()];
+
+    return tile->alive;
+  }
+
+  TM_DEVICE void release(ConsumerState& state, int step) {
+    auto& store = state.store;
+    auto& pipe = state.pipe;
+
+    __syncwarp();
+
+    if constexpr (Cluster::size == 1) {
+      if (cutlass::elect_one_sync()) {
+        cutlass::arch::ClusterBarrier::arrive(
+            &store.consumer_bar[pipe.index()]);
+      }
+    } else {
+      cutlass::arch::ClusterBarrier::arrive(&store.consumer_bar[pipe.index()],
+                                            0, cutlass::elect_one_sync());
     }
 
-    TM_DEVICE void
-    unswizzle(Tile& tile, int cluster_idx, int cta_id, int2 cta_tiles, int2 cluster_tiles, int2 swizzle_tiles) const
-    {
-        int cluster_idx_x, cluster_idx_y;
+    pipe.advance(step);
+  }
 
-        if constexpr (is_grouped_gemm) {
-            cluster_idx_x = cluster_idx % swizzle_tiles.x;
-            cluster_idx_y = cluster_idx / swizzle_tiles.x;
-        }
-        else {
-            swizzle_tile_x_(cluster_idx_y, cluster_idx_x, cluster_idx);
-        }
+  TM_DEVICE int4 gemm_shape() const { return gemm_shape_; }
 
-        auto [cluster_cta_m, cluster_cta_n] = Cluster::cta_mn(cta_id);
-
-        const int offset_x = cluster_cta_m * (striped_m ? cluster_tiles.x : 1);
-        const int offset_y = cluster_cta_n * (striped_n ? cluster_tiles.y : 1);
-
-        int2 cluster_tile_offset;
-
-        if constexpr (order == kColMajor) {
-            cluster_tile_offset = {(cluster_idx_x >> log_tile_),
-                                   (cluster_idx_y << log_tile_) + (cluster_idx_x & ((1 << log_tile_) - 1))};
-        }
-        else {
-            cluster_tile_offset = {(cluster_idx_y << log_tile_) + (cluster_idx_x & ((1 << log_tile_) - 1)),
-                                   (cluster_idx_x >> log_tile_)};
-        }
-
-        // `tile` may be on DSMEM
-        int tile_idx_x        = offset_x + cluster_tile_offset.x * (striped_m ? 1 : Cluster::M);
-        int tile_idx_y        = offset_y + cluster_tile_offset.y * (striped_n ? 1 : Cluster::N);
-        tile.offset_m         = tile_idx_x * tile_.x;
-        tile.offset_n         = tile_idx_y * tile_.y;
-        int valid_cluster_p   = cluster_tile_offset.x < cluster_tiles.x && cluster_tile_offset.y < cluster_tiles.y;
-        tile.is_valid_cta     = valid_cluster_p && tile_idx_x < cta_tiles.x && tile_idx_y < cta_tiles.y;
-        tile.is_valid_cluster = valid_cluster_p;
-    }
-
-    TM_DEVICE int get_start_index(int g) const
-    {
-        // return (__ldg(&offsets_[g]) / (cluster_tile_.x * swizzle_unit_.x) + g) * swizzle_unit_.x
-        //        * padded_cluster_tiles_.y;
-        return (swizzle_tile_x_.div(__ldg(&offsets_[g])) + g) * swizzle_unit_.x * padded_cluster_tiles_.y;
-    }
-
-    TM_DEVICE bool update_sync(int   cluster_idx,
-                               int&  group_id_offset,
-                               int&  group_idx,
-                               int&  group_beg,
-                               int&  group_m0,
-                               int&  group_m1,
-                               int2& tiled_shape,
-                               int2& cluster_tiles,
-                               int2& swizzled_tiles) const
-    {
-        const int lane_id = threadIdx.x % WARP_SIZE;
-
-        uint32_t mask;
-        while (true) {
-            int e    = group_id_offset + lane_id;
-            int pred = e > gemm_shape_.w || cluster_idx < get_start_index(e);
-            mask     = __ballot_sync((uint32_t)-1, pred);
-            if (mask) {
-                break;
-            }
-            group_id_offset += WARP_SIZE;
-        }
-
-        // 32 - clz(~mask) - 1
-        group_idx = group_id_offset + 31 - __clz(~mask);
-
-        group_m0 = __ldg(&offsets_[group_idx]);
-        group_m1 = __ldg(&offsets_[group_idx + 1]);
-        int m    = group_m1 - group_m0;
-
-        group_beg = get_start_index(group_idx);
-
-        tiled_shape.x   = cdiv(m, tile_.x);
-        cluster_tiles.x = cdiv(m, cluster_tile_.x);
-
-        swizzled_tiles = get_swizzled_shape(cluster_tiles, log_tile_);
-
-        return true;
-    }
-
-    TM_DEVICE bool next(ProducerState& state)
-    {
-        const int lane_id = cutlass::canonical_lane_idx();
-
-        auto& store = state.store;
-        auto& pipe  = state.pipe;
-
-        int cluster_idx{};
-
-        if constexpr (is_dynamic) {
-            if (lane_id == 0) {
-                cutlass::arch::ClusterBarrier::wait(&store.consumer_bar[pipe.index()], pipe.phase());
-                cluster_idx = atomicAdd(next_cluster_id_, 1);
-            }
-            cluster_idx = __shfl_sync((uint32_t)-1, cluster_idx, 0);
-        }
-        else {
-            cutlass::arch::ClusterBarrier::wait(&store.consumer_bar[pipe.index()], pipe.phase());
-            cluster_idx = state.cluster_idx;
-            state.cluster_idx += (int)cute::cluster_grid_dims().x;
-        }
-
-        Tile* tile{};
-
-        if constexpr (Cluster::size == 1) {
-            tile = &store.tile[pipe.index()];
-        }
-        else {
-            if (lane_id < Cluster::size) {
-                tile = (Tile*)map_to_cta(&store.tile[pipe.index()], lane_id);
-            }
-        }
-
-        const int alive = cluster_idx < clusters_;
-
-        if (alive) {
-            int  group_id      = 0;
-            int  group_beg     = 0;
-            int  group_m0      = 0;
-            int  group_m1      = 0;
-            auto cta_tiles     = tiled_shape_;
-            auto cluster_tiles = cluster_tiles_;
-            auto swizzle_tiles = swizzled_cluster_tiles_;
-            if constexpr (is_grouped_gemm) {
-                update_sync(cluster_idx,  //
-                            state.group_id_offset,
-                            group_id,
-                            group_beg,
-                            group_m0,
-                            group_m1,
-                            cta_tiles,
-                            cluster_tiles,
-                            swizzle_tiles);
-            }
-            if (lane_id < Cluster::size) {
-                unswizzle(*tile,  //
-                          cluster_idx - group_beg,
-                          lane_id,
-                          cta_tiles,
-                          cluster_tiles,
-                          swizzle_tiles);
-                if constexpr (is_grouped_gemm) {
-                    tile->group_idx = group_id;
-                    tile->m0        = group_m0;
-                    tile->m1        = group_m1;
-                }
-            }
-        }
-
-        if (lane_id < Cluster::size) {
-            tile->alive = alive;
-        }
-
-        if constexpr (Cluster::size == 1) {
-            if (lane_id == 0) {
-                cutlass::arch::ClusterBarrier::arrive(&store.producer_bar[pipe.index()]);
-            }
-        }
-        else {
-            mbarrier_arrive_cluster(&store.producer_bar[pipe.index()], lane_id, lane_id < Cluster::size);
-        }
-
-        ++pipe;
-
-        return alive;
-    }
-
-    TM_DEVICE void tail(ProducerState& state)
-    {
-        if constexpr (Cluster::size > 1) {
-            for (int i = 0; i < Stages; ++i) {
-                cutlass::arch::ClusterBarrier::wait(&state.store.consumer_bar[state.pipe.index()], state.pipe.phase());
-                ++state.pipe;
-            }
-        }
-    }
-
-    TM_DEVICE bool acquire(ConsumerState& state, Tile*& tile)
-    {
-        auto& store = state.store;
-        auto& pipe  = state.pipe;
-
-        if constexpr (Cluster::size == 1) {
-            cutlass::arch::ClusterBarrier::wait(&store.producer_bar[pipe.index()], pipe.phase());
-        }
-        else {
-            mbarrier_wait_cluster(&store.producer_bar[pipe.index()], pipe.phase());
-        }
-
-        tile = &store.tile[pipe.index()];
-
-        return tile->alive;
-    }
-
-    TM_DEVICE void release(ConsumerState& state, int step)
-    {
-        auto& store = state.store;
-        auto& pipe  = state.pipe;
-
-        __syncwarp();
-
-        if constexpr (Cluster::size == 1) {
-            if (cutlass::elect_one_sync()) {
-                cutlass::arch::ClusterBarrier::arrive(&store.consumer_bar[pipe.index()]);
-            }
-        }
-        else {
-            cutlass::arch::ClusterBarrier::arrive(&store.consumer_bar[pipe.index()], 0, cutlass::elect_one_sync());
-        }
-
-        pipe.advance(step);
-    }
-
-    TM_DEVICE int4 gemm_shape() const
-    {
-        return gemm_shape_;
-    }
-
-    TM_DEVICE int2 tiled_shape() const
-    {
-        return tiled_shape_;
-    }
+  TM_DEVICE int2 tiled_shape() const { return tiled_shape_; }
 };
 
 }  // namespace turbomind::gemm

--- a/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/scheduler_sm70.cuh
+++ b/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/scheduler_sm70.cuh
@@ -12,239 +12,239 @@
 
 namespace turbomind::gemm {
 
-template<Order order, int tile_m, int tile_n, int tile_k, int chunk_k, int split_k, int group_axis_>
+template <Order order, int tile_m, int tile_n, int tile_k, int chunk_k,
+          int split_k, int group_axis_>
 struct SchedulerSm70 {
+  static constexpr int group_axis = group_axis_;
 
-    static constexpr int group_axis = group_axis_;
+  static constexpr Array<int, 3> tile_shape{tile_m, tile_n, tile_k};
 
-    static constexpr Array<int, 3> tile_shape{tile_m, tile_n, tile_k};
+  static_assert(chunk_k % tile_k == 0);
+  static constexpr int chunk_iters = chunk_k / tile_k;
 
-    static_assert(chunk_k % tile_k == 0);
-    static constexpr int chunk_iters = chunk_k / tile_k;
+  Array<int, 4> gemm_shape_;
+  Array<int, 3> tiles_;
 
-    Array<int, 4> gemm_shape_;
-    Array<int, 3> tiles_;
+  int log_tile_;
 
-    int log_tile_;
+  int split_chunks_;
+  int chunk_offset_;
 
-    int split_chunks_;
-    int chunk_offset_;
+  const int* offsets_;
+  const int* active_group_idxs_;
+  int active_group_count_;
 
-    const int* offsets_;
-    const int* active_group_idxs_;
-    int        active_group_count_;
+  struct Tile {
+    Array<int, 3> tile_id;
+    Array<int, 3> shape;
+    Array<int, 2> k_iters;
 
-    struct Tile {
-        Array<int, 3> tile_id;
-        Array<int, 3> shape;
-        Array<int, 2> k_iters;
+    int group_id;
+    int linear_tile_id;
+  };
 
-        int group_id;
-        int linear_tile_id;
-    };
+  struct SharedStorage {
+    int group_id;
+    int dynamic_dim;
+    int base_tile_id;
+  };
 
-    struct SharedStorage {
-        int group_id;
-        int dynamic_dim;
-        int base_tile_id;
-    };
+  __host__ dim3 get_grid_shape() {
+    auto shape = get_swizzled_shape(tiles_, log_tile_);
+    return dim3(shape[0], shape[1], shape[2]);
+  }
 
-    __host__ dim3 get_grid_shape()
-    {
-        auto shape = get_swizzled_shape(tiles_, log_tile_);
-        return dim3(shape[0], shape[1], shape[2]);
+  __host__ SchedulerSm70(Array<int, 4> gemm_shape, int log_tile = 0,
+                         int splits = 1)
+      : gemm_shape_{gemm_shape}, log_tile_{log_tile} {
+    tiles_[0] = cdiv(gemm_shape[0], tile_m);
+    tiles_[1] = cdiv(gemm_shape[1], tile_n);
+    tiles_[2] = splits;
+
+    log_tile_ = log_tile;
+
+    Array<int, 2> log_unit{};
+    log_unit[1 - (int)order] = log_tile;
+
+    tiles_[0] = round_up(tiles_[0], 1 << log_unit[0]);
+    tiles_[1] = round_up(tiles_[1], 1 << log_unit[1]);
+
+    // printf("gemm shape: %d %d %d %d\n", gemm_shape_[0], gemm_shape_[1],
+    // gemm_shape_[2], gemm_shape_[3]); printf("tile shape: %d %d %d\n",
+    // tile_shape[0], tile_shape[1], tile_shape[2]);
+
+    if constexpr (group_axis >= 0) {
+      constexpr int i = group_axis;
+      // overwrite dynamic axis <- estimated upper bound
+      tiles_[i] =
+          ((gemm_shape_[i] / tile_shape[i] >> log_unit[i]) + gemm_shape_[3])
+          << log_unit[i];
     }
 
-    __host__ SchedulerSm70(Array<int, 4> gemm_shape, int log_tile = 0, int splits = 1):
-        gemm_shape_{gemm_shape}, log_tile_{log_tile}
-    {
-        tiles_[0] = cdiv(gemm_shape[0], tile_m);
-        tiles_[1] = cdiv(gemm_shape[1], tile_n);
-        tiles_[2] = splits;
+    int chunks = cdiv(gemm_shape[2], chunk_k);
+    split_chunks_ = chunks / splits;
+    chunk_offset_ = splits - chunks % splits;
+    active_group_idxs_ = nullptr;
+    active_group_count_ = 0;
+  }
 
-        log_tile_ = log_tile;
+  __host__ void set_active_groups(const int* group_idxs, int group_count) {
+    if constexpr (group_axis >= 0) {
+      if (group_idxs && group_count > 0 && group_count <= gemm_shape_[3]) {
+        active_group_idxs_ = group_idxs;
+        active_group_count_ = group_count;
 
-        Array<int, 2> log_unit{};
-        log_unit[1 - (int)order] = log_tile;
-
-        tiles_[0] = round_up(tiles_[0], 1 << log_unit[0]);
-        tiles_[1] = round_up(tiles_[1], 1 << log_unit[1]);
-
-        // printf("gemm shape: %d %d %d %d\n", gemm_shape_[0], gemm_shape_[1], gemm_shape_[2], gemm_shape_[3]);
-        // printf("tile shape: %d %d %d\n", tile_shape[0], tile_shape[1], tile_shape[2]);
-
-        if constexpr (group_axis >= 0) {
-            constexpr int i = group_axis;
-            // overwrite dynamic axis <- estimated upper bound
-            tiles_[i] = ((gemm_shape_[i] / tile_shape[i] >> log_unit[i]) + gemm_shape_[3]) << log_unit[i];
-        }
-
-        int chunks    = cdiv(gemm_shape[2], chunk_k);
-        split_chunks_ = chunks / splits;
-        chunk_offset_ = splits - chunks % splits;
-        active_group_idxs_  = nullptr;
-        active_group_count_ = 0;
-    }
-
-    __host__ void set_active_groups(const int* group_idxs, int group_count)
-    {
-        if constexpr (group_axis >= 0) {
-            if (group_idxs && group_count > 0 && group_count <= gemm_shape_[3]) {
-                active_group_idxs_  = group_idxs;
-                active_group_count_ = group_count;
-
-                constexpr int i = group_axis;
-
-                Array<int, 2> log_unit{};
-                log_unit[1 - (int)order] = log_tile_;
-
-                // Use the same upper-bound formula as grouped scheduling, but
-                // charge only active source groups to the compact dispatch axis.
-                tiles_[i] = ((gemm_shape_[i] / tile_shape[i] >> log_unit[i]) + group_count) << log_unit[i];
-            }
-        }
-    }
-
-    __device__ int source_group(int logical_group)
-    {
-        return active_group_idxs_ ? __ldg(active_group_idxs_ + logical_group) : logical_group;
-    }
-
-    __device__ void get_group_bounds(int logical_group, int& beg, int& end, int& beg_tile, int& end_tile)
-    {
         constexpr int i = group_axis;
 
         Array<int, 2> log_unit{};
         log_unit[1 - (int)order] = log_tile_;
 
-        const int source_g = source_group(logical_group);
-        beg               = __ldg(offsets_ + source_g);
-        end               = __ldg(offsets_ + source_g + 1);
-        beg_tile          = ((beg / tile_shape[i] >> log_unit[i]) + logical_group) << log_unit[i];
-        end_tile          = ((end / tile_shape[i] >> log_unit[i]) + logical_group + 1) << log_unit[i];
+        // Use the same upper-bound formula as grouped scheduling, but
+        // charge only active source groups to the compact dispatch axis.
+        tiles_[i] =
+            ((gemm_shape_[i] / tile_shape[i] >> log_unit[i]) + group_count)
+            << log_unit[i];
+      }
+    }
+  }
+
+  __device__ int source_group(int logical_group) {
+    return active_group_idxs_ ? __ldg(active_group_idxs_ + logical_group)
+                              : logical_group;
+  }
+
+  __device__ void get_group_bounds(int logical_group, int& beg, int& end,
+                                   int& beg_tile, int& end_tile) {
+    constexpr int i = group_axis;
+
+    Array<int, 2> log_unit{};
+    log_unit[1 - (int)order] = log_tile_;
+
+    const int source_g = source_group(logical_group);
+    beg = __ldg(offsets_ + source_g);
+    end = __ldg(offsets_ + source_g + 1);
+    beg_tile = ((beg / tile_shape[i] >> log_unit[i]) + logical_group)
+               << log_unit[i];
+    end_tile = ((end / tile_shape[i] >> log_unit[i]) + logical_group + 1)
+               << log_unit[i];
+  }
+
+  __device__ int find_group(Array<int, 3>& tile_id, SharedStorage& storage) {
+    constexpr int axis = group_axis;
+
+    int success = 0;
+
+    const int block_dim = blockDim.x;
+    const int group_count =
+        active_group_idxs_ ? active_group_count_ : gemm_shape_[3];
+
+    for (int g = threadIdx.x; g < group_count; g += block_dim) {
+      int beg, end, beg_tile, end_tile;
+      get_group_bounds(g, beg, end, beg_tile, end_tile);
+
+      if (beg_tile <= tile_id[axis] && tile_id[axis] < end_tile) {
+        storage.group_id = source_group(g);
+        storage.dynamic_dim = end - beg;
+        storage.base_tile_id = beg_tile;
+        success = 1;
+      }
+
+      if (tile_id[axis] < end_tile) {
+        break;
+      }
     }
 
-    __device__ int find_group(Array<int, 3>& tile_id, SharedStorage& storage)
-    {
-        constexpr int axis = group_axis;
+    return __syncthreads_or(success);
+  }
 
-        int success = 0;
+  template <class Reinit>
+  __device__ int init(Tile& tile, SharedStorage& storage, Reinit) {
+    Array<int, 3> cta_id{(int)blockIdx.x, (int)blockIdx.y, (int)blockIdx.z};
+    Array<int, 3> tile_id = unswizzle(cta_id);
+    Array<int, 3> shape{gemm_shape_[0], gemm_shape_[1], gemm_shape_[2]};
 
-        const int block_dim = blockDim.x;
-        const int group_count = active_group_idxs_ ? active_group_count_ : gemm_shape_[3];
+    tile.group_id = 0;
+    tile.linear_tile_id =
+        tile_id[1 - (int)order] * tiles_[(int)order] + tile_id[(int)order];
 
-        for (int g = threadIdx.x; g < group_count; g += block_dim) {
-            int beg, end, beg_tile, end_tile;
-            get_group_bounds(g, beg, end, beg_tile, end_tile);
+    constexpr int axis = group_axis;
 
-            if (beg_tile <= tile_id[axis] && tile_id[axis] < end_tile) {
-                storage.group_id     = source_group(g);
-                storage.dynamic_dim  = end - beg;
-                storage.base_tile_id = beg_tile;
-                success              = 1;
-            }
-
-            if (tile_id[axis] < end_tile) {
-                break;
-            }
+    if constexpr (axis >= 0) {
+      if (offsets_) {
+        if constexpr (!Reinit::value) {
+          if (!find_group(tile_id, storage)) {
+            return false;
+          }
         }
-
-        return __syncthreads_or(success);
+        tile_id[axis] -= storage.base_tile_id;
+        shape[axis] = storage.dynamic_dim;
+        tile.group_id = storage.group_id;
+        // Crucial for the values above to be recognized as warp uniform,
+        // `__syncwarp()` does not prevent modifying CTA scope SMEM from other
+        // warps
+        __syncthreads();
+      }
     }
 
-    template<class Reinit>
-    __device__ int init(Tile& tile, SharedStorage& storage, Reinit)
-    {
-        Array<int, 3> cta_id{(int)blockIdx.x, (int)blockIdx.y, (int)blockIdx.z};
-        Array<int, 3> tile_id = unswizzle(cta_id);
-        Array<int, 3> shape{gemm_shape_[0], gemm_shape_[1], gemm_shape_[2]};
-
-        tile.group_id       = 0;
-        tile.linear_tile_id = tile_id[1 - (int)order] * tiles_[(int)order] + tile_id[(int)order];
-
-        constexpr int axis = group_axis;
-
-        if constexpr (axis >= 0) {
-            if (offsets_) {
-                if constexpr (!Reinit::value) {
-                    if (!find_group(tile_id, storage)) {
-                        return false;
-                    }
-                }
-                tile_id[axis] -= storage.base_tile_id;
-                shape[axis]   = storage.dynamic_dim;
-                tile.group_id = storage.group_id;
-                // Crucial for the values above to be recognized as warp uniform, `__syncwarp()`
-                // does not prevent modifying CTA scope SMEM from other warps
-                __syncthreads();
-            }
-        }
-
-        if constexpr (split_k) {
-            int split_id    = tile_id[2];
-            int chunk_id    = split_id * split_chunks_ + max(split_id - chunk_offset_, 0);
-            tile.k_iters[0] = chunk_id * chunk_iters;
-            tile.k_iters[1] = (split_chunks_ + int(split_id >= chunk_offset_)) * chunk_iters;
-        }
-        else {
-            tile.k_iters[0] = 0;
-            tile.k_iters[1] = split_chunks_ * chunk_iters;
-        }
-
-        tile.tile_id = tile_id;
-        tile.shape   = shape;
-
-        return true;
+    if constexpr (split_k) {
+      int split_id = tile_id[2];
+      int chunk_id =
+          split_id * split_chunks_ + max(split_id - chunk_offset_, 0);
+      tile.k_iters[0] = chunk_id * chunk_iters;
+      tile.k_iters[1] =
+          (split_chunks_ + int(split_id >= chunk_offset_)) * chunk_iters;
+    } else {
+      tile.k_iters[0] = 0;
+      tile.k_iters[1] = split_chunks_ * chunk_iters;
     }
 
-    __device__ Array<int, 3> unswizzle(Array<int, 3> cta_id)
-    {
-        int tile_c = cta_id[0] >> log_tile_;
-        int tile_s = cta_id[1] << log_tile_ | (cta_id[0] & ((1 << log_tile_) - 1));
+    tile.tile_id = tile_id;
+    tile.shape = shape;
 
-        Array<int, 3> tile_id;
+    return true;
+  }
 
-        tile_id[(int)order]     = tile_c;
-        tile_id[1 - (int)order] = tile_s;
+  __device__ Array<int, 3> unswizzle(Array<int, 3> cta_id) {
+    int tile_c = cta_id[0] >> log_tile_;
+    int tile_s = cta_id[1] << log_tile_ | (cta_id[0] & ((1 << log_tile_) - 1));
 
-        tile_id[2] = cta_id[2];
+    Array<int, 3> tile_id;
 
-        return tile_id;
+    tile_id[(int)order] = tile_c;
+    tile_id[1 - (int)order] = tile_s;
+
+    tile_id[2] = cta_id[2];
+
+    return tile_id;
+  }
+
+  __host__ __device__ static Array<int, 3> get_swizzled_shape(
+      Array<int, 3> tiles, int log_tile) {
+    constexpr int i = (int)order;  // expansion axis
+    return {tiles[i] << log_tile,
+            (tiles[1 - i] + (1 << log_tile) - 1) >> log_tile, tiles[2]};
+  }
+
+  __host__ int get_max_swizzle() {
+    constexpr int axis = 1 - (int)order;
+
+    int n = tiles_[axis];
+
+    if (group_axis == axis) {
+      n = cdiv(n, gemm_shape_[3]);
     }
 
-    __host__ __device__ static Array<int, 3> get_swizzled_shape(Array<int, 3> tiles, int log_tile)
-    {
-        constexpr int i = (int)order;  // expansion axis
-        return {tiles[i] << log_tile, (tiles[1 - i] + (1 << log_tile) - 1) >> log_tile, tiles[2]};
-    }
+    return get_log_tile(n);
+  }
 
-    __host__ int get_max_swizzle()
-    {
-        constexpr int axis = 1 - (int)order;
-
-        int n = tiles_[axis];
-
-        if (group_axis == axis) {
-            n = cdiv(n, gemm_shape_[3]);
-        }
-
-        return get_log_tile(n);
-    }
-
-    __host__ __device__ static int get_log_tile(int size)
-    {
-        if (size >= 24)
-            return 5;
-        if (size >= 12)
-            return 4;
-        if (size >= 6)
-            return 3;
-        if (size >= 3)
-            return 2;
-        if (size >= 2)
-            return 1;
-        return 0;
-    }
+  __host__ __device__ static int get_log_tile(int size) {
+    if (size >= 24) return 5;
+    if (size >= 12) return 4;
+    if (size >= 6) return 3;
+    if (size >= 3) return 2;
+    if (size >= 2) return 1;
+    return 0;
+  }
 };
 
 }  // namespace turbomind::gemm

--- a/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/sm90_utils.h
+++ b/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/sm90_utils.h
@@ -16,174 +16,148 @@ namespace turbomind::gemm {
 
 namespace GMMA = cute::SM90::GMMA;
 
-inline __device__ cute::GmmaDescriptor make_smem_desc(void* smem_ptr, int layout_type)
-{
-    auto uint_ptr = cast_smem_ptr_to_uint(smem_ptr);
+inline __device__ cute::GmmaDescriptor make_smem_desc(void* smem_ptr,
+                                                      int layout_type) {
+  auto uint_ptr = cast_smem_ptr_to_uint(smem_ptr);
 
-    cute::GmmaDescriptor desc{};
-    desc.bitfield.start_address_       = uint_ptr >> 4;
-    desc.bitfield.layout_type_         = layout_type;
-    desc.bitfield.leading_byte_offset_ = 0;
-    desc.bitfield.stride_byte_offset_  = 1024 >> 4;
-    desc.bitfield.base_offset_         = 0;
+  cute::GmmaDescriptor desc{};
+  desc.bitfield.start_address_ = uint_ptr >> 4;
+  desc.bitfield.layout_type_ = layout_type;
+  desc.bitfield.leading_byte_offset_ = 0;
+  desc.bitfield.stride_byte_offset_ = 1024 >> 4;
+  desc.bitfield.base_offset_ = 0;
 
-    return desc;
+  return desc;
 }
 
-template<int Stages, int Step>
+template <int Stages, int Step>
 struct SmemDescIterV2 {
-    union {
-        uint32_t u32_[2];
-        uint64_t u64_;
-    };
+  union {
+    uint32_t u32_[2];
+    uint64_t u64_;
+  };
 
-    uint32_t base_;
+  uint32_t base_;
 
-    __device__ SmemDescIterV2(uint64_t desc): u64_{desc}, base_{u32_[0]} {}
+  __device__ SmemDescIterV2(uint64_t desc) : u64_{desc}, base_{u32_[0]} {}
 
-    __device__ void Advance(int stage)
-    {
-        u32_[0] += Step;
-        if (stage == Stages - 1) {
-            u32_[0] = base_;
-        }
+  __device__ void Advance(int stage) {
+    u32_[0] += Step;
+    if (stage == Stages - 1) {
+      u32_[0] = base_;
     }
+  }
 
-    __device__ void Reset(int stage)
-    {
-        u32_[0] = base_ + stage * Step;
-    }
+  __device__ void Reset(int stage) { u32_[0] = base_ + stage * Step; }
 
-    __device__ SmemDescIterV2& operator+=(int offset)
-    {
-        u32_[0] += offset;
-        return *this;
-    }
+  __device__ SmemDescIterV2& operator+=(int offset) {
+    u32_[0] += offset;
+    return *this;
+  }
 
-    __device__ SmemDescIterV2& operator-=(int offset)
-    {
-        u32_[0] -= offset;
-        return *this;
-    }
+  __device__ SmemDescIterV2& operator-=(int offset) {
+    u32_[0] -= offset;
+    return *this;
+  }
 
-    __device__ operator uint64_t()
-    {
-        return u64_;
-    }
+  __device__ operator uint64_t() { return u64_; }
 };
 
-template<class MMA_Atom, size_t... Is>
-inline __device__ void
-wgmma_impl(uint64_t desc_a, uint64_t desc_b, float* frag_C, bool clear, std::index_sequence<Is...>)
-{
-    return MMA_Atom::fma(desc_a, desc_b, frag_C[Is]..., clear ? GMMA::ScaleOut::Zero : GMMA::ScaleOut::One);
+template <class MMA_Atom, size_t... Is>
+inline __device__ void wgmma_impl(uint64_t desc_a, uint64_t desc_b,
+                                  float* frag_C, bool clear,
+                                  std::index_sequence<Is...>) {
+  return MMA_Atom::fma(desc_a, desc_b, frag_C[Is]...,
+                       clear ? GMMA::ScaleOut::Zero : GMMA::ScaleOut::One);
 }
 
-template<class MMA_Atom, int N>
-inline __device__ void wgmma(uint64_t desc_a, uint64_t desc_b, float (&frag_C)[N], bool clear)
-{
-    return wgmma_impl<MMA_Atom>(desc_a, desc_b, frag_C, clear, std::make_index_sequence<N>{});
+template <class MMA_Atom, int N>
+inline __device__ void wgmma(uint64_t desc_a, uint64_t desc_b,
+                             float (&frag_C)[N], bool clear) {
+  return wgmma_impl<MMA_Atom>(desc_a, desc_b, frag_C, clear,
+                              std::make_index_sequence<N>{});
 }
 
-inline __device__ void warpgroup_fence_operand(float& reg)
-{
-    asm volatile("" : "+f"(reg)::"memory");
+inline __device__ void warpgroup_fence_operand(float& reg) {
+  asm volatile("" : "+f"(reg)::"memory");
 }
 
-template<int M, int N, int K>
-inline __device__ void warpgroup_fence_operand(float (&x)[M][N][K])
-{
-    PRAGMA_UNROLL
-    for (int m = 0; m < M; ++m) {
-        PRAGMA_UNROLL
-        for (int n = 0; n < N; ++n) {
-            PRAGMA_UNROLL
-            for (int k = 0; k < K; ++k) {
-                warpgroup_fence_operand(x[m][n][k]);
-            }
-        }
-    }
-}
-
-template<int N, int K>
-inline __device__ void warpgroup_fence_operand(float (&x)[N][K])
-{
+template <int M, int N, int K>
+inline __device__ void warpgroup_fence_operand(float (&x)[M][N][K]) {
+  PRAGMA_UNROLL
+  for (int m = 0; m < M; ++m) {
     PRAGMA_UNROLL
     for (int n = 0; n < N; ++n) {
-        PRAGMA_UNROLL
-        for (int k = 0; k < K; ++k) {
-            warpgroup_fence_operand(x[n][k]);
-        }
+      PRAGMA_UNROLL
+      for (int k = 0; k < K; ++k) {
+        warpgroup_fence_operand(x[m][n][k]);
+      }
     }
+  }
 }
 
-template<class Func, size_t... Is>
-__device__ void for_(std::index_sequence<Is...>, Func func)
-{
-    return (func(constant<Is>{}), ...);
+template <int N, int K>
+inline __device__ void warpgroup_fence_operand(float (&x)[N][K]) {
+  PRAGMA_UNROLL
+  for (int n = 0; n < N; ++n) {
+    PRAGMA_UNROLL
+    for (int k = 0; k < K; ++k) {
+      warpgroup_fence_operand(x[n][k]);
+    }
+  }
+}
+
+template <class Func, size_t... Is>
+__device__ void for_(std::index_sequence<Is...>, Func func) {
+  return (func(constant<Is>{}), ...);
 }
 
 namespace arch {
 
-template<int M_, int N_, Order order>
+template <int M_, int N_, Order order>
 struct Cluster {
-    static constexpr int M = M_;
-    static constexpr int N = N_;
+  static constexpr int M = M_;
+  static constexpr int N = N_;
 
-    static constexpr int C = mk2cs<order>(M, N).x;
-    static constexpr int S = mk2cs<order>(M, N).y;
+  static constexpr int C = mk2cs<order>(M, N).x;
+  static constexpr int S = mk2cs<order>(M, N).y;
 
-    static constexpr int size = M * N;
+  static constexpr int size = M * N;
 
-    static constexpr uint16_t kMaskC = (1 << C) - 1;
-    static constexpr uint16_t kMaskS = ((1 << size) - 1) / kMaskC;
+  static constexpr uint16_t kMaskC = (1 << C) - 1;
+  static constexpr uint16_t kMaskS = ((1 << size) - 1) / kMaskC;
 
-    __device__ static ushort2 mask_cs(int cta_id)
-    {
-        const auto [c, s] = cta_cs(cta_id);
-        return make_ushort2(kMaskS << c, kMaskC << s * C);
-    }
+  __device__ static ushort2 mask_cs(int cta_id) {
+    const auto [c, s] = cta_cs(cta_id);
+    return make_ushort2(kMaskS << c, kMaskC << s * C);
+  }
 
-    __device__ static ushort2 mask_mn(int cta_id)
-    {
-        auto [c, s] = mask_cs(cta_id);
-        return order == kColMajor ? ushort2{c, s} : ushort2{s, c};
-    }
+  __device__ static ushort2 mask_mn(int cta_id) {
+    auto [c, s] = mask_cs(cta_id);
+    return order == kColMajor ? ushort2{c, s} : ushort2{s, c};
+  }
 
-    __device__ static int2 cta_cs(int cta_id)
-    {
-        return {C > 1 ? cta_id % C : 0, S > 1 ? cta_id / C : 0};
-    }
+  __device__ static int2 cta_cs(int cta_id) {
+    return {C > 1 ? cta_id % C : 0, S > 1 ? cta_id / C : 0};
+  }
 
-    __device__ static int2 cta_mn(int cta_id)
-    {
-        return cs2mk<order>(cta_cs(cta_id));
-    }
+  __device__ static int2 cta_mn(int cta_id) {
+    return cs2mk<order>(cta_cs(cta_id));
+  }
 
-    int2    cta_mn_;
-    ushort2 mask_mn_;
+  int2 cta_mn_;
+  ushort2 mask_mn_;
 
-    __device__ explicit Cluster(int cta_id): cta_mn_(cta_mn(cta_id)), mask_mn_(mask_mn(cta_id)) {}
+  __device__ explicit Cluster(int cta_id)
+      : cta_mn_(cta_mn(cta_id)), mask_mn_(mask_mn(cta_id)) {}
 
-    __device__ int cta_m()
-    {
-        return cta_mn_.x;
-    }
+  __device__ int cta_m() { return cta_mn_.x; }
 
-    __device__ int cta_n()
-    {
-        return cta_mn_.y;
-    }
+  __device__ int cta_n() { return cta_mn_.y; }
 
-    __device__ uint16_t mask_m()
-    {
-        return mask_mn_.x;
-    }
+  __device__ uint16_t mask_m() { return mask_mn_.x; }
 
-    __device__ uint16_t mask_n()
-    {
-        return mask_mn_.y;
-    }
+  __device__ uint16_t mask_n() { return mask_mn_.y; }
 };
 
 }  // namespace arch

--- a/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/smem_copy.h
+++ b/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/smem_copy.h
@@ -14,187 +14,174 @@
 namespace turbomind::gemm {
 
 struct VoidSmemCopyAtom {
+  static constexpr int M = 1;
+  static constexpr int K = 1;
 
-    static constexpr int M = 1;
-    static constexpr int K = 1;
+  static constexpr int kFragNum = 1;
 
-    static constexpr int kFragNum = 1;
+  using Frag = Array<int, 1>;
 
-    using Frag = Array<int, 1>;
+  template <class S, class D>
+  __device__ static void copy(S, D, bool) {}
 
-    template<class S, class D>
-    __device__ static void copy(S, D, bool)
-    {
-    }
+  __device__ static int2 get_offset(int) { return {}; }
 
-    __device__ static int2 get_offset(int)
-    {
-        return {};
-    }
-
-    __device__ static int2 unique(int thread_idx, int pack_idx)
-    {
-        return {};
-    }
+  __device__ static int2 unique(int thread_idx, int pack_idx) { return {}; }
 };
 
-template<class T, class Layout, Order order>
-struct SmemAccessorV2 {
+template <class T, class Layout, Order order>
+struct SmemAccessorV2 {};
+
+template <class T, class Layout>
+struct SmemAccessorV2<T, Layout, kRowMajor> : SmemAccessor<T, Layout> {
+  using SmemAccessor<T, Layout>::SmemAccessor;
 };
 
-template<class T, class Layout>
-struct SmemAccessorV2<T, Layout, kRowMajor>: SmemAccessor<T, Layout> {
-    using SmemAccessor<T, Layout>::SmemAccessor;
-};
-
-template<class T, class Layout>
+template <class T, class Layout>
 struct SmemAccessorV2<T, Layout, kColMajor> {
-    SmemAccessor<T, Layout> base_;
+  SmemAccessor<T, Layout> base_;
 
-    __device__ SmemAccessorV2(get_pointer_type<T> ptr): base_{ptr} {}
-    __device__ T& operator()(int m, int k)
-    {
-        return base_(k, m);
-    }
+  __device__ SmemAccessorV2(get_pointer_type<T> ptr) : base_{ptr} {}
+  __device__ T& operator()(int m, int k) { return base_(k, m); }
 };
 
-template<class T, Order order, int M_, int K_, int FragSize, int FragNum_, int RepeatC = 1>
+template <class T, Order order, int M_, int K_, int FragSize, int FragNum_,
+          int RepeatC = 1>
 struct SmemCopyAtom_Pack_v2 {
-    static constexpr int M = M_;
-    static constexpr int K = K_;
+  static constexpr int M = M_;
+  static constexpr int K = K_;
 
-    static constexpr int kFragNum = FragNum_;
+  static constexpr int kFragNum = FragNum_;
 
-    using Frag = Array<T, FragSize * kFragNum>;
+  using Frag = Array<T, FragSize * kFragNum>;
 
-    __device__ static int2 get_offset(int thread_idx)  // -> (m, k)
-    {
-        const int lane_id = thread_idx % WARP_SIZE;
+  __device__ static int2 get_offset(int thread_idx)  // -> (m, k)
+  {
+    const int lane_id = thread_idx % WARP_SIZE;
 
-        const int c = lane_id / RepeatC * Frag::size();
+    const int c = lane_id / RepeatC * Frag::size();
 
-        return order == kRowMajor ? int2{0, c} : int2{c, 0};
+    return order == kRowMajor ? int2{0, c} : int2{c, 0};
+  }
+
+  template <class S, class D>
+  __device__ static void copy(S src_ptr, D dst_ptr, bool mask) {
+    auto dst_raw_ptr = (T*)dst_ptr;  // SubBytePtr<T> -> T*
+    if (mask) {
+      Lds(*(Frag*)dst_raw_ptr, src_ptr);
     }
-
-    template<class S, class D>
-    __device__ static void copy(S src_ptr, D dst_ptr, bool mask)
-    {
-        auto dst_raw_ptr = (T*)dst_ptr;  // SubBytePtr<T> -> T*
-        if (mask) {
-            Lds(*(Frag*)dst_raw_ptr, src_ptr);
-        }
-    }
+  }
 };
 
-template<class T, class CopyAtom, Order order, int FragNum_>
+template <class T, class CopyAtom, Order order, int FragNum_>
 struct SmemCopyAtom_Pack_v3 {
-    static constexpr int M = CopyAtom::M * FragNum_;
-    static constexpr int K = CopyAtom::K;
+  static constexpr int M = CopyAtom::M * FragNum_;
+  static constexpr int K = CopyAtom::K;
 
-    static constexpr int kFragNum = FragNum_;
+  static constexpr int kFragNum = FragNum_;
 
-    using Frag = Array<T, CopyAtom::Frag::size() * kFragNum>;
+  using Frag = Array<T, CopyAtom::Frag::size() * kFragNum>;
 
-    __device__ static int2 get_offset(int thread_idx)  // -> (m, k)
-    {
-        const int c = CopyAtom::unique(thread_idx, 0).x * Frag::size();
+  __device__ static int2 get_offset(int thread_idx)  // -> (m, k)
+  {
+    const int c = CopyAtom::unique(thread_idx, 0).x * Frag::size();
 
-        return order == kRowMajor ? int2{0, c} : int2{c, 0};
+    return order == kRowMajor ? int2{0, c} : int2{c, 0};
+  }
+
+  template <class S, class D>
+  __device__ static void copy(S src_ptr, D dst_ptr, bool mask) {
+    if (mask) {
+      auto dst_raw_ptr = (T*)dst_ptr;  // SubBytePtr<T> -> T*
+      Lds(*(Frag*)dst_raw_ptr, src_ptr);
     }
-
-    template<class S, class D>
-    __device__ static void copy(S src_ptr, D dst_ptr, bool mask)
-    {
-        if (mask) {
-            auto dst_raw_ptr = (T*)dst_ptr;  // SubBytePtr<T> -> T*
-            Lds(*(Frag*)dst_raw_ptr, src_ptr);
-        }
-    }
+  }
 };
 
-template<class Operand, int iM, int iK, int dM, int dK>
+template <class Operand, int iM, int iK, int dM, int dK>
 struct SmemCopy {
-    using Atom = typename Operand::SmemCopyAtom;
+  using Atom = typename Operand::SmemCopyAtom;
 
-    static constexpr int kFragNum = Atom::kFragNum;
+  static constexpr int kFragNum = Atom::kFragNum;
 
-    static constexpr int ITER_M = iM / Atom::kFragNum;
+  static constexpr int ITER_M = iM / Atom::kFragNum;
 
-    static_assert(ITER_M > 0);
+  static_assert(ITER_M > 0);
 
-    using Frag = typename Atom::Frag[ITER_M];
+  using Frag = typename Atom::Frag[ITER_M];
 
-    using Pack = Packing_v2<Operand::kPack, Operand::kOrder>;
+  using Pack = Packing_v2<Operand::kPack, Operand::kOrder>;
 
-    static constexpr int2 delta = Pack::apply(int2{dM * kFragNum, dK});
+  static constexpr int2 delta = Pack::apply(int2{dM * kFragNum, dK});
 
-    using Layout = typename Operand::SmemLayout;
+  using Layout = typename Operand::SmemLayout;
 
-    static constexpr int2 kMK0 = cs2mk<Operand::kOrder>(Layout::C0, Layout::S0);
+  static constexpr int2 kMK0 = cs2mk<Operand::kOrder>(Layout::C0, Layout::S0);
 
-    static constexpr int kPeriodM = ceil_div(kMK0.x, delta.x);
-    static constexpr int kPeriodK = ceil_div(kMK0.y, delta.y);
+  static constexpr int kPeriodM = ceil_div(kMK0.x, delta.x);
+  static constexpr int kPeriodK = ceil_div(kMK0.y, delta.y);
 
-    const int2 offset_;
+  const int2 offset_;
 
-    int phases_[kPeriodK][kPeriodM];
+  int phases_[kPeriodK][kPeriodM];
 
-    __device__ SmemCopy(int2 offset): offset_{offset}
-    {
-        const int2 thr = Atom::get_offset(threadIdx.x);
-        PRAGMA_UNROLL
-        for (int k = 0; k < kPeriodK; ++k) {
-            PRAGMA_UNROLL
-            for (int m = 0; m < kPeriodM; ++m) {
-                const int2 pack = Pack::apply({offset.x + m * dM * kFragNum, offset.y + k * dK});
-                const int2 cs   = mk2cs<Operand::kOrder>({pack.x + thr.x, pack.y + thr.y});
-                phases_[k][m]   = Layout::apply(cs.y, cs.x);
-            }
-        }
+  __device__ SmemCopy(int2 offset) : offset_{offset} {
+    const int2 thr = Atom::get_offset(threadIdx.x);
+    PRAGMA_UNROLL
+    for (int k = 0; k < kPeriodK; ++k) {
+      PRAGMA_UNROLL
+      for (int m = 0; m < kPeriodM; ++m) {
+        const int2 pack =
+            Pack::apply({offset.x + m * dM * kFragNum, offset.y + k * dK});
+        const int2 cs =
+            mk2cs<Operand::kOrder>({pack.x + thr.x, pack.y + thr.y});
+        phases_[k][m] = Layout::apply(cs.y, cs.x);
+      }
     }
+  }
 
-    template<class Pointer>
-    __device__ void operator()(Pointer src_ptr, Frag& dst, int k, bool mask = true)
-    {
-        using Accessor = typename Operand::SmemAccessor;
-        if constexpr (Operand::kGroupSize == 1) {
-            PRAGMA_UNROLL
-            for (int m = 0; m < ITER_M; ++m) {
-                const int  mm = m / kPeriodM * kPeriodM * dM * kFragNum;
-                const int  kk = k / kPeriodK * kPeriodK * dK;
-                const int2 cs = mk2cs<Operand::kOrder>(Pack::apply(int2{mm, kk}));
-                const int  i0 = Layout::apply(cs.y, cs.x);
-                const int  i1 = phases_[k % kPeriodK][m % kPeriodM];
-                Atom::copy(&src_ptr[i0 + i1], dst[m].data(), mask);
-            }
-        }
-        else {  // generic case
-            Accessor   smem{src_ptr};
-            const int2 thr = Atom::get_offset(threadIdx.x);
-            PRAGMA_UNROLL
-            for (int m = 0; m < ITER_M; ++m) {
-                const int  mm = offset_.x + m * dM * kFragNum;
-                const int  kk = offset_.y + k * dK;  // Note: this forbids sub-tile group sizes
-                const int2 mk = Pack::apply(int2{mm, kk / Operand::kGroupSize});
-                Atom::copy(&smem(mk.x + thr.x, mk.y + thr.y), dst[m].data(), mask);
-            }
-        }
-        // else if constexpr (Operand::kPack != 0 && Operand::kGroupSize != 1) {  // group size = 1, pack != 0
-        //     const int  mask_k = Operand::kGroupSize == 1;
-        //     const int2 pack   = Pack::apply(int2{offset_.x, offset_.y});
-        //     const int2 thr    = Atom::get_offset(threadIdx.x);
-        //     const int2 cs     = mk2cs<Operand::kOrder>({pack.x + thr.x, (pack.y + thr.y) * mask_k});
-        //     auto       smem   = src_ptr + Layout::apply(cs.y, cs.x);
-        //     PRAGMA_UNROLL
-        //     for (int m = 0; m < ITER_M; ++m) {
-        //         const int  mm  = m * dM * kFragNum;
-        //         const int  kk  = k * dK;
-        //         const int2 cs  = mk2cs<Operand::kOrder>(Pack::apply(int2{mm, kk * mask_k}));
-        //         const int  idx = Layout::apply(cs.y, cs.x);
-        //         Atom::copy(&smem[idx], dst[m].data(), mask);
-        //     }
-        // }
+  template <class Pointer>
+  __device__ void operator()(Pointer src_ptr, Frag& dst, int k,
+                             bool mask = true) {
+    using Accessor = typename Operand::SmemAccessor;
+    if constexpr (Operand::kGroupSize == 1) {
+      PRAGMA_UNROLL
+      for (int m = 0; m < ITER_M; ++m) {
+        const int mm = m / kPeriodM * kPeriodM * dM * kFragNum;
+        const int kk = k / kPeriodK * kPeriodK * dK;
+        const int2 cs = mk2cs<Operand::kOrder>(Pack::apply(int2{mm, kk}));
+        const int i0 = Layout::apply(cs.y, cs.x);
+        const int i1 = phases_[k % kPeriodK][m % kPeriodM];
+        Atom::copy(&src_ptr[i0 + i1], dst[m].data(), mask);
+      }
+    } else {  // generic case
+      Accessor smem{src_ptr};
+      const int2 thr = Atom::get_offset(threadIdx.x);
+      PRAGMA_UNROLL
+      for (int m = 0; m < ITER_M; ++m) {
+        const int mm = offset_.x + m * dM * kFragNum;
+        const int kk =
+            offset_.y + k * dK;  // Note: this forbids sub-tile group sizes
+        const int2 mk = Pack::apply(int2{mm, kk / Operand::kGroupSize});
+        Atom::copy(&smem(mk.x + thr.x, mk.y + thr.y), dst[m].data(), mask);
+      }
     }
+    // else if constexpr (Operand::kPack != 0 && Operand::kGroupSize != 1) {  //
+    // group size = 1, pack != 0
+    //     const int  mask_k = Operand::kGroupSize == 1;
+    //     const int2 pack   = Pack::apply(int2{offset_.x, offset_.y});
+    //     const int2 thr    = Atom::get_offset(threadIdx.x);
+    //     const int2 cs     = mk2cs<Operand::kOrder>({pack.x + thr.x, (pack.y +
+    //     thr.y) * mask_k}); auto       smem   = src_ptr + Layout::apply(cs.y,
+    //     cs.x); PRAGMA_UNROLL for (int m = 0; m < ITER_M; ++m) {
+    //         const int  mm  = m * dM * kFragNum;
+    //         const int  kk  = k * dK;
+    //         const int2 cs  = mk2cs<Operand::kOrder>(Pack::apply(int2{mm, kk *
+    //         mask_k})); const int  idx = Layout::apply(cs.y, cs.x);
+    //         Atom::copy(&smem[idx], dst[m].data(), mask);
+    //     }
+    // }
+  }
 };
 
 }  // namespace turbomind::gemm

--- a/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/thread_group_map.h
+++ b/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/thread_group_map.h
@@ -11,103 +11,109 @@
 
 namespace turbomind::gemm {
 
-template<int M_, int N_, int K_, int TM, int TN, int TK, int GM, int GN, int GK>
+template <int M_, int N_, int K_, int TM, int TN, int TK, int GM, int GN,
+          int GK>
 struct RakedThreadGroupMap {
-    static constexpr int M = M_;
-    static constexpr int N = N_;
-    static constexpr int K = K_;
+  static constexpr int M = M_;
+  static constexpr int N = N_;
+  static constexpr int K = K_;
 
-    static constexpr int TileM = TM;
-    static constexpr int TileN = TN;
-    static constexpr int TileK = TK;
+  static constexpr int TileM = TM;
+  static constexpr int TileN = TN;
+  static constexpr int TileK = TK;
 
-    static constexpr int kGroupM = GM;
-    static constexpr int kGroupN = GN;
-    static constexpr int kGroupK = GK;
+  static constexpr int kGroupM = GM;
+  static constexpr int kGroupN = GN;
+  static constexpr int kGroupK = GK;
 
-    static constexpr int kGroupCount = GM * GN * GK;
+  static constexpr int kGroupCount = GM * GN * GK;
 
-    static constexpr int M1 = GM * TM;
-    static constexpr int N1 = GN * TN;
-    static constexpr int K1 = GK * TK;
+  static constexpr int M1 = GM * TM;
+  static constexpr int N1 = GN * TN;
+  static constexpr int K1 = GK * TK;
 
-    static constexpr int kIterM = M / M1;
-    static constexpr int kIterN = N / N1;
-    static constexpr int kIterK = K / K1;
+  static constexpr int kIterM = M / M1;
+  static constexpr int kIterN = N / N1;
+  static constexpr int kIterK = K / K1;
 
-    static constexpr int kFootprintM = kIterM * TM;
-    static constexpr int kFootprintN = kIterN * TN;
-    static constexpr int kFootprintK = kIterK * TK;
+  static constexpr int kFootprintM = kIterM * TM;
+  static constexpr int kFootprintN = kIterN * TN;
+  static constexpr int kFootprintK = kIterK * TK;
 
-    static constexpr int kDeltaM = TM;
-    static constexpr int kDeltaN = TN;
-    static constexpr int kDeltaK = TK;
+  static constexpr int kDeltaM = TM;
+  static constexpr int kDeltaN = TN;
+  static constexpr int kDeltaK = TK;
 
-    __device__ static int3 get_offset(int group_id)
-    {
-        const int m = group_id % GM;
-        const int n = group_id / GM % GN;
-        const int k = group_id / GM / GN;
-        return {m * kFootprintM, n * kFootprintN, k * kFootprintK};
-    }
+  __device__ static int3 get_offset(int group_id) {
+    const int m = group_id % GM;
+    const int n = group_id / GM % GN;
+    const int k = group_id / GM / GN;
+    return {m * kFootprintM, n * kFootprintN, k * kFootprintK};
+  }
 };
 
-template<int M_, int N_, int K_, int tM_, int tN_, int tK_, class ArrangementMN, int gK, bool rK = 0>
+template <int M_, int N_, int K_, int tM_, int tN_, int tK_,
+          class ArrangementMN, int gK, bool rK = 0>
 struct MMA_Map {
-    static constexpr int M = M_;
-    static constexpr int N = N_;
-    static constexpr int K = K_;
+  static constexpr int M = M_;
+  static constexpr int N = N_;
+  static constexpr int K = K_;
 
-    static constexpr int TileM = tM_;
-    static constexpr int TileN = tN_;
-    static constexpr int TileK = tK_;
+  static constexpr int TileM = tM_;
+  static constexpr int TileN = tN_;
+  static constexpr int TileK = tK_;
 
-    static constexpr int kGroupM = ArrangementMN::gM;
-    static constexpr int kGroupN = ArrangementMN::gN;
-    static constexpr int kGroupK = gK;
+  static constexpr int kGroupM = ArrangementMN::gM;
+  static constexpr int kGroupN = ArrangementMN::gN;
+  static constexpr int kGroupK = gK;
 
-    static constexpr int kGroupCount = kGroupM * kGroupN * kGroupK;
+  static constexpr int kGroupCount = kGroupM * kGroupN * kGroupK;
 
-    static constexpr int kIterM = M / tM_ / kGroupM;
-    static constexpr int kIterN = N / tN_ / kGroupN;
-    static constexpr int kIterK = K / tK_ / kGroupK;
+  static constexpr int kIterM = M / tM_ / kGroupM;
+  static constexpr int kIterN = N / tN_ / kGroupN;
+  static constexpr int kIterK = K / tK_ / kGroupK;
 
-    static constexpr int kFootprintM = kIterM * tM_;
-    static constexpr int kFootprintN = kIterN * tN_;
-    static constexpr int kFootprintK = kIterK * tK_;
+  static constexpr int kFootprintM = kIterM * tM_;
+  static constexpr int kFootprintN = kIterN * tN_;
+  static constexpr int kFootprintK = kIterK * tK_;
 
-    static constexpr int kDeltaM = tM_ * ArrangementMN::dM;
-    static constexpr int kDeltaN = tN_ * ArrangementMN::dN;
-    static constexpr int kDeltaK = tK_ * (rK ? gK : 1);
+  static constexpr int kDeltaM = tM_ * ArrangementMN::dM;
+  static constexpr int kDeltaN = tN_ * ArrangementMN::dN;
+  static constexpr int kDeltaK = tK_ * (rK ? gK : 1);
 
-    static constexpr auto kPartitionM = ArrangementMN::pM;
-    static constexpr auto kPartitionN = ArrangementMN::pN;
-    static constexpr auto kPartitionK = rK ? Partition::kRaked : Partition::kBlocked;
+  static constexpr auto kPartitionM = ArrangementMN::pM;
+  static constexpr auto kPartitionN = ArrangementMN::pN;
+  static constexpr auto kPartitionK =
+      rK ? Partition::kRaked : Partition::kBlocked;
 
-    __device__ static int3 get_offset(int group_id)
-    {
-        constexpr int kGroupMN = kGroupM * kGroupN;
+  __device__ static int3 get_offset(int group_id) {
+    constexpr int kGroupMN = kGroupM * kGroupN;
 
-        const auto mn = ArrangementMN::get_offset(group_id % kGroupMN, pair<M / TileM, N / TileN>{});
-        const int  k  = group_id / kGroupMN;
+    const auto mn = ArrangementMN::get_offset(group_id % kGroupMN,
+                                              pair<M / TileM, N / TileN>{});
+    const int k = group_id / kGroupMN;
 
-        return {mn.x * tM_, mn.y * tN_, k * tK_ * (rK ? 1 : kIterK)};
-    }
+    return {mn.x * tM_, mn.y * tN_, k * tK_ * (rK ? 1 : kIterK)};
+  }
 };
 
 namespace {
 
-template<class TMap>
-void Print_(TMap)
-{
-    std::cout << "M, N, K = " << TMap::M << " " << TMap::N << " " << TMap::K << "\n";
-    std::cout << "TM, TN, TK = " << TMap::TileM << " " << TMap::TileN << " " << TMap::TileK << "\n";
-    std::cout << "group count = " << TMap::kGroupCount << "\n";
-    // std::cout << "M1, N1, K1 = " << TMap::M1 << " " << TMap::N1 << " " << TMap::K1 << "\n";
-    std::cout << "itM, itN, itK = " << TMap::kIterM << " " << TMap::kIterN << " " << TMap::kIterK << "\n";
-    std::cout << "fpM, fpN, fpK = " << TMap::kFootprintM << " " << TMap::kFootprintN << " " << TMap::kFootprintK
-              << "\n";
-    std::cout << "dM, dN, dK = " << TMap::kDeltaM << " " << TMap::kDeltaN << " " << TMap::kDeltaK << "\n";
+template <class TMap>
+void Print_(TMap) {
+  std::cout << "M, N, K = " << TMap::M << " " << TMap::N << " " << TMap::K
+            << "\n";
+  std::cout << "TM, TN, TK = " << TMap::TileM << " " << TMap::TileN << " "
+            << TMap::TileK << "\n";
+  std::cout << "group count = " << TMap::kGroupCount << "\n";
+  // std::cout << "M1, N1, K1 = " << TMap::M1 << " " << TMap::N1 << " " <<
+  // TMap::K1 << "\n";
+  std::cout << "itM, itN, itK = " << TMap::kIterM << " " << TMap::kIterN << " "
+            << TMap::kIterK << "\n";
+  std::cout << "fpM, fpN, fpK = " << TMap::kFootprintM << " "
+            << TMap::kFootprintN << " " << TMap::kFootprintK << "\n";
+  std::cout << "dM, dN, dK = " << TMap::kDeltaM << " " << TMap::kDeltaN << " "
+            << TMap::kDeltaK << "\n";
 }
 
 }  // namespace

--- a/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/thread_map.h
+++ b/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/thread_map.h
@@ -12,233 +12,240 @@
 
 namespace turbomind::gemm {
 
-template<int DimC, int DimS, int AccessC, int WarpCount, int WarpThreadC = std::min(WARP_SIZE, DimC / AccessC)>
+template <int DimC, int DimS, int AccessC, int WarpCount,
+          int WarpThreadC = std::min(WARP_SIZE, DimC / AccessC)>
 struct ThreadMap {
-    static constexpr int kDimC = DimC;
-    static constexpr int kDimS = DimS;
+  static constexpr int kDimC = DimC;
+  static constexpr int kDimS = DimS;
 
-    static constexpr int kWarpCount = WarpCount;
-    static constexpr int kAccessC   = AccessC;
+  static constexpr int kWarpCount = WarpCount;
+  static constexpr int kAccessC = AccessC;
 
-    static constexpr int kWarpThreadC = WarpThreadC;
-    static constexpr int kWarpThreadS = WARP_SIZE / kWarpThreadC;
+  static constexpr int kWarpThreadC = WarpThreadC;
+  static constexpr int kWarpThreadS = WARP_SIZE / kWarpThreadC;
 
-    static_assert(kWarpThreadC <= WARP_SIZE);
+  static_assert(kWarpThreadC <= WARP_SIZE);
 
-    static constexpr int kWarpAccessC = kWarpThreadC * kAccessC;
-    static constexpr int kWarpAccessS = kWarpThreadS;
+  static constexpr int kWarpAccessC = kWarpThreadC * kAccessC;
+  static constexpr int kWarpAccessS = kWarpThreadS;
 
-    static constexpr int kWarpIterC = ceil_div(kDimC, kWarpAccessC);
-    static constexpr int kWarpIterS = ceil_div(kDimS, kWarpAccessS);
+  static constexpr int kWarpIterC = ceil_div(kDimC, kWarpAccessC);
+  static constexpr int kWarpIterS = ceil_div(kDimS, kWarpAccessS);
 
-    // Partition warps along the strided axis first to reduce strided iters
-    static constexpr int kWarpS = kWarpIterS >= kWarpCount ? kWarpCount : kWarpIterS;
-    static constexpr int kWarpC = kWarpCount > kWarpIterS ? kWarpCount / kWarpS : 1;
+  // Partition warps along the strided axis first to reduce strided iters
+  static constexpr int kWarpS =
+      kWarpIterS >= kWarpCount ? kWarpCount : kWarpIterS;
+  static constexpr int kWarpC =
+      kWarpCount > kWarpIterS ? kWarpCount / kWarpS : 1;
 
-    static constexpr int kIterC = ceil_div(kWarpIterC, kWarpC);
-    static constexpr int kIterS = ceil_div(kWarpIterS, kWarpS);
+  static constexpr int kIterC = ceil_div(kWarpIterC, kWarpC);
+  static constexpr int kIterS = ceil_div(kWarpIterS, kWarpS);
 
-    // Allow partial tile when there is ONLY 1 iteration
-    static_assert(kDimC % kWarpAccessC == 0 || kIterC == 1);
+  // Allow partial tile when there is ONLY 1 iteration
+  static_assert(kDimC % kWarpAccessC == 0 || kIterC == 1);
 
-    // static_assert(kIterC > 0);
-    // static_assert(kIterS > 0);
+  // static_assert(kIterC > 0);
+  // static_assert(kIterS > 0);
 
-    static constexpr bool kAlignedC = (kDimC % kWarpAccessC == 0) && (kWarpIterC % kWarpC == 0);
-    static constexpr bool kAlignedS = (kDimS % kWarpAccessS == 0) && (kWarpIterS % kWarpS == 0);
+  static constexpr bool kAlignedC =
+      (kDimC % kWarpAccessC == 0) && (kWarpIterC % kWarpC == 0);
+  static constexpr bool kAlignedS =
+      (kDimS % kWarpAccessS == 0) && (kWarpIterS % kWarpS == 0);
 
-    static constexpr int kFootprintC = kWarpAccessC * kIterC;
-    static constexpr int kFootprintS = kWarpAccessS * kIterS;
+  static constexpr int kFootprintC = kWarpAccessC * kIterC;
+  static constexpr int kFootprintS = kWarpAccessS * kIterS;
 
-    static constexpr int kDeltaC = kWarpAccessC;
-    static constexpr int kDeltaS = kWarpAccessS;
+  static constexpr int kDeltaC = kWarpAccessC;
+  static constexpr int kDeltaS = kWarpAccessS;
 
-    // static constexpr int kDeltaC = kWarpAccessC * kWarpC;
-    // static constexpr int kDeltaS = kWarpAccessS * kWarpS;
+  // static constexpr int kDeltaC = kWarpAccessC * kWarpC;
+  // static constexpr int kDeltaS = kWarpAccessS * kWarpS;
 
-    __device__ static int2 get_offset(int warp_id, int lane_id)
-    {
-        int warp_offset_c = warp_id % kWarpC;
-        int warp_offset_s = warp_id / kWarpC;
+  __device__ static int2 get_offset(int warp_id, int lane_id) {
+    int warp_offset_c = warp_id % kWarpC;
+    int warp_offset_s = warp_id / kWarpC;
 
-        int warp_thread_offset_c = lane_id % kWarpThreadC;
-        int warp_thread_offset_s = lane_id / kWarpThreadC;
+    int warp_thread_offset_c = lane_id % kWarpThreadC;
+    int warp_thread_offset_s = lane_id / kWarpThreadC;
 
-        int cta_thread_offset_c = kFootprintC * warp_offset_c + warp_thread_offset_c * kAccessC;
-        int cta_thread_offset_s = kFootprintS * warp_offset_s + warp_thread_offset_s;
+    int cta_thread_offset_c =
+        kFootprintC * warp_offset_c + warp_thread_offset_c * kAccessC;
+    int cta_thread_offset_s =
+        kFootprintS * warp_offset_s + warp_thread_offset_s;
 
-        // int cta_thread_offset_c = kWarpAccessC * warp_offset_c + warp_thread_offset_c * kAccessC;
-        // int cta_thread_offset_s = kWarpAccessS * warp_offset_s + warp_thread_offset_s;
+    // int cta_thread_offset_c = kWarpAccessC * warp_offset_c +
+    // warp_thread_offset_c * kAccessC; int cta_thread_offset_s = kWarpAccessS *
+    // warp_offset_s + warp_thread_offset_s;
 
-        return {cta_thread_offset_c, cta_thread_offset_s};
-    }
+    return {cta_thread_offset_c, cta_thread_offset_s};
+  }
 };
 
-template<Order order, int M, int K>
-__host__ __device__ static constexpr int2 idx2mk(int idx, pair<M, K>)
-{
-    if constexpr (order == kColMajor) {
-        return {idx % M, idx / M};
-    }
-    else {
-        return {idx / K, idx % K};
-    }
+template <Order order, int M, int K>
+__host__ __device__ static constexpr int2 idx2mk(int idx, pair<M, K>) {
+  if constexpr (order == kColMajor) {
+    return {idx % M, idx / M};
+  } else {
+    return {idx / K, idx % K};
+  }
 }
 
-enum class Partition
-{
-    kBlocked,
-    kRaked,
+enum class Partition {
+  kBlocked,
+  kRaked,
 };
 
-template<int gM_, int gN_, Order order>
+template <int gM_, int gN_, Order order>
 struct Blocked {
-    static constexpr int gM = gM_;
-    static constexpr int gN = gN_;
+  static constexpr int gM = gM_;
+  static constexpr int gN = gN_;
 
-    // static_assert((gM - 1) * sM + (gN - 1) * sN == gM * gN - 1);
+  // static_assert((gM - 1) * sM + (gN - 1) * sN == gM * gN - 1);
 
-    static constexpr int dM = 1;
-    static constexpr int dN = 1;
+  static constexpr int dM = 1;
+  static constexpr int dN = 1;
 
-    static constexpr Partition pM = Partition::kBlocked;
-    static constexpr Partition pN = Partition::kBlocked;
+  static constexpr Partition pM = Partition::kBlocked;
+  static constexpr Partition pN = Partition::kBlocked;
 
-    template<int M, int N>
-    __device__ static int2 get_offset(int idx, pair<M, N>)
-    {
-        constexpr int iM = ceil_div(M, gM);
-        constexpr int iN = ceil_div(N, gN);
+  template <int M, int N>
+  __device__ static int2 get_offset(int idx, pair<M, N>) {
+    constexpr int iM = ceil_div(M, gM);
+    constexpr int iN = ceil_div(N, gN);
 
-        // const int mi = idx / sM % gM;
-        // const int ni = idx / sN % gN;
+    // const int mi = idx / sM % gM;
+    // const int ni = idx / sN % gN;
 
-        const int2 mn = idx2mk<order>(idx, pair<gM, gN>{});
-        return {mn.x * iM, mn.y * iN};
-    }
+    const int2 mn = idx2mk<order>(idx, pair<gM, gN>{});
+    return {mn.x * iM, mn.y * iN};
+  }
 };
 
-template<int gM_, int gN_, Order order>
+template <int gM_, int gN_, Order order>
 struct Raked {
-    static constexpr int gM = gM_;
-    static constexpr int gN = gN_;
+  static constexpr int gM = gM_;
+  static constexpr int gN = gN_;
 
-    // static_assert((gM - 1) * sM + (gN - 1) * sN == gM * gN - 1);
+  // static_assert((gM - 1) * sM + (gN - 1) * sN == gM * gN - 1);
 
-    static constexpr int dM = gM;
-    static constexpr int dN = gN;
+  static constexpr int dM = gM;
+  static constexpr int dN = gN;
 
-    static constexpr Partition pM = Partition::kRaked;
-    static constexpr Partition pN = Partition::kRaked;
+  static constexpr Partition pM = Partition::kRaked;
+  static constexpr Partition pN = Partition::kRaked;
 
-    template<class Shape>
-    __device__ static int2 get_offset(int idx, Shape)
-    {
-        return idx2mk<order>(idx, pair<gM, gN>{});
-    }
+  template <class Shape>
+  __device__ static int2 get_offset(int idx, Shape) {
+    return idx2mk<order>(idx, pair<gM, gN>{});
+  }
 };
 
-template<int gM_, int gN_, Order order>
+template <int gM_, int gN_, Order order>
 struct Blocked_C_Raked_S {
-    static constexpr int gM = gM_;
-    static constexpr int gN = gN_;
+  static constexpr int gM = gM_;
+  static constexpr int gN = gN_;
 
-    static constexpr int dM = 1;
-    static constexpr int dN = gN;
+  static constexpr int dM = 1;
+  static constexpr int dN = gN;
 
-    static constexpr Partition pM = Partition::kBlocked;
-    static constexpr Partition pN = Partition::kRaked;
+  static constexpr Partition pM = Partition::kBlocked;
+  static constexpr Partition pN = Partition::kRaked;
 
-    template<int M, int N>
-    __device__ static int2 get_offset(int idx, pair<M, N>)
-    {
-        constexpr int iM = ceil_div(M, gM);
+  template <int M, int N>
+  __device__ static int2 get_offset(int idx, pair<M, N>) {
+    constexpr int iM = ceil_div(M, gM);
 
-        const int2 mn = idx2mk<order>(idx, pair<gM, gN>{});
-        return {mn.x * iM, mn.y};
-    }
+    const int2 mn = idx2mk<order>(idx, pair<gM, gN>{});
+    return {mn.x * iM, mn.y};
+  }
 };
 
-template<int C,
-         int S,
-         int AccessC,
-         template<int, int, Order>
-         typename Arrangement_,
-         int WarpCount,
-         int WarpThrC = std::min(WARP_SIZE, C / AccessC)>
+template <int C, int S, int AccessC,
+          template <int, int, Order> typename Arrangement_, int WarpCount,
+          int WarpThrC = std::min(WARP_SIZE, C / AccessC)>
 struct ThreadMap_V2 {
-    static constexpr int kDimC = C;
-    static constexpr int kDimS = S;
+  static constexpr int kDimC = C;
+  static constexpr int kDimS = S;
 
-    static constexpr int kWarpCount = WarpCount;
-    static constexpr int kAccessC   = AccessC;
+  static constexpr int kWarpCount = WarpCount;
+  static constexpr int kAccessC = AccessC;
 
-    static_assert(WarpThrC <= WARP_SIZE);
+  static_assert(WarpThrC <= WARP_SIZE);
 
-    static constexpr int kWarpThreadC = WarpThrC;
-    static constexpr int kWarpThreadS = WARP_SIZE / kWarpThreadC;
+  static constexpr int kWarpThreadC = WarpThrC;
+  static constexpr int kWarpThreadS = WARP_SIZE / kWarpThreadC;
 
-    static constexpr int kWarpAccessC = kWarpThreadC * kAccessC;
-    static constexpr int kWarpAccessS = kWarpThreadS;
+  static constexpr int kWarpAccessC = kWarpThreadC * kAccessC;
+  static constexpr int kWarpAccessS = kWarpThreadS;
 
-    static constexpr int kWarpIterC = ceil_div(kDimC, kWarpAccessC);
-    static constexpr int kWarpIterS = ceil_div(kDimS, kWarpAccessS);
+  static constexpr int kWarpIterC = ceil_div(kDimC, kWarpAccessC);
+  static constexpr int kWarpIterS = ceil_div(kDimS, kWarpAccessS);
 
-    static constexpr int kWarpS = kWarpIterS >= kWarpCount ? kWarpCount : kWarpIterS;
-    static constexpr int kWarpC = kWarpCount > kWarpIterS ? kWarpCount / kWarpS : 1;
+  static constexpr int kWarpS =
+      kWarpIterS >= kWarpCount ? kWarpCount : kWarpIterS;
+  static constexpr int kWarpC =
+      kWarpCount > kWarpIterS ? kWarpCount / kWarpS : 1;
 
-    using Arrangement = Arrangement_<kWarpC, kWarpS, kColMajor>;
+  using Arrangement = Arrangement_<kWarpC, kWarpS, kColMajor>;
 
-    static constexpr auto kPartitionM = Arrangement::pM;
-    static constexpr auto kPartitionN = Arrangement::pN;
+  static constexpr auto kPartitionM = Arrangement::pM;
+  static constexpr auto kPartitionN = Arrangement::pN;
 
-    static constexpr int kIterC = ceil_div(kWarpIterC, kWarpC);
-    static constexpr int kIterS = ceil_div(kWarpIterS, kWarpS);
+  static constexpr int kIterC = ceil_div(kWarpIterC, kWarpC);
+  static constexpr int kIterS = ceil_div(kWarpIterS, kWarpS);
 
-    static constexpr bool kAlignedC = (kDimC % kWarpAccessC == 0) && (kWarpIterC % kWarpC == 0);
-    static constexpr bool kAlignedS = (kDimS % kWarpAccessS == 0) && (kWarpIterS % kWarpS == 0);
+  static constexpr bool kAlignedC =
+      (kDimC % kWarpAccessC == 0) && (kWarpIterC % kWarpC == 0);
+  static constexpr bool kAlignedS =
+      (kDimS % kWarpAccessS == 0) && (kWarpIterS % kWarpS == 0);
 
-    static constexpr int kFootprintC = kWarpAccessC * kIterC;
-    static constexpr int kFootprintS = kWarpAccessS * kIterS;
+  static constexpr int kFootprintC = kWarpAccessC * kIterC;
+  static constexpr int kFootprintS = kWarpAccessS * kIterS;
 
-    static constexpr int kDeltaC = kWarpAccessC * Arrangement::dM;
-    static constexpr int kDeltaS = kWarpAccessS * Arrangement::dN;
+  static constexpr int kDeltaC = kWarpAccessC * Arrangement::dM;
+  static constexpr int kDeltaS = kWarpAccessS * Arrangement::dN;
 
-    __device__ static int2 get_offset(int warp_id, int lane_id)
-    {
-        const int2 warp_offset = Arrangement::get_offset(warp_id, pair<kWarpIterC, kWarpIterS>{});
+  __device__ static int2 get_offset(int warp_id, int lane_id) {
+    const int2 warp_offset =
+        Arrangement::get_offset(warp_id, pair<kWarpIterC, kWarpIterS>{});
 
-        int warp_thr_offset_c = lane_id % kWarpThreadC;
-        int warp_thr_offset_s = lane_id / kWarpThreadC;
+    int warp_thr_offset_c = lane_id % kWarpThreadC;
+    int warp_thr_offset_s = lane_id / kWarpThreadC;
 
-        if constexpr (kWarpThreadC == WARP_SIZE) {
-            warp_thr_offset_c = lane_id;
-            warp_thr_offset_s = 0;
-        }
-
-        const int offset_c = warp_offset.x * kWarpAccessC + warp_thr_offset_c * kAccessC;
-        const int offset_s = warp_offset.y * kWarpAccessS + warp_thr_offset_s;
-
-        return {offset_c, offset_s};
+    if constexpr (kWarpThreadC == WARP_SIZE) {
+      warp_thr_offset_c = lane_id;
+      warp_thr_offset_s = 0;
     }
+
+    const int offset_c =
+        warp_offset.x * kWarpAccessC + warp_thr_offset_c * kAccessC;
+    const int offset_s = warp_offset.y * kWarpAccessS + warp_thr_offset_s;
+
+    return {offset_c, offset_s};
+  }
 };
 
 namespace {
 
-template<class TMap>
-void Print(TMap)
-{
-    std::cout << "     warps: " << TMap::kWarpCount << "\n";
-    std::cout << "     shape: (" << TMap::kDimC << ", " << TMap::kDimS << ")\n";
-    std::cout << "    access: (" << TMap::kAccessC << ", " << 1 << ")\n";
-    std::cout << "warpThread: (" << TMap::kWarpThreadC << ", " << TMap::kWarpThreadS << ")\n";
-    std::cout << "warpAccess: (" << TMap::kWarpAccessC << ", " << TMap::kWarpAccessS << ")\n";
-    std::cout << "  warpIter: (" << TMap::kWarpIterC << ", " << TMap::kWarpIterS << ")\n";
-    std::cout << "      warp: (" << TMap::kWarpC << ", " << TMap::kWarpS << ")\n";
-    std::cout << "      iter: (" << TMap::kIterC << ", " << TMap::kIterS << ")\n";
-    std::cout << " footprint: (" << TMap::kFootprintC << ", " << TMap::kFootprintS << ")\n";
-    std::cout << "     delta: (" << TMap::kDeltaC << ", " << TMap::kDeltaS << ")\n";
-    std::cout << "   aligned: (" << TMap::kAlignedC << "," << TMap::kAlignedS << ")\n";
+template <class TMap>
+void Print(TMap) {
+  std::cout << "     warps: " << TMap::kWarpCount << "\n";
+  std::cout << "     shape: (" << TMap::kDimC << ", " << TMap::kDimS << ")\n";
+  std::cout << "    access: (" << TMap::kAccessC << ", " << 1 << ")\n";
+  std::cout << "warpThread: (" << TMap::kWarpThreadC << ", "
+            << TMap::kWarpThreadS << ")\n";
+  std::cout << "warpAccess: (" << TMap::kWarpAccessC << ", "
+            << TMap::kWarpAccessS << ")\n";
+  std::cout << "  warpIter: (" << TMap::kWarpIterC << ", " << TMap::kWarpIterS
+            << ")\n";
+  std::cout << "      warp: (" << TMap::kWarpC << ", " << TMap::kWarpS << ")\n";
+  std::cout << "      iter: (" << TMap::kIterC << ", " << TMap::kIterS << ")\n";
+  std::cout << " footprint: (" << TMap::kFootprintC << ", " << TMap::kFootprintS
+            << ")\n";
+  std::cout << "     delta: (" << TMap::kDeltaC << ", " << TMap::kDeltaS
+            << ")\n";
+  std::cout << "   aligned: (" << TMap::kAlignedC << "," << TMap::kAlignedS
+            << ")\n";
 }
 
 }  // namespace

--- a/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/tiled_mma.h
+++ b/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/tiled_mma.h
@@ -16,221 +16,225 @@
 
 namespace turbomind::gemm {
 
-template<class MMA_Atom_, class MMA_Map_, Order order_ = kColMajor>
+template <class MMA_Atom_, class MMA_Map_, Order order_ = kColMajor>
 struct Tiled_MMA_v2 {
-    using Atom = MMA_Atom_;
-    using Map  = MMA_Map_;
+  using Atom = MMA_Atom_;
+  using Map = MMA_Map_;
 
-    static constexpr int M = Map::M;
-    static constexpr int N = Map::N;
-    static constexpr int K = Map::K;
+  static constexpr int M = Map::M;
+  static constexpr int N = Map::N;
+  static constexpr int K = Map::K;
 
-    static constexpr int kGroupCount  = Map::kGroupCount;
-    static constexpr int kThreadCount = kGroupCount * Atom::kThreadCount;
+  static constexpr int kGroupCount = Map::kGroupCount;
+  static constexpr int kThreadCount = kGroupCount * Atom::kThreadCount;
 
-    static constexpr int kTileIterM = Map::kIterM;
-    static constexpr int kTileIterN = Map::kIterN;
-    static constexpr int kTileIterK = Map::kIterK;
+  static constexpr int kTileIterM = Map::kIterM;
+  static constexpr int kTileIterN = Map::kIterN;
+  static constexpr int kTileIterK = Map::kIterK;
 
-    static constexpr int kDeltaM = Map::kDeltaM;
-    static constexpr int kDeltaN = Map::kDeltaN;
-    static constexpr int kDeltaK = Map::kDeltaK;
+  static constexpr int kDeltaM = Map::kDeltaM;
+  static constexpr int kDeltaN = Map::kDeltaN;
+  static constexpr int kDeltaK = Map::kDeltaK;
 
-    static constexpr int kAtomM = Map::TileM / Atom::M;
-    static constexpr int kAtomN = Map::TileN / Atom::N;
-    static constexpr int kAtomK = Map::TileK / Atom::K;
+  static constexpr int kAtomM = Map::TileM / Atom::M;
+  static constexpr int kAtomN = Map::TileN / Atom::N;
+  static constexpr int kAtomK = Map::TileK / Atom::K;
 
-    static constexpr int kMmaIterM = kTileIterM * kAtomM;
-    static constexpr int kMmaIterN = kTileIterN * kAtomN;
-    static constexpr int kMmaIterK = kTileIterK * kAtomK;
+  static constexpr int kMmaIterM = kTileIterM * kAtomM;
+  static constexpr int kMmaIterN = kTileIterN * kAtomN;
+  static constexpr int kMmaIterK = kTileIterK * kAtomK;
 
-    __device__ static int3 get_offset(int thread_idx)
-    {
-        return Map::get_offset(Atom::get_group_id(thread_idx));
-    }
+  __device__ static int3 get_offset(int thread_idx) {
+    return Map::get_offset(Atom::get_group_id(thread_idx));
+  }
 
-    // (M,N)
-    template<class FragD, class FragA, class FragB, class FragC>
-    __device__ static void mma_k_iter(FragD& frag_D, const FragA& frag_A, const FragB& frag_B, const FragC& frag_C)
-    {
-        if constexpr (order_ == kColMajor) {
-            PRAGMA_UNROLL
-            for (int n = 0; n < kMmaIterN; ++n) {
-                PRAGMA_UNROLL
-                for (int m = 0; m < kMmaIterM; ++m) {
-                    int mm = n % 2 ? (kMmaIterM - m - 1) : m;
-                    Atom::fma(frag_D[mm][n], frag_A[mm], frag_B[n], frag_C[mm][n]);
-                }
-            }
+  // (M,N)
+  template <class FragD, class FragA, class FragB, class FragC>
+  __device__ static void mma_k_iter(FragD& frag_D, const FragA& frag_A,
+                                    const FragB& frag_B, const FragC& frag_C) {
+    if constexpr (order_ == kColMajor) {
+      PRAGMA_UNROLL
+      for (int n = 0; n < kMmaIterN; ++n) {
+        PRAGMA_UNROLL
+        for (int m = 0; m < kMmaIterM; ++m) {
+          int mm = n % 2 ? (kMmaIterM - m - 1) : m;
+          Atom::fma(frag_D[mm][n], frag_A[mm], frag_B[n], frag_C[mm][n]);
         }
-        else {
-            PRAGMA_UNROLL
-            for (int m = 0; m < kMmaIterM; ++m) {
-                PRAGMA_UNROLL
-                for (int n = 0; n < kMmaIterN; ++n) {
-                    int nn = n;
-                    int mm = m;
-                    Atom::fma(frag_D[mm][nn], frag_A[mm], frag_B[nn], frag_C[mm][nn]);
-                }
-            }
+      }
+    } else {
+      PRAGMA_UNROLL
+      for (int m = 0; m < kMmaIterM; ++m) {
+        PRAGMA_UNROLL
+        for (int n = 0; n < kMmaIterN; ++n) {
+          int nn = n;
+          int mm = m;
+          Atom::fma(frag_D[mm][nn], frag_A[mm], frag_B[nn], frag_C[mm][nn]);
         }
+      }
     }
+  }
 };
 
-template<class MMA>
+template <class MMA>
 struct Rearrange {
-    using Map  = typename MMA::Map;
-    using Atom = typename MMA::Atom;
+  using Map = typename MMA::Map;
+  using Atom = typename MMA::Atom;
 
-    template<class T, int V, int M, int N, class Layout, Order order, int TM, int TN>
-    __device__ static void
-    apply(Array<T, V> (&frag_C)[M][N], SmemAccessorV2<T, Layout, order>& smem_C, int2 offset_mn, pair<TM, TN>)
-    {
-        const int3 offset_mnk = MMA::get_offset(threadIdx.x);
-        const int  group_id_k = offset_mnk.z / Map::kFootprintK;
+  template <class T, int V, int M, int N, class Layout, Order order, int TM,
+            int TN>
+  __device__ static void apply(Array<T, V> (&frag_C)[M][N],
+                               SmemAccessorV2<T, Layout, order>& smem_C,
+                               int2 offset_mn, pair<TM, TN>) {
+    const int3 offset_mnk = MMA::get_offset(threadIdx.x);
+    const int group_id_k = offset_mnk.z / Map::kFootprintK;
 
-        constexpr bool kRakedM = Map::kPartitionM == Partition::kRaked;
-        constexpr bool kRakedN = Map::kPartitionN == Partition::kRaked;
+    constexpr bool kRakedM = Map::kPartitionM == Partition::kRaked;
+    constexpr bool kRakedN = Map::kPartitionN == Partition::kRaked;
 
-        static constexpr int2 kMN0 = cs2mk<order>(Layout::C0, Layout::S0);
+    static constexpr int2 kMN0 = cs2mk<order>(Layout::C0, Layout::S0);
 
-        constexpr int kPeriodM  = ceil_div(kMN0.x, Map::kDeltaM);
-        constexpr int kPeriodN  = ceil_div(kMN0.y, Map::kDeltaN);
-        constexpr int kPeriodM1 = ceil_div(kMN0.x, Atom::M);
-        constexpr int kPeriodN1 = ceil_div(kMN0.y, Atom::N);
+    constexpr int kPeriodM = ceil_div(kMN0.x, Map::kDeltaM);
+    constexpr int kPeriodN = ceil_div(kMN0.y, Map::kDeltaN);
+    constexpr int kPeriodM1 = ceil_div(kMN0.x, Atom::M);
+    constexpr int kPeriodN1 = ceil_div(kMN0.y, Atom::N);
 
-        constexpr auto offset_C = Atom::static_offset_C();
-        const int2     thr      = Atom::thread_offset_C();
+    constexpr auto offset_C = Atom::static_offset_C();
+    const int2 thr = Atom::thread_offset_C();
 
-        // Contract: All these indices is not a part of swizzling
-        int phases[kPeriodM][kPeriodN][kPeriodM1][kPeriodN1][offset_C.size()];
+    // Contract: All these indices is not a part of swizzling
+    int phases[kPeriodM][kPeriodN][kPeriodM1][kPeriodN1][offset_C.size()];
+    PRAGMA_UNROLL
+    for (int m = 0; m < kPeriodM; ++m) {
+      PRAGMA_UNROLL
+      for (int n = 0; n < kPeriodN; ++n) {
         PRAGMA_UNROLL
-        for (int m = 0; m < kPeriodM; ++m) {
+        for (int m1 = 0; m1 < kPeriodM1; ++m1) {
+          PRAGMA_UNROLL
+          for (int n1 = 0; n1 < kPeriodN1; ++n1) {
+            const int mm =
+                offset_mnk.x + m * Map::kDeltaM + m1 * Atom::M + thr.x;
+            const int nn =
+                offset_mnk.y + n * Map::kDeltaN + n1 * Atom::N + thr.y;
             PRAGMA_UNROLL
-            for (int n = 0; n < kPeriodN; ++n) {
-                PRAGMA_UNROLL
-                for (int m1 = 0; m1 < kPeriodM1; ++m1) {
-                    PRAGMA_UNROLL
-                    for (int n1 = 0; n1 < kPeriodN1; ++n1) {
-                        const int mm = offset_mnk.x + m * Map::kDeltaM + m1 * Atom::M + thr.x;
-                        const int nn = offset_mnk.y + n * Map::kDeltaN + n1 * Atom::N + thr.y;
-                        PRAGMA_UNROLL
-                        for (int i = 0; i < offset_C.size(); ++i) {
-                            const int2 cs           = mk2cs<order>(mm + offset_C[i].x, nn + offset_C[i].y);
-                            phases[m][n][m1][n1][i] = Layout::apply(cs.y, cs.x);
-                        }
-                    }
-                }
+            for (int i = 0; i < offset_C.size(); ++i) {
+              const int2 cs =
+                  mk2cs<order>(mm + offset_C[i].x, nn + offset_C[i].y);
+              phases[m][n][m1][n1][i] = Layout::apply(cs.y, cs.x);
             }
+          }
         }
+      }
+    }
 
-        constexpr int K = Map::kGroupK;
-        constexpr int C = offset_C.size();
+    constexpr int K = Map::kGroupK;
+    constexpr int C = offset_C.size();
 
-        int offsets[K][M][N][C];
-        int masks[K][M][N][C];
+    int offsets[K][M][N][C];
+    int masks[K][M][N][C];
 
+    PRAGMA_UNROLL
+    for (int k = 0; k < K; ++k) {
+      PRAGMA_UNROLL
+      for (int m = 0; m < M; ++m) {
         PRAGMA_UNROLL
-        for (int k = 0; k < K; ++k) {
-            PRAGMA_UNROLL
-            for (int m = 0; m < M; ++m) {
-                PRAGMA_UNROLL
-                for (int n = 0; n < N; ++n) {
-                    int m0 = m / MMA::kAtomM, m1 = m % MMA::kAtomM, n0 = n / MMA::kAtomN, n1 = n % MMA::kAtomN;
-                    int m01 =
-                        m0 / kPeriodM * kPeriodM * Map::kDeltaM + m1 / kPeriodM1 * kPeriodM1 * Atom::M - offset_mn.x;
-                    int n01 =
-                        n0 / kPeriodN * kPeriodN * Map::kDeltaN + n1 / kPeriodN1 * kPeriodN1 * Atom::N - offset_mn.y;
-                    const int2 cs       = mk2cs<order>(m01, n01);
-                    int        offset_0 = Layout::apply(cs.y, cs.x);
-                    PRAGMA_UNROLL
-                    for (int i = 0; i < offset_C.size(); ++i) {
-                        int offset_1        = phases[m0 % kPeriodM][n0 % kPeriodN][m1 % kPeriodM1][n1 % kPeriodN1][i];
-                        offsets[k][m][n][i] = offset_0 + offset_1;
-                        const int bm        = offset_mnk.x - offset_mn.x + m0 * Map::kDeltaM + m1 * Atom::M + thr.x;
-                        const int bn        = offset_mnk.y - offset_mn.y + n0 * Map::kDeltaN + n1 * Atom::N + thr.y;
-                        const int mm        = kRakedM ? m01 : bm;
-                        const int nn        = kRakedN ? n01 : bn;
-                        masks[k][m][n][i]   = (Map::kGroupK == 1 || group_id_k == k)
-                                            && (TM >= Map::M || (0 <= mm && mm < TM))
-                                            && (TN >= Map::N || (0 <= nn && nn < TN));
-                    }
-                }
-            }
+        for (int n = 0; n < N; ++n) {
+          int m0 = m / MMA::kAtomM, m1 = m % MMA::kAtomM, n0 = n / MMA::kAtomN,
+              n1 = n % MMA::kAtomN;
+          int m01 = m0 / kPeriodM * kPeriodM * Map::kDeltaM +
+                    m1 / kPeriodM1 * kPeriodM1 * Atom::M - offset_mn.x;
+          int n01 = n0 / kPeriodN * kPeriodN * Map::kDeltaN +
+                    n1 / kPeriodN1 * kPeriodN1 * Atom::N - offset_mn.y;
+          const int2 cs = mk2cs<order>(m01, n01);
+          int offset_0 = Layout::apply(cs.y, cs.x);
+          PRAGMA_UNROLL
+          for (int i = 0; i < offset_C.size(); ++i) {
+            int offset_1 = phases[m0 % kPeriodM][n0 % kPeriodN][m1 % kPeriodM1]
+                                 [n1 % kPeriodN1][i];
+            offsets[k][m][n][i] = offset_0 + offset_1;
+            const int bm = offset_mnk.x - offset_mn.x + m0 * Map::kDeltaM +
+                           m1 * Atom::M + thr.x;
+            const int bn = offset_mnk.y - offset_mn.y + n0 * Map::kDeltaN +
+                           n1 * Atom::N + thr.y;
+            const int mm = kRakedM ? m01 : bm;
+            const int nn = kRakedN ? n01 : bn;
+            masks[k][m][n][i] = (Map::kGroupK == 1 || group_id_k == k) &&
+                                (TM >= Map::M || (0 <= mm && mm < TM)) &&
+                                (TN >= Map::N || (0 <= nn && nn < TN));
+          }
         }
+      }
+    }
 
-        auto _store = [](auto ptr, auto offset, auto vec) {
-            if constexpr (order == kRowMajor) {
-                Store(&ptr[offset], vec);
-            }
-            else {
-                for (int i = 0; i < vec.size(); ++i) {
-                    ptr[offset + Layout::apply(i, 0)] = vec[i];
-                }
-            }
-        };
+    auto _store = [](auto ptr, auto offset, auto vec) {
+      if constexpr (order == kRowMajor) {
+        Store(&ptr[offset], vec);
+      } else {
+        for (int i = 0; i < vec.size(); ++i) {
+          ptr[offset + Layout::apply(i, 0)] = vec[i];
+        }
+      }
+    };
 
-        typename Atom::FragC_ reshape_C;
+    typename Atom::FragC_ reshape_C;
 
-        auto ptr = &smem_C(0, 0);
+    auto ptr = &smem_C(0, 0);
 
+    PRAGMA_UNROLL
+    for (int m = 0; m < M; ++m) {
+      PRAGMA_UNROLL
+      for (int n = 0; n < N; ++n) {
+        Atom::ReshapeC(frag_C[m][n], reshape_C);
         PRAGMA_UNROLL
-        for (int m = 0; m < M; ++m) {
-            PRAGMA_UNROLL
-            for (int n = 0; n < N; ++n) {
-                Atom::ReshapeC(frag_C[m][n], reshape_C);
-                PRAGMA_UNROLL
-                for (int c = 0; c < C; ++c) {
-                    auto& vec    = reshape_C[c];
-                    int   offset = offsets[0][m][n][c];
-                    if (masks[0][m][n][c]) {
-                        _store(ptr, offset, vec);
-                    }
-                }
-            }
+        for (int c = 0; c < C; ++c) {
+          auto& vec = reshape_C[c];
+          int offset = offsets[0][m][n][c];
+          if (masks[0][m][n][c]) {
+            _store(ptr, offset, vec);
+          }
         }
+      }
+    }
 
-        __syncthreads();
+    __syncthreads();
 
 #if 1
-        auto _load = [](auto ptr, auto offset, auto& vec) {
-            if constexpr (order == kRowMajor) {
-                Load(vec, &ptr[offset]);
-            }
-            else {
-                for (int i = 0; i < vec.size(); ++i) {
-                    vec[i] = ptr[offset + Layout::apply(i, 0)];
-                }
-            }
-        };
-
-        PRAGMA_UNROLL
-        for (int k = 1; k < K; ++k) {
-            PRAGMA_UNROLL
-            for (int m = 0; m < M; ++m) {
-                PRAGMA_UNROLL
-                for (int n = 0; n < N; ++n) {
-                    Atom::ReshapeC(frag_C[m][n], reshape_C);
-                    PRAGMA_UNROLL
-                    for (int c = 0; c < C; ++c) {
-                        auto& vec    = reshape_C[c];
-                        int   offset = offsets[k][m][n][c];
-                        if (masks[k][m][n][c]) {
-                            std::remove_reference_t<decltype(vec)> tmp;
-                            _load(ptr, offset, tmp);
-                            {
-                                using namespace ops;
-                                vec = vec + tmp;
-                            }
-                            _store(ptr, offset, vec);
-                        }
-                    }
-                }
-            }
-            __syncthreads();
+    auto _load = [](auto ptr, auto offset, auto& vec) {
+      if constexpr (order == kRowMajor) {
+        Load(vec, &ptr[offset]);
+      } else {
+        for (int i = 0; i < vec.size(); ++i) {
+          vec[i] = ptr[offset + Layout::apply(i, 0)];
         }
-#endif
+      }
+    };
+
+    PRAGMA_UNROLL
+    for (int k = 1; k < K; ++k) {
+      PRAGMA_UNROLL
+      for (int m = 0; m < M; ++m) {
+        PRAGMA_UNROLL
+        for (int n = 0; n < N; ++n) {
+          Atom::ReshapeC(frag_C[m][n], reshape_C);
+          PRAGMA_UNROLL
+          for (int c = 0; c < C; ++c) {
+            auto& vec = reshape_C[c];
+            int offset = offsets[k][m][n][c];
+            if (masks[k][m][n][c]) {
+              std::remove_reference_t<decltype(vec)> tmp;
+              _load(ptr, offset, tmp);
+              {
+                using namespace ops;
+                vec = vec + tmp;
+              }
+              _store(ptr, offset, vec);
+            }
+          }
+        }
+      }
+      __syncthreads();
     }
+#endif
+  }
 };
 
 }  // namespace turbomind::gemm

--- a/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/tma.h
+++ b/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/tma.h
@@ -10,34 +10,31 @@ namespace turbomind::gemm {
 
 #if __CUDACC_VER_MAJOR__ >= 12
 
-CUtensorMap make_2d_tma_desc(void*              global_address,
-                             DataType           data_type,
-                             uint32_t           gmem_rows,
-                             uint32_t           gmem_cols,
-                             uint32_t           smem_rows,
-                             uint32_t           smem_cols,
-                             Order              order,
-                             CUtensorMapSwizzle swizzle,
-                             int                ld = 0);
+CUtensorMap make_2d_tma_desc(void* global_address, DataType data_type,
+                             uint32_t gmem_rows, uint32_t gmem_cols,
+                             uint32_t smem_rows, uint32_t smem_cols,
+                             Order order, CUtensorMapSwizzle swizzle,
+                             int ld = 0);
 
-CUtensorMap make_2d_tma_desc(void* ptr, const MatrixLayout& desc, uint2 smem_shape, CUtensorMapSwizzle swizzle);
+CUtensorMap make_2d_tma_desc(void* ptr, const MatrixLayout& desc,
+                             uint2 smem_shape, CUtensorMapSwizzle swizzle);
 
-constexpr CUtensorMapSwizzle get_tma_swizzle(int bytes)
-{
-    switch (bytes) {
-        case 128:
-            return CU_TENSOR_MAP_SWIZZLE_128B;
-        case 64:
-            return CU_TENSOR_MAP_SWIZZLE_64B;
-        case 32:
-            return CU_TENSOR_MAP_SWIZZLE_32B;
-        case 16:  // unit swizzle is equivalent to "none"
-        case 0:
-            return CU_TENSOR_MAP_SWIZZLE_NONE;
-        default:
-            throw std::logic_error("unsupported swizzle type: " + std::to_string(bytes));
-    }
-    return {};
+constexpr CUtensorMapSwizzle get_tma_swizzle(int bytes) {
+  switch (bytes) {
+    case 128:
+      return CU_TENSOR_MAP_SWIZZLE_128B;
+    case 64:
+      return CU_TENSOR_MAP_SWIZZLE_64B;
+    case 32:
+      return CU_TENSOR_MAP_SWIZZLE_32B;
+    case 16:  // unit swizzle is equivalent to "none"
+    case 0:
+      return CU_TENSOR_MAP_SWIZZLE_NONE;
+    default:
+      throw std::logic_error("unsupported swizzle type: " +
+                             std::to_string(bytes));
+  }
+  return {};
 }
 
 #endif

--- a/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/transform.h
+++ b/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/transform.h
@@ -13,147 +13,143 @@
 namespace turbomind::gemm {
 
 struct Transform_Default {
-    template<class T, int Nf, int Mf, int K, int Nd, int Md, class S>
-    __device__ static void apply(Array<T, Nf> (&frag)[K][Mf], int k, Array<T, Nd> (&data)[K][Md], S&, int div)
-    {
-        static_assert(Nf * Mf == Nd * Md);
-        static_assert(Nd % Nf == 0 && Mf % Md == 0);
-        static_assert(sizeof(frag) == sizeof(data));
+  template <class T, int Nf, int Mf, int K, int Nd, int Md, class S>
+  __device__ static void apply(Array<T, Nf> (&frag)[K][Mf], int k,
+                               Array<T, Nd> (&data)[K][Md], S&, int div) {
+    static_assert(Nf * Mf == Nd * Md);
+    static_assert(Nd % Nf == 0 && Mf % Md == 0);
+    static_assert(sizeof(frag) == sizeof(data));
 
-        // Alignment must be manually enforced for `reinterpret_cast`
-        auto& frag_k = reinterpret_cast<Array<T, Nd>(&)[Md]>(frag[k]);
-        auto& data_k = data[k];
+    // Alignment must be manually enforced for `reinterpret_cast`
+    auto& frag_k = reinterpret_cast<Array<T, Nd>(&)[Md]>(frag[k]);
+    auto& data_k = data[k];
 
-        PRAGMA_UNROLL
-        for (int i = 0; i < std::size(frag_k); ++i) {
-            frag_k[i] = data_k[i];
-        }
+    PRAGMA_UNROLL
+    for (int i = 0; i < std::size(frag_k); ++i) {
+      frag_k[i] = data_k[i];
     }
+  }
 };
 
-template<int StatStepS, int StatStepC>
+template <int StatStepS, int StatStepC>
 struct Transform_HMMA_16816 {
-    template<class F, int Nf, int Mf, int K, class D, int Nd, int Md, class S, int Ns, int Ms, int Ks>
-    __device__ static void
-    apply(Array<F, Nf> (&frag)[K][Mf], int k, Array<D, Nd> (&data)[K][Md], Array<S, Ns> (&stat)[Ks][Ms], int div)
-    {
-        static_assert(Nf * Mf == Nd * Md);
-        static_assert(Nd % Nf == 0 && Mf % Md == 0);
-        static_assert(Nf * Mf == Ns * Ms * 4);
+  template <class F, int Nf, int Mf, int K, class D, int Nd, int Md, class S,
+            int Ns, int Ms, int Ks>
+  __device__ static void apply(Array<F, Nf> (&frag)[K][Mf], int k,
+                               Array<D, Nd> (&data)[K][Md],
+                               Array<S, Ns> (&stat)[Ks][Ms], int div) {
+    static_assert(Nf * Mf == Nd * Md);
+    static_assert(Nd % Nf == 0 && Mf % Md == 0);
+    static_assert(Nf * Mf == Ns * Ms * 4);
 
-        auto& frag_k = reinterpret_cast<Array<F, Nd>(&)[Md]>(frag[k]);
-        auto& stat_k = reinterpret_cast<Array<S, 1>(&)[Ns * Ms]>(stat[k / div]);
-        auto& data_k = data[k];
+    auto& frag_k = reinterpret_cast<Array<F, Nd>(&)[Md]>(frag[k]);
+    auto& stat_k = reinterpret_cast<Array<S, 1>(&)[Ns * Ms]>(stat[k / div]);
+    auto& data_k = data[k];
 
+    PRAGMA_UNROLL
+    for (int m = 0; m < Md; ++m) {
+      auto tmp = ConvertKvCache<D, F>::convert(data_k[m]);
+      static_assert(Nd % 8 == 0);
+      PRAGMA_UNROLL
+      for (int i = 0; i < Nd; i += 8) {
         PRAGMA_UNROLL
-        for (int m = 0; m < Md; ++m) {
-            auto tmp = ConvertKvCache<D, F>::convert(data_k[m]);
-            static_assert(Nd % 8 == 0);
-            PRAGMA_UNROLL
-            for (int i = 0; i < Nd; i += 8) {
-                PRAGMA_UNROLL
-                for (int s = 0; s < 2; ++s) {
-                    PRAGMA_UNROLL
-                    for (int c = 0; c < 2; ++c) {
-                        const int idx = (m * Nd + i) / 8 * 2 + s * StatStepS + c * StatStepC;
-                        dequant((Array<F, 2>&)tmp[i + s * 4 + c * 2], stat_k[idx]);
-                    }
-                }
-            }
-
-            frag_k[m] = tmp;
+        for (int s = 0; s < 2; ++s) {
+          PRAGMA_UNROLL
+          for (int c = 0; c < 2; ++c) {
+            const int idx =
+                (m * Nd + i) / 8 * 2 + s * StatStepS + c * StatStepC;
+            dequant((Array<F, 2>&)tmp[i + s * 4 + c * 2], stat_k[idx]);
+          }
         }
-    }
+      }
 
-    template<class F>
-    __device__ static void dequant(Array<F, 2>& x, Array<uint32_t, 1> s)
-    {
-        Array<F, 2>& _s = (Array<F, 2>&)s;
-        x[0]            = __hfma(x[0], _s[0], _s[1]);
-        x[1]            = __hfma(x[1], _s[0], _s[1]);
+      frag_k[m] = tmp;
     }
+  }
 
-    __device__ static void dequant(Array<bfloat16_t, 2>& x, Array<uint8_t, 1> s)
-    {
-        bfloat16_t s1 = __ushort_as_bfloat16((uint16_t)s[0] << 7);
-        x[0]          = __hmul(x[0], s1);
-        x[1]          = __hmul(x[1], s1);
-    }
+  template <class F>
+  __device__ static void dequant(Array<F, 2>& x, Array<uint32_t, 1> s) {
+    Array<F, 2>& _s = (Array<F, 2>&)s;
+    x[0] = __hfma(x[0], _s[0], _s[1]);
+    x[1] = __hfma(x[1], _s[0], _s[1]);
+  }
 
-    __device__ static void dequant(Array<half_t, 2>& x, Array<uint8_t, 1> s)
-    {
-        // half_t s1 = __ushort_as_half(((uint16_t)s[0] + 15 - 127) << 10);
-        // Adjusted in `AdjustUe8m0ScaleForHalf`
-        half_t s1 = __ushort_as_half((uint16_t)s[0] << 10);
-        x[0]      = __hmul(x[0], s1);
-        x[1]      = __hmul(x[1], s1);
-    }
+  __device__ static void dequant(Array<bfloat16_t, 2>& x, Array<uint8_t, 1> s) {
+    bfloat16_t s1 = __ushort_as_bfloat16((uint16_t)s[0] << 7);
+    x[0] = __hmul(x[0], s1);
+    x[1] = __hmul(x[1], s1);
+  }
 
-    __device__ static void dequant(Array<bfloat16_t, 2>& x, Array<uint16_t, 1> s)
-    {
-        auto s1 = __ushort_as_bfloat16(s[0]);
-        x[0]    = __hmul(x[0], s1);
-        x[1]    = __hmul(x[1], s1);
-    }
+  __device__ static void dequant(Array<half_t, 2>& x, Array<uint8_t, 1> s) {
+    // half_t s1 = __ushort_as_half(((uint16_t)s[0] + 15 - 127) << 10);
+    // Adjusted in `AdjustUe8m0ScaleForHalf`
+    half_t s1 = __ushort_as_half((uint16_t)s[0] << 10);
+    x[0] = __hmul(x[0], s1);
+    x[1] = __hmul(x[1], s1);
+  }
 
-    __device__ static void dequant(Array<half, 2>& x, Array<uint16_t, 1> s)
-    {
-        auto s1 = __ushort_as_half(s[0]);
-        x[0]    = __hmul(x[0], s1);
-        x[1]    = __hmul(x[1], s1);
-    }
+  __device__ static void dequant(Array<bfloat16_t, 2>& x,
+                                 Array<uint16_t, 1> s) {
+    auto s1 = __ushort_as_bfloat16(s[0]);
+    x[0] = __hmul(x[0], s1);
+    x[1] = __hmul(x[1], s1);
+  }
+
+  __device__ static void dequant(Array<half, 2>& x, Array<uint16_t, 1> s) {
+    auto s1 = __ushort_as_half(s[0]);
+    x[0] = __hmul(x[0], s1);
+    x[1] = __hmul(x[1], s1);
+  }
 };
 
 // Used by SM70 MMA
 struct Transform_HMMA_SIMT_B {
-    template<class F, int Nf, int Mf, int K, class D, int Nd, int Md, class S, int Ns, int Ms, int Ks>
-    __device__ static void
-    apply(Array<F, Nf> (&frag)[K][Mf], int k, Array<D, Nd> (&data)[K][Md], Array<S, Ns> (&stat)[Ks][Ms], int div)
-    {
-        static_assert(Nf * Mf == Nd * Md);
-        static_assert(Nd % Nf == 0 && Mf % Md == 0);
+  template <class F, int Nf, int Mf, int K, class D, int Nd, int Md, class S,
+            int Ns, int Ms, int Ks>
+  __device__ static void apply(Array<F, Nf> (&frag)[K][Mf], int k,
+                               Array<D, Nd> (&data)[K][Md],
+                               Array<S, Ns> (&stat)[Ks][Ms], int div) {
+    static_assert(Nf * Mf == Nd * Md);
+    static_assert(Nd % Nf == 0 && Mf % Md == 0);
 
-        auto& frag_k = reinterpret_cast<Array<F, Nd>(&)[Md]>(frag[k]);
-        auto& stat_k = reinterpret_cast<Array<S, 1>(&)[Ns * Ms]>(stat[k / div]);
-        auto& data_k = data[k];
+    auto& frag_k = reinterpret_cast<Array<F, Nd>(&)[Md]>(frag[k]);
+    auto& stat_k = reinterpret_cast<Array<S, 1>(&)[Ns * Ms]>(stat[k / div]);
+    auto& data_k = data[k];
 
-        // static_assert(Nf != Nf);
+    // static_assert(Nf != Nf);
 
-        PRAGMA_UNROLL
-        for (int m = 0; m < Md; ++m) {
-            auto tmp = ConvertKvCache<D, F>::convert(data_k[m]);
-            PRAGMA_UNROLL
-            for (int i = 0; i < Nd; i += 2) {
-                dequant((Array<F, 2>&)tmp[i], stat_k[(m * Nd + i) / Nf]);
-            }
-            frag_k[m] = tmp;
-        }
+    PRAGMA_UNROLL
+    for (int m = 0; m < Md; ++m) {
+      auto tmp = ConvertKvCache<D, F>::convert(data_k[m]);
+      PRAGMA_UNROLL
+      for (int i = 0; i < Nd; i += 2) {
+        dequant((Array<F, 2>&)tmp[i], stat_k[(m * Nd + i) / Nf]);
+      }
+      frag_k[m] = tmp;
     }
+  }
 
-    template<class F>
-    __device__ static void dequant(Array<F, 2>& x, Array<uint32_t, 1> s)
-    {
-        Array<F, 2>& _s = (Array<F, 2>&)s;
+  template <class F>
+  __device__ static void dequant(Array<F, 2>& x, Array<uint32_t, 1> s) {
+    Array<F, 2>& _s = (Array<F, 2>&)s;
 
-        x[0] = __hfma(x[0], _s[0], _s[1]);
-        x[1] = __hfma(x[1], _s[0], _s[1]);
-    }
+    x[0] = __hfma(x[0], _s[0], _s[1]);
+    x[1] = __hfma(x[1], _s[0], _s[1]);
+  }
 
-    __device__ static void dequant(Array<half_t, 2>& x, Array<uint8_t, 1> s)
-    {
-        // half_t s1 = __ushort_as_half(((uint16_t)s[0] + 15 - 127) << 10);
-        // Adjusted in `AdjustUe8m0ScaleForHalf`
-        half_t s1 = __ushort_as_half((uint16_t)s[0] << 10);
-        x[0]      = __hmul(x[0], s1);
-        x[1]      = __hmul(x[1], s1);
-    }
+  __device__ static void dequant(Array<half_t, 2>& x, Array<uint8_t, 1> s) {
+    // half_t s1 = __ushort_as_half(((uint16_t)s[0] + 15 - 127) << 10);
+    // Adjusted in `AdjustUe8m0ScaleForHalf`
+    half_t s1 = __ushort_as_half((uint16_t)s[0] << 10);
+    x[0] = __hmul(x[0], s1);
+    x[1] = __hmul(x[1], s1);
+  }
 
-    __device__ static void dequant(Array<half, 2>& x, Array<uint16_t, 1> s)
-    {
-        auto s1 = __ushort_as_half(s[0]);
-        x[0]    = __hmul(x[0], s1);
-        x[1]    = __hmul(x[1], s1);
-    }
+  __device__ static void dequant(Array<half, 2>& x, Array<uint16_t, 1> s) {
+    auto s1 = __ushort_as_half(s[0]);
+    x[0] = __hmul(x[0], s1);
+    x[1] = __hmul(x[1], s1);
+  }
 };
 
 }  // namespace turbomind::gemm

--- a/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/tuner/cache_utils.cu
+++ b/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/tuner/cache_utils.cu
@@ -4,25 +4,22 @@
 
 namespace turbomind::gemm {
 
-CacheFlushing::CacheFlushing()
-{
-    cudaDeviceProp props{};
-    cudaGetDeviceProperties(&props, 0);
+CacheFlushing::CacheFlushing() {
+  cudaDeviceProp props{};
+  cudaGetDeviceProperties(&props, 0);
 
-    size_ = props.l2CacheSize;
+  size_ = props.l2CacheSize;
 
-    cudaMalloc(&buffer_, size_);
+  cudaMalloc(&buffer_, size_);
 }
 
-void CacheFlushing::flush(cudaStream_t stream)
-{
-    thread_local CacheFlushing inst{};
-    inst(stream);
+void CacheFlushing::flush(cudaStream_t stream) {
+  thread_local CacheFlushing inst{};
+  inst(stream);
 }
 
-void CacheFlushing::operator()(cudaStream_t stream) const
-{
-    cudaMemsetAsync(buffer_, 0, size_, stream);
+void CacheFlushing::operator()(cudaStream_t stream) const {
+  cudaMemsetAsync(buffer_, 0, size_, stream);
 }
 
 }  // namespace turbomind::gemm

--- a/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/tuner/cache_utils.h
+++ b/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/tuner/cache_utils.h
@@ -7,15 +7,15 @@
 namespace turbomind::gemm {
 
 class CacheFlushing {
-public:
-    static void flush(cudaStream_t stream = {});
+ public:
+  static void flush(cudaStream_t stream = {});
 
-private:
-    CacheFlushing();
-    void operator()(cudaStream_t stream) const;
+ private:
+  CacheFlushing();
+  void operator()(cudaStream_t stream) const;
 
-    uint32_t* buffer_;
-    size_t    size_;
+  uint32_t* buffer_;
+  size_t size_;
 };
 
 }  // namespace turbomind::gemm

--- a/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/tuner/measurer.cu
+++ b/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/tuner/measurer.cu
@@ -7,83 +7,84 @@
 
 namespace turbomind::gemm {
 
-Measurer::Measurer(std::unique_ptr<StoppingCriterion> stop_criterion): stop_criterion_{std::move(stop_criterion)}
-{
-    cudaEventCreate(&ev_beg_);
-    cudaEventCreate(&ev_end_);
+Measurer::Measurer(std::unique_ptr<StoppingCriterion> stop_criterion)
+    : stop_criterion_{std::move(stop_criterion)} {
+  cudaEventCreate(&ev_beg_);
+  cudaEventCreate(&ev_end_);
 }
 
-Measurer::~Measurer()
-{
-    cudaEventDestroy(ev_beg_);
-    cudaEventDestroy(ev_end_);
-    ev_beg_ = ev_end_ = {};
+Measurer::~Measurer() {
+  cudaEventDestroy(ev_beg_);
+  cudaEventDestroy(ev_end_);
+  ev_beg_ = ev_end_ = {};
 }
 
-std::vector<Measurement>
-Measurer::Measure(const std::vector<LaunchSpec>& specs, const Launcher& launcher, cudaStream_t stream)
-{
-    std::vector<Measurement> m;
-    m.reserve(specs.size());
-    for (const auto& spec : specs) {
-        auto measure = MeasureOne(spec, launcher, stream);
-        if (measure.sample_count) {
-            m.push_back(measure);
-        }
-        /// TODO: report error
+std::vector<Measurement> Measurer::Measure(const std::vector<LaunchSpec>& specs,
+                                           const Launcher& launcher,
+                                           cudaStream_t stream) {
+  std::vector<Measurement> m;
+  m.reserve(specs.size());
+  for (const auto& spec : specs) {
+    auto measure = MeasureOne(spec, launcher, stream);
+    if (measure.sample_count) {
+      m.push_back(measure);
     }
-    return m;
+    /// TODO: report error
+  }
+  return m;
 }
 
-Measurement Measurer::MeasureOne(LaunchSpec spec, const Launcher& launcher, cudaStream_t stream)
-{
-    Stats       stats{};
-    cudaError_t status = cudaSuccess;
-    while (true) {
-        float ms{};
-        std::tie(ms, status) = ColdRun(spec, launcher, stream);
-        if (status != cudaSuccess) {
-            break;
-        }
-        stats.add_sample(ms);
-        // std::cout << spec.kernel->name() << " " << spec.swizzle << " " << stats.count() << " " << stats.mean() << " "
-        //           << stats.get_variance() << "\n";
-        if (stop_criterion_->should_stop(stats)) {
-            break;
-        }
+Measurement Measurer::MeasureOne(LaunchSpec spec, const Launcher& launcher,
+                                 cudaStream_t stream) {
+  Stats stats{};
+  cudaError_t status = cudaSuccess;
+  while (true) {
+    float ms{};
+    std::tie(ms, status) = ColdRun(spec, launcher, stream);
+    if (status != cudaSuccess) {
+      break;
     }
-    return Measurement{
-        status,
-        stats.count(),
-        stats.mean(),
-        stats.get_variance(),
-    };
+    stats.add_sample(ms);
+    // std::cout << spec.kernel->name() << " " << spec.swizzle << " " <<
+    // stats.count() << " " << stats.mean() << " "
+    //           << stats.get_variance() << "\n";
+    if (stop_criterion_->should_stop(stats)) {
+      break;
+    }
+  }
+  return Measurement{
+      status,
+      stats.count(),
+      stats.mean(),
+      stats.get_variance(),
+  };
 }
 
-std::pair<float, cudaError_t> Measurer::ColdRun(LaunchSpec spec, const Launcher& launcher, cudaStream_t stream)
-{
-    CacheFlushing::flush(stream);
+std::pair<float, cudaError_t> Measurer::ColdRun(LaunchSpec spec,
+                                                const Launcher& launcher,
+                                                cudaStream_t stream) {
+  CacheFlushing::flush(stream);
 
-    cudaEventRecord(ev_beg_, stream);
+  cudaEventRecord(ev_beg_, stream);
 
-    // std::cout << spec.kernel->name() << " " << spec.splits << " " << spec.swizzle << std::endl;
+  // std::cout << spec.kernel->name() << " " << spec.splits << " " <<
+  // spec.swizzle << std::endl;
 
-    launcher(spec, stream);
+  launcher(spec, stream);
 
-    cudaEventRecord(ev_end_, stream);
-    cudaEventSynchronize(ev_end_);
+  cudaEventRecord(ev_end_, stream);
+  cudaEventSynchronize(ev_end_);
 
-    const auto status = cudaGetLastError();
-    float      ms{};
+  const auto status = cudaGetLastError();
+  float ms{};
 
-    if (status == cudaSuccess) {
-        cudaEventElapsedTime(&ms, ev_beg_, ev_end_);
-    }
-    else {
-        TM_CHECK(status == cudaSuccess) << cudaGetErrorString(status);
-    }
+  if (status == cudaSuccess) {
+    cudaEventElapsedTime(&ms, ev_beg_, ev_end_);
+  } else {
+    TM_CHECK(status == cudaSuccess) << cudaGetErrorString(status);
+  }
 
-    return {ms, status};
+  return {ms, status};
 }
 
 }  // namespace turbomind::gemm

--- a/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/tuner/measurer.h
+++ b/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/tuner/measurer.h
@@ -10,32 +10,36 @@
 namespace turbomind::gemm {
 
 struct Measurement {
-    cudaError_t status;
-    int         sample_count;
-    float       mean;
-    float       variance;
+  cudaError_t status;
+  int sample_count;
+  float mean;
+  float variance;
 };
 
 using Launcher = std::function<int(LaunchSpec, cudaStream_t)>;
 
 class Measurer {
-public:
-    Measurer(std::unique_ptr<StoppingCriterion> stop_criterion);
+ public:
+  Measurer(std::unique_ptr<StoppingCriterion> stop_criterion);
 
-    ~Measurer();
+  ~Measurer();
 
-    std::vector<Measurement>
-    Measure(const std::vector<LaunchSpec>& specs, const Launcher& launcher, cudaStream_t stream);
+  std::vector<Measurement> Measure(const std::vector<LaunchSpec>& specs,
+                                   const Launcher& launcher,
+                                   cudaStream_t stream);
 
-private:
-    Measurement MeasureOne(LaunchSpec spec, const Launcher& launcher, cudaStream_t stream);
+ private:
+  Measurement MeasureOne(LaunchSpec spec, const Launcher& launcher,
+                         cudaStream_t stream);
 
-    std::pair<float, cudaError_t> ColdRun(LaunchSpec spec, const Launcher& launcher, cudaStream_t stream);
+  std::pair<float, cudaError_t> ColdRun(LaunchSpec spec,
+                                        const Launcher& launcher,
+                                        cudaStream_t stream);
 
-private:
-    cudaEvent_t                        ev_beg_;
-    cudaEvent_t                        ev_end_;
-    std::unique_ptr<StoppingCriterion> stop_criterion_;
+ private:
+  cudaEvent_t ev_beg_;
+  cudaEvent_t ev_end_;
+  std::unique_ptr<StoppingCriterion> stop_criterion_;
 };
 
 }  // namespace turbomind::gemm

--- a/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/tuner/params.cc
+++ b/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/tuner/params.cc
@@ -8,97 +8,95 @@
 
 namespace turbomind::gemm {
 
-void ParseTuningParams(TuningParams& params, const std::string& str)
-{
-    const auto list = ParseArgsList(str);
+void ParseTuningParams(TuningParams& params, const std::string& str) {
+  const auto list = ParseArgsList(str);
 
-    auto try_parse = [&](auto& value, auto name) {
-        auto it = std::find_if(list.begin(), list.end(), [&](auto a) { return a.first == name; });
-        if (it != list.end()) {
-            std::cout << name << " " << it->second << "\n";
-            Parse(value, it->second);
-        }
-    };
-
-    try_parse(params.max_splits, "max_splits");
-    try_parse(params.max_waves, "max_waves");
-    try_parse(params.swizzle, "swizzle");
-    try_parse(params.top_k, "top_k");
-    try_parse(params.clusters, "clusters");
-    try_parse(params.min_iter, "min_iter");
-    try_parse(params.max_iter, "max_iter");
-    try_parse(params.max_time, "max_time");
-
-    if (auto it = std::find_if(list.begin(), list.end(), [&](auto a) { return a.first == "seq"; }); it != list.end()) {
-        params.seq = ParseTuningSequence(it->second);
+  auto try_parse = [&](auto& value, auto name) {
+    auto it = std::find_if(list.begin(), list.end(),
+                           [&](auto a) { return a.first == name; });
+    if (it != list.end()) {
+      std::cout << name << " " << it->second << "\n";
+      Parse(value, it->second);
     }
+  };
+
+  try_parse(params.max_splits, "max_splits");
+  try_parse(params.max_waves, "max_waves");
+  try_parse(params.swizzle, "swizzle");
+  try_parse(params.top_k, "top_k");
+  try_parse(params.clusters, "clusters");
+  try_parse(params.min_iter, "min_iter");
+  try_parse(params.max_iter, "max_iter");
+  try_parse(params.max_time, "max_time");
+
+  if (auto it = std::find_if(list.begin(), list.end(),
+                             [&](auto a) { return a.first == "seq"; });
+      it != list.end()) {
+    params.seq = ParseTuningSequence(it->second);
+  }
 }
 
-std::vector<int> ParseTuningSequence(const std::string& str)
-{
-    const std::regex triplet(R"((\d+)-(\d+)-(\d+))");
+std::vector<int> ParseTuningSequence(const std::string& str) {
+  const std::regex triplet(R"((\d+)-(\d+)-(\d+))");
 
-    std::vector<std::array<int, 3>> generators;
+  std::vector<std::array<int, 3>> generators;
 
-    const auto tokens = ParseListOrTuple(str);
+  const auto tokens = ParseListOrTuple(str);
 
-    for (const auto& token : tokens) {
-        std::smatch match;
-        if (std::regex_match(token, match, triplet)) {
-            generators.push_back({std::stoi(match[1].str()),  //
-                                  std::stoi(match[2].str()),
-                                  std::stoi(match[3].str())});
-        }
-        else {  // must be an integer string
-            generators.push_back({std::stoi(token), 0, 0});
-        }
+  for (const auto& token : tokens) {
+    std::smatch match;
+    if (std::regex_match(token, match, triplet)) {
+      generators.push_back({std::stoi(match[1].str()),  //
+                            std::stoi(match[2].str()),
+                            std::stoi(match[3].str())});
+    } else {  // must be an integer string
+      generators.push_back({std::stoi(token), 0, 0});
     }
+  }
 
-    if (generators.size() == 1) {  // Replace sentinel of the default generators
-        auto fallback   = GetDefaultTuningGenerators();
-        fallback.back() = {generators.front().front(), 0, 0};
-        generators      = std::move(fallback);
-    }
+  if (generators.size() == 1) {  // Replace sentinel of the default generators
+    auto fallback = GetDefaultTuningGenerators();
+    fallback.back() = {generators.front().front(), 0, 0};
+    generators = std::move(fallback);
+  }
 
-    return GenerateTuningSequence(generators);
+  return GenerateTuningSequence(generators);
 }
 
-std::vector<int> GenerateTuningSequence(const std::vector<std::array<int, 3>>& generators)
-{
-    std::vector<int> ret;
-    if (generators.empty()) {
-        return ret;
-    }
-    const int last = generators.back().front();
-    // The last generator is a sentinel `(max_bs, 0, 0)`
-    for (int i = 0; i < (int)generators.size() - 1; ++i) {
-        auto [curr, next, step] = generators[i];
-        if (curr >= last) {
-            break;
-        }
-        if (next == 0 && step == 0) {  // single value
-            ret.push_back(curr);
-        }
-        else {  // generator
-            const int end = std::min(generators[i + 1][0], last);
-            while (curr < end) {
-                ret.push_back(curr);
-                if (curr == next) {
-                    step *= 2;
-                    next *= 2;
-                }
-                curr += step;
-            }
-        }
-    }
-    ret.push_back(last);
+std::vector<int> GenerateTuningSequence(
+    const std::vector<std::array<int, 3>>& generators) {
+  std::vector<int> ret;
+  if (generators.empty()) {
     return ret;
+  }
+  const int last = generators.back().front();
+  // The last generator is a sentinel `(max_bs, 0, 0)`
+  for (int i = 0; i < (int)generators.size() - 1; ++i) {
+    auto [curr, next, step] = generators[i];
+    if (curr >= last) {
+      break;
+    }
+    if (next == 0 && step == 0) {  // single value
+      ret.push_back(curr);
+    } else {  // generator
+      const int end = std::min(generators[i + 1][0], last);
+      while (curr < end) {
+        ret.push_back(curr);
+        if (curr == next) {
+          step *= 2;
+          next *= 2;
+        }
+        curr += step;
+      }
+    }
+  }
+  ret.push_back(last);
+  return ret;
 }
 
-std::vector<std::array<int, 3>> GetDefaultTuningGenerators()
-{
-    /// TODO: set generators based on device
-    return {{8, 16, 8}, {16, 64, 16}, {65536}};
+std::vector<std::array<int, 3>> GetDefaultTuningGenerators() {
+  /// TODO: set generators based on device
+  return {{8, 16, 8}, {16, 64, 16}, {65536}};
 }
 
 }  // namespace turbomind::gemm

--- a/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/tuner/params.h
+++ b/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/tuner/params.h
@@ -9,21 +9,21 @@
 namespace turbomind::gemm {
 
 struct TuningParams {
-    // Split-k params
-    int max_splits = 8;
-    int max_waves  = 10;
+  // Split-k params
+  int max_splits = 8;
+  int max_waves = 10;
 
-    // Swizzling params
-    std::vector<int> swizzle{0, 3};
+  // Swizzling params
+  std::vector<int> swizzle{0, 3};
 
-    // Sampling params for hierarchical kernel selection
-    float top_k    = 0;
-    int   clusters = 5;
-    int   min_iter = 1;
-    int   max_iter = 10;
-    float max_time = 1.f;
+  // Sampling params for hierarchical kernel selection
+  float top_k = 0;
+  int clusters = 5;
+  int min_iter = 1;
+  int max_iter = 10;
+  float max_time = 1.f;
 
-    std::vector<int> seq;
+  std::vector<int> seq;
 };
 
 // example
@@ -34,7 +34,8 @@ void ParseTuningParams(TuningParams& params, const std::string& str);
 //   16-16-128,256-128-1024,8192
 std::vector<int> ParseTuningSequence(const std::string& str);
 
-std::vector<int> GenerateTuningSequence(const std::vector<std::array<int, 3>>& generators);
+std::vector<int> GenerateTuningSequence(
+    const std::vector<std::array<int, 3>>& generators);
 
 std::vector<std::array<int, 3>> GetDefaultTuningGenerators();
 

--- a/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/tuner/sampler.cu
+++ b/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/tuner/sampler.cu
@@ -10,70 +10,72 @@
 
 namespace turbomind::gemm {
 
-template<class Cmp>
-static std::vector<int> ArgSort(size_t size, const Cmp& cmp)
-{
-    std::vector<int> idxs(size);
-    std::iota(idxs.begin(), idxs.end(), 0);
-    std::stable_sort(idxs.begin(), idxs.end(), cmp);
-    return idxs;
+template <class Cmp>
+static std::vector<int> ArgSort(size_t size, const Cmp& cmp) {
+  std::vector<int> idxs(size);
+  std::iota(idxs.begin(), idxs.end(), 0);
+  std::stable_sort(idxs.begin(), idxs.end(), cmp);
+  return idxs;
 }
 
-std::vector<LaunchSpec> Sampler::Run(std::vector<LaunchSpec> specs, const Launcher& launcher, cudaStream_t stream)
-{
-    std::vector<std::vector<LaunchSpec>> clusters;  // ptr into `specs`
-    if (k_clusters_) {
-        clusters = Cluster(specs, ClusteringParam{true, true});
+std::vector<LaunchSpec> Sampler::Run(std::vector<LaunchSpec> specs,
+                                     const Launcher& launcher,
+                                     cudaStream_t stream) {
+  std::vector<std::vector<LaunchSpec>> clusters;  // ptr into `specs`
+  if (k_clusters_) {
+    clusters = Cluster(specs, ClusteringParam{true, true});
+  } else {
+    for (auto& s : specs) {
+      clusters.push_back({s});
     }
-    else {
-        for (auto& s : specs) {
-            clusters.push_back({s});
-        }
-    }
-    // std::cout << "k_clusters=" << k_clusters_ << ", #specs" << specs.size() << ", #clusters" << clusters.size() <<
-    // "\n";
+  }
+  // std::cout << "k_clusters=" << k_clusters_ << ", #specs" << specs.size() <<
+  // ", #clusters" << clusters.size() <<
+  // "\n";
 
-    std::vector<LaunchSpec> s_1;
-    for (const auto& c : clusters) {
-        s_1.push_back(c.front());
-    }
+  std::vector<LaunchSpec> s_1;
+  for (const auto& c : clusters) {
+    s_1.push_back(c.front());
+  }
 
-    auto m_1 = measurer_.Measure(s_1, launcher, stream);
+  auto m_1 = measurer_.Measure(s_1, launcher, stream);
 
-    auto idxs = ArgSort(m_1.size(), [&](int i, int j) { return m_1[i].mean < m_1[j].mean; });
+  auto idxs = ArgSort(m_1.size(),
+                      [&](int i, int j) { return m_1[i].mean < m_1[j].mean; });
 
-    if (k_clusters_) {
-        const auto top_k = std::min(k_clusters_, (int)idxs.size());
-        idxs.resize(top_k);
+  if (k_clusters_) {
+    const auto top_k = std::min(k_clusters_, (int)idxs.size());
+    idxs.resize(top_k);
 
-        std::vector<LaunchSpec> s_2;
-        for (const auto& idx : idxs) {
-            auto& cluster = clusters[idx];
-            // Skip cluster leader
-            for (size_t j = 1; j < cluster.size(); ++j) {
-                s_2.push_back(cluster[j]);
-            }
-        }
-
-        // std::cout << "#s_2=" << s_2.size() << "\n";
-
-        auto m_2 = measurer_.Measure(s_2, launcher, stream);
-        // Merge measurements of the 2 runs
-        m_2.insert(m_2.end(), m_1.begin(), m_1.end());
-        s_2.insert(s_2.end(), s_1.begin(), s_1.end());
-        m_1.swap(m_2);
-        s_1.swap(s_2);
+    std::vector<LaunchSpec> s_2;
+    for (const auto& idx : idxs) {
+      auto& cluster = clusters[idx];
+      // Skip cluster leader
+      for (size_t j = 1; j < cluster.size(); ++j) {
+        s_2.push_back(cluster[j]);
+      }
     }
 
-    idxs = ArgSort(m_1.size(), [&](int i, int j) { return m_1[i].mean < m_1[j].mean; });
+    // std::cout << "#s_2=" << s_2.size() << "\n";
 
-    std::vector<LaunchSpec> ret;
-    for (const auto& i : idxs) {
-        s_1[i].measured = m_1[i].mean;
-        ret.push_back(s_1[i]);
-    }
+    auto m_2 = measurer_.Measure(s_2, launcher, stream);
+    // Merge measurements of the 2 runs
+    m_2.insert(m_2.end(), m_1.begin(), m_1.end());
+    s_2.insert(s_2.end(), s_1.begin(), s_1.end());
+    m_1.swap(m_2);
+    s_1.swap(s_2);
+  }
 
-    return ret;
+  idxs = ArgSort(m_1.size(),
+                 [&](int i, int j) { return m_1[i].mean < m_1[j].mean; });
+
+  std::vector<LaunchSpec> ret;
+  for (const auto& i : idxs) {
+    s_1[i].measured = m_1[i].mean;
+    ret.push_back(s_1[i]);
+  }
+
+  return ret;
 }
 
 }  // namespace turbomind::gemm

--- a/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/tuner/sampler.h
+++ b/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/tuner/sampler.h
@@ -10,14 +10,16 @@
 namespace turbomind::gemm {
 
 class Sampler {
-public:
-    explicit Sampler(Measurer& measurer, int k_clusters): measurer_{measurer}, k_clusters_{k_clusters} {}
+ public:
+  explicit Sampler(Measurer& measurer, int k_clusters)
+      : measurer_{measurer}, k_clusters_{k_clusters} {}
 
-    std::vector<LaunchSpec> Run(std::vector<LaunchSpec> specs, const Launcher& launcher, cudaStream_t stream);
+  std::vector<LaunchSpec> Run(std::vector<LaunchSpec> specs,
+                              const Launcher& launcher, cudaStream_t stream);
 
-private:
-    Measurer& measurer_;
-    int       k_clusters_;
+ private:
+  Measurer& measurer_;
+  int k_clusters_;
 };
 
 }  // namespace turbomind::gemm

--- a/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/tuner/stats.h
+++ b/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/tuner/stats.h
@@ -5,42 +5,31 @@
 namespace turbomind::gemm {
 
 class Stats {
-public:
-    Stats(): count_{}, mean_{}, m2_{} {}
+ public:
+  Stats() : count_{}, mean_{}, m2_{} {}
 
-    float mean() const noexcept
-    {
-        return mean_;
-    }
+  float mean() const noexcept { return mean_; }
 
-    float sum() const noexcept
-    {
-        return mean_ * count_;
-    }
+  float sum() const noexcept { return mean_ * count_; }
 
-    int count() const noexcept
-    {
-        return count_;
-    }
+  int count() const noexcept { return count_; }
 
-    float get_variance() const noexcept
-    {
-        return count_ < 2 ? std::numeric_limits<float>::quiet_NaN() : m2_ / count_;
-    }
+  float get_variance() const noexcept {
+    return count_ < 2 ? std::numeric_limits<float>::quiet_NaN() : m2_ / count_;
+  }
 
-    void add_sample(float x) noexcept
-    {
-        ++count_;
-        float delta = x - mean_;
-        mean_ += delta / count_;
-        float delta2 = x - mean_;
-        m2_ += delta * delta2;
-    }
+  void add_sample(float x) noexcept {
+    ++count_;
+    float delta = x - mean_;
+    mean_ += delta / count_;
+    float delta2 = x - mean_;
+    m2_ += delta * delta2;
+  }
 
-private:
-    int   count_;
-    float mean_;
-    float m2_;
+ private:
+  int count_;
+  float mean_;
+  float m2_;
 };
 
 }  // namespace turbomind::gemm

--- a/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/tuner/stopping_criterion.cc
+++ b/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/tuner/stopping_criterion.cc
@@ -7,30 +7,31 @@ namespace turbomind::gemm {
 
 namespace stopping_criterions {
 
-class Optimistic: public StoppingCriterion {
-public:
-    Optimistic(int min_iter, int max_iter, float max_ms)
-    {
-        min_iter_ = std::max(min_iter, 1);
-        max_iter_ = max_iter > 0 ? max_iter : std::numeric_limits<int>::max();
-        max_ms_   = max_ms > 0 ? max_ms : std::numeric_limits<float>::infinity();
-    }
-    bool should_stop(const Stats& stats) override
-    {
-        return stats.count() >= min_iter_ && (stats.count() >= max_iter_ || stats.sum() >= max_ms_);
-    }
+class Optimistic : public StoppingCriterion {
+ public:
+  Optimistic(int min_iter, int max_iter, float max_ms) {
+    min_iter_ = std::max(min_iter, 1);
+    max_iter_ = max_iter > 0 ? max_iter : std::numeric_limits<int>::max();
+    max_ms_ = max_ms > 0 ? max_ms : std::numeric_limits<float>::infinity();
+  }
+  bool should_stop(const Stats& stats) override {
+    return stats.count() >= min_iter_ &&
+           (stats.count() >= max_iter_ || stats.sum() >= max_ms_);
+  }
 
-private:
-    int   min_iter_;
-    int   max_iter_;
-    float max_ms_;
+ private:
+  int min_iter_;
+  int max_iter_;
+  float max_ms_;
 };
 
 }  // namespace stopping_criterions
 
-std::unique_ptr<StoppingCriterion> CreateStoppingCriterion(int min_iter, int max_iter, float max_ms)
-{
-    return std::make_unique<stopping_criterions::Optimistic>(min_iter, max_iter, max_ms);
+std::unique_ptr<StoppingCriterion> CreateStoppingCriterion(int min_iter,
+                                                           int max_iter,
+                                                           float max_ms) {
+  return std::make_unique<stopping_criterions::Optimistic>(min_iter, max_iter,
+                                                           max_ms);
 }
 
 }  // namespace turbomind::gemm

--- a/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/tuner/stopping_criterion.h
+++ b/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/tuner/stopping_criterion.h
@@ -6,11 +6,13 @@
 namespace turbomind::gemm {
 
 class StoppingCriterion {
-public:
-    virtual ~StoppingCriterion()                 = default;
-    virtual bool should_stop(const Stats& stats) = 0;
+ public:
+  virtual ~StoppingCriterion() = default;
+  virtual bool should_stop(const Stats& stats) = 0;
 };
 
-std::unique_ptr<StoppingCriterion> CreateStoppingCriterion(int min_iter, int max_iter, float max_ms);
+std::unique_ptr<StoppingCriterion> CreateStoppingCriterion(int min_iter,
+                                                           int max_iter,
+                                                           float max_ms);
 
 }  // namespace turbomind::gemm

--- a/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/types.h
+++ b/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/types.h
@@ -7,268 +7,242 @@
 #include <cuda_runtime.h>
 
 #if ENABLE_BF16
-#include <cuda_bf16.h>
+  #include <cuda_bf16.h>
 #endif
 
 namespace turbomind::gemm {
 
-enum class Order : int
-{
-    kColMajor = 0,
-    kRowMajor = 1,
+enum class Order : int {
+  kColMajor = 0,
+  kRowMajor = 1,
 };
 
 inline constexpr Order kColMajor = Order::kColMajor;
 inline constexpr Order kRowMajor = Order::kRowMajor;
 
-constexpr Order operator~(Order a)
-{
-    return a == kColMajor ? kRowMajor : kColMajor;
+constexpr Order operator~(Order a) {
+  return a == kColMajor ? kRowMajor : kColMajor;
 }
 
-constexpr const char* to_string(Order order)
-{
-    switch (order) {
-        case kColMajor:
-            return "Col";
-        case kRowMajor:
-            return "Row";
-    }
-    return "";
+constexpr const char* to_string(Order order) {
+  switch (order) {
+    case kColMajor:
+      return "Col";
+    case kRowMajor:
+      return "Row";
+  }
+  return "";
 }
 
 using Pack = uint32_t;
 
-typedef enum MMA_Tag
-{
-    HMMA_16816 = 0x100,  // sm80+
-    HMMA_1688  = 0x200,  // sm75
-    HMMA_884   = 0x300,  // sm70
-    HMMA_SIMT  = 0x400,  // sm75-
+typedef enum MMA_Tag {
+  HMMA_16816 = 0x100,  // sm80+
+  HMMA_1688 = 0x200,   // sm75
+  HMMA_884 = 0x300,    // sm70
+  HMMA_SIMT = 0x400,   // sm75-
 } MMA_Tag;
 
-typedef enum Op_Tag
-{
-    OPERAND_A = 0x010,
-    OPERAND_B = 0x020,
-    OPERAND_U = 0x030,
-    OPERAND_V = 0x040,
-    OPERAND_C = 0x050,
-    OPERAND_D = 0x060,
+typedef enum Op_Tag {
+  OPERAND_A = 0x010,
+  OPERAND_B = 0x020,
+  OPERAND_U = 0x030,
+  OPERAND_V = 0x040,
+  OPERAND_C = 0x050,
+  OPERAND_D = 0x060,
 } Op_Tag;
 
-constexpr MMA_Tag get_mma_tag(Pack pack)
-{
-    return static_cast<MMA_Tag>(pack & 0xf00);
+constexpr MMA_Tag get_mma_tag(Pack pack) {
+  return static_cast<MMA_Tag>(pack & 0xf00);
 }
 
-constexpr Op_Tag get_operand_tag(Pack pack)
-{
-    return static_cast<Op_Tag>(pack & 0x0f0);
+constexpr Op_Tag get_operand_tag(Pack pack) {
+  return static_cast<Op_Tag>(pack & 0x0f0);
 }
 
-constexpr int get_pack_num(Pack pack)
-{
-    return pack & 0x00f;
-}
+constexpr int get_pack_num(Pack pack) { return pack & 0x00f; }
 
-enum class Striding : int
-{
-    kFlat,     // [1111,2222,3333]
-    kRagged,   // [11,2222222,333]  [0 , 2      , 9  ]
-    kIndexed,  // [xx xxxxxxx xxx], [01, 2345678, 9ab]
-    kBlocked,  // [11][22222][333]
+enum class Striding : int {
+  kFlat,     // [1111,2222,3333]
+  kRagged,   // [11,2222222,333]  [0 , 2      , 9  ]
+  kIndexed,  // [xx xxxxxxx xxx], [01, 2345678, 9ab]
+  kBlocked,  // [11][22222][333]
 };
 
-inline const char* to_string(Striding striding)
-{
-    switch (striding) {
-        case Striding::kFlat:
-            return "f";
-        case Striding::kRagged:
-            return "r";
-        case Striding::kIndexed:
-            return "i";
-        case Striding::kBlocked:
-            return "b";
-        default:
-            return "unknown";
-    }
+inline const char* to_string(Striding striding) {
+  switch (striding) {
+    case Striding::kFlat:
+      return "f";
+    case Striding::kRagged:
+      return "r";
+    case Striding::kIndexed:
+      return "i";
+    case Striding::kBlocked:
+      return "b";
+    default:
+      return "unknown";
+  }
 }
 
-enum class QuantType : int
-{
-    kNone    = 0,
-    kK       = 1,
-    kM       = 2,
-    kB       = 3,
-    kDefault = kK,
+enum class QuantType : int {
+  kNone = 0,
+  kK = 1,
+  kM = 2,
+  kB = 3,
+  kDefault = kK,
 };
 
-inline const char* to_string(QuantType q)
-{
-    switch (q) {
-        case QuantType::kNone:
-            return "none";
-        case QuantType::kK:
-            return "k";
-        case QuantType::kM:
-            return "m";
-        case QuantType::kB:
-            return "b";
-        default:
-            return "unknown";
-    }
+inline const char* to_string(QuantType q) {
+  switch (q) {
+    case QuantType::kNone:
+      return "none";
+    case QuantType::kK:
+      return "k";
+    case QuantType::kM:
+      return "m";
+    case QuantType::kB:
+      return "b";
+    default:
+      return "unknown";
+  }
 }
 
-enum class Epilogue : int
-{
-    kNone               = 0,
-    kChannelCombination = 0x1,
-    kGatedSilu          = 0x2,
-    kMoeWeightedReduce  = 0x4,
-    kTileAllReduce      = 0x8,
+enum class Epilogue : int {
+  kNone = 0,
+  kChannelCombination = 0x1,
+  kGatedSilu = 0x2,
+  kMoeWeightedReduce = 0x4,
+  kTileAllReduce = 0x8,
 };
 
 struct QuantDesc {
-    QuantType type;
-    int       group_size;
+  QuantType type;
+  int group_size;
 
-    operator bool() const noexcept
-    {
-        return (int)type || group_size;
-    }
+  operator bool() const noexcept { return (int)type || group_size; }
 };
 
-inline std::string to_string(QuantDesc desc)
-{
-    if (desc) {
-        return to_string(desc.type) + std::to_string(desc.group_size);
-    }
-    else {
-        return to_string(desc.type);
-    }
+inline std::string to_string(QuantDesc desc) {
+  if (desc) {
+    return to_string(desc.type) + std::to_string(desc.group_size);
+  } else {
+    return to_string(desc.type);
+  }
 }
 
-enum class DispatchPolicy : int
-{
-    kDefault               = 0,
-    kMeasure               = 1,
-    kReuse                 = 2,
-    kAppend                = 3,
-    kPreserveDefaultSplits = 4,
-    kPreserveDefaultSplitCount = 8,
+enum class DispatchPolicy : int {
+  kDefault = 0,
+  kMeasure = 1,
+  kReuse = 2,
+  kAppend = 3,
+  kPreserveDefaultSplits = 4,
+  kPreserveDefaultSplitCount = 8,
 };
 
-constexpr bool operator&(const DispatchPolicy& a, const DispatchPolicy& b)
-{
-    return ((int)a & (int)b);
+constexpr bool operator&(const DispatchPolicy& a, const DispatchPolicy& b) {
+  return ((int)a & (int)b);
 }
 
-constexpr DispatchPolicy operator|(const DispatchPolicy& a, const DispatchPolicy& b)
-{
-    return static_cast<DispatchPolicy>((int)a | (int)b);
+constexpr DispatchPolicy operator|(const DispatchPolicy& a,
+                                   const DispatchPolicy& b) {
+  return static_cast<DispatchPolicy>((int)a | (int)b);
 }
 
 class Kernel;
 class Context;
 
 struct Tape {
-    int   ctas;
-    int   max_num;
-    int   max_ctas;
-    char* buffer;
-    int4* gemm_shapes;
-    int4* tiled_shapes;
-    int4* tile_offsets;
-    int2* iter_k_ranges;
-    int*  tile_ids;
+  int ctas;
+  int max_num;
+  int max_ctas;
+  char* buffer;
+  int4* gemm_shapes;
+  int4* tiled_shapes;
+  int4* tile_offsets;
+  int2* iter_k_ranges;
+  int* tile_ids;
 };
 
 struct Operation {
-    DispatchPolicy dispatch;
-    Epilogue       epilogue;
-    QuantDesc      quant_a;
-    QuantDesc      quant_b;
-    int            batch_dim;
-    int            dispatch_num_override;
-    int            active_group_count;
-    void*          reserved;
-    void*          tile_allreduce;
+  DispatchPolicy dispatch;
+  Epilogue epilogue;
+  QuantDesc quant_a;
+  QuantDesc quant_b;
+  int batch_dim;
+  int dispatch_num_override;
+  int active_group_count;
+  void* reserved;
+  void* tile_allreduce;
 };
 
 struct MoeWeightedReduceParam {
-    void*        out;
-    const float* sorted_weights;
-    const int*   offsets;
+  void* out;
+  const float* sorted_weights;
+  const int* offsets;
 };
 
 struct TileAllReduceParam {
-    void* signals[8];
-    void* self_signal;
-    void* rank_data;
-    void* output;
-    int   rank;
-    int   world_size;
-    int   tile_numel;
-    int   output_numel;
-    int   reducer_blocks;
-    int   kernel_reducer_blocks;
-    int   producer_grid_x;
-    int   producer_grid_y;
-    int   producer_grid_z;
+  void* signals[8];
+  void* self_signal;
+  void* rank_data;
+  void* output;
+  int rank;
+  int world_size;
+  int tile_numel;
+  int output_numel;
+  int reducer_blocks;
+  int kernel_reducer_blocks;
+  int producer_grid_x;
+  int producer_grid_y;
+  int producer_grid_z;
 };
 
-inline Operation transpose(Operation o)
-{
-    std::swap(o.quant_a, o.quant_b);
-    o.batch_dim = 1 - o.batch_dim;
-    return o;
+inline Operation transpose(Operation o) {
+  std::swap(o.quant_a, o.quant_b);
+  o.batch_dim = 1 - o.batch_dim;
+  return o;
 }
 
 struct MatrixLayout {
-    DataType type;
-    Order    order;
-    int      rows;
-    int      cols;
-    int      ld;
-    Pack     pack;
-    int      num;
-    int*     offsets;
-    int*     idxs;
-    int*     group_idxs;
+  DataType type;
+  Order order;
+  int rows;
+  int cols;
+  int ld;
+  Pack pack;
+  int num;
+  int* offsets;
+  int* idxs;
+  int* group_idxs;
 };
 
-inline std::ostream& operator<<(std::ostream& os, const MatrixLayout& x)
-{
-    os << x.type << " " << to_string(x.order) << " " << x.rows << " " << x.cols << " " << x.num << " " << x.ld;
-    return os;
+inline std::ostream& operator<<(std::ostream& os, const MatrixLayout& x) {
+  os << x.type << " " << to_string(x.order) << " " << x.rows << " " << x.cols
+     << " " << x.num << " " << x.ld;
+  return os;
 }
 
-inline int64_t byte_size(const MatrixLayout& m)
-{
-    return byte_size(m.type, (int64_t)m.rows * m.cols);
+inline int64_t byte_size(const MatrixLayout& m) {
+  return byte_size(m.type, (int64_t)m.rows * m.cols);
 }
 
-inline Striding get_mode(const MatrixLayout& m)
-{
-    if (m.idxs) {
-        return Striding::kIndexed;
-    }
-    else if (m.ld == 0 || m.offsets) {
-        return Striding::kBlocked;
-    }
-    return Striding::kFlat;
+inline Striding get_mode(const MatrixLayout& m) {
+  if (m.idxs) {
+    return Striding::kIndexed;
+  } else if (m.ld == 0 || m.offsets) {
+    return Striding::kBlocked;
+  }
+  return Striding::kFlat;
 }
 
 struct Workspace {
-    void*  barriers;
-    size_t barriers_size;
-    void*  partials;
-    size_t partials_size;
-    void*  tensormaps;
-    size_t tensormaps_size;
-    int*   flags;
+  void* barriers;
+  size_t barriers_size;
+  void* partials;
+  size_t partials_size;
+  void* tensormaps;
+  size_t tensormaps_size;
+  int* flags;
 };
 
 }  // namespace turbomind::gemm

--- a/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/unpack.cu
+++ b/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/unpack.cu
@@ -9,106 +9,108 @@ namespace turbomind {
 
 namespace {
 
-__device__ void atomic_assign_u4(uint32_t* address, uint32_t index, uint32_t value)
-{
-    uint32_t old = *address;
-    uint32_t assumed;
-    do {
-        assumed      = old;
-        uint32_t tmp = (assumed & ~(0xfu << (index * 4u))) | (value << (index * 4u));
-        old          = atomicCAS(address, assumed, tmp);
-    } while (assumed != old);
+__device__ void atomic_assign_u4(uint32_t* address, uint32_t index,
+                                 uint32_t value) {
+  uint32_t old = *address;
+  uint32_t assumed;
+  do {
+    assumed = old;
+    uint32_t tmp =
+        (assumed & ~(0xfu << (index * 4u))) | (value << (index * 4u));
+    old = atomicCAS(address, assumed, tmp);
+  } while (assumed != old);
 }
 
-__device__ uint32_t read_u4(const uint32_t* address, uint32_t index)
-{
-    return (*address >> (index * 4u)) & 0xfu;
+__device__ uint32_t read_u4(const uint32_t* address, uint32_t index) {
+  return (*address >> (index * 4u)) & 0xfu;
 }
 
-template<int... Ds>
-__global__ void permute_u4(uint* dst, const uint* src, Array<int, sizeof...(Ds)> dims)
-{
-    constexpr int N = sizeof...(Ds);
+template <int... Ds>
+__global__ void permute_u4(uint* dst, const uint* src,
+                           Array<int, sizeof...(Ds)> dims) {
+  constexpr int N = sizeof...(Ds);
 
-    size_t count = 1;
+  size_t count = 1;
+  PRAGMA_UNROLL
+  for (int i = 0; i < N; ++i) {
+    count *= dims[i];
+  }
+
+  constexpr int order[] = {Ds...};
+
+  for (int i = threadIdx.x + blockDim.x * blockIdx.x; i < count;
+       i += blockDim.x * gridDim.x) {
+    int indices[N]{};
+
     PRAGMA_UNROLL
-    for (int i = 0; i < N; ++i) {
-        count *= dims[i];
+    for (int j = N - 1, ii = i; j >= 0; --j) {
+      indices[j] = ii % dims[j];
+      ii /= dims[j];
     }
 
-    constexpr int order[] = {Ds...};
+    auto data = read_u4(src + i / 8, i % 8);
 
-    for (int i = threadIdx.x + blockDim.x * blockIdx.x; i < count; i += blockDim.x * gridDim.x) {
+    int index = 0;
 
-        int indices[N]{};
-
-        PRAGMA_UNROLL
-        for (int j = N - 1, ii = i; j >= 0; --j) {
-            indices[j] = ii % dims[j];
-            ii /= dims[j];
-        }
-
-        auto data = read_u4(src + i / 8, i % 8);
-
-        int index = 0;
-
-        PRAGMA_UNROLL
-        for (int j = N - 1, stride = 1; j >= 0; --j) {
-            index += indices[order[j]] * stride;
-            stride *= dims[order[j]];
-        }
-
-        atomic_assign_u4(dst + index / 8, index % 8, data);
+    PRAGMA_UNROLL
+    for (int j = N - 1, stride = 1; j >= 0; --j) {
+      index += indices[order[j]] * stride;
+      stride *= dims[order[j]];
     }
+
+    atomic_assign_u4(dst + index / 8, index % 8, data);
+  }
 }
 
 }  // namespace
 
 // col-major interleaved
-void unpack_awq_gemm(uint4_t* dst, const uint4_t* src, int rows, int cols, cudaStream_t st)
-{
-    Array<int, 4> shape{cols, rows / 8, 2, 4};
-    permute_u4<0, 1, 3, 2><<<512, 512, 0, st>>>((uint*)dst, (const uint*)src, shape);
+void unpack_awq_gemm(uint4_t* dst, const uint4_t* src, int rows, int cols,
+                     cudaStream_t st) {
+  Array<int, 4> shape{cols, rows / 8, 2, 4};
+  permute_u4<0, 1, 3, 2>
+      <<<512, 512, 0, st>>>((uint*)dst, (const uint*)src, shape);
 }
 
-__global__ void transpose_u4_kernel(uint4_t* dst, const uint4_t* src, int s, int c)
-{
-    const int idx_c = 8 * (threadIdx.x + blockIdx.x * blockDim.x);
-    const int idx_s = 8 * (threadIdx.y + blockIdx.y * blockDim.y);
-    if (idx_c >= c || idx_s >= s) {
-        return;
-    }
-    uint32_t ivec[8];
+__global__ void transpose_u4_kernel(uint4_t* dst, const uint4_t* src, int s,
+                                    int c) {
+  const int idx_c = 8 * (threadIdx.x + blockIdx.x * blockDim.x);
+  const int idx_s = 8 * (threadIdx.y + blockIdx.y * blockDim.y);
+  if (idx_c >= c || idx_s >= s) {
+    return;
+  }
+  uint32_t ivec[8];
+  PRAGMA_UNROLL
+  for (int i = 0; i < 8; ++i) {
+    ivec[i] = ((const uint32_t*)src)[((idx_s + i) * c + idx_c) / 8];
+  }
+  uint32_t ovec[8]{};
+  PRAGMA_UNROLL
+  for (int i = 0; i < 8; ++i) {
     PRAGMA_UNROLL
-    for (int i = 0; i < 8; ++i) {
-        ivec[i] = ((const uint32_t*)src)[((idx_s + i) * c + idx_c) / 8];
+    for (int j = 0; j < 8; ++j) {
+      ovec[i] |= (((ivec[j] >> (i * 4)) & 0xfu) << (j * 4));
     }
-    uint32_t ovec[8]{};
-    PRAGMA_UNROLL
-    for (int i = 0; i < 8; ++i) {
-        PRAGMA_UNROLL
-        for (int j = 0; j < 8; ++j) {
-            ovec[i] |= (((ivec[j] >> (i * 4)) & 0xfu) << (j * 4));
-        }
-    }
-    PRAGMA_UNROLL
-    for (int i = 0; i < 8; ++i) {
-        ((uint32_t*)dst)[((idx_c + i) * s + idx_s) / 8] = ovec[i];
-    }
+  }
+  PRAGMA_UNROLL
+  for (int i = 0; i < 8; ++i) {
+    ((uint32_t*)dst)[((idx_c + i) * s + idx_s) / 8] = ovec[i];
+  }
 }
 
-void transpose_u4(uint4_t* dst, const uint4_t* src, int s, int c, cudaStream_t st)
-{
-    if (s % 8 || c % 8) {
-        std::cerr << "transpose_u4: invalid shape (" << s << "," << c << "), must be multiple of 8" << std::endl;
-        return;
-    }
-    // Array<int, 2> shape{s, c};
-    // permute_u4<1, 0><<<512, 512, 0, st>>>((uint*)dst, (const uint*)src, shape);
+void transpose_u4(uint4_t* dst, const uint4_t* src, int s, int c,
+                  cudaStream_t st) {
+  if (s % 8 || c % 8) {
+    std::cerr << "transpose_u4: invalid shape (" << s << "," << c
+              << "), must be multiple of 8" << std::endl;
+    return;
+  }
+  // Array<int, 2> shape{s, c};
+  // permute_u4<1, 0><<<512, 512, 0, st>>>((uint*)dst, (const uint*)src, shape);
 
-    const dim3 block(16, 16);
-    const dim3 grid((c + 15) / 16, (s + 15) / 16);
-    transpose_u4_kernel<<<grid, block, 0, st>>>(dst, src, s, c);
+  const dim3 block(16, 16);
+  const dim3 grid((c + 15) / 16, (s + 15) / 16);
+  transpose_u4_kernel<<<grid, block, 0, st>>>(dst, src, s, c);
 }
 
 // load -> unpack -> extend_to_u8 -> manipulation -> compat_to_u4 -> store

--- a/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/utils.h
+++ b/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/utils.h
@@ -7,144 +7,122 @@
 
 namespace turbomind::gemm {
 
-__host__ __device__ constexpr Order transpose(Order order)
-{
-    return order == Order::kColMajor ? Order::kRowMajor : Order::kColMajor;
+__host__ __device__ constexpr Order transpose(Order order) {
+  return order == Order::kColMajor ? Order::kRowMajor : Order::kColMajor;
 }
 
-__host__ __device__ constexpr MatrixLayout transpose(MatrixLayout x)
-{
-    auto tmp = x.cols;  // `std::swap` is not constexpr
-    x.cols   = x.rows;
-    x.rows   = tmp;
-    x.order  = transpose(x.order);
-    return x;
+__host__ __device__ constexpr MatrixLayout transpose(MatrixLayout x) {
+  auto tmp = x.cols;  // `std::swap` is not constexpr
+  x.cols = x.rows;
+  x.rows = tmp;
+  x.order = transpose(x.order);
+  return x;
 }
 
-template<Order order>
-__host__ __device__ constexpr int2 mk2cs(int m, int k)
-{
-    if constexpr (order == Order::kRowMajor) {
-        return {k, m};
-    }
-    else {
-        return {m, k};
-    }
+template <Order order>
+__host__ __device__ constexpr int2 mk2cs(int m, int k) {
+  if constexpr (order == Order::kRowMajor) {
+    return {k, m};
+  } else {
+    return {m, k};
+  }
 }
 
-template<Order order>
-__host__ __device__ constexpr int2 mk2cs(int2 mk)
-{
-    return mk2cs<order>(mk.x, mk.y);
+template <Order order>
+__host__ __device__ constexpr int2 mk2cs(int2 mk) {
+  return mk2cs<order>(mk.x, mk.y);
 }
 
-template<Order order>
-__host__ __device__ constexpr int2 cs2mk(int c, int s)
-{
-    if constexpr (order == Order::kRowMajor) {
-        return {s, c};
-    }
-    else {
-        return {c, s};
-    }
+template <Order order>
+__host__ __device__ constexpr int2 cs2mk(int c, int s) {
+  if constexpr (order == Order::kRowMajor) {
+    return {s, c};
+  } else {
+    return {c, s};
+  }
 }
 
-template<Order order>
-__host__ __device__ constexpr int2 cs2mk(int2 cs)
-{
-    return cs2mk<order>(cs.x, cs.y);
+template <Order order>
+__host__ __device__ constexpr int2 cs2mk(int2 cs) {
+  return cs2mk<order>(cs.x, cs.y);
 }
 
-template<Order order>
-__host__ __device__ constexpr int2 _kn2cs(int k, int n)
-{
-    if constexpr (order == Order::kColMajor) {
-        return {k, n};
-    }
-    else {
-        return {n, k};
-    }
+template <Order order>
+__host__ __device__ constexpr int2 _kn2cs(int k, int n) {
+  if constexpr (order == Order::kColMajor) {
+    return {k, n};
+  } else {
+    return {n, k};
+  }
 }
 
-template<class Index>
-__host__ __device__ constexpr Index cs2idx(int2 cs, Index ld)
-{
-    return ld * cs.y + cs.x;
+template <class Index>
+__host__ __device__ constexpr Index cs2idx(int2 cs, Index ld) {
+  return ld * cs.y + cs.x;
 }
 
-template<class Index>
-__host__ __device__ constexpr Index cs2idx(int2 cs, Index ld, int s0)
-{
-    return ld * (cs.y + s0) + cs.x;
+template <class Index>
+__host__ __device__ constexpr Index cs2idx(int2 cs, Index ld, int s0) {
+  return ld * (cs.y + s0) + cs.x;
 }
 
-__host__ __device__ constexpr auto dot(int2 a, int2 b)
-{
-    return a.x * b.x + a.y * b.y;
+__host__ __device__ constexpr auto dot(int2 a, int2 b) {
+  return a.x * b.x + a.y * b.y;
 }
 
-__host__ __device__ constexpr auto dot(int2 a, long2 b)
-{
-    return a.x * b.x + a.y * b.y;
+__host__ __device__ constexpr auto dot(int2 a, long2 b) {
+  return a.x * b.x + a.y * b.y;
 }
 
-template<MMA_Tag mma, Op_Tag op, int num, Order order>
+template <MMA_Tag mma, Op_Tag op, int num, Order order>
 struct PackingImpl {
-    __host__ __device__ static constexpr int2 apply(int2 mk)
-    {
-        return mk;
-    }
+  __host__ __device__ static constexpr int2 apply(int2 mk) { return mk; }
 };
 
-template<Pack pack, Order order>
-struct Packing_v2: PackingImpl<get_mma_tag(pack), get_operand_tag(pack), get_pack_num(pack), order> {
-};
+template <Pack pack, Order order>
+struct Packing_v2 : PackingImpl<get_mma_tag(pack), get_operand_tag(pack),
+                                get_pack_num(pack), order> {};
 
 /// TODO: move packing utility to arch/smem_copy_xxx
 
-template<int num>
+template <int num>
 struct PackingImpl<HMMA_16816, OPERAND_A, num, kRowMajor> {
-    __host__ __device__ static constexpr int2 apply(int2 mk)
-    {
-        return {mk.x / 16 / num, mk.y * 16 * num};
-    }
+  __host__ __device__ static constexpr int2 apply(int2 mk) {
+    return {mk.x / 16 / num, mk.y * 16 * num};
+  }
 };
 
-template<int num>
+template <int num>
 struct PackingImpl<HMMA_16816, OPERAND_A, num, kColMajor> {
-    __host__ __device__ static constexpr int2 apply(int2 mk)
-    {
-        return {mk.x * 16, mk.y / 16};
-    }
+  __host__ __device__ static constexpr int2 apply(int2 mk) {
+    return {mk.x * 16, mk.y / 16};
+  }
 };
 
-template<int num, Order order>
-struct PackingImpl<HMMA_16816, OPERAND_B, num, order>: PackingImpl<HMMA_16816, OPERAND_A, num, order> {
-};
+template <int num, Order order>
+struct PackingImpl<HMMA_16816, OPERAND_B, num, order>
+    : PackingImpl<HMMA_16816, OPERAND_A, num, order> {};
 
-template<int num>
+template <int num>
 struct PackingImpl<HMMA_SIMT, OPERAND_A, num, kRowMajor> {
-    __host__ __device__ static constexpr int2 apply(int2 mk)
-    {
-        return {mk.x / (simt::OP_M * num), mk.y * simt::OP_M * num};
-    }
+  __host__ __device__ static constexpr int2 apply(int2 mk) {
+    return {mk.x / (simt::OP_M * num), mk.y * simt::OP_M * num};
+  }
 };
 
-template<int num>
+template <int num>
 struct PackingImpl<HMMA_SIMT, OPERAND_B, num, kRowMajor> {
-    __host__ __device__ static constexpr int2 apply(int2 mk)
-    {
-        return {mk.x / (simt::OP_N * num), mk.y * simt::OP_N * num};
-    }
+  __host__ __device__ static constexpr int2 apply(int2 mk) {
+    return {mk.x / (simt::OP_N * num), mk.y * simt::OP_N * num};
+  }
 };
 
-template<int num>
+template <int num>
 struct PackingImpl<HMMA_884, OPERAND_B, num, kRowMajor> {
-    __host__ __device__ static constexpr int2 apply(int2 mk)
-    {
-        // return {mk.x / (16 * num), mk.y * 16 * num};
-        return {mk.x / (32 * num), mk.y * 32 * num};
-    }
+  __host__ __device__ static constexpr int2 apply(int2 mk) {
+    // return {mk.x / (16 * num), mk.y * 16 * num};
+    return {mk.x / (32 * num), mk.y * 32 * num};
+  }
 };
 
 }  // namespace turbomind::gemm

--- a/csrc/sm70_turbomind/lmdeploy/src/turbomind/macro.h
+++ b/csrc/sm70_turbomind/lmdeploy/src/turbomind/macro.h
@@ -2,7 +2,7 @@
 
 #if !defined(__PRETTY_FUNCTION__) && !defined(__GNUC__)
 
-#define __PRETTY_FUNCTION__ __FUNCSIG__
+  #define __PRETTY_FUNCTION__ __FUNCSIG__
 
 #endif
 

--- a/csrc/sm70_turbomind/lmdeploy/src/turbomind/utils/anomaly_handler.h
+++ b/csrc/sm70_turbomind/lmdeploy/src/turbomind/utils/anomaly_handler.h
@@ -15,58 +15,57 @@
 namespace turbomind {
 
 class AnomalyHandler {
-public:
-    static constexpr size_t max_entries = 65536;
+ public:
+  static constexpr size_t max_entries = 65536;
 
-    using size_type = unsigned long long;
+  using size_type = unsigned long long;
 
-    ~AnomalyHandler();
+  ~AnomalyHandler();
 
-    static AnomalyHandler& instance();
+  static AnomalyHandler& instance();
 
-    static int level() noexcept;
+  static int level() noexcept;
 
-    void Init(int rank, int vocab_size, int fallback, int max_batch_size, cudaStream_t stream) noexcept;
+  void Init(int rank, int vocab_size, int fallback, int max_batch_size,
+            cudaStream_t stream) noexcept;
 
-    template<class T>
-    void CountAndFix(T* data, int64_t size, std::string key, int level);
+  template <class T>
+  void CountAndFix(T* data, int64_t size, std::string key, int level);
 
-    template<class T>
-    void FixLogits(T* logits, int batch_size, int level);
+  template <class T>
+  void FixLogits(T* logits, int batch_size, int level);
 
-    void Summarize(std::function<void(const int*, int)> handler);
+  void Summarize(std::function<void(const int*, int)> handler);
 
-    void Reset();
+  void Reset();
 
-private:
-    AnomalyHandler();
+ private:
+  AnomalyHandler();
 
-private:
-    struct Impl;
-    std::unique_ptr<Impl> impl_;
+ private:
+  struct Impl;
+  std::unique_ptr<Impl> impl_;
 };
 
-template<class T>
-void count_and_fix(T* data, size_t size, std::string key, int level)
-{
-    AnomalyHandler::instance().CountAndFix(data, size, key, level);
+template <class T>
+void count_and_fix(T* data, size_t size, std::string key, int level) {
+  AnomalyHandler::instance().CountAndFix(data, size, key, level);
 }
 
 void DebugTensor(Tensor& tensor, const std::string& key, int level);
 
-inline void DebugTensor(Tensor&& tensor, const std::string& key, int level)
-{
-    DebugTensor(tensor, key, level);
+inline void DebugTensor(Tensor&& tensor, const std::string& key, int level) {
+  DebugTensor(tensor, key, level);
 }
 
-#define TM_DEBUG_RAW(ptr, size, key, __level)                                                                          \
-    if (::turbomind::AnomalyHandler::level() >= __level) {                                                             \
-        ::turbomind::count_and_fix(ptr, size, key, __level);                                                           \
-    }
+#define TM_DEBUG_RAW(ptr, size, key, __level)            \
+  if (::turbomind::AnomalyHandler::level() >= __level) { \
+    ::turbomind::count_and_fix(ptr, size, key, __level); \
+  }
 
-#define TM_DEBUG_TENSOR(tensor, key, __level)                                                                          \
-    if (::turbomind::AnomalyHandler::level() >= __level) {                                                             \
-        ::turbomind::DebugTensor(tensor, key, __level);                                                                \
-    }
+#define TM_DEBUG_TENSOR(tensor, key, __level)            \
+  if (::turbomind::AnomalyHandler::level() >= __level) { \
+    ::turbomind::DebugTensor(tensor, key, __level);      \
+  }
 
 }  // namespace turbomind

--- a/csrc/sm70_turbomind/lmdeploy/src/turbomind/utils/cuda_bf16_fallbacks.cuh
+++ b/csrc/sm70_turbomind/lmdeploy/src/turbomind/utils/cuda_bf16_fallbacks.cuh
@@ -22,267 +22,268 @@
 namespace turbomind {
 
 #ifdef ENABLE_BF16
-inline __device__ float2 bf1622float2(const __nv_bfloat162 val)
-{
-#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ < 800
-    float2 f_val;
-    f_val.x = __low2float(val);
-    f_val.y = __high2float(val);
-    return f_val;
-#else
-    return __bfloat1622float2(val);
-#endif
+inline __device__ float2 bf1622float2(const __nv_bfloat162 val) {
+  #if defined(__CUDA_ARCH__) && __CUDA_ARCH__ < 800
+  float2 f_val;
+  f_val.x = __low2float(val);
+  f_val.y = __high2float(val);
+  return f_val;
+  #else
+  return __bfloat1622float2(val);
+  #endif
 }
 
-inline __device__ int16_t bf1622int16(__nv_bfloat162 val)
-{
-#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ < 800
-    float2 f_val;
-    f_val.x = max(min(__low2float(val), 127.f), -128.f);
-    f_val.y = max(min(__high2float(val), 127.f), -128.f);
-    union {
-        int8_t  int8[2];
-        int16_t int16;
-    };
-    int8[0] = static_cast<int8_t>(static_cast<short>(f_val.x));
-    int8[1] = static_cast<int8_t>(static_cast<short>(f_val.y));
-    return int16;
-#else
-    val = __hmin2(val, make_bfloat162(127., 127.));
-    val = __hmax2(val, make_bfloat162(-128., -128.));
-    union {
-        int8_t  int8[2];
-        int16_t int16;
-    };
-    int8[0] = static_cast<int8_t>(static_cast<short>(val.x));
-    int8[1] = static_cast<int8_t>(static_cast<short>(val.y));
-    return int16;
-#endif
+inline __device__ int16_t bf1622int16(__nv_bfloat162 val) {
+  #if defined(__CUDA_ARCH__) && __CUDA_ARCH__ < 800
+  float2 f_val;
+  f_val.x = max(min(__low2float(val), 127.f), -128.f);
+  f_val.y = max(min(__high2float(val), 127.f), -128.f);
+  union {
+    int8_t int8[2];
+    int16_t int16;
+  };
+  int8[0] = static_cast<int8_t>(static_cast<short>(f_val.x));
+  int8[1] = static_cast<int8_t>(static_cast<short>(f_val.y));
+  return int16;
+  #else
+  val = __hmin2(val, make_bfloat162(127., 127.));
+  val = __hmax2(val, make_bfloat162(-128., -128.));
+  union {
+    int8_t int8[2];
+    int16_t int16;
+  };
+  int8[0] = static_cast<int8_t>(static_cast<short>(val.x));
+  int8[1] = static_cast<int8_t>(static_cast<short>(val.y));
+  return int16;
+  #endif
 }
 
-inline __device__ __nv_bfloat162 float22bf162(const float2 val)
-{
-#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ < 800
-    return __floats2bfloat162_rn(val.x, val.y);
-#else
-    return __float22bfloat162_rn(val);
-#endif
+inline __device__ __nv_bfloat162 float22bf162(const float2 val) {
+  #if defined(__CUDA_ARCH__) && __CUDA_ARCH__ < 800
+  return __floats2bfloat162_rn(val.x, val.y);
+  #else
+  return __float22bfloat162_rn(val);
+  #endif
 }
 
-inline __device__ __nv_bfloat162 bf162bf162(const __nv_bfloat16 val)
-{
-#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ < 800
-    __nv_bfloat162 val2;
-    val2.x = val;
-    val2.y = val;
-    return val2;
-#else
-    return __bfloat162bfloat162(val);
-#endif
+inline __device__ __nv_bfloat162 bf162bf162(const __nv_bfloat16 val) {
+  #if defined(__CUDA_ARCH__) && __CUDA_ARCH__ < 800
+  __nv_bfloat162 val2;
+  val2.x = val;
+  val2.y = val;
+  return val2;
+  #else
+  return __bfloat162bfloat162(val);
+  #endif
 }
 
-inline __device__ __nv_bfloat162 bf16hadd2(const __nv_bfloat162 x, const __nv_bfloat162 y)
-{
-#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ < 800
-    float fxl, fxh, fyl, fyh;
-    fxl = __low2float(x);
-    fxh = __high2float(x);
-    fyl = __low2float(y);
-    fyh = __high2float(y);
-    return __floats2bfloat162_rn(fxl + fyl, fxh + fyh);
-#else
-    return __hadd2(x, y);
-#endif
+inline __device__ __nv_bfloat162 bf16hadd2(const __nv_bfloat162 x,
+                                           const __nv_bfloat162 y) {
+  #if defined(__CUDA_ARCH__) && __CUDA_ARCH__ < 800
+  float fxl, fxh, fyl, fyh;
+  fxl = __low2float(x);
+  fxh = __high2float(x);
+  fyl = __low2float(y);
+  fyh = __high2float(y);
+  return __floats2bfloat162_rn(fxl + fyl, fxh + fyh);
+  #else
+  return __hadd2(x, y);
+  #endif
 }
 
-inline __device__ __nv_bfloat16 bf16hadd(const __nv_bfloat16 x, const __nv_bfloat16 y)
-{
-#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ < 800
-    return __float2bfloat16(__bfloat162float(x) + __bfloat162float(y));
-#else
-    return __hadd(x, y);
-#endif
+inline __device__ __nv_bfloat16 bf16hadd(const __nv_bfloat16 x,
+                                         const __nv_bfloat16 y) {
+  #if defined(__CUDA_ARCH__) && __CUDA_ARCH__ < 800
+  return __float2bfloat16(__bfloat162float(x) + __bfloat162float(y));
+  #else
+  return __hadd(x, y);
+  #endif
 }
 
-inline __device__ __nv_bfloat162 bf16hsub2(const __nv_bfloat162 x, const __nv_bfloat162 y)
-{
-#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ < 800
-    float fxl, fxh, fyl, fyh;
-    fxl = __low2float(x);
-    fxh = __high2float(x);
-    fyl = __low2float(y);
-    fyh = __high2float(y);
-    return __floats2bfloat162_rn(fxl - fyl, fxh - fyh);
-#else
-    return __hsub2(x, y);
-#endif
+inline __device__ __nv_bfloat162 bf16hsub2(const __nv_bfloat162 x,
+                                           const __nv_bfloat162 y) {
+  #if defined(__CUDA_ARCH__) && __CUDA_ARCH__ < 800
+  float fxl, fxh, fyl, fyh;
+  fxl = __low2float(x);
+  fxh = __high2float(x);
+  fyl = __low2float(y);
+  fyh = __high2float(y);
+  return __floats2bfloat162_rn(fxl - fyl, fxh - fyh);
+  #else
+  return __hsub2(x, y);
+  #endif
 }
 
-inline __device__ __nv_bfloat16 bf16hsub(const __nv_bfloat16 x, const __nv_bfloat16 y)
-{
-#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ < 800
-    return __float2bfloat16(__bfloat162float(x) - __bfloat162float(y));
-#else
-    return __hsub(x, y);
-#endif
+inline __device__ __nv_bfloat16 bf16hsub(const __nv_bfloat16 x,
+                                         const __nv_bfloat16 y) {
+  #if defined(__CUDA_ARCH__) && __CUDA_ARCH__ < 800
+  return __float2bfloat16(__bfloat162float(x) - __bfloat162float(y));
+  #else
+  return __hsub(x, y);
+  #endif
 }
 
-inline __device__ __nv_bfloat162 bf16hmul2(const __nv_bfloat162 x, const __nv_bfloat162 y)
-{
-#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ < 800
-    float fxl, fxh, fyl, fyh;
-    fxl = __low2float(x);
-    fxh = __high2float(x);
-    fyl = __low2float(y);
-    fyh = __high2float(y);
-    return __floats2bfloat162_rn(fxl * fyl, fxh * fyh);
-#else
-    return __hmul2(x, y);
-#endif
+inline __device__ __nv_bfloat162 bf16hmul2(const __nv_bfloat162 x,
+                                           const __nv_bfloat162 y) {
+  #if defined(__CUDA_ARCH__) && __CUDA_ARCH__ < 800
+  float fxl, fxh, fyl, fyh;
+  fxl = __low2float(x);
+  fxh = __high2float(x);
+  fyl = __low2float(y);
+  fyh = __high2float(y);
+  return __floats2bfloat162_rn(fxl * fyl, fxh * fyh);
+  #else
+  return __hmul2(x, y);
+  #endif
 }
 
-inline __device__ __nv_bfloat16 bf16hmul(const __nv_bfloat16 x, const __nv_bfloat16 y)
-{
-#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ < 800
-    return __float2bfloat16(__bfloat162float(x) * __bfloat162float(y));
-#else
-    return __hmul(x, y);
-#endif
+inline __device__ __nv_bfloat16 bf16hmul(const __nv_bfloat16 x,
+                                         const __nv_bfloat16 y) {
+  #if defined(__CUDA_ARCH__) && __CUDA_ARCH__ < 800
+  return __float2bfloat16(__bfloat162float(x) * __bfloat162float(y));
+  #else
+  return __hmul(x, y);
+  #endif
 }
 
-inline __device__ __nv_bfloat162 bf16hfma2(const __nv_bfloat162 x, const __nv_bfloat162 y, const __nv_bfloat162 z)
-{
-#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ < 800
-    float fxl, fxh, fyl, fyh, fzl, fzh;
-    fxl = __low2float(x);
-    fxh = __high2float(x);
-    fyl = __low2float(y);
-    fyh = __high2float(y);
-    fzl = __low2float(z);
-    fzh = __high2float(z);
-    return __floats2bfloat162_rn(fxl * fyl + fzl, fxh * fyh + fzh);
-#else
-    return __hfma2(x, y, z);
-#endif
+inline __device__ __nv_bfloat162 bf16hfma2(const __nv_bfloat162 x,
+                                           const __nv_bfloat162 y,
+                                           const __nv_bfloat162 z) {
+  #if defined(__CUDA_ARCH__) && __CUDA_ARCH__ < 800
+  float fxl, fxh, fyl, fyh, fzl, fzh;
+  fxl = __low2float(x);
+  fxh = __high2float(x);
+  fyl = __low2float(y);
+  fyh = __high2float(y);
+  fzl = __low2float(z);
+  fzh = __high2float(z);
+  return __floats2bfloat162_rn(fxl * fyl + fzl, fxh * fyh + fzh);
+  #else
+  return __hfma2(x, y, z);
+  #endif
 }
 
-inline __device__ __nv_bfloat16 bf16hfma(const __nv_bfloat16 x, const __nv_bfloat16 y, const __nv_bfloat16 z)
-{
-#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ < 800
-    return __float2bfloat16(__bfloat162float(x) * __bfloat162float(y) + __bfloat162float(z));
-#else
-    return __hfma(x, y, z);
-#endif
+inline __device__ __nv_bfloat16 bf16hfma(const __nv_bfloat16 x,
+                                         const __nv_bfloat16 y,
+                                         const __nv_bfloat16 z) {
+  #if defined(__CUDA_ARCH__) && __CUDA_ARCH__ < 800
+  return __float2bfloat16(__bfloat162float(x) * __bfloat162float(y) +
+                          __bfloat162float(z));
+  #else
+  return __hfma(x, y, z);
+  #endif
 }
 
-inline __device__ __nv_bfloat162 bf16exp2(const __nv_bfloat162 x)
-{
-#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ < 800
-    float fxl, fxh;
-    fxl = __low2float(x);
-    fxh = __high2float(x);
-    ;
-    return __floats2bfloat162_rn(expf(fxl), expf(fxh));
-#else
-    return h2exp(x);
-#endif
+inline __device__ __nv_bfloat162 bf16exp2(const __nv_bfloat162 x) {
+  #if defined(__CUDA_ARCH__) && __CUDA_ARCH__ < 800
+  float fxl, fxh;
+  fxl = __low2float(x);
+  fxh = __high2float(x);
+  ;
+  return __floats2bfloat162_rn(expf(fxl), expf(fxh));
+  #else
+  return h2exp(x);
+  #endif
 }
 
-#if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ < 800)
-inline __device__ __nv_bfloat162 operator*(const __nv_bfloat162 x, const __nv_bfloat162 y)
-{
-    return bf16hmul2(x, y);
+  #if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ < 800)
+inline __device__ __nv_bfloat162 operator*(const __nv_bfloat162 x,
+                                           const __nv_bfloat162 y) {
+  return bf16hmul2(x, y);
 };
-inline __device__ __nv_bfloat162 operator+(const __nv_bfloat162 x, const __nv_bfloat162 y)
-{
-    return bf16hadd2(x, y);
+inline __device__ __nv_bfloat162 operator+(const __nv_bfloat162 x,
+                                           const __nv_bfloat162 y) {
+  return bf16hadd2(x, y);
 };
 
-inline __device__ __nv_bfloat162 make_bfloat162(const __nv_bfloat16 x, const __nv_bfloat16 y)
-{
-    __nv_bfloat162 t;
-    t.x = x;
-    t.y = y;
-    return t;
+inline __device__ __nv_bfloat162 make_bfloat162(const __nv_bfloat16 x,
+                                                const __nv_bfloat16 y) {
+  __nv_bfloat162 t;
+  t.x = x;
+  t.y = y;
+  return t;
 }
 
-#endif
+  #endif
 
-inline __device__ __nv_bfloat16 bf16hadd(__nv_bfloat16 a, __nv_bfloat16 b, __nv_bfloat16 c)
-{
-#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ < 800
-    return __float2bfloat16(__bfloat162float(a) + __bfloat162float(b) + __bfloat162float(c));
-#else
-    return a + b + c;
-#endif
+inline __device__ __nv_bfloat16 bf16hadd(__nv_bfloat16 a, __nv_bfloat16 b,
+                                         __nv_bfloat16 c) {
+  #if defined(__CUDA_ARCH__) && __CUDA_ARCH__ < 800
+  return __float2bfloat16(__bfloat162float(a) + __bfloat162float(b) +
+                          __bfloat162float(c));
+  #else
+  return a + b + c;
+  #endif
 }
 
-inline __device__ __nv_bfloat16 bf16hadd(__nv_bfloat16 a, __nv_bfloat16 b, __nv_bfloat16 c, __nv_bfloat16 d)
-{
-#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ < 800
-    return __float2bfloat16(__bfloat162float(a) + __bfloat162float(b) + __bfloat162float(c) + __bfloat162float(d));
-#else
-    return (__nv_bfloat16)((float)a + (float)b + (float)c + (float)d);
-#endif
+inline __device__ __nv_bfloat16 bf16hadd(__nv_bfloat16 a, __nv_bfloat16 b,
+                                         __nv_bfloat16 c, __nv_bfloat16 d) {
+  #if defined(__CUDA_ARCH__) && __CUDA_ARCH__ < 800
+  return __float2bfloat16(__bfloat162float(a) + __bfloat162float(b) +
+                          __bfloat162float(c) + __bfloat162float(d));
+  #else
+  return (__nv_bfloat16)((float)a + (float)b + (float)c + (float)d);
+  #endif
 }
 
-inline __device__ __nv_bfloat162 bf16hadd2(__nv_bfloat162 a, __nv_bfloat162 b, __nv_bfloat162 c)
-{
-#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ < 800
-    float fal, fah, fbl, fbh, fcl, fch;
-    fal = __low2float(a);
-    fah = __high2float(a);
-    fbl = __low2float(b);
-    fbh = __high2float(b);
-    fcl = __low2float(c);
-    fch = __high2float(c);
-    return __floats2bfloat162_rn(fal + fbl + fcl, fah + fbh + fch);
-#else
-    return a + b + c;
-#endif
+inline __device__ __nv_bfloat162 bf16hadd2(__nv_bfloat162 a, __nv_bfloat162 b,
+                                           __nv_bfloat162 c) {
+  #if defined(__CUDA_ARCH__) && __CUDA_ARCH__ < 800
+  float fal, fah, fbl, fbh, fcl, fch;
+  fal = __low2float(a);
+  fah = __high2float(a);
+  fbl = __low2float(b);
+  fbh = __high2float(b);
+  fcl = __low2float(c);
+  fch = __high2float(c);
+  return __floats2bfloat162_rn(fal + fbl + fcl, fah + fbh + fch);
+  #else
+  return a + b + c;
+  #endif
 }
 
-inline __device__ __nv_bfloat16 bf16hmul(__nv_bfloat16 a, __nv_bfloat16 b, __nv_bfloat16 c)
-{
-#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ < 800
-    return __float2bfloat16(__bfloat162float(a) * __bfloat162float(b) * __bfloat162float(c));
-#else
-    return a * b * c;
-#endif
+inline __device__ __nv_bfloat16 bf16hmul(__nv_bfloat16 a, __nv_bfloat16 b,
+                                         __nv_bfloat16 c) {
+  #if defined(__CUDA_ARCH__) && __CUDA_ARCH__ < 800
+  return __float2bfloat16(__bfloat162float(a) * __bfloat162float(b) *
+                          __bfloat162float(c));
+  #else
+  return a * b * c;
+  #endif
 }
 
-inline __device__ __nv_bfloat162 bf16hmul2(__nv_bfloat162 a, __nv_bfloat162 b, __nv_bfloat162 c)
-{
-#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ < 800
-    float fal, fah, fbl, fbh, fcl, fch;
-    fal = __low2float(a);
-    fah = __high2float(a);
-    fbl = __low2float(b);
-    fbh = __high2float(b);
-    fcl = __low2float(c);
-    fch = __high2float(c);
-    return __floats2bfloat162_rn(fal * fbl * fcl, fah * fbh * fch);
-#else
-    return a * b * c;
-#endif
+inline __device__ __nv_bfloat162 bf16hmul2(__nv_bfloat162 a, __nv_bfloat162 b,
+                                           __nv_bfloat162 c) {
+  #if defined(__CUDA_ARCH__) && __CUDA_ARCH__ < 800
+  float fal, fah, fbl, fbh, fcl, fch;
+  fal = __low2float(a);
+  fah = __high2float(a);
+  fbl = __low2float(b);
+  fbh = __high2float(b);
+  fcl = __low2float(c);
+  fch = __high2float(c);
+  return __floats2bfloat162_rn(fal * fbl * fcl, fah * fbh * fch);
+  #else
+  return a * b * c;
+  #endif
 }
 
-inline __device__ __nv_bfloat162 bf16hfma2(__nv_bfloat162 a, __nv_bfloat162 b, __nv_bfloat162 c, __nv_bfloat162 d)
-{
-#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ < 800
-    float fal, fah, fbl, fbh, fcl, fch, fdl, fdh;
-    fal = __low2float(a);
-    fah = __high2float(a);
-    fbl = __low2float(b);
-    fbh = __high2float(b);
-    fcl = __low2float(c);
-    fch = __high2float(c);
-    fdl = __low2float(d);
-    fdh = __high2float(d);
-    return __floats2bfloat162_rn(fal * fbl * fcl + fdl, fah * fbh * fch + fdh);
-#else
-    return a * b * c + d;
-#endif
+inline __device__ __nv_bfloat162 bf16hfma2(__nv_bfloat162 a, __nv_bfloat162 b,
+                                           __nv_bfloat162 c, __nv_bfloat162 d) {
+  #if defined(__CUDA_ARCH__) && __CUDA_ARCH__ < 800
+  float fal, fah, fbl, fbh, fcl, fch, fdl, fdh;
+  fal = __low2float(a);
+  fah = __high2float(a);
+  fbl = __low2float(b);
+  fbh = __high2float(b);
+  fcl = __low2float(c);
+  fch = __high2float(c);
+  fdl = __low2float(d);
+  fdh = __high2float(d);
+  return __floats2bfloat162_rn(fal * fbl * fcl + fdl, fah * fbh * fch + fdh);
+  #else
+  return a * b * c + d;
+  #endif
 }
 
 #endif  // ENABLE_BF16

--- a/csrc/sm70_turbomind/lmdeploy/src/turbomind/utils/cuda_bf16_wrapper.h
+++ b/csrc/sm70_turbomind/lmdeploy/src/turbomind/utils/cuda_bf16_wrapper.h
@@ -17,5 +17,5 @@
 #pragma once
 
 #ifdef ENABLE_BF16
-#include <cuda_bf16.h>
+  #include <cuda_bf16.h>
 #endif

--- a/csrc/sm70_turbomind/lmdeploy/src/turbomind/utils/cuda_type_utils.cuh
+++ b/csrc/sm70_turbomind/lmdeploy/src/turbomind/utils/cuda_type_utils.cuh
@@ -23,576 +23,515 @@
 
 namespace turbomind {
 
-template<typename T>
-inline __device__ T ldg(const T* val)
-{
-    return __ldg(val);
+template <typename T>
+inline __device__ T ldg(const T* val) {
+  return __ldg(val);
 }
 
 #if ENABLE_BF16
-template<>
-inline __device__ __nv_bfloat162 ldg(const __nv_bfloat162* val)
-{
-#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ < 800
-    return val[0];
-#else
-    return __ldg(val);
-#endif
+template <>
+inline __device__ __nv_bfloat162 ldg(const __nv_bfloat162* val) {
+  #if defined(__CUDA_ARCH__) && __CUDA_ARCH__ < 800
+  return val[0];
+  #else
+  return __ldg(val);
+  #endif
 }
 
-template<>
-inline __device__ __nv_bfloat16 ldg(const __nv_bfloat16* val)
-{
-#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ < 800
-    return val[0];
-#else
-    return __ldg(val);
-#endif
+template <>
+inline __device__ __nv_bfloat16 ldg(const __nv_bfloat16* val) {
+  #if defined(__CUDA_ARCH__) && __CUDA_ARCH__ < 800
+  return val[0];
+  #else
+  return __ldg(val);
+  #endif
 }
 #endif  // ENABLE_BF16
 
 // Get type2 from type or vice versa (applied to half and bfloat16)
-template<typename T>
+template <typename T>
 struct TypeConverter {
-    using Type = half2;
+  using Type = half2;
 };  // keep for generality
 
-template<>
+template <>
 struct TypeConverter<half2> {
-    using Type = half;
+  using Type = half;
 };
 
-template<>
+template <>
 struct TypeConverter<half> {
-    using Type = half2;
+  using Type = half2;
 };
 
 #if ENABLE_BF16
-template<>
+template <>
 struct TypeConverter<__nv_bfloat162> {
-    using Type = __nv_bfloat16;
+  using Type = __nv_bfloat16;
 };
 
-template<>
+template <>
 struct TypeConverter<__nv_bfloat16> {
-    using Type = __nv_bfloat162;
+  using Type = __nv_bfloat162;
 };
 #endif  // ENABLE_BF16
 
 // Defined math operations (bfloat16 fallback to fp32 when it is not supported)
-template<typename T>
-inline __device__ T hadd2(T a, T b)
-{
-    return __hadd2(a, b);
+template <typename T>
+inline __device__ T hadd2(T a, T b) {
+  return __hadd2(a, b);
 }
 
 #if ENABLE_BF16
-template<>
-inline __device__ __nv_bfloat162 hadd2(__nv_bfloat162 a, __nv_bfloat162 b)
-{
-    return bf16hadd2(a, b);
+template <>
+inline __device__ __nv_bfloat162 hadd2(__nv_bfloat162 a, __nv_bfloat162 b) {
+  return bf16hadd2(a, b);
 }
 #endif  // ENABLE_BF16
 
-template<typename T>
-inline __device__ T add(T a, T b)
-{
-    return a + b;
+template <typename T>
+inline __device__ T add(T a, T b) {
+  return a + b;
 }
 
-template<>
-inline __device__ half2 add(half2 a, half2 b)
-{
-    return __hadd2(a, b);
+template <>
+inline __device__ half2 add(half2 a, half2 b) {
+  return __hadd2(a, b);
 }
 
-template<>
-inline __device__ half add(half a, half b)
-{
-    return __hadd(a, b);
+template <>
+inline __device__ half add(half a, half b) {
+  return __hadd(a, b);
 }
 
 #if ENABLE_BF16
-template<>
-inline __device__ __nv_bfloat162 add(__nv_bfloat162 a, __nv_bfloat162 b)
-{
-    return bf16hadd2(a, b);
+template <>
+inline __device__ __nv_bfloat162 add(__nv_bfloat162 a, __nv_bfloat162 b) {
+  return bf16hadd2(a, b);
 }
 
-template<>
-inline __device__ __nv_bfloat16 add(__nv_bfloat16 a, __nv_bfloat16 b)
-{
-    return bf16hadd(a, b);
+template <>
+inline __device__ __nv_bfloat16 add(__nv_bfloat16 a, __nv_bfloat16 b) {
+  return bf16hadd(a, b);
 }
 
-inline __device__ __nv_bfloat16 add(__nv_bfloat16 a, float b)
-{
-    return bf16hadd(a, __float2bfloat16(b));
+inline __device__ __nv_bfloat16 add(__nv_bfloat16 a, float b) {
+  return bf16hadd(a, __float2bfloat16(b));
 }
 #endif  // ENABLE_BF16
 
 // applies to all 4 values addition
-template<typename T>
-inline __device__ T add(T a, T b, T c)
-{
-    return a + b + c;
+template <typename T>
+inline __device__ T add(T a, T b, T c) {
+  return a + b + c;
 }
 
 #if ENABLE_BF16
-inline __device__ __nv_bfloat16 add(__nv_bfloat16 a, __nv_bfloat16 b, __nv_bfloat16 c)
-{
-    return bf16hadd(a, b, c);
+inline __device__ __nv_bfloat16 add(__nv_bfloat16 a, __nv_bfloat16 b,
+                                    __nv_bfloat16 c) {
+  return bf16hadd(a, b, c);
 }
 
-inline __device__ __nv_bfloat162 add(__nv_bfloat162 a, __nv_bfloat162 b, __nv_bfloat162 c)
-{
-    return bf16hadd2(a, b, c);
+inline __device__ __nv_bfloat162 add(__nv_bfloat162 a, __nv_bfloat162 b,
+                                     __nv_bfloat162 c) {
+  return bf16hadd2(a, b, c);
 }
 #endif  // ENABLE_BF16
 
 // applies to all 4 values addition
-template<typename T>
-inline __device__ T add(T a, T b, T c, T d)
-{
-    return (T)((float)a + (float)b + (float)c + (float)d);
+template <typename T>
+inline __device__ T add(T a, T b, T c, T d) {
+  return (T)((float)a + (float)b + (float)c + (float)d);
 }
 
 #if ENABLE_BF16
-inline __device__ __nv_bfloat16 add(__nv_bfloat16 a, __nv_bfloat16 b, __nv_bfloat16 c, __nv_bfloat16 d)
-{
-    return bf16hadd(a, b, c, d);
+inline __device__ __nv_bfloat16 add(__nv_bfloat16 a, __nv_bfloat16 b,
+                                    __nv_bfloat16 c, __nv_bfloat16 d) {
+  return bf16hadd(a, b, c, d);
 }
 #endif  // ENABLE_BF16
 
-template<typename T>
-inline __device__ T hsub2(T a, T b)
-{
-    return __hsub2(a, b);
+template <typename T>
+inline __device__ T hsub2(T a, T b) {
+  return __hsub2(a, b);
 }
 
 #if ENABLE_BF16
-template<>
-inline __device__ __nv_bfloat162 hsub2(__nv_bfloat162 a, __nv_bfloat162 b)
-{
-    return bf16hsub2(a, b);
+template <>
+inline __device__ __nv_bfloat162 hsub2(__nv_bfloat162 a, __nv_bfloat162 b) {
+  return bf16hsub2(a, b);
 }
 #endif  // ENABLE_BF16
 
-template<typename T>
-inline __device__ T hmul2(T a, T b)
-{
-    return __hmul2(a, b);
+template <typename T>
+inline __device__ T hmul2(T a, T b) {
+  return __hmul2(a, b);
 }
 
 #if ENABLE_BF16
-template<>
-inline __device__ __nv_bfloat162 hmul2(__nv_bfloat162 a, __nv_bfloat162 b)
-{
-    return bf16hmul2(a, b);
+template <>
+inline __device__ __nv_bfloat162 hmul2(__nv_bfloat162 a, __nv_bfloat162 b) {
+  return bf16hmul2(a, b);
 }
 #endif  // ENABLE_BF16
 
-template<typename T>
-inline __device__ T hmul2(T a, T b, T c)
-{
-    return a * b * c;
+template <typename T>
+inline __device__ T hmul2(T a, T b, T c) {
+  return a * b * c;
 }
 
 #if ENABLE_BF16
-template<>
-inline __device__ __nv_bfloat162 hmul2(__nv_bfloat162 a, __nv_bfloat162 b, __nv_bfloat162 c)
-{
-    return bf16hmul2(a, b, c);
+template <>
+inline __device__ __nv_bfloat162 hmul2(__nv_bfloat162 a, __nv_bfloat162 b,
+                                       __nv_bfloat162 c) {
+  return bf16hmul2(a, b, c);
 }
 #endif  // ENABLE_BF16
 
-template<typename T>
-inline __device__ T mul(T a, T b, T c)
-{
-    return a * b * c;
+template <typename T>
+inline __device__ T mul(T a, T b, T c) {
+  return a * b * c;
 }
 
 #if ENABLE_BF16
-template<>
-inline __device__ __nv_bfloat16 mul(__nv_bfloat16 a, __nv_bfloat16 b, __nv_bfloat16 c)
-{
-    return bf16hmul(a, b, c);
+template <>
+inline __device__ __nv_bfloat16 mul(__nv_bfloat16 a, __nv_bfloat16 b,
+                                    __nv_bfloat16 c) {
+  return bf16hmul(a, b, c);
 }
 
-inline __device__ __nv_bfloat162 mul(__nv_bfloat162 a, __nv_bfloat162 b, __nv_bfloat162 c)
-{
-    return bf16hmul2(a, b, c);
+inline __device__ __nv_bfloat162 mul(__nv_bfloat162 a, __nv_bfloat162 b,
+                                     __nv_bfloat162 c) {
+  return bf16hmul2(a, b, c);
 }
 #endif  // ENABLE_BF16
 
-template<typename T>
-inline __device__ T fma(T a, T b, T c, T d)
-{
-    return a * b * c + d;
+template <typename T>
+inline __device__ T fma(T a, T b, T c, T d) {
+  return a * b * c + d;
 }
 
 #if ENABLE_BF16
-inline __device__ __nv_bfloat162 fma(__nv_bfloat162 a, __nv_bfloat162 b, __nv_bfloat162 c, __nv_bfloat162 d)
-{
-    return bf16hfma2(a, b, c, d);
+inline __device__ __nv_bfloat162 fma(__nv_bfloat162 a, __nv_bfloat162 b,
+                                     __nv_bfloat162 c, __nv_bfloat162 d) {
+  return bf16hfma2(a, b, c, d);
 }
 #endif  // ENABLE_BF16
 
-template<typename T>
-inline __device__ T fma(T a, T b, T c)
-{
-    return a * b + c;
+template <typename T>
+inline __device__ T fma(T a, T b, T c) {
+  return a * b + c;
 }
 
 #if ENABLE_BF16
-template<>
-inline __device__ __nv_bfloat162 fma(__nv_bfloat162 a, __nv_bfloat162 b, __nv_bfloat162 c)
-{
-    return bf16hfma2(a, b, c);
+template <>
+inline __device__ __nv_bfloat162 fma(__nv_bfloat162 a, __nv_bfloat162 b,
+                                     __nv_bfloat162 c) {
+  return bf16hfma2(a, b, c);
 }
 
-template<>
-inline __device__ __nv_bfloat16 fma(__nv_bfloat16 a, __nv_bfloat16 b, __nv_bfloat16 c)
-{
-    return bf16hfma(a, b, c);
+template <>
+inline __device__ __nv_bfloat16 fma(__nv_bfloat16 a, __nv_bfloat16 b,
+                                    __nv_bfloat16 c) {
+  return bf16hfma(a, b, c);
 }
 #endif  // ENABLE_BF16
 
-template<typename T>
-inline __device__ T hexp2(T a)
-{
-    return h2exp(a);
+template <typename T>
+inline __device__ T hexp2(T a) {
+  return h2exp(a);
 }
 
 #if ENABLE_BF16
-template<>
-inline __device__ __nv_bfloat162 hexp2(__nv_bfloat162 a)
-{
-    return bf16exp2(a);
+template <>
+inline __device__ __nv_bfloat162 hexp2(__nv_bfloat162 a) {
+  return bf16exp2(a);
 }
 #endif  // ENABLE_BF16
 
-template<typename T_OUT, typename T_IN>
-__device__ inline T_OUT cuda_cast(T_IN val)
-{
-    return val;
+template <typename T_OUT, typename T_IN>
+__device__ inline T_OUT cuda_cast(T_IN val) {
+  return val;
 }
 
-template<>
-__device__ inline float2 cuda_cast<float2, int2>(int2 val)
-{
-    return make_float2(val.x, val.y);
+template <>
+__device__ inline float2 cuda_cast<float2, int2>(int2 val) {
+  return make_float2(val.x, val.y);
 }
-template<>
-__device__ inline float2 cuda_cast<float2, float>(float val)
-{
-    return make_float2(val, val);
+template <>
+__device__ inline float2 cuda_cast<float2, float>(float val) {
+  return make_float2(val, val);
 }
-template<>
-__device__ inline float2 cuda_cast<float2, half2>(half2 val)
-{
-    return __half22float2(val);
+template <>
+__device__ inline float2 cuda_cast<float2, half2>(half2 val) {
+  return __half22float2(val);
 }
-template<>
-__device__ inline half2 cuda_cast<half2, float2>(float2 val)
-{
-    return __float22half2_rn(val);
+template <>
+__device__ inline half2 cuda_cast<half2, float2>(float2 val) {
+  return __float22half2_rn(val);
 }
-template<>
-__device__ inline half2 cuda_cast<half2, float>(float val)
-{
-    return __float2half2_rn(val);
+template <>
+__device__ inline half2 cuda_cast<half2, float>(float val) {
+  return __float2half2_rn(val);
 }
-template<>
-__device__ inline half2 cuda_cast<half2, half>(half val)
-{
-    return __half2half2(val);
+template <>
+__device__ inline half2 cuda_cast<half2, half>(half val) {
+  return __half2half2(val);
 }
 
-template<>
-__device__ inline int8_t cuda_cast<int8_t, half>(half val)
-{
-    union {
-        int8_t  int8[2];
-        int16_t int16;
-    };
-    union {
-        half    fp16;
-        int16_t int16_in;
-    };
-    fp16 = val;
-    asm volatile("cvt.rni.sat.s8.f16 %0, %1;" : "=h"(int16) : "h"(int16_in));
-    return int8[0];
+template <>
+__device__ inline int8_t cuda_cast<int8_t, half>(half val) {
+  union {
+    int8_t int8[2];
+    int16_t int16;
+  };
+  union {
+    half fp16;
+    int16_t int16_in;
+  };
+  fp16 = val;
+  asm volatile("cvt.rni.sat.s8.f16 %0, %1;" : "=h"(int16) : "h"(int16_in));
+  return int8[0];
 }
 
-template<>
-__device__ inline int16_t cuda_cast<int16_t, half2>(half2 val)
-{
-    union {
-        int8_t  int8[2];
-        int16_t int16;
-    };
-    int8[0] = cuda_cast<int8_t>(val.x);
-    int8[1] = cuda_cast<int8_t>(val.y);
-    return int16;
+template <>
+__device__ inline int16_t cuda_cast<int16_t, half2>(half2 val) {
+  union {
+    int8_t int8[2];
+    int16_t int16;
+  };
+  int8[0] = cuda_cast<int8_t>(val.x);
+  int8[1] = cuda_cast<int8_t>(val.y);
+  return int16;
 }
 
-template<>
-__device__ inline int8_t cuda_cast<int8_t, float>(float val)
-{
-    union {
-        int8_t  int8[2];
-        int16_t int16;
-    };
-    asm volatile("cvt.rni.sat.s8.f32 %0, %1;" : "=h"(int16) : "f"(val));
-    return int8[0];
+template <>
+__device__ inline int8_t cuda_cast<int8_t, float>(float val) {
+  union {
+    int8_t int8[2];
+    int16_t int16;
+  };
+  asm volatile("cvt.rni.sat.s8.f32 %0, %1;" : "=h"(int16) : "f"(val));
+  return int8[0];
 }
 
-template<>
-__device__ inline int16_t cuda_cast<int16_t, float2>(float2 val)
-{
-    union {
-        int8_t  int8[2];
-        int16_t int16;
-    };
-    int8[0] = cuda_cast<int8_t>(val.x);
-    int8[1] = cuda_cast<int8_t>(val.y);
-    return int16;
+template <>
+__device__ inline int16_t cuda_cast<int16_t, float2>(float2 val) {
+  union {
+    int8_t int8[2];
+    int16_t int16;
+  };
+  int8[0] = cuda_cast<int8_t>(val.x);
+  int8[1] = cuda_cast<int8_t>(val.y);
+  return int16;
 }
 
-template<>
-__device__ inline half2 cuda_cast<half2, int16_t>(int16_t val)
-{
-    union {
-        int8_t  int8[2];
-        int16_t int16;
-    };
-    int16 = val;
-    return make_half2(int8[0], int8[1]);
+template <>
+__device__ inline half2 cuda_cast<half2, int16_t>(int16_t val) {
+  union {
+    int8_t int8[2];
+    int16_t int16;
+  };
+  int16 = val;
+  return make_half2(int8[0], int8[1]);
 }
 
-template<>
-__device__ inline float2 cuda_cast<float2, int16_t>(int16_t val)
-{
-    union {
-        int8_t  int8[2];
-        int16_t int16;
-    };
-    int16 = val;
-    return make_float2(int8[0], int8[1]);
+template <>
+__device__ inline float2 cuda_cast<float2, int16_t>(int16_t val) {
+  union {
+    int8_t int8[2];
+    int16_t int16;
+  };
+  int16 = val;
+  return make_float2(int8[0], int8[1]);
 }
 
 #ifdef ENABLE_BF16
-template<>
-__device__ inline __nv_bfloat16 cuda_cast(int32_t val)
-{
-    return static_cast<float>(val);
+template <>
+__device__ inline __nv_bfloat16 cuda_cast(int32_t val) {
+  return static_cast<float>(val);
 }
-template<>
-__device__ inline __nv_bfloat16 cuda_cast(int8_t val)
-{
-    return static_cast<float>(val);
+template <>
+__device__ inline __nv_bfloat16 cuda_cast(int8_t val) {
+  return static_cast<float>(val);
 }
-template<>
-__device__ inline int8_t cuda_cast(__nv_bfloat16 val)
-{
-    return static_cast<float>(val);
+template <>
+__device__ inline int8_t cuda_cast(__nv_bfloat16 val) {
+  return static_cast<float>(val);
 }
 
-template<>
-__device__ inline float cuda_cast<float, __nv_bfloat16>(__nv_bfloat16 val)
-{
-    return __bfloat162float(val);
+template <>
+__device__ inline float cuda_cast<float, __nv_bfloat16>(__nv_bfloat16 val) {
+  return __bfloat162float(val);
 }
 
-template<>
-__device__ inline float2 cuda_cast<float2, __nv_bfloat162>(__nv_bfloat162 val)
-{
-    return bf1622float2(val);
+template <>
+__device__ inline float2 cuda_cast<float2, __nv_bfloat162>(__nv_bfloat162 val) {
+  return bf1622float2(val);
 }
 
-template<>
-__device__ inline half cuda_cast<half, __nv_bfloat16>(__nv_bfloat16 val)
-{
-    return __float2half(__bfloat162float(val));
+template <>
+__device__ inline half cuda_cast<half, __nv_bfloat16>(__nv_bfloat16 val) {
+  return __float2half(__bfloat162float(val));
 }
 
-template<>
-__device__ inline int16_t cuda_cast<int16_t, __nv_bfloat162>(__nv_bfloat162 val)
-{
-    return bf1622int16(val);
+template <>
+__device__ inline int16_t cuda_cast<int16_t, __nv_bfloat162>(
+    __nv_bfloat162 val) {
+  return bf1622int16(val);
 }
 
-template<>
-__device__ inline __nv_bfloat16 cuda_cast<__nv_bfloat16, float>(float val)
-{
-    return __float2bfloat16(val);
+template <>
+__device__ inline __nv_bfloat16 cuda_cast<__nv_bfloat16, float>(float val) {
+  return __float2bfloat16(val);
 }
-template<>
-__device__ inline __nv_bfloat16 cuda_cast<__nv_bfloat16, half>(half val)
-{
-    return __float2bfloat16(__half2float(val));
+template <>
+__device__ inline __nv_bfloat16 cuda_cast<__nv_bfloat16, half>(half val) {
+  return __float2bfloat16(__half2float(val));
 }
 
-template<>
-__device__ inline __nv_bfloat162 cuda_cast<__nv_bfloat162, __nv_bfloat16>(__nv_bfloat16 val)
-{
-    return bf162bf162(val);
+template <>
+__device__ inline __nv_bfloat162 cuda_cast<__nv_bfloat162, __nv_bfloat16>(
+    __nv_bfloat16 val) {
+  return bf162bf162(val);
 }
-template<>
-__device__ inline __nv_bfloat162 cuda_cast<__nv_bfloat162, float>(float val)
-{
-    return __float2bfloat162_rn(val);
+template <>
+__device__ inline __nv_bfloat162 cuda_cast<__nv_bfloat162, float>(float val) {
+  return __float2bfloat162_rn(val);
 }
-template<>
-__device__ inline __nv_bfloat162 cuda_cast<__nv_bfloat162, float2>(float2 val)
-{
-    return float22bf162(val);
+template <>
+__device__ inline __nv_bfloat162 cuda_cast<__nv_bfloat162, float2>(float2 val) {
+  return float22bf162(val);
 }
-template<>
-__device__ inline __nv_bfloat162 cuda_cast<__nv_bfloat162, int16_t>(int16_t val)
-{
-    union {
-        int8_t  int8[2];
-        int16_t int16;
-    };
-    int16 = val;
-    __nv_bfloat162 res;
-    res.x = cuda_cast<__nv_bfloat16>(int8[0]);
-    res.y = cuda_cast<__nv_bfloat16>(int8[1]);
-    return res;
+template <>
+__device__ inline __nv_bfloat162 cuda_cast<__nv_bfloat162, int16_t>(
+    int16_t val) {
+  union {
+    int8_t int8[2];
+    int16_t int16;
+  };
+  int16 = val;
+  __nv_bfloat162 res;
+  res.x = cuda_cast<__nv_bfloat16>(int8[0]);
+  res.y = cuda_cast<__nv_bfloat16>(int8[1]);
+  return res;
 }
 
-template<>
-__device__ inline __nv_bfloat162 cuda_cast<__nv_bfloat162, half2>(half2 val)
-{
-    return float22bf162(__half22float2(val));
+template <>
+__device__ inline __nv_bfloat162 cuda_cast<__nv_bfloat162, half2>(half2 val) {
+  return float22bf162(__half22float2(val));
 }
 
 #endif  // ENABLE BF16
 
-template<typename T>
+template <typename T>
 __device__ inline T cuda_abs(T val);
-template<>
-__device__ inline float cuda_abs(float val)
-{
-    return fabs(val);
+template <>
+__device__ inline float cuda_abs(float val) {
+  return fabs(val);
 }
-template<>
-__device__ inline half cuda_abs(half val)
-{
-    return __habs(val);
+template <>
+__device__ inline half cuda_abs(half val) {
+  return __habs(val);
 }
-template<>
-__device__ inline half2 cuda_abs(half2 val)
-{
-    return __habs2(val);
+template <>
+__device__ inline half2 cuda_abs(half2 val) {
+  return __habs2(val);
 }
 
 #ifdef ENABLE_BF16
 
-#if __CUDA_ARCH__ >= 800 || !defined(__CUDA_ARCH__)
-template<>
-__device__ inline __nv_bfloat16 cuda_abs(__nv_bfloat16 val)
-{
-    return __habs(val);
+  #if __CUDA_ARCH__ >= 800 || !defined(__CUDA_ARCH__)
+template <>
+__device__ inline __nv_bfloat16 cuda_abs(__nv_bfloat16 val) {
+  return __habs(val);
 }
-template<>
-__device__ inline __nv_bfloat162 cuda_abs(__nv_bfloat162 val)
-{
-    return __habs2(val);
+template <>
+__device__ inline __nv_bfloat162 cuda_abs(__nv_bfloat162 val) {
+  return __habs2(val);
 }
-#else
-template<>
-__device__ inline __nv_bfloat16 cuda_abs(__nv_bfloat16 val)
-{
-    return fabs(cuda_cast<float>(val));
+  #else
+template <>
+__device__ inline __nv_bfloat16 cuda_abs(__nv_bfloat16 val) {
+  return fabs(cuda_cast<float>(val));
 }
-template<>
-__device__ inline __nv_bfloat162 cuda_abs(__nv_bfloat162 val)
-{
-    return make_bfloat162(fabs(cuda_cast<float>(val.x)), fabs(cuda_cast<float>(val.y)));
+template <>
+__device__ inline __nv_bfloat162 cuda_abs(__nv_bfloat162 val) {
+  return make_bfloat162(fabs(cuda_cast<float>(val.x)),
+                        fabs(cuda_cast<float>(val.y)));
 }
-#endif
+  #endif
 
 #endif  // ENABLE_FP16
 
 // Unary maximum: compute the max of a vector type
-template<typename To, typename Ti>
-__device__ inline To cuda_max(Ti val)
-{
-    return cuda_cast<To>(val);
+template <typename To, typename Ti>
+__device__ inline To cuda_max(Ti val) {
+  return cuda_cast<To>(val);
 };
 
-template<>
-__device__ inline half cuda_max(half2 val)
-{
-    return (val.x > val.y) ? val.x : val.y;
+template <>
+__device__ inline half cuda_max(half2 val) {
+  return (val.x > val.y) ? val.x : val.y;
 }
 #ifdef ENABLE_BF16
-template<>
-__device__ inline __nv_bfloat16 cuda_max(__nv_bfloat162 val)
-{
-    return (val.x > val.y) ? val.x : val.y;
+template <>
+__device__ inline __nv_bfloat16 cuda_max(__nv_bfloat162 val) {
+  return (val.x > val.y) ? val.x : val.y;
 }
 #endif
 
 // Binary maximum: compute the max of two scalar types
-template<typename T>
-__device__ inline T cuda_max(T val1, T val2)
-{
-    return (val1 > val2) ? val1 : val2;
+template <typename T>
+__device__ inline T cuda_max(T val1, T val2) {
+  return (val1 > val2) ? val1 : val2;
 }
 
 #ifdef ENABLE_FP8
-template<>
-__device__ inline float2 cuda_cast<float2, __nv_fp8x2_e4m3>(__nv_fp8x2_e4m3 val)
-{
-    return bf1622float2(fp8x2_e4m3_to_bfloat2(&val));
+template <>
+__device__ inline float2 cuda_cast<float2, __nv_fp8x2_e4m3>(
+    __nv_fp8x2_e4m3 val) {
+  return bf1622float2(fp8x2_e4m3_to_bfloat2(&val));
 }
-template<>
-__device__ inline __nv_fp8x2_e4m3 cuda_cast<__nv_fp8x2_e4m3, float2>(float2 val)
-{
-    return __nv_fp8x2_e4m3(bf1622float2(float22bf162(val)));
-}
-
-template<>
-__device__ inline __nv_fp8_e4m3 cuda_cast<__nv_fp8_e4m3, half>(half val)
-{
-    return __nv_fp8_e4m3(val);
-}
-template<>
-__device__ inline __nv_fp8_e4m3 cuda_cast<__nv_fp8_e4m3, __nv_bfloat16>(__nv_bfloat16 val)
-{
-    return __nv_fp8_e4m3(val);
-}
-template<>
-__device__ inline __nv_fp8_e4m3 cuda_cast<__nv_fp8_e4m3, float>(float val)
-{
-    return __nv_fp8_e4m3(val);
-}
-template<>
-__device__ inline float cuda_cast<float, __nv_fp8_e4m3>(__nv_fp8_e4m3 val)
-{
-    return (float)val;
-}
-template<>
-__device__ inline __nv_bfloat162 cuda_cast<__nv_bfloat162, __nv_fp8x2_e4m3>(__nv_fp8x2_e4m3 val)
-{
-    return fp8x2_e4m3_to_bfloat2(&val);
+template <>
+__device__ inline __nv_fp8x2_e4m3 cuda_cast<__nv_fp8x2_e4m3, float2>(
+    float2 val) {
+  return __nv_fp8x2_e4m3(bf1622float2(float22bf162(val)));
 }
 
-template<>
-__device__ inline int8_t cuda_cast<int8_t, __nv_fp8_e4m3>(__nv_fp8_e4m3 val)
-{
-    // no impl
-    return 0;
+template <>
+__device__ inline __nv_fp8_e4m3 cuda_cast<__nv_fp8_e4m3, half>(half val) {
+  return __nv_fp8_e4m3(val);
+}
+template <>
+__device__ inline __nv_fp8_e4m3 cuda_cast<__nv_fp8_e4m3, __nv_bfloat16>(
+    __nv_bfloat16 val) {
+  return __nv_fp8_e4m3(val);
+}
+template <>
+__device__ inline __nv_fp8_e4m3 cuda_cast<__nv_fp8_e4m3, float>(float val) {
+  return __nv_fp8_e4m3(val);
+}
+template <>
+__device__ inline float cuda_cast<float, __nv_fp8_e4m3>(__nv_fp8_e4m3 val) {
+  return (float)val;
+}
+template <>
+__device__ inline __nv_bfloat162 cuda_cast<__nv_bfloat162, __nv_fp8x2_e4m3>(
+    __nv_fp8x2_e4m3 val) {
+  return fp8x2_e4m3_to_bfloat2(&val);
 }
 
-template<>
-__device__ inline __nv_fp8_e4m3 cuda_cast<__nv_fp8_e4m3, int8_t>(int8_t val)
-{
-    return cuda_cast<__nv_fp8_e4m3>(cuda_cast<__nv_bfloat16>(cuda_cast<float>(val)));
+template <>
+__device__ inline int8_t cuda_cast<int8_t, __nv_fp8_e4m3>(__nv_fp8_e4m3 val) {
+  // no impl
+  return 0;
+}
+
+template <>
+__device__ inline __nv_fp8_e4m3 cuda_cast<__nv_fp8_e4m3, int8_t>(int8_t val) {
+  return cuda_cast<__nv_fp8_e4m3>(
+      cuda_cast<__nv_bfloat16>(cuda_cast<float>(val)));
 }
 
 #endif  // ENABLE_FP8

--- a/csrc/sm70_turbomind/lmdeploy/src/turbomind/utils/cuda_utils.h
+++ b/csrc/sm70_turbomind/lmdeploy/src/turbomind/utils/cuda_utils.h
@@ -28,7 +28,7 @@
 #include <cublasLt.h>
 #include <cublas_v2.h>
 #ifdef SPARSITY_ENABLED
-#include <cusparseLt.h>
+  #include <cusparseLt.h>
 #endif
 
 #include "src/turbomind/core/check.h"
@@ -39,56 +39,55 @@
 namespace turbomind {
 
 /* **************************** debug tools ********************************* */
-static const char* _cudaGetErrorEnum(cudaError_t error)
-{
-    return cudaGetErrorString(error);
+static const char* _cudaGetErrorEnum(cudaError_t error) {
+  return cudaGetErrorString(error);
 }
 
-static const char* _cudaGetErrorEnum(cublasStatus_t error)
-{
-    switch (error) {
-        case CUBLAS_STATUS_SUCCESS:
-            return "CUBLAS_STATUS_SUCCESS";
+static const char* _cudaGetErrorEnum(cublasStatus_t error) {
+  switch (error) {
+    case CUBLAS_STATUS_SUCCESS:
+      return "CUBLAS_STATUS_SUCCESS";
 
-        case CUBLAS_STATUS_NOT_INITIALIZED:
-            return "CUBLAS_STATUS_NOT_INITIALIZED";
+    case CUBLAS_STATUS_NOT_INITIALIZED:
+      return "CUBLAS_STATUS_NOT_INITIALIZED";
 
-        case CUBLAS_STATUS_ALLOC_FAILED:
-            return "CUBLAS_STATUS_ALLOC_FAILED";
+    case CUBLAS_STATUS_ALLOC_FAILED:
+      return "CUBLAS_STATUS_ALLOC_FAILED";
 
-        case CUBLAS_STATUS_INVALID_VALUE:
-            return "CUBLAS_STATUS_INVALID_VALUE";
+    case CUBLAS_STATUS_INVALID_VALUE:
+      return "CUBLAS_STATUS_INVALID_VALUE";
 
-        case CUBLAS_STATUS_ARCH_MISMATCH:
-            return "CUBLAS_STATUS_ARCH_MISMATCH";
+    case CUBLAS_STATUS_ARCH_MISMATCH:
+      return "CUBLAS_STATUS_ARCH_MISMATCH";
 
-        case CUBLAS_STATUS_MAPPING_ERROR:
-            return "CUBLAS_STATUS_MAPPING_ERROR";
+    case CUBLAS_STATUS_MAPPING_ERROR:
+      return "CUBLAS_STATUS_MAPPING_ERROR";
 
-        case CUBLAS_STATUS_EXECUTION_FAILED:
-            return "CUBLAS_STATUS_EXECUTION_FAILED";
+    case CUBLAS_STATUS_EXECUTION_FAILED:
+      return "CUBLAS_STATUS_EXECUTION_FAILED";
 
-        case CUBLAS_STATUS_INTERNAL_ERROR:
-            return "CUBLAS_STATUS_INTERNAL_ERROR";
+    case CUBLAS_STATUS_INTERNAL_ERROR:
+      return "CUBLAS_STATUS_INTERNAL_ERROR";
 
-        case CUBLAS_STATUS_NOT_SUPPORTED:
-            return "CUBLAS_STATUS_NOT_SUPPORTED";
+    case CUBLAS_STATUS_NOT_SUPPORTED:
+      return "CUBLAS_STATUS_NOT_SUPPORTED";
 
-        case CUBLAS_STATUS_LICENSE_ERROR:
-            return "CUBLAS_STATUS_LICENSE_ERROR";
-    }
-    return "<unknown>";
+    case CUBLAS_STATUS_LICENSE_ERROR:
+      return "CUBLAS_STATUS_LICENSE_ERROR";
+  }
+  return "<unknown>";
 }
 
-template<typename T>
-void check(T result, char const* const func, const char* const file, int const line)
-{
-    if (result) {
-        TM_LOG_ERROR((std::string("CUDA runtime error: ") + (_cudaGetErrorEnum(result)) + " " + file + ":"
-                      + std::to_string(line))
-                         .c_str());
-        std::abort();
-    }
+template <typename T>
+void check(T result, char const* const func, const char* const file,
+           int const line) {
+  if (result) {
+    TM_LOG_ERROR((std::string("CUDA runtime error: ") +
+                  (_cudaGetErrorEnum(result)) + " " + file + ":" +
+                  std::to_string(line))
+                     .c_str());
+    std::abort();
+  }
 }
 
 #define check_cuda_error(val) check((val), #val, __FILE__, __LINE__)
@@ -98,54 +97,58 @@ void syncAndCheck(const char* const file, int const line);
 
 #define sync_check_cuda_error() syncAndCheck(__FILE__, __LINE__)
 
-#define CUDRVCHECK(expr)                                                                                               \
-    if (auto ec = expr; ec != CUDA_SUCCESS) {                                                                          \
-        const char* p_str{};                                                                                           \
-        cuGetErrorString(ec, &p_str);                                                                                  \
-        p_str    = p_str ? p_str : "Unknown error";                                                                    \
-        auto msg = fmtstr("[TM][ERROR] CUDA driver error: %s:%d '%s'", __FILE__, __LINE__, p_str);                     \
-        throw std::runtime_error(msg.c_str());                                                                         \
-    }
+#define CUDRVCHECK(expr)                                                     \
+  if (auto ec = expr; ec != CUDA_SUCCESS) {                                  \
+    const char* p_str{};                                                     \
+    cuGetErrorString(ec, &p_str);                                            \
+    p_str = p_str ? p_str : "Unknown error";                                 \
+    auto msg = fmtstr("[TM][ERROR] CUDA driver error: %s:%d '%s'", __FILE__, \
+                      __LINE__, p_str);                                      \
+    throw std::runtime_error(msg.c_str());                                   \
+  }
 
-template<typename T>
+template <typename T>
 void printMatrix(T* ptr, int m, int k, int stride, bool is_device_ptr);
 
-void printMatrix(unsigned long long* ptr, int m, int k, int stride, bool is_device_ptr);
+void printMatrix(unsigned long long* ptr, int m, int k, int stride,
+                 bool is_device_ptr);
 void printMatrix(int* ptr, int m, int k, int stride, bool is_device_ptr);
 void printMatrix(size_t* ptr, int m, int k, int stride, bool is_device_ptr);
 
-template<typename T>
+template <typename T>
 void check_max_val(const T* result, const int size);
 
-template<typename T>
+template <typename T>
 void check_abs_mean_val(const T* result, const int size);
 
-#define PRINT_FUNC_NAME_()                                                                                             \
-    do {                                                                                                               \
-        std::cout << "[TM][CALL] " << __FUNCTION__ << " " << std::endl;                                                \
-    } while (0)
+#define PRINT_FUNC_NAME_()                                          \
+  do {                                                              \
+    std::cout << "[TM][CALL] " << __FUNCTION__ << " " << std::endl; \
+  } while (0)
 
-[[noreturn]] inline void throwRuntimeError(const char* const file, int const line, std::string const& info = "")
-{
-    throw std::runtime_error(std::string("[TM][ERROR] ") + info + " Assertion fail: " + file + ":"
-                             + std::to_string(line) + " \n");
+[[noreturn]] inline void throwRuntimeError(const char* const file,
+                                           int const line,
+                                           std::string const& info = "") {
+  throw std::runtime_error(std::string("[TM][ERROR] ") + info +
+                           " Assertion fail: " + file + ":" +
+                           std::to_string(line) + " \n");
 }
 
-inline void myAssert(bool result, const char* const file, int const line, std::string const& info = "")
-{
-    if (!result) {
-        throwRuntimeError(file, line, info);
-    }
+inline void myAssert(bool result, const char* const file, int const line,
+                     std::string const& info = "") {
+  if (!result) {
+    throwRuntimeError(file, line, info);
+  }
 }
 
 #define FT_CHECK(val) myAssert(bool(val), __FILE__, __LINE__)
-#define FT_CHECK_WITH_INFO(val, info)                                                                                  \
-    do {                                                                                                               \
-        bool is_valid_val = bool(val);                                                                                 \
-        if (!is_valid_val) {                                                                                           \
-            turbomind::myAssert(is_valid_val, __FILE__, __LINE__, (info));                                             \
-        }                                                                                                              \
-    } while (0)
+#define FT_CHECK_WITH_INFO(val, info)                                \
+  do {                                                               \
+    bool is_valid_val = bool(val);                                   \
+    if (!is_valid_val) {                                             \
+      turbomind::myAssert(is_valid_val, __FILE__, __LINE__, (info)); \
+    }                                                                \
+  } while (0)
 
 #define FT_THROW(info) throwRuntimeError(__FILE__, __LINE__, info)
 
@@ -157,10 +160,9 @@ int getSMCount();
 
 std::string getDeviceName();
 
-template<class T>
-inline T div_up(T a, T n)
-{
-    return (a + n - 1) / n;
+template <class T>
+inline T div_up(T a, T n) {
+  return (a + n - 1) / n;
 }
 
 int getDevice();
@@ -168,22 +170,20 @@ int getDevice();
 int getDeviceCount();
 
 class CudaDeviceGuard {
-public:
-    CudaDeviceGuard(int device)
-    {
-        check_cuda_error(cudaGetDevice(&last_device_id_));
-        if (device != last_device_id_) {
-            check_cuda_error(cudaSetDevice(device));
-        }
+ public:
+  CudaDeviceGuard(int device) {
+    check_cuda_error(cudaGetDevice(&last_device_id_));
+    if (device != last_device_id_) {
+      check_cuda_error(cudaSetDevice(device));
     }
+  }
 
-    ~CudaDeviceGuard()
-    {
-        TM_CHECK_EQ(cudaSetDevice(last_device_id_), cudaSuccess);
-    }
+  ~CudaDeviceGuard() {
+    TM_CHECK_EQ(cudaSetDevice(last_device_id_), cudaSuccess);
+  }
 
-private:
-    int last_device_id_{-1};
+ private:
+  int last_device_id_{-1};
 };
 
 void trim_default_mempool(int device_id);

--- a/csrc/sm70_turbomind/lmdeploy/src/turbomind/utils/debug_utils.h
+++ b/csrc/sm70_turbomind/lmdeploy/src/turbomind/utils/debug_utils.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #if __has_include("3rdparty/dbg.h")
-#include "3rdparty/dbg.h"
+  #include "3rdparty/dbg.h"
 #else
-#define dbg(...)
+  #define dbg(...)
 #endif

--- a/csrc/sm70_turbomind/lmdeploy/src/turbomind/utils/dispatch.h
+++ b/csrc/sm70_turbomind/lmdeploy/src/turbomind/utils/dispatch.h
@@ -8,28 +8,29 @@ namespace turbomind {
 
 namespace detail {
 
-template<int X>
+template <int X>
 inline constexpr std::integral_constant<int, X> _Int{};
 
-template<class F, class P, class G, int... Xs, std::size_t... Is>
-bool dispatch_impl(F&& f, P&& p, G g, std::integer_sequence<int, Xs...>, std::index_sequence<Is...>)
-{
-    constexpr int N = sizeof...(Xs);
-    return (((((P &&) p)(_Int<Xs>) || (g && Is == N - 1)) && (((F &&) f)(_Int<Xs>), 1)) || ...);
+template <class F, class P, class G, int... Xs, std::size_t... Is>
+bool dispatch_impl(F&& f, P&& p, G g, std::integer_sequence<int, Xs...>,
+                   std::index_sequence<Is...>) {
+  constexpr int N = sizeof...(Xs);
+  return (
+      ((((P&&)p)(_Int<Xs>) || (g && Is == N - 1)) && (((F&&)f)(_Int<Xs>), 1)) ||
+      ...);
 }
 
 }  // namespace detail
 
-template<class F, class P, int... Is, class G = std::true_type>
-bool dispatch(std::integer_sequence<int, Is...> seq, P&& p, F&& f, G g = {})
-{
-    return detail::dispatch_impl((F &&) f, (P &&) p, g, seq, std::make_index_sequence<sizeof...(Is)>{});
+template <class F, class P, int... Is, class G = std::true_type>
+bool dispatch(std::integer_sequence<int, Is...> seq, P&& p, F&& f, G g = {}) {
+  return detail::dispatch_impl((F&&)f, (P&&)p, g, seq,
+                               std::make_index_sequence<sizeof...(Is)>{});
 }
 
-template<class F, int... Is, class G = std::true_type>
-bool dispatch(std::integer_sequence<int, Is...> seq, F&& f)
-{
-    return (((F &&) f)(detail::_Int<Is>) || ...);
+template <class F, int... Is, class G = std::true_type>
+bool dispatch(std::integer_sequence<int, Is...> seq, F&& f) {
+  return (((F&&)f)(detail::_Int<Is>) || ...);
 }
 
 }  // namespace turbomind

--- a/csrc/sm70_turbomind/lmdeploy/src/turbomind/utils/logger.cc
+++ b/csrc/sm70_turbomind/lmdeploy/src/turbomind/utils/logger.cc
@@ -19,47 +19,43 @@
 
 namespace turbomind {
 
-Logger& Logger::getLogger()
-{
-    thread_local Logger instance;
-    return instance;
+Logger& Logger::getLogger() {
+  thread_local Logger instance;
+  return instance;
 }
 
-Logger::Logger()
-{
-    char* is_first_rank_only_char = std::getenv("TM_LOG_FIRST_RANK_ONLY");
-    bool  is_first_rank_only =
-        (is_first_rank_only_char != nullptr && std::string(is_first_rank_only_char) == "ON") ? true : false;
+Logger::Logger() {
+  char* is_first_rank_only_char = std::getenv("TM_LOG_FIRST_RANK_ONLY");
+  bool is_first_rank_only = (is_first_rank_only_char != nullptr &&
+                             std::string(is_first_rank_only_char) == "ON")
+                                ? true
+                                : false;
 
-    int device_id;
-    cudaGetDevice(&device_id);
+  int device_id;
+  cudaGetDevice(&device_id);
 
-    char* level_name = std::getenv("TM_LOG_LEVEL");
-    if (level_name != nullptr) {
-        std::map<std::string, Level> name_to_level = {
-            {"TRACE", TRACE},
-            {"DEBUG", DEBUG},
-            {"INFO", INFO},
-            {"WARNING", WARNING},
-            {"ERROR", ERROR},
-        };
-        auto level = name_to_level.find(level_name);
-        // If TM_LOG_FIRST_RANK_ONLY=ON, set LOG LEVEL of other device to ERROR
-        if (is_first_rank_only && device_id != 0) {
-            level = name_to_level.find("ERROR");
-        }
-        if (level != name_to_level.end()) {
-            setLevel(level->second);
-        }
-        else {
-            fprintf(stderr,
-                    "[TM][WARNING] Invalid logger level TM_LOG_LEVEL=%s. "
-                    "Ignore the environment variable and use a default "
-                    "logging level.\n",
-                    level_name);
-            level_name = nullptr;
-        }
+  char* level_name = std::getenv("TM_LOG_LEVEL");
+  if (level_name != nullptr) {
+    std::map<std::string, Level> name_to_level = {
+        {"TRACE", TRACE},     {"DEBUG", DEBUG}, {"INFO", INFO},
+        {"WARNING", WARNING}, {"ERROR", ERROR},
+    };
+    auto level = name_to_level.find(level_name);
+    // If TM_LOG_FIRST_RANK_ONLY=ON, set LOG LEVEL of other device to ERROR
+    if (is_first_rank_only && device_id != 0) {
+      level = name_to_level.find("ERROR");
     }
+    if (level != name_to_level.end()) {
+      setLevel(level->second);
+    } else {
+      fprintf(stderr,
+              "[TM][WARNING] Invalid logger level TM_LOG_LEVEL=%s. "
+              "Ignore the environment variable and use a default "
+              "logging level.\n",
+              level_name);
+      level_name = nullptr;
+    }
+  }
 }
 
 }  // namespace turbomind

--- a/csrc/sm70_turbomind/lmdeploy/src/turbomind/utils/logger.h
+++ b/csrc/sm70_turbomind/lmdeploy/src/turbomind/utils/logger.h
@@ -27,94 +27,83 @@ namespace turbomind {
 // cub.cuh brings windows.h
 // should be included after cub.cuh
 #ifdef ERROR
-#undef ERROR
+  #undef ERROR
 #endif
 
 class Logger {
+ public:
+  enum Level { TRACE = 0, DEBUG = 10, INFO = 20, WARNING = 30, ERROR = 40 };
 
-public:
-    enum Level
-    {
-        TRACE   = 0,
-        DEBUG   = 10,
-        INFO    = 20,
-        WARNING = 30,
-        ERROR   = 40
-    };
+  static Logger& getLogger();
+  Logger(Logger const&) = delete;
+  void operator=(Logger const&) = delete;
 
-    static Logger& getLogger();
-    Logger(Logger const&) = delete;
-    void operator=(Logger const&) = delete;
-
-    template<typename... Args>
-    void log(const Level level, const std::string format, const Args&... args)
-    {
-        if (level_ <= level) {
-            std::string fmt = getPrefix(level) + format + "\n";
-            // FILE*       out    = level_ < WARNING ? stdout : stderr;
-            std::string logstr = fmtstr(fmt, args...);
-            fprintf(stderr, "%s", logstr.c_str());
-        }
+  template <typename... Args>
+  void log(const Level level, const std::string format, const Args&... args) {
+    if (level_ <= level) {
+      std::string fmt = getPrefix(level) + format + "\n";
+      // FILE*       out    = level_ < WARNING ? stdout : stderr;
+      std::string logstr = fmtstr(fmt, args...);
+      fprintf(stderr, "%s", logstr.c_str());
     }
+  }
 
-    template<typename... Args>
-    void log(const Level level, const int rank, const std::string format, const Args&... args)
-    {
-        if (level_ <= level) {
-            std::string fmt = getPrefix(level, rank) + format + "\n";
-            // FILE*       out    = level_ < WARNING ? stdout : stderr;
-            std::string logstr = fmtstr(fmt, args...);
-            fprintf(stderr, "%s", logstr.c_str());
-        }
+  template <typename... Args>
+  void log(const Level level, const int rank, const std::string format,
+           const Args&... args) {
+    if (level_ <= level) {
+      std::string fmt = getPrefix(level, rank) + format + "\n";
+      // FILE*       out    = level_ < WARNING ? stdout : stderr;
+      std::string logstr = fmtstr(fmt, args...);
+      fprintf(stderr, "%s", logstr.c_str());
     }
+  }
 
-    void setLevel(const Level level)
-    {
-        level_ = level;
-        log(DEBUG, "Set logger level by %s", getLevelName(level).c_str());
-    }
+  void setLevel(const Level level) {
+    level_ = level;
+    log(DEBUG, "Set logger level by %s", getLevelName(level).c_str());
+  }
 
-    int getLevel() const
-    {
-        return level_;
-    }
+  int getLevel() const { return level_; }
 
-private:
-    const std::string                              PREFIX      = "[TM]";
-    const std::map<const Level, const std::string> level_name_ = {
-        {TRACE, "TRACE"}, {DEBUG, "DEBUG"}, {INFO, "INFO"}, {WARNING, "WARNING"}, {ERROR, "ERROR"}};
+ private:
+  const std::string PREFIX = "[TM]";
+  const std::map<const Level, const std::string> level_name_ = {
+      {TRACE, "TRACE"},
+      {DEBUG, "DEBUG"},
+      {INFO, "INFO"},
+      {WARNING, "WARNING"},
+      {ERROR, "ERROR"}};
 
 #ifndef NDEBUG
-    const Level DEFAULT_LOG_LEVEL = DEBUG;
+  const Level DEFAULT_LOG_LEVEL = DEBUG;
 #else
-    const Level DEFAULT_LOG_LEVEL = INFO;
+  const Level DEFAULT_LOG_LEVEL = INFO;
 #endif
-    Level level_ = DEFAULT_LOG_LEVEL;
+  Level level_ = DEFAULT_LOG_LEVEL;
 
-    Logger();
+  Logger();
 
-    inline const std::string getLevelName(const Level level)
-    {
-        return level_name_.at(level);
-    }
+  inline const std::string getLevelName(const Level level) {
+    return level_name_.at(level);
+  }
 
-    inline const std::string getPrefix(const Level level)
-    {
-        return PREFIX + "[" + getLevelName(level) + "] ";
-    }
+  inline const std::string getPrefix(const Level level) {
+    return PREFIX + "[" + getLevelName(level) + "] ";
+  }
 
-    inline const std::string getPrefix(const Level level, const int rank)
-    {
-        return PREFIX + "[" + getLevelName(level) + "][" + std::to_string(rank) + "] ";
-    }
+  inline const std::string getPrefix(const Level level, const int rank) {
+    return PREFIX + "[" + getLevelName(level) + "][" + std::to_string(rank) +
+           "] ";
+  }
 };
 
-#define TM_LOG(level, ...)                                                                                             \
-    do {                                                                                                               \
-        if (turbomind::Logger::getLogger().getLevel() <= level) {                                                      \
-            turbomind::Logger::getLogger().log(level, __VA_ARGS__);                                                    \
-        }                                                                                                              \
-    } while (0)
+#define TM_LOG(level, ...)                                    \
+  do {                                                        \
+    if (turbomind::Logger::getLogger().getLevel() <= level) { \
+      turbomind::Logger::getLogger().log(level, __VA_ARGS__); \
+    }                                                         \
+  } while (0)
 
 #define TM_LOG_TRACE(...) TM_LOG(turbomind::Logger::TRACE, __VA_ARGS__)
 #define TM_LOG_DEBUG(...) TM_LOG(turbomind::Logger::DEBUG, __VA_ARGS__)

--- a/csrc/sm70_turbomind/lmdeploy/src/turbomind/utils/memory_utils.h
+++ b/csrc/sm70_turbomind/lmdeploy/src/turbomind/utils/memory_utils.h
@@ -20,8 +20,9 @@
 
 namespace turbomind {
 
-template<typename T>
-void invokeInPlaceTranspose102(
-    T* data, T* workspace, const int dim0, const int dim1, const int dim2, bool copy = true, cudaStream_t stream = 0);
+template <typename T>
+void invokeInPlaceTranspose102(T* data, T* workspace, const int dim0,
+                               const int dim1, const int dim2, bool copy = true,
+                               cudaStream_t stream = 0);
 
 }  // namespace turbomind

--- a/csrc/sm70_turbomind/lmdeploy/src/turbomind/utils/metrics.h
+++ b/csrc/sm70_turbomind/lmdeploy/src/turbomind/utils/metrics.h
@@ -8,52 +8,50 @@
 namespace turbomind {
 
 struct ScheduleMetrics {
-    // sequences
-    int total_seqs;    // the number of received sequence
-    int active_seqs;   // the number of active sequence
-    int waiting_seqs;  // the number of waiting sequence
+  // sequences
+  int total_seqs;    // the number of received sequence
+  int active_seqs;   // the number of active sequence
+  int waiting_seqs;  // the number of waiting sequence
 
-    // kv block usage
-    int total_blocks;   // the number of kv blocks
-    int active_blocks;  // the number of active kv blocks
-    int cached_blocks;  // the number of cached kv blocks
-    int free_blocks;    // the number of free kv blocks
+  // kv block usage
+  int total_blocks;   // the number of kv blocks
+  int active_blocks;  // the number of active kv blocks
+  int cached_blocks;  // the number of cached kv blocks
+  int free_blocks;    // the number of free kv blocks
 };
 
 struct RequestMetrics {
-    std::atomic<int64_t> enqueue_time{};    // when a request is enqued
-    std::atomic<int64_t> scheduled_time{};  // when a request is scheduled for inference
+  std::atomic<int64_t> enqueue_time{};  // when a request is enqued
+  std::atomic<int64_t>
+      scheduled_time{};  // when a request is scheduled for inference
 
-    static int64_t timestamp()
-    {
-        // Get current timestamp in microseconds since Unix epoch
-        // system_clock uses wall-clock time (matches Python's time.time())
-        return std::chrono::duration_cast<std::chrono::microseconds>(
-                   std::chrono::system_clock::now().time_since_epoch())
-            .count();
-    }
+  static int64_t timestamp() {
+    // Get current timestamp in microseconds since Unix epoch
+    // system_clock uses wall-clock time (matches Python's time.time())
+    return std::chrono::duration_cast<std::chrono::microseconds>(
+               std::chrono::system_clock::now().time_since_epoch())
+        .count();
+  }
 };
 
-inline std::ostream& operator<<(std::ostream& os, const ScheduleMetrics& m)
-{
-    os << "ScheduleMetrics { ";
-    os << "total_seqs=" << m.total_seqs;
-    os << ", active_seqs=" << m.active_seqs;
-    os << ", waiting_seqs=" << m.waiting_seqs;
-    os << ", total_blocks=" << m.total_blocks;
-    os << ", cached_blocks=" << m.cached_blocks;
-    os << ", free_blocks=" << m.free_blocks;
-    os << " }";
-    return os;
+inline std::ostream& operator<<(std::ostream& os, const ScheduleMetrics& m) {
+  os << "ScheduleMetrics { ";
+  os << "total_seqs=" << m.total_seqs;
+  os << ", active_seqs=" << m.active_seqs;
+  os << ", waiting_seqs=" << m.waiting_seqs;
+  os << ", total_blocks=" << m.total_blocks;
+  os << ", cached_blocks=" << m.cached_blocks;
+  os << ", free_blocks=" << m.free_blocks;
+  os << " }";
+  return os;
 }
 
-inline std::ostream& operator<<(std::ostream& os, const RequestMetrics& m)
-{
-    os << "RequestMetrics { ";
-    os << "enqueue_time=" << m.enqueue_time.load(std::memory_order_relaxed);
-    os << ", scheduled_time=" << m.scheduled_time.load(std::memory_order_relaxed);
-    os << " }";
-    return os;
+inline std::ostream& operator<<(std::ostream& os, const RequestMetrics& m) {
+  os << "RequestMetrics { ";
+  os << "enqueue_time=" << m.enqueue_time.load(std::memory_order_relaxed);
+  os << ", scheduled_time=" << m.scheduled_time.load(std::memory_order_relaxed);
+  os << " }";
+  return os;
 }
 
 }  // namespace turbomind

--- a/csrc/sm70_turbomind/lmdeploy/src/turbomind/utils/monotonic.h
+++ b/csrc/sm70_turbomind/lmdeploy/src/turbomind/utils/monotonic.h
@@ -7,37 +7,32 @@
 namespace turbomind {
 
 class Monotonic {
-public:
-    Monotonic(void* base, size_t alignment = 256): ptr_{base}, alignment_{alignment}
-    {
-        ptr_ = align(ptr_);
-    }
+ public:
+  Monotonic(void* base, size_t alignment = 256)
+      : ptr_{base}, alignment_{alignment} {
+    ptr_ = align(ptr_);
+  }
 
-    template<class T>
-    void operator()(T** ptr, size_t numel) noexcept
-    {
-        *ptr = (T*)std::exchange(ptr_, align((T*)ptr_ + numel));
-    }
+  template <class T>
+  void operator()(T** ptr, size_t numel) noexcept {
+    *ptr = (T*)std::exchange(ptr_, align((T*)ptr_ + numel));
+  }
 
-    void* ptr() const noexcept
-    {
-        return ptr_;
-    }
+  void* ptr() const noexcept { return ptr_; }
 
-private:
-    template<class T>
-    void* align(T* p)
-    {
-        static_assert(sizeof(T*) == sizeof(uintptr_t));
-        auto x = reinterpret_cast<uintptr_t>(p);
-        if (auto remainder = x % alignment_) {
-            x += alignment_ - remainder;
-        }
-        return reinterpret_cast<void*>(x);
+ private:
+  template <class T>
+  void* align(T* p) {
+    static_assert(sizeof(T*) == sizeof(uintptr_t));
+    auto x = reinterpret_cast<uintptr_t>(p);
+    if (auto remainder = x % alignment_) {
+      x += alignment_ - remainder;
     }
+    return reinterpret_cast<void*>(x);
+  }
 
-    void*  ptr_;
-    size_t alignment_;
+  void* ptr_;
+  size_t alignment_;
 };
 
 }  // namespace turbomind

--- a/csrc/sm70_turbomind/lmdeploy/src/turbomind/utils/nvtx_utils.h
+++ b/csrc/sm70_turbomind/lmdeploy/src/turbomind/utils/nvtx_utils.h
@@ -18,32 +18,32 @@
 
 namespace ft_nvtx {
 static std::string scope;
-std::string        getScope();
-void               addScope(std::string name);
-void               setScope(std::string name);
-void               resetScope();
-static int         domain = 0;
-void               setDeviceDomain(int deviceId);
-int                getDeviceDomain();
-void               resetDeviceDomain();
-bool               isEnableNvtx();
+std::string getScope();
+void addScope(std::string name);
+void setScope(std::string name);
+void resetScope();
+static int domain = 0;
+void setDeviceDomain(int deviceId);
+int getDeviceDomain();
+void resetDeviceDomain();
+bool isEnableNvtx();
 
 static bool has_read_nvtx_env = false;
 static bool is_enable_ft_nvtx = false;
-void        ftNvtxRangePush(std::string name);
-void        ftNvtxRangePop();
+void ftNvtxRangePush(std::string name);
+void ftNvtxRangePop();
 }  // namespace ft_nvtx
 
-#define PUSH_RANGE(name)                                                                                               \
-    {                                                                                                                  \
-        if (ft_nvtx::isEnableNvtx()) {                                                                                 \
-            ft_nvtx::ftNvtxRangePush(name);                                                                            \
-        }                                                                                                              \
-    }
+#define PUSH_RANGE(name)              \
+  {                                   \
+    if (ft_nvtx::isEnableNvtx()) {    \
+      ft_nvtx::ftNvtxRangePush(name); \
+    }                                 \
+  }
 
-#define POP_RANGE                                                                                                      \
-    {                                                                                                                  \
-        if (ft_nvtx::isEnableNvtx()) {                                                                                 \
-            ft_nvtx::ftNvtxRangePop();                                                                                 \
-        }                                                                                                              \
-    }
+#define POP_RANGE                  \
+  {                                \
+    if (ft_nvtx::isEnableNvtx()) { \
+      ft_nvtx::ftNvtxRangePop();   \
+    }                              \
+  }

--- a/csrc/sm70_turbomind/lmdeploy/src/turbomind/utils/parser.cc
+++ b/csrc/sm70_turbomind/lmdeploy/src/turbomind/utils/parser.cc
@@ -7,33 +7,31 @@
 
 namespace turbomind {
 
-std::vector<std::pair<std::string, std::string>> ParseArgsList(const std::string& str)
-{
-    const std::regex regex(R"((\w+)=([^,\[\(]+|\[.*\]|\(.*\)))");
+std::vector<std::pair<std::string, std::string>> ParseArgsList(
+    const std::string& str) {
+  const std::regex regex(R"((\w+)=([^,\[\(]+|\[.*\]|\(.*\)))");
 
-    std::sregex_iterator beg(str.begin(), str.end(), regex);
-    std::sregex_iterator end{};
+  std::sregex_iterator beg(str.begin(), str.end(), regex);
+  std::sregex_iterator end{};
 
-    std::vector<std::pair<std::string, std::string>> ret;
-    for (auto it = beg; it != end; ++it) {
-        std::smatch match = *it;
-        ret.emplace_back(match[1], match[2]);
-    }
+  std::vector<std::pair<std::string, std::string>> ret;
+  for (auto it = beg; it != end; ++it) {
+    std::smatch match = *it;
+    ret.emplace_back(match[1], match[2]);
+  }
 
-    return ret;
+  return ret;
 }
 
-std::vector<std::string> ParseListOrTuple(const std::string& str)
-{
-    const std::regex regex(R"([,\[\]\(\)]+)");
+std::vector<std::string> ParseListOrTuple(const std::string& str) {
+  const std::regex regex(R"([,\[\]\(\)]+)");
 
-    std::vector<std::string> ret;
-    std::copy_if(std::sregex_token_iterator(str.begin(), str.end(), regex, -1),
-                 std::sregex_token_iterator{},
-                 std::back_inserter(ret),
-                 [](const std::string& s) { return !s.empty(); });
+  std::vector<std::string> ret;
+  std::copy_if(std::sregex_token_iterator(str.begin(), str.end(), regex, -1),
+               std::sregex_token_iterator{}, std::back_inserter(ret),
+               [](const std::string& s) { return !s.empty(); });
 
-    return ret;
+  return ret;
 }
 
 }  // namespace turbomind

--- a/csrc/sm70_turbomind/lmdeploy/src/turbomind/utils/parser.h
+++ b/csrc/sm70_turbomind/lmdeploy/src/turbomind/utils/parser.h
@@ -3,28 +3,26 @@
 
 namespace turbomind {
 
-std::vector<std::pair<std::string, std::string>> ParseArgsList(const std::string& str);
+std::vector<std::pair<std::string, std::string>> ParseArgsList(
+    const std::string& str);
 
 std::vector<std::string> ParseListOrTuple(const std::string& str);
 
-inline void Parse(int& value, const std::string& str)
-{
-    value = std::stoi(str);
+inline void Parse(int& value, const std::string& str) {
+  value = std::stoi(str);
 }
 
-inline void Parse(float& value, const std::string& str)
-{
-    value = std::stof(str);
+inline void Parse(float& value, const std::string& str) {
+  value = std::stof(str);
 }
 
-template<class T>
-void Parse(std::vector<T>& xs, const std::string& str)
-{
-    const auto ss = ParseListOrTuple(str);
-    for (const auto& s : ss) {
-        xs.emplace_back();
-        Parse(xs.back(), s);
-    }
+template <class T>
+void Parse(std::vector<T>& xs, const std::string& str) {
+  const auto ss = ParseListOrTuple(str);
+  for (const auto& s : ss) {
+    xs.emplace_back();
+    Parse(xs.back(), s);
+  }
 }
 
 }  // namespace turbomind

--- a/csrc/sm70_turbomind/lmdeploy/src/turbomind/utils/string_utils.h
+++ b/csrc/sm70_turbomind/lmdeploy/src/turbomind/utils/string_utils.h
@@ -23,62 +23,61 @@
 
 namespace turbomind {
 
-template<typename... Args>
-inline std::string fmtstr(const std::string& format, Args... args)
-{
-    // This function came from a code snippet in stackoverflow under cc-by-1.0
-    //   https://stackoverflow.com/questions/2342162/stdstring-formatting-like-sprintf
+template <typename... Args>
+inline std::string fmtstr(const std::string& format, Args... args) {
+  // This function came from a code snippet in stackoverflow under cc-by-1.0
+  //   https://stackoverflow.com/questions/2342162/stdstring-formatting-like-sprintf
 
-    // Disable format-security warning in this function.
+  // Disable format-security warning in this function.
 #if defined(_MSC_VER)  // for visual studio
-#pragma warning(push)
-#pragma warning(warning(disable : 4996))
+  #pragma warning(push)
+  #pragma warning(warning(disable : 4996))
 #elif defined(__GNUC__) || defined(__clang__)  // for gcc or clang
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wformat-security"
+  #pragma GCC diagnostic push
+  #pragma GCC diagnostic ignored "-Wformat-security"
 #endif
-    int size_s = std::snprintf(nullptr, 0, format.c_str(), args...) + 1;  // Extra space for '\0'
-    if (size_s <= 0) {
-        throw std::runtime_error("Error during formatting.");
-    }
-    auto size = static_cast<size_t>(size_s);
-    auto buf  = std::make_unique<char[]>(size);
-    std::snprintf(buf.get(), size, format.c_str(), args...);
+  int size_s = std::snprintf(nullptr, 0, format.c_str(), args...) +
+               1;  // Extra space for '\0'
+  if (size_s <= 0) {
+    throw std::runtime_error("Error during formatting.");
+  }
+  auto size = static_cast<size_t>(size_s);
+  auto buf = std::make_unique<char[]>(size);
+  std::snprintf(buf.get(), size, format.c_str(), args...);
 #if defined(_MSC_VER)
-#pragma warning(pop)
+  #pragma warning(pop)
 #elif defined(__GNUC__) || defined(__clang__)
-#pragma GCC diagnostic pop
+  #pragma GCC diagnostic pop
 #endif
-    return std::string(buf.get(), buf.get() + size - 1);  // We don't want the '\0' inside
+  return std::string(buf.get(),
+                     buf.get() + size - 1);  // We don't want the '\0' inside
 }
 
-template<typename T>
-inline std::string vec2str(std::vector<T> vec)
-{
-    std::stringstream ss;
-    ss << "(";
-    if (!vec.empty()) {
-        for (size_t i = 0; i < vec.size() - 1; ++i) {
-            ss << vec[i] << ", ";
-        }
-        ss << vec.back();
+template <typename T>
+inline std::string vec2str(std::vector<T> vec) {
+  std::stringstream ss;
+  ss << "(";
+  if (!vec.empty()) {
+    for (size_t i = 0; i < vec.size() - 1; ++i) {
+      ss << vec[i] << ", ";
     }
-    ss << ")";
-    return ss.str();
+    ss << vec.back();
+  }
+  ss << ")";
+  return ss.str();
 }
 
-template<typename T>
-inline std::string arr2str(T* arr, size_t size)
-{
-    std::stringstream ss;
-    ss << "(";
-    for (size_t i = 0; i < size - 1; ++i) {
-        ss << arr[i] << ", ";
-    }
-    if (size > 0) {
-        ss << arr[size - 1];
-    }
-    ss << ")";
-    return ss.str();
+template <typename T>
+inline std::string arr2str(T* arr, size_t size) {
+  std::stringstream ss;
+  ss << "(";
+  for (size_t i = 0; i < size - 1; ++i) {
+    ss << arr[i] << ", ";
+  }
+  if (size > 0) {
+    ss << arr[size - 1];
+  }
+  ss << ")";
+  return ss.str();
 }
 }  // namespace turbomind

--- a/csrc/sm70_turbomind/lmdeploy/src/turbomind/utils/test_utils.h
+++ b/csrc/sm70_turbomind/lmdeploy/src/turbomind/utils/test_utils.h
@@ -22,39 +22,36 @@
 
 namespace turbomind {
 
-#define TIMEIT(print, n, stream, fn, ...)                                                                              \
-    ({                                                                                                                 \
-        cudaEvent_t _macro_event_start, _macro_event_stop;                                                             \
-        cudaEventCreate(&_macro_event_start);                                                                          \
-        cudaEventCreate(&_macro_event_stop);                                                                           \
-        cudaEventRecord(_macro_event_start, stream);                                                                   \
-        for (int i = 0; i < n; i++) {                                                                                  \
-            fn(__VA_ARGS__);                                                                                           \
-        }                                                                                                              \
-        cudaEventRecord(_macro_event_stop, stream);                                                                    \
-        cudaStreamSynchronize(stream);                                                                                 \
-        float ms = 0.0f;                                                                                               \
-        cudaEventElapsedTime(&ms, _macro_event_start, _macro_event_stop);                                              \
-        ms /= n;                                                                                                       \
-        if (print)                                                                                                     \
-            printf("[TIMEIT] " #fn ": %.2fµs\n", ms * 1000);                                                           \
-        ms;                                                                                                            \
-    })
+#define TIMEIT(print, n, stream, fn, ...)                             \
+  ({                                                                  \
+    cudaEvent_t _macro_event_start, _macro_event_stop;                \
+    cudaEventCreate(&_macro_event_start);                             \
+    cudaEventCreate(&_macro_event_stop);                              \
+    cudaEventRecord(_macro_event_start, stream);                      \
+    for (int i = 0; i < n; i++) {                                     \
+      fn(__VA_ARGS__);                                                \
+    }                                                                 \
+    cudaEventRecord(_macro_event_stop, stream);                       \
+    cudaStreamSynchronize(stream);                                    \
+    float ms = 0.0f;                                                  \
+    cudaEventElapsedTime(&ms, _macro_event_start, _macro_event_stop); \
+    ms /= n;                                                          \
+    if (print) printf("[TIMEIT] " #fn ": %.2fµs\n", ms * 1000);       \
+    ms;                                                               \
+  })
 
-template<typename T>
+template <typename T>
 struct rel_abs_diff {
-    T operator()(const T& lhs, const T& rhs) const
-    {
-        return lhs == 0 ? 0 : static_cast<T>(fabs(lhs - rhs) / fabs(lhs));
-    }
+  T operator()(const T& lhs, const T& rhs) const {
+    return lhs == 0 ? 0 : static_cast<T>(fabs(lhs - rhs) / fabs(lhs));
+  }
 };
 
-template<typename T>
+template <typename T>
 struct abs_diff {
-    T operator()(const T& lhs, const T& rhs) const
-    {
-        return static_cast<T>(fabs(lhs - rhs));
-    }
+  T operator()(const T& lhs, const T& rhs) const {
+    return static_cast<T>(fabs(lhs - rhs));
+  }
 };
 
 }  // namespace turbomind

--- a/csrc/sm70_turbomind/ops/tm_registry_sm70.cu
+++ b/csrc/sm70_turbomind/ops/tm_registry_sm70.cu
@@ -6,34 +6,33 @@
 
 namespace turbomind::gemm {
 
-Registry::Registry(std::shared_ptr<cudaDeviceProp> device_prop):
-    device_prop_{std::move(device_prop)}, arch_{device_prop_->major * 100 + device_prop_->minor * 10}
-{
-    // Register the V100 kernels we actually use in this build:
-    // AWQ uint4, FP8/E4M3, and dense fp16 Tensor Core paths.
-    sm70_884_4();
-    sm70_884_8();
-    sm70_884_16();
+Registry::Registry(std::shared_ptr<cudaDeviceProp> device_prop)
+    : device_prop_{std::move(device_prop)},
+      arch_{device_prop_->major * 100 + device_prop_->minor * 10} {
+  // Register the V100 kernels we actually use in this build:
+  // AWQ uint4, FP8/E4M3, and dense fp16 Tensor Core paths.
+  sm70_884_4();
+  sm70_884_8();
+  sm70_884_16();
 }
 
-bool Registry::Add(std::unique_ptr<Kernel> kernel)
-{
-    bool is_valid = true;
+bool Registry::Add(std::unique_ptr<Kernel> kernel) {
+  bool is_valid = true;
 
-    if (!is_arch_compatible(kernel->arch(), arch_)) {
-        is_valid = false;
-    }
+  if (!is_arch_compatible(kernel->arch(), arch_)) {
+    is_valid = false;
+  }
 
-    if ((int)device_prop_->sharedMemPerBlockOptin < kernel->smem_size()) {
-        is_valid = false;
-    }
+  if ((int)device_prop_->sharedMemPerBlockOptin < kernel->smem_size()) {
+    is_valid = false;
+  }
 
-    if (is_valid) {
-        ptrs_.push_back(kernels_.emplace_back(transpose(*kernel)).get());
-        ptrs_.push_back(kernels_.emplace_back(std::move(kernel)).get());
-    }
+  if (is_valid) {
+    ptrs_.push_back(kernels_.emplace_back(transpose(*kernel)).get());
+    ptrs_.push_back(kernels_.emplace_back(std::move(kernel)).get());
+  }
 
-    return true;
+  return true;
 }
 
 }  // namespace turbomind::gemm

--- a/csrc/torch_bindings.cpp
+++ b/csrc/torch_bindings.cpp
@@ -165,13 +165,13 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, ops) {
       "Tensor? qzeros_or_none, bool inplace) -> Tensor");
   // conditionally compiled so impl registrations are in source file
 
-#ifdef ENABLE_SM70_TURBOMIND
+  #ifdef ENABLE_SM70_TURBOMIND
   ops.def("silu_and_mul_interleaved(Tensor! result, Tensor input) -> ()");
-  ops.impl("silu_and_mul_interleaved", torch::kCUDA,
-           &silu_and_mul_interleaved);
+  ops.impl("silu_and_mul_interleaved", torch::kCUDA, &silu_and_mul_interleaved);
 
   ops.def(
-      "awq_sm70_prepare(Tensor _kernel, Tensor _scaling_factors, Tensor _zeros, "
+      "awq_sm70_prepare(Tensor _kernel, Tensor _scaling_factors, Tensor "
+      "_zeros, "
       "int group_size, bool interleave_gated_silu) -> Tensor[]");
   ops.impl("awq_sm70_prepare", torch::kCUDA, &awq_sm70_prepare);
 
@@ -242,34 +242,29 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, ops) {
       "nvfp4_gemv_sm70_raw_out(Tensor(a!) out, Tensor _in_feats, "
       "Tensor _kernel, Tensor _scaling_factors, Tensor(b!) partials, "
       "int group_size, int split_k) -> ()");
-  ops.impl("nvfp4_gemv_sm70_raw_out", torch::kCUDA,
-           &nvfp4_gemv_sm70_raw_out);
+  ops.impl("nvfp4_gemv_sm70_raw_out", torch::kCUDA, &nvfp4_gemv_sm70_raw_out);
 
   ops.def(
       "nvfp4_gemv_sm70_warp_out(Tensor(a!) out, Tensor _in_feats, "
       "Tensor _kernel, Tensor _scaling_factors, int group_size) -> ()");
-  ops.impl("nvfp4_gemv_sm70_warp_out", torch::kCUDA,
-           &nvfp4_gemv_sm70_warp_out);
+  ops.impl("nvfp4_gemv_sm70_warp_out", torch::kCUDA, &nvfp4_gemv_sm70_warp_out);
 
   ops.def(
       "nvfp4_gemv_sm70_h2_out(Tensor(a!) out, Tensor _in_feats, "
       "Tensor _kernel, Tensor _scaling_factors, Tensor(b!) partials, "
       "int group_size, int split_k) -> ()");
-  ops.impl("nvfp4_gemv_sm70_h2_out", torch::kCUDA,
-           &nvfp4_gemv_sm70_h2_out);
+  ops.impl("nvfp4_gemv_sm70_h2_out", torch::kCUDA, &nvfp4_gemv_sm70_h2_out);
 
   ops.def(
       "fp8_gemm_sm70_out_auto(Tensor(a!) out, Tensor _in_feats, "
       "Tensor _kernel, Tensor _scaling_factors) -> ()");
-  ops.impl("fp8_gemm_sm70_out_auto", torch::kCUDA,
-           &fp8_gemm_sm70_out_auto);
+  ops.impl("fp8_gemm_sm70_out_auto", torch::kCUDA, &fp8_gemm_sm70_out_auto);
 
   ops.def(
       "fp8_gemm_sm70_out_meta(Tensor(a!) out, Tensor _in_feats, "
       "Tensor _kernel, Tensor _scaling_factors, Tensor _meta, "
       "bool gated_silu) -> ()");
-  ops.impl("fp8_gemm_sm70_out_meta", torch::kCUDA,
-           &fp8_gemm_sm70_out_meta);
+  ops.impl("fp8_gemm_sm70_out_meta", torch::kCUDA, &fp8_gemm_sm70_out_meta);
 
   ops.def(
       "sm70_f16_gemm_out(Tensor(a!) out, Tensor _in_feats, Tensor _kernel, "
@@ -539,7 +534,7 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, ops) {
       "bool exact_per_route) -> ()");
   ops.impl("fp8_moe_single_token_sm70_out", torch::kCUDA,
            &fp8_moe_single_token_sm70_out);
-#endif
+  #endif
 
 #endif
 

--- a/flash-attention-v100/include/fused_mha.h
+++ b/flash-attention-v100/include/fused_mha.h
@@ -8,243 +8,122 @@
 #include <ATen/ATen.h>
 
 std::vector<at::Tensor> flash_attention_forward(
-    at::Tensor& q,
-    const at::Tensor& k,
-    const at::Tensor& v,
-    std::optional<at::Tensor>& out_,
-    std::optional<at::Tensor>& alibi_slopes_,
-    const float p_dropout,
-    const float softmax_scale,
-    bool is_causal,
-    int window_size_left,
-    int window_size_right,
-    const float softcap,
-    const bool return_softmax,
-    std::optional<at::Generator> gen_
-);
+    at::Tensor& q, const at::Tensor& k, const at::Tensor& v,
+    std::optional<at::Tensor>& out_, std::optional<at::Tensor>& alibi_slopes_,
+    const float p_dropout, const float softmax_scale, bool is_causal,
+    int window_size_left, int window_size_right, const float softcap,
+    const bool return_softmax, std::optional<at::Generator> gen_);
 
-at::Tensor flash_attention_qk_scores(
-    const at::Tensor& q,
-    const at::Tensor& k,
-    const float softmax_scale,
-    const bool is_causal
-);
+at::Tensor flash_attention_qk_scores(const at::Tensor& q, const at::Tensor& k,
+                                     const float softmax_scale,
+                                     const bool is_causal);
 
 at::Tensor flash_attention_decode_paged(
-    const at::Tensor& q,
-    const at::Tensor& k_cache,
-    const at::Tensor& v_cache,
-    std::optional<at::Tensor>& out_,
-    const at::Tensor& block_table,
-    const at::Tensor& seq_lens,
-    at::Tensor& tmp_out,
-    at::Tensor& max_logits,
-    at::Tensor& exp_sums,
-    const at::Tensor& active_num_partitions,
-    const float softmax_scale,
-    const int partition_size,
-    const int launch_num_partitions,
-    const std::string& kv_cache_dtype,
-    const float k_scale,
-    const float v_scale,
-    const int window_size_left,
-    const int window_size_right
-);
+    const at::Tensor& q, const at::Tensor& k_cache, const at::Tensor& v_cache,
+    std::optional<at::Tensor>& out_, const at::Tensor& block_table,
+    const at::Tensor& seq_lens, at::Tensor& tmp_out, at::Tensor& max_logits,
+    at::Tensor& exp_sums, const at::Tensor& active_num_partitions,
+    const float softmax_scale, const int partition_size,
+    const int launch_num_partitions, const std::string& kv_cache_dtype,
+    const float k_scale, const float v_scale, const int window_size_left,
+    const int window_size_right);
 
 at::Tensor flash_attention_decode_paged_xqa(
-    const at::Tensor& q,
-    const at::Tensor& k_cache,
-    const at::Tensor& v_cache,
-    std::optional<at::Tensor>& out_,
-    const at::Tensor& block_table,
-    const at::Tensor& seq_lens,
-    at::Tensor& tmp_out,
-    at::Tensor& max_logits,
-    at::Tensor& exp_sums,
-    const at::Tensor& active_num_partitions,
-    const float softmax_scale,
-    const int partition_size,
-    const int launch_num_partitions,
-    const std::string& kv_cache_dtype,
-    const float k_scale,
-    const float v_scale,
-    const int window_size_left,
-    const int window_size_right
-);
+    const at::Tensor& q, const at::Tensor& k_cache, const at::Tensor& v_cache,
+    std::optional<at::Tensor>& out_, const at::Tensor& block_table,
+    const at::Tensor& seq_lens, at::Tensor& tmp_out, at::Tensor& max_logits,
+    at::Tensor& exp_sums, const at::Tensor& active_num_partitions,
+    const float softmax_scale, const int partition_size,
+    const int launch_num_partitions, const std::string& kv_cache_dtype,
+    const float k_scale, const float v_scale, const int window_size_left,
+    const int window_size_right);
 
 at::Tensor flash_attention_decode_paged_xqa_staged(
-    const at::Tensor& q,
-    const at::Tensor& k_cache,
-    const at::Tensor& v_cache,
-    std::optional<at::Tensor>& out_,
-    const at::Tensor& block_table,
-    const at::Tensor& seq_lens,
-    at::Tensor& tmp_out,
-    at::Tensor& max_logits,
-    at::Tensor& exp_sums,
-    at::Tensor& online_rescales,
-    const at::Tensor& active_num_partitions,
-    const float softmax_scale,
-    const int partition_size,
-    const int launch_num_partitions,
-    const std::string& kv_cache_dtype,
-    const float k_scale,
-    const float v_scale,
-    const int window_size_left,
-    const int window_size_right
-);
+    const at::Tensor& q, const at::Tensor& k_cache, const at::Tensor& v_cache,
+    std::optional<at::Tensor>& out_, const at::Tensor& block_table,
+    const at::Tensor& seq_lens, at::Tensor& tmp_out, at::Tensor& max_logits,
+    at::Tensor& exp_sums, at::Tensor& online_rescales,
+    const at::Tensor& active_num_partitions, const float softmax_scale,
+    const int partition_size, const int launch_num_partitions,
+    const std::string& kv_cache_dtype, const float k_scale, const float v_scale,
+    const int window_size_left, const int window_size_right);
 
 at::Tensor flash_attention_decode_paged_wmma(
-    const at::Tensor& q,
-    const at::Tensor& k_cache,
-    const at::Tensor& v_cache,
-    std::optional<at::Tensor>& out_,
-    const at::Tensor& block_table,
-    const at::Tensor& seq_lens,
-    const float softmax_scale,
-    const std::string& kv_cache_dtype,
-    const float k_scale,
-    const float v_scale
-);
+    const at::Tensor& q, const at::Tensor& k_cache, const at::Tensor& v_cache,
+    std::optional<at::Tensor>& out_, const at::Tensor& block_table,
+    const at::Tensor& seq_lens, const float softmax_scale,
+    const std::string& kv_cache_dtype, const float k_scale,
+    const float v_scale);
 
 at::Tensor flash_attention_decode_qk_scores(
-    const at::Tensor& q,
-    const at::Tensor& k_cache,
-    const at::Tensor& block_table,
-    const at::Tensor& seq_lens,
-    const float softmax_scale,
-    const int partition_size,
-    const std::string& kv_cache_dtype,
-    const float k_scale
-);
+    const at::Tensor& q, const at::Tensor& k_cache,
+    const at::Tensor& block_table, const at::Tensor& seq_lens,
+    const float softmax_scale, const int partition_size,
+    const std::string& kv_cache_dtype, const float k_scale);
 
 at::Tensor flash_attention_turboquant_decode_paged(
-    const at::Tensor& q_rot,
-    const at::Tensor& kv_cache,
-    std::optional<at::Tensor>& out_,
-    const at::Tensor& block_table,
-    const at::Tensor& seq_lens,
-    at::Tensor& tmp_out,
-    at::Tensor& max_logits,
-    at::Tensor& exp_sums,
-    const at::Tensor& centroids,
-    const float softmax_scale,
-    const int partition_size,
-    const int mse_bits,
-    const int value_quant_bits,
-    const bool norm_correction
-);
+    const at::Tensor& q_rot, const at::Tensor& kv_cache,
+    std::optional<at::Tensor>& out_, const at::Tensor& block_table,
+    const at::Tensor& seq_lens, at::Tensor& tmp_out, at::Tensor& max_logits,
+    at::Tensor& exp_sums, const at::Tensor& centroids,
+    const float softmax_scale, const int partition_size, const int mse_bits,
+    const int value_quant_bits, const bool norm_correction);
 
 at::Tensor flash_attention_prefill_paged(
-    const at::Tensor& q,
-    const at::Tensor& k_cache,
-    const at::Tensor& v_cache,
-    std::optional<at::Tensor>& out_,
-    const at::Tensor& block_table,
-    const at::Tensor& seq_lens,
-    const float softmax_scale,
-    const std::string& kv_cache_dtype,
-    const float k_scale,
-    const float v_scale,
-    const bool is_causal,
-    const int window_size_left,
-    const int window_size_right
-);
+    const at::Tensor& q, const at::Tensor& k_cache, const at::Tensor& v_cache,
+    std::optional<at::Tensor>& out_, const at::Tensor& block_table,
+    const at::Tensor& seq_lens, const float softmax_scale,
+    const std::string& kv_cache_dtype, const float k_scale, const float v_scale,
+    const bool is_causal, const int window_size_left,
+    const int window_size_right);
 
 std::vector<at::Tensor>
 flash_attention_prefill_paged_d256_bm32_allp_pair_scratch(
-    const at::Tensor& q,
-    const at::Tensor& k_cache,
-    const at::Tensor& v_cache,
-    std::optional<at::Tensor>& out_,
-    std::optional<at::Tensor>& softmax_lse_,
-    const at::Tensor& block_table,
-    const at::Tensor& seq_lens,
-    const float softmax_scale
-);
+    const at::Tensor& q, const at::Tensor& k_cache, const at::Tensor& v_cache,
+    std::optional<at::Tensor>& out_, std::optional<at::Tensor>& softmax_lse_,
+    const at::Tensor& block_table, const at::Tensor& seq_lens,
+    const float softmax_scale);
 
 std::vector<at::Tensor>
 flash_attention_prefill_paged_d256_bm32_allp_pair_scratch_splitkv3(
-    const at::Tensor& q,
-    const at::Tensor& k_cache,
-    const at::Tensor& v_cache,
-    std::optional<at::Tensor>& out_,
-    std::optional<at::Tensor>& softmax_lse_,
-    at::Tensor& split_tmp_out,
-    at::Tensor& split_tmp_row_max,
-    at::Tensor& split_tmp_row_sum,
-    const at::Tensor& block_table,
-    const int64_t actual_n,
-    const float softmax_scale
-);
+    const at::Tensor& q, const at::Tensor& k_cache, const at::Tensor& v_cache,
+    std::optional<at::Tensor>& out_, std::optional<at::Tensor>& softmax_lse_,
+    at::Tensor& split_tmp_out, at::Tensor& split_tmp_row_max,
+    at::Tensor& split_tmp_row_sum, const at::Tensor& block_table,
+    const int64_t actual_n, const float softmax_scale);
 
 at::Tensor flash_attention_prefill_paged_bfla(
-    const at::Tensor& q,
-    const at::Tensor& k_cache,
-    const at::Tensor& v_cache,
-    std::optional<at::Tensor>& out_,
-    const at::Tensor& block_table,
-    const at::Tensor& seq_lens,
-    const at::Tensor& bfla_block_mask,
-    const int bfla_mask_block_n,
-    const float softmax_scale,
-    const std::string& kv_cache_dtype,
-    const float k_scale,
-    const float v_scale,
-    const bool is_causal,
-    const int window_size_left,
-    const int window_size_right
-);
+    const at::Tensor& q, const at::Tensor& k_cache, const at::Tensor& v_cache,
+    std::optional<at::Tensor>& out_, const at::Tensor& block_table,
+    const at::Tensor& seq_lens, const at::Tensor& bfla_block_mask,
+    const int bfla_mask_block_n, const float softmax_scale,
+    const std::string& kv_cache_dtype, const float k_scale, const float v_scale,
+    const bool is_causal, const int window_size_left,
+    const int window_size_right);
 
 at::Tensor flash_attention_prefill_paged_splitkv(
-    const at::Tensor& q,
-    const at::Tensor& k_cache,
-    const at::Tensor& v_cache,
-    std::optional<at::Tensor>& out_,
-    const at::Tensor& block_table,
-    const at::Tensor& seq_lens,
-    const float softmax_scale,
-    const std::string& kv_cache_dtype,
-    const float k_scale,
-    const float v_scale,
-    const bool is_causal,
-    const int window_size_left,
-    const int window_size_right,
-    const int split_kv_tokens,
-    const int max_seq_len_hint
-);
+    const at::Tensor& q, const at::Tensor& k_cache, const at::Tensor& v_cache,
+    std::optional<at::Tensor>& out_, const at::Tensor& block_table,
+    const at::Tensor& seq_lens, const float softmax_scale,
+    const std::string& kv_cache_dtype, const float k_scale, const float v_scale,
+    const bool is_causal, const int window_size_left,
+    const int window_size_right, const int split_kv_tokens,
+    const int max_seq_len_hint);
 
 void flash_attention_fp8_e5m2_paged_kv_to_fp16(
-    const at::Tensor& key_cache,
-    const at::Tensor& value_cache,
-    const at::Tensor& block_table,
-    const at::Tensor& seq_lens,
-    at::Tensor& key_out,
-    at::Tensor& value_out,
-    const float key_scale,
-    const float value_scale
-);
+    const at::Tensor& key_cache, const at::Tensor& value_cache,
+    const at::Tensor& block_table, const at::Tensor& seq_lens,
+    at::Tensor& key_out, at::Tensor& value_out, const float key_scale,
+    const float value_scale);
 
 std::vector<at::Tensor> flash_attention_backward(
-    const at::Tensor& dout,
-    const at::Tensor& q,
-    const at::Tensor& k,
-    const at::Tensor& v,
-    const at::Tensor& out,
-    const at::Tensor& softmax_lse,
-    std::optional<at::Tensor>& dq_,
-    std::optional<at::Tensor>& dk_,
-    std::optional<at::Tensor>& dv_,
-    std::optional<at::Tensor>& alibi_slopes_,
-    const float p_dropout,
-    const float softmax_scale,
-    const bool is_causal,
-    int window_size_left,
-    int window_size_right,
-    const float softcap,
-    const bool deterministic,
-    std::optional<at::Generator> gen_,
-    std::optional<at::Tensor>& rng_state
-);
+    const at::Tensor& dout, const at::Tensor& q, const at::Tensor& k,
+    const at::Tensor& v, const at::Tensor& out, const at::Tensor& softmax_lse,
+    std::optional<at::Tensor>& dq_, std::optional<at::Tensor>& dk_,
+    std::optional<at::Tensor>& dv_, std::optional<at::Tensor>& alibi_slopes_,
+    const float p_dropout, const float softmax_scale, const bool is_causal,
+    int window_size_left, int window_size_right, const float softcap,
+    const bool deterministic, std::optional<at::Generator> gen_,
+    std::optional<at::Tensor>& rng_state);
 
 #endif

--- a/flash-attention-v100/include/fused_mma.h
+++ b/flash-attention-v100/include/fused_mma.h
@@ -2,7 +2,7 @@
 #define FUSED_MMA_H
 
 #if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ != 700)
-#error "Volta WMMA: This header is for sm_70 ONLY! Compile with -arch=sm_70"
+  #error "Volta WMMA: This header is for sm_70 ONLY! Compile with -arch=sm_70"
 #endif
 
 #include <cuda_fp16.h>
@@ -15,385 +15,409 @@ struct matrix_a {};
 struct matrix_b {};
 struct accumulator {};
 
-enum layout_t {
-    mem_row_major,
-    mem_col_major
-};
+enum layout_t { mem_row_major, mem_col_major };
 
 template <typename Use, int M, int N, int K, typename T, typename Layout = void>
 struct fragment;
 
-template <> struct fragment<matrix_a, 16, 16, 16, half, row_major> { uint32_t x[8]; static constexpr int num_elements = 16; };
-template <> struct fragment<matrix_a, 16, 16, 16, half, col_major> { uint32_t x[8]; static constexpr int num_elements = 16; };
+template <>
+struct fragment<matrix_a, 16, 16, 16, half, row_major> {
+  uint32_t x[8];
+  static constexpr int num_elements = 16;
+};
+template <>
+struct fragment<matrix_a, 16, 16, 16, half, col_major> {
+  uint32_t x[8];
+  static constexpr int num_elements = 16;
+};
 
-template <> struct fragment<matrix_a, 32, 8, 16, half, row_major>  { uint32_t x[8]; static constexpr int num_elements = 16; };
-template <> struct fragment<matrix_a, 32, 8, 16, half, col_major>  { uint32_t x[8]; static constexpr int num_elements = 16; };
+template <>
+struct fragment<matrix_a, 32, 8, 16, half, row_major> {
+  uint32_t x[8];
+  static constexpr int num_elements = 16;
+};
+template <>
+struct fragment<matrix_a, 32, 8, 16, half, col_major> {
+  uint32_t x[8];
+  static constexpr int num_elements = 16;
+};
 
-template <> struct fragment<matrix_a, 8, 32, 16, half, row_major>  { uint32_t x[8]; static constexpr int num_elements = 16; };
-template <> struct fragment<matrix_a, 8, 32, 16, half, col_major>  { uint32_t x[8]; static constexpr int num_elements = 16; };
+template <>
+struct fragment<matrix_a, 8, 32, 16, half, row_major> {
+  uint32_t x[8];
+  static constexpr int num_elements = 16;
+};
+template <>
+struct fragment<matrix_a, 8, 32, 16, half, col_major> {
+  uint32_t x[8];
+  static constexpr int num_elements = 16;
+};
 
-template <> struct fragment<matrix_b, 16, 16, 16, half, row_major> { uint32_t x[8]; static constexpr int num_elements = 16; };
-template <> struct fragment<matrix_b, 16, 16, 16, half, col_major> { uint32_t x[8]; static constexpr int num_elements = 16; };
+template <>
+struct fragment<matrix_b, 16, 16, 16, half, row_major> {
+  uint32_t x[8];
+  static constexpr int num_elements = 16;
+};
+template <>
+struct fragment<matrix_b, 16, 16, 16, half, col_major> {
+  uint32_t x[8];
+  static constexpr int num_elements = 16;
+};
 
-template <> struct fragment<matrix_b, 32, 8, 16, half, row_major>  { uint32_t x[8]; static constexpr int num_elements = 16; };
-template <> struct fragment<matrix_b, 32, 8, 16, half, col_major>  { uint32_t x[8]; static constexpr int num_elements = 16; };
+template <>
+struct fragment<matrix_b, 32, 8, 16, half, row_major> {
+  uint32_t x[8];
+  static constexpr int num_elements = 16;
+};
+template <>
+struct fragment<matrix_b, 32, 8, 16, half, col_major> {
+  uint32_t x[8];
+  static constexpr int num_elements = 16;
+};
 
-template <> struct fragment<matrix_b, 8, 32, 16, half, row_major>  { uint32_t x[8]; static constexpr int num_elements = 16; };
-template <> struct fragment<matrix_b, 8, 32, 16, half, col_major>  { uint32_t x[8]; static constexpr int num_elements = 16; };
+template <>
+struct fragment<matrix_b, 8, 32, 16, half, row_major> {
+  uint32_t x[8];
+  static constexpr int num_elements = 16;
+};
+template <>
+struct fragment<matrix_b, 8, 32, 16, half, col_major> {
+  uint32_t x[8];
+  static constexpr int num_elements = 16;
+};
 
-template <> struct fragment<accumulator, 16, 16, 16, float> { float x[8]; static constexpr int num_elements = 8; };
-template <> struct fragment<accumulator, 32, 8, 16, float>  { float x[8]; static constexpr int num_elements = 8; };
-template <> struct fragment<accumulator, 8, 32, 16, float>  { float x[8]; static constexpr int num_elements = 8; };
+template <>
+struct fragment<accumulator, 16, 16, 16, float> {
+  float x[8];
+  static constexpr int num_elements = 8;
+};
+template <>
+struct fragment<accumulator, 32, 8, 16, float> {
+  float x[8];
+  static constexpr int num_elements = 8;
+};
+template <>
+struct fragment<accumulator, 8, 32, 16, float> {
+  float x[8];
+  static constexpr int num_elements = 8;
+};
 
 __device__ __forceinline__ unsigned get_lane_id() {
-    unsigned lane_id;
-    asm volatile ("mov.u32 %0, %%laneid;" : "=r"(lane_id));
-    return lane_id;
+  unsigned lane_id;
+  asm volatile("mov.u32 %0, %%laneid;" : "=r"(lane_id));
+  return lane_id;
 }
 
 template <int M, int N, int K>
-__device__ __forceinline__ void fill_fragment(fragment<accumulator, M, N, K, float>& frag, float value) {
-    #pragma unroll
-    for (int i = 0; i < 8; ++i) frag.x[i] = value;
+__device__ __forceinline__ void fill_fragment(
+    fragment<accumulator, M, N, K, float>& frag, float value) {
+#pragma unroll
+  for (int i = 0; i < 8; ++i) frag.x[i] = value;
 }
 
 __device__ __forceinline__ void load_matrix_sync(
-    fragment<matrix_a, 16, 16, 16, half, row_major>& frag,
-    const half* smem_ptr, unsigned ldm) {
+    fragment<matrix_a, 16, 16, 16, half, row_major>& frag, const half* smem_ptr,
+    unsigned ldm) {
+  asm volatile(
+      "wmma.load.a.sync.aligned.row.m16n16k16.f16 "
+      "{%0,%1,%2,%3,%4,%5,%6,%7}, [%8], %9;"
+      : "=r"(frag.x[0]), "=r"(frag.x[1]), "=r"(frag.x[2]), "=r"(frag.x[3]),
+        "=r"(frag.x[4]), "=r"(frag.x[5]), "=r"(frag.x[6]), "=r"(frag.x[7])
+      : "l"(smem_ptr), "r"(ldm)
+      : "memory");
+}
+
+__device__ __forceinline__ void load_matrix_sync(
+    fragment<matrix_a, 16, 16, 16, half, col_major>& frag, const half* smem_ptr,
+    unsigned ldm) {
+  asm volatile(
+      "wmma.load.a.sync.aligned.col.m16n16k16.f16 "
+      "{%0,%1,%2,%3,%4,%5,%6,%7}, [%8], %9;"
+      : "=r"(frag.x[0]), "=r"(frag.x[1]), "=r"(frag.x[2]), "=r"(frag.x[3]),
+        "=r"(frag.x[4]), "=r"(frag.x[5]), "=r"(frag.x[6]), "=r"(frag.x[7])
+      : "l"(smem_ptr), "r"(ldm)
+      : "memory");
+}
+
+__device__ __forceinline__ void load_matrix_sync(
+    fragment<matrix_b, 16, 16, 16, half, row_major>& frag, const half* smem_ptr,
+    unsigned ldm) {
+  asm volatile(
+      "wmma.load.b.sync.aligned.row.m16n16k16.f16 "
+      "{%0,%1,%2,%3,%4,%5,%6,%7}, [%8], %9;"
+      : "=r"(frag.x[0]), "=r"(frag.x[1]), "=r"(frag.x[2]), "=r"(frag.x[3]),
+        "=r"(frag.x[4]), "=r"(frag.x[5]), "=r"(frag.x[6]), "=r"(frag.x[7])
+      : "l"(smem_ptr), "r"(ldm)
+      : "memory");
+}
+
+__device__ __forceinline__ void load_matrix_sync(
+    fragment<matrix_b, 16, 16, 16, half, col_major>& frag, const half* smem_ptr,
+    unsigned ldm) {
+  asm volatile(
+      "wmma.load.b.sync.aligned.col.m16n16k16.f16 "
+      "{%0,%1,%2,%3,%4,%5,%6,%7}, [%8], %9;"
+      : "=r"(frag.x[0]), "=r"(frag.x[1]), "=r"(frag.x[2]), "=r"(frag.x[3]),
+        "=r"(frag.x[4]), "=r"(frag.x[5]), "=r"(frag.x[6]), "=r"(frag.x[7])
+      : "l"(smem_ptr), "r"(ldm)
+      : "memory");
+}
+
+__device__ __forceinline__ void load_matrix_sync(
+    fragment<accumulator, 16, 16, 16, float>& frag, const float* smem_ptr,
+    unsigned ldm, layout_t layout) {
+  if (layout == mem_row_major) {
     asm volatile(
-        "wmma.load.a.sync.aligned.row.m16n16k16.f16 "
+        "wmma.load.c.sync.aligned.row.m16n16k16.f32 "
         "{%0,%1,%2,%3,%4,%5,%6,%7}, [%8], %9;"
-        : "=r"(frag.x[0]), "=r"(frag.x[1]), "=r"(frag.x[2]), "=r"(frag.x[3]),
-          "=r"(frag.x[4]), "=r"(frag.x[5]), "=r"(frag.x[6]), "=r"(frag.x[7])
+        : "=f"(frag.x[0]), "=f"(frag.x[1]), "=f"(frag.x[2]), "=f"(frag.x[3]),
+          "=f"(frag.x[4]), "=f"(frag.x[5]), "=f"(frag.x[6]), "=f"(frag.x[7])
         : "l"(smem_ptr), "r"(ldm)
-        : "memory"
-    );
-}
-
-__device__ __forceinline__ void load_matrix_sync(
-    fragment<matrix_a, 16, 16, 16, half, col_major>& frag,
-    const half* smem_ptr, unsigned ldm) {
+        : "memory");
+  } else {
     asm volatile(
-        "wmma.load.a.sync.aligned.col.m16n16k16.f16 "
+        "wmma.load.c.sync.aligned.col.m16n16k16.f32 "
         "{%0,%1,%2,%3,%4,%5,%6,%7}, [%8], %9;"
-        : "=r"(frag.x[0]), "=r"(frag.x[1]), "=r"(frag.x[2]), "=r"(frag.x[3]),
-          "=r"(frag.x[4]), "=r"(frag.x[5]), "=r"(frag.x[6]), "=r"(frag.x[7])
+        : "=f"(frag.x[0]), "=f"(frag.x[1]), "=f"(frag.x[2]), "=f"(frag.x[3]),
+          "=f"(frag.x[4]), "=f"(frag.x[5]), "=f"(frag.x[6]), "=f"(frag.x[7])
         : "l"(smem_ptr), "r"(ldm)
-        : "memory"
-    );
+        : "memory");
+  }
 }
 
 __device__ __forceinline__ void load_matrix_sync(
-    fragment<matrix_b, 16, 16, 16, half, row_major>& frag,
-    const half* smem_ptr, unsigned ldm) {
+    fragment<matrix_a, 32, 8, 16, half, row_major>& frag, const half* smem_ptr,
+    unsigned ldm) {
+  asm volatile(
+      "wmma.load.a.sync.aligned.row.m32n8k16.f16 "
+      "{%0,%1,%2,%3,%4,%5,%6,%7}, [%8], %9;"
+      : "=r"(frag.x[0]), "=r"(frag.x[1]), "=r"(frag.x[2]), "=r"(frag.x[3]),
+        "=r"(frag.x[4]), "=r"(frag.x[5]), "=r"(frag.x[6]), "=r"(frag.x[7])
+      : "l"(smem_ptr), "r"(ldm)
+      : "memory");
+}
+
+__device__ __forceinline__ void load_matrix_sync(
+    fragment<matrix_a, 32, 8, 16, half, col_major>& frag, const half* smem_ptr,
+    unsigned ldm) {
+  asm volatile(
+      "wmma.load.a.sync.aligned.col.m32n8k16.f16 "
+      "{%0,%1,%2,%3,%4,%5,%6,%7}, [%8], %9;"
+      : "=r"(frag.x[0]), "=r"(frag.x[1]), "=r"(frag.x[2]), "=r"(frag.x[3]),
+        "=r"(frag.x[4]), "=r"(frag.x[5]), "=r"(frag.x[6]), "=r"(frag.x[7])
+      : "l"(smem_ptr), "r"(ldm)
+      : "memory");
+}
+
+__device__ __forceinline__ void load_matrix_sync(
+    fragment<matrix_b, 32, 8, 16, half, row_major>& frag, const half* smem_ptr,
+    unsigned ldm) {
+  asm volatile(
+      "wmma.load.b.sync.aligned.row.m32n8k16.f16 "
+      "{%0,%1,%2,%3,%4,%5,%6,%7}, [%8], %9;"
+      : "=r"(frag.x[0]), "=r"(frag.x[1]), "=r"(frag.x[2]), "=r"(frag.x[3]),
+        "=r"(frag.x[4]), "=r"(frag.x[5]), "=r"(frag.x[6]), "=r"(frag.x[7])
+      : "l"(smem_ptr), "r"(ldm)
+      : "memory");
+}
+
+__device__ __forceinline__ void load_matrix_sync(
+    fragment<matrix_b, 32, 8, 16, half, col_major>& frag, const half* smem_ptr,
+    unsigned ldm) {
+  asm volatile(
+      "wmma.load.b.sync.aligned.col.m32n8k16.f16 "
+      "{%0,%1,%2,%3,%4,%5,%6,%7}, [%8], %9;"
+      : "=r"(frag.x[0]), "=r"(frag.x[1]), "=r"(frag.x[2]), "=r"(frag.x[3]),
+        "=r"(frag.x[4]), "=r"(frag.x[5]), "=r"(frag.x[6]), "=r"(frag.x[7])
+      : "l"(smem_ptr), "r"(ldm)
+      : "memory");
+}
+
+__device__ __forceinline__ void load_matrix_sync(
+    fragment<accumulator, 32, 8, 16, float>& frag, const float* smem_ptr,
+    unsigned ldm, layout_t layout) {
+  if (layout == mem_row_major) {
     asm volatile(
-        "wmma.load.b.sync.aligned.row.m16n16k16.f16 "
+        "wmma.load.c.sync.aligned.row.m32n8k16.f32 "
         "{%0,%1,%2,%3,%4,%5,%6,%7}, [%8], %9;"
-        : "=r"(frag.x[0]), "=r"(frag.x[1]), "=r"(frag.x[2]), "=r"(frag.x[3]),
-          "=r"(frag.x[4]), "=r"(frag.x[5]), "=r"(frag.x[6]), "=r"(frag.x[7])
+        : "=f"(frag.x[0]), "=f"(frag.x[1]), "=f"(frag.x[2]), "=f"(frag.x[3]),
+          "=f"(frag.x[4]), "=f"(frag.x[5]), "=f"(frag.x[6]), "=f"(frag.x[7])
         : "l"(smem_ptr), "r"(ldm)
-        : "memory"
-    );
-}
-
-__device__ __forceinline__ void load_matrix_sync(
-    fragment<matrix_b, 16, 16, 16, half, col_major>& frag,
-    const half* smem_ptr, unsigned ldm) {
+        : "memory");
+  } else {
     asm volatile(
-        "wmma.load.b.sync.aligned.col.m16n16k16.f16 "
+        "wmma.load.c.sync.aligned.col.m32n8k16.f32 "
         "{%0,%1,%2,%3,%4,%5,%6,%7}, [%8], %9;"
-        : "=r"(frag.x[0]), "=r"(frag.x[1]), "=r"(frag.x[2]), "=r"(frag.x[3]),
-          "=r"(frag.x[4]), "=r"(frag.x[5]), "=r"(frag.x[6]), "=r"(frag.x[7])
+        : "=f"(frag.x[0]), "=f"(frag.x[1]), "=f"(frag.x[2]), "=f"(frag.x[3]),
+          "=f"(frag.x[4]), "=f"(frag.x[5]), "=f"(frag.x[6]), "=f"(frag.x[7])
         : "l"(smem_ptr), "r"(ldm)
-        : "memory"
-    );
+        : "memory");
+  }
 }
 
 __device__ __forceinline__ void load_matrix_sync(
-    fragment<accumulator, 16, 16, 16, float>& frag,
-    const float* smem_ptr, unsigned ldm, layout_t layout) {
-    if (layout == mem_row_major) {
-        asm volatile(
-            "wmma.load.c.sync.aligned.row.m16n16k16.f32 "
-            "{%0,%1,%2,%3,%4,%5,%6,%7}, [%8], %9;"
-            : "=f"(frag.x[0]), "=f"(frag.x[1]), "=f"(frag.x[2]), "=f"(frag.x[3]),
-              "=f"(frag.x[4]), "=f"(frag.x[5]), "=f"(frag.x[6]), "=f"(frag.x[7])
-            : "l"(smem_ptr), "r"(ldm)
-            : "memory"
-        );
-    } else {
-        asm volatile(
-            "wmma.load.c.sync.aligned.col.m16n16k16.f32 "
-            "{%0,%1,%2,%3,%4,%5,%6,%7}, [%8], %9;"
-            : "=f"(frag.x[0]), "=f"(frag.x[1]), "=f"(frag.x[2]), "=f"(frag.x[3]),
-              "=f"(frag.x[4]), "=f"(frag.x[5]), "=f"(frag.x[6]), "=f"(frag.x[7])
-            : "l"(smem_ptr), "r"(ldm)
-            : "memory"
-        );
-    }
+    fragment<matrix_a, 8, 32, 16, half, row_major>& frag, const half* smem_ptr,
+    unsigned ldm) {
+  asm volatile(
+      "wmma.load.a.sync.aligned.row.m8n32k16.f16 "
+      "{%0,%1,%2,%3,%4,%5,%6,%7}, [%8], %9;"
+      : "=r"(frag.x[0]), "=r"(frag.x[1]), "=r"(frag.x[2]), "=r"(frag.x[3]),
+        "=r"(frag.x[4]), "=r"(frag.x[5]), "=r"(frag.x[6]), "=r"(frag.x[7])
+      : "l"(smem_ptr), "r"(ldm)
+      : "memory");
 }
 
 __device__ __forceinline__ void load_matrix_sync(
-    fragment<matrix_a, 32, 8, 16, half, row_major>& frag,
-    const half* smem_ptr, unsigned ldm) {
+    fragment<matrix_a, 8, 32, 16, half, col_major>& frag, const half* smem_ptr,
+    unsigned ldm) {
+  asm volatile(
+      "wmma.load.a.sync.aligned.col.m8n32k16.f16 "
+      "{%0,%1,%2,%3,%4,%5,%6,%7}, [%8], %9;"
+      : "=r"(frag.x[0]), "=r"(frag.x[1]), "=r"(frag.x[2]), "=r"(frag.x[3]),
+        "=r"(frag.x[4]), "=r"(frag.x[5]), "=r"(frag.x[6]), "=r"(frag.x[7])
+      : "l"(smem_ptr), "r"(ldm)
+      : "memory");
+}
+
+__device__ __forceinline__ void load_matrix_sync(
+    fragment<matrix_b, 8, 32, 16, half, row_major>& frag, const half* smem_ptr,
+    unsigned ldm) {
+  asm volatile(
+      "wmma.load.b.sync.aligned.row.m8n32k16.f16 "
+      "{%0,%1,%2,%3,%4,%5,%6,%7}, [%8], %9;"
+      : "=r"(frag.x[0]), "=r"(frag.x[1]), "=r"(frag.x[2]), "=r"(frag.x[3]),
+        "=r"(frag.x[4]), "=r"(frag.x[5]), "=r"(frag.x[6]), "=r"(frag.x[7])
+      : "l"(smem_ptr), "r"(ldm)
+      : "memory");
+}
+
+__device__ __forceinline__ void load_matrix_sync(
+    fragment<matrix_b, 8, 32, 16, half, col_major>& frag, const half* smem_ptr,
+    unsigned ldm) {
+  asm volatile(
+      "wmma.load.b.sync.aligned.col.m8n32k16.f16 "
+      "{%0,%1,%2,%3,%4,%5,%6,%7}, [%8], %9;"
+      : "=r"(frag.x[0]), "=r"(frag.x[1]), "=r"(frag.x[2]), "=r"(frag.x[3]),
+        "=r"(frag.x[4]), "=r"(frag.x[5]), "=r"(frag.x[6]), "=r"(frag.x[7])
+      : "l"(smem_ptr), "r"(ldm)
+      : "memory");
+}
+
+__device__ __forceinline__ void load_matrix_sync(
+    fragment<accumulator, 8, 32, 16, float>& frag, const float* smem_ptr,
+    unsigned ldm, layout_t layout) {
+  if (layout == mem_row_major) {
     asm volatile(
-        "wmma.load.a.sync.aligned.row.m32n8k16.f16 "
+        "wmma.load.c.sync.aligned.row.m8n32k16.f32 "
         "{%0,%1,%2,%3,%4,%5,%6,%7}, [%8], %9;"
-        : "=r"(frag.x[0]), "=r"(frag.x[1]), "=r"(frag.x[2]), "=r"(frag.x[3]),
-          "=r"(frag.x[4]), "=r"(frag.x[5]), "=r"(frag.x[6]), "=r"(frag.x[7])
+        : "=f"(frag.x[0]), "=f"(frag.x[1]), "=f"(frag.x[2]), "=f"(frag.x[3]),
+          "=f"(frag.x[4]), "=f"(frag.x[5]), "=f"(frag.x[6]), "=f"(frag.x[7])
         : "l"(smem_ptr), "r"(ldm)
-        : "memory"
-    );
-}
-
-__device__ __forceinline__ void load_matrix_sync(
-    fragment<matrix_a, 32, 8, 16, half, col_major>& frag,
-    const half* smem_ptr, unsigned ldm) {
+        : "memory");
+  } else {
     asm volatile(
-        "wmma.load.a.sync.aligned.col.m32n8k16.f16 "
+        "wmma.load.c.sync.aligned.col.m8n32k16.f32 "
         "{%0,%1,%2,%3,%4,%5,%6,%7}, [%8], %9;"
-        : "=r"(frag.x[0]), "=r"(frag.x[1]), "=r"(frag.x[2]), "=r"(frag.x[3]),
-          "=r"(frag.x[4]), "=r"(frag.x[5]), "=r"(frag.x[6]), "=r"(frag.x[7])
+        : "=f"(frag.x[0]), "=f"(frag.x[1]), "=f"(frag.x[2]), "=f"(frag.x[3]),
+          "=f"(frag.x[4]), "=f"(frag.x[5]), "=f"(frag.x[6]), "=f"(frag.x[7])
         : "l"(smem_ptr), "r"(ldm)
-        : "memory"
-    );
-}
-
-__device__ __forceinline__ void load_matrix_sync(
-    fragment<matrix_b, 32, 8, 16, half, row_major>& frag,
-    const half* smem_ptr, unsigned ldm) {
-    asm volatile(
-        "wmma.load.b.sync.aligned.row.m32n8k16.f16 "
-        "{%0,%1,%2,%3,%4,%5,%6,%7}, [%8], %9;"
-        : "=r"(frag.x[0]), "=r"(frag.x[1]), "=r"(frag.x[2]), "=r"(frag.x[3]),
-          "=r"(frag.x[4]), "=r"(frag.x[5]), "=r"(frag.x[6]), "=r"(frag.x[7])
-        : "l"(smem_ptr), "r"(ldm)
-        : "memory"
-    );
-}
-
-__device__ __forceinline__ void load_matrix_sync(
-    fragment<matrix_b, 32, 8, 16, half, col_major>& frag,
-    const half* smem_ptr, unsigned ldm) {
-    asm volatile(
-        "wmma.load.b.sync.aligned.col.m32n8k16.f16 "
-        "{%0,%1,%2,%3,%4,%5,%6,%7}, [%8], %9;"
-        : "=r"(frag.x[0]), "=r"(frag.x[1]), "=r"(frag.x[2]), "=r"(frag.x[3]),
-          "=r"(frag.x[4]), "=r"(frag.x[5]), "=r"(frag.x[6]), "=r"(frag.x[7])
-        : "l"(smem_ptr), "r"(ldm)
-        : "memory"
-    );
-}
-
-__device__ __forceinline__ void load_matrix_sync(
-    fragment<accumulator, 32, 8, 16, float>& frag,
-    const float* smem_ptr, unsigned ldm, layout_t layout) {
-    if (layout == mem_row_major) {
-        asm volatile(
-            "wmma.load.c.sync.aligned.row.m32n8k16.f32 "
-            "{%0,%1,%2,%3,%4,%5,%6,%7}, [%8], %9;"
-            : "=f"(frag.x[0]), "=f"(frag.x[1]), "=f"(frag.x[2]), "=f"(frag.x[3]),
-              "=f"(frag.x[4]), "=f"(frag.x[5]), "=f"(frag.x[6]), "=f"(frag.x[7])
-            : "l"(smem_ptr), "r"(ldm)
-            : "memory"
-        );
-    } else {
-        asm volatile(
-            "wmma.load.c.sync.aligned.col.m32n8k16.f32 "
-            "{%0,%1,%2,%3,%4,%5,%6,%7}, [%8], %9;"
-            : "=f"(frag.x[0]), "=f"(frag.x[1]), "=f"(frag.x[2]), "=f"(frag.x[3]),
-              "=f"(frag.x[4]), "=f"(frag.x[5]), "=f"(frag.x[6]), "=f"(frag.x[7])
-            : "l"(smem_ptr), "r"(ldm)
-            : "memory"
-        );
-    }
-}
-
-__device__ __forceinline__ void load_matrix_sync(
-    fragment<matrix_a, 8, 32, 16, half, row_major>& frag,
-    const half* smem_ptr, unsigned ldm) {
-    asm volatile(
-        "wmma.load.a.sync.aligned.row.m8n32k16.f16 "
-        "{%0,%1,%2,%3,%4,%5,%6,%7}, [%8], %9;"
-        : "=r"(frag.x[0]), "=r"(frag.x[1]), "=r"(frag.x[2]), "=r"(frag.x[3]),
-          "=r"(frag.x[4]), "=r"(frag.x[5]), "=r"(frag.x[6]), "=r"(frag.x[7])
-        : "l"(smem_ptr), "r"(ldm)
-        : "memory"
-    );
-}
-
-__device__ __forceinline__ void load_matrix_sync(
-    fragment<matrix_a, 8, 32, 16, half, col_major>& frag,
-    const half* smem_ptr, unsigned ldm) {
-    asm volatile(
-        "wmma.load.a.sync.aligned.col.m8n32k16.f16 "
-        "{%0,%1,%2,%3,%4,%5,%6,%7}, [%8], %9;"
-        : "=r"(frag.x[0]), "=r"(frag.x[1]), "=r"(frag.x[2]), "=r"(frag.x[3]),
-          "=r"(frag.x[4]), "=r"(frag.x[5]), "=r"(frag.x[6]), "=r"(frag.x[7])
-        : "l"(smem_ptr), "r"(ldm)
-        : "memory"
-    );
-}
-
-__device__ __forceinline__ void load_matrix_sync(
-    fragment<matrix_b, 8, 32, 16, half, row_major>& frag,
-    const half* smem_ptr, unsigned ldm) {
-    asm volatile(
-        "wmma.load.b.sync.aligned.row.m8n32k16.f16 "
-        "{%0,%1,%2,%3,%4,%5,%6,%7}, [%8], %9;"
-        : "=r"(frag.x[0]), "=r"(frag.x[1]), "=r"(frag.x[2]), "=r"(frag.x[3]),
-          "=r"(frag.x[4]), "=r"(frag.x[5]), "=r"(frag.x[6]), "=r"(frag.x[7])
-        : "l"(smem_ptr), "r"(ldm)
-        : "memory"
-    );
-}
-
-__device__ __forceinline__ void load_matrix_sync(
-    fragment<matrix_b, 8, 32, 16, half, col_major>& frag,
-    const half* smem_ptr, unsigned ldm) {
-    asm volatile(
-        "wmma.load.b.sync.aligned.col.m8n32k16.f16 "
-        "{%0,%1,%2,%3,%4,%5,%6,%7}, [%8], %9;"
-        : "=r"(frag.x[0]), "=r"(frag.x[1]), "=r"(frag.x[2]), "=r"(frag.x[3]),
-          "=r"(frag.x[4]), "=r"(frag.x[5]), "=r"(frag.x[6]), "=r"(frag.x[7])
-        : "l"(smem_ptr), "r"(ldm)
-        : "memory"
-    );
-}
-
-__device__ __forceinline__ void load_matrix_sync(
-    fragment<accumulator, 8, 32, 16, float>& frag,
-    const float* smem_ptr, unsigned ldm, layout_t layout) {
-    if (layout == mem_row_major) {
-        asm volatile(
-            "wmma.load.c.sync.aligned.row.m8n32k16.f32 "
-            "{%0,%1,%2,%3,%4,%5,%6,%7}, [%8], %9;"
-            : "=f"(frag.x[0]), "=f"(frag.x[1]), "=f"(frag.x[2]), "=f"(frag.x[3]),
-              "=f"(frag.x[4]), "=f"(frag.x[5]), "=f"(frag.x[6]), "=f"(frag.x[7])
-            : "l"(smem_ptr), "r"(ldm)
-            : "memory"
-        );
-    } else {
-        asm volatile(
-            "wmma.load.c.sync.aligned.col.m8n32k16.f32 "
-            "{%0,%1,%2,%3,%4,%5,%6,%7}, [%8], %9;"
-            : "=f"(frag.x[0]), "=f"(frag.x[1]), "=f"(frag.x[2]), "=f"(frag.x[3]),
-              "=f"(frag.x[4]), "=f"(frag.x[5]), "=f"(frag.x[6]), "=f"(frag.x[7])
-            : "l"(smem_ptr), "r"(ldm)
-            : "memory"
-        );
-    }
+        : "memory");
+  }
 }
 
 __device__ __forceinline__ void store_matrix_sync(
-    float* smem_ptr,
-    const fragment<accumulator, 16, 16, 16, float>& frag,
+    float* smem_ptr, const fragment<accumulator, 16, 16, 16, float>& frag,
     unsigned ldm, layout_t layout) {
-    if (layout == mem_row_major) {
-        asm volatile(
-            "wmma.store.d.sync.aligned.row.m16n16k16.f32 "
-            "[%0], {%1,%2,%3,%4,%5,%6,%7,%8}, %9;"
-            :
-            : "l"(smem_ptr),
-              "f"(frag.x[0]), "f"(frag.x[1]), "f"(frag.x[2]), "f"(frag.x[3]),
-              "f"(frag.x[4]), "f"(frag.x[5]), "f"(frag.x[6]), "f"(frag.x[7]),
-              "r"(ldm)
-            : "memory"
-        );
-    } else {
-        asm volatile(
-            "wmma.store.d.sync.aligned.col.m16n16k16.f32 "
-            "[%0], {%1,%2,%3,%4,%5,%6,%7,%8}, %9;"
-            :
-            : "l"(smem_ptr),
-              "f"(frag.x[0]), "f"(frag.x[1]), "f"(frag.x[2]), "f"(frag.x[3]),
-              "f"(frag.x[4]), "f"(frag.x[5]), "f"(frag.x[6]), "f"(frag.x[7]),
-              "r"(ldm)
-            : "memory"
-        );
-    }
+  if (layout == mem_row_major) {
+    asm volatile(
+        "wmma.store.d.sync.aligned.row.m16n16k16.f32 "
+        "[%0], {%1,%2,%3,%4,%5,%6,%7,%8}, %9;"
+        :
+        : "l"(smem_ptr), "f"(frag.x[0]), "f"(frag.x[1]), "f"(frag.x[2]),
+          "f"(frag.x[3]), "f"(frag.x[4]), "f"(frag.x[5]), "f"(frag.x[6]),
+          "f"(frag.x[7]), "r"(ldm)
+        : "memory");
+  } else {
+    asm volatile(
+        "wmma.store.d.sync.aligned.col.m16n16k16.f32 "
+        "[%0], {%1,%2,%3,%4,%5,%6,%7,%8}, %9;"
+        :
+        : "l"(smem_ptr), "f"(frag.x[0]), "f"(frag.x[1]), "f"(frag.x[2]),
+          "f"(frag.x[3]), "f"(frag.x[4]), "f"(frag.x[5]), "f"(frag.x[6]),
+          "f"(frag.x[7]), "r"(ldm)
+        : "memory");
+  }
 }
 
 __device__ __forceinline__ void store_matrix_sync(
-    float* smem_ptr,
-    const fragment<accumulator, 32, 8, 16, float>& frag,
+    float* smem_ptr, const fragment<accumulator, 32, 8, 16, float>& frag,
     unsigned ldm, layout_t layout) {
-    if (layout == mem_row_major) {
-        asm volatile(
-            "wmma.store.d.sync.aligned.row.m32n8k16.f32 "
-            "[%0], {%1,%2,%3,%4,%5,%6,%7,%8}, %9;"
-            :
-            : "l"(smem_ptr),
-              "f"(frag.x[0]), "f"(frag.x[1]), "f"(frag.x[2]), "f"(frag.x[3]),
-              "f"(frag.x[4]), "f"(frag.x[5]), "f"(frag.x[6]), "f"(frag.x[7]),
-              "r"(ldm)
-            : "memory"
-        );
-    } else {
-        asm volatile(
-            "wmma.store.d.sync.aligned.col.m32n8k16.f32 "
-            "[%0], {%1,%2,%3,%4,%5,%6,%7,%8}, %9;"
-            :
-            : "l"(smem_ptr),
-              "f"(frag.x[0]), "f"(frag.x[1]), "f"(frag.x[2]), "f"(frag.x[3]),
-              "f"(frag.x[4]), "f"(frag.x[5]), "f"(frag.x[6]), "f"(frag.x[7]),
-              "r"(ldm)
-            : "memory"
-        );
-    }
+  if (layout == mem_row_major) {
+    asm volatile(
+        "wmma.store.d.sync.aligned.row.m32n8k16.f32 "
+        "[%0], {%1,%2,%3,%4,%5,%6,%7,%8}, %9;"
+        :
+        : "l"(smem_ptr), "f"(frag.x[0]), "f"(frag.x[1]), "f"(frag.x[2]),
+          "f"(frag.x[3]), "f"(frag.x[4]), "f"(frag.x[5]), "f"(frag.x[6]),
+          "f"(frag.x[7]), "r"(ldm)
+        : "memory");
+  } else {
+    asm volatile(
+        "wmma.store.d.sync.aligned.col.m32n8k16.f32 "
+        "[%0], {%1,%2,%3,%4,%5,%6,%7,%8}, %9;"
+        :
+        : "l"(smem_ptr), "f"(frag.x[0]), "f"(frag.x[1]), "f"(frag.x[2]),
+          "f"(frag.x[3]), "f"(frag.x[4]), "f"(frag.x[5]), "f"(frag.x[6]),
+          "f"(frag.x[7]), "r"(ldm)
+        : "memory");
+  }
 }
 
 __device__ __forceinline__ void store_matrix_sync(
-    float* smem_ptr,
-    const fragment<accumulator, 8, 32, 16, float>& frag,
+    float* smem_ptr, const fragment<accumulator, 8, 32, 16, float>& frag,
     unsigned ldm, layout_t layout) {
-    if (layout == mem_row_major) {
-        asm volatile(
-            "wmma.store.d.sync.aligned.row.m8n32k16.f32 "
-            "[%0], {%1,%2,%3,%4,%5,%6,%7,%8}, %9;"
-            :
-            : "l"(smem_ptr),
-              "f"(frag.x[0]), "f"(frag.x[1]), "f"(frag.x[2]), "f"(frag.x[3]),
-              "f"(frag.x[4]), "f"(frag.x[5]), "f"(frag.x[6]), "f"(frag.x[7]),
-              "r"(ldm)
-            : "memory"
-        );
-    } else {
-        asm volatile(
-            "wmma.store.d.sync.aligned.col.m8n32k16.f32 "
-            "[%0], {%1,%2,%3,%4,%5,%6,%7,%8}, %9;"
-            :
-            : "l"(smem_ptr),
-              "f"(frag.x[0]), "f"(frag.x[1]), "f"(frag.x[2]), "f"(frag.x[3]),
-              "f"(frag.x[4]), "f"(frag.x[5]), "f"(frag.x[6]), "f"(frag.x[7]),
-              "r"(ldm)
-            : "memory"
-        );
-    }
+  if (layout == mem_row_major) {
+    asm volatile(
+        "wmma.store.d.sync.aligned.row.m8n32k16.f32 "
+        "[%0], {%1,%2,%3,%4,%5,%6,%7,%8}, %9;"
+        :
+        : "l"(smem_ptr), "f"(frag.x[0]), "f"(frag.x[1]), "f"(frag.x[2]),
+          "f"(frag.x[3]), "f"(frag.x[4]), "f"(frag.x[5]), "f"(frag.x[6]),
+          "f"(frag.x[7]), "r"(ldm)
+        : "memory");
+  } else {
+    asm volatile(
+        "wmma.store.d.sync.aligned.col.m8n32k16.f32 "
+        "[%0], {%1,%2,%3,%4,%5,%6,%7,%8}, %9;"
+        :
+        : "l"(smem_ptr), "f"(frag.x[0]), "f"(frag.x[1]), "f"(frag.x[2]),
+          "f"(frag.x[3]), "f"(frag.x[4]), "f"(frag.x[5]), "f"(frag.x[6]),
+          "f"(frag.x[7]), "r"(ldm)
+        : "memory");
+  }
 }
 
-#define VOLTA_WMMA_MMA_F32(M, N, K, ALAY, BLAY) \
-__device__ __forceinline__ void mma_sync( \
-    fragment<accumulator, M, N, K, float>& d, \
-    const fragment<matrix_a, M, N, K, half, ALAY##_major>& a, \
-    const fragment<matrix_b, M, N, K, half, BLAY##_major>& b, \
-    const fragment<accumulator, M, N, K, float>& c) { \
-    asm volatile( \
-        "wmma.mma.sync.aligned." #ALAY "." #BLAY ".m" #M "n" #N "k" #K ".f32.f32 " \
-        "{%0,%1,%2,%3,%4,%5,%6,%7}, " \
-        "{%8,%9,%10,%11,%12,%13,%14,%15}, " \
-        "{%16,%17,%18,%19,%20,%21,%22,%23}, " \
-        "{%24,%25,%26,%27,%28,%29,%30,%31};" \
-        : "=f"(d.x[0]), "=f"(d.x[1]), "=f"(d.x[2]), "=f"(d.x[3]), \
-          "=f"(d.x[4]), "=f"(d.x[5]), "=f"(d.x[6]), "=f"(d.x[7]) \
-        : "r"(a.x[0]), "r"(a.x[1]), "r"(a.x[2]), "r"(a.x[3]), \
-          "r"(a.x[4]), "r"(a.x[5]), "r"(a.x[6]), "r"(a.x[7]), \
-          "r"(b.x[0]), "r"(b.x[1]), "r"(b.x[2]), "r"(b.x[3]), \
-          "r"(b.x[4]), "r"(b.x[5]), "r"(b.x[6]), "r"(b.x[7]), \
-          "f"(c.x[0]), "f"(c.x[1]), "f"(c.x[2]), "f"(c.x[3]), \
-          "f"(c.x[4]), "f"(c.x[5]), "f"(c.x[6]), "f"(c.x[7]) \
-    ); \
-}
+#define VOLTA_WMMA_MMA_F32(M, N, K, ALAY, BLAY)                            \
+  __device__ __forceinline__ void mma_sync(                                \
+      fragment<accumulator, M, N, K, float>& d,                            \
+      const fragment<matrix_a, M, N, K, half, ALAY##_major>& a,            \
+      const fragment<matrix_b, M, N, K, half, BLAY##_major>& b,            \
+      const fragment<accumulator, M, N, K, float>& c) {                    \
+    asm volatile(                                                          \
+        "wmma.mma.sync.aligned." #ALAY "." #BLAY ".m" #M "n" #N "k" #K     \
+        ".f32.f32 "                                                        \
+        "{%0,%1,%2,%3,%4,%5,%6,%7}, "                                      \
+        "{%8,%9,%10,%11,%12,%13,%14,%15}, "                                \
+        "{%16,%17,%18,%19,%20,%21,%22,%23}, "                              \
+        "{%24,%25,%26,%27,%28,%29,%30,%31};"                               \
+        : "=f"(d.x[0]), "=f"(d.x[1]), "=f"(d.x[2]), "=f"(d.x[3]),          \
+          "=f"(d.x[4]), "=f"(d.x[5]), "=f"(d.x[6]), "=f"(d.x[7])           \
+        : "r"(a.x[0]), "r"(a.x[1]), "r"(a.x[2]), "r"(a.x[3]), "r"(a.x[4]), \
+          "r"(a.x[5]), "r"(a.x[6]), "r"(a.x[7]), "r"(b.x[0]), "r"(b.x[1]), \
+          "r"(b.x[2]), "r"(b.x[3]), "r"(b.x[4]), "r"(b.x[5]), "r"(b.x[6]), \
+          "r"(b.x[7]), "f"(c.x[0]), "f"(c.x[1]), "f"(c.x[2]), "f"(c.x[3]), \
+          "f"(c.x[4]), "f"(c.x[5]), "f"(c.x[6]), "f"(c.x[7]));             \
+  }
 
 VOLTA_WMMA_MMA_F32(16, 16, 16, row, col)
 VOLTA_WMMA_MMA_F32(16, 16, 16, row, row)
@@ -412,6 +436,6 @@ VOLTA_WMMA_MMA_F32(8, 32, 16, col, row)
 
 #undef VOLTA_WMMA_MMA_F32
 
-}
+}  // namespace volta
 
 #endif

--- a/flash-attention-v100/kernel/contiguous_to_paged.cu
+++ b/flash-attention-v100/kernel/contiguous_to_paged.cu
@@ -4,89 +4,72 @@
 #include <torch/extension.h>
 
 __global__ void contiguous_to_paged_kernel(
-    const __half* __restrict__ key,
-    const __half* __restrict__ value,
-    const int64_t* __restrict__ slot_mapping,
-          __half* __restrict__ key_cache,
-          __half* __restrict__ value_cache,
-    const int64_t key_stride,
-    const int64_t value_stride,
-    const int64_t block_stride,
-    const int64_t page_stride,
-    const int64_t head_stride,
-    const int block_size,
-    const int num_heads,
-    const int head_dim
-) {
+    const __half* __restrict__ key, const __half* __restrict__ value,
+    const int64_t* __restrict__ slot_mapping, __half* __restrict__ key_cache,
+    __half* __restrict__ value_cache, const int64_t key_stride,
+    const int64_t value_stride, const int64_t block_stride,
+    const int64_t page_stride, const int64_t head_stride, const int block_size,
+    const int num_heads, const int head_dim) {
+  const int token_idx = blockIdx.x;
+  const int64_t slot_idx = slot_mapping[token_idx];
 
-    const int token_idx = blockIdx.x;
-    const int64_t slot_idx = slot_mapping[token_idx];
+  if (slot_idx < 0) {
+    return;
+  }
 
-    if (slot_idx < 0) {
-        return;
+  const int64_t block_idx = slot_idx / block_size;
+  const int64_t block_offset = slot_idx % block_size;
+
+  const int tid = threadIdx.x;
+  const int num_threads = blockDim.x;
+
+  const __half* __restrict__ key_src = key + token_idx * key_stride;
+  const __half* __restrict__ value_src = value + token_idx * value_stride;
+
+  __half* __restrict__ key_dst =
+      key_cache + block_idx * block_stride + block_offset * page_stride;
+  __half* __restrict__ value_dst =
+      value_cache + block_idx * block_stride + block_offset * page_stride;
+
+  for (int head_idx = 0; head_idx < num_heads; head_idx++) {
+    const __half* key_head_src = key_src + head_idx * head_dim;
+    const __half* value_head_src = value_src + head_idx * head_dim;
+    __half* key_head_dst = key_dst + head_idx * head_stride;
+    __half* value_head_dst = value_dst + head_idx * head_stride;
+
+    for (int elem_idx = tid; elem_idx < head_dim; elem_idx += num_threads) {
+      key_head_dst[elem_idx] = key_head_src[elem_idx];
+      value_head_dst[elem_idx] = value_head_src[elem_idx];
     }
-
-    const int64_t block_idx = slot_idx / block_size;
-    const int64_t block_offset = slot_idx % block_size;
-
-    const int tid = threadIdx.x;
-    const int num_threads = blockDim.x;
-
-    const __half* __restrict__ key_src = key + token_idx * key_stride;
-    const __half* __restrict__ value_src = value + token_idx * value_stride;
-
-    __half* __restrict__ key_dst = key_cache + block_idx * block_stride + block_offset * page_stride;
-    __half* __restrict__ value_dst = value_cache + block_idx * block_stride + block_offset * page_stride;
-
-    for (int head_idx = 0; head_idx < num_heads; head_idx++) {
-        const __half* key_head_src = key_src + head_idx * head_dim;
-        const __half* value_head_src = value_src + head_idx * head_dim;
-        __half* key_head_dst = key_dst + head_idx * head_stride;
-        __half* value_head_dst = value_dst + head_idx * head_stride;
-
-        for (int elem_idx = tid; elem_idx < head_dim; elem_idx += num_threads) {
-            key_head_dst[elem_idx] = key_head_src[elem_idx];
-            value_head_dst[elem_idx] = value_head_src[elem_idx];
-        }
-    }
+  }
 }
 
-void contiguous_to_paged(
-    torch::Tensor key,
-    torch::Tensor value,
-    torch::Tensor slot_mapping,
-    torch::Tensor key_cache,
-    torch::Tensor value_cache
-) {
-    const int num_tokens = slot_mapping.size(0);
-    const int num_heads = key.size(1);
-    const int head_dim = key.size(2);
-    const int block_size = key_cache.size(1);
+void contiguous_to_paged(torch::Tensor key, torch::Tensor value,
+                         torch::Tensor slot_mapping, torch::Tensor key_cache,
+                         torch::Tensor value_cache) {
+  const int num_tokens = slot_mapping.size(0);
+  const int num_heads = key.size(1);
+  const int head_dim = key.size(2);
+  const int block_size = key_cache.size(1);
 
-    const int64_t key_stride = key.stride(0);
-    const int64_t value_stride = value.stride(0);
-    const int64_t block_stride = key_cache.stride(0);
-    const int64_t page_stride = key_cache.stride(1);
-    const int64_t head_stride = key_cache.stride(2);
+  const int64_t key_stride = key.stride(0);
+  const int64_t value_stride = value.stride(0);
+  const int64_t block_stride = key_cache.stride(0);
+  const int64_t page_stride = key_cache.stride(1);
+  const int64_t head_stride = key_cache.stride(2);
 
-    const int threads = 256;
-    contiguous_to_paged_kernel<<<num_tokens, threads>>>(
-        reinterpret_cast<const __half*>(key.data_ptr<at::Half>()),
-        reinterpret_cast<const __half*>(value.data_ptr<at::Half>()),
-        slot_mapping.data_ptr<int64_t>(),
-        reinterpret_cast<__half*>(key_cache.data_ptr<at::Half>()),
-        reinterpret_cast<__half*>(value_cache.data_ptr<at::Half>()),
-        key_stride,
-        value_stride,
-        block_stride,
-        page_stride,
-        head_stride,
-        block_size,
-        num_heads,
-        head_dim
-    );
+  const int threads = 256;
+  contiguous_to_paged_kernel<<<num_tokens, threads>>>(
+      reinterpret_cast<const __half*>(key.data_ptr<at::Half>()),
+      reinterpret_cast<const __half*>(value.data_ptr<at::Half>()),
+      slot_mapping.data_ptr<int64_t>(),
+      reinterpret_cast<__half*>(key_cache.data_ptr<at::Half>()),
+      reinterpret_cast<__half*>(value_cache.data_ptr<at::Half>()), key_stride,
+      value_stride, block_stride, page_stride, head_stride, block_size,
+      num_heads, head_dim);
 }
 
 PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
-    m.def("contiguous_to_paged", &contiguous_to_paged, "Contiguous K/V to Paged KV Cache");
+  m.def("contiguous_to_paged", &contiguous_to_paged,
+        "Contiguous K/V to Paged KV Cache");
 }

--- a/flash-attention-v100/kernel/flash_decode_turboquant.cu
+++ b/flash-attention-v100/kernel/flash_decode_turboquant.cu
@@ -14,7 +14,7 @@ constexpr int kThreadsPerBlock = 256;
 constexpr int kWarpsPerBlock = kThreadsPerBlock / kWarpSize;
 
 __device__ __forceinline__ float warp_reduce_sum(float val) {
-  #pragma unroll
+#pragma unroll
   for (int offset = kWarpSize / 2; offset > 0; offset /= 2) {
     val += __shfl_down_sync(0xffffffff, val, offset);
   }
@@ -22,14 +22,14 @@ __device__ __forceinline__ float warp_reduce_sum(float val) {
 }
 
 __device__ __forceinline__ float warp_reduce_max(float val) {
-  #pragma unroll
+#pragma unroll
   for (int offset = kWarpSize / 2; offset > 0; offset /= 2) {
     val = fmaxf(val, __shfl_down_sync(0xffffffff, val, offset));
   }
   return val;
 }
 
-template<int NUM_WARPS>
+template <int NUM_WARPS>
 __device__ __forceinline__ float block_reduce_sum(float val) {
   __shared__ float shared[NUM_WARPS];
   __shared__ float result;
@@ -53,7 +53,7 @@ __device__ __forceinline__ float block_reduce_sum(float val) {
   return result;
 }
 
-template<int NUM_WARPS>
+template <int NUM_WARPS>
 __device__ __forceinline__ float block_reduce_max(float val) {
   __shared__ float shared[NUM_WARPS];
   __shared__ float result;
@@ -77,32 +77,28 @@ __device__ __forceinline__ float block_reduce_max(float val) {
   return result;
 }
 
-__device__ __forceinline__ uint16_t load_u16_le(
-    const uint8_t* __restrict__ data,
-    const int64_t byte_index) {
+__device__ __forceinline__ uint16_t
+load_u16_le(const uint8_t* __restrict__ data, const int64_t byte_index) {
   return static_cast<uint16_t>(data[byte_index]) |
          (static_cast<uint16_t>(data[byte_index + 1]) << 8);
 }
 
 __device__ __forceinline__ float load_f16_le_float(
-    const uint8_t* __restrict__ data,
-    const int64_t byte_index) {
+    const uint8_t* __restrict__ data, const int64_t byte_index) {
   return __half2float(__ushort_as_half(load_u16_le(data, byte_index)));
 }
 
-template<int D, int MSE_BITS, bool NORM_CORRECTION>
+template <int D, int MSE_BITS, bool NORM_CORRECTION>
 __device__ __forceinline__ float dot_qk_turboquant_mse(
-    const float* __restrict__ q_rot,
-    const uint8_t* __restrict__ kv_cache,
-    const int64_t slot_base,
-    const float* __restrict__ centroids,
+    const float* __restrict__ q_rot, const uint8_t* __restrict__ kv_cache,
+    const int64_t slot_base, const float* __restrict__ centroids,
     const int lane) {
   constexpr int kMseBytes = (D * MSE_BITS + 7) / 8;
   constexpr int kMseMask = (1 << MSE_BITS) - 1;
 
   float acc = 0.f;
   float centroid_norm_sq = 0.f;
-  #pragma unroll
+#pragma unroll
   for (int d = lane; d < D; d += kWarpSize) {
     const int bit_offset = d * MSE_BITS;
     const int byte_offset = bit_offset >> 3;
@@ -126,10 +122,9 @@ __device__ __forceinline__ float dot_qk_turboquant_mse(
   return acc * vec_norm;
 }
 
-template<int D, int MSE_BITS, int VQB>
+template <int D, int MSE_BITS, int VQB>
 __device__ __forceinline__ float load_turboquant_value_float(
-    const uint8_t* __restrict__ kv_cache,
-    const int64_t slot_base,
+    const uint8_t* __restrict__ kv_cache, const int64_t slot_base,
     const int d) {
   constexpr int kMseBytes = (D * MSE_BITS + 7) / 8;
   constexpr int kKeyPackedSize = kMseBytes + 2;
@@ -154,32 +149,20 @@ __device__ __forceinline__ float load_turboquant_value_float(
   return static_cast<float>(q_value) * scale + zero;
 }
 
-template<int D, int PARTITION_SIZE, int MSE_BITS, int VQB, bool NORM_CORRECTION>
+template <int D, int PARTITION_SIZE, int MSE_BITS, int VQB,
+          bool NORM_CORRECTION>
 __global__ void flash_attention_turboquant_decode_partition_kernel(
-    const float* __restrict__ q_rot,
-    const uint8_t* __restrict__ kv_cache,
-    float* __restrict__ tmp_out,
-    float* __restrict__ max_logits,
-    float* __restrict__ exp_sums,
-    const int* __restrict__ block_table,
-    const int* __restrict__ seq_lens,
-    const float* __restrict__ centroids,
-    const int batch_size,
-    const int max_num_blocks,
-    const int max_num_partitions,
-    const int num_heads_q,
-    const int num_heads_kv,
-    const int block_size,
-    const int64_t q_stride0,
-    const int64_t q_stride1,
-    const int64_t tmp_out_stride0,
-    const int64_t tmp_out_stride1,
-    const int64_t tmp_out_stride2,
-    const int64_t stats_stride0,
-    const int64_t stats_stride1,
-    const int64_t cache_block_stride,
-    const int64_t cache_token_stride,
-    const int64_t cache_head_stride,
+    const float* __restrict__ q_rot, const uint8_t* __restrict__ kv_cache,
+    float* __restrict__ tmp_out, float* __restrict__ max_logits,
+    float* __restrict__ exp_sums, const int* __restrict__ block_table,
+    const int* __restrict__ seq_lens, const float* __restrict__ centroids,
+    const int batch_size, const int max_num_blocks,
+    const int max_num_partitions, const int num_heads_q, const int num_heads_kv,
+    const int block_size, const int64_t q_stride0, const int64_t q_stride1,
+    const int64_t tmp_out_stride0, const int64_t tmp_out_stride1,
+    const int64_t tmp_out_stride2, const int64_t stats_stride0,
+    const int64_t stats_stride1, const int64_t cache_block_stride,
+    const int64_t cache_token_stride, const int64_t cache_head_stride,
     const float softmax_scale) {
   const int batch_idx = blockIdx.x;
   const int head_idx = blockIdx.y;
@@ -191,8 +174,7 @@ __global__ void flash_attention_turboquant_decode_partition_kernel(
   }
 
   const int seq_len = seq_lens[batch_idx];
-  const int split_len =
-      (seq_len + max_num_partitions - 1) / max_num_partitions;
+  const int split_len = (seq_len + max_num_partitions - 1) / max_num_partitions;
   const int start_token_idx = partition_idx * split_len;
   if (seq_len <= 0 || start_token_idx >= seq_len) {
     return;
@@ -268,8 +250,8 @@ __global__ void flash_attention_turboquant_decode_partition_kernel(
           static_cast<int64_t>(physical_block) * cache_block_stride +
           static_cast<int64_t>(block_offset) * cache_token_stride +
           static_cast<int64_t>(kv_head_idx) * cache_head_stride;
-      const float value = load_turboquant_value_float<D, MSE_BITS, VQB>(
-          kv_cache, slot_base, d);
+      const float value =
+          load_turboquant_value_float<D, MSE_BITS, VQB>(kv_cache, slot_base, d);
       acc = fmaf(scores_shared[i], value, acc);
     }
     tmp_out[tmp_out_base + d] = acc * inv_part_sum;
@@ -284,22 +266,15 @@ __global__ void flash_attention_turboquant_decode_partition_kernel(
   }
 }
 
-template<int D, int PARTITION_SIZE>
+template <int D, int PARTITION_SIZE>
 __global__ void flash_attention_turboquant_decode_reduce_kernel(
-    const float* __restrict__ tmp_out,
-    const float* __restrict__ max_logits,
-    const float* __restrict__ exp_sums,
-    const int* __restrict__ seq_lens,
-    __half* __restrict__ out,
-    const int batch_size,
-    const int max_num_partitions,
-    const int num_heads_q,
-    const int64_t tmp_out_stride0,
-    const int64_t tmp_out_stride1,
-    const int64_t tmp_out_stride2,
-    const int64_t stats_stride0,
-    const int64_t stats_stride1,
-    const int64_t out_stride0,
+    const float* __restrict__ tmp_out, const float* __restrict__ max_logits,
+    const float* __restrict__ exp_sums, const int* __restrict__ seq_lens,
+    __half* __restrict__ out, const int batch_size,
+    const int max_num_partitions, const int num_heads_q,
+    const int64_t tmp_out_stride0, const int64_t tmp_out_stride1,
+    const int64_t tmp_out_stride2, const int64_t stats_stride0,
+    const int64_t stats_stride1, const int64_t out_stride0,
     const int64_t out_stride1) {
   const int batch_idx = blockIdx.x;
   const int head_idx = blockIdx.y;
@@ -313,13 +288,11 @@ __global__ void flash_attention_turboquant_decode_reduce_kernel(
   if (seq_len <= 0) {
     for (int d = threadIdx.x; d < D; d += blockDim.x) {
       out[static_cast<int64_t>(batch_idx) * out_stride0 +
-          static_cast<int64_t>(head_idx) * out_stride1 + d] =
-          __float2half(0.f);
+          static_cast<int64_t>(head_idx) * out_stride1 + d] = __float2half(0.f);
     }
     return;
   }
-  const int split_len =
-      (seq_len + max_num_partitions - 1) / max_num_partitions;
+  const int split_len = (seq_len + max_num_partitions - 1) / max_num_partitions;
   const int num_partitions = (seq_len + split_len - 1) / split_len;
 
   extern __shared__ float shared_mem[];
@@ -342,7 +315,8 @@ __global__ void flash_attention_turboquant_decode_reduce_kernel(
     const int64_t stats_index =
         static_cast<int64_t>(batch_idx) * stats_stride0 +
         static_cast<int64_t>(head_idx) * stats_stride1 + i;
-    const float weight = exp_sums[stats_index] * __expf(max_shared[i] - global_max);
+    const float weight =
+        exp_sums[stats_index] * __expf(max_shared[i] - global_max);
     weight_shared[i] = weight;
     local_sum += weight;
   }
@@ -350,9 +324,8 @@ __global__ void flash_attention_turboquant_decode_reduce_kernel(
   const float inv_global_sum = global_sum > 0.f ? 1.f / global_sum : 0.f;
   __syncthreads();
 
-  const int64_t out_base =
-      static_cast<int64_t>(batch_idx) * out_stride0 +
-      static_cast<int64_t>(head_idx) * out_stride1;
+  const int64_t out_base = static_cast<int64_t>(batch_idx) * out_stride0 +
+                           static_cast<int64_t>(head_idx) * out_stride1;
   const int64_t tmp_out_base =
       static_cast<int64_t>(batch_idx) * tmp_out_stride0 +
       static_cast<int64_t>(head_idx) * tmp_out_stride1;
@@ -369,18 +342,13 @@ __global__ void flash_attention_turboquant_decode_reduce_kernel(
   }
 }
 
-template<int D, int PARTITION_SIZE, int MSE_BITS, int VQB, bool NORM_CORRECTION>
+template <int D, int PARTITION_SIZE, int MSE_BITS, int VQB,
+          bool NORM_CORRECTION>
 void launch_flash_attention_turboquant_decode_paged(
-    const at::Tensor& q_rot,
-    const at::Tensor& kv_cache,
-    at::Tensor& out,
-    const at::Tensor& block_table,
-    const at::Tensor& seq_lens,
-    at::Tensor& tmp_out,
-    at::Tensor& max_logits,
-    at::Tensor& exp_sums,
-    const at::Tensor& centroids,
-    const float softmax_scale,
+    const at::Tensor& q_rot, const at::Tensor& kv_cache, at::Tensor& out,
+    const at::Tensor& block_table, const at::Tensor& seq_lens,
+    at::Tensor& tmp_out, at::Tensor& max_logits, at::Tensor& exp_sums,
+    const at::Tensor& centroids, const float softmax_scale,
     cudaStream_t stream) {
   const int batch_size = q_rot.size(0);
   const int num_heads_q = q_rot.size(1);
@@ -398,68 +366,35 @@ void launch_flash_attention_turboquant_decode_paged(
   flash_attention_turboquant_decode_partition_kernel<
       D, PARTITION_SIZE, MSE_BITS, VQB, NORM_CORRECTION>
       <<<partition_grid, block, 0, stream>>>(
-      q_rot.data_ptr<float>(),
-      kv_cache.data_ptr<uint8_t>(),
-      tmp_out.data_ptr<float>(),
-      max_logits.data_ptr<float>(),
-      exp_sums.data_ptr<float>(),
-      block_table.data_ptr<int>(),
-      seq_lens.data_ptr<int>(),
-      centroids.data_ptr<float>(),
-      batch_size,
-      max_num_blocks,
-      max_num_partitions,
-      num_heads_q,
-      num_heads_kv,
-      block_size,
-      q_rot.stride(0),
-      q_rot.stride(1),
-      tmp_out.stride(0),
-      tmp_out.stride(1),
-      tmp_out.stride(2),
-      max_logits.stride(0),
-      max_logits.stride(1),
-      kv_cache.stride(0),
-      kv_cache.stride(1),
-      kv_cache.stride(2),
-      softmax_scale);
+          q_rot.data_ptr<float>(), kv_cache.data_ptr<uint8_t>(),
+          tmp_out.data_ptr<float>(), max_logits.data_ptr<float>(),
+          exp_sums.data_ptr<float>(), block_table.data_ptr<int>(),
+          seq_lens.data_ptr<int>(), centroids.data_ptr<float>(), batch_size,
+          max_num_blocks, max_num_partitions, num_heads_q, num_heads_kv,
+          block_size, q_rot.stride(0), q_rot.stride(1), tmp_out.stride(0),
+          tmp_out.stride(1), tmp_out.stride(2), max_logits.stride(0),
+          max_logits.stride(1), kv_cache.stride(0), kv_cache.stride(1),
+          kv_cache.stride(2), softmax_scale);
 
   flash_attention_turboquant_decode_reduce_kernel<D, PARTITION_SIZE>
       <<<reduce_grid, block, reduce_shared_mem, stream>>>(
-      tmp_out.data_ptr<float>(),
-      max_logits.data_ptr<float>(),
-      exp_sums.data_ptr<float>(),
-      seq_lens.data_ptr<int>(),
-      reinterpret_cast<__half*>(out.data_ptr<at::Half>()),
-      batch_size,
-      max_num_partitions,
-      num_heads_q,
-      tmp_out.stride(0),
-      tmp_out.stride(1),
-      tmp_out.stride(2),
-      max_logits.stride(0),
-      max_logits.stride(1),
-      out.stride(0),
-      out.stride(1));
+          tmp_out.data_ptr<float>(), max_logits.data_ptr<float>(),
+          exp_sums.data_ptr<float>(), seq_lens.data_ptr<int>(),
+          reinterpret_cast<__half*>(out.data_ptr<at::Half>()), batch_size,
+          max_num_partitions, num_heads_q, tmp_out.stride(0), tmp_out.stride(1),
+          tmp_out.stride(2), max_logits.stride(0), max_logits.stride(1),
+          out.stride(0), out.stride(1));
 }
 
 }  // namespace
 
 at::Tensor flash_attention_turboquant_decode_paged(
-    const at::Tensor& q_rot,
-    const at::Tensor& kv_cache,
-    std::optional<at::Tensor>& out_,
-    const at::Tensor& block_table,
-    const at::Tensor& seq_lens,
-    at::Tensor& tmp_out,
-    at::Tensor& max_logits,
-    at::Tensor& exp_sums,
-    const at::Tensor& centroids,
-    const float softmax_scale,
-    const int partition_size,
-    const int mse_bits,
-    const int value_quant_bits,
-    const bool norm_correction) {
+    const at::Tensor& q_rot, const at::Tensor& kv_cache,
+    std::optional<at::Tensor>& out_, const at::Tensor& block_table,
+    const at::Tensor& seq_lens, at::Tensor& tmp_out, at::Tensor& max_logits,
+    at::Tensor& exp_sums, const at::Tensor& centroids,
+    const float softmax_scale, const int partition_size, const int mse_bits,
+    const int value_quant_bits, const bool norm_correction) {
   TORCH_CHECK(q_rot.is_cuda(), "q_rot must be on CUDA");
   TORCH_CHECK(kv_cache.is_cuda(), "kv_cache must be on CUDA");
   TORCH_CHECK(block_table.is_cuda() && seq_lens.is_cuda(),
@@ -474,7 +409,8 @@ at::Tensor flash_attention_turboquant_decode_paged(
   TORCH_CHECK(tmp_out.dtype() == torch::kFloat32, "tmp_out must be fp32");
   TORCH_CHECK(max_logits.dtype() == torch::kFloat32, "max_logits must be fp32");
   TORCH_CHECK(exp_sums.dtype() == torch::kFloat32, "exp_sums must be fp32");
-  TORCH_CHECK(block_table.dtype() == torch::kInt32, "block_table must be int32");
+  TORCH_CHECK(block_table.dtype() == torch::kInt32,
+              "block_table must be int32");
   TORCH_CHECK(seq_lens.dtype() == torch::kInt32, "seq_lens must be int32");
   TORCH_CHECK(q_rot.dim() == 3, "q_rot must have shape [B, H, D]");
   TORCH_CHECK(kv_cache.dim() == 4,
@@ -483,7 +419,8 @@ at::Tensor flash_attention_turboquant_decode_paged(
               "block_table must have shape [B, max_num_blocks]");
   TORCH_CHECK(seq_lens.dim() == 1, "seq_lens must have shape [B]");
   TORCH_CHECK(tmp_out.dim() == 4, "tmp_out must have shape [B_cap, H, P, D]");
-  TORCH_CHECK(max_logits.dim() == 3, "max_logits must have shape [B_cap, H, P]");
+  TORCH_CHECK(max_logits.dim() == 3,
+              "max_logits must have shape [B_cap, H, P]");
   TORCH_CHECK(exp_sums.dim() == 3, "exp_sums must have shape [B_cap, H, P]");
   TORCH_CHECK(q_rot.stride(-1) == 1, "q_rot last dim must be contiguous");
   TORCH_CHECK(kv_cache.stride(-1) == 1, "kv_cache last dim must be contiguous");
@@ -500,23 +437,26 @@ at::Tensor flash_attention_turboquant_decode_paged(
               "seq_lens batch size must cover q_rot batch size");
   TORCH_CHECK(q_rot.size(0) <= tmp_out.size(0),
               "tmp_out batch size must cover q_rot batch size");
-  TORCH_CHECK(num_heads_q == tmp_out.size(1), "tmp_out head dimension mismatch");
+  TORCH_CHECK(num_heads_q == tmp_out.size(1),
+              "tmp_out head dimension mismatch");
   TORCH_CHECK(head_dim == tmp_out.size(3), "tmp_out head_dim mismatch");
   TORCH_CHECK(max_logits.size(0) == tmp_out.size(0) &&
                   max_logits.size(1) == tmp_out.size(1) &&
                   max_logits.size(2) == tmp_out.size(2),
               "max_logits shape mismatch");
-  TORCH_CHECK(exp_sums.sizes() == max_logits.sizes(), "exp_sums shape mismatch");
+  TORCH_CHECK(exp_sums.sizes() == max_logits.sizes(),
+              "exp_sums shape mismatch");
   TORCH_CHECK(num_heads_q % num_heads_kv == 0,
               "num_heads_q must be divisible by num_heads_kv");
-  TORCH_CHECK(partition_size == 256 || partition_size == 512 ||
-                  partition_size == 1024,
-              "Unsupported decode partition_size: ", partition_size);
   TORCH_CHECK(
-      block_table.size(1) * kv_cache.size(1) <= partition_size * tmp_out.size(2),
-      "TurboQuant decode workspace cannot cover block_table capacity");
-  TORCH_CHECK(mse_bits == 3 || mse_bits == 4,
-              "TurboQuant Flash-V100 decode currently supports 3/4-bit MSE keys");
+      partition_size == 256 || partition_size == 512 || partition_size == 1024,
+      "Unsupported decode partition_size: ", partition_size);
+  TORCH_CHECK(block_table.size(1) * kv_cache.size(1) <=
+                  partition_size * tmp_out.size(2),
+              "TurboQuant decode workspace cannot cover block_table capacity");
+  TORCH_CHECK(
+      mse_bits == 3 || mse_bits == 4,
+      "TurboQuant Flash-V100 decode currently supports 3/4-bit MSE keys");
   TORCH_CHECK(value_quant_bits == 3 || value_quant_bits == 4,
               "TurboQuant Flash-V100 decode currently supports 3/4-bit values");
   TORCH_CHECK(centroids.numel() >= (1 << mse_bits),
@@ -537,65 +477,67 @@ at::Tensor flash_attention_turboquant_decode_paged(
   auto stream = at::cuda::getCurrentCUDAStream().stream();
   c10::cuda::CUDAGuard device_guard(q_rot.device());
 
-  #define LAUNCH_TYPED(HDIM, PARTITION, MSE, VBITS, NC)                       \
-    launch_flash_attention_turboquant_decode_paged<HDIM, PARTITION, MSE,      \
-                                                    VBITS, NC>(               \
-        q_rot, kv_cache, out, block_table, seq_lens, tmp_out, max_logits,      \
-        exp_sums, centroids, softmax_scale, stream)
+#define LAUNCH_TYPED(HDIM, PARTITION, MSE, VBITS, NC)                         \
+  launch_flash_attention_turboquant_decode_paged<HDIM, PARTITION, MSE, VBITS, \
+                                                 NC>(                         \
+      q_rot, kv_cache, out, block_table, seq_lens, tmp_out, max_logits,       \
+      exp_sums, centroids, softmax_scale, stream)
 
-  #define LAUNCH_BY_NORM(HDIM, PARTITION, MSE, VBITS)                         \
-    do {                                                                      \
-      if (norm_correction) {                                                  \
-        LAUNCH_TYPED(HDIM, PARTITION, MSE, VBITS, true);                      \
-      } else {                                                                \
-        LAUNCH_TYPED(HDIM, PARTITION, MSE, VBITS, false);                     \
-      }                                                                       \
-    } while (0)
+#define LAUNCH_BY_NORM(HDIM, PARTITION, MSE, VBITS)     \
+  do {                                                  \
+    if (norm_correction) {                              \
+      LAUNCH_TYPED(HDIM, PARTITION, MSE, VBITS, true);  \
+    } else {                                            \
+      LAUNCH_TYPED(HDIM, PARTITION, MSE, VBITS, false); \
+    }                                                   \
+  } while (0)
 
-  #define LAUNCH_BY_VALUE(HDIM, PARTITION, MSE)                               \
-    do {                                                                      \
-      switch (value_quant_bits) {                                             \
-        case 3:                                                               \
-          LAUNCH_BY_NORM(HDIM, PARTITION, MSE, 3);                            \
-          break;                                                              \
-        case 4:                                                               \
-          LAUNCH_BY_NORM(HDIM, PARTITION, MSE, 4);                            \
-          break;                                                              \
-        default:                                                              \
-          TORCH_CHECK(false, "Unsupported value_quant_bits: ", value_quant_bits); \
-      }                                                                       \
-    } while (0)
+#define LAUNCH_BY_VALUE(HDIM, PARTITION, MSE)                            \
+  do {                                                                   \
+    switch (value_quant_bits) {                                          \
+      case 3:                                                            \
+        LAUNCH_BY_NORM(HDIM, PARTITION, MSE, 3);                         \
+        break;                                                           \
+      case 4:                                                            \
+        LAUNCH_BY_NORM(HDIM, PARTITION, MSE, 4);                         \
+        break;                                                           \
+      default:                                                           \
+        TORCH_CHECK(false,                                               \
+                    "Unsupported value_quant_bits: ", value_quant_bits); \
+    }                                                                    \
+  } while (0)
 
-  #define LAUNCH_BY_MSE(HDIM, PARTITION)                                      \
-    do {                                                                      \
-      switch (mse_bits) {                                                     \
-        case 3:                                                               \
-          LAUNCH_BY_VALUE(HDIM, PARTITION, 3);                                \
-          break;                                                              \
-        case 4:                                                               \
-          LAUNCH_BY_VALUE(HDIM, PARTITION, 4);                                \
-          break;                                                              \
-        default:                                                              \
-          TORCH_CHECK(false, "Unsupported mse_bits: ", mse_bits);            \
-      }                                                                       \
-    } while (0)
+#define LAUNCH_BY_MSE(HDIM, PARTITION)                          \
+  do {                                                          \
+    switch (mse_bits) {                                         \
+      case 3:                                                   \
+        LAUNCH_BY_VALUE(HDIM, PARTITION, 3);                    \
+        break;                                                  \
+      case 4:                                                   \
+        LAUNCH_BY_VALUE(HDIM, PARTITION, 4);                    \
+        break;                                                  \
+      default:                                                  \
+        TORCH_CHECK(false, "Unsupported mse_bits: ", mse_bits); \
+    }                                                           \
+  } while (0)
 
-  #define LAUNCH_BY_PARTITION(HDIM)                                           \
-    do {                                                                      \
-      switch (partition_size) {                                               \
-        case 256:                                                             \
-          LAUNCH_BY_MSE(HDIM, 256);                                           \
-          break;                                                              \
-        case 512:                                                             \
-          LAUNCH_BY_MSE(HDIM, 512);                                           \
-          break;                                                              \
-        case 1024:                                                            \
-          LAUNCH_BY_MSE(HDIM, 1024);                                          \
-          break;                                                              \
-        default:                                                              \
-          TORCH_CHECK(false, "Unsupported decode partition_size: ", partition_size); \
-      }                                                                       \
-    } while (0)
+#define LAUNCH_BY_PARTITION(HDIM)                                           \
+  do {                                                                      \
+    switch (partition_size) {                                               \
+      case 256:                                                             \
+        LAUNCH_BY_MSE(HDIM, 256);                                           \
+        break;                                                              \
+      case 512:                                                             \
+        LAUNCH_BY_MSE(HDIM, 512);                                           \
+        break;                                                              \
+      case 1024:                                                            \
+        LAUNCH_BY_MSE(HDIM, 1024);                                          \
+        break;                                                              \
+      default:                                                              \
+        TORCH_CHECK(false,                                                  \
+                    "Unsupported decode partition_size: ", partition_size); \
+    }                                                                       \
+  } while (0)
 
   switch (head_dim) {
     case 64:
@@ -617,14 +559,15 @@ at::Tensor flash_attention_turboquant_decode_paged(
       LAUNCH_BY_PARTITION(256);
       break;
     default:
-      TORCH_CHECK(false, "Unsupported head_dim for TurboQuant paged decode: ", head_dim);
+      TORCH_CHECK(false, "Unsupported head_dim for TurboQuant paged decode: ",
+                  head_dim);
   }
 
-  #undef LAUNCH_BY_PARTITION
-  #undef LAUNCH_BY_MSE
-  #undef LAUNCH_BY_VALUE
-  #undef LAUNCH_BY_NORM
-  #undef LAUNCH_TYPED
+#undef LAUNCH_BY_PARTITION
+#undef LAUNCH_BY_MSE
+#undef LAUNCH_BY_VALUE
+#undef LAUNCH_BY_NORM
+#undef LAUNCH_TYPED
 
   C10_CUDA_KERNEL_LAUNCH_CHECK();
   return out;

--- a/flash-attention-v100/kernel/flash_v100_traits.cuh
+++ b/flash-attention-v100/kernel/flash_v100_traits.cuh
@@ -3,137 +3,116 @@
 #include <cuda.h>
 #include <cuda_runtime.h>
 
-template<int D>
+template <int D>
 struct FlashV100Traits {
+  static constexpr int BLOCK_M_16 = 16;
+  static constexpr int BLOCK_N_16 = 512;
+  static constexpr int BLOCK_M_32 = 32;
+  static constexpr int BLOCK_N_32 = 256;
+  static constexpr int BLOCK_M_64 = 64;
+  static constexpr int BLOCK_N_64 = 128;
+  static constexpr int BLOCK_M_128 = 32;
+  static constexpr int BLOCK_N_128 = 176;
+  static constexpr int BLOCK_M_256 = 32;
+  static constexpr int BLOCK_N_256 = 64;
+  static constexpr int WARPS_PER_BLOCK = 16;
+  static constexpr int THREADS_PER_WARP = 32;
 
-    static constexpr int BLOCK_M_16  = 16;
-    static constexpr int BLOCK_N_16  = 512;
-    static constexpr int BLOCK_M_32  = 32;
-    static constexpr int BLOCK_N_32  = 256;
-    static constexpr int BLOCK_M_64  = 64;
-    static constexpr int BLOCK_N_64  = 128;
-    static constexpr int BLOCK_M_128 = 32;
-    static constexpr int BLOCK_N_128 = 176;
-    static constexpr int BLOCK_M_256 = 32;
-    static constexpr int BLOCK_N_256 = 64;
-    static constexpr int WARPS_PER_BLOCK = 16;
-    static constexpr int THREADS_PER_WARP = 32;
+  static constexpr int BLOCK_M = (D == 16)    ? BLOCK_M_16
+                                 : (D == 32)  ? BLOCK_M_32
+                                 : (D == 64)  ? BLOCK_M_64
+                                 : (D == 128) ? BLOCK_M_128
+                                              : BLOCK_M_256;
 
-    static constexpr int BLOCK_M = (D == 16) ? BLOCK_M_16 :
-                                   (D == 32) ? BLOCK_M_32 :
-                                   (D == 64) ? BLOCK_M_64 :
-                                   (D == 128) ? BLOCK_M_128 : BLOCK_M_256;
+  static constexpr int BLOCK_N = (D == 16)    ? BLOCK_N_16
+                                 : (D == 32)  ? BLOCK_N_32
+                                 : (D == 64)  ? BLOCK_N_64
+                                 : (D == 128) ? BLOCK_N_128
+                                              : BLOCK_N_256;
 
-    static constexpr int BLOCK_N = (D == 16) ? BLOCK_N_16 :
-                                   (D == 32) ? BLOCK_N_32 :
-                                   (D == 64) ? BLOCK_N_64 :
-                                   (D == 128) ? BLOCK_N_128 : BLOCK_N_256;
+  static constexpr int THREADS_PER_BLOCK = WARPS_PER_BLOCK * THREADS_PER_WARP;
+  static constexpr int THREADS_PER_ROW = THREADS_PER_BLOCK / BLOCK_M;
 
-    static constexpr int THREADS_PER_BLOCK = WARPS_PER_BLOCK * THREADS_PER_WARP;
-    static constexpr int THREADS_PER_ROW = THREADS_PER_BLOCK / BLOCK_M;
+  static constexpr int kBlockM = BLOCK_M;
+  static constexpr int kBlockN = BLOCK_N;
+  static constexpr int kHeadDim = D;
 
-    static constexpr int kBlockM = BLOCK_M;
-    static constexpr int kBlockN = BLOCK_N;
-    static constexpr int kHeadDim = D;
+  static constexpr int kGmemThreadsPerRow = THREADS_PER_ROW;
+  static constexpr int kGmemRowsPerThread = 1;
+  static constexpr int kGmemElemsPerLoad = 8;
 
-    static constexpr int kGmemThreadsPerRow = THREADS_PER_ROW;
-    static constexpr int kGmemRowsPerThread = 1;
-    static constexpr int kGmemElemsPerLoad = 8;
-
-    static constexpr int PER_UINT4 = 8;
-    static constexpr int d_stride_uint4 = (D + PER_UINT4 - 1) / PER_UINT4;
+  static constexpr int PER_UINT4 = 8;
+  static constexpr int d_stride_uint4 = (D + PER_UINT4 - 1) / PER_UINT4;
 };
 
-template<typename Traits>
-__device__ __forceinline__
-int64_t resolve_thread_kv_page_slice_offset(
-    const int tidx,
-    const int n_block,
-    const int page_block_size,
-    const int* __restrict__ block_table,
-    const int page_stride,
-    const int row_stride,
-    const int partial_block_size = -1
-) {
-    constexpr int kGmemThreadsPerRow = Traits::kGmemThreadsPerRow;
-    constexpr int kGmemRowsPerThread = Traits::kGmemRowsPerThread;
-    constexpr int kGmemElemsPerLoad = Traits::kGmemElemsPerLoad;
-    constexpr int kBlockN = Traits::kBlockN;
+template <typename Traits>
+__device__ __forceinline__ int64_t resolve_thread_kv_page_slice_offset(
+    const int tidx, const int n_block, const int page_block_size,
+    const int* __restrict__ block_table, const int page_stride,
+    const int row_stride, const int partial_block_size = -1) {
+  constexpr int kGmemThreadsPerRow = Traits::kGmemThreadsPerRow;
+  constexpr int kGmemRowsPerThread = Traits::kGmemRowsPerThread;
+  constexpr int kGmemElemsPerLoad = Traits::kGmemElemsPerLoad;
+  constexpr int kBlockN = Traits::kBlockN;
 
-    const int64_t col_offset = (tidx % kGmemThreadsPerRow) * kGmemElemsPerLoad;
-    int64_t block_row_offset = (tidx / kGmemThreadsPerRow) * kGmemRowsPerThread;
+  const int64_t col_offset = (tidx % kGmemThreadsPerRow) * kGmemElemsPerLoad;
+  int64_t block_row_offset = (tidx / kGmemThreadsPerRow) * kGmemRowsPerThread;
 
-    if (partial_block_size > 0) {
-        const int final_row_offset = max(partial_block_size - 1, 0);
-        const int final_thread_row_offset =
-            ((final_row_offset + kGmemRowsPerThread - 1) / kGmemRowsPerThread) * kGmemRowsPerThread;
-        block_row_offset = min(block_row_offset, (int64_t)final_thread_row_offset);
-    }
+  if (partial_block_size > 0) {
+    const int final_row_offset = max(partial_block_size - 1, 0);
+    const int final_thread_row_offset =
+        ((final_row_offset + kGmemRowsPerThread - 1) / kGmemRowsPerThread) *
+        kGmemRowsPerThread;
+    block_row_offset = min(block_row_offset, (int64_t)final_thread_row_offset);
+  }
 
-    const int64_t global_row_offset = block_row_offset + n_block * kBlockN;
+  const int64_t global_row_offset = block_row_offset + n_block * kBlockN;
 
-    const int64_t page_offset = global_row_offset % page_block_size;
-    const int64_t virtual_page_idx = global_row_offset / page_block_size;
+  const int64_t page_offset = global_row_offset % page_block_size;
+  const int64_t virtual_page_idx = global_row_offset / page_block_size;
 
-    const int64_t physical_offset =
-        ((int64_t)block_table[virtual_page_idx]) * ((int64_t)page_stride)
-        + page_offset * ((int64_t)row_stride)
-        + col_offset;
+  const int64_t physical_offset =
+      ((int64_t)block_table[virtual_page_idx]) * ((int64_t)page_stride) +
+      page_offset * ((int64_t)row_stride) + col_offset;
 
-    return physical_offset;
+  return physical_offset;
 }
 
-template<typename Traits>
-__device__ __forceinline__
-void load_kv_tile_paged(
-    const __half* __restrict__ kv_cache,
-    const int* __restrict__ block_table,
-    const int start_token_idx,
-    const int num_tokens,
-    const int n_block,
-    const int page_block_size,
-    const int page_stride,
-    const int row_stride,
-    __half* smem_dst,
-    const int smem_stride,
-    const int tid,
-    const int num_threads,
-    const int partial_block_size = -1
-) {
-    constexpr int PER_UINT4 = Traits::PER_UINT4;
-    constexpr int d_stride_uint4 = Traits::d_stride_uint4;
-    constexpr int kBlockN = Traits::kBlockN;
+template <typename Traits>
+__device__ __forceinline__ void load_kv_tile_paged(
+    const __half* __restrict__ kv_cache, const int* __restrict__ block_table,
+    const int start_token_idx, const int num_tokens, const int n_block,
+    const int page_block_size, const int page_stride, const int row_stride,
+    __half* smem_dst, const int smem_stride, const int tid,
+    const int num_threads, const int partial_block_size = -1) {
+  constexpr int PER_UINT4 = Traits::PER_UINT4;
+  constexpr int d_stride_uint4 = Traits::d_stride_uint4;
+  constexpr int kBlockN = Traits::kBlockN;
 
-    const uint4* kv_vec = reinterpret_cast<const uint4*>(kv_cache);
-    uint4* smem_vec = reinterpret_cast<uint4*>(smem_dst);
-    const int smem_stride_uint4 = (smem_stride + PER_UINT4 - 1) / PER_UINT4;
+  const uint4* kv_vec = reinterpret_cast<const uint4*>(kv_cache);
+  uint4* smem_vec = reinterpret_cast<uint4*>(smem_dst);
+  const int smem_stride_uint4 = (smem_stride + PER_UINT4 - 1) / PER_UINT4;
 
-    #pragma unroll 2
-    for (int idx = tid; idx < (num_tokens * d_stride_uint4); idx += num_threads) {
-        const int token_offset = idx / d_stride_uint4;
-        const int vec_col = idx % d_stride_uint4;
+#pragma unroll 2
+  for (int idx = tid; idx < (num_tokens * d_stride_uint4); idx += num_threads) {
+    const int token_offset = idx / d_stride_uint4;
+    const int vec_col = idx % d_stride_uint4;
 
-        uint4 kv_val = make_uint4(0, 0, 0, 0);
+    uint4 kv_val = make_uint4(0, 0, 0, 0);
 
-        if (token_offset < num_tokens && vec_col < d_stride_uint4) {
+    if (token_offset < num_tokens && vec_col < d_stride_uint4) {
+      const int global_token_idx = start_token_idx + token_offset;
 
-            const int global_token_idx = start_token_idx + token_offset;
+      const int64_t physical_offset_halves =
+          resolve_thread_kv_page_slice_offset<Traits>(
+              tid, n_block, page_block_size, block_table, page_stride,
+              row_stride, partial_block_size);
 
-            const int64_t physical_offset_halfs = resolve_thread_kv_page_slice_offset<Traits>(
-                tid,
-                n_block,
-                page_block_size,
-                block_table,
-                page_stride,
-                row_stride,
-                partial_block_size
-            );
+      const int64_t physical_offset_uint4 = physical_offset_halves / PER_UINT4;
 
-            const int64_t physical_offset_uint4 = physical_offset_halfs / PER_UINT4;
-
-            kv_val = __ldg(&kv_vec[physical_offset_uint4 + vec_col]);
-        }
-
-        smem_vec[token_offset * smem_stride_uint4 + vec_col] = kv_val;
+      kv_val = __ldg(&kv_vec[physical_offset_uint4 + vec_col]);
     }
+
+    smem_vec[token_offset * smem_stride_uint4 + vec_col] = kv_val;
+  }
 }

--- a/flash-attention-v100/kernel/fp8_kv_utils.cuh
+++ b/flash-attention-v100/kernel/fp8_kv_utils.cuh
@@ -14,9 +14,7 @@ __device__ __forceinline__ float quiet_nan_f() {
   return __int_as_float(0x7fffffff);
 }
 
-__device__ __forceinline__ float inf_f() {
-  return __int_as_float(0x7f800000);
-}
+__device__ __forceinline__ float inf_f() { return __int_as_float(0x7f800000); }
 
 __device__ __forceinline__ float exp2_int(const int exponent) {
   return __uint_as_float(static_cast<uint32_t>(exponent + 127) << 23);
@@ -38,8 +36,7 @@ __device__ __forceinline__ float fp8_e4m3fn_to_float(uint8_t raw) {
     if (exp == 0x0f && mant == 0x07) {
       return quiet_nan_f();
     }
-    value = (1.0f + static_cast<float>(mant) * 0.125f) *
-            exp2_int(exp - 7);
+    value = (1.0f + static_cast<float>(mant) * 0.125f) * exp2_int(exp - 7);
   }
   return sign ? -value : value;
 }
@@ -52,9 +49,8 @@ __device__ __forceinline__ __half fp8_e5m2_to_half(uint8_t raw) {
 }
 
 __device__ __forceinline__ __half2 fp8_e5m2_pair_to_half2(uint16_t raw_pair) {
-  const uint32_t half2_bits =
-      (static_cast<uint32_t>(raw_pair & 0x00ffu) << 8) |
-      (static_cast<uint32_t>(raw_pair & 0xff00u) << 16);
+  const uint32_t half2_bits = (static_cast<uint32_t>(raw_pair & 0x00ffu) << 8) |
+                              (static_cast<uint32_t>(raw_pair & 0xff00u) << 16);
   union {
     uint32_t u;
     __half2 h2;
@@ -64,8 +60,7 @@ __device__ __forceinline__ __half2 fp8_e5m2_pair_to_half2(uint16_t raw_pair) {
 }
 
 __device__ __forceinline__ __half2 load_fp8_e5m2_half2_unscaled(
-    const void* __restrict__ cache,
-    const int64_t byte_index) {
+    const void* __restrict__ cache, const int64_t byte_index) {
   const uint16_t* cache_u16 = reinterpret_cast<const uint16_t*>(cache);
   return fp8_e5m2_pair_to_half2(cache_u16[byte_index >> 1]);
 }
@@ -74,36 +69,31 @@ __device__ __forceinline__ float fp8_e5m2_to_float(uint8_t raw) {
   return __half2float(fp8_e5m2_to_half(raw));
 }
 
-template<int KV_DTYPE>
+template <int KV_DTYPE>
 __device__ __forceinline__ float load_kv_cache_float_unscaled(
-    const void* __restrict__ cache,
-    const int64_t index) {
+    const void* __restrict__ cache, const int64_t index) {
   if constexpr (KV_DTYPE == KV_CACHE_DTYPE_FP16) {
     const __half* cache_h = reinterpret_cast<const __half*>(cache);
     return __half2float(cache_h[index]);
   } else {
     const uint8_t* cache_u8 = reinterpret_cast<const uint8_t*>(cache);
     const uint8_t raw = cache_u8[index];
-    const float value =
-        KV_DTYPE == KV_CACHE_DTYPE_FP8_E4M3 ? fp8_e4m3fn_to_float(raw)
-                                            : fp8_e5m2_to_float(raw);
+    const float value = KV_DTYPE == KV_CACHE_DTYPE_FP8_E4M3
+                            ? fp8_e4m3fn_to_float(raw)
+                            : fp8_e5m2_to_float(raw);
     return value;
   }
 }
 
-template<int KV_DTYPE>
+template <int KV_DTYPE>
 __device__ __forceinline__ float load_kv_cache_float(
-    const void* __restrict__ cache,
-    const int64_t index,
-    const float scale) {
+    const void* __restrict__ cache, const int64_t index, const float scale) {
   return load_kv_cache_float_unscaled<KV_DTYPE>(cache, index) * scale;
 }
 
-template<int KV_DTYPE>
+template <int KV_DTYPE>
 __device__ __forceinline__ __half load_kv_cache_half(
-    const void* __restrict__ cache,
-    const int64_t index,
-    const float scale) {
+    const void* __restrict__ cache, const int64_t index, const float scale) {
   if constexpr (KV_DTYPE == KV_CACHE_DTYPE_FP8_E5M2) {
     const uint8_t* cache_u8 = reinterpret_cast<const uint8_t*>(cache);
     return __float2half_rn(__half2float(fp8_e5m2_to_half(cache_u8[index])) *

--- a/flash-attention-v100/kernel/fused_mha_api.cpp
+++ b/flash-attention-v100/kernel/fused_mha_api.cpp
@@ -9,59 +9,39 @@
 namespace py = pybind11;
 
 PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
-    m.doc() = "FlashAttention-2 implementation optimized for Volta";
-    m.def("fwd", &flash_attention_forward, "FlashAttention-2 Forward Pass (Volta)");
-    m.def(
-        "qk_scores_fwd",
-        &flash_attention_qk_scores,
+  m.doc() = "FlashAttention-2 implementation optimized for Volta";
+  m.def("fwd", &flash_attention_forward,
+        "FlashAttention-2 Forward Pass (Volta)");
+  m.def("qk_scores_fwd", &flash_attention_qk_scores,
         "Debug FlashAttention QK score dump before softmax (Volta)");
-    m.def("bwd", &flash_attention_backward, "FlashAttention-2 Backward Pass (Volta)");
-    m.def(
-        "decode_paged_fwd",
-        &flash_attention_decode_paged,
+  m.def("bwd", &flash_attention_backward,
+        "FlashAttention-2 Backward Pass (Volta)");
+  m.def("decode_paged_fwd", &flash_attention_decode_paged,
         "FlashAttention decode over paged KV cache (Volta)");
-    m.def(
-        "decode_paged_xqa_fwd",
-        &flash_attention_decode_paged_xqa,
+  m.def("decode_paged_xqa_fwd", &flash_attention_decode_paged_xqa,
         "FlashAttention XQA decode over paged KV cache (Volta)");
-    m.def(
-        "decode_paged_xqa_staged_fwd",
-        &flash_attention_decode_paged_xqa_staged,
+  m.def("decode_paged_xqa_staged_fwd", &flash_attention_decode_paged_xqa_staged,
         "Staged FlashAttention XQA decode over paged KV cache (Volta)");
-    m.def(
-        "decode_paged_wmma_fwd",
-        &flash_attention_decode_paged_wmma,
-        "FlashAttention single-query decode through paged-prefill WMMA order (Volta)");
-    m.def(
-        "decode_qk_scores_fwd",
-        &flash_attention_decode_qk_scores,
+  m.def("decode_paged_wmma_fwd", &flash_attention_decode_paged_wmma,
+        "FlashAttention single-query decode through paged-prefill WMMA order "
+        "(Volta)");
+  m.def("decode_qk_scores_fwd", &flash_attention_decode_qk_scores,
         "Debug scalar paged decode QK score dump before softmax (Volta)");
-    m.def(
-        "decode_turboquant_paged_fwd",
-        &flash_attention_turboquant_decode_paged,
+  m.def("decode_turboquant_paged_fwd", &flash_attention_turboquant_decode_paged,
         "FlashAttention decode over TurboQuant paged KV cache (Volta)");
-    m.def(
-        "prefill_paged_fwd",
-        &flash_attention_prefill_paged,
+  m.def("prefill_paged_fwd", &flash_attention_prefill_paged,
         "FlashAttention prefill over paged KV cache (Volta)");
-    m.def(
-        "prefill_paged_d256_bm32_allp_pair_scratch_fwd",
+  m.def("prefill_paged_d256_bm32_allp_pair_scratch_fwd",
         &flash_attention_prefill_paged_d256_bm32_allp_pair_scratch,
         "Fixed causal D256 BM32 ALL_P pair-scratch paged prefill (SM70)");
-    m.def(
-        "prefill_paged_d256_bm32_allp_pair_scratch_splitkv3_fwd",
+  m.def("prefill_paged_d256_bm32_allp_pair_scratch_splitkv3_fwd",
         &flash_attention_prefill_paged_d256_bm32_allp_pair_scratch_splitkv3,
-        "Fixed causal D256 BM32 ALL_P pair-scratch three-way split-KV paged prefill (SM70)");
-    m.def(
-        "prefill_paged_bfla_fwd",
-        &flash_attention_prefill_paged_bfla,
+        "Fixed causal D256 BM32 ALL_P pair-scratch three-way split-KV paged "
+        "prefill (SM70)");
+  m.def("prefill_paged_bfla_fwd", &flash_attention_prefill_paged_bfla,
         "BFLA sparse FlashAttention prefill over paged KV cache (Volta)");
-    m.def(
-        "prefill_paged_splitkv_fwd",
-        &flash_attention_prefill_paged_splitkv,
+  m.def("prefill_paged_splitkv_fwd", &flash_attention_prefill_paged_splitkv,
         "FlashAttention split-KV prefill over paged KV cache (Volta)");
-    m.def(
-        "fp8_e5m2_paged_kv_to_fp16",
-        &flash_attention_fp8_e5m2_paged_kv_to_fp16,
+  m.def("fp8_e5m2_paged_kv_to_fp16", &flash_attention_fp8_e5m2_paged_kv_to_fp16,
         "Expand paged FP8 E5M2 K/V into a preallocated FP16 paged workspace");
 }

--- a/flash-attention-v100/kernel/fused_mha_backward.cu
+++ b/flash-attention-v100/kernel/fused_mha_backward.cu
@@ -14,1176 +14,1235 @@ using namespace nvcuda::wmma;
 #define WMMA_N 16
 #define WMMA_K 16
 
-#define MAX_THREADS_PER_WARP    32
-#define MAX_THREADS_PER_SM      2048
-#define MAX_THREAD_BLOCK_SIZE   1024
+#define MAX_THREADS_PER_WARP 32
+#define MAX_THREADS_PER_SM 2048
+#define MAX_THREAD_BLOCK_SIZE 1024
 #define MAX_THREAD_BLOCK_PER_SM 32
-#define MAX_WARPS_PER_SM        64
-#define MAX_SM_PER_GPU          80
-#define MAX_SMEM_PER_SM         98304
+#define MAX_WARPS_PER_SM 64
+#define MAX_SM_PER_GPU 80
+#define MAX_SMEM_PER_SM 98304
 
-#define WARP_ALLOC_GROUP        4
+#define WARP_ALLOC_GROUP 4
 
-#define MAX_REG_PER_UNIT        256
-#define MAX_REG_PER_THREAD      255
-#define MAX_REG_PER_BLOCK       65536
-#define MAX_REG_BUFFER          65536
+#define MAX_REG_PER_UNIT 256
+#define MAX_REG_PER_THREAD 255
+#define MAX_REG_PER_BLOCK 65536
+#define MAX_REG_BUFFER 65536
 
-#define BLOCK_M_16  16
-#define BLOCK_N_16  256
-#define WARPS_16    16
+#define BLOCK_M_16 16
+#define BLOCK_N_16 256
+#define WARPS_16 16
 
-#define BLOCK_M_32  32
-#define BLOCK_N_32  128
-#define WARPS_32    16
+#define BLOCK_M_32 32
+#define BLOCK_N_32 128
+#define WARPS_32 16
 
-#define BLOCK_M_64  64
-#define BLOCK_N_64  80
-#define WARPS_64    16
+#define BLOCK_M_64 64
+#define BLOCK_N_64 80
+#define WARPS_64 16
 
 #define BLOCK_M_128 32
 #define BLOCK_N_128 112
-#define WARPS_128   16
+#define WARPS_128 16
 
 #define BLOCK_M_256 32
 #define BLOCK_N_256 32
-#define WARPS_256   16
+#define WARPS_256 16
 
-#define BLOCK_KV_16  32
-#define BLOCK_Q_16   224
+#define BLOCK_KV_16 32
+#define BLOCK_Q_16 224
 #define WARPS_DKV_16 14
 
-#define BLOCK_KV_32  32
-#define BLOCK_Q_32   192
+#define BLOCK_KV_32 32
+#define BLOCK_Q_32 192
 #define WARPS_DKV_32 12
 
-#define BLOCK_KV_64  32
-#define BLOCK_Q_64   128
-#define WARPS_DKV_64  8
+#define BLOCK_KV_64 32
+#define BLOCK_Q_64 128
+#define WARPS_DKV_64 8
 
-#define BLOCK_KV_128  16
-#define BLOCK_Q_128   144
+#define BLOCK_KV_128 16
+#define BLOCK_Q_128 144
 #define WARPS_DKV_128 12
 
-#define BLOCK_KV_256  16
-#define BLOCK_Q_256   64
+#define BLOCK_KV_256 16
+#define BLOCK_Q_256 64
 #define WARPS_DKV_256 16
 
-template<int D>
+template <int D>
 struct dQKernelConfig {
-    static constexpr int BLOCK_M = (D == 16) ? BLOCK_M_16 : (D == 32) ? BLOCK_M_32 : (D == 64)  ? BLOCK_M_64 : (D == 128) ? BLOCK_M_128 : BLOCK_M_256;
-    static constexpr int BLOCK_N = (D == 16) ? BLOCK_N_16 : (D == 32) ? BLOCK_N_32 : (D == 64)  ? BLOCK_N_64 : (D == 128) ? BLOCK_N_128 : BLOCK_N_256;
-    static constexpr int WARPS_PER_BLOCK = (D == 16) ? WARPS_16 : (D == 32) ? WARPS_32 : (D == 64) ? WARPS_64 : (D == 128) ? WARPS_128 : WARPS_256;
+  static constexpr int BLOCK_M = (D == 16)    ? BLOCK_M_16
+                                 : (D == 32)  ? BLOCK_M_32
+                                 : (D == 64)  ? BLOCK_M_64
+                                 : (D == 128) ? BLOCK_M_128
+                                              : BLOCK_M_256;
+  static constexpr int BLOCK_N = (D == 16)    ? BLOCK_N_16
+                                 : (D == 32)  ? BLOCK_N_32
+                                 : (D == 64)  ? BLOCK_N_64
+                                 : (D == 128) ? BLOCK_N_128
+                                              : BLOCK_N_256;
+  static constexpr int WARPS_PER_BLOCK = (D == 16)    ? WARPS_16
+                                         : (D == 32)  ? WARPS_32
+                                         : (D == 64)  ? WARPS_64
+                                         : (D == 128) ? WARPS_128
+                                                      : WARPS_256;
 
-    static constexpr int THREADS_PER_BLOCK  = WARPS_PER_BLOCK * MAX_THREADS_PER_WARP;
-    static constexpr int THREADS_PER_ROW    = THREADS_PER_BLOCK / BLOCK_M;
-    static constexpr int PAD                = (8 - (D % 32) + 32) % 32;
-    static constexpr int Q_STRIDE           = D + PAD;
-    static constexpr int KV_STRIDE          = D + PAD;
-    static constexpr int S_STRIDE           = BLOCK_N + PAD;
-    static constexpr int PER_UINT4          = 8;
-    static constexpr int NUM_UINT4_Q_BLOCK  = BLOCK_M * ((D + PER_UINT4 - 1) / PER_UINT4);
-    static constexpr int NUM_UINT4_KV_BLOCK = BLOCK_N * ((D + PER_UINT4 - 1) / PER_UINT4);
+  static constexpr int THREADS_PER_BLOCK =
+      WARPS_PER_BLOCK * MAX_THREADS_PER_WARP;
+  static constexpr int THREADS_PER_ROW = THREADS_PER_BLOCK / BLOCK_M;
+  static constexpr int PAD = (8 - (D % 32) + 32) % 32;
+  static constexpr int Q_STRIDE = D + PAD;
+  static constexpr int KV_STRIDE = D + PAD;
+  static constexpr int S_STRIDE = BLOCK_N + PAD;
+  static constexpr int PER_UINT4 = 8;
+  static constexpr int NUM_UINT4_Q_BLOCK =
+      BLOCK_M * ((D + PER_UINT4 - 1) / PER_UINT4);
+  static constexpr int NUM_UINT4_KV_BLOCK =
+      BLOCK_N * ((D + PER_UINT4 - 1) / PER_UINT4);
 
-    struct alignas(128) SmemLayout {
-        union {
-            alignas(16) __half k     [BLOCK_N * KV_STRIDE];
-            alignas(16) __half v     [BLOCK_N * KV_STRIDE];
-        } reuse_kv;
-            alignas(16) __half dO    [BLOCK_M * Q_STRIDE];
-            alignas(16) __half q     [BLOCK_M * Q_STRIDE];
-            alignas(16) float  s     [BLOCK_M * S_STRIDE];
-        union {
-            alignas(16) float  dOV   [BLOCK_M * S_STRIDE];
-            alignas(16) __half dS    [BLOCK_M * S_STRIDE];
-        } reuse_sdOVS;
-            alignas(16) float row_dot[BLOCK_M];
-            alignas(16) float lse    [BLOCK_M];
-            alignas(16) float dQ     [BLOCK_M * Q_STRIDE];
-    };
+  struct alignas(128) SmemLayout {
+    union {
+      alignas(16) __half k[BLOCK_N * KV_STRIDE];
+      alignas(16) __half v[BLOCK_N * KV_STRIDE];
+    } reuse_kv;
+    alignas(16) __half dO[BLOCK_M * Q_STRIDE];
+    alignas(16) __half q[BLOCK_M * Q_STRIDE];
+    alignas(16) float s[BLOCK_M * S_STRIDE];
+    union {
+      alignas(16) float dOV[BLOCK_M * S_STRIDE];
+      alignas(16) __half dS[BLOCK_M * S_STRIDE];
+    } reuse_sdOVS;
+    alignas(16) float row_dot[BLOCK_M];
+    alignas(16) float lse[BLOCK_M];
+    alignas(16) float dQ[BLOCK_M * Q_STRIDE];
+  };
 
-    static constexpr size_t TOTAL_SMEM = ((sizeof(SmemLayout) + 127) & ~size_t(127));
+  static constexpr size_t TOTAL_SMEM =
+      ((sizeof(SmemLayout) + 127) & ~size_t(127));
 };
 
-template<typename Config>
+template <typename Config>
 __device__ __forceinline__ void init_smem(char* smem_raw) {
-    constexpr int N_U4 = Config::TOTAL_SMEM / 16;
-    const int lane_id = threadIdx.x & 31;
+  constexpr int N_U4 = Config::TOTAL_SMEM / 16;
+  const int lane_id = threadIdx.x & 31;
 
-    uint32_t addr = static_cast<uint32_t>(__cvta_generic_to_shared(smem_raw));
-    #pragma unroll 1
-    for (int i = lane_id; i < N_U4; i += 32) {
-        asm volatile("st.shared.v4.u32 [%0], {%1,%1,%1,%1};"
-                     :: "r"(addr + (i << 4)), "r"(0) : "memory");
-    }
-    __syncwarp();
+  uint32_t addr = static_cast<uint32_t>(__cvta_generic_to_shared(smem_raw));
+#pragma unroll 1
+  for (int i = lane_id; i < N_U4; i += 32) {
+    asm volatile("st.shared.v4.u32 [%0], {%1,%1,%1,%1};" ::"r"(addr + (i << 4)),
+                 "r"(0)
+                 : "memory");
+  }
+  __syncwarp();
 }
 
-template<int D>
+template <int D>
 struct dKVKernelConfig {
-    static constexpr int BLOCK_M = (D == 16) ? BLOCK_KV_16 : (D == 32) ? BLOCK_KV_32 : (D == 64) ? BLOCK_KV_64 : (D == 128) ? BLOCK_KV_128 : BLOCK_KV_256;
-    static constexpr int BLOCK_N = (D == 16) ? BLOCK_Q_16 : (D == 32) ? BLOCK_Q_32 : (D == 64) ? BLOCK_Q_64 : (D == 128) ? BLOCK_Q_128 : BLOCK_Q_256;
-    static constexpr int WARPS_PER_BLOCK = (D == 16) ? WARPS_DKV_16 : (D == 32) ? WARPS_DKV_32 : (D == 64) ? WARPS_DKV_64 : (D == 128) ? WARPS_DKV_128 : WARPS_DKV_256;
+  static constexpr int BLOCK_M = (D == 16)    ? BLOCK_KV_16
+                                 : (D == 32)  ? BLOCK_KV_32
+                                 : (D == 64)  ? BLOCK_KV_64
+                                 : (D == 128) ? BLOCK_KV_128
+                                              : BLOCK_KV_256;
+  static constexpr int BLOCK_N = (D == 16)    ? BLOCK_Q_16
+                                 : (D == 32)  ? BLOCK_Q_32
+                                 : (D == 64)  ? BLOCK_Q_64
+                                 : (D == 128) ? BLOCK_Q_128
+                                              : BLOCK_Q_256;
+  static constexpr int WARPS_PER_BLOCK = (D == 16)    ? WARPS_DKV_16
+                                         : (D == 32)  ? WARPS_DKV_32
+                                         : (D == 64)  ? WARPS_DKV_64
+                                         : (D == 128) ? WARPS_DKV_128
+                                                      : WARPS_DKV_256;
 
-    static constexpr int THREADS_PER_BLOCK  = WARPS_PER_BLOCK * MAX_THREADS_PER_WARP;
-    static constexpr int THREADS_PER_ROW    = THREADS_PER_BLOCK / BLOCK_N;
-    static constexpr int PAD                = 8;
-    static constexpr int Q_STRIDE           = D + PAD;
-    static constexpr int KV_STRIDE          = D + PAD;
-    static constexpr int S_STRIDE           = BLOCK_M + PAD;
-    static constexpr int PER_UINT4          = 8;
-    static constexpr int NUM_UINT4_Q_BLOCK  = BLOCK_N * ((D + PER_UINT4 - 1) / PER_UINT4);
-    static constexpr int NUM_UINT4_KV_BLOCK = BLOCK_M * ((D + PER_UINT4 - 1) / PER_UINT4);
+  static constexpr int THREADS_PER_BLOCK =
+      WARPS_PER_BLOCK * MAX_THREADS_PER_WARP;
+  static constexpr int THREADS_PER_ROW = THREADS_PER_BLOCK / BLOCK_N;
+  static constexpr int PAD = 8;
+  static constexpr int Q_STRIDE = D + PAD;
+  static constexpr int KV_STRIDE = D + PAD;
+  static constexpr int S_STRIDE = BLOCK_M + PAD;
+  static constexpr int PER_UINT4 = 8;
+  static constexpr int NUM_UINT4_Q_BLOCK =
+      BLOCK_N * ((D + PER_UINT4 - 1) / PER_UINT4);
+  static constexpr int NUM_UINT4_KV_BLOCK =
+      BLOCK_M * ((D + PER_UINT4 - 1) / PER_UINT4);
 
-    struct alignas(128) SmemLayout {
-            alignas(16) __half k     [BLOCK_M * KV_STRIDE];
-            alignas(16) __half v     [BLOCK_M * KV_STRIDE];
-        union {
-            alignas(16) __half dO    [BLOCK_N * Q_STRIDE];
-            alignas(16) __half q     [BLOCK_N * Q_STRIDE];
-        } reuse_qdO;
-        union {
-            alignas(16) float  s     [BLOCK_N * S_STRIDE];
-            alignas(16) __half p     [BLOCK_N * BLOCK_M];
-        } reuse_sp;
-        union {
-            alignas(16) float  dOV   [BLOCK_N * S_STRIDE];
-            alignas(16) __half dS    [BLOCK_N * BLOCK_M];
-        } reuse_dOVS;
-            alignas(16) float row_dot[BLOCK_N];
-            alignas(16) float lse    [BLOCK_N];
-            alignas(16) float dK     [BLOCK_M * KV_STRIDE];
-            alignas(16) float dV     [BLOCK_M * KV_STRIDE];
-    };
+  struct alignas(128) SmemLayout {
+    alignas(16) __half k[BLOCK_M * KV_STRIDE];
+    alignas(16) __half v[BLOCK_M * KV_STRIDE];
+    union {
+      alignas(16) __half dO[BLOCK_N * Q_STRIDE];
+      alignas(16) __half q[BLOCK_N * Q_STRIDE];
+    } reuse_qdO;
+    union {
+      alignas(16) float s[BLOCK_N * S_STRIDE];
+      alignas(16) __half p[BLOCK_N * BLOCK_M];
+    } reuse_sp;
+    union {
+      alignas(16) float dOV[BLOCK_N * S_STRIDE];
+      alignas(16) __half dS[BLOCK_N * BLOCK_M];
+    } reuse_dOVS;
+    alignas(16) float row_dot[BLOCK_N];
+    alignas(16) float lse[BLOCK_N];
+    alignas(16) float dK[BLOCK_M * KV_STRIDE];
+    alignas(16) float dV[BLOCK_M * KV_STRIDE];
+  };
 
-    static constexpr size_t TOTAL_SMEM = ((sizeof(SmemLayout) + 127) & ~size_t(127));
+  static constexpr size_t TOTAL_SMEM =
+      ((sizeof(SmemLayout) + 127) & ~size_t(127));
 };
 
-template<int D, bool IS_CAUSAL>
+template <int D, bool IS_CAUSAL>
 __global__ void __launch_bounds__(dQKernelConfig<D>::THREADS_PER_BLOCK, 2)
-flash_attention_backward_dq_kernel(
-    const __half*  __restrict__ Q,
-    const __half*  __restrict__ K,
-    const __half*  __restrict__ V,
-    const __half*  __restrict__ O,
-    const __half*  __restrict__ dO,
-    const  float*  __restrict__ softmax_lse,
-          __half*  __restrict__ dQ,
-    const int B,
-    const int H,
-    const int M,
-    const int N,
-    const float softmax_scale
-) {
-    using Config = dQKernelConfig<D>;
+    flash_attention_backward_dq_kernel(
+        const __half* __restrict__ Q, const __half* __restrict__ K,
+        const __half* __restrict__ V, const __half* __restrict__ O,
+        const __half* __restrict__ dO, const float* __restrict__ softmax_lse,
+        __half* __restrict__ dQ, const int B, const int H, const int M,
+        const int N, const float softmax_scale) {
+  using Config = dQKernelConfig<D>;
 
-    constexpr int BLOCK_M           = Config::BLOCK_M;
-    constexpr int BLOCK_N           = Config::BLOCK_N;
-    constexpr int THREADS_PER_BLOCK = Config::THREADS_PER_BLOCK;
-    constexpr int THREADS_PER_ROW   = Config::THREADS_PER_ROW;
-    constexpr int WARPS_PER_BLOCK   = Config::WARPS_PER_BLOCK;
-    constexpr int Q_STRIDE          = Config::Q_STRIDE;
-    constexpr int KV_STRIDE         = Config::KV_STRIDE;
-    constexpr int S_STRIDE          = Config::S_STRIDE;
-    constexpr int PER_UINT4         = Config::PER_UINT4;
-    constexpr int NUM_UINT4_Q_BLOCK  = Config::NUM_UINT4_Q_BLOCK;
-    constexpr int NUM_UINT4_KV_BLOCK = Config::NUM_UINT4_KV_BLOCK;
+  constexpr int BLOCK_M = Config::BLOCK_M;
+  constexpr int BLOCK_N = Config::BLOCK_N;
+  constexpr int THREADS_PER_BLOCK = Config::THREADS_PER_BLOCK;
+  constexpr int THREADS_PER_ROW = Config::THREADS_PER_ROW;
+  constexpr int WARPS_PER_BLOCK = Config::WARPS_PER_BLOCK;
+  constexpr int Q_STRIDE = Config::Q_STRIDE;
+  constexpr int KV_STRIDE = Config::KV_STRIDE;
+  constexpr int S_STRIDE = Config::S_STRIDE;
+  constexpr int PER_UINT4 = Config::PER_UINT4;
+  constexpr int NUM_UINT4_Q_BLOCK = Config::NUM_UINT4_Q_BLOCK;
+  constexpr int NUM_UINT4_KV_BLOCK = Config::NUM_UINT4_KV_BLOCK;
 
-    const float NEG_INF = -1e30f;
+  const float NEG_INF = -1e30f;
 
-    const int batch_head_id = blockIdx.z;
-    if (batch_head_id >= B * H) return;
+  const int batch_head_id = blockIdx.z;
+  if (batch_head_id >= B * H) return;
 
-    const int block_m   = blockIdx.x;
-    const int start_row = block_m * BLOCK_M;
-    if (start_row >= M) return;
+  const int block_m = blockIdx.x;
+  const int start_row = block_m * BLOCK_M;
+  if (start_row >= M) return;
 
-    int num_n_tiles = (N + BLOCK_N - 1) / BLOCK_N;
-    const int valid_q_rows = min(BLOCK_M, M - start_row);
+  int num_n_tiles = (N + BLOCK_N - 1) / BLOCK_N;
+  const int valid_q_rows = min(BLOCK_M, M - start_row);
 
-    if constexpr (IS_CAUSAL) {
-        const int max_key_pos = start_row + valid_q_rows - 1;
-        if (max_key_pos < 0) {
-            num_n_tiles = 0;
-        } else {
-            num_n_tiles = min(num_n_tiles, (max_key_pos + BLOCK_N) / BLOCK_N);
-        }
+  if constexpr (IS_CAUSAL) {
+    const int max_key_pos = start_row + valid_q_rows - 1;
+    if (max_key_pos < 0) {
+      num_n_tiles = 0;
+    } else {
+      num_n_tiles = min(num_n_tiles, (max_key_pos + BLOCK_N) / BLOCK_N);
+    }
+  }
+
+  const int tid = threadIdx.x;
+  const int warp_id = tid / MAX_THREADS_PER_WARP;
+  const int lane_id = tid % MAX_THREADS_PER_WARP;
+
+  const __half* q_ptr = Q + (size_t)batch_head_id * M * D + start_row * D;
+  const __half* k_ptr = K + (size_t)batch_head_id * N * D;
+  const __half* v_ptr = V + (size_t)batch_head_id * N * D;
+  const __half* o_ptr = O + (size_t)batch_head_id * M * D + start_row * D;
+  const __half* dO_ptr = dO + (size_t)batch_head_id * M * D + start_row * D;
+  __half* dQ_ptr = dQ + (size_t)batch_head_id * M * D + start_row * D;
+  const float* lse_ptr = softmax_lse + (size_t)batch_head_id * M + start_row;
+
+  extern __shared__ char smem_raw[];
+  init_smem<Config>(smem_raw);
+  auto& smem = *reinterpret_cast<typename Config::SmemLayout*>(smem_raw);
+
+  __half* sK = smem.reuse_kv.k;
+  __half* sV = smem.reuse_kv.v;
+  __half* sdO = smem.dO;
+  __half* sQ = smem.q;
+  float* sS = smem.s;
+  float* sdOV = smem.reuse_sdOVS.dOV;
+  __half* sdS = smem.reuse_sdOVS.dS;
+  float* sRowDot = smem.row_dot;
+  float* sLse = smem.lse;
+  float* sdQ = smem.dQ;
+
+  const int d_stride_uint4 = (D + PER_UINT4 - 1) / PER_UINT4;
+  const int q_stride_uint4 = (Q_STRIDE + PER_UINT4 - 1) / PER_UINT4;
+  const int kv_stride_uint4 = (KV_STRIDE + PER_UINT4 - 1) / PER_UINT4;
+
+  const uint4* q_vec = reinterpret_cast<const uint4*>(q_ptr);
+  const uint4* do_vec = reinterpret_cast<const uint4*>(dO_ptr);
+  uint4* sQ_vec = reinterpret_cast<uint4*>(sQ);
+  uint4* sdO_vec = reinterpret_cast<uint4*>(sdO);
+
+#pragma unroll 2
+  for (int idx = tid; idx < NUM_UINT4_Q_BLOCK; idx += THREADS_PER_BLOCK) {
+    const int row = idx / d_stride_uint4;
+    const int vec_col = idx % d_stride_uint4;
+
+    uint4 q_val = make_uint4(0, 0, 0, 0);
+    uint4 do_val = make_uint4(0, 0, 0, 0);
+
+    if (row < valid_q_rows && vec_col < d_stride_uint4) {
+      q_val = __ldg(&q_vec[row * d_stride_uint4 + vec_col]);
+      do_val = __ldg(&do_vec[row * d_stride_uint4 + vec_col]);
+    }
+    sQ_vec[row * q_stride_uint4 + vec_col] = q_val;
+    sdO_vec[row * q_stride_uint4 + vec_col] = do_val;
+  }
+  __syncthreads();
+
+  if (tid < valid_q_rows * THREADS_PER_ROW) {
+    const int row = tid / THREADS_PER_ROW;
+    const int thread_in_row = tid % THREADS_PER_ROW;
+    const int fp16_x4_per_row = D / 4;
+    const int work_per_thread =
+        (fp16_x4_per_row + THREADS_PER_ROW - 1) / THREADS_PER_ROW;
+    const unsigned mask =
+        (valid_q_rows == BLOCK_M) ? 0xFFFFFFFFU : __activemask();
+
+    float thread_dot = 0.0f;
+
+#pragma unroll
+    for (int j = 0; j < work_per_thread; ++j) {
+      const int chunk_idx = thread_in_row + j * THREADS_PER_ROW;
+      if (chunk_idx >= fp16_x4_per_row) break;
+      const int col = chunk_idx * 4;
+
+      const __half* o_addr = o_ptr + row * D + col;
+      ushort o_h0, o_h1, o_h2, o_h3;
+      asm volatile("ld.global.v4.u16 {%0, %1, %2, %3}, [%4];"
+                   : "=h"(o_h0), "=h"(o_h1), "=h"(o_h2), "=h"(o_h3)
+                   : "l"(o_addr)
+                   : "memory");
+
+      const __half* dO_addr = sdO + row * Q_STRIDE + col;
+      ushort d_h0, d_h1, d_h2, d_h3;
+      const uint32_t ptr_dO = static_cast<uint32_t>(
+          reinterpret_cast<uintptr_t>(__cvta_generic_to_shared(dO_addr)));
+      asm volatile("ld.shared.v4.u16 {%0, %1, %2, %3}, [%4];"
+                   : "=h"(d_h0), "=h"(d_h1), "=h"(d_h2), "=h"(d_h3)
+                   : "r"(ptr_dO)
+                   : "memory");
+
+      const float fo_0 = __half2float(__ushort_as_half(o_h0));
+      const float fo_1 = __half2float(__ushort_as_half(o_h1));
+      const float fo_2 = __half2float(__ushort_as_half(o_h2));
+      const float fo_3 = __half2float(__ushort_as_half(o_h3));
+
+      const float fd_0 = __half2float(__ushort_as_half(d_h0));
+      const float fd_1 = __half2float(__ushort_as_half(d_h1));
+      const float fd_2 = __half2float(__ushort_as_half(d_h2));
+      const float fd_3 = __half2float(__ushort_as_half(d_h3));
+
+      thread_dot = __fmaf_rn(fo_0, fd_0, thread_dot);
+      thread_dot = __fmaf_rn(fo_1, fd_1, thread_dot);
+      thread_dot = __fmaf_rn(fo_2, fd_2, thread_dot);
+      thread_dot = __fmaf_rn(fo_3, fd_3, thread_dot);
     }
 
-    const int tid          = threadIdx.x;
-    const int warp_id      = tid / MAX_THREADS_PER_WARP;
-    const int lane_id      = tid % MAX_THREADS_PER_WARP;
+#pragma unroll
+    for (int o = THREADS_PER_ROW / 2; o > 0; o >>= 1)
+      thread_dot += __shfl_down_sync(mask, thread_dot, o, THREADS_PER_ROW);
 
-    const __half* q_ptr   = Q           + (size_t)batch_head_id * M * D + start_row * D;
-    const __half* k_ptr   = K           + (size_t)batch_head_id * N * D;
-    const __half* v_ptr   = V           + (size_t)batch_head_id * N * D;
-    const __half* o_ptr   = O           + (size_t)batch_head_id * M * D + start_row * D;
-    const __half* dO_ptr  = dO          + (size_t)batch_head_id * M * D + start_row * D;
-          __half* dQ_ptr  = dQ          + (size_t)batch_head_id * M * D + start_row * D;
-    const float*  lse_ptr = softmax_lse + (size_t)batch_head_id * M + start_row;
+    if (thread_in_row == 0) {
+      sRowDot[row] = thread_dot;
+    }
+  }
 
-    extern __shared__ char smem_raw[];
-    init_smem<Config>(smem_raw);
-    auto& smem = *reinterpret_cast<typename Config::SmemLayout*>(smem_raw);
+  if (tid < valid_q_rows) {
+    sLse[tid] = lse_ptr[tid];
+  }
+  __syncthreads();
 
-    __half* sK      = smem.reuse_kv.k;
-    __half* sV      = smem.reuse_kv.v;
-    __half* sdO     = smem.dO;
-    __half* sQ      = smem.q;
-     float* sS      = smem.s;
-     float* sdOV    = smem.reuse_sdOVS.dOV;
-    __half* sdS     = smem.reuse_sdOVS.dS;
-     float* sRowDot = smem.row_dot;
-     float* sLse    = smem.lse;
-     float* sdQ     = smem.dQ;
+  for (int block_n = 0; block_n < num_n_tiles; ++block_n) {
+    const int start_col = block_n * BLOCK_N;
+    if (start_col >= N) break;
+    const int valid_k_rows = min(BLOCK_N, N - start_col);
 
-    const int  d_stride_uint4 = (D + PER_UINT4 - 1) / PER_UINT4;
-    const int  q_stride_uint4 = (Q_STRIDE  + PER_UINT4 - 1) / PER_UINT4;
-    const int kv_stride_uint4 = (KV_STRIDE + PER_UINT4 - 1) / PER_UINT4;
+    if constexpr (IS_CAUSAL) {
+      if (start_col >= start_row + valid_q_rows) {
+        continue;
+      }
+    }
 
-    const uint4* q_vec  = reinterpret_cast<const uint4*>(q_ptr);
-    const uint4* do_vec = reinterpret_cast<const uint4*>(dO_ptr);
-    uint4* sQ_vec  = reinterpret_cast<uint4*>(sQ);
-    uint4* sdO_vec = reinterpret_cast<uint4*>(sdO);
+    const uint4* v_vec = reinterpret_cast<const uint4*>(v_ptr + start_col * D);
+    uint4* sV_vec = reinterpret_cast<uint4*>(sV);
 
-    #pragma unroll 2
-    for (int idx = tid; idx < NUM_UINT4_Q_BLOCK; idx += THREADS_PER_BLOCK) {
-        const int row = idx / d_stride_uint4;
-        const int vec_col = idx % d_stride_uint4;
+#pragma unroll 2
+    for (int idx = tid; idx < NUM_UINT4_KV_BLOCK; idx += THREADS_PER_BLOCK) {
+      const int row = idx / d_stride_uint4;
+      const int vec_col = idx % d_stride_uint4;
+      uint4 v_val = make_uint4(0, 0, 0, 0);
+      if (row < valid_k_rows && vec_col < d_stride_uint4) {
+        v_val = __ldg(&v_vec[row * d_stride_uint4 + vec_col]);
+      }
+      sV_vec[row * kv_stride_uint4 + vec_col] = v_val;
+    }
+    __syncthreads();
 
-        uint4 q_val  = make_uint4(0, 0, 0, 0);
-        uint4 do_val = make_uint4(0, 0, 0, 0);
+    const int num_tiles_m_dov = (BLOCK_M + WMMA_M - 1) / WMMA_M;
+    const int num_tiles_n_dov = (BLOCK_N + WMMA_N - 1) / WMMA_N;
+    const int num_tiles_k_dov = (D + WMMA_K - 1) / WMMA_K;
+    const int total_tiles_dov = num_tiles_m_dov * num_tiles_n_dov;
+    const int tiles_per_warp_dov =
+        (total_tiles_dov + WARPS_PER_BLOCK - 1) / WARPS_PER_BLOCK;
 
-        if (row < valid_q_rows && vec_col < d_stride_uint4) {
-            q_val =  __ldg(&q_vec[row * d_stride_uint4 + vec_col]);
-            do_val = __ldg(&do_vec[row * d_stride_uint4 + vec_col]);
+    for (int tile_idx = 0; tile_idx < tiles_per_warp_dov; ++tile_idx) {
+      const int global_tile_idx = warp_id * tiles_per_warp_dov + tile_idx;
+
+      if (global_tile_idx >= total_tiles_dov) break;
+
+      const int tile_m_idx = global_tile_idx / num_tiles_n_dov;
+      const int tile_n_idx = global_tile_idx % num_tiles_n_dov;
+
+      const int tile_m = tile_m_idx * WMMA_M;
+      const int tile_n = tile_n_idx * WMMA_N;
+
+      if (tile_m >= valid_q_rows || tile_n >= valid_k_rows) continue;
+
+      fragment<matrix_a, WMMA_M, WMMA_N, WMMA_K, __half, row_major> a_frag;
+      fragment<matrix_b, WMMA_M, WMMA_N, WMMA_K, __half, col_major> b_frag;
+      fragment<accumulator, WMMA_M, WMMA_N, WMMA_K, float> acc_frag;
+
+      fill_fragment(acc_frag, 0.0f);
+
+#pragma unroll
+      for (int k_tile = 0; k_tile < num_tiles_k_dov; ++k_tile) {
+        const int k_offset = k_tile * WMMA_K;
+        if (k_offset >= D) break;
+        load_matrix_sync(a_frag, sdO + tile_m * Q_STRIDE + k_offset, Q_STRIDE);
+        load_matrix_sync(b_frag, sV + tile_n * KV_STRIDE + k_offset, KV_STRIDE);
+        mma_sync(acc_frag, a_frag, b_frag, acc_frag);
+      }
+
+      store_matrix_sync(sdOV + tile_m * S_STRIDE + tile_n, acc_frag, S_STRIDE,
+                        mem_row_major);
+    }
+    __syncthreads();
+
+    const uint4* k_vec = reinterpret_cast<const uint4*>(k_ptr + start_col * D);
+    uint4* sK_vec = reinterpret_cast<uint4*>(sK);
+
+#pragma unroll 2
+    for (int idx = tid; idx < NUM_UINT4_KV_BLOCK; idx += THREADS_PER_BLOCK) {
+      const int row = idx / d_stride_uint4;
+      const int vec_col = idx % d_stride_uint4;
+      uint4 k_val = make_uint4(0, 0, 0, 0);
+      if (row < valid_k_rows && vec_col < d_stride_uint4) {
+        k_val = __ldg(&k_vec[row * d_stride_uint4 + vec_col]);
+      }
+      sK_vec[row * kv_stride_uint4 + vec_col] = k_val;
+    }
+    __syncthreads();
+
+    const int num_tiles_m_qk = (BLOCK_M + WMMA_M - 1) / WMMA_M;
+    const int num_tiles_n_qk = (BLOCK_N + WMMA_N - 1) / WMMA_N;
+    const int num_tiles_k_qk = (D + WMMA_K - 1) / WMMA_K;
+    const int total_tiles_qk = num_tiles_m_qk * num_tiles_n_qk;
+    const int tiles_per_warp_qk =
+        (total_tiles_qk + WARPS_PER_BLOCK - 1) / WARPS_PER_BLOCK;
+    const unsigned row_causal = (lane_id & 0b1) + ((lane_id >> 2) & 0b1) * 8 +
+                                ((lane_id >> 4) & 0b1) * 4;
+    const unsigned col_causal =
+        ((lane_id >> 1) & 0b1) * 2 + ((lane_id >> 3) & 0b1) * 8;
+
+    for (int tile_idx = 0; tile_idx < tiles_per_warp_qk; ++tile_idx) {
+      const int global_tile_idx = warp_id * tiles_per_warp_qk + tile_idx;
+
+      if (global_tile_idx >= total_tiles_qk) break;
+
+      const int tile_m_idx = global_tile_idx / num_tiles_n_qk;
+      const int tile_n_idx = global_tile_idx % num_tiles_n_qk;
+
+      const int tile_m = tile_m_idx * WMMA_M;
+      const int tile_n = tile_n_idx * WMMA_N;
+
+      if (tile_m >= valid_q_rows || tile_n >= valid_k_rows) continue;
+
+      fragment<matrix_a, WMMA_M, WMMA_N, WMMA_K, __half, row_major> a_frag;
+      fragment<matrix_b, WMMA_M, WMMA_N, WMMA_K, __half, col_major> b_frag;
+      fragment<accumulator, WMMA_M, WMMA_N, WMMA_K, float> acc_frag;
+
+      fill_fragment(acc_frag, 0.0f);
+
+#pragma unroll
+      for (int k_tile = 0; k_tile < num_tiles_k_qk; ++k_tile) {
+        const int k_offset = k_tile * WMMA_K;
+        if (k_offset >= D) break;
+        load_matrix_sync(a_frag, sQ + tile_m * Q_STRIDE + k_offset, Q_STRIDE);
+        load_matrix_sync(b_frag, sK + tile_n * KV_STRIDE + k_offset, KV_STRIDE);
+        mma_sync(acc_frag, a_frag, b_frag, acc_frag);
+      }
+
+      if constexpr (IS_CAUSAL) {
+#pragma unroll
+        for (int i = 0; i < acc_frag.num_elements; ++i) {
+          const unsigned col = col_causal + (i & 0b1) + ((i >> 2) & 0b1) * 4;
+          const unsigned row = row_causal + ((i >> 1) & 0b1) * 2;
+
+          const int global_m = start_row + tile_m + row;
+          const int global_n = start_col + tile_n + col;
+
+          const bool is_valid = (global_m < start_row + valid_q_rows) &&
+                                (global_n < start_col + valid_k_rows);
+
+          acc_frag.x[i] =
+              is_valid ? ((global_n > global_m) ? NEG_INF
+                                                : acc_frag.x[i] * softmax_scale)
+                       : NEG_INF;
         }
-         sQ_vec[row * q_stride_uint4 + vec_col] = q_val;
-        sdO_vec[row * q_stride_uint4 + vec_col] = do_val;
+      } else {
+#pragma unroll
+        for (int i = 0; i < acc_frag.num_elements; ++i) {
+          acc_frag.x[i] *= softmax_scale;
+        }
+      }
+      store_matrix_sync(sS + tile_m * S_STRIDE + tile_n, acc_frag, S_STRIDE,
+                        mem_row_major);
     }
     __syncthreads();
 
     if (tid < valid_q_rows * THREADS_PER_ROW) {
-        const int row = tid / THREADS_PER_ROW;
-        const int thread_in_row = tid % THREADS_PER_ROW;
-        const int fp16_x4_per_row = D / 4;
-        const int work_per_thread = (fp16_x4_per_row + THREADS_PER_ROW - 1) / THREADS_PER_ROW;
-        const unsigned mask = (valid_q_rows == BLOCK_M) ? 0xFFFFFFFFU : __activemask();
+      const int row = tid / THREADS_PER_ROW;
+      const int thread_in_row = tid % THREADS_PER_ROW;
 
-        float thread_dot = 0.0f;
+      float* sS_row = sS + row * S_STRIDE;
+      float* sdOV_row = sdOV + row * S_STRIDE;
+      __half* sdS_row = sdS + row * S_STRIDE;
 
-        #pragma unroll
-        for (int j = 0; j < work_per_thread; ++j) {
-            const int chunk_idx = thread_in_row + j * THREADS_PER_ROW;
-            if (chunk_idx >= fp16_x4_per_row) break;
-            const int col = chunk_idx * 4;
+      const float lse_val = sLse[row];
+      const float row_dot_val = sRowDot[row];
 
-            const __half* o_addr = o_ptr + row * D + col;
-            ushort o_h0, o_h1, o_h2, o_h3;
-            asm volatile(
-                "ld.global.v4.u16 {%0, %1, %2, %3}, [%4];"
-                : "=h"(o_h0), "=h"(o_h1), "=h"(o_h2), "=h"(o_h3)
-                : "l"(o_addr)
-                : "memory"
-            );
+      const int vec8_cols = valid_k_rows / 8;
+      const int vec8_per_thread =
+          (vec8_cols + THREADS_PER_ROW - 1) / THREADS_PER_ROW;
+      const int tail_start = vec8_cols * 8;
 
-            const __half* dO_addr = sdO + row * Q_STRIDE + col;
-            ushort d_h0, d_h1, d_h2, d_h3;
-            const uint32_t ptr_dO = static_cast<uint32_t>(reinterpret_cast<uintptr_t>(__cvta_generic_to_shared(dO_addr)));
-            asm volatile(
-                "ld.shared.v4.u16 {%0, %1, %2, %3}, [%4];"
-                : "=h"(d_h0), "=h"(d_h1), "=h"(d_h2), "=h"(d_h3)
-                : "r"(ptr_dO)
-                : "memory"
-            );
+      float4* sS_vec4 = reinterpret_cast<float4*>(sS_row);
+      float4* sdOV_vec4 = reinterpret_cast<float4*>(sdOV_row);
+      uint4* sdS_vec_u4 = reinterpret_cast<uint4*>(sdS_row);
 
-            const float fo_0 = __half2float(__ushort_as_half(o_h0));
-            const float fo_1 = __half2float(__ushort_as_half(o_h1));
-            const float fo_2 = __half2float(__ushort_as_half(o_h2));
-            const float fo_3 = __half2float(__ushort_as_half(o_h3));
+      uint4 buf[8];
+      int cnt = 0;
 
-            const float fd_0 = __half2float(__ushort_as_half(d_h0));
-            const float fd_1 = __half2float(__ushort_as_half(d_h1));
-            const float fd_2 = __half2float(__ushort_as_half(d_h2));
-            const float fd_3 = __half2float(__ushort_as_half(d_h3));
+#pragma unroll
+      for (int j = 0; j < vec8_per_thread; ++j) {
+        const int v8 = thread_in_row + j * THREADS_PER_ROW;
+        if (v8 >= vec8_cols) break;
 
-            thread_dot = __fmaf_rn(fo_0, fd_0, thread_dot);
-            thread_dot = __fmaf_rn(fo_1, fd_1, thread_dot);
-            thread_dot = __fmaf_rn(fo_2, fd_2, thread_dot);
-            thread_dot = __fmaf_rn(fo_3, fd_3, thread_dot);
+        float4 s0 = sS_vec4[v8 * 2], s1 = sS_vec4[v8 * 2 + 1];
+        float4 d0 = sdOV_vec4[v8 * 2], d1 = sdOV_vec4[v8 * 2 + 1];
+
+#define COMP(i, sf, df)                                 \
+  float sh##i = (sf) - lse_val;                         \
+  float p##i = (sh##i < -80.0f) ? 0.0f : __expf(sh##i); \
+  float ds##i = p##i * softmax_scale * ((df) - row_dot_val);
+
+        COMP(0, s0.x, d0.x);
+        COMP(1, s0.y, d0.y);
+        COMP(2, s0.z, d0.z);
+        COMP(3, s0.w, d0.w);
+        COMP(4, s1.x, d1.x);
+        COMP(5, s1.y, d1.y);
+        COMP(6, s1.z, d1.z);
+        COMP(7, s1.w, d1.w);
+#undef COMP
+
+        uint4 res;
+        asm volatile(
+            "{ mov.b32 %0, {%4,%5}; mov.b32 %1, {%6,%7}; mov.b32 %2, {%8,%9}; "
+            "mov.b32 %3, {%10,%11}; }\n"
+            : "=r"(res.x), "=r"(res.y), "=r"(res.z), "=r"(res.w)
+            : "h"(__half_as_ushort(__float2half_rn(ds0))),
+              "h"(__half_as_ushort(__float2half_rn(ds1))),
+              "h"(__half_as_ushort(__float2half_rn(ds2))),
+              "h"(__half_as_ushort(__float2half_rn(ds3))),
+              "h"(__half_as_ushort(__float2half_rn(ds4))),
+              "h"(__half_as_ushort(__float2half_rn(ds5))),
+              "h"(__half_as_ushort(__float2half_rn(ds6))),
+              "h"(__half_as_ushort(__float2half_rn(ds7))));
+        buf[cnt++] = res;
+      }
+
+#pragma unroll
+      for (int c = tail_start + thread_in_row; c < BLOCK_N;
+           c += THREADS_PER_ROW) {
+        float s = (c < valid_k_rows) ? sS_row[c] : NEG_INF;
+        float dov = (c < valid_k_rows) ? sdOV_row[c] : 0.0f;
+        float p = (s - lse_val < -80.0f) ? 0.0f : __expf(s - lse_val);
+        float ds = p * softmax_scale *
+                   ((c < valid_k_rows) ? (dov - row_dot_val) : 0.0f);
+        sdS_row[c] = __float2half_rn(ds);
+      }
+
+#pragma unroll
+      for (int i = 0; i < cnt; ++i) {
+        const int v8 = thread_in_row + i * THREADS_PER_ROW;
+        if (v8 < vec8_cols) {
+          sdS_vec_u4[v8] = buf[i];
         }
-
-        #pragma unroll
-        for (int o = THREADS_PER_ROW / 2; o > 0; o >>= 1)
-            thread_dot += __shfl_down_sync(mask, thread_dot, o, THREADS_PER_ROW);
-
-        if (thread_in_row == 0) {
-            sRowDot[row] = thread_dot;
-        }
+      }
     }
-
-    if (tid < valid_q_rows) { sLse[tid] = lse_ptr[tid]; }
     __syncthreads();
 
-    for (int block_n = 0; block_n < num_n_tiles; ++block_n) {
-        const int start_col = block_n * BLOCK_N;
-        if (start_col >= N) break;
-        const int valid_k_rows = min(BLOCK_N, N - start_col);
+    const int num_tiles_m_dq = (BLOCK_M + WMMA_M - 1) / WMMA_M;
+    const int num_tiles_n_dq = (D + WMMA_N - 1) / WMMA_N;
+    const int num_tiles_k_dq = (BLOCK_N + WMMA_K - 1) / WMMA_K;
+    const int total_tiles_dq = num_tiles_m_dq * num_tiles_n_dq;
+    const int tiles_per_warp_dq =
+        (total_tiles_dq + WARPS_PER_BLOCK - 1) / WARPS_PER_BLOCK;
 
-        if constexpr (IS_CAUSAL) {
-            if (start_col >= start_row + valid_q_rows) { continue; }
-        }
+    for (int tile_local = 0; tile_local < tiles_per_warp_dq; ++tile_local) {
+      const int global_tile_idx = warp_id * tiles_per_warp_dq + tile_local;
+      if (global_tile_idx >= total_tiles_dq) break;
 
-        const uint4* v_vec        = reinterpret_cast<const uint4*>(v_ptr + start_col * D);
-        uint4*       sV_vec       = reinterpret_cast<uint4*>(sV);
+      const int tile_m_idx = global_tile_idx / num_tiles_n_dq;
+      const int tile_n_idx = global_tile_idx % num_tiles_n_dq;
 
-        #pragma unroll 2
-        for (int idx = tid; idx < NUM_UINT4_KV_BLOCK; idx += THREADS_PER_BLOCK) {
-            const int row = idx / d_stride_uint4;
-            const int vec_col = idx % d_stride_uint4;
-            uint4 v_val = make_uint4(0, 0, 0, 0);
-            if (row < valid_k_rows && vec_col < d_stride_uint4) {
-                v_val = __ldg(&v_vec[row * d_stride_uint4 + vec_col]);
-            }
-            sV_vec[row * kv_stride_uint4 + vec_col] = v_val;
-        }
-        __syncthreads();
+      const int tile_m = tile_m_idx * WMMA_M;
+      const int tile_n = tile_n_idx * WMMA_N;
 
-        const int num_tiles_m_dov    = (BLOCK_M + WMMA_M - 1) / WMMA_M;
-        const int num_tiles_n_dov    = (BLOCK_N + WMMA_N - 1) / WMMA_N;
-        const int num_tiles_k_dov    = (D + WMMA_K - 1) / WMMA_K;
-        const int total_tiles_dov    = num_tiles_m_dov * num_tiles_n_dov;
-        const int tiles_per_warp_dov = (total_tiles_dov + WARPS_PER_BLOCK - 1) / WARPS_PER_BLOCK;
+      if (tile_m >= valid_q_rows || tile_n >= D) continue;
 
-        for (int tile_idx = 0; tile_idx < tiles_per_warp_dov; ++tile_idx) {
-            const int global_tile_idx = warp_id * tiles_per_warp_dov + tile_idx;
+      fragment<matrix_a, WMMA_M, WMMA_N, WMMA_K, __half, row_major> a_frag;
+      fragment<matrix_b, WMMA_M, WMMA_N, WMMA_K, __half, row_major> b_frag;
+      fragment<accumulator, WMMA_M, WMMA_N, WMMA_K, float> acc_frag;
+      fill_fragment(acc_frag, 0.0f);
 
-            if (global_tile_idx >= total_tiles_dov) break;
+#pragma unroll
+      for (int k_tile = 0; k_tile < num_tiles_k_dq; ++k_tile) {
+        const int k_offset = k_tile * WMMA_K;
+        if (k_offset >= valid_k_rows) break;
 
-            const int tile_m_idx = global_tile_idx / num_tiles_n_dov;
-            const int tile_n_idx = global_tile_idx % num_tiles_n_dov;
+        load_matrix_sync(a_frag, sdS + tile_m * S_STRIDE + k_offset, S_STRIDE);
+        load_matrix_sync(b_frag, sK + k_offset * KV_STRIDE + tile_n, KV_STRIDE);
+        mma_sync(acc_frag, a_frag, b_frag, acc_frag);
+      }
 
-            const int tile_m = tile_m_idx * WMMA_M;
-            const int tile_n = tile_n_idx * WMMA_N;
+      fragment<accumulator, WMMA_M, WMMA_N, WMMA_K, float> curr_frag;
+      load_matrix_sync(curr_frag, sdQ + tile_m * Q_STRIDE + tile_n, Q_STRIDE,
+                       mem_row_major);
 
-            if (tile_m >= valid_q_rows || tile_n >= valid_k_rows) continue;
-
-            fragment<matrix_a, WMMA_M, WMMA_N, WMMA_K, __half, row_major> a_frag;
-            fragment<matrix_b, WMMA_M, WMMA_N, WMMA_K, __half, col_major> b_frag;
-            fragment<accumulator, WMMA_M, WMMA_N, WMMA_K, float> acc_frag;
-
-            fill_fragment(acc_frag, 0.0f);
-
-            #pragma unroll
-            for (int k_tile = 0; k_tile < num_tiles_k_dov; ++k_tile) {
-                const int k_offset = k_tile * WMMA_K;
-                if (k_offset >= D) break;
-                load_matrix_sync(a_frag, sdO + tile_m * Q_STRIDE + k_offset, Q_STRIDE);
-                load_matrix_sync(b_frag, sV + tile_n * KV_STRIDE + k_offset, KV_STRIDE);
-                mma_sync(acc_frag, a_frag, b_frag, acc_frag);
-            }
-
-            store_matrix_sync(sdOV + tile_m * S_STRIDE + tile_n, acc_frag, S_STRIDE, mem_row_major);
-        }
-        __syncthreads();
-
-        const uint4* k_vec     = reinterpret_cast<const uint4*>(k_ptr + start_col * D);
-        uint4*       sK_vec    = reinterpret_cast<uint4*>(sK);
-
-        #pragma unroll 2
-        for (int idx = tid; idx < NUM_UINT4_KV_BLOCK; idx += THREADS_PER_BLOCK) {
-            const int row = idx / d_stride_uint4;
-            const int vec_col = idx % d_stride_uint4;
-            uint4 k_val = make_uint4(0, 0, 0, 0);
-            if (row < valid_k_rows && vec_col < d_stride_uint4) {
-                k_val = __ldg(&k_vec[row * d_stride_uint4 + vec_col]);
-            }
-            sK_vec[row * kv_stride_uint4 + vec_col] = k_val;
-        }
-        __syncthreads();
-
-        const int num_tiles_m_qk    = (BLOCK_M + WMMA_M - 1) / WMMA_M;
-        const int num_tiles_n_qk    = (BLOCK_N + WMMA_N - 1) / WMMA_N;
-        const int num_tiles_k_qk    = (D + WMMA_K - 1) / WMMA_K;
-        const int total_tiles_qk    = num_tiles_m_qk * num_tiles_n_qk;
-        const int tiles_per_warp_qk = (total_tiles_qk + WARPS_PER_BLOCK - 1) / WARPS_PER_BLOCK;
-        const unsigned row_causal   = (lane_id & 0b1) + ((lane_id >> 2) & 0b1) * 8 + ((lane_id >> 4) & 0b1) * 4;
-        const unsigned col_causal   = ((lane_id >> 1) & 0b1) * 2 + ((lane_id >> 3) & 0b1) * 8;
-
-        for (int tile_idx = 0; tile_idx < tiles_per_warp_qk; ++tile_idx) {
-            const int global_tile_idx = warp_id * tiles_per_warp_qk + tile_idx;
-
-            if (global_tile_idx >= total_tiles_qk) break;
-
-            const int tile_m_idx = global_tile_idx / num_tiles_n_qk;
-            const int tile_n_idx = global_tile_idx % num_tiles_n_qk;
-
-            const int tile_m = tile_m_idx * WMMA_M;
-            const int tile_n = tile_n_idx * WMMA_N;
-
-            if (tile_m >= valid_q_rows || tile_n >= valid_k_rows) continue;
-
-            fragment<matrix_a, WMMA_M, WMMA_N, WMMA_K, __half, row_major> a_frag;
-            fragment<matrix_b, WMMA_M, WMMA_N, WMMA_K, __half, col_major> b_frag;
-            fragment<accumulator, WMMA_M, WMMA_N, WMMA_K, float> acc_frag;
-
-            fill_fragment(acc_frag, 0.0f);
-
-            #pragma unroll
-            for (int k_tile = 0; k_tile < num_tiles_k_qk; ++k_tile) {
-                const int k_offset = k_tile * WMMA_K;
-                if (k_offset >= D) break;
-                load_matrix_sync(a_frag, sQ + tile_m * Q_STRIDE + k_offset, Q_STRIDE);
-                load_matrix_sync(b_frag, sK + tile_n * KV_STRIDE + k_offset, KV_STRIDE);
-                mma_sync(acc_frag, a_frag, b_frag, acc_frag);
-            }
-
-            if constexpr (IS_CAUSAL) {
-                #pragma unroll
-                for (int i = 0; i < acc_frag.num_elements; ++i) {
-                    const unsigned col = col_causal + (i & 0b1) + ((i >> 2) & 0b1) * 4;
-                    const unsigned row = row_causal + ((i >> 1) & 0b1) * 2;
-
-                    const int global_m = start_row + tile_m + row;
-                    const int global_n = start_col + tile_n + col;
-
-                    const bool is_valid = (global_m < start_row + valid_q_rows) &&
-                                          (global_n < start_col + valid_k_rows);
-
-                    acc_frag.x[i] = is_valid
-                        ? ((global_n > global_m) ? NEG_INF : acc_frag.x[i] * softmax_scale)
-                        : NEG_INF;
-                }
-            } else {
-                #pragma unroll
-                for (int i = 0; i < acc_frag.num_elements; ++i) {
-                    acc_frag.x[i] *= softmax_scale;
-                }
-            }
-            store_matrix_sync(sS + tile_m * S_STRIDE + tile_n, acc_frag, S_STRIDE, mem_row_major);
-        }
-        __syncthreads();
-
-        if (tid < valid_q_rows * THREADS_PER_ROW) {
-            const int row = tid / THREADS_PER_ROW;
-            const int thread_in_row = tid % THREADS_PER_ROW;
-
-            float*  sS_row   = sS   + row * S_STRIDE;
-            float*  sdOV_row = sdOV + row * S_STRIDE;
-            __half* sdS_row  = sdS  + row * S_STRIDE;
-
-            const float lse_val     = sLse[row];
-            const float row_dot_val = sRowDot[row];
-
-            const int vec8_cols = valid_k_rows / 8;
-            const int vec8_per_thread = (vec8_cols + THREADS_PER_ROW - 1) / THREADS_PER_ROW;
-            const int tail_start = vec8_cols * 8;
-
-            float4* sS_vec4    = reinterpret_cast<float4*>(sS_row);
-            float4* sdOV_vec4  = reinterpret_cast<float4*>(sdOV_row);
-            uint4*  sdS_vec_u4 = reinterpret_cast<uint4*>(sdS_row);
-
-            uint4 buf[8]; int cnt = 0;
-
-            #pragma unroll
-            for (int j = 0; j < vec8_per_thread; ++j) {
-                const int v8 = thread_in_row + j * THREADS_PER_ROW;
-                if (v8 >= vec8_cols) break;
-
-                float4 s0 = sS_vec4[v8 * 2],   s1 = sS_vec4[v8 * 2 + 1];
-                float4 d0 = sdOV_vec4[v8 * 2], d1 = sdOV_vec4[v8 * 2 + 1];
-
-                #define COMP(i, sf, df) \
-                    float sh##i = (sf) - lse_val; \
-                    float p##i = (sh##i < -80.0f) ? 0.0f : __expf(sh##i); \
-                    float ds##i = p##i * softmax_scale * ((df) - row_dot_val);
-
-                COMP(0, s0.x, d0.x) COMP(1, s0.y, d0.y) COMP(2, s0.z, d0.z) COMP(3, s0.w, d0.w)
-                COMP(4, s1.x, d1.x) COMP(5, s1.y, d1.y) COMP(6, s1.z, d1.z) COMP(7, s1.w, d1.w)
-                #undef COMP
-
-                uint4 res;
-                asm volatile(
-                    "{ mov.b32 %0, {%4,%5}; mov.b32 %1, {%6,%7}; mov.b32 %2, {%8,%9}; mov.b32 %3, {%10,%11}; }\n"
-                    : "=r"(res.x), "=r"(res.y), "=r"(res.z), "=r"(res.w)
-                    : "h"(__half_as_ushort(__float2half_rn(ds0))),
-                      "h"(__half_as_ushort(__float2half_rn(ds1))),
-                      "h"(__half_as_ushort(__float2half_rn(ds2))),
-                      "h"(__half_as_ushort(__float2half_rn(ds3))),
-                      "h"(__half_as_ushort(__float2half_rn(ds4))),
-                      "h"(__half_as_ushort(__float2half_rn(ds5))),
-                      "h"(__half_as_ushort(__float2half_rn(ds6))),
-                      "h"(__half_as_ushort(__float2half_rn(ds7)))
-                );
-                buf[cnt++] = res;
-            }
-
-            #pragma unroll
-            for (int c = tail_start + thread_in_row; c < BLOCK_N; c += THREADS_PER_ROW) {
-                float s = (c < valid_k_rows) ? sS_row[c] : NEG_INF;
-                float dov = (c < valid_k_rows) ? sdOV_row[c] : 0.0f;
-                float p = (s - lse_val < -80.0f) ? 0.0f : __expf(s - lse_val);
-                float ds = p * softmax_scale * ((c < valid_k_rows) ? (dov - row_dot_val) : 0.0f);
-                sdS_row[c] = __float2half_rn(ds);
-            }
-
-            #pragma unroll
-            for (int i = 0; i < cnt; ++i) {
-                    const int v8 = thread_in_row + i * THREADS_PER_ROW;
-                    if (v8 < vec8_cols) {
-                        sdS_vec_u4[v8] = buf[i];
-                    }
-            }
-        }
-        __syncthreads();
-
-        const int num_tiles_m_dq    = (BLOCK_M + WMMA_M - 1) / WMMA_M;
-        const int num_tiles_n_dq    = (D + WMMA_N - 1) / WMMA_N;
-        const int num_tiles_k_dq    = (BLOCK_N + WMMA_K - 1) / WMMA_K;
-        const int total_tiles_dq    = num_tiles_m_dq * num_tiles_n_dq;
-        const int tiles_per_warp_dq = (total_tiles_dq + WARPS_PER_BLOCK - 1) / WARPS_PER_BLOCK;
-
-        for (int tile_local = 0; tile_local < tiles_per_warp_dq; ++tile_local) {
-            const int global_tile_idx = warp_id * tiles_per_warp_dq + tile_local;
-            if (global_tile_idx >= total_tiles_dq) break;
-
-            const int tile_m_idx = global_tile_idx / num_tiles_n_dq;
-            const int tile_n_idx = global_tile_idx % num_tiles_n_dq;
-
-            const int tile_m = tile_m_idx * WMMA_M;
-            const int tile_n = tile_n_idx * WMMA_N;
-
-            if (tile_m >= valid_q_rows || tile_n >= D) continue;
-
-            fragment<matrix_a, WMMA_M, WMMA_N, WMMA_K, __half, row_major> a_frag;
-            fragment<matrix_b, WMMA_M, WMMA_N, WMMA_K, __half, row_major> b_frag;
-            fragment<accumulator, WMMA_M, WMMA_N, WMMA_K, float> acc_frag;
-            fill_fragment(acc_frag, 0.0f);
-
-            #pragma unroll
-            for (int k_tile = 0; k_tile < num_tiles_k_dq; ++k_tile) {
-                const int k_offset = k_tile * WMMA_K;
-                if (k_offset >= valid_k_rows) break;
-
-                load_matrix_sync(a_frag, sdS + tile_m * S_STRIDE + k_offset, S_STRIDE);
-                load_matrix_sync(b_frag, sK + k_offset * KV_STRIDE + tile_n, KV_STRIDE);
-                mma_sync(acc_frag, a_frag, b_frag, acc_frag);
-            }
-
-            fragment<accumulator, WMMA_M, WMMA_N, WMMA_K, float> curr_frag;
-            load_matrix_sync(curr_frag, sdQ + tile_m * Q_STRIDE + tile_n, Q_STRIDE, mem_row_major);
-
-            #pragma unroll
-            for (int i = 0; i < curr_frag.num_elements; ++i) {
-                curr_frag.x[i] += acc_frag.x[i];
-            }
-            store_matrix_sync(sdQ + tile_m * Q_STRIDE + tile_n, curr_frag, Q_STRIDE, mem_row_major);
-        }
-        __syncthreads();
+#pragma unroll
+      for (int i = 0; i < curr_frag.num_elements; ++i) {
+        curr_frag.x[i] += acc_frag.x[i];
+      }
+      store_matrix_sync(sdQ + tile_m * Q_STRIDE + tile_n, curr_frag, Q_STRIDE,
+                        mem_row_major);
     }
+    __syncthreads();
+  }
 
-    const int total_fp16_x4 = (valid_q_rows * D) / 4;
-    for (int i = tid; i < total_fp16_x4; i += THREADS_PER_BLOCK) {
-        const int row = i / (D / 4);
-        const int col = (i % (D / 4)) * 4;
+  const int total_fp16_x4 = (valid_q_rows * D) / 4;
+  for (int i = tid; i < total_fp16_x4; i += THREADS_PER_BLOCK) {
+    const int row = i / (D / 4);
+    const int col = (i % (D / 4)) * 4;
 
-        const float* s_dQ_row = sdQ + row * Q_STRIDE;
+    const float* s_dQ_row = sdQ + row * Q_STRIDE;
 
-        const __half h0 = __float2half_rn(s_dQ_row[col + 0]);
-        const __half h1 = __float2half_rn(s_dQ_row[col + 1]);
-        const __half h2 = __float2half_rn(s_dQ_row[col + 2]);
-        const __half h3 = __float2half_rn(s_dQ_row[col + 3]);
+    const __half h0 = __float2half_rn(s_dQ_row[col + 0]);
+    const __half h1 = __float2half_rn(s_dQ_row[col + 1]);
+    const __half h2 = __float2half_rn(s_dQ_row[col + 2]);
+    const __half h3 = __float2half_rn(s_dQ_row[col + 3]);
 
-        asm volatile(
-            "st.global.v4.u16 [%0], {%1, %2, %3, %4};"
-            :
-            : "l"(dQ_ptr + row * D + col),
-              "h"(__half_as_ushort(h0)),
-              "h"(__half_as_ushort(h1)),
-              "h"(__half_as_ushort(h2)),
-              "h"(__half_as_ushort(h3))
-            : "memory"
-        );
-    }
+    asm volatile("st.global.v4.u16 [%0], {%1, %2, %3, %4};"
+                 :
+                 : "l"(dQ_ptr + row * D + col), "h"(__half_as_ushort(h0)),
+                   "h"(__half_as_ushort(h1)), "h"(__half_as_ushort(h2)),
+                   "h"(__half_as_ushort(h3))
+                 : "memory");
+  }
 }
 
-template<int D, bool IS_CAUSAL>
+template <int D, bool IS_CAUSAL>
 __global__ void __launch_bounds__(dKVKernelConfig<D>::THREADS_PER_BLOCK, 2)
-flash_attention_backward_dkv_kernel(
-    const __half* __restrict__ Q,
-    const __half* __restrict__ K,
-    const __half* __restrict__ V,
-    const __half* __restrict__ O,
-    const __half* __restrict__ dO,
-    const  float* __restrict__ softmax_lse,
-          __half* __restrict__ dK,
-          __half* __restrict__ dV,
-    const int B,
-    const int H,
-    const int M,
-    const int N,
-    const float softmax_scale
-) {
-    using Config = dKVKernelConfig<D>;
-    constexpr int BLOCK_M            = Config::BLOCK_M;
-    constexpr int BLOCK_N            = Config::BLOCK_N;
-    constexpr int THREADS_PER_BLOCK  = Config::THREADS_PER_BLOCK;
-    constexpr int THREADS_PER_ROW    = Config::THREADS_PER_ROW;
-    constexpr int WARPS_PER_BLOCK    = Config::WARPS_PER_BLOCK;
-    constexpr int Q_STRIDE           = Config::Q_STRIDE;
-    constexpr int KV_STRIDE          = Config::KV_STRIDE;
-    constexpr int S_STRIDE           = Config::S_STRIDE;
-    constexpr int PER_UINT4          = Config::PER_UINT4;
-    constexpr int NUM_UINT4_Q_BLOCK  = Config::NUM_UINT4_Q_BLOCK;
-    constexpr int NUM_UINT4_KV_BLOCK = Config::NUM_UINT4_KV_BLOCK;
+    flash_attention_backward_dkv_kernel(
+        const __half* __restrict__ Q, const __half* __restrict__ K,
+        const __half* __restrict__ V, const __half* __restrict__ O,
+        const __half* __restrict__ dO, const float* __restrict__ softmax_lse,
+        __half* __restrict__ dK, __half* __restrict__ dV, const int B,
+        const int H, const int M, const int N, const float softmax_scale) {
+  using Config = dKVKernelConfig<D>;
+  constexpr int BLOCK_M = Config::BLOCK_M;
+  constexpr int BLOCK_N = Config::BLOCK_N;
+  constexpr int THREADS_PER_BLOCK = Config::THREADS_PER_BLOCK;
+  constexpr int THREADS_PER_ROW = Config::THREADS_PER_ROW;
+  constexpr int WARPS_PER_BLOCK = Config::WARPS_PER_BLOCK;
+  constexpr int Q_STRIDE = Config::Q_STRIDE;
+  constexpr int KV_STRIDE = Config::KV_STRIDE;
+  constexpr int S_STRIDE = Config::S_STRIDE;
+  constexpr int PER_UINT4 = Config::PER_UINT4;
+  constexpr int NUM_UINT4_Q_BLOCK = Config::NUM_UINT4_Q_BLOCK;
+  constexpr int NUM_UINT4_KV_BLOCK = Config::NUM_UINT4_KV_BLOCK;
 
-    const float NEG_INF = -1e30f;
-    const int batch_head_id = blockIdx.z;
-    if (batch_head_id >= B * H) return;
+  const float NEG_INF = -1e30f;
+  const int batch_head_id = blockIdx.z;
+  if (batch_head_id >= B * H) return;
 
-    const int block_kv = blockIdx.x;
-    const int start_kv = block_kv * BLOCK_M;
-    if (start_kv >= N) return;
+  const int block_kv = blockIdx.x;
+  const int start_kv = block_kv * BLOCK_M;
+  if (start_kv >= N) return;
 
-    int num_q_tiles = (M + BLOCK_N - 1) / BLOCK_N;
-    const int valid_kv_rows = min(BLOCK_M, N - start_kv);
+  int num_q_tiles = (M + BLOCK_N - 1) / BLOCK_N;
+  const int valid_kv_rows = min(BLOCK_M, N - start_kv);
 
-    const int tid     = threadIdx.x;
-    const int warp_id = tid / MAX_THREADS_PER_WARP;
-    const int lane_id = tid % MAX_THREADS_PER_WARP;
+  const int tid = threadIdx.x;
+  const int warp_id = tid / MAX_THREADS_PER_WARP;
+  const int lane_id = tid % MAX_THREADS_PER_WARP;
 
-    const __half*   q_ptr = Q           + (size_t)batch_head_id * M * D;
-    const __half*   k_ptr = K           + (size_t)batch_head_id * N * D + start_kv * D;
-    const __half*   v_ptr = V           + (size_t)batch_head_id * N * D + start_kv * D;
-    const __half*   o_ptr = O           + (size_t)batch_head_id * M * D;
-    const __half*  dO_ptr = dO          + (size_t)batch_head_id * M * D;
-    const  float* lse_ptr = softmax_lse + (size_t)batch_head_id * M;
-          __half*  dK_ptr = dK          + (size_t)batch_head_id * N * D + start_kv * D;
-          __half*  dV_ptr = dV          + (size_t)batch_head_id * N * D + start_kv * D;
+  const __half* q_ptr = Q + (size_t)batch_head_id * M * D;
+  const __half* k_ptr = K + (size_t)batch_head_id * N * D + start_kv * D;
+  const __half* v_ptr = V + (size_t)batch_head_id * N * D + start_kv * D;
+  const __half* o_ptr = O + (size_t)batch_head_id * M * D;
+  const __half* dO_ptr = dO + (size_t)batch_head_id * M * D;
+  const float* lse_ptr = softmax_lse + (size_t)batch_head_id * M;
+  __half* dK_ptr = dK + (size_t)batch_head_id * N * D + start_kv * D;
+  __half* dV_ptr = dV + (size_t)batch_head_id * N * D + start_kv * D;
 
-    extern __shared__ char smem_raw[];
-    init_smem<Config>(smem_raw);
-    auto& smem = *reinterpret_cast<typename Config::SmemLayout*>(smem_raw);
+  extern __shared__ char smem_raw[];
+  init_smem<Config>(smem_raw);
+  auto& smem = *reinterpret_cast<typename Config::SmemLayout*>(smem_raw);
 
-    __half* sK       = smem.k;
-    __half* sV       = smem.v;
-    __half* sdO      = smem.reuse_qdO.dO;
-    __half* sQ       = smem.reuse_qdO.q;
-     float* sS       = smem.reuse_sp.s;
-    __half* sP       = smem.reuse_sp.p;
-     float* sdOV     = smem.reuse_dOVS.dOV;
-    __half* sdS      = smem.reuse_dOVS.dS;
-     float* sRowDot  = smem.row_dot;
-     float* sLse     = smem.lse;
-     float* sdK      = smem.dK;
-     float* sdV      = smem.dV;
+  __half* sK = smem.k;
+  __half* sV = smem.v;
+  __half* sdO = smem.reuse_qdO.dO;
+  __half* sQ = smem.reuse_qdO.q;
+  float* sS = smem.reuse_sp.s;
+  __half* sP = smem.reuse_sp.p;
+  float* sdOV = smem.reuse_dOVS.dOV;
+  __half* sdS = smem.reuse_dOVS.dS;
+  float* sRowDot = smem.row_dot;
+  float* sLse = smem.lse;
+  float* sdK = smem.dK;
+  float* sdV = smem.dV;
 
-    const int  d_stride_uint4 = (D + PER_UINT4 - 1) / PER_UINT4;
-    const int  q_stride_uint4 = (Q_STRIDE  + PER_UINT4 - 1) / PER_UINT4;
-    const int kv_stride_uint4 = (KV_STRIDE + PER_UINT4 - 1) / PER_UINT4;
+  const int d_stride_uint4 = (D + PER_UINT4 - 1) / PER_UINT4;
+  const int q_stride_uint4 = (Q_STRIDE + PER_UINT4 - 1) / PER_UINT4;
+  const int kv_stride_uint4 = (KV_STRIDE + PER_UINT4 - 1) / PER_UINT4;
 
-    const uint4* k_vec = reinterpret_cast<const uint4*>(k_ptr);
-    const uint4* v_vec = reinterpret_cast<const uint4*>(v_ptr);
-    uint4* sK_vec = reinterpret_cast<uint4*>(sK);
-    uint4* sV_vec = reinterpret_cast<uint4*>(sV);
+  const uint4* k_vec = reinterpret_cast<const uint4*>(k_ptr);
+  const uint4* v_vec = reinterpret_cast<const uint4*>(v_ptr);
+  uint4* sK_vec = reinterpret_cast<uint4*>(sK);
+  uint4* sV_vec = reinterpret_cast<uint4*>(sV);
 
-    #pragma unroll 2
-    for (int idx = tid; idx < NUM_UINT4_KV_BLOCK; idx += THREADS_PER_BLOCK) {
-        const int row = idx / d_stride_uint4;
-        const int vec_col = idx % d_stride_uint4;
+#pragma unroll 2
+  for (int idx = tid; idx < NUM_UINT4_KV_BLOCK; idx += THREADS_PER_BLOCK) {
+    const int row = idx / d_stride_uint4;
+    const int vec_col = idx % d_stride_uint4;
 
-        uint4 k_val = make_uint4(0, 0, 0, 0);
-        uint4 v_val = make_uint4(0, 0, 0, 0);
+    uint4 k_val = make_uint4(0, 0, 0, 0);
+    uint4 v_val = make_uint4(0, 0, 0, 0);
 
-        if (row < valid_kv_rows && vec_col < d_stride_uint4) {
-            k_val = __ldg(&k_vec[row * d_stride_uint4 + vec_col]);
-            v_val = __ldg(&v_vec[row * d_stride_uint4 + vec_col]);
-        }
-        sK_vec[row * kv_stride_uint4 + vec_col] = k_val;
-        sV_vec[row * kv_stride_uint4 + vec_col] = v_val;
+    if (row < valid_kv_rows && vec_col < d_stride_uint4) {
+      k_val = __ldg(&k_vec[row * d_stride_uint4 + vec_col]);
+      v_val = __ldg(&v_vec[row * d_stride_uint4 + vec_col]);
+    }
+    sK_vec[row * kv_stride_uint4 + vec_col] = k_val;
+    sV_vec[row * kv_stride_uint4 + vec_col] = v_val;
+  }
+  __syncthreads();
+
+  for (int block_n = 0; block_n < num_q_tiles; ++block_n) {
+    const int start_col = block_n * BLOCK_N;
+    if (start_col >= M) break;
+    const int valid_q_rows = min(BLOCK_N, M - start_col);
+
+    if constexpr (IS_CAUSAL) {
+      if (start_kv >= start_col + valid_q_rows) {
+        continue;
+      }
+    }
+
+    const uint4* q_vec = reinterpret_cast<const uint4*>(q_ptr + start_col * D);
+    uint4* sQ_vec = reinterpret_cast<uint4*>(sdO);
+
+#pragma unroll 2
+    for (int idx = tid; idx < NUM_UINT4_Q_BLOCK; idx += THREADS_PER_BLOCK) {
+      const int row = idx / d_stride_uint4;
+      const int vec_col = idx % d_stride_uint4;
+      uint4 q_val = make_uint4(0, 0, 0, 0);
+      if (row < valid_q_rows && vec_col < d_stride_uint4) {
+        q_val = __ldg(&q_vec[row * d_stride_uint4 + vec_col]);
+      }
+      sQ_vec[row * q_stride_uint4 + vec_col] = q_val;
     }
     __syncthreads();
 
-    for (int block_n = 0; block_n < num_q_tiles; ++block_n) {
-        const int start_col = block_n * BLOCK_N;
-        if (start_col >= M) break;
-        const int valid_q_rows = min(BLOCK_N, M - start_col);
+    const int num_tiles_m_qk = (BLOCK_N + WMMA_M - 1) / WMMA_M;
+    const int num_tiles_n_qk = (BLOCK_M + WMMA_N - 1) / WMMA_N;
+    const int num_tiles_k_qk = (D + WMMA_K - 1) / WMMA_K;
+    const int total_tiles_qk = num_tiles_m_qk * num_tiles_n_qk;
+    const int tiles_per_warp_qk =
+        (total_tiles_qk + WARPS_PER_BLOCK - 1) / WARPS_PER_BLOCK;
+    const unsigned row_causal = (lane_id & 0b1) + ((lane_id >> 2) & 0b1) * 8 +
+                                ((lane_id >> 4) & 0b1) * 4;
+    const unsigned col_causal =
+        ((lane_id >> 1) & 0b1) * 2 + ((lane_id >> 3) & 0b1) * 8;
 
-        if constexpr (IS_CAUSAL) {
-            if (start_kv >= start_col + valid_q_rows) { continue; }
+    for (int tile_local = 0; tile_local < tiles_per_warp_qk; ++tile_local) {
+      const int tile_idx = warp_id * tiles_per_warp_qk + tile_local;
+      if (tile_idx >= total_tiles_qk) break;
+
+      const int tile_m_idx = tile_idx / num_tiles_n_qk;
+      const int tile_n_idx = tile_idx % num_tiles_n_qk;
+
+      const int tile_m = tile_m_idx * WMMA_M;
+      const int tile_n = tile_n_idx * WMMA_N;
+
+      if (tile_m >= valid_q_rows || tile_n >= valid_kv_rows) continue;
+
+      fragment<matrix_a, WMMA_M, WMMA_N, WMMA_K, half, row_major> a_frag;
+      fragment<matrix_b, WMMA_M, WMMA_N, WMMA_K, half, col_major> b_frag;
+      fragment<accumulator, WMMA_M, WMMA_N, WMMA_K, float> acc_frag;
+      fill_fragment(acc_frag, 0.0f);
+
+#pragma unroll
+      for (int k_tile = 0; k_tile < num_tiles_k_qk; ++k_tile) {
+        const int k_offset = k_tile * WMMA_K;
+        if (k_offset >= D) break;
+        load_matrix_sync(a_frag, sQ + tile_m * Q_STRIDE + k_offset, Q_STRIDE);
+        load_matrix_sync(b_frag, sK + tile_n * KV_STRIDE + k_offset, KV_STRIDE);
+        mma_sync(acc_frag, a_frag, b_frag, acc_frag);
+      }
+
+      if constexpr (IS_CAUSAL) {
+#pragma unroll
+        for (int i = 0; i < acc_frag.num_elements; ++i) {
+          const unsigned col = col_causal + (i & 0b1) + ((i >> 2) & 0b1) * 4;
+          const unsigned row = row_causal + ((i >> 1) & 0b1) * 2;
+
+          const int global_m = start_col + tile_m + row;
+          const int global_n = start_kv + tile_n + col;
+
+          const bool is_valid = (global_m < start_col + valid_q_rows) &&
+                                (global_n < start_kv + valid_kv_rows);
+
+          acc_frag.x[i] =
+              is_valid ? ((global_n > global_m) ? NEG_INF
+                                                : acc_frag.x[i] * softmax_scale)
+                       : NEG_INF;
         }
-
-        const uint4* q_vec = reinterpret_cast<const uint4*>(q_ptr + start_col * D);
-        uint4*      sQ_vec = reinterpret_cast<uint4*>(sdO);
-
-        #pragma unroll 2
-        for (int idx = tid; idx < NUM_UINT4_Q_BLOCK; idx += THREADS_PER_BLOCK) {
-            const int row = idx / d_stride_uint4;
-            const int vec_col = idx % d_stride_uint4;
-            uint4 q_val = make_uint4(0, 0, 0, 0);
-            if (row < valid_q_rows && vec_col < d_stride_uint4) {
-                q_val = __ldg(&q_vec[row * d_stride_uint4 + vec_col]);
-            }
-            sQ_vec[row * q_stride_uint4 + vec_col] = q_val;
+      } else {
+#pragma unroll
+        for (int i = 0; i < acc_frag.num_elements; ++i) {
+          acc_frag.x[i] *= softmax_scale;
         }
-        __syncthreads();
+      }
+      store_matrix_sync(sS + tile_m * S_STRIDE + tile_n, acc_frag, S_STRIDE,
+                        mem_row_major);
+    }
+    __syncthreads();
 
-        const int num_tiles_m_qk    = (BLOCK_N + WMMA_M - 1) / WMMA_M;
-        const int num_tiles_n_qk    = (BLOCK_M + WMMA_N - 1) / WMMA_N;
-        const int num_tiles_k_qk    = (D + WMMA_K - 1) / WMMA_K;
-        const int total_tiles_qk    = num_tiles_m_qk * num_tiles_n_qk;
-        const int tiles_per_warp_qk = (total_tiles_qk + WARPS_PER_BLOCK - 1) / WARPS_PER_BLOCK;
-        const unsigned row_causal   = (lane_id & 0b1) + ((lane_id >> 2) & 0b1) * 8 + ((lane_id >> 4) & 0b1) * 4;
-        const unsigned col_causal   = ((lane_id >> 1) & 0b1) * 2 + ((lane_id >> 3) & 0b1) * 8;
+    const uint4* do_vec =
+        reinterpret_cast<const uint4*>(dO_ptr + start_col * D);
+    uint4* sdO_vec = reinterpret_cast<uint4*>(sdO);
 
-        for (int tile_local = 0; tile_local < tiles_per_warp_qk; ++tile_local) {
-            const int tile_idx = warp_id * tiles_per_warp_qk + tile_local;
-            if (tile_idx >= total_tiles_qk) break;
+#pragma unroll 2
+    for (int idx = tid; idx < NUM_UINT4_Q_BLOCK; idx += THREADS_PER_BLOCK) {
+      const int row = idx / d_stride_uint4;
+      const int vec_col = idx % d_stride_uint4;
+      uint4 do_val = make_uint4(0, 0, 0, 0);
+      if (row < valid_q_rows && vec_col < d_stride_uint4) {
+        do_val = __ldg(&do_vec[row * d_stride_uint4 + vec_col]);
+      }
+      sdO_vec[row * q_stride_uint4 + vec_col] = do_val;
+    }
+    __syncthreads();
 
-            const int tile_m_idx = tile_idx / num_tiles_n_qk;
-            const int tile_n_idx = tile_idx % num_tiles_n_qk;
+    const __half* current_o_ptr = o_ptr + start_col * D;
 
-            const int tile_m = tile_m_idx * WMMA_M;
-            const int tile_n = tile_n_idx * WMMA_N;
+    if (tid < valid_q_rows * THREADS_PER_ROW) {
+      const int row = tid / THREADS_PER_ROW;
+      const int thread_in_row = tid % THREADS_PER_ROW;
+      const int fp16_x4_per_row = D / 4;
+      const int work_per_thread =
+          (fp16_x4_per_row + THREADS_PER_ROW - 1) / THREADS_PER_ROW;
+      const unsigned mask =
+          (valid_q_rows == BLOCK_N) ? 0xFFFFFFFFU : __activemask();
 
-            if (tile_m >= valid_q_rows || tile_n >= valid_kv_rows) continue;
+      float thread_dot = 0.0f;
 
-            fragment<matrix_a, WMMA_M, WMMA_N, WMMA_K, half, row_major> a_frag;
-            fragment<matrix_b, WMMA_M, WMMA_N, WMMA_K, half, col_major> b_frag;
-            fragment<accumulator, WMMA_M, WMMA_N, WMMA_K, float> acc_frag;
-            fill_fragment(acc_frag, 0.0f);
+#pragma unroll
+      for (int j = 0; j < work_per_thread; ++j) {
+        const int chunk_idx = thread_in_row + j * THREADS_PER_ROW;
+        if (chunk_idx >= fp16_x4_per_row) break;
+        const int col = chunk_idx * 4;
 
-            #pragma unroll
-            for (int k_tile = 0; k_tile < num_tiles_k_qk; ++k_tile) {
-                const int k_offset = k_tile * WMMA_K;
-                if (k_offset >= D) break;
-                load_matrix_sync(a_frag, sQ + tile_m * Q_STRIDE + k_offset, Q_STRIDE);
-                load_matrix_sync(b_frag, sK + tile_n * KV_STRIDE + k_offset, KV_STRIDE);
-                mma_sync(acc_frag, a_frag, b_frag, acc_frag);
-            }
+        const half* o_addr = current_o_ptr + row * D + col;
+        ushort o_h0, o_h1, o_h2, o_h3;
+        asm volatile("ld.global.v4.u16 {%0, %1, %2, %3}, [%4];"
+                     : "=h"(o_h0), "=h"(o_h1), "=h"(o_h2), "=h"(o_h3)
+                     : "l"(o_addr)
+                     : "memory");
 
-            if constexpr (IS_CAUSAL) {
-                #pragma unroll
-                for (int i = 0; i < acc_frag.num_elements; ++i) {
-                    const unsigned col = col_causal + (i & 0b1) + ((i >> 2) & 0b1) * 4;
-                    const unsigned row = row_causal + ((i >> 1) & 0b1) * 2;
+        const half* dO_addr = sdO + row * Q_STRIDE + col;
+        ushort d_h0, d_h1, d_h2, d_h3;
+        const uint32_t ptr_dO = static_cast<uint32_t>(
+            reinterpret_cast<uintptr_t>(__cvta_generic_to_shared(dO_addr)));
+        asm volatile("ld.shared.v4.u16 {%0, %1, %2, %3}, [%4];"
+                     : "=h"(d_h0), "=h"(d_h1), "=h"(d_h2), "=h"(d_h3)
+                     : "r"(ptr_dO)
+                     : "memory");
 
-                    const int global_m = start_col + tile_m + row;
-                    const int global_n = start_kv  + tile_n + col;
+        const float fo_0 = __half2float(__ushort_as_half(o_h0));
+        const float fo_1 = __half2float(__ushort_as_half(o_h1));
+        const float fo_2 = __half2float(__ushort_as_half(o_h2));
+        const float fo_3 = __half2float(__ushort_as_half(o_h3));
 
-                    const bool is_valid = (global_m < start_col + valid_q_rows) &&
-                                          (global_n < start_kv  + valid_kv_rows);
+        const float fd_0 = __half2float(__ushort_as_half(d_h0));
+        const float fd_1 = __half2float(__ushort_as_half(d_h1));
+        const float fd_2 = __half2float(__ushort_as_half(d_h2));
+        const float fd_3 = __half2float(__ushort_as_half(d_h3));
 
-                    acc_frag.x[i] = is_valid
-                        ? ((global_n > global_m) ? NEG_INF : acc_frag.x[i] * softmax_scale)
-                        : NEG_INF;
-                }
-            } else {
-                #pragma unroll
-                for (int i = 0; i < acc_frag.num_elements; ++i) {
-                    acc_frag.x[i] *= softmax_scale;
-                }
-            }
-            store_matrix_sync(sS + tile_m * S_STRIDE + tile_n, acc_frag, S_STRIDE, mem_row_major);
-        }
-        __syncthreads();
+        thread_dot = __fmaf_rn(fo_0, fd_0, thread_dot);
+        thread_dot = __fmaf_rn(fo_1, fd_1, thread_dot);
+        thread_dot = __fmaf_rn(fo_2, fd_2, thread_dot);
+        thread_dot = __fmaf_rn(fo_3, fd_3, thread_dot);
+      }
 
-        const uint4* do_vec = reinterpret_cast<const uint4*>(dO_ptr + start_col * D);
-        uint4*      sdO_vec = reinterpret_cast<uint4*>(sdO);
+#pragma unroll
+      for (int o = THREADS_PER_ROW / 2; o > 0; o >>= 1)
+        thread_dot += __shfl_down_sync(mask, thread_dot, o, THREADS_PER_ROW);
 
-        #pragma unroll 2
-        for (int idx = tid; idx < NUM_UINT4_Q_BLOCK; idx += THREADS_PER_BLOCK) {
-            const int row = idx / d_stride_uint4;
-            const int vec_col = idx % d_stride_uint4;
-            uint4 do_val = make_uint4(0, 0, 0, 0);
-            if (row < valid_q_rows && vec_col < d_stride_uint4) {
-                do_val = __ldg(&do_vec[row * d_stride_uint4 + vec_col]);
-            }
-            sdO_vec[row * q_stride_uint4 + vec_col] = do_val;
-        }
-        __syncthreads();
-
-        const __half* current_o_ptr = o_ptr + start_col * D;
-
-        if (tid < valid_q_rows * THREADS_PER_ROW) {
-            const int row = tid / THREADS_PER_ROW;
-            const int thread_in_row = tid % THREADS_PER_ROW;
-            const int fp16_x4_per_row = D / 4;
-            const int work_per_thread = (fp16_x4_per_row + THREADS_PER_ROW - 1) / THREADS_PER_ROW;
-            const unsigned mask = (valid_q_rows == BLOCK_N) ? 0xFFFFFFFFU : __activemask();
-
-            float thread_dot = 0.0f;
-
-            #pragma unroll
-            for (int j = 0; j < work_per_thread; ++j) {
-                const int chunk_idx = thread_in_row + j * THREADS_PER_ROW;
-                if (chunk_idx >= fp16_x4_per_row) break;
-                const int col = chunk_idx * 4;
-
-                const half* o_addr = current_o_ptr + row * D + col;
-                ushort o_h0, o_h1, o_h2, o_h3;
-                asm volatile(
-                    "ld.global.v4.u16 {%0, %1, %2, %3}, [%4];"
-                    : "=h"(o_h0), "=h"(o_h1), "=h"(o_h2), "=h"(o_h3)
-                    : "l"(o_addr)
-                    : "memory"
-                );
-
-                const half* dO_addr = sdO + row * Q_STRIDE + col;
-                ushort d_h0, d_h1, d_h2, d_h3;
-                const uint32_t ptr_dO = static_cast<uint32_t>(reinterpret_cast<uintptr_t>(__cvta_generic_to_shared(dO_addr)));
-                asm volatile(
-                    "ld.shared.v4.u16 {%0, %1, %2, %3}, [%4];"
-                    : "=h"(d_h0), "=h"(d_h1), "=h"(d_h2), "=h"(d_h3)
-                    : "r"(ptr_dO)
-                    : "memory"
-                );
-
-                const float fo_0 = __half2float(__ushort_as_half(o_h0));
-                const float fo_1 = __half2float(__ushort_as_half(o_h1));
-                const float fo_2 = __half2float(__ushort_as_half(o_h2));
-                const float fo_3 = __half2float(__ushort_as_half(o_h3));
-
-                const float fd_0 = __half2float(__ushort_as_half(d_h0));
-                const float fd_1 = __half2float(__ushort_as_half(d_h1));
-                const float fd_2 = __half2float(__ushort_as_half(d_h2));
-                const float fd_3 = __half2float(__ushort_as_half(d_h3));
-
-                thread_dot = __fmaf_rn(fo_0, fd_0, thread_dot);
-                thread_dot = __fmaf_rn(fo_1, fd_1, thread_dot);
-                thread_dot = __fmaf_rn(fo_2, fd_2, thread_dot);
-                thread_dot = __fmaf_rn(fo_3, fd_3, thread_dot);
-            }
-
-            #pragma unroll
-            for (int o = THREADS_PER_ROW / 2; o > 0; o >>= 1)
-                thread_dot += __shfl_down_sync(mask, thread_dot, o, THREADS_PER_ROW);
-
-            if (thread_in_row == 0) { sRowDot[row] = thread_dot; }
-        }
-
-        if (tid < valid_q_rows) { sLse[tid] = lse_ptr[start_col + tid]; }
-        __syncthreads();
-
-        const int num_tiles_m_dov    = (BLOCK_N + WMMA_M - 1) / WMMA_M;
-        const int num_tiles_n_dov    = (BLOCK_M + WMMA_N - 1) / WMMA_N;
-        const int num_tiles_k_dov    = (D + WMMA_K - 1) / WMMA_K;
-        const int total_tiles_dov    = num_tiles_m_dov * num_tiles_n_dov;
-        const int tiles_per_warp_dov = (total_tiles_dov + WARPS_PER_BLOCK - 1) / WARPS_PER_BLOCK;
-
-        for (int tile_local = 0; tile_local < tiles_per_warp_dov; ++tile_local) {
-            const int tile_idx = warp_id * tiles_per_warp_dov + tile_local;
-            if (tile_idx >= total_tiles_dov) break;
-
-            const int tile_m_idx = tile_idx / num_tiles_n_dov;
-            const int tile_n_idx = tile_idx % num_tiles_n_dov;
-
-            const int tile_m = tile_m_idx * WMMA_M;
-            const int tile_n = tile_n_idx * WMMA_N;
-
-            if (tile_m >= valid_q_rows || tile_n >= valid_kv_rows) continue;
-
-            fragment<matrix_a, WMMA_M, WMMA_N, WMMA_K, half, row_major> a_frag;
-            fragment<matrix_b, WMMA_M, WMMA_N, WMMA_K, half, col_major> b_frag;
-            fragment<accumulator, WMMA_M, WMMA_N, WMMA_K, float> acc_frag;
-            fill_fragment(acc_frag, 0.0f);
-
-            #pragma unroll
-            for (int k_tile = 0; k_tile < num_tiles_k_dov; ++k_tile) {
-                const int k_offset = k_tile * WMMA_K;
-                if (k_offset >= D) break;
-                load_matrix_sync(a_frag, sdO + tile_m * Q_STRIDE + k_offset, Q_STRIDE);
-                load_matrix_sync(b_frag, sV + tile_n * KV_STRIDE + k_offset, KV_STRIDE);
-                mma_sync(acc_frag, a_frag, b_frag, acc_frag);
-            }
-            store_matrix_sync(sdOV + tile_m * S_STRIDE + tile_n, acc_frag, S_STRIDE, mem_row_major);
-        }
-        __syncthreads();
-
-        const int total_elements = BLOCK_N * BLOCK_M;
-        const int total_pairs = (total_elements + 1) / 2;
-
-        #pragma unroll 2
-        for (int i = tid; i < total_pairs; i += THREADS_PER_BLOCK) {
-            const int linear_idx0 = i * 2;
-            const int linear_idx1 = linear_idx0 + 1;
-
-            const int row0 = linear_idx0 / BLOCK_M;
-            const int col0 = linear_idx0 % BLOCK_M;
-            const bool has_pair = (linear_idx1 < total_elements);
-            const int row1 = has_pair ? linear_idx1 / BLOCK_M : row0;
-            const int col1 = has_pair ? linear_idx1 % BLOCK_M : col0 + 1;
-
-            float s0 = 0.0f, s1 = 0.0f;
-            float dov0 = 0.0f, dov1 = 0.0f;
-
-            const bool in_bounds0 = (row0 < valid_q_rows) && (col0 < valid_kv_rows);
-            const bool causal_ok0 = !IS_CAUSAL || ((start_kv + col0) <= (start_col + row0));
-            const bool valid0 = in_bounds0 && causal_ok0;
-
-            bool valid1 = false;
-            if (has_pair) {
-                const bool in_bounds1 = (row1 < valid_q_rows) && (col1 < valid_kv_rows);
-                const bool causal_ok1 = !IS_CAUSAL || ((start_kv + col1) <= (start_col + row1));
-                valid1 = in_bounds1 && causal_ok1;
-            }
-
-            if (valid0) { s0 = sS[row0 * S_STRIDE + col0]; dov0 = sdOV[row0 * S_STRIDE + col0]; } else { s0 = NEG_INF; }
-            if (valid1) { s1 = sS[row1 * S_STRIDE + col1]; dov1 = sdOV[row1 * S_STRIDE + col1]; } else { s1 = NEG_INF; }
-
-            float lse0 = sLse[row0];
-            float lse1 = (valid1 && row1 != row0) ? sLse[row1] : lse0;
-            float row_dot0 = sRowDot[row0];
-            float row_dot1 = (valid1 && row1 != row0) ? sRowDot[row1] : row_dot0;
-
-            float shifted0 = s0 - lse0;
-            float shifted1 = s1 - lse1;
-
-            float p0 = (shifted0 < -80.0f) ? 0.0f : __expf(shifted0);
-            float p1 = (shifted1 < -80.0f) ? 0.0f : __expf(shifted1);
-
-            float diff0 = dov0 - row_dot0;
-            float diff1 = dov1 - row_dot1;
-            float ds0 = valid0 ? fmaf(p0, softmax_scale * diff0, 0.0f) : 0.0f;
-            float ds1 = valid1 ? fmaf(p1, softmax_scale * diff1, 0.0f) : 0.0f;
-
-            __half2 p_h2 = __float22half2_rn(make_float2(p0, p1));
-            __half2 ds_h2 = __float22half2_rn(make_float2(ds0, ds1));
-
-            if (col1 < BLOCK_M && row1 == row0) {
-                __half* p_dst  = sP  + row0 * BLOCK_M + col0;
-                __half* ds_dst = sdS + row0 * BLOCK_M + col0;
-                p_dst[0]  = p_h2.x;  p_dst[1]  = p_h2.y;
-                ds_dst[0] = ds_h2.x; ds_dst[1] = ds_h2.y;
-            } else {
-                if (valid0) { sP[row0 * BLOCK_M + col0] = p_h2.x; sdS[row0 * BLOCK_M + col0] = ds_h2.x; }
-                if (valid1) { sP[row1 * BLOCK_M + col1] = p_h2.y; sdS[row1 * BLOCK_M + col1] = ds_h2.y; }
-            }
-        }
-        __syncthreads();
-
-        const int num_tiles_m_dv    = (BLOCK_M + WMMA_M - 1) / WMMA_M;
-        const int num_tiles_n_dv    = (D + WMMA_N - 1) / WMMA_N;
-        const int num_tiles_k_dv    = (BLOCK_N + WMMA_K - 1) / WMMA_K;
-        const int total_tiles_dv    = num_tiles_m_dv * num_tiles_n_dv;
-        const int tiles_per_warp_dv = (total_tiles_dv + WARPS_PER_BLOCK - 1) / WARPS_PER_BLOCK;
-
-        for (int tile_local = 0; tile_local < tiles_per_warp_dv; ++tile_local) {
-            const int tile_idx = warp_id * tiles_per_warp_dv + tile_local;
-            if (tile_idx >= total_tiles_dv) break;
-
-            const int tile_m_idx = tile_idx / num_tiles_n_dv;
-            const int tile_n_idx = tile_idx % num_tiles_n_dv;
-
-            const int tile_m = tile_m_idx * WMMA_M;
-            const int tile_n = tile_n_idx * WMMA_N;
-
-            if (tile_m >= valid_kv_rows || tile_n >= D) continue;
-
-            fragment<matrix_a, WMMA_M, WMMA_N, WMMA_K, half, col_major> a_frag;
-            fragment<matrix_b, WMMA_M, WMMA_N, WMMA_K, half, row_major> b_frag;
-            fragment<accumulator, WMMA_M, WMMA_N, WMMA_K, float> acc_frag;
-            load_matrix_sync(acc_frag, sdV + tile_m * KV_STRIDE + tile_n, KV_STRIDE, mem_row_major);
-
-            #pragma unroll
-            for (int k_tile = 0; k_tile < num_tiles_k_dv; ++k_tile) {
-                const int k_offset = k_tile * WMMA_K;
-                if (k_offset >= valid_q_rows) break;
-
-                load_matrix_sync(a_frag, sP + k_offset * BLOCK_M + tile_m, BLOCK_M);
-                load_matrix_sync(b_frag, sdO + k_offset * Q_STRIDE + tile_n, Q_STRIDE);
-                mma_sync(acc_frag, a_frag, b_frag, acc_frag);
-            }
-            store_matrix_sync(sdV + tile_m * KV_STRIDE + tile_n, acc_frag, KV_STRIDE, mem_row_major);
-        }
-        __syncthreads();
-
-        __half* sQ = sdO;
-        #pragma unroll 2
-        for (int idx = tid; idx < NUM_UINT4_Q_BLOCK; idx += THREADS_PER_BLOCK) {
-            const int row = idx / d_stride_uint4;
-            const int vec_col = idx % d_stride_uint4;
-            uint4 q_val = make_uint4(0, 0, 0, 0);
-            if (row < valid_q_rows && vec_col < d_stride_uint4) {
-                q_val = __ldg(&q_vec[row * d_stride_uint4 + vec_col]);
-            }
-            sQ_vec[row * q_stride_uint4 + vec_col] = q_val;
-        }
-        __syncthreads();
-
-        const int num_tiles_m_dk    = (BLOCK_M + WMMA_M - 1) / WMMA_M;
-        const int num_tiles_n_dk    = (D + WMMA_N - 1) / WMMA_N;
-        const int num_tiles_k_dk    = (BLOCK_N + WMMA_K - 1) / WMMA_K;
-        const int total_tiles_dk    = num_tiles_m_dk * num_tiles_n_dk;
-        const int tiles_per_warp_dk = (total_tiles_dk + WARPS_PER_BLOCK - 1) / WARPS_PER_BLOCK;
-
-        for (int tile_local = 0; tile_local < tiles_per_warp_dk; ++tile_local) {
-            const int tile_idx = warp_id * tiles_per_warp_dk + tile_local;
-            if (tile_idx >= total_tiles_dk) break;
-
-            const int tile_m_idx = tile_idx / num_tiles_n_dk;
-            const int tile_n_idx = tile_idx % num_tiles_n_dk;
-
-            const int tile_m = tile_m_idx * WMMA_M;
-            const int tile_n = tile_n_idx * WMMA_N;
-
-            if (tile_m >= valid_kv_rows || tile_n >= D) continue;
-
-            fragment<matrix_a, WMMA_M, WMMA_N, WMMA_K, half, col_major> a_frag;
-            fragment<matrix_b, WMMA_M, WMMA_N, WMMA_K, half, row_major> b_frag;
-            fragment<accumulator, WMMA_M, WMMA_N, WMMA_K, float> acc_frag;
-            load_matrix_sync(acc_frag, sdK + tile_m * KV_STRIDE + tile_n, KV_STRIDE, mem_row_major);
-
-            #pragma unroll
-            for (int k_tile = 0; k_tile < num_tiles_k_dk; ++k_tile) {
-                const int k_offset = k_tile * WMMA_K;
-                if (k_offset >= valid_q_rows) break;
-
-                load_matrix_sync(a_frag, sdS + k_offset * BLOCK_M + tile_m, BLOCK_M);
-                load_matrix_sync(b_frag, sQ + k_offset * Q_STRIDE + tile_n, Q_STRIDE);
-                mma_sync(acc_frag, a_frag, b_frag, acc_frag);
-            }
-            store_matrix_sync(sdK + tile_m * KV_STRIDE + tile_n, acc_frag, KV_STRIDE, mem_row_major);
-        }
-        __syncthreads();
+      if (thread_in_row == 0) {
+        sRowDot[row] = thread_dot;
+      }
     }
 
-    const int total_fp16_x4 = (valid_kv_rows * D) / 4;
-    for (int i = tid; i < total_fp16_x4; i += THREADS_PER_BLOCK) {
-        const int row = i / (D / 4);
-        const int col = (i % (D / 4)) * 4;
-
-        const float* s_dK_row = sdK + row * KV_STRIDE;
-        const float* s_dV_row = sdV + row * KV_STRIDE;
-
-        const __half hk0 = __float2half_rn(s_dK_row[col + 0]);
-        const __half hk1 = __float2half_rn(s_dK_row[col + 1]);
-        const __half hk2 = __float2half_rn(s_dK_row[col + 2]);
-        const __half hk3 = __float2half_rn(s_dK_row[col + 3]);
-
-        const __half hv0 = __float2half_rn(s_dV_row[col + 0]);
-        const __half hv1 = __float2half_rn(s_dV_row[col + 1]);
-        const __half hv2 = __float2half_rn(s_dV_row[col + 2]);
-        const __half hv3 = __float2half_rn(s_dV_row[col + 3]);
-
-        asm volatile(
-            "st.global.v4.u16 [%0], {%1, %2, %3, %4};"
-            :
-            : "l"(dK_ptr + row * D + col),
-              "h"(__half_as_ushort(hk0)),
-              "h"(__half_as_ushort(hk1)),
-              "h"(__half_as_ushort(hk2)),
-              "h"(__half_as_ushort(hk3))
-            : "memory"
-        );
-
-        asm volatile(
-            "st.global.v4.u16 [%0], {%1, %2, %3, %4};"
-            :
-            : "l"(dV_ptr + row * D + col),
-              "h"(__half_as_ushort(hv0)),
-              "h"(__half_as_ushort(hv1)),
-              "h"(__half_as_ushort(hv2)),
-              "h"(__half_as_ushort(hv3))
-            : "memory"
-        );
+    if (tid < valid_q_rows) {
+      sLse[tid] = lse_ptr[start_col + tid];
     }
+    __syncthreads();
+
+    const int num_tiles_m_dov = (BLOCK_N + WMMA_M - 1) / WMMA_M;
+    const int num_tiles_n_dov = (BLOCK_M + WMMA_N - 1) / WMMA_N;
+    const int num_tiles_k_dov = (D + WMMA_K - 1) / WMMA_K;
+    const int total_tiles_dov = num_tiles_m_dov * num_tiles_n_dov;
+    const int tiles_per_warp_dov =
+        (total_tiles_dov + WARPS_PER_BLOCK - 1) / WARPS_PER_BLOCK;
+
+    for (int tile_local = 0; tile_local < tiles_per_warp_dov; ++tile_local) {
+      const int tile_idx = warp_id * tiles_per_warp_dov + tile_local;
+      if (tile_idx >= total_tiles_dov) break;
+
+      const int tile_m_idx = tile_idx / num_tiles_n_dov;
+      const int tile_n_idx = tile_idx % num_tiles_n_dov;
+
+      const int tile_m = tile_m_idx * WMMA_M;
+      const int tile_n = tile_n_idx * WMMA_N;
+
+      if (tile_m >= valid_q_rows || tile_n >= valid_kv_rows) continue;
+
+      fragment<matrix_a, WMMA_M, WMMA_N, WMMA_K, half, row_major> a_frag;
+      fragment<matrix_b, WMMA_M, WMMA_N, WMMA_K, half, col_major> b_frag;
+      fragment<accumulator, WMMA_M, WMMA_N, WMMA_K, float> acc_frag;
+      fill_fragment(acc_frag, 0.0f);
+
+#pragma unroll
+      for (int k_tile = 0; k_tile < num_tiles_k_dov; ++k_tile) {
+        const int k_offset = k_tile * WMMA_K;
+        if (k_offset >= D) break;
+        load_matrix_sync(a_frag, sdO + tile_m * Q_STRIDE + k_offset, Q_STRIDE);
+        load_matrix_sync(b_frag, sV + tile_n * KV_STRIDE + k_offset, KV_STRIDE);
+        mma_sync(acc_frag, a_frag, b_frag, acc_frag);
+      }
+      store_matrix_sync(sdOV + tile_m * S_STRIDE + tile_n, acc_frag, S_STRIDE,
+                        mem_row_major);
+    }
+    __syncthreads();
+
+    const int total_elements = BLOCK_N * BLOCK_M;
+    const int total_pairs = (total_elements + 1) / 2;
+
+#pragma unroll 2
+    for (int i = tid; i < total_pairs; i += THREADS_PER_BLOCK) {
+      const int linear_idx0 = i * 2;
+      const int linear_idx1 = linear_idx0 + 1;
+
+      const int row0 = linear_idx0 / BLOCK_M;
+      const int col0 = linear_idx0 % BLOCK_M;
+      const bool has_pair = (linear_idx1 < total_elements);
+      const int row1 = has_pair ? linear_idx1 / BLOCK_M : row0;
+      const int col1 = has_pair ? linear_idx1 % BLOCK_M : col0 + 1;
+
+      float s0 = 0.0f, s1 = 0.0f;
+      float dov0 = 0.0f, dov1 = 0.0f;
+
+      const bool in_bounds0 = (row0 < valid_q_rows) && (col0 < valid_kv_rows);
+      const bool causal_ok0 =
+          !IS_CAUSAL || ((start_kv + col0) <= (start_col + row0));
+      const bool valid0 = in_bounds0 && causal_ok0;
+
+      bool valid1 = false;
+      if (has_pair) {
+        const bool in_bounds1 = (row1 < valid_q_rows) && (col1 < valid_kv_rows);
+        const bool causal_ok1 =
+            !IS_CAUSAL || ((start_kv + col1) <= (start_col + row1));
+        valid1 = in_bounds1 && causal_ok1;
+      }
+
+      if (valid0) {
+        s0 = sS[row0 * S_STRIDE + col0];
+        dov0 = sdOV[row0 * S_STRIDE + col0];
+      } else {
+        s0 = NEG_INF;
+      }
+      if (valid1) {
+        s1 = sS[row1 * S_STRIDE + col1];
+        dov1 = sdOV[row1 * S_STRIDE + col1];
+      } else {
+        s1 = NEG_INF;
+      }
+
+      float lse0 = sLse[row0];
+      float lse1 = (valid1 && row1 != row0) ? sLse[row1] : lse0;
+      float row_dot0 = sRowDot[row0];
+      float row_dot1 = (valid1 && row1 != row0) ? sRowDot[row1] : row_dot0;
+
+      float shifted0 = s0 - lse0;
+      float shifted1 = s1 - lse1;
+
+      float p0 = (shifted0 < -80.0f) ? 0.0f : __expf(shifted0);
+      float p1 = (shifted1 < -80.0f) ? 0.0f : __expf(shifted1);
+
+      float diff0 = dov0 - row_dot0;
+      float diff1 = dov1 - row_dot1;
+      float ds0 = valid0 ? fmaf(p0, softmax_scale * diff0, 0.0f) : 0.0f;
+      float ds1 = valid1 ? fmaf(p1, softmax_scale * diff1, 0.0f) : 0.0f;
+
+      __half2 p_h2 = __float22half2_rn(make_float2(p0, p1));
+      __half2 ds_h2 = __float22half2_rn(make_float2(ds0, ds1));
+
+      if (col1 < BLOCK_M && row1 == row0) {
+        __half* p_dst = sP + row0 * BLOCK_M + col0;
+        __half* ds_dst = sdS + row0 * BLOCK_M + col0;
+        p_dst[0] = p_h2.x;
+        p_dst[1] = p_h2.y;
+        ds_dst[0] = ds_h2.x;
+        ds_dst[1] = ds_h2.y;
+      } else {
+        if (valid0) {
+          sP[row0 * BLOCK_M + col0] = p_h2.x;
+          sdS[row0 * BLOCK_M + col0] = ds_h2.x;
+        }
+        if (valid1) {
+          sP[row1 * BLOCK_M + col1] = p_h2.y;
+          sdS[row1 * BLOCK_M + col1] = ds_h2.y;
+        }
+      }
+    }
+    __syncthreads();
+
+    const int num_tiles_m_dv = (BLOCK_M + WMMA_M - 1) / WMMA_M;
+    const int num_tiles_n_dv = (D + WMMA_N - 1) / WMMA_N;
+    const int num_tiles_k_dv = (BLOCK_N + WMMA_K - 1) / WMMA_K;
+    const int total_tiles_dv = num_tiles_m_dv * num_tiles_n_dv;
+    const int tiles_per_warp_dv =
+        (total_tiles_dv + WARPS_PER_BLOCK - 1) / WARPS_PER_BLOCK;
+
+    for (int tile_local = 0; tile_local < tiles_per_warp_dv; ++tile_local) {
+      const int tile_idx = warp_id * tiles_per_warp_dv + tile_local;
+      if (tile_idx >= total_tiles_dv) break;
+
+      const int tile_m_idx = tile_idx / num_tiles_n_dv;
+      const int tile_n_idx = tile_idx % num_tiles_n_dv;
+
+      const int tile_m = tile_m_idx * WMMA_M;
+      const int tile_n = tile_n_idx * WMMA_N;
+
+      if (tile_m >= valid_kv_rows || tile_n >= D) continue;
+
+      fragment<matrix_a, WMMA_M, WMMA_N, WMMA_K, half, col_major> a_frag;
+      fragment<matrix_b, WMMA_M, WMMA_N, WMMA_K, half, row_major> b_frag;
+      fragment<accumulator, WMMA_M, WMMA_N, WMMA_K, float> acc_frag;
+      load_matrix_sync(acc_frag, sdV + tile_m * KV_STRIDE + tile_n, KV_STRIDE,
+                       mem_row_major);
+
+#pragma unroll
+      for (int k_tile = 0; k_tile < num_tiles_k_dv; ++k_tile) {
+        const int k_offset = k_tile * WMMA_K;
+        if (k_offset >= valid_q_rows) break;
+
+        load_matrix_sync(a_frag, sP + k_offset * BLOCK_M + tile_m, BLOCK_M);
+        load_matrix_sync(b_frag, sdO + k_offset * Q_STRIDE + tile_n, Q_STRIDE);
+        mma_sync(acc_frag, a_frag, b_frag, acc_frag);
+      }
+      store_matrix_sync(sdV + tile_m * KV_STRIDE + tile_n, acc_frag, KV_STRIDE,
+                        mem_row_major);
+    }
+    __syncthreads();
+
+    __half* sQ = sdO;
+#pragma unroll 2
+    for (int idx = tid; idx < NUM_UINT4_Q_BLOCK; idx += THREADS_PER_BLOCK) {
+      const int row = idx / d_stride_uint4;
+      const int vec_col = idx % d_stride_uint4;
+      uint4 q_val = make_uint4(0, 0, 0, 0);
+      if (row < valid_q_rows && vec_col < d_stride_uint4) {
+        q_val = __ldg(&q_vec[row * d_stride_uint4 + vec_col]);
+      }
+      sQ_vec[row * q_stride_uint4 + vec_col] = q_val;
+    }
+    __syncthreads();
+
+    const int num_tiles_m_dk = (BLOCK_M + WMMA_M - 1) / WMMA_M;
+    const int num_tiles_n_dk = (D + WMMA_N - 1) / WMMA_N;
+    const int num_tiles_k_dk = (BLOCK_N + WMMA_K - 1) / WMMA_K;
+    const int total_tiles_dk = num_tiles_m_dk * num_tiles_n_dk;
+    const int tiles_per_warp_dk =
+        (total_tiles_dk + WARPS_PER_BLOCK - 1) / WARPS_PER_BLOCK;
+
+    for (int tile_local = 0; tile_local < tiles_per_warp_dk; ++tile_local) {
+      const int tile_idx = warp_id * tiles_per_warp_dk + tile_local;
+      if (tile_idx >= total_tiles_dk) break;
+
+      const int tile_m_idx = tile_idx / num_tiles_n_dk;
+      const int tile_n_idx = tile_idx % num_tiles_n_dk;
+
+      const int tile_m = tile_m_idx * WMMA_M;
+      const int tile_n = tile_n_idx * WMMA_N;
+
+      if (tile_m >= valid_kv_rows || tile_n >= D) continue;
+
+      fragment<matrix_a, WMMA_M, WMMA_N, WMMA_K, half, col_major> a_frag;
+      fragment<matrix_b, WMMA_M, WMMA_N, WMMA_K, half, row_major> b_frag;
+      fragment<accumulator, WMMA_M, WMMA_N, WMMA_K, float> acc_frag;
+      load_matrix_sync(acc_frag, sdK + tile_m * KV_STRIDE + tile_n, KV_STRIDE,
+                       mem_row_major);
+
+#pragma unroll
+      for (int k_tile = 0; k_tile < num_tiles_k_dk; ++k_tile) {
+        const int k_offset = k_tile * WMMA_K;
+        if (k_offset >= valid_q_rows) break;
+
+        load_matrix_sync(a_frag, sdS + k_offset * BLOCK_M + tile_m, BLOCK_M);
+        load_matrix_sync(b_frag, sQ + k_offset * Q_STRIDE + tile_n, Q_STRIDE);
+        mma_sync(acc_frag, a_frag, b_frag, acc_frag);
+      }
+      store_matrix_sync(sdK + tile_m * KV_STRIDE + tile_n, acc_frag, KV_STRIDE,
+                        mem_row_major);
+    }
+    __syncthreads();
+  }
+
+  const int total_fp16_x4 = (valid_kv_rows * D) / 4;
+  for (int i = tid; i < total_fp16_x4; i += THREADS_PER_BLOCK) {
+    const int row = i / (D / 4);
+    const int col = (i % (D / 4)) * 4;
+
+    const float* s_dK_row = sdK + row * KV_STRIDE;
+    const float* s_dV_row = sdV + row * KV_STRIDE;
+
+    const __half hk0 = __float2half_rn(s_dK_row[col + 0]);
+    const __half hk1 = __float2half_rn(s_dK_row[col + 1]);
+    const __half hk2 = __float2half_rn(s_dK_row[col + 2]);
+    const __half hk3 = __float2half_rn(s_dK_row[col + 3]);
+
+    const __half hv0 = __float2half_rn(s_dV_row[col + 0]);
+    const __half hv1 = __float2half_rn(s_dV_row[col + 1]);
+    const __half hv2 = __float2half_rn(s_dV_row[col + 2]);
+    const __half hv3 = __float2half_rn(s_dV_row[col + 3]);
+
+    asm volatile("st.global.v4.u16 [%0], {%1, %2, %3, %4};"
+                 :
+                 : "l"(dK_ptr + row * D + col), "h"(__half_as_ushort(hk0)),
+                   "h"(__half_as_ushort(hk1)), "h"(__half_as_ushort(hk2)),
+                   "h"(__half_as_ushort(hk3))
+                 : "memory");
+
+    asm volatile("st.global.v4.u16 [%0], {%1, %2, %3, %4};"
+                 :
+                 : "l"(dV_ptr + row * D + col), "h"(__half_as_ushort(hv0)),
+                   "h"(__half_as_ushort(hv1)), "h"(__half_as_ushort(hv2)),
+                   "h"(__half_as_ushort(hv3))
+                 : "memory");
+  }
 }
 
-template<int D>
+template <int D>
 void launcher_flash_attention_backward_dq(
-    const torch::Tensor& Q,
-    const torch::Tensor& K,
-    const torch::Tensor& V,
-    const torch::Tensor& O,
-    torch::Tensor& dO,
-    const torch::Tensor& softmax_lse,
-    torch::Tensor& dQ,
-    float softmax_scale,
-    bool is_causal,
-    cudaStream_t stream
-) {
-    using Config = dQKernelConfig<D>;
+    const torch::Tensor& Q, const torch::Tensor& K, const torch::Tensor& V,
+    const torch::Tensor& O, torch::Tensor& dO, const torch::Tensor& softmax_lse,
+    torch::Tensor& dQ, float softmax_scale, bool is_causal,
+    cudaStream_t stream) {
+  using Config = dQKernelConfig<D>;
 
-    const int B = Q.size(0);
-    const int H = Q.size(1);
-    const int M = Q.size(2);
-    const int N = K.size(2);
+  const int B = Q.size(0);
+  const int H = Q.size(1);
+  const int M = Q.size(2);
+  const int N = K.size(2);
 
-    const int grid_x = (M + Config::BLOCK_M - 1) / Config::BLOCK_M;
-    const dim3 grid(grid_x, 1, B * H);
-    const dim3 block(Config::THREADS_PER_BLOCK);
-    const size_t smem = Config::TOTAL_SMEM;
+  const int grid_x = (M + Config::BLOCK_M - 1) / Config::BLOCK_M;
+  const dim3 grid(grid_x, 1, B * H);
+  const dim3 block(Config::THREADS_PER_BLOCK);
+  const size_t smem = Config::TOTAL_SMEM;
 
-    TORCH_CHECK(smem <= MAX_SMEM_PER_SM, "Shared memory exceeds 96KB for dQ: ", smem, " bytes");
+  TORCH_CHECK(smem <= MAX_SMEM_PER_SM,
+              "Shared memory exceeds 96KB for dQ: ", smem, " bytes");
 
-    auto kernel = is_causal ?
-        (void*)flash_attention_backward_dq_kernel<D, true> :
-        (void*)flash_attention_backward_dq_kernel<D, false>;
+  auto kernel = is_causal ? (void*)flash_attention_backward_dq_kernel<D, true>
+                          : (void*)flash_attention_backward_dq_kernel<D, false>;
 
-    cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem);
+  cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize,
+                       smem);
 
-    if (is_causal) {
-        flash_attention_backward_dq_kernel<D, true><<<grid, block, smem, stream>>>(
-            reinterpret_cast<const __half*>(Q.data_ptr()),
-            reinterpret_cast<const __half*>(K.data_ptr()),
-            reinterpret_cast<const __half*>(V.data_ptr()),
-            reinterpret_cast<const __half*>(O.data_ptr()),
-            reinterpret_cast<__half*>(dO.data_ptr()),
-            softmax_lse.data_ptr<float>(),
-            reinterpret_cast<__half*>(dQ.data_ptr()),
-            B, H, M, N, softmax_scale
-        );
-    } else {
-        flash_attention_backward_dq_kernel<D, false><<<grid, block, smem, stream>>>(
-            reinterpret_cast<const __half*>(Q.data_ptr()),
-            reinterpret_cast<const __half*>(K.data_ptr()),
-            reinterpret_cast<const __half*>(V.data_ptr()),
-            reinterpret_cast<const __half*>(O.data_ptr()),
-            reinterpret_cast<__half*>(dO.data_ptr()),
-            softmax_lse.data_ptr<float>(),
-            reinterpret_cast<__half*>(dQ.data_ptr()),
-            B, H, M, N, softmax_scale
-        );
-    }
+  if (is_causal) {
+    flash_attention_backward_dq_kernel<D, true><<<grid, block, smem, stream>>>(
+        reinterpret_cast<const __half*>(Q.data_ptr()),
+        reinterpret_cast<const __half*>(K.data_ptr()),
+        reinterpret_cast<const __half*>(V.data_ptr()),
+        reinterpret_cast<const __half*>(O.data_ptr()),
+        reinterpret_cast<__half*>(dO.data_ptr()), softmax_lse.data_ptr<float>(),
+        reinterpret_cast<__half*>(dQ.data_ptr()), B, H, M, N, softmax_scale);
+  } else {
+    flash_attention_backward_dq_kernel<D, false><<<grid, block, smem, stream>>>(
+        reinterpret_cast<const __half*>(Q.data_ptr()),
+        reinterpret_cast<const __half*>(K.data_ptr()),
+        reinterpret_cast<const __half*>(V.data_ptr()),
+        reinterpret_cast<const __half*>(O.data_ptr()),
+        reinterpret_cast<__half*>(dO.data_ptr()), softmax_lse.data_ptr<float>(),
+        reinterpret_cast<__half*>(dQ.data_ptr()), B, H, M, N, softmax_scale);
+  }
 }
 
-template<int D>
+template <int D>
 void launcher_flash_attention_backward_dkv(
-    const torch::Tensor& Q,
-    const torch::Tensor& K,
-    const torch::Tensor& V,
-    const torch::Tensor& O,
-    torch::Tensor& dO,
-    const torch::Tensor& softmax_lse,
-    torch::Tensor& dK,
-    torch::Tensor& dV,
-    float softmax_scale,
-    bool is_causal,
-    cudaStream_t stream
-) {
-    using Config = dKVKernelConfig<D>;
+    const torch::Tensor& Q, const torch::Tensor& K, const torch::Tensor& V,
+    const torch::Tensor& O, torch::Tensor& dO, const torch::Tensor& softmax_lse,
+    torch::Tensor& dK, torch::Tensor& dV, float softmax_scale, bool is_causal,
+    cudaStream_t stream) {
+  using Config = dKVKernelConfig<D>;
 
-    const int B = Q.size(0);
-    const int H = Q.size(1);
-    const int M = Q.size(2);
-    const int N = K.size(2);
+  const int B = Q.size(0);
+  const int H = Q.size(1);
+  const int M = Q.size(2);
+  const int N = K.size(2);
 
-    const int grid_x = (N + Config::BLOCK_M - 1) / Config::BLOCK_M;
-    const dim3 grid(grid_x, 1, B * H);
-    const dim3 block(Config::THREADS_PER_BLOCK);
-    const size_t smem = Config::TOTAL_SMEM;
+  const int grid_x = (N + Config::BLOCK_M - 1) / Config::BLOCK_M;
+  const dim3 grid(grid_x, 1, B * H);
+  const dim3 block(Config::THREADS_PER_BLOCK);
+  const size_t smem = Config::TOTAL_SMEM;
 
-    TORCH_CHECK(smem <= MAX_SMEM_PER_SM, "Shared memory exceeds 96KB for unified dKV: ", smem, " bytes (", smem / 1024, " KB)");
+  TORCH_CHECK(smem <= MAX_SMEM_PER_SM,
+              "Shared memory exceeds 96KB for unified dKV: ", smem, " bytes (",
+              smem / 1024, " KB)");
 
-    auto kernel = is_causal ?
-        (void*)flash_attention_backward_dkv_kernel<D, true> :
-        (void*)flash_attention_backward_dkv_kernel<D, false>;
+  auto kernel = is_causal
+                    ? (void*)flash_attention_backward_dkv_kernel<D, true>
+                    : (void*)flash_attention_backward_dkv_kernel<D, false>;
 
-    cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem);
+  cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize,
+                       smem);
 
-    if (is_causal) {
-        flash_attention_backward_dkv_kernel<D, true><<<grid, block, smem, stream>>>(
+  if (is_causal) {
+    flash_attention_backward_dkv_kernel<D, true><<<grid, block, smem, stream>>>(
+        reinterpret_cast<const __half*>(Q.data_ptr()),
+        reinterpret_cast<const __half*>(K.data_ptr()),
+        reinterpret_cast<const __half*>(V.data_ptr()),
+        reinterpret_cast<const __half*>(O.data_ptr()),
+        reinterpret_cast<__half*>(dO.data_ptr()), softmax_lse.data_ptr<float>(),
+        reinterpret_cast<__half*>(dK.data_ptr()),
+        reinterpret_cast<__half*>(dV.data_ptr()), B, H, M, N, softmax_scale);
+  } else {
+    flash_attention_backward_dkv_kernel<D, false>
+        <<<grid, block, smem, stream>>>(
             reinterpret_cast<const __half*>(Q.data_ptr()),
             reinterpret_cast<const __half*>(K.data_ptr()),
             reinterpret_cast<const __half*>(V.data_ptr()),
@@ -1191,104 +1250,104 @@ void launcher_flash_attention_backward_dkv(
             reinterpret_cast<__half*>(dO.data_ptr()),
             softmax_lse.data_ptr<float>(),
             reinterpret_cast<__half*>(dK.data_ptr()),
-            reinterpret_cast<__half*>(dV.data_ptr()),
-            B, H, M, N, softmax_scale
-        );
-    } else {
-        flash_attention_backward_dkv_kernel<D, false><<<grid, block, smem, stream>>>(
-            reinterpret_cast<const __half*>(Q.data_ptr()),
-            reinterpret_cast<const __half*>(K.data_ptr()),
-            reinterpret_cast<const __half*>(V.data_ptr()),
-            reinterpret_cast<const __half*>(O.data_ptr()),
-            reinterpret_cast<__half*>(dO.data_ptr()),
-            softmax_lse.data_ptr<float>(),
-            reinterpret_cast<__half*>(dK.data_ptr()),
-            reinterpret_cast<__half*>(dV.data_ptr()),
-            B, H, M, N, softmax_scale
-        );
-    }
+            reinterpret_cast<__half*>(dV.data_ptr()), B, H, M, N,
+            softmax_scale);
+  }
 }
 
 std::vector<at::Tensor> flash_attention_backward(
-    const at::Tensor& dout,
-    const at::Tensor& q,
-    const at::Tensor& k,
-    const at::Tensor& v,
-    const at::Tensor& out,
-    const at::Tensor& softmax_lse,
-    std::optional<at::Tensor>& dq_,
-    std::optional<at::Tensor>& dk_,
-    std::optional<at::Tensor>& dv_,
-    std::optional<at::Tensor>& alibi_slopes_,
-    const float p_dropout,
-    const float softmax_scale,
-    const bool is_causal,
-    int window_size_left,
-    int window_size_right,
-    const float softcap,
-    const bool deterministic,
-    std::optional<at::Generator> gen_,
-    std::optional<at::Tensor>& rng_state
-) {
+    const at::Tensor& dout, const at::Tensor& q, const at::Tensor& k,
+    const at::Tensor& v, const at::Tensor& out, const at::Tensor& softmax_lse,
+    std::optional<at::Tensor>& dq_, std::optional<at::Tensor>& dk_,
+    std::optional<at::Tensor>& dv_, std::optional<at::Tensor>& alibi_slopes_,
+    const float p_dropout, const float softmax_scale, const bool is_causal,
+    int window_size_left, int window_size_right, const float softcap,
+    const bool deterministic, std::optional<at::Generator> gen_,
+    std::optional<at::Tensor>& rng_state) {
+  TORCH_CHECK(!alibi_slopes_.has_value(), "alibi_slopes not supported");
+  TORCH_CHECK(p_dropout == 0.f, "dropout not supported");
+  TORCH_CHECK(window_size_left == -1, "window_size_left not supported");
+  TORCH_CHECK(window_size_right == -1 || (is_causal && window_size_right == 0),
+              "window not supported");
+  TORCH_CHECK(softcap == 0.f, "softcap not supported");
+  TORCH_CHECK(!deterministic, "deterministic mode not supported");
+  TORCH_CHECK(!gen_.has_value(), "Generator not supported");
+  TORCH_CHECK(!rng_state.has_value() || rng_state->numel() == 0,
+              "rng_state not supported");
 
-    TORCH_CHECK(!alibi_slopes_.has_value(), "alibi_slopes not supported");
-    TORCH_CHECK(p_dropout == 0.f, "dropout not supported");
-    TORCH_CHECK(window_size_left == -1, "window_size_left not supported");
-    TORCH_CHECK(window_size_right == -1 || (is_causal && window_size_right == 0), "window not supported");
-    TORCH_CHECK(softcap == 0.f, "softcap not supported");
-    TORCH_CHECK(!deterministic, "deterministic mode not supported");
-    TORCH_CHECK(!gen_.has_value(), "Generator not supported");
-    TORCH_CHECK(!rng_state.has_value() || rng_state->numel() == 0, "rng_state not supported");
+  TORCH_CHECK(q.dtype() == torch::kFloat16, "q must be fp16");
+  TORCH_CHECK(k.dtype() == torch::kFloat16, "k must be fp16");
+  TORCH_CHECK(v.dtype() == torch::kFloat16, "v must be fp16");
+  TORCH_CHECK(dout.dtype() == torch::kFloat16, "dout must be fp16");
+  TORCH_CHECK(out.dtype() == torch::kFloat16, "out must be fp16");
+  TORCH_CHECK(softmax_lse.dtype() == torch::kFloat32,
+              "softmax_lse must be fp32");
 
-    TORCH_CHECK(q.dtype() == torch::kFloat16, "q must be fp16");
-    TORCH_CHECK(k.dtype() == torch::kFloat16, "k must be fp16");
-    TORCH_CHECK(v.dtype() == torch::kFloat16, "v must be fp16");
-    TORCH_CHECK(dout.dtype() == torch::kFloat16, "dout must be fp16");
-    TORCH_CHECK(out.dtype() == torch::kFloat16, "out must be fp16");
-    TORCH_CHECK(softmax_lse.dtype() == torch::kFloat32, "softmax_lse must be fp32");
+  const auto sizes = q.sizes();
+  const int B = sizes[0], H = sizes[1], M = sizes[2], D = sizes[3];
+  const int N = k.size(2);
+  TORCH_CHECK(D <= 256 && D % 8 == 0 && D % 2 == 0,
+              "D must be even, <=256, multiple of 8");
 
-    const auto sizes = q.sizes();
-    const int B = sizes[0], H = sizes[1], M = sizes[2], D = sizes[3];
-    const int N = k.size(2);
-    TORCH_CHECK(D <= 256 && D % 8 == 0 && D % 2 == 0, "D must be even, <=256, multiple of 8");
+  at::Tensor dq_fp16 = dq_.has_value() ? dq_.value() : torch::zeros_like(q);
+  at::Tensor dk_fp16 = dk_.has_value() ? dk_.value() : torch::zeros_like(k);
+  at::Tensor dv_fp16 = dv_.has_value() ? dv_.value() : torch::zeros_like(v);
 
-    at::Tensor dq_fp16 = dq_.has_value() ? dq_.value() : torch::zeros_like(q);
-    at::Tensor dk_fp16 = dk_.has_value() ? dk_.value() : torch::zeros_like(k);
-    at::Tensor dv_fp16 = dv_.has_value() ? dv_.value() : torch::zeros_like(v);
+  TORCH_CHECK(dq_fp16.dtype() == torch::kFloat16, "dq must be fp16");
+  TORCH_CHECK(dk_fp16.dtype() == torch::kFloat16, "dk must be fp16");
+  TORCH_CHECK(dv_fp16.dtype() == torch::kFloat16, "dv must be fp16");
 
-    TORCH_CHECK(dq_fp16.dtype() == torch::kFloat16, "dq must be fp16");
-    TORCH_CHECK(dk_fp16.dtype() == torch::kFloat16, "dk must be fp16");
-    TORCH_CHECK(dv_fp16.dtype() == torch::kFloat16, "dv must be fp16");
+  auto dsoftmax_sum =
+      torch::zeros({B, H, M}, torch::dtype(torch::kFloat32).device(q.device()));
 
-    auto dsoftmax_sum = torch::zeros({B, H, M}, torch::dtype(torch::kFloat32).device(q.device()));
+  auto stream = at::cuda::getCurrentCUDAStream().stream();
+  auto props = at::cuda::getCurrentDeviceProperties();
+  bool sm70 = props->major == 7 && props->minor == 0;
+  TORCH_CHECK(sm70, "Kernel supports only Volta GPUs.");
 
-    auto stream = at::cuda::getCurrentCUDAStream().stream();
-    auto props  = at::cuda::getCurrentDeviceProperties();
-    bool sm70   = props->major == 7 && props->minor == 0;
-    TORCH_CHECK(sm70, "Kernel supports only Volta GPUs.");
-
-    switch (D) {
-        case 16:
-            launcher_flash_attention_backward_dq<16>(q, k, v, out, const_cast<at::Tensor&>(dout), softmax_lse, dq_fp16, softmax_scale, is_causal, stream);
-            launcher_flash_attention_backward_dkv<16>(q, k, v, out, const_cast<at::Tensor&>(dout), softmax_lse, dk_fp16, dv_fp16, softmax_scale, is_causal, stream);
-            break;
-        case 32:
-            launcher_flash_attention_backward_dq<32>(q, k, v, out, const_cast<at::Tensor&>(dout), softmax_lse, dq_fp16, softmax_scale, is_causal, stream);
-            launcher_flash_attention_backward_dkv<32>(q, k, v, out, const_cast<at::Tensor&>(dout), softmax_lse, dk_fp16, dv_fp16, softmax_scale, is_causal, stream);
-            break;
-        case 64:
-            launcher_flash_attention_backward_dq<64>(q, k, v, out, const_cast<at::Tensor&>(dout), softmax_lse, dq_fp16, softmax_scale, is_causal, stream);
-            launcher_flash_attention_backward_dkv<64>(q, k, v, out, const_cast<at::Tensor&>(dout), softmax_lse, dk_fp16, dv_fp16, softmax_scale, is_causal, stream);
-            break;
-        case 128:
-            launcher_flash_attention_backward_dq<128>(q, k, v, out, const_cast<at::Tensor&>(dout), softmax_lse, dq_fp16, softmax_scale, is_causal, stream);
-            launcher_flash_attention_backward_dkv<128>(q, k, v, out, const_cast<at::Tensor&>(dout), softmax_lse, dk_fp16, dv_fp16, softmax_scale, is_causal, stream);
-            break;
-        case 256:
-            launcher_flash_attention_backward_dq<256>(q, k, v, out, const_cast<at::Tensor&>(dout), softmax_lse, dq_fp16, softmax_scale, is_causal, stream);
-            launcher_flash_attention_backward_dkv<256>(q, k, v, out, const_cast<at::Tensor&>(dout), softmax_lse, dk_fp16, dv_fp16, softmax_scale, is_causal, stream);
-            break;
-        default: TORCH_CHECK(false, "Unsupported D: ", D);
-    }
-    return {dq_fp16, dk_fp16, dv_fp16, dsoftmax_sum};
+  switch (D) {
+    case 16:
+      launcher_flash_attention_backward_dq<16>(
+          q, k, v, out, const_cast<at::Tensor&>(dout), softmax_lse, dq_fp16,
+          softmax_scale, is_causal, stream);
+      launcher_flash_attention_backward_dkv<16>(
+          q, k, v, out, const_cast<at::Tensor&>(dout), softmax_lse, dk_fp16,
+          dv_fp16, softmax_scale, is_causal, stream);
+      break;
+    case 32:
+      launcher_flash_attention_backward_dq<32>(
+          q, k, v, out, const_cast<at::Tensor&>(dout), softmax_lse, dq_fp16,
+          softmax_scale, is_causal, stream);
+      launcher_flash_attention_backward_dkv<32>(
+          q, k, v, out, const_cast<at::Tensor&>(dout), softmax_lse, dk_fp16,
+          dv_fp16, softmax_scale, is_causal, stream);
+      break;
+    case 64:
+      launcher_flash_attention_backward_dq<64>(
+          q, k, v, out, const_cast<at::Tensor&>(dout), softmax_lse, dq_fp16,
+          softmax_scale, is_causal, stream);
+      launcher_flash_attention_backward_dkv<64>(
+          q, k, v, out, const_cast<at::Tensor&>(dout), softmax_lse, dk_fp16,
+          dv_fp16, softmax_scale, is_causal, stream);
+      break;
+    case 128:
+      launcher_flash_attention_backward_dq<128>(
+          q, k, v, out, const_cast<at::Tensor&>(dout), softmax_lse, dq_fp16,
+          softmax_scale, is_causal, stream);
+      launcher_flash_attention_backward_dkv<128>(
+          q, k, v, out, const_cast<at::Tensor&>(dout), softmax_lse, dk_fp16,
+          dv_fp16, softmax_scale, is_causal, stream);
+      break;
+    case 256:
+      launcher_flash_attention_backward_dq<256>(
+          q, k, v, out, const_cast<at::Tensor&>(dout), softmax_lse, dq_fp16,
+          softmax_scale, is_causal, stream);
+      launcher_flash_attention_backward_dkv<256>(
+          q, k, v, out, const_cast<at::Tensor&>(dout), softmax_lse, dk_fp16,
+          dv_fp16, softmax_scale, is_causal, stream);
+      break;
+    default:
+      TORCH_CHECK(false, "Unsupported D: ", D);
+  }
+  return {dq_fp16, dk_fp16, dv_fp16, dsoftmax_sum};
 }

--- a/flash-attention-v100/kernel/fused_mha_forward.cu
+++ b/flash-attention-v100/kernel/fused_mha_forward.cu
@@ -16,1133 +16,1109 @@ using namespace nvcuda::wmma;
 #define WMMA_N 16
 #define WMMA_K 16
 
-#define MAX_THREADS_PER_WARP    32
-#define MAX_THREADS_PER_SM      2048
-#define MAX_THREAD_BLOCK_SIZE   1024
+#define MAX_THREADS_PER_WARP 32
+#define MAX_THREADS_PER_SM 2048
+#define MAX_THREAD_BLOCK_SIZE 1024
 #define MAX_THREAD_BLOCK_PER_SM 32
-#define MAX_WARPS_PER_SM        64
-#define MAX_SM_PER_GPU          80
-#define MAX_SMEM_PER_SM         98304
+#define MAX_WARPS_PER_SM 64
+#define MAX_SM_PER_GPU 80
+#define MAX_SMEM_PER_SM 98304
 
-#define WARP_ALLOC_GROUP        4
+#define WARP_ALLOC_GROUP 4
 
-#define MAX_REG_PER_UNIT        256
-#define MAX_REG_PER_THREAD      255
-#define MAX_REG_PER_BLOCK       65536
-#define MAX_REG_BUFFER          65536
+#define MAX_REG_PER_UNIT 256
+#define MAX_REG_PER_THREAD 255
+#define MAX_REG_PER_BLOCK 65536
+#define MAX_REG_BUFFER 65536
 
-#define BLOCK_M_16  16
-#define BLOCK_N_16  512
-#define WARPS_16    16
+#define BLOCK_M_16 16
+#define BLOCK_N_16 512
+#define WARPS_16 16
 
-#define BLOCK_M_32  32
-#define BLOCK_N_32  256
-#define WARPS_32    16
+#define BLOCK_M_32 32
+#define BLOCK_N_32 256
+#define WARPS_32 16
 
-#define BLOCK_M_64  64
-#define BLOCK_N_64  128
-#define WARPS_64    16
+#define BLOCK_M_64 64
+#define BLOCK_N_64 128
+#define WARPS_64 16
 
 #define BLOCK_M_128 32
 #define BLOCK_N_128 176
-#define WARPS_128   16
+#define WARPS_128 16
 
 #define BLOCK_M_256 32
 #define BLOCK_N_256 64
-#define WARPS_256   16
+#define WARPS_256 16
 
 #define BLOCK_M_256_LOW_SMEM 16
 #define BLOCK_N_256_LOW_SMEM 32
-#define WARPS_256_LOW_SMEM   16
+#define WARPS_256_LOW_SMEM 16
 
 inline bool env_flag_enabled(const char* name) {
-    const char* raw = std::getenv(name);
-    return raw != nullptr && std::strcmp(raw, "0") != 0;
+  const char* raw = std::getenv(name);
+  return raw != nullptr && std::strcmp(raw, "0") != 0;
 }
 
 inline bool env_flag_enabled_default_on(const char* name) {
-    const char* raw = std::getenv(name);
-    return raw == nullptr || std::strcmp(raw, "0") != 0;
+  const char* raw = std::getenv(name);
+  return raw == nullptr || std::strcmp(raw, "0") != 0;
 }
 
-template<int D, bool LOW_SMEM = false>
+template <int D, bool LOW_SMEM = false>
 struct KernelConfig {
-    static constexpr int BLOCK_M = (D == 16) ? BLOCK_M_16 : (D == 32) ? BLOCK_M_32 : (D == 64) ? BLOCK_M_64 : (D == 128) ? BLOCK_M_128 : (LOW_SMEM ? BLOCK_M_256_LOW_SMEM : BLOCK_M_256);
-    static constexpr int BLOCK_N = (D == 16) ? BLOCK_N_16 : (D == 32) ? BLOCK_N_32 : (D == 64) ? BLOCK_N_64 : (D == 128) ? BLOCK_N_128 : (LOW_SMEM ? BLOCK_N_256_LOW_SMEM : BLOCK_N_256);
-    static constexpr int WARPS_PER_BLOCK = (D == 16) ? WARPS_16 : (D == 32) ? WARPS_32 : (D == 64) ? WARPS_64 : (D == 128) ? WARPS_128 : (LOW_SMEM ? WARPS_256_LOW_SMEM : WARPS_256);
+  static constexpr int BLOCK_M =
+      (D == 16)    ? BLOCK_M_16
+      : (D == 32)  ? BLOCK_M_32
+      : (D == 64)  ? BLOCK_M_64
+      : (D == 128) ? BLOCK_M_128
+                   : (LOW_SMEM ? BLOCK_M_256_LOW_SMEM : BLOCK_M_256);
+  static constexpr int BLOCK_N =
+      (D == 16)    ? BLOCK_N_16
+      : (D == 32)  ? BLOCK_N_32
+      : (D == 64)  ? BLOCK_N_64
+      : (D == 128) ? BLOCK_N_128
+                   : (LOW_SMEM ? BLOCK_N_256_LOW_SMEM : BLOCK_N_256);
+  static constexpr int WARPS_PER_BLOCK =
+      (D == 16)    ? WARPS_16
+      : (D == 32)  ? WARPS_32
+      : (D == 64)  ? WARPS_64
+      : (D == 128) ? WARPS_128
+                   : (LOW_SMEM ? WARPS_256_LOW_SMEM : WARPS_256);
 
-    static constexpr int THREADS_PER_BLOCK = WARPS_PER_BLOCK * MAX_THREADS_PER_WARP;
-    static constexpr int THREADS_PER_ROW   = THREADS_PER_BLOCK / BLOCK_M;
-    static constexpr int PAD               = (8 - (D % 32) + 32) % 32;
-    static constexpr int Q_STRIDE          = D + PAD;
-    static constexpr int KV_STRIDE         = D + PAD;
-    static constexpr int S_STRIDE          = BLOCK_N + PAD;
-    static constexpr int P_SUB_TILE        = 32;
-    static constexpr int P_STRIDE          = P_SUB_TILE + PAD;
-    static constexpr int P_STRICT_ELEMENTS = (D == 256) ? BLOCK_M * P_STRIDE : 1;
-    static constexpr int O_STRIDE          = D + PAD;
-    static constexpr int PER_UINT4         = 8;
+  static constexpr int THREADS_PER_BLOCK =
+      WARPS_PER_BLOCK * MAX_THREADS_PER_WARP;
+  static constexpr int THREADS_PER_ROW = THREADS_PER_BLOCK / BLOCK_M;
+  static constexpr int PAD = (8 - (D % 32) + 32) % 32;
+  static constexpr int Q_STRIDE = D + PAD;
+  static constexpr int KV_STRIDE = D + PAD;
+  static constexpr int S_STRIDE = BLOCK_N + PAD;
+  static constexpr int P_SUB_TILE = 32;
+  static constexpr int P_STRIDE = P_SUB_TILE + PAD;
+  static constexpr int P_STRICT_ELEMENTS = (D == 256) ? BLOCK_M * P_STRIDE : 1;
+  static constexpr int O_STRIDE = D + PAD;
+  static constexpr int PER_UINT4 = 8;
 
-    struct alignas(128) SmemLayout {
-        alignas(16) __half q      [BLOCK_M * Q_STRIDE];
+  struct alignas(128) SmemLayout {
+    alignas(16) __half q[BLOCK_M * Q_STRIDE];
     union {
-        alignas(16) __half k      [BLOCK_N * KV_STRIDE];
-        alignas(16) __half v      [BLOCK_N * KV_STRIDE];
+      alignas(16) __half k[BLOCK_N * KV_STRIDE];
+      alignas(16) __half v[BLOCK_N * KV_STRIDE];
     } reuse_kv;
     union {
-        alignas(16) float  s      [BLOCK_M * S_STRIDE];
-        alignas(16) __half p      [BLOCK_M * S_STRIDE];
+      alignas(16) float s[BLOCK_M * S_STRIDE];
+      alignas(16) __half p[BLOCK_M * S_STRIDE];
     } reuse_sp;
-        alignas(16) __half p_strict[P_STRICT_ELEMENTS];
-        alignas(16) float  o      [BLOCK_M * O_STRIDE];
-        alignas(16) float  row_max[BLOCK_M];
-        alignas(16) float  row_sum[BLOCK_M];
-    };
+    alignas(16) __half p_strict[P_STRICT_ELEMENTS];
+    alignas(16) float o[BLOCK_M * O_STRIDE];
+    alignas(16) float row_max[BLOCK_M];
+    alignas(16) float row_sum[BLOCK_M];
+  };
 
-    static constexpr size_t TOTAL_SMEM = ((sizeof(SmemLayout) + 127) & ~size_t(127));
+  static constexpr size_t TOTAL_SMEM =
+      ((sizeof(SmemLayout) + 127) & ~size_t(127));
 };
 
-template<typename Config>
+template <typename Config>
 __device__ __forceinline__ void init_smem(char* smem_raw) {
-    constexpr int N_U4 = Config::TOTAL_SMEM / 16;
-    constexpr int THREADS_PER_BLOCK = Config::THREADS_PER_BLOCK;
-    const int tid = threadIdx.x;
+  constexpr int N_U4 = Config::TOTAL_SMEM / 16;
+  constexpr int THREADS_PER_BLOCK = Config::THREADS_PER_BLOCK;
+  const int tid = threadIdx.x;
 
-    uint32_t addr = static_cast<uint32_t>(__cvta_generic_to_shared(smem_raw));
-    #pragma unroll 1
-    for (int i = tid; i < N_U4; i += THREADS_PER_BLOCK) {
-        asm volatile("st.shared.v4.u32 [%0], {%1,%1,%1,%1};"
-                     :: "r"(addr + (i << 4)), "r"(0) : "memory");
-    }
-    __syncthreads();
+  uint32_t addr = static_cast<uint32_t>(__cvta_generic_to_shared(smem_raw));
+#pragma unroll 1
+  for (int i = tid; i < N_U4; i += THREADS_PER_BLOCK) {
+    asm volatile("st.shared.v4.u32 [%0], {%1,%1,%1,%1};" ::"r"(addr + (i << 4)),
+                 "r"(0)
+                 : "memory");
+  }
+  __syncthreads();
 }
 
-template<int D, bool LOW_SMEM, bool IS_CAUSAL>
+template <int D, bool LOW_SMEM, bool IS_CAUSAL>
 __device__ __forceinline__ void compute_qk_scores_scalar_fp32(
-    const __half* __restrict__ sQ,
-    const __half* __restrict__ sK,
-    float* __restrict__ sS,
-    const int valid_q_rows,
-    const int valid_k_rows,
-    const int start_row,
-    const int start_col,
-    const int causal_q_offset,
-    const float score_scale,
-    const int window_size_left,
-    const int window_size_right
-) {
-    using Config = KernelConfig<D, LOW_SMEM>;
-    constexpr int THREADS_PER_BLOCK = Config::THREADS_PER_BLOCK;
-    constexpr int Q_STRIDE = Config::Q_STRIDE;
-    constexpr int KV_STRIDE = Config::KV_STRIDE;
-    constexpr int S_STRIDE = Config::S_STRIDE;
-    const float NEG_INF = -1e30f;
-    const int tid = threadIdx.x;
-    const int total_scores = valid_q_rows * valid_k_rows;
+    const __half* __restrict__ sQ, const __half* __restrict__ sK,
+    float* __restrict__ sS, const int valid_q_rows, const int valid_k_rows,
+    const int start_row, const int start_col, const int causal_q_offset,
+    const float score_scale, const int window_size_left,
+    const int window_size_right) {
+  using Config = KernelConfig<D, LOW_SMEM>;
+  constexpr int THREADS_PER_BLOCK = Config::THREADS_PER_BLOCK;
+  constexpr int Q_STRIDE = Config::Q_STRIDE;
+  constexpr int KV_STRIDE = Config::KV_STRIDE;
+  constexpr int S_STRIDE = Config::S_STRIDE;
+  const float NEG_INF = -1e30f;
+  const int tid = threadIdx.x;
+  const int total_scores = valid_q_rows * valid_k_rows;
 
-    for (int idx = tid; idx < total_scores; idx += THREADS_PER_BLOCK) {
-        const int row = idx / valid_k_rows;
-        const int col = idx - row * valid_k_rows;
-        const int global_m = start_row + row;
-        const int global_n = start_col + col;
-        const int global_q_pos = global_m + causal_q_offset;
+  for (int idx = tid; idx < total_scores; idx += THREADS_PER_BLOCK) {
+    const int row = idx / valid_k_rows;
+    const int col = idx - row * valid_k_rows;
+    const int global_m = start_row + row;
+    const int global_n = start_col + col;
+    const int global_q_pos = global_m + causal_q_offset;
 
-        bool is_valid = true;
-        if constexpr (IS_CAUSAL) {
-            is_valid = global_n <= global_q_pos;
-        }
-        if (window_size_left >= 0) {
-            is_valid = is_valid && global_n >= global_q_pos - window_size_left;
-        }
-        if (window_size_right >= 0) {
-            is_valid = is_valid && global_n <= global_q_pos + window_size_right;
-        }
-
-        float acc = 0.0f;
-        if (is_valid) {
-            #pragma unroll 8
-            for (int d = 0; d < D; d += 2) {
-                const __half2 q_h2 = *reinterpret_cast<const __half2*>(
-                    sQ + row * Q_STRIDE + d);
-                const __half2 k_h2 = *reinterpret_cast<const __half2*>(
-                    sK + col * KV_STRIDE + d);
-                const float2 q_f2 = __half22float2(q_h2);
-                const float2 k_f2 = __half22float2(k_h2);
-                acc = fmaf(q_f2.x, k_f2.x, acc);
-                acc = fmaf(q_f2.y, k_f2.y, acc);
-            }
-        }
-        sS[row * S_STRIDE + col] = is_valid ? acc * score_scale : NEG_INF;
-    }
-}
-
-template<int D, bool LOW_SMEM, bool D256_WMMA_QK, bool IS_CAUSAL>
-__global__ void __launch_bounds__(KernelConfig<D, LOW_SMEM>::THREADS_PER_BLOCK, 2)
-flash_attention_forward_kernel(
-    const __half* __restrict__ Q,
-    const __half* __restrict__ K,
-    const __half* __restrict__ V,
-          __half* __restrict__ Out,
-           float* __restrict__ softmax_lse,
-    const int B,
-    const int H,
-    const int H_KV,
-    const int M,
-    const int N,
-    const float softmax_scale,
-    const bool scalar_pv,
-    const int window_size_left,
-    const int window_size_right
-) {
-    using Config = KernelConfig<D, LOW_SMEM>;
-    constexpr int BLOCK_M           = Config::BLOCK_M;
-    constexpr int BLOCK_N           = Config::BLOCK_N;
-    constexpr int THREADS_PER_BLOCK = Config::THREADS_PER_BLOCK;
-    constexpr int THREADS_PER_ROW   = Config::THREADS_PER_ROW;
-    constexpr int WARPS_PER_BLOCK   = Config::WARPS_PER_BLOCK;
-    constexpr int Q_STRIDE          = Config::Q_STRIDE;
-    constexpr int KV_STRIDE         = Config::KV_STRIDE;
-    constexpr int S_STRIDE          = Config::S_STRIDE;
-    constexpr int P_SUB_TILE        = Config::P_SUB_TILE;
-    constexpr int P_STRIDE          = Config::P_STRIDE;
-    constexpr int O_STRIDE          = Config::O_STRIDE;
-    constexpr int PER_UINT4         = Config::PER_UINT4;
-    const float NEG_INF = -1e30f;
-
-    const int batch_head_id = blockIdx.z;
-    if (batch_head_id >= B * H) return;
-    const int batch_id = batch_head_id / H;
-    const int q_head_id = batch_head_id % H;
-    const int kv_group_size = H / H_KV;
-    const int kv_head_id = q_head_id / kv_group_size;
-
-    const int block_m = blockIdx.x;
-    const int start_row = block_m * BLOCK_M;
-    if (start_row >= M) return;
-
-    int num_n_tiles = (N + BLOCK_N - 1) / BLOCK_N;
-    const int valid_q_rows = min(BLOCK_M, M - start_row);
-    const int causal_q_offset = max(N - M, 0);
-
-    int max_key_pos = N - 1;
+    bool is_valid = true;
     if constexpr (IS_CAUSAL) {
-        max_key_pos = min(max_key_pos,
-                          causal_q_offset + start_row + valid_q_rows - 1);
+      is_valid = global_n <= global_q_pos;
+    }
+    if (window_size_left >= 0) {
+      is_valid = is_valid && global_n >= global_q_pos - window_size_left;
     }
     if (window_size_right >= 0) {
-        max_key_pos = min(max_key_pos,
-                          causal_q_offset + start_row + valid_q_rows - 1
-                              + window_size_right);
-    }
-    if (max_key_pos < 0) {
-        num_n_tiles = 0;
-    } else {
-        num_n_tiles = min(num_n_tiles, (max_key_pos + BLOCK_N) / BLOCK_N);
-    }
-    const int min_key_pos = window_size_left >= 0
-                                ? max(0, causal_q_offset + start_row
-                                             - window_size_left)
-                                : 0;
-
-    const int tid = threadIdx.x;
-    const int warp_id = tid / MAX_THREADS_PER_WARP;
-    const int lane_id = tid % MAX_THREADS_PER_WARP;
-
-    const size_t q_head_linear = (size_t)batch_id * H + q_head_id;
-    const size_t kv_head_linear = (size_t)batch_id * H_KV + kv_head_id;
-    const __half* q_ptr = Q + q_head_linear * M * D + start_row * D;
-    const __half* k_ptr = K + kv_head_linear * N * D;
-    const __half* v_ptr = V + kv_head_linear * N * D;
-    __half* out_ptr = Out + q_head_linear * M * D + start_row * D;
-    float* softmax_lse_ptr = softmax_lse + q_head_linear * M + start_row;
-
-    extern __shared__ char smem_raw[];
-    init_smem<Config>(smem_raw);
-    auto& smem = *reinterpret_cast<typename Config::SmemLayout*>(smem_raw);
-
-    __half* sQ      = smem.q;
-    __half* sK      = smem.reuse_kv.k;
-    __half* sV      = smem.reuse_kv.v;
-    float*  sS      = smem.reuse_sp.s;
-    __half* sP      = (D == 256) ? smem.p_strict : smem.reuse_sp.p;
-    const int p_stride = (D == 256) ? P_STRIDE : S_STRIDE;
-    const int p_tile_capacity = (D == 256) ? P_SUB_TILE : BLOCK_N;
-    float*  sO      = smem.o;
-    float*  sRowMax = smem.row_max;
-    float*  sRowSum = smem.row_sum;
-    constexpr float RCP_LN2 = 1.4426950408889634f;
-    constexpr float LN2 = 0.6931471805599453f;
-    constexpr float EXP2_CLAMP = -80.0f * RCP_LN2;
-    const float softmax_scale_log2 = softmax_scale * RCP_LN2;
-
-    const int  d_stride_uint4 = (D + PER_UINT4 - 1) / PER_UINT4;
-    const int  q_stride_uint4 = (Q_STRIDE  + PER_UINT4 - 1) / PER_UINT4;
-    const int kv_stride_uint4 = (KV_STRIDE + PER_UINT4 - 1) / PER_UINT4;
-
-    if (tid < BLOCK_M) {
-        sRowMax[tid] = NEG_INF;
+      is_valid = is_valid && global_n <= global_q_pos + window_size_right;
     }
 
-    const uint4*      q_vec = reinterpret_cast<const uint4*>(q_ptr);
-    uint4*           sQ_vec = reinterpret_cast<uint4*>(sQ);
-
-    #pragma unroll 4
-    for (int idx = tid; idx < (valid_q_rows * d_stride_uint4); idx += THREADS_PER_BLOCK) {
-        const int row = idx / d_stride_uint4;
-        const int vec_col = idx % d_stride_uint4;
-        uint4 q_val = make_uint4(0, 0, 0, 0);
-        if (row < valid_q_rows && vec_col < d_stride_uint4) {
-            q_val = __ldg(&q_vec[row * d_stride_uint4 + vec_col]);
-        }
-        sQ_vec[row * q_stride_uint4 + vec_col] = q_val;
+    float acc = 0.0f;
+    if (is_valid) {
+#pragma unroll 8
+      for (int d = 0; d < D; d += 2) {
+        const __half2 q_h2 =
+            *reinterpret_cast<const __half2*>(sQ + row * Q_STRIDE + d);
+        const __half2 k_h2 =
+            *reinterpret_cast<const __half2*>(sK + col * KV_STRIDE + d);
+        const float2 q_f2 = __half22float2(q_h2);
+        const float2 k_f2 = __half22float2(k_h2);
+        acc = fmaf(q_f2.x, k_f2.x, acc);
+        acc = fmaf(q_f2.y, k_f2.y, acc);
+      }
     }
-    __syncthreads();
-
-    for (int block_n = 0; block_n < num_n_tiles; ++block_n) {
-        const int start_col = block_n * BLOCK_N;
-        if (start_col >= N) break;
-        const int valid_k_rows = min(BLOCK_N, N - start_col);
-
-        if (start_col + valid_k_rows <= min_key_pos) {
-            continue;
-        }
-
-        const uint4* k_vec     = reinterpret_cast<const uint4*>(k_ptr + start_col * D);
-        uint4*       sK_vec    = reinterpret_cast<uint4*>(sK);
-
-        #pragma unroll 2
-        for (int idx = tid; idx < (valid_k_rows * d_stride_uint4); idx += THREADS_PER_BLOCK) {
-            const int row = idx / d_stride_uint4;
-            const int vec_col = idx % d_stride_uint4;
-
-            uint4 k_val = make_uint4(0, 0, 0, 0);
-            if (row < valid_k_rows && vec_col < d_stride_uint4) {
-                k_val = __ldg(&k_vec[row * d_stride_uint4 + vec_col]);
-            }
-            sK_vec[row * kv_stride_uint4 + vec_col] = k_val;
-        }
-        __syncthreads();
-
-        if constexpr (D == 256 && !D256_WMMA_QK) {
-            compute_qk_scores_scalar_fp32<D, LOW_SMEM, IS_CAUSAL>(
-                sQ, sK, sS, valid_q_rows, valid_k_rows, start_row, start_col,
-                causal_q_offset, softmax_scale, window_size_left,
-                window_size_right);
-        } else {
-            const int num_tiles_m_qk    = (BLOCK_M + WMMA_M - 1) / WMMA_M;
-            const int num_tiles_n_qk    = (BLOCK_N + WMMA_N - 1) / WMMA_N;
-            const int num_tiles_k_qk    = (D + WMMA_K - 1) / WMMA_K;
-            const int total_tiles_qk    = num_tiles_m_qk * num_tiles_n_qk;
-            const int tiles_per_warp_qk = (total_tiles_qk + WARPS_PER_BLOCK - 1) / WARPS_PER_BLOCK;
-            const unsigned row_causal   = (lane_id & 0b1) + ((lane_id >> 2) & 0b1) * 8 + ((lane_id >> 4) & 0b1) * 4;
-            const unsigned col_causal   = ((lane_id >> 1) & 0b1) * 2 + ((lane_id >> 3) & 0b1) * 8;
-
-            for (int tile_idx = 0; tile_idx < tiles_per_warp_qk; ++tile_idx) {
-                const int global_tile_idx = warp_id * tiles_per_warp_qk + tile_idx;
-                if (global_tile_idx >= total_tiles_qk) break;
-
-                const int tile_m_idx = global_tile_idx / num_tiles_n_qk;
-                const int tile_n_idx = global_tile_idx % num_tiles_n_qk;
-
-                const int tile_m = tile_m_idx * WMMA_M;
-                const int tile_n = tile_n_idx * WMMA_N;
-
-                if (tile_m >= valid_q_rows || tile_n >= valid_k_rows) continue;
-
-                fragment<matrix_a, WMMA_M, WMMA_N, WMMA_K, half, row_major> a_frag;
-                fragment<matrix_b, WMMA_M, WMMA_N, WMMA_K, half, col_major> b_frag;
-                fragment<accumulator, WMMA_M, WMMA_N, WMMA_K, float> acc_frag;
-                fill_fragment(acc_frag, 0.0f);
-
-                #pragma unroll
-                for (int k_tile = 0; k_tile < num_tiles_k_qk; ++k_tile) {
-                    const int k_offset = k_tile * WMMA_K;
-                    if (k_offset >= D) break;
-
-                    load_matrix_sync(a_frag, sQ + tile_m * Q_STRIDE + k_offset, Q_STRIDE);
-                    load_matrix_sync(b_frag, sK + tile_n * KV_STRIDE + k_offset, KV_STRIDE);
-                    mma_sync(acc_frag, a_frag, b_frag, acc_frag);
-                }
-
-                #pragma unroll
-                for (int i = 0; i < acc_frag.num_elements; ++i) {
-                    const unsigned col = col_causal + (i & 0b1) + ((i >> 2) & 0b1) * 4;
-                    const unsigned row = row_causal + ((i >> 1) & 0b1) * 2;
-
-                    const int global_m = start_row + tile_m + row;
-                    const int global_n = start_col + tile_n + col;
-                    const int global_q_pos = global_m + causal_q_offset;
-
-                    const bool is_valid = (global_m < start_row + valid_q_rows) &&
-                                          (global_n < start_col + valid_k_rows);
-                    bool is_causal_valid = true;
-                    if constexpr (IS_CAUSAL) {
-                        is_causal_valid = global_n <= global_q_pos;
-                    }
-                    bool is_window_valid = true;
-                    if (window_size_left >= 0) {
-                        is_window_valid = is_window_valid &&
-                                          global_n >= global_q_pos - window_size_left;
-                    }
-                    if (window_size_right >= 0) {
-                        is_window_valid = is_window_valid &&
-                                          global_n <= global_q_pos + window_size_right;
-                    }
-
-                    const float qk_scale =
-                        (D == 256) ? softmax_scale : softmax_scale_log2;
-                    acc_frag.x[i] =
-                        (is_valid && is_causal_valid && is_window_valid)
-                            ? acc_frag.x[i] * qk_scale
-                            : NEG_INF;
-                }
-                store_matrix_sync(sS + tile_m * S_STRIDE + tile_n, acc_frag, S_STRIDE, mem_row_major);
-            }
-        }
-        __syncthreads();
-
-        const uint4* v_vec     = reinterpret_cast<const uint4*>(v_ptr + start_col * D);
-        uint4*       sV_vec    = reinterpret_cast<uint4*>(sV);
-
-        #pragma unroll 2
-        for (int idx = tid; idx < (valid_k_rows * d_stride_uint4); idx += THREADS_PER_BLOCK) {
-            const int row = idx / d_stride_uint4;
-            const int vec_col = idx % d_stride_uint4;
-
-            uint4 v_val = make_uint4(0, 0, 0, 0);
-            if (row < valid_k_rows && vec_col < d_stride_uint4) {
-                v_val = __ldg(&v_vec[row * d_stride_uint4 + vec_col]);
-            }
-            sV_vec[row * kv_stride_uint4 + vec_col] = v_val;
-        }
-        __syncthreads();
-
-        const int num_tiles_m_pv    = (BLOCK_M + WMMA_M - 1) / WMMA_M;
-        const int num_tiles_n_pv    = (D + WMMA_N - 1) / WMMA_N;
-        const int total_tiles_pv    = num_tiles_m_pv * num_tiles_n_pv;
-        const int tiles_per_warp_pv = (total_tiles_pv + WARPS_PER_BLOCK - 1) / WARPS_PER_BLOCK;
-        const int softmax_sub_tile = (D == 256) ? P_SUB_TILE : p_tile_capacity;
-
-        for (int sub_start = 0; sub_start < valid_k_rows;
-             sub_start += softmax_sub_tile) {
-            const int sub_valid_k_rows = min(softmax_sub_tile,
-                                             valid_k_rows - sub_start);
-
-            if (tid < valid_q_rows * THREADS_PER_ROW) {
-                const int row = tid / THREADS_PER_ROW;
-                const int thread_in_row = tid % THREADS_PER_ROW;
-                const unsigned mask = (valid_q_rows == BLOCK_M)
-                                          ? 0xFFFFFFFFU
-                                          : __activemask();
-                const int row_leader = __ffs(mask) - 1;
-
-                float*  sS_row_f = sS + row * S_STRIDE + sub_start;
-                __half* sP_row_h = sP + row * p_stride;
-
-                const int vec_cols = sub_valid_k_rows >> 2;
-                const int vecs_per_thread =
-                    (vec_cols + THREADS_PER_ROW - 1) / THREADS_PER_ROW;
-                const int tail_start = vec_cols << 2;
-
-                float thread_max = NEG_INF;
-                float4* sS_vec4 = reinterpret_cast<float4*>(sS_row_f);
-
-                #pragma unroll 4
-                for (int j = 0; j < vecs_per_thread; ++j) {
-                    int vc = thread_in_row + j * THREADS_PER_ROW;
-                    if (vc < vec_cols) {
-                        float4 v4 = sS_vec4[vc];
-                        thread_max = fmaxf(
-                            thread_max,
-                            fmaxf(fmaxf(v4.x, v4.y), fmaxf(v4.z, v4.w)));
-                    }
-                }
-
-                #pragma unroll 4
-                for (int c = tail_start + thread_in_row; c < sub_valid_k_rows;
-                     c += THREADS_PER_ROW) {
-                    thread_max = fmaxf(thread_max, sS_row_f[c]);
-                }
-
-                #pragma unroll
-                for (int o = THREADS_PER_ROW / 2; o > 0; o >>= 1) {
-                    thread_max = fmaxf(
-                        thread_max,
-                        __shfl_down_sync(mask, thread_max, o, THREADS_PER_ROW));
-                }
-
-                const float row_max =
-                    __shfl_sync(mask, thread_max, row_leader, THREADS_PER_ROW);
-                const float old_max = sRowMax[row];
-                const float new_max = fmaxf(old_max, row_max);
-                const float exp_diff = (D == 256)
-                    ? expf(fmaxf(old_max - new_max, -80.0f))
-                    : exp2f(old_max - new_max);
-
-                float thread_sum = 0.0f;
-                __half2 half_buffer[20];
-                int vc_base = thread_in_row;
-                int h2_idx = 0;
-                int tail_col = -1;
-                __half tail_value = __float2half(0.f);
-
-                #pragma unroll 4
-                for (int j = 0; j < vecs_per_thread; ++j,
-                         vc_base += THREADS_PER_ROW) {
-                    if (vc_base < vec_cols) {
-                        float4 v4 = sS_vec4[vc_base];
-
-                        float e0 = (D == 256)
-                            ? expf(fmaxf(v4.x - new_max, -80.0f))
-                            : exp2f(fmaxf(v4.x - new_max, EXP2_CLAMP));
-                        float e1 = (D == 256)
-                            ? expf(fmaxf(v4.y - new_max, -80.0f))
-                            : exp2f(fmaxf(v4.y - new_max, EXP2_CLAMP));
-                        float e2 = (D == 256)
-                            ? expf(fmaxf(v4.z - new_max, -80.0f))
-                            : exp2f(fmaxf(v4.z - new_max, EXP2_CLAMP));
-                        float e3 = (D == 256)
-                            ? expf(fmaxf(v4.w - new_max, -80.0f))
-                            : exp2f(fmaxf(v4.w - new_max, EXP2_CLAMP));
-
-                        thread_sum += (e0 + e1) + (e2 + e3);
-
-                        half_buffer[h2_idx++] =
-                            __float22half2_rn(make_float2(e0, e1));
-                        half_buffer[h2_idx++] =
-                            __float22half2_rn(make_float2(e2, e3));
-                    }
-                }
-
-                #pragma unroll 4
-                for (int c = tail_start + thread_in_row; c < sub_valid_k_rows;
-                     c += THREADS_PER_ROW) {
-                    float v = sS_row_f[c];
-                    float e = (D == 256)
-                        ? expf(fmaxf(v - new_max, -80.0f))
-                        : exp2f(fmaxf(v - new_max, EXP2_CLAMP));
-                    thread_sum += e;
-                    tail_col = c;
-                    tail_value = __float2half_rn(e);
-                }
-
-                #pragma unroll
-                for (int o = THREADS_PER_ROW / 2; o > 0; o >>= 1) {
-                    thread_sum +=
-                        __shfl_down_sync(mask, thread_sum, o, THREADS_PER_ROW);
-                }
-
-                float row_sum =
-                    __shfl_sync(mask, thread_sum, row_leader, THREADS_PER_ROW);
-
-                if (thread_in_row == 0) {
-                    sRowSum[row] = exp_diff * sRowSum[row] + row_sum;
-                    sRowMax[row] = new_max;
-                }
-
-                h2_idx = 0;
-                vc_base = thread_in_row;
-                __half2* sP_half2 = reinterpret_cast<__half2*>(sP_row_h);
-
-                #pragma unroll 4
-                for (int j = 0; j < vecs_per_thread; ++j,
-                         vc_base += THREADS_PER_ROW) {
-                    if (vc_base < vec_cols) {
-                        int base_offset = vc_base * 2;
-                        sP_half2[base_offset] = half_buffer[h2_idx++];
-                        sP_half2[base_offset + 1] = half_buffer[h2_idx++];
-                    }
-                }
-
-                if (tail_col >= 0) {
-                    sP_row_h[tail_col] = tail_value;
-                }
-
-                #pragma unroll 4
-                for (int c = tail_start + thread_in_row; c < p_tile_capacity;
-                     c += THREADS_PER_ROW) {
-                    if (c >= sub_valid_k_rows) {
-                        sP_row_h[c] = __float2half(0.f);
-                    }
-                }
-
-                if (block_n > 0 || sub_start > 0) {
-                    float*  sO_row = sO + row * O_STRIDE;
-                    float4* sO_vec = reinterpret_cast<float4*>(sO_row);
-                    const int o_vec_count = (O_STRIDE + 3) >> 2;
-                    float scale = exp_diff;
-
-                    #pragma unroll 4
-                    for (int ov = thread_in_row; ov < o_vec_count;
-                         ov += THREADS_PER_ROW) {
-                        float4 v = sO_vec[ov];
-                        v.x *= scale;
-                        v.y *= scale;
-                        v.z *= scale;
-                        v.w *= scale;
-                        sO_vec[ov] = v;
-                    }
-                }
-            }
-            __syncthreads();
-
-            if (scalar_pv) {
-                const int total_row_cols = valid_q_rows * D;
-                for (int idx = tid; idx < total_row_cols;
-                     idx += THREADS_PER_BLOCK) {
-                    const int row = idx / D;
-                    const int d_col = idx - row * D;
-                    const __half* sP_row_h = sP + row * p_stride;
-                    float acc = 0.0f;
-
-                    #pragma unroll 1
-                    for (int k_idx = 0; k_idx < sub_valid_k_rows; ++k_idx) {
-                        const float p_val = __half2float(sP_row_h[k_idx]);
-                        const float v_val = __half2float(
-                            sV[(sub_start + k_idx) * KV_STRIDE + d_col]);
-                        acc += p_val * v_val;
-                    }
-                    sO[row * O_STRIDE + d_col] += acc;
-                }
-                __syncthreads();
-                continue;
-            }
-
-            const int num_tiles_k_pv =
-                (p_tile_capacity + WMMA_K - 1) / WMMA_K;
-
-            for (int tile_idx = 0; tile_idx < tiles_per_warp_pv; ++tile_idx) {
-                const int global_tile_idx = warp_id * tiles_per_warp_pv + tile_idx;
-                if (global_tile_idx >= total_tiles_pv) break;
-
-                const int tile_m_idx = global_tile_idx / num_tiles_n_pv;
-                const int tile_d_idx = global_tile_idx % num_tiles_n_pv;
-
-                const int tile_m = tile_m_idx * WMMA_M;
-                const int tile_d = tile_d_idx * WMMA_N;
-
-                if (tile_m >= valid_q_rows) continue;
-
-                fragment<matrix_a, WMMA_M, WMMA_N, WMMA_K, half, row_major> a_frag;
-                fragment<matrix_b, WMMA_M, WMMA_N, WMMA_K, half, row_major> b_frag;
-                fragment<accumulator, WMMA_M, WMMA_N, WMMA_K, float> acc_frag;
-
-                load_matrix_sync(
-                    acc_frag,
-                    sO + tile_m * O_STRIDE + tile_d,
-                    O_STRIDE,
-                    mem_row_major);
-
-                #pragma unroll
-                for (int tile_k = 0; tile_k < num_tiles_k_pv; ++tile_k) {
-                    const int k_offset = tile_k * WMMA_K;
-                    if (k_offset >= sub_valid_k_rows) break;
-
-                    load_matrix_sync(
-                        a_frag,
-                        sP + tile_m * p_stride + k_offset,
-                        p_stride);
-                    load_matrix_sync(
-                        b_frag,
-                        sV + (sub_start + k_offset) * KV_STRIDE + tile_d,
-                        KV_STRIDE);
-                    mma_sync(acc_frag, a_frag, b_frag, acc_frag);
-                }
-                store_matrix_sync(
-                    sO + tile_m * O_STRIDE + tile_d,
-                    acc_frag,
-                    O_STRIDE,
-                    mem_row_major);
-            }
-            __syncthreads();
-        }
-    }
-
-    const int total_fp16_x4 = (valid_q_rows * D) / 4;
-
-    for (int i = tid; i < total_fp16_x4; i += THREADS_PER_BLOCK) {
-        const int row = i / (D / 4);
-        const int col = (i % (D / 4)) * 4;
-
-        const float sum_clamped = fmaxf(sRowSum[row], 1e-24f);
-        const float inv_sum = 1.0f / sum_clamped;
-        const float* sO_row = sO + row * O_STRIDE;
-
-        const __half h0 = __float2half_rn(sO_row[col + 0] * inv_sum);
-        const __half h1 = __float2half_rn(sO_row[col + 1] * inv_sum);
-        const __half h2 = __float2half_rn(sO_row[col + 2] * inv_sum);
-        const __half h3 = __float2half_rn(sO_row[col + 3] * inv_sum);
-
-        asm volatile(
-            "st.global.v4.u16 [%0], {%1, %2, %3, %4};"
-            :
-            : "l"(out_ptr + row * D + col),
-              "h"(__half_as_ushort(h0)),
-              "h"(__half_as_ushort(h1)),
-              "h"(__half_as_ushort(h2)),
-              "h"(__half_as_ushort(h3))
-            : "memory"
-        );
-    }
-
-    if (tid < valid_q_rows) {
-        const float sum = fmaxf(sRowSum[tid], 1e-24f);
-        softmax_lse_ptr[tid] = (D == 256)
-            ? sRowMax[tid] + logf(sum)
-            : (sRowMax[tid] + log2f(sum)) * LN2;
-    }
+    sS[row * S_STRIDE + col] = is_valid ? acc * score_scale : NEG_INF;
+  }
 }
 
-template<int D, bool IS_CAUSAL>
-__global__ void __launch_bounds__(KernelConfig<D>::THREADS_PER_BLOCK, 2)
-flash_attention_qk_scores_kernel(
-    const __half* __restrict__ Q,
-    const __half* __restrict__ K,
-          float* __restrict__ Scores,
-    const int B,
-    const int H,
-    const int H_KV,
-    const int M,
-    const int N,
-    const float softmax_scale
-) {
-    using Config = KernelConfig<D>;
-    constexpr int BLOCK_M           = Config::BLOCK_M;
-    constexpr int BLOCK_N           = Config::BLOCK_N;
-    constexpr int THREADS_PER_BLOCK = Config::THREADS_PER_BLOCK;
-    constexpr int WARPS_PER_BLOCK   = Config::WARPS_PER_BLOCK;
-    constexpr int Q_STRIDE          = Config::Q_STRIDE;
-    constexpr int KV_STRIDE         = Config::KV_STRIDE;
-    constexpr int S_STRIDE          = Config::S_STRIDE;
-    constexpr int PER_UINT4         = Config::PER_UINT4;
-    const float NEG_INF = -1e30f;
+template <int D, bool LOW_SMEM, bool D256_WMMA_QK, bool IS_CAUSAL>
+__global__ void __launch_bounds__(KernelConfig<D, LOW_SMEM>::THREADS_PER_BLOCK,
+                                  2)
+    flash_attention_forward_kernel(
+        const __half* __restrict__ Q, const __half* __restrict__ K,
+        const __half* __restrict__ V, __half* __restrict__ Out,
+        float* __restrict__ softmax_lse, const int B, const int H,
+        const int H_KV, const int M, const int N, const float softmax_scale,
+        const bool scalar_pv, const int window_size_left,
+        const int window_size_right) {
+  using Config = KernelConfig<D, LOW_SMEM>;
+  constexpr int BLOCK_M = Config::BLOCK_M;
+  constexpr int BLOCK_N = Config::BLOCK_N;
+  constexpr int THREADS_PER_BLOCK = Config::THREADS_PER_BLOCK;
+  constexpr int THREADS_PER_ROW = Config::THREADS_PER_ROW;
+  constexpr int WARPS_PER_BLOCK = Config::WARPS_PER_BLOCK;
+  constexpr int Q_STRIDE = Config::Q_STRIDE;
+  constexpr int KV_STRIDE = Config::KV_STRIDE;
+  constexpr int S_STRIDE = Config::S_STRIDE;
+  constexpr int P_SUB_TILE = Config::P_SUB_TILE;
+  constexpr int P_STRIDE = Config::P_STRIDE;
+  constexpr int O_STRIDE = Config::O_STRIDE;
+  constexpr int PER_UINT4 = Config::PER_UINT4;
+  const float NEG_INF = -1e30f;
 
-    const int batch_head_id = blockIdx.z;
-    if (batch_head_id >= B * H) return;
-    const int batch_id = batch_head_id / H;
-    const int q_head_id = batch_head_id % H;
-    const int kv_group_size = H / H_KV;
-    const int kv_head_id = q_head_id / kv_group_size;
+  const int batch_head_id = blockIdx.z;
+  if (batch_head_id >= B * H) return;
+  const int batch_id = batch_head_id / H;
+  const int q_head_id = batch_head_id % H;
+  const int kv_group_size = H / H_KV;
+  const int kv_head_id = q_head_id / kv_group_size;
 
-    const int block_m = blockIdx.x;
-    const int block_n = blockIdx.y;
-    const int start_row = block_m * BLOCK_M;
+  const int block_m = blockIdx.x;
+  const int start_row = block_m * BLOCK_M;
+  if (start_row >= M) return;
+
+  int num_n_tiles = (N + BLOCK_N - 1) / BLOCK_N;
+  const int valid_q_rows = min(BLOCK_M, M - start_row);
+  const int causal_q_offset = max(N - M, 0);
+
+  int max_key_pos = N - 1;
+  if constexpr (IS_CAUSAL) {
+    max_key_pos =
+        min(max_key_pos, causal_q_offset + start_row + valid_q_rows - 1);
+  }
+  if (window_size_right >= 0) {
+    max_key_pos = min(max_key_pos, causal_q_offset + start_row + valid_q_rows -
+                                       1 + window_size_right);
+  }
+  if (max_key_pos < 0) {
+    num_n_tiles = 0;
+  } else {
+    num_n_tiles = min(num_n_tiles, (max_key_pos + BLOCK_N) / BLOCK_N);
+  }
+  const int min_key_pos =
+      window_size_left >= 0
+          ? max(0, causal_q_offset + start_row - window_size_left)
+          : 0;
+
+  const int tid = threadIdx.x;
+  const int warp_id = tid / MAX_THREADS_PER_WARP;
+  const int lane_id = tid % MAX_THREADS_PER_WARP;
+
+  const size_t q_head_linear = (size_t)batch_id * H + q_head_id;
+  const size_t kv_head_linear = (size_t)batch_id * H_KV + kv_head_id;
+  const __half* q_ptr = Q + q_head_linear * M * D + start_row * D;
+  const __half* k_ptr = K + kv_head_linear * N * D;
+  const __half* v_ptr = V + kv_head_linear * N * D;
+  __half* out_ptr = Out + q_head_linear * M * D + start_row * D;
+  float* softmax_lse_ptr = softmax_lse + q_head_linear * M + start_row;
+
+  extern __shared__ char smem_raw[];
+  init_smem<Config>(smem_raw);
+  auto& smem = *reinterpret_cast<typename Config::SmemLayout*>(smem_raw);
+
+  __half* sQ = smem.q;
+  __half* sK = smem.reuse_kv.k;
+  __half* sV = smem.reuse_kv.v;
+  float* sS = smem.reuse_sp.s;
+  __half* sP = (D == 256) ? smem.p_strict : smem.reuse_sp.p;
+  const int p_stride = (D == 256) ? P_STRIDE : S_STRIDE;
+  const int p_tile_capacity = (D == 256) ? P_SUB_TILE : BLOCK_N;
+  float* sO = smem.o;
+  float* sRowMax = smem.row_max;
+  float* sRowSum = smem.row_sum;
+  constexpr float RCP_LN2 = 1.4426950408889634f;
+  constexpr float LN2 = 0.6931471805599453f;
+  constexpr float EXP2_CLAMP = -80.0f * RCP_LN2;
+  const float softmax_scale_log2 = softmax_scale * RCP_LN2;
+
+  const int d_stride_uint4 = (D + PER_UINT4 - 1) / PER_UINT4;
+  const int q_stride_uint4 = (Q_STRIDE + PER_UINT4 - 1) / PER_UINT4;
+  const int kv_stride_uint4 = (KV_STRIDE + PER_UINT4 - 1) / PER_UINT4;
+
+  if (tid < BLOCK_M) {
+    sRowMax[tid] = NEG_INF;
+  }
+
+  const uint4* q_vec = reinterpret_cast<const uint4*>(q_ptr);
+  uint4* sQ_vec = reinterpret_cast<uint4*>(sQ);
+
+#pragma unroll 4
+  for (int idx = tid; idx < (valid_q_rows * d_stride_uint4);
+       idx += THREADS_PER_BLOCK) {
+    const int row = idx / d_stride_uint4;
+    const int vec_col = idx % d_stride_uint4;
+    uint4 q_val = make_uint4(0, 0, 0, 0);
+    if (row < valid_q_rows && vec_col < d_stride_uint4) {
+      q_val = __ldg(&q_vec[row * d_stride_uint4 + vec_col]);
+    }
+    sQ_vec[row * q_stride_uint4 + vec_col] = q_val;
+  }
+  __syncthreads();
+
+  for (int block_n = 0; block_n < num_n_tiles; ++block_n) {
     const int start_col = block_n * BLOCK_N;
-    if (start_row >= M || start_col >= N) return;
-
-    const int valid_q_rows = min(BLOCK_M, M - start_row);
+    if (start_col >= N) break;
     const int valid_k_rows = min(BLOCK_N, N - start_col);
-    const int causal_q_offset = max(N - M, 0);
 
-    if constexpr (IS_CAUSAL) {
-        if (start_col >= causal_q_offset + start_row + valid_q_rows) {
-            return;
-        }
+    if (start_col + valid_k_rows <= min_key_pos) {
+      continue;
     }
 
-    const int tid = threadIdx.x;
-    const int warp_id = tid / MAX_THREADS_PER_WARP;
-    const int lane_id = tid % MAX_THREADS_PER_WARP;
-
-    const size_t q_head_linear = (size_t)batch_id * H + q_head_id;
-    const size_t kv_head_linear = (size_t)batch_id * H_KV + kv_head_id;
-    const __half* q_ptr = Q + q_head_linear * M * D + start_row * D;
-    const __half* k_ptr = K + kv_head_linear * N * D + start_col * D;
-    float* score_ptr = Scores + q_head_linear * M * N + start_row * N + start_col;
-
-    extern __shared__ char smem_raw[];
-    init_smem<Config>(smem_raw);
-    auto& smem = *reinterpret_cast<typename Config::SmemLayout*>(smem_raw);
-
-    __half* sQ = smem.q;
-    __half* sK = smem.reuse_kv.k;
-    float*  sS = smem.reuse_sp.s;
-
-    const int d_stride_uint4  = (D + PER_UINT4 - 1) / PER_UINT4;
-    const int q_stride_uint4  = (Q_STRIDE + PER_UINT4 - 1) / PER_UINT4;
-    const int kv_stride_uint4 = (KV_STRIDE + PER_UINT4 - 1) / PER_UINT4;
-
-    const uint4* q_vec = reinterpret_cast<const uint4*>(q_ptr);
-    uint4* sQ_vec = reinterpret_cast<uint4*>(sQ);
-
-    #pragma unroll 4
-    for (int idx = tid; idx < (valid_q_rows * d_stride_uint4);
-         idx += THREADS_PER_BLOCK) {
-        const int row = idx / d_stride_uint4;
-        const int vec_col = idx % d_stride_uint4;
-        uint4 q_val = make_uint4(0, 0, 0, 0);
-        if (row < valid_q_rows && vec_col < d_stride_uint4) {
-            q_val = __ldg(&q_vec[row * d_stride_uint4 + vec_col]);
-        }
-        sQ_vec[row * q_stride_uint4 + vec_col] = q_val;
-    }
-
-    const uint4* k_vec = reinterpret_cast<const uint4*>(k_ptr);
+    const uint4* k_vec = reinterpret_cast<const uint4*>(k_ptr + start_col * D);
     uint4* sK_vec = reinterpret_cast<uint4*>(sK);
 
-    #pragma unroll 2
+#pragma unroll 2
     for (int idx = tid; idx < (valid_k_rows * d_stride_uint4);
          idx += THREADS_PER_BLOCK) {
-        const int row = idx / d_stride_uint4;
-        const int vec_col = idx % d_stride_uint4;
-        uint4 k_val = make_uint4(0, 0, 0, 0);
-        if (row < valid_k_rows && vec_col < d_stride_uint4) {
-            k_val = __ldg(&k_vec[row * d_stride_uint4 + vec_col]);
-        }
-        sK_vec[row * kv_stride_uint4 + vec_col] = k_val;
+      const int row = idx / d_stride_uint4;
+      const int vec_col = idx % d_stride_uint4;
+
+      uint4 k_val = make_uint4(0, 0, 0, 0);
+      if (row < valid_k_rows && vec_col < d_stride_uint4) {
+        k_val = __ldg(&k_vec[row * d_stride_uint4 + vec_col]);
+      }
+      sK_vec[row * kv_stride_uint4 + vec_col] = k_val;
     }
     __syncthreads();
 
-    if constexpr (D == 256) {
-        compute_qk_scores_scalar_fp32<D, false, IS_CAUSAL>(
-            sQ, sK, sS, valid_q_rows, valid_k_rows, start_row, start_col,
-            causal_q_offset, softmax_scale, -1, -1);
+    if constexpr (D == 256 && !D256_WMMA_QK) {
+      compute_qk_scores_scalar_fp32<D, LOW_SMEM, IS_CAUSAL>(
+          sQ, sK, sS, valid_q_rows, valid_k_rows, start_row, start_col,
+          causal_q_offset, softmax_scale, window_size_left, window_size_right);
     } else {
-        const int num_tiles_m_qk = (BLOCK_M + WMMA_M - 1) / WMMA_M;
-        const int num_tiles_n_qk = (BLOCK_N + WMMA_N - 1) / WMMA_N;
-        const int num_tiles_k_qk = (D + WMMA_K - 1) / WMMA_K;
-        const int total_tiles_qk = num_tiles_m_qk * num_tiles_n_qk;
-        const int tiles_per_warp_qk =
-            (total_tiles_qk + WARPS_PER_BLOCK - 1) / WARPS_PER_BLOCK;
-        const unsigned row_causal =
-            (lane_id & 0b1) + ((lane_id >> 2) & 0b1) * 8
-            + ((lane_id >> 4) & 0b1) * 4;
-        const unsigned col_causal =
-            ((lane_id >> 1) & 0b1) * 2 + ((lane_id >> 3) & 0b1) * 8;
+      const int num_tiles_m_qk = (BLOCK_M + WMMA_M - 1) / WMMA_M;
+      const int num_tiles_n_qk = (BLOCK_N + WMMA_N - 1) / WMMA_N;
+      const int num_tiles_k_qk = (D + WMMA_K - 1) / WMMA_K;
+      const int total_tiles_qk = num_tiles_m_qk * num_tiles_n_qk;
+      const int tiles_per_warp_qk =
+          (total_tiles_qk + WARPS_PER_BLOCK - 1) / WARPS_PER_BLOCK;
+      const unsigned row_causal = (lane_id & 0b1) + ((lane_id >> 2) & 0b1) * 8 +
+                                  ((lane_id >> 4) & 0b1) * 4;
+      const unsigned col_causal =
+          ((lane_id >> 1) & 0b1) * 2 + ((lane_id >> 3) & 0b1) * 8;
 
-        for (int tile_idx = 0; tile_idx < tiles_per_warp_qk; ++tile_idx) {
-            const int global_tile_idx = warp_id * tiles_per_warp_qk + tile_idx;
-            if (global_tile_idx >= total_tiles_qk) break;
+      for (int tile_idx = 0; tile_idx < tiles_per_warp_qk; ++tile_idx) {
+        const int global_tile_idx = warp_id * tiles_per_warp_qk + tile_idx;
+        if (global_tile_idx >= total_tiles_qk) break;
 
-            const int tile_m_idx = global_tile_idx / num_tiles_n_qk;
-            const int tile_n_idx = global_tile_idx % num_tiles_n_qk;
+        const int tile_m_idx = global_tile_idx / num_tiles_n_qk;
+        const int tile_n_idx = global_tile_idx % num_tiles_n_qk;
 
-            const int tile_m = tile_m_idx * WMMA_M;
-            const int tile_n = tile_n_idx * WMMA_N;
+        const int tile_m = tile_m_idx * WMMA_M;
+        const int tile_n = tile_n_idx * WMMA_N;
 
-            if (tile_m >= valid_q_rows || tile_n >= valid_k_rows) continue;
+        if (tile_m >= valid_q_rows || tile_n >= valid_k_rows) continue;
 
-            fragment<matrix_a, WMMA_M, WMMA_N, WMMA_K, half, row_major> a_frag;
-            fragment<matrix_b, WMMA_M, WMMA_N, WMMA_K, half, col_major> b_frag;
-            fragment<accumulator, WMMA_M, WMMA_N, WMMA_K, float> acc_frag;
-            fill_fragment(acc_frag, 0.0f);
+        fragment<matrix_a, WMMA_M, WMMA_N, WMMA_K, half, row_major> a_frag;
+        fragment<matrix_b, WMMA_M, WMMA_N, WMMA_K, half, col_major> b_frag;
+        fragment<accumulator, WMMA_M, WMMA_N, WMMA_K, float> acc_frag;
+        fill_fragment(acc_frag, 0.0f);
 
-            #pragma unroll
-            for (int k_tile = 0; k_tile < num_tiles_k_qk; ++k_tile) {
-                const int k_offset = k_tile * WMMA_K;
-                if (k_offset >= D) break;
+#pragma unroll
+        for (int k_tile = 0; k_tile < num_tiles_k_qk; ++k_tile) {
+          const int k_offset = k_tile * WMMA_K;
+          if (k_offset >= D) break;
 
-                load_matrix_sync(a_frag, sQ + tile_m * Q_STRIDE + k_offset,
-                                 Q_STRIDE);
-                load_matrix_sync(b_frag, sK + tile_n * KV_STRIDE + k_offset,
-                                 KV_STRIDE);
-                mma_sync(acc_frag, a_frag, b_frag, acc_frag);
-            }
-
-            if constexpr (IS_CAUSAL) {
-                #pragma unroll
-                for (int i = 0; i < acc_frag.num_elements; ++i) {
-                    const unsigned col =
-                        col_causal + (i & 0b1) + ((i >> 2) & 0b1) * 4;
-                    const unsigned row = row_causal + ((i >> 1) & 0b1) * 2;
-
-                    const int global_m = start_row + tile_m + row;
-                    const int global_n = start_col + tile_n + col;
-                    const int global_q_pos = global_m + causal_q_offset;
-
-                    const bool is_valid =
-                        (global_m < start_row + valid_q_rows) &&
-                        (global_n < start_col + valid_k_rows);
-
-                    acc_frag.x[i] = is_valid
-                        ? ((global_n > global_q_pos)
-                               ? NEG_INF
-                               : acc_frag.x[i] * softmax_scale)
-                        : NEG_INF;
-                }
-            } else {
-                #pragma unroll
-                for (int i = 0; i < acc_frag.num_elements; ++i) {
-                    acc_frag.x[i] *= softmax_scale;
-                }
-            }
-            store_matrix_sync(sS + tile_m * S_STRIDE + tile_n, acc_frag,
-                              S_STRIDE, mem_row_major);
+          load_matrix_sync(a_frag, sQ + tile_m * Q_STRIDE + k_offset, Q_STRIDE);
+          load_matrix_sync(b_frag, sK + tile_n * KV_STRIDE + k_offset,
+                           KV_STRIDE);
+          mma_sync(acc_frag, a_frag, b_frag, acc_frag);
         }
+
+#pragma unroll
+        for (int i = 0; i < acc_frag.num_elements; ++i) {
+          const unsigned col = col_causal + (i & 0b1) + ((i >> 2) & 0b1) * 4;
+          const unsigned row = row_causal + ((i >> 1) & 0b1) * 2;
+
+          const int global_m = start_row + tile_m + row;
+          const int global_n = start_col + tile_n + col;
+          const int global_q_pos = global_m + causal_q_offset;
+
+          const bool is_valid = (global_m < start_row + valid_q_rows) &&
+                                (global_n < start_col + valid_k_rows);
+          bool is_causal_valid = true;
+          if constexpr (IS_CAUSAL) {
+            is_causal_valid = global_n <= global_q_pos;
+          }
+          bool is_window_valid = true;
+          if (window_size_left >= 0) {
+            is_window_valid =
+                is_window_valid && global_n >= global_q_pos - window_size_left;
+          }
+          if (window_size_right >= 0) {
+            is_window_valid =
+                is_window_valid && global_n <= global_q_pos + window_size_right;
+          }
+
+          const float qk_scale =
+              (D == 256) ? softmax_scale : softmax_scale_log2;
+          acc_frag.x[i] = (is_valid && is_causal_valid && is_window_valid)
+                              ? acc_frag.x[i] * qk_scale
+                              : NEG_INF;
+        }
+        store_matrix_sync(sS + tile_m * S_STRIDE + tile_n, acc_frag, S_STRIDE,
+                          mem_row_major);
+      }
     }
     __syncthreads();
 
-    for (int idx = tid; idx < valid_q_rows * valid_k_rows;
+    const uint4* v_vec = reinterpret_cast<const uint4*>(v_ptr + start_col * D);
+    uint4* sV_vec = reinterpret_cast<uint4*>(sV);
+
+#pragma unroll 2
+    for (int idx = tid; idx < (valid_k_rows * d_stride_uint4);
          idx += THREADS_PER_BLOCK) {
-        const int row = idx / valid_k_rows;
-        const int col = idx % valid_k_rows;
-        score_ptr[row * N + col] = sS[row * S_STRIDE + col];
+      const int row = idx / d_stride_uint4;
+      const int vec_col = idx % d_stride_uint4;
+
+      uint4 v_val = make_uint4(0, 0, 0, 0);
+      if (row < valid_k_rows && vec_col < d_stride_uint4) {
+        v_val = __ldg(&v_vec[row * d_stride_uint4 + vec_col]);
+      }
+      sV_vec[row * kv_stride_uint4 + vec_col] = v_val;
     }
+    __syncthreads();
+
+    const int num_tiles_m_pv = (BLOCK_M + WMMA_M - 1) / WMMA_M;
+    const int num_tiles_n_pv = (D + WMMA_N - 1) / WMMA_N;
+    const int total_tiles_pv = num_tiles_m_pv * num_tiles_n_pv;
+    const int tiles_per_warp_pv =
+        (total_tiles_pv + WARPS_PER_BLOCK - 1) / WARPS_PER_BLOCK;
+    const int softmax_sub_tile = (D == 256) ? P_SUB_TILE : p_tile_capacity;
+
+    for (int sub_start = 0; sub_start < valid_k_rows;
+         sub_start += softmax_sub_tile) {
+      const int sub_valid_k_rows =
+          min(softmax_sub_tile, valid_k_rows - sub_start);
+
+      if (tid < valid_q_rows * THREADS_PER_ROW) {
+        const int row = tid / THREADS_PER_ROW;
+        const int thread_in_row = tid % THREADS_PER_ROW;
+        const unsigned mask =
+            (valid_q_rows == BLOCK_M) ? 0xFFFFFFFFU : __activemask();
+        const int row_leader = __ffs(mask) - 1;
+
+        float* sS_row_f = sS + row * S_STRIDE + sub_start;
+        __half* sP_row_h = sP + row * p_stride;
+
+        const int vec_cols = sub_valid_k_rows >> 2;
+        const int vecs_per_thread =
+            (vec_cols + THREADS_PER_ROW - 1) / THREADS_PER_ROW;
+        const int tail_start = vec_cols << 2;
+
+        float thread_max = NEG_INF;
+        float4* sS_vec4 = reinterpret_cast<float4*>(sS_row_f);
+
+#pragma unroll 4
+        for (int j = 0; j < vecs_per_thread; ++j) {
+          int vc = thread_in_row + j * THREADS_PER_ROW;
+          if (vc < vec_cols) {
+            float4 v4 = sS_vec4[vc];
+            thread_max =
+                fmaxf(thread_max, fmaxf(fmaxf(v4.x, v4.y), fmaxf(v4.z, v4.w)));
+          }
+        }
+
+#pragma unroll 4
+        for (int c = tail_start + thread_in_row; c < sub_valid_k_rows;
+             c += THREADS_PER_ROW) {
+          thread_max = fmaxf(thread_max, sS_row_f[c]);
+        }
+
+#pragma unroll
+        for (int o = THREADS_PER_ROW / 2; o > 0; o >>= 1) {
+          thread_max = fmaxf(thread_max, __shfl_down_sync(mask, thread_max, o,
+                                                          THREADS_PER_ROW));
+        }
+
+        const float row_max =
+            __shfl_sync(mask, thread_max, row_leader, THREADS_PER_ROW);
+        const float old_max = sRowMax[row];
+        const float new_max = fmaxf(old_max, row_max);
+        const float exp_diff = (D == 256)
+                                   ? expf(fmaxf(old_max - new_max, -80.0f))
+                                   : exp2f(old_max - new_max);
+
+        float thread_sum = 0.0f;
+        __half2 half_buffer[20];
+        int vc_base = thread_in_row;
+        int h2_idx = 0;
+        int tail_col = -1;
+        __half tail_value = __float2half(0.f);
+
+#pragma unroll 4
+        for (int j = 0; j < vecs_per_thread; ++j, vc_base += THREADS_PER_ROW) {
+          if (vc_base < vec_cols) {
+            float4 v4 = sS_vec4[vc_base];
+
+            float e0 = (D == 256) ? expf(fmaxf(v4.x - new_max, -80.0f))
+                                  : exp2f(fmaxf(v4.x - new_max, EXP2_CLAMP));
+            float e1 = (D == 256) ? expf(fmaxf(v4.y - new_max, -80.0f))
+                                  : exp2f(fmaxf(v4.y - new_max, EXP2_CLAMP));
+            float e2 = (D == 256) ? expf(fmaxf(v4.z - new_max, -80.0f))
+                                  : exp2f(fmaxf(v4.z - new_max, EXP2_CLAMP));
+            float e3 = (D == 256) ? expf(fmaxf(v4.w - new_max, -80.0f))
+                                  : exp2f(fmaxf(v4.w - new_max, EXP2_CLAMP));
+
+            thread_sum += (e0 + e1) + (e2 + e3);
+
+            half_buffer[h2_idx++] = __float22half2_rn(make_float2(e0, e1));
+            half_buffer[h2_idx++] = __float22half2_rn(make_float2(e2, e3));
+          }
+        }
+
+#pragma unroll 4
+        for (int c = tail_start + thread_in_row; c < sub_valid_k_rows;
+             c += THREADS_PER_ROW) {
+          float v = sS_row_f[c];
+          float e = (D == 256) ? expf(fmaxf(v - new_max, -80.0f))
+                               : exp2f(fmaxf(v - new_max, EXP2_CLAMP));
+          thread_sum += e;
+          tail_col = c;
+          tail_value = __float2half_rn(e);
+        }
+
+#pragma unroll
+        for (int o = THREADS_PER_ROW / 2; o > 0; o >>= 1) {
+          thread_sum += __shfl_down_sync(mask, thread_sum, o, THREADS_PER_ROW);
+        }
+
+        float row_sum =
+            __shfl_sync(mask, thread_sum, row_leader, THREADS_PER_ROW);
+
+        if (thread_in_row == 0) {
+          sRowSum[row] = exp_diff * sRowSum[row] + row_sum;
+          sRowMax[row] = new_max;
+        }
+
+        h2_idx = 0;
+        vc_base = thread_in_row;
+        __half2* sP_half2 = reinterpret_cast<__half2*>(sP_row_h);
+
+#pragma unroll 4
+        for (int j = 0; j < vecs_per_thread; ++j, vc_base += THREADS_PER_ROW) {
+          if (vc_base < vec_cols) {
+            int base_offset = vc_base * 2;
+            sP_half2[base_offset] = half_buffer[h2_idx++];
+            sP_half2[base_offset + 1] = half_buffer[h2_idx++];
+          }
+        }
+
+        if (tail_col >= 0) {
+          sP_row_h[tail_col] = tail_value;
+        }
+
+#pragma unroll 4
+        for (int c = tail_start + thread_in_row; c < p_tile_capacity;
+             c += THREADS_PER_ROW) {
+          if (c >= sub_valid_k_rows) {
+            sP_row_h[c] = __float2half(0.f);
+          }
+        }
+
+        if (block_n > 0 || sub_start > 0) {
+          float* sO_row = sO + row * O_STRIDE;
+          float4* sO_vec = reinterpret_cast<float4*>(sO_row);
+          const int o_vec_count = (O_STRIDE + 3) >> 2;
+          float scale = exp_diff;
+
+#pragma unroll 4
+          for (int ov = thread_in_row; ov < o_vec_count;
+               ov += THREADS_PER_ROW) {
+            float4 v = sO_vec[ov];
+            v.x *= scale;
+            v.y *= scale;
+            v.z *= scale;
+            v.w *= scale;
+            sO_vec[ov] = v;
+          }
+        }
+      }
+      __syncthreads();
+
+      if (scalar_pv) {
+        const int total_row_cols = valid_q_rows * D;
+        for (int idx = tid; idx < total_row_cols; idx += THREADS_PER_BLOCK) {
+          const int row = idx / D;
+          const int d_col = idx - row * D;
+          const __half* sP_row_h = sP + row * p_stride;
+          float acc = 0.0f;
+
+#pragma unroll 1
+          for (int k_idx = 0; k_idx < sub_valid_k_rows; ++k_idx) {
+            const float p_val = __half2float(sP_row_h[k_idx]);
+            const float v_val =
+                __half2float(sV[(sub_start + k_idx) * KV_STRIDE + d_col]);
+            acc += p_val * v_val;
+          }
+          sO[row * O_STRIDE + d_col] += acc;
+        }
+        __syncthreads();
+        continue;
+      }
+
+      const int num_tiles_k_pv = (p_tile_capacity + WMMA_K - 1) / WMMA_K;
+
+      for (int tile_idx = 0; tile_idx < tiles_per_warp_pv; ++tile_idx) {
+        const int global_tile_idx = warp_id * tiles_per_warp_pv + tile_idx;
+        if (global_tile_idx >= total_tiles_pv) break;
+
+        const int tile_m_idx = global_tile_idx / num_tiles_n_pv;
+        const int tile_d_idx = global_tile_idx % num_tiles_n_pv;
+
+        const int tile_m = tile_m_idx * WMMA_M;
+        const int tile_d = tile_d_idx * WMMA_N;
+
+        if (tile_m >= valid_q_rows) continue;
+
+        fragment<matrix_a, WMMA_M, WMMA_N, WMMA_K, half, row_major> a_frag;
+        fragment<matrix_b, WMMA_M, WMMA_N, WMMA_K, half, row_major> b_frag;
+        fragment<accumulator, WMMA_M, WMMA_N, WMMA_K, float> acc_frag;
+
+        load_matrix_sync(acc_frag, sO + tile_m * O_STRIDE + tile_d, O_STRIDE,
+                         mem_row_major);
+
+#pragma unroll
+        for (int tile_k = 0; tile_k < num_tiles_k_pv; ++tile_k) {
+          const int k_offset = tile_k * WMMA_K;
+          if (k_offset >= sub_valid_k_rows) break;
+
+          load_matrix_sync(a_frag, sP + tile_m * p_stride + k_offset, p_stride);
+          load_matrix_sync(b_frag,
+                           sV + (sub_start + k_offset) * KV_STRIDE + tile_d,
+                           KV_STRIDE);
+          mma_sync(acc_frag, a_frag, b_frag, acc_frag);
+        }
+        store_matrix_sync(sO + tile_m * O_STRIDE + tile_d, acc_frag, O_STRIDE,
+                          mem_row_major);
+      }
+      __syncthreads();
+    }
+  }
+
+  const int total_fp16_x4 = (valid_q_rows * D) / 4;
+
+  for (int i = tid; i < total_fp16_x4; i += THREADS_PER_BLOCK) {
+    const int row = i / (D / 4);
+    const int col = (i % (D / 4)) * 4;
+
+    const float sum_clamped = fmaxf(sRowSum[row], 1e-24f);
+    const float inv_sum = 1.0f / sum_clamped;
+    const float* sO_row = sO + row * O_STRIDE;
+
+    const __half h0 = __float2half_rn(sO_row[col + 0] * inv_sum);
+    const __half h1 = __float2half_rn(sO_row[col + 1] * inv_sum);
+    const __half h2 = __float2half_rn(sO_row[col + 2] * inv_sum);
+    const __half h3 = __float2half_rn(sO_row[col + 3] * inv_sum);
+
+    asm volatile("st.global.v4.u16 [%0], {%1, %2, %3, %4};"
+                 :
+                 : "l"(out_ptr + row * D + col), "h"(__half_as_ushort(h0)),
+                   "h"(__half_as_ushort(h1)), "h"(__half_as_ushort(h2)),
+                   "h"(__half_as_ushort(h3))
+                 : "memory");
+  }
+
+  if (tid < valid_q_rows) {
+    const float sum = fmaxf(sRowSum[tid], 1e-24f);
+    softmax_lse_ptr[tid] = (D == 256) ? sRowMax[tid] + logf(sum)
+                                      : (sRowMax[tid] + log2f(sum)) * LN2;
+  }
 }
 
-template<int D, bool LOW_SMEM, bool D256_WMMA_QK>
+template <int D, bool IS_CAUSAL>
+__global__ void __launch_bounds__(KernelConfig<D>::THREADS_PER_BLOCK, 2)
+    flash_attention_qk_scores_kernel(const __half* __restrict__ Q,
+                                     const __half* __restrict__ K,
+                                     float* __restrict__ Scores, const int B,
+                                     const int H, const int H_KV, const int M,
+                                     const int N, const float softmax_scale) {
+  using Config = KernelConfig<D>;
+  constexpr int BLOCK_M = Config::BLOCK_M;
+  constexpr int BLOCK_N = Config::BLOCK_N;
+  constexpr int THREADS_PER_BLOCK = Config::THREADS_PER_BLOCK;
+  constexpr int WARPS_PER_BLOCK = Config::WARPS_PER_BLOCK;
+  constexpr int Q_STRIDE = Config::Q_STRIDE;
+  constexpr int KV_STRIDE = Config::KV_STRIDE;
+  constexpr int S_STRIDE = Config::S_STRIDE;
+  constexpr int PER_UINT4 = Config::PER_UINT4;
+  const float NEG_INF = -1e30f;
+
+  const int batch_head_id = blockIdx.z;
+  if (batch_head_id >= B * H) return;
+  const int batch_id = batch_head_id / H;
+  const int q_head_id = batch_head_id % H;
+  const int kv_group_size = H / H_KV;
+  const int kv_head_id = q_head_id / kv_group_size;
+
+  const int block_m = blockIdx.x;
+  const int block_n = blockIdx.y;
+  const int start_row = block_m * BLOCK_M;
+  const int start_col = block_n * BLOCK_N;
+  if (start_row >= M || start_col >= N) return;
+
+  const int valid_q_rows = min(BLOCK_M, M - start_row);
+  const int valid_k_rows = min(BLOCK_N, N - start_col);
+  const int causal_q_offset = max(N - M, 0);
+
+  if constexpr (IS_CAUSAL) {
+    if (start_col >= causal_q_offset + start_row + valid_q_rows) {
+      return;
+    }
+  }
+
+  const int tid = threadIdx.x;
+  const int warp_id = tid / MAX_THREADS_PER_WARP;
+  const int lane_id = tid % MAX_THREADS_PER_WARP;
+
+  const size_t q_head_linear = (size_t)batch_id * H + q_head_id;
+  const size_t kv_head_linear = (size_t)batch_id * H_KV + kv_head_id;
+  const __half* q_ptr = Q + q_head_linear * M * D + start_row * D;
+  const __half* k_ptr = K + kv_head_linear * N * D + start_col * D;
+  float* score_ptr = Scores + q_head_linear * M * N + start_row * N + start_col;
+
+  extern __shared__ char smem_raw[];
+  init_smem<Config>(smem_raw);
+  auto& smem = *reinterpret_cast<typename Config::SmemLayout*>(smem_raw);
+
+  __half* sQ = smem.q;
+  __half* sK = smem.reuse_kv.k;
+  float* sS = smem.reuse_sp.s;
+
+  const int d_stride_uint4 = (D + PER_UINT4 - 1) / PER_UINT4;
+  const int q_stride_uint4 = (Q_STRIDE + PER_UINT4 - 1) / PER_UINT4;
+  const int kv_stride_uint4 = (KV_STRIDE + PER_UINT4 - 1) / PER_UINT4;
+
+  const uint4* q_vec = reinterpret_cast<const uint4*>(q_ptr);
+  uint4* sQ_vec = reinterpret_cast<uint4*>(sQ);
+
+#pragma unroll 4
+  for (int idx = tid; idx < (valid_q_rows * d_stride_uint4);
+       idx += THREADS_PER_BLOCK) {
+    const int row = idx / d_stride_uint4;
+    const int vec_col = idx % d_stride_uint4;
+    uint4 q_val = make_uint4(0, 0, 0, 0);
+    if (row < valid_q_rows && vec_col < d_stride_uint4) {
+      q_val = __ldg(&q_vec[row * d_stride_uint4 + vec_col]);
+    }
+    sQ_vec[row * q_stride_uint4 + vec_col] = q_val;
+  }
+
+  const uint4* k_vec = reinterpret_cast<const uint4*>(k_ptr);
+  uint4* sK_vec = reinterpret_cast<uint4*>(sK);
+
+#pragma unroll 2
+  for (int idx = tid; idx < (valid_k_rows * d_stride_uint4);
+       idx += THREADS_PER_BLOCK) {
+    const int row = idx / d_stride_uint4;
+    const int vec_col = idx % d_stride_uint4;
+    uint4 k_val = make_uint4(0, 0, 0, 0);
+    if (row < valid_k_rows && vec_col < d_stride_uint4) {
+      k_val = __ldg(&k_vec[row * d_stride_uint4 + vec_col]);
+    }
+    sK_vec[row * kv_stride_uint4 + vec_col] = k_val;
+  }
+  __syncthreads();
+
+  if constexpr (D == 256) {
+    compute_qk_scores_scalar_fp32<D, false, IS_CAUSAL>(
+        sQ, sK, sS, valid_q_rows, valid_k_rows, start_row, start_col,
+        causal_q_offset, softmax_scale, -1, -1);
+  } else {
+    const int num_tiles_m_qk = (BLOCK_M + WMMA_M - 1) / WMMA_M;
+    const int num_tiles_n_qk = (BLOCK_N + WMMA_N - 1) / WMMA_N;
+    const int num_tiles_k_qk = (D + WMMA_K - 1) / WMMA_K;
+    const int total_tiles_qk = num_tiles_m_qk * num_tiles_n_qk;
+    const int tiles_per_warp_qk =
+        (total_tiles_qk + WARPS_PER_BLOCK - 1) / WARPS_PER_BLOCK;
+    const unsigned row_causal = (lane_id & 0b1) + ((lane_id >> 2) & 0b1) * 8 +
+                                ((lane_id >> 4) & 0b1) * 4;
+    const unsigned col_causal =
+        ((lane_id >> 1) & 0b1) * 2 + ((lane_id >> 3) & 0b1) * 8;
+
+    for (int tile_idx = 0; tile_idx < tiles_per_warp_qk; ++tile_idx) {
+      const int global_tile_idx = warp_id * tiles_per_warp_qk + tile_idx;
+      if (global_tile_idx >= total_tiles_qk) break;
+
+      const int tile_m_idx = global_tile_idx / num_tiles_n_qk;
+      const int tile_n_idx = global_tile_idx % num_tiles_n_qk;
+
+      const int tile_m = tile_m_idx * WMMA_M;
+      const int tile_n = tile_n_idx * WMMA_N;
+
+      if (tile_m >= valid_q_rows || tile_n >= valid_k_rows) continue;
+
+      fragment<matrix_a, WMMA_M, WMMA_N, WMMA_K, half, row_major> a_frag;
+      fragment<matrix_b, WMMA_M, WMMA_N, WMMA_K, half, col_major> b_frag;
+      fragment<accumulator, WMMA_M, WMMA_N, WMMA_K, float> acc_frag;
+      fill_fragment(acc_frag, 0.0f);
+
+#pragma unroll
+      for (int k_tile = 0; k_tile < num_tiles_k_qk; ++k_tile) {
+        const int k_offset = k_tile * WMMA_K;
+        if (k_offset >= D) break;
+
+        load_matrix_sync(a_frag, sQ + tile_m * Q_STRIDE + k_offset, Q_STRIDE);
+        load_matrix_sync(b_frag, sK + tile_n * KV_STRIDE + k_offset, KV_STRIDE);
+        mma_sync(acc_frag, a_frag, b_frag, acc_frag);
+      }
+
+      if constexpr (IS_CAUSAL) {
+#pragma unroll
+        for (int i = 0; i < acc_frag.num_elements; ++i) {
+          const unsigned col = col_causal + (i & 0b1) + ((i >> 2) & 0b1) * 4;
+          const unsigned row = row_causal + ((i >> 1) & 0b1) * 2;
+
+          const int global_m = start_row + tile_m + row;
+          const int global_n = start_col + tile_n + col;
+          const int global_q_pos = global_m + causal_q_offset;
+
+          const bool is_valid = (global_m < start_row + valid_q_rows) &&
+                                (global_n < start_col + valid_k_rows);
+
+          acc_frag.x[i] = is_valid ? ((global_n > global_q_pos)
+                                          ? NEG_INF
+                                          : acc_frag.x[i] * softmax_scale)
+                                   : NEG_INF;
+        }
+      } else {
+#pragma unroll
+        for (int i = 0; i < acc_frag.num_elements; ++i) {
+          acc_frag.x[i] *= softmax_scale;
+        }
+      }
+      store_matrix_sync(sS + tile_m * S_STRIDE + tile_n, acc_frag, S_STRIDE,
+                        mem_row_major);
+    }
+  }
+  __syncthreads();
+
+  for (int idx = tid; idx < valid_q_rows * valid_k_rows;
+       idx += THREADS_PER_BLOCK) {
+    const int row = idx / valid_k_rows;
+    const int col = idx % valid_k_rows;
+    score_ptr[row * N + col] = sS[row * S_STRIDE + col];
+  }
+}
+
+template <int D, bool LOW_SMEM, bool D256_WMMA_QK>
 void launcher_flash_attention_forward_impl(
-    const torch::Tensor& Q,
-    const torch::Tensor& K,
-    const torch::Tensor& V,
-    torch::Tensor& Out,
-    torch::Tensor& softmax_lse,
-    float softmax_scale,
-    bool is_causal,
-    bool scalar_pv,
-    int window_size_left,
-    int window_size_right,
-    cudaStream_t stream
-) {
-    using Config = KernelConfig<D, LOW_SMEM>;
+    const torch::Tensor& Q, const torch::Tensor& K, const torch::Tensor& V,
+    torch::Tensor& Out, torch::Tensor& softmax_lse, float softmax_scale,
+    bool is_causal, bool scalar_pv, int window_size_left, int window_size_right,
+    cudaStream_t stream) {
+  using Config = KernelConfig<D, LOW_SMEM>;
 
-    const int B = Q.size(0);
-    const int H = Q.size(1);
-    const int H_KV = K.size(1);
-    const int M = Q.size(2);
-    const int N = K.size(2);
+  const int B = Q.size(0);
+  const int H = Q.size(1);
+  const int H_KV = K.size(1);
+  const int M = Q.size(2);
+  const int N = K.size(2);
 
-    const int grid_x = (M + Config::BLOCK_M - 1) / Config::BLOCK_M;
-    const dim3 grid(grid_x, 1, B * H);
-    const dim3 block(Config::THREADS_PER_BLOCK);
-    const size_t smem = Config::TOTAL_SMEM;
+  const int grid_x = (M + Config::BLOCK_M - 1) / Config::BLOCK_M;
+  const dim3 grid(grid_x, 1, B * H);
+  const dim3 block(Config::THREADS_PER_BLOCK);
+  const size_t smem = Config::TOTAL_SMEM;
 
-    TORCH_CHECK(smem <= MAX_SMEM_PER_SM, "Shared memory exceeds 96KB: ", smem, " bytes");
+  TORCH_CHECK(smem <= MAX_SMEM_PER_SM, "Shared memory exceeds 96KB: ", smem,
+              " bytes");
 
-    auto kernel = is_causal ?
-        (void*)flash_attention_forward_kernel<D, LOW_SMEM, D256_WMMA_QK, true> :
-        (void*)flash_attention_forward_kernel<D, LOW_SMEM, D256_WMMA_QK, false>;
+  auto kernel =
+      is_causal
+          ? (void*)
+                flash_attention_forward_kernel<D, LOW_SMEM, D256_WMMA_QK, true>
+          : (void*)flash_attention_forward_kernel<D, LOW_SMEM, D256_WMMA_QK,
+                                                  false>;
 
-    cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem);
+  cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize,
+                       smem);
 
-    if (is_causal) {
-        flash_attention_forward_kernel<D, LOW_SMEM, D256_WMMA_QK, true>
+  if (is_causal) {
+    flash_attention_forward_kernel<D, LOW_SMEM, D256_WMMA_QK, true>
         <<<grid, block, smem, stream>>>(
             reinterpret_cast<const __half*>(Q.data_ptr()),
             reinterpret_cast<const __half*>(K.data_ptr()),
             reinterpret_cast<const __half*>(V.data_ptr()),
             reinterpret_cast<__half*>(Out.data_ptr()),
-            softmax_lse.data_ptr<float>(),
-            B, H, H_KV, M, N, softmax_scale, scalar_pv,
-            window_size_left, window_size_right
-        );
-    } else {
-        flash_attention_forward_kernel<D, LOW_SMEM, D256_WMMA_QK, false>
+            softmax_lse.data_ptr<float>(), B, H, H_KV, M, N, softmax_scale,
+            scalar_pv, window_size_left, window_size_right);
+  } else {
+    flash_attention_forward_kernel<D, LOW_SMEM, D256_WMMA_QK, false>
         <<<grid, block, smem, stream>>>(
             reinterpret_cast<const __half*>(Q.data_ptr()),
             reinterpret_cast<const __half*>(K.data_ptr()),
             reinterpret_cast<const __half*>(V.data_ptr()),
             reinterpret_cast<__half*>(Out.data_ptr()),
-            softmax_lse.data_ptr<float>(),
-            B, H, H_KV, M, N, softmax_scale, scalar_pv,
-            window_size_left, window_size_right
-        );
-    }
+            softmax_lse.data_ptr<float>(), B, H, H_KV, M, N, softmax_scale,
+            scalar_pv, window_size_left, window_size_right);
+  }
 }
 
-template<int D>
+template <int D>
 void launcher_flash_attention_forward(
-    const torch::Tensor& Q,
-    const torch::Tensor& K,
-    const torch::Tensor& V,
-    torch::Tensor& Out,
-    torch::Tensor& softmax_lse,
-    float softmax_scale,
-    bool is_causal,
-    bool scalar_pv,
-    int window_size_left,
-    int window_size_right,
-    cudaStream_t stream
-) {
-    if constexpr (D == 256) {
-        const bool use_wmma_qk =
-            env_flag_enabled_default_on("VLLM_FLASH_V100_DENSE_D256_WMMA_QK");
-        if (env_flag_enabled("VLLM_FLASH_V100_DENSE_D256_LOW_SMEM")) {
-            if (use_wmma_qk) {
-                launcher_flash_attention_forward_impl<D, true, true>(
-                    Q, K, V, Out, softmax_lse, softmax_scale, is_causal,
-                    scalar_pv, window_size_left, window_size_right, stream);
-            } else {
-                launcher_flash_attention_forward_impl<D, true, false>(
-                    Q, K, V, Out, softmax_lse, softmax_scale, is_causal,
-                    scalar_pv, window_size_left, window_size_right, stream);
-            }
-            return;
-        }
-        if (use_wmma_qk) {
-            launcher_flash_attention_forward_impl<D, false, true>(
-                Q, K, V, Out, softmax_lse, softmax_scale, is_causal,
-                scalar_pv, window_size_left, window_size_right, stream);
-            return;
-        }
+    const torch::Tensor& Q, const torch::Tensor& K, const torch::Tensor& V,
+    torch::Tensor& Out, torch::Tensor& softmax_lse, float softmax_scale,
+    bool is_causal, bool scalar_pv, int window_size_left, int window_size_right,
+    cudaStream_t stream) {
+  if constexpr (D == 256) {
+    const bool use_wmma_qk =
+        env_flag_enabled_default_on("VLLM_FLASH_V100_DENSE_D256_WMMA_QK");
+    if (env_flag_enabled("VLLM_FLASH_V100_DENSE_D256_LOW_SMEM")) {
+      if (use_wmma_qk) {
+        launcher_flash_attention_forward_impl<D, true, true>(
+            Q, K, V, Out, softmax_lse, softmax_scale, is_causal, scalar_pv,
+            window_size_left, window_size_right, stream);
+      } else {
+        launcher_flash_attention_forward_impl<D, true, false>(
+            Q, K, V, Out, softmax_lse, softmax_scale, is_causal, scalar_pv,
+            window_size_left, window_size_right, stream);
+      }
+      return;
     }
-    launcher_flash_attention_forward_impl<D, false, false>(
-        Q, K, V, Out, softmax_lse, softmax_scale, is_causal, scalar_pv,
-        window_size_left, window_size_right, stream);
+    if (use_wmma_qk) {
+      launcher_flash_attention_forward_impl<D, false, true>(
+          Q, K, V, Out, softmax_lse, softmax_scale, is_causal, scalar_pv,
+          window_size_left, window_size_right, stream);
+      return;
+    }
+  }
+  launcher_flash_attention_forward_impl<D, false, false>(
+      Q, K, V, Out, softmax_lse, softmax_scale, is_causal, scalar_pv,
+      window_size_left, window_size_right, stream);
 }
 
-template<int D>
-void launcher_flash_attention_qk_scores(
-    const torch::Tensor& Q,
-    const torch::Tensor& K,
-    torch::Tensor& Scores,
-    float softmax_scale,
-    bool is_causal,
-    cudaStream_t stream
-) {
-    using Config = KernelConfig<D>;
+template <int D>
+void launcher_flash_attention_qk_scores(const torch::Tensor& Q,
+                                        const torch::Tensor& K,
+                                        torch::Tensor& Scores,
+                                        float softmax_scale, bool is_causal,
+                                        cudaStream_t stream) {
+  using Config = KernelConfig<D>;
 
-    const int B = Q.size(0);
-    const int H = Q.size(1);
-    const int M = Q.size(2);
-    const int H_KV = K.size(1);
-    const int N = K.size(2);
+  const int B = Q.size(0);
+  const int H = Q.size(1);
+  const int M = Q.size(2);
+  const int H_KV = K.size(1);
+  const int N = K.size(2);
 
-    const int grid_x = (M + Config::BLOCK_M - 1) / Config::BLOCK_M;
-    const int grid_y = (N + Config::BLOCK_N - 1) / Config::BLOCK_N;
-    const dim3 grid(grid_x, grid_y, B * H);
-    const dim3 block(Config::THREADS_PER_BLOCK);
-    const size_t smem = Config::TOTAL_SMEM;
+  const int grid_x = (M + Config::BLOCK_M - 1) / Config::BLOCK_M;
+  const int grid_y = (N + Config::BLOCK_N - 1) / Config::BLOCK_N;
+  const dim3 grid(grid_x, grid_y, B * H);
+  const dim3 block(Config::THREADS_PER_BLOCK);
+  const size_t smem = Config::TOTAL_SMEM;
 
-    TORCH_CHECK(smem <= MAX_SMEM_PER_SM, "Shared memory exceeds 96KB: ", smem, " bytes");
+  TORCH_CHECK(smem <= MAX_SMEM_PER_SM, "Shared memory exceeds 96KB: ", smem,
+              " bytes");
 
-    auto kernel = is_causal ?
-        (void*)flash_attention_qk_scores_kernel<D, true> :
-        (void*)flash_attention_qk_scores_kernel<D, false>;
+  auto kernel = is_causal ? (void*)flash_attention_qk_scores_kernel<D, true>
+                          : (void*)flash_attention_qk_scores_kernel<D, false>;
 
-    cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem);
+  cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize,
+                       smem);
 
-    if (is_causal) {
-        flash_attention_qk_scores_kernel<D, true><<<grid, block, smem, stream>>>(
-            reinterpret_cast<const __half*>(Q.data_ptr()),
-            reinterpret_cast<const __half*>(K.data_ptr()),
-            Scores.data_ptr<float>(),
-            B, H, H_KV, M, N, softmax_scale
-        );
-    } else {
-        flash_attention_qk_scores_kernel<D, false><<<grid, block, smem, stream>>>(
-            reinterpret_cast<const __half*>(Q.data_ptr()),
-            reinterpret_cast<const __half*>(K.data_ptr()),
-            Scores.data_ptr<float>(),
-            B, H, H_KV, M, N, softmax_scale
-        );
-    }
+  if (is_causal) {
+    flash_attention_qk_scores_kernel<D, true><<<grid, block, smem, stream>>>(
+        reinterpret_cast<const __half*>(Q.data_ptr()),
+        reinterpret_cast<const __half*>(K.data_ptr()), Scores.data_ptr<float>(),
+        B, H, H_KV, M, N, softmax_scale);
+  } else {
+    flash_attention_qk_scores_kernel<D, false><<<grid, block, smem, stream>>>(
+        reinterpret_cast<const __half*>(Q.data_ptr()),
+        reinterpret_cast<const __half*>(K.data_ptr()), Scores.data_ptr<float>(),
+        B, H, H_KV, M, N, softmax_scale);
+  }
 }
 
-at::Tensor flash_attention_qk_scores(
-    const at::Tensor& q,
-    const at::Tensor& k,
-    const float softmax_scale,
-    const bool is_causal
-) {
-    TORCH_CHECK(q.dtype() == torch::kFloat16, "q must be fp16");
-    TORCH_CHECK(k.dtype() == torch::kFloat16, "k must be fp16");
-    TORCH_CHECK(q.is_cuda() && k.is_cuda(), "Tensors must be on CUDA");
-    TORCH_CHECK(q.stride(-1) == 1 && k.stride(-1) == 1,
-                "Last dim must be contiguous");
-    TORCH_CHECK(q.dim() == 4 && k.dim() == 4,
-                "q/k must have shape [B, H, T, D]");
+at::Tensor flash_attention_qk_scores(const at::Tensor& q, const at::Tensor& k,
+                                     const float softmax_scale,
+                                     const bool is_causal) {
+  TORCH_CHECK(q.dtype() == torch::kFloat16, "q must be fp16");
+  TORCH_CHECK(k.dtype() == torch::kFloat16, "k must be fp16");
+  TORCH_CHECK(q.is_cuda() && k.is_cuda(), "Tensors must be on CUDA");
+  TORCH_CHECK(q.stride(-1) == 1 && k.stride(-1) == 1,
+              "Last dim must be contiguous");
+  TORCH_CHECK(q.dim() == 4 && k.dim() == 4, "q/k must have shape [B, H, T, D]");
 
-    const int B = q.size(0);
-    const int H = q.size(1);
-    const int M = q.size(2);
-    const int D = q.size(3);
-    const int H_KV = k.size(1);
-    const int N = k.size(2);
+  const int B = q.size(0);
+  const int H = q.size(1);
+  const int M = q.size(2);
+  const int D = q.size(3);
+  const int H_KV = k.size(1);
+  const int N = k.size(2);
 
-    TORCH_CHECK(k.size(0) == B, "K batch size must match Q");
-    TORCH_CHECK(k.size(3) == D, "K head_dim must match Q");
-    TORCH_CHECK(D <= 256 && D % 8 == 0 && D % 2 == 0,
-                "D must be even, <=256, multiple of 8");
-    TORCH_CHECK(H_KV > 0, "num_kv_heads must be positive");
-    TORCH_CHECK(H % H_KV == 0,
-                "num_attention_heads must be divisible by num_kv_heads");
+  TORCH_CHECK(k.size(0) == B, "K batch size must match Q");
+  TORCH_CHECK(k.size(3) == D, "K head_dim must match Q");
+  TORCH_CHECK(D <= 256 && D % 8 == 0 && D % 2 == 0,
+              "D must be even, <=256, multiple of 8");
+  TORCH_CHECK(H_KV > 0, "num_kv_heads must be positive");
+  TORCH_CHECK(H % H_KV == 0,
+              "num_attention_heads must be divisible by num_kv_heads");
 
-    auto props = at::cuda::getCurrentDeviceProperties();
-    bool sm70 = props->major == 7 && props->minor == 0;
-    TORCH_CHECK(sm70, "Kernel supports only Volta GPUs.");
+  auto props = at::cuda::getCurrentDeviceProperties();
+  bool sm70 = props->major == 7 && props->minor == 0;
+  TORCH_CHECK(sm70, "Kernel supports only Volta GPUs.");
 
-    auto scores = torch::full({B, H, M, N}, -1e30f,
-                              torch::dtype(torch::kFloat32).device(q.device()));
-    auto stream = at::cuda::getCurrentCUDAStream().stream();
+  auto scores = torch::full({B, H, M, N}, -1e30f,
+                            torch::dtype(torch::kFloat32).device(q.device()));
+  auto stream = at::cuda::getCurrentCUDAStream().stream();
 
-    switch (D) {
-        case 16:  launcher_flash_attention_qk_scores<16>(q, k, scores, softmax_scale, is_causal, stream); break;
-        case 32:  launcher_flash_attention_qk_scores<32>(q, k, scores, softmax_scale, is_causal, stream); break;
-        case 64:  launcher_flash_attention_qk_scores<64>(q, k, scores, softmax_scale, is_causal, stream); break;
-        case 128: launcher_flash_attention_qk_scores<128>(q, k, scores, softmax_scale, is_causal, stream); break;
-        case 256: launcher_flash_attention_qk_scores<256>(q, k, scores, softmax_scale, is_causal, stream); break;
-        default: TORCH_CHECK(false, "Unsupported D: ", D);
-    }
+  switch (D) {
+    case 16:
+      launcher_flash_attention_qk_scores<16>(q, k, scores, softmax_scale,
+                                             is_causal, stream);
+      break;
+    case 32:
+      launcher_flash_attention_qk_scores<32>(q, k, scores, softmax_scale,
+                                             is_causal, stream);
+      break;
+    case 64:
+      launcher_flash_attention_qk_scores<64>(q, k, scores, softmax_scale,
+                                             is_causal, stream);
+      break;
+    case 128:
+      launcher_flash_attention_qk_scores<128>(q, k, scores, softmax_scale,
+                                              is_causal, stream);
+      break;
+    case 256:
+      launcher_flash_attention_qk_scores<256>(q, k, scores, softmax_scale,
+                                              is_causal, stream);
+      break;
+    default:
+      TORCH_CHECK(false, "Unsupported D: ", D);
+  }
 
-    return scores;
+  return scores;
 }
 
 std::vector<at::Tensor> flash_attention_forward(
-    at::Tensor& q,
-    const at::Tensor& k,
-    const at::Tensor& v,
-    std::optional<at::Tensor>& out_,
-    std::optional<at::Tensor>& alibi_slopes_,
-    const float p_dropout,
-    const float softmax_scale,
-    bool is_causal,
-    int window_size_left,
-    int window_size_right,
-    const float softcap,
-    const bool return_softmax,
-    std::optional<at::Generator> gen_
-) {
+    at::Tensor& q, const at::Tensor& k, const at::Tensor& v,
+    std::optional<at::Tensor>& out_, std::optional<at::Tensor>& alibi_slopes_,
+    const float p_dropout, const float softmax_scale, bool is_causal,
+    int window_size_left, int window_size_right, const float softcap,
+    const bool return_softmax, std::optional<at::Generator> gen_) {
+  TORCH_CHECK(!alibi_slopes_.has_value(), "alibi_slopes not supported");
+  TORCH_CHECK(p_dropout == 0.f, "dropout not supported");
+  TORCH_CHECK(window_size_left >= -1 && window_size_right >= -1,
+              "window sizes must be >= -1");
+  TORCH_CHECK(softcap == 0.f, "softcap not supported");
+  TORCH_CHECK(!return_softmax, "return_softmax not supported");
+  TORCH_CHECK(!gen_.has_value(), "Generator not supported");
 
-    TORCH_CHECK(!alibi_slopes_.has_value(), "alibi_slopes not supported");
-    TORCH_CHECK(p_dropout == 0.f, "dropout not supported");
-    TORCH_CHECK(window_size_left >= -1 && window_size_right >= -1,
-                "window sizes must be >= -1");
-    TORCH_CHECK(softcap == 0.f, "softcap not supported");
-    TORCH_CHECK(!return_softmax, "return_softmax not supported");
-    TORCH_CHECK(!gen_.has_value(), "Generator not supported");
+  TORCH_CHECK(q.dtype() == torch::kFloat16, "q must be fp16");
+  TORCH_CHECK(k.dtype() == torch::kFloat16, "k must be fp16");
+  TORCH_CHECK(v.dtype() == torch::kFloat16, "v must be fp16");
+  TORCH_CHECK(q.is_cuda() && k.is_cuda() && v.is_cuda(),
+              "Tensors must be on CUDA");
+  TORCH_CHECK(q.stride(-1) == 1 && k.stride(-1) == 1 && v.stride(-1) == 1,
+              "Last dim must be contiguous");
 
-    TORCH_CHECK(q.dtype() == torch::kFloat16, "q must be fp16");
-    TORCH_CHECK(k.dtype() == torch::kFloat16, "k must be fp16");
-    TORCH_CHECK(v.dtype() == torch::kFloat16, "v must be fp16");
-    TORCH_CHECK(q.is_cuda() && k.is_cuda() && v.is_cuda(), "Tensors must be on CUDA");
-    TORCH_CHECK(q.stride(-1) == 1 && k.stride(-1) == 1 && v.stride(-1) == 1, "Last dim must be contiguous");
+  const auto sizes = q.sizes();
+  const int B = sizes[0], H = sizes[1], M = sizes[2], D = sizes[3];
+  const int H_KV = k.size(1);
+  const int N = k.size(2);
+  TORCH_CHECK(D <= 256 && D % 8 == 0 && D % 2 == 0,
+              "D must be even, <=256, multiple of 8");
+  TORCH_CHECK(H_KV > 0, "num_kv_heads must be positive");
+  TORCH_CHECK(H % H_KV == 0,
+              "num_attention_heads must be divisible by num_kv_heads");
+  TORCH_CHECK(k.size(0) == B && v.size(0) == B, "K/V batch size must match Q");
+  TORCH_CHECK(v.size(1) == H_KV, "K/V num_heads must match");
+  TORCH_CHECK(v.size(2) == N, "K/V sequence length must match");
+  TORCH_CHECK(k.size(3) == D && v.size(3) == D, "K/V head_dim must match Q");
 
-    const auto sizes = q.sizes();
-    const int B = sizes[0], H = sizes[1], M = sizes[2], D = sizes[3];
-    const int H_KV = k.size(1);
-    const int N = k.size(2);
-    TORCH_CHECK(D <= 256 && D % 8 == 0 && D % 2 == 0, "D must be even, <=256, multiple of 8");
-    TORCH_CHECK(H_KV > 0, "num_kv_heads must be positive");
-    TORCH_CHECK(H % H_KV == 0, "num_attention_heads must be divisible by num_kv_heads");
-    TORCH_CHECK(k.size(0) == B && v.size(0) == B, "K/V batch size must match Q");
-    TORCH_CHECK(v.size(1) == H_KV, "K/V num_heads must match");
-    TORCH_CHECK(v.size(2) == N, "K/V sequence length must match");
-    TORCH_CHECK(k.size(3) == D && v.size(3) == D, "K/V head_dim must match Q");
+  at::Tensor out_fp16 = out_.has_value() ? out_.value() : torch::zeros_like(q);
+  TORCH_CHECK(out_fp16.dtype() == torch::kFloat16, "out must be fp16");
+  auto softmax_lse =
+      torch::zeros({B, H, M}, torch::dtype(torch::kFloat32).device(q.device()));
+  TORCH_CHECK(softmax_lse.dtype() == torch::kFloat32,
+              "softmax_lse must be fp32");
 
-    at::Tensor out_fp16 = out_.has_value() ? out_.value() : torch::zeros_like(q);
-    TORCH_CHECK(out_fp16.dtype() == torch::kFloat16, "out must be fp16");
-    auto softmax_lse = torch::zeros({B, H, M}, torch::dtype(torch::kFloat32).device(q.device()));
-    TORCH_CHECK(softmax_lse.dtype() == torch::kFloat32, "softmax_lse must be fp32");
+  auto stream = at::cuda::getCurrentCUDAStream().stream();
+  auto props = at::cuda::getCurrentDeviceProperties();
+  bool sm70 = props->major == 7 && props->minor == 0;
+  TORCH_CHECK(sm70, "Kernel supports only Volta GPUs.");
+  const char* scalar_pv_env = std::getenv("VLLM_FLASH_V100_PREFILL_SCALAR_PV");
+  const bool scalar_pv = scalar_pv_env != nullptr && scalar_pv_env[0] != '\0' &&
+                         scalar_pv_env[0] != '0';
 
-    auto stream = at::cuda::getCurrentCUDAStream().stream();
-    auto props  = at::cuda::getCurrentDeviceProperties();
-    bool sm70   = props->major == 7 && props->minor == 0;
-    TORCH_CHECK(sm70, "Kernel supports only Volta GPUs.");
-    const char* scalar_pv_env = std::getenv("VLLM_FLASH_V100_PREFILL_SCALAR_PV");
-    const bool scalar_pv = scalar_pv_env != nullptr && scalar_pv_env[0] != '\0' &&
-                           scalar_pv_env[0] != '0';
+  switch (D) {
+    case 16:
+      launcher_flash_attention_forward<16>(
+          q, k, v, out_fp16, softmax_lse, softmax_scale, is_causal, scalar_pv,
+          window_size_left, window_size_right, stream);
+      break;
+    case 32:
+      launcher_flash_attention_forward<32>(
+          q, k, v, out_fp16, softmax_lse, softmax_scale, is_causal, scalar_pv,
+          window_size_left, window_size_right, stream);
+      break;
+    case 64:
+      launcher_flash_attention_forward<64>(
+          q, k, v, out_fp16, softmax_lse, softmax_scale, is_causal, scalar_pv,
+          window_size_left, window_size_right, stream);
+      break;
+    case 128:
+      launcher_flash_attention_forward<128>(
+          q, k, v, out_fp16, softmax_lse, softmax_scale, is_causal, scalar_pv,
+          window_size_left, window_size_right, stream);
+      break;
+    case 256:
+      launcher_flash_attention_forward<256>(
+          q, k, v, out_fp16, softmax_lse, softmax_scale, is_causal, scalar_pv,
+          window_size_left, window_size_right, stream);
+      break;
+    default:
+      TORCH_CHECK(false, "Unsupported D: ", D);
+  }
 
-    switch (D) {
-        case 16:  launcher_flash_attention_forward<16>(q, k, v, out_fp16, softmax_lse, softmax_scale, is_causal, scalar_pv, window_size_left, window_size_right, stream); break;
-        case 32:  launcher_flash_attention_forward<32>(q, k, v, out_fp16, softmax_lse, softmax_scale, is_causal, scalar_pv, window_size_left, window_size_right, stream); break;
-        case 64:  launcher_flash_attention_forward<64>(q, k, v, out_fp16, softmax_lse, softmax_scale, is_causal, scalar_pv, window_size_left, window_size_right, stream); break;
-        case 128: launcher_flash_attention_forward<128>(q, k, v, out_fp16, softmax_lse, softmax_scale, is_causal, scalar_pv, window_size_left, window_size_right, stream); break;
-        case 256: launcher_flash_attention_forward<256>(q, k, v, out_fp16, softmax_lse, softmax_scale, is_causal, scalar_pv, window_size_left, window_size_right, stream); break;
-        default: TORCH_CHECK(false, "Unsupported D: ", D);
-    }
-
-    auto p = torch::zeros({0}, q.options());
-    auto rng_state = torch::zeros({2}, torch::dtype(torch::kInt64).device(q.device()));
-    return {out_fp16, softmax_lse, p, rng_state};
+  auto p = torch::zeros({0}, q.options());
+  auto rng_state =
+      torch::zeros({2}, torch::dtype(torch::kInt64).device(q.device()));
+  return {out_fp16, softmax_lse, p, rng_state};
 }

--- a/flash-attention-v100/kernel/fused_mha_forward_paged.cu
+++ b/flash-attention-v100/kernel/fused_mha_forward_paged.cu
@@ -22,2056 +22,1753 @@ using namespace nvcuda::wmma;
 #define WMMA_N 16
 #define WMMA_K 16
 
-#define MAX_THREADS_PER_WARP    32
-#define MAX_THREADS_PER_SM      2048
-#define MAX_THREAD_BLOCK_SIZE   1024
+#define MAX_THREADS_PER_WARP 32
+#define MAX_THREADS_PER_SM 2048
+#define MAX_THREAD_BLOCK_SIZE 1024
 #define MAX_THREAD_BLOCK_PER_SM 32
-#define MAX_WARPS_PER_SM        64
-#define MAX_SM_PER_GPU          80
-#define MAX_SMEM_PER_SM         98304
+#define MAX_WARPS_PER_SM 64
+#define MAX_SM_PER_GPU 80
+#define MAX_SMEM_PER_SM 98304
 
-#define WARP_ALLOC_GROUP        4
+#define WARP_ALLOC_GROUP 4
 
 namespace {
 
 int kv_cache_dtype_code_from_string(const std::string& kv_cache_dtype) {
-    if (kv_cache_dtype == "auto" || kv_cache_dtype == "bfloat16") {
-        return flash_v100::KV_CACHE_DTYPE_FP16;
-    }
-    if (kv_cache_dtype == "fp8" || kv_cache_dtype == "fp8_e4m3") {
-        return flash_v100::KV_CACHE_DTYPE_FP8_E4M3;
-    }
-    if (kv_cache_dtype == "fp8_e5m2") {
-        return flash_v100::KV_CACHE_DTYPE_FP8_E5M2;
-    }
-    return -1;
+  if (kv_cache_dtype == "auto" || kv_cache_dtype == "bfloat16") {
+    return flash_v100::KV_CACHE_DTYPE_FP16;
+  }
+  if (kv_cache_dtype == "fp8" || kv_cache_dtype == "fp8_e4m3") {
+    return flash_v100::KV_CACHE_DTYPE_FP8_E4M3;
+  }
+  if (kv_cache_dtype == "fp8_e5m2") {
+    return flash_v100::KV_CACHE_DTYPE_FP8_E5M2;
+  }
+  return -1;
 }
 
 }  // namespace
 
-#define BLOCK_M_16  16
-#define BLOCK_N_16  512
-#define WARPS_16    16
+#define BLOCK_M_16 16
+#define BLOCK_N_16 512
+#define WARPS_16 16
 
-#define BLOCK_M_32  32
-#define BLOCK_N_32  256
-#define WARPS_32    16
+#define BLOCK_M_32 32
+#define BLOCK_N_32 256
+#define WARPS_32 16
 
-#define BLOCK_M_64  64
-#define BLOCK_N_64  128
-#define WARPS_64    16
+#define BLOCK_M_64 64
+#define BLOCK_N_64 128
+#define WARPS_64 16
 
 #define BLOCK_M_128 32
 #define BLOCK_N_128 176
-#define WARPS_128   16
+#define WARPS_128 16
 
 #define BLOCK_M_256 32
 #define BLOCK_N_256 64
-#define WARPS_256   16
+#define WARPS_256 16
 
 #define BLOCK_M_256_LOW_SMEM 16
 #define BLOCK_N_256_LOW_SMEM 128
 #define KV_STAGE_N_256_LOW_SMEM 1
-#define WARPS_256_LOW_SMEM   16
+#define WARPS_256_LOW_SMEM 16
 #define BLOCK_N_256_LOW_SMEM_SCALAR_QK 32
 #define KV_STAGE_N_256_LOW_SMEM_SCALAR_QK BLOCK_N_256_LOW_SMEM_SCALAR_QK
-#define LOW_SMEM_PAGE_SIZE   16
+#define LOW_SMEM_PAGE_SIZE 16
 
-template<int D, bool LOW_SMEM = false, bool LOW_SMEM_SCALAR_QK = false,
-         bool LOW_SMEM_BM32 = false,
-         bool D256_OUTPUT_STRIDE_268 = false,
-         bool D256_SW_PIPELINE_QK = false,
-         bool D256_SW_PIPELINE_PV = false>
+template <int D, bool LOW_SMEM = false, bool LOW_SMEM_SCALAR_QK = false,
+          bool LOW_SMEM_BM32 = false, bool D256_OUTPUT_STRIDE_268 = false,
+          bool D256_SW_PIPELINE_QK = false, bool D256_SW_PIPELINE_PV = false>
 struct KernelConfig {
-    static constexpr int BLOCK_M = (D == 16) ? BLOCK_M_16 : (D == 32) ? BLOCK_M_32 : (D == 64) ? BLOCK_M_64 : (D == 128) ? BLOCK_M_128 : (LOW_SMEM ? (LOW_SMEM_BM32 ? BLOCK_M_256 : BLOCK_M_256_LOW_SMEM) : BLOCK_M_256);
-    static constexpr int BLOCK_N = (D == 16) ? BLOCK_N_16 : (D == 32) ? BLOCK_N_32 : (D == 64) ? BLOCK_N_64 : (D == 128) ? BLOCK_N_128 : (LOW_SMEM ? (LOW_SMEM_SCALAR_QK ? BLOCK_N_256_LOW_SMEM_SCALAR_QK : BLOCK_N_256_LOW_SMEM) : BLOCK_N_256);
-    static constexpr int WARPS_PER_BLOCK = (D == 16) ? WARPS_16 : (D == 32) ? WARPS_32 : (D == 64) ? WARPS_64 : (D == 128) ? WARPS_128 : (LOW_SMEM ? WARPS_256_LOW_SMEM : WARPS_256);
+  static constexpr int BLOCK_M =
+      (D == 16)   ? BLOCK_M_16
+      : (D == 32) ? BLOCK_M_32
+      : (D == 64) ? BLOCK_M_64
+      : (D == 128)
+          ? BLOCK_M_128
+          : (LOW_SMEM ? (LOW_SMEM_BM32 ? BLOCK_M_256 : BLOCK_M_256_LOW_SMEM)
+                      : BLOCK_M_256);
+  static constexpr int BLOCK_N =
+      (D == 16)   ? BLOCK_N_16
+      : (D == 32) ? BLOCK_N_32
+      : (D == 64) ? BLOCK_N_64
+      : (D == 128)
+          ? BLOCK_N_128
+          : (LOW_SMEM ? (LOW_SMEM_SCALAR_QK ? BLOCK_N_256_LOW_SMEM_SCALAR_QK
+                                            : BLOCK_N_256_LOW_SMEM)
+                      : BLOCK_N_256);
+  static constexpr int WARPS_PER_BLOCK =
+      (D == 16)    ? WARPS_16
+      : (D == 32)  ? WARPS_32
+      : (D == 64)  ? WARPS_64
+      : (D == 128) ? WARPS_128
+                   : (LOW_SMEM ? WARPS_256_LOW_SMEM : WARPS_256);
 
-    static constexpr int THREADS_PER_BLOCK = WARPS_PER_BLOCK * MAX_THREADS_PER_WARP;
-    static constexpr int THREADS_PER_ROW   = THREADS_PER_BLOCK / BLOCK_M;
-    static constexpr int PAD               = (8 - (D % 32) + 32) % 32;
-    static constexpr int Q_STRIDE          = D + PAD;
-    static constexpr int KV_STRIDE         = D + PAD;
-    static constexpr int KV_STAGE_N        = (D == 256 && LOW_SMEM) ? (LOW_SMEM_SCALAR_QK ? KV_STAGE_N_256_LOW_SMEM_SCALAR_QK : KV_STAGE_N_256_LOW_SMEM) : BLOCK_N;
-    static constexpr int S_STRIDE          = BLOCK_N + PAD;
-    static constexpr int P_SUB_TILE        = 32;
-    static constexpr int P_STRIDE          = P_SUB_TILE + PAD;
-    static constexpr int P_STRICT_ELEMENTS = (D == 256) ? BLOCK_M * P_STRIDE : 1;
-    static constexpr int PIPELINE_S_ELEMENTS =
-        (D == 256 && LOW_SMEM && D256_SW_PIPELINE_QK
-         && D256_SW_PIPELINE_PV)
-            ? BLOCK_M * S_STRIDE
-            : 1;
-    static constexpr int PIPELINE_PAGE_ELEMENTS =
-        (D == 256 && LOW_SMEM && D256_SW_PIPELINE_QK
-         && D256_SW_PIPELINE_PV)
-            ? BLOCK_N / LOW_SMEM_PAGE_SIZE
-            : 1;
-    static constexpr bool PIPELINE_SWIZZLED_Q =
-        D == 256 && LOW_SMEM && D256_SW_PIPELINE_QK
-        && D256_SW_PIPELINE_PV;
-    static constexpr int Q_ELEMENTS =
-        PIPELINE_SWIZZLED_Q ? BLOCK_M * D : BLOCK_M * Q_STRIDE;
-    // The D256 low-SMEM candidate changes only the output accumulator pitch
-    // from 264 to 268 floats. This preserves all WMMA/softmax arithmetic and
-    // targets the largest 8-way shared-memory load/store groups.
-    static constexpr int OUTPUT_EXTRA_PAD =
-        (D == 256 && LOW_SMEM && D256_OUTPUT_STRIDE_268) ? 4 : 0;
-    static constexpr int O_STRIDE          = D + PAD + OUTPUT_EXTRA_PAD;
-    static constexpr int PER_UINT4         = 8;
-    static constexpr int LOW_SMEM_PAGE_COUNT =
-        (D == 256 && LOW_SMEM) ? (BLOCK_N / LOW_SMEM_PAGE_SIZE) : 1;
-    struct alignas(128) SmemLayout {
-        alignas(16) __half q      [Q_ELEMENTS];
+  static constexpr int THREADS_PER_BLOCK =
+      WARPS_PER_BLOCK * MAX_THREADS_PER_WARP;
+  static constexpr int THREADS_PER_ROW = THREADS_PER_BLOCK / BLOCK_M;
+  static constexpr int PAD = (8 - (D % 32) + 32) % 32;
+  static constexpr int Q_STRIDE = D + PAD;
+  static constexpr int KV_STRIDE = D + PAD;
+  static constexpr int KV_STAGE_N =
+      (D == 256 && LOW_SMEM)
+          ? (LOW_SMEM_SCALAR_QK ? KV_STAGE_N_256_LOW_SMEM_SCALAR_QK
+                                : KV_STAGE_N_256_LOW_SMEM)
+          : BLOCK_N;
+  static constexpr int S_STRIDE = BLOCK_N + PAD;
+  static constexpr int P_SUB_TILE = 32;
+  static constexpr int P_STRIDE = P_SUB_TILE + PAD;
+  static constexpr int P_STRICT_ELEMENTS = (D == 256) ? BLOCK_M * P_STRIDE : 1;
+  static constexpr int PIPELINE_S_ELEMENTS =
+      (D == 256 && LOW_SMEM && D256_SW_PIPELINE_QK && D256_SW_PIPELINE_PV)
+          ? BLOCK_M * S_STRIDE
+          : 1;
+  static constexpr int PIPELINE_PAGE_ELEMENTS =
+      (D == 256 && LOW_SMEM && D256_SW_PIPELINE_QK && D256_SW_PIPELINE_PV)
+          ? BLOCK_N / LOW_SMEM_PAGE_SIZE
+          : 1;
+  static constexpr bool PIPELINE_SWIZZLED_Q =
+      D == 256 && LOW_SMEM && D256_SW_PIPELINE_QK && D256_SW_PIPELINE_PV;
+  static constexpr int Q_ELEMENTS =
+      PIPELINE_SWIZZLED_Q ? BLOCK_M * D : BLOCK_M * Q_STRIDE;
+  // The D256 low-SMEM candidate changes only the output accumulator pitch
+  // from 264 to 268 floats. This preserves all WMMA/softmax arithmetic and
+  // targets the largest 8-way shared-memory load/store groups.
+  static constexpr int OUTPUT_EXTRA_PAD =
+      (D == 256 && LOW_SMEM && D256_OUTPUT_STRIDE_268) ? 4 : 0;
+  static constexpr int O_STRIDE = D + PAD + OUTPUT_EXTRA_PAD;
+  static constexpr int PER_UINT4 = 8;
+  static constexpr int LOW_SMEM_PAGE_COUNT =
+      (D == 256 && LOW_SMEM) ? (BLOCK_N / LOW_SMEM_PAGE_SIZE) : 1;
+  struct alignas(128) SmemLayout {
+    alignas(16) __half q[Q_ELEMENTS];
     union {
-        alignas(16) __half k      [KV_STAGE_N * KV_STRIDE];
-        alignas(16) __half v      [KV_STAGE_N * KV_STRIDE];
+      alignas(16) __half k[KV_STAGE_N * KV_STRIDE];
+      alignas(16) __half v[KV_STAGE_N * KV_STRIDE];
     } reuse_kv;
     union {
-        alignas(16) float  s      [BLOCK_M * S_STRIDE];
-        alignas(16) __half p      [BLOCK_M * S_STRIDE];
+      alignas(16) float s[BLOCK_M * S_STRIDE];
+      alignas(16) __half p[BLOCK_M * S_STRIDE];
     } reuse_sp;
-        alignas(16) __half p_strict[P_STRICT_ELEMENTS];
-        alignas(16) float  pipeline_s[PIPELINE_S_ELEMENTS];
-        alignas(16) int    pipeline_page_idx[PIPELINE_PAGE_ELEMENTS];
-        alignas(16) int    pipeline_page_offset[PIPELINE_PAGE_ELEMENTS];
-        alignas(16) float  o      [BLOCK_M * O_STRIDE];
-        alignas(16) float  row_max[BLOCK_M];
-        alignas(16) float  row_sum[BLOCK_M];
-        alignas(16) int    page_idx[LOW_SMEM_PAGE_COUNT];
-        alignas(16) int    page_offset[LOW_SMEM_PAGE_COUNT];
-    };
+    alignas(16) __half p_strict[P_STRICT_ELEMENTS];
+    alignas(16) float pipeline_s[PIPELINE_S_ELEMENTS];
+    alignas(16) int pipeline_page_idx[PIPELINE_PAGE_ELEMENTS];
+    alignas(16) int pipeline_page_offset[PIPELINE_PAGE_ELEMENTS];
+    alignas(16) float o[BLOCK_M * O_STRIDE];
+    alignas(16) float row_max[BLOCK_M];
+    alignas(16) float row_sum[BLOCK_M];
+    alignas(16) int page_idx[LOW_SMEM_PAGE_COUNT];
+    alignas(16) int page_offset[LOW_SMEM_PAGE_COUNT];
+  };
 
-    static constexpr size_t TOTAL_SMEM = ((sizeof(SmemLayout) + 127) & ~size_t(127));
+  static constexpr size_t TOTAL_SMEM =
+      ((sizeof(SmemLayout) + 127) & ~size_t(127));
 };
 
-template<typename Config>
+template <typename Config>
 __device__ __forceinline__ void init_smem(char* smem_raw) {
-    constexpr int N_U4 = Config::TOTAL_SMEM / 16;
-    constexpr int THREADS_PER_BLOCK = Config::THREADS_PER_BLOCK;
-    const int tid = threadIdx.x;
+  constexpr int N_U4 = Config::TOTAL_SMEM / 16;
+  constexpr int THREADS_PER_BLOCK = Config::THREADS_PER_BLOCK;
+  const int tid = threadIdx.x;
 
-    uint32_t addr = static_cast<uint32_t>(__cvta_generic_to_shared(smem_raw));
-    #pragma unroll 1
-    for (int i = tid; i < N_U4; i += THREADS_PER_BLOCK) {
-        asm volatile("st.shared.v4.u32 [%0], {%1,%1,%1,%1};"
-                     :: "r"(addr + (i << 4)), "r"(0) : "memory");
-    }
-    __syncthreads();
+  uint32_t addr = static_cast<uint32_t>(__cvta_generic_to_shared(smem_raw));
+#pragma unroll 1
+  for (int i = tid; i < N_U4; i += THREADS_PER_BLOCK) {
+    asm volatile("st.shared.v4.u32 [%0], {%1,%1,%1,%1};" ::"r"(addr + (i << 4)),
+                 "r"(0)
+                 : "memory");
+  }
+  __syncthreads();
 }
 
 __device__ __forceinline__ int pipeline_swizzled_q_row_slot(int row) {
-    return (row & 3) | ((row & 8) >> 1) | ((row & 4) << 1);
+  return (row & 3) | ((row & 8) >> 1) | ((row & 4) << 1);
 }
 
-__device__ __forceinline__ int pipeline_swizzled_matrix_a_offset(
-    int row,
-    int col) {
-    const int tile = col / WMMA_K;
-    const int within_tile = col - tile * WMMA_K;
-    const int plane = within_tile >> 3;
-    const int inner = within_tile & 7;
-    return tile * WMMA_M * WMMA_K + plane * WMMA_M * 8
-           + pipeline_swizzled_q_row_slot(row) * 8 + inner;
+__device__ __forceinline__ int pipeline_swizzled_matrix_a_offset(int row,
+                                                                 int col) {
+  const int tile = col / WMMA_K;
+  const int within_tile = col - tile * WMMA_K;
+  const int plane = within_tile >> 3;
+  const int inner = within_tile & 7;
+  return tile * WMMA_M * WMMA_K + plane * WMMA_M * 8 +
+         pipeline_swizzled_q_row_slot(row) * 8 + inner;
 }
 
 __device__ __forceinline__ void load_pipeline_swizzled_matrix_a_fragment(
     fragment<matrix_a, WMMA_M, WMMA_N, WMMA_K, half, row_major>& frag,
-    const __half* __restrict__ matrix,
-    int k_offset) {
-    const int lane = threadIdx.x & 31;
-    const int row =
-        (lane & 3) + ((lane >> 4) & 1) * 4 + ((lane >> 2) & 1) * 8;
-    const int slot = pipeline_swizzled_q_row_slot(row);
-    const int tile_offset = (k_offset / WMMA_K) * WMMA_M * WMMA_K;
-    uint32_t address = static_cast<uint32_t>(
-        __cvta_generic_to_shared(matrix + tile_offset + slot * 8));
-    uint32_t* words = reinterpret_cast<uint32_t*>(&frag);
-    asm volatile(
-        "ld.shared.v4.u32 {%0, %1, %2, %3}, [%4];"
-        : "=r"(words[0]), "=r"(words[1]), "=r"(words[2]), "=r"(words[3])
-        : "r"(address)
-        : "memory");
-    address += WMMA_M * 8 * sizeof(__half);
-    asm volatile(
-        "ld.shared.v4.u32 {%0, %1, %2, %3}, [%4];"
-        : "=r"(words[4]), "=r"(words[5]), "=r"(words[6]), "=r"(words[7])
-        : "r"(address)
-        : "memory");
+    const __half* __restrict__ matrix, int k_offset) {
+  const int lane = threadIdx.x & 31;
+  const int row = (lane & 3) + ((lane >> 4) & 1) * 4 + ((lane >> 2) & 1) * 8;
+  const int slot = pipeline_swizzled_q_row_slot(row);
+  const int tile_offset = (k_offset / WMMA_K) * WMMA_M * WMMA_K;
+  uint32_t address = static_cast<uint32_t>(
+      __cvta_generic_to_shared(matrix + tile_offset + slot * 8));
+  uint32_t* words = reinterpret_cast<uint32_t*>(&frag);
+  asm volatile("ld.shared.v4.u32 {%0, %1, %2, %3}, [%4];"
+               : "=r"(words[0]), "=r"(words[1]), "=r"(words[2]), "=r"(words[3])
+               : "r"(address)
+               : "memory");
+  address += WMMA_M * 8 * sizeof(__half);
+  asm volatile("ld.shared.v4.u32 {%0, %1, %2, %3}, [%4];"
+               : "=r"(words[4]), "=r"(words[5]), "=r"(words[6]), "=r"(words[7])
+               : "r"(address)
+               : "memory");
 }
 
-template<int Q_STRIDE, int S_STRIDE, int K_TILES, bool IS_CAUSAL,
-         bool SWIZZLED_Q = false>
+template <int Q_STRIDE, int S_STRIDE, int K_TILES, bool IS_CAUSAL,
+          bool SWIZZLED_Q = false>
 __device__ __forceinline__ void pipeline_qk_slice(
-    const __half* __restrict__ sQ,
-    float* __restrict__ score,
-    const __half* __restrict__ k_cache,
-    const int* __restrict__ page_idx,
-    const int* __restrict__ page_offset,
-    int64_t k_block_stride,
-    int64_t k_token_stride,
-    int64_t k_head_stride,
-    int kv_head_id,
-    int start_col,
-    int valid_k_rows,
-    int start_row,
-    int valid_q_rows,
-    int causal_q_offset,
-    int tile_n,
-    int k_begin,
-    bool load_partial,
-    bool finalize,
-    float softmax_scale,
-    int window_size_left,
-    int window_size_right,
-    float neg_inf) {
-    if (tile_n >= valid_k_rows) {
-        return;
-    }
+    const __half* __restrict__ sQ, float* __restrict__ score,
+    const __half* __restrict__ k_cache, const int* __restrict__ page_idx,
+    const int* __restrict__ page_offset, int64_t k_block_stride,
+    int64_t k_token_stride, int64_t k_head_stride, int kv_head_id,
+    int start_col, int valid_k_rows, int start_row, int valid_q_rows,
+    int causal_q_offset, int tile_n, int k_begin, bool load_partial,
+    bool finalize, float softmax_scale, int window_size_left,
+    int window_size_right, float neg_inf) {
+  if (tile_n >= valid_k_rows) {
+    return;
+  }
 
-    const int page_slot = tile_n >> 4;
-    const int block_offset = page_offset[page_slot];
-    const int physical_block_idx = page_idx[page_slot];
-    const __half* k_tile_base =
-        k_cache + (int64_t)physical_block_idx * k_block_stride
-        + (int64_t)block_offset * k_token_stride
-        + (int64_t)kv_head_id * k_head_stride;
+  const int page_slot = tile_n >> 4;
+  const int block_offset = page_offset[page_slot];
+  const int physical_block_idx = page_idx[page_slot];
+  const __half* k_tile_base = k_cache +
+                              (int64_t)physical_block_idx * k_block_stride +
+                              (int64_t)block_offset * k_token_stride +
+                              (int64_t)kv_head_id * k_head_stride;
 
-    fragment<matrix_a, WMMA_M, WMMA_N, WMMA_K, half, row_major> a_frag;
-    fragment<matrix_b, WMMA_M, WMMA_N, WMMA_K, half, col_major> b_frag;
-    fragment<accumulator, WMMA_M, WMMA_N, WMMA_K, float> acc_frag;
-    if (load_partial) {
-        load_matrix_sync(
-            acc_frag, score + tile_n, S_STRIDE, mem_row_major);
+  fragment<matrix_a, WMMA_M, WMMA_N, WMMA_K, half, row_major> a_frag;
+  fragment<matrix_b, WMMA_M, WMMA_N, WMMA_K, half, col_major> b_frag;
+  fragment<accumulator, WMMA_M, WMMA_N, WMMA_K, float> acc_frag;
+  if (load_partial) {
+    load_matrix_sync(acc_frag, score + tile_n, S_STRIDE, mem_row_major);
+  } else {
+    fill_fragment(acc_frag, 0.0f);
+  }
+
+#pragma unroll
+  for (int k_tile = 0; k_tile < K_TILES; ++k_tile) {
+    const int k_offset = k_begin + k_tile * WMMA_K;
+    if constexpr (SWIZZLED_Q) {
+      load_pipeline_swizzled_matrix_a_fragment(a_frag, sQ, k_offset);
     } else {
-        fill_fragment(acc_frag, 0.0f);
+      load_matrix_sync(a_frag, sQ + k_offset, Q_STRIDE);
     }
+    load_matrix_sync(b_frag, k_tile_base + k_offset, k_token_stride);
+    mma_sync(acc_frag, a_frag, b_frag, acc_frag);
+  }
 
-    #pragma unroll
-    for (int k_tile = 0; k_tile < K_TILES; ++k_tile) {
-        const int k_offset = k_begin + k_tile * WMMA_K;
-        if constexpr (SWIZZLED_Q) {
-            load_pipeline_swizzled_matrix_a_fragment(
-                a_frag, sQ, k_offset);
-        } else {
-            load_matrix_sync(a_frag, sQ + k_offset, Q_STRIDE);
+  if (finalize) {
+    const int lane_id = threadIdx.x & 31;
+    const unsigned row_causal = (lane_id & 0b1) + ((lane_id >> 2) & 0b1) * 8 +
+                                ((lane_id >> 4) & 0b1) * 4;
+    const unsigned col_causal =
+        ((lane_id >> 1) & 0b1) * 2 + ((lane_id >> 3) & 0b1) * 8;
+
+#pragma unroll
+    for (int i = 0; i < acc_frag.num_elements; ++i) {
+      const unsigned col = col_causal + (i & 0b1) + ((i >> 2) & 0b1) * 4;
+      const unsigned row = row_causal + ((i >> 1) & 0b1) * 2;
+      const int global_m = start_row + row;
+      const int global_n = start_col + tile_n + col;
+      const int global_q_pos = global_m + causal_q_offset;
+
+      const bool is_valid = global_m < start_row + valid_q_rows &&
+                            global_n < start_col + valid_k_rows;
+      bool is_causal_valid = true;
+      if constexpr (IS_CAUSAL) {
+        is_causal_valid = global_n <= global_q_pos;
+      }
+      bool is_window_valid = true;
+      if (window_size_left >= 0) {
+        is_window_valid = global_n >= global_q_pos - window_size_left;
+      }
+      if (window_size_right >= 0) {
+        is_window_valid =
+            is_window_valid && global_n <= global_q_pos + window_size_right;
+      }
+      acc_frag.x[i] = (is_valid && is_causal_valid && is_window_valid)
+                          ? acc_frag.x[i] * softmax_scale
+                          : neg_inf;
+    }
+  }
+
+  store_matrix_sync(score + tile_n, acc_frag, S_STRIDE, mem_row_major);
+}
+
+template <int P_STRIDE, int O_STRIDE, bool SWIZZLED_P = false>
+__device__ __forceinline__ void pipeline_pv_tile(
+    const __half* __restrict__ sP, float* __restrict__ sO,
+    const __half* __restrict__ v_cache, const int* __restrict__ page_idx,
+    const int* __restrict__ page_offset, int64_t v_block_stride,
+    int64_t v_token_stride, int64_t v_head_stride, int kv_head_id,
+    int sub_start, int sub_valid_k_rows, int tile_d) {
+  fragment<matrix_a, WMMA_M, WMMA_N, WMMA_K, half, row_major> a_frag;
+  fragment<matrix_b, WMMA_M, WMMA_N, WMMA_K, half, row_major> b_frag;
+  fragment<accumulator, WMMA_M, WMMA_N, WMMA_K, float> acc_frag;
+  load_matrix_sync(acc_frag, sO + tile_d, O_STRIDE, mem_row_major);
+
+#pragma unroll
+  for (int tile_k = 0; tile_k < 2; ++tile_k) {
+    const int k_offset = tile_k * WMMA_K;
+    if (k_offset >= sub_valid_k_rows) {
+      break;
+    }
+    const int token_offset = sub_start + k_offset;
+    const int page_slot = token_offset >> 4;
+    const int block_offset = page_offset[page_slot] + (token_offset & 15);
+    const int physical_block_idx = page_idx[page_slot];
+    const __half* v_tile_ptr = v_cache +
+                               (int64_t)physical_block_idx * v_block_stride +
+                               (int64_t)block_offset * v_token_stride +
+                               (int64_t)kv_head_id * v_head_stride + tile_d;
+    if constexpr (SWIZZLED_P) {
+      load_pipeline_swizzled_matrix_a_fragment(a_frag, sP, k_offset);
+    } else {
+      load_matrix_sync(a_frag, sP + k_offset, P_STRIDE);
+    }
+    load_matrix_sync(b_frag, v_tile_ptr, v_token_stride);
+    mma_sync(acc_frag, a_frag, b_frag, acc_frag);
+  }
+  store_matrix_sync(sO + tile_d, acc_frag, O_STRIDE, mem_row_major);
+}
+
+template <int D, bool LOW_SMEM, bool LOW_SMEM_CONTIG_FAST,
+          bool LOW_SMEM_SCALAR_QK, bool LOW_SMEM_BM32, bool SPLIT_KV,
+          bool IS_CAUSAL, int KV_DTYPE, bool D256_OUTPUT_STRIDE_268 = false,
+          bool D256_SW_PIPELINE_QK = false, bool D256_SW_PIPELINE_PV = false>
+__global__ void __launch_bounds__(
+    KernelConfig<D, LOW_SMEM, LOW_SMEM_SCALAR_QK, LOW_SMEM_BM32,
+                 D256_OUTPUT_STRIDE_268, D256_SW_PIPELINE_QK,
+                 D256_SW_PIPELINE_PV>::THREADS_PER_BLOCK,
+    2)
+    flash_attention_forward_kernel_paged(
+        const __half* __restrict__ Q, const void* __restrict__ K_cache,
+        const void* __restrict__ V_cache, __half* __restrict__ Out,
+        float* __restrict__ softmax_lse, const int* __restrict__ block_table,
+        const int* __restrict__ seqused_k, const int B, const int H,
+        const int M, const int N, const int* __restrict__ bfla_block_mask,
+        const int bfla_mask_block_n, const int64_t bfla_mask_stride_b,
+        const int64_t bfla_mask_stride_h, const int64_t bfla_mask_stride_q,
+        const int64_t bfla_mask_stride_k, const int page_block_size,
+        const int num_kv_heads, const int64_t k_block_stride,
+        const int64_t k_token_stride, const int64_t k_head_stride,
+        const int64_t v_block_stride, const int64_t v_token_stride,
+        const int64_t v_head_stride, const float softmax_scale,
+        const float k_scale, const float v_scale, const int window_size_left,
+        const int window_size_right, float* __restrict__ split_tmp_out,
+        float* __restrict__ split_tmp_row_max,
+        float* __restrict__ split_tmp_row_sum, const int split_kv_tiles) {
+  using Config = KernelConfig<D, LOW_SMEM, LOW_SMEM_SCALAR_QK, LOW_SMEM_BM32,
+                              D256_OUTPUT_STRIDE_268, D256_SW_PIPELINE_QK,
+                              D256_SW_PIPELINE_PV>;
+  using Traits = FlashV100Traits<D>;
+
+  constexpr int BLOCK_M = Config::BLOCK_M;
+  constexpr int BLOCK_N = Config::BLOCK_N;
+  constexpr int THREADS_PER_BLOCK = Config::THREADS_PER_BLOCK;
+  constexpr int THREADS_PER_ROW = Config::THREADS_PER_ROW;
+  constexpr int WARPS_PER_BLOCK = Config::WARPS_PER_BLOCK;
+  constexpr int Q_STRIDE = Config::Q_STRIDE;
+  constexpr int KV_STRIDE = Config::KV_STRIDE;
+  constexpr int S_STRIDE = Config::S_STRIDE;
+  constexpr int P_SUB_TILE = Config::P_SUB_TILE;
+  constexpr int P_STRIDE = Config::P_STRIDE;
+  constexpr int O_STRIDE = Config::O_STRIDE;
+  constexpr int PER_UINT4 = Config::PER_UINT4;
+  constexpr bool USE_SW_PIPELINE = D256_SW_PIPELINE_QK || D256_SW_PIPELINE_PV;
+  if constexpr (USE_SW_PIPELINE) {
+    static_assert(D == 256 && LOW_SMEM && !LOW_SMEM_CONTIG_FAST &&
+                      !LOW_SMEM_SCALAR_QK && !LOW_SMEM_BM32 && !SPLIT_KV &&
+                      BLOCK_M == 16 && BLOCK_N == 128 && WARPS_PER_BLOCK == 16,
+                  "software pipeline is specialized for D256 BM16 BN128");
+  }
+  const float NEG_INF = -1e30f;
+
+  const int batch_head_id = blockIdx.z;
+  if (batch_head_id >= B * H) return;
+
+  const int batch_id = batch_head_id / H;
+  const int q_head_id = batch_head_id % H;
+  const int kv_group_size = H / num_kv_heads;
+  const int kv_head_id = q_head_id / kv_group_size;
+
+  const int block_m = blockIdx.x;
+  const int start_row = block_m * BLOCK_M;
+  if (start_row >= M) return;
+
+  const int actual_N = seqused_k[batch_id];
+  int num_n_tiles = (actual_N + BLOCK_N - 1) / BLOCK_N;
+  const int valid_q_rows = min(BLOCK_M, M - start_row);
+  const int causal_q_offset = max(actual_N - M, 0);
+
+  int max_key_pos = actual_N - 1;
+  if constexpr (IS_CAUSAL) {
+    max_key_pos =
+        min(max_key_pos, start_row + valid_q_rows - 1 + causal_q_offset);
+  }
+  if (window_size_right >= 0) {
+    max_key_pos = min(max_key_pos, start_row + valid_q_rows - 1 +
+                                       causal_q_offset + window_size_right);
+  }
+  if (max_key_pos < 0) {
+    num_n_tiles = 0;
+  } else {
+    num_n_tiles = min(num_n_tiles, (max_key_pos + BLOCK_N) / BLOCK_N);
+  }
+  const int min_key_pos =
+      window_size_left >= 0
+          ? max(0, start_row + causal_q_offset - window_size_left)
+          : 0;
+
+  const int tid = threadIdx.x;
+  const int warp_id = tid / MAX_THREADS_PER_WARP;
+  const int lane_id = tid % MAX_THREADS_PER_WARP;
+
+  const size_t q_head_linear = (size_t)batch_id * H + q_head_id;
+  const __half* q_ptr = Q + q_head_linear * M * D + start_row * D;
+  __half* out_ptr = Out + q_head_linear * M * D + start_row * D;
+  float* softmax_lse_ptr = softmax_lse + q_head_linear * M + start_row;
+
+  const int max_num_blocks_per_seq =
+      (N + page_block_size - 1) / page_block_size;
+  const int* block_table_seq = block_table + batch_id * max_num_blocks_per_seq;
+
+  const int64_t k_row_stride = k_token_stride;
+  const int64_t v_row_stride = v_token_stride;
+
+  extern __shared__ char smem_raw[];
+  init_smem<Config>(smem_raw);
+  auto& smem = *reinterpret_cast<typename Config::SmemLayout*>(smem_raw);
+
+  __half* sQ = smem.q;
+  __half* sK = smem.reuse_kv.k;
+  __half* sV = smem.reuse_kv.v;
+  float* sS = smem.reuse_sp.s;
+  __half* sP = (D == 256) ? smem.p_strict : smem.reuse_sp.p;
+  const int p_stride = (D == 256) ? P_STRIDE : S_STRIDE;
+  const int p_tile_capacity = (D == 256) ? P_SUB_TILE : BLOCK_N;
+  float* sO = smem.o;
+  float* sRowMax = smem.row_max;
+  float* sRowSum = smem.row_sum;
+  int* sPageIdx = smem.page_idx;
+  int* sPageOffset = smem.page_offset;
+
+  const int d_stride_uint4 = (D + PER_UINT4 - 1) / PER_UINT4;
+  const int q_stride_uint4 = (Q_STRIDE + PER_UINT4 - 1) / PER_UINT4;
+  const int kv_stride_uint4 = (KV_STRIDE + PER_UINT4 - 1) / PER_UINT4;
+
+  if (tid < BLOCK_M) {
+    sRowMax[tid] = NEG_INF;
+    sRowSum[tid] = 0.0f;
+  }
+  constexpr int O_UINT4_PER_ROW = D / 4;
+  constexpr int O_UINT4_STRIDE = O_STRIDE / 4;
+  for (int idx = tid; idx < BLOCK_M * O_UINT4_PER_ROW;
+       idx += THREADS_PER_BLOCK) {
+    const int row = idx / O_UINT4_PER_ROW;
+    const int col = idx % O_UINT4_PER_ROW;
+    reinterpret_cast<uint4*>(sO)[row * O_UINT4_STRIDE + col] =
+        make_uint4(0, 0, 0, 0);
+  }
+  __syncthreads();
+
+  const uint4* q_vec = reinterpret_cast<const uint4*>(q_ptr);
+  uint4* sQ_vec = reinterpret_cast<uint4*>(sQ);
+
+#pragma unroll 4
+  for (int idx = tid; idx < (valid_q_rows * d_stride_uint4);
+       idx += THREADS_PER_BLOCK) {
+    const int row = idx / d_stride_uint4;
+    const int vec_col = idx % d_stride_uint4;
+    uint4 q_val = make_uint4(0, 0, 0, 0);
+    if (row < valid_q_rows && vec_col < d_stride_uint4) {
+      q_val = __ldg(&q_vec[row * d_stride_uint4 + vec_col]);
+    }
+    if constexpr (Config::PIPELINE_SWIZZLED_Q) {
+      const int k_tile = vec_col >> 1;
+      const int plane = vec_col & 1;
+      const int slot = pipeline_swizzled_q_row_slot(row);
+      sQ_vec[k_tile * (2 * BLOCK_M) + plane * BLOCK_M + slot] = q_val;
+    } else {
+      sQ_vec[row * q_stride_uint4 + vec_col] = q_val;
+    }
+  }
+  __syncthreads();
+
+  int cross_block_first_n_tile = 0;
+  if constexpr (D256_SW_PIPELINE_QK && D256_SW_PIPELINE_PV) {
+    const bool use_cross_block_pipeline =
+        valid_q_rows == BLOCK_M && actual_N > 0 && page_block_size == 784 &&
+        bfla_block_mask == nullptr && window_size_left < 0 &&
+        window_size_right < 0;
+    if (use_cross_block_pipeline) {
+      const __half* k_cache_h = reinterpret_cast<const __half*>(K_cache);
+      const __half* v_cache_h = reinterpret_cast<const __half*>(V_cache);
+
+      if (tid < Config::LOW_SMEM_PAGE_COUNT) {
+        const int global_token_idx = tid * LOW_SMEM_PAGE_SIZE;
+        const int virtual_block_idx = global_token_idx / page_block_size;
+        sPageIdx[tid] = __ldg(&block_table_seq[virtual_block_idx]);
+        sPageOffset[tid] =
+            global_token_idx - virtual_block_idx * page_block_size;
+      }
+      __syncthreads();
+
+      if (warp_id < BLOCK_N / WMMA_N) {
+        const int valid_k_rows = min(BLOCK_N, actual_N);
+        pipeline_qk_slice<Q_STRIDE, S_STRIDE, D / WMMA_K, IS_CAUSAL, true>(
+            sQ, sS, k_cache_h, sPageIdx, sPageOffset, k_block_stride,
+            k_token_stride, k_head_stride, kv_head_id, 0, valid_k_rows,
+            start_row, valid_q_rows, causal_q_offset, warp_id * WMMA_N, 0,
+            false, true, softmax_scale, window_size_left, window_size_right,
+            NEG_INF);
+      }
+      __syncthreads();
+
+      // Keep the hot loop on a compile-time steady-state path. The
+      // existing exact path below drains the final block, avoiding a
+      // loop-carried has_next predicate in every softmax/PV panel.
+      const int steady_n_tiles = num_n_tiles - 1;
+      for (int block_n = 0; block_n < steady_n_tiles; ++block_n) {
+        const int start_col = block_n * BLOCK_N;
+        const int valid_k_rows = BLOCK_N;
+        const int next_start_col = start_col + BLOCK_N;
+        const int next_valid_k_rows = min(BLOCK_N, actual_N - next_start_col);
+        const bool odd_block = (block_n & 1) != 0;
+        float* const score_current = odd_block ? smem.pipeline_s : sS;
+        float* const score_next = odd_block ? sS : smem.pipeline_s;
+        int* const page_idx_current =
+            odd_block ? smem.pipeline_page_idx : sPageIdx;
+        int* const page_offset_current =
+            odd_block ? smem.pipeline_page_offset : sPageOffset;
+        int* const page_idx_next =
+            odd_block ? sPageIdx : smem.pipeline_page_idx;
+        int* const page_offset_next =
+            odd_block ? sPageOffset : smem.pipeline_page_offset;
+
+        if (tid < Config::LOW_SMEM_PAGE_COUNT) {
+          const int page_token_offset = tid * LOW_SMEM_PAGE_SIZE;
+          const int global_token_idx = next_start_col + page_token_offset;
+          const int virtual_block_idx = global_token_idx / page_block_size;
+          page_idx_next[tid] = __ldg(&block_table_seq[virtual_block_idx]);
+          page_offset_next[tid] =
+              global_token_idx - virtual_block_idx * page_block_size;
         }
-        load_matrix_sync(
-            b_frag, k_tile_base + k_offset, k_token_stride);
-        mma_sync(acc_frag, a_frag, b_frag, acc_frag);
+        __syncthreads();
+
+        for (int sub_start = 0; sub_start < valid_k_rows;
+             sub_start += P_SUB_TILE) {
+          const int sub_valid_k_rows =
+              min(P_SUB_TILE, valid_k_rows - sub_start);
+          const int row = warp_id;
+          const int thread_in_row = lane_id;
+          const unsigned mask = 0xFFFFFFFFU;
+          float* sS_row_f = score_current + row * S_STRIDE + sub_start;
+
+          const int vec_cols = sub_valid_k_rows >> 2;
+          const int vecs_per_thread =
+              (vec_cols + THREADS_PER_ROW - 1) / THREADS_PER_ROW;
+          const int tail_start = vec_cols << 2;
+          float thread_max = NEG_INF;
+          float4* sS_vec4 = reinterpret_cast<float4*>(sS_row_f);
+
+#pragma unroll 4
+          for (int j = 0; j < vecs_per_thread; ++j) {
+            const int vc = thread_in_row + j * THREADS_PER_ROW;
+            if (vc < vec_cols) {
+              const float4 v4 = sS_vec4[vc];
+              thread_max = fmaxf(thread_max,
+                                 fmaxf(fmaxf(v4.x, v4.y), fmaxf(v4.z, v4.w)));
+            }
+          }
+#pragma unroll
+          for (int c = tail_start + thread_in_row; c < sub_valid_k_rows;
+               c += THREADS_PER_ROW) {
+            thread_max = fmaxf(thread_max, sS_row_f[c]);
+          }
+#pragma unroll
+          for (int o = THREADS_PER_ROW / 2; o > 0; o >>= 1) {
+            thread_max =
+                fmaxf(thread_max, __shfl_down_sync(mask, thread_max, o));
+          }
+
+          const float row_max = __shfl_sync(mask, thread_max, 0);
+          const float old_max = sRowMax[row];
+          const float new_max = fmaxf(old_max, row_max);
+          const float exp_diff = __expf(old_max - new_max);
+          float thread_sum = 0.0f;
+          int vc_base = thread_in_row;
+
+#pragma unroll 4
+          for (int j = 0; j < vecs_per_thread;
+               ++j, vc_base += THREADS_PER_ROW) {
+            if (vc_base < vec_cols) {
+              const float4 v4 = sS_vec4[vc_base];
+              const float e0 = __expf(fmaxf(v4.x - new_max, -80.0f));
+              const float e1 = __expf(fmaxf(v4.y - new_max, -80.0f));
+              const float e2 = __expf(fmaxf(v4.z - new_max, -80.0f));
+              const float e3 = __expf(fmaxf(v4.w - new_max, -80.0f));
+              thread_sum += (e0 + e1) + (e2 + e3);
+              const int p_col = vc_base * 4;
+              __half2* p_half2 = reinterpret_cast<__half2*>(
+                  sP + pipeline_swizzled_matrix_a_offset(row, p_col));
+              p_half2[0] = __float22half2_rn(make_float2(e0, e1));
+              p_half2[1] = __float22half2_rn(make_float2(e2, e3));
+            }
+          }
+#pragma unroll 4
+          for (int c = tail_start + thread_in_row; c < sub_valid_k_rows;
+               c += THREADS_PER_ROW) {
+            const float e = __expf(fmaxf(sS_row_f[c] - new_max, -80.0f));
+            thread_sum += e;
+            sP[pipeline_swizzled_matrix_a_offset(row, c)] = __float2half_rn(e);
+          }
+#pragma unroll
+          for (int o = THREADS_PER_ROW / 2; o > 0; o >>= 1) {
+            thread_sum += __shfl_down_sync(mask, thread_sum, o);
+          }
+          const float row_sum = __shfl_sync(mask, thread_sum, 0);
+          if (thread_in_row == 0) {
+            sRowSum[row] = exp_diff * sRowSum[row] + row_sum;
+            sRowMax[row] = new_max;
+          }
+
+#pragma unroll 4
+          for (int c = tail_start + thread_in_row; c < P_SUB_TILE;
+               c += THREADS_PER_ROW) {
+            if (c >= sub_valid_k_rows) {
+              sP[pipeline_swizzled_matrix_a_offset(row, c)] =
+                  __float2half(0.0f);
+            }
+          }
+
+          if (block_n > 0 || sub_start > 0) {
+            float4* sO_vec = reinterpret_cast<float4*>(sO + row * O_STRIDE);
+#pragma unroll 4
+            for (int ov = thread_in_row; ov < D / 4; ov += THREADS_PER_ROW) {
+              float4 v = sO_vec[ov];
+              v.x *= exp_diff;
+              v.y *= exp_diff;
+              v.z *= exp_diff;
+              v.w *= exp_diff;
+              sO_vec[ov] = v;
+            }
+          }
+          __syncthreads();
+
+          if (sub_start == 0) {
+            if (warp_id < BLOCK_N / WMMA_N) {
+              pipeline_qk_slice<Q_STRIDE, S_STRIDE, D / WMMA_K, IS_CAUSAL,
+                                true>(
+                  sQ, score_next, k_cache_h, page_idx_next, page_offset_next,
+                  k_block_stride, k_token_stride, k_head_stride, kv_head_id,
+                  next_start_col, next_valid_k_rows, start_row, valid_q_rows,
+                  causal_q_offset, warp_id * WMMA_N, 0, false, true,
+                  softmax_scale, window_size_left, window_size_right, NEG_INF);
+            } else {
+              const int pv_warp = warp_id - BLOCK_N / WMMA_N;
+              pipeline_pv_tile<P_STRIDE, O_STRIDE, true>(
+                  sP, sO, v_cache_h, page_idx_current, page_offset_current,
+                  v_block_stride, v_token_stride, v_head_stride, kv_head_id,
+                  sub_start, sub_valid_k_rows, pv_warp * WMMA_N);
+              pipeline_pv_tile<P_STRIDE, O_STRIDE, true>(
+                  sP, sO, v_cache_h, page_idx_current, page_offset_current,
+                  v_block_stride, v_token_stride, v_head_stride, kv_head_id,
+                  sub_start, sub_valid_k_rows,
+                  (pv_warp + BLOCK_N / WMMA_N) * WMMA_N);
+            }
+          } else {
+            pipeline_pv_tile<P_STRIDE, O_STRIDE, true>(
+                sP, sO, v_cache_h, page_idx_current, page_offset_current,
+                v_block_stride, v_token_stride, v_head_stride, kv_head_id,
+                sub_start, sub_valid_k_rows, warp_id * WMMA_N);
+          }
+          __syncthreads();
+        }
+      }
+      cross_block_first_n_tile = steady_n_tiles;
+    }
+  }
+
+  int first_n_tile = cross_block_first_n_tile;
+  int last_n_tile = num_n_tiles;
+  if constexpr (SPLIT_KV) {
+    const int partition_id = blockIdx.y;
+    const int tiles_per_partition = split_kv_tiles > 1 ? split_kv_tiles : 1;
+    first_n_tile = partition_id * tiles_per_partition;
+    last_n_tile = min(num_n_tiles, first_n_tile + tiles_per_partition);
+  }
+
+  for (int block_n = first_n_tile; block_n < last_n_tile; ++block_n) {
+    const int start_col = block_n * BLOCK_N;
+    if (start_col >= actual_N) break;
+    const int valid_k_rows = min(BLOCK_N, actual_N - start_col);
+
+    if (start_col + valid_k_rows <= min_key_pos) {
+      continue;
     }
 
-    if (finalize) {
-        const int lane_id = threadIdx.x & 31;
-        const unsigned row_causal =
-            (lane_id & 0b1) + ((lane_id >> 2) & 0b1) * 8
-            + ((lane_id >> 4) & 0b1) * 4;
+    if (bfla_block_mask != nullptr && bfla_mask_block_n > 0) {
+      const int mask_q_idx = start_row / bfla_mask_block_n;
+      const int mask_k_idx = start_col / bfla_mask_block_n;
+      const int keep_tile =
+          __ldg(bfla_block_mask + (int64_t)batch_id * bfla_mask_stride_b +
+                (int64_t)kv_head_id * bfla_mask_stride_h +
+                (int64_t)mask_q_idx * bfla_mask_stride_q +
+                (int64_t)mask_k_idx * bfla_mask_stride_k);
+      if (keep_tile == 0) {
+        continue;
+      }
+    }
+
+    const int partial_block_size =
+        (block_n == num_n_tiles - 1 && actual_N % BLOCK_N != 0)
+            ? (actual_N % BLOCK_N)
+            : -1;
+
+    uint4* sK_vec = reinterpret_cast<uint4*>(sK);
+    const int64_t row_stride_uint4 = k_row_stride / PER_UINT4;
+    const int start_page = start_col / page_block_size;
+    const int page_offset = start_col % page_block_size;
+    const bool single_page_tile =
+        (page_offset + valid_k_rows) <= page_block_size;
+    const bool two_page_tile =
+        !single_page_tile &&
+        (page_offset + valid_k_rows) <= (page_block_size * 2);
+    const int first_page_rows =
+        single_page_tile ? valid_k_rows
+                         : min(valid_k_rows, page_block_size - page_offset);
+    const int second_page_rows = valid_k_rows - first_page_rows;
+    const int physical_block_idx0 = __ldg(&block_table_seq[start_page]);
+    const int physical_block_idx1 =
+        second_page_rows > 0 ? __ldg(&block_table_seq[start_page + 1]) : -1;
+    const bool four_page_aligned_tile =
+        D == 256 && page_block_size == 16 && page_offset == 0 &&
+        BLOCK_N == page_block_size * 4 && valid_k_rows == BLOCK_N &&
+        k_block_stride == (int64_t)page_block_size * k_token_stride &&
+        v_block_stride == (int64_t)page_block_size * v_token_stride;
+    const int physical_block_idx2 =
+        four_page_aligned_tile ? __ldg(&block_table_seq[start_page + 2]) : -1;
+    const int physical_block_idx3 =
+        four_page_aligned_tile ? __ldg(&block_table_seq[start_page + 3]) : -1;
+    const bool four_page_contiguous_tile =
+        four_page_aligned_tile &&
+        physical_block_idx1 == physical_block_idx0 + 1 &&
+        physical_block_idx2 == physical_block_idx0 + 2 &&
+        physical_block_idx3 == physical_block_idx0 + 3;
+    bool low_smem_contiguous_page_tile = false;
+    if constexpr (LOW_SMEM) {
+      static_assert(D == 256, "low-smem paged prefill is D=256 only");
+      static_assert(KV_DTYPE == flash_v100::KV_CACHE_DTYPE_FP16,
+                    "low-smem paged prefill is fp16-KV only");
+      static_assert(BLOCK_N % LOW_SMEM_PAGE_SIZE == 0,
+                    "low-smem BLOCK_N must be page aligned");
+
+      constexpr int LOW_SMEM_PAGE_COUNT = Config::LOW_SMEM_PAGE_COUNT;
+      if (tid < LOW_SMEM_PAGE_COUNT) {
+        const int page_token_offset = tid * LOW_SMEM_PAGE_SIZE;
+        if (page_token_offset < valid_k_rows) {
+          const int global_token_idx = start_col + page_token_offset;
+          const int virtual_block_idx = global_token_idx / page_block_size;
+          sPageIdx[tid] = __ldg(&block_table_seq[virtual_block_idx]);
+          sPageOffset[tid] =
+              global_token_idx - virtual_block_idx * page_block_size;
+        } else {
+          sPageIdx[tid] = -1;
+          sPageOffset[tid] = 0;
+        }
+      }
+      __syncthreads();
+
+      if constexpr (LOW_SMEM_CONTIG_FAST) {
+        low_smem_contiguous_page_tile =
+            valid_k_rows == BLOCK_N &&
+            k_block_stride == (int64_t)page_block_size * k_token_stride &&
+            v_block_stride == (int64_t)page_block_size * v_token_stride &&
+            sPageIdx[0] >= 0;
+#pragma unroll
+        for (int i = 1; i < LOW_SMEM_PAGE_COUNT; ++i) {
+          const int linear_offset = sPageOffset[0] + i * LOW_SMEM_PAGE_SIZE;
+          const int expected_page_delta = linear_offset / page_block_size;
+          const int expected_page_offset =
+              linear_offset - expected_page_delta * page_block_size;
+          low_smem_contiguous_page_tile =
+              low_smem_contiguous_page_tile &&
+              sPageIdx[i] == sPageIdx[0] + expected_page_delta &&
+              sPageOffset[i] == expected_page_offset;
+        }
+      } else {
+        low_smem_contiguous_page_tile = false;
+      }
+
+      const __half* K_cache_h = reinterpret_cast<const __half*>(K_cache);
+
+      if constexpr (LOW_SMEM_SCALAR_QK) {
+        uint4* sK_vec = reinterpret_cast<uint4*>(sK);
+        for (int idx = tid; idx < valid_k_rows * d_stride_uint4;
+             idx += THREADS_PER_BLOCK) {
+          const int row = idx / d_stride_uint4;
+          const int vec_col = idx % d_stride_uint4;
+          uint4 k_val = make_uint4(0, 0, 0, 0);
+          if (row < valid_k_rows && vec_col < d_stride_uint4) {
+            const int page_slot = row >> 4;
+            const int block_offset =
+                sPageOffset[page_slot] + (row - page_slot * LOW_SMEM_PAGE_SIZE);
+            const int physical_block_idx_direct = sPageIdx[page_slot];
+            const __half* k_row_ptr;
+            if constexpr (LOW_SMEM_CONTIG_FAST) {
+              k_row_ptr =
+                  low_smem_contiguous_page_tile
+                      ? K_cache_h + (int64_t)sPageIdx[0] * k_block_stride +
+                            (int64_t)(sPageOffset[0] + row) * k_token_stride +
+                            (int64_t)kv_head_id * k_head_stride
+                      : K_cache_h +
+                            (int64_t)physical_block_idx_direct *
+                                k_block_stride +
+                            (int64_t)block_offset * k_token_stride +
+                            (int64_t)kv_head_id * k_head_stride;
+            } else {
+              k_row_ptr = K_cache_h +
+                          (int64_t)physical_block_idx_direct * k_block_stride +
+                          (int64_t)block_offset * k_token_stride +
+                          (int64_t)kv_head_id * k_head_stride;
+            }
+            const uint4* k_row_vec = reinterpret_cast<const uint4*>(k_row_ptr);
+            k_val = __ldg(&k_row_vec[vec_col]);
+          }
+          sK_vec[row * kv_stride_uint4 + vec_col] = k_val;
+        }
+        __syncthreads();
+
+        const int total_scores = valid_q_rows * valid_k_rows;
+        for (int idx = tid; idx < total_scores; idx += THREADS_PER_BLOCK) {
+          const int row = idx / valid_k_rows;
+          const int col = idx - row * valid_k_rows;
+          const int global_m = start_row + row;
+          const int global_n = start_col + col;
+          const int global_q_pos = global_m + causal_q_offset;
+
+          bool is_valid = true;
+          if constexpr (IS_CAUSAL) {
+            is_valid = global_n <= global_q_pos;
+          }
+          if (window_size_left >= 0) {
+            is_valid = is_valid && global_n >= global_q_pos - window_size_left;
+          }
+          if (window_size_right >= 0) {
+            is_valid = is_valid && global_n <= global_q_pos + window_size_right;
+          }
+
+          float acc = 0.0f;
+          if (is_valid) {
+#pragma unroll 8
+            for (int d = 0; d < D; d += 2) {
+              const __half2 q_h2 =
+                  *reinterpret_cast<const __half2*>(sQ + row * Q_STRIDE + d);
+              const __half2 k_h2 =
+                  *reinterpret_cast<const __half2*>(sK + col * KV_STRIDE + d);
+              const float2 q_f2 = __half22float2(q_h2);
+              const float2 k_f2 = __half22float2(k_h2);
+              acc = fmaf(q_f2.x, k_f2.x, acc);
+              acc = fmaf(q_f2.y, k_f2.y, acc);
+            }
+          }
+          sS[row * S_STRIDE + col] = is_valid ? acc * softmax_scale : NEG_INF;
+        }
+      } else if constexpr (D256_SW_PIPELINE_QK) {
+        constexpr int QK_TILES = BLOCK_N / WMMA_N;
+        if (warp_id < QK_TILES) {
+          pipeline_qk_slice<Q_STRIDE, S_STRIDE, D / WMMA_K, IS_CAUSAL,
+                            D256_SW_PIPELINE_PV>(
+              sQ, sS, K_cache_h, sPageIdx, sPageOffset, k_block_stride,
+              k_token_stride, k_head_stride, kv_head_id, start_col,
+              valid_k_rows, start_row, valid_q_rows, causal_q_offset,
+              warp_id * WMMA_N, 0, false, true, softmax_scale, window_size_left,
+              window_size_right, NEG_INF);
+        }
+      } else {
+        const int num_tiles_m_qk = (BLOCK_M + WMMA_M - 1) / WMMA_M;
+        const int num_tiles_n_qk = (BLOCK_N + WMMA_N - 1) / WMMA_N;
+        const int num_tiles_k_qk = (D + WMMA_K - 1) / WMMA_K;
+        const int total_tiles_qk = num_tiles_m_qk * num_tiles_n_qk;
+        const int tiles_per_warp_qk =
+            (total_tiles_qk + WARPS_PER_BLOCK - 1) / WARPS_PER_BLOCK;
+        const unsigned row_causal = (lane_id & 0b1) +
+                                    ((lane_id >> 2) & 0b1) * 8 +
+                                    ((lane_id >> 4) & 0b1) * 4;
         const unsigned col_causal =
             ((lane_id >> 1) & 0b1) * 2 + ((lane_id >> 3) & 0b1) * 8;
 
-        #pragma unroll
-        for (int i = 0; i < acc_frag.num_elements; ++i) {
-            const unsigned col =
-                col_causal + (i & 0b1) + ((i >> 2) & 0b1) * 4;
+        for (int tile_idx = 0; tile_idx < tiles_per_warp_qk; ++tile_idx) {
+          const int global_tile_idx = warp_id * tiles_per_warp_qk + tile_idx;
+          if (global_tile_idx >= total_tiles_qk) break;
+
+          const int tile_m_idx = global_tile_idx / num_tiles_n_qk;
+          const int tile_n_idx = global_tile_idx % num_tiles_n_qk;
+
+          const int tile_m = tile_m_idx * WMMA_M;
+          const int tile_n = tile_n_idx * WMMA_N;
+
+          if (tile_m >= valid_q_rows || tile_n >= valid_k_rows) {
+            continue;
+          }
+
+          const int page_slot = tile_n >> 4;
+          const int block_offset = sPageOffset[page_slot];
+          const int physical_block_idx_direct = sPageIdx[page_slot];
+
+          fragment<matrix_a, WMMA_M, WMMA_N, WMMA_K, half, row_major> a_frag;
+          fragment<matrix_b, WMMA_M, WMMA_N, WMMA_K, half, col_major> b_frag;
+          fragment<accumulator, WMMA_M, WMMA_N, WMMA_K, float> acc_frag;
+          fill_fragment(acc_frag, 0.0f);
+
+#pragma unroll
+          for (int k_tile = 0; k_tile < num_tiles_k_qk; ++k_tile) {
+            const int k_offset = k_tile * WMMA_K;
+            if (k_offset >= D) break;
+
+            const __half* k_tile_ptr;
+            if constexpr (LOW_SMEM_CONTIG_FAST) {
+              k_tile_ptr =
+                  low_smem_contiguous_page_tile
+                      ? K_cache_h + (int64_t)sPageIdx[0] * k_block_stride +
+                            (int64_t)(sPageOffset[0] + tile_n) *
+                                k_token_stride +
+                            (int64_t)kv_head_id * k_head_stride + k_offset
+                      : K_cache_h +
+                            (int64_t)physical_block_idx_direct *
+                                k_block_stride +
+                            (int64_t)block_offset * k_token_stride +
+                            (int64_t)kv_head_id * k_head_stride + k_offset;
+            } else {
+              k_tile_ptr = K_cache_h +
+                           (int64_t)physical_block_idx_direct * k_block_stride +
+                           (int64_t)block_offset * k_token_stride +
+                           (int64_t)kv_head_id * k_head_stride + k_offset;
+            }
+
+            load_matrix_sync(a_frag, sQ + tile_m * Q_STRIDE + k_offset,
+                             Q_STRIDE);
+            load_matrix_sync(b_frag, k_tile_ptr, k_token_stride);
+            mma_sync(acc_frag, a_frag, b_frag, acc_frag);
+          }
+
+#pragma unroll
+          for (int i = 0; i < acc_frag.num_elements; ++i) {
+            const unsigned col = col_causal + (i & 0b1) + ((i >> 2) & 0b1) * 4;
             const unsigned row = row_causal + ((i >> 1) & 0b1) * 2;
-            const int global_m = start_row + row;
+
+            const int global_m = start_row + tile_m + row;
             const int global_n = start_col + tile_n + col;
             const int global_q_pos = global_m + causal_q_offset;
 
-            const bool is_valid =
-                global_m < start_row + valid_q_rows
-                && global_n < start_col + valid_k_rows;
+            const bool is_valid = (global_m < start_row + valid_q_rows) &&
+                                  (global_n < start_col + valid_k_rows);
             bool is_causal_valid = true;
             if constexpr (IS_CAUSAL) {
-                is_causal_valid = global_n <= global_q_pos;
+              is_causal_valid = global_n <= global_q_pos;
             }
             bool is_window_valid = true;
             if (window_size_left >= 0) {
-                is_window_valid =
-                    global_n >= global_q_pos - window_size_left;
+              is_window_valid = is_window_valid &&
+                                global_n >= global_q_pos - window_size_left;
             }
             if (window_size_right >= 0) {
-                is_window_valid =
-                    is_window_valid
-                    && global_n <= global_q_pos + window_size_right;
-            }
-            acc_frag.x[i] =
-                (is_valid && is_causal_valid && is_window_valid)
-                    ? acc_frag.x[i] * softmax_scale
-                    : neg_inf;
-        }
-    }
-
-    store_matrix_sync(score + tile_n, acc_frag, S_STRIDE, mem_row_major);
-}
-
-template<int P_STRIDE, int O_STRIDE, bool SWIZZLED_P = false>
-__device__ __forceinline__ void pipeline_pv_tile(
-    const __half* __restrict__ sP,
-    float* __restrict__ sO,
-    const __half* __restrict__ v_cache,
-    const int* __restrict__ page_idx,
-    const int* __restrict__ page_offset,
-    int64_t v_block_stride,
-    int64_t v_token_stride,
-    int64_t v_head_stride,
-    int kv_head_id,
-    int sub_start,
-    int sub_valid_k_rows,
-    int tile_d) {
-    fragment<matrix_a, WMMA_M, WMMA_N, WMMA_K, half, row_major> a_frag;
-    fragment<matrix_b, WMMA_M, WMMA_N, WMMA_K, half, row_major> b_frag;
-    fragment<accumulator, WMMA_M, WMMA_N, WMMA_K, float> acc_frag;
-    load_matrix_sync(
-        acc_frag, sO + tile_d, O_STRIDE, mem_row_major);
-
-    #pragma unroll
-    for (int tile_k = 0; tile_k < 2; ++tile_k) {
-        const int k_offset = tile_k * WMMA_K;
-        if (k_offset >= sub_valid_k_rows) {
-            break;
-        }
-        const int token_offset = sub_start + k_offset;
-        const int page_slot = token_offset >> 4;
-        const int block_offset =
-            page_offset[page_slot] + (token_offset & 15);
-        const int physical_block_idx = page_idx[page_slot];
-        const __half* v_tile_ptr =
-            v_cache + (int64_t)physical_block_idx * v_block_stride
-            + (int64_t)block_offset * v_token_stride
-            + (int64_t)kv_head_id * v_head_stride + tile_d;
-        if constexpr (SWIZZLED_P) {
-            load_pipeline_swizzled_matrix_a_fragment(
-                a_frag, sP, k_offset);
-        } else {
-            load_matrix_sync(a_frag, sP + k_offset, P_STRIDE);
-        }
-        load_matrix_sync(b_frag, v_tile_ptr, v_token_stride);
-        mma_sync(acc_frag, a_frag, b_frag, acc_frag);
-    }
-    store_matrix_sync(sO + tile_d, acc_frag, O_STRIDE, mem_row_major);
-}
-
-template<int D, bool LOW_SMEM, bool LOW_SMEM_CONTIG_FAST,
-         bool LOW_SMEM_SCALAR_QK, bool LOW_SMEM_BM32, bool SPLIT_KV,
-         bool IS_CAUSAL, int KV_DTYPE, bool D256_OUTPUT_STRIDE_268 = false,
-         bool D256_SW_PIPELINE_QK = false,
-         bool D256_SW_PIPELINE_PV = false>
-__global__ void __launch_bounds__(
-    KernelConfig<D, LOW_SMEM, LOW_SMEM_SCALAR_QK,
-                 LOW_SMEM_BM32,
-                 D256_OUTPUT_STRIDE_268,
-                 D256_SW_PIPELINE_QK,
-                 D256_SW_PIPELINE_PV>::THREADS_PER_BLOCK, 2)
-flash_attention_forward_kernel_paged(
-    const __half* __restrict__ Q,
-    const void* __restrict__ K_cache,
-    const void* __restrict__ V_cache,
-          __half* __restrict__ Out,
-           float* __restrict__ softmax_lse,
-    const int* __restrict__ block_table,
-    const int* __restrict__ seqused_k,
-    const int B,
-    const int H,
-    const int M,
-    const int N,
-    const int* __restrict__ bfla_block_mask,
-    const int bfla_mask_block_n,
-    const int64_t bfla_mask_stride_b,
-    const int64_t bfla_mask_stride_h,
-    const int64_t bfla_mask_stride_q,
-    const int64_t bfla_mask_stride_k,
-    const int page_block_size,
-    const int num_kv_heads,
-    const int64_t k_block_stride,
-    const int64_t k_token_stride,
-    const int64_t k_head_stride,
-    const int64_t v_block_stride,
-    const int64_t v_token_stride,
-    const int64_t v_head_stride,
-    const float softmax_scale,
-    const float k_scale,
-    const float v_scale,
-    const int window_size_left,
-    const int window_size_right,
-          float* __restrict__ split_tmp_out,
-          float* __restrict__ split_tmp_row_max,
-          float* __restrict__ split_tmp_row_sum,
-    const int split_kv_tiles
-) {
-    using Config = KernelConfig<D, LOW_SMEM, LOW_SMEM_SCALAR_QK,
-                                LOW_SMEM_BM32, D256_OUTPUT_STRIDE_268,
-                                D256_SW_PIPELINE_QK,
-                                D256_SW_PIPELINE_PV>;
-    using Traits = FlashV100Traits<D>;
-
-    constexpr int BLOCK_M           = Config::BLOCK_M;
-    constexpr int BLOCK_N           = Config::BLOCK_N;
-    constexpr int THREADS_PER_BLOCK = Config::THREADS_PER_BLOCK;
-    constexpr int THREADS_PER_ROW   = Config::THREADS_PER_ROW;
-    constexpr int WARPS_PER_BLOCK   = Config::WARPS_PER_BLOCK;
-    constexpr int Q_STRIDE          = Config::Q_STRIDE;
-    constexpr int KV_STRIDE         = Config::KV_STRIDE;
-    constexpr int S_STRIDE          = Config::S_STRIDE;
-    constexpr int P_SUB_TILE        = Config::P_SUB_TILE;
-    constexpr int P_STRIDE          = Config::P_STRIDE;
-    constexpr int O_STRIDE          = Config::O_STRIDE;
-    constexpr int PER_UINT4         = Config::PER_UINT4;
-    constexpr bool USE_SW_PIPELINE =
-        D256_SW_PIPELINE_QK || D256_SW_PIPELINE_PV;
-    if constexpr (USE_SW_PIPELINE) {
-        static_assert(D == 256 && LOW_SMEM && !LOW_SMEM_CONTIG_FAST
-                          && !LOW_SMEM_SCALAR_QK && !LOW_SMEM_BM32
-                          && !SPLIT_KV && BLOCK_M == 16 && BLOCK_N == 128
-                          && WARPS_PER_BLOCK == 16,
-                      "software pipeline is specialized for D256 BM16 BN128");
-    }
-    const float NEG_INF = -1e30f;
-
-    const int batch_head_id = blockIdx.z;
-    if (batch_head_id >= B * H) return;
-
-    const int batch_id = batch_head_id / H;
-    const int q_head_id = batch_head_id % H;
-    const int kv_group_size = H / num_kv_heads;
-    const int kv_head_id = q_head_id / kv_group_size;
-
-    const int block_m = blockIdx.x;
-    const int start_row = block_m * BLOCK_M;
-    if (start_row >= M) return;
-
-    const int actual_N = seqused_k[batch_id];
-    int num_n_tiles = (actual_N + BLOCK_N - 1) / BLOCK_N;
-    const int valid_q_rows = min(BLOCK_M, M - start_row);
-    const int causal_q_offset = max(actual_N - M, 0);
-
-    int max_key_pos = actual_N - 1;
-    if constexpr (IS_CAUSAL) {
-        max_key_pos = min(max_key_pos,
-                          start_row + valid_q_rows - 1 + causal_q_offset);
-    }
-    if (window_size_right >= 0) {
-        max_key_pos = min(max_key_pos,
-                          start_row + valid_q_rows - 1 + causal_q_offset
-                              + window_size_right);
-    }
-    if (max_key_pos < 0) {
-        num_n_tiles = 0;
-    } else {
-        num_n_tiles = min(num_n_tiles, (max_key_pos + BLOCK_N) / BLOCK_N);
-    }
-    const int min_key_pos = window_size_left >= 0
-                                ? max(0, start_row + causal_q_offset
-                                             - window_size_left)
-                                : 0;
-
-    const int tid = threadIdx.x;
-    const int warp_id = tid / MAX_THREADS_PER_WARP;
-    const int lane_id = tid % MAX_THREADS_PER_WARP;
-
-    const size_t q_head_linear = (size_t)batch_id * H + q_head_id;
-    const __half* q_ptr = Q + q_head_linear * M * D + start_row * D;
-    __half* out_ptr = Out + q_head_linear * M * D + start_row * D;
-    float* softmax_lse_ptr = softmax_lse + q_head_linear * M + start_row;
-
-    const int max_num_blocks_per_seq = (N + page_block_size - 1) / page_block_size;
-    const int* block_table_seq = block_table + batch_id * max_num_blocks_per_seq;
-
-    const int64_t k_row_stride = k_token_stride;
-    const int64_t v_row_stride = v_token_stride;
-
-    extern __shared__ char smem_raw[];
-    init_smem<Config>(smem_raw);
-    auto& smem = *reinterpret_cast<typename Config::SmemLayout*>(smem_raw);
-
-    __half* sQ      = smem.q;
-    __half* sK      = smem.reuse_kv.k;
-    __half* sV      = smem.reuse_kv.v;
-    float*  sS      = smem.reuse_sp.s;
-    __half* sP      = (D == 256) ? smem.p_strict : smem.reuse_sp.p;
-    const int p_stride = (D == 256) ? P_STRIDE : S_STRIDE;
-    const int p_tile_capacity = (D == 256) ? P_SUB_TILE : BLOCK_N;
-    float*  sO      = smem.o;
-    float*  sRowMax = smem.row_max;
-    float*  sRowSum = smem.row_sum;
-    int*    sPageIdx = smem.page_idx;
-    int*    sPageOffset = smem.page_offset;
-
-    const int  d_stride_uint4 = (D + PER_UINT4 - 1) / PER_UINT4;
-    const int  q_stride_uint4 = (Q_STRIDE  + PER_UINT4 - 1) / PER_UINT4;
-    const int kv_stride_uint4 = (KV_STRIDE + PER_UINT4 - 1) / PER_UINT4;
-
-    if (tid < BLOCK_M) {
-        sRowMax[tid] = NEG_INF;
-        sRowSum[tid] = 0.0f;
-    }
-    constexpr int O_UINT4_PER_ROW = D / 4;
-    constexpr int O_UINT4_STRIDE = O_STRIDE / 4;
-    for (int idx = tid; idx < BLOCK_M * O_UINT4_PER_ROW;
-         idx += THREADS_PER_BLOCK) {
-        const int row = idx / O_UINT4_PER_ROW;
-        const int col = idx % O_UINT4_PER_ROW;
-        reinterpret_cast<uint4*>(sO)[row * O_UINT4_STRIDE + col] =
-            make_uint4(0, 0, 0, 0);
-    }
-    __syncthreads();
-
-    const uint4*      q_vec = reinterpret_cast<const uint4*>(q_ptr);
-    uint4*           sQ_vec = reinterpret_cast<uint4*>(sQ);
-
-    #pragma unroll 4
-    for (int idx = tid; idx < (valid_q_rows * d_stride_uint4); idx += THREADS_PER_BLOCK) {
-        const int row = idx / d_stride_uint4;
-        const int vec_col = idx % d_stride_uint4;
-        uint4 q_val = make_uint4(0, 0, 0, 0);
-        if (row < valid_q_rows && vec_col < d_stride_uint4) {
-            q_val = __ldg(&q_vec[row * d_stride_uint4 + vec_col]);
-        }
-        if constexpr (Config::PIPELINE_SWIZZLED_Q) {
-            const int k_tile = vec_col >> 1;
-            const int plane = vec_col & 1;
-            const int slot = pipeline_swizzled_q_row_slot(row);
-            sQ_vec[k_tile * (2 * BLOCK_M) + plane * BLOCK_M + slot] =
-                q_val;
-        } else {
-            sQ_vec[row * q_stride_uint4 + vec_col] = q_val;
-        }
-    }
-    __syncthreads();
-
-    int cross_block_first_n_tile = 0;
-    if constexpr (D256_SW_PIPELINE_QK && D256_SW_PIPELINE_PV) {
-        const bool use_cross_block_pipeline =
-            valid_q_rows == BLOCK_M && actual_N > 0
-            && page_block_size == 784 && bfla_block_mask == nullptr
-            && window_size_left < 0 && window_size_right < 0;
-        if (use_cross_block_pipeline) {
-            const __half* k_cache_h =
-                reinterpret_cast<const __half*>(K_cache);
-            const __half* v_cache_h =
-                reinterpret_cast<const __half*>(V_cache);
-
-            if (tid < Config::LOW_SMEM_PAGE_COUNT) {
-                const int global_token_idx = tid * LOW_SMEM_PAGE_SIZE;
-                const int virtual_block_idx =
-                    global_token_idx / page_block_size;
-                sPageIdx[tid] =
-                    __ldg(&block_table_seq[virtual_block_idx]);
-                sPageOffset[tid] =
-                    global_token_idx
-                    - virtual_block_idx * page_block_size;
-            }
-            __syncthreads();
-
-            if (warp_id < BLOCK_N / WMMA_N) {
-                const int valid_k_rows = min(BLOCK_N, actual_N);
-                pipeline_qk_slice<Q_STRIDE, S_STRIDE, D / WMMA_K,
-                                  IS_CAUSAL, true>(
-                    sQ, sS, k_cache_h, sPageIdx, sPageOffset,
-                    k_block_stride, k_token_stride,
-                    k_head_stride, kv_head_id, 0, valid_k_rows, start_row,
-                    valid_q_rows, causal_q_offset, warp_id * WMMA_N, 0, false,
-                    true, softmax_scale, window_size_left, window_size_right,
-                    NEG_INF);
-            }
-            __syncthreads();
-
-            // Keep the hot loop on a compile-time steady-state path. The
-            // existing exact path below drains the final block, avoiding a
-            // loop-carried has_next predicate in every softmax/PV panel.
-            const int steady_n_tiles = num_n_tiles - 1;
-            for (int block_n = 0; block_n < steady_n_tiles; ++block_n) {
-                const int start_col = block_n * BLOCK_N;
-                const int valid_k_rows = BLOCK_N;
-                const int next_start_col = start_col + BLOCK_N;
-                const int next_valid_k_rows =
-                    min(BLOCK_N, actual_N - next_start_col);
-                const bool odd_block = (block_n & 1) != 0;
-                float* const score_current =
-                    odd_block ? smem.pipeline_s : sS;
-                float* const score_next =
-                    odd_block ? sS : smem.pipeline_s;
-                int* const page_idx_current =
-                    odd_block ? smem.pipeline_page_idx : sPageIdx;
-                int* const page_offset_current =
-                    odd_block ? smem.pipeline_page_offset : sPageOffset;
-                int* const page_idx_next =
-                    odd_block ? sPageIdx : smem.pipeline_page_idx;
-                int* const page_offset_next =
-                    odd_block ? sPageOffset : smem.pipeline_page_offset;
-
-                if (tid < Config::LOW_SMEM_PAGE_COUNT) {
-                    const int page_token_offset =
-                        tid * LOW_SMEM_PAGE_SIZE;
-                    const int global_token_idx =
-                        next_start_col + page_token_offset;
-                    const int virtual_block_idx =
-                        global_token_idx / page_block_size;
-                    page_idx_next[tid] =
-                        __ldg(&block_table_seq[virtual_block_idx]);
-                    page_offset_next[tid] =
-                        global_token_idx
-                        - virtual_block_idx * page_block_size;
-                }
-                __syncthreads();
-
-                for (int sub_start = 0; sub_start < valid_k_rows;
-                     sub_start += P_SUB_TILE) {
-                    const int sub_valid_k_rows =
-                        min(P_SUB_TILE, valid_k_rows - sub_start);
-                    const int row = warp_id;
-                    const int thread_in_row = lane_id;
-                    const unsigned mask = 0xFFFFFFFFU;
-                    float* sS_row_f =
-                        score_current + row * S_STRIDE + sub_start;
-
-                    const int vec_cols = sub_valid_k_rows >> 2;
-                    const int vecs_per_thread =
-                        (vec_cols + THREADS_PER_ROW - 1) / THREADS_PER_ROW;
-                    const int tail_start = vec_cols << 2;
-                    float thread_max = NEG_INF;
-                    float4* sS_vec4 = reinterpret_cast<float4*>(sS_row_f);
-
-                    #pragma unroll 4
-                    for (int j = 0; j < vecs_per_thread; ++j) {
-                        const int vc =
-                            thread_in_row + j * THREADS_PER_ROW;
-                        if (vc < vec_cols) {
-                            const float4 v4 = sS_vec4[vc];
-                            thread_max = fmaxf(
-                                thread_max,
-                                fmaxf(
-                                    fmaxf(v4.x, v4.y),
-                                    fmaxf(v4.z, v4.w)));
-                        }
-                    }
-                    #pragma unroll
-                    for (int c = tail_start + thread_in_row;
-                         c < sub_valid_k_rows; c += THREADS_PER_ROW) {
-                        thread_max = fmaxf(thread_max, sS_row_f[c]);
-                    }
-                    #pragma unroll
-                    for (int o = THREADS_PER_ROW / 2; o > 0; o >>= 1) {
-                        thread_max = fmaxf(
-                            thread_max,
-                            __shfl_down_sync(mask, thread_max, o));
-                    }
-
-                    const float row_max =
-                        __shfl_sync(mask, thread_max, 0);
-                    const float old_max = sRowMax[row];
-                    const float new_max = fmaxf(old_max, row_max);
-                    const float exp_diff = __expf(old_max - new_max);
-                    float thread_sum = 0.0f;
-                    int vc_base = thread_in_row;
-
-                    #pragma unroll 4
-                    for (int j = 0; j < vecs_per_thread;
-                         ++j, vc_base += THREADS_PER_ROW) {
-                        if (vc_base < vec_cols) {
-                            const float4 v4 = sS_vec4[vc_base];
-                            const float e0 =
-                                __expf(fmaxf(v4.x - new_max, -80.0f));
-                            const float e1 =
-                                __expf(fmaxf(v4.y - new_max, -80.0f));
-                            const float e2 =
-                                __expf(fmaxf(v4.z - new_max, -80.0f));
-                            const float e3 =
-                                __expf(fmaxf(v4.w - new_max, -80.0f));
-                            thread_sum += (e0 + e1) + (e2 + e3);
-                            const int p_col = vc_base * 4;
-                            __half2* p_half2 = reinterpret_cast<__half2*>(
-                                sP + pipeline_swizzled_matrix_a_offset(
-                                         row, p_col));
-                            p_half2[0] =
-                                __float22half2_rn(make_float2(e0, e1));
-                            p_half2[1] =
-                                __float22half2_rn(make_float2(e2, e3));
-                        }
-                    }
-                    #pragma unroll 4
-                    for (int c = tail_start + thread_in_row;
-                         c < sub_valid_k_rows; c += THREADS_PER_ROW) {
-                        const float e = __expf(
-                            fmaxf(sS_row_f[c] - new_max, -80.0f));
-                        thread_sum += e;
-                        sP[pipeline_swizzled_matrix_a_offset(row, c)] =
-                            __float2half_rn(e);
-                    }
-                    #pragma unroll
-                    for (int o = THREADS_PER_ROW / 2; o > 0; o >>= 1) {
-                        thread_sum +=
-                            __shfl_down_sync(mask, thread_sum, o);
-                    }
-                    const float row_sum =
-                        __shfl_sync(mask, thread_sum, 0);
-                    if (thread_in_row == 0) {
-                        sRowSum[row] = exp_diff * sRowSum[row] + row_sum;
-                        sRowMax[row] = new_max;
-                    }
-
-                    #pragma unroll 4
-                    for (int c = tail_start + thread_in_row;
-                        c < P_SUB_TILE; c += THREADS_PER_ROW) {
-                        if (c >= sub_valid_k_rows) {
-                            sP[pipeline_swizzled_matrix_a_offset(row, c)] =
-                                __float2half(0.0f);
-                        }
-                    }
-
-                    if (block_n > 0 || sub_start > 0) {
-                        float4* sO_vec = reinterpret_cast<float4*>(
-                            sO + row * O_STRIDE);
-                        #pragma unroll 4
-                        for (int ov = thread_in_row; ov < D / 4;
-                             ov += THREADS_PER_ROW) {
-                            float4 v = sO_vec[ov];
-                            v.x *= exp_diff;
-                            v.y *= exp_diff;
-                            v.z *= exp_diff;
-                            v.w *= exp_diff;
-                            sO_vec[ov] = v;
-                        }
-                    }
-                    __syncthreads();
-
-                    if (sub_start == 0) {
-                        if (warp_id < BLOCK_N / WMMA_N) {
-                            pipeline_qk_slice<
-                                Q_STRIDE, S_STRIDE, D / WMMA_K, IS_CAUSAL,
-                                true>(
-                                sQ, score_next, k_cache_h, page_idx_next,
-                                page_offset_next, k_block_stride,
-                                k_token_stride, k_head_stride, kv_head_id,
-                                next_start_col, next_valid_k_rows, start_row,
-                                valid_q_rows, causal_q_offset,
-                                warp_id * WMMA_N, 0, false, true,
-                                softmax_scale, window_size_left,
-                                window_size_right, NEG_INF);
-                        } else {
-                            const int pv_warp =
-                                warp_id - BLOCK_N / WMMA_N;
-                            pipeline_pv_tile<P_STRIDE, O_STRIDE, true>(
-                                sP, sO, v_cache_h, page_idx_current,
-                                page_offset_current, v_block_stride,
-                                v_token_stride, v_head_stride, kv_head_id,
-                                sub_start, sub_valid_k_rows,
-                                pv_warp * WMMA_N);
-                            pipeline_pv_tile<P_STRIDE, O_STRIDE, true>(
-                                sP, sO, v_cache_h, page_idx_current,
-                                page_offset_current, v_block_stride,
-                                v_token_stride, v_head_stride, kv_head_id,
-                                sub_start, sub_valid_k_rows,
-                                (pv_warp + BLOCK_N / WMMA_N) * WMMA_N);
-                        }
-                    } else {
-                        pipeline_pv_tile<P_STRIDE, O_STRIDE, true>(
-                            sP, sO, v_cache_h, page_idx_current,
-                            page_offset_current, v_block_stride,
-                            v_token_stride, v_head_stride, kv_head_id,
-                            sub_start, sub_valid_k_rows, warp_id * WMMA_N);
-                    }
-                    __syncthreads();
-                }
-
-            }
-            cross_block_first_n_tile = steady_n_tiles;
-        }
-    }
-
-    int first_n_tile = cross_block_first_n_tile;
-    int last_n_tile = num_n_tiles;
-    if constexpr (SPLIT_KV) {
-        const int partition_id = blockIdx.y;
-        const int tiles_per_partition =
-            split_kv_tiles > 1 ? split_kv_tiles : 1;
-        first_n_tile = partition_id * tiles_per_partition;
-        last_n_tile = min(num_n_tiles, first_n_tile + tiles_per_partition);
-    }
-
-    for (int block_n = first_n_tile; block_n < last_n_tile; ++block_n) {
-        const int start_col = block_n * BLOCK_N;
-        if (start_col >= actual_N) break;
-        const int valid_k_rows = min(BLOCK_N, actual_N - start_col);
-
-        if (start_col + valid_k_rows <= min_key_pos) {
-            continue;
-        }
-
-        if (bfla_block_mask != nullptr && bfla_mask_block_n > 0) {
-            const int mask_q_idx = start_row / bfla_mask_block_n;
-            const int mask_k_idx = start_col / bfla_mask_block_n;
-            const int keep_tile = __ldg(
-                bfla_block_mask
-                + (int64_t)batch_id * bfla_mask_stride_b
-                + (int64_t)kv_head_id * bfla_mask_stride_h
-                + (int64_t)mask_q_idx * bfla_mask_stride_q
-                + (int64_t)mask_k_idx * bfla_mask_stride_k);
-            if (keep_tile == 0) {
-                continue;
-            }
-        }
-
-        const int partial_block_size = (block_n == num_n_tiles - 1 && actual_N % BLOCK_N != 0)
-                                       ? (actual_N % BLOCK_N) : -1;
-
-        uint4* sK_vec = reinterpret_cast<uint4*>(sK);
-        const int64_t row_stride_uint4 = k_row_stride / PER_UINT4;
-        const int start_page = start_col / page_block_size;
-        const int page_offset = start_col % page_block_size;
-        const bool single_page_tile =
-            (page_offset + valid_k_rows) <= page_block_size;
-        const bool two_page_tile =
-            !single_page_tile &&
-            (page_offset + valid_k_rows) <= (page_block_size * 2);
-        const int first_page_rows =
-            single_page_tile ? valid_k_rows
-                             : min(valid_k_rows, page_block_size - page_offset);
-        const int second_page_rows = valid_k_rows - first_page_rows;
-        const int physical_block_idx0 = __ldg(&block_table_seq[start_page]);
-        const int physical_block_idx1 =
-            second_page_rows > 0 ? __ldg(&block_table_seq[start_page + 1]) : -1;
-        const bool four_page_aligned_tile =
-            D == 256 && page_block_size == 16 && page_offset == 0
-            && BLOCK_N == page_block_size * 4
-            && valid_k_rows == BLOCK_N
-            && k_block_stride == (int64_t)page_block_size * k_token_stride
-            && v_block_stride == (int64_t)page_block_size * v_token_stride;
-        const int physical_block_idx2 =
-            four_page_aligned_tile ? __ldg(&block_table_seq[start_page + 2]) : -1;
-        const int physical_block_idx3 =
-            four_page_aligned_tile ? __ldg(&block_table_seq[start_page + 3]) : -1;
-        const bool four_page_contiguous_tile =
-            four_page_aligned_tile
-            && physical_block_idx1 == physical_block_idx0 + 1
-            && physical_block_idx2 == physical_block_idx0 + 2
-            && physical_block_idx3 == physical_block_idx0 + 3;
-        bool low_smem_contiguous_page_tile = false;
-        if constexpr (LOW_SMEM) {
-            static_assert(D == 256, "low-smem paged prefill is D=256 only");
-            static_assert(KV_DTYPE == flash_v100::KV_CACHE_DTYPE_FP16,
-                          "low-smem paged prefill is fp16-KV only");
-            static_assert(BLOCK_N % LOW_SMEM_PAGE_SIZE == 0,
-                          "low-smem BLOCK_N must be page aligned");
-
-            constexpr int LOW_SMEM_PAGE_COUNT =
-                Config::LOW_SMEM_PAGE_COUNT;
-            if (tid < LOW_SMEM_PAGE_COUNT) {
-                const int page_token_offset = tid * LOW_SMEM_PAGE_SIZE;
-                if (page_token_offset < valid_k_rows) {
-                    const int global_token_idx =
-                        start_col + page_token_offset;
-                    const int virtual_block_idx =
-                        global_token_idx / page_block_size;
-                    sPageIdx[tid] = __ldg(
-                        &block_table_seq[virtual_block_idx]);
-                    sPageOffset[tid] =
-                        global_token_idx
-                        - virtual_block_idx * page_block_size;
-                } else {
-                    sPageIdx[tid] = -1;
-                    sPageOffset[tid] = 0;
-                }
-            }
-            __syncthreads();
-
-            if constexpr (LOW_SMEM_CONTIG_FAST) {
-                low_smem_contiguous_page_tile =
-                    valid_k_rows == BLOCK_N
-                    && k_block_stride
-                        == (int64_t)page_block_size * k_token_stride
-                    && v_block_stride
-                        == (int64_t)page_block_size * v_token_stride
-                    && sPageIdx[0] >= 0;
-                #pragma unroll
-                for (int i = 1; i < LOW_SMEM_PAGE_COUNT; ++i) {
-                    const int linear_offset =
-                        sPageOffset[0] + i * LOW_SMEM_PAGE_SIZE;
-                    const int expected_page_delta =
-                        linear_offset / page_block_size;
-                    const int expected_page_offset =
-                        linear_offset
-                        - expected_page_delta * page_block_size;
-                    low_smem_contiguous_page_tile =
-                        low_smem_contiguous_page_tile
-                        && sPageIdx[i] == sPageIdx[0] + expected_page_delta
-                        && sPageOffset[i] == expected_page_offset;
-                }
-            } else {
-                low_smem_contiguous_page_tile = false;
+              is_window_valid = is_window_valid &&
+                                global_n <= global_q_pos + window_size_right;
             }
 
-            const __half* K_cache_h = reinterpret_cast<const __half*>(K_cache);
-
-            if constexpr (LOW_SMEM_SCALAR_QK) {
-                uint4* sK_vec = reinterpret_cast<uint4*>(sK);
-                for (int idx = tid; idx < valid_k_rows * d_stride_uint4;
-                     idx += THREADS_PER_BLOCK) {
-                    const int row = idx / d_stride_uint4;
-                    const int vec_col = idx % d_stride_uint4;
-                    uint4 k_val = make_uint4(0, 0, 0, 0);
-                    if (row < valid_k_rows && vec_col < d_stride_uint4) {
-                        const int page_slot = row >> 4;
-                        const int block_offset =
-                            sPageOffset[page_slot]
-                            + (row - page_slot * LOW_SMEM_PAGE_SIZE);
-                        const int physical_block_idx_direct =
-                            sPageIdx[page_slot];
-                        const __half* k_row_ptr;
-                        if constexpr (LOW_SMEM_CONTIG_FAST) {
-                            k_row_ptr =
-                                low_smem_contiguous_page_tile
-                                    ? K_cache_h
-                                          + (int64_t)sPageIdx[0] * k_block_stride
-                                          + (int64_t)(sPageOffset[0] + row)
-                                                * k_token_stride
-                                          + (int64_t)kv_head_id * k_head_stride
-                                    : K_cache_h
-                                          + (int64_t)physical_block_idx_direct
-                                                * k_block_stride
-                                          + (int64_t)block_offset
-                                                * k_token_stride
-                                          + (int64_t)kv_head_id * k_head_stride;
-                        } else {
-                            k_row_ptr =
-                                K_cache_h
-                                + (int64_t)physical_block_idx_direct
-                                      * k_block_stride
-                                + (int64_t)block_offset * k_token_stride
-                                + (int64_t)kv_head_id * k_head_stride;
-                        }
-                        const uint4* k_row_vec =
-                            reinterpret_cast<const uint4*>(k_row_ptr);
-                        k_val = __ldg(&k_row_vec[vec_col]);
-                    }
-                    sK_vec[row * kv_stride_uint4 + vec_col] = k_val;
-                }
-                __syncthreads();
-
-                const int total_scores = valid_q_rows * valid_k_rows;
-                for (int idx = tid; idx < total_scores;
-                     idx += THREADS_PER_BLOCK) {
-                    const int row = idx / valid_k_rows;
-                    const int col = idx - row * valid_k_rows;
-                    const int global_m = start_row + row;
-                    const int global_n = start_col + col;
-                    const int global_q_pos = global_m + causal_q_offset;
-
-                    bool is_valid = true;
-                    if constexpr (IS_CAUSAL) {
-                        is_valid = global_n <= global_q_pos;
-                    }
-                    if (window_size_left >= 0) {
-                        is_valid =
-                            is_valid
-                            && global_n >= global_q_pos - window_size_left;
-                    }
-                    if (window_size_right >= 0) {
-                        is_valid =
-                            is_valid
-                            && global_n <= global_q_pos + window_size_right;
-                    }
-
-                    float acc = 0.0f;
-                    if (is_valid) {
-                        #pragma unroll 8
-                        for (int d = 0; d < D; d += 2) {
-                            const __half2 q_h2 =
-                                *reinterpret_cast<const __half2*>(
-                                    sQ + row * Q_STRIDE + d);
-                            const __half2 k_h2 =
-                                *reinterpret_cast<const __half2*>(
-                                    sK + col * KV_STRIDE + d);
-                            const float2 q_f2 = __half22float2(q_h2);
-                            const float2 k_f2 = __half22float2(k_h2);
-                            acc = fmaf(q_f2.x, k_f2.x, acc);
-                            acc = fmaf(q_f2.y, k_f2.y, acc);
-                        }
-                    }
-                    sS[row * S_STRIDE + col] =
-                        is_valid ? acc * softmax_scale : NEG_INF;
-                }
-            } else if constexpr (D256_SW_PIPELINE_QK) {
-                constexpr int QK_TILES = BLOCK_N / WMMA_N;
-                if (warp_id < QK_TILES) {
-                    pipeline_qk_slice<Q_STRIDE, S_STRIDE, D / WMMA_K,
-                                      IS_CAUSAL, D256_SW_PIPELINE_PV>(
-                        sQ, sS, K_cache_h, sPageIdx, sPageOffset,
-                        k_block_stride, k_token_stride, k_head_stride,
-                        kv_head_id, start_col, valid_k_rows, start_row,
-                        valid_q_rows, causal_q_offset, warp_id * WMMA_N, 0,
-                        false, true, softmax_scale, window_size_left,
-                        window_size_right, NEG_INF);
-                }
-            } else {
-                const int num_tiles_m_qk = (BLOCK_M + WMMA_M - 1) / WMMA_M;
-                const int num_tiles_n_qk = (BLOCK_N + WMMA_N - 1) / WMMA_N;
-                const int num_tiles_k_qk = (D + WMMA_K - 1) / WMMA_K;
-                const int total_tiles_qk = num_tiles_m_qk * num_tiles_n_qk;
-                const int tiles_per_warp_qk =
-                    (total_tiles_qk + WARPS_PER_BLOCK - 1) / WARPS_PER_BLOCK;
-                const unsigned row_causal =
-                    (lane_id & 0b1) + ((lane_id >> 2) & 0b1) * 8
-                    + ((lane_id >> 4) & 0b1) * 4;
-                const unsigned col_causal =
-                    ((lane_id >> 1) & 0b1) * 2 + ((lane_id >> 3) & 0b1) * 8;
-
-                for (int tile_idx = 0; tile_idx < tiles_per_warp_qk;
-                     ++tile_idx) {
-                    const int global_tile_idx =
-                        warp_id * tiles_per_warp_qk + tile_idx;
-                    if (global_tile_idx >= total_tiles_qk) break;
-
-                    const int tile_m_idx = global_tile_idx / num_tiles_n_qk;
-                    const int tile_n_idx = global_tile_idx % num_tiles_n_qk;
-
-                    const int tile_m = tile_m_idx * WMMA_M;
-                    const int tile_n = tile_n_idx * WMMA_N;
-
-                    if (tile_m >= valid_q_rows || tile_n >= valid_k_rows) {
-                        continue;
-                    }
-
-                    const int page_slot = tile_n >> 4;
-                    const int block_offset = sPageOffset[page_slot];
-                    const int physical_block_idx_direct = sPageIdx[page_slot];
-
-                    fragment<matrix_a, WMMA_M, WMMA_N, WMMA_K, half, row_major>
-                        a_frag;
-                    fragment<matrix_b, WMMA_M, WMMA_N, WMMA_K, half, col_major>
-                        b_frag;
-                    fragment<accumulator, WMMA_M, WMMA_N, WMMA_K, float>
-                        acc_frag;
-                    fill_fragment(acc_frag, 0.0f);
-
-                    #pragma unroll
-                    for (int k_tile = 0; k_tile < num_tiles_k_qk; ++k_tile) {
-                        const int k_offset = k_tile * WMMA_K;
-                        if (k_offset >= D) break;
-
-                        const __half* k_tile_ptr;
-                        if constexpr (LOW_SMEM_CONTIG_FAST) {
-                            k_tile_ptr =
-                                low_smem_contiguous_page_tile
-                                    ? K_cache_h
-                                          + (int64_t)sPageIdx[0] * k_block_stride
-                                          + (int64_t)(sPageOffset[0] + tile_n)
-                                                * k_token_stride
-                                          + (int64_t)kv_head_id * k_head_stride
-                                          + k_offset
-                                    : K_cache_h
-                                          + (int64_t)physical_block_idx_direct
-                                                * k_block_stride
-                                          + (int64_t)block_offset
-                                                * k_token_stride
-                                          + (int64_t)kv_head_id * k_head_stride
-                                          + k_offset;
-                        } else {
-                            k_tile_ptr =
-                                K_cache_h
-                                + (int64_t)physical_block_idx_direct
-                                      * k_block_stride
-                                + (int64_t)block_offset * k_token_stride
-                                + (int64_t)kv_head_id * k_head_stride
-                                + k_offset;
-                        }
-
-                        load_matrix_sync(
-                            a_frag,
-                            sQ + tile_m * Q_STRIDE + k_offset,
-                            Q_STRIDE);
-                        load_matrix_sync(b_frag, k_tile_ptr, k_token_stride);
-                        mma_sync(acc_frag, a_frag, b_frag, acc_frag);
-                    }
-
-                    #pragma unroll
-                    for (int i = 0; i < acc_frag.num_elements; ++i) {
-                        const unsigned col =
-                            col_causal + (i & 0b1) + ((i >> 2) & 0b1) * 4;
-                        const unsigned row =
-                            row_causal + ((i >> 1) & 0b1) * 2;
-
-                        const int global_m = start_row + tile_m + row;
-                        const int global_n = start_col + tile_n + col;
-                        const int global_q_pos = global_m + causal_q_offset;
-
-                        const bool is_valid =
-                            (global_m < start_row + valid_q_rows)
-                            && (global_n < start_col + valid_k_rows);
-                        bool is_causal_valid = true;
-                        if constexpr (IS_CAUSAL) {
-                            is_causal_valid = global_n <= global_q_pos;
-                        }
-                        bool is_window_valid = true;
-                        if (window_size_left >= 0) {
-                            is_window_valid =
-                                is_window_valid
-                                && global_n
-                                       >= global_q_pos - window_size_left;
-                        }
-                        if (window_size_right >= 0) {
-                            is_window_valid =
-                                is_window_valid
-                                && global_n
-                                       <= global_q_pos + window_size_right;
-                        }
-
-                        acc_frag.x[i] =
-                            (is_valid && is_causal_valid && is_window_valid)
+            acc_frag.x[i] = (is_valid && is_causal_valid && is_window_valid)
                                 ? acc_frag.x[i] * softmax_scale
                                 : NEG_INF;
-                    }
+          }
 
-                    store_matrix_sync(
-                        sS + tile_m * S_STRIDE + tile_n, acc_frag, S_STRIDE,
-                        mem_row_major);
-                }
-            }
-            __syncthreads();
-        } else {
-        if constexpr (KV_DTYPE == flash_v100::KV_CACHE_DTYPE_FP16) {
-            const __half* K_cache_h = reinterpret_cast<const __half*>(K_cache);
-            const uint4* k_page0_vec = reinterpret_cast<const uint4*>(
-                K_cache_h + (int64_t)physical_block_idx0 * k_block_stride
-                + (int64_t)page_offset * k_token_stride
-                + (int64_t)kv_head_id * k_head_stride);
-            const uint4* k_page1_vec =
-                two_page_tile && second_page_rows > 0
-                    ? reinterpret_cast<const uint4*>(
-                          K_cache_h + (int64_t)physical_block_idx1 * k_block_stride
-                          + (int64_t)kv_head_id * k_head_stride)
-                    : nullptr;
-
-            #pragma unroll 2
-            for (int idx = tid; idx < (valid_k_rows * d_stride_uint4);
-                 idx += THREADS_PER_BLOCK) {
-                const int row = idx / d_stride_uint4;
-                const int vec_col = idx % d_stride_uint4;
-
-                uint4 k_val = make_uint4(0, 0, 0, 0);
-                if (row < valid_k_rows && vec_col < d_stride_uint4) {
-                    if (four_page_contiguous_tile) {
-                        k_val = __ldg(
-                            &k_page0_vec[row * row_stride_uint4 + vec_col]);
-                    } else if (single_page_tile) {
-                        k_val = __ldg(&k_page0_vec[row * row_stride_uint4 + vec_col]);
-                    } else if (two_page_tile) {
-                        if (row < first_page_rows) {
-                            k_val = __ldg(
-                                &k_page0_vec[row * row_stride_uint4 + vec_col]);
-                        } else {
-                            const int row_page1 = row - first_page_rows;
-                            k_val = __ldg(
-                                &k_page1_vec[row_page1 * row_stride_uint4 + vec_col]);
-                        }
-                    } else {
-                        const uint4* k_vec = reinterpret_cast<const uint4*>(K_cache_h);
-                        const int global_token_idx = start_col + row;
-                        const int virtual_block_idx =
-                            global_token_idx / page_block_size;
-                        const int block_offset = global_token_idx % page_block_size;
-                        const int physical_block_idx_slow =
-                            __ldg(&block_table_seq[virtual_block_idx]);
-                        const int64_t physical_offset_halfs =
-                            (int64_t)physical_block_idx_slow * k_block_stride
-                            + (int64_t)block_offset * k_token_stride
-                            + (int64_t)kv_head_id * k_head_stride;
-                        const int64_t physical_offset_uint4 =
-                            (physical_offset_halfs / PER_UINT4) + vec_col;
-                        k_val = __ldg(&k_vec[physical_offset_uint4]);
-                    }
-                }
-                sK_vec[row * kv_stride_uint4 + vec_col] = k_val;
-            }
-        } else {
-            for (int idx = tid; idx < valid_k_rows * D; idx += THREADS_PER_BLOCK) {
-                const int row = idx / D;
-                const int col = idx % D;
-                const int global_token_idx = start_col + row;
-                const int virtual_block_idx = global_token_idx / page_block_size;
-                const int block_offset = global_token_idx % page_block_size;
-                const int physical_block_idx_slow =
-                    __ldg(&block_table_seq[virtual_block_idx]);
-                const int64_t physical_offset =
-                    (int64_t)physical_block_idx_slow * k_block_stride
-                    + (int64_t)block_offset * k_token_stride
-                    + (int64_t)kv_head_id * k_head_stride + col;
-                sK[row * KV_STRIDE + col] =
-                    flash_v100::load_kv_cache_half<KV_DTYPE>(
-                        K_cache, physical_offset, k_scale);
-            }
+          store_matrix_sync(sS + tile_m * S_STRIDE + tile_n, acc_frag, S_STRIDE,
+                            mem_row_major);
         }
-        __syncthreads();
+      }
+      __syncthreads();
+    } else {
+      if constexpr (KV_DTYPE == flash_v100::KV_CACHE_DTYPE_FP16) {
+        const __half* K_cache_h = reinterpret_cast<const __half*>(K_cache);
+        const uint4* k_page0_vec = reinterpret_cast<const uint4*>(
+            K_cache_h + (int64_t)physical_block_idx0 * k_block_stride +
+            (int64_t)page_offset * k_token_stride +
+            (int64_t)kv_head_id * k_head_stride);
+        const uint4* k_page1_vec =
+            two_page_tile && second_page_rows > 0
+                ? reinterpret_cast<const uint4*>(
+                      K_cache_h +
+                      (int64_t)physical_block_idx1 * k_block_stride +
+                      (int64_t)kv_head_id * k_head_stride)
+                : nullptr;
 
-        const int num_tiles_m_qk    = (BLOCK_M + WMMA_M - 1) / WMMA_M;
-        const int num_tiles_n_qk    = (BLOCK_N + WMMA_N - 1) / WMMA_N;
-        const int num_tiles_k_qk    = (D + WMMA_K - 1) / WMMA_K;
-        const int total_tiles_qk    = num_tiles_m_qk * num_tiles_n_qk;
-        const int tiles_per_warp_qk = (total_tiles_qk + WARPS_PER_BLOCK - 1) / WARPS_PER_BLOCK;
-        const unsigned row_causal   = (lane_id & 0b1) + ((lane_id >> 2) & 0b1) * 8 + ((lane_id >> 4) & 0b1) * 4;
-        const unsigned col_causal   = ((lane_id >> 1) & 0b1) * 2 + ((lane_id >> 3) & 0b1) * 8;
+#pragma unroll 2
+        for (int idx = tid; idx < (valid_k_rows * d_stride_uint4);
+             idx += THREADS_PER_BLOCK) {
+          const int row = idx / d_stride_uint4;
+          const int vec_col = idx % d_stride_uint4;
 
-        for (int tile_idx = 0; tile_idx < tiles_per_warp_qk; ++tile_idx) {
-            const int global_tile_idx = warp_id * tiles_per_warp_qk + tile_idx;
-            if (global_tile_idx >= total_tiles_qk) break;
-
-            const int tile_m_idx = global_tile_idx / num_tiles_n_qk;
-            const int tile_n_idx = global_tile_idx % num_tiles_n_qk;
-
-            const int tile_m = tile_m_idx * WMMA_M;
-            const int tile_n = tile_n_idx * WMMA_N;
-
-            if (tile_m >= valid_q_rows || tile_n >= valid_k_rows) continue;
-
-            fragment<matrix_a, WMMA_M, WMMA_N, WMMA_K, half, row_major> a_frag;
-            fragment<matrix_b, WMMA_M, WMMA_N, WMMA_K, half, col_major> b_frag;
-            fragment<accumulator, WMMA_M, WMMA_N, WMMA_K, float> acc_frag;
-            fill_fragment(acc_frag, 0.0f);
-
-            #pragma unroll
-            for (int k_tile = 0; k_tile < num_tiles_k_qk; ++k_tile) {
-                const int k_offset = k_tile * WMMA_K;
-                if (k_offset >= D) break;
-
-                load_matrix_sync(a_frag, sQ + tile_m * Q_STRIDE + k_offset, Q_STRIDE);
-                load_matrix_sync(b_frag, sK + tile_n * KV_STRIDE + k_offset, KV_STRIDE);
-                mma_sync(acc_frag, a_frag, b_frag, acc_frag);
+          uint4 k_val = make_uint4(0, 0, 0, 0);
+          if (row < valid_k_rows && vec_col < d_stride_uint4) {
+            if (four_page_contiguous_tile) {
+              k_val = __ldg(&k_page0_vec[row * row_stride_uint4 + vec_col]);
+            } else if (single_page_tile) {
+              k_val = __ldg(&k_page0_vec[row * row_stride_uint4 + vec_col]);
+            } else if (two_page_tile) {
+              if (row < first_page_rows) {
+                k_val = __ldg(&k_page0_vec[row * row_stride_uint4 + vec_col]);
+              } else {
+                const int row_page1 = row - first_page_rows;
+                k_val =
+                    __ldg(&k_page1_vec[row_page1 * row_stride_uint4 + vec_col]);
+              }
+            } else {
+              const uint4* k_vec = reinterpret_cast<const uint4*>(K_cache_h);
+              const int global_token_idx = start_col + row;
+              const int virtual_block_idx = global_token_idx / page_block_size;
+              const int block_offset = global_token_idx % page_block_size;
+              const int physical_block_idx_slow =
+                  __ldg(&block_table_seq[virtual_block_idx]);
+              const int64_t physical_offset_halves =
+                  (int64_t)physical_block_idx_slow * k_block_stride +
+                  (int64_t)block_offset * k_token_stride +
+                  (int64_t)kv_head_id * k_head_stride;
+              const int64_t physical_offset_uint4 =
+                  (physical_offset_halves / PER_UINT4) + vec_col;
+              k_val = __ldg(&k_vec[physical_offset_uint4]);
             }
-
-            #pragma unroll
-            for (int i = 0; i < acc_frag.num_elements; ++i) {
-                const unsigned col = col_causal + (i & 0b1) + ((i >> 2) & 0b1) * 4;
-                const unsigned row = row_causal + ((i >> 1) & 0b1) * 2;
-
-                const int global_m = start_row + tile_m + row;
-                const int global_n = start_col + tile_n + col;
-                const int global_q_pos = global_m + causal_q_offset;
-
-                const bool is_valid = (global_m < start_row + valid_q_rows) &&
-                                      (global_n < start_col + valid_k_rows);
-                bool is_causal_valid = true;
-                if constexpr (IS_CAUSAL) {
-                    is_causal_valid = global_n <= global_q_pos;
-                }
-                bool is_window_valid = true;
-                if (window_size_left >= 0) {
-                    is_window_valid = is_window_valid &&
-                                      global_n >= global_q_pos - window_size_left;
-                }
-                if (window_size_right >= 0) {
-                    is_window_valid = is_window_valid &&
-                                      global_n <= global_q_pos + window_size_right;
-                }
-
-                acc_frag.x[i] = (is_valid && is_causal_valid && is_window_valid)
-                    ? acc_frag.x[i] * softmax_scale
-                    : NEG_INF;
-            }
-
-            store_matrix_sync(sS + tile_m * S_STRIDE + tile_n, acc_frag, S_STRIDE, mem_row_major);
+          }
+          sK_vec[row * kv_stride_uint4 + vec_col] = k_val;
         }
-        __syncthreads();
+      } else {
+        for (int idx = tid; idx < valid_k_rows * D; idx += THREADS_PER_BLOCK) {
+          const int row = idx / D;
+          const int col = idx % D;
+          const int global_token_idx = start_col + row;
+          const int virtual_block_idx = global_token_idx / page_block_size;
+          const int block_offset = global_token_idx % page_block_size;
+          const int physical_block_idx_slow =
+              __ldg(&block_table_seq[virtual_block_idx]);
+          const int64_t physical_offset =
+              (int64_t)physical_block_idx_slow * k_block_stride +
+              (int64_t)block_offset * k_token_stride +
+              (int64_t)kv_head_id * k_head_stride + col;
+          sK[row * KV_STRIDE + col] = flash_v100::load_kv_cache_half<KV_DTYPE>(
+              K_cache, physical_offset, k_scale);
+        }
+      }
+      __syncthreads();
+
+      const int num_tiles_m_qk = (BLOCK_M + WMMA_M - 1) / WMMA_M;
+      const int num_tiles_n_qk = (BLOCK_N + WMMA_N - 1) / WMMA_N;
+      const int num_tiles_k_qk = (D + WMMA_K - 1) / WMMA_K;
+      const int total_tiles_qk = num_tiles_m_qk * num_tiles_n_qk;
+      const int tiles_per_warp_qk =
+          (total_tiles_qk + WARPS_PER_BLOCK - 1) / WARPS_PER_BLOCK;
+      const unsigned row_causal = (lane_id & 0b1) + ((lane_id >> 2) & 0b1) * 8 +
+                                  ((lane_id >> 4) & 0b1) * 4;
+      const unsigned col_causal =
+          ((lane_id >> 1) & 0b1) * 2 + ((lane_id >> 3) & 0b1) * 8;
+
+      for (int tile_idx = 0; tile_idx < tiles_per_warp_qk; ++tile_idx) {
+        const int global_tile_idx = warp_id * tiles_per_warp_qk + tile_idx;
+        if (global_tile_idx >= total_tiles_qk) break;
+
+        const int tile_m_idx = global_tile_idx / num_tiles_n_qk;
+        const int tile_n_idx = global_tile_idx % num_tiles_n_qk;
+
+        const int tile_m = tile_m_idx * WMMA_M;
+        const int tile_n = tile_n_idx * WMMA_N;
+
+        if (tile_m >= valid_q_rows || tile_n >= valid_k_rows) continue;
+
+        fragment<matrix_a, WMMA_M, WMMA_N, WMMA_K, half, row_major> a_frag;
+        fragment<matrix_b, WMMA_M, WMMA_N, WMMA_K, half, col_major> b_frag;
+        fragment<accumulator, WMMA_M, WMMA_N, WMMA_K, float> acc_frag;
+        fill_fragment(acc_frag, 0.0f);
+
+#pragma unroll
+        for (int k_tile = 0; k_tile < num_tiles_k_qk; ++k_tile) {
+          const int k_offset = k_tile * WMMA_K;
+          if (k_offset >= D) break;
+
+          load_matrix_sync(a_frag, sQ + tile_m * Q_STRIDE + k_offset, Q_STRIDE);
+          load_matrix_sync(b_frag, sK + tile_n * KV_STRIDE + k_offset,
+                           KV_STRIDE);
+          mma_sync(acc_frag, a_frag, b_frag, acc_frag);
         }
 
-        uint4* sV_vec = reinterpret_cast<uint4*>(sV);
-        const int64_t v_row_stride_uint4 = v_row_stride / PER_UINT4;
-        if constexpr (!LOW_SMEM) {
-        if constexpr (KV_DTYPE == flash_v100::KV_CACHE_DTYPE_FP16) {
+#pragma unroll
+        for (int i = 0; i < acc_frag.num_elements; ++i) {
+          const unsigned col = col_causal + (i & 0b1) + ((i >> 2) & 0b1) * 4;
+          const unsigned row = row_causal + ((i >> 1) & 0b1) * 2;
+
+          const int global_m = start_row + tile_m + row;
+          const int global_n = start_col + tile_n + col;
+          const int global_q_pos = global_m + causal_q_offset;
+
+          const bool is_valid = (global_m < start_row + valid_q_rows) &&
+                                (global_n < start_col + valid_k_rows);
+          bool is_causal_valid = true;
+          if constexpr (IS_CAUSAL) {
+            is_causal_valid = global_n <= global_q_pos;
+          }
+          bool is_window_valid = true;
+          if (window_size_left >= 0) {
+            is_window_valid =
+                is_window_valid && global_n >= global_q_pos - window_size_left;
+          }
+          if (window_size_right >= 0) {
+            is_window_valid =
+                is_window_valid && global_n <= global_q_pos + window_size_right;
+          }
+
+          acc_frag.x[i] = (is_valid && is_causal_valid && is_window_valid)
+                              ? acc_frag.x[i] * softmax_scale
+                              : NEG_INF;
+        }
+
+        store_matrix_sync(sS + tile_m * S_STRIDE + tile_n, acc_frag, S_STRIDE,
+                          mem_row_major);
+      }
+      __syncthreads();
+    }
+
+    uint4* sV_vec = reinterpret_cast<uint4*>(sV);
+    const int64_t v_row_stride_uint4 = v_row_stride / PER_UINT4;
+    if constexpr (!LOW_SMEM) {
+      if constexpr (KV_DTYPE == flash_v100::KV_CACHE_DTYPE_FP16) {
+        const __half* V_cache_h = reinterpret_cast<const __half*>(V_cache);
+        const uint4* v_page0_vec = reinterpret_cast<const uint4*>(
+            V_cache_h + (int64_t)physical_block_idx0 * v_block_stride +
+            (int64_t)page_offset * v_token_stride +
+            (int64_t)kv_head_id * v_head_stride);
+        const uint4* v_page1_vec =
+            two_page_tile && second_page_rows > 0
+                ? reinterpret_cast<const uint4*>(
+                      V_cache_h +
+                      (int64_t)physical_block_idx1 * v_block_stride +
+                      (int64_t)kv_head_id * v_head_stride)
+                : nullptr;
+
+#pragma unroll 2
+        for (int idx = tid; idx < (valid_k_rows * d_stride_uint4);
+             idx += THREADS_PER_BLOCK) {
+          const int row = idx / d_stride_uint4;
+          const int vec_col = idx % d_stride_uint4;
+
+          uint4 v_val = make_uint4(0, 0, 0, 0);
+          if (row < valid_k_rows && vec_col < d_stride_uint4) {
+            if (four_page_contiguous_tile) {
+              v_val = __ldg(&v_page0_vec[row * v_row_stride_uint4 + vec_col]);
+            } else if (single_page_tile) {
+              v_val = __ldg(&v_page0_vec[row * v_row_stride_uint4 + vec_col]);
+            } else if (two_page_tile) {
+              if (row < first_page_rows) {
+                v_val = __ldg(&v_page0_vec[row * v_row_stride_uint4 + vec_col]);
+              } else {
+                const int row_page1 = row - first_page_rows;
+                v_val = __ldg(
+                    &v_page1_vec[row_page1 * v_row_stride_uint4 + vec_col]);
+              }
+            } else {
+              const uint4* v_vec = reinterpret_cast<const uint4*>(V_cache_h);
+              const int global_token_idx = start_col + row;
+              const int virtual_block_idx = global_token_idx / page_block_size;
+              const int block_offset = global_token_idx % page_block_size;
+              const int physical_block_idx_slow =
+                  __ldg(&block_table_seq[virtual_block_idx]);
+              const int64_t physical_offset_halves =
+                  (int64_t)physical_block_idx_slow * v_block_stride +
+                  (int64_t)block_offset * v_token_stride +
+                  (int64_t)kv_head_id * v_head_stride;
+              const int64_t physical_offset_uint4 =
+                  (physical_offset_halves / PER_UINT4) + vec_col;
+              v_val = __ldg(&v_vec[physical_offset_uint4]);
+            }
+          }
+          sV_vec[row * kv_stride_uint4 + vec_col] = v_val;
+        }
+      } else {
+        for (int idx = tid; idx < valid_k_rows * D; idx += THREADS_PER_BLOCK) {
+          const int row = idx / D;
+          const int col = idx % D;
+          const int global_token_idx = start_col + row;
+          const int virtual_block_idx = global_token_idx / page_block_size;
+          const int block_offset = global_token_idx % page_block_size;
+          const int physical_block_idx_slow =
+              __ldg(&block_table_seq[virtual_block_idx]);
+          const int64_t physical_offset =
+              (int64_t)physical_block_idx_slow * v_block_stride +
+              (int64_t)block_offset * v_token_stride +
+              (int64_t)kv_head_id * v_head_stride + col;
+          sV[row * KV_STRIDE + col] = flash_v100::load_kv_cache_half<KV_DTYPE>(
+              V_cache, physical_offset, v_scale);
+        }
+      }
+      __syncthreads();
+    }
+
+    const int num_tiles_m_pv = (BLOCK_M + WMMA_M - 1) / WMMA_M;
+    const int num_tiles_n_pv = (D + WMMA_N - 1) / WMMA_N;
+    const int total_tiles_pv = num_tiles_m_pv * num_tiles_n_pv;
+    const int tiles_per_warp_pv =
+        (total_tiles_pv + WARPS_PER_BLOCK - 1) / WARPS_PER_BLOCK;
+    const int softmax_sub_tile = (D == 256) ? P_SUB_TILE : p_tile_capacity;
+
+    for (int sub_start = 0; sub_start < valid_k_rows;
+         sub_start += softmax_sub_tile) {
+      const int sub_valid_k_rows =
+          min(softmax_sub_tile, valid_k_rows - sub_start);
+
+      if (tid < valid_q_rows * THREADS_PER_ROW) {
+        const int row = tid / THREADS_PER_ROW;
+        const int thread_in_row = tid % THREADS_PER_ROW;
+        const unsigned mask =
+            (valid_q_rows == BLOCK_M) ? 0xFFFFFFFFU : __activemask();
+        const int row_leader = __ffs(mask) - 1;
+
+        float* sS_row_f = sS + row * S_STRIDE + sub_start;
+        __half* sP_row_h = sP + row * p_stride;
+
+        const int vec_cols = sub_valid_k_rows >> 2;
+        const int vecs_per_thread =
+            (vec_cols + THREADS_PER_ROW - 1) / THREADS_PER_ROW;
+        const int tail_start = vec_cols << 2;
+
+        float thread_max = NEG_INF;
+        float4* sS_vec4 = reinterpret_cast<float4*>(sS_row_f);
+
+#pragma unroll 4
+        for (int j = 0; j < vecs_per_thread; ++j) {
+          int vc = thread_in_row + j * THREADS_PER_ROW;
+          if (vc < vec_cols) {
+            float4 v4 = sS_vec4[vc];
+            thread_max =
+                fmaxf(thread_max, fmaxf(fmaxf(v4.x, v4.y), fmaxf(v4.z, v4.w)));
+          }
+        }
+
+#pragma unroll
+        for (int c = tail_start + thread_in_row; c < sub_valid_k_rows;
+             c += THREADS_PER_ROW) {
+          thread_max = fmaxf(thread_max, sS_row_f[c]);
+        }
+
+#pragma unroll
+        for (int o = THREADS_PER_ROW / 2; o > 0; o >>= 1) {
+          thread_max = fmaxf(thread_max, __shfl_down_sync(mask, thread_max, o,
+                                                          THREADS_PER_ROW));
+        }
+
+        const float row_max =
+            __shfl_sync(mask, thread_max, row_leader, THREADS_PER_ROW);
+        const float old_max = sRowMax[row];
+        const float new_max = fmaxf(old_max, row_max);
+        const float exp_diff = __expf(old_max - new_max);
+
+        float thread_sum = 0.0f;
+        __half2 half_buffer[20];
+        int vc_base = thread_in_row;
+        int h2_idx = 0;
+        int tail_col = -1;
+        __half tail_value = __float2half(0.f);
+        __half2* sP_half2 = reinterpret_cast<__half2*>(sP_row_h);
+
+#pragma unroll 4
+        for (int j = 0; j < vecs_per_thread; ++j, vc_base += THREADS_PER_ROW) {
+          if (vc_base < vec_cols) {
+            float4 v4 = sS_vec4[vc_base];
+
+            float e0 = __expf(fmaxf(v4.x - new_max, -80.0f));
+            float e1 = __expf(fmaxf(v4.y - new_max, -80.0f));
+            float e2 = __expf(fmaxf(v4.z - new_max, -80.0f));
+            float e3 = __expf(fmaxf(v4.w - new_max, -80.0f));
+
+            thread_sum += (e0 + e1) + (e2 + e3);
+
+            const __half2 p01 = __float22half2_rn(make_float2(e0, e1));
+            const __half2 p23 = __float22half2_rn(make_float2(e2, e3));
+            if constexpr (D256_SW_PIPELINE_PV) {
+              // D256 owns a separate probability buffer, so the
+              // values can leave registers before row reduction.
+              const int base_offset = vc_base * 2;
+              sP_half2[base_offset] = p01;
+              sP_half2[base_offset + 1] = p23;
+            } else {
+              half_buffer[h2_idx++] = p01;
+              half_buffer[h2_idx++] = p23;
+            }
+          }
+        }
+
+#pragma unroll 4
+        for (int c = tail_start + thread_in_row; c < sub_valid_k_rows;
+             c += THREADS_PER_ROW) {
+          float v = sS_row_f[c];
+          float e = __expf(fmaxf(v - new_max, -80.0f));
+          thread_sum += e;
+          if constexpr (D256_SW_PIPELINE_PV) {
+            sP_row_h[c] = __float2half_rn(e);
+          } else {
+            tail_col = c;
+            tail_value = __float2half_rn(e);
+          }
+        }
+
+#pragma unroll
+        for (int o = THREADS_PER_ROW / 2; o > 0; o >>= 1) {
+          thread_sum += __shfl_down_sync(mask, thread_sum, o, THREADS_PER_ROW);
+        }
+
+        float row_sum =
+            __shfl_sync(mask, thread_sum, row_leader, THREADS_PER_ROW);
+
+        if (thread_in_row == 0) {
+          sRowSum[row] = exp_diff * sRowSum[row] + row_sum;
+          sRowMax[row] = new_max;
+        }
+
+        if constexpr (!D256_SW_PIPELINE_PV) {
+          h2_idx = 0;
+          vc_base = thread_in_row;
+#pragma unroll 4
+          for (int j = 0; j < vecs_per_thread;
+               ++j, vc_base += THREADS_PER_ROW) {
+            if (vc_base < vec_cols) {
+              int base_offset = vc_base * 2;
+              sP_half2[base_offset] = half_buffer[h2_idx++];
+              sP_half2[base_offset + 1] = half_buffer[h2_idx++];
+            }
+          }
+
+          if (tail_col >= 0) {
+            sP_row_h[tail_col] = tail_value;
+          }
+        }
+
+#pragma unroll 4
+        for (int c = tail_start + thread_in_row; c < p_tile_capacity;
+             c += THREADS_PER_ROW) {
+          if (c >= sub_valid_k_rows) {
+            sP_row_h[c] = __float2half(0.f);
+          }
+        }
+
+        if (block_n > 0 || sub_start > 0) {
+          float* sO_row = sO + row * O_STRIDE;
+          float4* sO_vec = reinterpret_cast<float4*>(sO_row);
+          const int o_vec_count = D / 4;
+          float scale = exp_diff;
+
+#pragma unroll 4
+          for (int ov = thread_in_row; ov < o_vec_count;
+               ov += THREADS_PER_ROW) {
+            float4 v = sO_vec[ov];
+            v.x *= scale;
+            v.y *= scale;
+            v.z *= scale;
+            v.w *= scale;
+            sO_vec[ov] = v;
+          }
+        }
+      }
+      __syncthreads();
+
+      const int num_tiles_k_pv = (p_tile_capacity + WMMA_K - 1) / WMMA_K;
+
+      for (int tile_idx = 0; tile_idx < tiles_per_warp_pv; ++tile_idx) {
+        const int global_tile_idx = warp_id * tiles_per_warp_pv + tile_idx;
+        if (global_tile_idx >= total_tiles_pv) break;
+
+        const int tile_m_idx = global_tile_idx / num_tiles_n_pv;
+        const int tile_d_idx = global_tile_idx % num_tiles_n_pv;
+
+        const int tile_m = tile_m_idx * WMMA_M;
+        const int tile_d = tile_d_idx * WMMA_N;
+
+        if (tile_m >= valid_q_rows) continue;
+
+        fragment<matrix_a, WMMA_M, WMMA_N, WMMA_K, half, row_major> a_frag;
+        fragment<matrix_b, WMMA_M, WMMA_N, WMMA_K, half, row_major> b_frag;
+        fragment<accumulator, WMMA_M, WMMA_N, WMMA_K, float> acc_frag;
+
+        load_matrix_sync(acc_frag, sO + tile_m * O_STRIDE + tile_d, O_STRIDE,
+                         mem_row_major);
+
+#pragma unroll
+        for (int tile_k = 0; tile_k < num_tiles_k_pv; ++tile_k) {
+          const int k_offset = tile_k * WMMA_K;
+          if (k_offset >= sub_valid_k_rows) break;
+
+          load_matrix_sync(a_frag, sP + tile_m * p_stride + k_offset, p_stride);
+          if constexpr (LOW_SMEM) {
             const __half* V_cache_h = reinterpret_cast<const __half*>(V_cache);
-            const uint4* v_page0_vec = reinterpret_cast<const uint4*>(
-                V_cache_h + (int64_t)physical_block_idx0 * v_block_stride
-                + (int64_t)page_offset * v_token_stride
-                + (int64_t)kv_head_id * v_head_stride);
-            const uint4* v_page1_vec =
-                two_page_tile && second_page_rows > 0
-                    ? reinterpret_cast<const uint4*>(
-                          V_cache_h + (int64_t)physical_block_idx1 * v_block_stride
-                          + (int64_t)kv_head_id * v_head_stride)
-                    : nullptr;
-
-            #pragma unroll 2
-            for (int idx = tid; idx < (valid_k_rows * d_stride_uint4);
-                 idx += THREADS_PER_BLOCK) {
-                const int row = idx / d_stride_uint4;
-                const int vec_col = idx % d_stride_uint4;
-
-                uint4 v_val = make_uint4(0, 0, 0, 0);
-                if (row < valid_k_rows && vec_col < d_stride_uint4) {
-                    if (four_page_contiguous_tile) {
-                        v_val = __ldg(
-                            &v_page0_vec[row * v_row_stride_uint4 + vec_col]);
-                    } else if (single_page_tile) {
-                        v_val = __ldg(&v_page0_vec[row * v_row_stride_uint4 + vec_col]);
-                    } else if (two_page_tile) {
-                        if (row < first_page_rows) {
-                            v_val = __ldg(
-                                &v_page0_vec[row * v_row_stride_uint4 + vec_col]);
-                        } else {
-                            const int row_page1 = row - first_page_rows;
-                            v_val = __ldg(
-                                &v_page1_vec[row_page1 * v_row_stride_uint4 + vec_col]);
-                        }
-                    } else {
-                        const uint4* v_vec = reinterpret_cast<const uint4*>(V_cache_h);
-                        const int global_token_idx = start_col + row;
-                        const int virtual_block_idx =
-                            global_token_idx / page_block_size;
-                        const int block_offset = global_token_idx % page_block_size;
-                        const int physical_block_idx_slow =
-                            __ldg(&block_table_seq[virtual_block_idx]);
-                        const int64_t physical_offset_halfs =
-                            (int64_t)physical_block_idx_slow * v_block_stride
-                            + (int64_t)block_offset * v_token_stride
-                            + (int64_t)kv_head_id * v_head_stride;
-                        const int64_t physical_offset_uint4 =
-                            (physical_offset_halfs / PER_UINT4) + vec_col;
-                        v_val = __ldg(&v_vec[physical_offset_uint4]);
-                    }
-                }
-                sV_vec[row * kv_stride_uint4 + vec_col] = v_val;
+            const int token_offset = sub_start + k_offset;
+            const int page_slot = token_offset >> 4;
+            const int block_offset = sPageOffset[page_slot];
+            const int physical_block_idx_direct = sPageIdx[page_slot];
+            const __half* v_tile_ptr;
+            if constexpr (LOW_SMEM_CONTIG_FAST) {
+              v_tile_ptr =
+                  low_smem_contiguous_page_tile
+                      ? V_cache_h + (int64_t)sPageIdx[0] * v_block_stride +
+                            (int64_t)(sPageOffset[0] + token_offset) *
+                                v_token_stride +
+                            (int64_t)kv_head_id * v_head_stride + tile_d
+                      : V_cache_h +
+                            (int64_t)physical_block_idx_direct *
+                                v_block_stride +
+                            (int64_t)block_offset * v_token_stride +
+                            (int64_t)kv_head_id * v_head_stride + tile_d;
+            } else {
+              v_tile_ptr = V_cache_h +
+                           (int64_t)physical_block_idx_direct * v_block_stride +
+                           (int64_t)block_offset * v_token_stride +
+                           (int64_t)kv_head_id * v_head_stride + tile_d;
             }
-        } else {
-            for (int idx = tid; idx < valid_k_rows * D; idx += THREADS_PER_BLOCK) {
-                const int row = idx / D;
-                const int col = idx % D;
-                const int global_token_idx = start_col + row;
-                const int virtual_block_idx = global_token_idx / page_block_size;
-                const int block_offset = global_token_idx % page_block_size;
-                const int physical_block_idx_slow =
-                    __ldg(&block_table_seq[virtual_block_idx]);
-                const int64_t physical_offset =
-                    (int64_t)physical_block_idx_slow * v_block_stride
-                    + (int64_t)block_offset * v_token_stride
-                    + (int64_t)kv_head_id * v_head_stride + col;
-                sV[row * KV_STRIDE + col] =
-                    flash_v100::load_kv_cache_half<KV_DTYPE>(
-                        V_cache, physical_offset, v_scale);
-            }
+            load_matrix_sync(b_frag, v_tile_ptr, v_token_stride);
+          } else {
+            load_matrix_sync(b_frag,
+                             sV + (sub_start + k_offset) * KV_STRIDE + tile_d,
+                             KV_STRIDE);
+          }
+          mma_sync(acc_frag, a_frag, b_frag, acc_frag);
         }
-        __syncthreads();
-        }
-
-        const int num_tiles_m_pv = (BLOCK_M + WMMA_M - 1) / WMMA_M;
-        const int num_tiles_n_pv = (D + WMMA_N - 1) / WMMA_N;
-        const int total_tiles_pv = num_tiles_m_pv * num_tiles_n_pv;
-        const int tiles_per_warp_pv =
-            (total_tiles_pv + WARPS_PER_BLOCK - 1) / WARPS_PER_BLOCK;
-        const int softmax_sub_tile = (D == 256) ? P_SUB_TILE : p_tile_capacity;
-
-        for (int sub_start = 0; sub_start < valid_k_rows;
-             sub_start += softmax_sub_tile) {
-            const int sub_valid_k_rows = min(softmax_sub_tile,
-                                             valid_k_rows - sub_start);
-
-            if (tid < valid_q_rows * THREADS_PER_ROW) {
-                const int row = tid / THREADS_PER_ROW;
-                const int thread_in_row = tid % THREADS_PER_ROW;
-                const unsigned mask = (valid_q_rows == BLOCK_M)
-                                          ? 0xFFFFFFFFU
-                                          : __activemask();
-                const int row_leader = __ffs(mask) - 1;
-
-                float*  sS_row_f = sS + row * S_STRIDE + sub_start;
-                __half* sP_row_h = sP + row * p_stride;
-
-                const int vec_cols = sub_valid_k_rows >> 2;
-                const int vecs_per_thread =
-                    (vec_cols + THREADS_PER_ROW - 1) / THREADS_PER_ROW;
-                const int tail_start = vec_cols << 2;
-
-                float thread_max = NEG_INF;
-                float4* sS_vec4 = reinterpret_cast<float4*>(sS_row_f);
-
-                #pragma unroll 4
-                for (int j = 0; j < vecs_per_thread; ++j) {
-                    int vc = thread_in_row + j * THREADS_PER_ROW;
-                    if (vc < vec_cols) {
-                        float4 v4 = sS_vec4[vc];
-                        thread_max = fmaxf(
-                            thread_max,
-                            fmaxf(fmaxf(v4.x, v4.y), fmaxf(v4.z, v4.w)));
-                    }
-                }
-
-                #pragma unroll
-                for (int c = tail_start + thread_in_row; c < sub_valid_k_rows;
-                     c += THREADS_PER_ROW) {
-                    thread_max = fmaxf(thread_max, sS_row_f[c]);
-                }
-
-                #pragma unroll
-                for (int o = THREADS_PER_ROW / 2; o > 0; o >>= 1) {
-                    thread_max = fmaxf(
-                        thread_max,
-                        __shfl_down_sync(mask, thread_max, o, THREADS_PER_ROW));
-                }
-
-                const float row_max =
-                    __shfl_sync(mask, thread_max, row_leader, THREADS_PER_ROW);
-                const float old_max = sRowMax[row];
-                const float new_max = fmaxf(old_max, row_max);
-                const float exp_diff = __expf(old_max - new_max);
-
-                float thread_sum = 0.0f;
-                __half2 half_buffer[20];
-                int vc_base = thread_in_row;
-                int h2_idx = 0;
-                int tail_col = -1;
-                __half tail_value = __float2half(0.f);
-                __half2* sP_half2 = reinterpret_cast<__half2*>(sP_row_h);
-
-                #pragma unroll 4
-                for (int j = 0; j < vecs_per_thread; ++j,
-                         vc_base += THREADS_PER_ROW) {
-                    if (vc_base < vec_cols) {
-                        float4 v4 = sS_vec4[vc_base];
-
-                        float e0 = __expf(fmaxf(v4.x - new_max, -80.0f));
-                        float e1 = __expf(fmaxf(v4.y - new_max, -80.0f));
-                        float e2 = __expf(fmaxf(v4.z - new_max, -80.0f));
-                        float e3 = __expf(fmaxf(v4.w - new_max, -80.0f));
-
-                        thread_sum += (e0 + e1) + (e2 + e3);
-
-                        const __half2 p01 =
-                            __float22half2_rn(make_float2(e0, e1));
-                        const __half2 p23 =
-                            __float22half2_rn(make_float2(e2, e3));
-                        if constexpr (D256_SW_PIPELINE_PV) {
-                            // D256 owns a separate probability buffer, so the
-                            // values can leave registers before row reduction.
-                            const int base_offset = vc_base * 2;
-                            sP_half2[base_offset] = p01;
-                            sP_half2[base_offset + 1] = p23;
-                        } else {
-                            half_buffer[h2_idx++] = p01;
-                            half_buffer[h2_idx++] = p23;
-                        }
-                    }
-                }
-
-                #pragma unroll 4
-                for (int c = tail_start + thread_in_row; c < sub_valid_k_rows;
-                     c += THREADS_PER_ROW) {
-                    float v = sS_row_f[c];
-                    float e = __expf(fmaxf(v - new_max, -80.0f));
-                    thread_sum += e;
-                    if constexpr (D256_SW_PIPELINE_PV) {
-                        sP_row_h[c] = __float2half_rn(e);
-                    } else {
-                        tail_col = c;
-                        tail_value = __float2half_rn(e);
-                    }
-                }
-
-                #pragma unroll
-                for (int o = THREADS_PER_ROW / 2; o > 0; o >>= 1) {
-                    thread_sum +=
-                        __shfl_down_sync(mask, thread_sum, o, THREADS_PER_ROW);
-                }
-
-                float row_sum =
-                    __shfl_sync(mask, thread_sum, row_leader, THREADS_PER_ROW);
-
-                if (thread_in_row == 0) {
-                    sRowSum[row] = exp_diff * sRowSum[row] + row_sum;
-                    sRowMax[row] = new_max;
-                }
-
-                if constexpr (!D256_SW_PIPELINE_PV) {
-                    h2_idx = 0;
-                    vc_base = thread_in_row;
-                    #pragma unroll 4
-                    for (int j = 0; j < vecs_per_thread; ++j,
-                             vc_base += THREADS_PER_ROW) {
-                        if (vc_base < vec_cols) {
-                            int base_offset = vc_base * 2;
-                            sP_half2[base_offset] = half_buffer[h2_idx++];
-                            sP_half2[base_offset + 1] = half_buffer[h2_idx++];
-                        }
-                    }
-
-                    if (tail_col >= 0) {
-                        sP_row_h[tail_col] = tail_value;
-                    }
-                }
-
-                #pragma unroll 4
-                for (int c = tail_start + thread_in_row; c < p_tile_capacity;
-                     c += THREADS_PER_ROW) {
-                    if (c >= sub_valid_k_rows) {
-                        sP_row_h[c] = __float2half(0.f);
-                    }
-                }
-
-                if (block_n > 0 || sub_start > 0) {
-                    float*  sO_row = sO + row * O_STRIDE;
-                    float4* sO_vec = reinterpret_cast<float4*>(sO_row);
-                    const int o_vec_count = D / 4;
-                    float scale = exp_diff;
-
-                    #pragma unroll 4
-                    for (int ov = thread_in_row; ov < o_vec_count;
-                         ov += THREADS_PER_ROW) {
-                        float4 v = sO_vec[ov];
-                        v.x *= scale;
-                        v.y *= scale;
-                        v.z *= scale;
-                        v.w *= scale;
-                        sO_vec[ov] = v;
-                    }
-                }
-            }
-            __syncthreads();
-
-            const int num_tiles_k_pv =
-                (p_tile_capacity + WMMA_K - 1) / WMMA_K;
-
-            for (int tile_idx = 0; tile_idx < tiles_per_warp_pv; ++tile_idx) {
-                const int global_tile_idx = warp_id * tiles_per_warp_pv + tile_idx;
-                if (global_tile_idx >= total_tiles_pv) break;
-
-                const int tile_m_idx = global_tile_idx / num_tiles_n_pv;
-                const int tile_d_idx = global_tile_idx % num_tiles_n_pv;
-
-                const int tile_m = tile_m_idx * WMMA_M;
-                const int tile_d = tile_d_idx * WMMA_N;
-
-                if (tile_m >= valid_q_rows) continue;
-
-                fragment<matrix_a, WMMA_M, WMMA_N, WMMA_K, half, row_major> a_frag;
-                fragment<matrix_b, WMMA_M, WMMA_N, WMMA_K, half, row_major> b_frag;
-                fragment<accumulator, WMMA_M, WMMA_N, WMMA_K, float> acc_frag;
-
-                load_matrix_sync(acc_frag, sO + tile_m * O_STRIDE + tile_d,
-                                 O_STRIDE, mem_row_major);
-
-                #pragma unroll
-                for (int tile_k = 0; tile_k < num_tiles_k_pv; ++tile_k) {
-                    const int k_offset = tile_k * WMMA_K;
-                    if (k_offset >= sub_valid_k_rows) break;
-
-                    load_matrix_sync(a_frag,
-                                     sP + tile_m * p_stride + k_offset,
-                                     p_stride);
-                    if constexpr (LOW_SMEM) {
-                        const __half* V_cache_h =
-                            reinterpret_cast<const __half*>(V_cache);
-                        const int token_offset = sub_start + k_offset;
-                        const int page_slot = token_offset >> 4;
-                        const int block_offset = sPageOffset[page_slot];
-                        const int physical_block_idx_direct =
-                            sPageIdx[page_slot];
-                        const __half* v_tile_ptr;
-                        if constexpr (LOW_SMEM_CONTIG_FAST) {
-                            v_tile_ptr =
-                                low_smem_contiguous_page_tile
-                                    ? V_cache_h
-                                          + (int64_t)sPageIdx[0] * v_block_stride
-                                          + (int64_t)(sPageOffset[0] + token_offset)
-                                                * v_token_stride
-                                          + (int64_t)kv_head_id * v_head_stride
-                                          + tile_d
-                                    : V_cache_h
-                                          + (int64_t)physical_block_idx_direct
-                                                * v_block_stride
-                                          + (int64_t)block_offset * v_token_stride
-                                          + (int64_t)kv_head_id * v_head_stride
-                                          + tile_d;
-                        } else {
-                            v_tile_ptr =
-                                V_cache_h
-                                + (int64_t)physical_block_idx_direct
-                                      * v_block_stride
-                                + (int64_t)block_offset * v_token_stride
-                                + (int64_t)kv_head_id * v_head_stride + tile_d;
-                        }
-                        load_matrix_sync(b_frag, v_tile_ptr, v_token_stride);
-                    } else {
-                        load_matrix_sync(
-                            b_frag,
-                            sV + (sub_start + k_offset) * KV_STRIDE + tile_d,
-                            KV_STRIDE);
-                    }
-                    mma_sync(acc_frag, a_frag, b_frag, acc_frag);
-                }
-                store_matrix_sync(sO + tile_m * O_STRIDE + tile_d, acc_frag,
-                                  O_STRIDE, mem_row_major);
-            }
-            __syncthreads();
-        }
-
+        store_matrix_sync(sO + tile_m * O_STRIDE + tile_d, acc_frag, O_STRIDE,
+                          mem_row_major);
+      }
+      __syncthreads();
     }
+  }
 
-    if constexpr (SPLIT_KV) {
-        const int partition_id = blockIdx.y;
-        const int num_partitions = gridDim.y;
-        const int64_t row_base =
-            ((int64_t)batch_head_id * num_partitions + partition_id) * M
-            + start_row;
+  if constexpr (SPLIT_KV) {
+    const int partition_id = blockIdx.y;
+    const int num_partitions = gridDim.y;
+    const int64_t row_base =
+        ((int64_t)batch_head_id * num_partitions + partition_id) * M +
+        start_row;
 
-        for (int i = tid; i < valid_q_rows * D; i += THREADS_PER_BLOCK) {
-            const int row = i / D;
-            const int col = i - row * D;
-            split_tmp_out[(row_base + row) * D + col] =
-                sO[row * O_STRIDE + col];
-        }
-
-        if (tid < valid_q_rows) {
-            split_tmp_row_max[row_base + tid] = sRowMax[tid];
-            split_tmp_row_sum[row_base + tid] = sRowSum[tid];
-        }
-        return;
-    }
-
-    const int total_fp16_x4 = (valid_q_rows * D) / 4;
-
-    for (int i = tid; i < total_fp16_x4; i += THREADS_PER_BLOCK) {
-        const int row = i / (D / 4);
-        const int col = (i % (D / 4)) * 4;
-
-        const float sum_clamped = fmaxf(sRowSum[row], 1e-24f);
-        const float inv_sum = 1.0f / sum_clamped;
-        const float* sO_row = sO + row * O_STRIDE;
-
-        const __half h0 = __float2half_rn(sO_row[col + 0] * inv_sum);
-        const __half h1 = __float2half_rn(sO_row[col + 1] * inv_sum);
-        const __half h2 = __float2half_rn(sO_row[col + 2] * inv_sum);
-        const __half h3 = __float2half_rn(sO_row[col + 3] * inv_sum);
-
-        asm volatile(
-            "st.global.v4.u16 [%0], {%1, %2, %3, %4};"
-            :
-            : "l"(out_ptr + row * D + col),
-              "h"(__half_as_ushort(h0)),
-              "h"(__half_as_ushort(h1)),
-              "h"(__half_as_ushort(h2)),
-              "h"(__half_as_ushort(h3))
-            : "memory"
-        );
+    for (int i = tid; i < valid_q_rows * D; i += THREADS_PER_BLOCK) {
+      const int row = i / D;
+      const int col = i - row * D;
+      split_tmp_out[(row_base + row) * D + col] = sO[row * O_STRIDE + col];
     }
 
     if (tid < valid_q_rows) {
-        const float sum = fmaxf(sRowSum[tid], 1e-24f);
-        softmax_lse_ptr[tid] = sRowMax[tid] + logf(sum);
+      split_tmp_row_max[row_base + tid] = sRowMax[tid];
+      split_tmp_row_sum[row_base + tid] = sRowSum[tid];
     }
+    return;
+  }
+
+  const int total_fp16_x4 = (valid_q_rows * D) / 4;
+
+  for (int i = tid; i < total_fp16_x4; i += THREADS_PER_BLOCK) {
+    const int row = i / (D / 4);
+    const int col = (i % (D / 4)) * 4;
+
+    const float sum_clamped = fmaxf(sRowSum[row], 1e-24f);
+    const float inv_sum = 1.0f / sum_clamped;
+    const float* sO_row = sO + row * O_STRIDE;
+
+    const __half h0 = __float2half_rn(sO_row[col + 0] * inv_sum);
+    const __half h1 = __float2half_rn(sO_row[col + 1] * inv_sum);
+    const __half h2 = __float2half_rn(sO_row[col + 2] * inv_sum);
+    const __half h3 = __float2half_rn(sO_row[col + 3] * inv_sum);
+
+    asm volatile("st.global.v4.u16 [%0], {%1, %2, %3, %4};"
+                 :
+                 : "l"(out_ptr + row * D + col), "h"(__half_as_ushort(h0)),
+                   "h"(__half_as_ushort(h1)), "h"(__half_as_ushort(h2)),
+                   "h"(__half_as_ushort(h3))
+                 : "memory");
+  }
+
+  if (tid < valid_q_rows) {
+    const float sum = fmaxf(sRowSum[tid], 1e-24f);
+    softmax_lse_ptr[tid] = sRowMax[tid] + logf(sum);
+  }
 }
 
 inline bool env_flag_enabled(const char* name) {
-    const char* raw = std::getenv(name);
-    return raw != nullptr && std::strcmp(raw, "0") != 0;
+  const char* raw = std::getenv(name);
+  return raw != nullptr && std::strcmp(raw, "0") != 0;
 }
 
 inline bool env_flag_default_enabled(const char* name) {
-    const char* raw = std::getenv(name);
-    return raw == nullptr || std::strcmp(raw, "0") != 0;
+  const char* raw = std::getenv(name);
+  return raw == nullptr || std::strcmp(raw, "0") != 0;
 }
 
-template<int D, int KV_DTYPE, bool LOW_SMEM, bool LOW_SMEM_CONTIG_FAST,
-         bool LOW_SMEM_SCALAR_QK, bool LOW_SMEM_BM32,
-         bool D256_OUTPUT_STRIDE_268 = false,
-         bool D256_SW_PIPELINE_QK = false,
-         bool D256_SW_PIPELINE_PV = false>
+template <int D, int KV_DTYPE, bool LOW_SMEM, bool LOW_SMEM_CONTIG_FAST,
+          bool LOW_SMEM_SCALAR_QK, bool LOW_SMEM_BM32,
+          bool D256_OUTPUT_STRIDE_268 = false, bool D256_SW_PIPELINE_QK = false,
+          bool D256_SW_PIPELINE_PV = false>
 void launcher_flash_attention_forward_paged_impl(
-    const torch::Tensor& Q,
-    const torch::Tensor& K_cache,
-    const torch::Tensor& V_cache,
-    torch::Tensor& Out,
-    torch::Tensor& softmax_lse,
-    const torch::Tensor& block_table,
-    const torch::Tensor& seq_lens,
-    const int* bfla_mask_ptr,
-    int bfla_mask_block_n,
-    int64_t bfla_mask_stride_b,
-    int64_t bfla_mask_stride_h,
-    int64_t bfla_mask_stride_q,
-    int64_t bfla_mask_stride_k,
-    float softmax_scale,
-    bool is_causal,
-    float k_scale,
-    float v_scale,
-    int window_size_left,
-    int window_size_right,
-    cudaStream_t stream
-) {
-    using Config = KernelConfig<D, LOW_SMEM, LOW_SMEM_SCALAR_QK,
-                                LOW_SMEM_BM32, D256_OUTPUT_STRIDE_268,
-                                D256_SW_PIPELINE_QK,
-                                D256_SW_PIPELINE_PV>;
+    const torch::Tensor& Q, const torch::Tensor& K_cache,
+    const torch::Tensor& V_cache, torch::Tensor& Out,
+    torch::Tensor& softmax_lse, const torch::Tensor& block_table,
+    const torch::Tensor& seq_lens, const int* bfla_mask_ptr,
+    int bfla_mask_block_n, int64_t bfla_mask_stride_b,
+    int64_t bfla_mask_stride_h, int64_t bfla_mask_stride_q,
+    int64_t bfla_mask_stride_k, float softmax_scale, bool is_causal,
+    float k_scale, float v_scale, int window_size_left, int window_size_right,
+    cudaStream_t stream) {
+  using Config = KernelConfig<D, LOW_SMEM, LOW_SMEM_SCALAR_QK, LOW_SMEM_BM32,
+                              D256_OUTPUT_STRIDE_268, D256_SW_PIPELINE_QK,
+                              D256_SW_PIPELINE_PV>;
 
-    const int B = Q.size(0);
-    const int H = Q.size(1);
-    const int M = Q.size(2);
-    const int page_block_size = K_cache.size(1);
-    const int num_kv_heads = K_cache.size(2);
-    const int max_num_blocks = block_table.size(1);
-    const int N = max_num_blocks * page_block_size;
-    const int64_t k_block_stride = K_cache.stride(0);
-    const int64_t k_token_stride = K_cache.stride(1);
-    const int64_t k_head_stride = K_cache.stride(2);
-    const int64_t v_block_stride = V_cache.stride(0);
-    const int64_t v_token_stride = V_cache.stride(1);
-    const int64_t v_head_stride = V_cache.stride(2);
+  const int B = Q.size(0);
+  const int H = Q.size(1);
+  const int M = Q.size(2);
+  const int page_block_size = K_cache.size(1);
+  const int num_kv_heads = K_cache.size(2);
+  const int max_num_blocks = block_table.size(1);
+  const int N = max_num_blocks * page_block_size;
+  const int64_t k_block_stride = K_cache.stride(0);
+  const int64_t k_token_stride = K_cache.stride(1);
+  const int64_t k_head_stride = K_cache.stride(2);
+  const int64_t v_block_stride = V_cache.stride(0);
+  const int64_t v_token_stride = V_cache.stride(1);
+  const int64_t v_head_stride = V_cache.stride(2);
 
-    const int grid_x = (M + Config::BLOCK_M - 1) / Config::BLOCK_M;
-    const dim3 grid(grid_x, 1, B * H);
-    const dim3 block(Config::THREADS_PER_BLOCK);
-    const size_t smem = Config::TOTAL_SMEM;
+  const int grid_x = (M + Config::BLOCK_M - 1) / Config::BLOCK_M;
+  const dim3 grid(grid_x, 1, B * H);
+  const dim3 block(Config::THREADS_PER_BLOCK);
+  const size_t smem = Config::TOTAL_SMEM;
 
-    TORCH_CHECK(smem <= MAX_SMEM_PER_SM, "Shared memory exceeds 96KB: ", smem,
-                " bytes");
+  TORCH_CHECK(smem <= MAX_SMEM_PER_SM, "Shared memory exceeds 96KB: ", smem,
+              " bytes");
 
-    auto kernel = is_causal
-                      ? (void*)flash_attention_forward_kernel_paged<
-                            D, LOW_SMEM, LOW_SMEM_CONTIG_FAST,
-                            LOW_SMEM_SCALAR_QK, LOW_SMEM_BM32, false, true,
-                            KV_DTYPE, D256_OUTPUT_STRIDE_268,
-                            D256_SW_PIPELINE_QK, D256_SW_PIPELINE_PV>
-                      : (void*)flash_attention_forward_kernel_paged<
-                            D, LOW_SMEM, LOW_SMEM_CONTIG_FAST,
-                            LOW_SMEM_SCALAR_QK, LOW_SMEM_BM32, false, false,
-                            KV_DTYPE, D256_OUTPUT_STRIDE_268,
-                            D256_SW_PIPELINE_QK, D256_SW_PIPELINE_PV>;
-    cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize,
-                         smem);
+  auto kernel =
+      is_causal
+          ? (void*)flash_attention_forward_kernel_paged<
+                D, LOW_SMEM, LOW_SMEM_CONTIG_FAST, LOW_SMEM_SCALAR_QK,
+                LOW_SMEM_BM32, false, true, KV_DTYPE, D256_OUTPUT_STRIDE_268,
+                D256_SW_PIPELINE_QK, D256_SW_PIPELINE_PV>
+          : (void*)flash_attention_forward_kernel_paged<
+                D, LOW_SMEM, LOW_SMEM_CONTIG_FAST, LOW_SMEM_SCALAR_QK,
+                LOW_SMEM_BM32, false, false, KV_DTYPE, D256_OUTPUT_STRIDE_268,
+                D256_SW_PIPELINE_QK, D256_SW_PIPELINE_PV>;
+  cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize,
+                       smem);
 
-    if (is_causal) {
-        flash_attention_forward_kernel_paged<
-            D, LOW_SMEM, LOW_SMEM_CONTIG_FAST, LOW_SMEM_SCALAR_QK,
-            LOW_SMEM_BM32, false, true, KV_DTYPE, D256_OUTPUT_STRIDE_268,
-            D256_SW_PIPELINE_QK, D256_SW_PIPELINE_PV>
-            <<<grid, block, smem, stream>>>(
-            reinterpret_cast<const __half*>(Q.data_ptr()),
-            K_cache.data_ptr(),
-            V_cache.data_ptr(),
-            reinterpret_cast<__half*>(Out.data_ptr()),
-            softmax_lse.data_ptr<float>(),
-            block_table.data_ptr<int>(),
-            seq_lens.data_ptr<int>(),
-            B,
-            H,
-            M,
-            N,
-            bfla_mask_ptr,
-            bfla_mask_block_n,
-            bfla_mask_stride_b,
-            bfla_mask_stride_h,
-            bfla_mask_stride_q,
-            bfla_mask_stride_k,
-            page_block_size,
-            num_kv_heads,
-            k_block_stride,
-            k_token_stride,
-            k_head_stride,
-            v_block_stride,
-            v_token_stride,
-            v_head_stride,
-            softmax_scale,
-            k_scale,
-            v_scale,
-            window_size_left,
-            window_size_right,
-            nullptr,
-            nullptr,
-            nullptr,
-            0
-        );
-    } else {
-        flash_attention_forward_kernel_paged<
-            D, LOW_SMEM, LOW_SMEM_CONTIG_FAST, LOW_SMEM_SCALAR_QK,
-            LOW_SMEM_BM32, false, false, KV_DTYPE, D256_OUTPUT_STRIDE_268,
-            D256_SW_PIPELINE_QK, D256_SW_PIPELINE_PV>
-            <<<grid, block, smem, stream>>>(
-            reinterpret_cast<const __half*>(Q.data_ptr()),
-            K_cache.data_ptr(),
-            V_cache.data_ptr(),
-            reinterpret_cast<__half*>(Out.data_ptr()),
-            softmax_lse.data_ptr<float>(),
-            block_table.data_ptr<int>(),
-            seq_lens.data_ptr<int>(),
-            B,
-            H,
-            M,
-            N,
-            bfla_mask_ptr,
-            bfla_mask_block_n,
-            bfla_mask_stride_b,
-            bfla_mask_stride_h,
-            bfla_mask_stride_q,
-            bfla_mask_stride_k,
-            page_block_size,
-            num_kv_heads,
-            k_block_stride,
-            k_token_stride,
-            k_head_stride,
-            v_block_stride,
-            v_token_stride,
-            v_head_stride,
-            softmax_scale,
-            k_scale,
-            v_scale,
-            window_size_left,
-            window_size_right,
-            nullptr,
-            nullptr,
-            nullptr,
-            0
-        );
-    }
+  if (is_causal) {
+    flash_attention_forward_kernel_paged<
+        D, LOW_SMEM, LOW_SMEM_CONTIG_FAST, LOW_SMEM_SCALAR_QK, LOW_SMEM_BM32,
+        false, true, KV_DTYPE, D256_OUTPUT_STRIDE_268, D256_SW_PIPELINE_QK,
+        D256_SW_PIPELINE_PV><<<grid, block, smem, stream>>>(
+        reinterpret_cast<const __half*>(Q.data_ptr()), K_cache.data_ptr(),
+        V_cache.data_ptr(), reinterpret_cast<__half*>(Out.data_ptr()),
+        softmax_lse.data_ptr<float>(), block_table.data_ptr<int>(),
+        seq_lens.data_ptr<int>(), B, H, M, N, bfla_mask_ptr, bfla_mask_block_n,
+        bfla_mask_stride_b, bfla_mask_stride_h, bfla_mask_stride_q,
+        bfla_mask_stride_k, page_block_size, num_kv_heads, k_block_stride,
+        k_token_stride, k_head_stride, v_block_stride, v_token_stride,
+        v_head_stride, softmax_scale, k_scale, v_scale, window_size_left,
+        window_size_right, nullptr, nullptr, nullptr, 0);
+  } else {
+    flash_attention_forward_kernel_paged<
+        D, LOW_SMEM, LOW_SMEM_CONTIG_FAST, LOW_SMEM_SCALAR_QK, LOW_SMEM_BM32,
+        false, false, KV_DTYPE, D256_OUTPUT_STRIDE_268, D256_SW_PIPELINE_QK,
+        D256_SW_PIPELINE_PV><<<grid, block, smem, stream>>>(
+        reinterpret_cast<const __half*>(Q.data_ptr()), K_cache.data_ptr(),
+        V_cache.data_ptr(), reinterpret_cast<__half*>(Out.data_ptr()),
+        softmax_lse.data_ptr<float>(), block_table.data_ptr<int>(),
+        seq_lens.data_ptr<int>(), B, H, M, N, bfla_mask_ptr, bfla_mask_block_n,
+        bfla_mask_stride_b, bfla_mask_stride_h, bfla_mask_stride_q,
+        bfla_mask_stride_k, page_block_size, num_kv_heads, k_block_stride,
+        k_token_stride, k_head_stride, v_block_stride, v_token_stride,
+        v_head_stride, softmax_scale, k_scale, v_scale, window_size_left,
+        window_size_right, nullptr, nullptr, nullptr, 0);
+  }
 }
 
-template<int D>
+template <int D>
 __global__ void flash_attention_forward_paged_splitkv_merge_kernel(
     const float* __restrict__ split_tmp_out,
     const float* __restrict__ split_tmp_row_max,
-    const float* __restrict__ split_tmp_row_sum,
-          __half* __restrict__ Out,
-           float* __restrict__ softmax_lse,
-    const int B,
-    const int H,
-    const int M,
-    const int num_partitions
-) {
-    static_assert(D == 256, "split-KV paged prefill merge is D=256 only");
-    constexpr int BLOCK_M = BLOCK_M_256_LOW_SMEM;
-    constexpr int THREADS = 512;
-    const float NEG_INF = -1e30f;
+    const float* __restrict__ split_tmp_row_sum, __half* __restrict__ Out,
+    float* __restrict__ softmax_lse, const int B, const int H, const int M,
+    const int num_partitions) {
+  static_assert(D == 256, "split-KV paged prefill merge is D=256 only");
+  constexpr int BLOCK_M = BLOCK_M_256_LOW_SMEM;
+  constexpr int THREADS = 512;
+  const float NEG_INF = -1e30f;
 
-    const int batch_head_id = blockIdx.z;
-    if (batch_head_id >= B * H) return;
+  const int batch_head_id = blockIdx.z;
+  if (batch_head_id >= B * H) return;
 
-    const int block_m = blockIdx.x;
-    const int start_row = block_m * BLOCK_M;
-    if (start_row >= M) return;
-    const int valid_q_rows = min(BLOCK_M, M - start_row);
-    const int tid = threadIdx.x;
+  const int block_m = blockIdx.x;
+  const int start_row = block_m * BLOCK_M;
+  if (start_row >= M) return;
+  const int valid_q_rows = min(BLOCK_M, M - start_row);
+  const int tid = threadIdx.x;
 
-    __shared__ float sFinalMax[BLOCK_M];
-    __shared__ float sFinalSum[BLOCK_M];
+  __shared__ float sFinalMax[BLOCK_M];
+  __shared__ float sFinalSum[BLOCK_M];
 
-    if (tid < valid_q_rows) {
-        const int row = start_row + tid;
-        float final_max = NEG_INF;
-        #pragma unroll 1
-        for (int p = 0; p < num_partitions; ++p) {
-            const int64_t state_idx =
-                ((int64_t)batch_head_id * num_partitions + p) * M + row;
-            final_max = fmaxf(final_max, split_tmp_row_max[state_idx]);
-        }
-
-        float final_sum = 0.0f;
-        #pragma unroll 1
-        for (int p = 0; p < num_partitions; ++p) {
-            const int64_t state_idx =
-                ((int64_t)batch_head_id * num_partitions + p) * M + row;
-            const float part_sum = split_tmp_row_sum[state_idx];
-            if (part_sum > 0.0f) {
-                final_sum +=
-                    __expf(fmaxf(split_tmp_row_max[state_idx] - final_max,
-                                  -80.0f)) * part_sum;
-            }
-        }
-        sFinalMax[tid] = final_max;
-        sFinalSum[tid] = final_sum;
-        softmax_lse[(int64_t)batch_head_id * M + row] =
-            final_max + logf(fmaxf(final_sum, 1e-24f));
+  if (tid < valid_q_rows) {
+    const int row = start_row + tid;
+    float final_max = NEG_INF;
+#pragma unroll 1
+    for (int p = 0; p < num_partitions; ++p) {
+      const int64_t state_idx =
+          ((int64_t)batch_head_id * num_partitions + p) * M + row;
+      final_max = fmaxf(final_max, split_tmp_row_max[state_idx]);
     }
-    __syncthreads();
 
-    for (int idx = tid; idx < valid_q_rows * D; idx += THREADS) {
-        const int row_local = idx / D;
-        const int col = idx - row_local * D;
-        const int row = start_row + row_local;
-        const float final_max = sFinalMax[row_local];
-        const float inv_sum = 1.0f / fmaxf(sFinalSum[row_local], 1e-24f);
-
-        float acc = 0.0f;
-        #pragma unroll 1
-        for (int p = 0; p < num_partitions; ++p) {
-            const int64_t state_idx =
-                ((int64_t)batch_head_id * num_partitions + p) * M + row;
-            const float part_sum = split_tmp_row_sum[state_idx];
-            if (part_sum > 0.0f) {
-                const float scale =
-                    __expf(fmaxf(split_tmp_row_max[state_idx] - final_max,
-                                  -80.0f));
-                const int64_t out_idx = state_idx * D + col;
-                acc = fmaf(scale, split_tmp_out[out_idx], acc);
-            }
-        }
-        Out[((int64_t)batch_head_id * M + row) * D + col] =
-            __float2half_rn(acc * inv_sum);
+    float final_sum = 0.0f;
+#pragma unroll 1
+    for (int p = 0; p < num_partitions; ++p) {
+      const int64_t state_idx =
+          ((int64_t)batch_head_id * num_partitions + p) * M + row;
+      const float part_sum = split_tmp_row_sum[state_idx];
+      if (part_sum > 0.0f) {
+        final_sum +=
+            __expf(fmaxf(split_tmp_row_max[state_idx] - final_max, -80.0f)) *
+            part_sum;
+      }
     }
+    sFinalMax[tid] = final_max;
+    sFinalSum[tid] = final_sum;
+    softmax_lse[(int64_t)batch_head_id * M + row] =
+        final_max + logf(fmaxf(final_sum, 1e-24f));
+  }
+  __syncthreads();
+
+  for (int idx = tid; idx < valid_q_rows * D; idx += THREADS) {
+    const int row_local = idx / D;
+    const int col = idx - row_local * D;
+    const int row = start_row + row_local;
+    const float final_max = sFinalMax[row_local];
+    const float inv_sum = 1.0f / fmaxf(sFinalSum[row_local], 1e-24f);
+
+    float acc = 0.0f;
+#pragma unroll 1
+    for (int p = 0; p < num_partitions; ++p) {
+      const int64_t state_idx =
+          ((int64_t)batch_head_id * num_partitions + p) * M + row;
+      const float part_sum = split_tmp_row_sum[state_idx];
+      if (part_sum > 0.0f) {
+        const float scale =
+            __expf(fmaxf(split_tmp_row_max[state_idx] - final_max, -80.0f));
+        const int64_t out_idx = state_idx * D + col;
+        acc = fmaf(scale, split_tmp_out[out_idx], acc);
+      }
+    }
+    Out[((int64_t)batch_head_id * M + row) * D + col] =
+        __float2half_rn(acc * inv_sum);
+  }
 }
 
-template<int D, bool LOW_SMEM_CONTIG_FAST, bool LOW_SMEM_SCALAR_QK>
+template <int D, bool LOW_SMEM_CONTIG_FAST, bool LOW_SMEM_SCALAR_QK>
 void launcher_flash_attention_forward_paged_splitkv_impl(
-    const torch::Tensor& Q,
-    const torch::Tensor& K_cache,
-    const torch::Tensor& V_cache,
-    torch::Tensor& Out,
-    torch::Tensor& softmax_lse,
-    torch::Tensor& split_tmp_out,
-    torch::Tensor& split_tmp_row_max,
-    torch::Tensor& split_tmp_row_sum,
-    const torch::Tensor& block_table,
-    const torch::Tensor& seq_lens,
-    float softmax_scale,
-    bool is_causal,
-    float k_scale,
-    float v_scale,
-    int window_size_left,
-    int window_size_right,
-    int split_kv_tokens,
-    int max_seq_len_hint,
-    cudaStream_t stream
-) {
-    static_assert(D == 256, "split-KV paged prefill is D=256 only");
-    using Config = KernelConfig<D, true, LOW_SMEM_SCALAR_QK>;
-    constexpr int KV_DTYPE = flash_v100::KV_CACHE_DTYPE_FP16;
+    const torch::Tensor& Q, const torch::Tensor& K_cache,
+    const torch::Tensor& V_cache, torch::Tensor& Out,
+    torch::Tensor& softmax_lse, torch::Tensor& split_tmp_out,
+    torch::Tensor& split_tmp_row_max, torch::Tensor& split_tmp_row_sum,
+    const torch::Tensor& block_table, const torch::Tensor& seq_lens,
+    float softmax_scale, bool is_causal, float k_scale, float v_scale,
+    int window_size_left, int window_size_right, int split_kv_tokens,
+    int max_seq_len_hint, cudaStream_t stream) {
+  static_assert(D == 256, "split-KV paged prefill is D=256 only");
+  using Config = KernelConfig<D, true, LOW_SMEM_SCALAR_QK>;
+  constexpr int KV_DTYPE = flash_v100::KV_CACHE_DTYPE_FP16;
 
-    const int B = Q.size(0);
-    const int H = Q.size(1);
-    const int M = Q.size(2);
-    const int page_block_size = K_cache.size(1);
-    const int num_kv_heads = K_cache.size(2);
-    const int max_num_blocks = block_table.size(1);
-    const int N = max_num_blocks * page_block_size;
-    const int64_t k_block_stride = K_cache.stride(0);
-    const int64_t k_token_stride = K_cache.stride(1);
-    const int64_t k_head_stride = K_cache.stride(2);
-    const int64_t v_block_stride = V_cache.stride(0);
-    const int64_t v_token_stride = V_cache.stride(1);
-    const int64_t v_head_stride = V_cache.stride(2);
+  const int B = Q.size(0);
+  const int H = Q.size(1);
+  const int M = Q.size(2);
+  const int page_block_size = K_cache.size(1);
+  const int num_kv_heads = K_cache.size(2);
+  const int max_num_blocks = block_table.size(1);
+  const int N = max_num_blocks * page_block_size;
+  const int64_t k_block_stride = K_cache.stride(0);
+  const int64_t k_token_stride = K_cache.stride(1);
+  const int64_t k_head_stride = K_cache.stride(2);
+  const int64_t v_block_stride = V_cache.stride(0);
+  const int64_t v_token_stride = V_cache.stride(1);
+  const int64_t v_head_stride = V_cache.stride(2);
 
-    split_kv_tokens = std::max(split_kv_tokens, Config::BLOCK_N);
-    max_seq_len_hint = std::max(max_seq_len_hint, 1);
-    const int split_kv_tiles =
-        std::max(1, (split_kv_tokens + Config::BLOCK_N - 1) / Config::BLOCK_N);
-    const int max_kv_tiles =
-        std::max(1, (max_seq_len_hint + Config::BLOCK_N - 1) / Config::BLOCK_N);
-    const int num_partitions =
-        std::max(1, (max_kv_tiles + split_kv_tiles - 1) / split_kv_tiles);
+  split_kv_tokens = std::max(split_kv_tokens, Config::BLOCK_N);
+  max_seq_len_hint = std::max(max_seq_len_hint, 1);
+  const int split_kv_tiles =
+      std::max(1, (split_kv_tokens + Config::BLOCK_N - 1) / Config::BLOCK_N);
+  const int max_kv_tiles =
+      std::max(1, (max_seq_len_hint + Config::BLOCK_N - 1) / Config::BLOCK_N);
+  const int num_partitions =
+      std::max(1, (max_kv_tiles + split_kv_tiles - 1) / split_kv_tiles);
 
-    const int grid_x = (M + Config::BLOCK_M - 1) / Config::BLOCK_M;
-    const dim3 grid(grid_x, num_partitions, B * H);
-    const dim3 block(Config::THREADS_PER_BLOCK);
-    const size_t smem = Config::TOTAL_SMEM;
+  const int grid_x = (M + Config::BLOCK_M - 1) / Config::BLOCK_M;
+  const dim3 grid(grid_x, num_partitions, B * H);
+  const dim3 block(Config::THREADS_PER_BLOCK);
+  const size_t smem = Config::TOTAL_SMEM;
 
-    TORCH_CHECK(smem <= MAX_SMEM_PER_SM, "Shared memory exceeds 96KB: ", smem,
-                " bytes");
-    TORCH_CHECK(split_tmp_out.size(2) == num_partitions,
-                "split_tmp_out partition mismatch");
-    TORCH_CHECK(split_tmp_row_max.size(2) == num_partitions,
-                "split_tmp_row_max partition mismatch");
-    TORCH_CHECK(split_tmp_row_sum.size(2) == num_partitions,
-                "split_tmp_row_sum partition mismatch");
+  TORCH_CHECK(smem <= MAX_SMEM_PER_SM, "Shared memory exceeds 96KB: ", smem,
+              " bytes");
+  TORCH_CHECK(split_tmp_out.size(2) == num_partitions,
+              "split_tmp_out partition mismatch");
+  TORCH_CHECK(split_tmp_row_max.size(2) == num_partitions,
+              "split_tmp_row_max partition mismatch");
+  TORCH_CHECK(split_tmp_row_sum.size(2) == num_partitions,
+              "split_tmp_row_sum partition mismatch");
 
-    auto kernel = is_causal
-                      ? (void*)flash_attention_forward_kernel_paged<
-                            D, true, LOW_SMEM_CONTIG_FAST,
-                            LOW_SMEM_SCALAR_QK, false, true, true, KV_DTYPE>
-                      : (void*)flash_attention_forward_kernel_paged<
-                            D, true, LOW_SMEM_CONTIG_FAST,
-                            LOW_SMEM_SCALAR_QK, false, true, false, KV_DTYPE>;
-    cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize,
-                         smem);
+  auto kernel = is_causal
+                    ? (void*)flash_attention_forward_kernel_paged<
+                          D, true, LOW_SMEM_CONTIG_FAST, LOW_SMEM_SCALAR_QK,
+                          false, true, true, KV_DTYPE>
+                    : (void*)flash_attention_forward_kernel_paged<
+                          D, true, LOW_SMEM_CONTIG_FAST, LOW_SMEM_SCALAR_QK,
+                          false, true, false, KV_DTYPE>;
+  cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize,
+                       smem);
 
-    if (is_causal) {
-        flash_attention_forward_kernel_paged<
-            D, true, LOW_SMEM_CONTIG_FAST, LOW_SMEM_SCALAR_QK, false, true, true,
-            KV_DTYPE>
-            <<<grid, block, smem, stream>>>(
-            reinterpret_cast<const __half*>(Q.data_ptr()),
-            K_cache.data_ptr(),
-            V_cache.data_ptr(),
-            reinterpret_cast<__half*>(Out.data_ptr()),
-            softmax_lse.data_ptr<float>(),
-            block_table.data_ptr<int>(),
-            seq_lens.data_ptr<int>(),
-            B,
-            H,
-            M,
-            N,
-            nullptr,
-            0,
-            0,
-            0,
-            0,
-            0,
-            page_block_size,
-            num_kv_heads,
-            k_block_stride,
-            k_token_stride,
-            k_head_stride,
-            v_block_stride,
-            v_token_stride,
-            v_head_stride,
-            softmax_scale,
-            k_scale,
-            v_scale,
-            window_size_left,
-            window_size_right,
-            split_tmp_out.data_ptr<float>(),
+  if (is_causal) {
+    flash_attention_forward_kernel_paged<D, true, LOW_SMEM_CONTIG_FAST,
+                                         LOW_SMEM_SCALAR_QK, false, true, true,
+                                         KV_DTYPE>
+        <<<grid, block, smem, stream>>>(
+            reinterpret_cast<const __half*>(Q.data_ptr()), K_cache.data_ptr(),
+            V_cache.data_ptr(), reinterpret_cast<__half*>(Out.data_ptr()),
+            softmax_lse.data_ptr<float>(), block_table.data_ptr<int>(),
+            seq_lens.data_ptr<int>(), B, H, M, N, nullptr, 0, 0, 0, 0, 0,
+            page_block_size, num_kv_heads, k_block_stride, k_token_stride,
+            k_head_stride, v_block_stride, v_token_stride, v_head_stride,
+            softmax_scale, k_scale, v_scale, window_size_left,
+            window_size_right, split_tmp_out.data_ptr<float>(),
             split_tmp_row_max.data_ptr<float>(),
-            split_tmp_row_sum.data_ptr<float>(),
-            split_kv_tiles
-        );
-    } else {
-        flash_attention_forward_kernel_paged<
-            D, true, LOW_SMEM_CONTIG_FAST, LOW_SMEM_SCALAR_QK, false, true, false,
-            KV_DTYPE>
-            <<<grid, block, smem, stream>>>(
-            reinterpret_cast<const __half*>(Q.data_ptr()),
-            K_cache.data_ptr(),
-            V_cache.data_ptr(),
-            reinterpret_cast<__half*>(Out.data_ptr()),
-            softmax_lse.data_ptr<float>(),
-            block_table.data_ptr<int>(),
-            seq_lens.data_ptr<int>(),
-            B,
-            H,
-            M,
-            N,
-            nullptr,
-            0,
-            0,
-            0,
-            0,
-            0,
-            page_block_size,
-            num_kv_heads,
-            k_block_stride,
-            k_token_stride,
-            k_head_stride,
-            v_block_stride,
-            v_token_stride,
-            v_head_stride,
-            softmax_scale,
-            k_scale,
-            v_scale,
-            window_size_left,
-            window_size_right,
-            split_tmp_out.data_ptr<float>(),
+            split_tmp_row_sum.data_ptr<float>(), split_kv_tiles);
+  } else {
+    flash_attention_forward_kernel_paged<D, true, LOW_SMEM_CONTIG_FAST,
+                                         LOW_SMEM_SCALAR_QK, false, true, false,
+                                         KV_DTYPE>
+        <<<grid, block, smem, stream>>>(
+            reinterpret_cast<const __half*>(Q.data_ptr()), K_cache.data_ptr(),
+            V_cache.data_ptr(), reinterpret_cast<__half*>(Out.data_ptr()),
+            softmax_lse.data_ptr<float>(), block_table.data_ptr<int>(),
+            seq_lens.data_ptr<int>(), B, H, M, N, nullptr, 0, 0, 0, 0, 0,
+            page_block_size, num_kv_heads, k_block_stride, k_token_stride,
+            k_head_stride, v_block_stride, v_token_stride, v_head_stride,
+            softmax_scale, k_scale, v_scale, window_size_left,
+            window_size_right, split_tmp_out.data_ptr<float>(),
             split_tmp_row_max.data_ptr<float>(),
-            split_tmp_row_sum.data_ptr<float>(),
-            split_kv_tiles
-        );
-    }
+            split_tmp_row_sum.data_ptr<float>(), split_kv_tiles);
+  }
 
-    const dim3 merge_grid(grid_x, 1, B * H);
-    const dim3 merge_block(512);
-    flash_attention_forward_paged_splitkv_merge_kernel<D>
-        <<<merge_grid, merge_block, 0, stream>>>(
-            split_tmp_out.data_ptr<float>(),
-            split_tmp_row_max.data_ptr<float>(),
-            split_tmp_row_sum.data_ptr<float>(),
-            reinterpret_cast<__half*>(Out.data_ptr()),
-            softmax_lse.data_ptr<float>(),
-            B,
-            H,
-            M,
-            num_partitions);
+  const dim3 merge_grid(grid_x, 1, B * H);
+  const dim3 merge_block(512);
+  flash_attention_forward_paged_splitkv_merge_kernel<D>
+      <<<merge_grid, merge_block, 0, stream>>>(
+          split_tmp_out.data_ptr<float>(), split_tmp_row_max.data_ptr<float>(),
+          split_tmp_row_sum.data_ptr<float>(),
+          reinterpret_cast<__half*>(Out.data_ptr()),
+          softmax_lse.data_ptr<float>(), B, H, M, num_partitions);
 }
 
 constexpr int D256_BM32_PHASE_BLOCK_M = 32;
@@ -2090,41 +1787,41 @@ constexpr int D256_BM32_PHASE_PANELS =
 constexpr int D256_BM32_PHASE_PROBABILITY_ELEMENTS =
     D256_BM32_PHASE_PANEL_M * D256_BM32_PHASE_SOFTMAX_N;
 
-template<int PROBABILITY_PANELS>
+template <int PROBABILITY_PANELS>
 struct alignas(16) D256BM32PhaseSharedStorage {
-    __half query[D256_BM32_PHASE_BLOCK_M * D256_BM32_PHASE_D];
-    float score[D256_BM32_PHASE_BLOCK_M * D256_BM32_PHASE_BLOCK_N];
-    __half probability_top[PROBABILITY_PANELS
-                           * D256_BM32_PHASE_PROBABILITY_ELEMENTS];
-    __half probability_bottom[PROBABILITY_PANELS
-                              * D256_BM32_PHASE_PROBABILITY_ELEMENTS];
-    float row_max[D256_BM32_PHASE_BLOCK_M];
-    float row_sum[D256_BM32_PHASE_BLOCK_M];
-    float row_exp_diff[PROBABILITY_PANELS * D256_BM32_PHASE_BLOCK_M];
-    int page_idx[D256_BM32_PHASE_PAGE_SLOTS];
-    int page_offset[D256_BM32_PHASE_PAGE_SLOTS];
-    uint64_t k_tile_ptr[D256_BM32_PHASE_PAGE_SLOTS];
-    uint64_t v_tile_ptr[D256_BM32_PHASE_PAGE_SLOTS];
-    int block_index;
-    int batch_id;
-    int kv_head_id;
-    int actual_n;
+  __half query[D256_BM32_PHASE_BLOCK_M * D256_BM32_PHASE_D];
+  float score[D256_BM32_PHASE_BLOCK_M * D256_BM32_PHASE_BLOCK_N];
+  __half probability_top[PROBABILITY_PANELS *
+                         D256_BM32_PHASE_PROBABILITY_ELEMENTS];
+  __half probability_bottom[PROBABILITY_PANELS *
+                            D256_BM32_PHASE_PROBABILITY_ELEMENTS];
+  float row_max[D256_BM32_PHASE_BLOCK_M];
+  float row_sum[D256_BM32_PHASE_BLOCK_M];
+  float row_exp_diff[PROBABILITY_PANELS * D256_BM32_PHASE_BLOCK_M];
+  int page_idx[D256_BM32_PHASE_PAGE_SLOTS];
+  int page_offset[D256_BM32_PHASE_PAGE_SLOTS];
+  uint64_t k_tile_ptr[D256_BM32_PHASE_PAGE_SLOTS];
+  uint64_t v_tile_ptr[D256_BM32_PHASE_PAGE_SLOTS];
+  int block_index;
+  int batch_id;
+  int kv_head_id;
+  int actual_n;
 };
 
-template<int PROBABILITY_PANELS>
+template <int PROBABILITY_PANELS>
 struct alignas(16) D256BM32PhaseSplitSharedStorage
     : D256BM32PhaseSharedStorage<PROBABILITY_PANELS> {
-    int split_end_block;
+  int split_end_block;
 };
 
-template<bool SPLIT_KV, int PROBABILITY_PANELS>
+template <bool SPLIT_KV, int PROBABILITY_PANELS>
 struct D256BM32PhaseSharedStorageSelector {
-    using Type = D256BM32PhaseSharedStorage<PROBABILITY_PANELS>;
+  using Type = D256BM32PhaseSharedStorage<PROBABILITY_PANELS>;
 };
 
-template<int PROBABILITY_PANELS>
+template <int PROBABILITY_PANELS>
 struct D256BM32PhaseSharedStorageSelector<true, PROBABILITY_PANELS> {
-    using Type = D256BM32PhaseSplitSharedStorage<PROBABILITY_PANELS>;
+  using Type = D256BM32PhaseSplitSharedStorage<PROBABILITY_PANELS>;
 };
 
 using D256BM32PhaseSharedStorageSingle = D256BM32PhaseSharedStorage<1>;
@@ -2137,8 +1834,8 @@ static_assert(sizeof(D256BM32PhaseSharedStorageAllP) == 41936,
               "D256 BM32 all-P shared layout changed unexpectedly");
 static_assert(sizeof(D256BM32PhaseSharedStorageAllP) <= 48 * 1024,
               "D256 BM32 phase shared storage exceeds 48 KiB");
-static_assert(sizeof(D256BM32PhaseSplitSharedStorage<
-                      D256_BM32_PHASE_PANELS>) == 41952,
+static_assert(sizeof(D256BM32PhaseSplitSharedStorage<D256_BM32_PHASE_PANELS>) ==
+                  41952,
               "D256 BM32 split shared layout changed unexpectedly");
 
 using D256BM32PhaseMatrixAFragment =
@@ -2151,2143 +1848,1846 @@ using D256BM32PhaseAccumulatorFragment =
     fragment<accumulator, WMMA_M, WMMA_N, WMMA_K, float>;
 
 __device__ __forceinline__ int d256_bm32_phase_swizzled_row_slot(int row) {
-    return (row & 3) | ((row & 8) >> 1) | ((row & 4) << 1);
+  return (row & 3) | ((row & 8) >> 1) | ((row & 4) << 1);
 }
 
-__device__ __forceinline__ int d256_bm32_phase_matrix_a_offset(
-    int row,
-    int column) {
-    const int tile = column / WMMA_K;
-    const int within_tile = column - tile * WMMA_K;
-    const int plane = within_tile >> 3;
-    const int inner = within_tile & 7;
-    return tile * WMMA_M * WMMA_K + plane * WMMA_M * 8
-           + d256_bm32_phase_swizzled_row_slot(row) * 8 + inner;
+__device__ __forceinline__ int d256_bm32_phase_matrix_a_offset(int row,
+                                                               int column) {
+  const int tile = column / WMMA_K;
+  const int within_tile = column - tile * WMMA_K;
+  const int plane = within_tile >> 3;
+  const int inner = within_tile & 7;
+  return tile * WMMA_M * WMMA_K + plane * WMMA_M * 8 +
+         d256_bm32_phase_swizzled_row_slot(row) * 8 + inner;
 }
 
 __device__ __forceinline__ void d256_bm32_phase_stage_query(
-    const __half* __restrict__ source,
-    __half* __restrict__ destination) {
-    constexpr int HALF_PER_UINT4 = sizeof(uint4) / sizeof(__half);
-    constexpr int VECTORS_PER_ROW = D256_BM32_PHASE_D / HALF_PER_UINT4;
-    constexpr int VECTORS_PER_PANEL =
-        D256_BM32_PHASE_PANEL_M * VECTORS_PER_ROW;
-    constexpr int QUERY_VECTORS =
-        D256_BM32_PHASE_BLOCK_M * VECTORS_PER_ROW;
+    const __half* __restrict__ source, __half* __restrict__ destination) {
+  constexpr int HALF_PER_UINT4 = sizeof(uint4) / sizeof(__half);
+  constexpr int VECTORS_PER_ROW = D256_BM32_PHASE_D / HALF_PER_UINT4;
+  constexpr int VECTORS_PER_PANEL = D256_BM32_PHASE_PANEL_M * VECTORS_PER_ROW;
+  constexpr int QUERY_VECTORS = D256_BM32_PHASE_BLOCK_M * VECTORS_PER_ROW;
 
-    const uint4* source_vectors = reinterpret_cast<const uint4*>(source);
-    uint4* destination_vectors = reinterpret_cast<uint4*>(destination);
+  const uint4* source_vectors = reinterpret_cast<const uint4*>(source);
+  uint4* destination_vectors = reinterpret_cast<uint4*>(destination);
 
-    #pragma unroll
-    for (int index = threadIdx.x; index < QUERY_VECTORS;
-         index += D256_BM32_PHASE_THREADS) {
-        const int row = index / VECTORS_PER_ROW;
-        const int vector_column = index % VECTORS_PER_ROW;
-        const int panel = row / D256_BM32_PHASE_PANEL_M;
-        const int panel_row = row - panel * D256_BM32_PHASE_PANEL_M;
-        const int k_tile = vector_column >> 1;
-        const int plane = vector_column & 1;
-        const int slot = d256_bm32_phase_swizzled_row_slot(panel_row);
-        destination_vectors[panel * VECTORS_PER_PANEL
-                            + k_tile * (2 * D256_BM32_PHASE_PANEL_M)
-                            + plane * D256_BM32_PHASE_PANEL_M + slot] =
-            __ldg(source_vectors + index);
-    }
+#pragma unroll
+  for (int index = threadIdx.x; index < QUERY_VECTORS;
+       index += D256_BM32_PHASE_THREADS) {
+    const int row = index / VECTORS_PER_ROW;
+    const int vector_column = index % VECTORS_PER_ROW;
+    const int panel = row / D256_BM32_PHASE_PANEL_M;
+    const int panel_row = row - panel * D256_BM32_PHASE_PANEL_M;
+    const int k_tile = vector_column >> 1;
+    const int plane = vector_column & 1;
+    const int slot = d256_bm32_phase_swizzled_row_slot(panel_row);
+    destination_vectors[panel * VECTORS_PER_PANEL +
+                        k_tile * (2 * D256_BM32_PHASE_PANEL_M) +
+                        plane * D256_BM32_PHASE_PANEL_M + slot] =
+        __ldg(source_vectors + index);
+  }
 }
 
 __device__ __forceinline__ void d256_bm32_phase_stage_query_partial(
-    const __half* __restrict__ source,
-    __half* __restrict__ destination,
+    const __half* __restrict__ source, __half* __restrict__ destination,
     int valid_rows) {
-    constexpr int HALF_PER_UINT4 = sizeof(uint4) / sizeof(__half);
-    constexpr int VECTORS_PER_ROW = D256_BM32_PHASE_D / HALF_PER_UINT4;
-    constexpr int VECTORS_PER_PANEL =
-        D256_BM32_PHASE_PANEL_M * VECTORS_PER_ROW;
-    constexpr int QUERY_VECTORS =
-        D256_BM32_PHASE_BLOCK_M * VECTORS_PER_ROW;
+  constexpr int HALF_PER_UINT4 = sizeof(uint4) / sizeof(__half);
+  constexpr int VECTORS_PER_ROW = D256_BM32_PHASE_D / HALF_PER_UINT4;
+  constexpr int VECTORS_PER_PANEL = D256_BM32_PHASE_PANEL_M * VECTORS_PER_ROW;
+  constexpr int QUERY_VECTORS = D256_BM32_PHASE_BLOCK_M * VECTORS_PER_ROW;
 
-    const uint4* source_vectors = reinterpret_cast<const uint4*>(source);
-    uint4* destination_vectors = reinterpret_cast<uint4*>(destination);
+  const uint4* source_vectors = reinterpret_cast<const uint4*>(source);
+  uint4* destination_vectors = reinterpret_cast<uint4*>(destination);
 
-    #pragma unroll
-    for (int index = threadIdx.x; index < QUERY_VECTORS;
-         index += D256_BM32_PHASE_THREADS) {
-        const int row = index / VECTORS_PER_ROW;
-        const int vector_column = index % VECTORS_PER_ROW;
-        const int panel = row / D256_BM32_PHASE_PANEL_M;
-        const int panel_row = row - panel * D256_BM32_PHASE_PANEL_M;
-        const int k_tile = vector_column >> 1;
-        const int plane = vector_column & 1;
-        const int slot = d256_bm32_phase_swizzled_row_slot(panel_row);
-        uint4 value = {0, 0, 0, 0};
-        if (row < valid_rows) {
-            value = __ldg(source_vectors + index);
-        }
-        destination_vectors[panel * VECTORS_PER_PANEL
-                            + k_tile * (2 * D256_BM32_PHASE_PANEL_M)
-                            + plane * D256_BM32_PHASE_PANEL_M + slot] = value;
+#pragma unroll
+  for (int index = threadIdx.x; index < QUERY_VECTORS;
+       index += D256_BM32_PHASE_THREADS) {
+    const int row = index / VECTORS_PER_ROW;
+    const int vector_column = index % VECTORS_PER_ROW;
+    const int panel = row / D256_BM32_PHASE_PANEL_M;
+    const int panel_row = row - panel * D256_BM32_PHASE_PANEL_M;
+    const int k_tile = vector_column >> 1;
+    const int plane = vector_column & 1;
+    const int slot = d256_bm32_phase_swizzled_row_slot(panel_row);
+    uint4 value = {0, 0, 0, 0};
+    if (row < valid_rows) {
+      value = __ldg(source_vectors + index);
     }
+    destination_vectors[panel * VECTORS_PER_PANEL +
+                        k_tile * (2 * D256_BM32_PHASE_PANEL_M) +
+                        plane * D256_BM32_PHASE_PANEL_M + slot] = value;
+  }
 }
 
 __device__ __forceinline__ void d256_bm32_phase_load_matrix_a(
-    D256BM32PhaseMatrixAFragment& fragment,
-    const __half* __restrict__ matrix,
+    D256BM32PhaseMatrixAFragment& fragment, const __half* __restrict__ matrix,
     int k_offset) {
-    const int lane = threadIdx.x & 31;
-    const int row =
-        (lane & 3) + ((lane >> 4) & 1) * 4 + ((lane >> 2) & 1) * 8;
-    const int slot = d256_bm32_phase_swizzled_row_slot(row);
-    const int tile_offset = (k_offset / WMMA_K) * WMMA_M * WMMA_K;
-    uint32_t address = static_cast<uint32_t>(
-        __cvta_generic_to_shared(matrix + tile_offset + slot * 8));
-    uint32_t* words = reinterpret_cast<uint32_t*>(&fragment);
-    asm volatile(
-        "ld.shared.v4.u32 {%0, %1, %2, %3}, [%4];"
-        : "=r"(words[0]), "=r"(words[1]), "=r"(words[2]), "=r"(words[3])
-        : "r"(address)
-        : "memory");
-    address += WMMA_M * 8 * sizeof(__half);
-    asm volatile(
-        "ld.shared.v4.u32 {%0, %1, %2, %3}, [%4];"
-        : "=r"(words[4]), "=r"(words[5]), "=r"(words[6]), "=r"(words[7])
-        : "r"(address)
-        : "memory");
+  const int lane = threadIdx.x & 31;
+  const int row = (lane & 3) + ((lane >> 4) & 1) * 4 + ((lane >> 2) & 1) * 8;
+  const int slot = d256_bm32_phase_swizzled_row_slot(row);
+  const int tile_offset = (k_offset / WMMA_K) * WMMA_M * WMMA_K;
+  uint32_t address = static_cast<uint32_t>(
+      __cvta_generic_to_shared(matrix + tile_offset + slot * 8));
+  uint32_t* words = reinterpret_cast<uint32_t*>(&fragment);
+  asm volatile("ld.shared.v4.u32 {%0, %1, %2, %3}, [%4];"
+               : "=r"(words[0]), "=r"(words[1]), "=r"(words[2]), "=r"(words[3])
+               : "r"(address)
+               : "memory");
+  address += WMMA_M * 8 * sizeof(__half);
+  asm volatile("ld.shared.v4.u32 {%0, %1, %2, %3}, [%4];"
+               : "=r"(words[4]), "=r"(words[5]), "=r"(words[6]), "=r"(words[7])
+               : "r"(address)
+               : "memory");
 }
 
-__device__ __forceinline__ int d256_bm32_phase_accumulator_row(
-    int lane,
-    int element) {
-    const int row_base =
-        (lane & 1) + ((lane >> 2) & 1) * 8 + ((lane >> 4) & 1) * 4;
-    return row_base + ((element >> 1) & 1) * 2;
+__device__ __forceinline__ int d256_bm32_phase_accumulator_row(int lane,
+                                                               int element) {
+  const int row_base =
+      (lane & 1) + ((lane >> 2) & 1) * 8 + ((lane >> 4) & 1) * 4;
+  return row_base + ((element >> 1) & 1) * 2;
 }
 
-__device__ __forceinline__ int d256_bm32_phase_accumulator_column(
-    int lane,
-    int element) {
-    const int column_base = ((lane >> 1) & 1) * 2 + ((lane >> 3) & 1) * 8;
-    return column_base + (element & 1) + ((element >> 2) & 1) * 4;
+__device__ __forceinline__ int d256_bm32_phase_accumulator_column(int lane,
+                                                                  int element) {
+  const int column_base = ((lane >> 1) & 1) * 2 + ((lane >> 3) & 1) * 8;
+  return column_base + (element & 1) + ((element >> 2) & 1) * 4;
 }
 
 __device__ __forceinline__ void d256_bm32_phase_spill_pair_scratch(
     float* __restrict__ score,
     D256BM32PhaseAccumulatorFragment& accumulator_top,
     D256BM32PhaseAccumulatorFragment& accumulator_bottom) {
-    const int warp = threadIdx.x >> 5;
-    const int lane = threadIdx.x & 31;
-    const int warp_pair = warp >> 1;
-    const int warp_in_pair = warp & 1;
-    const int pair_column = warp_pair * 32 + (lane & 15) * 2;
-    const int lane_row = lane >> 4;
+  const int warp = threadIdx.x >> 5;
+  const int lane = threadIdx.x & 31;
+  const int warp_pair = warp >> 1;
+  const int warp_in_pair = warp & 1;
+  const int pair_column = warp_pair * 32 + (lane & 15) * 2;
+  const int lane_row = lane >> 4;
 
-    #pragma unroll
-    for (int element_pair = 0; element_pair < 4; ++element_pair) {
-        const int element = element_pair * 2;
-        const int offset =
-            (warp_in_pair * 16 + element_pair * 2 + lane_row)
-                * D256_BM32_PHASE_BLOCK_N
-            + pair_column;
-        const uint32_t address = static_cast<uint32_t>(
-            __cvta_generic_to_shared(score + offset));
-        asm volatile(
-            "st.shared.v2.u32 [%0], {%1, %2};"
-            :
-            : "r"(address),
-              "r"(__float_as_uint(accumulator_top.x[element])),
-              "r"(__float_as_uint(accumulator_top.x[element + 1]))
-            : "memory");
-        asm volatile(
-            "st.shared.v2.u32 [%0+4096], {%1, %2};"
-            :
-            : "r"(address),
-              "r"(__float_as_uint(accumulator_bottom.x[element])),
-              "r"(__float_as_uint(accumulator_bottom.x[element + 1]))
-            : "memory");
-    }
+#pragma unroll
+  for (int element_pair = 0; element_pair < 4; ++element_pair) {
+    const int element = element_pair * 2;
+    const int offset = (warp_in_pair * 16 + element_pair * 2 + lane_row) *
+                           D256_BM32_PHASE_BLOCK_N +
+                       pair_column;
+    const uint32_t address =
+        static_cast<uint32_t>(__cvta_generic_to_shared(score + offset));
+    asm volatile("st.shared.v2.u32 [%0], {%1, %2};"
+                 :
+                 : "r"(address),
+                   "r"(__float_as_uint(accumulator_top.x[element])),
+                   "r"(__float_as_uint(accumulator_top.x[element + 1]))
+                 : "memory");
+    asm volatile("st.shared.v2.u32 [%0+4096], {%1, %2};"
+                 :
+                 : "r"(address),
+                   "r"(__float_as_uint(accumulator_bottom.x[element])),
+                   "r"(__float_as_uint(accumulator_bottom.x[element + 1]))
+                 : "memory");
+  }
 }
 
 __device__ __forceinline__ void d256_bm32_phase_reload_pair_scratch(
     const float* __restrict__ score,
     D256BM32PhaseAccumulatorFragment& accumulator_top,
     D256BM32PhaseAccumulatorFragment& accumulator_bottom) {
-    const int warp = threadIdx.x >> 5;
-    const int lane = threadIdx.x & 31;
-    const int warp_pair = warp >> 1;
-    const int warp_in_pair = warp & 1;
-    const int pair_column = warp_pair * 32 + (lane & 15) * 2;
-    const int lane_row = lane >> 4;
+  const int warp = threadIdx.x >> 5;
+  const int lane = threadIdx.x & 31;
+  const int warp_pair = warp >> 1;
+  const int warp_in_pair = warp & 1;
+  const int pair_column = warp_pair * 32 + (lane & 15) * 2;
+  const int lane_row = lane >> 4;
 
-    #pragma unroll
-    for (int element_pair = 0; element_pair < 4; ++element_pair) {
-        const int element = element_pair * 2;
-        const int offset =
-            (warp_in_pair * 16 + element_pair * 2 + lane_row)
-                * D256_BM32_PHASE_BLOCK_N
-            + pair_column;
-        const uint32_t address = static_cast<uint32_t>(
-            __cvta_generic_to_shared(score + offset));
-        uint32_t first_word;
-        uint32_t second_word;
-        asm volatile(
-            "ld.shared.v2.u32 {%0, %1}, [%2];"
-            : "=r"(first_word), "=r"(second_word)
-            : "r"(address)
-            : "memory");
-        accumulator_top.x[element] = __uint_as_float(first_word);
-        accumulator_top.x[element + 1] = __uint_as_float(second_word);
-        asm volatile(
-            "ld.shared.v2.u32 {%0, %1}, [%2+4096];"
-            : "=r"(first_word), "=r"(second_word)
-            : "r"(address)
-            : "memory");
-        accumulator_bottom.x[element] = __uint_as_float(first_word);
-        accumulator_bottom.x[element + 1] = __uint_as_float(second_word);
-    }
+#pragma unroll
+  for (int element_pair = 0; element_pair < 4; ++element_pair) {
+    const int element = element_pair * 2;
+    const int offset = (warp_in_pair * 16 + element_pair * 2 + lane_row) *
+                           D256_BM32_PHASE_BLOCK_N +
+                       pair_column;
+    const uint32_t address =
+        static_cast<uint32_t>(__cvta_generic_to_shared(score + offset));
+    uint32_t first_word;
+    uint32_t second_word;
+    asm volatile("ld.shared.v2.u32 {%0, %1}, [%2];"
+                 : "=r"(first_word), "=r"(second_word)
+                 : "r"(address)
+                 : "memory");
+    accumulator_top.x[element] = __uint_as_float(first_word);
+    accumulator_top.x[element + 1] = __uint_as_float(second_word);
+    asm volatile("ld.shared.v2.u32 {%0, %1}, [%2+4096];"
+                 : "=r"(first_word), "=r"(second_word)
+                 : "r"(address)
+                 : "memory");
+    accumulator_bottom.x[element] = __uint_as_float(first_word);
+    accumulator_bottom.x[element + 1] = __uint_as_float(second_word);
+  }
 }
 
 __device__ __forceinline__ void d256_bm32_phase_sync_warp_pair(int warp_pair) {
-    const int barrier_id = warp_pair + 1;
-    asm volatile("bar.sync %0, 64;" : : "r"(barrier_id) : "memory");
+  const int barrier_id = warp_pair + 1;
+  asm volatile("bar.sync %0, 64;" : : "r"(barrier_id) : "memory");
 }
 
 __device__ __forceinline__ float d256_bm32_phase_make_probability_row(
-    const float* __restrict__ score_row,
-    __half* __restrict__ probability,
-    int probability_row,
-    float* __restrict__ row_max,
-    float* __restrict__ row_sum,
-    int state_row,
-    int panel,
-    float neg_inf) {
-    const int lane = threadIdx.x & 31;
-    const float* panel_score =
-        score_row + panel * D256_BM32_PHASE_SOFTMAX_N;
-    float thread_max = neg_inf;
-    if (lane < D256_BM32_PHASE_SOFTMAX_N / 4) {
-        const float4 values =
-            reinterpret_cast<const float4*>(panel_score)[lane];
-        thread_max = fmaxf(fmaxf(values.x, values.y),
-                           fmaxf(values.z, values.w));
-    }
-    #pragma unroll
-    for (int offset = 16; offset > 0; offset >>= 1) {
-        thread_max = fmaxf(
-            thread_max, __shfl_down_sync(0xffffffffU, thread_max, offset));
-    }
-    const float panel_max = __shfl_sync(0xffffffffU, thread_max, 0);
-    const float old_max = row_max[state_row];
-    const float new_max = fmaxf(old_max, panel_max);
-    const float exp_diff = __expf(old_max - new_max);
+    const float* __restrict__ score_row, __half* __restrict__ probability,
+    int probability_row, float* __restrict__ row_max,
+    float* __restrict__ row_sum, int state_row, int panel, float neg_inf) {
+  const int lane = threadIdx.x & 31;
+  const float* panel_score = score_row + panel * D256_BM32_PHASE_SOFTMAX_N;
+  float thread_max = neg_inf;
+  if (lane < D256_BM32_PHASE_SOFTMAX_N / 4) {
+    const float4 values = reinterpret_cast<const float4*>(panel_score)[lane];
+    thread_max = fmaxf(fmaxf(values.x, values.y), fmaxf(values.z, values.w));
+  }
+#pragma unroll
+  for (int offset = 16; offset > 0; offset >>= 1) {
+    thread_max =
+        fmaxf(thread_max, __shfl_down_sync(0xffffffffU, thread_max, offset));
+  }
+  const float panel_max = __shfl_sync(0xffffffffU, thread_max, 0);
+  const float old_max = row_max[state_row];
+  const float new_max = fmaxf(old_max, panel_max);
+  const float exp_diff = __expf(old_max - new_max);
 
-    float thread_sum = 0.0f;
-    if (lane < D256_BM32_PHASE_SOFTMAX_N / 4) {
-        float4 values = reinterpret_cast<const float4*>(panel_score)[lane];
-        values.x = __expf(fmaxf(values.x - new_max, -80.0f));
-        values.y = __expf(fmaxf(values.y - new_max, -80.0f));
-        values.z = __expf(fmaxf(values.z - new_max, -80.0f));
-        values.w = __expf(fmaxf(values.w - new_max, -80.0f));
-        thread_sum = (values.x + values.y) + (values.z + values.w);
-        const int column = lane * 4;
-        __half2* first_pair = reinterpret_cast<__half2*>(
-            probability + d256_bm32_phase_matrix_a_offset(
-                              probability_row, column));
-        __half2* second_pair = reinterpret_cast<__half2*>(
-            probability + d256_bm32_phase_matrix_a_offset(
-                              probability_row, column + 2));
-        *first_pair = __float22half2_rn(make_float2(values.x, values.y));
-        *second_pair = __float22half2_rn(make_float2(values.z, values.w));
-    }
-    #pragma unroll
-    for (int offset = 16; offset > 0; offset >>= 1) {
-        thread_sum +=
-            __shfl_down_sync(0xffffffffU, thread_sum, offset);
-    }
-    const float panel_sum = __shfl_sync(0xffffffffU, thread_sum, 0);
-    if (lane == 0) {
-        row_sum[state_row] = exp_diff * row_sum[state_row] + panel_sum;
-        row_max[state_row] = new_max;
-    }
-    return exp_diff;
+  float thread_sum = 0.0f;
+  if (lane < D256_BM32_PHASE_SOFTMAX_N / 4) {
+    float4 values = reinterpret_cast<const float4*>(panel_score)[lane];
+    values.x = __expf(fmaxf(values.x - new_max, -80.0f));
+    values.y = __expf(fmaxf(values.y - new_max, -80.0f));
+    values.z = __expf(fmaxf(values.z - new_max, -80.0f));
+    values.w = __expf(fmaxf(values.w - new_max, -80.0f));
+    thread_sum = (values.x + values.y) + (values.z + values.w);
+    const int column = lane * 4;
+    __half2* first_pair = reinterpret_cast<__half2*>(
+        probability + d256_bm32_phase_matrix_a_offset(probability_row, column));
+    __half2* second_pair = reinterpret_cast<__half2*>(
+        probability +
+        d256_bm32_phase_matrix_a_offset(probability_row, column + 2));
+    *first_pair = __float22half2_rn(make_float2(values.x, values.y));
+    *second_pair = __float22half2_rn(make_float2(values.z, values.w));
+  }
+#pragma unroll
+  for (int offset = 16; offset > 0; offset >>= 1) {
+    thread_sum += __shfl_down_sync(0xffffffffU, thread_sum, offset);
+  }
+  const float panel_sum = __shfl_sync(0xffffffffU, thread_sum, 0);
+  if (lane == 0) {
+    row_sum[state_row] = exp_diff * row_sum[state_row] + panel_sum;
+    row_max[state_row] = new_max;
+  }
+  return exp_diff;
 }
 
-__device__ __forceinline__ float
-d256_bm32_phase_make_split_probability_row(
-    const float* __restrict__ score_row,
-    __half* __restrict__ probability,
-    int probability_row,
-    float* __restrict__ row_max,
-    float* __restrict__ row_sum,
-    int state_row,
-    int panel,
-    float neg_inf,
+__device__ __forceinline__ float d256_bm32_phase_make_split_probability_row(
+    const float* __restrict__ score_row, __half* __restrict__ probability,
+    int probability_row, float* __restrict__ row_max,
+    float* __restrict__ row_sum, int state_row, int panel, float neg_inf,
     bool has_visible_value) {
-    if (!has_visible_value) {
-        const int lane = threadIdx.x & 31;
-        if (lane < D256_BM32_PHASE_SOFTMAX_N / 4) {
-            const int column = lane * 4;
-            __half2* first_pair = reinterpret_cast<__half2*>(
-                probability + d256_bm32_phase_matrix_a_offset(
-                                  probability_row, column));
-            __half2* second_pair = reinterpret_cast<__half2*>(
-                probability + d256_bm32_phase_matrix_a_offset(
-                                  probability_row, column + 2));
-            const __half2 zero = __float2half2_rn(0.0f);
-            *first_pair = zero;
-            *second_pair = zero;
-        }
-        return 1.0f;
+  if (!has_visible_value) {
+    const int lane = threadIdx.x & 31;
+    if (lane < D256_BM32_PHASE_SOFTMAX_N / 4) {
+      const int column = lane * 4;
+      __half2* first_pair = reinterpret_cast<__half2*>(
+          probability +
+          d256_bm32_phase_matrix_a_offset(probability_row, column));
+      __half2* second_pair = reinterpret_cast<__half2*>(
+          probability +
+          d256_bm32_phase_matrix_a_offset(probability_row, column + 2));
+      const __half2 zero = __float2half2_rn(0.0f);
+      *first_pair = zero;
+      *second_pair = zero;
     }
-    return d256_bm32_phase_make_probability_row(
-        score_row, probability, probability_row, row_max, row_sum,
-        state_row, panel, neg_inf);
+    return 1.0f;
+  }
+  return d256_bm32_phase_make_probability_row(score_row, probability,
+                                              probability_row, row_max, row_sum,
+                                              state_row, panel, neg_inf);
 }
 
 __device__ __forceinline__ void d256_bm32_phase_scale_accumulator_rows(
-    D256BM32PhaseAccumulatorFragment& accumulator,
-    float first_row_scale,
+    D256BM32PhaseAccumulatorFragment& accumulator, float first_row_scale,
     float second_row_scale) {
-    accumulator.x[0] *= first_row_scale;
-    accumulator.x[1] *= first_row_scale;
-    accumulator.x[2] *= second_row_scale;
-    accumulator.x[3] *= second_row_scale;
-    accumulator.x[4] *= first_row_scale;
-    accumulator.x[5] *= first_row_scale;
-    accumulator.x[6] *= second_row_scale;
-    accumulator.x[7] *= second_row_scale;
+  accumulator.x[0] *= first_row_scale;
+  accumulator.x[1] *= first_row_scale;
+  accumulator.x[2] *= second_row_scale;
+  accumulator.x[3] *= second_row_scale;
+  accumulator.x[4] *= first_row_scale;
+  accumulator.x[5] *= first_row_scale;
+  accumulator.x[6] *= second_row_scale;
+  accumulator.x[7] *= second_row_scale;
 }
 
 __device__ __forceinline__ void d256_bm32_phase_scale_accumulators(
     D256BM32PhaseAccumulatorFragment& accumulator_top,
     D256BM32PhaseAccumulatorFragment& accumulator_bottom,
     const float* __restrict__ row_exp_diff) {
-    const int row = d256_bm32_phase_accumulator_row(threadIdx.x & 31, 0);
-    d256_bm32_phase_scale_accumulator_rows(
-        accumulator_top, row_exp_diff[row], row_exp_diff[row + 2]);
-    d256_bm32_phase_scale_accumulator_rows(
-        accumulator_bottom,
-        row_exp_diff[D256_BM32_PHASE_PANEL_M + row],
-        row_exp_diff[D256_BM32_PHASE_PANEL_M + row + 2]);
+  const int row = d256_bm32_phase_accumulator_row(threadIdx.x & 31, 0);
+  d256_bm32_phase_scale_accumulator_rows(accumulator_top, row_exp_diff[row],
+                                         row_exp_diff[row + 2]);
+  d256_bm32_phase_scale_accumulator_rows(
+      accumulator_bottom, row_exp_diff[D256_BM32_PHASE_PANEL_M + row],
+      row_exp_diff[D256_BM32_PHASE_PANEL_M + row + 2]);
 }
 
 __device__ __forceinline__ void d256_bm32_phase_update_pv_panel(
     const __half* __restrict__ probability_top,
     const __half* __restrict__ probability_bottom,
-    const __half* __restrict__ value_k0,
-    const __half* __restrict__ value_k16,
-    int64_t value_token_stride,
-    int d_offset,
-    int valid_columns,
+    const __half* __restrict__ value_k0, const __half* __restrict__ value_k16,
+    int64_t value_token_stride, int d_offset, int valid_columns,
     D256BM32PhaseAccumulatorFragment& accumulator_top,
     D256BM32PhaseAccumulatorFragment& accumulator_bottom) {
-    D256BM32PhaseMatrixAFragment a_fragment;
-    D256BM32PhasePVMatrixBFragment b_fragment;
+  D256BM32PhaseMatrixAFragment a_fragment;
+  D256BM32PhasePVMatrixBFragment b_fragment;
 
-    load_matrix_sync(b_fragment, value_k0 + d_offset, value_token_stride);
-    d256_bm32_phase_load_matrix_a(a_fragment, probability_top, 0);
+  load_matrix_sync(b_fragment, value_k0 + d_offset, value_token_stride);
+  d256_bm32_phase_load_matrix_a(a_fragment, probability_top, 0);
+  mma_sync(accumulator_top, a_fragment, b_fragment, accumulator_top);
+  d256_bm32_phase_load_matrix_a(a_fragment, probability_bottom, 0);
+  mma_sync(accumulator_bottom, a_fragment, b_fragment, accumulator_bottom);
+  if (valid_columns > WMMA_K) {
+    load_matrix_sync(b_fragment, value_k16 + d_offset, value_token_stride);
+    d256_bm32_phase_load_matrix_a(a_fragment, probability_top, WMMA_K);
     mma_sync(accumulator_top, a_fragment, b_fragment, accumulator_top);
-    d256_bm32_phase_load_matrix_a(a_fragment, probability_bottom, 0);
+    d256_bm32_phase_load_matrix_a(a_fragment, probability_bottom, WMMA_K);
     mma_sync(accumulator_bottom, a_fragment, b_fragment, accumulator_bottom);
-    if (valid_columns > WMMA_K) {
-        load_matrix_sync(
-            b_fragment, value_k16 + d_offset, value_token_stride);
-        d256_bm32_phase_load_matrix_a(a_fragment, probability_top, WMMA_K);
-        mma_sync(accumulator_top, a_fragment, b_fragment, accumulator_top);
-        d256_bm32_phase_load_matrix_a(a_fragment, probability_bottom, WMMA_K);
-        mma_sync(accumulator_bottom, a_fragment, b_fragment,
-                 accumulator_bottom);
-    }
+  }
 }
 
 __device__ __forceinline__ void d256_bm32_phase_store_output(
     const D256BM32PhaseAccumulatorFragment& accumulator,
-    __half* __restrict__ output,
-    const float* __restrict__ row_sum,
-    int row_offset,
-    int d_offset) {
-    const int lane = threadIdx.x & 31;
-    #pragma unroll
-    for (int element = 0; element < accumulator.num_elements; ++element) {
-        const int row = row_offset
-                        + d256_bm32_phase_accumulator_row(lane, element);
-        const int column = d_offset
-                           + d256_bm32_phase_accumulator_column(lane, element);
-        const float inverse_sum = 1.0f / fmaxf(row_sum[row], 1e-24f);
-        output[row * D256_BM32_PHASE_D + column] =
-            __float2half_rn(accumulator.x[element] * inverse_sum);
-    }
+    __half* __restrict__ output, const float* __restrict__ row_sum,
+    int row_offset, int d_offset) {
+  const int lane = threadIdx.x & 31;
+#pragma unroll
+  for (int element = 0; element < accumulator.num_elements; ++element) {
+    const int row = row_offset + d256_bm32_phase_accumulator_row(lane, element);
+    const int column =
+        d_offset + d256_bm32_phase_accumulator_column(lane, element);
+    const float inverse_sum = 1.0f / fmaxf(row_sum[row], 1e-24f);
+    output[row * D256_BM32_PHASE_D + column] =
+        __float2half_rn(accumulator.x[element] * inverse_sum);
+  }
 }
 
 __device__ __forceinline__ void d256_bm32_phase_store_output_partial(
     const D256BM32PhaseAccumulatorFragment& accumulator,
-    __half* __restrict__ output,
-    const float* __restrict__ row_sum,
-    int row_offset,
-    int d_offset,
-    int valid_rows) {
-    const int lane = threadIdx.x & 31;
-    #pragma unroll
-    for (int element = 0; element < accumulator.num_elements; ++element) {
-        const int row = row_offset
-                        + d256_bm32_phase_accumulator_row(lane, element);
-        if (row < valid_rows) {
-            const int column =
-                d_offset
-                + d256_bm32_phase_accumulator_column(lane, element);
-            const float inverse_sum = 1.0f / fmaxf(row_sum[row], 1e-24f);
-            output[row * D256_BM32_PHASE_D + column] =
-                __float2half_rn(accumulator.x[element] * inverse_sum);
-        }
+    __half* __restrict__ output, const float* __restrict__ row_sum,
+    int row_offset, int d_offset, int valid_rows) {
+  const int lane = threadIdx.x & 31;
+#pragma unroll
+  for (int element = 0; element < accumulator.num_elements; ++element) {
+    const int row = row_offset + d256_bm32_phase_accumulator_row(lane, element);
+    if (row < valid_rows) {
+      const int column =
+          d_offset + d256_bm32_phase_accumulator_column(lane, element);
+      const float inverse_sum = 1.0f / fmaxf(row_sum[row], 1e-24f);
+      output[row * D256_BM32_PHASE_D + column] =
+          __float2half_rn(accumulator.x[element] * inverse_sum);
     }
+  }
 }
 
 __device__ __forceinline__ void d256_bm32_phase_store_unnormalized_partial(
     const D256BM32PhaseAccumulatorFragment& accumulator,
-    float* __restrict__ output,
-    int row_offset,
-    int d_offset,
-    int valid_rows) {
-    const int lane = threadIdx.x & 31;
-    #pragma unroll
-    for (int element = 0; element < accumulator.num_elements; ++element) {
-        const int row = row_offset
-                        + d256_bm32_phase_accumulator_row(lane, element);
-        if (row < valid_rows) {
-            const int column =
-                d_offset
-                + d256_bm32_phase_accumulator_column(lane, element);
-            output[row * D256_BM32_PHASE_D + column] = accumulator.x[element];
-        }
+    float* __restrict__ output, int row_offset, int d_offset, int valid_rows) {
+  const int lane = threadIdx.x & 31;
+#pragma unroll
+  for (int element = 0; element < accumulator.num_elements; ++element) {
+    const int row = row_offset + d256_bm32_phase_accumulator_row(lane, element);
+    if (row < valid_rows) {
+      const int column =
+          d_offset + d256_bm32_phase_accumulator_column(lane, element);
+      output[row * D256_BM32_PHASE_D + column] = accumulator.x[element];
     }
+  }
 }
 
-template<bool IS_CAUSAL, bool ALL_P = false, bool PAIR_SCRATCH = false,
-         bool SPLIT_KV = false, bool CHECK_SPLIT_EMPTY = true>
-__device__ __forceinline__
-void flash_attention_forward_paged_d256_bm32_phase_body(
-    const __half* __restrict__ Q,
-    const __half* __restrict__ K_cache,
-    const __half* __restrict__ V_cache,
-          __half* __restrict__ Out,
-           float* __restrict__ softmax_lse,
-    const int* __restrict__ block_table,
-    const int* __restrict__ seqused_k,
-    int H,
-    int M,
-    int max_num_blocks_per_seq,
-    int num_kv_heads,
-    int64_t k_block_stride,
-    int64_t k_token_stride,
-    int64_t k_head_stride,
-    int64_t v_block_stride,
-    int64_t v_token_stride,
-    int64_t v_head_stride,
-    float softmax_scale,
-    float* __restrict__ split_tmp_out,
-    float* __restrict__ split_tmp_row_max,
-    float* __restrict__ split_tmp_row_sum,
-    int split_actual_n) {
-    constexpr float NEG_INF = -1e30f;
-    static_assert(!SPLIT_KV || (ALL_P && PAIR_SCRATCH),
-                  "BM32 split-KV requires the accepted all-P pair-scratch body");
-    __shared__ __align__(16)
-        typename D256BM32PhaseSharedStorageSelector<
-            SPLIT_KV,
-            ALL_P ? D256_BM32_PHASE_PANELS : 1>::Type shared;
+template <bool IS_CAUSAL, bool ALL_P = false, bool PAIR_SCRATCH = false,
+          bool SPLIT_KV = false, bool CHECK_SPLIT_EMPTY = true>
+__device__ __forceinline__ void
+flash_attention_forward_paged_d256_bm32_phase_body(
+    const __half* __restrict__ Q, const __half* __restrict__ K_cache,
+    const __half* __restrict__ V_cache, __half* __restrict__ Out,
+    float* __restrict__ softmax_lse, const int* __restrict__ block_table,
+    const int* __restrict__ seqused_k, int H, int M, int max_num_blocks_per_seq,
+    int num_kv_heads, int64_t k_block_stride, int64_t k_token_stride,
+    int64_t k_head_stride, int64_t v_block_stride, int64_t v_token_stride,
+    int64_t v_head_stride, float softmax_scale,
+    float* __restrict__ split_tmp_out, float* __restrict__ split_tmp_row_max,
+    float* __restrict__ split_tmp_row_sum, int split_actual_n) {
+  constexpr float NEG_INF = -1e30f;
+  static_assert(!SPLIT_KV || (ALL_P && PAIR_SCRATCH),
+                "BM32 split-KV requires the accepted all-P pair-scratch body");
+  __shared__ __align__(16) typename D256BM32PhaseSharedStorageSelector<
+      SPLIT_KV, ALL_P ? D256_BM32_PHASE_PANELS : 1>::Type shared;
 
-    const int start_row = blockIdx.x * D256_BM32_PHASE_BLOCK_M;
-    const int tid = threadIdx.x;
-    const int warp_id = tid >> 5;
-    const int lane_id = tid & 31;
-    const int valid_q_rows =
-        min(D256_BM32_PHASE_BLOCK_M, M - start_row);
+  const int start_row = blockIdx.x * D256_BM32_PHASE_BLOCK_M;
+  const int tid = threadIdx.x;
+  const int warp_id = tid >> 5;
+  const int lane_id = tid & 31;
+  const int valid_q_rows = min(D256_BM32_PHASE_BLOCK_M, M - start_row);
 
-    {
-        const __half* q_ptr =
-            Q + static_cast<size_t>(blockIdx.z) * M * D256_BM32_PHASE_D
-            + start_row * D256_BM32_PHASE_D;
-        if (valid_q_rows == D256_BM32_PHASE_BLOCK_M) {
-            d256_bm32_phase_stage_query(q_ptr, shared.query);
-        } else {
-            d256_bm32_phase_stage_query_partial(
-                q_ptr, shared.query, valid_q_rows);
-        }
+  {
+    const __half* q_ptr =
+        Q + static_cast<size_t>(blockIdx.z) * M * D256_BM32_PHASE_D +
+        start_row * D256_BM32_PHASE_D;
+    if (valid_q_rows == D256_BM32_PHASE_BLOCK_M) {
+      d256_bm32_phase_stage_query(q_ptr, shared.query);
+    } else {
+      d256_bm32_phase_stage_query_partial(q_ptr, shared.query, valid_q_rows);
     }
-    if (tid < D256_BM32_PHASE_BLOCK_M) {
-        shared.row_max[tid] = NEG_INF;
-        shared.row_sum[tid] = 0.0f;
+  }
+  if (tid < D256_BM32_PHASE_BLOCK_M) {
+    shared.row_max[tid] = NEG_INF;
+    shared.row_sum[tid] = 0.0f;
+  }
+  if (tid == 0) {
+    shared.block_index = 0;
+    shared.batch_id = blockIdx.z / H;
+    shared.kv_head_id = (blockIdx.z % H) / (H / num_kv_heads);
+    if constexpr (SPLIT_KV) {
+      shared.actual_n = split_actual_n;
+    } else {
+      shared.actual_n = seqused_k[shared.batch_id];
     }
+  }
+  __syncthreads();
+
+  const int total_n_blocks =
+      (shared.actual_n + D256_BM32_PHASE_BLOCK_N - 1) / D256_BM32_PHASE_BLOCK_N;
+  if constexpr (SPLIT_KV) {
     if (tid == 0) {
-        shared.block_index = 0;
-        shared.batch_id = blockIdx.z / H;
-        shared.kv_head_id =
-            (blockIdx.z % H) / (H / num_kv_heads);
-        if constexpr (SPLIT_KV) {
-            shared.actual_n = split_actual_n;
-        } else {
-            shared.actual_n = seqused_k[shared.batch_id];
-        }
+      shared.block_index = static_cast<int>(blockIdx.y) * total_n_blocks /
+                           D256_BM32_PHASE_SPLIT_PARTS;
+      shared.split_end_block = (static_cast<int>(blockIdx.y) + 1) *
+                               total_n_blocks / D256_BM32_PHASE_SPLIT_PARTS;
+    }
+    __syncthreads();
+  }
+
+  D256BM32PhaseAccumulatorFragment accumulator_top;
+  D256BM32PhaseAccumulatorFragment accumulator_bottom;
+  fill_fragment(accumulator_top, 0.0f);
+  fill_fragment(accumulator_bottom, 0.0f);
+
+  for (;;) {
+    if constexpr (SPLIT_KV) {
+      if (shared.block_index >= shared.split_end_block) {
+        break;
+      }
+    } else {
+      if (shared.block_index >= total_n_blocks) {
+        break;
+      }
+    }
+    const int start_col = shared.block_index * D256_BM32_PHASE_BLOCK_N;
+    const int valid_k_rows =
+        min(D256_BM32_PHASE_BLOCK_N, shared.actual_n - start_col);
+
+    if (tid < D256_BM32_PHASE_PAGE_SLOTS) {
+      const int token_offset = tid * D256_BM32_PHASE_PAGE_SIZE;
+      if (token_offset < valid_k_rows) {
+        const int global_token_idx = start_col + token_offset;
+        const int virtual_block_idx =
+            global_token_idx / D256_BM32_PHASE_PAGE_BLOCK_SIZE;
+        shared.page_idx[tid] =
+            __ldg(&block_table[shared.batch_id * max_num_blocks_per_seq +
+                               virtual_block_idx]);
+        shared.page_offset[tid] =
+            global_token_idx -
+            virtual_block_idx * D256_BM32_PHASE_PAGE_BLOCK_SIZE;
+        shared.k_tile_ptr[tid] = reinterpret_cast<uint64_t>(
+            K_cache + (int64_t)shared.page_idx[tid] * k_block_stride +
+            (int64_t)shared.page_offset[tid] * k_token_stride +
+            (int64_t)shared.kv_head_id * k_head_stride);
+        shared.v_tile_ptr[tid] = reinterpret_cast<uint64_t>(
+            V_cache + (int64_t)shared.page_idx[tid] * v_block_stride +
+            (int64_t)shared.page_offset[tid] * v_token_stride +
+            (int64_t)shared.kv_head_id * v_head_stride);
+      } else {
+        shared.page_idx[tid] = -1;
+        shared.page_offset[tid] = 0;
+        shared.k_tile_ptr[tid] = 0;
+        shared.v_tile_ptr[tid] = 0;
+      }
     }
     __syncthreads();
 
-    const int total_n_blocks =
-        (shared.actual_n + D256_BM32_PHASE_BLOCK_N - 1)
-        / D256_BM32_PHASE_BLOCK_N;
+    if (warp_id < D256_BM32_PHASE_BLOCK_N / WMMA_N &&
+        warp_id * WMMA_N < valid_k_rows) {
+      const int tile_n = warp_id * WMMA_N;
+      const __half* k_tile =
+          reinterpret_cast<const __half*>(shared.k_tile_ptr[warp_id]);
+      if constexpr (PAIR_SCRATCH) {
+        d256_bm32_phase_spill_pair_scratch(shared.score, accumulator_top,
+                                           accumulator_bottom);
+      } else {
+        store_matrix_sync(shared.score + tile_n, accumulator_top,
+                          D256_BM32_PHASE_BLOCK_N, mem_row_major);
+        store_matrix_sync(
+            shared.score + D256_BM32_PHASE_PANEL_M * D256_BM32_PHASE_BLOCK_N +
+                tile_n,
+            accumulator_bottom, D256_BM32_PHASE_BLOCK_N, mem_row_major);
+      }
+      asm volatile("" ::: "memory");
+
+      D256BM32PhaseAccumulatorFragment qk_top;
+      D256BM32PhaseAccumulatorFragment qk_bottom;
+      {
+        D256BM32PhaseMatrixAFragment a_fragment;
+        D256BM32PhaseQKMatrixBFragment b_fragment;
+        fill_fragment(qk_top, 0.0f);
+        fill_fragment(qk_bottom, 0.0f);
+
+#pragma unroll
+        for (int k_offset = 0; k_offset < D256_BM32_PHASE_D;
+             k_offset += WMMA_K) {
+          load_matrix_sync(b_fragment, k_tile + k_offset, k_token_stride);
+          d256_bm32_phase_load_matrix_a(a_fragment, shared.query, k_offset);
+          mma_sync(qk_top, a_fragment, b_fragment, qk_top);
+          d256_bm32_phase_load_matrix_a(
+              a_fragment,
+              shared.query + D256_BM32_PHASE_PANEL_M * D256_BM32_PHASE_D,
+              k_offset);
+          mma_sync(qk_bottom, a_fragment, b_fragment, qk_bottom);
+        }
+      }
+      asm volatile("" ::: "memory");
+
+      if constexpr (PAIR_SCRATCH) {
+        d256_bm32_phase_reload_pair_scratch(shared.score, accumulator_top,
+                                            accumulator_bottom);
+        const int partner_warp = warp_id ^ 1;
+        if (partner_warp * WMMA_N < valid_k_rows) {
+          d256_bm32_phase_sync_warp_pair(warp_id >> 1);
+        }
+      } else {
+        load_matrix_sync(accumulator_top, shared.score + tile_n,
+                         D256_BM32_PHASE_BLOCK_N, mem_row_major);
+        load_matrix_sync(accumulator_bottom,
+                         shared.score +
+                             D256_BM32_PHASE_PANEL_M * D256_BM32_PHASE_BLOCK_N +
+                             tile_n,
+                         D256_BM32_PHASE_BLOCK_N, mem_row_major);
+      }
+
+      store_matrix_sync(shared.score + tile_n, qk_top, D256_BM32_PHASE_BLOCK_N,
+                        mem_row_major);
+      store_matrix_sync(shared.score +
+                            D256_BM32_PHASE_PANEL_M * D256_BM32_PHASE_BLOCK_N +
+                            tile_n,
+                        qk_bottom, D256_BM32_PHASE_BLOCK_N, mem_row_major);
+    }
+    __syncthreads();
+
+    const int causal_q_offset = max(shared.actual_n - M, 0);
+#pragma unroll 1
+    for (int index = tid;
+         index < D256_BM32_PHASE_BLOCK_M * D256_BM32_PHASE_BLOCK_N;
+         index += D256_BM32_PHASE_THREADS) {
+      const int row = index / D256_BM32_PHASE_BLOCK_N;
+      const int column = index - row * D256_BM32_PHASE_BLOCK_N;
+      const int global_m = start_row + row;
+      const int global_n = start_col + column;
+      const bool is_valid = global_m < M && global_n < start_col + valid_k_rows;
+      if constexpr (IS_CAUSAL) {
+        if (is_valid && global_n <= global_m + causal_q_offset) {
+          shared.score[index] *= softmax_scale;
+        } else {
+          shared.score[index] = NEG_INF;
+        }
+      } else {
+        if (is_valid) {
+          shared.score[index] *= softmax_scale;
+        } else {
+          shared.score[index] = NEG_INF;
+        }
+      }
+    }
+    __syncthreads();
+
+    if constexpr (ALL_P) {
+#pragma unroll
+      for (int panel = 0; panel < D256_BM32_PHASE_PANELS; ++panel) {
+        const int panel_start = panel * D256_BM32_PHASE_SOFTMAX_N;
+        const int valid_panel_columns =
+            min(D256_BM32_PHASE_SOFTMAX_N, valid_k_rows - panel_start);
+        if (valid_panel_columns > 0) {
+          __half* probability_top =
+              shared.probability_top +
+              panel * D256_BM32_PHASE_PROBABILITY_ELEMENTS;
+          __half* probability_bottom =
+              shared.probability_bottom +
+              panel * D256_BM32_PHASE_PROBABILITY_ELEMENTS;
+          float* row_exp_diff =
+              shared.row_exp_diff + panel * D256_BM32_PHASE_BLOCK_M;
+          float top_exp_diff;
+          float bottom_exp_diff;
+          if constexpr (SPLIT_KV && CHECK_SPLIT_EMPTY) {
+            const int first_global_n = start_col + panel_start;
+            const bool top_has_visible_value =
+                warp_id < valid_q_rows &&
+                (!IS_CAUSAL ||
+                 first_global_n <= start_row + warp_id + causal_q_offset);
+            const bool bottom_has_visible_value =
+                D256_BM32_PHASE_PANEL_M + warp_id < valid_q_rows &&
+                (!IS_CAUSAL || first_global_n <= start_row +
+                                                     D256_BM32_PHASE_PANEL_M +
+                                                     warp_id + causal_q_offset);
+            top_exp_diff = d256_bm32_phase_make_split_probability_row(
+                shared.score + warp_id * D256_BM32_PHASE_BLOCK_N,
+                probability_top, warp_id, shared.row_max, shared.row_sum,
+                warp_id, panel, NEG_INF, top_has_visible_value);
+            bottom_exp_diff = d256_bm32_phase_make_split_probability_row(
+                shared.score + (D256_BM32_PHASE_PANEL_M + warp_id) *
+                                   D256_BM32_PHASE_BLOCK_N,
+                probability_bottom, warp_id, shared.row_max, shared.row_sum,
+                D256_BM32_PHASE_PANEL_M + warp_id, panel, NEG_INF,
+                bottom_has_visible_value);
+          } else {
+            top_exp_diff = d256_bm32_phase_make_probability_row(
+                shared.score + warp_id * D256_BM32_PHASE_BLOCK_N,
+                probability_top, warp_id, shared.row_max, shared.row_sum,
+                warp_id, panel, NEG_INF);
+            bottom_exp_diff = d256_bm32_phase_make_probability_row(
+                shared.score + (D256_BM32_PHASE_PANEL_M + warp_id) *
+                                   D256_BM32_PHASE_BLOCK_N,
+                probability_bottom, warp_id, shared.row_max, shared.row_sum,
+                D256_BM32_PHASE_PANEL_M + warp_id, panel, NEG_INF);
+          }
+          if (lane_id == 0) {
+            row_exp_diff[warp_id] = top_exp_diff;
+            row_exp_diff[D256_BM32_PHASE_PANEL_M + warp_id] = bottom_exp_diff;
+          }
+        }
+        // Publish lane 0's online-softmax state to this warp before
+        // it advances to the next panel.
+        __syncwarp();
+      }
+      __syncthreads();
+
+#pragma unroll
+      for (int panel = 0; panel < D256_BM32_PHASE_PANELS; ++panel) {
+        const int panel_start = panel * D256_BM32_PHASE_SOFTMAX_N;
+        const int valid_panel_columns =
+            min(D256_BM32_PHASE_SOFTMAX_N, valid_k_rows - panel_start);
+        if (valid_panel_columns > 0) {
+          const __half* probability_top =
+              shared.probability_top +
+              panel * D256_BM32_PHASE_PROBABILITY_ELEMENTS;
+          const __half* probability_bottom =
+              shared.probability_bottom +
+              panel * D256_BM32_PHASE_PROBABILITY_ELEMENTS;
+          const float* row_exp_diff =
+              shared.row_exp_diff + panel * D256_BM32_PHASE_BLOCK_M;
+          if constexpr (SPLIT_KV) {
+            d256_bm32_phase_scale_accumulators(
+                accumulator_top, accumulator_bottom, row_exp_diff);
+          } else if (shared.block_index != 0 || panel != 0) {
+            d256_bm32_phase_scale_accumulators(
+                accumulator_top, accumulator_bottom, row_exp_diff);
+          }
+          const int page_slot_k0 = panel_start >> 4;
+          const __half* value_k0 =
+              reinterpret_cast<const __half*>(shared.v_tile_ptr[page_slot_k0]);
+          const __half* value_k16 = nullptr;
+          if (valid_panel_columns > WMMA_K) {
+            const int page_slot_k16 = (panel_start + WMMA_K) >> 4;
+            value_k16 = reinterpret_cast<const __half*>(
+                shared.v_tile_ptr[page_slot_k16]);
+          }
+          d256_bm32_phase_update_pv_panel(probability_top, probability_bottom,
+                                          value_k0, value_k16, v_token_stride,
+                                          warp_id * WMMA_N, valid_panel_columns,
+                                          accumulator_top, accumulator_bottom);
+        }
+      }
+      // Protect the current V pointers and block index from the next
+      // iteration while slower warps finish the last PV panel.
+      __syncthreads();
+    } else {
+#pragma unroll
+      for (int panel = 0; panel < D256_BM32_PHASE_PANELS; ++panel) {
+        const int panel_start = panel * D256_BM32_PHASE_SOFTMAX_N;
+        const int valid_panel_columns =
+            min(D256_BM32_PHASE_SOFTMAX_N, valid_k_rows - panel_start);
+        if (valid_panel_columns > 0) {
+          const float top_exp_diff = d256_bm32_phase_make_probability_row(
+              shared.score + warp_id * D256_BM32_PHASE_BLOCK_N,
+              shared.probability_top, warp_id, shared.row_max, shared.row_sum,
+              warp_id, panel, NEG_INF);
+          const float bottom_exp_diff = d256_bm32_phase_make_probability_row(
+              shared.score +
+                  (D256_BM32_PHASE_PANEL_M + warp_id) * D256_BM32_PHASE_BLOCK_N,
+              shared.probability_bottom, warp_id, shared.row_max,
+              shared.row_sum, D256_BM32_PHASE_PANEL_M + warp_id, panel,
+              NEG_INF);
+          if (lane_id == 0) {
+            shared.row_exp_diff[warp_id] = top_exp_diff;
+            shared.row_exp_diff[D256_BM32_PHASE_PANEL_M + warp_id] =
+                bottom_exp_diff;
+          }
+        }
+        __syncthreads();
+
+        if (valid_panel_columns > 0) {
+          if constexpr (SPLIT_KV) {
+            d256_bm32_phase_scale_accumulators(
+                accumulator_top, accumulator_bottom, shared.row_exp_diff);
+          } else if (shared.block_index != 0 || panel != 0) {
+            d256_bm32_phase_scale_accumulators(
+                accumulator_top, accumulator_bottom, shared.row_exp_diff);
+          }
+          const int page_slot_k0 = panel_start >> 4;
+          const __half* value_k0 =
+              reinterpret_cast<const __half*>(shared.v_tile_ptr[page_slot_k0]);
+          const __half* value_k16 = nullptr;
+          if (valid_panel_columns > WMMA_K) {
+            const int page_slot_k16 = (panel_start + WMMA_K) >> 4;
+            value_k16 = reinterpret_cast<const __half*>(
+                shared.v_tile_ptr[page_slot_k16]);
+          }
+          d256_bm32_phase_update_pv_panel(
+              shared.probability_top, shared.probability_bottom, value_k0,
+              value_k16, v_token_stride, warp_id * WMMA_N, valid_panel_columns,
+              accumulator_top, accumulator_bottom);
+        }
+        __syncthreads();
+      }
+    }
+
+    if (tid == 0) {
+      ++shared.block_index;
+    }
+    __syncthreads();
+  }
+
+  {
+    const size_t q_head_linear = static_cast<size_t>(blockIdx.z);
     if constexpr (SPLIT_KV) {
-        if (tid == 0) {
-            shared.block_index =
-                static_cast<int>(blockIdx.y) * total_n_blocks
-                / D256_BM32_PHASE_SPLIT_PARTS;
-            shared.split_end_block =
-                (static_cast<int>(blockIdx.y) + 1) * total_n_blocks
-                / D256_BM32_PHASE_SPLIT_PARTS;
-        }
-        __syncthreads();
+      const size_t partial_row_base =
+          (q_head_linear * D256_BM32_PHASE_SPLIT_PARTS +
+           static_cast<int>(blockIdx.y)) *
+              M +
+          start_row;
+      float* partial_out = split_tmp_out + partial_row_base * D256_BM32_PHASE_D;
+      d256_bm32_phase_store_unnormalized_partial(
+          accumulator_top, partial_out, 0, warp_id * WMMA_N, valid_q_rows);
+      d256_bm32_phase_store_unnormalized_partial(
+          accumulator_bottom, partial_out, D256_BM32_PHASE_PANEL_M,
+          warp_id * WMMA_N, valid_q_rows);
+      if (tid < valid_q_rows) {
+        split_tmp_row_max[partial_row_base + tid] = shared.row_max[tid];
+        split_tmp_row_sum[partial_row_base + tid] = shared.row_sum[tid];
+      }
+    } else {
+      __half* out_ptr = Out + q_head_linear * M * D256_BM32_PHASE_D +
+                        start_row * D256_BM32_PHASE_D;
+      float* softmax_lse_ptr = softmax_lse + q_head_linear * M + start_row;
+      if (valid_q_rows == D256_BM32_PHASE_BLOCK_M) {
+        d256_bm32_phase_store_output(accumulator_top, out_ptr, shared.row_sum,
+                                     0, warp_id * WMMA_N);
+        d256_bm32_phase_store_output(accumulator_bottom, out_ptr,
+                                     shared.row_sum, D256_BM32_PHASE_PANEL_M,
+                                     warp_id * WMMA_N);
+      } else {
+        d256_bm32_phase_store_output_partial(accumulator_top, out_ptr,
+                                             shared.row_sum, 0,
+                                             warp_id * WMMA_N, valid_q_rows);
+        d256_bm32_phase_store_output_partial(
+            accumulator_bottom, out_ptr, shared.row_sum,
+            D256_BM32_PHASE_PANEL_M, warp_id * WMMA_N, valid_q_rows);
+      }
+
+      if (tid < valid_q_rows) {
+        const float sum = fmaxf(shared.row_sum[tid], 1e-24f);
+        softmax_lse_ptr[tid] = shared.row_max[tid] + logf(sum);
+      }
     }
-
-    D256BM32PhaseAccumulatorFragment accumulator_top;
-    D256BM32PhaseAccumulatorFragment accumulator_bottom;
-    fill_fragment(accumulator_top, 0.0f);
-    fill_fragment(accumulator_bottom, 0.0f);
-
-    for (;;) {
-        if constexpr (SPLIT_KV) {
-            if (shared.block_index >= shared.split_end_block) {
-                break;
-            }
-        } else {
-            if (shared.block_index >= total_n_blocks) {
-                break;
-            }
-        }
-        const int start_col =
-            shared.block_index * D256_BM32_PHASE_BLOCK_N;
-        const int valid_k_rows = min(D256_BM32_PHASE_BLOCK_N,
-                                     shared.actual_n - start_col);
-
-        if (tid < D256_BM32_PHASE_PAGE_SLOTS) {
-            const int token_offset = tid * D256_BM32_PHASE_PAGE_SIZE;
-            if (token_offset < valid_k_rows) {
-                const int global_token_idx = start_col + token_offset;
-                const int virtual_block_idx =
-                    global_token_idx / D256_BM32_PHASE_PAGE_BLOCK_SIZE;
-                shared.page_idx[tid] =
-                    __ldg(&block_table[shared.batch_id
-                                       * max_num_blocks_per_seq
-                                       + virtual_block_idx]);
-                shared.page_offset[tid] =
-                    global_token_idx
-                    - virtual_block_idx * D256_BM32_PHASE_PAGE_BLOCK_SIZE;
-                shared.k_tile_ptr[tid] = reinterpret_cast<uint64_t>(
-                    K_cache
-                    + (int64_t)shared.page_idx[tid] * k_block_stride
-                    + (int64_t)shared.page_offset[tid] * k_token_stride
-                    + (int64_t)shared.kv_head_id * k_head_stride);
-                shared.v_tile_ptr[tid] = reinterpret_cast<uint64_t>(
-                    V_cache
-                    + (int64_t)shared.page_idx[tid] * v_block_stride
-                    + (int64_t)shared.page_offset[tid] * v_token_stride
-                    + (int64_t)shared.kv_head_id * v_head_stride);
-            } else {
-                shared.page_idx[tid] = -1;
-                shared.page_offset[tid] = 0;
-                shared.k_tile_ptr[tid] = 0;
-                shared.v_tile_ptr[tid] = 0;
-            }
-        }
-        __syncthreads();
-
-        if (warp_id < D256_BM32_PHASE_BLOCK_N / WMMA_N
-            && warp_id * WMMA_N < valid_k_rows) {
-            const int tile_n = warp_id * WMMA_N;
-            const __half* k_tile =
-                reinterpret_cast<const __half*>(shared.k_tile_ptr[warp_id]);
-            if constexpr (PAIR_SCRATCH) {
-                d256_bm32_phase_spill_pair_scratch(
-                    shared.score, accumulator_top, accumulator_bottom);
-            } else {
-                store_matrix_sync(shared.score + tile_n, accumulator_top,
-                                  D256_BM32_PHASE_BLOCK_N, mem_row_major);
-                store_matrix_sync(
-                    shared.score + D256_BM32_PHASE_PANEL_M
-                                       * D256_BM32_PHASE_BLOCK_N + tile_n,
-                    accumulator_bottom, D256_BM32_PHASE_BLOCK_N,
-                    mem_row_major);
-            }
-            asm volatile("" ::: "memory");
-
-            D256BM32PhaseAccumulatorFragment qk_top;
-            D256BM32PhaseAccumulatorFragment qk_bottom;
-            {
-                D256BM32PhaseMatrixAFragment a_fragment;
-                D256BM32PhaseQKMatrixBFragment b_fragment;
-                fill_fragment(qk_top, 0.0f);
-                fill_fragment(qk_bottom, 0.0f);
-
-                #pragma unroll
-                for (int k_offset = 0; k_offset < D256_BM32_PHASE_D;
-                     k_offset += WMMA_K) {
-                    load_matrix_sync(b_fragment, k_tile + k_offset,
-                                     k_token_stride);
-                    d256_bm32_phase_load_matrix_a(
-                        a_fragment, shared.query, k_offset);
-                    mma_sync(qk_top, a_fragment, b_fragment, qk_top);
-                    d256_bm32_phase_load_matrix_a(
-                        a_fragment,
-                        shared.query
-                            + D256_BM32_PHASE_PANEL_M
-                                  * D256_BM32_PHASE_D,
-                        k_offset);
-                    mma_sync(qk_bottom, a_fragment, b_fragment, qk_bottom);
-                }
-            }
-            asm volatile("" ::: "memory");
-
-            if constexpr (PAIR_SCRATCH) {
-                d256_bm32_phase_reload_pair_scratch(
-                    shared.score, accumulator_top, accumulator_bottom);
-                const int partner_warp = warp_id ^ 1;
-                if (partner_warp * WMMA_N < valid_k_rows) {
-                    d256_bm32_phase_sync_warp_pair(warp_id >> 1);
-                }
-            } else {
-                load_matrix_sync(accumulator_top, shared.score + tile_n,
-                                 D256_BM32_PHASE_BLOCK_N, mem_row_major);
-                load_matrix_sync(
-                    accumulator_bottom,
-                    shared.score + D256_BM32_PHASE_PANEL_M
-                                       * D256_BM32_PHASE_BLOCK_N + tile_n,
-                    D256_BM32_PHASE_BLOCK_N, mem_row_major);
-            }
-
-            store_matrix_sync(shared.score + tile_n, qk_top,
-                              D256_BM32_PHASE_BLOCK_N, mem_row_major);
-            store_matrix_sync(
-                shared.score + D256_BM32_PHASE_PANEL_M
-                                   * D256_BM32_PHASE_BLOCK_N + tile_n,
-                qk_bottom, D256_BM32_PHASE_BLOCK_N, mem_row_major);
-        }
-        __syncthreads();
-
-        const int causal_q_offset = max(shared.actual_n - M, 0);
-        #pragma unroll 1
-        for (int index = tid;
-             index < D256_BM32_PHASE_BLOCK_M * D256_BM32_PHASE_BLOCK_N;
-             index += D256_BM32_PHASE_THREADS) {
-            const int row = index / D256_BM32_PHASE_BLOCK_N;
-            const int column = index - row * D256_BM32_PHASE_BLOCK_N;
-            const int global_m = start_row + row;
-            const int global_n = start_col + column;
-            const bool is_valid = global_m < M
-                                  && global_n < start_col + valid_k_rows;
-            if constexpr (IS_CAUSAL) {
-                if (is_valid && global_n <= global_m + causal_q_offset) {
-                    shared.score[index] *= softmax_scale;
-                } else {
-                    shared.score[index] = NEG_INF;
-                }
-            } else {
-                if (is_valid) {
-                    shared.score[index] *= softmax_scale;
-                } else {
-                    shared.score[index] = NEG_INF;
-                }
-            }
-        }
-        __syncthreads();
-
-        if constexpr (ALL_P) {
-            #pragma unroll
-            for (int panel = 0; panel < D256_BM32_PHASE_PANELS;
-                 ++panel) {
-                const int panel_start =
-                    panel * D256_BM32_PHASE_SOFTMAX_N;
-                const int valid_panel_columns =
-                    min(D256_BM32_PHASE_SOFTMAX_N,
-                        valid_k_rows - panel_start);
-                if (valid_panel_columns > 0) {
-                    __half* probability_top =
-                        shared.probability_top
-                        + panel * D256_BM32_PHASE_PROBABILITY_ELEMENTS;
-                    __half* probability_bottom =
-                        shared.probability_bottom
-                        + panel * D256_BM32_PHASE_PROBABILITY_ELEMENTS;
-                    float* row_exp_diff =
-                        shared.row_exp_diff
-                        + panel * D256_BM32_PHASE_BLOCK_M;
-                    float top_exp_diff;
-                    float bottom_exp_diff;
-                    if constexpr (SPLIT_KV && CHECK_SPLIT_EMPTY) {
-                        const int first_global_n = start_col + panel_start;
-                        const bool top_has_visible_value =
-                            warp_id < valid_q_rows
-                            && (!IS_CAUSAL
-                                || first_global_n
-                                       <= start_row + warp_id
-                                              + causal_q_offset);
-                        const bool bottom_has_visible_value =
-                            D256_BM32_PHASE_PANEL_M + warp_id < valid_q_rows
-                            && (!IS_CAUSAL
-                                || first_global_n
-                                       <= start_row
-                                              + D256_BM32_PHASE_PANEL_M
-                                              + warp_id + causal_q_offset);
-                        top_exp_diff =
-                            d256_bm32_phase_make_split_probability_row(
-                                shared.score
-                                    + warp_id * D256_BM32_PHASE_BLOCK_N,
-                                probability_top, warp_id, shared.row_max,
-                                shared.row_sum, warp_id, panel, NEG_INF,
-                                top_has_visible_value);
-                        bottom_exp_diff =
-                            d256_bm32_phase_make_split_probability_row(
-                                shared.score
-                                    + (D256_BM32_PHASE_PANEL_M + warp_id)
-                                          * D256_BM32_PHASE_BLOCK_N,
-                                probability_bottom, warp_id, shared.row_max,
-                                shared.row_sum,
-                                D256_BM32_PHASE_PANEL_M + warp_id, panel,
-                                NEG_INF, bottom_has_visible_value);
-                    } else {
-                        top_exp_diff = d256_bm32_phase_make_probability_row(
-                            shared.score
-                                + warp_id * D256_BM32_PHASE_BLOCK_N,
-                            probability_top, warp_id, shared.row_max,
-                            shared.row_sum, warp_id, panel, NEG_INF);
-                        bottom_exp_diff =
-                            d256_bm32_phase_make_probability_row(
-                                shared.score
-                                    + (D256_BM32_PHASE_PANEL_M + warp_id)
-                                          * D256_BM32_PHASE_BLOCK_N,
-                                probability_bottom, warp_id, shared.row_max,
-                                shared.row_sum,
-                                D256_BM32_PHASE_PANEL_M + warp_id, panel,
-                                NEG_INF);
-                    }
-                    if (lane_id == 0) {
-                        row_exp_diff[warp_id] = top_exp_diff;
-                        row_exp_diff[D256_BM32_PHASE_PANEL_M + warp_id] =
-                            bottom_exp_diff;
-                    }
-                }
-                // Publish lane 0's online-softmax state to this warp before
-                // it advances to the next panel.
-                __syncwarp();
-            }
-            __syncthreads();
-
-            #pragma unroll
-            for (int panel = 0; panel < D256_BM32_PHASE_PANELS;
-                 ++panel) {
-                const int panel_start =
-                    panel * D256_BM32_PHASE_SOFTMAX_N;
-                const int valid_panel_columns =
-                    min(D256_BM32_PHASE_SOFTMAX_N,
-                        valid_k_rows - panel_start);
-                if (valid_panel_columns > 0) {
-                    const __half* probability_top =
-                        shared.probability_top
-                        + panel * D256_BM32_PHASE_PROBABILITY_ELEMENTS;
-                    const __half* probability_bottom =
-                        shared.probability_bottom
-                        + panel * D256_BM32_PHASE_PROBABILITY_ELEMENTS;
-                    const float* row_exp_diff =
-                        shared.row_exp_diff
-                        + panel * D256_BM32_PHASE_BLOCK_M;
-                    if constexpr (SPLIT_KV) {
-                        d256_bm32_phase_scale_accumulators(
-                            accumulator_top, accumulator_bottom,
-                            row_exp_diff);
-                    } else if (shared.block_index != 0 || panel != 0) {
-                        d256_bm32_phase_scale_accumulators(
-                            accumulator_top, accumulator_bottom,
-                            row_exp_diff);
-                    }
-                    const int page_slot_k0 = panel_start >> 4;
-                    const __half* value_k0 =
-                        reinterpret_cast<const __half*>(
-                            shared.v_tile_ptr[page_slot_k0]);
-                    const __half* value_k16 = nullptr;
-                    if (valid_panel_columns > WMMA_K) {
-                        const int page_slot_k16 =
-                            (panel_start + WMMA_K) >> 4;
-                        value_k16 =
-                            reinterpret_cast<const __half*>(
-                                shared.v_tile_ptr[page_slot_k16]);
-                    }
-                    d256_bm32_phase_update_pv_panel(
-                        probability_top, probability_bottom,
-                        value_k0, value_k16, v_token_stride,
-                        warp_id * WMMA_N,
-                        valid_panel_columns,
-                        accumulator_top, accumulator_bottom);
-                }
-            }
-            // Protect the current V pointers and block index from the next
-            // iteration while slower warps finish the last PV panel.
-            __syncthreads();
-        } else {
-            #pragma unroll
-            for (int panel = 0; panel < D256_BM32_PHASE_PANELS;
-                 ++panel) {
-                const int panel_start =
-                    panel * D256_BM32_PHASE_SOFTMAX_N;
-                const int valid_panel_columns =
-                    min(D256_BM32_PHASE_SOFTMAX_N,
-                        valid_k_rows - panel_start);
-                if (valid_panel_columns > 0) {
-                    const float top_exp_diff =
-                        d256_bm32_phase_make_probability_row(
-                            shared.score
-                                + warp_id * D256_BM32_PHASE_BLOCK_N,
-                            shared.probability_top, warp_id, shared.row_max,
-                            shared.row_sum, warp_id, panel, NEG_INF);
-                    const float bottom_exp_diff =
-                        d256_bm32_phase_make_probability_row(
-                            shared.score
-                                + (D256_BM32_PHASE_PANEL_M + warp_id)
-                                      * D256_BM32_PHASE_BLOCK_N,
-                            shared.probability_bottom, warp_id,
-                            shared.row_max, shared.row_sum,
-                            D256_BM32_PHASE_PANEL_M + warp_id, panel,
-                            NEG_INF);
-                    if (lane_id == 0) {
-                        shared.row_exp_diff[warp_id] = top_exp_diff;
-                        shared.row_exp_diff[
-                            D256_BM32_PHASE_PANEL_M + warp_id] =
-                            bottom_exp_diff;
-                    }
-                }
-                __syncthreads();
-
-                if (valid_panel_columns > 0) {
-                    if constexpr (SPLIT_KV) {
-                        d256_bm32_phase_scale_accumulators(
-                            accumulator_top, accumulator_bottom,
-                            shared.row_exp_diff);
-                    } else if (shared.block_index != 0 || panel != 0) {
-                        d256_bm32_phase_scale_accumulators(
-                            accumulator_top, accumulator_bottom,
-                            shared.row_exp_diff);
-                    }
-                    const int page_slot_k0 = panel_start >> 4;
-                    const __half* value_k0 =
-                        reinterpret_cast<const __half*>(
-                            shared.v_tile_ptr[page_slot_k0]);
-                    const __half* value_k16 = nullptr;
-                    if (valid_panel_columns > WMMA_K) {
-                        const int page_slot_k16 =
-                            (panel_start + WMMA_K) >> 4;
-                        value_k16 =
-                            reinterpret_cast<const __half*>(
-                                shared.v_tile_ptr[page_slot_k16]);
-                    }
-                    d256_bm32_phase_update_pv_panel(
-                        shared.probability_top,
-                        shared.probability_bottom,
-                        value_k0, value_k16, v_token_stride,
-                        warp_id * WMMA_N,
-                        valid_panel_columns,
-                        accumulator_top, accumulator_bottom);
-                }
-                __syncthreads();
-            }
-        }
-
-        if (tid == 0) {
-            ++shared.block_index;
-        }
-        __syncthreads();
-    }
-
-    {
-        const size_t q_head_linear = static_cast<size_t>(blockIdx.z);
-        if constexpr (SPLIT_KV) {
-            const size_t partial_row_base =
-                (q_head_linear * D256_BM32_PHASE_SPLIT_PARTS
-                 + static_cast<int>(blockIdx.y))
-                    * M
-                + start_row;
-            float* partial_out =
-                split_tmp_out
-                + partial_row_base * D256_BM32_PHASE_D;
-            d256_bm32_phase_store_unnormalized_partial(
-                accumulator_top, partial_out, 0,
-                warp_id * WMMA_N, valid_q_rows);
-            d256_bm32_phase_store_unnormalized_partial(
-                accumulator_bottom, partial_out,
-                D256_BM32_PHASE_PANEL_M, warp_id * WMMA_N, valid_q_rows);
-            if (tid < valid_q_rows) {
-                split_tmp_row_max[partial_row_base + tid] =
-                    shared.row_max[tid];
-                split_tmp_row_sum[partial_row_base + tid] =
-                    shared.row_sum[tid];
-            }
-        } else {
-            __half* out_ptr =
-                Out + q_head_linear * M * D256_BM32_PHASE_D
-                + start_row * D256_BM32_PHASE_D;
-            float* softmax_lse_ptr =
-                softmax_lse + q_head_linear * M + start_row;
-            if (valid_q_rows == D256_BM32_PHASE_BLOCK_M) {
-                d256_bm32_phase_store_output(
-                    accumulator_top, out_ptr, shared.row_sum, 0,
-                    warp_id * WMMA_N);
-                d256_bm32_phase_store_output(
-                    accumulator_bottom, out_ptr, shared.row_sum,
-                    D256_BM32_PHASE_PANEL_M, warp_id * WMMA_N);
-            } else {
-                d256_bm32_phase_store_output_partial(
-                    accumulator_top, out_ptr, shared.row_sum, 0,
-                    warp_id * WMMA_N, valid_q_rows);
-                d256_bm32_phase_store_output_partial(
-                    accumulator_bottom, out_ptr, shared.row_sum,
-                    D256_BM32_PHASE_PANEL_M, warp_id * WMMA_N, valid_q_rows);
-            }
-
-            if (tid < valid_q_rows) {
-                const float sum = fmaxf(shared.row_sum[tid], 1e-24f);
-                softmax_lse_ptr[tid] = shared.row_max[tid] + logf(sum);
-            }
-        }
-    }
+  }
 }
 
-template<bool IS_CAUSAL, bool ALL_P = false, bool PAIR_SCRATCH = false>
-__global__ __launch_bounds__(D256_BM32_PHASE_THREADS, 2)
-void flash_attention_forward_paged_d256_bm32_phase_kernel(
-    const __half* __restrict__ Q,
-    const __half* __restrict__ K_cache,
-    const __half* __restrict__ V_cache,
-          __half* __restrict__ Out,
-           float* __restrict__ softmax_lse,
-    const int* __restrict__ block_table,
-    const int* __restrict__ seqused_k,
-    int H,
-    int M,
-    int max_num_blocks_per_seq,
-    int num_kv_heads,
-    int64_t k_block_stride,
-    int64_t k_token_stride,
-    int64_t k_head_stride,
-    int64_t v_block_stride,
-    int64_t v_token_stride,
-    int64_t v_head_stride,
-    float softmax_scale) {
-    flash_attention_forward_paged_d256_bm32_phase_body<
-        IS_CAUSAL, ALL_P, PAIR_SCRATCH, false>(
-            Q, K_cache, V_cache, Out, softmax_lse, block_table, seqused_k,
-            H, M, max_num_blocks_per_seq, num_kv_heads, k_block_stride,
-            k_token_stride, k_head_stride, v_block_stride, v_token_stride,
-            v_head_stride, softmax_scale, nullptr, nullptr, nullptr, 0);
+template <bool IS_CAUSAL, bool ALL_P = false, bool PAIR_SCRATCH = false>
+__global__
+__launch_bounds__(D256_BM32_PHASE_THREADS, 2) void flash_attention_forward_paged_d256_bm32_phase_kernel(
+    const __half* __restrict__ Q, const __half* __restrict__ K_cache,
+    const __half* __restrict__ V_cache, __half* __restrict__ Out,
+    float* __restrict__ softmax_lse, const int* __restrict__ block_table,
+    const int* __restrict__ seqused_k, int H, int M, int max_num_blocks_per_seq,
+    int num_kv_heads, int64_t k_block_stride, int64_t k_token_stride,
+    int64_t k_head_stride, int64_t v_block_stride, int64_t v_token_stride,
+    int64_t v_head_stride, float softmax_scale) {
+  flash_attention_forward_paged_d256_bm32_phase_body<IS_CAUSAL, ALL_P,
+                                                     PAIR_SCRATCH, false>(
+      Q, K_cache, V_cache, Out, softmax_lse, block_table, seqused_k, H, M,
+      max_num_blocks_per_seq, num_kv_heads, k_block_stride, k_token_stride,
+      k_head_stride, v_block_stride, v_token_stride, v_head_stride,
+      softmax_scale, nullptr, nullptr, nullptr, 0);
 }
 
-template<bool CHECK_SPLIT_EMPTY>
-__global__ __launch_bounds__(D256_BM32_PHASE_THREADS, 2)
-void flash_attention_forward_paged_d256_bm32_splitkv3_partial_kernel(
-    const __half* __restrict__ Q,
-    const __half* __restrict__ K_cache,
-    const __half* __restrict__ V_cache,
-    const int* __restrict__ block_table,
-    int H,
-    int M,
-    int actual_n,
-    int max_num_blocks_per_seq,
-    int num_kv_heads,
-    int64_t k_block_stride,
-    int64_t k_token_stride,
-    int64_t k_head_stride,
-    int64_t v_block_stride,
-    int64_t v_token_stride,
-    int64_t v_head_stride,
-    float softmax_scale,
-    float* __restrict__ split_tmp_out,
+template <bool CHECK_SPLIT_EMPTY>
+__global__
+__launch_bounds__(D256_BM32_PHASE_THREADS, 2) void flash_attention_forward_paged_d256_bm32_splitkv3_partial_kernel(
+    const __half* __restrict__ Q, const __half* __restrict__ K_cache,
+    const __half* __restrict__ V_cache, const int* __restrict__ block_table,
+    int H, int M, int actual_n, int max_num_blocks_per_seq, int num_kv_heads,
+    int64_t k_block_stride, int64_t k_token_stride, int64_t k_head_stride,
+    int64_t v_block_stride, int64_t v_token_stride, int64_t v_head_stride,
+    float softmax_scale, float* __restrict__ split_tmp_out,
     float* __restrict__ split_tmp_row_max,
     float* __restrict__ split_tmp_row_sum) {
-    flash_attention_forward_paged_d256_bm32_phase_body<
-        true, true, true, true, CHECK_SPLIT_EMPTY>(
-            Q, K_cache, V_cache, nullptr, nullptr, block_table, nullptr,
-            H, M, max_num_blocks_per_seq, num_kv_heads, k_block_stride,
-            k_token_stride, k_head_stride, v_block_stride, v_token_stride,
-            v_head_stride, softmax_scale, split_tmp_out,
-            split_tmp_row_max, split_tmp_row_sum, actual_n);
+  flash_attention_forward_paged_d256_bm32_phase_body<true, true, true, true,
+                                                     CHECK_SPLIT_EMPTY>(
+      Q, K_cache, V_cache, nullptr, nullptr, block_table, nullptr, H, M,
+      max_num_blocks_per_seq, num_kv_heads, k_block_stride, k_token_stride,
+      k_head_stride, v_block_stride, v_token_stride, v_head_stride,
+      softmax_scale, split_tmp_out, split_tmp_row_max, split_tmp_row_sum,
+      actual_n);
 }
 
-template<bool IS_CAUSAL, bool ALL_P, bool PAIR_SCRATCH>
+template <bool IS_CAUSAL, bool ALL_P, bool PAIR_SCRATCH>
 void launch_flash_attention_forward_paged_d256_bm32_phase_kernel(
-    const torch::Tensor& Q,
-    const torch::Tensor& K_cache,
-    const torch::Tensor& V_cache,
-    torch::Tensor& Out,
-    torch::Tensor& softmax_lse,
-    const torch::Tensor& block_table,
-    const torch::Tensor& seq_lens,
-    float softmax_scale,
-    cudaStream_t stream) {
-    const int H = Q.size(1);
-    const int M = Q.size(2);
-    const int num_kv_heads = K_cache.size(2);
-    const int max_num_blocks_per_seq = block_table.size(1);
-    const int64_t k_block_stride = K_cache.stride(0);
-    const int64_t k_token_stride = K_cache.stride(1);
-    const int64_t k_head_stride = K_cache.stride(2);
-    const int64_t v_block_stride = V_cache.stride(0);
-    const int64_t v_token_stride = V_cache.stride(1);
-    const int64_t v_head_stride = V_cache.stride(2);
-    const dim3 grid((M + D256_BM32_PHASE_BLOCK_M - 1)
-                        / D256_BM32_PHASE_BLOCK_M,
-                    1, Q.size(0) * H);
-    const dim3 block(D256_BM32_PHASE_THREADS);
-    flash_attention_forward_paged_d256_bm32_phase_kernel<
-        IS_CAUSAL, ALL_P, PAIR_SCRATCH><<<grid, block, 0, stream>>>(
-            reinterpret_cast<const __half*>(Q.data_ptr()),
-            reinterpret_cast<const __half*>(K_cache.data_ptr()),
-            reinterpret_cast<const __half*>(V_cache.data_ptr()),
-            reinterpret_cast<__half*>(Out.data_ptr()),
-            softmax_lse.data_ptr<float>(), block_table.data_ptr<int>(),
-            seq_lens.data_ptr<int>(), H, M, max_num_blocks_per_seq,
-            num_kv_heads, k_block_stride, k_token_stride, k_head_stride,
-            v_block_stride, v_token_stride, v_head_stride, softmax_scale);
+    const torch::Tensor& Q, const torch::Tensor& K_cache,
+    const torch::Tensor& V_cache, torch::Tensor& Out,
+    torch::Tensor& softmax_lse, const torch::Tensor& block_table,
+    const torch::Tensor& seq_lens, float softmax_scale, cudaStream_t stream) {
+  const int H = Q.size(1);
+  const int M = Q.size(2);
+  const int num_kv_heads = K_cache.size(2);
+  const int max_num_blocks_per_seq = block_table.size(1);
+  const int64_t k_block_stride = K_cache.stride(0);
+  const int64_t k_token_stride = K_cache.stride(1);
+  const int64_t k_head_stride = K_cache.stride(2);
+  const int64_t v_block_stride = V_cache.stride(0);
+  const int64_t v_token_stride = V_cache.stride(1);
+  const int64_t v_head_stride = V_cache.stride(2);
+  const dim3 grid((M + D256_BM32_PHASE_BLOCK_M - 1) / D256_BM32_PHASE_BLOCK_M,
+                  1, Q.size(0) * H);
+  const dim3 block(D256_BM32_PHASE_THREADS);
+  flash_attention_forward_paged_d256_bm32_phase_kernel<IS_CAUSAL, ALL_P,
+                                                       PAIR_SCRATCH>
+      <<<grid, block, 0, stream>>>(
+          reinterpret_cast<const __half*>(Q.data_ptr()),
+          reinterpret_cast<const __half*>(K_cache.data_ptr()),
+          reinterpret_cast<const __half*>(V_cache.data_ptr()),
+          reinterpret_cast<__half*>(Out.data_ptr()),
+          softmax_lse.data_ptr<float>(), block_table.data_ptr<int>(),
+          seq_lens.data_ptr<int>(), H, M, max_num_blocks_per_seq, num_kv_heads,
+          k_block_stride, k_token_stride, k_head_stride, v_block_stride,
+          v_token_stride, v_head_stride, softmax_scale);
 }
 
-__global__ __launch_bounds__(256)
-void flash_attention_forward_paged_d256_bm32_splitkv3_merge_kernel(
+__global__
+__launch_bounds__(256) void flash_attention_forward_paged_d256_bm32_splitkv3_merge_kernel(
     const float* __restrict__ split_tmp_out,
     const float* __restrict__ split_tmp_row_max,
-    const float* __restrict__ split_tmp_row_sum,
-    __half* __restrict__ Out,
-    float* __restrict__ softmax_lse,
-    int M) {
-    const int start_row = blockIdx.x * D256_BM32_PHASE_BLOCK_M;
-    const int row_local = threadIdx.x >> 3;
-    const int lane_in_row = threadIdx.x & 7;
-    const int row = start_row + row_local;
-    if (row >= M) {
-        return;
-    }
+    const float* __restrict__ split_tmp_row_sum, __half* __restrict__ Out,
+    float* __restrict__ softmax_lse, int M) {
+  const int start_row = blockIdx.x * D256_BM32_PHASE_BLOCK_M;
+  const int row_local = threadIdx.x >> 3;
+  const int lane_in_row = threadIdx.x & 7;
+  const int row = start_row + row_local;
+  if (row >= M) {
+    return;
+  }
 
-    const size_t q_head_linear = static_cast<size_t>(blockIdx.z);
-    const size_t first_state =
-        (q_head_linear * D256_BM32_PHASE_SPLIT_PARTS) * M + row;
-    const float max_0 = split_tmp_row_max[first_state];
-    const float max_1 = split_tmp_row_max[first_state + M];
-    const float max_2 = split_tmp_row_max[first_state + 2 * M];
-    const float sum_0 = split_tmp_row_sum[first_state];
-    const float sum_1 = split_tmp_row_sum[first_state + M];
-    const float sum_2 = split_tmp_row_sum[first_state + 2 * M];
-    const float merged_max = fmaxf(max_0, fmaxf(max_1, max_2));
-    const float weight_0 =
-        sum_0 > 0.0f ? __expf(fmaxf(max_0 - merged_max, -80.0f)) : 0.0f;
-    const float weight_1 =
-        sum_1 > 0.0f ? __expf(fmaxf(max_1 - merged_max, -80.0f)) : 0.0f;
-    const float weight_2 =
-        sum_2 > 0.0f ? __expf(fmaxf(max_2 - merged_max, -80.0f)) : 0.0f;
-    const float denominator =
-        weight_0 * sum_0 + weight_1 * sum_1 + weight_2 * sum_2;
-    const float inverse_denominator =
-        1.0f / fmaxf(denominator, 1e-24f);
+  const size_t q_head_linear = static_cast<size_t>(blockIdx.z);
+  const size_t first_state =
+      (q_head_linear * D256_BM32_PHASE_SPLIT_PARTS) * M + row;
+  const float max_0 = split_tmp_row_max[first_state];
+  const float max_1 = split_tmp_row_max[first_state + M];
+  const float max_2 = split_tmp_row_max[first_state + 2 * M];
+  const float sum_0 = split_tmp_row_sum[first_state];
+  const float sum_1 = split_tmp_row_sum[first_state + M];
+  const float sum_2 = split_tmp_row_sum[first_state + 2 * M];
+  const float merged_max = fmaxf(max_0, fmaxf(max_1, max_2));
+  const float weight_0 =
+      sum_0 > 0.0f ? __expf(fmaxf(max_0 - merged_max, -80.0f)) : 0.0f;
+  const float weight_1 =
+      sum_1 > 0.0f ? __expf(fmaxf(max_1 - merged_max, -80.0f)) : 0.0f;
+  const float weight_2 =
+      sum_2 > 0.0f ? __expf(fmaxf(max_2 - merged_max, -80.0f)) : 0.0f;
+  const float denominator =
+      weight_0 * sum_0 + weight_1 * sum_1 + weight_2 * sum_2;
+  const float inverse_denominator = 1.0f / fmaxf(denominator, 1e-24f);
 
-    if (lane_in_row == 0) {
-        softmax_lse[q_head_linear * M + row] =
-            merged_max + logf(fmaxf(denominator, 1e-24f));
-    }
+  if (lane_in_row == 0) {
+    softmax_lse[q_head_linear * M + row] =
+        merged_max + logf(fmaxf(denominator, 1e-24f));
+  }
 
-    const size_t output_base =
-        (q_head_linear * M + row) * D256_BM32_PHASE_D;
-    const size_t partial_base_0 = first_state * D256_BM32_PHASE_D;
-    const size_t partial_base_1 =
-        (first_state + M) * D256_BM32_PHASE_D;
-    const size_t partial_base_2 =
-        (first_state + 2 * M) * D256_BM32_PHASE_D;
-    #pragma unroll
-    for (int column = lane_in_row; column < D256_BM32_PHASE_D; column += 8) {
-        const float numerator =
-            weight_0 * split_tmp_out[partial_base_0 + column]
-            + weight_1 * split_tmp_out[partial_base_1 + column]
-            + weight_2 * split_tmp_out[partial_base_2 + column];
-        Out[output_base + column] =
-            __float2half_rn(numerator * inverse_denominator);
-    }
+  const size_t output_base = (q_head_linear * M + row) * D256_BM32_PHASE_D;
+  const size_t partial_base_0 = first_state * D256_BM32_PHASE_D;
+  const size_t partial_base_1 = (first_state + M) * D256_BM32_PHASE_D;
+  const size_t partial_base_2 = (first_state + 2 * M) * D256_BM32_PHASE_D;
+#pragma unroll
+  for (int column = lane_in_row; column < D256_BM32_PHASE_D; column += 8) {
+    const float numerator = weight_0 * split_tmp_out[partial_base_0 + column] +
+                            weight_1 * split_tmp_out[partial_base_1 + column] +
+                            weight_2 * split_tmp_out[partial_base_2 + column];
+    Out[output_base + column] =
+        __float2half_rn(numerator * inverse_denominator);
+  }
 }
 
 void launch_flash_attention_forward_paged_d256_bm32_splitkv3_kernel(
-    const torch::Tensor& Q,
-    const torch::Tensor& K_cache,
-    const torch::Tensor& V_cache,
-    torch::Tensor& Out,
-    torch::Tensor& softmax_lse,
-    torch::Tensor& split_tmp_out,
-    torch::Tensor& split_tmp_row_max,
-    torch::Tensor& split_tmp_row_sum,
-    const torch::Tensor& block_table,
-    int actual_n,
-    float softmax_scale,
+    const torch::Tensor& Q, const torch::Tensor& K_cache,
+    const torch::Tensor& V_cache, torch::Tensor& Out,
+    torch::Tensor& softmax_lse, torch::Tensor& split_tmp_out,
+    torch::Tensor& split_tmp_row_max, torch::Tensor& split_tmp_row_sum,
+    const torch::Tensor& block_table, int actual_n, float softmax_scale,
     cudaStream_t stream) {
-    const int H = Q.size(1);
-    const int M = Q.size(2);
-    const int num_kv_heads = K_cache.size(2);
-    const int max_num_blocks_per_seq = block_table.size(1);
-    const int64_t k_block_stride = K_cache.stride(0);
-    const int64_t k_token_stride = K_cache.stride(1);
-    const int64_t k_head_stride = K_cache.stride(2);
-    const int64_t v_block_stride = V_cache.stride(0);
-    const int64_t v_token_stride = V_cache.stride(1);
-    const int64_t v_head_stride = V_cache.stride(2);
-    const dim3 partial_grid(
-        (M + D256_BM32_PHASE_BLOCK_M - 1) / D256_BM32_PHASE_BLOCK_M,
-        D256_BM32_PHASE_SPLIT_PARTS,
-        Q.size(0) * H);
-    const dim3 partial_block(D256_BM32_PHASE_THREADS);
-    const int64_t total_n_blocks =
-        (static_cast<int64_t>(actual_n) + D256_BM32_PHASE_BLOCK_N - 1)
-        / D256_BM32_PHASE_BLOCK_N;
-    const int64_t last_split_begin =
-        (D256_BM32_PHASE_SPLIT_PARTS - 1) * total_n_blocks
-        / D256_BM32_PHASE_SPLIT_PARTS * D256_BM32_PHASE_BLOCK_N;
-    const bool check_split_empty =
-        total_n_blocks < D256_BM32_PHASE_SPLIT_PARTS
-        || last_split_begin > static_cast<int64_t>(actual_n) - M;
-    if (check_split_empty) {
-        flash_attention_forward_paged_d256_bm32_splitkv3_partial_kernel<true>
-            <<<partial_grid, partial_block, 0, stream>>>(
-                reinterpret_cast<const __half*>(Q.data_ptr()),
-                reinterpret_cast<const __half*>(K_cache.data_ptr()),
-                reinterpret_cast<const __half*>(V_cache.data_ptr()),
-                block_table.data_ptr<int>(), H, M, actual_n,
-                max_num_blocks_per_seq, num_kv_heads, k_block_stride,
-                k_token_stride, k_head_stride, v_block_stride,
-                v_token_stride, v_head_stride, softmax_scale,
-                split_tmp_out.data_ptr<float>(),
-                split_tmp_row_max.data_ptr<float>(),
-                split_tmp_row_sum.data_ptr<float>());
-    } else {
-        flash_attention_forward_paged_d256_bm32_splitkv3_partial_kernel<false>
-            <<<partial_grid, partial_block, 0, stream>>>(
+  const int H = Q.size(1);
+  const int M = Q.size(2);
+  const int num_kv_heads = K_cache.size(2);
+  const int max_num_blocks_per_seq = block_table.size(1);
+  const int64_t k_block_stride = K_cache.stride(0);
+  const int64_t k_token_stride = K_cache.stride(1);
+  const int64_t k_head_stride = K_cache.stride(2);
+  const int64_t v_block_stride = V_cache.stride(0);
+  const int64_t v_token_stride = V_cache.stride(1);
+  const int64_t v_head_stride = V_cache.stride(2);
+  const dim3 partial_grid(
+      (M + D256_BM32_PHASE_BLOCK_M - 1) / D256_BM32_PHASE_BLOCK_M,
+      D256_BM32_PHASE_SPLIT_PARTS, Q.size(0) * H);
+  const dim3 partial_block(D256_BM32_PHASE_THREADS);
+  const int64_t total_n_blocks =
+      (static_cast<int64_t>(actual_n) + D256_BM32_PHASE_BLOCK_N - 1) /
+      D256_BM32_PHASE_BLOCK_N;
+  const int64_t last_split_begin =
+      (D256_BM32_PHASE_SPLIT_PARTS - 1) * total_n_blocks /
+      D256_BM32_PHASE_SPLIT_PARTS * D256_BM32_PHASE_BLOCK_N;
+  const bool check_split_empty =
+      total_n_blocks < D256_BM32_PHASE_SPLIT_PARTS ||
+      last_split_begin > static_cast<int64_t>(actual_n) - M;
+  if (check_split_empty) {
+    flash_attention_forward_paged_d256_bm32_splitkv3_partial_kernel<true>
+        <<<partial_grid, partial_block, 0, stream>>>(
             reinterpret_cast<const __half*>(Q.data_ptr()),
             reinterpret_cast<const __half*>(K_cache.data_ptr()),
             reinterpret_cast<const __half*>(V_cache.data_ptr()),
-                block_table.data_ptr<int>(), H, M, actual_n,
-                max_num_blocks_per_seq, num_kv_heads, k_block_stride,
-                k_token_stride, k_head_stride, v_block_stride,
-                v_token_stride, v_head_stride, softmax_scale,
-                split_tmp_out.data_ptr<float>(),
-                split_tmp_row_max.data_ptr<float>(),
-                split_tmp_row_sum.data_ptr<float>());
-    }
-
-    const dim3 merge_grid(
-        (M + D256_BM32_PHASE_BLOCK_M - 1) / D256_BM32_PHASE_BLOCK_M,
-        1,
-        Q.size(0) * H);
-    flash_attention_forward_paged_d256_bm32_splitkv3_merge_kernel
-        <<<merge_grid, 256, 0, stream>>>(
+            block_table.data_ptr<int>(), H, M, actual_n, max_num_blocks_per_seq,
+            num_kv_heads, k_block_stride, k_token_stride, k_head_stride,
+            v_block_stride, v_token_stride, v_head_stride, softmax_scale,
             split_tmp_out.data_ptr<float>(),
             split_tmp_row_max.data_ptr<float>(),
-            split_tmp_row_sum.data_ptr<float>(),
-            reinterpret_cast<__half*>(Out.data_ptr()),
-            softmax_lse.data_ptr<float>(), M);
+            split_tmp_row_sum.data_ptr<float>());
+  } else {
+    flash_attention_forward_paged_d256_bm32_splitkv3_partial_kernel<false>
+        <<<partial_grid, partial_block, 0, stream>>>(
+            reinterpret_cast<const __half*>(Q.data_ptr()),
+            reinterpret_cast<const __half*>(K_cache.data_ptr()),
+            reinterpret_cast<const __half*>(V_cache.data_ptr()),
+            block_table.data_ptr<int>(), H, M, actual_n, max_num_blocks_per_seq,
+            num_kv_heads, k_block_stride, k_token_stride, k_head_stride,
+            v_block_stride, v_token_stride, v_head_stride, softmax_scale,
+            split_tmp_out.data_ptr<float>(),
+            split_tmp_row_max.data_ptr<float>(),
+            split_tmp_row_sum.data_ptr<float>());
+  }
+
+  const dim3 merge_grid(
+      (M + D256_BM32_PHASE_BLOCK_M - 1) / D256_BM32_PHASE_BLOCK_M, 1,
+      Q.size(0) * H);
+  flash_attention_forward_paged_d256_bm32_splitkv3_merge_kernel<<<
+      merge_grid, 256, 0, stream>>>(split_tmp_out.data_ptr<float>(),
+                                    split_tmp_row_max.data_ptr<float>(),
+                                    split_tmp_row_sum.data_ptr<float>(),
+                                    reinterpret_cast<__half*>(Out.data_ptr()),
+                                    softmax_lse.data_ptr<float>(), M);
 }
 
 void launcher_flash_attention_forward_paged_d256_bm32_phase(
-    const torch::Tensor& Q,
-    const torch::Tensor& K_cache,
-    const torch::Tensor& V_cache,
-    torch::Tensor& Out,
-    torch::Tensor& softmax_lse,
-    const torch::Tensor& block_table,
-    const torch::Tensor& seq_lens,
-    float softmax_scale,
-    bool is_causal,
+    const torch::Tensor& Q, const torch::Tensor& K_cache,
+    const torch::Tensor& V_cache, torch::Tensor& Out,
+    torch::Tensor& softmax_lse, const torch::Tensor& block_table,
+    const torch::Tensor& seq_lens, float softmax_scale, bool is_causal,
     cudaStream_t stream) {
-    const bool use_all_p =
-        env_flag_default_enabled("VLLM_FLASH_V100_PREFILL_D256_BM32_ALL_P");
-    const bool use_pair_scratch =
-        use_all_p
-        && env_flag_default_enabled(
-            "VLLM_FLASH_V100_PREFILL_D256_BM32_PAIR_SCRATCH");
+  const bool use_all_p =
+      env_flag_default_enabled("VLLM_FLASH_V100_PREFILL_D256_BM32_ALL_P");
+  const bool use_pair_scratch =
+      use_all_p && env_flag_default_enabled(
+                       "VLLM_FLASH_V100_PREFILL_D256_BM32_PAIR_SCRATCH");
 
-    if (is_causal) {
-        if (use_all_p) {
-            if (use_pair_scratch) {
-                launch_flash_attention_forward_paged_d256_bm32_phase_kernel<
-                    true, true, true>(
-                    Q, K_cache, V_cache, Out, softmax_lse, block_table,
-                    seq_lens, softmax_scale, stream);
-            } else {
-                launch_flash_attention_forward_paged_d256_bm32_phase_kernel<
-                    true, true, false>(
-                    Q, K_cache, V_cache, Out, softmax_lse, block_table,
-                    seq_lens, softmax_scale, stream);
-            }
-        } else {
-            launch_flash_attention_forward_paged_d256_bm32_phase_kernel<
-                true, false, false>(
-                Q, K_cache, V_cache, Out, softmax_lse, block_table, seq_lens,
-                softmax_scale, stream);
-        }
-        return;
-    }
-
+  if (is_causal) {
     if (use_all_p) {
-        if (use_pair_scratch) {
-            launch_flash_attention_forward_paged_d256_bm32_phase_kernel<
-                false, true, true>(
-                Q, K_cache, V_cache, Out, softmax_lse, block_table, seq_lens,
-                softmax_scale, stream);
-        } else {
-            launch_flash_attention_forward_paged_d256_bm32_phase_kernel<
-                false, true, false>(
-                Q, K_cache, V_cache, Out, softmax_lse, block_table, seq_lens,
-                softmax_scale, stream);
-        }
-    } else {
-        launch_flash_attention_forward_paged_d256_bm32_phase_kernel<
-            false, false, false>(
+      if (use_pair_scratch) {
+        launch_flash_attention_forward_paged_d256_bm32_phase_kernel<true, true,
+                                                                    true>(
             Q, K_cache, V_cache, Out, softmax_lse, block_table, seq_lens,
             softmax_scale, stream);
+      } else {
+        launch_flash_attention_forward_paged_d256_bm32_phase_kernel<true, true,
+                                                                    false>(
+            Q, K_cache, V_cache, Out, softmax_lse, block_table, seq_lens,
+            softmax_scale, stream);
+      }
+    } else {
+      launch_flash_attention_forward_paged_d256_bm32_phase_kernel<true, false,
+                                                                  false>(
+          Q, K_cache, V_cache, Out, softmax_lse, block_table, seq_lens,
+          softmax_scale, stream);
     }
+    return;
+  }
+
+  if (use_all_p) {
+    if (use_pair_scratch) {
+      launch_flash_attention_forward_paged_d256_bm32_phase_kernel<false, true,
+                                                                  true>(
+          Q, K_cache, V_cache, Out, softmax_lse, block_table, seq_lens,
+          softmax_scale, stream);
+    } else {
+      launch_flash_attention_forward_paged_d256_bm32_phase_kernel<false, true,
+                                                                  false>(
+          Q, K_cache, V_cache, Out, softmax_lse, block_table, seq_lens,
+          softmax_scale, stream);
+    }
+  } else {
+    launch_flash_attention_forward_paged_d256_bm32_phase_kernel<false, false,
+                                                                false>(
+        Q, K_cache, V_cache, Out, softmax_lse, block_table, seq_lens,
+        softmax_scale, stream);
+  }
 }
 
-template<int D, int KV_DTYPE>
+template <int D, int KV_DTYPE>
 void launcher_flash_attention_forward_paged(
-    const torch::Tensor& Q,
-    const torch::Tensor& K_cache,
-    const torch::Tensor& V_cache,
-    torch::Tensor& Out,
-    torch::Tensor& softmax_lse,
-    const torch::Tensor& block_table,
-    const torch::Tensor& seq_lens,
-    float softmax_scale,
-    bool is_causal,
-    float k_scale,
-    float v_scale,
-    int window_size_left,
-    int window_size_right,
-    cudaStream_t stream,
-    const int* bfla_mask_ptr = nullptr,
-    int bfla_mask_block_n = 0,
-    int64_t bfla_mask_stride_b = 0,
-    int64_t bfla_mask_stride_h = 0,
-    int64_t bfla_mask_stride_q = 0,
-    int64_t bfla_mask_stride_k = 0
-) {
-    if constexpr (D == 256 && KV_DTYPE == flash_v100::KV_CACHE_DTYPE_FP16) {
-        const int M = Q.size(2);
-        const int page_block_size = K_cache.size(1);
-        const bool use_low_smem =
-            M > 1 && page_block_size >= 16 && (page_block_size % 16) == 0
-            && env_flag_default_enabled(
-                "VLLM_FLASH_V100_PREFILL_D256_LOW_SMEM");
-        if (use_low_smem) {
-            const bool use_d256_bm32_phase =
-                env_flag_default_enabled(
-                    "VLLM_FLASH_V100_PREFILL_D256_BM32_PHASE")
-                && page_block_size == D256_BM32_PHASE_PAGE_BLOCK_SIZE
-                && M >= D256_BM32_PHASE_BLOCK_M
-                && bfla_mask_ptr == nullptr && window_size_left < 0
-                && window_size_right < 0;
-            if (use_d256_bm32_phase) {
-                launcher_flash_attention_forward_paged_d256_bm32_phase(
-                    Q, K_cache, V_cache, Out, softmax_lse, block_table,
-                    seq_lens, softmax_scale, is_causal, stream);
-                return;
-            }
-            const bool use_low_smem_contig_fast =
-                page_block_size == 16 ||
-                env_flag_enabled("VLLM_FLASH_V100_PREFILL_CONTIG_FAST");
-            const bool use_low_smem_scalar_qk =
-                env_flag_enabled("VLLM_FLASH_V100_PREFILL_D256_SCALAR_QK");
-            const bool use_low_smem_bm32 =
-                env_flag_enabled("VLLM_FLASH_V100_PREFILL_D256_BM32");
-            // Default only for the measured hybrid-cache page size. Other
-            // page sizes retain the prior layout unless explicitly enabled.
-            const bool use_low_smem_output_stride_268 =
-                page_block_size == 784
-                    ? env_flag_default_enabled(
-                          "VLLM_FLASH_V100_PREFILL_D256_OUTPUT_STRIDE_268")
-                    : env_flag_enabled(
-                          "VLLM_FLASH_V100_PREFILL_D256_OUTPUT_STRIDE_268");
-            const bool use_sw_pipeline =
-                page_block_size == 784
-                && env_flag_enabled(
-                    "VLLM_FLASH_V100_PREFILL_D256_SOFTWARE_PIPELINE");
-            const bool use_sw_pipeline_qk =
-                page_block_size == 784
-                && (use_sw_pipeline
-                    || env_flag_default_enabled(
-                        "VLLM_FLASH_V100_PREFILL_D256_SW_PIPELINE_QK"));
-            const bool use_sw_pipeline_pv =
-                page_block_size == 784
-                && (use_sw_pipeline
-                    || env_flag_default_enabled(
-                        "VLLM_FLASH_V100_PREFILL_D256_SW_PIPELINE_PV"));
-            if (use_low_smem_contig_fast) {
-                if (use_low_smem_scalar_qk) {
-                    if (use_low_smem_bm32) {
-                        launcher_flash_attention_forward_paged_impl<
-                            D, KV_DTYPE, true, true, true, true>(
-                            Q, K_cache, V_cache, Out, softmax_lse, block_table,
-                            seq_lens, bfla_mask_ptr, bfla_mask_block_n,
-                            bfla_mask_stride_b, bfla_mask_stride_h,
-                            bfla_mask_stride_q, bfla_mask_stride_k,
-                            softmax_scale, is_causal, k_scale, v_scale,
-                            window_size_left, window_size_right, stream);
-                    } else {
-                        launcher_flash_attention_forward_paged_impl<
-                            D, KV_DTYPE, true, true, true, false>(
-                            Q, K_cache, V_cache, Out, softmax_lse, block_table,
-                            seq_lens, bfla_mask_ptr, bfla_mask_block_n,
-                            bfla_mask_stride_b, bfla_mask_stride_h,
-                            bfla_mask_stride_q, bfla_mask_stride_k,
-                            softmax_scale, is_causal, k_scale, v_scale,
-                            window_size_left, window_size_right, stream);
-                    }
-                } else {
-                    if (use_low_smem_bm32) {
-                        launcher_flash_attention_forward_paged_impl<
-                            D, KV_DTYPE, true, true, false, true>(
-                            Q, K_cache, V_cache, Out, softmax_lse, block_table,
-                            seq_lens, bfla_mask_ptr, bfla_mask_block_n,
-                            bfla_mask_stride_b, bfla_mask_stride_h,
-                            bfla_mask_stride_q, bfla_mask_stride_k,
-                            softmax_scale, is_causal, k_scale, v_scale,
-                            window_size_left, window_size_right, stream);
-                    } else {
-                        launcher_flash_attention_forward_paged_impl<
-                            D, KV_DTYPE, true, true, false, false>(
-                            Q, K_cache, V_cache, Out, softmax_lse, block_table,
-                            seq_lens, bfla_mask_ptr, bfla_mask_block_n,
-                            bfla_mask_stride_b, bfla_mask_stride_h,
-                            bfla_mask_stride_q, bfla_mask_stride_k,
-                            softmax_scale, is_causal, k_scale, v_scale,
-                            window_size_left, window_size_right, stream);
-                    }
-                }
-            } else {
-                if (use_low_smem_scalar_qk) {
-                    if (use_low_smem_bm32) {
-                        launcher_flash_attention_forward_paged_impl<
-                            D, KV_DTYPE, true, false, true, true>(
-                            Q, K_cache, V_cache, Out, softmax_lse, block_table,
-                            seq_lens, bfla_mask_ptr, bfla_mask_block_n,
-                            bfla_mask_stride_b, bfla_mask_stride_h,
-                            bfla_mask_stride_q, bfla_mask_stride_k,
-                            softmax_scale, is_causal, k_scale, v_scale,
-                            window_size_left, window_size_right, stream);
-                    } else {
-                        launcher_flash_attention_forward_paged_impl<
-                            D, KV_DTYPE, true, false, true, false>(
-                            Q, K_cache, V_cache, Out, softmax_lse, block_table,
-                            seq_lens, bfla_mask_ptr, bfla_mask_block_n,
-                            bfla_mask_stride_b, bfla_mask_stride_h,
-                            bfla_mask_stride_q, bfla_mask_stride_k,
-                            softmax_scale, is_causal, k_scale, v_scale,
-                            window_size_left, window_size_right, stream);
-                    }
-                } else {
-                    if (use_low_smem_bm32) {
-                        launcher_flash_attention_forward_paged_impl<
-                            D, KV_DTYPE, true, false, false, true>(
-                            Q, K_cache, V_cache, Out, softmax_lse, block_table,
-                            seq_lens, bfla_mask_ptr, bfla_mask_block_n,
-                            bfla_mask_stride_b, bfla_mask_stride_h,
-                            bfla_mask_stride_q, bfla_mask_stride_k,
-                            softmax_scale, is_causal, k_scale, v_scale,
-                            window_size_left, window_size_right, stream);
-                    } else {
-                        if (use_low_smem_output_stride_268) {
-                            if (use_sw_pipeline_qk) {
-                                if (use_sw_pipeline_pv) {
-                                    launcher_flash_attention_forward_paged_impl<
-                                        D, KV_DTYPE, true, false, false,
-                                        false, true, true, true>(
-                                        Q, K_cache, V_cache, Out,
-                                        softmax_lse, block_table, seq_lens,
-                                        bfla_mask_ptr, bfla_mask_block_n,
-                                        bfla_mask_stride_b,
-                                        bfla_mask_stride_h,
-                                        bfla_mask_stride_q,
-                                        bfla_mask_stride_k, softmax_scale,
-                                        is_causal, k_scale, v_scale,
-                                        window_size_left,
-                                        window_size_right, stream);
-                                } else {
-                                    launcher_flash_attention_forward_paged_impl<
-                                        D, KV_DTYPE, true, false, false, false,
-                                        true, true, false>(
-                                        Q, K_cache, V_cache, Out, softmax_lse,
-                                        block_table, seq_lens, bfla_mask_ptr,
-                                        bfla_mask_block_n, bfla_mask_stride_b,
-                                        bfla_mask_stride_h,
-                                        bfla_mask_stride_q,
-                                        bfla_mask_stride_k, softmax_scale,
-                                        is_causal, k_scale, v_scale,
-                                        window_size_left, window_size_right,
-                                        stream);
-                                }
-                            } else if (use_sw_pipeline_pv) {
-                                launcher_flash_attention_forward_paged_impl<
-                                    D, KV_DTYPE, true, false, false, false,
-                                    true, false, true>(
-                                    Q, K_cache, V_cache, Out, softmax_lse,
-                                    block_table, seq_lens, bfla_mask_ptr,
-                                    bfla_mask_block_n, bfla_mask_stride_b,
-                                    bfla_mask_stride_h, bfla_mask_stride_q,
-                                    bfla_mask_stride_k, softmax_scale,
-                                    is_causal, k_scale, v_scale,
-                                    window_size_left, window_size_right,
-                                    stream);
-                            } else {
-                                launcher_flash_attention_forward_paged_impl<
-                                    D, KV_DTYPE, true, false, false, false,
-                                    true>(
-                                    Q, K_cache, V_cache, Out, softmax_lse,
-                                    block_table, seq_lens, bfla_mask_ptr,
-                                    bfla_mask_block_n, bfla_mask_stride_b,
-                                    bfla_mask_stride_h, bfla_mask_stride_q,
-                                    bfla_mask_stride_k, softmax_scale,
-                                    is_causal, k_scale, v_scale,
-                                    window_size_left, window_size_right,
-                                    stream);
-                            }
-                        } else {
-                            launcher_flash_attention_forward_paged_impl<
-                                D, KV_DTYPE, true, false, false, false>(
-                                Q, K_cache, V_cache, Out, softmax_lse,
-                                block_table, seq_lens, bfla_mask_ptr,
-                                bfla_mask_block_n, bfla_mask_stride_b,
-                                bfla_mask_stride_h, bfla_mask_stride_q,
-                                bfla_mask_stride_k, softmax_scale, is_causal,
-                                k_scale, v_scale, window_size_left,
-                                window_size_right, stream);
-                        }
-                    }
-                }
-            }
-        } else {
-            launcher_flash_attention_forward_paged_impl<
-                D, KV_DTYPE, false, false, false, false>(
+    const torch::Tensor& Q, const torch::Tensor& K_cache,
+    const torch::Tensor& V_cache, torch::Tensor& Out,
+    torch::Tensor& softmax_lse, const torch::Tensor& block_table,
+    const torch::Tensor& seq_lens, float softmax_scale, bool is_causal,
+    float k_scale, float v_scale, int window_size_left, int window_size_right,
+    cudaStream_t stream, const int* bfla_mask_ptr = nullptr,
+    int bfla_mask_block_n = 0, int64_t bfla_mask_stride_b = 0,
+    int64_t bfla_mask_stride_h = 0, int64_t bfla_mask_stride_q = 0,
+    int64_t bfla_mask_stride_k = 0) {
+  if constexpr (D == 256 && KV_DTYPE == flash_v100::KV_CACHE_DTYPE_FP16) {
+    const int M = Q.size(2);
+    const int page_block_size = K_cache.size(1);
+    const bool use_low_smem =
+        M > 1 && page_block_size >= 16 && (page_block_size % 16) == 0 &&
+        env_flag_default_enabled("VLLM_FLASH_V100_PREFILL_D256_LOW_SMEM");
+    if (use_low_smem) {
+      const bool use_d256_bm32_phase =
+          env_flag_default_enabled("VLLM_FLASH_V100_PREFILL_D256_BM32_PHASE") &&
+          page_block_size == D256_BM32_PHASE_PAGE_BLOCK_SIZE &&
+          M >= D256_BM32_PHASE_BLOCK_M && bfla_mask_ptr == nullptr &&
+          window_size_left < 0 && window_size_right < 0;
+      if (use_d256_bm32_phase) {
+        launcher_flash_attention_forward_paged_d256_bm32_phase(
+            Q, K_cache, V_cache, Out, softmax_lse, block_table, seq_lens,
+            softmax_scale, is_causal, stream);
+        return;
+      }
+      const bool use_low_smem_contig_fast =
+          page_block_size == 16 ||
+          env_flag_enabled("VLLM_FLASH_V100_PREFILL_CONTIG_FAST");
+      const bool use_low_smem_scalar_qk =
+          env_flag_enabled("VLLM_FLASH_V100_PREFILL_D256_SCALAR_QK");
+      const bool use_low_smem_bm32 =
+          env_flag_enabled("VLLM_FLASH_V100_PREFILL_D256_BM32");
+      // Default only for the measured hybrid-cache page size. Other
+      // page sizes retain the prior layout unless explicitly enabled.
+      const bool use_low_smem_output_stride_268 =
+          page_block_size == 784
+              ? env_flag_default_enabled(
+                    "VLLM_FLASH_V100_PREFILL_D256_OUTPUT_STRIDE_268")
+              : env_flag_enabled(
+                    "VLLM_FLASH_V100_PREFILL_D256_OUTPUT_STRIDE_268");
+      const bool use_sw_pipeline =
+          page_block_size == 784 &&
+          env_flag_enabled("VLLM_FLASH_V100_PREFILL_D256_SOFTWARE_PIPELINE");
+      const bool use_sw_pipeline_qk =
+          page_block_size == 784 &&
+          (use_sw_pipeline ||
+           env_flag_default_enabled(
+               "VLLM_FLASH_V100_PREFILL_D256_SW_PIPELINE_QK"));
+      const bool use_sw_pipeline_pv =
+          page_block_size == 784 &&
+          (use_sw_pipeline ||
+           env_flag_default_enabled(
+               "VLLM_FLASH_V100_PREFILL_D256_SW_PIPELINE_PV"));
+      if (use_low_smem_contig_fast) {
+        if (use_low_smem_scalar_qk) {
+          if (use_low_smem_bm32) {
+            launcher_flash_attention_forward_paged_impl<D, KV_DTYPE, true, true,
+                                                        true, true>(
                 Q, K_cache, V_cache, Out, softmax_lse, block_table, seq_lens,
                 bfla_mask_ptr, bfla_mask_block_n, bfla_mask_stride_b,
                 bfla_mask_stride_h, bfla_mask_stride_q, bfla_mask_stride_k,
                 softmax_scale, is_causal, k_scale, v_scale, window_size_left,
                 window_size_right, stream);
+          } else {
+            launcher_flash_attention_forward_paged_impl<D, KV_DTYPE, true, true,
+                                                        true, false>(
+                Q, K_cache, V_cache, Out, softmax_lse, block_table, seq_lens,
+                bfla_mask_ptr, bfla_mask_block_n, bfla_mask_stride_b,
+                bfla_mask_stride_h, bfla_mask_stride_q, bfla_mask_stride_k,
+                softmax_scale, is_causal, k_scale, v_scale, window_size_left,
+                window_size_right, stream);
+          }
+        } else {
+          if (use_low_smem_bm32) {
+            launcher_flash_attention_forward_paged_impl<D, KV_DTYPE, true, true,
+                                                        false, true>(
+                Q, K_cache, V_cache, Out, softmax_lse, block_table, seq_lens,
+                bfla_mask_ptr, bfla_mask_block_n, bfla_mask_stride_b,
+                bfla_mask_stride_h, bfla_mask_stride_q, bfla_mask_stride_k,
+                softmax_scale, is_causal, k_scale, v_scale, window_size_left,
+                window_size_right, stream);
+          } else {
+            launcher_flash_attention_forward_paged_impl<D, KV_DTYPE, true, true,
+                                                        false, false>(
+                Q, K_cache, V_cache, Out, softmax_lse, block_table, seq_lens,
+                bfla_mask_ptr, bfla_mask_block_n, bfla_mask_stride_b,
+                bfla_mask_stride_h, bfla_mask_stride_q, bfla_mask_stride_k,
+                softmax_scale, is_causal, k_scale, v_scale, window_size_left,
+                window_size_right, stream);
+          }
         }
+      } else {
+        if (use_low_smem_scalar_qk) {
+          if (use_low_smem_bm32) {
+            launcher_flash_attention_forward_paged_impl<D, KV_DTYPE, true,
+                                                        false, true, true>(
+                Q, K_cache, V_cache, Out, softmax_lse, block_table, seq_lens,
+                bfla_mask_ptr, bfla_mask_block_n, bfla_mask_stride_b,
+                bfla_mask_stride_h, bfla_mask_stride_q, bfla_mask_stride_k,
+                softmax_scale, is_causal, k_scale, v_scale, window_size_left,
+                window_size_right, stream);
+          } else {
+            launcher_flash_attention_forward_paged_impl<D, KV_DTYPE, true,
+                                                        false, true, false>(
+                Q, K_cache, V_cache, Out, softmax_lse, block_table, seq_lens,
+                bfla_mask_ptr, bfla_mask_block_n, bfla_mask_stride_b,
+                bfla_mask_stride_h, bfla_mask_stride_q, bfla_mask_stride_k,
+                softmax_scale, is_causal, k_scale, v_scale, window_size_left,
+                window_size_right, stream);
+          }
+        } else {
+          if (use_low_smem_bm32) {
+            launcher_flash_attention_forward_paged_impl<D, KV_DTYPE, true,
+                                                        false, false, true>(
+                Q, K_cache, V_cache, Out, softmax_lse, block_table, seq_lens,
+                bfla_mask_ptr, bfla_mask_block_n, bfla_mask_stride_b,
+                bfla_mask_stride_h, bfla_mask_stride_q, bfla_mask_stride_k,
+                softmax_scale, is_causal, k_scale, v_scale, window_size_left,
+                window_size_right, stream);
+          } else {
+            if (use_low_smem_output_stride_268) {
+              if (use_sw_pipeline_qk) {
+                if (use_sw_pipeline_pv) {
+                  launcher_flash_attention_forward_paged_impl<
+                      D, KV_DTYPE, true, false, false, false, true, true, true>(
+                      Q, K_cache, V_cache, Out, softmax_lse, block_table,
+                      seq_lens, bfla_mask_ptr, bfla_mask_block_n,
+                      bfla_mask_stride_b, bfla_mask_stride_h,
+                      bfla_mask_stride_q, bfla_mask_stride_k, softmax_scale,
+                      is_causal, k_scale, v_scale, window_size_left,
+                      window_size_right, stream);
+                } else {
+                  launcher_flash_attention_forward_paged_impl<
+                      D, KV_DTYPE, true, false, false, false, true, true,
+                      false>(Q, K_cache, V_cache, Out, softmax_lse, block_table,
+                             seq_lens, bfla_mask_ptr, bfla_mask_block_n,
+                             bfla_mask_stride_b, bfla_mask_stride_h,
+                             bfla_mask_stride_q, bfla_mask_stride_k,
+                             softmax_scale, is_causal, k_scale, v_scale,
+                             window_size_left, window_size_right, stream);
+                }
+              } else if (use_sw_pipeline_pv) {
+                launcher_flash_attention_forward_paged_impl<
+                    D, KV_DTYPE, true, false, false, false, true, false, true>(
+                    Q, K_cache, V_cache, Out, softmax_lse, block_table,
+                    seq_lens, bfla_mask_ptr, bfla_mask_block_n,
+                    bfla_mask_stride_b, bfla_mask_stride_h, bfla_mask_stride_q,
+                    bfla_mask_stride_k, softmax_scale, is_causal, k_scale,
+                    v_scale, window_size_left, window_size_right, stream);
+              } else {
+                launcher_flash_attention_forward_paged_impl<
+                    D, KV_DTYPE, true, false, false, false, true>(
+                    Q, K_cache, V_cache, Out, softmax_lse, block_table,
+                    seq_lens, bfla_mask_ptr, bfla_mask_block_n,
+                    bfla_mask_stride_b, bfla_mask_stride_h, bfla_mask_stride_q,
+                    bfla_mask_stride_k, softmax_scale, is_causal, k_scale,
+                    v_scale, window_size_left, window_size_right, stream);
+              }
+            } else {
+              launcher_flash_attention_forward_paged_impl<D, KV_DTYPE, true,
+                                                          false, false, false>(
+                  Q, K_cache, V_cache, Out, softmax_lse, block_table, seq_lens,
+                  bfla_mask_ptr, bfla_mask_block_n, bfla_mask_stride_b,
+                  bfla_mask_stride_h, bfla_mask_stride_q, bfla_mask_stride_k,
+                  softmax_scale, is_causal, k_scale, v_scale, window_size_left,
+                  window_size_right, stream);
+            }
+          }
+        }
+      }
     } else {
-        launcher_flash_attention_forward_paged_impl<
-            D, KV_DTYPE, false, false, false, false>(
-            Q, K_cache, V_cache, Out, softmax_lse, block_table, seq_lens,
-            bfla_mask_ptr, bfla_mask_block_n, bfla_mask_stride_b,
-            bfla_mask_stride_h, bfla_mask_stride_q, bfla_mask_stride_k,
-            softmax_scale, is_causal, k_scale, v_scale, window_size_left,
-            window_size_right, stream);
+      launcher_flash_attention_forward_paged_impl<D, KV_DTYPE, false, false,
+                                                  false, false>(
+          Q, K_cache, V_cache, Out, softmax_lse, block_table, seq_lens,
+          bfla_mask_ptr, bfla_mask_block_n, bfla_mask_stride_b,
+          bfla_mask_stride_h, bfla_mask_stride_q, bfla_mask_stride_k,
+          softmax_scale, is_causal, k_scale, v_scale, window_size_left,
+          window_size_right, stream);
     }
+  } else {
+    launcher_flash_attention_forward_paged_impl<D, KV_DTYPE, false, false,
+                                                false, false>(
+        Q, K_cache, V_cache, Out, softmax_lse, block_table, seq_lens,
+        bfla_mask_ptr, bfla_mask_block_n, bfla_mask_stride_b,
+        bfla_mask_stride_h, bfla_mask_stride_q, bfla_mask_stride_k,
+        softmax_scale, is_causal, k_scale, v_scale, window_size_left,
+        window_size_right, stream);
+  }
 }
 
 at::Tensor flash_attention_prefill_paged_splitkv(
-    const at::Tensor& q,
-    const at::Tensor& k_cache,
-    const at::Tensor& v_cache,
-    std::optional<at::Tensor>& out_,
-    const at::Tensor& block_table,
-    const at::Tensor& seq_lens,
-    const float softmax_scale,
-    const std::string& kv_cache_dtype,
-    const float k_scale,
-    const float v_scale,
-    const bool is_causal,
-    const int window_size_left,
-    const int window_size_right,
-    const int split_kv_tokens,
-    const int max_seq_len_hint
-) {
-    TORCH_CHECK(q.dtype() == torch::kFloat16, "q must be fp16");
-    const int kv_dtype_code = kv_cache_dtype_code_from_string(kv_cache_dtype);
-    TORCH_CHECK(kv_dtype_code == flash_v100::KV_CACHE_DTYPE_FP16,
-                "split-KV paged prefill supports fp16 KV cache only");
-    TORCH_CHECK(k_cache.dtype() == torch::kFloat16, "k_cache must be fp16");
-    TORCH_CHECK(v_cache.dtype() == torch::kFloat16, "v_cache must be fp16");
-    TORCH_CHECK(q.is_cuda() && k_cache.is_cuda() && v_cache.is_cuda(),
-                "Tensors must be on CUDA");
-    TORCH_CHECK(block_table.is_cuda() && seq_lens.is_cuda(),
-                "block_table and seq_lens must be CUDA tensors");
-    TORCH_CHECK(q.stride(-1) == 1 && k_cache.stride(-1) == 1 &&
-                    v_cache.stride(-1) == 1,
-                "Last dim must be contiguous");
-    TORCH_CHECK(k_cache.stride(1) % 8 == 0 && k_cache.stride(2) % 8 == 0 &&
-                    v_cache.stride(1) % 8 == 0 && v_cache.stride(2) % 8 == 0,
-                "Paged KV strides must be divisible by 8 half elements");
+    const at::Tensor& q, const at::Tensor& k_cache, const at::Tensor& v_cache,
+    std::optional<at::Tensor>& out_, const at::Tensor& block_table,
+    const at::Tensor& seq_lens, const float softmax_scale,
+    const std::string& kv_cache_dtype, const float k_scale, const float v_scale,
+    const bool is_causal, const int window_size_left,
+    const int window_size_right, const int split_kv_tokens,
+    const int max_seq_len_hint) {
+  TORCH_CHECK(q.dtype() == torch::kFloat16, "q must be fp16");
+  const int kv_dtype_code = kv_cache_dtype_code_from_string(kv_cache_dtype);
+  TORCH_CHECK(kv_dtype_code == flash_v100::KV_CACHE_DTYPE_FP16,
+              "split-KV paged prefill supports fp16 KV cache only");
+  TORCH_CHECK(k_cache.dtype() == torch::kFloat16, "k_cache must be fp16");
+  TORCH_CHECK(v_cache.dtype() == torch::kFloat16, "v_cache must be fp16");
+  TORCH_CHECK(q.is_cuda() && k_cache.is_cuda() && v_cache.is_cuda(),
+              "Tensors must be on CUDA");
+  TORCH_CHECK(block_table.is_cuda() && seq_lens.is_cuda(),
+              "block_table and seq_lens must be CUDA tensors");
+  TORCH_CHECK(
+      q.stride(-1) == 1 && k_cache.stride(-1) == 1 && v_cache.stride(-1) == 1,
+      "Last dim must be contiguous");
+  TORCH_CHECK(k_cache.stride(1) % 8 == 0 && k_cache.stride(2) % 8 == 0 &&
+                  v_cache.stride(1) % 8 == 0 && v_cache.stride(2) % 8 == 0,
+              "Paged KV strides must be divisible by 8 half elements");
 
-    const int B = q.size(0);
-    const int H = q.size(1);
-    const int M = q.size(2);
-    const int D = q.size(3);
-    const int num_kv_heads = k_cache.size(2);
-    const int page_block_size = k_cache.size(1);
+  const int B = q.size(0);
+  const int H = q.size(1);
+  const int M = q.size(2);
+  const int D = q.size(3);
+  const int num_kv_heads = k_cache.size(2);
+  const int page_block_size = k_cache.size(1);
 
-    TORCH_CHECK(D == 256, "split-KV paged prefill supports D=256 only");
-    TORCH_CHECK(H % num_kv_heads == 0,
-                "num_heads must be divisible by num_kv_heads");
-    TORCH_CHECK(M > 1, "split-KV paged prefill requires prefill M > 1");
-    TORCH_CHECK(page_block_size >= 16 && (page_block_size % 16) == 0,
-                "split-KV paged prefill requires page block size multiple of 16");
-    TORCH_CHECK(window_size_left >= -1 && window_size_right >= -1,
-                "window sizes must be >= -1");
+  TORCH_CHECK(D == 256, "split-KV paged prefill supports D=256 only");
+  TORCH_CHECK(H % num_kv_heads == 0,
+              "num_heads must be divisible by num_kv_heads");
+  TORCH_CHECK(M > 1, "split-KV paged prefill requires prefill M > 1");
+  TORCH_CHECK(page_block_size >= 16 && (page_block_size % 16) == 0,
+              "split-KV paged prefill requires page block size multiple of 16");
+  TORCH_CHECK(window_size_left >= -1 && window_size_right >= -1,
+              "window sizes must be >= -1");
 
-    at::Tensor out_fp16 = out_.has_value() ? out_.value() : torch::zeros_like(q);
-    auto softmax_lse = torch::zeros({B, H, M},
-                                    torch::dtype(torch::kFloat32).device(q.device()));
+  at::Tensor out_fp16 = out_.has_value() ? out_.value() : torch::zeros_like(q);
+  auto softmax_lse =
+      torch::zeros({B, H, M}, torch::dtype(torch::kFloat32).device(q.device()));
 
-    auto stream = at::cuda::getCurrentCUDAStream().stream();
-    auto props = at::cuda::getCurrentDeviceProperties();
-    bool sm70 = props->major == 7 && props->minor == 0;
-    TORCH_CHECK(sm70, "Kernel supports only Volta GPUs.");
+  auto stream = at::cuda::getCurrentCUDAStream().stream();
+  auto props = at::cuda::getCurrentDeviceProperties();
+  bool sm70 = props->major == 7 && props->minor == 0;
+  TORCH_CHECK(sm70, "Kernel supports only Volta GPUs.");
 
-    const bool use_low_smem_contig_fast =
-        page_block_size == 16 ||
-        env_flag_enabled("VLLM_FLASH_V100_PREFILL_CONTIG_FAST");
-    const bool use_low_smem_scalar_qk =
-        env_flag_enabled("VLLM_FLASH_V100_PREFILL_D256_SCALAR_QK");
-    const int block_n =
-        use_low_smem_scalar_qk
-            ? BLOCK_N_256_LOW_SMEM_SCALAR_QK
-            : BLOCK_N_256_LOW_SMEM;
-    const int split_tokens_rounded = std::max(split_kv_tokens, block_n);
-    const int split_kv_tiles =
-        std::max(1, (split_tokens_rounded + block_n - 1) / block_n);
-    const int max_hint = std::max(max_seq_len_hint, 1);
-    const int max_kv_tiles = std::max(1, (max_hint + block_n - 1) / block_n);
-    const int num_partitions =
-        std::max(1, (max_kv_tiles + split_kv_tiles - 1) / split_kv_tiles);
+  const bool use_low_smem_contig_fast =
+      page_block_size == 16 ||
+      env_flag_enabled("VLLM_FLASH_V100_PREFILL_CONTIG_FAST");
+  const bool use_low_smem_scalar_qk =
+      env_flag_enabled("VLLM_FLASH_V100_PREFILL_D256_SCALAR_QK");
+  const int block_n = use_low_smem_scalar_qk ? BLOCK_N_256_LOW_SMEM_SCALAR_QK
+                                             : BLOCK_N_256_LOW_SMEM;
+  const int split_tokens_rounded = std::max(split_kv_tokens, block_n);
+  const int split_kv_tiles =
+      std::max(1, (split_tokens_rounded + block_n - 1) / block_n);
+  const int max_hint = std::max(max_seq_len_hint, 1);
+  const int max_kv_tiles = std::max(1, (max_hint + block_n - 1) / block_n);
+  const int num_partitions =
+      std::max(1, (max_kv_tiles + split_kv_tiles - 1) / split_kv_tiles);
 
-    if (num_partitions <= 1) {
-        launcher_flash_attention_forward_paged<256, flash_v100::KV_CACHE_DTYPE_FP16>(
-            q, k_cache, v_cache, out_fp16, softmax_lse, block_table, seq_lens,
-            softmax_scale, is_causal, k_scale, v_scale, window_size_left,
-            window_size_right, stream);
-        return out_fp16;
-    }
-
-    auto tmp_options = torch::dtype(torch::kFloat32).device(q.device());
-    auto split_tmp_out =
-        torch::empty({B, H, num_partitions, M, D}, tmp_options);
-    auto split_tmp_row_max =
-        torch::empty({B, H, num_partitions, M}, tmp_options);
-    auto split_tmp_row_sum =
-        torch::empty({B, H, num_partitions, M}, tmp_options);
-
-    if (use_low_smem_contig_fast) {
-        if (use_low_smem_scalar_qk) {
-            launcher_flash_attention_forward_paged_splitkv_impl<
-                256, true, true>(
-                q, k_cache, v_cache, out_fp16, softmax_lse, split_tmp_out,
-                split_tmp_row_max, split_tmp_row_sum, block_table, seq_lens,
-                softmax_scale, is_causal, k_scale, v_scale, window_size_left,
-                window_size_right, split_kv_tokens, max_seq_len_hint, stream);
-        } else {
-            launcher_flash_attention_forward_paged_splitkv_impl<
-                256, true, false>(
-                q, k_cache, v_cache, out_fp16, softmax_lse, split_tmp_out,
-                split_tmp_row_max, split_tmp_row_sum, block_table, seq_lens,
-                softmax_scale, is_causal, k_scale, v_scale, window_size_left,
-                window_size_right, split_kv_tokens, max_seq_len_hint, stream);
-        }
-    } else {
-        if (use_low_smem_scalar_qk) {
-            launcher_flash_attention_forward_paged_splitkv_impl<
-                256, false, true>(
-                q, k_cache, v_cache, out_fp16, softmax_lse, split_tmp_out,
-                split_tmp_row_max, split_tmp_row_sum, block_table, seq_lens,
-                softmax_scale, is_causal, k_scale, v_scale, window_size_left,
-                window_size_right, split_kv_tokens, max_seq_len_hint, stream);
-        } else {
-            launcher_flash_attention_forward_paged_splitkv_impl<
-                256, false, false>(
-                q, k_cache, v_cache, out_fp16, softmax_lse, split_tmp_out,
-                split_tmp_row_max, split_tmp_row_sum, block_table, seq_lens,
-                softmax_scale, is_causal, k_scale, v_scale, window_size_left,
-                window_size_right, split_kv_tokens, max_seq_len_hint, stream);
-        }
-    }
-
+  if (num_partitions <= 1) {
+    launcher_flash_attention_forward_paged<256,
+                                           flash_v100::KV_CACHE_DTYPE_FP16>(
+        q, k_cache, v_cache, out_fp16, softmax_lse, block_table, seq_lens,
+        softmax_scale, is_causal, k_scale, v_scale, window_size_left,
+        window_size_right, stream);
     return out_fp16;
+  }
+
+  auto tmp_options = torch::dtype(torch::kFloat32).device(q.device());
+  auto split_tmp_out = torch::empty({B, H, num_partitions, M, D}, tmp_options);
+  auto split_tmp_row_max = torch::empty({B, H, num_partitions, M}, tmp_options);
+  auto split_tmp_row_sum = torch::empty({B, H, num_partitions, M}, tmp_options);
+
+  if (use_low_smem_contig_fast) {
+    if (use_low_smem_scalar_qk) {
+      launcher_flash_attention_forward_paged_splitkv_impl<256, true, true>(
+          q, k_cache, v_cache, out_fp16, softmax_lse, split_tmp_out,
+          split_tmp_row_max, split_tmp_row_sum, block_table, seq_lens,
+          softmax_scale, is_causal, k_scale, v_scale, window_size_left,
+          window_size_right, split_kv_tokens, max_seq_len_hint, stream);
+    } else {
+      launcher_flash_attention_forward_paged_splitkv_impl<256, true, false>(
+          q, k_cache, v_cache, out_fp16, softmax_lse, split_tmp_out,
+          split_tmp_row_max, split_tmp_row_sum, block_table, seq_lens,
+          softmax_scale, is_causal, k_scale, v_scale, window_size_left,
+          window_size_right, split_kv_tokens, max_seq_len_hint, stream);
+    }
+  } else {
+    if (use_low_smem_scalar_qk) {
+      launcher_flash_attention_forward_paged_splitkv_impl<256, false, true>(
+          q, k_cache, v_cache, out_fp16, softmax_lse, split_tmp_out,
+          split_tmp_row_max, split_tmp_row_sum, block_table, seq_lens,
+          softmax_scale, is_causal, k_scale, v_scale, window_size_left,
+          window_size_right, split_kv_tokens, max_seq_len_hint, stream);
+    } else {
+      launcher_flash_attention_forward_paged_splitkv_impl<256, false, false>(
+          q, k_cache, v_cache, out_fp16, softmax_lse, split_tmp_out,
+          split_tmp_row_max, split_tmp_row_sum, block_table, seq_lens,
+          softmax_scale, is_causal, k_scale, v_scale, window_size_left,
+          window_size_right, split_kv_tokens, max_seq_len_hint, stream);
+    }
+  }
+
+  return out_fp16;
 }
 
 at::Tensor flash_attention_prefill_paged(
-    const at::Tensor& q,
-    const at::Tensor& k_cache,
-    const at::Tensor& v_cache,
-    std::optional<at::Tensor>& out_,
-    const at::Tensor& block_table,
-    const at::Tensor& seq_lens,
-    const float softmax_scale,
-    const std::string& kv_cache_dtype,
-    const float k_scale,
-    const float v_scale,
-    const bool is_causal,
-    const int window_size_left,
-    const int window_size_right
-) {
-    TORCH_CHECK(q.dtype() == torch::kFloat16, "q must be fp16");
-    const int kv_dtype_code = kv_cache_dtype_code_from_string(kv_cache_dtype);
-    TORCH_CHECK(kv_dtype_code >= 0, "Unsupported kv_cache_dtype: ", kv_cache_dtype);
-    if (kv_dtype_code == flash_v100::KV_CACHE_DTYPE_FP16) {
-        TORCH_CHECK(k_cache.dtype() == torch::kFloat16, "k_cache must be fp16");
-        TORCH_CHECK(v_cache.dtype() == torch::kFloat16, "v_cache must be fp16");
-    } else {
-        TORCH_CHECK(k_cache.dtype() == torch::kUInt8,
-                    "fp8 k_cache must be stored as uint8");
-        TORCH_CHECK(v_cache.dtype() == torch::kUInt8,
-                    "fp8 v_cache must be stored as uint8");
-        TORCH_CHECK(k_scale > 0.f && v_scale > 0.f,
-                    "fp8 k/v scales must be positive");
-    }
-    TORCH_CHECK(q.is_cuda() && k_cache.is_cuda() && v_cache.is_cuda(),
-                "Tensors must be on CUDA");
-    TORCH_CHECK(block_table.is_cuda() && seq_lens.is_cuda(),
-                "block_table and seq_lens must be CUDA tensors");
-    TORCH_CHECK(q.stride(-1) == 1 && k_cache.stride(-1) == 1 &&
-                    v_cache.stride(-1) == 1,
-                "Last dim must be contiguous");
-    TORCH_CHECK(k_cache.stride(1) % 8 == 0 && k_cache.stride(2) % 8 == 0 &&
-                    v_cache.stride(1) % 8 == 0 && v_cache.stride(2) % 8 == 0,
-                "Paged KV strides must be divisible by 8 half elements");
+    const at::Tensor& q, const at::Tensor& k_cache, const at::Tensor& v_cache,
+    std::optional<at::Tensor>& out_, const at::Tensor& block_table,
+    const at::Tensor& seq_lens, const float softmax_scale,
+    const std::string& kv_cache_dtype, const float k_scale, const float v_scale,
+    const bool is_causal, const int window_size_left,
+    const int window_size_right) {
+  TORCH_CHECK(q.dtype() == torch::kFloat16, "q must be fp16");
+  const int kv_dtype_code = kv_cache_dtype_code_from_string(kv_cache_dtype);
+  TORCH_CHECK(kv_dtype_code >= 0,
+              "Unsupported kv_cache_dtype: ", kv_cache_dtype);
+  if (kv_dtype_code == flash_v100::KV_CACHE_DTYPE_FP16) {
+    TORCH_CHECK(k_cache.dtype() == torch::kFloat16, "k_cache must be fp16");
+    TORCH_CHECK(v_cache.dtype() == torch::kFloat16, "v_cache must be fp16");
+  } else {
+    TORCH_CHECK(k_cache.dtype() == torch::kUInt8,
+                "fp8 k_cache must be stored as uint8");
+    TORCH_CHECK(v_cache.dtype() == torch::kUInt8,
+                "fp8 v_cache must be stored as uint8");
+    TORCH_CHECK(k_scale > 0.f && v_scale > 0.f,
+                "fp8 k/v scales must be positive");
+  }
+  TORCH_CHECK(q.is_cuda() && k_cache.is_cuda() && v_cache.is_cuda(),
+              "Tensors must be on CUDA");
+  TORCH_CHECK(block_table.is_cuda() && seq_lens.is_cuda(),
+              "block_table and seq_lens must be CUDA tensors");
+  TORCH_CHECK(
+      q.stride(-1) == 1 && k_cache.stride(-1) == 1 && v_cache.stride(-1) == 1,
+      "Last dim must be contiguous");
+  TORCH_CHECK(k_cache.stride(1) % 8 == 0 && k_cache.stride(2) % 8 == 0 &&
+                  v_cache.stride(1) % 8 == 0 && v_cache.stride(2) % 8 == 0,
+              "Paged KV strides must be divisible by 8 half elements");
 
-    const int B = q.size(0);
-    const int H = q.size(1);
-    const int M = q.size(2);
-    const int D = q.size(3);
-    const int num_kv_heads = k_cache.size(2);
+  const int B = q.size(0);
+  const int H = q.size(1);
+  const int M = q.size(2);
+  const int D = q.size(3);
+  const int num_kv_heads = k_cache.size(2);
 
-    TORCH_CHECK(D <= 256 && D % 8 == 0 && D % 2 == 0,
-                "D must be even, <=256, multiple of 8");
-    TORCH_CHECK(H % num_kv_heads == 0,
-                "num_heads must be divisible by num_kv_heads");
-    TORCH_CHECK(window_size_left >= -1 && window_size_right >= -1,
-                "window sizes must be >= -1");
+  TORCH_CHECK(D <= 256 && D % 8 == 0 && D % 2 == 0,
+              "D must be even, <=256, multiple of 8");
+  TORCH_CHECK(H % num_kv_heads == 0,
+              "num_heads must be divisible by num_kv_heads");
+  TORCH_CHECK(window_size_left >= -1 && window_size_right >= -1,
+              "window sizes must be >= -1");
 
-    at::Tensor out_fp16 = out_.has_value() ? out_.value() : torch::zeros_like(q);
-    auto softmax_lse = torch::zeros({B, H, M},
-                                    torch::dtype(torch::kFloat32).device(q.device()));
+  at::Tensor out_fp16 = out_.has_value() ? out_.value() : torch::zeros_like(q);
+  auto softmax_lse =
+      torch::zeros({B, H, M}, torch::dtype(torch::kFloat32).device(q.device()));
 
-    auto stream = at::cuda::getCurrentCUDAStream().stream();
-    auto props = at::cuda::getCurrentDeviceProperties();
-    bool sm70 = props->major == 7 && props->minor == 0;
-    TORCH_CHECK(sm70, "Kernel supports only Volta GPUs.");
+  auto stream = at::cuda::getCurrentCUDAStream().stream();
+  auto props = at::cuda::getCurrentDeviceProperties();
+  bool sm70 = props->major == 7 && props->minor == 0;
+  TORCH_CHECK(sm70, "Kernel supports only Volta GPUs.");
 
-    #define LAUNCH_PAGED_TYPED(HDIM, KV_DTYPE_CODE)                             \
-        launcher_flash_attention_forward_paged<HDIM, KV_DTYPE_CODE>(            \
-            q, k_cache, v_cache, out_fp16, softmax_lse, block_table, seq_lens,  \
-            softmax_scale, is_causal, k_scale, v_scale, window_size_left,       \
-            window_size_right, stream)
+#define LAUNCH_PAGED_TYPED(HDIM, KV_DTYPE_CODE)                          \
+  launcher_flash_attention_forward_paged<HDIM, KV_DTYPE_CODE>(           \
+      q, k_cache, v_cache, out_fp16, softmax_lse, block_table, seq_lens, \
+      softmax_scale, is_causal, k_scale, v_scale, window_size_left,      \
+      window_size_right, stream)
 
-    #define LAUNCH_PAGED_BY_KV(HDIM)                                            \
-        do {                                                                    \
-            switch (kv_dtype_code) {                                            \
-                case flash_v100::KV_CACHE_DTYPE_FP16:                           \
-                    LAUNCH_PAGED_TYPED(HDIM, flash_v100::KV_CACHE_DTYPE_FP16);  \
-                    break;                                                      \
-                case flash_v100::KV_CACHE_DTYPE_FP8_E4M3:                       \
-                    LAUNCH_PAGED_TYPED(HDIM, flash_v100::KV_CACHE_DTYPE_FP8_E4M3); \
-                    break;                                                      \
-                case flash_v100::KV_CACHE_DTYPE_FP8_E5M2:                       \
-                    LAUNCH_PAGED_TYPED(HDIM, flash_v100::KV_CACHE_DTYPE_FP8_E5M2); \
-                    break;                                                      \
-                default:                                                        \
-                    TORCH_CHECK(false, "Unsupported kv_cache_dtype: ", kv_cache_dtype); \
-            }                                                                   \
-        } while (0)
+#define LAUNCH_PAGED_BY_KV(HDIM)                                            \
+  do {                                                                      \
+    switch (kv_dtype_code) {                                                \
+      case flash_v100::KV_CACHE_DTYPE_FP16:                                 \
+        LAUNCH_PAGED_TYPED(HDIM, flash_v100::KV_CACHE_DTYPE_FP16);          \
+        break;                                                              \
+      case flash_v100::KV_CACHE_DTYPE_FP8_E4M3:                             \
+        LAUNCH_PAGED_TYPED(HDIM, flash_v100::KV_CACHE_DTYPE_FP8_E4M3);      \
+        break;                                                              \
+      case flash_v100::KV_CACHE_DTYPE_FP8_E5M2:                             \
+        LAUNCH_PAGED_TYPED(HDIM, flash_v100::KV_CACHE_DTYPE_FP8_E5M2);      \
+        break;                                                              \
+      default:                                                              \
+        TORCH_CHECK(false, "Unsupported kv_cache_dtype: ", kv_cache_dtype); \
+    }                                                                       \
+  } while (0)
 
-    switch (D) {
-        case 16:
-            LAUNCH_PAGED_BY_KV(16);
-            break;
-        case 32:
-            LAUNCH_PAGED_BY_KV(32);
-            break;
-        case 64:
-            LAUNCH_PAGED_BY_KV(64);
-            break;
-        case 128:
-            LAUNCH_PAGED_BY_KV(128);
-            break;
-        case 256:
-            LAUNCH_PAGED_BY_KV(256);
-            break;
-        default:
-            TORCH_CHECK(false, "Unsupported D: ", D);
-    }
+  switch (D) {
+    case 16:
+      LAUNCH_PAGED_BY_KV(16);
+      break;
+    case 32:
+      LAUNCH_PAGED_BY_KV(32);
+      break;
+    case 64:
+      LAUNCH_PAGED_BY_KV(64);
+      break;
+    case 128:
+      LAUNCH_PAGED_BY_KV(128);
+      break;
+    case 256:
+      LAUNCH_PAGED_BY_KV(256);
+      break;
+    default:
+      TORCH_CHECK(false, "Unsupported D: ", D);
+  }
 
-    #undef LAUNCH_PAGED_BY_KV
-    #undef LAUNCH_PAGED_TYPED
+#undef LAUNCH_PAGED_BY_KV
+#undef LAUNCH_PAGED_TYPED
 
-    return out_fp16;
+  return out_fp16;
 }
 
 std::vector<at::Tensor>
 flash_attention_prefill_paged_d256_bm32_allp_pair_scratch(
-    const at::Tensor& q,
-    const at::Tensor& k_cache,
-    const at::Tensor& v_cache,
-    std::optional<at::Tensor>& out_,
-    std::optional<at::Tensor>& softmax_lse_,
-    const at::Tensor& block_table,
-    const at::Tensor& seq_lens,
-    const float softmax_scale
-) {
-    TORCH_CHECK(q.dim() == 4, "q must have shape [B, H, M, D]");
-    TORCH_CHECK(k_cache.dim() == 4 && v_cache.dim() == 4,
-                "k_cache and v_cache must have shape [blocks, page, Hkv, D]");
-    TORCH_CHECK(block_table.dim() == 2,
-                "block_table must have shape [B, max_num_blocks]");
-    TORCH_CHECK(seq_lens.dim() == 1, "seq_lens must have shape [B]");
-    TORCH_CHECK(q.dtype() == torch::kFloat16, "q must be fp16");
-    TORCH_CHECK(k_cache.dtype() == torch::kFloat16,
-                "k_cache must be fp16");
-    TORCH_CHECK(v_cache.dtype() == torch::kFloat16,
-                "v_cache must be fp16");
-    TORCH_CHECK(block_table.dtype() == torch::kInt32,
-                "block_table must be int32");
-    TORCH_CHECK(seq_lens.dtype() == torch::kInt32, "seq_lens must be int32");
-    TORCH_CHECK(q.is_cuda() && k_cache.is_cuda() && v_cache.is_cuda(),
-                "q, k_cache, and v_cache must be CUDA tensors");
-    TORCH_CHECK(block_table.is_cuda() && seq_lens.is_cuda(),
-                "block_table and seq_lens must be CUDA tensors");
-    TORCH_CHECK(
-        q.device() == k_cache.device() && q.device() == v_cache.device()
-            && q.device() == block_table.device() && q.device() == seq_lens.device(),
-        "all input tensors must be on the q device");
-    TORCH_CHECK(q.is_contiguous(), "q must be contiguous [B, H, M, D]");
-    TORCH_CHECK(block_table.is_contiguous(), "block_table must be contiguous");
-    TORCH_CHECK(seq_lens.is_contiguous(), "seq_lens must be contiguous");
-    TORCH_CHECK(k_cache.sizes() == v_cache.sizes(),
-                "k_cache and v_cache must have the same shape");
-    TORCH_CHECK(k_cache.stride(-1) == 1 && v_cache.stride(-1) == 1,
-                "K/V head dimensions must be contiguous");
-    TORCH_CHECK(k_cache.stride(1) % 8 == 0 && k_cache.stride(2) % 8 == 0
-                    && v_cache.stride(1) % 8 == 0
-                    && v_cache.stride(2) % 8 == 0,
-                "K/V strides must be divisible by 8 half elements");
+    const at::Tensor& q, const at::Tensor& k_cache, const at::Tensor& v_cache,
+    std::optional<at::Tensor>& out_, std::optional<at::Tensor>& softmax_lse_,
+    const at::Tensor& block_table, const at::Tensor& seq_lens,
+    const float softmax_scale) {
+  TORCH_CHECK(q.dim() == 4, "q must have shape [B, H, M, D]");
+  TORCH_CHECK(k_cache.dim() == 4 && v_cache.dim() == 4,
+              "k_cache and v_cache must have shape [blocks, page, Hkv, D]");
+  TORCH_CHECK(block_table.dim() == 2,
+              "block_table must have shape [B, max_num_blocks]");
+  TORCH_CHECK(seq_lens.dim() == 1, "seq_lens must have shape [B]");
+  TORCH_CHECK(q.dtype() == torch::kFloat16, "q must be fp16");
+  TORCH_CHECK(k_cache.dtype() == torch::kFloat16, "k_cache must be fp16");
+  TORCH_CHECK(v_cache.dtype() == torch::kFloat16, "v_cache must be fp16");
+  TORCH_CHECK(block_table.dtype() == torch::kInt32,
+              "block_table must be int32");
+  TORCH_CHECK(seq_lens.dtype() == torch::kInt32, "seq_lens must be int32");
+  TORCH_CHECK(q.is_cuda() && k_cache.is_cuda() && v_cache.is_cuda(),
+              "q, k_cache, and v_cache must be CUDA tensors");
+  TORCH_CHECK(block_table.is_cuda() && seq_lens.is_cuda(),
+              "block_table and seq_lens must be CUDA tensors");
+  TORCH_CHECK(
+      q.device() == k_cache.device() && q.device() == v_cache.device() &&
+          q.device() == block_table.device() && q.device() == seq_lens.device(),
+      "all input tensors must be on the q device");
+  TORCH_CHECK(q.is_contiguous(), "q must be contiguous [B, H, M, D]");
+  TORCH_CHECK(block_table.is_contiguous(), "block_table must be contiguous");
+  TORCH_CHECK(seq_lens.is_contiguous(), "seq_lens must be contiguous");
+  TORCH_CHECK(k_cache.sizes() == v_cache.sizes(),
+              "k_cache and v_cache must have the same shape");
+  TORCH_CHECK(k_cache.stride(-1) == 1 && v_cache.stride(-1) == 1,
+              "K/V head dimensions must be contiguous");
+  TORCH_CHECK(k_cache.stride(1) % 8 == 0 && k_cache.stride(2) % 8 == 0 &&
+                  v_cache.stride(1) % 8 == 0 && v_cache.stride(2) % 8 == 0,
+              "K/V strides must be divisible by 8 half elements");
 
-    const int B = q.size(0);
-    const int H = q.size(1);
-    const int M = q.size(2);
-    const int D = q.size(3);
-    const int num_kv_heads = k_cache.size(2);
+  const int B = q.size(0);
+  const int H = q.size(1);
+  const int M = q.size(2);
+  const int D = q.size(3);
+  const int num_kv_heads = k_cache.size(2);
 
-    TORCH_CHECK(B > 0 && H > 0, "q batch and head dimensions must be positive");
-    TORCH_CHECK(M >= D256_BM32_PHASE_BLOCK_M,
-                "fixed BM32 prefill requires M >= ",
-                D256_BM32_PHASE_BLOCK_M);
-    TORCH_CHECK(D == D256_BM32_PHASE_D,
-                "fixed BM32 prefill requires D=", D256_BM32_PHASE_D);
-    TORCH_CHECK(k_cache.size(0) > 0 && num_kv_heads > 0,
-                "K/V cache block and head dimensions must be positive");
-    TORCH_CHECK(k_cache.size(1) == D256_BM32_PHASE_PAGE_BLOCK_SIZE,
-                "fixed BM32 prefill requires page size ",
-                D256_BM32_PHASE_PAGE_BLOCK_SIZE);
-    TORCH_CHECK(k_cache.size(3) == D256_BM32_PHASE_D,
-                "K/V cache head dimension must be D=",
-                D256_BM32_PHASE_D);
-    TORCH_CHECK(H % num_kv_heads == 0,
-                "num_q_heads must be divisible by num_kv_heads");
-    TORCH_CHECK(block_table.size(0) == B && seq_lens.size(0) == B,
-                "block_table and seq_lens batch dimensions must equal q batch");
-    TORCH_CHECK(block_table.size(1) > 0,
-                "block_table must provide at least one page index");
+  TORCH_CHECK(B > 0 && H > 0, "q batch and head dimensions must be positive");
+  TORCH_CHECK(M >= D256_BM32_PHASE_BLOCK_M,
+              "fixed BM32 prefill requires M >= ", D256_BM32_PHASE_BLOCK_M);
+  TORCH_CHECK(D == D256_BM32_PHASE_D,
+              "fixed BM32 prefill requires D=", D256_BM32_PHASE_D);
+  TORCH_CHECK(k_cache.size(0) > 0 && num_kv_heads > 0,
+              "K/V cache block and head dimensions must be positive");
+  TORCH_CHECK(k_cache.size(1) == D256_BM32_PHASE_PAGE_BLOCK_SIZE,
+              "fixed BM32 prefill requires page size ",
+              D256_BM32_PHASE_PAGE_BLOCK_SIZE);
+  TORCH_CHECK(k_cache.size(3) == D256_BM32_PHASE_D,
+              "K/V cache head dimension must be D=", D256_BM32_PHASE_D);
+  TORCH_CHECK(H % num_kv_heads == 0,
+              "num_q_heads must be divisible by num_kv_heads");
+  TORCH_CHECK(block_table.size(0) == B && seq_lens.size(0) == B,
+              "block_table and seq_lens batch dimensions must equal q batch");
+  TORCH_CHECK(block_table.size(1) > 0,
+              "block_table must provide at least one page index");
 
-    if (out_.has_value()) {
-        const at::Tensor& out = out_.value();
-        TORCH_CHECK(out.is_cuda() && out.device() == q.device(),
-                    "out must be a CUDA tensor on the q device");
-        TORCH_CHECK(out.dtype() == torch::kFloat16, "out must be fp16");
-        TORCH_CHECK(out.sizes() == q.sizes(), "out must have shape [B, H, M, D]");
-        TORCH_CHECK(out.is_contiguous(), "out must be contiguous [B, H, M, D]");
-    }
-    if (softmax_lse_.has_value()) {
-        const at::Tensor& softmax_lse = softmax_lse_.value();
-        TORCH_CHECK(softmax_lse.is_cuda() && softmax_lse.device() == q.device(),
-                    "softmax_lse must be a CUDA tensor on the q device");
-        TORCH_CHECK(softmax_lse.dtype() == torch::kFloat32,
-                    "softmax_lse must be fp32");
-        TORCH_CHECK(softmax_lse.dim() == 3 && softmax_lse.size(0) == B
-                        && softmax_lse.size(1) == H && softmax_lse.size(2) == M,
-                    "softmax_lse must have shape [B, H, M]");
-        TORCH_CHECK(softmax_lse.is_contiguous(),
-                    "softmax_lse must be contiguous [B, H, M]");
-    }
+  if (out_.has_value()) {
+    const at::Tensor& out = out_.value();
+    TORCH_CHECK(out.is_cuda() && out.device() == q.device(),
+                "out must be a CUDA tensor on the q device");
+    TORCH_CHECK(out.dtype() == torch::kFloat16, "out must be fp16");
+    TORCH_CHECK(out.sizes() == q.sizes(), "out must have shape [B, H, M, D]");
+    TORCH_CHECK(out.is_contiguous(), "out must be contiguous [B, H, M, D]");
+  }
+  if (softmax_lse_.has_value()) {
+    const at::Tensor& softmax_lse = softmax_lse_.value();
+    TORCH_CHECK(softmax_lse.is_cuda() && softmax_lse.device() == q.device(),
+                "softmax_lse must be a CUDA tensor on the q device");
+    TORCH_CHECK(softmax_lse.dtype() == torch::kFloat32,
+                "softmax_lse must be fp32");
+    TORCH_CHECK(softmax_lse.dim() == 3 && softmax_lse.size(0) == B &&
+                    softmax_lse.size(1) == H && softmax_lse.size(2) == M,
+                "softmax_lse must have shape [B, H, M]");
+    TORCH_CHECK(softmax_lse.is_contiguous(),
+                "softmax_lse must be contiguous [B, H, M]");
+  }
 
-    c10::cuda::CUDAGuard device_guard(q.device());
-    auto stream = at::cuda::getCurrentCUDAStream().stream();
-    cudaStreamCaptureStatus capture_status = cudaStreamCaptureStatusNone;
-    const cudaError_t capture_error = cudaStreamIsCapturing(stream, &capture_status);
-    TORCH_CHECK(capture_error == cudaSuccess, "cudaStreamIsCapturing failed: ",
-                cudaGetErrorString(capture_error));
-    TORCH_CHECK(capture_status == cudaStreamCaptureStatusNone,
-                "fixed BM32 prefill CUDA graph capture is not validated");
+  c10::cuda::CUDAGuard device_guard(q.device());
+  auto stream = at::cuda::getCurrentCUDAStream().stream();
+  cudaStreamCaptureStatus capture_status = cudaStreamCaptureStatusNone;
+  const cudaError_t capture_error =
+      cudaStreamIsCapturing(stream, &capture_status);
+  TORCH_CHECK(capture_error == cudaSuccess, "cudaStreamIsCapturing failed: ",
+              cudaGetErrorString(capture_error));
+  TORCH_CHECK(capture_status == cudaStreamCaptureStatusNone,
+              "fixed BM32 prefill CUDA graph capture is not validated");
 
-    auto props = at::cuda::getCurrentDeviceProperties();
-    TORCH_CHECK(props->major == 7 && props->minor == 0,
-                "fixed BM32 prefill supports only SM70 GPUs");
+  auto props = at::cuda::getCurrentDeviceProperties();
+  TORCH_CHECK(props->major == 7 && props->minor == 0,
+              "fixed BM32 prefill supports only SM70 GPUs");
 
-    at::Tensor out_fp16 = out_.has_value() ? out_.value() : torch::empty_like(q);
-    at::Tensor softmax_lse =
-        softmax_lse_.has_value()
-            ? softmax_lse_.value()
-            : torch::empty({B, H, M},
-                           torch::dtype(torch::kFloat32).device(q.device()));
+  at::Tensor out_fp16 = out_.has_value() ? out_.value() : torch::empty_like(q);
+  at::Tensor softmax_lse =
+      softmax_lse_.has_value()
+          ? softmax_lse_.value()
+          : torch::empty({B, H, M},
+                         torch::dtype(torch::kFloat32).device(q.device()));
 
-    launch_flash_attention_forward_paged_d256_bm32_phase_kernel<true, true, true>(
-        q, k_cache, v_cache, out_fp16, softmax_lse, block_table, seq_lens,
-        softmax_scale, stream);
+  launch_flash_attention_forward_paged_d256_bm32_phase_kernel<true, true, true>(
+      q, k_cache, v_cache, out_fp16, softmax_lse, block_table, seq_lens,
+      softmax_scale, stream);
 
-    return {out_fp16, softmax_lse};
+  return {out_fp16, softmax_lse};
 }
 
 std::vector<at::Tensor>
 flash_attention_prefill_paged_d256_bm32_allp_pair_scratch_splitkv3(
-    const at::Tensor& q,
-    const at::Tensor& k_cache,
-    const at::Tensor& v_cache,
-    std::optional<at::Tensor>& out_,
-    std::optional<at::Tensor>& softmax_lse_,
-    at::Tensor& split_tmp_out,
-    at::Tensor& split_tmp_row_max,
-    at::Tensor& split_tmp_row_sum,
-    const at::Tensor& block_table,
-    const int64_t actual_n,
-    const float softmax_scale
-) {
-    TORCH_CHECK(q.dim() == 4, "q must have shape [B, H, M, D]");
-    TORCH_CHECK(k_cache.dim() == 4 && v_cache.dim() == 4,
-                "k_cache and v_cache must have shape [blocks, page, Hkv, D]");
-    TORCH_CHECK(block_table.dim() == 2,
-                "block_table must have shape [B, max_num_blocks]");
-    TORCH_CHECK(q.dtype() == torch::kFloat16, "q must be fp16");
-    TORCH_CHECK(k_cache.dtype() == torch::kFloat16,
-                "k_cache must be fp16");
-    TORCH_CHECK(v_cache.dtype() == torch::kFloat16,
-                "v_cache must be fp16");
-    TORCH_CHECK(block_table.dtype() == torch::kInt32,
-                "block_table must be int32");
-    TORCH_CHECK(q.is_cuda() && k_cache.is_cuda() && v_cache.is_cuda(),
-                "q, k_cache, and v_cache must be CUDA tensors");
-    TORCH_CHECK(block_table.is_cuda(), "block_table must be a CUDA tensor");
-    TORCH_CHECK(
-        q.device() == k_cache.device() && q.device() == v_cache.device()
-            && q.device() == block_table.device(),
-        "all input tensors must be on the q device");
-    TORCH_CHECK(q.is_contiguous(), "q must be contiguous [B, H, M, D]");
-    TORCH_CHECK(block_table.is_contiguous(), "block_table must be contiguous");
-    TORCH_CHECK(k_cache.sizes() == v_cache.sizes(),
-                "k_cache and v_cache must have the same shape");
-    TORCH_CHECK(k_cache.stride(-1) == 1 && v_cache.stride(-1) == 1,
-                "K/V head dimensions must be contiguous");
-    TORCH_CHECK(k_cache.stride(1) % 8 == 0 && k_cache.stride(2) % 8 == 0
-                    && v_cache.stride(1) % 8 == 0
-                    && v_cache.stride(2) % 8 == 0,
-                "K/V strides must be divisible by 8 half elements");
+    const at::Tensor& q, const at::Tensor& k_cache, const at::Tensor& v_cache,
+    std::optional<at::Tensor>& out_, std::optional<at::Tensor>& softmax_lse_,
+    at::Tensor& split_tmp_out, at::Tensor& split_tmp_row_max,
+    at::Tensor& split_tmp_row_sum, const at::Tensor& block_table,
+    const int64_t actual_n, const float softmax_scale) {
+  TORCH_CHECK(q.dim() == 4, "q must have shape [B, H, M, D]");
+  TORCH_CHECK(k_cache.dim() == 4 && v_cache.dim() == 4,
+              "k_cache and v_cache must have shape [blocks, page, Hkv, D]");
+  TORCH_CHECK(block_table.dim() == 2,
+              "block_table must have shape [B, max_num_blocks]");
+  TORCH_CHECK(q.dtype() == torch::kFloat16, "q must be fp16");
+  TORCH_CHECK(k_cache.dtype() == torch::kFloat16, "k_cache must be fp16");
+  TORCH_CHECK(v_cache.dtype() == torch::kFloat16, "v_cache must be fp16");
+  TORCH_CHECK(block_table.dtype() == torch::kInt32,
+              "block_table must be int32");
+  TORCH_CHECK(q.is_cuda() && k_cache.is_cuda() && v_cache.is_cuda(),
+              "q, k_cache, and v_cache must be CUDA tensors");
+  TORCH_CHECK(block_table.is_cuda(), "block_table must be a CUDA tensor");
+  TORCH_CHECK(q.device() == k_cache.device() &&
+                  q.device() == v_cache.device() &&
+                  q.device() == block_table.device(),
+              "all input tensors must be on the q device");
+  TORCH_CHECK(q.is_contiguous(), "q must be contiguous [B, H, M, D]");
+  TORCH_CHECK(block_table.is_contiguous(), "block_table must be contiguous");
+  TORCH_CHECK(k_cache.sizes() == v_cache.sizes(),
+              "k_cache and v_cache must have the same shape");
+  TORCH_CHECK(k_cache.stride(-1) == 1 && v_cache.stride(-1) == 1,
+              "K/V head dimensions must be contiguous");
+  TORCH_CHECK(k_cache.stride(1) % 8 == 0 && k_cache.stride(2) % 8 == 0 &&
+                  v_cache.stride(1) % 8 == 0 && v_cache.stride(2) % 8 == 0,
+              "K/V strides must be divisible by 8 half elements");
 
-    const int B = q.size(0);
-    const int H = q.size(1);
-    const int M = q.size(2);
-    const int D = q.size(3);
-    const int num_kv_heads = k_cache.size(2);
+  const int B = q.size(0);
+  const int H = q.size(1);
+  const int M = q.size(2);
+  const int D = q.size(3);
+  const int num_kv_heads = k_cache.size(2);
 
-    TORCH_CHECK(B == 1,
-                "fixed BM32 split-KV host-length path requires B=1");
-    TORCH_CHECK(H > 0, "q head dimension must be positive");
-    TORCH_CHECK(M >= D256_BM32_PHASE_BLOCK_M,
-                "fixed BM32 split-KV prefill requires M >= ",
-                D256_BM32_PHASE_BLOCK_M);
-    TORCH_CHECK(D == D256_BM32_PHASE_D,
-                "fixed BM32 split-KV prefill requires D=",
-                D256_BM32_PHASE_D);
-    TORCH_CHECK(k_cache.size(0) > 0 && num_kv_heads > 0,
-                "K/V cache block and head dimensions must be positive");
-    TORCH_CHECK(k_cache.size(1) == D256_BM32_PHASE_PAGE_BLOCK_SIZE,
-                "fixed BM32 split-KV prefill requires page size ",
-                D256_BM32_PHASE_PAGE_BLOCK_SIZE);
-    TORCH_CHECK(k_cache.size(3) == D256_BM32_PHASE_D,
-                "K/V cache head dimension must be D=",
-                D256_BM32_PHASE_D);
-    TORCH_CHECK(H % num_kv_heads == 0,
-                "num_q_heads must be divisible by num_kv_heads");
-    TORCH_CHECK(block_table.size(0) == B,
-                "block_table batch dimension must equal q batch");
-    TORCH_CHECK(actual_n >= M && actual_n <= 2147483647LL,
-                "actual_n must satisfy M <= actual_n <= INT_MAX");
-    const int64_t required_pages =
-        (actual_n + D256_BM32_PHASE_PAGE_BLOCK_SIZE - 1)
-        / D256_BM32_PHASE_PAGE_BLOCK_SIZE;
-    TORCH_CHECK(block_table.size(1) >= required_pages,
-                "block_table does not cover actual_n host length");
+  TORCH_CHECK(B == 1, "fixed BM32 split-KV host-length path requires B=1");
+  TORCH_CHECK(H > 0, "q head dimension must be positive");
+  TORCH_CHECK(
+      M >= D256_BM32_PHASE_BLOCK_M,
+      "fixed BM32 split-KV prefill requires M >= ", D256_BM32_PHASE_BLOCK_M);
+  TORCH_CHECK(D == D256_BM32_PHASE_D,
+              "fixed BM32 split-KV prefill requires D=", D256_BM32_PHASE_D);
+  TORCH_CHECK(k_cache.size(0) > 0 && num_kv_heads > 0,
+              "K/V cache block and head dimensions must be positive");
+  TORCH_CHECK(k_cache.size(1) == D256_BM32_PHASE_PAGE_BLOCK_SIZE,
+              "fixed BM32 split-KV prefill requires page size ",
+              D256_BM32_PHASE_PAGE_BLOCK_SIZE);
+  TORCH_CHECK(k_cache.size(3) == D256_BM32_PHASE_D,
+              "K/V cache head dimension must be D=", D256_BM32_PHASE_D);
+  TORCH_CHECK(H % num_kv_heads == 0,
+              "num_q_heads must be divisible by num_kv_heads");
+  TORCH_CHECK(block_table.size(0) == B,
+              "block_table batch dimension must equal q batch");
+  TORCH_CHECK(actual_n >= M && actual_n <= 2147483647LL,
+              "actual_n must satisfy M <= actual_n <= INT_MAX");
+  const int64_t required_pages =
+      (actual_n + D256_BM32_PHASE_PAGE_BLOCK_SIZE - 1) /
+      D256_BM32_PHASE_PAGE_BLOCK_SIZE;
+  TORCH_CHECK(block_table.size(1) >= required_pages,
+              "block_table does not cover actual_n host length");
 
-    if (out_.has_value()) {
-        const at::Tensor& out = out_.value();
-        TORCH_CHECK(out.is_cuda() && out.device() == q.device(),
-                    "out must be a CUDA tensor on the q device");
-        TORCH_CHECK(out.dtype() == torch::kFloat16, "out must be fp16");
-        TORCH_CHECK(out.sizes() == q.sizes(), "out must have shape [B, H, M, D]");
-        TORCH_CHECK(out.is_contiguous(), "out must be contiguous [B, H, M, D]");
-    }
-    if (softmax_lse_.has_value()) {
-        const at::Tensor& softmax_lse = softmax_lse_.value();
-        TORCH_CHECK(softmax_lse.is_cuda() && softmax_lse.device() == q.device(),
-                    "softmax_lse must be a CUDA tensor on the q device");
-        TORCH_CHECK(softmax_lse.dtype() == torch::kFloat32,
-                    "softmax_lse must be fp32");
-        TORCH_CHECK(softmax_lse.dim() == 3 && softmax_lse.size(0) == B
-                        && softmax_lse.size(1) == H && softmax_lse.size(2) == M,
-                    "softmax_lse must have shape [B, H, M]");
-        TORCH_CHECK(softmax_lse.is_contiguous(),
-                    "softmax_lse must be contiguous [B, H, M]");
-    }
+  if (out_.has_value()) {
+    const at::Tensor& out = out_.value();
+    TORCH_CHECK(out.is_cuda() && out.device() == q.device(),
+                "out must be a CUDA tensor on the q device");
+    TORCH_CHECK(out.dtype() == torch::kFloat16, "out must be fp16");
+    TORCH_CHECK(out.sizes() == q.sizes(), "out must have shape [B, H, M, D]");
+    TORCH_CHECK(out.is_contiguous(), "out must be contiguous [B, H, M, D]");
+  }
+  if (softmax_lse_.has_value()) {
+    const at::Tensor& softmax_lse = softmax_lse_.value();
+    TORCH_CHECK(softmax_lse.is_cuda() && softmax_lse.device() == q.device(),
+                "softmax_lse must be a CUDA tensor on the q device");
+    TORCH_CHECK(softmax_lse.dtype() == torch::kFloat32,
+                "softmax_lse must be fp32");
+    TORCH_CHECK(softmax_lse.dim() == 3 && softmax_lse.size(0) == B &&
+                    softmax_lse.size(1) == H && softmax_lse.size(2) == M,
+                "softmax_lse must have shape [B, H, M]");
+    TORCH_CHECK(softmax_lse.is_contiguous(),
+                "softmax_lse must be contiguous [B, H, M]");
+  }
 
-    const std::vector<int64_t> expected_partial_out = {
-        B, H, D256_BM32_PHASE_SPLIT_PARTS, M, D};
-    const std::vector<int64_t> expected_partial_rows = {
-        B, H, D256_BM32_PHASE_SPLIT_PARTS, M};
-    for (const at::Tensor* workspace : {
-             &split_tmp_out, &split_tmp_row_max, &split_tmp_row_sum}) {
-        TORCH_CHECK(workspace->is_cuda() && workspace->device() == q.device(),
-                    "split-KV workspaces must be CUDA tensors on the q device");
-        TORCH_CHECK(workspace->dtype() == torch::kFloat32,
-                    "split-KV workspaces must be fp32");
-        TORCH_CHECK(workspace->is_contiguous(),
-                    "split-KV workspaces must be contiguous");
-    }
-    TORCH_CHECK(split_tmp_out.sizes() == expected_partial_out,
-                "split_tmp_out must have shape [B, H, 3, M, D]");
-    TORCH_CHECK(split_tmp_row_max.sizes() == expected_partial_rows,
-                "split_tmp_row_max must have shape [B, H, 3, M]");
-    TORCH_CHECK(split_tmp_row_sum.sizes() == expected_partial_rows,
-                "split_tmp_row_sum must have shape [B, H, 3, M]");
+  const std::vector<int64_t> expected_partial_out = {
+      B, H, D256_BM32_PHASE_SPLIT_PARTS, M, D};
+  const std::vector<int64_t> expected_partial_rows = {
+      B, H, D256_BM32_PHASE_SPLIT_PARTS, M};
+  for (const at::Tensor* workspace :
+       {&split_tmp_out, &split_tmp_row_max, &split_tmp_row_sum}) {
+    TORCH_CHECK(workspace->is_cuda() && workspace->device() == q.device(),
+                "split-KV workspaces must be CUDA tensors on the q device");
+    TORCH_CHECK(workspace->dtype() == torch::kFloat32,
+                "split-KV workspaces must be fp32");
+    TORCH_CHECK(workspace->is_contiguous(),
+                "split-KV workspaces must be contiguous");
+  }
+  TORCH_CHECK(split_tmp_out.sizes() == expected_partial_out,
+              "split_tmp_out must have shape [B, H, 3, M, D]");
+  TORCH_CHECK(split_tmp_row_max.sizes() == expected_partial_rows,
+              "split_tmp_row_max must have shape [B, H, 3, M]");
+  TORCH_CHECK(split_tmp_row_sum.sizes() == expected_partial_rows,
+              "split_tmp_row_sum must have shape [B, H, 3, M]");
 
-    c10::cuda::CUDAGuard device_guard(q.device());
-    auto stream = at::cuda::getCurrentCUDAStream().stream();
-    cudaStreamCaptureStatus capture_status = cudaStreamCaptureStatusNone;
-    const cudaError_t capture_error = cudaStreamIsCapturing(stream, &capture_status);
-    TORCH_CHECK(capture_error == cudaSuccess, "cudaStreamIsCapturing failed: ",
-                cudaGetErrorString(capture_error));
-    TORCH_CHECK(capture_status == cudaStreamCaptureStatusNone,
-                "fixed BM32 split-KV CUDA graph capture is not validated");
+  c10::cuda::CUDAGuard device_guard(q.device());
+  auto stream = at::cuda::getCurrentCUDAStream().stream();
+  cudaStreamCaptureStatus capture_status = cudaStreamCaptureStatusNone;
+  const cudaError_t capture_error =
+      cudaStreamIsCapturing(stream, &capture_status);
+  TORCH_CHECK(capture_error == cudaSuccess, "cudaStreamIsCapturing failed: ",
+              cudaGetErrorString(capture_error));
+  TORCH_CHECK(capture_status == cudaStreamCaptureStatusNone,
+              "fixed BM32 split-KV CUDA graph capture is not validated");
 
-    auto props = at::cuda::getCurrentDeviceProperties();
-    TORCH_CHECK(props->major == 7 && props->minor == 0,
-                "fixed BM32 split-KV prefill supports only SM70 GPUs");
+  auto props = at::cuda::getCurrentDeviceProperties();
+  TORCH_CHECK(props->major == 7 && props->minor == 0,
+              "fixed BM32 split-KV prefill supports only SM70 GPUs");
 
-    at::Tensor out_fp16 = out_.has_value() ? out_.value() : torch::empty_like(q);
-    at::Tensor softmax_lse =
-        softmax_lse_.has_value()
-            ? softmax_lse_.value()
-            : torch::empty({B, H, M},
-                           torch::dtype(torch::kFloat32).device(q.device()));
-    launch_flash_attention_forward_paged_d256_bm32_splitkv3_kernel(
-        q, k_cache, v_cache, out_fp16, softmax_lse,
-        split_tmp_out, split_tmp_row_max, split_tmp_row_sum,
-        block_table, static_cast<int>(actual_n),
-        softmax_scale, stream);
+  at::Tensor out_fp16 = out_.has_value() ? out_.value() : torch::empty_like(q);
+  at::Tensor softmax_lse =
+      softmax_lse_.has_value()
+          ? softmax_lse_.value()
+          : torch::empty({B, H, M},
+                         torch::dtype(torch::kFloat32).device(q.device()));
+  launch_flash_attention_forward_paged_d256_bm32_splitkv3_kernel(
+      q, k_cache, v_cache, out_fp16, softmax_lse, split_tmp_out,
+      split_tmp_row_max, split_tmp_row_sum, block_table,
+      static_cast<int>(actual_n), softmax_scale, stream);
 
-    return {out_fp16, softmax_lse};
+  return {out_fp16, softmax_lse};
 }
 
 at::Tensor flash_attention_prefill_paged_bfla(
-    const at::Tensor& q,
-    const at::Tensor& k_cache,
-    const at::Tensor& v_cache,
-    std::optional<at::Tensor>& out_,
-    const at::Tensor& block_table,
-    const at::Tensor& seq_lens,
-    const at::Tensor& bfla_block_mask,
-    const int bfla_mask_block_n,
-    const float softmax_scale,
-    const std::string& kv_cache_dtype,
-    const float k_scale,
-    const float v_scale,
-    const bool is_causal,
-    const int window_size_left,
-    const int window_size_right
-) {
-    TORCH_CHECK(q.dtype() == torch::kFloat16, "q must be fp16");
-    const int kv_dtype_code = kv_cache_dtype_code_from_string(kv_cache_dtype);
-    TORCH_CHECK(kv_dtype_code == flash_v100::KV_CACHE_DTYPE_FP16,
-                "BFLA paged prefill supports fp16 KV cache only");
-    TORCH_CHECK(k_cache.dtype() == torch::kFloat16, "k_cache must be fp16");
-    TORCH_CHECK(v_cache.dtype() == torch::kFloat16, "v_cache must be fp16");
-    TORCH_CHECK(q.is_cuda() && k_cache.is_cuda() && v_cache.is_cuda(),
-                "Tensors must be on CUDA");
-    TORCH_CHECK(block_table.is_cuda() && seq_lens.is_cuda(),
-                "block_table and seq_lens must be CUDA tensors");
-    TORCH_CHECK(bfla_block_mask.is_cuda(),
-                "bfla_block_mask must be a CUDA tensor");
-    TORCH_CHECK(bfla_block_mask.dtype() == torch::kInt32,
-                "bfla_block_mask must be int32");
-    TORCH_CHECK(bfla_block_mask.dim() == 4,
-                "bfla_block_mask must have shape [B, Hkv, q_tiles, kv_tiles]");
-    TORCH_CHECK(q.stride(-1) == 1 && k_cache.stride(-1) == 1 &&
-                    v_cache.stride(-1) == 1,
-                "Last dim must be contiguous");
-    TORCH_CHECK(k_cache.stride(1) % 8 == 0 && k_cache.stride(2) % 8 == 0 &&
-                    v_cache.stride(1) % 8 == 0 && v_cache.stride(2) % 8 == 0,
-                "Paged KV strides must be divisible by 8 half elements");
+    const at::Tensor& q, const at::Tensor& k_cache, const at::Tensor& v_cache,
+    std::optional<at::Tensor>& out_, const at::Tensor& block_table,
+    const at::Tensor& seq_lens, const at::Tensor& bfla_block_mask,
+    const int bfla_mask_block_n, const float softmax_scale,
+    const std::string& kv_cache_dtype, const float k_scale, const float v_scale,
+    const bool is_causal, const int window_size_left,
+    const int window_size_right) {
+  TORCH_CHECK(q.dtype() == torch::kFloat16, "q must be fp16");
+  const int kv_dtype_code = kv_cache_dtype_code_from_string(kv_cache_dtype);
+  TORCH_CHECK(kv_dtype_code == flash_v100::KV_CACHE_DTYPE_FP16,
+              "BFLA paged prefill supports fp16 KV cache only");
+  TORCH_CHECK(k_cache.dtype() == torch::kFloat16, "k_cache must be fp16");
+  TORCH_CHECK(v_cache.dtype() == torch::kFloat16, "v_cache must be fp16");
+  TORCH_CHECK(q.is_cuda() && k_cache.is_cuda() && v_cache.is_cuda(),
+              "Tensors must be on CUDA");
+  TORCH_CHECK(block_table.is_cuda() && seq_lens.is_cuda(),
+              "block_table and seq_lens must be CUDA tensors");
+  TORCH_CHECK(bfla_block_mask.is_cuda(),
+              "bfla_block_mask must be a CUDA tensor");
+  TORCH_CHECK(bfla_block_mask.dtype() == torch::kInt32,
+              "bfla_block_mask must be int32");
+  TORCH_CHECK(bfla_block_mask.dim() == 4,
+              "bfla_block_mask must have shape [B, Hkv, q_tiles, kv_tiles]");
+  TORCH_CHECK(
+      q.stride(-1) == 1 && k_cache.stride(-1) == 1 && v_cache.stride(-1) == 1,
+      "Last dim must be contiguous");
+  TORCH_CHECK(k_cache.stride(1) % 8 == 0 && k_cache.stride(2) % 8 == 0 &&
+                  v_cache.stride(1) % 8 == 0 && v_cache.stride(2) % 8 == 0,
+              "Paged KV strides must be divisible by 8 half elements");
 
-    const int B = q.size(0);
-    const int H = q.size(1);
-    const int M = q.size(2);
-    const int D = q.size(3);
-    const int num_kv_heads = k_cache.size(2);
-    const int page_block_size = k_cache.size(1);
+  const int B = q.size(0);
+  const int H = q.size(1);
+  const int M = q.size(2);
+  const int D = q.size(3);
+  const int num_kv_heads = k_cache.size(2);
+  const int page_block_size = k_cache.size(1);
 
-    TORCH_CHECK(D == 256, "BFLA paged prefill supports D=256 only");
-    TORCH_CHECK(H % num_kv_heads == 0,
-                "num_heads must be divisible by num_kv_heads");
-    TORCH_CHECK(M > 1, "BFLA paged prefill requires prefill M > 1");
-    TORCH_CHECK(page_block_size >= 16 && (page_block_size % 16) == 0,
-                "BFLA paged prefill requires page block size multiple of 16");
-    TORCH_CHECK(is_causal, "BFLA paged prefill supports causal attention only");
-    TORCH_CHECK(window_size_left == -1 && window_size_right == -1,
-                "BFLA paged prefill does not support sliding window");
-    TORCH_CHECK(bfla_mask_block_n > 0,
-                "bfla_mask_block_n must be positive");
-    TORCH_CHECK(B <= bfla_block_mask.size(0),
-                "bfla_block_mask batch dimension must cover q");
-    TORCH_CHECK(num_kv_heads <= bfla_block_mask.size(1),
-                "bfla_block_mask head dimension must cover KV heads");
+  TORCH_CHECK(D == 256, "BFLA paged prefill supports D=256 only");
+  TORCH_CHECK(H % num_kv_heads == 0,
+              "num_heads must be divisible by num_kv_heads");
+  TORCH_CHECK(M > 1, "BFLA paged prefill requires prefill M > 1");
+  TORCH_CHECK(page_block_size >= 16 && (page_block_size % 16) == 0,
+              "BFLA paged prefill requires page block size multiple of 16");
+  TORCH_CHECK(is_causal, "BFLA paged prefill supports causal attention only");
+  TORCH_CHECK(window_size_left == -1 && window_size_right == -1,
+              "BFLA paged prefill does not support sliding window");
+  TORCH_CHECK(bfla_mask_block_n > 0, "bfla_mask_block_n must be positive");
+  TORCH_CHECK(B <= bfla_block_mask.size(0),
+              "bfla_block_mask batch dimension must cover q");
+  TORCH_CHECK(num_kv_heads <= bfla_block_mask.size(1),
+              "bfla_block_mask head dimension must cover KV heads");
 
-    at::Tensor out_fp16 = out_.has_value() ? out_.value() : torch::zeros_like(q);
-    auto softmax_lse = torch::zeros({B, H, M},
-                                    torch::dtype(torch::kFloat32).device(q.device()));
+  at::Tensor out_fp16 = out_.has_value() ? out_.value() : torch::zeros_like(q);
+  auto softmax_lse =
+      torch::zeros({B, H, M}, torch::dtype(torch::kFloat32).device(q.device()));
 
-    auto stream = at::cuda::getCurrentCUDAStream().stream();
-    auto props = at::cuda::getCurrentDeviceProperties();
-    bool sm70 = props->major == 7 && props->minor == 0;
-    TORCH_CHECK(sm70, "Kernel supports only Volta GPUs.");
+  auto stream = at::cuda::getCurrentCUDAStream().stream();
+  auto props = at::cuda::getCurrentDeviceProperties();
+  bool sm70 = props->major == 7 && props->minor == 0;
+  TORCH_CHECK(sm70, "Kernel supports only Volta GPUs.");
 
-    launcher_flash_attention_forward_paged<256, flash_v100::KV_CACHE_DTYPE_FP16>(
-        q, k_cache, v_cache, out_fp16, softmax_lse, block_table, seq_lens,
-        softmax_scale, is_causal, k_scale, v_scale, window_size_left,
-        window_size_right, stream, bfla_block_mask.data_ptr<int>(),
-        bfla_mask_block_n, bfla_block_mask.stride(0),
-        bfla_block_mask.stride(1), bfla_block_mask.stride(2),
-        bfla_block_mask.stride(3));
+  launcher_flash_attention_forward_paged<256, flash_v100::KV_CACHE_DTYPE_FP16>(
+      q, k_cache, v_cache, out_fp16, softmax_lse, block_table, seq_lens,
+      softmax_scale, is_causal, k_scale, v_scale, window_size_left,
+      window_size_right, stream, bfla_block_mask.data_ptr<int>(),
+      bfla_mask_block_n, bfla_block_mask.stride(0), bfla_block_mask.stride(1),
+      bfla_block_mask.stride(2), bfla_block_mask.stride(3));
 
-    return out_fp16;
+  return out_fp16;
 }
 
 at::Tensor flash_attention_decode_paged_wmma(
-    const at::Tensor& q,
-    const at::Tensor& k_cache,
-    const at::Tensor& v_cache,
-    std::optional<at::Tensor>& out_,
-    const at::Tensor& block_table,
-    const at::Tensor& seq_lens,
-    const float softmax_scale,
-    const std::string& kv_cache_dtype,
-    const float k_scale,
-    const float v_scale
-) {
-    TORCH_CHECK(q.dtype() == torch::kFloat16, "q must be fp16");
-    const int kv_dtype_code = kv_cache_dtype_code_from_string(kv_cache_dtype);
-    TORCH_CHECK(kv_dtype_code >= 0, "Unsupported kv_cache_dtype: ", kv_cache_dtype);
-    if (kv_dtype_code == flash_v100::KV_CACHE_DTYPE_FP16) {
-        TORCH_CHECK(k_cache.dtype() == torch::kFloat16, "k_cache must be fp16");
-        TORCH_CHECK(v_cache.dtype() == torch::kFloat16, "v_cache must be fp16");
-    } else {
-        TORCH_CHECK(k_cache.dtype() == torch::kUInt8,
-                    "fp8 k_cache must be stored as uint8");
-        TORCH_CHECK(v_cache.dtype() == torch::kUInt8,
-                    "fp8 v_cache must be stored as uint8");
-        TORCH_CHECK(k_scale > 0.f && v_scale > 0.f,
-                    "fp8 k/v scales must be positive");
-    }
-    TORCH_CHECK(q.is_cuda() && k_cache.is_cuda() && v_cache.is_cuda(),
-                "Tensors must be on CUDA");
-    TORCH_CHECK(block_table.is_cuda() && seq_lens.is_cuda(),
-                "block_table and seq_lens must be CUDA tensors");
-    TORCH_CHECK(q.dim() == 3, "q must have shape [B, H, D]");
-    TORCH_CHECK(block_table.dim() == 2,
-                "block_table must have shape [B, max_num_blocks]");
-    TORCH_CHECK(seq_lens.dim() == 1, "seq_lens must have shape [B]");
-    TORCH_CHECK(q.stride(-1) == 1 && k_cache.stride(-1) == 1 &&
-                    v_cache.stride(-1) == 1,
-                "Last dim must be contiguous");
-    TORCH_CHECK(k_cache.stride(1) % 8 == 0 && k_cache.stride(2) % 8 == 0 &&
-                    v_cache.stride(1) % 8 == 0 && v_cache.stride(2) % 8 == 0,
-                "Paged KV strides must be divisible by 8 half elements");
+    const at::Tensor& q, const at::Tensor& k_cache, const at::Tensor& v_cache,
+    std::optional<at::Tensor>& out_, const at::Tensor& block_table,
+    const at::Tensor& seq_lens, const float softmax_scale,
+    const std::string& kv_cache_dtype, const float k_scale,
+    const float v_scale) {
+  TORCH_CHECK(q.dtype() == torch::kFloat16, "q must be fp16");
+  const int kv_dtype_code = kv_cache_dtype_code_from_string(kv_cache_dtype);
+  TORCH_CHECK(kv_dtype_code >= 0,
+              "Unsupported kv_cache_dtype: ", kv_cache_dtype);
+  if (kv_dtype_code == flash_v100::KV_CACHE_DTYPE_FP16) {
+    TORCH_CHECK(k_cache.dtype() == torch::kFloat16, "k_cache must be fp16");
+    TORCH_CHECK(v_cache.dtype() == torch::kFloat16, "v_cache must be fp16");
+  } else {
+    TORCH_CHECK(k_cache.dtype() == torch::kUInt8,
+                "fp8 k_cache must be stored as uint8");
+    TORCH_CHECK(v_cache.dtype() == torch::kUInt8,
+                "fp8 v_cache must be stored as uint8");
+    TORCH_CHECK(k_scale > 0.f && v_scale > 0.f,
+                "fp8 k/v scales must be positive");
+  }
+  TORCH_CHECK(q.is_cuda() && k_cache.is_cuda() && v_cache.is_cuda(),
+              "Tensors must be on CUDA");
+  TORCH_CHECK(block_table.is_cuda() && seq_lens.is_cuda(),
+              "block_table and seq_lens must be CUDA tensors");
+  TORCH_CHECK(q.dim() == 3, "q must have shape [B, H, D]");
+  TORCH_CHECK(block_table.dim() == 2,
+              "block_table must have shape [B, max_num_blocks]");
+  TORCH_CHECK(seq_lens.dim() == 1, "seq_lens must have shape [B]");
+  TORCH_CHECK(
+      q.stride(-1) == 1 && k_cache.stride(-1) == 1 && v_cache.stride(-1) == 1,
+      "Last dim must be contiguous");
+  TORCH_CHECK(k_cache.stride(1) % 8 == 0 && k_cache.stride(2) % 8 == 0 &&
+                  v_cache.stride(1) % 8 == 0 && v_cache.stride(2) % 8 == 0,
+              "Paged KV strides must be divisible by 8 half elements");
 
-    const int B = q.size(0);
-    const int H = q.size(1);
-    const int D = q.size(2);
-    const int num_kv_heads = k_cache.size(2);
+  const int B = q.size(0);
+  const int H = q.size(1);
+  const int D = q.size(2);
+  const int num_kv_heads = k_cache.size(2);
 
-    TORCH_CHECK(B <= block_table.size(0), "block_table batch size must cover q");
-    TORCH_CHECK(B <= seq_lens.size(0), "seq_lens batch size must cover q");
-    TORCH_CHECK(D <= 256 && D % 8 == 0 && D % 2 == 0,
-                "D must be even, <=256, multiple of 8");
-    TORCH_CHECK(H % num_kv_heads == 0,
-                "num_heads must be divisible by num_kv_heads");
+  TORCH_CHECK(B <= block_table.size(0), "block_table batch size must cover q");
+  TORCH_CHECK(B <= seq_lens.size(0), "seq_lens batch size must cover q");
+  TORCH_CHECK(D <= 256 && D % 8 == 0 && D % 2 == 0,
+              "D must be even, <=256, multiple of 8");
+  TORCH_CHECK(H % num_kv_heads == 0,
+              "num_heads must be divisible by num_kv_heads");
 
-    at::Tensor out_fp16 = out_.has_value() ? out_.value() : torch::zeros_like(q);
-    TORCH_CHECK(out_fp16.is_cuda(), "out must be on CUDA");
-    TORCH_CHECK(out_fp16.dtype() == torch::kFloat16, "out must be fp16");
-    TORCH_CHECK(out_fp16.sizes() == q.sizes(), "out must have same shape as q");
-    TORCH_CHECK(out_fp16.stride(-1) == 1, "out last dim must be contiguous");
+  at::Tensor out_fp16 = out_.has_value() ? out_.value() : torch::zeros_like(q);
+  TORCH_CHECK(out_fp16.is_cuda(), "out must be on CUDA");
+  TORCH_CHECK(out_fp16.dtype() == torch::kFloat16, "out must be fp16");
+  TORCH_CHECK(out_fp16.sizes() == q.sizes(), "out must have same shape as q");
+  TORCH_CHECK(out_fp16.stride(-1) == 1, "out last dim must be contiguous");
 
-    at::Tensor q_m1 = q.unsqueeze(2);
-    at::Tensor out_m1 = out_fp16.unsqueeze(2);
-    auto softmax_lse = torch::zeros({B, H, 1},
-                                    torch::dtype(torch::kFloat32).device(q.device()));
+  at::Tensor q_m1 = q.unsqueeze(2);
+  at::Tensor out_m1 = out_fp16.unsqueeze(2);
+  auto softmax_lse =
+      torch::zeros({B, H, 1}, torch::dtype(torch::kFloat32).device(q.device()));
 
-    auto stream = at::cuda::getCurrentCUDAStream().stream();
-    auto props = at::cuda::getCurrentDeviceProperties();
-    bool sm70 = props->major == 7 && props->minor == 0;
-    TORCH_CHECK(sm70, "Kernel supports only Volta GPUs.");
+  auto stream = at::cuda::getCurrentCUDAStream().stream();
+  auto props = at::cuda::getCurrentDeviceProperties();
+  bool sm70 = props->major == 7 && props->minor == 0;
+  TORCH_CHECK(sm70, "Kernel supports only Volta GPUs.");
 
-    #define LAUNCH_DECODE_WMMA_TYPED(HDIM, KV_DTYPE_CODE)                       \
-        launcher_flash_attention_forward_paged<HDIM, KV_DTYPE_CODE>(            \
-            q_m1, k_cache, v_cache, out_m1, softmax_lse, block_table, seq_lens, \
-            softmax_scale, true, k_scale, v_scale, -1, -1, stream)
+#define LAUNCH_DECODE_WMMA_TYPED(HDIM, KV_DTYPE_CODE)                     \
+  launcher_flash_attention_forward_paged<HDIM, KV_DTYPE_CODE>(            \
+      q_m1, k_cache, v_cache, out_m1, softmax_lse, block_table, seq_lens, \
+      softmax_scale, true, k_scale, v_scale, -1, -1, stream)
 
-    #define LAUNCH_DECODE_WMMA_BY_KV(HDIM)                                      \
-        do {                                                                    \
-            switch (kv_dtype_code) {                                            \
-                case flash_v100::KV_CACHE_DTYPE_FP16:                           \
-                    LAUNCH_DECODE_WMMA_TYPED(HDIM, flash_v100::KV_CACHE_DTYPE_FP16); \
-                    break;                                                      \
-                case flash_v100::KV_CACHE_DTYPE_FP8_E4M3:                       \
-                    LAUNCH_DECODE_WMMA_TYPED(HDIM, flash_v100::KV_CACHE_DTYPE_FP8_E4M3); \
-                    break;                                                      \
-                case flash_v100::KV_CACHE_DTYPE_FP8_E5M2:                       \
-                    LAUNCH_DECODE_WMMA_TYPED(HDIM, flash_v100::KV_CACHE_DTYPE_FP8_E5M2); \
-                    break;                                                      \
-                default:                                                        \
-                    TORCH_CHECK(false, "Unsupported kv_cache_dtype: ", kv_cache_dtype); \
-            }                                                                   \
-        } while (0)
+#define LAUNCH_DECODE_WMMA_BY_KV(HDIM)                                       \
+  do {                                                                       \
+    switch (kv_dtype_code) {                                                 \
+      case flash_v100::KV_CACHE_DTYPE_FP16:                                  \
+        LAUNCH_DECODE_WMMA_TYPED(HDIM, flash_v100::KV_CACHE_DTYPE_FP16);     \
+        break;                                                               \
+      case flash_v100::KV_CACHE_DTYPE_FP8_E4M3:                              \
+        LAUNCH_DECODE_WMMA_TYPED(HDIM, flash_v100::KV_CACHE_DTYPE_FP8_E4M3); \
+        break;                                                               \
+      case flash_v100::KV_CACHE_DTYPE_FP8_E5M2:                              \
+        LAUNCH_DECODE_WMMA_TYPED(HDIM, flash_v100::KV_CACHE_DTYPE_FP8_E5M2); \
+        break;                                                               \
+      default:                                                               \
+        TORCH_CHECK(false, "Unsupported kv_cache_dtype: ", kv_cache_dtype);  \
+    }                                                                        \
+  } while (0)
 
-    switch (D) {
-        case 16:
-            LAUNCH_DECODE_WMMA_BY_KV(16);
-            break;
-        case 32:
-            LAUNCH_DECODE_WMMA_BY_KV(32);
-            break;
-        case 64:
-            LAUNCH_DECODE_WMMA_BY_KV(64);
-            break;
-        case 128:
-            LAUNCH_DECODE_WMMA_BY_KV(128);
-            break;
-        case 256:
-            LAUNCH_DECODE_WMMA_BY_KV(256);
-            break;
-        default:
-            TORCH_CHECK(false, "Unsupported D: ", D);
-    }
+  switch (D) {
+    case 16:
+      LAUNCH_DECODE_WMMA_BY_KV(16);
+      break;
+    case 32:
+      LAUNCH_DECODE_WMMA_BY_KV(32);
+      break;
+    case 64:
+      LAUNCH_DECODE_WMMA_BY_KV(64);
+      break;
+    case 128:
+      LAUNCH_DECODE_WMMA_BY_KV(128);
+      break;
+    case 256:
+      LAUNCH_DECODE_WMMA_BY_KV(256);
+      break;
+    default:
+      TORCH_CHECK(false, "Unsupported D: ", D);
+  }
 
-    #undef LAUNCH_DECODE_WMMA_BY_KV
-    #undef LAUNCH_DECODE_WMMA_TYPED
+#undef LAUNCH_DECODE_WMMA_BY_KV
+#undef LAUNCH_DECODE_WMMA_TYPED
 
-    C10_CUDA_KERNEL_LAUNCH_CHECK();
-    return out_fp16;
+  C10_CUDA_KERNEL_LAUNCH_CHECK();
+  return out_fp16;
 }

--- a/flash-attention-v100/kernel/fused_mha_forward_paged_full.cu
+++ b/flash-attention-v100/kernel/fused_mha_forward_paged_full.cu
@@ -16,589 +16,621 @@ using namespace nvcuda::wmma;
 #define WMMA_N 16
 #define WMMA_K 16
 
-#define MAX_THREADS_PER_WARP    32
-#define MAX_THREADS_PER_SM      2048
-#define MAX_THREAD_BLOCK_SIZE   1024
+#define MAX_THREADS_PER_WARP 32
+#define MAX_THREADS_PER_SM 2048
+#define MAX_THREAD_BLOCK_SIZE 1024
 #define MAX_THREAD_BLOCK_PER_SM 32
-#define MAX_WARPS_PER_SM        64
-#define MAX_SM_PER_GPU          80
-#define MAX_SMEM_PER_SM         98304
+#define MAX_WARPS_PER_SM 64
+#define MAX_SM_PER_GPU 80
+#define MAX_SMEM_PER_SM 98304
 
-#define WARP_ALLOC_GROUP        4
+#define WARP_ALLOC_GROUP 4
 
-#define MAX_REG_PER_UNIT        256
-#define MAX_REG_PER_THREAD      255
-#define MAX_REG_PER_BLOCK       65536
-#define MAX_REG_BUFFER          65536
+#define MAX_REG_PER_UNIT 256
+#define MAX_REG_PER_THREAD 255
+#define MAX_REG_PER_BLOCK 65536
+#define MAX_REG_BUFFER 65536
 
-#define BLOCK_M_16  16
-#define BLOCK_N_16  512
-#define WARPS_16    16
+#define BLOCK_M_16 16
+#define BLOCK_N_16 512
+#define WARPS_16 16
 
-#define BLOCK_M_32  32
-#define BLOCK_N_32  256
-#define WARPS_32    16
+#define BLOCK_M_32 32
+#define BLOCK_N_32 256
+#define WARPS_32 16
 
-#define BLOCK_M_64  64
-#define BLOCK_N_64  128
-#define WARPS_64    16
+#define BLOCK_M_64 64
+#define BLOCK_N_64 128
+#define WARPS_64 16
 
 #define BLOCK_M_128 32
 #define BLOCK_N_128 176
-#define WARPS_128   16
+#define WARPS_128 16
 
 #define BLOCK_M_256 32
 #define BLOCK_N_256 64
-#define WARPS_256   16
+#define WARPS_256 16
 
-template<int D>
+template <int D>
 struct KernelConfig {
-    static constexpr int BLOCK_M = (D == 16) ? BLOCK_M_16 : (D == 32) ? BLOCK_M_32 : (D == 64) ? BLOCK_M_64 : (D == 128) ? BLOCK_M_128 : BLOCK_M_256;
-    static constexpr int BLOCK_N = (D == 16) ? BLOCK_N_16 : (D == 32) ? BLOCK_N_32 : (D == 64) ? BLOCK_N_64 : (D == 128) ? BLOCK_N_128 : BLOCK_N_256;
-    static constexpr int WARPS_PER_BLOCK = (D == 16) ? WARPS_16 : (D == 32) ? WARPS_32 : (D == 64) ? WARPS_64 : (D == 128) ? WARPS_128 : WARPS_256;
+  static constexpr int BLOCK_M = (D == 16)    ? BLOCK_M_16
+                                 : (D == 32)  ? BLOCK_M_32
+                                 : (D == 64)  ? BLOCK_M_64
+                                 : (D == 128) ? BLOCK_M_128
+                                              : BLOCK_M_256;
+  static constexpr int BLOCK_N = (D == 16)    ? BLOCK_N_16
+                                 : (D == 32)  ? BLOCK_N_32
+                                 : (D == 64)  ? BLOCK_N_64
+                                 : (D == 128) ? BLOCK_N_128
+                                              : BLOCK_N_256;
+  static constexpr int WARPS_PER_BLOCK = (D == 16)    ? WARPS_16
+                                         : (D == 32)  ? WARPS_32
+                                         : (D == 64)  ? WARPS_64
+                                         : (D == 128) ? WARPS_128
+                                                      : WARPS_256;
 
-    static constexpr int THREADS_PER_BLOCK = WARPS_PER_BLOCK * MAX_THREADS_PER_WARP;
-    static constexpr int THREADS_PER_ROW   = THREADS_PER_BLOCK / BLOCK_M;
-    static constexpr int PAD               = (8 - (D % 32) + 32) % 32;
-    static constexpr int Q_STRIDE          = D + PAD;
-    static constexpr int KV_STRIDE         = D + PAD;
-    static constexpr int S_STRIDE          = BLOCK_N + PAD;
-    static constexpr int O_STRIDE          = D + PAD;
-    static constexpr int PER_UINT4         = 8;
+  static constexpr int THREADS_PER_BLOCK =
+      WARPS_PER_BLOCK * MAX_THREADS_PER_WARP;
+  static constexpr int THREADS_PER_ROW = THREADS_PER_BLOCK / BLOCK_M;
+  static constexpr int PAD = (8 - (D % 32) + 32) % 32;
+  static constexpr int Q_STRIDE = D + PAD;
+  static constexpr int KV_STRIDE = D + PAD;
+  static constexpr int S_STRIDE = BLOCK_N + PAD;
+  static constexpr int O_STRIDE = D + PAD;
+  static constexpr int PER_UINT4 = 8;
 
-    struct alignas(128) SmemLayout {
-        alignas(16) __half q      [BLOCK_M * Q_STRIDE];
+  struct alignas(128) SmemLayout {
+    alignas(16) __half q[BLOCK_M * Q_STRIDE];
     union {
-        alignas(16) __half k      [BLOCK_N * KV_STRIDE];
-        alignas(16) __half v      [BLOCK_N * KV_STRIDE];
+      alignas(16) __half k[BLOCK_N * KV_STRIDE];
+      alignas(16) __half v[BLOCK_N * KV_STRIDE];
     } reuse_kv;
     union {
-        alignas(16) float  s      [BLOCK_M * S_STRIDE];
-        alignas(16) __half p      [BLOCK_M * S_STRIDE];
+      alignas(16) float s[BLOCK_M * S_STRIDE];
+      alignas(16) __half p[BLOCK_M * S_STRIDE];
     } reuse_sp;
-        alignas(16) float  o      [BLOCK_M * O_STRIDE];
-        alignas(16) float  row_max[BLOCK_M];
-        alignas(16) float  row_sum[BLOCK_M];
-    };
+    alignas(16) float o[BLOCK_M * O_STRIDE];
+    alignas(16) float row_max[BLOCK_M];
+    alignas(16) float row_sum[BLOCK_M];
+  };
 
-    static constexpr size_t TOTAL_SMEM = ((sizeof(SmemLayout) + 127) & ~size_t(127));
+  static constexpr size_t TOTAL_SMEM =
+      ((sizeof(SmemLayout) + 127) & ~size_t(127));
 };
 
-template<typename Config>
+template <typename Config>
 __device__ __forceinline__ void init_smem(char* smem_raw) {
-    constexpr int N_U4 = Config::TOTAL_SMEM / 16;
-    constexpr int THREADS_PER_BLOCK = Config::THREADS_PER_BLOCK;
-    const int tid = threadIdx.x;
+  constexpr int N_U4 = Config::TOTAL_SMEM / 16;
+  constexpr int THREADS_PER_BLOCK = Config::THREADS_PER_BLOCK;
+  const int tid = threadIdx.x;
 
-    uint32_t addr = static_cast<uint32_t>(__cvta_generic_to_shared(smem_raw));
-    #pragma unroll 1
-    for (int i = tid; i < N_U4; i += THREADS_PER_BLOCK) {
-        asm volatile("st.shared.v4.u32 [%0], {%1,%1,%1,%1};"
-                     :: "r"(addr + (i << 4)), "r"(0) : "memory");
-    }
-    __syncthreads();
+  uint32_t addr = static_cast<uint32_t>(__cvta_generic_to_shared(smem_raw));
+#pragma unroll 1
+  for (int i = tid; i < N_U4; i += THREADS_PER_BLOCK) {
+    asm volatile("st.shared.v4.u32 [%0], {%1,%1,%1,%1};" ::"r"(addr + (i << 4)),
+                 "r"(0)
+                 : "memory");
+  }
+  __syncthreads();
 }
 
-template<int D, bool IS_CAUSAL>
+template <int D, bool IS_CAUSAL>
 __global__ void __launch_bounds__(KernelConfig<D>::THREADS_PER_BLOCK, 2)
-flash_attention_forward_kernel(
-    const __half* __restrict__ Q,
-    const __half* __restrict__ K,
-    const __half* __restrict__ V,
-          __half* __restrict__ Out,
-           float* __restrict__ softmax_lse,
-    const int B,
-    const int H,
-    const int M,
-    const int N,
-    const float softmax_scale
-) {
-    using Config = KernelConfig<D>;
-    constexpr int BLOCK_M           = Config::BLOCK_M;
-    constexpr int BLOCK_N           = Config::BLOCK_N;
-    constexpr int THREADS_PER_BLOCK = Config::THREADS_PER_BLOCK;
-    constexpr int THREADS_PER_ROW   = Config::THREADS_PER_ROW;
-    constexpr int WARPS_PER_BLOCK   = Config::WARPS_PER_BLOCK;
-    constexpr int Q_STRIDE          = Config::Q_STRIDE;
-    constexpr int KV_STRIDE         = Config::KV_STRIDE;
-    constexpr int S_STRIDE          = Config::S_STRIDE;
-    constexpr int O_STRIDE          = Config::O_STRIDE;
-    constexpr int PER_UINT4         = Config::PER_UINT4;
-    const float NEG_INF = -1e30f;
+    flash_attention_forward_kernel(const __half* __restrict__ Q,
+                                   const __half* __restrict__ K,
+                                   const __half* __restrict__ V,
+                                   __half* __restrict__ Out,
+                                   float* __restrict__ softmax_lse, const int B,
+                                   const int H, const int M, const int N,
+                                   const float softmax_scale) {
+  using Config = KernelConfig<D>;
+  constexpr int BLOCK_M = Config::BLOCK_M;
+  constexpr int BLOCK_N = Config::BLOCK_N;
+  constexpr int THREADS_PER_BLOCK = Config::THREADS_PER_BLOCK;
+  constexpr int THREADS_PER_ROW = Config::THREADS_PER_ROW;
+  constexpr int WARPS_PER_BLOCK = Config::WARPS_PER_BLOCK;
+  constexpr int Q_STRIDE = Config::Q_STRIDE;
+  constexpr int KV_STRIDE = Config::KV_STRIDE;
+  constexpr int S_STRIDE = Config::S_STRIDE;
+  constexpr int O_STRIDE = Config::O_STRIDE;
+  constexpr int PER_UINT4 = Config::PER_UINT4;
+  const float NEG_INF = -1e30f;
 
-    const int batch_head_id = blockIdx.z;
-    if (batch_head_id >= B * H) return;
+  const int batch_head_id = blockIdx.z;
+  if (batch_head_id >= B * H) return;
 
-    const int block_m = blockIdx.x;
-    const int start_row = block_m * BLOCK_M;
-    if (start_row >= M) return;
+  const int block_m = blockIdx.x;
+  const int start_row = block_m * BLOCK_M;
+  if (start_row >= M) return;
 
-    int num_n_tiles = (N + BLOCK_N - 1) / BLOCK_N;
-    const int valid_q_rows = min(BLOCK_M, M - start_row);
+  int num_n_tiles = (N + BLOCK_N - 1) / BLOCK_N;
+  const int valid_q_rows = min(BLOCK_M, M - start_row);
+
+  if constexpr (IS_CAUSAL) {
+    const int max_key_pos = start_row + valid_q_rows - 1;
+    if (max_key_pos < 0) {
+      num_n_tiles = 0;
+    } else {
+      num_n_tiles = min(num_n_tiles, (max_key_pos + BLOCK_N + 0) / BLOCK_N);
+    }
+  }
+
+  const int tid = threadIdx.x;
+  const int warp_id = tid / MAX_THREADS_PER_WARP;
+  const int lane_id = tid % MAX_THREADS_PER_WARP;
+
+  const __half* q_ptr = Q + (size_t)batch_head_id * M * D + start_row * D;
+  const __half* k_ptr = K + (size_t)batch_head_id * N * D;
+  const __half* v_ptr = V + (size_t)batch_head_id * N * D;
+  __half* out_ptr = Out + (size_t)batch_head_id * M * D + start_row * D;
+  float* softmax_lse_ptr = softmax_lse + (size_t)batch_head_id * M + start_row;
+
+  extern __shared__ char smem_raw[];
+  init_smem<Config>(smem_raw);
+  auto& smem = *reinterpret_cast<typename Config::SmemLayout*>(smem_raw);
+
+  __half* sQ = smem.q;
+  __half* sK = smem.reuse_kv.k;
+  __half* sV = smem.reuse_kv.v;
+  float* sS = smem.reuse_sp.s;
+  __half* sP = smem.reuse_sp.p;
+  float* sO = smem.o;
+  float* sRowMax = smem.row_max;
+  float* sRowSum = smem.row_sum;
+
+  const int d_stride_uint4 = (D + PER_UINT4 - 1) / PER_UINT4;
+  const int q_stride_uint4 = (Q_STRIDE + PER_UINT4 - 1) / PER_UINT4;
+  const int kv_stride_uint4 = (KV_STRIDE + PER_UINT4 - 1) / PER_UINT4;
+
+  if (tid < BLOCK_M) {
+    sRowMax[tid] = NEG_INF;
+  }
+
+  const uint4* q_vec = reinterpret_cast<const uint4*>(q_ptr);
+  uint4* sQ_vec = reinterpret_cast<uint4*>(sQ);
+
+#pragma unroll 4
+  for (int idx = tid; idx < (valid_q_rows * d_stride_uint4);
+       idx += THREADS_PER_BLOCK) {
+    const int row = idx / d_stride_uint4;
+    const int vec_col = idx % d_stride_uint4;
+    uint4 q_val = make_uint4(0, 0, 0, 0);
+    if (row < valid_q_rows && vec_col < d_stride_uint4) {
+      q_val = __ldg(&q_vec[row * d_stride_uint4 + vec_col]);
+    }
+    sQ_vec[row * q_stride_uint4 + vec_col] = q_val;
+  }
+  __syncthreads();
+
+  for (int block_n = 0; block_n < num_n_tiles; ++block_n) {
+    const int start_col = block_n * BLOCK_N;
+    if (start_col >= N) break;
+    const int valid_k_rows = min(BLOCK_N, N - start_col);
 
     if constexpr (IS_CAUSAL) {
-        const int max_key_pos = start_row + valid_q_rows - 1;
-        if (max_key_pos < 0) {
-            num_n_tiles = 0;
-        } else {
-            num_n_tiles = min(num_n_tiles, (max_key_pos + BLOCK_N + 0) / BLOCK_N);
-        }
+      if (start_col >= start_row + valid_q_rows) {
+        continue;
+      }
     }
 
-    const int tid = threadIdx.x;
-    const int warp_id = tid / MAX_THREADS_PER_WARP;
-    const int lane_id = tid % MAX_THREADS_PER_WARP;
+    const uint4* k_vec = reinterpret_cast<const uint4*>(k_ptr + start_col * D);
+    uint4* sK_vec = reinterpret_cast<uint4*>(sK);
 
-    const __half* q_ptr    = Q +           (size_t)batch_head_id * M * D + start_row * D;
-    const __half* k_ptr    = K +           (size_t)batch_head_id * N * D;
-    const __half* v_ptr    = V +           (size_t)batch_head_id * N * D;
-          __half* out_ptr  = Out +         (size_t)batch_head_id * M * D + start_row * D;
-    float* softmax_lse_ptr = softmax_lse + (size_t)batch_head_id * M + start_row;
+#pragma unroll 2
+    for (int idx = tid; idx < (valid_k_rows * d_stride_uint4);
+         idx += THREADS_PER_BLOCK) {
+      const int row = idx / d_stride_uint4;
+      const int vec_col = idx % d_stride_uint4;
 
-    extern __shared__ char smem_raw[];
-    init_smem<Config>(smem_raw);
-    auto& smem = *reinterpret_cast<typename Config::SmemLayout*>(smem_raw);
-
-    __half* sQ      = smem.q;
-    __half* sK      = smem.reuse_kv.k;
-    __half* sV      = smem.reuse_kv.v;
-    float*  sS      = smem.reuse_sp.s;
-    __half* sP      = smem.reuse_sp.p;
-    float*  sO      = smem.o;
-    float*  sRowMax = smem.row_max;
-    float*  sRowSum = smem.row_sum;
-
-    const int  d_stride_uint4 = (D + PER_UINT4 - 1) / PER_UINT4;
-    const int  q_stride_uint4 = (Q_STRIDE  + PER_UINT4 - 1) / PER_UINT4;
-    const int kv_stride_uint4 = (KV_STRIDE + PER_UINT4 - 1) / PER_UINT4;
-
-    if (tid < BLOCK_M) {
-        sRowMax[tid] = NEG_INF;
-    }
-
-    const uint4*      q_vec = reinterpret_cast<const uint4*>(q_ptr);
-    uint4*           sQ_vec = reinterpret_cast<uint4*>(sQ);
-
-    #pragma unroll 4
-    for (int idx = tid; idx < (valid_q_rows * d_stride_uint4); idx += THREADS_PER_BLOCK) {
-        const int row = idx / d_stride_uint4;
-        const int vec_col = idx % d_stride_uint4;
-        uint4 q_val = make_uint4(0, 0, 0, 0);
-        if (row < valid_q_rows && vec_col < d_stride_uint4) {
-            q_val = __ldg(&q_vec[row * d_stride_uint4 + vec_col]);
-        }
-        sQ_vec[row * q_stride_uint4 + vec_col] = q_val;
+      uint4 k_val = make_uint4(0, 0, 0, 0);
+      if (row < valid_k_rows && vec_col < d_stride_uint4) {
+        k_val = __ldg(&k_vec[row * d_stride_uint4 + vec_col]);
+      }
+      sK_vec[row * kv_stride_uint4 + vec_col] = k_val;
     }
     __syncthreads();
 
-    for (int block_n = 0; block_n < num_n_tiles; ++block_n) {
-        const int start_col = block_n * BLOCK_N;
-        if (start_col >= N) break;
-        const int valid_k_rows = min(BLOCK_N, N - start_col);
+    const int num_tiles_m_qk = (BLOCK_M + WMMA_M - 1) / WMMA_M;
+    const int num_tiles_n_qk = (BLOCK_N + WMMA_N - 1) / WMMA_N;
+    const int num_tiles_k_qk = (D + WMMA_K - 1) / WMMA_K;
+    const int total_tiles_qk = num_tiles_m_qk * num_tiles_n_qk;
+    const int tiles_per_warp_qk =
+        (total_tiles_qk + WARPS_PER_BLOCK - 1) / WARPS_PER_BLOCK;
+    const unsigned row_causal = (lane_id & 0b1) + ((lane_id >> 2) & 0b1) * 8 +
+                                ((lane_id >> 4) & 0b1) * 4;
+    const unsigned col_causal =
+        ((lane_id >> 1) & 0b1) * 2 + ((lane_id >> 3) & 0b1) * 8;
 
-        if constexpr (IS_CAUSAL) {
-            if (start_col >= start_row + valid_q_rows) { continue; }
+    for (int tile_idx = 0; tile_idx < tiles_per_warp_qk; ++tile_idx) {
+      const int global_tile_idx = warp_id * tiles_per_warp_qk + tile_idx;
+      if (global_tile_idx >= total_tiles_qk) break;
+
+      const int tile_m_idx = global_tile_idx / num_tiles_n_qk;
+      const int tile_n_idx = global_tile_idx % num_tiles_n_qk;
+
+      const int tile_m = tile_m_idx * WMMA_M;
+      const int tile_n = tile_n_idx * WMMA_N;
+
+      if (tile_m >= valid_q_rows || tile_n >= valid_k_rows) continue;
+
+      fragment<matrix_a, WMMA_M, WMMA_N, WMMA_K, half, row_major> a_frag;
+      fragment<matrix_b, WMMA_M, WMMA_N, WMMA_K, half, col_major> b_frag;
+      fragment<accumulator, WMMA_M, WMMA_N, WMMA_K, float> acc_frag;
+      fill_fragment(acc_frag, 0.0f);
+
+#pragma unroll
+      for (int k_tile = 0; k_tile < num_tiles_k_qk; ++k_tile) {
+        const int k_offset = k_tile * WMMA_K;
+        if (k_offset >= D) break;
+
+        load_matrix_sync(a_frag, sQ + tile_m * Q_STRIDE + k_offset, Q_STRIDE);
+        load_matrix_sync(b_frag, sK + tile_n * KV_STRIDE + k_offset, KV_STRIDE);
+        mma_sync(acc_frag, a_frag, b_frag, acc_frag);
+      }
+
+      if constexpr (IS_CAUSAL) {
+#pragma unroll
+        for (int i = 0; i < acc_frag.num_elements; ++i) {
+          const unsigned col = col_causal + (i & 0b1) + ((i >> 2) & 0b1) * 4;
+          const unsigned row = row_causal + ((i >> 1) & 0b1) * 2;
+
+          const int global_m = start_row + tile_m + row;
+          const int global_n = start_col + tile_n + col;
+
+          const bool is_valid = (global_m < start_row + valid_q_rows) &&
+                                (global_n < start_col + valid_k_rows);
+
+          acc_frag.x[i] =
+              is_valid ? ((global_n > global_m) ? NEG_INF
+                                                : acc_frag.x[i] * softmax_scale)
+                       : NEG_INF;
         }
-
-        const uint4* k_vec     = reinterpret_cast<const uint4*>(k_ptr + start_col * D);
-        uint4*       sK_vec    = reinterpret_cast<uint4*>(sK);
-
-        #pragma unroll 2
-        for (int idx = tid; idx < (valid_k_rows * d_stride_uint4); idx += THREADS_PER_BLOCK) {
-            const int row = idx / d_stride_uint4;
-            const int vec_col = idx % d_stride_uint4;
-
-            uint4 k_val = make_uint4(0, 0, 0, 0);
-            if (row < valid_k_rows && vec_col < d_stride_uint4) {
-                k_val = __ldg(&k_vec[row * d_stride_uint4 + vec_col]);
-            }
-            sK_vec[row * kv_stride_uint4 + vec_col] = k_val;
+      } else {
+#pragma unroll
+        for (int i = 0; i < acc_frag.num_elements; ++i) {
+          acc_frag.x[i] *= softmax_scale;
         }
-        __syncthreads();
-
-        const int num_tiles_m_qk    = (BLOCK_M + WMMA_M - 1) / WMMA_M;
-        const int num_tiles_n_qk    = (BLOCK_N + WMMA_N - 1) / WMMA_N;
-        const int num_tiles_k_qk    = (D + WMMA_K - 1) / WMMA_K;
-        const int total_tiles_qk    = num_tiles_m_qk * num_tiles_n_qk;
-        const int tiles_per_warp_qk = (total_tiles_qk + WARPS_PER_BLOCK - 1) / WARPS_PER_BLOCK;
-        const unsigned row_causal   = (lane_id & 0b1) + ((lane_id >> 2) & 0b1) * 8 + ((lane_id >> 4) & 0b1) * 4;
-        const unsigned col_causal   = ((lane_id >> 1) & 0b1) * 2 + ((lane_id >> 3) & 0b1) * 8;
-
-        for (int tile_idx = 0; tile_idx < tiles_per_warp_qk; ++tile_idx) {
-            const int global_tile_idx = warp_id * tiles_per_warp_qk + tile_idx;
-            if (global_tile_idx >= total_tiles_qk) break;
-
-            const int tile_m_idx = global_tile_idx / num_tiles_n_qk;
-            const int tile_n_idx = global_tile_idx % num_tiles_n_qk;
-
-            const int tile_m = tile_m_idx * WMMA_M;
-            const int tile_n = tile_n_idx * WMMA_N;
-
-            if (tile_m >= valid_q_rows || tile_n >= valid_k_rows) continue;
-
-            fragment<matrix_a, WMMA_M, WMMA_N, WMMA_K, half, row_major> a_frag;
-            fragment<matrix_b, WMMA_M, WMMA_N, WMMA_K, half, col_major> b_frag;
-            fragment<accumulator, WMMA_M, WMMA_N, WMMA_K, float> acc_frag;
-            fill_fragment(acc_frag, 0.0f);
-
-            #pragma unroll
-            for (int k_tile = 0; k_tile < num_tiles_k_qk; ++k_tile) {
-                const int k_offset = k_tile * WMMA_K;
-                if (k_offset >= D) break;
-
-                load_matrix_sync(a_frag, sQ + tile_m * Q_STRIDE + k_offset, Q_STRIDE);
-                load_matrix_sync(b_frag, sK + tile_n * KV_STRIDE + k_offset, KV_STRIDE);
-                mma_sync(acc_frag, a_frag, b_frag, acc_frag);
-            }
-
-            if constexpr (IS_CAUSAL) {
-                #pragma unroll
-                for (int i = 0; i < acc_frag.num_elements; ++i) {
-                    const unsigned col = col_causal + (i & 0b1) + ((i >> 2) & 0b1) * 4;
-                    const unsigned row = row_causal + ((i >> 1) & 0b1) * 2;
-
-                    const int global_m = start_row + tile_m + row;
-                    const int global_n = start_col + tile_n + col;
-
-                    const bool is_valid = (global_m < start_row + valid_q_rows) &&
-                                          (global_n < start_col + valid_k_rows);
-
-                    acc_frag.x[i] = is_valid
-                        ? ((global_n > global_m) ? NEG_INF : acc_frag.x[i] * softmax_scale)
-                        : NEG_INF;
-                }
-            } else {
-                #pragma unroll
-                for (int i = 0; i < acc_frag.num_elements; ++i) {
-                    acc_frag.x[i] *= softmax_scale;
-                }
-            }
-            store_matrix_sync(sS + tile_m * S_STRIDE + tile_n, acc_frag, S_STRIDE, mem_row_major);
-        }
-        __syncthreads();
-
-        if (tid < valid_q_rows * THREADS_PER_ROW) {
-            const int row = tid / THREADS_PER_ROW;
-            const int thread_in_row = tid % THREADS_PER_ROW;
-            const unsigned mask = (valid_q_rows == BLOCK_M) ? 0xFFFFFFFFU : __activemask();
-            const int row_leader = __ffs(mask) - 1;
-
-            float*  sS_row_f = sS + row * S_STRIDE;
-            __half* sP_row_h = sP + row * S_STRIDE;
-
-            const int vec_cols = valid_k_rows >> 2;
-            const int vecs_per_thread = (vec_cols + THREADS_PER_ROW - 1) / THREADS_PER_ROW;
-            const int tail_start = vec_cols << 2;
-
-            float thread_max = NEG_INF;
-            float4* sS_vec4 = reinterpret_cast<float4*>(sS_row_f);
-
-            #pragma unroll 4
-            for (int j = 0; j < vecs_per_thread; ++j) {
-                int vc = thread_in_row + j * THREADS_PER_ROW;
-                if (vc < vec_cols) {
-                    float4 v4 = sS_vec4[vc];
-                    thread_max = fmaxf(thread_max, fmaxf(fmaxf(v4.x, v4.y), fmaxf(v4.z, v4.w)));
-                }
-            }
-
-            #pragma unroll 4
-            for (int c = tail_start + thread_in_row; c < valid_k_rows; c += THREADS_PER_ROW) {
-                thread_max = fmaxf(thread_max, sS_row_f[c]);
-            }
-
-            #pragma unroll
-            for (int o = THREADS_PER_ROW / 2; o > 0; o >>= 1)
-                thread_max = fmaxf(thread_max, __shfl_down_sync(mask, thread_max, o, THREADS_PER_ROW));
-
-            const float row_max  = __shfl_sync(mask, thread_max, row_leader, THREADS_PER_ROW);
-            const float old_max  = sRowMax[row];
-            const float new_max  = fmaxf(old_max, row_max);
-            const float exp_diff = __expf(old_max - new_max);
-
-            float thread_sum = 0.0f;
-            __half2 half_buffer[20];
-            int vc_base = thread_in_row;
-            int h2_idx = 0;
-            int tail_col = -1;
-            __half tail_value = __float2half(0.f);
-
-            #pragma unroll 4
-            for (int j = 0; j < vecs_per_thread; ++j, vc_base += THREADS_PER_ROW) {
-                if (vc_base < vec_cols) {
-                    float4 v4 = sS_vec4[vc_base];
-
-                    float e0 = __expf(fmaxf(v4.x - new_max, -80.0f));
-                    float e1 = __expf(fmaxf(v4.y - new_max, -80.0f));
-                    float e2 = __expf(fmaxf(v4.z - new_max, -80.0f));
-                    float e3 = __expf(fmaxf(v4.w - new_max, -80.0f));
-
-                    thread_sum += (e0 + e1) + (e2 + e3);
-
-                    half_buffer[h2_idx++] = __float22half2_rn(make_float2(e0, e1));
-                    half_buffer[h2_idx++] = __float22half2_rn(make_float2(e2, e3));
-                }
-            }
-
-            #pragma unroll 4
-            for (int c = tail_start + thread_in_row; c < valid_k_rows; c += THREADS_PER_ROW) {
-                float v = sS_row_f[c];
-                float e = __expf(fmaxf(v - new_max, -80.0f));
-                thread_sum += e;
-                tail_col = c;
-                tail_value = __float2half_rn(e);
-            }
-
-            #pragma unroll
-            for (int o = THREADS_PER_ROW / 2; o > 0; o >>= 1)
-                thread_sum += __shfl_down_sync(mask, thread_sum, o, THREADS_PER_ROW);
-
-            float row_sum = __shfl_sync(mask, thread_sum, row_leader, THREADS_PER_ROW);
-
-            if (thread_in_row == 0) {
-                sRowSum[row] = exp_diff * sRowSum[row] + row_sum;
-                sRowMax[row] = new_max;
-            }
-
-            h2_idx = 0;
-            vc_base = thread_in_row;
-            __half2* sP_half2 = reinterpret_cast<__half2*>(sP_row_h);
-
-            #pragma unroll 4
-            for (int j = 0; j < vecs_per_thread; ++j, vc_base += THREADS_PER_ROW) {
-                if (vc_base < vec_cols) {
-                    int base_offset = vc_base * 2;
-
-                    sP_half2[base_offset]     = half_buffer[h2_idx++];
-                    sP_half2[base_offset + 1] = half_buffer[h2_idx++];
-                }
-            }
-
-            if (tail_col >= 0) {
-                sP_row_h[tail_col] = tail_value;
-            }
-
-            #pragma unroll 4
-            for (int c = tail_start + thread_in_row; c < BLOCK_N; c += THREADS_PER_ROW) {
-                if (c >= valid_k_rows) {
-                    sP_row_h[c] = __float2half(0.f);
-                }
-            }
-
-            if (block_n > 0) {
-                float*  sO_row = sO + row * O_STRIDE;
-                float4* sO_vec = reinterpret_cast<float4*>(sO_row);
-                const int o_vec_count = (O_STRIDE + 3) >> 2;
-                float scale = exp_diff;
-
-                #pragma unroll 4
-                for (int ov = thread_in_row; ov < o_vec_count; ov += THREADS_PER_ROW) {
-                    float4 v = sO_vec[ov];
-                    v.x *= scale;
-                    v.y *= scale;
-                    v.z *= scale;
-                    v.w *= scale;
-
-                    sO_vec[ov] = v;
-                }
-            }
-        }
-        __syncthreads();
-
-        const uint4* v_vec     = reinterpret_cast<const uint4*>(v_ptr + start_col * D);
-        uint4*       sV_vec    = reinterpret_cast<uint4*>(sV);
-
-        #pragma unroll 2
-        for (int idx = tid; idx < (valid_k_rows * d_stride_uint4); idx += THREADS_PER_BLOCK) {
-            const int row = idx / d_stride_uint4;
-            const int vec_col = idx % d_stride_uint4;
-
-            uint4 v_val = make_uint4(0, 0, 0, 0);
-            if (row < valid_k_rows && vec_col < d_stride_uint4) {
-                v_val = __ldg(&v_vec[row * d_stride_uint4 + vec_col]);
-            }
-            sV_vec[row * kv_stride_uint4 + vec_col] = v_val;
-        }
-        __syncthreads();
-
-        const int num_tiles_m_pv    = (BLOCK_M + WMMA_M - 1) / WMMA_M;
-        const int num_tiles_n_pv    = (D + WMMA_N - 1) / WMMA_N;
-        const int num_tiles_k_pv    = (BLOCK_N + WMMA_K - 1) / WMMA_K;
-        const int total_tiles_pv    = num_tiles_m_pv * num_tiles_n_pv;
-        const int tiles_per_warp_pv = (total_tiles_pv + WARPS_PER_BLOCK - 1) / WARPS_PER_BLOCK;
-
-        for (int tile_idx = 0; tile_idx < tiles_per_warp_pv; ++tile_idx) {
-            const int global_tile_idx = warp_id * tiles_per_warp_pv + tile_idx;
-            if (global_tile_idx >= total_tiles_pv) break;
-
-            const int tile_m_idx = global_tile_idx / num_tiles_n_pv;
-            const int tile_d_idx = global_tile_idx % num_tiles_n_pv;
-
-            const int tile_m = tile_m_idx * WMMA_M;
-            const int tile_d = tile_d_idx * WMMA_N;
-
-            if (tile_m >= valid_q_rows) continue;
-
-            fragment<matrix_a, WMMA_M, WMMA_N, WMMA_K, half, row_major> a_frag;
-            fragment<matrix_b, WMMA_M, WMMA_N, WMMA_K, half, row_major> b_frag;
-            fragment<accumulator, WMMA_M, WMMA_N, WMMA_K, float> acc_frag;
-
-            load_matrix_sync(acc_frag, sO + tile_m * O_STRIDE + tile_d, O_STRIDE, mem_row_major);
-
-            #pragma unroll
-            for (int tile_k = 0; tile_k < num_tiles_k_pv; ++tile_k) {
-                const int k_offset = tile_k * WMMA_K;
-                if (k_offset >= valid_k_rows) break;
-
-                load_matrix_sync(a_frag, sP + tile_m * S_STRIDE + k_offset, S_STRIDE);
-                load_matrix_sync(b_frag, sV + k_offset * KV_STRIDE + tile_d, KV_STRIDE);
-                mma_sync(acc_frag, a_frag, b_frag, acc_frag);
-            }
-            store_matrix_sync(sO + tile_m * O_STRIDE + tile_d, acc_frag, O_STRIDE, mem_row_major);
-        }
-        __syncthreads();
+      }
+      store_matrix_sync(sS + tile_m * S_STRIDE + tile_n, acc_frag, S_STRIDE,
+                        mem_row_major);
     }
+    __syncthreads();
 
-    const int total_fp16_x4 = (valid_q_rows * D) / 4;
+    if (tid < valid_q_rows * THREADS_PER_ROW) {
+      const int row = tid / THREADS_PER_ROW;
+      const int thread_in_row = tid % THREADS_PER_ROW;
+      const unsigned mask =
+          (valid_q_rows == BLOCK_M) ? 0xFFFFFFFFU : __activemask();
+      const int row_leader = __ffs(mask) - 1;
 
-    for (int i = tid; i < total_fp16_x4; i += THREADS_PER_BLOCK) {
-        const int row = i / (D / 4);
-        const int col = (i % (D / 4)) * 4;
+      float* sS_row_f = sS + row * S_STRIDE;
+      __half* sP_row_h = sP + row * S_STRIDE;
 
-        const float sum_clamped = fmaxf(sRowSum[row], 1e-24f);
-        const float inv_sum = 1.0f / sum_clamped;
-        const float* sO_row = sO + row * O_STRIDE;
+      const int vec_cols = valid_k_rows >> 2;
+      const int vecs_per_thread =
+          (vec_cols + THREADS_PER_ROW - 1) / THREADS_PER_ROW;
+      const int tail_start = vec_cols << 2;
 
-        const __half h0 = __float2half_rn(sO_row[col + 0] * inv_sum);
-        const __half h1 = __float2half_rn(sO_row[col + 1] * inv_sum);
-        const __half h2 = __float2half_rn(sO_row[col + 2] * inv_sum);
-        const __half h3 = __float2half_rn(sO_row[col + 3] * inv_sum);
+      float thread_max = NEG_INF;
+      float4* sS_vec4 = reinterpret_cast<float4*>(sS_row_f);
 
-        asm volatile(
-            "st.global.v4.u16 [%0], {%1, %2, %3, %4};"
-            :
-            : "l"(out_ptr + row * D + col),
-              "h"(__half_as_ushort(h0)),
-              "h"(__half_as_ushort(h1)),
-              "h"(__half_as_ushort(h2)),
-              "h"(__half_as_ushort(h3))
-            : "memory"
-        );
+#pragma unroll 4
+      for (int j = 0; j < vecs_per_thread; ++j) {
+        int vc = thread_in_row + j * THREADS_PER_ROW;
+        if (vc < vec_cols) {
+          float4 v4 = sS_vec4[vc];
+          thread_max =
+              fmaxf(thread_max, fmaxf(fmaxf(v4.x, v4.y), fmaxf(v4.z, v4.w)));
+        }
+      }
+
+#pragma unroll 4
+      for (int c = tail_start + thread_in_row; c < valid_k_rows;
+           c += THREADS_PER_ROW) {
+        thread_max = fmaxf(thread_max, sS_row_f[c]);
+      }
+
+#pragma unroll
+      for (int o = THREADS_PER_ROW / 2; o > 0; o >>= 1)
+        thread_max = fmaxf(
+            thread_max, __shfl_down_sync(mask, thread_max, o, THREADS_PER_ROW));
+
+      const float row_max =
+          __shfl_sync(mask, thread_max, row_leader, THREADS_PER_ROW);
+      const float old_max = sRowMax[row];
+      const float new_max = fmaxf(old_max, row_max);
+      const float exp_diff = __expf(old_max - new_max);
+
+      float thread_sum = 0.0f;
+      __half2 half_buffer[20];
+      int vc_base = thread_in_row;
+      int h2_idx = 0;
+      int tail_col = -1;
+      __half tail_value = __float2half(0.f);
+
+#pragma unroll 4
+      for (int j = 0; j < vecs_per_thread; ++j, vc_base += THREADS_PER_ROW) {
+        if (vc_base < vec_cols) {
+          float4 v4 = sS_vec4[vc_base];
+
+          float e0 = __expf(fmaxf(v4.x - new_max, -80.0f));
+          float e1 = __expf(fmaxf(v4.y - new_max, -80.0f));
+          float e2 = __expf(fmaxf(v4.z - new_max, -80.0f));
+          float e3 = __expf(fmaxf(v4.w - new_max, -80.0f));
+
+          thread_sum += (e0 + e1) + (e2 + e3);
+
+          half_buffer[h2_idx++] = __float22half2_rn(make_float2(e0, e1));
+          half_buffer[h2_idx++] = __float22half2_rn(make_float2(e2, e3));
+        }
+      }
+
+#pragma unroll 4
+      for (int c = tail_start + thread_in_row; c < valid_k_rows;
+           c += THREADS_PER_ROW) {
+        float v = sS_row_f[c];
+        float e = __expf(fmaxf(v - new_max, -80.0f));
+        thread_sum += e;
+        tail_col = c;
+        tail_value = __float2half_rn(e);
+      }
+
+#pragma unroll
+      for (int o = THREADS_PER_ROW / 2; o > 0; o >>= 1)
+        thread_sum += __shfl_down_sync(mask, thread_sum, o, THREADS_PER_ROW);
+
+      float row_sum =
+          __shfl_sync(mask, thread_sum, row_leader, THREADS_PER_ROW);
+
+      if (thread_in_row == 0) {
+        sRowSum[row] = exp_diff * sRowSum[row] + row_sum;
+        sRowMax[row] = new_max;
+      }
+
+      h2_idx = 0;
+      vc_base = thread_in_row;
+      __half2* sP_half2 = reinterpret_cast<__half2*>(sP_row_h);
+
+#pragma unroll 4
+      for (int j = 0; j < vecs_per_thread; ++j, vc_base += THREADS_PER_ROW) {
+        if (vc_base < vec_cols) {
+          int base_offset = vc_base * 2;
+
+          sP_half2[base_offset] = half_buffer[h2_idx++];
+          sP_half2[base_offset + 1] = half_buffer[h2_idx++];
+        }
+      }
+
+      if (tail_col >= 0) {
+        sP_row_h[tail_col] = tail_value;
+      }
+
+#pragma unroll 4
+      for (int c = tail_start + thread_in_row; c < BLOCK_N;
+           c += THREADS_PER_ROW) {
+        if (c >= valid_k_rows) {
+          sP_row_h[c] = __float2half(0.f);
+        }
+      }
+
+      if (block_n > 0) {
+        float* sO_row = sO + row * O_STRIDE;
+        float4* sO_vec = reinterpret_cast<float4*>(sO_row);
+        const int o_vec_count = (O_STRIDE + 3) >> 2;
+        float scale = exp_diff;
+
+#pragma unroll 4
+        for (int ov = thread_in_row; ov < o_vec_count; ov += THREADS_PER_ROW) {
+          float4 v = sO_vec[ov];
+          v.x *= scale;
+          v.y *= scale;
+          v.z *= scale;
+          v.w *= scale;
+
+          sO_vec[ov] = v;
+        }
+      }
     }
+    __syncthreads();
 
-    if (tid < valid_q_rows) {
-        const float sum = fmaxf(sRowSum[tid], 1e-24f);
-        softmax_lse_ptr[tid] = sRowMax[tid] + logf(sum);
+    const uint4* v_vec = reinterpret_cast<const uint4*>(v_ptr + start_col * D);
+    uint4* sV_vec = reinterpret_cast<uint4*>(sV);
+
+#pragma unroll 2
+    for (int idx = tid; idx < (valid_k_rows * d_stride_uint4);
+         idx += THREADS_PER_BLOCK) {
+      const int row = idx / d_stride_uint4;
+      const int vec_col = idx % d_stride_uint4;
+
+      uint4 v_val = make_uint4(0, 0, 0, 0);
+      if (row < valid_k_rows && vec_col < d_stride_uint4) {
+        v_val = __ldg(&v_vec[row * d_stride_uint4 + vec_col]);
+      }
+      sV_vec[row * kv_stride_uint4 + vec_col] = v_val;
     }
+    __syncthreads();
+
+    const int num_tiles_m_pv = (BLOCK_M + WMMA_M - 1) / WMMA_M;
+    const int num_tiles_n_pv = (D + WMMA_N - 1) / WMMA_N;
+    const int num_tiles_k_pv = (BLOCK_N + WMMA_K - 1) / WMMA_K;
+    const int total_tiles_pv = num_tiles_m_pv * num_tiles_n_pv;
+    const int tiles_per_warp_pv =
+        (total_tiles_pv + WARPS_PER_BLOCK - 1) / WARPS_PER_BLOCK;
+
+    for (int tile_idx = 0; tile_idx < tiles_per_warp_pv; ++tile_idx) {
+      const int global_tile_idx = warp_id * tiles_per_warp_pv + tile_idx;
+      if (global_tile_idx >= total_tiles_pv) break;
+
+      const int tile_m_idx = global_tile_idx / num_tiles_n_pv;
+      const int tile_d_idx = global_tile_idx % num_tiles_n_pv;
+
+      const int tile_m = tile_m_idx * WMMA_M;
+      const int tile_d = tile_d_idx * WMMA_N;
+
+      if (tile_m >= valid_q_rows) continue;
+
+      fragment<matrix_a, WMMA_M, WMMA_N, WMMA_K, half, row_major> a_frag;
+      fragment<matrix_b, WMMA_M, WMMA_N, WMMA_K, half, row_major> b_frag;
+      fragment<accumulator, WMMA_M, WMMA_N, WMMA_K, float> acc_frag;
+
+      load_matrix_sync(acc_frag, sO + tile_m * O_STRIDE + tile_d, O_STRIDE,
+                       mem_row_major);
+
+#pragma unroll
+      for (int tile_k = 0; tile_k < num_tiles_k_pv; ++tile_k) {
+        const int k_offset = tile_k * WMMA_K;
+        if (k_offset >= valid_k_rows) break;
+
+        load_matrix_sync(a_frag, sP + tile_m * S_STRIDE + k_offset, S_STRIDE);
+        load_matrix_sync(b_frag, sV + k_offset * KV_STRIDE + tile_d, KV_STRIDE);
+        mma_sync(acc_frag, a_frag, b_frag, acc_frag);
+      }
+      store_matrix_sync(sO + tile_m * O_STRIDE + tile_d, acc_frag, O_STRIDE,
+                        mem_row_major);
+    }
+    __syncthreads();
+  }
+
+  const int total_fp16_x4 = (valid_q_rows * D) / 4;
+
+  for (int i = tid; i < total_fp16_x4; i += THREADS_PER_BLOCK) {
+    const int row = i / (D / 4);
+    const int col = (i % (D / 4)) * 4;
+
+    const float sum_clamped = fmaxf(sRowSum[row], 1e-24f);
+    const float inv_sum = 1.0f / sum_clamped;
+    const float* sO_row = sO + row * O_STRIDE;
+
+    const __half h0 = __float2half_rn(sO_row[col + 0] * inv_sum);
+    const __half h1 = __float2half_rn(sO_row[col + 1] * inv_sum);
+    const __half h2 = __float2half_rn(sO_row[col + 2] * inv_sum);
+    const __half h3 = __float2half_rn(sO_row[col + 3] * inv_sum);
+
+    asm volatile("st.global.v4.u16 [%0], {%1, %2, %3, %4};"
+                 :
+                 : "l"(out_ptr + row * D + col), "h"(__half_as_ushort(h0)),
+                   "h"(__half_as_ushort(h1)), "h"(__half_as_ushort(h2)),
+                   "h"(__half_as_ushort(h3))
+                 : "memory");
+  }
+
+  if (tid < valid_q_rows) {
+    const float sum = fmaxf(sRowSum[tid], 1e-24f);
+    softmax_lse_ptr[tid] = sRowMax[tid] + logf(sum);
+  }
 }
 
-template<int D>
+template <int D>
 void launcher_flash_attention_forward(
-    const torch::Tensor& Q,
-    const torch::Tensor& K,
-    const torch::Tensor& V,
-    torch::Tensor& Out,
-    torch::Tensor& softmax_lse,
-    float softmax_scale,
-    bool is_causal,
-    cudaStream_t stream
-) {
-    using Config = KernelConfig<D>;
+    const torch::Tensor& Q, const torch::Tensor& K, const torch::Tensor& V,
+    torch::Tensor& Out, torch::Tensor& softmax_lse, float softmax_scale,
+    bool is_causal, cudaStream_t stream) {
+  using Config = KernelConfig<D>;
 
-    const int B = Q.size(0);
-    const int H = Q.size(1);
-    const int M = Q.size(2);
-    const int N = K.size(2);
+  const int B = Q.size(0);
+  const int H = Q.size(1);
+  const int M = Q.size(2);
+  const int N = K.size(2);
 
-    const int grid_x = (M + Config::BLOCK_M - 1) / Config::BLOCK_M;
-    const dim3 grid(grid_x, 1, B * H);
-    const dim3 block(Config::THREADS_PER_BLOCK);
-    const size_t smem = Config::TOTAL_SMEM;
+  const int grid_x = (M + Config::BLOCK_M - 1) / Config::BLOCK_M;
+  const dim3 grid(grid_x, 1, B * H);
+  const dim3 block(Config::THREADS_PER_BLOCK);
+  const size_t smem = Config::TOTAL_SMEM;
 
-    TORCH_CHECK(smem <= MAX_SMEM_PER_SM, "Shared memory exceeds 96KB: ", smem, " bytes");
+  TORCH_CHECK(smem <= MAX_SMEM_PER_SM, "Shared memory exceeds 96KB: ", smem,
+              " bytes");
 
-    auto kernel = is_causal ?
-        (void*)flash_attention_forward_kernel<D, true> :
-        (void*)flash_attention_forward_kernel<D, false>;
+  auto kernel = is_causal ? (void*)flash_attention_forward_kernel<D, true>
+                          : (void*)flash_attention_forward_kernel<D, false>;
 
-    cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem);
+  cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize,
+                       smem);
 
-    if (is_causal) {
-        flash_attention_forward_kernel<D, true><<<grid, block, smem, stream>>>(
-            reinterpret_cast<const __half*>(Q.data_ptr()),
-            reinterpret_cast<const __half*>(K.data_ptr()),
-            reinterpret_cast<const __half*>(V.data_ptr()),
-            reinterpret_cast<__half*>(Out.data_ptr()),
-            softmax_lse.data_ptr<float>(),
-            B, H, M, N, softmax_scale
-        );
-    } else {
-        flash_attention_forward_kernel<D, false><<<grid, block, smem, stream>>>(
-            reinterpret_cast<const __half*>(Q.data_ptr()),
-            reinterpret_cast<const __half*>(K.data_ptr()),
-            reinterpret_cast<const __half*>(V.data_ptr()),
-            reinterpret_cast<__half*>(Out.data_ptr()),
-            softmax_lse.data_ptr<float>(),
-            B, H, M, N, softmax_scale
-        );
-    }
+  if (is_causal) {
+    flash_attention_forward_kernel<D, true><<<grid, block, smem, stream>>>(
+        reinterpret_cast<const __half*>(Q.data_ptr()),
+        reinterpret_cast<const __half*>(K.data_ptr()),
+        reinterpret_cast<const __half*>(V.data_ptr()),
+        reinterpret_cast<__half*>(Out.data_ptr()),
+        softmax_lse.data_ptr<float>(), B, H, M, N, softmax_scale);
+  } else {
+    flash_attention_forward_kernel<D, false><<<grid, block, smem, stream>>>(
+        reinterpret_cast<const __half*>(Q.data_ptr()),
+        reinterpret_cast<const __half*>(K.data_ptr()),
+        reinterpret_cast<const __half*>(V.data_ptr()),
+        reinterpret_cast<__half*>(Out.data_ptr()),
+        softmax_lse.data_ptr<float>(), B, H, M, N, softmax_scale);
+  }
 }
 
 std::vector<at::Tensor> flash_attention_forward(
-    at::Tensor& q,
-    const at::Tensor& k,
-    const at::Tensor& v,
-    std::optional<at::Tensor>& out_,
-    std::optional<at::Tensor>& alibi_slopes_,
-    const float p_dropout,
-    const float softmax_scale,
-    bool is_causal,
-    int window_size_left,
-    int window_size_right,
-    const float softcap,
-    const bool return_softmax,
-    std::optional<at::Generator> gen_
-) {
+    at::Tensor& q, const at::Tensor& k, const at::Tensor& v,
+    std::optional<at::Tensor>& out_, std::optional<at::Tensor>& alibi_slopes_,
+    const float p_dropout, const float softmax_scale, bool is_causal,
+    int window_size_left, int window_size_right, const float softcap,
+    const bool return_softmax, std::optional<at::Generator> gen_) {
+  TORCH_CHECK(!alibi_slopes_.has_value(), "alibi_slopes not supported");
+  TORCH_CHECK(p_dropout == 0.f, "dropout not supported");
+  TORCH_CHECK(window_size_left == -1, "window_size_left not supported");
+  TORCH_CHECK(window_size_right == -1 || (is_causal && window_size_right == 0),
+              "window not supported");
+  TORCH_CHECK(softcap == 0.f, "softcap not supported");
+  TORCH_CHECK(!return_softmax, "return_softmax not supported");
+  TORCH_CHECK(!gen_.has_value(), "Generator not supported");
 
-    TORCH_CHECK(!alibi_slopes_.has_value(), "alibi_slopes not supported");
-    TORCH_CHECK(p_dropout == 0.f, "dropout not supported");
-    TORCH_CHECK(window_size_left == -1, "window_size_left not supported");
-    TORCH_CHECK(window_size_right == -1 || (is_causal && window_size_right == 0), "window not supported");
-    TORCH_CHECK(softcap == 0.f, "softcap not supported");
-    TORCH_CHECK(!return_softmax, "return_softmax not supported");
-    TORCH_CHECK(!gen_.has_value(), "Generator not supported");
+  TORCH_CHECK(q.dtype() == torch::kFloat16, "q must be fp16");
+  TORCH_CHECK(k.dtype() == torch::kFloat16, "k must be fp16");
+  TORCH_CHECK(v.dtype() == torch::kFloat16, "v must be fp16");
+  TORCH_CHECK(q.is_cuda() && k.is_cuda() && v.is_cuda(),
+              "Tensors must be on CUDA");
+  TORCH_CHECK(q.stride(-1) == 1 && k.stride(-1) == 1 && v.stride(-1) == 1,
+              "Last dim must be contiguous");
 
-    TORCH_CHECK(q.dtype() == torch::kFloat16, "q must be fp16");
-    TORCH_CHECK(k.dtype() == torch::kFloat16, "k must be fp16");
-    TORCH_CHECK(v.dtype() == torch::kFloat16, "v must be fp16");
-    TORCH_CHECK(q.is_cuda() && k.is_cuda() && v.is_cuda(), "Tensors must be on CUDA");
-    TORCH_CHECK(q.stride(-1) == 1 && k.stride(-1) == 1 && v.stride(-1) == 1, "Last dim must be contiguous");
+  const auto sizes = q.sizes();
+  const int B = sizes[0], H = sizes[1], M = sizes[2], D = sizes[3];
+  const int N = k.size(2);
+  TORCH_CHECK(D <= 256 && D % 8 == 0 && D % 2 == 0,
+              "D must be even, <=256, multiple of 8");
 
-    const auto sizes = q.sizes();
-    const int B = sizes[0], H = sizes[1], M = sizes[2], D = sizes[3];
-    const int N = k.size(2);
-    TORCH_CHECK(D <= 256 && D % 8 == 0 && D % 2 == 0, "D must be even, <=256, multiple of 8");
+  at::Tensor out_fp16 = out_.has_value() ? out_.value() : torch::zeros_like(q);
+  TORCH_CHECK(out_fp16.dtype() == torch::kFloat16, "out must be fp16");
+  auto softmax_lse =
+      torch::zeros({B, H, M}, torch::dtype(torch::kFloat32).device(q.device()));
+  TORCH_CHECK(softmax_lse.dtype() == torch::kFloat32,
+              "softmax_lse must be fp32");
 
-    at::Tensor out_fp16 = out_.has_value() ? out_.value() : torch::zeros_like(q);
-    TORCH_CHECK(out_fp16.dtype() == torch::kFloat16, "out must be fp16");
-    auto softmax_lse = torch::zeros({B, H, M}, torch::dtype(torch::kFloat32).device(q.device()));
-    TORCH_CHECK(softmax_lse.dtype() == torch::kFloat32, "softmax_lse must be fp32");
+  auto stream = at::cuda::getCurrentCUDAStream().stream();
+  auto props = at::cuda::getCurrentDeviceProperties();
+  bool sm70 = props->major == 7 && props->minor == 0;
+  TORCH_CHECK(sm70, "Kernel supports only Volta GPUs.");
 
-    auto stream = at::cuda::getCurrentCUDAStream().stream();
-    auto props  = at::cuda::getCurrentDeviceProperties();
-    bool sm70   = props->major == 7 && props->minor == 0;
-    TORCH_CHECK(sm70, "Kernel supports only Volta GPUs.");
+  switch (D) {
+    case 16:
+      launcher_flash_attention_forward<16>(q, k, v, out_fp16, softmax_lse,
+                                           softmax_scale, is_causal, stream);
+      break;
+    case 32:
+      launcher_flash_attention_forward<32>(q, k, v, out_fp16, softmax_lse,
+                                           softmax_scale, is_causal, stream);
+      break;
+    case 64:
+      launcher_flash_attention_forward<64>(q, k, v, out_fp16, softmax_lse,
+                                           softmax_scale, is_causal, stream);
+      break;
+    case 128:
+      launcher_flash_attention_forward<128>(q, k, v, out_fp16, softmax_lse,
+                                            softmax_scale, is_causal, stream);
+      break;
+    case 256:
+      launcher_flash_attention_forward<256>(q, k, v, out_fp16, softmax_lse,
+                                            softmax_scale, is_causal, stream);
+      break;
+    default:
+      TORCH_CHECK(false, "Unsupported D: ", D);
+  }
 
-    switch (D) {
-        case 16:  launcher_flash_attention_forward<16>(q, k, v, out_fp16, softmax_lse, softmax_scale, is_causal, stream); break;
-        case 32:  launcher_flash_attention_forward<32>(q, k, v, out_fp16, softmax_lse, softmax_scale, is_causal, stream); break;
-        case 64:  launcher_flash_attention_forward<64>(q, k, v, out_fp16, softmax_lse, softmax_scale, is_causal, stream); break;
-        case 128: launcher_flash_attention_forward<128>(q, k, v, out_fp16, softmax_lse, softmax_scale, is_causal, stream); break;
-        case 256: launcher_flash_attention_forward<256>(q, k, v, out_fp16, softmax_lse, softmax_scale, is_causal, stream); break;
-        default: TORCH_CHECK(false, "Unsupported D: ", D);
-    }
-
-    auto p = torch::zeros({0}, q.options());
-    auto rng_state = torch::zeros({2}, torch::dtype(torch::kInt64).device(q.device()));
-    return {out_fp16, softmax_lse, p, rng_state};
+  auto p = torch::zeros({0}, q.options());
+  auto rng_state =
+      torch::zeros({2}, torch::dtype(torch::kInt64).device(q.device()));
+  return {out_fp16, softmax_lse, p, rng_state};
 }

--- a/flash-attention-v100/kernel/paged_kv_utils.cuh
+++ b/flash-attention-v100/kernel/paged_kv_utils.cuh
@@ -4,78 +4,58 @@
 #include <cuda_runtime.h>
 #include <cuda_fp16.h>
 
-__device__ __forceinline__
-size_t resolve_paged_kv_offset(
-    const int token_idx,
-    const int page_block_size,
-    const int* __restrict__ block_table,
-    const int kv_head_offset,
-    const int num_kv_heads,
-    const int head_dim
-) {
+__device__ __forceinline__ size_t resolve_paged_kv_offset(
+    const int token_idx, const int page_block_size,
+    const int* __restrict__ block_table, const int kv_head_offset,
+    const int num_kv_heads, const int head_dim) {
+  const int virtual_page_idx = token_idx / page_block_size;
+  const int page_offset = token_idx % page_block_size;
 
-    const int virtual_page_idx = token_idx / page_block_size;
-    const int page_offset = token_idx % page_block_size;
+  const int physical_block_idx = block_table[virtual_page_idx];
 
-    const int physical_block_idx = block_table[virtual_page_idx];
+  const size_t physical_offset =
+      (size_t)physical_block_idx * page_block_size * num_kv_heads * head_dim +
+      (size_t)page_offset * num_kv_heads * head_dim + (size_t)kv_head_offset;
 
-    const size_t physical_offset =
-        (size_t)physical_block_idx * page_block_size * num_kv_heads * head_dim
-        + (size_t)page_offset * num_kv_heads * head_dim
-        + (size_t)kv_head_offset;
-
-    return physical_offset;
+  return physical_offset;
 }
 
-template<int D>
-__device__ __forceinline__
-void load_kv_tile_paged(
-    const __half* __restrict__ kv_cache,
-    const int* __restrict__ block_table,
-    const int start_token_idx,
-    const int num_tokens,
-    const int kv_head_idx,
-    const int num_kv_heads,
-    const int head_dim,
-    const int page_block_size,
-    __half* smem_dst,
-    const int smem_stride,
-    const int tid,
-    const int num_threads
-) {
-    constexpr int PER_UINT4 = 8;
-    const int d_stride_uint4 = (D + PER_UINT4 - 1) / PER_UINT4;
-    const int smem_stride_uint4 = (smem_stride + PER_UINT4 - 1) / PER_UINT4;
+template <int D>
+__device__ __forceinline__ void load_kv_tile_paged(
+    const __half* __restrict__ kv_cache, const int* __restrict__ block_table,
+    const int start_token_idx, const int num_tokens, const int kv_head_idx,
+    const int num_kv_heads, const int head_dim, const int page_block_size,
+    __half* smem_dst, const int smem_stride, const int tid,
+    const int num_threads) {
+  constexpr int PER_UINT4 = 8;
+  const int d_stride_uint4 = (D + PER_UINT4 - 1) / PER_UINT4;
+  const int smem_stride_uint4 = (smem_stride + PER_UINT4 - 1) / PER_UINT4;
 
-    const int kv_head_offset = kv_head_idx * head_dim;
+  const int kv_head_offset = kv_head_idx * head_dim;
 
-    uint4* smem_vec = reinterpret_cast<uint4*>(smem_dst);
+  uint4* smem_vec = reinterpret_cast<uint4*>(smem_dst);
 
-    #pragma unroll 2
-    for (int idx = tid; idx < (num_tokens * d_stride_uint4); idx += num_threads) {
-        const int token_offset = idx / d_stride_uint4;
-        const int vec_col = idx % d_stride_uint4;
+#pragma unroll 2
+  for (int idx = tid; idx < (num_tokens * d_stride_uint4); idx += num_threads) {
+    const int token_offset = idx / d_stride_uint4;
+    const int vec_col = idx % d_stride_uint4;
 
-        uint4 kv_val = make_uint4(0, 0, 0, 0);
+    uint4 kv_val = make_uint4(0, 0, 0, 0);
 
-        if (token_offset < num_tokens && vec_col < d_stride_uint4) {
-            const int global_token_idx = start_token_idx + token_offset;
+    if (token_offset < num_tokens && vec_col < d_stride_uint4) {
+      const int global_token_idx = start_token_idx + token_offset;
 
-            const size_t base_offset = resolve_paged_kv_offset(
-                global_token_idx,
-                page_block_size,
-                block_table,
-                kv_head_offset,
-                num_kv_heads,
-                head_dim
-            );
+      const size_t base_offset = resolve_paged_kv_offset(
+          global_token_idx, page_block_size, block_table, kv_head_offset,
+          num_kv_heads, head_dim);
 
-            const uint4* kv_vec = reinterpret_cast<const uint4*>(kv_cache + base_offset);
-            kv_val = __ldg(&kv_vec[vec_col]);
-        }
-
-        smem_vec[token_offset * smem_stride_uint4 + vec_col] = kv_val;
+      const uint4* kv_vec =
+          reinterpret_cast<const uint4*>(kv_cache + base_offset);
+      kv_val = __ldg(&kv_vec[vec_col]);
     }
+
+    smem_vec[token_offset * smem_stride_uint4 + vec_col] = kv_val;
+  }
 }
 
 #endif

--- a/flash-attention-v100/kernel/paged_to_contiguous.cu
+++ b/flash-attention-v100/kernel/paged_to_contiguous.cu
@@ -4,215 +4,178 @@
 #include <torch/extension.h>
 
 __global__ void paged_to_contiguous_stride_aware_kernel(
-    const __half* __restrict__ paged_cache,
-    const int* __restrict__ block_table,
-    const int* __restrict__ seq_lens,
-          __half* __restrict__ contiguous,
-    const int64_t block_stride,
-    const int64_t page_stride,
-    const int64_t head_stride,
-    const int block_size,
-    const int num_heads,
-    const int head_dim,
-    const int max_num_blocks
-) {
+    const __half* __restrict__ paged_cache, const int* __restrict__ block_table,
+    const int* __restrict__ seq_lens, __half* __restrict__ contiguous,
+    const int64_t block_stride, const int64_t page_stride,
+    const int64_t head_stride, const int block_size, const int num_heads,
+    const int head_dim, const int max_num_blocks) {
+  const int batch_idx = blockIdx.x;
+  const int seq_len = seq_lens[batch_idx];
+  if (seq_len == 0) return;
 
-    const int batch_idx = blockIdx.x;
-    const int seq_len = seq_lens[batch_idx];
-    if (seq_len == 0) return;
+  int output_offset = 0;
+  for (int i = 0; i < batch_idx; ++i) {
+    output_offset += seq_lens[i];
+  }
 
-    int output_offset = 0;
-    for (int i = 0; i < batch_idx; ++i) {
-        output_offset += seq_lens[i];
+  const int* block_table_seq = block_table + batch_idx * max_num_blocks;
+
+  const int tid = threadIdx.x;
+  const int num_threads = blockDim.x;
+  const int elements_per_token = num_heads * head_dim;
+
+  for (int token_idx = 0; token_idx < seq_len; ++token_idx) {
+    const int virtual_block_idx = token_idx / block_size;
+    const int block_offset = token_idx % block_size;
+    const int physical_block_idx = block_table_seq[virtual_block_idx];
+
+    const __half* token_base = paged_cache + physical_block_idx * block_stride +
+                               block_offset * page_stride;
+
+    __half* output_token =
+        contiguous + (output_offset + token_idx) * elements_per_token;
+
+    for (int head_idx = 0; head_idx < num_heads; ++head_idx) {
+      const __half* head_src = token_base + head_idx * head_stride;
+      __half* head_dst = output_token + head_idx * head_dim;
+
+      for (int elem_idx = tid; elem_idx < head_dim; elem_idx += num_threads) {
+        head_dst[elem_idx] = head_src[elem_idx];
+      }
     }
-
-    const int* block_table_seq = block_table + batch_idx * max_num_blocks;
-
-    const int tid = threadIdx.x;
-    const int num_threads = blockDim.x;
-    const int elements_per_token = num_heads * head_dim;
-
-    for (int token_idx = 0; token_idx < seq_len; ++token_idx) {
-
-        const int virtual_block_idx = token_idx / block_size;
-        const int block_offset = token_idx % block_size;
-        const int physical_block_idx = block_table_seq[virtual_block_idx];
-
-        const __half* token_base = paged_cache
-            + physical_block_idx * block_stride
-            + block_offset * page_stride;
-
-        __half* output_token = contiguous + (output_offset + token_idx) * elements_per_token;
-
-        for (int head_idx = 0; head_idx < num_heads; ++head_idx) {
-            const __half* head_src = token_base + head_idx * head_stride;
-            __half* head_dst = output_token + head_idx * head_dim;
-
-            for (int elem_idx = tid; elem_idx < head_dim; elem_idx += num_threads) {
-                head_dst[elem_idx] = head_src[elem_idx];
-            }
-        }
-    }
+  }
 }
 
 __global__ void paged_kv_to_contiguous_stride_aware_kernel(
     const __half* __restrict__ paged_key_cache,
     const __half* __restrict__ paged_value_cache,
-    const int* __restrict__ block_table,
-    const int* __restrict__ seq_lens,
-          __half* __restrict__ contiguous_key,
-          __half* __restrict__ contiguous_value,
-    const int64_t key_block_stride,
-    const int64_t key_page_stride,
-    const int64_t key_head_stride,
-    const int64_t value_block_stride,
-    const int64_t value_page_stride,
-    const int64_t value_head_stride,
-    const int block_size,
-    const int num_heads,
-    const int head_dim,
-    const int max_num_blocks
-) {
-    const int batch_idx = blockIdx.x;
-    const int seq_len = seq_lens[batch_idx];
-    if (seq_len == 0) return;
+    const int* __restrict__ block_table, const int* __restrict__ seq_lens,
+    __half* __restrict__ contiguous_key, __half* __restrict__ contiguous_value,
+    const int64_t key_block_stride, const int64_t key_page_stride,
+    const int64_t key_head_stride, const int64_t value_block_stride,
+    const int64_t value_page_stride, const int64_t value_head_stride,
+    const int block_size, const int num_heads, const int head_dim,
+    const int max_num_blocks) {
+  const int batch_idx = blockIdx.x;
+  const int seq_len = seq_lens[batch_idx];
+  if (seq_len == 0) return;
 
-    int output_offset = 0;
-    for (int i = 0; i < batch_idx; ++i) {
-        output_offset += seq_lens[i];
+  int output_offset = 0;
+  for (int i = 0; i < batch_idx; ++i) {
+    output_offset += seq_lens[i];
+  }
+
+  const int* block_table_seq = block_table + batch_idx * max_num_blocks;
+  const int tid = threadIdx.x;
+  const int num_threads = blockDim.x;
+  const int elements_per_token = num_heads * head_dim;
+
+  for (int token_idx = 0; token_idx < seq_len; ++token_idx) {
+    const int virtual_block_idx = token_idx / block_size;
+    const int block_offset = token_idx % block_size;
+    const int physical_block_idx = block_table_seq[virtual_block_idx];
+
+    const __half* key_token_base = paged_key_cache +
+                                   physical_block_idx * key_block_stride +
+                                   block_offset * key_page_stride;
+    const __half* value_token_base = paged_value_cache +
+                                     physical_block_idx * value_block_stride +
+                                     block_offset * value_page_stride;
+
+    __half* key_output_token =
+        contiguous_key + (output_offset + token_idx) * elements_per_token;
+    __half* value_output_token =
+        contiguous_value + (output_offset + token_idx) * elements_per_token;
+
+    for (int head_idx = 0; head_idx < num_heads; ++head_idx) {
+      const __half* key_head_src = key_token_base + head_idx * key_head_stride;
+      const __half* value_head_src =
+          value_token_base + head_idx * value_head_stride;
+      __half* key_head_dst = key_output_token + head_idx * head_dim;
+      __half* value_head_dst = value_output_token + head_idx * head_dim;
+
+      for (int elem_idx = tid; elem_idx < head_dim; elem_idx += num_threads) {
+        key_head_dst[elem_idx] = key_head_src[elem_idx];
+        value_head_dst[elem_idx] = value_head_src[elem_idx];
+      }
     }
-
-    const int* block_table_seq = block_table + batch_idx * max_num_blocks;
-    const int tid = threadIdx.x;
-    const int num_threads = blockDim.x;
-    const int elements_per_token = num_heads * head_dim;
-
-    for (int token_idx = 0; token_idx < seq_len; ++token_idx) {
-        const int virtual_block_idx = token_idx / block_size;
-        const int block_offset = token_idx % block_size;
-        const int physical_block_idx = block_table_seq[virtual_block_idx];
-
-        const __half* key_token_base = paged_key_cache
-            + physical_block_idx * key_block_stride
-            + block_offset * key_page_stride;
-        const __half* value_token_base = paged_value_cache
-            + physical_block_idx * value_block_stride
-            + block_offset * value_page_stride;
-
-        __half* key_output_token =
-            contiguous_key + (output_offset + token_idx) * elements_per_token;
-        __half* value_output_token =
-            contiguous_value + (output_offset + token_idx) * elements_per_token;
-
-        for (int head_idx = 0; head_idx < num_heads; ++head_idx) {
-            const __half* key_head_src = key_token_base + head_idx * key_head_stride;
-            const __half* value_head_src =
-                value_token_base + head_idx * value_head_stride;
-            __half* key_head_dst = key_output_token + head_idx * head_dim;
-            __half* value_head_dst = value_output_token + head_idx * head_dim;
-
-            for (int elem_idx = tid; elem_idx < head_dim; elem_idx += num_threads) {
-                key_head_dst[elem_idx] = key_head_src[elem_idx];
-                value_head_dst[elem_idx] = value_head_src[elem_idx];
-            }
-        }
-    }
+  }
 }
 
-torch::Tensor paged_to_contiguous(
-    torch::Tensor paged_cache,
-    torch::Tensor block_table,
-    torch::Tensor seq_lens
-) {
-    const int batch_size = block_table.size(0);
-    const int max_num_blocks = block_table.size(1);
-    const int num_blocks = paged_cache.size(0);
-    const int block_size = paged_cache.size(1);
-    const int num_heads = paged_cache.size(2);
-    const int head_dim = paged_cache.size(3);
+torch::Tensor paged_to_contiguous(torch::Tensor paged_cache,
+                                  torch::Tensor block_table,
+                                  torch::Tensor seq_lens) {
+  const int batch_size = block_table.size(0);
+  const int max_num_blocks = block_table.size(1);
+  const int num_blocks = paged_cache.size(0);
+  const int block_size = paged_cache.size(1);
+  const int num_heads = paged_cache.size(2);
+  const int head_dim = paged_cache.size(3);
 
-    const int64_t block_stride = paged_cache.stride(0);
-    const int64_t page_stride = paged_cache.stride(1);
-    const int64_t head_stride = paged_cache.stride(2);
+  const int64_t block_stride = paged_cache.stride(0);
+  const int64_t page_stride = paged_cache.stride(1);
+  const int64_t head_stride = paged_cache.stride(2);
 
-    const int total_tokens = batch_size * max_num_blocks * block_size;
+  const int total_tokens = batch_size * max_num_blocks * block_size;
 
-    auto contiguous = torch::zeros(
-        {total_tokens, num_heads, head_dim},
-        torch::TensorOptions().dtype(paged_cache.dtype()).device(paged_cache.device())
-    );
+  auto contiguous = torch::zeros({total_tokens, num_heads, head_dim},
+                                 torch::TensorOptions()
+                                     .dtype(paged_cache.dtype())
+                                     .device(paged_cache.device()));
 
-    const int threads = 256;
-    paged_to_contiguous_stride_aware_kernel<<<batch_size, threads>>>(
-        reinterpret_cast<const __half*>(paged_cache.data_ptr<at::Half>()),
-        block_table.data_ptr<int>(),
-        seq_lens.data_ptr<int>(),
-        reinterpret_cast<__half*>(contiguous.data_ptr<at::Half>()),
-        block_stride,
-        page_stride,
-        head_stride,
-        block_size,
-        num_heads,
-        head_dim,
-        max_num_blocks
-    );
+  const int threads = 256;
+  paged_to_contiguous_stride_aware_kernel<<<batch_size, threads>>>(
+      reinterpret_cast<const __half*>(paged_cache.data_ptr<at::Half>()),
+      block_table.data_ptr<int>(), seq_lens.data_ptr<int>(),
+      reinterpret_cast<__half*>(contiguous.data_ptr<at::Half>()), block_stride,
+      page_stride, head_stride, block_size, num_heads, head_dim,
+      max_num_blocks);
 
-    return contiguous;
+  return contiguous;
 }
 
 std::vector<torch::Tensor> paged_kv_to_contiguous(
-    torch::Tensor paged_key_cache,
-    torch::Tensor paged_value_cache,
-    torch::Tensor block_table,
-    torch::Tensor seq_lens
-) {
-    const int batch_size = block_table.size(0);
-    const int max_num_blocks = block_table.size(1);
-    const int block_size = paged_key_cache.size(1);
-    const int num_heads = paged_key_cache.size(2);
-    const int head_dim = paged_key_cache.size(3);
+    torch::Tensor paged_key_cache, torch::Tensor paged_value_cache,
+    torch::Tensor block_table, torch::Tensor seq_lens) {
+  const int batch_size = block_table.size(0);
+  const int max_num_blocks = block_table.size(1);
+  const int block_size = paged_key_cache.size(1);
+  const int num_heads = paged_key_cache.size(2);
+  const int head_dim = paged_key_cache.size(3);
 
-    const int64_t key_block_stride = paged_key_cache.stride(0);
-    const int64_t key_page_stride = paged_key_cache.stride(1);
-    const int64_t key_head_stride = paged_key_cache.stride(2);
-    const int64_t value_block_stride = paged_value_cache.stride(0);
-    const int64_t value_page_stride = paged_value_cache.stride(1);
-    const int64_t value_head_stride = paged_value_cache.stride(2);
+  const int64_t key_block_stride = paged_key_cache.stride(0);
+  const int64_t key_page_stride = paged_key_cache.stride(1);
+  const int64_t key_head_stride = paged_key_cache.stride(2);
+  const int64_t value_block_stride = paged_value_cache.stride(0);
+  const int64_t value_page_stride = paged_value_cache.stride(1);
+  const int64_t value_head_stride = paged_value_cache.stride(2);
 
-    const int total_tokens = batch_size * max_num_blocks * block_size;
+  const int total_tokens = batch_size * max_num_blocks * block_size;
 
-    auto opts = torch::TensorOptions()
-                    .dtype(paged_key_cache.dtype())
-                    .device(paged_key_cache.device());
-    auto contiguous_key = torch::zeros({total_tokens, num_heads, head_dim}, opts);
-    auto contiguous_value = torch::zeros({total_tokens, num_heads, head_dim}, opts);
+  auto opts = torch::TensorOptions()
+                  .dtype(paged_key_cache.dtype())
+                  .device(paged_key_cache.device());
+  auto contiguous_key = torch::zeros({total_tokens, num_heads, head_dim}, opts);
+  auto contiguous_value =
+      torch::zeros({total_tokens, num_heads, head_dim}, opts);
 
-    const int threads = 256;
-    paged_kv_to_contiguous_stride_aware_kernel<<<batch_size, threads>>>(
-        reinterpret_cast<const __half*>(paged_key_cache.data_ptr<at::Half>()),
-        reinterpret_cast<const __half*>(paged_value_cache.data_ptr<at::Half>()),
-        block_table.data_ptr<int>(),
-        seq_lens.data_ptr<int>(),
-        reinterpret_cast<__half*>(contiguous_key.data_ptr<at::Half>()),
-        reinterpret_cast<__half*>(contiguous_value.data_ptr<at::Half>()),
-        key_block_stride,
-        key_page_stride,
-        key_head_stride,
-        value_block_stride,
-        value_page_stride,
-        value_head_stride,
-        block_size,
-        num_heads,
-        head_dim,
-        max_num_blocks
-    );
+  const int threads = 256;
+  paged_kv_to_contiguous_stride_aware_kernel<<<batch_size, threads>>>(
+      reinterpret_cast<const __half*>(paged_key_cache.data_ptr<at::Half>()),
+      reinterpret_cast<const __half*>(paged_value_cache.data_ptr<at::Half>()),
+      block_table.data_ptr<int>(), seq_lens.data_ptr<int>(),
+      reinterpret_cast<__half*>(contiguous_key.data_ptr<at::Half>()),
+      reinterpret_cast<__half*>(contiguous_value.data_ptr<at::Half>()),
+      key_block_stride, key_page_stride, key_head_stride, value_block_stride,
+      value_page_stride, value_head_stride, block_size, num_heads, head_dim,
+      max_num_blocks);
 
-    return {contiguous_key, contiguous_value};
+  return {contiguous_key, contiguous_value};
 }
 
 PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
-    m.def("paged_to_contiguous", &paged_to_contiguous, "Paged KV Cache to Contiguous (Stride-Aware)");
-    m.def("paged_kv_to_contiguous",
-          &paged_kv_to_contiguous,
-          "Paged KV Cache to Contiguous K/V Pair (Stride-Aware)");
+  m.def("paged_to_contiguous", &paged_to_contiguous,
+        "Paged KV Cache to Contiguous (Stride-Aware)");
+  m.def("paged_kv_to_contiguous", &paged_kv_to_contiguous,
+        "Paged KV Cache to Contiguous K/V Pair (Stride-Aware)");
 }

--- a/flash-attention-v100/kernel/paged_to_contiguous_fixed.cu
+++ b/flash-attention-v100/kernel/paged_to_contiguous_fixed.cu
@@ -4,102 +4,85 @@
 #include <torch/extension.h>
 
 __global__ void paged_to_contiguous_stride_aware_kernel(
-    const __half* __restrict__ paged_cache,
-    const int* __restrict__ block_table,
-    const int* __restrict__ seq_lens,
-          __half* __restrict__ contiguous,
-    const int64_t block_stride,
-    const int64_t page_stride,
-    const int64_t head_stride,
-    const int block_size,
-    const int num_heads,
-    const int head_dim,
-    const int max_num_blocks
-) {
+    const __half* __restrict__ paged_cache, const int* __restrict__ block_table,
+    const int* __restrict__ seq_lens, __half* __restrict__ contiguous,
+    const int64_t block_stride, const int64_t page_stride,
+    const int64_t head_stride, const int block_size, const int num_heads,
+    const int head_dim, const int max_num_blocks) {
+  const int batch_idx = blockIdx.x;
+  const int seq_len = seq_lens[batch_idx];
+  if (seq_len == 0) return;
 
-    const int batch_idx = blockIdx.x;
-    const int seq_len = seq_lens[batch_idx];
-    if (seq_len == 0) return;
+  int output_offset = 0;
+  for (int i = 0; i < batch_idx; ++i) {
+    output_offset += seq_lens[i];
+  }
 
-    int output_offset = 0;
-    for (int i = 0; i < batch_idx; ++i) {
-        output_offset += seq_lens[i];
+  const int* block_table_seq = block_table + batch_idx * max_num_blocks;
+
+  const int tid = threadIdx.x;
+  const int num_threads = blockDim.x;
+  const int elements_per_token = num_heads * head_dim;
+
+  for (int token_idx = 0; token_idx < seq_len; ++token_idx) {
+    const int virtual_block_idx = token_idx / block_size;
+    const int block_offset = token_idx % block_size;
+    const int physical_block_idx = block_table_seq[virtual_block_idx];
+
+    const __half* token_base = paged_cache + physical_block_idx * block_stride +
+                               block_offset * page_stride;
+
+    __half* output_token =
+        contiguous + (output_offset + token_idx) * elements_per_token;
+
+    for (int head_idx = 0; head_idx < num_heads; ++head_idx) {
+      const __half* head_src = token_base + head_idx * head_stride;
+      __half* head_dst = output_token + head_idx * head_dim;
+
+      for (int elem_idx = tid; elem_idx < head_dim; elem_idx += num_threads) {
+        head_dst[elem_idx] = head_src[elem_idx];
+      }
     }
-
-    const int* block_table_seq = block_table + batch_idx * max_num_blocks;
-
-    const int tid = threadIdx.x;
-    const int num_threads = blockDim.x;
-    const int elements_per_token = num_heads * head_dim;
-
-    for (int token_idx = 0; token_idx < seq_len; ++token_idx) {
-
-        const int virtual_block_idx = token_idx / block_size;
-        const int block_offset = token_idx % block_size;
-        const int physical_block_idx = block_table_seq[virtual_block_idx];
-
-        const __half* token_base = paged_cache
-            + physical_block_idx * block_stride
-            + block_offset * page_stride;
-
-        __half* output_token = contiguous + (output_offset + token_idx) * elements_per_token;
-
-        for (int head_idx = 0; head_idx < num_heads; ++head_idx) {
-            const __half* head_src = token_base + head_idx * head_stride;
-            __half* head_dst = output_token + head_idx * head_dim;
-
-            for (int elem_idx = tid; elem_idx < head_dim; elem_idx += num_threads) {
-                head_dst[elem_idx] = head_src[elem_idx];
-            }
-        }
-    }
+  }
 }
 
-torch::Tensor paged_to_contiguous(
-    torch::Tensor paged_cache,
-    torch::Tensor block_table,
-    torch::Tensor seq_lens
-) {
-    const int batch_size = block_table.size(0);
-    const int max_num_blocks = block_table.size(1);
-    const int num_blocks = paged_cache.size(0);
-    const int block_size = paged_cache.size(1);
-    const int num_heads = paged_cache.size(2);
-    const int head_dim = paged_cache.size(3);
+torch::Tensor paged_to_contiguous(torch::Tensor paged_cache,
+                                  torch::Tensor block_table,
+                                  torch::Tensor seq_lens) {
+  const int batch_size = block_table.size(0);
+  const int max_num_blocks = block_table.size(1);
+  const int num_blocks = paged_cache.size(0);
+  const int block_size = paged_cache.size(1);
+  const int num_heads = paged_cache.size(2);
+  const int head_dim = paged_cache.size(3);
 
-    const int64_t block_stride = paged_cache.stride(0);
-    const int64_t page_stride = paged_cache.stride(1);
-    const int64_t head_stride = paged_cache.stride(2);
+  const int64_t block_stride = paged_cache.stride(0);
+  const int64_t page_stride = paged_cache.stride(1);
+  const int64_t head_stride = paged_cache.stride(2);
 
-    int total_tokens = 0;
-    auto seq_lens_cpu = seq_lens.cpu();
-    for (int i = 0; i < batch_size; ++i) {
-        total_tokens += seq_lens_cpu[i].item<int>();
-    }
+  int total_tokens = 0;
+  auto seq_lens_cpu = seq_lens.cpu();
+  for (int i = 0; i < batch_size; ++i) {
+    total_tokens += seq_lens_cpu[i].item<int>();
+  }
 
-    auto contiguous = torch::zeros(
-        {total_tokens, num_heads, head_dim},
-        torch::TensorOptions().dtype(paged_cache.dtype()).device(paged_cache.device())
-    );
+  auto contiguous = torch::zeros({total_tokens, num_heads, head_dim},
+                                 torch::TensorOptions()
+                                     .dtype(paged_cache.dtype())
+                                     .device(paged_cache.device()));
 
-    const int threads = 256;
-    paged_to_contiguous_stride_aware_kernel<<<batch_size, threads>>>(
-        reinterpret_cast<const __half*>(paged_cache.data_ptr<at::Half>()),
-        block_table.data_ptr<int>(),
-        seq_lens.data_ptr<int>(),
-        reinterpret_cast<__half*>(contiguous.data_ptr<at::Half>()),
-        block_stride,
-        page_stride,
-        head_stride,
-        block_size,
-        num_heads,
-        head_dim,
-        max_num_blocks
-    );
+  const int threads = 256;
+  paged_to_contiguous_stride_aware_kernel<<<batch_size, threads>>>(
+      reinterpret_cast<const __half*>(paged_cache.data_ptr<at::Half>()),
+      block_table.data_ptr<int>(), seq_lens.data_ptr<int>(),
+      reinterpret_cast<__half*>(contiguous.data_ptr<at::Half>()), block_stride,
+      page_stride, head_stride, block_size, num_heads, head_dim,
+      max_num_blocks);
 
-    return contiguous;
+  return contiguous;
 }
 
 PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
-    m.def("paged_to_contiguous", &paged_to_contiguous, "Paged KV Cache to Contiguous (Stride-Aware)");
+  m.def("paged_to_contiguous", &paged_to_contiguous,
+        "Paged KV Cache to Contiguous (Stride-Aware)");
 }

--- a/flash-attention-v100/kernel/paged_to_contiguous_old.cu
+++ b/flash-attention-v100/kernel/paged_to_contiguous_old.cu
@@ -4,85 +4,75 @@
 #include <torch/extension.h>
 
 __global__ void paged_to_contiguous_kernel(
-    const __half* __restrict__ paged_cache,
-    const int* __restrict__ block_table,
-    const int* __restrict__ seq_lens,
-          __half* __restrict__ contiguous,
-    const int block_size,
-    const int num_heads,
-    const int head_dim,
-    const int max_num_blocks
-) {
+    const __half* __restrict__ paged_cache, const int* __restrict__ block_table,
+    const int* __restrict__ seq_lens, __half* __restrict__ contiguous,
+    const int block_size, const int num_heads, const int head_dim,
+    const int max_num_blocks) {
+  const int batch_idx = blockIdx.x;
+  const int seq_len = seq_lens[batch_idx];
+  if (seq_len == 0) return;
 
-    const int batch_idx = blockIdx.x;
-    const int seq_len = seq_lens[batch_idx];
-    if (seq_len == 0) return;
+  int output_offset = 0;
+  for (int i = 0; i < batch_idx; ++i) {
+    output_offset += seq_lens[i];
+  }
 
-    int output_offset = 0;
-    for (int i = 0; i < batch_idx; ++i) {
-        output_offset += seq_lens[i];
+  const int* block_table_seq = block_table + batch_idx * max_num_blocks;
+
+  const int tid = threadIdx.x;
+  const int num_threads = blockDim.x;
+  const int elements_per_token = num_heads * head_dim;
+
+  for (int token_idx = 0; token_idx < seq_len; ++token_idx) {
+    const int virtual_block_idx = token_idx / block_size;
+    const int block_offset = token_idx % block_size;
+    const int physical_block_idx = block_table_seq[virtual_block_idx];
+
+    const size_t paged_offset =
+        (size_t)physical_block_idx * block_size * elements_per_token +
+        (size_t)block_offset * elements_per_token;
+
+    const size_t cont_offset =
+        (size_t)(output_offset + token_idx) * elements_per_token;
+
+    for (int elem_idx = tid; elem_idx < elements_per_token;
+         elem_idx += num_threads) {
+      contiguous[cont_offset + elem_idx] = paged_cache[paged_offset + elem_idx];
     }
-
-    const int* block_table_seq = block_table + batch_idx * max_num_blocks;
-
-    const int tid = threadIdx.x;
-    const int num_threads = blockDim.x;
-    const int elements_per_token = num_heads * head_dim;
-
-    for (int token_idx = 0; token_idx < seq_len; ++token_idx) {
-
-        const int virtual_block_idx = token_idx / block_size;
-        const int block_offset = token_idx % block_size;
-        const int physical_block_idx = block_table_seq[virtual_block_idx];
-
-        const size_t paged_offset = (size_t)physical_block_idx * block_size * elements_per_token
-                                  + (size_t)block_offset * elements_per_token;
-
-        const size_t cont_offset = (size_t)(output_offset + token_idx) * elements_per_token;
-
-        for (int elem_idx = tid; elem_idx < elements_per_token; elem_idx += num_threads) {
-            contiguous[cont_offset + elem_idx] = paged_cache[paged_offset + elem_idx];
-        }
-    }
+  }
 }
 
-torch::Tensor paged_to_contiguous(
-    torch::Tensor paged_cache,
-    torch::Tensor block_table,
-    torch::Tensor seq_lens
-) {
-    const int batch_size = block_table.size(0);
-    const int max_num_blocks = block_table.size(1);
-    const int block_size = paged_cache.size(1);
-    const int num_heads = paged_cache.size(2);
-    const int head_dim = paged_cache.size(3);
+torch::Tensor paged_to_contiguous(torch::Tensor paged_cache,
+                                  torch::Tensor block_table,
+                                  torch::Tensor seq_lens) {
+  const int batch_size = block_table.size(0);
+  const int max_num_blocks = block_table.size(1);
+  const int block_size = paged_cache.size(1);
+  const int num_heads = paged_cache.size(2);
+  const int head_dim = paged_cache.size(3);
 
-    int total_tokens = 0;
-    auto seq_lens_cpu = seq_lens.cpu();
-    for (int i = 0; i < batch_size; ++i) {
-        total_tokens += seq_lens_cpu[i].item<int>();
-    }
+  int total_tokens = 0;
+  auto seq_lens_cpu = seq_lens.cpu();
+  for (int i = 0; i < batch_size; ++i) {
+    total_tokens += seq_lens_cpu[i].item<int>();
+  }
 
-    auto contiguous = torch::zeros(
-        {total_tokens, num_heads, head_dim},
-        torch::TensorOptions().dtype(paged_cache.dtype()).device(paged_cache.device())
-    );
+  auto contiguous = torch::zeros({total_tokens, num_heads, head_dim},
+                                 torch::TensorOptions()
+                                     .dtype(paged_cache.dtype())
+                                     .device(paged_cache.device()));
 
-    const int threads = 256;
-    paged_to_contiguous_kernel<<<batch_size, threads>>>(
-        reinterpret_cast<const __half*>(paged_cache.data_ptr<at::Half>()),
-        block_table.data_ptr<int>(),
-        seq_lens.data_ptr<int>(),
-        reinterpret_cast<__half*>(contiguous.data_ptr<at::Half>()),
-        block_size,
-        num_heads,
-        head_dim,
-        max_num_blocks
-    );
+  const int threads = 256;
+  paged_to_contiguous_kernel<<<batch_size, threads>>>(
+      reinterpret_cast<const __half*>(paged_cache.data_ptr<at::Half>()),
+      block_table.data_ptr<int>(), seq_lens.data_ptr<int>(),
+      reinterpret_cast<__half*>(contiguous.data_ptr<at::Half>()), block_size,
+      num_heads, head_dim, max_num_blocks);
 
-    return contiguous;
+  return contiguous;
 }
 
 PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
-    m.def("paged_to_contiguous", &paged_to_contiguous, "Paged KV Cache to Contiguous");
+  m.def("paged_to_contiguous", &paged_to_contiguous,
+        "Paged KV Cache to Contiguous");
 }


### PR DESCRIPTION
Refs #126

## Purpose
Restore the C/CUDA portion of the static baseline without changing runtime behavior.

## Scope
- Applied repository clang-format 21.1.2 to tracked C/CUDA/header files under csrc and flash-attention-v100.
- Corrected 18 C/CUDA typos in internal identifiers, diagnostics, local variables, and comments.
- Added semicolon terminators to eight local macro invocations in fused_mha_backward.cu so clang-format is idempotent. The macro already expands to terminated declarations, so this adds only empty statements.
- Normalized one mixed-CRLF C++ file to LF.
- No Python, docs, requirements, CI configuration, generated artifacts, performance logic, or semantic Marlin/kernel changes.

## Baseline and size
- Base: onecat/main at 3ec0c68c6596d6ab31fbdee9fa676254a52c2b7d
- Head: d3b59af9c656413270e37cd55c0bf88e932a1c5d
- 181 files: 166 under csrc and 15 under flash-attention-v100.
- 25,371 insertions and 27,910 deletions. This is intentionally a large mechanical formatting PR.

## Validation
- Focused clang-format hook: passed after re-run across all 459 tracked C/CUDA/header inputs.
- Focused typos hook: passed.
- Focused SPDX hook: skipped because repository hook accepts Python files only; no C/CUDA SPDX changes were required.
- git diff --check and git show --check: passed.
- Offline build: CUDA_HOME=/usr/local/cuda, TORCH_CUDA_ARCH_LIST=7.0, MAX_JOBS=1, PyTorch 2.10.0+cu128, CUDA 12.8. Built both Flash-V100 extensions into /tmp/v100-static-126-flash-v100-build.
- cuobjdump confirmed SM70 cubins only. A clean Python 3.12 process imported both built extensions.

## Risk and gates
- No physical GPU is available, so no runtime, correctness, performance, or V100 serving validation is claimed.
- Review as a format/static-only PR. Full pre-commit remains tracked by #126 and has separate non-C/CUDA debt.