### PR TITLE
[CI/Build] Type GDN metadata state (#126)

### DIFF
--- a/vllm/v1/attention/backends/gdn_attn.py
+++ b/vllm/v1/attention/backends/gdn_attn.py
@@ -691,7 +691,7 @@ class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]
             dtype=torch.int32,
             device=device,
         )
-        self._spec_token_indx_initialized_size = 0
+        self._spec_token_indx_initialized_size: int = 0
         self.spec_query_start_loc: torch.Tensor = torch.empty(
             (self.decode_cudagraph_max_bs + 1,),
             dtype=torch.int32,


### PR DESCRIPTION
## Purpose
Remove the five Python 3.13 mypy has-type baseline errors in vllm/v1/attention/backends/gdn_attn.py. This is a typing-only change with no Flash-V100, TurboMind, CUDA, or runtime behavior modification.

Tracking issue: #126

## Base
Base SHA: 3ec0c68c6596d6ab31fbdee9fa676254a52c2b7d
Head SHA: f5d423e0e620c93ceccbb0118806753a8bc745c8

## Implementation
- Declare GDNAttentionMetadataBuilder._spec_token_indx_initialized_size as int while preserving its existing initial value and all assignments.
- No tests were added because the runtime contract is unchanged.

## Errors Eliminated
- Python 3.13 has-type at gdn_attn.py lines 934, 956, 1433, 1434, and 1444.

## Validation
- Targeted project mypy hooks for Python 3.10, 3.11, 3.12, and 3.13: passed.
- Full Python 3.13 hook: the five GDN errors are absent. It still reports 43 unrelated baseline errors from the scope of Draft PR #132, which has not yet merged into main.
- GDN metadata tests under an explicitly injected CpuPlatform: 32 passed, 1 deselected.
- The deselected test directly queries CUDA stream-capture state and cannot execute with CUDA error 804 on this host.
- Ruff check and git diff --check: passed.

## Risk
No usable physical GPU is available. No CUDA Graph, Flash-V100, TurboMind, or GPU runtime validation was performed.

## AI Assistance
This PR was implemented with Codex. A human maintainer must review and own the final merge.