### PR TITLE
[CI/Build] Use accelerator warmup synchronization

### DIFF
--- a/vllm/model_executor/warmup/awq_sm70_warmup.py
+++ b/vllm/model_executor/warmup/awq_sm70_warmup.py
@@ -641,7 +641,7 @@ def sm70_awq_warmup(worker: Worker) -> None:
             moe_layers, moe_token_counts
         )
         single_token_calls = _warmup_moe_single_token_layers(moe_layers)
-    torch.cuda.synchronize(device)
+    torch.accelerator.synchronize(device)
     logger.info(
         "SM70 TurboMind warmup finished (%d AWQ dense calls, %d FP8 dense "
         "calls, %d FP4 dense calls, %d MoE stage calls, "


### PR DESCRIPTION
## Purpose

Part of #126. Replace the SM70 TurboMind warmup synchronization with `torch.accelerator.synchronize(device)` while preserving its exact location, explicit device, warmup ordering, and error behavior.

## Scope

Only `vllm/model_executor/warmup/awq_sm70_warmup.py` changes: one line.

## Test Plan

- `check-torch-cuda-call` on the changed file
- Ruff check and Python compile
- CPU mock-worker ordering test for AWQ/FP8/FP4/MoE warmup -> synchronize(device) -> LUT export
- `git diff --check`

## Test Result

All scoped checks above pass. Mypy 3.12/3.13 retain the pre-existing line 593 `worker.device` optionality error; this PR does not modify that line. Ruff format reports six existing formatting differences already covered by #128; no formatting diff is included here.

## Required V100 Gate

Before merge, validate SM70 worker startup with TurboMind AWQ, FP8, and NVFP4 paths, including failure propagation and LUT import/export behavior.