### PR TITLE
[CI/Build] Fix mypy baseline errors

### DIFF
--- a/tests/model_executor/test_qwen3_5_quantization.py
+++ b/tests/model_executor/test_qwen3_5_quantization.py
@@ -5,7 +5,9 @@ from unittest.mock import Mock, patch
 
 
 class _QuantConfig:
-    pass
+    def __init__(self) -> None:
+        self.ignore: list[str] | None = None
+        self.config: dict[str, list[str]] = {}
 
 
 def test_qwen3_5_split_gdn_detects_compressed_tensors_ignore():

--- a/tests/v1/attention/test_gdn_metadata_builder.py
+++ b/tests/v1/attention/test_gdn_metadata_builder.py
@@ -468,9 +468,7 @@ def test_spec_state_slot_selector_can_differ_from_accepted_count(local_gdn_model
         common_prefix_len=0,
         common_attn_metadata=common,
         num_accepted_tokens=torch.tensor([2], dtype=torch.int32, device=DEVICE),
-        spec_state_slot_selectors=torch.tensor(
-            [4], dtype=torch.int32, device=DEVICE
-        ),
+        spec_state_slot_selectors=torch.tensor([4], dtype=torch.int32, device=DEVICE),
         num_decode_draft_tokens_cpu=torch.tensor([4], dtype=torch.int32, device="cpu"),
     )
 
@@ -749,9 +747,7 @@ def test_gdn_state_contract_debug_assert_rejects_pad_accepted_slot(
             spec_sequence_masks_cpu=torch.tensor(
                 [True], dtype=torch.bool, device="cpu"
             ),
-            num_accepted_tokens=torch.tensor(
-                [5], dtype=torch.int32, device=DEVICE
-            ),
+            num_accepted_tokens=torch.tensor([5], dtype=torch.int32, device=DEVICE),
             current_state_block_ids=None,
             is_mamba_cache_all=False,
         )
@@ -778,9 +774,7 @@ def test_spec_commit_pure_decode_consumes_padded_graph_rows_without_metadata_pat
         num_spec_decodes=2,
         num_spec_decode_tokens=10,
         num_actual_tokens=10,
-        spec_query_start_loc=torch.tensor(
-            [0, 5, 10], dtype=torch.int32, device=DEVICE
-        ),
+        spec_query_start_loc=torch.tensor([0, 5, 10], dtype=torch.int32, device=DEVICE),
         spec_state_indices_tensor=torch.tensor(
             [[10, 11, 12, 13, 14], [20, 21, 22, 23, 24]],
             dtype=torch.int32,
@@ -821,7 +815,6 @@ def test_spec_commit_pure_decode_consumes_padded_graph_rows_without_metadata_pat
     seen: dict[str, object] = {}
 
     class FakeLayer:
-
         def __init__(self) -> None:
             self.conv1d = torch.nn.Identity()
             self.conv1d.weight = torch.empty((8, 1, 1), device=DEVICE)
@@ -1023,9 +1016,7 @@ def test_sm70_qwen_gdn_blocks_003_spec_core_only_for_deep_native_mtp(
     expected,
 ):
     monkeypatch.setenv("VLLM_SM70_QWEN_GDN_003_SPEC_CORE_OP", "1")
-    monkeypatch.delenv(
-        "VLLM_SM70_QWEN_GDN_003_SPEC_ALLOW_DEEP_MTP", raising=False
-    )
+    monkeypatch.delenv("VLLM_SM70_QWEN_GDN_003_SPEC_ALLOW_DEEP_MTP", raising=False)
     _clear_envs_cache()
 
     vllm_config = SimpleNamespace(
@@ -1036,9 +1027,7 @@ def test_sm70_qwen_gdn_blocks_003_spec_core_only_for_deep_native_mtp(
     )
 
     assert (
-        qwen_gdn._sm70_qwen_gdn_block_003_spec_for_deep_native_mtp(
-            vllm_config
-        )
+        qwen_gdn._sm70_qwen_gdn_block_003_spec_for_deep_native_mtp(vllm_config)
         is expected
     )
 
@@ -1057,9 +1046,7 @@ def test_sm70_qwen_gdn_003_spec_core_deep_mtp_override_is_diagnostic(
         )
     )
 
-    assert not qwen_gdn._sm70_qwen_gdn_block_003_spec_for_deep_native_mtp(
-        vllm_config
-    )
+    assert not qwen_gdn._sm70_qwen_gdn_block_003_spec_for_deep_native_mtp(vllm_config)
 
 
 def test_sm70_qwen_gdn_003_spec_core_route_has_priority(

--- a/tests/v1/attention/test_sm70_flashinfer_backend.py
+++ b/tests/v1/attention/test_sm70_flashinfer_backend.py
@@ -95,9 +95,7 @@ def _make_fixed_prefill_impl(fixed_entry, splitkv3_entry=None):
     impl.logits_soft_cap = 0.0
     impl.sinks = None
     impl.flash_attn_prefill_paged_d256_bm32_allp_pair_scratch = fixed_entry
-    impl.flash_attn_prefill_paged_d256_bm32_allp_pair_scratch_splitkv3 = (
-        splitkv3_entry
-    )
+    impl.flash_attn_prefill_paged_d256_bm32_allp_pair_scratch_splitkv3 = splitkv3_entry
     impl.last_route_proof = None
     impl._flashinfer_sm70_active_metadata = None
     return impl

--- a/tests/v1/attention/test_sm70_flashinfer_backend.py
+++ b/tests/v1/attention/test_sm70_flashinfer_backend.py
@@ -103,6 +103,30 @@ def _make_fixed_prefill_impl(fixed_entry, splitkv3_entry=None):
     return impl
 
 
+def test_metadata_none_zeros_output_and_records_profile_route(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    impl = object.__new__(FlashInferSM70Impl)
+    output = torch.ones((2, 3), dtype=torch.float32)
+    route_calls: list[str] = []
+    monkeypatch.setattr(flashinfer_sm70_backend, "_record_route", route_calls.append)
+
+    result = impl.forward(
+        object(),
+        torch.empty(0),
+        torch.empty(0),
+        torch.empty(0),
+        torch.empty(0),
+        None,
+        output,
+    )
+
+    assert result is output
+    assert torch.equal(output, torch.zeros_like(output))
+    assert impl.last_route_proof is None
+    assert route_calls == ["metadata_none_zero_output"]
+
+
 def test_flashinfer_sm70_registry_is_independent() -> None:
     assert AttentionBackendEnum.FLASHINFER_SM70.get_class() is FlashInferSM70Backend
     assert FlashInferSM70Backend.get_name() == "FLASHINFER_SM70"
@@ -247,7 +271,7 @@ def test_eligible_fixed_prefill_bypasses_parent_and_records_runtime_proof(
 ) -> None:
     decision, metadata, query, kv_cache, output = _make_fixed_prefill_case()
     calls = []
-    route_calls = []
+    route_calls: list[str] = []
 
     def fixed_entry(
         query_bhmd,
@@ -351,7 +375,7 @@ def test_promoted_splitkv3_bypasses_fixed_entry_and_records_actual_n(
 ) -> None:
     decision, metadata, query, kv_cache, output = _make_fixed_prefill_case()
     calls = []
-    route_calls = []
+    route_calls: list[str] = []
 
     def splitkv3_entry(
         query_bhmd,
@@ -541,7 +565,7 @@ def test_fixed_prefill_entry_error_is_fail_closed(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     _, metadata, query, kv_cache, output = _make_fixed_prefill_case()
-    route_calls = []
+    route_calls: list[str] = []
 
     def failed_fixed_entry(*args, **kwargs):
         raise RuntimeError("fixed entry failed")

--- a/tests/v1/spec_decode/test_ddtree_sampler.py
+++ b/tests/v1/spec_decode/test_ddtree_sampler.py
@@ -3,7 +3,7 @@
 
 import torch
 
-from vllm.v1.spec_decode.ddtree_payload import payload_from_tree
+from vllm.v1.spec_decode.ddtree_payload import DDTreeDraftPayload, payload_from_tree
 from vllm.v1.spec_decode.ddtree_sampler import (
     greedy_sample_ddtree_payloads,
     greedy_sample_ddtree_payloads_from_top_tokens,
@@ -12,7 +12,7 @@ from vllm.v1.spec_decode.ddtree_sampler import (
 from vllm.v1.spec_decode.ddtree_tree import build_ddtree
 
 
-def _payload() -> object:
+def _payload() -> DDTreeDraftPayload:
     tree = build_ddtree(
         [
             [(11, 0.0), (12, -0.1)],

--- a/tests/v1/spec_decode/test_ddtree_scheduler.py
+++ b/tests/v1/spec_decode/test_ddtree_scheduler.py
@@ -123,9 +123,7 @@ def test_update_draft_token_ids_caches_matching_ddtree_payload() -> None:
     scheduler = _scheduler(request)
     payload = _payload()
 
-    scheduler.update_draft_token_ids(
-        DraftTokenIds(["r0"], [[11, 21, 31]], [payload])
-    )
+    scheduler.update_draft_token_ids(DraftTokenIds(["r0"], [[11, 21, 31]], [payload]))
 
     assert request.spec_token_ids == [11, 21, 31]
     assert scheduler.ddtree_payloads_by_req_id == {"r0": payload}
@@ -137,9 +135,7 @@ def test_update_draft_token_ids_drops_payload_after_grammar_trim() -> None:
     scheduler = _scheduler(request, advance=True)
     payload = _payload()
 
-    scheduler.update_draft_token_ids(
-        DraftTokenIds(["r0"], [[11, 21, 31]], [payload])
-    )
+    scheduler.update_draft_token_ids(DraftTokenIds(["r0"], [[11, 21, 31]], [payload]))
 
     assert request.spec_token_ids == [11, 21]
     assert scheduler.ddtree_payloads_by_req_id == {}
@@ -152,9 +148,7 @@ def test_update_draft_token_ids_drops_payload_for_prefill_chunk() -> None:
     payload = _payload()
     scheduler.ddtree_payloads_by_req_id = {"r0": payload}
 
-    scheduler.update_draft_token_ids(
-        DraftTokenIds(["r0"], [[11, 21, 31]], [payload])
-    )
+    scheduler.update_draft_token_ids(DraftTokenIds(["r0"], [[11, 21, 31]], [payload]))
 
     assert request.spec_token_ids == []
     assert scheduler.ddtree_payloads_by_req_id == {}

--- a/tests/v1/spec_decode/test_ddtree_scheduler.py
+++ b/tests/v1/spec_decode/test_ddtree_scheduler.py
@@ -14,7 +14,7 @@ class _Request:
         self.request_id = "r0"
         self.is_prefill_chunk = is_prefill_chunk
         self.spec_token_ids: list[int] = []
-        self.structured_output_request = None
+        self.structured_output_request: SimpleNamespace | None = None
         self.max_tokens = 8
         self._output_token_ids: list[int] = []
         self.num_output_placeholders = 0

--- a/tests/v1/spec_decode/test_mtp_proposer_step_index.py
+++ b/tests/v1/spec_decode/test_mtp_proposer_step_index.py
@@ -231,9 +231,7 @@ def test_gemma4_non_centroid_greedy_sample_passes_spec_step_idx(
         spec_step_idx: int = 0,
     ) -> torch.Tensor:
         observed_spec_step_indices.append(spec_step_idx)
-        return torch.full(
-            (hidden_states.shape[0],), spec_step_idx, dtype=torch.int64
-        )
+        return torch.full((hidden_states.shape[0],), spec_step_idx, dtype=torch.int64)
 
     monkeypatch.setattr(SpecDecodeBaseProposer, "_greedy_sample", fake_greedy_sample)
 

--- a/tests/v1/spec_decode/test_mtp_proposer_step_index.py
+++ b/tests/v1/spec_decode/test_mtp_proposer_step_index.py
@@ -1,10 +1,16 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+from contextlib import nullcontext
+
 import pytest
 import torch
 
+from vllm.forward_context import BatchDescriptor
+from vllm.v1.spec_decode import step3p5 as step3p5_module
+from vllm.v1.spec_decode.gemma4 import Gemma4Proposer
 from vllm.v1.spec_decode.llm_base_proposer import SpecDecodeBaseProposer
+from vllm.v1.spec_decode.step3p5 import Step3p5MTPProposer
 from vllm.v1.worker.gpu_model_runner import GPUModelRunner
 
 
@@ -69,11 +75,36 @@ class _SchedulerOutput:
     scheduled_spec_decode_tokens = {"r0": [123]}
 
 
+class _Step3p5CommonAttentionMetadata:
+    def __init__(self) -> None:
+        self.num_actual_tokens = 1
+        self.max_query_len = 1
+        self.query_start_loc = torch.zeros(2, dtype=torch.int32)
+        self.query_start_loc_cpu = torch.zeros(2, dtype=torch.int32)
+        self.seq_lens = torch.ones(1, dtype=torch.int32)
+        self._seq_lens_cpu = None
+        self._num_computed_tokens_cpu = None
+        self.slot_mapping = torch.zeros(1, dtype=torch.int64)
+
+    def batch_size(self) -> int:
+        return 1
+
+
+class _Step3p5Model:
+    def __init__(self) -> None:
+        self.spec_step_indices: list[int] = []
+
+    def __call__(self, **kwargs) -> torch.Tensor:
+        self.spec_step_indices.append(kwargs["spec_step_idx"])
+        return torch.zeros((1, 4), dtype=torch.float32)
+
+
 def _proposer(method: str, model: object) -> SpecDecodeBaseProposer:
     proposer = object.__new__(SpecDecodeBaseProposer)
     proposer.method = method
     proposer.model = model
     proposer._enable_probabilistic_draft_probs = False
+    proposer._static_draft_vocab = None
     proposer.use_local_argmax_reduction = True
     return proposer
 
@@ -110,6 +141,108 @@ def test_non_mtp_does_not_pass_spec_step_idx_kwarg():
     tokens = proposer._greedy_sample(torch.zeros((2, 4)), spec_step_idx=3)
 
     assert torch.equal(tokens, torch.tensor([7, 7]))
+
+
+def test_step3p5_proposer_uses_batch_descriptor_graph_variant(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    proposer = object.__new__(Step3p5MTPProposer)
+    model = _Step3p5Model()
+    metadata = _Step3p5CommonAttentionMetadata()
+    context_descriptors: list[BatchDescriptor] = []
+
+    proposer.model = model
+    proposer._last_draft_probs = None
+    proposer.num_speculative_tokens = 2
+    proposer.parallel_drafting = False
+    proposer.uses_mrope = False
+    proposer.constant_draft_positions = True
+    proposer.allowed_attn_types = None
+    proposer.supports_mm_inputs = False
+    proposer.pass_hidden_states_to_model = False
+    proposer.block_size = 1
+    proposer.positions = torch.zeros(2, dtype=torch.int64)
+    proposer.arange = torch.arange(2, dtype=torch.int32)
+    proposer.token_arange_np = torch.arange(2, dtype=torch.int32).numpy()
+    proposer.input_ids = torch.zeros(2, dtype=torch.int32)
+    proposer.hidden_states = torch.zeros((2, 4), dtype=torch.float32)
+    proposer.vllm_config = object()
+    proposer.set_inputs_first_pass = lambda **kwargs: (
+        1,
+        torch.tensor([0], dtype=torch.int64),
+        metadata,
+    )
+    proposer.build_per_group_and_layer_attn_metadata = (
+        lambda common_attn_metadata, draft_index=0: ([], {})
+    )
+    proposer._determine_batch_execution_and_padding = lambda num_tokens: (
+        None,
+        1,
+        None,
+        BatchDescriptor(num_tokens=1),
+    )
+    proposer._batch_descriptor_for_spec_step = (
+        lambda descriptor, spec_step_idx: BatchDescriptor(
+            num_tokens=descriptor.num_tokens,
+            graph_variant=17 + spec_step_idx,
+        )
+    )
+    proposer.build_model_inputs_first_pass = lambda *args: ({}, 1)
+    proposer.model_returns_tuple = lambda: False
+    proposer._sample_draft_tokens_for_step = (
+        lambda hidden_states, sampling_metadata, spec_step_idx: (
+            torch.tensor([spec_step_idx + 1], dtype=torch.int64),
+            None,
+        )
+    )
+    proposer._get_positions = lambda num_tokens: proposer.positions[:num_tokens]
+    proposer._get_slot_mapping = lambda *args, **kwargs: {}
+
+    def fake_set_forward_context(*args, **kwargs):
+        context_descriptors.append(kwargs["batch_descriptor"])
+        return nullcontext()
+
+    monkeypatch.setattr(step3p5_module, "set_forward_context", fake_set_forward_context)
+
+    proposer.propose(
+        torch.zeros(1, dtype=torch.int64),
+        torch.zeros(1, dtype=torch.int64),
+        torch.zeros((1, 4), dtype=torch.float32),
+        torch.zeros(1, dtype=torch.int64),
+        None,
+        metadata,  # type: ignore[arg-type]
+        object(),  # type: ignore[arg-type]
+    )
+
+    assert model.spec_step_indices == [17, 18]
+    assert [descriptor.graph_variant for descriptor in context_descriptors] == [17, 18]
+
+
+def test_gemma4_non_centroid_greedy_sample_passes_spec_step_idx(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    proposer = object.__new__(Gemma4Proposer)
+    proposer._centroids_sizes = []
+    observed_spec_step_indices: list[int] = []
+
+    def fake_greedy_sample(
+        _proposer: SpecDecodeBaseProposer,
+        hidden_states: torch.Tensor,
+        spec_step_idx: int = 0,
+    ) -> torch.Tensor:
+        observed_spec_step_indices.append(spec_step_idx)
+        return torch.full(
+            (hidden_states.shape[0],), spec_step_idx, dtype=torch.int64
+        )
+
+    monkeypatch.setattr(SpecDecodeBaseProposer, "_greedy_sample", fake_greedy_sample)
+
+    token_ids = proposer._greedy_sample(
+        torch.zeros((2, 4), dtype=torch.float32), spec_step_idx=5
+    )
+
+    assert torch.equal(token_ids, torch.tensor([5, 5]))
+    assert observed_spec_step_indices == [5]
 
 
 def test_list_draft_tokens_use_generation_req_id_snapshot():

--- a/vllm/model_executor/layers/fused_moe/runner/moe_runner.py
+++ b/vllm/model_executor/layers/fused_moe/runner/moe_runner.py
@@ -3,7 +3,7 @@
 import os
 from collections.abc import Callable
 from contextlib import nullcontext
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, SupportsInt, cast
 
 import torch
 import torch.nn.functional as F
@@ -190,7 +190,7 @@ def dump_sm70_moe_runner_graph_buffers(step: int, stage: str) -> None:
         meta = _SM70_MOE_RUNNER_DUMP_META.get(key, {})
         label = str(meta.get("label", "unknown")).replace("/", "_").replace(".", "_")
         layer_type = str(meta.get("layer_type", "moe_runner"))
-        layer_idx = int(meta.get("layer_idx", -1))
+        layer_idx = int(cast(SupportsInt, meta.get("layer_idx", -1)))
         shape = "x".join(str(dim) for dim in tuple(buffer.shape))
         path = os.path.join(
             dump_dir,

--- a/vllm/model_executor/layers/quantization/__init__.py
+++ b/vllm/model_executor/layers/quantization/__init__.py
@@ -111,12 +111,12 @@ def get_quantization_config(quantization: str) -> type[QuantizationConfig]:
     # lazy import to avoid triggering `torch.compile` too early
     if quantization == "humming":
         try:
-            from .humming import HummingConfig
+            from .humming import HummingConfig as _HummingConfig
         except ModuleNotFoundError as exc:
             if exc.name != "humming":
                 raise
 
-            class HummingConfig(QuantizationConfig):
+            class _MissingHummingConfig(QuantizationConfig):
                 """Placeholder used when the optional humming package is absent."""
 
                 def get_name(self) -> QuantizationMethods:
@@ -134,7 +134,7 @@ def get_quantization_config(quantization: str) -> type[QuantizationConfig]:
                     return []
 
                 @classmethod
-                def from_config(cls, config: dict) -> "HummingConfig":
+                def from_config(cls, config: dict) -> "_MissingHummingConfig":
                     del config
                     raise ModuleNotFoundError(
                         "The optional 'humming' package is required for "
@@ -160,7 +160,8 @@ def get_quantization_config(quantization: str) -> type[QuantizationConfig]:
                         "quantization='humming'."
                     )
 
-        return HummingConfig
+            return _MissingHummingConfig
+        return _HummingConfig
 
     from vllm.config.quantization import _ONLINE_SHORTHANDS
     from vllm.model_executor.layers.quantization.quark.quark import QuarkConfig

--- a/vllm/model_executor/layers/quantization/fp8.py
+++ b/vllm/model_executor/layers/quantization/fp8.py
@@ -482,9 +482,7 @@ class Fp8LinearMethod(LinearMethodBase):
             if weight_scale_inv.dtype != torch.float32:
                 weight_scale_inv = weight_scale_inv.to(torch.float32)
             is_gated_silu_layer = self._is_sm70_gated_silu_layer(layer)
-            use_gated_silu = (
-                is_gated_silu_layer and envs.VLLM_SM70_FP8_DENSE_GATED_SILU
-            )
+            use_gated_silu = is_gated_silu_layer and envs.VLLM_SM70_FP8_DENSE_GATED_SILU
             tm_weight, tm_scales, meta = sm70_ops.fp8_sm70_prepare(
                 weight,
                 weight_scale_inv,
@@ -1124,16 +1122,12 @@ class Fp8MoEMethod(FusedMoEMethodBase):
                 w13 = self._dequantize_block_moe_weight(
                     w13, w13_scale, layer.orig_dtype
                 )
-                w2 = self._dequantize_block_moe_weight(
-                    w2, w2_scale, layer.orig_dtype
-                )
+                w2 = self._dequantize_block_moe_weight(w2, w2_scale, layer.orig_dtype)
             else:
                 w13 = self._dequantize_tensor_moe_weight(
                     w13, w13_scale, layer.orig_dtype
                 )
-                w2 = self._dequantize_tensor_moe_weight(
-                    w2, w2_scale, layer.orig_dtype
-                )
+                w2 = self._dequantize_tensor_moe_weight(w2, w2_scale, layer.orig_dtype)
             replace_parameter(layer, "w13_weight", w13)
             replace_parameter(layer, "w2_weight", w2)
             layer.w13_input_scale = None

--- a/vllm/model_executor/layers/quantization/fp8.py
+++ b/vllm/model_executor/layers/quantization/fp8.py
@@ -1042,6 +1042,7 @@ class Fp8MoEMethod(FusedMoEMethodBase):
         w13_input_scale: torch.Tensor | None,
         w2_input_scale: torch.Tensor | None,
     ) -> None:
+        assert self.fp8_backend is not None
         # Shuffle weights to runtime format.
         w13, w2, w13_scale, w2_scale = convert_to_fp8_moe_kernel_format(
             fp8_backend=self.fp8_backend,
@@ -1214,6 +1215,7 @@ class Fp8MoEMethod(FusedMoEMethodBase):
         )
 
     def get_fused_moe_quant_config(self, layer: RoutedExperts) -> FusedMoEQuantConfig:
+        assert self.fp8_backend is not None
         w1_scale = getattr(layer, f"w13_{self.weight_scale_name}")
         w2_scale = getattr(layer, f"w2_{self.weight_scale_name}")
         a1_scale = layer.w13_input_scale

--- a/vllm/model_executor/warmup/awq_sm70_warmup.py
+++ b/vllm/model_executor/warmup/awq_sm70_warmup.py
@@ -590,7 +590,9 @@ def sm70_awq_warmup(worker: Worker) -> None:
         return
 
     device = worker.device
-    if device.type != "cuda" or torch.cuda.get_device_capability(device) != (7, 0):
+    if device is None or (
+        device.type != "cuda" or torch.cuda.get_device_capability(device) != (7, 0)
+    ):
         return
 
     model = worker.get_model()

--- a/vllm/model_executor/warmup/awq_sm70_warmup.py
+++ b/vllm/model_executor/warmup/awq_sm70_warmup.py
@@ -50,12 +50,8 @@ def _lut_cache_disabled_for_dynamic_quant_dispatch(
         and not envs.VLLM_SM70_AWQ_PRESERVE_DEFAULT_SPLITS_ONLY
     )
     fp8_dynamic = has_fp8_dense and envs.VLLM_SM70_FP8_TUNE_SMALL_SHAPES
-    mxfp4_dynamic = (
-        "mxfp4" in fp4_kinds and envs.VLLM_SM70_MXFP4_TUNE_SMALL_SHAPES
-    )
-    nvfp4_dynamic = (
-        "nvfp4" in fp4_kinds and envs.VLLM_SM70_NVFP4_TUNE_SMALL_SHAPES
-    )
+    mxfp4_dynamic = "mxfp4" in fp4_kinds and envs.VLLM_SM70_MXFP4_TUNE_SMALL_SHAPES
+    nvfp4_dynamic = "nvfp4" in fp4_kinds and envs.VLLM_SM70_NVFP4_TUNE_SMALL_SHAPES
     return awq_no_preserve or fp8_dynamic or mxfp4_dynamic or nvfp4_dynamic
 
 
@@ -72,9 +68,7 @@ def _load_lut_cache(device: torch.device, skip_import: bool = False) -> int:
         )
         return 0
     if not Path(path).exists():
-        logger.info(
-            "No SM70 GEMM LUT cache found at %s for device %s.", path, device
-        )
+        logger.info("No SM70 GEMM LUT cache found at %s for device %s.", path, device)
         return 0
     device_hint = torch.empty(0, dtype=torch.uint8, device=device)
     try:
@@ -393,9 +387,7 @@ def _warmup_moe_dense_stage_layers(
         dense_expert_ids = torch.arange(num_experts, dtype=torch.int32, device=device)
         for num_tokens in token_counts:
             total_slots = num_tokens * top_k
-            expert_offsets = _build_balanced_offsets(
-                total_slots, num_experts, device
-            )
+            expert_offsets = _build_balanced_offsets(total_slots, num_experts, device)
             permuted_input = torch.empty(
                 (total_slots, int(layer.sm70_w13_k_dim)),
                 dtype=torch.float16,
@@ -550,9 +542,7 @@ def _warmup_moe_single_token_layers(moe_layers: list[torch.nn.Module]) -> int:
                 (1, hidden_size), dtype=torch.float16, device=device
             )
             legacy_output.zero_()
-            legacy_offsets = torch.empty(
-                top_k + 1, dtype=torch.int32, device=device
-            )
+            legacy_offsets = torch.empty(top_k + 1, dtype=torch.int32, device=device)
             sm70_ops.awq_moe_single_token_sm70_out(
                 legacy_output,
                 x,
@@ -600,9 +590,7 @@ def sm70_awq_warmup(worker: Worker) -> None:
     fp8_dense_layers = list(_iter_unique_fp8_dense_layers(model))
     fp4_dense_layers = list(_iter_unique_fp4_dense_layers(model))
     moe_layers = list(_iter_unique_moe_layers(model))
-    if not (
-        dense_layers or fp8_dense_layers or fp4_dense_layers or moe_layers
-    ):
+    if not (dense_layers or fp8_dense_layers or fp4_dense_layers or moe_layers):
         return
 
     fp4_kinds = {str(state.op_kind) for state in fp4_dense_layers}
@@ -639,9 +627,7 @@ def sm70_awq_warmup(worker: Worker) -> None:
         dense_calls = _warmup_dense_layers(dense_layers, m_values)
         fp8_dense_calls = _warmup_fp8_dense_layers(fp8_dense_layers, m_values)
         fp4_dense_calls = _warmup_fp4_dense_layers(fp4_dense_layers, m_values)
-        moe_stage_calls = _warmup_moe_dense_stage_layers(
-            moe_layers, moe_token_counts
-        )
+        moe_stage_calls = _warmup_moe_dense_stage_layers(moe_layers, moe_token_counts)
         single_token_calls = _warmup_moe_single_token_layers(moe_layers)
     torch.cuda.synchronize(device)
     logger.info(

--- a/vllm/v1/attention/backends/flashinfer_sm70.py
+++ b/vllm/v1/attention/backends/flashinfer_sm70.py
@@ -587,17 +587,9 @@ class FlashInferSM70Impl(FlashAttnV100Impl):
     ):
         if attn_metadata is None:
             self.last_route_proof = None
-            return super().forward(
-                layer,
-                query,
-                key,
-                value,
-                kv_cache,
-                attn_metadata,
-                output,
-                output_scale,
-                output_block_scale,
-            )
+            assert output is not None
+            _record_route("metadata_none_zero_output")
+            return output.fill_(0)
 
         decision = self._validate_route_proof(attn_metadata)
         attn_metadata.flashinfer_sm70_dispatch_observed = None

--- a/vllm/v1/attention/backends/flex_attention.py
+++ b/vllm/v1/attention/backends/flex_attention.py
@@ -491,6 +491,7 @@ class FlexAttentionMetadata:
         layout of the query and key/value tensors.
         """
         assert self.doc_ids is not None
+        doc_ids = self.doc_ids
 
         def final_mask_mod(
             b: torch.Tensor,
@@ -499,14 +500,14 @@ class FlexAttentionMetadata:
             physical_kv_idx: torch.Tensor,
         ) -> torch.Tensor:
             (is_valid, logical_q_idx, logical_kv_idx) = (
-                self._convert_physical_to_logical(self.doc_ids, q_idx, physical_kv_idx)
+                self._convert_physical_to_logical(doc_ids, q_idx, physical_kv_idx)
             )
             base_mask = self.logical_mask_mod(b, h, logical_q_idx, logical_kv_idx)
             if (
                 self.ddtree_parent_ids is not None
                 and self.ddtree_num_tree_tokens is not None
             ):
-                q_req = self.doc_ids[q_idx]
+                q_req = doc_ids[q_idx]
                 base_mask = ddtree_logical_mask(
                     base_mask=base_mask,
                     q_req=q_req,
@@ -904,9 +905,10 @@ class FlexAttentionMetadataBuilder(AttentionMetadataBuilder[FlexAttentionMetadat
         self,
         common_prefix_len: int,
         common_attn_metadata: CommonAttentionMetadata,
+        fast_build: bool = False,
+        *,
         ddtree_parent_ids: torch.Tensor | None = None,
         ddtree_num_tree_tokens_cpu: torch.Tensor | None = None,
-        fast_build: bool = False,
     ) -> FlexAttentionMetadata:
         num_reqs = common_attn_metadata.num_reqs
         num_actual_tokens = common_attn_metadata.num_actual_tokens

--- a/vllm/v1/spec_decode/draft_prob_alignment.py
+++ b/vllm/v1/spec_decode/draft_prob_alignment.py
@@ -2,12 +2,13 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 from collections.abc import Sequence
+from typing import TypeAlias
 
 import torch
 
 from vllm.v1.spec_decode.metadata import SpecDecodeMetadata
 
-DraftProbTokenIds = Sequence[Sequence[int]] | torch.Tensor
+DraftProbTokenIds: TypeAlias = Sequence[Sequence[int]] | torch.Tensor
 
 
 def _assert_cached_tokens_match(
@@ -38,7 +39,7 @@ def _assert_cached_tokens_match(
 def clone_draft_prob_token_ids(
     draft_token_ids: Sequence[Sequence[int]] | torch.Tensor,
 ) -> DraftProbTokenIds:
-    if torch.is_tensor(draft_token_ids):
+    if isinstance(draft_token_ids, torch.Tensor):
         return draft_token_ids.detach().clone()
     return [list(token_ids) for token_ids in draft_token_ids]
 
@@ -70,7 +71,7 @@ def get_aligned_draft_probs(
             "Cached draft probability row count does not match request ids: "
             f"rows={draft_probs.shape[0]}, req_ids={len(draft_prob_req_ids)}."
         )
-    if torch.is_tensor(draft_prob_token_ids):
+    if isinstance(draft_prob_token_ids, torch.Tensor):
         if draft_prob_token_ids.ndim != 2:
             raise RuntimeError(
                 "Cached draft probability token ids must have shape "
@@ -126,7 +127,7 @@ def get_aligned_draft_probs(
         expected_tokens = spec_decode_metadata.draft_token_ids[
             draft_token_offset : draft_token_offset + num_draft
         ]
-        if torch.is_tensor(draft_prob_token_ids):
+        if isinstance(draft_prob_token_ids, torch.Tensor):
             if draft_prob_token_ids.shape[1] < num_draft:
                 raise RuntimeError(
                     "Cached draft probability token ids do not have enough "

--- a/vllm/v1/spec_decode/gemma4.py
+++ b/vllm/v1/spec_decode/gemma4.py
@@ -96,7 +96,11 @@ class Gemma4Proposer(SpecDecodeBaseProposer):
                 per_layer_attn_metadata[layer_name] = attn_metadata
         return per_group_attn_metadata, per_layer_attn_metadata
 
-    def _greedy_sample(self, hidden_states: torch.Tensor) -> torch.Tensor:
+    def _greedy_sample(
+        self,
+        hidden_states: torch.Tensor,
+        spec_step_idx: int = 0,
+    ) -> torch.Tensor:
         if self._centroids_sizes:
             T = hidden_states.shape[0]
             for size in self._centroids_sizes:
@@ -105,7 +109,7 @@ class Gemma4Proposer(SpecDecodeBaseProposer):
                     self._centroids_graphs[size].replay()
                     return self._centroids_outputs[size][:T].clone()
             return self.model.get_top_tokens(hidden_states)
-        return super()._greedy_sample(hidden_states)
+        return super()._greedy_sample(hidden_states, spec_step_idx)
 
     def _setup_centroids_cuda_graphs(self) -> None:
         """Capture CUDA graphs for centroids get_top_tokens at key sizes."""

--- a/vllm/v1/spec_decode/llm_base_proposer.py
+++ b/vllm/v1/spec_decode/llm_base_proposer.py
@@ -176,7 +176,9 @@ class SpecDecodeBaseProposer:
         assert vllm_config.speculative_config is not None
         self.speculative_config = vllm_config.speculative_config
         self.draft_model_config = self.speculative_config.draft_model_config
-        self.method = self.speculative_config.method
+        method = self.speculative_config.method
+        assert method is not None
+        self.method: str = method
         self.pass_hidden_states_to_model = pass_hidden_states_to_model
 
         self.device = device
@@ -992,7 +994,9 @@ class SpecDecodeBaseProposer:
             self._static_draft_vocab.begin_proposal()
         batch_size = common_attn_metadata.batch_size()
         common_attn_metadata = _clone_drafter_mutable_metadata(common_attn_metadata)
-        profile_events = [] if self._sm70_mtp_profile_enabled() else None
+        profile_events: list[tuple[str, torch.cuda.Event, torch.cuda.Event]] | None = (
+            [] if self._sm70_mtp_profile_enabled() else None
+        )
         profile_cpu_ms: dict[str, float] = {}
         profile_wall_start = time.perf_counter() if profile_events is not None else 0.0
         profile_total_start = self._sm70_mtp_profile_start(profile_events)
@@ -2305,6 +2309,7 @@ class SpecDecodeBaseProposer:
         if target_lm_head is None or not hasattr(target_lm_head, "weight"):
             raise ValueError("MTP model does not expose a shared target LM-head.")
 
+        runtime: StaticDraftVocabRuntime | DynamicDraftVocabRuntime
         if dynamic_tail_size:
             runtime = initialize_dynamic_draft_vocab(
                 target_lm_head,
@@ -2676,10 +2681,12 @@ def compute_probs_and_sample_next_token(
         top_k,
         top_p,
     ):
+        top_k_cpu = sampling_metadata.top_k_cpu
+        assert top_k_cpu is not None
         return _compute_sparse_topk_draft_probs_and_sample_next_token(
             logits,
             sampling_metadata,
-            int(sampling_metadata.top_k_cpu[0]),
+            int(top_k_cpu[0]),
         )
 
     logits = apply_top_k_top_p(logits, top_k, top_p)

--- a/vllm/v1/spec_decode/static_draft_vocab.py
+++ b/vllm/v1/spec_decode/static_draft_vocab.py
@@ -387,6 +387,11 @@ class DynamicDraftVocabRuntime(StaticDraftVocabRuntime):
         )
         if self.tp_group is None or any(tensor is None for tensor in tensors):
             raise RuntimeError("Dynamic fused proposal buffers are not initialized.")
+        assert self.fused_exponentials is not None
+        assert self.fused_sampled_tokens is not None
+        assert self.fused_sparse_ids is not None
+        assert self.fused_sparse_probs is not None
+        assert self.fused_dense_probs is not None
 
         sm70_ops = _get_sm70_ops()
         sm70_ops.sm70_f16_lm_head_top20_tc_out(

--- a/vllm/v1/spec_decode/step3p5.py
+++ b/vllm/v1/spec_decode/step3p5.py
@@ -305,9 +305,12 @@ class Step3p5MTPProposer(EagleProposer):
             self.build_per_group_and_layer_attn_metadata(common_attn_metadata)
         )
 
-        cudagraph_runtime_mode, num_input_tokens, num_tokens_across_dp = (
-            self._determine_batch_execution_and_padding(num_tokens)
-        )
+        (
+            cudagraph_runtime_mode,
+            num_input_tokens,
+            num_tokens_across_dp,
+            batch_descriptor,
+        ) = self._determine_batch_execution_and_padding(num_tokens)
 
         model_kwargs, slot_mapping_size = self.build_model_inputs_first_pass(
             num_tokens, num_input_tokens, mm_embed_inputs
@@ -320,6 +323,7 @@ class Step3p5MTPProposer(EagleProposer):
             num_tokens=num_input_tokens,
             num_tokens_across_dp=num_tokens_across_dp,
             cudagraph_runtime_mode=cudagraph_runtime_mode,
+            batch_descriptor=self._batch_descriptor_for_spec_step(batch_descriptor, 0),
             slot_mapping=self._get_slot_mapping(
                 slot_mapping_size, common_attn_metadata.slot_mapping
             ),
@@ -369,9 +373,12 @@ class Step3p5MTPProposer(EagleProposer):
 
         draft_token_ids_list = [draft_token_ids]
 
-        cudagraph_runtime_mode, input_batch_size, batch_size_across_dp = (
-            self._determine_batch_execution_and_padding(batch_size)
-        )
+        (
+            cudagraph_runtime_mode,
+            input_batch_size,
+            batch_size_across_dp,
+            batch_descriptor,
+        ) = self._determine_batch_execution_and_padding(batch_size)
 
         common_attn_metadata.num_actual_tokens = batch_size
         common_attn_metadata.max_query_len = 1
@@ -433,6 +440,9 @@ class Step3p5MTPProposer(EagleProposer):
                 num_tokens=input_batch_size,
                 num_tokens_across_dp=batch_size_across_dp,
                 cudagraph_runtime_mode=cudagraph_runtime_mode,
+                batch_descriptor=self._batch_descriptor_for_spec_step(
+                    batch_descriptor, spec_step_idx
+                ),
                 slot_mapping=self._get_slot_mapping(input_batch_size),
             ):
                 ret_hidden_states = self.model(**model_kwargs)

--- a/vllm/v1/spec_decode/step3p5.py
+++ b/vllm/v1/spec_decode/step3p5.py
@@ -311,11 +311,14 @@ class Step3p5MTPProposer(EagleProposer):
             num_tokens_across_dp,
             batch_descriptor,
         ) = self._determine_batch_execution_and_padding(num_tokens)
+        first_batch_descriptor = self._batch_descriptor_for_spec_step(
+            batch_descriptor, 0
+        )
 
         model_kwargs, slot_mapping_size = self.build_model_inputs_first_pass(
             num_tokens, num_input_tokens, mm_embed_inputs
         )
-        model_kwargs["spec_step_idx"] = 0
+        model_kwargs["spec_step_idx"] = first_batch_descriptor.graph_variant
 
         with set_forward_context(
             per_layer_attn_metadata,
@@ -323,7 +326,7 @@ class Step3p5MTPProposer(EagleProposer):
             num_tokens=num_input_tokens,
             num_tokens_across_dp=num_tokens_across_dp,
             cudagraph_runtime_mode=cudagraph_runtime_mode,
-            batch_descriptor=self._batch_descriptor_for_spec_step(batch_descriptor, 0),
+            batch_descriptor=first_batch_descriptor,
             slot_mapping=self._get_slot_mapping(
                 slot_mapping_size, common_attn_metadata.slot_mapping
             ),
@@ -396,6 +399,9 @@ class Step3p5MTPProposer(EagleProposer):
         assert block_size > 0, "block_size has not been initialized."
         for token_index in range(self.num_speculative_tokens - 1):
             spec_step_idx = token_index + 1
+            step_batch_descriptor = self._batch_descriptor_for_spec_step(
+                batch_descriptor, spec_step_idx
+            )
             input_ids = draft_token_ids_list[-1].int()
 
             if not self.constant_draft_positions:
@@ -429,7 +435,7 @@ class Step3p5MTPProposer(EagleProposer):
                 "input_ids": input_ids,
                 "positions": self._get_positions(input_batch_size),
                 "inputs_embeds": inputs_embeds,
-                "spec_step_idx": spec_step_idx,
+                "spec_step_idx": step_batch_descriptor.graph_variant,
             }
             if self.pass_hidden_states_to_model:
                 model_kwargs["hidden_states"] = self.hidden_states[:input_batch_size]
@@ -440,9 +446,7 @@ class Step3p5MTPProposer(EagleProposer):
                 num_tokens=input_batch_size,
                 num_tokens_across_dp=batch_size_across_dp,
                 cudagraph_runtime_mode=cudagraph_runtime_mode,
-                batch_descriptor=self._batch_descriptor_for_spec_step(
-                    batch_descriptor, spec_step_idx
-                ),
+                batch_descriptor=step_batch_descriptor,
                 slot_mapping=self._get_slot_mapping(input_batch_size),
             ):
                 ret_hidden_states = self.model(**model_kwargs)


### PR DESCRIPTION
## Purpose
Fix the current mypy baseline errors tracked by #126, restricted to the listed production modules and focused tests. No CUDA, C++, dependency, documentation, or performance changes are included.

## Duplicate Check
No open pull request matched the mypy scope when this task started.

## Base
Base SHA: 3ec0c68c6596d6ab31fbdee9fa676254a52c2b7d
Head SHA: 395631d5f61f7817f7dbba14a82fb71e59c4d1d6

## Implementation
- Narrow Optional state only after existing runtime guards.
- Restore parent-compatible attention and speculative-decoding method contracts.
- Preserve the FlashInfer profiling output-zero route and add a focused regression test.
- Carry each Step3p5 draft-step BatchDescriptor through forward context and use its graph variant for the matching model input step.
- Add CPU-only regressions for first and subsequent Step3p5 draft steps, plus non-centroid Gemma4 superclass step propagation.
- Add precise test-fixture annotations.
- Apply Ruff format only to the six integration-reported files; review confirmed formatting-only changes.

## Validation
- mypy Python 3.10: passed.
- mypy Python 3.11: passed.
- mypy Python 3.12: passed.
- mypy Python 3.13: the independent five has-type errors in vllm/v1/attention/backends/gdn_attn.py remain on this branch and are covered by Draft PR #141.
- ruff check and targeted ruff format: passed.
- Focused pytest suite: 71 passed.
- git diff --check: passed.

## Risk
No physical GPU is available in this environment. GPU kernels and CUDA Graph replay were not executed. Remaining Python 3.13 GDN typing debt is isolated in Draft PR #141.

## AI Assistance
This PR was implemented with Codex. A human maintainer must review and own the final merge.