### PR TITLE
[Benchmark] Correct SM70 FP8 dense hotspot timing

### DIFF
--- a/benchmarks/benchmark_sm70_deepseek_v4_fp8_dense.py
+++ b/benchmarks/benchmark_sm70_deepseek_v4_fp8_dense.py
@@ -8,6 +8,7 @@ import argparse
 import hashlib
 import json
 import statistics
+from collections.abc import Callable
 from dataclasses import asdict, dataclass
 from pathlib import Path
 
@@ -56,7 +57,30 @@ def _time_graph(graph: torch.cuda.CUDAGraph, replays: int, repeats: int) -> list
     return samples_ms
 
 
-def _measure(shape: Shape, replays: int, repeats: int) -> dict[str, object]:
+def _profile_graph_replay(graph: torch.cuda.CUDAGraph) -> None:
+    cudart = torch.cuda.cudart()
+    cudart.cudaProfilerStart()
+    graph.replay()
+    torch.cuda.synchronize()
+    cudart.cudaProfilerStop()
+
+
+def _capture_graph(run: Callable[[], None]) -> torch.cuda.CUDAGraph:
+    capture_stream = torch.cuda.Stream()
+    capture_stream.wait_stream(torch.cuda.current_stream())
+    with torch.cuda.stream(capture_stream):
+        run()
+    capture_stream.synchronize()
+
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph, stream=capture_stream):
+        run()
+    return graph
+
+
+def _measure(
+    shape: Shape, replays: int, repeats: int, profile_replay: bool
+) -> dict[str, object]:
     qweight = torch.randn((shape.n, shape.k), device="cuda", dtype=torch.float16).to(
         torch.float8_e4m3fn
     )
@@ -79,15 +103,19 @@ def _measure(shape: Shape, replays: int, repeats: int) -> dict[str, object]:
         )
     torch.cuda.synchronize()
 
-    graph = torch.cuda.CUDAGraph()
-    with torch.cuda.graph(graph):
+    def run_graph() -> None:
         sm70_ops.fp8_gemm_sm70_out_meta(
             graph_out, x, weight, tm_scales, meta, shape.gated_silu
         )
+
+    graph = _capture_graph(run_graph)
     graph.replay()
     torch.cuda.synchronize()
     equal = torch.equal(direct, graph_out)
     max_abs = float((direct.float() - graph_out.float()).abs().max().item())
+
+    if profile_replay:
+        _profile_graph_replay(graph)
 
     samples_ms = _time_graph(graph, replays, repeats)
 
@@ -152,12 +180,8 @@ def _measure_split_parity(replays: int, repeats: int) -> dict[str, object]:
         run_split()
     torch.cuda.synchronize()
 
-    fused_graph = torch.cuda.CUDAGraph()
-    with torch.cuda.graph(fused_graph):
-        run_fused()
-    split_graph = torch.cuda.CUDAGraph()
-    with torch.cuda.graph(split_graph):
-        run_split()
+    fused_graph = _capture_graph(run_fused)
+    split_graph = _capture_graph(run_split)
     fused_graph.replay()
     split_graph.replay()
     torch.cuda.synchronize()
@@ -187,6 +211,7 @@ def main() -> int:
     parser.add_argument("--json-out", type=Path, required=True)
     parser.add_argument("--replays", type=int, default=1000)
     parser.add_argument("--repeats", type=int, default=5)
+    parser.add_argument("--profile-replay", action="store_true")
     parser.add_argument("--seed", type=int, default=20260802)
     parser.add_argument(
         "--name", choices=[shape.name for shape in SHAPES + DIAGNOSTIC_SHAPES]
@@ -213,7 +238,10 @@ def main() -> int:
     )
     if args.name is None:
         selected_shapes = SHAPES
-    results = [_measure(shape, args.replays, args.repeats) for shape in selected_shapes]
+    results = [
+        _measure(shape, args.replays, args.repeats, args.profile_replay)
+        for shape in selected_shapes
+    ]
     projected_ms = sum(float(item["projected_ms_per_token"]) for item in results)
     failures = [item["name"] for item in results if not item["graph_equal"]]
     payload = {

--- a/benchmarks/benchmark_sm70_deepseek_v4_fp8_weight_entropy.py
+++ b/benchmarks/benchmark_sm70_deepseek_v4_fp8_weight_entropy.py
@@ -1,0 +1,177 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Measure lossless-compression headroom in DeepSeek V4 FP8 dense weights."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+from pathlib import Path
+from typing import Any
+
+import torch
+from safetensors import safe_open
+
+DEFAULT_WEIGHTS = (
+    "layers.2.attn.wq_a.weight",
+    "layers.2.attn.wkv.weight",
+    "layers.2.attn.wq_b.weight",
+    "layers.2.attn.wo_a.weight",
+    "layers.2.attn.wo_b.weight",
+    "layers.2.ffn.shared_experts.w1.weight",
+    "layers.2.ffn.shared_experts.w3.weight",
+    "layers.2.ffn.shared_experts.w2.weight",
+    "layers.2.attn.indexer.wq_b.weight",
+)
+BLOCK = 128
+
+
+def _percentile(values: torch.Tensor, q: float) -> float:
+    return float(torch.quantile(values.to(torch.float32), q).item())
+
+
+def _sample_block_unique_counts(raw: torch.Tensor, max_blocks: int) -> torch.Tensor:
+    n, k = raw.shape
+    if n % BLOCK != 0 or k % BLOCK != 0:
+        return torch.empty(0, dtype=torch.int64)
+    blocks = (
+        raw.reshape(n // BLOCK, BLOCK, k // BLOCK, BLOCK)
+        .permute(0, 2, 1, 3)
+        .reshape(-1, BLOCK * BLOCK)
+    )
+    if max_blocks > 0 and blocks.shape[0] > max_blocks:
+        indices = torch.linspace(
+            0, blocks.shape[0] - 1, steps=max_blocks, dtype=torch.float64
+        ).round()
+        blocks = blocks.index_select(0, indices.to(torch.int64))
+
+    unique_counts: list[torch.Tensor] = []
+    for chunk in blocks.split(64):
+        ordered = torch.sort(chunk, dim=1).values
+        counts = 1 + (ordered[:, 1:] != ordered[:, :-1]).sum(dim=1)
+        unique_counts.append(counts)
+    return torch.cat(unique_counts)
+
+
+def _analyze_weight(weight: torch.Tensor, max_blocks: int) -> dict[str, Any]:
+    if weight.dtype != torch.float8_e4m3fn:
+        return {
+            "shape": list(weight.shape),
+            "dtype": str(weight.dtype),
+            "skip": "not_float8_e4m3fn",
+        }
+    if weight.ndim != 2:
+        return {
+            "shape": list(weight.shape),
+            "dtype": str(weight.dtype),
+            "skip": "not_2d",
+        }
+
+    raw = weight.contiguous().view(torch.uint8)
+    histogram = torch.bincount(raw.reshape(-1).to(torch.int64), minlength=256)
+    used = histogram > 0
+    probabilities = histogram[used].to(torch.float64) / raw.numel()
+    entropy_bits = float((-(probabilities * torch.log2(probabilities))).sum().item())
+    global_unique = int(used.sum().item())
+    global_fixed_bits = max(1, math.ceil(math.log2(global_unique)))
+    positive_zero_fraction = float(histogram[0].item() / raw.numel())
+    negative_zero_fraction = float(histogram[128].item() / raw.numel())
+
+    unique_counts = _sample_block_unique_counts(raw, max_blocks)
+    block_summary: dict[str, Any] = {"sampled_blocks": int(unique_counts.numel())}
+    if unique_counts.numel() > 0:
+        index_bits = torch.ceil(torch.log2(unique_counts.to(torch.float64))).clamp_min(
+            1
+        )
+        packed_bytes = (BLOCK * BLOCK * index_bits / 8).ceil() + unique_counts
+        block_summary.update(
+            {
+                "unique_min": int(unique_counts.min().item()),
+                "unique_p50": _percentile(unique_counts, 0.50),
+                "unique_p90": _percentile(unique_counts, 0.90),
+                "unique_p99": _percentile(unique_counts, 0.99),
+                "unique_max": int(unique_counts.max().item()),
+                "blocks_le_16_fraction": float(
+                    (unique_counts <= 16).to(torch.float32).mean().item()
+                ),
+                "blocks_le_32_fraction": float(
+                    (unique_counts <= 32).to(torch.float32).mean().item()
+                ),
+                "blocks_le_64_fraction": float(
+                    (unique_counts <= 64).to(torch.float32).mean().item()
+                ),
+                "blocks_le_128_fraction": float(
+                    (unique_counts <= 128).to(torch.float32).mean().item()
+                ),
+                "sampled_codebook_ratio": float(
+                    (packed_bytes / (BLOCK * BLOCK)).mean().item()
+                ),
+            }
+        )
+
+    top_counts, top_codes = torch.topk(histogram, 16)
+    return {
+        "shape": list(weight.shape),
+        "dtype": str(weight.dtype),
+        "numel": weight.numel(),
+        "global_unique_codes": global_unique,
+        "global_fixed_bits": global_fixed_bits,
+        "shannon_entropy_bits": entropy_bits,
+        "entropy_lower_bound_ratio": entropy_bits / 8,
+        "positive_zero_code_fraction": positive_zero_fraction,
+        "negative_zero_code_fraction": negative_zero_fraction,
+        "zero_value_fraction": positive_zero_fraction + negative_zero_fraction,
+        "top_codes": [
+            {
+                "code": int(code.item()),
+                "count": int(count.item()),
+                "fraction": float(count.item() / raw.numel()),
+            }
+            for count, code in zip(top_counts, top_codes, strict=True)
+        ],
+        "block_128x128": block_summary,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--model", type=Path, required=True)
+    parser.add_argument("--json-out", type=Path, required=True)
+    parser.add_argument("--weight", action="append", dest="weights")
+    parser.add_argument("--max-blocks", type=int, default=1024)
+    args = parser.parse_args()
+
+    index_path = args.model / "model.safetensors.index.json"
+    index = json.loads(index_path.read_text(encoding="utf-8"))
+    weight_map: dict[str, str] = index["weight_map"]
+    selected = tuple(args.weights or DEFAULT_WEIGHTS)
+    missing = [name for name in selected if name not in weight_map]
+    if missing:
+        raise KeyError(f"Weights missing from checkpoint index: {missing}")
+
+    results: dict[str, dict[str, Any]] = {}
+    for name in selected:
+        filename = weight_map[name]
+        with safe_open(args.model / filename, framework="pt", device="cpu") as handle:
+            results[name] = _analyze_weight(
+                handle.get_tensor(name), max_blocks=args.max_blocks
+            )
+
+    payload = {
+        "contract": {
+            "model": str(args.model),
+            "format": "lossless raw E4M3 code analysis",
+            "block": [BLOCK, BLOCK],
+            "max_sampled_blocks_per_weight": args.max_blocks,
+        },
+        "results": results,
+    }
+    args.json_out.parent.mkdir(parents=True, exist_ok=True)
+    args.json_out.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    print(json.dumps(payload, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/design/sm70_deepseek_v4_mxfp4_grouped_decode.md
+++ b/docs/design/sm70_deepseek_v4_mxfp4_grouped_decode.md
@@ -150,6 +150,23 @@ split epilogue work. Other model streams already consume the nominally idle
 SMs, so increasing this kernel's CTA count does not recover end-to-end wall
 time. The candidates are rejected before endpoint testing.
 
+## FP8 Lossless Packing Screen
+
+Real checkpoint weights rule out a fixed-width, per-block codebook as a useful
+way to reduce the FP8 weight stream. Across nine layer-2 dense projections,
+each complete weight uses 254 raw E4M3 codes. A sampled 128x128 block typically
+contains 191-215 unique codes and no sampled block contains at most 128 codes.
+The codebook plus 8-bit indices therefore consumes 1.012-1.013 times the raw
+weight size instead of compressing it.
+
+Global Shannon entropy is 6.51-6.66 bits per weight for most projections and
+6.95 bits for the indexer. That lower bound cannot be realized by the random,
+fixed-width accesses required by the HMMA main loop; Huffman or arithmetic
+decoding would add serial, irregular work on the critical path. Lossless FP8
+codebook/entropy packing is rejected. The next FP8 work must reduce execution
+overhead or improve the existing shared-memory path without changing weight
+values or accumulation order.
+
 ## Artifacts
 
 ```text
@@ -158,6 +175,7 @@ time. The candidates are rejected before endpoint testing.
   dsv4-mxfp4-direct-top6-clamp10-micro-20260802/
   dsv4-fp8-dense-shapes-20260802/
   dsv4-fp8-dense-ncu-20260803/
+  dsv4-sparse-mla-qk-dsplit-fullmodel-20260803/fp8_weight_entropy_layer2.json
   dsv4-sm70-kv-insert-parallel-micro-20260802/
   dsv4-tp8-stacked-mxfp4-fp8split-i1024-o256-20260802/
   dsv4-tp8-stacked-candidate-nsys-i1024-o128-20260802/

--- a/docs/design/sm70_deepseek_v4_mxfp4_grouped_decode.md
+++ b/docs/design/sm70_deepseek_v4_mxfp4_grouped_decode.md
@@ -83,6 +83,28 @@ Based on measured operator deltas, the current projection is approximately
 25.3 ms/token, or 39.5 tok/s. Only an unprofiled three-run TP8 result can replace
 that projection.
 
+## Latest Accepted Endpoint
+
+The accumulated TP8 1024/256 run measured 25.663779, 25.605544, and
+25.621125 ms/token. The accepted mean is **25.630149 ms/token**, or
+**39.01655 tok/s**. Relative to the original 33.853 ms/token baseline, this is
+a 24.3% TPOT reduction and a 32.1% decode-throughput increase.
+
+The latest graph-node trace attributes the following aggregate GPU service per
+token. These categories overlap across streams and are not additive wall-time
+savings.
+
+| Category | Service per token |
+|---|---:|
+| FP8 dense | 5.964 ms |
+| TP communication | 4.192 ms |
+| Sparse MLA | 3.448 ms |
+| mHC | 2.977 ms |
+| FP16 GEMV/compressor | 2.395 ms |
+| Routing | 2.134 ms |
+| MXFP4 | 1.979 ms |
+| Q/KV preparation | 1.364 ms |
+
 ## Rejected Paths
 
 | Path | Evidence | Decision |
@@ -97,6 +119,37 @@ The FP8 split result is the key scheduling lesson: service-time improvements
 on an auxiliary stream are invalid unless the full overlap timeline also
 shortens.
 
+## FP8 Dense CTA Screen
+
+The first exact-shape FP8 microbenchmark accidentally initialized the
+TurboMind workspace during CUDA Graph capture. Its replay therefore included
+workspace fill kernels and overestimated standalone FP8 service. The benchmark
+now warms the operation on the capture stream before capture and can delimit a
+single steady replay with `cudaProfilerStart`/`cudaProfilerStop`.
+
+With the corrected method, the six dense FP8 shapes project to 3.906 ms/token
+in isolation. The latest full-model trace reports 5.964 ms/token of aggregate
+FP8 service; the difference is multi-stream contention and profiling overhead,
+not extra model GEMMs.
+
+NCU on the main `M1 K4096 N1536` projection showed only 60 CTAs, 6.21% achieved
+occupancy, 82.76% scheduler cycles with no eligible warp, and 8.2-way average
+shared-load conflict. Exact `CTA_N=64/32` candidates increased the launch to
+120/240 CTAs and used the existing conflict-free `A[8,64]` shared layout. They
+were tested with the baseline `split-K=5`; allowing the tuner to choose
+`split-K=7` is not a quality-equivalent comparison.
+
+| Exact route | Median | Delta from CTA_N=128 |
+|---|---:|---:|
+| CTA_N=128, split-K=5 | 21.212 us | baseline |
+| CTA_N=64, split-K=5 | 22.558 us | +6.3% |
+| CTA_N=32, split-K=5 | 23.541 us | +11.0% |
+
+The smaller tiles duplicate activation/metadata traffic and add scheduling and
+split epilogue work. Other model streams already consume the nominally idle
+SMs, so increasing this kernel's CTA count does not recover end-to-end wall
+time. The candidates are rejected before endpoint testing.
+
 ## Artifacts
 
 ```text
@@ -104,6 +157,7 @@ shortens.
   dsv4-mxfp4-grouped-decode-micro-20260802/
   dsv4-mxfp4-direct-top6-clamp10-micro-20260802/
   dsv4-fp8-dense-shapes-20260802/
+  dsv4-fp8-dense-ncu-20260803/
   dsv4-sm70-kv-insert-parallel-micro-20260802/
   dsv4-tp8-stacked-mxfp4-fp8split-i1024-o256-20260802/
   dsv4-tp8-stacked-candidate-nsys-i1024-o128-20260802/
@@ -111,7 +165,8 @@ shortens.
 
 ## Remaining Gates
 
-1. Run one accumulated TP8 1024/256 three-seed endpoint benchmark.
-2. Verify route-hit logs and absence of the rejected FP8 split.
-3. Re-capture graph nodes and confirm the projected routing and SWA reductions.
-4. Run official-sampling text health and the model-specific quality gate.
+1. Finish official-sampling text health and the model-specific quality gate.
+2. Measure exposed, non-overlapped TP communication on the graph critical path.
+3. Screen a topology-aware TP8 collective only if its projected wall-time
+   saving exceeds 0.2 ms/token.
+4. Move to sparse MLA or mHC when the TP path is below that threshold.

--- a/docs/design/sm70_deepseek_v4_mxfp4_grouped_decode.md
+++ b/docs/design/sm70_deepseek_v4_mxfp4_grouped_decode.md
@@ -150,6 +150,25 @@ split epilogue work. Other model streams already consume the nominally idle
 SMs, so increasing this kernel's CTA count does not recover end-to-end wall
 time. The candidates are rejected before endpoint testing.
 
+NCU SASS attribution placed about 85% of the excessive shared wavefronts on
+the eight 128-bit A-fragment loads. An exact-shape experiment therefore kept
+the baseline `CTA_N=128` tactic and replaced only the A operand with the
+existing `A[8,64]` swizzle for all six real decode shapes. The extension was
+rebuilt from the same source as the runtime under test; earlier numbers from a
+stale build tree are invalid.
+
+| Run order | Baseline | A-swizzle | Projected saving |
+|---|---:|---:|---:|
+| baseline then candidate | 3.8835 ms/token | 3.8499 ms/token | 0.0336 ms/token |
+| candidate then baseline | 3.8885 ms/token | 3.8844 ms/token | 0.0041 ms/token |
+
+Both results are below the 0.2 ms/token admission threshold and the reverse
+run reduces the apparent gain to timer noise. Five shapes retained the same
+output SHA, but `fused_wqa_wkv` did not, so the candidate also fails the exact
+output contract. The source candidate was removed without endpoint testing.
+The shared conflict is real, but removing it does not materially shorten this
+kernel family at the current tactic and overlap schedule.
+
 ## FP8 Lossless Packing Screen
 
 Real checkpoint weights rule out a fixed-width, per-block codebook as a useful


### PR DESCRIPTION
## Purpose

Correct the DeepSeek-V4-Flash SM70 FP8 CUDA Graph microbenchmark and record the rejected exact CTA_N=64/32 screen. No unproven kernel is enabled.

Base/dependency: PR #164.

## Test Plan

- Warm the TurboMind workspace on the capture stream before graph capture
- Delimit a single steady replay for NSYS/NCU
- Hold split-K=5 constant when comparing CTA_N=128/64/32
- Keep direct-vs-graph output parity

## Test Result

- Corrected six-shape standalone projection: 3.906 ms/token
- CTA_N=128: 21.212 us
- CTA_N=64: 22.558 us (+6.3%)
- CTA_N=32: 23.541 us (+11.0%)
- Candidate kernels rejected before endpoint testing
- Ruff check/format and git diff --check pass