### PR TITLE
[Doc] Update recommended model providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,9 +39,9 @@ for long-context serving, and OpenAI-compatible API fixes for common clients.
 
 ## Recommended Model Providers
 
-- `tclf90/Qwen3.6-27B-AWQ`
-- `tclf90/Qwen3.6-35B-A3B-AWQ`
-- `tclf90/Qwen3.5-122B-A10B-AWQ` for larger 4-GPU setups
+- [QuantTrio/Qwen3.6-27B-AWQ](https://huggingface.co/QuantTrio/Qwen3.6-27B-AWQ)
+- [QuantTrio/Qwen3.6-35B-A3B-AWQ](https://huggingface.co/QuantTrio/Qwen3.6-35B-A3B-AWQ)
+- [QuantTrio/Qwen3.5-122B-A10B-AWQ](https://huggingface.co/QuantTrio/Qwen3.5-122B-A10B-AWQ) for larger 4-GPU setups
 
 The launch examples use local paths such as `/path/to/Qwen3.6-27B-AWQ`.
 Replace them with your local model path or a Hugging Face repository id.


### PR DESCRIPTION
## Purpose
Replace the stale Recommended Model Providers entries with the current QuantTrio Hugging Face model links.

Closes #36.

## Base
- Integration base: onecat/main at 3ec0c68c6596d6ab31fbdee9fa676254a52c2b7d
- Head: 31aac81eaac770a4e699189572245993e436f98d

## Scope
- README.md only.
- Preserves the local-path caveat.
- Does not change performance claims, compatibility policy, or code.

## Validation
- PRE_COMMIT_HOME=/tmp/onecat-precommit-docs36 uvx pre-commit run markdownlint-cli2 --files README.md
- git diff --check

## Risk
Documentation-only change; no runtime behavior is affected.