### PR TITLE
[Kernel] Reduce SM70 DeepSeek V4 MXFP4 expert launches

### DIFF
--- a/benchmarks/benchmark_sm70_mxfp4_moe_active_experts.py
+++ b/benchmarks/benchmark_sm70_mxfp4_moe_active_experts.py
@@ -1,0 +1,367 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Benchmark dense-expert versus active-expert SM70 MXFP4 MoE stages.
+
+This benchmark uses the exact DeepSeek-V4-Flash TP8 W13/W2 shapes. Both paths
+call the same TurboMind per-expert GEMM. They differ only in whether the fixed
+CUDA Graph contains all 256 experts or the six routed slots.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from dataclasses import dataclass
+
+import torch
+
+from vllm import _sm70_ops as sm70_ops
+
+
+@dataclass(frozen=True)
+class StageShape:
+    name: str
+    k: int
+    n: int
+
+
+STAGES = {
+    "w13": StageShape("w13", 4096, 512),
+    "w2": StageShape("w2", 256, 4096),
+}
+
+
+def _require_sm70() -> None:
+    if not torch.cuda.is_available():
+        raise RuntimeError("CUDA is required")
+    major, minor = torch.cuda.get_device_capability()
+    if (major, minor) != (7, 0):
+        raise RuntimeError(f"This benchmark requires SM70, got SM{major}{minor}")
+    for op_name in (
+        "mxfp4_sm70_prepare",
+        "mxfp4_moe_dense_stage_sm70_out",
+        "awq_moe_build_strided_ptrs",
+    ):
+        if not hasattr(torch.ops._C, op_name):
+            raise RuntimeError(f"Required operator is missing: _C::{op_name}")
+
+
+def _expert_pattern(num_experts: int, device: torch.device) -> torch.Tensor:
+    nibble = torch.arange(num_experts, dtype=torch.int32, device=device) & 0xF
+    pattern = nibble.clone()
+    for shift in range(4, 32, 4):
+        pattern |= nibble << shift
+    return pattern
+
+
+def _prepare_experts(
+    shape: StageShape, num_experts: int, device: torch.device
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    qweight = torch.randint(
+        0,
+        16,
+        (shape.k, shape.n),
+        dtype=torch.uint8,
+        device=device,
+    )
+    scales = torch.full(
+        (shape.k // 32, shape.n),
+        127,
+        dtype=torch.uint8,
+        device=device,
+    )
+    weight, prepared_scales, meta = sm70_ops.mxfp4_sm70_prepare(qweight, scales, 32)
+    weights = weight.unsqueeze(0).repeat(num_experts, 1, 1)
+    weights.bitwise_xor_(_expert_pattern(num_experts, device)[:, None, None])
+    expert_scales = prepared_scales.unsqueeze(0).repeat(num_experts, 1, 1)
+    ptrs_w, ptrs_s = sm70_ops.awq_moe_build_strided_ptrs(
+        weights,
+        expert_scales,
+        int(meta[0].item()),
+        int(meta[1].item()),
+        num_experts,
+    )
+    return weights, expert_scales, ptrs_w, ptrs_s
+
+
+def _full_offsets(route: list[int], num_experts: int) -> list[int]:
+    counts = [0] * num_experts
+    for expert_id in route:
+        counts[expert_id] += 1
+    offsets = [0]
+    for count in counts:
+        offsets.append(offsets[-1] + count)
+    return offsets
+
+
+def _capture(fn) -> torch.cuda.CUDAGraph:
+    stream = torch.cuda.Stream()
+    stream.wait_stream(torch.cuda.current_stream())
+    with torch.cuda.stream(stream):
+        fn()
+    torch.cuda.current_stream().wait_stream(stream)
+    torch.cuda.synchronize()
+
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        fn()
+    torch.cuda.synchronize()
+    return graph
+
+
+def _time_graph(graph: torch.cuda.CUDAGraph, repeats: int) -> float:
+    for _ in range(5):
+        graph.replay()
+    torch.cuda.synchronize()
+    start = torch.cuda.Event(enable_timing=True)
+    end = torch.cuda.Event(enable_timing=True)
+    start.record()
+    for _ in range(repeats):
+        graph.replay()
+    end.record()
+    end.synchronize()
+    return start.elapsed_time(end) / repeats
+
+
+def _validate_permute_contract(
+    shape: StageShape,
+    *,
+    ptrs_w: torch.Tensor,
+    ptrs_s: torch.Tensor,
+    num_experts: int,
+    route: list[int],
+) -> dict[str, object]:
+    device = ptrs_w.device
+    top_k = len(route)
+    x = torch.randn(1, shape.k, dtype=torch.float16, device=device) * 0.01
+    topk_ids = torch.tensor([route], dtype=torch.int32, device=device)
+    token_expert_indices = torch.arange(top_k, dtype=torch.int32, device=device).view(
+        1, top_k
+    )
+    permuted_input = torch.empty(top_k, shape.k, dtype=torch.float16, device=device)
+    expert_offsets64 = torch.empty(num_experts + 1, dtype=torch.int64, device=device)
+    inv_permuted_idx = torch.empty(1, top_k, dtype=torch.int32, device=device)
+    permuted_idx = torch.full((top_k,), top_k, dtype=torch.int32, device=device)
+    permuted_experts_id = torch.empty(top_k, dtype=torch.int32, device=device)
+    sorted_row_idx = torch.empty(top_k, dtype=torch.int32, device=device)
+    topk_ids_for_sort = torch.empty(top_k, dtype=torch.int32, device=device)
+    workspace_size = torch.ops._moe_C.moe_permute_sort_workspace_size(
+        top_k, num_experts
+    )
+    workspace = torch.empty(workspace_size, dtype=torch.int8, device=device)
+
+    torch.ops._moe_C.moe_permute_with_scratch(
+        x,
+        topk_ids,
+        token_expert_indices,
+        None,
+        num_experts,
+        num_experts,
+        top_k,
+        permuted_input,
+        expert_offsets64,
+        inv_permuted_idx,
+        permuted_idx,
+        workspace,
+        permuted_experts_id,
+        sorted_row_idx,
+        topk_ids_for_sort,
+    )
+    expert_offsets = expert_offsets64.to(torch.int32)
+    dense_ids = torch.arange(num_experts, dtype=torch.int32, device=device)
+    compact_offsets = torch.arange(top_k + 1, dtype=torch.int32, device=device)
+    dense_out = torch.empty(top_k, shape.n, dtype=torch.float16, device=device)
+    active_out = torch.empty_like(dense_out)
+    sm70_ops.mxfp4_moe_dense_stage_sm70_out(
+        dense_out,
+        permuted_input,
+        expert_offsets,
+        dense_ids,
+        ptrs_w,
+        ptrs_s,
+        num_experts,
+        shape.k,
+        shape.n,
+        32,
+    )
+    sm70_ops.mxfp4_moe_dense_stage_sm70_out(
+        active_out,
+        permuted_input,
+        compact_offsets,
+        permuted_experts_id,
+        ptrs_w,
+        ptrs_s,
+        top_k,
+        shape.k,
+        shape.n,
+        32,
+    )
+    torch.cuda.synchronize()
+    expected_sorted = sorted(route)
+    actual_sorted = permuted_experts_id.cpu().tolist()
+    result = {
+        "bitwise_equal": torch.equal(dense_out, active_out),
+        "max_abs": float((dense_out - active_out).abs().max().item()),
+        "expected_sorted_expert_ids": expected_sorted,
+        "actual_sorted_expert_ids": actual_sorted,
+        "sorted_expert_ids_match": actual_sorted == expected_sorted,
+    }
+    if not result["bitwise_equal"] or not result["sorted_expert_ids_match"]:
+        raise RuntimeError(f"MXFP4 permute contract gate failed: {result}")
+    return result
+
+
+def benchmark_stage(
+    shape: StageShape,
+    *,
+    num_experts: int,
+    top_k: int,
+    repeats: int,
+    seed: int,
+) -> dict[str, object]:
+    torch.manual_seed(seed)
+    device = torch.device("cuda")
+    _weights, _scales, ptrs_w, ptrs_s = _prepare_experts(shape, num_experts, device)
+
+    route_a = [3, 17, 42, 99, 128, 255]
+    route_b = [1, 9, 63, 111, 177, 240]
+    if top_k != len(route_a) or max(route_a + route_b) >= num_experts:
+        raise ValueError("The exact benchmark requires 256 experts and top-k=6")
+
+    x = torch.randn(top_k, shape.k, dtype=torch.float16, device=device) * 0.01
+    dense_out = torch.empty(top_k, shape.n, dtype=torch.float16, device=device)
+    active_out = torch.empty_like(dense_out)
+    dense_ids = torch.arange(num_experts, dtype=torch.int32, device=device)
+    active_ids = torch.tensor(route_a, dtype=torch.int32, device=device)
+    dense_offsets = torch.tensor(
+        _full_offsets(route_a, num_experts), dtype=torch.int32, device=device
+    )
+    active_offsets = torch.arange(top_k + 1, dtype=torch.int32, device=device)
+
+    def dense_call() -> None:
+        sm70_ops.mxfp4_moe_dense_stage_sm70_out(
+            dense_out,
+            x,
+            dense_offsets,
+            dense_ids,
+            ptrs_w,
+            ptrs_s,
+            num_experts,
+            shape.k,
+            shape.n,
+            32,
+        )
+
+    def active_call() -> None:
+        sm70_ops.mxfp4_moe_dense_stage_sm70_out(
+            active_out,
+            x,
+            active_offsets,
+            active_ids,
+            ptrs_w,
+            ptrs_s,
+            top_k,
+            shape.k,
+            shape.n,
+            32,
+        )
+
+    dense_call()
+    active_call()
+    torch.cuda.synchronize()
+    initial_equal = torch.equal(dense_out, active_out)
+    initial_max_abs = float((dense_out - active_out).abs().max().item())
+
+    dense_graph = _capture(dense_call)
+    active_graph = _capture(active_call)
+    dense_ms = _time_graph(dense_graph, repeats)
+    active_ms = _time_graph(active_graph, repeats)
+
+    active_ids.copy_(torch.tensor(route_b, dtype=torch.int32, device=device))
+    active_graph.replay()
+    torch.cuda.synchronize()
+    route_b_graph_out = active_out.clone()
+
+    dense_offsets.copy_(
+        torch.tensor(
+            _full_offsets(route_b, num_experts), dtype=torch.int32, device=device
+        )
+    )
+    dense_call()
+    torch.cuda.synchronize()
+    replay_equal = torch.equal(dense_out, route_b_graph_out)
+    replay_max_abs = float((dense_out - route_b_graph_out).abs().max().item())
+
+    active_ids.copy_(torch.tensor(route_a, dtype=torch.int32, device=device))
+    active_graph.replay()
+    torch.cuda.synchronize()
+    route_a_graph_out = active_out.clone()
+    route_changes_output = not torch.equal(route_a_graph_out, route_b_graph_out)
+
+    result = {
+        "stage": shape.name,
+        "k": shape.k,
+        "n": shape.n,
+        "num_experts": num_experts,
+        "top_k": top_k,
+        "dense_graph_ms": dense_ms,
+        "active_graph_ms": active_ms,
+        "speedup": dense_ms / active_ms,
+        "saved_expert_launches_per_stage": num_experts - top_k,
+        "initial_bitwise_equal": initial_equal,
+        "initial_max_abs": initial_max_abs,
+        "dynamic_replay_bitwise_equal": replay_equal,
+        "dynamic_replay_max_abs": replay_max_abs,
+        "dynamic_route_changes_output": route_changes_output,
+        "moe_permute_contract": _validate_permute_contract(
+            shape,
+            ptrs_w=ptrs_w,
+            ptrs_s=ptrs_s,
+            num_experts=num_experts,
+            route=list(reversed(route_a)),
+        ),
+    }
+    if not initial_equal or not replay_equal or not route_changes_output:
+        raise RuntimeError(f"MXFP4 active-expert correctness gate failed: {result}")
+    return result
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--stage", choices=("w13", "w2", "both"), default="both")
+    parser.add_argument("--num-experts", type=int, default=256)
+    parser.add_argument("--top-k", type=int, default=6)
+    parser.add_argument("--repeats", type=int, default=100)
+    parser.add_argument("--seed", type=int, default=17)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    _require_sm70()
+    selected = STAGES.values() if args.stage == "both" else (STAGES[args.stage],)
+    results = [
+        benchmark_stage(
+            shape,
+            num_experts=args.num_experts,
+            top_k=args.top_k,
+            repeats=args.repeats,
+            seed=args.seed + index,
+        )
+        for index, shape in enumerate(selected)
+    ]
+    print(
+        json.dumps(
+            {
+                "benchmark": "sm70_mxfp4_moe_active_experts",
+                "device": torch.cuda.get_device_name(),
+                "results": results,
+            },
+            indent=2,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/design/sm70_deepseek_v4_mxfp4_active_expert.md
+++ b/docs/design/sm70_deepseek_v4_mxfp4_active_expert.md
@@ -1,0 +1,86 @@
+# SM70 DeepSeek V4 MXFP4 Active-Expert Optimization
+
+## Scope
+
+- Base: `dd462e37f2552f3e038f1ed7128e62bd7b4ab0d7`
+- Dependency: DeepSeek V4 SM70 bring-up PR #159
+- Model: `deepseek-ai/DeepSeek-V4-Flash`, MXFP4 experts
+- Runtime: 8 x V100-SXM2-32GB, TP8, FP16 activations, `fp8_ds_mla` KV
+- Quantization backend: TurboMind only; Marlin is out of scope
+- Decode mode: CUDA Graph enabled, no MTP, no eager execution
+
+The first optimization target is the graph-safe batch-one MXFP4 MoE path. The
+change must preserve expert routing, accumulation order, output dtype, graph
+replay stability, and official-sampling output quality.
+
+## Baseline Evidence
+
+The accepted trace request used exactly 1024 prompt tokens and 256 generated
+tokens with `temperature=1.0`, `top_p=1.0`, and natural EOS behavior. It
+completed all 256 tokens without malformed output.
+
+Raw artifacts are retained on the profiling host at:
+
+```text
+/home/fudanwl/v100-worktrees/runs/
+  dsv4-tp8-nsys-i1024-o256-retry1-20260802/
+```
+
+The Nsight Systems report contains 255 decode replays per rank: the first
+emitted token comes from prefill, followed by 255 decode forwards. The parser
+drops four fill/drain steps at each edge and aggregates 247 steady steps.
+
+| Item | Mean per token | Notes |
+|---|---:|---|
+| Node-trace TPOT | 149.687 ms | Composition only; CUPTI adds overhead |
+| TP rank interval max | 150.183 ms | Replay-to-next-replay |
+| Rank-average GPU service | 130.080 ms | Categories sum exactly to this value |
+| TurboMind MXFP4 MoE | 54.594 ms | 22,016 launches/rank/token |
+| SM70 sparse MLA attention | 46.880 ms | 43 launches/rank/token |
+| TP all-reduce | 10.154 ms | Overlaps other streams; not additive wall |
+| TurboMind FP8 dense | 6.064 ms | 279 launches/rank/token |
+
+The prior unprofiled artifact was labeled 1024 tokens but the serving
+tokenizer reports 1020. Its 134.143 ms TPOT remains useful as a provisional
+speed reference only. An exact-1024 unprofiled baseline is required before an
+end-to-end speed claim.
+
+## Root Cause
+
+The graph-safe path launches both MXFP4 stages for every local expert:
+
+```text
+43 layers * 256 experts * 2 stages = 22,016 launches/token/rank
+```
+
+On rank 0, 5,476,780 of 5,614,080 MXFP4 decode launches (97.55%) finish in
+less than 2.5 microseconds. Those empty or near-empty launches consume
+42.738 ms/token of traced GPU service. Approximately 538 launches/token do
+material work, close to the `43 * top_k(6) * 2 = 516` active-expert bound.
+
+This makes active-expert device-side dispatch or a persistent grouped stage a
+higher-value target than tuning the existing per-expert GEMM tile.
+
+## Optimization Gate
+
+1. Reproduce the exact DeepSeek V4 shapes in an operator microbenchmark.
+2. Compare against the current graph-safe dense-expert path with fixed routing.
+3. Verify numerical output against the current FP16 output, including repeated
+   expert IDs and all six routed slots; do not change quantization or precision.
+4. Prove CUDA Graph capture/replay with routing IDs changed between replays.
+5. Require fewer expert-stage launches and lower CUDA-event wall time.
+6. Run the full-model 1024/256 official-sampling quality gate.
+7. Accept an end-to-end claim only from an unprofiled same-contract A/B.
+
+If active-expert dispatch cannot remain graph-safe or its numerical result
+changes, reject it and move to the next trace hotspot rather than weakening the
+quality contract.
+
+## Rejected Profiling Paths
+
+- The old token parser grouped TP ranks by an 8 ms time window and recognized
+  only `cudagraph.FULL.replay`; that is invalid for this TP8 Breakable Graph
+  trace. The profiling skill now aligns each worker's Nth replay by ordinal.
+- `nsys stats cuda_gpu_kern_sum` reached 77 GB RSS on the 49-million-kernel
+  trace and was stopped before OOM. SQLite streaming aggregation produced the
+  accepted table with bounded memory.

--- a/docs/design/sm70_deepseek_v4_mxfp4_active_expert.md
+++ b/docs/design/sm70_deepseek_v4_mxfp4_active_expert.md
@@ -41,9 +41,7 @@ drops four fill/drain steps at each edge and aggregates 247 steady steps.
 | TurboMind FP8 dense | 6.064 ms | 279 launches/rank/token |
 
 The prior unprofiled artifact was labeled 1024 tokens but the serving
-tokenizer reports 1020. Its 134.143 ms TPOT remains useful as a provisional
-speed reference only. An exact-1024 unprofiled baseline is required before an
-end-to-end speed claim.
+tokenizer reports 1020. It is excluded from the accepted A/B below.
 
 ## Root Cause
 
@@ -61,12 +59,57 @@ material work, close to the `43 * top_k(6) * 2 = 516` active-expert bound.
 This makes active-expert device-side dispatch or a persistent grouped stage a
 higher-value target than tuning the existing per-expert GEMM tile.
 
+The first microbenchmark avoids a new arithmetic kernel. It reuses the exact
+existing per-expert TurboMind GEMM but captures only six fixed route slots.
+Expert IDs stay in a device tensor, so their values can change at replay time.
+
+| Exact TP8 stage | 256-expert graph | 6-expert graph | Speedup | Numeric gate |
+|---|---:|---:|---:|---|
+| W13, K4096/N512 | 0.7369 ms | 0.1268 ms | 5.81x | Bitwise exact |
+| W2, K256/N4096 | 0.5255 ms | 0.0461 ms | 11.41x | Bitwise exact |
+
+Changing all six expert IDs after graph capture also remains bitwise equal to
+the 256-expert reference and changes the output as expected. A second gate
+uses the production `moe_permute_with_scratch` output directly; its sorted
+expert IDs match the six selected experts and both stages remain bitwise equal
+to the 256-expert reference. The retained artifact is
+`dsv4-mxfp4-active-expert-micro/baseline_vs_active_permute.json`.
+
+The active-expert route remains explicit opt-in until the final deterministic
+full-model gate passes. It also falls back to dense dispatch for expert-parallel
+layouts and when either legacy single-token permute fastpath is enabled. Those
+paths do not guarantee the six valid local runtime expert IDs required by
+active-expert dispatch.
+
+## Unprofiled A/B
+
+Both sides use exact 1024-token input, 256-token output, TP8, FP8 MLA KV,
+official `temperature=1.0` / `top_p=1.0`, no MTP, and CUDA Graph. Three requests
+per side completed with `finish_reason=length`.
+
+| Route | Mean TPOT | Throughput | Mean TTFT |
+|---|---:|---:|---:|
+| Dense 256-expert control | 133.480 ms | 7.492 tok/s | 1783.624 ms |
+| Active six-slot candidate | 76.268 ms | 13.112 tok/s | 1789.254 ms |
+| Delta | -57.212 ms (-42.86%) | +75.01% | +5.630 ms |
+
+Artifacts are retained in
+`dsv4-tp8-active-expert-b1-{control,candidate}`. Official-sampling outputs are
+structurally healthy, but random sampling is not reproducible within one
+service on this runtime, so cross-service text equality is not a valid quality
+oracle. Greedy text is also not reproducible across two requests in the same
+candidate service; one repeat entered a repetitive continuation. A repeated
+dense-control run is still required to separate a baseline determinism problem
+from an active-expert regression. Until that comparison is complete, the route
+remains opt-in and the quality gate is explicitly open.
+
 ## Optimization Gate
 
 1. Reproduce the exact DeepSeek V4 shapes in an operator microbenchmark.
 2. Compare against the current graph-safe dense-expert path with fixed routing.
-3. Verify numerical output against the current FP16 output, including repeated
-   expert IDs and all six routed slots; do not change quantization or precision.
+3. Verify numerical output against the current FP16 output using the real
+   permute metadata and all six distinct routed slots; do not change
+   quantization or precision.
 4. Prove CUDA Graph capture/replay with routing IDs changed between replays.
 5. Require fewer expert-stage launches and lower CUDA-event wall time.
 6. Run the full-model 1024/256 official-sampling quality gate.

--- a/tests/quantization/test_sm70_mxfp4_moe.py
+++ b/tests/quantization/test_sm70_mxfp4_moe.py
@@ -6,18 +6,21 @@ from types import SimpleNamespace
 import pytest
 import torch
 
+from vllm import envs
 from vllm.model_executor.layers.fused_moe import (
     FusedMoEConfig,
     FusedMoEParallelConfig,
     MoEActivation,
     RoutingMethodType,
 )
+from vllm.model_executor.layers.quantization import mxfp4_sm70_moe as mxfp4_moe
 from vllm.model_executor.layers.quantization import sm70_turbomind as sm70_tm
 from vllm.model_executor.layers.quantization.mxfp4 import (
     make_deepseek_v4_mxfp4_moe_method,
 )
 from vllm.model_executor.layers.quantization.mxfp4_sm70_moe import (
     Mxfp4SM70MoEMethod,
+    _select_mxfp4_stage_dispatch,
     validate_mxfp4_sm70_moe_contract,
     validate_mxfp4_sm70_moe_weight_layout,
 )
@@ -178,6 +181,94 @@ def test_mxfp4_sm70_factory_rejects_marlin_or_emulation(monkeypatch):
 
     with pytest.raises(NotImplementedError, match="Marlin"):
         make_deepseek_v4_mxfp4_moe_method(_v4_flash_moe_config())
+
+
+def test_mxfp4_sm70_b1_dispatch_selects_six_runtime_experts(monkeypatch):
+    buffers = {
+        "compact_expert_offsets": torch.arange(7, dtype=torch.int32),
+        "permuted_experts_id": torch.tensor(
+            [3, 17, 42, 99, 128, 255], dtype=torch.int32
+        ),
+        "expert_offsets": torch.arange(257, dtype=torch.int32),
+        "dense_expert_ids": torch.arange(256, dtype=torch.int32),
+    }
+    monkeypatch.setattr(mxfp4_moe, "_mxfp4_active_expert_b1_enabled", lambda: True)
+
+    offsets, expert_ids, count = _select_mxfp4_stage_dispatch(
+        buffers,
+        num_tokens=1,
+        num_experts=256,
+        fully_replicated_experts=True,
+    )
+
+    assert offsets is buffers["compact_expert_offsets"]
+    assert expert_ids is buffers["permuted_experts_id"]
+    assert count == 6
+
+
+def test_mxfp4_sm70_b1_dispatch_rejects_incompatible_permute_fastpath(
+    monkeypatch,
+):
+    monkeypatch.setattr(envs, "VLLM_SM70_MXFP4_MOE_ACTIVE_EXPERT_B1", True)
+    monkeypatch.setattr(envs, "VLLM_SM70_MOE_SINGLE_TOKEN_PERMUTE_FASTPATH", True)
+
+    assert not mxfp4_moe._mxfp4_active_expert_b1_enabled()
+
+
+def test_mxfp4_sm70_b1_dispatch_rejects_generic_single_token_fastpath(
+    monkeypatch,
+):
+    monkeypatch.setattr(envs, "VLLM_SM70_MXFP4_MOE_ACTIVE_EXPERT_B1", True)
+    monkeypatch.setattr(envs, "VLLM_SM70_MOE_SINGLE_TOKEN_FASTPATH", True)
+
+    assert not mxfp4_moe._mxfp4_active_expert_b1_enabled()
+
+
+def test_mxfp4_sm70_b1_dispatch_rejects_expert_parallel_metadata(monkeypatch):
+    buffers = {
+        "compact_expert_offsets": torch.arange(7, dtype=torch.int32),
+        "permuted_experts_id": torch.arange(6, dtype=torch.int32),
+        "expert_offsets": torch.arange(257, dtype=torch.int32),
+        "dense_expert_ids": torch.arange(256, dtype=torch.int32),
+    }
+    monkeypatch.setattr(mxfp4_moe, "_mxfp4_active_expert_b1_enabled", lambda: True)
+
+    offsets, expert_ids, count = _select_mxfp4_stage_dispatch(
+        buffers,
+        num_tokens=1,
+        num_experts=256,
+        fully_replicated_experts=False,
+    )
+
+    assert offsets is buffers["expert_offsets"]
+    assert expert_ids is buffers["dense_expert_ids"]
+    assert count == 256
+
+
+@pytest.mark.parametrize("num_tokens", [1, 2])
+def test_mxfp4_sm70_dispatch_retains_dense_fallback(monkeypatch, num_tokens):
+    buffers = {
+        "compact_expert_offsets": torch.arange(7, dtype=torch.int32),
+        "permuted_experts_id": torch.arange(6, dtype=torch.int32),
+        "expert_offsets": torch.arange(257, dtype=torch.int32),
+        "dense_expert_ids": torch.arange(256, dtype=torch.int32),
+    }
+    monkeypatch.setattr(
+        mxfp4_moe,
+        "_mxfp4_active_expert_b1_enabled",
+        lambda: num_tokens != 1,
+    )
+
+    offsets, expert_ids, count = _select_mxfp4_stage_dispatch(
+        buffers,
+        num_tokens=num_tokens,
+        num_experts=256,
+        fully_replicated_experts=True,
+    )
+
+    assert offsets is buffers["expert_offsets"]
+    assert expert_ids is buffers["dense_expert_ids"]
+    assert count == 256
 
 
 def test_mxfp4_sm70_post_load_reads_bias_from_method_config(monkeypatch):

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -193,6 +193,7 @@ if TYPE_CHECKING:
     VLLM_SM70_FP8_DENSE_GATED_SILU: bool = True
     VLLM_SM70_NVFP4_TURBOMIND: bool = True
     VLLM_SM70_MXFP4_TURBOMIND: bool = True
+    VLLM_SM70_MXFP4_MOE_ACTIVE_EXPERT_B1: bool = False
     VLLM_SM70_FP8_MOE_DEQUANT_FALLBACK: bool = False
     VLLM_SM70_FP8_MOE_BATCHED_GEMM: bool = True
     VLLM_SM70_FP8_MOE_BATCHED_W13_PER_EXPERT_DISPATCH: bool = False
@@ -1809,6 +1810,12 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # back to the generic vLLM permute path in Python.
     "VLLM_SM70_FP8_MOE_PERMUTE_WITH_SCRATCH": lambda: bool(
         int(os.getenv("VLLM_SM70_FP8_MOE_PERMUTE_WITH_SCRATCH", "1"))
+    ),
+    # DeepSeek V4 batch-one MXFP4 decode has six routed slots but 256 local
+    # experts. Dispatch only those six fixed graph slots; expert IDs remain
+    # device tensors and can change between CUDA Graph replays.
+    "VLLM_SM70_MXFP4_MOE_ACTIVE_EXPERT_B1": lambda: bool(
+        int(os.getenv("VLLM_SM70_MXFP4_MOE_ACTIVE_EXPERT_B1", "0"))
     ),
     # FP8 caller for the generic SM70 TurboMind active-source-group compact
     # decode path. The backend scheduler keeps source expert group semantics

--- a/vllm/model_executor/layers/quantization/mxfp4_sm70_moe.py
+++ b/vllm/model_executor/layers/quantization/mxfp4_sm70_moe.py
@@ -15,6 +15,7 @@ import torch
 from torch.nn import Parameter
 
 from vllm import _sm70_ops as sm70_ops
+from vllm import envs
 from vllm.logger import init_logger
 from vllm.model_executor.layers.fused_moe import (
     FusedMoEConfig,
@@ -39,6 +40,34 @@ _DEEPSEEK_V4_FLASH_INTERMEDIATE_SIZE: Final = 2048
 _DEEPSEEK_V4_FLASH_NUM_EXPERTS: Final = 256
 _DEEPSEEK_V4_FLASH_TOP_K: Final = 6
 _GRAPH_SAFE_MAX_TOKENS: Final = 1
+
+
+def _mxfp4_active_expert_b1_enabled() -> bool:
+    return bool(
+        envs.VLLM_SM70_MXFP4_MOE_ACTIVE_EXPERT_B1
+        and not envs.VLLM_SM70_MOE_SINGLE_TOKEN_FASTPATH
+        and not envs.VLLM_SM70_MOE_SINGLE_TOKEN_PERMUTE_FASTPATH
+    )
+
+
+def _select_mxfp4_stage_dispatch(
+    buffers: dict[str, torch.Tensor],
+    *,
+    num_tokens: int,
+    num_experts: int,
+    fully_replicated_experts: bool,
+) -> tuple[torch.Tensor, torch.Tensor, int]:
+    if (
+        num_tokens == 1
+        and fully_replicated_experts
+        and _mxfp4_active_expert_b1_enabled()
+    ):
+        return (
+            buffers["compact_expert_offsets"],
+            buffers["permuted_experts_id"],
+            _DEEPSEEK_V4_FLASH_TOP_K,
+        )
+    return buffers["expert_offsets"], buffers["dense_expert_ids"], num_experts
 
 
 def validate_mxfp4_sm70_moe_contract(
@@ -317,8 +346,9 @@ class Mxfp4SM70MoEMethod(Mxfp4MoEMethod):
         del layer.w2_weight_scale
         logger.info_once(
             "SM70 TurboMind MXFP4 MoE enabled for DeepSeek-V4-Flash "
-            "(local_experts=%d, graph_safe_decode=B1).",
+            "(local_experts=%d, graph_safe_decode=B1, active_expert_b1=%s).",
             num_experts,
+            _mxfp4_active_expert_b1_enabled(),
         )
 
     def _allocate_graph_safe_b1_buffers(self, layer: RoutedExperts) -> None:
@@ -386,6 +416,9 @@ class Mxfp4SM70MoEMethod(Mxfp4MoEMethod):
         layer._mxfp4_sm70_buf_dense_expert_ids = torch.arange(
             num_experts, dtype=torch.int32, device=device
         )
+        layer._mxfp4_sm70_buf_compact_expert_offsets = torch.arange(
+            top_k + 1, dtype=torch.int32, device=device
+        )
 
     @staticmethod
     def _persistent_b1_buffers(layer: RoutedExperts) -> dict[str, torch.Tensor]:
@@ -406,6 +439,7 @@ class Mxfp4SM70MoEMethod(Mxfp4MoEMethod):
             "sorted_row_idx": layer._mxfp4_sm70_buf_sorted_row_idx,
             "topk_ids_for_sort": layer._mxfp4_sm70_buf_topk_ids_for_sort,
             "dense_expert_ids": layer._mxfp4_sm70_buf_dense_expert_ids,
+            "compact_expert_offsets": (layer._mxfp4_sm70_buf_compact_expert_offsets),
         }
 
     @staticmethod
@@ -469,6 +503,7 @@ class Mxfp4SM70MoEMethod(Mxfp4MoEMethod):
                 total_slots, dtype=torch.int32, device=device
             ),
             "dense_expert_ids": layer._mxfp4_sm70_buf_dense_expert_ids,
+            "compact_expert_offsets": (layer._mxfp4_sm70_buf_compact_expert_offsets),
         }
 
     def _get_buffers(
@@ -556,14 +591,26 @@ class Mxfp4SM70MoEMethod(Mxfp4MoEMethod):
         )
         buffers["expert_offsets"].copy_(buffers["expert_offsets64"], non_blocking=True)
 
+        stage_offsets, stage_expert_ids, stage_expert_count = (
+            _select_mxfp4_stage_dispatch(
+                buffers,
+                num_tokens=num_tokens,
+                num_experts=layer.sm70_mxfp4_num_experts,
+                fully_replicated_experts=(
+                    layer.expert_map is None
+                    and layer.local_num_experts == layer.global_num_experts
+                ),
+            )
+        )
+
         sm70_ops.mxfp4_moe_dense_stage_sm70_out(
             buffers["gate_up"],
             buffers["permuted_input"],
-            buffers["expert_offsets"],
-            buffers["dense_expert_ids"],
+            stage_offsets,
+            stage_expert_ids,
             layer.w13_strided_ptrs_w,
             layer.w13_strided_ptrs_s,
-            layer.sm70_mxfp4_num_experts,
+            stage_expert_count,
             layer.sm70_mxfp4_w13_k_dim,
             layer.sm70_mxfp4_w13_n_dim,
             layer.sm70_mxfp4_group_size,
@@ -572,11 +619,11 @@ class Mxfp4SM70MoEMethod(Mxfp4MoEMethod):
         sm70_ops.mxfp4_moe_dense_stage_sm70_out(
             buffers["sorted_output"],
             buffers["intermediate"],
-            buffers["expert_offsets"],
-            buffers["dense_expert_ids"],
+            stage_offsets,
+            stage_expert_ids,
             layer.w2_strided_ptrs_w,
             layer.w2_strided_ptrs_s,
-            layer.sm70_mxfp4_num_experts,
+            stage_expert_count,
             layer.sm70_mxfp4_w2_k_dim,
             layer.sm70_mxfp4_w2_n_dim,
             layer.sm70_mxfp4_group_size,


### PR DESCRIPTION
## Purpose
Reduce graph-safe DeepSeek V4 batch-one MXFP4 MoE launch overhead on V100 without changing routing, quantization, accumulation order, or CUDA Graph behavior.

Depends on #159. The route remains explicit opt-in until the remaining quality diagnostic closes.

## Baseline
- Base SHA: `dd462e37f2552f3e038f1ed7128e62bd7b4ab0d7`
- TP8, 8x V100-SXM2-32GB, exact 1024 input / 256 output, no MTP, FP8 MLA KV, CUDA Graph
- Nsight: MXFP4 MoE 54.594 ms rank-average GPU service/token
- 22,016 expert-stage launches/rank/token; 97.55% of rank0 launches are under 2.5 us

## Implementation
- For B1 with all 256 experts replicated, dispatch the six routed slots using device-resident `permuted_experts_id` and fixed `[0..6]` offsets.
- Keep B>1, EP/expert-map layouts, and disabled configurations on dense-256 fallback.
- Automatically reject both legacy single-token permute fastpath combinations because they do not produce runtime expert-ID metadata.
- Default `VLLM_SM70_MXFP4_MOE_ACTIVE_EXPERT_B1=0` while the final quality diagnostic is open.

## Test Result
- Focused unit tests: `19 passed`
- Ruff check and format check: pass
- Exact stage microbenchmark, CUDA Graph replay, dynamic route IDs, and real `moe_permute_with_scratch`: bitwise exact
- W13 `0.7369 -> 0.1268 ms` (`5.81x`)
- W2 `0.5255 -> 0.0461 ms` (`11.41x`)
- Unprofiled official-sampling 3-run mean: `133.480 -> 76.268 ms/token` (`-42.86%`), `7.492 -> 13.112 tok/s` (`+75.01%`)

## Quality Status
Official-sampling outputs completed 256 tokens and were structurally healthy. Random and greedy generation are not reproducible within one candidate service; one repeated greedy continuation became repetitive. A repeated dense-control run is in progress to distinguish an existing baseline determinism issue from a candidate regression. The route will not be enabled by default until that gate closes.

## Artifacts
Remote worklog paths and exact contracts are recorded in `docs/design/sm70_deepseek_v4_mxfp4_active_expert.md`.
