### PR TITLE
[CI/Build] Normalize core C/CUDA static baseline

### DIFF
--- a/csrc/custom_all_reduce.cu
+++ b/csrc/custom_all_reduce.cu
@@ -161,12 +161,12 @@ void sm70_all_reduce_gemma_rms_norm_impl(
                 "SM70 TP4 Gemma RMSNorm prototype residual must be float32.");
   } else {
     TORCH_CHECK(residual.scalar_type() == at::ScalarType::Half ||
-                residual.scalar_type() == at::ScalarType::Float,
+                    residual.scalar_type() == at::ScalarType::Float,
                 "SM70 Gemma RMSNorm prototype residual must be float16 or "
                 "float32.");
   }
   TORCH_CHECK(weight.scalar_type() == at::ScalarType::Half ||
-              weight.scalar_type() == at::ScalarType::Float,
+                  weight.scalar_type() == at::ScalarType::Float,
               "SM70 Gemma RMSNorm prototype weight must be float16 or "
               "float32.");
   TORCH_CHECK_EQ(inp.dim(), 2);
@@ -176,8 +176,9 @@ void sm70_all_reduce_gemma_rms_norm_impl(
   TORCH_CHECK(normalized_out.sizes() == inp.sizes(),
               "SM70 Gemma RMSNorm prototype normalized_out shape must match "
               "inp.");
-  TORCH_CHECK(residual_out.sizes() == inp.sizes(),
-              "SM70 Gemma RMSNorm prototype residual_out shape must match inp.");
+  TORCH_CHECK(
+      residual_out.sizes() == inp.sizes(),
+      "SM70 Gemma RMSNorm prototype residual_out shape must match inp.");
   TORCH_CHECK_EQ(weight.dim(), 1);
   TORCH_CHECK_EQ(weight.numel(), kHiddenSize);
   TORCH_CHECK_EQ(residual.get_device(), inp.get_device());
@@ -307,17 +308,17 @@ void all_reduce_sum2(fptr_t _fa, torch::Tensor& inp_a, torch::Tensor& inp_b,
 
   switch (out.scalar_type()) {
     case at::ScalarType::Float: {
-      fa->allreduce_sum2<float>(stream, reinterpret_cast<float*>(inp_a.data_ptr()),
-                                reinterpret_cast<float*>(inp_b.data_ptr()),
-                                reinterpret_cast<float*>(out.data_ptr()),
-                                out.numel());
+      fa->allreduce_sum2<float>(
+          stream, reinterpret_cast<float*>(inp_a.data_ptr()),
+          reinterpret_cast<float*>(inp_b.data_ptr()),
+          reinterpret_cast<float*>(out.data_ptr()), out.numel());
       break;
     }
     case at::ScalarType::Half: {
-      fa->allreduce_sum2<half>(stream, reinterpret_cast<half*>(inp_a.data_ptr()),
-                               reinterpret_cast<half*>(inp_b.data_ptr()),
-                               reinterpret_cast<half*>(out.data_ptr()),
-                               out.numel());
+      fa->allreduce_sum2<half>(
+          stream, reinterpret_cast<half*>(inp_a.data_ptr()),
+          reinterpret_cast<half*>(inp_b.data_ptr()),
+          reinterpret_cast<half*>(out.data_ptr()), out.numel());
       break;
     }
 #if (__CUDA_ARCH__ >= 800 || !defined(__CUDA_ARCH__))
@@ -363,8 +364,7 @@ void top1_argmax(fptr_t _fa, torch::Tensor& input_pair, torch::Tensor& output,
 }
 
 void tile_runtime_all_reduce(fptr_t _fa, torch::Tensor& inp, torch::Tensor& out,
-                             fptr_t _reg_buffer,
-                             int64_t reg_buffer_sz_bytes,
+                             fptr_t _reg_buffer, int64_t reg_buffer_sz_bytes,
                              int64_t tile_numel, int64_t engine_blocks,
                              int64_t compute_iters) {
   auto fa = reinterpret_cast<vllm::CustomAllreduce*>(_fa);
@@ -412,8 +412,7 @@ void tile_runtime_all_reduce(fptr_t _fa, torch::Tensor& inp, torch::Tensor& out,
 void tile_runtime_all_reduce_engine(fptr_t _fa, torch::Tensor& inp,
                                     torch::Tensor& out, fptr_t _reg_buffer,
                                     int64_t reg_buffer_sz_bytes,
-                                    int64_t tile_numel,
-                                    int64_t producer_blocks,
+                                    int64_t tile_numel, int64_t producer_blocks,
                                     int64_t reducer_blocks,
                                     int64_t compute_iters) {
   auto fa = reinterpret_cast<vllm::CustomAllreduce*>(_fa);

--- a/csrc/custom_all_reduce.cuh
+++ b/csrc/custom_all_reduce.cuh
@@ -83,8 +83,7 @@ inline bool custom_allreduce_current_device_is_sm70() {
 #endif
 }
 
-inline int custom_allreduce_block_limit(int default_limit,
-                                        int world_size,
+inline int custom_allreduce_block_limit(int default_limit, int world_size,
                                         size_t bytes) {
   const char* raw = std::getenv("VLLM_CUSTOM_ALLREDUCE_BLOCK_LIMIT");
   if (raw == nullptr || raw[0] == '\0') {
@@ -104,8 +103,7 @@ inline int custom_allreduce_block_limit(int default_limit,
   return static_cast<int>(parsed);
 }
 
-inline int sm70_tp4_m5_allreduce_threads(int world_size,
-                                         bool fully_connected,
+inline int sm70_tp4_m5_allreduce_threads(int world_size, bool fully_connected,
                                          size_t bytes) {
   const char* raw = std::getenv("VLLM_SM70_TP4_M5_AR_THREADS");
   if (raw == nullptr || raw[0] == '\0') return 512;
@@ -264,8 +262,7 @@ static DINLINE FlagType ld_flag_volatile(FlagType* flag_addr) {
 }
 
 static DINLINE void st_flag_sys_visible(FlagType* flag_addr, FlagType flag) {
-  asm volatile("membar.sys; st.volatile.global.u32 [%1], %0;"
-               ::"r"(flag),
+  asm volatile("membar.sys; st.volatile.global.u32 [%1], %0;" ::"r"(flag),
                "l"(flag_addr)
                : "memory");
 }
@@ -421,11 +418,13 @@ __global__ void __launch_bounds__(512, 1)
 // residual after the peer reduction.
 template <int Threads, int ngpus, typename ResidualT, typename WeightT>
 __global__ void __launch_bounds__(Threads, 1)
-    sm70_peer_reduce_gemma_rms_norm(
-        RankData* _dp, RankSignals sg, Signal* self_sg,
-        const ResidualT* __restrict__ residual,
-        const WeightT* __restrict__ weight, half* __restrict__ normalized_out,
-        float* __restrict__ residual_out, int rank, float epsilon) {
+    sm70_peer_reduce_gemma_rms_norm(RankData* _dp, RankSignals sg,
+                                    Signal* self_sg,
+                                    const ResidualT* __restrict__ residual,
+                                    const WeightT* __restrict__ weight,
+                                    half* __restrict__ normalized_out,
+                                    float* __restrict__ residual_out, int rank,
+                                    float epsilon) {
   using P = typename packed_t<half>::P;
   using A = typename packed_t<half>::A;
   constexpr int kPackedWidth = P::size;
@@ -446,15 +445,14 @@ __global__ void __launch_bounds__(Threads, 1)
 
   for (int packed_idx = tid; packed_idx < packed_per_row;
        packed_idx += blockDim.x) {
-    const P reduced =
-        packed_reduce<P, ngpus, A>((const P**)&dp.ptrs[0],
-                                    row * packed_per_row + packed_idx);
+    const P reduced = packed_reduce<P, ngpus, A>(
+        (const P**)&dp.ptrs[0], row * packed_per_row + packed_idx);
     const int element_offset = row_offset + packed_idx * kPackedWidth;
 #pragma unroll
     for (int i = 0; i < kPackedWidth; ++i) {
-      const float value = __half2float(reduced.data[i]) +
-                          sm70_gemma_rms_norm_to_float(
-                              residual[element_offset + i]);
+      const float value =
+          __half2float(reduced.data[i]) +
+          sm70_gemma_rms_norm_to_float(residual[element_offset + i]);
       residual_values[packed_idx * kPackedWidth + i] = value;
       residual_out[element_offset + i] = value;
     }
@@ -490,8 +488,8 @@ __global__ void __launch_bounds__(Threads, 1)
       const int column = element_offset + i;
       const float gemma_weight =
           sm70_gemma_rms_norm_to_float(weight[column]) + 1.0f;
-      normalized_out[row_offset + column] = __float2half_rn(
-          residual_values[column] * inverse_rms * gemma_weight);
+      normalized_out[row_offset + column] =
+          __float2half_rn(residual_values[column] * inverse_rms * gemma_weight);
     }
   }
 
@@ -500,10 +498,9 @@ __global__ void __launch_bounds__(Threads, 1)
 
 template <typename T, int ngpus>
 __global__ void __launch_bounds__(256, 1) sm70_tile_runtime_reduce_kernel(
-    RankData* _dp, RankSignals sg, Signal* self_sg,
-    const T* __restrict__ input, T* __restrict__ staging,
-    T* __restrict__ result, int rank, int packed_size, int tile_packed_size,
-    int tile_count, int compute_iters) {
+    RankData* _dp, RankSignals sg, Signal* self_sg, const T* __restrict__ input,
+    T* __restrict__ staging, T* __restrict__ result, int rank, int packed_size,
+    int tile_packed_size, int tile_count, int compute_iters) {
   using P = typename packed_t<T>::P;
   using A = typename packed_t<T>::A;
 
@@ -554,11 +551,10 @@ __global__ void __launch_bounds__(256, 1) sm70_tile_runtime_reduce_kernel(
 
 template <typename T, int ngpus>
 __global__ void __launch_bounds__(256, 1) sm70_tile_runtime_engine_kernel(
-    RankData* _dp, RankSignals sg, Signal* self_sg,
-    const T* __restrict__ input, T* __restrict__ staging,
-    T* __restrict__ result, int rank, int packed_size, int tile_packed_size,
-    int tile_count, int producer_blocks, int reducer_blocks,
-    int compute_iters) {
+    RankData* _dp, RankSignals sg, Signal* self_sg, const T* __restrict__ input,
+    T* __restrict__ staging, T* __restrict__ result, int rank, int packed_size,
+    int tile_packed_size, int tile_count, int producer_blocks,
+    int reducer_blocks, int compute_iters) {
   using P = typename packed_t<T>::P;
   using A = typename packed_t<T>::A;
 
@@ -621,10 +617,11 @@ __global__ void __launch_bounds__(256, 1) sm70_tile_runtime_engine_kernel(
 
 template <typename T, int ngpus>
 __global__ void __launch_bounds__(256, 1)
-    sm70_tile_runtime_wait_reduce_kernel(
-        RankData* _dp, RankSignals sg, Signal* self_sg,
-        T* __restrict__ result, int rank, int packed_size,
-        int tile_packed_size, int tile_count) {
+    sm70_tile_runtime_wait_reduce_kernel(RankData* _dp, RankSignals sg,
+                                         Signal* self_sg,
+                                         T* __restrict__ result, int rank,
+                                         int packed_size, int tile_packed_size,
+                                         int tile_count) {
   using P = typename packed_t<T>::P;
   using A = typename packed_t<T>::A;
 
@@ -656,9 +653,11 @@ __global__ void __launch_bounds__(256, 1)
 }
 
 template <typename T, int ngpus>
-__global__ void __launch_bounds__(512, 1) cross_device_reduce_sum2_1stage(
-    RankData* _dp_a, RankData* _dp_b, RankSignals sg, Signal* self_sg,
-    T* __restrict__ result, int rank, int size) {
+__global__ void __launch_bounds__(512, 1)
+    cross_device_reduce_sum2_1stage(RankData* _dp_a, RankData* _dp_b,
+                                    RankSignals sg, Signal* self_sg,
+                                    T* __restrict__ result, int rank,
+                                    int size) {
   using P = typename packed_t<T>::P;
   using A = typename packed_t<T>::A;
   auto dp_a = *_dp_a;
@@ -666,9 +665,8 @@ __global__ void __launch_bounds__(512, 1) cross_device_reduce_sum2_1stage(
   barrier_at_start<ngpus>(sg, self_sg, rank);
   for (int idx = blockIdx.x * blockDim.x + threadIdx.x; idx < size;
        idx += gridDim.x * blockDim.x) {
-    ((P*)result)[idx] =
-        packed_reduce_sum2<P, ngpus, A>((const P**)&dp_a.ptrs[0],
-                                        (const P**)&dp_b.ptrs[0], idx);
+    ((P*)result)[idx] = packed_reduce_sum2<P, ngpus, A>(
+        (const P**)&dp_a.ptrs[0], (const P**)&dp_b.ptrs[0], idx);
   }
   barrier_at_end<ngpus, true>(sg, self_sg, rank);
 }
@@ -726,9 +724,11 @@ __global__ void __launch_bounds__(512, 1)
 }
 
 template <typename T, int ngpus>
-__global__ void __launch_bounds__(512, 1) cross_device_reduce_sum2_2stage(
-    RankData* _dp_a, RankData* _dp_b, RankSignals sg, Signal* self_sg,
-    T* __restrict__ result, int rank, int size) {
+__global__ void __launch_bounds__(512, 1)
+    cross_device_reduce_sum2_2stage(RankData* _dp_a, RankData* _dp_b,
+                                    RankSignals sg, Signal* self_sg,
+                                    T* __restrict__ result, int rank,
+                                    int size) {
   int tid = blockIdx.x * blockDim.x + threadIdx.x;
   int stride = gridDim.x * blockDim.x;
   using P = typename packed_t<T>::P;
@@ -753,8 +753,7 @@ __global__ void __launch_bounds__(512, 1) cross_device_reduce_sum2_2stage(
   // Stage 1 mirrors cross_device_reduce_2stage, but each rank first forms
   // its local input_a + input_b value before the cross-rank reduction.
   for (int idx = start + tid; idx < end; idx += stride) {
-    tmp_out[idx - start] =
-        packed_reduce_sum2<P, ngpus, A>(ptrs_a, ptrs_b, idx);
+    tmp_out[idx - start] = packed_reduce_sum2<P, ngpus, A>(ptrs_a, ptrs_b, idx);
   }
   barrier_at_end<ngpus>(sg, self_sg, rank);
 
@@ -925,11 +924,10 @@ class CustomAllreduce {
     } else {
       auto it = buffers_.find(buffer);
       if (it == buffers_.end()) {
-        throw std::runtime_error(std::string(op_name) +
-                                 " buffer address " +
-                                 std::to_string(
-                                     reinterpret_cast<uint64_t>(buffer)) +
-                                 " is not registered!");
+        throw std::runtime_error(
+            std::string(op_name) + " buffer address " +
+            std::to_string(reinterpret_cast<uint64_t>(buffer)) +
+            " is not registered!");
       }
       ptrs = it->second;
     }
@@ -1013,8 +1011,8 @@ class CustomAllreduce {
 
     size /= d;
     auto bytes = size * sizeof(typename packed_t<T>::P);
-    threads = sm70_tp4_m5_allreduce_threads(world_size_, fully_connected_,
-                                            bytes);
+    threads =
+        sm70_tp4_m5_allreduce_threads(world_size_, fully_connected_, bytes);
     int blocks = std::min(block_limit, (size + threads - 1) / threads);
 
     // Check environment variable once
@@ -1077,11 +1075,11 @@ class CustomAllreduce {
 
   template <int ngpus, typename ResidualT, typename WeightT>
   void sm70_allreduce_gemma_rms_norm(cudaStream_t stream, half* input,
-                                      const ResidualT* residual,
-                                      const WeightT* weight,
-                                      half* normalized_out,
-                                      float* residual_out, int num_tokens,
-                                      int hidden_size, float epsilon) {
+                                     const ResidualT* residual,
+                                     const WeightT* weight,
+                                     half* normalized_out, float* residual_out,
+                                     int num_tokens, int hidden_size,
+                                     float epsilon) {
     if (world_size_ != ngpus || !custom_allreduce_current_device_is_sm70()) {
       throw std::runtime_error("SM70 Gemma RMSNorm prototype requires TP" +
                                std::to_string(ngpus) + " on an SM70 device.");
@@ -1095,18 +1093,18 @@ class CustomAllreduce {
     if (num_tokens <= 0 || num_tokens > kMaxTokens) {
       throw std::runtime_error(
           "SM70 Gemma RMSNorm prototype supports tokens in [1, " +
-          std::to_string(kMaxTokens) + "]. Got " +
-          std::to_string(num_tokens) + ".");
+          std::to_string(kMaxTokens) + "]. Got " + std::to_string(num_tokens) +
+          ".");
     }
 
-    RankData* ptrs = rank_data_for_buffer(
-        stream, input, "SM70 Gemma RMSNorm prototype input");
+    RankData* ptrs = rank_data_for_buffer(stream, input,
+                                          "SM70 Gemma RMSNorm prototype input");
     if constexpr (ngpus == 4) {
       // Keep the same 1024-thread CUB reduction topology as vLLM rms_norm.
       // packed_reduce preserves the cross_device_reduce_1stage<half, 4>
       // rank order before the FP32 residual add.
       sm70_peer_reduce_gemma_rms_norm<kSm70GemmaRmsNormThreads, ngpus,
-                                       ResidualT, WeightT>
+                                      ResidualT, WeightT>
           <<<num_tokens, kSm70GemmaRmsNormThreads, 0, stream>>>(
               ptrs, sg_, self_sg_, residual, weight, normalized_out,
               residual_out, rank_, epsilon);
@@ -1114,11 +1112,11 @@ class CustomAllreduce {
     }
 
     const int threads = sm70_gemma_rms_norm_threads();
-#define VLLM_LAUNCH_SM70_GEMMA_RMS_NORM(THREADS)                         \
+#define VLLM_LAUNCH_SM70_GEMMA_RMS_NORM(THREADS)                          \
   sm70_peer_reduce_gemma_rms_norm<THREADS, ngpus, ResidualT, WeightT>     \
-      <<<num_tokens, THREADS, 0, stream>>>(                               \
-          ptrs, sg_, self_sg_, residual, weight, normalized_out,          \
-          residual_out, rank_, epsilon)
+      <<<num_tokens, THREADS, 0, stream>>>(ptrs, sg_, self_sg_, residual, \
+                                           weight, normalized_out,        \
+                                           residual_out, rank_, epsilon)
     switch (threads) {
       case 256:
         VLLM_LAUNCH_SM70_GEMMA_RMS_NORM(256);
@@ -1190,29 +1188,28 @@ class CustomAllreduce {
       }
     }
 
-#define SUM2_KL(ngpus, name)                                                  \
-  name<T, ngpus><<<blocks, threads, 0, stream>>>(ptrs_a, ptrs_b, sg_,         \
-                                                 self_sg_, output, rank_,     \
-                                                 size);
-#define SUM2_CASE(ngpus)                              \
-  case ngpus: {                                      \
-    if (force_1stage) {                              \
-      SUM2_KL(ngpus, cross_device_reduce_sum2_1stage); \
-    } else if (force_2stage) {                       \
-      SUM2_KL(ngpus, cross_device_reduce_sum2_2stage); \
-    } else {                                         \
-      if (world_size_ == 2) {                        \
-        SUM2_KL(ngpus, cross_device_reduce_sum2_1stage); \
-      } else if (fully_connected_) {                 \
-        if ((world_size_ <= 4 && bytes < 512 * 1024) || \
-            (world_size_ <= 8 && bytes < 256 * 1024)) { \
+#define SUM2_KL(ngpus, name)                      \
+  name<T, ngpus><<<blocks, threads, 0, stream>>>( \
+      ptrs_a, ptrs_b, sg_, self_sg_, output, rank_, size);
+#define SUM2_CASE(ngpus)                                   \
+  case ngpus: {                                            \
+    if (force_1stage) {                                    \
+      SUM2_KL(ngpus, cross_device_reduce_sum2_1stage);     \
+    } else if (force_2stage) {                             \
+      SUM2_KL(ngpus, cross_device_reduce_sum2_2stage);     \
+    } else {                                               \
+      if (world_size_ == 2) {                              \
+        SUM2_KL(ngpus, cross_device_reduce_sum2_1stage);   \
+      } else if (fully_connected_) {                       \
+        if ((world_size_ <= 4 && bytes < 512 * 1024) ||    \
+            (world_size_ <= 8 && bytes < 256 * 1024)) {    \
           SUM2_KL(ngpus, cross_device_reduce_sum2_1stage); \
-        } else {                                     \
+        } else {                                           \
           SUM2_KL(ngpus, cross_device_reduce_sum2_2stage); \
-        }                                            \
-      }                                              \
-    }                                                \
-    break;                                           \
+        }                                                  \
+      }                                                    \
+    }                                                      \
+    break;                                                 \
   }
 
     switch (world_size_) {
@@ -1252,12 +1249,12 @@ class CustomAllreduce {
 
     const int packed_size = size / pack;
     const int tile_packed_size = tile_numel / pack;
-    const int tile_count = (packed_size + tile_packed_size - 1) / tile_packed_size;
+    const int tile_count =
+        (packed_size + tile_packed_size - 1) / tile_packed_size;
     if (tile_count <= 0 || tile_count > kMaxBlocks) {
       throw std::runtime_error(
           "SM70 tile runtime prototype supports tile_count in [1, " +
-          std::to_string(kMaxBlocks) + "]. Got " +
-          std::to_string(tile_count));
+          std::to_string(kMaxBlocks) + "]. Got " + std::to_string(tile_count));
     }
 
     auto it = buffers_.find(staging);
@@ -1274,14 +1271,12 @@ class CustomAllreduce {
     blocks = std::max(1, std::min(blocks, tile_count));
     compute_iters = std::max(0, compute_iters);
 
-#define TILE_RUNTIME_CASE(ngpus)                                             \
-  case ngpus: {                                                              \
-    sm70_tile_runtime_reduce_kernel<T, ngpus>                                \
-        <<<blocks, threads, 0, stream>>>(ptrs, sg_, self_sg_, input, staging, \
-                                         output, rank_, packed_size,          \
-                                         tile_packed_size, tile_count,        \
-                                         compute_iters);                     \
-    break;                                                                   \
+#define TILE_RUNTIME_CASE(ngpus)                                               \
+  case ngpus: {                                                                \
+    sm70_tile_runtime_reduce_kernel<T, ngpus><<<blocks, threads, 0, stream>>>( \
+        ptrs, sg_, self_sg_, input, staging, output, rank_, packed_size,       \
+        tile_packed_size, tile_count, compute_iters);                          \
+    break;                                                                     \
   }
 
     switch (world_size_) {
@@ -1321,8 +1316,7 @@ class CustomAllreduce {
     if (tile_count <= 0 || tile_count > kMaxBlocks) {
       throw std::runtime_error(
           "SM70 tile runtime engine supports tile_count in [1, " +
-          std::to_string(kMaxBlocks) + "]. Got " +
-          std::to_string(tile_count));
+          std::to_string(kMaxBlocks) + "]. Got " + std::to_string(tile_count));
     }
 
     auto it = buffers_.find(staging);
@@ -1344,15 +1338,13 @@ class CustomAllreduce {
     const int threads = 256;
     const int blocks = producer_blocks + reducer_blocks;
 
-#define TILE_RUNTIME_ENGINE_CASE(ngpus)                                      \
-  case ngpus: {                                                              \
-    sm70_tile_runtime_engine_kernel<T, ngpus>                                \
-        <<<blocks, threads, 0, stream>>>(ptrs, sg_, self_sg_, input, staging, \
-                                         output, rank_, packed_size,          \
-                                         tile_packed_size, tile_count,        \
-                                         producer_blocks, reducer_blocks,     \
-                                         compute_iters);                     \
-    break;                                                                   \
+#define TILE_RUNTIME_ENGINE_CASE(ngpus)                                        \
+  case ngpus: {                                                                \
+    sm70_tile_runtime_engine_kernel<T, ngpus><<<blocks, threads, 0, stream>>>( \
+        ptrs, sg_, self_sg_, input, staging, output, rank_, packed_size,       \
+        tile_packed_size, tile_count, producer_blocks, reducer_blocks,         \
+        compute_iters);                                                        \
+    break;                                                                     \
   }
 
     switch (world_size_) {
@@ -1366,8 +1358,7 @@ class CustomAllreduce {
 
   template <typename T>
   void tile_runtime_wait_reduce(cudaStream_t stream, T* staging, T* output,
-                                int size, int tile_numel,
-                                int reducer_blocks) {
+                                int size, int tile_numel, int reducer_blocks) {
     if (world_size_ != 2) {
       throw std::runtime_error(
           "SM70 tile runtime wait-reduce currently supports only TP2.");
@@ -1391,8 +1382,7 @@ class CustomAllreduce {
     if (tile_count <= 0 || tile_count > kMaxBlocks) {
       throw std::runtime_error(
           "SM70 tile runtime wait-reduce supports tile_count in [1, " +
-          std::to_string(kMaxBlocks) + "]. Got " +
-          std::to_string(tile_count));
+          std::to_string(kMaxBlocks) + "]. Got " + std::to_string(tile_count));
     }
 
     RankData* ptrs;
@@ -1418,13 +1408,13 @@ class CustomAllreduce {
 
     constexpr int threads = 256;
 
-#define TILE_RUNTIME_WAIT_REDUCE_CASE(ngpus)                                 \
-  case ngpus: {                                                              \
-    sm70_tile_runtime_wait_reduce_kernel<T, ngpus>                           \
-        <<<reducer_blocks, threads, 0, stream>>>(                            \
-            ptrs, sg_, self_sg_, output, rank_, packed_size,                 \
-            tile_packed_size, tile_count);                                   \
-    break;                                                                   \
+#define TILE_RUNTIME_WAIT_REDUCE_CASE(ngpus)                                   \
+  case ngpus: {                                                                \
+    sm70_tile_runtime_wait_reduce_kernel<T, ngpus>                             \
+        <<<reducer_blocks, threads, 0, stream>>>(                              \
+            ptrs, sg_, self_sg_, output, rank_, packed_size, tile_packed_size, \
+            tile_count);                                                       \
+    break;                                                                     \
   }
 
     switch (world_size_) {
@@ -1453,11 +1443,11 @@ class CustomAllreduce {
       ptrs = it->second;
     }
 
-#define TOP1_CASE(ngpus)                                   \
-  case ngpus: {                                            \
-    cross_device_top1_argmax<ngpus><<<1, 32, 0, stream>>>( \
-        ptrs, sg_, self_sg_, output, rank_);               \
-    break;                                                 \
+#define TOP1_CASE(ngpus)                                            \
+  case ngpus: {                                                     \
+    cross_device_top1_argmax<ngpus>                                 \
+        <<<1, 32, 0, stream>>>(ptrs, sg_, self_sg_, output, rank_); \
+    break;                                                          \
   }
 
     switch (world_size_) {

--- a/csrc/moe/moe_permute_unpermute_op.cu
+++ b/csrc/moe/moe_permute_unpermute_op.cu
@@ -28,9 +28,7 @@ torch::Tensor maybe_allocate_tensor(
   return torch::empty(expected_sizes, torch::dtype(dtype).device(device));
 }
 
-int64_t pad_to_multiple_of_16(int64_t value) {
-  return (value + 15) / 16 * 16;
-}
+int64_t pad_to_multiple_of_16(int64_t value) { return (value + 15) / 16 * 16; }
 
 }  // namespace
 
@@ -72,16 +70,15 @@ void moe_permute_impl(
   auto expanded_rows = n_token * topk;
   auto stream = at::cuda::getCurrentCUDAStream().stream();
 
-  if (canUseSingleTokenMoePermuteFastPath(
-          n_token, topk, expert_map.has_value(), n_expert, n_local_expert)) {
+  if (canUseSingleTokenMoePermuteFastPath(n_token, topk, expert_map.has_value(),
+                                          n_expert, n_local_expert)) {
     if (input.scalar_type() == at::ScalarType::Half) {
       singleTokenMoePermuteLauncher<half>(
           get_ptr<half>(input), get_ptr<int>(topk_ids),
           get_ptr<half>(permuted_input),
           get_ptr<int64_t>(expert_first_token_offset),
           get_ptr<int>(inv_permuted_idx), get_ptr<int>(permuted_idx),
-          static_cast<int>(n_expert), static_cast<int>(topk), n_hidden,
-          stream);
+          static_cast<int>(n_expert), static_cast<int>(topk), n_hidden, stream);
       return;
     }
     if (input.scalar_type() == at::ScalarType::BFloat16) {
@@ -90,8 +87,7 @@ void moe_permute_impl(
           get_ptr<__nv_bfloat16>(permuted_input),
           get_ptr<int64_t>(expert_first_token_offset),
           get_ptr<int>(inv_permuted_idx), get_ptr<int>(permuted_idx),
-          static_cast<int>(n_expert), static_cast<int>(topk), n_hidden,
-          stream);
+          static_cast<int>(n_expert), static_cast<int>(topk), n_hidden, stream);
       return;
     }
     if (input.scalar_type() == at::ScalarType::Float) {
@@ -100,8 +96,7 @@ void moe_permute_impl(
           get_ptr<float>(permuted_input),
           get_ptr<int64_t>(expert_first_token_offset),
           get_ptr<int>(inv_permuted_idx), get_ptr<int>(permuted_idx),
-          static_cast<int>(n_expert), static_cast<int>(topk), n_hidden,
-          stream);
+          static_cast<int>(n_expert), static_cast<int>(topk), n_hidden, stream);
       return;
     }
   }

--- a/csrc/moe/permute_unpermute_kernels/moe_permute_unpermute_kernel.cu
+++ b/csrc/moe/permute_unpermute_kernels/moe_permute_unpermute_kernel.cu
@@ -93,10 +93,12 @@ bool singleTokenUnpermuteFastPathEnabled() {
 }
 
 template <typename T>
-__global__ void singleTokenMoePermuteKernel(
-    T const* input, int const* topk_ids, T* permuted_output,
-    int64_t* expert_first_token_offset, int* inv_permuted_idx,
-    int* permuted_idx, int num_experts, int topk, int64_t cols) {
+__global__ void singleTokenMoePermuteKernel(T const* input, int const* topk_ids,
+                                            T* permuted_output,
+                                            int64_t* expert_first_token_offset,
+                                            int* inv_permuted_idx,
+                                            int* permuted_idx, int num_experts,
+                                            int topk, int64_t cols) {
   __shared__ int sorted_ids[kSingleTokenFastPathMaxTopK];
   __shared__ int sorted_src[kSingleTokenFastPathMaxTopK];
 
@@ -177,8 +179,8 @@ __global__ void singleTokenMoeUnpermuteKernel(
 
   auto const* expanded_rows_v =
       reinterpret_cast<InputElem const*>(expanded_permuted_rows);
-  auto* reduced_row_ptr_v = reinterpret_cast<OutputElem*>(
-      reduced_unpermuted_output);
+  auto* reduced_row_ptr_v =
+      reinterpret_cast<OutputElem*>(reduced_unpermuted_output);
   int64_t const num_elems_in_col = cols / FINALIZE_ELEM_PER_THREAD;
 
   for (int64_t elem_index = threadIdx.x; elem_index < num_elems_in_col;
@@ -186,7 +188,7 @@ __global__ void singleTokenMoeUnpermuteKernel(
     ComputeElem thread_output;
     thread_output.fill(0);
 
-#pragma unroll
+  #pragma unroll
     for (int k_idx = 0; k_idx < kSingleTokenFastPathMaxTopK; ++k_idx) {
       if (k_idx >= topk) {
         break;
@@ -222,11 +224,12 @@ bool canUseSingleTokenMoePermuteFastPath(int64_t n_token, int64_t topk,
 }
 
 template <typename T>
-void singleTokenMoePermuteLauncher(
-    T const* input, int const* topk_ids, T* permuted_output,
-    int64_t* expert_first_token_offset, int* inv_permuted_idx,
-    int* permuted_idx, int num_experts, int topk, int64_t cols,
-    cudaStream_t stream) {
+void singleTokenMoePermuteLauncher(T const* input, int const* topk_ids,
+                                   T* permuted_output,
+                                   int64_t* expert_first_token_offset,
+                                   int* inv_permuted_idx, int* permuted_idx,
+                                   int num_experts, int topk, int64_t cols,
+                                   cudaStream_t stream) {
   constexpr int threads = 256;
   singleTokenMoePermuteKernel<T><<<1, threads, 0, stream>>>(
       input, topk_ids, permuted_output, expert_first_token_offset,

--- a/csrc/moe/permute_unpermute_kernels/moe_permute_unpermute_kernel.h
+++ b/csrc/moe/permute_unpermute_kernels/moe_permute_unpermute_kernel.h
@@ -80,11 +80,12 @@ bool canUseSingleTokenMoePermuteFastPath(int64_t n_token, int64_t topk,
                                          int64_t n_local_expert);
 
 template <typename T>
-void singleTokenMoePermuteLauncher(
-    T const* input, int const* topk_ids, T* permuted_output,
-    int64_t* expert_first_token_offset, int* inv_permuted_idx,
-    int* permuted_idx, int num_experts, int topk, int64_t cols,
-    cudaStream_t stream);
+void singleTokenMoePermuteLauncher(T const* input, int const* topk_ids,
+                                   T* permuted_output,
+                                   int64_t* expert_first_token_offset,
+                                   int* inv_permuted_idx, int* permuted_idx,
+                                   int num_experts, int topk, int64_t cols,
+                                   cudaStream_t stream);
 
 bool canUseSingleTokenMoeUnpermuteFastPath(int64_t n_token, int64_t topk);
 

--- a/csrc/ops.h
+++ b/csrc/ops.h
@@ -124,126 +124,84 @@ std::vector<torch::Tensor> nvfp4_sm70_prepare(torch::Tensor _kernel,
 
 std::vector<torch::Tensor> sm70_f16_prepare(torch::Tensor _kernel);
 
-torch::Tensor awq_gemm_sm70(torch::Tensor _in_feats,
-                            torch::Tensor _kernel,
-                            torch::Tensor _scaling_factors,
-                            int64_t group_size,
-                            int64_t k_ld,
-                            int64_t q_ld);
+torch::Tensor awq_gemm_sm70(torch::Tensor _in_feats, torch::Tensor _kernel,
+                            torch::Tensor _scaling_factors, int64_t group_size,
+                            int64_t k_ld, int64_t q_ld);
 
 torch::Tensor sm70_f16_gemm(torch::Tensor _in_feats, torch::Tensor _kernel);
 
-void awq_gemm_sm70_out(torch::Tensor out,
-                       torch::Tensor _in_feats,
-                       torch::Tensor _kernel,
-                       torch::Tensor _scaling_factors,
-                       int64_t group_size,
-                       int64_t k_ld,
-                       int64_t q_ld,
+void awq_gemm_sm70_out(torch::Tensor out, torch::Tensor _in_feats,
+                       torch::Tensor _kernel, torch::Tensor _scaling_factors,
+                       int64_t group_size, int64_t k_ld, int64_t q_ld,
                        bool gated_silu);
 
-void awq_gemm_sm70_out_tile_reduce(torch::Tensor out,
-                                   torch::Tensor staging,
-                                   torch::Tensor _in_feats,
-                                   torch::Tensor _kernel,
-                                   torch::Tensor _scaling_factors,
-                                   int64_t group_size,
-                                   int64_t k_ld,
-                                   int64_t q_ld,
-                                   int64_t fa_ptr,
-                                   int64_t tile_numel,
-                                   int64_t reducer_blocks,
-                                   int64_t kernel_reducer_blocks,
-                                   bool overlap);
+void awq_gemm_sm70_out_tile_reduce(
+    torch::Tensor out, torch::Tensor staging, torch::Tensor _in_feats,
+    torch::Tensor _kernel, torch::Tensor _scaling_factors, int64_t group_size,
+    int64_t k_ld, int64_t q_ld, int64_t fa_ptr, int64_t tile_numel,
+    int64_t reducer_blocks, int64_t kernel_reducer_blocks, bool overlap);
 
-void fp8_gemm_sm70_out(torch::Tensor out,
-                       torch::Tensor _in_feats,
-                       torch::Tensor _kernel,
-                       torch::Tensor _scaling_factors,
-                       int64_t group_size,
-                       int64_t k_ld,
-                       int64_t q_ld,
+void fp8_gemm_sm70_out(torch::Tensor out, torch::Tensor _in_feats,
+                       torch::Tensor _kernel, torch::Tensor _scaling_factors,
+                       int64_t group_size, int64_t k_ld, int64_t q_ld,
                        bool gated_silu);
 
-void mxfp4_gemm_sm70_out(torch::Tensor out,
-                         torch::Tensor _in_feats,
-                         torch::Tensor _kernel,
-                         torch::Tensor _scaling_factors,
-                         int64_t group_size,
-                         int64_t k_ld,
-                         int64_t q_ld,
+void mxfp4_gemm_sm70_out(torch::Tensor out, torch::Tensor _in_feats,
+                         torch::Tensor _kernel, torch::Tensor _scaling_factors,
+                         int64_t group_size, int64_t k_ld, int64_t q_ld,
                          bool gated_silu);
 
-void nvfp4_gemm_sm70_out(torch::Tensor out,
-                         torch::Tensor _in_feats,
-                         torch::Tensor _kernel,
-                         torch::Tensor _scaling_factors,
-                         int64_t group_size,
-                         int64_t k_ld,
-                         int64_t q_ld,
+void nvfp4_gemm_sm70_out(torch::Tensor out, torch::Tensor _in_feats,
+                         torch::Tensor _kernel, torch::Tensor _scaling_factors,
+                         int64_t group_size, int64_t k_ld, int64_t q_ld,
                          bool gated_silu);
 
-void nvfp4_gemv_sm70_raw_out(torch::Tensor out,
-                             torch::Tensor _in_feats,
+void nvfp4_gemv_sm70_raw_out(torch::Tensor out, torch::Tensor _in_feats,
                              torch::Tensor _kernel,
                              torch::Tensor _scaling_factors,
-                             torch::Tensor partials,
-                             int64_t group_size,
+                             torch::Tensor partials, int64_t group_size,
                              int64_t split_k);
 
-void nvfp4_gemv_sm70_warp_out(torch::Tensor out,
-                              torch::Tensor _in_feats,
+void nvfp4_gemv_sm70_warp_out(torch::Tensor out, torch::Tensor _in_feats,
                               torch::Tensor _kernel,
                               torch::Tensor _scaling_factors,
                               int64_t group_size);
 
-void nvfp4_gemv_sm70_h2_out(torch::Tensor out,
-                            torch::Tensor _in_feats,
+void nvfp4_gemv_sm70_h2_out(torch::Tensor out, torch::Tensor _in_feats,
                             torch::Tensor _kernel,
                             torch::Tensor _scaling_factors,
-                            torch::Tensor partials,
-                            int64_t group_size,
+                            torch::Tensor partials, int64_t group_size,
                             int64_t split_k);
 
-void fp8_gemm_sm70_out_auto(torch::Tensor out,
-                            torch::Tensor _in_feats,
+void fp8_gemm_sm70_out_auto(torch::Tensor out, torch::Tensor _in_feats,
                             torch::Tensor _kernel,
                             torch::Tensor _scaling_factors);
 
-void fp8_gemm_sm70_out_meta(torch::Tensor out,
-                            torch::Tensor _in_feats,
+void fp8_gemm_sm70_out_meta(torch::Tensor out, torch::Tensor _in_feats,
                             torch::Tensor _kernel,
-                            torch::Tensor _scaling_factors,
-                            torch::Tensor _meta,
+                            torch::Tensor _scaling_factors, torch::Tensor _meta,
                             bool gated_silu);
 
-void sm70_f16_gemm_out(torch::Tensor out,
-                       torch::Tensor _in_feats,
-                       torch::Tensor _kernel,
-                       int64_t k_ld,
-                       bool gated_silu);
+void sm70_f16_gemm_out(torch::Tensor out, torch::Tensor _in_feats,
+                       torch::Tensor _kernel, int64_t k_ld, bool gated_silu);
 
 void sm70_f16_lm_head_top1_out(torch::Tensor values_out,
                                torch::Tensor indices_out,
-                               torch::Tensor _in_feats,
-                               torch::Tensor _kernel,
-                               int64_t k_ld,
-                               int64_t vocab_start_index,
+                               torch::Tensor _in_feats, torch::Tensor _kernel,
+                               int64_t k_ld, int64_t vocab_start_index,
                                int64_t num_vocab_padding);
 
 void sm70_f16_lm_head_top1_tc_out(torch::Tensor values_out,
                                   torch::Tensor indices_out,
                                   torch::Tensor _in_feats,
-                                  torch::Tensor _kernel,
-                                  int64_t k_ld,
+                                  torch::Tensor _kernel, int64_t k_ld,
                                   int64_t vocab_start_index,
                                   int64_t num_vocab_padding);
 
 void sm70_f16_lm_head_top20_tc_out(torch::Tensor values_out,
                                    torch::Tensor indices_out,
                                    torch::Tensor _in_feats,
-                                   torch::Tensor _kernel,
-                                   int64_t k_ld,
+                                   torch::Tensor _kernel, int64_t k_ld,
                                    int64_t vocab_start_index,
                                    int64_t num_vocab_padding);
 
@@ -259,27 +217,20 @@ void sm70_sample_packed_top20_out(torch::Tensor sampled_token_out,
                                   torch::Tensor sparse_ids_out,
                                   torch::Tensor sparse_probs_out,
                                   torch::Tensor gathered_pairs,
-                                  torch::Tensor exponential,
-                                  double top_p);
+                                  torch::Tensor exponential, double top_p);
 
 void sm70_dynamic_draft_vocab_update_tail_out(
-    torch::Tensor lru_token_ids,
-    torch::Tensor local_tail_token_ids,
-    torch::Tensor source_row_indices,
-    torch::Tensor observed_output_ids,
-    torch::Tensor target_candidate_ids,
-    torch::Tensor base_token_mask,
-    int64_t full_vocab_size,
-    int64_t local_shard_start,
+    torch::Tensor lru_token_ids, torch::Tensor local_tail_token_ids,
+    torch::Tensor source_row_indices, torch::Tensor observed_output_ids,
+    torch::Tensor target_candidate_ids, torch::Tensor base_token_mask,
+    int64_t full_vocab_size, int64_t local_shard_start,
     int64_t local_shard_end);
 
 void sm70_dynamic_draft_vocab_refresh_tail_weight_out(
-    torch::Tensor local_tail_weight,
-    torch::Tensor source_weight,
+    torch::Tensor local_tail_weight, torch::Tensor source_weight,
     torch::Tensor source_row_indices);
 
-void sm70_f16_gate_mul_out(torch::Tensor out,
-                           torch::Tensor _in_feats,
+void sm70_f16_gate_mul_out(torch::Tensor out, torch::Tensor _in_feats,
                            torch::Tensor _gate_weight);
 
 int64_t sm70_gemm_import_cache(torch::Tensor device_hint,
@@ -288,317 +239,167 @@ int64_t sm70_gemm_import_cache(torch::Tensor device_hint,
 int64_t sm70_gemm_export_cache(torch::Tensor device_hint,
                                const std::string& path);
 
-std::vector<torch::Tensor> awq_moe_build_strided_ptrs(
-    torch::Tensor tm_weights,
-    torch::Tensor tm_scales,
-    int64_t k_ld,
-    int64_t q_ld,
-    int64_t num_experts);
+std::vector<torch::Tensor> awq_moe_build_strided_ptrs(torch::Tensor tm_weights,
+                                                      torch::Tensor tm_scales,
+                                                      int64_t k_ld,
+                                                      int64_t q_ld,
+                                                      int64_t num_experts);
 
-void awq_moe_gemm_sm70_out(torch::Tensor out,
-                           torch::Tensor sorted_input,
+void awq_moe_gemm_sm70_out(torch::Tensor out, torch::Tensor sorted_input,
                            torch::Tensor expert_offsets,
                            torch::Tensor strided_ptrs_w,
-                           torch::Tensor strided_ptrs_s,
-                           int64_t num_experts,
-                           int64_t k,
-                           int64_t n,
-                           int64_t group_size,
+                           torch::Tensor strided_ptrs_s, int64_t num_experts,
+                           int64_t k, int64_t n, int64_t group_size,
                            bool gated_silu);
 
-void awq_moe_gemm_sm70_per_expert_dispatch_out(torch::Tensor out,
-                                               torch::Tensor sorted_input,
-                                               torch::Tensor expert_offsets,
-                                               torch::Tensor strided_ptrs_w,
-                                               torch::Tensor strided_ptrs_s,
-                                               int64_t num_experts,
-                                               int64_t k,
-                                               int64_t n,
-                                               int64_t group_size,
-                                               bool gated_silu);
+void awq_moe_gemm_sm70_per_expert_dispatch_out(
+    torch::Tensor out, torch::Tensor sorted_input, torch::Tensor expert_offsets,
+    torch::Tensor strided_ptrs_w, torch::Tensor strided_ptrs_s,
+    int64_t num_experts, int64_t k, int64_t n, int64_t group_size,
+    bool gated_silu);
 
-void awq_moe_dense_stage_sm70_out(torch::Tensor out,
-                                  torch::Tensor input,
+void awq_moe_dense_stage_sm70_out(torch::Tensor out, torch::Tensor input,
                                   torch::Tensor expert_offsets,
                                   torch::Tensor dense_expert_ids,
-                                  torch::Tensor ptrs_w,
-                                  torch::Tensor ptrs_s,
-                                  int64_t num_experts,
-                                  int64_t k,
-                                  int64_t n,
+                                  torch::Tensor ptrs_w, torch::Tensor ptrs_s,
+                                  int64_t num_experts, int64_t k, int64_t n,
                                   int64_t group_size);
 
 void awq_moe_active_dense_stage_sm70_out(
-    torch::Tensor out,
-    torch::Tensor input,
-    torch::Tensor permuted_experts_id,
-    torch::Tensor active_expert_offsets,
-    torch::Tensor active_expert_ids,
-    torch::Tensor ptrs_w,
-    torch::Tensor ptrs_s,
-    int64_t total_slots,
-    int64_t k,
-    int64_t n,
-    int64_t group_size);
+    torch::Tensor out, torch::Tensor input, torch::Tensor permuted_experts_id,
+    torch::Tensor active_expert_offsets, torch::Tensor active_expert_ids,
+    torch::Tensor ptrs_w, torch::Tensor ptrs_s, int64_t total_slots, int64_t k,
+    int64_t n, int64_t group_size);
 
 void awq_moe_single_token_dense_stage_sm70_out(
-    torch::Tensor out,
-    torch::Tensor input,
-    torch::Tensor expert_offsets,
-    torch::Tensor sorted_expert_ids,
-    torch::Tensor ptrs_w,
-    torch::Tensor ptrs_s,
-    int64_t top_k,
-    int64_t k,
-    int64_t n,
-    int64_t group_size);
+    torch::Tensor out, torch::Tensor input, torch::Tensor expert_offsets,
+    torch::Tensor sorted_expert_ids, torch::Tensor ptrs_w, torch::Tensor ptrs_s,
+    int64_t top_k, int64_t k, int64_t n, int64_t group_size);
 
 void awq_moe_single_token_indexed_dense_stage_sm70_out(
-    torch::Tensor out,
-    torch::Tensor input,
-    torch::Tensor expert_offsets,
-    torch::Tensor sorted_expert_ids,
-    torch::Tensor ptrs_w,
-    torch::Tensor ptrs_s,
-    int64_t top_k,
-    int64_t k,
-    int64_t n,
-    int64_t group_size);
+    torch::Tensor out, torch::Tensor input, torch::Tensor expert_offsets,
+    torch::Tensor sorted_expert_ids, torch::Tensor ptrs_w, torch::Tensor ptrs_s,
+    int64_t top_k, int64_t k, int64_t n, int64_t group_size);
 
 void awq_moe_single_token_dense_w13_sm70_out(
-    torch::Tensor gate_up,
-    torch::Tensor compact_input,
-    torch::Tensor x,
-    torch::Tensor topk_ids,
-    torch::Tensor w13_ptrs_w,
-    torch::Tensor w13_ptrs_s,
-    torch::Tensor expert_offsets,
-    torch::Tensor expert_offsets64,
-    torch::Tensor inv_permuted_idx,
-    torch::Tensor sorted_expert_ids,
-    int64_t w13_k,
-    int64_t w13_n,
-    int64_t group_size,
+    torch::Tensor gate_up, torch::Tensor compact_input, torch::Tensor x,
+    torch::Tensor topk_ids, torch::Tensor w13_ptrs_w, torch::Tensor w13_ptrs_s,
+    torch::Tensor expert_offsets, torch::Tensor expert_offsets64,
+    torch::Tensor inv_permuted_idx, torch::Tensor sorted_expert_ids,
+    int64_t w13_k, int64_t w13_n, int64_t group_size,
     int64_t hidden_logical_size);
 
 void awq_moe_single_token_indexed_dense_w13_sm70_out(
-    torch::Tensor gate_up,
-    torch::Tensor compact_input,
-    torch::Tensor x,
-    torch::Tensor topk_ids,
-    torch::Tensor w13_ptrs_w,
-    torch::Tensor w13_ptrs_s,
-    torch::Tensor expert_offsets,
-    torch::Tensor expert_offsets64,
-    torch::Tensor inv_permuted_idx,
-    torch::Tensor sorted_expert_ids,
-    int64_t w13_k,
-    int64_t w13_n,
-    int64_t group_size,
+    torch::Tensor gate_up, torch::Tensor compact_input, torch::Tensor x,
+    torch::Tensor topk_ids, torch::Tensor w13_ptrs_w, torch::Tensor w13_ptrs_s,
+    torch::Tensor expert_offsets, torch::Tensor expert_offsets64,
+    torch::Tensor inv_permuted_idx, torch::Tensor sorted_expert_ids,
+    int64_t w13_k, int64_t w13_n, int64_t group_size,
     int64_t hidden_logical_size);
 
 void awq_moe_single_token_compact_dense_w13_sm70_out(
-    torch::Tensor gate_up,
-    torch::Tensor compact_input,
-    torch::Tensor x,
-    torch::Tensor topk_ids,
-    torch::Tensor w13_ptrs_w,
-    torch::Tensor w13_ptrs_s,
-    torch::Tensor compact_w13_ptrs_w,
-    torch::Tensor compact_w13_ptrs_s,
-    torch::Tensor expert_offsets,
-    torch::Tensor expert_offsets64,
-    torch::Tensor inv_permuted_idx,
-    torch::Tensor sorted_expert_ids,
-    int64_t w13_k,
-    int64_t w13_n,
-    int64_t group_size,
+    torch::Tensor gate_up, torch::Tensor compact_input, torch::Tensor x,
+    torch::Tensor topk_ids, torch::Tensor w13_ptrs_w, torch::Tensor w13_ptrs_s,
+    torch::Tensor compact_w13_ptrs_w, torch::Tensor compact_w13_ptrs_s,
+    torch::Tensor expert_offsets, torch::Tensor expert_offsets64,
+    torch::Tensor inv_permuted_idx, torch::Tensor sorted_expert_ids,
+    int64_t w13_k, int64_t w13_n, int64_t group_size,
     int64_t hidden_logical_size);
 
-void awq_moe_single_token_exact_layout_prepare(torch::Tensor topk_ids,
-                                               torch::Tensor x,
-                                               torch::Tensor compact_input,
-                                               torch::Tensor expert_offsets,
-                                               torch::Tensor expert_offsets64,
-                                               torch::Tensor inv_permuted_idx,
-                                               int64_t num_experts);
+void awq_moe_single_token_exact_layout_prepare(
+    torch::Tensor topk_ids, torch::Tensor x, torch::Tensor compact_input,
+    torch::Tensor expert_offsets, torch::Tensor expert_offsets64,
+    torch::Tensor inv_permuted_idx, int64_t num_experts);
 
 void awq_moe_single_token_weighted_reduce_out(torch::Tensor sorted_output,
                                               torch::Tensor topk_weights,
                                               torch::Tensor inv_permuted_idx,
-                                              torch::Tensor out,
-                                              int64_t top_k,
+                                              torch::Tensor out, int64_t top_k,
                                               int64_t hidden_logical_size);
 
 void awq_moe_single_token_sm70_out(
-    torch::Tensor out,
-    torch::Tensor x,
-    torch::Tensor topk_weights,
-    torch::Tensor topk_ids,
-    torch::Tensor src_w13_ptrs_w_rows,
-    torch::Tensor src_w13_ptrs_s_rows,
-    torch::Tensor src_w2_ptrs_w_rows,
-    torch::Tensor src_w2_ptrs_s_rows,
-    torch::Tensor compact_input,
-    torch::Tensor intermediate,
-    torch::Tensor sorted_output,
-    torch::Tensor sorted_weights,
-    torch::Tensor dst_w13_ptrs_w_rows,
-    torch::Tensor dst_w13_ptrs_s_rows,
-    torch::Tensor dst_w2_ptrs_w_rows,
-    torch::Tensor dst_w2_ptrs_s_rows,
-    torch::Tensor expert_offsets,
-    torch::Tensor inv_permuted_idx,
-    int64_t w13_k,
-    int64_t w13_n,
-    int64_t w2_k,
-    int64_t w2_n,
-    int64_t group_size,
-    int64_t hidden_logical_size);
+    torch::Tensor out, torch::Tensor x, torch::Tensor topk_weights,
+    torch::Tensor topk_ids, torch::Tensor src_w13_ptrs_w_rows,
+    torch::Tensor src_w13_ptrs_s_rows, torch::Tensor src_w2_ptrs_w_rows,
+    torch::Tensor src_w2_ptrs_s_rows, torch::Tensor compact_input,
+    torch::Tensor intermediate, torch::Tensor sorted_output,
+    torch::Tensor sorted_weights, torch::Tensor dst_w13_ptrs_w_rows,
+    torch::Tensor dst_w13_ptrs_s_rows, torch::Tensor dst_w2_ptrs_w_rows,
+    torch::Tensor dst_w2_ptrs_s_rows, torch::Tensor expert_offsets,
+    torch::Tensor inv_permuted_idx, int64_t w13_k, int64_t w13_n, int64_t w2_k,
+    int64_t w2_n, int64_t group_size, int64_t hidden_logical_size);
 
-void fp8_moe_gemm_sm70_out(torch::Tensor out,
-                           torch::Tensor sorted_input,
+void fp8_moe_gemm_sm70_out(torch::Tensor out, torch::Tensor sorted_input,
                            torch::Tensor expert_offsets,
                            torch::Tensor strided_ptrs_w,
-                           torch::Tensor strided_ptrs_s,
-                           int64_t num_experts,
-                           int64_t k,
-                           int64_t n,
-                           int64_t group_size,
+                           torch::Tensor strided_ptrs_s, int64_t num_experts,
+                           int64_t k, int64_t n, int64_t group_size,
                            bool gated_silu);
 
-void fp8_moe_gemm_sm70_per_expert_dispatch_out(torch::Tensor out,
-                                               torch::Tensor sorted_input,
-                                               torch::Tensor expert_offsets,
-                                               torch::Tensor strided_ptrs_w,
-                                               torch::Tensor strided_ptrs_s,
-                                               int64_t num_experts,
-                                               int64_t k,
-                                               int64_t n,
-                                               int64_t group_size,
-                                               bool gated_silu);
+void fp8_moe_gemm_sm70_per_expert_dispatch_out(
+    torch::Tensor out, torch::Tensor sorted_input, torch::Tensor expert_offsets,
+    torch::Tensor strided_ptrs_w, torch::Tensor strided_ptrs_s,
+    int64_t num_experts, int64_t k, int64_t n, int64_t group_size,
+    bool gated_silu);
 
-void fp8_moe_dense_stage_sm70_out(torch::Tensor out,
-                                  torch::Tensor input,
+void fp8_moe_dense_stage_sm70_out(torch::Tensor out, torch::Tensor input,
                                   torch::Tensor expert_offsets,
                                   torch::Tensor dense_expert_ids,
-                                  torch::Tensor ptrs_w,
-                                  torch::Tensor ptrs_s,
-                                  int64_t num_experts,
-                                  int64_t k,
-                                  int64_t n,
+                                  torch::Tensor ptrs_w, torch::Tensor ptrs_s,
+                                  int64_t num_experts, int64_t k, int64_t n,
                                   int64_t group_size);
 
 void fp8_moe_single_token_dense_stage_sm70_out(
-    torch::Tensor out,
-    torch::Tensor input,
-    torch::Tensor expert_offsets,
-    torch::Tensor sorted_expert_ids,
-    torch::Tensor ptrs_w,
-    torch::Tensor ptrs_s,
-    int64_t top_k,
-    int64_t k,
-    int64_t n,
-    int64_t group_size);
+    torch::Tensor out, torch::Tensor input, torch::Tensor expert_offsets,
+    torch::Tensor sorted_expert_ids, torch::Tensor ptrs_w, torch::Tensor ptrs_s,
+    int64_t top_k, int64_t k, int64_t n, int64_t group_size);
 
 void fp8_moe_single_token_indexed_dense_stage_sm70_out(
-    torch::Tensor out,
-    torch::Tensor input,
-    torch::Tensor expert_offsets,
-    torch::Tensor sorted_expert_ids,
-    torch::Tensor ptrs_w,
-    torch::Tensor ptrs_s,
-    int64_t top_k,
-    int64_t k,
-    int64_t n,
-    int64_t group_size);
+    torch::Tensor out, torch::Tensor input, torch::Tensor expert_offsets,
+    torch::Tensor sorted_expert_ids, torch::Tensor ptrs_w, torch::Tensor ptrs_s,
+    int64_t top_k, int64_t k, int64_t n, int64_t group_size);
 
 void fp8_moe_single_token_dense_w13_sm70_out(
-    torch::Tensor gate_up,
-    torch::Tensor compact_input,
-    torch::Tensor x,
-    torch::Tensor topk_ids,
-    torch::Tensor w13_ptrs_w,
-    torch::Tensor w13_ptrs_s,
-    torch::Tensor expert_offsets,
-    torch::Tensor expert_offsets64,
-    torch::Tensor inv_permuted_idx,
-    torch::Tensor sorted_expert_ids,
-    int64_t w13_k,
-    int64_t w13_n,
-    int64_t group_size,
+    torch::Tensor gate_up, torch::Tensor compact_input, torch::Tensor x,
+    torch::Tensor topk_ids, torch::Tensor w13_ptrs_w, torch::Tensor w13_ptrs_s,
+    torch::Tensor expert_offsets, torch::Tensor expert_offsets64,
+    torch::Tensor inv_permuted_idx, torch::Tensor sorted_expert_ids,
+    int64_t w13_k, int64_t w13_n, int64_t group_size,
     int64_t hidden_logical_size);
 
 void fp8_moe_single_token_indexed_dense_w13_sm70_out(
-    torch::Tensor gate_up,
-    torch::Tensor compact_input,
-    torch::Tensor x,
-    torch::Tensor topk_ids,
-    torch::Tensor w13_ptrs_w,
-    torch::Tensor w13_ptrs_s,
-    torch::Tensor expert_offsets,
-    torch::Tensor expert_offsets64,
-    torch::Tensor inv_permuted_idx,
-    torch::Tensor sorted_expert_ids,
-    int64_t w13_k,
-    int64_t w13_n,
-    int64_t group_size,
+    torch::Tensor gate_up, torch::Tensor compact_input, torch::Tensor x,
+    torch::Tensor topk_ids, torch::Tensor w13_ptrs_w, torch::Tensor w13_ptrs_s,
+    torch::Tensor expert_offsets, torch::Tensor expert_offsets64,
+    torch::Tensor inv_permuted_idx, torch::Tensor sorted_expert_ids,
+    int64_t w13_k, int64_t w13_n, int64_t group_size,
     int64_t hidden_logical_size);
 
 void fp8_moe_single_token_compact_dense_w13_sm70_out(
-    torch::Tensor gate_up,
-    torch::Tensor compact_input,
-    torch::Tensor x,
-    torch::Tensor topk_ids,
-    torch::Tensor w13_ptrs_w,
-    torch::Tensor w13_ptrs_s,
-    torch::Tensor compact_w13_ptrs_w,
-    torch::Tensor compact_w13_ptrs_s,
-    torch::Tensor expert_offsets,
-    torch::Tensor expert_offsets64,
-    torch::Tensor inv_permuted_idx,
-    torch::Tensor sorted_expert_ids,
-    int64_t w13_k,
-    int64_t w13_n,
-    int64_t group_size,
+    torch::Tensor gate_up, torch::Tensor compact_input, torch::Tensor x,
+    torch::Tensor topk_ids, torch::Tensor w13_ptrs_w, torch::Tensor w13_ptrs_s,
+    torch::Tensor compact_w13_ptrs_w, torch::Tensor compact_w13_ptrs_s,
+    torch::Tensor expert_offsets, torch::Tensor expert_offsets64,
+    torch::Tensor inv_permuted_idx, torch::Tensor sorted_expert_ids,
+    int64_t w13_k, int64_t w13_n, int64_t group_size,
     int64_t hidden_logical_size);
 
 void fp8_moe_single_token_sm70_out(
-    torch::Tensor out,
-    torch::Tensor x,
-    torch::Tensor topk_weights,
-    torch::Tensor topk_ids,
-    torch::Tensor src_w13_ptrs_w_rows,
-    torch::Tensor src_w13_ptrs_s_rows,
-    torch::Tensor src_w2_ptrs_w_rows,
-    torch::Tensor src_w2_ptrs_s_rows,
-    torch::Tensor compact_input,
-    torch::Tensor gate_up,
-    torch::Tensor intermediate,
-    torch::Tensor sorted_output,
-    torch::Tensor sorted_weights,
-    torch::Tensor dst_w13_ptrs_w_rows,
-    torch::Tensor dst_w13_ptrs_s_rows,
-    torch::Tensor dst_w2_ptrs_w_rows,
-    torch::Tensor dst_w2_ptrs_s_rows,
-    torch::Tensor expert_offsets,
-    torch::Tensor inv_permuted_idx,
-    torch::Tensor sorted_expert_ids,
-    torch::Tensor broadcast_input_indices,
-    torch::Tensor w2_raw_weight,
-    torch::Tensor w2_raw_scale_inv,
-    int64_t w13_k,
-    int64_t w13_n,
-    int64_t w2_k,
-    int64_t w2_n,
-    int64_t group_size,
-    int64_t hidden_logical_size,
-    bool fused_gated_silu,
-    bool fused_weighted_reduce,
-    bool broadcast_input,
-    bool w2_direct_reduce,
-    bool indexed_expert_ptrs,
-    bool exact_per_route);
+    torch::Tensor out, torch::Tensor x, torch::Tensor topk_weights,
+    torch::Tensor topk_ids, torch::Tensor src_w13_ptrs_w_rows,
+    torch::Tensor src_w13_ptrs_s_rows, torch::Tensor src_w2_ptrs_w_rows,
+    torch::Tensor src_w2_ptrs_s_rows, torch::Tensor compact_input,
+    torch::Tensor gate_up, torch::Tensor intermediate,
+    torch::Tensor sorted_output, torch::Tensor sorted_weights,
+    torch::Tensor dst_w13_ptrs_w_rows, torch::Tensor dst_w13_ptrs_s_rows,
+    torch::Tensor dst_w2_ptrs_w_rows, torch::Tensor dst_w2_ptrs_s_rows,
+    torch::Tensor expert_offsets, torch::Tensor inv_permuted_idx,
+    torch::Tensor sorted_expert_ids, torch::Tensor broadcast_input_indices,
+    torch::Tensor w2_raw_weight, torch::Tensor w2_raw_scale_inv, int64_t w13_k,
+    int64_t w13_n, int64_t w2_k, int64_t w2_n, int64_t group_size,
+    int64_t hidden_logical_size, bool fused_gated_silu,
+    bool fused_weighted_reduce, bool broadcast_input, bool w2_direct_reduce,
+    bool indexed_expert_ptrs, bool exact_per_route);
 #endif
 
 void static_scaled_int8_quant(torch::Tensor& out, torch::Tensor const& input,
@@ -624,27 +425,25 @@ void all_reduce(fptr_t _fa, torch::Tensor& inp, torch::Tensor& out,
 void sm70_tp2_all_reduce_gemma_rms_norm(
     fptr_t _fa, torch::Tensor& inp, torch::Tensor& residual,
     torch::Tensor& weight, torch::Tensor& normalized_out,
-    torch::Tensor& residual_out, fptr_t reg_buffer,
-    int64_t reg_buffer_sz_bytes, double epsilon);
+    torch::Tensor& residual_out, fptr_t reg_buffer, int64_t reg_buffer_sz_bytes,
+    double epsilon);
 void sm70_tp4_all_reduce_gemma_rms_norm(
     fptr_t _fa, torch::Tensor& inp, torch::Tensor& residual,
     torch::Tensor& weight, torch::Tensor& normalized_out,
-    torch::Tensor& residual_out, fptr_t reg_buffer,
-    int64_t reg_buffer_sz_bytes, double epsilon);
+    torch::Tensor& residual_out, fptr_t reg_buffer, int64_t reg_buffer_sz_bytes,
+    double epsilon);
 void all_reduce_sum2(fptr_t _fa, torch::Tensor& inp_a, torch::Tensor& inp_b,
                      torch::Tensor& out);
 void top1_argmax(fptr_t _fa, torch::Tensor& input_pair, torch::Tensor& output,
                  fptr_t reg_buffer, int64_t reg_buffer_sz_bytes);
 void tile_runtime_all_reduce(fptr_t _fa, torch::Tensor& inp, torch::Tensor& out,
-                             fptr_t reg_buffer,
-                             int64_t reg_buffer_sz_bytes,
+                             fptr_t reg_buffer, int64_t reg_buffer_sz_bytes,
                              int64_t tile_numel, int64_t engine_blocks,
                              int64_t compute_iters);
 void tile_runtime_all_reduce_engine(fptr_t _fa, torch::Tensor& inp,
                                     torch::Tensor& out, fptr_t reg_buffer,
                                     int64_t reg_buffer_sz_bytes,
-                                    int64_t tile_numel,
-                                    int64_t producer_blocks,
+                                    int64_t tile_numel, int64_t producer_blocks,
                                     int64_t reducer_blocks,
                                     int64_t compute_iters);
 void tile_runtime_wait_reduce(fptr_t _fa, torch::Tensor& staging,

--- a/csrc/sm70_tile_runtime_signal.cuh
+++ b/csrc/sm70_tile_runtime_signal.cuh
@@ -28,14 +28,13 @@ struct __align__(16) RankSignals {
 #if !defined(USE_ROCM)
 static __device__ __forceinline__ void store_flag_sys_visible(
     FlagType* flag_addr, FlagType flag) {
-  asm volatile("membar.sys; st.volatile.global.u32 [%1], %0;"
-               ::"r"(flag),
+  asm volatile("membar.sys; st.volatile.global.u32 [%1], %0;" ::"r"(flag),
                "l"(flag_addr)
                : "memory");
 }
 
-static __device__ __forceinline__ FlagType load_flag_sys_visible(
-    FlagType* flag_addr) {
+static __device__ __forceinline__ FlagType
+load_flag_sys_visible(FlagType* flag_addr) {
   FlagType flag;
   asm volatile("ld.volatile.global.u32 %0, [%1]; membar.sys;"
                : "=r"(flag)

--- a/csrc/torch_bindings.cpp
+++ b/csrc/torch_bindings.cpp
@@ -165,13 +165,13 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, ops) {
       "Tensor? qzeros_or_none, bool inplace) -> Tensor");
   // conditionally compiled so impl registrations are in source file
 
-#ifdef ENABLE_SM70_TURBOMIND
+  #ifdef ENABLE_SM70_TURBOMIND
   ops.def("silu_and_mul_interleaved(Tensor! result, Tensor input) -> ()");
-  ops.impl("silu_and_mul_interleaved", torch::kCUDA,
-           &silu_and_mul_interleaved);
+  ops.impl("silu_and_mul_interleaved", torch::kCUDA, &silu_and_mul_interleaved);
 
   ops.def(
-      "awq_sm70_prepare(Tensor _kernel, Tensor _scaling_factors, Tensor _zeros, "
+      "awq_sm70_prepare(Tensor _kernel, Tensor _scaling_factors, Tensor "
+      "_zeros, "
       "int group_size, bool interleave_gated_silu) -> Tensor[]");
   ops.impl("awq_sm70_prepare", torch::kCUDA, &awq_sm70_prepare);
 
@@ -242,34 +242,29 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, ops) {
       "nvfp4_gemv_sm70_raw_out(Tensor(a!) out, Tensor _in_feats, "
       "Tensor _kernel, Tensor _scaling_factors, Tensor(b!) partials, "
       "int group_size, int split_k) -> ()");
-  ops.impl("nvfp4_gemv_sm70_raw_out", torch::kCUDA,
-           &nvfp4_gemv_sm70_raw_out);
+  ops.impl("nvfp4_gemv_sm70_raw_out", torch::kCUDA, &nvfp4_gemv_sm70_raw_out);
 
   ops.def(
       "nvfp4_gemv_sm70_warp_out(Tensor(a!) out, Tensor _in_feats, "
       "Tensor _kernel, Tensor _scaling_factors, int group_size) -> ()");
-  ops.impl("nvfp4_gemv_sm70_warp_out", torch::kCUDA,
-           &nvfp4_gemv_sm70_warp_out);
+  ops.impl("nvfp4_gemv_sm70_warp_out", torch::kCUDA, &nvfp4_gemv_sm70_warp_out);
 
   ops.def(
       "nvfp4_gemv_sm70_h2_out(Tensor(a!) out, Tensor _in_feats, "
       "Tensor _kernel, Tensor _scaling_factors, Tensor(b!) partials, "
       "int group_size, int split_k) -> ()");
-  ops.impl("nvfp4_gemv_sm70_h2_out", torch::kCUDA,
-           &nvfp4_gemv_sm70_h2_out);
+  ops.impl("nvfp4_gemv_sm70_h2_out", torch::kCUDA, &nvfp4_gemv_sm70_h2_out);
 
   ops.def(
       "fp8_gemm_sm70_out_auto(Tensor(a!) out, Tensor _in_feats, "
       "Tensor _kernel, Tensor _scaling_factors) -> ()");
-  ops.impl("fp8_gemm_sm70_out_auto", torch::kCUDA,
-           &fp8_gemm_sm70_out_auto);
+  ops.impl("fp8_gemm_sm70_out_auto", torch::kCUDA, &fp8_gemm_sm70_out_auto);
 
   ops.def(
       "fp8_gemm_sm70_out_meta(Tensor(a!) out, Tensor _in_feats, "
       "Tensor _kernel, Tensor _scaling_factors, Tensor _meta, "
       "bool gated_silu) -> ()");
-  ops.impl("fp8_gemm_sm70_out_meta", torch::kCUDA,
-           &fp8_gemm_sm70_out_meta);
+  ops.impl("fp8_gemm_sm70_out_meta", torch::kCUDA, &fp8_gemm_sm70_out_meta);
 
   ops.def(
       "sm70_f16_gemm_out(Tensor(a!) out, Tensor _in_feats, Tensor _kernel, "
@@ -539,7 +534,7 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, ops) {
       "bool exact_per_route) -> ()");
   ops.impl("fp8_moe_single_token_sm70_out", torch::kCUDA,
            &fp8_moe_single_token_sm70_out);
-#endif
+  #endif
 
 #endif
 


### PR DESCRIPTION
Refs #126. Split from Draft PR #131.

## Scope
- Eight core C/CUDA/header files only.
- Excludes csrc/sm70_turbomind, flash-attention-v100, and all Marlin paths.
- Exact mechanical sub-diff of d3b59af9c656413270e37cd55c0bf88e932a1c5d.
- clang-format output only. No runtime behavior change intended.

## Validation
- Focused clang-format hook: passed.
- Focused typos hook: passed.
- Focused SPDX hook: skipped because the repository hook only accepts Python files.
- git diff --check and git show --check: passed.

## Risk
- No physical GPU is available. No GPU runtime, performance, or numerical claim is made.