### PR TITLE
[CI/Build] Normalize Flash-V100 static baseline

### DIFF
--- a/flash-attention-v100/include/fused_mha.h
+++ b/flash-attention-v100/include/fused_mha.h
@@ -8,243 +8,122 @@
 #include <ATen/ATen.h>
 
 std::vector<at::Tensor> flash_attention_forward(
-    at::Tensor& q,
-    const at::Tensor& k,
-    const at::Tensor& v,
-    std::optional<at::Tensor>& out_,
-    std::optional<at::Tensor>& alibi_slopes_,
-    const float p_dropout,
-    const float softmax_scale,
-    bool is_causal,
-    int window_size_left,
-    int window_size_right,
-    const float softcap,
-    const bool return_softmax,
-    std::optional<at::Generator> gen_
-);
+    at::Tensor& q, const at::Tensor& k, const at::Tensor& v,
+    std::optional<at::Tensor>& out_, std::optional<at::Tensor>& alibi_slopes_,
+    const float p_dropout, const float softmax_scale, bool is_causal,
+    int window_size_left, int window_size_right, const float softcap,
+    const bool return_softmax, std::optional<at::Generator> gen_);
 
-at::Tensor flash_attention_qk_scores(
-    const at::Tensor& q,
-    const at::Tensor& k,
-    const float softmax_scale,
-    const bool is_causal
-);
+at::Tensor flash_attention_qk_scores(const at::Tensor& q, const at::Tensor& k,
+                                     const float softmax_scale,
+                                     const bool is_causal);
 
 at::Tensor flash_attention_decode_paged(
-    const at::Tensor& q,
-    const at::Tensor& k_cache,
-    const at::Tensor& v_cache,
-    std::optional<at::Tensor>& out_,
-    const at::Tensor& block_table,
-    const at::Tensor& seq_lens,
-    at::Tensor& tmp_out,
-    at::Tensor& max_logits,
-    at::Tensor& exp_sums,
-    const at::Tensor& active_num_partitions,
-    const float softmax_scale,
-    const int partition_size,
-    const int launch_num_partitions,
-    const std::string& kv_cache_dtype,
-    const float k_scale,
-    const float v_scale,
-    const int window_size_left,
-    const int window_size_right
-);
+    const at::Tensor& q, const at::Tensor& k_cache, const at::Tensor& v_cache,
+    std::optional<at::Tensor>& out_, const at::Tensor& block_table,
+    const at::Tensor& seq_lens, at::Tensor& tmp_out, at::Tensor& max_logits,
+    at::Tensor& exp_sums, const at::Tensor& active_num_partitions,
+    const float softmax_scale, const int partition_size,
+    const int launch_num_partitions, const std::string& kv_cache_dtype,
+    const float k_scale, const float v_scale, const int window_size_left,
+    const int window_size_right);
 
 at::Tensor flash_attention_decode_paged_xqa(
-    const at::Tensor& q,
-    const at::Tensor& k_cache,
-    const at::Tensor& v_cache,
-    std::optional<at::Tensor>& out_,
-    const at::Tensor& block_table,
-    const at::Tensor& seq_lens,
-    at::Tensor& tmp_out,
-    at::Tensor& max_logits,
-    at::Tensor& exp_sums,
-    const at::Tensor& active_num_partitions,
-    const float softmax_scale,
-    const int partition_size,
-    const int launch_num_partitions,
-    const std::string& kv_cache_dtype,
-    const float k_scale,
-    const float v_scale,
-    const int window_size_left,
-    const int window_size_right
-);
+    const at::Tensor& q, const at::Tensor& k_cache, const at::Tensor& v_cache,
+    std::optional<at::Tensor>& out_, const at::Tensor& block_table,
+    const at::Tensor& seq_lens, at::Tensor& tmp_out, at::Tensor& max_logits,
+    at::Tensor& exp_sums, const at::Tensor& active_num_partitions,
+    const float softmax_scale, const int partition_size,
+    const int launch_num_partitions, const std::string& kv_cache_dtype,
+    const float k_scale, const float v_scale, const int window_size_left,
+    const int window_size_right);
 
 at::Tensor flash_attention_decode_paged_xqa_staged(
-    const at::Tensor& q,
-    const at::Tensor& k_cache,
-    const at::Tensor& v_cache,
-    std::optional<at::Tensor>& out_,
-    const at::Tensor& block_table,
-    const at::Tensor& seq_lens,
-    at::Tensor& tmp_out,
-    at::Tensor& max_logits,
-    at::Tensor& exp_sums,
-    at::Tensor& online_rescales,
-    const at::Tensor& active_num_partitions,
-    const float softmax_scale,
-    const int partition_size,
-    const int launch_num_partitions,
-    const std::string& kv_cache_dtype,
-    const float k_scale,
-    const float v_scale,
-    const int window_size_left,
-    const int window_size_right
-);
+    const at::Tensor& q, const at::Tensor& k_cache, const at::Tensor& v_cache,
+    std::optional<at::Tensor>& out_, const at::Tensor& block_table,
+    const at::Tensor& seq_lens, at::Tensor& tmp_out, at::Tensor& max_logits,
+    at::Tensor& exp_sums, at::Tensor& online_rescales,
+    const at::Tensor& active_num_partitions, const float softmax_scale,
+    const int partition_size, const int launch_num_partitions,
+    const std::string& kv_cache_dtype, const float k_scale, const float v_scale,
+    const int window_size_left, const int window_size_right);
 
 at::Tensor flash_attention_decode_paged_wmma(
-    const at::Tensor& q,
-    const at::Tensor& k_cache,
-    const at::Tensor& v_cache,
-    std::optional<at::Tensor>& out_,
-    const at::Tensor& block_table,
-    const at::Tensor& seq_lens,
-    const float softmax_scale,
-    const std::string& kv_cache_dtype,
-    const float k_scale,
-    const float v_scale
-);
+    const at::Tensor& q, const at::Tensor& k_cache, const at::Tensor& v_cache,
+    std::optional<at::Tensor>& out_, const at::Tensor& block_table,
+    const at::Tensor& seq_lens, const float softmax_scale,
+    const std::string& kv_cache_dtype, const float k_scale,
+    const float v_scale);
 
 at::Tensor flash_attention_decode_qk_scores(
-    const at::Tensor& q,
-    const at::Tensor& k_cache,
-    const at::Tensor& block_table,
-    const at::Tensor& seq_lens,
-    const float softmax_scale,
-    const int partition_size,
-    const std::string& kv_cache_dtype,
-    const float k_scale
-);
+    const at::Tensor& q, const at::Tensor& k_cache,
+    const at::Tensor& block_table, const at::Tensor& seq_lens,
+    const float softmax_scale, const int partition_size,
+    const std::string& kv_cache_dtype, const float k_scale);
 
 at::Tensor flash_attention_turboquant_decode_paged(
-    const at::Tensor& q_rot,
-    const at::Tensor& kv_cache,
-    std::optional<at::Tensor>& out_,
-    const at::Tensor& block_table,
-    const at::Tensor& seq_lens,
-    at::Tensor& tmp_out,
-    at::Tensor& max_logits,
-    at::Tensor& exp_sums,
-    const at::Tensor& centroids,
-    const float softmax_scale,
-    const int partition_size,
-    const int mse_bits,
-    const int value_quant_bits,
-    const bool norm_correction
-);
+    const at::Tensor& q_rot, const at::Tensor& kv_cache,
+    std::optional<at::Tensor>& out_, const at::Tensor& block_table,
+    const at::Tensor& seq_lens, at::Tensor& tmp_out, at::Tensor& max_logits,
+    at::Tensor& exp_sums, const at::Tensor& centroids,
+    const float softmax_scale, const int partition_size, const int mse_bits,
+    const int value_quant_bits, const bool norm_correction);
 
 at::Tensor flash_attention_prefill_paged(
-    const at::Tensor& q,
-    const at::Tensor& k_cache,
-    const at::Tensor& v_cache,
-    std::optional<at::Tensor>& out_,
-    const at::Tensor& block_table,
-    const at::Tensor& seq_lens,
-    const float softmax_scale,
-    const std::string& kv_cache_dtype,
-    const float k_scale,
-    const float v_scale,
-    const bool is_causal,
-    const int window_size_left,
-    const int window_size_right
-);
+    const at::Tensor& q, const at::Tensor& k_cache, const at::Tensor& v_cache,
+    std::optional<at::Tensor>& out_, const at::Tensor& block_table,
+    const at::Tensor& seq_lens, const float softmax_scale,
+    const std::string& kv_cache_dtype, const float k_scale, const float v_scale,
+    const bool is_causal, const int window_size_left,
+    const int window_size_right);
 
 std::vector<at::Tensor>
 flash_attention_prefill_paged_d256_bm32_allp_pair_scratch(
-    const at::Tensor& q,
-    const at::Tensor& k_cache,
-    const at::Tensor& v_cache,
-    std::optional<at::Tensor>& out_,
-    std::optional<at::Tensor>& softmax_lse_,
-    const at::Tensor& block_table,
-    const at::Tensor& seq_lens,
-    const float softmax_scale
-);
+    const at::Tensor& q, const at::Tensor& k_cache, const at::Tensor& v_cache,
+    std::optional<at::Tensor>& out_, std::optional<at::Tensor>& softmax_lse_,
+    const at::Tensor& block_table, const at::Tensor& seq_lens,
+    const float softmax_scale);
 
 std::vector<at::Tensor>
 flash_attention_prefill_paged_d256_bm32_allp_pair_scratch_splitkv3(
-    const at::Tensor& q,
-    const at::Tensor& k_cache,
-    const at::Tensor& v_cache,
-    std::optional<at::Tensor>& out_,
-    std::optional<at::Tensor>& softmax_lse_,
-    at::Tensor& split_tmp_out,
-    at::Tensor& split_tmp_row_max,
-    at::Tensor& split_tmp_row_sum,
-    const at::Tensor& block_table,
-    const int64_t actual_n,
-    const float softmax_scale
-);
+    const at::Tensor& q, const at::Tensor& k_cache, const at::Tensor& v_cache,
+    std::optional<at::Tensor>& out_, std::optional<at::Tensor>& softmax_lse_,
+    at::Tensor& split_tmp_out, at::Tensor& split_tmp_row_max,
+    at::Tensor& split_tmp_row_sum, const at::Tensor& block_table,
+    const int64_t actual_n, const float softmax_scale);
 
 at::Tensor flash_attention_prefill_paged_bfla(
-    const at::Tensor& q,
-    const at::Tensor& k_cache,
-    const at::Tensor& v_cache,
-    std::optional<at::Tensor>& out_,
-    const at::Tensor& block_table,
-    const at::Tensor& seq_lens,
-    const at::Tensor& bfla_block_mask,
-    const int bfla_mask_block_n,
-    const float softmax_scale,
-    const std::string& kv_cache_dtype,
-    const float k_scale,
-    const float v_scale,
-    const bool is_causal,
-    const int window_size_left,
-    const int window_size_right
-);
+    const at::Tensor& q, const at::Tensor& k_cache, const at::Tensor& v_cache,
+    std::optional<at::Tensor>& out_, const at::Tensor& block_table,
+    const at::Tensor& seq_lens, const at::Tensor& bfla_block_mask,
+    const int bfla_mask_block_n, const float softmax_scale,
+    const std::string& kv_cache_dtype, const float k_scale, const float v_scale,
+    const bool is_causal, const int window_size_left,
+    const int window_size_right);
 
 at::Tensor flash_attention_prefill_paged_splitkv(
-    const at::Tensor& q,
-    const at::Tensor& k_cache,
-    const at::Tensor& v_cache,
-    std::optional<at::Tensor>& out_,
-    const at::Tensor& block_table,
-    const at::Tensor& seq_lens,
-    const float softmax_scale,
-    const std::string& kv_cache_dtype,
-    const float k_scale,
-    const float v_scale,
-    const bool is_causal,
-    const int window_size_left,
-    const int window_size_right,
-    const int split_kv_tokens,
-    const int max_seq_len_hint
-);
+    const at::Tensor& q, const at::Tensor& k_cache, const at::Tensor& v_cache,
+    std::optional<at::Tensor>& out_, const at::Tensor& block_table,
+    const at::Tensor& seq_lens, const float softmax_scale,
+    const std::string& kv_cache_dtype, const float k_scale, const float v_scale,
+    const bool is_causal, const int window_size_left,
+    const int window_size_right, const int split_kv_tokens,
+    const int max_seq_len_hint);
 
 void flash_attention_fp8_e5m2_paged_kv_to_fp16(
-    const at::Tensor& key_cache,
-    const at::Tensor& value_cache,
-    const at::Tensor& block_table,
-    const at::Tensor& seq_lens,
-    at::Tensor& key_out,
-    at::Tensor& value_out,
-    const float key_scale,
-    const float value_scale
-);
+    const at::Tensor& key_cache, const at::Tensor& value_cache,
+    const at::Tensor& block_table, const at::Tensor& seq_lens,
+    at::Tensor& key_out, at::Tensor& value_out, const float key_scale,
+    const float value_scale);
 
 std::vector<at::Tensor> flash_attention_backward(
-    const at::Tensor& dout,
-    const at::Tensor& q,
-    const at::Tensor& k,
-    const at::Tensor& v,
-    const at::Tensor& out,
-    const at::Tensor& softmax_lse,
-    std::optional<at::Tensor>& dq_,
-    std::optional<at::Tensor>& dk_,
-    std::optional<at::Tensor>& dv_,
-    std::optional<at::Tensor>& alibi_slopes_,
-    const float p_dropout,
-    const float softmax_scale,
-    const bool is_causal,
-    int window_size_left,
-    int window_size_right,
-    const float softcap,
-    const bool deterministic,
-    std::optional<at::Generator> gen_,
-    std::optional<at::Tensor>& rng_state
-);
+    const at::Tensor& dout, const at::Tensor& q, const at::Tensor& k,
+    const at::Tensor& v, const at::Tensor& out, const at::Tensor& softmax_lse,
+    std::optional<at::Tensor>& dq_, std::optional<at::Tensor>& dk_,
+    std::optional<at::Tensor>& dv_, std::optional<at::Tensor>& alibi_slopes_,
+    const float p_dropout, const float softmax_scale, const bool is_causal,
+    int window_size_left, int window_size_right, const float softcap,
+    const bool deterministic, std::optional<at::Generator> gen_,
+    std::optional<at::Tensor>& rng_state);
 
 #endif

--- a/flash-attention-v100/include/fused_mma.h
+++ b/flash-attention-v100/include/fused_mma.h
@@ -2,7 +2,7 @@
 #define FUSED_MMA_H
 
 #if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ != 700)
-#error "Volta WMMA: This header is for sm_70 ONLY! Compile with -arch=sm_70"
+  #error "Volta WMMA: This header is for sm_70 ONLY! Compile with -arch=sm_70"
 #endif
 
 #include <cuda_fp16.h>
@@ -15,385 +15,409 @@ struct matrix_a {};
 struct matrix_b {};
 struct accumulator {};
 
-enum layout_t {
-    mem_row_major,
-    mem_col_major
-};
+enum layout_t { mem_row_major, mem_col_major };
 
 template <typename Use, int M, int N, int K, typename T, typename Layout = void>
 struct fragment;
 
-template <> struct fragment<matrix_a, 16, 16, 16, half, row_major> { uint32_t x[8]; static constexpr int num_elements = 16; };
-template <> struct fragment<matrix_a, 16, 16, 16, half, col_major> { uint32_t x[8]; static constexpr int num_elements = 16; };
+template <>
+struct fragment<matrix_a, 16, 16, 16, half, row_major> {
+  uint32_t x[8];
+  static constexpr int num_elements = 16;
+};
+template <>
+struct fragment<matrix_a, 16, 16, 16, half, col_major> {
+  uint32_t x[8];
+  static constexpr int num_elements = 16;
+};
 
-template <> struct fragment<matrix_a, 32, 8, 16, half, row_major>  { uint32_t x[8]; static constexpr int num_elements = 16; };
-template <> struct fragment<matrix_a, 32, 8, 16, half, col_major>  { uint32_t x[8]; static constexpr int num_elements = 16; };
+template <>
+struct fragment<matrix_a, 32, 8, 16, half, row_major> {
+  uint32_t x[8];
+  static constexpr int num_elements = 16;
+};
+template <>
+struct fragment<matrix_a, 32, 8, 16, half, col_major> {
+  uint32_t x[8];
+  static constexpr int num_elements = 16;
+};
 
-template <> struct fragment<matrix_a, 8, 32, 16, half, row_major>  { uint32_t x[8]; static constexpr int num_elements = 16; };
-template <> struct fragment<matrix_a, 8, 32, 16, half, col_major>  { uint32_t x[8]; static constexpr int num_elements = 16; };
+template <>
+struct fragment<matrix_a, 8, 32, 16, half, row_major> {
+  uint32_t x[8];
+  static constexpr int num_elements = 16;
+};
+template <>
+struct fragment<matrix_a, 8, 32, 16, half, col_major> {
+  uint32_t x[8];
+  static constexpr int num_elements = 16;
+};
 
-template <> struct fragment<matrix_b, 16, 16, 16, half, row_major> { uint32_t x[8]; static constexpr int num_elements = 16; };
-template <> struct fragment<matrix_b, 16, 16, 16, half, col_major> { uint32_t x[8]; static constexpr int num_elements = 16; };
+template <>
+struct fragment<matrix_b, 16, 16, 16, half, row_major> {
+  uint32_t x[8];
+  static constexpr int num_elements = 16;
+};
+template <>
+struct fragment<matrix_b, 16, 16, 16, half, col_major> {
+  uint32_t x[8];
+  static constexpr int num_elements = 16;
+};
 
-template <> struct fragment<matrix_b, 32, 8, 16, half, row_major>  { uint32_t x[8]; static constexpr int num_elements = 16; };
-template <> struct fragment<matrix_b, 32, 8, 16, half, col_major>  { uint32_t x[8]; static constexpr int num_elements = 16; };
+template <>
+struct fragment<matrix_b, 32, 8, 16, half, row_major> {
+  uint32_t x[8];
+  static constexpr int num_elements = 16;
+};
+template <>
+struct fragment<matrix_b, 32, 8, 16, half, col_major> {
+  uint32_t x[8];
+  static constexpr int num_elements = 16;
+};
 
-template <> struct fragment<matrix_b, 8, 32, 16, half, row_major>  { uint32_t x[8]; static constexpr int num_elements = 16; };
-template <> struct fragment<matrix_b, 8, 32, 16, half, col_major>  { uint32_t x[8]; static constexpr int num_elements = 16; };
+template <>
+struct fragment<matrix_b, 8, 32, 16, half, row_major> {
+  uint32_t x[8];
+  static constexpr int num_elements = 16;
+};
+template <>
+struct fragment<matrix_b, 8, 32, 16, half, col_major> {
+  uint32_t x[8];
+  static constexpr int num_elements = 16;
+};
 
-template <> struct fragment<accumulator, 16, 16, 16, float> { float x[8]; static constexpr int num_elements = 8; };
-template <> struct fragment<accumulator, 32, 8, 16, float>  { float x[8]; static constexpr int num_elements = 8; };
-template <> struct fragment<accumulator, 8, 32, 16, float>  { float x[8]; static constexpr int num_elements = 8; };
+template <>
+struct fragment<accumulator, 16, 16, 16, float> {
+  float x[8];
+  static constexpr int num_elements = 8;
+};
+template <>
+struct fragment<accumulator, 32, 8, 16, float> {
+  float x[8];
+  static constexpr int num_elements = 8;
+};
+template <>
+struct fragment<accumulator, 8, 32, 16, float> {
+  float x[8];
+  static constexpr int num_elements = 8;
+};
 
 __device__ __forceinline__ unsigned get_lane_id() {
-    unsigned lane_id;
-    asm volatile ("mov.u32 %0, %%laneid;" : "=r"(lane_id));
-    return lane_id;
+  unsigned lane_id;
+  asm volatile("mov.u32 %0, %%laneid;" : "=r"(lane_id));
+  return lane_id;
 }
 
 template <int M, int N, int K>
-__device__ __forceinline__ void fill_fragment(fragment<accumulator, M, N, K, float>& frag, float value) {
-    #pragma unroll
-    for (int i = 0; i < 8; ++i) frag.x[i] = value;
+__device__ __forceinline__ void fill_fragment(
+    fragment<accumulator, M, N, K, float>& frag, float value) {
+#pragma unroll
+  for (int i = 0; i < 8; ++i) frag.x[i] = value;
 }
 
 __device__ __forceinline__ void load_matrix_sync(
-    fragment<matrix_a, 16, 16, 16, half, row_major>& frag,
-    const half* smem_ptr, unsigned ldm) {
+    fragment<matrix_a, 16, 16, 16, half, row_major>& frag, const half* smem_ptr,
+    unsigned ldm) {
+  asm volatile(
+      "wmma.load.a.sync.aligned.row.m16n16k16.f16 "
+      "{%0,%1,%2,%3,%4,%5,%6,%7}, [%8], %9;"
+      : "=r"(frag.x[0]), "=r"(frag.x[1]), "=r"(frag.x[2]), "=r"(frag.x[3]),
+        "=r"(frag.x[4]), "=r"(frag.x[5]), "=r"(frag.x[6]), "=r"(frag.x[7])
+      : "l"(smem_ptr), "r"(ldm)
+      : "memory");
+}
+
+__device__ __forceinline__ void load_matrix_sync(
+    fragment<matrix_a, 16, 16, 16, half, col_major>& frag, const half* smem_ptr,
+    unsigned ldm) {
+  asm volatile(
+      "wmma.load.a.sync.aligned.col.m16n16k16.f16 "
+      "{%0,%1,%2,%3,%4,%5,%6,%7}, [%8], %9;"
+      : "=r"(frag.x[0]), "=r"(frag.x[1]), "=r"(frag.x[2]), "=r"(frag.x[3]),
+        "=r"(frag.x[4]), "=r"(frag.x[5]), "=r"(frag.x[6]), "=r"(frag.x[7])
+      : "l"(smem_ptr), "r"(ldm)
+      : "memory");
+}
+
+__device__ __forceinline__ void load_matrix_sync(
+    fragment<matrix_b, 16, 16, 16, half, row_major>& frag, const half* smem_ptr,
+    unsigned ldm) {
+  asm volatile(
+      "wmma.load.b.sync.aligned.row.m16n16k16.f16 "
+      "{%0,%1,%2,%3,%4,%5,%6,%7}, [%8], %9;"
+      : "=r"(frag.x[0]), "=r"(frag.x[1]), "=r"(frag.x[2]), "=r"(frag.x[3]),
+        "=r"(frag.x[4]), "=r"(frag.x[5]), "=r"(frag.x[6]), "=r"(frag.x[7])
+      : "l"(smem_ptr), "r"(ldm)
+      : "memory");
+}
+
+__device__ __forceinline__ void load_matrix_sync(
+    fragment<matrix_b, 16, 16, 16, half, col_major>& frag, const half* smem_ptr,
+    unsigned ldm) {
+  asm volatile(
+      "wmma.load.b.sync.aligned.col.m16n16k16.f16 "
+      "{%0,%1,%2,%3,%4,%5,%6,%7}, [%8], %9;"
+      : "=r"(frag.x[0]), "=r"(frag.x[1]), "=r"(frag.x[2]), "=r"(frag.x[3]),
+        "=r"(frag.x[4]), "=r"(frag.x[5]), "=r"(frag.x[6]), "=r"(frag.x[7])
+      : "l"(smem_ptr), "r"(ldm)
+      : "memory");
+}
+
+__device__ __forceinline__ void load_matrix_sync(
+    fragment<accumulator, 16, 16, 16, float>& frag, const float* smem_ptr,
+    unsigned ldm, layout_t layout) {
+  if (layout == mem_row_major) {
     asm volatile(
-        "wmma.load.a.sync.aligned.row.m16n16k16.f16 "
+        "wmma.load.c.sync.aligned.row.m16n16k16.f32 "
         "{%0,%1,%2,%3,%4,%5,%6,%7}, [%8], %9;"
-        : "=r"(frag.x[0]), "=r"(frag.x[1]), "=r"(frag.x[2]), "=r"(frag.x[3]),
-          "=r"(frag.x[4]), "=r"(frag.x[5]), "=r"(frag.x[6]), "=r"(frag.x[7])
+        : "=f"(frag.x[0]), "=f"(frag.x[1]), "=f"(frag.x[2]), "=f"(frag.x[3]),
+          "=f"(frag.x[4]), "=f"(frag.x[5]), "=f"(frag.x[6]), "=f"(frag.x[7])
         : "l"(smem_ptr), "r"(ldm)
-        : "memory"
-    );
-}
-
-__device__ __forceinline__ void load_matrix_sync(
-    fragment<matrix_a, 16, 16, 16, half, col_major>& frag,
-    const half* smem_ptr, unsigned ldm) {
+        : "memory");
+  } else {
     asm volatile(
-        "wmma.load.a.sync.aligned.col.m16n16k16.f16 "
+        "wmma.load.c.sync.aligned.col.m16n16k16.f32 "
         "{%0,%1,%2,%3,%4,%5,%6,%7}, [%8], %9;"
-        : "=r"(frag.x[0]), "=r"(frag.x[1]), "=r"(frag.x[2]), "=r"(frag.x[3]),
-          "=r"(frag.x[4]), "=r"(frag.x[5]), "=r"(frag.x[6]), "=r"(frag.x[7])
+        : "=f"(frag.x[0]), "=f"(frag.x[1]), "=f"(frag.x[2]), "=f"(frag.x[3]),
+          "=f"(frag.x[4]), "=f"(frag.x[5]), "=f"(frag.x[6]), "=f"(frag.x[7])
         : "l"(smem_ptr), "r"(ldm)
-        : "memory"
-    );
+        : "memory");
+  }
 }
 
 __device__ __forceinline__ void load_matrix_sync(
-    fragment<matrix_b, 16, 16, 16, half, row_major>& frag,
-    const half* smem_ptr, unsigned ldm) {
+    fragment<matrix_a, 32, 8, 16, half, row_major>& frag, const half* smem_ptr,
+    unsigned ldm) {
+  asm volatile(
+      "wmma.load.a.sync.aligned.row.m32n8k16.f16 "
+      "{%0,%1,%2,%3,%4,%5,%6,%7}, [%8], %9;"
+      : "=r"(frag.x[0]), "=r"(frag.x[1]), "=r"(frag.x[2]), "=r"(frag.x[3]),
+        "=r"(frag.x[4]), "=r"(frag.x[5]), "=r"(frag.x[6]), "=r"(frag.x[7])
+      : "l"(smem_ptr), "r"(ldm)
+      : "memory");
+}
+
+__device__ __forceinline__ void load_matrix_sync(
+    fragment<matrix_a, 32, 8, 16, half, col_major>& frag, const half* smem_ptr,
+    unsigned ldm) {
+  asm volatile(
+      "wmma.load.a.sync.aligned.col.m32n8k16.f16 "
+      "{%0,%1,%2,%3,%4,%5,%6,%7}, [%8], %9;"
+      : "=r"(frag.x[0]), "=r"(frag.x[1]), "=r"(frag.x[2]), "=r"(frag.x[3]),
+        "=r"(frag.x[4]), "=r"(frag.x[5]), "=r"(frag.x[6]), "=r"(frag.x[7])
+      : "l"(smem_ptr), "r"(ldm)
+      : "memory");
+}
+
+__device__ __forceinline__ void load_matrix_sync(
+    fragment<matrix_b, 32, 8, 16, half, row_major>& frag, const half* smem_ptr,
+    unsigned ldm) {
+  asm volatile(
+      "wmma.load.b.sync.aligned.row.m32n8k16.f16 "
+      "{%0,%1,%2,%3,%4,%5,%6,%7}, [%8], %9;"
+      : "=r"(frag.x[0]), "=r"(frag.x[1]), "=r"(frag.x[2]), "=r"(frag.x[3]),
+        "=r"(frag.x[4]), "=r"(frag.x[5]), "=r"(frag.x[6]), "=r"(frag.x[7])
+      : "l"(smem_ptr), "r"(ldm)
+      : "memory");
+}
+
+__device__ __forceinline__ void load_matrix_sync(
+    fragment<matrix_b, 32, 8, 16, half, col_major>& frag, const half* smem_ptr,
+    unsigned ldm) {
+  asm volatile(
+      "wmma.load.b.sync.aligned.col.m32n8k16.f16 "
+      "{%0,%1,%2,%3,%4,%5,%6,%7}, [%8], %9;"
+      : "=r"(frag.x[0]), "=r"(frag.x[1]), "=r"(frag.x[2]), "=r"(frag.x[3]),
+        "=r"(frag.x[4]), "=r"(frag.x[5]), "=r"(frag.x[6]), "=r"(frag.x[7])
+      : "l"(smem_ptr), "r"(ldm)
+      : "memory");
+}
+
+__device__ __forceinline__ void load_matrix_sync(
+    fragment<accumulator, 32, 8, 16, float>& frag, const float* smem_ptr,
+    unsigned ldm, layout_t layout) {
+  if (layout == mem_row_major) {
     asm volatile(
-        "wmma.load.b.sync.aligned.row.m16n16k16.f16 "
+        "wmma.load.c.sync.aligned.row.m32n8k16.f32 "
         "{%0,%1,%2,%3,%4,%5,%6,%7}, [%8], %9;"
-        : "=r"(frag.x[0]), "=r"(frag.x[1]), "=r"(frag.x[2]), "=r"(frag.x[3]),
-          "=r"(frag.x[4]), "=r"(frag.x[5]), "=r"(frag.x[6]), "=r"(frag.x[7])
+        : "=f"(frag.x[0]), "=f"(frag.x[1]), "=f"(frag.x[2]), "=f"(frag.x[3]),
+          "=f"(frag.x[4]), "=f"(frag.x[5]), "=f"(frag.x[6]), "=f"(frag.x[7])
         : "l"(smem_ptr), "r"(ldm)
-        : "memory"
-    );
-}
-
-__device__ __forceinline__ void load_matrix_sync(
-    fragment<matrix_b, 16, 16, 16, half, col_major>& frag,
-    const half* smem_ptr, unsigned ldm) {
+        : "memory");
+  } else {
     asm volatile(
-        "wmma.load.b.sync.aligned.col.m16n16k16.f16 "
+        "wmma.load.c.sync.aligned.col.m32n8k16.f32 "
         "{%0,%1,%2,%3,%4,%5,%6,%7}, [%8], %9;"
-        : "=r"(frag.x[0]), "=r"(frag.x[1]), "=r"(frag.x[2]), "=r"(frag.x[3]),
-          "=r"(frag.x[4]), "=r"(frag.x[5]), "=r"(frag.x[6]), "=r"(frag.x[7])
+        : "=f"(frag.x[0]), "=f"(frag.x[1]), "=f"(frag.x[2]), "=f"(frag.x[3]),
+          "=f"(frag.x[4]), "=f"(frag.x[5]), "=f"(frag.x[6]), "=f"(frag.x[7])
         : "l"(smem_ptr), "r"(ldm)
-        : "memory"
-    );
+        : "memory");
+  }
 }
 
 __device__ __forceinline__ void load_matrix_sync(
-    fragment<accumulator, 16, 16, 16, float>& frag,
-    const float* smem_ptr, unsigned ldm, layout_t layout) {
-    if (layout == mem_row_major) {
-        asm volatile(
-            "wmma.load.c.sync.aligned.row.m16n16k16.f32 "
-            "{%0,%1,%2,%3,%4,%5,%6,%7}, [%8], %9;"
-            : "=f"(frag.x[0]), "=f"(frag.x[1]), "=f"(frag.x[2]), "=f"(frag.x[3]),
-              "=f"(frag.x[4]), "=f"(frag.x[5]), "=f"(frag.x[6]), "=f"(frag.x[7])
-            : "l"(smem_ptr), "r"(ldm)
-            : "memory"
-        );
-    } else {
-        asm volatile(
-            "wmma.load.c.sync.aligned.col.m16n16k16.f32 "
-            "{%0,%1,%2,%3,%4,%5,%6,%7}, [%8], %9;"
-            : "=f"(frag.x[0]), "=f"(frag.x[1]), "=f"(frag.x[2]), "=f"(frag.x[3]),
-              "=f"(frag.x[4]), "=f"(frag.x[5]), "=f"(frag.x[6]), "=f"(frag.x[7])
-            : "l"(smem_ptr), "r"(ldm)
-            : "memory"
-        );
-    }
+    fragment<matrix_a, 8, 32, 16, half, row_major>& frag, const half* smem_ptr,
+    unsigned ldm) {
+  asm volatile(
+      "wmma.load.a.sync.aligned.row.m8n32k16.f16 "
+      "{%0,%1,%2,%3,%4,%5,%6,%7}, [%8], %9;"
+      : "=r"(frag.x[0]), "=r"(frag.x[1]), "=r"(frag.x[2]), "=r"(frag.x[3]),
+        "=r"(frag.x[4]), "=r"(frag.x[5]), "=r"(frag.x[6]), "=r"(frag.x[7])
+      : "l"(smem_ptr), "r"(ldm)
+      : "memory");
 }
 
 __device__ __forceinline__ void load_matrix_sync(
-    fragment<matrix_a, 32, 8, 16, half, row_major>& frag,
-    const half* smem_ptr, unsigned ldm) {
+    fragment<matrix_a, 8, 32, 16, half, col_major>& frag, const half* smem_ptr,
+    unsigned ldm) {
+  asm volatile(
+      "wmma.load.a.sync.aligned.col.m8n32k16.f16 "
+      "{%0,%1,%2,%3,%4,%5,%6,%7}, [%8], %9;"
+      : "=r"(frag.x[0]), "=r"(frag.x[1]), "=r"(frag.x[2]), "=r"(frag.x[3]),
+        "=r"(frag.x[4]), "=r"(frag.x[5]), "=r"(frag.x[6]), "=r"(frag.x[7])
+      : "l"(smem_ptr), "r"(ldm)
+      : "memory");
+}
+
+__device__ __forceinline__ void load_matrix_sync(
+    fragment<matrix_b, 8, 32, 16, half, row_major>& frag, const half* smem_ptr,
+    unsigned ldm) {
+  asm volatile(
+      "wmma.load.b.sync.aligned.row.m8n32k16.f16 "
+      "{%0,%1,%2,%3,%4,%5,%6,%7}, [%8], %9;"
+      : "=r"(frag.x[0]), "=r"(frag.x[1]), "=r"(frag.x[2]), "=r"(frag.x[3]),
+        "=r"(frag.x[4]), "=r"(frag.x[5]), "=r"(frag.x[6]), "=r"(frag.x[7])
+      : "l"(smem_ptr), "r"(ldm)
+      : "memory");
+}
+
+__device__ __forceinline__ void load_matrix_sync(
+    fragment<matrix_b, 8, 32, 16, half, col_major>& frag, const half* smem_ptr,
+    unsigned ldm) {
+  asm volatile(
+      "wmma.load.b.sync.aligned.col.m8n32k16.f16 "
+      "{%0,%1,%2,%3,%4,%5,%6,%7}, [%8], %9;"
+      : "=r"(frag.x[0]), "=r"(frag.x[1]), "=r"(frag.x[2]), "=r"(frag.x[3]),
+        "=r"(frag.x[4]), "=r"(frag.x[5]), "=r"(frag.x[6]), "=r"(frag.x[7])
+      : "l"(smem_ptr), "r"(ldm)
+      : "memory");
+}
+
+__device__ __forceinline__ void load_matrix_sync(
+    fragment<accumulator, 8, 32, 16, float>& frag, const float* smem_ptr,
+    unsigned ldm, layout_t layout) {
+  if (layout == mem_row_major) {
     asm volatile(
-        "wmma.load.a.sync.aligned.row.m32n8k16.f16 "
+        "wmma.load.c.sync.aligned.row.m8n32k16.f32 "
         "{%0,%1,%2,%3,%4,%5,%6,%7}, [%8], %9;"
-        : "=r"(frag.x[0]), "=r"(frag.x[1]), "=r"(frag.x[2]), "=r"(frag.x[3]),
-          "=r"(frag.x[4]), "=r"(frag.x[5]), "=r"(frag.x[6]), "=r"(frag.x[7])
+        : "=f"(frag.x[0]), "=f"(frag.x[1]), "=f"(frag.x[2]), "=f"(frag.x[3]),
+          "=f"(frag.x[4]), "=f"(frag.x[5]), "=f"(frag.x[6]), "=f"(frag.x[7])
         : "l"(smem_ptr), "r"(ldm)
-        : "memory"
-    );
-}
-
-__device__ __forceinline__ void load_matrix_sync(
-    fragment<matrix_a, 32, 8, 16, half, col_major>& frag,
-    const half* smem_ptr, unsigned ldm) {
+        : "memory");
+  } else {
     asm volatile(
-        "wmma.load.a.sync.aligned.col.m32n8k16.f16 "
+        "wmma.load.c.sync.aligned.col.m8n32k16.f32 "
         "{%0,%1,%2,%3,%4,%5,%6,%7}, [%8], %9;"
-        : "=r"(frag.x[0]), "=r"(frag.x[1]), "=r"(frag.x[2]), "=r"(frag.x[3]),
-          "=r"(frag.x[4]), "=r"(frag.x[5]), "=r"(frag.x[6]), "=r"(frag.x[7])
+        : "=f"(frag.x[0]), "=f"(frag.x[1]), "=f"(frag.x[2]), "=f"(frag.x[3]),
+          "=f"(frag.x[4]), "=f"(frag.x[5]), "=f"(frag.x[6]), "=f"(frag.x[7])
         : "l"(smem_ptr), "r"(ldm)
-        : "memory"
-    );
-}
-
-__device__ __forceinline__ void load_matrix_sync(
-    fragment<matrix_b, 32, 8, 16, half, row_major>& frag,
-    const half* smem_ptr, unsigned ldm) {
-    asm volatile(
-        "wmma.load.b.sync.aligned.row.m32n8k16.f16 "
-        "{%0,%1,%2,%3,%4,%5,%6,%7}, [%8], %9;"
-        : "=r"(frag.x[0]), "=r"(frag.x[1]), "=r"(frag.x[2]), "=r"(frag.x[3]),
-          "=r"(frag.x[4]), "=r"(frag.x[5]), "=r"(frag.x[6]), "=r"(frag.x[7])
-        : "l"(smem_ptr), "r"(ldm)
-        : "memory"
-    );
-}
-
-__device__ __forceinline__ void load_matrix_sync(
-    fragment<matrix_b, 32, 8, 16, half, col_major>& frag,
-    const half* smem_ptr, unsigned ldm) {
-    asm volatile(
-        "wmma.load.b.sync.aligned.col.m32n8k16.f16 "
-        "{%0,%1,%2,%3,%4,%5,%6,%7}, [%8], %9;"
-        : "=r"(frag.x[0]), "=r"(frag.x[1]), "=r"(frag.x[2]), "=r"(frag.x[3]),
-          "=r"(frag.x[4]), "=r"(frag.x[5]), "=r"(frag.x[6]), "=r"(frag.x[7])
-        : "l"(smem_ptr), "r"(ldm)
-        : "memory"
-    );
-}
-
-__device__ __forceinline__ void load_matrix_sync(
-    fragment<accumulator, 32, 8, 16, float>& frag,
-    const float* smem_ptr, unsigned ldm, layout_t layout) {
-    if (layout == mem_row_major) {
-        asm volatile(
-            "wmma.load.c.sync.aligned.row.m32n8k16.f32 "
-            "{%0,%1,%2,%3,%4,%5,%6,%7}, [%8], %9;"
-            : "=f"(frag.x[0]), "=f"(frag.x[1]), "=f"(frag.x[2]), "=f"(frag.x[3]),
-              "=f"(frag.x[4]), "=f"(frag.x[5]), "=f"(frag.x[6]), "=f"(frag.x[7])
-            : "l"(smem_ptr), "r"(ldm)
-            : "memory"
-        );
-    } else {
-        asm volatile(
-            "wmma.load.c.sync.aligned.col.m32n8k16.f32 "
-            "{%0,%1,%2,%3,%4,%5,%6,%7}, [%8], %9;"
-            : "=f"(frag.x[0]), "=f"(frag.x[1]), "=f"(frag.x[2]), "=f"(frag.x[3]),
-              "=f"(frag.x[4]), "=f"(frag.x[5]), "=f"(frag.x[6]), "=f"(frag.x[7])
-            : "l"(smem_ptr), "r"(ldm)
-            : "memory"
-        );
-    }
-}
-
-__device__ __forceinline__ void load_matrix_sync(
-    fragment<matrix_a, 8, 32, 16, half, row_major>& frag,
-    const half* smem_ptr, unsigned ldm) {
-    asm volatile(
-        "wmma.load.a.sync.aligned.row.m8n32k16.f16 "
-        "{%0,%1,%2,%3,%4,%5,%6,%7}, [%8], %9;"
-        : "=r"(frag.x[0]), "=r"(frag.x[1]), "=r"(frag.x[2]), "=r"(frag.x[3]),
-          "=r"(frag.x[4]), "=r"(frag.x[5]), "=r"(frag.x[6]), "=r"(frag.x[7])
-        : "l"(smem_ptr), "r"(ldm)
-        : "memory"
-    );
-}
-
-__device__ __forceinline__ void load_matrix_sync(
-    fragment<matrix_a, 8, 32, 16, half, col_major>& frag,
-    const half* smem_ptr, unsigned ldm) {
-    asm volatile(
-        "wmma.load.a.sync.aligned.col.m8n32k16.f16 "
-        "{%0,%1,%2,%3,%4,%5,%6,%7}, [%8], %9;"
-        : "=r"(frag.x[0]), "=r"(frag.x[1]), "=r"(frag.x[2]), "=r"(frag.x[3]),
-          "=r"(frag.x[4]), "=r"(frag.x[5]), "=r"(frag.x[6]), "=r"(frag.x[7])
-        : "l"(smem_ptr), "r"(ldm)
-        : "memory"
-    );
-}
-
-__device__ __forceinline__ void load_matrix_sync(
-    fragment<matrix_b, 8, 32, 16, half, row_major>& frag,
-    const half* smem_ptr, unsigned ldm) {
-    asm volatile(
-        "wmma.load.b.sync.aligned.row.m8n32k16.f16 "
-        "{%0,%1,%2,%3,%4,%5,%6,%7}, [%8], %9;"
-        : "=r"(frag.x[0]), "=r"(frag.x[1]), "=r"(frag.x[2]), "=r"(frag.x[3]),
-          "=r"(frag.x[4]), "=r"(frag.x[5]), "=r"(frag.x[6]), "=r"(frag.x[7])
-        : "l"(smem_ptr), "r"(ldm)
-        : "memory"
-    );
-}
-
-__device__ __forceinline__ void load_matrix_sync(
-    fragment<matrix_b, 8, 32, 16, half, col_major>& frag,
-    const half* smem_ptr, unsigned ldm) {
-    asm volatile(
-        "wmma.load.b.sync.aligned.col.m8n32k16.f16 "
-        "{%0,%1,%2,%3,%4,%5,%6,%7}, [%8], %9;"
-        : "=r"(frag.x[0]), "=r"(frag.x[1]), "=r"(frag.x[2]), "=r"(frag.x[3]),
-          "=r"(frag.x[4]), "=r"(frag.x[5]), "=r"(frag.x[6]), "=r"(frag.x[7])
-        : "l"(smem_ptr), "r"(ldm)
-        : "memory"
-    );
-}
-
-__device__ __forceinline__ void load_matrix_sync(
-    fragment<accumulator, 8, 32, 16, float>& frag,
-    const float* smem_ptr, unsigned ldm, layout_t layout) {
-    if (layout == mem_row_major) {
-        asm volatile(
-            "wmma.load.c.sync.aligned.row.m8n32k16.f32 "
-            "{%0,%1,%2,%3,%4,%5,%6,%7}, [%8], %9;"
-            : "=f"(frag.x[0]), "=f"(frag.x[1]), "=f"(frag.x[2]), "=f"(frag.x[3]),
-              "=f"(frag.x[4]), "=f"(frag.x[5]), "=f"(frag.x[6]), "=f"(frag.x[7])
-            : "l"(smem_ptr), "r"(ldm)
-            : "memory"
-        );
-    } else {
-        asm volatile(
-            "wmma.load.c.sync.aligned.col.m8n32k16.f32 "
-            "{%0,%1,%2,%3,%4,%5,%6,%7}, [%8], %9;"
-            : "=f"(frag.x[0]), "=f"(frag.x[1]), "=f"(frag.x[2]), "=f"(frag.x[3]),
-              "=f"(frag.x[4]), "=f"(frag.x[5]), "=f"(frag.x[6]), "=f"(frag.x[7])
-            : "l"(smem_ptr), "r"(ldm)
-            : "memory"
-        );
-    }
+        : "memory");
+  }
 }
 
 __device__ __forceinline__ void store_matrix_sync(
-    float* smem_ptr,
-    const fragment<accumulator, 16, 16, 16, float>& frag,
+    float* smem_ptr, const fragment<accumulator, 16, 16, 16, float>& frag,
     unsigned ldm, layout_t layout) {
-    if (layout == mem_row_major) {
-        asm volatile(
-            "wmma.store.d.sync.aligned.row.m16n16k16.f32 "
-            "[%0], {%1,%2,%3,%4,%5,%6,%7,%8}, %9;"
-            :
-            : "l"(smem_ptr),
-              "f"(frag.x[0]), "f"(frag.x[1]), "f"(frag.x[2]), "f"(frag.x[3]),
-              "f"(frag.x[4]), "f"(frag.x[5]), "f"(frag.x[6]), "f"(frag.x[7]),
-              "r"(ldm)
-            : "memory"
-        );
-    } else {
-        asm volatile(
-            "wmma.store.d.sync.aligned.col.m16n16k16.f32 "
-            "[%0], {%1,%2,%3,%4,%5,%6,%7,%8}, %9;"
-            :
-            : "l"(smem_ptr),
-              "f"(frag.x[0]), "f"(frag.x[1]), "f"(frag.x[2]), "f"(frag.x[3]),
-              "f"(frag.x[4]), "f"(frag.x[5]), "f"(frag.x[6]), "f"(frag.x[7]),
-              "r"(ldm)
-            : "memory"
-        );
-    }
+  if (layout == mem_row_major) {
+    asm volatile(
+        "wmma.store.d.sync.aligned.row.m16n16k16.f32 "
+        "[%0], {%1,%2,%3,%4,%5,%6,%7,%8}, %9;"
+        :
+        : "l"(smem_ptr), "f"(frag.x[0]), "f"(frag.x[1]), "f"(frag.x[2]),
+          "f"(frag.x[3]), "f"(frag.x[4]), "f"(frag.x[5]), "f"(frag.x[6]),
+          "f"(frag.x[7]), "r"(ldm)
+        : "memory");
+  } else {
+    asm volatile(
+        "wmma.store.d.sync.aligned.col.m16n16k16.f32 "
+        "[%0], {%1,%2,%3,%4,%5,%6,%7,%8}, %9;"
+        :
+        : "l"(smem_ptr), "f"(frag.x[0]), "f"(frag.x[1]), "f"(frag.x[2]),
+          "f"(frag.x[3]), "f"(frag.x[4]), "f"(frag.x[5]), "f"(frag.x[6]),
+          "f"(frag.x[7]), "r"(ldm)
+        : "memory");
+  }
 }
 
 __device__ __forceinline__ void store_matrix_sync(
-    float* smem_ptr,
-    const fragment<accumulator, 32, 8, 16, float>& frag,
+    float* smem_ptr, const fragment<accumulator, 32, 8, 16, float>& frag,
     unsigned ldm, layout_t layout) {
-    if (layout == mem_row_major) {
-        asm volatile(
-            "wmma.store.d.sync.aligned.row.m32n8k16.f32 "
-            "[%0], {%1,%2,%3,%4,%5,%6,%7,%8}, %9;"
-            :
-            : "l"(smem_ptr),
-              "f"(frag.x[0]), "f"(frag.x[1]), "f"(frag.x[2]), "f"(frag.x[3]),
-              "f"(frag.x[4]), "f"(frag.x[5]), "f"(frag.x[6]), "f"(frag.x[7]),
-              "r"(ldm)
-            : "memory"
-        );
-    } else {
-        asm volatile(
-            "wmma.store.d.sync.aligned.col.m32n8k16.f32 "
-            "[%0], {%1,%2,%3,%4,%5,%6,%7,%8}, %9;"
-            :
-            : "l"(smem_ptr),
-              "f"(frag.x[0]), "f"(frag.x[1]), "f"(frag.x[2]), "f"(frag.x[3]),
-              "f"(frag.x[4]), "f"(frag.x[5]), "f"(frag.x[6]), "f"(frag.x[7]),
-              "r"(ldm)
-            : "memory"
-        );
-    }
+  if (layout == mem_row_major) {
+    asm volatile(
+        "wmma.store.d.sync.aligned.row.m32n8k16.f32 "
+        "[%0], {%1,%2,%3,%4,%5,%6,%7,%8}, %9;"
+        :
+        : "l"(smem_ptr), "f"(frag.x[0]), "f"(frag.x[1]), "f"(frag.x[2]),
+          "f"(frag.x[3]), "f"(frag.x[4]), "f"(frag.x[5]), "f"(frag.x[6]),
+          "f"(frag.x[7]), "r"(ldm)
+        : "memory");
+  } else {
+    asm volatile(
+        "wmma.store.d.sync.aligned.col.m32n8k16.f32 "
+        "[%0], {%1,%2,%3,%4,%5,%6,%7,%8}, %9;"
+        :
+        : "l"(smem_ptr), "f"(frag.x[0]), "f"(frag.x[1]), "f"(frag.x[2]),
+          "f"(frag.x[3]), "f"(frag.x[4]), "f"(frag.x[5]), "f"(frag.x[6]),
+          "f"(frag.x[7]), "r"(ldm)
+        : "memory");
+  }
 }
 
 __device__ __forceinline__ void store_matrix_sync(
-    float* smem_ptr,
-    const fragment<accumulator, 8, 32, 16, float>& frag,
+    float* smem_ptr, const fragment<accumulator, 8, 32, 16, float>& frag,
     unsigned ldm, layout_t layout) {
-    if (layout == mem_row_major) {
-        asm volatile(
-            "wmma.store.d.sync.aligned.row.m8n32k16.f32 "
-            "[%0], {%1,%2,%3,%4,%5,%6,%7,%8}, %9;"
-            :
-            : "l"(smem_ptr),
-              "f"(frag.x[0]), "f"(frag.x[1]), "f"(frag.x[2]), "f"(frag.x[3]),
-              "f"(frag.x[4]), "f"(frag.x[5]), "f"(frag.x[6]), "f"(frag.x[7]),
-              "r"(ldm)
-            : "memory"
-        );
-    } else {
-        asm volatile(
-            "wmma.store.d.sync.aligned.col.m8n32k16.f32 "
-            "[%0], {%1,%2,%3,%4,%5,%6,%7,%8}, %9;"
-            :
-            : "l"(smem_ptr),
-              "f"(frag.x[0]), "f"(frag.x[1]), "f"(frag.x[2]), "f"(frag.x[3]),
-              "f"(frag.x[4]), "f"(frag.x[5]), "f"(frag.x[6]), "f"(frag.x[7]),
-              "r"(ldm)
-            : "memory"
-        );
-    }
+  if (layout == mem_row_major) {
+    asm volatile(
+        "wmma.store.d.sync.aligned.row.m8n32k16.f32 "
+        "[%0], {%1,%2,%3,%4,%5,%6,%7,%8}, %9;"
+        :
+        : "l"(smem_ptr), "f"(frag.x[0]), "f"(frag.x[1]), "f"(frag.x[2]),
+          "f"(frag.x[3]), "f"(frag.x[4]), "f"(frag.x[5]), "f"(frag.x[6]),
+          "f"(frag.x[7]), "r"(ldm)
+        : "memory");
+  } else {
+    asm volatile(
+        "wmma.store.d.sync.aligned.col.m8n32k16.f32 "
+        "[%0], {%1,%2,%3,%4,%5,%6,%7,%8}, %9;"
+        :
+        : "l"(smem_ptr), "f"(frag.x[0]), "f"(frag.x[1]), "f"(frag.x[2]),
+          "f"(frag.x[3]), "f"(frag.x[4]), "f"(frag.x[5]), "f"(frag.x[6]),
+          "f"(frag.x[7]), "r"(ldm)
+        : "memory");
+  }
 }
 
-#define VOLTA_WMMA_MMA_F32(M, N, K, ALAY, BLAY) \
-__device__ __forceinline__ void mma_sync( \
-    fragment<accumulator, M, N, K, float>& d, \
-    const fragment<matrix_a, M, N, K, half, ALAY##_major>& a, \
-    const fragment<matrix_b, M, N, K, half, BLAY##_major>& b, \
-    const fragment<accumulator, M, N, K, float>& c) { \
-    asm volatile( \
-        "wmma.mma.sync.aligned." #ALAY "." #BLAY ".m" #M "n" #N "k" #K ".f32.f32 " \
-        "{%0,%1,%2,%3,%4,%5,%6,%7}, " \
-        "{%8,%9,%10,%11,%12,%13,%14,%15}, " \
-        "{%16,%17,%18,%19,%20,%21,%22,%23}, " \
-        "{%24,%25,%26,%27,%28,%29,%30,%31};" \
-        : "=f"(d.x[0]), "=f"(d.x[1]), "=f"(d.x[2]), "=f"(d.x[3]), \
-          "=f"(d.x[4]), "=f"(d.x[5]), "=f"(d.x[6]), "=f"(d.x[7]) \
-        : "r"(a.x[0]), "r"(a.x[1]), "r"(a.x[2]), "r"(a.x[3]), \
-          "r"(a.x[4]), "r"(a.x[5]), "r"(a.x[6]), "r"(a.x[7]), \
-          "r"(b.x[0]), "r"(b.x[1]), "r"(b.x[2]), "r"(b.x[3]), \
-          "r"(b.x[4]), "r"(b.x[5]), "r"(b.x[6]), "r"(b.x[7]), \
-          "f"(c.x[0]), "f"(c.x[1]), "f"(c.x[2]), "f"(c.x[3]), \
-          "f"(c.x[4]), "f"(c.x[5]), "f"(c.x[6]), "f"(c.x[7]) \
-    ); \
-}
+#define VOLTA_WMMA_MMA_F32(M, N, K, ALAY, BLAY)                            \
+  __device__ __forceinline__ void mma_sync(                                \
+      fragment<accumulator, M, N, K, float>& d,                            \
+      const fragment<matrix_a, M, N, K, half, ALAY##_major>& a,            \
+      const fragment<matrix_b, M, N, K, half, BLAY##_major>& b,            \
+      const fragment<accumulator, M, N, K, float>& c) {                    \
+    asm volatile(                                                          \
+        "wmma.mma.sync.aligned." #ALAY "." #BLAY ".m" #M "n" #N "k" #K     \
+        ".f32.f32 "                                                        \
+        "{%0,%1,%2,%3,%4,%5,%6,%7}, "                                      \
+        "{%8,%9,%10,%11,%12,%13,%14,%15}, "                                \
+        "{%16,%17,%18,%19,%20,%21,%22,%23}, "                              \
+        "{%24,%25,%26,%27,%28,%29,%30,%31};"                               \
+        : "=f"(d.x[0]), "=f"(d.x[1]), "=f"(d.x[2]), "=f"(d.x[3]),          \
+          "=f"(d.x[4]), "=f"(d.x[5]), "=f"(d.x[6]), "=f"(d.x[7])           \
+        : "r"(a.x[0]), "r"(a.x[1]), "r"(a.x[2]), "r"(a.x[3]), "r"(a.x[4]), \
+          "r"(a.x[5]), "r"(a.x[6]), "r"(a.x[7]), "r"(b.x[0]), "r"(b.x[1]), \
+          "r"(b.x[2]), "r"(b.x[3]), "r"(b.x[4]), "r"(b.x[5]), "r"(b.x[6]), \
+          "r"(b.x[7]), "f"(c.x[0]), "f"(c.x[1]), "f"(c.x[2]), "f"(c.x[3]), \
+          "f"(c.x[4]), "f"(c.x[5]), "f"(c.x[6]), "f"(c.x[7]));             \
+  }
 
 VOLTA_WMMA_MMA_F32(16, 16, 16, row, col)
 VOLTA_WMMA_MMA_F32(16, 16, 16, row, row)
@@ -412,6 +436,6 @@ VOLTA_WMMA_MMA_F32(8, 32, 16, col, row)
 
 #undef VOLTA_WMMA_MMA_F32
 
-}
+}  // namespace volta
 
 #endif

--- a/flash-attention-v100/kernel/contiguous_to_paged.cu
+++ b/flash-attention-v100/kernel/contiguous_to_paged.cu
@@ -4,89 +4,72 @@
 #include <torch/extension.h>
 
 __global__ void contiguous_to_paged_kernel(
-    const __half* __restrict__ key,
-    const __half* __restrict__ value,
-    const int64_t* __restrict__ slot_mapping,
-          __half* __restrict__ key_cache,
-          __half* __restrict__ value_cache,
-    const int64_t key_stride,
-    const int64_t value_stride,
-    const int64_t block_stride,
-    const int64_t page_stride,
-    const int64_t head_stride,
-    const int block_size,
-    const int num_heads,
-    const int head_dim
-) {
+    const __half* __restrict__ key, const __half* __restrict__ value,
+    const int64_t* __restrict__ slot_mapping, __half* __restrict__ key_cache,
+    __half* __restrict__ value_cache, const int64_t key_stride,
+    const int64_t value_stride, const int64_t block_stride,
+    const int64_t page_stride, const int64_t head_stride, const int block_size,
+    const int num_heads, const int head_dim) {
+  const int token_idx = blockIdx.x;
+  const int64_t slot_idx = slot_mapping[token_idx];
 
-    const int token_idx = blockIdx.x;
-    const int64_t slot_idx = slot_mapping[token_idx];
+  if (slot_idx < 0) {
+    return;
+  }
 
-    if (slot_idx < 0) {
-        return;
+  const int64_t block_idx = slot_idx / block_size;
+  const int64_t block_offset = slot_idx % block_size;
+
+  const int tid = threadIdx.x;
+  const int num_threads = blockDim.x;
+
+  const __half* __restrict__ key_src = key + token_idx * key_stride;
+  const __half* __restrict__ value_src = value + token_idx * value_stride;
+
+  __half* __restrict__ key_dst =
+      key_cache + block_idx * block_stride + block_offset * page_stride;
+  __half* __restrict__ value_dst =
+      value_cache + block_idx * block_stride + block_offset * page_stride;
+
+  for (int head_idx = 0; head_idx < num_heads; head_idx++) {
+    const __half* key_head_src = key_src + head_idx * head_dim;
+    const __half* value_head_src = value_src + head_idx * head_dim;
+    __half* key_head_dst = key_dst + head_idx * head_stride;
+    __half* value_head_dst = value_dst + head_idx * head_stride;
+
+    for (int elem_idx = tid; elem_idx < head_dim; elem_idx += num_threads) {
+      key_head_dst[elem_idx] = key_head_src[elem_idx];
+      value_head_dst[elem_idx] = value_head_src[elem_idx];
     }
-
-    const int64_t block_idx = slot_idx / block_size;
-    const int64_t block_offset = slot_idx % block_size;
-
-    const int tid = threadIdx.x;
-    const int num_threads = blockDim.x;
-
-    const __half* __restrict__ key_src = key + token_idx * key_stride;
-    const __half* __restrict__ value_src = value + token_idx * value_stride;
-
-    __half* __restrict__ key_dst = key_cache + block_idx * block_stride + block_offset * page_stride;
-    __half* __restrict__ value_dst = value_cache + block_idx * block_stride + block_offset * page_stride;
-
-    for (int head_idx = 0; head_idx < num_heads; head_idx++) {
-        const __half* key_head_src = key_src + head_idx * head_dim;
-        const __half* value_head_src = value_src + head_idx * head_dim;
-        __half* key_head_dst = key_dst + head_idx * head_stride;
-        __half* value_head_dst = value_dst + head_idx * head_stride;
-
-        for (int elem_idx = tid; elem_idx < head_dim; elem_idx += num_threads) {
-            key_head_dst[elem_idx] = key_head_src[elem_idx];
-            value_head_dst[elem_idx] = value_head_src[elem_idx];
-        }
-    }
+  }
 }
 
-void contiguous_to_paged(
-    torch::Tensor key,
-    torch::Tensor value,
-    torch::Tensor slot_mapping,
-    torch::Tensor key_cache,
-    torch::Tensor value_cache
-) {
-    const int num_tokens = slot_mapping.size(0);
-    const int num_heads = key.size(1);
-    const int head_dim = key.size(2);
-    const int block_size = key_cache.size(1);
+void contiguous_to_paged(torch::Tensor key, torch::Tensor value,
+                         torch::Tensor slot_mapping, torch::Tensor key_cache,
+                         torch::Tensor value_cache) {
+  const int num_tokens = slot_mapping.size(0);
+  const int num_heads = key.size(1);
+  const int head_dim = key.size(2);
+  const int block_size = key_cache.size(1);
 
-    const int64_t key_stride = key.stride(0);
-    const int64_t value_stride = value.stride(0);
-    const int64_t block_stride = key_cache.stride(0);
-    const int64_t page_stride = key_cache.stride(1);
-    const int64_t head_stride = key_cache.stride(2);
+  const int64_t key_stride = key.stride(0);
+  const int64_t value_stride = value.stride(0);
+  const int64_t block_stride = key_cache.stride(0);
+  const int64_t page_stride = key_cache.stride(1);
+  const int64_t head_stride = key_cache.stride(2);
 
-    const int threads = 256;
-    contiguous_to_paged_kernel<<<num_tokens, threads>>>(
-        reinterpret_cast<const __half*>(key.data_ptr<at::Half>()),
-        reinterpret_cast<const __half*>(value.data_ptr<at::Half>()),
-        slot_mapping.data_ptr<int64_t>(),
-        reinterpret_cast<__half*>(key_cache.data_ptr<at::Half>()),
-        reinterpret_cast<__half*>(value_cache.data_ptr<at::Half>()),
-        key_stride,
-        value_stride,
-        block_stride,
-        page_stride,
-        head_stride,
-        block_size,
-        num_heads,
-        head_dim
-    );
+  const int threads = 256;
+  contiguous_to_paged_kernel<<<num_tokens, threads>>>(
+      reinterpret_cast<const __half*>(key.data_ptr<at::Half>()),
+      reinterpret_cast<const __half*>(value.data_ptr<at::Half>()),
+      slot_mapping.data_ptr<int64_t>(),
+      reinterpret_cast<__half*>(key_cache.data_ptr<at::Half>()),
+      reinterpret_cast<__half*>(value_cache.data_ptr<at::Half>()), key_stride,
+      value_stride, block_stride, page_stride, head_stride, block_size,
+      num_heads, head_dim);
 }
 
 PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
-    m.def("contiguous_to_paged", &contiguous_to_paged, "Contiguous K/V to Paged KV Cache");
+  m.def("contiguous_to_paged", &contiguous_to_paged,
+        "Contiguous K/V to Paged KV Cache");
 }

--- a/flash-attention-v100/kernel/flash_decode_turboquant.cu
+++ b/flash-attention-v100/kernel/flash_decode_turboquant.cu
@@ -14,7 +14,7 @@ constexpr int kThreadsPerBlock = 256;
 constexpr int kWarpsPerBlock = kThreadsPerBlock / kWarpSize;
 
 __device__ __forceinline__ float warp_reduce_sum(float val) {
-  #pragma unroll
+#pragma unroll
   for (int offset = kWarpSize / 2; offset > 0; offset /= 2) {
     val += __shfl_down_sync(0xffffffff, val, offset);
   }
@@ -22,14 +22,14 @@ __device__ __forceinline__ float warp_reduce_sum(float val) {
 }
 
 __device__ __forceinline__ float warp_reduce_max(float val) {
-  #pragma unroll
+#pragma unroll
   for (int offset = kWarpSize / 2; offset > 0; offset /= 2) {
     val = fmaxf(val, __shfl_down_sync(0xffffffff, val, offset));
   }
   return val;
 }
 
-template<int NUM_WARPS>
+template <int NUM_WARPS>
 __device__ __forceinline__ float block_reduce_sum(float val) {
   __shared__ float shared[NUM_WARPS];
   __shared__ float result;
@@ -53,7 +53,7 @@ __device__ __forceinline__ float block_reduce_sum(float val) {
   return result;
 }
 
-template<int NUM_WARPS>
+template <int NUM_WARPS>
 __device__ __forceinline__ float block_reduce_max(float val) {
   __shared__ float shared[NUM_WARPS];
   __shared__ float result;
@@ -77,32 +77,28 @@ __device__ __forceinline__ float block_reduce_max(float val) {
   return result;
 }
 
-__device__ __forceinline__ uint16_t load_u16_le(
-    const uint8_t* __restrict__ data,
-    const int64_t byte_index) {
+__device__ __forceinline__ uint16_t
+load_u16_le(const uint8_t* __restrict__ data, const int64_t byte_index) {
   return static_cast<uint16_t>(data[byte_index]) |
          (static_cast<uint16_t>(data[byte_index + 1]) << 8);
 }
 
 __device__ __forceinline__ float load_f16_le_float(
-    const uint8_t* __restrict__ data,
-    const int64_t byte_index) {
+    const uint8_t* __restrict__ data, const int64_t byte_index) {
   return __half2float(__ushort_as_half(load_u16_le(data, byte_index)));
 }
 
-template<int D, int MSE_BITS, bool NORM_CORRECTION>
+template <int D, int MSE_BITS, bool NORM_CORRECTION>
 __device__ __forceinline__ float dot_qk_turboquant_mse(
-    const float* __restrict__ q_rot,
-    const uint8_t* __restrict__ kv_cache,
-    const int64_t slot_base,
-    const float* __restrict__ centroids,
+    const float* __restrict__ q_rot, const uint8_t* __restrict__ kv_cache,
+    const int64_t slot_base, const float* __restrict__ centroids,
     const int lane) {
   constexpr int kMseBytes = (D * MSE_BITS + 7) / 8;
   constexpr int kMseMask = (1 << MSE_BITS) - 1;
 
   float acc = 0.f;
   float centroid_norm_sq = 0.f;
-  #pragma unroll
+#pragma unroll
   for (int d = lane; d < D; d += kWarpSize) {
     const int bit_offset = d * MSE_BITS;
     const int byte_offset = bit_offset >> 3;
@@ -126,10 +122,9 @@ __device__ __forceinline__ float dot_qk_turboquant_mse(
   return acc * vec_norm;
 }
 
-template<int D, int MSE_BITS, int VQB>
+template <int D, int MSE_BITS, int VQB>
 __device__ __forceinline__ float load_turboquant_value_float(
-    const uint8_t* __restrict__ kv_cache,
-    const int64_t slot_base,
+    const uint8_t* __restrict__ kv_cache, const int64_t slot_base,
     const int d) {
   constexpr int kMseBytes = (D * MSE_BITS + 7) / 8;
   constexpr int kKeyPackedSize = kMseBytes + 2;
@@ -154,32 +149,20 @@ __device__ __forceinline__ float load_turboquant_value_float(
   return static_cast<float>(q_value) * scale + zero;
 }
 
-template<int D, int PARTITION_SIZE, int MSE_BITS, int VQB, bool NORM_CORRECTION>
+template <int D, int PARTITION_SIZE, int MSE_BITS, int VQB,
+          bool NORM_CORRECTION>
 __global__ void flash_attention_turboquant_decode_partition_kernel(
-    const float* __restrict__ q_rot,
-    const uint8_t* __restrict__ kv_cache,
-    float* __restrict__ tmp_out,
-    float* __restrict__ max_logits,
-    float* __restrict__ exp_sums,
-    const int* __restrict__ block_table,
-    const int* __restrict__ seq_lens,
-    const float* __restrict__ centroids,
-    const int batch_size,
-    const int max_num_blocks,
-    const int max_num_partitions,
-    const int num_heads_q,
-    const int num_heads_kv,
-    const int block_size,
-    const int64_t q_stride0,
-    const int64_t q_stride1,
-    const int64_t tmp_out_stride0,
-    const int64_t tmp_out_stride1,
-    const int64_t tmp_out_stride2,
-    const int64_t stats_stride0,
-    const int64_t stats_stride1,
-    const int64_t cache_block_stride,
-    const int64_t cache_token_stride,
-    const int64_t cache_head_stride,
+    const float* __restrict__ q_rot, const uint8_t* __restrict__ kv_cache,
+    float* __restrict__ tmp_out, float* __restrict__ max_logits,
+    float* __restrict__ exp_sums, const int* __restrict__ block_table,
+    const int* __restrict__ seq_lens, const float* __restrict__ centroids,
+    const int batch_size, const int max_num_blocks,
+    const int max_num_partitions, const int num_heads_q, const int num_heads_kv,
+    const int block_size, const int64_t q_stride0, const int64_t q_stride1,
+    const int64_t tmp_out_stride0, const int64_t tmp_out_stride1,
+    const int64_t tmp_out_stride2, const int64_t stats_stride0,
+    const int64_t stats_stride1, const int64_t cache_block_stride,
+    const int64_t cache_token_stride, const int64_t cache_head_stride,
     const float softmax_scale) {
   const int batch_idx = blockIdx.x;
   const int head_idx = blockIdx.y;
@@ -191,8 +174,7 @@ __global__ void flash_attention_turboquant_decode_partition_kernel(
   }
 
   const int seq_len = seq_lens[batch_idx];
-  const int split_len =
-      (seq_len + max_num_partitions - 1) / max_num_partitions;
+  const int split_len = (seq_len + max_num_partitions - 1) / max_num_partitions;
   const int start_token_idx = partition_idx * split_len;
   if (seq_len <= 0 || start_token_idx >= seq_len) {
     return;
@@ -268,8 +250,8 @@ __global__ void flash_attention_turboquant_decode_partition_kernel(
           static_cast<int64_t>(physical_block) * cache_block_stride +
           static_cast<int64_t>(block_offset) * cache_token_stride +
           static_cast<int64_t>(kv_head_idx) * cache_head_stride;
-      const float value = load_turboquant_value_float<D, MSE_BITS, VQB>(
-          kv_cache, slot_base, d);
+      const float value =
+          load_turboquant_value_float<D, MSE_BITS, VQB>(kv_cache, slot_base, d);
       acc = fmaf(scores_shared[i], value, acc);
     }
     tmp_out[tmp_out_base + d] = acc * inv_part_sum;
@@ -284,22 +266,15 @@ __global__ void flash_attention_turboquant_decode_partition_kernel(
   }
 }
 
-template<int D, int PARTITION_SIZE>
+template <int D, int PARTITION_SIZE>
 __global__ void flash_attention_turboquant_decode_reduce_kernel(
-    const float* __restrict__ tmp_out,
-    const float* __restrict__ max_logits,
-    const float* __restrict__ exp_sums,
-    const int* __restrict__ seq_lens,
-    __half* __restrict__ out,
-    const int batch_size,
-    const int max_num_partitions,
-    const int num_heads_q,
-    const int64_t tmp_out_stride0,
-    const int64_t tmp_out_stride1,
-    const int64_t tmp_out_stride2,
-    const int64_t stats_stride0,
-    const int64_t stats_stride1,
-    const int64_t out_stride0,
+    const float* __restrict__ tmp_out, const float* __restrict__ max_logits,
+    const float* __restrict__ exp_sums, const int* __restrict__ seq_lens,
+    __half* __restrict__ out, const int batch_size,
+    const int max_num_partitions, const int num_heads_q,
+    const int64_t tmp_out_stride0, const int64_t tmp_out_stride1,
+    const int64_t tmp_out_stride2, const int64_t stats_stride0,
+    const int64_t stats_stride1, const int64_t out_stride0,
     const int64_t out_stride1) {
   const int batch_idx = blockIdx.x;
   const int head_idx = blockIdx.y;
@@ -313,13 +288,11 @@ __global__ void flash_attention_turboquant_decode_reduce_kernel(
   if (seq_len <= 0) {
     for (int d = threadIdx.x; d < D; d += blockDim.x) {
       out[static_cast<int64_t>(batch_idx) * out_stride0 +
-          static_cast<int64_t>(head_idx) * out_stride1 + d] =
-          __float2half(0.f);
+          static_cast<int64_t>(head_idx) * out_stride1 + d] = __float2half(0.f);
     }
     return;
   }
-  const int split_len =
-      (seq_len + max_num_partitions - 1) / max_num_partitions;
+  const int split_len = (seq_len + max_num_partitions - 1) / max_num_partitions;
   const int num_partitions = (seq_len + split_len - 1) / split_len;
 
   extern __shared__ float shared_mem[];
@@ -342,7 +315,8 @@ __global__ void flash_attention_turboquant_decode_reduce_kernel(
     const int64_t stats_index =
         static_cast<int64_t>(batch_idx) * stats_stride0 +
         static_cast<int64_t>(head_idx) * stats_stride1 + i;
-    const float weight = exp_sums[stats_index] * __expf(max_shared[i] - global_max);
+    const float weight =
+        exp_sums[stats_index] * __expf(max_shared[i] - global_max);
     weight_shared[i] = weight;
     local_sum += weight;
   }
@@ -350,9 +324,8 @@ __global__ void flash_attention_turboquant_decode_reduce_kernel(
   const float inv_global_sum = global_sum > 0.f ? 1.f / global_sum : 0.f;
   __syncthreads();
 
-  const int64_t out_base =
-      static_cast<int64_t>(batch_idx) * out_stride0 +
-      static_cast<int64_t>(head_idx) * out_stride1;
+  const int64_t out_base = static_cast<int64_t>(batch_idx) * out_stride0 +
+                           static_cast<int64_t>(head_idx) * out_stride1;
   const int64_t tmp_out_base =
       static_cast<int64_t>(batch_idx) * tmp_out_stride0 +
       static_cast<int64_t>(head_idx) * tmp_out_stride1;
@@ -369,18 +342,13 @@ __global__ void flash_attention_turboquant_decode_reduce_kernel(
   }
 }
 
-template<int D, int PARTITION_SIZE, int MSE_BITS, int VQB, bool NORM_CORRECTION>
+template <int D, int PARTITION_SIZE, int MSE_BITS, int VQB,
+          bool NORM_CORRECTION>
 void launch_flash_attention_turboquant_decode_paged(
-    const at::Tensor& q_rot,
-    const at::Tensor& kv_cache,
-    at::Tensor& out,
-    const at::Tensor& block_table,
-    const at::Tensor& seq_lens,
-    at::Tensor& tmp_out,
-    at::Tensor& max_logits,
-    at::Tensor& exp_sums,
-    const at::Tensor& centroids,
-    const float softmax_scale,
+    const at::Tensor& q_rot, const at::Tensor& kv_cache, at::Tensor& out,
+    const at::Tensor& block_table, const at::Tensor& seq_lens,
+    at::Tensor& tmp_out, at::Tensor& max_logits, at::Tensor& exp_sums,
+    const at::Tensor& centroids, const float softmax_scale,
     cudaStream_t stream) {
   const int batch_size = q_rot.size(0);
   const int num_heads_q = q_rot.size(1);
@@ -398,68 +366,35 @@ void launch_flash_attention_turboquant_decode_paged(
   flash_attention_turboquant_decode_partition_kernel<
       D, PARTITION_SIZE, MSE_BITS, VQB, NORM_CORRECTION>
       <<<partition_grid, block, 0, stream>>>(
-      q_rot.data_ptr<float>(),
-      kv_cache.data_ptr<uint8_t>(),
-      tmp_out.data_ptr<float>(),
-      max_logits.data_ptr<float>(),
-      exp_sums.data_ptr<float>(),
-      block_table.data_ptr<int>(),
-      seq_lens.data_ptr<int>(),
-      centroids.data_ptr<float>(),
-      batch_size,
-      max_num_blocks,
-      max_num_partitions,
-      num_heads_q,
-      num_heads_kv,
-      block_size,
-      q_rot.stride(0),
-      q_rot.stride(1),
-      tmp_out.stride(0),
-      tmp_out.stride(1),
-      tmp_out.stride(2),
-      max_logits.stride(0),
-      max_logits.stride(1),
-      kv_cache.stride(0),
-      kv_cache.stride(1),
-      kv_cache.stride(2),
-      softmax_scale);
+          q_rot.data_ptr<float>(), kv_cache.data_ptr<uint8_t>(),
+          tmp_out.data_ptr<float>(), max_logits.data_ptr<float>(),
+          exp_sums.data_ptr<float>(), block_table.data_ptr<int>(),
+          seq_lens.data_ptr<int>(), centroids.data_ptr<float>(), batch_size,
+          max_num_blocks, max_num_partitions, num_heads_q, num_heads_kv,
+          block_size, q_rot.stride(0), q_rot.stride(1), tmp_out.stride(0),
+          tmp_out.stride(1), tmp_out.stride(2), max_logits.stride(0),
+          max_logits.stride(1), kv_cache.stride(0), kv_cache.stride(1),
+          kv_cache.stride(2), softmax_scale);
 
   flash_attention_turboquant_decode_reduce_kernel<D, PARTITION_SIZE>
       <<<reduce_grid, block, reduce_shared_mem, stream>>>(
-      tmp_out.data_ptr<float>(),
-      max_logits.data_ptr<float>(),
-      exp_sums.data_ptr<float>(),
-      seq_lens.data_ptr<int>(),
-      reinterpret_cast<__half*>(out.data_ptr<at::Half>()),
-      batch_size,
-      max_num_partitions,
-      num_heads_q,
-      tmp_out.stride(0),
-      tmp_out.stride(1),
-      tmp_out.stride(2),
-      max_logits.stride(0),
-      max_logits.stride(1),
-      out.stride(0),
-      out.stride(1));
+          tmp_out.data_ptr<float>(), max_logits.data_ptr<float>(),
+          exp_sums.data_ptr<float>(), seq_lens.data_ptr<int>(),
+          reinterpret_cast<__half*>(out.data_ptr<at::Half>()), batch_size,
+          max_num_partitions, num_heads_q, tmp_out.stride(0), tmp_out.stride(1),
+          tmp_out.stride(2), max_logits.stride(0), max_logits.stride(1),
+          out.stride(0), out.stride(1));
 }
 
 }  // namespace
 
 at::Tensor flash_attention_turboquant_decode_paged(
-    const at::Tensor& q_rot,
-    const at::Tensor& kv_cache,
-    std::optional<at::Tensor>& out_,
-    const at::Tensor& block_table,
-    const at::Tensor& seq_lens,
-    at::Tensor& tmp_out,
-    at::Tensor& max_logits,
-    at::Tensor& exp_sums,
-    const at::Tensor& centroids,
-    const float softmax_scale,
-    const int partition_size,
-    const int mse_bits,
-    const int value_quant_bits,
-    const bool norm_correction) {
+    const at::Tensor& q_rot, const at::Tensor& kv_cache,
+    std::optional<at::Tensor>& out_, const at::Tensor& block_table,
+    const at::Tensor& seq_lens, at::Tensor& tmp_out, at::Tensor& max_logits,
+    at::Tensor& exp_sums, const at::Tensor& centroids,
+    const float softmax_scale, const int partition_size, const int mse_bits,
+    const int value_quant_bits, const bool norm_correction) {
   TORCH_CHECK(q_rot.is_cuda(), "q_rot must be on CUDA");
   TORCH_CHECK(kv_cache.is_cuda(), "kv_cache must be on CUDA");
   TORCH_CHECK(block_table.is_cuda() && seq_lens.is_cuda(),
@@ -474,7 +409,8 @@ at::Tensor flash_attention_turboquant_decode_paged(
   TORCH_CHECK(tmp_out.dtype() == torch::kFloat32, "tmp_out must be fp32");
   TORCH_CHECK(max_logits.dtype() == torch::kFloat32, "max_logits must be fp32");
   TORCH_CHECK(exp_sums.dtype() == torch::kFloat32, "exp_sums must be fp32");
-  TORCH_CHECK(block_table.dtype() == torch::kInt32, "block_table must be int32");
+  TORCH_CHECK(block_table.dtype() == torch::kInt32,
+              "block_table must be int32");
   TORCH_CHECK(seq_lens.dtype() == torch::kInt32, "seq_lens must be int32");
   TORCH_CHECK(q_rot.dim() == 3, "q_rot must have shape [B, H, D]");
   TORCH_CHECK(kv_cache.dim() == 4,
@@ -483,7 +419,8 @@ at::Tensor flash_attention_turboquant_decode_paged(
               "block_table must have shape [B, max_num_blocks]");
   TORCH_CHECK(seq_lens.dim() == 1, "seq_lens must have shape [B]");
   TORCH_CHECK(tmp_out.dim() == 4, "tmp_out must have shape [B_cap, H, P, D]");
-  TORCH_CHECK(max_logits.dim() == 3, "max_logits must have shape [B_cap, H, P]");
+  TORCH_CHECK(max_logits.dim() == 3,
+              "max_logits must have shape [B_cap, H, P]");
   TORCH_CHECK(exp_sums.dim() == 3, "exp_sums must have shape [B_cap, H, P]");
   TORCH_CHECK(q_rot.stride(-1) == 1, "q_rot last dim must be contiguous");
   TORCH_CHECK(kv_cache.stride(-1) == 1, "kv_cache last dim must be contiguous");
@@ -500,23 +437,26 @@ at::Tensor flash_attention_turboquant_decode_paged(
               "seq_lens batch size must cover q_rot batch size");
   TORCH_CHECK(q_rot.size(0) <= tmp_out.size(0),
               "tmp_out batch size must cover q_rot batch size");
-  TORCH_CHECK(num_heads_q == tmp_out.size(1), "tmp_out head dimension mismatch");
+  TORCH_CHECK(num_heads_q == tmp_out.size(1),
+              "tmp_out head dimension mismatch");
   TORCH_CHECK(head_dim == tmp_out.size(3), "tmp_out head_dim mismatch");
   TORCH_CHECK(max_logits.size(0) == tmp_out.size(0) &&
                   max_logits.size(1) == tmp_out.size(1) &&
                   max_logits.size(2) == tmp_out.size(2),
               "max_logits shape mismatch");
-  TORCH_CHECK(exp_sums.sizes() == max_logits.sizes(), "exp_sums shape mismatch");
+  TORCH_CHECK(exp_sums.sizes() == max_logits.sizes(),
+              "exp_sums shape mismatch");
   TORCH_CHECK(num_heads_q % num_heads_kv == 0,
               "num_heads_q must be divisible by num_heads_kv");
-  TORCH_CHECK(partition_size == 256 || partition_size == 512 ||
-                  partition_size == 1024,
-              "Unsupported decode partition_size: ", partition_size);
   TORCH_CHECK(
-      block_table.size(1) * kv_cache.size(1) <= partition_size * tmp_out.size(2),
-      "TurboQuant decode workspace cannot cover block_table capacity");
-  TORCH_CHECK(mse_bits == 3 || mse_bits == 4,
-              "TurboQuant Flash-V100 decode currently supports 3/4-bit MSE keys");
+      partition_size == 256 || partition_size == 512 || partition_size == 1024,
+      "Unsupported decode partition_size: ", partition_size);
+  TORCH_CHECK(block_table.size(1) * kv_cache.size(1) <=
+                  partition_size * tmp_out.size(2),
+              "TurboQuant decode workspace cannot cover block_table capacity");
+  TORCH_CHECK(
+      mse_bits == 3 || mse_bits == 4,
+      "TurboQuant Flash-V100 decode currently supports 3/4-bit MSE keys");
   TORCH_CHECK(value_quant_bits == 3 || value_quant_bits == 4,
               "TurboQuant Flash-V100 decode currently supports 3/4-bit values");
   TORCH_CHECK(centroids.numel() >= (1 << mse_bits),
@@ -537,65 +477,67 @@ at::Tensor flash_attention_turboquant_decode_paged(
   auto stream = at::cuda::getCurrentCUDAStream().stream();
   c10::cuda::CUDAGuard device_guard(q_rot.device());
 
-  #define LAUNCH_TYPED(HDIM, PARTITION, MSE, VBITS, NC)                       \
-    launch_flash_attention_turboquant_decode_paged<HDIM, PARTITION, MSE,      \
-                                                    VBITS, NC>(               \
-        q_rot, kv_cache, out, block_table, seq_lens, tmp_out, max_logits,      \
-        exp_sums, centroids, softmax_scale, stream)
+#define LAUNCH_TYPED(HDIM, PARTITION, MSE, VBITS, NC)                         \
+  launch_flash_attention_turboquant_decode_paged<HDIM, PARTITION, MSE, VBITS, \
+                                                 NC>(                         \
+      q_rot, kv_cache, out, block_table, seq_lens, tmp_out, max_logits,       \
+      exp_sums, centroids, softmax_scale, stream)
 
-  #define LAUNCH_BY_NORM(HDIM, PARTITION, MSE, VBITS)                         \
-    do {                                                                      \
-      if (norm_correction) {                                                  \
-        LAUNCH_TYPED(HDIM, PARTITION, MSE, VBITS, true);                      \
-      } else {                                                                \
-        LAUNCH_TYPED(HDIM, PARTITION, MSE, VBITS, false);                     \
-      }                                                                       \
-    } while (0)
+#define LAUNCH_BY_NORM(HDIM, PARTITION, MSE, VBITS)     \
+  do {                                                  \
+    if (norm_correction) {                              \
+      LAUNCH_TYPED(HDIM, PARTITION, MSE, VBITS, true);  \
+    } else {                                            \
+      LAUNCH_TYPED(HDIM, PARTITION, MSE, VBITS, false); \
+    }                                                   \
+  } while (0)
 
-  #define LAUNCH_BY_VALUE(HDIM, PARTITION, MSE)                               \
-    do {                                                                      \
-      switch (value_quant_bits) {                                             \
-        case 3:                                                               \
-          LAUNCH_BY_NORM(HDIM, PARTITION, MSE, 3);                            \
-          break;                                                              \
-        case 4:                                                               \
-          LAUNCH_BY_NORM(HDIM, PARTITION, MSE, 4);                            \
-          break;                                                              \
-        default:                                                              \
-          TORCH_CHECK(false, "Unsupported value_quant_bits: ", value_quant_bits); \
-      }                                                                       \
-    } while (0)
+#define LAUNCH_BY_VALUE(HDIM, PARTITION, MSE)                            \
+  do {                                                                   \
+    switch (value_quant_bits) {                                          \
+      case 3:                                                            \
+        LAUNCH_BY_NORM(HDIM, PARTITION, MSE, 3);                         \
+        break;                                                           \
+      case 4:                                                            \
+        LAUNCH_BY_NORM(HDIM, PARTITION, MSE, 4);                         \
+        break;                                                           \
+      default:                                                           \
+        TORCH_CHECK(false,                                               \
+                    "Unsupported value_quant_bits: ", value_quant_bits); \
+    }                                                                    \
+  } while (0)
 
-  #define LAUNCH_BY_MSE(HDIM, PARTITION)                                      \
-    do {                                                                      \
-      switch (mse_bits) {                                                     \
-        case 3:                                                               \
-          LAUNCH_BY_VALUE(HDIM, PARTITION, 3);                                \
-          break;                                                              \
-        case 4:                                                               \
-          LAUNCH_BY_VALUE(HDIM, PARTITION, 4);                                \
-          break;                                                              \
-        default:                                                              \
-          TORCH_CHECK(false, "Unsupported mse_bits: ", mse_bits);            \
-      }                                                                       \
-    } while (0)
+#define LAUNCH_BY_MSE(HDIM, PARTITION)                          \
+  do {                                                          \
+    switch (mse_bits) {                                         \
+      case 3:                                                   \
+        LAUNCH_BY_VALUE(HDIM, PARTITION, 3);                    \
+        break;                                                  \
+      case 4:                                                   \
+        LAUNCH_BY_VALUE(HDIM, PARTITION, 4);                    \
+        break;                                                  \
+      default:                                                  \
+        TORCH_CHECK(false, "Unsupported mse_bits: ", mse_bits); \
+    }                                                           \
+  } while (0)
 
-  #define LAUNCH_BY_PARTITION(HDIM)                                           \
-    do {                                                                      \
-      switch (partition_size) {                                               \
-        case 256:                                                             \
-          LAUNCH_BY_MSE(HDIM, 256);                                           \
-          break;                                                              \
-        case 512:                                                             \
-          LAUNCH_BY_MSE(HDIM, 512);                                           \
-          break;                                                              \
-        case 1024:                                                            \
-          LAUNCH_BY_MSE(HDIM, 1024);                                          \
-          break;                                                              \
-        default:                                                              \
-          TORCH_CHECK(false, "Unsupported decode partition_size: ", partition_size); \
-      }                                                                       \
-    } while (0)
+#define LAUNCH_BY_PARTITION(HDIM)                                           \
+  do {                                                                      \
+    switch (partition_size) {                                               \
+      case 256:                                                             \
+        LAUNCH_BY_MSE(HDIM, 256);                                           \
+        break;                                                              \
+      case 512:                                                             \
+        LAUNCH_BY_MSE(HDIM, 512);                                           \
+        break;                                                              \
+      case 1024:                                                            \
+        LAUNCH_BY_MSE(HDIM, 1024);                                          \
+        break;                                                              \
+      default:                                                              \
+        TORCH_CHECK(false,                                                  \
+                    "Unsupported decode partition_size: ", partition_size); \
+    }                                                                       \
+  } while (0)
 
   switch (head_dim) {
     case 64:
@@ -617,14 +559,15 @@ at::Tensor flash_attention_turboquant_decode_paged(
       LAUNCH_BY_PARTITION(256);
       break;
     default:
-      TORCH_CHECK(false, "Unsupported head_dim for TurboQuant paged decode: ", head_dim);
+      TORCH_CHECK(false, "Unsupported head_dim for TurboQuant paged decode: ",
+                  head_dim);
   }
 
-  #undef LAUNCH_BY_PARTITION
-  #undef LAUNCH_BY_MSE
-  #undef LAUNCH_BY_VALUE
-  #undef LAUNCH_BY_NORM
-  #undef LAUNCH_TYPED
+#undef LAUNCH_BY_PARTITION
+#undef LAUNCH_BY_MSE
+#undef LAUNCH_BY_VALUE
+#undef LAUNCH_BY_NORM
+#undef LAUNCH_TYPED
 
   C10_CUDA_KERNEL_LAUNCH_CHECK();
   return out;

--- a/flash-attention-v100/kernel/flash_v100_traits.cuh
+++ b/flash-attention-v100/kernel/flash_v100_traits.cuh
@@ -3,137 +3,116 @@
 #include <cuda.h>
 #include <cuda_runtime.h>
 
-template<int D>
+template <int D>
 struct FlashV100Traits {
+  static constexpr int BLOCK_M_16 = 16;
+  static constexpr int BLOCK_N_16 = 512;
+  static constexpr int BLOCK_M_32 = 32;
+  static constexpr int BLOCK_N_32 = 256;
+  static constexpr int BLOCK_M_64 = 64;
+  static constexpr int BLOCK_N_64 = 128;
+  static constexpr int BLOCK_M_128 = 32;
+  static constexpr int BLOCK_N_128 = 176;
+  static constexpr int BLOCK_M_256 = 32;
+  static constexpr int BLOCK_N_256 = 64;
+  static constexpr int WARPS_PER_BLOCK = 16;
+  static constexpr int THREADS_PER_WARP = 32;
 
-    static constexpr int BLOCK_M_16  = 16;
-    static constexpr int BLOCK_N_16  = 512;
-    static constexpr int BLOCK_M_32  = 32;
-    static constexpr int BLOCK_N_32  = 256;
-    static constexpr int BLOCK_M_64  = 64;
-    static constexpr int BLOCK_N_64  = 128;
-    static constexpr int BLOCK_M_128 = 32;
-    static constexpr int BLOCK_N_128 = 176;
-    static constexpr int BLOCK_M_256 = 32;
-    static constexpr int BLOCK_N_256 = 64;
-    static constexpr int WARPS_PER_BLOCK = 16;
-    static constexpr int THREADS_PER_WARP = 32;
+  static constexpr int BLOCK_M = (D == 16)    ? BLOCK_M_16
+                                 : (D == 32)  ? BLOCK_M_32
+                                 : (D == 64)  ? BLOCK_M_64
+                                 : (D == 128) ? BLOCK_M_128
+                                              : BLOCK_M_256;
 
-    static constexpr int BLOCK_M = (D == 16) ? BLOCK_M_16 :
-                                   (D == 32) ? BLOCK_M_32 :
-                                   (D == 64) ? BLOCK_M_64 :
-                                   (D == 128) ? BLOCK_M_128 : BLOCK_M_256;
+  static constexpr int BLOCK_N = (D == 16)    ? BLOCK_N_16
+                                 : (D == 32)  ? BLOCK_N_32
+                                 : (D == 64)  ? BLOCK_N_64
+                                 : (D == 128) ? BLOCK_N_128
+                                              : BLOCK_N_256;
 
-    static constexpr int BLOCK_N = (D == 16) ? BLOCK_N_16 :
-                                   (D == 32) ? BLOCK_N_32 :
-                                   (D == 64) ? BLOCK_N_64 :
-                                   (D == 128) ? BLOCK_N_128 : BLOCK_N_256;
+  static constexpr int THREADS_PER_BLOCK = WARPS_PER_BLOCK * THREADS_PER_WARP;
+  static constexpr int THREADS_PER_ROW = THREADS_PER_BLOCK / BLOCK_M;
 
-    static constexpr int THREADS_PER_BLOCK = WARPS_PER_BLOCK * THREADS_PER_WARP;
-    static constexpr int THREADS_PER_ROW = THREADS_PER_BLOCK / BLOCK_M;
+  static constexpr int kBlockM = BLOCK_M;
+  static constexpr int kBlockN = BLOCK_N;
+  static constexpr int kHeadDim = D;
 
-    static constexpr int kBlockM = BLOCK_M;
-    static constexpr int kBlockN = BLOCK_N;
-    static constexpr int kHeadDim = D;
+  static constexpr int kGmemThreadsPerRow = THREADS_PER_ROW;
+  static constexpr int kGmemRowsPerThread = 1;
+  static constexpr int kGmemElemsPerLoad = 8;
 
-    static constexpr int kGmemThreadsPerRow = THREADS_PER_ROW;
-    static constexpr int kGmemRowsPerThread = 1;
-    static constexpr int kGmemElemsPerLoad = 8;
-
-    static constexpr int PER_UINT4 = 8;
-    static constexpr int d_stride_uint4 = (D + PER_UINT4 - 1) / PER_UINT4;
+  static constexpr int PER_UINT4 = 8;
+  static constexpr int d_stride_uint4 = (D + PER_UINT4 - 1) / PER_UINT4;
 };
 
-template<typename Traits>
-__device__ __forceinline__
-int64_t resolve_thread_kv_page_slice_offset(
-    const int tidx,
-    const int n_block,
-    const int page_block_size,
-    const int* __restrict__ block_table,
-    const int page_stride,
-    const int row_stride,
-    const int partial_block_size = -1
-) {
-    constexpr int kGmemThreadsPerRow = Traits::kGmemThreadsPerRow;
-    constexpr int kGmemRowsPerThread = Traits::kGmemRowsPerThread;
-    constexpr int kGmemElemsPerLoad = Traits::kGmemElemsPerLoad;
-    constexpr int kBlockN = Traits::kBlockN;
+template <typename Traits>
+__device__ __forceinline__ int64_t resolve_thread_kv_page_slice_offset(
+    const int tidx, const int n_block, const int page_block_size,
+    const int* __restrict__ block_table, const int page_stride,
+    const int row_stride, const int partial_block_size = -1) {
+  constexpr int kGmemThreadsPerRow = Traits::kGmemThreadsPerRow;
+  constexpr int kGmemRowsPerThread = Traits::kGmemRowsPerThread;
+  constexpr int kGmemElemsPerLoad = Traits::kGmemElemsPerLoad;
+  constexpr int kBlockN = Traits::kBlockN;
 
-    const int64_t col_offset = (tidx % kGmemThreadsPerRow) * kGmemElemsPerLoad;
-    int64_t block_row_offset = (tidx / kGmemThreadsPerRow) * kGmemRowsPerThread;
+  const int64_t col_offset = (tidx % kGmemThreadsPerRow) * kGmemElemsPerLoad;
+  int64_t block_row_offset = (tidx / kGmemThreadsPerRow) * kGmemRowsPerThread;
 
-    if (partial_block_size > 0) {
-        const int final_row_offset = max(partial_block_size - 1, 0);
-        const int final_thread_row_offset =
-            ((final_row_offset + kGmemRowsPerThread - 1) / kGmemRowsPerThread) * kGmemRowsPerThread;
-        block_row_offset = min(block_row_offset, (int64_t)final_thread_row_offset);
-    }
+  if (partial_block_size > 0) {
+    const int final_row_offset = max(partial_block_size - 1, 0);
+    const int final_thread_row_offset =
+        ((final_row_offset + kGmemRowsPerThread - 1) / kGmemRowsPerThread) *
+        kGmemRowsPerThread;
+    block_row_offset = min(block_row_offset, (int64_t)final_thread_row_offset);
+  }
 
-    const int64_t global_row_offset = block_row_offset + n_block * kBlockN;
+  const int64_t global_row_offset = block_row_offset + n_block * kBlockN;
 
-    const int64_t page_offset = global_row_offset % page_block_size;
-    const int64_t virtual_page_idx = global_row_offset / page_block_size;
+  const int64_t page_offset = global_row_offset % page_block_size;
+  const int64_t virtual_page_idx = global_row_offset / page_block_size;
 
-    const int64_t physical_offset =
-        ((int64_t)block_table[virtual_page_idx]) * ((int64_t)page_stride)
-        + page_offset * ((int64_t)row_stride)
-        + col_offset;
+  const int64_t physical_offset =
+      ((int64_t)block_table[virtual_page_idx]) * ((int64_t)page_stride) +
+      page_offset * ((int64_t)row_stride) + col_offset;
 
-    return physical_offset;
+  return physical_offset;
 }
 
-template<typename Traits>
-__device__ __forceinline__
-void load_kv_tile_paged(
-    const __half* __restrict__ kv_cache,
-    const int* __restrict__ block_table,
-    const int start_token_idx,
-    const int num_tokens,
-    const int n_block,
-    const int page_block_size,
-    const int page_stride,
-    const int row_stride,
-    __half* smem_dst,
-    const int smem_stride,
-    const int tid,
-    const int num_threads,
-    const int partial_block_size = -1
-) {
-    constexpr int PER_UINT4 = Traits::PER_UINT4;
-    constexpr int d_stride_uint4 = Traits::d_stride_uint4;
-    constexpr int kBlockN = Traits::kBlockN;
+template <typename Traits>
+__device__ __forceinline__ void load_kv_tile_paged(
+    const __half* __restrict__ kv_cache, const int* __restrict__ block_table,
+    const int start_token_idx, const int num_tokens, const int n_block,
+    const int page_block_size, const int page_stride, const int row_stride,
+    __half* smem_dst, const int smem_stride, const int tid,
+    const int num_threads, const int partial_block_size = -1) {
+  constexpr int PER_UINT4 = Traits::PER_UINT4;
+  constexpr int d_stride_uint4 = Traits::d_stride_uint4;
+  constexpr int kBlockN = Traits::kBlockN;
 
-    const uint4* kv_vec = reinterpret_cast<const uint4*>(kv_cache);
-    uint4* smem_vec = reinterpret_cast<uint4*>(smem_dst);
-    const int smem_stride_uint4 = (smem_stride + PER_UINT4 - 1) / PER_UINT4;
+  const uint4* kv_vec = reinterpret_cast<const uint4*>(kv_cache);
+  uint4* smem_vec = reinterpret_cast<uint4*>(smem_dst);
+  const int smem_stride_uint4 = (smem_stride + PER_UINT4 - 1) / PER_UINT4;
 
-    #pragma unroll 2
-    for (int idx = tid; idx < (num_tokens * d_stride_uint4); idx += num_threads) {
-        const int token_offset = idx / d_stride_uint4;
-        const int vec_col = idx % d_stride_uint4;
+#pragma unroll 2
+  for (int idx = tid; idx < (num_tokens * d_stride_uint4); idx += num_threads) {
+    const int token_offset = idx / d_stride_uint4;
+    const int vec_col = idx % d_stride_uint4;
 
-        uint4 kv_val = make_uint4(0, 0, 0, 0);
+    uint4 kv_val = make_uint4(0, 0, 0, 0);
 
-        if (token_offset < num_tokens && vec_col < d_stride_uint4) {
+    if (token_offset < num_tokens && vec_col < d_stride_uint4) {
+      const int global_token_idx = start_token_idx + token_offset;
 
-            const int global_token_idx = start_token_idx + token_offset;
+      const int64_t physical_offset_halves =
+          resolve_thread_kv_page_slice_offset<Traits>(
+              tid, n_block, page_block_size, block_table, page_stride,
+              row_stride, partial_block_size);
 
-            const int64_t physical_offset_halfs = resolve_thread_kv_page_slice_offset<Traits>(
-                tid,
-                n_block,
-                page_block_size,
-                block_table,
-                page_stride,
-                row_stride,
-                partial_block_size
-            );
+      const int64_t physical_offset_uint4 = physical_offset_halves / PER_UINT4;
 
-            const int64_t physical_offset_uint4 = physical_offset_halfs / PER_UINT4;
-
-            kv_val = __ldg(&kv_vec[physical_offset_uint4 + vec_col]);
-        }
-
-        smem_vec[token_offset * smem_stride_uint4 + vec_col] = kv_val;
+      kv_val = __ldg(&kv_vec[physical_offset_uint4 + vec_col]);
     }
+
+    smem_vec[token_offset * smem_stride_uint4 + vec_col] = kv_val;
+  }
 }

--- a/flash-attention-v100/kernel/fp8_kv_utils.cuh
+++ b/flash-attention-v100/kernel/fp8_kv_utils.cuh
@@ -14,9 +14,7 @@ __device__ __forceinline__ float quiet_nan_f() {
   return __int_as_float(0x7fffffff);
 }
 
-__device__ __forceinline__ float inf_f() {
-  return __int_as_float(0x7f800000);
-}
+__device__ __forceinline__ float inf_f() { return __int_as_float(0x7f800000); }
 
 __device__ __forceinline__ float exp2_int(const int exponent) {
   return __uint_as_float(static_cast<uint32_t>(exponent + 127) << 23);
@@ -38,8 +36,7 @@ __device__ __forceinline__ float fp8_e4m3fn_to_float(uint8_t raw) {
     if (exp == 0x0f && mant == 0x07) {
       return quiet_nan_f();
     }
-    value = (1.0f + static_cast<float>(mant) * 0.125f) *
-            exp2_int(exp - 7);
+    value = (1.0f + static_cast<float>(mant) * 0.125f) * exp2_int(exp - 7);
   }
   return sign ? -value : value;
 }
@@ -52,9 +49,8 @@ __device__ __forceinline__ __half fp8_e5m2_to_half(uint8_t raw) {
 }
 
 __device__ __forceinline__ __half2 fp8_e5m2_pair_to_half2(uint16_t raw_pair) {
-  const uint32_t half2_bits =
-      (static_cast<uint32_t>(raw_pair & 0x00ffu) << 8) |
-      (static_cast<uint32_t>(raw_pair & 0xff00u) << 16);
+  const uint32_t half2_bits = (static_cast<uint32_t>(raw_pair & 0x00ffu) << 8) |
+                              (static_cast<uint32_t>(raw_pair & 0xff00u) << 16);
   union {
     uint32_t u;
     __half2 h2;
@@ -64,8 +60,7 @@ __device__ __forceinline__ __half2 fp8_e5m2_pair_to_half2(uint16_t raw_pair) {
 }
 
 __device__ __forceinline__ __half2 load_fp8_e5m2_half2_unscaled(
-    const void* __restrict__ cache,
-    const int64_t byte_index) {
+    const void* __restrict__ cache, const int64_t byte_index) {
   const uint16_t* cache_u16 = reinterpret_cast<const uint16_t*>(cache);
   return fp8_e5m2_pair_to_half2(cache_u16[byte_index >> 1]);
 }
@@ -74,36 +69,31 @@ __device__ __forceinline__ float fp8_e5m2_to_float(uint8_t raw) {
   return __half2float(fp8_e5m2_to_half(raw));
 }
 
-template<int KV_DTYPE>
+template <int KV_DTYPE>
 __device__ __forceinline__ float load_kv_cache_float_unscaled(
-    const void* __restrict__ cache,
-    const int64_t index) {
+    const void* __restrict__ cache, const int64_t index) {
   if constexpr (KV_DTYPE == KV_CACHE_DTYPE_FP16) {
     const __half* cache_h = reinterpret_cast<const __half*>(cache);
     return __half2float(cache_h[index]);
   } else {
     const uint8_t* cache_u8 = reinterpret_cast<const uint8_t*>(cache);
     const uint8_t raw = cache_u8[index];
-    const float value =
-        KV_DTYPE == KV_CACHE_DTYPE_FP8_E4M3 ? fp8_e4m3fn_to_float(raw)
-                                            : fp8_e5m2_to_float(raw);
+    const float value = KV_DTYPE == KV_CACHE_DTYPE_FP8_E4M3
+                            ? fp8_e4m3fn_to_float(raw)
+                            : fp8_e5m2_to_float(raw);
     return value;
   }
 }
 
-template<int KV_DTYPE>
+template <int KV_DTYPE>
 __device__ __forceinline__ float load_kv_cache_float(
-    const void* __restrict__ cache,
-    const int64_t index,
-    const float scale) {
+    const void* __restrict__ cache, const int64_t index, const float scale) {
   return load_kv_cache_float_unscaled<KV_DTYPE>(cache, index) * scale;
 }
 
-template<int KV_DTYPE>
+template <int KV_DTYPE>
 __device__ __forceinline__ __half load_kv_cache_half(
-    const void* __restrict__ cache,
-    const int64_t index,
-    const float scale) {
+    const void* __restrict__ cache, const int64_t index, const float scale) {
   if constexpr (KV_DTYPE == KV_CACHE_DTYPE_FP8_E5M2) {
     const uint8_t* cache_u8 = reinterpret_cast<const uint8_t*>(cache);
     return __float2half_rn(__half2float(fp8_e5m2_to_half(cache_u8[index])) *

--- a/flash-attention-v100/kernel/fused_mha_api.cpp
+++ b/flash-attention-v100/kernel/fused_mha_api.cpp
@@ -9,59 +9,39 @@
 namespace py = pybind11;
 
 PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
-    m.doc() = "FlashAttention-2 implementation optimized for Volta";
-    m.def("fwd", &flash_attention_forward, "FlashAttention-2 Forward Pass (Volta)");
-    m.def(
-        "qk_scores_fwd",
-        &flash_attention_qk_scores,
+  m.doc() = "FlashAttention-2 implementation optimized for Volta";
+  m.def("fwd", &flash_attention_forward,
+        "FlashAttention-2 Forward Pass (Volta)");
+  m.def("qk_scores_fwd", &flash_attention_qk_scores,
         "Debug FlashAttention QK score dump before softmax (Volta)");
-    m.def("bwd", &flash_attention_backward, "FlashAttention-2 Backward Pass (Volta)");
-    m.def(
-        "decode_paged_fwd",
-        &flash_attention_decode_paged,
+  m.def("bwd", &flash_attention_backward,
+        "FlashAttention-2 Backward Pass (Volta)");
+  m.def("decode_paged_fwd", &flash_attention_decode_paged,
         "FlashAttention decode over paged KV cache (Volta)");
-    m.def(
-        "decode_paged_xqa_fwd",
-        &flash_attention_decode_paged_xqa,
+  m.def("decode_paged_xqa_fwd", &flash_attention_decode_paged_xqa,
         "FlashAttention XQA decode over paged KV cache (Volta)");
-    m.def(
-        "decode_paged_xqa_staged_fwd",
-        &flash_attention_decode_paged_xqa_staged,
+  m.def("decode_paged_xqa_staged_fwd", &flash_attention_decode_paged_xqa_staged,
         "Staged FlashAttention XQA decode over paged KV cache (Volta)");
-    m.def(
-        "decode_paged_wmma_fwd",
-        &flash_attention_decode_paged_wmma,
-        "FlashAttention single-query decode through paged-prefill WMMA order (Volta)");
-    m.def(
-        "decode_qk_scores_fwd",
-        &flash_attention_decode_qk_scores,
+  m.def("decode_paged_wmma_fwd", &flash_attention_decode_paged_wmma,
+        "FlashAttention single-query decode through paged-prefill WMMA order "
+        "(Volta)");
+  m.def("decode_qk_scores_fwd", &flash_attention_decode_qk_scores,
         "Debug scalar paged decode QK score dump before softmax (Volta)");
-    m.def(
-        "decode_turboquant_paged_fwd",
-        &flash_attention_turboquant_decode_paged,
+  m.def("decode_turboquant_paged_fwd", &flash_attention_turboquant_decode_paged,
         "FlashAttention decode over TurboQuant paged KV cache (Volta)");
-    m.def(
-        "prefill_paged_fwd",
-        &flash_attention_prefill_paged,
+  m.def("prefill_paged_fwd", &flash_attention_prefill_paged,
         "FlashAttention prefill over paged KV cache (Volta)");
-    m.def(
-        "prefill_paged_d256_bm32_allp_pair_scratch_fwd",
+  m.def("prefill_paged_d256_bm32_allp_pair_scratch_fwd",
         &flash_attention_prefill_paged_d256_bm32_allp_pair_scratch,
         "Fixed causal D256 BM32 ALL_P pair-scratch paged prefill (SM70)");
-    m.def(
-        "prefill_paged_d256_bm32_allp_pair_scratch_splitkv3_fwd",
+  m.def("prefill_paged_d256_bm32_allp_pair_scratch_splitkv3_fwd",
         &flash_attention_prefill_paged_d256_bm32_allp_pair_scratch_splitkv3,
-        "Fixed causal D256 BM32 ALL_P pair-scratch three-way split-KV paged prefill (SM70)");
-    m.def(
-        "prefill_paged_bfla_fwd",
-        &flash_attention_prefill_paged_bfla,
+        "Fixed causal D256 BM32 ALL_P pair-scratch three-way split-KV paged "
+        "prefill (SM70)");
+  m.def("prefill_paged_bfla_fwd", &flash_attention_prefill_paged_bfla,
         "BFLA sparse FlashAttention prefill over paged KV cache (Volta)");
-    m.def(
-        "prefill_paged_splitkv_fwd",
-        &flash_attention_prefill_paged_splitkv,
+  m.def("prefill_paged_splitkv_fwd", &flash_attention_prefill_paged_splitkv,
         "FlashAttention split-KV prefill over paged KV cache (Volta)");
-    m.def(
-        "fp8_e5m2_paged_kv_to_fp16",
-        &flash_attention_fp8_e5m2_paged_kv_to_fp16,
+  m.def("fp8_e5m2_paged_kv_to_fp16", &flash_attention_fp8_e5m2_paged_kv_to_fp16,
         "Expand paged FP8 E5M2 K/V into a preallocated FP16 paged workspace");
 }

--- a/flash-attention-v100/kernel/fused_mha_backward.cu
+++ b/flash-attention-v100/kernel/fused_mha_backward.cu
@@ -14,1176 +14,1235 @@ using namespace nvcuda::wmma;
 #define WMMA_N 16
 #define WMMA_K 16
 
-#define MAX_THREADS_PER_WARP    32
-#define MAX_THREADS_PER_SM      2048
-#define MAX_THREAD_BLOCK_SIZE   1024
+#define MAX_THREADS_PER_WARP 32
+#define MAX_THREADS_PER_SM 2048
+#define MAX_THREAD_BLOCK_SIZE 1024
 #define MAX_THREAD_BLOCK_PER_SM 32
-#define MAX_WARPS_PER_SM        64
-#define MAX_SM_PER_GPU          80
-#define MAX_SMEM_PER_SM         98304
+#define MAX_WARPS_PER_SM 64
+#define MAX_SM_PER_GPU 80
+#define MAX_SMEM_PER_SM 98304
 
-#define WARP_ALLOC_GROUP        4
+#define WARP_ALLOC_GROUP 4
 
-#define MAX_REG_PER_UNIT        256
-#define MAX_REG_PER_THREAD      255
-#define MAX_REG_PER_BLOCK       65536
-#define MAX_REG_BUFFER          65536
+#define MAX_REG_PER_UNIT 256
+#define MAX_REG_PER_THREAD 255
+#define MAX_REG_PER_BLOCK 65536
+#define MAX_REG_BUFFER 65536
 
-#define BLOCK_M_16  16
-#define BLOCK_N_16  256
-#define WARPS_16    16
+#define BLOCK_M_16 16
+#define BLOCK_N_16 256
+#define WARPS_16 16
 
-#define BLOCK_M_32  32
-#define BLOCK_N_32  128
-#define WARPS_32    16
+#define BLOCK_M_32 32
+#define BLOCK_N_32 128
+#define WARPS_32 16
 
-#define BLOCK_M_64  64
-#define BLOCK_N_64  80
-#define WARPS_64    16
+#define BLOCK_M_64 64
+#define BLOCK_N_64 80
+#define WARPS_64 16
 
 #define BLOCK_M_128 32
 #define BLOCK_N_128 112
-#define WARPS_128   16
+#define WARPS_128 16
 
 #define BLOCK_M_256 32
 #define BLOCK_N_256 32
-#define WARPS_256   16
+#define WARPS_256 16
 
-#define BLOCK_KV_16  32
-#define BLOCK_Q_16   224
+#define BLOCK_KV_16 32
+#define BLOCK_Q_16 224
 #define WARPS_DKV_16 14
 
-#define BLOCK_KV_32  32
-#define BLOCK_Q_32   192
+#define BLOCK_KV_32 32
+#define BLOCK_Q_32 192
 #define WARPS_DKV_32 12
 
-#define BLOCK_KV_64  32
-#define BLOCK_Q_64   128
-#define WARPS_DKV_64  8
+#define BLOCK_KV_64 32
+#define BLOCK_Q_64 128
+#define WARPS_DKV_64 8
 
-#define BLOCK_KV_128  16
-#define BLOCK_Q_128   144
+#define BLOCK_KV_128 16
+#define BLOCK_Q_128 144
 #define WARPS_DKV_128 12
 
-#define BLOCK_KV_256  16
-#define BLOCK_Q_256   64
+#define BLOCK_KV_256 16
+#define BLOCK_Q_256 64
 #define WARPS_DKV_256 16
 
-template<int D>
+template <int D>
 struct dQKernelConfig {
-    static constexpr int BLOCK_M = (D == 16) ? BLOCK_M_16 : (D == 32) ? BLOCK_M_32 : (D == 64)  ? BLOCK_M_64 : (D == 128) ? BLOCK_M_128 : BLOCK_M_256;
-    static constexpr int BLOCK_N = (D == 16) ? BLOCK_N_16 : (D == 32) ? BLOCK_N_32 : (D == 64)  ? BLOCK_N_64 : (D == 128) ? BLOCK_N_128 : BLOCK_N_256;
-    static constexpr int WARPS_PER_BLOCK = (D == 16) ? WARPS_16 : (D == 32) ? WARPS_32 : (D == 64) ? WARPS_64 : (D == 128) ? WARPS_128 : WARPS_256;
+  static constexpr int BLOCK_M = (D == 16)    ? BLOCK_M_16
+                                 : (D == 32)  ? BLOCK_M_32
+                                 : (D == 64)  ? BLOCK_M_64
+                                 : (D == 128) ? BLOCK_M_128
+                                              : BLOCK_M_256;
+  static constexpr int BLOCK_N = (D == 16)    ? BLOCK_N_16
+                                 : (D == 32)  ? BLOCK_N_32
+                                 : (D == 64)  ? BLOCK_N_64
+                                 : (D == 128) ? BLOCK_N_128
+                                              : BLOCK_N_256;
+  static constexpr int WARPS_PER_BLOCK = (D == 16)    ? WARPS_16
+                                         : (D == 32)  ? WARPS_32
+                                         : (D == 64)  ? WARPS_64
+                                         : (D == 128) ? WARPS_128
+                                                      : WARPS_256;
 
-    static constexpr int THREADS_PER_BLOCK  = WARPS_PER_BLOCK * MAX_THREADS_PER_WARP;
-    static constexpr int THREADS_PER_ROW    = THREADS_PER_BLOCK / BLOCK_M;
-    static constexpr int PAD                = (8 - (D % 32) + 32) % 32;
-    static constexpr int Q_STRIDE           = D + PAD;
-    static constexpr int KV_STRIDE          = D + PAD;
-    static constexpr int S_STRIDE           = BLOCK_N + PAD;
-    static constexpr int PER_UINT4          = 8;
-    static constexpr int NUM_UINT4_Q_BLOCK  = BLOCK_M * ((D + PER_UINT4 - 1) / PER_UINT4);
-    static constexpr int NUM_UINT4_KV_BLOCK = BLOCK_N * ((D + PER_UINT4 - 1) / PER_UINT4);
+  static constexpr int THREADS_PER_BLOCK =
+      WARPS_PER_BLOCK * MAX_THREADS_PER_WARP;
+  static constexpr int THREADS_PER_ROW = THREADS_PER_BLOCK / BLOCK_M;
+  static constexpr int PAD = (8 - (D % 32) + 32) % 32;
+  static constexpr int Q_STRIDE = D + PAD;
+  static constexpr int KV_STRIDE = D + PAD;
+  static constexpr int S_STRIDE = BLOCK_N + PAD;
+  static constexpr int PER_UINT4 = 8;
+  static constexpr int NUM_UINT4_Q_BLOCK =
+      BLOCK_M * ((D + PER_UINT4 - 1) / PER_UINT4);
+  static constexpr int NUM_UINT4_KV_BLOCK =
+      BLOCK_N * ((D + PER_UINT4 - 1) / PER_UINT4);
 
-    struct alignas(128) SmemLayout {
-        union {
-            alignas(16) __half k     [BLOCK_N * KV_STRIDE];
-            alignas(16) __half v     [BLOCK_N * KV_STRIDE];
-        } reuse_kv;
-            alignas(16) __half dO    [BLOCK_M * Q_STRIDE];
-            alignas(16) __half q     [BLOCK_M * Q_STRIDE];
-            alignas(16) float  s     [BLOCK_M * S_STRIDE];
-        union {
-            alignas(16) float  dOV   [BLOCK_M * S_STRIDE];
-            alignas(16) __half dS    [BLOCK_M * S_STRIDE];
-        } reuse_sdOVS;
-            alignas(16) float row_dot[BLOCK_M];
-            alignas(16) float lse    [BLOCK_M];
-            alignas(16) float dQ     [BLOCK_M * Q_STRIDE];
-    };
+  struct alignas(128) SmemLayout {
+    union {
+      alignas(16) __half k[BLOCK_N * KV_STRIDE];
+      alignas(16) __half v[BLOCK_N * KV_STRIDE];
+    } reuse_kv;
+    alignas(16) __half dO[BLOCK_M * Q_STRIDE];
+    alignas(16) __half q[BLOCK_M * Q_STRIDE];
+    alignas(16) float s[BLOCK_M * S_STRIDE];
+    union {
+      alignas(16) float dOV[BLOCK_M * S_STRIDE];
+      alignas(16) __half dS[BLOCK_M * S_STRIDE];
+    } reuse_sdOVS;
+    alignas(16) float row_dot[BLOCK_M];
+    alignas(16) float lse[BLOCK_M];
+    alignas(16) float dQ[BLOCK_M * Q_STRIDE];
+  };
 
-    static constexpr size_t TOTAL_SMEM = ((sizeof(SmemLayout) + 127) & ~size_t(127));
+  static constexpr size_t TOTAL_SMEM =
+      ((sizeof(SmemLayout) + 127) & ~size_t(127));
 };
 
-template<typename Config>
+template <typename Config>
 __device__ __forceinline__ void init_smem(char* smem_raw) {
-    constexpr int N_U4 = Config::TOTAL_SMEM / 16;
-    const int lane_id = threadIdx.x & 31;
+  constexpr int N_U4 = Config::TOTAL_SMEM / 16;
+  const int lane_id = threadIdx.x & 31;
 
-    uint32_t addr = static_cast<uint32_t>(__cvta_generic_to_shared(smem_raw));
-    #pragma unroll 1
-    for (int i = lane_id; i < N_U4; i += 32) {
-        asm volatile("st.shared.v4.u32 [%0], {%1,%1,%1,%1};"
-                     :: "r"(addr + (i << 4)), "r"(0) : "memory");
-    }
-    __syncwarp();
+  uint32_t addr = static_cast<uint32_t>(__cvta_generic_to_shared(smem_raw));
+#pragma unroll 1
+  for (int i = lane_id; i < N_U4; i += 32) {
+    asm volatile("st.shared.v4.u32 [%0], {%1,%1,%1,%1};" ::"r"(addr + (i << 4)),
+                 "r"(0)
+                 : "memory");
+  }
+  __syncwarp();
 }
 
-template<int D>
+template <int D>
 struct dKVKernelConfig {
-    static constexpr int BLOCK_M = (D == 16) ? BLOCK_KV_16 : (D == 32) ? BLOCK_KV_32 : (D == 64) ? BLOCK_KV_64 : (D == 128) ? BLOCK_KV_128 : BLOCK_KV_256;
-    static constexpr int BLOCK_N = (D == 16) ? BLOCK_Q_16 : (D == 32) ? BLOCK_Q_32 : (D == 64) ? BLOCK_Q_64 : (D == 128) ? BLOCK_Q_128 : BLOCK_Q_256;
-    static constexpr int WARPS_PER_BLOCK = (D == 16) ? WARPS_DKV_16 : (D == 32) ? WARPS_DKV_32 : (D == 64) ? WARPS_DKV_64 : (D == 128) ? WARPS_DKV_128 : WARPS_DKV_256;
+  static constexpr int BLOCK_M = (D == 16)    ? BLOCK_KV_16
+                                 : (D == 32)  ? BLOCK_KV_32
+                                 : (D == 64)  ? BLOCK_KV_64
+                                 : (D == 128) ? BLOCK_KV_128
+                                              : BLOCK_KV_256;
+  static constexpr int BLOCK_N = (D == 16)    ? BLOCK_Q_16
+                                 : (D == 32)  ? BLOCK_Q_32
+                                 : (D == 64)  ? BLOCK_Q_64
+                                 : (D == 128) ? BLOCK_Q_128
+                                              : BLOCK_Q_256;
+  static constexpr int WARPS_PER_BLOCK = (D == 16)    ? WARPS_DKV_16
+                                         : (D == 32)  ? WARPS_DKV_32
+                                         : (D == 64)  ? WARPS_DKV_64
+                                         : (D == 128) ? WARPS_DKV_128
+                                                      : WARPS_DKV_256;
 
-    static constexpr int THREADS_PER_BLOCK  = WARPS_PER_BLOCK * MAX_THREADS_PER_WARP;
-    static constexpr int THREADS_PER_ROW    = THREADS_PER_BLOCK / BLOCK_N;
-    static constexpr int PAD                = 8;
-    static constexpr int Q_STRIDE           = D + PAD;
-    static constexpr int KV_STRIDE          = D + PAD;
-    static constexpr int S_STRIDE           = BLOCK_M + PAD;
-    static constexpr int PER_UINT4          = 8;
-    static constexpr int NUM_UINT4_Q_BLOCK  = BLOCK_N * ((D + PER_UINT4 - 1) / PER_UINT4);
-    static constexpr int NUM_UINT4_KV_BLOCK = BLOCK_M * ((D + PER_UINT4 - 1) / PER_UINT4);
+  static constexpr int THREADS_PER_BLOCK =
+      WARPS_PER_BLOCK * MAX_THREADS_PER_WARP;
+  static constexpr int THREADS_PER_ROW = THREADS_PER_BLOCK / BLOCK_N;
+  static constexpr int PAD = 8;
+  static constexpr int Q_STRIDE = D + PAD;
+  static constexpr int KV_STRIDE = D + PAD;
+  static constexpr int S_STRIDE = BLOCK_M + PAD;
+  static constexpr int PER_UINT4 = 8;
+  static constexpr int NUM_UINT4_Q_BLOCK =
+      BLOCK_N * ((D + PER_UINT4 - 1) / PER_UINT4);
+  static constexpr int NUM_UINT4_KV_BLOCK =
+      BLOCK_M * ((D + PER_UINT4 - 1) / PER_UINT4);
 
-    struct alignas(128) SmemLayout {
-            alignas(16) __half k     [BLOCK_M * KV_STRIDE];
-            alignas(16) __half v     [BLOCK_M * KV_STRIDE];
-        union {
-            alignas(16) __half dO    [BLOCK_N * Q_STRIDE];
-            alignas(16) __half q     [BLOCK_N * Q_STRIDE];
-        } reuse_qdO;
-        union {
-            alignas(16) float  s     [BLOCK_N * S_STRIDE];
-            alignas(16) __half p     [BLOCK_N * BLOCK_M];
-        } reuse_sp;
-        union {
-            alignas(16) float  dOV   [BLOCK_N * S_STRIDE];
-            alignas(16) __half dS    [BLOCK_N * BLOCK_M];
-        } reuse_dOVS;
-            alignas(16) float row_dot[BLOCK_N];
-            alignas(16) float lse    [BLOCK_N];
-            alignas(16) float dK     [BLOCK_M * KV_STRIDE];
-            alignas(16) float dV     [BLOCK_M * KV_STRIDE];
-    };
+  struct alignas(128) SmemLayout {
+    alignas(16) __half k[BLOCK_M * KV_STRIDE];
+    alignas(16) __half v[BLOCK_M * KV_STRIDE];
+    union {
+      alignas(16) __half dO[BLOCK_N * Q_STRIDE];
+      alignas(16) __half q[BLOCK_N * Q_STRIDE];
+    } reuse_qdO;
+    union {
+      alignas(16) float s[BLOCK_N * S_STRIDE];
+      alignas(16) __half p[BLOCK_N * BLOCK_M];
+    } reuse_sp;
+    union {
+      alignas(16) float dOV[BLOCK_N * S_STRIDE];
+      alignas(16) __half dS[BLOCK_N * BLOCK_M];
+    } reuse_dOVS;
+    alignas(16) float row_dot[BLOCK_N];
+    alignas(16) float lse[BLOCK_N];
+    alignas(16) float dK[BLOCK_M * KV_STRIDE];
+    alignas(16) float dV[BLOCK_M * KV_STRIDE];
+  };
 
-    static constexpr size_t TOTAL_SMEM = ((sizeof(SmemLayout) + 127) & ~size_t(127));
+  static constexpr size_t TOTAL_SMEM =
+      ((sizeof(SmemLayout) + 127) & ~size_t(127));
 };
 
-template<int D, bool IS_CAUSAL>
+template <int D, bool IS_CAUSAL>
 __global__ void __launch_bounds__(dQKernelConfig<D>::THREADS_PER_BLOCK, 2)
-flash_attention_backward_dq_kernel(
-    const __half*  __restrict__ Q,
-    const __half*  __restrict__ K,
-    const __half*  __restrict__ V,
-    const __half*  __restrict__ O,
-    const __half*  __restrict__ dO,
-    const  float*  __restrict__ softmax_lse,
-          __half*  __restrict__ dQ,
-    const int B,
-    const int H,
-    const int M,
-    const int N,
-    const float softmax_scale
-) {
-    using Config = dQKernelConfig<D>;
+    flash_attention_backward_dq_kernel(
+        const __half* __restrict__ Q, const __half* __restrict__ K,
+        const __half* __restrict__ V, const __half* __restrict__ O,
+        const __half* __restrict__ dO, const float* __restrict__ softmax_lse,
+        __half* __restrict__ dQ, const int B, const int H, const int M,
+        const int N, const float softmax_scale) {
+  using Config = dQKernelConfig<D>;
 
-    constexpr int BLOCK_M           = Config::BLOCK_M;
-    constexpr int BLOCK_N           = Config::BLOCK_N;
-    constexpr int THREADS_PER_BLOCK = Config::THREADS_PER_BLOCK;
-    constexpr int THREADS_PER_ROW   = Config::THREADS_PER_ROW;
-    constexpr int WARPS_PER_BLOCK   = Config::WARPS_PER_BLOCK;
-    constexpr int Q_STRIDE          = Config::Q_STRIDE;
-    constexpr int KV_STRIDE         = Config::KV_STRIDE;
-    constexpr int S_STRIDE          = Config::S_STRIDE;
-    constexpr int PER_UINT4         = Config::PER_UINT4;
-    constexpr int NUM_UINT4_Q_BLOCK  = Config::NUM_UINT4_Q_BLOCK;
-    constexpr int NUM_UINT4_KV_BLOCK = Config::NUM_UINT4_KV_BLOCK;
+  constexpr int BLOCK_M = Config::BLOCK_M;
+  constexpr int BLOCK_N = Config::BLOCK_N;
+  constexpr int THREADS_PER_BLOCK = Config::THREADS_PER_BLOCK;
+  constexpr int THREADS_PER_ROW = Config::THREADS_PER_ROW;
+  constexpr int WARPS_PER_BLOCK = Config::WARPS_PER_BLOCK;
+  constexpr int Q_STRIDE = Config::Q_STRIDE;
+  constexpr int KV_STRIDE = Config::KV_STRIDE;
+  constexpr int S_STRIDE = Config::S_STRIDE;
+  constexpr int PER_UINT4 = Config::PER_UINT4;
+  constexpr int NUM_UINT4_Q_BLOCK = Config::NUM_UINT4_Q_BLOCK;
+  constexpr int NUM_UINT4_KV_BLOCK = Config::NUM_UINT4_KV_BLOCK;
 
-    const float NEG_INF = -1e30f;
+  const float NEG_INF = -1e30f;
 
-    const int batch_head_id = blockIdx.z;
-    if (batch_head_id >= B * H) return;
+  const int batch_head_id = blockIdx.z;
+  if (batch_head_id >= B * H) return;
 
-    const int block_m   = blockIdx.x;
-    const int start_row = block_m * BLOCK_M;
-    if (start_row >= M) return;
+  const int block_m = blockIdx.x;
+  const int start_row = block_m * BLOCK_M;
+  if (start_row >= M) return;
 
-    int num_n_tiles = (N + BLOCK_N - 1) / BLOCK_N;
-    const int valid_q_rows = min(BLOCK_M, M - start_row);
+  int num_n_tiles = (N + BLOCK_N - 1) / BLOCK_N;
+  const int valid_q_rows = min(BLOCK_M, M - start_row);
 
-    if constexpr (IS_CAUSAL) {
-        const int max_key_pos = start_row + valid_q_rows - 1;
-        if (max_key_pos < 0) {
-            num_n_tiles = 0;
-        } else {
-            num_n_tiles = min(num_n_tiles, (max_key_pos + BLOCK_N) / BLOCK_N);
-        }
+  if constexpr (IS_CAUSAL) {
+    const int max_key_pos = start_row + valid_q_rows - 1;
+    if (max_key_pos < 0) {
+      num_n_tiles = 0;
+    } else {
+      num_n_tiles = min(num_n_tiles, (max_key_pos + BLOCK_N) / BLOCK_N);
+    }
+  }
+
+  const int tid = threadIdx.x;
+  const int warp_id = tid / MAX_THREADS_PER_WARP;
+  const int lane_id = tid % MAX_THREADS_PER_WARP;
+
+  const __half* q_ptr = Q + (size_t)batch_head_id * M * D + start_row * D;
+  const __half* k_ptr = K + (size_t)batch_head_id * N * D;
+  const __half* v_ptr = V + (size_t)batch_head_id * N * D;
+  const __half* o_ptr = O + (size_t)batch_head_id * M * D + start_row * D;
+  const __half* dO_ptr = dO + (size_t)batch_head_id * M * D + start_row * D;
+  __half* dQ_ptr = dQ + (size_t)batch_head_id * M * D + start_row * D;
+  const float* lse_ptr = softmax_lse + (size_t)batch_head_id * M + start_row;
+
+  extern __shared__ char smem_raw[];
+  init_smem<Config>(smem_raw);
+  auto& smem = *reinterpret_cast<typename Config::SmemLayout*>(smem_raw);
+
+  __half* sK = smem.reuse_kv.k;
+  __half* sV = smem.reuse_kv.v;
+  __half* sdO = smem.dO;
+  __half* sQ = smem.q;
+  float* sS = smem.s;
+  float* sdOV = smem.reuse_sdOVS.dOV;
+  __half* sdS = smem.reuse_sdOVS.dS;
+  float* sRowDot = smem.row_dot;
+  float* sLse = smem.lse;
+  float* sdQ = smem.dQ;
+
+  const int d_stride_uint4 = (D + PER_UINT4 - 1) / PER_UINT4;
+  const int q_stride_uint4 = (Q_STRIDE + PER_UINT4 - 1) / PER_UINT4;
+  const int kv_stride_uint4 = (KV_STRIDE + PER_UINT4 - 1) / PER_UINT4;
+
+  const uint4* q_vec = reinterpret_cast<const uint4*>(q_ptr);
+  const uint4* do_vec = reinterpret_cast<const uint4*>(dO_ptr);
+  uint4* sQ_vec = reinterpret_cast<uint4*>(sQ);
+  uint4* sdO_vec = reinterpret_cast<uint4*>(sdO);
+
+#pragma unroll 2
+  for (int idx = tid; idx < NUM_UINT4_Q_BLOCK; idx += THREADS_PER_BLOCK) {
+    const int row = idx / d_stride_uint4;
+    const int vec_col = idx % d_stride_uint4;
+
+    uint4 q_val = make_uint4(0, 0, 0, 0);
+    uint4 do_val = make_uint4(0, 0, 0, 0);
+
+    if (row < valid_q_rows && vec_col < d_stride_uint4) {
+      q_val = __ldg(&q_vec[row * d_stride_uint4 + vec_col]);
+      do_val = __ldg(&do_vec[row * d_stride_uint4 + vec_col]);
+    }
+    sQ_vec[row * q_stride_uint4 + vec_col] = q_val;
+    sdO_vec[row * q_stride_uint4 + vec_col] = do_val;
+  }
+  __syncthreads();
+
+  if (tid < valid_q_rows * THREADS_PER_ROW) {
+    const int row = tid / THREADS_PER_ROW;
+    const int thread_in_row = tid % THREADS_PER_ROW;
+    const int fp16_x4_per_row = D / 4;
+    const int work_per_thread =
+        (fp16_x4_per_row + THREADS_PER_ROW - 1) / THREADS_PER_ROW;
+    const unsigned mask =
+        (valid_q_rows == BLOCK_M) ? 0xFFFFFFFFU : __activemask();
+
+    float thread_dot = 0.0f;
+
+#pragma unroll
+    for (int j = 0; j < work_per_thread; ++j) {
+      const int chunk_idx = thread_in_row + j * THREADS_PER_ROW;
+      if (chunk_idx >= fp16_x4_per_row) break;
+      const int col = chunk_idx * 4;
+
+      const __half* o_addr = o_ptr + row * D + col;
+      ushort o_h0, o_h1, o_h2, o_h3;
+      asm volatile("ld.global.v4.u16 {%0, %1, %2, %3}, [%4];"
+                   : "=h"(o_h0), "=h"(o_h1), "=h"(o_h2), "=h"(o_h3)
+                   : "l"(o_addr)
+                   : "memory");
+
+      const __half* dO_addr = sdO + row * Q_STRIDE + col;
+      ushort d_h0, d_h1, d_h2, d_h3;
+      const uint32_t ptr_dO = static_cast<uint32_t>(
+          reinterpret_cast<uintptr_t>(__cvta_generic_to_shared(dO_addr)));
+      asm volatile("ld.shared.v4.u16 {%0, %1, %2, %3}, [%4];"
+                   : "=h"(d_h0), "=h"(d_h1), "=h"(d_h2), "=h"(d_h3)
+                   : "r"(ptr_dO)
+                   : "memory");
+
+      const float fo_0 = __half2float(__ushort_as_half(o_h0));
+      const float fo_1 = __half2float(__ushort_as_half(o_h1));
+      const float fo_2 = __half2float(__ushort_as_half(o_h2));
+      const float fo_3 = __half2float(__ushort_as_half(o_h3));
+
+      const float fd_0 = __half2float(__ushort_as_half(d_h0));
+      const float fd_1 = __half2float(__ushort_as_half(d_h1));
+      const float fd_2 = __half2float(__ushort_as_half(d_h2));
+      const float fd_3 = __half2float(__ushort_as_half(d_h3));
+
+      thread_dot = __fmaf_rn(fo_0, fd_0, thread_dot);
+      thread_dot = __fmaf_rn(fo_1, fd_1, thread_dot);
+      thread_dot = __fmaf_rn(fo_2, fd_2, thread_dot);
+      thread_dot = __fmaf_rn(fo_3, fd_3, thread_dot);
     }
 
-    const int tid          = threadIdx.x;
-    const int warp_id      = tid / MAX_THREADS_PER_WARP;
-    const int lane_id      = tid % MAX_THREADS_PER_WARP;
+#pragma unroll
+    for (int o = THREADS_PER_ROW / 2; o > 0; o >>= 1)
+      thread_dot += __shfl_down_sync(mask, thread_dot, o, THREADS_PER_ROW);
 
-    const __half* q_ptr   = Q           + (size_t)batch_head_id * M * D + start_row * D;
-    const __half* k_ptr   = K           + (size_t)batch_head_id * N * D;
-    const __half* v_ptr   = V           + (size_t)batch_head_id * N * D;
-    const __half* o_ptr   = O           + (size_t)batch_head_id * M * D + start_row * D;
-    const __half* dO_ptr  = dO          + (size_t)batch_head_id * M * D + start_row * D;
-          __half* dQ_ptr  = dQ          + (size_t)batch_head_id * M * D + start_row * D;
-    const float*  lse_ptr = softmax_lse + (size_t)batch_head_id * M + start_row;
+    if (thread_in_row == 0) {
+      sRowDot[row] = thread_dot;
+    }
+  }
 
-    extern __shared__ char smem_raw[];
-    init_smem<Config>(smem_raw);
-    auto& smem = *reinterpret_cast<typename Config::SmemLayout*>(smem_raw);
+  if (tid < valid_q_rows) {
+    sLse[tid] = lse_ptr[tid];
+  }
+  __syncthreads();
 
-    __half* sK      = smem.reuse_kv.k;
-    __half* sV      = smem.reuse_kv.v;
-    __half* sdO     = smem.dO;
-    __half* sQ      = smem.q;
-     float* sS      = smem.s;
-     float* sdOV    = smem.reuse_sdOVS.dOV;
-    __half* sdS     = smem.reuse_sdOVS.dS;
-     float* sRowDot = smem.row_dot;
-     float* sLse    = smem.lse;
-     float* sdQ     = smem.dQ;
+  for (int block_n = 0; block_n < num_n_tiles; ++block_n) {
+    const int start_col = block_n * BLOCK_N;
+    if (start_col >= N) break;
+    const int valid_k_rows = min(BLOCK_N, N - start_col);
 
-    const int  d_stride_uint4 = (D + PER_UINT4 - 1) / PER_UINT4;
-    const int  q_stride_uint4 = (Q_STRIDE  + PER_UINT4 - 1) / PER_UINT4;
-    const int kv_stride_uint4 = (KV_STRIDE + PER_UINT4 - 1) / PER_UINT4;
+    if constexpr (IS_CAUSAL) {
+      if (start_col >= start_row + valid_q_rows) {
+        continue;
+      }
+    }
 
-    const uint4* q_vec  = reinterpret_cast<const uint4*>(q_ptr);
-    const uint4* do_vec = reinterpret_cast<const uint4*>(dO_ptr);
-    uint4* sQ_vec  = reinterpret_cast<uint4*>(sQ);
-    uint4* sdO_vec = reinterpret_cast<uint4*>(sdO);
+    const uint4* v_vec = reinterpret_cast<const uint4*>(v_ptr + start_col * D);
+    uint4* sV_vec = reinterpret_cast<uint4*>(sV);
 
-    #pragma unroll 2
-    for (int idx = tid; idx < NUM_UINT4_Q_BLOCK; idx += THREADS_PER_BLOCK) {
-        const int row = idx / d_stride_uint4;
-        const int vec_col = idx % d_stride_uint4;
+#pragma unroll 2
+    for (int idx = tid; idx < NUM_UINT4_KV_BLOCK; idx += THREADS_PER_BLOCK) {
+      const int row = idx / d_stride_uint4;
+      const int vec_col = idx % d_stride_uint4;
+      uint4 v_val = make_uint4(0, 0, 0, 0);
+      if (row < valid_k_rows && vec_col < d_stride_uint4) {
+        v_val = __ldg(&v_vec[row * d_stride_uint4 + vec_col]);
+      }
+      sV_vec[row * kv_stride_uint4 + vec_col] = v_val;
+    }
+    __syncthreads();
 
-        uint4 q_val  = make_uint4(0, 0, 0, 0);
-        uint4 do_val = make_uint4(0, 0, 0, 0);
+    const int num_tiles_m_dov = (BLOCK_M + WMMA_M - 1) / WMMA_M;
+    const int num_tiles_n_dov = (BLOCK_N + WMMA_N - 1) / WMMA_N;
+    const int num_tiles_k_dov = (D + WMMA_K - 1) / WMMA_K;
+    const int total_tiles_dov = num_tiles_m_dov * num_tiles_n_dov;
+    const int tiles_per_warp_dov =
+        (total_tiles_dov + WARPS_PER_BLOCK - 1) / WARPS_PER_BLOCK;
 
-        if (row < valid_q_rows && vec_col < d_stride_uint4) {
-            q_val =  __ldg(&q_vec[row * d_stride_uint4 + vec_col]);
-            do_val = __ldg(&do_vec[row * d_stride_uint4 + vec_col]);
+    for (int tile_idx = 0; tile_idx < tiles_per_warp_dov; ++tile_idx) {
+      const int global_tile_idx = warp_id * tiles_per_warp_dov + tile_idx;
+
+      if (global_tile_idx >= total_tiles_dov) break;
+
+      const int tile_m_idx = global_tile_idx / num_tiles_n_dov;
+      const int tile_n_idx = global_tile_idx % num_tiles_n_dov;
+
+      const int tile_m = tile_m_idx * WMMA_M;
+      const int tile_n = tile_n_idx * WMMA_N;
+
+      if (tile_m >= valid_q_rows || tile_n >= valid_k_rows) continue;
+
+      fragment<matrix_a, WMMA_M, WMMA_N, WMMA_K, __half, row_major> a_frag;
+      fragment<matrix_b, WMMA_M, WMMA_N, WMMA_K, __half, col_major> b_frag;
+      fragment<accumulator, WMMA_M, WMMA_N, WMMA_K, float> acc_frag;
+
+      fill_fragment(acc_frag, 0.0f);
+
+#pragma unroll
+      for (int k_tile = 0; k_tile < num_tiles_k_dov; ++k_tile) {
+        const int k_offset = k_tile * WMMA_K;
+        if (k_offset >= D) break;
+        load_matrix_sync(a_frag, sdO + tile_m * Q_STRIDE + k_offset, Q_STRIDE);
+        load_matrix_sync(b_frag, sV + tile_n * KV_STRIDE + k_offset, KV_STRIDE);
+        mma_sync(acc_frag, a_frag, b_frag, acc_frag);
+      }
+
+      store_matrix_sync(sdOV + tile_m * S_STRIDE + tile_n, acc_frag, S_STRIDE,
+                        mem_row_major);
+    }
+    __syncthreads();
+
+    const uint4* k_vec = reinterpret_cast<const uint4*>(k_ptr + start_col * D);
+    uint4* sK_vec = reinterpret_cast<uint4*>(sK);
+
+#pragma unroll 2
+    for (int idx = tid; idx < NUM_UINT4_KV_BLOCK; idx += THREADS_PER_BLOCK) {
+      const int row = idx / d_stride_uint4;
+      const int vec_col = idx % d_stride_uint4;
+      uint4 k_val = make_uint4(0, 0, 0, 0);
+      if (row < valid_k_rows && vec_col < d_stride_uint4) {
+        k_val = __ldg(&k_vec[row * d_stride_uint4 + vec_col]);
+      }
+      sK_vec[row * kv_stride_uint4 + vec_col] = k_val;
+    }
+    __syncthreads();
+
+    const int num_tiles_m_qk = (BLOCK_M + WMMA_M - 1) / WMMA_M;
+    const int num_tiles_n_qk = (BLOCK_N + WMMA_N - 1) / WMMA_N;
+    const int num_tiles_k_qk = (D + WMMA_K - 1) / WMMA_K;
+    const int total_tiles_qk = num_tiles_m_qk * num_tiles_n_qk;
+    const int tiles_per_warp_qk =
+        (total_tiles_qk + WARPS_PER_BLOCK - 1) / WARPS_PER_BLOCK;
+    const unsigned row_causal = (lane_id & 0b1) + ((lane_id >> 2) & 0b1) * 8 +
+                                ((lane_id >> 4) & 0b1) * 4;
+    const unsigned col_causal =
+        ((lane_id >> 1) & 0b1) * 2 + ((lane_id >> 3) & 0b1) * 8;
+
+    for (int tile_idx = 0; tile_idx < tiles_per_warp_qk; ++tile_idx) {
+      const int global_tile_idx = warp_id * tiles_per_warp_qk + tile_idx;
+
+      if (global_tile_idx >= total_tiles_qk) break;
+
+      const int tile_m_idx = global_tile_idx / num_tiles_n_qk;
+      const int tile_n_idx = global_tile_idx % num_tiles_n_qk;
+
+      const int tile_m = tile_m_idx * WMMA_M;
+      const int tile_n = tile_n_idx * WMMA_N;
+
+      if (tile_m >= valid_q_rows || tile_n >= valid_k_rows) continue;
+
+      fragment<matrix_a, WMMA_M, WMMA_N, WMMA_K, __half, row_major> a_frag;
+      fragment<matrix_b, WMMA_M, WMMA_N, WMMA_K, __half, col_major> b_frag;
+      fragment<accumulator, WMMA_M, WMMA_N, WMMA_K, float> acc_frag;
+
+      fill_fragment(acc_frag, 0.0f);
+
+#pragma unroll
+      for (int k_tile = 0; k_tile < num_tiles_k_qk; ++k_tile) {
+        const int k_offset = k_tile * WMMA_K;
+        if (k_offset >= D) break;
+        load_matrix_sync(a_frag, sQ + tile_m * Q_STRIDE + k_offset, Q_STRIDE);
+        load_matrix_sync(b_frag, sK + tile_n * KV_STRIDE + k_offset, KV_STRIDE);
+        mma_sync(acc_frag, a_frag, b_frag, acc_frag);
+      }
+
+      if constexpr (IS_CAUSAL) {
+#pragma unroll
+        for (int i = 0; i < acc_frag.num_elements; ++i) {
+          const unsigned col = col_causal + (i & 0b1) + ((i >> 2) & 0b1) * 4;
+          const unsigned row = row_causal + ((i >> 1) & 0b1) * 2;
+
+          const int global_m = start_row + tile_m + row;
+          const int global_n = start_col + tile_n + col;
+
+          const bool is_valid = (global_m < start_row + valid_q_rows) &&
+                                (global_n < start_col + valid_k_rows);
+
+          acc_frag.x[i] =
+              is_valid ? ((global_n > global_m) ? NEG_INF
+                                                : acc_frag.x[i] * softmax_scale)
+                       : NEG_INF;
         }
-         sQ_vec[row * q_stride_uint4 + vec_col] = q_val;
-        sdO_vec[row * q_stride_uint4 + vec_col] = do_val;
+      } else {
+#pragma unroll
+        for (int i = 0; i < acc_frag.num_elements; ++i) {
+          acc_frag.x[i] *= softmax_scale;
+        }
+      }
+      store_matrix_sync(sS + tile_m * S_STRIDE + tile_n, acc_frag, S_STRIDE,
+                        mem_row_major);
     }
     __syncthreads();
 
     if (tid < valid_q_rows * THREADS_PER_ROW) {
-        const int row = tid / THREADS_PER_ROW;
-        const int thread_in_row = tid % THREADS_PER_ROW;
-        const int fp16_x4_per_row = D / 4;
-        const int work_per_thread = (fp16_x4_per_row + THREADS_PER_ROW - 1) / THREADS_PER_ROW;
-        const unsigned mask = (valid_q_rows == BLOCK_M) ? 0xFFFFFFFFU : __activemask();
+      const int row = tid / THREADS_PER_ROW;
+      const int thread_in_row = tid % THREADS_PER_ROW;
 
-        float thread_dot = 0.0f;
+      float* sS_row = sS + row * S_STRIDE;
+      float* sdOV_row = sdOV + row * S_STRIDE;
+      __half* sdS_row = sdS + row * S_STRIDE;
 
-        #pragma unroll
-        for (int j = 0; j < work_per_thread; ++j) {
-            const int chunk_idx = thread_in_row + j * THREADS_PER_ROW;
-            if (chunk_idx >= fp16_x4_per_row) break;
-            const int col = chunk_idx * 4;
+      const float lse_val = sLse[row];
+      const float row_dot_val = sRowDot[row];
 
-            const __half* o_addr = o_ptr + row * D + col;
-            ushort o_h0, o_h1, o_h2, o_h3;
-            asm volatile(
-                "ld.global.v4.u16 {%0, %1, %2, %3}, [%4];"
-                : "=h"(o_h0), "=h"(o_h1), "=h"(o_h2), "=h"(o_h3)
-                : "l"(o_addr)
-                : "memory"
-            );
+      const int vec8_cols = valid_k_rows / 8;
+      const int vec8_per_thread =
+          (vec8_cols + THREADS_PER_ROW - 1) / THREADS_PER_ROW;
+      const int tail_start = vec8_cols * 8;
 
-            const __half* dO_addr = sdO + row * Q_STRIDE + col;
-            ushort d_h0, d_h1, d_h2, d_h3;
-            const uint32_t ptr_dO = static_cast<uint32_t>(reinterpret_cast<uintptr_t>(__cvta_generic_to_shared(dO_addr)));
-            asm volatile(
-                "ld.shared.v4.u16 {%0, %1, %2, %3}, [%4];"
-                : "=h"(d_h0), "=h"(d_h1), "=h"(d_h2), "=h"(d_h3)
-                : "r"(ptr_dO)
-                : "memory"
-            );
+      float4* sS_vec4 = reinterpret_cast<float4*>(sS_row);
+      float4* sdOV_vec4 = reinterpret_cast<float4*>(sdOV_row);
+      uint4* sdS_vec_u4 = reinterpret_cast<uint4*>(sdS_row);
 
-            const float fo_0 = __half2float(__ushort_as_half(o_h0));
-            const float fo_1 = __half2float(__ushort_as_half(o_h1));
-            const float fo_2 = __half2float(__ushort_as_half(o_h2));
-            const float fo_3 = __half2float(__ushort_as_half(o_h3));
+      uint4 buf[8];
+      int cnt = 0;
 
-            const float fd_0 = __half2float(__ushort_as_half(d_h0));
-            const float fd_1 = __half2float(__ushort_as_half(d_h1));
-            const float fd_2 = __half2float(__ushort_as_half(d_h2));
-            const float fd_3 = __half2float(__ushort_as_half(d_h3));
+#pragma unroll
+      for (int j = 0; j < vec8_per_thread; ++j) {
+        const int v8 = thread_in_row + j * THREADS_PER_ROW;
+        if (v8 >= vec8_cols) break;
 
-            thread_dot = __fmaf_rn(fo_0, fd_0, thread_dot);
-            thread_dot = __fmaf_rn(fo_1, fd_1, thread_dot);
-            thread_dot = __fmaf_rn(fo_2, fd_2, thread_dot);
-            thread_dot = __fmaf_rn(fo_3, fd_3, thread_dot);
+        float4 s0 = sS_vec4[v8 * 2], s1 = sS_vec4[v8 * 2 + 1];
+        float4 d0 = sdOV_vec4[v8 * 2], d1 = sdOV_vec4[v8 * 2 + 1];
+
+#define COMP(i, sf, df)                                 \
+  float sh##i = (sf) - lse_val;                         \
+  float p##i = (sh##i < -80.0f) ? 0.0f : __expf(sh##i); \
+  float ds##i = p##i * softmax_scale * ((df) - row_dot_val);
+
+        COMP(0, s0.x, d0.x);
+        COMP(1, s0.y, d0.y);
+        COMP(2, s0.z, d0.z);
+        COMP(3, s0.w, d0.w);
+        COMP(4, s1.x, d1.x);
+        COMP(5, s1.y, d1.y);
+        COMP(6, s1.z, d1.z);
+        COMP(7, s1.w, d1.w);
+#undef COMP
+
+        uint4 res;
+        asm volatile(
+            "{ mov.b32 %0, {%4,%5}; mov.b32 %1, {%6,%7}; mov.b32 %2, {%8,%9}; "
+            "mov.b32 %3, {%10,%11}; }\n"
+            : "=r"(res.x), "=r"(res.y), "=r"(res.z), "=r"(res.w)
+            : "h"(__half_as_ushort(__float2half_rn(ds0))),
+              "h"(__half_as_ushort(__float2half_rn(ds1))),
+              "h"(__half_as_ushort(__float2half_rn(ds2))),
+              "h"(__half_as_ushort(__float2half_rn(ds3))),
+              "h"(__half_as_ushort(__float2half_rn(ds4))),
+              "h"(__half_as_ushort(__float2half_rn(ds5))),
+              "h"(__half_as_ushort(__float2half_rn(ds6))),
+              "h"(__half_as_ushort(__float2half_rn(ds7))));
+        buf[cnt++] = res;
+      }
+
+#pragma unroll
+      for (int c = tail_start + thread_in_row; c < BLOCK_N;
+           c += THREADS_PER_ROW) {
+        float s = (c < valid_k_rows) ? sS_row[c] : NEG_INF;
+        float dov = (c < valid_k_rows) ? sdOV_row[c] : 0.0f;
+        float p = (s - lse_val < -80.0f) ? 0.0f : __expf(s - lse_val);
+        float ds = p * softmax_scale *
+                   ((c < valid_k_rows) ? (dov - row_dot_val) : 0.0f);
+        sdS_row[c] = __float2half_rn(ds);
+      }
+
+#pragma unroll
+      for (int i = 0; i < cnt; ++i) {
+        const int v8 = thread_in_row + i * THREADS_PER_ROW;
+        if (v8 < vec8_cols) {
+          sdS_vec_u4[v8] = buf[i];
         }
-
-        #pragma unroll
-        for (int o = THREADS_PER_ROW / 2; o > 0; o >>= 1)
-            thread_dot += __shfl_down_sync(mask, thread_dot, o, THREADS_PER_ROW);
-
-        if (thread_in_row == 0) {
-            sRowDot[row] = thread_dot;
-        }
+      }
     }
-
-    if (tid < valid_q_rows) { sLse[tid] = lse_ptr[tid]; }
     __syncthreads();
 
-    for (int block_n = 0; block_n < num_n_tiles; ++block_n) {
-        const int start_col = block_n * BLOCK_N;
-        if (start_col >= N) break;
-        const int valid_k_rows = min(BLOCK_N, N - start_col);
+    const int num_tiles_m_dq = (BLOCK_M + WMMA_M - 1) / WMMA_M;
+    const int num_tiles_n_dq = (D + WMMA_N - 1) / WMMA_N;
+    const int num_tiles_k_dq = (BLOCK_N + WMMA_K - 1) / WMMA_K;
+    const int total_tiles_dq = num_tiles_m_dq * num_tiles_n_dq;
+    const int tiles_per_warp_dq =
+        (total_tiles_dq + WARPS_PER_BLOCK - 1) / WARPS_PER_BLOCK;
 
-        if constexpr (IS_CAUSAL) {
-            if (start_col >= start_row + valid_q_rows) { continue; }
-        }
+    for (int tile_local = 0; tile_local < tiles_per_warp_dq; ++tile_local) {
+      const int global_tile_idx = warp_id * tiles_per_warp_dq + tile_local;
+      if (global_tile_idx >= total_tiles_dq) break;
 
-        const uint4* v_vec        = reinterpret_cast<const uint4*>(v_ptr + start_col * D);
-        uint4*       sV_vec       = reinterpret_cast<uint4*>(sV);
+      const int tile_m_idx = global_tile_idx / num_tiles_n_dq;
+      const int tile_n_idx = global_tile_idx % num_tiles_n_dq;
 
-        #pragma unroll 2
-        for (int idx = tid; idx < NUM_UINT4_KV_BLOCK; idx += THREADS_PER_BLOCK) {
-            const int row = idx / d_stride_uint4;
-            const int vec_col = idx % d_stride_uint4;
-            uint4 v_val = make_uint4(0, 0, 0, 0);
-            if (row < valid_k_rows && vec_col < d_stride_uint4) {
-                v_val = __ldg(&v_vec[row * d_stride_uint4 + vec_col]);
-            }
-            sV_vec[row * kv_stride_uint4 + vec_col] = v_val;
-        }
-        __syncthreads();
+      const int tile_m = tile_m_idx * WMMA_M;
+      const int tile_n = tile_n_idx * WMMA_N;
 
-        const int num_tiles_m_dov    = (BLOCK_M + WMMA_M - 1) / WMMA_M;
-        const int num_tiles_n_dov    = (BLOCK_N + WMMA_N - 1) / WMMA_N;
-        const int num_tiles_k_dov    = (D + WMMA_K - 1) / WMMA_K;
-        const int total_tiles_dov    = num_tiles_m_dov * num_tiles_n_dov;
-        const int tiles_per_warp_dov = (total_tiles_dov + WARPS_PER_BLOCK - 1) / WARPS_PER_BLOCK;
+      if (tile_m >= valid_q_rows || tile_n >= D) continue;
 
-        for (int tile_idx = 0; tile_idx < tiles_per_warp_dov; ++tile_idx) {
-            const int global_tile_idx = warp_id * tiles_per_warp_dov + tile_idx;
+      fragment<matrix_a, WMMA_M, WMMA_N, WMMA_K, __half, row_major> a_frag;
+      fragment<matrix_b, WMMA_M, WMMA_N, WMMA_K, __half, row_major> b_frag;
+      fragment<accumulator, WMMA_M, WMMA_N, WMMA_K, float> acc_frag;
+      fill_fragment(acc_frag, 0.0f);
 
-            if (global_tile_idx >= total_tiles_dov) break;
+#pragma unroll
+      for (int k_tile = 0; k_tile < num_tiles_k_dq; ++k_tile) {
+        const int k_offset = k_tile * WMMA_K;
+        if (k_offset >= valid_k_rows) break;
 
-            const int tile_m_idx = global_tile_idx / num_tiles_n_dov;
-            const int tile_n_idx = global_tile_idx % num_tiles_n_dov;
+        load_matrix_sync(a_frag, sdS + tile_m * S_STRIDE + k_offset, S_STRIDE);
+        load_matrix_sync(b_frag, sK + k_offset * KV_STRIDE + tile_n, KV_STRIDE);
+        mma_sync(acc_frag, a_frag, b_frag, acc_frag);
+      }
 
-            const int tile_m = tile_m_idx * WMMA_M;
-            const int tile_n = tile_n_idx * WMMA_N;
+      fragment<accumulator, WMMA_M, WMMA_N, WMMA_K, float> curr_frag;
+      load_matrix_sync(curr_frag, sdQ + tile_m * Q_STRIDE + tile_n, Q_STRIDE,
+                       mem_row_major);
 
-            if (tile_m >= valid_q_rows || tile_n >= valid_k_rows) continue;
-
-            fragment<matrix_a, WMMA_M, WMMA_N, WMMA_K, __half, row_major> a_frag;
-            fragment<matrix_b, WMMA_M, WMMA_N, WMMA_K, __half, col_major> b_frag;
-            fragment<accumulator, WMMA_M, WMMA_N, WMMA_K, float> acc_frag;
-
-            fill_fragment(acc_frag, 0.0f);
-
-            #pragma unroll
-            for (int k_tile = 0; k_tile < num_tiles_k_dov; ++k_tile) {
-                const int k_offset = k_tile * WMMA_K;
-                if (k_offset >= D) break;
-                load_matrix_sync(a_frag, sdO + tile_m * Q_STRIDE + k_offset, Q_STRIDE);
-                load_matrix_sync(b_frag, sV + tile_n * KV_STRIDE + k_offset, KV_STRIDE);
-                mma_sync(acc_frag, a_frag, b_frag, acc_frag);
-            }
-
-            store_matrix_sync(sdOV + tile_m * S_STRIDE + tile_n, acc_frag, S_STRIDE, mem_row_major);
-        }
-        __syncthreads();
-
-        const uint4* k_vec     = reinterpret_cast<const uint4*>(k_ptr + start_col * D);
-        uint4*       sK_vec    = reinterpret_cast<uint4*>(sK);
-
-        #pragma unroll 2
-        for (int idx = tid; idx < NUM_UINT4_KV_BLOCK; idx += THREADS_PER_BLOCK) {
-            const int row = idx / d_stride_uint4;
-            const int vec_col = idx % d_stride_uint4;
-            uint4 k_val = make_uint4(0, 0, 0, 0);
-            if (row < valid_k_rows && vec_col < d_stride_uint4) {
-                k_val = __ldg(&k_vec[row * d_stride_uint4 + vec_col]);
-            }
-            sK_vec[row * kv_stride_uint4 + vec_col] = k_val;
-        }
-        __syncthreads();
-
-        const int num_tiles_m_qk    = (BLOCK_M + WMMA_M - 1) / WMMA_M;
-        const int num_tiles_n_qk    = (BLOCK_N + WMMA_N - 1) / WMMA_N;
-        const int num_tiles_k_qk    = (D + WMMA_K - 1) / WMMA_K;
-        const int total_tiles_qk    = num_tiles_m_qk * num_tiles_n_qk;
-        const int tiles_per_warp_qk = (total_tiles_qk + WARPS_PER_BLOCK - 1) / WARPS_PER_BLOCK;
-        const unsigned row_causal   = (lane_id & 0b1) + ((lane_id >> 2) & 0b1) * 8 + ((lane_id >> 4) & 0b1) * 4;
-        const unsigned col_causal   = ((lane_id >> 1) & 0b1) * 2 + ((lane_id >> 3) & 0b1) * 8;
-
-        for (int tile_idx = 0; tile_idx < tiles_per_warp_qk; ++tile_idx) {
-            const int global_tile_idx = warp_id * tiles_per_warp_qk + tile_idx;
-
-            if (global_tile_idx >= total_tiles_qk) break;
-
-            const int tile_m_idx = global_tile_idx / num_tiles_n_qk;
-            const int tile_n_idx = global_tile_idx % num_tiles_n_qk;
-
-            const int tile_m = tile_m_idx * WMMA_M;
-            const int tile_n = tile_n_idx * WMMA_N;
-
-            if (tile_m >= valid_q_rows || tile_n >= valid_k_rows) continue;
-
-            fragment<matrix_a, WMMA_M, WMMA_N, WMMA_K, __half, row_major> a_frag;
-            fragment<matrix_b, WMMA_M, WMMA_N, WMMA_K, __half, col_major> b_frag;
-            fragment<accumulator, WMMA_M, WMMA_N, WMMA_K, float> acc_frag;
-
-            fill_fragment(acc_frag, 0.0f);
-
-            #pragma unroll
-            for (int k_tile = 0; k_tile < num_tiles_k_qk; ++k_tile) {
-                const int k_offset = k_tile * WMMA_K;
-                if (k_offset >= D) break;
-                load_matrix_sync(a_frag, sQ + tile_m * Q_STRIDE + k_offset, Q_STRIDE);
-                load_matrix_sync(b_frag, sK + tile_n * KV_STRIDE + k_offset, KV_STRIDE);
-                mma_sync(acc_frag, a_frag, b_frag, acc_frag);
-            }
-
-            if constexpr (IS_CAUSAL) {
-                #pragma unroll
-                for (int i = 0; i < acc_frag.num_elements; ++i) {
-                    const unsigned col = col_causal + (i & 0b1) + ((i >> 2) & 0b1) * 4;
-                    const unsigned row = row_causal + ((i >> 1) & 0b1) * 2;
-
-                    const int global_m = start_row + tile_m + row;
-                    const int global_n = start_col + tile_n + col;
-
-                    const bool is_valid = (global_m < start_row + valid_q_rows) &&
-                                          (global_n < start_col + valid_k_rows);
-
-                    acc_frag.x[i] = is_valid
-                        ? ((global_n > global_m) ? NEG_INF : acc_frag.x[i] * softmax_scale)
-                        : NEG_INF;
-                }
-            } else {
-                #pragma unroll
-                for (int i = 0; i < acc_frag.num_elements; ++i) {
-                    acc_frag.x[i] *= softmax_scale;
-                }
-            }
-            store_matrix_sync(sS + tile_m * S_STRIDE + tile_n, acc_frag, S_STRIDE, mem_row_major);
-        }
-        __syncthreads();
-
-        if (tid < valid_q_rows * THREADS_PER_ROW) {
-            const int row = tid / THREADS_PER_ROW;
-            const int thread_in_row = tid % THREADS_PER_ROW;
-
-            float*  sS_row   = sS   + row * S_STRIDE;
-            float*  sdOV_row = sdOV + row * S_STRIDE;
-            __half* sdS_row  = sdS  + row * S_STRIDE;
-
-            const float lse_val     = sLse[row];
-            const float row_dot_val = sRowDot[row];
-
-            const int vec8_cols = valid_k_rows / 8;
-            const int vec8_per_thread = (vec8_cols + THREADS_PER_ROW - 1) / THREADS_PER_ROW;
-            const int tail_start = vec8_cols * 8;
-
-            float4* sS_vec4    = reinterpret_cast<float4*>(sS_row);
-            float4* sdOV_vec4  = reinterpret_cast<float4*>(sdOV_row);
-            uint4*  sdS_vec_u4 = reinterpret_cast<uint4*>(sdS_row);
-
-            uint4 buf[8]; int cnt = 0;
-
-            #pragma unroll
-            for (int j = 0; j < vec8_per_thread; ++j) {
-                const int v8 = thread_in_row + j * THREADS_PER_ROW;
-                if (v8 >= vec8_cols) break;
-
-                float4 s0 = sS_vec4[v8 * 2],   s1 = sS_vec4[v8 * 2 + 1];
-                float4 d0 = sdOV_vec4[v8 * 2], d1 = sdOV_vec4[v8 * 2 + 1];
-
-                #define COMP(i, sf, df) \
-                    float sh##i = (sf) - lse_val; \
-                    float p##i = (sh##i < -80.0f) ? 0.0f : __expf(sh##i); \
-                    float ds##i = p##i * softmax_scale * ((df) - row_dot_val);
-
-                COMP(0, s0.x, d0.x) COMP(1, s0.y, d0.y) COMP(2, s0.z, d0.z) COMP(3, s0.w, d0.w)
-                COMP(4, s1.x, d1.x) COMP(5, s1.y, d1.y) COMP(6, s1.z, d1.z) COMP(7, s1.w, d1.w)
-                #undef COMP
-
-                uint4 res;
-                asm volatile(
-                    "{ mov.b32 %0, {%4,%5}; mov.b32 %1, {%6,%7}; mov.b32 %2, {%8,%9}; mov.b32 %3, {%10,%11}; }\n"
-                    : "=r"(res.x), "=r"(res.y), "=r"(res.z), "=r"(res.w)
-                    : "h"(__half_as_ushort(__float2half_rn(ds0))),
-                      "h"(__half_as_ushort(__float2half_rn(ds1))),
-                      "h"(__half_as_ushort(__float2half_rn(ds2))),
-                      "h"(__half_as_ushort(__float2half_rn(ds3))),
-                      "h"(__half_as_ushort(__float2half_rn(ds4))),
-                      "h"(__half_as_ushort(__float2half_rn(ds5))),
-                      "h"(__half_as_ushort(__float2half_rn(ds6))),
-                      "h"(__half_as_ushort(__float2half_rn(ds7)))
-                );
-                buf[cnt++] = res;
-            }
-
-            #pragma unroll
-            for (int c = tail_start + thread_in_row; c < BLOCK_N; c += THREADS_PER_ROW) {
-                float s = (c < valid_k_rows) ? sS_row[c] : NEG_INF;
-                float dov = (c < valid_k_rows) ? sdOV_row[c] : 0.0f;
-                float p = (s - lse_val < -80.0f) ? 0.0f : __expf(s - lse_val);
-                float ds = p * softmax_scale * ((c < valid_k_rows) ? (dov - row_dot_val) : 0.0f);
-                sdS_row[c] = __float2half_rn(ds);
-            }
-
-            #pragma unroll
-            for (int i = 0; i < cnt; ++i) {
-                    const int v8 = thread_in_row + i * THREADS_PER_ROW;
-                    if (v8 < vec8_cols) {
-                        sdS_vec_u4[v8] = buf[i];
-                    }
-            }
-        }
-        __syncthreads();
-
-        const int num_tiles_m_dq    = (BLOCK_M + WMMA_M - 1) / WMMA_M;
-        const int num_tiles_n_dq    = (D + WMMA_N - 1) / WMMA_N;
-        const int num_tiles_k_dq    = (BLOCK_N + WMMA_K - 1) / WMMA_K;
-        const int total_tiles_dq    = num_tiles_m_dq * num_tiles_n_dq;
-        const int tiles_per_warp_dq = (total_tiles_dq + WARPS_PER_BLOCK - 1) / WARPS_PER_BLOCK;
-
-        for (int tile_local = 0; tile_local < tiles_per_warp_dq; ++tile_local) {
-            const int global_tile_idx = warp_id * tiles_per_warp_dq + tile_local;
-            if (global_tile_idx >= total_tiles_dq) break;
-
-            const int tile_m_idx = global_tile_idx / num_tiles_n_dq;
-            const int tile_n_idx = global_tile_idx % num_tiles_n_dq;
-
-            const int tile_m = tile_m_idx * WMMA_M;
-            const int tile_n = tile_n_idx * WMMA_N;
-
-            if (tile_m >= valid_q_rows || tile_n >= D) continue;
-
-            fragment<matrix_a, WMMA_M, WMMA_N, WMMA_K, __half, row_major> a_frag;
-            fragment<matrix_b, WMMA_M, WMMA_N, WMMA_K, __half, row_major> b_frag;
-            fragment<accumulator, WMMA_M, WMMA_N, WMMA_K, float> acc_frag;
-            fill_fragment(acc_frag, 0.0f);
-
-            #pragma unroll
-            for (int k_tile = 0; k_tile < num_tiles_k_dq; ++k_tile) {
-                const int k_offset = k_tile * WMMA_K;
-                if (k_offset >= valid_k_rows) break;
-
-                load_matrix_sync(a_frag, sdS + tile_m * S_STRIDE + k_offset, S_STRIDE);
-                load_matrix_sync(b_frag, sK + k_offset * KV_STRIDE + tile_n, KV_STRIDE);
-                mma_sync(acc_frag, a_frag, b_frag, acc_frag);
-            }
-
-            fragment<accumulator, WMMA_M, WMMA_N, WMMA_K, float> curr_frag;
-            load_matrix_sync(curr_frag, sdQ + tile_m * Q_STRIDE + tile_n, Q_STRIDE, mem_row_major);
-
-            #pragma unroll
-            for (int i = 0; i < curr_frag.num_elements; ++i) {
-                curr_frag.x[i] += acc_frag.x[i];
-            }
-            store_matrix_sync(sdQ + tile_m * Q_STRIDE + tile_n, curr_frag, Q_STRIDE, mem_row_major);
-        }
-        __syncthreads();
+#pragma unroll
+      for (int i = 0; i < curr_frag.num_elements; ++i) {
+        curr_frag.x[i] += acc_frag.x[i];
+      }
+      store_matrix_sync(sdQ + tile_m * Q_STRIDE + tile_n, curr_frag, Q_STRIDE,
+                        mem_row_major);
     }
+    __syncthreads();
+  }
 
-    const int total_fp16_x4 = (valid_q_rows * D) / 4;
-    for (int i = tid; i < total_fp16_x4; i += THREADS_PER_BLOCK) {
-        const int row = i / (D / 4);
-        const int col = (i % (D / 4)) * 4;
+  const int total_fp16_x4 = (valid_q_rows * D) / 4;
+  for (int i = tid; i < total_fp16_x4; i += THREADS_PER_BLOCK) {
+    const int row = i / (D / 4);
+    const int col = (i % (D / 4)) * 4;
 
-        const float* s_dQ_row = sdQ + row * Q_STRIDE;
+    const float* s_dQ_row = sdQ + row * Q_STRIDE;
 
-        const __half h0 = __float2half_rn(s_dQ_row[col + 0]);
-        const __half h1 = __float2half_rn(s_dQ_row[col + 1]);
-        const __half h2 = __float2half_rn(s_dQ_row[col + 2]);
-        const __half h3 = __float2half_rn(s_dQ_row[col + 3]);
+    const __half h0 = __float2half_rn(s_dQ_row[col + 0]);
+    const __half h1 = __float2half_rn(s_dQ_row[col + 1]);
+    const __half h2 = __float2half_rn(s_dQ_row[col + 2]);
+    const __half h3 = __float2half_rn(s_dQ_row[col + 3]);
 
-        asm volatile(
-            "st.global.v4.u16 [%0], {%1, %2, %3, %4};"
-            :
-            : "l"(dQ_ptr + row * D + col),
-              "h"(__half_as_ushort(h0)),
-              "h"(__half_as_ushort(h1)),
-              "h"(__half_as_ushort(h2)),
-              "h"(__half_as_ushort(h3))
-            : "memory"
-        );
-    }
+    asm volatile("st.global.v4.u16 [%0], {%1, %2, %3, %4};"
+                 :
+                 : "l"(dQ_ptr + row * D + col), "h"(__half_as_ushort(h0)),
+                   "h"(__half_as_ushort(h1)), "h"(__half_as_ushort(h2)),
+                   "h"(__half_as_ushort(h3))
+                 : "memory");
+  }
 }
 
-template<int D, bool IS_CAUSAL>
+template <int D, bool IS_CAUSAL>
 __global__ void __launch_bounds__(dKVKernelConfig<D>::THREADS_PER_BLOCK, 2)
-flash_attention_backward_dkv_kernel(
-    const __half* __restrict__ Q,
-    const __half* __restrict__ K,
-    const __half* __restrict__ V,
-    const __half* __restrict__ O,
-    const __half* __restrict__ dO,
-    const  float* __restrict__ softmax_lse,
-          __half* __restrict__ dK,
-          __half* __restrict__ dV,
-    const int B,
-    const int H,
-    const int M,
-    const int N,
-    const float softmax_scale
-) {
-    using Config = dKVKernelConfig<D>;
-    constexpr int BLOCK_M            = Config::BLOCK_M;
-    constexpr int BLOCK_N            = Config::BLOCK_N;
-    constexpr int THREADS_PER_BLOCK  = Config::THREADS_PER_BLOCK;
-    constexpr int THREADS_PER_ROW    = Config::THREADS_PER_ROW;
-    constexpr int WARPS_PER_BLOCK    = Config::WARPS_PER_BLOCK;
-    constexpr int Q_STRIDE           = Config::Q_STRIDE;
-    constexpr int KV_STRIDE          = Config::KV_STRIDE;
-    constexpr int S_STRIDE           = Config::S_STRIDE;
-    constexpr int PER_UINT4          = Config::PER_UINT4;
-    constexpr int NUM_UINT4_Q_BLOCK  = Config::NUM_UINT4_Q_BLOCK;
-    constexpr int NUM_UINT4_KV_BLOCK = Config::NUM_UINT4_KV_BLOCK;
+    flash_attention_backward_dkv_kernel(
+        const __half* __restrict__ Q, const __half* __restrict__ K,
+        const __half* __restrict__ V, const __half* __restrict__ O,
+        const __half* __restrict__ dO, const float* __restrict__ softmax_lse,
+        __half* __restrict__ dK, __half* __restrict__ dV, const int B,
+        const int H, const int M, const int N, const float softmax_scale) {
+  using Config = dKVKernelConfig<D>;
+  constexpr int BLOCK_M = Config::BLOCK_M;
+  constexpr int BLOCK_N = Config::BLOCK_N;
+  constexpr int THREADS_PER_BLOCK = Config::THREADS_PER_BLOCK;
+  constexpr int THREADS_PER_ROW = Config::THREADS_PER_ROW;
+  constexpr int WARPS_PER_BLOCK = Config::WARPS_PER_BLOCK;
+  constexpr int Q_STRIDE = Config::Q_STRIDE;
+  constexpr int KV_STRIDE = Config::KV_STRIDE;
+  constexpr int S_STRIDE = Config::S_STRIDE;
+  constexpr int PER_UINT4 = Config::PER_UINT4;
+  constexpr int NUM_UINT4_Q_BLOCK = Config::NUM_UINT4_Q_BLOCK;
+  constexpr int NUM_UINT4_KV_BLOCK = Config::NUM_UINT4_KV_BLOCK;
 
-    const float NEG_INF = -1e30f;
-    const int batch_head_id = blockIdx.z;
-    if (batch_head_id >= B * H) return;
+  const float NEG_INF = -1e30f;
+  const int batch_head_id = blockIdx.z;
+  if (batch_head_id >= B * H) return;
 
-    const int block_kv = blockIdx.x;
-    const int start_kv = block_kv * BLOCK_M;
-    if (start_kv >= N) return;
+  const int block_kv = blockIdx.x;
+  const int start_kv = block_kv * BLOCK_M;
+  if (start_kv >= N) return;
 
-    int num_q_tiles = (M + BLOCK_N - 1) / BLOCK_N;
-    const int valid_kv_rows = min(BLOCK_M, N - start_kv);
+  int num_q_tiles = (M + BLOCK_N - 1) / BLOCK_N;
+  const int valid_kv_rows = min(BLOCK_M, N - start_kv);
 
-    const int tid     = threadIdx.x;
-    const int warp_id = tid / MAX_THREADS_PER_WARP;
-    const int lane_id = tid % MAX_THREADS_PER_WARP;
+  const int tid = threadIdx.x;
+  const int warp_id = tid / MAX_THREADS_PER_WARP;
+  const int lane_id = tid % MAX_THREADS_PER_WARP;
 
-    const __half*   q_ptr = Q           + (size_t)batch_head_id * M * D;
-    const __half*   k_ptr = K           + (size_t)batch_head_id * N * D + start_kv * D;
-    const __half*   v_ptr = V           + (size_t)batch_head_id * N * D + start_kv * D;
-    const __half*   o_ptr = O           + (size_t)batch_head_id * M * D;
-    const __half*  dO_ptr = dO          + (size_t)batch_head_id * M * D;
-    const  float* lse_ptr = softmax_lse + (size_t)batch_head_id * M;
-          __half*  dK_ptr = dK          + (size_t)batch_head_id * N * D + start_kv * D;
-          __half*  dV_ptr = dV          + (size_t)batch_head_id * N * D + start_kv * D;
+  const __half* q_ptr = Q + (size_t)batch_head_id * M * D;
+  const __half* k_ptr = K + (size_t)batch_head_id * N * D + start_kv * D;
+  const __half* v_ptr = V + (size_t)batch_head_id * N * D + start_kv * D;
+  const __half* o_ptr = O + (size_t)batch_head_id * M * D;
+  const __half* dO_ptr = dO + (size_t)batch_head_id * M * D;
+  const float* lse_ptr = softmax_lse + (size_t)batch_head_id * M;
+  __half* dK_ptr = dK + (size_t)batch_head_id * N * D + start_kv * D;
+  __half* dV_ptr = dV + (size_t)batch_head_id * N * D + start_kv * D;
 
-    extern __shared__ char smem_raw[];
-    init_smem<Config>(smem_raw);
-    auto& smem = *reinterpret_cast<typename Config::SmemLayout*>(smem_raw);
+  extern __shared__ char smem_raw[];
+  init_smem<Config>(smem_raw);
+  auto& smem = *reinterpret_cast<typename Config::SmemLayout*>(smem_raw);
 
-    __half* sK       = smem.k;
-    __half* sV       = smem.v;
-    __half* sdO      = smem.reuse_qdO.dO;
-    __half* sQ       = smem.reuse_qdO.q;
-     float* sS       = smem.reuse_sp.s;
-    __half* sP       = smem.reuse_sp.p;
-     float* sdOV     = smem.reuse_dOVS.dOV;
-    __half* sdS      = smem.reuse_dOVS.dS;
-     float* sRowDot  = smem.row_dot;
-     float* sLse     = smem.lse;
-     float* sdK      = smem.dK;
-     float* sdV      = smem.dV;
+  __half* sK = smem.k;
+  __half* sV = smem.v;
+  __half* sdO = smem.reuse_qdO.dO;
+  __half* sQ = smem.reuse_qdO.q;
+  float* sS = smem.reuse_sp.s;
+  __half* sP = smem.reuse_sp.p;
+  float* sdOV = smem.reuse_dOVS.dOV;
+  __half* sdS = smem.reuse_dOVS.dS;
+  float* sRowDot = smem.row_dot;
+  float* sLse = smem.lse;
+  float* sdK = smem.dK;
+  float* sdV = smem.dV;
 
-    const int  d_stride_uint4 = (D + PER_UINT4 - 1) / PER_UINT4;
-    const int  q_stride_uint4 = (Q_STRIDE  + PER_UINT4 - 1) / PER_UINT4;
-    const int kv_stride_uint4 = (KV_STRIDE + PER_UINT4 - 1) / PER_UINT4;
+  const int d_stride_uint4 = (D + PER_UINT4 - 1) / PER_UINT4;
+  const int q_stride_uint4 = (Q_STRIDE + PER_UINT4 - 1) / PER_UINT4;
+  const int kv_stride_uint4 = (KV_STRIDE + PER_UINT4 - 1) / PER_UINT4;
 
-    const uint4* k_vec = reinterpret_cast<const uint4*>(k_ptr);
-    const uint4* v_vec = reinterpret_cast<const uint4*>(v_ptr);
-    uint4* sK_vec = reinterpret_cast<uint4*>(sK);
-    uint4* sV_vec = reinterpret_cast<uint4*>(sV);
+  const uint4* k_vec = reinterpret_cast<const uint4*>(k_ptr);
+  const uint4* v_vec = reinterpret_cast<const uint4*>(v_ptr);
+  uint4* sK_vec = reinterpret_cast<uint4*>(sK);
+  uint4* sV_vec = reinterpret_cast<uint4*>(sV);
 
-    #pragma unroll 2
-    for (int idx = tid; idx < NUM_UINT4_KV_BLOCK; idx += THREADS_PER_BLOCK) {
-        const int row = idx / d_stride_uint4;
-        const int vec_col = idx % d_stride_uint4;
+#pragma unroll 2
+  for (int idx = tid; idx < NUM_UINT4_KV_BLOCK; idx += THREADS_PER_BLOCK) {
+    const int row = idx / d_stride_uint4;
+    const int vec_col = idx % d_stride_uint4;
 
-        uint4 k_val = make_uint4(0, 0, 0, 0);
-        uint4 v_val = make_uint4(0, 0, 0, 0);
+    uint4 k_val = make_uint4(0, 0, 0, 0);
+    uint4 v_val = make_uint4(0, 0, 0, 0);
 
-        if (row < valid_kv_rows && vec_col < d_stride_uint4) {
-            k_val = __ldg(&k_vec[row * d_stride_uint4 + vec_col]);
-            v_val = __ldg(&v_vec[row * d_stride_uint4 + vec_col]);
-        }
-        sK_vec[row * kv_stride_uint4 + vec_col] = k_val;
-        sV_vec[row * kv_stride_uint4 + vec_col] = v_val;
+    if (row < valid_kv_rows && vec_col < d_stride_uint4) {
+      k_val = __ldg(&k_vec[row * d_stride_uint4 + vec_col]);
+      v_val = __ldg(&v_vec[row * d_stride_uint4 + vec_col]);
+    }
+    sK_vec[row * kv_stride_uint4 + vec_col] = k_val;
+    sV_vec[row * kv_stride_uint4 + vec_col] = v_val;
+  }
+  __syncthreads();
+
+  for (int block_n = 0; block_n < num_q_tiles; ++block_n) {
+    const int start_col = block_n * BLOCK_N;
+    if (start_col >= M) break;
+    const int valid_q_rows = min(BLOCK_N, M - start_col);
+
+    if constexpr (IS_CAUSAL) {
+      if (start_kv >= start_col + valid_q_rows) {
+        continue;
+      }
+    }
+
+    const uint4* q_vec = reinterpret_cast<const uint4*>(q_ptr + start_col * D);
+    uint4* sQ_vec = reinterpret_cast<uint4*>(sdO);
+
+#pragma unroll 2
+    for (int idx = tid; idx < NUM_UINT4_Q_BLOCK; idx += THREADS_PER_BLOCK) {
+      const int row = idx / d_stride_uint4;
+      const int vec_col = idx % d_stride_uint4;
+      uint4 q_val = make_uint4(0, 0, 0, 0);
+      if (row < valid_q_rows && vec_col < d_stride_uint4) {
+        q_val = __ldg(&q_vec[row * d_stride_uint4 + vec_col]);
+      }
+      sQ_vec[row * q_stride_uint4 + vec_col] = q_val;
     }
     __syncthreads();
 
-    for (int block_n = 0; block_n < num_q_tiles; ++block_n) {
-        const int start_col = block_n * BLOCK_N;
-        if (start_col >= M) break;
-        const int valid_q_rows = min(BLOCK_N, M - start_col);
+    const int num_tiles_m_qk = (BLOCK_N + WMMA_M - 1) / WMMA_M;
+    const int num_tiles_n_qk = (BLOCK_M + WMMA_N - 1) / WMMA_N;
+    const int num_tiles_k_qk = (D + WMMA_K - 1) / WMMA_K;
+    const int total_tiles_qk = num_tiles_m_qk * num_tiles_n_qk;
+    const int tiles_per_warp_qk =
+        (total_tiles_qk + WARPS_PER_BLOCK - 1) / WARPS_PER_BLOCK;
+    const unsigned row_causal = (lane_id & 0b1) + ((lane_id >> 2) & 0b1) * 8 +
+                                ((lane_id >> 4) & 0b1) * 4;
+    const unsigned col_causal =
+        ((lane_id >> 1) & 0b1) * 2 + ((lane_id >> 3) & 0b1) * 8;
 
-        if constexpr (IS_CAUSAL) {
-            if (start_kv >= start_col + valid_q_rows) { continue; }
+    for (int tile_local = 0; tile_local < tiles_per_warp_qk; ++tile_local) {
+      const int tile_idx = warp_id * tiles_per_warp_qk + tile_local;
+      if (tile_idx >= total_tiles_qk) break;
+
+      const int tile_m_idx = tile_idx / num_tiles_n_qk;
+      const int tile_n_idx = tile_idx % num_tiles_n_qk;
+
+      const int tile_m = tile_m_idx * WMMA_M;
+      const int tile_n = tile_n_idx * WMMA_N;
+
+      if (tile_m >= valid_q_rows || tile_n >= valid_kv_rows) continue;
+
+      fragment<matrix_a, WMMA_M, WMMA_N, WMMA_K, half, row_major> a_frag;
+      fragment<matrix_b, WMMA_M, WMMA_N, WMMA_K, half, col_major> b_frag;
+      fragment<accumulator, WMMA_M, WMMA_N, WMMA_K, float> acc_frag;
+      fill_fragment(acc_frag, 0.0f);
+
+#pragma unroll
+      for (int k_tile = 0; k_tile < num_tiles_k_qk; ++k_tile) {
+        const int k_offset = k_tile * WMMA_K;
+        if (k_offset >= D) break;
+        load_matrix_sync(a_frag, sQ + tile_m * Q_STRIDE + k_offset, Q_STRIDE);
+        load_matrix_sync(b_frag, sK + tile_n * KV_STRIDE + k_offset, KV_STRIDE);
+        mma_sync(acc_frag, a_frag, b_frag, acc_frag);
+      }
+
+      if constexpr (IS_CAUSAL) {
+#pragma unroll
+        for (int i = 0; i < acc_frag.num_elements; ++i) {
+          const unsigned col = col_causal + (i & 0b1) + ((i >> 2) & 0b1) * 4;
+          const unsigned row = row_causal + ((i >> 1) & 0b1) * 2;
+
+          const int global_m = start_col + tile_m + row;
+          const int global_n = start_kv + tile_n + col;
+
+          const bool is_valid = (global_m < start_col + valid_q_rows) &&
+                                (global_n < start_kv + valid_kv_rows);
+
+          acc_frag.x[i] =
+              is_valid ? ((global_n > global_m) ? NEG_INF
+                                                : acc_frag.x[i] * softmax_scale)
+                       : NEG_INF;
         }
-
-        const uint4* q_vec = reinterpret_cast<const uint4*>(q_ptr + start_col * D);
-        uint4*      sQ_vec = reinterpret_cast<uint4*>(sdO);
-
-        #pragma unroll 2
-        for (int idx = tid; idx < NUM_UINT4_Q_BLOCK; idx += THREADS_PER_BLOCK) {
-            const int row = idx / d_stride_uint4;
-            const int vec_col = idx % d_stride_uint4;
-            uint4 q_val = make_uint4(0, 0, 0, 0);
-            if (row < valid_q_rows && vec_col < d_stride_uint4) {
-                q_val = __ldg(&q_vec[row * d_stride_uint4 + vec_col]);
-            }
-            sQ_vec[row * q_stride_uint4 + vec_col] = q_val;
+      } else {
+#pragma unroll
+        for (int i = 0; i < acc_frag.num_elements; ++i) {
+          acc_frag.x[i] *= softmax_scale;
         }
-        __syncthreads();
+      }
+      store_matrix_sync(sS + tile_m * S_STRIDE + tile_n, acc_frag, S_STRIDE,
+                        mem_row_major);
+    }
+    __syncthreads();
 
-        const int num_tiles_m_qk    = (BLOCK_N + WMMA_M - 1) / WMMA_M;
-        const int num_tiles_n_qk    = (BLOCK_M + WMMA_N - 1) / WMMA_N;
-        const int num_tiles_k_qk    = (D + WMMA_K - 1) / WMMA_K;
-        const int total_tiles_qk    = num_tiles_m_qk * num_tiles_n_qk;
-        const int tiles_per_warp_qk = (total_tiles_qk + WARPS_PER_BLOCK - 1) / WARPS_PER_BLOCK;
-        const unsigned row_causal   = (lane_id & 0b1) + ((lane_id >> 2) & 0b1) * 8 + ((lane_id >> 4) & 0b1) * 4;
-        const unsigned col_causal   = ((lane_id >> 1) & 0b1) * 2 + ((lane_id >> 3) & 0b1) * 8;
+    const uint4* do_vec =
+        reinterpret_cast<const uint4*>(dO_ptr + start_col * D);
+    uint4* sdO_vec = reinterpret_cast<uint4*>(sdO);
 
-        for (int tile_local = 0; tile_local < tiles_per_warp_qk; ++tile_local) {
-            const int tile_idx = warp_id * tiles_per_warp_qk + tile_local;
-            if (tile_idx >= total_tiles_qk) break;
+#pragma unroll 2
+    for (int idx = tid; idx < NUM_UINT4_Q_BLOCK; idx += THREADS_PER_BLOCK) {
+      const int row = idx / d_stride_uint4;
+      const int vec_col = idx % d_stride_uint4;
+      uint4 do_val = make_uint4(0, 0, 0, 0);
+      if (row < valid_q_rows && vec_col < d_stride_uint4) {
+        do_val = __ldg(&do_vec[row * d_stride_uint4 + vec_col]);
+      }
+      sdO_vec[row * q_stride_uint4 + vec_col] = do_val;
+    }
+    __syncthreads();
 
-            const int tile_m_idx = tile_idx / num_tiles_n_qk;
-            const int tile_n_idx = tile_idx % num_tiles_n_qk;
+    const __half* current_o_ptr = o_ptr + start_col * D;
 
-            const int tile_m = tile_m_idx * WMMA_M;
-            const int tile_n = tile_n_idx * WMMA_N;
+    if (tid < valid_q_rows * THREADS_PER_ROW) {
+      const int row = tid / THREADS_PER_ROW;
+      const int thread_in_row = tid % THREADS_PER_ROW;
+      const int fp16_x4_per_row = D / 4;
+      const int work_per_thread =
+          (fp16_x4_per_row + THREADS_PER_ROW - 1) / THREADS_PER_ROW;
+      const unsigned mask =
+          (valid_q_rows == BLOCK_N) ? 0xFFFFFFFFU : __activemask();
 
-            if (tile_m >= valid_q_rows || tile_n >= valid_kv_rows) continue;
+      float thread_dot = 0.0f;
 
-            fragment<matrix_a, WMMA_M, WMMA_N, WMMA_K, half, row_major> a_frag;
-            fragment<matrix_b, WMMA_M, WMMA_N, WMMA_K, half, col_major> b_frag;
-            fragment<accumulator, WMMA_M, WMMA_N, WMMA_K, float> acc_frag;
-            fill_fragment(acc_frag, 0.0f);
+#pragma unroll
+      for (int j = 0; j < work_per_thread; ++j) {
+        const int chunk_idx = thread_in_row + j * THREADS_PER_ROW;
+        if (chunk_idx >= fp16_x4_per_row) break;
+        const int col = chunk_idx * 4;
 
-            #pragma unroll
-            for (int k_tile = 0; k_tile < num_tiles_k_qk; ++k_tile) {
-                const int k_offset = k_tile * WMMA_K;
-                if (k_offset >= D) break;
-                load_matrix_sync(a_frag, sQ + tile_m * Q_STRIDE + k_offset, Q_STRIDE);
-                load_matrix_sync(b_frag, sK + tile_n * KV_STRIDE + k_offset, KV_STRIDE);
-                mma_sync(acc_frag, a_frag, b_frag, acc_frag);
-            }
+        const half* o_addr = current_o_ptr + row * D + col;
+        ushort o_h0, o_h1, o_h2, o_h3;
+        asm volatile("ld.global.v4.u16 {%0, %1, %2, %3}, [%4];"
+                     : "=h"(o_h0), "=h"(o_h1), "=h"(o_h2), "=h"(o_h3)
+                     : "l"(o_addr)
+                     : "memory");
 
-            if constexpr (IS_CAUSAL) {
-                #pragma unroll
-                for (int i = 0; i < acc_frag.num_elements; ++i) {
-                    const unsigned col = col_causal + (i & 0b1) + ((i >> 2) & 0b1) * 4;
-                    const unsigned row = row_causal + ((i >> 1) & 0b1) * 2;
+        const half* dO_addr = sdO + row * Q_STRIDE + col;
+        ushort d_h0, d_h1, d_h2, d_h3;
+        const uint32_t ptr_dO = static_cast<uint32_t>(
+            reinterpret_cast<uintptr_t>(__cvta_generic_to_shared(dO_addr)));
+        asm volatile("ld.shared.v4.u16 {%0, %1, %2, %3}, [%4];"
+                     : "=h"(d_h0), "=h"(d_h1), "=h"(d_h2), "=h"(d_h3)
+                     : "r"(ptr_dO)
+                     : "memory");
 
-                    const int global_m = start_col + tile_m + row;
-                    const int global_n = start_kv  + tile_n + col;
+        const float fo_0 = __half2float(__ushort_as_half(o_h0));
+        const float fo_1 = __half2float(__ushort_as_half(o_h1));
+        const float fo_2 = __half2float(__ushort_as_half(o_h2));
+        const float fo_3 = __half2float(__ushort_as_half(o_h3));
 
-                    const bool is_valid = (global_m < start_col + valid_q_rows) &&
-                                          (global_n < start_kv  + valid_kv_rows);
+        const float fd_0 = __half2float(__ushort_as_half(d_h0));
+        const float fd_1 = __half2float(__ushort_as_half(d_h1));
+        const float fd_2 = __half2float(__ushort_as_half(d_h2));
+        const float fd_3 = __half2float(__ushort_as_half(d_h3));
 
-                    acc_frag.x[i] = is_valid
-                        ? ((global_n > global_m) ? NEG_INF : acc_frag.x[i] * softmax_scale)
-                        : NEG_INF;
-                }
-            } else {
-                #pragma unroll
-                for (int i = 0; i < acc_frag.num_elements; ++i) {
-                    acc_frag.x[i] *= softmax_scale;
-                }
-            }
-            store_matrix_sync(sS + tile_m * S_STRIDE + tile_n, acc_frag, S_STRIDE, mem_row_major);
-        }
-        __syncthreads();
+        thread_dot = __fmaf_rn(fo_0, fd_0, thread_dot);
+        thread_dot = __fmaf_rn(fo_1, fd_1, thread_dot);
+        thread_dot = __fmaf_rn(fo_2, fd_2, thread_dot);
+        thread_dot = __fmaf_rn(fo_3, fd_3, thread_dot);
+      }
 
-        const uint4* do_vec = reinterpret_cast<const uint4*>(dO_ptr + start_col * D);
-        uint4*      sdO_vec = reinterpret_cast<uint4*>(sdO);
+#pragma unroll
+      for (int o = THREADS_PER_ROW / 2; o > 0; o >>= 1)
+        thread_dot += __shfl_down_sync(mask, thread_dot, o, THREADS_PER_ROW);
 
-        #pragma unroll 2
-        for (int idx = tid; idx < NUM_UINT4_Q_BLOCK; idx += THREADS_PER_BLOCK) {
-            const int row = idx / d_stride_uint4;
-            const int vec_col = idx % d_stride_uint4;
-            uint4 do_val = make_uint4(0, 0, 0, 0);
-            if (row < valid_q_rows && vec_col < d_stride_uint4) {
-                do_val = __ldg(&do_vec[row * d_stride_uint4 + vec_col]);
-            }
-            sdO_vec[row * q_stride_uint4 + vec_col] = do_val;
-        }
-        __syncthreads();
-
-        const __half* current_o_ptr = o_ptr + start_col * D;
-
-        if (tid < valid_q_rows * THREADS_PER_ROW) {
-            const int row = tid / THREADS_PER_ROW;
-            const int thread_in_row = tid % THREADS_PER_ROW;
-            const int fp16_x4_per_row = D / 4;
-            const int work_per_thread = (fp16_x4_per_row + THREADS_PER_ROW - 1) / THREADS_PER_ROW;
-            const unsigned mask = (valid_q_rows == BLOCK_N) ? 0xFFFFFFFFU : __activemask();
-
-            float thread_dot = 0.0f;
-
-            #pragma unroll
-            for (int j = 0; j < work_per_thread; ++j) {
-                const int chunk_idx = thread_in_row + j * THREADS_PER_ROW;
-                if (chunk_idx >= fp16_x4_per_row) break;
-                const int col = chunk_idx * 4;
-
-                const half* o_addr = current_o_ptr + row * D + col;
-                ushort o_h0, o_h1, o_h2, o_h3;
-                asm volatile(
-                    "ld.global.v4.u16 {%0, %1, %2, %3}, [%4];"
-                    : "=h"(o_h0), "=h"(o_h1), "=h"(o_h2), "=h"(o_h3)
-                    : "l"(o_addr)
-                    : "memory"
-                );
-
-                const half* dO_addr = sdO + row * Q_STRIDE + col;
-                ushort d_h0, d_h1, d_h2, d_h3;
-                const uint32_t ptr_dO = static_cast<uint32_t>(reinterpret_cast<uintptr_t>(__cvta_generic_to_shared(dO_addr)));
-                asm volatile(
-                    "ld.shared.v4.u16 {%0, %1, %2, %3}, [%4];"
-                    : "=h"(d_h0), "=h"(d_h1), "=h"(d_h2), "=h"(d_h3)
-                    : "r"(ptr_dO)
-                    : "memory"
-                );
-
-                const float fo_0 = __half2float(__ushort_as_half(o_h0));
-                const float fo_1 = __half2float(__ushort_as_half(o_h1));
-                const float fo_2 = __half2float(__ushort_as_half(o_h2));
-                const float fo_3 = __half2float(__ushort_as_half(o_h3));
-
-                const float fd_0 = __half2float(__ushort_as_half(d_h0));
-                const float fd_1 = __half2float(__ushort_as_half(d_h1));
-                const float fd_2 = __half2float(__ushort_as_half(d_h2));
-                const float fd_3 = __half2float(__ushort_as_half(d_h3));
-
-                thread_dot = __fmaf_rn(fo_0, fd_0, thread_dot);
-                thread_dot = __fmaf_rn(fo_1, fd_1, thread_dot);
-                thread_dot = __fmaf_rn(fo_2, fd_2, thread_dot);
-                thread_dot = __fmaf_rn(fo_3, fd_3, thread_dot);
-            }
-
-            #pragma unroll
-            for (int o = THREADS_PER_ROW / 2; o > 0; o >>= 1)
-                thread_dot += __shfl_down_sync(mask, thread_dot, o, THREADS_PER_ROW);
-
-            if (thread_in_row == 0) { sRowDot[row] = thread_dot; }
-        }
-
-        if (tid < valid_q_rows) { sLse[tid] = lse_ptr[start_col + tid]; }
-        __syncthreads();
-
-        const int num_tiles_m_dov    = (BLOCK_N + WMMA_M - 1) / WMMA_M;
-        const int num_tiles_n_dov    = (BLOCK_M + WMMA_N - 1) / WMMA_N;
-        const int num_tiles_k_dov    = (D + WMMA_K - 1) / WMMA_K;
-        const int total_tiles_dov    = num_tiles_m_dov * num_tiles_n_dov;
-        const int tiles_per_warp_dov = (total_tiles_dov + WARPS_PER_BLOCK - 1) / WARPS_PER_BLOCK;
-
-        for (int tile_local = 0; tile_local < tiles_per_warp_dov; ++tile_local) {
-            const int tile_idx = warp_id * tiles_per_warp_dov + tile_local;
-            if (tile_idx >= total_tiles_dov) break;
-
-            const int tile_m_idx = tile_idx / num_tiles_n_dov;
-            const int tile_n_idx = tile_idx % num_tiles_n_dov;
-
-            const int tile_m = tile_m_idx * WMMA_M;
-            const int tile_n = tile_n_idx * WMMA_N;
-
-            if (tile_m >= valid_q_rows || tile_n >= valid_kv_rows) continue;
-
-            fragment<matrix_a, WMMA_M, WMMA_N, WMMA_K, half, row_major> a_frag;
-            fragment<matrix_b, WMMA_M, WMMA_N, WMMA_K, half, col_major> b_frag;
-            fragment<accumulator, WMMA_M, WMMA_N, WMMA_K, float> acc_frag;
-            fill_fragment(acc_frag, 0.0f);
-
-            #pragma unroll
-            for (int k_tile = 0; k_tile < num_tiles_k_dov; ++k_tile) {
-                const int k_offset = k_tile * WMMA_K;
-                if (k_offset >= D) break;
-                load_matrix_sync(a_frag, sdO + tile_m * Q_STRIDE + k_offset, Q_STRIDE);
-                load_matrix_sync(b_frag, sV + tile_n * KV_STRIDE + k_offset, KV_STRIDE);
-                mma_sync(acc_frag, a_frag, b_frag, acc_frag);
-            }
-            store_matrix_sync(sdOV + tile_m * S_STRIDE + tile_n, acc_frag, S_STRIDE, mem_row_major);
-        }
-        __syncthreads();
-
-        const int total_elements = BLOCK_N * BLOCK_M;
-        const int total_pairs = (total_elements + 1) / 2;
-
-        #pragma unroll 2
-        for (int i = tid; i < total_pairs; i += THREADS_PER_BLOCK) {
-            const int linear_idx0 = i * 2;
-            const int linear_idx1 = linear_idx0 + 1;
-
-            const int row0 = linear_idx0 / BLOCK_M;
-            const int col0 = linear_idx0 % BLOCK_M;
-            const bool has_pair = (linear_idx1 < total_elements);
-            const int row1 = has_pair ? linear_idx1 / BLOCK_M : row0;
-            const int col1 = has_pair ? linear_idx1 % BLOCK_M : col0 + 1;
-
-            float s0 = 0.0f, s1 = 0.0f;
-            float dov0 = 0.0f, dov1 = 0.0f;
-
-            const bool in_bounds0 = (row0 < valid_q_rows) && (col0 < valid_kv_rows);
-            const bool causal_ok0 = !IS_CAUSAL || ((start_kv + col0) <= (start_col + row0));
-            const bool valid0 = in_bounds0 && causal_ok0;
-
-            bool valid1 = false;
-            if (has_pair) {
-                const bool in_bounds1 = (row1 < valid_q_rows) && (col1 < valid_kv_rows);
-                const bool causal_ok1 = !IS_CAUSAL || ((start_kv + col1) <= (start_col + row1));
-                valid1 = in_bounds1 && causal_ok1;
-            }
-
-            if (valid0) { s0 = sS[row0 * S_STRIDE + col0]; dov0 = sdOV[row0 * S_STRIDE + col0]; } else { s0 = NEG_INF; }
-            if (valid1) { s1 = sS[row1 * S_STRIDE + col1]; dov1 = sdOV[row1 * S_STRIDE + col1]; } else { s1 = NEG_INF; }
-
-            float lse0 = sLse[row0];
-            float lse1 = (valid1 && row1 != row0) ? sLse[row1] : lse0;
-            float row_dot0 = sRowDot[row0];
-            float row_dot1 = (valid1 && row1 != row0) ? sRowDot[row1] : row_dot0;
-
-            float shifted0 = s0 - lse0;
-            float shifted1 = s1 - lse1;
-
-            float p0 = (shifted0 < -80.0f) ? 0.0f : __expf(shifted0);
-            float p1 = (shifted1 < -80.0f) ? 0.0f : __expf(shifted1);
-
-            float diff0 = dov0 - row_dot0;
-            float diff1 = dov1 - row_dot1;
-            float ds0 = valid0 ? fmaf(p0, softmax_scale * diff0, 0.0f) : 0.0f;
-            float ds1 = valid1 ? fmaf(p1, softmax_scale * diff1, 0.0f) : 0.0f;
-
-            __half2 p_h2 = __float22half2_rn(make_float2(p0, p1));
-            __half2 ds_h2 = __float22half2_rn(make_float2(ds0, ds1));
-
-            if (col1 < BLOCK_M && row1 == row0) {
-                __half* p_dst  = sP  + row0 * BLOCK_M + col0;
-                __half* ds_dst = sdS + row0 * BLOCK_M + col0;
-                p_dst[0]  = p_h2.x;  p_dst[1]  = p_h2.y;
-                ds_dst[0] = ds_h2.x; ds_dst[1] = ds_h2.y;
-            } else {
-                if (valid0) { sP[row0 * BLOCK_M + col0] = p_h2.x; sdS[row0 * BLOCK_M + col0] = ds_h2.x; }
-                if (valid1) { sP[row1 * BLOCK_M + col1] = p_h2.y; sdS[row1 * BLOCK_M + col1] = ds_h2.y; }
-            }
-        }
-        __syncthreads();
-
-        const int num_tiles_m_dv    = (BLOCK_M + WMMA_M - 1) / WMMA_M;
-        const int num_tiles_n_dv    = (D + WMMA_N - 1) / WMMA_N;
-        const int num_tiles_k_dv    = (BLOCK_N + WMMA_K - 1) / WMMA_K;
-        const int total_tiles_dv    = num_tiles_m_dv * num_tiles_n_dv;
-        const int tiles_per_warp_dv = (total_tiles_dv + WARPS_PER_BLOCK - 1) / WARPS_PER_BLOCK;
-
-        for (int tile_local = 0; tile_local < tiles_per_warp_dv; ++tile_local) {
-            const int tile_idx = warp_id * tiles_per_warp_dv + tile_local;
-            if (tile_idx >= total_tiles_dv) break;
-
-            const int tile_m_idx = tile_idx / num_tiles_n_dv;
-            const int tile_n_idx = tile_idx % num_tiles_n_dv;
-
-            const int tile_m = tile_m_idx * WMMA_M;
-            const int tile_n = tile_n_idx * WMMA_N;
-
-            if (tile_m >= valid_kv_rows || tile_n >= D) continue;
-
-            fragment<matrix_a, WMMA_M, WMMA_N, WMMA_K, half, col_major> a_frag;
-            fragment<matrix_b, WMMA_M, WMMA_N, WMMA_K, half, row_major> b_frag;
-            fragment<accumulator, WMMA_M, WMMA_N, WMMA_K, float> acc_frag;
-            load_matrix_sync(acc_frag, sdV + tile_m * KV_STRIDE + tile_n, KV_STRIDE, mem_row_major);
-
-            #pragma unroll
-            for (int k_tile = 0; k_tile < num_tiles_k_dv; ++k_tile) {
-                const int k_offset = k_tile * WMMA_K;
-                if (k_offset >= valid_q_rows) break;
-
-                load_matrix_sync(a_frag, sP + k_offset * BLOCK_M + tile_m, BLOCK_M);
-                load_matrix_sync(b_frag, sdO + k_offset * Q_STRIDE + tile_n, Q_STRIDE);
-                mma_sync(acc_frag, a_frag, b_frag, acc_frag);
-            }
-            store_matrix_sync(sdV + tile_m * KV_STRIDE + tile_n, acc_frag, KV_STRIDE, mem_row_major);
-        }
-        __syncthreads();
-
-        __half* sQ = sdO;
-        #pragma unroll 2
-        for (int idx = tid; idx < NUM_UINT4_Q_BLOCK; idx += THREADS_PER_BLOCK) {
-            const int row = idx / d_stride_uint4;
-            const int vec_col = idx % d_stride_uint4;
-            uint4 q_val = make_uint4(0, 0, 0, 0);
-            if (row < valid_q_rows && vec_col < d_stride_uint4) {
-                q_val = __ldg(&q_vec[row * d_stride_uint4 + vec_col]);
-            }
-            sQ_vec[row * q_stride_uint4 + vec_col] = q_val;
-        }
-        __syncthreads();
-
-        const int num_tiles_m_dk    = (BLOCK_M + WMMA_M - 1) / WMMA_M;
-        const int num_tiles_n_dk    = (D + WMMA_N - 1) / WMMA_N;
-        const int num_tiles_k_dk    = (BLOCK_N + WMMA_K - 1) / WMMA_K;
-        const int total_tiles_dk    = num_tiles_m_dk * num_tiles_n_dk;
-        const int tiles_per_warp_dk = (total_tiles_dk + WARPS_PER_BLOCK - 1) / WARPS_PER_BLOCK;
-
-        for (int tile_local = 0; tile_local < tiles_per_warp_dk; ++tile_local) {
-            const int tile_idx = warp_id * tiles_per_warp_dk + tile_local;
-            if (tile_idx >= total_tiles_dk) break;
-
-            const int tile_m_idx = tile_idx / num_tiles_n_dk;
-            const int tile_n_idx = tile_idx % num_tiles_n_dk;
-
-            const int tile_m = tile_m_idx * WMMA_M;
-            const int tile_n = tile_n_idx * WMMA_N;
-
-            if (tile_m >= valid_kv_rows || tile_n >= D) continue;
-
-            fragment<matrix_a, WMMA_M, WMMA_N, WMMA_K, half, col_major> a_frag;
-            fragment<matrix_b, WMMA_M, WMMA_N, WMMA_K, half, row_major> b_frag;
-            fragment<accumulator, WMMA_M, WMMA_N, WMMA_K, float> acc_frag;
-            load_matrix_sync(acc_frag, sdK + tile_m * KV_STRIDE + tile_n, KV_STRIDE, mem_row_major);
-
-            #pragma unroll
-            for (int k_tile = 0; k_tile < num_tiles_k_dk; ++k_tile) {
-                const int k_offset = k_tile * WMMA_K;
-                if (k_offset >= valid_q_rows) break;
-
-                load_matrix_sync(a_frag, sdS + k_offset * BLOCK_M + tile_m, BLOCK_M);
-                load_matrix_sync(b_frag, sQ + k_offset * Q_STRIDE + tile_n, Q_STRIDE);
-                mma_sync(acc_frag, a_frag, b_frag, acc_frag);
-            }
-            store_matrix_sync(sdK + tile_m * KV_STRIDE + tile_n, acc_frag, KV_STRIDE, mem_row_major);
-        }
-        __syncthreads();
+      if (thread_in_row == 0) {
+        sRowDot[row] = thread_dot;
+      }
     }
 
-    const int total_fp16_x4 = (valid_kv_rows * D) / 4;
-    for (int i = tid; i < total_fp16_x4; i += THREADS_PER_BLOCK) {
-        const int row = i / (D / 4);
-        const int col = (i % (D / 4)) * 4;
-
-        const float* s_dK_row = sdK + row * KV_STRIDE;
-        const float* s_dV_row = sdV + row * KV_STRIDE;
-
-        const __half hk0 = __float2half_rn(s_dK_row[col + 0]);
-        const __half hk1 = __float2half_rn(s_dK_row[col + 1]);
-        const __half hk2 = __float2half_rn(s_dK_row[col + 2]);
-        const __half hk3 = __float2half_rn(s_dK_row[col + 3]);
-
-        const __half hv0 = __float2half_rn(s_dV_row[col + 0]);
-        const __half hv1 = __float2half_rn(s_dV_row[col + 1]);
-        const __half hv2 = __float2half_rn(s_dV_row[col + 2]);
-        const __half hv3 = __float2half_rn(s_dV_row[col + 3]);
-
-        asm volatile(
-            "st.global.v4.u16 [%0], {%1, %2, %3, %4};"
-            :
-            : "l"(dK_ptr + row * D + col),
-              "h"(__half_as_ushort(hk0)),
-              "h"(__half_as_ushort(hk1)),
-              "h"(__half_as_ushort(hk2)),
-              "h"(__half_as_ushort(hk3))
-            : "memory"
-        );
-
-        asm volatile(
-            "st.global.v4.u16 [%0], {%1, %2, %3, %4};"
-            :
-            : "l"(dV_ptr + row * D + col),
-              "h"(__half_as_ushort(hv0)),
-              "h"(__half_as_ushort(hv1)),
-              "h"(__half_as_ushort(hv2)),
-              "h"(__half_as_ushort(hv3))
-            : "memory"
-        );
+    if (tid < valid_q_rows) {
+      sLse[tid] = lse_ptr[start_col + tid];
     }
+    __syncthreads();
+
+    const int num_tiles_m_dov = (BLOCK_N + WMMA_M - 1) / WMMA_M;
+    const int num_tiles_n_dov = (BLOCK_M + WMMA_N - 1) / WMMA_N;
+    const int num_tiles_k_dov = (D + WMMA_K - 1) / WMMA_K;
+    const int total_tiles_dov = num_tiles_m_dov * num_tiles_n_dov;
+    const int tiles_per_warp_dov =
+        (total_tiles_dov + WARPS_PER_BLOCK - 1) / WARPS_PER_BLOCK;
+
+    for (int tile_local = 0; tile_local < tiles_per_warp_dov; ++tile_local) {
+      const int tile_idx = warp_id * tiles_per_warp_dov + tile_local;
+      if (tile_idx >= total_tiles_dov) break;
+
+      const int tile_m_idx = tile_idx / num_tiles_n_dov;
+      const int tile_n_idx = tile_idx % num_tiles_n_dov;
+
+      const int tile_m = tile_m_idx * WMMA_M;
+      const int tile_n = tile_n_idx * WMMA_N;
+
+      if (tile_m >= valid_q_rows || tile_n >= valid_kv_rows) continue;
+
+      fragment<matrix_a, WMMA_M, WMMA_N, WMMA_K, half, row_major> a_frag;
+      fragment<matrix_b, WMMA_M, WMMA_N, WMMA_K, half, col_major> b_frag;
+      fragment<accumulator, WMMA_M, WMMA_N, WMMA_K, float> acc_frag;
+      fill_fragment(acc_frag, 0.0f);
+
+#pragma unroll
+      for (int k_tile = 0; k_tile < num_tiles_k_dov; ++k_tile) {
+        const int k_offset = k_tile * WMMA_K;
+        if (k_offset >= D) break;
+        load_matrix_sync(a_frag, sdO + tile_m * Q_STRIDE + k_offset, Q_STRIDE);
+        load_matrix_sync(b_frag, sV + tile_n * KV_STRIDE + k_offset, KV_STRIDE);
+        mma_sync(acc_frag, a_frag, b_frag, acc_frag);
+      }
+      store_matrix_sync(sdOV + tile_m * S_STRIDE + tile_n, acc_frag, S_STRIDE,
+                        mem_row_major);
+    }
+    __syncthreads();
+
+    const int total_elements = BLOCK_N * BLOCK_M;
+    const int total_pairs = (total_elements + 1) / 2;
+
+#pragma unroll 2
+    for (int i = tid; i < total_pairs; i += THREADS_PER_BLOCK) {
+      const int linear_idx0 = i * 2;
+      const int linear_idx1 = linear_idx0 + 1;
+
+      const int row0 = linear_idx0 / BLOCK_M;
+      const int col0 = linear_idx0 % BLOCK_M;
+      const bool has_pair = (linear_idx1 < total_elements);
+      const int row1 = has_pair ? linear_idx1 / BLOCK_M : row0;
+      const int col1 = has_pair ? linear_idx1 % BLOCK_M : col0 + 1;
+
+      float s0 = 0.0f, s1 = 0.0f;
+      float dov0 = 0.0f, dov1 = 0.0f;
+
+      const bool in_bounds0 = (row0 < valid_q_rows) && (col0 < valid_kv_rows);
+      const bool causal_ok0 =
+          !IS_CAUSAL || ((start_kv + col0) <= (start_col + row0));
+      const bool valid0 = in_bounds0 && causal_ok0;
+
+      bool valid1 = false;
+      if (has_pair) {
+        const bool in_bounds1 = (row1 < valid_q_rows) && (col1 < valid_kv_rows);
+        const bool causal_ok1 =
+            !IS_CAUSAL || ((start_kv + col1) <= (start_col + row1));
+        valid1 = in_bounds1 && causal_ok1;
+      }
+
+      if (valid0) {
+        s0 = sS[row0 * S_STRIDE + col0];
+        dov0 = sdOV[row0 * S_STRIDE + col0];
+      } else {
+        s0 = NEG_INF;
+      }
+      if (valid1) {
+        s1 = sS[row1 * S_STRIDE + col1];
+        dov1 = sdOV[row1 * S_STRIDE + col1];
+      } else {
+        s1 = NEG_INF;
+      }
+
+      float lse0 = sLse[row0];
+      float lse1 = (valid1 && row1 != row0) ? sLse[row1] : lse0;
+      float row_dot0 = sRowDot[row0];
+      float row_dot1 = (valid1 && row1 != row0) ? sRowDot[row1] : row_dot0;
+
+      float shifted0 = s0 - lse0;
+      float shifted1 = s1 - lse1;
+
+      float p0 = (shifted0 < -80.0f) ? 0.0f : __expf(shifted0);
+      float p1 = (shifted1 < -80.0f) ? 0.0f : __expf(shifted1);
+
+      float diff0 = dov0 - row_dot0;
+      float diff1 = dov1 - row_dot1;
+      float ds0 = valid0 ? fmaf(p0, softmax_scale * diff0, 0.0f) : 0.0f;
+      float ds1 = valid1 ? fmaf(p1, softmax_scale * diff1, 0.0f) : 0.0f;
+
+      __half2 p_h2 = __float22half2_rn(make_float2(p0, p1));
+      __half2 ds_h2 = __float22half2_rn(make_float2(ds0, ds1));
+
+      if (col1 < BLOCK_M && row1 == row0) {
+        __half* p_dst = sP + row0 * BLOCK_M + col0;
+        __half* ds_dst = sdS + row0 * BLOCK_M + col0;
+        p_dst[0] = p_h2.x;
+        p_dst[1] = p_h2.y;
+        ds_dst[0] = ds_h2.x;
+        ds_dst[1] = ds_h2.y;
+      } else {
+        if (valid0) {
+          sP[row0 * BLOCK_M + col0] = p_h2.x;
+          sdS[row0 * BLOCK_M + col0] = ds_h2.x;
+        }
+        if (valid1) {
+          sP[row1 * BLOCK_M + col1] = p_h2.y;
+          sdS[row1 * BLOCK_M + col1] = ds_h2.y;
+        }
+      }
+    }
+    __syncthreads();
+
+    const int num_tiles_m_dv = (BLOCK_M + WMMA_M - 1) / WMMA_M;
+    const int num_tiles_n_dv = (D + WMMA_N - 1) / WMMA_N;
+    const int num_tiles_k_dv = (BLOCK_N + WMMA_K - 1) / WMMA_K;
+    const int total_tiles_dv = num_tiles_m_dv * num_tiles_n_dv;
+    const int tiles_per_warp_dv =
+        (total_tiles_dv + WARPS_PER_BLOCK - 1) / WARPS_PER_BLOCK;
+
+    for (int tile_local = 0; tile_local < tiles_per_warp_dv; ++tile_local) {
+      const int tile_idx = warp_id * tiles_per_warp_dv + tile_local;
+      if (tile_idx >= total_tiles_dv) break;
+
+      const int tile_m_idx = tile_idx / num_tiles_n_dv;
+      const int tile_n_idx = tile_idx % num_tiles_n_dv;
+
+      const int tile_m = tile_m_idx * WMMA_M;
+      const int tile_n = tile_n_idx * WMMA_N;
+
+      if (tile_m >= valid_kv_rows || tile_n >= D) continue;
+
+      fragment<matrix_a, WMMA_M, WMMA_N, WMMA_K, half, col_major> a_frag;
+      fragment<matrix_b, WMMA_M, WMMA_N, WMMA_K, half, row_major> b_frag;
+      fragment<accumulator, WMMA_M, WMMA_N, WMMA_K, float> acc_frag;
+      load_matrix_sync(acc_frag, sdV + tile_m * KV_STRIDE + tile_n, KV_STRIDE,
+                       mem_row_major);
+
+#pragma unroll
+      for (int k_tile = 0; k_tile < num_tiles_k_dv; ++k_tile) {
+        const int k_offset = k_tile * WMMA_K;
+        if (k_offset >= valid_q_rows) break;
+
+        load_matrix_sync(a_frag, sP + k_offset * BLOCK_M + tile_m, BLOCK_M);
+        load_matrix_sync(b_frag, sdO + k_offset * Q_STRIDE + tile_n, Q_STRIDE);
+        mma_sync(acc_frag, a_frag, b_frag, acc_frag);
+      }
+      store_matrix_sync(sdV + tile_m * KV_STRIDE + tile_n, acc_frag, KV_STRIDE,
+                        mem_row_major);
+    }
+    __syncthreads();
+
+    __half* sQ = sdO;
+#pragma unroll 2
+    for (int idx = tid; idx < NUM_UINT4_Q_BLOCK; idx += THREADS_PER_BLOCK) {
+      const int row = idx / d_stride_uint4;
+      const int vec_col = idx % d_stride_uint4;
+      uint4 q_val = make_uint4(0, 0, 0, 0);
+      if (row < valid_q_rows && vec_col < d_stride_uint4) {
+        q_val = __ldg(&q_vec[row * d_stride_uint4 + vec_col]);
+      }
+      sQ_vec[row * q_stride_uint4 + vec_col] = q_val;
+    }
+    __syncthreads();
+
+    const int num_tiles_m_dk = (BLOCK_M + WMMA_M - 1) / WMMA_M;
+    const int num_tiles_n_dk = (D + WMMA_N - 1) / WMMA_N;
+    const int num_tiles_k_dk = (BLOCK_N + WMMA_K - 1) / WMMA_K;
+    const int total_tiles_dk = num_tiles_m_dk * num_tiles_n_dk;
+    const int tiles_per_warp_dk =
+        (total_tiles_dk + WARPS_PER_BLOCK - 1) / WARPS_PER_BLOCK;
+
+    for (int tile_local = 0; tile_local < tiles_per_warp_dk; ++tile_local) {
+      const int tile_idx = warp_id * tiles_per_warp_dk + tile_local;
+      if (tile_idx >= total_tiles_dk) break;
+
+      const int tile_m_idx = tile_idx / num_tiles_n_dk;
+      const int tile_n_idx = tile_idx % num_tiles_n_dk;
+
+      const int tile_m = tile_m_idx * WMMA_M;
+      const int tile_n = tile_n_idx * WMMA_N;
+
+      if (tile_m >= valid_kv_rows || tile_n >= D) continue;
+
+      fragment<matrix_a, WMMA_M, WMMA_N, WMMA_K, half, col_major> a_frag;
+      fragment<matrix_b, WMMA_M, WMMA_N, WMMA_K, half, row_major> b_frag;
+      fragment<accumulator, WMMA_M, WMMA_N, WMMA_K, float> acc_frag;
+      load_matrix_sync(acc_frag, sdK + tile_m * KV_STRIDE + tile_n, KV_STRIDE,
+                       mem_row_major);
+
+#pragma unroll
+      for (int k_tile = 0; k_tile < num_tiles_k_dk; ++k_tile) {
+        const int k_offset = k_tile * WMMA_K;
+        if (k_offset >= valid_q_rows) break;
+
+        load_matrix_sync(a_frag, sdS + k_offset * BLOCK_M + tile_m, BLOCK_M);
+        load_matrix_sync(b_frag, sQ + k_offset * Q_STRIDE + tile_n, Q_STRIDE);
+        mma_sync(acc_frag, a_frag, b_frag, acc_frag);
+      }
+      store_matrix_sync(sdK + tile_m * KV_STRIDE + tile_n, acc_frag, KV_STRIDE,
+                        mem_row_major);
+    }
+    __syncthreads();
+  }
+
+  const int total_fp16_x4 = (valid_kv_rows * D) / 4;
+  for (int i = tid; i < total_fp16_x4; i += THREADS_PER_BLOCK) {
+    const int row = i / (D / 4);
+    const int col = (i % (D / 4)) * 4;
+
+    const float* s_dK_row = sdK + row * KV_STRIDE;
+    const float* s_dV_row = sdV + row * KV_STRIDE;
+
+    const __half hk0 = __float2half_rn(s_dK_row[col + 0]);
+    const __half hk1 = __float2half_rn(s_dK_row[col + 1]);
+    const __half hk2 = __float2half_rn(s_dK_row[col + 2]);
+    const __half hk3 = __float2half_rn(s_dK_row[col + 3]);
+
+    const __half hv0 = __float2half_rn(s_dV_row[col + 0]);
+    const __half hv1 = __float2half_rn(s_dV_row[col + 1]);
+    const __half hv2 = __float2half_rn(s_dV_row[col + 2]);
+    const __half hv3 = __float2half_rn(s_dV_row[col + 3]);
+
+    asm volatile("st.global.v4.u16 [%0], {%1, %2, %3, %4};"
+                 :
+                 : "l"(dK_ptr + row * D + col), "h"(__half_as_ushort(hk0)),
+                   "h"(__half_as_ushort(hk1)), "h"(__half_as_ushort(hk2)),
+                   "h"(__half_as_ushort(hk3))
+                 : "memory");
+
+    asm volatile("st.global.v4.u16 [%0], {%1, %2, %3, %4};"
+                 :
+                 : "l"(dV_ptr + row * D + col), "h"(__half_as_ushort(hv0)),
+                   "h"(__half_as_ushort(hv1)), "h"(__half_as_ushort(hv2)),
+                   "h"(__half_as_ushort(hv3))
+                 : "memory");
+  }
 }
 
-template<int D>
+template <int D>
 void launcher_flash_attention_backward_dq(
-    const torch::Tensor& Q,
-    const torch::Tensor& K,
-    const torch::Tensor& V,
-    const torch::Tensor& O,
-    torch::Tensor& dO,
-    const torch::Tensor& softmax_lse,
-    torch::Tensor& dQ,
-    float softmax_scale,
-    bool is_causal,
-    cudaStream_t stream
-) {
-    using Config = dQKernelConfig<D>;
+    const torch::Tensor& Q, const torch::Tensor& K, const torch::Tensor& V,
+    const torch::Tensor& O, torch::Tensor& dO, const torch::Tensor& softmax_lse,
+    torch::Tensor& dQ, float softmax_scale, bool is_causal,
+    cudaStream_t stream) {
+  using Config = dQKernelConfig<D>;
 
-    const int B = Q.size(0);
-    const int H = Q.size(1);
-    const int M = Q.size(2);
-    const int N = K.size(2);
+  const int B = Q.size(0);
+  const int H = Q.size(1);
+  const int M = Q.size(2);
+  const int N = K.size(2);
 
-    const int grid_x = (M + Config::BLOCK_M - 1) / Config::BLOCK_M;
-    const dim3 grid(grid_x, 1, B * H);
-    const dim3 block(Config::THREADS_PER_BLOCK);
-    const size_t smem = Config::TOTAL_SMEM;
+  const int grid_x = (M + Config::BLOCK_M - 1) / Config::BLOCK_M;
+  const dim3 grid(grid_x, 1, B * H);
+  const dim3 block(Config::THREADS_PER_BLOCK);
+  const size_t smem = Config::TOTAL_SMEM;
 
-    TORCH_CHECK(smem <= MAX_SMEM_PER_SM, "Shared memory exceeds 96KB for dQ: ", smem, " bytes");
+  TORCH_CHECK(smem <= MAX_SMEM_PER_SM,
+              "Shared memory exceeds 96KB for dQ: ", smem, " bytes");
 
-    auto kernel = is_causal ?
-        (void*)flash_attention_backward_dq_kernel<D, true> :
-        (void*)flash_attention_backward_dq_kernel<D, false>;
+  auto kernel = is_causal ? (void*)flash_attention_backward_dq_kernel<D, true>
+                          : (void*)flash_attention_backward_dq_kernel<D, false>;
 
-    cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem);
+  cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize,
+                       smem);
 
-    if (is_causal) {
-        flash_attention_backward_dq_kernel<D, true><<<grid, block, smem, stream>>>(
-            reinterpret_cast<const __half*>(Q.data_ptr()),
-            reinterpret_cast<const __half*>(K.data_ptr()),
-            reinterpret_cast<const __half*>(V.data_ptr()),
-            reinterpret_cast<const __half*>(O.data_ptr()),
-            reinterpret_cast<__half*>(dO.data_ptr()),
-            softmax_lse.data_ptr<float>(),
-            reinterpret_cast<__half*>(dQ.data_ptr()),
-            B, H, M, N, softmax_scale
-        );
-    } else {
-        flash_attention_backward_dq_kernel<D, false><<<grid, block, smem, stream>>>(
-            reinterpret_cast<const __half*>(Q.data_ptr()),
-            reinterpret_cast<const __half*>(K.data_ptr()),
-            reinterpret_cast<const __half*>(V.data_ptr()),
-            reinterpret_cast<const __half*>(O.data_ptr()),
-            reinterpret_cast<__half*>(dO.data_ptr()),
-            softmax_lse.data_ptr<float>(),
-            reinterpret_cast<__half*>(dQ.data_ptr()),
-            B, H, M, N, softmax_scale
-        );
-    }
+  if (is_causal) {
+    flash_attention_backward_dq_kernel<D, true><<<grid, block, smem, stream>>>(
+        reinterpret_cast<const __half*>(Q.data_ptr()),
+        reinterpret_cast<const __half*>(K.data_ptr()),
+        reinterpret_cast<const __half*>(V.data_ptr()),
+        reinterpret_cast<const __half*>(O.data_ptr()),
+        reinterpret_cast<__half*>(dO.data_ptr()), softmax_lse.data_ptr<float>(),
+        reinterpret_cast<__half*>(dQ.data_ptr()), B, H, M, N, softmax_scale);
+  } else {
+    flash_attention_backward_dq_kernel<D, false><<<grid, block, smem, stream>>>(
+        reinterpret_cast<const __half*>(Q.data_ptr()),
+        reinterpret_cast<const __half*>(K.data_ptr()),
+        reinterpret_cast<const __half*>(V.data_ptr()),
+        reinterpret_cast<const __half*>(O.data_ptr()),
+        reinterpret_cast<__half*>(dO.data_ptr()), softmax_lse.data_ptr<float>(),
+        reinterpret_cast<__half*>(dQ.data_ptr()), B, H, M, N, softmax_scale);
+  }
 }
 
-template<int D>
+template <int D>
 void launcher_flash_attention_backward_dkv(
-    const torch::Tensor& Q,
-    const torch::Tensor& K,
-    const torch::Tensor& V,
-    const torch::Tensor& O,
-    torch::Tensor& dO,
-    const torch::Tensor& softmax_lse,
-    torch::Tensor& dK,
-    torch::Tensor& dV,
-    float softmax_scale,
-    bool is_causal,
-    cudaStream_t stream
-) {
-    using Config = dKVKernelConfig<D>;
+    const torch::Tensor& Q, const torch::Tensor& K, const torch::Tensor& V,
+    const torch::Tensor& O, torch::Tensor& dO, const torch::Tensor& softmax_lse,
+    torch::Tensor& dK, torch::Tensor& dV, float softmax_scale, bool is_causal,
+    cudaStream_t stream) {
+  using Config = dKVKernelConfig<D>;
 
-    const int B = Q.size(0);
-    const int H = Q.size(1);
-    const int M = Q.size(2);
-    const int N = K.size(2);
+  const int B = Q.size(0);
+  const int H = Q.size(1);
+  const int M = Q.size(2);
+  const int N = K.size(2);
 
-    const int grid_x = (N + Config::BLOCK_M - 1) / Config::BLOCK_M;
-    const dim3 grid(grid_x, 1, B * H);
-    const dim3 block(Config::THREADS_PER_BLOCK);
-    const size_t smem = Config::TOTAL_SMEM;
+  const int grid_x = (N + Config::BLOCK_M - 1) / Config::BLOCK_M;
+  const dim3 grid(grid_x, 1, B * H);
+  const dim3 block(Config::THREADS_PER_BLOCK);
+  const size_t smem = Config::TOTAL_SMEM;
 
-    TORCH_CHECK(smem <= MAX_SMEM_PER_SM, "Shared memory exceeds 96KB for unified dKV: ", smem, " bytes (", smem / 1024, " KB)");
+  TORCH_CHECK(smem <= MAX_SMEM_PER_SM,
+              "Shared memory exceeds 96KB for unified dKV: ", smem, " bytes (",
+              smem / 1024, " KB)");
 
-    auto kernel = is_causal ?
-        (void*)flash_attention_backward_dkv_kernel<D, true> :
-        (void*)flash_attention_backward_dkv_kernel<D, false>;
+  auto kernel = is_causal
+                    ? (void*)flash_attention_backward_dkv_kernel<D, true>
+                    : (void*)flash_attention_backward_dkv_kernel<D, false>;
 
-    cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem);
+  cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize,
+                       smem);
 
-    if (is_causal) {
-        flash_attention_backward_dkv_kernel<D, true><<<grid, block, smem, stream>>>(
+  if (is_causal) {
+    flash_attention_backward_dkv_kernel<D, true><<<grid, block, smem, stream>>>(
+        reinterpret_cast<const __half*>(Q.data_ptr()),
+        reinterpret_cast<const __half*>(K.data_ptr()),
+        reinterpret_cast<const __half*>(V.data_ptr()),
+        reinterpret_cast<const __half*>(O.data_ptr()),
+        reinterpret_cast<__half*>(dO.data_ptr()), softmax_lse.data_ptr<float>(),
+        reinterpret_cast<__half*>(dK.data_ptr()),
+        reinterpret_cast<__half*>(dV.data_ptr()), B, H, M, N, softmax_scale);
+  } else {
+    flash_attention_backward_dkv_kernel<D, false>
+        <<<grid, block, smem, stream>>>(
             reinterpret_cast<const __half*>(Q.data_ptr()),
             reinterpret_cast<const __half*>(K.data_ptr()),
             reinterpret_cast<const __half*>(V.data_ptr()),
@@ -1191,104 +1250,104 @@ void launcher_flash_attention_backward_dkv(
             reinterpret_cast<__half*>(dO.data_ptr()),
             softmax_lse.data_ptr<float>(),
             reinterpret_cast<__half*>(dK.data_ptr()),
-            reinterpret_cast<__half*>(dV.data_ptr()),
-            B, H, M, N, softmax_scale
-        );
-    } else {
-        flash_attention_backward_dkv_kernel<D, false><<<grid, block, smem, stream>>>(
-            reinterpret_cast<const __half*>(Q.data_ptr()),
-            reinterpret_cast<const __half*>(K.data_ptr()),
-            reinterpret_cast<const __half*>(V.data_ptr()),
-            reinterpret_cast<const __half*>(O.data_ptr()),
-            reinterpret_cast<__half*>(dO.data_ptr()),
-            softmax_lse.data_ptr<float>(),
-            reinterpret_cast<__half*>(dK.data_ptr()),
-            reinterpret_cast<__half*>(dV.data_ptr()),
-            B, H, M, N, softmax_scale
-        );
-    }
+            reinterpret_cast<__half*>(dV.data_ptr()), B, H, M, N,
+            softmax_scale);
+  }
 }
 
 std::vector<at::Tensor> flash_attention_backward(
-    const at::Tensor& dout,
-    const at::Tensor& q,
-    const at::Tensor& k,
-    const at::Tensor& v,
-    const at::Tensor& out,
-    const at::Tensor& softmax_lse,
-    std::optional<at::Tensor>& dq_,
-    std::optional<at::Tensor>& dk_,
-    std::optional<at::Tensor>& dv_,
-    std::optional<at::Tensor>& alibi_slopes_,
-    const float p_dropout,
-    const float softmax_scale,
-    const bool is_causal,
-    int window_size_left,
-    int window_size_right,
-    const float softcap,
-    const bool deterministic,
-    std::optional<at::Generator> gen_,
-    std::optional<at::Tensor>& rng_state
-) {
+    const at::Tensor& dout, const at::Tensor& q, const at::Tensor& k,
+    const at::Tensor& v, const at::Tensor& out, const at::Tensor& softmax_lse,
+    std::optional<at::Tensor>& dq_, std::optional<at::Tensor>& dk_,
+    std::optional<at::Tensor>& dv_, std::optional<at::Tensor>& alibi_slopes_,
+    const float p_dropout, const float softmax_scale, const bool is_causal,
+    int window_size_left, int window_size_right, const float softcap,
+    const bool deterministic, std::optional<at::Generator> gen_,
+    std::optional<at::Tensor>& rng_state) {
+  TORCH_CHECK(!alibi_slopes_.has_value(), "alibi_slopes not supported");
+  TORCH_CHECK(p_dropout == 0.f, "dropout not supported");
+  TORCH_CHECK(window_size_left == -1, "window_size_left not supported");
+  TORCH_CHECK(window_size_right == -1 || (is_causal && window_size_right == 0),
+              "window not supported");
+  TORCH_CHECK(softcap == 0.f, "softcap not supported");
+  TORCH_CHECK(!deterministic, "deterministic mode not supported");
+  TORCH_CHECK(!gen_.has_value(), "Generator not supported");
+  TORCH_CHECK(!rng_state.has_value() || rng_state->numel() == 0,
+              "rng_state not supported");
 
-    TORCH_CHECK(!alibi_slopes_.has_value(), "alibi_slopes not supported");
-    TORCH_CHECK(p_dropout == 0.f, "dropout not supported");
-    TORCH_CHECK(window_size_left == -1, "window_size_left not supported");
-    TORCH_CHECK(window_size_right == -1 || (is_causal && window_size_right == 0), "window not supported");
-    TORCH_CHECK(softcap == 0.f, "softcap not supported");
-    TORCH_CHECK(!deterministic, "deterministic mode not supported");
-    TORCH_CHECK(!gen_.has_value(), "Generator not supported");
-    TORCH_CHECK(!rng_state.has_value() || rng_state->numel() == 0, "rng_state not supported");
+  TORCH_CHECK(q.dtype() == torch::kFloat16, "q must be fp16");
+  TORCH_CHECK(k.dtype() == torch::kFloat16, "k must be fp16");
+  TORCH_CHECK(v.dtype() == torch::kFloat16, "v must be fp16");
+  TORCH_CHECK(dout.dtype() == torch::kFloat16, "dout must be fp16");
+  TORCH_CHECK(out.dtype() == torch::kFloat16, "out must be fp16");
+  TORCH_CHECK(softmax_lse.dtype() == torch::kFloat32,
+              "softmax_lse must be fp32");
 
-    TORCH_CHECK(q.dtype() == torch::kFloat16, "q must be fp16");
-    TORCH_CHECK(k.dtype() == torch::kFloat16, "k must be fp16");
-    TORCH_CHECK(v.dtype() == torch::kFloat16, "v must be fp16");
-    TORCH_CHECK(dout.dtype() == torch::kFloat16, "dout must be fp16");
-    TORCH_CHECK(out.dtype() == torch::kFloat16, "out must be fp16");
-    TORCH_CHECK(softmax_lse.dtype() == torch::kFloat32, "softmax_lse must be fp32");
+  const auto sizes = q.sizes();
+  const int B = sizes[0], H = sizes[1], M = sizes[2], D = sizes[3];
+  const int N = k.size(2);
+  TORCH_CHECK(D <= 256 && D % 8 == 0 && D % 2 == 0,
+              "D must be even, <=256, multiple of 8");
 
-    const auto sizes = q.sizes();
-    const int B = sizes[0], H = sizes[1], M = sizes[2], D = sizes[3];
-    const int N = k.size(2);
-    TORCH_CHECK(D <= 256 && D % 8 == 0 && D % 2 == 0, "D must be even, <=256, multiple of 8");
+  at::Tensor dq_fp16 = dq_.has_value() ? dq_.value() : torch::zeros_like(q);
+  at::Tensor dk_fp16 = dk_.has_value() ? dk_.value() : torch::zeros_like(k);
+  at::Tensor dv_fp16 = dv_.has_value() ? dv_.value() : torch::zeros_like(v);
 
-    at::Tensor dq_fp16 = dq_.has_value() ? dq_.value() : torch::zeros_like(q);
-    at::Tensor dk_fp16 = dk_.has_value() ? dk_.value() : torch::zeros_like(k);
-    at::Tensor dv_fp16 = dv_.has_value() ? dv_.value() : torch::zeros_like(v);
+  TORCH_CHECK(dq_fp16.dtype() == torch::kFloat16, "dq must be fp16");
+  TORCH_CHECK(dk_fp16.dtype() == torch::kFloat16, "dk must be fp16");
+  TORCH_CHECK(dv_fp16.dtype() == torch::kFloat16, "dv must be fp16");
 
-    TORCH_CHECK(dq_fp16.dtype() == torch::kFloat16, "dq must be fp16");
-    TORCH_CHECK(dk_fp16.dtype() == torch::kFloat16, "dk must be fp16");
-    TORCH_CHECK(dv_fp16.dtype() == torch::kFloat16, "dv must be fp16");
+  auto dsoftmax_sum =
+      torch::zeros({B, H, M}, torch::dtype(torch::kFloat32).device(q.device()));
 
-    auto dsoftmax_sum = torch::zeros({B, H, M}, torch::dtype(torch::kFloat32).device(q.device()));
+  auto stream = at::cuda::getCurrentCUDAStream().stream();
+  auto props = at::cuda::getCurrentDeviceProperties();
+  bool sm70 = props->major == 7 && props->minor == 0;
+  TORCH_CHECK(sm70, "Kernel supports only Volta GPUs.");
 
-    auto stream = at::cuda::getCurrentCUDAStream().stream();
-    auto props  = at::cuda::getCurrentDeviceProperties();
-    bool sm70   = props->major == 7 && props->minor == 0;
-    TORCH_CHECK(sm70, "Kernel supports only Volta GPUs.");
-
-    switch (D) {
-        case 16:
-            launcher_flash_attention_backward_dq<16>(q, k, v, out, const_cast<at::Tensor&>(dout), softmax_lse, dq_fp16, softmax_scale, is_causal, stream);
-            launcher_flash_attention_backward_dkv<16>(q, k, v, out, const_cast<at::Tensor&>(dout), softmax_lse, dk_fp16, dv_fp16, softmax_scale, is_causal, stream);
-            break;
-        case 32:
-            launcher_flash_attention_backward_dq<32>(q, k, v, out, const_cast<at::Tensor&>(dout), softmax_lse, dq_fp16, softmax_scale, is_causal, stream);
-            launcher_flash_attention_backward_dkv<32>(q, k, v, out, const_cast<at::Tensor&>(dout), softmax_lse, dk_fp16, dv_fp16, softmax_scale, is_causal, stream);
-            break;
-        case 64:
-            launcher_flash_attention_backward_dq<64>(q, k, v, out, const_cast<at::Tensor&>(dout), softmax_lse, dq_fp16, softmax_scale, is_causal, stream);
-            launcher_flash_attention_backward_dkv<64>(q, k, v, out, const_cast<at::Tensor&>(dout), softmax_lse, dk_fp16, dv_fp16, softmax_scale, is_causal, stream);
-            break;
-        case 128:
-            launcher_flash_attention_backward_dq<128>(q, k, v, out, const_cast<at::Tensor&>(dout), softmax_lse, dq_fp16, softmax_scale, is_causal, stream);
-            launcher_flash_attention_backward_dkv<128>(q, k, v, out, const_cast<at::Tensor&>(dout), softmax_lse, dk_fp16, dv_fp16, softmax_scale, is_causal, stream);
-            break;
-        case 256:
-            launcher_flash_attention_backward_dq<256>(q, k, v, out, const_cast<at::Tensor&>(dout), softmax_lse, dq_fp16, softmax_scale, is_causal, stream);
-            launcher_flash_attention_backward_dkv<256>(q, k, v, out, const_cast<at::Tensor&>(dout), softmax_lse, dk_fp16, dv_fp16, softmax_scale, is_causal, stream);
-            break;
-        default: TORCH_CHECK(false, "Unsupported D: ", D);
-    }
-    return {dq_fp16, dk_fp16, dv_fp16, dsoftmax_sum};
+  switch (D) {
+    case 16:
+      launcher_flash_attention_backward_dq<16>(
+          q, k, v, out, const_cast<at::Tensor&>(dout), softmax_lse, dq_fp16,
+          softmax_scale, is_causal, stream);
+      launcher_flash_attention_backward_dkv<16>(
+          q, k, v, out, const_cast<at::Tensor&>(dout), softmax_lse, dk_fp16,
+          dv_fp16, softmax_scale, is_causal, stream);
+      break;
+    case 32:
+      launcher_flash_attention_backward_dq<32>(
+          q, k, v, out, const_cast<at::Tensor&>(dout), softmax_lse, dq_fp16,
+          softmax_scale, is_causal, stream);
+      launcher_flash_attention_backward_dkv<32>(
+          q, k, v, out, const_cast<at::Tensor&>(dout), softmax_lse, dk_fp16,
+          dv_fp16, softmax_scale, is_causal, stream);
+      break;
+    case 64:
+      launcher_flash_attention_backward_dq<64>(
+          q, k, v, out, const_cast<at::Tensor&>(dout), softmax_lse, dq_fp16,
+          softmax_scale, is_causal, stream);
+      launcher_flash_attention_backward_dkv<64>(
+          q, k, v, out, const_cast<at::Tensor&>(dout), softmax_lse, dk_fp16,
+          dv_fp16, softmax_scale, is_causal, stream);
+      break;
+    case 128:
+      launcher_flash_attention_backward_dq<128>(
+          q, k, v, out, const_cast<at::Tensor&>(dout), softmax_lse, dq_fp16,
+          softmax_scale, is_causal, stream);
+      launcher_flash_attention_backward_dkv<128>(
+          q, k, v, out, const_cast<at::Tensor&>(dout), softmax_lse, dk_fp16,
+          dv_fp16, softmax_scale, is_causal, stream);
+      break;
+    case 256:
+      launcher_flash_attention_backward_dq<256>(
+          q, k, v, out, const_cast<at::Tensor&>(dout), softmax_lse, dq_fp16,
+          softmax_scale, is_causal, stream);
+      launcher_flash_attention_backward_dkv<256>(
+          q, k, v, out, const_cast<at::Tensor&>(dout), softmax_lse, dk_fp16,
+          dv_fp16, softmax_scale, is_causal, stream);
+      break;
+    default:
+      TORCH_CHECK(false, "Unsupported D: ", D);
+  }
+  return {dq_fp16, dk_fp16, dv_fp16, dsoftmax_sum};
 }

--- a/flash-attention-v100/kernel/fused_mha_forward.cu
+++ b/flash-attention-v100/kernel/fused_mha_forward.cu
@@ -16,1133 +16,1109 @@ using namespace nvcuda::wmma;
 #define WMMA_N 16
 #define WMMA_K 16
 
-#define MAX_THREADS_PER_WARP    32
-#define MAX_THREADS_PER_SM      2048
-#define MAX_THREAD_BLOCK_SIZE   1024
+#define MAX_THREADS_PER_WARP 32
+#define MAX_THREADS_PER_SM 2048
+#define MAX_THREAD_BLOCK_SIZE 1024
 #define MAX_THREAD_BLOCK_PER_SM 32
-#define MAX_WARPS_PER_SM        64
-#define MAX_SM_PER_GPU          80
-#define MAX_SMEM_PER_SM         98304
+#define MAX_WARPS_PER_SM 64
+#define MAX_SM_PER_GPU 80
+#define MAX_SMEM_PER_SM 98304
 
-#define WARP_ALLOC_GROUP        4
+#define WARP_ALLOC_GROUP 4
 
-#define MAX_REG_PER_UNIT        256
-#define MAX_REG_PER_THREAD      255
-#define MAX_REG_PER_BLOCK       65536
-#define MAX_REG_BUFFER          65536
+#define MAX_REG_PER_UNIT 256
+#define MAX_REG_PER_THREAD 255
+#define MAX_REG_PER_BLOCK 65536
+#define MAX_REG_BUFFER 65536
 
-#define BLOCK_M_16  16
-#define BLOCK_N_16  512
-#define WARPS_16    16
+#define BLOCK_M_16 16
+#define BLOCK_N_16 512
+#define WARPS_16 16
 
-#define BLOCK_M_32  32
-#define BLOCK_N_32  256
-#define WARPS_32    16
+#define BLOCK_M_32 32
+#define BLOCK_N_32 256
+#define WARPS_32 16
 
-#define BLOCK_M_64  64
-#define BLOCK_N_64  128
-#define WARPS_64    16
+#define BLOCK_M_64 64
+#define BLOCK_N_64 128
+#define WARPS_64 16
 
 #define BLOCK_M_128 32
 #define BLOCK_N_128 176
-#define WARPS_128   16
+#define WARPS_128 16
 
 #define BLOCK_M_256 32
 #define BLOCK_N_256 64
-#define WARPS_256   16
+#define WARPS_256 16
 
 #define BLOCK_M_256_LOW_SMEM 16
 #define BLOCK_N_256_LOW_SMEM 32
-#define WARPS_256_LOW_SMEM   16
+#define WARPS_256_LOW_SMEM 16
 
 inline bool env_flag_enabled(const char* name) {
-    const char* raw = std::getenv(name);
-    return raw != nullptr && std::strcmp(raw, "0") != 0;
+  const char* raw = std::getenv(name);
+  return raw != nullptr && std::strcmp(raw, "0") != 0;
 }
 
 inline bool env_flag_enabled_default_on(const char* name) {
-    const char* raw = std::getenv(name);
-    return raw == nullptr || std::strcmp(raw, "0") != 0;
+  const char* raw = std::getenv(name);
+  return raw == nullptr || std::strcmp(raw, "0") != 0;
 }
 
-template<int D, bool LOW_SMEM = false>
+template <int D, bool LOW_SMEM = false>
 struct KernelConfig {
-    static constexpr int BLOCK_M = (D == 16) ? BLOCK_M_16 : (D == 32) ? BLOCK_M_32 : (D == 64) ? BLOCK_M_64 : (D == 128) ? BLOCK_M_128 : (LOW_SMEM ? BLOCK_M_256_LOW_SMEM : BLOCK_M_256);
-    static constexpr int BLOCK_N = (D == 16) ? BLOCK_N_16 : (D == 32) ? BLOCK_N_32 : (D == 64) ? BLOCK_N_64 : (D == 128) ? BLOCK_N_128 : (LOW_SMEM ? BLOCK_N_256_LOW_SMEM : BLOCK_N_256);
-    static constexpr int WARPS_PER_BLOCK = (D == 16) ? WARPS_16 : (D == 32) ? WARPS_32 : (D == 64) ? WARPS_64 : (D == 128) ? WARPS_128 : (LOW_SMEM ? WARPS_256_LOW_SMEM : WARPS_256);
+  static constexpr int BLOCK_M =
+      (D == 16)    ? BLOCK_M_16
+      : (D == 32)  ? BLOCK_M_32
+      : (D == 64)  ? BLOCK_M_64
+      : (D == 128) ? BLOCK_M_128
+                   : (LOW_SMEM ? BLOCK_M_256_LOW_SMEM : BLOCK_M_256);
+  static constexpr int BLOCK_N =
+      (D == 16)    ? BLOCK_N_16
+      : (D == 32)  ? BLOCK_N_32
+      : (D == 64)  ? BLOCK_N_64
+      : (D == 128) ? BLOCK_N_128
+                   : (LOW_SMEM ? BLOCK_N_256_LOW_SMEM : BLOCK_N_256);
+  static constexpr int WARPS_PER_BLOCK =
+      (D == 16)    ? WARPS_16
+      : (D == 32)  ? WARPS_32
+      : (D == 64)  ? WARPS_64
+      : (D == 128) ? WARPS_128
+                   : (LOW_SMEM ? WARPS_256_LOW_SMEM : WARPS_256);
 
-    static constexpr int THREADS_PER_BLOCK = WARPS_PER_BLOCK * MAX_THREADS_PER_WARP;
-    static constexpr int THREADS_PER_ROW   = THREADS_PER_BLOCK / BLOCK_M;
-    static constexpr int PAD               = (8 - (D % 32) + 32) % 32;
-    static constexpr int Q_STRIDE          = D + PAD;
-    static constexpr int KV_STRIDE         = D + PAD;
-    static constexpr int S_STRIDE          = BLOCK_N + PAD;
-    static constexpr int P_SUB_TILE        = 32;
-    static constexpr int P_STRIDE          = P_SUB_TILE + PAD;
-    static constexpr int P_STRICT_ELEMENTS = (D == 256) ? BLOCK_M * P_STRIDE : 1;
-    static constexpr int O_STRIDE          = D + PAD;
-    static constexpr int PER_UINT4         = 8;
+  static constexpr int THREADS_PER_BLOCK =
+      WARPS_PER_BLOCK * MAX_THREADS_PER_WARP;
+  static constexpr int THREADS_PER_ROW = THREADS_PER_BLOCK / BLOCK_M;
+  static constexpr int PAD = (8 - (D % 32) + 32) % 32;
+  static constexpr int Q_STRIDE = D + PAD;
+  static constexpr int KV_STRIDE = D + PAD;
+  static constexpr int S_STRIDE = BLOCK_N + PAD;
+  static constexpr int P_SUB_TILE = 32;
+  static constexpr int P_STRIDE = P_SUB_TILE + PAD;
+  static constexpr int P_STRICT_ELEMENTS = (D == 256) ? BLOCK_M * P_STRIDE : 1;
+  static constexpr int O_STRIDE = D + PAD;
+  static constexpr int PER_UINT4 = 8;
 
-    struct alignas(128) SmemLayout {
-        alignas(16) __half q      [BLOCK_M * Q_STRIDE];
+  struct alignas(128) SmemLayout {
+    alignas(16) __half q[BLOCK_M * Q_STRIDE];
     union {
-        alignas(16) __half k      [BLOCK_N * KV_STRIDE];
-        alignas(16) __half v      [BLOCK_N * KV_STRIDE];
+      alignas(16) __half k[BLOCK_N * KV_STRIDE];
+      alignas(16) __half v[BLOCK_N * KV_STRIDE];
     } reuse_kv;
     union {
-        alignas(16) float  s      [BLOCK_M * S_STRIDE];
-        alignas(16) __half p      [BLOCK_M * S_STRIDE];
+      alignas(16) float s[BLOCK_M * S_STRIDE];
+      alignas(16) __half p[BLOCK_M * S_STRIDE];
     } reuse_sp;
-        alignas(16) __half p_strict[P_STRICT_ELEMENTS];
-        alignas(16) float  o      [BLOCK_M * O_STRIDE];
-        alignas(16) float  row_max[BLOCK_M];
-        alignas(16) float  row_sum[BLOCK_M];
-    };
+    alignas(16) __half p_strict[P_STRICT_ELEMENTS];
+    alignas(16) float o[BLOCK_M * O_STRIDE];
+    alignas(16) float row_max[BLOCK_M];
+    alignas(16) float row_sum[BLOCK_M];
+  };
 
-    static constexpr size_t TOTAL_SMEM = ((sizeof(SmemLayout) + 127) & ~size_t(127));
+  static constexpr size_t TOTAL_SMEM =
+      ((sizeof(SmemLayout) + 127) & ~size_t(127));
 };
 
-template<typename Config>
+template <typename Config>
 __device__ __forceinline__ void init_smem(char* smem_raw) {
-    constexpr int N_U4 = Config::TOTAL_SMEM / 16;
-    constexpr int THREADS_PER_BLOCK = Config::THREADS_PER_BLOCK;
-    const int tid = threadIdx.x;
+  constexpr int N_U4 = Config::TOTAL_SMEM / 16;
+  constexpr int THREADS_PER_BLOCK = Config::THREADS_PER_BLOCK;
+  const int tid = threadIdx.x;
 
-    uint32_t addr = static_cast<uint32_t>(__cvta_generic_to_shared(smem_raw));
-    #pragma unroll 1
-    for (int i = tid; i < N_U4; i += THREADS_PER_BLOCK) {
-        asm volatile("st.shared.v4.u32 [%0], {%1,%1,%1,%1};"
-                     :: "r"(addr + (i << 4)), "r"(0) : "memory");
-    }
-    __syncthreads();
+  uint32_t addr = static_cast<uint32_t>(__cvta_generic_to_shared(smem_raw));
+#pragma unroll 1
+  for (int i = tid; i < N_U4; i += THREADS_PER_BLOCK) {
+    asm volatile("st.shared.v4.u32 [%0], {%1,%1,%1,%1};" ::"r"(addr + (i << 4)),
+                 "r"(0)
+                 : "memory");
+  }
+  __syncthreads();
 }
 
-template<int D, bool LOW_SMEM, bool IS_CAUSAL>
+template <int D, bool LOW_SMEM, bool IS_CAUSAL>
 __device__ __forceinline__ void compute_qk_scores_scalar_fp32(
-    const __half* __restrict__ sQ,
-    const __half* __restrict__ sK,
-    float* __restrict__ sS,
-    const int valid_q_rows,
-    const int valid_k_rows,
-    const int start_row,
-    const int start_col,
-    const int causal_q_offset,
-    const float score_scale,
-    const int window_size_left,
-    const int window_size_right
-) {
-    using Config = KernelConfig<D, LOW_SMEM>;
-    constexpr int THREADS_PER_BLOCK = Config::THREADS_PER_BLOCK;
-    constexpr int Q_STRIDE = Config::Q_STRIDE;
-    constexpr int KV_STRIDE = Config::KV_STRIDE;
-    constexpr int S_STRIDE = Config::S_STRIDE;
-    const float NEG_INF = -1e30f;
-    const int tid = threadIdx.x;
-    const int total_scores = valid_q_rows * valid_k_rows;
+    const __half* __restrict__ sQ, const __half* __restrict__ sK,
+    float* __restrict__ sS, const int valid_q_rows, const int valid_k_rows,
+    const int start_row, const int start_col, const int causal_q_offset,
+    const float score_scale, const int window_size_left,
+    const int window_size_right) {
+  using Config = KernelConfig<D, LOW_SMEM>;
+  constexpr int THREADS_PER_BLOCK = Config::THREADS_PER_BLOCK;
+  constexpr int Q_STRIDE = Config::Q_STRIDE;
+  constexpr int KV_STRIDE = Config::KV_STRIDE;
+  constexpr int S_STRIDE = Config::S_STRIDE;
+  const float NEG_INF = -1e30f;
+  const int tid = threadIdx.x;
+  const int total_scores = valid_q_rows * valid_k_rows;
 
-    for (int idx = tid; idx < total_scores; idx += THREADS_PER_BLOCK) {
-        const int row = idx / valid_k_rows;
-        const int col = idx - row * valid_k_rows;
-        const int global_m = start_row + row;
-        const int global_n = start_col + col;
-        const int global_q_pos = global_m + causal_q_offset;
+  for (int idx = tid; idx < total_scores; idx += THREADS_PER_BLOCK) {
+    const int row = idx / valid_k_rows;
+    const int col = idx - row * valid_k_rows;
+    const int global_m = start_row + row;
+    const int global_n = start_col + col;
+    const int global_q_pos = global_m + causal_q_offset;
 
-        bool is_valid = true;
-        if constexpr (IS_CAUSAL) {
-            is_valid = global_n <= global_q_pos;
-        }
-        if (window_size_left >= 0) {
-            is_valid = is_valid && global_n >= global_q_pos - window_size_left;
-        }
-        if (window_size_right >= 0) {
-            is_valid = is_valid && global_n <= global_q_pos + window_size_right;
-        }
-
-        float acc = 0.0f;
-        if (is_valid) {
-            #pragma unroll 8
-            for (int d = 0; d < D; d += 2) {
-                const __half2 q_h2 = *reinterpret_cast<const __half2*>(
-                    sQ + row * Q_STRIDE + d);
-                const __half2 k_h2 = *reinterpret_cast<const __half2*>(
-                    sK + col * KV_STRIDE + d);
-                const float2 q_f2 = __half22float2(q_h2);
-                const float2 k_f2 = __half22float2(k_h2);
-                acc = fmaf(q_f2.x, k_f2.x, acc);
-                acc = fmaf(q_f2.y, k_f2.y, acc);
-            }
-        }
-        sS[row * S_STRIDE + col] = is_valid ? acc * score_scale : NEG_INF;
-    }
-}
-
-template<int D, bool LOW_SMEM, bool D256_WMMA_QK, bool IS_CAUSAL>
-__global__ void __launch_bounds__(KernelConfig<D, LOW_SMEM>::THREADS_PER_BLOCK, 2)
-flash_attention_forward_kernel(
-    const __half* __restrict__ Q,
-    const __half* __restrict__ K,
-    const __half* __restrict__ V,
-          __half* __restrict__ Out,
-           float* __restrict__ softmax_lse,
-    const int B,
-    const int H,
-    const int H_KV,
-    const int M,
-    const int N,
-    const float softmax_scale,
-    const bool scalar_pv,
-    const int window_size_left,
-    const int window_size_right
-) {
-    using Config = KernelConfig<D, LOW_SMEM>;
-    constexpr int BLOCK_M           = Config::BLOCK_M;
-    constexpr int BLOCK_N           = Config::BLOCK_N;
-    constexpr int THREADS_PER_BLOCK = Config::THREADS_PER_BLOCK;
-    constexpr int THREADS_PER_ROW   = Config::THREADS_PER_ROW;
-    constexpr int WARPS_PER_BLOCK   = Config::WARPS_PER_BLOCK;
-    constexpr int Q_STRIDE          = Config::Q_STRIDE;
-    constexpr int KV_STRIDE         = Config::KV_STRIDE;
-    constexpr int S_STRIDE          = Config::S_STRIDE;
-    constexpr int P_SUB_TILE        = Config::P_SUB_TILE;
-    constexpr int P_STRIDE          = Config::P_STRIDE;
-    constexpr int O_STRIDE          = Config::O_STRIDE;
-    constexpr int PER_UINT4         = Config::PER_UINT4;
-    const float NEG_INF = -1e30f;
-
-    const int batch_head_id = blockIdx.z;
-    if (batch_head_id >= B * H) return;
-    const int batch_id = batch_head_id / H;
-    const int q_head_id = batch_head_id % H;
-    const int kv_group_size = H / H_KV;
-    const int kv_head_id = q_head_id / kv_group_size;
-
-    const int block_m = blockIdx.x;
-    const int start_row = block_m * BLOCK_M;
-    if (start_row >= M) return;
-
-    int num_n_tiles = (N + BLOCK_N - 1) / BLOCK_N;
-    const int valid_q_rows = min(BLOCK_M, M - start_row);
-    const int causal_q_offset = max(N - M, 0);
-
-    int max_key_pos = N - 1;
+    bool is_valid = true;
     if constexpr (IS_CAUSAL) {
-        max_key_pos = min(max_key_pos,
-                          causal_q_offset + start_row + valid_q_rows - 1);
+      is_valid = global_n <= global_q_pos;
+    }
+    if (window_size_left >= 0) {
+      is_valid = is_valid && global_n >= global_q_pos - window_size_left;
     }
     if (window_size_right >= 0) {
-        max_key_pos = min(max_key_pos,
-                          causal_q_offset + start_row + valid_q_rows - 1
-                              + window_size_right);
-    }
-    if (max_key_pos < 0) {
-        num_n_tiles = 0;
-    } else {
-        num_n_tiles = min(num_n_tiles, (max_key_pos + BLOCK_N) / BLOCK_N);
-    }
-    const int min_key_pos = window_size_left >= 0
-                                ? max(0, causal_q_offset + start_row
-                                             - window_size_left)
-                                : 0;
-
-    const int tid = threadIdx.x;
-    const int warp_id = tid / MAX_THREADS_PER_WARP;
-    const int lane_id = tid % MAX_THREADS_PER_WARP;
-
-    const size_t q_head_linear = (size_t)batch_id * H + q_head_id;
-    const size_t kv_head_linear = (size_t)batch_id * H_KV + kv_head_id;
-    const __half* q_ptr = Q + q_head_linear * M * D + start_row * D;
-    const __half* k_ptr = K + kv_head_linear * N * D;
-    const __half* v_ptr = V + kv_head_linear * N * D;
-    __half* out_ptr = Out + q_head_linear * M * D + start_row * D;
-    float* softmax_lse_ptr = softmax_lse + q_head_linear * M + start_row;
-
-    extern __shared__ char smem_raw[];
-    init_smem<Config>(smem_raw);
-    auto& smem = *reinterpret_cast<typename Config::SmemLayout*>(smem_raw);
-
-    __half* sQ      = smem.q;
-    __half* sK      = smem.reuse_kv.k;
-    __half* sV      = smem.reuse_kv.v;
-    float*  sS      = smem.reuse_sp.s;
-    __half* sP      = (D == 256) ? smem.p_strict : smem.reuse_sp.p;
-    const int p_stride = (D == 256) ? P_STRIDE : S_STRIDE;
-    const int p_tile_capacity = (D == 256) ? P_SUB_TILE : BLOCK_N;
-    float*  sO      = smem.o;
-    float*  sRowMax = smem.row_max;
-    float*  sRowSum = smem.row_sum;
-    constexpr float RCP_LN2 = 1.4426950408889634f;
-    constexpr float LN2 = 0.6931471805599453f;
-    constexpr float EXP2_CLAMP = -80.0f * RCP_LN2;
-    const float softmax_scale_log2 = softmax_scale * RCP_LN2;
-
-    const int  d_stride_uint4 = (D + PER_UINT4 - 1) / PER_UINT4;
-    const int  q_stride_uint4 = (Q_STRIDE  + PER_UINT4 - 1) / PER_UINT4;
-    const int kv_stride_uint4 = (KV_STRIDE + PER_UINT4 - 1) / PER_UINT4;
-
-    if (tid < BLOCK_M) {
-        sRowMax[tid] = NEG_INF;
+      is_valid = is_valid && global_n <= global_q_pos + window_size_right;
     }
 
-    const uint4*      q_vec = reinterpret_cast<const uint4*>(q_ptr);
-    uint4*           sQ_vec = reinterpret_cast<uint4*>(sQ);
-
-    #pragma unroll 4
-    for (int idx = tid; idx < (valid_q_rows * d_stride_uint4); idx += THREADS_PER_BLOCK) {
-        const int row = idx / d_stride_uint4;
-        const int vec_col = idx % d_stride_uint4;
-        uint4 q_val = make_uint4(0, 0, 0, 0);
-        if (row < valid_q_rows && vec_col < d_stride_uint4) {
-            q_val = __ldg(&q_vec[row * d_stride_uint4 + vec_col]);
-        }
-        sQ_vec[row * q_stride_uint4 + vec_col] = q_val;
+    float acc = 0.0f;
+    if (is_valid) {
+#pragma unroll 8
+      for (int d = 0; d < D; d += 2) {
+        const __half2 q_h2 =
+            *reinterpret_cast<const __half2*>(sQ + row * Q_STRIDE + d);
+        const __half2 k_h2 =
+            *reinterpret_cast<const __half2*>(sK + col * KV_STRIDE + d);
+        const float2 q_f2 = __half22float2(q_h2);
+        const float2 k_f2 = __half22float2(k_h2);
+        acc = fmaf(q_f2.x, k_f2.x, acc);
+        acc = fmaf(q_f2.y, k_f2.y, acc);
+      }
     }
-    __syncthreads();
-
-    for (int block_n = 0; block_n < num_n_tiles; ++block_n) {
-        const int start_col = block_n * BLOCK_N;
-        if (start_col >= N) break;
-        const int valid_k_rows = min(BLOCK_N, N - start_col);
-
-        if (start_col + valid_k_rows <= min_key_pos) {
-            continue;
-        }
-
-        const uint4* k_vec     = reinterpret_cast<const uint4*>(k_ptr + start_col * D);
-        uint4*       sK_vec    = reinterpret_cast<uint4*>(sK);
-
-        #pragma unroll 2
-        for (int idx = tid; idx < (valid_k_rows * d_stride_uint4); idx += THREADS_PER_BLOCK) {
-            const int row = idx / d_stride_uint4;
-            const int vec_col = idx % d_stride_uint4;
-
-            uint4 k_val = make_uint4(0, 0, 0, 0);
-            if (row < valid_k_rows && vec_col < d_stride_uint4) {
-                k_val = __ldg(&k_vec[row * d_stride_uint4 + vec_col]);
-            }
-            sK_vec[row * kv_stride_uint4 + vec_col] = k_val;
-        }
-        __syncthreads();
-
-        if constexpr (D == 256 && !D256_WMMA_QK) {
-            compute_qk_scores_scalar_fp32<D, LOW_SMEM, IS_CAUSAL>(
-                sQ, sK, sS, valid_q_rows, valid_k_rows, start_row, start_col,
-                causal_q_offset, softmax_scale, window_size_left,
-                window_size_right);
-        } else {
-            const int num_tiles_m_qk    = (BLOCK_M + WMMA_M - 1) / WMMA_M;
-            const int num_tiles_n_qk    = (BLOCK_N + WMMA_N - 1) / WMMA_N;
-            const int num_tiles_k_qk    = (D + WMMA_K - 1) / WMMA_K;
-            const int total_tiles_qk    = num_tiles_m_qk * num_tiles_n_qk;
-            const int tiles_per_warp_qk = (total_tiles_qk + WARPS_PER_BLOCK - 1) / WARPS_PER_BLOCK;
-            const unsigned row_causal   = (lane_id & 0b1) + ((lane_id >> 2) & 0b1) * 8 + ((lane_id >> 4) & 0b1) * 4;
-            const unsigned col_causal   = ((lane_id >> 1) & 0b1) * 2 + ((lane_id >> 3) & 0b1) * 8;
-
-            for (int tile_idx = 0; tile_idx < tiles_per_warp_qk; ++tile_idx) {
-                const int global_tile_idx = warp_id * tiles_per_warp_qk + tile_idx;
-                if (global_tile_idx >= total_tiles_qk) break;
-
-                const int tile_m_idx = global_tile_idx / num_tiles_n_qk;
-                const int tile_n_idx = global_tile_idx % num_tiles_n_qk;
-
-                const int tile_m = tile_m_idx * WMMA_M;
-                const int tile_n = tile_n_idx * WMMA_N;
-
-                if (tile_m >= valid_q_rows || tile_n >= valid_k_rows) continue;
-
-                fragment<matrix_a, WMMA_M, WMMA_N, WMMA_K, half, row_major> a_frag;
-                fragment<matrix_b, WMMA_M, WMMA_N, WMMA_K, half, col_major> b_frag;
-                fragment<accumulator, WMMA_M, WMMA_N, WMMA_K, float> acc_frag;
-                fill_fragment(acc_frag, 0.0f);
-
-                #pragma unroll
-                for (int k_tile = 0; k_tile < num_tiles_k_qk; ++k_tile) {
-                    const int k_offset = k_tile * WMMA_K;
-                    if (k_offset >= D) break;
-
-                    load_matrix_sync(a_frag, sQ + tile_m * Q_STRIDE + k_offset, Q_STRIDE);
-                    load_matrix_sync(b_frag, sK + tile_n * KV_STRIDE + k_offset, KV_STRIDE);
-                    mma_sync(acc_frag, a_frag, b_frag, acc_frag);
-                }
-
-                #pragma unroll
-                for (int i = 0; i < acc_frag.num_elements; ++i) {
-                    const unsigned col = col_causal + (i & 0b1) + ((i >> 2) & 0b1) * 4;
-                    const unsigned row = row_causal + ((i >> 1) & 0b1) * 2;
-
-                    const int global_m = start_row + tile_m + row;
-                    const int global_n = start_col + tile_n + col;
-                    const int global_q_pos = global_m + causal_q_offset;
-
-                    const bool is_valid = (global_m < start_row + valid_q_rows) &&
-                                          (global_n < start_col + valid_k_rows);
-                    bool is_causal_valid = true;
-                    if constexpr (IS_CAUSAL) {
-                        is_causal_valid = global_n <= global_q_pos;
-                    }
-                    bool is_window_valid = true;
-                    if (window_size_left >= 0) {
-                        is_window_valid = is_window_valid &&
-                                          global_n >= global_q_pos - window_size_left;
-                    }
-                    if (window_size_right >= 0) {
-                        is_window_valid = is_window_valid &&
-                                          global_n <= global_q_pos + window_size_right;
-                    }
-
-                    const float qk_scale =
-                        (D == 256) ? softmax_scale : softmax_scale_log2;
-                    acc_frag.x[i] =
-                        (is_valid && is_causal_valid && is_window_valid)
-                            ? acc_frag.x[i] * qk_scale
-                            : NEG_INF;
-                }
-                store_matrix_sync(sS + tile_m * S_STRIDE + tile_n, acc_frag, S_STRIDE, mem_row_major);
-            }
-        }
-        __syncthreads();
-
-        const uint4* v_vec     = reinterpret_cast<const uint4*>(v_ptr + start_col * D);
-        uint4*       sV_vec    = reinterpret_cast<uint4*>(sV);
-
-        #pragma unroll 2
-        for (int idx = tid; idx < (valid_k_rows * d_stride_uint4); idx += THREADS_PER_BLOCK) {
-            const int row = idx / d_stride_uint4;
-            const int vec_col = idx % d_stride_uint4;
-
-            uint4 v_val = make_uint4(0, 0, 0, 0);
-            if (row < valid_k_rows && vec_col < d_stride_uint4) {
-                v_val = __ldg(&v_vec[row * d_stride_uint4 + vec_col]);
-            }
-            sV_vec[row * kv_stride_uint4 + vec_col] = v_val;
-        }
-        __syncthreads();
-
-        const int num_tiles_m_pv    = (BLOCK_M + WMMA_M - 1) / WMMA_M;
-        const int num_tiles_n_pv    = (D + WMMA_N - 1) / WMMA_N;
-        const int total_tiles_pv    = num_tiles_m_pv * num_tiles_n_pv;
-        const int tiles_per_warp_pv = (total_tiles_pv + WARPS_PER_BLOCK - 1) / WARPS_PER_BLOCK;
-        const int softmax_sub_tile = (D == 256) ? P_SUB_TILE : p_tile_capacity;
-
-        for (int sub_start = 0; sub_start < valid_k_rows;
-             sub_start += softmax_sub_tile) {
-            const int sub_valid_k_rows = min(softmax_sub_tile,
-                                             valid_k_rows - sub_start);
-
-            if (tid < valid_q_rows * THREADS_PER_ROW) {
-                const int row = tid / THREADS_PER_ROW;
-                const int thread_in_row = tid % THREADS_PER_ROW;
-                const unsigned mask = (valid_q_rows == BLOCK_M)
-                                          ? 0xFFFFFFFFU
-                                          : __activemask();
-                const int row_leader = __ffs(mask) - 1;
-
-                float*  sS_row_f = sS + row * S_STRIDE + sub_start;
-                __half* sP_row_h = sP + row * p_stride;
-
-                const int vec_cols = sub_valid_k_rows >> 2;
-                const int vecs_per_thread =
-                    (vec_cols + THREADS_PER_ROW - 1) / THREADS_PER_ROW;
-                const int tail_start = vec_cols << 2;
-
-                float thread_max = NEG_INF;
-                float4* sS_vec4 = reinterpret_cast<float4*>(sS_row_f);
-
-                #pragma unroll 4
-                for (int j = 0; j < vecs_per_thread; ++j) {
-                    int vc = thread_in_row + j * THREADS_PER_ROW;
-                    if (vc < vec_cols) {
-                        float4 v4 = sS_vec4[vc];
-                        thread_max = fmaxf(
-                            thread_max,
-                            fmaxf(fmaxf(v4.x, v4.y), fmaxf(v4.z, v4.w)));
-                    }
-                }
-
-                #pragma unroll 4
-                for (int c = tail_start + thread_in_row; c < sub_valid_k_rows;
-                     c += THREADS_PER_ROW) {
-                    thread_max = fmaxf(thread_max, sS_row_f[c]);
-                }
-
-                #pragma unroll
-                for (int o = THREADS_PER_ROW / 2; o > 0; o >>= 1) {
-                    thread_max = fmaxf(
-                        thread_max,
-                        __shfl_down_sync(mask, thread_max, o, THREADS_PER_ROW));
-                }
-
-                const float row_max =
-                    __shfl_sync(mask, thread_max, row_leader, THREADS_PER_ROW);
-                const float old_max = sRowMax[row];
-                const float new_max = fmaxf(old_max, row_max);
-                const float exp_diff = (D == 256)
-                    ? expf(fmaxf(old_max - new_max, -80.0f))
-                    : exp2f(old_max - new_max);
-
-                float thread_sum = 0.0f;
-                __half2 half_buffer[20];
-                int vc_base = thread_in_row;
-                int h2_idx = 0;
-                int tail_col = -1;
-                __half tail_value = __float2half(0.f);
-
-                #pragma unroll 4
-                for (int j = 0; j < vecs_per_thread; ++j,
-                         vc_base += THREADS_PER_ROW) {
-                    if (vc_base < vec_cols) {
-                        float4 v4 = sS_vec4[vc_base];
-
-                        float e0 = (D == 256)
-                            ? expf(fmaxf(v4.x - new_max, -80.0f))
-                            : exp2f(fmaxf(v4.x - new_max, EXP2_CLAMP));
-                        float e1 = (D == 256)
-                            ? expf(fmaxf(v4.y - new_max, -80.0f))
-                            : exp2f(fmaxf(v4.y - new_max, EXP2_CLAMP));
-                        float e2 = (D == 256)
-                            ? expf(fmaxf(v4.z - new_max, -80.0f))
-                            : exp2f(fmaxf(v4.z - new_max, EXP2_CLAMP));
-                        float e3 = (D == 256)
-                            ? expf(fmaxf(v4.w - new_max, -80.0f))
-                            : exp2f(fmaxf(v4.w - new_max, EXP2_CLAMP));
-
-                        thread_sum += (e0 + e1) + (e2 + e3);
-
-                        half_buffer[h2_idx++] =
-                            __float22half2_rn(make_float2(e0, e1));
-                        half_buffer[h2_idx++] =
-                            __float22half2_rn(make_float2(e2, e3));
-                    }
-                }
-
-                #pragma unroll 4
-                for (int c = tail_start + thread_in_row; c < sub_valid_k_rows;
-                     c += THREADS_PER_ROW) {
-                    float v = sS_row_f[c];
-                    float e = (D == 256)
-                        ? expf(fmaxf(v - new_max, -80.0f))
-                        : exp2f(fmaxf(v - new_max, EXP2_CLAMP));
-                    thread_sum += e;
-                    tail_col = c;
-                    tail_value = __float2half_rn(e);
-                }
-
-                #pragma unroll
-                for (int o = THREADS_PER_ROW / 2; o > 0; o >>= 1) {
-                    thread_sum +=
-                        __shfl_down_sync(mask, thread_sum, o, THREADS_PER_ROW);
-                }
-
-                float row_sum =
-                    __shfl_sync(mask, thread_sum, row_leader, THREADS_PER_ROW);
-
-                if (thread_in_row == 0) {
-                    sRowSum[row] = exp_diff * sRowSum[row] + row_sum;
-                    sRowMax[row] = new_max;
-                }
-
-                h2_idx = 0;
-                vc_base = thread_in_row;
-                __half2* sP_half2 = reinterpret_cast<__half2*>(sP_row_h);
-
-                #pragma unroll 4
-                for (int j = 0; j < vecs_per_thread; ++j,
-                         vc_base += THREADS_PER_ROW) {
-                    if (vc_base < vec_cols) {
-                        int base_offset = vc_base * 2;
-                        sP_half2[base_offset] = half_buffer[h2_idx++];
-                        sP_half2[base_offset + 1] = half_buffer[h2_idx++];
-                    }
-                }
-
-                if (tail_col >= 0) {
-                    sP_row_h[tail_col] = tail_value;
-                }
-
-                #pragma unroll 4
-                for (int c = tail_start + thread_in_row; c < p_tile_capacity;
-                     c += THREADS_PER_ROW) {
-                    if (c >= sub_valid_k_rows) {
-                        sP_row_h[c] = __float2half(0.f);
-                    }
-                }
-
-                if (block_n > 0 || sub_start > 0) {
-                    float*  sO_row = sO + row * O_STRIDE;
-                    float4* sO_vec = reinterpret_cast<float4*>(sO_row);
-                    const int o_vec_count = (O_STRIDE + 3) >> 2;
-                    float scale = exp_diff;
-
-                    #pragma unroll 4
-                    for (int ov = thread_in_row; ov < o_vec_count;
-                         ov += THREADS_PER_ROW) {
-                        float4 v = sO_vec[ov];
-                        v.x *= scale;
-                        v.y *= scale;
-                        v.z *= scale;
-                        v.w *= scale;
-                        sO_vec[ov] = v;
-                    }
-                }
-            }
-            __syncthreads();
-
-            if (scalar_pv) {
-                const int total_row_cols = valid_q_rows * D;
-                for (int idx = tid; idx < total_row_cols;
-                     idx += THREADS_PER_BLOCK) {
-                    const int row = idx / D;
-                    const int d_col = idx - row * D;
-                    const __half* sP_row_h = sP + row * p_stride;
-                    float acc = 0.0f;
-
-                    #pragma unroll 1
-                    for (int k_idx = 0; k_idx < sub_valid_k_rows; ++k_idx) {
-                        const float p_val = __half2float(sP_row_h[k_idx]);
-                        const float v_val = __half2float(
-                            sV[(sub_start + k_idx) * KV_STRIDE + d_col]);
-                        acc += p_val * v_val;
-                    }
-                    sO[row * O_STRIDE + d_col] += acc;
-                }
-                __syncthreads();
-                continue;
-            }
-
-            const int num_tiles_k_pv =
-                (p_tile_capacity + WMMA_K - 1) / WMMA_K;
-
-            for (int tile_idx = 0; tile_idx < tiles_per_warp_pv; ++tile_idx) {
-                const int global_tile_idx = warp_id * tiles_per_warp_pv + tile_idx;
-                if (global_tile_idx >= total_tiles_pv) break;
-
-                const int tile_m_idx = global_tile_idx / num_tiles_n_pv;
-                const int tile_d_idx = global_tile_idx % num_tiles_n_pv;
-
-                const int tile_m = tile_m_idx * WMMA_M;
-                const int tile_d = tile_d_idx * WMMA_N;
-
-                if (tile_m >= valid_q_rows) continue;
-
-                fragment<matrix_a, WMMA_M, WMMA_N, WMMA_K, half, row_major> a_frag;
-                fragment<matrix_b, WMMA_M, WMMA_N, WMMA_K, half, row_major> b_frag;
-                fragment<accumulator, WMMA_M, WMMA_N, WMMA_K, float> acc_frag;
-
-                load_matrix_sync(
-                    acc_frag,
-                    sO + tile_m * O_STRIDE + tile_d,
-                    O_STRIDE,
-                    mem_row_major);
-
-                #pragma unroll
-                for (int tile_k = 0; tile_k < num_tiles_k_pv; ++tile_k) {
-                    const int k_offset = tile_k * WMMA_K;
-                    if (k_offset >= sub_valid_k_rows) break;
-
-                    load_matrix_sync(
-                        a_frag,
-                        sP + tile_m * p_stride + k_offset,
-                        p_stride);
-                    load_matrix_sync(
-                        b_frag,
-                        sV + (sub_start + k_offset) * KV_STRIDE + tile_d,
-                        KV_STRIDE);
-                    mma_sync(acc_frag, a_frag, b_frag, acc_frag);
-                }
-                store_matrix_sync(
-                    sO + tile_m * O_STRIDE + tile_d,
-                    acc_frag,
-                    O_STRIDE,
-                    mem_row_major);
-            }
-            __syncthreads();
-        }
-    }
-
-    const int total_fp16_x4 = (valid_q_rows * D) / 4;
-
-    for (int i = tid; i < total_fp16_x4; i += THREADS_PER_BLOCK) {
-        const int row = i / (D / 4);
-        const int col = (i % (D / 4)) * 4;
-
-        const float sum_clamped = fmaxf(sRowSum[row], 1e-24f);
-        const float inv_sum = 1.0f / sum_clamped;
-        const float* sO_row = sO + row * O_STRIDE;
-
-        const __half h0 = __float2half_rn(sO_row[col + 0] * inv_sum);
-        const __half h1 = __float2half_rn(sO_row[col + 1] * inv_sum);
-        const __half h2 = __float2half_rn(sO_row[col + 2] * inv_sum);
-        const __half h3 = __float2half_rn(sO_row[col + 3] * inv_sum);
-
-        asm volatile(
-            "st.global.v4.u16 [%0], {%1, %2, %3, %4};"
-            :
-            : "l"(out_ptr + row * D + col),
-              "h"(__half_as_ushort(h0)),
-              "h"(__half_as_ushort(h1)),
-              "h"(__half_as_ushort(h2)),
-              "h"(__half_as_ushort(h3))
-            : "memory"
-        );
-    }
-
-    if (tid < valid_q_rows) {
-        const float sum = fmaxf(sRowSum[tid], 1e-24f);
-        softmax_lse_ptr[tid] = (D == 256)
-            ? sRowMax[tid] + logf(sum)
-            : (sRowMax[tid] + log2f(sum)) * LN2;
-    }
+    sS[row * S_STRIDE + col] = is_valid ? acc * score_scale : NEG_INF;
+  }
 }
 
-template<int D, bool IS_CAUSAL>
-__global__ void __launch_bounds__(KernelConfig<D>::THREADS_PER_BLOCK, 2)
-flash_attention_qk_scores_kernel(
-    const __half* __restrict__ Q,
-    const __half* __restrict__ K,
-          float* __restrict__ Scores,
-    const int B,
-    const int H,
-    const int H_KV,
-    const int M,
-    const int N,
-    const float softmax_scale
-) {
-    using Config = KernelConfig<D>;
-    constexpr int BLOCK_M           = Config::BLOCK_M;
-    constexpr int BLOCK_N           = Config::BLOCK_N;
-    constexpr int THREADS_PER_BLOCK = Config::THREADS_PER_BLOCK;
-    constexpr int WARPS_PER_BLOCK   = Config::WARPS_PER_BLOCK;
-    constexpr int Q_STRIDE          = Config::Q_STRIDE;
-    constexpr int KV_STRIDE         = Config::KV_STRIDE;
-    constexpr int S_STRIDE          = Config::S_STRIDE;
-    constexpr int PER_UINT4         = Config::PER_UINT4;
-    const float NEG_INF = -1e30f;
+template <int D, bool LOW_SMEM, bool D256_WMMA_QK, bool IS_CAUSAL>
+__global__ void __launch_bounds__(KernelConfig<D, LOW_SMEM>::THREADS_PER_BLOCK,
+                                  2)
+    flash_attention_forward_kernel(
+        const __half* __restrict__ Q, const __half* __restrict__ K,
+        const __half* __restrict__ V, __half* __restrict__ Out,
+        float* __restrict__ softmax_lse, const int B, const int H,
+        const int H_KV, const int M, const int N, const float softmax_scale,
+        const bool scalar_pv, const int window_size_left,
+        const int window_size_right) {
+  using Config = KernelConfig<D, LOW_SMEM>;
+  constexpr int BLOCK_M = Config::BLOCK_M;
+  constexpr int BLOCK_N = Config::BLOCK_N;
+  constexpr int THREADS_PER_BLOCK = Config::THREADS_PER_BLOCK;
+  constexpr int THREADS_PER_ROW = Config::THREADS_PER_ROW;
+  constexpr int WARPS_PER_BLOCK = Config::WARPS_PER_BLOCK;
+  constexpr int Q_STRIDE = Config::Q_STRIDE;
+  constexpr int KV_STRIDE = Config::KV_STRIDE;
+  constexpr int S_STRIDE = Config::S_STRIDE;
+  constexpr int P_SUB_TILE = Config::P_SUB_TILE;
+  constexpr int P_STRIDE = Config::P_STRIDE;
+  constexpr int O_STRIDE = Config::O_STRIDE;
+  constexpr int PER_UINT4 = Config::PER_UINT4;
+  const float NEG_INF = -1e30f;
 
-    const int batch_head_id = blockIdx.z;
-    if (batch_head_id >= B * H) return;
-    const int batch_id = batch_head_id / H;
-    const int q_head_id = batch_head_id % H;
-    const int kv_group_size = H / H_KV;
-    const int kv_head_id = q_head_id / kv_group_size;
+  const int batch_head_id = blockIdx.z;
+  if (batch_head_id >= B * H) return;
+  const int batch_id = batch_head_id / H;
+  const int q_head_id = batch_head_id % H;
+  const int kv_group_size = H / H_KV;
+  const int kv_head_id = q_head_id / kv_group_size;
 
-    const int block_m = blockIdx.x;
-    const int block_n = blockIdx.y;
-    const int start_row = block_m * BLOCK_M;
+  const int block_m = blockIdx.x;
+  const int start_row = block_m * BLOCK_M;
+  if (start_row >= M) return;
+
+  int num_n_tiles = (N + BLOCK_N - 1) / BLOCK_N;
+  const int valid_q_rows = min(BLOCK_M, M - start_row);
+  const int causal_q_offset = max(N - M, 0);
+
+  int max_key_pos = N - 1;
+  if constexpr (IS_CAUSAL) {
+    max_key_pos =
+        min(max_key_pos, causal_q_offset + start_row + valid_q_rows - 1);
+  }
+  if (window_size_right >= 0) {
+    max_key_pos = min(max_key_pos, causal_q_offset + start_row + valid_q_rows -
+                                       1 + window_size_right);
+  }
+  if (max_key_pos < 0) {
+    num_n_tiles = 0;
+  } else {
+    num_n_tiles = min(num_n_tiles, (max_key_pos + BLOCK_N) / BLOCK_N);
+  }
+  const int min_key_pos =
+      window_size_left >= 0
+          ? max(0, causal_q_offset + start_row - window_size_left)
+          : 0;
+
+  const int tid = threadIdx.x;
+  const int warp_id = tid / MAX_THREADS_PER_WARP;
+  const int lane_id = tid % MAX_THREADS_PER_WARP;
+
+  const size_t q_head_linear = (size_t)batch_id * H + q_head_id;
+  const size_t kv_head_linear = (size_t)batch_id * H_KV + kv_head_id;
+  const __half* q_ptr = Q + q_head_linear * M * D + start_row * D;
+  const __half* k_ptr = K + kv_head_linear * N * D;
+  const __half* v_ptr = V + kv_head_linear * N * D;
+  __half* out_ptr = Out + q_head_linear * M * D + start_row * D;
+  float* softmax_lse_ptr = softmax_lse + q_head_linear * M + start_row;
+
+  extern __shared__ char smem_raw[];
+  init_smem<Config>(smem_raw);
+  auto& smem = *reinterpret_cast<typename Config::SmemLayout*>(smem_raw);
+
+  __half* sQ = smem.q;
+  __half* sK = smem.reuse_kv.k;
+  __half* sV = smem.reuse_kv.v;
+  float* sS = smem.reuse_sp.s;
+  __half* sP = (D == 256) ? smem.p_strict : smem.reuse_sp.p;
+  const int p_stride = (D == 256) ? P_STRIDE : S_STRIDE;
+  const int p_tile_capacity = (D == 256) ? P_SUB_TILE : BLOCK_N;
+  float* sO = smem.o;
+  float* sRowMax = smem.row_max;
+  float* sRowSum = smem.row_sum;
+  constexpr float RCP_LN2 = 1.4426950408889634f;
+  constexpr float LN2 = 0.6931471805599453f;
+  constexpr float EXP2_CLAMP = -80.0f * RCP_LN2;
+  const float softmax_scale_log2 = softmax_scale * RCP_LN2;
+
+  const int d_stride_uint4 = (D + PER_UINT4 - 1) / PER_UINT4;
+  const int q_stride_uint4 = (Q_STRIDE + PER_UINT4 - 1) / PER_UINT4;
+  const int kv_stride_uint4 = (KV_STRIDE + PER_UINT4 - 1) / PER_UINT4;
+
+  if (tid < BLOCK_M) {
+    sRowMax[tid] = NEG_INF;
+  }
+
+  const uint4* q_vec = reinterpret_cast<const uint4*>(q_ptr);
+  uint4* sQ_vec = reinterpret_cast<uint4*>(sQ);
+
+#pragma unroll 4
+  for (int idx = tid; idx < (valid_q_rows * d_stride_uint4);
+       idx += THREADS_PER_BLOCK) {
+    const int row = idx / d_stride_uint4;
+    const int vec_col = idx % d_stride_uint4;
+    uint4 q_val = make_uint4(0, 0, 0, 0);
+    if (row < valid_q_rows && vec_col < d_stride_uint4) {
+      q_val = __ldg(&q_vec[row * d_stride_uint4 + vec_col]);
+    }
+    sQ_vec[row * q_stride_uint4 + vec_col] = q_val;
+  }
+  __syncthreads();
+
+  for (int block_n = 0; block_n < num_n_tiles; ++block_n) {
     const int start_col = block_n * BLOCK_N;
-    if (start_row >= M || start_col >= N) return;
-
-    const int valid_q_rows = min(BLOCK_M, M - start_row);
+    if (start_col >= N) break;
     const int valid_k_rows = min(BLOCK_N, N - start_col);
-    const int causal_q_offset = max(N - M, 0);
 
-    if constexpr (IS_CAUSAL) {
-        if (start_col >= causal_q_offset + start_row + valid_q_rows) {
-            return;
-        }
+    if (start_col + valid_k_rows <= min_key_pos) {
+      continue;
     }
 
-    const int tid = threadIdx.x;
-    const int warp_id = tid / MAX_THREADS_PER_WARP;
-    const int lane_id = tid % MAX_THREADS_PER_WARP;
-
-    const size_t q_head_linear = (size_t)batch_id * H + q_head_id;
-    const size_t kv_head_linear = (size_t)batch_id * H_KV + kv_head_id;
-    const __half* q_ptr = Q + q_head_linear * M * D + start_row * D;
-    const __half* k_ptr = K + kv_head_linear * N * D + start_col * D;
-    float* score_ptr = Scores + q_head_linear * M * N + start_row * N + start_col;
-
-    extern __shared__ char smem_raw[];
-    init_smem<Config>(smem_raw);
-    auto& smem = *reinterpret_cast<typename Config::SmemLayout*>(smem_raw);
-
-    __half* sQ = smem.q;
-    __half* sK = smem.reuse_kv.k;
-    float*  sS = smem.reuse_sp.s;
-
-    const int d_stride_uint4  = (D + PER_UINT4 - 1) / PER_UINT4;
-    const int q_stride_uint4  = (Q_STRIDE + PER_UINT4 - 1) / PER_UINT4;
-    const int kv_stride_uint4 = (KV_STRIDE + PER_UINT4 - 1) / PER_UINT4;
-
-    const uint4* q_vec = reinterpret_cast<const uint4*>(q_ptr);
-    uint4* sQ_vec = reinterpret_cast<uint4*>(sQ);
-
-    #pragma unroll 4
-    for (int idx = tid; idx < (valid_q_rows * d_stride_uint4);
-         idx += THREADS_PER_BLOCK) {
-        const int row = idx / d_stride_uint4;
-        const int vec_col = idx % d_stride_uint4;
-        uint4 q_val = make_uint4(0, 0, 0, 0);
-        if (row < valid_q_rows && vec_col < d_stride_uint4) {
-            q_val = __ldg(&q_vec[row * d_stride_uint4 + vec_col]);
-        }
-        sQ_vec[row * q_stride_uint4 + vec_col] = q_val;
-    }
-
-    const uint4* k_vec = reinterpret_cast<const uint4*>(k_ptr);
+    const uint4* k_vec = reinterpret_cast<const uint4*>(k_ptr + start_col * D);
     uint4* sK_vec = reinterpret_cast<uint4*>(sK);
 
-    #pragma unroll 2
+#pragma unroll 2
     for (int idx = tid; idx < (valid_k_rows * d_stride_uint4);
          idx += THREADS_PER_BLOCK) {
-        const int row = idx / d_stride_uint4;
-        const int vec_col = idx % d_stride_uint4;
-        uint4 k_val = make_uint4(0, 0, 0, 0);
-        if (row < valid_k_rows && vec_col < d_stride_uint4) {
-            k_val = __ldg(&k_vec[row * d_stride_uint4 + vec_col]);
-        }
-        sK_vec[row * kv_stride_uint4 + vec_col] = k_val;
+      const int row = idx / d_stride_uint4;
+      const int vec_col = idx % d_stride_uint4;
+
+      uint4 k_val = make_uint4(0, 0, 0, 0);
+      if (row < valid_k_rows && vec_col < d_stride_uint4) {
+        k_val = __ldg(&k_vec[row * d_stride_uint4 + vec_col]);
+      }
+      sK_vec[row * kv_stride_uint4 + vec_col] = k_val;
     }
     __syncthreads();
 
-    if constexpr (D == 256) {
-        compute_qk_scores_scalar_fp32<D, false, IS_CAUSAL>(
-            sQ, sK, sS, valid_q_rows, valid_k_rows, start_row, start_col,
-            causal_q_offset, softmax_scale, -1, -1);
+    if constexpr (D == 256 && !D256_WMMA_QK) {
+      compute_qk_scores_scalar_fp32<D, LOW_SMEM, IS_CAUSAL>(
+          sQ, sK, sS, valid_q_rows, valid_k_rows, start_row, start_col,
+          causal_q_offset, softmax_scale, window_size_left, window_size_right);
     } else {
-        const int num_tiles_m_qk = (BLOCK_M + WMMA_M - 1) / WMMA_M;
-        const int num_tiles_n_qk = (BLOCK_N + WMMA_N - 1) / WMMA_N;
-        const int num_tiles_k_qk = (D + WMMA_K - 1) / WMMA_K;
-        const int total_tiles_qk = num_tiles_m_qk * num_tiles_n_qk;
-        const int tiles_per_warp_qk =
-            (total_tiles_qk + WARPS_PER_BLOCK - 1) / WARPS_PER_BLOCK;
-        const unsigned row_causal =
-            (lane_id & 0b1) + ((lane_id >> 2) & 0b1) * 8
-            + ((lane_id >> 4) & 0b1) * 4;
-        const unsigned col_causal =
-            ((lane_id >> 1) & 0b1) * 2 + ((lane_id >> 3) & 0b1) * 8;
+      const int num_tiles_m_qk = (BLOCK_M + WMMA_M - 1) / WMMA_M;
+      const int num_tiles_n_qk = (BLOCK_N + WMMA_N - 1) / WMMA_N;
+      const int num_tiles_k_qk = (D + WMMA_K - 1) / WMMA_K;
+      const int total_tiles_qk = num_tiles_m_qk * num_tiles_n_qk;
+      const int tiles_per_warp_qk =
+          (total_tiles_qk + WARPS_PER_BLOCK - 1) / WARPS_PER_BLOCK;
+      const unsigned row_causal = (lane_id & 0b1) + ((lane_id >> 2) & 0b1) * 8 +
+                                  ((lane_id >> 4) & 0b1) * 4;
+      const unsigned col_causal =
+          ((lane_id >> 1) & 0b1) * 2 + ((lane_id >> 3) & 0b1) * 8;
 
-        for (int tile_idx = 0; tile_idx < tiles_per_warp_qk; ++tile_idx) {
-            const int global_tile_idx = warp_id * tiles_per_warp_qk + tile_idx;
-            if (global_tile_idx >= total_tiles_qk) break;
+      for (int tile_idx = 0; tile_idx < tiles_per_warp_qk; ++tile_idx) {
+        const int global_tile_idx = warp_id * tiles_per_warp_qk + tile_idx;
+        if (global_tile_idx >= total_tiles_qk) break;
 
-            const int tile_m_idx = global_tile_idx / num_tiles_n_qk;
-            const int tile_n_idx = global_tile_idx % num_tiles_n_qk;
+        const int tile_m_idx = global_tile_idx / num_tiles_n_qk;
+        const int tile_n_idx = global_tile_idx % num_tiles_n_qk;
 
-            const int tile_m = tile_m_idx * WMMA_M;
-            const int tile_n = tile_n_idx * WMMA_N;
+        const int tile_m = tile_m_idx * WMMA_M;
+        const int tile_n = tile_n_idx * WMMA_N;
 
-            if (tile_m >= valid_q_rows || tile_n >= valid_k_rows) continue;
+        if (tile_m >= valid_q_rows || tile_n >= valid_k_rows) continue;
 
-            fragment<matrix_a, WMMA_M, WMMA_N, WMMA_K, half, row_major> a_frag;
-            fragment<matrix_b, WMMA_M, WMMA_N, WMMA_K, half, col_major> b_frag;
-            fragment<accumulator, WMMA_M, WMMA_N, WMMA_K, float> acc_frag;
-            fill_fragment(acc_frag, 0.0f);
+        fragment<matrix_a, WMMA_M, WMMA_N, WMMA_K, half, row_major> a_frag;
+        fragment<matrix_b, WMMA_M, WMMA_N, WMMA_K, half, col_major> b_frag;
+        fragment<accumulator, WMMA_M, WMMA_N, WMMA_K, float> acc_frag;
+        fill_fragment(acc_frag, 0.0f);
 
-            #pragma unroll
-            for (int k_tile = 0; k_tile < num_tiles_k_qk; ++k_tile) {
-                const int k_offset = k_tile * WMMA_K;
-                if (k_offset >= D) break;
+#pragma unroll
+        for (int k_tile = 0; k_tile < num_tiles_k_qk; ++k_tile) {
+          const int k_offset = k_tile * WMMA_K;
+          if (k_offset >= D) break;
 
-                load_matrix_sync(a_frag, sQ + tile_m * Q_STRIDE + k_offset,
-                                 Q_STRIDE);
-                load_matrix_sync(b_frag, sK + tile_n * KV_STRIDE + k_offset,
-                                 KV_STRIDE);
-                mma_sync(acc_frag, a_frag, b_frag, acc_frag);
-            }
-
-            if constexpr (IS_CAUSAL) {
-                #pragma unroll
-                for (int i = 0; i < acc_frag.num_elements; ++i) {
-                    const unsigned col =
-                        col_causal + (i & 0b1) + ((i >> 2) & 0b1) * 4;
-                    const unsigned row = row_causal + ((i >> 1) & 0b1) * 2;
-
-                    const int global_m = start_row + tile_m + row;
-                    const int global_n = start_col + tile_n + col;
-                    const int global_q_pos = global_m + causal_q_offset;
-
-                    const bool is_valid =
-                        (global_m < start_row + valid_q_rows) &&
-                        (global_n < start_col + valid_k_rows);
-
-                    acc_frag.x[i] = is_valid
-                        ? ((global_n > global_q_pos)
-                               ? NEG_INF
-                               : acc_frag.x[i] * softmax_scale)
-                        : NEG_INF;
-                }
-            } else {
-                #pragma unroll
-                for (int i = 0; i < acc_frag.num_elements; ++i) {
-                    acc_frag.x[i] *= softmax_scale;
-                }
-            }
-            store_matrix_sync(sS + tile_m * S_STRIDE + tile_n, acc_frag,
-                              S_STRIDE, mem_row_major);
+          load_matrix_sync(a_frag, sQ + tile_m * Q_STRIDE + k_offset, Q_STRIDE);
+          load_matrix_sync(b_frag, sK + tile_n * KV_STRIDE + k_offset,
+                           KV_STRIDE);
+          mma_sync(acc_frag, a_frag, b_frag, acc_frag);
         }
+
+#pragma unroll
+        for (int i = 0; i < acc_frag.num_elements; ++i) {
+          const unsigned col = col_causal + (i & 0b1) + ((i >> 2) & 0b1) * 4;
+          const unsigned row = row_causal + ((i >> 1) & 0b1) * 2;
+
+          const int global_m = start_row + tile_m + row;
+          const int global_n = start_col + tile_n + col;
+          const int global_q_pos = global_m + causal_q_offset;
+
+          const bool is_valid = (global_m < start_row + valid_q_rows) &&
+                                (global_n < start_col + valid_k_rows);
+          bool is_causal_valid = true;
+          if constexpr (IS_CAUSAL) {
+            is_causal_valid = global_n <= global_q_pos;
+          }
+          bool is_window_valid = true;
+          if (window_size_left >= 0) {
+            is_window_valid =
+                is_window_valid && global_n >= global_q_pos - window_size_left;
+          }
+          if (window_size_right >= 0) {
+            is_window_valid =
+                is_window_valid && global_n <= global_q_pos + window_size_right;
+          }
+
+          const float qk_scale =
+              (D == 256) ? softmax_scale : softmax_scale_log2;
+          acc_frag.x[i] = (is_valid && is_causal_valid && is_window_valid)
+                              ? acc_frag.x[i] * qk_scale
+                              : NEG_INF;
+        }
+        store_matrix_sync(sS + tile_m * S_STRIDE + tile_n, acc_frag, S_STRIDE,
+                          mem_row_major);
+      }
     }
     __syncthreads();
 
-    for (int idx = tid; idx < valid_q_rows * valid_k_rows;
+    const uint4* v_vec = reinterpret_cast<const uint4*>(v_ptr + start_col * D);
+    uint4* sV_vec = reinterpret_cast<uint4*>(sV);
+
+#pragma unroll 2
+    for (int idx = tid; idx < (valid_k_rows * d_stride_uint4);
          idx += THREADS_PER_BLOCK) {
-        const int row = idx / valid_k_rows;
-        const int col = idx % valid_k_rows;
-        score_ptr[row * N + col] = sS[row * S_STRIDE + col];
+      const int row = idx / d_stride_uint4;
+      const int vec_col = idx % d_stride_uint4;
+
+      uint4 v_val = make_uint4(0, 0, 0, 0);
+      if (row < valid_k_rows && vec_col < d_stride_uint4) {
+        v_val = __ldg(&v_vec[row * d_stride_uint4 + vec_col]);
+      }
+      sV_vec[row * kv_stride_uint4 + vec_col] = v_val;
     }
+    __syncthreads();
+
+    const int num_tiles_m_pv = (BLOCK_M + WMMA_M - 1) / WMMA_M;
+    const int num_tiles_n_pv = (D + WMMA_N - 1) / WMMA_N;
+    const int total_tiles_pv = num_tiles_m_pv * num_tiles_n_pv;
+    const int tiles_per_warp_pv =
+        (total_tiles_pv + WARPS_PER_BLOCK - 1) / WARPS_PER_BLOCK;
+    const int softmax_sub_tile = (D == 256) ? P_SUB_TILE : p_tile_capacity;
+
+    for (int sub_start = 0; sub_start < valid_k_rows;
+         sub_start += softmax_sub_tile) {
+      const int sub_valid_k_rows =
+          min(softmax_sub_tile, valid_k_rows - sub_start);
+
+      if (tid < valid_q_rows * THREADS_PER_ROW) {
+        const int row = tid / THREADS_PER_ROW;
+        const int thread_in_row = tid % THREADS_PER_ROW;
+        const unsigned mask =
+            (valid_q_rows == BLOCK_M) ? 0xFFFFFFFFU : __activemask();
+        const int row_leader = __ffs(mask) - 1;
+
+        float* sS_row_f = sS + row * S_STRIDE + sub_start;
+        __half* sP_row_h = sP + row * p_stride;
+
+        const int vec_cols = sub_valid_k_rows >> 2;
+        const int vecs_per_thread =
+            (vec_cols + THREADS_PER_ROW - 1) / THREADS_PER_ROW;
+        const int tail_start = vec_cols << 2;
+
+        float thread_max = NEG_INF;
+        float4* sS_vec4 = reinterpret_cast<float4*>(sS_row_f);
+
+#pragma unroll 4
+        for (int j = 0; j < vecs_per_thread; ++j) {
+          int vc = thread_in_row + j * THREADS_PER_ROW;
+          if (vc < vec_cols) {
+            float4 v4 = sS_vec4[vc];
+            thread_max =
+                fmaxf(thread_max, fmaxf(fmaxf(v4.x, v4.y), fmaxf(v4.z, v4.w)));
+          }
+        }
+
+#pragma unroll 4
+        for (int c = tail_start + thread_in_row; c < sub_valid_k_rows;
+             c += THREADS_PER_ROW) {
+          thread_max = fmaxf(thread_max, sS_row_f[c]);
+        }
+
+#pragma unroll
+        for (int o = THREADS_PER_ROW / 2; o > 0; o >>= 1) {
+          thread_max = fmaxf(thread_max, __shfl_down_sync(mask, thread_max, o,
+                                                          THREADS_PER_ROW));
+        }
+
+        const float row_max =
+            __shfl_sync(mask, thread_max, row_leader, THREADS_PER_ROW);
+        const float old_max = sRowMax[row];
+        const float new_max = fmaxf(old_max, row_max);
+        const float exp_diff = (D == 256)
+                                   ? expf(fmaxf(old_max - new_max, -80.0f))
+                                   : exp2f(old_max - new_max);
+
+        float thread_sum = 0.0f;
+        __half2 half_buffer[20];
+        int vc_base = thread_in_row;
+        int h2_idx = 0;
+        int tail_col = -1;
+        __half tail_value = __float2half(0.f);
+
+#pragma unroll 4
+        for (int j = 0; j < vecs_per_thread; ++j, vc_base += THREADS_PER_ROW) {
+          if (vc_base < vec_cols) {
+            float4 v4 = sS_vec4[vc_base];
+
+            float e0 = (D == 256) ? expf(fmaxf(v4.x - new_max, -80.0f))
+                                  : exp2f(fmaxf(v4.x - new_max, EXP2_CLAMP));
+            float e1 = (D == 256) ? expf(fmaxf(v4.y - new_max, -80.0f))
+                                  : exp2f(fmaxf(v4.y - new_max, EXP2_CLAMP));
+            float e2 = (D == 256) ? expf(fmaxf(v4.z - new_max, -80.0f))
+                                  : exp2f(fmaxf(v4.z - new_max, EXP2_CLAMP));
+            float e3 = (D == 256) ? expf(fmaxf(v4.w - new_max, -80.0f))
+                                  : exp2f(fmaxf(v4.w - new_max, EXP2_CLAMP));
+
+            thread_sum += (e0 + e1) + (e2 + e3);
+
+            half_buffer[h2_idx++] = __float22half2_rn(make_float2(e0, e1));
+            half_buffer[h2_idx++] = __float22half2_rn(make_float2(e2, e3));
+          }
+        }
+
+#pragma unroll 4
+        for (int c = tail_start + thread_in_row; c < sub_valid_k_rows;
+             c += THREADS_PER_ROW) {
+          float v = sS_row_f[c];
+          float e = (D == 256) ? expf(fmaxf(v - new_max, -80.0f))
+                               : exp2f(fmaxf(v - new_max, EXP2_CLAMP));
+          thread_sum += e;
+          tail_col = c;
+          tail_value = __float2half_rn(e);
+        }
+
+#pragma unroll
+        for (int o = THREADS_PER_ROW / 2; o > 0; o >>= 1) {
+          thread_sum += __shfl_down_sync(mask, thread_sum, o, THREADS_PER_ROW);
+        }
+
+        float row_sum =
+            __shfl_sync(mask, thread_sum, row_leader, THREADS_PER_ROW);
+
+        if (thread_in_row == 0) {
+          sRowSum[row] = exp_diff * sRowSum[row] + row_sum;
+          sRowMax[row] = new_max;
+        }
+
+        h2_idx = 0;
+        vc_base = thread_in_row;
+        __half2* sP_half2 = reinterpret_cast<__half2*>(sP_row_h);
+
+#pragma unroll 4
+        for (int j = 0; j < vecs_per_thread; ++j, vc_base += THREADS_PER_ROW) {
+          if (vc_base < vec_cols) {
+            int base_offset = vc_base * 2;
+            sP_half2[base_offset] = half_buffer[h2_idx++];
+            sP_half2[base_offset + 1] = half_buffer[h2_idx++];
+          }
+        }
+
+        if (tail_col >= 0) {
+          sP_row_h[tail_col] = tail_value;
+        }
+
+#pragma unroll 4
+        for (int c = tail_start + thread_in_row; c < p_tile_capacity;
+             c += THREADS_PER_ROW) {
+          if (c >= sub_valid_k_rows) {
+            sP_row_h[c] = __float2half(0.f);
+          }
+        }
+
+        if (block_n > 0 || sub_start > 0) {
+          float* sO_row = sO + row * O_STRIDE;
+          float4* sO_vec = reinterpret_cast<float4*>(sO_row);
+          const int o_vec_count = (O_STRIDE + 3) >> 2;
+          float scale = exp_diff;
+
+#pragma unroll 4
+          for (int ov = thread_in_row; ov < o_vec_count;
+               ov += THREADS_PER_ROW) {
+            float4 v = sO_vec[ov];
+            v.x *= scale;
+            v.y *= scale;
+            v.z *= scale;
+            v.w *= scale;
+            sO_vec[ov] = v;
+          }
+        }
+      }
+      __syncthreads();
+
+      if (scalar_pv) {
+        const int total_row_cols = valid_q_rows * D;
+        for (int idx = tid; idx < total_row_cols; idx += THREADS_PER_BLOCK) {
+          const int row = idx / D;
+          const int d_col = idx - row * D;
+          const __half* sP_row_h = sP + row * p_stride;
+          float acc = 0.0f;
+
+#pragma unroll 1
+          for (int k_idx = 0; k_idx < sub_valid_k_rows; ++k_idx) {
+            const float p_val = __half2float(sP_row_h[k_idx]);
+            const float v_val =
+                __half2float(sV[(sub_start + k_idx) * KV_STRIDE + d_col]);
+            acc += p_val * v_val;
+          }
+          sO[row * O_STRIDE + d_col] += acc;
+        }
+        __syncthreads();
+        continue;
+      }
+
+      const int num_tiles_k_pv = (p_tile_capacity + WMMA_K - 1) / WMMA_K;
+
+      for (int tile_idx = 0; tile_idx < tiles_per_warp_pv; ++tile_idx) {
+        const int global_tile_idx = warp_id * tiles_per_warp_pv + tile_idx;
+        if (global_tile_idx >= total_tiles_pv) break;
+
+        const int tile_m_idx = global_tile_idx / num_tiles_n_pv;
+        const int tile_d_idx = global_tile_idx % num_tiles_n_pv;
+
+        const int tile_m = tile_m_idx * WMMA_M;
+        const int tile_d = tile_d_idx * WMMA_N;
+
+        if (tile_m >= valid_q_rows) continue;
+
+        fragment<matrix_a, WMMA_M, WMMA_N, WMMA_K, half, row_major> a_frag;
+        fragment<matrix_b, WMMA_M, WMMA_N, WMMA_K, half, row_major> b_frag;
+        fragment<accumulator, WMMA_M, WMMA_N, WMMA_K, float> acc_frag;
+
+        load_matrix_sync(acc_frag, sO + tile_m * O_STRIDE + tile_d, O_STRIDE,
+                         mem_row_major);
+
+#pragma unroll
+        for (int tile_k = 0; tile_k < num_tiles_k_pv; ++tile_k) {
+          const int k_offset = tile_k * WMMA_K;
+          if (k_offset >= sub_valid_k_rows) break;
+
+          load_matrix_sync(a_frag, sP + tile_m * p_stride + k_offset, p_stride);
+          load_matrix_sync(b_frag,
+                           sV + (sub_start + k_offset) * KV_STRIDE + tile_d,
+                           KV_STRIDE);
+          mma_sync(acc_frag, a_frag, b_frag, acc_frag);
+        }
+        store_matrix_sync(sO + tile_m * O_STRIDE + tile_d, acc_frag, O_STRIDE,
+                          mem_row_major);
+      }
+      __syncthreads();
+    }
+  }
+
+  const int total_fp16_x4 = (valid_q_rows * D) / 4;
+
+  for (int i = tid; i < total_fp16_x4; i += THREADS_PER_BLOCK) {
+    const int row = i / (D / 4);
+    const int col = (i % (D / 4)) * 4;
+
+    const float sum_clamped = fmaxf(sRowSum[row], 1e-24f);
+    const float inv_sum = 1.0f / sum_clamped;
+    const float* sO_row = sO + row * O_STRIDE;
+
+    const __half h0 = __float2half_rn(sO_row[col + 0] * inv_sum);
+    const __half h1 = __float2half_rn(sO_row[col + 1] * inv_sum);
+    const __half h2 = __float2half_rn(sO_row[col + 2] * inv_sum);
+    const __half h3 = __float2half_rn(sO_row[col + 3] * inv_sum);
+
+    asm volatile("st.global.v4.u16 [%0], {%1, %2, %3, %4};"
+                 :
+                 : "l"(out_ptr + row * D + col), "h"(__half_as_ushort(h0)),
+                   "h"(__half_as_ushort(h1)), "h"(__half_as_ushort(h2)),
+                   "h"(__half_as_ushort(h3))
+                 : "memory");
+  }
+
+  if (tid < valid_q_rows) {
+    const float sum = fmaxf(sRowSum[tid], 1e-24f);
+    softmax_lse_ptr[tid] = (D == 256) ? sRowMax[tid] + logf(sum)
+                                      : (sRowMax[tid] + log2f(sum)) * LN2;
+  }
 }
 
-template<int D, bool LOW_SMEM, bool D256_WMMA_QK>
+template <int D, bool IS_CAUSAL>
+__global__ void __launch_bounds__(KernelConfig<D>::THREADS_PER_BLOCK, 2)
+    flash_attention_qk_scores_kernel(const __half* __restrict__ Q,
+                                     const __half* __restrict__ K,
+                                     float* __restrict__ Scores, const int B,
+                                     const int H, const int H_KV, const int M,
+                                     const int N, const float softmax_scale) {
+  using Config = KernelConfig<D>;
+  constexpr int BLOCK_M = Config::BLOCK_M;
+  constexpr int BLOCK_N = Config::BLOCK_N;
+  constexpr int THREADS_PER_BLOCK = Config::THREADS_PER_BLOCK;
+  constexpr int WARPS_PER_BLOCK = Config::WARPS_PER_BLOCK;
+  constexpr int Q_STRIDE = Config::Q_STRIDE;
+  constexpr int KV_STRIDE = Config::KV_STRIDE;
+  constexpr int S_STRIDE = Config::S_STRIDE;
+  constexpr int PER_UINT4 = Config::PER_UINT4;
+  const float NEG_INF = -1e30f;
+
+  const int batch_head_id = blockIdx.z;
+  if (batch_head_id >= B * H) return;
+  const int batch_id = batch_head_id / H;
+  const int q_head_id = batch_head_id % H;
+  const int kv_group_size = H / H_KV;
+  const int kv_head_id = q_head_id / kv_group_size;
+
+  const int block_m = blockIdx.x;
+  const int block_n = blockIdx.y;
+  const int start_row = block_m * BLOCK_M;
+  const int start_col = block_n * BLOCK_N;
+  if (start_row >= M || start_col >= N) return;
+
+  const int valid_q_rows = min(BLOCK_M, M - start_row);
+  const int valid_k_rows = min(BLOCK_N, N - start_col);
+  const int causal_q_offset = max(N - M, 0);
+
+  if constexpr (IS_CAUSAL) {
+    if (start_col >= causal_q_offset + start_row + valid_q_rows) {
+      return;
+    }
+  }
+
+  const int tid = threadIdx.x;
+  const int warp_id = tid / MAX_THREADS_PER_WARP;
+  const int lane_id = tid % MAX_THREADS_PER_WARP;
+
+  const size_t q_head_linear = (size_t)batch_id * H + q_head_id;
+  const size_t kv_head_linear = (size_t)batch_id * H_KV + kv_head_id;
+  const __half* q_ptr = Q + q_head_linear * M * D + start_row * D;
+  const __half* k_ptr = K + kv_head_linear * N * D + start_col * D;
+  float* score_ptr = Scores + q_head_linear * M * N + start_row * N + start_col;
+
+  extern __shared__ char smem_raw[];
+  init_smem<Config>(smem_raw);
+  auto& smem = *reinterpret_cast<typename Config::SmemLayout*>(smem_raw);
+
+  __half* sQ = smem.q;
+  __half* sK = smem.reuse_kv.k;
+  float* sS = smem.reuse_sp.s;
+
+  const int d_stride_uint4 = (D + PER_UINT4 - 1) / PER_UINT4;
+  const int q_stride_uint4 = (Q_STRIDE + PER_UINT4 - 1) / PER_UINT4;
+  const int kv_stride_uint4 = (KV_STRIDE + PER_UINT4 - 1) / PER_UINT4;
+
+  const uint4* q_vec = reinterpret_cast<const uint4*>(q_ptr);
+  uint4* sQ_vec = reinterpret_cast<uint4*>(sQ);
+
+#pragma unroll 4
+  for (int idx = tid; idx < (valid_q_rows * d_stride_uint4);
+       idx += THREADS_PER_BLOCK) {
+    const int row = idx / d_stride_uint4;
+    const int vec_col = idx % d_stride_uint4;
+    uint4 q_val = make_uint4(0, 0, 0, 0);
+    if (row < valid_q_rows && vec_col < d_stride_uint4) {
+      q_val = __ldg(&q_vec[row * d_stride_uint4 + vec_col]);
+    }
+    sQ_vec[row * q_stride_uint4 + vec_col] = q_val;
+  }
+
+  const uint4* k_vec = reinterpret_cast<const uint4*>(k_ptr);
+  uint4* sK_vec = reinterpret_cast<uint4*>(sK);
+
+#pragma unroll 2
+  for (int idx = tid; idx < (valid_k_rows * d_stride_uint4);
+       idx += THREADS_PER_BLOCK) {
+    const int row = idx / d_stride_uint4;
+    const int vec_col = idx % d_stride_uint4;
+    uint4 k_val = make_uint4(0, 0, 0, 0);
+    if (row < valid_k_rows && vec_col < d_stride_uint4) {
+      k_val = __ldg(&k_vec[row * d_stride_uint4 + vec_col]);
+    }
+    sK_vec[row * kv_stride_uint4 + vec_col] = k_val;
+  }
+  __syncthreads();
+
+  if constexpr (D == 256) {
+    compute_qk_scores_scalar_fp32<D, false, IS_CAUSAL>(
+        sQ, sK, sS, valid_q_rows, valid_k_rows, start_row, start_col,
+        causal_q_offset, softmax_scale, -1, -1);
+  } else {
+    const int num_tiles_m_qk = (BLOCK_M + WMMA_M - 1) / WMMA_M;
+    const int num_tiles_n_qk = (BLOCK_N + WMMA_N - 1) / WMMA_N;
+    const int num_tiles_k_qk = (D + WMMA_K - 1) / WMMA_K;
+    const int total_tiles_qk = num_tiles_m_qk * num_tiles_n_qk;
+    const int tiles_per_warp_qk =
+        (total_tiles_qk + WARPS_PER_BLOCK - 1) / WARPS_PER_BLOCK;
+    const unsigned row_causal = (lane_id & 0b1) + ((lane_id >> 2) & 0b1) * 8 +
+                                ((lane_id >> 4) & 0b1) * 4;
+    const unsigned col_causal =
+        ((lane_id >> 1) & 0b1) * 2 + ((lane_id >> 3) & 0b1) * 8;
+
+    for (int tile_idx = 0; tile_idx < tiles_per_warp_qk; ++tile_idx) {
+      const int global_tile_idx = warp_id * tiles_per_warp_qk + tile_idx;
+      if (global_tile_idx >= total_tiles_qk) break;
+
+      const int tile_m_idx = global_tile_idx / num_tiles_n_qk;
+      const int tile_n_idx = global_tile_idx % num_tiles_n_qk;
+
+      const int tile_m = tile_m_idx * WMMA_M;
+      const int tile_n = tile_n_idx * WMMA_N;
+
+      if (tile_m >= valid_q_rows || tile_n >= valid_k_rows) continue;
+
+      fragment<matrix_a, WMMA_M, WMMA_N, WMMA_K, half, row_major> a_frag;
+      fragment<matrix_b, WMMA_M, WMMA_N, WMMA_K, half, col_major> b_frag;
+      fragment<accumulator, WMMA_M, WMMA_N, WMMA_K, float> acc_frag;
+      fill_fragment(acc_frag, 0.0f);
+
+#pragma unroll
+      for (int k_tile = 0; k_tile < num_tiles_k_qk; ++k_tile) {
+        const int k_offset = k_tile * WMMA_K;
+        if (k_offset >= D) break;
+
+        load_matrix_sync(a_frag, sQ + tile_m * Q_STRIDE + k_offset, Q_STRIDE);
+        load_matrix_sync(b_frag, sK + tile_n * KV_STRIDE + k_offset, KV_STRIDE);
+        mma_sync(acc_frag, a_frag, b_frag, acc_frag);
+      }
+
+      if constexpr (IS_CAUSAL) {
+#pragma unroll
+        for (int i = 0; i < acc_frag.num_elements; ++i) {
+          const unsigned col = col_causal + (i & 0b1) + ((i >> 2) & 0b1) * 4;
+          const unsigned row = row_causal + ((i >> 1) & 0b1) * 2;
+
+          const int global_m = start_row + tile_m + row;
+          const int global_n = start_col + tile_n + col;
+          const int global_q_pos = global_m + causal_q_offset;
+
+          const bool is_valid = (global_m < start_row + valid_q_rows) &&
+                                (global_n < start_col + valid_k_rows);
+
+          acc_frag.x[i] = is_valid ? ((global_n > global_q_pos)
+                                          ? NEG_INF
+                                          : acc_frag.x[i] * softmax_scale)
+                                   : NEG_INF;
+        }
+      } else {
+#pragma unroll
+        for (int i = 0; i < acc_frag.num_elements; ++i) {
+          acc_frag.x[i] *= softmax_scale;
+        }
+      }
+      store_matrix_sync(sS + tile_m * S_STRIDE + tile_n, acc_frag, S_STRIDE,
+                        mem_row_major);
+    }
+  }
+  __syncthreads();
+
+  for (int idx = tid; idx < valid_q_rows * valid_k_rows;
+       idx += THREADS_PER_BLOCK) {
+    const int row = idx / valid_k_rows;
+    const int col = idx % valid_k_rows;
+    score_ptr[row * N + col] = sS[row * S_STRIDE + col];
+  }
+}
+
+template <int D, bool LOW_SMEM, bool D256_WMMA_QK>
 void launcher_flash_attention_forward_impl(
-    const torch::Tensor& Q,
-    const torch::Tensor& K,
-    const torch::Tensor& V,
-    torch::Tensor& Out,
-    torch::Tensor& softmax_lse,
-    float softmax_scale,
-    bool is_causal,
-    bool scalar_pv,
-    int window_size_left,
-    int window_size_right,
-    cudaStream_t stream
-) {
-    using Config = KernelConfig<D, LOW_SMEM>;
+    const torch::Tensor& Q, const torch::Tensor& K, const torch::Tensor& V,
+    torch::Tensor& Out, torch::Tensor& softmax_lse, float softmax_scale,
+    bool is_causal, bool scalar_pv, int window_size_left, int window_size_right,
+    cudaStream_t stream) {
+  using Config = KernelConfig<D, LOW_SMEM>;
 
-    const int B = Q.size(0);
-    const int H = Q.size(1);
-    const int H_KV = K.size(1);
-    const int M = Q.size(2);
-    const int N = K.size(2);
+  const int B = Q.size(0);
+  const int H = Q.size(1);
+  const int H_KV = K.size(1);
+  const int M = Q.size(2);
+  const int N = K.size(2);
 
-    const int grid_x = (M + Config::BLOCK_M - 1) / Config::BLOCK_M;
-    const dim3 grid(grid_x, 1, B * H);
-    const dim3 block(Config::THREADS_PER_BLOCK);
-    const size_t smem = Config::TOTAL_SMEM;
+  const int grid_x = (M + Config::BLOCK_M - 1) / Config::BLOCK_M;
+  const dim3 grid(grid_x, 1, B * H);
+  const dim3 block(Config::THREADS_PER_BLOCK);
+  const size_t smem = Config::TOTAL_SMEM;
 
-    TORCH_CHECK(smem <= MAX_SMEM_PER_SM, "Shared memory exceeds 96KB: ", smem, " bytes");
+  TORCH_CHECK(smem <= MAX_SMEM_PER_SM, "Shared memory exceeds 96KB: ", smem,
+              " bytes");
 
-    auto kernel = is_causal ?
-        (void*)flash_attention_forward_kernel<D, LOW_SMEM, D256_WMMA_QK, true> :
-        (void*)flash_attention_forward_kernel<D, LOW_SMEM, D256_WMMA_QK, false>;
+  auto kernel =
+      is_causal
+          ? (void*)
+                flash_attention_forward_kernel<D, LOW_SMEM, D256_WMMA_QK, true>
+          : (void*)flash_attention_forward_kernel<D, LOW_SMEM, D256_WMMA_QK,
+                                                  false>;
 
-    cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem);
+  cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize,
+                       smem);
 
-    if (is_causal) {
-        flash_attention_forward_kernel<D, LOW_SMEM, D256_WMMA_QK, true>
+  if (is_causal) {
+    flash_attention_forward_kernel<D, LOW_SMEM, D256_WMMA_QK, true>
         <<<grid, block, smem, stream>>>(
             reinterpret_cast<const __half*>(Q.data_ptr()),
             reinterpret_cast<const __half*>(K.data_ptr()),
             reinterpret_cast<const __half*>(V.data_ptr()),
             reinterpret_cast<__half*>(Out.data_ptr()),
-            softmax_lse.data_ptr<float>(),
-            B, H, H_KV, M, N, softmax_scale, scalar_pv,
-            window_size_left, window_size_right
-        );
-    } else {
-        flash_attention_forward_kernel<D, LOW_SMEM, D256_WMMA_QK, false>
+            softmax_lse.data_ptr<float>(), B, H, H_KV, M, N, softmax_scale,
+            scalar_pv, window_size_left, window_size_right);
+  } else {
+    flash_attention_forward_kernel<D, LOW_SMEM, D256_WMMA_QK, false>
         <<<grid, block, smem, stream>>>(
             reinterpret_cast<const __half*>(Q.data_ptr()),
             reinterpret_cast<const __half*>(K.data_ptr()),
             reinterpret_cast<const __half*>(V.data_ptr()),
             reinterpret_cast<__half*>(Out.data_ptr()),
-            softmax_lse.data_ptr<float>(),
-            B, H, H_KV, M, N, softmax_scale, scalar_pv,
-            window_size_left, window_size_right
-        );
-    }
+            softmax_lse.data_ptr<float>(), B, H, H_KV, M, N, softmax_scale,
+            scalar_pv, window_size_left, window_size_right);
+  }
 }
 
-template<int D>
+template <int D>
 void launcher_flash_attention_forward(
-    const torch::Tensor& Q,
-    const torch::Tensor& K,
-    const torch::Tensor& V,
-    torch::Tensor& Out,
-    torch::Tensor& softmax_lse,
-    float softmax_scale,
-    bool is_causal,
-    bool scalar_pv,
-    int window_size_left,
-    int window_size_right,
-    cudaStream_t stream
-) {
-    if constexpr (D == 256) {
-        const bool use_wmma_qk =
-            env_flag_enabled_default_on("VLLM_FLASH_V100_DENSE_D256_WMMA_QK");
-        if (env_flag_enabled("VLLM_FLASH_V100_DENSE_D256_LOW_SMEM")) {
-            if (use_wmma_qk) {
-                launcher_flash_attention_forward_impl<D, true, true>(
-                    Q, K, V, Out, softmax_lse, softmax_scale, is_causal,
-                    scalar_pv, window_size_left, window_size_right, stream);
-            } else {
-                launcher_flash_attention_forward_impl<D, true, false>(
-                    Q, K, V, Out, softmax_lse, softmax_scale, is_causal,
-                    scalar_pv, window_size_left, window_size_right, stream);
-            }
-            return;
-        }
-        if (use_wmma_qk) {
-            launcher_flash_attention_forward_impl<D, false, true>(
-                Q, K, V, Out, softmax_lse, softmax_scale, is_causal,
-                scalar_pv, window_size_left, window_size_right, stream);
-            return;
-        }
+    const torch::Tensor& Q, const torch::Tensor& K, const torch::Tensor& V,
+    torch::Tensor& Out, torch::Tensor& softmax_lse, float softmax_scale,
+    bool is_causal, bool scalar_pv, int window_size_left, int window_size_right,
+    cudaStream_t stream) {
+  if constexpr (D == 256) {
+    const bool use_wmma_qk =
+        env_flag_enabled_default_on("VLLM_FLASH_V100_DENSE_D256_WMMA_QK");
+    if (env_flag_enabled("VLLM_FLASH_V100_DENSE_D256_LOW_SMEM")) {
+      if (use_wmma_qk) {
+        launcher_flash_attention_forward_impl<D, true, true>(
+            Q, K, V, Out, softmax_lse, softmax_scale, is_causal, scalar_pv,
+            window_size_left, window_size_right, stream);
+      } else {
+        launcher_flash_attention_forward_impl<D, true, false>(
+            Q, K, V, Out, softmax_lse, softmax_scale, is_causal, scalar_pv,
+            window_size_left, window_size_right, stream);
+      }
+      return;
     }
-    launcher_flash_attention_forward_impl<D, false, false>(
-        Q, K, V, Out, softmax_lse, softmax_scale, is_causal, scalar_pv,
-        window_size_left, window_size_right, stream);
+    if (use_wmma_qk) {
+      launcher_flash_attention_forward_impl<D, false, true>(
+          Q, K, V, Out, softmax_lse, softmax_scale, is_causal, scalar_pv,
+          window_size_left, window_size_right, stream);
+      return;
+    }
+  }
+  launcher_flash_attention_forward_impl<D, false, false>(
+      Q, K, V, Out, softmax_lse, softmax_scale, is_causal, scalar_pv,
+      window_size_left, window_size_right, stream);
 }
 
-template<int D>
-void launcher_flash_attention_qk_scores(
-    const torch::Tensor& Q,
-    const torch::Tensor& K,
-    torch::Tensor& Scores,
-    float softmax_scale,
-    bool is_causal,
-    cudaStream_t stream
-) {
-    using Config = KernelConfig<D>;
+template <int D>
+void launcher_flash_attention_qk_scores(const torch::Tensor& Q,
+                                        const torch::Tensor& K,
+                                        torch::Tensor& Scores,
+                                        float softmax_scale, bool is_causal,
+                                        cudaStream_t stream) {
+  using Config = KernelConfig<D>;
 
-    const int B = Q.size(0);
-    const int H = Q.size(1);
-    const int M = Q.size(2);
-    const int H_KV = K.size(1);
-    const int N = K.size(2);
+  const int B = Q.size(0);
+  const int H = Q.size(1);
+  const int M = Q.size(2);
+  const int H_KV = K.size(1);
+  const int N = K.size(2);
 
-    const int grid_x = (M + Config::BLOCK_M - 1) / Config::BLOCK_M;
-    const int grid_y = (N + Config::BLOCK_N - 1) / Config::BLOCK_N;
-    const dim3 grid(grid_x, grid_y, B * H);
-    const dim3 block(Config::THREADS_PER_BLOCK);
-    const size_t smem = Config::TOTAL_SMEM;
+  const int grid_x = (M + Config::BLOCK_M - 1) / Config::BLOCK_M;
+  const int grid_y = (N + Config::BLOCK_N - 1) / Config::BLOCK_N;
+  const dim3 grid(grid_x, grid_y, B * H);
+  const dim3 block(Config::THREADS_PER_BLOCK);
+  const size_t smem = Config::TOTAL_SMEM;
 
-    TORCH_CHECK(smem <= MAX_SMEM_PER_SM, "Shared memory exceeds 96KB: ", smem, " bytes");
+  TORCH_CHECK(smem <= MAX_SMEM_PER_SM, "Shared memory exceeds 96KB: ", smem,
+              " bytes");
 
-    auto kernel = is_causal ?
-        (void*)flash_attention_qk_scores_kernel<D, true> :
-        (void*)flash_attention_qk_scores_kernel<D, false>;
+  auto kernel = is_causal ? (void*)flash_attention_qk_scores_kernel<D, true>
+                          : (void*)flash_attention_qk_scores_kernel<D, false>;
 
-    cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem);
+  cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize,
+                       smem);
 
-    if (is_causal) {
-        flash_attention_qk_scores_kernel<D, true><<<grid, block, smem, stream>>>(
-            reinterpret_cast<const __half*>(Q.data_ptr()),
-            reinterpret_cast<const __half*>(K.data_ptr()),
-            Scores.data_ptr<float>(),
-            B, H, H_KV, M, N, softmax_scale
-        );
-    } else {
-        flash_attention_qk_scores_kernel<D, false><<<grid, block, smem, stream>>>(
-            reinterpret_cast<const __half*>(Q.data_ptr()),
-            reinterpret_cast<const __half*>(K.data_ptr()),
-            Scores.data_ptr<float>(),
-            B, H, H_KV, M, N, softmax_scale
-        );
-    }
+  if (is_causal) {
+    flash_attention_qk_scores_kernel<D, true><<<grid, block, smem, stream>>>(
+        reinterpret_cast<const __half*>(Q.data_ptr()),
+        reinterpret_cast<const __half*>(K.data_ptr()), Scores.data_ptr<float>(),
+        B, H, H_KV, M, N, softmax_scale);
+  } else {
+    flash_attention_qk_scores_kernel<D, false><<<grid, block, smem, stream>>>(
+        reinterpret_cast<const __half*>(Q.data_ptr()),
+        reinterpret_cast<const __half*>(K.data_ptr()), Scores.data_ptr<float>(),
+        B, H, H_KV, M, N, softmax_scale);
+  }
 }
 
-at::Tensor flash_attention_qk_scores(
-    const at::Tensor& q,
-    const at::Tensor& k,
-    const float softmax_scale,
-    const bool is_causal
-) {
-    TORCH_CHECK(q.dtype() == torch::kFloat16, "q must be fp16");
-    TORCH_CHECK(k.dtype() == torch::kFloat16, "k must be fp16");
-    TORCH_CHECK(q.is_cuda() && k.is_cuda(), "Tensors must be on CUDA");
-    TORCH_CHECK(q.stride(-1) == 1 && k.stride(-1) == 1,
-                "Last dim must be contiguous");
-    TORCH_CHECK(q.dim() == 4 && k.dim() == 4,
-                "q/k must have shape [B, H, T, D]");
+at::Tensor flash_attention_qk_scores(const at::Tensor& q, const at::Tensor& k,
+                                     const float softmax_scale,
+                                     const bool is_causal) {
+  TORCH_CHECK(q.dtype() == torch::kFloat16, "q must be fp16");
+  TORCH_CHECK(k.dtype() == torch::kFloat16, "k must be fp16");
+  TORCH_CHECK(q.is_cuda() && k.is_cuda(), "Tensors must be on CUDA");
+  TORCH_CHECK(q.stride(-1) == 1 && k.stride(-1) == 1,
+              "Last dim must be contiguous");
+  TORCH_CHECK(q.dim() == 4 && k.dim() == 4, "q/k must have shape [B, H, T, D]");
 
-    const int B = q.size(0);
-    const int H = q.size(1);
-    const int M = q.size(2);
-    const int D = q.size(3);
-    const int H_KV = k.size(1);
-    const int N = k.size(2);
+  const int B = q.size(0);
+  const int H = q.size(1);
+  const int M = q.size(2);
+  const int D = q.size(3);
+  const int H_KV = k.size(1);
+  const int N = k.size(2);
 
-    TORCH_CHECK(k.size(0) == B, "K batch size must match Q");
-    TORCH_CHECK(k.size(3) == D, "K head_dim must match Q");
-    TORCH_CHECK(D <= 256 && D % 8 == 0 && D % 2 == 0,
-                "D must be even, <=256, multiple of 8");
-    TORCH_CHECK(H_KV > 0, "num_kv_heads must be positive");
-    TORCH_CHECK(H % H_KV == 0,
-                "num_attention_heads must be divisible by num_kv_heads");
+  TORCH_CHECK(k.size(0) == B, "K batch size must match Q");
+  TORCH_CHECK(k.size(3) == D, "K head_dim must match Q");
+  TORCH_CHECK(D <= 256 && D % 8 == 0 && D % 2 == 0,
+              "D must be even, <=256, multiple of 8");
+  TORCH_CHECK(H_KV > 0, "num_kv_heads must be positive");
+  TORCH_CHECK(H % H_KV == 0,
+              "num_attention_heads must be divisible by num_kv_heads");
 
-    auto props = at::cuda::getCurrentDeviceProperties();
-    bool sm70 = props->major == 7 && props->minor == 0;
-    TORCH_CHECK(sm70, "Kernel supports only Volta GPUs.");
+  auto props = at::cuda::getCurrentDeviceProperties();
+  bool sm70 = props->major == 7 && props->minor == 0;
+  TORCH_CHECK(sm70, "Kernel supports only Volta GPUs.");
 
-    auto scores = torch::full({B, H, M, N}, -1e30f,
-                              torch::dtype(torch::kFloat32).device(q.device()));
-    auto stream = at::cuda::getCurrentCUDAStream().stream();
+  auto scores = torch::full({B, H, M, N}, -1e30f,
+                            torch::dtype(torch::kFloat32).device(q.device()));
+  auto stream = at::cuda::getCurrentCUDAStream().stream();
 
-    switch (D) {
-        case 16:  launcher_flash_attention_qk_scores<16>(q, k, scores, softmax_scale, is_causal, stream); break;
-        case 32:  launcher_flash_attention_qk_scores<32>(q, k, scores, softmax_scale, is_causal, stream); break;
-        case 64:  launcher_flash_attention_qk_scores<64>(q, k, scores, softmax_scale, is_causal, stream); break;
-        case 128: launcher_flash_attention_qk_scores<128>(q, k, scores, softmax_scale, is_causal, stream); break;
-        case 256: launcher_flash_attention_qk_scores<256>(q, k, scores, softmax_scale, is_causal, stream); break;
-        default: TORCH_CHECK(false, "Unsupported D: ", D);
-    }
+  switch (D) {
+    case 16:
+      launcher_flash_attention_qk_scores<16>(q, k, scores, softmax_scale,
+                                             is_causal, stream);
+      break;
+    case 32:
+      launcher_flash_attention_qk_scores<32>(q, k, scores, softmax_scale,
+                                             is_causal, stream);
+      break;
+    case 64:
+      launcher_flash_attention_qk_scores<64>(q, k, scores, softmax_scale,
+                                             is_causal, stream);
+      break;
+    case 128:
+      launcher_flash_attention_qk_scores<128>(q, k, scores, softmax_scale,
+                                              is_causal, stream);
+      break;
+    case 256:
+      launcher_flash_attention_qk_scores<256>(q, k, scores, softmax_scale,
+                                              is_causal, stream);
+      break;
+    default:
+      TORCH_CHECK(false, "Unsupported D: ", D);
+  }
 
-    return scores;
+  return scores;
 }
 
 std::vector<at::Tensor> flash_attention_forward(
-    at::Tensor& q,
-    const at::Tensor& k,
-    const at::Tensor& v,
-    std::optional<at::Tensor>& out_,
-    std::optional<at::Tensor>& alibi_slopes_,
-    const float p_dropout,
-    const float softmax_scale,
-    bool is_causal,
-    int window_size_left,
-    int window_size_right,
-    const float softcap,
-    const bool return_softmax,
-    std::optional<at::Generator> gen_
-) {
+    at::Tensor& q, const at::Tensor& k, const at::Tensor& v,
+    std::optional<at::Tensor>& out_, std::optional<at::Tensor>& alibi_slopes_,
+    const float p_dropout, const float softmax_scale, bool is_causal,
+    int window_size_left, int window_size_right, const float softcap,
+    const bool return_softmax, std::optional<at::Generator> gen_) {
+  TORCH_CHECK(!alibi_slopes_.has_value(), "alibi_slopes not supported");
+  TORCH_CHECK(p_dropout == 0.f, "dropout not supported");
+  TORCH_CHECK(window_size_left >= -1 && window_size_right >= -1,
+              "window sizes must be >= -1");
+  TORCH_CHECK(softcap == 0.f, "softcap not supported");
+  TORCH_CHECK(!return_softmax, "return_softmax not supported");
+  TORCH_CHECK(!gen_.has_value(), "Generator not supported");
 
-    TORCH_CHECK(!alibi_slopes_.has_value(), "alibi_slopes not supported");
-    TORCH_CHECK(p_dropout == 0.f, "dropout not supported");
-    TORCH_CHECK(window_size_left >= -1 && window_size_right >= -1,
-                "window sizes must be >= -1");
-    TORCH_CHECK(softcap == 0.f, "softcap not supported");
-    TORCH_CHECK(!return_softmax, "return_softmax not supported");
-    TORCH_CHECK(!gen_.has_value(), "Generator not supported");
+  TORCH_CHECK(q.dtype() == torch::kFloat16, "q must be fp16");
+  TORCH_CHECK(k.dtype() == torch::kFloat16, "k must be fp16");
+  TORCH_CHECK(v.dtype() == torch::kFloat16, "v must be fp16");
+  TORCH_CHECK(q.is_cuda() && k.is_cuda() && v.is_cuda(),
+              "Tensors must be on CUDA");
+  TORCH_CHECK(q.stride(-1) == 1 && k.stride(-1) == 1 && v.stride(-1) == 1,
+              "Last dim must be contiguous");
 
-    TORCH_CHECK(q.dtype() == torch::kFloat16, "q must be fp16");
-    TORCH_CHECK(k.dtype() == torch::kFloat16, "k must be fp16");
-    TORCH_CHECK(v.dtype() == torch::kFloat16, "v must be fp16");
-    TORCH_CHECK(q.is_cuda() && k.is_cuda() && v.is_cuda(), "Tensors must be on CUDA");
-    TORCH_CHECK(q.stride(-1) == 1 && k.stride(-1) == 1 && v.stride(-1) == 1, "Last dim must be contiguous");
+  const auto sizes = q.sizes();
+  const int B = sizes[0], H = sizes[1], M = sizes[2], D = sizes[3];
+  const int H_KV = k.size(1);
+  const int N = k.size(2);
+  TORCH_CHECK(D <= 256 && D % 8 == 0 && D % 2 == 0,
+              "D must be even, <=256, multiple of 8");
+  TORCH_CHECK(H_KV > 0, "num_kv_heads must be positive");
+  TORCH_CHECK(H % H_KV == 0,
+              "num_attention_heads must be divisible by num_kv_heads");
+  TORCH_CHECK(k.size(0) == B && v.size(0) == B, "K/V batch size must match Q");
+  TORCH_CHECK(v.size(1) == H_KV, "K/V num_heads must match");
+  TORCH_CHECK(v.size(2) == N, "K/V sequence length must match");
+  TORCH_CHECK(k.size(3) == D && v.size(3) == D, "K/V head_dim must match Q");
 
-    const auto sizes = q.sizes();
-    const int B = sizes[0], H = sizes[1], M = sizes[2], D = sizes[3];
-    const int H_KV = k.size(1);
-    const int N = k.size(2);
-    TORCH_CHECK(D <= 256 && D % 8 == 0 && D % 2 == 0, "D must be even, <=256, multiple of 8");
-    TORCH_CHECK(H_KV > 0, "num_kv_heads must be positive");
-    TORCH_CHECK(H % H_KV == 0, "num_attention_heads must be divisible by num_kv_heads");
-    TORCH_CHECK(k.size(0) == B && v.size(0) == B, "K/V batch size must match Q");
-    TORCH_CHECK(v.size(1) == H_KV, "K/V num_heads must match");
-    TORCH_CHECK(v.size(2) == N, "K/V sequence length must match");
-    TORCH_CHECK(k.size(3) == D && v.size(3) == D, "K/V head_dim must match Q");
+  at::Tensor out_fp16 = out_.has_value() ? out_.value() : torch::zeros_like(q);
+  TORCH_CHECK(out_fp16.dtype() == torch::kFloat16, "out must be fp16");
+  auto softmax_lse =
+      torch::zeros({B, H, M}, torch::dtype(torch::kFloat32).device(q.device()));
+  TORCH_CHECK(softmax_lse.dtype() == torch::kFloat32,
+              "softmax_lse must be fp32");
 
-    at::Tensor out_fp16 = out_.has_value() ? out_.value() : torch::zeros_like(q);
-    TORCH_CHECK(out_fp16.dtype() == torch::kFloat16, "out must be fp16");
-    auto softmax_lse = torch::zeros({B, H, M}, torch::dtype(torch::kFloat32).device(q.device()));
-    TORCH_CHECK(softmax_lse.dtype() == torch::kFloat32, "softmax_lse must be fp32");
+  auto stream = at::cuda::getCurrentCUDAStream().stream();
+  auto props = at::cuda::getCurrentDeviceProperties();
+  bool sm70 = props->major == 7 && props->minor == 0;
+  TORCH_CHECK(sm70, "Kernel supports only Volta GPUs.");
+  const char* scalar_pv_env = std::getenv("VLLM_FLASH_V100_PREFILL_SCALAR_PV");
+  const bool scalar_pv = scalar_pv_env != nullptr && scalar_pv_env[0] != '\0' &&
+                         scalar_pv_env[0] != '0';
 
-    auto stream = at::cuda::getCurrentCUDAStream().stream();
-    auto props  = at::cuda::getCurrentDeviceProperties();
-    bool sm70   = props->major == 7 && props->minor == 0;
-    TORCH_CHECK(sm70, "Kernel supports only Volta GPUs.");
-    const char* scalar_pv_env = std::getenv("VLLM_FLASH_V100_PREFILL_SCALAR_PV");
-    const bool scalar_pv = scalar_pv_env != nullptr && scalar_pv_env[0] != '\0' &&
-                           scalar_pv_env[0] != '0';
+  switch (D) {
+    case 16:
+      launcher_flash_attention_forward<16>(
+          q, k, v, out_fp16, softmax_lse, softmax_scale, is_causal, scalar_pv,
+          window_size_left, window_size_right, stream);
+      break;
+    case 32:
+      launcher_flash_attention_forward<32>(
+          q, k, v, out_fp16, softmax_lse, softmax_scale, is_causal, scalar_pv,
+          window_size_left, window_size_right, stream);
+      break;
+    case 64:
+      launcher_flash_attention_forward<64>(
+          q, k, v, out_fp16, softmax_lse, softmax_scale, is_causal, scalar_pv,
+          window_size_left, window_size_right, stream);
+      break;
+    case 128:
+      launcher_flash_attention_forward<128>(
+          q, k, v, out_fp16, softmax_lse, softmax_scale, is_causal, scalar_pv,
+          window_size_left, window_size_right, stream);
+      break;
+    case 256:
+      launcher_flash_attention_forward<256>(
+          q, k, v, out_fp16, softmax_lse, softmax_scale, is_causal, scalar_pv,
+          window_size_left, window_size_right, stream);
+      break;
+    default:
+      TORCH_CHECK(false, "Unsupported D: ", D);
+  }
 
-    switch (D) {
-        case 16:  launcher_flash_attention_forward<16>(q, k, v, out_fp16, softmax_lse, softmax_scale, is_causal, scalar_pv, window_size_left, window_size_right, stream); break;
-        case 32:  launcher_flash_attention_forward<32>(q, k, v, out_fp16, softmax_lse, softmax_scale, is_causal, scalar_pv, window_size_left, window_size_right, stream); break;
-        case 64:  launcher_flash_attention_forward<64>(q, k, v, out_fp16, softmax_lse, softmax_scale, is_causal, scalar_pv, window_size_left, window_size_right, stream); break;
-        case 128: launcher_flash_attention_forward<128>(q, k, v, out_fp16, softmax_lse, softmax_scale, is_causal, scalar_pv, window_size_left, window_size_right, stream); break;
-        case 256: launcher_flash_attention_forward<256>(q, k, v, out_fp16, softmax_lse, softmax_scale, is_causal, scalar_pv, window_size_left, window_size_right, stream); break;
-        default: TORCH_CHECK(false, "Unsupported D: ", D);
-    }
-
-    auto p = torch::zeros({0}, q.options());
-    auto rng_state = torch::zeros({2}, torch::dtype(torch::kInt64).device(q.device()));
-    return {out_fp16, softmax_lse, p, rng_state};
+  auto p = torch::zeros({0}, q.options());
+  auto rng_state =
+      torch::zeros({2}, torch::dtype(torch::kInt64).device(q.device()));
+  return {out_fp16, softmax_lse, p, rng_state};
 }

--- a/flash-attention-v100/kernel/fused_mha_forward_paged.cu
+++ b/flash-attention-v100/kernel/fused_mha_forward_paged.cu
@@ -22,2056 +22,1753 @@ using namespace nvcuda::wmma;
 #define WMMA_N 16
 #define WMMA_K 16
 
-#define MAX_THREADS_PER_WARP    32
-#define MAX_THREADS_PER_SM      2048
-#define MAX_THREAD_BLOCK_SIZE   1024
+#define MAX_THREADS_PER_WARP 32
+#define MAX_THREADS_PER_SM 2048
+#define MAX_THREAD_BLOCK_SIZE 1024
 #define MAX_THREAD_BLOCK_PER_SM 32
-#define MAX_WARPS_PER_SM        64
-#define MAX_SM_PER_GPU          80
-#define MAX_SMEM_PER_SM         98304
+#define MAX_WARPS_PER_SM 64
+#define MAX_SM_PER_GPU 80
+#define MAX_SMEM_PER_SM 98304
 
-#define WARP_ALLOC_GROUP        4
+#define WARP_ALLOC_GROUP 4
 
 namespace {
 
 int kv_cache_dtype_code_from_string(const std::string& kv_cache_dtype) {
-    if (kv_cache_dtype == "auto" || kv_cache_dtype == "bfloat16") {
-        return flash_v100::KV_CACHE_DTYPE_FP16;
-    }
-    if (kv_cache_dtype == "fp8" || kv_cache_dtype == "fp8_e4m3") {
-        return flash_v100::KV_CACHE_DTYPE_FP8_E4M3;
-    }
-    if (kv_cache_dtype == "fp8_e5m2") {
-        return flash_v100::KV_CACHE_DTYPE_FP8_E5M2;
-    }
-    return -1;
+  if (kv_cache_dtype == "auto" || kv_cache_dtype == "bfloat16") {
+    return flash_v100::KV_CACHE_DTYPE_FP16;
+  }
+  if (kv_cache_dtype == "fp8" || kv_cache_dtype == "fp8_e4m3") {
+    return flash_v100::KV_CACHE_DTYPE_FP8_E4M3;
+  }
+  if (kv_cache_dtype == "fp8_e5m2") {
+    return flash_v100::KV_CACHE_DTYPE_FP8_E5M2;
+  }
+  return -1;
 }
 
 }  // namespace
 
-#define BLOCK_M_16  16
-#define BLOCK_N_16  512
-#define WARPS_16    16
+#define BLOCK_M_16 16
+#define BLOCK_N_16 512
+#define WARPS_16 16
 
-#define BLOCK_M_32  32
-#define BLOCK_N_32  256
-#define WARPS_32    16
+#define BLOCK_M_32 32
+#define BLOCK_N_32 256
+#define WARPS_32 16
 
-#define BLOCK_M_64  64
-#define BLOCK_N_64  128
-#define WARPS_64    16
+#define BLOCK_M_64 64
+#define BLOCK_N_64 128
+#define WARPS_64 16
 
 #define BLOCK_M_128 32
 #define BLOCK_N_128 176
-#define WARPS_128   16
+#define WARPS_128 16
 
 #define BLOCK_M_256 32
 #define BLOCK_N_256 64
-#define WARPS_256   16
+#define WARPS_256 16
 
 #define BLOCK_M_256_LOW_SMEM 16
 #define BLOCK_N_256_LOW_SMEM 128
 #define KV_STAGE_N_256_LOW_SMEM 1
-#define WARPS_256_LOW_SMEM   16
+#define WARPS_256_LOW_SMEM 16
 #define BLOCK_N_256_LOW_SMEM_SCALAR_QK 32
 #define KV_STAGE_N_256_LOW_SMEM_SCALAR_QK BLOCK_N_256_LOW_SMEM_SCALAR_QK
-#define LOW_SMEM_PAGE_SIZE   16
+#define LOW_SMEM_PAGE_SIZE 16
 
-template<int D, bool LOW_SMEM = false, bool LOW_SMEM_SCALAR_QK = false,
-         bool LOW_SMEM_BM32 = false,
-         bool D256_OUTPUT_STRIDE_268 = false,
-         bool D256_SW_PIPELINE_QK = false,
-         bool D256_SW_PIPELINE_PV = false>
+template <int D, bool LOW_SMEM = false, bool LOW_SMEM_SCALAR_QK = false,
+          bool LOW_SMEM_BM32 = false, bool D256_OUTPUT_STRIDE_268 = false,
+          bool D256_SW_PIPELINE_QK = false, bool D256_SW_PIPELINE_PV = false>
 struct KernelConfig {
-    static constexpr int BLOCK_M = (D == 16) ? BLOCK_M_16 : (D == 32) ? BLOCK_M_32 : (D == 64) ? BLOCK_M_64 : (D == 128) ? BLOCK_M_128 : (LOW_SMEM ? (LOW_SMEM_BM32 ? BLOCK_M_256 : BLOCK_M_256_LOW_SMEM) : BLOCK_M_256);
-    static constexpr int BLOCK_N = (D == 16) ? BLOCK_N_16 : (D == 32) ? BLOCK_N_32 : (D == 64) ? BLOCK_N_64 : (D == 128) ? BLOCK_N_128 : (LOW_SMEM ? (LOW_SMEM_SCALAR_QK ? BLOCK_N_256_LOW_SMEM_SCALAR_QK : BLOCK_N_256_LOW_SMEM) : BLOCK_N_256);
-    static constexpr int WARPS_PER_BLOCK = (D == 16) ? WARPS_16 : (D == 32) ? WARPS_32 : (D == 64) ? WARPS_64 : (D == 128) ? WARPS_128 : (LOW_SMEM ? WARPS_256_LOW_SMEM : WARPS_256);
+  static constexpr int BLOCK_M =
+      (D == 16)   ? BLOCK_M_16
+      : (D == 32) ? BLOCK_M_32
+      : (D == 64) ? BLOCK_M_64
+      : (D == 128)
+          ? BLOCK_M_128
+          : (LOW_SMEM ? (LOW_SMEM_BM32 ? BLOCK_M_256 : BLOCK_M_256_LOW_SMEM)
+                      : BLOCK_M_256);
+  static constexpr int BLOCK_N =
+      (D == 16)   ? BLOCK_N_16
+      : (D == 32) ? BLOCK_N_32
+      : (D == 64) ? BLOCK_N_64
+      : (D == 128)
+          ? BLOCK_N_128
+          : (LOW_SMEM ? (LOW_SMEM_SCALAR_QK ? BLOCK_N_256_LOW_SMEM_SCALAR_QK
+                                            : BLOCK_N_256_LOW_SMEM)
+                      : BLOCK_N_256);
+  static constexpr int WARPS_PER_BLOCK =
+      (D == 16)    ? WARPS_16
+      : (D == 32)  ? WARPS_32
+      : (D == 64)  ? WARPS_64
+      : (D == 128) ? WARPS_128
+                   : (LOW_SMEM ? WARPS_256_LOW_SMEM : WARPS_256);
 
-    static constexpr int THREADS_PER_BLOCK = WARPS_PER_BLOCK * MAX_THREADS_PER_WARP;
-    static constexpr int THREADS_PER_ROW   = THREADS_PER_BLOCK / BLOCK_M;
-    static constexpr int PAD               = (8 - (D % 32) + 32) % 32;
-    static constexpr int Q_STRIDE          = D + PAD;
-    static constexpr int KV_STRIDE         = D + PAD;
-    static constexpr int KV_STAGE_N        = (D == 256 && LOW_SMEM) ? (LOW_SMEM_SCALAR_QK ? KV_STAGE_N_256_LOW_SMEM_SCALAR_QK : KV_STAGE_N_256_LOW_SMEM) : BLOCK_N;
-    static constexpr int S_STRIDE          = BLOCK_N + PAD;
-    static constexpr int P_SUB_TILE        = 32;
-    static constexpr int P_STRIDE          = P_SUB_TILE + PAD;
-    static constexpr int P_STRICT_ELEMENTS = (D == 256) ? BLOCK_M * P_STRIDE : 1;
-    static constexpr int PIPELINE_S_ELEMENTS =
-        (D == 256 && LOW_SMEM && D256_SW_PIPELINE_QK
-         && D256_SW_PIPELINE_PV)
-            ? BLOCK_M * S_STRIDE
-            : 1;
-    static constexpr int PIPELINE_PAGE_ELEMENTS =
-        (D == 256 && LOW_SMEM && D256_SW_PIPELINE_QK
-         && D256_SW_PIPELINE_PV)
-            ? BLOCK_N / LOW_SMEM_PAGE_SIZE
-            : 1;
-    static constexpr bool PIPELINE_SWIZZLED_Q =
-        D == 256 && LOW_SMEM && D256_SW_PIPELINE_QK
-        && D256_SW_PIPELINE_PV;
-    static constexpr int Q_ELEMENTS =
-        PIPELINE_SWIZZLED_Q ? BLOCK_M * D : BLOCK_M * Q_STRIDE;
-    // The D256 low-SMEM candidate changes only the output accumulator pitch
-    // from 264 to 268 floats. This preserves all WMMA/softmax arithmetic and
-    // targets the largest 8-way shared-memory load/store groups.
-    static constexpr int OUTPUT_EXTRA_PAD =
-        (D == 256 && LOW_SMEM && D256_OUTPUT_STRIDE_268) ? 4 : 0;
-    static constexpr int O_STRIDE          = D + PAD + OUTPUT_EXTRA_PAD;
-    static constexpr int PER_UINT4         = 8;
-    static constexpr int LOW_SMEM_PAGE_COUNT =
-        (D == 256 && LOW_SMEM) ? (BLOCK_N / LOW_SMEM_PAGE_SIZE) : 1;
-    struct alignas(128) SmemLayout {
-        alignas(16) __half q      [Q_ELEMENTS];
+  static constexpr int THREADS_PER_BLOCK =
+      WARPS_PER_BLOCK * MAX_THREADS_PER_WARP;
+  static constexpr int THREADS_PER_ROW = THREADS_PER_BLOCK / BLOCK_M;
+  static constexpr int PAD = (8 - (D % 32) + 32) % 32;
+  static constexpr int Q_STRIDE = D + PAD;
+  static constexpr int KV_STRIDE = D + PAD;
+  static constexpr int KV_STAGE_N =
+      (D == 256 && LOW_SMEM)
+          ? (LOW_SMEM_SCALAR_QK ? KV_STAGE_N_256_LOW_SMEM_SCALAR_QK
+                                : KV_STAGE_N_256_LOW_SMEM)
+          : BLOCK_N;
+  static constexpr int S_STRIDE = BLOCK_N + PAD;
+  static constexpr int P_SUB_TILE = 32;
+  static constexpr int P_STRIDE = P_SUB_TILE + PAD;
+  static constexpr int P_STRICT_ELEMENTS = (D == 256) ? BLOCK_M * P_STRIDE : 1;
+  static constexpr int PIPELINE_S_ELEMENTS =
+      (D == 256 && LOW_SMEM && D256_SW_PIPELINE_QK && D256_SW_PIPELINE_PV)
+          ? BLOCK_M * S_STRIDE
+          : 1;
+  static constexpr int PIPELINE_PAGE_ELEMENTS =
+      (D == 256 && LOW_SMEM && D256_SW_PIPELINE_QK && D256_SW_PIPELINE_PV)
+          ? BLOCK_N / LOW_SMEM_PAGE_SIZE
+          : 1;
+  static constexpr bool PIPELINE_SWIZZLED_Q =
+      D == 256 && LOW_SMEM && D256_SW_PIPELINE_QK && D256_SW_PIPELINE_PV;
+  static constexpr int Q_ELEMENTS =
+      PIPELINE_SWIZZLED_Q ? BLOCK_M * D : BLOCK_M * Q_STRIDE;
+  // The D256 low-SMEM candidate changes only the output accumulator pitch
+  // from 264 to 268 floats. This preserves all WMMA/softmax arithmetic and
+  // targets the largest 8-way shared-memory load/store groups.
+  static constexpr int OUTPUT_EXTRA_PAD =
+      (D == 256 && LOW_SMEM && D256_OUTPUT_STRIDE_268) ? 4 : 0;
+  static constexpr int O_STRIDE = D + PAD + OUTPUT_EXTRA_PAD;
+  static constexpr int PER_UINT4 = 8;
+  static constexpr int LOW_SMEM_PAGE_COUNT =
+      (D == 256 && LOW_SMEM) ? (BLOCK_N / LOW_SMEM_PAGE_SIZE) : 1;
+  struct alignas(128) SmemLayout {
+    alignas(16) __half q[Q_ELEMENTS];
     union {
-        alignas(16) __half k      [KV_STAGE_N * KV_STRIDE];
-        alignas(16) __half v      [KV_STAGE_N * KV_STRIDE];
+      alignas(16) __half k[KV_STAGE_N * KV_STRIDE];
+      alignas(16) __half v[KV_STAGE_N * KV_STRIDE];
     } reuse_kv;
     union {
-        alignas(16) float  s      [BLOCK_M * S_STRIDE];
-        alignas(16) __half p      [BLOCK_M * S_STRIDE];
+      alignas(16) float s[BLOCK_M * S_STRIDE];
+      alignas(16) __half p[BLOCK_M * S_STRIDE];
     } reuse_sp;
-        alignas(16) __half p_strict[P_STRICT_ELEMENTS];
-        alignas(16) float  pipeline_s[PIPELINE_S_ELEMENTS];
-        alignas(16) int    pipeline_page_idx[PIPELINE_PAGE_ELEMENTS];
-        alignas(16) int    pipeline_page_offset[PIPELINE_PAGE_ELEMENTS];
-        alignas(16) float  o      [BLOCK_M * O_STRIDE];
-        alignas(16) float  row_max[BLOCK_M];
-        alignas(16) float  row_sum[BLOCK_M];
-        alignas(16) int    page_idx[LOW_SMEM_PAGE_COUNT];
-        alignas(16) int    page_offset[LOW_SMEM_PAGE_COUNT];
-    };
+    alignas(16) __half p_strict[P_STRICT_ELEMENTS];
+    alignas(16) float pipeline_s[PIPELINE_S_ELEMENTS];
+    alignas(16) int pipeline_page_idx[PIPELINE_PAGE_ELEMENTS];
+    alignas(16) int pipeline_page_offset[PIPELINE_PAGE_ELEMENTS];
+    alignas(16) float o[BLOCK_M * O_STRIDE];
+    alignas(16) float row_max[BLOCK_M];
+    alignas(16) float row_sum[BLOCK_M];
+    alignas(16) int page_idx[LOW_SMEM_PAGE_COUNT];
+    alignas(16) int page_offset[LOW_SMEM_PAGE_COUNT];
+  };
 
-    static constexpr size_t TOTAL_SMEM = ((sizeof(SmemLayout) + 127) & ~size_t(127));
+  static constexpr size_t TOTAL_SMEM =
+      ((sizeof(SmemLayout) + 127) & ~size_t(127));
 };
 
-template<typename Config>
+template <typename Config>
 __device__ __forceinline__ void init_smem(char* smem_raw) {
-    constexpr int N_U4 = Config::TOTAL_SMEM / 16;
-    constexpr int THREADS_PER_BLOCK = Config::THREADS_PER_BLOCK;
-    const int tid = threadIdx.x;
+  constexpr int N_U4 = Config::TOTAL_SMEM / 16;
+  constexpr int THREADS_PER_BLOCK = Config::THREADS_PER_BLOCK;
+  const int tid = threadIdx.x;
 
-    uint32_t addr = static_cast<uint32_t>(__cvta_generic_to_shared(smem_raw));
-    #pragma unroll 1
-    for (int i = tid; i < N_U4; i += THREADS_PER_BLOCK) {
-        asm volatile("st.shared.v4.u32 [%0], {%1,%1,%1,%1};"
-                     :: "r"(addr + (i << 4)), "r"(0) : "memory");
-    }
-    __syncthreads();
+  uint32_t addr = static_cast<uint32_t>(__cvta_generic_to_shared(smem_raw));
+#pragma unroll 1
+  for (int i = tid; i < N_U4; i += THREADS_PER_BLOCK) {
+    asm volatile("st.shared.v4.u32 [%0], {%1,%1,%1,%1};" ::"r"(addr + (i << 4)),
+                 "r"(0)
+                 : "memory");
+  }
+  __syncthreads();
 }
 
 __device__ __forceinline__ int pipeline_swizzled_q_row_slot(int row) {
-    return (row & 3) | ((row & 8) >> 1) | ((row & 4) << 1);
+  return (row & 3) | ((row & 8) >> 1) | ((row & 4) << 1);
 }
 
-__device__ __forceinline__ int pipeline_swizzled_matrix_a_offset(
-    int row,
-    int col) {
-    const int tile = col / WMMA_K;
-    const int within_tile = col - tile * WMMA_K;
-    const int plane = within_tile >> 3;
-    const int inner = within_tile & 7;
-    return tile * WMMA_M * WMMA_K + plane * WMMA_M * 8
-           + pipeline_swizzled_q_row_slot(row) * 8 + inner;
+__device__ __forceinline__ int pipeline_swizzled_matrix_a_offset(int row,
+                                                                 int col) {
+  const int tile = col / WMMA_K;
+  const int within_tile = col - tile * WMMA_K;
+  const int plane = within_tile >> 3;
+  const int inner = within_tile & 7;
+  return tile * WMMA_M * WMMA_K + plane * WMMA_M * 8 +
+         pipeline_swizzled_q_row_slot(row) * 8 + inner;
 }
 
 __device__ __forceinline__ void load_pipeline_swizzled_matrix_a_fragment(
     fragment<matrix_a, WMMA_M, WMMA_N, WMMA_K, half, row_major>& frag,
-    const __half* __restrict__ matrix,
-    int k_offset) {
-    const int lane = threadIdx.x & 31;
-    const int row =
-        (lane & 3) + ((lane >> 4) & 1) * 4 + ((lane >> 2) & 1) * 8;
-    const int slot = pipeline_swizzled_q_row_slot(row);
-    const int tile_offset = (k_offset / WMMA_K) * WMMA_M * WMMA_K;
-    uint32_t address = static_cast<uint32_t>(
-        __cvta_generic_to_shared(matrix + tile_offset + slot * 8));
-    uint32_t* words = reinterpret_cast<uint32_t*>(&frag);
-    asm volatile(
-        "ld.shared.v4.u32 {%0, %1, %2, %3}, [%4];"
-        : "=r"(words[0]), "=r"(words[1]), "=r"(words[2]), "=r"(words[3])
-        : "r"(address)
-        : "memory");
-    address += WMMA_M * 8 * sizeof(__half);
-    asm volatile(
-        "ld.shared.v4.u32 {%0, %1, %2, %3}, [%4];"
-        : "=r"(words[4]), "=r"(words[5]), "=r"(words[6]), "=r"(words[7])
-        : "r"(address)
-        : "memory");
+    const __half* __restrict__ matrix, int k_offset) {
+  const int lane = threadIdx.x & 31;
+  const int row = (lane & 3) + ((lane >> 4) & 1) * 4 + ((lane >> 2) & 1) * 8;
+  const int slot = pipeline_swizzled_q_row_slot(row);
+  const int tile_offset = (k_offset / WMMA_K) * WMMA_M * WMMA_K;
+  uint32_t address = static_cast<uint32_t>(
+      __cvta_generic_to_shared(matrix + tile_offset + slot * 8));
+  uint32_t* words = reinterpret_cast<uint32_t*>(&frag);
+  asm volatile("ld.shared.v4.u32 {%0, %1, %2, %3}, [%4];"
+               : "=r"(words[0]), "=r"(words[1]), "=r"(words[2]), "=r"(words[3])
+               : "r"(address)
+               : "memory");
+  address += WMMA_M * 8 * sizeof(__half);
+  asm volatile("ld.shared.v4.u32 {%0, %1, %2, %3}, [%4];"
+               : "=r"(words[4]), "=r"(words[5]), "=r"(words[6]), "=r"(words[7])
+               : "r"(address)
+               : "memory");
 }
 
-template<int Q_STRIDE, int S_STRIDE, int K_TILES, bool IS_CAUSAL,
-         bool SWIZZLED_Q = false>
+template <int Q_STRIDE, int S_STRIDE, int K_TILES, bool IS_CAUSAL,
+          bool SWIZZLED_Q = false>
 __device__ __forceinline__ void pipeline_qk_slice(
-    const __half* __restrict__ sQ,
-    float* __restrict__ score,
-    const __half* __restrict__ k_cache,
-    const int* __restrict__ page_idx,
-    const int* __restrict__ page_offset,
-    int64_t k_block_stride,
-    int64_t k_token_stride,
-    int64_t k_head_stride,
-    int kv_head_id,
-    int start_col,
-    int valid_k_rows,
-    int start_row,
-    int valid_q_rows,
-    int causal_q_offset,
-    int tile_n,
-    int k_begin,
-    bool load_partial,
-    bool finalize,
-    float softmax_scale,
-    int window_size_left,
-    int window_size_right,
-    float neg_inf) {
-    if (tile_n >= valid_k_rows) {
-        return;
-    }
+    const __half* __restrict__ sQ, float* __restrict__ score,
+    const __half* __restrict__ k_cache, const int* __restrict__ page_idx,
+    const int* __restrict__ page_offset, int64_t k_block_stride,
+    int64_t k_token_stride, int64_t k_head_stride, int kv_head_id,
+    int start_col, int valid_k_rows, int start_row, int valid_q_rows,
+    int causal_q_offset, int tile_n, int k_begin, bool load_partial,
+    bool finalize, float softmax_scale, int window_size_left,
+    int window_size_right, float neg_inf) {
+  if (tile_n >= valid_k_rows) {
+    return;
+  }
 
-    const int page_slot = tile_n >> 4;
-    const int block_offset = page_offset[page_slot];
-    const int physical_block_idx = page_idx[page_slot];
-    const __half* k_tile_base =
-        k_cache + (int64_t)physical_block_idx * k_block_stride
-        + (int64_t)block_offset * k_token_stride
-        + (int64_t)kv_head_id * k_head_stride;
+  const int page_slot = tile_n >> 4;
+  const int block_offset = page_offset[page_slot];
+  const int physical_block_idx = page_idx[page_slot];
+  const __half* k_tile_base = k_cache +
+                              (int64_t)physical_block_idx * k_block_stride +
+                              (int64_t)block_offset * k_token_stride +
+                              (int64_t)kv_head_id * k_head_stride;
 
-    fragment<matrix_a, WMMA_M, WMMA_N, WMMA_K, half, row_major> a_frag;
-    fragment<matrix_b, WMMA_M, WMMA_N, WMMA_K, half, col_major> b_frag;
-    fragment<accumulator, WMMA_M, WMMA_N, WMMA_K, float> acc_frag;
-    if (load_partial) {
-        load_matrix_sync(
-            acc_frag, score + tile_n, S_STRIDE, mem_row_major);
+  fragment<matrix_a, WMMA_M, WMMA_N, WMMA_K, half, row_major> a_frag;
+  fragment<matrix_b, WMMA_M, WMMA_N, WMMA_K, half, col_major> b_frag;
+  fragment<accumulator, WMMA_M, WMMA_N, WMMA_K, float> acc_frag;
+  if (load_partial) {
+    load_matrix_sync(acc_frag, score + tile_n, S_STRIDE, mem_row_major);
+  } else {
+    fill_fragment(acc_frag, 0.0f);
+  }
+
+#pragma unroll
+  for (int k_tile = 0; k_tile < K_TILES; ++k_tile) {
+    const int k_offset = k_begin + k_tile * WMMA_K;
+    if constexpr (SWIZZLED_Q) {
+      load_pipeline_swizzled_matrix_a_fragment(a_frag, sQ, k_offset);
     } else {
-        fill_fragment(acc_frag, 0.0f);
+      load_matrix_sync(a_frag, sQ + k_offset, Q_STRIDE);
     }
+    load_matrix_sync(b_frag, k_tile_base + k_offset, k_token_stride);
+    mma_sync(acc_frag, a_frag, b_frag, acc_frag);
+  }
 
-    #pragma unroll
-    for (int k_tile = 0; k_tile < K_TILES; ++k_tile) {
-        const int k_offset = k_begin + k_tile * WMMA_K;
-        if constexpr (SWIZZLED_Q) {
-            load_pipeline_swizzled_matrix_a_fragment(
-                a_frag, sQ, k_offset);
-        } else {
-            load_matrix_sync(a_frag, sQ + k_offset, Q_STRIDE);
+  if (finalize) {
+    const int lane_id = threadIdx.x & 31;
+    const unsigned row_causal = (lane_id & 0b1) + ((lane_id >> 2) & 0b1) * 8 +
+                                ((lane_id >> 4) & 0b1) * 4;
+    const unsigned col_causal =
+        ((lane_id >> 1) & 0b1) * 2 + ((lane_id >> 3) & 0b1) * 8;
+
+#pragma unroll
+    for (int i = 0; i < acc_frag.num_elements; ++i) {
+      const unsigned col = col_causal + (i & 0b1) + ((i >> 2) & 0b1) * 4;
+      const unsigned row = row_causal + ((i >> 1) & 0b1) * 2;
+      const int global_m = start_row + row;
+      const int global_n = start_col + tile_n + col;
+      const int global_q_pos = global_m + causal_q_offset;
+
+      const bool is_valid = global_m < start_row + valid_q_rows &&
+                            global_n < start_col + valid_k_rows;
+      bool is_causal_valid = true;
+      if constexpr (IS_CAUSAL) {
+        is_causal_valid = global_n <= global_q_pos;
+      }
+      bool is_window_valid = true;
+      if (window_size_left >= 0) {
+        is_window_valid = global_n >= global_q_pos - window_size_left;
+      }
+      if (window_size_right >= 0) {
+        is_window_valid =
+            is_window_valid && global_n <= global_q_pos + window_size_right;
+      }
+      acc_frag.x[i] = (is_valid && is_causal_valid && is_window_valid)
+                          ? acc_frag.x[i] * softmax_scale
+                          : neg_inf;
+    }
+  }
+
+  store_matrix_sync(score + tile_n, acc_frag, S_STRIDE, mem_row_major);
+}
+
+template <int P_STRIDE, int O_STRIDE, bool SWIZZLED_P = false>
+__device__ __forceinline__ void pipeline_pv_tile(
+    const __half* __restrict__ sP, float* __restrict__ sO,
+    const __half* __restrict__ v_cache, const int* __restrict__ page_idx,
+    const int* __restrict__ page_offset, int64_t v_block_stride,
+    int64_t v_token_stride, int64_t v_head_stride, int kv_head_id,
+    int sub_start, int sub_valid_k_rows, int tile_d) {
+  fragment<matrix_a, WMMA_M, WMMA_N, WMMA_K, half, row_major> a_frag;
+  fragment<matrix_b, WMMA_M, WMMA_N, WMMA_K, half, row_major> b_frag;
+  fragment<accumulator, WMMA_M, WMMA_N, WMMA_K, float> acc_frag;
+  load_matrix_sync(acc_frag, sO + tile_d, O_STRIDE, mem_row_major);
+
+#pragma unroll
+  for (int tile_k = 0; tile_k < 2; ++tile_k) {
+    const int k_offset = tile_k * WMMA_K;
+    if (k_offset >= sub_valid_k_rows) {
+      break;
+    }
+    const int token_offset = sub_start + k_offset;
+    const int page_slot = token_offset >> 4;
+    const int block_offset = page_offset[page_slot] + (token_offset & 15);
+    const int physical_block_idx = page_idx[page_slot];
+    const __half* v_tile_ptr = v_cache +
+                               (int64_t)physical_block_idx * v_block_stride +
+                               (int64_t)block_offset * v_token_stride +
+                               (int64_t)kv_head_id * v_head_stride + tile_d;
+    if constexpr (SWIZZLED_P) {
+      load_pipeline_swizzled_matrix_a_fragment(a_frag, sP, k_offset);
+    } else {
+      load_matrix_sync(a_frag, sP + k_offset, P_STRIDE);
+    }
+    load_matrix_sync(b_frag, v_tile_ptr, v_token_stride);
+    mma_sync(acc_frag, a_frag, b_frag, acc_frag);
+  }
+  store_matrix_sync(sO + tile_d, acc_frag, O_STRIDE, mem_row_major);
+}
+
+template <int D, bool LOW_SMEM, bool LOW_SMEM_CONTIG_FAST,
+          bool LOW_SMEM_SCALAR_QK, bool LOW_SMEM_BM32, bool SPLIT_KV,
+          bool IS_CAUSAL, int KV_DTYPE, bool D256_OUTPUT_STRIDE_268 = false,
+          bool D256_SW_PIPELINE_QK = false, bool D256_SW_PIPELINE_PV = false>
+__global__ void __launch_bounds__(
+    KernelConfig<D, LOW_SMEM, LOW_SMEM_SCALAR_QK, LOW_SMEM_BM32,
+                 D256_OUTPUT_STRIDE_268, D256_SW_PIPELINE_QK,
+                 D256_SW_PIPELINE_PV>::THREADS_PER_BLOCK,
+    2)
+    flash_attention_forward_kernel_paged(
+        const __half* __restrict__ Q, const void* __restrict__ K_cache,
+        const void* __restrict__ V_cache, __half* __restrict__ Out,
+        float* __restrict__ softmax_lse, const int* __restrict__ block_table,
+        const int* __restrict__ seqused_k, const int B, const int H,
+        const int M, const int N, const int* __restrict__ bfla_block_mask,
+        const int bfla_mask_block_n, const int64_t bfla_mask_stride_b,
+        const int64_t bfla_mask_stride_h, const int64_t bfla_mask_stride_q,
+        const int64_t bfla_mask_stride_k, const int page_block_size,
+        const int num_kv_heads, const int64_t k_block_stride,
+        const int64_t k_token_stride, const int64_t k_head_stride,
+        const int64_t v_block_stride, const int64_t v_token_stride,
+        const int64_t v_head_stride, const float softmax_scale,
+        const float k_scale, const float v_scale, const int window_size_left,
+        const int window_size_right, float* __restrict__ split_tmp_out,
+        float* __restrict__ split_tmp_row_max,
+        float* __restrict__ split_tmp_row_sum, const int split_kv_tiles) {
+  using Config = KernelConfig<D, LOW_SMEM, LOW_SMEM_SCALAR_QK, LOW_SMEM_BM32,
+                              D256_OUTPUT_STRIDE_268, D256_SW_PIPELINE_QK,
+                              D256_SW_PIPELINE_PV>;
+  using Traits = FlashV100Traits<D>;
+
+  constexpr int BLOCK_M = Config::BLOCK_M;
+  constexpr int BLOCK_N = Config::BLOCK_N;
+  constexpr int THREADS_PER_BLOCK = Config::THREADS_PER_BLOCK;
+  constexpr int THREADS_PER_ROW = Config::THREADS_PER_ROW;
+  constexpr int WARPS_PER_BLOCK = Config::WARPS_PER_BLOCK;
+  constexpr int Q_STRIDE = Config::Q_STRIDE;
+  constexpr int KV_STRIDE = Config::KV_STRIDE;
+  constexpr int S_STRIDE = Config::S_STRIDE;
+  constexpr int P_SUB_TILE = Config::P_SUB_TILE;
+  constexpr int P_STRIDE = Config::P_STRIDE;
+  constexpr int O_STRIDE = Config::O_STRIDE;
+  constexpr int PER_UINT4 = Config::PER_UINT4;
+  constexpr bool USE_SW_PIPELINE = D256_SW_PIPELINE_QK || D256_SW_PIPELINE_PV;
+  if constexpr (USE_SW_PIPELINE) {
+    static_assert(D == 256 && LOW_SMEM && !LOW_SMEM_CONTIG_FAST &&
+                      !LOW_SMEM_SCALAR_QK && !LOW_SMEM_BM32 && !SPLIT_KV &&
+                      BLOCK_M == 16 && BLOCK_N == 128 && WARPS_PER_BLOCK == 16,
+                  "software pipeline is specialized for D256 BM16 BN128");
+  }
+  const float NEG_INF = -1e30f;
+
+  const int batch_head_id = blockIdx.z;
+  if (batch_head_id >= B * H) return;
+
+  const int batch_id = batch_head_id / H;
+  const int q_head_id = batch_head_id % H;
+  const int kv_group_size = H / num_kv_heads;
+  const int kv_head_id = q_head_id / kv_group_size;
+
+  const int block_m = blockIdx.x;
+  const int start_row = block_m * BLOCK_M;
+  if (start_row >= M) return;
+
+  const int actual_N = seqused_k[batch_id];
+  int num_n_tiles = (actual_N + BLOCK_N - 1) / BLOCK_N;
+  const int valid_q_rows = min(BLOCK_M, M - start_row);
+  const int causal_q_offset = max(actual_N - M, 0);
+
+  int max_key_pos = actual_N - 1;
+  if constexpr (IS_CAUSAL) {
+    max_key_pos =
+        min(max_key_pos, start_row + valid_q_rows - 1 + causal_q_offset);
+  }
+  if (window_size_right >= 0) {
+    max_key_pos = min(max_key_pos, start_row + valid_q_rows - 1 +
+                                       causal_q_offset + window_size_right);
+  }
+  if (max_key_pos < 0) {
+    num_n_tiles = 0;
+  } else {
+    num_n_tiles = min(num_n_tiles, (max_key_pos + BLOCK_N) / BLOCK_N);
+  }
+  const int min_key_pos =
+      window_size_left >= 0
+          ? max(0, start_row + causal_q_offset - window_size_left)
+          : 0;
+
+  const int tid = threadIdx.x;
+  const int warp_id = tid / MAX_THREADS_PER_WARP;
+  const int lane_id = tid % MAX_THREADS_PER_WARP;
+
+  const size_t q_head_linear = (size_t)batch_id * H + q_head_id;
+  const __half* q_ptr = Q + q_head_linear * M * D + start_row * D;
+  __half* out_ptr = Out + q_head_linear * M * D + start_row * D;
+  float* softmax_lse_ptr = softmax_lse + q_head_linear * M + start_row;
+
+  const int max_num_blocks_per_seq =
+      (N + page_block_size - 1) / page_block_size;
+  const int* block_table_seq = block_table + batch_id * max_num_blocks_per_seq;
+
+  const int64_t k_row_stride = k_token_stride;
+  const int64_t v_row_stride = v_token_stride;
+
+  extern __shared__ char smem_raw[];
+  init_smem<Config>(smem_raw);
+  auto& smem = *reinterpret_cast<typename Config::SmemLayout*>(smem_raw);
+
+  __half* sQ = smem.q;
+  __half* sK = smem.reuse_kv.k;
+  __half* sV = smem.reuse_kv.v;
+  float* sS = smem.reuse_sp.s;
+  __half* sP = (D == 256) ? smem.p_strict : smem.reuse_sp.p;
+  const int p_stride = (D == 256) ? P_STRIDE : S_STRIDE;
+  const int p_tile_capacity = (D == 256) ? P_SUB_TILE : BLOCK_N;
+  float* sO = smem.o;
+  float* sRowMax = smem.row_max;
+  float* sRowSum = smem.row_sum;
+  int* sPageIdx = smem.page_idx;
+  int* sPageOffset = smem.page_offset;
+
+  const int d_stride_uint4 = (D + PER_UINT4 - 1) / PER_UINT4;
+  const int q_stride_uint4 = (Q_STRIDE + PER_UINT4 - 1) / PER_UINT4;
+  const int kv_stride_uint4 = (KV_STRIDE + PER_UINT4 - 1) / PER_UINT4;
+
+  if (tid < BLOCK_M) {
+    sRowMax[tid] = NEG_INF;
+    sRowSum[tid] = 0.0f;
+  }
+  constexpr int O_UINT4_PER_ROW = D / 4;
+  constexpr int O_UINT4_STRIDE = O_STRIDE / 4;
+  for (int idx = tid; idx < BLOCK_M * O_UINT4_PER_ROW;
+       idx += THREADS_PER_BLOCK) {
+    const int row = idx / O_UINT4_PER_ROW;
+    const int col = idx % O_UINT4_PER_ROW;
+    reinterpret_cast<uint4*>(sO)[row * O_UINT4_STRIDE + col] =
+        make_uint4(0, 0, 0, 0);
+  }
+  __syncthreads();
+
+  const uint4* q_vec = reinterpret_cast<const uint4*>(q_ptr);
+  uint4* sQ_vec = reinterpret_cast<uint4*>(sQ);
+
+#pragma unroll 4
+  for (int idx = tid; idx < (valid_q_rows * d_stride_uint4);
+       idx += THREADS_PER_BLOCK) {
+    const int row = idx / d_stride_uint4;
+    const int vec_col = idx % d_stride_uint4;
+    uint4 q_val = make_uint4(0, 0, 0, 0);
+    if (row < valid_q_rows && vec_col < d_stride_uint4) {
+      q_val = __ldg(&q_vec[row * d_stride_uint4 + vec_col]);
+    }
+    if constexpr (Config::PIPELINE_SWIZZLED_Q) {
+      const int k_tile = vec_col >> 1;
+      const int plane = vec_col & 1;
+      const int slot = pipeline_swizzled_q_row_slot(row);
+      sQ_vec[k_tile * (2 * BLOCK_M) + plane * BLOCK_M + slot] = q_val;
+    } else {
+      sQ_vec[row * q_stride_uint4 + vec_col] = q_val;
+    }
+  }
+  __syncthreads();
+
+  int cross_block_first_n_tile = 0;
+  if constexpr (D256_SW_PIPELINE_QK && D256_SW_PIPELINE_PV) {
+    const bool use_cross_block_pipeline =
+        valid_q_rows == BLOCK_M && actual_N > 0 && page_block_size == 784 &&
+        bfla_block_mask == nullptr && window_size_left < 0 &&
+        window_size_right < 0;
+    if (use_cross_block_pipeline) {
+      const __half* k_cache_h = reinterpret_cast<const __half*>(K_cache);
+      const __half* v_cache_h = reinterpret_cast<const __half*>(V_cache);
+
+      if (tid < Config::LOW_SMEM_PAGE_COUNT) {
+        const int global_token_idx = tid * LOW_SMEM_PAGE_SIZE;
+        const int virtual_block_idx = global_token_idx / page_block_size;
+        sPageIdx[tid] = __ldg(&block_table_seq[virtual_block_idx]);
+        sPageOffset[tid] =
+            global_token_idx - virtual_block_idx * page_block_size;
+      }
+      __syncthreads();
+
+      if (warp_id < BLOCK_N / WMMA_N) {
+        const int valid_k_rows = min(BLOCK_N, actual_N);
+        pipeline_qk_slice<Q_STRIDE, S_STRIDE, D / WMMA_K, IS_CAUSAL, true>(
+            sQ, sS, k_cache_h, sPageIdx, sPageOffset, k_block_stride,
+            k_token_stride, k_head_stride, kv_head_id, 0, valid_k_rows,
+            start_row, valid_q_rows, causal_q_offset, warp_id * WMMA_N, 0,
+            false, true, softmax_scale, window_size_left, window_size_right,
+            NEG_INF);
+      }
+      __syncthreads();
+
+      // Keep the hot loop on a compile-time steady-state path. The
+      // existing exact path below drains the final block, avoiding a
+      // loop-carried has_next predicate in every softmax/PV panel.
+      const int steady_n_tiles = num_n_tiles - 1;
+      for (int block_n = 0; block_n < steady_n_tiles; ++block_n) {
+        const int start_col = block_n * BLOCK_N;
+        const int valid_k_rows = BLOCK_N;
+        const int next_start_col = start_col + BLOCK_N;
+        const int next_valid_k_rows = min(BLOCK_N, actual_N - next_start_col);
+        const bool odd_block = (block_n & 1) != 0;
+        float* const score_current = odd_block ? smem.pipeline_s : sS;
+        float* const score_next = odd_block ? sS : smem.pipeline_s;
+        int* const page_idx_current =
+            odd_block ? smem.pipeline_page_idx : sPageIdx;
+        int* const page_offset_current =
+            odd_block ? smem.pipeline_page_offset : sPageOffset;
+        int* const page_idx_next =
+            odd_block ? sPageIdx : smem.pipeline_page_idx;
+        int* const page_offset_next =
+            odd_block ? sPageOffset : smem.pipeline_page_offset;
+
+        if (tid < Config::LOW_SMEM_PAGE_COUNT) {
+          const int page_token_offset = tid * LOW_SMEM_PAGE_SIZE;
+          const int global_token_idx = next_start_col + page_token_offset;
+          const int virtual_block_idx = global_token_idx / page_block_size;
+          page_idx_next[tid] = __ldg(&block_table_seq[virtual_block_idx]);
+          page_offset_next[tid] =
+              global_token_idx - virtual_block_idx * page_block_size;
         }
-        load_matrix_sync(
-            b_frag, k_tile_base + k_offset, k_token_stride);
-        mma_sync(acc_frag, a_frag, b_frag, acc_frag);
+        __syncthreads();
+
+        for (int sub_start = 0; sub_start < valid_k_rows;
+             sub_start += P_SUB_TILE) {
+          const int sub_valid_k_rows =
+              min(P_SUB_TILE, valid_k_rows - sub_start);
+          const int row = warp_id;
+          const int thread_in_row = lane_id;
+          const unsigned mask = 0xFFFFFFFFU;
+          float* sS_row_f = score_current + row * S_STRIDE + sub_start;
+
+          const int vec_cols = sub_valid_k_rows >> 2;
+          const int vecs_per_thread =
+              (vec_cols + THREADS_PER_ROW - 1) / THREADS_PER_ROW;
+          const int tail_start = vec_cols << 2;
+          float thread_max = NEG_INF;
+          float4* sS_vec4 = reinterpret_cast<float4*>(sS_row_f);
+
+#pragma unroll 4
+          for (int j = 0; j < vecs_per_thread; ++j) {
+            const int vc = thread_in_row + j * THREADS_PER_ROW;
+            if (vc < vec_cols) {
+              const float4 v4 = sS_vec4[vc];
+              thread_max = fmaxf(thread_max,
+                                 fmaxf(fmaxf(v4.x, v4.y), fmaxf(v4.z, v4.w)));
+            }
+          }
+#pragma unroll
+          for (int c = tail_start + thread_in_row; c < sub_valid_k_rows;
+               c += THREADS_PER_ROW) {
+            thread_max = fmaxf(thread_max, sS_row_f[c]);
+          }
+#pragma unroll
+          for (int o = THREADS_PER_ROW / 2; o > 0; o >>= 1) {
+            thread_max =
+                fmaxf(thread_max, __shfl_down_sync(mask, thread_max, o));
+          }
+
+          const float row_max = __shfl_sync(mask, thread_max, 0);
+          const float old_max = sRowMax[row];
+          const float new_max = fmaxf(old_max, row_max);
+          const float exp_diff = __expf(old_max - new_max);
+          float thread_sum = 0.0f;
+          int vc_base = thread_in_row;
+
+#pragma unroll 4
+          for (int j = 0; j < vecs_per_thread;
+               ++j, vc_base += THREADS_PER_ROW) {
+            if (vc_base < vec_cols) {
+              const float4 v4 = sS_vec4[vc_base];
+              const float e0 = __expf(fmaxf(v4.x - new_max, -80.0f));
+              const float e1 = __expf(fmaxf(v4.y - new_max, -80.0f));
+              const float e2 = __expf(fmaxf(v4.z - new_max, -80.0f));
+              const float e3 = __expf(fmaxf(v4.w - new_max, -80.0f));
+              thread_sum += (e0 + e1) + (e2 + e3);
+              const int p_col = vc_base * 4;
+              __half2* p_half2 = reinterpret_cast<__half2*>(
+                  sP + pipeline_swizzled_matrix_a_offset(row, p_col));
+              p_half2[0] = __float22half2_rn(make_float2(e0, e1));
+              p_half2[1] = __float22half2_rn(make_float2(e2, e3));
+            }
+          }
+#pragma unroll 4
+          for (int c = tail_start + thread_in_row; c < sub_valid_k_rows;
+               c += THREADS_PER_ROW) {
+            const float e = __expf(fmaxf(sS_row_f[c] - new_max, -80.0f));
+            thread_sum += e;
+            sP[pipeline_swizzled_matrix_a_offset(row, c)] = __float2half_rn(e);
+          }
+#pragma unroll
+          for (int o = THREADS_PER_ROW / 2; o > 0; o >>= 1) {
+            thread_sum += __shfl_down_sync(mask, thread_sum, o);
+          }
+          const float row_sum = __shfl_sync(mask, thread_sum, 0);
+          if (thread_in_row == 0) {
+            sRowSum[row] = exp_diff * sRowSum[row] + row_sum;
+            sRowMax[row] = new_max;
+          }
+
+#pragma unroll 4
+          for (int c = tail_start + thread_in_row; c < P_SUB_TILE;
+               c += THREADS_PER_ROW) {
+            if (c >= sub_valid_k_rows) {
+              sP[pipeline_swizzled_matrix_a_offset(row, c)] =
+                  __float2half(0.0f);
+            }
+          }
+
+          if (block_n > 0 || sub_start > 0) {
+            float4* sO_vec = reinterpret_cast<float4*>(sO + row * O_STRIDE);
+#pragma unroll 4
+            for (int ov = thread_in_row; ov < D / 4; ov += THREADS_PER_ROW) {
+              float4 v = sO_vec[ov];
+              v.x *= exp_diff;
+              v.y *= exp_diff;
+              v.z *= exp_diff;
+              v.w *= exp_diff;
+              sO_vec[ov] = v;
+            }
+          }
+          __syncthreads();
+
+          if (sub_start == 0) {
+            if (warp_id < BLOCK_N / WMMA_N) {
+              pipeline_qk_slice<Q_STRIDE, S_STRIDE, D / WMMA_K, IS_CAUSAL,
+                                true>(
+                  sQ, score_next, k_cache_h, page_idx_next, page_offset_next,
+                  k_block_stride, k_token_stride, k_head_stride, kv_head_id,
+                  next_start_col, next_valid_k_rows, start_row, valid_q_rows,
+                  causal_q_offset, warp_id * WMMA_N, 0, false, true,
+                  softmax_scale, window_size_left, window_size_right, NEG_INF);
+            } else {
+              const int pv_warp = warp_id - BLOCK_N / WMMA_N;
+              pipeline_pv_tile<P_STRIDE, O_STRIDE, true>(
+                  sP, sO, v_cache_h, page_idx_current, page_offset_current,
+                  v_block_stride, v_token_stride, v_head_stride, kv_head_id,
+                  sub_start, sub_valid_k_rows, pv_warp * WMMA_N);
+              pipeline_pv_tile<P_STRIDE, O_STRIDE, true>(
+                  sP, sO, v_cache_h, page_idx_current, page_offset_current,
+                  v_block_stride, v_token_stride, v_head_stride, kv_head_id,
+                  sub_start, sub_valid_k_rows,
+                  (pv_warp + BLOCK_N / WMMA_N) * WMMA_N);
+            }
+          } else {
+            pipeline_pv_tile<P_STRIDE, O_STRIDE, true>(
+                sP, sO, v_cache_h, page_idx_current, page_offset_current,
+                v_block_stride, v_token_stride, v_head_stride, kv_head_id,
+                sub_start, sub_valid_k_rows, warp_id * WMMA_N);
+          }
+          __syncthreads();
+        }
+      }
+      cross_block_first_n_tile = steady_n_tiles;
+    }
+  }
+
+  int first_n_tile = cross_block_first_n_tile;
+  int last_n_tile = num_n_tiles;
+  if constexpr (SPLIT_KV) {
+    const int partition_id = blockIdx.y;
+    const int tiles_per_partition = split_kv_tiles > 1 ? split_kv_tiles : 1;
+    first_n_tile = partition_id * tiles_per_partition;
+    last_n_tile = min(num_n_tiles, first_n_tile + tiles_per_partition);
+  }
+
+  for (int block_n = first_n_tile; block_n < last_n_tile; ++block_n) {
+    const int start_col = block_n * BLOCK_N;
+    if (start_col >= actual_N) break;
+    const int valid_k_rows = min(BLOCK_N, actual_N - start_col);
+
+    if (start_col + valid_k_rows <= min_key_pos) {
+      continue;
     }
 
-    if (finalize) {
-        const int lane_id = threadIdx.x & 31;
-        const unsigned row_causal =
-            (lane_id & 0b1) + ((lane_id >> 2) & 0b1) * 8
-            + ((lane_id >> 4) & 0b1) * 4;
+    if (bfla_block_mask != nullptr && bfla_mask_block_n > 0) {
+      const int mask_q_idx = start_row / bfla_mask_block_n;
+      const int mask_k_idx = start_col / bfla_mask_block_n;
+      const int keep_tile =
+          __ldg(bfla_block_mask + (int64_t)batch_id * bfla_mask_stride_b +
+                (int64_t)kv_head_id * bfla_mask_stride_h +
+                (int64_t)mask_q_idx * bfla_mask_stride_q +
+                (int64_t)mask_k_idx * bfla_mask_stride_k);
+      if (keep_tile == 0) {
+        continue;
+      }
+    }
+
+    const int partial_block_size =
+        (block_n == num_n_tiles - 1 && actual_N % BLOCK_N != 0)
+            ? (actual_N % BLOCK_N)
+            : -1;
+
+    uint4* sK_vec = reinterpret_cast<uint4*>(sK);
+    const int64_t row_stride_uint4 = k_row_stride / PER_UINT4;
+    const int start_page = start_col / page_block_size;
+    const int page_offset = start_col % page_block_size;
+    const bool single_page_tile =
+        (page_offset + valid_k_rows) <= page_block_size;
+    const bool two_page_tile =
+        !single_page_tile &&
+        (page_offset + valid_k_rows) <= (page_block_size * 2);
+    const int first_page_rows =
+        single_page_tile ? valid_k_rows
+                         : min(valid_k_rows, page_block_size - page_offset);
+    const int second_page_rows = valid_k_rows - first_page_rows;
+    const int physical_block_idx0 = __ldg(&block_table_seq[start_page]);
+    const int physical_block_idx1 =
+        second_page_rows > 0 ? __ldg(&block_table_seq[start_page + 1]) : -1;
+    const bool four_page_aligned_tile =
+        D == 256 && page_block_size == 16 && page_offset == 0 &&
+        BLOCK_N == page_block_size * 4 && valid_k_rows == BLOCK_N &&
+        k_block_stride == (int64_t)page_block_size * k_token_stride &&
+        v_block_stride == (int64_t)page_block_size * v_token_stride;
+    const int physical_block_idx2 =
+        four_page_aligned_tile ? __ldg(&block_table_seq[start_page + 2]) : -1;
+    const int physical_block_idx3 =
+        four_page_aligned_tile ? __ldg(&block_table_seq[start_page + 3]) : -1;
+    const bool four_page_contiguous_tile =
+        four_page_aligned_tile &&
+        physical_block_idx1 == physical_block_idx0 + 1 &&
+        physical_block_idx2 == physical_block_idx0 + 2 &&
+        physical_block_idx3 == physical_block_idx0 + 3;
+    bool low_smem_contiguous_page_tile = false;
+    if constexpr (LOW_SMEM) {
+      static_assert(D == 256, "low-smem paged prefill is D=256 only");
+      static_assert(KV_DTYPE == flash_v100::KV_CACHE_DTYPE_FP16,
+                    "low-smem paged prefill is fp16-KV only");
+      static_assert(BLOCK_N % LOW_SMEM_PAGE_SIZE == 0,
+                    "low-smem BLOCK_N must be page aligned");
+
+      constexpr int LOW_SMEM_PAGE_COUNT = Config::LOW_SMEM_PAGE_COUNT;
+      if (tid < LOW_SMEM_PAGE_COUNT) {
+        const int page_token_offset = tid * LOW_SMEM_PAGE_SIZE;
+        if (page_token_offset < valid_k_rows) {
+          const int global_token_idx = start_col + page_token_offset;
+          const int virtual_block_idx = global_token_idx / page_block_size;
+          sPageIdx[tid] = __ldg(&block_table_seq[virtual_block_idx]);
+          sPageOffset[tid] =
+              global_token_idx - virtual_block_idx * page_block_size;
+        } else {
+          sPageIdx[tid] = -1;
+          sPageOffset[tid] = 0;
+        }
+      }
+      __syncthreads();
+
+      if constexpr (LOW_SMEM_CONTIG_FAST) {
+        low_smem_contiguous_page_tile =
+            valid_k_rows == BLOCK_N &&
+            k_block_stride == (int64_t)page_block_size * k_token_stride &&
+            v_block_stride == (int64_t)page_block_size * v_token_stride &&
+            sPageIdx[0] >= 0;
+#pragma unroll
+        for (int i = 1; i < LOW_SMEM_PAGE_COUNT; ++i) {
+          const int linear_offset = sPageOffset[0] + i * LOW_SMEM_PAGE_SIZE;
+          const int expected_page_delta = linear_offset / page_block_size;
+          const int expected_page_offset =
+              linear_offset - expected_page_delta * page_block_size;
+          low_smem_contiguous_page_tile =
+              low_smem_contiguous_page_tile &&
+              sPageIdx[i] == sPageIdx[0] + expected_page_delta &&
+              sPageOffset[i] == expected_page_offset;
+        }
+      } else {
+        low_smem_contiguous_page_tile = false;
+      }
+
+      const __half* K_cache_h = reinterpret_cast<const __half*>(K_cache);
+
+      if constexpr (LOW_SMEM_SCALAR_QK) {
+        uint4* sK_vec = reinterpret_cast<uint4*>(sK);
+        for (int idx = tid; idx < valid_k_rows * d_stride_uint4;
+             idx += THREADS_PER_BLOCK) {
+          const int row = idx / d_stride_uint4;
+          const int vec_col = idx % d_stride_uint4;
+          uint4 k_val = make_uint4(0, 0, 0, 0);
+          if (row < valid_k_rows && vec_col < d_stride_uint4) {
+            const int page_slot = row >> 4;
+            const int block_offset =
+                sPageOffset[page_slot] + (row - page_slot * LOW_SMEM_PAGE_SIZE);
+            const int physical_block_idx_direct = sPageIdx[page_slot];
+            const __half* k_row_ptr;
+            if constexpr (LOW_SMEM_CONTIG_FAST) {
+              k_row_ptr =
+                  low_smem_contiguous_page_tile
+                      ? K_cache_h + (int64_t)sPageIdx[0] * k_block_stride +
+                            (int64_t)(sPageOffset[0] + row) * k_token_stride +
+                            (int64_t)kv_head_id * k_head_stride
+                      : K_cache_h +
+                            (int64_t)physical_block_idx_direct *
+                                k_block_stride +
+                            (int64_t)block_offset * k_token_stride +
+                            (int64_t)kv_head_id * k_head_stride;
+            } else {
+              k_row_ptr = K_cache_h +
+                          (int64_t)physical_block_idx_direct * k_block_stride +
+                          (int64_t)block_offset * k_token_stride +
+                          (int64_t)kv_head_id * k_head_stride;
+            }
+            const uint4* k_row_vec = reinterpret_cast<const uint4*>(k_row_ptr);
+            k_val = __ldg(&k_row_vec[vec_col]);
+          }
+          sK_vec[row * kv_stride_uint4 + vec_col] = k_val;
+        }
+        __syncthreads();
+
+        const int total_scores = valid_q_rows * valid_k_rows;
+        for (int idx = tid; idx < total_scores; idx += THREADS_PER_BLOCK) {
+          const int row = idx / valid_k_rows;
+          const int col = idx - row * valid_k_rows;
+          const int global_m = start_row + row;
+          const int global_n = start_col + col;
+          const int global_q_pos = global_m + causal_q_offset;
+
+          bool is_valid = true;
+          if constexpr (IS_CAUSAL) {
+            is_valid = global_n <= global_q_pos;
+          }
+          if (window_size_left >= 0) {
+            is_valid = is_valid && global_n >= global_q_pos - window_size_left;
+          }
+          if (window_size_right >= 0) {
+            is_valid = is_valid && global_n <= global_q_pos + window_size_right;
+          }
+
+          float acc = 0.0f;
+          if (is_valid) {
+#pragma unroll 8
+            for (int d = 0; d < D; d += 2) {
+              const __half2 q_h2 =
+                  *reinterpret_cast<const __half2*>(sQ + row * Q_STRIDE + d);
+              const __half2 k_h2 =
+                  *reinterpret_cast<const __half2*>(sK + col * KV_STRIDE + d);
+              const float2 q_f2 = __half22float2(q_h2);
+              const float2 k_f2 = __half22float2(k_h2);
+              acc = fmaf(q_f2.x, k_f2.x, acc);
+              acc = fmaf(q_f2.y, k_f2.y, acc);
+            }
+          }
+          sS[row * S_STRIDE + col] = is_valid ? acc * softmax_scale : NEG_INF;
+        }
+      } else if constexpr (D256_SW_PIPELINE_QK) {
+        constexpr int QK_TILES = BLOCK_N / WMMA_N;
+        if (warp_id < QK_TILES) {
+          pipeline_qk_slice<Q_STRIDE, S_STRIDE, D / WMMA_K, IS_CAUSAL,
+                            D256_SW_PIPELINE_PV>(
+              sQ, sS, K_cache_h, sPageIdx, sPageOffset, k_block_stride,
+              k_token_stride, k_head_stride, kv_head_id, start_col,
+              valid_k_rows, start_row, valid_q_rows, causal_q_offset,
+              warp_id * WMMA_N, 0, false, true, softmax_scale, window_size_left,
+              window_size_right, NEG_INF);
+        }
+      } else {
+        const int num_tiles_m_qk = (BLOCK_M + WMMA_M - 1) / WMMA_M;
+        const int num_tiles_n_qk = (BLOCK_N + WMMA_N - 1) / WMMA_N;
+        const int num_tiles_k_qk = (D + WMMA_K - 1) / WMMA_K;
+        const int total_tiles_qk = num_tiles_m_qk * num_tiles_n_qk;
+        const int tiles_per_warp_qk =
+            (total_tiles_qk + WARPS_PER_BLOCK - 1) / WARPS_PER_BLOCK;
+        const unsigned row_causal = (lane_id & 0b1) +
+                                    ((lane_id >> 2) & 0b1) * 8 +
+                                    ((lane_id >> 4) & 0b1) * 4;
         const unsigned col_causal =
             ((lane_id >> 1) & 0b1) * 2 + ((lane_id >> 3) & 0b1) * 8;
 
-        #pragma unroll
-        for (int i = 0; i < acc_frag.num_elements; ++i) {
-            const unsigned col =
-                col_causal + (i & 0b1) + ((i >> 2) & 0b1) * 4;
+        for (int tile_idx = 0; tile_idx < tiles_per_warp_qk; ++tile_idx) {
+          const int global_tile_idx = warp_id * tiles_per_warp_qk + tile_idx;
+          if (global_tile_idx >= total_tiles_qk) break;
+
+          const int tile_m_idx = global_tile_idx / num_tiles_n_qk;
+          const int tile_n_idx = global_tile_idx % num_tiles_n_qk;
+
+          const int tile_m = tile_m_idx * WMMA_M;
+          const int tile_n = tile_n_idx * WMMA_N;
+
+          if (tile_m >= valid_q_rows || tile_n >= valid_k_rows) {
+            continue;
+          }
+
+          const int page_slot = tile_n >> 4;
+          const int block_offset = sPageOffset[page_slot];
+          const int physical_block_idx_direct = sPageIdx[page_slot];
+
+          fragment<matrix_a, WMMA_M, WMMA_N, WMMA_K, half, row_major> a_frag;
+          fragment<matrix_b, WMMA_M, WMMA_N, WMMA_K, half, col_major> b_frag;
+          fragment<accumulator, WMMA_M, WMMA_N, WMMA_K, float> acc_frag;
+          fill_fragment(acc_frag, 0.0f);
+
+#pragma unroll
+          for (int k_tile = 0; k_tile < num_tiles_k_qk; ++k_tile) {
+            const int k_offset = k_tile * WMMA_K;
+            if (k_offset >= D) break;
+
+            const __half* k_tile_ptr;
+            if constexpr (LOW_SMEM_CONTIG_FAST) {
+              k_tile_ptr =
+                  low_smem_contiguous_page_tile
+                      ? K_cache_h + (int64_t)sPageIdx[0] * k_block_stride +
+                            (int64_t)(sPageOffset[0] + tile_n) *
+                                k_token_stride +
+                            (int64_t)kv_head_id * k_head_stride + k_offset
+                      : K_cache_h +
+                            (int64_t)physical_block_idx_direct *
+                                k_block_stride +
+                            (int64_t)block_offset * k_token_stride +
+                            (int64_t)kv_head_id * k_head_stride + k_offset;
+            } else {
+              k_tile_ptr = K_cache_h +
+                           (int64_t)physical_block_idx_direct * k_block_stride +
+                           (int64_t)block_offset * k_token_stride +
+                           (int64_t)kv_head_id * k_head_stride + k_offset;
+            }
+
+            load_matrix_sync(a_frag, sQ + tile_m * Q_STRIDE + k_offset,
+                             Q_STRIDE);
+            load_matrix_sync(b_frag, k_tile_ptr, k_token_stride);
+            mma_sync(acc_frag, a_frag, b_frag, acc_frag);
+          }
+
+#pragma unroll
+          for (int i = 0; i < acc_frag.num_elements; ++i) {
+            const unsigned col = col_causal + (i & 0b1) + ((i >> 2) & 0b1) * 4;
             const unsigned row = row_causal + ((i >> 1) & 0b1) * 2;
-            const int global_m = start_row + row;
+
+            const int global_m = start_row + tile_m + row;
             const int global_n = start_col + tile_n + col;
             const int global_q_pos = global_m + causal_q_offset;
 
-            const bool is_valid =
-                global_m < start_row + valid_q_rows
-                && global_n < start_col + valid_k_rows;
+            const bool is_valid = (global_m < start_row + valid_q_rows) &&
+                                  (global_n < start_col + valid_k_rows);
             bool is_causal_valid = true;
             if constexpr (IS_CAUSAL) {
-                is_causal_valid = global_n <= global_q_pos;
+              is_causal_valid = global_n <= global_q_pos;
             }
             bool is_window_valid = true;
             if (window_size_left >= 0) {
-                is_window_valid =
-                    global_n >= global_q_pos - window_size_left;
+              is_window_valid = is_window_valid &&
+                                global_n >= global_q_pos - window_size_left;
             }
             if (window_size_right >= 0) {
-                is_window_valid =
-                    is_window_valid
-                    && global_n <= global_q_pos + window_size_right;
-            }
-            acc_frag.x[i] =
-                (is_valid && is_causal_valid && is_window_valid)
-                    ? acc_frag.x[i] * softmax_scale
-                    : neg_inf;
-        }
-    }
-
-    store_matrix_sync(score + tile_n, acc_frag, S_STRIDE, mem_row_major);
-}
-
-template<int P_STRIDE, int O_STRIDE, bool SWIZZLED_P = false>
-__device__ __forceinline__ void pipeline_pv_tile(
-    const __half* __restrict__ sP,
-    float* __restrict__ sO,
-    const __half* __restrict__ v_cache,
-    const int* __restrict__ page_idx,
-    const int* __restrict__ page_offset,
-    int64_t v_block_stride,
-    int64_t v_token_stride,
-    int64_t v_head_stride,
-    int kv_head_id,
-    int sub_start,
-    int sub_valid_k_rows,
-    int tile_d) {
-    fragment<matrix_a, WMMA_M, WMMA_N, WMMA_K, half, row_major> a_frag;
-    fragment<matrix_b, WMMA_M, WMMA_N, WMMA_K, half, row_major> b_frag;
-    fragment<accumulator, WMMA_M, WMMA_N, WMMA_K, float> acc_frag;
-    load_matrix_sync(
-        acc_frag, sO + tile_d, O_STRIDE, mem_row_major);
-
-    #pragma unroll
-    for (int tile_k = 0; tile_k < 2; ++tile_k) {
-        const int k_offset = tile_k * WMMA_K;
-        if (k_offset >= sub_valid_k_rows) {
-            break;
-        }
-        const int token_offset = sub_start + k_offset;
-        const int page_slot = token_offset >> 4;
-        const int block_offset =
-            page_offset[page_slot] + (token_offset & 15);
-        const int physical_block_idx = page_idx[page_slot];
-        const __half* v_tile_ptr =
-            v_cache + (int64_t)physical_block_idx * v_block_stride
-            + (int64_t)block_offset * v_token_stride
-            + (int64_t)kv_head_id * v_head_stride + tile_d;
-        if constexpr (SWIZZLED_P) {
-            load_pipeline_swizzled_matrix_a_fragment(
-                a_frag, sP, k_offset);
-        } else {
-            load_matrix_sync(a_frag, sP + k_offset, P_STRIDE);
-        }
-        load_matrix_sync(b_frag, v_tile_ptr, v_token_stride);
-        mma_sync(acc_frag, a_frag, b_frag, acc_frag);
-    }
-    store_matrix_sync(sO + tile_d, acc_frag, O_STRIDE, mem_row_major);
-}
-
-template<int D, bool LOW_SMEM, bool LOW_SMEM_CONTIG_FAST,
-         bool LOW_SMEM_SCALAR_QK, bool LOW_SMEM_BM32, bool SPLIT_KV,
-         bool IS_CAUSAL, int KV_DTYPE, bool D256_OUTPUT_STRIDE_268 = false,
-         bool D256_SW_PIPELINE_QK = false,
-         bool D256_SW_PIPELINE_PV = false>
-__global__ void __launch_bounds__(
-    KernelConfig<D, LOW_SMEM, LOW_SMEM_SCALAR_QK,
-                 LOW_SMEM_BM32,
-                 D256_OUTPUT_STRIDE_268,
-                 D256_SW_PIPELINE_QK,
-                 D256_SW_PIPELINE_PV>::THREADS_PER_BLOCK, 2)
-flash_attention_forward_kernel_paged(
-    const __half* __restrict__ Q,
-    const void* __restrict__ K_cache,
-    const void* __restrict__ V_cache,
-          __half* __restrict__ Out,
-           float* __restrict__ softmax_lse,
-    const int* __restrict__ block_table,
-    const int* __restrict__ seqused_k,
-    const int B,
-    const int H,
-    const int M,
-    const int N,
-    const int* __restrict__ bfla_block_mask,
-    const int bfla_mask_block_n,
-    const int64_t bfla_mask_stride_b,
-    const int64_t bfla_mask_stride_h,
-    const int64_t bfla_mask_stride_q,
-    const int64_t bfla_mask_stride_k,
-    const int page_block_size,
-    const int num_kv_heads,
-    const int64_t k_block_stride,
-    const int64_t k_token_stride,
-    const int64_t k_head_stride,
-    const int64_t v_block_stride,
-    const int64_t v_token_stride,
-    const int64_t v_head_stride,
-    const float softmax_scale,
-    const float k_scale,
-    const float v_scale,
-    const int window_size_left,
-    const int window_size_right,
-          float* __restrict__ split_tmp_out,
-          float* __restrict__ split_tmp_row_max,
-          float* __restrict__ split_tmp_row_sum,
-    const int split_kv_tiles
-) {
-    using Config = KernelConfig<D, LOW_SMEM, LOW_SMEM_SCALAR_QK,
-                                LOW_SMEM_BM32, D256_OUTPUT_STRIDE_268,
-                                D256_SW_PIPELINE_QK,
-                                D256_SW_PIPELINE_PV>;
-    using Traits = FlashV100Traits<D>;
-
-    constexpr int BLOCK_M           = Config::BLOCK_M;
-    constexpr int BLOCK_N           = Config::BLOCK_N;
-    constexpr int THREADS_PER_BLOCK = Config::THREADS_PER_BLOCK;
-    constexpr int THREADS_PER_ROW   = Config::THREADS_PER_ROW;
-    constexpr int WARPS_PER_BLOCK   = Config::WARPS_PER_BLOCK;
-    constexpr int Q_STRIDE          = Config::Q_STRIDE;
-    constexpr int KV_STRIDE         = Config::KV_STRIDE;
-    constexpr int S_STRIDE          = Config::S_STRIDE;
-    constexpr int P_SUB_TILE        = Config::P_SUB_TILE;
-    constexpr int P_STRIDE          = Config::P_STRIDE;
-    constexpr int O_STRIDE          = Config::O_STRIDE;
-    constexpr int PER_UINT4         = Config::PER_UINT4;
-    constexpr bool USE_SW_PIPELINE =
-        D256_SW_PIPELINE_QK || D256_SW_PIPELINE_PV;
-    if constexpr (USE_SW_PIPELINE) {
-        static_assert(D == 256 && LOW_SMEM && !LOW_SMEM_CONTIG_FAST
-                          && !LOW_SMEM_SCALAR_QK && !LOW_SMEM_BM32
-                          && !SPLIT_KV && BLOCK_M == 16 && BLOCK_N == 128
-                          && WARPS_PER_BLOCK == 16,
-                      "software pipeline is specialized for D256 BM16 BN128");
-    }
-    const float NEG_INF = -1e30f;
-
-    const int batch_head_id = blockIdx.z;
-    if (batch_head_id >= B * H) return;
-
-    const int batch_id = batch_head_id / H;
-    const int q_head_id = batch_head_id % H;
-    const int kv_group_size = H / num_kv_heads;
-    const int kv_head_id = q_head_id / kv_group_size;
-
-    const int block_m = blockIdx.x;
-    const int start_row = block_m * BLOCK_M;
-    if (start_row >= M) return;
-
-    const int actual_N = seqused_k[batch_id];
-    int num_n_tiles = (actual_N + BLOCK_N - 1) / BLOCK_N;
-    const int valid_q_rows = min(BLOCK_M, M - start_row);
-    const int causal_q_offset = max(actual_N - M, 0);
-
-    int max_key_pos = actual_N - 1;
-    if constexpr (IS_CAUSAL) {
-        max_key_pos = min(max_key_pos,
-                          start_row + valid_q_rows - 1 + causal_q_offset);
-    }
-    if (window_size_right >= 0) {
-        max_key_pos = min(max_key_pos,
-                          start_row + valid_q_rows - 1 + causal_q_offset
-                              + window_size_right);
-    }
-    if (max_key_pos < 0) {
-        num_n_tiles = 0;
-    } else {
-        num_n_tiles = min(num_n_tiles, (max_key_pos + BLOCK_N) / BLOCK_N);
-    }
-    const int min_key_pos = window_size_left >= 0
-                                ? max(0, start_row + causal_q_offset
-                                             - window_size_left)
-                                : 0;
-
-    const int tid = threadIdx.x;
-    const int warp_id = tid / MAX_THREADS_PER_WARP;
-    const int lane_id = tid % MAX_THREADS_PER_WARP;
-
-    const size_t q_head_linear = (size_t)batch_id * H + q_head_id;
-    const __half* q_ptr = Q + q_head_linear * M * D + start_row * D;
-    __half* out_ptr = Out + q_head_linear * M * D + start_row * D;
-    float* softmax_lse_ptr = softmax_lse + q_head_linear * M + start_row;
-
-    const int max_num_blocks_per_seq = (N + page_block_size - 1) / page_block_size;
-    const int* block_table_seq = block_table + batch_id * max_num_blocks_per_seq;
-
-    const int64_t k_row_stride = k_token_stride;
-    const int64_t v_row_stride = v_token_stride;
-
-    extern __shared__ char smem_raw[];
-    init_smem<Config>(smem_raw);
-    auto& smem = *reinterpret_cast<typename Config::SmemLayout*>(smem_raw);
-
-    __half* sQ      = smem.q;
-    __half* sK      = smem.reuse_kv.k;
-    __half* sV      = smem.reuse_kv.v;
-    float*  sS      = smem.reuse_sp.s;
-    __half* sP      = (D == 256) ? smem.p_strict : smem.reuse_sp.p;
-    const int p_stride = (D == 256) ? P_STRIDE : S_STRIDE;
-    const int p_tile_capacity = (D == 256) ? P_SUB_TILE : BLOCK_N;
-    float*  sO      = smem.o;
-    float*  sRowMax = smem.row_max;
-    float*  sRowSum = smem.row_sum;
-    int*    sPageIdx = smem.page_idx;
-    int*    sPageOffset = smem.page_offset;
-
-    const int  d_stride_uint4 = (D + PER_UINT4 - 1) / PER_UINT4;
-    const int  q_stride_uint4 = (Q_STRIDE  + PER_UINT4 - 1) / PER_UINT4;
-    const int kv_stride_uint4 = (KV_STRIDE + PER_UINT4 - 1) / PER_UINT4;
-
-    if (tid < BLOCK_M) {
-        sRowMax[tid] = NEG_INF;
-        sRowSum[tid] = 0.0f;
-    }
-    constexpr int O_UINT4_PER_ROW = D / 4;
-    constexpr int O_UINT4_STRIDE = O_STRIDE / 4;
-    for (int idx = tid; idx < BLOCK_M * O_UINT4_PER_ROW;
-         idx += THREADS_PER_BLOCK) {
-        const int row = idx / O_UINT4_PER_ROW;
-        const int col = idx % O_UINT4_PER_ROW;
-        reinterpret_cast<uint4*>(sO)[row * O_UINT4_STRIDE + col] =
-            make_uint4(0, 0, 0, 0);
-    }
-    __syncthreads();
-
-    const uint4*      q_vec = reinterpret_cast<const uint4*>(q_ptr);
-    uint4*           sQ_vec = reinterpret_cast<uint4*>(sQ);
-
-    #pragma unroll 4
-    for (int idx = tid; idx < (valid_q_rows * d_stride_uint4); idx += THREADS_PER_BLOCK) {
-        const int row = idx / d_stride_uint4;
-        const int vec_col = idx % d_stride_uint4;
-        uint4 q_val = make_uint4(0, 0, 0, 0);
-        if (row < valid_q_rows && vec_col < d_stride_uint4) {
-            q_val = __ldg(&q_vec[row * d_stride_uint4 + vec_col]);
-        }
-        if constexpr (Config::PIPELINE_SWIZZLED_Q) {
-            const int k_tile = vec_col >> 1;
-            const int plane = vec_col & 1;
-            const int slot = pipeline_swizzled_q_row_slot(row);
-            sQ_vec[k_tile * (2 * BLOCK_M) + plane * BLOCK_M + slot] =
-                q_val;
-        } else {
-            sQ_vec[row * q_stride_uint4 + vec_col] = q_val;
-        }
-    }
-    __syncthreads();
-
-    int cross_block_first_n_tile = 0;
-    if constexpr (D256_SW_PIPELINE_QK && D256_SW_PIPELINE_PV) {
-        const bool use_cross_block_pipeline =
-            valid_q_rows == BLOCK_M && actual_N > 0
-            && page_block_size == 784 && bfla_block_mask == nullptr
-            && window_size_left < 0 && window_size_right < 0;
-        if (use_cross_block_pipeline) {
-            const __half* k_cache_h =
-                reinterpret_cast<const __half*>(K_cache);
-            const __half* v_cache_h =
-                reinterpret_cast<const __half*>(V_cache);
-
-            if (tid < Config::LOW_SMEM_PAGE_COUNT) {
-                const int global_token_idx = tid * LOW_SMEM_PAGE_SIZE;
-                const int virtual_block_idx =
-                    global_token_idx / page_block_size;
-                sPageIdx[tid] =
-                    __ldg(&block_table_seq[virtual_block_idx]);
-                sPageOffset[tid] =
-                    global_token_idx
-                    - virtual_block_idx * page_block_size;
-            }
-            __syncthreads();
-
-            if (warp_id < BLOCK_N / WMMA_N) {
-                const int valid_k_rows = min(BLOCK_N, actual_N);
-                pipeline_qk_slice<Q_STRIDE, S_STRIDE, D / WMMA_K,
-                                  IS_CAUSAL, true>(
-                    sQ, sS, k_cache_h, sPageIdx, sPageOffset,
-                    k_block_stride, k_token_stride,
-                    k_head_stride, kv_head_id, 0, valid_k_rows, start_row,
-                    valid_q_rows, causal_q_offset, warp_id * WMMA_N, 0, false,
-                    true, softmax_scale, window_size_left, window_size_right,
-                    NEG_INF);
-            }
-            __syncthreads();
-
-            // Keep the hot loop on a compile-time steady-state path. The
-            // existing exact path below drains the final block, avoiding a
-            // loop-carried has_next predicate in every softmax/PV panel.
-            const int steady_n_tiles = num_n_tiles - 1;
-            for (int block_n = 0; block_n < steady_n_tiles; ++block_n) {
-                const int start_col = block_n * BLOCK_N;
-                const int valid_k_rows = BLOCK_N;
-                const int next_start_col = start_col + BLOCK_N;
-                const int next_valid_k_rows =
-                    min(BLOCK_N, actual_N - next_start_col);
-                const bool odd_block = (block_n & 1) != 0;
-                float* const score_current =
-                    odd_block ? smem.pipeline_s : sS;
-                float* const score_next =
-                    odd_block ? sS : smem.pipeline_s;
-                int* const page_idx_current =
-                    odd_block ? smem.pipeline_page_idx : sPageIdx;
-                int* const page_offset_current =
-                    odd_block ? smem.pipeline_page_offset : sPageOffset;
-                int* const page_idx_next =
-                    odd_block ? sPageIdx : smem.pipeline_page_idx;
-                int* const page_offset_next =
-                    odd_block ? sPageOffset : smem.pipeline_page_offset;
-
-                if (tid < Config::LOW_SMEM_PAGE_COUNT) {
-                    const int page_token_offset =
-                        tid * LOW_SMEM_PAGE_SIZE;
-                    const int global_token_idx =
-                        next_start_col + page_token_offset;
-                    const int virtual_block_idx =
-                        global_token_idx / page_block_size;
-                    page_idx_next[tid] =
-                        __ldg(&block_table_seq[virtual_block_idx]);
-                    page_offset_next[tid] =
-                        global_token_idx
-                        - virtual_block_idx * page_block_size;
-                }
-                __syncthreads();
-
-                for (int sub_start = 0; sub_start < valid_k_rows;
-                     sub_start += P_SUB_TILE) {
-                    const int sub_valid_k_rows =
-                        min(P_SUB_TILE, valid_k_rows - sub_start);
-                    const int row = warp_id;
-                    const int thread_in_row = lane_id;
-                    const unsigned mask = 0xFFFFFFFFU;
-                    float* sS_row_f =
-                        score_current + row * S_STRIDE + sub_start;
-
-                    const int vec_cols = sub_valid_k_rows >> 2;
-                    const int vecs_per_thread =
-                        (vec_cols + THREADS_PER_ROW - 1) / THREADS_PER_ROW;
-                    const int tail_start = vec_cols << 2;
-                    float thread_max = NEG_INF;
-                    float4* sS_vec4 = reinterpret_cast<float4*>(sS_row_f);
-
-                    #pragma unroll 4
-                    for (int j = 0; j < vecs_per_thread; ++j) {
-                        const int vc =
-                            thread_in_row + j * THREADS_PER_ROW;
-                        if (vc < vec_cols) {
-                            const float4 v4 = sS_vec4[vc];
-                            thread_max = fmaxf(
-                                thread_max,
-                                fmaxf(
-                                    fmaxf(v4.x, v4.y),
-                                    fmaxf(v4.z, v4.w)));
-                        }
-                    }
-                    #pragma unroll
-                    for (int c = tail_start + thread_in_row;
-                         c < sub_valid_k_rows; c += THREADS_PER_ROW) {
-                        thread_max = fmaxf(thread_max, sS_row_f[c]);
-                    }
-                    #pragma unroll
-                    for (int o = THREADS_PER_ROW / 2; o > 0; o >>= 1) {
-                        thread_max = fmaxf(
-                            thread_max,
-                            __shfl_down_sync(mask, thread_max, o));
-                    }
-
-                    const float row_max =
-                        __shfl_sync(mask, thread_max, 0);
-                    const float old_max = sRowMax[row];
-                    const float new_max = fmaxf(old_max, row_max);
-                    const float exp_diff = __expf(old_max - new_max);
-                    float thread_sum = 0.0f;
-                    int vc_base = thread_in_row;
-
-                    #pragma unroll 4
-                    for (int j = 0; j < vecs_per_thread;
-                         ++j, vc_base += THREADS_PER_ROW) {
-                        if (vc_base < vec_cols) {
-                            const float4 v4 = sS_vec4[vc_base];
-                            const float e0 =
-                                __expf(fmaxf(v4.x - new_max, -80.0f));
-                            const float e1 =
-                                __expf(fmaxf(v4.y - new_max, -80.0f));
-                            const float e2 =
-                                __expf(fmaxf(v4.z - new_max, -80.0f));
-                            const float e3 =
-                                __expf(fmaxf(v4.w - new_max, -80.0f));
-                            thread_sum += (e0 + e1) + (e2 + e3);
-                            const int p_col = vc_base * 4;
-                            __half2* p_half2 = reinterpret_cast<__half2*>(
-                                sP + pipeline_swizzled_matrix_a_offset(
-                                         row, p_col));
-                            p_half2[0] =
-                                __float22half2_rn(make_float2(e0, e1));
-                            p_half2[1] =
-                                __float22half2_rn(make_float2(e2, e3));
-                        }
-                    }
-                    #pragma unroll 4
-                    for (int c = tail_start + thread_in_row;
-                         c < sub_valid_k_rows; c += THREADS_PER_ROW) {
-                        const float e = __expf(
-                            fmaxf(sS_row_f[c] - new_max, -80.0f));
-                        thread_sum += e;
-                        sP[pipeline_swizzled_matrix_a_offset(row, c)] =
-                            __float2half_rn(e);
-                    }
-                    #pragma unroll
-                    for (int o = THREADS_PER_ROW / 2; o > 0; o >>= 1) {
-                        thread_sum +=
-                            __shfl_down_sync(mask, thread_sum, o);
-                    }
-                    const float row_sum =
-                        __shfl_sync(mask, thread_sum, 0);
-                    if (thread_in_row == 0) {
-                        sRowSum[row] = exp_diff * sRowSum[row] + row_sum;
-                        sRowMax[row] = new_max;
-                    }
-
-                    #pragma unroll 4
-                    for (int c = tail_start + thread_in_row;
-                        c < P_SUB_TILE; c += THREADS_PER_ROW) {
-                        if (c >= sub_valid_k_rows) {
-                            sP[pipeline_swizzled_matrix_a_offset(row, c)] =
-                                __float2half(0.0f);
-                        }
-                    }
-
-                    if (block_n > 0 || sub_start > 0) {
-                        float4* sO_vec = reinterpret_cast<float4*>(
-                            sO + row * O_STRIDE);
-                        #pragma unroll 4
-                        for (int ov = thread_in_row; ov < D / 4;
-                             ov += THREADS_PER_ROW) {
-                            float4 v = sO_vec[ov];
-                            v.x *= exp_diff;
-                            v.y *= exp_diff;
-                            v.z *= exp_diff;
-                            v.w *= exp_diff;
-                            sO_vec[ov] = v;
-                        }
-                    }
-                    __syncthreads();
-
-                    if (sub_start == 0) {
-                        if (warp_id < BLOCK_N / WMMA_N) {
-                            pipeline_qk_slice<
-                                Q_STRIDE, S_STRIDE, D / WMMA_K, IS_CAUSAL,
-                                true>(
-                                sQ, score_next, k_cache_h, page_idx_next,
-                                page_offset_next, k_block_stride,
-                                k_token_stride, k_head_stride, kv_head_id,
-                                next_start_col, next_valid_k_rows, start_row,
-                                valid_q_rows, causal_q_offset,
-                                warp_id * WMMA_N, 0, false, true,
-                                softmax_scale, window_size_left,
-                                window_size_right, NEG_INF);
-                        } else {
-                            const int pv_warp =
-                                warp_id - BLOCK_N / WMMA_N;
-                            pipeline_pv_tile<P_STRIDE, O_STRIDE, true>(
-                                sP, sO, v_cache_h, page_idx_current,
-                                page_offset_current, v_block_stride,
-                                v_token_stride, v_head_stride, kv_head_id,
-                                sub_start, sub_valid_k_rows,
-                                pv_warp * WMMA_N);
-                            pipeline_pv_tile<P_STRIDE, O_STRIDE, true>(
-                                sP, sO, v_cache_h, page_idx_current,
-                                page_offset_current, v_block_stride,
-                                v_token_stride, v_head_stride, kv_head_id,
-                                sub_start, sub_valid_k_rows,
-                                (pv_warp + BLOCK_N / WMMA_N) * WMMA_N);
-                        }
-                    } else {
-                        pipeline_pv_tile<P_STRIDE, O_STRIDE, true>(
-                            sP, sO, v_cache_h, page_idx_current,
-                            page_offset_current, v_block_stride,
-                            v_token_stride, v_head_stride, kv_head_id,
-                            sub_start, sub_valid_k_rows, warp_id * WMMA_N);
-                    }
-                    __syncthreads();
-                }
-
-            }
-            cross_block_first_n_tile = steady_n_tiles;
-        }
-    }
-
-    int first_n_tile = cross_block_first_n_tile;
-    int last_n_tile = num_n_tiles;
-    if constexpr (SPLIT_KV) {
-        const int partition_id = blockIdx.y;
-        const int tiles_per_partition =
-            split_kv_tiles > 1 ? split_kv_tiles : 1;
-        first_n_tile = partition_id * tiles_per_partition;
-        last_n_tile = min(num_n_tiles, first_n_tile + tiles_per_partition);
-    }
-
-    for (int block_n = first_n_tile; block_n < last_n_tile; ++block_n) {
-        const int start_col = block_n * BLOCK_N;
-        if (start_col >= actual_N) break;
-        const int valid_k_rows = min(BLOCK_N, actual_N - start_col);
-
-        if (start_col + valid_k_rows <= min_key_pos) {
-            continue;
-        }
-
-        if (bfla_block_mask != nullptr && bfla_mask_block_n > 0) {
-            const int mask_q_idx = start_row / bfla_mask_block_n;
-            const int mask_k_idx = start_col / bfla_mask_block_n;
-            const int keep_tile = __ldg(
-                bfla_block_mask
-                + (int64_t)batch_id * bfla_mask_stride_b
-                + (int64_t)kv_head_id * bfla_mask_stride_h
-                + (int64_t)mask_q_idx * bfla_mask_stride_q
-                + (int64_t)mask_k_idx * bfla_mask_stride_k);
-            if (keep_tile == 0) {
-                continue;
-            }
-        }
-
-        const int partial_block_size = (block_n == num_n_tiles - 1 && actual_N % BLOCK_N != 0)
-                                       ? (actual_N % BLOCK_N) : -1;
-
-        uint4* sK_vec = reinterpret_cast<uint4*>(sK);
-        const int64_t row_stride_uint4 = k_row_stride / PER_UINT4;
-        const int start_page = start_col / page_block_size;
-        const int page_offset = start_col % page_block_size;
-        const bool single_page_tile =
-            (page_offset + valid_k_rows) <= page_block_size;
-        const bool two_page_tile =
-            !single_page_tile &&
-            (page_offset + valid_k_rows) <= (page_block_size * 2);
-        const int first_page_rows =
-            single_page_tile ? valid_k_rows
-                             : min(valid_k_rows, page_block_size - page_offset);
-        const int second_page_rows = valid_k_rows - first_page_rows;
-        const int physical_block_idx0 = __ldg(&block_table_seq[start_page]);
-        const int physical_block_idx1 =
-            second_page_rows > 0 ? __ldg(&block_table_seq[start_page + 1]) : -1;
-        const bool four_page_aligned_tile =
-            D == 256 && page_block_size == 16 && page_offset == 0
-            && BLOCK_N == page_block_size * 4
-            && valid_k_rows == BLOCK_N
-            && k_block_stride == (int64_t)page_block_size * k_token_stride
-            && v_block_stride == (int64_t)page_block_size * v_token_stride;
-        const int physical_block_idx2 =
-            four_page_aligned_tile ? __ldg(&block_table_seq[start_page + 2]) : -1;
-        const int physical_block_idx3 =
-            four_page_aligned_tile ? __ldg(&block_table_seq[start_page + 3]) : -1;
-        const bool four_page_contiguous_tile =
-            four_page_aligned_tile
-            && physical_block_idx1 == physical_block_idx0 + 1
-            && physical_block_idx2 == physical_block_idx0 + 2
-            && physical_block_idx3 == physical_block_idx0 + 3;
-        bool low_smem_contiguous_page_tile = false;
-        if constexpr (LOW_SMEM) {
-            static_assert(D == 256, "low-smem paged prefill is D=256 only");
-            static_assert(KV_DTYPE == flash_v100::KV_CACHE_DTYPE_FP16,
-                          "low-smem paged prefill is fp16-KV only");
-            static_assert(BLOCK_N % LOW_SMEM_PAGE_SIZE == 0,
-                          "low-smem BLOCK_N must be page aligned");
-
-            constexpr int LOW_SMEM_PAGE_COUNT =
-                Config::LOW_SMEM_PAGE_COUNT;
-            if (tid < LOW_SMEM_PAGE_COUNT) {
-                const int page_token_offset = tid * LOW_SMEM_PAGE_SIZE;
-                if (page_token_offset < valid_k_rows) {
-                    const int global_token_idx =
-                        start_col + page_token_offset;
-                    const int virtual_block_idx =
-                        global_token_idx / page_block_size;
-                    sPageIdx[tid] = __ldg(
-                        &block_table_seq[virtual_block_idx]);
-                    sPageOffset[tid] =
-                        global_token_idx
-                        - virtual_block_idx * page_block_size;
-                } else {
-                    sPageIdx[tid] = -1;
-                    sPageOffset[tid] = 0;
-                }
-            }
-            __syncthreads();
-
-            if constexpr (LOW_SMEM_CONTIG_FAST) {
-                low_smem_contiguous_page_tile =
-                    valid_k_rows == BLOCK_N
-                    && k_block_stride
-                        == (int64_t)page_block_size * k_token_stride
-                    && v_block_stride
-                        == (int64_t)page_block_size * v_token_stride
-                    && sPageIdx[0] >= 0;
-                #pragma unroll
-                for (int i = 1; i < LOW_SMEM_PAGE_COUNT; ++i) {
-                    const int linear_offset =
-                        sPageOffset[0] + i * LOW_SMEM_PAGE_SIZE;
-                    const int expected_page_delta =
-                        linear_offset / page_block_size;
-                    const int expected_page_offset =
-                        linear_offset
-                        - expected_page_delta * page_block_size;
-                    low_smem_contiguous_page_tile =
-                        low_smem_contiguous_page_tile
-                        && sPageIdx[i] == sPageIdx[0] + expected_page_delta
-                        && sPageOffset[i] == expected_page_offset;
-                }
-            } else {
-                low_smem_contiguous_page_tile = false;
+              is_window_valid = is_window_valid &&
+                                global_n <= global_q_pos + window_size_right;
             }
 
-            const __half* K_cache_h = reinterpret_cast<const __half*>(K_cache);
-
-            if constexpr (LOW_SMEM_SCALAR_QK) {
-                uint4* sK_vec = reinterpret_cast<uint4*>(sK);
-                for (int idx = tid; idx < valid_k_rows * d_stride_uint4;
-                     idx += THREADS_PER_BLOCK) {
-                    const int row = idx / d_stride_uint4;
-                    const int vec_col = idx % d_stride_uint4;
-                    uint4 k_val = make_uint4(0, 0, 0, 0);
-                    if (row < valid_k_rows && vec_col < d_stride_uint4) {
-                        const int page_slot = row >> 4;
-                        const int block_offset =
-                            sPageOffset[page_slot]
-                            + (row - page_slot * LOW_SMEM_PAGE_SIZE);
-                        const int physical_block_idx_direct =
-                            sPageIdx[page_slot];
-                        const __half* k_row_ptr;
-                        if constexpr (LOW_SMEM_CONTIG_FAST) {
-                            k_row_ptr =
-                                low_smem_contiguous_page_tile
-                                    ? K_cache_h
-                                          + (int64_t)sPageIdx[0] * k_block_stride
-                                          + (int64_t)(sPageOffset[0] + row)
-                                                * k_token_stride
-                                          + (int64_t)kv_head_id * k_head_stride
-                                    : K_cache_h
-                                          + (int64_t)physical_block_idx_direct
-                                                * k_block_stride
-                                          + (int64_t)block_offset
-                                                * k_token_stride
-                                          + (int64_t)kv_head_id * k_head_stride;
-                        } else {
-                            k_row_ptr =
-                                K_cache_h
-                                + (int64_t)physical_block_idx_direct
-                                      * k_block_stride
-                                + (int64_t)block_offset * k_token_stride
-                                + (int64_t)kv_head_id * k_head_stride;
-                        }
-                        const uint4* k_row_vec =
-                            reinterpret_cast<const uint4*>(k_row_ptr);
-                        k_val = __ldg(&k_row_vec[vec_col]);
-                    }
-                    sK_vec[row * kv_stride_uint4 + vec_col] = k_val;
-                }
-                __syncthreads();
-
-                const int total_scores = valid_q_rows * valid_k_rows;
-                for (int idx = tid; idx < total_scores;
-                     idx += THREADS_PER_BLOCK) {
-                    const int row = idx / valid_k_rows;
-                    const int col = idx - row * valid_k_rows;
-                    const int global_m = start_row + row;
-                    const int global_n = start_col + col;
-                    const int global_q_pos = global_m + causal_q_offset;
-
-                    bool is_valid = true;
-                    if constexpr (IS_CAUSAL) {
-                        is_valid = global_n <= global_q_pos;
-                    }
-                    if (window_size_left >= 0) {
-                        is_valid =
-                            is_valid
-                            && global_n >= global_q_pos - window_size_left;
-                    }
-                    if (window_size_right >= 0) {
-                        is_valid =
-                            is_valid
-                            && global_n <= global_q_pos + window_size_right;
-                    }
-
-                    float acc = 0.0f;
-                    if (is_valid) {
-                        #pragma unroll 8
-                        for (int d = 0; d < D; d += 2) {
-                            const __half2 q_h2 =
-                                *reinterpret_cast<const __half2*>(
-                                    sQ + row * Q_STRIDE + d);
-                            const __half2 k_h2 =
-                                *reinterpret_cast<const __half2*>(
-                                    sK + col * KV_STRIDE + d);
-                            const float2 q_f2 = __half22float2(q_h2);
-                            const float2 k_f2 = __half22float2(k_h2);
-                            acc = fmaf(q_f2.x, k_f2.x, acc);
-                            acc = fmaf(q_f2.y, k_f2.y, acc);
-                        }
-                    }
-                    sS[row * S_STRIDE + col] =
-                        is_valid ? acc * softmax_scale : NEG_INF;
-                }
-            } else if constexpr (D256_SW_PIPELINE_QK) {
-                constexpr int QK_TILES = BLOCK_N / WMMA_N;
-                if (warp_id < QK_TILES) {
-                    pipeline_qk_slice<Q_STRIDE, S_STRIDE, D / WMMA_K,
-                                      IS_CAUSAL, D256_SW_PIPELINE_PV>(
-                        sQ, sS, K_cache_h, sPageIdx, sPageOffset,
-                        k_block_stride, k_token_stride, k_head_stride,
-                        kv_head_id, start_col, valid_k_rows, start_row,
-                        valid_q_rows, causal_q_offset, warp_id * WMMA_N, 0,
-                        false, true, softmax_scale, window_size_left,
-                        window_size_right, NEG_INF);
-                }
-            } else {
-                const int num_tiles_m_qk = (BLOCK_M + WMMA_M - 1) / WMMA_M;
-                const int num_tiles_n_qk = (BLOCK_N + WMMA_N - 1) / WMMA_N;
-                const int num_tiles_k_qk = (D + WMMA_K - 1) / WMMA_K;
-                const int total_tiles_qk = num_tiles_m_qk * num_tiles_n_qk;
-                const int tiles_per_warp_qk =
-                    (total_tiles_qk + WARPS_PER_BLOCK - 1) / WARPS_PER_BLOCK;
-                const unsigned row_causal =
-                    (lane_id & 0b1) + ((lane_id >> 2) & 0b1) * 8
-                    + ((lane_id >> 4) & 0b1) * 4;
-                const unsigned col_causal =
-                    ((lane_id >> 1) & 0b1) * 2 + ((lane_id >> 3) & 0b1) * 8;
-
-                for (int tile_idx = 0; tile_idx < tiles_per_warp_qk;
-                     ++tile_idx) {
-                    const int global_tile_idx =
-                        warp_id * tiles_per_warp_qk + tile_idx;
-                    if (global_tile_idx >= total_tiles_qk) break;
-
-                    const int tile_m_idx = global_tile_idx / num_tiles_n_qk;
-                    const int tile_n_idx = global_tile_idx % num_tiles_n_qk;
-
-                    const int tile_m = tile_m_idx * WMMA_M;
-                    const int tile_n = tile_n_idx * WMMA_N;
-
-                    if (tile_m >= valid_q_rows || tile_n >= valid_k_rows) {
-                        continue;
-                    }
-
-                    const int page_slot = tile_n >> 4;
-                    const int block_offset = sPageOffset[page_slot];
-                    const int physical_block_idx_direct = sPageIdx[page_slot];
-
-                    fragment<matrix_a, WMMA_M, WMMA_N, WMMA_K, half, row_major>
-                        a_frag;
-                    fragment<matrix_b, WMMA_M, WMMA_N, WMMA_K, half, col_major>
-                        b_frag;
-                    fragment<accumulator, WMMA_M, WMMA_N, WMMA_K, float>
-                        acc_frag;
-                    fill_fragment(acc_frag, 0.0f);
-
-                    #pragma unroll
-                    for (int k_tile = 0; k_tile < num_tiles_k_qk; ++k_tile) {
-                        const int k_offset = k_tile * WMMA_K;
-                        if (k_offset >= D) break;
-
-                        const __half* k_tile_ptr;
-                        if constexpr (LOW_SMEM_CONTIG_FAST) {
-                            k_tile_ptr =
-                                low_smem_contiguous_page_tile
-                                    ? K_cache_h
-                                          + (int64_t)sPageIdx[0] * k_block_stride
-                                          + (int64_t)(sPageOffset[0] + tile_n)
-                                                * k_token_stride
-                                          + (int64_t)kv_head_id * k_head_stride
-                                          + k_offset
-                                    : K_cache_h
-                                          + (int64_t)physical_block_idx_direct
-                                                * k_block_stride
-                                          + (int64_t)block_offset
-                                                * k_token_stride
-                                          + (int64_t)kv_head_id * k_head_stride
-                                          + k_offset;
-                        } else {
-                            k_tile_ptr =
-                                K_cache_h
-                                + (int64_t)physical_block_idx_direct
-                                      * k_block_stride
-                                + (int64_t)block_offset * k_token_stride
-                                + (int64_t)kv_head_id * k_head_stride
-                                + k_offset;
-                        }
-
-                        load_matrix_sync(
-                            a_frag,
-                            sQ + tile_m * Q_STRIDE + k_offset,
-                            Q_STRIDE);
-                        load_matrix_sync(b_frag, k_tile_ptr, k_token_stride);
-                        mma_sync(acc_frag, a_frag, b_frag, acc_frag);
-                    }
-
-                    #pragma unroll
-                    for (int i = 0; i < acc_frag.num_elements; ++i) {
-                        const unsigned col =
-                            col_causal + (i & 0b1) + ((i >> 2) & 0b1) * 4;
-                        const unsigned row =
-                            row_causal + ((i >> 1) & 0b1) * 2;
-
-                        const int global_m = start_row + tile_m + row;
-                        const int global_n = start_col + tile_n + col;
-                        const int global_q_pos = global_m + causal_q_offset;
-
-                        const bool is_valid =
-                            (global_m < start_row + valid_q_rows)
-                            && (global_n < start_col + valid_k_rows);
-                        bool is_causal_valid = true;
-                        if constexpr (IS_CAUSAL) {
-                            is_causal_valid = global_n <= global_q_pos;
-                        }
-                        bool is_window_valid = true;
-                        if (window_size_left >= 0) {
-                            is_window_valid =
-                                is_window_valid
-                                && global_n
-                                       >= global_q_pos - window_size_left;
-                        }
-                        if (window_size_right >= 0) {
-                            is_window_valid =
-                                is_window_valid
-                                && global_n
-                                       <= global_q_pos + window_size_right;
-                        }
-
-                        acc_frag.x[i] =
-                            (is_valid && is_causal_valid && is_window_valid)
+            acc_frag.x[i] = (is_valid && is_causal_valid && is_window_valid)
                                 ? acc_frag.x[i] * softmax_scale
                                 : NEG_INF;
-                    }
+          }
 
-                    store_matrix_sync(
-                        sS + tile_m * S_STRIDE + tile_n, acc_frag, S_STRIDE,
-                        mem_row_major);
-                }
-            }
-            __syncthreads();
-        } else {
-        if constexpr (KV_DTYPE == flash_v100::KV_CACHE_DTYPE_FP16) {
-            const __half* K_cache_h = reinterpret_cast<const __half*>(K_cache);
-            const uint4* k_page0_vec = reinterpret_cast<const uint4*>(
-                K_cache_h + (int64_t)physical_block_idx0 * k_block_stride
-                + (int64_t)page_offset * k_token_stride
-                + (int64_t)kv_head_id * k_head_stride);
-            const uint4* k_page1_vec =
-                two_page_tile && second_page_rows > 0
-                    ? reinterpret_cast<const uint4*>(
-                          K_cache_h + (int64_t)physical_block_idx1 * k_block_stride
-                          + (int64_t)kv_head_id * k_head_stride)
-                    : nullptr;
-
-            #pragma unroll 2
-            for (int idx = tid; idx < (valid_k_rows * d_stride_uint4);
-                 idx += THREADS_PER_BLOCK) {
-                const int row = idx / d_stride_uint4;
-                const int vec_col = idx % d_stride_uint4;
-
-                uint4 k_val = make_uint4(0, 0, 0, 0);
-                if (row < valid_k_rows && vec_col < d_stride_uint4) {
-                    if (four_page_contiguous_tile) {
-                        k_val = __ldg(
-                            &k_page0_vec[row * row_stride_uint4 + vec_col]);
-                    } else if (single_page_tile) {
-                        k_val = __ldg(&k_page0_vec[row * row_stride_uint4 + vec_col]);
-                    } else if (two_page_tile) {
-                        if (row < first_page_rows) {
-                            k_val = __ldg(
-                                &k_page0_vec[row * row_stride_uint4 + vec_col]);
-                        } else {
-                            const int row_page1 = row - first_page_rows;
-                            k_val = __ldg(
-                                &k_page1_vec[row_page1 * row_stride_uint4 + vec_col]);
-                        }
-                    } else {
-                        const uint4* k_vec = reinterpret_cast<const uint4*>(K_cache_h);
-                        const int global_token_idx = start_col + row;
-                        const int virtual_block_idx =
-                            global_token_idx / page_block_size;
-                        const int block_offset = global_token_idx % page_block_size;
-                        const int physical_block_idx_slow =
-                            __ldg(&block_table_seq[virtual_block_idx]);
-                        const int64_t physical_offset_halfs =
-                            (int64_t)physical_block_idx_slow * k_block_stride
-                            + (int64_t)block_offset * k_token_stride
-                            + (int64_t)kv_head_id * k_head_stride;
-                        const int64_t physical_offset_uint4 =
-                            (physical_offset_halfs / PER_UINT4) + vec_col;
-                        k_val = __ldg(&k_vec[physical_offset_uint4]);
-                    }
-                }
-                sK_vec[row * kv_stride_uint4 + vec_col] = k_val;
-            }
-        } else {
-            for (int idx = tid; idx < valid_k_rows * D; idx += THREADS_PER_BLOCK) {
-                const int row = idx / D;
-                const int col = idx % D;
-                const int global_token_idx = start_col + row;
-                const int virtual_block_idx = global_token_idx / page_block_size;
-                const int block_offset = global_token_idx % page_block_size;
-                const int physical_block_idx_slow =
-                    __ldg(&block_table_seq[virtual_block_idx]);
-                const int64_t physical_offset =
-                    (int64_t)physical_block_idx_slow * k_block_stride
-                    + (int64_t)block_offset * k_token_stride
-                    + (int64_t)kv_head_id * k_head_stride + col;
-                sK[row * KV_STRIDE + col] =
-                    flash_v100::load_kv_cache_half<KV_DTYPE>(
-                        K_cache, physical_offset, k_scale);
-            }
+          store_matrix_sync(sS + tile_m * S_STRIDE + tile_n, acc_frag, S_STRIDE,
+                            mem_row_major);
         }
-        __syncthreads();
+      }
+      __syncthreads();
+    } else {
+      if constexpr (KV_DTYPE == flash_v100::KV_CACHE_DTYPE_FP16) {
+        const __half* K_cache_h = reinterpret_cast<const __half*>(K_cache);
+        const uint4* k_page0_vec = reinterpret_cast<const uint4*>(
+            K_cache_h + (int64_t)physical_block_idx0 * k_block_stride +
+            (int64_t)page_offset * k_token_stride +
+            (int64_t)kv_head_id * k_head_stride);
+        const uint4* k_page1_vec =
+            two_page_tile && second_page_rows > 0
+                ? reinterpret_cast<const uint4*>(
+                      K_cache_h +
+                      (int64_t)physical_block_idx1 * k_block_stride +
+                      (int64_t)kv_head_id * k_head_stride)
+                : nullptr;
 
-        const int num_tiles_m_qk    = (BLOCK_M + WMMA_M - 1) / WMMA_M;
-        const int num_tiles_n_qk    = (BLOCK_N + WMMA_N - 1) / WMMA_N;
-        const int num_tiles_k_qk    = (D + WMMA_K - 1) / WMMA_K;
-        const int total_tiles_qk    = num_tiles_m_qk * num_tiles_n_qk;
-        const int tiles_per_warp_qk = (total_tiles_qk + WARPS_PER_BLOCK - 1) / WARPS_PER_BLOCK;
-        const unsigned row_causal   = (lane_id & 0b1) + ((lane_id >> 2) & 0b1) * 8 + ((lane_id >> 4) & 0b1) * 4;
-        const unsigned col_causal   = ((lane_id >> 1) & 0b1) * 2 + ((lane_id >> 3) & 0b1) * 8;
+#pragma unroll 2
+        for (int idx = tid; idx < (valid_k_rows * d_stride_uint4);
+             idx += THREADS_PER_BLOCK) {
+          const int row = idx / d_stride_uint4;
+          const int vec_col = idx % d_stride_uint4;
 
-        for (int tile_idx = 0; tile_idx < tiles_per_warp_qk; ++tile_idx) {
-            const int global_tile_idx = warp_id * tiles_per_warp_qk + tile_idx;
-            if (global_tile_idx >= total_tiles_qk) break;
-
-            const int tile_m_idx = global_tile_idx / num_tiles_n_qk;
-            const int tile_n_idx = global_tile_idx % num_tiles_n_qk;
-
-            const int tile_m = tile_m_idx * WMMA_M;
-            const int tile_n = tile_n_idx * WMMA_N;
-
-            if (tile_m >= valid_q_rows || tile_n >= valid_k_rows) continue;
-
-            fragment<matrix_a, WMMA_M, WMMA_N, WMMA_K, half, row_major> a_frag;
-            fragment<matrix_b, WMMA_M, WMMA_N, WMMA_K, half, col_major> b_frag;
-            fragment<accumulator, WMMA_M, WMMA_N, WMMA_K, float> acc_frag;
-            fill_fragment(acc_frag, 0.0f);
-
-            #pragma unroll
-            for (int k_tile = 0; k_tile < num_tiles_k_qk; ++k_tile) {
-                const int k_offset = k_tile * WMMA_K;
-                if (k_offset >= D) break;
-
-                load_matrix_sync(a_frag, sQ + tile_m * Q_STRIDE + k_offset, Q_STRIDE);
-                load_matrix_sync(b_frag, sK + tile_n * KV_STRIDE + k_offset, KV_STRIDE);
-                mma_sync(acc_frag, a_frag, b_frag, acc_frag);
+          uint4 k_val = make_uint4(0, 0, 0, 0);
+          if (row < valid_k_rows && vec_col < d_stride_uint4) {
+            if (four_page_contiguous_tile) {
+              k_val = __ldg(&k_page0_vec[row * row_stride_uint4 + vec_col]);
+            } else if (single_page_tile) {
+              k_val = __ldg(&k_page0_vec[row * row_stride_uint4 + vec_col]);
+            } else if (two_page_tile) {
+              if (row < first_page_rows) {
+                k_val = __ldg(&k_page0_vec[row * row_stride_uint4 + vec_col]);
+              } else {
+                const int row_page1 = row - first_page_rows;
+                k_val =
+                    __ldg(&k_page1_vec[row_page1 * row_stride_uint4 + vec_col]);
+              }
+            } else {
+              const uint4* k_vec = reinterpret_cast<const uint4*>(K_cache_h);
+              const int global_token_idx = start_col + row;
+              const int virtual_block_idx = global_token_idx / page_block_size;
+              const int block_offset = global_token_idx % page_block_size;
+              const int physical_block_idx_slow =
+                  __ldg(&block_table_seq[virtual_block_idx]);
+              const int64_t physical_offset_halves =
+                  (int64_t)physical_block_idx_slow * k_block_stride +
+                  (int64_t)block_offset * k_token_stride +
+                  (int64_t)kv_head_id * k_head_stride;
+              const int64_t physical_offset_uint4 =
+                  (physical_offset_halves / PER_UINT4) + vec_col;
+              k_val = __ldg(&k_vec[physical_offset_uint4]);
             }
-
-            #pragma unroll
-            for (int i = 0; i < acc_frag.num_elements; ++i) {
-                const unsigned col = col_causal + (i & 0b1) + ((i >> 2) & 0b1) * 4;
-                const unsigned row = row_causal + ((i >> 1) & 0b1) * 2;
-
-                const int global_m = start_row + tile_m + row;
-                const int global_n = start_col + tile_n + col;
-                const int global_q_pos = global_m + causal_q_offset;
-
-                const bool is_valid = (global_m < start_row + valid_q_rows) &&
-                                      (global_n < start_col + valid_k_rows);
-                bool is_causal_valid = true;
-                if constexpr (IS_CAUSAL) {
-                    is_causal_valid = global_n <= global_q_pos;
-                }
-                bool is_window_valid = true;
-                if (window_size_left >= 0) {
-                    is_window_valid = is_window_valid &&
-                                      global_n >= global_q_pos - window_size_left;
-                }
-                if (window_size_right >= 0) {
-                    is_window_valid = is_window_valid &&
-                                      global_n <= global_q_pos + window_size_right;
-                }
-
-                acc_frag.x[i] = (is_valid && is_causal_valid && is_window_valid)
-                    ? acc_frag.x[i] * softmax_scale
-                    : NEG_INF;
-            }
-
-            store_matrix_sync(sS + tile_m * S_STRIDE + tile_n, acc_frag, S_STRIDE, mem_row_major);
+          }
+          sK_vec[row * kv_stride_uint4 + vec_col] = k_val;
         }
-        __syncthreads();
+      } else {
+        for (int idx = tid; idx < valid_k_rows * D; idx += THREADS_PER_BLOCK) {
+          const int row = idx / D;
+          const int col = idx % D;
+          const int global_token_idx = start_col + row;
+          const int virtual_block_idx = global_token_idx / page_block_size;
+          const int block_offset = global_token_idx % page_block_size;
+          const int physical_block_idx_slow =
+              __ldg(&block_table_seq[virtual_block_idx]);
+          const int64_t physical_offset =
+              (int64_t)physical_block_idx_slow * k_block_stride +
+              (int64_t)block_offset * k_token_stride +
+              (int64_t)kv_head_id * k_head_stride + col;
+          sK[row * KV_STRIDE + col] = flash_v100::load_kv_cache_half<KV_DTYPE>(
+              K_cache, physical_offset, k_scale);
+        }
+      }
+      __syncthreads();
+
+      const int num_tiles_m_qk = (BLOCK_M + WMMA_M - 1) / WMMA_M;
+      const int num_tiles_n_qk = (BLOCK_N + WMMA_N - 1) / WMMA_N;
+      const int num_tiles_k_qk = (D + WMMA_K - 1) / WMMA_K;
+      const int total_tiles_qk = num_tiles_m_qk * num_tiles_n_qk;
+      const int tiles_per_warp_qk =
+          (total_tiles_qk + WARPS_PER_BLOCK - 1) / WARPS_PER_BLOCK;
+      const unsigned row_causal = (lane_id & 0b1) + ((lane_id >> 2) & 0b1) * 8 +
+                                  ((lane_id >> 4) & 0b1) * 4;
+      const unsigned col_causal =
+          ((lane_id >> 1) & 0b1) * 2 + ((lane_id >> 3) & 0b1) * 8;
+
+      for (int tile_idx = 0; tile_idx < tiles_per_warp_qk; ++tile_idx) {
+        const int global_tile_idx = warp_id * tiles_per_warp_qk + tile_idx;
+        if (global_tile_idx >= total_tiles_qk) break;
+
+        const int tile_m_idx = global_tile_idx / num_tiles_n_qk;
+        const int tile_n_idx = global_tile_idx % num_tiles_n_qk;
+
+        const int tile_m = tile_m_idx * WMMA_M;
+        const int tile_n = tile_n_idx * WMMA_N;
+
+        if (tile_m >= valid_q_rows || tile_n >= valid_k_rows) continue;
+
+        fragment<matrix_a, WMMA_M, WMMA_N, WMMA_K, half, row_major> a_frag;
+        fragment<matrix_b, WMMA_M, WMMA_N, WMMA_K, half, col_major> b_frag;
+        fragment<accumulator, WMMA_M, WMMA_N, WMMA_K, float> acc_frag;
+        fill_fragment(acc_frag, 0.0f);
+
+#pragma unroll
+        for (int k_tile = 0; k_tile < num_tiles_k_qk; ++k_tile) {
+          const int k_offset = k_tile * WMMA_K;
+          if (k_offset >= D) break;
+
+          load_matrix_sync(a_frag, sQ + tile_m * Q_STRIDE + k_offset, Q_STRIDE);
+          load_matrix_sync(b_frag, sK + tile_n * KV_STRIDE + k_offset,
+                           KV_STRIDE);
+          mma_sync(acc_frag, a_frag, b_frag, acc_frag);
         }
 
-        uint4* sV_vec = reinterpret_cast<uint4*>(sV);
-        const int64_t v_row_stride_uint4 = v_row_stride / PER_UINT4;
-        if constexpr (!LOW_SMEM) {
-        if constexpr (KV_DTYPE == flash_v100::KV_CACHE_DTYPE_FP16) {
+#pragma unroll
+        for (int i = 0; i < acc_frag.num_elements; ++i) {
+          const unsigned col = col_causal + (i & 0b1) + ((i >> 2) & 0b1) * 4;
+          const unsigned row = row_causal + ((i >> 1) & 0b1) * 2;
+
+          const int global_m = start_row + tile_m + row;
+          const int global_n = start_col + tile_n + col;
+          const int global_q_pos = global_m + causal_q_offset;
+
+          const bool is_valid = (global_m < start_row + valid_q_rows) &&
+                                (global_n < start_col + valid_k_rows);
+          bool is_causal_valid = true;
+          if constexpr (IS_CAUSAL) {
+            is_causal_valid = global_n <= global_q_pos;
+          }
+          bool is_window_valid = true;
+          if (window_size_left >= 0) {
+            is_window_valid =
+                is_window_valid && global_n >= global_q_pos - window_size_left;
+          }
+          if (window_size_right >= 0) {
+            is_window_valid =
+                is_window_valid && global_n <= global_q_pos + window_size_right;
+          }
+
+          acc_frag.x[i] = (is_valid && is_causal_valid && is_window_valid)
+                              ? acc_frag.x[i] * softmax_scale
+                              : NEG_INF;
+        }
+
+        store_matrix_sync(sS + tile_m * S_STRIDE + tile_n, acc_frag, S_STRIDE,
+                          mem_row_major);
+      }
+      __syncthreads();
+    }
+
+    uint4* sV_vec = reinterpret_cast<uint4*>(sV);
+    const int64_t v_row_stride_uint4 = v_row_stride / PER_UINT4;
+    if constexpr (!LOW_SMEM) {
+      if constexpr (KV_DTYPE == flash_v100::KV_CACHE_DTYPE_FP16) {
+        const __half* V_cache_h = reinterpret_cast<const __half*>(V_cache);
+        const uint4* v_page0_vec = reinterpret_cast<const uint4*>(
+            V_cache_h + (int64_t)physical_block_idx0 * v_block_stride +
+            (int64_t)page_offset * v_token_stride +
+            (int64_t)kv_head_id * v_head_stride);
+        const uint4* v_page1_vec =
+            two_page_tile && second_page_rows > 0
+                ? reinterpret_cast<const uint4*>(
+                      V_cache_h +
+                      (int64_t)physical_block_idx1 * v_block_stride +
+                      (int64_t)kv_head_id * v_head_stride)
+                : nullptr;
+
+#pragma unroll 2
+        for (int idx = tid; idx < (valid_k_rows * d_stride_uint4);
+             idx += THREADS_PER_BLOCK) {
+          const int row = idx / d_stride_uint4;
+          const int vec_col = idx % d_stride_uint4;
+
+          uint4 v_val = make_uint4(0, 0, 0, 0);
+          if (row < valid_k_rows && vec_col < d_stride_uint4) {
+            if (four_page_contiguous_tile) {
+              v_val = __ldg(&v_page0_vec[row * v_row_stride_uint4 + vec_col]);
+            } else if (single_page_tile) {
+              v_val = __ldg(&v_page0_vec[row * v_row_stride_uint4 + vec_col]);
+            } else if (two_page_tile) {
+              if (row < first_page_rows) {
+                v_val = __ldg(&v_page0_vec[row * v_row_stride_uint4 + vec_col]);
+              } else {
+                const int row_page1 = row - first_page_rows;
+                v_val = __ldg(
+                    &v_page1_vec[row_page1 * v_row_stride_uint4 + vec_col]);
+              }
+            } else {
+              const uint4* v_vec = reinterpret_cast<const uint4*>(V_cache_h);
+              const int global_token_idx = start_col + row;
+              const int virtual_block_idx = global_token_idx / page_block_size;
+              const int block_offset = global_token_idx % page_block_size;
+              const int physical_block_idx_slow =
+                  __ldg(&block_table_seq[virtual_block_idx]);
+              const int64_t physical_offset_halves =
+                  (int64_t)physical_block_idx_slow * v_block_stride +
+                  (int64_t)block_offset * v_token_stride +
+                  (int64_t)kv_head_id * v_head_stride;
+              const int64_t physical_offset_uint4 =
+                  (physical_offset_halves / PER_UINT4) + vec_col;
+              v_val = __ldg(&v_vec[physical_offset_uint4]);
+            }
+          }
+          sV_vec[row * kv_stride_uint4 + vec_col] = v_val;
+        }
+      } else {
+        for (int idx = tid; idx < valid_k_rows * D; idx += THREADS_PER_BLOCK) {
+          const int row = idx / D;
+          const int col = idx % D;
+          const int global_token_idx = start_col + row;
+          const int virtual_block_idx = global_token_idx / page_block_size;
+          const int block_offset = global_token_idx % page_block_size;
+          const int physical_block_idx_slow =
+              __ldg(&block_table_seq[virtual_block_idx]);
+          const int64_t physical_offset =
+              (int64_t)physical_block_idx_slow * v_block_stride +
+              (int64_t)block_offset * v_token_stride +
+              (int64_t)kv_head_id * v_head_stride + col;
+          sV[row * KV_STRIDE + col] = flash_v100::load_kv_cache_half<KV_DTYPE>(
+              V_cache, physical_offset, v_scale);
+        }
+      }
+      __syncthreads();
+    }
+
+    const int num_tiles_m_pv = (BLOCK_M + WMMA_M - 1) / WMMA_M;
+    const int num_tiles_n_pv = (D + WMMA_N - 1) / WMMA_N;
+    const int total_tiles_pv = num_tiles_m_pv * num_tiles_n_pv;
+    const int tiles_per_warp_pv =
+        (total_tiles_pv + WARPS_PER_BLOCK - 1) / WARPS_PER_BLOCK;
+    const int softmax_sub_tile = (D == 256) ? P_SUB_TILE : p_tile_capacity;
+
+    for (int sub_start = 0; sub_start < valid_k_rows;
+         sub_start += softmax_sub_tile) {
+      const int sub_valid_k_rows =
+          min(softmax_sub_tile, valid_k_rows - sub_start);
+
+      if (tid < valid_q_rows * THREADS_PER_ROW) {
+        const int row = tid / THREADS_PER_ROW;
+        const int thread_in_row = tid % THREADS_PER_ROW;
+        const unsigned mask =
+            (valid_q_rows == BLOCK_M) ? 0xFFFFFFFFU : __activemask();
+        const int row_leader = __ffs(mask) - 1;
+
+        float* sS_row_f = sS + row * S_STRIDE + sub_start;
+        __half* sP_row_h = sP + row * p_stride;
+
+        const int vec_cols = sub_valid_k_rows >> 2;
+        const int vecs_per_thread =
+            (vec_cols + THREADS_PER_ROW - 1) / THREADS_PER_ROW;
+        const int tail_start = vec_cols << 2;
+
+        float thread_max = NEG_INF;
+        float4* sS_vec4 = reinterpret_cast<float4*>(sS_row_f);
+
+#pragma unroll 4
+        for (int j = 0; j < vecs_per_thread; ++j) {
+          int vc = thread_in_row + j * THREADS_PER_ROW;
+          if (vc < vec_cols) {
+            float4 v4 = sS_vec4[vc];
+            thread_max =
+                fmaxf(thread_max, fmaxf(fmaxf(v4.x, v4.y), fmaxf(v4.z, v4.w)));
+          }
+        }
+
+#pragma unroll
+        for (int c = tail_start + thread_in_row; c < sub_valid_k_rows;
+             c += THREADS_PER_ROW) {
+          thread_max = fmaxf(thread_max, sS_row_f[c]);
+        }
+
+#pragma unroll
+        for (int o = THREADS_PER_ROW / 2; o > 0; o >>= 1) {
+          thread_max = fmaxf(thread_max, __shfl_down_sync(mask, thread_max, o,
+                                                          THREADS_PER_ROW));
+        }
+
+        const float row_max =
+            __shfl_sync(mask, thread_max, row_leader, THREADS_PER_ROW);
+        const float old_max = sRowMax[row];
+        const float new_max = fmaxf(old_max, row_max);
+        const float exp_diff = __expf(old_max - new_max);
+
+        float thread_sum = 0.0f;
+        __half2 half_buffer[20];
+        int vc_base = thread_in_row;
+        int h2_idx = 0;
+        int tail_col = -1;
+        __half tail_value = __float2half(0.f);
+        __half2* sP_half2 = reinterpret_cast<__half2*>(sP_row_h);
+
+#pragma unroll 4
+        for (int j = 0; j < vecs_per_thread; ++j, vc_base += THREADS_PER_ROW) {
+          if (vc_base < vec_cols) {
+            float4 v4 = sS_vec4[vc_base];
+
+            float e0 = __expf(fmaxf(v4.x - new_max, -80.0f));
+            float e1 = __expf(fmaxf(v4.y - new_max, -80.0f));
+            float e2 = __expf(fmaxf(v4.z - new_max, -80.0f));
+            float e3 = __expf(fmaxf(v4.w - new_max, -80.0f));
+
+            thread_sum += (e0 + e1) + (e2 + e3);
+
+            const __half2 p01 = __float22half2_rn(make_float2(e0, e1));
+            const __half2 p23 = __float22half2_rn(make_float2(e2, e3));
+            if constexpr (D256_SW_PIPELINE_PV) {
+              // D256 owns a separate probability buffer, so the
+              // values can leave registers before row reduction.
+              const int base_offset = vc_base * 2;
+              sP_half2[base_offset] = p01;
+              sP_half2[base_offset + 1] = p23;
+            } else {
+              half_buffer[h2_idx++] = p01;
+              half_buffer[h2_idx++] = p23;
+            }
+          }
+        }
+
+#pragma unroll 4
+        for (int c = tail_start + thread_in_row; c < sub_valid_k_rows;
+             c += THREADS_PER_ROW) {
+          float v = sS_row_f[c];
+          float e = __expf(fmaxf(v - new_max, -80.0f));
+          thread_sum += e;
+          if constexpr (D256_SW_PIPELINE_PV) {
+            sP_row_h[c] = __float2half_rn(e);
+          } else {
+            tail_col = c;
+            tail_value = __float2half_rn(e);
+          }
+        }
+
+#pragma unroll
+        for (int o = THREADS_PER_ROW / 2; o > 0; o >>= 1) {
+          thread_sum += __shfl_down_sync(mask, thread_sum, o, THREADS_PER_ROW);
+        }
+
+        float row_sum =
+            __shfl_sync(mask, thread_sum, row_leader, THREADS_PER_ROW);
+
+        if (thread_in_row == 0) {
+          sRowSum[row] = exp_diff * sRowSum[row] + row_sum;
+          sRowMax[row] = new_max;
+        }
+
+        if constexpr (!D256_SW_PIPELINE_PV) {
+          h2_idx = 0;
+          vc_base = thread_in_row;
+#pragma unroll 4
+          for (int j = 0; j < vecs_per_thread;
+               ++j, vc_base += THREADS_PER_ROW) {
+            if (vc_base < vec_cols) {
+              int base_offset = vc_base * 2;
+              sP_half2[base_offset] = half_buffer[h2_idx++];
+              sP_half2[base_offset + 1] = half_buffer[h2_idx++];
+            }
+          }
+
+          if (tail_col >= 0) {
+            sP_row_h[tail_col] = tail_value;
+          }
+        }
+
+#pragma unroll 4
+        for (int c = tail_start + thread_in_row; c < p_tile_capacity;
+             c += THREADS_PER_ROW) {
+          if (c >= sub_valid_k_rows) {
+            sP_row_h[c] = __float2half(0.f);
+          }
+        }
+
+        if (block_n > 0 || sub_start > 0) {
+          float* sO_row = sO + row * O_STRIDE;
+          float4* sO_vec = reinterpret_cast<float4*>(sO_row);
+          const int o_vec_count = D / 4;
+          float scale = exp_diff;
+
+#pragma unroll 4
+          for (int ov = thread_in_row; ov < o_vec_count;
+               ov += THREADS_PER_ROW) {
+            float4 v = sO_vec[ov];
+            v.x *= scale;
+            v.y *= scale;
+            v.z *= scale;
+            v.w *= scale;
+            sO_vec[ov] = v;
+          }
+        }
+      }
+      __syncthreads();
+
+      const int num_tiles_k_pv = (p_tile_capacity + WMMA_K - 1) / WMMA_K;
+
+      for (int tile_idx = 0; tile_idx < tiles_per_warp_pv; ++tile_idx) {
+        const int global_tile_idx = warp_id * tiles_per_warp_pv + tile_idx;
+        if (global_tile_idx >= total_tiles_pv) break;
+
+        const int tile_m_idx = global_tile_idx / num_tiles_n_pv;
+        const int tile_d_idx = global_tile_idx % num_tiles_n_pv;
+
+        const int tile_m = tile_m_idx * WMMA_M;
+        const int tile_d = tile_d_idx * WMMA_N;
+
+        if (tile_m >= valid_q_rows) continue;
+
+        fragment<matrix_a, WMMA_M, WMMA_N, WMMA_K, half, row_major> a_frag;
+        fragment<matrix_b, WMMA_M, WMMA_N, WMMA_K, half, row_major> b_frag;
+        fragment<accumulator, WMMA_M, WMMA_N, WMMA_K, float> acc_frag;
+
+        load_matrix_sync(acc_frag, sO + tile_m * O_STRIDE + tile_d, O_STRIDE,
+                         mem_row_major);
+
+#pragma unroll
+        for (int tile_k = 0; tile_k < num_tiles_k_pv; ++tile_k) {
+          const int k_offset = tile_k * WMMA_K;
+          if (k_offset >= sub_valid_k_rows) break;
+
+          load_matrix_sync(a_frag, sP + tile_m * p_stride + k_offset, p_stride);
+          if constexpr (LOW_SMEM) {
             const __half* V_cache_h = reinterpret_cast<const __half*>(V_cache);
-            const uint4* v_page0_vec = reinterpret_cast<const uint4*>(
-                V_cache_h + (int64_t)physical_block_idx0 * v_block_stride
-                + (int64_t)page_offset * v_token_stride
-                + (int64_t)kv_head_id * v_head_stride);
-            const uint4* v_page1_vec =
-                two_page_tile && second_page_rows > 0
-                    ? reinterpret_cast<const uint4*>(
-                          V_cache_h + (int64_t)physical_block_idx1 * v_block_stride
-                          + (int64_t)kv_head_id * v_head_stride)
-                    : nullptr;
-
-            #pragma unroll 2
-            for (int idx = tid; idx < (valid_k_rows * d_stride_uint4);
-                 idx += THREADS_PER_BLOCK) {
-                const int row = idx / d_stride_uint4;
-                const int vec_col = idx % d_stride_uint4;
-
-                uint4 v_val = make_uint4(0, 0, 0, 0);
-                if (row < valid_k_rows && vec_col < d_stride_uint4) {
-                    if (four_page_contiguous_tile) {
-                        v_val = __ldg(
-                            &v_page0_vec[row * v_row_stride_uint4 + vec_col]);
-                    } else if (single_page_tile) {
-                        v_val = __ldg(&v_page0_vec[row * v_row_stride_uint4 + vec_col]);
-                    } else if (two_page_tile) {
-                        if (row < first_page_rows) {
-                            v_val = __ldg(
-                                &v_page0_vec[row * v_row_stride_uint4 + vec_col]);
-                        } else {
-                            const int row_page1 = row - first_page_rows;
-                            v_val = __ldg(
-                                &v_page1_vec[row_page1 * v_row_stride_uint4 + vec_col]);
-                        }
-                    } else {
-                        const uint4* v_vec = reinterpret_cast<const uint4*>(V_cache_h);
-                        const int global_token_idx = start_col + row;
-                        const int virtual_block_idx =
-                            global_token_idx / page_block_size;
-                        const int block_offset = global_token_idx % page_block_size;
-                        const int physical_block_idx_slow =
-                            __ldg(&block_table_seq[virtual_block_idx]);
-                        const int64_t physical_offset_halfs =
-                            (int64_t)physical_block_idx_slow * v_block_stride
-                            + (int64_t)block_offset * v_token_stride
-                            + (int64_t)kv_head_id * v_head_stride;
-                        const int64_t physical_offset_uint4 =
-                            (physical_offset_halfs / PER_UINT4) + vec_col;
-                        v_val = __ldg(&v_vec[physical_offset_uint4]);
-                    }
-                }
-                sV_vec[row * kv_stride_uint4 + vec_col] = v_val;
+            const int token_offset = sub_start + k_offset;
+            const int page_slot = token_offset >> 4;
+            const int block_offset = sPageOffset[page_slot];
+            const int physical_block_idx_direct = sPageIdx[page_slot];
+            const __half* v_tile_ptr;
+            if constexpr (LOW_SMEM_CONTIG_FAST) {
+              v_tile_ptr =
+                  low_smem_contiguous_page_tile
+                      ? V_cache_h + (int64_t)sPageIdx[0] * v_block_stride +
+                            (int64_t)(sPageOffset[0] + token_offset) *
+                                v_token_stride +
+                            (int64_t)kv_head_id * v_head_stride + tile_d
+                      : V_cache_h +
+                            (int64_t)physical_block_idx_direct *
+                                v_block_stride +
+                            (int64_t)block_offset * v_token_stride +
+                            (int64_t)kv_head_id * v_head_stride + tile_d;
+            } else {
+              v_tile_ptr = V_cache_h +
+                           (int64_t)physical_block_idx_direct * v_block_stride +
+                           (int64_t)block_offset * v_token_stride +
+                           (int64_t)kv_head_id * v_head_stride + tile_d;
             }
-        } else {
-            for (int idx = tid; idx < valid_k_rows * D; idx += THREADS_PER_BLOCK) {
-                const int row = idx / D;
-                const int col = idx % D;
-                const int global_token_idx = start_col + row;
-                const int virtual_block_idx = global_token_idx / page_block_size;
-                const int block_offset = global_token_idx % page_block_size;
-                const int physical_block_idx_slow =
-                    __ldg(&block_table_seq[virtual_block_idx]);
-                const int64_t physical_offset =
-                    (int64_t)physical_block_idx_slow * v_block_stride
-                    + (int64_t)block_offset * v_token_stride
-                    + (int64_t)kv_head_id * v_head_stride + col;
-                sV[row * KV_STRIDE + col] =
-                    flash_v100::load_kv_cache_half<KV_DTYPE>(
-                        V_cache, physical_offset, v_scale);
-            }
+            load_matrix_sync(b_frag, v_tile_ptr, v_token_stride);
+          } else {
+            load_matrix_sync(b_frag,
+                             sV + (sub_start + k_offset) * KV_STRIDE + tile_d,
+                             KV_STRIDE);
+          }
+          mma_sync(acc_frag, a_frag, b_frag, acc_frag);
         }
-        __syncthreads();
-        }
-
-        const int num_tiles_m_pv = (BLOCK_M + WMMA_M - 1) / WMMA_M;
-        const int num_tiles_n_pv = (D + WMMA_N - 1) / WMMA_N;
-        const int total_tiles_pv = num_tiles_m_pv * num_tiles_n_pv;
-        const int tiles_per_warp_pv =
-            (total_tiles_pv + WARPS_PER_BLOCK - 1) / WARPS_PER_BLOCK;
-        const int softmax_sub_tile = (D == 256) ? P_SUB_TILE : p_tile_capacity;
-
-        for (int sub_start = 0; sub_start < valid_k_rows;
-             sub_start += softmax_sub_tile) {
-            const int sub_valid_k_rows = min(softmax_sub_tile,
-                                             valid_k_rows - sub_start);
-
-            if (tid < valid_q_rows * THREADS_PER_ROW) {
-                const int row = tid / THREADS_PER_ROW;
-                const int thread_in_row = tid % THREADS_PER_ROW;
-                const unsigned mask = (valid_q_rows == BLOCK_M)
-                                          ? 0xFFFFFFFFU
-                                          : __activemask();
-                const int row_leader = __ffs(mask) - 1;
-
-                float*  sS_row_f = sS + row * S_STRIDE + sub_start;
-                __half* sP_row_h = sP + row * p_stride;
-
-                const int vec_cols = sub_valid_k_rows >> 2;
-                const int vecs_per_thread =
-                    (vec_cols + THREADS_PER_ROW - 1) / THREADS_PER_ROW;
-                const int tail_start = vec_cols << 2;
-
-                float thread_max = NEG_INF;
-                float4* sS_vec4 = reinterpret_cast<float4*>(sS_row_f);
-
-                #pragma unroll 4
-                for (int j = 0; j < vecs_per_thread; ++j) {
-                    int vc = thread_in_row + j * THREADS_PER_ROW;
-                    if (vc < vec_cols) {
-                        float4 v4 = sS_vec4[vc];
-                        thread_max = fmaxf(
-                            thread_max,
-                            fmaxf(fmaxf(v4.x, v4.y), fmaxf(v4.z, v4.w)));
-                    }
-                }
-
-                #pragma unroll
-                for (int c = tail_start + thread_in_row; c < sub_valid_k_rows;
-                     c += THREADS_PER_ROW) {
-                    thread_max = fmaxf(thread_max, sS_row_f[c]);
-                }
-
-                #pragma unroll
-                for (int o = THREADS_PER_ROW / 2; o > 0; o >>= 1) {
-                    thread_max = fmaxf(
-                        thread_max,
-                        __shfl_down_sync(mask, thread_max, o, THREADS_PER_ROW));
-                }
-
-                const float row_max =
-                    __shfl_sync(mask, thread_max, row_leader, THREADS_PER_ROW);
-                const float old_max = sRowMax[row];
-                const float new_max = fmaxf(old_max, row_max);
-                const float exp_diff = __expf(old_max - new_max);
-
-                float thread_sum = 0.0f;
-                __half2 half_buffer[20];
-                int vc_base = thread_in_row;
-                int h2_idx = 0;
-                int tail_col = -1;
-                __half tail_value = __float2half(0.f);
-                __half2* sP_half2 = reinterpret_cast<__half2*>(sP_row_h);
-
-                #pragma unroll 4
-                for (int j = 0; j < vecs_per_thread; ++j,
-                         vc_base += THREADS_PER_ROW) {
-                    if (vc_base < vec_cols) {
-                        float4 v4 = sS_vec4[vc_base];
-
-                        float e0 = __expf(fmaxf(v4.x - new_max, -80.0f));
-                        float e1 = __expf(fmaxf(v4.y - new_max, -80.0f));
-                        float e2 = __expf(fmaxf(v4.z - new_max, -80.0f));
-                        float e3 = __expf(fmaxf(v4.w - new_max, -80.0f));
-
-                        thread_sum += (e0 + e1) + (e2 + e3);
-
-                        const __half2 p01 =
-                            __float22half2_rn(make_float2(e0, e1));
-                        const __half2 p23 =
-                            __float22half2_rn(make_float2(e2, e3));
-                        if constexpr (D256_SW_PIPELINE_PV) {
-                            // D256 owns a separate probability buffer, so the
-                            // values can leave registers before row reduction.
-                            const int base_offset = vc_base * 2;
-                            sP_half2[base_offset] = p01;
-                            sP_half2[base_offset + 1] = p23;
-                        } else {
-                            half_buffer[h2_idx++] = p01;
-                            half_buffer[h2_idx++] = p23;
-                        }
-                    }
-                }
-
-                #pragma unroll 4
-                for (int c = tail_start + thread_in_row; c < sub_valid_k_rows;
-                     c += THREADS_PER_ROW) {
-                    float v = sS_row_f[c];
-                    float e = __expf(fmaxf(v - new_max, -80.0f));
-                    thread_sum += e;
-                    if constexpr (D256_SW_PIPELINE_PV) {
-                        sP_row_h[c] = __float2half_rn(e);
-                    } else {
-                        tail_col = c;
-                        tail_value = __float2half_rn(e);
-                    }
-                }
-
-                #pragma unroll
-                for (int o = THREADS_PER_ROW / 2; o > 0; o >>= 1) {
-                    thread_sum +=
-                        __shfl_down_sync(mask, thread_sum, o, THREADS_PER_ROW);
-                }
-
-                float row_sum =
-                    __shfl_sync(mask, thread_sum, row_leader, THREADS_PER_ROW);
-
-                if (thread_in_row == 0) {
-                    sRowSum[row] = exp_diff * sRowSum[row] + row_sum;
-                    sRowMax[row] = new_max;
-                }
-
-                if constexpr (!D256_SW_PIPELINE_PV) {
-                    h2_idx = 0;
-                    vc_base = thread_in_row;
-                    #pragma unroll 4
-                    for (int j = 0; j < vecs_per_thread; ++j,
-                             vc_base += THREADS_PER_ROW) {
-                        if (vc_base < vec_cols) {
-                            int base_offset = vc_base * 2;
-                            sP_half2[base_offset] = half_buffer[h2_idx++];
-                            sP_half2[base_offset + 1] = half_buffer[h2_idx++];
-                        }
-                    }
-
-                    if (tail_col >= 0) {
-                        sP_row_h[tail_col] = tail_value;
-                    }
-                }
-
-                #pragma unroll 4
-                for (int c = tail_start + thread_in_row; c < p_tile_capacity;
-                     c += THREADS_PER_ROW) {
-                    if (c >= sub_valid_k_rows) {
-                        sP_row_h[c] = __float2half(0.f);
-                    }
-                }
-
-                if (block_n > 0 || sub_start > 0) {
-                    float*  sO_row = sO + row * O_STRIDE;
-                    float4* sO_vec = reinterpret_cast<float4*>(sO_row);
-                    const int o_vec_count = D / 4;
-                    float scale = exp_diff;
-
-                    #pragma unroll 4
-                    for (int ov = thread_in_row; ov < o_vec_count;
-                         ov += THREADS_PER_ROW) {
-                        float4 v = sO_vec[ov];
-                        v.x *= scale;
-                        v.y *= scale;
-                        v.z *= scale;
-                        v.w *= scale;
-                        sO_vec[ov] = v;
-                    }
-                }
-            }
-            __syncthreads();
-
-            const int num_tiles_k_pv =
-                (p_tile_capacity + WMMA_K - 1) / WMMA_K;
-
-            for (int tile_idx = 0; tile_idx < tiles_per_warp_pv; ++tile_idx) {
-                const int global_tile_idx = warp_id * tiles_per_warp_pv + tile_idx;
-                if (global_tile_idx >= total_tiles_pv) break;
-
-                const int tile_m_idx = global_tile_idx / num_tiles_n_pv;
-                const int tile_d_idx = global_tile_idx % num_tiles_n_pv;
-
-                const int tile_m = tile_m_idx * WMMA_M;
-                const int tile_d = tile_d_idx * WMMA_N;
-
-                if (tile_m >= valid_q_rows) continue;
-
-                fragment<matrix_a, WMMA_M, WMMA_N, WMMA_K, half, row_major> a_frag;
-                fragment<matrix_b, WMMA_M, WMMA_N, WMMA_K, half, row_major> b_frag;
-                fragment<accumulator, WMMA_M, WMMA_N, WMMA_K, float> acc_frag;
-
-                load_matrix_sync(acc_frag, sO + tile_m * O_STRIDE + tile_d,
-                                 O_STRIDE, mem_row_major);
-
-                #pragma unroll
-                for (int tile_k = 0; tile_k < num_tiles_k_pv; ++tile_k) {
-                    const int k_offset = tile_k * WMMA_K;
-                    if (k_offset >= sub_valid_k_rows) break;
-
-                    load_matrix_sync(a_frag,
-                                     sP + tile_m * p_stride + k_offset,
-                                     p_stride);
-                    if constexpr (LOW_SMEM) {
-                        const __half* V_cache_h =
-                            reinterpret_cast<const __half*>(V_cache);
-                        const int token_offset = sub_start + k_offset;
-                        const int page_slot = token_offset >> 4;
-                        const int block_offset = sPageOffset[page_slot];
-                        const int physical_block_idx_direct =
-                            sPageIdx[page_slot];
-                        const __half* v_tile_ptr;
-                        if constexpr (LOW_SMEM_CONTIG_FAST) {
-                            v_tile_ptr =
-                                low_smem_contiguous_page_tile
-                                    ? V_cache_h
-                                          + (int64_t)sPageIdx[0] * v_block_stride
-                                          + (int64_t)(sPageOffset[0] + token_offset)
-                                                * v_token_stride
-                                          + (int64_t)kv_head_id * v_head_stride
-                                          + tile_d
-                                    : V_cache_h
-                                          + (int64_t)physical_block_idx_direct
-                                                * v_block_stride
-                                          + (int64_t)block_offset * v_token_stride
-                                          + (int64_t)kv_head_id * v_head_stride
-                                          + tile_d;
-                        } else {
-                            v_tile_ptr =
-                                V_cache_h
-                                + (int64_t)physical_block_idx_direct
-                                      * v_block_stride
-                                + (int64_t)block_offset * v_token_stride
-                                + (int64_t)kv_head_id * v_head_stride + tile_d;
-                        }
-                        load_matrix_sync(b_frag, v_tile_ptr, v_token_stride);
-                    } else {
-                        load_matrix_sync(
-                            b_frag,
-                            sV + (sub_start + k_offset) * KV_STRIDE + tile_d,
-                            KV_STRIDE);
-                    }
-                    mma_sync(acc_frag, a_frag, b_frag, acc_frag);
-                }
-                store_matrix_sync(sO + tile_m * O_STRIDE + tile_d, acc_frag,
-                                  O_STRIDE, mem_row_major);
-            }
-            __syncthreads();
-        }
-
+        store_matrix_sync(sO + tile_m * O_STRIDE + tile_d, acc_frag, O_STRIDE,
+                          mem_row_major);
+      }
+      __syncthreads();
     }
+  }
 
-    if constexpr (SPLIT_KV) {
-        const int partition_id = blockIdx.y;
-        const int num_partitions = gridDim.y;
-        const int64_t row_base =
-            ((int64_t)batch_head_id * num_partitions + partition_id) * M
-            + start_row;
+  if constexpr (SPLIT_KV) {
+    const int partition_id = blockIdx.y;
+    const int num_partitions = gridDim.y;
+    const int64_t row_base =
+        ((int64_t)batch_head_id * num_partitions + partition_id) * M +
+        start_row;
 
-        for (int i = tid; i < valid_q_rows * D; i += THREADS_PER_BLOCK) {
-            const int row = i / D;
-            const int col = i - row * D;
-            split_tmp_out[(row_base + row) * D + col] =
-                sO[row * O_STRIDE + col];
-        }
-
-        if (tid < valid_q_rows) {
-            split_tmp_row_max[row_base + tid] = sRowMax[tid];
-            split_tmp_row_sum[row_base + tid] = sRowSum[tid];
-        }
-        return;
-    }
-
-    const int total_fp16_x4 = (valid_q_rows * D) / 4;
-
-    for (int i = tid; i < total_fp16_x4; i += THREADS_PER_BLOCK) {
-        const int row = i / (D / 4);
-        const int col = (i % (D / 4)) * 4;
-
-        const float sum_clamped = fmaxf(sRowSum[row], 1e-24f);
-        const float inv_sum = 1.0f / sum_clamped;
-        const float* sO_row = sO + row * O_STRIDE;
-
-        const __half h0 = __float2half_rn(sO_row[col + 0] * inv_sum);
-        const __half h1 = __float2half_rn(sO_row[col + 1] * inv_sum);
-        const __half h2 = __float2half_rn(sO_row[col + 2] * inv_sum);
-        const __half h3 = __float2half_rn(sO_row[col + 3] * inv_sum);
-
-        asm volatile(
-            "st.global.v4.u16 [%0], {%1, %2, %3, %4};"
-            :
-            : "l"(out_ptr + row * D + col),
-              "h"(__half_as_ushort(h0)),
-              "h"(__half_as_ushort(h1)),
-              "h"(__half_as_ushort(h2)),
-              "h"(__half_as_ushort(h3))
-            : "memory"
-        );
+    for (int i = tid; i < valid_q_rows * D; i += THREADS_PER_BLOCK) {
+      const int row = i / D;
+      const int col = i - row * D;
+      split_tmp_out[(row_base + row) * D + col] = sO[row * O_STRIDE + col];
     }
 
     if (tid < valid_q_rows) {
-        const float sum = fmaxf(sRowSum[tid], 1e-24f);
-        softmax_lse_ptr[tid] = sRowMax[tid] + logf(sum);
+      split_tmp_row_max[row_base + tid] = sRowMax[tid];
+      split_tmp_row_sum[row_base + tid] = sRowSum[tid];
     }
+    return;
+  }
+
+  const int total_fp16_x4 = (valid_q_rows * D) / 4;
+
+  for (int i = tid; i < total_fp16_x4; i += THREADS_PER_BLOCK) {
+    const int row = i / (D / 4);
+    const int col = (i % (D / 4)) * 4;
+
+    const float sum_clamped = fmaxf(sRowSum[row], 1e-24f);
+    const float inv_sum = 1.0f / sum_clamped;
+    const float* sO_row = sO + row * O_STRIDE;
+
+    const __half h0 = __float2half_rn(sO_row[col + 0] * inv_sum);
+    const __half h1 = __float2half_rn(sO_row[col + 1] * inv_sum);
+    const __half h2 = __float2half_rn(sO_row[col + 2] * inv_sum);
+    const __half h3 = __float2half_rn(sO_row[col + 3] * inv_sum);
+
+    asm volatile("st.global.v4.u16 [%0], {%1, %2, %3, %4};"
+                 :
+                 : "l"(out_ptr + row * D + col), "h"(__half_as_ushort(h0)),
+                   "h"(__half_as_ushort(h1)), "h"(__half_as_ushort(h2)),
+                   "h"(__half_as_ushort(h3))
+                 : "memory");
+  }
+
+  if (tid < valid_q_rows) {
+    const float sum = fmaxf(sRowSum[tid], 1e-24f);
+    softmax_lse_ptr[tid] = sRowMax[tid] + logf(sum);
+  }
 }
 
 inline bool env_flag_enabled(const char* name) {
-    const char* raw = std::getenv(name);
-    return raw != nullptr && std::strcmp(raw, "0") != 0;
+  const char* raw = std::getenv(name);
+  return raw != nullptr && std::strcmp(raw, "0") != 0;
 }
 
 inline bool env_flag_default_enabled(const char* name) {
-    const char* raw = std::getenv(name);
-    return raw == nullptr || std::strcmp(raw, "0") != 0;
+  const char* raw = std::getenv(name);
+  return raw == nullptr || std::strcmp(raw, "0") != 0;
 }
 
-template<int D, int KV_DTYPE, bool LOW_SMEM, bool LOW_SMEM_CONTIG_FAST,
-         bool LOW_SMEM_SCALAR_QK, bool LOW_SMEM_BM32,
-         bool D256_OUTPUT_STRIDE_268 = false,
-         bool D256_SW_PIPELINE_QK = false,
-         bool D256_SW_PIPELINE_PV = false>
+template <int D, int KV_DTYPE, bool LOW_SMEM, bool LOW_SMEM_CONTIG_FAST,
+          bool LOW_SMEM_SCALAR_QK, bool LOW_SMEM_BM32,
+          bool D256_OUTPUT_STRIDE_268 = false, bool D256_SW_PIPELINE_QK = false,
+          bool D256_SW_PIPELINE_PV = false>
 void launcher_flash_attention_forward_paged_impl(
-    const torch::Tensor& Q,
-    const torch::Tensor& K_cache,
-    const torch::Tensor& V_cache,
-    torch::Tensor& Out,
-    torch::Tensor& softmax_lse,
-    const torch::Tensor& block_table,
-    const torch::Tensor& seq_lens,
-    const int* bfla_mask_ptr,
-    int bfla_mask_block_n,
-    int64_t bfla_mask_stride_b,
-    int64_t bfla_mask_stride_h,
-    int64_t bfla_mask_stride_q,
-    int64_t bfla_mask_stride_k,
-    float softmax_scale,
-    bool is_causal,
-    float k_scale,
-    float v_scale,
-    int window_size_left,
-    int window_size_right,
-    cudaStream_t stream
-) {
-    using Config = KernelConfig<D, LOW_SMEM, LOW_SMEM_SCALAR_QK,
-                                LOW_SMEM_BM32, D256_OUTPUT_STRIDE_268,
-                                D256_SW_PIPELINE_QK,
-                                D256_SW_PIPELINE_PV>;
+    const torch::Tensor& Q, const torch::Tensor& K_cache,
+    const torch::Tensor& V_cache, torch::Tensor& Out,
+    torch::Tensor& softmax_lse, const torch::Tensor& block_table,
+    const torch::Tensor& seq_lens, const int* bfla_mask_ptr,
+    int bfla_mask_block_n, int64_t bfla_mask_stride_b,
+    int64_t bfla_mask_stride_h, int64_t bfla_mask_stride_q,
+    int64_t bfla_mask_stride_k, float softmax_scale, bool is_causal,
+    float k_scale, float v_scale, int window_size_left, int window_size_right,
+    cudaStream_t stream) {
+  using Config = KernelConfig<D, LOW_SMEM, LOW_SMEM_SCALAR_QK, LOW_SMEM_BM32,
+                              D256_OUTPUT_STRIDE_268, D256_SW_PIPELINE_QK,
+                              D256_SW_PIPELINE_PV>;
 
-    const int B = Q.size(0);
-    const int H = Q.size(1);
-    const int M = Q.size(2);
-    const int page_block_size = K_cache.size(1);
-    const int num_kv_heads = K_cache.size(2);
-    const int max_num_blocks = block_table.size(1);
-    const int N = max_num_blocks * page_block_size;
-    const int64_t k_block_stride = K_cache.stride(0);
-    const int64_t k_token_stride = K_cache.stride(1);
-    const int64_t k_head_stride = K_cache.stride(2);
-    const int64_t v_block_stride = V_cache.stride(0);
-    const int64_t v_token_stride = V_cache.stride(1);
-    const int64_t v_head_stride = V_cache.stride(2);
+  const int B = Q.size(0);
+  const int H = Q.size(1);
+  const int M = Q.size(2);
+  const int page_block_size = K_cache.size(1);
+  const int num_kv_heads = K_cache.size(2);
+  const int max_num_blocks = block_table.size(1);
+  const int N = max_num_blocks * page_block_size;
+  const int64_t k_block_stride = K_cache.stride(0);
+  const int64_t k_token_stride = K_cache.stride(1);
+  const int64_t k_head_stride = K_cache.stride(2);
+  const int64_t v_block_stride = V_cache.stride(0);
+  const int64_t v_token_stride = V_cache.stride(1);
+  const int64_t v_head_stride = V_cache.stride(2);
 
-    const int grid_x = (M + Config::BLOCK_M - 1) / Config::BLOCK_M;
-    const dim3 grid(grid_x, 1, B * H);
-    const dim3 block(Config::THREADS_PER_BLOCK);
-    const size_t smem = Config::TOTAL_SMEM;
+  const int grid_x = (M + Config::BLOCK_M - 1) / Config::BLOCK_M;
+  const dim3 grid(grid_x, 1, B * H);
+  const dim3 block(Config::THREADS_PER_BLOCK);
+  const size_t smem = Config::TOTAL_SMEM;
 
-    TORCH_CHECK(smem <= MAX_SMEM_PER_SM, "Shared memory exceeds 96KB: ", smem,
-                " bytes");
+  TORCH_CHECK(smem <= MAX_SMEM_PER_SM, "Shared memory exceeds 96KB: ", smem,
+              " bytes");
 
-    auto kernel = is_causal
-                      ? (void*)flash_attention_forward_kernel_paged<
-                            D, LOW_SMEM, LOW_SMEM_CONTIG_FAST,
-                            LOW_SMEM_SCALAR_QK, LOW_SMEM_BM32, false, true,
-                            KV_DTYPE, D256_OUTPUT_STRIDE_268,
-                            D256_SW_PIPELINE_QK, D256_SW_PIPELINE_PV>
-                      : (void*)flash_attention_forward_kernel_paged<
-                            D, LOW_SMEM, LOW_SMEM_CONTIG_FAST,
-                            LOW_SMEM_SCALAR_QK, LOW_SMEM_BM32, false, false,
-                            KV_DTYPE, D256_OUTPUT_STRIDE_268,
-                            D256_SW_PIPELINE_QK, D256_SW_PIPELINE_PV>;
-    cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize,
-                         smem);
+  auto kernel =
+      is_causal
+          ? (void*)flash_attention_forward_kernel_paged<
+                D, LOW_SMEM, LOW_SMEM_CONTIG_FAST, LOW_SMEM_SCALAR_QK,
+                LOW_SMEM_BM32, false, true, KV_DTYPE, D256_OUTPUT_STRIDE_268,
+                D256_SW_PIPELINE_QK, D256_SW_PIPELINE_PV>
+          : (void*)flash_attention_forward_kernel_paged<
+                D, LOW_SMEM, LOW_SMEM_CONTIG_FAST, LOW_SMEM_SCALAR_QK,
+                LOW_SMEM_BM32, false, false, KV_DTYPE, D256_OUTPUT_STRIDE_268,
+                D256_SW_PIPELINE_QK, D256_SW_PIPELINE_PV>;
+  cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize,
+                       smem);
 
-    if (is_causal) {
-        flash_attention_forward_kernel_paged<
-            D, LOW_SMEM, LOW_SMEM_CONTIG_FAST, LOW_SMEM_SCALAR_QK,
-            LOW_SMEM_BM32, false, true, KV_DTYPE, D256_OUTPUT_STRIDE_268,
-            D256_SW_PIPELINE_QK, D256_SW_PIPELINE_PV>
-            <<<grid, block, smem, stream>>>(
-            reinterpret_cast<const __half*>(Q.data_ptr()),
-            K_cache.data_ptr(),
-            V_cache.data_ptr(),
-            reinterpret_cast<__half*>(Out.data_ptr()),
-            softmax_lse.data_ptr<float>(),
-            block_table.data_ptr<int>(),
-            seq_lens.data_ptr<int>(),
-            B,
-            H,
-            M,
-            N,
-            bfla_mask_ptr,
-            bfla_mask_block_n,
-            bfla_mask_stride_b,
-            bfla_mask_stride_h,
-            bfla_mask_stride_q,
-            bfla_mask_stride_k,
-            page_block_size,
-            num_kv_heads,
-            k_block_stride,
-            k_token_stride,
-            k_head_stride,
-            v_block_stride,
-            v_token_stride,
-            v_head_stride,
-            softmax_scale,
-            k_scale,
-            v_scale,
-            window_size_left,
-            window_size_right,
-            nullptr,
-            nullptr,
-            nullptr,
-            0
-        );
-    } else {
-        flash_attention_forward_kernel_paged<
-            D, LOW_SMEM, LOW_SMEM_CONTIG_FAST, LOW_SMEM_SCALAR_QK,
-            LOW_SMEM_BM32, false, false, KV_DTYPE, D256_OUTPUT_STRIDE_268,
-            D256_SW_PIPELINE_QK, D256_SW_PIPELINE_PV>
-            <<<grid, block, smem, stream>>>(
-            reinterpret_cast<const __half*>(Q.data_ptr()),
-            K_cache.data_ptr(),
-            V_cache.data_ptr(),
-            reinterpret_cast<__half*>(Out.data_ptr()),
-            softmax_lse.data_ptr<float>(),
-            block_table.data_ptr<int>(),
-            seq_lens.data_ptr<int>(),
-            B,
-            H,
-            M,
-            N,
-            bfla_mask_ptr,
-            bfla_mask_block_n,
-            bfla_mask_stride_b,
-            bfla_mask_stride_h,
-            bfla_mask_stride_q,
-            bfla_mask_stride_k,
-            page_block_size,
-            num_kv_heads,
-            k_block_stride,
-            k_token_stride,
-            k_head_stride,
-            v_block_stride,
-            v_token_stride,
-            v_head_stride,
-            softmax_scale,
-            k_scale,
-            v_scale,
-            window_size_left,
-            window_size_right,
-            nullptr,
-            nullptr,
-            nullptr,
-            0
-        );
-    }
+  if (is_causal) {
+    flash_attention_forward_kernel_paged<
+        D, LOW_SMEM, LOW_SMEM_CONTIG_FAST, LOW_SMEM_SCALAR_QK, LOW_SMEM_BM32,
+        false, true, KV_DTYPE, D256_OUTPUT_STRIDE_268, D256_SW_PIPELINE_QK,
+        D256_SW_PIPELINE_PV><<<grid, block, smem, stream>>>(
+        reinterpret_cast<const __half*>(Q.data_ptr()), K_cache.data_ptr(),
+        V_cache.data_ptr(), reinterpret_cast<__half*>(Out.data_ptr()),
+        softmax_lse.data_ptr<float>(), block_table.data_ptr<int>(),
+        seq_lens.data_ptr<int>(), B, H, M, N, bfla_mask_ptr, bfla_mask_block_n,
+        bfla_mask_stride_b, bfla_mask_stride_h, bfla_mask_stride_q,
+        bfla_mask_stride_k, page_block_size, num_kv_heads, k_block_stride,
+        k_token_stride, k_head_stride, v_block_stride, v_token_stride,
+        v_head_stride, softmax_scale, k_scale, v_scale, window_size_left,
+        window_size_right, nullptr, nullptr, nullptr, 0);
+  } else {
+    flash_attention_forward_kernel_paged<
+        D, LOW_SMEM, LOW_SMEM_CONTIG_FAST, LOW_SMEM_SCALAR_QK, LOW_SMEM_BM32,
+        false, false, KV_DTYPE, D256_OUTPUT_STRIDE_268, D256_SW_PIPELINE_QK,
+        D256_SW_PIPELINE_PV><<<grid, block, smem, stream>>>(
+        reinterpret_cast<const __half*>(Q.data_ptr()), K_cache.data_ptr(),
+        V_cache.data_ptr(), reinterpret_cast<__half*>(Out.data_ptr()),
+        softmax_lse.data_ptr<float>(), block_table.data_ptr<int>(),
+        seq_lens.data_ptr<int>(), B, H, M, N, bfla_mask_ptr, bfla_mask_block_n,
+        bfla_mask_stride_b, bfla_mask_stride_h, bfla_mask_stride_q,
+        bfla_mask_stride_k, page_block_size, num_kv_heads, k_block_stride,
+        k_token_stride, k_head_stride, v_block_stride, v_token_stride,
+        v_head_stride, softmax_scale, k_scale, v_scale, window_size_left,
+        window_size_right, nullptr, nullptr, nullptr, 0);
+  }
 }
 
-template<int D>
+template <int D>
 __global__ void flash_attention_forward_paged_splitkv_merge_kernel(
     const float* __restrict__ split_tmp_out,
     const float* __restrict__ split_tmp_row_max,
-    const float* __restrict__ split_tmp_row_sum,
-          __half* __restrict__ Out,
-           float* __restrict__ softmax_lse,
-    const int B,
-    const int H,
-    const int M,
-    const int num_partitions
-) {
-    static_assert(D == 256, "split-KV paged prefill merge is D=256 only");
-    constexpr int BLOCK_M = BLOCK_M_256_LOW_SMEM;
-    constexpr int THREADS = 512;
-    const float NEG_INF = -1e30f;
+    const float* __restrict__ split_tmp_row_sum, __half* __restrict__ Out,
+    float* __restrict__ softmax_lse, const int B, const int H, const int M,
+    const int num_partitions) {
+  static_assert(D == 256, "split-KV paged prefill merge is D=256 only");
+  constexpr int BLOCK_M = BLOCK_M_256_LOW_SMEM;
+  constexpr int THREADS = 512;
+  const float NEG_INF = -1e30f;
 
-    const int batch_head_id = blockIdx.z;
-    if (batch_head_id >= B * H) return;
+  const int batch_head_id = blockIdx.z;
+  if (batch_head_id >= B * H) return;
 
-    const int block_m = blockIdx.x;
-    const int start_row = block_m * BLOCK_M;
-    if (start_row >= M) return;
-    const int valid_q_rows = min(BLOCK_M, M - start_row);
-    const int tid = threadIdx.x;
+  const int block_m = blockIdx.x;
+  const int start_row = block_m * BLOCK_M;
+  if (start_row >= M) return;
+  const int valid_q_rows = min(BLOCK_M, M - start_row);
+  const int tid = threadIdx.x;
 
-    __shared__ float sFinalMax[BLOCK_M];
-    __shared__ float sFinalSum[BLOCK_M];
+  __shared__ float sFinalMax[BLOCK_M];
+  __shared__ float sFinalSum[BLOCK_M];
 
-    if (tid < valid_q_rows) {
-        const int row = start_row + tid;
-        float final_max = NEG_INF;
-        #pragma unroll 1
-        for (int p = 0; p < num_partitions; ++p) {
-            const int64_t state_idx =
-                ((int64_t)batch_head_id * num_partitions + p) * M + row;
-            final_max = fmaxf(final_max, split_tmp_row_max[state_idx]);
-        }
-
-        float final_sum = 0.0f;
-        #pragma unroll 1
-        for (int p = 0; p < num_partitions; ++p) {
-            const int64_t state_idx =
-                ((int64_t)batch_head_id * num_partitions + p) * M + row;
-            const float part_sum = split_tmp_row_sum[state_idx];
-            if (part_sum > 0.0f) {
-                final_sum +=
-                    __expf(fmaxf(split_tmp_row_max[state_idx] - final_max,
-                                  -80.0f)) * part_sum;
-            }
-        }
-        sFinalMax[tid] = final_max;
-        sFinalSum[tid] = final_sum;
-        softmax_lse[(int64_t)batch_head_id * M + row] =
-            final_max + logf(fmaxf(final_sum, 1e-24f));
+  if (tid < valid_q_rows) {
+    const int row = start_row + tid;
+    float final_max = NEG_INF;
+#pragma unroll 1
+    for (int p = 0; p < num_partitions; ++p) {
+      const int64_t state_idx =
+          ((int64_t)batch_head_id * num_partitions + p) * M + row;
+      final_max = fmaxf(final_max, split_tmp_row_max[state_idx]);
     }
-    __syncthreads();
 
-    for (int idx = tid; idx < valid_q_rows * D; idx += THREADS) {
-        const int row_local = idx / D;
-        const int col = idx - row_local * D;
-        const int row = start_row + row_local;
-        const float final_max = sFinalMax[row_local];
-        const float inv_sum = 1.0f / fmaxf(sFinalSum[row_local], 1e-24f);
-
-        float acc = 0.0f;
-        #pragma unroll 1
-        for (int p = 0; p < num_partitions; ++p) {
-            const int64_t state_idx =
-                ((int64_t)batch_head_id * num_partitions + p) * M + row;
-            const float part_sum = split_tmp_row_sum[state_idx];
-            if (part_sum > 0.0f) {
-                const float scale =
-                    __expf(fmaxf(split_tmp_row_max[state_idx] - final_max,
-                                  -80.0f));
-                const int64_t out_idx = state_idx * D + col;
-                acc = fmaf(scale, split_tmp_out[out_idx], acc);
-            }
-        }
-        Out[((int64_t)batch_head_id * M + row) * D + col] =
-            __float2half_rn(acc * inv_sum);
+    float final_sum = 0.0f;
+#pragma unroll 1
+    for (int p = 0; p < num_partitions; ++p) {
+      const int64_t state_idx =
+          ((int64_t)batch_head_id * num_partitions + p) * M + row;
+      const float part_sum = split_tmp_row_sum[state_idx];
+      if (part_sum > 0.0f) {
+        final_sum +=
+            __expf(fmaxf(split_tmp_row_max[state_idx] - final_max, -80.0f)) *
+            part_sum;
+      }
     }
+    sFinalMax[tid] = final_max;
+    sFinalSum[tid] = final_sum;
+    softmax_lse[(int64_t)batch_head_id * M + row] =
+        final_max + logf(fmaxf(final_sum, 1e-24f));
+  }
+  __syncthreads();
+
+  for (int idx = tid; idx < valid_q_rows * D; idx += THREADS) {
+    const int row_local = idx / D;
+    const int col = idx - row_local * D;
+    const int row = start_row + row_local;
+    const float final_max = sFinalMax[row_local];
+    const float inv_sum = 1.0f / fmaxf(sFinalSum[row_local], 1e-24f);
+
+    float acc = 0.0f;
+#pragma unroll 1
+    for (int p = 0; p < num_partitions; ++p) {
+      const int64_t state_idx =
+          ((int64_t)batch_head_id * num_partitions + p) * M + row;
+      const float part_sum = split_tmp_row_sum[state_idx];
+      if (part_sum > 0.0f) {
+        const float scale =
+            __expf(fmaxf(split_tmp_row_max[state_idx] - final_max, -80.0f));
+        const int64_t out_idx = state_idx * D + col;
+        acc = fmaf(scale, split_tmp_out[out_idx], acc);
+      }
+    }
+    Out[((int64_t)batch_head_id * M + row) * D + col] =
+        __float2half_rn(acc * inv_sum);
+  }
 }
 
-template<int D, bool LOW_SMEM_CONTIG_FAST, bool LOW_SMEM_SCALAR_QK>
+template <int D, bool LOW_SMEM_CONTIG_FAST, bool LOW_SMEM_SCALAR_QK>
 void launcher_flash_attention_forward_paged_splitkv_impl(
-    const torch::Tensor& Q,
-    const torch::Tensor& K_cache,
-    const torch::Tensor& V_cache,
-    torch::Tensor& Out,
-    torch::Tensor& softmax_lse,
-    torch::Tensor& split_tmp_out,
-    torch::Tensor& split_tmp_row_max,
-    torch::Tensor& split_tmp_row_sum,
-    const torch::Tensor& block_table,
-    const torch::Tensor& seq_lens,
-    float softmax_scale,
-    bool is_causal,
-    float k_scale,
-    float v_scale,
-    int window_size_left,
-    int window_size_right,
-    int split_kv_tokens,
-    int max_seq_len_hint,
-    cudaStream_t stream
-) {
-    static_assert(D == 256, "split-KV paged prefill is D=256 only");
-    using Config = KernelConfig<D, true, LOW_SMEM_SCALAR_QK>;
-    constexpr int KV_DTYPE = flash_v100::KV_CACHE_DTYPE_FP16;
+    const torch::Tensor& Q, const torch::Tensor& K_cache,
+    const torch::Tensor& V_cache, torch::Tensor& Out,
+    torch::Tensor& softmax_lse, torch::Tensor& split_tmp_out,
+    torch::Tensor& split_tmp_row_max, torch::Tensor& split_tmp_row_sum,
+    const torch::Tensor& block_table, const torch::Tensor& seq_lens,
+    float softmax_scale, bool is_causal, float k_scale, float v_scale,
+    int window_size_left, int window_size_right, int split_kv_tokens,
+    int max_seq_len_hint, cudaStream_t stream) {
+  static_assert(D == 256, "split-KV paged prefill is D=256 only");
+  using Config = KernelConfig<D, true, LOW_SMEM_SCALAR_QK>;
+  constexpr int KV_DTYPE = flash_v100::KV_CACHE_DTYPE_FP16;
 
-    const int B = Q.size(0);
-    const int H = Q.size(1);
-    const int M = Q.size(2);
-    const int page_block_size = K_cache.size(1);
-    const int num_kv_heads = K_cache.size(2);
-    const int max_num_blocks = block_table.size(1);
-    const int N = max_num_blocks * page_block_size;
-    const int64_t k_block_stride = K_cache.stride(0);
-    const int64_t k_token_stride = K_cache.stride(1);
-    const int64_t k_head_stride = K_cache.stride(2);
-    const int64_t v_block_stride = V_cache.stride(0);
-    const int64_t v_token_stride = V_cache.stride(1);
-    const int64_t v_head_stride = V_cache.stride(2);
+  const int B = Q.size(0);
+  const int H = Q.size(1);
+  const int M = Q.size(2);
+  const int page_block_size = K_cache.size(1);
+  const int num_kv_heads = K_cache.size(2);
+  const int max_num_blocks = block_table.size(1);
+  const int N = max_num_blocks * page_block_size;
+  const int64_t k_block_stride = K_cache.stride(0);
+  const int64_t k_token_stride = K_cache.stride(1);
+  const int64_t k_head_stride = K_cache.stride(2);
+  const int64_t v_block_stride = V_cache.stride(0);
+  const int64_t v_token_stride = V_cache.stride(1);
+  const int64_t v_head_stride = V_cache.stride(2);
 
-    split_kv_tokens = std::max(split_kv_tokens, Config::BLOCK_N);
-    max_seq_len_hint = std::max(max_seq_len_hint, 1);
-    const int split_kv_tiles =
-        std::max(1, (split_kv_tokens + Config::BLOCK_N - 1) / Config::BLOCK_N);
-    const int max_kv_tiles =
-        std::max(1, (max_seq_len_hint + Config::BLOCK_N - 1) / Config::BLOCK_N);
-    const int num_partitions =
-        std::max(1, (max_kv_tiles + split_kv_tiles - 1) / split_kv_tiles);
+  split_kv_tokens = std::max(split_kv_tokens, Config::BLOCK_N);
+  max_seq_len_hint = std::max(max_seq_len_hint, 1);
+  const int split_kv_tiles =
+      std::max(1, (split_kv_tokens + Config::BLOCK_N - 1) / Config::BLOCK_N);
+  const int max_kv_tiles =
+      std::max(1, (max_seq_len_hint + Config::BLOCK_N - 1) / Config::BLOCK_N);
+  const int num_partitions =
+      std::max(1, (max_kv_tiles + split_kv_tiles - 1) / split_kv_tiles);
 
-    const int grid_x = (M + Config::BLOCK_M - 1) / Config::BLOCK_M;
-    const dim3 grid(grid_x, num_partitions, B * H);
-    const dim3 block(Config::THREADS_PER_BLOCK);
-    const size_t smem = Config::TOTAL_SMEM;
+  const int grid_x = (M + Config::BLOCK_M - 1) / Config::BLOCK_M;
+  const dim3 grid(grid_x, num_partitions, B * H);
+  const dim3 block(Config::THREADS_PER_BLOCK);
+  const size_t smem = Config::TOTAL_SMEM;
 
-    TORCH_CHECK(smem <= MAX_SMEM_PER_SM, "Shared memory exceeds 96KB: ", smem,
-                " bytes");
-    TORCH_CHECK(split_tmp_out.size(2) == num_partitions,
-                "split_tmp_out partition mismatch");
-    TORCH_CHECK(split_tmp_row_max.size(2) == num_partitions,
-                "split_tmp_row_max partition mismatch");
-    TORCH_CHECK(split_tmp_row_sum.size(2) == num_partitions,
-                "split_tmp_row_sum partition mismatch");
+  TORCH_CHECK(smem <= MAX_SMEM_PER_SM, "Shared memory exceeds 96KB: ", smem,
+              " bytes");
+  TORCH_CHECK(split_tmp_out.size(2) == num_partitions,
+              "split_tmp_out partition mismatch");
+  TORCH_CHECK(split_tmp_row_max.size(2) == num_partitions,
+              "split_tmp_row_max partition mismatch");
+  TORCH_CHECK(split_tmp_row_sum.size(2) == num_partitions,
+              "split_tmp_row_sum partition mismatch");
 
-    auto kernel = is_causal
-                      ? (void*)flash_attention_forward_kernel_paged<
-                            D, true, LOW_SMEM_CONTIG_FAST,
-                            LOW_SMEM_SCALAR_QK, false, true, true, KV_DTYPE>
-                      : (void*)flash_attention_forward_kernel_paged<
-                            D, true, LOW_SMEM_CONTIG_FAST,
-                            LOW_SMEM_SCALAR_QK, false, true, false, KV_DTYPE>;
-    cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize,
-                         smem);
+  auto kernel = is_causal
+                    ? (void*)flash_attention_forward_kernel_paged<
+                          D, true, LOW_SMEM_CONTIG_FAST, LOW_SMEM_SCALAR_QK,
+                          false, true, true, KV_DTYPE>
+                    : (void*)flash_attention_forward_kernel_paged<
+                          D, true, LOW_SMEM_CONTIG_FAST, LOW_SMEM_SCALAR_QK,
+                          false, true, false, KV_DTYPE>;
+  cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize,
+                       smem);
 
-    if (is_causal) {
-        flash_attention_forward_kernel_paged<
-            D, true, LOW_SMEM_CONTIG_FAST, LOW_SMEM_SCALAR_QK, false, true, true,
-            KV_DTYPE>
-            <<<grid, block, smem, stream>>>(
-            reinterpret_cast<const __half*>(Q.data_ptr()),
-            K_cache.data_ptr(),
-            V_cache.data_ptr(),
-            reinterpret_cast<__half*>(Out.data_ptr()),
-            softmax_lse.data_ptr<float>(),
-            block_table.data_ptr<int>(),
-            seq_lens.data_ptr<int>(),
-            B,
-            H,
-            M,
-            N,
-            nullptr,
-            0,
-            0,
-            0,
-            0,
-            0,
-            page_block_size,
-            num_kv_heads,
-            k_block_stride,
-            k_token_stride,
-            k_head_stride,
-            v_block_stride,
-            v_token_stride,
-            v_head_stride,
-            softmax_scale,
-            k_scale,
-            v_scale,
-            window_size_left,
-            window_size_right,
-            split_tmp_out.data_ptr<float>(),
+  if (is_causal) {
+    flash_attention_forward_kernel_paged<D, true, LOW_SMEM_CONTIG_FAST,
+                                         LOW_SMEM_SCALAR_QK, false, true, true,
+                                         KV_DTYPE>
+        <<<grid, block, smem, stream>>>(
+            reinterpret_cast<const __half*>(Q.data_ptr()), K_cache.data_ptr(),
+            V_cache.data_ptr(), reinterpret_cast<__half*>(Out.data_ptr()),
+            softmax_lse.data_ptr<float>(), block_table.data_ptr<int>(),
+            seq_lens.data_ptr<int>(), B, H, M, N, nullptr, 0, 0, 0, 0, 0,
+            page_block_size, num_kv_heads, k_block_stride, k_token_stride,
+            k_head_stride, v_block_stride, v_token_stride, v_head_stride,
+            softmax_scale, k_scale, v_scale, window_size_left,
+            window_size_right, split_tmp_out.data_ptr<float>(),
             split_tmp_row_max.data_ptr<float>(),
-            split_tmp_row_sum.data_ptr<float>(),
-            split_kv_tiles
-        );
-    } else {
-        flash_attention_forward_kernel_paged<
-            D, true, LOW_SMEM_CONTIG_FAST, LOW_SMEM_SCALAR_QK, false, true, false,
-            KV_DTYPE>
-            <<<grid, block, smem, stream>>>(
-            reinterpret_cast<const __half*>(Q.data_ptr()),
-            K_cache.data_ptr(),
-            V_cache.data_ptr(),
-            reinterpret_cast<__half*>(Out.data_ptr()),
-            softmax_lse.data_ptr<float>(),
-            block_table.data_ptr<int>(),
-            seq_lens.data_ptr<int>(),
-            B,
-            H,
-            M,
-            N,
-            nullptr,
-            0,
-            0,
-            0,
-            0,
-            0,
-            page_block_size,
-            num_kv_heads,
-            k_block_stride,
-            k_token_stride,
-            k_head_stride,
-            v_block_stride,
-            v_token_stride,
-            v_head_stride,
-            softmax_scale,
-            k_scale,
-            v_scale,
-            window_size_left,
-            window_size_right,
-            split_tmp_out.data_ptr<float>(),
+            split_tmp_row_sum.data_ptr<float>(), split_kv_tiles);
+  } else {
+    flash_attention_forward_kernel_paged<D, true, LOW_SMEM_CONTIG_FAST,
+                                         LOW_SMEM_SCALAR_QK, false, true, false,
+                                         KV_DTYPE>
+        <<<grid, block, smem, stream>>>(
+            reinterpret_cast<const __half*>(Q.data_ptr()), K_cache.data_ptr(),
+            V_cache.data_ptr(), reinterpret_cast<__half*>(Out.data_ptr()),
+            softmax_lse.data_ptr<float>(), block_table.data_ptr<int>(),
+            seq_lens.data_ptr<int>(), B, H, M, N, nullptr, 0, 0, 0, 0, 0,
+            page_block_size, num_kv_heads, k_block_stride, k_token_stride,
+            k_head_stride, v_block_stride, v_token_stride, v_head_stride,
+            softmax_scale, k_scale, v_scale, window_size_left,
+            window_size_right, split_tmp_out.data_ptr<float>(),
             split_tmp_row_max.data_ptr<float>(),
-            split_tmp_row_sum.data_ptr<float>(),
-            split_kv_tiles
-        );
-    }
+            split_tmp_row_sum.data_ptr<float>(), split_kv_tiles);
+  }
 
-    const dim3 merge_grid(grid_x, 1, B * H);
-    const dim3 merge_block(512);
-    flash_attention_forward_paged_splitkv_merge_kernel<D>
-        <<<merge_grid, merge_block, 0, stream>>>(
-            split_tmp_out.data_ptr<float>(),
-            split_tmp_row_max.data_ptr<float>(),
-            split_tmp_row_sum.data_ptr<float>(),
-            reinterpret_cast<__half*>(Out.data_ptr()),
-            softmax_lse.data_ptr<float>(),
-            B,
-            H,
-            M,
-            num_partitions);
+  const dim3 merge_grid(grid_x, 1, B * H);
+  const dim3 merge_block(512);
+  flash_attention_forward_paged_splitkv_merge_kernel<D>
+      <<<merge_grid, merge_block, 0, stream>>>(
+          split_tmp_out.data_ptr<float>(), split_tmp_row_max.data_ptr<float>(),
+          split_tmp_row_sum.data_ptr<float>(),
+          reinterpret_cast<__half*>(Out.data_ptr()),
+          softmax_lse.data_ptr<float>(), B, H, M, num_partitions);
 }
 
 constexpr int D256_BM32_PHASE_BLOCK_M = 32;
@@ -2090,41 +1787,41 @@ constexpr int D256_BM32_PHASE_PANELS =
 constexpr int D256_BM32_PHASE_PROBABILITY_ELEMENTS =
     D256_BM32_PHASE_PANEL_M * D256_BM32_PHASE_SOFTMAX_N;
 
-template<int PROBABILITY_PANELS>
+template <int PROBABILITY_PANELS>
 struct alignas(16) D256BM32PhaseSharedStorage {
-    __half query[D256_BM32_PHASE_BLOCK_M * D256_BM32_PHASE_D];
-    float score[D256_BM32_PHASE_BLOCK_M * D256_BM32_PHASE_BLOCK_N];
-    __half probability_top[PROBABILITY_PANELS
-                           * D256_BM32_PHASE_PROBABILITY_ELEMENTS];
-    __half probability_bottom[PROBABILITY_PANELS
-                              * D256_BM32_PHASE_PROBABILITY_ELEMENTS];
-    float row_max[D256_BM32_PHASE_BLOCK_M];
-    float row_sum[D256_BM32_PHASE_BLOCK_M];
-    float row_exp_diff[PROBABILITY_PANELS * D256_BM32_PHASE_BLOCK_M];
-    int page_idx[D256_BM32_PHASE_PAGE_SLOTS];
-    int page_offset[D256_BM32_PHASE_PAGE_SLOTS];
-    uint64_t k_tile_ptr[D256_BM32_PHASE_PAGE_SLOTS];
-    uint64_t v_tile_ptr[D256_BM32_PHASE_PAGE_SLOTS];
-    int block_index;
-    int batch_id;
-    int kv_head_id;
-    int actual_n;
+  __half query[D256_BM32_PHASE_BLOCK_M * D256_BM32_PHASE_D];
+  float score[D256_BM32_PHASE_BLOCK_M * D256_BM32_PHASE_BLOCK_N];
+  __half probability_top[PROBABILITY_PANELS *
+                         D256_BM32_PHASE_PROBABILITY_ELEMENTS];
+  __half probability_bottom[PROBABILITY_PANELS *
+                            D256_BM32_PHASE_PROBABILITY_ELEMENTS];
+  float row_max[D256_BM32_PHASE_BLOCK_M];
+  float row_sum[D256_BM32_PHASE_BLOCK_M];
+  float row_exp_diff[PROBABILITY_PANELS * D256_BM32_PHASE_BLOCK_M];
+  int page_idx[D256_BM32_PHASE_PAGE_SLOTS];
+  int page_offset[D256_BM32_PHASE_PAGE_SLOTS];
+  uint64_t k_tile_ptr[D256_BM32_PHASE_PAGE_SLOTS];
+  uint64_t v_tile_ptr[D256_BM32_PHASE_PAGE_SLOTS];
+  int block_index;
+  int batch_id;
+  int kv_head_id;
+  int actual_n;
 };
 
-template<int PROBABILITY_PANELS>
+template <int PROBABILITY_PANELS>
 struct alignas(16) D256BM32PhaseSplitSharedStorage
     : D256BM32PhaseSharedStorage<PROBABILITY_PANELS> {
-    int split_end_block;
+  int split_end_block;
 };
 
-template<bool SPLIT_KV, int PROBABILITY_PANELS>
+template <bool SPLIT_KV, int PROBABILITY_PANELS>
 struct D256BM32PhaseSharedStorageSelector {
-    using Type = D256BM32PhaseSharedStorage<PROBABILITY_PANELS>;
+  using Type = D256BM32PhaseSharedStorage<PROBABILITY_PANELS>;
 };
 
-template<int PROBABILITY_PANELS>
+template <int PROBABILITY_PANELS>
 struct D256BM32PhaseSharedStorageSelector<true, PROBABILITY_PANELS> {
-    using Type = D256BM32PhaseSplitSharedStorage<PROBABILITY_PANELS>;
+  using Type = D256BM32PhaseSplitSharedStorage<PROBABILITY_PANELS>;
 };
 
 using D256BM32PhaseSharedStorageSingle = D256BM32PhaseSharedStorage<1>;
@@ -2137,8 +1834,8 @@ static_assert(sizeof(D256BM32PhaseSharedStorageAllP) == 41936,
               "D256 BM32 all-P shared layout changed unexpectedly");
 static_assert(sizeof(D256BM32PhaseSharedStorageAllP) <= 48 * 1024,
               "D256 BM32 phase shared storage exceeds 48 KiB");
-static_assert(sizeof(D256BM32PhaseSplitSharedStorage<
-                      D256_BM32_PHASE_PANELS>) == 41952,
+static_assert(sizeof(D256BM32PhaseSplitSharedStorage<D256_BM32_PHASE_PANELS>) ==
+                  41952,
               "D256 BM32 split shared layout changed unexpectedly");
 
 using D256BM32PhaseMatrixAFragment =
@@ -2151,2143 +1848,1846 @@ using D256BM32PhaseAccumulatorFragment =
     fragment<accumulator, WMMA_M, WMMA_N, WMMA_K, float>;
 
 __device__ __forceinline__ int d256_bm32_phase_swizzled_row_slot(int row) {
-    return (row & 3) | ((row & 8) >> 1) | ((row & 4) << 1);
+  return (row & 3) | ((row & 8) >> 1) | ((row & 4) << 1);
 }
 
-__device__ __forceinline__ int d256_bm32_phase_matrix_a_offset(
-    int row,
-    int column) {
-    const int tile = column / WMMA_K;
-    const int within_tile = column - tile * WMMA_K;
-    const int plane = within_tile >> 3;
-    const int inner = within_tile & 7;
-    return tile * WMMA_M * WMMA_K + plane * WMMA_M * 8
-           + d256_bm32_phase_swizzled_row_slot(row) * 8 + inner;
+__device__ __forceinline__ int d256_bm32_phase_matrix_a_offset(int row,
+                                                               int column) {
+  const int tile = column / WMMA_K;
+  const int within_tile = column - tile * WMMA_K;
+  const int plane = within_tile >> 3;
+  const int inner = within_tile & 7;
+  return tile * WMMA_M * WMMA_K + plane * WMMA_M * 8 +
+         d256_bm32_phase_swizzled_row_slot(row) * 8 + inner;
 }
 
 __device__ __forceinline__ void d256_bm32_phase_stage_query(
-    const __half* __restrict__ source,
-    __half* __restrict__ destination) {
-    constexpr int HALF_PER_UINT4 = sizeof(uint4) / sizeof(__half);
-    constexpr int VECTORS_PER_ROW = D256_BM32_PHASE_D / HALF_PER_UINT4;
-    constexpr int VECTORS_PER_PANEL =
-        D256_BM32_PHASE_PANEL_M * VECTORS_PER_ROW;
-    constexpr int QUERY_VECTORS =
-        D256_BM32_PHASE_BLOCK_M * VECTORS_PER_ROW;
+    const __half* __restrict__ source, __half* __restrict__ destination) {
+  constexpr int HALF_PER_UINT4 = sizeof(uint4) / sizeof(__half);
+  constexpr int VECTORS_PER_ROW = D256_BM32_PHASE_D / HALF_PER_UINT4;
+  constexpr int VECTORS_PER_PANEL = D256_BM32_PHASE_PANEL_M * VECTORS_PER_ROW;
+  constexpr int QUERY_VECTORS = D256_BM32_PHASE_BLOCK_M * VECTORS_PER_ROW;
 
-    const uint4* source_vectors = reinterpret_cast<const uint4*>(source);
-    uint4* destination_vectors = reinterpret_cast<uint4*>(destination);
+  const uint4* source_vectors = reinterpret_cast<const uint4*>(source);
+  uint4* destination_vectors = reinterpret_cast<uint4*>(destination);
 
-    #pragma unroll
-    for (int index = threadIdx.x; index < QUERY_VECTORS;
-         index += D256_BM32_PHASE_THREADS) {
-        const int row = index / VECTORS_PER_ROW;
-        const int vector_column = index % VECTORS_PER_ROW;
-        const int panel = row / D256_BM32_PHASE_PANEL_M;
-        const int panel_row = row - panel * D256_BM32_PHASE_PANEL_M;
-        const int k_tile = vector_column >> 1;
-        const int plane = vector_column & 1;
-        const int slot = d256_bm32_phase_swizzled_row_slot(panel_row);
-        destination_vectors[panel * VECTORS_PER_PANEL
-                            + k_tile * (2 * D256_BM32_PHASE_PANEL_M)
-                            + plane * D256_BM32_PHASE_PANEL_M + slot] =
-            __ldg(source_vectors + index);
-    }
+#pragma unroll
+  for (int index = threadIdx.x; index < QUERY_VECTORS;
+       index += D256_BM32_PHASE_THREADS) {
+    const int row = index / VECTORS_PER_ROW;
+    const int vector_column = index % VECTORS_PER_ROW;
+    const int panel = row / D256_BM32_PHASE_PANEL_M;
+    const int panel_row = row - panel * D256_BM32_PHASE_PANEL_M;
+    const int k_tile = vector_column >> 1;
+    const int plane = vector_column & 1;
+    const int slot = d256_bm32_phase_swizzled_row_slot(panel_row);
+    destination_vectors[panel * VECTORS_PER_PANEL +
+                        k_tile * (2 * D256_BM32_PHASE_PANEL_M) +
+                        plane * D256_BM32_PHASE_PANEL_M + slot] =
+        __ldg(source_vectors + index);
+  }
 }
 
 __device__ __forceinline__ void d256_bm32_phase_stage_query_partial(
-    const __half* __restrict__ source,
-    __half* __restrict__ destination,
+    const __half* __restrict__ source, __half* __restrict__ destination,
     int valid_rows) {
-    constexpr int HALF_PER_UINT4 = sizeof(uint4) / sizeof(__half);
-    constexpr int VECTORS_PER_ROW = D256_BM32_PHASE_D / HALF_PER_UINT4;
-    constexpr int VECTORS_PER_PANEL =
-        D256_BM32_PHASE_PANEL_M * VECTORS_PER_ROW;
-    constexpr int QUERY_VECTORS =
-        D256_BM32_PHASE_BLOCK_M * VECTORS_PER_ROW;
+  constexpr int HALF_PER_UINT4 = sizeof(uint4) / sizeof(__half);
+  constexpr int VECTORS_PER_ROW = D256_BM32_PHASE_D / HALF_PER_UINT4;
+  constexpr int VECTORS_PER_PANEL = D256_BM32_PHASE_PANEL_M * VECTORS_PER_ROW;
+  constexpr int QUERY_VECTORS = D256_BM32_PHASE_BLOCK_M * VECTORS_PER_ROW;
 
-    const uint4* source_vectors = reinterpret_cast<const uint4*>(source);
-    uint4* destination_vectors = reinterpret_cast<uint4*>(destination);
+  const uint4* source_vectors = reinterpret_cast<const uint4*>(source);
+  uint4* destination_vectors = reinterpret_cast<uint4*>(destination);
 
-    #pragma unroll
-    for (int index = threadIdx.x; index < QUERY_VECTORS;
-         index += D256_BM32_PHASE_THREADS) {
-        const int row = index / VECTORS_PER_ROW;
-        const int vector_column = index % VECTORS_PER_ROW;
-        const int panel = row / D256_BM32_PHASE_PANEL_M;
-        const int panel_row = row - panel * D256_BM32_PHASE_PANEL_M;
-        const int k_tile = vector_column >> 1;
-        const int plane = vector_column & 1;
-        const int slot = d256_bm32_phase_swizzled_row_slot(panel_row);
-        uint4 value = {0, 0, 0, 0};
-        if (row < valid_rows) {
-            value = __ldg(source_vectors + index);
-        }
-        destination_vectors[panel * VECTORS_PER_PANEL
-                            + k_tile * (2 * D256_BM32_PHASE_PANEL_M)
-                            + plane * D256_BM32_PHASE_PANEL_M + slot] = value;
+#pragma unroll
+  for (int index = threadIdx.x; index < QUERY_VECTORS;
+       index += D256_BM32_PHASE_THREADS) {
+    const int row = index / VECTORS_PER_ROW;
+    const int vector_column = index % VECTORS_PER_ROW;
+    const int panel = row / D256_BM32_PHASE_PANEL_M;
+    const int panel_row = row - panel * D256_BM32_PHASE_PANEL_M;
+    const int k_tile = vector_column >> 1;
+    const int plane = vector_column & 1;
+    const int slot = d256_bm32_phase_swizzled_row_slot(panel_row);
+    uint4 value = {0, 0, 0, 0};
+    if (row < valid_rows) {
+      value = __ldg(source_vectors + index);
     }
+    destination_vectors[panel * VECTORS_PER_PANEL +
+                        k_tile * (2 * D256_BM32_PHASE_PANEL_M) +
+                        plane * D256_BM32_PHASE_PANEL_M + slot] = value;
+  }
 }
 
 __device__ __forceinline__ void d256_bm32_phase_load_matrix_a(
-    D256BM32PhaseMatrixAFragment& fragment,
-    const __half* __restrict__ matrix,
+    D256BM32PhaseMatrixAFragment& fragment, const __half* __restrict__ matrix,
     int k_offset) {
-    const int lane = threadIdx.x & 31;
-    const int row =
-        (lane & 3) + ((lane >> 4) & 1) * 4 + ((lane >> 2) & 1) * 8;
-    const int slot = d256_bm32_phase_swizzled_row_slot(row);
-    const int tile_offset = (k_offset / WMMA_K) * WMMA_M * WMMA_K;
-    uint32_t address = static_cast<uint32_t>(
-        __cvta_generic_to_shared(matrix + tile_offset + slot * 8));
-    uint32_t* words = reinterpret_cast<uint32_t*>(&fragment);
-    asm volatile(
-        "ld.shared.v4.u32 {%0, %1, %2, %3}, [%4];"
-        : "=r"(words[0]), "=r"(words[1]), "=r"(words[2]), "=r"(words[3])
-        : "r"(address)
-        : "memory");
-    address += WMMA_M * 8 * sizeof(__half);
-    asm volatile(
-        "ld.shared.v4.u32 {%0, %1, %2, %3}, [%4];"
-        : "=r"(words[4]), "=r"(words[5]), "=r"(words[6]), "=r"(words[7])
-        : "r"(address)
-        : "memory");
+  const int lane = threadIdx.x & 31;
+  const int row = (lane & 3) + ((lane >> 4) & 1) * 4 + ((lane >> 2) & 1) * 8;
+  const int slot = d256_bm32_phase_swizzled_row_slot(row);
+  const int tile_offset = (k_offset / WMMA_K) * WMMA_M * WMMA_K;
+  uint32_t address = static_cast<uint32_t>(
+      __cvta_generic_to_shared(matrix + tile_offset + slot * 8));
+  uint32_t* words = reinterpret_cast<uint32_t*>(&fragment);
+  asm volatile("ld.shared.v4.u32 {%0, %1, %2, %3}, [%4];"
+               : "=r"(words[0]), "=r"(words[1]), "=r"(words[2]), "=r"(words[3])
+               : "r"(address)
+               : "memory");
+  address += WMMA_M * 8 * sizeof(__half);
+  asm volatile("ld.shared.v4.u32 {%0, %1, %2, %3}, [%4];"
+               : "=r"(words[4]), "=r"(words[5]), "=r"(words[6]), "=r"(words[7])
+               : "r"(address)
+               : "memory");
 }
 
-__device__ __forceinline__ int d256_bm32_phase_accumulator_row(
-    int lane,
-    int element) {
-    const int row_base =
-        (lane & 1) + ((lane >> 2) & 1) * 8 + ((lane >> 4) & 1) * 4;
-    return row_base + ((element >> 1) & 1) * 2;
+__device__ __forceinline__ int d256_bm32_phase_accumulator_row(int lane,
+                                                               int element) {
+  const int row_base =
+      (lane & 1) + ((lane >> 2) & 1) * 8 + ((lane >> 4) & 1) * 4;
+  return row_base + ((element >> 1) & 1) * 2;
 }
 
-__device__ __forceinline__ int d256_bm32_phase_accumulator_column(
-    int lane,
-    int element) {
-    const int column_base = ((lane >> 1) & 1) * 2 + ((lane >> 3) & 1) * 8;
-    return column_base + (element & 1) + ((element >> 2) & 1) * 4;
+__device__ __forceinline__ int d256_bm32_phase_accumulator_column(int lane,
+                                                                  int element) {
+  const int column_base = ((lane >> 1) & 1) * 2 + ((lane >> 3) & 1) * 8;
+  return column_base + (element & 1) + ((element >> 2) & 1) * 4;
 }
 
 __device__ __forceinline__ void d256_bm32_phase_spill_pair_scratch(
     float* __restrict__ score,
     D256BM32PhaseAccumulatorFragment& accumulator_top,
     D256BM32PhaseAccumulatorFragment& accumulator_bottom) {
-    const int warp = threadIdx.x >> 5;
-    const int lane = threadIdx.x & 31;
-    const int warp_pair = warp >> 1;
-    const int warp_in_pair = warp & 1;
-    const int pair_column = warp_pair * 32 + (lane & 15) * 2;
-    const int lane_row = lane >> 4;
+  const int warp = threadIdx.x >> 5;
+  const int lane = threadIdx.x & 31;
+  const int warp_pair = warp >> 1;
+  const int warp_in_pair = warp & 1;
+  const int pair_column = warp_pair * 32 + (lane & 15) * 2;
+  const int lane_row = lane >> 4;
 
-    #pragma unroll
-    for (int element_pair = 0; element_pair < 4; ++element_pair) {
-        const int element = element_pair * 2;
-        const int offset =
-            (warp_in_pair * 16 + element_pair * 2 + lane_row)
-                * D256_BM32_PHASE_BLOCK_N
-            + pair_column;
-        const uint32_t address = static_cast<uint32_t>(
-            __cvta_generic_to_shared(score + offset));
-        asm volatile(
-            "st.shared.v2.u32 [%0], {%1, %2};"
-            :
-            : "r"(address),
-              "r"(__float_as_uint(accumulator_top.x[element])),
-              "r"(__float_as_uint(accumulator_top.x[element + 1]))
-            : "memory");
-        asm volatile(
-            "st.shared.v2.u32 [%0+4096], {%1, %2};"
-            :
-            : "r"(address),
-              "r"(__float_as_uint(accumulator_bottom.x[element])),
-              "r"(__float_as_uint(accumulator_bottom.x[element + 1]))
-            : "memory");
-    }
+#pragma unroll
+  for (int element_pair = 0; element_pair < 4; ++element_pair) {
+    const int element = element_pair * 2;
+    const int offset = (warp_in_pair * 16 + element_pair * 2 + lane_row) *
+                           D256_BM32_PHASE_BLOCK_N +
+                       pair_column;
+    const uint32_t address =
+        static_cast<uint32_t>(__cvta_generic_to_shared(score + offset));
+    asm volatile("st.shared.v2.u32 [%0], {%1, %2};"
+                 :
+                 : "r"(address),
+                   "r"(__float_as_uint(accumulator_top.x[element])),
+                   "r"(__float_as_uint(accumulator_top.x[element + 1]))
+                 : "memory");
+    asm volatile("st.shared.v2.u32 [%0+4096], {%1, %2};"
+                 :
+                 : "r"(address),
+                   "r"(__float_as_uint(accumulator_bottom.x[element])),
+                   "r"(__float_as_uint(accumulator_bottom.x[element + 1]))
+                 : "memory");
+  }
 }
 
 __device__ __forceinline__ void d256_bm32_phase_reload_pair_scratch(
     const float* __restrict__ score,
     D256BM32PhaseAccumulatorFragment& accumulator_top,
     D256BM32PhaseAccumulatorFragment& accumulator_bottom) {
-    const int warp = threadIdx.x >> 5;
-    const int lane = threadIdx.x & 31;
-    const int warp_pair = warp >> 1;
-    const int warp_in_pair = warp & 1;
-    const int pair_column = warp_pair * 32 + (lane & 15) * 2;
-    const int lane_row = lane >> 4;
+  const int warp = threadIdx.x >> 5;
+  const int lane = threadIdx.x & 31;
+  const int warp_pair = warp >> 1;
+  const int warp_in_pair = warp & 1;
+  const int pair_column = warp_pair * 32 + (lane & 15) * 2;
+  const int lane_row = lane >> 4;
 
-    #pragma unroll
-    for (int element_pair = 0; element_pair < 4; ++element_pair) {
-        const int element = element_pair * 2;
-        const int offset =
-            (warp_in_pair * 16 + element_pair * 2 + lane_row)
-                * D256_BM32_PHASE_BLOCK_N
-            + pair_column;
-        const uint32_t address = static_cast<uint32_t>(
-            __cvta_generic_to_shared(score + offset));
-        uint32_t first_word;
-        uint32_t second_word;
-        asm volatile(
-            "ld.shared.v2.u32 {%0, %1}, [%2];"
-            : "=r"(first_word), "=r"(second_word)
-            : "r"(address)
-            : "memory");
-        accumulator_top.x[element] = __uint_as_float(first_word);
-        accumulator_top.x[element + 1] = __uint_as_float(second_word);
-        asm volatile(
-            "ld.shared.v2.u32 {%0, %1}, [%2+4096];"
-            : "=r"(first_word), "=r"(second_word)
-            : "r"(address)
-            : "memory");
-        accumulator_bottom.x[element] = __uint_as_float(first_word);
-        accumulator_bottom.x[element + 1] = __uint_as_float(second_word);
-    }
+#pragma unroll
+  for (int element_pair = 0; element_pair < 4; ++element_pair) {
+    const int element = element_pair * 2;
+    const int offset = (warp_in_pair * 16 + element_pair * 2 + lane_row) *
+                           D256_BM32_PHASE_BLOCK_N +
+                       pair_column;
+    const uint32_t address =
+        static_cast<uint32_t>(__cvta_generic_to_shared(score + offset));
+    uint32_t first_word;
+    uint32_t second_word;
+    asm volatile("ld.shared.v2.u32 {%0, %1}, [%2];"
+                 : "=r"(first_word), "=r"(second_word)
+                 : "r"(address)
+                 : "memory");
+    accumulator_top.x[element] = __uint_as_float(first_word);
+    accumulator_top.x[element + 1] = __uint_as_float(second_word);
+    asm volatile("ld.shared.v2.u32 {%0, %1}, [%2+4096];"
+                 : "=r"(first_word), "=r"(second_word)
+                 : "r"(address)
+                 : "memory");
+    accumulator_bottom.x[element] = __uint_as_float(first_word);
+    accumulator_bottom.x[element + 1] = __uint_as_float(second_word);
+  }
 }
 
 __device__ __forceinline__ void d256_bm32_phase_sync_warp_pair(int warp_pair) {
-    const int barrier_id = warp_pair + 1;
-    asm volatile("bar.sync %0, 64;" : : "r"(barrier_id) : "memory");
+  const int barrier_id = warp_pair + 1;
+  asm volatile("bar.sync %0, 64;" : : "r"(barrier_id) : "memory");
 }
 
 __device__ __forceinline__ float d256_bm32_phase_make_probability_row(
-    const float* __restrict__ score_row,
-    __half* __restrict__ probability,
-    int probability_row,
-    float* __restrict__ row_max,
-    float* __restrict__ row_sum,
-    int state_row,
-    int panel,
-    float neg_inf) {
-    const int lane = threadIdx.x & 31;
-    const float* panel_score =
-        score_row + panel * D256_BM32_PHASE_SOFTMAX_N;
-    float thread_max = neg_inf;
-    if (lane < D256_BM32_PHASE_SOFTMAX_N / 4) {
-        const float4 values =
-            reinterpret_cast<const float4*>(panel_score)[lane];
-        thread_max = fmaxf(fmaxf(values.x, values.y),
-                           fmaxf(values.z, values.w));
-    }
-    #pragma unroll
-    for (int offset = 16; offset > 0; offset >>= 1) {
-        thread_max = fmaxf(
-            thread_max, __shfl_down_sync(0xffffffffU, thread_max, offset));
-    }
-    const float panel_max = __shfl_sync(0xffffffffU, thread_max, 0);
-    const float old_max = row_max[state_row];
-    const float new_max = fmaxf(old_max, panel_max);
-    const float exp_diff = __expf(old_max - new_max);
+    const float* __restrict__ score_row, __half* __restrict__ probability,
+    int probability_row, float* __restrict__ row_max,
+    float* __restrict__ row_sum, int state_row, int panel, float neg_inf) {
+  const int lane = threadIdx.x & 31;
+  const float* panel_score = score_row + panel * D256_BM32_PHASE_SOFTMAX_N;
+  float thread_max = neg_inf;
+  if (lane < D256_BM32_PHASE_SOFTMAX_N / 4) {
+    const float4 values = reinterpret_cast<const float4*>(panel_score)[lane];
+    thread_max = fmaxf(fmaxf(values.x, values.y), fmaxf(values.z, values.w));
+  }
+#pragma unroll
+  for (int offset = 16; offset > 0; offset >>= 1) {
+    thread_max =
+        fmaxf(thread_max, __shfl_down_sync(0xffffffffU, thread_max, offset));
+  }
+  const float panel_max = __shfl_sync(0xffffffffU, thread_max, 0);
+  const float old_max = row_max[state_row];
+  const float new_max = fmaxf(old_max, panel_max);
+  const float exp_diff = __expf(old_max - new_max);
 
-    float thread_sum = 0.0f;
-    if (lane < D256_BM32_PHASE_SOFTMAX_N / 4) {
-        float4 values = reinterpret_cast<const float4*>(panel_score)[lane];
-        values.x = __expf(fmaxf(values.x - new_max, -80.0f));
-        values.y = __expf(fmaxf(values.y - new_max, -80.0f));
-        values.z = __expf(fmaxf(values.z - new_max, -80.0f));
-        values.w = __expf(fmaxf(values.w - new_max, -80.0f));
-        thread_sum = (values.x + values.y) + (values.z + values.w);
-        const int column = lane * 4;
-        __half2* first_pair = reinterpret_cast<__half2*>(
-            probability + d256_bm32_phase_matrix_a_offset(
-                              probability_row, column));
-        __half2* second_pair = reinterpret_cast<__half2*>(
-            probability + d256_bm32_phase_matrix_a_offset(
-                              probability_row, column + 2));
-        *first_pair = __float22half2_rn(make_float2(values.x, values.y));
-        *second_pair = __float22half2_rn(make_float2(values.z, values.w));
-    }
-    #pragma unroll
-    for (int offset = 16; offset > 0; offset >>= 1) {
-        thread_sum +=
-            __shfl_down_sync(0xffffffffU, thread_sum, offset);
-    }
-    const float panel_sum = __shfl_sync(0xffffffffU, thread_sum, 0);
-    if (lane == 0) {
-        row_sum[state_row] = exp_diff * row_sum[state_row] + panel_sum;
-        row_max[state_row] = new_max;
-    }
-    return exp_diff;
+  float thread_sum = 0.0f;
+  if (lane < D256_BM32_PHASE_SOFTMAX_N / 4) {
+    float4 values = reinterpret_cast<const float4*>(panel_score)[lane];
+    values.x = __expf(fmaxf(values.x - new_max, -80.0f));
+    values.y = __expf(fmaxf(values.y - new_max, -80.0f));
+    values.z = __expf(fmaxf(values.z - new_max, -80.0f));
+    values.w = __expf(fmaxf(values.w - new_max, -80.0f));
+    thread_sum = (values.x + values.y) + (values.z + values.w);
+    const int column = lane * 4;
+    __half2* first_pair = reinterpret_cast<__half2*>(
+        probability + d256_bm32_phase_matrix_a_offset(probability_row, column));
+    __half2* second_pair = reinterpret_cast<__half2*>(
+        probability +
+        d256_bm32_phase_matrix_a_offset(probability_row, column + 2));
+    *first_pair = __float22half2_rn(make_float2(values.x, values.y));
+    *second_pair = __float22half2_rn(make_float2(values.z, values.w));
+  }
+#pragma unroll
+  for (int offset = 16; offset > 0; offset >>= 1) {
+    thread_sum += __shfl_down_sync(0xffffffffU, thread_sum, offset);
+  }
+  const float panel_sum = __shfl_sync(0xffffffffU, thread_sum, 0);
+  if (lane == 0) {
+    row_sum[state_row] = exp_diff * row_sum[state_row] + panel_sum;
+    row_max[state_row] = new_max;
+  }
+  return exp_diff;
 }
 
-__device__ __forceinline__ float
-d256_bm32_phase_make_split_probability_row(
-    const float* __restrict__ score_row,
-    __half* __restrict__ probability,
-    int probability_row,
-    float* __restrict__ row_max,
-    float* __restrict__ row_sum,
-    int state_row,
-    int panel,
-    float neg_inf,
+__device__ __forceinline__ float d256_bm32_phase_make_split_probability_row(
+    const float* __restrict__ score_row, __half* __restrict__ probability,
+    int probability_row, float* __restrict__ row_max,
+    float* __restrict__ row_sum, int state_row, int panel, float neg_inf,
     bool has_visible_value) {
-    if (!has_visible_value) {
-        const int lane = threadIdx.x & 31;
-        if (lane < D256_BM32_PHASE_SOFTMAX_N / 4) {
-            const int column = lane * 4;
-            __half2* first_pair = reinterpret_cast<__half2*>(
-                probability + d256_bm32_phase_matrix_a_offset(
-                                  probability_row, column));
-            __half2* second_pair = reinterpret_cast<__half2*>(
-                probability + d256_bm32_phase_matrix_a_offset(
-                                  probability_row, column + 2));
-            const __half2 zero = __float2half2_rn(0.0f);
-            *first_pair = zero;
-            *second_pair = zero;
-        }
-        return 1.0f;
+  if (!has_visible_value) {
+    const int lane = threadIdx.x & 31;
+    if (lane < D256_BM32_PHASE_SOFTMAX_N / 4) {
+      const int column = lane * 4;
+      __half2* first_pair = reinterpret_cast<__half2*>(
+          probability +
+          d256_bm32_phase_matrix_a_offset(probability_row, column));
+      __half2* second_pair = reinterpret_cast<__half2*>(
+          probability +
+          d256_bm32_phase_matrix_a_offset(probability_row, column + 2));
+      const __half2 zero = __float2half2_rn(0.0f);
+      *first_pair = zero;
+      *second_pair = zero;
     }
-    return d256_bm32_phase_make_probability_row(
-        score_row, probability, probability_row, row_max, row_sum,
-        state_row, panel, neg_inf);
+    return 1.0f;
+  }
+  return d256_bm32_phase_make_probability_row(score_row, probability,
+                                              probability_row, row_max, row_sum,
+                                              state_row, panel, neg_inf);
 }
 
 __device__ __forceinline__ void d256_bm32_phase_scale_accumulator_rows(
-    D256BM32PhaseAccumulatorFragment& accumulator,
-    float first_row_scale,
+    D256BM32PhaseAccumulatorFragment& accumulator, float first_row_scale,
     float second_row_scale) {
-    accumulator.x[0] *= first_row_scale;
-    accumulator.x[1] *= first_row_scale;
-    accumulator.x[2] *= second_row_scale;
-    accumulator.x[3] *= second_row_scale;
-    accumulator.x[4] *= first_row_scale;
-    accumulator.x[5] *= first_row_scale;
-    accumulator.x[6] *= second_row_scale;
-    accumulator.x[7] *= second_row_scale;
+  accumulator.x[0] *= first_row_scale;
+  accumulator.x[1] *= first_row_scale;
+  accumulator.x[2] *= second_row_scale;
+  accumulator.x[3] *= second_row_scale;
+  accumulator.x[4] *= first_row_scale;
+  accumulator.x[5] *= first_row_scale;
+  accumulator.x[6] *= second_row_scale;
+  accumulator.x[7] *= second_row_scale;
 }
 
 __device__ __forceinline__ void d256_bm32_phase_scale_accumulators(
     D256BM32PhaseAccumulatorFragment& accumulator_top,
     D256BM32PhaseAccumulatorFragment& accumulator_bottom,
     const float* __restrict__ row_exp_diff) {
-    const int row = d256_bm32_phase_accumulator_row(threadIdx.x & 31, 0);
-    d256_bm32_phase_scale_accumulator_rows(
-        accumulator_top, row_exp_diff[row], row_exp_diff[row + 2]);
-    d256_bm32_phase_scale_accumulator_rows(
-        accumulator_bottom,
-        row_exp_diff[D256_BM32_PHASE_PANEL_M + row],
-        row_exp_diff[D256_BM32_PHASE_PANEL_M + row + 2]);
+  const int row = d256_bm32_phase_accumulator_row(threadIdx.x & 31, 0);
+  d256_bm32_phase_scale_accumulator_rows(accumulator_top, row_exp_diff[row],
+                                         row_exp_diff[row + 2]);
+  d256_bm32_phase_scale_accumulator_rows(
+      accumulator_bottom, row_exp_diff[D256_BM32_PHASE_PANEL_M + row],
+      row_exp_diff[D256_BM32_PHASE_PANEL_M + row + 2]);
 }
 
 __device__ __forceinline__ void d256_bm32_phase_update_pv_panel(
     const __half* __restrict__ probability_top,
     const __half* __restrict__ probability_bottom,
-    const __half* __restrict__ value_k0,
-    const __half* __restrict__ value_k16,
-    int64_t value_token_stride,
-    int d_offset,
-    int valid_columns,
+    const __half* __restrict__ value_k0, const __half* __restrict__ value_k16,
+    int64_t value_token_stride, int d_offset, int valid_columns,
     D256BM32PhaseAccumulatorFragment& accumulator_top,
     D256BM32PhaseAccumulatorFragment& accumulator_bottom) {
-    D256BM32PhaseMatrixAFragment a_fragment;
-    D256BM32PhasePVMatrixBFragment b_fragment;
+  D256BM32PhaseMatrixAFragment a_fragment;
+  D256BM32PhasePVMatrixBFragment b_fragment;
 
-    load_matrix_sync(b_fragment, value_k0 + d_offset, value_token_stride);
-    d256_bm32_phase_load_matrix_a(a_fragment, probability_top, 0);
+  load_matrix_sync(b_fragment, value_k0 + d_offset, value_token_stride);
+  d256_bm32_phase_load_matrix_a(a_fragment, probability_top, 0);
+  mma_sync(accumulator_top, a_fragment, b_fragment, accumulator_top);
+  d256_bm32_phase_load_matrix_a(a_fragment, probability_bottom, 0);
+  mma_sync(accumulator_bottom, a_fragment, b_fragment, accumulator_bottom);
+  if (valid_columns > WMMA_K) {
+    load_matrix_sync(b_fragment, value_k16 + d_offset, value_token_stride);
+    d256_bm32_phase_load_matrix_a(a_fragment, probability_top, WMMA_K);
     mma_sync(accumulator_top, a_fragment, b_fragment, accumulator_top);
-    d256_bm32_phase_load_matrix_a(a_fragment, probability_bottom, 0);
+    d256_bm32_phase_load_matrix_a(a_fragment, probability_bottom, WMMA_K);
     mma_sync(accumulator_bottom, a_fragment, b_fragment, accumulator_bottom);
-    if (valid_columns > WMMA_K) {
-        load_matrix_sync(
-            b_fragment, value_k16 + d_offset, value_token_stride);
-        d256_bm32_phase_load_matrix_a(a_fragment, probability_top, WMMA_K);
-        mma_sync(accumulator_top, a_fragment, b_fragment, accumulator_top);
-        d256_bm32_phase_load_matrix_a(a_fragment, probability_bottom, WMMA_K);
-        mma_sync(accumulator_bottom, a_fragment, b_fragment,
-                 accumulator_bottom);
-    }
+  }
 }
 
 __device__ __forceinline__ void d256_bm32_phase_store_output(
     const D256BM32PhaseAccumulatorFragment& accumulator,
-    __half* __restrict__ output,
-    const float* __restrict__ row_sum,
-    int row_offset,
-    int d_offset) {
-    const int lane = threadIdx.x & 31;
-    #pragma unroll
-    for (int element = 0; element < accumulator.num_elements; ++element) {
-        const int row = row_offset
-                        + d256_bm32_phase_accumulator_row(lane, element);
-        const int column = d_offset
-                           + d256_bm32_phase_accumulator_column(lane, element);
-        const float inverse_sum = 1.0f / fmaxf(row_sum[row], 1e-24f);
-        output[row * D256_BM32_PHASE_D + column] =
-            __float2half_rn(accumulator.x[element] * inverse_sum);
-    }
+    __half* __restrict__ output, const float* __restrict__ row_sum,
+    int row_offset, int d_offset) {
+  const int lane = threadIdx.x & 31;
+#pragma unroll
+  for (int element = 0; element < accumulator.num_elements; ++element) {
+    const int row = row_offset + d256_bm32_phase_accumulator_row(lane, element);
+    const int column =
+        d_offset + d256_bm32_phase_accumulator_column(lane, element);
+    const float inverse_sum = 1.0f / fmaxf(row_sum[row], 1e-24f);
+    output[row * D256_BM32_PHASE_D + column] =
+        __float2half_rn(accumulator.x[element] * inverse_sum);
+  }
 }
 
 __device__ __forceinline__ void d256_bm32_phase_store_output_partial(
     const D256BM32PhaseAccumulatorFragment& accumulator,
-    __half* __restrict__ output,
-    const float* __restrict__ row_sum,
-    int row_offset,
-    int d_offset,
-    int valid_rows) {
-    const int lane = threadIdx.x & 31;
-    #pragma unroll
-    for (int element = 0; element < accumulator.num_elements; ++element) {
-        const int row = row_offset
-                        + d256_bm32_phase_accumulator_row(lane, element);
-        if (row < valid_rows) {
-            const int column =
-                d_offset
-                + d256_bm32_phase_accumulator_column(lane, element);
-            const float inverse_sum = 1.0f / fmaxf(row_sum[row], 1e-24f);
-            output[row * D256_BM32_PHASE_D + column] =
-                __float2half_rn(accumulator.x[element] * inverse_sum);
-        }
+    __half* __restrict__ output, const float* __restrict__ row_sum,
+    int row_offset, int d_offset, int valid_rows) {
+  const int lane = threadIdx.x & 31;
+#pragma unroll
+  for (int element = 0; element < accumulator.num_elements; ++element) {
+    const int row = row_offset + d256_bm32_phase_accumulator_row(lane, element);
+    if (row < valid_rows) {
+      const int column =
+          d_offset + d256_bm32_phase_accumulator_column(lane, element);
+      const float inverse_sum = 1.0f / fmaxf(row_sum[row], 1e-24f);
+      output[row * D256_BM32_PHASE_D + column] =
+          __float2half_rn(accumulator.x[element] * inverse_sum);
     }
+  }
 }
 
 __device__ __forceinline__ void d256_bm32_phase_store_unnormalized_partial(
     const D256BM32PhaseAccumulatorFragment& accumulator,
-    float* __restrict__ output,
-    int row_offset,
-    int d_offset,
-    int valid_rows) {
-    const int lane = threadIdx.x & 31;
-    #pragma unroll
-    for (int element = 0; element < accumulator.num_elements; ++element) {
-        const int row = row_offset
-                        + d256_bm32_phase_accumulator_row(lane, element);
-        if (row < valid_rows) {
-            const int column =
-                d_offset
-                + d256_bm32_phase_accumulator_column(lane, element);
-            output[row * D256_BM32_PHASE_D + column] = accumulator.x[element];
-        }
+    float* __restrict__ output, int row_offset, int d_offset, int valid_rows) {
+  const int lane = threadIdx.x & 31;
+#pragma unroll
+  for (int element = 0; element < accumulator.num_elements; ++element) {
+    const int row = row_offset + d256_bm32_phase_accumulator_row(lane, element);
+    if (row < valid_rows) {
+      const int column =
+          d_offset + d256_bm32_phase_accumulator_column(lane, element);
+      output[row * D256_BM32_PHASE_D + column] = accumulator.x[element];
     }
+  }
 }
 
-template<bool IS_CAUSAL, bool ALL_P = false, bool PAIR_SCRATCH = false,
-         bool SPLIT_KV = false, bool CHECK_SPLIT_EMPTY = true>
-__device__ __forceinline__
-void flash_attention_forward_paged_d256_bm32_phase_body(
-    const __half* __restrict__ Q,
-    const __half* __restrict__ K_cache,
-    const __half* __restrict__ V_cache,
-          __half* __restrict__ Out,
-           float* __restrict__ softmax_lse,
-    const int* __restrict__ block_table,
-    const int* __restrict__ seqused_k,
-    int H,
-    int M,
-    int max_num_blocks_per_seq,
-    int num_kv_heads,
-    int64_t k_block_stride,
-    int64_t k_token_stride,
-    int64_t k_head_stride,
-    int64_t v_block_stride,
-    int64_t v_token_stride,
-    int64_t v_head_stride,
-    float softmax_scale,
-    float* __restrict__ split_tmp_out,
-    float* __restrict__ split_tmp_row_max,
-    float* __restrict__ split_tmp_row_sum,
-    int split_actual_n) {
-    constexpr float NEG_INF = -1e30f;
-    static_assert(!SPLIT_KV || (ALL_P && PAIR_SCRATCH),
-                  "BM32 split-KV requires the accepted all-P pair-scratch body");
-    __shared__ __align__(16)
-        typename D256BM32PhaseSharedStorageSelector<
-            SPLIT_KV,
-            ALL_P ? D256_BM32_PHASE_PANELS : 1>::Type shared;
+template <bool IS_CAUSAL, bool ALL_P = false, bool PAIR_SCRATCH = false,
+          bool SPLIT_KV = false, bool CHECK_SPLIT_EMPTY = true>
+__device__ __forceinline__ void
+flash_attention_forward_paged_d256_bm32_phase_body(
+    const __half* __restrict__ Q, const __half* __restrict__ K_cache,
+    const __half* __restrict__ V_cache, __half* __restrict__ Out,
+    float* __restrict__ softmax_lse, const int* __restrict__ block_table,
+    const int* __restrict__ seqused_k, int H, int M, int max_num_blocks_per_seq,
+    int num_kv_heads, int64_t k_block_stride, int64_t k_token_stride,
+    int64_t k_head_stride, int64_t v_block_stride, int64_t v_token_stride,
+    int64_t v_head_stride, float softmax_scale,
+    float* __restrict__ split_tmp_out, float* __restrict__ split_tmp_row_max,
+    float* __restrict__ split_tmp_row_sum, int split_actual_n) {
+  constexpr float NEG_INF = -1e30f;
+  static_assert(!SPLIT_KV || (ALL_P && PAIR_SCRATCH),
+                "BM32 split-KV requires the accepted all-P pair-scratch body");
+  __shared__ __align__(16) typename D256BM32PhaseSharedStorageSelector<
+      SPLIT_KV, ALL_P ? D256_BM32_PHASE_PANELS : 1>::Type shared;
 
-    const int start_row = blockIdx.x * D256_BM32_PHASE_BLOCK_M;
-    const int tid = threadIdx.x;
-    const int warp_id = tid >> 5;
-    const int lane_id = tid & 31;
-    const int valid_q_rows =
-        min(D256_BM32_PHASE_BLOCK_M, M - start_row);
+  const int start_row = blockIdx.x * D256_BM32_PHASE_BLOCK_M;
+  const int tid = threadIdx.x;
+  const int warp_id = tid >> 5;
+  const int lane_id = tid & 31;
+  const int valid_q_rows = min(D256_BM32_PHASE_BLOCK_M, M - start_row);
 
-    {
-        const __half* q_ptr =
-            Q + static_cast<size_t>(blockIdx.z) * M * D256_BM32_PHASE_D
-            + start_row * D256_BM32_PHASE_D;
-        if (valid_q_rows == D256_BM32_PHASE_BLOCK_M) {
-            d256_bm32_phase_stage_query(q_ptr, shared.query);
-        } else {
-            d256_bm32_phase_stage_query_partial(
-                q_ptr, shared.query, valid_q_rows);
-        }
+  {
+    const __half* q_ptr =
+        Q + static_cast<size_t>(blockIdx.z) * M * D256_BM32_PHASE_D +
+        start_row * D256_BM32_PHASE_D;
+    if (valid_q_rows == D256_BM32_PHASE_BLOCK_M) {
+      d256_bm32_phase_stage_query(q_ptr, shared.query);
+    } else {
+      d256_bm32_phase_stage_query_partial(q_ptr, shared.query, valid_q_rows);
     }
-    if (tid < D256_BM32_PHASE_BLOCK_M) {
-        shared.row_max[tid] = NEG_INF;
-        shared.row_sum[tid] = 0.0f;
+  }
+  if (tid < D256_BM32_PHASE_BLOCK_M) {
+    shared.row_max[tid] = NEG_INF;
+    shared.row_sum[tid] = 0.0f;
+  }
+  if (tid == 0) {
+    shared.block_index = 0;
+    shared.batch_id = blockIdx.z / H;
+    shared.kv_head_id = (blockIdx.z % H) / (H / num_kv_heads);
+    if constexpr (SPLIT_KV) {
+      shared.actual_n = split_actual_n;
+    } else {
+      shared.actual_n = seqused_k[shared.batch_id];
     }
+  }
+  __syncthreads();
+
+  const int total_n_blocks =
+      (shared.actual_n + D256_BM32_PHASE_BLOCK_N - 1) / D256_BM32_PHASE_BLOCK_N;
+  if constexpr (SPLIT_KV) {
     if (tid == 0) {
-        shared.block_index = 0;
-        shared.batch_id = blockIdx.z / H;
-        shared.kv_head_id =
-            (blockIdx.z % H) / (H / num_kv_heads);
-        if constexpr (SPLIT_KV) {
-            shared.actual_n = split_actual_n;
-        } else {
-            shared.actual_n = seqused_k[shared.batch_id];
-        }
+      shared.block_index = static_cast<int>(blockIdx.y) * total_n_blocks /
+                           D256_BM32_PHASE_SPLIT_PARTS;
+      shared.split_end_block = (static_cast<int>(blockIdx.y) + 1) *
+                               total_n_blocks / D256_BM32_PHASE_SPLIT_PARTS;
+    }
+    __syncthreads();
+  }
+
+  D256BM32PhaseAccumulatorFragment accumulator_top;
+  D256BM32PhaseAccumulatorFragment accumulator_bottom;
+  fill_fragment(accumulator_top, 0.0f);
+  fill_fragment(accumulator_bottom, 0.0f);
+
+  for (;;) {
+    if constexpr (SPLIT_KV) {
+      if (shared.block_index >= shared.split_end_block) {
+        break;
+      }
+    } else {
+      if (shared.block_index >= total_n_blocks) {
+        break;
+      }
+    }
+    const int start_col = shared.block_index * D256_BM32_PHASE_BLOCK_N;
+    const int valid_k_rows =
+        min(D256_BM32_PHASE_BLOCK_N, shared.actual_n - start_col);
+
+    if (tid < D256_BM32_PHASE_PAGE_SLOTS) {
+      const int token_offset = tid * D256_BM32_PHASE_PAGE_SIZE;
+      if (token_offset < valid_k_rows) {
+        const int global_token_idx = start_col + token_offset;
+        const int virtual_block_idx =
+            global_token_idx / D256_BM32_PHASE_PAGE_BLOCK_SIZE;
+        shared.page_idx[tid] =
+            __ldg(&block_table[shared.batch_id * max_num_blocks_per_seq +
+                               virtual_block_idx]);
+        shared.page_offset[tid] =
+            global_token_idx -
+            virtual_block_idx * D256_BM32_PHASE_PAGE_BLOCK_SIZE;
+        shared.k_tile_ptr[tid] = reinterpret_cast<uint64_t>(
+            K_cache + (int64_t)shared.page_idx[tid] * k_block_stride +
+            (int64_t)shared.page_offset[tid] * k_token_stride +
+            (int64_t)shared.kv_head_id * k_head_stride);
+        shared.v_tile_ptr[tid] = reinterpret_cast<uint64_t>(
+            V_cache + (int64_t)shared.page_idx[tid] * v_block_stride +
+            (int64_t)shared.page_offset[tid] * v_token_stride +
+            (int64_t)shared.kv_head_id * v_head_stride);
+      } else {
+        shared.page_idx[tid] = -1;
+        shared.page_offset[tid] = 0;
+        shared.k_tile_ptr[tid] = 0;
+        shared.v_tile_ptr[tid] = 0;
+      }
     }
     __syncthreads();
 
-    const int total_n_blocks =
-        (shared.actual_n + D256_BM32_PHASE_BLOCK_N - 1)
-        / D256_BM32_PHASE_BLOCK_N;
+    if (warp_id < D256_BM32_PHASE_BLOCK_N / WMMA_N &&
+        warp_id * WMMA_N < valid_k_rows) {
+      const int tile_n = warp_id * WMMA_N;
+      const __half* k_tile =
+          reinterpret_cast<const __half*>(shared.k_tile_ptr[warp_id]);
+      if constexpr (PAIR_SCRATCH) {
+        d256_bm32_phase_spill_pair_scratch(shared.score, accumulator_top,
+                                           accumulator_bottom);
+      } else {
+        store_matrix_sync(shared.score + tile_n, accumulator_top,
+                          D256_BM32_PHASE_BLOCK_N, mem_row_major);
+        store_matrix_sync(
+            shared.score + D256_BM32_PHASE_PANEL_M * D256_BM32_PHASE_BLOCK_N +
+                tile_n,
+            accumulator_bottom, D256_BM32_PHASE_BLOCK_N, mem_row_major);
+      }
+      asm volatile("" ::: "memory");
+
+      D256BM32PhaseAccumulatorFragment qk_top;
+      D256BM32PhaseAccumulatorFragment qk_bottom;
+      {
+        D256BM32PhaseMatrixAFragment a_fragment;
+        D256BM32PhaseQKMatrixBFragment b_fragment;
+        fill_fragment(qk_top, 0.0f);
+        fill_fragment(qk_bottom, 0.0f);
+
+#pragma unroll
+        for (int k_offset = 0; k_offset < D256_BM32_PHASE_D;
+             k_offset += WMMA_K) {
+          load_matrix_sync(b_fragment, k_tile + k_offset, k_token_stride);
+          d256_bm32_phase_load_matrix_a(a_fragment, shared.query, k_offset);
+          mma_sync(qk_top, a_fragment, b_fragment, qk_top);
+          d256_bm32_phase_load_matrix_a(
+              a_fragment,
+              shared.query + D256_BM32_PHASE_PANEL_M * D256_BM32_PHASE_D,
+              k_offset);
+          mma_sync(qk_bottom, a_fragment, b_fragment, qk_bottom);
+        }
+      }
+      asm volatile("" ::: "memory");
+
+      if constexpr (PAIR_SCRATCH) {
+        d256_bm32_phase_reload_pair_scratch(shared.score, accumulator_top,
+                                            accumulator_bottom);
+        const int partner_warp = warp_id ^ 1;
+        if (partner_warp * WMMA_N < valid_k_rows) {
+          d256_bm32_phase_sync_warp_pair(warp_id >> 1);
+        }
+      } else {
+        load_matrix_sync(accumulator_top, shared.score + tile_n,
+                         D256_BM32_PHASE_BLOCK_N, mem_row_major);
+        load_matrix_sync(accumulator_bottom,
+                         shared.score +
+                             D256_BM32_PHASE_PANEL_M * D256_BM32_PHASE_BLOCK_N +
+                             tile_n,
+                         D256_BM32_PHASE_BLOCK_N, mem_row_major);
+      }
+
+      store_matrix_sync(shared.score + tile_n, qk_top, D256_BM32_PHASE_BLOCK_N,
+                        mem_row_major);
+      store_matrix_sync(shared.score +
+                            D256_BM32_PHASE_PANEL_M * D256_BM32_PHASE_BLOCK_N +
+                            tile_n,
+                        qk_bottom, D256_BM32_PHASE_BLOCK_N, mem_row_major);
+    }
+    __syncthreads();
+
+    const int causal_q_offset = max(shared.actual_n - M, 0);
+#pragma unroll 1
+    for (int index = tid;
+         index < D256_BM32_PHASE_BLOCK_M * D256_BM32_PHASE_BLOCK_N;
+         index += D256_BM32_PHASE_THREADS) {
+      const int row = index / D256_BM32_PHASE_BLOCK_N;
+      const int column = index - row * D256_BM32_PHASE_BLOCK_N;
+      const int global_m = start_row + row;
+      const int global_n = start_col + column;
+      const bool is_valid = global_m < M && global_n < start_col + valid_k_rows;
+      if constexpr (IS_CAUSAL) {
+        if (is_valid && global_n <= global_m + causal_q_offset) {
+          shared.score[index] *= softmax_scale;
+        } else {
+          shared.score[index] = NEG_INF;
+        }
+      } else {
+        if (is_valid) {
+          shared.score[index] *= softmax_scale;
+        } else {
+          shared.score[index] = NEG_INF;
+        }
+      }
+    }
+    __syncthreads();
+
+    if constexpr (ALL_P) {
+#pragma unroll
+      for (int panel = 0; panel < D256_BM32_PHASE_PANELS; ++panel) {
+        const int panel_start = panel * D256_BM32_PHASE_SOFTMAX_N;
+        const int valid_panel_columns =
+            min(D256_BM32_PHASE_SOFTMAX_N, valid_k_rows - panel_start);
+        if (valid_panel_columns > 0) {
+          __half* probability_top =
+              shared.probability_top +
+              panel * D256_BM32_PHASE_PROBABILITY_ELEMENTS;
+          __half* probability_bottom =
+              shared.probability_bottom +
+              panel * D256_BM32_PHASE_PROBABILITY_ELEMENTS;
+          float* row_exp_diff =
+              shared.row_exp_diff + panel * D256_BM32_PHASE_BLOCK_M;
+          float top_exp_diff;
+          float bottom_exp_diff;
+          if constexpr (SPLIT_KV && CHECK_SPLIT_EMPTY) {
+            const int first_global_n = start_col + panel_start;
+            const bool top_has_visible_value =
+                warp_id < valid_q_rows &&
+                (!IS_CAUSAL ||
+                 first_global_n <= start_row + warp_id + causal_q_offset);
+            const bool bottom_has_visible_value =
+                D256_BM32_PHASE_PANEL_M + warp_id < valid_q_rows &&
+                (!IS_CAUSAL || first_global_n <= start_row +
+                                                     D256_BM32_PHASE_PANEL_M +
+                                                     warp_id + causal_q_offset);
+            top_exp_diff = d256_bm32_phase_make_split_probability_row(
+                shared.score + warp_id * D256_BM32_PHASE_BLOCK_N,
+                probability_top, warp_id, shared.row_max, shared.row_sum,
+                warp_id, panel, NEG_INF, top_has_visible_value);
+            bottom_exp_diff = d256_bm32_phase_make_split_probability_row(
+                shared.score + (D256_BM32_PHASE_PANEL_M + warp_id) *
+                                   D256_BM32_PHASE_BLOCK_N,
+                probability_bottom, warp_id, shared.row_max, shared.row_sum,
+                D256_BM32_PHASE_PANEL_M + warp_id, panel, NEG_INF,
+                bottom_has_visible_value);
+          } else {
+            top_exp_diff = d256_bm32_phase_make_probability_row(
+                shared.score + warp_id * D256_BM32_PHASE_BLOCK_N,
+                probability_top, warp_id, shared.row_max, shared.row_sum,
+                warp_id, panel, NEG_INF);
+            bottom_exp_diff = d256_bm32_phase_make_probability_row(
+                shared.score + (D256_BM32_PHASE_PANEL_M + warp_id) *
+                                   D256_BM32_PHASE_BLOCK_N,
+                probability_bottom, warp_id, shared.row_max, shared.row_sum,
+                D256_BM32_PHASE_PANEL_M + warp_id, panel, NEG_INF);
+          }
+          if (lane_id == 0) {
+            row_exp_diff[warp_id] = top_exp_diff;
+            row_exp_diff[D256_BM32_PHASE_PANEL_M + warp_id] = bottom_exp_diff;
+          }
+        }
+        // Publish lane 0's online-softmax state to this warp before
+        // it advances to the next panel.
+        __syncwarp();
+      }
+      __syncthreads();
+
+#pragma unroll
+      for (int panel = 0; panel < D256_BM32_PHASE_PANELS; ++panel) {
+        const int panel_start = panel * D256_BM32_PHASE_SOFTMAX_N;
+        const int valid_panel_columns =
+            min(D256_BM32_PHASE_SOFTMAX_N, valid_k_rows - panel_start);
+        if (valid_panel_columns > 0) {
+          const __half* probability_top =
+              shared.probability_top +
+              panel * D256_BM32_PHASE_PROBABILITY_ELEMENTS;
+          const __half* probability_bottom =
+              shared.probability_bottom +
+              panel * D256_BM32_PHASE_PROBABILITY_ELEMENTS;
+          const float* row_exp_diff =
+              shared.row_exp_diff + panel * D256_BM32_PHASE_BLOCK_M;
+          if constexpr (SPLIT_KV) {
+            d256_bm32_phase_scale_accumulators(
+                accumulator_top, accumulator_bottom, row_exp_diff);
+          } else if (shared.block_index != 0 || panel != 0) {
+            d256_bm32_phase_scale_accumulators(
+                accumulator_top, accumulator_bottom, row_exp_diff);
+          }
+          const int page_slot_k0 = panel_start >> 4;
+          const __half* value_k0 =
+              reinterpret_cast<const __half*>(shared.v_tile_ptr[page_slot_k0]);
+          const __half* value_k16 = nullptr;
+          if (valid_panel_columns > WMMA_K) {
+            const int page_slot_k16 = (panel_start + WMMA_K) >> 4;
+            value_k16 = reinterpret_cast<const __half*>(
+                shared.v_tile_ptr[page_slot_k16]);
+          }
+          d256_bm32_phase_update_pv_panel(probability_top, probability_bottom,
+                                          value_k0, value_k16, v_token_stride,
+                                          warp_id * WMMA_N, valid_panel_columns,
+                                          accumulator_top, accumulator_bottom);
+        }
+      }
+      // Protect the current V pointers and block index from the next
+      // iteration while slower warps finish the last PV panel.
+      __syncthreads();
+    } else {
+#pragma unroll
+      for (int panel = 0; panel < D256_BM32_PHASE_PANELS; ++panel) {
+        const int panel_start = panel * D256_BM32_PHASE_SOFTMAX_N;
+        const int valid_panel_columns =
+            min(D256_BM32_PHASE_SOFTMAX_N, valid_k_rows - panel_start);
+        if (valid_panel_columns > 0) {
+          const float top_exp_diff = d256_bm32_phase_make_probability_row(
+              shared.score + warp_id * D256_BM32_PHASE_BLOCK_N,
+              shared.probability_top, warp_id, shared.row_max, shared.row_sum,
+              warp_id, panel, NEG_INF);
+          const float bottom_exp_diff = d256_bm32_phase_make_probability_row(
+              shared.score +
+                  (D256_BM32_PHASE_PANEL_M + warp_id) * D256_BM32_PHASE_BLOCK_N,
+              shared.probability_bottom, warp_id, shared.row_max,
+              shared.row_sum, D256_BM32_PHASE_PANEL_M + warp_id, panel,
+              NEG_INF);
+          if (lane_id == 0) {
+            shared.row_exp_diff[warp_id] = top_exp_diff;
+            shared.row_exp_diff[D256_BM32_PHASE_PANEL_M + warp_id] =
+                bottom_exp_diff;
+          }
+        }
+        __syncthreads();
+
+        if (valid_panel_columns > 0) {
+          if constexpr (SPLIT_KV) {
+            d256_bm32_phase_scale_accumulators(
+                accumulator_top, accumulator_bottom, shared.row_exp_diff);
+          } else if (shared.block_index != 0 || panel != 0) {
+            d256_bm32_phase_scale_accumulators(
+                accumulator_top, accumulator_bottom, shared.row_exp_diff);
+          }
+          const int page_slot_k0 = panel_start >> 4;
+          const __half* value_k0 =
+              reinterpret_cast<const __half*>(shared.v_tile_ptr[page_slot_k0]);
+          const __half* value_k16 = nullptr;
+          if (valid_panel_columns > WMMA_K) {
+            const int page_slot_k16 = (panel_start + WMMA_K) >> 4;
+            value_k16 = reinterpret_cast<const __half*>(
+                shared.v_tile_ptr[page_slot_k16]);
+          }
+          d256_bm32_phase_update_pv_panel(
+              shared.probability_top, shared.probability_bottom, value_k0,
+              value_k16, v_token_stride, warp_id * WMMA_N, valid_panel_columns,
+              accumulator_top, accumulator_bottom);
+        }
+        __syncthreads();
+      }
+    }
+
+    if (tid == 0) {
+      ++shared.block_index;
+    }
+    __syncthreads();
+  }
+
+  {
+    const size_t q_head_linear = static_cast<size_t>(blockIdx.z);
     if constexpr (SPLIT_KV) {
-        if (tid == 0) {
-            shared.block_index =
-                static_cast<int>(blockIdx.y) * total_n_blocks
-                / D256_BM32_PHASE_SPLIT_PARTS;
-            shared.split_end_block =
-                (static_cast<int>(blockIdx.y) + 1) * total_n_blocks
-                / D256_BM32_PHASE_SPLIT_PARTS;
-        }
-        __syncthreads();
+      const size_t partial_row_base =
+          (q_head_linear * D256_BM32_PHASE_SPLIT_PARTS +
+           static_cast<int>(blockIdx.y)) *
+              M +
+          start_row;
+      float* partial_out = split_tmp_out + partial_row_base * D256_BM32_PHASE_D;
+      d256_bm32_phase_store_unnormalized_partial(
+          accumulator_top, partial_out, 0, warp_id * WMMA_N, valid_q_rows);
+      d256_bm32_phase_store_unnormalized_partial(
+          accumulator_bottom, partial_out, D256_BM32_PHASE_PANEL_M,
+          warp_id * WMMA_N, valid_q_rows);
+      if (tid < valid_q_rows) {
+        split_tmp_row_max[partial_row_base + tid] = shared.row_max[tid];
+        split_tmp_row_sum[partial_row_base + tid] = shared.row_sum[tid];
+      }
+    } else {
+      __half* out_ptr = Out + q_head_linear * M * D256_BM32_PHASE_D +
+                        start_row * D256_BM32_PHASE_D;
+      float* softmax_lse_ptr = softmax_lse + q_head_linear * M + start_row;
+      if (valid_q_rows == D256_BM32_PHASE_BLOCK_M) {
+        d256_bm32_phase_store_output(accumulator_top, out_ptr, shared.row_sum,
+                                     0, warp_id * WMMA_N);
+        d256_bm32_phase_store_output(accumulator_bottom, out_ptr,
+                                     shared.row_sum, D256_BM32_PHASE_PANEL_M,
+                                     warp_id * WMMA_N);
+      } else {
+        d256_bm32_phase_store_output_partial(accumulator_top, out_ptr,
+                                             shared.row_sum, 0,
+                                             warp_id * WMMA_N, valid_q_rows);
+        d256_bm32_phase_store_output_partial(
+            accumulator_bottom, out_ptr, shared.row_sum,
+            D256_BM32_PHASE_PANEL_M, warp_id * WMMA_N, valid_q_rows);
+      }
+
+      if (tid < valid_q_rows) {
+        const float sum = fmaxf(shared.row_sum[tid], 1e-24f);
+        softmax_lse_ptr[tid] = shared.row_max[tid] + logf(sum);
+      }
     }
-
-    D256BM32PhaseAccumulatorFragment accumulator_top;
-    D256BM32PhaseAccumulatorFragment accumulator_bottom;
-    fill_fragment(accumulator_top, 0.0f);
-    fill_fragment(accumulator_bottom, 0.0f);
-
-    for (;;) {
-        if constexpr (SPLIT_KV) {
-            if (shared.block_index >= shared.split_end_block) {
-                break;
-            }
-        } else {
-            if (shared.block_index >= total_n_blocks) {
-                break;
-            }
-        }
-        const int start_col =
-            shared.block_index * D256_BM32_PHASE_BLOCK_N;
-        const int valid_k_rows = min(D256_BM32_PHASE_BLOCK_N,
-                                     shared.actual_n - start_col);
-
-        if (tid < D256_BM32_PHASE_PAGE_SLOTS) {
-            const int token_offset = tid * D256_BM32_PHASE_PAGE_SIZE;
-            if (token_offset < valid_k_rows) {
-                const int global_token_idx = start_col + token_offset;
-                const int virtual_block_idx =
-                    global_token_idx / D256_BM32_PHASE_PAGE_BLOCK_SIZE;
-                shared.page_idx[tid] =
-                    __ldg(&block_table[shared.batch_id
-                                       * max_num_blocks_per_seq
-                                       + virtual_block_idx]);
-                shared.page_offset[tid] =
-                    global_token_idx
-                    - virtual_block_idx * D256_BM32_PHASE_PAGE_BLOCK_SIZE;
-                shared.k_tile_ptr[tid] = reinterpret_cast<uint64_t>(
-                    K_cache
-                    + (int64_t)shared.page_idx[tid] * k_block_stride
-                    + (int64_t)shared.page_offset[tid] * k_token_stride
-                    + (int64_t)shared.kv_head_id * k_head_stride);
-                shared.v_tile_ptr[tid] = reinterpret_cast<uint64_t>(
-                    V_cache
-                    + (int64_t)shared.page_idx[tid] * v_block_stride
-                    + (int64_t)shared.page_offset[tid] * v_token_stride
-                    + (int64_t)shared.kv_head_id * v_head_stride);
-            } else {
-                shared.page_idx[tid] = -1;
-                shared.page_offset[tid] = 0;
-                shared.k_tile_ptr[tid] = 0;
-                shared.v_tile_ptr[tid] = 0;
-            }
-        }
-        __syncthreads();
-
-        if (warp_id < D256_BM32_PHASE_BLOCK_N / WMMA_N
-            && warp_id * WMMA_N < valid_k_rows) {
-            const int tile_n = warp_id * WMMA_N;
-            const __half* k_tile =
-                reinterpret_cast<const __half*>(shared.k_tile_ptr[warp_id]);
-            if constexpr (PAIR_SCRATCH) {
-                d256_bm32_phase_spill_pair_scratch(
-                    shared.score, accumulator_top, accumulator_bottom);
-            } else {
-                store_matrix_sync(shared.score + tile_n, accumulator_top,
-                                  D256_BM32_PHASE_BLOCK_N, mem_row_major);
-                store_matrix_sync(
-                    shared.score + D256_BM32_PHASE_PANEL_M
-                                       * D256_BM32_PHASE_BLOCK_N + tile_n,
-                    accumulator_bottom, D256_BM32_PHASE_BLOCK_N,
-                    mem_row_major);
-            }
-            asm volatile("" ::: "memory");
-
-            D256BM32PhaseAccumulatorFragment qk_top;
-            D256BM32PhaseAccumulatorFragment qk_bottom;
-            {
-                D256BM32PhaseMatrixAFragment a_fragment;
-                D256BM32PhaseQKMatrixBFragment b_fragment;
-                fill_fragment(qk_top, 0.0f);
-                fill_fragment(qk_bottom, 0.0f);
-
-                #pragma unroll
-                for (int k_offset = 0; k_offset < D256_BM32_PHASE_D;
-                     k_offset += WMMA_K) {
-                    load_matrix_sync(b_fragment, k_tile + k_offset,
-                                     k_token_stride);
-                    d256_bm32_phase_load_matrix_a(
-                        a_fragment, shared.query, k_offset);
-                    mma_sync(qk_top, a_fragment, b_fragment, qk_top);
-                    d256_bm32_phase_load_matrix_a(
-                        a_fragment,
-                        shared.query
-                            + D256_BM32_PHASE_PANEL_M
-                                  * D256_BM32_PHASE_D,
-                        k_offset);
-                    mma_sync(qk_bottom, a_fragment, b_fragment, qk_bottom);
-                }
-            }
-            asm volatile("" ::: "memory");
-
-            if constexpr (PAIR_SCRATCH) {
-                d256_bm32_phase_reload_pair_scratch(
-                    shared.score, accumulator_top, accumulator_bottom);
-                const int partner_warp = warp_id ^ 1;
-                if (partner_warp * WMMA_N < valid_k_rows) {
-                    d256_bm32_phase_sync_warp_pair(warp_id >> 1);
-                }
-            } else {
-                load_matrix_sync(accumulator_top, shared.score + tile_n,
-                                 D256_BM32_PHASE_BLOCK_N, mem_row_major);
-                load_matrix_sync(
-                    accumulator_bottom,
-                    shared.score + D256_BM32_PHASE_PANEL_M
-                                       * D256_BM32_PHASE_BLOCK_N + tile_n,
-                    D256_BM32_PHASE_BLOCK_N, mem_row_major);
-            }
-
-            store_matrix_sync(shared.score + tile_n, qk_top,
-                              D256_BM32_PHASE_BLOCK_N, mem_row_major);
-            store_matrix_sync(
-                shared.score + D256_BM32_PHASE_PANEL_M
-                                   * D256_BM32_PHASE_BLOCK_N + tile_n,
-                qk_bottom, D256_BM32_PHASE_BLOCK_N, mem_row_major);
-        }
-        __syncthreads();
-
-        const int causal_q_offset = max(shared.actual_n - M, 0);
-        #pragma unroll 1
-        for (int index = tid;
-             index < D256_BM32_PHASE_BLOCK_M * D256_BM32_PHASE_BLOCK_N;
-             index += D256_BM32_PHASE_THREADS) {
-            const int row = index / D256_BM32_PHASE_BLOCK_N;
-            const int column = index - row * D256_BM32_PHASE_BLOCK_N;
-            const int global_m = start_row + row;
-            const int global_n = start_col + column;
-            const bool is_valid = global_m < M
-                                  && global_n < start_col + valid_k_rows;
-            if constexpr (IS_CAUSAL) {
-                if (is_valid && global_n <= global_m + causal_q_offset) {
-                    shared.score[index] *= softmax_scale;
-                } else {
-                    shared.score[index] = NEG_INF;
-                }
-            } else {
-                if (is_valid) {
-                    shared.score[index] *= softmax_scale;
-                } else {
-                    shared.score[index] = NEG_INF;
-                }
-            }
-        }
-        __syncthreads();
-
-        if constexpr (ALL_P) {
-            #pragma unroll
-            for (int panel = 0; panel < D256_BM32_PHASE_PANELS;
-                 ++panel) {
-                const int panel_start =
-                    panel * D256_BM32_PHASE_SOFTMAX_N;
-                const int valid_panel_columns =
-                    min(D256_BM32_PHASE_SOFTMAX_N,
-                        valid_k_rows - panel_start);
-                if (valid_panel_columns > 0) {
-                    __half* probability_top =
-                        shared.probability_top
-                        + panel * D256_BM32_PHASE_PROBABILITY_ELEMENTS;
-                    __half* probability_bottom =
-                        shared.probability_bottom
-                        + panel * D256_BM32_PHASE_PROBABILITY_ELEMENTS;
-                    float* row_exp_diff =
-                        shared.row_exp_diff
-                        + panel * D256_BM32_PHASE_BLOCK_M;
-                    float top_exp_diff;
-                    float bottom_exp_diff;
-                    if constexpr (SPLIT_KV && CHECK_SPLIT_EMPTY) {
-                        const int first_global_n = start_col + panel_start;
-                        const bool top_has_visible_value =
-                            warp_id < valid_q_rows
-                            && (!IS_CAUSAL
-                                || first_global_n
-                                       <= start_row + warp_id
-                                              + causal_q_offset);
-                        const bool bottom_has_visible_value =
-                            D256_BM32_PHASE_PANEL_M + warp_id < valid_q_rows
-                            && (!IS_CAUSAL
-                                || first_global_n
-                                       <= start_row
-                                              + D256_BM32_PHASE_PANEL_M
-                                              + warp_id + causal_q_offset);
-                        top_exp_diff =
-                            d256_bm32_phase_make_split_probability_row(
-                                shared.score
-                                    + warp_id * D256_BM32_PHASE_BLOCK_N,
-                                probability_top, warp_id, shared.row_max,
-                                shared.row_sum, warp_id, panel, NEG_INF,
-                                top_has_visible_value);
-                        bottom_exp_diff =
-                            d256_bm32_phase_make_split_probability_row(
-                                shared.score
-                                    + (D256_BM32_PHASE_PANEL_M + warp_id)
-                                          * D256_BM32_PHASE_BLOCK_N,
-                                probability_bottom, warp_id, shared.row_max,
-                                shared.row_sum,
-                                D256_BM32_PHASE_PANEL_M + warp_id, panel,
-                                NEG_INF, bottom_has_visible_value);
-                    } else {
-                        top_exp_diff = d256_bm32_phase_make_probability_row(
-                            shared.score
-                                + warp_id * D256_BM32_PHASE_BLOCK_N,
-                            probability_top, warp_id, shared.row_max,
-                            shared.row_sum, warp_id, panel, NEG_INF);
-                        bottom_exp_diff =
-                            d256_bm32_phase_make_probability_row(
-                                shared.score
-                                    + (D256_BM32_PHASE_PANEL_M + warp_id)
-                                          * D256_BM32_PHASE_BLOCK_N,
-                                probability_bottom, warp_id, shared.row_max,
-                                shared.row_sum,
-                                D256_BM32_PHASE_PANEL_M + warp_id, panel,
-                                NEG_INF);
-                    }
-                    if (lane_id == 0) {
-                        row_exp_diff[warp_id] = top_exp_diff;
-                        row_exp_diff[D256_BM32_PHASE_PANEL_M + warp_id] =
-                            bottom_exp_diff;
-                    }
-                }
-                // Publish lane 0's online-softmax state to this warp before
-                // it advances to the next panel.
-                __syncwarp();
-            }
-            __syncthreads();
-
-            #pragma unroll
-            for (int panel = 0; panel < D256_BM32_PHASE_PANELS;
-                 ++panel) {
-                const int panel_start =
-                    panel * D256_BM32_PHASE_SOFTMAX_N;
-                const int valid_panel_columns =
-                    min(D256_BM32_PHASE_SOFTMAX_N,
-                        valid_k_rows - panel_start);
-                if (valid_panel_columns > 0) {
-                    const __half* probability_top =
-                        shared.probability_top
-                        + panel * D256_BM32_PHASE_PROBABILITY_ELEMENTS;
-                    const __half* probability_bottom =
-                        shared.probability_bottom
-                        + panel * D256_BM32_PHASE_PROBABILITY_ELEMENTS;
-                    const float* row_exp_diff =
-                        shared.row_exp_diff
-                        + panel * D256_BM32_PHASE_BLOCK_M;
-                    if constexpr (SPLIT_KV) {
-                        d256_bm32_phase_scale_accumulators(
-                            accumulator_top, accumulator_bottom,
-                            row_exp_diff);
-                    } else if (shared.block_index != 0 || panel != 0) {
-                        d256_bm32_phase_scale_accumulators(
-                            accumulator_top, accumulator_bottom,
-                            row_exp_diff);
-                    }
-                    const int page_slot_k0 = panel_start >> 4;
-                    const __half* value_k0 =
-                        reinterpret_cast<const __half*>(
-                            shared.v_tile_ptr[page_slot_k0]);
-                    const __half* value_k16 = nullptr;
-                    if (valid_panel_columns > WMMA_K) {
-                        const int page_slot_k16 =
-                            (panel_start + WMMA_K) >> 4;
-                        value_k16 =
-                            reinterpret_cast<const __half*>(
-                                shared.v_tile_ptr[page_slot_k16]);
-                    }
-                    d256_bm32_phase_update_pv_panel(
-                        probability_top, probability_bottom,
-                        value_k0, value_k16, v_token_stride,
-                        warp_id * WMMA_N,
-                        valid_panel_columns,
-                        accumulator_top, accumulator_bottom);
-                }
-            }
-            // Protect the current V pointers and block index from the next
-            // iteration while slower warps finish the last PV panel.
-            __syncthreads();
-        } else {
-            #pragma unroll
-            for (int panel = 0; panel < D256_BM32_PHASE_PANELS;
-                 ++panel) {
-                const int panel_start =
-                    panel * D256_BM32_PHASE_SOFTMAX_N;
-                const int valid_panel_columns =
-                    min(D256_BM32_PHASE_SOFTMAX_N,
-                        valid_k_rows - panel_start);
-                if (valid_panel_columns > 0) {
-                    const float top_exp_diff =
-                        d256_bm32_phase_make_probability_row(
-                            shared.score
-                                + warp_id * D256_BM32_PHASE_BLOCK_N,
-                            shared.probability_top, warp_id, shared.row_max,
-                            shared.row_sum, warp_id, panel, NEG_INF);
-                    const float bottom_exp_diff =
-                        d256_bm32_phase_make_probability_row(
-                            shared.score
-                                + (D256_BM32_PHASE_PANEL_M + warp_id)
-                                      * D256_BM32_PHASE_BLOCK_N,
-                            shared.probability_bottom, warp_id,
-                            shared.row_max, shared.row_sum,
-                            D256_BM32_PHASE_PANEL_M + warp_id, panel,
-                            NEG_INF);
-                    if (lane_id == 0) {
-                        shared.row_exp_diff[warp_id] = top_exp_diff;
-                        shared.row_exp_diff[
-                            D256_BM32_PHASE_PANEL_M + warp_id] =
-                            bottom_exp_diff;
-                    }
-                }
-                __syncthreads();
-
-                if (valid_panel_columns > 0) {
-                    if constexpr (SPLIT_KV) {
-                        d256_bm32_phase_scale_accumulators(
-                            accumulator_top, accumulator_bottom,
-                            shared.row_exp_diff);
-                    } else if (shared.block_index != 0 || panel != 0) {
-                        d256_bm32_phase_scale_accumulators(
-                            accumulator_top, accumulator_bottom,
-                            shared.row_exp_diff);
-                    }
-                    const int page_slot_k0 = panel_start >> 4;
-                    const __half* value_k0 =
-                        reinterpret_cast<const __half*>(
-                            shared.v_tile_ptr[page_slot_k0]);
-                    const __half* value_k16 = nullptr;
-                    if (valid_panel_columns > WMMA_K) {
-                        const int page_slot_k16 =
-                            (panel_start + WMMA_K) >> 4;
-                        value_k16 =
-                            reinterpret_cast<const __half*>(
-                                shared.v_tile_ptr[page_slot_k16]);
-                    }
-                    d256_bm32_phase_update_pv_panel(
-                        shared.probability_top,
-                        shared.probability_bottom,
-                        value_k0, value_k16, v_token_stride,
-                        warp_id * WMMA_N,
-                        valid_panel_columns,
-                        accumulator_top, accumulator_bottom);
-                }
-                __syncthreads();
-            }
-        }
-
-        if (tid == 0) {
-            ++shared.block_index;
-        }
-        __syncthreads();
-    }
-
-    {
-        const size_t q_head_linear = static_cast<size_t>(blockIdx.z);
-        if constexpr (SPLIT_KV) {
-            const size_t partial_row_base =
-                (q_head_linear * D256_BM32_PHASE_SPLIT_PARTS
-                 + static_cast<int>(blockIdx.y))
-                    * M
-                + start_row;
-            float* partial_out =
-                split_tmp_out
-                + partial_row_base * D256_BM32_PHASE_D;
-            d256_bm32_phase_store_unnormalized_partial(
-                accumulator_top, partial_out, 0,
-                warp_id * WMMA_N, valid_q_rows);
-            d256_bm32_phase_store_unnormalized_partial(
-                accumulator_bottom, partial_out,
-                D256_BM32_PHASE_PANEL_M, warp_id * WMMA_N, valid_q_rows);
-            if (tid < valid_q_rows) {
-                split_tmp_row_max[partial_row_base + tid] =
-                    shared.row_max[tid];
-                split_tmp_row_sum[partial_row_base + tid] =
-                    shared.row_sum[tid];
-            }
-        } else {
-            __half* out_ptr =
-                Out + q_head_linear * M * D256_BM32_PHASE_D
-                + start_row * D256_BM32_PHASE_D;
-            float* softmax_lse_ptr =
-                softmax_lse + q_head_linear * M + start_row;
-            if (valid_q_rows == D256_BM32_PHASE_BLOCK_M) {
-                d256_bm32_phase_store_output(
-                    accumulator_top, out_ptr, shared.row_sum, 0,
-                    warp_id * WMMA_N);
-                d256_bm32_phase_store_output(
-                    accumulator_bottom, out_ptr, shared.row_sum,
-                    D256_BM32_PHASE_PANEL_M, warp_id * WMMA_N);
-            } else {
-                d256_bm32_phase_store_output_partial(
-                    accumulator_top, out_ptr, shared.row_sum, 0,
-                    warp_id * WMMA_N, valid_q_rows);
-                d256_bm32_phase_store_output_partial(
-                    accumulator_bottom, out_ptr, shared.row_sum,
-                    D256_BM32_PHASE_PANEL_M, warp_id * WMMA_N, valid_q_rows);
-            }
-
-            if (tid < valid_q_rows) {
-                const float sum = fmaxf(shared.row_sum[tid], 1e-24f);
-                softmax_lse_ptr[tid] = shared.row_max[tid] + logf(sum);
-            }
-        }
-    }
+  }
 }
 
-template<bool IS_CAUSAL, bool ALL_P = false, bool PAIR_SCRATCH = false>
-__global__ __launch_bounds__(D256_BM32_PHASE_THREADS, 2)
-void flash_attention_forward_paged_d256_bm32_phase_kernel(
-    const __half* __restrict__ Q,
-    const __half* __restrict__ K_cache,
-    const __half* __restrict__ V_cache,
-          __half* __restrict__ Out,
-           float* __restrict__ softmax_lse,
-    const int* __restrict__ block_table,
-    const int* __restrict__ seqused_k,
-    int H,
-    int M,
-    int max_num_blocks_per_seq,
-    int num_kv_heads,
-    int64_t k_block_stride,
-    int64_t k_token_stride,
-    int64_t k_head_stride,
-    int64_t v_block_stride,
-    int64_t v_token_stride,
-    int64_t v_head_stride,
-    float softmax_scale) {
-    flash_attention_forward_paged_d256_bm32_phase_body<
-        IS_CAUSAL, ALL_P, PAIR_SCRATCH, false>(
-            Q, K_cache, V_cache, Out, softmax_lse, block_table, seqused_k,
-            H, M, max_num_blocks_per_seq, num_kv_heads, k_block_stride,
-            k_token_stride, k_head_stride, v_block_stride, v_token_stride,
-            v_head_stride, softmax_scale, nullptr, nullptr, nullptr, 0);
+template <bool IS_CAUSAL, bool ALL_P = false, bool PAIR_SCRATCH = false>
+__global__
+__launch_bounds__(D256_BM32_PHASE_THREADS, 2) void flash_attention_forward_paged_d256_bm32_phase_kernel(
+    const __half* __restrict__ Q, const __half* __restrict__ K_cache,
+    const __half* __restrict__ V_cache, __half* __restrict__ Out,
+    float* __restrict__ softmax_lse, const int* __restrict__ block_table,
+    const int* __restrict__ seqused_k, int H, int M, int max_num_blocks_per_seq,
+    int num_kv_heads, int64_t k_block_stride, int64_t k_token_stride,
+    int64_t k_head_stride, int64_t v_block_stride, int64_t v_token_stride,
+    int64_t v_head_stride, float softmax_scale) {
+  flash_attention_forward_paged_d256_bm32_phase_body<IS_CAUSAL, ALL_P,
+                                                     PAIR_SCRATCH, false>(
+      Q, K_cache, V_cache, Out, softmax_lse, block_table, seqused_k, H, M,
+      max_num_blocks_per_seq, num_kv_heads, k_block_stride, k_token_stride,
+      k_head_stride, v_block_stride, v_token_stride, v_head_stride,
+      softmax_scale, nullptr, nullptr, nullptr, 0);
 }
 
-template<bool CHECK_SPLIT_EMPTY>
-__global__ __launch_bounds__(D256_BM32_PHASE_THREADS, 2)
-void flash_attention_forward_paged_d256_bm32_splitkv3_partial_kernel(
-    const __half* __restrict__ Q,
-    const __half* __restrict__ K_cache,
-    const __half* __restrict__ V_cache,
-    const int* __restrict__ block_table,
-    int H,
-    int M,
-    int actual_n,
-    int max_num_blocks_per_seq,
-    int num_kv_heads,
-    int64_t k_block_stride,
-    int64_t k_token_stride,
-    int64_t k_head_stride,
-    int64_t v_block_stride,
-    int64_t v_token_stride,
-    int64_t v_head_stride,
-    float softmax_scale,
-    float* __restrict__ split_tmp_out,
+template <bool CHECK_SPLIT_EMPTY>
+__global__
+__launch_bounds__(D256_BM32_PHASE_THREADS, 2) void flash_attention_forward_paged_d256_bm32_splitkv3_partial_kernel(
+    const __half* __restrict__ Q, const __half* __restrict__ K_cache,
+    const __half* __restrict__ V_cache, const int* __restrict__ block_table,
+    int H, int M, int actual_n, int max_num_blocks_per_seq, int num_kv_heads,
+    int64_t k_block_stride, int64_t k_token_stride, int64_t k_head_stride,
+    int64_t v_block_stride, int64_t v_token_stride, int64_t v_head_stride,
+    float softmax_scale, float* __restrict__ split_tmp_out,
     float* __restrict__ split_tmp_row_max,
     float* __restrict__ split_tmp_row_sum) {
-    flash_attention_forward_paged_d256_bm32_phase_body<
-        true, true, true, true, CHECK_SPLIT_EMPTY>(
-            Q, K_cache, V_cache, nullptr, nullptr, block_table, nullptr,
-            H, M, max_num_blocks_per_seq, num_kv_heads, k_block_stride,
-            k_token_stride, k_head_stride, v_block_stride, v_token_stride,
-            v_head_stride, softmax_scale, split_tmp_out,
-            split_tmp_row_max, split_tmp_row_sum, actual_n);
+  flash_attention_forward_paged_d256_bm32_phase_body<true, true, true, true,
+                                                     CHECK_SPLIT_EMPTY>(
+      Q, K_cache, V_cache, nullptr, nullptr, block_table, nullptr, H, M,
+      max_num_blocks_per_seq, num_kv_heads, k_block_stride, k_token_stride,
+      k_head_stride, v_block_stride, v_token_stride, v_head_stride,
+      softmax_scale, split_tmp_out, split_tmp_row_max, split_tmp_row_sum,
+      actual_n);
 }
 
-template<bool IS_CAUSAL, bool ALL_P, bool PAIR_SCRATCH>
+template <bool IS_CAUSAL, bool ALL_P, bool PAIR_SCRATCH>
 void launch_flash_attention_forward_paged_d256_bm32_phase_kernel(
-    const torch::Tensor& Q,
-    const torch::Tensor& K_cache,
-    const torch::Tensor& V_cache,
-    torch::Tensor& Out,
-    torch::Tensor& softmax_lse,
-    const torch::Tensor& block_table,
-    const torch::Tensor& seq_lens,
-    float softmax_scale,
-    cudaStream_t stream) {
-    const int H = Q.size(1);
-    const int M = Q.size(2);
-    const int num_kv_heads = K_cache.size(2);
-    const int max_num_blocks_per_seq = block_table.size(1);
-    const int64_t k_block_stride = K_cache.stride(0);
-    const int64_t k_token_stride = K_cache.stride(1);
-    const int64_t k_head_stride = K_cache.stride(2);
-    const int64_t v_block_stride = V_cache.stride(0);
-    const int64_t v_token_stride = V_cache.stride(1);
-    const int64_t v_head_stride = V_cache.stride(2);
-    const dim3 grid((M + D256_BM32_PHASE_BLOCK_M - 1)
-                        / D256_BM32_PHASE_BLOCK_M,
-                    1, Q.size(0) * H);
-    const dim3 block(D256_BM32_PHASE_THREADS);
-    flash_attention_forward_paged_d256_bm32_phase_kernel<
-        IS_CAUSAL, ALL_P, PAIR_SCRATCH><<<grid, block, 0, stream>>>(
-            reinterpret_cast<const __half*>(Q.data_ptr()),
-            reinterpret_cast<const __half*>(K_cache.data_ptr()),
-            reinterpret_cast<const __half*>(V_cache.data_ptr()),
-            reinterpret_cast<__half*>(Out.data_ptr()),
-            softmax_lse.data_ptr<float>(), block_table.data_ptr<int>(),
-            seq_lens.data_ptr<int>(), H, M, max_num_blocks_per_seq,
-            num_kv_heads, k_block_stride, k_token_stride, k_head_stride,
-            v_block_stride, v_token_stride, v_head_stride, softmax_scale);
+    const torch::Tensor& Q, const torch::Tensor& K_cache,
+    const torch::Tensor& V_cache, torch::Tensor& Out,
+    torch::Tensor& softmax_lse, const torch::Tensor& block_table,
+    const torch::Tensor& seq_lens, float softmax_scale, cudaStream_t stream) {
+  const int H = Q.size(1);
+  const int M = Q.size(2);
+  const int num_kv_heads = K_cache.size(2);
+  const int max_num_blocks_per_seq = block_table.size(1);
+  const int64_t k_block_stride = K_cache.stride(0);
+  const int64_t k_token_stride = K_cache.stride(1);
+  const int64_t k_head_stride = K_cache.stride(2);
+  const int64_t v_block_stride = V_cache.stride(0);
+  const int64_t v_token_stride = V_cache.stride(1);
+  const int64_t v_head_stride = V_cache.stride(2);
+  const dim3 grid((M + D256_BM32_PHASE_BLOCK_M - 1) / D256_BM32_PHASE_BLOCK_M,
+                  1, Q.size(0) * H);
+  const dim3 block(D256_BM32_PHASE_THREADS);
+  flash_attention_forward_paged_d256_bm32_phase_kernel<IS_CAUSAL, ALL_P,
+                                                       PAIR_SCRATCH>
+      <<<grid, block, 0, stream>>>(
+          reinterpret_cast<const __half*>(Q.data_ptr()),
+          reinterpret_cast<const __half*>(K_cache.data_ptr()),
+          reinterpret_cast<const __half*>(V_cache.data_ptr()),
+          reinterpret_cast<__half*>(Out.data_ptr()),
+          softmax_lse.data_ptr<float>(), block_table.data_ptr<int>(),
+          seq_lens.data_ptr<int>(), H, M, max_num_blocks_per_seq, num_kv_heads,
+          k_block_stride, k_token_stride, k_head_stride, v_block_stride,
+          v_token_stride, v_head_stride, softmax_scale);
 }
 
-__global__ __launch_bounds__(256)
-void flash_attention_forward_paged_d256_bm32_splitkv3_merge_kernel(
+__global__
+__launch_bounds__(256) void flash_attention_forward_paged_d256_bm32_splitkv3_merge_kernel(
     const float* __restrict__ split_tmp_out,
     const float* __restrict__ split_tmp_row_max,
-    const float* __restrict__ split_tmp_row_sum,
-    __half* __restrict__ Out,
-    float* __restrict__ softmax_lse,
-    int M) {
-    const int start_row = blockIdx.x * D256_BM32_PHASE_BLOCK_M;
-    const int row_local = threadIdx.x >> 3;
-    const int lane_in_row = threadIdx.x & 7;
-    const int row = start_row + row_local;
-    if (row >= M) {
-        return;
-    }
+    const float* __restrict__ split_tmp_row_sum, __half* __restrict__ Out,
+    float* __restrict__ softmax_lse, int M) {
+  const int start_row = blockIdx.x * D256_BM32_PHASE_BLOCK_M;
+  const int row_local = threadIdx.x >> 3;
+  const int lane_in_row = threadIdx.x & 7;
+  const int row = start_row + row_local;
+  if (row >= M) {
+    return;
+  }
 
-    const size_t q_head_linear = static_cast<size_t>(blockIdx.z);
-    const size_t first_state =
-        (q_head_linear * D256_BM32_PHASE_SPLIT_PARTS) * M + row;
-    const float max_0 = split_tmp_row_max[first_state];
-    const float max_1 = split_tmp_row_max[first_state + M];
-    const float max_2 = split_tmp_row_max[first_state + 2 * M];
-    const float sum_0 = split_tmp_row_sum[first_state];
-    const float sum_1 = split_tmp_row_sum[first_state + M];
-    const float sum_2 = split_tmp_row_sum[first_state + 2 * M];
-    const float merged_max = fmaxf(max_0, fmaxf(max_1, max_2));
-    const float weight_0 =
-        sum_0 > 0.0f ? __expf(fmaxf(max_0 - merged_max, -80.0f)) : 0.0f;
-    const float weight_1 =
-        sum_1 > 0.0f ? __expf(fmaxf(max_1 - merged_max, -80.0f)) : 0.0f;
-    const float weight_2 =
-        sum_2 > 0.0f ? __expf(fmaxf(max_2 - merged_max, -80.0f)) : 0.0f;
-    const float denominator =
-        weight_0 * sum_0 + weight_1 * sum_1 + weight_2 * sum_2;
-    const float inverse_denominator =
-        1.0f / fmaxf(denominator, 1e-24f);
+  const size_t q_head_linear = static_cast<size_t>(blockIdx.z);
+  const size_t first_state =
+      (q_head_linear * D256_BM32_PHASE_SPLIT_PARTS) * M + row;
+  const float max_0 = split_tmp_row_max[first_state];
+  const float max_1 = split_tmp_row_max[first_state + M];
+  const float max_2 = split_tmp_row_max[first_state + 2 * M];
+  const float sum_0 = split_tmp_row_sum[first_state];
+  const float sum_1 = split_tmp_row_sum[first_state + M];
+  const float sum_2 = split_tmp_row_sum[first_state + 2 * M];
+  const float merged_max = fmaxf(max_0, fmaxf(max_1, max_2));
+  const float weight_0 =
+      sum_0 > 0.0f ? __expf(fmaxf(max_0 - merged_max, -80.0f)) : 0.0f;
+  const float weight_1 =
+      sum_1 > 0.0f ? __expf(fmaxf(max_1 - merged_max, -80.0f)) : 0.0f;
+  const float weight_2 =
+      sum_2 > 0.0f ? __expf(fmaxf(max_2 - merged_max, -80.0f)) : 0.0f;
+  const float denominator =
+      weight_0 * sum_0 + weight_1 * sum_1 + weight_2 * sum_2;
+  const float inverse_denominator = 1.0f / fmaxf(denominator, 1e-24f);
 
-    if (lane_in_row == 0) {
-        softmax_lse[q_head_linear * M + row] =
-            merged_max + logf(fmaxf(denominator, 1e-24f));
-    }
+  if (lane_in_row == 0) {
+    softmax_lse[q_head_linear * M + row] =
+        merged_max + logf(fmaxf(denominator, 1e-24f));
+  }
 
-    const size_t output_base =
-        (q_head_linear * M + row) * D256_BM32_PHASE_D;
-    const size_t partial_base_0 = first_state * D256_BM32_PHASE_D;
-    const size_t partial_base_1 =
-        (first_state + M) * D256_BM32_PHASE_D;
-    const size_t partial_base_2 =
-        (first_state + 2 * M) * D256_BM32_PHASE_D;
-    #pragma unroll
-    for (int column = lane_in_row; column < D256_BM32_PHASE_D; column += 8) {
-        const float numerator =
-            weight_0 * split_tmp_out[partial_base_0 + column]
-            + weight_1 * split_tmp_out[partial_base_1 + column]
-            + weight_2 * split_tmp_out[partial_base_2 + column];
-        Out[output_base + column] =
-            __float2half_rn(numerator * inverse_denominator);
-    }
+  const size_t output_base = (q_head_linear * M + row) * D256_BM32_PHASE_D;
+  const size_t partial_base_0 = first_state * D256_BM32_PHASE_D;
+  const size_t partial_base_1 = (first_state + M) * D256_BM32_PHASE_D;
+  const size_t partial_base_2 = (first_state + 2 * M) * D256_BM32_PHASE_D;
+#pragma unroll
+  for (int column = lane_in_row; column < D256_BM32_PHASE_D; column += 8) {
+    const float numerator = weight_0 * split_tmp_out[partial_base_0 + column] +
+                            weight_1 * split_tmp_out[partial_base_1 + column] +
+                            weight_2 * split_tmp_out[partial_base_2 + column];
+    Out[output_base + column] =
+        __float2half_rn(numerator * inverse_denominator);
+  }
 }
 
 void launch_flash_attention_forward_paged_d256_bm32_splitkv3_kernel(
-    const torch::Tensor& Q,
-    const torch::Tensor& K_cache,
-    const torch::Tensor& V_cache,
-    torch::Tensor& Out,
-    torch::Tensor& softmax_lse,
-    torch::Tensor& split_tmp_out,
-    torch::Tensor& split_tmp_row_max,
-    torch::Tensor& split_tmp_row_sum,
-    const torch::Tensor& block_table,
-    int actual_n,
-    float softmax_scale,
+    const torch::Tensor& Q, const torch::Tensor& K_cache,
+    const torch::Tensor& V_cache, torch::Tensor& Out,
+    torch::Tensor& softmax_lse, torch::Tensor& split_tmp_out,
+    torch::Tensor& split_tmp_row_max, torch::Tensor& split_tmp_row_sum,
+    const torch::Tensor& block_table, int actual_n, float softmax_scale,
     cudaStream_t stream) {
-    const int H = Q.size(1);
-    const int M = Q.size(2);
-    const int num_kv_heads = K_cache.size(2);
-    const int max_num_blocks_per_seq = block_table.size(1);
-    const int64_t k_block_stride = K_cache.stride(0);
-    const int64_t k_token_stride = K_cache.stride(1);
-    const int64_t k_head_stride = K_cache.stride(2);
-    const int64_t v_block_stride = V_cache.stride(0);
-    const int64_t v_token_stride = V_cache.stride(1);
-    const int64_t v_head_stride = V_cache.stride(2);
-    const dim3 partial_grid(
-        (M + D256_BM32_PHASE_BLOCK_M - 1) / D256_BM32_PHASE_BLOCK_M,
-        D256_BM32_PHASE_SPLIT_PARTS,
-        Q.size(0) * H);
-    const dim3 partial_block(D256_BM32_PHASE_THREADS);
-    const int64_t total_n_blocks =
-        (static_cast<int64_t>(actual_n) + D256_BM32_PHASE_BLOCK_N - 1)
-        / D256_BM32_PHASE_BLOCK_N;
-    const int64_t last_split_begin =
-        (D256_BM32_PHASE_SPLIT_PARTS - 1) * total_n_blocks
-        / D256_BM32_PHASE_SPLIT_PARTS * D256_BM32_PHASE_BLOCK_N;
-    const bool check_split_empty =
-        total_n_blocks < D256_BM32_PHASE_SPLIT_PARTS
-        || last_split_begin > static_cast<int64_t>(actual_n) - M;
-    if (check_split_empty) {
-        flash_attention_forward_paged_d256_bm32_splitkv3_partial_kernel<true>
-            <<<partial_grid, partial_block, 0, stream>>>(
-                reinterpret_cast<const __half*>(Q.data_ptr()),
-                reinterpret_cast<const __half*>(K_cache.data_ptr()),
-                reinterpret_cast<const __half*>(V_cache.data_ptr()),
-                block_table.data_ptr<int>(), H, M, actual_n,
-                max_num_blocks_per_seq, num_kv_heads, k_block_stride,
-                k_token_stride, k_head_stride, v_block_stride,
-                v_token_stride, v_head_stride, softmax_scale,
-                split_tmp_out.data_ptr<float>(),
-                split_tmp_row_max.data_ptr<float>(),
-                split_tmp_row_sum.data_ptr<float>());
-    } else {
-        flash_attention_forward_paged_d256_bm32_splitkv3_partial_kernel<false>
-            <<<partial_grid, partial_block, 0, stream>>>(
+  const int H = Q.size(1);
+  const int M = Q.size(2);
+  const int num_kv_heads = K_cache.size(2);
+  const int max_num_blocks_per_seq = block_table.size(1);
+  const int64_t k_block_stride = K_cache.stride(0);
+  const int64_t k_token_stride = K_cache.stride(1);
+  const int64_t k_head_stride = K_cache.stride(2);
+  const int64_t v_block_stride = V_cache.stride(0);
+  const int64_t v_token_stride = V_cache.stride(1);
+  const int64_t v_head_stride = V_cache.stride(2);
+  const dim3 partial_grid(
+      (M + D256_BM32_PHASE_BLOCK_M - 1) / D256_BM32_PHASE_BLOCK_M,
+      D256_BM32_PHASE_SPLIT_PARTS, Q.size(0) * H);
+  const dim3 partial_block(D256_BM32_PHASE_THREADS);
+  const int64_t total_n_blocks =
+      (static_cast<int64_t>(actual_n) + D256_BM32_PHASE_BLOCK_N - 1) /
+      D256_BM32_PHASE_BLOCK_N;
+  const int64_t last_split_begin =
+      (D256_BM32_PHASE_SPLIT_PARTS - 1) * total_n_blocks /
+      D256_BM32_PHASE_SPLIT_PARTS * D256_BM32_PHASE_BLOCK_N;
+  const bool check_split_empty =
+      total_n_blocks < D256_BM32_PHASE_SPLIT_PARTS ||
+      last_split_begin > static_cast<int64_t>(actual_n) - M;
+  if (check_split_empty) {
+    flash_attention_forward_paged_d256_bm32_splitkv3_partial_kernel<true>
+        <<<partial_grid, partial_block, 0, stream>>>(
             reinterpret_cast<const __half*>(Q.data_ptr()),
             reinterpret_cast<const __half*>(K_cache.data_ptr()),
             reinterpret_cast<const __half*>(V_cache.data_ptr()),
-                block_table.data_ptr<int>(), H, M, actual_n,
-                max_num_blocks_per_seq, num_kv_heads, k_block_stride,
-                k_token_stride, k_head_stride, v_block_stride,
-                v_token_stride, v_head_stride, softmax_scale,
-                split_tmp_out.data_ptr<float>(),
-                split_tmp_row_max.data_ptr<float>(),
-                split_tmp_row_sum.data_ptr<float>());
-    }
-
-    const dim3 merge_grid(
-        (M + D256_BM32_PHASE_BLOCK_M - 1) / D256_BM32_PHASE_BLOCK_M,
-        1,
-        Q.size(0) * H);
-    flash_attention_forward_paged_d256_bm32_splitkv3_merge_kernel
-        <<<merge_grid, 256, 0, stream>>>(
+            block_table.data_ptr<int>(), H, M, actual_n, max_num_blocks_per_seq,
+            num_kv_heads, k_block_stride, k_token_stride, k_head_stride,
+            v_block_stride, v_token_stride, v_head_stride, softmax_scale,
             split_tmp_out.data_ptr<float>(),
             split_tmp_row_max.data_ptr<float>(),
-            split_tmp_row_sum.data_ptr<float>(),
-            reinterpret_cast<__half*>(Out.data_ptr()),
-            softmax_lse.data_ptr<float>(), M);
+            split_tmp_row_sum.data_ptr<float>());
+  } else {
+    flash_attention_forward_paged_d256_bm32_splitkv3_partial_kernel<false>
+        <<<partial_grid, partial_block, 0, stream>>>(
+            reinterpret_cast<const __half*>(Q.data_ptr()),
+            reinterpret_cast<const __half*>(K_cache.data_ptr()),
+            reinterpret_cast<const __half*>(V_cache.data_ptr()),
+            block_table.data_ptr<int>(), H, M, actual_n, max_num_blocks_per_seq,
+            num_kv_heads, k_block_stride, k_token_stride, k_head_stride,
+            v_block_stride, v_token_stride, v_head_stride, softmax_scale,
+            split_tmp_out.data_ptr<float>(),
+            split_tmp_row_max.data_ptr<float>(),
+            split_tmp_row_sum.data_ptr<float>());
+  }
+
+  const dim3 merge_grid(
+      (M + D256_BM32_PHASE_BLOCK_M - 1) / D256_BM32_PHASE_BLOCK_M, 1,
+      Q.size(0) * H);
+  flash_attention_forward_paged_d256_bm32_splitkv3_merge_kernel<<<
+      merge_grid, 256, 0, stream>>>(split_tmp_out.data_ptr<float>(),
+                                    split_tmp_row_max.data_ptr<float>(),
+                                    split_tmp_row_sum.data_ptr<float>(),
+                                    reinterpret_cast<__half*>(Out.data_ptr()),
+                                    softmax_lse.data_ptr<float>(), M);
 }
 
 void launcher_flash_attention_forward_paged_d256_bm32_phase(
-    const torch::Tensor& Q,
-    const torch::Tensor& K_cache,
-    const torch::Tensor& V_cache,
-    torch::Tensor& Out,
-    torch::Tensor& softmax_lse,
-    const torch::Tensor& block_table,
-    const torch::Tensor& seq_lens,
-    float softmax_scale,
-    bool is_causal,
+    const torch::Tensor& Q, const torch::Tensor& K_cache,
+    const torch::Tensor& V_cache, torch::Tensor& Out,
+    torch::Tensor& softmax_lse, const torch::Tensor& block_table,
+    const torch::Tensor& seq_lens, float softmax_scale, bool is_causal,
     cudaStream_t stream) {
-    const bool use_all_p =
-        env_flag_default_enabled("VLLM_FLASH_V100_PREFILL_D256_BM32_ALL_P");
-    const bool use_pair_scratch =
-        use_all_p
-        && env_flag_default_enabled(
-            "VLLM_FLASH_V100_PREFILL_D256_BM32_PAIR_SCRATCH");
+  const bool use_all_p =
+      env_flag_default_enabled("VLLM_FLASH_V100_PREFILL_D256_BM32_ALL_P");
+  const bool use_pair_scratch =
+      use_all_p && env_flag_default_enabled(
+                       "VLLM_FLASH_V100_PREFILL_D256_BM32_PAIR_SCRATCH");
 
-    if (is_causal) {
-        if (use_all_p) {
-            if (use_pair_scratch) {
-                launch_flash_attention_forward_paged_d256_bm32_phase_kernel<
-                    true, true, true>(
-                    Q, K_cache, V_cache, Out, softmax_lse, block_table,
-                    seq_lens, softmax_scale, stream);
-            } else {
-                launch_flash_attention_forward_paged_d256_bm32_phase_kernel<
-                    true, true, false>(
-                    Q, K_cache, V_cache, Out, softmax_lse, block_table,
-                    seq_lens, softmax_scale, stream);
-            }
-        } else {
-            launch_flash_attention_forward_paged_d256_bm32_phase_kernel<
-                true, false, false>(
-                Q, K_cache, V_cache, Out, softmax_lse, block_table, seq_lens,
-                softmax_scale, stream);
-        }
-        return;
-    }
-
+  if (is_causal) {
     if (use_all_p) {
-        if (use_pair_scratch) {
-            launch_flash_attention_forward_paged_d256_bm32_phase_kernel<
-                false, true, true>(
-                Q, K_cache, V_cache, Out, softmax_lse, block_table, seq_lens,
-                softmax_scale, stream);
-        } else {
-            launch_flash_attention_forward_paged_d256_bm32_phase_kernel<
-                false, true, false>(
-                Q, K_cache, V_cache, Out, softmax_lse, block_table, seq_lens,
-                softmax_scale, stream);
-        }
-    } else {
-        launch_flash_attention_forward_paged_d256_bm32_phase_kernel<
-            false, false, false>(
+      if (use_pair_scratch) {
+        launch_flash_attention_forward_paged_d256_bm32_phase_kernel<true, true,
+                                                                    true>(
             Q, K_cache, V_cache, Out, softmax_lse, block_table, seq_lens,
             softmax_scale, stream);
+      } else {
+        launch_flash_attention_forward_paged_d256_bm32_phase_kernel<true, true,
+                                                                    false>(
+            Q, K_cache, V_cache, Out, softmax_lse, block_table, seq_lens,
+            softmax_scale, stream);
+      }
+    } else {
+      launch_flash_attention_forward_paged_d256_bm32_phase_kernel<true, false,
+                                                                  false>(
+          Q, K_cache, V_cache, Out, softmax_lse, block_table, seq_lens,
+          softmax_scale, stream);
     }
+    return;
+  }
+
+  if (use_all_p) {
+    if (use_pair_scratch) {
+      launch_flash_attention_forward_paged_d256_bm32_phase_kernel<false, true,
+                                                                  true>(
+          Q, K_cache, V_cache, Out, softmax_lse, block_table, seq_lens,
+          softmax_scale, stream);
+    } else {
+      launch_flash_attention_forward_paged_d256_bm32_phase_kernel<false, true,
+                                                                  false>(
+          Q, K_cache, V_cache, Out, softmax_lse, block_table, seq_lens,
+          softmax_scale, stream);
+    }
+  } else {
+    launch_flash_attention_forward_paged_d256_bm32_phase_kernel<false, false,
+                                                                false>(
+        Q, K_cache, V_cache, Out, softmax_lse, block_table, seq_lens,
+        softmax_scale, stream);
+  }
 }
 
-template<int D, int KV_DTYPE>
+template <int D, int KV_DTYPE>
 void launcher_flash_attention_forward_paged(
-    const torch::Tensor& Q,
-    const torch::Tensor& K_cache,
-    const torch::Tensor& V_cache,
-    torch::Tensor& Out,
-    torch::Tensor& softmax_lse,
-    const torch::Tensor& block_table,
-    const torch::Tensor& seq_lens,
-    float softmax_scale,
-    bool is_causal,
-    float k_scale,
-    float v_scale,
-    int window_size_left,
-    int window_size_right,
-    cudaStream_t stream,
-    const int* bfla_mask_ptr = nullptr,
-    int bfla_mask_block_n = 0,
-    int64_t bfla_mask_stride_b = 0,
-    int64_t bfla_mask_stride_h = 0,
-    int64_t bfla_mask_stride_q = 0,
-    int64_t bfla_mask_stride_k = 0
-) {
-    if constexpr (D == 256 && KV_DTYPE == flash_v100::KV_CACHE_DTYPE_FP16) {
-        const int M = Q.size(2);
-        const int page_block_size = K_cache.size(1);
-        const bool use_low_smem =
-            M > 1 && page_block_size >= 16 && (page_block_size % 16) == 0
-            && env_flag_default_enabled(
-                "VLLM_FLASH_V100_PREFILL_D256_LOW_SMEM");
-        if (use_low_smem) {
-            const bool use_d256_bm32_phase =
-                env_flag_default_enabled(
-                    "VLLM_FLASH_V100_PREFILL_D256_BM32_PHASE")
-                && page_block_size == D256_BM32_PHASE_PAGE_BLOCK_SIZE
-                && M >= D256_BM32_PHASE_BLOCK_M
-                && bfla_mask_ptr == nullptr && window_size_left < 0
-                && window_size_right < 0;
-            if (use_d256_bm32_phase) {
-                launcher_flash_attention_forward_paged_d256_bm32_phase(
-                    Q, K_cache, V_cache, Out, softmax_lse, block_table,
-                    seq_lens, softmax_scale, is_causal, stream);
-                return;
-            }
-            const bool use_low_smem_contig_fast =
-                page_block_size == 16 ||
-                env_flag_enabled("VLLM_FLASH_V100_PREFILL_CONTIG_FAST");
-            const bool use_low_smem_scalar_qk =
-                env_flag_enabled("VLLM_FLASH_V100_PREFILL_D256_SCALAR_QK");
-            const bool use_low_smem_bm32 =
-                env_flag_enabled("VLLM_FLASH_V100_PREFILL_D256_BM32");
-            // Default only for the measured hybrid-cache page size. Other
-            // page sizes retain the prior layout unless explicitly enabled.
-            const bool use_low_smem_output_stride_268 =
-                page_block_size == 784
-                    ? env_flag_default_enabled(
-                          "VLLM_FLASH_V100_PREFILL_D256_OUTPUT_STRIDE_268")
-                    : env_flag_enabled(
-                          "VLLM_FLASH_V100_PREFILL_D256_OUTPUT_STRIDE_268");
-            const bool use_sw_pipeline =
-                page_block_size == 784
-                && env_flag_enabled(
-                    "VLLM_FLASH_V100_PREFILL_D256_SOFTWARE_PIPELINE");
-            const bool use_sw_pipeline_qk =
-                page_block_size == 784
-                && (use_sw_pipeline
-                    || env_flag_default_enabled(
-                        "VLLM_FLASH_V100_PREFILL_D256_SW_PIPELINE_QK"));
-            const bool use_sw_pipeline_pv =
-                page_block_size == 784
-                && (use_sw_pipeline
-                    || env_flag_default_enabled(
-                        "VLLM_FLASH_V100_PREFILL_D256_SW_PIPELINE_PV"));
-            if (use_low_smem_contig_fast) {
-                if (use_low_smem_scalar_qk) {
-                    if (use_low_smem_bm32) {
-                        launcher_flash_attention_forward_paged_impl<
-                            D, KV_DTYPE, true, true, true, true>(
-                            Q, K_cache, V_cache, Out, softmax_lse, block_table,
-                            seq_lens, bfla_mask_ptr, bfla_mask_block_n,
-                            bfla_mask_stride_b, bfla_mask_stride_h,
-                            bfla_mask_stride_q, bfla_mask_stride_k,
-                            softmax_scale, is_causal, k_scale, v_scale,
-                            window_size_left, window_size_right, stream);
-                    } else {
-                        launcher_flash_attention_forward_paged_impl<
-                            D, KV_DTYPE, true, true, true, false>(
-                            Q, K_cache, V_cache, Out, softmax_lse, block_table,
-                            seq_lens, bfla_mask_ptr, bfla_mask_block_n,
-                            bfla_mask_stride_b, bfla_mask_stride_h,
-                            bfla_mask_stride_q, bfla_mask_stride_k,
-                            softmax_scale, is_causal, k_scale, v_scale,
-                            window_size_left, window_size_right, stream);
-                    }
-                } else {
-                    if (use_low_smem_bm32) {
-                        launcher_flash_attention_forward_paged_impl<
-                            D, KV_DTYPE, true, true, false, true>(
-                            Q, K_cache, V_cache, Out, softmax_lse, block_table,
-                            seq_lens, bfla_mask_ptr, bfla_mask_block_n,
-                            bfla_mask_stride_b, bfla_mask_stride_h,
-                            bfla_mask_stride_q, bfla_mask_stride_k,
-                            softmax_scale, is_causal, k_scale, v_scale,
-                            window_size_left, window_size_right, stream);
-                    } else {
-                        launcher_flash_attention_forward_paged_impl<
-                            D, KV_DTYPE, true, true, false, false>(
-                            Q, K_cache, V_cache, Out, softmax_lse, block_table,
-                            seq_lens, bfla_mask_ptr, bfla_mask_block_n,
-                            bfla_mask_stride_b, bfla_mask_stride_h,
-                            bfla_mask_stride_q, bfla_mask_stride_k,
-                            softmax_scale, is_causal, k_scale, v_scale,
-                            window_size_left, window_size_right, stream);
-                    }
-                }
-            } else {
-                if (use_low_smem_scalar_qk) {
-                    if (use_low_smem_bm32) {
-                        launcher_flash_attention_forward_paged_impl<
-                            D, KV_DTYPE, true, false, true, true>(
-                            Q, K_cache, V_cache, Out, softmax_lse, block_table,
-                            seq_lens, bfla_mask_ptr, bfla_mask_block_n,
-                            bfla_mask_stride_b, bfla_mask_stride_h,
-                            bfla_mask_stride_q, bfla_mask_stride_k,
-                            softmax_scale, is_causal, k_scale, v_scale,
-                            window_size_left, window_size_right, stream);
-                    } else {
-                        launcher_flash_attention_forward_paged_impl<
-                            D, KV_DTYPE, true, false, true, false>(
-                            Q, K_cache, V_cache, Out, softmax_lse, block_table,
-                            seq_lens, bfla_mask_ptr, bfla_mask_block_n,
-                            bfla_mask_stride_b, bfla_mask_stride_h,
-                            bfla_mask_stride_q, bfla_mask_stride_k,
-                            softmax_scale, is_causal, k_scale, v_scale,
-                            window_size_left, window_size_right, stream);
-                    }
-                } else {
-                    if (use_low_smem_bm32) {
-                        launcher_flash_attention_forward_paged_impl<
-                            D, KV_DTYPE, true, false, false, true>(
-                            Q, K_cache, V_cache, Out, softmax_lse, block_table,
-                            seq_lens, bfla_mask_ptr, bfla_mask_block_n,
-                            bfla_mask_stride_b, bfla_mask_stride_h,
-                            bfla_mask_stride_q, bfla_mask_stride_k,
-                            softmax_scale, is_causal, k_scale, v_scale,
-                            window_size_left, window_size_right, stream);
-                    } else {
-                        if (use_low_smem_output_stride_268) {
-                            if (use_sw_pipeline_qk) {
-                                if (use_sw_pipeline_pv) {
-                                    launcher_flash_attention_forward_paged_impl<
-                                        D, KV_DTYPE, true, false, false,
-                                        false, true, true, true>(
-                                        Q, K_cache, V_cache, Out,
-                                        softmax_lse, block_table, seq_lens,
-                                        bfla_mask_ptr, bfla_mask_block_n,
-                                        bfla_mask_stride_b,
-                                        bfla_mask_stride_h,
-                                        bfla_mask_stride_q,
-                                        bfla_mask_stride_k, softmax_scale,
-                                        is_causal, k_scale, v_scale,
-                                        window_size_left,
-                                        window_size_right, stream);
-                                } else {
-                                    launcher_flash_attention_forward_paged_impl<
-                                        D, KV_DTYPE, true, false, false, false,
-                                        true, true, false>(
-                                        Q, K_cache, V_cache, Out, softmax_lse,
-                                        block_table, seq_lens, bfla_mask_ptr,
-                                        bfla_mask_block_n, bfla_mask_stride_b,
-                                        bfla_mask_stride_h,
-                                        bfla_mask_stride_q,
-                                        bfla_mask_stride_k, softmax_scale,
-                                        is_causal, k_scale, v_scale,
-                                        window_size_left, window_size_right,
-                                        stream);
-                                }
-                            } else if (use_sw_pipeline_pv) {
-                                launcher_flash_attention_forward_paged_impl<
-                                    D, KV_DTYPE, true, false, false, false,
-                                    true, false, true>(
-                                    Q, K_cache, V_cache, Out, softmax_lse,
-                                    block_table, seq_lens, bfla_mask_ptr,
-                                    bfla_mask_block_n, bfla_mask_stride_b,
-                                    bfla_mask_stride_h, bfla_mask_stride_q,
-                                    bfla_mask_stride_k, softmax_scale,
-                                    is_causal, k_scale, v_scale,
-                                    window_size_left, window_size_right,
-                                    stream);
-                            } else {
-                                launcher_flash_attention_forward_paged_impl<
-                                    D, KV_DTYPE, true, false, false, false,
-                                    true>(
-                                    Q, K_cache, V_cache, Out, softmax_lse,
-                                    block_table, seq_lens, bfla_mask_ptr,
-                                    bfla_mask_block_n, bfla_mask_stride_b,
-                                    bfla_mask_stride_h, bfla_mask_stride_q,
-                                    bfla_mask_stride_k, softmax_scale,
-                                    is_causal, k_scale, v_scale,
-                                    window_size_left, window_size_right,
-                                    stream);
-                            }
-                        } else {
-                            launcher_flash_attention_forward_paged_impl<
-                                D, KV_DTYPE, true, false, false, false>(
-                                Q, K_cache, V_cache, Out, softmax_lse,
-                                block_table, seq_lens, bfla_mask_ptr,
-                                bfla_mask_block_n, bfla_mask_stride_b,
-                                bfla_mask_stride_h, bfla_mask_stride_q,
-                                bfla_mask_stride_k, softmax_scale, is_causal,
-                                k_scale, v_scale, window_size_left,
-                                window_size_right, stream);
-                        }
-                    }
-                }
-            }
-        } else {
-            launcher_flash_attention_forward_paged_impl<
-                D, KV_DTYPE, false, false, false, false>(
+    const torch::Tensor& Q, const torch::Tensor& K_cache,
+    const torch::Tensor& V_cache, torch::Tensor& Out,
+    torch::Tensor& softmax_lse, const torch::Tensor& block_table,
+    const torch::Tensor& seq_lens, float softmax_scale, bool is_causal,
+    float k_scale, float v_scale, int window_size_left, int window_size_right,
+    cudaStream_t stream, const int* bfla_mask_ptr = nullptr,
+    int bfla_mask_block_n = 0, int64_t bfla_mask_stride_b = 0,
+    int64_t bfla_mask_stride_h = 0, int64_t bfla_mask_stride_q = 0,
+    int64_t bfla_mask_stride_k = 0) {
+  if constexpr (D == 256 && KV_DTYPE == flash_v100::KV_CACHE_DTYPE_FP16) {
+    const int M = Q.size(2);
+    const int page_block_size = K_cache.size(1);
+    const bool use_low_smem =
+        M > 1 && page_block_size >= 16 && (page_block_size % 16) == 0 &&
+        env_flag_default_enabled("VLLM_FLASH_V100_PREFILL_D256_LOW_SMEM");
+    if (use_low_smem) {
+      const bool use_d256_bm32_phase =
+          env_flag_default_enabled("VLLM_FLASH_V100_PREFILL_D256_BM32_PHASE") &&
+          page_block_size == D256_BM32_PHASE_PAGE_BLOCK_SIZE &&
+          M >= D256_BM32_PHASE_BLOCK_M && bfla_mask_ptr == nullptr &&
+          window_size_left < 0 && window_size_right < 0;
+      if (use_d256_bm32_phase) {
+        launcher_flash_attention_forward_paged_d256_bm32_phase(
+            Q, K_cache, V_cache, Out, softmax_lse, block_table, seq_lens,
+            softmax_scale, is_causal, stream);
+        return;
+      }
+      const bool use_low_smem_contig_fast =
+          page_block_size == 16 ||
+          env_flag_enabled("VLLM_FLASH_V100_PREFILL_CONTIG_FAST");
+      const bool use_low_smem_scalar_qk =
+          env_flag_enabled("VLLM_FLASH_V100_PREFILL_D256_SCALAR_QK");
+      const bool use_low_smem_bm32 =
+          env_flag_enabled("VLLM_FLASH_V100_PREFILL_D256_BM32");
+      // Default only for the measured hybrid-cache page size. Other
+      // page sizes retain the prior layout unless explicitly enabled.
+      const bool use_low_smem_output_stride_268 =
+          page_block_size == 784
+              ? env_flag_default_enabled(
+                    "VLLM_FLASH_V100_PREFILL_D256_OUTPUT_STRIDE_268")
+              : env_flag_enabled(
+                    "VLLM_FLASH_V100_PREFILL_D256_OUTPUT_STRIDE_268");
+      const bool use_sw_pipeline =
+          page_block_size == 784 &&
+          env_flag_enabled("VLLM_FLASH_V100_PREFILL_D256_SOFTWARE_PIPELINE");
+      const bool use_sw_pipeline_qk =
+          page_block_size == 784 &&
+          (use_sw_pipeline ||
+           env_flag_default_enabled(
+               "VLLM_FLASH_V100_PREFILL_D256_SW_PIPELINE_QK"));
+      const bool use_sw_pipeline_pv =
+          page_block_size == 784 &&
+          (use_sw_pipeline ||
+           env_flag_default_enabled(
+               "VLLM_FLASH_V100_PREFILL_D256_SW_PIPELINE_PV"));
+      if (use_low_smem_contig_fast) {
+        if (use_low_smem_scalar_qk) {
+          if (use_low_smem_bm32) {
+            launcher_flash_attention_forward_paged_impl<D, KV_DTYPE, true, true,
+                                                        true, true>(
                 Q, K_cache, V_cache, Out, softmax_lse, block_table, seq_lens,
                 bfla_mask_ptr, bfla_mask_block_n, bfla_mask_stride_b,
                 bfla_mask_stride_h, bfla_mask_stride_q, bfla_mask_stride_k,
                 softmax_scale, is_causal, k_scale, v_scale, window_size_left,
                 window_size_right, stream);
+          } else {
+            launcher_flash_attention_forward_paged_impl<D, KV_DTYPE, true, true,
+                                                        true, false>(
+                Q, K_cache, V_cache, Out, softmax_lse, block_table, seq_lens,
+                bfla_mask_ptr, bfla_mask_block_n, bfla_mask_stride_b,
+                bfla_mask_stride_h, bfla_mask_stride_q, bfla_mask_stride_k,
+                softmax_scale, is_causal, k_scale, v_scale, window_size_left,
+                window_size_right, stream);
+          }
+        } else {
+          if (use_low_smem_bm32) {
+            launcher_flash_attention_forward_paged_impl<D, KV_DTYPE, true, true,
+                                                        false, true>(
+                Q, K_cache, V_cache, Out, softmax_lse, block_table, seq_lens,
+                bfla_mask_ptr, bfla_mask_block_n, bfla_mask_stride_b,
+                bfla_mask_stride_h, bfla_mask_stride_q, bfla_mask_stride_k,
+                softmax_scale, is_causal, k_scale, v_scale, window_size_left,
+                window_size_right, stream);
+          } else {
+            launcher_flash_attention_forward_paged_impl<D, KV_DTYPE, true, true,
+                                                        false, false>(
+                Q, K_cache, V_cache, Out, softmax_lse, block_table, seq_lens,
+                bfla_mask_ptr, bfla_mask_block_n, bfla_mask_stride_b,
+                bfla_mask_stride_h, bfla_mask_stride_q, bfla_mask_stride_k,
+                softmax_scale, is_causal, k_scale, v_scale, window_size_left,
+                window_size_right, stream);
+          }
         }
+      } else {
+        if (use_low_smem_scalar_qk) {
+          if (use_low_smem_bm32) {
+            launcher_flash_attention_forward_paged_impl<D, KV_DTYPE, true,
+                                                        false, true, true>(
+                Q, K_cache, V_cache, Out, softmax_lse, block_table, seq_lens,
+                bfla_mask_ptr, bfla_mask_block_n, bfla_mask_stride_b,
+                bfla_mask_stride_h, bfla_mask_stride_q, bfla_mask_stride_k,
+                softmax_scale, is_causal, k_scale, v_scale, window_size_left,
+                window_size_right, stream);
+          } else {
+            launcher_flash_attention_forward_paged_impl<D, KV_DTYPE, true,
+                                                        false, true, false>(
+                Q, K_cache, V_cache, Out, softmax_lse, block_table, seq_lens,
+                bfla_mask_ptr, bfla_mask_block_n, bfla_mask_stride_b,
+                bfla_mask_stride_h, bfla_mask_stride_q, bfla_mask_stride_k,
+                softmax_scale, is_causal, k_scale, v_scale, window_size_left,
+                window_size_right, stream);
+          }
+        } else {
+          if (use_low_smem_bm32) {
+            launcher_flash_attention_forward_paged_impl<D, KV_DTYPE, true,
+                                                        false, false, true>(
+                Q, K_cache, V_cache, Out, softmax_lse, block_table, seq_lens,
+                bfla_mask_ptr, bfla_mask_block_n, bfla_mask_stride_b,
+                bfla_mask_stride_h, bfla_mask_stride_q, bfla_mask_stride_k,
+                softmax_scale, is_causal, k_scale, v_scale, window_size_left,
+                window_size_right, stream);
+          } else {
+            if (use_low_smem_output_stride_268) {
+              if (use_sw_pipeline_qk) {
+                if (use_sw_pipeline_pv) {
+                  launcher_flash_attention_forward_paged_impl<
+                      D, KV_DTYPE, true, false, false, false, true, true, true>(
+                      Q, K_cache, V_cache, Out, softmax_lse, block_table,
+                      seq_lens, bfla_mask_ptr, bfla_mask_block_n,
+                      bfla_mask_stride_b, bfla_mask_stride_h,
+                      bfla_mask_stride_q, bfla_mask_stride_k, softmax_scale,
+                      is_causal, k_scale, v_scale, window_size_left,
+                      window_size_right, stream);
+                } else {
+                  launcher_flash_attention_forward_paged_impl<
+                      D, KV_DTYPE, true, false, false, false, true, true,
+                      false>(Q, K_cache, V_cache, Out, softmax_lse, block_table,
+                             seq_lens, bfla_mask_ptr, bfla_mask_block_n,
+                             bfla_mask_stride_b, bfla_mask_stride_h,
+                             bfla_mask_stride_q, bfla_mask_stride_k,
+                             softmax_scale, is_causal, k_scale, v_scale,
+                             window_size_left, window_size_right, stream);
+                }
+              } else if (use_sw_pipeline_pv) {
+                launcher_flash_attention_forward_paged_impl<
+                    D, KV_DTYPE, true, false, false, false, true, false, true>(
+                    Q, K_cache, V_cache, Out, softmax_lse, block_table,
+                    seq_lens, bfla_mask_ptr, bfla_mask_block_n,
+                    bfla_mask_stride_b, bfla_mask_stride_h, bfla_mask_stride_q,
+                    bfla_mask_stride_k, softmax_scale, is_causal, k_scale,
+                    v_scale, window_size_left, window_size_right, stream);
+              } else {
+                launcher_flash_attention_forward_paged_impl<
+                    D, KV_DTYPE, true, false, false, false, true>(
+                    Q, K_cache, V_cache, Out, softmax_lse, block_table,
+                    seq_lens, bfla_mask_ptr, bfla_mask_block_n,
+                    bfla_mask_stride_b, bfla_mask_stride_h, bfla_mask_stride_q,
+                    bfla_mask_stride_k, softmax_scale, is_causal, k_scale,
+                    v_scale, window_size_left, window_size_right, stream);
+              }
+            } else {
+              launcher_flash_attention_forward_paged_impl<D, KV_DTYPE, true,
+                                                          false, false, false>(
+                  Q, K_cache, V_cache, Out, softmax_lse, block_table, seq_lens,
+                  bfla_mask_ptr, bfla_mask_block_n, bfla_mask_stride_b,
+                  bfla_mask_stride_h, bfla_mask_stride_q, bfla_mask_stride_k,
+                  softmax_scale, is_causal, k_scale, v_scale, window_size_left,
+                  window_size_right, stream);
+            }
+          }
+        }
+      }
     } else {
-        launcher_flash_attention_forward_paged_impl<
-            D, KV_DTYPE, false, false, false, false>(
-            Q, K_cache, V_cache, Out, softmax_lse, block_table, seq_lens,
-            bfla_mask_ptr, bfla_mask_block_n, bfla_mask_stride_b,
-            bfla_mask_stride_h, bfla_mask_stride_q, bfla_mask_stride_k,
-            softmax_scale, is_causal, k_scale, v_scale, window_size_left,
-            window_size_right, stream);
+      launcher_flash_attention_forward_paged_impl<D, KV_DTYPE, false, false,
+                                                  false, false>(
+          Q, K_cache, V_cache, Out, softmax_lse, block_table, seq_lens,
+          bfla_mask_ptr, bfla_mask_block_n, bfla_mask_stride_b,
+          bfla_mask_stride_h, bfla_mask_stride_q, bfla_mask_stride_k,
+          softmax_scale, is_causal, k_scale, v_scale, window_size_left,
+          window_size_right, stream);
     }
+  } else {
+    launcher_flash_attention_forward_paged_impl<D, KV_DTYPE, false, false,
+                                                false, false>(
+        Q, K_cache, V_cache, Out, softmax_lse, block_table, seq_lens,
+        bfla_mask_ptr, bfla_mask_block_n, bfla_mask_stride_b,
+        bfla_mask_stride_h, bfla_mask_stride_q, bfla_mask_stride_k,
+        softmax_scale, is_causal, k_scale, v_scale, window_size_left,
+        window_size_right, stream);
+  }
 }
 
 at::Tensor flash_attention_prefill_paged_splitkv(
-    const at::Tensor& q,
-    const at::Tensor& k_cache,
-    const at::Tensor& v_cache,
-    std::optional<at::Tensor>& out_,
-    const at::Tensor& block_table,
-    const at::Tensor& seq_lens,
-    const float softmax_scale,
-    const std::string& kv_cache_dtype,
-    const float k_scale,
-    const float v_scale,
-    const bool is_causal,
-    const int window_size_left,
-    const int window_size_right,
-    const int split_kv_tokens,
-    const int max_seq_len_hint
-) {
-    TORCH_CHECK(q.dtype() == torch::kFloat16, "q must be fp16");
-    const int kv_dtype_code = kv_cache_dtype_code_from_string(kv_cache_dtype);
-    TORCH_CHECK(kv_dtype_code == flash_v100::KV_CACHE_DTYPE_FP16,
-                "split-KV paged prefill supports fp16 KV cache only");
-    TORCH_CHECK(k_cache.dtype() == torch::kFloat16, "k_cache must be fp16");
-    TORCH_CHECK(v_cache.dtype() == torch::kFloat16, "v_cache must be fp16");
-    TORCH_CHECK(q.is_cuda() && k_cache.is_cuda() && v_cache.is_cuda(),
-                "Tensors must be on CUDA");
-    TORCH_CHECK(block_table.is_cuda() && seq_lens.is_cuda(),
-                "block_table and seq_lens must be CUDA tensors");
-    TORCH_CHECK(q.stride(-1) == 1 && k_cache.stride(-1) == 1 &&
-                    v_cache.stride(-1) == 1,
-                "Last dim must be contiguous");
-    TORCH_CHECK(k_cache.stride(1) % 8 == 0 && k_cache.stride(2) % 8 == 0 &&
-                    v_cache.stride(1) % 8 == 0 && v_cache.stride(2) % 8 == 0,
-                "Paged KV strides must be divisible by 8 half elements");
+    const at::Tensor& q, const at::Tensor& k_cache, const at::Tensor& v_cache,
+    std::optional<at::Tensor>& out_, const at::Tensor& block_table,
+    const at::Tensor& seq_lens, const float softmax_scale,
+    const std::string& kv_cache_dtype, const float k_scale, const float v_scale,
+    const bool is_causal, const int window_size_left,
+    const int window_size_right, const int split_kv_tokens,
+    const int max_seq_len_hint) {
+  TORCH_CHECK(q.dtype() == torch::kFloat16, "q must be fp16");
+  const int kv_dtype_code = kv_cache_dtype_code_from_string(kv_cache_dtype);
+  TORCH_CHECK(kv_dtype_code == flash_v100::KV_CACHE_DTYPE_FP16,
+              "split-KV paged prefill supports fp16 KV cache only");
+  TORCH_CHECK(k_cache.dtype() == torch::kFloat16, "k_cache must be fp16");
+  TORCH_CHECK(v_cache.dtype() == torch::kFloat16, "v_cache must be fp16");
+  TORCH_CHECK(q.is_cuda() && k_cache.is_cuda() && v_cache.is_cuda(),
+              "Tensors must be on CUDA");
+  TORCH_CHECK(block_table.is_cuda() && seq_lens.is_cuda(),
+              "block_table and seq_lens must be CUDA tensors");
+  TORCH_CHECK(
+      q.stride(-1) == 1 && k_cache.stride(-1) == 1 && v_cache.stride(-1) == 1,
+      "Last dim must be contiguous");
+  TORCH_CHECK(k_cache.stride(1) % 8 == 0 && k_cache.stride(2) % 8 == 0 &&
+                  v_cache.stride(1) % 8 == 0 && v_cache.stride(2) % 8 == 0,
+              "Paged KV strides must be divisible by 8 half elements");
 
-    const int B = q.size(0);
-    const int H = q.size(1);
-    const int M = q.size(2);
-    const int D = q.size(3);
-    const int num_kv_heads = k_cache.size(2);
-    const int page_block_size = k_cache.size(1);
+  const int B = q.size(0);
+  const int H = q.size(1);
+  const int M = q.size(2);
+  const int D = q.size(3);
+  const int num_kv_heads = k_cache.size(2);
+  const int page_block_size = k_cache.size(1);
 
-    TORCH_CHECK(D == 256, "split-KV paged prefill supports D=256 only");
-    TORCH_CHECK(H % num_kv_heads == 0,
-                "num_heads must be divisible by num_kv_heads");
-    TORCH_CHECK(M > 1, "split-KV paged prefill requires prefill M > 1");
-    TORCH_CHECK(page_block_size >= 16 && (page_block_size % 16) == 0,
-                "split-KV paged prefill requires page block size multiple of 16");
-    TORCH_CHECK(window_size_left >= -1 && window_size_right >= -1,
-                "window sizes must be >= -1");
+  TORCH_CHECK(D == 256, "split-KV paged prefill supports D=256 only");
+  TORCH_CHECK(H % num_kv_heads == 0,
+              "num_heads must be divisible by num_kv_heads");
+  TORCH_CHECK(M > 1, "split-KV paged prefill requires prefill M > 1");
+  TORCH_CHECK(page_block_size >= 16 && (page_block_size % 16) == 0,
+              "split-KV paged prefill requires page block size multiple of 16");
+  TORCH_CHECK(window_size_left >= -1 && window_size_right >= -1,
+              "window sizes must be >= -1");
 
-    at::Tensor out_fp16 = out_.has_value() ? out_.value() : torch::zeros_like(q);
-    auto softmax_lse = torch::zeros({B, H, M},
-                                    torch::dtype(torch::kFloat32).device(q.device()));
+  at::Tensor out_fp16 = out_.has_value() ? out_.value() : torch::zeros_like(q);
+  auto softmax_lse =
+      torch::zeros({B, H, M}, torch::dtype(torch::kFloat32).device(q.device()));
 
-    auto stream = at::cuda::getCurrentCUDAStream().stream();
-    auto props = at::cuda::getCurrentDeviceProperties();
-    bool sm70 = props->major == 7 && props->minor == 0;
-    TORCH_CHECK(sm70, "Kernel supports only Volta GPUs.");
+  auto stream = at::cuda::getCurrentCUDAStream().stream();
+  auto props = at::cuda::getCurrentDeviceProperties();
+  bool sm70 = props->major == 7 && props->minor == 0;
+  TORCH_CHECK(sm70, "Kernel supports only Volta GPUs.");
 
-    const bool use_low_smem_contig_fast =
-        page_block_size == 16 ||
-        env_flag_enabled("VLLM_FLASH_V100_PREFILL_CONTIG_FAST");
-    const bool use_low_smem_scalar_qk =
-        env_flag_enabled("VLLM_FLASH_V100_PREFILL_D256_SCALAR_QK");
-    const int block_n =
-        use_low_smem_scalar_qk
-            ? BLOCK_N_256_LOW_SMEM_SCALAR_QK
-            : BLOCK_N_256_LOW_SMEM;
-    const int split_tokens_rounded = std::max(split_kv_tokens, block_n);
-    const int split_kv_tiles =
-        std::max(1, (split_tokens_rounded + block_n - 1) / block_n);
-    const int max_hint = std::max(max_seq_len_hint, 1);
-    const int max_kv_tiles = std::max(1, (max_hint + block_n - 1) / block_n);
-    const int num_partitions =
-        std::max(1, (max_kv_tiles + split_kv_tiles - 1) / split_kv_tiles);
+  const bool use_low_smem_contig_fast =
+      page_block_size == 16 ||
+      env_flag_enabled("VLLM_FLASH_V100_PREFILL_CONTIG_FAST");
+  const bool use_low_smem_scalar_qk =
+      env_flag_enabled("VLLM_FLASH_V100_PREFILL_D256_SCALAR_QK");
+  const int block_n = use_low_smem_scalar_qk ? BLOCK_N_256_LOW_SMEM_SCALAR_QK
+                                             : BLOCK_N_256_LOW_SMEM;
+  const int split_tokens_rounded = std::max(split_kv_tokens, block_n);
+  const int split_kv_tiles =
+      std::max(1, (split_tokens_rounded + block_n - 1) / block_n);
+  const int max_hint = std::max(max_seq_len_hint, 1);
+  const int max_kv_tiles = std::max(1, (max_hint + block_n - 1) / block_n);
+  const int num_partitions =
+      std::max(1, (max_kv_tiles + split_kv_tiles - 1) / split_kv_tiles);
 
-    if (num_partitions <= 1) {
-        launcher_flash_attention_forward_paged<256, flash_v100::KV_CACHE_DTYPE_FP16>(
-            q, k_cache, v_cache, out_fp16, softmax_lse, block_table, seq_lens,
-            softmax_scale, is_causal, k_scale, v_scale, window_size_left,
-            window_size_right, stream);
-        return out_fp16;
-    }
-
-    auto tmp_options = torch::dtype(torch::kFloat32).device(q.device());
-    auto split_tmp_out =
-        torch::empty({B, H, num_partitions, M, D}, tmp_options);
-    auto split_tmp_row_max =
-        torch::empty({B, H, num_partitions, M}, tmp_options);
-    auto split_tmp_row_sum =
-        torch::empty({B, H, num_partitions, M}, tmp_options);
-
-    if (use_low_smem_contig_fast) {
-        if (use_low_smem_scalar_qk) {
-            launcher_flash_attention_forward_paged_splitkv_impl<
-                256, true, true>(
-                q, k_cache, v_cache, out_fp16, softmax_lse, split_tmp_out,
-                split_tmp_row_max, split_tmp_row_sum, block_table, seq_lens,
-                softmax_scale, is_causal, k_scale, v_scale, window_size_left,
-                window_size_right, split_kv_tokens, max_seq_len_hint, stream);
-        } else {
-            launcher_flash_attention_forward_paged_splitkv_impl<
-                256, true, false>(
-                q, k_cache, v_cache, out_fp16, softmax_lse, split_tmp_out,
-                split_tmp_row_max, split_tmp_row_sum, block_table, seq_lens,
-                softmax_scale, is_causal, k_scale, v_scale, window_size_left,
-                window_size_right, split_kv_tokens, max_seq_len_hint, stream);
-        }
-    } else {
-        if (use_low_smem_scalar_qk) {
-            launcher_flash_attention_forward_paged_splitkv_impl<
-                256, false, true>(
-                q, k_cache, v_cache, out_fp16, softmax_lse, split_tmp_out,
-                split_tmp_row_max, split_tmp_row_sum, block_table, seq_lens,
-                softmax_scale, is_causal, k_scale, v_scale, window_size_left,
-                window_size_right, split_kv_tokens, max_seq_len_hint, stream);
-        } else {
-            launcher_flash_attention_forward_paged_splitkv_impl<
-                256, false, false>(
-                q, k_cache, v_cache, out_fp16, softmax_lse, split_tmp_out,
-                split_tmp_row_max, split_tmp_row_sum, block_table, seq_lens,
-                softmax_scale, is_causal, k_scale, v_scale, window_size_left,
-                window_size_right, split_kv_tokens, max_seq_len_hint, stream);
-        }
-    }
-
+  if (num_partitions <= 1) {
+    launcher_flash_attention_forward_paged<256,
+                                           flash_v100::KV_CACHE_DTYPE_FP16>(
+        q, k_cache, v_cache, out_fp16, softmax_lse, block_table, seq_lens,
+        softmax_scale, is_causal, k_scale, v_scale, window_size_left,
+        window_size_right, stream);
     return out_fp16;
+  }
+
+  auto tmp_options = torch::dtype(torch::kFloat32).device(q.device());
+  auto split_tmp_out = torch::empty({B, H, num_partitions, M, D}, tmp_options);
+  auto split_tmp_row_max = torch::empty({B, H, num_partitions, M}, tmp_options);
+  auto split_tmp_row_sum = torch::empty({B, H, num_partitions, M}, tmp_options);
+
+  if (use_low_smem_contig_fast) {
+    if (use_low_smem_scalar_qk) {
+      launcher_flash_attention_forward_paged_splitkv_impl<256, true, true>(
+          q, k_cache, v_cache, out_fp16, softmax_lse, split_tmp_out,
+          split_tmp_row_max, split_tmp_row_sum, block_table, seq_lens,
+          softmax_scale, is_causal, k_scale, v_scale, window_size_left,
+          window_size_right, split_kv_tokens, max_seq_len_hint, stream);
+    } else {
+      launcher_flash_attention_forward_paged_splitkv_impl<256, true, false>(
+          q, k_cache, v_cache, out_fp16, softmax_lse, split_tmp_out,
+          split_tmp_row_max, split_tmp_row_sum, block_table, seq_lens,
+          softmax_scale, is_causal, k_scale, v_scale, window_size_left,
+          window_size_right, split_kv_tokens, max_seq_len_hint, stream);
+    }
+  } else {
+    if (use_low_smem_scalar_qk) {
+      launcher_flash_attention_forward_paged_splitkv_impl<256, false, true>(
+          q, k_cache, v_cache, out_fp16, softmax_lse, split_tmp_out,
+          split_tmp_row_max, split_tmp_row_sum, block_table, seq_lens,
+          softmax_scale, is_causal, k_scale, v_scale, window_size_left,
+          window_size_right, split_kv_tokens, max_seq_len_hint, stream);
+    } else {
+      launcher_flash_attention_forward_paged_splitkv_impl<256, false, false>(
+          q, k_cache, v_cache, out_fp16, softmax_lse, split_tmp_out,
+          split_tmp_row_max, split_tmp_row_sum, block_table, seq_lens,
+          softmax_scale, is_causal, k_scale, v_scale, window_size_left,
+          window_size_right, split_kv_tokens, max_seq_len_hint, stream);
+    }
+  }
+
+  return out_fp16;
 }
 
 at::Tensor flash_attention_prefill_paged(
-    const at::Tensor& q,
-    const at::Tensor& k_cache,
-    const at::Tensor& v_cache,
-    std::optional<at::Tensor>& out_,
-    const at::Tensor& block_table,
-    const at::Tensor& seq_lens,
-    const float softmax_scale,
-    const std::string& kv_cache_dtype,
-    const float k_scale,
-    const float v_scale,
-    const bool is_causal,
-    const int window_size_left,
-    const int window_size_right
-) {
-    TORCH_CHECK(q.dtype() == torch::kFloat16, "q must be fp16");
-    const int kv_dtype_code = kv_cache_dtype_code_from_string(kv_cache_dtype);
-    TORCH_CHECK(kv_dtype_code >= 0, "Unsupported kv_cache_dtype: ", kv_cache_dtype);
-    if (kv_dtype_code == flash_v100::KV_CACHE_DTYPE_FP16) {
-        TORCH_CHECK(k_cache.dtype() == torch::kFloat16, "k_cache must be fp16");
-        TORCH_CHECK(v_cache.dtype() == torch::kFloat16, "v_cache must be fp16");
-    } else {
-        TORCH_CHECK(k_cache.dtype() == torch::kUInt8,
-                    "fp8 k_cache must be stored as uint8");
-        TORCH_CHECK(v_cache.dtype() == torch::kUInt8,
-                    "fp8 v_cache must be stored as uint8");
-        TORCH_CHECK(k_scale > 0.f && v_scale > 0.f,
-                    "fp8 k/v scales must be positive");
-    }
-    TORCH_CHECK(q.is_cuda() && k_cache.is_cuda() && v_cache.is_cuda(),
-                "Tensors must be on CUDA");
-    TORCH_CHECK(block_table.is_cuda() && seq_lens.is_cuda(),
-                "block_table and seq_lens must be CUDA tensors");
-    TORCH_CHECK(q.stride(-1) == 1 && k_cache.stride(-1) == 1 &&
-                    v_cache.stride(-1) == 1,
-                "Last dim must be contiguous");
-    TORCH_CHECK(k_cache.stride(1) % 8 == 0 && k_cache.stride(2) % 8 == 0 &&
-                    v_cache.stride(1) % 8 == 0 && v_cache.stride(2) % 8 == 0,
-                "Paged KV strides must be divisible by 8 half elements");
+    const at::Tensor& q, const at::Tensor& k_cache, const at::Tensor& v_cache,
+    std::optional<at::Tensor>& out_, const at::Tensor& block_table,
+    const at::Tensor& seq_lens, const float softmax_scale,
+    const std::string& kv_cache_dtype, const float k_scale, const float v_scale,
+    const bool is_causal, const int window_size_left,
+    const int window_size_right) {
+  TORCH_CHECK(q.dtype() == torch::kFloat16, "q must be fp16");
+  const int kv_dtype_code = kv_cache_dtype_code_from_string(kv_cache_dtype);
+  TORCH_CHECK(kv_dtype_code >= 0,
+              "Unsupported kv_cache_dtype: ", kv_cache_dtype);
+  if (kv_dtype_code == flash_v100::KV_CACHE_DTYPE_FP16) {
+    TORCH_CHECK(k_cache.dtype() == torch::kFloat16, "k_cache must be fp16");
+    TORCH_CHECK(v_cache.dtype() == torch::kFloat16, "v_cache must be fp16");
+  } else {
+    TORCH_CHECK(k_cache.dtype() == torch::kUInt8,
+                "fp8 k_cache must be stored as uint8");
+    TORCH_CHECK(v_cache.dtype() == torch::kUInt8,
+                "fp8 v_cache must be stored as uint8");
+    TORCH_CHECK(k_scale > 0.f && v_scale > 0.f,
+                "fp8 k/v scales must be positive");
+  }
+  TORCH_CHECK(q.is_cuda() && k_cache.is_cuda() && v_cache.is_cuda(),
+              "Tensors must be on CUDA");
+  TORCH_CHECK(block_table.is_cuda() && seq_lens.is_cuda(),
+              "block_table and seq_lens must be CUDA tensors");
+  TORCH_CHECK(
+      q.stride(-1) == 1 && k_cache.stride(-1) == 1 && v_cache.stride(-1) == 1,
+      "Last dim must be contiguous");
+  TORCH_CHECK(k_cache.stride(1) % 8 == 0 && k_cache.stride(2) % 8 == 0 &&
+                  v_cache.stride(1) % 8 == 0 && v_cache.stride(2) % 8 == 0,
+              "Paged KV strides must be divisible by 8 half elements");
 
-    const int B = q.size(0);
-    const int H = q.size(1);
-    const int M = q.size(2);
-    const int D = q.size(3);
-    const int num_kv_heads = k_cache.size(2);
+  const int B = q.size(0);
+  const int H = q.size(1);
+  const int M = q.size(2);
+  const int D = q.size(3);
+  const int num_kv_heads = k_cache.size(2);
 
-    TORCH_CHECK(D <= 256 && D % 8 == 0 && D % 2 == 0,
-                "D must be even, <=256, multiple of 8");
-    TORCH_CHECK(H % num_kv_heads == 0,
-                "num_heads must be divisible by num_kv_heads");
-    TORCH_CHECK(window_size_left >= -1 && window_size_right >= -1,
-                "window sizes must be >= -1");
+  TORCH_CHECK(D <= 256 && D % 8 == 0 && D % 2 == 0,
+              "D must be even, <=256, multiple of 8");
+  TORCH_CHECK(H % num_kv_heads == 0,
+              "num_heads must be divisible by num_kv_heads");
+  TORCH_CHECK(window_size_left >= -1 && window_size_right >= -1,
+              "window sizes must be >= -1");
 
-    at::Tensor out_fp16 = out_.has_value() ? out_.value() : torch::zeros_like(q);
-    auto softmax_lse = torch::zeros({B, H, M},
-                                    torch::dtype(torch::kFloat32).device(q.device()));
+  at::Tensor out_fp16 = out_.has_value() ? out_.value() : torch::zeros_like(q);
+  auto softmax_lse =
+      torch::zeros({B, H, M}, torch::dtype(torch::kFloat32).device(q.device()));
 
-    auto stream = at::cuda::getCurrentCUDAStream().stream();
-    auto props = at::cuda::getCurrentDeviceProperties();
-    bool sm70 = props->major == 7 && props->minor == 0;
-    TORCH_CHECK(sm70, "Kernel supports only Volta GPUs.");
+  auto stream = at::cuda::getCurrentCUDAStream().stream();
+  auto props = at::cuda::getCurrentDeviceProperties();
+  bool sm70 = props->major == 7 && props->minor == 0;
+  TORCH_CHECK(sm70, "Kernel supports only Volta GPUs.");
 
-    #define LAUNCH_PAGED_TYPED(HDIM, KV_DTYPE_CODE)                             \
-        launcher_flash_attention_forward_paged<HDIM, KV_DTYPE_CODE>(            \
-            q, k_cache, v_cache, out_fp16, softmax_lse, block_table, seq_lens,  \
-            softmax_scale, is_causal, k_scale, v_scale, window_size_left,       \
-            window_size_right, stream)
+#define LAUNCH_PAGED_TYPED(HDIM, KV_DTYPE_CODE)                          \
+  launcher_flash_attention_forward_paged<HDIM, KV_DTYPE_CODE>(           \
+      q, k_cache, v_cache, out_fp16, softmax_lse, block_table, seq_lens, \
+      softmax_scale, is_causal, k_scale, v_scale, window_size_left,      \
+      window_size_right, stream)
 
-    #define LAUNCH_PAGED_BY_KV(HDIM)                                            \
-        do {                                                                    \
-            switch (kv_dtype_code) {                                            \
-                case flash_v100::KV_CACHE_DTYPE_FP16:                           \
-                    LAUNCH_PAGED_TYPED(HDIM, flash_v100::KV_CACHE_DTYPE_FP16);  \
-                    break;                                                      \
-                case flash_v100::KV_CACHE_DTYPE_FP8_E4M3:                       \
-                    LAUNCH_PAGED_TYPED(HDIM, flash_v100::KV_CACHE_DTYPE_FP8_E4M3); \
-                    break;                                                      \
-                case flash_v100::KV_CACHE_DTYPE_FP8_E5M2:                       \
-                    LAUNCH_PAGED_TYPED(HDIM, flash_v100::KV_CACHE_DTYPE_FP8_E5M2); \
-                    break;                                                      \
-                default:                                                        \
-                    TORCH_CHECK(false, "Unsupported kv_cache_dtype: ", kv_cache_dtype); \
-            }                                                                   \
-        } while (0)
+#define LAUNCH_PAGED_BY_KV(HDIM)                                            \
+  do {                                                                      \
+    switch (kv_dtype_code) {                                                \
+      case flash_v100::KV_CACHE_DTYPE_FP16:                                 \
+        LAUNCH_PAGED_TYPED(HDIM, flash_v100::KV_CACHE_DTYPE_FP16);          \
+        break;                                                              \
+      case flash_v100::KV_CACHE_DTYPE_FP8_E4M3:                             \
+        LAUNCH_PAGED_TYPED(HDIM, flash_v100::KV_CACHE_DTYPE_FP8_E4M3);      \
+        break;                                                              \
+      case flash_v100::KV_CACHE_DTYPE_FP8_E5M2:                             \
+        LAUNCH_PAGED_TYPED(HDIM, flash_v100::KV_CACHE_DTYPE_FP8_E5M2);      \
+        break;                                                              \
+      default:                                                              \
+        TORCH_CHECK(false, "Unsupported kv_cache_dtype: ", kv_cache_dtype); \
+    }                                                                       \
+  } while (0)
 
-    switch (D) {
-        case 16:
-            LAUNCH_PAGED_BY_KV(16);
-            break;
-        case 32:
-            LAUNCH_PAGED_BY_KV(32);
-            break;
-        case 64:
-            LAUNCH_PAGED_BY_KV(64);
-            break;
-        case 128:
-            LAUNCH_PAGED_BY_KV(128);
-            break;
-        case 256:
-            LAUNCH_PAGED_BY_KV(256);
-            break;
-        default:
-            TORCH_CHECK(false, "Unsupported D: ", D);
-    }
+  switch (D) {
+    case 16:
+      LAUNCH_PAGED_BY_KV(16);
+      break;
+    case 32:
+      LAUNCH_PAGED_BY_KV(32);
+      break;
+    case 64:
+      LAUNCH_PAGED_BY_KV(64);
+      break;
+    case 128:
+      LAUNCH_PAGED_BY_KV(128);
+      break;
+    case 256:
+      LAUNCH_PAGED_BY_KV(256);
+      break;
+    default:
+      TORCH_CHECK(false, "Unsupported D: ", D);
+  }
 
-    #undef LAUNCH_PAGED_BY_KV
-    #undef LAUNCH_PAGED_TYPED
+#undef LAUNCH_PAGED_BY_KV
+#undef LAUNCH_PAGED_TYPED
 
-    return out_fp16;
+  return out_fp16;
 }
 
 std::vector<at::Tensor>
 flash_attention_prefill_paged_d256_bm32_allp_pair_scratch(
-    const at::Tensor& q,
-    const at::Tensor& k_cache,
-    const at::Tensor& v_cache,
-    std::optional<at::Tensor>& out_,
-    std::optional<at::Tensor>& softmax_lse_,
-    const at::Tensor& block_table,
-    const at::Tensor& seq_lens,
-    const float softmax_scale
-) {
-    TORCH_CHECK(q.dim() == 4, "q must have shape [B, H, M, D]");
-    TORCH_CHECK(k_cache.dim() == 4 && v_cache.dim() == 4,
-                "k_cache and v_cache must have shape [blocks, page, Hkv, D]");
-    TORCH_CHECK(block_table.dim() == 2,
-                "block_table must have shape [B, max_num_blocks]");
-    TORCH_CHECK(seq_lens.dim() == 1, "seq_lens must have shape [B]");
-    TORCH_CHECK(q.dtype() == torch::kFloat16, "q must be fp16");
-    TORCH_CHECK(k_cache.dtype() == torch::kFloat16,
-                "k_cache must be fp16");
-    TORCH_CHECK(v_cache.dtype() == torch::kFloat16,
-                "v_cache must be fp16");
-    TORCH_CHECK(block_table.dtype() == torch::kInt32,
-                "block_table must be int32");
-    TORCH_CHECK(seq_lens.dtype() == torch::kInt32, "seq_lens must be int32");
-    TORCH_CHECK(q.is_cuda() && k_cache.is_cuda() && v_cache.is_cuda(),
-                "q, k_cache, and v_cache must be CUDA tensors");
-    TORCH_CHECK(block_table.is_cuda() && seq_lens.is_cuda(),
-                "block_table and seq_lens must be CUDA tensors");
-    TORCH_CHECK(
-        q.device() == k_cache.device() && q.device() == v_cache.device()
-            && q.device() == block_table.device() && q.device() == seq_lens.device(),
-        "all input tensors must be on the q device");
-    TORCH_CHECK(q.is_contiguous(), "q must be contiguous [B, H, M, D]");
-    TORCH_CHECK(block_table.is_contiguous(), "block_table must be contiguous");
-    TORCH_CHECK(seq_lens.is_contiguous(), "seq_lens must be contiguous");
-    TORCH_CHECK(k_cache.sizes() == v_cache.sizes(),
-                "k_cache and v_cache must have the same shape");
-    TORCH_CHECK(k_cache.stride(-1) == 1 && v_cache.stride(-1) == 1,
-                "K/V head dimensions must be contiguous");
-    TORCH_CHECK(k_cache.stride(1) % 8 == 0 && k_cache.stride(2) % 8 == 0
-                    && v_cache.stride(1) % 8 == 0
-                    && v_cache.stride(2) % 8 == 0,
-                "K/V strides must be divisible by 8 half elements");
+    const at::Tensor& q, const at::Tensor& k_cache, const at::Tensor& v_cache,
+    std::optional<at::Tensor>& out_, std::optional<at::Tensor>& softmax_lse_,
+    const at::Tensor& block_table, const at::Tensor& seq_lens,
+    const float softmax_scale) {
+  TORCH_CHECK(q.dim() == 4, "q must have shape [B, H, M, D]");
+  TORCH_CHECK(k_cache.dim() == 4 && v_cache.dim() == 4,
+              "k_cache and v_cache must have shape [blocks, page, Hkv, D]");
+  TORCH_CHECK(block_table.dim() == 2,
+              "block_table must have shape [B, max_num_blocks]");
+  TORCH_CHECK(seq_lens.dim() == 1, "seq_lens must have shape [B]");
+  TORCH_CHECK(q.dtype() == torch::kFloat16, "q must be fp16");
+  TORCH_CHECK(k_cache.dtype() == torch::kFloat16, "k_cache must be fp16");
+  TORCH_CHECK(v_cache.dtype() == torch::kFloat16, "v_cache must be fp16");
+  TORCH_CHECK(block_table.dtype() == torch::kInt32,
+              "block_table must be int32");
+  TORCH_CHECK(seq_lens.dtype() == torch::kInt32, "seq_lens must be int32");
+  TORCH_CHECK(q.is_cuda() && k_cache.is_cuda() && v_cache.is_cuda(),
+              "q, k_cache, and v_cache must be CUDA tensors");
+  TORCH_CHECK(block_table.is_cuda() && seq_lens.is_cuda(),
+              "block_table and seq_lens must be CUDA tensors");
+  TORCH_CHECK(
+      q.device() == k_cache.device() && q.device() == v_cache.device() &&
+          q.device() == block_table.device() && q.device() == seq_lens.device(),
+      "all input tensors must be on the q device");
+  TORCH_CHECK(q.is_contiguous(), "q must be contiguous [B, H, M, D]");
+  TORCH_CHECK(block_table.is_contiguous(), "block_table must be contiguous");
+  TORCH_CHECK(seq_lens.is_contiguous(), "seq_lens must be contiguous");
+  TORCH_CHECK(k_cache.sizes() == v_cache.sizes(),
+              "k_cache and v_cache must have the same shape");
+  TORCH_CHECK(k_cache.stride(-1) == 1 && v_cache.stride(-1) == 1,
+              "K/V head dimensions must be contiguous");
+  TORCH_CHECK(k_cache.stride(1) % 8 == 0 && k_cache.stride(2) % 8 == 0 &&
+                  v_cache.stride(1) % 8 == 0 && v_cache.stride(2) % 8 == 0,
+              "K/V strides must be divisible by 8 half elements");
 
-    const int B = q.size(0);
-    const int H = q.size(1);
-    const int M = q.size(2);
-    const int D = q.size(3);
-    const int num_kv_heads = k_cache.size(2);
+  const int B = q.size(0);
+  const int H = q.size(1);
+  const int M = q.size(2);
+  const int D = q.size(3);
+  const int num_kv_heads = k_cache.size(2);
 
-    TORCH_CHECK(B > 0 && H > 0, "q batch and head dimensions must be positive");
-    TORCH_CHECK(M >= D256_BM32_PHASE_BLOCK_M,
-                "fixed BM32 prefill requires M >= ",
-                D256_BM32_PHASE_BLOCK_M);
-    TORCH_CHECK(D == D256_BM32_PHASE_D,
-                "fixed BM32 prefill requires D=", D256_BM32_PHASE_D);
-    TORCH_CHECK(k_cache.size(0) > 0 && num_kv_heads > 0,
-                "K/V cache block and head dimensions must be positive");
-    TORCH_CHECK(k_cache.size(1) == D256_BM32_PHASE_PAGE_BLOCK_SIZE,
-                "fixed BM32 prefill requires page size ",
-                D256_BM32_PHASE_PAGE_BLOCK_SIZE);
-    TORCH_CHECK(k_cache.size(3) == D256_BM32_PHASE_D,
-                "K/V cache head dimension must be D=",
-                D256_BM32_PHASE_D);
-    TORCH_CHECK(H % num_kv_heads == 0,
-                "num_q_heads must be divisible by num_kv_heads");
-    TORCH_CHECK(block_table.size(0) == B && seq_lens.size(0) == B,
-                "block_table and seq_lens batch dimensions must equal q batch");
-    TORCH_CHECK(block_table.size(1) > 0,
-                "block_table must provide at least one page index");
+  TORCH_CHECK(B > 0 && H > 0, "q batch and head dimensions must be positive");
+  TORCH_CHECK(M >= D256_BM32_PHASE_BLOCK_M,
+              "fixed BM32 prefill requires M >= ", D256_BM32_PHASE_BLOCK_M);
+  TORCH_CHECK(D == D256_BM32_PHASE_D,
+              "fixed BM32 prefill requires D=", D256_BM32_PHASE_D);
+  TORCH_CHECK(k_cache.size(0) > 0 && num_kv_heads > 0,
+              "K/V cache block and head dimensions must be positive");
+  TORCH_CHECK(k_cache.size(1) == D256_BM32_PHASE_PAGE_BLOCK_SIZE,
+              "fixed BM32 prefill requires page size ",
+              D256_BM32_PHASE_PAGE_BLOCK_SIZE);
+  TORCH_CHECK(k_cache.size(3) == D256_BM32_PHASE_D,
+              "K/V cache head dimension must be D=", D256_BM32_PHASE_D);
+  TORCH_CHECK(H % num_kv_heads == 0,
+              "num_q_heads must be divisible by num_kv_heads");
+  TORCH_CHECK(block_table.size(0) == B && seq_lens.size(0) == B,
+              "block_table and seq_lens batch dimensions must equal q batch");
+  TORCH_CHECK(block_table.size(1) > 0,
+              "block_table must provide at least one page index");
 
-    if (out_.has_value()) {
-        const at::Tensor& out = out_.value();
-        TORCH_CHECK(out.is_cuda() && out.device() == q.device(),
-                    "out must be a CUDA tensor on the q device");
-        TORCH_CHECK(out.dtype() == torch::kFloat16, "out must be fp16");
-        TORCH_CHECK(out.sizes() == q.sizes(), "out must have shape [B, H, M, D]");
-        TORCH_CHECK(out.is_contiguous(), "out must be contiguous [B, H, M, D]");
-    }
-    if (softmax_lse_.has_value()) {
-        const at::Tensor& softmax_lse = softmax_lse_.value();
-        TORCH_CHECK(softmax_lse.is_cuda() && softmax_lse.device() == q.device(),
-                    "softmax_lse must be a CUDA tensor on the q device");
-        TORCH_CHECK(softmax_lse.dtype() == torch::kFloat32,
-                    "softmax_lse must be fp32");
-        TORCH_CHECK(softmax_lse.dim() == 3 && softmax_lse.size(0) == B
-                        && softmax_lse.size(1) == H && softmax_lse.size(2) == M,
-                    "softmax_lse must have shape [B, H, M]");
-        TORCH_CHECK(softmax_lse.is_contiguous(),
-                    "softmax_lse must be contiguous [B, H, M]");
-    }
+  if (out_.has_value()) {
+    const at::Tensor& out = out_.value();
+    TORCH_CHECK(out.is_cuda() && out.device() == q.device(),
+                "out must be a CUDA tensor on the q device");
+    TORCH_CHECK(out.dtype() == torch::kFloat16, "out must be fp16");
+    TORCH_CHECK(out.sizes() == q.sizes(), "out must have shape [B, H, M, D]");
+    TORCH_CHECK(out.is_contiguous(), "out must be contiguous [B, H, M, D]");
+  }
+  if (softmax_lse_.has_value()) {
+    const at::Tensor& softmax_lse = softmax_lse_.value();
+    TORCH_CHECK(softmax_lse.is_cuda() && softmax_lse.device() == q.device(),
+                "softmax_lse must be a CUDA tensor on the q device");
+    TORCH_CHECK(softmax_lse.dtype() == torch::kFloat32,
+                "softmax_lse must be fp32");
+    TORCH_CHECK(softmax_lse.dim() == 3 && softmax_lse.size(0) == B &&
+                    softmax_lse.size(1) == H && softmax_lse.size(2) == M,
+                "softmax_lse must have shape [B, H, M]");
+    TORCH_CHECK(softmax_lse.is_contiguous(),
+                "softmax_lse must be contiguous [B, H, M]");
+  }
 
-    c10::cuda::CUDAGuard device_guard(q.device());
-    auto stream = at::cuda::getCurrentCUDAStream().stream();
-    cudaStreamCaptureStatus capture_status = cudaStreamCaptureStatusNone;
-    const cudaError_t capture_error = cudaStreamIsCapturing(stream, &capture_status);
-    TORCH_CHECK(capture_error == cudaSuccess, "cudaStreamIsCapturing failed: ",
-                cudaGetErrorString(capture_error));
-    TORCH_CHECK(capture_status == cudaStreamCaptureStatusNone,
-                "fixed BM32 prefill CUDA graph capture is not validated");
+  c10::cuda::CUDAGuard device_guard(q.device());
+  auto stream = at::cuda::getCurrentCUDAStream().stream();
+  cudaStreamCaptureStatus capture_status = cudaStreamCaptureStatusNone;
+  const cudaError_t capture_error =
+      cudaStreamIsCapturing(stream, &capture_status);
+  TORCH_CHECK(capture_error == cudaSuccess, "cudaStreamIsCapturing failed: ",
+              cudaGetErrorString(capture_error));
+  TORCH_CHECK(capture_status == cudaStreamCaptureStatusNone,
+              "fixed BM32 prefill CUDA graph capture is not validated");
 
-    auto props = at::cuda::getCurrentDeviceProperties();
-    TORCH_CHECK(props->major == 7 && props->minor == 0,
-                "fixed BM32 prefill supports only SM70 GPUs");
+  auto props = at::cuda::getCurrentDeviceProperties();
+  TORCH_CHECK(props->major == 7 && props->minor == 0,
+              "fixed BM32 prefill supports only SM70 GPUs");
 
-    at::Tensor out_fp16 = out_.has_value() ? out_.value() : torch::empty_like(q);
-    at::Tensor softmax_lse =
-        softmax_lse_.has_value()
-            ? softmax_lse_.value()
-            : torch::empty({B, H, M},
-                           torch::dtype(torch::kFloat32).device(q.device()));
+  at::Tensor out_fp16 = out_.has_value() ? out_.value() : torch::empty_like(q);
+  at::Tensor softmax_lse =
+      softmax_lse_.has_value()
+          ? softmax_lse_.value()
+          : torch::empty({B, H, M},
+                         torch::dtype(torch::kFloat32).device(q.device()));
 
-    launch_flash_attention_forward_paged_d256_bm32_phase_kernel<true, true, true>(
-        q, k_cache, v_cache, out_fp16, softmax_lse, block_table, seq_lens,
-        softmax_scale, stream);
+  launch_flash_attention_forward_paged_d256_bm32_phase_kernel<true, true, true>(
+      q, k_cache, v_cache, out_fp16, softmax_lse, block_table, seq_lens,
+      softmax_scale, stream);
 
-    return {out_fp16, softmax_lse};
+  return {out_fp16, softmax_lse};
 }
 
 std::vector<at::Tensor>
 flash_attention_prefill_paged_d256_bm32_allp_pair_scratch_splitkv3(
-    const at::Tensor& q,
-    const at::Tensor& k_cache,
-    const at::Tensor& v_cache,
-    std::optional<at::Tensor>& out_,
-    std::optional<at::Tensor>& softmax_lse_,
-    at::Tensor& split_tmp_out,
-    at::Tensor& split_tmp_row_max,
-    at::Tensor& split_tmp_row_sum,
-    const at::Tensor& block_table,
-    const int64_t actual_n,
-    const float softmax_scale
-) {
-    TORCH_CHECK(q.dim() == 4, "q must have shape [B, H, M, D]");
-    TORCH_CHECK(k_cache.dim() == 4 && v_cache.dim() == 4,
-                "k_cache and v_cache must have shape [blocks, page, Hkv, D]");
-    TORCH_CHECK(block_table.dim() == 2,
-                "block_table must have shape [B, max_num_blocks]");
-    TORCH_CHECK(q.dtype() == torch::kFloat16, "q must be fp16");
-    TORCH_CHECK(k_cache.dtype() == torch::kFloat16,
-                "k_cache must be fp16");
-    TORCH_CHECK(v_cache.dtype() == torch::kFloat16,
-                "v_cache must be fp16");
-    TORCH_CHECK(block_table.dtype() == torch::kInt32,
-                "block_table must be int32");
-    TORCH_CHECK(q.is_cuda() && k_cache.is_cuda() && v_cache.is_cuda(),
-                "q, k_cache, and v_cache must be CUDA tensors");
-    TORCH_CHECK(block_table.is_cuda(), "block_table must be a CUDA tensor");
-    TORCH_CHECK(
-        q.device() == k_cache.device() && q.device() == v_cache.device()
-            && q.device() == block_table.device(),
-        "all input tensors must be on the q device");
-    TORCH_CHECK(q.is_contiguous(), "q must be contiguous [B, H, M, D]");
-    TORCH_CHECK(block_table.is_contiguous(), "block_table must be contiguous");
-    TORCH_CHECK(k_cache.sizes() == v_cache.sizes(),
-                "k_cache and v_cache must have the same shape");
-    TORCH_CHECK(k_cache.stride(-1) == 1 && v_cache.stride(-1) == 1,
-                "K/V head dimensions must be contiguous");
-    TORCH_CHECK(k_cache.stride(1) % 8 == 0 && k_cache.stride(2) % 8 == 0
-                    && v_cache.stride(1) % 8 == 0
-                    && v_cache.stride(2) % 8 == 0,
-                "K/V strides must be divisible by 8 half elements");
+    const at::Tensor& q, const at::Tensor& k_cache, const at::Tensor& v_cache,
+    std::optional<at::Tensor>& out_, std::optional<at::Tensor>& softmax_lse_,
+    at::Tensor& split_tmp_out, at::Tensor& split_tmp_row_max,
+    at::Tensor& split_tmp_row_sum, const at::Tensor& block_table,
+    const int64_t actual_n, const float softmax_scale) {
+  TORCH_CHECK(q.dim() == 4, "q must have shape [B, H, M, D]");
+  TORCH_CHECK(k_cache.dim() == 4 && v_cache.dim() == 4,
+              "k_cache and v_cache must have shape [blocks, page, Hkv, D]");
+  TORCH_CHECK(block_table.dim() == 2,
+              "block_table must have shape [B, max_num_blocks]");
+  TORCH_CHECK(q.dtype() == torch::kFloat16, "q must be fp16");
+  TORCH_CHECK(k_cache.dtype() == torch::kFloat16, "k_cache must be fp16");
+  TORCH_CHECK(v_cache.dtype() == torch::kFloat16, "v_cache must be fp16");
+  TORCH_CHECK(block_table.dtype() == torch::kInt32,
+              "block_table must be int32");
+  TORCH_CHECK(q.is_cuda() && k_cache.is_cuda() && v_cache.is_cuda(),
+              "q, k_cache, and v_cache must be CUDA tensors");
+  TORCH_CHECK(block_table.is_cuda(), "block_table must be a CUDA tensor");
+  TORCH_CHECK(q.device() == k_cache.device() &&
+                  q.device() == v_cache.device() &&
+                  q.device() == block_table.device(),
+              "all input tensors must be on the q device");
+  TORCH_CHECK(q.is_contiguous(), "q must be contiguous [B, H, M, D]");
+  TORCH_CHECK(block_table.is_contiguous(), "block_table must be contiguous");
+  TORCH_CHECK(k_cache.sizes() == v_cache.sizes(),
+              "k_cache and v_cache must have the same shape");
+  TORCH_CHECK(k_cache.stride(-1) == 1 && v_cache.stride(-1) == 1,
+              "K/V head dimensions must be contiguous");
+  TORCH_CHECK(k_cache.stride(1) % 8 == 0 && k_cache.stride(2) % 8 == 0 &&
+                  v_cache.stride(1) % 8 == 0 && v_cache.stride(2) % 8 == 0,
+              "K/V strides must be divisible by 8 half elements");
 
-    const int B = q.size(0);
-    const int H = q.size(1);
-    const int M = q.size(2);
-    const int D = q.size(3);
-    const int num_kv_heads = k_cache.size(2);
+  const int B = q.size(0);
+  const int H = q.size(1);
+  const int M = q.size(2);
+  const int D = q.size(3);
+  const int num_kv_heads = k_cache.size(2);
 
-    TORCH_CHECK(B == 1,
-                "fixed BM32 split-KV host-length path requires B=1");
-    TORCH_CHECK(H > 0, "q head dimension must be positive");
-    TORCH_CHECK(M >= D256_BM32_PHASE_BLOCK_M,
-                "fixed BM32 split-KV prefill requires M >= ",
-                D256_BM32_PHASE_BLOCK_M);
-    TORCH_CHECK(D == D256_BM32_PHASE_D,
-                "fixed BM32 split-KV prefill requires D=",
-                D256_BM32_PHASE_D);
-    TORCH_CHECK(k_cache.size(0) > 0 && num_kv_heads > 0,
-                "K/V cache block and head dimensions must be positive");
-    TORCH_CHECK(k_cache.size(1) == D256_BM32_PHASE_PAGE_BLOCK_SIZE,
-                "fixed BM32 split-KV prefill requires page size ",
-                D256_BM32_PHASE_PAGE_BLOCK_SIZE);
-    TORCH_CHECK(k_cache.size(3) == D256_BM32_PHASE_D,
-                "K/V cache head dimension must be D=",
-                D256_BM32_PHASE_D);
-    TORCH_CHECK(H % num_kv_heads == 0,
-                "num_q_heads must be divisible by num_kv_heads");
-    TORCH_CHECK(block_table.size(0) == B,
-                "block_table batch dimension must equal q batch");
-    TORCH_CHECK(actual_n >= M && actual_n <= 2147483647LL,
-                "actual_n must satisfy M <= actual_n <= INT_MAX");
-    const int64_t required_pages =
-        (actual_n + D256_BM32_PHASE_PAGE_BLOCK_SIZE - 1)
-        / D256_BM32_PHASE_PAGE_BLOCK_SIZE;
-    TORCH_CHECK(block_table.size(1) >= required_pages,
-                "block_table does not cover actual_n host length");
+  TORCH_CHECK(B == 1, "fixed BM32 split-KV host-length path requires B=1");
+  TORCH_CHECK(H > 0, "q head dimension must be positive");
+  TORCH_CHECK(
+      M >= D256_BM32_PHASE_BLOCK_M,
+      "fixed BM32 split-KV prefill requires M >= ", D256_BM32_PHASE_BLOCK_M);
+  TORCH_CHECK(D == D256_BM32_PHASE_D,
+              "fixed BM32 split-KV prefill requires D=", D256_BM32_PHASE_D);
+  TORCH_CHECK(k_cache.size(0) > 0 && num_kv_heads > 0,
+              "K/V cache block and head dimensions must be positive");
+  TORCH_CHECK(k_cache.size(1) == D256_BM32_PHASE_PAGE_BLOCK_SIZE,
+              "fixed BM32 split-KV prefill requires page size ",
+              D256_BM32_PHASE_PAGE_BLOCK_SIZE);
+  TORCH_CHECK(k_cache.size(3) == D256_BM32_PHASE_D,
+              "K/V cache head dimension must be D=", D256_BM32_PHASE_D);
+  TORCH_CHECK(H % num_kv_heads == 0,
+              "num_q_heads must be divisible by num_kv_heads");
+  TORCH_CHECK(block_table.size(0) == B,
+              "block_table batch dimension must equal q batch");
+  TORCH_CHECK(actual_n >= M && actual_n <= 2147483647LL,
+              "actual_n must satisfy M <= actual_n <= INT_MAX");
+  const int64_t required_pages =
+      (actual_n + D256_BM32_PHASE_PAGE_BLOCK_SIZE - 1) /
+      D256_BM32_PHASE_PAGE_BLOCK_SIZE;
+  TORCH_CHECK(block_table.size(1) >= required_pages,
+              "block_table does not cover actual_n host length");
 
-    if (out_.has_value()) {
-        const at::Tensor& out = out_.value();
-        TORCH_CHECK(out.is_cuda() && out.device() == q.device(),
-                    "out must be a CUDA tensor on the q device");
-        TORCH_CHECK(out.dtype() == torch::kFloat16, "out must be fp16");
-        TORCH_CHECK(out.sizes() == q.sizes(), "out must have shape [B, H, M, D]");
-        TORCH_CHECK(out.is_contiguous(), "out must be contiguous [B, H, M, D]");
-    }
-    if (softmax_lse_.has_value()) {
-        const at::Tensor& softmax_lse = softmax_lse_.value();
-        TORCH_CHECK(softmax_lse.is_cuda() && softmax_lse.device() == q.device(),
-                    "softmax_lse must be a CUDA tensor on the q device");
-        TORCH_CHECK(softmax_lse.dtype() == torch::kFloat32,
-                    "softmax_lse must be fp32");
-        TORCH_CHECK(softmax_lse.dim() == 3 && softmax_lse.size(0) == B
-                        && softmax_lse.size(1) == H && softmax_lse.size(2) == M,
-                    "softmax_lse must have shape [B, H, M]");
-        TORCH_CHECK(softmax_lse.is_contiguous(),
-                    "softmax_lse must be contiguous [B, H, M]");
-    }
+  if (out_.has_value()) {
+    const at::Tensor& out = out_.value();
+    TORCH_CHECK(out.is_cuda() && out.device() == q.device(),
+                "out must be a CUDA tensor on the q device");
+    TORCH_CHECK(out.dtype() == torch::kFloat16, "out must be fp16");
+    TORCH_CHECK(out.sizes() == q.sizes(), "out must have shape [B, H, M, D]");
+    TORCH_CHECK(out.is_contiguous(), "out must be contiguous [B, H, M, D]");
+  }
+  if (softmax_lse_.has_value()) {
+    const at::Tensor& softmax_lse = softmax_lse_.value();
+    TORCH_CHECK(softmax_lse.is_cuda() && softmax_lse.device() == q.device(),
+                "softmax_lse must be a CUDA tensor on the q device");
+    TORCH_CHECK(softmax_lse.dtype() == torch::kFloat32,
+                "softmax_lse must be fp32");
+    TORCH_CHECK(softmax_lse.dim() == 3 && softmax_lse.size(0) == B &&
+                    softmax_lse.size(1) == H && softmax_lse.size(2) == M,
+                "softmax_lse must have shape [B, H, M]");
+    TORCH_CHECK(softmax_lse.is_contiguous(),
+                "softmax_lse must be contiguous [B, H, M]");
+  }
 
-    const std::vector<int64_t> expected_partial_out = {
-        B, H, D256_BM32_PHASE_SPLIT_PARTS, M, D};
-    const std::vector<int64_t> expected_partial_rows = {
-        B, H, D256_BM32_PHASE_SPLIT_PARTS, M};
-    for (const at::Tensor* workspace : {
-             &split_tmp_out, &split_tmp_row_max, &split_tmp_row_sum}) {
-        TORCH_CHECK(workspace->is_cuda() && workspace->device() == q.device(),
-                    "split-KV workspaces must be CUDA tensors on the q device");
-        TORCH_CHECK(workspace->dtype() == torch::kFloat32,
-                    "split-KV workspaces must be fp32");
-        TORCH_CHECK(workspace->is_contiguous(),
-                    "split-KV workspaces must be contiguous");
-    }
-    TORCH_CHECK(split_tmp_out.sizes() == expected_partial_out,
-                "split_tmp_out must have shape [B, H, 3, M, D]");
-    TORCH_CHECK(split_tmp_row_max.sizes() == expected_partial_rows,
-                "split_tmp_row_max must have shape [B, H, 3, M]");
-    TORCH_CHECK(split_tmp_row_sum.sizes() == expected_partial_rows,
-                "split_tmp_row_sum must have shape [B, H, 3, M]");
+  const std::vector<int64_t> expected_partial_out = {
+      B, H, D256_BM32_PHASE_SPLIT_PARTS, M, D};
+  const std::vector<int64_t> expected_partial_rows = {
+      B, H, D256_BM32_PHASE_SPLIT_PARTS, M};
+  for (const at::Tensor* workspace :
+       {&split_tmp_out, &split_tmp_row_max, &split_tmp_row_sum}) {
+    TORCH_CHECK(workspace->is_cuda() && workspace->device() == q.device(),
+                "split-KV workspaces must be CUDA tensors on the q device");
+    TORCH_CHECK(workspace->dtype() == torch::kFloat32,
+                "split-KV workspaces must be fp32");
+    TORCH_CHECK(workspace->is_contiguous(),
+                "split-KV workspaces must be contiguous");
+  }
+  TORCH_CHECK(split_tmp_out.sizes() == expected_partial_out,
+              "split_tmp_out must have shape [B, H, 3, M, D]");
+  TORCH_CHECK(split_tmp_row_max.sizes() == expected_partial_rows,
+              "split_tmp_row_max must have shape [B, H, 3, M]");
+  TORCH_CHECK(split_tmp_row_sum.sizes() == expected_partial_rows,
+              "split_tmp_row_sum must have shape [B, H, 3, M]");
 
-    c10::cuda::CUDAGuard device_guard(q.device());
-    auto stream = at::cuda::getCurrentCUDAStream().stream();
-    cudaStreamCaptureStatus capture_status = cudaStreamCaptureStatusNone;
-    const cudaError_t capture_error = cudaStreamIsCapturing(stream, &capture_status);
-    TORCH_CHECK(capture_error == cudaSuccess, "cudaStreamIsCapturing failed: ",
-                cudaGetErrorString(capture_error));
-    TORCH_CHECK(capture_status == cudaStreamCaptureStatusNone,
-                "fixed BM32 split-KV CUDA graph capture is not validated");
+  c10::cuda::CUDAGuard device_guard(q.device());
+  auto stream = at::cuda::getCurrentCUDAStream().stream();
+  cudaStreamCaptureStatus capture_status = cudaStreamCaptureStatusNone;
+  const cudaError_t capture_error =
+      cudaStreamIsCapturing(stream, &capture_status);
+  TORCH_CHECK(capture_error == cudaSuccess, "cudaStreamIsCapturing failed: ",
+              cudaGetErrorString(capture_error));
+  TORCH_CHECK(capture_status == cudaStreamCaptureStatusNone,
+              "fixed BM32 split-KV CUDA graph capture is not validated");
 
-    auto props = at::cuda::getCurrentDeviceProperties();
-    TORCH_CHECK(props->major == 7 && props->minor == 0,
-                "fixed BM32 split-KV prefill supports only SM70 GPUs");
+  auto props = at::cuda::getCurrentDeviceProperties();
+  TORCH_CHECK(props->major == 7 && props->minor == 0,
+              "fixed BM32 split-KV prefill supports only SM70 GPUs");
 
-    at::Tensor out_fp16 = out_.has_value() ? out_.value() : torch::empty_like(q);
-    at::Tensor softmax_lse =
-        softmax_lse_.has_value()
-            ? softmax_lse_.value()
-            : torch::empty({B, H, M},
-                           torch::dtype(torch::kFloat32).device(q.device()));
-    launch_flash_attention_forward_paged_d256_bm32_splitkv3_kernel(
-        q, k_cache, v_cache, out_fp16, softmax_lse,
-        split_tmp_out, split_tmp_row_max, split_tmp_row_sum,
-        block_table, static_cast<int>(actual_n),
-        softmax_scale, stream);
+  at::Tensor out_fp16 = out_.has_value() ? out_.value() : torch::empty_like(q);
+  at::Tensor softmax_lse =
+      softmax_lse_.has_value()
+          ? softmax_lse_.value()
+          : torch::empty({B, H, M},
+                         torch::dtype(torch::kFloat32).device(q.device()));
+  launch_flash_attention_forward_paged_d256_bm32_splitkv3_kernel(
+      q, k_cache, v_cache, out_fp16, softmax_lse, split_tmp_out,
+      split_tmp_row_max, split_tmp_row_sum, block_table,
+      static_cast<int>(actual_n), softmax_scale, stream);
 
-    return {out_fp16, softmax_lse};
+  return {out_fp16, softmax_lse};
 }
 
 at::Tensor flash_attention_prefill_paged_bfla(
-    const at::Tensor& q,
-    const at::Tensor& k_cache,
-    const at::Tensor& v_cache,
-    std::optional<at::Tensor>& out_,
-    const at::Tensor& block_table,
-    const at::Tensor& seq_lens,
-    const at::Tensor& bfla_block_mask,
-    const int bfla_mask_block_n,
-    const float softmax_scale,
-    const std::string& kv_cache_dtype,
-    const float k_scale,
-    const float v_scale,
-    const bool is_causal,
-    const int window_size_left,
-    const int window_size_right
-) {
-    TORCH_CHECK(q.dtype() == torch::kFloat16, "q must be fp16");
-    const int kv_dtype_code = kv_cache_dtype_code_from_string(kv_cache_dtype);
-    TORCH_CHECK(kv_dtype_code == flash_v100::KV_CACHE_DTYPE_FP16,
-                "BFLA paged prefill supports fp16 KV cache only");
-    TORCH_CHECK(k_cache.dtype() == torch::kFloat16, "k_cache must be fp16");
-    TORCH_CHECK(v_cache.dtype() == torch::kFloat16, "v_cache must be fp16");
-    TORCH_CHECK(q.is_cuda() && k_cache.is_cuda() && v_cache.is_cuda(),
-                "Tensors must be on CUDA");
-    TORCH_CHECK(block_table.is_cuda() && seq_lens.is_cuda(),
-                "block_table and seq_lens must be CUDA tensors");
-    TORCH_CHECK(bfla_block_mask.is_cuda(),
-                "bfla_block_mask must be a CUDA tensor");
-    TORCH_CHECK(bfla_block_mask.dtype() == torch::kInt32,
-                "bfla_block_mask must be int32");
-    TORCH_CHECK(bfla_block_mask.dim() == 4,
-                "bfla_block_mask must have shape [B, Hkv, q_tiles, kv_tiles]");
-    TORCH_CHECK(q.stride(-1) == 1 && k_cache.stride(-1) == 1 &&
-                    v_cache.stride(-1) == 1,
-                "Last dim must be contiguous");
-    TORCH_CHECK(k_cache.stride(1) % 8 == 0 && k_cache.stride(2) % 8 == 0 &&
-                    v_cache.stride(1) % 8 == 0 && v_cache.stride(2) % 8 == 0,
-                "Paged KV strides must be divisible by 8 half elements");
+    const at::Tensor& q, const at::Tensor& k_cache, const at::Tensor& v_cache,
+    std::optional<at::Tensor>& out_, const at::Tensor& block_table,
+    const at::Tensor& seq_lens, const at::Tensor& bfla_block_mask,
+    const int bfla_mask_block_n, const float softmax_scale,
+    const std::string& kv_cache_dtype, const float k_scale, const float v_scale,
+    const bool is_causal, const int window_size_left,
+    const int window_size_right) {
+  TORCH_CHECK(q.dtype() == torch::kFloat16, "q must be fp16");
+  const int kv_dtype_code = kv_cache_dtype_code_from_string(kv_cache_dtype);
+  TORCH_CHECK(kv_dtype_code == flash_v100::KV_CACHE_DTYPE_FP16,
+              "BFLA paged prefill supports fp16 KV cache only");
+  TORCH_CHECK(k_cache.dtype() == torch::kFloat16, "k_cache must be fp16");
+  TORCH_CHECK(v_cache.dtype() == torch::kFloat16, "v_cache must be fp16");
+  TORCH_CHECK(q.is_cuda() && k_cache.is_cuda() && v_cache.is_cuda(),
+              "Tensors must be on CUDA");
+  TORCH_CHECK(block_table.is_cuda() && seq_lens.is_cuda(),
+              "block_table and seq_lens must be CUDA tensors");
+  TORCH_CHECK(bfla_block_mask.is_cuda(),
+              "bfla_block_mask must be a CUDA tensor");
+  TORCH_CHECK(bfla_block_mask.dtype() == torch::kInt32,
+              "bfla_block_mask must be int32");
+  TORCH_CHECK(bfla_block_mask.dim() == 4,
+              "bfla_block_mask must have shape [B, Hkv, q_tiles, kv_tiles]");
+  TORCH_CHECK(
+      q.stride(-1) == 1 && k_cache.stride(-1) == 1 && v_cache.stride(-1) == 1,
+      "Last dim must be contiguous");
+  TORCH_CHECK(k_cache.stride(1) % 8 == 0 && k_cache.stride(2) % 8 == 0 &&
+                  v_cache.stride(1) % 8 == 0 && v_cache.stride(2) % 8 == 0,
+              "Paged KV strides must be divisible by 8 half elements");
 
-    const int B = q.size(0);
-    const int H = q.size(1);
-    const int M = q.size(2);
-    const int D = q.size(3);
-    const int num_kv_heads = k_cache.size(2);
-    const int page_block_size = k_cache.size(1);
+  const int B = q.size(0);
+  const int H = q.size(1);
+  const int M = q.size(2);
+  const int D = q.size(3);
+  const int num_kv_heads = k_cache.size(2);
+  const int page_block_size = k_cache.size(1);
 
-    TORCH_CHECK(D == 256, "BFLA paged prefill supports D=256 only");
-    TORCH_CHECK(H % num_kv_heads == 0,
-                "num_heads must be divisible by num_kv_heads");
-    TORCH_CHECK(M > 1, "BFLA paged prefill requires prefill M > 1");
-    TORCH_CHECK(page_block_size >= 16 && (page_block_size % 16) == 0,
-                "BFLA paged prefill requires page block size multiple of 16");
-    TORCH_CHECK(is_causal, "BFLA paged prefill supports causal attention only");
-    TORCH_CHECK(window_size_left == -1 && window_size_right == -1,
-                "BFLA paged prefill does not support sliding window");
-    TORCH_CHECK(bfla_mask_block_n > 0,
-                "bfla_mask_block_n must be positive");
-    TORCH_CHECK(B <= bfla_block_mask.size(0),
-                "bfla_block_mask batch dimension must cover q");
-    TORCH_CHECK(num_kv_heads <= bfla_block_mask.size(1),
-                "bfla_block_mask head dimension must cover KV heads");
+  TORCH_CHECK(D == 256, "BFLA paged prefill supports D=256 only");
+  TORCH_CHECK(H % num_kv_heads == 0,
+              "num_heads must be divisible by num_kv_heads");
+  TORCH_CHECK(M > 1, "BFLA paged prefill requires prefill M > 1");
+  TORCH_CHECK(page_block_size >= 16 && (page_block_size % 16) == 0,
+              "BFLA paged prefill requires page block size multiple of 16");
+  TORCH_CHECK(is_causal, "BFLA paged prefill supports causal attention only");
+  TORCH_CHECK(window_size_left == -1 && window_size_right == -1,
+              "BFLA paged prefill does not support sliding window");
+  TORCH_CHECK(bfla_mask_block_n > 0, "bfla_mask_block_n must be positive");
+  TORCH_CHECK(B <= bfla_block_mask.size(0),
+              "bfla_block_mask batch dimension must cover q");
+  TORCH_CHECK(num_kv_heads <= bfla_block_mask.size(1),
+              "bfla_block_mask head dimension must cover KV heads");
 
-    at::Tensor out_fp16 = out_.has_value() ? out_.value() : torch::zeros_like(q);
-    auto softmax_lse = torch::zeros({B, H, M},
-                                    torch::dtype(torch::kFloat32).device(q.device()));
+  at::Tensor out_fp16 = out_.has_value() ? out_.value() : torch::zeros_like(q);
+  auto softmax_lse =
+      torch::zeros({B, H, M}, torch::dtype(torch::kFloat32).device(q.device()));
 
-    auto stream = at::cuda::getCurrentCUDAStream().stream();
-    auto props = at::cuda::getCurrentDeviceProperties();
-    bool sm70 = props->major == 7 && props->minor == 0;
-    TORCH_CHECK(sm70, "Kernel supports only Volta GPUs.");
+  auto stream = at::cuda::getCurrentCUDAStream().stream();
+  auto props = at::cuda::getCurrentDeviceProperties();
+  bool sm70 = props->major == 7 && props->minor == 0;
+  TORCH_CHECK(sm70, "Kernel supports only Volta GPUs.");
 
-    launcher_flash_attention_forward_paged<256, flash_v100::KV_CACHE_DTYPE_FP16>(
-        q, k_cache, v_cache, out_fp16, softmax_lse, block_table, seq_lens,
-        softmax_scale, is_causal, k_scale, v_scale, window_size_left,
-        window_size_right, stream, bfla_block_mask.data_ptr<int>(),
-        bfla_mask_block_n, bfla_block_mask.stride(0),
-        bfla_block_mask.stride(1), bfla_block_mask.stride(2),
-        bfla_block_mask.stride(3));
+  launcher_flash_attention_forward_paged<256, flash_v100::KV_CACHE_DTYPE_FP16>(
+      q, k_cache, v_cache, out_fp16, softmax_lse, block_table, seq_lens,
+      softmax_scale, is_causal, k_scale, v_scale, window_size_left,
+      window_size_right, stream, bfla_block_mask.data_ptr<int>(),
+      bfla_mask_block_n, bfla_block_mask.stride(0), bfla_block_mask.stride(1),
+      bfla_block_mask.stride(2), bfla_block_mask.stride(3));
 
-    return out_fp16;
+  return out_fp16;
 }
 
 at::Tensor flash_attention_decode_paged_wmma(
-    const at::Tensor& q,
-    const at::Tensor& k_cache,
-    const at::Tensor& v_cache,
-    std::optional<at::Tensor>& out_,
-    const at::Tensor& block_table,
-    const at::Tensor& seq_lens,
-    const float softmax_scale,
-    const std::string& kv_cache_dtype,
-    const float k_scale,
-    const float v_scale
-) {
-    TORCH_CHECK(q.dtype() == torch::kFloat16, "q must be fp16");
-    const int kv_dtype_code = kv_cache_dtype_code_from_string(kv_cache_dtype);
-    TORCH_CHECK(kv_dtype_code >= 0, "Unsupported kv_cache_dtype: ", kv_cache_dtype);
-    if (kv_dtype_code == flash_v100::KV_CACHE_DTYPE_FP16) {
-        TORCH_CHECK(k_cache.dtype() == torch::kFloat16, "k_cache must be fp16");
-        TORCH_CHECK(v_cache.dtype() == torch::kFloat16, "v_cache must be fp16");
-    } else {
-        TORCH_CHECK(k_cache.dtype() == torch::kUInt8,
-                    "fp8 k_cache must be stored as uint8");
-        TORCH_CHECK(v_cache.dtype() == torch::kUInt8,
-                    "fp8 v_cache must be stored as uint8");
-        TORCH_CHECK(k_scale > 0.f && v_scale > 0.f,
-                    "fp8 k/v scales must be positive");
-    }
-    TORCH_CHECK(q.is_cuda() && k_cache.is_cuda() && v_cache.is_cuda(),
-                "Tensors must be on CUDA");
-    TORCH_CHECK(block_table.is_cuda() && seq_lens.is_cuda(),
-                "block_table and seq_lens must be CUDA tensors");
-    TORCH_CHECK(q.dim() == 3, "q must have shape [B, H, D]");
-    TORCH_CHECK(block_table.dim() == 2,
-                "block_table must have shape [B, max_num_blocks]");
-    TORCH_CHECK(seq_lens.dim() == 1, "seq_lens must have shape [B]");
-    TORCH_CHECK(q.stride(-1) == 1 && k_cache.stride(-1) == 1 &&
-                    v_cache.stride(-1) == 1,
-                "Last dim must be contiguous");
-    TORCH_CHECK(k_cache.stride(1) % 8 == 0 && k_cache.stride(2) % 8 == 0 &&
-                    v_cache.stride(1) % 8 == 0 && v_cache.stride(2) % 8 == 0,
-                "Paged KV strides must be divisible by 8 half elements");
+    const at::Tensor& q, const at::Tensor& k_cache, const at::Tensor& v_cache,
+    std::optional<at::Tensor>& out_, const at::Tensor& block_table,
+    const at::Tensor& seq_lens, const float softmax_scale,
+    const std::string& kv_cache_dtype, const float k_scale,
+    const float v_scale) {
+  TORCH_CHECK(q.dtype() == torch::kFloat16, "q must be fp16");
+  const int kv_dtype_code = kv_cache_dtype_code_from_string(kv_cache_dtype);
+  TORCH_CHECK(kv_dtype_code >= 0,
+              "Unsupported kv_cache_dtype: ", kv_cache_dtype);
+  if (kv_dtype_code == flash_v100::KV_CACHE_DTYPE_FP16) {
+    TORCH_CHECK(k_cache.dtype() == torch::kFloat16, "k_cache must be fp16");
+    TORCH_CHECK(v_cache.dtype() == torch::kFloat16, "v_cache must be fp16");
+  } else {
+    TORCH_CHECK(k_cache.dtype() == torch::kUInt8,
+                "fp8 k_cache must be stored as uint8");
+    TORCH_CHECK(v_cache.dtype() == torch::kUInt8,
+                "fp8 v_cache must be stored as uint8");
+    TORCH_CHECK(k_scale > 0.f && v_scale > 0.f,
+                "fp8 k/v scales must be positive");
+  }
+  TORCH_CHECK(q.is_cuda() && k_cache.is_cuda() && v_cache.is_cuda(),
+              "Tensors must be on CUDA");
+  TORCH_CHECK(block_table.is_cuda() && seq_lens.is_cuda(),
+              "block_table and seq_lens must be CUDA tensors");
+  TORCH_CHECK(q.dim() == 3, "q must have shape [B, H, D]");
+  TORCH_CHECK(block_table.dim() == 2,
+              "block_table must have shape [B, max_num_blocks]");
+  TORCH_CHECK(seq_lens.dim() == 1, "seq_lens must have shape [B]");
+  TORCH_CHECK(
+      q.stride(-1) == 1 && k_cache.stride(-1) == 1 && v_cache.stride(-1) == 1,
+      "Last dim must be contiguous");
+  TORCH_CHECK(k_cache.stride(1) % 8 == 0 && k_cache.stride(2) % 8 == 0 &&
+                  v_cache.stride(1) % 8 == 0 && v_cache.stride(2) % 8 == 0,
+              "Paged KV strides must be divisible by 8 half elements");
 
-    const int B = q.size(0);
-    const int H = q.size(1);
-    const int D = q.size(2);
-    const int num_kv_heads = k_cache.size(2);
+  const int B = q.size(0);
+  const int H = q.size(1);
+  const int D = q.size(2);
+  const int num_kv_heads = k_cache.size(2);
 
-    TORCH_CHECK(B <= block_table.size(0), "block_table batch size must cover q");
-    TORCH_CHECK(B <= seq_lens.size(0), "seq_lens batch size must cover q");
-    TORCH_CHECK(D <= 256 && D % 8 == 0 && D % 2 == 0,
-                "D must be even, <=256, multiple of 8");
-    TORCH_CHECK(H % num_kv_heads == 0,
-                "num_heads must be divisible by num_kv_heads");
+  TORCH_CHECK(B <= block_table.size(0), "block_table batch size must cover q");
+  TORCH_CHECK(B <= seq_lens.size(0), "seq_lens batch size must cover q");
+  TORCH_CHECK(D <= 256 && D % 8 == 0 && D % 2 == 0,
+              "D must be even, <=256, multiple of 8");
+  TORCH_CHECK(H % num_kv_heads == 0,
+              "num_heads must be divisible by num_kv_heads");
 
-    at::Tensor out_fp16 = out_.has_value() ? out_.value() : torch::zeros_like(q);
-    TORCH_CHECK(out_fp16.is_cuda(), "out must be on CUDA");
-    TORCH_CHECK(out_fp16.dtype() == torch::kFloat16, "out must be fp16");
-    TORCH_CHECK(out_fp16.sizes() == q.sizes(), "out must have same shape as q");
-    TORCH_CHECK(out_fp16.stride(-1) == 1, "out last dim must be contiguous");
+  at::Tensor out_fp16 = out_.has_value() ? out_.value() : torch::zeros_like(q);
+  TORCH_CHECK(out_fp16.is_cuda(), "out must be on CUDA");
+  TORCH_CHECK(out_fp16.dtype() == torch::kFloat16, "out must be fp16");
+  TORCH_CHECK(out_fp16.sizes() == q.sizes(), "out must have same shape as q");
+  TORCH_CHECK(out_fp16.stride(-1) == 1, "out last dim must be contiguous");
 
-    at::Tensor q_m1 = q.unsqueeze(2);
-    at::Tensor out_m1 = out_fp16.unsqueeze(2);
-    auto softmax_lse = torch::zeros({B, H, 1},
-                                    torch::dtype(torch::kFloat32).device(q.device()));
+  at::Tensor q_m1 = q.unsqueeze(2);
+  at::Tensor out_m1 = out_fp16.unsqueeze(2);
+  auto softmax_lse =
+      torch::zeros({B, H, 1}, torch::dtype(torch::kFloat32).device(q.device()));
 
-    auto stream = at::cuda::getCurrentCUDAStream().stream();
-    auto props = at::cuda::getCurrentDeviceProperties();
-    bool sm70 = props->major == 7 && props->minor == 0;
-    TORCH_CHECK(sm70, "Kernel supports only Volta GPUs.");
+  auto stream = at::cuda::getCurrentCUDAStream().stream();
+  auto props = at::cuda::getCurrentDeviceProperties();
+  bool sm70 = props->major == 7 && props->minor == 0;
+  TORCH_CHECK(sm70, "Kernel supports only Volta GPUs.");
 
-    #define LAUNCH_DECODE_WMMA_TYPED(HDIM, KV_DTYPE_CODE)                       \
-        launcher_flash_attention_forward_paged<HDIM, KV_DTYPE_CODE>(            \
-            q_m1, k_cache, v_cache, out_m1, softmax_lse, block_table, seq_lens, \
-            softmax_scale, true, k_scale, v_scale, -1, -1, stream)
+#define LAUNCH_DECODE_WMMA_TYPED(HDIM, KV_DTYPE_CODE)                     \
+  launcher_flash_attention_forward_paged<HDIM, KV_DTYPE_CODE>(            \
+      q_m1, k_cache, v_cache, out_m1, softmax_lse, block_table, seq_lens, \
+      softmax_scale, true, k_scale, v_scale, -1, -1, stream)
 
-    #define LAUNCH_DECODE_WMMA_BY_KV(HDIM)                                      \
-        do {                                                                    \
-            switch (kv_dtype_code) {                                            \
-                case flash_v100::KV_CACHE_DTYPE_FP16:                           \
-                    LAUNCH_DECODE_WMMA_TYPED(HDIM, flash_v100::KV_CACHE_DTYPE_FP16); \
-                    break;                                                      \
-                case flash_v100::KV_CACHE_DTYPE_FP8_E4M3:                       \
-                    LAUNCH_DECODE_WMMA_TYPED(HDIM, flash_v100::KV_CACHE_DTYPE_FP8_E4M3); \
-                    break;                                                      \
-                case flash_v100::KV_CACHE_DTYPE_FP8_E5M2:                       \
-                    LAUNCH_DECODE_WMMA_TYPED(HDIM, flash_v100::KV_CACHE_DTYPE_FP8_E5M2); \
-                    break;                                                      \
-                default:                                                        \
-                    TORCH_CHECK(false, "Unsupported kv_cache_dtype: ", kv_cache_dtype); \
-            }                                                                   \
-        } while (0)
+#define LAUNCH_DECODE_WMMA_BY_KV(HDIM)                                       \
+  do {                                                                       \
+    switch (kv_dtype_code) {                                                 \
+      case flash_v100::KV_CACHE_DTYPE_FP16:                                  \
+        LAUNCH_DECODE_WMMA_TYPED(HDIM, flash_v100::KV_CACHE_DTYPE_FP16);     \
+        break;                                                               \
+      case flash_v100::KV_CACHE_DTYPE_FP8_E4M3:                              \
+        LAUNCH_DECODE_WMMA_TYPED(HDIM, flash_v100::KV_CACHE_DTYPE_FP8_E4M3); \
+        break;                                                               \
+      case flash_v100::KV_CACHE_DTYPE_FP8_E5M2:                              \
+        LAUNCH_DECODE_WMMA_TYPED(HDIM, flash_v100::KV_CACHE_DTYPE_FP8_E5M2); \
+        break;                                                               \
+      default:                                                               \
+        TORCH_CHECK(false, "Unsupported kv_cache_dtype: ", kv_cache_dtype);  \
+    }                                                                        \
+  } while (0)
 
-    switch (D) {
-        case 16:
-            LAUNCH_DECODE_WMMA_BY_KV(16);
-            break;
-        case 32:
-            LAUNCH_DECODE_WMMA_BY_KV(32);
-            break;
-        case 64:
-            LAUNCH_DECODE_WMMA_BY_KV(64);
-            break;
-        case 128:
-            LAUNCH_DECODE_WMMA_BY_KV(128);
-            break;
-        case 256:
-            LAUNCH_DECODE_WMMA_BY_KV(256);
-            break;
-        default:
-            TORCH_CHECK(false, "Unsupported D: ", D);
-    }
+  switch (D) {
+    case 16:
+      LAUNCH_DECODE_WMMA_BY_KV(16);
+      break;
+    case 32:
+      LAUNCH_DECODE_WMMA_BY_KV(32);
+      break;
+    case 64:
+      LAUNCH_DECODE_WMMA_BY_KV(64);
+      break;
+    case 128:
+      LAUNCH_DECODE_WMMA_BY_KV(128);
+      break;
+    case 256:
+      LAUNCH_DECODE_WMMA_BY_KV(256);
+      break;
+    default:
+      TORCH_CHECK(false, "Unsupported D: ", D);
+  }
 
-    #undef LAUNCH_DECODE_WMMA_BY_KV
-    #undef LAUNCH_DECODE_WMMA_TYPED
+#undef LAUNCH_DECODE_WMMA_BY_KV
+#undef LAUNCH_DECODE_WMMA_TYPED
 
-    C10_CUDA_KERNEL_LAUNCH_CHECK();
-    return out_fp16;
+  C10_CUDA_KERNEL_LAUNCH_CHECK();
+  return out_fp16;
 }

--- a/flash-attention-v100/kernel/fused_mha_forward_paged_full.cu
+++ b/flash-attention-v100/kernel/fused_mha_forward_paged_full.cu
@@ -16,589 +16,621 @@ using namespace nvcuda::wmma;
 #define WMMA_N 16
 #define WMMA_K 16
 
-#define MAX_THREADS_PER_WARP    32
-#define MAX_THREADS_PER_SM      2048
-#define MAX_THREAD_BLOCK_SIZE   1024
+#define MAX_THREADS_PER_WARP 32
+#define MAX_THREADS_PER_SM 2048
+#define MAX_THREAD_BLOCK_SIZE 1024
 #define MAX_THREAD_BLOCK_PER_SM 32
-#define MAX_WARPS_PER_SM        64
-#define MAX_SM_PER_GPU          80
-#define MAX_SMEM_PER_SM         98304
+#define MAX_WARPS_PER_SM 64
+#define MAX_SM_PER_GPU 80
+#define MAX_SMEM_PER_SM 98304
 
-#define WARP_ALLOC_GROUP        4
+#define WARP_ALLOC_GROUP 4
 
-#define MAX_REG_PER_UNIT        256
-#define MAX_REG_PER_THREAD      255
-#define MAX_REG_PER_BLOCK       65536
-#define MAX_REG_BUFFER          65536
+#define MAX_REG_PER_UNIT 256
+#define MAX_REG_PER_THREAD 255
+#define MAX_REG_PER_BLOCK 65536
+#define MAX_REG_BUFFER 65536
 
-#define BLOCK_M_16  16
-#define BLOCK_N_16  512
-#define WARPS_16    16
+#define BLOCK_M_16 16
+#define BLOCK_N_16 512
+#define WARPS_16 16
 
-#define BLOCK_M_32  32
-#define BLOCK_N_32  256
-#define WARPS_32    16
+#define BLOCK_M_32 32
+#define BLOCK_N_32 256
+#define WARPS_32 16
 
-#define BLOCK_M_64  64
-#define BLOCK_N_64  128
-#define WARPS_64    16
+#define BLOCK_M_64 64
+#define BLOCK_N_64 128
+#define WARPS_64 16
 
 #define BLOCK_M_128 32
 #define BLOCK_N_128 176
-#define WARPS_128   16
+#define WARPS_128 16
 
 #define BLOCK_M_256 32
 #define BLOCK_N_256 64
-#define WARPS_256   16
+#define WARPS_256 16
 
-template<int D>
+template <int D>
 struct KernelConfig {
-    static constexpr int BLOCK_M = (D == 16) ? BLOCK_M_16 : (D == 32) ? BLOCK_M_32 : (D == 64) ? BLOCK_M_64 : (D == 128) ? BLOCK_M_128 : BLOCK_M_256;
-    static constexpr int BLOCK_N = (D == 16) ? BLOCK_N_16 : (D == 32) ? BLOCK_N_32 : (D == 64) ? BLOCK_N_64 : (D == 128) ? BLOCK_N_128 : BLOCK_N_256;
-    static constexpr int WARPS_PER_BLOCK = (D == 16) ? WARPS_16 : (D == 32) ? WARPS_32 : (D == 64) ? WARPS_64 : (D == 128) ? WARPS_128 : WARPS_256;
+  static constexpr int BLOCK_M = (D == 16)    ? BLOCK_M_16
+                                 : (D == 32)  ? BLOCK_M_32
+                                 : (D == 64)  ? BLOCK_M_64
+                                 : (D == 128) ? BLOCK_M_128
+                                              : BLOCK_M_256;
+  static constexpr int BLOCK_N = (D == 16)    ? BLOCK_N_16
+                                 : (D == 32)  ? BLOCK_N_32
+                                 : (D == 64)  ? BLOCK_N_64
+                                 : (D == 128) ? BLOCK_N_128
+                                              : BLOCK_N_256;
+  static constexpr int WARPS_PER_BLOCK = (D == 16)    ? WARPS_16
+                                         : (D == 32)  ? WARPS_32
+                                         : (D == 64)  ? WARPS_64
+                                         : (D == 128) ? WARPS_128
+                                                      : WARPS_256;
 
-    static constexpr int THREADS_PER_BLOCK = WARPS_PER_BLOCK * MAX_THREADS_PER_WARP;
-    static constexpr int THREADS_PER_ROW   = THREADS_PER_BLOCK / BLOCK_M;
-    static constexpr int PAD               = (8 - (D % 32) + 32) % 32;
-    static constexpr int Q_STRIDE          = D + PAD;
-    static constexpr int KV_STRIDE         = D + PAD;
-    static constexpr int S_STRIDE          = BLOCK_N + PAD;
-    static constexpr int O_STRIDE          = D + PAD;
-    static constexpr int PER_UINT4         = 8;
+  static constexpr int THREADS_PER_BLOCK =
+      WARPS_PER_BLOCK * MAX_THREADS_PER_WARP;
+  static constexpr int THREADS_PER_ROW = THREADS_PER_BLOCK / BLOCK_M;
+  static constexpr int PAD = (8 - (D % 32) + 32) % 32;
+  static constexpr int Q_STRIDE = D + PAD;
+  static constexpr int KV_STRIDE = D + PAD;
+  static constexpr int S_STRIDE = BLOCK_N + PAD;
+  static constexpr int O_STRIDE = D + PAD;
+  static constexpr int PER_UINT4 = 8;
 
-    struct alignas(128) SmemLayout {
-        alignas(16) __half q      [BLOCK_M * Q_STRIDE];
+  struct alignas(128) SmemLayout {
+    alignas(16) __half q[BLOCK_M * Q_STRIDE];
     union {
-        alignas(16) __half k      [BLOCK_N * KV_STRIDE];
-        alignas(16) __half v      [BLOCK_N * KV_STRIDE];
+      alignas(16) __half k[BLOCK_N * KV_STRIDE];
+      alignas(16) __half v[BLOCK_N * KV_STRIDE];
     } reuse_kv;
     union {
-        alignas(16) float  s      [BLOCK_M * S_STRIDE];
-        alignas(16) __half p      [BLOCK_M * S_STRIDE];
+      alignas(16) float s[BLOCK_M * S_STRIDE];
+      alignas(16) __half p[BLOCK_M * S_STRIDE];
     } reuse_sp;
-        alignas(16) float  o      [BLOCK_M * O_STRIDE];
-        alignas(16) float  row_max[BLOCK_M];
-        alignas(16) float  row_sum[BLOCK_M];
-    };
+    alignas(16) float o[BLOCK_M * O_STRIDE];
+    alignas(16) float row_max[BLOCK_M];
+    alignas(16) float row_sum[BLOCK_M];
+  };
 
-    static constexpr size_t TOTAL_SMEM = ((sizeof(SmemLayout) + 127) & ~size_t(127));
+  static constexpr size_t TOTAL_SMEM =
+      ((sizeof(SmemLayout) + 127) & ~size_t(127));
 };
 
-template<typename Config>
+template <typename Config>
 __device__ __forceinline__ void init_smem(char* smem_raw) {
-    constexpr int N_U4 = Config::TOTAL_SMEM / 16;
-    constexpr int THREADS_PER_BLOCK = Config::THREADS_PER_BLOCK;
-    const int tid = threadIdx.x;
+  constexpr int N_U4 = Config::TOTAL_SMEM / 16;
+  constexpr int THREADS_PER_BLOCK = Config::THREADS_PER_BLOCK;
+  const int tid = threadIdx.x;
 
-    uint32_t addr = static_cast<uint32_t>(__cvta_generic_to_shared(smem_raw));
-    #pragma unroll 1
-    for (int i = tid; i < N_U4; i += THREADS_PER_BLOCK) {
-        asm volatile("st.shared.v4.u32 [%0], {%1,%1,%1,%1};"
-                     :: "r"(addr + (i << 4)), "r"(0) : "memory");
-    }
-    __syncthreads();
+  uint32_t addr = static_cast<uint32_t>(__cvta_generic_to_shared(smem_raw));
+#pragma unroll 1
+  for (int i = tid; i < N_U4; i += THREADS_PER_BLOCK) {
+    asm volatile("st.shared.v4.u32 [%0], {%1,%1,%1,%1};" ::"r"(addr + (i << 4)),
+                 "r"(0)
+                 : "memory");
+  }
+  __syncthreads();
 }
 
-template<int D, bool IS_CAUSAL>
+template <int D, bool IS_CAUSAL>
 __global__ void __launch_bounds__(KernelConfig<D>::THREADS_PER_BLOCK, 2)
-flash_attention_forward_kernel(
-    const __half* __restrict__ Q,
-    const __half* __restrict__ K,
-    const __half* __restrict__ V,
-          __half* __restrict__ Out,
-           float* __restrict__ softmax_lse,
-    const int B,
-    const int H,
-    const int M,
-    const int N,
-    const float softmax_scale
-) {
-    using Config = KernelConfig<D>;
-    constexpr int BLOCK_M           = Config::BLOCK_M;
-    constexpr int BLOCK_N           = Config::BLOCK_N;
-    constexpr int THREADS_PER_BLOCK = Config::THREADS_PER_BLOCK;
-    constexpr int THREADS_PER_ROW   = Config::THREADS_PER_ROW;
-    constexpr int WARPS_PER_BLOCK   = Config::WARPS_PER_BLOCK;
-    constexpr int Q_STRIDE          = Config::Q_STRIDE;
-    constexpr int KV_STRIDE         = Config::KV_STRIDE;
-    constexpr int S_STRIDE          = Config::S_STRIDE;
-    constexpr int O_STRIDE          = Config::O_STRIDE;
-    constexpr int PER_UINT4         = Config::PER_UINT4;
-    const float NEG_INF = -1e30f;
+    flash_attention_forward_kernel(const __half* __restrict__ Q,
+                                   const __half* __restrict__ K,
+                                   const __half* __restrict__ V,
+                                   __half* __restrict__ Out,
+                                   float* __restrict__ softmax_lse, const int B,
+                                   const int H, const int M, const int N,
+                                   const float softmax_scale) {
+  using Config = KernelConfig<D>;
+  constexpr int BLOCK_M = Config::BLOCK_M;
+  constexpr int BLOCK_N = Config::BLOCK_N;
+  constexpr int THREADS_PER_BLOCK = Config::THREADS_PER_BLOCK;
+  constexpr int THREADS_PER_ROW = Config::THREADS_PER_ROW;
+  constexpr int WARPS_PER_BLOCK = Config::WARPS_PER_BLOCK;
+  constexpr int Q_STRIDE = Config::Q_STRIDE;
+  constexpr int KV_STRIDE = Config::KV_STRIDE;
+  constexpr int S_STRIDE = Config::S_STRIDE;
+  constexpr int O_STRIDE = Config::O_STRIDE;
+  constexpr int PER_UINT4 = Config::PER_UINT4;
+  const float NEG_INF = -1e30f;
 
-    const int batch_head_id = blockIdx.z;
-    if (batch_head_id >= B * H) return;
+  const int batch_head_id = blockIdx.z;
+  if (batch_head_id >= B * H) return;
 
-    const int block_m = blockIdx.x;
-    const int start_row = block_m * BLOCK_M;
-    if (start_row >= M) return;
+  const int block_m = blockIdx.x;
+  const int start_row = block_m * BLOCK_M;
+  if (start_row >= M) return;
 
-    int num_n_tiles = (N + BLOCK_N - 1) / BLOCK_N;
-    const int valid_q_rows = min(BLOCK_M, M - start_row);
+  int num_n_tiles = (N + BLOCK_N - 1) / BLOCK_N;
+  const int valid_q_rows = min(BLOCK_M, M - start_row);
+
+  if constexpr (IS_CAUSAL) {
+    const int max_key_pos = start_row + valid_q_rows - 1;
+    if (max_key_pos < 0) {
+      num_n_tiles = 0;
+    } else {
+      num_n_tiles = min(num_n_tiles, (max_key_pos + BLOCK_N + 0) / BLOCK_N);
+    }
+  }
+
+  const int tid = threadIdx.x;
+  const int warp_id = tid / MAX_THREADS_PER_WARP;
+  const int lane_id = tid % MAX_THREADS_PER_WARP;
+
+  const __half* q_ptr = Q + (size_t)batch_head_id * M * D + start_row * D;
+  const __half* k_ptr = K + (size_t)batch_head_id * N * D;
+  const __half* v_ptr = V + (size_t)batch_head_id * N * D;
+  __half* out_ptr = Out + (size_t)batch_head_id * M * D + start_row * D;
+  float* softmax_lse_ptr = softmax_lse + (size_t)batch_head_id * M + start_row;
+
+  extern __shared__ char smem_raw[];
+  init_smem<Config>(smem_raw);
+  auto& smem = *reinterpret_cast<typename Config::SmemLayout*>(smem_raw);
+
+  __half* sQ = smem.q;
+  __half* sK = smem.reuse_kv.k;
+  __half* sV = smem.reuse_kv.v;
+  float* sS = smem.reuse_sp.s;
+  __half* sP = smem.reuse_sp.p;
+  float* sO = smem.o;
+  float* sRowMax = smem.row_max;
+  float* sRowSum = smem.row_sum;
+
+  const int d_stride_uint4 = (D + PER_UINT4 - 1) / PER_UINT4;
+  const int q_stride_uint4 = (Q_STRIDE + PER_UINT4 - 1) / PER_UINT4;
+  const int kv_stride_uint4 = (KV_STRIDE + PER_UINT4 - 1) / PER_UINT4;
+
+  if (tid < BLOCK_M) {
+    sRowMax[tid] = NEG_INF;
+  }
+
+  const uint4* q_vec = reinterpret_cast<const uint4*>(q_ptr);
+  uint4* sQ_vec = reinterpret_cast<uint4*>(sQ);
+
+#pragma unroll 4
+  for (int idx = tid; idx < (valid_q_rows * d_stride_uint4);
+       idx += THREADS_PER_BLOCK) {
+    const int row = idx / d_stride_uint4;
+    const int vec_col = idx % d_stride_uint4;
+    uint4 q_val = make_uint4(0, 0, 0, 0);
+    if (row < valid_q_rows && vec_col < d_stride_uint4) {
+      q_val = __ldg(&q_vec[row * d_stride_uint4 + vec_col]);
+    }
+    sQ_vec[row * q_stride_uint4 + vec_col] = q_val;
+  }
+  __syncthreads();
+
+  for (int block_n = 0; block_n < num_n_tiles; ++block_n) {
+    const int start_col = block_n * BLOCK_N;
+    if (start_col >= N) break;
+    const int valid_k_rows = min(BLOCK_N, N - start_col);
 
     if constexpr (IS_CAUSAL) {
-        const int max_key_pos = start_row + valid_q_rows - 1;
-        if (max_key_pos < 0) {
-            num_n_tiles = 0;
-        } else {
-            num_n_tiles = min(num_n_tiles, (max_key_pos + BLOCK_N + 0) / BLOCK_N);
-        }
+      if (start_col >= start_row + valid_q_rows) {
+        continue;
+      }
     }
 
-    const int tid = threadIdx.x;
-    const int warp_id = tid / MAX_THREADS_PER_WARP;
-    const int lane_id = tid % MAX_THREADS_PER_WARP;
+    const uint4* k_vec = reinterpret_cast<const uint4*>(k_ptr + start_col * D);
+    uint4* sK_vec = reinterpret_cast<uint4*>(sK);
 
-    const __half* q_ptr    = Q +           (size_t)batch_head_id * M * D + start_row * D;
-    const __half* k_ptr    = K +           (size_t)batch_head_id * N * D;
-    const __half* v_ptr    = V +           (size_t)batch_head_id * N * D;
-          __half* out_ptr  = Out +         (size_t)batch_head_id * M * D + start_row * D;
-    float* softmax_lse_ptr = softmax_lse + (size_t)batch_head_id * M + start_row;
+#pragma unroll 2
+    for (int idx = tid; idx < (valid_k_rows * d_stride_uint4);
+         idx += THREADS_PER_BLOCK) {
+      const int row = idx / d_stride_uint4;
+      const int vec_col = idx % d_stride_uint4;
 
-    extern __shared__ char smem_raw[];
-    init_smem<Config>(smem_raw);
-    auto& smem = *reinterpret_cast<typename Config::SmemLayout*>(smem_raw);
-
-    __half* sQ      = smem.q;
-    __half* sK      = smem.reuse_kv.k;
-    __half* sV      = smem.reuse_kv.v;
-    float*  sS      = smem.reuse_sp.s;
-    __half* sP      = smem.reuse_sp.p;
-    float*  sO      = smem.o;
-    float*  sRowMax = smem.row_max;
-    float*  sRowSum = smem.row_sum;
-
-    const int  d_stride_uint4 = (D + PER_UINT4 - 1) / PER_UINT4;
-    const int  q_stride_uint4 = (Q_STRIDE  + PER_UINT4 - 1) / PER_UINT4;
-    const int kv_stride_uint4 = (KV_STRIDE + PER_UINT4 - 1) / PER_UINT4;
-
-    if (tid < BLOCK_M) {
-        sRowMax[tid] = NEG_INF;
-    }
-
-    const uint4*      q_vec = reinterpret_cast<const uint4*>(q_ptr);
-    uint4*           sQ_vec = reinterpret_cast<uint4*>(sQ);
-
-    #pragma unroll 4
-    for (int idx = tid; idx < (valid_q_rows * d_stride_uint4); idx += THREADS_PER_BLOCK) {
-        const int row = idx / d_stride_uint4;
-        const int vec_col = idx % d_stride_uint4;
-        uint4 q_val = make_uint4(0, 0, 0, 0);
-        if (row < valid_q_rows && vec_col < d_stride_uint4) {
-            q_val = __ldg(&q_vec[row * d_stride_uint4 + vec_col]);
-        }
-        sQ_vec[row * q_stride_uint4 + vec_col] = q_val;
+      uint4 k_val = make_uint4(0, 0, 0, 0);
+      if (row < valid_k_rows && vec_col < d_stride_uint4) {
+        k_val = __ldg(&k_vec[row * d_stride_uint4 + vec_col]);
+      }
+      sK_vec[row * kv_stride_uint4 + vec_col] = k_val;
     }
     __syncthreads();
 
-    for (int block_n = 0; block_n < num_n_tiles; ++block_n) {
-        const int start_col = block_n * BLOCK_N;
-        if (start_col >= N) break;
-        const int valid_k_rows = min(BLOCK_N, N - start_col);
+    const int num_tiles_m_qk = (BLOCK_M + WMMA_M - 1) / WMMA_M;
+    const int num_tiles_n_qk = (BLOCK_N + WMMA_N - 1) / WMMA_N;
+    const int num_tiles_k_qk = (D + WMMA_K - 1) / WMMA_K;
+    const int total_tiles_qk = num_tiles_m_qk * num_tiles_n_qk;
+    const int tiles_per_warp_qk =
+        (total_tiles_qk + WARPS_PER_BLOCK - 1) / WARPS_PER_BLOCK;
+    const unsigned row_causal = (lane_id & 0b1) + ((lane_id >> 2) & 0b1) * 8 +
+                                ((lane_id >> 4) & 0b1) * 4;
+    const unsigned col_causal =
+        ((lane_id >> 1) & 0b1) * 2 + ((lane_id >> 3) & 0b1) * 8;
 
-        if constexpr (IS_CAUSAL) {
-            if (start_col >= start_row + valid_q_rows) { continue; }
+    for (int tile_idx = 0; tile_idx < tiles_per_warp_qk; ++tile_idx) {
+      const int global_tile_idx = warp_id * tiles_per_warp_qk + tile_idx;
+      if (global_tile_idx >= total_tiles_qk) break;
+
+      const int tile_m_idx = global_tile_idx / num_tiles_n_qk;
+      const int tile_n_idx = global_tile_idx % num_tiles_n_qk;
+
+      const int tile_m = tile_m_idx * WMMA_M;
+      const int tile_n = tile_n_idx * WMMA_N;
+
+      if (tile_m >= valid_q_rows || tile_n >= valid_k_rows) continue;
+
+      fragment<matrix_a, WMMA_M, WMMA_N, WMMA_K, half, row_major> a_frag;
+      fragment<matrix_b, WMMA_M, WMMA_N, WMMA_K, half, col_major> b_frag;
+      fragment<accumulator, WMMA_M, WMMA_N, WMMA_K, float> acc_frag;
+      fill_fragment(acc_frag, 0.0f);
+
+#pragma unroll
+      for (int k_tile = 0; k_tile < num_tiles_k_qk; ++k_tile) {
+        const int k_offset = k_tile * WMMA_K;
+        if (k_offset >= D) break;
+
+        load_matrix_sync(a_frag, sQ + tile_m * Q_STRIDE + k_offset, Q_STRIDE);
+        load_matrix_sync(b_frag, sK + tile_n * KV_STRIDE + k_offset, KV_STRIDE);
+        mma_sync(acc_frag, a_frag, b_frag, acc_frag);
+      }
+
+      if constexpr (IS_CAUSAL) {
+#pragma unroll
+        for (int i = 0; i < acc_frag.num_elements; ++i) {
+          const unsigned col = col_causal + (i & 0b1) + ((i >> 2) & 0b1) * 4;
+          const unsigned row = row_causal + ((i >> 1) & 0b1) * 2;
+
+          const int global_m = start_row + tile_m + row;
+          const int global_n = start_col + tile_n + col;
+
+          const bool is_valid = (global_m < start_row + valid_q_rows) &&
+                                (global_n < start_col + valid_k_rows);
+
+          acc_frag.x[i] =
+              is_valid ? ((global_n > global_m) ? NEG_INF
+                                                : acc_frag.x[i] * softmax_scale)
+                       : NEG_INF;
         }
-
-        const uint4* k_vec     = reinterpret_cast<const uint4*>(k_ptr + start_col * D);
-        uint4*       sK_vec    = reinterpret_cast<uint4*>(sK);
-
-        #pragma unroll 2
-        for (int idx = tid; idx < (valid_k_rows * d_stride_uint4); idx += THREADS_PER_BLOCK) {
-            const int row = idx / d_stride_uint4;
-            const int vec_col = idx % d_stride_uint4;
-
-            uint4 k_val = make_uint4(0, 0, 0, 0);
-            if (row < valid_k_rows && vec_col < d_stride_uint4) {
-                k_val = __ldg(&k_vec[row * d_stride_uint4 + vec_col]);
-            }
-            sK_vec[row * kv_stride_uint4 + vec_col] = k_val;
+      } else {
+#pragma unroll
+        for (int i = 0; i < acc_frag.num_elements; ++i) {
+          acc_frag.x[i] *= softmax_scale;
         }
-        __syncthreads();
-
-        const int num_tiles_m_qk    = (BLOCK_M + WMMA_M - 1) / WMMA_M;
-        const int num_tiles_n_qk    = (BLOCK_N + WMMA_N - 1) / WMMA_N;
-        const int num_tiles_k_qk    = (D + WMMA_K - 1) / WMMA_K;
-        const int total_tiles_qk    = num_tiles_m_qk * num_tiles_n_qk;
-        const int tiles_per_warp_qk = (total_tiles_qk + WARPS_PER_BLOCK - 1) / WARPS_PER_BLOCK;
-        const unsigned row_causal   = (lane_id & 0b1) + ((lane_id >> 2) & 0b1) * 8 + ((lane_id >> 4) & 0b1) * 4;
-        const unsigned col_causal   = ((lane_id >> 1) & 0b1) * 2 + ((lane_id >> 3) & 0b1) * 8;
-
-        for (int tile_idx = 0; tile_idx < tiles_per_warp_qk; ++tile_idx) {
-            const int global_tile_idx = warp_id * tiles_per_warp_qk + tile_idx;
-            if (global_tile_idx >= total_tiles_qk) break;
-
-            const int tile_m_idx = global_tile_idx / num_tiles_n_qk;
-            const int tile_n_idx = global_tile_idx % num_tiles_n_qk;
-
-            const int tile_m = tile_m_idx * WMMA_M;
-            const int tile_n = tile_n_idx * WMMA_N;
-
-            if (tile_m >= valid_q_rows || tile_n >= valid_k_rows) continue;
-
-            fragment<matrix_a, WMMA_M, WMMA_N, WMMA_K, half, row_major> a_frag;
-            fragment<matrix_b, WMMA_M, WMMA_N, WMMA_K, half, col_major> b_frag;
-            fragment<accumulator, WMMA_M, WMMA_N, WMMA_K, float> acc_frag;
-            fill_fragment(acc_frag, 0.0f);
-
-            #pragma unroll
-            for (int k_tile = 0; k_tile < num_tiles_k_qk; ++k_tile) {
-                const int k_offset = k_tile * WMMA_K;
-                if (k_offset >= D) break;
-
-                load_matrix_sync(a_frag, sQ + tile_m * Q_STRIDE + k_offset, Q_STRIDE);
-                load_matrix_sync(b_frag, sK + tile_n * KV_STRIDE + k_offset, KV_STRIDE);
-                mma_sync(acc_frag, a_frag, b_frag, acc_frag);
-            }
-
-            if constexpr (IS_CAUSAL) {
-                #pragma unroll
-                for (int i = 0; i < acc_frag.num_elements; ++i) {
-                    const unsigned col = col_causal + (i & 0b1) + ((i >> 2) & 0b1) * 4;
-                    const unsigned row = row_causal + ((i >> 1) & 0b1) * 2;
-
-                    const int global_m = start_row + tile_m + row;
-                    const int global_n = start_col + tile_n + col;
-
-                    const bool is_valid = (global_m < start_row + valid_q_rows) &&
-                                          (global_n < start_col + valid_k_rows);
-
-                    acc_frag.x[i] = is_valid
-                        ? ((global_n > global_m) ? NEG_INF : acc_frag.x[i] * softmax_scale)
-                        : NEG_INF;
-                }
-            } else {
-                #pragma unroll
-                for (int i = 0; i < acc_frag.num_elements; ++i) {
-                    acc_frag.x[i] *= softmax_scale;
-                }
-            }
-            store_matrix_sync(sS + tile_m * S_STRIDE + tile_n, acc_frag, S_STRIDE, mem_row_major);
-        }
-        __syncthreads();
-
-        if (tid < valid_q_rows * THREADS_PER_ROW) {
-            const int row = tid / THREADS_PER_ROW;
-            const int thread_in_row = tid % THREADS_PER_ROW;
-            const unsigned mask = (valid_q_rows == BLOCK_M) ? 0xFFFFFFFFU : __activemask();
-            const int row_leader = __ffs(mask) - 1;
-
-            float*  sS_row_f = sS + row * S_STRIDE;
-            __half* sP_row_h = sP + row * S_STRIDE;
-
-            const int vec_cols = valid_k_rows >> 2;
-            const int vecs_per_thread = (vec_cols + THREADS_PER_ROW - 1) / THREADS_PER_ROW;
-            const int tail_start = vec_cols << 2;
-
-            float thread_max = NEG_INF;
-            float4* sS_vec4 = reinterpret_cast<float4*>(sS_row_f);
-
-            #pragma unroll 4
-            for (int j = 0; j < vecs_per_thread; ++j) {
-                int vc = thread_in_row + j * THREADS_PER_ROW;
-                if (vc < vec_cols) {
-                    float4 v4 = sS_vec4[vc];
-                    thread_max = fmaxf(thread_max, fmaxf(fmaxf(v4.x, v4.y), fmaxf(v4.z, v4.w)));
-                }
-            }
-
-            #pragma unroll 4
-            for (int c = tail_start + thread_in_row; c < valid_k_rows; c += THREADS_PER_ROW) {
-                thread_max = fmaxf(thread_max, sS_row_f[c]);
-            }
-
-            #pragma unroll
-            for (int o = THREADS_PER_ROW / 2; o > 0; o >>= 1)
-                thread_max = fmaxf(thread_max, __shfl_down_sync(mask, thread_max, o, THREADS_PER_ROW));
-
-            const float row_max  = __shfl_sync(mask, thread_max, row_leader, THREADS_PER_ROW);
-            const float old_max  = sRowMax[row];
-            const float new_max  = fmaxf(old_max, row_max);
-            const float exp_diff = __expf(old_max - new_max);
-
-            float thread_sum = 0.0f;
-            __half2 half_buffer[20];
-            int vc_base = thread_in_row;
-            int h2_idx = 0;
-            int tail_col = -1;
-            __half tail_value = __float2half(0.f);
-
-            #pragma unroll 4
-            for (int j = 0; j < vecs_per_thread; ++j, vc_base += THREADS_PER_ROW) {
-                if (vc_base < vec_cols) {
-                    float4 v4 = sS_vec4[vc_base];
-
-                    float e0 = __expf(fmaxf(v4.x - new_max, -80.0f));
-                    float e1 = __expf(fmaxf(v4.y - new_max, -80.0f));
-                    float e2 = __expf(fmaxf(v4.z - new_max, -80.0f));
-                    float e3 = __expf(fmaxf(v4.w - new_max, -80.0f));
-
-                    thread_sum += (e0 + e1) + (e2 + e3);
-
-                    half_buffer[h2_idx++] = __float22half2_rn(make_float2(e0, e1));
-                    half_buffer[h2_idx++] = __float22half2_rn(make_float2(e2, e3));
-                }
-            }
-
-            #pragma unroll 4
-            for (int c = tail_start + thread_in_row; c < valid_k_rows; c += THREADS_PER_ROW) {
-                float v = sS_row_f[c];
-                float e = __expf(fmaxf(v - new_max, -80.0f));
-                thread_sum += e;
-                tail_col = c;
-                tail_value = __float2half_rn(e);
-            }
-
-            #pragma unroll
-            for (int o = THREADS_PER_ROW / 2; o > 0; o >>= 1)
-                thread_sum += __shfl_down_sync(mask, thread_sum, o, THREADS_PER_ROW);
-
-            float row_sum = __shfl_sync(mask, thread_sum, row_leader, THREADS_PER_ROW);
-
-            if (thread_in_row == 0) {
-                sRowSum[row] = exp_diff * sRowSum[row] + row_sum;
-                sRowMax[row] = new_max;
-            }
-
-            h2_idx = 0;
-            vc_base = thread_in_row;
-            __half2* sP_half2 = reinterpret_cast<__half2*>(sP_row_h);
-
-            #pragma unroll 4
-            for (int j = 0; j < vecs_per_thread; ++j, vc_base += THREADS_PER_ROW) {
-                if (vc_base < vec_cols) {
-                    int base_offset = vc_base * 2;
-
-                    sP_half2[base_offset]     = half_buffer[h2_idx++];
-                    sP_half2[base_offset + 1] = half_buffer[h2_idx++];
-                }
-            }
-
-            if (tail_col >= 0) {
-                sP_row_h[tail_col] = tail_value;
-            }
-
-            #pragma unroll 4
-            for (int c = tail_start + thread_in_row; c < BLOCK_N; c += THREADS_PER_ROW) {
-                if (c >= valid_k_rows) {
-                    sP_row_h[c] = __float2half(0.f);
-                }
-            }
-
-            if (block_n > 0) {
-                float*  sO_row = sO + row * O_STRIDE;
-                float4* sO_vec = reinterpret_cast<float4*>(sO_row);
-                const int o_vec_count = (O_STRIDE + 3) >> 2;
-                float scale = exp_diff;
-
-                #pragma unroll 4
-                for (int ov = thread_in_row; ov < o_vec_count; ov += THREADS_PER_ROW) {
-                    float4 v = sO_vec[ov];
-                    v.x *= scale;
-                    v.y *= scale;
-                    v.z *= scale;
-                    v.w *= scale;
-
-                    sO_vec[ov] = v;
-                }
-            }
-        }
-        __syncthreads();
-
-        const uint4* v_vec     = reinterpret_cast<const uint4*>(v_ptr + start_col * D);
-        uint4*       sV_vec    = reinterpret_cast<uint4*>(sV);
-
-        #pragma unroll 2
-        for (int idx = tid; idx < (valid_k_rows * d_stride_uint4); idx += THREADS_PER_BLOCK) {
-            const int row = idx / d_stride_uint4;
-            const int vec_col = idx % d_stride_uint4;
-
-            uint4 v_val = make_uint4(0, 0, 0, 0);
-            if (row < valid_k_rows && vec_col < d_stride_uint4) {
-                v_val = __ldg(&v_vec[row * d_stride_uint4 + vec_col]);
-            }
-            sV_vec[row * kv_stride_uint4 + vec_col] = v_val;
-        }
-        __syncthreads();
-
-        const int num_tiles_m_pv    = (BLOCK_M + WMMA_M - 1) / WMMA_M;
-        const int num_tiles_n_pv    = (D + WMMA_N - 1) / WMMA_N;
-        const int num_tiles_k_pv    = (BLOCK_N + WMMA_K - 1) / WMMA_K;
-        const int total_tiles_pv    = num_tiles_m_pv * num_tiles_n_pv;
-        const int tiles_per_warp_pv = (total_tiles_pv + WARPS_PER_BLOCK - 1) / WARPS_PER_BLOCK;
-
-        for (int tile_idx = 0; tile_idx < tiles_per_warp_pv; ++tile_idx) {
-            const int global_tile_idx = warp_id * tiles_per_warp_pv + tile_idx;
-            if (global_tile_idx >= total_tiles_pv) break;
-
-            const int tile_m_idx = global_tile_idx / num_tiles_n_pv;
-            const int tile_d_idx = global_tile_idx % num_tiles_n_pv;
-
-            const int tile_m = tile_m_idx * WMMA_M;
-            const int tile_d = tile_d_idx * WMMA_N;
-
-            if (tile_m >= valid_q_rows) continue;
-
-            fragment<matrix_a, WMMA_M, WMMA_N, WMMA_K, half, row_major> a_frag;
-            fragment<matrix_b, WMMA_M, WMMA_N, WMMA_K, half, row_major> b_frag;
-            fragment<accumulator, WMMA_M, WMMA_N, WMMA_K, float> acc_frag;
-
-            load_matrix_sync(acc_frag, sO + tile_m * O_STRIDE + tile_d, O_STRIDE, mem_row_major);
-
-            #pragma unroll
-            for (int tile_k = 0; tile_k < num_tiles_k_pv; ++tile_k) {
-                const int k_offset = tile_k * WMMA_K;
-                if (k_offset >= valid_k_rows) break;
-
-                load_matrix_sync(a_frag, sP + tile_m * S_STRIDE + k_offset, S_STRIDE);
-                load_matrix_sync(b_frag, sV + k_offset * KV_STRIDE + tile_d, KV_STRIDE);
-                mma_sync(acc_frag, a_frag, b_frag, acc_frag);
-            }
-            store_matrix_sync(sO + tile_m * O_STRIDE + tile_d, acc_frag, O_STRIDE, mem_row_major);
-        }
-        __syncthreads();
+      }
+      store_matrix_sync(sS + tile_m * S_STRIDE + tile_n, acc_frag, S_STRIDE,
+                        mem_row_major);
     }
+    __syncthreads();
 
-    const int total_fp16_x4 = (valid_q_rows * D) / 4;
+    if (tid < valid_q_rows * THREADS_PER_ROW) {
+      const int row = tid / THREADS_PER_ROW;
+      const int thread_in_row = tid % THREADS_PER_ROW;
+      const unsigned mask =
+          (valid_q_rows == BLOCK_M) ? 0xFFFFFFFFU : __activemask();
+      const int row_leader = __ffs(mask) - 1;
 
-    for (int i = tid; i < total_fp16_x4; i += THREADS_PER_BLOCK) {
-        const int row = i / (D / 4);
-        const int col = (i % (D / 4)) * 4;
+      float* sS_row_f = sS + row * S_STRIDE;
+      __half* sP_row_h = sP + row * S_STRIDE;
 
-        const float sum_clamped = fmaxf(sRowSum[row], 1e-24f);
-        const float inv_sum = 1.0f / sum_clamped;
-        const float* sO_row = sO + row * O_STRIDE;
+      const int vec_cols = valid_k_rows >> 2;
+      const int vecs_per_thread =
+          (vec_cols + THREADS_PER_ROW - 1) / THREADS_PER_ROW;
+      const int tail_start = vec_cols << 2;
 
-        const __half h0 = __float2half_rn(sO_row[col + 0] * inv_sum);
-        const __half h1 = __float2half_rn(sO_row[col + 1] * inv_sum);
-        const __half h2 = __float2half_rn(sO_row[col + 2] * inv_sum);
-        const __half h3 = __float2half_rn(sO_row[col + 3] * inv_sum);
+      float thread_max = NEG_INF;
+      float4* sS_vec4 = reinterpret_cast<float4*>(sS_row_f);
 
-        asm volatile(
-            "st.global.v4.u16 [%0], {%1, %2, %3, %4};"
-            :
-            : "l"(out_ptr + row * D + col),
-              "h"(__half_as_ushort(h0)),
-              "h"(__half_as_ushort(h1)),
-              "h"(__half_as_ushort(h2)),
-              "h"(__half_as_ushort(h3))
-            : "memory"
-        );
+#pragma unroll 4
+      for (int j = 0; j < vecs_per_thread; ++j) {
+        int vc = thread_in_row + j * THREADS_PER_ROW;
+        if (vc < vec_cols) {
+          float4 v4 = sS_vec4[vc];
+          thread_max =
+              fmaxf(thread_max, fmaxf(fmaxf(v4.x, v4.y), fmaxf(v4.z, v4.w)));
+        }
+      }
+
+#pragma unroll 4
+      for (int c = tail_start + thread_in_row; c < valid_k_rows;
+           c += THREADS_PER_ROW) {
+        thread_max = fmaxf(thread_max, sS_row_f[c]);
+      }
+
+#pragma unroll
+      for (int o = THREADS_PER_ROW / 2; o > 0; o >>= 1)
+        thread_max = fmaxf(
+            thread_max, __shfl_down_sync(mask, thread_max, o, THREADS_PER_ROW));
+
+      const float row_max =
+          __shfl_sync(mask, thread_max, row_leader, THREADS_PER_ROW);
+      const float old_max = sRowMax[row];
+      const float new_max = fmaxf(old_max, row_max);
+      const float exp_diff = __expf(old_max - new_max);
+
+      float thread_sum = 0.0f;
+      __half2 half_buffer[20];
+      int vc_base = thread_in_row;
+      int h2_idx = 0;
+      int tail_col = -1;
+      __half tail_value = __float2half(0.f);
+
+#pragma unroll 4
+      for (int j = 0; j < vecs_per_thread; ++j, vc_base += THREADS_PER_ROW) {
+        if (vc_base < vec_cols) {
+          float4 v4 = sS_vec4[vc_base];
+
+          float e0 = __expf(fmaxf(v4.x - new_max, -80.0f));
+          float e1 = __expf(fmaxf(v4.y - new_max, -80.0f));
+          float e2 = __expf(fmaxf(v4.z - new_max, -80.0f));
+          float e3 = __expf(fmaxf(v4.w - new_max, -80.0f));
+
+          thread_sum += (e0 + e1) + (e2 + e3);
+
+          half_buffer[h2_idx++] = __float22half2_rn(make_float2(e0, e1));
+          half_buffer[h2_idx++] = __float22half2_rn(make_float2(e2, e3));
+        }
+      }
+
+#pragma unroll 4
+      for (int c = tail_start + thread_in_row; c < valid_k_rows;
+           c += THREADS_PER_ROW) {
+        float v = sS_row_f[c];
+        float e = __expf(fmaxf(v - new_max, -80.0f));
+        thread_sum += e;
+        tail_col = c;
+        tail_value = __float2half_rn(e);
+      }
+
+#pragma unroll
+      for (int o = THREADS_PER_ROW / 2; o > 0; o >>= 1)
+        thread_sum += __shfl_down_sync(mask, thread_sum, o, THREADS_PER_ROW);
+
+      float row_sum =
+          __shfl_sync(mask, thread_sum, row_leader, THREADS_PER_ROW);
+
+      if (thread_in_row == 0) {
+        sRowSum[row] = exp_diff * sRowSum[row] + row_sum;
+        sRowMax[row] = new_max;
+      }
+
+      h2_idx = 0;
+      vc_base = thread_in_row;
+      __half2* sP_half2 = reinterpret_cast<__half2*>(sP_row_h);
+
+#pragma unroll 4
+      for (int j = 0; j < vecs_per_thread; ++j, vc_base += THREADS_PER_ROW) {
+        if (vc_base < vec_cols) {
+          int base_offset = vc_base * 2;
+
+          sP_half2[base_offset] = half_buffer[h2_idx++];
+          sP_half2[base_offset + 1] = half_buffer[h2_idx++];
+        }
+      }
+
+      if (tail_col >= 0) {
+        sP_row_h[tail_col] = tail_value;
+      }
+
+#pragma unroll 4
+      for (int c = tail_start + thread_in_row; c < BLOCK_N;
+           c += THREADS_PER_ROW) {
+        if (c >= valid_k_rows) {
+          sP_row_h[c] = __float2half(0.f);
+        }
+      }
+
+      if (block_n > 0) {
+        float* sO_row = sO + row * O_STRIDE;
+        float4* sO_vec = reinterpret_cast<float4*>(sO_row);
+        const int o_vec_count = (O_STRIDE + 3) >> 2;
+        float scale = exp_diff;
+
+#pragma unroll 4
+        for (int ov = thread_in_row; ov < o_vec_count; ov += THREADS_PER_ROW) {
+          float4 v = sO_vec[ov];
+          v.x *= scale;
+          v.y *= scale;
+          v.z *= scale;
+          v.w *= scale;
+
+          sO_vec[ov] = v;
+        }
+      }
     }
+    __syncthreads();
 
-    if (tid < valid_q_rows) {
-        const float sum = fmaxf(sRowSum[tid], 1e-24f);
-        softmax_lse_ptr[tid] = sRowMax[tid] + logf(sum);
+    const uint4* v_vec = reinterpret_cast<const uint4*>(v_ptr + start_col * D);
+    uint4* sV_vec = reinterpret_cast<uint4*>(sV);
+
+#pragma unroll 2
+    for (int idx = tid; idx < (valid_k_rows * d_stride_uint4);
+         idx += THREADS_PER_BLOCK) {
+      const int row = idx / d_stride_uint4;
+      const int vec_col = idx % d_stride_uint4;
+
+      uint4 v_val = make_uint4(0, 0, 0, 0);
+      if (row < valid_k_rows && vec_col < d_stride_uint4) {
+        v_val = __ldg(&v_vec[row * d_stride_uint4 + vec_col]);
+      }
+      sV_vec[row * kv_stride_uint4 + vec_col] = v_val;
     }
+    __syncthreads();
+
+    const int num_tiles_m_pv = (BLOCK_M + WMMA_M - 1) / WMMA_M;
+    const int num_tiles_n_pv = (D + WMMA_N - 1) / WMMA_N;
+    const int num_tiles_k_pv = (BLOCK_N + WMMA_K - 1) / WMMA_K;
+    const int total_tiles_pv = num_tiles_m_pv * num_tiles_n_pv;
+    const int tiles_per_warp_pv =
+        (total_tiles_pv + WARPS_PER_BLOCK - 1) / WARPS_PER_BLOCK;
+
+    for (int tile_idx = 0; tile_idx < tiles_per_warp_pv; ++tile_idx) {
+      const int global_tile_idx = warp_id * tiles_per_warp_pv + tile_idx;
+      if (global_tile_idx >= total_tiles_pv) break;
+
+      const int tile_m_idx = global_tile_idx / num_tiles_n_pv;
+      const int tile_d_idx = global_tile_idx % num_tiles_n_pv;
+
+      const int tile_m = tile_m_idx * WMMA_M;
+      const int tile_d = tile_d_idx * WMMA_N;
+
+      if (tile_m >= valid_q_rows) continue;
+
+      fragment<matrix_a, WMMA_M, WMMA_N, WMMA_K, half, row_major> a_frag;
+      fragment<matrix_b, WMMA_M, WMMA_N, WMMA_K, half, row_major> b_frag;
+      fragment<accumulator, WMMA_M, WMMA_N, WMMA_K, float> acc_frag;
+
+      load_matrix_sync(acc_frag, sO + tile_m * O_STRIDE + tile_d, O_STRIDE,
+                       mem_row_major);
+
+#pragma unroll
+      for (int tile_k = 0; tile_k < num_tiles_k_pv; ++tile_k) {
+        const int k_offset = tile_k * WMMA_K;
+        if (k_offset >= valid_k_rows) break;
+
+        load_matrix_sync(a_frag, sP + tile_m * S_STRIDE + k_offset, S_STRIDE);
+        load_matrix_sync(b_frag, sV + k_offset * KV_STRIDE + tile_d, KV_STRIDE);
+        mma_sync(acc_frag, a_frag, b_frag, acc_frag);
+      }
+      store_matrix_sync(sO + tile_m * O_STRIDE + tile_d, acc_frag, O_STRIDE,
+                        mem_row_major);
+    }
+    __syncthreads();
+  }
+
+  const int total_fp16_x4 = (valid_q_rows * D) / 4;
+
+  for (int i = tid; i < total_fp16_x4; i += THREADS_PER_BLOCK) {
+    const int row = i / (D / 4);
+    const int col = (i % (D / 4)) * 4;
+
+    const float sum_clamped = fmaxf(sRowSum[row], 1e-24f);
+    const float inv_sum = 1.0f / sum_clamped;
+    const float* sO_row = sO + row * O_STRIDE;
+
+    const __half h0 = __float2half_rn(sO_row[col + 0] * inv_sum);
+    const __half h1 = __float2half_rn(sO_row[col + 1] * inv_sum);
+    const __half h2 = __float2half_rn(sO_row[col + 2] * inv_sum);
+    const __half h3 = __float2half_rn(sO_row[col + 3] * inv_sum);
+
+    asm volatile("st.global.v4.u16 [%0], {%1, %2, %3, %4};"
+                 :
+                 : "l"(out_ptr + row * D + col), "h"(__half_as_ushort(h0)),
+                   "h"(__half_as_ushort(h1)), "h"(__half_as_ushort(h2)),
+                   "h"(__half_as_ushort(h3))
+                 : "memory");
+  }
+
+  if (tid < valid_q_rows) {
+    const float sum = fmaxf(sRowSum[tid], 1e-24f);
+    softmax_lse_ptr[tid] = sRowMax[tid] + logf(sum);
+  }
 }
 
-template<int D>
+template <int D>
 void launcher_flash_attention_forward(
-    const torch::Tensor& Q,
-    const torch::Tensor& K,
-    const torch::Tensor& V,
-    torch::Tensor& Out,
-    torch::Tensor& softmax_lse,
-    float softmax_scale,
-    bool is_causal,
-    cudaStream_t stream
-) {
-    using Config = KernelConfig<D>;
+    const torch::Tensor& Q, const torch::Tensor& K, const torch::Tensor& V,
+    torch::Tensor& Out, torch::Tensor& softmax_lse, float softmax_scale,
+    bool is_causal, cudaStream_t stream) {
+  using Config = KernelConfig<D>;
 
-    const int B = Q.size(0);
-    const int H = Q.size(1);
-    const int M = Q.size(2);
-    const int N = K.size(2);
+  const int B = Q.size(0);
+  const int H = Q.size(1);
+  const int M = Q.size(2);
+  const int N = K.size(2);
 
-    const int grid_x = (M + Config::BLOCK_M - 1) / Config::BLOCK_M;
-    const dim3 grid(grid_x, 1, B * H);
-    const dim3 block(Config::THREADS_PER_BLOCK);
-    const size_t smem = Config::TOTAL_SMEM;
+  const int grid_x = (M + Config::BLOCK_M - 1) / Config::BLOCK_M;
+  const dim3 grid(grid_x, 1, B * H);
+  const dim3 block(Config::THREADS_PER_BLOCK);
+  const size_t smem = Config::TOTAL_SMEM;
 
-    TORCH_CHECK(smem <= MAX_SMEM_PER_SM, "Shared memory exceeds 96KB: ", smem, " bytes");
+  TORCH_CHECK(smem <= MAX_SMEM_PER_SM, "Shared memory exceeds 96KB: ", smem,
+              " bytes");
 
-    auto kernel = is_causal ?
-        (void*)flash_attention_forward_kernel<D, true> :
-        (void*)flash_attention_forward_kernel<D, false>;
+  auto kernel = is_causal ? (void*)flash_attention_forward_kernel<D, true>
+                          : (void*)flash_attention_forward_kernel<D, false>;
 
-    cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem);
+  cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize,
+                       smem);
 
-    if (is_causal) {
-        flash_attention_forward_kernel<D, true><<<grid, block, smem, stream>>>(
-            reinterpret_cast<const __half*>(Q.data_ptr()),
-            reinterpret_cast<const __half*>(K.data_ptr()),
-            reinterpret_cast<const __half*>(V.data_ptr()),
-            reinterpret_cast<__half*>(Out.data_ptr()),
-            softmax_lse.data_ptr<float>(),
-            B, H, M, N, softmax_scale
-        );
-    } else {
-        flash_attention_forward_kernel<D, false><<<grid, block, smem, stream>>>(
-            reinterpret_cast<const __half*>(Q.data_ptr()),
-            reinterpret_cast<const __half*>(K.data_ptr()),
-            reinterpret_cast<const __half*>(V.data_ptr()),
-            reinterpret_cast<__half*>(Out.data_ptr()),
-            softmax_lse.data_ptr<float>(),
-            B, H, M, N, softmax_scale
-        );
-    }
+  if (is_causal) {
+    flash_attention_forward_kernel<D, true><<<grid, block, smem, stream>>>(
+        reinterpret_cast<const __half*>(Q.data_ptr()),
+        reinterpret_cast<const __half*>(K.data_ptr()),
+        reinterpret_cast<const __half*>(V.data_ptr()),
+        reinterpret_cast<__half*>(Out.data_ptr()),
+        softmax_lse.data_ptr<float>(), B, H, M, N, softmax_scale);
+  } else {
+    flash_attention_forward_kernel<D, false><<<grid, block, smem, stream>>>(
+        reinterpret_cast<const __half*>(Q.data_ptr()),
+        reinterpret_cast<const __half*>(K.data_ptr()),
+        reinterpret_cast<const __half*>(V.data_ptr()),
+        reinterpret_cast<__half*>(Out.data_ptr()),
+        softmax_lse.data_ptr<float>(), B, H, M, N, softmax_scale);
+  }
 }
 
 std::vector<at::Tensor> flash_attention_forward(
-    at::Tensor& q,
-    const at::Tensor& k,
-    const at::Tensor& v,
-    std::optional<at::Tensor>& out_,
-    std::optional<at::Tensor>& alibi_slopes_,
-    const float p_dropout,
-    const float softmax_scale,
-    bool is_causal,
-    int window_size_left,
-    int window_size_right,
-    const float softcap,
-    const bool return_softmax,
-    std::optional<at::Generator> gen_
-) {
+    at::Tensor& q, const at::Tensor& k, const at::Tensor& v,
+    std::optional<at::Tensor>& out_, std::optional<at::Tensor>& alibi_slopes_,
+    const float p_dropout, const float softmax_scale, bool is_causal,
+    int window_size_left, int window_size_right, const float softcap,
+    const bool return_softmax, std::optional<at::Generator> gen_) {
+  TORCH_CHECK(!alibi_slopes_.has_value(), "alibi_slopes not supported");
+  TORCH_CHECK(p_dropout == 0.f, "dropout not supported");
+  TORCH_CHECK(window_size_left == -1, "window_size_left not supported");
+  TORCH_CHECK(window_size_right == -1 || (is_causal && window_size_right == 0),
+              "window not supported");
+  TORCH_CHECK(softcap == 0.f, "softcap not supported");
+  TORCH_CHECK(!return_softmax, "return_softmax not supported");
+  TORCH_CHECK(!gen_.has_value(), "Generator not supported");
 
-    TORCH_CHECK(!alibi_slopes_.has_value(), "alibi_slopes not supported");
-    TORCH_CHECK(p_dropout == 0.f, "dropout not supported");
-    TORCH_CHECK(window_size_left == -1, "window_size_left not supported");
-    TORCH_CHECK(window_size_right == -1 || (is_causal && window_size_right == 0), "window not supported");
-    TORCH_CHECK(softcap == 0.f, "softcap not supported");
-    TORCH_CHECK(!return_softmax, "return_softmax not supported");
-    TORCH_CHECK(!gen_.has_value(), "Generator not supported");
+  TORCH_CHECK(q.dtype() == torch::kFloat16, "q must be fp16");
+  TORCH_CHECK(k.dtype() == torch::kFloat16, "k must be fp16");
+  TORCH_CHECK(v.dtype() == torch::kFloat16, "v must be fp16");
+  TORCH_CHECK(q.is_cuda() && k.is_cuda() && v.is_cuda(),
+              "Tensors must be on CUDA");
+  TORCH_CHECK(q.stride(-1) == 1 && k.stride(-1) == 1 && v.stride(-1) == 1,
+              "Last dim must be contiguous");
 
-    TORCH_CHECK(q.dtype() == torch::kFloat16, "q must be fp16");
-    TORCH_CHECK(k.dtype() == torch::kFloat16, "k must be fp16");
-    TORCH_CHECK(v.dtype() == torch::kFloat16, "v must be fp16");
-    TORCH_CHECK(q.is_cuda() && k.is_cuda() && v.is_cuda(), "Tensors must be on CUDA");
-    TORCH_CHECK(q.stride(-1) == 1 && k.stride(-1) == 1 && v.stride(-1) == 1, "Last dim must be contiguous");
+  const auto sizes = q.sizes();
+  const int B = sizes[0], H = sizes[1], M = sizes[2], D = sizes[3];
+  const int N = k.size(2);
+  TORCH_CHECK(D <= 256 && D % 8 == 0 && D % 2 == 0,
+              "D must be even, <=256, multiple of 8");
 
-    const auto sizes = q.sizes();
-    const int B = sizes[0], H = sizes[1], M = sizes[2], D = sizes[3];
-    const int N = k.size(2);
-    TORCH_CHECK(D <= 256 && D % 8 == 0 && D % 2 == 0, "D must be even, <=256, multiple of 8");
+  at::Tensor out_fp16 = out_.has_value() ? out_.value() : torch::zeros_like(q);
+  TORCH_CHECK(out_fp16.dtype() == torch::kFloat16, "out must be fp16");
+  auto softmax_lse =
+      torch::zeros({B, H, M}, torch::dtype(torch::kFloat32).device(q.device()));
+  TORCH_CHECK(softmax_lse.dtype() == torch::kFloat32,
+              "softmax_lse must be fp32");
 
-    at::Tensor out_fp16 = out_.has_value() ? out_.value() : torch::zeros_like(q);
-    TORCH_CHECK(out_fp16.dtype() == torch::kFloat16, "out must be fp16");
-    auto softmax_lse = torch::zeros({B, H, M}, torch::dtype(torch::kFloat32).device(q.device()));
-    TORCH_CHECK(softmax_lse.dtype() == torch::kFloat32, "softmax_lse must be fp32");
+  auto stream = at::cuda::getCurrentCUDAStream().stream();
+  auto props = at::cuda::getCurrentDeviceProperties();
+  bool sm70 = props->major == 7 && props->minor == 0;
+  TORCH_CHECK(sm70, "Kernel supports only Volta GPUs.");
 
-    auto stream = at::cuda::getCurrentCUDAStream().stream();
-    auto props  = at::cuda::getCurrentDeviceProperties();
-    bool sm70   = props->major == 7 && props->minor == 0;
-    TORCH_CHECK(sm70, "Kernel supports only Volta GPUs.");
+  switch (D) {
+    case 16:
+      launcher_flash_attention_forward<16>(q, k, v, out_fp16, softmax_lse,
+                                           softmax_scale, is_causal, stream);
+      break;
+    case 32:
+      launcher_flash_attention_forward<32>(q, k, v, out_fp16, softmax_lse,
+                                           softmax_scale, is_causal, stream);
+      break;
+    case 64:
+      launcher_flash_attention_forward<64>(q, k, v, out_fp16, softmax_lse,
+                                           softmax_scale, is_causal, stream);
+      break;
+    case 128:
+      launcher_flash_attention_forward<128>(q, k, v, out_fp16, softmax_lse,
+                                            softmax_scale, is_causal, stream);
+      break;
+    case 256:
+      launcher_flash_attention_forward<256>(q, k, v, out_fp16, softmax_lse,
+                                            softmax_scale, is_causal, stream);
+      break;
+    default:
+      TORCH_CHECK(false, "Unsupported D: ", D);
+  }
 
-    switch (D) {
-        case 16:  launcher_flash_attention_forward<16>(q, k, v, out_fp16, softmax_lse, softmax_scale, is_causal, stream); break;
-        case 32:  launcher_flash_attention_forward<32>(q, k, v, out_fp16, softmax_lse, softmax_scale, is_causal, stream); break;
-        case 64:  launcher_flash_attention_forward<64>(q, k, v, out_fp16, softmax_lse, softmax_scale, is_causal, stream); break;
-        case 128: launcher_flash_attention_forward<128>(q, k, v, out_fp16, softmax_lse, softmax_scale, is_causal, stream); break;
-        case 256: launcher_flash_attention_forward<256>(q, k, v, out_fp16, softmax_lse, softmax_scale, is_causal, stream); break;
-        default: TORCH_CHECK(false, "Unsupported D: ", D);
-    }
-
-    auto p = torch::zeros({0}, q.options());
-    auto rng_state = torch::zeros({2}, torch::dtype(torch::kInt64).device(q.device()));
-    return {out_fp16, softmax_lse, p, rng_state};
+  auto p = torch::zeros({0}, q.options());
+  auto rng_state =
+      torch::zeros({2}, torch::dtype(torch::kInt64).device(q.device()));
+  return {out_fp16, softmax_lse, p, rng_state};
 }

--- a/flash-attention-v100/kernel/paged_kv_utils.cuh
+++ b/flash-attention-v100/kernel/paged_kv_utils.cuh
@@ -4,78 +4,58 @@
 #include <cuda_runtime.h>
 #include <cuda_fp16.h>
 
-__device__ __forceinline__
-size_t resolve_paged_kv_offset(
-    const int token_idx,
-    const int page_block_size,
-    const int* __restrict__ block_table,
-    const int kv_head_offset,
-    const int num_kv_heads,
-    const int head_dim
-) {
+__device__ __forceinline__ size_t resolve_paged_kv_offset(
+    const int token_idx, const int page_block_size,
+    const int* __restrict__ block_table, const int kv_head_offset,
+    const int num_kv_heads, const int head_dim) {
+  const int virtual_page_idx = token_idx / page_block_size;
+  const int page_offset = token_idx % page_block_size;
 
-    const int virtual_page_idx = token_idx / page_block_size;
-    const int page_offset = token_idx % page_block_size;
+  const int physical_block_idx = block_table[virtual_page_idx];
 
-    const int physical_block_idx = block_table[virtual_page_idx];
+  const size_t physical_offset =
+      (size_t)physical_block_idx * page_block_size * num_kv_heads * head_dim +
+      (size_t)page_offset * num_kv_heads * head_dim + (size_t)kv_head_offset;
 
-    const size_t physical_offset =
-        (size_t)physical_block_idx * page_block_size * num_kv_heads * head_dim
-        + (size_t)page_offset * num_kv_heads * head_dim
-        + (size_t)kv_head_offset;
-
-    return physical_offset;
+  return physical_offset;
 }
 
-template<int D>
-__device__ __forceinline__
-void load_kv_tile_paged(
-    const __half* __restrict__ kv_cache,
-    const int* __restrict__ block_table,
-    const int start_token_idx,
-    const int num_tokens,
-    const int kv_head_idx,
-    const int num_kv_heads,
-    const int head_dim,
-    const int page_block_size,
-    __half* smem_dst,
-    const int smem_stride,
-    const int tid,
-    const int num_threads
-) {
-    constexpr int PER_UINT4 = 8;
-    const int d_stride_uint4 = (D + PER_UINT4 - 1) / PER_UINT4;
-    const int smem_stride_uint4 = (smem_stride + PER_UINT4 - 1) / PER_UINT4;
+template <int D>
+__device__ __forceinline__ void load_kv_tile_paged(
+    const __half* __restrict__ kv_cache, const int* __restrict__ block_table,
+    const int start_token_idx, const int num_tokens, const int kv_head_idx,
+    const int num_kv_heads, const int head_dim, const int page_block_size,
+    __half* smem_dst, const int smem_stride, const int tid,
+    const int num_threads) {
+  constexpr int PER_UINT4 = 8;
+  const int d_stride_uint4 = (D + PER_UINT4 - 1) / PER_UINT4;
+  const int smem_stride_uint4 = (smem_stride + PER_UINT4 - 1) / PER_UINT4;
 
-    const int kv_head_offset = kv_head_idx * head_dim;
+  const int kv_head_offset = kv_head_idx * head_dim;
 
-    uint4* smem_vec = reinterpret_cast<uint4*>(smem_dst);
+  uint4* smem_vec = reinterpret_cast<uint4*>(smem_dst);
 
-    #pragma unroll 2
-    for (int idx = tid; idx < (num_tokens * d_stride_uint4); idx += num_threads) {
-        const int token_offset = idx / d_stride_uint4;
-        const int vec_col = idx % d_stride_uint4;
+#pragma unroll 2
+  for (int idx = tid; idx < (num_tokens * d_stride_uint4); idx += num_threads) {
+    const int token_offset = idx / d_stride_uint4;
+    const int vec_col = idx % d_stride_uint4;
 
-        uint4 kv_val = make_uint4(0, 0, 0, 0);
+    uint4 kv_val = make_uint4(0, 0, 0, 0);
 
-        if (token_offset < num_tokens && vec_col < d_stride_uint4) {
-            const int global_token_idx = start_token_idx + token_offset;
+    if (token_offset < num_tokens && vec_col < d_stride_uint4) {
+      const int global_token_idx = start_token_idx + token_offset;
 
-            const size_t base_offset = resolve_paged_kv_offset(
-                global_token_idx,
-                page_block_size,
-                block_table,
-                kv_head_offset,
-                num_kv_heads,
-                head_dim
-            );
+      const size_t base_offset = resolve_paged_kv_offset(
+          global_token_idx, page_block_size, block_table, kv_head_offset,
+          num_kv_heads, head_dim);
 
-            const uint4* kv_vec = reinterpret_cast<const uint4*>(kv_cache + base_offset);
-            kv_val = __ldg(&kv_vec[vec_col]);
-        }
-
-        smem_vec[token_offset * smem_stride_uint4 + vec_col] = kv_val;
+      const uint4* kv_vec =
+          reinterpret_cast<const uint4*>(kv_cache + base_offset);
+      kv_val = __ldg(&kv_vec[vec_col]);
     }
+
+    smem_vec[token_offset * smem_stride_uint4 + vec_col] = kv_val;
+  }
 }
 
 #endif

--- a/flash-attention-v100/kernel/paged_to_contiguous.cu
+++ b/flash-attention-v100/kernel/paged_to_contiguous.cu
@@ -4,215 +4,178 @@
 #include <torch/extension.h>
 
 __global__ void paged_to_contiguous_stride_aware_kernel(
-    const __half* __restrict__ paged_cache,
-    const int* __restrict__ block_table,
-    const int* __restrict__ seq_lens,
-          __half* __restrict__ contiguous,
-    const int64_t block_stride,
-    const int64_t page_stride,
-    const int64_t head_stride,
-    const int block_size,
-    const int num_heads,
-    const int head_dim,
-    const int max_num_blocks
-) {
+    const __half* __restrict__ paged_cache, const int* __restrict__ block_table,
+    const int* __restrict__ seq_lens, __half* __restrict__ contiguous,
+    const int64_t block_stride, const int64_t page_stride,
+    const int64_t head_stride, const int block_size, const int num_heads,
+    const int head_dim, const int max_num_blocks) {
+  const int batch_idx = blockIdx.x;
+  const int seq_len = seq_lens[batch_idx];
+  if (seq_len == 0) return;
 
-    const int batch_idx = blockIdx.x;
-    const int seq_len = seq_lens[batch_idx];
-    if (seq_len == 0) return;
+  int output_offset = 0;
+  for (int i = 0; i < batch_idx; ++i) {
+    output_offset += seq_lens[i];
+  }
 
-    int output_offset = 0;
-    for (int i = 0; i < batch_idx; ++i) {
-        output_offset += seq_lens[i];
+  const int* block_table_seq = block_table + batch_idx * max_num_blocks;
+
+  const int tid = threadIdx.x;
+  const int num_threads = blockDim.x;
+  const int elements_per_token = num_heads * head_dim;
+
+  for (int token_idx = 0; token_idx < seq_len; ++token_idx) {
+    const int virtual_block_idx = token_idx / block_size;
+    const int block_offset = token_idx % block_size;
+    const int physical_block_idx = block_table_seq[virtual_block_idx];
+
+    const __half* token_base = paged_cache + physical_block_idx * block_stride +
+                               block_offset * page_stride;
+
+    __half* output_token =
+        contiguous + (output_offset + token_idx) * elements_per_token;
+
+    for (int head_idx = 0; head_idx < num_heads; ++head_idx) {
+      const __half* head_src = token_base + head_idx * head_stride;
+      __half* head_dst = output_token + head_idx * head_dim;
+
+      for (int elem_idx = tid; elem_idx < head_dim; elem_idx += num_threads) {
+        head_dst[elem_idx] = head_src[elem_idx];
+      }
     }
-
-    const int* block_table_seq = block_table + batch_idx * max_num_blocks;
-
-    const int tid = threadIdx.x;
-    const int num_threads = blockDim.x;
-    const int elements_per_token = num_heads * head_dim;
-
-    for (int token_idx = 0; token_idx < seq_len; ++token_idx) {
-
-        const int virtual_block_idx = token_idx / block_size;
-        const int block_offset = token_idx % block_size;
-        const int physical_block_idx = block_table_seq[virtual_block_idx];
-
-        const __half* token_base = paged_cache
-            + physical_block_idx * block_stride
-            + block_offset * page_stride;
-
-        __half* output_token = contiguous + (output_offset + token_idx) * elements_per_token;
-
-        for (int head_idx = 0; head_idx < num_heads; ++head_idx) {
-            const __half* head_src = token_base + head_idx * head_stride;
-            __half* head_dst = output_token + head_idx * head_dim;
-
-            for (int elem_idx = tid; elem_idx < head_dim; elem_idx += num_threads) {
-                head_dst[elem_idx] = head_src[elem_idx];
-            }
-        }
-    }
+  }
 }
 
 __global__ void paged_kv_to_contiguous_stride_aware_kernel(
     const __half* __restrict__ paged_key_cache,
     const __half* __restrict__ paged_value_cache,
-    const int* __restrict__ block_table,
-    const int* __restrict__ seq_lens,
-          __half* __restrict__ contiguous_key,
-          __half* __restrict__ contiguous_value,
-    const int64_t key_block_stride,
-    const int64_t key_page_stride,
-    const int64_t key_head_stride,
-    const int64_t value_block_stride,
-    const int64_t value_page_stride,
-    const int64_t value_head_stride,
-    const int block_size,
-    const int num_heads,
-    const int head_dim,
-    const int max_num_blocks
-) {
-    const int batch_idx = blockIdx.x;
-    const int seq_len = seq_lens[batch_idx];
-    if (seq_len == 0) return;
+    const int* __restrict__ block_table, const int* __restrict__ seq_lens,
+    __half* __restrict__ contiguous_key, __half* __restrict__ contiguous_value,
+    const int64_t key_block_stride, const int64_t key_page_stride,
+    const int64_t key_head_stride, const int64_t value_block_stride,
+    const int64_t value_page_stride, const int64_t value_head_stride,
+    const int block_size, const int num_heads, const int head_dim,
+    const int max_num_blocks) {
+  const int batch_idx = blockIdx.x;
+  const int seq_len = seq_lens[batch_idx];
+  if (seq_len == 0) return;
 
-    int output_offset = 0;
-    for (int i = 0; i < batch_idx; ++i) {
-        output_offset += seq_lens[i];
+  int output_offset = 0;
+  for (int i = 0; i < batch_idx; ++i) {
+    output_offset += seq_lens[i];
+  }
+
+  const int* block_table_seq = block_table + batch_idx * max_num_blocks;
+  const int tid = threadIdx.x;
+  const int num_threads = blockDim.x;
+  const int elements_per_token = num_heads * head_dim;
+
+  for (int token_idx = 0; token_idx < seq_len; ++token_idx) {
+    const int virtual_block_idx = token_idx / block_size;
+    const int block_offset = token_idx % block_size;
+    const int physical_block_idx = block_table_seq[virtual_block_idx];
+
+    const __half* key_token_base = paged_key_cache +
+                                   physical_block_idx * key_block_stride +
+                                   block_offset * key_page_stride;
+    const __half* value_token_base = paged_value_cache +
+                                     physical_block_idx * value_block_stride +
+                                     block_offset * value_page_stride;
+
+    __half* key_output_token =
+        contiguous_key + (output_offset + token_idx) * elements_per_token;
+    __half* value_output_token =
+        contiguous_value + (output_offset + token_idx) * elements_per_token;
+
+    for (int head_idx = 0; head_idx < num_heads; ++head_idx) {
+      const __half* key_head_src = key_token_base + head_idx * key_head_stride;
+      const __half* value_head_src =
+          value_token_base + head_idx * value_head_stride;
+      __half* key_head_dst = key_output_token + head_idx * head_dim;
+      __half* value_head_dst = value_output_token + head_idx * head_dim;
+
+      for (int elem_idx = tid; elem_idx < head_dim; elem_idx += num_threads) {
+        key_head_dst[elem_idx] = key_head_src[elem_idx];
+        value_head_dst[elem_idx] = value_head_src[elem_idx];
+      }
     }
-
-    const int* block_table_seq = block_table + batch_idx * max_num_blocks;
-    const int tid = threadIdx.x;
-    const int num_threads = blockDim.x;
-    const int elements_per_token = num_heads * head_dim;
-
-    for (int token_idx = 0; token_idx < seq_len; ++token_idx) {
-        const int virtual_block_idx = token_idx / block_size;
-        const int block_offset = token_idx % block_size;
-        const int physical_block_idx = block_table_seq[virtual_block_idx];
-
-        const __half* key_token_base = paged_key_cache
-            + physical_block_idx * key_block_stride
-            + block_offset * key_page_stride;
-        const __half* value_token_base = paged_value_cache
-            + physical_block_idx * value_block_stride
-            + block_offset * value_page_stride;
-
-        __half* key_output_token =
-            contiguous_key + (output_offset + token_idx) * elements_per_token;
-        __half* value_output_token =
-            contiguous_value + (output_offset + token_idx) * elements_per_token;
-
-        for (int head_idx = 0; head_idx < num_heads; ++head_idx) {
-            const __half* key_head_src = key_token_base + head_idx * key_head_stride;
-            const __half* value_head_src =
-                value_token_base + head_idx * value_head_stride;
-            __half* key_head_dst = key_output_token + head_idx * head_dim;
-            __half* value_head_dst = value_output_token + head_idx * head_dim;
-
-            for (int elem_idx = tid; elem_idx < head_dim; elem_idx += num_threads) {
-                key_head_dst[elem_idx] = key_head_src[elem_idx];
-                value_head_dst[elem_idx] = value_head_src[elem_idx];
-            }
-        }
-    }
+  }
 }
 
-torch::Tensor paged_to_contiguous(
-    torch::Tensor paged_cache,
-    torch::Tensor block_table,
-    torch::Tensor seq_lens
-) {
-    const int batch_size = block_table.size(0);
-    const int max_num_blocks = block_table.size(1);
-    const int num_blocks = paged_cache.size(0);
-    const int block_size = paged_cache.size(1);
-    const int num_heads = paged_cache.size(2);
-    const int head_dim = paged_cache.size(3);
+torch::Tensor paged_to_contiguous(torch::Tensor paged_cache,
+                                  torch::Tensor block_table,
+                                  torch::Tensor seq_lens) {
+  const int batch_size = block_table.size(0);
+  const int max_num_blocks = block_table.size(1);
+  const int num_blocks = paged_cache.size(0);
+  const int block_size = paged_cache.size(1);
+  const int num_heads = paged_cache.size(2);
+  const int head_dim = paged_cache.size(3);
 
-    const int64_t block_stride = paged_cache.stride(0);
-    const int64_t page_stride = paged_cache.stride(1);
-    const int64_t head_stride = paged_cache.stride(2);
+  const int64_t block_stride = paged_cache.stride(0);
+  const int64_t page_stride = paged_cache.stride(1);
+  const int64_t head_stride = paged_cache.stride(2);
 
-    const int total_tokens = batch_size * max_num_blocks * block_size;
+  const int total_tokens = batch_size * max_num_blocks * block_size;
 
-    auto contiguous = torch::zeros(
-        {total_tokens, num_heads, head_dim},
-        torch::TensorOptions().dtype(paged_cache.dtype()).device(paged_cache.device())
-    );
+  auto contiguous = torch::zeros({total_tokens, num_heads, head_dim},
+                                 torch::TensorOptions()
+                                     .dtype(paged_cache.dtype())
+                                     .device(paged_cache.device()));
 
-    const int threads = 256;
-    paged_to_contiguous_stride_aware_kernel<<<batch_size, threads>>>(
-        reinterpret_cast<const __half*>(paged_cache.data_ptr<at::Half>()),
-        block_table.data_ptr<int>(),
-        seq_lens.data_ptr<int>(),
-        reinterpret_cast<__half*>(contiguous.data_ptr<at::Half>()),
-        block_stride,
-        page_stride,
-        head_stride,
-        block_size,
-        num_heads,
-        head_dim,
-        max_num_blocks
-    );
+  const int threads = 256;
+  paged_to_contiguous_stride_aware_kernel<<<batch_size, threads>>>(
+      reinterpret_cast<const __half*>(paged_cache.data_ptr<at::Half>()),
+      block_table.data_ptr<int>(), seq_lens.data_ptr<int>(),
+      reinterpret_cast<__half*>(contiguous.data_ptr<at::Half>()), block_stride,
+      page_stride, head_stride, block_size, num_heads, head_dim,
+      max_num_blocks);
 
-    return contiguous;
+  return contiguous;
 }
 
 std::vector<torch::Tensor> paged_kv_to_contiguous(
-    torch::Tensor paged_key_cache,
-    torch::Tensor paged_value_cache,
-    torch::Tensor block_table,
-    torch::Tensor seq_lens
-) {
-    const int batch_size = block_table.size(0);
-    const int max_num_blocks = block_table.size(1);
-    const int block_size = paged_key_cache.size(1);
-    const int num_heads = paged_key_cache.size(2);
-    const int head_dim = paged_key_cache.size(3);
+    torch::Tensor paged_key_cache, torch::Tensor paged_value_cache,
+    torch::Tensor block_table, torch::Tensor seq_lens) {
+  const int batch_size = block_table.size(0);
+  const int max_num_blocks = block_table.size(1);
+  const int block_size = paged_key_cache.size(1);
+  const int num_heads = paged_key_cache.size(2);
+  const int head_dim = paged_key_cache.size(3);
 
-    const int64_t key_block_stride = paged_key_cache.stride(0);
-    const int64_t key_page_stride = paged_key_cache.stride(1);
-    const int64_t key_head_stride = paged_key_cache.stride(2);
-    const int64_t value_block_stride = paged_value_cache.stride(0);
-    const int64_t value_page_stride = paged_value_cache.stride(1);
-    const int64_t value_head_stride = paged_value_cache.stride(2);
+  const int64_t key_block_stride = paged_key_cache.stride(0);
+  const int64_t key_page_stride = paged_key_cache.stride(1);
+  const int64_t key_head_stride = paged_key_cache.stride(2);
+  const int64_t value_block_stride = paged_value_cache.stride(0);
+  const int64_t value_page_stride = paged_value_cache.stride(1);
+  const int64_t value_head_stride = paged_value_cache.stride(2);
 
-    const int total_tokens = batch_size * max_num_blocks * block_size;
+  const int total_tokens = batch_size * max_num_blocks * block_size;
 
-    auto opts = torch::TensorOptions()
-                    .dtype(paged_key_cache.dtype())
-                    .device(paged_key_cache.device());
-    auto contiguous_key = torch::zeros({total_tokens, num_heads, head_dim}, opts);
-    auto contiguous_value = torch::zeros({total_tokens, num_heads, head_dim}, opts);
+  auto opts = torch::TensorOptions()
+                  .dtype(paged_key_cache.dtype())
+                  .device(paged_key_cache.device());
+  auto contiguous_key = torch::zeros({total_tokens, num_heads, head_dim}, opts);
+  auto contiguous_value =
+      torch::zeros({total_tokens, num_heads, head_dim}, opts);
 
-    const int threads = 256;
-    paged_kv_to_contiguous_stride_aware_kernel<<<batch_size, threads>>>(
-        reinterpret_cast<const __half*>(paged_key_cache.data_ptr<at::Half>()),
-        reinterpret_cast<const __half*>(paged_value_cache.data_ptr<at::Half>()),
-        block_table.data_ptr<int>(),
-        seq_lens.data_ptr<int>(),
-        reinterpret_cast<__half*>(contiguous_key.data_ptr<at::Half>()),
-        reinterpret_cast<__half*>(contiguous_value.data_ptr<at::Half>()),
-        key_block_stride,
-        key_page_stride,
-        key_head_stride,
-        value_block_stride,
-        value_page_stride,
-        value_head_stride,
-        block_size,
-        num_heads,
-        head_dim,
-        max_num_blocks
-    );
+  const int threads = 256;
+  paged_kv_to_contiguous_stride_aware_kernel<<<batch_size, threads>>>(
+      reinterpret_cast<const __half*>(paged_key_cache.data_ptr<at::Half>()),
+      reinterpret_cast<const __half*>(paged_value_cache.data_ptr<at::Half>()),
+      block_table.data_ptr<int>(), seq_lens.data_ptr<int>(),
+      reinterpret_cast<__half*>(contiguous_key.data_ptr<at::Half>()),
+      reinterpret_cast<__half*>(contiguous_value.data_ptr<at::Half>()),
+      key_block_stride, key_page_stride, key_head_stride, value_block_stride,
+      value_page_stride, value_head_stride, block_size, num_heads, head_dim,
+      max_num_blocks);
 
-    return {contiguous_key, contiguous_value};
+  return {contiguous_key, contiguous_value};
 }
 
 PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
-    m.def("paged_to_contiguous", &paged_to_contiguous, "Paged KV Cache to Contiguous (Stride-Aware)");
-    m.def("paged_kv_to_contiguous",
-          &paged_kv_to_contiguous,
-          "Paged KV Cache to Contiguous K/V Pair (Stride-Aware)");
+  m.def("paged_to_contiguous", &paged_to_contiguous,
+        "Paged KV Cache to Contiguous (Stride-Aware)");
+  m.def("paged_kv_to_contiguous", &paged_kv_to_contiguous,
+        "Paged KV Cache to Contiguous K/V Pair (Stride-Aware)");
 }

--- a/flash-attention-v100/kernel/paged_to_contiguous_fixed.cu
+++ b/flash-attention-v100/kernel/paged_to_contiguous_fixed.cu
@@ -4,102 +4,85 @@
 #include <torch/extension.h>
 
 __global__ void paged_to_contiguous_stride_aware_kernel(
-    const __half* __restrict__ paged_cache,
-    const int* __restrict__ block_table,
-    const int* __restrict__ seq_lens,
-          __half* __restrict__ contiguous,
-    const int64_t block_stride,
-    const int64_t page_stride,
-    const int64_t head_stride,
-    const int block_size,
-    const int num_heads,
-    const int head_dim,
-    const int max_num_blocks
-) {
+    const __half* __restrict__ paged_cache, const int* __restrict__ block_table,
+    const int* __restrict__ seq_lens, __half* __restrict__ contiguous,
+    const int64_t block_stride, const int64_t page_stride,
+    const int64_t head_stride, const int block_size, const int num_heads,
+    const int head_dim, const int max_num_blocks) {
+  const int batch_idx = blockIdx.x;
+  const int seq_len = seq_lens[batch_idx];
+  if (seq_len == 0) return;
 
-    const int batch_idx = blockIdx.x;
-    const int seq_len = seq_lens[batch_idx];
-    if (seq_len == 0) return;
+  int output_offset = 0;
+  for (int i = 0; i < batch_idx; ++i) {
+    output_offset += seq_lens[i];
+  }
 
-    int output_offset = 0;
-    for (int i = 0; i < batch_idx; ++i) {
-        output_offset += seq_lens[i];
+  const int* block_table_seq = block_table + batch_idx * max_num_blocks;
+
+  const int tid = threadIdx.x;
+  const int num_threads = blockDim.x;
+  const int elements_per_token = num_heads * head_dim;
+
+  for (int token_idx = 0; token_idx < seq_len; ++token_idx) {
+    const int virtual_block_idx = token_idx / block_size;
+    const int block_offset = token_idx % block_size;
+    const int physical_block_idx = block_table_seq[virtual_block_idx];
+
+    const __half* token_base = paged_cache + physical_block_idx * block_stride +
+                               block_offset * page_stride;
+
+    __half* output_token =
+        contiguous + (output_offset + token_idx) * elements_per_token;
+
+    for (int head_idx = 0; head_idx < num_heads; ++head_idx) {
+      const __half* head_src = token_base + head_idx * head_stride;
+      __half* head_dst = output_token + head_idx * head_dim;
+
+      for (int elem_idx = tid; elem_idx < head_dim; elem_idx += num_threads) {
+        head_dst[elem_idx] = head_src[elem_idx];
+      }
     }
-
-    const int* block_table_seq = block_table + batch_idx * max_num_blocks;
-
-    const int tid = threadIdx.x;
-    const int num_threads = blockDim.x;
-    const int elements_per_token = num_heads * head_dim;
-
-    for (int token_idx = 0; token_idx < seq_len; ++token_idx) {
-
-        const int virtual_block_idx = token_idx / block_size;
-        const int block_offset = token_idx % block_size;
-        const int physical_block_idx = block_table_seq[virtual_block_idx];
-
-        const __half* token_base = paged_cache
-            + physical_block_idx * block_stride
-            + block_offset * page_stride;
-
-        __half* output_token = contiguous + (output_offset + token_idx) * elements_per_token;
-
-        for (int head_idx = 0; head_idx < num_heads; ++head_idx) {
-            const __half* head_src = token_base + head_idx * head_stride;
-            __half* head_dst = output_token + head_idx * head_dim;
-
-            for (int elem_idx = tid; elem_idx < head_dim; elem_idx += num_threads) {
-                head_dst[elem_idx] = head_src[elem_idx];
-            }
-        }
-    }
+  }
 }
 
-torch::Tensor paged_to_contiguous(
-    torch::Tensor paged_cache,
-    torch::Tensor block_table,
-    torch::Tensor seq_lens
-) {
-    const int batch_size = block_table.size(0);
-    const int max_num_blocks = block_table.size(1);
-    const int num_blocks = paged_cache.size(0);
-    const int block_size = paged_cache.size(1);
-    const int num_heads = paged_cache.size(2);
-    const int head_dim = paged_cache.size(3);
+torch::Tensor paged_to_contiguous(torch::Tensor paged_cache,
+                                  torch::Tensor block_table,
+                                  torch::Tensor seq_lens) {
+  const int batch_size = block_table.size(0);
+  const int max_num_blocks = block_table.size(1);
+  const int num_blocks = paged_cache.size(0);
+  const int block_size = paged_cache.size(1);
+  const int num_heads = paged_cache.size(2);
+  const int head_dim = paged_cache.size(3);
 
-    const int64_t block_stride = paged_cache.stride(0);
-    const int64_t page_stride = paged_cache.stride(1);
-    const int64_t head_stride = paged_cache.stride(2);
+  const int64_t block_stride = paged_cache.stride(0);
+  const int64_t page_stride = paged_cache.stride(1);
+  const int64_t head_stride = paged_cache.stride(2);
 
-    int total_tokens = 0;
-    auto seq_lens_cpu = seq_lens.cpu();
-    for (int i = 0; i < batch_size; ++i) {
-        total_tokens += seq_lens_cpu[i].item<int>();
-    }
+  int total_tokens = 0;
+  auto seq_lens_cpu = seq_lens.cpu();
+  for (int i = 0; i < batch_size; ++i) {
+    total_tokens += seq_lens_cpu[i].item<int>();
+  }
 
-    auto contiguous = torch::zeros(
-        {total_tokens, num_heads, head_dim},
-        torch::TensorOptions().dtype(paged_cache.dtype()).device(paged_cache.device())
-    );
+  auto contiguous = torch::zeros({total_tokens, num_heads, head_dim},
+                                 torch::TensorOptions()
+                                     .dtype(paged_cache.dtype())
+                                     .device(paged_cache.device()));
 
-    const int threads = 256;
-    paged_to_contiguous_stride_aware_kernel<<<batch_size, threads>>>(
-        reinterpret_cast<const __half*>(paged_cache.data_ptr<at::Half>()),
-        block_table.data_ptr<int>(),
-        seq_lens.data_ptr<int>(),
-        reinterpret_cast<__half*>(contiguous.data_ptr<at::Half>()),
-        block_stride,
-        page_stride,
-        head_stride,
-        block_size,
-        num_heads,
-        head_dim,
-        max_num_blocks
-    );
+  const int threads = 256;
+  paged_to_contiguous_stride_aware_kernel<<<batch_size, threads>>>(
+      reinterpret_cast<const __half*>(paged_cache.data_ptr<at::Half>()),
+      block_table.data_ptr<int>(), seq_lens.data_ptr<int>(),
+      reinterpret_cast<__half*>(contiguous.data_ptr<at::Half>()), block_stride,
+      page_stride, head_stride, block_size, num_heads, head_dim,
+      max_num_blocks);
 
-    return contiguous;
+  return contiguous;
 }
 
 PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
-    m.def("paged_to_contiguous", &paged_to_contiguous, "Paged KV Cache to Contiguous (Stride-Aware)");
+  m.def("paged_to_contiguous", &paged_to_contiguous,
+        "Paged KV Cache to Contiguous (Stride-Aware)");
 }

--- a/flash-attention-v100/kernel/paged_to_contiguous_old.cu
+++ b/flash-attention-v100/kernel/paged_to_contiguous_old.cu
@@ -4,85 +4,75 @@
 #include <torch/extension.h>
 
 __global__ void paged_to_contiguous_kernel(
-    const __half* __restrict__ paged_cache,
-    const int* __restrict__ block_table,
-    const int* __restrict__ seq_lens,
-          __half* __restrict__ contiguous,
-    const int block_size,
-    const int num_heads,
-    const int head_dim,
-    const int max_num_blocks
-) {
+    const __half* __restrict__ paged_cache, const int* __restrict__ block_table,
+    const int* __restrict__ seq_lens, __half* __restrict__ contiguous,
+    const int block_size, const int num_heads, const int head_dim,
+    const int max_num_blocks) {
+  const int batch_idx = blockIdx.x;
+  const int seq_len = seq_lens[batch_idx];
+  if (seq_len == 0) return;
 
-    const int batch_idx = blockIdx.x;
-    const int seq_len = seq_lens[batch_idx];
-    if (seq_len == 0) return;
+  int output_offset = 0;
+  for (int i = 0; i < batch_idx; ++i) {
+    output_offset += seq_lens[i];
+  }
 
-    int output_offset = 0;
-    for (int i = 0; i < batch_idx; ++i) {
-        output_offset += seq_lens[i];
+  const int* block_table_seq = block_table + batch_idx * max_num_blocks;
+
+  const int tid = threadIdx.x;
+  const int num_threads = blockDim.x;
+  const int elements_per_token = num_heads * head_dim;
+
+  for (int token_idx = 0; token_idx < seq_len; ++token_idx) {
+    const int virtual_block_idx = token_idx / block_size;
+    const int block_offset = token_idx % block_size;
+    const int physical_block_idx = block_table_seq[virtual_block_idx];
+
+    const size_t paged_offset =
+        (size_t)physical_block_idx * block_size * elements_per_token +
+        (size_t)block_offset * elements_per_token;
+
+    const size_t cont_offset =
+        (size_t)(output_offset + token_idx) * elements_per_token;
+
+    for (int elem_idx = tid; elem_idx < elements_per_token;
+         elem_idx += num_threads) {
+      contiguous[cont_offset + elem_idx] = paged_cache[paged_offset + elem_idx];
     }
-
-    const int* block_table_seq = block_table + batch_idx * max_num_blocks;
-
-    const int tid = threadIdx.x;
-    const int num_threads = blockDim.x;
-    const int elements_per_token = num_heads * head_dim;
-
-    for (int token_idx = 0; token_idx < seq_len; ++token_idx) {
-
-        const int virtual_block_idx = token_idx / block_size;
-        const int block_offset = token_idx % block_size;
-        const int physical_block_idx = block_table_seq[virtual_block_idx];
-
-        const size_t paged_offset = (size_t)physical_block_idx * block_size * elements_per_token
-                                  + (size_t)block_offset * elements_per_token;
-
-        const size_t cont_offset = (size_t)(output_offset + token_idx) * elements_per_token;
-
-        for (int elem_idx = tid; elem_idx < elements_per_token; elem_idx += num_threads) {
-            contiguous[cont_offset + elem_idx] = paged_cache[paged_offset + elem_idx];
-        }
-    }
+  }
 }
 
-torch::Tensor paged_to_contiguous(
-    torch::Tensor paged_cache,
-    torch::Tensor block_table,
-    torch::Tensor seq_lens
-) {
-    const int batch_size = block_table.size(0);
-    const int max_num_blocks = block_table.size(1);
-    const int block_size = paged_cache.size(1);
-    const int num_heads = paged_cache.size(2);
-    const int head_dim = paged_cache.size(3);
+torch::Tensor paged_to_contiguous(torch::Tensor paged_cache,
+                                  torch::Tensor block_table,
+                                  torch::Tensor seq_lens) {
+  const int batch_size = block_table.size(0);
+  const int max_num_blocks = block_table.size(1);
+  const int block_size = paged_cache.size(1);
+  const int num_heads = paged_cache.size(2);
+  const int head_dim = paged_cache.size(3);
 
-    int total_tokens = 0;
-    auto seq_lens_cpu = seq_lens.cpu();
-    for (int i = 0; i < batch_size; ++i) {
-        total_tokens += seq_lens_cpu[i].item<int>();
-    }
+  int total_tokens = 0;
+  auto seq_lens_cpu = seq_lens.cpu();
+  for (int i = 0; i < batch_size; ++i) {
+    total_tokens += seq_lens_cpu[i].item<int>();
+  }
 
-    auto contiguous = torch::zeros(
-        {total_tokens, num_heads, head_dim},
-        torch::TensorOptions().dtype(paged_cache.dtype()).device(paged_cache.device())
-    );
+  auto contiguous = torch::zeros({total_tokens, num_heads, head_dim},
+                                 torch::TensorOptions()
+                                     .dtype(paged_cache.dtype())
+                                     .device(paged_cache.device()));
 
-    const int threads = 256;
-    paged_to_contiguous_kernel<<<batch_size, threads>>>(
-        reinterpret_cast<const __half*>(paged_cache.data_ptr<at::Half>()),
-        block_table.data_ptr<int>(),
-        seq_lens.data_ptr<int>(),
-        reinterpret_cast<__half*>(contiguous.data_ptr<at::Half>()),
-        block_size,
-        num_heads,
-        head_dim,
-        max_num_blocks
-    );
+  const int threads = 256;
+  paged_to_contiguous_kernel<<<batch_size, threads>>>(
+      reinterpret_cast<const __half*>(paged_cache.data_ptr<at::Half>()),
+      block_table.data_ptr<int>(), seq_lens.data_ptr<int>(),
+      reinterpret_cast<__half*>(contiguous.data_ptr<at::Half>()), block_size,
+      num_heads, head_dim, max_num_blocks);
 
-    return contiguous;
+  return contiguous;
 }
 
 PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
-    m.def("paged_to_contiguous", &paged_to_contiguous, "Paged KV Cache to Contiguous");
+  m.def("paged_to_contiguous", &paged_to_contiguous,
+        "Paged KV Cache to Contiguous");
 }


### PR DESCRIPTION
Refs #126. Split from Draft PR #131.

## Scope
- Fifteen Flash-V100 C/CUDA/header files only.
- Exact mechanical sub-diff of d3b59af9c656413270e37cd55c0bf88e932a1c5d.
- clang-format, six local physical_offset_halfs typo corrections, and eight macro invocation terminators required to make clang-format idempotent.
- No algorithm, data layout, numerical contract, or performance behavior change intended.

## Validation
- Focused clang-format hook: passed.
- Focused typos hook: passed.
- Focused SPDX hook: skipped because the repository hook only accepts Python files.
- git diff --check and git show --check: passed.
- The exact Flash-V100 source delta previously completed an offline CUDA 12.8 SM70 extension build and clean extension import; no physical GPU run is claimed.