### PR TITLE
[CI/Build] Modernize Flash-V100 benchmark CUDA APIs

### DIFF
--- a/benchmarks/benchmark_sm70_flashinfer_fixed_entry.py
+++ b/benchmarks/benchmark_sm70_flashinfer_fixed_entry.py
@@ -144,11 +144,11 @@ def _require_accepted_runtime() -> None:
     _load_torch()
     if not torch.cuda.is_available():
         raise RuntimeError("CUDA is required")
-    if torch.cuda.device_count() != 1:
+    if torch.accelerator.device_count() != 1:
         raise RuntimeError(
             "benchmark must expose only physical GPU0 through CUDA_VISIBLE_DEVICES=0"
         )
-    torch.cuda.set_device(0)
+    torch.accelerator.set_device_index(0)
     if torch.cuda.get_device_capability(0) != (7, 0):
         raise RuntimeError(
             "fixed entry requires SM70; got "
@@ -262,9 +262,7 @@ def _active_ctas_per_sm(
     threads_per_cta: int,
     shared_bytes_per_cta: int,
 ) -> int:
-    register_limited = SM70_REGISTERS_PER_SM // (
-        registers_per_thread * threads_per_cta
-    )
+    register_limited = SM70_REGISTERS_PER_SM // (registers_per_thread * threads_per_cta)
     shared_limited = SM70_SHARED_BYTES_PER_SM // shared_bytes_per_cta
     thread_limited = SM70_THREADS_PER_SM // threads_per_cta
     return min(register_limited, shared_limited, thread_limited, SM70_MAX_CTA_PER_SM)
@@ -349,9 +347,7 @@ def _paged_resource_gate(kernel: Mapping[str, Any]) -> dict[str, Any]:
             f"requires <= {PAGED_MAX_SHARED_BYTES}"
         )
     if kernel["active_ctas_per_sm"] != 2:
-        reasons.append(
-            f"active_ctas_per_sm={kernel['active_ctas_per_sm']}, requires 2"
-        )
+        reasons.append(f"active_ctas_per_sm={kernel['active_ctas_per_sm']}, requires 2")
     instructions = kernel["instructions"]
     if instructions["hmma"] == 0:
         reasons.append("paged target has no HMMA")
@@ -616,15 +612,9 @@ def _pairwise_stats(
     return {
         "right_minus_left_mean_ms": float(statistics.mean(deltas)),
         "right_minus_left_p50_ms": float(statistics.median(deltas)),
-        "right_faster_wins": sum(
-            right_ms < left_ms for left_ms, right_ms in paired
-        ),
-        "left_faster_wins": sum(
-            left_ms < right_ms for left_ms, right_ms in paired
-        ),
-        "ties": sum(
-            left_ms == right_ms for left_ms, right_ms in paired
-        ),
+        "right_faster_wins": sum(right_ms < left_ms for left_ms, right_ms in paired),
+        "left_faster_wins": sum(left_ms < right_ms for left_ms, right_ms in paired),
+        "ties": sum(left_ms == right_ms for left_ms, right_ms in paired),
         "right_vs_left_mean_pct": (
             (right_stats["mean_ms"] / left_stats["mean_ms"] - 1.0) * 100.0
         ),
@@ -678,7 +668,7 @@ def _interleaved_time(
     for warmup_index in range(warmup_rounds):
         for name in orders[warmup_index % len(orders)]:
             routes[name]()
-    torch.cuda.synchronize()
+    torch.accelerator.synchronize()
 
     samples = {name: [] for name in names}
     for round_index in range(rounds):
@@ -888,7 +878,7 @@ def main() -> None:
                     out=case["fixed_out"],
                     softmax_lse=case["fixed_lse"],
                 )
-                torch.cuda.synchronize()
+                torch.accelerator.synchronize()
                 if fixed_out.data_ptr() != case["fixed_out"].data_ptr():
                     raise RuntimeError("fixed entry allocated replacement output")
                 if fixed_lse.data_ptr() != case["fixed_lse"].data_ptr():
@@ -918,7 +908,7 @@ def main() -> None:
                         causal=True,
                         out=case["dense_out"],
                     )
-                    torch.cuda.synchronize()
+                    torch.accelerator.synchronize()
                     if dense_out.data_ptr() != case["dense_out"].data_ptr():
                         raise RuntimeError("dense entry allocated replacement output")
                     dense_evidence = _dense_diagnostic_evidence(generic_out, dense_out)

--- a/benchmarks/benchmark_sm70_flashinfer_realshape_ab.py
+++ b/benchmarks/benchmark_sm70_flashinfer_realshape_ab.py
@@ -275,11 +275,11 @@ def _require_cuda_runtime() -> None:
     _load_torch()
     if not torch.cuda.is_available():
         raise RuntimeError("CUDA is required")
-    if torch.cuda.device_count() != 1:
+    if torch.accelerator.device_count() != 1:
         raise RuntimeError(
             "benchmark must expose exactly one GPU through CUDA_VISIBLE_DEVICES"
         )
-    torch.cuda.set_device(0)
+    torch.accelerator.set_device_index(0)
     if torch.cuda.get_device_capability(0) != (7, 0):
         raise RuntimeError(
             "fixed entry requires SM70; got "
@@ -823,7 +823,7 @@ def _run_correctness(
             sequence_lengths,
             SOFTMAX_SCALE,
         )
-        torch.cuda.synchronize()
+        torch.accelerator.synchronize()
         _assert_alias(fixed_out, case["fixed_out"], f"{name} fixed output")
         _assert_alias(fixed_lse, case["fixed_lse"], f"{name} fixed LSE")
 
@@ -847,7 +847,7 @@ def _run_correctness(
                 causal=True,
                 out=case["dense_out"],
             )
-            torch.cuda.synchronize()
+            torch.accelerator.synchronize()
             _assert_alias(dense_out, case["dense_out"], f"{name} dense output")
             dense_evidence = _comparison_evidence(generic_out, dense_out)
             dense_evidence["output_preallocated"] = True
@@ -964,7 +964,7 @@ def _run_interleaved_timing(
             _set_environment(routes[name].environment)
             routes[name].launch()
         health_check()
-    torch.cuda.synchronize()
+    torch.accelerator.synchronize()
 
     events = {
         name: (
@@ -1164,7 +1164,7 @@ def _run_gpu_benchmark(args: argparse.Namespace, result: dict[str, Any]) -> None
     result["page_tables"]["identity"]["dense_zero_copy"]["value_view"] = (
         dense_value_details
     )
-    torch.cuda.synchronize()
+    torch.accelerator.synchronize()
     _record_gpu_snapshot(
         result,
         physical_gpu=args.physical_gpu,
@@ -1194,7 +1194,7 @@ def _run_gpu_benchmark(args: argparse.Namespace, result: dict[str, Any]) -> None
                 dense_value=dense_value,
                 health_check=monitor.assert_healthy,
             )
-            torch.cuda.synchronize()
+            torch.accelerator.synchronize()
             monitor.assert_healthy()
             _record_gpu_snapshot(
                 result,
@@ -1220,7 +1220,7 @@ def _run_gpu_benchmark(args: argparse.Namespace, result: dict[str, Any]) -> None
                 warmup_rounds=args.warmup_rounds,
                 health_check=monitor.assert_healthy,
             )
-            torch.cuda.synchronize()
+            torch.accelerator.synchronize()
             monitor.assert_healthy()
         finally:
             monitor_record = monitor.stop()

--- a/benchmarks/benchmark_sm70_flashinfer_splitkv3_realshape_ab.py
+++ b/benchmarks/benchmark_sm70_flashinfer_splitkv3_realshape_ab.py
@@ -561,11 +561,11 @@ def _require_cuda_runtime() -> None:
     _load_torch()
     if not torch.cuda.is_available():
         raise RuntimeError("CUDA is required")
-    if torch.cuda.device_count() != 1:
+    if torch.accelerator.device_count() != 1:
         raise RuntimeError(
             "benchmark must expose exactly one GPU through CUDA_VISIBLE_DEVICES"
         )
-    torch.cuda.set_device(0)
+    torch.accelerator.set_device_index(0)
     if torch.cuda.get_device_capability(0) != (7, 0):
         raise RuntimeError(
             "fixed splitkv3 entry requires SM70; got "
@@ -1282,7 +1282,7 @@ def _run_correctness(
             case=case,
             actual_n=shape.n,
         )
-        torch.cuda.synchronize()
+        torch.accelerator.synchronize()
         _assert_alias(unsplit_out, case["unsplit_out"], f"{name} unsplit output")
         _assert_alias(unsplit_lse, case["unsplit_lse"], f"{name} unsplit LSE")
         _assert_alias(splitkv3_out, case["splitkv3_out"], f"{name} splitkv3 output")
@@ -1422,7 +1422,7 @@ def _run_interleaved_timing(
         for name in ORDER_SCHEDULE[warmup_round % len(ORDER_SCHEDULE)]:
             routes[name].launch()
         health_check()
-    torch.cuda.synchronize()
+    torch.accelerator.synchronize()
     health_check()
 
     events = {
@@ -1765,7 +1765,7 @@ def _run_gpu_benchmark(
         "screening_not_acceptance": args.screen,
     }
     result["split_workspace"] = _workspace_metadata(workspace)
-    torch.cuda.synchronize()
+    torch.accelerator.synchronize()
     _record_gpu_snapshot(
         result,
         physical_gpu=args.physical_gpu,
@@ -1804,7 +1804,7 @@ def _run_gpu_benchmark(
                 result["numerical_gate"]["status"] = "failed"
                 raise
             result["numerical_gate"]["status"] = "passed"
-            torch.cuda.synchronize()
+            torch.accelerator.synchronize()
             monitor.assert_healthy()
             _record_gpu_snapshot(
                 result,
@@ -1862,7 +1862,7 @@ def _run_gpu_benchmark(
                         paired_rounds=timing_paired_rounds,
                         health_check=monitor.assert_healthy,
                     )
-                    torch.cuda.synchronize()
+                    torch.accelerator.synchronize()
                     monitor.assert_healthy()
                     _record_gpu_snapshot(
                         result,

--- a/benchmarks/benchmark_sm70_triton_attention_schedule.py
+++ b/benchmarks/benchmark_sm70_triton_attention_schedule.py
@@ -194,7 +194,7 @@ def _time_attention(
             q_heads=q_heads,
             head_dim=head_dim,
         )
-    torch.cuda.synchronize()
+    torch.accelerator.synchronize()
 
     times = []
     out = None
@@ -214,7 +214,7 @@ def _time_attention(
             head_dim=head_dim,
         )
         end.record()
-        torch.cuda.synchronize()
+        torch.accelerator.synchronize()
         times.append(start.elapsed_time(end))
     assert out is not None
     times.sort()

--- a/benchmarks/kernels/benchmark_flash_v100_prefill_decay.py
+++ b/benchmarks/kernels/benchmark_flash_v100_prefill_decay.py
@@ -64,7 +64,7 @@ PROFILE_SHAPES = {
 
 
 def _sync() -> None:
-    torch.cuda.synchronize()
+    torch.accelerator.synchronize()
 
 
 def _paged_block_m(
@@ -609,7 +609,7 @@ def bench_chunked_prompt(
         chunk_results.append(chunk)
         pos += q_len
         chunk_idx += 1
-        torch.cuda.empty_cache()
+        torch.accelerator.empty_cache()
 
     total_layer_ms = sum(float(chunk["median_ms"]) for chunk in chunk_results)
     total_flops = sum(
@@ -788,7 +788,7 @@ def main() -> None:
         raise ValueError(f"heads_q={heads_q} must be divisible by heads_kv={heads_kv}")
 
     torch.manual_seed(args.seed)
-    torch.cuda.set_device(args.device)
+    torch.accelerator.set_device_index(args.device)
     device = torch.device(f"cuda:{args.device}")
     props = torch.cuda.get_device_properties(device)
     if props.major != 7 or props.minor != 0:
@@ -911,7 +911,7 @@ def main() -> None:
     results: list[dict[str, Any]] = []
     if args.mode in ("dense", "all"):
         for length in args.dense_lens or args.prompt_lens:
-            torch.cuda.empty_cache()
+            torch.accelerator.empty_cache()
             result = bench_dense(
                 length,
                 heads_q=heads_q,
@@ -929,7 +929,7 @@ def main() -> None:
 
     if args.mode in ("paged-step", "all"):
         for q_len, kv_len in args.paged_steps:
-            torch.cuda.empty_cache()
+            torch.accelerator.empty_cache()
             result = bench_paged_step(
                 q_len,
                 kv_len,
@@ -956,7 +956,7 @@ def main() -> None:
 
     if args.mode in ("chunked", "all"):
         for prompt_len in args.prompt_lens:
-            torch.cuda.empty_cache()
+            torch.accelerator.empty_cache()
             result = bench_chunked_prompt(
                 prompt_len,
                 chunk_size=args.chunk_size,

--- a/benchmarks/kernels/benchmark_sm70_flash_v100_xqa_layout.py
+++ b/benchmarks/kernels/benchmark_sm70_flash_v100_xqa_layout.py
@@ -103,7 +103,7 @@ def elapsed_ms(
             seq_len=seq_len,
             partition_size=partition_size,
         )
-    torch.cuda.synchronize()
+    torch.accelerator.synchronize()
     start = torch.cuda.Event(enable_timing=True)
     end = torch.cuda.Event(enable_timing=True)
     start.record()
@@ -249,8 +249,9 @@ def main() -> None:
         raise ValueError("--candidate-partition-size must be one of 256, 512, 1024")
 
     # Qwen3.6-27B-AWQ TP4 full-attention per-rank shape: Hq=6, Hkv=1, D=256.
-    torch.manual_seed(20260713)
-    torch.cuda.manual_seed_all(20260713)
+    from vllm.utils.torch_utils import set_random_seed
+
+    set_random_seed(20260713)
     block_size, q_heads, kv_heads, head_dim = (
         args.block_size,
         6,
@@ -313,7 +314,7 @@ def main() -> None:
                 candidate_partition_size if padded else args.partition_size
             ),
         )
-        torch.cuda.synchronize()
+        torch.accelerator.synchronize()
         return
 
     baseline = run_once(
@@ -350,7 +351,7 @@ def main() -> None:
         seq_len=args.seq_len,
         partition_size=candidate_partition_size,
     )
-    torch.cuda.synchronize()
+    torch.accelerator.synchronize()
 
     diff_mask = baseline.ne(padded)
     mismatch_indices = diff_mask.nonzero(as_tuple=False)


### PR DESCRIPTION
## Purpose
Resolve the scoped check-torch-cuda-call baseline under issue 126 for Flash-V100 benchmark scripts.

Base: onecat/main at 3ec0c68c6596d6ab31fbdee9fa676254a52c2b7d.

## Scope
Only these six benchmark files are changed:
- benchmarks/benchmark_sm70_flashinfer_fixed_entry.py
- benchmarks/benchmark_sm70_flashinfer_realshape_ab.py
- benchmarks/benchmark_sm70_flashinfer_splitkv3_realshape_ab.py
- benchmarks/benchmark_sm70_triton_attention_schedule.py
- benchmarks/kernels/benchmark_flash_v100_prefill_decay.py
- benchmarks/kernels/benchmark_sm70_flash_v100_xqa_layout.py

Eligible synchronization, accelerator selection, device-count, cache-clear, and all-device seed calls use the PyTorch accelerator or project APIs. CUDA Events, NVTX, CUDA device properties, and SM70 capability checks remain CUDA-specific. Existing timing, numerical-check, and monitoring boundaries are unchanged.

## Validation
- check-torch-cuda-call on all six files: passed
- Ruff check: passed
- Ruff format check: passed
- Python compile check: passed
- Git diff whitespace check: passed
- CLI help smoke: passed
- Seed helper smoke preserves the Torch RNG sequence and delegates all-device seeding.
- The formatter also resolves five pre-existing formatting items in benchmark_sm70_flashinfer_fixed_entry.py, within the declared scope.

## Required Hardware Gate
This host cannot initialize CUDA because of error 804, so it did not run benchmarks. Before merge, rerun the affected Flash-V100 fixed-entry, real-shape, SplitKV3, Triton-schedule, prefill-decay, and XQA benchmarks on a real V100. Verify numerical gates, timing boundaries, route dispatch, and benchmark outputs remain unchanged apart from this API migration.