### PR TITLE
[Core] Preserve static draft vocab synchronization

### DIFF
--- a/vllm/v1/spec_decode/static_draft_vocab.py
+++ b/vllm/v1/spec_decode/static_draft_vocab.py
@@ -782,7 +782,7 @@ def initialize_static_draft_vocab(
             input_split_sizes=input_splits,
             group=tp_group.device_group,
         )
-    torch.cuda.synchronize(device)
+    torch.accelerator.synchronize(device)
 
     fingerprints = payload.get("fingerprints")
     ranking_fingerprint = None
@@ -1044,5 +1044,5 @@ def initialize_dynamic_draft_vocab(
         )
     else:
         runtime._refresh_tail()
-    torch.cuda.synchronize(device)
+    torch.accelerator.synchronize(device)
     return runtime


### PR DESCRIPTION
## Purpose

Resolve the #126 check-torch-cuda-call finding in static/dynamic draft-vocabulary initialization without changing synchronization behavior.

## Base

- onecat/main@3ec0c68c6596d6ab31fbdee9fa676254a52c2b7d

## Change

Only vllm/v1/spec_decode/static_draft_vocab.py changes.

- Keep device synchronization immediately after TP all_to_all_single in initialize_static_draft_vocab.
- Keep device synchronization immediately after _refresh_gpu_tail / _refresh_tail in initialize_dynamic_draft_vocab.
- Preserve the same device argument, ordering, and CUDA-backed execution path; replace only torch.cuda.synchronize(device) with torch.accelerator.synchronize(device).

## Validation

- python -m pytest -q tests/v1/spec_decode/test_static_draft_vocab.py: 18 passed.
- check-torch-cuda-call on the changed file: passed.
- Ruff check and Ruff format --check on the changed file: passed.
- git diff --check: passed.
- File-scoped default pre-commit hooks pass except five existing mypy errors at unchanged lines 421-436 in this file. They are outside this two-line diff and remain tracked separately under #126.

## V100 Gates Still Required

Run on real V100 hardware after integration:

- TP2 and TP4 static/dynamic draft-vocabulary initialization.
- MTP CUDA-graph replay, acceptance length, and long-output quality for AWQ and FP8 routes.
- Confirm synchronization ordering around TP communication and dynamic-tail refresh; no performance claim is made here.