### PR TITLE
[SM70][MTP] Make dynamic draft-vocab cudagraph-capture-safe by default

### DIFF
--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -6,6 +6,7 @@ import copy
 import dataclasses
 import functools
 import json
+import os
 import sys
 from collections.abc import Callable
 from dataclasses import MISSING, asdict, dataclass, fields, is_dataclass
@@ -1784,6 +1785,25 @@ class EngineArgs:
         spec_method = self.speculative_config.get("method")
         if spec_method not in ("mtp", "dflash"):
             return
+
+        # SM70 dynamic draft-vocab keeps a per-step, LRU-mutated vocabulary tail
+        # (see v1/spec_decode/static_draft_vocab.py) whose shapes and device
+        # addresses change during decode. That is not CUDA-graph-capture-safe:
+        # under graph capture it corrupts the SM70 NVFP4 decode path into garbage
+        # output ("!!!!" / token salad), while --enforce-eager stays coherent.
+        # Default it off whenever cudagraphs are active so the static (fixed-shape)
+        # draft vocab is used. Probabilistic rejection sampling and its draft_probs
+        # are unaffected, so draft acceptance is preserved. Operators can force the
+        # dynamic vocab back on by setting the env var explicitly.
+        if (
+            not self.enforce_eager
+            and "VLLM_SM70_MTP_DYNAMIC_DRAFT_VOCAB_DEFAULT" not in os.environ
+        ):
+            os.environ["VLLM_SM70_MTP_DYNAMIC_DRAFT_VOCAB_DEFAULT"] = "0"
+            profile_updates.append(
+                "VLLM_SM70_MTP_DYNAMIC_DRAFT_VOCAB_DEFAULT=0 "
+                "(cudagraph-capture-safety; set explicitly to override)"
+            )
 
         if "draft_sample_method" not in self.speculative_config:
             # For SM70 native MTP, official Qwen sampling is non-greedy


### PR DESCRIPTION
## Summary

On SM70 (Tesla V100), the native-MTP serving defaults turn on
`VLLM_SM70_MTP_DYNAMIC_DRAFT_VOCAB_DEFAULT`, but the dynamic draft-vocab keeps a
**per-step, LRU-mutated vocabulary tail** (`v1/spec_decode/static_draft_vocab.py`
— `update_dynamic_draft_vocab_lru_state`, `sm70_dynamic_draft_vocab_update_tail_out`,
`compact_dynamic_draft_vocab_tail_state`) whose shapes and device addresses change
during decode. That is **not CUDA-graph-capture-safe**: under graph capture it
corrupts the SM70 NVFP4 decode path into garbage output (`!!!!` / token salad),
while `--enforce-eager` stays coherent.

This PR defaults the dynamic vocab **off when cudagraphs are active**
(`not enforce_eager`), so the static (fixed-shape) draft vocab is used. Probabilistic
rejection sampling and its `draft_probs` are unaffected, so **draft acceptance is
preserved**. Operators can still force the dynamic vocab on by setting the env var
explicitly, and behavior under `--enforce-eager` is unchanged.

## Symptom

NVFP4 (compressed-tensors, SM70 TurboMind) checkpoints serve:
- **coherent** under `--enforce-eager`
- **`!!!!` / multilingual token salad** under cudagraphs

…on an **identical wheel** (`_C.so` byte-for-byte match), identical overlay, and
identical checkpoint. Not the kernel, not the quantization, not the weights —
purely a graph-capture-safety issue in the dynamic draft-vocab.

## Root cause

`_maybe_apply_sm70_mtp_defaults` defaults `draft_sample_method="probabilistic"`,
which enables the dynamic draft-vocab. The dynamic path mutates its vocab tail every
decode step (LRU update / refresh / compact), producing variable shapes and addresses
that a captured CUDA graph replays incorrectly → corrupted decode.

## Fix

When cudagraphs are active and the operator has not set the env explicitly, default
`VLLM_SM70_MTP_DYNAMIC_DRAFT_VOCAB_DEFAULT=0`, falling back to the static
(fixed-shape) draft-vocab plan (`build_static_draft_vocab_tp_plan`). One-line
behavioral change, gated on `not self.enforce_eager`; explicit env always wins.

## Validation

Reproduced independently on two separate 2× Tesla V100 (SM70) hosts, NVFP4 27B + MTP:
- **Before:** garbage under cudagraphs; coherent only with `--enforce-eager`.
- **After (env off):** coherent under cudagraphs at full speed (~60 tok/s), draft
  acceptance unchanged.
