### PR TITLE
[CI/Build] Core C++ formatter debt only

### DIFF
--- a/csrc/custom_all_reduce.cu
+++ b/csrc/custom_all_reduce.cu
@@ -161,12 +161,12 @@ void sm70_all_reduce_gemma_rms_norm_impl(
                 "SM70 TP4 Gemma RMSNorm prototype residual must be float32.");
   } else {
     TORCH_CHECK(residual.scalar_type() == at::ScalarType::Half ||
-                residual.scalar_type() == at::ScalarType::Float,
+                    residual.scalar_type() == at::ScalarType::Float,
                 "SM70 Gemma RMSNorm prototype residual must be float16 or "
                 "float32.");
   }
   TORCH_CHECK(weight.scalar_type() == at::ScalarType::Half ||
-              weight.scalar_type() == at::ScalarType::Float,
+                  weight.scalar_type() == at::ScalarType::Float,
               "SM70 Gemma RMSNorm prototype weight must be float16 or "
               "float32.");
   TORCH_CHECK_EQ(inp.dim(), 2);
@@ -176,8 +176,9 @@ void sm70_all_reduce_gemma_rms_norm_impl(
   TORCH_CHECK(normalized_out.sizes() == inp.sizes(),
               "SM70 Gemma RMSNorm prototype normalized_out shape must match "
               "inp.");
-  TORCH_CHECK(residual_out.sizes() == inp.sizes(),
-              "SM70 Gemma RMSNorm prototype residual_out shape must match inp.");
+  TORCH_CHECK(
+      residual_out.sizes() == inp.sizes(),
+      "SM70 Gemma RMSNorm prototype residual_out shape must match inp.");
   TORCH_CHECK_EQ(weight.dim(), 1);
   TORCH_CHECK_EQ(weight.numel(), kHiddenSize);
   TORCH_CHECK_EQ(residual.get_device(), inp.get_device());
@@ -307,17 +308,17 @@ void all_reduce_sum2(fptr_t _fa, torch::Tensor& inp_a, torch::Tensor& inp_b,
 
   switch (out.scalar_type()) {
     case at::ScalarType::Float: {
-      fa->allreduce_sum2<float>(stream, reinterpret_cast<float*>(inp_a.data_ptr()),
-                                reinterpret_cast<float*>(inp_b.data_ptr()),
-                                reinterpret_cast<float*>(out.data_ptr()),
-                                out.numel());
+      fa->allreduce_sum2<float>(
+          stream, reinterpret_cast<float*>(inp_a.data_ptr()),
+          reinterpret_cast<float*>(inp_b.data_ptr()),
+          reinterpret_cast<float*>(out.data_ptr()), out.numel());
       break;
     }
     case at::ScalarType::Half: {
-      fa->allreduce_sum2<half>(stream, reinterpret_cast<half*>(inp_a.data_ptr()),
-                               reinterpret_cast<half*>(inp_b.data_ptr()),
-                               reinterpret_cast<half*>(out.data_ptr()),
-                               out.numel());
+      fa->allreduce_sum2<half>(
+          stream, reinterpret_cast<half*>(inp_a.data_ptr()),
+          reinterpret_cast<half*>(inp_b.data_ptr()),
+          reinterpret_cast<half*>(out.data_ptr()), out.numel());
       break;
     }
 #if (__CUDA_ARCH__ >= 800 || !defined(__CUDA_ARCH__))
@@ -363,8 +364,7 @@ void top1_argmax(fptr_t _fa, torch::Tensor& input_pair, torch::Tensor& output,
 }
 
 void tile_runtime_all_reduce(fptr_t _fa, torch::Tensor& inp, torch::Tensor& out,
-                             fptr_t _reg_buffer,
-                             int64_t reg_buffer_sz_bytes,
+                             fptr_t _reg_buffer, int64_t reg_buffer_sz_bytes,
                              int64_t tile_numel, int64_t engine_blocks,
                              int64_t compute_iters) {
   auto fa = reinterpret_cast<vllm::CustomAllreduce*>(_fa);
@@ -412,8 +412,7 @@ void tile_runtime_all_reduce(fptr_t _fa, torch::Tensor& inp, torch::Tensor& out,
 void tile_runtime_all_reduce_engine(fptr_t _fa, torch::Tensor& inp,
                                     torch::Tensor& out, fptr_t _reg_buffer,
                                     int64_t reg_buffer_sz_bytes,
-                                    int64_t tile_numel,
-                                    int64_t producer_blocks,
+                                    int64_t tile_numel, int64_t producer_blocks,
                                     int64_t reducer_blocks,
                                     int64_t compute_iters) {
   auto fa = reinterpret_cast<vllm::CustomAllreduce*>(_fa);

--- a/csrc/custom_all_reduce.cuh
+++ b/csrc/custom_all_reduce.cuh
@@ -83,8 +83,7 @@ inline bool custom_allreduce_current_device_is_sm70() {
 #endif
 }
 
-inline int custom_allreduce_block_limit(int default_limit,
-                                        int world_size,
+inline int custom_allreduce_block_limit(int default_limit, int world_size,
                                         size_t bytes) {
   const char* raw = std::getenv("VLLM_CUSTOM_ALLREDUCE_BLOCK_LIMIT");
   if (raw == nullptr || raw[0] == '\0') {
@@ -104,8 +103,7 @@ inline int custom_allreduce_block_limit(int default_limit,
   return static_cast<int>(parsed);
 }
 
-inline int sm70_tp4_m5_allreduce_threads(int world_size,
-                                         bool fully_connected,
+inline int sm70_tp4_m5_allreduce_threads(int world_size, bool fully_connected,
                                          size_t bytes) {
   const char* raw = std::getenv("VLLM_SM70_TP4_M5_AR_THREADS");
   if (raw == nullptr || raw[0] == '\0') return 512;
@@ -264,8 +262,7 @@ static DINLINE FlagType ld_flag_volatile(FlagType* flag_addr) {
 }
 
 static DINLINE void st_flag_sys_visible(FlagType* flag_addr, FlagType flag) {
-  asm volatile("membar.sys; st.volatile.global.u32 [%1], %0;"
-               ::"r"(flag),
+  asm volatile("membar.sys; st.volatile.global.u32 [%1], %0;" ::"r"(flag),
                "l"(flag_addr)
                : "memory");
 }
@@ -421,11 +418,13 @@ __global__ void __launch_bounds__(512, 1)
 // residual after the peer reduction.
 template <int Threads, int ngpus, typename ResidualT, typename WeightT>
 __global__ void __launch_bounds__(Threads, 1)
-    sm70_peer_reduce_gemma_rms_norm(
-        RankData* _dp, RankSignals sg, Signal* self_sg,
-        const ResidualT* __restrict__ residual,
-        const WeightT* __restrict__ weight, half* __restrict__ normalized_out,
-        float* __restrict__ residual_out, int rank, float epsilon) {
+    sm70_peer_reduce_gemma_rms_norm(RankData* _dp, RankSignals sg,
+                                    Signal* self_sg,
+                                    const ResidualT* __restrict__ residual,
+                                    const WeightT* __restrict__ weight,
+                                    half* __restrict__ normalized_out,
+                                    float* __restrict__ residual_out, int rank,
+                                    float epsilon) {
   using P = typename packed_t<half>::P;
   using A = typename packed_t<half>::A;
   constexpr int kPackedWidth = P::size;
@@ -446,15 +445,14 @@ __global__ void __launch_bounds__(Threads, 1)
 
   for (int packed_idx = tid; packed_idx < packed_per_row;
        packed_idx += blockDim.x) {
-    const P reduced =
-        packed_reduce<P, ngpus, A>((const P**)&dp.ptrs[0],
-                                    row * packed_per_row + packed_idx);
+    const P reduced = packed_reduce<P, ngpus, A>(
+        (const P**)&dp.ptrs[0], row * packed_per_row + packed_idx);
     const int element_offset = row_offset + packed_idx * kPackedWidth;
 #pragma unroll
     for (int i = 0; i < kPackedWidth; ++i) {
-      const float value = __half2float(reduced.data[i]) +
-                          sm70_gemma_rms_norm_to_float(
-                              residual[element_offset + i]);
+      const float value =
+          __half2float(reduced.data[i]) +
+          sm70_gemma_rms_norm_to_float(residual[element_offset + i]);
       residual_values[packed_idx * kPackedWidth + i] = value;
       residual_out[element_offset + i] = value;
     }
@@ -490,8 +488,8 @@ __global__ void __launch_bounds__(Threads, 1)
       const int column = element_offset + i;
       const float gemma_weight =
           sm70_gemma_rms_norm_to_float(weight[column]) + 1.0f;
-      normalized_out[row_offset + column] = __float2half_rn(
-          residual_values[column] * inverse_rms * gemma_weight);
+      normalized_out[row_offset + column] =
+          __float2half_rn(residual_values[column] * inverse_rms * gemma_weight);
     }
   }
 
@@ -500,10 +498,9 @@ __global__ void __launch_bounds__(Threads, 1)
 
 template <typename T, int ngpus>
 __global__ void __launch_bounds__(256, 1) sm70_tile_runtime_reduce_kernel(
-    RankData* _dp, RankSignals sg, Signal* self_sg,
-    const T* __restrict__ input, T* __restrict__ staging,
-    T* __restrict__ result, int rank, int packed_size, int tile_packed_size,
-    int tile_count, int compute_iters) {
+    RankData* _dp, RankSignals sg, Signal* self_sg, const T* __restrict__ input,
+    T* __restrict__ staging, T* __restrict__ result, int rank, int packed_size,
+    int tile_packed_size, int tile_count, int compute_iters) {
   using P = typename packed_t<T>::P;
   using A = typename packed_t<T>::A;
 
@@ -554,11 +551,10 @@ __global__ void __launch_bounds__(256, 1) sm70_tile_runtime_reduce_kernel(
 
 template <typename T, int ngpus>
 __global__ void __launch_bounds__(256, 1) sm70_tile_runtime_engine_kernel(
-    RankData* _dp, RankSignals sg, Signal* self_sg,
-    const T* __restrict__ input, T* __restrict__ staging,
-    T* __restrict__ result, int rank, int packed_size, int tile_packed_size,
-    int tile_count, int producer_blocks, int reducer_blocks,
-    int compute_iters) {
+    RankData* _dp, RankSignals sg, Signal* self_sg, const T* __restrict__ input,
+    T* __restrict__ staging, T* __restrict__ result, int rank, int packed_size,
+    int tile_packed_size, int tile_count, int producer_blocks,
+    int reducer_blocks, int compute_iters) {
   using P = typename packed_t<T>::P;
   using A = typename packed_t<T>::A;
 
@@ -621,10 +617,11 @@ __global__ void __launch_bounds__(256, 1) sm70_tile_runtime_engine_kernel(
 
 template <typename T, int ngpus>
 __global__ void __launch_bounds__(256, 1)
-    sm70_tile_runtime_wait_reduce_kernel(
-        RankData* _dp, RankSignals sg, Signal* self_sg,
-        T* __restrict__ result, int rank, int packed_size,
-        int tile_packed_size, int tile_count) {
+    sm70_tile_runtime_wait_reduce_kernel(RankData* _dp, RankSignals sg,
+                                         Signal* self_sg,
+                                         T* __restrict__ result, int rank,
+                                         int packed_size, int tile_packed_size,
+                                         int tile_count) {
   using P = typename packed_t<T>::P;
   using A = typename packed_t<T>::A;
 
@@ -656,9 +653,11 @@ __global__ void __launch_bounds__(256, 1)
 }
 
 template <typename T, int ngpus>
-__global__ void __launch_bounds__(512, 1) cross_device_reduce_sum2_1stage(
-    RankData* _dp_a, RankData* _dp_b, RankSignals sg, Signal* self_sg,
-    T* __restrict__ result, int rank, int size) {
+__global__ void __launch_bounds__(512, 1)
+    cross_device_reduce_sum2_1stage(RankData* _dp_a, RankData* _dp_b,
+                                    RankSignals sg, Signal* self_sg,
+                                    T* __restrict__ result, int rank,
+                                    int size) {
   using P = typename packed_t<T>::P;
   using A = typename packed_t<T>::A;
   auto dp_a = *_dp_a;
@@ -666,9 +665,8 @@ __global__ void __launch_bounds__(512, 1) cross_device_reduce_sum2_1stage(
   barrier_at_start<ngpus>(sg, self_sg, rank);
   for (int idx = blockIdx.x * blockDim.x + threadIdx.x; idx < size;
        idx += gridDim.x * blockDim.x) {
-    ((P*)result)[idx] =
-        packed_reduce_sum2<P, ngpus, A>((const P**)&dp_a.ptrs[0],
-                                        (const P**)&dp_b.ptrs[0], idx);
+    ((P*)result)[idx] = packed_reduce_sum2<P, ngpus, A>(
+        (const P**)&dp_a.ptrs[0], (const P**)&dp_b.ptrs[0], idx);
   }
   barrier_at_end<ngpus, true>(sg, self_sg, rank);
 }
@@ -726,9 +724,11 @@ __global__ void __launch_bounds__(512, 1)
 }
 
 template <typename T, int ngpus>
-__global__ void __launch_bounds__(512, 1) cross_device_reduce_sum2_2stage(
-    RankData* _dp_a, RankData* _dp_b, RankSignals sg, Signal* self_sg,
-    T* __restrict__ result, int rank, int size) {
+__global__ void __launch_bounds__(512, 1)
+    cross_device_reduce_sum2_2stage(RankData* _dp_a, RankData* _dp_b,
+                                    RankSignals sg, Signal* self_sg,
+                                    T* __restrict__ result, int rank,
+                                    int size) {
   int tid = blockIdx.x * blockDim.x + threadIdx.x;
   int stride = gridDim.x * blockDim.x;
   using P = typename packed_t<T>::P;
@@ -753,8 +753,7 @@ __global__ void __launch_bounds__(512, 1) cross_device_reduce_sum2_2stage(
   // Stage 1 mirrors cross_device_reduce_2stage, but each rank first forms
   // its local input_a + input_b value before the cross-rank reduction.
   for (int idx = start + tid; idx < end; idx += stride) {
-    tmp_out[idx - start] =
-        packed_reduce_sum2<P, ngpus, A>(ptrs_a, ptrs_b, idx);
+    tmp_out[idx - start] = packed_reduce_sum2<P, ngpus, A>(ptrs_a, ptrs_b, idx);
   }
   barrier_at_end<ngpus>(sg, self_sg, rank);
 
@@ -925,11 +924,10 @@ class CustomAllreduce {
     } else {
       auto it = buffers_.find(buffer);
       if (it == buffers_.end()) {
-        throw std::runtime_error(std::string(op_name) +
-                                 " buffer address " +
-                                 std::to_string(
-                                     reinterpret_cast<uint64_t>(buffer)) +
-                                 " is not registered!");
+        throw std::runtime_error(
+            std::string(op_name) + " buffer address " +
+            std::to_string(reinterpret_cast<uint64_t>(buffer)) +
+            " is not registered!");
       }
       ptrs = it->second;
     }
@@ -1013,8 +1011,8 @@ class CustomAllreduce {
 
     size /= d;
     auto bytes = size * sizeof(typename packed_t<T>::P);
-    threads = sm70_tp4_m5_allreduce_threads(world_size_, fully_connected_,
-                                            bytes);
+    threads =
+        sm70_tp4_m5_allreduce_threads(world_size_, fully_connected_, bytes);
     int blocks = std::min(block_limit, (size + threads - 1) / threads);
 
     // Check environment variable once
@@ -1077,11 +1075,11 @@ class CustomAllreduce {
 
   template <int ngpus, typename ResidualT, typename WeightT>
   void sm70_allreduce_gemma_rms_norm(cudaStream_t stream, half* input,
-                                      const ResidualT* residual,
-                                      const WeightT* weight,
-                                      half* normalized_out,
-                                      float* residual_out, int num_tokens,
-                                      int hidden_size, float epsilon) {
+                                     const ResidualT* residual,
+                                     const WeightT* weight,
+                                     half* normalized_out, float* residual_out,
+                                     int num_tokens, int hidden_size,
+                                     float epsilon) {
     if (world_size_ != ngpus || !custom_allreduce_current_device_is_sm70()) {
       throw std::runtime_error("SM70 Gemma RMSNorm prototype requires TP" +
                                std::to_string(ngpus) + " on an SM70 device.");
@@ -1095,18 +1093,18 @@ class CustomAllreduce {
     if (num_tokens <= 0 || num_tokens > kMaxTokens) {
       throw std::runtime_error(
           "SM70 Gemma RMSNorm prototype supports tokens in [1, " +
-          std::to_string(kMaxTokens) + "]. Got " +
-          std::to_string(num_tokens) + ".");
+          std::to_string(kMaxTokens) + "]. Got " + std::to_string(num_tokens) +
+          ".");
     }
 
-    RankData* ptrs = rank_data_for_buffer(
-        stream, input, "SM70 Gemma RMSNorm prototype input");
+    RankData* ptrs = rank_data_for_buffer(stream, input,
+                                          "SM70 Gemma RMSNorm prototype input");
     if constexpr (ngpus == 4) {
       // Keep the same 1024-thread CUB reduction topology as vLLM rms_norm.
       // packed_reduce preserves the cross_device_reduce_1stage<half, 4>
       // rank order before the FP32 residual add.
       sm70_peer_reduce_gemma_rms_norm<kSm70GemmaRmsNormThreads, ngpus,
-                                       ResidualT, WeightT>
+                                      ResidualT, WeightT>
           <<<num_tokens, kSm70GemmaRmsNormThreads, 0, stream>>>(
               ptrs, sg_, self_sg_, residual, weight, normalized_out,
               residual_out, rank_, epsilon);
@@ -1114,11 +1112,11 @@ class CustomAllreduce {
     }
 
     const int threads = sm70_gemma_rms_norm_threads();
-#define VLLM_LAUNCH_SM70_GEMMA_RMS_NORM(THREADS)                         \
+#define VLLM_LAUNCH_SM70_GEMMA_RMS_NORM(THREADS)                          \
   sm70_peer_reduce_gemma_rms_norm<THREADS, ngpus, ResidualT, WeightT>     \
-      <<<num_tokens, THREADS, 0, stream>>>(                               \
-          ptrs, sg_, self_sg_, residual, weight, normalized_out,          \
-          residual_out, rank_, epsilon)
+      <<<num_tokens, THREADS, 0, stream>>>(ptrs, sg_, self_sg_, residual, \
+                                           weight, normalized_out,        \
+                                           residual_out, rank_, epsilon)
     switch (threads) {
       case 256:
         VLLM_LAUNCH_SM70_GEMMA_RMS_NORM(256);
@@ -1190,29 +1188,28 @@ class CustomAllreduce {
       }
     }
 
-#define SUM2_KL(ngpus, name)                                                  \
-  name<T, ngpus><<<blocks, threads, 0, stream>>>(ptrs_a, ptrs_b, sg_,         \
-                                                 self_sg_, output, rank_,     \
-                                                 size);
-#define SUM2_CASE(ngpus)                              \
-  case ngpus: {                                      \
-    if (force_1stage) {                              \
-      SUM2_KL(ngpus, cross_device_reduce_sum2_1stage); \
-    } else if (force_2stage) {                       \
-      SUM2_KL(ngpus, cross_device_reduce_sum2_2stage); \
-    } else {                                         \
-      if (world_size_ == 2) {                        \
-        SUM2_KL(ngpus, cross_device_reduce_sum2_1stage); \
-      } else if (fully_connected_) {                 \
-        if ((world_size_ <= 4 && bytes < 512 * 1024) || \
-            (world_size_ <= 8 && bytes < 256 * 1024)) { \
+#define SUM2_KL(ngpus, name)                      \
+  name<T, ngpus><<<blocks, threads, 0, stream>>>( \
+      ptrs_a, ptrs_b, sg_, self_sg_, output, rank_, size);
+#define SUM2_CASE(ngpus)                                   \
+  case ngpus: {                                            \
+    if (force_1stage) {                                    \
+      SUM2_KL(ngpus, cross_device_reduce_sum2_1stage);     \
+    } else if (force_2stage) {                             \
+      SUM2_KL(ngpus, cross_device_reduce_sum2_2stage);     \
+    } else {                                               \
+      if (world_size_ == 2) {                              \
+        SUM2_KL(ngpus, cross_device_reduce_sum2_1stage);   \
+      } else if (fully_connected_) {                       \
+        if ((world_size_ <= 4 && bytes < 512 * 1024) ||    \
+            (world_size_ <= 8 && bytes < 256 * 1024)) {    \
           SUM2_KL(ngpus, cross_device_reduce_sum2_1stage); \
-        } else {                                     \
+        } else {                                           \
           SUM2_KL(ngpus, cross_device_reduce_sum2_2stage); \
-        }                                            \
-      }                                              \
-    }                                                \
-    break;                                           \
+        }                                                  \
+      }                                                    \
+    }                                                      \
+    break;                                                 \
   }
 
     switch (world_size_) {
@@ -1252,12 +1249,12 @@ class CustomAllreduce {
 
     const int packed_size = size / pack;
     const int tile_packed_size = tile_numel / pack;
-    const int tile_count = (packed_size + tile_packed_size - 1) / tile_packed_size;
+    const int tile_count =
+        (packed_size + tile_packed_size - 1) / tile_packed_size;
     if (tile_count <= 0 || tile_count > kMaxBlocks) {
       throw std::runtime_error(
           "SM70 tile runtime prototype supports tile_count in [1, " +
-          std::to_string(kMaxBlocks) + "]. Got " +
-          std::to_string(tile_count));
+          std::to_string(kMaxBlocks) + "]. Got " + std::to_string(tile_count));
     }
 
     auto it = buffers_.find(staging);
@@ -1274,14 +1271,12 @@ class CustomAllreduce {
     blocks = std::max(1, std::min(blocks, tile_count));
     compute_iters = std::max(0, compute_iters);
 
-#define TILE_RUNTIME_CASE(ngpus)                                             \
-  case ngpus: {                                                              \
-    sm70_tile_runtime_reduce_kernel<T, ngpus>                                \
-        <<<blocks, threads, 0, stream>>>(ptrs, sg_, self_sg_, input, staging, \
-                                         output, rank_, packed_size,          \
-                                         tile_packed_size, tile_count,        \
-                                         compute_iters);                     \
-    break;                                                                   \
+#define TILE_RUNTIME_CASE(ngpus)                                               \
+  case ngpus: {                                                                \
+    sm70_tile_runtime_reduce_kernel<T, ngpus><<<blocks, threads, 0, stream>>>( \
+        ptrs, sg_, self_sg_, input, staging, output, rank_, packed_size,       \
+        tile_packed_size, tile_count, compute_iters);                          \
+    break;                                                                     \
   }
 
     switch (world_size_) {
@@ -1321,8 +1316,7 @@ class CustomAllreduce {
     if (tile_count <= 0 || tile_count > kMaxBlocks) {
       throw std::runtime_error(
           "SM70 tile runtime engine supports tile_count in [1, " +
-          std::to_string(kMaxBlocks) + "]. Got " +
-          std::to_string(tile_count));
+          std::to_string(kMaxBlocks) + "]. Got " + std::to_string(tile_count));
     }
 
     auto it = buffers_.find(staging);
@@ -1344,15 +1338,13 @@ class CustomAllreduce {
     const int threads = 256;
     const int blocks = producer_blocks + reducer_blocks;
 
-#define TILE_RUNTIME_ENGINE_CASE(ngpus)                                      \
-  case ngpus: {                                                              \
-    sm70_tile_runtime_engine_kernel<T, ngpus>                                \
-        <<<blocks, threads, 0, stream>>>(ptrs, sg_, self_sg_, input, staging, \
-                                         output, rank_, packed_size,          \
-                                         tile_packed_size, tile_count,        \
-                                         producer_blocks, reducer_blocks,     \
-                                         compute_iters);                     \
-    break;                                                                   \
+#define TILE_RUNTIME_ENGINE_CASE(ngpus)                                        \
+  case ngpus: {                                                                \
+    sm70_tile_runtime_engine_kernel<T, ngpus><<<blocks, threads, 0, stream>>>( \
+        ptrs, sg_, self_sg_, input, staging, output, rank_, packed_size,       \
+        tile_packed_size, tile_count, producer_blocks, reducer_blocks,         \
+        compute_iters);                                                        \
+    break;                                                                     \
   }
 
     switch (world_size_) {
@@ -1366,8 +1358,7 @@ class CustomAllreduce {
 
   template <typename T>
   void tile_runtime_wait_reduce(cudaStream_t stream, T* staging, T* output,
-                                int size, int tile_numel,
-                                int reducer_blocks) {
+                                int size, int tile_numel, int reducer_blocks) {
     if (world_size_ != 2) {
       throw std::runtime_error(
           "SM70 tile runtime wait-reduce currently supports only TP2.");
@@ -1391,8 +1382,7 @@ class CustomAllreduce {
     if (tile_count <= 0 || tile_count > kMaxBlocks) {
       throw std::runtime_error(
           "SM70 tile runtime wait-reduce supports tile_count in [1, " +
-          std::to_string(kMaxBlocks) + "]. Got " +
-          std::to_string(tile_count));
+          std::to_string(kMaxBlocks) + "]. Got " + std::to_string(tile_count));
     }
 
     RankData* ptrs;
@@ -1418,13 +1408,13 @@ class CustomAllreduce {
 
     constexpr int threads = 256;
 
-#define TILE_RUNTIME_WAIT_REDUCE_CASE(ngpus)                                 \
-  case ngpus: {                                                              \
-    sm70_tile_runtime_wait_reduce_kernel<T, ngpus>                           \
-        <<<reducer_blocks, threads, 0, stream>>>(                            \
-            ptrs, sg_, self_sg_, output, rank_, packed_size,                 \
-            tile_packed_size, tile_count);                                   \
-    break;                                                                   \
+#define TILE_RUNTIME_WAIT_REDUCE_CASE(ngpus)                                   \
+  case ngpus: {                                                                \
+    sm70_tile_runtime_wait_reduce_kernel<T, ngpus>                             \
+        <<<reducer_blocks, threads, 0, stream>>>(                              \
+            ptrs, sg_, self_sg_, output, rank_, packed_size, tile_packed_size, \
+            tile_count);                                                       \
+    break;                                                                     \
   }
 
     switch (world_size_) {
@@ -1453,11 +1443,11 @@ class CustomAllreduce {
       ptrs = it->second;
     }
 
-#define TOP1_CASE(ngpus)                                   \
-  case ngpus: {                                            \
-    cross_device_top1_argmax<ngpus><<<1, 32, 0, stream>>>( \
-        ptrs, sg_, self_sg_, output, rank_);               \
-    break;                                                 \
+#define TOP1_CASE(ngpus)                                            \
+  case ngpus: {                                                     \
+    cross_device_top1_argmax<ngpus>                                 \
+        <<<1, 32, 0, stream>>>(ptrs, sg_, self_sg_, output, rank_); \
+    break;                                                          \
   }
 
     switch (world_size_) {

--- a/csrc/moe/moe_permute_unpermute_op.cu
+++ b/csrc/moe/moe_permute_unpermute_op.cu
@@ -28,9 +28,7 @@ torch::Tensor maybe_allocate_tensor(
   return torch::empty(expected_sizes, torch::dtype(dtype).device(device));
 }
 
-int64_t pad_to_multiple_of_16(int64_t value) {
-  return (value + 15) / 16 * 16;
-}
+int64_t pad_to_multiple_of_16(int64_t value) { return (value + 15) / 16 * 16; }
 
 }  // namespace
 
@@ -72,16 +70,15 @@ void moe_permute_impl(
   auto expanded_rows = n_token * topk;
   auto stream = at::cuda::getCurrentCUDAStream().stream();
 
-  if (canUseSingleTokenMoePermuteFastPath(
-          n_token, topk, expert_map.has_value(), n_expert, n_local_expert)) {
+  if (canUseSingleTokenMoePermuteFastPath(n_token, topk, expert_map.has_value(),
+                                          n_expert, n_local_expert)) {
     if (input.scalar_type() == at::ScalarType::Half) {
       singleTokenMoePermuteLauncher<half>(
           get_ptr<half>(input), get_ptr<int>(topk_ids),
           get_ptr<half>(permuted_input),
           get_ptr<int64_t>(expert_first_token_offset),
           get_ptr<int>(inv_permuted_idx), get_ptr<int>(permuted_idx),
-          static_cast<int>(n_expert), static_cast<int>(topk), n_hidden,
-          stream);
+          static_cast<int>(n_expert), static_cast<int>(topk), n_hidden, stream);
       return;
     }
     if (input.scalar_type() == at::ScalarType::BFloat16) {
@@ -90,8 +87,7 @@ void moe_permute_impl(
           get_ptr<__nv_bfloat16>(permuted_input),
           get_ptr<int64_t>(expert_first_token_offset),
           get_ptr<int>(inv_permuted_idx), get_ptr<int>(permuted_idx),
-          static_cast<int>(n_expert), static_cast<int>(topk), n_hidden,
-          stream);
+          static_cast<int>(n_expert), static_cast<int>(topk), n_hidden, stream);
       return;
     }
     if (input.scalar_type() == at::ScalarType::Float) {
@@ -100,8 +96,7 @@ void moe_permute_impl(
           get_ptr<float>(permuted_input),
           get_ptr<int64_t>(expert_first_token_offset),
           get_ptr<int>(inv_permuted_idx), get_ptr<int>(permuted_idx),
-          static_cast<int>(n_expert), static_cast<int>(topk), n_hidden,
-          stream);
+          static_cast<int>(n_expert), static_cast<int>(topk), n_hidden, stream);
       return;
     }
   }

--- a/csrc/moe/permute_unpermute_kernels/moe_permute_unpermute_kernel.cu
+++ b/csrc/moe/permute_unpermute_kernels/moe_permute_unpermute_kernel.cu
@@ -93,10 +93,12 @@ bool singleTokenUnpermuteFastPathEnabled() {
 }
 
 template <typename T>
-__global__ void singleTokenMoePermuteKernel(
-    T const* input, int const* topk_ids, T* permuted_output,
-    int64_t* expert_first_token_offset, int* inv_permuted_idx,
-    int* permuted_idx, int num_experts, int topk, int64_t cols) {
+__global__ void singleTokenMoePermuteKernel(T const* input, int const* topk_ids,
+                                            T* permuted_output,
+                                            int64_t* expert_first_token_offset,
+                                            int* inv_permuted_idx,
+                                            int* permuted_idx, int num_experts,
+                                            int topk, int64_t cols) {
   __shared__ int sorted_ids[kSingleTokenFastPathMaxTopK];
   __shared__ int sorted_src[kSingleTokenFastPathMaxTopK];
 
@@ -177,8 +179,8 @@ __global__ void singleTokenMoeUnpermuteKernel(
 
   auto const* expanded_rows_v =
       reinterpret_cast<InputElem const*>(expanded_permuted_rows);
-  auto* reduced_row_ptr_v = reinterpret_cast<OutputElem*>(
-      reduced_unpermuted_output);
+  auto* reduced_row_ptr_v =
+      reinterpret_cast<OutputElem*>(reduced_unpermuted_output);
   int64_t const num_elems_in_col = cols / FINALIZE_ELEM_PER_THREAD;
 
   for (int64_t elem_index = threadIdx.x; elem_index < num_elems_in_col;
@@ -186,7 +188,7 @@ __global__ void singleTokenMoeUnpermuteKernel(
     ComputeElem thread_output;
     thread_output.fill(0);
 
-#pragma unroll
+  #pragma unroll
     for (int k_idx = 0; k_idx < kSingleTokenFastPathMaxTopK; ++k_idx) {
       if (k_idx >= topk) {
         break;
@@ -222,11 +224,12 @@ bool canUseSingleTokenMoePermuteFastPath(int64_t n_token, int64_t topk,
 }
 
 template <typename T>
-void singleTokenMoePermuteLauncher(
-    T const* input, int const* topk_ids, T* permuted_output,
-    int64_t* expert_first_token_offset, int* inv_permuted_idx,
-    int* permuted_idx, int num_experts, int topk, int64_t cols,
-    cudaStream_t stream) {
+void singleTokenMoePermuteLauncher(T const* input, int const* topk_ids,
+                                   T* permuted_output,
+                                   int64_t* expert_first_token_offset,
+                                   int* inv_permuted_idx, int* permuted_idx,
+                                   int num_experts, int topk, int64_t cols,
+                                   cudaStream_t stream) {
   constexpr int threads = 256;
   singleTokenMoePermuteKernel<T><<<1, threads, 0, stream>>>(
       input, topk_ids, permuted_output, expert_first_token_offset,

--- a/csrc/moe/permute_unpermute_kernels/moe_permute_unpermute_kernel.h
+++ b/csrc/moe/permute_unpermute_kernels/moe_permute_unpermute_kernel.h
@@ -80,11 +80,12 @@ bool canUseSingleTokenMoePermuteFastPath(int64_t n_token, int64_t topk,
                                          int64_t n_local_expert);
 
 template <typename T>
-void singleTokenMoePermuteLauncher(
-    T const* input, int const* topk_ids, T* permuted_output,
-    int64_t* expert_first_token_offset, int* inv_permuted_idx,
-    int* permuted_idx, int num_experts, int topk, int64_t cols,
-    cudaStream_t stream);
+void singleTokenMoePermuteLauncher(T const* input, int const* topk_ids,
+                                   T* permuted_output,
+                                   int64_t* expert_first_token_offset,
+                                   int* inv_permuted_idx, int* permuted_idx,
+                                   int num_experts, int topk, int64_t cols,
+                                   cudaStream_t stream);
 
 bool canUseSingleTokenMoeUnpermuteFastPath(int64_t n_token, int64_t topk);
 

--- a/csrc/sm70_tile_runtime_signal.cuh
+++ b/csrc/sm70_tile_runtime_signal.cuh
@@ -28,14 +28,13 @@ struct __align__(16) RankSignals {
 #if !defined(USE_ROCM)
 static __device__ __forceinline__ void store_flag_sys_visible(
     FlagType* flag_addr, FlagType flag) {
-  asm volatile("membar.sys; st.volatile.global.u32 [%1], %0;"
-               ::"r"(flag),
+  asm volatile("membar.sys; st.volatile.global.u32 [%1], %0;" ::"r"(flag),
                "l"(flag_addr)
                : "memory");
 }
 
-static __device__ __forceinline__ FlagType load_flag_sys_visible(
-    FlagType* flag_addr) {
+static __device__ __forceinline__ FlagType
+load_flag_sys_visible(FlagType* flag_addr) {
   FlagType flag;
   asm volatile("ld.volatile.global.u32 %0, [%1]; membar.sys;"
                : "=r"(flag)


### PR DESCRIPTION
Refs #126. Exact scoped replacement for the core portion of Draft PR #133. Do not merge #133.

## Scope
- Exactly six files: custom_all_reduce.cu, custom_all_reduce.cuh, moe_permute_unpermute_op.cu, moe_permute_unpermute_kernel.cu, moe_permute_unpermute_kernel.h, and sm70_tile_runtime_signal.cuh.
- Exact byte-for-byte mechanical sub-diff of #133 commit 4af43444a38d5dd2437ada364d4f44f159d29213.
- clang-format only. Excludes csrc/ops.h and csrc/torch_bindings.cpp.
- No runtime, numerical, kernel, or performance change intended.

## Validation
- Focused clang-format hook: passed.
- Focused typos hook: passed.
- Focused SPDX hook: skipped because the repository hook only accepts Python files.
- git diff --check and git show --check: passed.

## Risk
- No physical GPU validation is available or claimed.