### PR TITLE
[Core] Integrate DeepSeek V4 SM70 performance stack

### DIFF
--- a/docs/design/sm70_deepseek_v4_performance_integration.md
+++ b/docs/design/sm70_deepseek_v4_performance_integration.md
@@ -2,37 +2,45 @@
 
 ## Source Composition
 
-This Draft provides one reproducible Git tree for the current DeepSeek V4
+This branch provides one reproducible Git tree for the current DeepSeek V4
 Flash SM70 work. It starts from `onecat/main` at
-`270a468d112a628182c748c171ad002f44d79b21`, which already contains PRs
-`#159`, `#160`, and `#162`, then integrates:
+`3a12f4cef3ee3df911a24bf84c74f26a711f27a3`, which already contains PRs
+`#159`, `#160`, `#162`, and `#165`, then integrates:
 
 | PR | Scope |
 |---|---|
-| #165 | DeepSeek V4 DSpark N7 support |
 | #170 | Compact MXFP4 decode and skew-safe TP8 graph all-reduce |
 | #171 | Sparse MLA split-K and QK dimension split |
 | #175 | Exact SM70 FP16 GEMV and mHC FP32 staging |
 
-The component PRs remain the review and rollback boundaries. This branch does
-not replace them and must not be merged before their required quality gates.
+The component PRs remain the review and rollback boundaries. This branch is
+the exact build and endpoint validation target.
 
 ## Endpoint Evidence
 
-The matched TP8, 8 x V100, 1024-input/256-output, FP8 MLA KV, no-MTP, CUDA
-Graph endpoint A/B recorded by PR #175 measured:
+The exact `6f946b603a281c0e7ea6008108e7d25d04b8df5f` tree was built and run with
+TP8 on 8 x V100-SXM2-32GB, 1024 input tokens, 256 output tokens, FP8 MLA KV,
+no MTP, Breakable CUDA Graph, `temperature=1.0`, and `top_p=1.0`. Only
+`VLLM_SM70_DSV4_MHC_FP32_STAGE` changed between the matched sides.
 
 | Route | Median TPOT | Decode throughput |
 |---|---:|---:|
-| Combined stack, mHC route off | 20.764 ms/token | 48.16 token/s |
-| Combined stack, mHC route on | 19.366 ms/token | 51.64 token/s |
+| Exact stack, mHC route off | 20.401 ms/token | 49.02 token/s |
+| Exact stack, mHC route on | 19.457 ms/token | 51.40 token/s |
 
-This merge-only integration tree has not been rebuilt and rerun as one SHA.
-That exact-tree endpoint and official-sampling quality run remain mandatory
-before promotion.
+The candidate reduces median TPOT by 0.944 ms (4.63%) and raises decode
+throughput by 4.85%. The full SM70 extension linked after internalizing the
+header-defined TP8 reduce kernel. Ten TP8 collective tests and 24 FP16 GEMV,
+mHC, and DeepSeek V4 route tests passed. Runtime logs selected every requested
+SM70 route. The official-sampling three-prompt text-health suite passed; a
+separate concise chat request also stopped naturally. Long HTML requests hit
+their token limit without malformed tag prefixes, replacement characters, or
+code/natural-language contamination before truncation.
 
 ## Excluded Drafts
 
 PR #178 compressor state-save fusion and PR #179 MXFP4 grouped prefill remain
 default-off WIP screens and are intentionally excluded. Negative benchmark
-PRs remain separate documentation and do not alter this runtime tree.
+PRs remain separate documentation and do not alter this runtime tree. Sparse
+MLA, grouped MXFP4, TP8 hierarchical all-reduce, and FP16 GEMV stay opt-in
+until long-context, concurrency, and second-host promotion gates pass.

--- a/docs/design/sm70_deepseek_v4_performance_integration.md
+++ b/docs/design/sm70_deepseek_v4_performance_integration.md
@@ -1,0 +1,38 @@
+# SM70 DeepSeek V4 Performance Integration
+
+## Source Composition
+
+This Draft provides one reproducible Git tree for the current DeepSeek V4
+Flash SM70 work. It starts from `onecat/main` at
+`270a468d112a628182c748c171ad002f44d79b21`, which already contains PRs
+#159, #160, and #162, then integrates:
+
+| PR | Scope |
+|---|---|
+| #165 | DeepSeek V4 DSpark N7 support |
+| #170 | Compact MXFP4 decode and skew-safe TP8 graph all-reduce |
+| #171 | Sparse MLA split-K and QK dimension split |
+| #175 | Exact SM70 FP16 GEMV and mHC FP32 staging |
+
+The component PRs remain the review and rollback boundaries. This branch does
+not replace them and must not be merged before their required quality gates.
+
+## Endpoint Evidence
+
+The matched TP8, 8 x V100, 1024-input/256-output, FP8 MLA KV, no-MTP, CUDA
+Graph endpoint A/B recorded by PR #175 measured:
+
+| Route | Median TPOT | Decode throughput |
+|---|---:|---:|
+| Combined stack, mHC route off | 20.764 ms/token | 48.16 token/s |
+| Combined stack, mHC route on | 19.366 ms/token | 51.64 token/s |
+
+This merge-only integration tree has not been rebuilt and rerun as one SHA.
+That exact-tree endpoint and official-sampling quality run remain mandatory
+before promotion.
+
+## Excluded Drafts
+
+PR #178 compressor state-save fusion and PR #179 MXFP4 grouped prefill remain
+default-off WIP screens and are intentionally excluded. Negative benchmark
+PRs remain separate documentation and do not alter this runtime tree.

--- a/docs/design/sm70_deepseek_v4_performance_integration.md
+++ b/docs/design/sm70_deepseek_v4_performance_integration.md
@@ -5,7 +5,7 @@
 This Draft provides one reproducible Git tree for the current DeepSeek V4
 Flash SM70 work. It starts from `onecat/main` at
 `270a468d112a628182c748c171ad002f44d79b21`, which already contains PRs
-#159, #160, and #162, then integrates:
+`#159`, `#160`, and `#162`, then integrates:
 
 | PR | Scope |
 |---|---|


### PR DESCRIPTION
## Purpose

Provide one reproducible Git tree for the accepted DeepSeek V4 Flash SM70 performance stack while preserving the component PRs as independent review and rollback scopes.

Integration base: `3a12f4cef3ee3df911a24bf84c74f26a711f27a3`
Integration head: `aba28d33197d3b641a2edb9acbd7c331262b784d`
Exact runtime tree tested: `6f946b603a281c0e7ea6008108e7d25d04b8df5f`; the head differs only by the final evidence document.

## Composition

The current `main` already contains #159, #160, #162, and #165. This PR combines the remaining accepted branches:

- #163 and #171: sparse MLA split-K and QK dimension split.
- #164 and #170: compact MXFP4 decode and skew-safe TP8 CUDA Graph all-reduce.
- #168 and #175: fixed-shape FP16 GEMV and exact mHC FP32 staging.

The component PRs remain authoritative and are merged independently.

## Exact 8xV100 Validation

- Full SM70 `_C` build and link: passed after #170 internalized its header-defined TP8 reduce kernel.
- Focused tests: 10 TP8 custom all-reduce tests plus 24 FP16 GEMV, mHC, and DeepSeek V4 route tests passed.
- Dispatch: runtime logs selected SM70 FP8 TurboMind dense, MXFP4 active-expert/grouped decode, hierarchical custom all-reduce, sparse MLA SWA/C4/C128 QK-D split, FP16 GEMV, mHC FP32 staging, and Breakable CUDA Graph.
- Official-sampling text health: three chat prompts and 1536 generated tokens passed the automated suite; a concise chat request stopped naturally. HTML output showed no malformed tag prefixes, replacement characters, repetition collapse, or code/natural-language contamination before token-limit truncation.
- Exact 1K/256 A/B, TP8, FP8 MLA KV, no MTP, `temperature=1.0`, `top_p=1.0`, no `ignore_eos`:
  - mHC off: 20.4646 / 20.4009 / 20.3674 ms, median 20.4009 ms, 49.02 token/s.
  - mHC on: 19.4988 / 19.4463 / 19.4566 ms, median 19.4566 ms, 51.40 token/s.
  - Result: TPOT -0.9443 ms (-4.63%), decode throughput +4.85%.

`git diff --check`, conflict-marker audit, scoped Python compile/Ruff/format, DCO for all non-merge commits, and GitHub pre-run checks pass. Full-repository pre-commit still reports pre-existing main-wide debt outside this stack; the integration-specific findings were fixed.

## Exclusions And Risk

#178 compressor state-save fusion and #179 MXFP4 grouped prefill are default-off WIP screens and are intentionally excluded. Negative benchmark branches are also excluded. Sparse MLA, grouped MXFP4, TP8 hierarchical all-reduce, and FP16 GEMV remain opt-in pending long-context, concurrency, and second-host promotion gates.