### PR TITLE
[Kernel] Stage SM70 MXFP4 grouped prefill

### DIFF
--- a/benchmarks/benchmark_sm70_mxfp4_moe_active_experts.py
+++ b/benchmarks/benchmark_sm70_mxfp4_moe_active_experts.py
@@ -149,29 +149,49 @@ def _validate_permute_contract(
         top_k, num_experts
     )
     workspace = torch.empty(workspace_size, dtype=torch.int8, device=device)
-
-    torch.ops._moe_C.moe_permute_with_scratch(
-        x,
-        topk_ids,
-        token_expert_indices,
-        None,
-        num_experts,
-        num_experts,
-        top_k,
-        permuted_input,
-        expert_offsets64,
-        inv_permuted_idx,
-        permuted_idx,
-        workspace,
-        permuted_experts_id,
-        sorted_row_idx,
-        topk_ids_for_sort,
-    )
-    expert_offsets = expert_offsets64.to(torch.int32)
+    expert_offsets = torch.empty(num_experts + 1, dtype=torch.int32, device=device)
     dense_ids = torch.arange(num_experts, dtype=torch.int32, device=device)
     compact_offsets = torch.arange(top_k + 1, dtype=torch.int32, device=device)
     dense_out = torch.empty(top_k, shape.n, dtype=torch.float16, device=device)
     active_out = torch.empty_like(dense_out)
+
+    def permute_call() -> None:
+        permuted_idx.fill_(top_k)
+        torch.ops._moe_C.moe_permute_with_scratch(
+            x,
+            topk_ids,
+            token_expert_indices,
+            None,
+            num_experts,
+            num_experts,
+            top_k,
+            permuted_input,
+            expert_offsets64,
+            inv_permuted_idx,
+            permuted_idx,
+            workspace,
+            permuted_experts_id,
+            sorted_row_idx,
+            topk_ids_for_sort,
+        )
+        expert_offsets.copy_(expert_offsets64, non_blocking=True)
+
+    def active_graph_call() -> None:
+        permute_call()
+        sm70_ops.mxfp4_moe_dense_stage_sm70_out(
+            active_out,
+            permuted_input,
+            compact_offsets,
+            permuted_experts_id,
+            ptrs_w,
+            ptrs_s,
+            top_k,
+            shape.k,
+            shape.n,
+            32,
+        )
+
+    permute_call()
     sm70_ops.mxfp4_moe_dense_stage_sm70_out(
         dense_out,
         permuted_input,
@@ -184,29 +204,61 @@ def _validate_permute_contract(
         shape.n,
         32,
     )
+    active_graph_call()
+    torch.cuda.synchronize()
+    expected_sorted = sorted(route)
+    actual_sorted = permuted_experts_id.cpu().tolist()
+    initial_equal = torch.equal(dense_out, active_out)
+    initial_max_abs = float((dense_out - active_out).abs().max().item())
+
+    graph = _capture(active_graph_call)
+    route_a_graph_out = active_out.clone()
+    route_b = [1, 9, 63, 111, 177, 240]
+    topk_ids.copy_(torch.tensor([route_b], dtype=torch.int32, device=device))
+    graph.replay()
+    torch.cuda.synchronize()
+    route_b_graph_out = active_out.clone()
+    graph_sorted = permuted_experts_id.cpu().tolist()
+
+    permute_call()
     sm70_ops.mxfp4_moe_dense_stage_sm70_out(
-        active_out,
+        dense_out,
         permuted_input,
-        compact_offsets,
-        permuted_experts_id,
+        expert_offsets,
+        dense_ids,
         ptrs_w,
         ptrs_s,
-        top_k,
+        num_experts,
         shape.k,
         shape.n,
         32,
     )
     torch.cuda.synchronize()
-    expected_sorted = sorted(route)
-    actual_sorted = permuted_experts_id.cpu().tolist()
+    graph_equal = torch.equal(dense_out, route_b_graph_out)
+    graph_max_abs = float((dense_out - route_b_graph_out).abs().max().item())
+    graph_route_changes_output = not torch.equal(route_a_graph_out, route_b_graph_out)
     result = {
-        "bitwise_equal": torch.equal(dense_out, active_out),
-        "max_abs": float((dense_out - active_out).abs().max().item()),
+        "bitwise_equal": initial_equal,
+        "max_abs": initial_max_abs,
         "expected_sorted_expert_ids": expected_sorted,
         "actual_sorted_expert_ids": actual_sorted,
         "sorted_expert_ids_match": actual_sorted == expected_sorted,
+        "full_graph_dynamic_replay_bitwise_equal": graph_equal,
+        "full_graph_dynamic_replay_max_abs": graph_max_abs,
+        "full_graph_expected_sorted_expert_ids": sorted(route_b),
+        "full_graph_actual_sorted_expert_ids": graph_sorted,
+        "full_graph_sorted_expert_ids_match": graph_sorted == sorted(route_b),
+        "full_graph_dynamic_route_changes_output": graph_route_changes_output,
     }
-    if not result["bitwise_equal"] or not result["sorted_expert_ids_match"]:
+    if not all(
+        (
+            result["bitwise_equal"],
+            result["sorted_expert_ids_match"],
+            result["full_graph_dynamic_replay_bitwise_equal"],
+            result["full_graph_sorted_expert_ids_match"],
+            result["full_graph_dynamic_route_changes_output"],
+        )
+    ):
         raise RuntimeError(f"MXFP4 permute contract gate failed: {result}")
     return result
 

--- a/benchmarks/benchmark_sm70_mxfp4_moe_prefill.py
+++ b/benchmarks/benchmark_sm70_mxfp4_moe_prefill.py
@@ -1,0 +1,252 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Check SM70 MXFP4 MoE prefill latency and repeatability.
+
+The default shape models one DeepSeek-V4-Flash TP8 MoE stage after routing:
+1024 prompt tokens, top-k=6, and 256 evenly populated experts. The benchmark
+keeps all inputs and routing metadata fixed so any output drift is an operator
+correctness failure rather than a routing or sampling effect.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from dataclasses import dataclass
+
+import torch
+
+from vllm import _sm70_ops as sm70_ops
+
+
+@dataclass(frozen=True)
+class StageShape:
+    name: str
+    k: int
+    n: int
+
+
+STAGES = {
+    "w13": StageShape("w13", 4096, 512),
+    "w2": StageShape("w2", 256, 4096),
+}
+
+
+def _expert_pattern(num_experts: int, device: torch.device) -> torch.Tensor:
+    nibble = torch.arange(num_experts, dtype=torch.int32, device=device) & 0xF
+    pattern = nibble.clone()
+    for shift in range(4, 32, 4):
+        pattern |= nibble << shift
+    return pattern
+
+
+def _require_sm70() -> None:
+    if not torch.cuda.is_available():
+        raise RuntimeError("CUDA is required")
+    major, minor = torch.cuda.get_device_capability()
+    if (major, minor) != (7, 0):
+        raise RuntimeError(f"This benchmark requires SM70, got SM{major}{minor}")
+    for op_name in (
+        "mxfp4_sm70_prepare",
+        "mxfp4_moe_dense_stage_sm70_out",
+        "awq_moe_build_strided_ptrs",
+    ):
+        if not hasattr(torch.ops._C, op_name):
+            raise RuntimeError(f"Required operator is missing: _C::{op_name}")
+
+
+def _prepare_experts(
+    shape: StageShape, num_experts: int, device: torch.device
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    qweight = torch.randint(
+        0,
+        16,
+        (shape.k, shape.n),
+        dtype=torch.uint8,
+        device=device,
+    )
+    scales = torch.full(
+        (shape.k // 32, shape.n),
+        127,
+        dtype=torch.uint8,
+        device=device,
+    )
+    weight, prepared_scales, meta = sm70_ops.mxfp4_sm70_prepare(qweight, scales, 32)
+    weights = weight.unsqueeze(0).repeat(num_experts, 1, 1)
+    weights.bitwise_xor_(_expert_pattern(num_experts, device)[:, None, None])
+    expert_scales = prepared_scales.unsqueeze(0).repeat(num_experts, 1, 1)
+    ptrs_w, ptrs_s = sm70_ops.awq_moe_build_strided_ptrs(
+        weights,
+        expert_scales,
+        int(meta[0].item()),
+        int(meta[1].item()),
+        num_experts,
+    )
+    return weights, expert_scales, ptrs_w, ptrs_s
+
+
+def _run_stage(
+    shape: StageShape,
+    *,
+    prompt_tokens: int,
+    top_k: int,
+    num_experts: int,
+    repeats: int,
+    zero_output: bool,
+    route: str,
+    seed: int,
+) -> dict[str, object]:
+    routed_rows = prompt_tokens * top_k
+    if routed_rows % num_experts != 0:
+        raise ValueError("prompt_tokens * top_k must be divisible by num_experts")
+
+    torch.manual_seed(seed)
+    device = torch.device("cuda")
+    weights, scales, ptrs_w, ptrs_s = _prepare_experts(shape, num_experts, device)
+    input_tensor = (
+        torch.randn(routed_rows, shape.k, dtype=torch.float16, device=device) * 0.01
+    )
+    output = torch.empty(routed_rows, shape.n, dtype=torch.float16, device=device)
+    rows_per_expert = routed_rows // num_experts
+    expert_offsets = torch.arange(
+        0,
+        routed_rows + 1,
+        rows_per_expert,
+        dtype=torch.int32,
+        device=device,
+    )
+    dense_ids = torch.arange(num_experts, dtype=torch.int32, device=device)
+
+    def call() -> None:
+        if zero_output:
+            output.zero_()
+        sm70_ops.mxfp4_moe_dense_stage_sm70_out(
+            output,
+            input_tensor,
+            expert_offsets,
+            dense_ids,
+            ptrs_w,
+            ptrs_s,
+            num_experts,
+            shape.k,
+            shape.n,
+            32,
+        )
+
+    def measure(grouped: bool) -> tuple[dict[str, object], torch.Tensor]:
+        os.environ["VLLM_SM70_MXFP4_MOE_GROUPED_PREFILL"] = "1" if grouped else "0"
+        reference: torch.Tensor | None = None
+        times_ms: list[float] = []
+        bitwise_by_repeat: list[bool] = []
+        max_abs_by_repeat: list[float] = []
+        for _ in range(repeats):
+            start = torch.cuda.Event(enable_timing=True)
+            end = torch.cuda.Event(enable_timing=True)
+            start.record()
+            call()
+            end.record()
+            end.synchronize()
+            times_ms.append(start.elapsed_time(end))
+            if reference is None:
+                reference = output.clone()
+            else:
+                bitwise_by_repeat.append(torch.equal(output, reference))
+                max_abs_by_repeat.append(float((output - reference).abs().max().item()))
+        assert reference is not None
+        return (
+            {
+                "route": "grouped" if grouped else "legacy_loop",
+                "times_ms": times_ms,
+                "repeat_bitwise": bitwise_by_repeat,
+                "repeat_max_abs": max_abs_by_repeat,
+                "all_repeats_bitwise": all(bitwise_by_repeat),
+            },
+            reference,
+        )
+
+    route_results: list[dict[str, object]] = []
+    references: list[torch.Tensor] = []
+    if route in ("legacy", "compare"):
+        legacy_result, legacy_reference = measure(False)
+        route_results.append(legacy_result)
+        references.append(legacy_reference)
+    if route in ("grouped", "compare"):
+        grouped_result, grouped_reference = measure(True)
+        route_results.append(grouped_result)
+        references.append(grouped_reference)
+
+    cross_route_bitwise = None
+    cross_route_max_abs = None
+    if route == "compare":
+        cross_route_bitwise = torch.equal(references[0], references[1])
+        cross_route_max_abs = float((references[0] - references[1]).abs().max().item())
+
+    # Keep owning tensors alive until all asynchronous pointer-table uses finish.
+    torch.cuda.synchronize()
+    del weights, scales
+    return {
+        "stage": shape.name,
+        "prompt_tokens": prompt_tokens,
+        "top_k": top_k,
+        "routed_rows": routed_rows,
+        "num_experts": num_experts,
+        "rows_per_expert": rows_per_expert,
+        "zero_output": zero_output,
+        "route_results": route_results,
+        "cross_route_bitwise": cross_route_bitwise,
+        "cross_route_max_abs": cross_route_max_abs,
+    }
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--stage", choices=("w13", "w2", "both"), default="both")
+    parser.add_argument("--prompt-tokens", type=int, default=1024)
+    parser.add_argument("--top-k", type=int, default=6)
+    parser.add_argument("--num-experts", type=int, default=256)
+    parser.add_argument("--repeats", type=int, default=10)
+    parser.add_argument("--zero-output", action="store_true")
+    parser.add_argument(
+        "--route",
+        choices=("legacy", "grouped", "compare"),
+        default="legacy",
+    )
+    parser.add_argument("--seed", type=int, default=29)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    if args.repeats < 3:
+        raise ValueError("--repeats must be at least 3")
+    _require_sm70()
+    selected = STAGES.values() if args.stage == "both" else (STAGES[args.stage],)
+    results = [
+        _run_stage(
+            shape,
+            prompt_tokens=args.prompt_tokens,
+            top_k=args.top_k,
+            num_experts=args.num_experts,
+            repeats=args.repeats,
+            zero_output=args.zero_output,
+            route=args.route,
+            seed=args.seed + index,
+        )
+        for index, shape in enumerate(selected)
+    ]
+    print(
+        json.dumps(
+            {
+                "benchmark": "sm70_mxfp4_moe_prefill_repeatability",
+                "device": torch.cuda.get_device_name(),
+                "results": results,
+            },
+            indent=2,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmarks/benchmark_sm70_openai_stream_request.py
+++ b/benchmarks/benchmark_sm70_openai_stream_request.py
@@ -1,0 +1,127 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Issue one timed OpenAI completions request for SM70 Nsight captures."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import statistics
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+
+def _post(url: str, payload: dict[str, object] | None = None):
+    data = None if payload is None else json.dumps(payload).encode()
+    request = urllib.request.Request(
+        url,
+        data=data,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    return urllib.request.urlopen(request, timeout=900)
+
+
+def _percentile(values: list[float], percentile: float) -> float | None:
+    if not values:
+        return None
+    ordered = sorted(values)
+    index = (len(ordered) - 1) * percentile
+    lower = int(index)
+    upper = min(lower + 1, len(ordered) - 1)
+    fraction = index - lower
+    return ordered[lower] * (1 - fraction) + ordered[upper] * fraction
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--base-url", default="http://127.0.0.1:18080")
+    parser.add_argument("--model", default="deepseek-v4-flash")
+    parser.add_argument("--prompt-file", type=Path, required=True)
+    parser.add_argument("--max-tokens", type=int, required=True)
+    parser.add_argument("--temperature", type=float, default=1.0)
+    parser.add_argument("--top-p", type=float, default=1.0)
+    parser.add_argument("--seed", type=int, default=4111)
+    parser.add_argument("--out", type=Path, required=True)
+    parser.add_argument("--profile", action="store_true")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    if args.profile:
+        with _post(f"{args.base_url}/start_profile") as response:
+            response.read()
+
+    payload = {
+        "model": args.model,
+        "prompt": args.prompt_file.read_text(),
+        "max_tokens": args.max_tokens,
+        "temperature": args.temperature,
+        "top_p": args.top_p,
+        "seed": args.seed,
+        "stream": True,
+        "stream_options": {"include_usage": True},
+    }
+    started = time.perf_counter()
+    token_times: list[float] = []
+    output_parts: list[str] = []
+    usage = None
+    finish_reason = None
+    with _post(f"{args.base_url}/v1/completions", payload) as response:
+        for raw_line in response:
+            line = raw_line.decode().strip()
+            if not line.startswith("data: ") or line == "data: [DONE]":
+                continue
+            event = json.loads(line[6:])
+            if event.get("usage"):
+                usage = event["usage"]
+            for choice in event.get("choices", []):
+                text = choice.get("text", "")
+                if text:
+                    token_times.append(time.perf_counter())
+                    output_parts.append(text)
+                if choice.get("finish_reason") is not None:
+                    finish_reason = choice["finish_reason"]
+    finished = time.perf_counter()
+
+    intervals_ms = [
+        (right - left) * 1000
+        for left, right in zip(token_times, token_times[1:], strict=False)
+    ]
+    result = {
+        "contract": {
+            "max_output_tokens": args.max_tokens,
+            "temperature": args.temperature,
+            "top_p": args.top_p,
+            "seed": args.seed,
+        },
+        "usage": usage,
+        "stream_chunks": len(token_times),
+        "finish_reason": finish_reason,
+        "generation_wall_ms": (finished - started) * 1000,
+        "ttft_ms": (token_times[0] - started) * 1000 if token_times else None,
+        "trace_tpot_mean_ms": (statistics.mean(intervals_ms) if intervals_ms else None),
+        "trace_tpot_p50_ms": _percentile(intervals_ms, 0.50),
+        "trace_tpot_p90_ms": _percentile(intervals_ms, 0.90),
+        "trace_tpot_p99_ms": _percentile(intervals_ms, 0.99),
+        "output": "".join(output_parts),
+        "profile_stop_result": None,
+    }
+    args.out.write_text(json.dumps(result, ensure_ascii=False, indent=2))
+
+    if args.profile:
+        try:
+            with _post(f"{args.base_url}/stop_profile") as response:
+                result["profile_stop_result"] = response.read().decode()
+        except (urllib.error.URLError, TimeoutError, ConnectionError) as exc:
+            result["profile_stop_result"] = f"{type(exc).__name__}: {exc}"
+        args.out.write_text(json.dumps(result, ensure_ascii=False, indent=2))
+    print(json.dumps(result, ensure_ascii=False, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/csrc/sm70_turbomind/ops/awq_sm70_gemm.cu
+++ b/csrc/sm70_turbomind/ops/awq_sm70_gemm.cu
@@ -1067,6 +1067,12 @@ bool mxfp4_tune_small_shapes_enabled() {
   return raw == nullptr || std::atoi(raw) != 0;
 }
 
+bool mxfp4_moe_grouped_prefill_enabled() {
+  const char* raw =
+      std::getenv("VLLM_SM70_MXFP4_MOE_GROUPED_PREFILL");
+  return raw != nullptr && std::atoi(raw) != 0;
+}
+
 bool nvfp4_tune_small_shapes_enabled() {
   const char* raw = std::getenv("VLLM_SM70_NVFP4_TUNE_SMALL_SHAPES");
   return raw == nullptr || std::atoi(raw) != 0;
@@ -7289,6 +7295,13 @@ void mxfp4_moe_dense_stage_sm70_out(
       logged_mxfp4_dense_stage,
       "SM70 MXFP4 MoE CUDA-graph-safe dense-stage path enabled C++ op reached",
       input, input.size(0), num_experts);
+  if (vllm::awq_sm70::mxfp4_moe_grouped_prefill_enabled() &&
+      input.size(0) >= num_experts) {
+    mxfp4_moe_gemm_sm70_out_impl(out, input, expert_offsets, ptrs_w, ptrs_s,
+                                 num_experts, k, n, group_size,
+                                 dense_expert_ids);
+    return;
+  }
   for (int expert = 0; expert < static_cast<int>(num_experts); ++expert) {
     torch::Tensor offsets = expert_offsets.narrow(0, expert, 2);
     torch::Tensor expert_idx = dense_expert_ids.narrow(0, expert, 1);

--- a/docs/design/sm70_deepseek_v4_mxfp4_grouped_prefill.md
+++ b/docs/design/sm70_deepseek_v4_mxfp4_grouped_prefill.md
@@ -1,0 +1,23 @@
+# SM70 DeepSeek V4 MXFP4 Grouped Prefill
+
+## Scope
+
+This WIP routes populated prefill experts through one TurboMind grouped MoE
+launch instead of the per-expert loop. The route is opt-in through
+`VLLM_SM70_MXFP4_MOE_GROUPED_PREFILL=1` and is based on the accepted active
+expert branch `2872c6a3af4897fc59855b8a59310fa3789ab5fc`.
+
+The branch also strengthens the CUDA Graph dynamic-route contract benchmark
+and adds focused operator and streaming endpoint benchmark drivers.
+
+## Current Gate
+
+Python compile, Ruff, Ruff format, and `git diff --check` pass. The C++ route
+has not yet been rebuilt and run on the TP8 V100 host, so there is no numerical,
+prefill, or endpoint performance claim.
+
+## Status
+
+Keep the route disabled and the PR in Draft. Promotion requires a grouped vs.
+legacy operator exactness comparison, repeatability across routing patterns,
+and a matched 1K prefill endpoint A/B with decode held constant.

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -194,6 +194,7 @@ if TYPE_CHECKING:
     VLLM_SM70_NVFP4_TURBOMIND: bool = True
     VLLM_SM70_MXFP4_TURBOMIND: bool = True
     VLLM_SM70_MXFP4_MOE_ACTIVE_EXPERT_B1: bool = False
+    VLLM_SM70_MXFP4_MOE_GROUPED_PREFILL: bool = False
     VLLM_SM70_FP8_MOE_DEQUANT_FALLBACK: bool = False
     VLLM_SM70_FP8_MOE_BATCHED_GEMM: bool = True
     VLLM_SM70_FP8_MOE_BATCHED_W13_PER_EXPERT_DISPATCH: bool = False
@@ -1816,6 +1817,11 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # device tensors and can change between CUDA Graph replays.
     "VLLM_SM70_MXFP4_MOE_ACTIVE_EXPERT_B1": lambda: bool(
         int(os.getenv("VLLM_SM70_MXFP4_MOE_ACTIVE_EXPERT_B1", "0"))
+    ),
+    # Process all populated prefill experts in one TurboMind grouped launch.
+    # Keep this opt-in until the exact operator and model quality gates pass.
+    "VLLM_SM70_MXFP4_MOE_GROUPED_PREFILL": lambda: bool(
+        int(os.getenv("VLLM_SM70_MXFP4_MOE_GROUPED_PREFILL", "0"))
     ),
     # FP8 caller for the generic SM70 TurboMind active-source-group compact
     # decode path. The backend scheduler keeps source expert group semantics


### PR DESCRIPTION
## Purpose

Preserve and review the in-progress SM70 DeepSeek V4 MXFP4 grouped-prefill route without adding it to the accepted active-expert PR.

Base SHA: `2872c6a3af4897fc59855b8a59310fa3789ab5fc`
Head SHA: `ea72ec086b`

## Implementation

- Route populated prefill experts through the existing TurboMind grouped MoE entry point.
- Keep the candidate opt-in behind `VLLM_SM70_MXFP4_MOE_GROUPED_PREFILL=1`.
- Strengthen the dynamic-routing CUDA Graph benchmark.
- Add operator-prefill and timed streaming endpoint benchmark drivers.

## Test Plan And Result

- `py_compile`, Ruff, Ruff format, and `git diff --check`: pass.
- GPU rebuild, numerical exactness, prefill A/B, and endpoint quality/performance: not run yet.

## Status

WIP Draft only. The default route is unchanged. Do not promote or enable until the TP8 V100 exactness, repeatability, matched prefill, and decode-neutrality gates pass.