### PR TITLE
[CI/Build] Marlin formatter debt only

### DIFF
--- a/csrc/moe/marlin_moe_wna16/sm70_marlin_fp8_gemm.cu
+++ b/csrc/moe/marlin_moe_wna16/sm70_marlin_fp8_gemm.cu
@@ -35,22 +35,25 @@ class Sm70MoeFp8IteratorB {
   static int const kPackedMacroN = PackedMacroN_;
   static constexpr bool kUseMetadataVectorWords = UseMetadataVectorWords_;
   using Element = cutlass::half_t;
-  using Fragment = cutlass::Array<
-      Element, ThreadMap::Iterations::kCount * ThreadMap::kElementsPerAccess>;
-    static_assert(Shape::kN == 64 || Shape::kN == 128 || Shape::kN == 256,
-                "SM70 Marlin MoE FP8 IteratorB expects CTA_N in {64, 128, 256}.");
-  static_assert(ThreadMap::Iterations::kContiguous ==
-                    Shape::kN / kQuantTileN,
-                "SM70 Marlin MoE FP8 IteratorB expects one contiguous iteration per "
-                "64-column quant tile.");
+  using Fragment = cutlass::Array<Element, ThreadMap::Iterations::kCount *
+                                               ThreadMap::kElementsPerAccess>;
+  static_assert(
+      Shape::kN == 64 || Shape::kN == 128 || Shape::kN == 256,
+      "SM70 Marlin MoE FP8 IteratorB expects CTA_N in {64, 128, 256}.");
+  static_assert(
+      ThreadMap::Iterations::kContiguous == Shape::kN / kQuantTileN,
+      "SM70 Marlin MoE FP8 IteratorB expects one contiguous iteration per "
+      "64-column quant tile.");
   static_assert(ThreadMap::Delta::kContiguous == kQuantTileN,
                 "SM70 Marlin MoE FP8 IteratorB expects 64-column deltas.");
-  static_assert(ThreadMap::kElementsPerAccess == kFp8ValuesPerAccess,
-                "SM70 Marlin MoE FP8 IteratorB expects two packed FP8 words per "
-                "access.");
-  static_assert(ThreadMap::Iterations::kStrided >= 1,
-                "SM70 Marlin MoE U8-family IteratorB expects one or more strided "
-                "iterations.");
+  static_assert(
+      ThreadMap::kElementsPerAccess == kFp8ValuesPerAccess,
+      "SM70 Marlin MoE FP8 IteratorB expects two packed FP8 words per "
+      "access.");
+  static_assert(
+      ThreadMap::Iterations::kStrided >= 1,
+      "SM70 Marlin MoE U8-family IteratorB expects one or more strided "
+      "iterations.");
   static constexpr int kQweightWordStrideWords = kPackedMacroN / kQuantTileN;
 
   struct Params {
@@ -83,12 +86,11 @@ class Sm70MoeFp8IteratorB {
  public:
   CUTLASS_DEVICE
   Sm70MoeFp8IteratorB(Params const& params, uint32_t const* qweight,
-                       half const* scales, half const*, int thread_id,
-                       int expert, int k_offset, int n_offset)
+                      half const* scales, half const*, int thread_id,
+                      int expert, int k_offset, int n_offset)
       : qweight_(qweight),
-        scales_expert_base_(scales +
-                            (expert >= 0 ? expert : 0) *
-                                params.num_groups * params.size_n),
+        scales_expert_base_(scales + (expert >= 0 ? expert : 0) *
+                                         params.num_groups * params.size_n),
         params_(params),
         thread_offset_(ThreadMap::initial_offset(thread_id)),
         expert_(expert),
@@ -130,9 +132,7 @@ class Sm70MoeFp8IteratorB {
   }
 
   CUTLASS_DEVICE
-  int metadata_group_offset(int group) const {
-    return group * params_.size_n;
-  }
+  int metadata_group_offset(int group) const { return group * params_.size_n; }
 
   CUTLASS_DEVICE
   int scale_group(int logical_k) const {
@@ -155,8 +155,8 @@ class Sm70MoeFp8IteratorB {
   CUTLASS_DEVICE
   void cache_metadata_lane_vectors(int c, int group, int cache_n) const {
     int const metadata_offset = metadata_group_offset(group) + cache_n;
-    half2 const* scale_vec = reinterpret_cast<half2 const*>(
-        scales_expert_base_ + metadata_offset);
+    half2 const* scale_vec =
+        reinterpret_cast<half2 const*>(scales_expert_base_ + metadata_offset);
     half2* scale_cache = cached_scales_ + c * 4;
     scale_cache[0] = scale_vec[0];
     scale_cache[1] = scale_vec[1];
@@ -167,8 +167,8 @@ class Sm70MoeFp8IteratorB {
   CUTLASS_DEVICE
   void cache_metadata_vector_words(int c, int group, int cache_n) const {
     int const metadata_offset = metadata_group_offset(group) + cache_n;
-    uint4 const scale_words = *reinterpret_cast<uint4 const*>(
-        scales_expert_base_ + metadata_offset);
+    uint4 const scale_words =
+        *reinterpret_cast<uint4 const*>(scales_expert_base_ + metadata_offset);
     half2 const* scale_vec = reinterpret_cast<half2 const*>(&scale_words);
     half2* scale_cache = cached_scales_ + c * 4;
     scale_cache[0] = scale_vec[0];
@@ -181,9 +181,8 @@ class Sm70MoeFp8IteratorB {
   void cache_current_group_metadata(int group) const {
     CUTLASS_PRAGMA_UNROLL
     for (int c = 0; c < ThreadMap::Iterations::kContiguous; ++c) {
-      int const cache_n =
-          n_offset_ + thread_offset_.contiguous() +
-          c * ThreadMap::Delta::kContiguous;
+      int const cache_n = n_offset_ + thread_offset_.contiguous() +
+                          c * ThreadMap::Delta::kContiguous;
       if constexpr (kUseMetadataVectorWords) {
         cache_metadata_vector_words(c, group, cache_n);
       } else {
@@ -244,8 +243,9 @@ class Sm70MoeFp8IteratorB {
           frag_vec[3] = __hmul2(deq[1], scale_vec[3]);
         }
       } else {
-        static_assert(ThreadMap::Iterations::kContiguous == 1,
-                      "Unsupported SM70 Marlin MoE FP8 contiguous iteration count.");
+        static_assert(
+            ThreadMap::Iterations::kContiguous == 1,
+            "Unsupported SM70 Marlin MoE FP8 contiguous iteration count.");
         uint32_t const qword0 =
             load_qword_vector<1>(qweight_ + qweight_base_offset_);
         uint32_t const qword1 = load_qword_vector<1>(
@@ -267,9 +267,8 @@ class Sm70MoeFp8IteratorB {
       int const logical_n_base = n_offset_ + thread_offset_.contiguous();
       CUTLASS_PRAGMA_UNROLL
       for (int s = 0; s < ThreadMap::Iterations::kStrided; ++s) {
-        int const logical_k_s =
-            k_offset_ + thread_offset_.strided() +
-            s * ThreadMap::Delta::kStrided;
+        int const logical_k_s = k_offset_ + thread_offset_.strided() +
+                                s * ThreadMap::Delta::kStrided;
         if constexpr (kGroupSize != -1) {
           cache_current_group_metadata(scale_group(logical_k_s));
         }
@@ -277,10 +276,9 @@ class Sm70MoeFp8IteratorB {
             expert_qweight_base_offset() +
             qweight_offset_from_logical(params_, logical_k_s, logical_n_base);
         if constexpr (ThreadMap::Iterations::kContiguous == 4) {
-          uint4 const qwords0 =
-              load_qword_vector<4>(qweight_ + qweight_base_s);
-          uint4 const qwords1 = load_qword_vector<4>(
-              qweight_ + qweight_base_s + kQweightWordStrideWords);
+          uint4 const qwords0 = load_qword_vector<4>(qweight_ + qweight_base_s);
+          uint4 const qwords1 = load_qword_vector<4>(qweight_ + qweight_base_s +
+                                                     kQweightWordStrideWords);
           CUTLASS_PRAGMA_UNROLL
           for (int c = 0; c < ThreadMap::Iterations::kContiguous; ++c) {
             constexpr int kAccess = ThreadMap::kElementsPerAccess;
@@ -294,22 +292,17 @@ class Sm70MoeFp8IteratorB {
             half2* frag_vec = reinterpret_cast<half2*>(frag.data() + frag_base);
             marlin::dequant<half2, vllm::kFE4M3fn.id(), true>(
                 static_cast<int>(qword0), deq);
-            frag_vec[0] =
-                __hmul2(deq[0], scale_vec[0]);
-            frag_vec[1] =
-                __hmul2(deq[1], scale_vec[1]);
+            frag_vec[0] = __hmul2(deq[0], scale_vec[0]);
+            frag_vec[1] = __hmul2(deq[1], scale_vec[1]);
             marlin::dequant<half2, vllm::kFE4M3fn.id(), true>(
                 static_cast<int>(qword1), deq);
-            frag_vec[2] =
-                __hmul2(deq[0], scale_vec[2]);
-            frag_vec[3] =
-                __hmul2(deq[1], scale_vec[3]);
+            frag_vec[2] = __hmul2(deq[0], scale_vec[2]);
+            frag_vec[3] = __hmul2(deq[1], scale_vec[3]);
           }
         } else if constexpr (ThreadMap::Iterations::kContiguous == 2) {
-          uint2 const qwords0 =
-              load_qword_vector<2>(qweight_ + qweight_base_s);
-          uint2 const qwords1 = load_qword_vector<2>(
-              qweight_ + qweight_base_s + kQweightWordStrideWords);
+          uint2 const qwords0 = load_qword_vector<2>(qweight_ + qweight_base_s);
+          uint2 const qwords1 = load_qword_vector<2>(qweight_ + qweight_base_s +
+                                                     kQweightWordStrideWords);
           CUTLASS_PRAGMA_UNROLL
           for (int c = 0; c < ThreadMap::Iterations::kContiguous; ++c) {
             constexpr int kAccess = ThreadMap::kElementsPerAccess;
@@ -323,20 +316,17 @@ class Sm70MoeFp8IteratorB {
             half2* frag_vec = reinterpret_cast<half2*>(frag.data() + frag_base);
             marlin::dequant<half2, vllm::kFE4M3fn.id(), true>(
                 static_cast<int>(qword0), deq);
-            frag_vec[0] =
-                __hmul2(deq[0], scale_vec[0]);
-            frag_vec[1] =
-                __hmul2(deq[1], scale_vec[1]);
+            frag_vec[0] = __hmul2(deq[0], scale_vec[0]);
+            frag_vec[1] = __hmul2(deq[1], scale_vec[1]);
             marlin::dequant<half2, vllm::kFE4M3fn.id(), true>(
                 static_cast<int>(qword1), deq);
-            frag_vec[2] =
-                __hmul2(deq[0], scale_vec[2]);
-            frag_vec[3] =
-                __hmul2(deq[1], scale_vec[3]);
+            frag_vec[2] = __hmul2(deq[0], scale_vec[2]);
+            frag_vec[3] = __hmul2(deq[1], scale_vec[3]);
           }
         } else {
-          static_assert(ThreadMap::Iterations::kContiguous == 1,
-                        "Unsupported SM70 Marlin MoE FP8 contiguous iteration count.");
+          static_assert(
+              ThreadMap::Iterations::kContiguous == 1,
+              "Unsupported SM70 Marlin MoE FP8 contiguous iteration count.");
           uint32_t const qword0 =
               load_qword_vector<1>(qweight_ + qweight_base_s);
           uint32_t const qword1 = load_qword_vector<1>(
@@ -366,8 +356,7 @@ class Sm70MoeFp8IteratorB {
       return;
     }
 
-    if constexpr (kGroupSize != -1 &&
-                  ThreadMap::Iterations::kStrided == 1) {
+    if constexpr (kGroupSize != -1 && ThreadMap::Iterations::kStrided == 1) {
       int const first_logical_k = k_offset_ + thread_offset_.strided();
       cache_current_group_metadata(scale_group(first_logical_k));
     }
@@ -386,18 +375,17 @@ struct Sm70MoeFp8GemmSpec {
   using IteratorA = Sm70MoeGatherIteratorA<Shape, ThreadMap>;
 
   template <typename Shape, typename ThreadMap, int GroupSize, int PackedMacroN>
-  using IteratorB =
-      Sm70MoeFp8IteratorB<Shape, ThreadMap, GroupSize, PackedMacroN,
-                          UseMetadataVectorWords>;
+  using IteratorB = Sm70MoeFp8IteratorB<Shape, ThreadMap, GroupSize,
+                                        PackedMacroN, UseMetadataVectorWords>;
 };
 
-template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM,
-          int WarpN, int WarpK, int GroupSize, int PackedMacroN,
+template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM, int WarpN,
+          int WarpK, int GroupSize, int PackedMacroN,
           bool UseMetadataVectorWords = true>
 using Sm70MoeFp8GemmTraits =
-    Sm70MarlinMoeGemmTraits<
-        Sm70MoeFp8GemmSpec<UseMetadataVectorWords>, CtaM, CtaN, CtaK,
-        Warps, WarpM, WarpN, WarpK, GroupSize, PackedMacroN>;
+    Sm70MarlinMoeGemmTraits<Sm70MoeFp8GemmSpec<UseMetadataVectorWords>, CtaM,
+                            CtaN, CtaK, Warps, WarpM, WarpN, WarpK, GroupSize,
+                            PackedMacroN>;
 
 template <bool UseMetadataVectorWords = true>
 struct Sm70MoeFp8Launcher {
@@ -419,16 +407,16 @@ struct Sm70MoeFp8Launcher {
   int64_t size_k;
   int requested_split_k;
 
-  template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM,
-          int WarpN, int WarpK, int GroupSize, int PackedMacroN>
+  template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM, int WarpN,
+            int WarpK, int GroupSize, int PackedMacroN>
   torch::Tensor operator()() const {
-    using Traits = Sm70MoeFp8GemmTraits<CtaM, CtaN, CtaK, Warps, WarpM,
-                                        WarpN, WarpK, GroupSize, PackedMacroN,
-                                        UseMetadataVectorWords>;
+    using Traits =
+        Sm70MoeFp8GemmTraits<CtaM, CtaN, CtaK, Warps, WarpM, WarpN, WarpK,
+                             GroupSize, PackedMacroN, UseMetadataVectorWords>;
     return launch_sm70_marlin_moe_gemm<Traits>(
         a, c, b_q_weight, b_scales, b_zeros, global_scale, sorted_token_ids,
-        expert_ids, num_tokens_past_padded, topk_weights, moe_block_size,
-        top_k, mul_topk_weights, size_m, size_n, size_k, requested_split_k);
+        expert_ids, num_tokens_past_padded, topk_weights, moe_block_size, top_k,
+        mul_topk_weights, size_m, size_n, size_k, requested_split_k);
   }
 };
 
@@ -446,9 +434,10 @@ torch::Tensor sm70_marlin_fp8_gemm(
   auto const params = sm70_marlin_moe_auto_stage_params(
       "fp8_e4m3", group_size, moe_block_size, top_k, size_m, size_n, size_k);
   Sm70CtaGeometry const geometry = params.geometry;
-  validate_sm70_marlin_moe_stage_cta_geometry_supported("SM70 Marlin MoE fp8_e4m3", geometry);
-  validate_sm70_marlin_moe_stage_cta_n_alignment("SM70 Marlin MoE fp8_e4m3", geometry,
-                                        size_n);
+  validate_sm70_marlin_moe_stage_cta_geometry_supported(
+      "SM70 Marlin MoE fp8_e4m3", geometry);
+  validate_sm70_marlin_moe_stage_cta_n_alignment("SM70 Marlin MoE fp8_e4m3",
+                                                 geometry, size_n);
   TORCH_CHECK(size_k % geometry.cta_k == 0,
               "SM70 Marlin MoE fp8_e4m3 requires K divisible by CTA_K=",
               geometry.cta_k, ". Got K=", size_k, ".");
@@ -457,17 +446,45 @@ torch::Tensor sm70_marlin_fp8_gemm(
   auto empty_float = torch::empty(
       {0}, torch::TensorOptions().dtype(at::kFloat).device(a.device()));
   if (params.use_metadata_vector_words) {
-    Sm70MoeFp8Launcher<true> const launcher{
-        a, c, b_q_weight, b_scales, empty_half, empty_float, sorted_token_ids,
-        expert_ids, num_tokens_past_padded, topk_weights, moe_block_size, top_k,
-        mul_topk_weights, size_m, size_n, size_k, params.requested_split_k};
-    return dispatch_sm70_marlin_moe_fp8_geometry(launcher, geometry, params.packed_macro_n, group_size);
+    Sm70MoeFp8Launcher<true> const launcher{a,
+                                            c,
+                                            b_q_weight,
+                                            b_scales,
+                                            empty_half,
+                                            empty_float,
+                                            sorted_token_ids,
+                                            expert_ids,
+                                            num_tokens_past_padded,
+                                            topk_weights,
+                                            moe_block_size,
+                                            top_k,
+                                            mul_topk_weights,
+                                            size_m,
+                                            size_n,
+                                            size_k,
+                                            params.requested_split_k};
+    return dispatch_sm70_marlin_moe_fp8_geometry(
+        launcher, geometry, params.packed_macro_n, group_size);
   }
-  Sm70MoeFp8Launcher<false> const launcher{
-      a, c, b_q_weight, b_scales, empty_half, empty_float, sorted_token_ids,
-      expert_ids, num_tokens_past_padded, topk_weights, moe_block_size, top_k,
-      mul_topk_weights, size_m, size_n, size_k, params.requested_split_k};
-  return dispatch_sm70_marlin_moe_fp8_geometry(launcher, geometry, params.packed_macro_n, group_size);
+  Sm70MoeFp8Launcher<false> const launcher{a,
+                                           c,
+                                           b_q_weight,
+                                           b_scales,
+                                           empty_half,
+                                           empty_float,
+                                           sorted_token_ids,
+                                           expert_ids,
+                                           num_tokens_past_padded,
+                                           topk_weights,
+                                           moe_block_size,
+                                           top_k,
+                                           mul_topk_weights,
+                                           size_m,
+                                           size_n,
+                                           size_k,
+                                           params.requested_split_k};
+  return dispatch_sm70_marlin_moe_fp8_geometry(
+      launcher, geometry, params.packed_macro_n, group_size);
 }
 
 }  // namespace marlin_moe_wna16

--- a/csrc/moe/marlin_moe_wna16/sm70_marlin_gemm.cuh
+++ b/csrc/moe/marlin_moe_wna16/sm70_marlin_gemm.cuh
@@ -27,22 +27,22 @@
 
 namespace marlin_moe_wna16 {
 
-using marlin::sm70::Sm70CtaGeometry;
-using marlin::sm70::Sm70MarlinAutoParams;
-using marlin::sm70::Sm70MarlinMoeAutoParamsContext;
-using marlin::sm70::Sm70SplitKPartition;
-using marlin::sm70::Sm70MarlinMmaPipelined;
-using marlin::sm70::Sm70WarpShape;
 using marlin::sm70::configure_sm70_dynamic_smem;
 using marlin::sm70::kQuantTileK;
 using marlin::sm70::kQuantTileN;
+using marlin::sm70::sm70_active_split_k;
 using marlin::sm70::sm70_marlin_any_auto_env_is_set;
 using marlin::sm70::sm70_marlin_auto_packed_macro_n;
 using marlin::sm70::sm70_marlin_auto_params_from_env;
 using marlin::sm70::sm70_marlin_cta_geometry_is_supported;
 using marlin::sm70::sm70_marlin_default_auto_params;
-using marlin::sm70::sm70_active_split_k;
 using marlin::sm70::sm70_splitk_partition;
+using marlin::sm70::Sm70CtaGeometry;
+using marlin::sm70::Sm70MarlinAutoParams;
+using marlin::sm70::Sm70MarlinMmaPipelined;
+using marlin::sm70::Sm70MarlinMoeAutoParamsContext;
+using marlin::sm70::Sm70SplitKPartition;
+using marlin::sm70::Sm70WarpShape;
 using marlin::sm70::validate_sm70_marlin_auto_params;
 
 inline constexpr char const* kSupportedSm70MarlinMoeCtaGeometries =
@@ -55,9 +55,9 @@ inline constexpr char const* kSupportedSm70MarlinMoeCtaGeometries =
     "geometries are dense-only.";
 
 inline bool sm70_marlin_moe_auto_env_is_set() {
-  return sm70_marlin_any_auto_env_is_set(
-      "SM70_MARLIN_MOE_CTA_GEOMETRY", "SM70_MARLIN_MOE_SPLIT_K",
-      "SM70_MARLIN_MOE_METADATA_CACHE");
+  return sm70_marlin_any_auto_env_is_set("SM70_MARLIN_MOE_CTA_GEOMETRY",
+                                         "SM70_MARLIN_MOE_SPLIT_K",
+                                         "SM70_MARLIN_MOE_METADATA_CACHE");
 }
 
 inline Sm70MarlinAutoParams sm70_marlin_moe_auto_params_from_env(
@@ -68,16 +68,14 @@ inline Sm70MarlinAutoParams sm70_marlin_moe_auto_params_from_env(
 }
 
 inline bool sm70_marlin_moe_try_select_quanttrio_qwen3_6_35b_a3b_awq_params(
-    Sm70MarlinMoeAutoParamsContext const& ctx,
-    Sm70MarlinAutoParams& params) {
+    Sm70MarlinMoeAutoParamsContext const& ctx, Sm70MarlinAutoParams& params) {
   if (ctx.quant_format == nullptr ||
-      std::strcmp(ctx.quant_format, "uint4") != 0 ||
-      ctx.group_size != 128 || ctx.size_m <= 0) {
+      std::strcmp(ctx.quant_format, "uint4") != 0 || ctx.group_size != 128 ||
+      ctx.size_m <= 0) {
     return false;
   }
 
-  auto const set_params = [&](Sm70CtaGeometry geometry,
-                              int requested_split_k,
+  auto const set_params = [&](Sm70CtaGeometry geometry, int requested_split_k,
                               bool use_metadata_vector_words) {
     params = {geometry, requested_split_k, use_metadata_vector_words,
               ctx.packed_macro_n};
@@ -152,8 +150,7 @@ inline bool sm70_marlin_moe_try_select_quanttrio_qwen3_6_35b_a3b_awq_params(
       }
       return set_params({64, 128, 32, 8, 32, 32, 32}, 1, false);
     }
-    if (ctx.moe_block_size == 64 &&
-        (ctx.size_n == 256 || ctx.size_n == 1024)) {
+    if (ctx.moe_block_size == 64 && (ctx.size_n == 256 || ctx.size_n == 1024)) {
       return set_params({64, 256, 32, 4, 64, 64, 32}, 1, false);
     }
   }
@@ -162,16 +159,14 @@ inline bool sm70_marlin_moe_try_select_quanttrio_qwen3_6_35b_a3b_awq_params(
 }
 
 inline bool sm70_marlin_moe_try_select_quanttrio_qwen3_5_122b_a10b_awq_params(
-    Sm70MarlinMoeAutoParamsContext const& ctx,
-    Sm70MarlinAutoParams& params) {
+    Sm70MarlinMoeAutoParamsContext const& ctx, Sm70MarlinAutoParams& params) {
   if (ctx.quant_format == nullptr ||
-      std::strcmp(ctx.quant_format, "uint4") != 0 ||
-      ctx.group_size != 128 || ctx.size_m <= 0) {
+      std::strcmp(ctx.quant_format, "uint4") != 0 || ctx.group_size != 128 ||
+      ctx.size_m <= 0) {
     return false;
   }
 
-  auto const set_params = [&](Sm70CtaGeometry geometry,
-                              int requested_split_k,
+  auto const set_params = [&](Sm70CtaGeometry geometry, int requested_split_k,
                               bool use_metadata_vector_words) {
     params = {geometry, requested_split_k, use_metadata_vector_words,
               ctx.packed_macro_n};
@@ -278,16 +273,14 @@ inline bool sm70_marlin_moe_try_select_quanttrio_qwen3_5_122b_a10b_awq_params(
 }
 
 inline bool sm70_marlin_moe_try_select_quanttrio_minimax_m2_7_awq_params(
-    Sm70MarlinMoeAutoParamsContext const& ctx,
-    Sm70MarlinAutoParams& params) {
+    Sm70MarlinMoeAutoParamsContext const& ctx, Sm70MarlinAutoParams& params) {
   if (ctx.quant_format == nullptr ||
-      std::strcmp(ctx.quant_format, "uint4") != 0 ||
-      ctx.group_size != 128 || ctx.size_m <= 0) {
+      std::strcmp(ctx.quant_format, "uint4") != 0 || ctx.group_size != 128 ||
+      ctx.size_m <= 0) {
     return false;
   }
 
-  auto const set_params = [&](Sm70CtaGeometry geometry,
-                              int requested_split_k,
+  auto const set_params = [&](Sm70CtaGeometry geometry, int requested_split_k,
                               bool use_metadata_vector_words) {
     params = {geometry, requested_split_k, use_metadata_vector_words,
               ctx.packed_macro_n};
@@ -378,17 +371,16 @@ inline bool sm70_marlin_moe_try_select_quanttrio_minimax_m2_7_awq_params(
   return false;
 }
 
-inline bool sm70_marlin_moe_try_select_cyankiwi_qwen3_5_122b_a10b_awq_8bit_params(
-    Sm70MarlinMoeAutoParamsContext const& ctx,
-    Sm70MarlinAutoParams& params) {
+inline bool
+sm70_marlin_moe_try_select_cyankiwi_qwen3_5_122b_a10b_awq_8bit_params(
+    Sm70MarlinMoeAutoParamsContext const& ctx, Sm70MarlinAutoParams& params) {
   if (ctx.quant_format == nullptr ||
-      std::strcmp(ctx.quant_format, "uint8b128") != 0 ||
-      ctx.group_size != 32 || ctx.size_m <= 0) {
+      std::strcmp(ctx.quant_format, "uint8b128") != 0 || ctx.group_size != 32 ||
+      ctx.size_m <= 0) {
     return false;
   }
 
-  auto const set_params = [&](Sm70CtaGeometry geometry,
-                              int requested_split_k,
+  auto const set_params = [&](Sm70CtaGeometry geometry, int requested_split_k,
                               bool use_metadata_vector_words) {
     params = {geometry, requested_split_k, use_metadata_vector_words,
               ctx.packed_macro_n};
@@ -400,57 +392,57 @@ inline bool sm70_marlin_moe_try_select_cyankiwi_qwen3_5_122b_a10b_awq_8bit_param
     // top_k=1
     if (ctx.top_k == 1 && ctx.size_n == 3072) {
       if (ctx.size_k == 128) {
-          if (ctx.size_m <= 8) {
-            return set_params({32,128,32,4,32,32,32}, 1, true);
-          }
-          if (ctx.size_m <= 256) {
-            return set_params({32,256,32,4,32,64,32}, 1, true);
-          }
-          return set_params({32,256,32,4,32,64,32}, 1, true);
+        if (ctx.size_m <= 8) {
+          return set_params({32, 128, 32, 4, 32, 32, 32}, 1, true);
+        }
+        if (ctx.size_m <= 256) {
+          return set_params({32, 256, 32, 4, 32, 64, 32}, 1, true);
+        }
+        return set_params({32, 256, 32, 4, 32, 64, 32}, 1, true);
       }
     }
     if (ctx.top_k == 1 && ctx.size_n == 3072) {
       if (ctx.size_k == 256) {
-        return set_params({32,256,32,4,32,64,32}, 1, true);
+        return set_params({32, 256, 32, 4, 32, 64, 32}, 1, true);
       }
     }
     if (ctx.top_k == 1 && ctx.size_n == 3072) {
       if (ctx.size_k == 1024) {
-          if (ctx.size_m <= 8) {
-            return set_params({32,128,32,4,32,32,32}, 1, true);
-          }
-          return set_params({32,256,32,4,32,64,32}, 1, true);
+        if (ctx.size_m <= 8) {
+          return set_params({32, 128, 32, 4, 32, 32, 32}, 1, true);
+        }
+        return set_params({32, 256, 32, 4, 32, 64, 32}, 1, true);
       }
     }
     // top_k=8
     if (ctx.top_k == 8 && ctx.size_k == 3072) {
       if (ctx.size_n == 256) {
-          if (ctx.size_m <= 1) {
-            return set_params({32,128,32,4,32,32,32}, 8, true);
-          }
-          if (ctx.size_m <= 32) {
-            return set_params({32,128,128,8,32,64,32}, 1, true);
-          }
-          return set_params({32,128,64,8,32,32,32}, 1, true);
+        if (ctx.size_m <= 1) {
+          return set_params({32, 128, 32, 4, 32, 32, 32}, 8, true);
+        }
+        if (ctx.size_m <= 32) {
+          return set_params({32, 128, 128, 8, 32, 64, 32}, 1, true);
+        }
+        return set_params({32, 128, 64, 8, 32, 32, 32}, 1, true);
       }
     }
     if (ctx.top_k == 8 && ctx.size_k == 3072) {
       if (ctx.size_n == 512) {
-          if (ctx.size_m <= 1) {
-            return set_params({32,256,32,4,32,64,32}, 8, true);
-          }
-          if (ctx.size_m <= 32) {
-            return set_params({32,256,64,8,32,64,32}, 1, true);
-          }
-          return set_params({32,256,32,4,32,64,32}, 1, true);
+        if (ctx.size_m <= 1) {
+          return set_params({32, 256, 32, 4, 32, 64, 32}, 8, true);
+        }
+        if (ctx.size_m <= 32) {
+          return set_params({32, 256, 64, 8, 32, 64, 32}, 1, true);
+        }
+        return set_params({32, 256, 32, 4, 32, 64, 32}, 1, true);
       }
     }
     if (ctx.top_k == 8 && ctx.size_k == 3072) {
       if (ctx.size_n == 2048) {
-          if (ctx.size_m <= 1) {
-            return set_params({32,256,32,4,32,64,32}, 2, true);
-          }
-          return set_params({32,256,32,4,32,64,32}, 1, true);
+        if (ctx.size_m <= 1) {
+          return set_params({32, 256, 32, 4, 32, 64, 32}, 2, true);
+        }
+        return set_params({32, 256, 32, 4, 32, 64, 32}, 1, true);
       }
     }
   }
@@ -460,13 +452,13 @@ inline bool sm70_marlin_moe_try_select_cyankiwi_qwen3_5_122b_a10b_awq_8bit_param
     // top_k=1
     if (ctx.top_k == 1 && ctx.size_n == 3072) {
       if (ctx.size_k == 1024) {
-        return set_params({32,256,32,4,32,64,32}, 1, true);
+        return set_params({32, 256, 32, 4, 32, 64, 32}, 1, true);
       }
     }
     // top_k=8
     if (ctx.top_k == 8 && ctx.size_k == 3072) {
       if (ctx.size_n == 2048) {
-        return set_params({32,256,32,4,32,64,32}, 1, true);
+        return set_params({32, 256, 32, 4, 32, 64, 32}, 1, true);
       }
     }
   }
@@ -476,13 +468,13 @@ inline bool sm70_marlin_moe_try_select_cyankiwi_qwen3_5_122b_a10b_awq_8bit_param
     // top_k=1
     if (ctx.top_k == 1 && ctx.size_n == 3072) {
       if (ctx.size_k == 1024) {
-        return set_params({32,256,32,4,32,64,32}, 1, true);
+        return set_params({32, 256, 32, 4, 32, 64, 32}, 1, true);
       }
     }
     // top_k=8
     if (ctx.top_k == 8 && ctx.size_k == 3072) {
       if (ctx.size_n == 2048) {
-        return set_params({32,256,32,4,32,64,32}, 1, true);
+        return set_params({32, 256, 32, 4, 32, 64, 32}, 1, true);
       }
     }
   }
@@ -492,33 +484,33 @@ inline bool sm70_marlin_moe_try_select_cyankiwi_qwen3_5_122b_a10b_awq_8bit_param
     // top_k=1
     if (ctx.top_k == 1 && ctx.size_n == 3072) {
       if (ctx.size_k == 128) {
-        return set_params({64,256,32,4,64,64,32}, 1, false);
+        return set_params({64, 256, 32, 4, 64, 64, 32}, 1, false);
       }
     }
     if (ctx.top_k == 1 && ctx.size_n == 3072) {
       if (ctx.size_k == 256) {
-        return set_params({64,256,32,4,64,64,32}, 1, false);
+        return set_params({64, 256, 32, 4, 64, 64, 32}, 1, false);
       }
     }
     if (ctx.top_k == 1 && ctx.size_n == 3072) {
       if (ctx.size_k == 1024) {
-        return set_params({64,256,32,4,64,64,32}, 1, false);
+        return set_params({64, 256, 32, 4, 64, 64, 32}, 1, false);
       }
     }
     // top_k=8
     if (ctx.top_k == 8 && ctx.size_k == 3072) {
       if (ctx.size_n == 256) {
-        return set_params({64,256,32,4,64,64,32}, 1, false);
+        return set_params({64, 256, 32, 4, 64, 64, 32}, 1, false);
       }
     }
     if (ctx.top_k == 8 && ctx.size_k == 3072) {
       if (ctx.size_n == 512) {
-        return set_params({64,256,32,4,64,64,32}, 1, false);
+        return set_params({64, 256, 32, 4, 64, 64, 32}, 1, false);
       }
     }
     if (ctx.top_k == 8 && ctx.size_k == 3072) {
       if (ctx.size_n == 2048) {
-        return set_params({64,256,32,4,64,64,32}, 1, false);
+        return set_params({64, 256, 32, 4, 64, 64, 32}, 1, false);
       }
     }
   }
@@ -527,16 +519,14 @@ inline bool sm70_marlin_moe_try_select_cyankiwi_qwen3_5_122b_a10b_awq_8bit_param
 }
 
 inline bool sm70_marlin_moe_try_select_cyankiwi_qwen3_6_35b_a3b_awq_4bit_params(
-    Sm70MarlinMoeAutoParamsContext const& ctx,
-    Sm70MarlinAutoParams& params) {
+    Sm70MarlinMoeAutoParamsContext const& ctx, Sm70MarlinAutoParams& params) {
   if (ctx.quant_format == nullptr ||
-      std::strcmp(ctx.quant_format, "uint4") != 0 ||
-      ctx.group_size != 32 || ctx.size_m <= 0) {
+      std::strcmp(ctx.quant_format, "uint4") != 0 || ctx.group_size != 32 ||
+      ctx.size_m <= 0) {
     return false;
   }
 
-  auto const set_params = [&](Sm70CtaGeometry geometry,
-                              int requested_split_k,
+  auto const set_params = [&](Sm70CtaGeometry geometry, int requested_split_k,
                               bool use_metadata_vector_words) {
     params = {geometry, requested_split_k, use_metadata_vector_words,
               ctx.packed_macro_n};
@@ -548,63 +538,63 @@ inline bool sm70_marlin_moe_try_select_cyankiwi_qwen3_6_35b_a3b_awq_4bit_params(
     // top_k=1
     if (ctx.top_k == 1 && ctx.size_n == 2048) {
       if (ctx.size_k == 64) {
-          if (ctx.size_m <= 8) {
-            return set_params({32,64,32,4,32,32,16}, 1, false);
-          }
-          if (ctx.size_m <= 256) {
-            return set_params({32,256,32,4,32,64,32}, 1, true);
-          }
-          return set_params({32,256,32,4,32,64,32}, 1, true);
+        if (ctx.size_m <= 8) {
+          return set_params({32, 64, 32, 4, 32, 32, 16}, 1, false);
+        }
+        if (ctx.size_m <= 256) {
+          return set_params({32, 256, 32, 4, 32, 64, 32}, 1, true);
+        }
+        return set_params({32, 256, 32, 4, 32, 64, 32}, 1, true);
       }
     }
     if (ctx.top_k == 1 && ctx.size_n == 2048) {
       if (ctx.size_k == 128) {
-          if (ctx.size_m <= 8) {
-            return set_params({32,64,32,4,32,32,16}, 1, true);
-          }
-          if (ctx.size_m <= 256) {
-            return set_params({32,256,32,4,32,64,32}, 1, true);
-          }
-          return set_params({32,256,32,4,32,64,32}, 1, true);
+        if (ctx.size_m <= 8) {
+          return set_params({32, 64, 32, 4, 32, 32, 16}, 1, true);
+        }
+        if (ctx.size_m <= 256) {
+          return set_params({32, 256, 32, 4, 32, 64, 32}, 1, true);
+        }
+        return set_params({32, 256, 32, 4, 32, 64, 32}, 1, true);
       }
     }
     if (ctx.top_k == 1 && ctx.size_n == 2048) {
       if (ctx.size_k == 512) {
-          if (ctx.size_m <= 8) {
-            return set_params({32,128,32,4,32,64,16}, 1, true);
-          }
-          return set_params({32,256,32,4,32,64,32}, 1, true);
+        if (ctx.size_m <= 8) {
+          return set_params({32, 128, 32, 4, 32, 64, 16}, 1, true);
+        }
+        return set_params({32, 256, 32, 4, 32, 64, 32}, 1, true);
       }
     }
     // top_k=8
     if (ctx.top_k == 8 && ctx.size_k == 2048) {
       if (ctx.size_n == 128) {
-          if (ctx.size_m <= 1) {
-            return set_params({32,128,32,4,32,32,32}, 8, false);
-          }
-          if (ctx.size_m <= 32) {
-            return set_params({32,128,64,8,32,64,16}, 2, false);
-          }
-          return set_params({32,128,128,8,32,64,32}, 1, true);
+        if (ctx.size_m <= 1) {
+          return set_params({32, 128, 32, 4, 32, 32, 32}, 8, false);
+        }
+        if (ctx.size_m <= 32) {
+          return set_params({32, 128, 64, 8, 32, 64, 16}, 2, false);
+        }
+        return set_params({32, 128, 128, 8, 32, 64, 32}, 1, true);
       }
     }
     if (ctx.top_k == 8 && ctx.size_k == 2048) {
       if (ctx.size_n == 256) {
-          if (ctx.size_m <= 1) {
-            return set_params({32,128,32,4,32,32,32}, 8, true);
-          }
-          if (ctx.size_m <= 32) {
-            return set_params({32,128,128,8,32,64,32}, 1, true);
-          }
-          return set_params({32,256,64,8,32,64,32}, 1, false);
+        if (ctx.size_m <= 1) {
+          return set_params({32, 128, 32, 4, 32, 32, 32}, 8, true);
+        }
+        if (ctx.size_m <= 32) {
+          return set_params({32, 128, 128, 8, 32, 64, 32}, 1, true);
+        }
+        return set_params({32, 256, 64, 8, 32, 64, 32}, 1, false);
       }
     }
     if (ctx.top_k == 8 && ctx.size_k == 2048) {
       if (ctx.size_n == 1024) {
-          if (ctx.size_m <= 1) {
-            return set_params({32,256,32,4,32,64,32}, 4, true);
-          }
-          return set_params({32,256,32,4,32,64,32}, 1, true);
+        if (ctx.size_m <= 1) {
+          return set_params({32, 256, 32, 4, 32, 64, 32}, 4, true);
+        }
+        return set_params({32, 256, 32, 4, 32, 64, 32}, 1, true);
       }
     }
   }
@@ -614,16 +604,16 @@ inline bool sm70_marlin_moe_try_select_cyankiwi_qwen3_6_35b_a3b_awq_4bit_params(
     // top_k=1
     if (ctx.top_k == 1 && ctx.size_n == 2048) {
       if (ctx.size_k == 512) {
-        return set_params({32,256,32,4,32,64,32}, 1, true);
+        return set_params({32, 256, 32, 4, 32, 64, 32}, 1, true);
       }
     }
     // top_k=8
     if (ctx.top_k == 8 && ctx.size_k == 2048) {
       if (ctx.size_n == 1024) {
-          if (ctx.size_m <= 32) {
-            return set_params({32,256,64,8,32,64,32}, 1, false);
-          }
-          return set_params({32,256,32,4,32,64,32}, 1, true);
+        if (ctx.size_m <= 32) {
+          return set_params({32, 256, 64, 8, 32, 64, 32}, 1, false);
+        }
+        return set_params({32, 256, 32, 4, 32, 64, 32}, 1, true);
       }
     }
   }
@@ -633,13 +623,13 @@ inline bool sm70_marlin_moe_try_select_cyankiwi_qwen3_6_35b_a3b_awq_4bit_params(
     // top_k=1
     if (ctx.top_k == 1 && ctx.size_n == 2048) {
       if (ctx.size_k == 512) {
-        return set_params({32,256,32,4,32,64,32}, 1, true);
+        return set_params({32, 256, 32, 4, 32, 64, 32}, 1, true);
       }
     }
     // top_k=8
     if (ctx.top_k == 8 && ctx.size_k == 2048) {
       if (ctx.size_n == 1024) {
-        return set_params({32,256,64,8,32,64,32}, 1, true);
+        return set_params({32, 256, 64, 8, 32, 64, 32}, 1, true);
       }
     }
   }
@@ -649,36 +639,36 @@ inline bool sm70_marlin_moe_try_select_cyankiwi_qwen3_6_35b_a3b_awq_4bit_params(
     // top_k=1
     if (ctx.top_k == 1 && ctx.size_n == 2048) {
       if (ctx.size_k == 64) {
-        return set_params({64,256,32,4,64,64,32}, 1, false);
+        return set_params({64, 256, 32, 4, 64, 64, 32}, 1, false);
       }
     }
     if (ctx.top_k == 1 && ctx.size_n == 2048) {
       if (ctx.size_k == 128) {
-        return set_params({64,256,32,4,64,64,32}, 1, false);
+        return set_params({64, 256, 32, 4, 64, 64, 32}, 1, false);
       }
     }
     if (ctx.top_k == 1 && ctx.size_n == 2048) {
       if (ctx.size_k == 512) {
-        return set_params({64,256,32,4,64,64,32}, 1, false);
+        return set_params({64, 256, 32, 4, 64, 64, 32}, 1, false);
       }
     }
     // top_k=8
     if (ctx.top_k == 8 && ctx.size_k == 2048) {
       if (ctx.size_n == 128) {
-          if (ctx.size_m <= 2048) {
-            return set_params({64,128,32,4,64,64,16}, 1, false);
-          }
-          return set_params({64,128,32,8,32,32,32}, 1, true);
+        if (ctx.size_m <= 2048) {
+          return set_params({64, 128, 32, 4, 64, 64, 16}, 1, false);
+        }
+        return set_params({64, 128, 32, 8, 32, 32, 32}, 1, true);
       }
     }
     if (ctx.top_k == 8 && ctx.size_k == 2048) {
       if (ctx.size_n == 256) {
-        return set_params({64,256,32,4,64,64,32}, 1, false);
+        return set_params({64, 256, 32, 4, 64, 64, 32}, 1, false);
       }
     }
     if (ctx.top_k == 8 && ctx.size_k == 2048) {
       if (ctx.size_n == 1024) {
-        return set_params({64,256,32,4,64,64,32}, 1, false);
+        return set_params({64, 256, 32, 4, 64, 64, 32}, 1, false);
       }
     }
   }
@@ -686,17 +676,16 @@ inline bool sm70_marlin_moe_try_select_cyankiwi_qwen3_6_35b_a3b_awq_4bit_params(
   return false;
 }
 
-inline bool sm70_marlin_moe_try_select_cyankiwi_qwen3_6_35b_a3b_awq_nvfp4_params(
-    Sm70MarlinMoeAutoParamsContext const& ctx,
-    Sm70MarlinAutoParams& params) {
+inline bool
+sm70_marlin_moe_try_select_cyankiwi_qwen3_6_35b_a3b_awq_nvfp4_params(
+    Sm70MarlinMoeAutoParamsContext const& ctx, Sm70MarlinAutoParams& params) {
   if (ctx.quant_format == nullptr ||
-      std::strcmp(ctx.quant_format, "nvfp4") != 0 ||
-      ctx.group_size != 16 || ctx.size_m <= 0) {
+      std::strcmp(ctx.quant_format, "nvfp4") != 0 || ctx.group_size != 16 ||
+      ctx.size_m <= 0) {
     return false;
   }
 
-  auto const set_params = [&](Sm70CtaGeometry geometry,
-                              int requested_split_k,
+  auto const set_params = [&](Sm70CtaGeometry geometry, int requested_split_k,
                               bool use_metadata_vector_words) {
     params = {geometry, requested_split_k, use_metadata_vector_words,
               ctx.packed_macro_n};
@@ -708,63 +697,63 @@ inline bool sm70_marlin_moe_try_select_cyankiwi_qwen3_6_35b_a3b_awq_nvfp4_params
     // top_k=1
     if (ctx.top_k == 1 && ctx.size_n == 2048) {
       if (ctx.size_k == 64) {
-          if (ctx.size_m <= 8) {
-            return set_params({32,128,64,4,32,64,32}, 1, true);
-          }
-          if (ctx.size_m <= 256) {
-            return set_params({32,128,32,4,32,32,32}, 1, true);
-          }
-          return set_params({32,128,32,4,32,32,32}, 1, true);
+        if (ctx.size_m <= 8) {
+          return set_params({32, 128, 64, 4, 32, 64, 32}, 1, true);
+        }
+        if (ctx.size_m <= 256) {
+          return set_params({32, 128, 32, 4, 32, 32, 32}, 1, true);
+        }
+        return set_params({32, 128, 32, 4, 32, 32, 32}, 1, true);
       }
     }
     if (ctx.top_k == 1 && ctx.size_n == 2048) {
       if (ctx.size_k == 128) {
-          if (ctx.size_m <= 8) {
-            return set_params({32,128,32,4,32,32,32}, 1, false);
-          }
-          if (ctx.size_m <= 256) {
-            return set_params({32,128,32,4,32,32,32}, 1, true);
-          }
-          return set_params({32,128,32,4,32,32,32}, 1, false);
+        if (ctx.size_m <= 8) {
+          return set_params({32, 128, 32, 4, 32, 32, 32}, 1, false);
+        }
+        if (ctx.size_m <= 256) {
+          return set_params({32, 128, 32, 4, 32, 32, 32}, 1, true);
+        }
+        return set_params({32, 128, 32, 4, 32, 32, 32}, 1, false);
       }
     }
     if (ctx.top_k == 1 && ctx.size_n == 2048) {
       if (ctx.size_k == 512) {
-          if (ctx.size_m <= 8) {
-            return set_params({32,128,64,4,32,64,32}, 1, true);
-          }
-          return set_params({32,128,32,4,32,32,32}, 1, true);
+        if (ctx.size_m <= 8) {
+          return set_params({32, 128, 64, 4, 32, 64, 32}, 1, true);
+        }
+        return set_params({32, 128, 32, 4, 32, 32, 32}, 1, true);
       }
     }
     // top_k=8
     if (ctx.top_k == 8 && ctx.size_k == 2048) {
       if (ctx.size_n == 128) {
-          if (ctx.size_m <= 1) {
-            return set_params({32,64,32,4,32,32,16}, 8, true);
-          }
-          if (ctx.size_m <= 32) {
-            return set_params({32,128,64,8,32,32,32}, 4, true);
-          }
-          return set_params({32,128,128,8,32,64,32}, 1, true);
+        if (ctx.size_m <= 1) {
+          return set_params({32, 64, 32, 4, 32, 32, 16}, 8, true);
+        }
+        if (ctx.size_m <= 32) {
+          return set_params({32, 128, 64, 8, 32, 32, 32}, 4, true);
+        }
+        return set_params({32, 128, 128, 8, 32, 64, 32}, 1, true);
       }
     }
     if (ctx.top_k == 8 && ctx.size_k == 2048) {
       if (ctx.size_n == 256) {
-          if (ctx.size_m <= 1) {
-            return set_params({32,128,32,4,32,32,32}, 8, true);
-          }
-          if (ctx.size_m <= 32) {
-            return set_params({32,128,128,8,32,64,32}, 1, true);
-          }
-          return set_params({32,256,64,8,32,64,32}, 1, true);
+        if (ctx.size_m <= 1) {
+          return set_params({32, 128, 32, 4, 32, 32, 32}, 8, true);
+        }
+        if (ctx.size_m <= 32) {
+          return set_params({32, 128, 128, 8, 32, 64, 32}, 1, true);
+        }
+        return set_params({32, 256, 64, 8, 32, 64, 32}, 1, true);
       }
     }
     if (ctx.top_k == 8 && ctx.size_k == 2048) {
       if (ctx.size_n == 1024) {
-          if (ctx.size_m <= 1) {
-            return set_params({32,128,32,4,32,32,32}, 4, false);
-          }
-          return set_params({32,128,32,4,32,32,32}, 1, true);
+        if (ctx.size_m <= 1) {
+          return set_params({32, 128, 32, 4, 32, 32, 32}, 4, false);
+        }
+        return set_params({32, 128, 32, 4, 32, 32, 32}, 1, true);
       }
     }
   }
@@ -774,16 +763,16 @@ inline bool sm70_marlin_moe_try_select_cyankiwi_qwen3_6_35b_a3b_awq_nvfp4_params
     // top_k=1
     if (ctx.top_k == 1 && ctx.size_n == 2048) {
       if (ctx.size_k == 512) {
-        return set_params({32,128,32,4,32,32,32}, 1, false);
+        return set_params({32, 128, 32, 4, 32, 32, 32}, 1, false);
       }
     }
     // top_k=8
     if (ctx.top_k == 8 && ctx.size_k == 2048) {
       if (ctx.size_n == 1024) {
-          if (ctx.size_m <= 32) {
-            return set_params({32,256,64,8,32,64,32}, 1, true);
-          }
-          return set_params({32,128,32,4,32,32,32}, 1, true);
+        if (ctx.size_m <= 32) {
+          return set_params({32, 256, 64, 8, 32, 64, 32}, 1, true);
+        }
+        return set_params({32, 128, 32, 4, 32, 32, 32}, 1, true);
       }
     }
   }
@@ -793,13 +782,13 @@ inline bool sm70_marlin_moe_try_select_cyankiwi_qwen3_6_35b_a3b_awq_nvfp4_params
     // top_k=1
     if (ctx.top_k == 1 && ctx.size_n == 2048) {
       if (ctx.size_k == 512) {
-        return set_params({32,128,32,4,32,32,32}, 1, true);
+        return set_params({32, 128, 32, 4, 32, 32, 32}, 1, true);
       }
     }
     // top_k=8
     if (ctx.top_k == 8 && ctx.size_k == 2048) {
       if (ctx.size_n == 1024) {
-        return set_params({32,256,64,8,32,64,32}, 1, false);
+        return set_params({32, 256, 64, 8, 32, 64, 32}, 1, false);
       }
     }
   }
@@ -809,45 +798,45 @@ inline bool sm70_marlin_moe_try_select_cyankiwi_qwen3_6_35b_a3b_awq_nvfp4_params
     // top_k=1
     if (ctx.top_k == 1 && ctx.size_n == 2048) {
       if (ctx.size_k == 64) {
-          if (ctx.size_m <= 16384) {
-            return set_params({64,64,32,4,32,32,32}, 1, true);
-          }
-          return set_params({64,256,32,4,64,64,32}, 1, false);
+        if (ctx.size_m <= 16384) {
+          return set_params({64, 64, 32, 4, 32, 32, 32}, 1, true);
+        }
+        return set_params({64, 256, 32, 4, 64, 64, 32}, 1, false);
       }
     }
     if (ctx.top_k == 1 && ctx.size_n == 2048) {
       if (ctx.size_k == 128) {
-        return set_params({64,256,32,4,64,64,32}, 1, true);
+        return set_params({64, 256, 32, 4, 64, 64, 32}, 1, true);
       }
     }
     if (ctx.top_k == 1 && ctx.size_n == 2048) {
       if (ctx.size_k == 512) {
-          if (ctx.size_m <= 16384) {
-            return set_params({64,256,32,4,64,64,32}, 1, false);
-          }
-          return set_params({64,256,32,4,64,64,32}, 1, true);
+        if (ctx.size_m <= 16384) {
+          return set_params({64, 256, 32, 4, 64, 64, 32}, 1, false);
+        }
+        return set_params({64, 256, 32, 4, 64, 64, 32}, 1, true);
       }
     }
     // top_k=8
     if (ctx.top_k == 8 && ctx.size_k == 2048) {
       if (ctx.size_n == 128) {
-          if (ctx.size_m <= 2048) {
-            return set_params({32,128,32,4,32,32,32}, 1, true);
-          }
-          return set_params({64,128,32,8,32,32,32}, 1, true);
+        if (ctx.size_m <= 2048) {
+          return set_params({32, 128, 32, 4, 32, 32, 32}, 1, true);
+        }
+        return set_params({64, 128, 32, 8, 32, 32, 32}, 1, true);
       }
     }
     if (ctx.top_k == 8 && ctx.size_k == 2048) {
       if (ctx.size_n == 256) {
-          if (ctx.size_m <= 2048) {
-            return set_params({64,256,32,4,64,64,32}, 1, true);
-          }
-          return set_params({64,256,64,8,64,64,32}, 1, false);
+        if (ctx.size_m <= 2048) {
+          return set_params({64, 256, 32, 4, 64, 64, 32}, 1, true);
+        }
+        return set_params({64, 256, 64, 8, 64, 64, 32}, 1, false);
       }
     }
     if (ctx.top_k == 8 && ctx.size_k == 2048) {
       if (ctx.size_n == 1024) {
-        return set_params({64,256,32,4,64,64,32}, 1, true);
+        return set_params({64, 256, 32, 4, 64, 64, 32}, 1, true);
       }
     }
   }
@@ -855,17 +844,16 @@ inline bool sm70_marlin_moe_try_select_cyankiwi_qwen3_6_35b_a3b_awq_nvfp4_params
   return false;
 }
 
-inline bool sm70_marlin_moe_try_select_cyankiwi_qwen3_coder_next_awq_4bit_params(
-    Sm70MarlinMoeAutoParamsContext const& ctx,
-    Sm70MarlinAutoParams& params) {
+inline bool
+sm70_marlin_moe_try_select_cyankiwi_qwen3_coder_next_awq_4bit_params(
+    Sm70MarlinMoeAutoParamsContext const& ctx, Sm70MarlinAutoParams& params) {
   if (ctx.quant_format == nullptr ||
-      std::strcmp(ctx.quant_format, "uint4b8") != 0 ||
-      ctx.group_size != 32 || ctx.size_m <= 0) {
+      std::strcmp(ctx.quant_format, "uint4b8") != 0 || ctx.group_size != 32 ||
+      ctx.size_m <= 0) {
     return false;
   }
 
-  auto const set_params = [&](Sm70CtaGeometry geometry,
-                              int requested_split_k,
+  auto const set_params = [&](Sm70CtaGeometry geometry, int requested_split_k,
                               bool use_metadata_vector_words) {
     params = {geometry, requested_split_k, use_metadata_vector_words,
               ctx.packed_macro_n};
@@ -877,63 +865,63 @@ inline bool sm70_marlin_moe_try_select_cyankiwi_qwen3_coder_next_awq_4bit_params
     // top_k=1
     if (ctx.top_k == 1 && ctx.size_n == 2048) {
       if (ctx.size_k == 64) {
-          if (ctx.size_m <= 10) {
-            return set_params({32,128,32,4,32,32,32}, 1, true);
-          }
-          if (ctx.size_m <= 320) {
-            return set_params({32,256,32,4,32,64,32}, 1, true);
-          }
-          return set_params({32,256,32,4,32,64,32}, 1, true);
+        if (ctx.size_m <= 10) {
+          return set_params({32, 128, 32, 4, 32, 32, 32}, 1, true);
+        }
+        if (ctx.size_m <= 320) {
+          return set_params({32, 256, 32, 4, 32, 64, 32}, 1, true);
+        }
+        return set_params({32, 256, 32, 4, 32, 64, 32}, 1, true);
       }
     }
     if (ctx.top_k == 1 && ctx.size_n == 2048) {
       if (ctx.size_k == 128) {
-        return set_params({32,256,32,4,32,64,32}, 1, true);
+        return set_params({32, 256, 32, 4, 32, 64, 32}, 1, true);
       }
     }
     if (ctx.top_k == 1 && ctx.size_n == 2048) {
       if (ctx.size_k == 512) {
-          if (ctx.size_m <= 10) {
-            return set_params({32,128,64,4,32,64,32}, 1, true);
-          }
-          if (ctx.size_m <= 320) {
-            return set_params({32,256,32,4,32,64,32}, 1, true);
-          }
-          return set_params({32,256,32,4,32,64,32}, 1, true);
+        if (ctx.size_m <= 10) {
+          return set_params({32, 128, 64, 4, 32, 64, 32}, 1, true);
+        }
+        if (ctx.size_m <= 320) {
+          return set_params({32, 256, 32, 4, 32, 64, 32}, 1, true);
+        }
+        return set_params({32, 256, 32, 4, 32, 64, 32}, 1, true);
       }
     }
     // top_k=10
     if (ctx.top_k == 10 && ctx.size_k == 2048) {
       if (ctx.size_n == 128) {
-          if (ctx.size_m <= 1) {
-            return set_params({32,64,32,4,32,32,16}, 8, true);
-          }
-          if (ctx.size_m <= 32) {
-            return set_params({32,128,64,8,32,64,16}, 2, true);
-          }
-          return set_params({32,128,128,8,32,64,32}, 1, true);
+        if (ctx.size_m <= 1) {
+          return set_params({32, 64, 32, 4, 32, 32, 16}, 8, true);
+        }
+        if (ctx.size_m <= 32) {
+          return set_params({32, 128, 64, 8, 32, 64, 16}, 2, true);
+        }
+        return set_params({32, 128, 128, 8, 32, 64, 32}, 1, true);
       }
     }
     if (ctx.top_k == 10 && ctx.size_k == 2048) {
       if (ctx.size_n == 256) {
-          if (ctx.size_m <= 1) {
-            return set_params({32,128,32,4,32,32,32}, 8, true);
-          }
-          if (ctx.size_m <= 32) {
-            return set_params({32,128,128,8,32,64,32}, 1, true);
-          }
-          return set_params({32,256,64,8,32,64,32}, 1, true);
+        if (ctx.size_m <= 1) {
+          return set_params({32, 128, 32, 4, 32, 32, 32}, 8, true);
+        }
+        if (ctx.size_m <= 32) {
+          return set_params({32, 128, 128, 8, 32, 64, 32}, 1, true);
+        }
+        return set_params({32, 256, 64, 8, 32, 64, 32}, 1, true);
       }
     }
     if (ctx.top_k == 10 && ctx.size_k == 2048) {
       if (ctx.size_n == 1024) {
-          if (ctx.size_m <= 1) {
-            return set_params({32,256,32,4,32,64,32}, 4, true);
-          }
-          if (ctx.size_m <= 32) {
-            return set_params({32,256,32,4,32,64,32}, 1, true);
-          }
-          return set_params({32,256,32,4,32,64,32}, 1, true);
+        if (ctx.size_m <= 1) {
+          return set_params({32, 256, 32, 4, 32, 64, 32}, 4, true);
+        }
+        if (ctx.size_m <= 32) {
+          return set_params({32, 256, 32, 4, 32, 64, 32}, 1, true);
+        }
+        return set_params({32, 256, 32, 4, 32, 64, 32}, 1, true);
       }
     }
   }
@@ -943,13 +931,13 @@ inline bool sm70_marlin_moe_try_select_cyankiwi_qwen3_coder_next_awq_4bit_params
     // top_k=1
     if (ctx.top_k == 1 && ctx.size_n == 2048) {
       if (ctx.size_k == 512) {
-        return set_params({32,256,32,4,32,64,32}, 1, true);
+        return set_params({32, 256, 32, 4, 32, 64, 32}, 1, true);
       }
     }
     // top_k=10
     if (ctx.top_k == 10 && ctx.size_k == 2048) {
       if (ctx.size_n == 1024) {
-        return set_params({32,256,32,4,32,64,32}, 1, true);
+        return set_params({32, 256, 32, 4, 32, 64, 32}, 1, true);
       }
     }
   }
@@ -959,23 +947,23 @@ inline bool sm70_marlin_moe_try_select_cyankiwi_qwen3_coder_next_awq_4bit_params
     // top_k=1
     if (ctx.top_k == 1 && ctx.size_n == 2048) {
       if (ctx.size_k == 64) {
-        return set_params({64,256,32,4,64,64,32}, 1, false);
+        return set_params({64, 256, 32, 4, 64, 64, 32}, 1, false);
       }
     }
     if (ctx.top_k == 1 && ctx.size_n == 2048) {
       if (ctx.size_k == 128) {
-        return set_params({64,256,32,4,64,64,32}, 1, false);
+        return set_params({64, 256, 32, 4, 64, 64, 32}, 1, false);
       }
     }
     // top_k=10
     if (ctx.top_k == 10 && ctx.size_k == 2048) {
       if (ctx.size_n == 128) {
-        return set_params({64,128,32,8,32,32,32}, 1, false);
+        return set_params({64, 128, 32, 8, 32, 32, 32}, 1, false);
       }
     }
     if (ctx.top_k == 10 && ctx.size_k == 2048) {
       if (ctx.size_n == 256) {
-        return set_params({64,256,32,4,64,64,32}, 1, false);
+        return set_params({64, 256, 32, 4, 64, 64, 32}, 1, false);
       }
     }
   }
@@ -985,33 +973,33 @@ inline bool sm70_marlin_moe_try_select_cyankiwi_qwen3_coder_next_awq_4bit_params
     // top_k=1
     if (ctx.top_k == 1 && ctx.size_n == 2048) {
       if (ctx.size_k == 64) {
-        return set_params({64,256,32,4,64,64,32}, 1, false);
+        return set_params({64, 256, 32, 4, 64, 64, 32}, 1, false);
       }
     }
     if (ctx.top_k == 1 && ctx.size_n == 2048) {
       if (ctx.size_k == 128) {
-        return set_params({64,256,32,4,64,64,32}, 1, false);
+        return set_params({64, 256, 32, 4, 64, 64, 32}, 1, false);
       }
     }
     if (ctx.top_k == 1 && ctx.size_n == 2048) {
       if (ctx.size_k == 512) {
-        return set_params({64,256,32,4,64,64,32}, 1, false);
+        return set_params({64, 256, 32, 4, 64, 64, 32}, 1, false);
       }
     }
     // top_k=10
     if (ctx.top_k == 10 && ctx.size_k == 2048) {
       if (ctx.size_n == 128) {
-        return set_params({64,128,32,4,32,64,32}, 1, true);
+        return set_params({64, 128, 32, 4, 32, 64, 32}, 1, true);
       }
     }
     if (ctx.top_k == 10 && ctx.size_k == 2048) {
       if (ctx.size_n == 256) {
-        return set_params({64,256,32,4,64,64,32}, 1, false);
+        return set_params({64, 256, 32, 4, 64, 64, 32}, 1, false);
       }
     }
     if (ctx.top_k == 10 && ctx.size_k == 2048) {
       if (ctx.size_n == 1024) {
-        return set_params({64,256,32,4,64,64,32}, 1, false);
+        return set_params({64, 256, 32, 4, 64, 64, 32}, 1, false);
       }
     }
   }
@@ -1019,17 +1007,16 @@ inline bool sm70_marlin_moe_try_select_cyankiwi_qwen3_coder_next_awq_4bit_params
   return false;
 }
 
-inline bool sm70_marlin_moe_try_select_cyankiwi_qwen3_coder_next_awq_8bit_params(
-    Sm70MarlinMoeAutoParamsContext const& ctx,
-    Sm70MarlinAutoParams& params) {
+inline bool
+sm70_marlin_moe_try_select_cyankiwi_qwen3_coder_next_awq_8bit_params(
+    Sm70MarlinMoeAutoParamsContext const& ctx, Sm70MarlinAutoParams& params) {
   if (ctx.quant_format == nullptr ||
-      std::strcmp(ctx.quant_format, "uint8b128") != 0 ||
-      ctx.group_size != 32 || ctx.size_m <= 0) {
+      std::strcmp(ctx.quant_format, "uint8b128") != 0 || ctx.group_size != 32 ||
+      ctx.size_m <= 0) {
     return false;
   }
 
-  auto const set_params = [&](Sm70CtaGeometry geometry,
-                              int requested_split_k,
+  auto const set_params = [&](Sm70CtaGeometry geometry, int requested_split_k,
                               bool use_metadata_vector_words) {
     params = {geometry, requested_split_k, use_metadata_vector_words,
               ctx.packed_macro_n};
@@ -1041,63 +1028,63 @@ inline bool sm70_marlin_moe_try_select_cyankiwi_qwen3_coder_next_awq_8bit_params
     // top_k=1
     if (ctx.top_k == 1 && ctx.size_n == 2048) {
       if (ctx.size_k == 64) {
-        return set_params({32,256,32,4,32,64,32}, 1, true);
+        return set_params({32, 256, 32, 4, 32, 64, 32}, 1, true);
       }
     }
     if (ctx.top_k == 1 && ctx.size_n == 2048) {
       if (ctx.size_k == 128) {
-          if (ctx.size_m <= 10) {
-            return set_params({32,128,32,4,32,32,32}, 1, true);
-          }
-          if (ctx.size_m <= 320) {
-            return set_params({32,256,32,4,32,64,32}, 1, true);
-          }
-          return set_params({32,256,32,4,32,64,32}, 1, true);
+        if (ctx.size_m <= 10) {
+          return set_params({32, 128, 32, 4, 32, 32, 32}, 1, true);
+        }
+        if (ctx.size_m <= 320) {
+          return set_params({32, 256, 32, 4, 32, 64, 32}, 1, true);
+        }
+        return set_params({32, 256, 32, 4, 32, 64, 32}, 1, true);
       }
     }
     if (ctx.top_k == 1 && ctx.size_n == 2048) {
       if (ctx.size_k == 512) {
-          if (ctx.size_m <= 10) {
-            return set_params({32,256,64,8,32,64,32}, 1, true);
-          }
-          if (ctx.size_m <= 320) {
-            return set_params({32,256,32,4,32,64,32}, 1, true);
-          }
-          return set_params({32,256,32,4,32,64,32}, 1, true);
+        if (ctx.size_m <= 10) {
+          return set_params({32, 256, 64, 8, 32, 64, 32}, 1, true);
+        }
+        if (ctx.size_m <= 320) {
+          return set_params({32, 256, 32, 4, 32, 64, 32}, 1, true);
+        }
+        return set_params({32, 256, 32, 4, 32, 64, 32}, 1, true);
       }
     }
     // top_k=10
     if (ctx.top_k == 10 && ctx.size_k == 2048) {
       if (ctx.size_n == 128) {
-          if (ctx.size_m <= 1) {
-            return set_params({32,64,32,4,32,32,16}, 8, true);
-          }
-          if (ctx.size_m <= 32) {
-            return set_params({32,128,64,8,32,64,16}, 2, true);
-          }
-          return set_params({32,128,128,8,32,64,32}, 1, true);
+        if (ctx.size_m <= 1) {
+          return set_params({32, 64, 32, 4, 32, 32, 16}, 8, true);
+        }
+        if (ctx.size_m <= 32) {
+          return set_params({32, 128, 64, 8, 32, 64, 16}, 2, true);
+        }
+        return set_params({32, 128, 128, 8, 32, 64, 32}, 1, true);
       }
     }
     if (ctx.top_k == 10 && ctx.size_k == 2048) {
       if (ctx.size_n == 256) {
-          if (ctx.size_m <= 1) {
-            return set_params({32,256,32,4,32,64,32}, 8, true);
-          }
-          if (ctx.size_m <= 32) {
-            return set_params({32,128,128,8,32,64,32}, 1, true);
-          }
-          return set_params({32,256,64,8,32,64,32}, 1, true);
+        if (ctx.size_m <= 1) {
+          return set_params({32, 256, 32, 4, 32, 64, 32}, 8, true);
+        }
+        if (ctx.size_m <= 32) {
+          return set_params({32, 128, 128, 8, 32, 64, 32}, 1, true);
+        }
+        return set_params({32, 256, 64, 8, 32, 64, 32}, 1, true);
       }
     }
     if (ctx.top_k == 10 && ctx.size_k == 2048) {
       if (ctx.size_n == 1024) {
-          if (ctx.size_m <= 1) {
-            return set_params({32,128,128,8,32,64,32}, 1, true);
-          }
-          if (ctx.size_m <= 32) {
-            return set_params({32,256,32,4,32,64,32}, 1, true);
-          }
-          return set_params({32,256,32,4,32,64,32}, 1, true);
+        if (ctx.size_m <= 1) {
+          return set_params({32, 128, 128, 8, 32, 64, 32}, 1, true);
+        }
+        if (ctx.size_m <= 32) {
+          return set_params({32, 256, 32, 4, 32, 64, 32}, 1, true);
+        }
+        return set_params({32, 256, 32, 4, 32, 64, 32}, 1, true);
       }
     }
   }
@@ -1107,13 +1094,13 @@ inline bool sm70_marlin_moe_try_select_cyankiwi_qwen3_coder_next_awq_8bit_params
     // top_k=1
     if (ctx.top_k == 1 && ctx.size_n == 2048) {
       if (ctx.size_k == 512) {
-        return set_params({32,256,32,4,32,64,32}, 1, true);
+        return set_params({32, 256, 32, 4, 32, 64, 32}, 1, true);
       }
     }
     // top_k=10
     if (ctx.top_k == 10 && ctx.size_k == 2048) {
       if (ctx.size_n == 1024) {
-        return set_params({32,256,32,4,32,64,32}, 1, true);
+        return set_params({32, 256, 32, 4, 32, 64, 32}, 1, true);
       }
     }
   }
@@ -1123,23 +1110,23 @@ inline bool sm70_marlin_moe_try_select_cyankiwi_qwen3_coder_next_awq_8bit_params
     // top_k=1
     if (ctx.top_k == 1 && ctx.size_n == 2048) {
       if (ctx.size_k == 64) {
-        return set_params({64,256,32,4,64,64,32}, 1, false);
+        return set_params({64, 256, 32, 4, 64, 64, 32}, 1, false);
       }
     }
     if (ctx.top_k == 1 && ctx.size_n == 2048) {
       if (ctx.size_k == 128) {
-        return set_params({64,256,32,4,64,64,32}, 1, false);
+        return set_params({64, 256, 32, 4, 64, 64, 32}, 1, false);
       }
     }
     // top_k=10
     if (ctx.top_k == 10 && ctx.size_k == 2048) {
       if (ctx.size_n == 128) {
-        return set_params({64,128,32,8,32,32,32}, 1, false);
+        return set_params({64, 128, 32, 8, 32, 32, 32}, 1, false);
       }
     }
     if (ctx.top_k == 10 && ctx.size_k == 2048) {
       if (ctx.size_n == 256) {
-        return set_params({64,256,32,4,64,64,32}, 1, false);
+        return set_params({64, 256, 32, 4, 64, 64, 32}, 1, false);
       }
     }
   }
@@ -1149,33 +1136,33 @@ inline bool sm70_marlin_moe_try_select_cyankiwi_qwen3_coder_next_awq_8bit_params
     // top_k=1
     if (ctx.top_k == 1 && ctx.size_n == 2048) {
       if (ctx.size_k == 64) {
-        return set_params({64,256,32,4,64,64,32}, 1, false);
+        return set_params({64, 256, 32, 4, 64, 64, 32}, 1, false);
       }
     }
     if (ctx.top_k == 1 && ctx.size_n == 2048) {
       if (ctx.size_k == 128) {
-        return set_params({64,256,32,4,64,64,32}, 1, false);
+        return set_params({64, 256, 32, 4, 64, 64, 32}, 1, false);
       }
     }
     if (ctx.top_k == 1 && ctx.size_n == 2048) {
       if (ctx.size_k == 512) {
-        return set_params({64,256,32,4,64,64,32}, 1, false);
+        return set_params({64, 256, 32, 4, 64, 64, 32}, 1, false);
       }
     }
     // top_k=10
     if (ctx.top_k == 10 && ctx.size_k == 2048) {
       if (ctx.size_n == 128) {
-        return set_params({64,128,32,8,32,32,32}, 1, false);
+        return set_params({64, 128, 32, 8, 32, 32, 32}, 1, false);
       }
     }
     if (ctx.top_k == 10 && ctx.size_k == 2048) {
       if (ctx.size_n == 256) {
-        return set_params({64,256,32,4,64,64,32}, 1, false);
+        return set_params({64, 256, 32, 4, 64, 64, 32}, 1, false);
       }
     }
     if (ctx.top_k == 10 && ctx.size_k == 2048) {
       if (ctx.size_n == 1024) {
-        return set_params({64,256,32,4,64,64,32}, 1, false);
+        return set_params({64, 256, 32, 4, 64, 64, 32}, 1, false);
       }
     }
   }
@@ -1184,16 +1171,14 @@ inline bool sm70_marlin_moe_try_select_cyankiwi_qwen3_coder_next_awq_8bit_params
 }
 
 inline bool sm70_marlin_moe_try_select_nvidia_glm_4_7_nvfp4_params(
-    Sm70MarlinMoeAutoParamsContext const& ctx,
-    Sm70MarlinAutoParams& params) {
+    Sm70MarlinMoeAutoParamsContext const& ctx, Sm70MarlinAutoParams& params) {
   if (ctx.quant_format == nullptr ||
-      std::strcmp(ctx.quant_format, "nvfp4") != 0 ||
-      ctx.group_size != 16 || ctx.size_m <= 0) {
+      std::strcmp(ctx.quant_format, "nvfp4") != 0 || ctx.group_size != 16 ||
+      ctx.size_m <= 0) {
     return false;
   }
 
-  auto const set_params = [&](Sm70CtaGeometry geometry,
-                              int requested_split_k,
+  auto const set_params = [&](Sm70CtaGeometry geometry, int requested_split_k,
                               bool use_metadata_vector_words) {
     params = {geometry, requested_split_k, use_metadata_vector_words,
               ctx.packed_macro_n};
@@ -1205,63 +1190,63 @@ inline bool sm70_marlin_moe_try_select_nvidia_glm_4_7_nvfp4_params(
     // top_k=1
     if (ctx.top_k == 1 && ctx.size_n == 5120) {
       if (ctx.size_k == 192) {
-          if (ctx.size_m <= 8) {
-            return set_params({32,128,32,4,32,32,32}, 1, false);
-          }
-          if (ctx.size_m <= 256) {
-            return set_params({32,128,32,4,32,32,32}, 1, false);
-          }
-          return set_params({32,128,32,4,32,32,32}, 1, true);
+        if (ctx.size_m <= 8) {
+          return set_params({32, 128, 32, 4, 32, 32, 32}, 1, false);
+        }
+        if (ctx.size_m <= 256) {
+          return set_params({32, 128, 32, 4, 32, 32, 32}, 1, false);
+        }
+        return set_params({32, 128, 32, 4, 32, 32, 32}, 1, true);
       }
     }
     if (ctx.top_k == 1 && ctx.size_n == 5120) {
       if (ctx.size_k == 384) {
-          if (ctx.size_m <= 8) {
-            return set_params({32,256,32,4,32,64,32}, 1, true);
-          }
-          if (ctx.size_m <= 256) {
-            return set_params({32,128,32,4,32,32,32}, 1, true);
-          }
-          return set_params({32,128,32,4,32,32,32}, 1, true);
+        if (ctx.size_m <= 8) {
+          return set_params({32, 256, 32, 4, 32, 64, 32}, 1, true);
+        }
+        if (ctx.size_m <= 256) {
+          return set_params({32, 128, 32, 4, 32, 32, 32}, 1, true);
+        }
+        return set_params({32, 128, 32, 4, 32, 32, 32}, 1, true);
       }
     }
     if (ctx.top_k == 1 && ctx.size_n == 5120) {
       if (ctx.size_k == 1536) {
-          if (ctx.size_m <= 8) {
-            return set_params({32,128,32,4,32,32,32}, 1, true);
-          }
-          return set_params({32,128,32,4,32,32,32}, 1, false);
+        if (ctx.size_m <= 8) {
+          return set_params({32, 128, 32, 4, 32, 32, 32}, 1, true);
+        }
+        return set_params({32, 128, 32, 4, 32, 32, 32}, 1, false);
       }
     }
     // top_k=8
     if (ctx.top_k == 8 && ctx.size_k == 5120) {
       if (ctx.size_n == 384) {
-          if (ctx.size_m <= 1) {
-            return set_params({32,128,32,4,32,32,32}, 8, true);
-          }
-          if (ctx.size_m <= 32) {
-            return set_params({32,128,32,4,32,64,16}, 2, true);
-          }
-          return set_params({32,128,32,4,32,64,16}, 1, true);
+        if (ctx.size_m <= 1) {
+          return set_params({32, 128, 32, 4, 32, 32, 32}, 8, true);
+        }
+        if (ctx.size_m <= 32) {
+          return set_params({32, 128, 32, 4, 32, 64, 16}, 2, true);
+        }
+        return set_params({32, 128, 32, 4, 32, 64, 16}, 1, true);
       }
     }
     if (ctx.top_k == 8 && ctx.size_k == 5120) {
       if (ctx.size_n == 768) {
-          if (ctx.size_m <= 1) {
-            return set_params({32,128,32,4,32,64,16}, 4, true);
-          }
-          if (ctx.size_m <= 32) {
-            return set_params({32,128,32,4,32,64,16}, 1, true);
-          }
-          return set_params({32,128,32,4,32,32,32}, 4, true);
+        if (ctx.size_m <= 1) {
+          return set_params({32, 128, 32, 4, 32, 64, 16}, 4, true);
+        }
+        if (ctx.size_m <= 32) {
+          return set_params({32, 128, 32, 4, 32, 64, 16}, 1, true);
+        }
+        return set_params({32, 128, 32, 4, 32, 32, 32}, 4, true);
       }
     }
     if (ctx.top_k == 8 && ctx.size_k == 5120) {
       if (ctx.size_n == 3072) {
-          if (ctx.size_m <= 1) {
-            return set_params({32,128,32,4,32,32,32}, 8, true);
-          }
-          return set_params({32,128,32,4,32,32,32}, 2, true);
+        if (ctx.size_m <= 1) {
+          return set_params({32, 128, 32, 4, 32, 32, 32}, 8, true);
+        }
+        return set_params({32, 128, 32, 4, 32, 32, 32}, 2, true);
       }
     }
   }
@@ -1271,19 +1256,19 @@ inline bool sm70_marlin_moe_try_select_nvidia_glm_4_7_nvfp4_params(
     // top_k=1
     if (ctx.top_k == 1 && ctx.size_n == 5120) {
       if (ctx.size_k == 1536) {
-          if (ctx.size_m <= 256) {
-            return set_params({32,256,64,8,32,64,32}, 1, true);
-          }
-          return set_params({32,128,32,4,32,32,32}, 1, true);
+        if (ctx.size_m <= 256) {
+          return set_params({32, 256, 64, 8, 32, 64, 32}, 1, true);
+        }
+        return set_params({32, 128, 32, 4, 32, 32, 32}, 1, true);
       }
     }
     // top_k=8
     if (ctx.top_k == 8 && ctx.size_k == 5120) {
       if (ctx.size_n == 3072) {
-          if (ctx.size_m <= 32) {
-            return set_params({32,128,32,4,32,32,32}, 4, true);
-          }
-          return set_params({32,256,64,8,32,64,32}, 1, true);
+        if (ctx.size_m <= 32) {
+          return set_params({32, 128, 32, 4, 32, 32, 32}, 4, true);
+        }
+        return set_params({32, 256, 64, 8, 32, 64, 32}, 1, true);
       }
     }
   }
@@ -1293,13 +1278,13 @@ inline bool sm70_marlin_moe_try_select_nvidia_glm_4_7_nvfp4_params(
     // top_k=1
     if (ctx.top_k == 1 && ctx.size_n == 5120) {
       if (ctx.size_k == 1536) {
-        return set_params({32,256,64,8,32,64,32}, 1, true);
+        return set_params({32, 256, 64, 8, 32, 64, 32}, 1, true);
       }
     }
     // top_k=8
     if (ctx.top_k == 8 && ctx.size_k == 5120) {
       if (ctx.size_n == 3072) {
-        return set_params({32,256,64,8,32,64,32}, 1, true);
+        return set_params({32, 256, 64, 8, 32, 64, 32}, 1, true);
       }
     }
   }
@@ -1309,42 +1294,42 @@ inline bool sm70_marlin_moe_try_select_nvidia_glm_4_7_nvfp4_params(
     // top_k=1
     if (ctx.top_k == 1 && ctx.size_n == 5120) {
       if (ctx.size_k == 192) {
-          if (ctx.size_m <= 16384) {
-            return set_params({64,256,32,4,64,64,32}, 1, true);
-          }
-          return set_params({64,256,32,4,64,64,32}, 1, false);
+        if (ctx.size_m <= 16384) {
+          return set_params({64, 256, 32, 4, 64, 64, 32}, 1, true);
+        }
+        return set_params({64, 256, 32, 4, 64, 64, 32}, 1, false);
       }
     }
     if (ctx.top_k == 1 && ctx.size_n == 5120) {
       if (ctx.size_k == 384) {
-          if (ctx.size_m <= 16384) {
-            return set_params({64,256,32,4,64,64,32}, 1, false);
-          }
-          return set_params({64,256,32,4,64,64,32}, 1, true);
+        if (ctx.size_m <= 16384) {
+          return set_params({64, 256, 32, 4, 64, 64, 32}, 1, false);
+        }
+        return set_params({64, 256, 32, 4, 64, 64, 32}, 1, true);
       }
     }
     if (ctx.top_k == 1 && ctx.size_n == 5120) {
       if (ctx.size_k == 1536) {
-        return set_params({64,256,32,4,64,64,32}, 1, true);
+        return set_params({64, 256, 32, 4, 64, 64, 32}, 1, true);
       }
     }
     // top_k=8
     if (ctx.top_k == 8 && ctx.size_k == 5120) {
       if (ctx.size_n == 384) {
-          if (ctx.size_m <= 2048) {
-            return set_params({64,128,32,8,32,32,32}, 1, false);
-          }
-          return set_params({64,128,32,8,32,32,32}, 1, true);
+        if (ctx.size_m <= 2048) {
+          return set_params({64, 128, 32, 8, 32, 32, 32}, 1, false);
+        }
+        return set_params({64, 128, 32, 8, 32, 32, 32}, 1, true);
       }
     }
     if (ctx.top_k == 8 && ctx.size_k == 5120) {
       if (ctx.size_n == 768) {
-        return set_params({64,256,32,4,64,64,32}, 1, true);
+        return set_params({64, 256, 32, 4, 64, 64, 32}, 1, true);
       }
     }
     if (ctx.top_k == 8 && ctx.size_k == 5120) {
       if (ctx.size_n == 3072) {
-        return set_params({64,256,32,4,64,64,32}, 1, true);
+        return set_params({64, 256, 32, 4, 64, 64, 32}, 1, true);
       }
     }
   }
@@ -1353,16 +1338,14 @@ inline bool sm70_marlin_moe_try_select_nvidia_glm_4_7_nvfp4_params(
 }
 
 inline bool sm70_marlin_moe_try_select_nvidia_minimax_m2_7_nvfp4_params(
-    Sm70MarlinMoeAutoParamsContext const& ctx,
-    Sm70MarlinAutoParams& params) {
+    Sm70MarlinMoeAutoParamsContext const& ctx, Sm70MarlinAutoParams& params) {
   if (ctx.quant_format == nullptr ||
-      std::strcmp(ctx.quant_format, "nvfp4") != 0 ||
-      ctx.group_size != 16 || ctx.size_m <= 0) {
+      std::strcmp(ctx.quant_format, "nvfp4") != 0 || ctx.group_size != 16 ||
+      ctx.size_m <= 0) {
     return false;
   }
 
-  auto const set_params = [&](Sm70CtaGeometry geometry,
-                              int requested_split_k,
+  auto const set_params = [&](Sm70CtaGeometry geometry, int requested_split_k,
                               bool use_metadata_vector_words) {
     params = {geometry, requested_split_k, use_metadata_vector_words,
               ctx.packed_macro_n};
@@ -1374,63 +1357,63 @@ inline bool sm70_marlin_moe_try_select_nvidia_minimax_m2_7_nvfp4_params(
     // top_k=1
     if (ctx.top_k == 1 && ctx.size_n == 3072) {
       if (ctx.size_k == 192) {
-          if (ctx.size_m <= 8) {
-            return set_params({32,128,32,4,32,32,32}, 1, true);
-          }
-          if (ctx.size_m <= 256) {
-            return set_params({32,128,32,4,32,32,32}, 1, true);
-          }
-          return set_params({32,256,32,4,32,64,32}, 1, true);
+        if (ctx.size_m <= 8) {
+          return set_params({32, 128, 32, 4, 32, 32, 32}, 1, true);
+        }
+        if (ctx.size_m <= 256) {
+          return set_params({32, 128, 32, 4, 32, 32, 32}, 1, true);
+        }
+        return set_params({32, 256, 32, 4, 32, 64, 32}, 1, true);
       }
     }
     if (ctx.top_k == 1 && ctx.size_n == 3072) {
       if (ctx.size_k == 384) {
-          if (ctx.size_m <= 8) {
-            return set_params({32,256,32,4,32,64,32}, 1, true);
-          }
-          if (ctx.size_m <= 256) {
-            return set_params({32,256,32,4,32,64,32}, 1, false);
-          }
-          return set_params({32,256,32,4,32,64,32}, 1, true);
+        if (ctx.size_m <= 8) {
+          return set_params({32, 256, 32, 4, 32, 64, 32}, 1, true);
+        }
+        if (ctx.size_m <= 256) {
+          return set_params({32, 256, 32, 4, 32, 64, 32}, 1, false);
+        }
+        return set_params({32, 256, 32, 4, 32, 64, 32}, 1, true);
       }
     }
     if (ctx.top_k == 1 && ctx.size_n == 3072) {
       if (ctx.size_k == 1536) {
-          if (ctx.size_m <= 8) {
-            return set_params({32,128,32,4,32,64,16}, 1, true);
-          }
-          return set_params({32,128,32,4,32,32,32}, 1, true);
+        if (ctx.size_m <= 8) {
+          return set_params({32, 128, 32, 4, 32, 64, 16}, 1, true);
+        }
+        return set_params({32, 128, 32, 4, 32, 32, 32}, 1, true);
       }
     }
     // top_k=8
     if (ctx.top_k == 8 && ctx.size_k == 3072) {
       if (ctx.size_n == 384) {
-          if (ctx.size_m <= 1) {
-            return set_params({32,128,32,4,32,32,32}, 8, false);
-          }
-          if (ctx.size_m <= 32) {
-            return set_params({32,128,32,4,32,64,16}, 2, true);
-          }
-          return set_params({32,128,32,4,32,64,16}, 1, true);
+        if (ctx.size_m <= 1) {
+          return set_params({32, 128, 32, 4, 32, 32, 32}, 8, false);
+        }
+        if (ctx.size_m <= 32) {
+          return set_params({32, 128, 32, 4, 32, 64, 16}, 2, true);
+        }
+        return set_params({32, 128, 32, 4, 32, 64, 16}, 1, true);
       }
     }
     if (ctx.top_k == 8 && ctx.size_k == 3072) {
       if (ctx.size_n == 768) {
-          if (ctx.size_m <= 1) {
-            return set_params({32,128,32,4,32,32,32}, 4, true);
-          }
-          if (ctx.size_m <= 32) {
-            return set_params({32,128,32,4,32,64,16}, 1, true);
-          }
-          return set_params({32,128,32,4,32,64,16}, 1, true);
+        if (ctx.size_m <= 1) {
+          return set_params({32, 128, 32, 4, 32, 32, 32}, 4, true);
+        }
+        if (ctx.size_m <= 32) {
+          return set_params({32, 128, 32, 4, 32, 64, 16}, 1, true);
+        }
+        return set_params({32, 128, 32, 4, 32, 64, 16}, 1, true);
       }
     }
     if (ctx.top_k == 8 && ctx.size_k == 3072) {
       if (ctx.size_n == 3072) {
-          if (ctx.size_m <= 1) {
-            return set_params({32,128,32,4,32,32,32}, 4, true);
-          }
-          return set_params({32,256,64,8,32,64,32}, 1, true);
+        if (ctx.size_m <= 1) {
+          return set_params({32, 128, 32, 4, 32, 32, 32}, 4, true);
+        }
+        return set_params({32, 256, 64, 8, 32, 64, 32}, 1, true);
       }
     }
   }
@@ -1440,19 +1423,19 @@ inline bool sm70_marlin_moe_try_select_nvidia_minimax_m2_7_nvfp4_params(
     // top_k=1
     if (ctx.top_k == 1 && ctx.size_n == 3072) {
       if (ctx.size_k == 1536) {
-          if (ctx.size_m <= 256) {
-            return set_params({32,256,64,8,32,64,32}, 1, true);
-          }
-          return set_params({32,128,32,4,32,32,32}, 1, true);
+        if (ctx.size_m <= 256) {
+          return set_params({32, 256, 64, 8, 32, 64, 32}, 1, true);
+        }
+        return set_params({32, 128, 32, 4, 32, 32, 32}, 1, true);
       }
     }
     // top_k=8
     if (ctx.top_k == 8 && ctx.size_k == 3072) {
       if (ctx.size_n == 3072) {
-          if (ctx.size_m <= 32) {
-            return set_params({32,256,64,8,32,64,32}, 1, true);
-          }
-          return set_params({32,128,32,4,32,32,32}, 1, true);
+        if (ctx.size_m <= 32) {
+          return set_params({32, 256, 64, 8, 32, 64, 32}, 1, true);
+        }
+        return set_params({32, 128, 32, 4, 32, 32, 32}, 1, true);
       }
     }
   }
@@ -1462,13 +1445,13 @@ inline bool sm70_marlin_moe_try_select_nvidia_minimax_m2_7_nvfp4_params(
     // top_k=1
     if (ctx.top_k == 1 && ctx.size_n == 3072) {
       if (ctx.size_k == 1536) {
-        return set_params({32,256,64,8,32,64,32}, 1, true);
+        return set_params({32, 256, 64, 8, 32, 64, 32}, 1, true);
       }
     }
     // top_k=8
     if (ctx.top_k == 8 && ctx.size_k == 3072) {
       if (ctx.size_n == 3072) {
-        return set_params({32,256,64,8,32,64,32}, 1, false);
+        return set_params({32, 256, 64, 8, 32, 64, 32}, 1, false);
       }
     }
   }
@@ -1478,45 +1461,45 @@ inline bool sm70_marlin_moe_try_select_nvidia_minimax_m2_7_nvfp4_params(
     // top_k=1
     if (ctx.top_k == 1 && ctx.size_n == 3072) {
       if (ctx.size_k == 192) {
-          if (ctx.size_m <= 16384) {
-            return set_params({64,256,32,4,64,64,32}, 1, true);
-          }
-          return set_params({64,256,32,4,64,64,32}, 1, false);
+        if (ctx.size_m <= 16384) {
+          return set_params({64, 256, 32, 4, 64, 64, 32}, 1, true);
+        }
+        return set_params({64, 256, 32, 4, 64, 64, 32}, 1, false);
       }
     }
     if (ctx.top_k == 1 && ctx.size_n == 3072) {
       if (ctx.size_k == 384) {
-          if (ctx.size_m <= 16384) {
-            return set_params({64,256,32,4,64,64,32}, 1, false);
-          }
-          return set_params({64,256,32,4,64,64,32}, 1, true);
+        if (ctx.size_m <= 16384) {
+          return set_params({64, 256, 32, 4, 64, 64, 32}, 1, false);
+        }
+        return set_params({64, 256, 32, 4, 64, 64, 32}, 1, true);
       }
     }
     if (ctx.top_k == 1 && ctx.size_n == 3072) {
       if (ctx.size_k == 1536) {
-          if (ctx.size_m <= 16384) {
-            return set_params({64,256,32,4,64,64,32}, 1, true);
-          }
-          return set_params({64,256,32,4,64,64,32}, 1, false);
+        if (ctx.size_m <= 16384) {
+          return set_params({64, 256, 32, 4, 64, 64, 32}, 1, true);
+        }
+        return set_params({64, 256, 32, 4, 64, 64, 32}, 1, false);
       }
     }
     // top_k=8
     if (ctx.top_k == 8 && ctx.size_k == 3072) {
       if (ctx.size_n == 384) {
-          if (ctx.size_m <= 2048) {
-            return set_params({64,128,32,8,32,32,32}, 1, true);
-          }
-          return set_params({64,128,32,8,32,32,32}, 1, false);
+        if (ctx.size_m <= 2048) {
+          return set_params({64, 128, 32, 8, 32, 32, 32}, 1, true);
+        }
+        return set_params({64, 128, 32, 8, 32, 32, 32}, 1, false);
       }
     }
     if (ctx.top_k == 8 && ctx.size_k == 3072) {
       if (ctx.size_n == 768) {
-        return set_params({64,256,32,4,64,64,32}, 1, true);
+        return set_params({64, 256, 32, 4, 64, 64, 32}, 1, true);
       }
     }
     if (ctx.top_k == 8 && ctx.size_k == 3072) {
       if (ctx.size_n == 3072) {
-        return set_params({64,256,32,4,64,64,32}, 1, true);
+        return set_params({64, 256, 32, 4, 64, 64, 32}, 1, true);
       }
     }
   }
@@ -1525,16 +1508,14 @@ inline bool sm70_marlin_moe_try_select_nvidia_minimax_m2_7_nvfp4_params(
 }
 
 inline bool sm70_marlin_moe_try_select_nvidia_qwen3_6_35b_a3b_nvfp4_params(
-    Sm70MarlinMoeAutoParamsContext const& ctx,
-    Sm70MarlinAutoParams& params) {
+    Sm70MarlinMoeAutoParamsContext const& ctx, Sm70MarlinAutoParams& params) {
   if (ctx.quant_format == nullptr ||
-      std::strcmp(ctx.quant_format, "nvfp4") != 0 ||
-      ctx.group_size != 16 || ctx.size_m <= 0) {
+      std::strcmp(ctx.quant_format, "nvfp4") != 0 || ctx.group_size != 16 ||
+      ctx.size_m <= 0) {
     return false;
   }
 
-  auto const set_params = [&](Sm70CtaGeometry geometry,
-                              int requested_split_k,
+  auto const set_params = [&](Sm70CtaGeometry geometry, int requested_split_k,
                               bool use_metadata_vector_words) {
     params = {geometry, requested_split_k, use_metadata_vector_words,
               ctx.packed_macro_n};
@@ -1546,63 +1527,63 @@ inline bool sm70_marlin_moe_try_select_nvidia_qwen3_6_35b_a3b_nvfp4_params(
     // top_k=1
     if (ctx.top_k == 1 && ctx.size_n == 2048) {
       if (ctx.size_k == 64) {
-          if (ctx.size_m <= 8) {
-            return set_params({32,64,64,4,32,32,32}, 1, true);
-          }
-          if (ctx.size_m <= 256) {
-            return set_params({32,128,32,4,32,32,32}, 1, true);
-          }
-          return set_params({32,128,32,4,32,32,32}, 1, true);
+        if (ctx.size_m <= 8) {
+          return set_params({32, 64, 64, 4, 32, 32, 32}, 1, true);
+        }
+        if (ctx.size_m <= 256) {
+          return set_params({32, 128, 32, 4, 32, 32, 32}, 1, true);
+        }
+        return set_params({32, 128, 32, 4, 32, 32, 32}, 1, true);
       }
     }
     if (ctx.top_k == 1 && ctx.size_n == 2048) {
       if (ctx.size_k == 128) {
-          if (ctx.size_m <= 8) {
-            return set_params({32,64,64,4,32,32,32}, 1, true);
-          }
-          if (ctx.size_m <= 256) {
-            return set_params({32,128,32,4,32,32,32}, 1, true);
-          }
-          return set_params({32,128,32,4,32,32,32}, 1, true);
+        if (ctx.size_m <= 8) {
+          return set_params({32, 64, 64, 4, 32, 32, 32}, 1, true);
+        }
+        if (ctx.size_m <= 256) {
+          return set_params({32, 128, 32, 4, 32, 32, 32}, 1, true);
+        }
+        return set_params({32, 128, 32, 4, 32, 32, 32}, 1, true);
       }
     }
     if (ctx.top_k == 1 && ctx.size_n == 2048) {
       if (ctx.size_k == 512) {
-          if (ctx.size_m <= 8) {
-            return set_params({32,128,64,4,32,64,32}, 1, true);
-          }
-          return set_params({32,128,32,4,32,32,32}, 1, true);
+        if (ctx.size_m <= 8) {
+          return set_params({32, 128, 64, 4, 32, 64, 32}, 1, true);
+        }
+        return set_params({32, 128, 32, 4, 32, 32, 32}, 1, true);
       }
     }
     // top_k=8
     if (ctx.top_k == 8 && ctx.size_k == 2048) {
       if (ctx.size_n == 128) {
-          if (ctx.size_m <= 1) {
-            return set_params({32,64,32,4,32,32,16}, 8, true);
-          }
-          if (ctx.size_m <= 32) {
-            return set_params({32,128,64,8,32,32,32}, 4, true);
-          }
-          return set_params({32,128,128,8,32,64,32}, 1, true);
+        if (ctx.size_m <= 1) {
+          return set_params({32, 64, 32, 4, 32, 32, 16}, 8, true);
+        }
+        if (ctx.size_m <= 32) {
+          return set_params({32, 128, 64, 8, 32, 32, 32}, 4, true);
+        }
+        return set_params({32, 128, 128, 8, 32, 64, 32}, 1, true);
       }
     }
     if (ctx.top_k == 8 && ctx.size_k == 2048) {
       if (ctx.size_n == 256) {
-          if (ctx.size_m <= 1) {
-            return set_params({32,128,32,4,32,32,32}, 8, true);
-          }
-          if (ctx.size_m <= 32) {
-            return set_params({32,128,128,8,32,64,32}, 1, true);
-          }
-          return set_params({32,256,64,8,32,64,32}, 1, true);
+        if (ctx.size_m <= 1) {
+          return set_params({32, 128, 32, 4, 32, 32, 32}, 8, true);
+        }
+        if (ctx.size_m <= 32) {
+          return set_params({32, 128, 128, 8, 32, 64, 32}, 1, true);
+        }
+        return set_params({32, 256, 64, 8, 32, 64, 32}, 1, true);
       }
     }
     if (ctx.top_k == 8 && ctx.size_k == 2048) {
       if (ctx.size_n == 1024) {
-          if (ctx.size_m <= 1) {
-            return set_params({32,128,32,4,32,32,32}, 4, true);
-          }
-          return set_params({32,128,32,4,32,32,32}, 1, true);
+        if (ctx.size_m <= 1) {
+          return set_params({32, 128, 32, 4, 32, 32, 32}, 4, true);
+        }
+        return set_params({32, 128, 32, 4, 32, 32, 32}, 1, true);
       }
     }
   }
@@ -1612,16 +1593,16 @@ inline bool sm70_marlin_moe_try_select_nvidia_qwen3_6_35b_a3b_nvfp4_params(
     // top_k=1
     if (ctx.top_k == 1 && ctx.size_n == 2048) {
       if (ctx.size_k == 512) {
-        return set_params({32,128,32,4,32,32,32}, 1, true);
+        return set_params({32, 128, 32, 4, 32, 32, 32}, 1, true);
       }
     }
     // top_k=8
     if (ctx.top_k == 8 && ctx.size_k == 2048) {
       if (ctx.size_n == 1024) {
-          if (ctx.size_m <= 32) {
-            return set_params({32,256,64,8,32,64,32}, 1, true);
-          }
-          return set_params({32,128,32,4,32,32,32}, 1, true);
+        if (ctx.size_m <= 32) {
+          return set_params({32, 256, 64, 8, 32, 64, 32}, 1, true);
+        }
+        return set_params({32, 128, 32, 4, 32, 32, 32}, 1, true);
       }
     }
   }
@@ -1631,13 +1612,13 @@ inline bool sm70_marlin_moe_try_select_nvidia_qwen3_6_35b_a3b_nvfp4_params(
     // top_k=1
     if (ctx.top_k == 1 && ctx.size_n == 2048) {
       if (ctx.size_k == 512) {
-        return set_params({32,128,32,4,32,32,32}, 1, true);
+        return set_params({32, 128, 32, 4, 32, 32, 32}, 1, true);
       }
     }
     // top_k=8
     if (ctx.top_k == 8 && ctx.size_k == 2048) {
       if (ctx.size_n == 1024) {
-        return set_params({32,256,64,8,32,64,32}, 1, true);
+        return set_params({32, 256, 64, 8, 32, 64, 32}, 1, true);
       }
     }
   }
@@ -1647,48 +1628,48 @@ inline bool sm70_marlin_moe_try_select_nvidia_qwen3_6_35b_a3b_nvfp4_params(
     // top_k=1
     if (ctx.top_k == 1 && ctx.size_n == 2048) {
       if (ctx.size_k == 64) {
-          if (ctx.size_m <= 16384) {
-            return set_params({64,64,32,4,32,32,32}, 1, false);
-          }
-          return set_params({64,256,32,4,64,64,32}, 1, false);
+        if (ctx.size_m <= 16384) {
+          return set_params({64, 64, 32, 4, 32, 32, 32}, 1, false);
+        }
+        return set_params({64, 256, 32, 4, 64, 64, 32}, 1, false);
       }
     }
     if (ctx.top_k == 1 && ctx.size_n == 2048) {
       if (ctx.size_k == 128) {
-        return set_params({64,256,32,4,64,64,32}, 1, true);
+        return set_params({64, 256, 32, 4, 64, 64, 32}, 1, true);
       }
     }
     if (ctx.top_k == 1 && ctx.size_n == 2048) {
       if (ctx.size_k == 512) {
-          if (ctx.size_m <= 16384) {
-            return set_params({64,256,32,4,64,64,32}, 1, false);
-          }
-          return set_params({64,256,32,4,64,64,32}, 1, true);
+        if (ctx.size_m <= 16384) {
+          return set_params({64, 256, 32, 4, 64, 64, 32}, 1, false);
+        }
+        return set_params({64, 256, 32, 4, 64, 64, 32}, 1, true);
       }
     }
     // top_k=8
     if (ctx.top_k == 8 && ctx.size_k == 2048) {
       if (ctx.size_n == 128) {
-          if (ctx.size_m <= 2048) {
-            return set_params({32,128,32,4,32,32,32}, 1, true);
-          }
-          return set_params({64,128,32,8,32,32,32}, 1, true);
+        if (ctx.size_m <= 2048) {
+          return set_params({32, 128, 32, 4, 32, 32, 32}, 1, true);
+        }
+        return set_params({64, 128, 32, 8, 32, 32, 32}, 1, true);
       }
     }
     if (ctx.top_k == 8 && ctx.size_k == 2048) {
       if (ctx.size_n == 256) {
-          if (ctx.size_m <= 2048) {
-            return set_params({64,256,32,4,64,64,32}, 1, true);
-          }
-          return set_params({64,256,64,8,64,64,32}, 1, false);
+        if (ctx.size_m <= 2048) {
+          return set_params({64, 256, 32, 4, 64, 64, 32}, 1, true);
+        }
+        return set_params({64, 256, 64, 8, 64, 64, 32}, 1, false);
       }
     }
     if (ctx.top_k == 8 && ctx.size_k == 2048) {
       if (ctx.size_n == 1024) {
-          if (ctx.size_m <= 2048) {
-            return set_params({64,256,32,4,64,64,32}, 1, false);
-          }
-          return set_params({64,256,32,4,64,64,32}, 1, true);
+        if (ctx.size_m <= 2048) {
+          return set_params({64, 256, 32, 4, 64, 64, 32}, 1, false);
+        }
+        return set_params({64, 256, 32, 4, 64, 64, 32}, 1, true);
       }
     }
   }
@@ -1696,17 +1677,16 @@ inline bool sm70_marlin_moe_try_select_nvidia_qwen3_6_35b_a3b_nvfp4_params(
   return false;
 }
 
-inline bool sm70_marlin_moe_try_select_nvidia_qwen3_next_80b_a3b_thinking_nvfp4_params(
-    Sm70MarlinMoeAutoParamsContext const& ctx,
-    Sm70MarlinAutoParams& params) {
+inline bool
+sm70_marlin_moe_try_select_nvidia_qwen3_next_80b_a3b_thinking_nvfp4_params(
+    Sm70MarlinMoeAutoParamsContext const& ctx, Sm70MarlinAutoParams& params) {
   if (ctx.quant_format == nullptr ||
-      std::strcmp(ctx.quant_format, "nvfp4") != 0 ||
-      ctx.group_size != 16 || ctx.size_m <= 0) {
+      std::strcmp(ctx.quant_format, "nvfp4") != 0 || ctx.group_size != 16 ||
+      ctx.size_m <= 0) {
     return false;
   }
 
-  auto const set_params = [&](Sm70CtaGeometry geometry,
-                              int requested_split_k,
+  auto const set_params = [&](Sm70CtaGeometry geometry, int requested_split_k,
                               bool use_metadata_vector_words) {
     params = {geometry, requested_split_k, use_metadata_vector_words,
               ctx.packed_macro_n};
@@ -1718,69 +1698,69 @@ inline bool sm70_marlin_moe_try_select_nvidia_qwen3_next_80b_a3b_thinking_nvfp4_
     // top_k=1
     if (ctx.top_k == 1 && ctx.size_n == 2048) {
       if (ctx.size_k == 64) {
-          if (ctx.size_m <= 10) {
-            return set_params({32,128,32,4,32,32,32}, 1, false);
-          }
-          if (ctx.size_m <= 320) {
-            return set_params({32,128,32,4,32,32,32}, 1, true);
-          }
-          return set_params({32,256,32,4,32,64,32}, 1, true);
+        if (ctx.size_m <= 10) {
+          return set_params({32, 128, 32, 4, 32, 32, 32}, 1, false);
+        }
+        if (ctx.size_m <= 320) {
+          return set_params({32, 128, 32, 4, 32, 32, 32}, 1, true);
+        }
+        return set_params({32, 256, 32, 4, 32, 64, 32}, 1, true);
       }
     }
     if (ctx.top_k == 1 && ctx.size_n == 2048) {
       if (ctx.size_k == 128) {
-          if (ctx.size_m <= 10) {
-            return set_params({32,128,32,4,32,32,32}, 1, true);
-          }
-          if (ctx.size_m <= 320) {
-            return set_params({32,128,32,4,32,32,32}, 1, true);
-          }
-          return set_params({32,256,32,4,32,64,32}, 1, true);
+        if (ctx.size_m <= 10) {
+          return set_params({32, 128, 32, 4, 32, 32, 32}, 1, true);
+        }
+        if (ctx.size_m <= 320) {
+          return set_params({32, 128, 32, 4, 32, 32, 32}, 1, true);
+        }
+        return set_params({32, 256, 32, 4, 32, 64, 32}, 1, true);
       }
     }
     if (ctx.top_k == 1 && ctx.size_n == 2048) {
       if (ctx.size_k == 512) {
-          if (ctx.size_m <= 10) {
-            return set_params({32,256,64,8,32,64,32}, 1, true);
-          }
-          if (ctx.size_m <= 320) {
-            return set_params({32,128,32,4,32,32,32}, 1, true);
-          }
-          return set_params({32,128,32,4,32,32,32}, 1, false);
+        if (ctx.size_m <= 10) {
+          return set_params({32, 256, 64, 8, 32, 64, 32}, 1, true);
+        }
+        if (ctx.size_m <= 320) {
+          return set_params({32, 128, 32, 4, 32, 32, 32}, 1, true);
+        }
+        return set_params({32, 128, 32, 4, 32, 32, 32}, 1, false);
       }
     }
     // top_k=10
     if (ctx.top_k == 10 && ctx.size_k == 2048) {
       if (ctx.size_n == 128) {
-          if (ctx.size_m <= 1) {
-            return set_params({32,64,32,4,32,32,16}, 8, false);
-          }
-          if (ctx.size_m <= 32) {
-            return set_params({32,128,64,8,32,64,16}, 2, true);
-          }
-          return set_params({32,128,128,8,32,64,32}, 1, true);
+        if (ctx.size_m <= 1) {
+          return set_params({32, 64, 32, 4, 32, 32, 16}, 8, false);
+        }
+        if (ctx.size_m <= 32) {
+          return set_params({32, 128, 64, 8, 32, 64, 16}, 2, true);
+        }
+        return set_params({32, 128, 128, 8, 32, 64, 32}, 1, true);
       }
     }
     if (ctx.top_k == 10 && ctx.size_k == 2048) {
       if (ctx.size_n == 256) {
-          if (ctx.size_m <= 1) {
-            return set_params({32,128,32,4,32,32,32}, 8, true);
-          }
-          if (ctx.size_m <= 32) {
-            return set_params({32,128,128,8,32,64,32}, 1, true);
-          }
-          return set_params({32,256,64,8,32,64,32}, 1, true);
+        if (ctx.size_m <= 1) {
+          return set_params({32, 128, 32, 4, 32, 32, 32}, 8, true);
+        }
+        if (ctx.size_m <= 32) {
+          return set_params({32, 128, 128, 8, 32, 64, 32}, 1, true);
+        }
+        return set_params({32, 256, 64, 8, 32, 64, 32}, 1, true);
       }
     }
     if (ctx.top_k == 10 && ctx.size_k == 2048) {
       if (ctx.size_n == 1024) {
-          if (ctx.size_m <= 1) {
-            return set_params({32,128,128,8,32,64,32}, 1, true);
-          }
-          if (ctx.size_m <= 32) {
-            return set_params({32,256,32,4,32,64,32}, 1, false);
-          }
-          return set_params({32,128,32,4,32,32,32}, 1, true);
+        if (ctx.size_m <= 1) {
+          return set_params({32, 128, 128, 8, 32, 64, 32}, 1, true);
+        }
+        if (ctx.size_m <= 32) {
+          return set_params({32, 256, 32, 4, 32, 64, 32}, 1, false);
+        }
+        return set_params({32, 128, 32, 4, 32, 32, 32}, 1, true);
       }
     }
   }
@@ -1790,13 +1770,13 @@ inline bool sm70_marlin_moe_try_select_nvidia_qwen3_next_80b_a3b_thinking_nvfp4_
     // top_k=1
     if (ctx.top_k == 1 && ctx.size_n == 2048) {
       if (ctx.size_k == 512) {
-        return set_params({32,128,32,4,32,32,32}, 1, true);
+        return set_params({32, 128, 32, 4, 32, 32, 32}, 1, true);
       }
     }
     // top_k=10
     if (ctx.top_k == 10 && ctx.size_k == 2048) {
       if (ctx.size_n == 1024) {
-        return set_params({32,128,32,4,32,32,32}, 1, true);
+        return set_params({32, 128, 32, 4, 32, 32, 32}, 1, true);
       }
     }
   }
@@ -1806,23 +1786,23 @@ inline bool sm70_marlin_moe_try_select_nvidia_qwen3_next_80b_a3b_thinking_nvfp4_
     // top_k=1
     if (ctx.top_k == 1 && ctx.size_n == 2048) {
       if (ctx.size_k == 64) {
-        return set_params({64,256,32,4,64,64,32}, 1, true);
+        return set_params({64, 256, 32, 4, 64, 64, 32}, 1, true);
       }
     }
     if (ctx.top_k == 1 && ctx.size_n == 2048) {
       if (ctx.size_k == 128) {
-        return set_params({64,256,32,4,64,64,32}, 1, true);
+        return set_params({64, 256, 32, 4, 64, 64, 32}, 1, true);
       }
     }
     // top_k=10
     if (ctx.top_k == 10 && ctx.size_k == 2048) {
       if (ctx.size_n == 128) {
-        return set_params({64,128,32,8,32,32,32}, 1, false);
+        return set_params({64, 128, 32, 8, 32, 32, 32}, 1, false);
       }
     }
     if (ctx.top_k == 10 && ctx.size_k == 2048) {
       if (ctx.size_n == 256) {
-        return set_params({64,256,32,4,64,64,32}, 1, false);
+        return set_params({64, 256, 32, 4, 64, 64, 32}, 1, false);
       }
     }
   }
@@ -1832,36 +1812,36 @@ inline bool sm70_marlin_moe_try_select_nvidia_qwen3_next_80b_a3b_thinking_nvfp4_
     // top_k=1
     if (ctx.top_k == 1 && ctx.size_n == 2048) {
       if (ctx.size_k == 64) {
-        return set_params({64,256,32,4,64,64,32}, 1, true);
+        return set_params({64, 256, 32, 4, 64, 64, 32}, 1, true);
       }
     }
     if (ctx.top_k == 1 && ctx.size_n == 2048) {
       if (ctx.size_k == 128) {
-        return set_params({64,256,32,4,64,64,32}, 1, true);
+        return set_params({64, 256, 32, 4, 64, 64, 32}, 1, true);
       }
     }
     if (ctx.top_k == 1 && ctx.size_n == 2048) {
       if (ctx.size_k == 512) {
-          if (ctx.size_m <= 20480) {
-            return set_params({64,256,32,4,64,64,32}, 1, false);
-          }
-          return set_params({64,256,32,4,64,64,32}, 1, true);
+        if (ctx.size_m <= 20480) {
+          return set_params({64, 256, 32, 4, 64, 64, 32}, 1, false);
+        }
+        return set_params({64, 256, 32, 4, 64, 64, 32}, 1, true);
       }
     }
     // top_k=10
     if (ctx.top_k == 10 && ctx.size_k == 2048) {
       if (ctx.size_n == 128) {
-        return set_params({64,128,32,8,32,32,32}, 1, true);
+        return set_params({64, 128, 32, 8, 32, 32, 32}, 1, true);
       }
     }
     if (ctx.top_k == 10 && ctx.size_k == 2048) {
       if (ctx.size_n == 256) {
-        return set_params({64,256,32,4,64,64,32}, 1, true);
+        return set_params({64, 256, 32, 4, 64, 64, 32}, 1, true);
       }
     }
     if (ctx.top_k == 10 && ctx.size_k == 2048) {
       if (ctx.size_n == 1024) {
-        return set_params({64,256,32,4,64,64,32}, 1, true);
+        return set_params({64, 256, 32, 4, 64, 64, 32}, 1, true);
       }
     }
   }
@@ -1870,16 +1850,14 @@ inline bool sm70_marlin_moe_try_select_nvidia_qwen3_next_80b_a3b_thinking_nvfp4_
 }
 
 inline bool sm70_marlin_moe_try_select_cyankiwi_minimax_m2_7_awq_4bit_params(
-    Sm70MarlinMoeAutoParamsContext const& ctx,
-    Sm70MarlinAutoParams& params) {
+    Sm70MarlinMoeAutoParamsContext const& ctx, Sm70MarlinAutoParams& params) {
   if (ctx.quant_format == nullptr ||
-      std::strcmp(ctx.quant_format, "uint4b8") != 0 ||
-      ctx.group_size != 32 || ctx.size_m <= 0) {
+      std::strcmp(ctx.quant_format, "uint4b8") != 0 || ctx.group_size != 32 ||
+      ctx.size_m <= 0) {
     return false;
   }
 
-  auto const set_params = [&](Sm70CtaGeometry geometry,
-                              int requested_split_k,
+  auto const set_params = [&](Sm70CtaGeometry geometry, int requested_split_k,
                               bool use_metadata_vector_words) {
     params = {geometry, requested_split_k, use_metadata_vector_words,
               ctx.packed_macro_n};
@@ -1995,16 +1973,14 @@ inline bool sm70_marlin_moe_try_select_cyankiwi_minimax_m2_7_awq_4bit_params(
 }
 
 inline bool sm70_marlin_moe_try_select_cyankiwi_glm_4_7_awq_4bit_params(
-    Sm70MarlinMoeAutoParamsContext const& ctx,
-    Sm70MarlinAutoParams& params) {
+    Sm70MarlinMoeAutoParamsContext const& ctx, Sm70MarlinAutoParams& params) {
   if (ctx.quant_format == nullptr ||
-      std::strcmp(ctx.quant_format, "uint4b8") != 0 ||
-      ctx.group_size != 32 || ctx.size_m <= 0) {
+      std::strcmp(ctx.quant_format, "uint4b8") != 0 || ctx.group_size != 32 ||
+      ctx.size_m <= 0) {
     return false;
   }
 
-  auto const set_params = [&](Sm70CtaGeometry geometry,
-                              int requested_split_k,
+  auto const set_params = [&](Sm70CtaGeometry geometry, int requested_split_k,
                               bool use_metadata_vector_words) {
     params = {geometry, requested_split_k, use_metadata_vector_words,
               ctx.packed_macro_n};
@@ -2108,16 +2084,14 @@ inline bool sm70_marlin_moe_try_select_cyankiwi_glm_4_7_awq_4bit_params(
 }
 
 inline bool sm70_marlin_moe_try_select_quanttrio_glm_4_7_awq_params(
-    Sm70MarlinMoeAutoParamsContext const& ctx,
-    Sm70MarlinAutoParams& params) {
+    Sm70MarlinMoeAutoParamsContext const& ctx, Sm70MarlinAutoParams& params) {
   if (ctx.quant_format == nullptr ||
-      std::strcmp(ctx.quant_format, "uint4") != 0 ||
-      ctx.group_size != 128 || ctx.size_m <= 0) {
+      std::strcmp(ctx.quant_format, "uint4") != 0 || ctx.group_size != 128 ||
+      ctx.size_m <= 0) {
     return false;
   }
 
-  auto const set_params = [&](Sm70CtaGeometry geometry,
-                              int requested_split_k,
+  auto const set_params = [&](Sm70CtaGeometry geometry, int requested_split_k,
                               bool use_metadata_vector_words) {
     params = {geometry, requested_split_k, use_metadata_vector_words,
               ctx.packed_macro_n};
@@ -2206,20 +2180,21 @@ inline bool sm70_marlin_moe_try_select_quanttrio_glm_4_7_awq_params(
 }
 
 inline Sm70MarlinAutoParams sm70_marlin_moe_auto_stage_params(
-    char const* quant_format, int64_t group_size,
-    int64_t moe_block_size, int64_t top_k, int64_t size_m,
-    int64_t size_n, int64_t size_k) {
+    char const* quant_format, int64_t group_size, int64_t moe_block_size,
+    int64_t top_k, int64_t size_m, int64_t size_n, int64_t size_k) {
   Sm70MarlinMoeAutoParamsContext const ctx{
-      quant_format, group_size, moe_block_size, top_k, size_m, size_n, size_k,
-      sm70_marlin_auto_packed_macro_n(size_n)};
+      quant_format,   group_size,
+      moe_block_size, top_k,
+      size_m,         size_n,
+      size_k,         sm70_marlin_auto_packed_macro_n(size_n)};
 
   if (sm70_marlin_moe_auto_env_is_set()) {
     return sm70_marlin_moe_auto_params_from_env(ctx);
   }
 
   Sm70MarlinAutoParams params{};
-  if (sm70_marlin_moe_try_select_quanttrio_qwen3_6_35b_a3b_awq_params(
-          ctx, params)) {
+  if (sm70_marlin_moe_try_select_quanttrio_qwen3_6_35b_a3b_awq_params(ctx,
+                                                                      params)) {
     validate_sm70_marlin_auto_params("MoE", params);
     return params;
   }
@@ -2228,8 +2203,8 @@ inline Sm70MarlinAutoParams sm70_marlin_moe_auto_stage_params(
     validate_sm70_marlin_auto_params("MoE", params);
     return params;
   }
-  if (sm70_marlin_moe_try_select_quanttrio_minimax_m2_7_awq_params(
-          ctx, params)) {
+  if (sm70_marlin_moe_try_select_quanttrio_minimax_m2_7_awq_params(ctx,
+                                                                   params)) {
     validate_sm70_marlin_auto_params("MoE", params);
     return params;
   }
@@ -2258,18 +2233,17 @@ inline Sm70MarlinAutoParams sm70_marlin_moe_auto_stage_params(
     validate_sm70_marlin_auto_params("MoE", params);
     return params;
   }
-  if (sm70_marlin_moe_try_select_nvidia_glm_4_7_nvfp4_params(
-          ctx, params)) {
+  if (sm70_marlin_moe_try_select_nvidia_glm_4_7_nvfp4_params(ctx, params)) {
     validate_sm70_marlin_auto_params("MoE", params);
     return params;
   }
-  if (sm70_marlin_moe_try_select_nvidia_minimax_m2_7_nvfp4_params(
-          ctx, params)) {
+  if (sm70_marlin_moe_try_select_nvidia_minimax_m2_7_nvfp4_params(ctx,
+                                                                  params)) {
     validate_sm70_marlin_auto_params("MoE", params);
     return params;
   }
-  if (sm70_marlin_moe_try_select_nvidia_qwen3_6_35b_a3b_nvfp4_params(
-          ctx, params)) {
+  if (sm70_marlin_moe_try_select_nvidia_qwen3_6_35b_a3b_nvfp4_params(ctx,
+                                                                     params)) {
     validate_sm70_marlin_auto_params("MoE", params);
     return params;
   }
@@ -2283,13 +2257,12 @@ inline Sm70MarlinAutoParams sm70_marlin_moe_auto_stage_params(
     validate_sm70_marlin_auto_params("MoE", params);
     return params;
   }
-  if (sm70_marlin_moe_try_select_cyankiwi_glm_4_7_awq_4bit_params(
-          ctx, params)) {
+  if (sm70_marlin_moe_try_select_cyankiwi_glm_4_7_awq_4bit_params(ctx,
+                                                                  params)) {
     validate_sm70_marlin_auto_params("MoE", params);
     return params;
   }
-  if (sm70_marlin_moe_try_select_quanttrio_glm_4_7_awq_params(
-          ctx, params)) {
+  if (sm70_marlin_moe_try_select_quanttrio_glm_4_7_awq_params(ctx, params)) {
     validate_sm70_marlin_auto_params("MoE", params);
     return params;
   }
@@ -2303,46 +2276,44 @@ inline bool sm70_marlin_moe_cta_geometry_is_supported(
          sm70_marlin_cta_geometry_is_supported(geometry);
 }
 
-inline void validate_sm70_marlin_moe_stage_cta_geometry_supported(char const* op_name,
-                                                                  Sm70CtaGeometry geometry) {
+inline void validate_sm70_marlin_moe_stage_cta_geometry_supported(
+    char const* op_name, Sm70CtaGeometry geometry) {
   TORCH_CHECK(sm70_marlin_moe_cta_geometry_is_supported(geometry),
               "Unsupported SM70 Marlin MoE CTA geometry for ", op_name, ": ",
-              geometry.cta_m, "x", geometry.cta_n, "x", geometry.cta_k,
-              "x", geometry.warps, "x", geometry.warp_m, "x",
-              geometry.warp_n, "x", geometry.warp_k,
-              ". Supported geometries are ",
+              geometry.cta_m, "x", geometry.cta_n, "x", geometry.cta_k, "x",
+              geometry.warps, "x", geometry.warp_m, "x", geometry.warp_n, "x",
+              geometry.warp_k, ". Supported geometries are ",
               kSupportedSm70MarlinMoeCtaGeometries, ".");
 }
 
-inline void validate_sm70_marlin_moe_stage_cta_n_alignment(char const* op_name,
-                                                           Sm70CtaGeometry geometry,
-                                                           int64_t size_n) {
+inline void validate_sm70_marlin_moe_stage_cta_n_alignment(
+    char const* op_name, Sm70CtaGeometry geometry, int64_t size_n) {
   TORCH_CHECK(
       size_n % geometry.cta_n == 0 && size_n % kQuantTileN == 0,
       "SM70 Marlin MoE requires size_n divisible by both CTA_N and 64 for ",
-      op_name, " with CTA geometry ", geometry.cta_m, "x", geometry.cta_n,
-      "x", geometry.cta_k, "x", geometry.warps, "x", geometry.warp_m,
-      "x", geometry.warp_n, "x", geometry.warp_k, ". Got size_n = ",
-      size_n, ".");
+      op_name, " with CTA geometry ", geometry.cta_m, "x", geometry.cta_n, "x",
+      geometry.cta_k, "x", geometry.warps, "x", geometry.warp_m, "x",
+      geometry.warp_n, "x", geometry.warp_k, ". Got size_n = ", size_n, ".");
 }
 
 template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM, int WarpN,
           int WarpK, int PackedMacroN, typename Launcher>
-torch::Tensor dispatch_sm70_marlin_moe_group_size(
-    Launcher const& launcher, int64_t group_size, char const* quant_name) {
+torch::Tensor dispatch_sm70_marlin_moe_group_size(Launcher const& launcher,
+                                                  int64_t group_size,
+                                                  char const* quant_name) {
   switch (group_size) {
     case -1:
-      return launcher.template operator()<CtaM, CtaN, CtaK, Warps, WarpM,
-                                          WarpN, WarpK, -1, PackedMacroN>();
+      return launcher.template operator()<CtaM, CtaN, CtaK, Warps, WarpM, WarpN,
+                                          WarpK, -1, PackedMacroN>();
     case 32:
-      return launcher.template operator()<CtaM, CtaN, CtaK, Warps, WarpM,
-                                          WarpN, WarpK, 32, PackedMacroN>();
+      return launcher.template operator()<CtaM, CtaN, CtaK, Warps, WarpM, WarpN,
+                                          WarpK, 32, PackedMacroN>();
     case 64:
-      return launcher.template operator()<CtaM, CtaN, CtaK, Warps, WarpM,
-                                          WarpN, WarpK, 64, PackedMacroN>();
+      return launcher.template operator()<CtaM, CtaN, CtaK, Warps, WarpM, WarpN,
+                                          WarpK, 64, PackedMacroN>();
     case 128:
-      return launcher.template operator()<CtaM, CtaN, CtaK, Warps, WarpM,
-                                          WarpN, WarpK, 128, PackedMacroN>();
+      return launcher.template operator()<CtaM, CtaN, CtaK, Warps, WarpM, WarpN,
+                                          WarpK, 128, PackedMacroN>();
     default:
       TORCH_CHECK(false, "SM70 Marlin MoE ", quant_name,
                   " supports only group_size -1, 32, 64, or 128. Got ",
@@ -2357,17 +2328,17 @@ torch::Tensor dispatch_sm70_marlin_moe_group_size_with_group32(
     Launcher const& launcher, int64_t group_size, char const* quant_name) {
   switch (group_size) {
     case -1:
-      return launcher.template operator()<CtaM, CtaN, CtaK, Warps, WarpM,
-                                          WarpN, WarpK, -1, PackedMacroN>();
+      return launcher.template operator()<CtaM, CtaN, CtaK, Warps, WarpM, WarpN,
+                                          WarpK, -1, PackedMacroN>();
     case 32:
-      return launcher.template operator()<CtaM, CtaN, CtaK, Warps, WarpM,
-                                          WarpN, WarpK, 32, PackedMacroN>();
+      return launcher.template operator()<CtaM, CtaN, CtaK, Warps, WarpM, WarpN,
+                                          WarpK, 32, PackedMacroN>();
     case 64:
-      return launcher.template operator()<CtaM, CtaN, CtaK, Warps, WarpM,
-                                          WarpN, WarpK, 64, PackedMacroN>();
+      return launcher.template operator()<CtaM, CtaN, CtaK, Warps, WarpM, WarpN,
+                                          WarpK, 64, PackedMacroN>();
     case 128:
-      return launcher.template operator()<CtaM, CtaN, CtaK, Warps, WarpM,
-                                          WarpN, WarpK, 128, PackedMacroN>();
+      return launcher.template operator()<CtaM, CtaN, CtaK, Warps, WarpM, WarpN,
+                                          WarpK, 128, PackedMacroN>();
     default:
       TORCH_CHECK(false, "SM70 Marlin MoE ", quant_name,
                   " supports only group_size -1, 32, 64, or 128. Got ",
@@ -2378,15 +2349,15 @@ torch::Tensor dispatch_sm70_marlin_moe_group_size_with_group32(
 
 template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM, int WarpN,
           int WarpK, int PackedMacroN, typename Launcher>
-torch::Tensor dispatch_sm70_marlin_moe_fp8_group_size(
-    Launcher const& launcher, int64_t group_size) {
+torch::Tensor dispatch_sm70_marlin_moe_fp8_group_size(Launcher const& launcher,
+                                                      int64_t group_size) {
   switch (group_size) {
     case -1:
-      return launcher.template operator()<CtaM, CtaN, CtaK, Warps, WarpM,
-                                          WarpN, WarpK, -1, PackedMacroN>();
+      return launcher.template operator()<CtaM, CtaN, CtaK, Warps, WarpM, WarpN,
+                                          WarpK, -1, PackedMacroN>();
     case 128:
-      return launcher.template operator()<CtaM, CtaN, CtaK, Warps, WarpM,
-                                          WarpN, WarpK, 128, PackedMacroN>();
+      return launcher.template operator()<CtaM, CtaN, CtaK, Warps, WarpM, WarpN,
+                                          WarpK, 128, PackedMacroN>();
     default:
       TORCH_CHECK(false,
                   "SM70 Marlin MoE fp8_e4m3 supports only group_size -1 "
@@ -2448,10 +2419,9 @@ struct Sm70MarlinMoeFp8GroupSizeDispatchLauncher {
   template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM, int WarpN,
             int WarpK, int PackedMacroN>
   torch::Tensor operator()() const {
-    return dispatch_sm70_marlin_moe_fp8_group_size<CtaM, CtaN, CtaK, Warps,
-                                                   WarpM, WarpN, WarpK,
-                                                   PackedMacroN>(
-        inner, group_size);
+    return dispatch_sm70_marlin_moe_fp8_group_size<
+        CtaM, CtaN, CtaK, Warps, WarpM, WarpN, WarpK, PackedMacroN>(inner,
+                                                                    group_size);
   }
 };
 
@@ -2465,59 +2435,59 @@ struct Sm70MarlinMoeFixedGroupSizeDispatchLauncher {
             int WarpK, int PackedMacroN>
   torch::Tensor operator()() const {
     return dispatch_sm70_marlin_moe_fixed_group_size<
-        CtaM, CtaN, CtaK, Warps, WarpM, WarpN, WarpK, GroupSize,
-        PackedMacroN>(inner, group_size, quant_name);
+        CtaM, CtaN, CtaK, Warps, WarpM, WarpN, WarpK, GroupSize, PackedMacroN>(
+        inner, group_size, quant_name);
   }
 };
 
 template <typename Launcher>
-torch::Tensor dispatch_sm70_marlin_moe_cta_geometry(
-    Launcher const& launcher, Sm70CtaGeometry geometry, int packed_macro_n,
-    char const* quant_name) {
-#define DISPATCH_SM70_MOE_PACKED_MACRO_N(CM, CN, CK, W, WM, WN, WK, PMN)  \
+torch::Tensor dispatch_sm70_marlin_moe_cta_geometry(Launcher const& launcher,
+                                                    Sm70CtaGeometry geometry,
+                                                    int packed_macro_n,
+                                                    char const* quant_name) {
+#define DISPATCH_SM70_MOE_PACKED_MACRO_N(CM, CN, CK, W, WM, WN, WK, PMN)   \
   if (packed_macro_n == PMN) {                                             \
     return launcher.template operator()<CM, CN, CK, W, WM, WN, WK, PMN>(); \
   }
 
-#define DISPATCH_SM70_MOE_GEOMETRY(CM, CN, CK, W, WM, WN, WK, PMN)         \
-  if (geometry.cta_m == CM && geometry.cta_n == CN &&                      \
-      geometry.cta_k == CK && geometry.warps == W &&                       \
-      geometry.warp_m == WM && geometry.warp_n == WN &&                    \
-      geometry.warp_k == WK) {                                             \
-    DISPATCH_SM70_MOE_PACKED_MACRO_N(CM, CN, CK, W, WM, WN, WK, PMN)       \
+#define DISPATCH_SM70_MOE_GEOMETRY(CM, CN, CK, W, WM, WN, WK, PMN)             \
+  if (geometry.cta_m == CM && geometry.cta_n == CN && geometry.cta_k == CK &&  \
+      geometry.warps == W && geometry.warp_m == WM && geometry.warp_n == WN && \
+      geometry.warp_k == WK) {                                                 \
+    DISPATCH_SM70_MOE_PACKED_MACRO_N(CM, CN, CK, W, WM, WN, WK, PMN)           \
   }
 
-#define FOR_EACH_SM70_MOE_GEOMETRY(M)                                     \
-  M(32, 64, 32, 4, 32, 32, 16, 128)                                       \
-  M(32, 64, 32, 4, 32, 32, 16, 256)                                       \
-  M(32, 64, 64, 4, 32, 32, 32, 128)                                       \
-  M(32, 64, 64, 4, 32, 32, 32, 256)                                       \
-  M(32, 128, 32, 4, 32, 32, 32, 128)                                      \
-  M(32, 128, 32, 4, 32, 32, 32, 256)                                      \
-  M(32, 128, 32, 4, 32, 64, 16, 128)                                      \
-  M(32, 128, 32, 4, 32, 64, 16, 256)                                      \
-  M(32, 128, 64, 4, 32, 64, 32, 128)                                      \
-  M(32, 128, 64, 4, 32, 64, 32, 256)                                      \
-  M(32, 128, 64, 8, 32, 32, 32, 128)                                      \
-  M(32, 128, 64, 8, 32, 32, 32, 256)                                      \
-  M(32, 128, 64, 8, 32, 64, 16, 128)                                      \
-  M(32, 128, 64, 8, 32, 64, 16, 256)                                      \
-  M(32, 128, 128, 8, 32, 64, 32, 128)                                     \
-  M(32, 128, 128, 8, 32, 64, 32, 256)                                     \
-  M(32, 256, 32, 4, 32, 64, 32, 256)                                      \
-  M(32, 256, 64, 8, 32, 64, 32, 256)                                      \
-  M(64, 64, 32, 4, 32, 32, 32, 64)                                        \
-  M(64, 64, 32, 4, 32, 32, 32, 128)                                       \
-  M(64, 64, 32, 4, 32, 32, 32, 256)                                       \
-  M(64, 128, 32, 4, 32, 64, 32, 128)                                      \
-  M(64, 128, 32, 4, 32, 64, 32, 256)                                      \
-  M(64, 128, 32, 4, 64, 64, 16, 128)                                      \
-  M(64, 128, 32, 4, 64, 64, 16, 256)                                      \
-  M(64, 128, 32, 8, 32, 32, 32, 128)                                      \
-  M(64, 128, 32, 8, 32, 32, 32, 256)                                      \
-  M(64, 128, 64, 4, 64, 64, 32, 128)                                      \
-  M(64, 128, 64, 4, 64, 64, 32, 256)                                      \
-  M(64, 256, 32, 4, 64, 64, 32, 256)                                      \
+#define FOR_EACH_SM70_MOE_GEOMETRY(M) \
+  M(32, 64, 32, 4, 32, 32, 16, 128)   \
+  M(32, 64, 32, 4, 32, 32, 16, 256)   \
+  M(32, 64, 64, 4, 32, 32, 32, 128)   \
+  M(32, 64, 64, 4, 32, 32, 32, 256)   \
+  M(32, 128, 32, 4, 32, 32, 32, 128)  \
+  M(32, 128, 32, 4, 32, 32, 32, 256)  \
+  M(32, 128, 32, 4, 32, 64, 16, 128)  \
+  M(32, 128, 32, 4, 32, 64, 16, 256)  \
+  M(32, 128, 64, 4, 32, 64, 32, 128)  \
+  M(32, 128, 64, 4, 32, 64, 32, 256)  \
+  M(32, 128, 64, 8, 32, 32, 32, 128)  \
+  M(32, 128, 64, 8, 32, 32, 32, 256)  \
+  M(32, 128, 64, 8, 32, 64, 16, 128)  \
+  M(32, 128, 64, 8, 32, 64, 16, 256)  \
+  M(32, 128, 128, 8, 32, 64, 32, 128) \
+  M(32, 128, 128, 8, 32, 64, 32, 256) \
+  M(32, 256, 32, 4, 32, 64, 32, 256)  \
+  M(32, 256, 64, 8, 32, 64, 32, 256)  \
+  M(64, 64, 32, 4, 32, 32, 32, 64)    \
+  M(64, 64, 32, 4, 32, 32, 32, 128)   \
+  M(64, 64, 32, 4, 32, 32, 32, 256)   \
+  M(64, 128, 32, 4, 32, 64, 32, 128)  \
+  M(64, 128, 32, 4, 32, 64, 32, 256)  \
+  M(64, 128, 32, 4, 64, 64, 16, 128)  \
+  M(64, 128, 32, 4, 64, 64, 16, 256)  \
+  M(64, 128, 32, 8, 32, 32, 32, 128)  \
+  M(64, 128, 32, 8, 32, 32, 32, 256)  \
+  M(64, 128, 64, 4, 64, 64, 32, 128)  \
+  M(64, 128, 64, 4, 64, 64, 32, 256)  \
+  M(64, 256, 32, 4, 64, 64, 32, 256)  \
   M(64, 256, 64, 8, 64, 64, 32, 256)
 
   FOR_EACH_SM70_MOE_GEOMETRY(DISPATCH_SM70_MOE_GEOMETRY)
@@ -2537,8 +2507,8 @@ torch::Tensor dispatch_sm70_marlin_moe_geometry(Launcher const& launcher,
                                                 int64_t group_size,
                                                 char const* quant_name) {
   return dispatch_sm70_marlin_moe_cta_geometry(
-      Sm70MarlinMoeGroupSizeDispatchLauncher<Launcher>{
-          launcher, group_size, quant_name},
+      Sm70MarlinMoeGroupSizeDispatchLauncher<Launcher>{launcher, group_size,
+                                                       quant_name},
       geometry, packed_macro_n, quant_name);
 }
 
@@ -2547,18 +2517,18 @@ torch::Tensor dispatch_sm70_marlin_moe_geometry_with_group32(
     Launcher const& launcher, Sm70CtaGeometry geometry, int packed_macro_n,
     int64_t group_size, char const* quant_name) {
   return dispatch_sm70_marlin_moe_cta_geometry(
-      Sm70MarlinMoeGroupSize32DispatchLauncher<Launcher>{
-          launcher, group_size, quant_name},
+      Sm70MarlinMoeGroupSize32DispatchLauncher<Launcher>{launcher, group_size,
+                                                         quant_name},
       geometry, packed_macro_n, quant_name);
 }
 
 template <typename Launcher>
-torch::Tensor dispatch_sm70_marlin_moe_fp8_geometry(
-    Launcher const& launcher, Sm70CtaGeometry geometry, int packed_macro_n,
-    int64_t group_size) {
+torch::Tensor dispatch_sm70_marlin_moe_fp8_geometry(Launcher const& launcher,
+                                                    Sm70CtaGeometry geometry,
+                                                    int packed_macro_n,
+                                                    int64_t group_size) {
   return dispatch_sm70_marlin_moe_cta_geometry(
-      Sm70MarlinMoeFp8GroupSizeDispatchLauncher<Launcher>{launcher,
-                                                          group_size},
+      Sm70MarlinMoeFp8GroupSizeDispatchLauncher<Launcher>{launcher, group_size},
       geometry, packed_macro_n, "fp8_e4m3");
 }
 
@@ -2603,8 +2573,8 @@ class Sm70MoeGatherIteratorA {
   using Element = cutlass::half_t;
   using Layout = cutlass::layout::RowMajor;
   using TensorCoord = cutlass::MatrixCoord;
-  using Fragment = cutlass::Array<
-      Element, ThreadMap::Iterations::kCount * ThreadMap::kElementsPerAccess>;
+  using Fragment = cutlass::Array<Element, ThreadMap::Iterations::kCount *
+                                               ThreadMap::kElementsPerAccess>;
   struct Params {
     int lda;
     int moe_block_size;
@@ -2689,9 +2659,8 @@ class Sm70MoeGatherIteratorA {
 
     CUTLASS_PRAGMA_UNROLL
     for (int s = 0; s < ThreadMap::Iterations::kStrided; ++s) {
-      int const local_row =
-          local_m_offset_ + thread_offset_.strided() +
-          s * ThreadMap::Delta::kStrided;
+      int const local_row = local_m_offset_ + thread_offset_.strided() +
+                            s * ThreadMap::Delta::kStrided;
       int const route_row = moe_block_ * params_.moe_block_size + local_row;
 
       int sorted_id = -1;
@@ -2699,20 +2668,17 @@ class Sm70MoeGatherIteratorA {
                        route_row < params_.padded_tokens;
       if (valid_row) {
         sorted_id = sorted_token_ids_[route_row];
-        valid_row =
-            sorted_id >= 0 && sorted_id < params_.expanded_token_count;
+        valid_row = sorted_id >= 0 && sorted_id < params_.expanded_token_count;
       }
 
       int const token_row = valid_row ? (sorted_id / params_.top_k) : 0;
 
       CUTLASS_PRAGMA_UNROLL
       for (int c = 0; c < ThreadMap::Iterations::kContiguous; ++c) {
-        int const logical_k =
-            k_offset_ + thread_offset_.contiguous() +
-            c * ThreadMap::Delta::kContiguous;
-        int const frag_base =
-            (c + s * ThreadMap::Iterations::kContiguous) *
-            ThreadMap::kElementsPerAccess;
+        int const logical_k = k_offset_ + thread_offset_.contiguous() +
+                              c * ThreadMap::Delta::kContiguous;
+        int const frag_base = (c + s * ThreadMap::Iterations::kContiguous) *
+                              ThreadMap::kElementsPerAccess;
         bool const valid = valid_row && logical_k < params_.lda;
 
         CUTLASS_PRAGMA_UNROLL
@@ -2754,8 +2720,8 @@ struct Sm70MarlinMoeGemmTraits {
   using LayoutB = cutlass::layout::RowMajor;
   using LayoutC = cutlass::layout::RowMajor;
   using ThreadblockShape = cutlass::gemm::GemmShape<CtaM, CtaN, CtaK>;
-  using WarpShape =
-      typename Sm70WarpShape<CtaM, CtaN, CtaK, Warps, WarpM, WarpN, WarpK>::Type;
+  using WarpShape = typename Sm70WarpShape<CtaM, CtaN, CtaK, Warps, WarpM,
+                                           WarpN, WarpK>::Type;
   static_assert(WarpShape::kM <= 64 && WarpShape::kN <= 64,
                 "SM70 Marlin MoE keeps per-warp M/N no larger than 64.");
   using InstructionShape = cutlass::gemm::GemmShape<8, 8, 4>;
@@ -2763,13 +2729,16 @@ struct Sm70MarlinMoeGemmTraits {
       ThreadblockShape, WarpShape, InstructionShape, ElementA, LayoutA,
       ElementB, LayoutB, ElementAccumulator, LayoutC,
       cutlass::arch::OpClassTensorOp, 2, cutlass::arch::OpMultiplyAdd>;
-  static_assert(MmaCore::kThreads == Warps * 32,
-                "SM70 Marlin MoE launch threads must match CUTLASS warp count.");
-  using IteratorA = typename Spec::template IteratorA<
-      ThreadblockShape, typename MmaCore::IteratorThreadMapA>;
-  using IteratorB = typename Spec::template IteratorB<
-      ThreadblockShape, typename MmaCore::IteratorThreadMapB, GroupSize,
-      PackedMacroN>;
+  static_assert(
+      MmaCore::kThreads == Warps * 32,
+      "SM70 Marlin MoE launch threads must match CUTLASS warp count.");
+  using IteratorA =
+      typename Spec::template IteratorA<ThreadblockShape,
+                                        typename MmaCore::IteratorThreadMapA>;
+  using IteratorB =
+      typename Spec::template IteratorB<ThreadblockShape,
+                                        typename MmaCore::IteratorThreadMapB,
+                                        GroupSize, PackedMacroN>;
   using Mma = Sm70MarlinMmaPipelined<
       ThreadblockShape, IteratorA, typename MmaCore::SmemIteratorA, IteratorB,
       typename MmaCore::SmemIteratorB, ElementAccumulator, LayoutC,
@@ -2818,11 +2787,11 @@ class Sm70MoeScatterEpilogue {
                       typename SharedLoadIterator::Fragment const& frag,
                       int32_t const* __restrict__ sorted_token_ids,
                       float const* __restrict__ topk_weights,
-                      cutlass::half_t* __restrict__ c,
-                      int n, int moe_block, int local_m_offset,
-                      int moe_block_size, int expanded_token_count,
-                      int padded_tokens, bool mul_topk_weights,
-                      bool atomic_store, float output_scale) const {
+                      cutlass::half_t* __restrict__ c, int n, int moe_block,
+                      int local_m_offset, int moe_block_size,
+                      int expanded_token_count, int padded_tokens,
+                      bool mul_topk_weights, bool atomic_store,
+                      float output_scale) const {
     float const* frag_ptr = reinterpret_cast<float const*>(&frag);
     half* c_half = reinterpret_cast<half*>(c);
     int const thread_start_row = destination_iterator.thread_start_row();
@@ -2838,20 +2807,17 @@ class Sm70MoeScatterEpilogue {
           int const frag_row_idx =
               row + ThreadMap::Iterations::kRow *
                         (group + ThreadMap::Iterations::kGroup * cluster);
-          int const row_offset =
-              row * ThreadMap::Delta::kRow +
-              group * ThreadMap::Delta::kGroup +
-              cluster * ThreadMap::Delta::kCluster;
-          int const local_row =
-              local_m_offset + thread_start_row + row_offset;
+          int const row_offset = row * ThreadMap::Delta::kRow +
+                                 group * ThreadMap::Delta::kGroup +
+                                 cluster * ThreadMap::Delta::kCluster;
+          int const local_row = local_m_offset + thread_start_row + row_offset;
           int const route_row = moe_block * moe_block_size + local_row;
           bool valid_row =
               local_row < moe_block_size && route_row < padded_tokens;
           int sorted_id = -1;
           if (valid_row) {
             sorted_id = sorted_token_ids[route_row];
-            valid_row =
-                sorted_id >= 0 && sorted_id < expanded_token_count;
+            valid_row = sorted_id >= 0 && sorted_id < expanded_token_count;
           }
           float const route_scale =
               (valid_row && mul_topk_weights) ? topk_weights[sorted_id] : 1.0f;
@@ -2896,8 +2862,7 @@ class Sm70MoeScatterEpilogue {
     int const warp_mn = warp_idx % (WarpCount::kM * WarpCount::kN);
     int const warp_m = warp_mn % WarpCount::kM;
     int const warp_n = warp_mn / WarpCount::kM;
-    cutlass::MatrixCoord warp_offset{warp_k * WarpCount::kM + warp_m,
-                                     warp_n};
+    cutlass::MatrixCoord warp_offset{warp_k * WarpCount::kM + warp_m, warp_n};
     warp_tile_iterator_.add_tile_offset(warp_offset);
   }
 
@@ -2906,11 +2871,11 @@ class Sm70MoeScatterEpilogue {
                   AccumulatorTile const& accumulators,
                   int32_t const* __restrict__ sorted_token_ids,
                   float const* __restrict__ topk_weights,
-                  cutlass::half_t* __restrict__ c,
-                  int n, int moe_block, int local_m_offset,
-                  int moe_block_size, int expanded_token_count,
-                  int padded_tokens, bool mul_topk_weights,
-                  bool atomic_store, float output_scale = 1.0f) {
+                  cutlass::half_t* __restrict__ c, int n, int moe_block,
+                  int local_m_offset, int moe_block_size,
+                  int expanded_token_count, int padded_tokens,
+                  bool mul_topk_weights, bool atomic_store,
+                  float output_scale = 1.0f) {
     AccumulatorFragmentIterator accum_fragment_iterator(accumulators);
 
     CUTLASS_PRAGMA_UNROLL
@@ -2956,19 +2921,19 @@ class Sm70MoeScatterEpilogue {
 };
 
 template <typename Traits, bool SplitK>
-__global__ __launch_bounds__(Traits::MmaCore::kThreads, 1)
-void sm70_marlin_moe_gemm_kernel(
+__global__
+__launch_bounds__(Traits::MmaCore::kThreads, 1) void sm70_marlin_moe_gemm_kernel(
     cutlass::half_t const* __restrict__ a,
     uint32_t const* __restrict__ b_q_weight,
     typename Traits::GemmSpec::ScaleElement const* __restrict__ b_scales,
     typename Traits::GemmSpec::ZeroElement const* __restrict__ b_zeros,
-    float const* __restrict__ global_scale,
-    cutlass::half_t* __restrict__ c,
+    float const* __restrict__ global_scale, cutlass::half_t* __restrict__ c,
     int32_t const* __restrict__ sorted_token_ids,
     int32_t const* __restrict__ expert_ids,
     int32_t const* __restrict__ num_tokens_past_padded,
     float const* __restrict__ topk_weights, int moe_block_size, int top_k,
-    bool mul_topk_weights, int m, int n, int k, int lda, int requested_split_k) {
+    bool mul_topk_weights, int m, int n, int k, int lda,
+    int requested_split_k) {
   using Mma = typename Traits::Mma;
   using Epilogue = Sm70MoeScatterEpilogue<Traits>;
   constexpr int CtaM = Traits::ThreadblockShape::kM;
@@ -3002,8 +2967,8 @@ void sm70_marlin_moe_gemm_kernel(
   int partition_k = k;
   if constexpr (SplitK) {
     Sm70SplitKPartition const partition =
-        sm70_splitk_partition<Traits::kGroupSize, CtaK>(
-            k, requested_split_k, int(blockIdx.z));
+        sm70_splitk_partition<Traits::kGroupSize, CtaK>(k, requested_split_k,
+                                                        int(blockIdx.z));
     if (partition.partition_k == 0) {
       return;
     }
@@ -3014,8 +2979,8 @@ void sm70_marlin_moe_gemm_kernel(
   int const n_offset = int(blockIdx.y) * CtaN;
 
   typename Mma::IteratorA iterator_A(
-      typename Mma::IteratorA::Params(lda, moe_block_size, top_k, m,
-                                      m * top_k, padded_tokens),
+      typename Mma::IteratorA::Params(lda, moe_block_size, top_k, m, m * top_k,
+                                      padded_tokens),
       a, sorted_token_ids, thread_idx, moe_block, local_m_offset, k_begin);
   typename Mma::IteratorB iterator_B(
       typename Mma::IteratorB::Params(k, n),
@@ -3042,8 +3007,8 @@ void sm70_marlin_moe_gemm_kernel(
   }
   Epilogue epilogue(shared_storage.epilogue, thread_idx, warp_idx, lane_idx);
   epilogue(iterator_D, accumulators, sorted_token_ids, topk_weights, c, n,
-           moe_block, local_m_offset, moe_block_size, m * top_k,
-           padded_tokens, mul_topk_weights, SplitK, output_scale);
+           moe_block, local_m_offset, moe_block_size, m * top_k, padded_tokens,
+           mul_topk_weights, SplitK, output_scale);
 }
 
 template <typename Traits>
@@ -3103,9 +3068,9 @@ torch::Tensor launch_sm70_marlin_moe_gemm(
   smem_bytes = configure_sm70_dynamic_smem<SharedStorage>(split_kernel);
 
   int64_t const numel = size_m * top_k * size_n;
-  C10_CUDA_CHECK(cudaMemsetAsync(
-      c.data_ptr<at::Half>(), 0,
-      static_cast<size_t>(numel) * sizeof(at::Half), stream));
+  C10_CUDA_CHECK(cudaMemsetAsync(c.data_ptr<at::Half>(), 0,
+                                 static_cast<size_t>(numel) * sizeof(at::Half),
+                                 stream));
 
   int const active_split_k =
       sm70_active_split_k(static_cast<int>(size_k), requested_split_k, CtaK);
@@ -3115,11 +3080,11 @@ torch::Tensor launch_sm70_marlin_moe_gemm(
       reinterpret_cast<uint32_t const*>(b_q_weight.data_ptr<int32_t>()),
       b_scales_ptr, b_zeros_ptr, global_scale_ptr,
       reinterpret_cast<cutlass::half_t*>(c.data_ptr<at::Half>()),
-      sorted_token_ids.data_ptr<int32_t>(),
-      expert_ids.data_ptr<int32_t>(), num_tokens_past_padded.data_ptr<int32_t>(),
+      sorted_token_ids.data_ptr<int32_t>(), expert_ids.data_ptr<int32_t>(),
+      num_tokens_past_padded.data_ptr<int32_t>(),
       topk_weights.data_ptr<float>(), int(moe_block_size), int(top_k),
-      mul_topk_weights, int(size_m), int(size_n), int(size_k),
-      int(a.stride(0)), requested_split_k);
+      mul_topk_weights, int(size_m), int(size_n), int(size_k), int(a.stride(0)),
+      requested_split_k);
   C10_CUDA_KERNEL_LAUNCH_CHECK();
   return c;
 }

--- a/csrc/moe/marlin_moe_wna16/sm70_marlin_moe_dispatch.cu
+++ b/csrc/moe/marlin_moe_wna16/sm70_marlin_moe_dispatch.cu
@@ -43,15 +43,13 @@ __device__ __forceinline__ int sm70_inverse_zp_interleave(int idx,
   return inv[idx];
 }
 
-__device__ __forceinline__ int sm70_inverse_scale_perm(int idx,
-                                                       int perm_len) {
+__device__ __forceinline__ int sm70_inverse_scale_perm(int idx, int perm_len) {
   if (perm_len == 64) {
     return (idx % 8) * 8 + idx / 8;
   }
-  constexpr int inv[32] = {0,  1,  8,  9,  16, 17, 24, 25,
-                           2,  3,  10, 11, 18, 19, 26, 27,
-                           4,  5,  12, 13, 20, 21, 28, 29,
-                           6,  7,  14, 15, 22, 23, 30, 31};
+  constexpr int inv[32] = {0,  1,  8,  9,  16, 17, 24, 25, 2,  3,  10,
+                           11, 18, 19, 26, 27, 4,  5,  12, 13, 20, 21,
+                           28, 29, 6,  7,  14, 15, 22, 23, 30, 31};
   return inv[idx];
 }
 
@@ -66,10 +64,9 @@ __global__ void sm70_unpermute_half_metadata_kernel(
 }
 
 __global__ void sm70_unpack_moe_zp_to_half_kernel(
-    const int32_t* __restrict__ packed_zp,
-    const half* __restrict__ scales, half* __restrict__ out,
-    int64_t total, int64_t num_groups, int64_t size_n, int64_t packed_n,
-    int num_bits, bool is_a_8bit) {
+    const int32_t* __restrict__ packed_zp, const half* __restrict__ scales,
+    half* __restrict__ out, int64_t total, int64_t num_groups, int64_t size_n,
+    int64_t packed_n, int num_bits, bool is_a_8bit) {
   const int64_t idx = blockIdx.x * blockDim.x + threadIdx.x;
   if (idx >= total) return;
 
@@ -83,15 +80,14 @@ __global__ void sm70_unpack_moe_zp_to_half_kernel(
   if (!is_a_8bit) {
     packed_col_in_block =
         (packed_col_in_block / pack_factor) * pack_factor +
-        sm70_inverse_zp_interleave(packed_col_in_block % pack_factor,
-                                   num_bits);
+        sm70_inverse_zp_interleave(packed_col_in_block % pack_factor, num_bits);
   }
   const int64_t packed_col = block64 * 64 + packed_col_in_block;
-  const uint32_t word = reinterpret_cast<const uint32_t*>(packed_zp)
-      [(expert * num_groups + group) * packed_n + packed_col / pack_factor];
-  const uint32_t zp =
-      (word >> ((packed_col % pack_factor) * num_bits)) &
-      ((1u << num_bits) - 1u);
+  const uint32_t word = reinterpret_cast<const uint32_t*>(
+      packed_zp)[(expert * num_groups + group) * packed_n +
+                 packed_col / pack_factor];
+  const uint32_t zp = (word >> ((packed_col % pack_factor) * num_bits)) &
+                      ((1u << num_bits) - 1u);
   out[idx] = __float2half(static_cast<float>(zp) * __half2float(scales[idx]));
 }
 
@@ -111,8 +107,8 @@ torch::Tensor sm70_moe_scales_as_logical(torch::Tensor const& b_scales,
   const int64_t total = out.numel();
   constexpr int threads = 256;
   const int blocks = static_cast<int>((total + threads - 1) / threads);
-  sm70_unpermute_half_metadata_kernel<<<
-      blocks, threads, 0, at::cuda::getCurrentCUDAStream()>>>(
+  sm70_unpermute_half_metadata_kernel<<<blocks, threads, 0,
+                                        at::cuda::getCurrentCUDAStream()>>>(
       reinterpret_cast<const half*>(b_scales.data_ptr<at::Half>()),
       reinterpret_cast<half*>(out.data_ptr<at::Half>()), total, perm_len);
   C10_CUDA_KERNEL_LAUNCH_CHECK();
@@ -120,9 +116,8 @@ torch::Tensor sm70_moe_scales_as_logical(torch::Tensor const& b_scales,
 }
 
 torch::Tensor sm70_moe_zp_as_half(torch::Tensor const& b_zeros,
-                                  torch::Tensor const& b_scales,
-                                  int64_t size_n, int num_bits,
-                                  bool is_a_8bit) {
+                                  torch::Tensor const& b_scales, int64_t size_n,
+                                  int num_bits, bool is_a_8bit) {
   if (b_zeros.scalar_type() == at::ScalarType::Half) {
     return b_zeros;
   }
@@ -143,14 +138,13 @@ torch::Tensor sm70_moe_zp_as_half(torch::Tensor const& b_zeros,
   TORCH_CHECK(b_scales.scalar_type() == at::ScalarType::Half,
               "SM70 Marlin MoE packed zero-point adapter expects fp16 scales.");
 
-  auto out =
-      torch::empty({b_scales.size(0), b_scales.size(1), size_n},
-                   b_scales.options());
+  auto out = torch::empty({b_scales.size(0), b_scales.size(1), size_n},
+                          b_scales.options());
   const int64_t total = out.numel();
   constexpr int threads = 256;
   const int blocks = static_cast<int>((total + threads - 1) / threads);
-  sm70_unpack_moe_zp_to_half_kernel<<<
-      blocks, threads, 0, at::cuda::getCurrentCUDAStream()>>>(
+  sm70_unpack_moe_zp_to_half_kernel<<<blocks, threads, 0,
+                                      at::cuda::getCurrentCUDAStream()>>>(
       b_zeros.data_ptr<int32_t>(),
       reinterpret_cast<const half*>(b_scales.data_ptr<at::Half>()),
       reinterpret_cast<half*>(out.data_ptr<at::Half>()), total,
@@ -229,8 +223,7 @@ torch::Tensor moe_wna16_marlin_gemm(
     std::optional<torch::Tensor> const& global_scale_or_none,
     std::optional<torch::Tensor> const& b_zeros_or_none,
     std::optional<torch::Tensor> const& g_idx_or_none,
-    std::optional<torch::Tensor> const& perm_or_none,
-    torch::Tensor& workspace,
+    std::optional<torch::Tensor> const& perm_or_none, torch::Tensor& workspace,
     torch::Tensor& sorted_token_ids, torch::Tensor& expert_ids,
     torch::Tensor& num_tokens_past_padded, torch::Tensor& topk_weights,
     int64_t moe_block_size, int64_t top_k, bool mul_topk_weights,
@@ -308,8 +301,7 @@ torch::Tensor moe_wna16_marlin_gemm(
               "SM70 Marlin MoE supports only float16 outputs.");
   TORCH_CHECK(s_type == vllm::kFloat16 ||
                   (b_type == vllm::kFE2M1f &&
-                   (s_type == vllm::kFE4M3fn ||
-                    s_type == vllm::kFE8M0fnu)),
+                   (s_type == vllm::kFE4M3fn || s_type == vllm::kFE8M0fnu)),
               "SM70 Marlin MoE supports only float16 scales, "
               "except FP4 uses float8_e4m3fn scales for NVFP4 or "
               "float8_e8m0fnu scales for MXFP4.");
@@ -364,10 +356,8 @@ torch::Tensor moe_wna16_marlin_gemm(
   TORCH_CHECK(b_scales.is_contiguous(), "b_scales is not contiguous");
   TORCH_CHECK(b_scales.scalar_type() == at::ScalarType::Half ||
                   (b_type == vllm::kFE2M1f &&
-                   (b_scales.scalar_type() ==
-                        at::ScalarType::Float8_e4m3fn ||
-                    b_scales.scalar_type() ==
-                        at::ScalarType::Float8_e8m0fnu)),
+                   (b_scales.scalar_type() == at::ScalarType::Float8_e4m3fn ||
+                    b_scales.scalar_type() == at::ScalarType::Float8_e8m0fnu)),
               "SM70 Marlin MoE supports float16 scales, except FP4 uses "
               "float8_e4m3fn scales for NVFP4 or float8_e8m0fnu scales for "
               "MXFP4.");
@@ -457,17 +447,15 @@ torch::Tensor moe_wna16_marlin_gemm(
 
   torch::Tensor b_scales_kernel = b_scales;
   if (b_scales.scalar_type() == at::ScalarType::Half) {
-    b_scales_kernel =
-        sm70_moe_scales_as_logical(b_scales, size_k, group_size,
-                                   a_type.size_bits() == 8);
+    b_scales_kernel = sm70_moe_scales_as_logical(b_scales, size_k, group_size,
+                                                 a_type.size_bits() == 8);
   }
 
   torch::Tensor global_scale;
   if (global_scale_or_none.has_value()) {
     global_scale = global_scale_or_none.value();
-    TORCH_CHECK(
-        b_type == vllm::kFE2M1f && s_type == vllm::kFE4M3fn,
-        "SM70 Marlin MoE supports global_scale only for nvfp4 format.");
+    TORCH_CHECK(b_type == vllm::kFE2M1f && s_type == vllm::kFE4M3fn,
+                "SM70 Marlin MoE supports global_scale only for nvfp4 format.");
     TORCH_CHECK(global_scale.device().is_cuda(), "global_scale is not on GPU");
     TORCH_CHECK(global_scale.is_contiguous(), "global_scale is not contiguous");
     TORCH_CHECK(global_scale.scalar_type() == at::ScalarType::Float,
@@ -510,9 +498,9 @@ torch::Tensor moe_wna16_marlin_gemm(
                 "weights when zero-points are enabled. Got = ",
                 b_type.str());
     if (!is_zp_float && b_zeros.scalar_type() == at::ScalarType::Int) {
-      b_zeros = sm70_moe_zp_as_half(
-          b_zeros, b_scales_kernel, size_n, b_type == vllm::kU4 ? 4 : 8,
-          a_type.size_bits() == 8);
+      b_zeros = sm70_moe_zp_as_half(b_zeros, b_scales_kernel, size_n,
+                                    b_type == vllm::kU4 ? 4 : 8,
+                                    a_type.size_bits() == 8);
       zp_is_float = true;
     }
   } else {
@@ -535,8 +523,7 @@ torch::Tensor moe_wna16_marlin_gemm(
     TORCH_CHECK(num_groups == b_zeros.size(1),
                 "b_zeros dim 1 = ", b_zeros.size(1),
                 " is not num_groups = ", num_groups);
-    TORCH_CHECK(b_zeros.size(2) == size_n,
-                "b_zeros dim 2 = ", b_zeros.size(2),
+    TORCH_CHECK(b_zeros.size(2) == size_n, "b_zeros dim 2 = ", b_zeros.size(2),
                 " is not size_n = ", size_n);
   } else {
     TORCH_CHECK(!zp_is_float,
@@ -559,20 +546,18 @@ torch::Tensor moe_wna16_marlin_gemm(
 
   TORCH_CHECK(!has_act_order,
               "act_order is not supported for the SM70 Marlin MoE path.");
-  TORCH_CHECK(!has_bias,
-              "SM70 Marlin MoE does not support bias.");
+  TORCH_CHECK(!has_bias, "SM70 Marlin MoE does not support bias.");
   TORCH_CHECK(!use_atomic_add,
               "SM70 Marlin MoE does not support atomic-add "
               "output.");
-  TORCH_CHECK(is_k_full,
-              "SM70 Marlin MoE requires full-K inputs.");
+  TORCH_CHECK(is_k_full, "SM70 Marlin MoE requires full-K inputs.");
 
   if (b_type == vllm::kU4) {
     TORCH_CHECK(has_zp && zp_is_float,
                 "SM70 Marlin MoE uint4 path requires fp16 zero points.");
     return MARLIN_NAMESPACE_NAME::sm70_marlin_u4_gemm(
-        a, c, b_q_weight, b_scales_kernel, b_zeros, sorted_token_ids, expert_ids,
-        num_tokens_past_padded, topk_weights, moe_block_size, top_k,
+        a, c, b_q_weight, b_scales_kernel, b_zeros, sorted_token_ids,
+        expert_ids, num_tokens_past_padded, topk_weights, moe_block_size, top_k,
         mul_topk_weights, size_m, size_n, size_k, group_size);
   }
 
@@ -580,8 +565,8 @@ torch::Tensor moe_wna16_marlin_gemm(
     TORCH_CHECK(has_zp && zp_is_float,
                 "SM70 Marlin MoE uint8 path requires fp16 zero points.");
     return MARLIN_NAMESPACE_NAME::sm70_marlin_u8_gemm(
-        a, c, b_q_weight, b_scales_kernel, b_zeros, sorted_token_ids, expert_ids,
-        num_tokens_past_padded, topk_weights, moe_block_size, top_k,
+        a, c, b_q_weight, b_scales_kernel, b_zeros, sorted_token_ids,
+        expert_ids, num_tokens_past_padded, topk_weights, moe_block_size, top_k,
         mul_topk_weights, size_m, size_n, size_k, group_size);
   }
 
@@ -622,8 +607,9 @@ torch::Tensor moe_wna16_marlin_gemm(
     TORCH_CHECK(!has_zp && !is_zp_float,
                 "SM70 Marlin MoE fp4 does not support zero-point metadata.");
     if (s_type == vllm::kFE4M3fn) {
-      TORCH_CHECK(global_scale.numel() == num_experts,
-                  "the global_scale parameter must be passed for nvfp4 format.");
+      TORCH_CHECK(
+          global_scale.numel() == num_experts,
+          "the global_scale parameter must be passed for nvfp4 format.");
       TORCH_CHECK(group_size == 16,
                   "SM70 Marlin MoE NVFP4 supports only group_size 16. "
                   "Got ",

--- a/csrc/moe/marlin_moe_wna16/sm70_marlin_mxfp4_gemm.cu
+++ b/csrc/moe/marlin_moe_wna16/sm70_marlin_mxfp4_gemm.cu
@@ -56,7 +56,8 @@ void dequant_e8m0_scales_to_half2(int q, half2* scale_cache) {
   *reinterpret_cast<uint2*>(scale_cache) = vec_res;
 }
 
-template <typename Shape_, typename ThreadMap_, int GroupSize_, int PackedMacroN_>
+template <typename Shape_, typename ThreadMap_, int GroupSize_,
+          int PackedMacroN_>
 class Sm70MoeMxfp4IteratorB {
  public:
   using Shape = Shape_;
@@ -64,22 +65,25 @@ class Sm70MoeMxfp4IteratorB {
   static int const kGroupSize = GroupSize_;
   static int const kPackedMacroN = PackedMacroN_;
   using Element = cutlass::half_t;
-  using Fragment = cutlass::Array<
-      Element, ThreadMap::Iterations::kCount * ThreadMap::kElementsPerAccess>;
-    static_assert(Shape::kN == 64 || Shape::kN == 128 || Shape::kN == 256,
-                "SM70 Marlin MoE MXFP4 IteratorB expects CTA_N in {64, 128, 256}.");
-  static_assert(ThreadMap::Iterations::kContiguous ==
-                    Shape::kN / kQuantTileN,
-                "SM70 Marlin MoE MXFP4 IteratorB expects one contiguous iteration "
-                "per 64-column quant tile.");
+  using Fragment = cutlass::Array<Element, ThreadMap::Iterations::kCount *
+                                               ThreadMap::kElementsPerAccess>;
+  static_assert(
+      Shape::kN == 64 || Shape::kN == 128 || Shape::kN == 256,
+      "SM70 Marlin MoE MXFP4 IteratorB expects CTA_N in {64, 128, 256}.");
+  static_assert(
+      ThreadMap::Iterations::kContiguous == Shape::kN / kQuantTileN,
+      "SM70 Marlin MoE MXFP4 IteratorB expects one contiguous iteration "
+      "per 64-column quant tile.");
   static_assert(ThreadMap::Delta::kContiguous == kQuantTileN,
                 "SM70 Marlin MoE MXFP4 IteratorB expects 64-column deltas.");
-  static_assert(ThreadMap::kElementsPerAccess == kMxfp4ValuesPerWord,
-                "SM70 Marlin MoE MXFP4 IteratorB expects one packed FP4 word per "
-                "access.");
-  static_assert(ThreadMap::Iterations::kStrided >= 1,
-                "SM70 Marlin MoE U4-family IteratorB expects one or more strided "
-                "iterations.");
+  static_assert(
+      ThreadMap::kElementsPerAccess == kMxfp4ValuesPerWord,
+      "SM70 Marlin MoE MXFP4 IteratorB expects one packed FP4 word per "
+      "access.");
+  static_assert(
+      ThreadMap::Iterations::kStrided >= 1,
+      "SM70 Marlin MoE U4-family IteratorB expects one or more strided "
+      "iterations.");
   struct Params {
     int size_k;
     int size_n;
@@ -90,9 +94,7 @@ class Sm70MoeMxfp4IteratorB {
 
     CUTLASS_HOST_DEVICE
     Params(int size_k_, int size_n_)
-        : size_k(size_k_),
-          size_n(size_n_),
-          num_groups(size_k_ / GroupSize_) {}
+        : size_k(size_k_), size_n(size_n_), num_groups(size_k_ / GroupSize_) {}
   };
 
  private:
@@ -113,9 +115,8 @@ class Sm70MoeMxfp4IteratorB {
                         uint8_t const* scales, half const*, int thread_id,
                         int expert, int k_offset, int n_offset)
       : qweight_(qweight),
-        scales_expert_base_(scales +
-                            (expert >= 0 ? expert : 0) *
-                                params.num_groups * params.size_n),
+        scales_expert_base_(scales + (expert >= 0 ? expert : 0) *
+                                         params.num_groups * params.size_n),
         params_(params),
         thread_offset_(ThreadMap::initial_offset(thread_id)),
         expert_(expert),
@@ -154,9 +155,7 @@ class Sm70MoeMxfp4IteratorB {
   }
 
   CUTLASS_DEVICE
-  int metadata_group_offset(int group) const {
-    return group * params_.size_n;
-  }
+  int metadata_group_offset(int group) const { return group * params_.size_n; }
 
   CUTLASS_DEVICE
   int scale_group(int logical_k) const {
@@ -189,14 +188,12 @@ class Sm70MoeMxfp4IteratorB {
     CUTLASS_PRAGMA_UNROLL
     for (int s = 0; s < ThreadMap::Iterations::kStrided; ++s) {
       int const logical_k =
-          k_offset_ + thread_offset_.strided() +
-          s * ThreadMap::Delta::kStrided;
+          k_offset_ + thread_offset_.strided() + s * ThreadMap::Delta::kStrided;
       int const group = scale_group(logical_k);
       CUTLASS_PRAGMA_UNROLL
       for (int c = 0; c < ThreadMap::Iterations::kContiguous; ++c) {
-        int const cache_n =
-            n_offset_ + thread_offset_.contiguous() +
-            c * ThreadMap::Delta::kContiguous;
+        int const cache_n = n_offset_ + thread_offset_.contiguous() +
+                            c * ThreadMap::Delta::kContiguous;
         int const cache_index = c + s * ThreadMap::Iterations::kContiguous;
         cache_metadata_e8m0_scales(cache_index, group, cache_n);
       }
@@ -249,8 +246,9 @@ class Sm70MoeMxfp4IteratorB {
           frag_vec[3] = __hmul2(deq[1], scale_vec[3]);
         }
       } else {
-        static_assert(ThreadMap::Iterations::kContiguous == 1,
-                      "Unsupported SM70 Marlin MoE MXFP4 contiguous iteration count.");
+        static_assert(
+            ThreadMap::Iterations::kContiguous == 1,
+            "Unsupported SM70 Marlin MoE MXFP4 contiguous iteration count.");
         uint32_t const qword =
             load_qword_vector<1>(qweight_ + qweight_base_offset_);
         half2 const* scale_vec = cached_scales_;
@@ -270,15 +268,13 @@ class Sm70MoeMxfp4IteratorB {
       int const logical_n_base = n_offset_ + thread_offset_.contiguous();
       CUTLASS_PRAGMA_UNROLL
       for (int s = 0; s < ThreadMap::Iterations::kStrided; ++s) {
-        int const logical_k_s =
-            k_offset_ + thread_offset_.strided() +
-            s * ThreadMap::Delta::kStrided;
+        int const logical_k_s = k_offset_ + thread_offset_.strided() +
+                                s * ThreadMap::Delta::kStrided;
         int const qweight_base_s =
             expert_qweight_base_offset() +
             qweight_offset_from_logical(params_, logical_k_s, logical_n_base);
         if constexpr (ThreadMap::Iterations::kContiguous == 4) {
-          auto const qwords =
-              load_qword_vector<4>(qweight_ + qweight_base_s);
+          auto const qwords = load_qword_vector<4>(qweight_ + qweight_base_s);
           CUTLASS_PRAGMA_UNROLL
           for (int c = 0; c < ThreadMap::Iterations::kContiguous; ++c) {
             constexpr int kAccess = ThreadMap::kElementsPerAccess;
@@ -301,8 +297,7 @@ class Sm70MoeMxfp4IteratorB {
             frag_vec[3] = __hmul2(deq[1], scale_vec[3]);
           }
         } else if constexpr (ThreadMap::Iterations::kContiguous == 2) {
-          auto const qwords =
-              load_qword_vector<2>(qweight_ + qweight_base_s);
+          auto const qwords = load_qword_vector<2>(qweight_ + qweight_base_s);
           CUTLASS_PRAGMA_UNROLL
           for (int c = 0; c < ThreadMap::Iterations::kContiguous; ++c) {
             constexpr int kAccess = ThreadMap::kElementsPerAccess;
@@ -325,8 +320,9 @@ class Sm70MoeMxfp4IteratorB {
             frag_vec[3] = __hmul2(deq[1], scale_vec[3]);
           }
         } else {
-          static_assert(ThreadMap::Iterations::kContiguous == 1,
-                        "Unsupported SM70 Marlin MoE MXFP4 contiguous iteration count.");
+          static_assert(
+              ThreadMap::Iterations::kContiguous == 1,
+              "Unsupported SM70 Marlin MoE MXFP4 contiguous iteration count.");
           uint32_t const qword =
               load_qword_vector<1>(qweight_ + qweight_base_s);
           constexpr int kAccess = ThreadMap::kElementsPerAccess;
@@ -369,15 +365,15 @@ struct Sm70MoeMxfp4GemmSpec {
   using IteratorA = Sm70MoeGatherIteratorA<Shape, ThreadMap>;
 
   template <typename Shape, typename ThreadMap, int GroupSize, int PackedMacroN>
-  using IteratorB = Sm70MoeMxfp4IteratorB<Shape, ThreadMap, GroupSize, PackedMacroN>;
+  using IteratorB =
+      Sm70MoeMxfp4IteratorB<Shape, ThreadMap, GroupSize, PackedMacroN>;
 };
 
-template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM,
-          int WarpN, int WarpK, int GroupSize, int PackedMacroN>
+template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM, int WarpN,
+          int WarpK, int GroupSize, int PackedMacroN>
 using Sm70MoeMxfp4GemmTraits =
-    Sm70MarlinMoeGemmTraits<Sm70MoeMxfp4GemmSpec, CtaM, CtaN, CtaK,
-                            Warps, WarpM, WarpN, WarpK, GroupSize,
-                            PackedMacroN>;
+    Sm70MarlinMoeGemmTraits<Sm70MoeMxfp4GemmSpec, CtaM, CtaN, CtaK, Warps,
+                            WarpM, WarpN, WarpK, GroupSize, PackedMacroN>;
 
 struct Sm70MoeMxfp4Launcher {
   torch::Tensor& a;
@@ -398,15 +394,15 @@ struct Sm70MoeMxfp4Launcher {
   int64_t size_k;
   int requested_split_k;
 
-  template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM,
-          int WarpN, int WarpK, int GroupSize, int PackedMacroN>
+  template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM, int WarpN,
+            int WarpK, int GroupSize, int PackedMacroN>
   torch::Tensor operator()() const {
-    using Traits = Sm70MoeMxfp4GemmTraits<CtaM, CtaN, CtaK, Warps, WarpM,
-                                    WarpN, WarpK, GroupSize, PackedMacroN>;
+    using Traits = Sm70MoeMxfp4GemmTraits<CtaM, CtaN, CtaK, Warps, WarpM, WarpN,
+                                          WarpK, GroupSize, PackedMacroN>;
     return launch_sm70_marlin_moe_gemm<Traits>(
         a, c, b_q_weight, b_scales, b_zeros, global_scale, sorted_token_ids,
-        expert_ids, num_tokens_past_padded, topk_weights, moe_block_size,
-        top_k, mul_topk_weights, size_m, size_n, size_k, requested_split_k);
+        expert_ids, num_tokens_past_padded, topk_weights, moe_block_size, top_k,
+        mul_topk_weights, size_m, size_n, size_k, requested_split_k);
   }
 };
 
@@ -424,9 +420,10 @@ torch::Tensor sm70_marlin_mxfp4_gemm(
   auto const params = sm70_marlin_moe_auto_stage_params(
       "mxfp4", group_size, moe_block_size, top_k, size_m, size_n, size_k);
   Sm70CtaGeometry const geometry = params.geometry;
-  validate_sm70_marlin_moe_stage_cta_geometry_supported("SM70 Marlin MoE mxfp4", geometry);
-  validate_sm70_marlin_moe_stage_cta_n_alignment("SM70 Marlin MoE mxfp4", geometry,
-                                        size_n);
+  validate_sm70_marlin_moe_stage_cta_geometry_supported("SM70 Marlin MoE mxfp4",
+                                                        geometry);
+  validate_sm70_marlin_moe_stage_cta_n_alignment("SM70 Marlin MoE mxfp4",
+                                                 geometry, size_n);
   TORCH_CHECK(size_k % geometry.cta_k == 0,
               "SM70 Marlin MoE mxfp4 requires K divisible by CTA_K=",
               geometry.cta_k, ". Got K=", size_k, ".");
@@ -434,10 +431,23 @@ torch::Tensor sm70_marlin_mxfp4_gemm(
   auto empty_half = torch::empty({0}, b_scales.options().dtype(at::kHalf));
   auto empty_float = torch::empty(
       {0}, torch::TensorOptions().dtype(at::kFloat).device(a.device()));
-  Sm70MoeMxfp4Launcher const launcher{
-      a, c, b_q_weight, b_scales, empty_half, empty_float, sorted_token_ids,
-      expert_ids, num_tokens_past_padded, topk_weights, moe_block_size, top_k,
-      mul_topk_weights, size_m, size_n, size_k, params.requested_split_k};
+  Sm70MoeMxfp4Launcher const launcher{a,
+                                      c,
+                                      b_q_weight,
+                                      b_scales,
+                                      empty_half,
+                                      empty_float,
+                                      sorted_token_ids,
+                                      expert_ids,
+                                      num_tokens_past_padded,
+                                      topk_weights,
+                                      moe_block_size,
+                                      top_k,
+                                      mul_topk_weights,
+                                      size_m,
+                                      size_n,
+                                      size_k,
+                                      params.requested_split_k};
   return dispatch_sm70_marlin_moe_fixed_group_geometry<32>(
       launcher, geometry, params.packed_macro_n, group_size, "mxfp4");
 }

--- a/csrc/moe/marlin_moe_wna16/sm70_marlin_nvfp4_gemm.cu
+++ b/csrc/moe/marlin_moe_wna16/sm70_marlin_nvfp4_gemm.cu
@@ -26,7 +26,8 @@ namespace {
 
 constexpr int kNvfp4ValuesPerWord = 8;
 
-template <typename Shape_, typename ThreadMap_, int GroupSize_, int PackedMacroN_>
+template <typename Shape_, typename ThreadMap_, int GroupSize_,
+          int PackedMacroN_>
 class Sm70MoeNvfp4IteratorB {
  public:
   using Shape = Shape_;
@@ -34,22 +35,25 @@ class Sm70MoeNvfp4IteratorB {
   static int const kGroupSize = GroupSize_;
   static int const kPackedMacroN = PackedMacroN_;
   using Element = cutlass::half_t;
-  using Fragment = cutlass::Array<
-      Element, ThreadMap::Iterations::kCount * ThreadMap::kElementsPerAccess>;
-    static_assert(Shape::kN == 64 || Shape::kN == 128 || Shape::kN == 256,
-                "SM70 Marlin MoE NVFP4 IteratorB expects CTA_N in {64, 128, 256}.");
-  static_assert(ThreadMap::Iterations::kContiguous ==
-                    Shape::kN / kQuantTileN,
-                "SM70 Marlin MoE NVFP4 IteratorB expects one contiguous iteration "
-                "per 64-column quant tile.");
+  using Fragment = cutlass::Array<Element, ThreadMap::Iterations::kCount *
+                                               ThreadMap::kElementsPerAccess>;
+  static_assert(
+      Shape::kN == 64 || Shape::kN == 128 || Shape::kN == 256,
+      "SM70 Marlin MoE NVFP4 IteratorB expects CTA_N in {64, 128, 256}.");
+  static_assert(
+      ThreadMap::Iterations::kContiguous == Shape::kN / kQuantTileN,
+      "SM70 Marlin MoE NVFP4 IteratorB expects one contiguous iteration "
+      "per 64-column quant tile.");
   static_assert(ThreadMap::Delta::kContiguous == kQuantTileN,
                 "SM70 Marlin MoE NVFP4 IteratorB expects 64-column deltas.");
-  static_assert(ThreadMap::kElementsPerAccess == kNvfp4ValuesPerWord,
-                "SM70 Marlin MoE NVFP4 IteratorB expects one packed FP4 word per "
-                "access.");
-  static_assert(ThreadMap::Iterations::kStrided >= 1,
-                "SM70 Marlin MoE U4-family IteratorB expects one or more strided "
-                "iterations.");
+  static_assert(
+      ThreadMap::kElementsPerAccess == kNvfp4ValuesPerWord,
+      "SM70 Marlin MoE NVFP4 IteratorB expects one packed FP4 word per "
+      "access.");
+  static_assert(
+      ThreadMap::Iterations::kStrided >= 1,
+      "SM70 Marlin MoE U4-family IteratorB expects one or more strided "
+      "iterations.");
   struct Params {
     int size_k;
     int size_n;
@@ -60,9 +64,7 @@ class Sm70MoeNvfp4IteratorB {
 
     CUTLASS_HOST_DEVICE
     Params(int size_k_, int size_n_)
-        : size_k(size_k_),
-          size_n(size_n_),
-          num_groups(size_k_ / GroupSize_) {}
+        : size_k(size_k_), size_n(size_n_), num_groups(size_k_ / GroupSize_) {}
   };
 
  private:
@@ -83,9 +85,8 @@ class Sm70MoeNvfp4IteratorB {
                         uint8_t const* scales, half const*, int thread_id,
                         int expert, int k_offset, int n_offset)
       : qweight_(qweight),
-        scales_expert_base_(scales +
-                            (expert >= 0 ? expert : 0) *
-                                params.num_groups * params.size_n),
+        scales_expert_base_(scales + (expert >= 0 ? expert : 0) *
+                                         params.num_groups * params.size_n),
         params_(params),
         thread_offset_(ThreadMap::initial_offset(thread_id)),
         expert_(expert),
@@ -124,9 +125,7 @@ class Sm70MoeNvfp4IteratorB {
   }
 
   CUTLASS_DEVICE
-  int metadata_group_offset(int group) const {
-    return group * params_.size_n;
-  }
+  int metadata_group_offset(int group) const { return group * params_.size_n; }
 
   CUTLASS_DEVICE
   int scale_group(int logical_k) const {
@@ -159,14 +158,12 @@ class Sm70MoeNvfp4IteratorB {
     CUTLASS_PRAGMA_UNROLL
     for (int s = 0; s < ThreadMap::Iterations::kStrided; ++s) {
       int const logical_k =
-          k_offset_ + thread_offset_.strided() +
-          s * ThreadMap::Delta::kStrided;
+          k_offset_ + thread_offset_.strided() + s * ThreadMap::Delta::kStrided;
       int const group = scale_group(logical_k);
       CUTLASS_PRAGMA_UNROLL
       for (int c = 0; c < ThreadMap::Iterations::kContiguous; ++c) {
-        int const cache_n =
-            n_offset_ + thread_offset_.contiguous() +
-            c * ThreadMap::Delta::kContiguous;
+        int const cache_n = n_offset_ + thread_offset_.contiguous() +
+                            c * ThreadMap::Delta::kContiguous;
         int const cache_index = c + s * ThreadMap::Iterations::kContiguous;
         cache_metadata_fp8_scales(cache_index, group, cache_n);
       }
@@ -219,8 +216,9 @@ class Sm70MoeNvfp4IteratorB {
           frag_vec[3] = __hmul2(deq[1], scale_vec[3]);
         }
       } else {
-        static_assert(ThreadMap::Iterations::kContiguous == 1,
-                      "Unsupported SM70 Marlin MoE NVFP4 contiguous iteration count.");
+        static_assert(
+            ThreadMap::Iterations::kContiguous == 1,
+            "Unsupported SM70 Marlin MoE NVFP4 contiguous iteration count.");
         uint32_t const qword =
             load_qword_vector<1>(qweight_ + qweight_base_offset_);
         half2 const* scale_vec = cached_scales_;
@@ -240,15 +238,13 @@ class Sm70MoeNvfp4IteratorB {
       int const logical_n_base = n_offset_ + thread_offset_.contiguous();
       CUTLASS_PRAGMA_UNROLL
       for (int s = 0; s < ThreadMap::Iterations::kStrided; ++s) {
-        int const logical_k_s =
-            k_offset_ + thread_offset_.strided() +
-            s * ThreadMap::Delta::kStrided;
+        int const logical_k_s = k_offset_ + thread_offset_.strided() +
+                                s * ThreadMap::Delta::kStrided;
         int const qweight_base_s =
             expert_qweight_base_offset() +
             qweight_offset_from_logical(params_, logical_k_s, logical_n_base);
         if constexpr (ThreadMap::Iterations::kContiguous == 4) {
-          auto const qwords =
-              load_qword_vector<4>(qweight_ + qweight_base_s);
+          auto const qwords = load_qword_vector<4>(qweight_ + qweight_base_s);
           CUTLASS_PRAGMA_UNROLL
           for (int c = 0; c < ThreadMap::Iterations::kContiguous; ++c) {
             constexpr int kAccess = ThreadMap::kElementsPerAccess;
@@ -271,8 +267,7 @@ class Sm70MoeNvfp4IteratorB {
             frag_vec[3] = __hmul2(deq[1], scale_vec[3]);
           }
         } else if constexpr (ThreadMap::Iterations::kContiguous == 2) {
-          auto const qwords =
-              load_qword_vector<2>(qweight_ + qweight_base_s);
+          auto const qwords = load_qword_vector<2>(qweight_ + qweight_base_s);
           CUTLASS_PRAGMA_UNROLL
           for (int c = 0; c < ThreadMap::Iterations::kContiguous; ++c) {
             constexpr int kAccess = ThreadMap::kElementsPerAccess;
@@ -295,8 +290,9 @@ class Sm70MoeNvfp4IteratorB {
             frag_vec[3] = __hmul2(deq[1], scale_vec[3]);
           }
         } else {
-          static_assert(ThreadMap::Iterations::kContiguous == 1,
-                        "Unsupported SM70 Marlin MoE NVFP4 contiguous iteration count.");
+          static_assert(
+              ThreadMap::Iterations::kContiguous == 1,
+              "Unsupported SM70 Marlin MoE NVFP4 contiguous iteration count.");
           uint32_t const qword =
               load_qword_vector<1>(qweight_ + qweight_base_s);
           constexpr int kAccess = ThreadMap::kElementsPerAccess;
@@ -339,15 +335,15 @@ struct Sm70MoeNvfp4GemmSpec {
   using IteratorA = Sm70MoeGatherIteratorA<Shape, ThreadMap>;
 
   template <typename Shape, typename ThreadMap, int GroupSize, int PackedMacroN>
-  using IteratorB = Sm70MoeNvfp4IteratorB<Shape, ThreadMap, GroupSize, PackedMacroN>;
+  using IteratorB =
+      Sm70MoeNvfp4IteratorB<Shape, ThreadMap, GroupSize, PackedMacroN>;
 };
 
-template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM,
-          int WarpN, int WarpK, int GroupSize, int PackedMacroN>
+template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM, int WarpN,
+          int WarpK, int GroupSize, int PackedMacroN>
 using Sm70MoeNvfp4GemmTraits =
-    Sm70MarlinMoeGemmTraits<Sm70MoeNvfp4GemmSpec, CtaM, CtaN, CtaK,
-                            Warps, WarpM, WarpN, WarpK, GroupSize,
-                            PackedMacroN>;
+    Sm70MarlinMoeGemmTraits<Sm70MoeNvfp4GemmSpec, CtaM, CtaN, CtaK, Warps,
+                            WarpM, WarpN, WarpK, GroupSize, PackedMacroN>;
 
 struct Sm70MoeNvfp4Launcher {
   torch::Tensor& a;
@@ -368,15 +364,15 @@ struct Sm70MoeNvfp4Launcher {
   int64_t size_k;
   int requested_split_k;
 
-  template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM,
-          int WarpN, int WarpK, int GroupSize, int PackedMacroN>
+  template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM, int WarpN,
+            int WarpK, int GroupSize, int PackedMacroN>
   torch::Tensor operator()() const {
-    using Traits = Sm70MoeNvfp4GemmTraits<CtaM, CtaN, CtaK, Warps, WarpM,
-                                    WarpN, WarpK, GroupSize, PackedMacroN>;
+    using Traits = Sm70MoeNvfp4GemmTraits<CtaM, CtaN, CtaK, Warps, WarpM, WarpN,
+                                          WarpK, GroupSize, PackedMacroN>;
     return launch_sm70_marlin_moe_gemm<Traits>(
         a, c, b_q_weight, b_scales, b_zeros, global_scale, sorted_token_ids,
-        expert_ids, num_tokens_past_padded, topk_weights, moe_block_size,
-        top_k, mul_topk_weights, size_m, size_n, size_k, requested_split_k);
+        expert_ids, num_tokens_past_padded, topk_weights, moe_block_size, top_k,
+        mul_topk_weights, size_m, size_n, size_k, requested_split_k);
   }
 };
 
@@ -394,18 +390,32 @@ torch::Tensor sm70_marlin_nvfp4_gemm(
   auto const params = sm70_marlin_moe_auto_stage_params(
       "nvfp4", group_size, moe_block_size, top_k, size_m, size_n, size_k);
   Sm70CtaGeometry const geometry = params.geometry;
-  validate_sm70_marlin_moe_stage_cta_geometry_supported("SM70 Marlin MoE nvfp4", geometry);
-  validate_sm70_marlin_moe_stage_cta_n_alignment("SM70 Marlin MoE nvfp4", geometry,
-                                        size_n);
+  validate_sm70_marlin_moe_stage_cta_geometry_supported("SM70 Marlin MoE nvfp4",
+                                                        geometry);
+  validate_sm70_marlin_moe_stage_cta_n_alignment("SM70 Marlin MoE nvfp4",
+                                                 geometry, size_n);
   TORCH_CHECK(size_k % geometry.cta_k == 0,
               "SM70 Marlin MoE nvfp4 requires K divisible by CTA_K=",
               geometry.cta_k, ". Got K=", size_k, ".");
 
   auto empty_half = torch::empty({0}, b_scales.options().dtype(at::kHalf));
-  Sm70MoeNvfp4Launcher const launcher{
-      a, c, b_q_weight, b_scales, empty_half, global_scale, sorted_token_ids,
-      expert_ids, num_tokens_past_padded, topk_weights, moe_block_size, top_k,
-      mul_topk_weights, size_m, size_n, size_k, params.requested_split_k};
+  Sm70MoeNvfp4Launcher const launcher{a,
+                                      c,
+                                      b_q_weight,
+                                      b_scales,
+                                      empty_half,
+                                      global_scale,
+                                      sorted_token_ids,
+                                      expert_ids,
+                                      num_tokens_past_padded,
+                                      topk_weights,
+                                      moe_block_size,
+                                      top_k,
+                                      mul_topk_weights,
+                                      size_m,
+                                      size_n,
+                                      size_k,
+                                      params.requested_split_k};
   return dispatch_sm70_marlin_moe_fixed_group_geometry<16>(
       launcher, geometry, params.packed_macro_n, group_size, "nvfp4");
 }

--- a/csrc/moe/marlin_moe_wna16/sm70_marlin_u4_gemm.cu
+++ b/csrc/moe/marlin_moe_wna16/sm70_marlin_u4_gemm.cu
@@ -35,21 +35,23 @@ class Sm70MoeU4ZpIteratorB {
   static int const kPackedMacroN = PackedMacroN_;
   static constexpr bool kUseMetadataVectorWords = UseMetadataVectorWords_;
   using Element = cutlass::half_t;
-  using Fragment = cutlass::Array<
-      Element, ThreadMap::Iterations::kCount * ThreadMap::kElementsPerAccess>;
-  static_assert(Shape::kN == 64 || Shape::kN == 128 || Shape::kN == 256,
-                "SM70 Marlin MoE U4 IteratorB expects CTA_N in {64, 128, 256}.");
-  static_assert(ThreadMap::Iterations::kContiguous ==
-                    Shape::kN / kQuantTileN,
-                "SM70 Marlin MoE U4 IteratorB expects one contiguous iteration per "
-                "64-column quant tile.");
+  using Fragment = cutlass::Array<Element, ThreadMap::Iterations::kCount *
+                                               ThreadMap::kElementsPerAccess>;
+  static_assert(
+      Shape::kN == 64 || Shape::kN == 128 || Shape::kN == 256,
+      "SM70 Marlin MoE U4 IteratorB expects CTA_N in {64, 128, 256}.");
+  static_assert(
+      ThreadMap::Iterations::kContiguous == Shape::kN / kQuantTileN,
+      "SM70 Marlin MoE U4 IteratorB expects one contiguous iteration per "
+      "64-column quant tile.");
   static_assert(ThreadMap::Delta::kContiguous == kQuantTileN,
                 "SM70 Marlin MoE U4 IteratorB expects 64-column deltas.");
   static_assert(ThreadMap::kElementsPerAccess == kU4ValuesPerWord,
                 "SM70 Marlin MoE U4 IteratorB expects one packed int4 word per "
                 "access.");
   static_assert(ThreadMap::Iterations::kStrided >= 1,
-                "SM70 Marlin MoE U4-family IteratorB expects one or more strided iterations.");
+                "SM70 Marlin MoE U4-family IteratorB expects one or more "
+                "strided iterations.");
   struct Params {
     int size_k;
     int size_n;
@@ -85,11 +87,10 @@ class Sm70MoeU4ZpIteratorB {
                        half const* scales, half const* zp, int thread_id,
                        int expert, int k_offset, int n_offset)
       : qweight_(qweight),
-        scales_expert_base_(scales +
-                            (expert >= 0 ? expert : 0) *
-                                params.num_groups * params.size_n),
-        zp_expert_base_(zp + (expert >= 0 ? expert : 0) *
-                                 params.num_groups * params.size_n),
+        scales_expert_base_(scales + (expert >= 0 ? expert : 0) *
+                                         params.num_groups * params.size_n),
+        zp_expert_base_(zp + (expert >= 0 ? expert : 0) * params.num_groups *
+                                 params.size_n),
         params_(params),
         thread_offset_(ThreadMap::initial_offset(thread_id)),
         expert_(expert),
@@ -131,17 +132,14 @@ class Sm70MoeU4ZpIteratorB {
   }
 
   CUTLASS_DEVICE
-  int metadata_group_offset(int group) const {
-    return group * params_.size_n;
-  }
+  int metadata_group_offset(int group) const { return group * params_.size_n; }
 
   CUTLASS_DEVICE
   int scale_group(int logical_k) const {
     if constexpr (kGroupSize == -1) {
       return 0;
     } else {
-      static_assert(kGroupSize == 32 || kGroupSize == 64 ||
-                        kGroupSize == 128,
+      static_assert(kGroupSize == 32 || kGroupSize == 64 || kGroupSize == 128,
                     "SM70 Marlin MoE U4 supports only group sizes -1, 32, 64, "
                     "and 128.");
       return logical_k / kGroupSize;
@@ -158,16 +156,16 @@ class Sm70MoeU4ZpIteratorB {
   CUTLASS_DEVICE
   void cache_metadata_lane_vectors(int c, int group, int cache_n) const {
     int const metadata_offset = metadata_group_offset(group) + cache_n;
-    half2 const* scale_vec = reinterpret_cast<half2 const*>(
-        scales_expert_base_ + metadata_offset);
+    half2 const* scale_vec =
+        reinterpret_cast<half2 const*>(scales_expert_base_ + metadata_offset);
     half2* scale_cache = cached_scales_ + c * 4;
     scale_cache[0] = scale_vec[0];
     scale_cache[1] = scale_vec[1];
     scale_cache[2] = scale_vec[2];
     scale_cache[3] = scale_vec[3];
 
-    half2 const* zp_vec = reinterpret_cast<half2 const*>(
-        zp_expert_base_ + metadata_offset);
+    half2 const* zp_vec =
+        reinterpret_cast<half2 const*>(zp_expert_base_ + metadata_offset);
     half2* zp_cache = cached_zp_ + c * 4;
     zp_cache[0] = zp_vec[0];
     zp_cache[1] = zp_vec[1];
@@ -178,8 +176,8 @@ class Sm70MoeU4ZpIteratorB {
   CUTLASS_DEVICE
   void cache_metadata_vector_words(int c, int group, int cache_n) const {
     int const metadata_offset = metadata_group_offset(group) + cache_n;
-    uint4 const scale_words = *reinterpret_cast<uint4 const*>(
-        scales_expert_base_ + metadata_offset);
+    uint4 const scale_words =
+        *reinterpret_cast<uint4 const*>(scales_expert_base_ + metadata_offset);
     half2 const* scale_vec = reinterpret_cast<half2 const*>(&scale_words);
     half2* scale_cache = cached_scales_ + c * 4;
     scale_cache[0] = scale_vec[0];
@@ -187,8 +185,8 @@ class Sm70MoeU4ZpIteratorB {
     scale_cache[2] = scale_vec[2];
     scale_cache[3] = scale_vec[3];
 
-    uint4 const zp_words = *reinterpret_cast<uint4 const*>(
-        zp_expert_base_ + metadata_offset);
+    uint4 const zp_words =
+        *reinterpret_cast<uint4 const*>(zp_expert_base_ + metadata_offset);
     half2 const* zp_vec = reinterpret_cast<half2 const*>(&zp_words);
     half2* zp_cache = cached_zp_ + c * 4;
     zp_cache[0] = zp_vec[0];
@@ -201,9 +199,8 @@ class Sm70MoeU4ZpIteratorB {
   void cache_current_group_metadata(int group) const {
     CUTLASS_PRAGMA_UNROLL
     for (int c = 0; c < ThreadMap::Iterations::kContiguous; ++c) {
-      int const cache_n =
-          n_offset_ + thread_offset_.contiguous() +
-          c * ThreadMap::Delta::kContiguous;
+      int const cache_n = n_offset_ + thread_offset_.contiguous() +
+                          c * ThreadMap::Delta::kContiguous;
       if constexpr (kUseMetadataVectorWords) {
         cache_metadata_vector_words(c, group, cache_n);
       } else {
@@ -228,8 +225,8 @@ class Sm70MoeU4ZpIteratorB {
 
           half2 deq[2];
           half2* frag_vec = reinterpret_cast<half2*>(frag.data() + frag_base);
-          marlin::dequant<half2, vllm::kU4.id(), false>(
-              static_cast<int>(qword), deq);
+          marlin::dequant<half2, vllm::kU4.id(), false>(static_cast<int>(qword),
+                                                        deq);
           frag_vec[0] = __hfma2(deq[0], scale_vec[0], __hneg2(zp_vec[0]));
           frag_vec[1] = __hfma2(deq[1], scale_vec[1], __hneg2(zp_vec[1]));
           marlin::dequant<half2, vllm::kU4.id(), false>(
@@ -250,8 +247,8 @@ class Sm70MoeU4ZpIteratorB {
 
           half2 deq[2];
           half2* frag_vec = reinterpret_cast<half2*>(frag.data() + frag_base);
-          marlin::dequant<half2, vllm::kU4.id(), false>(
-              static_cast<int>(qword), deq);
+          marlin::dequant<half2, vllm::kU4.id(), false>(static_cast<int>(qword),
+                                                        deq);
           frag_vec[0] = __hfma2(deq[0], scale_vec[0], __hneg2(zp_vec[0]));
           frag_vec[1] = __hfma2(deq[1], scale_vec[1], __hneg2(zp_vec[1]));
           marlin::dequant<half2, vllm::kU4.id(), false>(
@@ -260,16 +257,18 @@ class Sm70MoeU4ZpIteratorB {
           frag_vec[3] = __hfma2(deq[1], scale_vec[3], __hneg2(zp_vec[3]));
         }
       } else {
-        static_assert(ThreadMap::Iterations::kContiguous == 1,
-                      "Unsupported SM70 Marlin MoE U4 contiguous iteration count.");
-        uint32_t const qword = load_qword_vector<1>(qweight_ + qweight_base_offset_);
+        static_assert(
+            ThreadMap::Iterations::kContiguous == 1,
+            "Unsupported SM70 Marlin MoE U4 contiguous iteration count.");
+        uint32_t const qword =
+            load_qword_vector<1>(qweight_ + qweight_base_offset_);
         half2 const* scale_vec = cached_scales_;
         half2 const* zp_vec = cached_zp_;
 
         half2 deq[2];
         half2* frag_vec = reinterpret_cast<half2*>(frag.data());
-        marlin::dequant<half2, vllm::kU4.id(), false>(
-            static_cast<int>(qword), deq);
+        marlin::dequant<half2, vllm::kU4.id(), false>(static_cast<int>(qword),
+                                                      deq);
         frag_vec[0] = __hfma2(deq[0], scale_vec[0], __hneg2(zp_vec[0]));
         frag_vec[1] = __hfma2(deq[1], scale_vec[1], __hneg2(zp_vec[1]));
         marlin::dequant<half2, vllm::kU4.id(), false>(
@@ -281,9 +280,8 @@ class Sm70MoeU4ZpIteratorB {
       int const logical_n_base = n_offset_ + thread_offset_.contiguous();
       CUTLASS_PRAGMA_UNROLL
       for (int s = 0; s < ThreadMap::Iterations::kStrided; ++s) {
-        int const logical_k_s =
-            k_offset_ + thread_offset_.strided() +
-            s * ThreadMap::Delta::kStrided;
+        int const logical_k_s = k_offset_ + thread_offset_.strided() +
+                                s * ThreadMap::Delta::kStrided;
         if constexpr (kGroupSize != -1) {
           cache_current_group_metadata(scale_group(logical_k_s));
         }
@@ -291,8 +289,7 @@ class Sm70MoeU4ZpIteratorB {
             expert_qweight_base_offset() +
             qweight_offset_from_logical(params_, logical_k_s, logical_n_base);
         if constexpr (ThreadMap::Iterations::kContiguous == 4) {
-          auto const qwords =
-              load_qword_vector<4>(qweight_ + qweight_base_s);
+          auto const qwords = load_qword_vector<4>(qweight_ + qweight_base_s);
           CUTLASS_PRAGMA_UNROLL
           for (int c = 0; c < ThreadMap::Iterations::kContiguous; ++c) {
             constexpr int kAccess = ThreadMap::kElementsPerAccess;
@@ -314,8 +311,7 @@ class Sm70MoeU4ZpIteratorB {
             frag_vec[3] = __hfma2(deq[1], scale_vec[3], __hneg2(zp_vec[3]));
           }
         } else if constexpr (ThreadMap::Iterations::kContiguous == 2) {
-          auto const qwords =
-              load_qword_vector<2>(qweight_ + qweight_base_s);
+          auto const qwords = load_qword_vector<2>(qweight_ + qweight_base_s);
           CUTLASS_PRAGMA_UNROLL
           for (int c = 0; c < ThreadMap::Iterations::kContiguous; ++c) {
             constexpr int kAccess = ThreadMap::kElementsPerAccess;
@@ -337,9 +333,11 @@ class Sm70MoeU4ZpIteratorB {
             frag_vec[3] = __hfma2(deq[1], scale_vec[3], __hneg2(zp_vec[3]));
           }
         } else {
-          static_assert(ThreadMap::Iterations::kContiguous == 1,
-                        "Unsupported SM70 Marlin MoE U4 contiguous iteration count.");
-          uint32_t const qword = load_qword_vector<1>(qweight_ + qweight_base_s);
+          static_assert(
+              ThreadMap::Iterations::kContiguous == 1,
+              "Unsupported SM70 Marlin MoE U4 contiguous iteration count.");
+          uint32_t const qword =
+              load_qword_vector<1>(qweight_ + qweight_base_s);
           constexpr int kAccess = ThreadMap::kElementsPerAccess;
           int const frag_base = s * kAccess;
           half2 const* scale_vec = cached_scales_;
@@ -347,8 +345,8 @@ class Sm70MoeU4ZpIteratorB {
 
           half2 deq[2];
           half2* frag_vec = reinterpret_cast<half2*>(frag.data() + frag_base);
-          marlin::dequant<half2, vllm::kU4.id(), false>(
-              static_cast<int>(qword), deq);
+          marlin::dequant<half2, vllm::kU4.id(), false>(static_cast<int>(qword),
+                                                        deq);
           frag_vec[0] = __hfma2(deq[0], scale_vec[0], __hneg2(zp_vec[0]));
           frag_vec[1] = __hfma2(deq[1], scale_vec[1], __hneg2(zp_vec[1]));
           marlin::dequant<half2, vllm::kU4.id(), false>(
@@ -366,8 +364,7 @@ class Sm70MoeU4ZpIteratorB {
       return;
     }
 
-    if constexpr (kGroupSize != -1 &&
-                  ThreadMap::Iterations::kStrided == 1) {
+    if constexpr (kGroupSize != -1 && ThreadMap::Iterations::kStrided == 1) {
       int const first_logical_k = k_offset_ + thread_offset_.strided();
       cache_current_group_metadata(scale_group(first_logical_k));
     }
@@ -386,18 +383,17 @@ struct Sm70MoeU4ZpGemmSpec {
   using IteratorA = Sm70MoeGatherIteratorA<Shape, ThreadMap>;
 
   template <typename Shape, typename ThreadMap, int GroupSize, int PackedMacroN>
-  using IteratorB =
-      Sm70MoeU4ZpIteratorB<Shape, ThreadMap, GroupSize, PackedMacroN,
-                           UseMetadataVectorWords>;
+  using IteratorB = Sm70MoeU4ZpIteratorB<Shape, ThreadMap, GroupSize,
+                                         PackedMacroN, UseMetadataVectorWords>;
 };
 
-template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM,
-          int WarpN, int WarpK, int GroupSize, int PackedMacroN,
+template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM, int WarpN,
+          int WarpK, int GroupSize, int PackedMacroN,
           bool UseMetadataVectorWords = true>
 using Sm70MoeU4ZpGemmTraits =
-    Sm70MarlinMoeGemmTraits<
-        Sm70MoeU4ZpGemmSpec<UseMetadataVectorWords>, CtaM, CtaN, CtaK,
-        Warps, WarpM, WarpN, WarpK, GroupSize, PackedMacroN>;
+    Sm70MarlinMoeGemmTraits<Sm70MoeU4ZpGemmSpec<UseMetadataVectorWords>, CtaM,
+                            CtaN, CtaK, Warps, WarpM, WarpN, WarpK, GroupSize,
+                            PackedMacroN>;
 
 template <bool UseMetadataVectorWords = true>
 struct Sm70MoeU4Launcher {
@@ -419,16 +415,16 @@ struct Sm70MoeU4Launcher {
   int64_t size_k;
   int requested_split_k;
 
-  template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM,
-          int WarpN, int WarpK, int GroupSize, int PackedMacroN>
+  template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM, int WarpN,
+            int WarpK, int GroupSize, int PackedMacroN>
   torch::Tensor operator()() const {
-    using Traits = Sm70MoeU4ZpGemmTraits<CtaM, CtaN, CtaK, Warps, WarpM,
-                                         WarpN, WarpK, GroupSize, PackedMacroN,
-                                         UseMetadataVectorWords>;
+    using Traits =
+        Sm70MoeU4ZpGemmTraits<CtaM, CtaN, CtaK, Warps, WarpM, WarpN, WarpK,
+                              GroupSize, PackedMacroN, UseMetadataVectorWords>;
     return launch_sm70_marlin_moe_gemm<Traits>(
         a, c, b_q_weight, b_scales, b_zeros, global_scale, sorted_token_ids,
-        expert_ids, num_tokens_past_padded, topk_weights, moe_block_size,
-        top_k, mul_topk_weights, size_m, size_n, size_k, requested_split_k);
+        expert_ids, num_tokens_past_padded, topk_weights, moe_block_size, top_k,
+        mul_topk_weights, size_m, size_n, size_k, requested_split_k);
   }
 };
 
@@ -446,9 +442,10 @@ torch::Tensor sm70_marlin_u4_gemm(
   auto const params = sm70_marlin_moe_auto_stage_params(
       "uint4", group_size, moe_block_size, top_k, size_m, size_n, size_k);
   Sm70CtaGeometry const geometry = params.geometry;
-  validate_sm70_marlin_moe_stage_cta_geometry_supported("SM70 Marlin MoE uint4", geometry);
-  validate_sm70_marlin_moe_stage_cta_n_alignment("SM70 Marlin MoE uint4", geometry,
-                                        size_n);
+  validate_sm70_marlin_moe_stage_cta_geometry_supported("SM70 Marlin MoE uint4",
+                                                        geometry);
+  validate_sm70_marlin_moe_stage_cta_n_alignment("SM70 Marlin MoE uint4",
+                                                 geometry, size_n);
   TORCH_CHECK(size_k % geometry.cta_k == 0,
               "SM70 Marlin MoE uint4 requires K divisible by CTA_K=",
               geometry.cta_k, ". Got K=", size_k, ".");
@@ -456,19 +453,45 @@ torch::Tensor sm70_marlin_u4_gemm(
   auto empty_float = torch::empty(
       {0}, torch::TensorOptions().dtype(at::kFloat).device(a.device()));
   if (params.use_metadata_vector_words) {
-    Sm70MoeU4Launcher<true> const launcher{
-        a, c, b_q_weight, b_scales, b_zeros, empty_float, sorted_token_ids,
-        expert_ids, num_tokens_past_padded, topk_weights, moe_block_size, top_k,
-        mul_topk_weights, size_m, size_n, size_k, params.requested_split_k};
-    return dispatch_sm70_marlin_moe_geometry(launcher, geometry, params.packed_macro_n, group_size,
-        "uint4");
+    Sm70MoeU4Launcher<true> const launcher{a,
+                                           c,
+                                           b_q_weight,
+                                           b_scales,
+                                           b_zeros,
+                                           empty_float,
+                                           sorted_token_ids,
+                                           expert_ids,
+                                           num_tokens_past_padded,
+                                           topk_weights,
+                                           moe_block_size,
+                                           top_k,
+                                           mul_topk_weights,
+                                           size_m,
+                                           size_n,
+                                           size_k,
+                                           params.requested_split_k};
+    return dispatch_sm70_marlin_moe_geometry(
+        launcher, geometry, params.packed_macro_n, group_size, "uint4");
   }
-  Sm70MoeU4Launcher<false> const launcher{
-      a, c, b_q_weight, b_scales, b_zeros, empty_float, sorted_token_ids,
-      expert_ids, num_tokens_past_padded, topk_weights, moe_block_size, top_k,
-      mul_topk_weights, size_m, size_n, size_k, params.requested_split_k};
-  return dispatch_sm70_marlin_moe_geometry(launcher, geometry, params.packed_macro_n, group_size,
-      "uint4");
+  Sm70MoeU4Launcher<false> const launcher{a,
+                                          c,
+                                          b_q_weight,
+                                          b_scales,
+                                          b_zeros,
+                                          empty_float,
+                                          sorted_token_ids,
+                                          expert_ids,
+                                          num_tokens_past_padded,
+                                          topk_weights,
+                                          moe_block_size,
+                                          top_k,
+                                          mul_topk_weights,
+                                          size_m,
+                                          size_n,
+                                          size_k,
+                                          params.requested_split_k};
+  return dispatch_sm70_marlin_moe_geometry(
+      launcher, geometry, params.packed_macro_n, group_size, "uint4");
 }
 
 }  // namespace marlin_moe_wna16

--- a/csrc/moe/marlin_moe_wna16/sm70_marlin_u4b8_gemm.cu
+++ b/csrc/moe/marlin_moe_wna16/sm70_marlin_u4b8_gemm.cu
@@ -35,22 +35,25 @@ class Sm70MoeU4B8IteratorB {
   static int const kPackedMacroN = PackedMacroN_;
   static constexpr bool kUseMetadataVectorWords = UseMetadataVectorWords_;
   using Element = cutlass::half_t;
-  using Fragment = cutlass::Array<
-      Element, ThreadMap::Iterations::kCount * ThreadMap::kElementsPerAccess>;
-    static_assert(Shape::kN == 64 || Shape::kN == 128 || Shape::kN == 256,
-                "SM70 Marlin MoE U4B8 IteratorB expects CTA_N in {64, 128, 256}.");
-  static_assert(ThreadMap::Iterations::kContiguous ==
-                    Shape::kN / kQuantTileN,
-                "SM70 Marlin MoE U4B8 IteratorB expects one contiguous iteration per "
-                "64-column quant tile.");
+  using Fragment = cutlass::Array<Element, ThreadMap::Iterations::kCount *
+                                               ThreadMap::kElementsPerAccess>;
+  static_assert(
+      Shape::kN == 64 || Shape::kN == 128 || Shape::kN == 256,
+      "SM70 Marlin MoE U4B8 IteratorB expects CTA_N in {64, 128, 256}.");
+  static_assert(
+      ThreadMap::Iterations::kContiguous == Shape::kN / kQuantTileN,
+      "SM70 Marlin MoE U4B8 IteratorB expects one contiguous iteration per "
+      "64-column quant tile.");
   static_assert(ThreadMap::Delta::kContiguous == kQuantTileN,
                 "SM70 Marlin MoE U4B8 IteratorB expects 64-column deltas.");
-  static_assert(ThreadMap::kElementsPerAccess == kU4ValuesPerWord,
-                "SM70 Marlin MoE U4B8 IteratorB expects one packed int4 word per "
-                "access.");
-  static_assert(ThreadMap::Iterations::kStrided >= 1,
-                "SM70 Marlin MoE U4-family IteratorB expects one or more strided "
-                "iterations.");
+  static_assert(
+      ThreadMap::kElementsPerAccess == kU4ValuesPerWord,
+      "SM70 Marlin MoE U4B8 IteratorB expects one packed int4 word per "
+      "access.");
+  static_assert(
+      ThreadMap::Iterations::kStrided >= 1,
+      "SM70 Marlin MoE U4-family IteratorB expects one or more strided "
+      "iterations.");
   struct Params {
     int size_k;
     int size_n;
@@ -84,9 +87,8 @@ class Sm70MoeU4B8IteratorB {
                        half const* scales, half const*, int thread_id,
                        int expert, int k_offset, int n_offset)
       : qweight_(qweight),
-        scales_expert_base_(scales +
-                            (expert >= 0 ? expert : 0) *
-                                params.num_groups * params.size_n),
+        scales_expert_base_(scales + (expert >= 0 ? expert : 0) *
+                                         params.num_groups * params.size_n),
         params_(params),
         thread_offset_(ThreadMap::initial_offset(thread_id)),
         expert_(expert),
@@ -128,19 +130,17 @@ class Sm70MoeU4B8IteratorB {
   }
 
   CUTLASS_DEVICE
-  int metadata_group_offset(int group) const {
-    return group * params_.size_n;
-  }
+  int metadata_group_offset(int group) const { return group * params_.size_n; }
 
   CUTLASS_DEVICE
   int scale_group(int logical_k) const {
     if constexpr (kGroupSize == -1) {
       return 0;
     } else {
-      static_assert(kGroupSize == 32 || kGroupSize == 64 ||
-                        kGroupSize == 128,
-                    "SM70 Marlin MoE U4B8 supports only group sizes -1, 32, 64, "
-                    "and 128.");
+      static_assert(
+          kGroupSize == 32 || kGroupSize == 64 || kGroupSize == 128,
+          "SM70 Marlin MoE U4B8 supports only group sizes -1, 32, 64, "
+          "and 128.");
       return logical_k / kGroupSize;
     }
   }
@@ -155,8 +155,8 @@ class Sm70MoeU4B8IteratorB {
   CUTLASS_DEVICE
   void cache_metadata_lane_vectors(int c, int group, int cache_n) const {
     int const metadata_offset = metadata_group_offset(group) + cache_n;
-    half2 const* scale_vec = reinterpret_cast<half2 const*>(
-        scales_expert_base_ + metadata_offset);
+    half2 const* scale_vec =
+        reinterpret_cast<half2 const*>(scales_expert_base_ + metadata_offset);
     half2* scale_cache = cached_scales_ + c * 4;
     scale_cache[0] = scale_vec[0];
     scale_cache[1] = scale_vec[1];
@@ -167,8 +167,8 @@ class Sm70MoeU4B8IteratorB {
   CUTLASS_DEVICE
   void cache_metadata_vector_words(int c, int group, int cache_n) const {
     int const metadata_offset = metadata_group_offset(group) + cache_n;
-    uint4 const scale_words = *reinterpret_cast<uint4 const*>(
-        scales_expert_base_ + metadata_offset);
+    uint4 const scale_words =
+        *reinterpret_cast<uint4 const*>(scales_expert_base_ + metadata_offset);
     half2 const* scale_vec = reinterpret_cast<half2 const*>(&scale_words);
     half2* scale_cache = cached_scales_ + c * 4;
     scale_cache[0] = scale_vec[0];
@@ -181,9 +181,8 @@ class Sm70MoeU4B8IteratorB {
   void cache_current_group_metadata(int group) const {
     CUTLASS_PRAGMA_UNROLL
     for (int c = 0; c < ThreadMap::Iterations::kContiguous; ++c) {
-      int const cache_n =
-          n_offset_ + thread_offset_.contiguous() +
-          c * ThreadMap::Delta::kContiguous;
+      int const cache_n = n_offset_ + thread_offset_.contiguous() +
+                          c * ThreadMap::Delta::kContiguous;
       if constexpr (kUseMetadataVectorWords) {
         cache_metadata_vector_words(c, group, cache_n);
       } else {
@@ -238,16 +237,17 @@ class Sm70MoeU4B8IteratorB {
           frag_vec[3] = __hmul2(deq[1], scale_vec[3]);
         }
       } else {
-        static_assert(ThreadMap::Iterations::kContiguous == 1,
-                      "Unsupported SM70 Marlin MoE U4B8 contiguous iteration count.");
+        static_assert(
+            ThreadMap::Iterations::kContiguous == 1,
+            "Unsupported SM70 Marlin MoE U4B8 contiguous iteration count.");
         uint32_t const qword =
             load_qword_vector<1>(qweight_ + qweight_base_offset_);
         half2 const* scale_vec = cached_scales_;
 
         half2 deq[2];
         half2* frag_vec = reinterpret_cast<half2*>(frag.data());
-        marlin::dequant<half2, vllm::kU4B8.id(), false>(
-            static_cast<int>(qword), deq);
+        marlin::dequant<half2, vllm::kU4B8.id(), false>(static_cast<int>(qword),
+                                                        deq);
         frag_vec[0] = __hmul2(deq[0], scale_vec[0]);
         frag_vec[1] = __hmul2(deq[1], scale_vec[1]);
         marlin::dequant<half2, vllm::kU4B8.id(), false>(
@@ -259,9 +259,8 @@ class Sm70MoeU4B8IteratorB {
       int const logical_n_base = n_offset_ + thread_offset_.contiguous();
       CUTLASS_PRAGMA_UNROLL
       for (int s = 0; s < ThreadMap::Iterations::kStrided; ++s) {
-        int const logical_k_s =
-            k_offset_ + thread_offset_.strided() +
-            s * ThreadMap::Delta::kStrided;
+        int const logical_k_s = k_offset_ + thread_offset_.strided() +
+                                s * ThreadMap::Delta::kStrided;
         if constexpr (kGroupSize != -1) {
           cache_current_group_metadata(scale_group(logical_k_s));
         }
@@ -269,8 +268,7 @@ class Sm70MoeU4B8IteratorB {
             expert_qweight_base_offset() +
             qweight_offset_from_logical(params_, logical_k_s, logical_n_base);
         if constexpr (ThreadMap::Iterations::kContiguous == 4) {
-          auto const qwords =
-              load_qword_vector<4>(qweight_ + qweight_base_s);
+          auto const qwords = load_qword_vector<4>(qweight_ + qweight_base_s);
           CUTLASS_PRAGMA_UNROLL
           for (int c = 0; c < ThreadMap::Iterations::kContiguous; ++c) {
             constexpr int kAccess = ThreadMap::kElementsPerAccess;
@@ -291,8 +289,7 @@ class Sm70MoeU4B8IteratorB {
             frag_vec[3] = __hmul2(deq[1], scale_vec[3]);
           }
         } else if constexpr (ThreadMap::Iterations::kContiguous == 2) {
-          auto const qwords =
-              load_qword_vector<2>(qweight_ + qweight_base_s);
+          auto const qwords = load_qword_vector<2>(qweight_ + qweight_base_s);
           CUTLASS_PRAGMA_UNROLL
           for (int c = 0; c < ThreadMap::Iterations::kContiguous; ++c) {
             constexpr int kAccess = ThreadMap::kElementsPerAccess;
@@ -313,8 +310,9 @@ class Sm70MoeU4B8IteratorB {
             frag_vec[3] = __hmul2(deq[1], scale_vec[3]);
           }
         } else {
-          static_assert(ThreadMap::Iterations::kContiguous == 1,
-                        "Unsupported SM70 Marlin MoE U4B8 contiguous iteration count.");
+          static_assert(
+              ThreadMap::Iterations::kContiguous == 1,
+              "Unsupported SM70 Marlin MoE U4B8 contiguous iteration count.");
           uint32_t const qword =
               load_qword_vector<1>(qweight_ + qweight_base_s);
           constexpr int kAccess = ThreadMap::kElementsPerAccess;
@@ -342,8 +340,7 @@ class Sm70MoeU4B8IteratorB {
       return;
     }
 
-    if constexpr (kGroupSize != -1 &&
-                  ThreadMap::Iterations::kStrided == 1) {
+    if constexpr (kGroupSize != -1 && ThreadMap::Iterations::kStrided == 1) {
       int const first_logical_k = k_offset_ + thread_offset_.strided();
       cache_current_group_metadata(scale_group(first_logical_k));
     }
@@ -362,18 +359,17 @@ struct Sm70MoeU4B8GemmSpec {
   using IteratorA = Sm70MoeGatherIteratorA<Shape, ThreadMap>;
 
   template <typename Shape, typename ThreadMap, int GroupSize, int PackedMacroN>
-  using IteratorB =
-      Sm70MoeU4B8IteratorB<Shape, ThreadMap, GroupSize, PackedMacroN,
-                           UseMetadataVectorWords>;
+  using IteratorB = Sm70MoeU4B8IteratorB<Shape, ThreadMap, GroupSize,
+                                         PackedMacroN, UseMetadataVectorWords>;
 };
 
-template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM,
-          int WarpN, int WarpK, int GroupSize, int PackedMacroN,
+template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM, int WarpN,
+          int WarpK, int GroupSize, int PackedMacroN,
           bool UseMetadataVectorWords = true>
 using Sm70MoeU4B8GemmTraits =
-    Sm70MarlinMoeGemmTraits<
-        Sm70MoeU4B8GemmSpec<UseMetadataVectorWords>, CtaM, CtaN, CtaK,
-        Warps, WarpM, WarpN, WarpK, GroupSize, PackedMacroN>;
+    Sm70MarlinMoeGemmTraits<Sm70MoeU4B8GemmSpec<UseMetadataVectorWords>, CtaM,
+                            CtaN, CtaK, Warps, WarpM, WarpN, WarpK, GroupSize,
+                            PackedMacroN>;
 
 template <bool UseMetadataVectorWords = true>
 struct Sm70MoeU4B8Launcher {
@@ -395,16 +391,16 @@ struct Sm70MoeU4B8Launcher {
   int64_t size_k;
   int requested_split_k;
 
-  template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM,
-          int WarpN, int WarpK, int GroupSize, int PackedMacroN>
+  template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM, int WarpN,
+            int WarpK, int GroupSize, int PackedMacroN>
   torch::Tensor operator()() const {
-    using Traits = Sm70MoeU4B8GemmTraits<CtaM, CtaN, CtaK, Warps, WarpM,
-                                         WarpN, WarpK, GroupSize, PackedMacroN,
-                                         UseMetadataVectorWords>;
+    using Traits =
+        Sm70MoeU4B8GemmTraits<CtaM, CtaN, CtaK, Warps, WarpM, WarpN, WarpK,
+                              GroupSize, PackedMacroN, UseMetadataVectorWords>;
     return launch_sm70_marlin_moe_gemm<Traits>(
         a, c, b_q_weight, b_scales, b_zeros, global_scale, sorted_token_ids,
-        expert_ids, num_tokens_past_padded, topk_weights, moe_block_size,
-        top_k, mul_topk_weights, size_m, size_n, size_k, requested_split_k);
+        expert_ids, num_tokens_past_padded, topk_weights, moe_block_size, top_k,
+        mul_topk_weights, size_m, size_n, size_k, requested_split_k);
   }
 };
 
@@ -422,9 +418,10 @@ torch::Tensor sm70_marlin_u4b8_gemm(
   auto const params = sm70_marlin_moe_auto_stage_params(
       "uint4b8", group_size, moe_block_size, top_k, size_m, size_n, size_k);
   Sm70CtaGeometry const geometry = params.geometry;
-  validate_sm70_marlin_moe_stage_cta_geometry_supported("SM70 Marlin MoE uint4b8", geometry);
-  validate_sm70_marlin_moe_stage_cta_n_alignment("SM70 Marlin MoE uint4b8", geometry,
-                                        size_n);
+  validate_sm70_marlin_moe_stage_cta_geometry_supported(
+      "SM70 Marlin MoE uint4b8", geometry);
+  validate_sm70_marlin_moe_stage_cta_n_alignment("SM70 Marlin MoE uint4b8",
+                                                 geometry, size_n);
   TORCH_CHECK(size_k % geometry.cta_k == 0,
               "SM70 Marlin MoE uint4b8 requires K divisible by CTA_K=",
               geometry.cta_k, ". Got K=", size_k, ".");
@@ -433,17 +430,43 @@ torch::Tensor sm70_marlin_u4b8_gemm(
   auto empty_float = torch::empty(
       {0}, torch::TensorOptions().dtype(at::kFloat).device(a.device()));
   if (params.use_metadata_vector_words) {
-    Sm70MoeU4B8Launcher<true> const launcher{
-        a, c, b_q_weight, b_scales, empty_half, empty_float, sorted_token_ids,
-        expert_ids, num_tokens_past_padded, topk_weights, moe_block_size, top_k,
-        mul_topk_weights, size_m, size_n, size_k, params.requested_split_k};
+    Sm70MoeU4B8Launcher<true> const launcher{a,
+                                             c,
+                                             b_q_weight,
+                                             b_scales,
+                                             empty_half,
+                                             empty_float,
+                                             sorted_token_ids,
+                                             expert_ids,
+                                             num_tokens_past_padded,
+                                             topk_weights,
+                                             moe_block_size,
+                                             top_k,
+                                             mul_topk_weights,
+                                             size_m,
+                                             size_n,
+                                             size_k,
+                                             params.requested_split_k};
     return dispatch_sm70_marlin_moe_geometry(
         launcher, geometry, params.packed_macro_n, group_size, "uint4b8");
   }
-  Sm70MoeU4B8Launcher<false> const launcher{
-      a, c, b_q_weight, b_scales, empty_half, empty_float, sorted_token_ids,
-      expert_ids, num_tokens_past_padded, topk_weights, moe_block_size, top_k,
-      mul_topk_weights, size_m, size_n, size_k, params.requested_split_k};
+  Sm70MoeU4B8Launcher<false> const launcher{a,
+                                            c,
+                                            b_q_weight,
+                                            b_scales,
+                                            empty_half,
+                                            empty_float,
+                                            sorted_token_ids,
+                                            expert_ids,
+                                            num_tokens_past_padded,
+                                            topk_weights,
+                                            moe_block_size,
+                                            top_k,
+                                            mul_topk_weights,
+                                            size_m,
+                                            size_n,
+                                            size_k,
+                                            params.requested_split_k};
   return dispatch_sm70_marlin_moe_geometry(
       launcher, geometry, params.packed_macro_n, group_size, "uint4b8");
 }

--- a/csrc/moe/marlin_moe_wna16/sm70_marlin_u8_gemm.cu
+++ b/csrc/moe/marlin_moe_wna16/sm70_marlin_u8_gemm.cu
@@ -35,22 +35,24 @@ class Sm70MoeU8ZpIteratorB {
   static int const kPackedMacroN = PackedMacroN_;
   static constexpr bool kUseMetadataVectorWords = UseMetadataVectorWords_;
   using Element = cutlass::half_t;
-  using Fragment = cutlass::Array<
-      Element, ThreadMap::Iterations::kCount * ThreadMap::kElementsPerAccess>;
-    static_assert(Shape::kN == 64 || Shape::kN == 128 || Shape::kN == 256,
-                "SM70 Marlin MoE U8 IteratorB expects CTA_N in {64, 128, 256}.");
-  static_assert(ThreadMap::Iterations::kContiguous ==
-                    Shape::kN / kQuantTileN,
-                "SM70 Marlin MoE U8 IteratorB expects one contiguous iteration per "
-                "64-column quant tile.");
+  using Fragment = cutlass::Array<Element, ThreadMap::Iterations::kCount *
+                                               ThreadMap::kElementsPerAccess>;
+  static_assert(
+      Shape::kN == 64 || Shape::kN == 128 || Shape::kN == 256,
+      "SM70 Marlin MoE U8 IteratorB expects CTA_N in {64, 128, 256}.");
+  static_assert(
+      ThreadMap::Iterations::kContiguous == Shape::kN / kQuantTileN,
+      "SM70 Marlin MoE U8 IteratorB expects one contiguous iteration per "
+      "64-column quant tile.");
   static_assert(ThreadMap::Delta::kContiguous == kQuantTileN,
                 "SM70 Marlin MoE U8 IteratorB expects 64-column deltas.");
   static_assert(ThreadMap::kElementsPerAccess == kU8ValuesPerAccess,
                 "SM70 Marlin MoE U8 IteratorB expects two packed U8 words per "
                 "access.");
-  static_assert(ThreadMap::Iterations::kStrided >= 1,
-                "SM70 Marlin MoE U8-family IteratorB expects one or more strided "
-                "iterations.");
+  static_assert(
+      ThreadMap::Iterations::kStrided >= 1,
+      "SM70 Marlin MoE U8-family IteratorB expects one or more strided "
+      "iterations.");
   static constexpr int kQweightWordStrideWords = kPackedMacroN / kQuantTileN;
 
   struct Params {
@@ -88,11 +90,10 @@ class Sm70MoeU8ZpIteratorB {
                        half const* scales, half const* zp, int thread_id,
                        int expert, int k_offset, int n_offset)
       : qweight_(qweight),
-        scales_expert_base_(scales +
-                            (expert >= 0 ? expert : 0) *
-                                params.num_groups * params.size_n),
-        zp_expert_base_(zp + (expert >= 0 ? expert : 0) *
-                                 params.num_groups * params.size_n),
+        scales_expert_base_(scales + (expert >= 0 ? expert : 0) *
+                                         params.num_groups * params.size_n),
+        zp_expert_base_(zp + (expert >= 0 ? expert : 0) * params.num_groups *
+                                 params.size_n),
         params_(params),
         thread_offset_(ThreadMap::initial_offset(thread_id)),
         expert_(expert),
@@ -134,17 +135,14 @@ class Sm70MoeU8ZpIteratorB {
   }
 
   CUTLASS_DEVICE
-  int metadata_group_offset(int group) const {
-    return group * params_.size_n;
-  }
+  int metadata_group_offset(int group) const { return group * params_.size_n; }
 
   CUTLASS_DEVICE
   int scale_group(int logical_k) const {
     if constexpr (kGroupSize == -1) {
       return 0;
     } else {
-      static_assert(kGroupSize == 32 || kGroupSize == 64 ||
-                        kGroupSize == 128,
+      static_assert(kGroupSize == 32 || kGroupSize == 64 || kGroupSize == 128,
                     "SM70 Marlin MoE U8 supports only group sizes -1, 32, 64, "
                     "and 128.");
       return logical_k / kGroupSize;
@@ -161,16 +159,16 @@ class Sm70MoeU8ZpIteratorB {
   CUTLASS_DEVICE
   void cache_metadata_lane_vectors(int c, int group, int cache_n) const {
     int const metadata_offset = metadata_group_offset(group) + cache_n;
-    half2 const* scale_vec = reinterpret_cast<half2 const*>(
-        scales_expert_base_ + metadata_offset);
+    half2 const* scale_vec =
+        reinterpret_cast<half2 const*>(scales_expert_base_ + metadata_offset);
     half2* scale_cache = cached_scales_ + c * 4;
     scale_cache[0] = scale_vec[0];
     scale_cache[1] = scale_vec[1];
     scale_cache[2] = scale_vec[2];
     scale_cache[3] = scale_vec[3];
 
-    half2 const* zp_vec = reinterpret_cast<half2 const*>(
-        zp_expert_base_ + metadata_offset);
+    half2 const* zp_vec =
+        reinterpret_cast<half2 const*>(zp_expert_base_ + metadata_offset);
     half2* zp_cache = cached_zp_ + c * 4;
     zp_cache[0] = zp_vec[0];
     zp_cache[1] = zp_vec[1];
@@ -181,8 +179,8 @@ class Sm70MoeU8ZpIteratorB {
   CUTLASS_DEVICE
   void cache_metadata_vector_words(int c, int group, int cache_n) const {
     int const metadata_offset = metadata_group_offset(group) + cache_n;
-    uint4 const scale_words = *reinterpret_cast<uint4 const*>(
-        scales_expert_base_ + metadata_offset);
+    uint4 const scale_words =
+        *reinterpret_cast<uint4 const*>(scales_expert_base_ + metadata_offset);
     half2 const* scale_vec = reinterpret_cast<half2 const*>(&scale_words);
     half2* scale_cache = cached_scales_ + c * 4;
     scale_cache[0] = scale_vec[0];
@@ -190,8 +188,8 @@ class Sm70MoeU8ZpIteratorB {
     scale_cache[2] = scale_vec[2];
     scale_cache[3] = scale_vec[3];
 
-    uint4 const zp_words = *reinterpret_cast<uint4 const*>(
-        zp_expert_base_ + metadata_offset);
+    uint4 const zp_words =
+        *reinterpret_cast<uint4 const*>(zp_expert_base_ + metadata_offset);
     half2 const* zp_vec = reinterpret_cast<half2 const*>(&zp_words);
     half2* zp_cache = cached_zp_ + c * 4;
     zp_cache[0] = zp_vec[0];
@@ -204,9 +202,8 @@ class Sm70MoeU8ZpIteratorB {
   void cache_current_group_metadata(int group) const {
     CUTLASS_PRAGMA_UNROLL
     for (int c = 0; c < ThreadMap::Iterations::kContiguous; ++c) {
-      int const cache_n =
-          n_offset_ + thread_offset_.contiguous() +
-          c * ThreadMap::Delta::kContiguous;
+      int const cache_n = n_offset_ + thread_offset_.contiguous() +
+                          c * ThreadMap::Delta::kContiguous;
       if constexpr (kUseMetadataVectorWords) {
         cache_metadata_vector_words(c, group, cache_n);
       } else {
@@ -269,8 +266,9 @@ class Sm70MoeU8ZpIteratorB {
           frag_vec[3] = __hfma2(deq[1], scale_vec[3], __hneg2(zp_vec[3]));
         }
       } else {
-        static_assert(ThreadMap::Iterations::kContiguous == 1,
-                      "Unsupported SM70 Marlin MoE U8 contiguous iteration count.");
+        static_assert(
+            ThreadMap::Iterations::kContiguous == 1,
+            "Unsupported SM70 Marlin MoE U8 contiguous iteration count.");
         uint32_t const qword0 =
             load_qword_vector<1>(qweight_ + qweight_base_offset_);
         uint32_t const qword1 = load_qword_vector<1>(
@@ -280,12 +278,12 @@ class Sm70MoeU8ZpIteratorB {
 
         half2 deq[2];
         half2* frag_vec = reinterpret_cast<half2*>(frag.data());
-        marlin::dequant<half2, vllm::kU8.id(), false>(
-            static_cast<int>(qword0), deq);
+        marlin::dequant<half2, vllm::kU8.id(), false>(static_cast<int>(qword0),
+                                                      deq);
         frag_vec[0] = __hfma2(deq[0], scale_vec[0], __hneg2(zp_vec[0]));
         frag_vec[1] = __hfma2(deq[1], scale_vec[1], __hneg2(zp_vec[1]));
-        marlin::dequant<half2, vllm::kU8.id(), false>(
-            static_cast<int>(qword1), deq);
+        marlin::dequant<half2, vllm::kU8.id(), false>(static_cast<int>(qword1),
+                                                      deq);
         frag_vec[2] = __hfma2(deq[0], scale_vec[2], __hneg2(zp_vec[2]));
         frag_vec[3] = __hfma2(deq[1], scale_vec[3], __hneg2(zp_vec[3]));
       }
@@ -293,9 +291,8 @@ class Sm70MoeU8ZpIteratorB {
       int const logical_n_base = n_offset_ + thread_offset_.contiguous();
       CUTLASS_PRAGMA_UNROLL
       for (int s = 0; s < ThreadMap::Iterations::kStrided; ++s) {
-        int const logical_k_s =
-            k_offset_ + thread_offset_.strided() +
-            s * ThreadMap::Delta::kStrided;
+        int const logical_k_s = k_offset_ + thread_offset_.strided() +
+                                s * ThreadMap::Delta::kStrided;
         if constexpr (kGroupSize != -1) {
           cache_current_group_metadata(scale_group(logical_k_s));
         }
@@ -303,10 +300,9 @@ class Sm70MoeU8ZpIteratorB {
             expert_qweight_base_offset() +
             qweight_offset_from_logical(params_, logical_k_s, logical_n_base);
         if constexpr (ThreadMap::Iterations::kContiguous == 4) {
-          uint4 const qwords0 =
-              load_qword_vector<4>(qweight_ + qweight_base_s);
-          uint4 const qwords1 = load_qword_vector<4>(
-              qweight_ + qweight_base_s + kQweightWordStrideWords);
+          uint4 const qwords0 = load_qword_vector<4>(qweight_ + qweight_base_s);
+          uint4 const qwords1 = load_qword_vector<4>(qweight_ + qweight_base_s +
+                                                     kQweightWordStrideWords);
           CUTLASS_PRAGMA_UNROLL
           for (int c = 0; c < ThreadMap::Iterations::kContiguous; ++c) {
             constexpr int kAccess = ThreadMap::kElementsPerAccess;
@@ -321,22 +317,17 @@ class Sm70MoeU8ZpIteratorB {
             half2* frag_vec = reinterpret_cast<half2*>(frag.data() + frag_base);
             marlin::dequant<half2, vllm::kU8.id(), false>(
                 static_cast<int>(qword0), deq);
-            frag_vec[0] =
-                __hfma2(deq[0], scale_vec[0], __hneg2(zp_vec[0]));
-            frag_vec[1] =
-                __hfma2(deq[1], scale_vec[1], __hneg2(zp_vec[1]));
+            frag_vec[0] = __hfma2(deq[0], scale_vec[0], __hneg2(zp_vec[0]));
+            frag_vec[1] = __hfma2(deq[1], scale_vec[1], __hneg2(zp_vec[1]));
             marlin::dequant<half2, vllm::kU8.id(), false>(
                 static_cast<int>(qword1), deq);
-            frag_vec[2] =
-                __hfma2(deq[0], scale_vec[2], __hneg2(zp_vec[2]));
-            frag_vec[3] =
-                __hfma2(deq[1], scale_vec[3], __hneg2(zp_vec[3]));
+            frag_vec[2] = __hfma2(deq[0], scale_vec[2], __hneg2(zp_vec[2]));
+            frag_vec[3] = __hfma2(deq[1], scale_vec[3], __hneg2(zp_vec[3]));
           }
         } else if constexpr (ThreadMap::Iterations::kContiguous == 2) {
-          uint2 const qwords0 =
-              load_qword_vector<2>(qweight_ + qweight_base_s);
-          uint2 const qwords1 = load_qword_vector<2>(
-              qweight_ + qweight_base_s + kQweightWordStrideWords);
+          uint2 const qwords0 = load_qword_vector<2>(qweight_ + qweight_base_s);
+          uint2 const qwords1 = load_qword_vector<2>(qweight_ + qweight_base_s +
+                                                     kQweightWordStrideWords);
           CUTLASS_PRAGMA_UNROLL
           for (int c = 0; c < ThreadMap::Iterations::kContiguous; ++c) {
             constexpr int kAccess = ThreadMap::kElementsPerAccess;
@@ -351,20 +342,17 @@ class Sm70MoeU8ZpIteratorB {
             half2* frag_vec = reinterpret_cast<half2*>(frag.data() + frag_base);
             marlin::dequant<half2, vllm::kU8.id(), false>(
                 static_cast<int>(qword0), deq);
-            frag_vec[0] =
-                __hfma2(deq[0], scale_vec[0], __hneg2(zp_vec[0]));
-            frag_vec[1] =
-                __hfma2(deq[1], scale_vec[1], __hneg2(zp_vec[1]));
+            frag_vec[0] = __hfma2(deq[0], scale_vec[0], __hneg2(zp_vec[0]));
+            frag_vec[1] = __hfma2(deq[1], scale_vec[1], __hneg2(zp_vec[1]));
             marlin::dequant<half2, vllm::kU8.id(), false>(
                 static_cast<int>(qword1), deq);
-            frag_vec[2] =
-                __hfma2(deq[0], scale_vec[2], __hneg2(zp_vec[2]));
-            frag_vec[3] =
-                __hfma2(deq[1], scale_vec[3], __hneg2(zp_vec[3]));
+            frag_vec[2] = __hfma2(deq[0], scale_vec[2], __hneg2(zp_vec[2]));
+            frag_vec[3] = __hfma2(deq[1], scale_vec[3], __hneg2(zp_vec[3]));
           }
         } else {
-          static_assert(ThreadMap::Iterations::kContiguous == 1,
-                        "Unsupported SM70 Marlin MoE U8 contiguous iteration count.");
+          static_assert(
+              ThreadMap::Iterations::kContiguous == 1,
+              "Unsupported SM70 Marlin MoE U8 contiguous iteration count.");
           uint32_t const qword0 =
               load_qword_vector<1>(qweight_ + qweight_base_s);
           uint32_t const qword1 = load_qword_vector<1>(
@@ -395,8 +383,7 @@ class Sm70MoeU8ZpIteratorB {
       return;
     }
 
-    if constexpr (kGroupSize != -1 &&
-                  ThreadMap::Iterations::kStrided == 1) {
+    if constexpr (kGroupSize != -1 && ThreadMap::Iterations::kStrided == 1) {
       int const first_logical_k = k_offset_ + thread_offset_.strided();
       cache_current_group_metadata(scale_group(first_logical_k));
     }
@@ -415,18 +402,17 @@ struct Sm70MoeU8ZpGemmSpec {
   using IteratorA = Sm70MoeGatherIteratorA<Shape, ThreadMap>;
 
   template <typename Shape, typename ThreadMap, int GroupSize, int PackedMacroN>
-  using IteratorB =
-      Sm70MoeU8ZpIteratorB<Shape, ThreadMap, GroupSize, PackedMacroN,
-                           UseMetadataVectorWords>;
+  using IteratorB = Sm70MoeU8ZpIteratorB<Shape, ThreadMap, GroupSize,
+                                         PackedMacroN, UseMetadataVectorWords>;
 };
 
-template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM,
-          int WarpN, int WarpK, int GroupSize, int PackedMacroN,
+template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM, int WarpN,
+          int WarpK, int GroupSize, int PackedMacroN,
           bool UseMetadataVectorWords = true>
 using Sm70MoeU8ZpGemmTraits =
-    Sm70MarlinMoeGemmTraits<
-        Sm70MoeU8ZpGemmSpec<UseMetadataVectorWords>, CtaM, CtaN, CtaK,
-        Warps, WarpM, WarpN, WarpK, GroupSize, PackedMacroN>;
+    Sm70MarlinMoeGemmTraits<Sm70MoeU8ZpGemmSpec<UseMetadataVectorWords>, CtaM,
+                            CtaN, CtaK, Warps, WarpM, WarpN, WarpK, GroupSize,
+                            PackedMacroN>;
 
 template <bool UseMetadataVectorWords = true>
 struct Sm70MoeU8Launcher {
@@ -448,16 +434,16 @@ struct Sm70MoeU8Launcher {
   int64_t size_k;
   int requested_split_k;
 
-  template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM,
-          int WarpN, int WarpK, int GroupSize, int PackedMacroN>
+  template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM, int WarpN,
+            int WarpK, int GroupSize, int PackedMacroN>
   torch::Tensor operator()() const {
-    using Traits = Sm70MoeU8ZpGemmTraits<CtaM, CtaN, CtaK, Warps, WarpM,
-                                         WarpN, WarpK, GroupSize, PackedMacroN,
-                                         UseMetadataVectorWords>;
+    using Traits =
+        Sm70MoeU8ZpGemmTraits<CtaM, CtaN, CtaK, Warps, WarpM, WarpN, WarpK,
+                              GroupSize, PackedMacroN, UseMetadataVectorWords>;
     return launch_sm70_marlin_moe_gemm<Traits>(
         a, c, b_q_weight, b_scales, b_zeros, global_scale, sorted_token_ids,
-        expert_ids, num_tokens_past_padded, topk_weights, moe_block_size,
-        top_k, mul_topk_weights, size_m, size_n, size_k, requested_split_k);
+        expert_ids, num_tokens_past_padded, topk_weights, moe_block_size, top_k,
+        mul_topk_weights, size_m, size_n, size_k, requested_split_k);
   }
 };
 
@@ -475,9 +461,10 @@ torch::Tensor sm70_marlin_u8_gemm(
   auto const params = sm70_marlin_moe_auto_stage_params(
       "uint8", group_size, moe_block_size, top_k, size_m, size_n, size_k);
   Sm70CtaGeometry const geometry = params.geometry;
-  validate_sm70_marlin_moe_stage_cta_geometry_supported("SM70 Marlin MoE uint8", geometry);
-  validate_sm70_marlin_moe_stage_cta_n_alignment("SM70 Marlin MoE uint8", geometry,
-                                        size_n);
+  validate_sm70_marlin_moe_stage_cta_geometry_supported("SM70 Marlin MoE uint8",
+                                                        geometry);
+  validate_sm70_marlin_moe_stage_cta_n_alignment("SM70 Marlin MoE uint8",
+                                                 geometry, size_n);
   TORCH_CHECK(size_k % geometry.cta_k == 0,
               "SM70 Marlin MoE uint8 requires K divisible by CTA_K=",
               geometry.cta_k, ". Got K=", size_k, ".");
@@ -485,19 +472,45 @@ torch::Tensor sm70_marlin_u8_gemm(
   auto empty_float = torch::empty(
       {0}, torch::TensorOptions().dtype(at::kFloat).device(a.device()));
   if (params.use_metadata_vector_words) {
-    Sm70MoeU8Launcher<true> const launcher{
-        a, c, b_q_weight, b_scales, b_zeros, empty_float, sorted_token_ids,
-        expert_ids, num_tokens_past_padded, topk_weights, moe_block_size, top_k,
-        mul_topk_weights, size_m, size_n, size_k, params.requested_split_k};
-    return dispatch_sm70_marlin_moe_geometry_with_group32(launcher, geometry, params.packed_macro_n, group_size,
-        "uint8");
+    Sm70MoeU8Launcher<true> const launcher{a,
+                                           c,
+                                           b_q_weight,
+                                           b_scales,
+                                           b_zeros,
+                                           empty_float,
+                                           sorted_token_ids,
+                                           expert_ids,
+                                           num_tokens_past_padded,
+                                           topk_weights,
+                                           moe_block_size,
+                                           top_k,
+                                           mul_topk_weights,
+                                           size_m,
+                                           size_n,
+                                           size_k,
+                                           params.requested_split_k};
+    return dispatch_sm70_marlin_moe_geometry_with_group32(
+        launcher, geometry, params.packed_macro_n, group_size, "uint8");
   }
-  Sm70MoeU8Launcher<false> const launcher{
-      a, c, b_q_weight, b_scales, b_zeros, empty_float, sorted_token_ids,
-      expert_ids, num_tokens_past_padded, topk_weights, moe_block_size, top_k,
-      mul_topk_weights, size_m, size_n, size_k, params.requested_split_k};
-  return dispatch_sm70_marlin_moe_geometry_with_group32(launcher, geometry, params.packed_macro_n, group_size,
-      "uint8");
+  Sm70MoeU8Launcher<false> const launcher{a,
+                                          c,
+                                          b_q_weight,
+                                          b_scales,
+                                          b_zeros,
+                                          empty_float,
+                                          sorted_token_ids,
+                                          expert_ids,
+                                          num_tokens_past_padded,
+                                          topk_weights,
+                                          moe_block_size,
+                                          top_k,
+                                          mul_topk_weights,
+                                          size_m,
+                                          size_n,
+                                          size_k,
+                                          params.requested_split_k};
+  return dispatch_sm70_marlin_moe_geometry_with_group32(
+      launcher, geometry, params.packed_macro_n, group_size, "uint8");
 }
 
 }  // namespace marlin_moe_wna16

--- a/csrc/moe/marlin_moe_wna16/sm70_marlin_u8b128_gemm.cu
+++ b/csrc/moe/marlin_moe_wna16/sm70_marlin_u8b128_gemm.cu
@@ -35,22 +35,25 @@ class Sm70MoeU8B128IteratorB {
   static int const kPackedMacroN = PackedMacroN_;
   static constexpr bool kUseMetadataVectorWords = UseMetadataVectorWords_;
   using Element = cutlass::half_t;
-  using Fragment = cutlass::Array<
-      Element, ThreadMap::Iterations::kCount * ThreadMap::kElementsPerAccess>;
-    static_assert(Shape::kN == 64 || Shape::kN == 128 || Shape::kN == 256,
-                "SM70 Marlin MoE U8B128 IteratorB expects CTA_N in {64, 128, 256}.");
-  static_assert(ThreadMap::Iterations::kContiguous ==
-                    Shape::kN / kQuantTileN,
-                "SM70 Marlin MoE U8B128 IteratorB expects one contiguous iteration per "
-                "64-column quant tile.");
+  using Fragment = cutlass::Array<Element, ThreadMap::Iterations::kCount *
+                                               ThreadMap::kElementsPerAccess>;
+  static_assert(
+      Shape::kN == 64 || Shape::kN == 128 || Shape::kN == 256,
+      "SM70 Marlin MoE U8B128 IteratorB expects CTA_N in {64, 128, 256}.");
+  static_assert(
+      ThreadMap::Iterations::kContiguous == Shape::kN / kQuantTileN,
+      "SM70 Marlin MoE U8B128 IteratorB expects one contiguous iteration per "
+      "64-column quant tile.");
   static_assert(ThreadMap::Delta::kContiguous == kQuantTileN,
                 "SM70 Marlin MoE U8B128 IteratorB expects 64-column deltas.");
-  static_assert(ThreadMap::kElementsPerAccess == kU8B128ValuesPerAccess,
-                "SM70 Marlin MoE U8B128 IteratorB expects two packed U8B128 words "
-                "per access.");
-  static_assert(ThreadMap::Iterations::kStrided >= 1,
-                "SM70 Marlin MoE U8-family IteratorB expects one or more strided "
-                "iterations.");
+  static_assert(
+      ThreadMap::kElementsPerAccess == kU8B128ValuesPerAccess,
+      "SM70 Marlin MoE U8B128 IteratorB expects two packed U8B128 words "
+      "per access.");
+  static_assert(
+      ThreadMap::Iterations::kStrided >= 1,
+      "SM70 Marlin MoE U8-family IteratorB expects one or more strided "
+      "iterations.");
   static constexpr int kQweightWordStrideWords = kPackedMacroN / kQuantTileN;
 
   struct Params {
@@ -86,9 +89,8 @@ class Sm70MoeU8B128IteratorB {
                          half const* scales, half const*, int thread_id,
                          int expert, int k_offset, int n_offset)
       : qweight_(qweight),
-        scales_expert_base_(scales +
-                            (expert >= 0 ? expert : 0) *
-                                params.num_groups * params.size_n),
+        scales_expert_base_(scales + (expert >= 0 ? expert : 0) *
+                                         params.num_groups * params.size_n),
         params_(params),
         thread_offset_(ThreadMap::initial_offset(thread_id)),
         expert_(expert),
@@ -130,19 +132,17 @@ class Sm70MoeU8B128IteratorB {
   }
 
   CUTLASS_DEVICE
-  int metadata_group_offset(int group) const {
-    return group * params_.size_n;
-  }
+  int metadata_group_offset(int group) const { return group * params_.size_n; }
 
   CUTLASS_DEVICE
   int scale_group(int logical_k) const {
     if constexpr (kGroupSize == -1) {
       return 0;
     } else {
-      static_assert(kGroupSize == 32 || kGroupSize == 64 ||
-                        kGroupSize == 128,
-                    "SM70 Marlin MoE U8B128 supports only group sizes -1, 32, 64, "
-                    "and 128.");
+      static_assert(
+          kGroupSize == 32 || kGroupSize == 64 || kGroupSize == 128,
+          "SM70 Marlin MoE U8B128 supports only group sizes -1, 32, 64, "
+          "and 128.");
       return logical_k / kGroupSize;
     }
   }
@@ -157,8 +157,8 @@ class Sm70MoeU8B128IteratorB {
   CUTLASS_DEVICE
   void cache_metadata_lane_vectors(int c, int group, int cache_n) const {
     int const metadata_offset = metadata_group_offset(group) + cache_n;
-    half2 const* scale_vec = reinterpret_cast<half2 const*>(
-        scales_expert_base_ + metadata_offset);
+    half2 const* scale_vec =
+        reinterpret_cast<half2 const*>(scales_expert_base_ + metadata_offset);
     half2* scale_cache = cached_scales_ + c * 4;
     scale_cache[0] = scale_vec[0];
     scale_cache[1] = scale_vec[1];
@@ -169,8 +169,8 @@ class Sm70MoeU8B128IteratorB {
   CUTLASS_DEVICE
   void cache_metadata_vector_words(int c, int group, int cache_n) const {
     int const metadata_offset = metadata_group_offset(group) + cache_n;
-    uint4 const scale_words = *reinterpret_cast<uint4 const*>(
-        scales_expert_base_ + metadata_offset);
+    uint4 const scale_words =
+        *reinterpret_cast<uint4 const*>(scales_expert_base_ + metadata_offset);
     half2 const* scale_vec = reinterpret_cast<half2 const*>(&scale_words);
     half2* scale_cache = cached_scales_ + c * 4;
     scale_cache[0] = scale_vec[0];
@@ -183,9 +183,8 @@ class Sm70MoeU8B128IteratorB {
   void cache_current_group_metadata(int group) const {
     CUTLASS_PRAGMA_UNROLL
     for (int c = 0; c < ThreadMap::Iterations::kContiguous; ++c) {
-      int const cache_n =
-          n_offset_ + thread_offset_.contiguous() +
-          c * ThreadMap::Delta::kContiguous;
+      int const cache_n = n_offset_ + thread_offset_.contiguous() +
+                          c * ThreadMap::Delta::kContiguous;
       if constexpr (kUseMetadataVectorWords) {
         cache_metadata_vector_words(c, group, cache_n);
       } else {
@@ -246,8 +245,9 @@ class Sm70MoeU8B128IteratorB {
           frag_vec[3] = __hmul2(deq[1], scale_vec[3]);
         }
       } else {
-        static_assert(ThreadMap::Iterations::kContiguous == 1,
-                      "Unsupported SM70 Marlin MoE U8B128 contiguous iteration count.");
+        static_assert(
+            ThreadMap::Iterations::kContiguous == 1,
+            "Unsupported SM70 Marlin MoE U8B128 contiguous iteration count.");
         uint32_t const qword0 =
             load_qword_vector<1>(qweight_ + qweight_base_offset_);
         uint32_t const qword1 = load_qword_vector<1>(
@@ -269,9 +269,8 @@ class Sm70MoeU8B128IteratorB {
       int const logical_n_base = n_offset_ + thread_offset_.contiguous();
       CUTLASS_PRAGMA_UNROLL
       for (int s = 0; s < ThreadMap::Iterations::kStrided; ++s) {
-        int const logical_k_s =
-            k_offset_ + thread_offset_.strided() +
-            s * ThreadMap::Delta::kStrided;
+        int const logical_k_s = k_offset_ + thread_offset_.strided() +
+                                s * ThreadMap::Delta::kStrided;
         if constexpr (kGroupSize != -1) {
           cache_current_group_metadata(scale_group(logical_k_s));
         }
@@ -279,10 +278,9 @@ class Sm70MoeU8B128IteratorB {
             expert_qweight_base_offset() +
             qweight_offset_from_logical(params_, logical_k_s, logical_n_base);
         if constexpr (ThreadMap::Iterations::kContiguous == 4) {
-          uint4 const qwords0 =
-              load_qword_vector<4>(qweight_ + qweight_base_s);
-          uint4 const qwords1 = load_qword_vector<4>(
-              qweight_ + qweight_base_s + kQweightWordStrideWords);
+          uint4 const qwords0 = load_qword_vector<4>(qweight_ + qweight_base_s);
+          uint4 const qwords1 = load_qword_vector<4>(qweight_ + qweight_base_s +
+                                                     kQweightWordStrideWords);
           CUTLASS_PRAGMA_UNROLL
           for (int c = 0; c < ThreadMap::Iterations::kContiguous; ++c) {
             constexpr int kAccess = ThreadMap::kElementsPerAccess;
@@ -296,22 +294,17 @@ class Sm70MoeU8B128IteratorB {
             half2* frag_vec = reinterpret_cast<half2*>(frag.data() + frag_base);
             marlin::dequant<half2, vllm::kU8B128.id(), false>(
                 static_cast<int>(qword0), deq);
-            frag_vec[0] =
-                __hmul2(deq[0], scale_vec[0]);
-            frag_vec[1] =
-                __hmul2(deq[1], scale_vec[1]);
+            frag_vec[0] = __hmul2(deq[0], scale_vec[0]);
+            frag_vec[1] = __hmul2(deq[1], scale_vec[1]);
             marlin::dequant<half2, vllm::kU8B128.id(), false>(
                 static_cast<int>(qword1), deq);
-            frag_vec[2] =
-                __hmul2(deq[0], scale_vec[2]);
-            frag_vec[3] =
-                __hmul2(deq[1], scale_vec[3]);
+            frag_vec[2] = __hmul2(deq[0], scale_vec[2]);
+            frag_vec[3] = __hmul2(deq[1], scale_vec[3]);
           }
         } else if constexpr (ThreadMap::Iterations::kContiguous == 2) {
-          uint2 const qwords0 =
-              load_qword_vector<2>(qweight_ + qweight_base_s);
-          uint2 const qwords1 = load_qword_vector<2>(
-              qweight_ + qweight_base_s + kQweightWordStrideWords);
+          uint2 const qwords0 = load_qword_vector<2>(qweight_ + qweight_base_s);
+          uint2 const qwords1 = load_qword_vector<2>(qweight_ + qweight_base_s +
+                                                     kQweightWordStrideWords);
           CUTLASS_PRAGMA_UNROLL
           for (int c = 0; c < ThreadMap::Iterations::kContiguous; ++c) {
             constexpr int kAccess = ThreadMap::kElementsPerAccess;
@@ -325,20 +318,17 @@ class Sm70MoeU8B128IteratorB {
             half2* frag_vec = reinterpret_cast<half2*>(frag.data() + frag_base);
             marlin::dequant<half2, vllm::kU8B128.id(), false>(
                 static_cast<int>(qword0), deq);
-            frag_vec[0] =
-                __hmul2(deq[0], scale_vec[0]);
-            frag_vec[1] =
-                __hmul2(deq[1], scale_vec[1]);
+            frag_vec[0] = __hmul2(deq[0], scale_vec[0]);
+            frag_vec[1] = __hmul2(deq[1], scale_vec[1]);
             marlin::dequant<half2, vllm::kU8B128.id(), false>(
                 static_cast<int>(qword1), deq);
-            frag_vec[2] =
-                __hmul2(deq[0], scale_vec[2]);
-            frag_vec[3] =
-                __hmul2(deq[1], scale_vec[3]);
+            frag_vec[2] = __hmul2(deq[0], scale_vec[2]);
+            frag_vec[3] = __hmul2(deq[1], scale_vec[3]);
           }
         } else {
-          static_assert(ThreadMap::Iterations::kContiguous == 1,
-                        "Unsupported SM70 Marlin MoE U8B128 contiguous iteration count.");
+          static_assert(
+              ThreadMap::Iterations::kContiguous == 1,
+              "Unsupported SM70 Marlin MoE U8B128 contiguous iteration count.");
           uint32_t const qword0 =
               load_qword_vector<1>(qweight_ + qweight_base_s);
           uint32_t const qword1 = load_qword_vector<1>(
@@ -368,8 +358,7 @@ class Sm70MoeU8B128IteratorB {
       return;
     }
 
-    if constexpr (kGroupSize != -1 &&
-                  ThreadMap::Iterations::kStrided == 1) {
+    if constexpr (kGroupSize != -1 && ThreadMap::Iterations::kStrided == 1) {
       int const first_logical_k = k_offset_ + thread_offset_.strided();
       cache_current_group_metadata(scale_group(first_logical_k));
     }
@@ -393,13 +382,13 @@ struct Sm70MoeU8B128GemmSpec {
                              UseMetadataVectorWords>;
 };
 
-template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM,
-          int WarpN, int WarpK, int GroupSize, int PackedMacroN,
+template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM, int WarpN,
+          int WarpK, int GroupSize, int PackedMacroN,
           bool UseMetadataVectorWords = true>
 using Sm70MoeU8B128GemmTraits =
-    Sm70MarlinMoeGemmTraits<
-        Sm70MoeU8B128GemmSpec<UseMetadataVectorWords>, CtaM, CtaN, CtaK,
-        Warps, WarpM, WarpN, WarpK, GroupSize, PackedMacroN>;
+    Sm70MarlinMoeGemmTraits<Sm70MoeU8B128GemmSpec<UseMetadataVectorWords>, CtaM,
+                            CtaN, CtaK, Warps, WarpM, WarpN, WarpK, GroupSize,
+                            PackedMacroN>;
 
 template <bool UseMetadataVectorWords = true>
 struct Sm70MoeU8B128Launcher {
@@ -421,16 +410,17 @@ struct Sm70MoeU8B128Launcher {
   int64_t size_k;
   int requested_split_k;
 
-  template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM,
-          int WarpN, int WarpK, int GroupSize, int PackedMacroN>
+  template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM, int WarpN,
+            int WarpK, int GroupSize, int PackedMacroN>
   torch::Tensor operator()() const {
-    using Traits = Sm70MoeU8B128GemmTraits<CtaM, CtaN, CtaK, Warps, WarpM,
-                                           WarpN, WarpK, GroupSize, PackedMacroN,
-                                           UseMetadataVectorWords>;
+    using Traits =
+        Sm70MoeU8B128GemmTraits<CtaM, CtaN, CtaK, Warps, WarpM, WarpN, WarpK,
+                                GroupSize, PackedMacroN,
+                                UseMetadataVectorWords>;
     return launch_sm70_marlin_moe_gemm<Traits>(
         a, c, b_q_weight, b_scales, b_zeros, global_scale, sorted_token_ids,
-        expert_ids, num_tokens_past_padded, topk_weights, moe_block_size,
-        top_k, mul_topk_weights, size_m, size_n, size_k, requested_split_k);
+        expert_ids, num_tokens_past_padded, topk_weights, moe_block_size, top_k,
+        mul_topk_weights, size_m, size_n, size_k, requested_split_k);
   }
 };
 
@@ -448,9 +438,10 @@ torch::Tensor sm70_marlin_u8b128_gemm(
   auto const params = sm70_marlin_moe_auto_stage_params(
       "uint8b128", group_size, moe_block_size, top_k, size_m, size_n, size_k);
   Sm70CtaGeometry const geometry = params.geometry;
-  validate_sm70_marlin_moe_stage_cta_geometry_supported("SM70 Marlin MoE uint8b128", geometry);
-  validate_sm70_marlin_moe_stage_cta_n_alignment("SM70 Marlin MoE uint8b128", geometry,
-                                        size_n);
+  validate_sm70_marlin_moe_stage_cta_geometry_supported(
+      "SM70 Marlin MoE uint8b128", geometry);
+  validate_sm70_marlin_moe_stage_cta_n_alignment("SM70 Marlin MoE uint8b128",
+                                                 geometry, size_n);
   TORCH_CHECK(size_k % geometry.cta_k == 0,
               "SM70 Marlin MoE uint8b128 requires K divisible by CTA_K=",
               geometry.cta_k, ". Got K=", size_k, ".");
@@ -459,17 +450,43 @@ torch::Tensor sm70_marlin_u8b128_gemm(
   auto empty_float = torch::empty(
       {0}, torch::TensorOptions().dtype(at::kFloat).device(a.device()));
   if (params.use_metadata_vector_words) {
-    Sm70MoeU8B128Launcher<true> const launcher{
-        a, c, b_q_weight, b_scales, empty_half, empty_float, sorted_token_ids,
-        expert_ids, num_tokens_past_padded, topk_weights, moe_block_size, top_k,
-        mul_topk_weights, size_m, size_n, size_k, params.requested_split_k};
+    Sm70MoeU8B128Launcher<true> const launcher{a,
+                                               c,
+                                               b_q_weight,
+                                               b_scales,
+                                               empty_half,
+                                               empty_float,
+                                               sorted_token_ids,
+                                               expert_ids,
+                                               num_tokens_past_padded,
+                                               topk_weights,
+                                               moe_block_size,
+                                               top_k,
+                                               mul_topk_weights,
+                                               size_m,
+                                               size_n,
+                                               size_k,
+                                               params.requested_split_k};
     return dispatch_sm70_marlin_moe_geometry_with_group32(
         launcher, geometry, params.packed_macro_n, group_size, "uint8b128");
   }
-  Sm70MoeU8B128Launcher<false> const launcher{
-      a, c, b_q_weight, b_scales, empty_half, empty_float, sorted_token_ids,
-      expert_ids, num_tokens_past_padded, topk_weights, moe_block_size, top_k,
-      mul_topk_weights, size_m, size_n, size_k, params.requested_split_k};
+  Sm70MoeU8B128Launcher<false> const launcher{a,
+                                              c,
+                                              b_q_weight,
+                                              b_scales,
+                                              empty_half,
+                                              empty_float,
+                                              sorted_token_ids,
+                                              expert_ids,
+                                              num_tokens_past_padded,
+                                              topk_weights,
+                                              moe_block_size,
+                                              top_k,
+                                              mul_topk_weights,
+                                              size_m,
+                                              size_n,
+                                              size_k,
+                                              params.requested_split_k};
   return dispatch_sm70_marlin_moe_geometry_with_group32(
       launcher, geometry, params.packed_macro_n, group_size, "uint8b128");
 }

--- a/csrc/quantization/marlin/sm70_awq_marlin_repack.cu
+++ b/csrc/quantization/marlin/sm70_awq_marlin_repack.cu
@@ -92,8 +92,7 @@ __global__ void awq_marlin_repack_kernel(
       constexpr int sh_stride = tile_n_ints;
       int4* sh_stage_ptr = sh + stage_size * pipe;
       uint32_t* sh_stage_int_ptr = reinterpret_cast<uint32_t*>(sh_stage_ptr);
-      uint32_t packed_src =
-          sh_stage_int_ptr[local_k * sh_stride + local_n_vec];
+      uint32_t packed_src = sh_stage_int_ptr[local_k * sh_stride + local_n_vec];
 
       constexpr int undo_pack[8] = {0, 4, 1, 5, 2, 6, 3, 7};
       constexpr int pack_idx[8] = {0, 2, 4, 6, 1, 3, 5, 7};
@@ -114,9 +113,8 @@ __global__ void awq_marlin_repack_kernel(
       int const cta_first_n_tile = cta_n_tile * cta_n_tiles;
       int const subtile = n_tile_id - cta_first_n_tile;
       int const local_word = local_k * 8 + local_n_vec;
-      int const cta_n_offset =
-          cta_n_tile * cta_n_tiles * tile_size +
-          local_word * cta_n_tiles + subtile;
+      int const cta_n_offset = cta_n_tile * cta_n_tiles * tile_size +
+                               local_word * cta_n_tiles + subtile;
       out_ptr[k_tile_id * n_tiles * tile_size + cta_n_offset] = res;
       return;
     }
@@ -155,9 +153,8 @@ __global__ void awq_marlin_repack_kernel(
       int const cta_first_n_tile = cta_n_tile * cta_n_tiles;
       int const subtile = n_tile_id - cta_first_n_tile;
       int const local_word = local_k * 16 + local_n_word;
-      int const cta_n_offset =
-          cta_n_tile * cta_n_tiles * tile_size +
-          local_word * cta_n_tiles + subtile;
+      int const cta_n_offset = cta_n_tile * cta_n_tiles * tile_size +
+                               local_word * cta_n_tiles + subtile;
       out_ptr[k_tile_id * n_tiles * tile_size + cta_n_offset] = res;
       return;
     }
@@ -304,16 +301,15 @@ __global__ void awq_marlin_repack_kernel(
             b_q_weight_ptr, out_ptr, size_k, size_n);                      \
   } else
 
-#define CALL_FOR_CTA(CTA_N)                                                \
-  do {                                                                     \
-    CALL_IF(4, false, CTA_N)                                               \
-    CALL_IF(8, false, CTA_N)                                               \
-    CALL_IF(4, true, CTA_N)                                                \
-    CALL_IF(8, true, CTA_N)                                                \
-    {                                                                      \
-      TORCH_CHECK(false, "Unsupported repack config: num_bits = ",         \
-                  num_bits, ", is_a_8bit = ", is_a_8bit);                 \
-    }                                                                      \
+#define CALL_FOR_CTA(CTA_N)                                                  \
+  do {                                                                       \
+    CALL_IF(4, false, CTA_N)                                                 \
+    CALL_IF(8, false, CTA_N)                                                 \
+    CALL_IF(4, true, CTA_N)                                                  \
+    CALL_IF(8, true, CTA_N) {                                                \
+      TORCH_CHECK(false, "Unsupported repack config: num_bits = ", num_bits, \
+                  ", is_a_8bit = ", is_a_8bit);                              \
+    }                                                                        \
   } while (false)
 
 torch::Tensor awq_marlin_repack(torch::Tensor& b_q_weight, int64_t size_k,

--- a/csrc/quantization/marlin/sm70_gptq_marlin_repack.cu
+++ b/csrc/quantization/marlin/sm70_gptq_marlin_repack.cu
@@ -164,9 +164,8 @@ __global__ void gptq_marlin_repack_kernel(
       int const cta_first_n_tile = cta_n_tile * cta_n_tiles;
       int const subtile = n_tile_id - cta_first_n_tile;
       int const local_word = local_k * 8 + local_n_vec;
-      int const cta_n_offset =
-          cta_n_tile * cta_n_tiles * tile_size +
-          local_word * cta_n_tiles + subtile;
+      int const cta_n_offset = cta_n_tile * cta_n_tiles * tile_size +
+                               local_word * cta_n_tiles + subtile;
       out_ptr[k_tile_id * n_tiles * tile_size + cta_n_offset] = res;
       return;
     }
@@ -215,9 +214,8 @@ __global__ void gptq_marlin_repack_kernel(
       int const cta_first_n_tile = cta_n_tile * cta_n_tiles;
       int const subtile = n_tile_id - cta_first_n_tile;
       int const local_word = local_k * 16 + local_n_word;
-      int const cta_n_offset =
-          cta_n_tile * cta_n_tiles * tile_size +
-          local_word * cta_n_tiles + subtile;
+      int const cta_n_offset = cta_n_tile * cta_n_tiles * tile_size +
+                               local_word * cta_n_tiles + subtile;
       out_ptr[k_tile_id * n_tiles * tile_size + cta_n_offset] = res;
       return;
     }
@@ -381,19 +379,17 @@ __global__ void gptq_marlin_repack_kernel(
             b_q_weight_ptr, perm_ptr, out_ptr, size_k, size_n);             \
   } else
 
-#define CALL_FOR_CTA(CTA_N)                                                 \
-  do {                                                                      \
-    CALL_IF(4, false, false, CTA_N)                                         \
-    CALL_IF(4, true, false, CTA_N)                                          \
-    CALL_IF(8, false, false, CTA_N)                                         \
-    CALL_IF(8, true, false, CTA_N)                                          \
-    CALL_IF(4, false, true, CTA_N)                                          \
-    CALL_IF(8, false, true, CTA_N)                                          \
-    {                                                                       \
-      TORCH_CHECK(false, "Unsupported repack config: num_bits = ",          \
-                  num_bits, ", has_perm = ", has_perm,                     \
-                  ", is_a_8bit = ", is_a_8bit);                            \
-    }                                                                       \
+#define CALL_FOR_CTA(CTA_N)                                                  \
+  do {                                                                       \
+    CALL_IF(4, false, false, CTA_N)                                          \
+    CALL_IF(4, true, false, CTA_N)                                           \
+    CALL_IF(8, false, false, CTA_N)                                          \
+    CALL_IF(8, true, false, CTA_N)                                           \
+    CALL_IF(4, false, true, CTA_N)                                           \
+    CALL_IF(8, false, true, CTA_N) {                                         \
+      TORCH_CHECK(false, "Unsupported repack config: num_bits = ", num_bits, \
+                  ", has_perm = ", has_perm, ", is_a_8bit = ", is_a_8bit);   \
+    }                                                                        \
   } while (false)
 
 torch::Tensor gptq_marlin_repack(torch::Tensor& b_q_weight, torch::Tensor& perm,

--- a/csrc/quantization/marlin/sm70_marlin_common.cuh
+++ b/csrc/quantization/marlin/sm70_marlin_common.cuh
@@ -28,31 +28,29 @@ inline size_t configure_sm70_dynamic_smem(Kernel kernel) {
   return smem_bytes;
 }
 
-constexpr int sm70_const_min(int lhs, int rhs) {
-  return lhs < rhs ? lhs : rhs;
-}
+constexpr int sm70_const_min(int lhs, int rhs) { return lhs < rhs ? lhs : rhs; }
 
-constexpr bool sm70_marlin_basic_geometry_values_supported(
-    int cta_m, int cta_n, int cta_k, int warps, int warp_m, int warp_n,
-    int warp_k) {
+constexpr bool sm70_marlin_basic_geometry_values_supported(int cta_m, int cta_n,
+                                                           int cta_k, int warps,
+                                                           int warp_m,
+                                                           int warp_n,
+                                                           int warp_k) {
   return (cta_m == 32 || cta_m == 64 || cta_m == 128 || cta_m == 256) &&
          (cta_n == 64 || cta_n == 128 || cta_n == 256) &&
          (cta_k == 16 || cta_k == 32 || cta_k == 64 || cta_k == 128) &&
-         (warps == 4 || warps == 8) &&
-         (warp_m == 32 || warp_m == 64) &&
-         (warp_n == 32 || warp_n == 64) &&
-         (warp_k == 16 || warp_k == 32);
+         (warps == 4 || warps == 8) && (warp_m == 32 || warp_m == 64) &&
+         (warp_n == 32 || warp_n == 64) && (warp_k == 16 || warp_k == 32);
 }
 
-constexpr bool sm70_marlin_warp_decomposition_supported(
-    int cta_m, int cta_n, int cta_k, int warps, int warp_m, int warp_n,
-    int warp_k) {
-  if (!sm70_marlin_basic_geometry_values_supported(
-          cta_m, cta_n, cta_k, warps, warp_m, warp_n, warp_k)) {
+constexpr bool sm70_marlin_warp_decomposition_supported(int cta_m, int cta_n,
+                                                        int cta_k, int warps,
+                                                        int warp_m, int warp_n,
+                                                        int warp_k) {
+  if (!sm70_marlin_basic_geometry_values_supported(cta_m, cta_n, cta_k, warps,
+                                                   warp_m, warp_n, warp_k)) {
     return false;
   }
-  if (cta_m % warp_m != 0 || cta_n % warp_n != 0 ||
-      cta_k % warp_k != 0) {
+  if (cta_m % warp_m != 0 || cta_n % warp_n != 0 || cta_k % warp_k != 0) {
     return false;
   }
   return (cta_m / warp_m) * (cta_n / warp_n) * (cta_k / warp_k) == warps;
@@ -65,8 +63,7 @@ constexpr bool sm70_marlin_pitchlinear_threadmap_supported(
   if (shape_contiguous % elements_per_access != 0) {
     return false;
   }
-  int const shape_access_contiguous =
-      shape_contiguous / elements_per_access;
+  int const shape_access_contiguous = shape_contiguous / elements_per_access;
   int const shape_access_strided = shape_strided;
   if (shape_access_contiguous % warp_thread_contiguous != 0 ||
       shape_access_strided % warp_thread_strided != 0) {
@@ -74,8 +71,7 @@ constexpr bool sm70_marlin_pitchlinear_threadmap_supported(
   }
   int const warp_access_contiguous =
       shape_access_contiguous / warp_thread_contiguous;
-  int const warp_access_strided =
-      shape_access_strided / warp_thread_strided;
+  int const warp_access_strided = shape_access_strided / warp_thread_strided;
   int const warp_count = threads / 32;
   if (warp_access_strided <= 0 || warp_count <= 0) {
     return false;
@@ -90,43 +86,40 @@ constexpr bool sm70_marlin_pitchlinear_threadmap_supported(
   if (warps_contiguous <= 0) {
     return false;
   }
-  int const iterations_contiguous =
-      warp_access_contiguous / warps_contiguous;
+  int const iterations_contiguous = warp_access_contiguous / warps_contiguous;
   int const iterations_strided = warp_access_strided / warps_strided;
   return iterations_contiguous > 0 && iterations_strided > 0;
 }
 
-constexpr bool sm70_marlin_b_threadmap_matches_quant_iterator(
-    int cta_n, int cta_k, int threads) {
+constexpr bool sm70_marlin_b_threadmap_matches_quant_iterator(int cta_n,
+                                                              int cta_k,
+                                                              int threads) {
   constexpr int kElementsPerAccess = 8;
   constexpr int kWarpThreadContiguous = 8;
   constexpr int kWarpThreadStrided = 4;
   if (!sm70_marlin_pitchlinear_threadmap_supported(
-          cta_n, cta_k, threads, kWarpThreadContiguous,
-          kWarpThreadStrided, kElementsPerAccess)) {
+          cta_n, cta_k, threads, kWarpThreadContiguous, kWarpThreadStrided,
+          kElementsPerAccess)) {
     return false;
   }
   int const shape_access_contiguous = cta_n / kElementsPerAccess;
   int const shape_access_strided = cta_k;
   int const warp_access_contiguous =
       shape_access_contiguous / kWarpThreadContiguous;
-  int const warp_access_strided =
-      shape_access_strided / kWarpThreadStrided;
+  int const warp_access_strided = shape_access_strided / kWarpThreadStrided;
   int const warp_count = threads / 32;
   int const warps_strided =
       warp_access_strided >= warp_count ? warp_count : warp_access_strided;
   int const warps_contiguous =
       warp_count > warp_access_strided ? warp_count / warps_strided : 1;
-  int const iterations_contiguous =
-      warp_access_contiguous / warps_contiguous;
-  int const delta_contiguous =
-      kWarpThreadContiguous * kElementsPerAccess;
+  int const iterations_contiguous = warp_access_contiguous / warps_contiguous;
+  int const delta_contiguous = kWarpThreadContiguous * kElementsPerAccess;
   return iterations_contiguous == cta_n / kQuantTileN &&
          delta_contiguous == kQuantTileN;
 }
 
-constexpr bool sm70_marlin_volta_epilogue_supported(
-    int cta_m, int cta_n, int warps, int warp_m) {
+constexpr bool sm70_marlin_volta_epilogue_supported(int cta_m, int cta_n,
+                                                    int warps, int warp_m) {
   constexpr int kShapeRow = 4;
   constexpr int kShapeGroup = 4;
   constexpr int kElementsPerAccess = 8;
@@ -183,8 +176,8 @@ constexpr bool sm70_marlin_volta_epilogue_supported(
 constexpr bool sm70_marlin_cta_geometry_is_supported_constexpr(
     int cta_m, int cta_n, int cta_k, int warps, int warp_m, int warp_n,
     int warp_k) {
-  if (!sm70_marlin_warp_decomposition_supported(
-          cta_m, cta_n, cta_k, warps, warp_m, warp_n, warp_k)) {
+  if (!sm70_marlin_warp_decomposition_supported(cta_m, cta_n, cta_k, warps,
+                                                warp_m, warp_n, warp_k)) {
     return false;
   }
   int const threads = warps * 32;
@@ -192,12 +185,11 @@ constexpr bool sm70_marlin_cta_geometry_is_supported_constexpr(
   // DefaultMmaCore. Its A/B thread maps are fixed to 128-bit half loads.
   // CTA_K=16 is a mathematical GEMM shape but does not provide enough
   // contiguous A accesses for that thread map.
-  if (!sm70_marlin_pitchlinear_threadmap_supported(
-          cta_k, cta_m, threads, 4, 8, 8)) {
+  if (!sm70_marlin_pitchlinear_threadmap_supported(cta_k, cta_m, threads, 4, 8,
+                                                   8)) {
     return false;
   }
-  if (!sm70_marlin_b_threadmap_matches_quant_iterator(cta_n, cta_k,
-                                                      threads)) {
+  if (!sm70_marlin_b_threadmap_matches_quant_iterator(cta_n, cta_k, threads)) {
     return false;
   }
   return sm70_marlin_volta_epilogue_supported(cta_m, cta_n, warps, warp_m);
@@ -212,8 +204,7 @@ struct Sm70WarpShape {
                 "SM70 Marlin supports CTA_N in {64, 128, 256}.");
   static_assert(CtaK == 16 || CtaK == 32 || CtaK == 64 || CtaK == 128,
                 "SM70 Marlin supports CTA_K in {16, 32, 64, 128}.");
-  static_assert(Warps == 4 || Warps == 8,
-                "SM70 Marlin supports 4 or 8 warps.");
+  static_assert(Warps == 4 || Warps == 8, "SM70 Marlin supports 4 or 8 warps.");
   static_assert(WarpM == 32 || WarpM == 64,
                 "SM70 Marlin supports Warp_M in {32, 64}.");
   static_assert(WarpN == 32 || WarpN == 64,
@@ -283,8 +274,7 @@ inline constexpr char const* kSupportedSm70MarlinCtaGeometries =
     "decomposition, current CUTLASS Volta thread-map support, and "
     "phase-aware SM70 Marlin warp-K offset support.";
 
-inline bool sm70_marlin_cta_geometry_is_supported(
-    Sm70CtaGeometry geometry) {
+inline bool sm70_marlin_cta_geometry_is_supported(Sm70CtaGeometry geometry) {
   return sm70_marlin_cta_geometry_is_supported_constexpr(
       geometry.cta_m, geometry.cta_n, geometry.cta_k, geometry.warps,
       geometry.warp_m, geometry.warp_n, geometry.warp_k);
@@ -300,8 +290,10 @@ inline int sm70_marlin_auto_packed_macro_n(int64_t size_n) {
   if (size_n % 64 == 0) {
     return 64;
   }
-  TORCH_CHECK(false, "SM70 Marlin requires size_n divisible "
-                     "by 64. Got size_n = ", size_n, ".");
+  TORCH_CHECK(false,
+              "SM70 Marlin requires size_n divisible "
+              "by 64. Got size_n = ",
+              size_n, ".");
   return 0;
 }
 
@@ -309,14 +301,12 @@ inline bool sm70_marlin_packed_macro_n_is_supported(int packed_macro_n) {
   return packed_macro_n == 64 || packed_macro_n == 128 || packed_macro_n == 256;
 }
 
-inline bool sm70_marlin_requested_split_k_is_supported(
-    int requested_split_k) {
+inline bool sm70_marlin_requested_split_k_is_supported(int requested_split_k) {
   return requested_split_k == 1 || requested_split_k == 2 ||
          requested_split_k == 4 || requested_split_k == 8;
 }
 
-inline Sm70MarlinAutoParams sm70_marlin_default_auto_params(
-    int packed_macro_n);
+inline Sm70MarlinAutoParams sm70_marlin_default_auto_params(int packed_macro_n);
 
 inline Sm70CtaGeometry sm70_marlin_default_geometry_from_packed_macro_n(
     int packed_macro_n) {
@@ -328,8 +318,8 @@ inline Sm70CtaGeometry sm70_marlin_default_geometry_from_packed_macro_n(
     case 256:
       return {32, 256, 32, 4, 32, 64, 32};
     default:
-      TORCH_CHECK(false, "Unsupported SM70 Marlin packed macro-N=",
-                  packed_macro_n,
+      TORCH_CHECK(false,
+                  "Unsupported SM70 Marlin packed macro-N=", packed_macro_n,
                   ".");
   }
   return {0, 0, 0, 0, 0, 0, 0};
@@ -337,10 +327,8 @@ inline Sm70CtaGeometry sm70_marlin_default_geometry_from_packed_macro_n(
 
 inline Sm70MarlinAutoParams sm70_marlin_default_auto_params(
     int packed_macro_n) {
-  return {sm70_marlin_default_geometry_from_packed_macro_n(packed_macro_n),
-          1,
-          true,
-          packed_macro_n};
+  return {sm70_marlin_default_geometry_from_packed_macro_n(packed_macro_n), 1,
+          true, packed_macro_n};
 }
 
 inline bool sm70_marlin_parse_int_component(char const*& cursor, int& value) {
@@ -386,9 +374,10 @@ inline bool sm70_marlin_try_get_geometry_env(char const* env_name,
   if (value == nullptr || value[0] == '\0') {
     return false;
   }
-  TORCH_CHECK(sm70_marlin_parse_geometry_env_value(value, geometry),
-              "Invalid ", env_name, " value '", value,
-              "'. Expected {CTA_M}x{CTA_N}x{CTA_K}x{Warps}x{WarpM}x{WarpN}x{WarpK}.");
+  TORCH_CHECK(
+      sm70_marlin_parse_geometry_env_value(value, geometry), "Invalid ",
+      env_name, " value '", value,
+      "'. Expected {CTA_M}x{CTA_N}x{CTA_K}x{Warps}x{WarpM}x{WarpN}x{WarpK}.");
   return true;
 }
 
@@ -409,8 +398,8 @@ inline bool sm70_marlin_try_get_split_k_env(char const* env_name,
   return true;
 }
 
-inline bool sm70_marlin_try_get_metadata_env(
-    char const* env_name, bool& use_metadata_vector_words) {
+inline bool sm70_marlin_try_get_metadata_env(char const* env_name,
+                                             bool& use_metadata_vector_words) {
   char const* value = std::getenv(env_name);
   if (value == nullptr || value[0] == '\0') {
     return false;
@@ -433,9 +422,9 @@ inline bool sm70_marlin_env_is_set(char const* env_name) {
   return value != nullptr && value[0] != '\0';
 }
 
-inline bool sm70_marlin_any_auto_env_is_set(
-    char const* geometry_env_name, char const* split_k_env_name,
-    char const* metadata_env_name) {
+inline bool sm70_marlin_any_auto_env_is_set(char const* geometry_env_name,
+                                            char const* split_k_env_name,
+                                            char const* metadata_env_name) {
   return sm70_marlin_env_is_set(geometry_env_name) ||
          sm70_marlin_env_is_set(split_k_env_name) ||
          sm70_marlin_env_is_set(metadata_env_name);
@@ -447,14 +436,13 @@ inline void validate_sm70_marlin_packed_macro_n(char const* op_name,
   TORCH_CHECK(sm70_marlin_packed_macro_n_is_supported(packed_macro_n),
               "Unsupported SM70 Marlin packed macro-N for ", op_name, ": ",
               packed_macro_n, ".");
-  TORCH_CHECK(packed_macro_n % geometry.cta_n == 0,
-              "SM70 Marlin ", op_name,
+  TORCH_CHECK(packed_macro_n % geometry.cta_n == 0, "SM70 Marlin ", op_name,
               " requires PackedMacroN divisible by CTA_N. Got PackedMacroN=",
               packed_macro_n, ", CTA_N=", geometry.cta_n, ".");
 }
 
-inline void validate_sm70_marlin_auto_params(
-    char const* op_name, Sm70MarlinAutoParams params) {
+inline void validate_sm70_marlin_auto_params(char const* op_name,
+                                             Sm70MarlinAutoParams params) {
   TORCH_CHECK(sm70_marlin_cta_geometry_is_supported(params.geometry),
               "Unsupported SM70 Marlin CTA geometry for ", op_name, ": ",
               params.geometry.cta_m, "x", params.geometry.cta_n, "x",
@@ -474,8 +462,7 @@ inline Sm70MarlinAutoParams sm70_marlin_auto_params_from_env(
     char const* op_name, char const* geometry_env_name,
     char const* split_k_env_name, char const* metadata_env_name,
     int packed_macro_n) {
-  Sm70MarlinAutoParams params =
-      sm70_marlin_default_auto_params(packed_macro_n);
+  Sm70MarlinAutoParams params = sm70_marlin_default_auto_params(packed_macro_n);
   sm70_marlin_try_get_geometry_env(geometry_env_name, params.geometry);
   sm70_marlin_try_get_split_k_env(split_k_env_name, params.requested_split_k);
   sm70_marlin_try_get_metadata_env(metadata_env_name,
@@ -485,31 +472,27 @@ inline Sm70MarlinAutoParams sm70_marlin_auto_params_from_env(
 }
 
 inline bool sm70_marlin_dense_auto_env_is_set() {
-  return sm70_marlin_any_auto_env_is_set(
-      "SM70_MARLIN_DENSE_CTA_GEOMETRY", "SM70_MARLIN_DENSE_SPLIT_K",
-      "SM70_MARLIN_DENSE_METADATA_CACHE");
+  return sm70_marlin_any_auto_env_is_set("SM70_MARLIN_DENSE_CTA_GEOMETRY",
+                                         "SM70_MARLIN_DENSE_SPLIT_K",
+                                         "SM70_MARLIN_DENSE_METADATA_CACHE");
 }
 
 inline Sm70MarlinAutoParams sm70_marlin_dense_auto_params_from_env(
     Sm70MarlinDenseAutoParamsContext const& ctx) {
   return sm70_marlin_auto_params_from_env(
-      "Dense", "SM70_MARLIN_DENSE_CTA_GEOMETRY",
-      "SM70_MARLIN_DENSE_SPLIT_K", "SM70_MARLIN_DENSE_METADATA_CACHE",
-      ctx.packed_macro_n);
+      "Dense", "SM70_MARLIN_DENSE_CTA_GEOMETRY", "SM70_MARLIN_DENSE_SPLIT_K",
+      "SM70_MARLIN_DENSE_METADATA_CACHE", ctx.packed_macro_n);
 }
 
-inline bool
-sm70_marlin_dense_try_select_quanttrio_qwen3_6_27b_awq_params(
-    Sm70MarlinDenseAutoParamsContext const& ctx,
-    Sm70MarlinAutoParams& params) {
+inline bool sm70_marlin_dense_try_select_quanttrio_qwen3_6_27b_awq_params(
+    Sm70MarlinDenseAutoParamsContext const& ctx, Sm70MarlinAutoParams& params) {
   if (ctx.quant_format == nullptr ||
-      std::strcmp(ctx.quant_format, "uint4") != 0 ||
-      ctx.group_size != 128 || ctx.size_m <= 0) {
+      std::strcmp(ctx.quant_format, "uint4") != 0 || ctx.group_size != 128 ||
+      ctx.size_m <= 0) {
     return false;
   }
 
-  auto const set_params = [&](Sm70CtaGeometry geometry,
-                              int requested_split_k,
+  auto const set_params = [&](Sm70CtaGeometry geometry, int requested_split_k,
                               bool use_metadata_vector_words) {
     params = {geometry, requested_split_k, use_metadata_vector_words,
               ctx.packed_macro_n};
@@ -596,16 +579,14 @@ sm70_marlin_dense_try_select_quanttrio_qwen3_6_27b_awq_params(
 
 inline bool
 sm70_marlin_dense_try_select_cyankiwi_qwen3_6_27b_awq_bf16_nvfp4_params(
-    Sm70MarlinDenseAutoParamsContext const& ctx,
-    Sm70MarlinAutoParams& params) {
+    Sm70MarlinDenseAutoParamsContext const& ctx, Sm70MarlinAutoParams& params) {
   if (ctx.quant_format == nullptr ||
-      std::strcmp(ctx.quant_format, "nvfp4") != 0 ||
-      ctx.group_size != 16 || ctx.size_m <= 0) {
+      std::strcmp(ctx.quant_format, "nvfp4") != 0 || ctx.group_size != 16 ||
+      ctx.size_m <= 0) {
     return false;
   }
 
-  auto const set_params = [&](Sm70CtaGeometry geometry,
-                              int requested_split_k,
+  auto const set_params = [&](Sm70CtaGeometry geometry, int requested_split_k,
                               bool use_metadata_vector_words) {
     params = {geometry, requested_split_k, use_metadata_vector_words,
               ctx.packed_macro_n};
@@ -614,147 +595,144 @@ sm70_marlin_dense_try_select_cyankiwi_qwen3_6_27b_awq_bf16_nvfp4_params(
 
   if (ctx.size_n == 2048 && ctx.size_k == 5120) {
     if (ctx.size_m <= 1) {
-      return set_params({32,128,32,4,32,32,32}, 8, true);
+      return set_params({32, 128, 32, 4, 32, 32, 32}, 8, true);
     }
     if (ctx.size_m <= 32) {
-      return set_params({32,64,64,4,32,64,16}, 4, true);
+      return set_params({32, 64, 64, 4, 32, 64, 16}, 4, true);
     }
     if (ctx.size_m <= 64) {
-      return set_params({64,64,64,4,32,64,32}, 4, true);
+      return set_params({64, 64, 64, 4, 32, 64, 32}, 4, true);
     }
     if (ctx.size_m <= 2048) {
-      return set_params({128,256,32,8,64,64,32}, 1, true);
+      return set_params({128, 256, 32, 8, 64, 64, 32}, 1, true);
     }
-    return set_params({128,256,32,8,64,64,32}, 1, false);
+    return set_params({128, 256, 32, 8, 64, 64, 32}, 1, false);
   }
 
   if (ctx.size_n == 3584 && ctx.size_k == 5120) {
     if (ctx.size_m <= 1) {
-      return set_params({32,128,32,4,32,32,32}, 8, true);
+      return set_params({32, 128, 32, 4, 32, 32, 32}, 8, true);
     }
     if (ctx.size_m <= 32) {
-      return set_params({32,64,64,4,32,64,16}, 4, true);
+      return set_params({32, 64, 64, 4, 32, 64, 16}, 4, true);
     }
     if (ctx.size_m <= 64) {
-      return set_params({64,64,32,4,32,32,32}, 4, true);
+      return set_params({64, 64, 32, 4, 32, 32, 32}, 4, true);
     }
     if (ctx.size_m <= 2048) {
-      return set_params({128,256,32,8,64,64,32}, 1, true);
+      return set_params({128, 256, 32, 8, 64, 64, 32}, 1, true);
     }
-    return set_params({128,256,32,8,64,64,32}, 1, true);
+    return set_params({128, 256, 32, 8, 64, 64, 32}, 1, true);
   }
 
   if (ctx.size_n == 4352 && ctx.size_k == 5120) {
     if (ctx.size_m <= 1) {
-      return set_params({32,128,32,4,32,32,32}, 8, true);
+      return set_params({32, 128, 32, 4, 32, 32, 32}, 8, true);
     }
     if (ctx.size_m <= 32) {
-      return set_params({32,64,64,4,32,32,32}, 4, true);
+      return set_params({32, 64, 64, 4, 32, 32, 32}, 4, true);
     }
     if (ctx.size_m <= 64) {
-      return set_params({64,64,32,4,32,32,32}, 4, false);
+      return set_params({64, 64, 32, 4, 32, 32, 32}, 4, false);
     }
     if (ctx.size_m <= 2048) {
-      return set_params({128,256,32,8,64,64,32}, 1, false);
+      return set_params({128, 256, 32, 8, 64, 64, 32}, 1, false);
     }
-    return set_params({128,256,32,8,64,64,32}, 1, true);
+    return set_params({128, 256, 32, 8, 64, 64, 32}, 1, true);
   }
 
   if (ctx.size_n == 5120 && ctx.size_k == 768) {
     if (ctx.size_m <= 1) {
-      return set_params({64,64,64,4,32,64,32}, 1, false);
+      return set_params({64, 64, 64, 4, 32, 64, 32}, 1, false);
     }
     if (ctx.size_m <= 32) {
-      return set_params({32,64,64,4,32,64,16}, 1, false);
+      return set_params({32, 64, 64, 4, 32, 64, 16}, 1, false);
     }
     if (ctx.size_m <= 64) {
-      return set_params({32,64,32,4,32,32,16}, 1, true);
+      return set_params({32, 64, 32, 4, 32, 32, 16}, 1, true);
     }
     if (ctx.size_m <= 2048) {
-      return set_params({128,256,32,8,64,64,32}, 1, true);
+      return set_params({128, 256, 32, 8, 64, 64, 32}, 1, true);
     }
-    return set_params({128,256,32,8,64,64,32}, 1, false);
+    return set_params({128, 256, 32, 8, 64, 64, 32}, 1, false);
   }
 
   if (ctx.size_n == 5120 && ctx.size_k == 1536) {
     if (ctx.size_m <= 1) {
-      return set_params({32,64,64,4,32,64,16}, 1, true);
+      return set_params({32, 64, 64, 4, 32, 64, 16}, 1, true);
     }
     if (ctx.size_m <= 32) {
-      return set_params({64,64,32,4,32,32,32}, 1, true);
+      return set_params({64, 64, 32, 4, 32, 32, 32}, 1, true);
     }
     if (ctx.size_m <= 64) {
-      return set_params({64,64,32,4,32,32,32}, 1, false);
+      return set_params({64, 64, 32, 4, 32, 32, 32}, 1, false);
     }
     if (ctx.size_m <= 2048) {
-      return set_params({128,256,32,8,64,64,32}, 1, true);
+      return set_params({128, 256, 32, 8, 64, 64, 32}, 1, true);
     }
-    return set_params({128,256,32,8,64,64,32}, 1, true);
+    return set_params({128, 256, 32, 8, 64, 64, 32}, 1, true);
   }
 
   if (ctx.size_n == 5120 && ctx.size_k == 2176) {
     if (ctx.size_m <= 1) {
-      return set_params({32,128,32,4,32,32,32}, 8, true);
+      return set_params({32, 128, 32, 4, 32, 32, 32}, 8, true);
     }
     if (ctx.size_m <= 32) {
-      return set_params({32,64,128,4,32,64,32}, 1, true);
+      return set_params({32, 64, 128, 4, 32, 64, 32}, 1, true);
     }
     if (ctx.size_m <= 64) {
-      return set_params({32,128,128,8,32,64,32}, 1, true);
+      return set_params({32, 128, 128, 8, 32, 64, 32}, 1, true);
     }
     if (ctx.size_m <= 2048) {
-      return set_params({128,256,32,8,64,64,32}, 1, true);
+      return set_params({128, 256, 32, 8, 64, 64, 32}, 1, true);
     }
-    return set_params({128,256,32,8,64,64,32}, 1, true);
+    return set_params({128, 256, 32, 8, 64, 64, 32}, 1, true);
   }
 
   if (ctx.size_n == 5120 && ctx.size_k == 4352) {
     if (ctx.size_m <= 1) {
-      return set_params({32,128,32,4,32,32,32}, 8, true);
+      return set_params({32, 128, 32, 4, 32, 32, 32}, 8, true);
     }
     if (ctx.size_m <= 32) {
-      return set_params({32,128,64,8,32,32,32}, 2, true);
+      return set_params({32, 128, 64, 8, 32, 32, 32}, 2, true);
     }
     if (ctx.size_m <= 64) {
-      return set_params({32,128,128,8,32,64,32}, 1, true);
+      return set_params({32, 128, 128, 8, 32, 64, 32}, 1, true);
     }
     if (ctx.size_m <= 2048) {
-      return set_params({128,256,32,8,64,64,32}, 1, true);
+      return set_params({128, 256, 32, 8, 64, 64, 32}, 1, true);
     }
-    return set_params({128,256,32,8,64,64,32}, 1, true);
+    return set_params({128, 256, 32, 8, 64, 64, 32}, 1, true);
   }
 
   if (ctx.size_n == 8704 && ctx.size_k == 5120) {
     if (ctx.size_m <= 1) {
-      return set_params({32,128,32,4,32,32,32}, 4, true);
+      return set_params({32, 128, 32, 4, 32, 32, 32}, 4, true);
     }
     if (ctx.size_m <= 32) {
-      return set_params({32,128,32,4,32,32,32}, 4, false);
+      return set_params({32, 128, 32, 4, 32, 32, 32}, 4, false);
     }
     if (ctx.size_m <= 64) {
-      return set_params({64,128,128,8,64,64,32}, 1, true);
+      return set_params({64, 128, 128, 8, 64, 64, 32}, 1, true);
     }
     if (ctx.size_m <= 2048) {
-      return set_params({128,256,32,8,64,64,32}, 1, true);
+      return set_params({128, 256, 32, 8, 64, 64, 32}, 1, true);
     }
-    return set_params({128,256,32,8,64,64,32}, 1, true);
+    return set_params({128, 256, 32, 8, 64, 64, 32}, 1, true);
   }
 
   return false;
 }
 
-inline bool
-sm70_marlin_dense_try_select_nvidia_glm_4_7_nvfp4_params(
-    Sm70MarlinDenseAutoParamsContext const& ctx,
-    Sm70MarlinAutoParams& params) {
+inline bool sm70_marlin_dense_try_select_nvidia_glm_4_7_nvfp4_params(
+    Sm70MarlinDenseAutoParamsContext const& ctx, Sm70MarlinAutoParams& params) {
   if (ctx.quant_format == nullptr ||
-      std::strcmp(ctx.quant_format, "nvfp4") != 0 ||
-      ctx.group_size != 16 || ctx.size_m <= 0) {
+      std::strcmp(ctx.quant_format, "nvfp4") != 0 || ctx.group_size != 16 ||
+      ctx.size_m <= 0) {
     return false;
   }
 
-  auto const set_params = [&](Sm70CtaGeometry geometry,
-                              int requested_split_k,
+  auto const set_params = [&](Sm70CtaGeometry geometry, int requested_split_k,
                               bool use_metadata_vector_words) {
     params = {geometry, requested_split_k, use_metadata_vector_words,
               ctx.packed_macro_n};
@@ -763,293 +741,282 @@ sm70_marlin_dense_try_select_nvidia_glm_4_7_nvfp4_params(
 
   if (ctx.size_n == 384 && ctx.size_k == 5120) {
     if (ctx.size_m <= 1) {
-      return set_params({32,64,64,4,32,64,16}, 8, true);
+      return set_params({32, 64, 64, 4, 32, 64, 16}, 8, true);
     }
     if (ctx.size_m <= 32) {
-      return set_params({32,64,64,4,32,32,32}, 8, true);
+      return set_params({32, 64, 64, 4, 32, 32, 32}, 8, true);
     }
     if (ctx.size_m <= 64) {
-      return set_params({32,64,64,4,32,64,16}, 8, true);
+      return set_params({32, 64, 64, 4, 32, 64, 16}, 8, true);
     }
     if (ctx.size_m <= 2048) {
-      return set_params({64,64,64,4,64,32,32}, 1, true);
+      return set_params({64, 64, 64, 4, 64, 32, 32}, 1, true);
     }
-    return set_params({64,128,32,4,32,64,32}, 1, true);
+    return set_params({64, 128, 32, 4, 32, 64, 32}, 1, true);
   }
 
   if (ctx.size_n == 768 && ctx.size_k == 5120) {
     if (ctx.size_m <= 1) {
-      return set_params({32,64,64,4,32,32,32}, 8, true);
+      return set_params({32, 64, 64, 4, 32, 32, 32}, 8, true);
     }
     if (ctx.size_m <= 32) {
-      return set_params({32,64,64,4,32,64,16}, 8, false);
+      return set_params({32, 64, 64, 4, 32, 64, 16}, 8, false);
     }
     if (ctx.size_m <= 64) {
-      return set_params({32,64,64,4,32,32,32}, 4, true);
+      return set_params({32, 64, 64, 4, 32, 32, 32}, 4, true);
     }
     if (ctx.size_m <= 2048) {
-      return set_params({128,64,32,4,32,64,32}, 1, true);
+      return set_params({128, 64, 32, 4, 32, 64, 32}, 1, true);
     }
-    return set_params({64,128,32,4,32,64,32}, 1, true);
+    return set_params({64, 128, 32, 4, 32, 64, 32}, 1, true);
   }
 
   if (ctx.size_n == 3072 && ctx.size_k == 5120) {
     if (ctx.size_m <= 1) {
-      return set_params({32,128,32,4,32,32,32}, 8, true);
+      return set_params({32, 128, 32, 4, 32, 32, 32}, 8, true);
     }
     if (ctx.size_m <= 32) {
-      return set_params({32,64,64,4,32,64,16}, 4, true);
+      return set_params({32, 64, 64, 4, 32, 64, 16}, 4, true);
     }
     if (ctx.size_m <= 64) {
-      return set_params({64,64,32,4,32,32,32}, 4, true);
+      return set_params({64, 64, 32, 4, 32, 32, 32}, 4, true);
     }
     if (ctx.size_m <= 2048) {
-      return set_params({128,128,64,8,64,64,32}, 1, true);
+      return set_params({128, 128, 64, 8, 64, 64, 32}, 1, true);
     }
-    return set_params({128,256,32,8,64,64,32}, 1, true);
+    return set_params({128, 256, 32, 8, 64, 64, 32}, 1, true);
   }
 
   if (ctx.size_n == 5120 && ctx.size_k == 192) {
     if (ctx.size_m <= 1) {
-      return set_params({32,64,64,4,32,32,32}, 1, true);
+      return set_params({32, 64, 64, 4, 32, 32, 32}, 1, true);
     }
     if (ctx.size_m <= 32) {
-      return set_params({32,64,32,4,32,32,16}, 1, true);
+      return set_params({32, 64, 32, 4, 32, 32, 16}, 1, true);
     }
     if (ctx.size_m <= 64) {
-      return set_params({32,64,32,4,32,32,16}, 1, true);
+      return set_params({32, 64, 32, 4, 32, 32, 16}, 1, true);
     }
     if (ctx.size_m <= 2048) {
-      return set_params({128,128,32,4,64,64,32}, 1, true);
+      return set_params({128, 128, 32, 4, 64, 64, 32}, 1, true);
     }
-    return set_params({128,128,32,4,64,64,32}, 1, true);
+    return set_params({128, 128, 32, 4, 64, 64, 32}, 1, true);
   }
 
   if (ctx.size_n == 5120 && ctx.size_k == 384) {
     if (ctx.size_m <= 1) {
-      return set_params({32,64,32,4,32,32,16}, 1, true);
+      return set_params({32, 64, 32, 4, 32, 32, 16}, 1, true);
     }
     if (ctx.size_m <= 32) {
-      return set_params({32,64,32,4,32,32,16}, 1, true);
+      return set_params({32, 64, 32, 4, 32, 32, 16}, 1, true);
     }
     if (ctx.size_m <= 64) {
-      return set_params({32,64,32,4,32,32,16}, 1, true);
+      return set_params({32, 64, 32, 4, 32, 32, 16}, 1, true);
     }
     if (ctx.size_m <= 2048) {
-      return set_params({128,256,32,8,64,64,32}, 1, true);
+      return set_params({128, 256, 32, 8, 64, 64, 32}, 1, true);
     }
-    return set_params({128,256,32,8,64,64,32}, 1, true);
+    return set_params({128, 256, 32, 8, 64, 64, 32}, 1, true);
   }
 
   if (ctx.size_n == 5120 && ctx.size_k == 1536) {
     if (ctx.size_m <= 1) {
-      return set_params({32,64,64,4,32,32,32}, 4, true);
+      return set_params({32, 64, 64, 4, 32, 32, 32}, 4, true);
     }
     if (ctx.size_m <= 32) {
-      return set_params({32,64,64,4,32,32,32}, 1, true);
+      return set_params({32, 64, 64, 4, 32, 32, 32}, 1, true);
     }
     if (ctx.size_m <= 64) {
-      return set_params({32,128,32,4,32,32,32}, 1, true);
+      return set_params({32, 128, 32, 4, 32, 32, 32}, 1, true);
     }
     if (ctx.size_m <= 2048) {
-      return set_params({128,256,32,8,64,64,32}, 1, true);
+      return set_params({128, 256, 32, 8, 64, 64, 32}, 1, true);
     }
-    return set_params({128,256,32,8,64,64,32}, 1, true);
+    return set_params({128, 256, 32, 8, 64, 64, 32}, 1, true);
   }
 
   if (ctx.size_n == 5120 && ctx.size_k == 3072) {
     if (ctx.size_m <= 1) {
-      return set_params({32,128,32,4,32,32,32}, 8, true);
+      return set_params({32, 128, 32, 4, 32, 32, 32}, 8, true);
     }
     if (ctx.size_m <= 32) {
-      return set_params({32,64,64,4,32,64,16}, 2, false);
+      return set_params({32, 64, 64, 4, 32, 64, 16}, 2, false);
     }
     if (ctx.size_m <= 64) {
-      return set_params({32,128,128,8,32,64,32}, 1, true);
+      return set_params({32, 128, 128, 8, 32, 64, 32}, 1, true);
     }
     if (ctx.size_m <= 2048) {
-      return set_params({128,256,32,8,64,64,32}, 1, true);
+      return set_params({128, 256, 32, 8, 64, 64, 32}, 1, true);
     }
-    return set_params({128,256,32,8,64,64,32}, 1, true);
+    return set_params({128, 256, 32, 8, 64, 64, 32}, 1, true);
   }
 
   if (ctx.size_n == 6144 && ctx.size_k == 5120) {
     if (ctx.size_m <= 1) {
-      return set_params({32,128,32,4,32,32,32}, 4, true);
+      return set_params({32, 128, 32, 4, 32, 32, 32}, 4, true);
     }
     if (ctx.size_m <= 32) {
-      return set_params({32,128,32,4,32,32,32}, 4, true);
+      return set_params({32, 128, 32, 4, 32, 32, 32}, 4, true);
     }
     if (ctx.size_m <= 64) {
-      return set_params({64,128,32,4,32,64,32}, 4, false);
+      return set_params({64, 128, 32, 4, 32, 64, 32}, 4, false);
     }
     if (ctx.size_m <= 2048) {
-      return set_params({128,256,32,8,64,64,32}, 1, true);
+      return set_params({128, 256, 32, 8, 64, 64, 32}, 1, true);
     }
-    return set_params({128,256,32,8,64,64,32}, 1, true);
+    return set_params({128, 256, 32, 8, 64, 64, 32}, 1, true);
   }
 
   return false;
 }
 
-inline bool
-sm70_marlin_dense_try_select_nvidia_qwen3_6_35b_a3b_nvfp4_params(
-    Sm70MarlinDenseAutoParamsContext const& ctx,
-    Sm70MarlinAutoParams& params) {
+inline bool sm70_marlin_dense_try_select_nvidia_qwen3_6_35b_a3b_nvfp4_params(
+    Sm70MarlinDenseAutoParamsContext const& ctx, Sm70MarlinAutoParams& params) {
   if (ctx.quant_format == nullptr || ctx.size_m <= 0) {
     return false;
   }
 
-  auto const set_params = [&](Sm70CtaGeometry geometry,
-                              int requested_split_k,
+  auto const set_params = [&](Sm70CtaGeometry geometry, int requested_split_k,
                               bool use_metadata_vector_words) {
     params = {geometry, requested_split_k, use_metadata_vector_words,
               ctx.packed_macro_n};
     return true;
   };
 
-  if (std::strcmp(ctx.quant_format, "fp8_e4m3") == 0 &&
-      ctx.group_size == 512 &&
+  if (std::strcmp(ctx.quant_format, "fp8_e4m3") == 0 && ctx.group_size == 512 &&
       ctx.size_n == 2048 && ctx.size_k == 512) {
     if (ctx.size_m <= 1) {
-      return set_params({32,64,32,4,32,32,16}, 1, true);
+      return set_params({32, 64, 32, 4, 32, 32, 16}, 1, true);
     }
     if (ctx.size_m <= 32) {
-      return set_params({32,64,32,4,32,32,16}, 1, false);
+      return set_params({32, 64, 32, 4, 32, 32, 16}, 1, false);
     }
     if (ctx.size_m <= 64) {
-      return set_params({32,64,32,4,32,32,16}, 1, true);
+      return set_params({32, 64, 32, 4, 32, 32, 16}, 1, true);
     }
     if (ctx.size_m <= 2048) {
-      return set_params({128,256,32,8,64,64,32}, 1, true);
+      return set_params({128, 256, 32, 8, 64, 64, 32}, 1, true);
     }
-    return set_params({128,256,32,8,64,64,32}, 1, true);
+    return set_params({128, 256, 32, 8, 64, 64, 32}, 1, true);
   }
 
   if (std::strcmp(ctx.quant_format, "fp8_e4m3") == 0 &&
-      ctx.group_size == 1024 &&
-      ctx.size_n == 2048 && ctx.size_k == 1024) {
+      ctx.group_size == 1024 && ctx.size_n == 2048 && ctx.size_k == 1024) {
     if (ctx.size_m <= 1) {
-      return set_params({32,64,64,4,32,32,32}, 1, true);
+      return set_params({32, 64, 64, 4, 32, 32, 32}, 1, true);
     }
     if (ctx.size_m <= 32) {
-      return set_params({32,64,64,4,32,32,32}, 1, true);
+      return set_params({32, 64, 64, 4, 32, 32, 32}, 1, true);
     }
     if (ctx.size_m <= 64) {
-      return set_params({32,64,64,4,32,32,32}, 1, true);
+      return set_params({32, 64, 64, 4, 32, 32, 32}, 1, true);
     }
     if (ctx.size_m <= 2048) {
-      return set_params({128,256,32,8,64,64,32}, 1, true);
+      return set_params({128, 256, 32, 8, 64, 64, 32}, 1, true);
     }
-    return set_params({128,256,32,8,64,64,32}, 1, true);
+    return set_params({128, 256, 32, 8, 64, 64, 32}, 1, true);
   }
 
   if (std::strcmp(ctx.quant_format, "fp8_e4m3") == 0 &&
-      ctx.group_size == 2048 &&
-      ctx.size_n == 1536 && ctx.size_k == 2048) {
+      ctx.group_size == 2048 && ctx.size_n == 1536 && ctx.size_k == 2048) {
     if (ctx.size_m <= 1) {
-      return set_params({32,64,32,4,32,32,16}, 4, true);
+      return set_params({32, 64, 32, 4, 32, 32, 16}, 4, true);
     }
     if (ctx.size_m <= 32) {
-      return set_params({32,64,64,4,32,32,32}, 4, true);
+      return set_params({32, 64, 64, 4, 32, 32, 32}, 4, true);
     }
     if (ctx.size_m <= 64) {
-      return set_params({32,64,64,4,32,32,32}, 4, true);
+      return set_params({32, 64, 64, 4, 32, 32, 32}, 4, true);
     }
     if (ctx.size_m <= 2048) {
-      return set_params({64,128,32,4,32,64,32}, 1, false);
+      return set_params({64, 128, 32, 4, 32, 64, 32}, 1, false);
     }
-    return set_params({128,256,32,8,64,64,32}, 1, true);
+    return set_params({128, 256, 32, 8, 64, 64, 32}, 1, true);
   }
 
   if (std::strcmp(ctx.quant_format, "fp8_e4m3") == 0 &&
-      ctx.group_size == 2048 &&
-      ctx.size_n == 2560 && ctx.size_k == 2048) {
+      ctx.group_size == 2048 && ctx.size_n == 2560 && ctx.size_k == 2048) {
     if (ctx.size_m <= 1) {
-      return set_params({32,64,32,4,32,32,16}, 8, true);
+      return set_params({32, 64, 32, 4, 32, 32, 16}, 8, true);
     }
     if (ctx.size_m <= 32) {
-      return set_params({32,64,64,4,32,32,32}, 2, true);
+      return set_params({32, 64, 64, 4, 32, 32, 32}, 2, true);
     }
     if (ctx.size_m <= 64) {
-      return set_params({32,64,64,4,32,64,16}, 1, true);
+      return set_params({32, 64, 64, 4, 32, 64, 16}, 1, true);
     }
     if (ctx.size_m <= 2048) {
-      return set_params({128,256,32,8,64,64,32}, 1, true);
+      return set_params({128, 256, 32, 8, 64, 64, 32}, 1, true);
     }
-    return set_params({128,256,32,8,64,64,32}, 1, true);
+    return set_params({128, 256, 32, 8, 64, 64, 32}, 1, true);
   }
 
-  if (std::strcmp(ctx.quant_format, "nvfp4") == 0 &&
-      ctx.group_size == 16 &&
+  if (std::strcmp(ctx.quant_format, "nvfp4") == 0 && ctx.group_size == 16 &&
       ctx.size_n == 128 && ctx.size_k == 2048) {
     if (ctx.size_m <= 1) {
-      return set_params({32,64,32,4,32,32,16}, 4, true);
+      return set_params({32, 64, 32, 4, 32, 32, 16}, 4, true);
     }
     if (ctx.size_m <= 32) {
-      return set_params({32,64,64,4,32,32,32}, 4, true);
+      return set_params({32, 64, 64, 4, 32, 32, 32}, 4, true);
     }
     if (ctx.size_m <= 64) {
-      return set_params({32,64,64,4,32,32,32}, 4, true);
+      return set_params({32, 64, 64, 4, 32, 32, 32}, 4, true);
     }
     if (ctx.size_m <= 2048) {
-      return set_params({64,64,64,4,32,64,32}, 1, true);
+      return set_params({64, 64, 64, 4, 32, 64, 32}, 1, true);
     }
-    return set_params({128,64,128,8,64,64,32}, 1, true);
+    return set_params({128, 64, 128, 8, 64, 64, 32}, 1, true);
   }
 
-  if (std::strcmp(ctx.quant_format, "nvfp4") == 0 &&
-      ctx.group_size == 16 &&
+  if (std::strcmp(ctx.quant_format, "nvfp4") == 0 && ctx.group_size == 16 &&
       ctx.size_n == 256 && ctx.size_k == 2048) {
     if (ctx.size_m <= 1) {
-      return set_params({32,64,32,4,32,32,16}, 4, true);
+      return set_params({32, 64, 32, 4, 32, 32, 16}, 4, true);
     }
     if (ctx.size_m <= 32) {
-      return set_params({32,64,64,4,32,32,32}, 4, true);
+      return set_params({32, 64, 64, 4, 32, 32, 32}, 4, true);
     }
     if (ctx.size_m <= 64) {
-      return set_params({32,64,64,4,32,32,32}, 4, true);
+      return set_params({32, 64, 64, 4, 32, 32, 32}, 4, true);
     }
     if (ctx.size_m <= 2048) {
-      return set_params({128,64,128,8,64,64,32}, 1, false);
+      return set_params({128, 64, 128, 8, 64, 64, 32}, 1, false);
     }
-    return set_params({128,64,32,4,32,64,32}, 1, false);
+    return set_params({128, 64, 32, 4, 32, 64, 32}, 1, false);
   }
 
-  if (std::strcmp(ctx.quant_format, "nvfp4") == 0 &&
-      ctx.group_size == 16 &&
+  if (std::strcmp(ctx.quant_format, "nvfp4") == 0 && ctx.group_size == 16 &&
       ctx.size_n == 2048 && ctx.size_k == 64) {
     if (ctx.size_m <= 1) {
-      return set_params({32,64,64,4,32,64,16}, 1, false);
+      return set_params({32, 64, 64, 4, 32, 64, 16}, 1, false);
     }
     if (ctx.size_m <= 32) {
-      return set_params({32,64,64,4,32,32,32}, 1, true);
+      return set_params({32, 64, 64, 4, 32, 32, 32}, 1, true);
     }
     if (ctx.size_m <= 64) {
-      return set_params({32,64,64,4,32,64,16}, 1, false);
+      return set_params({32, 64, 64, 4, 32, 64, 16}, 1, false);
     }
     if (ctx.size_m <= 2048) {
-      return set_params({32,128,32,4,32,32,32}, 1, true);
+      return set_params({32, 128, 32, 4, 32, 32, 32}, 1, true);
     }
-    return set_params({128,64,32,4,32,64,32}, 1, false);
+    return set_params({128, 64, 32, 4, 32, 64, 32}, 1, false);
   }
 
-  if (std::strcmp(ctx.quant_format, "nvfp4") == 0 &&
-      ctx.group_size == 16 &&
+  if (std::strcmp(ctx.quant_format, "nvfp4") == 0 && ctx.group_size == 16 &&
       ctx.size_n == 2048 && ctx.size_k == 128) {
     if (ctx.size_m <= 1) {
-      return set_params({32,64,64,4,32,32,32}, 1, false);
+      return set_params({32, 64, 64, 4, 32, 32, 32}, 1, false);
     }
     if (ctx.size_m <= 32) {
-      return set_params({32,64,64,4,32,32,32}, 1, true);
+      return set_params({32, 64, 64, 4, 32, 32, 32}, 1, true);
     }
     if (ctx.size_m <= 64) {
-      return set_params({32,64,64,4,32,64,16}, 1, false);
+      return set_params({32, 64, 64, 4, 32, 64, 16}, 1, false);
     }
     if (ctx.size_m <= 2048) {
-      return set_params({128,64,32,4,32,64,32}, 1, true);
+      return set_params({128, 64, 32, 4, 32, 64, 32}, 1, true);
     }
-    return set_params({128,64,32,4,32,64,32}, 1, true);
+    return set_params({128, 64, 32, 4, 32, 64, 32}, 1, true);
   }
 
   return false;
@@ -1057,16 +1024,14 @@ sm70_marlin_dense_try_select_nvidia_qwen3_6_35b_a3b_nvfp4_params(
 
 inline bool
 sm70_marlin_dense_try_select_nvidia_qwen3_next_80b_a3b_thinking_nvfp4_params(
-    Sm70MarlinDenseAutoParamsContext const& ctx,
-    Sm70MarlinAutoParams& params) {
+    Sm70MarlinDenseAutoParamsContext const& ctx, Sm70MarlinAutoParams& params) {
   if (ctx.quant_format == nullptr ||
-      std::strcmp(ctx.quant_format, "nvfp4") != 0 ||
-      ctx.group_size != 16 || ctx.size_m <= 0) {
+      std::strcmp(ctx.quant_format, "nvfp4") != 0 || ctx.group_size != 16 ||
+      ctx.size_m <= 0) {
     return false;
   }
 
-  auto const set_params = [&](Sm70CtaGeometry geometry,
-                              int requested_split_k,
+  auto const set_params = [&](Sm70CtaGeometry geometry, int requested_split_k,
                               bool use_metadata_vector_words) {
     params = {geometry, requested_split_k, use_metadata_vector_words,
               ctx.packed_macro_n};
@@ -1075,115 +1040,112 @@ sm70_marlin_dense_try_select_nvidia_qwen3_next_80b_a3b_thinking_nvfp4_params(
 
   if (ctx.size_n == 128 && ctx.size_k == 2048) {
     if (ctx.size_m <= 1) {
-      return set_params({32,64,32,4,32,32,16}, 4, true);
+      return set_params({32, 64, 32, 4, 32, 32, 16}, 4, true);
     }
     if (ctx.size_m <= 32) {
-      return set_params({32,64,32,4,32,32,16}, 4, true);
+      return set_params({32, 64, 32, 4, 32, 32, 16}, 4, true);
     }
     if (ctx.size_m <= 64) {
-      return set_params({32,64,64,4,32,32,32}, 4, true);
+      return set_params({32, 64, 64, 4, 32, 32, 32}, 4, true);
     }
     if (ctx.size_m <= 2048) {
-      return set_params({64,64,64,4,32,64,32}, 1, true);
+      return set_params({64, 64, 64, 4, 32, 64, 32}, 1, true);
     }
-    return set_params({128,64,128,8,64,64,32}, 1, true);
+    return set_params({128, 64, 128, 8, 64, 64, 32}, 1, true);
   }
 
   if (ctx.size_n == 256 && ctx.size_k == 2048) {
     if (ctx.size_m <= 1) {
-      return set_params({32,64,32,4,32,32,16}, 4, true);
+      return set_params({32, 64, 32, 4, 32, 32, 16}, 4, true);
     }
     if (ctx.size_m <= 32) {
-      return set_params({32,64,64,4,32,32,32}, 4, true);
+      return set_params({32, 64, 64, 4, 32, 32, 32}, 4, true);
     }
     if (ctx.size_m <= 64) {
-      return set_params({32,64,64,4,32,32,32}, 4, true);
+      return set_params({32, 64, 64, 4, 32, 32, 32}, 4, true);
     }
     if (ctx.size_m <= 2048) {
-      return set_params({128,64,128,8,64,64,32}, 1, true);
+      return set_params({128, 64, 128, 8, 64, 64, 32}, 1, true);
     }
-    return set_params({128,64,32,4,32,64,32}, 1, true);
+    return set_params({128, 64, 32, 4, 32, 64, 32}, 1, true);
   }
 
   if (ctx.size_n == 2048 && ctx.size_k == 64) {
     if (ctx.size_m <= 1) {
-      return set_params({32,64,64,4,32,64,16}, 1, true);
+      return set_params({32, 64, 64, 4, 32, 64, 16}, 1, true);
     }
     if (ctx.size_m <= 32) {
-      return set_params({32,64,64,4,32,32,32}, 1, true);
+      return set_params({32, 64, 64, 4, 32, 32, 32}, 1, true);
     }
     if (ctx.size_m <= 64) {
-      return set_params({32,64,64,4,32,32,32}, 1, false);
+      return set_params({32, 64, 64, 4, 32, 32, 32}, 1, false);
     }
     if (ctx.size_m <= 2048) {
-      return set_params({64,64,32,4,32,32,32}, 1, true);
+      return set_params({64, 64, 32, 4, 32, 32, 32}, 1, true);
     }
-    return set_params({128,64,32,4,32,64,32}, 1, true);
+    return set_params({128, 64, 32, 4, 32, 64, 32}, 1, true);
   }
 
   if (ctx.size_n == 2048 && ctx.size_k == 128) {
     if (ctx.size_m <= 1) {
-      return set_params({32,128,32,4,32,32,32}, 1, true);
+      return set_params({32, 128, 32, 4, 32, 32, 32}, 1, true);
     }
     if (ctx.size_m <= 32) {
-      return set_params({32,64,64,4,32,64,16}, 1, true);
+      return set_params({32, 64, 64, 4, 32, 64, 16}, 1, true);
     }
     if (ctx.size_m <= 64) {
-      return set_params({32,64,64,4,32,32,32}, 1, true);
+      return set_params({32, 64, 64, 4, 32, 32, 32}, 1, true);
     }
     if (ctx.size_m <= 2048) {
-      return set_params({128,64,32,4,32,64,32}, 1, true);
+      return set_params({128, 64, 32, 4, 32, 64, 32}, 1, true);
     }
-    return set_params({128,64,32,4,32,64,32}, 1, false);
+    return set_params({128, 64, 32, 4, 32, 64, 32}, 1, false);
   }
 
   if (ctx.size_n == 2048 && ctx.size_k == 512) {
     if (ctx.size_m <= 1) {
-      return set_params({32,64,64,4,32,32,32}, 1, true);
+      return set_params({32, 64, 64, 4, 32, 32, 32}, 1, true);
     }
     if (ctx.size_m <= 32) {
-      return set_params({32,64,64,4,32,32,32}, 1, false);
+      return set_params({32, 64, 64, 4, 32, 32, 32}, 1, false);
     }
     if (ctx.size_m <= 64) {
-      return set_params({32,64,32,4,32,32,16}, 1, false);
+      return set_params({32, 64, 32, 4, 32, 32, 16}, 1, false);
     }
     if (ctx.size_m <= 2048) {
-      return set_params({128,128,32,4,64,64,32}, 1, true);
+      return set_params({128, 128, 32, 4, 64, 64, 32}, 1, true);
     }
-    return set_params({128,256,32,8,64,64,32}, 1, true);
+    return set_params({128, 256, 32, 8, 64, 64, 32}, 1, true);
   }
 
   if (ctx.size_n == 2048 && ctx.size_k == 1024) {
     if (ctx.size_m <= 1) {
-      return set_params({64,64,32,4,32,32,32}, 1, true);
+      return set_params({64, 64, 32, 4, 32, 32, 32}, 1, true);
     }
     if (ctx.size_m <= 32) {
-      return set_params({32,64,64,4,32,32,32}, 1, false);
+      return set_params({32, 64, 64, 4, 32, 32, 32}, 1, false);
     }
     if (ctx.size_m <= 64) {
-      return set_params({32,64,64,4,32,32,32}, 1, true);
+      return set_params({32, 64, 64, 4, 32, 32, 32}, 1, true);
     }
     if (ctx.size_m <= 2048) {
-      return set_params({128,256,32,8,64,64,32}, 1, true);
+      return set_params({128, 256, 32, 8, 64, 64, 32}, 1, true);
     }
-    return set_params({128,256,32,8,64,64,32}, 1, true);
+    return set_params({128, 256, 32, 8, 64, 64, 32}, 1, true);
   }
 
   return false;
 }
 
-inline bool
-sm70_marlin_dense_try_select_cyankiwi_minimax_m2_7_awq_4bit_params(
-    Sm70MarlinDenseAutoParamsContext const& ctx,
-    Sm70MarlinAutoParams& params) {
+inline bool sm70_marlin_dense_try_select_cyankiwi_minimax_m2_7_awq_4bit_params(
+    Sm70MarlinDenseAutoParamsContext const& ctx, Sm70MarlinAutoParams& params) {
   if (ctx.quant_format == nullptr ||
-      std::strcmp(ctx.quant_format, "uint4b8") != 0 ||
-      ctx.group_size != 32 || ctx.size_m <= 0) {
+      std::strcmp(ctx.quant_format, "uint4b8") != 0 || ctx.group_size != 32 ||
+      ctx.size_m <= 0) {
     return false;
   }
 
-  auto const set_params = [&](Sm70CtaGeometry geometry,
-                              int requested_split_k,
+  auto const set_params = [&](Sm70CtaGeometry geometry, int requested_split_k,
                               bool use_metadata_vector_words) {
     params = {geometry, requested_split_k, use_metadata_vector_words,
               ctx.packed_macro_n};
@@ -1246,18 +1208,15 @@ sm70_marlin_dense_try_select_cyankiwi_minimax_m2_7_awq_4bit_params(
   return false;
 }
 
-inline bool
-sm70_marlin_dense_try_select_cyankiwi_glm_4_7_awq_4bit_params(
-    Sm70MarlinDenseAutoParamsContext const& ctx,
-    Sm70MarlinAutoParams& params) {
+inline bool sm70_marlin_dense_try_select_cyankiwi_glm_4_7_awq_4bit_params(
+    Sm70MarlinDenseAutoParamsContext const& ctx, Sm70MarlinAutoParams& params) {
   if (ctx.quant_format == nullptr ||
-      std::strcmp(ctx.quant_format, "uint4b8") != 0 ||
-      ctx.group_size != 32 || ctx.size_m <= 0) {
+      std::strcmp(ctx.quant_format, "uint4b8") != 0 || ctx.group_size != 32 ||
+      ctx.size_m <= 0) {
     return false;
   }
 
-  auto const set_params = [&](Sm70CtaGeometry geometry,
-                              int requested_split_k,
+  auto const set_params = [&](Sm70CtaGeometry geometry, int requested_split_k,
                               bool use_metadata_vector_words) {
     params = {geometry, requested_split_k, use_metadata_vector_words,
               ctx.packed_macro_n};
@@ -1323,18 +1282,15 @@ sm70_marlin_dense_try_select_cyankiwi_glm_4_7_awq_4bit_params(
   return false;
 }
 
-inline bool
-sm70_marlin_dense_try_select_quanttrio_glm_4_7_awq_params(
-    Sm70MarlinDenseAutoParamsContext const& ctx,
-    Sm70MarlinAutoParams& params) {
+inline bool sm70_marlin_dense_try_select_quanttrio_glm_4_7_awq_params(
+    Sm70MarlinDenseAutoParamsContext const& ctx, Sm70MarlinAutoParams& params) {
   if (ctx.quant_format == nullptr ||
-      std::strcmp(ctx.quant_format, "uint4") != 0 ||
-      ctx.group_size != 128 || ctx.size_m <= 0) {
+      std::strcmp(ctx.quant_format, "uint4") != 0 || ctx.group_size != 128 ||
+      ctx.size_m <= 0) {
     return false;
   }
 
-  auto const set_params = [&](Sm70CtaGeometry geometry,
-                              int requested_split_k,
+  auto const set_params = [&](Sm70CtaGeometry geometry, int requested_split_k,
                               bool use_metadata_vector_words) {
     params = {geometry, requested_split_k, use_metadata_vector_words,
               ctx.packed_macro_n};
@@ -1426,16 +1382,16 @@ inline Sm70MarlinAutoParams sm70_marlin_dense_auto_params(
     char const* quant_format, int64_t group_size, int64_t size_m,
     int64_t size_n, int64_t size_k) {
   Sm70MarlinDenseAutoParamsContext const ctx{
-      quant_format, group_size, size_m, size_n, size_k,
-      sm70_marlin_auto_packed_macro_n(size_n)};
+      quant_format, group_size, size_m,
+      size_n,       size_k,     sm70_marlin_auto_packed_macro_n(size_n)};
 
   if (sm70_marlin_dense_auto_env_is_set()) {
     return sm70_marlin_dense_auto_params_from_env(ctx);
   }
 
   Sm70MarlinAutoParams params{};
-  if (sm70_marlin_dense_try_select_quanttrio_qwen3_6_27b_awq_params(
-          ctx, params)) {
+  if (sm70_marlin_dense_try_select_quanttrio_qwen3_6_27b_awq_params(ctx,
+                                                                    params)) {
     validate_sm70_marlin_auto_params("Dense", params);
     return params;
   }
@@ -1444,8 +1400,7 @@ inline Sm70MarlinAutoParams sm70_marlin_dense_auto_params(
     validate_sm70_marlin_auto_params("Dense", params);
     return params;
   }
-  if (sm70_marlin_dense_try_select_nvidia_glm_4_7_nvfp4_params(
-          ctx, params)) {
+  if (sm70_marlin_dense_try_select_nvidia_glm_4_7_nvfp4_params(ctx, params)) {
     validate_sm70_marlin_auto_params("Dense", params);
     return params;
   }
@@ -1464,13 +1419,12 @@ inline Sm70MarlinAutoParams sm70_marlin_dense_auto_params(
     validate_sm70_marlin_auto_params("Dense", params);
     return params;
   }
-  if (sm70_marlin_dense_try_select_cyankiwi_glm_4_7_awq_4bit_params(
-          ctx, params)) {
+  if (sm70_marlin_dense_try_select_cyankiwi_glm_4_7_awq_4bit_params(ctx,
+                                                                    params)) {
     validate_sm70_marlin_auto_params("Dense", params);
     return params;
   }
-  if (sm70_marlin_dense_try_select_quanttrio_glm_4_7_awq_params(
-          ctx, params)) {
+  if (sm70_marlin_dense_try_select_quanttrio_glm_4_7_awq_params(ctx, params)) {
     validate_sm70_marlin_auto_params("Dense", params);
     return params;
   }
@@ -1478,27 +1432,25 @@ inline Sm70MarlinAutoParams sm70_marlin_dense_auto_params(
   return sm70_marlin_default_auto_params(ctx.packed_macro_n);
 }
 
-inline void validate_sm70_marlin_dense_cta_geometry_supported(char const* op_name,
-                                                              Sm70CtaGeometry geometry) {
+inline void validate_sm70_marlin_dense_cta_geometry_supported(
+    char const* op_name, Sm70CtaGeometry geometry) {
   TORCH_CHECK(sm70_marlin_cta_geometry_is_supported(geometry),
               "Unsupported SM70 Marlin CTA geometry for ", op_name, ": ",
-              geometry.cta_m, "x", geometry.cta_n, "x", geometry.cta_k,
-              "x", geometry.warps, "x", geometry.warp_m, "x",
-              geometry.warp_n, "x", geometry.warp_k,
-              ". Supported geometries are ",
+              geometry.cta_m, "x", geometry.cta_n, "x", geometry.cta_k, "x",
+              geometry.warps, "x", geometry.warp_m, "x", geometry.warp_n, "x",
+              geometry.warp_k, ". Supported geometries are ",
               kSupportedSm70MarlinCtaGeometries, ".");
 }
 
 inline void validate_sm70_marlin_dense_cta_n_alignment(char const* op_name,
                                                        Sm70CtaGeometry geometry,
                                                        int64_t size_n) {
-  TORCH_CHECK(
-      size_n % geometry.cta_n == 0 && size_n % kQuantTileN == 0,
-      "SM70 Marlin requires size_n divisible by both CTA_N and 64 for ",
-      op_name, " with CTA geometry ", geometry.cta_m, "x", geometry.cta_n,
-      "x", geometry.cta_k, "x", geometry.warps, "x", geometry.warp_m,
-      "x", geometry.warp_n, "x", geometry.warp_k, ". Got size_n = ",
-      size_n, ".");
+  TORCH_CHECK(size_n % geometry.cta_n == 0 && size_n % kQuantTileN == 0,
+              "SM70 Marlin requires size_n divisible by both CTA_N and 64 for ",
+              op_name, " with CTA geometry ", geometry.cta_m, "x",
+              geometry.cta_n, "x", geometry.cta_k, "x", geometry.warps, "x",
+              geometry.warp_m, "x", geometry.warp_n, "x", geometry.warp_k,
+              ". Got size_n = ", size_n, ".");
 }
 
 }  // namespace marlin::sm70

--- a/csrc/quantization/marlin/sm70_marlin_dispatch.cu
+++ b/csrc/quantization/marlin/sm70_marlin_dispatch.cu
@@ -43,15 +43,13 @@ __device__ __forceinline__ int sm70_inverse_zp_interleave(int idx,
   return inv[idx];
 }
 
-__device__ __forceinline__ int sm70_inverse_scale_perm(int idx,
-                                                       int perm_len) {
+__device__ __forceinline__ int sm70_inverse_scale_perm(int idx, int perm_len) {
   if (perm_len == 64) {
     return (idx % 8) * 8 + idx / 8;
   }
-  constexpr int inv[32] = {0,  1,  8,  9,  16, 17, 24, 25,
-                           2,  3,  10, 11, 18, 19, 26, 27,
-                           4,  5,  12, 13, 20, 21, 28, 29,
-                           6,  7,  14, 15, 22, 23, 30, 31};
+  constexpr int inv[32] = {0,  1,  8,  9,  16, 17, 24, 25, 2,  3,  10,
+                           11, 18, 19, 26, 27, 4,  5,  12, 13, 20, 21,
+                           28, 29, 6,  7,  14, 15, 22, 23, 30, 31};
   return inv[idx];
 }
 
@@ -66,10 +64,9 @@ __global__ void sm70_unpermute_half_metadata_kernel(
 }
 
 __global__ void sm70_unpack_dense_zp_to_half_kernel(
-    const int32_t* __restrict__ packed_zp,
-    const half* __restrict__ scales, half* __restrict__ out,
-    int64_t total, int64_t size_n, int64_t packed_n, int num_bits,
-    bool is_a_8bit) {
+    const int32_t* __restrict__ packed_zp, const half* __restrict__ scales,
+    half* __restrict__ out, int64_t total, int64_t size_n, int64_t packed_n,
+    int num_bits, bool is_a_8bit) {
   const int64_t idx = blockIdx.x * blockDim.x + threadIdx.x;
   if (idx >= total) return;
 
@@ -81,21 +78,18 @@ __global__ void sm70_unpack_dense_zp_to_half_kernel(
   if (!is_a_8bit) {
     packed_col_in_block =
         (packed_col_in_block / pack_factor) * pack_factor +
-        sm70_inverse_zp_interleave(packed_col_in_block % pack_factor,
-                                   num_bits);
+        sm70_inverse_zp_interleave(packed_col_in_block % pack_factor, num_bits);
   }
   const int64_t packed_col = block64 * 64 + packed_col_in_block;
-  const uint32_t word = reinterpret_cast<const uint32_t*>(packed_zp)
-      [(idx / size_n) * packed_n + packed_col / pack_factor];
-  const uint32_t zp =
-      (word >> ((packed_col % pack_factor) * num_bits)) &
-      ((1u << num_bits) - 1u);
+  const uint32_t word = reinterpret_cast<const uint32_t*>(
+      packed_zp)[(idx / size_n) * packed_n + packed_col / pack_factor];
+  const uint32_t zp = (word >> ((packed_col % pack_factor) * num_bits)) &
+                      ((1u << num_bits) - 1u);
   out[idx] = __float2half(static_cast<float>(zp) * __half2float(scales[idx]));
 }
 
 torch::Tensor sm70_dense_scales_as_logical(torch::Tensor const& b_scales,
-                                           int64_t size_k,
-                                           int64_t group_size,
+                                           int64_t size_k, int64_t group_size,
                                            bool is_a_8bit) {
   TORCH_CHECK(b_scales.scalar_type() == at::ScalarType::Half,
               "SM70 Marlin adapter expects fp16 scales.");
@@ -103,15 +97,14 @@ torch::Tensor sm70_dense_scales_as_logical(torch::Tensor const& b_scales,
       group_size < size_k && group_size != -1 && !is_a_8bit;
   const int perm_len = uses_group_perm ? 64 : 32;
   TORCH_CHECK(b_scales.numel() % perm_len == 0,
-              "SM70 Marlin scale metadata size is not divisible by ",
-              perm_len);
+              "SM70 Marlin scale metadata size is not divisible by ", perm_len);
 
   auto out = torch::empty_like(b_scales);
   const int64_t total = out.numel();
   constexpr int threads = 256;
   const int blocks = static_cast<int>((total + threads - 1) / threads);
-  sm70_unpermute_half_metadata_kernel<<<
-      blocks, threads, 0, at::cuda::getCurrentCUDAStream()>>>(
+  sm70_unpermute_half_metadata_kernel<<<blocks, threads, 0,
+                                        at::cuda::getCurrentCUDAStream()>>>(
       reinterpret_cast<const half*>(b_scales.data_ptr<at::Half>()),
       reinterpret_cast<half*>(out.data_ptr<at::Half>()), total, perm_len);
   C10_CUDA_KERNEL_LAUNCH_CHECK();
@@ -143,8 +136,8 @@ torch::Tensor sm70_dense_zp_as_half(torch::Tensor const& b_zeros,
   const int64_t total = out.numel();
   constexpr int threads = 256;
   const int blocks = static_cast<int>((total + threads - 1) / threads);
-  sm70_unpack_dense_zp_to_half_kernel<<<
-      blocks, threads, 0, at::cuda::getCurrentCUDAStream()>>>(
+  sm70_unpack_dense_zp_to_half_kernel<<<blocks, threads, 0,
+                                        at::cuda::getCurrentCUDAStream()>>>(
       b_zeros.data_ptr<int32_t>(),
       reinterpret_cast<const half*>(b_scales.data_ptr<at::Half>()),
       reinterpret_cast<half*>(out.data_ptr<at::Half>()), total, size_n,
@@ -202,8 +195,7 @@ torch::Tensor marlin_gemm(
     std::optional<torch::Tensor> const& global_scale_or_none,
     std::optional<torch::Tensor> const& b_zeros_or_none,
     std::optional<torch::Tensor> const& g_idx_or_none,
-    std::optional<torch::Tensor> const& perm_or_none,
-    torch::Tensor& workspace,
+    std::optional<torch::Tensor> const& perm_or_none, torch::Tensor& workspace,
     vllm::ScalarTypeId const& b_type_id, int64_t size_m, int64_t size_n,
     int64_t size_k, bool is_k_full, bool use_atomic_add, bool use_fp32_reduce,
     bool is_zp_float) {
@@ -273,8 +265,7 @@ torch::Tensor marlin_gemm(
               "SM70 build only supports float16 outputs.");
   TORCH_CHECK(s_type == vllm::kFloat16 ||
                   (b_type == vllm::kFE2M1f &&
-                   (s_type == vllm::kFE4M3fn ||
-                    s_type == vllm::kFE8M0fnu)),
+                   (s_type == vllm::kFE4M3fn || s_type == vllm::kFE8M0fnu)),
               "SM70 build only supports float16 scales, except FP4 uses "
               "float8_e4m3fn scales for NVFP4 or float8_e8m0fnu scales for "
               "MXFP4.");
@@ -325,10 +316,8 @@ torch::Tensor marlin_gemm(
   TORCH_CHECK(b_scales.is_contiguous(), "b_scales is not contiguous");
   TORCH_CHECK(b_scales.scalar_type() == at::ScalarType::Half ||
                   (b_type == vllm::kFE2M1f &&
-                   (b_scales.scalar_type() ==
-                        at::ScalarType::Float8_e4m3fn ||
-                    b_scales.scalar_type() ==
-                        at::ScalarType::Float8_e8m0fnu)),
+                   (b_scales.scalar_type() == at::ScalarType::Float8_e4m3fn ||
+                    b_scales.scalar_type() == at::ScalarType::Float8_e8m0fnu)),
               "SM70 build only supports float16 scales, except FP4 uses "
               "float8_e4m3fn scales for NVFP4 or float8_e8m0fnu scales for "
               "MXFP4.");
@@ -421,21 +410,18 @@ torch::Tensor marlin_gemm(
 
   torch::Tensor b_scales_kernel = b_scales;
   if (b_scales.scalar_type() == at::ScalarType::Half) {
-    b_scales_kernel =
-        sm70_dense_scales_as_logical(b_scales, size_k, group_size,
-                                     a_type.size_bits() == 8);
+    b_scales_kernel = sm70_dense_scales_as_logical(b_scales, size_k, group_size,
+                                                   a_type.size_bits() == 8);
   }
 
   torch::Tensor global_scale;
   if (global_scale_or_none.has_value()) {
     global_scale = global_scale_or_none.value();
-    TORCH_CHECK(
-        b_type == vllm::kFE2M1f && s_type == vllm::kFE4M3fn,
-        "SM70 Marlin supports global_scale only for "
-        "nvfp4 format.");
+    TORCH_CHECK(b_type == vllm::kFE2M1f && s_type == vllm::kFE4M3fn,
+                "SM70 Marlin supports global_scale only for "
+                "nvfp4 format.");
     TORCH_CHECK(global_scale.device().is_cuda(), "global_scale is not on GPU");
-    TORCH_CHECK(global_scale.is_contiguous(),
-                "global_scale is not contiguous");
+    TORCH_CHECK(global_scale.is_contiguous(), "global_scale is not contiguous");
     TORCH_CHECK(global_scale.scalar_type() == at::ScalarType::Float,
                 "SM70 Marlin NVFP4 expects fp32 global_scale.");
     TORCH_CHECK(global_scale.numel() == 1,
@@ -463,8 +449,7 @@ torch::Tensor marlin_gemm(
   if (b_zeros_or_none.has_value()) {
     b_zeros = b_zeros_or_none.value();
     TORCH_CHECK(b_zeros.device().is_cuda(), "b_zeros is not on GPU");
-    TORCH_CHECK(b_zeros.is_contiguous(),
-                "b_zeros is not contiguous");
+    TORCH_CHECK(b_zeros.is_contiguous(), "b_zeros is not contiguous");
   } else {
     b_zeros = torch::empty({0}, options);
   }
@@ -477,9 +462,9 @@ torch::Tensor marlin_gemm(
 
   if (has_zp) {
     if (!is_zp_float && b_zeros.scalar_type() == at::ScalarType::Int) {
-      b_zeros = sm70_dense_zp_as_half(
-          b_zeros, b_scales_kernel, size_n, b_type == vllm::kU4 ? 4 : 8,
-          a_type.size_bits() == 8);
+      b_zeros = sm70_dense_zp_as_half(b_zeros, b_scales_kernel, size_n,
+                                      b_type == vllm::kU4 ? 4 : 8,
+                                      a_type.size_bits() == 8);
       zp_is_float = true;
     }
   }
@@ -493,8 +478,7 @@ torch::Tensor marlin_gemm(
     TORCH_CHECK(b_zeros.scalar_type() == at::ScalarType::Half,
                 "SM70 Marlin uint4/uint8 dense path expects fp16 "
                 "zero points.");
-    TORCH_CHECK(b_zeros.size(1) == size_n,
-                "b_zeros dim 1 = ", b_zeros.size(1),
+    TORCH_CHECK(b_zeros.size(1) == size_n, "b_zeros dim 1 = ", b_zeros.size(1),
                 " is not size_n = ", size_n);
     TORCH_CHECK(num_groups == b_zeros.size(0),
                 "b_zeros dim 0 = ", b_zeros.size(0),
@@ -523,30 +507,26 @@ torch::Tensor marlin_gemm(
               "SM70 Marlin expects int32 packed weights.");
   TORCH_CHECK(!has_act_order,
               "act_order is not supported for the SM70 Marlin path.");
-  TORCH_CHECK(!has_bias,
-              "SM70 Marlin does not support bias. TODO: add epilogue bias fusion.");
+  TORCH_CHECK(
+      !has_bias,
+      "SM70 Marlin does not support bias. TODO: add epilogue bias fusion.");
   TORCH_CHECK((b_type == vllm::kFE2M1f && s_type == vllm::kFE4M3fn) ||
                   global_scale.numel() == 0,
               "SM70 Marlin supports global_scale only for "
               "nvfp4 format.");
   TORCH_CHECK(!use_atomic_add,
               "SM70 Marlin does not support atomic-add output.");
-  TORCH_CHECK(is_k_full,
-              "SM70 Marlin requires full-K non act-order inputs.");
-  TORCH_CHECK(size_k % 32 == 0,
-              "SM70 Marlin requires size_k % 32 == 0.");
-  TORCH_CHECK(size_n % 64 == 0,
-              "SM70 Marlin requires size_n % 64 == 0.");
+  TORCH_CHECK(is_k_full, "SM70 Marlin requires full-K non act-order inputs.");
+  TORCH_CHECK(size_k % 32 == 0, "SM70 Marlin requires size_k % 32 == 0.");
+  TORCH_CHECK(size_n % 64 == 0, "SM70 Marlin requires size_n % 64 == 0.");
   TORCH_CHECK(group_size == -1 || group_size > 0,
-              "SM70 Marlin received invalid group_size = ",
-              group_size);
+              "SM70 Marlin received invalid group_size = ", group_size);
 
   if (b_type == vllm::kU4) {
     TORCH_CHECK(size_k % 32 == 0,
                 "SM70 Marlin uint4 dense path requires size_k % 32 == 0.");
-    TORCH_CHECK(
-        has_zp && zp_is_float,
-        "SM70 Marlin uint4 dense path requires fp16 zero points.");
+    TORCH_CHECK(has_zp && zp_is_float,
+                "SM70 Marlin uint4 dense path requires fp16 zero points.");
     return sm70_marlin_u4_gemm(a, c, b_q_weight, b_scales_kernel, b_zeros,
                                size_m, size_n, size_k, group_size);
   }
@@ -554,17 +534,15 @@ torch::Tensor marlin_gemm(
   if (b_type == vllm::kU8) {
     TORCH_CHECK(size_k % 32 == 0,
                 "SM70 Marlin uint8 dense path requires size_k % 32 == 0.");
-    TORCH_CHECK(
-        has_zp && zp_is_float,
-        "SM70 Marlin uint8 dense path requires fp16 zero points.");
+    TORCH_CHECK(has_zp && zp_is_float,
+                "SM70 Marlin uint8 dense path requires fp16 zero points.");
     return sm70_marlin_u8_gemm(a, c, b_q_weight, b_scales_kernel, b_zeros,
                                size_m, size_n, size_k, group_size);
   }
 
   if (b_type == vllm::kU8B128) {
-    TORCH_CHECK(
-        size_k % 32 == 0,
-        "SM70 Marlin uint8b128 dense path requires size_k % 32 == 0.");
+    TORCH_CHECK(size_k % 32 == 0,
+                "SM70 Marlin uint8b128 dense path requires size_k % 32 == 0.");
     TORCH_CHECK(!has_zp && !is_zp_float,
                 "SM70 Marlin uint8b128 does not support "
                 "zero-point metadata.");
@@ -573,9 +551,8 @@ torch::Tensor marlin_gemm(
   }
 
   if (b_type == vllm::kFE4M3fn) {
-    TORCH_CHECK(
-        size_k % 32 == 0,
-        "SM70 Marlin FP8 dense path requires size_k % 32 == 0.");
+    TORCH_CHECK(size_k % 32 == 0,
+                "SM70 Marlin FP8 dense path requires size_k % 32 == 0.");
     TORCH_CHECK(group_size == -1 || group_size == 128,
                 "SM70 Marlin FP8 supports only group_size -1 or "
                 "128. Got ",
@@ -588,15 +565,15 @@ torch::Tensor marlin_gemm(
   }
 
   if (b_type == vllm::kFE2M1f) {
-    TORCH_CHECK(
-        size_k % 32 == 0,
-        "SM70 Marlin FP4 dense path requires size_k % 32 == 0.");
+    TORCH_CHECK(size_k % 32 == 0,
+                "SM70 Marlin FP4 dense path requires size_k % 32 == 0.");
     TORCH_CHECK(!has_zp && !is_zp_float,
                 "SM70 Marlin FP4 does not support zero-point "
                 "metadata.");
     if (s_type == vllm::kFE4M3fn) {
-      TORCH_CHECK(global_scale.numel() == 1,
-                  "the global_scale parameter must be passed for nvfp4 format.");
+      TORCH_CHECK(
+          global_scale.numel() == 1,
+          "the global_scale parameter must be passed for nvfp4 format.");
       TORCH_CHECK(group_size == 16,
                   "SM70 Marlin NVFP4 supports only group_size 16. "
                   "Got ",

--- a/csrc/quantization/marlin/sm70_marlin_fp8_gemm.cu
+++ b/csrc/quantization/marlin/sm70_marlin_fp8_gemm.cu
@@ -20,24 +20,24 @@
 #include "cutlass/layout/tensor_op_multiplicand_sm70.h"
 #include "cutlass/transform/threadblock/predicated_tile_iterator.h"
 
-using marlin::sm70::Sm70CtaGeometry;
-using marlin::sm70::Sm70AtomicFp16Epilogue;
-using marlin::sm70::Sm70MarlinGemmTraits;
-using marlin::sm70::Sm70SplitKPartition;
-using marlin::sm70::validate_sm70_marlin_dense_cta_geometry_supported;
-using marlin::sm70::validate_sm70_marlin_dense_cta_n_alignment;
 using marlin::sm70::configure_sm70_dynamic_smem;
 using marlin::sm70::dispatch_sm70_marlin_fp8_geometry;
 using marlin::sm70::kQuantTileK;
 using marlin::sm70::kQuantTileN;
-using marlin::sm70::sm70_marlin_dense_auto_params;
 using marlin::sm70::load_qword_vector;
 using marlin::sm70::qword_from_vector;
-using marlin::sm70::sm70_marlin_cta_grid;
 using marlin::sm70::sm70_active_split_k;
+using marlin::sm70::sm70_marlin_cta_grid;
+using marlin::sm70::sm70_marlin_dense_auto_params;
 using marlin::sm70::sm70_splitk_partition;
+using marlin::sm70::Sm70AtomicFp16Epilogue;
+using marlin::sm70::Sm70CtaGeometry;
+using marlin::sm70::Sm70MarlinGemmTraits;
+using marlin::sm70::Sm70SplitKPartition;
 using marlin::sm70::u8_packed_macro_n_qweight_offset_from_logical;
 using marlin::sm70::u8_packed_macro_n_qweight_word_stride;
+using marlin::sm70::validate_sm70_marlin_dense_cta_geometry_supported;
+using marlin::sm70::validate_sm70_marlin_dense_cta_n_alignment;
 
 namespace {
 
@@ -53,12 +53,11 @@ class Sm70Fp8IteratorB {
   static int const kPackedMacroN = PackedMacroN_;
   static constexpr bool kUseMetadataVectorWords = UseMetadataVectorWords_;
   using Element = cutlass::half_t;
-  using Fragment = cutlass::Array<
-      Element, ThreadMap::Iterations::kCount * ThreadMap::kElementsPerAccess>;
+  using Fragment = cutlass::Array<Element, ThreadMap::Iterations::kCount *
+                                               ThreadMap::kElementsPerAccess>;
   static_assert(Shape::kN == 64 || Shape::kN == 128 || Shape::kN == 256,
                 "SM70 Marlin FP8 IteratorB expects CTA_N in {64, 128, 256}.");
-  static_assert(ThreadMap::Iterations::kContiguous ==
-                    Shape::kN / kQuantTileN,
+  static_assert(ThreadMap::Iterations::kContiguous == Shape::kN / kQuantTileN,
                 "SM70 Marlin FP8 IteratorB expects one contiguous iteration "
                 "per 64-column quant tile.");
   static_assert(ThreadMap::Delta::kContiguous == kQuantTileN,
@@ -159,13 +158,12 @@ class Sm70Fp8IteratorB {
   CUTLASS_DEVICE
   static int qweight_offset_from_logical(Params const& params, int logical_k,
                                          int logical_n) {
-    return u8_packed_macro_n_qweight_offset_from_logical<kPackedMacroN>(params.size_n, logical_k,
-                                                     logical_n);
+    return u8_packed_macro_n_qweight_offset_from_logical<kPackedMacroN>(
+        params.size_n, logical_k, logical_n);
   }
 
   CUTLASS_DEVICE
-  static int qweight_word_stride_from_logical(Params const&,
-                                              int logical_n) {
+  static int qweight_word_stride_from_logical(Params const&, int logical_n) {
     return u8_packed_macro_n_qweight_word_stride<kPackedMacroN>();
   }
 
@@ -196,9 +194,8 @@ class Sm70Fp8IteratorB {
   void cache_current_group_metadata(int group) const {
     CUTLASS_PRAGMA_UNROLL
     for (int c = 0; c < ThreadMap::Iterations::kContiguous; ++c) {
-      int const cache_n =
-          n_offset_ + thread_offset_.contiguous() +
-          c * ThreadMap::Delta::kContiguous;
+      int const cache_n = n_offset_ + thread_offset_.contiguous() +
+                          c * ThreadMap::Delta::kContiguous;
       if constexpr (kUseMetadataVectorWords) {
         cache_metadata_vector_words(c, group, cache_n);
       } else {
@@ -259,8 +256,9 @@ class Sm70Fp8IteratorB {
           frag_vec[3] = __hmul2(deq[1], scale_vec[3]);
         }
       } else {
-        static_assert(ThreadMap::Iterations::kContiguous == 1,
-                      "Unsupported SM70 Marlin FP8 contiguous iteration count.");
+        static_assert(
+            ThreadMap::Iterations::kContiguous == 1,
+            "Unsupported SM70 Marlin FP8 contiguous iteration count.");
         uint32_t const qword0 =
             load_qword_vector<1>(qweight_ + qweight_base_offset_);
         uint32_t const qword1 = load_qword_vector<1>(
@@ -282,19 +280,17 @@ class Sm70Fp8IteratorB {
       int const logical_n_base = n_offset_ + thread_offset_.contiguous();
       CUTLASS_PRAGMA_UNROLL
       for (int s = 0; s < ThreadMap::Iterations::kStrided; ++s) {
-        int const logical_k_s =
-            k_offset_ + thread_offset_.strided() +
-            s * ThreadMap::Delta::kStrided;
+        int const logical_k_s = k_offset_ + thread_offset_.strided() +
+                                s * ThreadMap::Delta::kStrided;
         if constexpr (kGroupSize != -1) {
           cache_current_group_metadata(scale_group(logical_k_s));
         }
         int const qweight_base_s =
             qweight_offset_from_logical(params_, logical_k_s, logical_n_base);
         if constexpr (ThreadMap::Iterations::kContiguous == 4) {
-          uint4 const qwords0 =
-              load_qword_vector<4>(qweight_ + qweight_base_s);
-          uint4 const qwords1 = load_qword_vector<4>(
-              qweight_ + qweight_base_s + kQweightWordStrideWords);
+          uint4 const qwords0 = load_qword_vector<4>(qweight_ + qweight_base_s);
+          uint4 const qwords1 = load_qword_vector<4>(qweight_ + qweight_base_s +
+                                                     kQweightWordStrideWords);
           CUTLASS_PRAGMA_UNROLL
           for (int c = 0; c < ThreadMap::Iterations::kContiguous; ++c) {
             constexpr int kAccess = ThreadMap::kElementsPerAccess;
@@ -316,10 +312,9 @@ class Sm70Fp8IteratorB {
             frag_vec[3] = __hmul2(deq[1], scale_vec[3]);
           }
         } else if constexpr (ThreadMap::Iterations::kContiguous == 2) {
-          uint2 const qwords0 =
-              load_qword_vector<2>(qweight_ + qweight_base_s);
-          uint2 const qwords1 = load_qword_vector<2>(
-              qweight_ + qweight_base_s + kQweightWordStrideWords);
+          uint2 const qwords0 = load_qword_vector<2>(qweight_ + qweight_base_s);
+          uint2 const qwords1 = load_qword_vector<2>(qweight_ + qweight_base_s +
+                                                     kQweightWordStrideWords);
           CUTLASS_PRAGMA_UNROLL
           for (int c = 0; c < ThreadMap::Iterations::kContiguous; ++c) {
             constexpr int kAccess = ThreadMap::kElementsPerAccess;
@@ -341,8 +336,9 @@ class Sm70Fp8IteratorB {
             frag_vec[3] = __hmul2(deq[1], scale_vec[3]);
           }
         } else {
-          static_assert(ThreadMap::Iterations::kContiguous == 1,
-                        "Unsupported SM70 Marlin FP8 contiguous iteration count.");
+          static_assert(
+              ThreadMap::Iterations::kContiguous == 1,
+              "Unsupported SM70 Marlin FP8 contiguous iteration count.");
           uint32_t const qword0 =
               load_qword_vector<1>(qweight_ + qweight_base_s);
           uint32_t const qword1 = load_qword_vector<1>(
@@ -372,8 +368,7 @@ class Sm70Fp8IteratorB {
       return;
     }
 
-    if constexpr (kGroupSize != -1 &&
-                  ThreadMap::Iterations::kStrided == 1) {
+    if constexpr (kGroupSize != -1 && ThreadMap::Iterations::kStrided == 1) {
       int const first_logical_k = k_offset_ + thread_offset_.strided();
       cache_current_group_metadata(scale_group(first_logical_k));
     }
@@ -385,32 +380,29 @@ class Sm70Fp8IteratorB {
 template <bool UseMetadataVectorWords = true>
 struct Sm70Fp8GemmSpec {
   template <typename Shape, typename ThreadMap, int GroupSize, int PackedMacroN>
-  using IteratorB =
-      Sm70Fp8IteratorB<Shape, ThreadMap, GroupSize, PackedMacroN,
-                       UseMetadataVectorWords>;
+  using IteratorB = Sm70Fp8IteratorB<Shape, ThreadMap, GroupSize, PackedMacroN,
+                                     UseMetadataVectorWords>;
 };
 
-template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM,
-          int WarpN, int WarpK, int GroupSize, int PackedMacroN,
+template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM, int WarpN,
+          int WarpK, int GroupSize, int PackedMacroN,
           bool UseMetadataVectorWords = true>
 using Sm70Fp8GemmTraits =
-    Sm70MarlinGemmTraits<Sm70Fp8GemmSpec<UseMetadataVectorWords>, CtaM,
-                         CtaN, CtaK, Warps, WarpM, WarpN, WarpK,
-                         GroupSize, PackedMacroN>;
+    Sm70MarlinGemmTraits<Sm70Fp8GemmSpec<UseMetadataVectorWords>, CtaM, CtaN,
+                         CtaK, Warps, WarpM, WarpN, WarpK, GroupSize,
+                         PackedMacroN>;
 
-template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM,
-          int WarpN, int WarpK, int GroupSize, int PackedMacroN,
+template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM, int WarpN,
+          int WarpK, int GroupSize, int PackedMacroN,
           bool UseMetadataVectorWords = true>
-__global__ __launch_bounds__(Warps * 32, 1)
-void sm70_marlin_fp8_gemm_kernel(
+__global__ __launch_bounds__(Warps * 32, 1) void sm70_marlin_fp8_gemm_kernel(
     cutlass::half_t const* __restrict__ a,
     uint32_t const* __restrict__ b_q_weight,
     cutlass::half_t const* __restrict__ b_scales,
     cutlass::half_t* __restrict__ c, int m, int n, int k, int lda) {
   using Traits =
-      Sm70Fp8GemmTraits<CtaM, CtaN, CtaK, Warps, WarpM, WarpN, WarpK,
-                        GroupSize, PackedMacroN,
-                        UseMetadataVectorWords>;
+      Sm70Fp8GemmTraits<CtaM, CtaN, CtaK, Warps, WarpM, WarpN, WarpK, GroupSize,
+                        PackedMacroN, UseMetadataVectorWords>;
   using Mma = typename Traits::Mma;
   using Epilogue = typename Traits::Epilogue;
 
@@ -430,10 +422,10 @@ void sm70_marlin_fp8_gemm_kernel(
   typename Traits::LayoutA layout_a(lda);
   typename Traits::LayoutC layout_c(n);
 
-  typename Mma::IteratorA iterator_A(
-      typename Mma::IteratorA::Params(layout_a),
-      const_cast<cutlass::half_t*>(a), cutlass::MatrixCoord(m, k), thread_idx,
-      tb_offset_A);
+  typename Mma::IteratorA iterator_A(typename Mma::IteratorA::Params(layout_a),
+                                     const_cast<cutlass::half_t*>(a),
+                                     cutlass::MatrixCoord(m, k), thread_idx,
+                                     tb_offset_A);
   typename Mma::IteratorB iterator_B(
       typename Mma::IteratorB::Params(k, n),
       reinterpret_cast<uint32_t const*>(b_q_weight),
@@ -458,18 +450,19 @@ void sm70_marlin_fp8_gemm_kernel(
   epilogue(output_op, iterator_D, accumulators, iterator_C);
 }
 
-template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM,
-          int WarpN, int WarpK, int GroupSize, int PackedMacroN,
+template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM, int WarpN,
+          int WarpK, int GroupSize, int PackedMacroN,
           bool UseMetadataVectorWords = true>
-__global__ __launch_bounds__(Warps * 32, 1)
-void sm70_marlin_fp8_gemm_splitk_kernel(
+__global__
+__launch_bounds__(Warps * 32, 1) void sm70_marlin_fp8_gemm_splitk_kernel(
     cutlass::half_t const* __restrict__ a,
     uint32_t const* __restrict__ b_q_weight,
     cutlass::half_t const* __restrict__ b_scales,
-    cutlass::half_t* __restrict__ c, int m, int n, int k, int lda, int requested_split_k) {
-  using Traits = Sm70Fp8GemmTraits<CtaM, CtaN, CtaK, Warps, WarpM, WarpN,
-                                   WarpK, GroupSize, PackedMacroN,
-                                   UseMetadataVectorWords>;
+    cutlass::half_t* __restrict__ c, int m, int n, int k, int lda,
+    int requested_split_k) {
+  using Traits =
+      Sm70Fp8GemmTraits<CtaM, CtaN, CtaK, Warps, WarpM, WarpN, WarpK, GroupSize,
+                        PackedMacroN, UseMetadataVectorWords>;
   using Mma = typename Traits::Mma;
   using AtomicEpilogue = Sm70AtomicFp16Epilogue<Traits>;
 
@@ -480,14 +473,13 @@ void sm70_marlin_fp8_gemm_splitk_kernel(
   int const thread_idx = threadIdx.x;
   int const warp_idx = cutlass::canonical_warp_idx_sync();
   int const lane_idx = threadIdx.x % 32;
-  Sm70SplitKPartition const partition =
-      sm70_splitk_partition<GroupSize, CtaK>(k, requested_split_k, int(blockIdx.z));
+  Sm70SplitKPartition const partition = sm70_splitk_partition<GroupSize, CtaK>(
+      k, requested_split_k, int(blockIdx.z));
   if (partition.partition_k == 0) {
     return;
   }
 
-  cutlass::MatrixCoord tb_offset_A{int(blockIdx.x) * CtaM,
-                                   partition.k_begin};
+  cutlass::MatrixCoord tb_offset_A{int(blockIdx.x) * CtaM, partition.k_begin};
   cutlass::MatrixCoord tb_offset_B{partition.k_begin, int(blockIdx.y) * CtaN};
   cutlass::MatrixCoord tb_offset_C{int(blockIdx.x) * CtaM,
                                    int(blockIdx.y) * CtaN};
@@ -495,10 +487,10 @@ void sm70_marlin_fp8_gemm_splitk_kernel(
   typename Traits::LayoutA layout_a(lda);
   typename Traits::LayoutC layout_c(n);
 
-  typename Mma::IteratorA iterator_A(
-      typename Mma::IteratorA::Params(layout_a),
-      const_cast<cutlass::half_t*>(a), cutlass::MatrixCoord(m, k), thread_idx,
-      tb_offset_A);
+  typename Mma::IteratorA iterator_A(typename Mma::IteratorA::Params(layout_a),
+                                     const_cast<cutlass::half_t*>(a),
+                                     cutlass::MatrixCoord(m, k), thread_idx,
+                                     tb_offset_A);
   typename Mma::IteratorB iterator_B(
       typename Mma::IteratorB::Params(k, n),
       reinterpret_cast<uint32_t const*>(b_q_weight),
@@ -512,9 +504,8 @@ void sm70_marlin_fp8_gemm_splitk_kernel(
   mma(gemm_k_iterations, accumulators, iterator_A, iterator_B, accumulators);
 
   typename AtomicEpilogue::OutputTileIterator iterator_D(
-      typename AtomicEpilogue::OutputTileIterator::Params(layout_c),
-      c, cutlass::MatrixCoord(m, n),
-      thread_idx, tb_offset_C);
+      typename AtomicEpilogue::OutputTileIterator::Params(layout_c), c,
+      cutlass::MatrixCoord(m, n), thread_idx, tb_offset_C);
 
   AtomicEpilogue epilogue(shared_storage.epilogue, thread_idx, warp_idx,
                           lane_idx);
@@ -523,20 +514,23 @@ void sm70_marlin_fp8_gemm_splitk_kernel(
 
 }  // namespace
 
-template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM,
-          int WarpN, int WarpK, int GroupSize, int PackedMacroN,
+template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM, int WarpN,
+          int WarpK, int GroupSize, int PackedMacroN,
           bool UseMetadataVectorWords = true>
-torch::Tensor launch_sm70_marlin_fp8_gemm(
-    torch::Tensor& a, torch::Tensor& c, torch::Tensor& b_q_weight,
-    torch::Tensor& b_scales, int64_t size_m, int64_t size_n, int64_t size_k,
-    int requested_split_k) {
+torch::Tensor launch_sm70_marlin_fp8_gemm(torch::Tensor& a, torch::Tensor& c,
+                                          torch::Tensor& b_q_weight,
+                                          torch::Tensor& b_scales,
+                                          int64_t size_m, int64_t size_n,
+                                          int64_t size_k,
+                                          int requested_split_k) {
   auto kernel =
-      sm70_marlin_fp8_gemm_kernel<CtaM, CtaN, CtaK, Warps, WarpM, WarpN,
-                                  WarpK, GroupSize, PackedMacroN,
+      sm70_marlin_fp8_gemm_kernel<CtaM, CtaN, CtaK, Warps, WarpM, WarpN, WarpK,
+                                  GroupSize, PackedMacroN,
                                   UseMetadataVectorWords>;
-  using SharedStorage = typename Sm70Fp8GemmTraits<
-      CtaM, CtaN, CtaK, Warps, WarpM, WarpN, WarpK, GroupSize,
-      PackedMacroN, UseMetadataVectorWords>::SharedStorage;
+  using SharedStorage =
+      typename Sm70Fp8GemmTraits<CtaM, CtaN, CtaK, Warps, WarpM, WarpN, WarpK,
+                                 GroupSize, PackedMacroN,
+                                 UseMetadataVectorWords>::SharedStorage;
   size_t smem_bytes = configure_sm70_dynamic_smem<SharedStorage>(kernel);
 
   dim3 block(Warps * 32);
@@ -556,21 +550,20 @@ torch::Tensor launch_sm70_marlin_fp8_gemm(
   }
 
   TORCH_CHECK(size_k % int64_t(CtaK) == 0,
-              "SM70 Marlin fp8_e4m3 requires K divisible by CTA_K=",
-              CtaK, " for requested_split_k > 1. Got K=", size_k,
+              "SM70 Marlin fp8_e4m3 requires K divisible by CTA_K=", CtaK,
+              " for requested_split_k > 1. Got K=", size_k,
               ", requested_split_k=", requested_split_k, ".");
 
   auto split_kernel =
-      sm70_marlin_fp8_gemm_splitk_kernel<CtaM, CtaN, CtaK, Warps, WarpM,
-                                         WarpN, WarpK, GroupSize,
-                                         PackedMacroN,
+      sm70_marlin_fp8_gemm_splitk_kernel<CtaM, CtaN, CtaK, Warps, WarpM, WarpN,
+                                         WarpK, GroupSize, PackedMacroN,
                                          UseMetadataVectorWords>;
   smem_bytes = configure_sm70_dynamic_smem<SharedStorage>(split_kernel);
 
   int64_t const numel = size_m * size_n;
-  C10_CUDA_CHECK(cudaMemsetAsync(
-      c.data_ptr<at::Half>(), 0,
-      static_cast<size_t>(numel) * sizeof(at::Half), stream));
+  C10_CUDA_CHECK(cudaMemsetAsync(c.data_ptr<at::Half>(), 0,
+                                 static_cast<size_t>(numel) * sizeof(at::Half),
+                                 stream));
 
   dim3 grid = sm70_marlin_cta_grid(size_m, size_n, CtaM, CtaN);
   int const active_split_k =
@@ -582,7 +575,8 @@ torch::Tensor launch_sm70_marlin_fp8_gemm(
       reinterpret_cast<cutlass::half_t const*>(b_scales.data_ptr<at::Half>()),
       reinterpret_cast<cutlass::half_t*>(c.data_ptr<at::Half>()),
       static_cast<int>(size_m), static_cast<int>(size_n),
-      static_cast<int>(size_k), static_cast<int>(a.stride(0)), requested_split_k);
+      static_cast<int>(size_k), static_cast<int>(a.stride(0)),
+      requested_split_k);
   C10_CUDA_KERNEL_LAUNCH_CHECK();
 
   return c;
@@ -599,8 +593,8 @@ struct Sm70Fp8Launcher {
   int64_t size_k;
   int requested_split_k;
 
-  template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM,
-            int WarpN, int WarpK, int GroupSize, int PackedMacroN>
+  template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM, int WarpN,
+            int WarpK, int GroupSize, int PackedMacroN>
   torch::Tensor operator()() const {
     return launch_sm70_marlin_fp8_gemm<CtaM, CtaN, CtaK, Warps, WarpM, WarpN,
                                        WarpK, GroupSize, PackedMacroN,
@@ -616,21 +610,23 @@ torch::Tensor sm70_marlin_fp8_gemm(torch::Tensor& a, torch::Tensor& c,
                                    int64_t group_size) {
   c10::cuda::CUDAGuard device_guard(a.device());
 
-  auto const params = sm70_marlin_dense_auto_params(
-      "fp8_e4m3", group_size, size_m, size_n, size_k);
+  auto const params = sm70_marlin_dense_auto_params("fp8_e4m3", group_size,
+                                                    size_m, size_n, size_k);
   Sm70CtaGeometry const geometry = params.geometry;
-  validate_sm70_marlin_dense_cta_geometry_supported("SM70 Marlin fp8_e4m3", geometry);
-  validate_sm70_marlin_dense_cta_n_alignment("SM70 Marlin fp8_e4m3", geometry, size_n);
+  validate_sm70_marlin_dense_cta_geometry_supported("SM70 Marlin fp8_e4m3",
+                                                    geometry);
+  validate_sm70_marlin_dense_cta_n_alignment("SM70 Marlin fp8_e4m3", geometry,
+                                             size_n);
   if (params.use_metadata_vector_words) {
     Sm70Fp8Launcher<true> const launcher{
-        a, c, b_q_weight, b_scales, size_m, size_n, size_k,
-        params.requested_split_k};
-    return dispatch_sm70_marlin_fp8_geometry(
-        launcher, geometry, params.packed_macro_n, group_size);
+        a,      c,      b_q_weight, b_scales,
+        size_m, size_n, size_k,     params.requested_split_k};
+    return dispatch_sm70_marlin_fp8_geometry(launcher, geometry,
+                                             params.packed_macro_n, group_size);
   }
   Sm70Fp8Launcher<false> const launcher{
-      a, c, b_q_weight, b_scales, size_m, size_n, size_k,
-      params.requested_split_k};
-  return dispatch_sm70_marlin_fp8_geometry(
-      launcher, geometry, params.packed_macro_n, group_size);
+      a,      c,      b_q_weight, b_scales,
+      size_m, size_n, size_k,     params.requested_split_k};
+  return dispatch_sm70_marlin_fp8_geometry(launcher, geometry,
+                                           params.packed_macro_n, group_size);
 }

--- a/csrc/quantization/marlin/sm70_marlin_gemm.cuh
+++ b/csrc/quantization/marlin/sm70_marlin_gemm.cuh
@@ -30,8 +30,7 @@ struct Sm70MarlinGemmTraits {
                 "SM70 Marlin supports CTA_N in {64, 128, 256}.");
   static_assert(CtaK == 16 || CtaK == 32 || CtaK == 64 || CtaK == 128,
                 "SM70 Marlin supports CTA_K in {16, 32, 64, 128}.");
-  static_assert(Warps == 4 || Warps == 8,
-                "SM70 Marlin supports 4 or 8 warps.");
+  static_assert(Warps == 4 || Warps == 8, "SM70 Marlin supports 4 or 8 warps.");
   static_assert(PackedMacroN == 64 || PackedMacroN == 128 ||
                     PackedMacroN == 256,
                 "SM70 Marlin packed macro-N must be 64, 128, or 256.");
@@ -45,8 +44,8 @@ struct Sm70MarlinGemmTraits {
   using LayoutB = cutlass::layout::RowMajor;
   using LayoutC = cutlass::layout::RowMajor;
   using ThreadblockShape = cutlass::gemm::GemmShape<CtaM, CtaN, CtaK>;
-  using WarpShape =
-      typename Sm70WarpShape<CtaM, CtaN, CtaK, Warps, WarpM, WarpN, WarpK>::Type;
+  using WarpShape = typename Sm70WarpShape<CtaM, CtaN, CtaK, Warps, WarpM,
+                                           WarpN, WarpK>::Type;
   static_assert(WarpShape::kM <= 64 && WarpShape::kN <= 64,
                 "SM70 Marlin keeps per-warp M/N no larger than 64.");
   using InstructionShape = cutlass::gemm::GemmShape<8, 8, 4>;
@@ -60,9 +59,10 @@ struct Sm70MarlinGemmTraits {
       cutlass::MatrixShape<ThreadblockShape::kM, ThreadblockShape::kK>,
       ElementA, LayoutA, 1, typename MmaCore::IteratorThreadMapA,
       128 / cutlass::sizeof_bits<ElementA>::value>;
-  using IteratorB = typename Spec::template IteratorB<
-      ThreadblockShape, typename MmaCore::IteratorThreadMapB, GroupSize,
-      PackedMacroN>;
+  using IteratorB =
+      typename Spec::template IteratorB<ThreadblockShape,
+                                        typename MmaCore::IteratorThreadMapB,
+                                        GroupSize, PackedMacroN>;
   using Mma = Sm70MarlinMmaPipelined<
       ThreadblockShape, IteratorA, typename MmaCore::SmemIteratorA, IteratorB,
       typename MmaCore::SmemIteratorB, ElementAccumulator, LayoutC,
@@ -102,17 +102,17 @@ torch::Tensor dispatch_sm70_marlin_group_size(Launcher const& launcher,
                                               char const* quant_name) {
   switch (group_size) {
     case -1:
-      return launcher.template operator()<CtaM, CtaN, CtaK, Warps, WarpM,
-                                          WarpN, WarpK, -1, PackedMacroN>();
+      return launcher.template operator()<CtaM, CtaN, CtaK, Warps, WarpM, WarpN,
+                                          WarpK, -1, PackedMacroN>();
     case 32:
-      return launcher.template operator()<CtaM, CtaN, CtaK, Warps, WarpM,
-                                          WarpN, WarpK, 32, PackedMacroN>();
+      return launcher.template operator()<CtaM, CtaN, CtaK, Warps, WarpM, WarpN,
+                                          WarpK, 32, PackedMacroN>();
     case 64:
-      return launcher.template operator()<CtaM, CtaN, CtaK, Warps, WarpM,
-                                          WarpN, WarpK, 64, PackedMacroN>();
+      return launcher.template operator()<CtaM, CtaN, CtaK, Warps, WarpM, WarpN,
+                                          WarpK, 64, PackedMacroN>();
     case 128:
-      return launcher.template operator()<CtaM, CtaN, CtaK, Warps, WarpM,
-                                          WarpN, WarpK, 128, PackedMacroN>();
+      return launcher.template operator()<CtaM, CtaN, CtaK, Warps, WarpM, WarpN,
+                                          WarpK, 128, PackedMacroN>();
     default:
       TORCH_CHECK(false, "SM70 Marlin ", quant_name,
                   " supports only group_size -1, 32, 64, or 128. Got ",
@@ -127,17 +127,17 @@ torch::Tensor dispatch_sm70_marlin_group_size_with_group32(
     Launcher const& launcher, int64_t group_size, char const* quant_name) {
   switch (group_size) {
     case -1:
-      return launcher.template operator()<CtaM, CtaN, CtaK, Warps, WarpM,
-                                          WarpN, WarpK, -1, PackedMacroN>();
+      return launcher.template operator()<CtaM, CtaN, CtaK, Warps, WarpM, WarpN,
+                                          WarpK, -1, PackedMacroN>();
     case 32:
-      return launcher.template operator()<CtaM, CtaN, CtaK, Warps, WarpM,
-                                          WarpN, WarpK, 32, PackedMacroN>();
+      return launcher.template operator()<CtaM, CtaN, CtaK, Warps, WarpM, WarpN,
+                                          WarpK, 32, PackedMacroN>();
     case 64:
-      return launcher.template operator()<CtaM, CtaN, CtaK, Warps, WarpM,
-                                          WarpN, WarpK, 64, PackedMacroN>();
+      return launcher.template operator()<CtaM, CtaN, CtaK, Warps, WarpM, WarpN,
+                                          WarpK, 64, PackedMacroN>();
     case 128:
-      return launcher.template operator()<CtaM, CtaN, CtaK, Warps, WarpM,
-                                          WarpN, WarpK, 128, PackedMacroN>();
+      return launcher.template operator()<CtaM, CtaN, CtaK, Warps, WarpM, WarpN,
+                                          WarpK, 128, PackedMacroN>();
     default:
       TORCH_CHECK(false, "SM70 Marlin ", quant_name,
                   " supports only group_size -1, 32, 64, or 128. Got ",
@@ -152,15 +152,16 @@ torch::Tensor dispatch_sm70_marlin_fp8_group_size(Launcher const& launcher,
                                                   int64_t group_size) {
   switch (group_size) {
     case -1:
-      return launcher.template operator()<CtaM, CtaN, CtaK, Warps, WarpM,
-                                          WarpN, WarpK, -1, PackedMacroN>();
+      return launcher.template operator()<CtaM, CtaN, CtaK, Warps, WarpM, WarpN,
+                                          WarpK, -1, PackedMacroN>();
     case 128:
-      return launcher.template operator()<CtaM, CtaN, CtaK, Warps, WarpM,
-                                          WarpN, WarpK, 128, PackedMacroN>();
+      return launcher.template operator()<CtaM, CtaN, CtaK, Warps, WarpM, WarpN,
+                                          WarpK, 128, PackedMacroN>();
     default:
-      TORCH_CHECK(false,
-                  "SM70 Marlin fp8_e4m3 supports only group_size -1 or 128. Got ",
-                  group_size, ".");
+      TORCH_CHECK(
+          false,
+          "SM70 Marlin fp8_e4m3 supports only group_size -1 or 128. Got ",
+          group_size, ".");
   }
   return torch::Tensor();
 }
@@ -175,58 +176,57 @@ torch::Tensor dispatch_sm70_marlin_cta_geometry(Launcher const& launcher,
     return launcher.template operator()<CM, CN, CK, W, WM, WN, WK, PMN>(); \
   }
 
-#define DISPATCH_SM70_GEOMETRY(CM, CN, CK, W, WM, WN, WK, PMN)             \
-  if (geometry.cta_m == CM && geometry.cta_n == CN &&                      \
-      geometry.cta_k == CK && geometry.warps == W &&                       \
-      geometry.warp_m == WM && geometry.warp_n == WN &&                    \
-      geometry.warp_k == WK) {                                             \
-    DISPATCH_SM70_PACKED_MACRO_N(CM, CN, CK, W, WM, WN, WK, PMN)           \
+#define DISPATCH_SM70_GEOMETRY(CM, CN, CK, W, WM, WN, WK, PMN)                 \
+  if (geometry.cta_m == CM && geometry.cta_n == CN && geometry.cta_k == CK &&  \
+      geometry.warps == W && geometry.warp_m == WM && geometry.warp_n == WN && \
+      geometry.warp_k == WK) {                                                 \
+    DISPATCH_SM70_PACKED_MACRO_N(CM, CN, CK, W, WM, WN, WK, PMN)               \
   }
 
-#define FOR_EACH_SM70_GEOMETRY(M)                                         \
-  M(32, 64, 32, 4, 32, 32, 16, 128)                                       \
-  M(32, 64, 32, 4, 32, 32, 16, 256)                                       \
-  M(32, 64, 64, 4, 32, 32, 32, 128)                                       \
-  M(32, 64, 64, 4, 32, 32, 32, 256)                                       \
-  M(32, 64, 64, 4, 32, 64, 16, 128)                                       \
-  M(32, 64, 64, 4, 32, 64, 16, 256)                                       \
-  M(32, 64, 128, 4, 32, 64, 32, 128)                                      \
-  M(32, 64, 128, 4, 32, 64, 32, 256)                                      \
-  M(32, 128, 32, 4, 32, 32, 32, 128)                                      \
-  M(32, 128, 32, 4, 32, 32, 32, 256)                                      \
-  M(32, 128, 64, 4, 32, 64, 32, 128)                                      \
-  M(32, 128, 64, 4, 32, 64, 32, 256)                                      \
-  M(32, 128, 64, 8, 32, 32, 32, 128)                                      \
-  M(32, 128, 64, 8, 32, 32, 32, 256)                                      \
-  M(32, 128, 128, 8, 32, 64, 32, 128)                                     \
-  M(32, 128, 128, 8, 32, 64, 32, 256)                                     \
-  M(32, 256, 32, 4, 32, 64, 32, 256)                                      \
-  M(32, 256, 64, 8, 32, 64, 32, 256)                                      \
-  M(64, 64, 32, 4, 32, 32, 32, 64)                                        \
-  M(64, 64, 32, 4, 32, 32, 32, 128)                                       \
-  M(64, 64, 32, 4, 32, 32, 32, 256)                                       \
-  M(64, 64, 32, 4, 64, 32, 16, 128)                                       \
-  M(64, 64, 32, 4, 64, 32, 16, 256)                                       \
-  M(64, 64, 64, 4, 32, 64, 32, 128)                                       \
-  M(64, 64, 64, 4, 32, 64, 32, 256)                                       \
-  M(64, 64, 64, 4, 64, 32, 32, 128)                                       \
-  M(64, 64, 64, 4, 64, 32, 32, 256)                                       \
-  M(64, 64, 64, 4, 64, 64, 16, 128)                                       \
-  M(64, 64, 64, 4, 64, 64, 16, 256)                                       \
-  M(64, 128, 32, 4, 32, 64, 32, 128)                                      \
-  M(64, 128, 32, 4, 32, 64, 32, 256)                                      \
-  M(64, 128, 32, 4, 64, 32, 32, 128)                                      \
-  M(64, 128, 32, 4, 64, 32, 32, 256)                                      \
-  M(64, 128, 128, 8, 64, 64, 32, 128)                                     \
-  M(64, 128, 128, 8, 64, 64, 32, 256)                                     \
-  M(128, 64, 32, 4, 32, 64, 32, 128)                                      \
-  M(128, 64, 32, 4, 32, 64, 32, 256)                                      \
-  M(128, 64, 128, 8, 64, 64, 32, 128)                                     \
-  M(128, 64, 128, 8, 64, 64, 32, 256)                                     \
-  M(128, 128, 32, 4, 64, 64, 32, 128)                                     \
-  M(128, 128, 32, 4, 64, 64, 32, 256)                                     \
-  M(128, 128, 64, 8, 64, 64, 32, 128)                                     \
-  M(128, 128, 64, 8, 64, 64, 32, 256)                                     \
+#define FOR_EACH_SM70_GEOMETRY(M)     \
+  M(32, 64, 32, 4, 32, 32, 16, 128)   \
+  M(32, 64, 32, 4, 32, 32, 16, 256)   \
+  M(32, 64, 64, 4, 32, 32, 32, 128)   \
+  M(32, 64, 64, 4, 32, 32, 32, 256)   \
+  M(32, 64, 64, 4, 32, 64, 16, 128)   \
+  M(32, 64, 64, 4, 32, 64, 16, 256)   \
+  M(32, 64, 128, 4, 32, 64, 32, 128)  \
+  M(32, 64, 128, 4, 32, 64, 32, 256)  \
+  M(32, 128, 32, 4, 32, 32, 32, 128)  \
+  M(32, 128, 32, 4, 32, 32, 32, 256)  \
+  M(32, 128, 64, 4, 32, 64, 32, 128)  \
+  M(32, 128, 64, 4, 32, 64, 32, 256)  \
+  M(32, 128, 64, 8, 32, 32, 32, 128)  \
+  M(32, 128, 64, 8, 32, 32, 32, 256)  \
+  M(32, 128, 128, 8, 32, 64, 32, 128) \
+  M(32, 128, 128, 8, 32, 64, 32, 256) \
+  M(32, 256, 32, 4, 32, 64, 32, 256)  \
+  M(32, 256, 64, 8, 32, 64, 32, 256)  \
+  M(64, 64, 32, 4, 32, 32, 32, 64)    \
+  M(64, 64, 32, 4, 32, 32, 32, 128)   \
+  M(64, 64, 32, 4, 32, 32, 32, 256)   \
+  M(64, 64, 32, 4, 64, 32, 16, 128)   \
+  M(64, 64, 32, 4, 64, 32, 16, 256)   \
+  M(64, 64, 64, 4, 32, 64, 32, 128)   \
+  M(64, 64, 64, 4, 32, 64, 32, 256)   \
+  M(64, 64, 64, 4, 64, 32, 32, 128)   \
+  M(64, 64, 64, 4, 64, 32, 32, 256)   \
+  M(64, 64, 64, 4, 64, 64, 16, 128)   \
+  M(64, 64, 64, 4, 64, 64, 16, 256)   \
+  M(64, 128, 32, 4, 32, 64, 32, 128)  \
+  M(64, 128, 32, 4, 32, 64, 32, 256)  \
+  M(64, 128, 32, 4, 64, 32, 32, 128)  \
+  M(64, 128, 32, 4, 64, 32, 32, 256)  \
+  M(64, 128, 128, 8, 64, 64, 32, 128) \
+  M(64, 128, 128, 8, 64, 64, 32, 256) \
+  M(128, 64, 32, 4, 32, 64, 32, 128)  \
+  M(128, 64, 32, 4, 32, 64, 32, 256)  \
+  M(128, 64, 128, 8, 64, 64, 32, 128) \
+  M(128, 64, 128, 8, 64, 64, 32, 256) \
+  M(128, 128, 32, 4, 64, 64, 32, 128) \
+  M(128, 128, 32, 4, 64, 64, 32, 256) \
+  M(128, 128, 64, 8, 64, 64, 32, 128) \
+  M(128, 128, 64, 8, 64, 64, 32, 256) \
   M(128, 256, 32, 8, 64, 64, 32, 256)
 
   FOR_EACH_SM70_GEOMETRY(DISPATCH_SM70_GEOMETRY)
@@ -261,8 +261,8 @@ torch::Tensor dispatch_sm70_marlin_geometry(Launcher const& launcher,
                                             int64_t group_size,
                                             char const* quant_name) {
   return dispatch_sm70_marlin_cta_geometry(
-      Sm70MarlinGroupSizeDispatchLauncher<Launcher>{
-          launcher, group_size, quant_name},
+      Sm70MarlinGroupSizeDispatchLauncher<Launcher>{launcher, group_size,
+                                                    quant_name},
       geometry, packed_macro_n, quant_name);
 }
 
@@ -300,8 +300,8 @@ torch::Tensor dispatch_sm70_marlin_geometry_with_group32(
     Launcher const& launcher, Sm70CtaGeometry geometry, int packed_macro_n,
     int64_t group_size, char const* quant_name) {
   return dispatch_sm70_marlin_cta_geometry(
-      Sm70MarlinGroupSize32DispatchLauncher<Launcher>{
-          launcher, group_size, quant_name},
+      Sm70MarlinGroupSize32DispatchLauncher<Launcher>{launcher, group_size,
+                                                      quant_name},
       geometry, packed_macro_n, quant_name);
 }
 
@@ -339,8 +339,8 @@ struct Sm70MarlinFixedGroupDispatchLauncher {
             int WarpK, int PackedMacroN>
   torch::Tensor operator()() const {
     return dispatch_sm70_marlin_fixed_group_size<
-        CtaM, CtaN, CtaK, Warps, WarpM, WarpN, WarpK, GroupSize,
-        PackedMacroN>(inner, group_size, quant_name);
+        CtaM, CtaN, CtaK, Warps, WarpM, WarpN, WarpK, GroupSize, PackedMacroN>(
+        inner, group_size, quant_name);
   }
 };
 

--- a/csrc/quantization/marlin/sm70_marlin_iterator_utils.cuh
+++ b/csrc/quantization/marlin/sm70_marlin_iterator_utils.cuh
@@ -30,23 +30,23 @@ struct QwordVector<4> {
 template <int ContiguousWords>
 CUTLASS_DEVICE typename QwordVector<ContiguousWords>::Type load_qword_vector(
     uint32_t const* ptr) {
-  static_assert(ContiguousWords == 1 || ContiguousWords == 2 ||
-                    ContiguousWords == 4,
-                "SM70 qword vector load supports 1, 2, or 4 words.");
+  static_assert(
+      ContiguousWords == 1 || ContiguousWords == 2 || ContiguousWords == 4,
+      "SM70 qword vector load supports 1, 2, or 4 words.");
   if constexpr (ContiguousWords == 1) {
     return *ptr;
   } else {
-    return *reinterpret_cast<typename QwordVector<ContiguousWords>::Type const*>(
-        ptr);
+    return *reinterpret_cast<
+        typename QwordVector<ContiguousWords>::Type const*>(ptr);
   }
 }
 
 template <int ContiguousWords>
 CUTLASS_DEVICE uint32_t qword_from_vector(
     typename QwordVector<ContiguousWords>::Type const& words, int c) {
-  static_assert(ContiguousWords == 1 || ContiguousWords == 2 ||
-                    ContiguousWords == 4,
-                "SM70 qword vector access supports 1, 2, or 4 words.");
+  static_assert(
+      ContiguousWords == 1 || ContiguousWords == 2 || ContiguousWords == 4,
+      "SM70 qword vector access supports 1, 2, or 4 words.");
   if constexpr (ContiguousWords == 1) {
     return words;
   } else {
@@ -68,9 +68,9 @@ CUTLASS_DEVICE uint32_t qword_from_vector(uint2 const& words, int c) {
 template <int PackedMacroN>
 CUTLASS_DEVICE int u4_packed_macro_n_qweight_offset_from_logical(
     int size_n, int logical_k, int logical_n) {
-  static_assert(PackedMacroN == 64 || PackedMacroN == 128 ||
-                    PackedMacroN == 256,
-                "SM70 Marlin packed macro-N must be 64, 128, or 256.");
+  static_assert(
+      PackedMacroN == 64 || PackedMacroN == 128 || PackedMacroN == 256,
+      "SM70 Marlin packed macro-N must be 64, 128, or 256.");
   constexpr int kGroupTiles = PackedMacroN / kQuantTileN;
   int const k_tile = logical_k / kQuantTileK;
   int const local_k = logical_k - k_tile * kQuantTileK;
@@ -89,9 +89,9 @@ CUTLASS_DEVICE int u4_packed_macro_n_qweight_offset_from_logical(
 template <int PackedMacroN>
 CUTLASS_DEVICE int u8_packed_macro_n_qweight_offset_from_logical(
     int size_n, int logical_k, int logical_n) {
-  static_assert(PackedMacroN == 64 || PackedMacroN == 128 ||
-                    PackedMacroN == 256,
-                "SM70 Marlin packed macro-N must be 64, 128, or 256.");
+  static_assert(
+      PackedMacroN == 64 || PackedMacroN == 128 || PackedMacroN == 256,
+      "SM70 Marlin packed macro-N must be 64, 128, or 256.");
   constexpr int kGroupTiles = PackedMacroN / kQuantTileN;
   int const k_tile = logical_k / kQuantTileK;
   int const local_k = logical_k - k_tile * kQuantTileK;
@@ -109,9 +109,9 @@ CUTLASS_DEVICE int u8_packed_macro_n_qweight_offset_from_logical(
 
 template <int PackedMacroN>
 CUTLASS_DEVICE int u8_packed_macro_n_qweight_word_stride() {
-  static_assert(PackedMacroN == 64 || PackedMacroN == 128 ||
-                    PackedMacroN == 256,
-                "SM70 Marlin packed macro-N must be 64, 128, or 256.");
+  static_assert(
+      PackedMacroN == 64 || PackedMacroN == 128 || PackedMacroN == 256,
+      "SM70 Marlin packed macro-N must be 64, 128, or 256.");
   return PackedMacroN / kQuantTileN;
 }
 

--- a/csrc/quantization/marlin/sm70_marlin_mma.cuh
+++ b/csrc/quantization/marlin/sm70_marlin_mma.cuh
@@ -7,17 +7,16 @@
 
 namespace marlin::sm70 {
 
-template <
-    typename Shape_, typename IteratorA_, typename SmemIteratorA_,
-    typename IteratorB_, typename SmemIteratorB_, typename ElementC_,
-    typename LayoutC_, typename Policy_,
-    typename TransformA_ = cutlass::NumericArrayConverter<
-        typename SmemIteratorA_::Element, typename IteratorA_::Element,
-        IteratorA_::Fragment::kElements>,
-    typename TransformB_ = cutlass::NumericArrayConverter<
-        typename SmemIteratorB_::Element, typename IteratorB_::Element,
-        IteratorB_::Fragment::kElements>,
-    typename Enable = bool>
+template <typename Shape_, typename IteratorA_, typename SmemIteratorA_,
+          typename IteratorB_, typename SmemIteratorB_, typename ElementC_,
+          typename LayoutC_, typename Policy_,
+          typename TransformA_ = cutlass::NumericArrayConverter<
+              typename SmemIteratorA_::Element, typename IteratorA_::Element,
+              IteratorA_::Fragment::kElements>,
+          typename TransformB_ = cutlass::NumericArrayConverter<
+              typename SmemIteratorB_::Element, typename IteratorB_::Element,
+              IteratorB_::Fragment::kElements>,
+          typename Enable = bool>
 class Sm70MarlinMmaPipelined
     : public cutlass::gemm::threadblock::MmaBase<Shape_, Policy_, 2> {
  public:
@@ -106,10 +105,10 @@ class Sm70MarlinMmaPipelined
 
  public:
   CUTLASS_DEVICE
-  Sm70MarlinMmaPipelined(
-      typename Base::SharedStorage& shared_storage, int thread_idx,
-      int warp_idx, int lane_idx, TransformA transform_A = TransformA(),
-      TransformB transform_B = TransformB())
+  Sm70MarlinMmaPipelined(typename Base::SharedStorage& shared_storage,
+                         int thread_idx, int warp_idx, int lane_idx,
+                         TransformA transform_A = TransformA(),
+                         TransformB transform_B = TransformB())
       : Base(shared_storage, thread_idx, warp_idx, lane_idx),
         smem_iterator_A_(shared_storage.operand_A_ref(), thread_idx),
         smem_iterator_B_(shared_storage.operand_B_ref(), thread_idx),
@@ -154,12 +153,12 @@ class Sm70MarlinMmaPipelined
       this->smem_iterator_B_.add_tile_offset({-Base::kStages, 0});
 
       if constexpr (Policy::kPartitionsK > 1) {
-        add_warp_tile_k_group_offset(
-            (Policy::kPartitionsK - 1) * Base::kWarpGemmIterations);
+        add_warp_tile_k_group_offset((Policy::kPartitionsK - 1) *
+                                     Base::kWarpGemmIterations);
       }
     } else {
-      add_warp_tile_k_group_offset(
-          -(Policy::kPartitionsK + 1) * Base::kWarpGemmIterations);
+      add_warp_tile_k_group_offset(-(Policy::kPartitionsK + 1) *
+                                   Base::kWarpGemmIterations);
     }
 
     smem_write_stage_idx ^= 1;
@@ -222,10 +221,10 @@ class Sm70MarlinMmaPipelined
           advance_smem_stages();
         }
 
-        this->warp_tile_iterator_A_.set_kgroup_index(
-            (warp_mma_k + 1) % Base::kWarpGemmIterations);
-        this->warp_tile_iterator_B_.set_kgroup_index(
-            (warp_mma_k + 1) % Base::kWarpGemmIterations);
+        this->warp_tile_iterator_A_.set_kgroup_index((warp_mma_k + 1) %
+                                                     Base::kWarpGemmIterations);
+        this->warp_tile_iterator_B_.set_kgroup_index((warp_mma_k + 1) %
+                                                     Base::kWarpGemmIterations);
 
         this->warp_tile_iterator_A_.load(warp_frag_A[(warp_mma_k + 1) % 2]);
         this->warp_tile_iterator_B_.load(warp_frag_B[(warp_mma_k + 1) % 2]);

--- a/csrc/quantization/marlin/sm70_marlin_mxfp4_gemm.cu
+++ b/csrc/quantization/marlin/sm70_marlin_mxfp4_gemm.cu
@@ -21,23 +21,23 @@
 #include "cutlass/layout/tensor_op_multiplicand_sm70.h"
 #include "cutlass/transform/threadblock/predicated_tile_iterator.h"
 
-using marlin::sm70::Sm70CtaGeometry;
-using marlin::sm70::Sm70AtomicFp16Epilogue;
-using marlin::sm70::Sm70MarlinGemmTraits;
-using marlin::sm70::Sm70SplitKPartition;
-using marlin::sm70::validate_sm70_marlin_dense_cta_geometry_supported;
-using marlin::sm70::validate_sm70_marlin_dense_cta_n_alignment;
 using marlin::sm70::configure_sm70_dynamic_smem;
 using marlin::sm70::dispatch_sm70_marlin_fixed_group_geometry;
 using marlin::sm70::kQuantTileK;
 using marlin::sm70::kQuantTileN;
-using marlin::sm70::sm70_marlin_dense_auto_params;
 using marlin::sm70::load_qword_vector;
 using marlin::sm70::qword_from_vector;
-using marlin::sm70::sm70_marlin_cta_grid;
 using marlin::sm70::sm70_active_split_k;
+using marlin::sm70::sm70_marlin_cta_grid;
+using marlin::sm70::sm70_marlin_dense_auto_params;
 using marlin::sm70::sm70_splitk_partition;
+using marlin::sm70::Sm70AtomicFp16Epilogue;
+using marlin::sm70::Sm70CtaGeometry;
+using marlin::sm70::Sm70MarlinGemmTraits;
+using marlin::sm70::Sm70SplitKPartition;
 using marlin::sm70::u4_packed_macro_n_qweight_offset_from_logical;
+using marlin::sm70::validate_sm70_marlin_dense_cta_geometry_supported;
+using marlin::sm70::validate_sm70_marlin_dense_cta_n_alignment;
 
 namespace {
 
@@ -76,7 +76,8 @@ void dequant_e8m0_scales_to_half2(int q, half2* scale_cache) {
   *reinterpret_cast<uint2*>(scale_cache) = vec_res;
 }
 
-template <typename Shape_, typename ThreadMap_, int GroupSize_, int PackedMacroN_>
+template <typename Shape_, typename ThreadMap_, int GroupSize_,
+          int PackedMacroN_>
 class Sm70Mxfp4IteratorB {
  public:
   using Shape = Shape_;
@@ -84,12 +85,11 @@ class Sm70Mxfp4IteratorB {
   static int const kGroupSize = GroupSize_;
   static int const kPackedMacroN = PackedMacroN_;
   using Element = cutlass::half_t;
-  using Fragment = cutlass::Array<
-      Element, ThreadMap::Iterations::kCount * ThreadMap::kElementsPerAccess>;
+  using Fragment = cutlass::Array<Element, ThreadMap::Iterations::kCount *
+                                               ThreadMap::kElementsPerAccess>;
   static_assert(Shape::kN == 64 || Shape::kN == 128 || Shape::kN == 256,
                 "SM70 Marlin MXFP4 IteratorB expects CTA_N in {64, 128, 256}.");
-  static_assert(ThreadMap::Iterations::kContiguous ==
-                    Shape::kN / kQuantTileN,
+  static_assert(ThreadMap::Iterations::kContiguous == Shape::kN / kQuantTileN,
                 "SM70 Marlin MXFP4 IteratorB expects one contiguous iteration "
                 "per 64-column quant tile.");
   static_assert(ThreadMap::Delta::kContiguous == kQuantTileN,
@@ -98,7 +98,8 @@ class Sm70Mxfp4IteratorB {
                 "SM70 Marlin MXFP4 IteratorB expects one packed FP4 word per "
                 "access.");
   static_assert(ThreadMap::Iterations::kStrided >= 1,
-                "SM70 Marlin U4-family IteratorB expects one or more strided iterations.");
+                "SM70 Marlin U4-family IteratorB expects one or more strided "
+                "iterations.");
   struct Params {
     int size_n;
     int aligned_initial_k_step;
@@ -180,8 +181,8 @@ class Sm70Mxfp4IteratorB {
   CUTLASS_DEVICE
   static int qweight_offset_from_logical(Params const& params, int logical_k,
                                          int logical_n) {
-    return u4_packed_macro_n_qweight_offset_from_logical<kPackedMacroN>(params.size_n, logical_k,
-                                                     logical_n);
+    return u4_packed_macro_n_qweight_offset_from_logical<kPackedMacroN>(
+        params.size_n, logical_k, logical_n);
   }
 
   CUTLASS_DEVICE
@@ -200,14 +201,12 @@ class Sm70Mxfp4IteratorB {
     CUTLASS_PRAGMA_UNROLL
     for (int s = 0; s < ThreadMap::Iterations::kStrided; ++s) {
       int const logical_k =
-          k_offset_ + thread_offset_.strided() +
-          s * ThreadMap::Delta::kStrided;
+          k_offset_ + thread_offset_.strided() + s * ThreadMap::Delta::kStrided;
       int const group = scale_group(logical_k);
       CUTLASS_PRAGMA_UNROLL
       for (int c = 0; c < ThreadMap::Iterations::kContiguous; ++c) {
-        int const cache_n =
-            n_offset_ + thread_offset_.contiguous() +
-            c * ThreadMap::Delta::kContiguous;
+        int const cache_n = n_offset_ + thread_offset_.contiguous() +
+                            c * ThreadMap::Delta::kContiguous;
         int const cache_index = c + s * ThreadMap::Iterations::kContiguous;
         cache_metadata_e8m0_scales(cache_index, group, cache_n);
       }
@@ -260,9 +259,11 @@ class Sm70Mxfp4IteratorB {
           frag_vec[3] = __hmul2(deq[1], scale_vec[3]);
         }
       } else {
-        static_assert(ThreadMap::Iterations::kContiguous == 1,
-                      "Unsupported SM70 Marlin MXFP4 contiguous iteration count.");
-        uint32_t const qword = load_qword_vector<1>(qweight_ + qweight_base_offset_);
+        static_assert(
+            ThreadMap::Iterations::kContiguous == 1,
+            "Unsupported SM70 Marlin MXFP4 contiguous iteration count.");
+        uint32_t const qword =
+            load_qword_vector<1>(qweight_ + qweight_base_offset_);
         half2 const* scale_vec = cached_scales_;
 
         half2 deq[2];
@@ -280,14 +281,12 @@ class Sm70Mxfp4IteratorB {
       int const logical_n_base = n_offset_ + thread_offset_.contiguous();
       CUTLASS_PRAGMA_UNROLL
       for (int s = 0; s < ThreadMap::Iterations::kStrided; ++s) {
-        int const logical_k_s =
-            k_offset_ + thread_offset_.strided() +
-            s * ThreadMap::Delta::kStrided;
+        int const logical_k_s = k_offset_ + thread_offset_.strided() +
+                                s * ThreadMap::Delta::kStrided;
         int const qweight_base_s =
             qweight_offset_from_logical(params_, logical_k_s, logical_n_base);
         if constexpr (ThreadMap::Iterations::kContiguous == 4) {
-          auto const qwords =
-              load_qword_vector<4>(qweight_ + qweight_base_s);
+          auto const qwords = load_qword_vector<4>(qweight_ + qweight_base_s);
           CUTLASS_PRAGMA_UNROLL
           for (int c = 0; c < ThreadMap::Iterations::kContiguous; ++c) {
             constexpr int kAccess = ThreadMap::kElementsPerAccess;
@@ -308,8 +307,7 @@ class Sm70Mxfp4IteratorB {
             frag_vec[3] = __hmul2(deq[1], scale_vec[3]);
           }
         } else if constexpr (ThreadMap::Iterations::kContiguous == 2) {
-          auto const qwords =
-              load_qword_vector<2>(qweight_ + qweight_base_s);
+          auto const qwords = load_qword_vector<2>(qweight_ + qweight_base_s);
           CUTLASS_PRAGMA_UNROLL
           for (int c = 0; c < ThreadMap::Iterations::kContiguous; ++c) {
             constexpr int kAccess = ThreadMap::kElementsPerAccess;
@@ -330,9 +328,11 @@ class Sm70Mxfp4IteratorB {
             frag_vec[3] = __hmul2(deq[1], scale_vec[3]);
           }
         } else {
-          static_assert(ThreadMap::Iterations::kContiguous == 1,
-                        "Unsupported SM70 Marlin MXFP4 contiguous iteration count.");
-          uint32_t const qword = load_qword_vector<1>(qweight_ + qweight_base_s);
+          static_assert(
+              ThreadMap::Iterations::kContiguous == 1,
+              "Unsupported SM70 Marlin MXFP4 contiguous iteration count.");
+          uint32_t const qword =
+              load_qword_vector<1>(qweight_ + qweight_base_s);
           constexpr int kAccess = ThreadMap::kElementsPerAccess;
           int const frag_base = s * kAccess;
           half2 const* scale_vec = cached_scales_;
@@ -365,26 +365,25 @@ class Sm70Mxfp4IteratorB {
 
 struct Sm70Mxfp4GemmSpec {
   template <typename Shape, typename ThreadMap, int GroupSize, int PackedMacroN>
-  using IteratorB = Sm70Mxfp4IteratorB<Shape, ThreadMap, GroupSize, PackedMacroN>;
+  using IteratorB =
+      Sm70Mxfp4IteratorB<Shape, ThreadMap, GroupSize, PackedMacroN>;
 };
 
-template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM,
-          int WarpN, int WarpK, int GroupSize, int PackedMacroN>
+template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM, int WarpN,
+          int WarpK, int GroupSize, int PackedMacroN>
 using Sm70Mxfp4GemmTraits =
-    Sm70MarlinGemmTraits<Sm70Mxfp4GemmSpec, CtaM, CtaN, CtaK,
-                         Warps, WarpM, WarpN, WarpK, GroupSize, PackedMacroN>;
+    Sm70MarlinGemmTraits<Sm70Mxfp4GemmSpec, CtaM, CtaN, CtaK, Warps, WarpM,
+                         WarpN, WarpK, GroupSize, PackedMacroN>;
 
-template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM,
-          int WarpN, int WarpK, int GroupSize, int PackedMacroN>
-__global__ __launch_bounds__(Warps * 32, 1)
-void sm70_marlin_mxfp4_gemm_kernel(
+template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM, int WarpN,
+          int WarpK, int GroupSize, int PackedMacroN>
+__global__ __launch_bounds__(Warps * 32, 1) void sm70_marlin_mxfp4_gemm_kernel(
     cutlass::half_t const* __restrict__ a,
     uint32_t const* __restrict__ b_q_weight,
-    uint8_t const* __restrict__ b_scales,
-    cutlass::half_t* __restrict__ c, int m, int n, int k, int lda) {
-  using Traits =
-      Sm70Mxfp4GemmTraits<CtaM, CtaN, CtaK, Warps, WarpM,
-                                  WarpN, WarpK, GroupSize, PackedMacroN>;
+    uint8_t const* __restrict__ b_scales, cutlass::half_t* __restrict__ c,
+    int m, int n, int k, int lda) {
+  using Traits = Sm70Mxfp4GemmTraits<CtaM, CtaN, CtaK, Warps, WarpM, WarpN,
+                                     WarpK, GroupSize, PackedMacroN>;
   using Mma = typename Traits::Mma;
   using Epilogue = typename Traits::Epilogue;
 
@@ -404,10 +403,10 @@ void sm70_marlin_mxfp4_gemm_kernel(
   typename Traits::LayoutA layout_a(lda);
   typename Traits::LayoutC layout_c(n);
 
-  typename Mma::IteratorA iterator_A(
-      typename Mma::IteratorA::Params(layout_a),
-      const_cast<cutlass::half_t*>(a), cutlass::MatrixCoord(m, k), thread_idx,
-      tb_offset_A);
+  typename Mma::IteratorA iterator_A(typename Mma::IteratorA::Params(layout_a),
+                                     const_cast<cutlass::half_t*>(a),
+                                     cutlass::MatrixCoord(m, k), thread_idx,
+                                     tb_offset_A);
   typename Mma::IteratorB iterator_B(
       typename Mma::IteratorB::Params(k, n),
       reinterpret_cast<uint32_t const*>(b_q_weight),
@@ -432,16 +431,16 @@ void sm70_marlin_mxfp4_gemm_kernel(
   epilogue(output_op, iterator_D, accumulators, iterator_C);
 }
 
-template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM,
-          int WarpN, int WarpK, int GroupSize, int PackedMacroN>
-__global__ __launch_bounds__(Warps * 32, 1)
-void sm70_marlin_mxfp4_gemm_splitk_kernel(
+template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM, int WarpN,
+          int WarpK, int GroupSize, int PackedMacroN>
+__global__
+__launch_bounds__(Warps * 32, 1) void sm70_marlin_mxfp4_gemm_splitk_kernel(
     cutlass::half_t const* __restrict__ a,
     uint32_t const* __restrict__ b_q_weight,
-    uint8_t const* __restrict__ b_scales,
-    cutlass::half_t* __restrict__ c, int m, int n, int k, int lda, int requested_split_k) {
-  using Traits = Sm70Mxfp4GemmTraits<CtaM, CtaN, CtaK, Warps, WarpM,
-                                  WarpN, WarpK, GroupSize, PackedMacroN>;
+    uint8_t const* __restrict__ b_scales, cutlass::half_t* __restrict__ c,
+    int m, int n, int k, int lda, int requested_split_k) {
+  using Traits = Sm70Mxfp4GemmTraits<CtaM, CtaN, CtaK, Warps, WarpM, WarpN,
+                                     WarpK, GroupSize, PackedMacroN>;
   using Mma = typename Traits::Mma;
   using AtomicEpilogue = Sm70AtomicFp16Epilogue<Traits>;
 
@@ -452,14 +451,13 @@ void sm70_marlin_mxfp4_gemm_splitk_kernel(
   int const thread_idx = threadIdx.x;
   int const warp_idx = cutlass::canonical_warp_idx_sync();
   int const lane_idx = threadIdx.x % 32;
-  Sm70SplitKPartition const partition =
-      sm70_splitk_partition<GroupSize, CtaK>(k, requested_split_k, int(blockIdx.z));
+  Sm70SplitKPartition const partition = sm70_splitk_partition<GroupSize, CtaK>(
+      k, requested_split_k, int(blockIdx.z));
   if (partition.partition_k == 0) {
     return;
   }
 
-  cutlass::MatrixCoord tb_offset_A{int(blockIdx.x) * CtaM,
-                                   partition.k_begin};
+  cutlass::MatrixCoord tb_offset_A{int(blockIdx.x) * CtaM, partition.k_begin};
   cutlass::MatrixCoord tb_offset_B{partition.k_begin, int(blockIdx.y) * CtaN};
   cutlass::MatrixCoord tb_offset_C{int(blockIdx.x) * CtaM,
                                    int(blockIdx.y) * CtaN};
@@ -467,10 +465,10 @@ void sm70_marlin_mxfp4_gemm_splitk_kernel(
   typename Traits::LayoutA layout_a(lda);
   typename Traits::LayoutC layout_c(n);
 
-  typename Mma::IteratorA iterator_A(
-      typename Mma::IteratorA::Params(layout_a),
-      const_cast<cutlass::half_t*>(a), cutlass::MatrixCoord(m, k), thread_idx,
-      tb_offset_A);
+  typename Mma::IteratorA iterator_A(typename Mma::IteratorA::Params(layout_a),
+                                     const_cast<cutlass::half_t*>(a),
+                                     cutlass::MatrixCoord(m, k), thread_idx,
+                                     tb_offset_A);
   typename Mma::IteratorB iterator_B(
       typename Mma::IteratorB::Params(k, n),
       reinterpret_cast<uint32_t const*>(b_q_weight),
@@ -484,9 +482,8 @@ void sm70_marlin_mxfp4_gemm_splitk_kernel(
   mma(gemm_k_iterations, accumulators, iterator_A, iterator_B, accumulators);
 
   typename AtomicEpilogue::OutputTileIterator iterator_D(
-      typename AtomicEpilogue::OutputTileIterator::Params(layout_c),
-      c, cutlass::MatrixCoord(m, n),
-      thread_idx, tb_offset_C);
+      typename AtomicEpilogue::OutputTileIterator::Params(layout_c), c,
+      cutlass::MatrixCoord(m, n), thread_idx, tb_offset_C);
 
   AtomicEpilogue epilogue(shared_storage.epilogue, thread_idx, warp_idx,
                           lane_idx);
@@ -495,18 +492,20 @@ void sm70_marlin_mxfp4_gemm_splitk_kernel(
 
 }  // namespace
 
-template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM,
-          int WarpN, int WarpK, int GroupSize, int PackedMacroN>
-torch::Tensor launch_sm70_marlin_mxfp4_gemm(
-    torch::Tensor& a, torch::Tensor& c, torch::Tensor& b_q_weight,
-    torch::Tensor& b_scales, int64_t size_m, int64_t size_n, int64_t size_k,
-    int requested_split_k) {
+template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM, int WarpN,
+          int WarpK, int GroupSize, int PackedMacroN>
+torch::Tensor launch_sm70_marlin_mxfp4_gemm(torch::Tensor& a, torch::Tensor& c,
+                                            torch::Tensor& b_q_weight,
+                                            torch::Tensor& b_scales,
+                                            int64_t size_m, int64_t size_n,
+                                            int64_t size_k,
+                                            int requested_split_k) {
   auto kernel =
-      sm70_marlin_mxfp4_gemm_kernel<CtaM, CtaN, CtaK, Warps, WarpM, WarpN, WarpK,
-                  GroupSize, PackedMacroN>;
-  using SharedStorage = typename Sm70Mxfp4GemmTraits<
-      CtaM, CtaN, CtaK, Warps, WarpM, WarpN, WarpK, GroupSize,
-      PackedMacroN>::SharedStorage;
+      sm70_marlin_mxfp4_gemm_kernel<CtaM, CtaN, CtaK, Warps, WarpM, WarpN,
+                                    WarpK, GroupSize, PackedMacroN>;
+  using SharedStorage =
+      typename Sm70Mxfp4GemmTraits<CtaM, CtaN, CtaK, Warps, WarpM, WarpN, WarpK,
+                                   GroupSize, PackedMacroN>::SharedStorage;
   size_t smem_bytes = configure_sm70_dynamic_smem<SharedStorage>(kernel);
 
   dim3 block(Warps * 32);
@@ -526,19 +525,18 @@ torch::Tensor launch_sm70_marlin_mxfp4_gemm(
   }
 
   TORCH_CHECK(size_k % int64_t(CtaK) == 0,
-              "SM70 Marlin mxfp4 requires K divisible by CTA_K=",
-              CtaK, " for requested_split_k > 1. Got K=", size_k,
+              "SM70 Marlin mxfp4 requires K divisible by CTA_K=", CtaK,
+              " for requested_split_k > 1. Got K=", size_k,
               ", requested_split_k=", requested_split_k, ".");
 
-  auto split_kernel =
-      sm70_marlin_mxfp4_gemm_splitk_kernel<CtaM, CtaN, CtaK, Warps, WarpM, WarpN,
-                  WarpK, GroupSize, PackedMacroN>;
+  auto split_kernel = sm70_marlin_mxfp4_gemm_splitk_kernel<
+      CtaM, CtaN, CtaK, Warps, WarpM, WarpN, WarpK, GroupSize, PackedMacroN>;
   smem_bytes = configure_sm70_dynamic_smem<SharedStorage>(split_kernel);
 
   int64_t const numel = size_m * size_n;
-  C10_CUDA_CHECK(cudaMemsetAsync(
-      c.data_ptr<at::Half>(), 0,
-      static_cast<size_t>(numel) * sizeof(at::Half), stream));
+  C10_CUDA_CHECK(cudaMemsetAsync(c.data_ptr<at::Half>(), 0,
+                                 static_cast<size_t>(numel) * sizeof(at::Half),
+                                 stream));
 
   dim3 grid = sm70_marlin_cta_grid(size_m, size_n, CtaM, CtaN);
   int const active_split_k =
@@ -550,7 +548,8 @@ torch::Tensor launch_sm70_marlin_mxfp4_gemm(
       reinterpret_cast<uint8_t const*>(b_scales.data_ptr()),
       reinterpret_cast<cutlass::half_t*>(c.data_ptr<at::Half>()),
       static_cast<int>(size_m), static_cast<int>(size_n),
-      static_cast<int>(size_k), static_cast<int>(a.stride(0)), requested_split_k);
+      static_cast<int>(size_k), static_cast<int>(a.stride(0)),
+      requested_split_k);
   C10_CUDA_KERNEL_LAUNCH_CHECK();
 
   return c;
@@ -566,11 +565,11 @@ struct Sm70Mxfp4Launcher {
   int64_t size_k;
   int requested_split_k;
 
-  template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM,
-            int WarpN, int WarpK, int GroupSize, int PackedMacroN>
+  template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM, int WarpN,
+            int WarpK, int GroupSize, int PackedMacroN>
   torch::Tensor operator()() const {
-    return launch_sm70_marlin_mxfp4_gemm<CtaM, CtaN, CtaK, Warps, WarpM, WarpN, WarpK,
-                  GroupSize, PackedMacroN>(
+    return launch_sm70_marlin_mxfp4_gemm<CtaM, CtaN, CtaK, Warps, WarpM, WarpN,
+                                         WarpK, GroupSize, PackedMacroN>(
         a, c, b_q_weight, b_scales, size_m, size_n, size_k, requested_split_k);
   }
 };
@@ -582,14 +581,16 @@ torch::Tensor sm70_marlin_mxfp4_gemm(torch::Tensor& a, torch::Tensor& c,
                                      int64_t group_size) {
   c10::cuda::CUDAGuard device_guard(a.device());
 
-  auto const params = sm70_marlin_dense_auto_params(
-      "mxfp4", group_size, size_m, size_n, size_k);
+  auto const params = sm70_marlin_dense_auto_params("mxfp4", group_size, size_m,
+                                                    size_n, size_k);
   Sm70CtaGeometry const geometry = params.geometry;
-  validate_sm70_marlin_dense_cta_geometry_supported("SM70 Marlin mxfp4", geometry);
-  validate_sm70_marlin_dense_cta_n_alignment("SM70 Marlin mxfp4", geometry, size_n);
+  validate_sm70_marlin_dense_cta_geometry_supported("SM70 Marlin mxfp4",
+                                                    geometry);
+  validate_sm70_marlin_dense_cta_n_alignment("SM70 Marlin mxfp4", geometry,
+                                             size_n);
   Sm70Mxfp4Launcher const launcher{
-      a, c, b_q_weight, b_scales, size_m, size_n, size_k,
-      params.requested_split_k};
+      a,      c,      b_q_weight, b_scales,
+      size_m, size_n, size_k,     params.requested_split_k};
   return dispatch_sm70_marlin_fixed_group_geometry<32>(
       launcher, geometry, params.packed_macro_n, group_size, "mxfp4");
 }

--- a/csrc/quantization/marlin/sm70_marlin_nvfp4_gemm.cu
+++ b/csrc/quantization/marlin/sm70_marlin_nvfp4_gemm.cu
@@ -21,29 +21,30 @@
 #include "cutlass/layout/tensor_op_multiplicand_sm70.h"
 #include "cutlass/transform/threadblock/predicated_tile_iterator.h"
 
-using marlin::sm70::Sm70CtaGeometry;
-using marlin::sm70::Sm70AtomicFp16Epilogue;
-using marlin::sm70::Sm70MarlinGemmTraits;
-using marlin::sm70::Sm70SplitKPartition;
-using marlin::sm70::validate_sm70_marlin_dense_cta_geometry_supported;
-using marlin::sm70::validate_sm70_marlin_dense_cta_n_alignment;
 using marlin::sm70::configure_sm70_dynamic_smem;
 using marlin::sm70::dispatch_sm70_marlin_fixed_group_geometry;
 using marlin::sm70::kQuantTileK;
 using marlin::sm70::kQuantTileN;
-using marlin::sm70::sm70_marlin_dense_auto_params;
 using marlin::sm70::load_qword_vector;
 using marlin::sm70::qword_from_vector;
-using marlin::sm70::sm70_marlin_cta_grid;
 using marlin::sm70::sm70_active_split_k;
+using marlin::sm70::sm70_marlin_cta_grid;
+using marlin::sm70::sm70_marlin_dense_auto_params;
 using marlin::sm70::sm70_splitk_partition;
+using marlin::sm70::Sm70AtomicFp16Epilogue;
+using marlin::sm70::Sm70CtaGeometry;
+using marlin::sm70::Sm70MarlinGemmTraits;
+using marlin::sm70::Sm70SplitKPartition;
 using marlin::sm70::u4_packed_macro_n_qweight_offset_from_logical;
+using marlin::sm70::validate_sm70_marlin_dense_cta_geometry_supported;
+using marlin::sm70::validate_sm70_marlin_dense_cta_n_alignment;
 
 namespace {
 
 constexpr int kNvfp4ValuesPerWord = 8;
 
-template <typename Shape_, typename ThreadMap_, int GroupSize_, int PackedMacroN_>
+template <typename Shape_, typename ThreadMap_, int GroupSize_,
+          int PackedMacroN_>
 class Sm70Nvfp4IteratorB {
  public:
   using Shape = Shape_;
@@ -51,12 +52,11 @@ class Sm70Nvfp4IteratorB {
   static int const kGroupSize = GroupSize_;
   static int const kPackedMacroN = PackedMacroN_;
   using Element = cutlass::half_t;
-  using Fragment = cutlass::Array<
-      Element, ThreadMap::Iterations::kCount * ThreadMap::kElementsPerAccess>;
+  using Fragment = cutlass::Array<Element, ThreadMap::Iterations::kCount *
+                                               ThreadMap::kElementsPerAccess>;
   static_assert(Shape::kN == 64 || Shape::kN == 128 || Shape::kN == 256,
                 "SM70 Marlin NVFP4 IteratorB expects CTA_N in {64, 128, 256}.");
-  static_assert(ThreadMap::Iterations::kContiguous ==
-                    Shape::kN / kQuantTileN,
+  static_assert(ThreadMap::Iterations::kContiguous == Shape::kN / kQuantTileN,
                 "SM70 Marlin NVFP4 IteratorB expects one contiguous iteration "
                 "per 64-column quant tile.");
   static_assert(ThreadMap::Delta::kContiguous == kQuantTileN,
@@ -65,7 +65,8 @@ class Sm70Nvfp4IteratorB {
                 "SM70 Marlin NVFP4 IteratorB expects one packed FP4 word per "
                 "access.");
   static_assert(ThreadMap::Iterations::kStrided >= 1,
-                "SM70 Marlin U4-family IteratorB expects one or more strided iterations.");
+                "SM70 Marlin U4-family IteratorB expects one or more strided "
+                "iterations.");
   struct Params {
     int size_n;
     int aligned_initial_k_step;
@@ -147,8 +148,8 @@ class Sm70Nvfp4IteratorB {
   CUTLASS_DEVICE
   static int qweight_offset_from_logical(Params const& params, int logical_k,
                                          int logical_n) {
-    return u4_packed_macro_n_qweight_offset_from_logical<kPackedMacroN>(params.size_n, logical_k,
-                                                     logical_n);
+    return u4_packed_macro_n_qweight_offset_from_logical<kPackedMacroN>(
+        params.size_n, logical_k, logical_n);
   }
 
   CUTLASS_DEVICE
@@ -168,14 +169,12 @@ class Sm70Nvfp4IteratorB {
     CUTLASS_PRAGMA_UNROLL
     for (int s = 0; s < ThreadMap::Iterations::kStrided; ++s) {
       int const logical_k =
-          k_offset_ + thread_offset_.strided() +
-          s * ThreadMap::Delta::kStrided;
+          k_offset_ + thread_offset_.strided() + s * ThreadMap::Delta::kStrided;
       int const group = scale_group(logical_k);
       CUTLASS_PRAGMA_UNROLL
       for (int c = 0; c < ThreadMap::Iterations::kContiguous; ++c) {
-        int const cache_n =
-            n_offset_ + thread_offset_.contiguous() +
-            c * ThreadMap::Delta::kContiguous;
+        int const cache_n = n_offset_ + thread_offset_.contiguous() +
+                            c * ThreadMap::Delta::kContiguous;
         int const cache_index = c + s * ThreadMap::Iterations::kContiguous;
         cache_metadata_fp8_scales(cache_index, group, cache_n);
       }
@@ -228,9 +227,11 @@ class Sm70Nvfp4IteratorB {
           frag_vec[3] = __hmul2(deq[1], scale_vec[3]);
         }
       } else {
-        static_assert(ThreadMap::Iterations::kContiguous == 1,
-                      "Unsupported SM70 Marlin NVFP4 contiguous iteration count.");
-        uint32_t const qword = load_qword_vector<1>(qweight_ + qweight_base_offset_);
+        static_assert(
+            ThreadMap::Iterations::kContiguous == 1,
+            "Unsupported SM70 Marlin NVFP4 contiguous iteration count.");
+        uint32_t const qword =
+            load_qword_vector<1>(qweight_ + qweight_base_offset_);
         half2 const* scale_vec = cached_scales_;
 
         half2 deq[2];
@@ -248,14 +249,12 @@ class Sm70Nvfp4IteratorB {
       int const logical_n_base = n_offset_ + thread_offset_.contiguous();
       CUTLASS_PRAGMA_UNROLL
       for (int s = 0; s < ThreadMap::Iterations::kStrided; ++s) {
-        int const logical_k_s =
-            k_offset_ + thread_offset_.strided() +
-            s * ThreadMap::Delta::kStrided;
+        int const logical_k_s = k_offset_ + thread_offset_.strided() +
+                                s * ThreadMap::Delta::kStrided;
         int const qweight_base_s =
             qweight_offset_from_logical(params_, logical_k_s, logical_n_base);
         if constexpr (ThreadMap::Iterations::kContiguous == 4) {
-          auto const qwords =
-              load_qword_vector<4>(qweight_ + qweight_base_s);
+          auto const qwords = load_qword_vector<4>(qweight_ + qweight_base_s);
           CUTLASS_PRAGMA_UNROLL
           for (int c = 0; c < ThreadMap::Iterations::kContiguous; ++c) {
             constexpr int kAccess = ThreadMap::kElementsPerAccess;
@@ -278,8 +277,7 @@ class Sm70Nvfp4IteratorB {
             frag_vec[3] = __hmul2(deq[1], scale_vec[3]);
           }
         } else if constexpr (ThreadMap::Iterations::kContiguous == 2) {
-          auto const qwords =
-              load_qword_vector<2>(qweight_ + qweight_base_s);
+          auto const qwords = load_qword_vector<2>(qweight_ + qweight_base_s);
           CUTLASS_PRAGMA_UNROLL
           for (int c = 0; c < ThreadMap::Iterations::kContiguous; ++c) {
             constexpr int kAccess = ThreadMap::kElementsPerAccess;
@@ -302,9 +300,11 @@ class Sm70Nvfp4IteratorB {
             frag_vec[3] = __hmul2(deq[1], scale_vec[3]);
           }
         } else {
-          static_assert(ThreadMap::Iterations::kContiguous == 1,
-                        "Unsupported SM70 Marlin NVFP4 contiguous iteration count.");
-          uint32_t const qword = load_qword_vector<1>(qweight_ + qweight_base_s);
+          static_assert(
+              ThreadMap::Iterations::kContiguous == 1,
+              "Unsupported SM70 Marlin NVFP4 contiguous iteration count.");
+          uint32_t const qword =
+              load_qword_vector<1>(qweight_ + qweight_base_s);
           constexpr int kAccess = ThreadMap::kElementsPerAccess;
           int const frag_base = s * kAccess;
           half2 const* scale_vec =
@@ -338,27 +338,26 @@ class Sm70Nvfp4IteratorB {
 
 struct Sm70Nvfp4GemmSpec {
   template <typename Shape, typename ThreadMap, int GroupSize, int PackedMacroN>
-  using IteratorB = Sm70Nvfp4IteratorB<Shape, ThreadMap, GroupSize, PackedMacroN>;
+  using IteratorB =
+      Sm70Nvfp4IteratorB<Shape, ThreadMap, GroupSize, PackedMacroN>;
 };
 
-template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM,
-          int WarpN, int WarpK, int GroupSize, int PackedMacroN>
+template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM, int WarpN,
+          int WarpK, int GroupSize, int PackedMacroN>
 using Sm70Nvfp4GemmTraits =
-    Sm70MarlinGemmTraits<Sm70Nvfp4GemmSpec, CtaM, CtaN, CtaK,
-                         Warps, WarpM, WarpN, WarpK, GroupSize, PackedMacroN>;
+    Sm70MarlinGemmTraits<Sm70Nvfp4GemmSpec, CtaM, CtaN, CtaK, Warps, WarpM,
+                         WarpN, WarpK, GroupSize, PackedMacroN>;
 
-template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM,
-          int WarpN, int WarpK, int GroupSize, int PackedMacroN>
-__global__ __launch_bounds__(Warps * 32, 1)
-void sm70_marlin_nvfp4_gemm_kernel(
+template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM, int WarpN,
+          int WarpK, int GroupSize, int PackedMacroN>
+__global__ __launch_bounds__(Warps * 32, 1) void sm70_marlin_nvfp4_gemm_kernel(
     cutlass::half_t const* __restrict__ a,
     uint32_t const* __restrict__ b_q_weight,
     uint8_t const* __restrict__ b_scales,
-    float const* __restrict__ global_scale,
-    cutlass::half_t* __restrict__ c, int m, int n, int k, int lda) {
-  using Traits =
-      Sm70Nvfp4GemmTraits<CtaM, CtaN, CtaK, Warps, WarpM,
-                                  WarpN, WarpK, GroupSize, PackedMacroN>;
+    float const* __restrict__ global_scale, cutlass::half_t* __restrict__ c,
+    int m, int n, int k, int lda) {
+  using Traits = Sm70Nvfp4GemmTraits<CtaM, CtaN, CtaK, Warps, WarpM, WarpN,
+                                     WarpK, GroupSize, PackedMacroN>;
   using Mma = typename Traits::Mma;
   using Epilogue = typename Traits::Epilogue;
 
@@ -378,10 +377,10 @@ void sm70_marlin_nvfp4_gemm_kernel(
   typename Traits::LayoutA layout_a(lda);
   typename Traits::LayoutC layout_c(n);
 
-  typename Mma::IteratorA iterator_A(
-      typename Mma::IteratorA::Params(layout_a),
-      const_cast<cutlass::half_t*>(a), cutlass::MatrixCoord(m, k), thread_idx,
-      tb_offset_A);
+  typename Mma::IteratorA iterator_A(typename Mma::IteratorA::Params(layout_a),
+                                     const_cast<cutlass::half_t*>(a),
+                                     cutlass::MatrixCoord(m, k), thread_idx,
+                                     tb_offset_A);
   typename Mma::IteratorB iterator_B(
       typename Mma::IteratorB::Params(k, n),
       reinterpret_cast<uint32_t const*>(b_q_weight),
@@ -406,17 +405,17 @@ void sm70_marlin_nvfp4_gemm_kernel(
   epilogue(output_op, iterator_D, accumulators, iterator_C);
 }
 
-template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM,
-          int WarpN, int WarpK, int GroupSize, int PackedMacroN>
-__global__ __launch_bounds__(Warps * 32, 1)
-void sm70_marlin_nvfp4_gemm_splitk_kernel(
+template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM, int WarpN,
+          int WarpK, int GroupSize, int PackedMacroN>
+__global__
+__launch_bounds__(Warps * 32, 1) void sm70_marlin_nvfp4_gemm_splitk_kernel(
     cutlass::half_t const* __restrict__ a,
     uint32_t const* __restrict__ b_q_weight,
     uint8_t const* __restrict__ b_scales,
-    float const* __restrict__ global_scale,
-    cutlass::half_t* __restrict__ c, int m, int n, int k, int lda, int requested_split_k) {
-  using Traits = Sm70Nvfp4GemmTraits<CtaM, CtaN, CtaK, Warps, WarpM,
-                                  WarpN, WarpK, GroupSize, PackedMacroN>;
+    float const* __restrict__ global_scale, cutlass::half_t* __restrict__ c,
+    int m, int n, int k, int lda, int requested_split_k) {
+  using Traits = Sm70Nvfp4GemmTraits<CtaM, CtaN, CtaK, Warps, WarpM, WarpN,
+                                     WarpK, GroupSize, PackedMacroN>;
   using Mma = typename Traits::Mma;
   using AtomicEpilogue = Sm70AtomicFp16Epilogue<Traits>;
 
@@ -427,14 +426,13 @@ void sm70_marlin_nvfp4_gemm_splitk_kernel(
   int const thread_idx = threadIdx.x;
   int const warp_idx = cutlass::canonical_warp_idx_sync();
   int const lane_idx = threadIdx.x % 32;
-  Sm70SplitKPartition const partition =
-      sm70_splitk_partition<GroupSize, CtaK>(k, requested_split_k, int(blockIdx.z));
+  Sm70SplitKPartition const partition = sm70_splitk_partition<GroupSize, CtaK>(
+      k, requested_split_k, int(blockIdx.z));
   if (partition.partition_k == 0) {
     return;
   }
 
-  cutlass::MatrixCoord tb_offset_A{int(blockIdx.x) * CtaM,
-                                   partition.k_begin};
+  cutlass::MatrixCoord tb_offset_A{int(blockIdx.x) * CtaM, partition.k_begin};
   cutlass::MatrixCoord tb_offset_B{partition.k_begin, int(blockIdx.y) * CtaN};
   cutlass::MatrixCoord tb_offset_C{int(blockIdx.x) * CtaM,
                                    int(blockIdx.y) * CtaN};
@@ -442,10 +440,10 @@ void sm70_marlin_nvfp4_gemm_splitk_kernel(
   typename Traits::LayoutA layout_a(lda);
   typename Traits::LayoutC layout_c(n);
 
-  typename Mma::IteratorA iterator_A(
-      typename Mma::IteratorA::Params(layout_a),
-      const_cast<cutlass::half_t*>(a), cutlass::MatrixCoord(m, k), thread_idx,
-      tb_offset_A);
+  typename Mma::IteratorA iterator_A(typename Mma::IteratorA::Params(layout_a),
+                                     const_cast<cutlass::half_t*>(a),
+                                     cutlass::MatrixCoord(m, k), thread_idx,
+                                     tb_offset_A);
   typename Mma::IteratorB iterator_B(
       typename Mma::IteratorB::Params(k, n),
       reinterpret_cast<uint32_t const*>(b_q_weight),
@@ -461,9 +459,8 @@ void sm70_marlin_nvfp4_gemm_splitk_kernel(
   accumulators = scale_accumulators(accumulators, global_scale[0]);
 
   typename AtomicEpilogue::OutputTileIterator iterator_D(
-      typename AtomicEpilogue::OutputTileIterator::Params(layout_c),
-      c, cutlass::MatrixCoord(m, n),
-      thread_idx, tb_offset_C);
+      typename AtomicEpilogue::OutputTileIterator::Params(layout_c), c,
+      cutlass::MatrixCoord(m, n), thread_idx, tb_offset_C);
 
   AtomicEpilogue epilogue(shared_storage.epilogue, thread_idx, warp_idx,
                           lane_idx);
@@ -472,18 +469,18 @@ void sm70_marlin_nvfp4_gemm_splitk_kernel(
 
 }  // namespace
 
-template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM,
-          int WarpN, int WarpK, int GroupSize, int PackedMacroN>
+template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM, int WarpN,
+          int WarpK, int GroupSize, int PackedMacroN>
 torch::Tensor launch_sm70_marlin_nvfp4_gemm(
     torch::Tensor& a, torch::Tensor& c, torch::Tensor& b_q_weight,
     torch::Tensor& b_scales, torch::Tensor& global_scale, int64_t size_m,
     int64_t size_n, int64_t size_k, int requested_split_k) {
   auto kernel =
-      sm70_marlin_nvfp4_gemm_kernel<CtaM, CtaN, CtaK, Warps, WarpM, WarpN, WarpK,
-                  GroupSize, PackedMacroN>;
-  using SharedStorage = typename Sm70Nvfp4GemmTraits<
-      CtaM, CtaN, CtaK, Warps, WarpM, WarpN, WarpK, GroupSize,
-      PackedMacroN>::SharedStorage;
+      sm70_marlin_nvfp4_gemm_kernel<CtaM, CtaN, CtaK, Warps, WarpM, WarpN,
+                                    WarpK, GroupSize, PackedMacroN>;
+  using SharedStorage =
+      typename Sm70Nvfp4GemmTraits<CtaM, CtaN, CtaK, Warps, WarpM, WarpN, WarpK,
+                                   GroupSize, PackedMacroN>::SharedStorage;
   size_t smem_bytes = configure_sm70_dynamic_smem<SharedStorage>(kernel);
 
   dim3 block(Warps * 32);
@@ -504,19 +501,18 @@ torch::Tensor launch_sm70_marlin_nvfp4_gemm(
   }
 
   TORCH_CHECK(size_k % int64_t(CtaK) == 0,
-              "SM70 Marlin nvfp4 requires K divisible by CTA_K=",
-              CtaK, " for requested_split_k > 1. Got K=", size_k,
+              "SM70 Marlin nvfp4 requires K divisible by CTA_K=", CtaK,
+              " for requested_split_k > 1. Got K=", size_k,
               ", requested_split_k=", requested_split_k, ".");
 
-  auto split_kernel =
-      sm70_marlin_nvfp4_gemm_splitk_kernel<CtaM, CtaN, CtaK, Warps, WarpM, WarpN,
-                  WarpK, GroupSize, PackedMacroN>;
+  auto split_kernel = sm70_marlin_nvfp4_gemm_splitk_kernel<
+      CtaM, CtaN, CtaK, Warps, WarpM, WarpN, WarpK, GroupSize, PackedMacroN>;
   smem_bytes = configure_sm70_dynamic_smem<SharedStorage>(split_kernel);
 
   int64_t const numel = size_m * size_n;
-  C10_CUDA_CHECK(cudaMemsetAsync(
-      c.data_ptr<at::Half>(), 0,
-      static_cast<size_t>(numel) * sizeof(at::Half), stream));
+  C10_CUDA_CHECK(cudaMemsetAsync(c.data_ptr<at::Half>(), 0,
+                                 static_cast<size_t>(numel) * sizeof(at::Half),
+                                 stream));
 
   dim3 grid = sm70_marlin_cta_grid(size_m, size_n, CtaM, CtaN);
   int const active_split_k =
@@ -529,7 +525,8 @@ torch::Tensor launch_sm70_marlin_nvfp4_gemm(
       reinterpret_cast<float const*>(global_scale.data_ptr<float>()),
       reinterpret_cast<cutlass::half_t*>(c.data_ptr<at::Half>()),
       static_cast<int>(size_m), static_cast<int>(size_n),
-      static_cast<int>(size_k), static_cast<int>(a.stride(0)), requested_split_k);
+      static_cast<int>(size_k), static_cast<int>(a.stride(0)),
+      requested_split_k);
   C10_CUDA_KERNEL_LAUNCH_CHECK();
 
   return c;
@@ -546,11 +543,11 @@ struct Sm70Nvfp4Launcher {
   int64_t size_k;
   int requested_split_k;
 
-  template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM,
-            int WarpN, int WarpK, int GroupSize, int PackedMacroN>
+  template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM, int WarpN,
+            int WarpK, int GroupSize, int PackedMacroN>
   torch::Tensor operator()() const {
-    return launch_sm70_marlin_nvfp4_gemm<CtaM, CtaN, CtaK, Warps, WarpM, WarpN, WarpK,
-                  GroupSize, PackedMacroN>(
+    return launch_sm70_marlin_nvfp4_gemm<CtaM, CtaN, CtaK, Warps, WarpM, WarpN,
+                                         WarpK, GroupSize, PackedMacroN>(
         a, c, b_q_weight, b_scales, global_scale, size_m, size_n, size_k,
         requested_split_k);
   }
@@ -564,14 +561,22 @@ torch::Tensor sm70_marlin_nvfp4_gemm(torch::Tensor& a, torch::Tensor& c,
                                      int64_t size_k, int64_t group_size) {
   c10::cuda::CUDAGuard device_guard(a.device());
 
-  auto const params = sm70_marlin_dense_auto_params(
-      "nvfp4", group_size, size_m, size_n, size_k);
+  auto const params = sm70_marlin_dense_auto_params("nvfp4", group_size, size_m,
+                                                    size_n, size_k);
   Sm70CtaGeometry const geometry = params.geometry;
-  validate_sm70_marlin_dense_cta_geometry_supported("SM70 Marlin nvfp4", geometry);
-  validate_sm70_marlin_dense_cta_n_alignment("SM70 Marlin nvfp4", geometry, size_n);
-  Sm70Nvfp4Launcher const launcher{
-      a, c, b_q_weight, b_scales, global_scale, size_m, size_n, size_k,
-      params.requested_split_k};
+  validate_sm70_marlin_dense_cta_geometry_supported("SM70 Marlin nvfp4",
+                                                    geometry);
+  validate_sm70_marlin_dense_cta_n_alignment("SM70 Marlin nvfp4", geometry,
+                                             size_n);
+  Sm70Nvfp4Launcher const launcher{a,
+                                   c,
+                                   b_q_weight,
+                                   b_scales,
+                                   global_scale,
+                                   size_m,
+                                   size_n,
+                                   size_k,
+                                   params.requested_split_k};
   return dispatch_sm70_marlin_fixed_group_geometry<16>(
       launcher, geometry, params.packed_macro_n, group_size, "nvfp4");
 }

--- a/csrc/quantization/marlin/sm70_marlin_splitk.cuh
+++ b/csrc/quantization/marlin/sm70_marlin_splitk.cuh
@@ -22,9 +22,7 @@ int sm70_splitk_ceil_div_int(int numerator, int denominator) {
 }
 
 CUTLASS_HOST_DEVICE
-int sm70_splitk_min_int(int lhs, int rhs) {
-  return lhs < rhs ? lhs : rhs;
-}
+int sm70_splitk_min_int(int lhs, int rhs) { return lhs < rhs ? lhs : rhs; }
 
 template <int GroupSize, int CtaK = kCtaK>
 CUTLASS_HOST_DEVICE int sm70_splitk_group_tiles() {
@@ -76,8 +74,8 @@ int sm70_splitk_partition_tile_count(int remaining_tiles,
 }
 
 template <int GroupSize, int CtaK = kCtaK>
-CUTLASS_HOST_DEVICE Sm70SplitKPartition sm70_splitk_partition(
-    int k, int requested_split_k, int partition_idx) {
+CUTLASS_HOST_DEVICE Sm70SplitKPartition
+sm70_splitk_partition(int k, int requested_split_k, int partition_idx) {
   int const active_split_k = sm70_active_split_k(k, requested_split_k, CtaK);
   if (partition_idx >= active_split_k) {
     return {0, 0};
@@ -135,10 +133,9 @@ class Sm70AtomicFp16Epilogue {
           int const frag_row_idx =
               row + ThreadMap::Iterations::kRow *
                         (group + ThreadMap::Iterations::kGroup * cluster);
-          int const row_offset =
-              row * ThreadMap::Delta::kRow +
-              group * ThreadMap::Delta::kGroup +
-              cluster * ThreadMap::Delta::kCluster;
+          int const row_offset = row * ThreadMap::Delta::kRow +
+                                 group * ThreadMap::Delta::kGroup +
+                                 cluster * ThreadMap::Delta::kCluster;
           int const logical_row = thread_start_row + row_offset;
 
           CUTLASS_PRAGMA_UNROLL
@@ -168,7 +165,7 @@ class Sm70AtomicFp16Epilogue {
  public:
   CUTLASS_DEVICE
   Sm70AtomicFp16Epilogue(SharedStorage& shared_storage, int thread_idx,
-                              int warp_idx, int lane_idx)
+                         int warp_idx, int lane_idx)
       : warp_tile_iterator_(shared_storage.reference(), lane_idx),
         shared_load_iterator_(shared_storage.reference(), thread_idx) {
     using WarpCount = typename CutlassEpilogue::WarpCount;
@@ -177,8 +174,7 @@ class Sm70AtomicFp16Epilogue {
     int const warp_m = warp_mn % WarpCount::kM;
     int const warp_n = warp_mn / WarpCount::kM;
 
-    cutlass::MatrixCoord warp_offset{warp_k * WarpCount::kM + warp_m,
-                                     warp_n};
+    cutlass::MatrixCoord warp_offset{warp_k * WarpCount::kM + warp_m, warp_n};
     warp_tile_iterator_.add_tile_offset(warp_offset);
   }
 
@@ -220,8 +216,7 @@ class Sm70AtomicFp16Epilogue {
             CutlassEpilogue::kSmemPointerOffset);
       }
 
-      atomic_store_fragment(destination_iterator, aligned_accum_fragment, c,
-                            n);
+      atomic_store_fragment(destination_iterator, aligned_accum_fragment, c, n);
       ++destination_iterator;
     }
   }

--- a/csrc/quantization/marlin/sm70_marlin_u4_gemm.cu
+++ b/csrc/quantization/marlin/sm70_marlin_u4_gemm.cu
@@ -20,23 +20,23 @@
 #include "cutlass/layout/tensor_op_multiplicand_sm70.h"
 #include "cutlass/transform/threadblock/predicated_tile_iterator.h"
 
-using marlin::sm70::Sm70CtaGeometry;
-using marlin::sm70::Sm70AtomicFp16Epilogue;
-using marlin::sm70::Sm70MarlinGemmTraits;
-using marlin::sm70::Sm70SplitKPartition;
-using marlin::sm70::validate_sm70_marlin_dense_cta_geometry_supported;
-using marlin::sm70::validate_sm70_marlin_dense_cta_n_alignment;
 using marlin::sm70::configure_sm70_dynamic_smem;
 using marlin::sm70::dispatch_sm70_marlin_geometry;
 using marlin::sm70::kQuantTileK;
 using marlin::sm70::kQuantTileN;
-using marlin::sm70::sm70_marlin_dense_auto_params;
 using marlin::sm70::load_qword_vector;
 using marlin::sm70::qword_from_vector;
-using marlin::sm70::sm70_marlin_cta_grid;
 using marlin::sm70::sm70_active_split_k;
+using marlin::sm70::sm70_marlin_cta_grid;
+using marlin::sm70::sm70_marlin_dense_auto_params;
 using marlin::sm70::sm70_splitk_partition;
+using marlin::sm70::Sm70AtomicFp16Epilogue;
+using marlin::sm70::Sm70CtaGeometry;
+using marlin::sm70::Sm70MarlinGemmTraits;
+using marlin::sm70::Sm70SplitKPartition;
 using marlin::sm70::u4_packed_macro_n_qweight_offset_from_logical;
+using marlin::sm70::validate_sm70_marlin_dense_cta_geometry_supported;
+using marlin::sm70::validate_sm70_marlin_dense_cta_n_alignment;
 
 namespace {
 
@@ -52,12 +52,11 @@ class Sm70U4ZpIteratorB {
   static int const kPackedMacroN = PackedMacroN_;
   static constexpr bool kUseMetadataVectorWords = UseMetadataVectorWords_;
   using Element = cutlass::half_t;
-  using Fragment = cutlass::Array<
-      Element, ThreadMap::Iterations::kCount * ThreadMap::kElementsPerAccess>;
+  using Fragment = cutlass::Array<Element, ThreadMap::Iterations::kCount *
+                                               ThreadMap::kElementsPerAccess>;
   static_assert(Shape::kN == 64 || Shape::kN == 128 || Shape::kN == 256,
                 "SM70 Marlin U4 IteratorB expects CTA_N in {64, 128, 256}.");
-  static_assert(ThreadMap::Iterations::kContiguous ==
-                    Shape::kN / kQuantTileN,
+  static_assert(ThreadMap::Iterations::kContiguous == Shape::kN / kQuantTileN,
                 "SM70 Marlin U4 IteratorB expects one contiguous iteration per "
                 "64-column quant tile.");
   static_assert(ThreadMap::Delta::kContiguous == kQuantTileN,
@@ -66,7 +65,8 @@ class Sm70U4ZpIteratorB {
                 "SM70 Marlin U4 IteratorB expects one packed int4 word per "
                 "access.");
   static_assert(ThreadMap::Iterations::kStrided >= 1,
-                "SM70 Marlin U4-family IteratorB expects one or more strided iterations.");
+                "SM70 Marlin U4-family IteratorB expects one or more strided "
+                "iterations.");
   struct Params {
     int size_n;
     int aligned_initial_k_step;
@@ -113,7 +113,7 @@ class Sm70U4ZpIteratorB {
     qweight_base_offset_ =
         qweight_offset_from_logical(params_, logical_k, logical_n);
     if constexpr (kGroupSize == -1) {
-        cache_current_group_metadata(0);
+      cache_current_group_metadata(0);
     }
   }
 
@@ -149,8 +149,7 @@ class Sm70U4ZpIteratorB {
     if constexpr (kGroupSize == -1) {
       return 0;
     } else {
-      static_assert(kGroupSize == 32 || kGroupSize == 64 ||
-                        kGroupSize == 128,
+      static_assert(kGroupSize == 32 || kGroupSize == 64 || kGroupSize == 128,
                     "SM70 Marlin U4 supports only group sizes "
                     "-1, 32, 64, and 128.");
       return logical_k / kGroupSize;
@@ -160,8 +159,8 @@ class Sm70U4ZpIteratorB {
   CUTLASS_DEVICE
   static int qweight_offset_from_logical(Params const& params, int logical_k,
                                          int logical_n) {
-    return u4_packed_macro_n_qweight_offset_from_logical<kPackedMacroN>(params.size_n, logical_k,
-                                                  logical_n);
+    return u4_packed_macro_n_qweight_offset_from_logical<kPackedMacroN>(
+        params.size_n, logical_k, logical_n);
   }
 
   CUTLASS_DEVICE
@@ -174,8 +173,8 @@ class Sm70U4ZpIteratorB {
     scale_cache[2] = scale_vec[2];
     scale_cache[3] = scale_vec[3];
 
-    half2 const* zp_vec = reinterpret_cast<half2 const*>(
-        zp_ + group * params_.size_n + cache_n);
+    half2 const* zp_vec =
+        reinterpret_cast<half2 const*>(zp_ + group * params_.size_n + cache_n);
     half2* zp_cache = cached_zp_ + c * 4;
     zp_cache[0] = zp_vec[0];
     zp_cache[1] = zp_vec[1];
@@ -194,8 +193,8 @@ class Sm70U4ZpIteratorB {
     scale_cache[2] = scale_vec[2];
     scale_cache[3] = scale_vec[3];
 
-    uint4 const zp_words = *reinterpret_cast<uint4 const*>(
-        zp_ + group * params_.size_n + cache_n);
+    uint4 const zp_words =
+        *reinterpret_cast<uint4 const*>(zp_ + group * params_.size_n + cache_n);
     half2 const* zp_vec = reinterpret_cast<half2 const*>(&zp_words);
     half2* zp_cache = cached_zp_ + c * 4;
     zp_cache[0] = zp_vec[0];
@@ -208,9 +207,8 @@ class Sm70U4ZpIteratorB {
   void cache_current_group_metadata(int group) const {
     CUTLASS_PRAGMA_UNROLL
     for (int c = 0; c < ThreadMap::Iterations::kContiguous; ++c) {
-      int const cache_n =
-          n_offset_ + thread_offset_.contiguous() +
-          c * ThreadMap::Delta::kContiguous;
+      int const cache_n = n_offset_ + thread_offset_.contiguous() +
+                          c * ThreadMap::Delta::kContiguous;
       if constexpr (kUseMetadataVectorWords) {
         cache_metadata_vector_words(c, group, cache_n);
       } else {
@@ -235,8 +233,8 @@ class Sm70U4ZpIteratorB {
 
           half2 deq[2];
           half2* frag_vec = reinterpret_cast<half2*>(frag.data() + frag_base);
-          marlin::dequant<half2, vllm::kU4.id(), false>(
-              static_cast<int>(qword), deq);
+          marlin::dequant<half2, vllm::kU4.id(), false>(static_cast<int>(qword),
+                                                        deq);
           frag_vec[0] = __hfma2(deq[0], scale_vec[0], __hneg2(zp_vec[0]));
           frag_vec[1] = __hfma2(deq[1], scale_vec[1], __hneg2(zp_vec[1]));
           marlin::dequant<half2, vllm::kU4.id(), false>(
@@ -257,8 +255,8 @@ class Sm70U4ZpIteratorB {
 
           half2 deq[2];
           half2* frag_vec = reinterpret_cast<half2*>(frag.data() + frag_base);
-          marlin::dequant<half2, vllm::kU4.id(), false>(
-              static_cast<int>(qword), deq);
+          marlin::dequant<half2, vllm::kU4.id(), false>(static_cast<int>(qword),
+                                                        deq);
           frag_vec[0] = __hfma2(deq[0], scale_vec[0], __hneg2(zp_vec[0]));
           frag_vec[1] = __hfma2(deq[1], scale_vec[1], __hneg2(zp_vec[1]));
           marlin::dequant<half2, vllm::kU4.id(), false>(
@@ -269,14 +267,15 @@ class Sm70U4ZpIteratorB {
       } else {
         static_assert(ThreadMap::Iterations::kContiguous == 1,
                       "Unsupported SM70 Marlin U4 contiguous iteration count.");
-        uint32_t const qword = load_qword_vector<1>(qweight_ + qweight_base_offset_);
+        uint32_t const qword =
+            load_qword_vector<1>(qweight_ + qweight_base_offset_);
         half2 const* scale_vec = cached_scales_;
         half2 const* zp_vec = cached_zp_;
 
         half2 deq[2];
         half2* frag_vec = reinterpret_cast<half2*>(frag.data());
-        marlin::dequant<half2, vllm::kU4.id(), false>(
-            static_cast<int>(qword), deq);
+        marlin::dequant<half2, vllm::kU4.id(), false>(static_cast<int>(qword),
+                                                      deq);
         frag_vec[0] = __hfma2(deq[0], scale_vec[0], __hneg2(zp_vec[0]));
         frag_vec[1] = __hfma2(deq[1], scale_vec[1], __hneg2(zp_vec[1]));
         marlin::dequant<half2, vllm::kU4.id(), false>(
@@ -288,17 +287,15 @@ class Sm70U4ZpIteratorB {
       int const logical_n_base = n_offset_ + thread_offset_.contiguous();
       CUTLASS_PRAGMA_UNROLL
       for (int s = 0; s < ThreadMap::Iterations::kStrided; ++s) {
-        int const logical_k_s =
-            k_offset_ + thread_offset_.strided() +
-            s * ThreadMap::Delta::kStrided;
+        int const logical_k_s = k_offset_ + thread_offset_.strided() +
+                                s * ThreadMap::Delta::kStrided;
         if constexpr (kGroupSize != -1) {
           cache_current_group_metadata(scale_group(logical_k_s));
         }
         int const qweight_base_s =
             qweight_offset_from_logical(params_, logical_k_s, logical_n_base);
         if constexpr (ThreadMap::Iterations::kContiguous == 4) {
-          auto const qwords =
-              load_qword_vector<4>(qweight_ + qweight_base_s);
+          auto const qwords = load_qword_vector<4>(qweight_ + qweight_base_s);
           CUTLASS_PRAGMA_UNROLL
           for (int c = 0; c < ThreadMap::Iterations::kContiguous; ++c) {
             constexpr int kAccess = ThreadMap::kElementsPerAccess;
@@ -312,20 +309,15 @@ class Sm70U4ZpIteratorB {
             half2* frag_vec = reinterpret_cast<half2*>(frag.data() + frag_base);
             marlin::dequant<half2, vllm::kU4.id(), false>(
                 static_cast<int>(qword), deq);
-            frag_vec[0] =
-                __hfma2(deq[0], scale_vec[0], __hneg2(zp_vec[0]));
-            frag_vec[1] =
-                __hfma2(deq[1], scale_vec[1], __hneg2(zp_vec[1]));
+            frag_vec[0] = __hfma2(deq[0], scale_vec[0], __hneg2(zp_vec[0]));
+            frag_vec[1] = __hfma2(deq[1], scale_vec[1], __hneg2(zp_vec[1]));
             marlin::dequant<half2, vllm::kU4.id(), false>(
                 static_cast<int>(qword >> 8), deq);
-            frag_vec[2] =
-                __hfma2(deq[0], scale_vec[2], __hneg2(zp_vec[2]));
-            frag_vec[3] =
-                __hfma2(deq[1], scale_vec[3], __hneg2(zp_vec[3]));
+            frag_vec[2] = __hfma2(deq[0], scale_vec[2], __hneg2(zp_vec[2]));
+            frag_vec[3] = __hfma2(deq[1], scale_vec[3], __hneg2(zp_vec[3]));
           }
         } else if constexpr (ThreadMap::Iterations::kContiguous == 2) {
-          auto const qwords =
-              load_qword_vector<2>(qweight_ + qweight_base_s);
+          auto const qwords = load_qword_vector<2>(qweight_ + qweight_base_s);
           CUTLASS_PRAGMA_UNROLL
           for (int c = 0; c < ThreadMap::Iterations::kContiguous; ++c) {
             constexpr int kAccess = ThreadMap::kElementsPerAccess;
@@ -339,21 +331,19 @@ class Sm70U4ZpIteratorB {
             half2* frag_vec = reinterpret_cast<half2*>(frag.data() + frag_base);
             marlin::dequant<half2, vllm::kU4.id(), false>(
                 static_cast<int>(qword), deq);
-            frag_vec[0] =
-                __hfma2(deq[0], scale_vec[0], __hneg2(zp_vec[0]));
-            frag_vec[1] =
-                __hfma2(deq[1], scale_vec[1], __hneg2(zp_vec[1]));
+            frag_vec[0] = __hfma2(deq[0], scale_vec[0], __hneg2(zp_vec[0]));
+            frag_vec[1] = __hfma2(deq[1], scale_vec[1], __hneg2(zp_vec[1]));
             marlin::dequant<half2, vllm::kU4.id(), false>(
                 static_cast<int>(qword >> 8), deq);
-            frag_vec[2] =
-                __hfma2(deq[0], scale_vec[2], __hneg2(zp_vec[2]));
-            frag_vec[3] =
-                __hfma2(deq[1], scale_vec[3], __hneg2(zp_vec[3]));
+            frag_vec[2] = __hfma2(deq[0], scale_vec[2], __hneg2(zp_vec[2]));
+            frag_vec[3] = __hfma2(deq[1], scale_vec[3], __hneg2(zp_vec[3]));
           }
         } else {
-          static_assert(ThreadMap::Iterations::kContiguous == 1,
-                        "Unsupported SM70 Marlin U4 contiguous iteration count.");
-          uint32_t const qword = load_qword_vector<1>(qweight_ + qweight_base_s);
+          static_assert(
+              ThreadMap::Iterations::kContiguous == 1,
+              "Unsupported SM70 Marlin U4 contiguous iteration count.");
+          uint32_t const qword =
+              load_qword_vector<1>(qweight_ + qweight_base_s);
           constexpr int kAccess = ThreadMap::kElementsPerAccess;
           int const frag_base = s * kAccess;
           half2 const* scale_vec = cached_scales_;
@@ -361,8 +351,8 @@ class Sm70U4ZpIteratorB {
 
           half2 deq[2];
           half2* frag_vec = reinterpret_cast<half2*>(frag.data() + frag_base);
-          marlin::dequant<half2, vllm::kU4.id(), false>(
-              static_cast<int>(qword), deq);
+          marlin::dequant<half2, vllm::kU4.id(), false>(static_cast<int>(qword),
+                                                        deq);
           frag_vec[0] = __hfma2(deq[0], scale_vec[0], __hneg2(zp_vec[0]));
           frag_vec[1] = __hfma2(deq[1], scale_vec[1], __hneg2(zp_vec[1]));
           marlin::dequant<half2, vllm::kU4.id(), false>(
@@ -380,8 +370,7 @@ class Sm70U4ZpIteratorB {
       return;
     }
 
-    if constexpr (kGroupSize != -1 &&
-                  ThreadMap::Iterations::kStrided == 1) {
+    if constexpr (kGroupSize != -1 && ThreadMap::Iterations::kStrided == 1) {
       int const first_logical_k = k_offset_ + thread_offset_.strided();
       cache_current_group_metadata(scale_group(first_logical_k));
     }
@@ -393,32 +382,30 @@ class Sm70U4ZpIteratorB {
 template <bool UseMetadataVectorWords = true>
 struct Sm70U4ZpGemmSpec {
   template <typename Shape, typename ThreadMap, int GroupSize, int PackedMacroN>
-  using IteratorB =
-      Sm70U4ZpIteratorB<Shape, ThreadMap, GroupSize, PackedMacroN,
-                        UseMetadataVectorWords>;
+  using IteratorB = Sm70U4ZpIteratorB<Shape, ThreadMap, GroupSize, PackedMacroN,
+                                      UseMetadataVectorWords>;
 };
 
-template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM,
-          int WarpN, int WarpK, int GroupSize, int PackedMacroN,
+template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM, int WarpN,
+          int WarpK, int GroupSize, int PackedMacroN,
           bool UseMetadataVectorWords = true>
 using Sm70U4ZpGemmTraits =
-    Sm70MarlinGemmTraits<Sm70U4ZpGemmSpec<UseMetadataVectorWords>, CtaM,
-                         CtaN, CtaK, Warps, WarpM, WarpN, WarpK,
-                         GroupSize, PackedMacroN>;
+    Sm70MarlinGemmTraits<Sm70U4ZpGemmSpec<UseMetadataVectorWords>, CtaM, CtaN,
+                         CtaK, Warps, WarpM, WarpN, WarpK, GroupSize,
+                         PackedMacroN>;
 
-template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM,
-          int WarpN, int WarpK, int GroupSize, int PackedMacroN,
+template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM, int WarpN,
+          int WarpK, int GroupSize, int PackedMacroN,
           bool UseMetadataVectorWords = true>
-__global__ __launch_bounds__(Warps * 32, 1)
-void sm70_marlin_u4_gemm_kernel(
+__global__ __launch_bounds__(Warps * 32, 1) void sm70_marlin_u4_gemm_kernel(
     cutlass::half_t const* __restrict__ a,
     uint32_t const* __restrict__ b_q_weight,
     cutlass::half_t const* __restrict__ b_scales,
     cutlass::half_t const* __restrict__ b_zeros,
     cutlass::half_t* __restrict__ c, int m, int n, int k, int lda) {
-  using Traits = Sm70U4ZpGemmTraits<CtaM, CtaN, CtaK, Warps, WarpM,
-                                    WarpN, WarpK, GroupSize, PackedMacroN,
-                                    UseMetadataVectorWords>;
+  using Traits =
+      Sm70U4ZpGemmTraits<CtaM, CtaN, CtaK, Warps, WarpM, WarpN, WarpK,
+                         GroupSize, PackedMacroN, UseMetadataVectorWords>;
   using Mma = typename Traits::Mma;
   using Epilogue = typename Traits::Epilogue;
 
@@ -438,10 +425,10 @@ void sm70_marlin_u4_gemm_kernel(
   typename Traits::LayoutA layout_a(lda);
   typename Traits::LayoutC layout_c(n);
 
-  typename Mma::IteratorA iterator_A(
-      typename Mma::IteratorA::Params(layout_a),
-      const_cast<cutlass::half_t*>(a), cutlass::MatrixCoord(m, k), thread_idx,
-      tb_offset_A);
+  typename Mma::IteratorA iterator_A(typename Mma::IteratorA::Params(layout_a),
+                                     const_cast<cutlass::half_t*>(a),
+                                     cutlass::MatrixCoord(m, k), thread_idx,
+                                     tb_offset_A);
   typename Mma::IteratorB iterator_B(
       typename Mma::IteratorB::Params(k, n),
       reinterpret_cast<uint32_t const*>(b_q_weight),
@@ -467,19 +454,20 @@ void sm70_marlin_u4_gemm_kernel(
   epilogue(output_op, iterator_D, accumulators, iterator_C);
 }
 
-template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM,
-          int WarpN, int WarpK, int GroupSize, int PackedMacroN,
+template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM, int WarpN,
+          int WarpK, int GroupSize, int PackedMacroN,
           bool UseMetadataVectorWords = true>
-__global__ __launch_bounds__(Warps * 32, 1)
-void sm70_marlin_u4_gemm_splitk_kernel(
+__global__
+__launch_bounds__(Warps * 32, 1) void sm70_marlin_u4_gemm_splitk_kernel(
     cutlass::half_t const* __restrict__ a,
     uint32_t const* __restrict__ b_q_weight,
     cutlass::half_t const* __restrict__ b_scales,
     cutlass::half_t const* __restrict__ b_zeros,
-    cutlass::half_t* __restrict__ c, int m, int n, int k, int lda, int requested_split_k) {
-  using Traits = Sm70U4ZpGemmTraits<CtaM, CtaN, CtaK, Warps, WarpM,
-                                    WarpN, WarpK, GroupSize, PackedMacroN,
-                                    UseMetadataVectorWords>;
+    cutlass::half_t* __restrict__ c, int m, int n, int k, int lda,
+    int requested_split_k) {
+  using Traits =
+      Sm70U4ZpGemmTraits<CtaM, CtaN, CtaK, Warps, WarpM, WarpN, WarpK,
+                         GroupSize, PackedMacroN, UseMetadataVectorWords>;
   using Mma = typename Traits::Mma;
   using AtomicEpilogue = Sm70AtomicFp16Epilogue<Traits>;
 
@@ -490,14 +478,13 @@ void sm70_marlin_u4_gemm_splitk_kernel(
   int const thread_idx = threadIdx.x;
   int const warp_idx = cutlass::canonical_warp_idx_sync();
   int const lane_idx = threadIdx.x % 32;
-  Sm70SplitKPartition const partition =
-      sm70_splitk_partition<GroupSize, CtaK>(k, requested_split_k, int(blockIdx.z));
+  Sm70SplitKPartition const partition = sm70_splitk_partition<GroupSize, CtaK>(
+      k, requested_split_k, int(blockIdx.z));
   if (partition.partition_k == 0) {
     return;
   }
 
-  cutlass::MatrixCoord tb_offset_A{int(blockIdx.x) * CtaM,
-                                   partition.k_begin};
+  cutlass::MatrixCoord tb_offset_A{int(blockIdx.x) * CtaM, partition.k_begin};
   cutlass::MatrixCoord tb_offset_B{partition.k_begin, int(blockIdx.y) * CtaN};
   cutlass::MatrixCoord tb_offset_C{int(blockIdx.x) * CtaM,
                                    int(blockIdx.y) * CtaN};
@@ -505,10 +492,10 @@ void sm70_marlin_u4_gemm_splitk_kernel(
   typename Traits::LayoutA layout_a(lda);
   typename Traits::LayoutC layout_c(n);
 
-  typename Mma::IteratorA iterator_A(
-      typename Mma::IteratorA::Params(layout_a),
-      const_cast<cutlass::half_t*>(a), cutlass::MatrixCoord(m, k), thread_idx,
-      tb_offset_A);
+  typename Mma::IteratorA iterator_A(typename Mma::IteratorA::Params(layout_a),
+                                     const_cast<cutlass::half_t*>(a),
+                                     cutlass::MatrixCoord(m, k), thread_idx,
+                                     tb_offset_A);
   typename Mma::IteratorB iterator_B(
       typename Mma::IteratorB::Params(k, n),
       reinterpret_cast<uint32_t const*>(b_q_weight),
@@ -523,9 +510,8 @@ void sm70_marlin_u4_gemm_splitk_kernel(
   mma(gemm_k_iterations, accumulators, iterator_A, iterator_B, accumulators);
 
   typename AtomicEpilogue::OutputTileIterator iterator_D(
-      typename AtomicEpilogue::OutputTileIterator::Params(layout_c),
-      c, cutlass::MatrixCoord(m, n),
-      thread_idx, tb_offset_C);
+      typename AtomicEpilogue::OutputTileIterator::Params(layout_c), c,
+      cutlass::MatrixCoord(m, n), thread_idx, tb_offset_C);
 
   AtomicEpilogue epilogue(shared_storage.epilogue, thread_idx, warp_idx,
                           lane_idx);
@@ -534,19 +520,23 @@ void sm70_marlin_u4_gemm_splitk_kernel(
 
 }  // namespace
 
-template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM,
-          int WarpN, int WarpK, int GroupSize, int PackedMacroN,
+template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM, int WarpN,
+          int WarpK, int GroupSize, int PackedMacroN,
           bool UseMetadataVectorWords = true>
-torch::Tensor launch_sm70_marlin_u4_gemm(
-    torch::Tensor& a, torch::Tensor& c, torch::Tensor& b_q_weight,
-    torch::Tensor& b_scales, torch::Tensor& b_zeros, int64_t size_m,
-    int64_t size_n, int64_t size_k, int requested_split_k) {
-  auto kernel = sm70_marlin_u4_gemm_kernel<CtaM, CtaN, CtaK, Warps, WarpM, WarpN, WarpK,
-                                           GroupSize, PackedMacroN,
-                                           UseMetadataVectorWords>;
-  using SharedStorage = typename Sm70U4ZpGemmTraits<
-      CtaM, CtaN, CtaK, Warps, WarpM, WarpN, WarpK, GroupSize,
-      PackedMacroN, UseMetadataVectorWords>::SharedStorage;
+torch::Tensor launch_sm70_marlin_u4_gemm(torch::Tensor& a, torch::Tensor& c,
+                                         torch::Tensor& b_q_weight,
+                                         torch::Tensor& b_scales,
+                                         torch::Tensor& b_zeros, int64_t size_m,
+                                         int64_t size_n, int64_t size_k,
+                                         int requested_split_k) {
+  auto kernel =
+      sm70_marlin_u4_gemm_kernel<CtaM, CtaN, CtaK, Warps, WarpM, WarpN, WarpK,
+                                 GroupSize, PackedMacroN,
+                                 UseMetadataVectorWords>;
+  using SharedStorage =
+      typename Sm70U4ZpGemmTraits<CtaM, CtaN, CtaK, Warps, WarpM, WarpN, WarpK,
+                                  GroupSize, PackedMacroN,
+                                  UseMetadataVectorWords>::SharedStorage;
   size_t smem_bytes = configure_sm70_dynamic_smem<SharedStorage>(kernel);
   dim3 block(Warps * 32);
   cudaStream_t stream = at::cuda::getCurrentCUDAStream(a.get_device()).stream();
@@ -556,8 +546,7 @@ torch::Tensor launch_sm70_marlin_u4_gemm(
     kernel<<<grid, block, smem_bytes, stream>>>(
         reinterpret_cast<cutlass::half_t const*>(a.data_ptr<at::Half>()),
         reinterpret_cast<uint32_t const*>(b_q_weight.data_ptr<int32_t>()),
-        reinterpret_cast<cutlass::half_t const*>(
-            b_scales.data_ptr<at::Half>()),
+        reinterpret_cast<cutlass::half_t const*>(b_scales.data_ptr<at::Half>()),
         reinterpret_cast<cutlass::half_t const*>(b_zeros.data_ptr<at::Half>()),
         reinterpret_cast<cutlass::half_t*>(c.data_ptr<at::Half>()),
         static_cast<int>(size_m), static_cast<int>(size_n),
@@ -567,8 +556,8 @@ torch::Tensor launch_sm70_marlin_u4_gemm(
   }
 
   TORCH_CHECK(size_k % int64_t(CtaK) == 0,
-              "SM70 Marlin uint4 requires K divisible by CTA_K=",
-              CtaK, " for requested_split_k > 1. Got K=", size_k,
+              "SM70 Marlin uint4 requires K divisible by CTA_K=", CtaK,
+              " for requested_split_k > 1. Got K=", size_k,
               ", requested_split_k=", requested_split_k, ".");
 
   auto split_kernel =
@@ -578,9 +567,9 @@ torch::Tensor launch_sm70_marlin_u4_gemm(
   smem_bytes = configure_sm70_dynamic_smem<SharedStorage>(split_kernel);
 
   int64_t const numel = size_m * size_n;
-  C10_CUDA_CHECK(cudaMemsetAsync(
-      c.data_ptr<at::Half>(), 0,
-      static_cast<size_t>(numel) * sizeof(at::Half), stream));
+  C10_CUDA_CHECK(cudaMemsetAsync(c.data_ptr<at::Half>(), 0,
+                                 static_cast<size_t>(numel) * sizeof(at::Half),
+                                 stream));
 
   dim3 grid = sm70_marlin_cta_grid(size_m, size_n, CtaM, CtaN);
   int const active_split_k =
@@ -593,7 +582,8 @@ torch::Tensor launch_sm70_marlin_u4_gemm(
       reinterpret_cast<cutlass::half_t const*>(b_zeros.data_ptr<at::Half>()),
       reinterpret_cast<cutlass::half_t*>(c.data_ptr<at::Half>()),
       static_cast<int>(size_m), static_cast<int>(size_n),
-      static_cast<int>(size_k), static_cast<int>(a.stride(0)), requested_split_k);
+      static_cast<int>(size_k), static_cast<int>(a.stride(0)),
+      requested_split_k);
   C10_CUDA_KERNEL_LAUNCH_CHECK();
 
   return c;
@@ -611,38 +601,44 @@ struct Sm70U4Launcher {
   int64_t size_k;
   int requested_split_k;
 
-  template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM,
-            int WarpN, int WarpK, int GroupSize, int PackedMacroN>
+  template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM, int WarpN,
+            int WarpK, int GroupSize, int PackedMacroN>
   torch::Tensor operator()() const {
-    return launch_sm70_marlin_u4_gemm<CtaM, CtaN, CtaK, Warps, WarpM, WarpN, WarpK,
-                                      GroupSize, PackedMacroN,
+    return launch_sm70_marlin_u4_gemm<CtaM, CtaN, CtaK, Warps, WarpM, WarpN,
+                                      WarpK, GroupSize, PackedMacroN,
                                       UseMetadataVectorWords>(
-        a, c, b_q_weight, b_scales, b_zeros, size_m, size_n, size_k, requested_split_k);
+        a, c, b_q_weight, b_scales, b_zeros, size_m, size_n, size_k,
+        requested_split_k);
   }
 };
 
-torch::Tensor sm70_marlin_u4_gemm(
-    torch::Tensor& a, torch::Tensor& c, torch::Tensor& b_q_weight,
-    torch::Tensor& b_scales, torch::Tensor& b_zeros, int64_t size_m,
-    int64_t size_n, int64_t size_k, int64_t group_size) {
+torch::Tensor sm70_marlin_u4_gemm(torch::Tensor& a, torch::Tensor& c,
+                                  torch::Tensor& b_q_weight,
+                                  torch::Tensor& b_scales,
+                                  torch::Tensor& b_zeros, int64_t size_m,
+                                  int64_t size_n, int64_t size_k,
+                                  int64_t group_size) {
   c10::cuda::CUDAGuard device_guard(a.device());
 
-  auto const params =
-      sm70_marlin_dense_auto_params("uint4", group_size, size_m, size_n,
-                                    size_k);
+  auto const params = sm70_marlin_dense_auto_params("uint4", group_size, size_m,
+                                                    size_n, size_k);
   Sm70CtaGeometry const geometry = params.geometry;
-  validate_sm70_marlin_dense_cta_geometry_supported("SM70 Marlin uint4", geometry);
-  validate_sm70_marlin_dense_cta_n_alignment("SM70 Marlin uint4", geometry, size_n);
+  validate_sm70_marlin_dense_cta_geometry_supported("SM70 Marlin uint4",
+                                                    geometry);
+  validate_sm70_marlin_dense_cta_n_alignment("SM70 Marlin uint4", geometry,
+                                             size_n);
   if (params.use_metadata_vector_words) {
     Sm70U4Launcher<true> const launcher{
-        a, c, b_q_weight, b_scales, b_zeros, size_m, size_n,
-        size_k, params.requested_split_k};
+        a,        c,       b_q_weight,
+        b_scales, b_zeros, size_m,
+        size_n,   size_k,  params.requested_split_k};
     return dispatch_sm70_marlin_geometry(
         launcher, geometry, params.packed_macro_n, group_size, "uint4");
   }
   Sm70U4Launcher<false> const launcher{
-      a, c, b_q_weight, b_scales, b_zeros, size_m, size_n,
-      size_k, params.requested_split_k};
+      a,        c,       b_q_weight,
+      b_scales, b_zeros, size_m,
+      size_n,   size_k,  params.requested_split_k};
   return dispatch_sm70_marlin_geometry(
       launcher, geometry, params.packed_macro_n, group_size, "uint4");
 }

--- a/csrc/quantization/marlin/sm70_marlin_u4b8_gemm.cu
+++ b/csrc/quantization/marlin/sm70_marlin_u4b8_gemm.cu
@@ -20,23 +20,23 @@
 #include "cutlass/layout/tensor_op_multiplicand_sm70.h"
 #include "cutlass/transform/threadblock/predicated_tile_iterator.h"
 
-using marlin::sm70::Sm70CtaGeometry;
-using marlin::sm70::Sm70AtomicFp16Epilogue;
-using marlin::sm70::Sm70MarlinGemmTraits;
-using marlin::sm70::Sm70SplitKPartition;
-using marlin::sm70::validate_sm70_marlin_dense_cta_geometry_supported;
-using marlin::sm70::validate_sm70_marlin_dense_cta_n_alignment;
 using marlin::sm70::configure_sm70_dynamic_smem;
 using marlin::sm70::dispatch_sm70_marlin_geometry;
 using marlin::sm70::kQuantTileK;
 using marlin::sm70::kQuantTileN;
-using marlin::sm70::sm70_marlin_dense_auto_params;
 using marlin::sm70::load_qword_vector;
 using marlin::sm70::qword_from_vector;
-using marlin::sm70::sm70_marlin_cta_grid;
 using marlin::sm70::sm70_active_split_k;
+using marlin::sm70::sm70_marlin_cta_grid;
+using marlin::sm70::sm70_marlin_dense_auto_params;
 using marlin::sm70::sm70_splitk_partition;
+using marlin::sm70::Sm70AtomicFp16Epilogue;
+using marlin::sm70::Sm70CtaGeometry;
+using marlin::sm70::Sm70MarlinGemmTraits;
+using marlin::sm70::Sm70SplitKPartition;
 using marlin::sm70::u4_packed_macro_n_qweight_offset_from_logical;
+using marlin::sm70::validate_sm70_marlin_dense_cta_geometry_supported;
+using marlin::sm70::validate_sm70_marlin_dense_cta_n_alignment;
 
 namespace {
 
@@ -52,12 +52,11 @@ class Sm70U4B8IteratorB {
   static int const kPackedMacroN = PackedMacroN_;
   static constexpr bool kUseMetadataVectorWords = UseMetadataVectorWords_;
   using Element = cutlass::half_t;
-  using Fragment = cutlass::Array<
-      Element, ThreadMap::Iterations::kCount * ThreadMap::kElementsPerAccess>;
+  using Fragment = cutlass::Array<Element, ThreadMap::Iterations::kCount *
+                                               ThreadMap::kElementsPerAccess>;
   static_assert(Shape::kN == 64 || Shape::kN == 128 || Shape::kN == 256,
                 "SM70 Marlin U4B8 IteratorB expects CTA_N in {64, 128, 256}.");
-  static_assert(ThreadMap::Iterations::kContiguous ==
-                    Shape::kN / kQuantTileN,
+  static_assert(ThreadMap::Iterations::kContiguous == Shape::kN / kQuantTileN,
                 "SM70 Marlin U4B8 IteratorB expects one contiguous iteration "
                 "per 64-column quant tile.");
   static_assert(ThreadMap::Delta::kContiguous == kQuantTileN,
@@ -66,7 +65,8 @@ class Sm70U4B8IteratorB {
                 "SM70 Marlin U4B8 IteratorB expects one packed int4 word per "
                 "access.");
   static_assert(ThreadMap::Iterations::kStrided >= 1,
-                "SM70 Marlin U4-family IteratorB expects one or more strided iterations.");
+                "SM70 Marlin U4-family IteratorB expects one or more strided "
+                "iterations.");
   struct Params {
     int size_n;
     int aligned_initial_k_step;
@@ -146,8 +146,7 @@ class Sm70U4B8IteratorB {
     if constexpr (kGroupSize == -1) {
       return 0;
     } else {
-      static_assert(kGroupSize == 32 || kGroupSize == 64 ||
-                        kGroupSize == 128,
+      static_assert(kGroupSize == 32 || kGroupSize == 64 || kGroupSize == 128,
                     "SM70 Marlin U4B8 supports only group sizes "
                     "-1, 32, 64, and 128.");
       return logical_k / kGroupSize;
@@ -157,8 +156,8 @@ class Sm70U4B8IteratorB {
   CUTLASS_DEVICE
   static int qweight_offset_from_logical(Params const& params, int logical_k,
                                          int logical_n) {
-    return u4_packed_macro_n_qweight_offset_from_logical<kPackedMacroN>(params.size_n, logical_k,
-                                                  logical_n);
+    return u4_packed_macro_n_qweight_offset_from_logical<kPackedMacroN>(
+        params.size_n, logical_k, logical_n);
   }
 
   CUTLASS_DEVICE
@@ -188,9 +187,8 @@ class Sm70U4B8IteratorB {
   void cache_current_group_metadata(int group) const {
     CUTLASS_PRAGMA_UNROLL
     for (int c = 0; c < ThreadMap::Iterations::kContiguous; ++c) {
-      int const cache_n =
-          n_offset_ + thread_offset_.contiguous() +
-          c * ThreadMap::Delta::kContiguous;
+      int const cache_n = n_offset_ + thread_offset_.contiguous() +
+                          c * ThreadMap::Delta::kContiguous;
       if constexpr (kUseMetadataVectorWords) {
         cache_metadata_vector_words(c, group, cache_n);
       } else {
@@ -245,15 +243,17 @@ class Sm70U4B8IteratorB {
           frag_vec[3] = __hmul2(deq[1], scale_vec[3]);
         }
       } else {
-        static_assert(ThreadMap::Iterations::kContiguous == 1,
-                      "Unsupported SM70 Marlin U4B8 contiguous iteration count.");
-        uint32_t const qword = load_qword_vector<1>(qweight_ + qweight_base_offset_);
+        static_assert(
+            ThreadMap::Iterations::kContiguous == 1,
+            "Unsupported SM70 Marlin U4B8 contiguous iteration count.");
+        uint32_t const qword =
+            load_qword_vector<1>(qweight_ + qweight_base_offset_);
         half2 const* scale_vec = cached_scales_;
 
         half2 deq[2];
         half2* frag_vec = reinterpret_cast<half2*>(frag.data());
-        marlin::dequant<half2, vllm::kU4B8.id(), false>(
-            static_cast<int>(qword), deq);
+        marlin::dequant<half2, vllm::kU4B8.id(), false>(static_cast<int>(qword),
+                                                        deq);
         frag_vec[0] = __hmul2(deq[0], scale_vec[0]);
         frag_vec[1] = __hmul2(deq[1], scale_vec[1]);
         marlin::dequant<half2, vllm::kU4B8.id(), false>(
@@ -265,17 +265,15 @@ class Sm70U4B8IteratorB {
       int const logical_n_base = n_offset_ + thread_offset_.contiguous();
       CUTLASS_PRAGMA_UNROLL
       for (int s = 0; s < ThreadMap::Iterations::kStrided; ++s) {
-        int const logical_k_s =
-            k_offset_ + thread_offset_.strided() +
-            s * ThreadMap::Delta::kStrided;
+        int const logical_k_s = k_offset_ + thread_offset_.strided() +
+                                s * ThreadMap::Delta::kStrided;
         if constexpr (kGroupSize != -1) {
           cache_current_group_metadata(scale_group(logical_k_s));
         }
         int const qweight_base_s =
             qweight_offset_from_logical(params_, logical_k_s, logical_n_base);
         if constexpr (ThreadMap::Iterations::kContiguous == 4) {
-          auto const qwords =
-              load_qword_vector<4>(qweight_ + qweight_base_s);
+          auto const qwords = load_qword_vector<4>(qweight_ + qweight_base_s);
           CUTLASS_PRAGMA_UNROLL
           for (int c = 0; c < ThreadMap::Iterations::kContiguous; ++c) {
             constexpr int kAccess = ThreadMap::kElementsPerAccess;
@@ -296,8 +294,7 @@ class Sm70U4B8IteratorB {
             frag_vec[3] = __hmul2(deq[1], scale_vec[3]);
           }
         } else if constexpr (ThreadMap::Iterations::kContiguous == 2) {
-          auto const qwords =
-              load_qword_vector<2>(qweight_ + qweight_base_s);
+          auto const qwords = load_qword_vector<2>(qweight_ + qweight_base_s);
           CUTLASS_PRAGMA_UNROLL
           for (int c = 0; c < ThreadMap::Iterations::kContiguous; ++c) {
             constexpr int kAccess = ThreadMap::kElementsPerAccess;
@@ -318,9 +315,11 @@ class Sm70U4B8IteratorB {
             frag_vec[3] = __hmul2(deq[1], scale_vec[3]);
           }
         } else {
-          static_assert(ThreadMap::Iterations::kContiguous == 1,
-                        "Unsupported SM70 Marlin U4B8 contiguous iteration count.");
-          uint32_t const qword = load_qword_vector<1>(qweight_ + qweight_base_s);
+          static_assert(
+              ThreadMap::Iterations::kContiguous == 1,
+              "Unsupported SM70 Marlin U4B8 contiguous iteration count.");
+          uint32_t const qword =
+              load_qword_vector<1>(qweight_ + qweight_base_s);
           constexpr int kAccess = ThreadMap::kElementsPerAccess;
           int const frag_base = s * kAccess;
           half2 const* scale_vec = cached_scales_;
@@ -346,8 +345,7 @@ class Sm70U4B8IteratorB {
       return;
     }
 
-    if constexpr (kGroupSize != -1 &&
-                  ThreadMap::Iterations::kStrided == 1) {
+    if constexpr (kGroupSize != -1 && ThreadMap::Iterations::kStrided == 1) {
       int const first_logical_k = k_offset_ + thread_offset_.strided();
       cache_current_group_metadata(scale_group(first_logical_k));
     }
@@ -359,31 +357,29 @@ class Sm70U4B8IteratorB {
 template <bool UseMetadataVectorWords = true>
 struct Sm70U4B8GemmSpec {
   template <typename Shape, typename ThreadMap, int GroupSize, int PackedMacroN>
-  using IteratorB =
-      Sm70U4B8IteratorB<Shape, ThreadMap, GroupSize, PackedMacroN,
-                        UseMetadataVectorWords>;
+  using IteratorB = Sm70U4B8IteratorB<Shape, ThreadMap, GroupSize, PackedMacroN,
+                                      UseMetadataVectorWords>;
 };
 
-template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM,
-          int WarpN, int WarpK, int GroupSize, int PackedMacroN,
+template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM, int WarpN,
+          int WarpK, int GroupSize, int PackedMacroN,
           bool UseMetadataVectorWords = true>
 using Sm70U4B8GemmTraits =
-    Sm70MarlinGemmTraits<Sm70U4B8GemmSpec<UseMetadataVectorWords>, CtaM,
-                         CtaN, CtaK, Warps, WarpM, WarpN, WarpK,
-                         GroupSize, PackedMacroN>;
+    Sm70MarlinGemmTraits<Sm70U4B8GemmSpec<UseMetadataVectorWords>, CtaM, CtaN,
+                         CtaK, Warps, WarpM, WarpN, WarpK, GroupSize,
+                         PackedMacroN>;
 
-template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM,
-          int WarpN, int WarpK, int GroupSize, int PackedMacroN,
+template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM, int WarpN,
+          int WarpK, int GroupSize, int PackedMacroN,
           bool UseMetadataVectorWords = true>
-__global__ __launch_bounds__(Warps * 32, 1)
-void sm70_marlin_u4b8_gemm_kernel(
+__global__ __launch_bounds__(Warps * 32, 1) void sm70_marlin_u4b8_gemm_kernel(
     cutlass::half_t const* __restrict__ a,
     uint32_t const* __restrict__ b_q_weight,
     cutlass::half_t const* __restrict__ b_scales,
     cutlass::half_t* __restrict__ c, int m, int n, int k, int lda) {
-  using Traits = Sm70U4B8GemmTraits<CtaM, CtaN, CtaK, Warps, WarpM,
-                                    WarpN, WarpK, GroupSize, PackedMacroN,
-                                    UseMetadataVectorWords>;
+  using Traits =
+      Sm70U4B8GemmTraits<CtaM, CtaN, CtaK, Warps, WarpM, WarpN, WarpK,
+                         GroupSize, PackedMacroN, UseMetadataVectorWords>;
   using Mma = typename Traits::Mma;
   using Epilogue = typename Traits::Epilogue;
 
@@ -403,10 +399,10 @@ void sm70_marlin_u4b8_gemm_kernel(
   typename Traits::LayoutA layout_a(lda);
   typename Traits::LayoutC layout_c(n);
 
-  typename Mma::IteratorA iterator_A(
-      typename Mma::IteratorA::Params(layout_a),
-      const_cast<cutlass::half_t*>(a), cutlass::MatrixCoord(m, k), thread_idx,
-      tb_offset_A);
+  typename Mma::IteratorA iterator_A(typename Mma::IteratorA::Params(layout_a),
+                                     const_cast<cutlass::half_t*>(a),
+                                     cutlass::MatrixCoord(m, k), thread_idx,
+                                     tb_offset_A);
   typename Mma::IteratorB iterator_B(
       typename Mma::IteratorB::Params(k, n),
       reinterpret_cast<uint32_t const*>(b_q_weight),
@@ -431,18 +427,19 @@ void sm70_marlin_u4b8_gemm_kernel(
   epilogue(output_op, iterator_D, accumulators, iterator_C);
 }
 
-template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM,
-          int WarpN, int WarpK, int GroupSize, int PackedMacroN,
+template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM, int WarpN,
+          int WarpK, int GroupSize, int PackedMacroN,
           bool UseMetadataVectorWords = true>
-__global__ __launch_bounds__(Warps * 32, 1)
-void sm70_marlin_u4b8_gemm_splitk_kernel(
+__global__
+__launch_bounds__(Warps * 32, 1) void sm70_marlin_u4b8_gemm_splitk_kernel(
     cutlass::half_t const* __restrict__ a,
     uint32_t const* __restrict__ b_q_weight,
     cutlass::half_t const* __restrict__ b_scales,
-    cutlass::half_t* __restrict__ c, int m, int n, int k, int lda, int requested_split_k) {
-  using Traits = Sm70U4B8GemmTraits<CtaM, CtaN, CtaK, Warps, WarpM,
-                                    WarpN, WarpK, GroupSize, PackedMacroN,
-                                    UseMetadataVectorWords>;
+    cutlass::half_t* __restrict__ c, int m, int n, int k, int lda,
+    int requested_split_k) {
+  using Traits =
+      Sm70U4B8GemmTraits<CtaM, CtaN, CtaK, Warps, WarpM, WarpN, WarpK,
+                         GroupSize, PackedMacroN, UseMetadataVectorWords>;
   using Mma = typename Traits::Mma;
   using AtomicEpilogue = Sm70AtomicFp16Epilogue<Traits>;
 
@@ -453,14 +450,13 @@ void sm70_marlin_u4b8_gemm_splitk_kernel(
   int const thread_idx = threadIdx.x;
   int const warp_idx = cutlass::canonical_warp_idx_sync();
   int const lane_idx = threadIdx.x % 32;
-  Sm70SplitKPartition const partition =
-      sm70_splitk_partition<GroupSize, CtaK>(k, requested_split_k, int(blockIdx.z));
+  Sm70SplitKPartition const partition = sm70_splitk_partition<GroupSize, CtaK>(
+      k, requested_split_k, int(blockIdx.z));
   if (partition.partition_k == 0) {
     return;
   }
 
-  cutlass::MatrixCoord tb_offset_A{int(blockIdx.x) * CtaM,
-                                   partition.k_begin};
+  cutlass::MatrixCoord tb_offset_A{int(blockIdx.x) * CtaM, partition.k_begin};
   cutlass::MatrixCoord tb_offset_B{partition.k_begin, int(blockIdx.y) * CtaN};
   cutlass::MatrixCoord tb_offset_C{int(blockIdx.x) * CtaM,
                                    int(blockIdx.y) * CtaN};
@@ -468,10 +464,10 @@ void sm70_marlin_u4b8_gemm_splitk_kernel(
   typename Traits::LayoutA layout_a(lda);
   typename Traits::LayoutC layout_c(n);
 
-  typename Mma::IteratorA iterator_A(
-      typename Mma::IteratorA::Params(layout_a),
-      const_cast<cutlass::half_t*>(a), cutlass::MatrixCoord(m, k), thread_idx,
-      tb_offset_A);
+  typename Mma::IteratorA iterator_A(typename Mma::IteratorA::Params(layout_a),
+                                     const_cast<cutlass::half_t*>(a),
+                                     cutlass::MatrixCoord(m, k), thread_idx,
+                                     tb_offset_A);
   typename Mma::IteratorB iterator_B(
       typename Mma::IteratorB::Params(k, n),
       reinterpret_cast<uint32_t const*>(b_q_weight),
@@ -485,9 +481,8 @@ void sm70_marlin_u4b8_gemm_splitk_kernel(
   mma(gemm_k_iterations, accumulators, iterator_A, iterator_B, accumulators);
 
   typename AtomicEpilogue::OutputTileIterator iterator_D(
-      typename AtomicEpilogue::OutputTileIterator::Params(layout_c),
-      c, cutlass::MatrixCoord(m, n),
-      thread_idx, tb_offset_C);
+      typename AtomicEpilogue::OutputTileIterator::Params(layout_c), c,
+      cutlass::MatrixCoord(m, n), thread_idx, tb_offset_C);
 
   AtomicEpilogue epilogue(shared_storage.epilogue, thread_idx, warp_idx,
                           lane_idx);
@@ -496,20 +491,23 @@ void sm70_marlin_u4b8_gemm_splitk_kernel(
 
 }  // namespace
 
-template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM,
-          int WarpN, int WarpK, int GroupSize, int PackedMacroN,
+template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM, int WarpN,
+          int WarpK, int GroupSize, int PackedMacroN,
           bool UseMetadataVectorWords = true>
-torch::Tensor launch_sm70_marlin_u4b8_gemm(
-    torch::Tensor& a, torch::Tensor& c, torch::Tensor& b_q_weight,
-    torch::Tensor& b_scales, int64_t size_m, int64_t size_n, int64_t size_k,
-    int requested_split_k) {
+torch::Tensor launch_sm70_marlin_u4b8_gemm(torch::Tensor& a, torch::Tensor& c,
+                                           torch::Tensor& b_q_weight,
+                                           torch::Tensor& b_scales,
+                                           int64_t size_m, int64_t size_n,
+                                           int64_t size_k,
+                                           int requested_split_k) {
   auto kernel =
-      sm70_marlin_u4b8_gemm_kernel<CtaM, CtaN, CtaK, Warps, WarpM, WarpN,
-                                   WarpK, GroupSize, PackedMacroN,
+      sm70_marlin_u4b8_gemm_kernel<CtaM, CtaN, CtaK, Warps, WarpM, WarpN, WarpK,
+                                   GroupSize, PackedMacroN,
                                    UseMetadataVectorWords>;
-  using SharedStorage = typename Sm70U4B8GemmTraits<
-      CtaM, CtaN, CtaK, Warps, WarpM, WarpN, WarpK, GroupSize,
-      PackedMacroN, UseMetadataVectorWords>::SharedStorage;
+  using SharedStorage =
+      typename Sm70U4B8GemmTraits<CtaM, CtaN, CtaK, Warps, WarpM, WarpN, WarpK,
+                                  GroupSize, PackedMacroN,
+                                  UseMetadataVectorWords>::SharedStorage;
   size_t smem_bytes = configure_sm70_dynamic_smem<SharedStorage>(kernel);
 
   dim3 block(Warps * 32);
@@ -529,21 +527,20 @@ torch::Tensor launch_sm70_marlin_u4b8_gemm(
   }
 
   TORCH_CHECK(size_k % int64_t(CtaK) == 0,
-              "SM70 Marlin uint4b8 requires K divisible by CTA_K=",
-              CtaK, " for requested_split_k > 1. Got K=", size_k,
+              "SM70 Marlin uint4b8 requires K divisible by CTA_K=", CtaK,
+              " for requested_split_k > 1. Got K=", size_k,
               ", requested_split_k=", requested_split_k, ".");
 
   auto split_kernel =
-      sm70_marlin_u4b8_gemm_splitk_kernel<CtaM, CtaN, CtaK, Warps, WarpM,
-                                          WarpN, WarpK, GroupSize,
-                                          PackedMacroN,
+      sm70_marlin_u4b8_gemm_splitk_kernel<CtaM, CtaN, CtaK, Warps, WarpM, WarpN,
+                                          WarpK, GroupSize, PackedMacroN,
                                           UseMetadataVectorWords>;
   smem_bytes = configure_sm70_dynamic_smem<SharedStorage>(split_kernel);
 
   int64_t const numel = size_m * size_n;
-  C10_CUDA_CHECK(cudaMemsetAsync(
-      c.data_ptr<at::Half>(), 0,
-      static_cast<size_t>(numel) * sizeof(at::Half), stream));
+  C10_CUDA_CHECK(cudaMemsetAsync(c.data_ptr<at::Half>(), 0,
+                                 static_cast<size_t>(numel) * sizeof(at::Half),
+                                 stream));
 
   dim3 grid = sm70_marlin_cta_grid(size_m, size_n, CtaM, CtaN);
   int const active_split_k =
@@ -555,7 +552,8 @@ torch::Tensor launch_sm70_marlin_u4b8_gemm(
       reinterpret_cast<cutlass::half_t const*>(b_scales.data_ptr<at::Half>()),
       reinterpret_cast<cutlass::half_t*>(c.data_ptr<at::Half>()),
       static_cast<int>(size_m), static_cast<int>(size_n),
-      static_cast<int>(size_k), static_cast<int>(a.stride(0)), requested_split_k);
+      static_cast<int>(size_k), static_cast<int>(a.stride(0)),
+      requested_split_k);
   C10_CUDA_KERNEL_LAUNCH_CHECK();
 
   return c;
@@ -572,8 +570,8 @@ struct Sm70U4B8Launcher {
   int64_t size_k;
   int requested_split_k;
 
-  template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM,
-            int WarpN, int WarpK, int GroupSize, int PackedMacroN>
+  template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM, int WarpN,
+            int WarpK, int GroupSize, int PackedMacroN>
   torch::Tensor operator()() const {
     return launch_sm70_marlin_u4b8_gemm<CtaM, CtaN, CtaK, Warps, WarpM, WarpN,
                                         WarpK, GroupSize, PackedMacroN,
@@ -589,21 +587,23 @@ torch::Tensor sm70_marlin_u4b8_gemm(torch::Tensor& a, torch::Tensor& c,
                                     int64_t group_size) {
   c10::cuda::CUDAGuard device_guard(a.device());
 
-  auto const params = sm70_marlin_dense_auto_params(
-      "uint4b8", group_size, size_m, size_n, size_k);
+  auto const params = sm70_marlin_dense_auto_params("uint4b8", group_size,
+                                                    size_m, size_n, size_k);
   Sm70CtaGeometry const geometry = params.geometry;
-  validate_sm70_marlin_dense_cta_geometry_supported("SM70 Marlin uint4b8", geometry);
-  validate_sm70_marlin_dense_cta_n_alignment("SM70 Marlin uint4b8", geometry, size_n);
+  validate_sm70_marlin_dense_cta_geometry_supported("SM70 Marlin uint4b8",
+                                                    geometry);
+  validate_sm70_marlin_dense_cta_n_alignment("SM70 Marlin uint4b8", geometry,
+                                             size_n);
   if (params.use_metadata_vector_words) {
     Sm70U4B8Launcher<true> const launcher{
-        a, c, b_q_weight, b_scales, size_m, size_n, size_k,
-        params.requested_split_k};
+        a,      c,      b_q_weight, b_scales,
+        size_m, size_n, size_k,     params.requested_split_k};
     return dispatch_sm70_marlin_geometry(
         launcher, geometry, params.packed_macro_n, group_size, "uint4b8");
   }
   Sm70U4B8Launcher<false> const launcher{
-      a, c, b_q_weight, b_scales, size_m, size_n, size_k,
-      params.requested_split_k};
+      a,      c,      b_q_weight, b_scales,
+      size_m, size_n, size_k,     params.requested_split_k};
   return dispatch_sm70_marlin_geometry(
       launcher, geometry, params.packed_macro_n, group_size, "uint4b8");
 }

--- a/csrc/quantization/marlin/sm70_marlin_u8_gemm.cu
+++ b/csrc/quantization/marlin/sm70_marlin_u8_gemm.cu
@@ -20,24 +20,24 @@
 #include "cutlass/layout/tensor_op_multiplicand_sm70.h"
 #include "cutlass/transform/threadblock/predicated_tile_iterator.h"
 
-using marlin::sm70::Sm70CtaGeometry;
-using marlin::sm70::Sm70AtomicFp16Epilogue;
-using marlin::sm70::Sm70MarlinGemmTraits;
-using marlin::sm70::Sm70SplitKPartition;
-using marlin::sm70::validate_sm70_marlin_dense_cta_geometry_supported;
-using marlin::sm70::validate_sm70_marlin_dense_cta_n_alignment;
 using marlin::sm70::configure_sm70_dynamic_smem;
 using marlin::sm70::dispatch_sm70_marlin_geometry_with_group32;
 using marlin::sm70::kQuantTileK;
 using marlin::sm70::kQuantTileN;
-using marlin::sm70::sm70_marlin_dense_auto_params;
 using marlin::sm70::load_qword_vector;
 using marlin::sm70::qword_from_vector;
-using marlin::sm70::sm70_marlin_cta_grid;
 using marlin::sm70::sm70_active_split_k;
+using marlin::sm70::sm70_marlin_cta_grid;
+using marlin::sm70::sm70_marlin_dense_auto_params;
 using marlin::sm70::sm70_splitk_partition;
+using marlin::sm70::Sm70AtomicFp16Epilogue;
+using marlin::sm70::Sm70CtaGeometry;
+using marlin::sm70::Sm70MarlinGemmTraits;
+using marlin::sm70::Sm70SplitKPartition;
 using marlin::sm70::u8_packed_macro_n_qweight_offset_from_logical;
 using marlin::sm70::u8_packed_macro_n_qweight_word_stride;
+using marlin::sm70::validate_sm70_marlin_dense_cta_geometry_supported;
+using marlin::sm70::validate_sm70_marlin_dense_cta_n_alignment;
 
 namespace {
 
@@ -53,12 +53,11 @@ class Sm70U8ZpIteratorB {
   static int const kPackedMacroN = PackedMacroN_;
   static constexpr bool kUseMetadataVectorWords = UseMetadataVectorWords_;
   using Element = cutlass::half_t;
-  using Fragment = cutlass::Array<
-      Element, ThreadMap::Iterations::kCount * ThreadMap::kElementsPerAccess>;
+  using Fragment = cutlass::Array<Element, ThreadMap::Iterations::kCount *
+                                               ThreadMap::kElementsPerAccess>;
   static_assert(Shape::kN == 64 || Shape::kN == 128 || Shape::kN == 256,
                 "SM70 Marlin U8 IteratorB expects CTA_N in {64, 128, 256}.");
-  static_assert(ThreadMap::Iterations::kContiguous ==
-                    Shape::kN / kQuantTileN,
+  static_assert(ThreadMap::Iterations::kContiguous == Shape::kN / kQuantTileN,
                 "SM70 Marlin U8 IteratorB expects one contiguous iteration per "
                 "64-column quant tile.");
   static_assert(ThreadMap::Delta::kContiguous == kQuantTileN,
@@ -117,7 +116,7 @@ class Sm70U8ZpIteratorB {
     qweight_base_offset_ =
         qweight_offset_from_logical(params_, logical_k, logical_n);
     if constexpr (kGroupSize == -1) {
-        cache_current_group_metadata(0);
+      cache_current_group_metadata(0);
     }
   }
 
@@ -153,8 +152,7 @@ class Sm70U8ZpIteratorB {
     if constexpr (kGroupSize == -1) {
       return 0;
     } else {
-      static_assert(kGroupSize == 32 || kGroupSize == 64 ||
-                        kGroupSize == 128,
+      static_assert(kGroupSize == 32 || kGroupSize == 64 || kGroupSize == 128,
                     "SM70 Marlin U8 supports only group sizes "
                     "-1, 32, 64, and 128.");
       return logical_k / kGroupSize;
@@ -164,8 +162,8 @@ class Sm70U8ZpIteratorB {
   CUTLASS_DEVICE
   static int qweight_offset_from_logical(Params const& params, int logical_k,
                                          int logical_n) {
-    return u8_packed_macro_n_qweight_offset_from_logical<kPackedMacroN>(params.size_n, logical_k,
-                                                  logical_n);
+    return u8_packed_macro_n_qweight_offset_from_logical<kPackedMacroN>(
+        params.size_n, logical_k, logical_n);
   }
 
   CUTLASS_DEVICE
@@ -183,8 +181,8 @@ class Sm70U8ZpIteratorB {
     scale_cache[2] = scale_vec[2];
     scale_cache[3] = scale_vec[3];
 
-    half2 const* zp_vec = reinterpret_cast<half2 const*>(
-        zp_ + group * params_.size_n + cache_n);
+    half2 const* zp_vec =
+        reinterpret_cast<half2 const*>(zp_ + group * params_.size_n + cache_n);
     half2* zp_cache = cached_zp_ + c * 4;
     zp_cache[0] = zp_vec[0];
     zp_cache[1] = zp_vec[1];
@@ -203,8 +201,8 @@ class Sm70U8ZpIteratorB {
     scale_cache[2] = scale_vec[2];
     scale_cache[3] = scale_vec[3];
 
-    uint4 const zp_words = *reinterpret_cast<uint4 const*>(
-        zp_ + group * params_.size_n + cache_n);
+    uint4 const zp_words =
+        *reinterpret_cast<uint4 const*>(zp_ + group * params_.size_n + cache_n);
     half2 const* zp_vec = reinterpret_cast<half2 const*>(&zp_words);
     half2* zp_cache = cached_zp_ + c * 4;
     zp_cache[0] = zp_vec[0];
@@ -217,9 +215,8 @@ class Sm70U8ZpIteratorB {
   void cache_current_group_metadata(int group) const {
     CUTLASS_PRAGMA_UNROLL
     for (int c = 0; c < ThreadMap::Iterations::kContiguous; ++c) {
-      int const cache_n =
-          n_offset_ + thread_offset_.contiguous() +
-          c * ThreadMap::Delta::kContiguous;
+      int const cache_n = n_offset_ + thread_offset_.contiguous() +
+                          c * ThreadMap::Delta::kContiguous;
       if constexpr (kUseMetadataVectorWords) {
         cache_metadata_vector_words(c, group, cache_n);
       } else {
@@ -293,12 +290,12 @@ class Sm70U8ZpIteratorB {
 
         half2 deq[2];
         half2* frag_vec = reinterpret_cast<half2*>(frag.data());
-        marlin::dequant<half2, vllm::kU8.id(), false>(
-            static_cast<int>(qword0), deq);
+        marlin::dequant<half2, vllm::kU8.id(), false>(static_cast<int>(qword0),
+                                                      deq);
         frag_vec[0] = __hfma2(deq[0], scale_vec[0], __hneg2(zp_vec[0]));
         frag_vec[1] = __hfma2(deq[1], scale_vec[1], __hneg2(zp_vec[1]));
-        marlin::dequant<half2, vllm::kU8.id(), false>(
-            static_cast<int>(qword1), deq);
+        marlin::dequant<half2, vllm::kU8.id(), false>(static_cast<int>(qword1),
+                                                      deq);
         frag_vec[2] = __hfma2(deq[0], scale_vec[2], __hneg2(zp_vec[2]));
         frag_vec[3] = __hfma2(deq[1], scale_vec[3], __hneg2(zp_vec[3]));
       }
@@ -306,19 +303,17 @@ class Sm70U8ZpIteratorB {
       int const logical_n_base = n_offset_ + thread_offset_.contiguous();
       CUTLASS_PRAGMA_UNROLL
       for (int s = 0; s < ThreadMap::Iterations::kStrided; ++s) {
-        int const logical_k_s =
-            k_offset_ + thread_offset_.strided() +
-            s * ThreadMap::Delta::kStrided;
+        int const logical_k_s = k_offset_ + thread_offset_.strided() +
+                                s * ThreadMap::Delta::kStrided;
         if constexpr (kGroupSize != -1) {
           cache_current_group_metadata(scale_group(logical_k_s));
         }
         int const qweight_base_s =
             qweight_offset_from_logical(params_, logical_k_s, logical_n_base);
         if constexpr (ThreadMap::Iterations::kContiguous == 4) {
-          uint4 const qwords0 =
-              load_qword_vector<4>(qweight_ + qweight_base_s);
-          uint4 const qwords1 = load_qword_vector<4>(
-              qweight_ + qweight_base_s + kQweightWordStrideWords);
+          uint4 const qwords0 = load_qword_vector<4>(qweight_ + qweight_base_s);
+          uint4 const qwords1 = load_qword_vector<4>(qweight_ + qweight_base_s +
+                                                     kQweightWordStrideWords);
           CUTLASS_PRAGMA_UNROLL
           for (int c = 0; c < ThreadMap::Iterations::kContiguous; ++c) {
             constexpr int kAccess = ThreadMap::kElementsPerAccess;
@@ -333,22 +328,17 @@ class Sm70U8ZpIteratorB {
             half2* frag_vec = reinterpret_cast<half2*>(frag.data() + frag_base);
             marlin::dequant<half2, vllm::kU8.id(), false>(
                 static_cast<int>(qword0), deq);
-            frag_vec[0] =
-                __hfma2(deq[0], scale_vec[0], __hneg2(zp_vec[0]));
-            frag_vec[1] =
-                __hfma2(deq[1], scale_vec[1], __hneg2(zp_vec[1]));
+            frag_vec[0] = __hfma2(deq[0], scale_vec[0], __hneg2(zp_vec[0]));
+            frag_vec[1] = __hfma2(deq[1], scale_vec[1], __hneg2(zp_vec[1]));
             marlin::dequant<half2, vllm::kU8.id(), false>(
                 static_cast<int>(qword1), deq);
-            frag_vec[2] =
-                __hfma2(deq[0], scale_vec[2], __hneg2(zp_vec[2]));
-            frag_vec[3] =
-                __hfma2(deq[1], scale_vec[3], __hneg2(zp_vec[3]));
+            frag_vec[2] = __hfma2(deq[0], scale_vec[2], __hneg2(zp_vec[2]));
+            frag_vec[3] = __hfma2(deq[1], scale_vec[3], __hneg2(zp_vec[3]));
           }
         } else if constexpr (ThreadMap::Iterations::kContiguous == 2) {
-          uint2 const qwords0 =
-              load_qword_vector<2>(qweight_ + qweight_base_s);
-          uint2 const qwords1 = load_qword_vector<2>(
-              qweight_ + qweight_base_s + kQweightWordStrideWords);
+          uint2 const qwords0 = load_qword_vector<2>(qweight_ + qweight_base_s);
+          uint2 const qwords1 = load_qword_vector<2>(qweight_ + qweight_base_s +
+                                                     kQweightWordStrideWords);
           CUTLASS_PRAGMA_UNROLL
           for (int c = 0; c < ThreadMap::Iterations::kContiguous; ++c) {
             constexpr int kAccess = ThreadMap::kElementsPerAccess;
@@ -363,20 +353,17 @@ class Sm70U8ZpIteratorB {
             half2* frag_vec = reinterpret_cast<half2*>(frag.data() + frag_base);
             marlin::dequant<half2, vllm::kU8.id(), false>(
                 static_cast<int>(qword0), deq);
-            frag_vec[0] =
-                __hfma2(deq[0], scale_vec[0], __hneg2(zp_vec[0]));
-            frag_vec[1] =
-                __hfma2(deq[1], scale_vec[1], __hneg2(zp_vec[1]));
+            frag_vec[0] = __hfma2(deq[0], scale_vec[0], __hneg2(zp_vec[0]));
+            frag_vec[1] = __hfma2(deq[1], scale_vec[1], __hneg2(zp_vec[1]));
             marlin::dequant<half2, vllm::kU8.id(), false>(
                 static_cast<int>(qword1), deq);
-            frag_vec[2] =
-                __hfma2(deq[0], scale_vec[2], __hneg2(zp_vec[2]));
-            frag_vec[3] =
-                __hfma2(deq[1], scale_vec[3], __hneg2(zp_vec[3]));
+            frag_vec[2] = __hfma2(deq[0], scale_vec[2], __hneg2(zp_vec[2]));
+            frag_vec[3] = __hfma2(deq[1], scale_vec[3], __hneg2(zp_vec[3]));
           }
         } else {
-          static_assert(ThreadMap::Iterations::kContiguous == 1,
-                        "Unsupported SM70 Marlin U8 contiguous iteration count.");
+          static_assert(
+              ThreadMap::Iterations::kContiguous == 1,
+              "Unsupported SM70 Marlin U8 contiguous iteration count.");
           uint32_t const qword0 =
               load_qword_vector<1>(qweight_ + qweight_base_s);
           uint32_t const qword1 = load_qword_vector<1>(
@@ -407,8 +394,7 @@ class Sm70U8ZpIteratorB {
       return;
     }
 
-    if constexpr (kGroupSize != -1 &&
-                  ThreadMap::Iterations::kStrided == 1) {
+    if constexpr (kGroupSize != -1 && ThreadMap::Iterations::kStrided == 1) {
       int const first_logical_k = k_offset_ + thread_offset_.strided();
       cache_current_group_metadata(scale_group(first_logical_k));
     }
@@ -420,32 +406,30 @@ class Sm70U8ZpIteratorB {
 template <bool UseMetadataVectorWords = true>
 struct Sm70U8ZpGemmSpec {
   template <typename Shape, typename ThreadMap, int GroupSize, int PackedMacroN>
-  using IteratorB =
-      Sm70U8ZpIteratorB<Shape, ThreadMap, GroupSize, PackedMacroN,
-                        UseMetadataVectorWords>;
+  using IteratorB = Sm70U8ZpIteratorB<Shape, ThreadMap, GroupSize, PackedMacroN,
+                                      UseMetadataVectorWords>;
 };
 
-template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM,
-          int WarpN, int WarpK, int GroupSize, int PackedMacroN,
+template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM, int WarpN,
+          int WarpK, int GroupSize, int PackedMacroN,
           bool UseMetadataVectorWords = true>
 using Sm70U8ZpGemmTraits =
-    Sm70MarlinGemmTraits<Sm70U8ZpGemmSpec<UseMetadataVectorWords>, CtaM,
-                         CtaN, CtaK, Warps, WarpM, WarpN, WarpK,
-                         GroupSize, PackedMacroN>;
+    Sm70MarlinGemmTraits<Sm70U8ZpGemmSpec<UseMetadataVectorWords>, CtaM, CtaN,
+                         CtaK, Warps, WarpM, WarpN, WarpK, GroupSize,
+                         PackedMacroN>;
 
-template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM,
-          int WarpN, int WarpK, int GroupSize, int PackedMacroN,
+template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM, int WarpN,
+          int WarpK, int GroupSize, int PackedMacroN,
           bool UseMetadataVectorWords = true>
-__global__ __launch_bounds__(Warps * 32, 1)
-void sm70_marlin_u8_gemm_kernel(
+__global__ __launch_bounds__(Warps * 32, 1) void sm70_marlin_u8_gemm_kernel(
     cutlass::half_t const* __restrict__ a,
     uint32_t const* __restrict__ b_q_weight,
     cutlass::half_t const* __restrict__ b_scales,
     cutlass::half_t const* __restrict__ b_zeros,
     cutlass::half_t* __restrict__ c, int m, int n, int k, int lda) {
-  using Traits = Sm70U8ZpGemmTraits<CtaM, CtaN, CtaK, Warps, WarpM,
-                                    WarpN, WarpK, GroupSize, PackedMacroN,
-                                    UseMetadataVectorWords>;
+  using Traits =
+      Sm70U8ZpGemmTraits<CtaM, CtaN, CtaK, Warps, WarpM, WarpN, WarpK,
+                         GroupSize, PackedMacroN, UseMetadataVectorWords>;
   using Mma = typename Traits::Mma;
   using Epilogue = typename Traits::Epilogue;
 
@@ -465,10 +449,10 @@ void sm70_marlin_u8_gemm_kernel(
   typename Traits::LayoutA layout_a(lda);
   typename Traits::LayoutC layout_c(n);
 
-  typename Mma::IteratorA iterator_A(
-      typename Mma::IteratorA::Params(layout_a),
-      const_cast<cutlass::half_t*>(a), cutlass::MatrixCoord(m, k), thread_idx,
-      tb_offset_A);
+  typename Mma::IteratorA iterator_A(typename Mma::IteratorA::Params(layout_a),
+                                     const_cast<cutlass::half_t*>(a),
+                                     cutlass::MatrixCoord(m, k), thread_idx,
+                                     tb_offset_A);
   typename Mma::IteratorB iterator_B(
       typename Mma::IteratorB::Params(k, n),
       reinterpret_cast<uint32_t const*>(b_q_weight),
@@ -494,19 +478,20 @@ void sm70_marlin_u8_gemm_kernel(
   epilogue(output_op, iterator_D, accumulators, iterator_C);
 }
 
-template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM,
-          int WarpN, int WarpK, int GroupSize, int PackedMacroN,
+template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM, int WarpN,
+          int WarpK, int GroupSize, int PackedMacroN,
           bool UseMetadataVectorWords = true>
-__global__ __launch_bounds__(Warps * 32, 1)
-void sm70_marlin_u8_gemm_splitk_kernel(
+__global__
+__launch_bounds__(Warps * 32, 1) void sm70_marlin_u8_gemm_splitk_kernel(
     cutlass::half_t const* __restrict__ a,
     uint32_t const* __restrict__ b_q_weight,
     cutlass::half_t const* __restrict__ b_scales,
     cutlass::half_t const* __restrict__ b_zeros,
-    cutlass::half_t* __restrict__ c, int m, int n, int k, int lda, int requested_split_k) {
-  using Traits = Sm70U8ZpGemmTraits<CtaM, CtaN, CtaK, Warps, WarpM,
-                                    WarpN, WarpK, GroupSize, PackedMacroN,
-                                    UseMetadataVectorWords>;
+    cutlass::half_t* __restrict__ c, int m, int n, int k, int lda,
+    int requested_split_k) {
+  using Traits =
+      Sm70U8ZpGemmTraits<CtaM, CtaN, CtaK, Warps, WarpM, WarpN, WarpK,
+                         GroupSize, PackedMacroN, UseMetadataVectorWords>;
   using Mma = typename Traits::Mma;
   using AtomicEpilogue = Sm70AtomicFp16Epilogue<Traits>;
 
@@ -517,14 +502,13 @@ void sm70_marlin_u8_gemm_splitk_kernel(
   int const thread_idx = threadIdx.x;
   int const warp_idx = cutlass::canonical_warp_idx_sync();
   int const lane_idx = threadIdx.x % 32;
-  Sm70SplitKPartition const partition =
-      sm70_splitk_partition<GroupSize, CtaK>(k, requested_split_k, int(blockIdx.z));
+  Sm70SplitKPartition const partition = sm70_splitk_partition<GroupSize, CtaK>(
+      k, requested_split_k, int(blockIdx.z));
   if (partition.partition_k == 0) {
     return;
   }
 
-  cutlass::MatrixCoord tb_offset_A{int(blockIdx.x) * CtaM,
-                                   partition.k_begin};
+  cutlass::MatrixCoord tb_offset_A{int(blockIdx.x) * CtaM, partition.k_begin};
   cutlass::MatrixCoord tb_offset_B{partition.k_begin, int(blockIdx.y) * CtaN};
   cutlass::MatrixCoord tb_offset_C{int(blockIdx.x) * CtaM,
                                    int(blockIdx.y) * CtaN};
@@ -532,10 +516,10 @@ void sm70_marlin_u8_gemm_splitk_kernel(
   typename Traits::LayoutA layout_a(lda);
   typename Traits::LayoutC layout_c(n);
 
-  typename Mma::IteratorA iterator_A(
-      typename Mma::IteratorA::Params(layout_a),
-      const_cast<cutlass::half_t*>(a), cutlass::MatrixCoord(m, k), thread_idx,
-      tb_offset_A);
+  typename Mma::IteratorA iterator_A(typename Mma::IteratorA::Params(layout_a),
+                                     const_cast<cutlass::half_t*>(a),
+                                     cutlass::MatrixCoord(m, k), thread_idx,
+                                     tb_offset_A);
   typename Mma::IteratorB iterator_B(
       typename Mma::IteratorB::Params(k, n),
       reinterpret_cast<uint32_t const*>(b_q_weight),
@@ -550,9 +534,8 @@ void sm70_marlin_u8_gemm_splitk_kernel(
   mma(gemm_k_iterations, accumulators, iterator_A, iterator_B, accumulators);
 
   typename AtomicEpilogue::OutputTileIterator iterator_D(
-      typename AtomicEpilogue::OutputTileIterator::Params(layout_c),
-      c, cutlass::MatrixCoord(m, n),
-      thread_idx, tb_offset_C);
+      typename AtomicEpilogue::OutputTileIterator::Params(layout_c), c,
+      cutlass::MatrixCoord(m, n), thread_idx, tb_offset_C);
 
   AtomicEpilogue epilogue(shared_storage.epilogue, thread_idx, warp_idx,
                           lane_idx);
@@ -561,20 +544,23 @@ void sm70_marlin_u8_gemm_splitk_kernel(
 
 }  // namespace
 
-template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM,
-          int WarpN, int WarpK, int GroupSize, int PackedMacroN,
+template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM, int WarpN,
+          int WarpK, int GroupSize, int PackedMacroN,
           bool UseMetadataVectorWords = true>
-torch::Tensor launch_sm70_marlin_u8_gemm(
-    torch::Tensor& a, torch::Tensor& c, torch::Tensor& b_q_weight,
-    torch::Tensor& b_scales, torch::Tensor& b_zeros, int64_t size_m,
-    int64_t size_n, int64_t size_k, int requested_split_k) {
+torch::Tensor launch_sm70_marlin_u8_gemm(torch::Tensor& a, torch::Tensor& c,
+                                         torch::Tensor& b_q_weight,
+                                         torch::Tensor& b_scales,
+                                         torch::Tensor& b_zeros, int64_t size_m,
+                                         int64_t size_n, int64_t size_k,
+                                         int requested_split_k) {
   auto kernel =
       sm70_marlin_u8_gemm_kernel<CtaM, CtaN, CtaK, Warps, WarpM, WarpN, WarpK,
                                  GroupSize, PackedMacroN,
                                  UseMetadataVectorWords>;
-  using SharedStorage = typename Sm70U8ZpGemmTraits<
-      CtaM, CtaN, CtaK, Warps, WarpM, WarpN, WarpK, GroupSize,
-      PackedMacroN, UseMetadataVectorWords>::SharedStorage;
+  using SharedStorage =
+      typename Sm70U8ZpGemmTraits<CtaM, CtaN, CtaK, Warps, WarpM, WarpN, WarpK,
+                                  GroupSize, PackedMacroN,
+                                  UseMetadataVectorWords>::SharedStorage;
   size_t smem_bytes = configure_sm70_dynamic_smem<SharedStorage>(kernel);
 
   dim3 block(Warps * 32);
@@ -595,8 +581,8 @@ torch::Tensor launch_sm70_marlin_u8_gemm(
   }
 
   TORCH_CHECK(size_k % int64_t(CtaK) == 0,
-              "SM70 Marlin uint8 requires K divisible by CTA_K=",
-              CtaK, " for requested_split_k > 1. Got K=", size_k,
+              "SM70 Marlin uint8 requires K divisible by CTA_K=", CtaK,
+              " for requested_split_k > 1. Got K=", size_k,
               ", requested_split_k=", requested_split_k, ".");
 
   auto split_kernel =
@@ -606,9 +592,9 @@ torch::Tensor launch_sm70_marlin_u8_gemm(
   smem_bytes = configure_sm70_dynamic_smem<SharedStorage>(split_kernel);
 
   int64_t const numel = size_m * size_n;
-  C10_CUDA_CHECK(cudaMemsetAsync(
-      c.data_ptr<at::Half>(), 0,
-      static_cast<size_t>(numel) * sizeof(at::Half), stream));
+  C10_CUDA_CHECK(cudaMemsetAsync(c.data_ptr<at::Half>(), 0,
+                                 static_cast<size_t>(numel) * sizeof(at::Half),
+                                 stream));
 
   dim3 grid = sm70_marlin_cta_grid(size_m, size_n, CtaM, CtaN);
   int const active_split_k =
@@ -621,7 +607,8 @@ torch::Tensor launch_sm70_marlin_u8_gemm(
       reinterpret_cast<cutlass::half_t const*>(b_zeros.data_ptr<at::Half>()),
       reinterpret_cast<cutlass::half_t*>(c.data_ptr<at::Half>()),
       static_cast<int>(size_m), static_cast<int>(size_n),
-      static_cast<int>(size_k), static_cast<int>(a.stride(0)), requested_split_k);
+      static_cast<int>(size_k), static_cast<int>(a.stride(0)),
+      requested_split_k);
   C10_CUDA_KERNEL_LAUNCH_CHECK();
 
   return c;
@@ -639,13 +626,14 @@ struct Sm70U8Launcher {
   int64_t size_k;
   int requested_split_k;
 
-  template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM,
-            int WarpN, int WarpK, int GroupSize, int PackedMacroN>
+  template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM, int WarpN,
+            int WarpK, int GroupSize, int PackedMacroN>
   torch::Tensor operator()() const {
-    return launch_sm70_marlin_u8_gemm<CtaM, CtaN, CtaK, Warps, WarpM, WarpN, WarpK,
-                                      GroupSize, PackedMacroN,
+    return launch_sm70_marlin_u8_gemm<CtaM, CtaN, CtaK, Warps, WarpM, WarpN,
+                                      WarpK, GroupSize, PackedMacroN,
                                       UseMetadataVectorWords>(
-        a, c, b_q_weight, b_scales, b_zeros, size_m, size_n, size_k, requested_split_k);
+        a, c, b_q_weight, b_scales, b_zeros, size_m, size_n, size_k,
+        requested_split_k);
   }
 };
 
@@ -657,22 +645,25 @@ torch::Tensor sm70_marlin_u8_gemm(torch::Tensor& a, torch::Tensor& c,
                                   int64_t group_size) {
   c10::cuda::CUDAGuard device_guard(a.device());
 
-  auto const params =
-      sm70_marlin_dense_auto_params("uint8", group_size, size_m, size_n,
-                                    size_k);
+  auto const params = sm70_marlin_dense_auto_params("uint8", group_size, size_m,
+                                                    size_n, size_k);
   Sm70CtaGeometry const geometry = params.geometry;
-  validate_sm70_marlin_dense_cta_geometry_supported("SM70 Marlin uint8", geometry);
-  validate_sm70_marlin_dense_cta_n_alignment("SM70 Marlin uint8", geometry, size_n);
+  validate_sm70_marlin_dense_cta_geometry_supported("SM70 Marlin uint8",
+                                                    geometry);
+  validate_sm70_marlin_dense_cta_n_alignment("SM70 Marlin uint8", geometry,
+                                             size_n);
   if (params.use_metadata_vector_words) {
     Sm70U8Launcher<true> const launcher{
-        a, c, b_q_weight, b_scales, b_zeros, size_m, size_n, size_k,
-        params.requested_split_k};
+        a,        c,       b_q_weight,
+        b_scales, b_zeros, size_m,
+        size_n,   size_k,  params.requested_split_k};
     return dispatch_sm70_marlin_geometry_with_group32(
         launcher, geometry, params.packed_macro_n, group_size, "uint8");
   }
   Sm70U8Launcher<false> const launcher{
-      a, c, b_q_weight, b_scales, b_zeros, size_m, size_n, size_k,
-      params.requested_split_k};
+      a,        c,       b_q_weight,
+      b_scales, b_zeros, size_m,
+      size_n,   size_k,  params.requested_split_k};
   return dispatch_sm70_marlin_geometry_with_group32(
       launcher, geometry, params.packed_macro_n, group_size, "uint8");
 }

--- a/csrc/quantization/marlin/sm70_marlin_u8b128_gemm.cu
+++ b/csrc/quantization/marlin/sm70_marlin_u8b128_gemm.cu
@@ -20,24 +20,24 @@
 #include "cutlass/layout/tensor_op_multiplicand_sm70.h"
 #include "cutlass/transform/threadblock/predicated_tile_iterator.h"
 
-using marlin::sm70::Sm70CtaGeometry;
-using marlin::sm70::Sm70AtomicFp16Epilogue;
-using marlin::sm70::Sm70MarlinGemmTraits;
-using marlin::sm70::Sm70SplitKPartition;
-using marlin::sm70::validate_sm70_marlin_dense_cta_geometry_supported;
-using marlin::sm70::validate_sm70_marlin_dense_cta_n_alignment;
 using marlin::sm70::configure_sm70_dynamic_smem;
 using marlin::sm70::dispatch_sm70_marlin_geometry_with_group32;
 using marlin::sm70::kQuantTileK;
 using marlin::sm70::kQuantTileN;
-using marlin::sm70::sm70_marlin_dense_auto_params;
 using marlin::sm70::load_qword_vector;
 using marlin::sm70::qword_from_vector;
-using marlin::sm70::sm70_marlin_cta_grid;
 using marlin::sm70::sm70_active_split_k;
+using marlin::sm70::sm70_marlin_cta_grid;
+using marlin::sm70::sm70_marlin_dense_auto_params;
 using marlin::sm70::sm70_splitk_partition;
+using marlin::sm70::Sm70AtomicFp16Epilogue;
+using marlin::sm70::Sm70CtaGeometry;
+using marlin::sm70::Sm70MarlinGemmTraits;
+using marlin::sm70::Sm70SplitKPartition;
 using marlin::sm70::u8_packed_macro_n_qweight_offset_from_logical;
 using marlin::sm70::u8_packed_macro_n_qweight_word_stride;
+using marlin::sm70::validate_sm70_marlin_dense_cta_geometry_supported;
+using marlin::sm70::validate_sm70_marlin_dense_cta_n_alignment;
 
 namespace {
 
@@ -53,12 +53,12 @@ class Sm70U8B128IteratorB {
   static int const kPackedMacroN = PackedMacroN_;
   static constexpr bool kUseMetadataVectorWords = UseMetadataVectorWords_;
   using Element = cutlass::half_t;
-  using Fragment = cutlass::Array<
-      Element, ThreadMap::Iterations::kCount * ThreadMap::kElementsPerAccess>;
-  static_assert(Shape::kN == 64 || Shape::kN == 128 || Shape::kN == 256,
-                "SM70 Marlin U8B128 IteratorB expects CTA_N in {64, 128, 256}.");
-  static_assert(ThreadMap::Iterations::kContiguous ==
-                    Shape::kN / kQuantTileN,
+  using Fragment = cutlass::Array<Element, ThreadMap::Iterations::kCount *
+                                               ThreadMap::kElementsPerAccess>;
+  static_assert(
+      Shape::kN == 64 || Shape::kN == 128 || Shape::kN == 256,
+      "SM70 Marlin U8B128 IteratorB expects CTA_N in {64, 128, 256}.");
+  static_assert(ThreadMap::Iterations::kContiguous == Shape::kN / kQuantTileN,
                 "SM70 Marlin U8B128 IteratorB expects one contiguous iteration "
                 "per 64-column quant tile.");
   static_assert(ThreadMap::Delta::kContiguous == kQuantTileN,
@@ -150,8 +150,7 @@ class Sm70U8B128IteratorB {
     if constexpr (kGroupSize == -1) {
       return 0;
     } else {
-      static_assert(kGroupSize == 32 || kGroupSize == 64 ||
-                        kGroupSize == 128,
+      static_assert(kGroupSize == 32 || kGroupSize == 64 || kGroupSize == 128,
                     "SM70 Marlin U8B128 supports only group sizes "
                     "-1, 32, 64, and 128.");
       return logical_k / kGroupSize;
@@ -161,13 +160,12 @@ class Sm70U8B128IteratorB {
   CUTLASS_DEVICE
   static int qweight_offset_from_logical(Params const& params, int logical_k,
                                          int logical_n) {
-    return u8_packed_macro_n_qweight_offset_from_logical<kPackedMacroN>(params.size_n, logical_k,
-                                                     logical_n);
+    return u8_packed_macro_n_qweight_offset_from_logical<kPackedMacroN>(
+        params.size_n, logical_k, logical_n);
   }
 
   CUTLASS_DEVICE
-  static int qweight_word_stride_from_logical(Params const&,
-                                              int logical_n) {
+  static int qweight_word_stride_from_logical(Params const&, int logical_n) {
     return u8_packed_macro_n_qweight_word_stride<kPackedMacroN>();
   }
 
@@ -198,9 +196,8 @@ class Sm70U8B128IteratorB {
   void cache_current_group_metadata(int group) const {
     CUTLASS_PRAGMA_UNROLL
     for (int c = 0; c < ThreadMap::Iterations::kContiguous; ++c) {
-      int const cache_n =
-          n_offset_ + thread_offset_.contiguous() +
-          c * ThreadMap::Delta::kContiguous;
+      int const cache_n = n_offset_ + thread_offset_.contiguous() +
+                          c * ThreadMap::Delta::kContiguous;
       if constexpr (kUseMetadataVectorWords) {
         cache_metadata_vector_words(c, group, cache_n);
       } else {
@@ -261,8 +258,9 @@ class Sm70U8B128IteratorB {
           frag_vec[3] = __hmul2(deq[1], scale_vec[3]);
         }
       } else {
-        static_assert(ThreadMap::Iterations::kContiguous == 1,
-                      "Unsupported SM70 Marlin U8B128 contiguous iteration count.");
+        static_assert(
+            ThreadMap::Iterations::kContiguous == 1,
+            "Unsupported SM70 Marlin U8B128 contiguous iteration count.");
         uint32_t const qword0 =
             load_qword_vector<1>(qweight_ + qweight_base_offset_);
         uint32_t const qword1 = load_qword_vector<1>(
@@ -284,19 +282,17 @@ class Sm70U8B128IteratorB {
       int const logical_n_base = n_offset_ + thread_offset_.contiguous();
       CUTLASS_PRAGMA_UNROLL
       for (int s = 0; s < ThreadMap::Iterations::kStrided; ++s) {
-        int const logical_k_s =
-            k_offset_ + thread_offset_.strided() +
-            s * ThreadMap::Delta::kStrided;
+        int const logical_k_s = k_offset_ + thread_offset_.strided() +
+                                s * ThreadMap::Delta::kStrided;
         if constexpr (kGroupSize != -1) {
           cache_current_group_metadata(scale_group(logical_k_s));
         }
         int const qweight_base_s =
             qweight_offset_from_logical(params_, logical_k_s, logical_n_base);
         if constexpr (ThreadMap::Iterations::kContiguous == 4) {
-          uint4 const qwords0 =
-              load_qword_vector<4>(qweight_ + qweight_base_s);
-          uint4 const qwords1 = load_qword_vector<4>(
-              qweight_ + qweight_base_s + kQweightWordStrideWords);
+          uint4 const qwords0 = load_qword_vector<4>(qweight_ + qweight_base_s);
+          uint4 const qwords1 = load_qword_vector<4>(qweight_ + qweight_base_s +
+                                                     kQweightWordStrideWords);
           CUTLASS_PRAGMA_UNROLL
           for (int c = 0; c < ThreadMap::Iterations::kContiguous; ++c) {
             constexpr int kAccess = ThreadMap::kElementsPerAccess;
@@ -318,10 +314,9 @@ class Sm70U8B128IteratorB {
             frag_vec[3] = __hmul2(deq[1], scale_vec[3]);
           }
         } else if constexpr (ThreadMap::Iterations::kContiguous == 2) {
-          uint2 const qwords0 =
-              load_qword_vector<2>(qweight_ + qweight_base_s);
-          uint2 const qwords1 = load_qword_vector<2>(
-              qweight_ + qweight_base_s + kQweightWordStrideWords);
+          uint2 const qwords0 = load_qword_vector<2>(qweight_ + qweight_base_s);
+          uint2 const qwords1 = load_qword_vector<2>(qweight_ + qweight_base_s +
+                                                     kQweightWordStrideWords);
           CUTLASS_PRAGMA_UNROLL
           for (int c = 0; c < ThreadMap::Iterations::kContiguous; ++c) {
             constexpr int kAccess = ThreadMap::kElementsPerAccess;
@@ -343,8 +338,9 @@ class Sm70U8B128IteratorB {
             frag_vec[3] = __hmul2(deq[1], scale_vec[3]);
           }
         } else {
-          static_assert(ThreadMap::Iterations::kContiguous == 1,
-                        "Unsupported SM70 Marlin U8B128 contiguous iteration count.");
+          static_assert(
+              ThreadMap::Iterations::kContiguous == 1,
+              "Unsupported SM70 Marlin U8B128 contiguous iteration count.");
           uint32_t const qword0 =
               load_qword_vector<1>(qweight_ + qweight_base_s);
           uint32_t const qword1 = load_qword_vector<1>(
@@ -374,8 +370,7 @@ class Sm70U8B128IteratorB {
       return;
     }
 
-    if constexpr (kGroupSize != -1 &&
-                  ThreadMap::Iterations::kStrided == 1) {
+    if constexpr (kGroupSize != -1 && ThreadMap::Iterations::kStrided == 1) {
       int const first_logical_k = k_offset_ + thread_offset_.strided();
       cache_current_group_metadata(scale_group(first_logical_k));
     }
@@ -387,32 +382,29 @@ class Sm70U8B128IteratorB {
 template <bool UseMetadataVectorWords = true>
 struct Sm70U8B128GemmSpec {
   template <typename Shape, typename ThreadMap, int GroupSize, int PackedMacroN>
-  using IteratorB =
-      Sm70U8B128IteratorB<Shape, ThreadMap, GroupSize, PackedMacroN,
-                          UseMetadataVectorWords>;
+  using IteratorB = Sm70U8B128IteratorB<Shape, ThreadMap, GroupSize,
+                                        PackedMacroN, UseMetadataVectorWords>;
 };
 
-template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM,
-          int WarpN, int WarpK, int GroupSize, int PackedMacroN,
+template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM, int WarpN,
+          int WarpK, int GroupSize, int PackedMacroN,
           bool UseMetadataVectorWords = true>
 using Sm70U8B128GemmTraits =
-    Sm70MarlinGemmTraits<Sm70U8B128GemmSpec<UseMetadataVectorWords>, CtaM,
-                         CtaN, CtaK, Warps, WarpM, WarpN, WarpK,
-                         GroupSize, PackedMacroN>;
+    Sm70MarlinGemmTraits<Sm70U8B128GemmSpec<UseMetadataVectorWords>, CtaM, CtaN,
+                         CtaK, Warps, WarpM, WarpN, WarpK, GroupSize,
+                         PackedMacroN>;
 
-template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM,
-          int WarpN, int WarpK, int GroupSize, int PackedMacroN,
+template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM, int WarpN,
+          int WarpK, int GroupSize, int PackedMacroN,
           bool UseMetadataVectorWords = true>
-__global__ __launch_bounds__(Warps * 32, 1)
-void sm70_marlin_u8b128_gemm_kernel(
+__global__ __launch_bounds__(Warps * 32, 1) void sm70_marlin_u8b128_gemm_kernel(
     cutlass::half_t const* __restrict__ a,
     uint32_t const* __restrict__ b_q_weight,
     cutlass::half_t const* __restrict__ b_scales,
     cutlass::half_t* __restrict__ c, int m, int n, int k, int lda) {
   using Traits =
       Sm70U8B128GemmTraits<CtaM, CtaN, CtaK, Warps, WarpM, WarpN, WarpK,
-                           GroupSize, PackedMacroN,
-                           UseMetadataVectorWords>;
+                           GroupSize, PackedMacroN, UseMetadataVectorWords>;
   using Mma = typename Traits::Mma;
   using Epilogue = typename Traits::Epilogue;
 
@@ -432,10 +424,10 @@ void sm70_marlin_u8b128_gemm_kernel(
   typename Traits::LayoutA layout_a(lda);
   typename Traits::LayoutC layout_c(n);
 
-  typename Mma::IteratorA iterator_A(
-      typename Mma::IteratorA::Params(layout_a),
-      const_cast<cutlass::half_t*>(a), cutlass::MatrixCoord(m, k), thread_idx,
-      tb_offset_A);
+  typename Mma::IteratorA iterator_A(typename Mma::IteratorA::Params(layout_a),
+                                     const_cast<cutlass::half_t*>(a),
+                                     cutlass::MatrixCoord(m, k), thread_idx,
+                                     tb_offset_A);
   typename Mma::IteratorB iterator_B(
       typename Mma::IteratorB::Params(k, n),
       reinterpret_cast<uint32_t const*>(b_q_weight),
@@ -460,18 +452,19 @@ void sm70_marlin_u8b128_gemm_kernel(
   epilogue(output_op, iterator_D, accumulators, iterator_C);
 }
 
-template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM,
-          int WarpN, int WarpK, int GroupSize, int PackedMacroN,
+template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM, int WarpN,
+          int WarpK, int GroupSize, int PackedMacroN,
           bool UseMetadataVectorWords = true>
-__global__ __launch_bounds__(Warps * 32, 1)
-void sm70_marlin_u8b128_gemm_splitk_kernel(
+__global__
+__launch_bounds__(Warps * 32, 1) void sm70_marlin_u8b128_gemm_splitk_kernel(
     cutlass::half_t const* __restrict__ a,
     uint32_t const* __restrict__ b_q_weight,
     cutlass::half_t const* __restrict__ b_scales,
-    cutlass::half_t* __restrict__ c, int m, int n, int k, int lda, int requested_split_k) {
-  using Traits = Sm70U8B128GemmTraits<CtaM, CtaN, CtaK, Warps, WarpM,
-                                      WarpN, WarpK, GroupSize, PackedMacroN,
-                                      UseMetadataVectorWords>;
+    cutlass::half_t* __restrict__ c, int m, int n, int k, int lda,
+    int requested_split_k) {
+  using Traits =
+      Sm70U8B128GemmTraits<CtaM, CtaN, CtaK, Warps, WarpM, WarpN, WarpK,
+                           GroupSize, PackedMacroN, UseMetadataVectorWords>;
   using Mma = typename Traits::Mma;
   using AtomicEpilogue = Sm70AtomicFp16Epilogue<Traits>;
 
@@ -482,14 +475,13 @@ void sm70_marlin_u8b128_gemm_splitk_kernel(
   int const thread_idx = threadIdx.x;
   int const warp_idx = cutlass::canonical_warp_idx_sync();
   int const lane_idx = threadIdx.x % 32;
-  Sm70SplitKPartition const partition =
-      sm70_splitk_partition<GroupSize, CtaK>(k, requested_split_k, int(blockIdx.z));
+  Sm70SplitKPartition const partition = sm70_splitk_partition<GroupSize, CtaK>(
+      k, requested_split_k, int(blockIdx.z));
   if (partition.partition_k == 0) {
     return;
   }
 
-  cutlass::MatrixCoord tb_offset_A{int(blockIdx.x) * CtaM,
-                                   partition.k_begin};
+  cutlass::MatrixCoord tb_offset_A{int(blockIdx.x) * CtaM, partition.k_begin};
   cutlass::MatrixCoord tb_offset_B{partition.k_begin, int(blockIdx.y) * CtaN};
   cutlass::MatrixCoord tb_offset_C{int(blockIdx.x) * CtaM,
                                    int(blockIdx.y) * CtaN};
@@ -497,10 +489,10 @@ void sm70_marlin_u8b128_gemm_splitk_kernel(
   typename Traits::LayoutA layout_a(lda);
   typename Traits::LayoutC layout_c(n);
 
-  typename Mma::IteratorA iterator_A(
-      typename Mma::IteratorA::Params(layout_a),
-      const_cast<cutlass::half_t*>(a), cutlass::MatrixCoord(m, k), thread_idx,
-      tb_offset_A);
+  typename Mma::IteratorA iterator_A(typename Mma::IteratorA::Params(layout_a),
+                                     const_cast<cutlass::half_t*>(a),
+                                     cutlass::MatrixCoord(m, k), thread_idx,
+                                     tb_offset_A);
   typename Mma::IteratorB iterator_B(
       typename Mma::IteratorB::Params(k, n),
       reinterpret_cast<uint32_t const*>(b_q_weight),
@@ -514,9 +506,8 @@ void sm70_marlin_u8b128_gemm_splitk_kernel(
   mma(gemm_k_iterations, accumulators, iterator_A, iterator_B, accumulators);
 
   typename AtomicEpilogue::OutputTileIterator iterator_D(
-      typename AtomicEpilogue::OutputTileIterator::Params(layout_c),
-      c, cutlass::MatrixCoord(m, n),
-      thread_idx, tb_offset_C);
+      typename AtomicEpilogue::OutputTileIterator::Params(layout_c), c,
+      cutlass::MatrixCoord(m, n), thread_idx, tb_offset_C);
 
   AtomicEpilogue epilogue(shared_storage.epilogue, thread_idx, warp_idx,
                           lane_idx);
@@ -525,20 +516,23 @@ void sm70_marlin_u8b128_gemm_splitk_kernel(
 
 }  // namespace
 
-template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM,
-          int WarpN, int WarpK, int GroupSize, int PackedMacroN,
+template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM, int WarpN,
+          int WarpK, int GroupSize, int PackedMacroN,
           bool UseMetadataVectorWords = true>
-torch::Tensor launch_sm70_marlin_u8b128_gemm(
-    torch::Tensor& a, torch::Tensor& c, torch::Tensor& b_q_weight,
-    torch::Tensor& b_scales, int64_t size_m, int64_t size_n, int64_t size_k,
-    int requested_split_k) {
+torch::Tensor launch_sm70_marlin_u8b128_gemm(torch::Tensor& a, torch::Tensor& c,
+                                             torch::Tensor& b_q_weight,
+                                             torch::Tensor& b_scales,
+                                             int64_t size_m, int64_t size_n,
+                                             int64_t size_k,
+                                             int requested_split_k) {
   auto kernel =
       sm70_marlin_u8b128_gemm_kernel<CtaM, CtaN, CtaK, Warps, WarpM, WarpN,
                                      WarpK, GroupSize, PackedMacroN,
                                      UseMetadataVectorWords>;
-  using SharedStorage = typename Sm70U8B128GemmTraits<
-      CtaM, CtaN, CtaK, Warps, WarpM, WarpN, WarpK, GroupSize,
-      PackedMacroN, UseMetadataVectorWords>::SharedStorage;
+  using SharedStorage =
+      typename Sm70U8B128GemmTraits<CtaM, CtaN, CtaK, Warps, WarpM, WarpN,
+                                    WarpK, GroupSize, PackedMacroN,
+                                    UseMetadataVectorWords>::SharedStorage;
   size_t smem_bytes = configure_sm70_dynamic_smem<SharedStorage>(kernel);
 
   dim3 block(Warps * 32);
@@ -558,21 +552,19 @@ torch::Tensor launch_sm70_marlin_u8b128_gemm(
   }
 
   TORCH_CHECK(size_k % int64_t(CtaK) == 0,
-              "SM70 Marlin uint8b128 requires K divisible by CTA_K=",
-              CtaK, " for requested_split_k > 1. Got K=", size_k,
+              "SM70 Marlin uint8b128 requires K divisible by CTA_K=", CtaK,
+              " for requested_split_k > 1. Got K=", size_k,
               ", requested_split_k=", requested_split_k, ".");
 
-  auto split_kernel =
-      sm70_marlin_u8b128_gemm_splitk_kernel<CtaM, CtaN, CtaK, Warps, WarpM,
-                                            WarpN, WarpK, GroupSize,
-                                            PackedMacroN,
-                                            UseMetadataVectorWords>;
+  auto split_kernel = sm70_marlin_u8b128_gemm_splitk_kernel<
+      CtaM, CtaN, CtaK, Warps, WarpM, WarpN, WarpK, GroupSize, PackedMacroN,
+      UseMetadataVectorWords>;
   smem_bytes = configure_sm70_dynamic_smem<SharedStorage>(split_kernel);
 
   int64_t const numel = size_m * size_n;
-  C10_CUDA_CHECK(cudaMemsetAsync(
-      c.data_ptr<at::Half>(), 0,
-      static_cast<size_t>(numel) * sizeof(at::Half), stream));
+  C10_CUDA_CHECK(cudaMemsetAsync(c.data_ptr<at::Half>(), 0,
+                                 static_cast<size_t>(numel) * sizeof(at::Half),
+                                 stream));
 
   dim3 grid = sm70_marlin_cta_grid(size_m, size_n, CtaM, CtaN);
   int const active_split_k =
@@ -584,7 +576,8 @@ torch::Tensor launch_sm70_marlin_u8b128_gemm(
       reinterpret_cast<cutlass::half_t const*>(b_scales.data_ptr<at::Half>()),
       reinterpret_cast<cutlass::half_t*>(c.data_ptr<at::Half>()),
       static_cast<int>(size_m), static_cast<int>(size_n),
-      static_cast<int>(size_k), static_cast<int>(a.stride(0)), requested_split_k);
+      static_cast<int>(size_k), static_cast<int>(a.stride(0)),
+      requested_split_k);
   C10_CUDA_KERNEL_LAUNCH_CHECK();
 
   return c;
@@ -601,12 +594,11 @@ struct Sm70U8B128Launcher {
   int64_t size_k;
   int requested_split_k;
 
-  template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM,
-            int WarpN, int WarpK, int GroupSize, int PackedMacroN>
+  template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM, int WarpN,
+            int WarpK, int GroupSize, int PackedMacroN>
   torch::Tensor operator()() const {
-    return launch_sm70_marlin_u8b128_gemm<CtaM, CtaN, CtaK, Warps, WarpM,
-                                          WarpN, WarpK, GroupSize,
-                                          PackedMacroN,
+    return launch_sm70_marlin_u8b128_gemm<CtaM, CtaN, CtaK, Warps, WarpM, WarpN,
+                                          WarpK, GroupSize, PackedMacroN,
                                           UseMetadataVectorWords>(
         a, c, b_q_weight, b_scales, size_m, size_n, size_k, requested_split_k);
   }
@@ -619,21 +611,23 @@ torch::Tensor sm70_marlin_u8b128_gemm(torch::Tensor& a, torch::Tensor& c,
                                       int64_t group_size) {
   c10::cuda::CUDAGuard device_guard(a.device());
 
-  auto const params = sm70_marlin_dense_auto_params(
-      "uint8b128", group_size, size_m, size_n, size_k);
+  auto const params = sm70_marlin_dense_auto_params("uint8b128", group_size,
+                                                    size_m, size_n, size_k);
   Sm70CtaGeometry const geometry = params.geometry;
-  validate_sm70_marlin_dense_cta_geometry_supported("SM70 Marlin uint8b128", geometry);
-  validate_sm70_marlin_dense_cta_n_alignment("SM70 Marlin uint8b128", geometry, size_n);
+  validate_sm70_marlin_dense_cta_geometry_supported("SM70 Marlin uint8b128",
+                                                    geometry);
+  validate_sm70_marlin_dense_cta_n_alignment("SM70 Marlin uint8b128", geometry,
+                                             size_n);
   if (params.use_metadata_vector_words) {
     Sm70U8B128Launcher<true> const launcher{
-        a, c, b_q_weight, b_scales, size_m, size_n, size_k,
-        params.requested_split_k};
+        a,      c,      b_q_weight, b_scales,
+        size_m, size_n, size_k,     params.requested_split_k};
     return dispatch_sm70_marlin_geometry_with_group32(
         launcher, geometry, params.packed_macro_n, group_size, "uint8b128");
   }
   Sm70U8B128Launcher<false> const launcher{
-      a, c, b_q_weight, b_scales, size_m, size_n, size_k,
-      params.requested_split_k};
+      a,      c,      b_q_weight, b_scales,
+      size_m, size_n, size_k,     params.requested_split_k};
   return dispatch_sm70_marlin_geometry_with_group32(
       launcher, geometry, params.packed_macro_n, group_size, "uint8b128");
 }


### PR DESCRIPTION
Refs #126. Split from Draft PR #131.

## Scope
- 24 files under csrc/quantization/marlin and csrc/moe/marlin_moe_wna16 only.
- Exact mechanical sub-diff of d3b59af9c656413270e37cd55c0bf88e932a1c5d.
- Formatter debt only. No typo, algorithm, dispatch, numerical, or performance change is intended.
- This PR does not change the V100 TurboMind optimization policy.

## Validation
- Focused clang-format hook: passed.
- Focused typos hook: passed.
- Focused SPDX hook: skipped because the repository hook only accepts Python files.
- git diff --check and git show --check: passed.

## Risk
- Review as a formatter-only baseline cleanup. No physical GPU validation is available or claimed.