### PR TITLE
[SM70][NVFP4] ModelOpt admit + hybrid + MoE fallback + W4A4 + Medium scale fix

### DIFF
--- a/docs/design/sm70_nvfp4_checkpoint_serve_runbook.md
+++ b/docs/design/sm70_nvfp4_checkpoint_serve_runbook.md
@@ -113,6 +113,10 @@ python3 scripts/sm70_nvfp4_smoke_paris.py --model my-nvfp4
 
 ## Graph vs eager bisect
 
+pve3 A/B on `tc-medium-nvfp4` (2026-08-03): **graph PASS**, **eager PASS**
+(Paris + 323 both modes) with scale normalize + campaign flags. The graph-safe
+compilation/spec pins above are the preferred production path.
+
 ```bash
 bash scripts/sm70_nvfp4_ab_graph_eager.sh /path/to/ckpt served-name
 ```

--- a/docs/design/sm70_nvfp4_checkpoint_serve_runbook.md
+++ b/docs/design/sm70_nvfp4_checkpoint_serve_runbook.md
@@ -1,0 +1,132 @@
+# SM70 NVFP4 checkpoint scale + serve runbook
+
+Date: 2026-08-03  
+Related: PR scale normalize (`normalize_nvfp4_global_scale_for_sm70`),
+`docs/design/sm70_nvfp4_turbomind_operator_optimization.md`
+
+## Problem summary
+
+### 1) Scale convention (Python fix in this PR)
+
+Some GPTQ / Magpie NVFP4 exports (Medium, ThinkingCap, cyber) store **tiny**
+FP8 block scales with a large disk global. CT turns global into `1/G`;
+TurboMind multiplies `block * global` and under-scales → token salad.
+
+**Fix:** detect tiny block scales and set `weight_global_scale = 1.0`
+(leave block scales untouched).
+
+### 2) CUDA-graph garbage with identical wheel (serve flags)
+
+Third-party V100 hosts with the **same** public 1.2.2 `_C.abi3.so` have seen
+coherent output under `--enforce-eager` but salad under default graphs.
+
+**Fix (preferred over permanent eager):** pin graph capture mode and greedy
+MTP draft sampling:
+
+```bash
+  --compilation-config '{"cudagraph_mode":"full_and_piecewise","cudagraph_capture_sizes":[1,2,4,8]}' \
+  --speculative-config '{"method":"mtp","num_speculative_tokens":4,"attention_backend":"FLASH_ATTN_V100","draft_sample_method":"greedy"}'
+```
+
+Why these matter on 1.2.2:
+
+- **`full_and_piecewise` + explicit capture sizes** — avoids the
+  “MTP accepting but not amortized / wrong graph partition” failure mode
+  (piecewise-only or missing size-1 graphs). See deckard tok/s runbook notes.
+- **`draft_sample_method: greedy`** — 1.2.2 auto-promotes MTP draft to
+  probabilistic, which requires `draft_probs` only the dynamic-vocab path
+  emits. With dynamic draft vocab off (or multi-seq), non-greedy draft can
+  corrupt or crash; greedy is the safe production pin (same as
+  voice-coexist-mtp122).
+
+Also set `VLLM_SM70_MTP_DYNAMIC_DRAFT_VOCAB_DEFAULT=0` when
+`max_num_seqs != 1`.
+
+## Wheel identity
+
+Public **1Cat-vLLM 1.2.2** release:
+
+| Artifact | sha256 |
+| --- | --- |
+| wheel | `8a628983ad9d675559910372643220c418b307ddc7fd52ac65a7f5fbcb104bc6` |
+| `_C.abi3.so` | `ffc6271aaf25d96fe690d0f899544801cc1e39486905c49ad0090cb2cbe7a147` |
+
+https://github.com/1CatAI/1Cat-vLLM/releases/tag/v1.2.2  
+Tag commit: `644d8a7cd05ed4ecd1cd188e3c05b4bbd074f504`
+
+Scale normalize is **Python-only**. Matching `_C` + still garbage → serve
+flags / overlay, not a second wheel.
+
+```bash
+python3 scripts/sm70_nvfp4_verify_identity.py
+```
+
+## Recommended serve (wrapper)
+
+```bash
+export VLLM_SM70_NVFP4_TURBOMIND=1
+bash scripts/sm70_nvfp4_campaign_serve.sh /path/to/nvfp4-ckpt my-nvfp4
+```
+
+Full argv (graph-safe):
+
+```bash
+export VLLM_SM70_FLASH_ATTN_V100=1
+export VLLM_SM70_QUANT_BACKEND=turbomind
+export VLLM_SM70_NVFP4_TURBOMIND=1
+export VLLM_SM70_MTP_DYNAMIC_DRAFT_VOCAB_DEFAULT=0
+export VLLM_WORKER_MULTIPROC_METHOD=spawn
+export PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True
+
+python3 -m vllm.entrypoints.openai.api_server \
+  --model /path/to/nvfp4-ckpt \
+  --served-model-name my-nvfp4 \
+  --trust-remote-code --dtype half \
+  --attention-backend FLASH_ATTN_V100 \
+  --host 0.0.0.0 --port 8003 \
+  --tensor-parallel-size 2 \
+  --gpu-memory-utilization 0.85 \
+  --max-model-len 32768 \
+  --max-num-seqs 1 \
+  --max-num-batched-tokens 8192 \
+  --kv-cache-dtype fp8_e5m2 \
+  --compilation-config '{"cudagraph_mode":"full_and_piecewise","cudagraph_capture_sizes":[1,2,4,8]}' \
+  --speculative-config '{"method":"mtp","num_speculative_tokens":4,"attention_backend":"FLASH_ATTN_V100","draft_sample_method":"greedy"}' \
+  --enable-auto-tool-choice --tool-call-parser qwen3_coder \
+  --reasoning-parser qwen3 \
+  --default-chat-template-kwargs '{"enable_thinking":true,"preserve_thinking":true}'
+```
+
+Smoke:
+
+```bash
+python3 scripts/sm70_nvfp4_smoke_paris.py --model my-nvfp4
+# expects Paris + 17*19 → 323
+```
+
+### Measured (pve3, 2×V100, 1.2.2 + this PR)
+
+| Model | smoke | c1 tok/s |
+| --- | --- | ---: |
+| tc-medium-nvfp4 | Paris + 323 | ~66 |
+| tc-aggressive-nvfp4 | Paris + 323 | ~70 |
+
+## Graph vs eager bisect
+
+```bash
+bash scripts/sm70_nvfp4_ab_graph_eager.sh /path/to/ckpt served-name
+```
+
+| Result | Action |
+| --- | --- |
+| graph PASS (with flags above) | Ship that serve line |
+| graph FAIL, eager PASS | Missing compilation/spec pins — add flags above before permanent eager |
+| both FAIL | Overlay / TINY-scale normalize / env |
+
+## Checklist for third-party V100 hosts (JJ)
+
+1. Public `1cat_vllm==1.2.2` — `_C` sha matches above.
+2. This PR’s scale normalize (or release that includes it).
+3. Serve with **compilation-config + greedy MTP draft** (not default graphs alone).
+4. `VLLM_SM70_NVFP4_TURBOMIND=1`.
+5. Smoke Paris + 323 before long benches.

--- a/scripts/sm70_nvfp4_ab_graph_eager.sh
+++ b/scripts/sm70_nvfp4_ab_graph_eager.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# A/B: campaign serve with CUDA graphs vs --enforce-eager.
+# Usage: ab_graph_vs_eager.sh MODEL_DIR [SERVED_NAME]
+set -euo pipefail
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+# repo root when script lives in scripts/
+DIR="${1:?model dir}"
+NAME="${2:-tc-ab-graph}"
+PORT="${PORT:-8003}"
+OUT="${OUT_DIR:-$ROOT/results}"
+mkdir -p "$OUT"
+LOG="$OUT/ab_graph_eager.log"
+L(){ echo "[AB $(date -u +%H:%M:%S)] $*" | tee -a "$LOG"; }
+
+kill_port() {
+  local pids
+  pids=$(ss -lntp 2>/dev/null | awk -v p=":$PORT" '$0 ~ p {print}' | sed -n 's/.*pid=\([0-9]*\).*/\1/p')
+  for pid in $pids; do
+    local pgid; pgid=$(ps -o pgid= -p "$pid" 2>/dev/null | tr -d ' ')
+    [ -n "$pgid" ] && [ "$pgid" != "0" ] && kill -9 -"$pgid" 2>/dev/null || true
+    kill -9 "$pid" 2>/dev/null || true
+  done
+  sleep 2
+  pkill -9 -f 'VLLM::Worker' 2>/dev/null || true
+  sleep 2
+}
+
+wait_health() {
+  local slog=$1 i
+  for i in $(seq 1 90); do
+    if curl -sf -m5 "http://127.0.0.1:${PORT}/v1/models" >/dev/null 2>&1; then return 0; fi
+    if [ -f "$slog" ] && grep -qiE 'RuntimeError|Engine core initialization failed|CUDA out of memory|ValueError:|Traceback \(most recent' "$slog"; then
+      L "FATAL"; tail -40 "$slog" | tee -a "$LOG"; return 1
+    fi
+    sleep 10
+  done
+  return 1
+}
+
+run_arm() {
+  local mode=$1  # graph | eager
+  local slog="$OUT/serve_${mode}.log"
+  local flag=()
+  [ "$mode" = "eager" ] && flag=(--eager)
+  L "=== boot mode=$mode ==="
+  kill_port
+  nohup bash "$ROOT/scripts/sm70_nvfp4_campaign_serve.sh" "$DIR" "$NAME" "${flag[@]}" >"$slog" 2>&1 &
+  if ! wait_health "$slog"; then
+    L "BOOT_FAIL $mode"
+    echo "BOOT_FAIL" > "$OUT/${mode}.result"
+    return 1
+  fi
+  L "healthy — smoke $mode"
+  if python3 "$ROOT/scripts/sm70_nvfp4_smoke_paris.py" --url "http://127.0.0.1:${PORT}" --model "$NAME" --label "$mode" 2>&1 | tee -a "$LOG" | tee "$OUT/${mode}.smoke"; then
+    echo "PASS" > "$OUT/${mode}.result"
+    L "PASS $mode"
+  else
+    echo "FAIL" > "$OUT/${mode}.result"
+    L "FAIL $mode"
+  fi
+  kill_port
+}
+
+: > "$LOG"
+L "model=$DIR served=$NAME"
+# verify overlay if possible
+python3 "$ROOT/scripts/sm70_nvfp4_verify_identity.py" 2>&1 | tee -a "$LOG" || L "verify soft-fail (continue)"
+
+run_arm graph || true
+run_arm eager || true
+
+python3 - <<PY | tee -a "$LOG"
+import pathlib
+out = pathlib.Path("$OUT")
+print("\n# Graph vs eager summary")
+print("| mode | result | notes |")
+print("|------|--------|-------|")
+for mode in ("graph", "eager"):
+    r = (out / f"{mode}.result").read_text().strip() if (out / f"{mode}.result").exists() else "missing"
+    smoke = (out / f"{mode}.smoke").read_text().replace("\n", " ")[:120] if (out / f"{mode}.smoke").exists() else ""
+    print(f"| {mode} | {r} | {smoke} |")
+print("""
+Interpretation:
+- graph PASS + eager PASS → match pve3; JJ should use campaign flags (not wheel)
+- graph FAIL + eager PASS → CUDA-graph path bug / config; use --enforce-eager workaround + file 1Cat issue
+- both FAIL → overlay/checkpoint/env (check normalize hashes, VLLM_SM70_NVFP4_TURBOMIND=1, TINY scales)
+- graph PASS + eager FAIL → unexpected; collect logs
+""")
+PY
+L "=== AB COMPLETE ==="

--- a/scripts/sm70_nvfp4_campaign_serve.sh
+++ b/scripts/sm70_nvfp4_campaign_serve.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# SM70 NVFP4 campaign serve (graph-safe + coherent on TC/Medium TINY-scale quants).
+#
+# Critical flags that fix "garbage under CUDA graphs / OK in eager" on 1.2.2:
+#   --compilation-config full_and_piecewise + capture sizes [1,2,4,8]
+#   --speculative-config ... draft_sample_method=greedy  (with MTP k=4)
+#
+# Also requires: VLLM_SM70_NVFP4_TURBOMIND=1 and scale-normalize (this PR).
+#
+# Usage: sm70_nvfp4_campaign_serve.sh MODEL_DIR SERVED_NAME [--eager]
+#   --eager  adds --enforce-eager (bisect only; not the preferred fix)
+set -euo pipefail
+DIR="${1:?model dir}"
+NAME="${2:?served name}"
+EAGER=0
+if [ "${3:-}" = "--eager" ] || [ "${ENFORCE_EAGER:-0}" = "1" ]; then
+  EAGER=1
+fi
+
+if [ -x /opt/1cat-release-122/.venv/bin/python3 ]; then
+  PY=/opt/1cat-release-122/.venv/bin/python3
+  export PATH=/opt/1cat-release-122/.venv/bin:$PATH
+else
+  PY="${VLLM_PYTHON:-python3}"
+fi
+export CUDA_VISIBLE_DEVICES="${CUDA_VISIBLE_DEVICES:-0,1}"
+export NCCL_P2P_DISABLE=1 NCCL_SHM_DISABLE=0
+export VLLM_WORKER_MULTIPROC_METHOD=spawn
+export PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True
+export VLLM_SM70_FLASH_ATTN_V100=1
+export VLLM_SM70_QUANT_BACKEND=turbomind
+export VLLM_SM70_NVFP4_TURBOMIND=1
+# When max_num_seqs>1, dynamic draft vocab must stay off (1.2.2).
+export VLLM_SM70_MTP_DYNAMIC_DRAFT_VOCAB_DEFAULT="${VLLM_SM70_MTP_DYNAMIC_DRAFT_VOCAB_DEFAULT:-0}"
+
+MTP_K="${MTP_K:-4}"
+SPEC="{\"method\": \"mtp\", \"num_speculative_tokens\": ${MTP_K}, \"attention_backend\": \"FLASH_ATTN_V100\", \"draft_sample_method\": \"greedy\"}"
+COMP='{"cudagraph_mode":"full_and_piecewise","cudagraph_capture_sizes":[1,2,4,8]}'
+
+ARGS=(
+  -m vllm.entrypoints.openai.api_server
+  --model "$DIR"
+  --served-model-name "$NAME" qwen-27b deckard-40b
+  --trust-remote-code
+  --dtype half
+  --attention-backend FLASH_ATTN_V100
+  --host 0.0.0.0 --port "${PORT:-8003}"
+  --tensor-parallel-size "${TP:-2}"
+  --gpu-memory-utilization "${UTIL:-0.85}"
+  --max-model-len "${MAX_LEN:-32768}"
+  --max-num-seqs "${MAX_SEQS:-1}"
+  --max-num-batched-tokens 8192
+  --kv-cache-dtype fp8_e5m2
+  --speculative-config "$SPEC"
+  --compilation-config "$COMP"
+  --enable-auto-tool-choice
+  --tool-call-parser qwen3_coder
+  --reasoning-parser qwen3
+  --default-chat-template-kwargs '{"enable_thinking": true, "preserve_thinking": true}'
+)
+if [ "$EAGER" = "1" ]; then
+  ARGS+=(--enforce-eager)
+  echo "[serve] ENFORCE_EAGER=1 (no CUDA graphs) — bisect only"
+else
+  echo "[serve] CUDA graphs: full_and_piecewise sizes=[1,2,4,8]; MTP k=${MTP_K} draft=greedy"
+fi
+
+exec "$PY" "${ARGS[@]}"

--- a/scripts/sm70_nvfp4_smoke_paris.py
+++ b/scripts/sm70_nvfp4_smoke_paris.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""Paris smoke + short coherent gen. Exit 0=ok, 2=salad/fail."""
+import argparse, json, re, sys, urllib.request
+
+def post(url, payload, timeout=180):
+    req = urllib.request.Request(
+        url,
+        data=json.dumps(payload).encode(),
+        headers={"Content-Type": "application/json"},
+    )
+    return json.load(urllib.request.urlopen(req, timeout=timeout))
+
+def text_of(r):
+    m = r["choices"][0]["message"]
+    return ((m.get("content") or "") + (m.get("reasoning_content") or "")).strip()
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--url", default="http://127.0.0.1:8003")
+    ap.add_argument("--model", required=True)
+    ap.add_argument("--label", default="")
+    args = ap.parse_args()
+    base = args.url.rstrip("/")
+    api = base + "/v1/chat/completions"
+
+    # 1) Paris
+    r = post(api, {
+        "model": args.model,
+        "messages": [{"role": "user", "content": "What is the capital of France? Answer in one word."}],
+        "max_tokens": 2048,
+        "temperature": 0,
+    })
+    t = text_of(r)
+    paris = "paris" in t.lower()
+    print(f"[{args.label}] paris={'OK' if paris else 'FAIL'} sample={t[:200]!r}")
+
+    # 2) short math (catches scale salad / !!!! )
+    r2 = post(api, {
+        "model": args.model,
+        "messages": [{"role": "user", "content": "What is 17*19? Reply with just the number."}],
+        "max_tokens": 1024,
+        "temperature": 0,
+    })
+    t2 = text_of(r2)
+    has_323 = bool(re.search(r"\b323\b", t2))
+    salad = bool(re.search(r"!{4,}|[\uFFFD]{2,}|asdfs|lorem", t2, re.I)) or (len(t2) > 20 and not re.search(r"\d", t2))
+    print(f"[{args.label}] math323={'OK' if has_323 else 'FAIL'} salad={'YES' if salad else 'no'} sample={t2[:200]!r}")
+
+    ok = paris and has_323 and not salad
+    print(f"[{args.label}] RESULT={'PASS' if ok else 'FAIL'}")
+    sys.exit(0 if ok else 2)
+
+if __name__ == "__main__":
+    main()

--- a/scripts/sm70_nvfp4_verify_identity.py
+++ b/scripts/sm70_nvfp4_verify_identity.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""Verify public 1.2.2 _C hash + presence of NVFP4 scale normalize helpers."""
+from __future__ import annotations
+
+import hashlib
+import importlib.metadata as m
+import pathlib
+import sys
+
+WANT_C = "ffc6271aaf25d96fe690d0f899544801cc1e39486905c49ad0090cb2cbe7a147"
+WANT_WHEEL = "8a628983ad9d675559910372643220c418b307ddc7fd52ac65a7f5fbcb104bc6"
+
+
+def main() -> int:
+    try:
+        ver = m.version("1cat-vllm")
+    except Exception:
+        ver = None
+    print(f"1cat-vllm version: {ver}")
+    if ver and ver != "1.2.2":
+        print("WARN: documented wheel hashes are for 1.2.2; re-check for other releases")
+
+    import vllm
+
+    base = pathlib.Path(vllm.__file__).parent
+    c = base / "_C.abi3.so"
+    if not c.exists():
+        print(f"MISSING {c}")
+        return 2
+    h = hashlib.sha256(c.read_bytes()).hexdigest()
+    print(f"_C.abi3.so: {h}")
+    print(f"  match_public_1.2.2: {h == WANT_C}")
+    print(f"  expected_wheel_sha256: {WANT_WHEEL}")
+
+    paths = [
+        base / "model_executor/layers/quantization/sm70_turbomind.py",
+        base
+        / "model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_w4a16_nvfp4.py",
+        base
+        / "model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_w4a4_nvfp4.py",
+    ]
+    ok = h == WANT_C
+    for p in paths:
+        if not p.exists():
+            print(f"MISSING {p}")
+            ok = False
+            continue
+        text = p.read_text(errors="replace")
+        has = "normalize_nvfp4_global_scale_for_sm70" in text or "normalize_nvfp4_global" in text
+        print(f"{p.name}: normalize_helper={has} sha256={hashlib.sha256(p.read_bytes()).hexdigest()[:16]}...")
+        if not has:
+            ok = False
+    print("PASS" if ok else "FAIL")
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/quantization/test_sm70_nvfp4_moe_fallback.py
+++ b/tests/quantization/test_sm70_nvfp4_moe_fallback.py
@@ -1,0 +1,356 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""SM70 NVFP4 MoE fallback + W4A4 weight-only routing unit tests.
+
+Drives real selection helpers (oracle reorder / prefer flag) and prepare
+hooks — not reimplementations.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+import torch
+from torch.nn.parameter import Parameter
+
+
+def test_sm70_compat_backend_order_puts_marlin_emulation_first():
+    from vllm.model_executor.layers.fused_moe.oracle.nvfp4 import (
+        NvFp4MoeBackend,
+        sm70_compat_nvfp4_moe_backend_order,
+    )
+
+    original = [
+        NvFp4MoeBackend.FLASHINFER_TRTLLM,
+        NvFp4MoeBackend.FLASHINFER_CUTLASS,
+        NvFp4MoeBackend.VLLM_CUTLASS,
+        NvFp4MoeBackend.MARLIN,
+        NvFp4MoeBackend.EMULATION,
+    ]
+    ordered = sm70_compat_nvfp4_moe_backend_order(original)
+    assert ordered[0] is NvFp4MoeBackend.MARLIN
+    assert ordered[1] is NvFp4MoeBackend.EMULATION
+    assert set(ordered) == set(original)
+    # Relative order of non-compat backends preserved.
+    assert ordered[2:] == [
+        NvFp4MoeBackend.FLASHINFER_TRTLLM,
+        NvFp4MoeBackend.FLASHINFER_CUTLASS,
+        NvFp4MoeBackend.VLLM_CUTLASS,
+    ]
+
+
+def test_prefer_sm70_nvfp4_moe_fallback_env_override(monkeypatch):
+    from vllm.model_executor.layers.fused_moe.oracle import nvfp4 as oracle
+
+    monkeypatch.setenv("VLLM_SM70_NVFP4_MOE_FALLBACK", "1")
+    assert oracle.prefer_sm70_nvfp4_moe_fallback() is True
+
+    monkeypatch.setenv("VLLM_SM70_NVFP4_MOE_FALLBACK", "0")
+    assert oracle.prefer_sm70_nvfp4_moe_fallback() is False
+
+
+def test_prefer_sm70_detects_volta_from_platform(monkeypatch):
+    from vllm.model_executor.layers.fused_moe.oracle import nvfp4 as oracle
+
+    monkeypatch.delenv("VLLM_SM70_NVFP4_MOE_FALLBACK", raising=False)
+
+    class _SM70:
+        def is_cuda(self):
+            return True
+
+        def has_device_capability(self, cap):
+            return cap == 70
+
+    class _SM80:
+        def is_cuda(self):
+            return True
+
+        def has_device_capability(self, cap):
+            return cap in (70, 75, 80)
+
+    with patch(
+        "vllm.platforms.current_platform",
+        _SM70(),
+    ):
+        # prefer imports current_platform inside the function
+        with patch.object(
+            oracle,
+            "prefer_sm70_nvfp4_moe_fallback",
+            wraps=oracle.prefer_sm70_nvfp4_moe_fallback,
+        ):
+            pass
+
+    # Call with patched platforms module used by the helper
+    import vllm.platforms as platforms_mod
+
+    monkeypatch.setattr(platforms_mod, "current_platform", _SM70())
+    # Re-import path: helper does `from vllm.platforms import current_platform`
+    # so patch the attribute on the platforms package.
+    assert oracle.prefer_sm70_nvfp4_moe_fallback() is True
+
+    monkeypatch.setattr(platforms_mod, "current_platform", _SM80())
+    assert oracle.prefer_sm70_nvfp4_moe_fallback() is False
+
+
+def _minimal_moe_config(moe_backend: str = "auto"):
+    """Build a lightweight FusedMoEConfig-like object for oracle selection."""
+    from vllm.model_executor.layers.fused_moe.activation import MoEActivation
+    from vllm.model_executor.layers.fused_moe.config import (
+        FusedMoEConfig,
+        FusedMoEParallelConfig,
+    )
+
+    # Prefer constructing a real config when possible; fall back to MagicMock
+    # with the fields the oracle reads.
+    try:
+        # Parallel config with non-batched format.
+        pc = MagicMock(spec=FusedMoEParallelConfig)
+        pc.use_batched_activation_format = False
+        pc.use_fi_nvl_two_sided_kernels = False
+        pc.use_fi_nvl_one_sided_kernels = False
+        cfg = MagicMock(spec=FusedMoEConfig)
+        cfg.swiglu_limit = None
+        cfg.moe_backend = moe_backend
+        cfg.moe_parallel_config = pc
+        cfg.is_act_and_mul = True
+        cfg.activation = MoEActivation.SILU
+        cfg.routing_method = None
+        cfg.router_logits_dtype = None
+        cfg.hidden_dim = 128
+        cfg.is_lora_enabled = False
+        return cfg
+    except Exception:
+        cfg = MagicMock()
+        cfg.swiglu_limit = None
+        cfg.moe_backend = moe_backend
+        cfg.moe_parallel_config.use_batched_activation_format = False
+        return cfg
+
+
+def test_select_nvfp4_moe_backend_sm70_auto_picks_marlin(monkeypatch):
+    """On SM70 fallback, auto-select must land on Marlin (weight-only)."""
+    from vllm.model_executor.layers.fused_moe.experts.marlin_moe import MarlinExperts
+    from vllm.model_executor.layers.fused_moe.oracle.nvfp4 import (
+        NvFp4MoeBackend,
+        select_nvfp4_moe_backend,
+    )
+    from vllm.model_executor.layers.quantization.utils.quant_utils import (
+        kNvfp4Dynamic,
+        kNvfp4Static,
+    )
+
+    monkeypatch.setenv("VLLM_SM70_NVFP4_MOE_FALLBACK", "1")
+    # Avoid FlashInfer env forcing a different branch.
+    monkeypatch.delenv("VLLM_USE_FLASHINFER_MOE_FP4", raising=False)
+    monkeypatch.delenv("VLLM_TEST_FORCE_FP8_MARLIN", raising=False)
+
+    # Make only Marlin (and optionally Emulation) report support so we
+    # exercise the real is_supported_config path for Marlin.
+    def _supported(cls, moe_config, weight_key, activation_key, activation_format):
+        name = getattr(cls, "__name__", str(cls))
+        if name == "MarlinExperts":
+            return True, None
+        if name == "Nvfp4QuantizationEmulationTritonExperts":
+            # Only for W4A4 scheme
+            if (weight_key, activation_key) == (kNvfp4Static, kNvfp4Dynamic):
+                return True, None
+            return False, "scheme"
+        return False, f"mocked-unsupported:{name}"
+
+    monkeypatch.setattr(
+        "vllm.model_executor.layers.fused_moe.modular_kernel.FusedMoEExperts."
+        "is_supported_config",
+        staticmethod(_supported),
+    )
+    # Also patch on MarlinExperts if it overrides (it doesn't — uses base).
+
+    cfg = _minimal_moe_config("auto")
+    backend, experts_cls = select_nvfp4_moe_backend(
+        config=cfg,
+        weight_key=kNvfp4Static,
+        activation_key=kNvfp4Dynamic,
+    )
+    assert backend is NvFp4MoeBackend.MARLIN
+    assert experts_cls is MarlinExperts
+
+
+def test_select_nvfp4_moe_backend_sm70_w4a16_still_marlin(monkeypatch):
+    """W4A16 (activation_key=None): Emulation rejects scheme; Marlin wins."""
+    from vllm.model_executor.layers.fused_moe.experts.marlin_moe import MarlinExperts
+    from vllm.model_executor.layers.fused_moe.oracle.nvfp4 import (
+        NvFp4MoeBackend,
+        select_nvfp4_moe_backend,
+    )
+    from vllm.model_executor.layers.quantization.utils.quant_utils import kNvfp4Static
+
+    monkeypatch.setenv("VLLM_SM70_NVFP4_MOE_FALLBACK", "1")
+    monkeypatch.delenv("VLLM_USE_FLASHINFER_MOE_FP4", raising=False)
+    monkeypatch.delenv("VLLM_TEST_FORCE_FP8_MARLIN", raising=False)
+
+    def _supported(cls, moe_config, weight_key, activation_key, activation_format):
+        name = getattr(cls, "__name__", str(cls))
+        if name == "MarlinExperts":
+            return True, None
+        return False, f"mocked-unsupported:{name}"
+
+    monkeypatch.setattr(
+        "vllm.model_executor.layers.fused_moe.modular_kernel.FusedMoEExperts."
+        "is_supported_config",
+        staticmethod(_supported),
+    )
+
+    cfg = _minimal_moe_config("auto")
+    backend, experts_cls = select_nvfp4_moe_backend(
+        config=cfg,
+        weight_key=kNvfp4Static,
+        activation_key=None,
+    )
+    assert backend is NvFp4MoeBackend.MARLIN
+    assert experts_cls is MarlinExperts
+
+
+def test_select_falls_through_to_emulation_when_marlin_unsupported(monkeypatch):
+    from vllm.model_executor.layers.fused_moe.experts.nvfp4_emulation_moe import (
+        Nvfp4QuantizationEmulationTritonExperts,
+    )
+    from vllm.model_executor.layers.fused_moe.oracle.nvfp4 import (
+        NvFp4MoeBackend,
+        select_nvfp4_moe_backend,
+    )
+    from vllm.model_executor.layers.quantization.utils.quant_utils import (
+        kNvfp4Dynamic,
+        kNvfp4Static,
+    )
+
+    monkeypatch.setenv("VLLM_SM70_NVFP4_MOE_FALLBACK", "1")
+    monkeypatch.delenv("VLLM_USE_FLASHINFER_MOE_FP4", raising=False)
+    monkeypatch.delenv("VLLM_TEST_FORCE_FP8_MARLIN", raising=False)
+
+    def _supported(cls, moe_config, weight_key, activation_key, activation_format):
+        name = getattr(cls, "__name__", str(cls))
+        if name == "Nvfp4QuantizationEmulationTritonExperts":
+            return True, None
+        return False, f"mocked-unsupported:{name}"
+
+    monkeypatch.setattr(
+        "vllm.model_executor.layers.fused_moe.modular_kernel.FusedMoEExperts."
+        "is_supported_config",
+        staticmethod(_supported),
+    )
+
+    cfg = _minimal_moe_config("auto")
+    backend, experts_cls = select_nvfp4_moe_backend(
+        config=cfg,
+        weight_key=kNvfp4Static,
+        activation_key=kNvfp4Dynamic,
+    )
+    assert backend is NvFp4MoeBackend.EMULATION
+    assert experts_cls is Nvfp4QuantizationEmulationTritonExperts
+
+
+def test_ct_w4a4_prepare_routes_through_sm70_try_prepare(monkeypatch):
+    """CT W4A4 process_weights must call try_prepare_sm70_nvfp4_linear."""
+    from vllm.model_executor.layers.quantization.compressed_tensors.schemes.compressed_tensors_w4a4_nvfp4 import (  # noqa: E501
+        CompressedTensorsW4A4Fp4,
+    )
+    from vllm.model_executor.layers.quantization import sm70_turbomind as sm70_tm
+
+    layer = torch.nn.Module()
+    layer.weight_packed = Parameter(
+        torch.zeros((4, 2), dtype=torch.uint8), requires_grad=False
+    )
+    layer.weight_global_scale = Parameter(
+        torch.ones(1, dtype=torch.float32), requires_grad=False
+    )
+    layer.weight_scale = Parameter(
+        torch.ones((4, 1), dtype=torch.float8_e4m3fn), requires_grad=False
+    )
+    layer.input_global_scale = Parameter(
+        torch.ones(1, dtype=torch.float32), requires_grad=False
+    )
+
+    called = {"prepare": False}
+
+    def fake_prepare(prepared: torch.nn.Module) -> bool:
+        called["prepare"] = True
+        return True
+
+    monkeypatch.setattr(sm70_tm, "try_prepare_sm70_nvfp4_linear", fake_prepare)
+    # Avoid init_nvfp4_linear_kernel in scheme __init__ when TM is on.
+    monkeypatch.setattr(
+        sm70_tm, "use_turbomind", lambda default_enabled: True
+    )
+
+    scheme = CompressedTensorsW4A4Fp4()
+    scheme.process_weights_after_loading(layer)
+    assert called["prepare"] is True
+
+
+def test_modelopt_w4a4_prepare_routes_through_sm70_try_prepare(monkeypatch):
+    """ModelOpt W4A4 linear must use the shared SM70 prepare path."""
+    from vllm.model_executor.layers.quantization import sm70_turbomind as sm70_tm
+    from vllm.model_executor.layers.quantization.modelopt import (
+        ModelOptNvFp4Config,
+        ModelOptNvFp4LinearMethod,
+    )
+
+    config = ModelOptNvFp4Config(
+        quant_method="NVFP4",
+        is_checkpoint_nvfp4_serialized=True,
+        kv_cache_quant_algo=None,
+        exclude_modules=[],
+        group_size=16,
+    )
+
+    # Avoid heavy kernel init; pin a stub.
+    class _StubKernel:
+        def process_weights_after_loading(self, layer):
+            raise AssertionError("should not fall through to kernel on SM70 hit")
+
+        def apply_weights(self, layer, x, bias=None):
+            raise AssertionError("should not fall through")
+
+    monkeypatch.setattr(
+        "vllm.model_executor.layers.quantization.modelopt.init_nvfp4_linear_kernel",
+        lambda: _StubKernel(),
+    )
+
+    method = ModelOptNvFp4LinearMethod(config)
+    method.kernel = _StubKernel()
+
+    layer = torch.nn.Module()
+    layer.weight = Parameter(torch.zeros((4, 2), dtype=torch.uint8), requires_grad=False)
+    layer.weight_scale = Parameter(
+        torch.ones((4, 1), dtype=torch.float8_e4m3fn), requires_grad=False
+    )
+    layer.weight_scale_2 = Parameter(
+        torch.ones(1, dtype=torch.float32), requires_grad=False
+    )
+    layer.input_scale = Parameter(
+        torch.ones(1, dtype=torch.float32), requires_grad=False
+    )
+
+    called = {"prepare": False}
+
+    def fake_prepare(prepared: torch.nn.Module) -> bool:
+        called["prepare"] = True
+        return True
+
+    monkeypatch.setattr(sm70_tm, "try_prepare_sm70_nvfp4_linear", fake_prepare)
+
+    method.process_weights_after_loading(layer)
+    assert called["prepare"] is True
+    assert hasattr(layer, "weight_global_scale")
+
+    # apply path
+    applied = {"hit": False}
+
+    def fake_apply(layer, x, bias=None):
+        applied["hit"] = True
+        return torch.zeros((*x.shape[:-1], 4), dtype=x.dtype)
+
+    monkeypatch.setattr(sm70_tm, "try_apply_sm70_nvfp4_linear", fake_apply)
+    out = method.apply(layer, torch.ones((1, 4), dtype=torch.float16), None)
+    assert applied["hit"] is True
+    assert out.shape == (1, 4)

--- a/tests/quantization/test_sm70_nvfp4_scale_convention.py
+++ b/tests/quantization/test_sm70_nvfp4_scale_convention.py
@@ -26,79 +26,69 @@ def test_tiny_block_scales_detected():
 
     tiny = _layer(
         torch.tensor([[0.0037, 0.01]], dtype=torch.float32),
-        torch.tensor([1.0 / 6048.0], dtype=torch.float32),
+        torch.tensor([6048.0], dtype=torch.float32),
     )
     big = _layer(
         torch.tensor([[22.0, 40.0]], dtype=torch.float32),
-        torch.tensor([1.0 / 6048.0], dtype=torch.float32),
+        torch.tensor([6048.0], dtype=torch.float32),
     )
     assert tm.nvfp4_block_scales_are_tiny(tiny) is True
     assert tm.nvfp4_block_scales_are_tiny(big) is False
 
 
-def test_combine_skips_global_for_tiny_block_scales():
-    """Medium convention: effective scale ≈ block (not block/G)."""
+def test_normalize_sets_global_one_for_tiny_blocks_leaves_scale():
+    """Claude/g1-fix: set global=1.0, never weight_scale *= global (fp8 overflow)."""
     from vllm.model_executor.layers.quantization import sm70_turbomind as tm
 
-    # After CT reciprocal: global is already 1/disk_global.
-    g_inv = torch.tensor([1.0 / 6048.0], dtype=torch.float32)
-    tiny_block = torch.tensor([[0.0037, 0.0040]], dtype=torch.float32)
-    layer = _layer(tiny_block, g_inv)
-
-    combined = tm.combine_nvfp4_scales_for_sm70_tm(layer)
-    # weight_scale is transposed in combine; input was [1, 2] -> t -> [2, 1]
-    assert combined.dtype == torch.float16
-    # Must NOT be tiny_block * g_inv (~6e-7)
-    expected = tiny_block.t().to(torch.float16)
-    assert torch.allclose(combined.float(), expected.float(), rtol=1e-3, atol=1e-5)
-    assert float(combined.abs().max()) > 1e-3
+    block = torch.tensor([[0.078125, 0.01]], dtype=torch.float32)
+    layer = _layer(block.clone(), torch.tensor([6048.0], dtype=torch.float32))
+    tm.normalize_nvfp4_global_scale_for_sm70(layer)
+    assert abs(float(layer.weight_global_scale.item()) - 1.0) < 1e-6
+    # block scales untouched
+    assert torch.equal(layer.weight_scale.data, block)
 
 
-def test_combine_multiplies_global_for_aggressive_block_scales():
-    """Aggressive convention: effective = block * (1/disk_global)."""
+def test_normalize_reciprocates_global_for_aggressive_blocks():
     from vllm.model_executor.layers.quantization import sm70_turbomind as tm
 
-    g_inv = torch.tensor([1.0 / 6048.0], dtype=torch.float32)
-    big_block = torch.tensor([[22.0, 40.0]], dtype=torch.float32)
-    layer = _layer(big_block, g_inv)
-
-    combined = tm.combine_nvfp4_scales_for_sm70_tm(layer)
-    expected = (big_block.t().float() * g_inv).to(torch.float16)
-    assert torch.allclose(combined.float(), expected.float(), rtol=1e-3, atol=1e-6)
-    # Same order of magnitude as Medium's tiny block scales (~0.003–0.007)
-    assert 1e-4 < float(combined.abs().mean()) < 0.1
+    layer = _layer(
+        torch.tensor([[22.0, 40.0]], dtype=torch.float32),
+        torch.tensor([6048.0], dtype=torch.float32),
+    )
+    tm.normalize_nvfp4_global_scale_for_sm70(layer)
+    assert abs(float(layer.weight_global_scale.item()) - (1.0 / 6048.0)) < 1e-9
 
 
-def test_medium_and_aggressive_effective_scales_align():
-    """Sanity: after combine, both conventions land near the same magnitude."""
+def test_combine_after_normalize_aligns_conventions():
+    """After normalize, both conventions land near the same TM effective scale."""
     from vllm.model_executor.layers.quantization import sm70_turbomind as tm
 
-    g_inv = torch.tensor([1.0 / 6048.0], dtype=torch.float32)
-    # Field measurement: aggressive ≈ medium_disk_block * disk_global
-    # After CT: med uses tiny blocks; agg uses large blocks * g_inv.
-    med = _layer(torch.full((4, 8), 0.0037), g_inv)
-    agg = _layer(torch.full((4, 8), 22.0), g_inv)
+    med = _layer(torch.full((4, 8), 0.0037), torch.tensor([6048.0]))
+    agg = _layer(torch.full((4, 8), 22.0), torch.tensor([6048.0]))
+    tm.normalize_nvfp4_global_scale_for_sm70(med)
+    tm.normalize_nvfp4_global_scale_for_sm70(agg)
     c_med = tm.combine_nvfp4_scales_for_sm70_tm(med).float().mean().item()
     c_agg = tm.combine_nvfp4_scales_for_sm70_tm(agg).float().mean().item()
-    # Within ~20% (fp8 quantization noise on real weights is larger)
     ratio = c_med / c_agg
     assert 0.5 < ratio < 2.0, (c_med, c_agg, ratio)
 
 
-def test_dequant_global_is_one_for_tiny_blocks():
+def test_combine_safety_net_if_caller_skipped_normalize():
+    """If global is still 1/disk (tiny) with tiny blocks, skip multiply."""
+    from vllm.model_executor.layers.quantization import sm70_turbomind as tm
+
+    g_inv = torch.tensor([1.0 / 6048.0], dtype=torch.float32)
+    tiny_block = torch.tensor([[0.0037, 0.0040]], dtype=torch.float32)
+    layer = _layer(tiny_block, g_inv)
+    combined = tm.combine_nvfp4_scales_for_sm70_tm(layer)
+    expected = tiny_block.t().to(torch.float16)
+    assert torch.allclose(combined.float(), expected.float(), rtol=1e-3, atol=1e-5)
+
+
+def test_dequant_global_is_one_when_unnormalized_tiny():
     from vllm.model_executor.layers.quantization import sm70_turbomind as tm
 
     g_inv = torch.tensor([1.0 / 6048.0], dtype=torch.float32)
     layer = _layer(torch.tensor([[0.01]], dtype=torch.float32), g_inv)
     g = tm.resolve_nvfp4_global_for_dequant(layer)
-    assert g.numel() == 1
     assert abs(float(g.item()) - 1.0) < 1e-6
-
-
-def test_dequant_global_preserved_for_large_blocks():
-    from vllm.model_executor.layers.quantization import sm70_turbomind as tm
-
-    g_inv = torch.tensor([1.0 / 6048.0], dtype=torch.float32)
-    layer = _layer(torch.tensor([[22.0]], dtype=torch.float32), g_inv)
-    g = tm.resolve_nvfp4_global_for_dequant(layer)
-    assert abs(float(g.item()) - float(g_inv.item())) < 1e-9

--- a/tests/quantization/test_sm70_nvfp4_scale_convention.py
+++ b/tests/quantization/test_sm70_nvfp4_scale_convention.py
@@ -1,0 +1,104 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""SM70 NVFP4 block/global scale convention (Aggressive vs Medium GPTQ).
+
+Aggressive CT exports use large FP8 block scales and a large disk global
+(CT then stores global as 1/disk). Medium/TC GPTQ leaves tiny block scales;
+multiplying by inverted global underflows. These tests drive the real
+combine helpers.
+"""
+
+from __future__ import annotations
+
+import torch
+from torch.nn.parameter import Parameter
+
+
+def _layer(block: torch.Tensor, global_scale: torch.Tensor) -> torch.nn.Module:
+    layer = torch.nn.Module()
+    layer.weight_scale = Parameter(block, requires_grad=False)
+    layer.weight_global_scale = Parameter(global_scale, requires_grad=False)
+    return layer
+
+
+def test_tiny_block_scales_detected():
+    from vllm.model_executor.layers.quantization import sm70_turbomind as tm
+
+    tiny = _layer(
+        torch.tensor([[0.0037, 0.01]], dtype=torch.float32),
+        torch.tensor([1.0 / 6048.0], dtype=torch.float32),
+    )
+    big = _layer(
+        torch.tensor([[22.0, 40.0]], dtype=torch.float32),
+        torch.tensor([1.0 / 6048.0], dtype=torch.float32),
+    )
+    assert tm.nvfp4_block_scales_are_tiny(tiny) is True
+    assert tm.nvfp4_block_scales_are_tiny(big) is False
+
+
+def test_combine_skips_global_for_tiny_block_scales():
+    """Medium convention: effective scale ≈ block (not block/G)."""
+    from vllm.model_executor.layers.quantization import sm70_turbomind as tm
+
+    # After CT reciprocal: global is already 1/disk_global.
+    g_inv = torch.tensor([1.0 / 6048.0], dtype=torch.float32)
+    tiny_block = torch.tensor([[0.0037, 0.0040]], dtype=torch.float32)
+    layer = _layer(tiny_block, g_inv)
+
+    combined = tm.combine_nvfp4_scales_for_sm70_tm(layer)
+    # weight_scale is transposed in combine; input was [1, 2] -> t -> [2, 1]
+    assert combined.dtype == torch.float16
+    # Must NOT be tiny_block * g_inv (~6e-7)
+    expected = tiny_block.t().to(torch.float16)
+    assert torch.allclose(combined.float(), expected.float(), rtol=1e-3, atol=1e-5)
+    assert float(combined.abs().max()) > 1e-3
+
+
+def test_combine_multiplies_global_for_aggressive_block_scales():
+    """Aggressive convention: effective = block * (1/disk_global)."""
+    from vllm.model_executor.layers.quantization import sm70_turbomind as tm
+
+    g_inv = torch.tensor([1.0 / 6048.0], dtype=torch.float32)
+    big_block = torch.tensor([[22.0, 40.0]], dtype=torch.float32)
+    layer = _layer(big_block, g_inv)
+
+    combined = tm.combine_nvfp4_scales_for_sm70_tm(layer)
+    expected = (big_block.t().float() * g_inv).to(torch.float16)
+    assert torch.allclose(combined.float(), expected.float(), rtol=1e-3, atol=1e-6)
+    # Same order of magnitude as Medium's tiny block scales (~0.003–0.007)
+    assert 1e-4 < float(combined.abs().mean()) < 0.1
+
+
+def test_medium_and_aggressive_effective_scales_align():
+    """Sanity: after combine, both conventions land near the same magnitude."""
+    from vllm.model_executor.layers.quantization import sm70_turbomind as tm
+
+    g_inv = torch.tensor([1.0 / 6048.0], dtype=torch.float32)
+    # Field measurement: aggressive ≈ medium_disk_block * disk_global
+    # After CT: med uses tiny blocks; agg uses large blocks * g_inv.
+    med = _layer(torch.full((4, 8), 0.0037), g_inv)
+    agg = _layer(torch.full((4, 8), 22.0), g_inv)
+    c_med = tm.combine_nvfp4_scales_for_sm70_tm(med).float().mean().item()
+    c_agg = tm.combine_nvfp4_scales_for_sm70_tm(agg).float().mean().item()
+    # Within ~20% (fp8 quantization noise on real weights is larger)
+    ratio = c_med / c_agg
+    assert 0.5 < ratio < 2.0, (c_med, c_agg, ratio)
+
+
+def test_dequant_global_is_one_for_tiny_blocks():
+    from vllm.model_executor.layers.quantization import sm70_turbomind as tm
+
+    g_inv = torch.tensor([1.0 / 6048.0], dtype=torch.float32)
+    layer = _layer(torch.tensor([[0.01]], dtype=torch.float32), g_inv)
+    g = tm.resolve_nvfp4_global_for_dequant(layer)
+    assert g.numel() == 1
+    assert abs(float(g.item()) - 1.0) < 1e-6
+
+
+def test_dequant_global_preserved_for_large_blocks():
+    from vllm.model_executor.layers.quantization import sm70_turbomind as tm
+
+    g_inv = torch.tensor([1.0 / 6048.0], dtype=torch.float32)
+    layer = _layer(torch.tensor([[22.0]], dtype=torch.float32), g_inv)
+    g = tm.resolve_nvfp4_global_for_dequant(layer)
+    assert abs(float(g.item()) - float(g_inv.item())) < 1e-9

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -192,7 +192,7 @@ if TYPE_CHECKING:
     VLLM_SM70_FP8_TURBOMIND: bool = True
     VLLM_SM70_FP8_DENSE_GATED_SILU: bool = True
     VLLM_SM70_NVFP4_TURBOMIND: bool = True
-    VLLM_SM70_NVFP4_LINEAR_ATTN: Literal["auto", "tm", "dequant"] = "auto"
+    VLLM_SM70_NVFP4_LINEAR_ATTN: Literal["auto", "tm", "dequant"] = "tm"
     VLLM_SM70_MXFP4_TURBOMIND: bool = True
     VLLM_SM70_FP8_MOE_DEQUANT_FALLBACK: bool = False
     VLLM_SM70_FP8_MOE_BATCHED_GEMM: bool = True
@@ -788,20 +788,65 @@ SM70_NVFP4_LINEAR_ATTN_MODES = ("auto", "tm", "dequant")
 SM70Nvfp4LinearAttnMode = Literal["auto", "tm", "dequant"]
 
 
+def _checkpoint_sm70_linear_attn_mode() -> SM70Nvfp4LinearAttnMode | None:
+    """Read optional ``quantization_config.sm70_linear_attn`` from the HF config.
+
+    Stamped at quant/validate time so fragile checkpoints self-declare
+    ``"dequant"`` without requiring operators to set an env var.
+    """
+    try:
+        from vllm.config import get_current_vllm_config
+
+        vllm_config = get_current_vllm_config()
+        model_config = vllm_config.model_config
+        candidates: list[object] = []
+        hf = getattr(model_config, "hf_config", None)
+        if hf is not None:
+            candidates.append(getattr(hf, "quantization_config", None))
+        arch = getattr(model_config, "model_arch_config", None)
+        if arch is not None:
+            candidates.append(getattr(arch, "quantization_config", None))
+        for qc in candidates:
+            if not isinstance(qc, dict):
+                continue
+            raw = qc.get("sm70_linear_attn") or qc.get("sm70_nvfp4_linear_attn")
+            if raw is None:
+                continue
+            value = str(raw).strip().lower()
+            if value in SM70_NVFP4_LINEAR_ATTN_MODES:
+                return cast(SM70Nvfp4LinearAttnMode, value)
+    except Exception:
+        return None
+    return None
+
+
 def get_sm70_nvfp4_linear_attn_mode() -> SM70Nvfp4LinearAttnMode:
     """Policy for hybrid GDN ``linear_attn`` NVFP4 linears on SM70.
 
-    auto: TurboMind when scale-health passes, else load-time dequant
-    tm: always TurboMind for hybrid candidates
-    dequant: always dequant hybrid candidates (safe for fragile bases)
+    Resolution order:
+      1. Explicit env ``VLLM_SM70_NVFP4_LINEAR_ATTN`` (override)
+      2. Checkpoint stamp ``quantization_config.sm70_linear_attn``
+      3. Default ``tm`` (speed; Aggressive-proven hybrid-on-TM)
+
+    Modes:
+      tm: always TurboMind for hybrid candidates (default)
+      dequant: always load-time dequant → half GEMM (fragile bases)
+      auto: experimental scale-health heuristic (not a quality oracle;
+            prefer stamping the checkpoint over relying on auto)
     """
-    value = os.getenv("VLLM_SM70_NVFP4_LINEAR_ATTN", "auto").strip().lower()
-    if value not in SM70_NVFP4_LINEAR_ATTN_MODES:
-        raise ValueError(
-            "VLLM_SM70_NVFP4_LINEAR_ATTN must be one of auto, tm, dequant; "
-            f"got {value!r}."
-        )
-    return cast(SM70Nvfp4LinearAttnMode, value)
+    if "VLLM_SM70_NVFP4_LINEAR_ATTN" in os.environ:
+        value = os.environ["VLLM_SM70_NVFP4_LINEAR_ATTN"].strip().lower()
+        if value not in SM70_NVFP4_LINEAR_ATTN_MODES:
+            raise ValueError(
+                "VLLM_SM70_NVFP4_LINEAR_ATTN must be one of auto, tm, dequant; "
+                f"got {value!r}."
+            )
+        return cast(SM70Nvfp4LinearAttnMode, value)
+
+    stamped = _checkpoint_sm70_linear_attn_mode()
+    if stamped is not None:
+        return stamped
+    return "tm"
 
 
 def env_list_with_choices(

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -192,6 +192,7 @@ if TYPE_CHECKING:
     VLLM_SM70_FP8_TURBOMIND: bool = True
     VLLM_SM70_FP8_DENSE_GATED_SILU: bool = True
     VLLM_SM70_NVFP4_TURBOMIND: bool = True
+    VLLM_SM70_NVFP4_LINEAR_ATTN: Literal["auto", "tm", "dequant"] = "auto"
     VLLM_SM70_MXFP4_TURBOMIND: bool = True
     VLLM_SM70_FP8_MOE_DEQUANT_FALLBACK: bool = False
     VLLM_SM70_FP8_MOE_BATCHED_GEMM: bool = True
@@ -781,6 +782,26 @@ def use_sm70_turbomind(default_enabled: bool) -> bool:
 
 def force_sm70_marlin() -> bool:
     return get_sm70_quant_backend() == "marlin"
+
+
+SM70_NVFP4_LINEAR_ATTN_MODES = ("auto", "tm", "dequant")
+SM70Nvfp4LinearAttnMode = Literal["auto", "tm", "dequant"]
+
+
+def get_sm70_nvfp4_linear_attn_mode() -> SM70Nvfp4LinearAttnMode:
+    """Policy for hybrid GDN ``linear_attn`` NVFP4 linears on SM70.
+
+    auto: TurboMind when scale-health passes, else load-time dequant
+    tm: always TurboMind for hybrid candidates
+    dequant: always dequant hybrid candidates (safe for fragile bases)
+    """
+    value = os.getenv("VLLM_SM70_NVFP4_LINEAR_ATTN", "auto").strip().lower()
+    if value not in SM70_NVFP4_LINEAR_ATTN_MODES:
+        raise ValueError(
+            "VLLM_SM70_NVFP4_LINEAR_ATTN must be one of auto, tm, dequant; "
+            f"got {value!r}."
+        )
+    return cast(SM70Nvfp4LinearAttnMode, value)
 
 
 def env_list_with_choices(

--- a/vllm/model_executor/layers/fused_moe/oracle/nvfp4.py
+++ b/vllm/model_executor/layers/fused_moe/oracle/nvfp4.py
@@ -157,6 +157,46 @@ def map_nvfp4_backend(runner_backend: MoEBackend) -> NvFp4MoeBackend:
     )
 
 
+# SM70 has no native nvfp4_moe_* kernels (FlashInfer TRTLLM/CUTLASS FP4, etc.).
+# Prefer weight-only Marlin, then on-the-fly EMULATION, before Blackwell paths.
+_SM70_NVFP4_MOE_COMPAT_BACKENDS = (
+    NvFp4MoeBackend.MARLIN,
+    NvFp4MoeBackend.EMULATION,
+)
+
+
+def prefer_sm70_nvfp4_moe_fallback() -> bool:
+    """Whether auto-select should prefer Marlin/EMULATION for NVFP4 MoE.
+
+    Default: exact Volta SM70 (cap ≥ 70 and not ≥ 75). Override with env
+    ``VLLM_SM70_NVFP4_MOE_FALLBACK=0|1`` for force disable/enable.
+    """
+    import os
+
+    if "VLLM_SM70_NVFP4_MOE_FALLBACK" in os.environ:
+        return bool(int(os.environ["VLLM_SM70_NVFP4_MOE_FALLBACK"]))
+    try:
+        from vllm.platforms import current_platform
+
+        p = current_platform
+        return (
+            p.is_cuda()
+            and p.has_device_capability(70)
+            and not p.has_device_capability(75)
+        )
+    except Exception:
+        return False
+
+
+def sm70_compat_nvfp4_moe_backend_order(
+    backends: list[NvFp4MoeBackend],
+) -> list[NvFp4MoeBackend]:
+    """Reorder so Marlin then EMULATION are tried before native FP4 kernels."""
+    preferred = [b for b in _SM70_NVFP4_MOE_COMPAT_BACKENDS if b in backends]
+    rest = [b for b in backends if b not in _SM70_NVFP4_MOE_COMPAT_BACKENDS]
+    return preferred + rest
+
+
 def select_nvfp4_moe_backend(
     config: FusedMoEConfig,
     weight_key: QuantKey | None,
@@ -189,6 +229,17 @@ def select_nvfp4_moe_backend(
         AVAILABLE_BACKENDS = [
             b for b in AVAILABLE_BACKENDS if b in NVFP4_BACKENDS_WITH_CLAMP
         ]
+
+    # Volta SM70: no native nvfp4_moe_* — put Marlin/EMULATION first so auto
+    # selection does not hard-fail after probing only Blackwell FlashInfer paths.
+    # Explicit moe_backend= / VLLM_USE_FLASHINFER_MOE_FP4 still honored below.
+    if prefer_sm70_nvfp4_moe_fallback() and config.swiglu_limit is None:
+        AVAILABLE_BACKENDS = sm70_compat_nvfp4_moe_backend_order(AVAILABLE_BACKENDS)
+        logger.info_once(
+            "SM70 NVFP4 MoE compat: preferring Marlin then EMULATION "
+            "(no native nvfp4_moe_* SM70 kernels). Marlin is weight-only "
+            "(activations remain half/bf16)."
+        )
 
     use_batched = config.moe_parallel_config.use_batched_activation_format
     activation_format = (

--- a/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_w4a16_nvfp4.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_w4a16_nvfp4.py
@@ -93,24 +93,8 @@ class CompressedTensorsW4A16Fp4(CompressedTensorsScheme):
             1.0 / layer.weight_global_scale.max().to(torch.float32), requires_grad=False
         )
 
-        if sm70_tm.should_prepare_turbomind(
-            layer.weight, envs.VLLM_SM70_NVFP4_TURBOMIND
-        ):
-            logger.info_once(
-                "SM70 compressed-tensors NVFP4 TurboMind W4A16 dense path "
-                "enabled."
-            )
-            sm70_tm.prepare_nvfp4_linear(layer)
-            layer.weight = Parameter(
-                torch.empty(0, dtype=torch.uint8, device=layer.weight.device),
-                requires_grad=False,
-            )
-            layer.weight_scale = Parameter(
-                torch.empty(
-                    0, dtype=torch.float8_e4m3fn, device=layer.weight_scale.device
-                ),
-                requires_grad=False,
-            )
+        # SM70 TurboMind / hybrid linear_attn dequant policy.
+        if sm70_tm.try_prepare_sm70_nvfp4_linear(layer):
             return
 
         prepare_fp4_layer_for_marlin(layer)
@@ -121,8 +105,9 @@ class CompressedTensorsW4A16Fp4(CompressedTensorsScheme):
         x: torch.Tensor,
         bias: torch.Tensor | None = None,
     ) -> torch.Tensor:
-        if sm70_tm.has_prepared_linear(layer):
-            return sm70_tm.apply_prepared_linear(layer, x, bias)
+        out = sm70_tm.try_apply_sm70_nvfp4_linear(layer, x, bias)
+        if out is not None:
+            return out
         return apply_fp4_marlin_linear(
             input=x,
             weight=layer.weight,

--- a/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_w4a16_nvfp4.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_w4a16_nvfp4.py
@@ -88,10 +88,9 @@ class CompressedTensorsW4A16Fp4(CompressedTensorsScheme):
         # Rename weight_packed to weight that marlin expects
         layer.weight = Parameter(layer.weight_packed.data, requires_grad=False)
         del layer.weight_packed
-        # ct stores the inverse of what is expected by the marlin kernel
-        layer.weight_global_scale = Parameter(
-            1.0 / layer.weight_global_scale.max().to(torch.float32), requires_grad=False
-        )
+        # Global scale: Aggressive uses 1/disk_global; Medium/TC tiny-block
+        # exports need global=1.0 (do not fold into fp8 block scales).
+        sm70_tm.normalize_nvfp4_global_scale_for_sm70(layer)
 
         # SM70 TurboMind / hybrid linear_attn dequant policy.
         if sm70_tm.try_prepare_sm70_nvfp4_linear(layer):

--- a/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_w4a4_nvfp4.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_w4a4_nvfp4.py
@@ -147,23 +147,9 @@ class CompressedTensorsW4A4Fp4(CompressedTensorsScheme):
             layer.input_global_scale * layer.weight_global_scale, requires_grad=False
         )
 
-        if sm70_tm.should_prepare_turbomind(
-            layer.weight, envs.VLLM_SM70_NVFP4_TURBOMIND
-        ):
-            logger.info_once(
-                "SM70 compressed-tensors NVFP4 TurboMind W4A16 dense path enabled."
-            )
-            sm70_tm.prepare_nvfp4_linear(layer)
-            layer.weight = Parameter(
-                torch.empty(0, dtype=torch.uint8, device=layer.weight.device),
-                requires_grad=False,
-            )
-            layer.weight_scale = Parameter(
-                torch.empty(
-                    0, dtype=torch.float8_e4m3fn, device=layer.weight_scale.device
-                ),
-                requires_grad=False,
-            )
+        # SM70: serve W4A4 weights via W4A16 TurboMind / hybrid dequant policy
+        # (activations remain half; true W4A4 act-quant is not used on SM70).
+        if sm70_tm.try_prepare_sm70_nvfp4_linear(layer):
             return
 
         # Convert layer to NVFP4 linear kernel format
@@ -180,6 +166,7 @@ class CompressedTensorsW4A4Fp4(CompressedTensorsScheme):
         x: torch.Tensor,
         bias: torch.Tensor | None = None,
     ) -> torch.Tensor:
-        if sm70_tm.has_prepared_linear(layer):
-            return sm70_tm.apply_prepared_linear(layer, x, bias)
+        out = sm70_tm.try_apply_sm70_nvfp4_linear(layer, x, bias)
+        if out is not None:
+            return out
         return self._fallback_kernel().apply_weights(layer=layer, x=x, bias=bias)

--- a/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_w4a4_nvfp4.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_w4a4_nvfp4.py
@@ -150,6 +150,10 @@ class CompressedTensorsW4A4Fp4(CompressedTensorsScheme):
         # SM70: serve W4A4 weights via W4A16 TurboMind / hybrid dequant policy
         # (activations remain half; true W4A4 act-quant is not used on SM70).
         if sm70_tm.try_prepare_sm70_nvfp4_linear(layer):
+            logger.info_once(
+                "SM70 compressed-tensors NVFP4 W4A4-on-disk: weight-only path "
+                "(W4A16 semantics); activations remain half/bf16."
+            )
             return
 
         # Convert layer to NVFP4 linear kernel format

--- a/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_w4a4_nvfp4.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_w4a4_nvfp4.py
@@ -134,10 +134,8 @@ class CompressedTensorsW4A4Fp4(CompressedTensorsScheme):
         layer.input_global_scale = Parameter(
             (1.0 / input_global_scale_inv).to(torch.float32), requires_grad=False
         )
-        weight_global_scale = layer.weight_global_scale.max().to(torch.float32)
-        layer.weight_global_scale = Parameter(
-            1.0 / weight_global_scale, requires_grad=False
-        )
+        # Weight global: Medium/TC tiny-block → 1.0; Aggressive → 1/disk.
+        sm70_tm.normalize_nvfp4_global_scale_for_sm70(layer)
 
         # Pre-compute alpha and inverse for runtime quantization
         layer.input_global_scale_inv = Parameter(

--- a/vllm/model_executor/layers/quantization/modelopt.py
+++ b/vllm/model_executor/layers/quantization/modelopt.py
@@ -63,6 +63,8 @@ from vllm.model_executor.layers.quantization.utils.fp8_utils import (
 from vllm.model_executor.layers.quantization.utils.marlin_utils import (
     get_marlin_input_dtype,
 )
+from vllm.model_executor.layers.quantization import sm70_turbomind as sm70_tm
+from vllm import envs
 from vllm.model_executor.layers.quantization.utils.mxfp8_utils import (
     MXFP8_BLOCK_SIZE,
     MXFP8_SCALE_DTYPE,
@@ -1050,7 +1052,10 @@ class ModelOptNvFp4Config(ModelOptQuantConfigBase):
 
     @classmethod
     def get_min_capability(cls) -> int:
-        return 75
+        # SM70 (Volta): software NVFP4 via Marlin/emulation or TurboMind.
+        # Native FP4 tensor cores remain Blackwell-only; this only admits
+        # the dequant-to-half path already used on older GPUs.
+        return 70
 
     @classmethod
     def override_quantization_method(
@@ -1367,6 +1372,13 @@ class ModelOptNvFp4W4A16LinearMethod(LinearMethodBase):
         )
         del layer.weight_scale_2
 
+        if sm70_tm.should_prepare_turbomind(
+            layer.weight, envs.VLLM_SM70_NVFP4_TURBOMIND
+        ):
+            # Match compressed-tensors W4A16 NVFP4: TurboMind SM70 path.
+            sm70_tm.prepare_nvfp4_linear(layer)
+            return
+
         self.kernel.process_weights_after_loading(layer)
 
     def apply(
@@ -1375,6 +1387,8 @@ class ModelOptNvFp4W4A16LinearMethod(LinearMethodBase):
         x: torch.Tensor,
         bias: torch.Tensor | None = None,
     ) -> torch.Tensor:
+        if sm70_tm.has_prepared_linear(layer):
+            return sm70_tm.apply_prepared_linear(layer, x, bias)
         return self.kernel.apply_weights(layer=layer, x=x, bias=bias)
 
 

--- a/vllm/model_executor/layers/quantization/modelopt.py
+++ b/vllm/model_executor/layers/quantization/modelopt.py
@@ -1372,11 +1372,8 @@ class ModelOptNvFp4W4A16LinearMethod(LinearMethodBase):
         )
         del layer.weight_scale_2
 
-        if sm70_tm.should_prepare_turbomind(
-            layer.weight, envs.VLLM_SM70_NVFP4_TURBOMIND
-        ):
-            # Match compressed-tensors W4A16 NVFP4: TurboMind SM70 path.
-            sm70_tm.prepare_nvfp4_linear(layer)
+        # SM70 TurboMind / hybrid linear_attn dequant policy.
+        if sm70_tm.try_prepare_sm70_nvfp4_linear(layer):
             return
 
         self.kernel.process_weights_after_loading(layer)
@@ -1387,8 +1384,9 @@ class ModelOptNvFp4W4A16LinearMethod(LinearMethodBase):
         x: torch.Tensor,
         bias: torch.Tensor | None = None,
     ) -> torch.Tensor:
-        if sm70_tm.has_prepared_linear(layer):
-            return sm70_tm.apply_prepared_linear(layer, x, bias)
+        out = sm70_tm.try_apply_sm70_nvfp4_linear(layer, x, bias)
+        if out is not None:
+            return out
         return self.kernel.apply_weights(layer=layer, x=x, bias=bias)
 
 

--- a/vllm/model_executor/layers/quantization/modelopt.py
+++ b/vllm/model_executor/layers/quantization/modelopt.py
@@ -1225,6 +1225,15 @@ class ModelOptNvFp4LinearMethod(LinearMethodBase):
             (1.0 / layer.input_global_scale).to(torch.float32), requires_grad=False
         )
 
+        # SM70: serve W4A4-on-disk weights via weight-only TurboMind / hybrid
+        # dequant (activations remain half/bf16 — not true act-quant W4A4).
+        if sm70_tm.try_prepare_sm70_nvfp4_linear(layer):
+            logger.info_once(
+                "SM70 ModelOpt NVFP4 W4A4-on-disk: weight-only path "
+                "(W4A16 semantics); activations remain half/bf16."
+            )
+            return
+
         # Convert layer to NVFP4 linear kernel format
         self.kernel.process_weights_after_loading(layer)
 
@@ -1234,6 +1243,9 @@ class ModelOptNvFp4LinearMethod(LinearMethodBase):
         x: torch.Tensor,
         bias: torch.Tensor | None = None,
     ) -> torch.Tensor:
+        out = sm70_tm.try_apply_sm70_nvfp4_linear(layer, x, bias)
+        if out is not None:
+            return out
         return self.kernel.apply_weights(layer=layer, x=x, bias=bias)
 
 

--- a/vllm/model_executor/layers/quantization/sm70_turbomind.py
+++ b/vllm/model_executor/layers/quantization/sm70_turbomind.py
@@ -3,7 +3,6 @@
 
 from dataclasses import dataclass
 from typing import Literal
-from collections.abc import Sequence
 
 import torch
 import torch.nn.functional as F

--- a/vllm/model_executor/layers/quantization/sm70_turbomind.py
+++ b/vllm/model_executor/layers/quantization/sm70_turbomind.py
@@ -326,14 +326,17 @@ def apply_prepared_linear(
 # Hybrid linear-attention (GatedDeltaNet) policy for SM70 NVFP4
 # ---------------------------------------------------------------------------
 # Qwen3.6 hybrid layers expose NVFP4-able linears under ``*.linear_attn.*``.
-# Aggressive-style checkpoints often run those on TurboMind safely; abliterated
-# Medium/TC builds can emit garbage if forced through the fused path. Policy:
-#   VLLM_SM70_NVFP4_LINEAR_ATTN=auto|tm|dequant  (default: auto)
-#     auto    – TM when scale-health passes, else load-time dequant → half GEMM
-#     tm      – always TurboMind for hybrid candidates
-#     dequant – always dequant hybrid candidates (safe default for fragile bases)
+# Aggressive-style checkpoints run those on TurboMind safely; abliterated
+# Medium/TC builds can garbage if forced through the fused path.
 #
-# Non-candidate dense linears are unchanged (TM when enabled).
+# Policy resolution (see envs.get_sm70_nvfp4_linear_attn_mode):
+#   1. env VLLM_SM70_NVFP4_LINEAR_ATTN=tm|dequant|auto  (override)
+#   2. checkpoint quantization_config.sm70_linear_attn stamp
+#   3. default tm  (speed; do not tax the good case)
+#
+# Stamp fragile builds at quant time, e.g.:
+#   quantization_config["sm70_linear_attn"] = "dequant"
+# so operators need no env. Non-candidate dense linears always use TM.
 
 DEQUANT_ATTR = "_sm70_nvfp4_dequant_weight"
 HYBRID_LINEAR_ATTN_LEAVES = (
@@ -394,9 +397,26 @@ def has_dequant_linear(layer: torch.nn.Module) -> bool:
     return getattr(layer, DEQUANT_ATTR, None) is not None
 
 
+def _resolve_dequant_dtype(layer: torch.nn.Module) -> torch.dtype:
+    """Prefer the layer/model compute dtype over a hardcoded fp16."""
+    for attr in ("params_dtype", "dtype"):
+        dt = getattr(layer, attr, None)
+        if isinstance(dt, torch.dtype) and dt in (torch.float16, torch.bfloat16):
+            return dt
+    try:
+        from vllm.config import get_current_vllm_config
+
+        dt = get_current_vllm_config().model_config.dtype
+        if dt in (torch.float16, torch.bfloat16):
+            return dt
+    except Exception:
+        pass
+    return torch.float16
+
+
 def prepare_nvfp4_dequant_linear(
     layer: torch.nn.Module,
-    dtype: torch.dtype = torch.float16,
+    dtype: torch.dtype | None = None,
 ) -> None:
     """Load-time dequant of packed NVFP4 weights to half/bf16 for F.linear."""
     from vllm.logger import init_logger
@@ -405,6 +425,8 @@ def prepare_nvfp4_dequant_linear(
     )
 
     logger = init_logger(__name__)
+    if dtype is None:
+        dtype = _resolve_dequant_dtype(layer)
     weight = layer.weight.data
     scale = layer.weight_scale.data
     global_scale = layer.weight_global_scale.data
@@ -436,10 +458,15 @@ def prepare_nvfp4_dequant_linear(
     layer.weight_scale = Parameter(
         torch.empty(0, dtype=torch.float8_e4m3fn, device=device), requires_grad=False
     )
+    if hasattr(layer, "weight_global_scale"):
+        layer.weight_global_scale = Parameter(
+            torch.empty(0, dtype=torch.float32, device=device), requires_grad=False
+        )
     logger.info_once(
         "SM70 NVFP4 hybrid linear_attn dequant path enabled "
-        "(VLLM_SM70_NVFP4_LINEAR_ATTN=%s).",
+        "(mode=%s, dtype=%s).",
         hybrid_linear_attn_mode(),
+        dtype,
     )
 
 
@@ -449,7 +476,10 @@ def apply_dequant_linear(
     bias: torch.Tensor | None,
 ) -> torch.Tensor:
     w = getattr(layer, DEQUANT_ATTR)
-    return F.linear(x, w.to(dtype=x.dtype), bias)
+    # Weight already dequanted to compute dtype; cast only if mismatch.
+    if w.dtype != x.dtype:
+        w = w.to(dtype=x.dtype)
+    return F.linear(x, w, bias)
 
 
 def should_dequant_hybrid_linear_attn(layer: torch.nn.Module) -> bool:
@@ -474,7 +504,7 @@ def try_prepare_sm70_nvfp4_linear(layer: torch.nn.Module) -> bool:
         return False
 
     if should_dequant_hybrid_linear_attn(layer):
-        prepare_nvfp4_dequant_linear(layer, dtype=torch.float16)
+        prepare_nvfp4_dequant_linear(layer)
         return True
 
     from vllm.logger import init_logger
@@ -483,7 +513,7 @@ def try_prepare_sm70_nvfp4_linear(layer: torch.nn.Module) -> bool:
     if is_hybrid_linear_attn_nvfp4_candidate(layer):
         logger.info_once(
             "SM70 NVFP4 hybrid linear_attn TurboMind path enabled "
-            "(VLLM_SM70_NVFP4_LINEAR_ATTN=%s).",
+            "(mode=%s).",
             hybrid_linear_attn_mode(),
         )
     else:

--- a/vllm/model_executor/layers/quantization/sm70_turbomind.py
+++ b/vllm/model_executor/layers/quantization/sm70_turbomind.py
@@ -3,8 +3,11 @@
 
 from dataclasses import dataclass
 from typing import Literal
+from collections.abc import Sequence
 
 import torch
+import torch.nn.functional as F
+from torch.nn.parameter import Parameter
 
 from vllm import envs
 
@@ -318,3 +321,199 @@ def apply_prepared_linear(
     if bias is not None:
         out.add_(bias)
     return out.reshape(out_shape)
+
+
+# ---------------------------------------------------------------------------
+# Hybrid linear-attention (GatedDeltaNet) policy for SM70 NVFP4
+# ---------------------------------------------------------------------------
+# Qwen3.6 hybrid layers expose NVFP4-able linears under ``*.linear_attn.*``.
+# Aggressive-style checkpoints often run those on TurboMind safely; abliterated
+# Medium/TC builds can emit garbage if forced through the fused path. Policy:
+#   VLLM_SM70_NVFP4_LINEAR_ATTN=auto|tm|dequant  (default: auto)
+#     auto    – TM when scale-health passes, else load-time dequant → half GEMM
+#     tm      – always TurboMind for hybrid candidates
+#     dequant – always dequant hybrid candidates (safe default for fragile bases)
+#
+# Non-candidate dense linears are unchanged (TM when enabled).
+
+DEQUANT_ATTR = "_sm70_nvfp4_dequant_weight"
+HYBRID_LINEAR_ATTN_LEAVES = (
+    "in_proj_qkv",
+    "in_proj_z",
+    "out_proj",
+)
+
+
+def _layer_prefix(layer: torch.nn.Module) -> str:
+    return str(getattr(layer, "prefix", "") or "")
+
+
+def is_hybrid_linear_attn_nvfp4_candidate(layer: torch.nn.Module) -> bool:
+    """True for GDN linears that are commonly NVFP4-packed (not a/b/norm/conv)."""
+    prefix = _layer_prefix(layer)
+    if "linear_attn" not in prefix:
+        return False
+    leaf = prefix.rsplit(".", 1)[-1]
+    return leaf in HYBRID_LINEAR_ATTN_LEAVES
+
+
+def hybrid_linear_attn_mode() -> Literal["auto", "tm", "dequant"]:
+    return envs.get_sm70_nvfp4_linear_attn_mode()
+
+
+def nvfp4_scale_health_ok(layer: torch.nn.Module) -> bool:
+    """Cheap finite / dynamic-range check on NVFP4 scales before TM prepare."""
+    try:
+        if not hasattr(layer, "weight_scale") or not hasattr(layer, "weight_global_scale"):
+            return False
+        gs = layer.weight_global_scale.detach().float().reshape(-1)
+        if gs.numel() == 0 or not torch.isfinite(gs).all():
+            return False
+        gmax = float(gs.abs().max().item())
+        gmin = float(gs.abs().clamp_min(1e-30).min().item())
+        if gmax > 1e6 or gmin < 1e-12:
+            return False
+        sc = layer.weight_scale.detach()
+        if sc.dtype == torch.float8_e4m3fn:
+            scf = sc.to(torch.float32)
+        else:
+            scf = sc.float()
+        if not torch.isfinite(scf).all():
+            return False
+        pos = scf.abs()
+        pos = pos[pos > 0]
+        if pos.numel() > 0:
+            ratio = float((pos.max() / pos.min().clamp_min(1e-30)).item())
+            if ratio > 1e6:
+                return False
+        return True
+    except Exception:
+        return False
+
+
+def has_dequant_linear(layer: torch.nn.Module) -> bool:
+    return getattr(layer, DEQUANT_ATTR, None) is not None
+
+
+def prepare_nvfp4_dequant_linear(
+    layer: torch.nn.Module,
+    dtype: torch.dtype = torch.float16,
+) -> None:
+    """Load-time dequant of packed NVFP4 weights to half/bf16 for F.linear."""
+    from vllm.logger import init_logger
+    from vllm.model_executor.layers.quantization.utils.nvfp4_emulation_utils import (
+        dequantize_to_dtype,
+    )
+
+    logger = init_logger(__name__)
+    weight = layer.weight.data
+    scale = layer.weight_scale.data
+    global_scale = layer.weight_global_scale.data
+    # PerTensorScaleParameter may be multi-element for fused shards; take max.
+    if global_scale.numel() > 1:
+        global_scale = global_scale.reshape(-1).max().reshape(1)
+    else:
+        global_scale = global_scale.reshape(1)
+
+    # CT/ModelOpt packed layout is linear (non-swizzled) after loader rename.
+    w_hp = dequantize_to_dtype(
+        weight.contiguous(),
+        scale.contiguous(),
+        global_scale.contiguous(),
+        dtype=dtype,
+        block_size=NVFP4_GROUP_SIZE,
+        swizzle=False,
+    )
+    setattr(
+        layer,
+        DEQUANT_ATTR,
+        Parameter(w_hp.contiguous(), requires_grad=False),
+    )
+    # Drop packed tensors to free VRAM (match TM prepare cleanup).
+    device = w_hp.device
+    layer.weight = Parameter(
+        torch.empty(0, dtype=torch.uint8, device=device), requires_grad=False
+    )
+    layer.weight_scale = Parameter(
+        torch.empty(0, dtype=torch.float8_e4m3fn, device=device), requires_grad=False
+    )
+    logger.info_once(
+        "SM70 NVFP4 hybrid linear_attn dequant path enabled "
+        "(VLLM_SM70_NVFP4_LINEAR_ATTN=%s).",
+        hybrid_linear_attn_mode(),
+    )
+
+
+def apply_dequant_linear(
+    layer: torch.nn.Module,
+    x: torch.Tensor,
+    bias: torch.Tensor | None,
+) -> torch.Tensor:
+    w = getattr(layer, DEQUANT_ATTR)
+    return F.linear(x, w.to(dtype=x.dtype), bias)
+
+
+def should_dequant_hybrid_linear_attn(layer: torch.nn.Module) -> bool:
+    if not is_hybrid_linear_attn_nvfp4_candidate(layer):
+        return False
+    mode = hybrid_linear_attn_mode()
+    if mode == "dequant":
+        return True
+    if mode == "tm":
+        return False
+    # auto
+    return not nvfp4_scale_health_ok(layer)
+
+
+def try_prepare_sm70_nvfp4_linear(layer: torch.nn.Module) -> bool:
+    """Prepare SM70 NVFP4 for a linear layer.
+
+    Returns True if the layer was handled (TurboMind or hybrid dequant).
+    Callers should fall back to Marlin / default kernels when False.
+    """
+    if not should_prepare_turbomind(layer.weight, envs.VLLM_SM70_NVFP4_TURBOMIND):
+        return False
+
+    if should_dequant_hybrid_linear_attn(layer):
+        prepare_nvfp4_dequant_linear(layer, dtype=torch.float16)
+        return True
+
+    from vllm.logger import init_logger
+
+    logger = init_logger(__name__)
+    if is_hybrid_linear_attn_nvfp4_candidate(layer):
+        logger.info_once(
+            "SM70 NVFP4 hybrid linear_attn TurboMind path enabled "
+            "(VLLM_SM70_NVFP4_LINEAR_ATTN=%s).",
+            hybrid_linear_attn_mode(),
+        )
+    else:
+        logger.info_once(
+            "SM70 compressed-tensors/ModelOpt NVFP4 TurboMind W4A16 dense path "
+            "enabled."
+        )
+    prepare_nvfp4_linear(layer)
+    # Free packed storage after TM prepare (weights live in STATE_ATTR).
+    device = layer.weight.device
+    layer.weight = Parameter(
+        torch.empty(0, dtype=torch.uint8, device=device), requires_grad=False
+    )
+    if hasattr(layer, "weight_scale"):
+        layer.weight_scale = Parameter(
+            torch.empty(0, dtype=torch.float8_e4m3fn, device=device),
+            requires_grad=False,
+        )
+    return True
+
+
+def try_apply_sm70_nvfp4_linear(
+    layer: torch.nn.Module,
+    x: torch.Tensor,
+    bias: torch.Tensor | None,
+) -> torch.Tensor | None:
+    """Apply SM70 NVFP4 path if prepared; else return None."""
+    if has_dequant_linear(layer):
+        return apply_dequant_linear(layer, x, bias)
+    if has_prepared_linear(layer):
+        return apply_prepared_linear(layer, x, bias)
+    return None

--- a/vllm/model_executor/layers/quantization/sm70_turbomind.py
+++ b/vllm/model_executor/layers/quantization/sm70_turbomind.py
@@ -518,8 +518,8 @@ def try_prepare_sm70_nvfp4_linear(layer: torch.nn.Module) -> bool:
         )
     else:
         logger.info_once(
-            "SM70 compressed-tensors/ModelOpt NVFP4 TurboMind W4A16 dense path "
-            "enabled."
+            "SM70 compressed-tensors/ModelOpt NVFP4 TurboMind weight-only "
+            "dense path enabled (W4A16 semantics; acts remain half/bf16)."
         )
     prepare_nvfp4_linear(layer)
     # Free packed storage after TM prepare (weights live in STATE_ATTR).

--- a/vllm/model_executor/layers/quantization/sm70_turbomind.py
+++ b/vllm/model_executor/layers/quantization/sm70_turbomind.py
@@ -241,11 +241,18 @@ def prepare_mxfp4_linear(
 
 
 # Block-scale magnitude threshold for NVFP4 scale-convention detection.
-# Aggressive-style CT exports fold magnitude into FP8 block scales (often
-# O(1)–448). Later GPTQ exports (Medium/TC/cyber) leave tiny block scales
-# (max ≪ 1) with a large disk global; after CT's ``global := 1/disk_global``,
-# multiplying block*global underflows (~1e-6) and produces token salad.
-# Detect tiny block scales and skip the global factor for SM70 combine.
+#
+# Aggressive CT exports fold magnitude into FP8 block scales (often O(1)–448)
+# with a large disk global; CT then stores ``global := 1/disk_global`` and
+# TM/dequant do ``e2m1 * block * global`` (= block/disk_global).
+#
+# Medium/TC/cyber GPTQ exports leave *tiny* block scales (max ≪ 1) that
+# already hold the true per-block scale, but still ship a large disk global.
+# Applying 1/disk_global then multiplies under-scales weights by ~G → salad.
+#
+# Fix (do NOT do ``weight_scale *= global`` — that overflows fp8-e4m3 at 448):
+# set ``weight_global_scale = 1.0`` (fp32) and leave block scales untouched.
+# See /rivet-shared/plans/nvfp4-medium-scale-fix.md.
 _NVFP4_TINY_BLOCK_SCALE_MAX = 1.0
 
 
@@ -263,37 +270,73 @@ def nvfp4_block_scales_are_tiny(layer: torch.nn.Module) -> bool:
     return float(scf.abs().max().item()) < _NVFP4_TINY_BLOCK_SCALE_MAX
 
 
+def normalize_nvfp4_global_scale_for_sm70(layer: torch.nn.Module) -> None:
+    """Rewrite ``weight_global_scale`` for SM70-safe dequant/TM combine.
+
+    Call **before** CT's usual ``global := 1/disk_global`` (or instead of it):
+
+    - Tiny block scales (Medium/TC): set global to **1.0** (identity). Block
+      scales already hold the true per-block value; do not touch weight_scale
+      (fp8 overflow if you fold global into block scales without clamping).
+    - Large block scales (Aggressive): ``global := 1/disk_global`` (existing CT
+      convention expected by TurboMind / Marlin).
+    """
+    from vllm.logger import init_logger
+
+    if not hasattr(layer, "weight_global_scale"):
+        return
+    raw = layer.weight_global_scale.detach().float()
+    if raw.numel() == 0:
+        return
+    device = layer.weight_global_scale.device
+    if nvfp4_block_scales_are_tiny(layer):
+        layer.weight_global_scale = Parameter(
+            torch.ones(1, dtype=torch.float32, device=device),
+            requires_grad=False,
+        )
+        init_logger(__name__).info_once(
+            "SM70 NVFP4: tiny block-scale convention (max |weight_scale| < 1); "
+            "set weight_global_scale=1.0 (leave block scales untouched). "
+            "Fixes Medium/TC GPTQ under-scale without fp8 overflow."
+        )
+        return
+    # Aggressive / folded-block convention: CT stores the reciprocal.
+    g = float(raw.reshape(-1).max().item())
+    layer.weight_global_scale = Parameter(
+        torch.tensor([1.0 / g], dtype=torch.float32, device=device),
+        requires_grad=False,
+    )
+
+
 def combine_nvfp4_scales_for_sm70_tm(layer: torch.nn.Module) -> torch.Tensor:
     """Combine block + global scales for ``nvfp4_sm70_prepare``.
 
-    CT ``process_weights`` stores ``weight_global_scale = 1/disk_global``.
-    TurboMind then does ``block * global``. That matches Aggressive exports
-    (large block scales). Tiny-block exports already encode the effective
-    scale in the block tensor — multiplying by inverted global again is wrong.
+    Expects ``weight_global_scale`` already normalized via
+    ``normalize_nvfp4_global_scale_for_sm70`` (or equivalent). Always
+    ``block * global``; for Medium, global is 1.0 so this is a no-op multiply.
     """
     block = layer.weight_scale.data.t().to(torch.float32)
-    if nvfp4_block_scales_are_tiny(layer):
-        from vllm.logger import init_logger
-
-        init_logger(__name__).info_once(
-            "SM70 NVFP4: tiny block-scale convention detected "
-            "(max |weight_scale| < 1); combining without global factor "
-            "so Medium/TC GPTQ checkpoints match Aggressive effective scale."
-        )
-        return block.to(torch.float16).contiguous()
     g = layer.weight_global_scale.to(torch.float32)
+    # Safety net if a caller skipped normalize_*: treat as identity global.
+    if nvfp4_block_scales_are_tiny(layer):
+        g_abs = float(g.detach().float().abs().max().item()) if g.numel() else 1.0
+        # After proper normalize, g is 1.0. If still ~1/disk_global (≪ 1), skip.
+        if g_abs < 0.5:
+            return block.to(torch.float16).contiguous()
     return (block * g).to(torch.float16).contiguous()
 
 
 def resolve_nvfp4_global_for_dequant(layer: torch.nn.Module) -> torch.Tensor:
-    """Global scale for ``dequantize_to_dtype`` (also does block * global)."""
+    """Global scale for ``dequantize_to_dtype`` (``block * global``)."""
     global_scale = layer.weight_global_scale.data
     if global_scale.numel() > 1:
         global_scale = global_scale.reshape(-1).max().reshape(1)
     else:
         global_scale = global_scale.reshape(1)
     if nvfp4_block_scales_are_tiny(layer):
-        return torch.ones(1, dtype=torch.float32, device=global_scale.device)
+        g_abs = float(global_scale.detach().float().abs().max().item())
+        if g_abs < 0.5:
+            return torch.ones(1, dtype=torch.float32, device=global_scale.device)
     return global_scale.to(torch.float32)
 
 

--- a/vllm/model_executor/layers/quantization/sm70_turbomind.py
+++ b/vllm/model_executor/layers/quantization/sm70_turbomind.py
@@ -240,6 +240,63 @@ def prepare_mxfp4_linear(
     )
 
 
+# Block-scale magnitude threshold for NVFP4 scale-convention detection.
+# Aggressive-style CT exports fold magnitude into FP8 block scales (often
+# O(1)–448). Later GPTQ exports (Medium/TC/cyber) leave tiny block scales
+# (max ≪ 1) with a large disk global; after CT's ``global := 1/disk_global``,
+# multiplying block*global underflows (~1e-6) and produces token salad.
+# Detect tiny block scales and skip the global factor for SM70 combine.
+_NVFP4_TINY_BLOCK_SCALE_MAX = 1.0
+
+
+def nvfp4_block_scales_are_tiny(layer: torch.nn.Module) -> bool:
+    """True when per-group weight_scale looks like the "tiny-block" CT export."""
+    if not hasattr(layer, "weight_scale"):
+        return False
+    sc = layer.weight_scale.detach()
+    if sc.dtype == torch.float8_e4m3fn:
+        scf = sc.to(torch.float32)
+    else:
+        scf = sc.float()
+    if scf.numel() == 0 or not torch.isfinite(scf).all():
+        return False
+    return float(scf.abs().max().item()) < _NVFP4_TINY_BLOCK_SCALE_MAX
+
+
+def combine_nvfp4_scales_for_sm70_tm(layer: torch.nn.Module) -> torch.Tensor:
+    """Combine block + global scales for ``nvfp4_sm70_prepare``.
+
+    CT ``process_weights`` stores ``weight_global_scale = 1/disk_global``.
+    TurboMind then does ``block * global``. That matches Aggressive exports
+    (large block scales). Tiny-block exports already encode the effective
+    scale in the block tensor — multiplying by inverted global again is wrong.
+    """
+    block = layer.weight_scale.data.t().to(torch.float32)
+    if nvfp4_block_scales_are_tiny(layer):
+        from vllm.logger import init_logger
+
+        init_logger(__name__).info_once(
+            "SM70 NVFP4: tiny block-scale convention detected "
+            "(max |weight_scale| < 1); combining without global factor "
+            "so Medium/TC GPTQ checkpoints match Aggressive effective scale."
+        )
+        return block.to(torch.float16).contiguous()
+    g = layer.weight_global_scale.to(torch.float32)
+    return (block * g).to(torch.float16).contiguous()
+
+
+def resolve_nvfp4_global_for_dequant(layer: torch.nn.Module) -> torch.Tensor:
+    """Global scale for ``dequantize_to_dtype`` (also does block * global)."""
+    global_scale = layer.weight_global_scale.data
+    if global_scale.numel() > 1:
+        global_scale = global_scale.reshape(-1).max().reshape(1)
+    else:
+        global_scale = global_scale.reshape(1)
+    if nvfp4_block_scales_are_tiny(layer):
+        return torch.ones(1, dtype=torch.float32, device=global_scale.device)
+    return global_scale.to(torch.float32)
+
+
 def prepare_nvfp4_linear(
     layer: torch.nn.Module,
     interleave_gated_silu: bool = False,
@@ -252,10 +309,7 @@ def prepare_nvfp4_linear(
     from vllm import _sm70_ops as sm70_ops
 
     qweight = unpack_mxfp4_weight(layer.weight.data)
-    scales = (
-        layer.weight_scale.data.t().to(torch.float32)
-        * layer.weight_global_scale.to(torch.float32)
-    ).to(torch.float16).contiguous()
+    scales = combine_nvfp4_scales_for_sm70_tm(layer)
     tm_weight, tm_scales, meta = sm70_ops.nvfp4_sm70_prepare(
         qweight, scales, NVFP4_GROUP_SIZE, interleave_gated_silu
     )
@@ -326,8 +380,10 @@ def apply_prepared_linear(
 # Hybrid linear-attention (GatedDeltaNet) policy for SM70 NVFP4
 # ---------------------------------------------------------------------------
 # Qwen3.6 hybrid layers expose NVFP4-able linears under ``*.linear_attn.*``.
-# Aggressive-style checkpoints run those on TurboMind safely; abliterated
-# Medium/TC builds can garbage if forced through the fused path.
+# Aggressive-style checkpoints run those on TurboMind safely. Medium/TC dense
+# garbage was largely a block/global scale convention mismatch (see
+# combine_nvfp4_scales_for_sm70_tm); hybrid dequant remains available as a
+# stamp/env override for residual fragility.
 #
 # Policy resolution (see envs.get_sm70_nvfp4_linear_attn_mode):
 #   1. env VLLM_SM70_NVFP4_LINEAR_ATTN=tm|dequant|auto  (override)
@@ -429,12 +485,8 @@ def prepare_nvfp4_dequant_linear(
         dtype = _resolve_dequant_dtype(layer)
     weight = layer.weight.data
     scale = layer.weight_scale.data
-    global_scale = layer.weight_global_scale.data
-    # PerTensorScaleParameter may be multi-element for fused shards; take max.
-    if global_scale.numel() > 1:
-        global_scale = global_scale.reshape(-1).max().reshape(1)
-    else:
-        global_scale = global_scale.reshape(1)
+    # Same tiny-block convention handling as TurboMind combine.
+    global_scale = resolve_nvfp4_global_for_dequant(layer)
 
     # CT/ModelOpt packed layout is linear (non-swizzled) after loader rename.
     w_hp = dequantize_to_dtype(


### PR DESCRIPTION
## Summary

Enables **NVFP4 on Tesla V100 (SM70)** for Qwen3.6-class models:

1. **ModelOpt W4A16 NVFP4 admit** — `get_min_capability` **75 → 70**; wire through `sm70_turbomind`.
2. **Hybrid linear attention policy** — GDN `linear_attn` linears; default `tm`, stamp + env override, dequant path.
3. **W4A4-on-disk weight path** — CT/ModelOpt weight-only / W4A16 semantics; acts remain half (logged).
4. **MoE NVFP4 SM70 compat** — auto-select prefers **Marlin then EMULATION**.
5. **Medium/TC scale convention fix** — tiny block-scale GPTQ exports no longer under-scale through TM (`block * 1/G`); detect `max|weight_scale| < 1` and skip global factor. Fixes token salad on Medium/TC NVFP4 while keeping Aggressive path unchanged.

### Medium/TC NVFP4 (important)

Field check: Aggressive and Medium share the same CT schema, but **block-scale ranges differ** (Aggressive ~O(10–448), Medium GPTQ ~O(1e-3)). SM70 prepare does `block * global` after CT stores `global=1/disk_global`, so Medium was under-scaled by ~G. Load-time convention detect fixes serve without requant.

Validated on pve3: `grok-medium2-nvfp4` equivalent fix → **Paris** + **17×19=323**.

### Hybrid policy

Env `VLLM_SM70_NVFP4_LINEAR_ATTN` → stamp `quantization_config.sm70_linear_attn` → default **`tm`**.

### MoE SM70

Marlin → EMULATION first on Volta. Not a native `nvfp4_moe_*` kernel.

## Serve (dense)

```bash
export VLLM_SM70_FLASH_ATTN_V100=1
export VLLM_SM70_QUANT_BACKEND=turbomind
export VLLM_SM70_NVFP4_TURBOMIND=1
# Medium/TC NVFP4: no special env needed after scale fix
python -m vllm.entrypoints.openai.api_server \
  --model <nvfp4-checkpoint> --trust-remote-code --dtype half \
  --attention-backend FLASH_ATTN_V100 -tp 2 --max-num-seqs 1 \
  --kv-cache-dtype fp8_e5m2
```

## Tests

- `tests/quantization/test_sm70_nvfp4_scale_convention.py` (combine helpers)
- `tests/quantization/test_sm70_nvfp4_moe_fallback.py` (MoE + W4A4 routing)
- pve3: 14 passed; live medium2 Paris/math smoke with scale fix

## Out of scope

- True W4A4 act-quant on SM70
- Native `nvfp4_moe_*` SASS kernels
- Changing quant export to unify CT conventions at source (optional follow-up)
