### PR TITLE
[Kernel] Accelerate DeepSeek V4 SM70 prefill

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -321,6 +321,7 @@ set(VLLM_EXT_SRC
 
 if(VLLM_GPU_LANG STREQUAL "CUDA")
   list(APPEND VLLM_EXT_SRC
+    "csrc/deepseek_v4_sm70_sparse_attention.cu"
     "csrc/minimax_reduce_rms_kernel.cu")
 
   SET(CUTLASS_ENABLE_HEADERS_ONLY ON CACHE BOOL "Enable only the header library")

--- a/benchmarks/analyze_sm70_nsys_prefill.py
+++ b/benchmarks/analyze_sm70_nsys_prefill.py
@@ -49,7 +49,10 @@ def _category(name: str) -> str:
         )
     ):
         return "KV compression/indexer/rope"
-    if "sparse_gathered" in lower or "sparse_attn" in lower:
+    if any(
+        marker in lower
+        for marker in ("sparse_gathered", "sparse_attn", "sparse_attention_hmma")
+    ):
         return "SM70 sparse MLA/SWA attention"
     if any(
         marker in lower
@@ -100,6 +103,11 @@ def main() -> int:
     )
     parser.add_argument("--device", type=int)
     parser.add_argument("--top-kernels", type=int, default=20)
+    parser.add_argument(
+        "--kernel-filter",
+        help="Restrict the top-kernel table to names containing this substring.",
+    )
+    parser.add_argument("--full-kernel-names", action="store_true")
     args = parser.parse_args()
 
     connection = sqlite3.connect(args.sqlite)
@@ -228,16 +236,23 @@ def main() -> int:
 
     print("\nTop kernels by summed service time")
     print("service_ms  service_%  launches  launch geometry and kernel")
-    for signature, (duration, count) in sorted(
+    sorted_kernels = sorted(
         kernel_totals.items(), key=lambda item: item[1][0], reverse=True
-    )[: args.top_kernels]:
+    )
+    if args.kernel_filter:
+        needle = args.kernel_filter.lower()
+        sorted_kernels = [
+            item for item in sorted_kernels if needle in item[0][0].lower()
+        ]
+    for signature, (duration, count) in sorted_kernels[: args.top_kernels]:
         name, grid, block, registers, dynamic_smem = signature
         geometry = (
             f"grid={grid} block={block} regs={registers} dynamic_smem={dynamic_smem}B"
         )
         print(
             f"{duration / 1e6:>10.3f}  {duration / total_service_ns * 100:>8.2f}  "
-            f"{count:>8}  {geometry}  {_short_name(name)}"
+            f"{count:>8}  {geometry}  "
+            f"{name if args.full_kernel_names else _short_name(name)}"
         )
     return 0
 

--- a/benchmarks/analyze_sm70_nsys_prefill.py
+++ b/benchmarks/analyze_sm70_nsys_prefill.py
@@ -8,7 +8,20 @@ from __future__ import annotations
 import argparse
 import sqlite3
 from collections import defaultdict
+from dataclasses import dataclass
 from pathlib import Path
+
+
+@dataclass(frozen=True)
+class Kernel:
+    start: int
+    end: int
+    graph_node: int | None
+    name: str
+    grid: tuple[int, int, int]
+    block: tuple[int, int, int]
+    registers: int
+    dynamic_smem: int
 
 
 def _category(name: str) -> str:
@@ -93,32 +106,62 @@ def main() -> int:
     rows = list(
         connection.execute(
             """
-            SELECT k.deviceId, k.start, k.end, k.graphNodeId, s.value
+            SELECT k.deviceId, k.start, k.end, k.graphNodeId, s.value,
+                   k.gridX, k.gridY, k.gridZ,
+                   k.blockX, k.blockY, k.blockZ,
+                   k.registersPerThread, k.dynamicSharedMemory
             FROM CUPTI_ACTIVITY_KIND_KERNEL AS k
             JOIN StringIds AS s ON s.id = k.demangledName
             ORDER BY k.deviceId, k.start
             """
         )
     )
-    by_device: dict[int, list[tuple[int, int, int | None, str]]] = defaultdict(list)
-    for device, start, end, graph_node, name in rows:
-        by_device[device].append((start, end, graph_node, name))
+    by_device: dict[int, list[Kernel]] = defaultdict(list)
+    for (
+        device,
+        start,
+        end,
+        graph_node,
+        name,
+        grid_x,
+        grid_y,
+        grid_z,
+        block_x,
+        block_y,
+        block_z,
+        registers,
+        dynamic_smem,
+    ) in rows:
+        by_device[device].append(
+            Kernel(
+                start=start,
+                end=end,
+                graph_node=graph_node,
+                name=name,
+                grid=(grid_x, grid_y, grid_z),
+                block=(block_x, block_y, block_z),
+                registers=registers,
+                dynamic_smem=dynamic_smem,
+            )
+        )
 
-    selected: dict[int, list[tuple[int, int, str]]] = {}
+    selected: dict[int, list[Kernel]] = {}
     for device, kernels in by_device.items():
-        graph_starts = [start for start, _, graph, _ in kernels if graph is not None]
+        graph_starts = [
+            kernel.start for kernel in kernels if kernel.graph_node is not None
+        ]
         cutoff = min(graph_starts) if args.before_first_graph and graph_starts else None
         selected[device] = [
-            (start, end, name)
-            for start, end, graph, name in kernels
-            if (cutoff is None or (graph is None and end <= cutoff))
+            kernel
+            for kernel in kernels
+            if (cutoff is None or (kernel.graph_node is None and kernel.end <= cutoff))
         ]
 
     summaries = {}
     for device, kernels in selected.items():
         if not kernels:
             continue
-        intervals = [(start, end) for start, end, _ in kernels]
+        intervals = [(kernel.start, kernel.end) for kernel in kernels]
         start = min(item[0] for item in intervals)
         end = max(item[1] for item in intervals)
         summaries[device] = {
@@ -145,17 +188,33 @@ def main() -> int:
     if device is None:
         device = max(summaries, key=lambda item: summaries[item]["envelope_ns"])
     kernels = selected[device]
-    total_service_ns = sum(end - start for start, end, _ in kernels)
+    total_service_ns = sum(kernel.end - kernel.start for kernel in kernels)
 
     categories: dict[str, list[int]] = defaultdict(lambda: [0, 0])
-    kernel_totals: dict[str, list[int]] = defaultdict(lambda: [0, 0])
-    for start, end, name in kernels:
-        duration = end - start
-        category = _category(name)
+    kernel_totals: dict[
+        tuple[
+            str,
+            tuple[int, int, int],
+            tuple[int, int, int],
+            int,
+            int,
+        ],
+        list[int],
+    ] = defaultdict(lambda: [0, 0])
+    for kernel in kernels:
+        duration = kernel.end - kernel.start
+        category = _category(kernel.name)
         categories[category][0] += duration
         categories[category][1] += 1
-        kernel_totals[name][0] += duration
-        kernel_totals[name][1] += 1
+        signature = (
+            kernel.name,
+            kernel.grid,
+            kernel.block,
+            kernel.registers,
+            kernel.dynamic_smem,
+        )
+        kernel_totals[signature][0] += duration
+        kernel_totals[signature][1] += 1
 
     print(f"\nCritical device: {device}")
     print("category                            service_ms  service_%  launches")
@@ -168,13 +227,17 @@ def main() -> int:
         )
 
     print("\nTop kernels by summed service time")
-    print("service_ms  service_%  launches  kernel")
-    for name, (duration, count) in sorted(
+    print("service_ms  service_%  launches  launch geometry and kernel")
+    for signature, (duration, count) in sorted(
         kernel_totals.items(), key=lambda item: item[1][0], reverse=True
     )[: args.top_kernels]:
+        name, grid, block, registers, dynamic_smem = signature
+        geometry = (
+            f"grid={grid} block={block} regs={registers} dynamic_smem={dynamic_smem}B"
+        )
         print(
             f"{duration / 1e6:>10.3f}  {duration / total_service_ns * 100:>8.2f}  "
-            f"{count:>8}  {_short_name(name)}"
+            f"{count:>8}  {geometry}  {_short_name(name)}"
         )
     return 0
 

--- a/benchmarks/analyze_sm70_nsys_prefill.py
+++ b/benchmarks/analyze_sm70_nsys_prefill.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Summarize one SM70 prefill request from an Nsight Systems SQLite export."""
+
+from __future__ import annotations
+
+import argparse
+import sqlite3
+from collections import defaultdict
+from pathlib import Path
+
+
+def _category(name: str) -> str:
+    lower = name.lower()
+    if "turbomind::gemm" in lower and "fp4_e2m1_t" in lower:
+        return "TurboMind MXFP4 MoE GEMM"
+    if "turbomind::gemm" in lower and "__nv_fp8_e4m3" in lower:
+        return "TurboMind FP8 dense GEMM"
+    if "turbomind::gemm" in lower:
+        return "TurboMind other GEMM"
+    if "nccl" in lower:
+        return "NCCL collectives"
+    if "mhc_" in lower or "hc_prenorm" in lower or "hc_head" in lower:
+        return "mHC"
+    if any(
+        marker in lower
+        for marker in (
+            "kv_compress",
+            "insert_k",
+            "gather_k",
+            "slot_mapping",
+            "qnorm_rope",
+            "inverse_rope",
+            "save_partial_states",
+        )
+    ):
+        return "KV compression/indexer/rope"
+    if "sparse_gathered" in lower or "sparse_attn" in lower:
+        return "SM70 sparse MLA/SWA attention"
+    if any(
+        marker in lower
+        for marker in (
+            "moerouting",
+            "topkgating",
+            "experttoken",
+            "expertfirsttoken",
+            "expandinputrows",
+            "radixsort",
+        )
+    ):
+        return "MoE routing"
+    if any(marker in lower for marker in ("volta_", "cublas", "cutlass")):
+        return "FP16/CUTLASS GEMM"
+    if any(marker in lower for marker in ("rms_norm", "rmsnorm", "act_and_mul")):
+        return "Norm/activation"
+    if any(marker in lower for marker in ("argmax", "softmax")):
+        return "LM head/sample"
+    return "Other"
+
+
+def _union_ns(intervals: list[tuple[int, int]]) -> int:
+    if not intervals:
+        return 0
+    total = 0
+    current_start, current_end = sorted(intervals)[0]
+    for start, end in sorted(intervals)[1:]:
+        if start <= current_end:
+            current_end = max(current_end, end)
+        else:
+            total += current_end - current_start
+            current_start, current_end = start, end
+    return total + current_end - current_start
+
+
+def _short_name(name: str) -> str:
+    return name if len(name) <= 120 else name[:117] + "..."
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("sqlite", type=Path)
+    parser.add_argument(
+        "--before-first-graph",
+        action="store_true",
+        help="Exclude decode beginning at the first CUDA Graph kernel per GPU.",
+    )
+    parser.add_argument("--device", type=int)
+    parser.add_argument("--top-kernels", type=int, default=20)
+    args = parser.parse_args()
+
+    connection = sqlite3.connect(args.sqlite)
+    rows = list(
+        connection.execute(
+            """
+            SELECT k.deviceId, k.start, k.end, k.graphNodeId, s.value
+            FROM CUPTI_ACTIVITY_KIND_KERNEL AS k
+            JOIN StringIds AS s ON s.id = k.demangledName
+            ORDER BY k.deviceId, k.start
+            """
+        )
+    )
+    by_device: dict[int, list[tuple[int, int, int | None, str]]] = defaultdict(list)
+    for device, start, end, graph_node, name in rows:
+        by_device[device].append((start, end, graph_node, name))
+
+    selected: dict[int, list[tuple[int, int, str]]] = {}
+    for device, kernels in by_device.items():
+        graph_starts = [start for start, _, graph, _ in kernels if graph is not None]
+        cutoff = min(graph_starts) if args.before_first_graph and graph_starts else None
+        selected[device] = [
+            (start, end, name)
+            for start, end, graph, name in kernels
+            if (cutoff is None or (graph is None and end <= cutoff))
+        ]
+
+    summaries = {}
+    for device, kernels in selected.items():
+        if not kernels:
+            continue
+        intervals = [(start, end) for start, end, _ in kernels]
+        start = min(item[0] for item in intervals)
+        end = max(item[1] for item in intervals)
+        summaries[device] = {
+            "count": len(kernels),
+            "service_ns": sum(item[1] - item[0] for item in intervals),
+            "busy_ns": _union_ns(intervals),
+            "envelope_ns": end - start,
+        }
+
+    print("device  kernels  service_ms  busy_union_ms  envelope_ms  idle_gap_ms")
+    for device, summary in sorted(summaries.items()):
+        idle_ns = summary["envelope_ns"] - summary["busy_ns"]
+        print(
+            f"{device:>6}  {summary['count']:>7}  "
+            f"{summary['service_ns'] / 1e6:>10.3f}  "
+            f"{summary['busy_ns'] / 1e6:>13.3f}  "
+            f"{summary['envelope_ns'] / 1e6:>11.3f}  "
+            f"{idle_ns / 1e6:>11.3f}"
+        )
+
+    if not summaries:
+        raise SystemExit("No CUDA kernels found in the selected window")
+    device = args.device
+    if device is None:
+        device = max(summaries, key=lambda item: summaries[item]["envelope_ns"])
+    kernels = selected[device]
+    total_service_ns = sum(end - start for start, end, _ in kernels)
+
+    categories: dict[str, list[int]] = defaultdict(lambda: [0, 0])
+    kernel_totals: dict[str, list[int]] = defaultdict(lambda: [0, 0])
+    for start, end, name in kernels:
+        duration = end - start
+        category = _category(name)
+        categories[category][0] += duration
+        categories[category][1] += 1
+        kernel_totals[name][0] += duration
+        kernel_totals[name][1] += 1
+
+    print(f"\nCritical device: {device}")
+    print("category                            service_ms  service_%  launches")
+    for category, (duration, count) in sorted(
+        categories.items(), key=lambda item: item[1][0], reverse=True
+    ):
+        print(
+            f"{category:<35} {duration / 1e6:>10.3f}  "
+            f"{duration / total_service_ns * 100:>8.2f}  {count:>8}"
+        )
+
+    print("\nTop kernels by summed service time")
+    print("service_ms  service_%  launches  kernel")
+    for name, (duration, count) in sorted(
+        kernel_totals.items(), key=lambda item: item[1][0], reverse=True
+    )[: args.top_kernels]:
+        print(
+            f"{duration / 1e6:>10.3f}  {duration / total_service_ns * 100:>8.2f}  "
+            f"{count:>8}  {_short_name(name)}"
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmarks/benchmark_sm70_deepseek_v4_fp8_dense.py
+++ b/benchmarks/benchmark_sm70_deepseek_v4_fp8_dense.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-"""Profile the exact DeepSeek V4 TP8 FP8 dense decode shapes on SM70."""
+"""Profile exact DeepSeek V4 TP8 FP8 dense shapes on SM70."""
 
 from __future__ import annotations
 
@@ -21,7 +21,7 @@ class Shape:
     name: str
     k: int
     n: int
-    calls_per_token: int
+    calls_per_model_forward: int
     gated_silu: bool = False
 
 
@@ -42,7 +42,16 @@ def _digest(tensor: torch.Tensor) -> str:
     return hashlib.sha256(raw).hexdigest()
 
 
-def _time_graph(graph: torch.cuda.CUDAGraph, replays: int, repeats: int) -> list[float]:
+def _time_graph(
+    graph: torch.cuda.CUDAGraph,
+    replays: int,
+    repeats: int,
+    warmup_replays: int,
+) -> list[float]:
+    for _ in range(warmup_replays):
+        graph.replay()
+    torch.cuda.synchronize()
+
     samples_ms: list[float] = []
     for _ in range(repeats):
         start = torch.cuda.Event(enable_timing=True)
@@ -56,7 +65,14 @@ def _time_graph(graph: torch.cuda.CUDAGraph, replays: int, repeats: int) -> list
     return samples_ms
 
 
-def _measure(shape: Shape, replays: int, repeats: int) -> dict[str, object]:
+def _measure(
+    shape: Shape,
+    num_tokens: int,
+    replays: int,
+    repeats: int,
+    warmup_replays: int,
+    profile_replay: bool,
+) -> dict[str, object]:
     qweight = torch.randn((shape.n, shape.k), device="cuda", dtype=torch.float16).to(
         torch.float8_e4m3fn
     )
@@ -68,9 +84,9 @@ def _measure(shape: Shape, replays: int, repeats: int) -> dict[str, object]:
     weight, tm_scales, meta = sm70_ops.fp8_sm70_prepare(
         qweight, scales, 128, shape.gated_silu
     )
-    x = torch.randn((1, shape.k), device="cuda", dtype=torch.float16)
+    x = torch.randn((num_tokens, shape.k), device="cuda", dtype=torch.float16)
     out_n = shape.n // 2 if shape.gated_silu else shape.n
-    direct = torch.empty((1, out_n), device="cuda", dtype=torch.float16)
+    direct = torch.empty((num_tokens, out_n), device="cuda", dtype=torch.float16)
     graph_out = torch.empty_like(direct)
 
     for _ in range(4):
@@ -89,21 +105,32 @@ def _measure(shape: Shape, replays: int, repeats: int) -> dict[str, object]:
     equal = torch.equal(direct, graph_out)
     max_abs = float((direct.float() - graph_out.float()).abs().max().item())
 
-    samples_ms = _time_graph(graph, replays, repeats)
+    if profile_replay:
+        torch.cuda.cudart().cudaProfilerStart()
+        graph.replay()
+        torch.cuda.cudart().cudaProfilerStop()
+        torch.cuda.synchronize()
+
+    samples_ms = _time_graph(graph, replays, repeats, warmup_replays)
 
     median_ms = statistics.median(samples_ms)
     return {
         **asdict(shape),
         "samples_ms": samples_ms,
         "median_ms": median_ms,
-        "projected_ms_per_token": median_ms * shape.calls_per_token,
+        "num_tokens": num_tokens,
+        "projected_ms_per_model_forward": (median_ms * shape.calls_per_model_forward),
         "graph_equal": equal,
         "graph_max_abs": max_abs,
         "output_sha256": _digest(graph_out),
     }
 
 
-def _measure_split_parity(replays: int, repeats: int) -> dict[str, object]:
+def _measure_split_parity(
+    replays: int,
+    repeats: int,
+    warmup_replays: int,
+) -> dict[str, object]:
     k, fused_n, split_n = 4096, 1536, 1024
     qweight = torch.randn((fused_n, k), device="cuda", dtype=torch.float16).to(
         torch.float8_e4m3fn
@@ -163,8 +190,8 @@ def _measure_split_parity(replays: int, repeats: int) -> dict[str, object]:
     torch.cuda.synchronize()
 
     diff = (fused_out.float() - split_out.float()).abs()
-    fused_samples = _time_graph(fused_graph, replays, repeats)
-    split_samples = _time_graph(split_graph, replays, repeats)
+    fused_samples = _time_graph(fused_graph, replays, repeats, warmup_replays)
+    split_samples = _time_graph(split_graph, replays, repeats, warmup_replays)
     fused_median = statistics.median(fused_samples)
     split_median = statistics.median(split_samples)
     return {
@@ -187,20 +214,33 @@ def main() -> int:
     parser.add_argument("--json-out", type=Path, required=True)
     parser.add_argument("--replays", type=int, default=1000)
     parser.add_argument("--repeats", type=int, default=5)
+    parser.add_argument("--warmup-replays", type=int, default=100)
+    parser.add_argument("--num-tokens", type=int, default=1)
     parser.add_argument("--seed", type=int, default=20260802)
     parser.add_argument(
         "--name", choices=[shape.name for shape in SHAPES + DIAGNOSTIC_SHAPES]
     )
     parser.add_argument("--split-parity", action="store_true")
+    parser.add_argument("--profile-replay", action="store_true")
     args = parser.parse_args()
 
     if not torch.cuda.is_available() or torch.cuda.get_device_capability() != (7, 0):
         raise RuntimeError("This benchmark requires an NVIDIA V100 (SM70).")
+    if args.num_tokens < 1:
+        raise ValueError("num-tokens must be positive")
+    if args.warmup_replays < 0:
+        raise ValueError("warmup-replays must be non-negative")
+    if args.split_parity and args.num_tokens != 1:
+        raise ValueError("split-parity currently requires num-tokens=1")
 
     torch.manual_seed(args.seed)
     torch.cuda.manual_seed_all(args.seed)
     if args.split_parity:
-        result = _measure_split_parity(args.replays, args.repeats)
+        result = _measure_split_parity(
+            args.replays,
+            args.repeats,
+            args.warmup_replays,
+        )
         payload = {"contract": {"m": 1, "tp": 8}, "split_parity": result}
         args.json_out.parent.mkdir(parents=True, exist_ok=True)
         args.json_out.write_text(json.dumps(payload, indent=2), encoding="utf-8")
@@ -213,24 +253,39 @@ def main() -> int:
     )
     if args.name is None:
         selected_shapes = SHAPES
-    results = [_measure(shape, args.replays, args.repeats) for shape in selected_shapes]
-    projected_ms = sum(float(item["projected_ms_per_token"]) for item in results)
+    results = [
+        _measure(
+            shape,
+            args.num_tokens,
+            args.replays,
+            args.repeats,
+            args.warmup_replays,
+            args.profile_replay,
+        )
+        for shape in selected_shapes
+    ]
+    projected_ms = sum(
+        float(item["projected_ms_per_model_forward"]) for item in results
+    )
     failures = [item["name"] for item in results if not item["graph_equal"]]
     payload = {
         "contract": {
             "model": "DeepSeek-V4-Flash",
             "tp": 8,
-            "m": 1,
+            "m": args.num_tokens,
             "group_size": 128,
             "cuda_graph": True,
             "replays": args.replays,
             "repeats": args.repeats,
+            "warmup_replays": args.warmup_replays,
             "seed": args.seed,
         },
         "summary": {
             "shape_count": len(results),
-            "calls_per_token": sum(shape.calls_per_token for shape in selected_shapes),
-            "projected_ms_per_token": projected_ms,
+            "calls_per_model_forward": sum(
+                shape.calls_per_model_forward for shape in selected_shapes
+            ),
+            "projected_ms_per_model_forward": projected_ms,
             "graph_failures": failures,
         },
         "results": results,
@@ -241,8 +296,9 @@ def main() -> int:
     for item in results:
         print(
             f"{item['name']:20s} K={item['k']:5d} N={item['n']:5d} "
-            f"{item['median_ms']:.6f} ms x {item['calls_per_token']:3d} = "
-            f"{item['projected_ms_per_token']:.3f} ms/token"
+            f"{item['median_ms']:.6f} ms x "
+            f"{item['calls_per_model_forward']:3d} = "
+            f"{item['projected_ms_per_model_forward']:.3f} ms/forward"
         )
     return 1 if failures else 0
 

--- a/benchmarks/benchmark_sm70_deepseek_v4_mhc.py
+++ b/benchmarks/benchmark_sm70_deepseek_v4_mhc.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-"""Profile the exact DeepSeek V4 M=1 mHC decode path on SM70."""
+"""Profile exact DeepSeek V4 mHC decode and prefill shapes on SM70."""
 
 from __future__ import annotations
 
@@ -16,10 +16,12 @@ import torch
 from safetensors import safe_open
 
 from vllm.model_executor.kernels.mhc.tilelang import (
+    _select_hc_prenorm_block_config,
     _tilelang_hc_prenorm_gemm,
     mhc_fused_post_pre_tilelang,
 )
 from vllm.model_executor.kernels.mhc.tilelang_kernels import (
+    hc_prenorm_gemm_block_m_tilelang,
     mhc_fused_tilelang,
     mhc_post_tilelang,
     mhc_pre_big_fuse_with_norm_tilelang,
@@ -34,7 +36,11 @@ from vllm.model_executor.kernels.mhc.tilelang_kernels import (
 HIDDEN_SIZE = 4096
 HC_MULT = 4
 HC_OUT = 2 * HC_MULT + HC_MULT * HC_MULT
-CALLS_PER_TOKEN = 85
+MODEL_CALLS_BY_COMPONENT = {
+    "post": 86,
+    "dot": 86,
+    "pre": 85,
+}
 
 
 def _load_tensor(
@@ -67,7 +73,12 @@ def _time_graph(
     graph: torch.cuda.CUDAGraph,
     replays: int,
     repeats: int,
+    warmup_replays: int,
 ) -> list[float]:
+    for _ in range(warmup_replays):
+        graph.replay()
+    torch.cuda.synchronize()
+
     samples = []
     for _ in range(repeats):
         start = torch.cuda.Event(enable_timing=True)
@@ -96,6 +107,12 @@ def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("--model", type=Path, required=True)
     parser.add_argument("--layer", type=int, default=3)
+    parser.add_argument("--num-tokens", type=int, default=1)
+    parser.add_argument(
+        "--block-m",
+        type=int,
+        help="Override the SM70 prenorm GEMM token block for staged dot runs.",
+    )
     parser.add_argument(
         "--path", choices=("fused", "separate", "fp32_stage"), default="fused"
     )
@@ -108,6 +125,7 @@ def main() -> int:
     )
     parser.add_argument("--replays", type=int, default=3000)
     parser.add_argument("--repeats", type=int, default=9)
+    parser.add_argument("--warmup-replays", type=int, default=100)
     parser.add_argument("--seed", type=int, default=20260803)
     parser.add_argument("--profile-replay", action="store_true")
     parser.add_argument("--json-out", type=Path)
@@ -115,7 +133,15 @@ def main() -> int:
 
     if not torch.cuda.is_available() or torch.cuda.get_device_capability() != (7, 0):
         raise RuntimeError("This benchmark requires NVIDIA V100/SM70.")
-    if HC_OUT % args.tile_n != 0:
+    if args.num_tokens < 1:
+        raise ValueError("num-tokens must be positive")
+    if args.warmup_replays < 0:
+        raise ValueError("warmup-replays must be non-negative")
+    if args.block_m is not None and args.block_m < 1:
+        raise ValueError("block-m must be positive")
+    if args.block_m is not None and args.path != "separate":
+        raise ValueError("block-m requires --path separate")
+    if args.block_m is None and HC_OUT % args.tile_n != 0:
         raise ValueError(f"tile-n must divide {HC_OUT}")
     if HIDDEN_SIZE % args.n_splits != 0:
         raise ValueError(f"n-splits must divide {HIDDEN_SIZE}")
@@ -139,15 +165,21 @@ def main() -> int:
 
     torch.manual_seed(args.seed)
     torch.cuda.manual_seed_all(args.seed)
-    x = torch.randn((1, HIDDEN_SIZE), device="cuda", dtype=torch.float16)
+    x = torch.randn((args.num_tokens, HIDDEN_SIZE), device="cuda", dtype=torch.float16)
     residual = torch.randn(
-        (1, HC_MULT, HIDDEN_SIZE), device="cuda", dtype=torch.float16
+        (args.num_tokens, HC_MULT, HIDDEN_SIZE),
+        device="cuda",
+        dtype=torch.float16,
     )
     post_mix = torch.sigmoid(
-        torch.randn((1, HC_MULT), device="cuda", dtype=torch.float32)
+        torch.randn((args.num_tokens, HC_MULT), device="cuda", dtype=torch.float32)
     )
     comb_mix = torch.softmax(
-        torch.randn((1, HC_MULT, HC_MULT), device="cuda", dtype=torch.float32),
+        torch.randn(
+            (args.num_tokens, HC_MULT, HC_MULT),
+            device="cuda",
+            dtype=torch.float32,
+        ),
         dim=1,
     )
 
@@ -171,18 +203,30 @@ def main() -> int:
 
     active_splits = 1 if args.path == "separate" else args.n_splits
     gemm_out_mul = torch.empty(
-        (active_splits, 1, HC_OUT), device="cuda", dtype=torch.float32
+        (active_splits, args.num_tokens, HC_OUT),
+        device="cuda",
+        dtype=torch.float32,
     )
     gemm_out_sqrsum = torch.empty(
-        (active_splits, 1), device="cuda", dtype=torch.float32
+        (active_splits, args.num_tokens), device="cuda", dtype=torch.float32
     )
     residual_out = torch.empty_like(residual)
     residual_fp32 = torch.empty(
-        (1, HC_MULT, HIDDEN_SIZE), device="cuda", dtype=torch.float32
+        (args.num_tokens, HC_MULT, HIDDEN_SIZE),
+        device="cuda",
+        dtype=torch.float32,
     )
-    post_out = torch.empty((1, HC_MULT), device="cuda", dtype=torch.float32)
-    comb_out = torch.empty((1, HC_MULT * HC_MULT), device="cuda", dtype=torch.float32)
-    layer_input = torch.empty((1, HIDDEN_SIZE), device="cuda", dtype=torch.float16)
+    post_out = torch.empty(
+        (args.num_tokens, HC_MULT), device="cuda", dtype=torch.float32
+    )
+    comb_out = torch.empty(
+        (args.num_tokens, HC_MULT * HC_MULT),
+        device="cuda",
+        dtype=torch.float32,
+    )
+    layer_input = torch.empty(
+        (args.num_tokens, HIDDEN_SIZE), device="cuda", dtype=torch.float16
+    )
 
     def fused_call() -> None:
         mhc_fused_tilelang(
@@ -215,8 +259,23 @@ def main() -> int:
         )
 
     def dot_call() -> None:
+        if args.block_m is not None:
+            hc_prenorm_gemm_block_m_tilelang(
+                residual_out.view(args.num_tokens, HC_MULT * HIDDEN_SIZE),
+                fn,
+                gemm_out_mul,
+                gemm_out_sqrsum,
+                HIDDEN_SIZE,
+                HC_MULT,
+                HC_OUT,
+                512,
+                args.tile_n,
+                args.block_m,
+                use_fp16=True,
+            )
+            return
         _tilelang_hc_prenorm_gemm(
-            residual_out.view(1, HC_MULT * HIDDEN_SIZE),
+            residual_out.view(args.num_tokens, HC_MULT * HIDDEN_SIZE),
             fn,
             gemm_out_mul,
             gemm_out_sqrsum,
@@ -291,8 +350,8 @@ def main() -> int:
     torch.cuda.synchronize()
     eager_outputs = (
         residual_out.clone(),
-        post_out.view(1, HC_MULT, 1).clone(),
-        comb_out.view(1, HC_MULT, HC_MULT).clone(),
+        post_out.view(args.num_tokens, HC_MULT, 1).clone(),
+        comb_out.view(args.num_tokens, HC_MULT, HC_MULT).clone(),
         layer_input.clone(),
     )
 
@@ -316,11 +375,16 @@ def main() -> int:
         torch.cuda.cudart().cudaProfilerStop()
         torch.cuda.synchronize()
 
-    samples = _time_graph(graph, args.replays, args.repeats)
+    samples = _time_graph(
+        graph,
+        args.replays,
+        args.repeats,
+        args.warmup_replays,
+    )
     graph_outputs = (
         residual_out,
-        post_out.view(1, HC_MULT, 1),
-        comb_out.view(1, HC_MULT, HC_MULT),
+        post_out.view(args.num_tokens, HC_MULT, 1),
+        comb_out.view(args.num_tokens, HC_MULT, HC_MULT),
         layer_input,
     )
     names = ("residual", "post_mix", "comb_mix", "layer_input")
@@ -336,23 +400,46 @@ def main() -> int:
     }
 
     median_ms = statistics.median(samples)
+    model_calls = MODEL_CALLS_BY_COMPONENT.get(args.component)
+    prenorm_block_config = None
+    if args.path == "separate" and args.num_tokens >= 1024:
+        if args.block_m is None:
+            selected_tile_n, selected_block_m = _select_hc_prenorm_block_config(
+                torch.float16,
+                HIDDEN_SIZE,
+                HC_MULT,
+                HC_OUT,
+                12,
+            )
+        else:
+            selected_tile_n = args.tile_n
+            selected_block_m = args.block_m
+        prenorm_block_config = {
+            "tile_n": selected_tile_n,
+            "block_m": selected_block_m,
+        }
     result = {
         "contract": {
             "layer": args.layer,
-            "num_tokens": 1,
+            "num_tokens": args.num_tokens,
             "hidden_size": HIDDEN_SIZE,
             "hc_mult": HC_MULT,
             "hc_out": HC_OUT,
             "path": args.path,
+            "block_m": args.block_m,
             "tile_n": args.tile_n,
+            "prenorm_block_config": prenorm_block_config,
             "n_splits": active_splits,
             "component": args.component,
-            "calls_per_token": CALLS_PER_TOKEN,
+            "warmup_replays": args.warmup_replays,
+            "calls_per_model_forward": model_calls,
             "cuda_graph": True,
         },
         "samples_ms": samples,
         "median_ms": median_ms,
-        "projected_ms_per_token": median_ms * CALLS_PER_TOKEN,
+        "projected_ms_per_model_forward": (
+            median_ms * model_calls if model_calls is not None else None
+        ),
         "exactness_vs_runtime_oracle": exactness,
         "exactness_graph_vs_eager": graph_exactness,
     }

--- a/benchmarks/benchmark_sm70_deepseek_v4_sparse_prefill.py
+++ b/benchmarks/benchmark_sm70_deepseek_v4_sparse_prefill.py
@@ -1,0 +1,233 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Benchmark the DeepSeek V4 gathered sparse-prefill kernel on SM70."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import statistics
+from pathlib import Path
+
+import torch
+
+from vllm.models.deepseek_v4.sm70.sparse_kernels import (
+    _sm70_sparse_gathered_kernel,
+)
+from vllm.triton_utils import triton
+
+
+def _cuda_device_module():
+    if not torch.accelerator.is_available():
+        raise RuntimeError("CUDA is required")
+    accelerator = torch.accelerator.current_accelerator()
+    if accelerator is None or accelerator.type != "cuda":
+        raise RuntimeError(f"CUDA is required, got {accelerator}")
+    return torch.get_device_module(accelerator)
+
+
+def _launch(
+    q: torch.Tensor,
+    kv: torch.Tensor,
+    indices: torch.Tensor,
+    lengths: torch.Tensor,
+    sink: torch.Tensor,
+    out: torch.Tensor,
+    *,
+    block_h: int,
+    block_k: int,
+    num_warps: int,
+) -> None:
+    _sm70_sparse_gathered_kernel[(q.shape[0], triton.cdiv(q.shape[1], block_h))](
+        q,
+        kv,
+        indices,
+        lengths,
+        sink,
+        out,
+        q.stride(0),
+        q.stride(1),
+        kv.stride(0),
+        indices.stride(0),
+        out.stride(0),
+        out.stride(1),
+        q.shape[1],
+        kv.shape[0],
+        512**-0.5,
+        INDEX_WIDTH=indices.shape[1],
+        BLOCK_H=block_h,
+        BLOCK_K=block_k,
+        BLOCK_D=512,
+        num_warps=num_warps,
+    )
+
+
+def _measure(call, *, warmups: int, repeats: int) -> list[float]:
+    for _ in range(warmups):
+        call()
+    torch.accelerator.synchronize()
+    samples = []
+    for _ in range(repeats):
+        start = torch.Event(enable_timing=True)
+        end = torch.Event(enable_timing=True)
+        start.record()
+        call()
+        end.record()
+        end.synchronize()
+        samples.append(start.elapsed_time(end))
+    return samples
+
+
+def _make_inputs(
+    *, q_tokens: int, num_heads: int, pattern: str, seed: int
+) -> tuple[torch.Tensor, ...]:
+    device = torch.device("cuda")
+    torch.manual_seed(seed)
+    q = torch.randn((q_tokens, num_heads, 512), dtype=torch.float16, device=device)
+    if pattern == "c4":
+        compress_ratio, index_width = 4, 640
+    elif pattern == "c128":
+        compress_ratio, index_width = 128, 256
+    else:
+        compress_ratio, index_width = 1, 128
+    compressed_tokens = 0 if pattern == "swa" else triton.cdiv(q_tokens, compress_ratio)
+    num_kv = compressed_tokens + q_tokens
+    kv = torch.randn((num_kv, 512), dtype=torch.float16, device=device)
+
+    rows = torch.arange(q_tokens, dtype=torch.int64, device=device)[:, None]
+    columns = torch.arange(index_width, dtype=torch.int64, device=device)[None, :]
+    compressed_lens = torch.clamp(
+        (rows[:, 0] + 1) // compress_ratio,
+        max=index_width - 128,
+    )
+    if pattern == "swa":
+        compressed_lens.zero_()
+    swa_lens = torch.clamp(rows[:, 0] + 1, max=128)
+    lengths = (compressed_lens + swa_lens).to(torch.int32)
+    indices = ((rows * 131 + columns * 67) % num_kv).to(torch.int32)
+    indices.masked_fill_(columns >= lengths[:, None], -1)
+
+    sink = torch.full((num_heads,), -float("inf"), dtype=torch.float32, device=device)
+    reference = torch.empty_like(q)
+    candidate = torch.empty_like(q)
+    return q, kv, indices, lengths, sink, reference, candidate
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--q-tokens", type=int, default=8192)
+    parser.add_argument("--num-heads", type=int, default=8)
+    parser.add_argument("--candidate", choices=("triton", "hmma"), default="triton")
+    parser.add_argument("--pattern", choices=("c4", "c128", "swa"), default="c4")
+    parser.add_argument("--block-h", type=int, default=8)
+    parser.add_argument("--block-k", type=int, default=16)
+    parser.add_argument("--num-warps", type=int, choices=(4, 8), default=4)
+    parser.add_argument("--warmups", type=int, default=3)
+    parser.add_argument("--repeats", type=int, default=5)
+    parser.add_argument("--seed", type=int, default=20260803)
+    parser.add_argument("--output", type=Path)
+    args = parser.parse_args()
+
+    if _cuda_device_module().get_device_capability() != (7, 0):
+        raise RuntimeError("This benchmark requires an NVIDIA V100 (SM70)")
+    if args.block_h not in (1, 2, 4, 8, 16):
+        raise ValueError("--block-h must be one of 1, 2, 4, 8, or 16")
+    if args.block_k != 16:
+        raise ValueError("--block-k must be 16 on SM70")
+    if args.q_tokens < 1 or args.num_heads < 1:
+        raise ValueError("token and head counts must be positive")
+
+    q, kv, indices, lengths, sink, reference, candidate = _make_inputs(
+        q_tokens=args.q_tokens,
+        num_heads=args.num_heads,
+        pattern=args.pattern,
+        seed=args.seed,
+    )
+
+    baseline_call = lambda: _launch(
+        q,
+        kv,
+        indices,
+        lengths,
+        sink,
+        reference,
+        block_h=8,
+        block_k=16,
+        num_warps=4,
+    )
+    if args.candidate == "hmma":
+        if args.num_heads != 8:
+            raise ValueError("the HMMA candidate requires --num-heads 8")
+
+        candidate_call = lambda: torch.ops._C.sm70_deepseek_v4_sparse_attention_hmma(
+            q, kv, indices, lengths, sink, candidate, 512**-0.5
+        )
+    else:
+        candidate_call = lambda: _launch(
+            q,
+            kv,
+            indices,
+            lengths,
+            sink,
+            candidate,
+            block_h=args.block_h,
+            block_k=args.block_k,
+            num_warps=args.num_warps,
+        )
+
+    baseline_call()
+    candidate_call()
+    torch.accelerator.synchronize()
+    difference = (reference.float() - candidate.float()).abs()
+    baseline_samples = _measure(
+        baseline_call, warmups=args.warmups, repeats=args.repeats
+    )
+    candidate_samples = _measure(
+        candidate_call, warmups=args.warmups, repeats=args.repeats
+    )
+    baseline_median = statistics.median(baseline_samples)
+    candidate_median = statistics.median(candidate_samples)
+
+    result = {
+        "shape": {
+            "pattern": args.pattern,
+            "q_tokens": args.q_tokens,
+            "num_heads": args.num_heads,
+            "head_dim": 512,
+            "index_width": indices.shape[1],
+            "kv_rows": kv.shape[0],
+        },
+        "baseline": {
+            "block_h": 8,
+            "block_k": 16,
+            "num_warps": 4,
+            "samples_ms": baseline_samples,
+            "median_ms": baseline_median,
+        },
+        "candidate": {
+            "backend": args.candidate,
+            "block_h": args.block_h,
+            "block_k": args.block_k,
+            "num_warps": 8 if args.candidate == "hmma" else args.num_warps,
+            "samples_ms": candidate_samples,
+            "median_ms": candidate_median,
+        },
+        "speedup": baseline_median / candidate_median,
+        "bitwise_equal": torch.equal(reference, candidate),
+        "max_abs": float(difference.max().item()),
+        "mean_abs": float(difference.mean().item()),
+        "mismatch_elements": int(torch.count_nonzero(difference).item()),
+        "mismatch_fraction": float(torch.count_nonzero(difference).item())
+        / difference.numel(),
+        "all_finite": bool(torch.isfinite(candidate).all().item()),
+    }
+    rendered = json.dumps(result, indent=2)
+    print(rendered)
+    if args.output is not None:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(rendered + "\n", encoding="utf-8")
+    return 0 if result["all_finite"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmarks/benchmark_sm70_mxfp4_moe_indexed_prefill.py
+++ b/benchmarks/benchmark_sm70_mxfp4_moe_indexed_prefill.py
@@ -1,0 +1,284 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Compare materialized and indexed DeepSeek V4 MXFP4 W13 prefill."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import statistics
+from pathlib import Path
+
+import torch
+from benchmark_sm70_mxfp4_moe_prefill import (
+    STAGES,
+    _prepare_experts,
+    _require_sm70,
+)
+
+from vllm import _sm70_ops as sm70_ops
+
+
+def _make_scratch(
+    prompt_tokens: int,
+    top_k: int,
+    num_experts: int,
+    hidden_size: int,
+    device: torch.device,
+) -> dict[str, torch.Tensor]:
+    expanded_rows = prompt_tokens * top_k
+    return {
+        "token_expert_indices": torch.arange(
+            expanded_rows, dtype=torch.int32, device=device
+        ).view(prompt_tokens, top_k),
+        "permuted_input": torch.empty(
+            expanded_rows, hidden_size, dtype=torch.float16, device=device
+        ),
+        "expert_offsets64": torch.empty(
+            num_experts + 1, dtype=torch.int64, device=device
+        ),
+        "expert_offsets": torch.empty(
+            num_experts + 1, dtype=torch.int32, device=device
+        ),
+        "inv_permuted_idx": torch.empty(
+            prompt_tokens, top_k, dtype=torch.int32, device=device
+        ),
+        "permuted_idx": torch.empty(expanded_rows, dtype=torch.int32, device=device),
+        "permuted_experts_id": torch.empty(
+            prompt_tokens, top_k, dtype=torch.int32, device=device
+        ),
+        "sorted_row_idx": torch.empty(
+            prompt_tokens, top_k, dtype=torch.int32, device=device
+        ),
+        "topk_ids_for_sort": torch.empty(
+            prompt_tokens, top_k, dtype=torch.int32, device=device
+        ),
+        "sort_workspace": torch.empty(
+            torch.ops._moe_C.moe_permute_sort_workspace_size(
+                expanded_rows, num_experts
+            ),
+            dtype=torch.int8,
+            device=device,
+        ),
+    }
+
+
+def _time(call, repeats: int) -> list[float]:
+    for _ in range(3):
+        call()
+    torch.cuda.synchronize()
+    samples = []
+    for _ in range(repeats):
+        start = torch.cuda.Event(enable_timing=True)
+        end = torch.cuda.Event(enable_timing=True)
+        start.record()
+        call()
+        end.record()
+        end.synchronize()
+        samples.append(start.elapsed_time(end))
+    return samples
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--prompt-tokens", type=int, default=8192)
+    parser.add_argument("--top-k", type=int, default=6)
+    parser.add_argument("--num-experts", type=int, default=256)
+    parser.add_argument("--repeats", type=int, default=9)
+    parser.add_argument("--seed", type=int, default=20260803)
+    parser.add_argument("--json-out", type=Path, required=True)
+    args = parser.parse_args()
+
+    if args.prompt_tokens < 1 or args.top_k < 1 or args.repeats < 3:
+        raise ValueError("prompt-tokens/top-k must be positive and repeats >= 3")
+    _require_sm70()
+    for op_name in (
+        "moe_permute_with_scratch",
+        "moe_permute_indexed_with_scratch",
+    ):
+        if not hasattr(torch.ops._moe_C, op_name):
+            raise RuntimeError(f"Required operator is missing: _moe_C::{op_name}")
+    if not hasattr(torch.ops._C, "mxfp4_moe_indexed_dense_stage_sm70_out"):
+        raise RuntimeError(
+            "Required operator is missing: _C::mxfp4_moe_indexed_dense_stage_sm70_out"
+        )
+
+    torch.manual_seed(args.seed)
+    torch.cuda.manual_seed_all(args.seed)
+    device = torch.device("cuda")
+    shape = STAGES["w13"]
+    expanded_rows = args.prompt_tokens * args.top_k
+    x = torch.randn(args.prompt_tokens, shape.k, dtype=torch.float16, device=device)
+    scores = torch.rand(
+        args.prompt_tokens, args.num_experts, dtype=torch.float32, device=device
+    )
+    topk_ids = scores.topk(args.top_k, dim=-1).indices.to(torch.int32)
+    del scores
+
+    weights, scales, ptrs_w, ptrs_s = _prepare_experts(shape, args.num_experts, device)
+    scratch = _make_scratch(
+        args.prompt_tokens, args.top_k, args.num_experts, shape.k, device
+    )
+    dense_ids = torch.arange(args.num_experts, dtype=torch.int32, device=device)
+    reference_out = torch.empty(
+        expanded_rows, shape.n, dtype=torch.float16, device=device
+    )
+    indexed_out = torch.empty_like(reference_out)
+
+    def prepare_common() -> None:
+        scratch["permuted_idx"].fill_(expanded_rows)
+
+    def reference() -> None:
+        prepare_common()
+        torch.ops._moe_C.moe_permute_with_scratch(
+            x,
+            topk_ids,
+            scratch["token_expert_indices"],
+            None,
+            args.num_experts,
+            args.num_experts,
+            args.top_k,
+            scratch["permuted_input"],
+            scratch["expert_offsets64"],
+            scratch["inv_permuted_idx"],
+            scratch["permuted_idx"],
+            scratch["sort_workspace"],
+            scratch["permuted_experts_id"],
+            scratch["sorted_row_idx"],
+            scratch["topk_ids_for_sort"],
+        )
+        scratch["expert_offsets"].copy_(scratch["expert_offsets64"])
+        sm70_ops.mxfp4_moe_dense_stage_sm70_out(
+            reference_out,
+            scratch["permuted_input"],
+            scratch["expert_offsets"],
+            dense_ids,
+            ptrs_w,
+            ptrs_s,
+            args.num_experts,
+            shape.k,
+            shape.n,
+            32,
+        )
+
+    def indexed() -> None:
+        prepare_common()
+        torch.ops._moe_C.moe_permute_indexed_with_scratch(
+            x,
+            topk_ids,
+            scratch["token_expert_indices"],
+            args.num_experts,
+            args.num_experts,
+            args.top_k,
+            scratch["permuted_input"],
+            scratch["expert_offsets64"],
+            scratch["inv_permuted_idx"],
+            scratch["permuted_idx"],
+            scratch["sort_workspace"],
+            scratch["permuted_experts_id"],
+            scratch["sorted_row_idx"],
+            scratch["topk_ids_for_sort"],
+        )
+        scratch["expert_offsets"].copy_(scratch["expert_offsets64"])
+        sm70_ops.mxfp4_moe_indexed_dense_stage_sm70_out(
+            indexed_out,
+            x,
+            scratch["sorted_row_idx"].view(-1),
+            scratch["expert_offsets"],
+            dense_ids,
+            ptrs_w,
+            ptrs_s,
+            args.num_experts,
+            shape.k,
+            shape.n,
+            32,
+        )
+
+    grouped_env = "VLLM_SM70_MXFP4_MOE_GROUPED_PREFILL"
+    original_grouped = os.environ.get(grouped_env)
+    try:
+        os.environ[grouped_env] = "1"
+        reference()
+        torch.cuda.synchronize()
+        expected_out = reference_out.clone()
+        expected_offsets = scratch["expert_offsets64"].clone()
+        expected_inv = scratch["inv_permuted_idx"].clone()
+        expected_permuted = scratch["permuted_idx"].clone()
+
+        indexed()
+        torch.cuda.synchronize()
+        output_equal = torch.equal(expected_out, indexed_out)
+        max_abs = float((expected_out - indexed_out).abs().max().item())
+        metadata_equal = {
+            "expert_offsets": torch.equal(
+                expected_offsets, scratch["expert_offsets64"]
+            ),
+            "inverse_permutation": torch.equal(
+                expected_inv, scratch["inv_permuted_idx"]
+            ),
+            "expanded_permutation": torch.equal(
+                expected_permuted, scratch["permuted_idx"]
+            ),
+            "source_row_indices": torch.equal(
+                expected_permuted // args.top_k,
+                scratch["sorted_row_idx"].view(-1),
+            ),
+        }
+
+        eager_indexed = indexed_out.clone()
+        graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(graph):
+            indexed()
+        graph.replay()
+        torch.cuda.synchronize()
+        graph_equal = torch.equal(eager_indexed, indexed_out)
+
+        reference_samples = _time(reference, args.repeats)
+        indexed_samples = _time(indexed, args.repeats)
+    finally:
+        if original_grouped is None:
+            os.environ.pop(grouped_env, None)
+        else:
+            os.environ[grouped_env] = original_grouped
+
+    reference_median = statistics.median(reference_samples)
+    indexed_median = statistics.median(indexed_samples)
+    payload = {
+        "contract": {
+            "model": "DeepSeek-V4-Flash",
+            "tp": 8,
+            "prompt_tokens": args.prompt_tokens,
+            "top_k": args.top_k,
+            "expanded_rows": expanded_rows,
+            "num_experts": args.num_experts,
+            "stage": "w13",
+            "k": shape.k,
+            "n": shape.n,
+            "seed": args.seed,
+        },
+        "correctness": {
+            "output_bitwise": output_equal,
+            "output_max_abs": max_abs,
+            "metadata_bitwise": metadata_equal,
+            "graph_replay_bitwise": graph_equal,
+        },
+        "timing": {
+            "reference_samples_ms": reference_samples,
+            "indexed_samples_ms": indexed_samples,
+            "reference_median_ms": reference_median,
+            "indexed_median_ms": indexed_median,
+            "speedup": reference_median / indexed_median,
+            "projected_43_layer_savings_ms": (reference_median - indexed_median) * 43,
+        },
+    }
+    args.json_out.parent.mkdir(parents=True, exist_ok=True)
+    args.json_out.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    print(json.dumps(payload, indent=2))
+
+    del weights, scales
+    return 0 if output_equal and graph_equal and all(metadata_equal.values()) else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmarks/benchmark_sm70_mxfp4_moe_prefill.py
+++ b/benchmarks/benchmark_sm70_mxfp4_moe_prefill.py
@@ -1,0 +1,367 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Compare legacy and grouped SM70 MXFP4 MoE prefill dispatch.
+
+The default shape is one DeepSeek-V4-Flash TP8 MoE stage after routing:
+1024 prompt tokens, top-k=6, and 256 local experts. Inputs and routing remain
+fixed between routes so any drift is an operator correctness failure.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import statistics
+import time
+from dataclasses import dataclass
+
+import torch
+
+from vllm import _sm70_ops as sm70_ops
+
+
+@dataclass(frozen=True)
+class StageShape:
+    name: str
+    k: int
+    n: int
+
+
+STAGES = {
+    "w13": StageShape("w13", 4096, 512),
+    "w2": StageShape("w2", 256, 4096),
+}
+
+
+def _require_sm70() -> None:
+    if not torch.cuda.is_available():
+        raise RuntimeError("CUDA is required")
+    capability = torch.cuda.get_device_capability()
+    if capability != (7, 0):
+        raise RuntimeError(f"This benchmark requires SM70, got SM{capability}")
+    for op_name in (
+        "mxfp4_sm70_prepare",
+        "mxfp4_moe_dense_stage_sm70_out",
+        "awq_moe_build_strided_ptrs",
+    ):
+        if not hasattr(torch.ops._C, op_name):
+            raise RuntimeError(f"Required operator is missing: _C::{op_name}")
+
+
+def _expert_pattern(num_experts: int, device: torch.device) -> torch.Tensor:
+    nibble = torch.arange(num_experts, dtype=torch.int32, device=device) & 0xF
+    pattern = nibble.clone()
+    for shift in range(4, 32, 4):
+        pattern |= nibble << shift
+    return pattern
+
+
+def _prepare_experts(
+    shape: StageShape, num_experts: int, device: torch.device
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    qweight = torch.randint(0, 16, (shape.k, shape.n), dtype=torch.uint8, device=device)
+    scales = torch.full((shape.k // 32, shape.n), 127, dtype=torch.uint8, device=device)
+    weight, prepared_scales, meta = sm70_ops.mxfp4_sm70_prepare(qweight, scales, 32)
+    weights = weight.unsqueeze(0).repeat(num_experts, 1, 1)
+    weights.bitwise_xor_(_expert_pattern(num_experts, device)[:, None, None])
+    expert_scales = prepared_scales.unsqueeze(0).repeat(num_experts, 1, 1)
+    ptrs_w, ptrs_s = sm70_ops.awq_moe_build_strided_ptrs(
+        weights,
+        expert_scales,
+        int(meta[0].item()),
+        int(meta[1].item()),
+        num_experts,
+    )
+    return weights, expert_scales, ptrs_w, ptrs_s
+
+
+def _routing_counts(
+    pattern: str,
+    routed_rows: int,
+    num_experts: int,
+    seed: int,
+) -> list[int]:
+    if pattern == "balanced":
+        if routed_rows % num_experts:
+            raise ValueError("balanced routing requires divisible routed rows")
+        return [routed_rows // num_experts] * num_experts
+    if pattern == "half_active":
+        active_experts = num_experts // 2
+        if routed_rows % active_experts:
+            raise ValueError("half-active routing requires divisible routed rows")
+        return [routed_rows // active_experts] * active_experts + [0] * (
+            num_experts - active_experts
+        )
+    if pattern == "random":
+        generator = torch.Generator(device="cpu").manual_seed(seed)
+        assignments = torch.randint(
+            num_experts,
+            (routed_rows,),
+            generator=generator,
+            dtype=torch.int64,
+        )
+        return torch.bincount(assignments, minlength=num_experts).tolist()
+    raise ValueError(f"Unknown routing pattern: {pattern}")
+
+
+def _offsets_from_counts(counts: list[int], device: torch.device) -> torch.Tensor:
+    offsets = [0]
+    for count in counts:
+        offsets.append(offsets[-1] + count)
+    return torch.tensor(offsets, dtype=torch.int32, device=device)
+
+
+def _measure(call, repeats: int) -> dict[str, object]:
+    for _ in range(3):
+        call()
+    torch.cuda.synchronize()
+
+    gpu_ms: list[float] = []
+    wall_ms: list[float] = []
+    for _ in range(repeats):
+        start = torch.cuda.Event(enable_timing=True)
+        end = torch.cuda.Event(enable_timing=True)
+        torch.cuda.synchronize()
+        wall_start = time.perf_counter()
+        start.record()
+        call()
+        end.record()
+        end.synchronize()
+        wall_ms.append((time.perf_counter() - wall_start) * 1000)
+        gpu_ms.append(start.elapsed_time(end))
+    return {
+        "gpu_ms": gpu_ms,
+        "gpu_median_ms": statistics.median(gpu_ms),
+        "wall_ms": wall_ms,
+        "wall_median_ms": statistics.median(wall_ms),
+    }
+
+
+def _diff_summary(
+    reference: torch.Tensor,
+    candidate: torch.Tensor,
+    counts: list[int],
+) -> dict[str, object]:
+    mismatch = reference != candidate
+    row_mismatch = mismatch.any(dim=1)
+    routed_rows = sum(counts)
+    mismatch_rows = row_mismatch.nonzero().flatten()
+    first_element = mismatch.nonzero()
+
+    expert_ids = []
+    row_start = 0
+    for expert_id, count in enumerate(counts):
+        row_end = row_start + count
+        if count and bool(row_mismatch[row_start:row_end].any().item()):
+            expert_ids.append(expert_id)
+        row_start = row_end
+
+    return {
+        "mismatch_elements": int(mismatch.sum().item()),
+        "mismatch_rows": int(row_mismatch.sum().item()),
+        "active_mismatch_elements": int(mismatch[:routed_rows].sum().item()),
+        "active_mismatch_rows": int(row_mismatch[:routed_rows].sum().item()),
+        "tail_mismatch_elements": int(mismatch[routed_rows:].sum().item()),
+        "tail_mismatch_rows": int(row_mismatch[routed_rows:].sum().item()),
+        "mismatched_experts": expert_ids,
+        "first_mismatch_element": (
+            first_element[0].cpu().tolist() if first_element.numel() else None
+        ),
+        "first_mismatch_row": (
+            int(mismatch_rows[0].item()) if mismatch_rows.numel() else None
+        ),
+        "sign_flip_elements": int(((reference < 0) != (candidate < 0)).sum().item()),
+        "argmax_change_rows": int(
+            (reference.argmax(dim=1) != candidate.argmax(dim=1)).sum().item()
+        ),
+    }
+
+
+def _run_stage(
+    shape: StageShape,
+    *,
+    prompt_tokens: int,
+    capacity_prompt_tokens: int,
+    top_k: int,
+    num_experts: int,
+    pattern: str,
+    grouped_experts_per_launch: int,
+    repeats: int,
+    seed: int,
+) -> dict[str, object]:
+    routed_rows = prompt_tokens * top_k
+    capacity_rows = capacity_prompt_tokens * top_k
+    if capacity_rows < routed_rows:
+        raise ValueError("capacity rows must cover all routed rows")
+    torch.manual_seed(seed)
+    device = torch.device("cuda")
+    weights, scales, ptrs_w, ptrs_s = _prepare_experts(shape, num_experts, device)
+    input_tensor = (
+        torch.randn(capacity_rows, shape.k, dtype=torch.float16, device=device) * 0.01
+    )
+    output = torch.empty(capacity_rows, shape.n, dtype=torch.float16, device=device)
+    counts = _routing_counts(pattern, routed_rows, num_experts, seed)
+    expert_offsets = _offsets_from_counts(counts, device)
+    dense_ids = torch.arange(num_experts, dtype=torch.int32, device=device)
+
+    def call() -> None:
+        sm70_ops.mxfp4_moe_dense_stage_sm70_out(
+            output,
+            input_tensor,
+            expert_offsets,
+            dense_ids,
+            ptrs_w,
+            ptrs_s,
+            num_experts,
+            shape.k,
+            shape.n,
+            32,
+        )
+
+    original = os.environ.get("VLLM_SM70_MXFP4_MOE_GROUPED_PREFILL")
+    batch_env = "VLLM_SM70_MXFP4_MOE_GROUPED_PREFILL_EXPERTS_PER_LAUNCH"
+    original_batch = os.environ.get(batch_env)
+    try:
+        os.environ[batch_env] = str(grouped_experts_per_launch)
+        os.environ["VLLM_SM70_MXFP4_MOE_GROUPED_PREFILL"] = "0"
+        output.fill_(7.0)
+        call()
+        torch.cuda.synchronize()
+        legacy_output = output.clone()
+
+        os.environ["VLLM_SM70_MXFP4_MOE_GROUPED_PREFILL"] = "1"
+        output.fill_(7.0)
+        call()
+        torch.cuda.synchronize()
+        grouped_output = output.clone()
+        cross_route_equal = torch.equal(legacy_output, grouped_output)
+        cross_route_max_abs = float((legacy_output - grouped_output).abs().max().item())
+
+        output.fill_(7.0)
+        call()
+        torch.cuda.synchronize()
+        repeated_output = output
+        repeat_equal = torch.equal(grouped_output, repeated_output)
+        repeat_max_abs = float((grouped_output - repeated_output).abs().max().item())
+
+        os.environ["VLLM_SM70_MXFP4_MOE_GROUPED_PREFILL"] = "0"
+        legacy_timing = _measure(call, repeats)
+        os.environ["VLLM_SM70_MXFP4_MOE_GROUPED_PREFILL"] = "1"
+        grouped_timing = _measure(call, repeats)
+    finally:
+        if original is None:
+            os.environ.pop("VLLM_SM70_MXFP4_MOE_GROUPED_PREFILL", None)
+        else:
+            os.environ["VLLM_SM70_MXFP4_MOE_GROUPED_PREFILL"] = original
+        if original_batch is None:
+            os.environ.pop(batch_env, None)
+        else:
+            os.environ[batch_env] = original_batch
+
+    result = {
+        "stage": shape.name,
+        "k": shape.k,
+        "n": shape.n,
+        "prompt_tokens": prompt_tokens,
+        "capacity_prompt_tokens": capacity_prompt_tokens,
+        "top_k": top_k,
+        "routed_rows": routed_rows,
+        "capacity_rows": capacity_rows,
+        "num_experts": num_experts,
+        "routing_pattern": pattern,
+        "active_experts": sum(count > 0 for count in counts),
+        "grouped_experts_per_launch": grouped_experts_per_launch,
+        "legacy": legacy_timing,
+        "grouped": grouped_timing,
+        "gpu_speedup": (
+            legacy_timing["gpu_median_ms"] / grouped_timing["gpu_median_ms"]
+        ),
+        "wall_speedup": (
+            legacy_timing["wall_median_ms"] / grouped_timing["wall_median_ms"]
+        ),
+        "cross_route_bitwise": cross_route_equal,
+        "cross_route_max_abs": cross_route_max_abs,
+        "cross_route_diff": _diff_summary(legacy_output, grouped_output, counts),
+        "grouped_repeat_bitwise": repeat_equal,
+        "grouped_repeat_max_abs": repeat_max_abs,
+    }
+    if not cross_route_equal or not repeat_equal:
+        raise RuntimeError(f"Grouped MXFP4 prefill correctness gate failed: {result}")
+
+    torch.cuda.synchronize()
+    del weights, scales
+    return result
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--stage", choices=("w13", "w2", "both"), default="both")
+    parser.add_argument("--prompt-tokens", type=int, default=1024)
+    parser.add_argument(
+        "--capacity-prompt-tokens",
+        type=int,
+        help=(
+            "Graph-safe token capacity. Defaults to --prompt-tokens; use 2048 "
+            "to reproduce a 1024-token request in a 2048-token staging buffer."
+        ),
+    )
+    parser.add_argument("--top-k", type=int, default=6)
+    parser.add_argument("--num-experts", type=int, default=256)
+    parser.add_argument("--grouped-experts-per-launch", type=int, default=64)
+    parser.add_argument(
+        "--routing-pattern",
+        choices=("balanced", "random", "half_active", "both", "all"),
+        default="all",
+    )
+    parser.add_argument("--repeats", type=int, default=10)
+    parser.add_argument("--seed", type=int, default=29)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    if args.repeats < 3:
+        raise ValueError("--repeats must be at least 3")
+    if args.grouped_experts_per_launch < 1:
+        raise ValueError("--grouped-experts-per-launch must be positive")
+    _require_sm70()
+    capacity_prompt_tokens = args.capacity_prompt_tokens or args.prompt_tokens
+    stages = STAGES.values() if args.stage == "both" else (STAGES[args.stage],)
+    if args.routing_pattern == "both":
+        patterns = ("balanced", "half_active")
+    elif args.routing_pattern == "all":
+        patterns = ("balanced", "random", "half_active")
+    else:
+        patterns = (args.routing_pattern,)
+    results = []
+    for stage_index, shape in enumerate(stages):
+        for pattern_index, pattern in enumerate(patterns):
+            results.append(
+                _run_stage(
+                    shape,
+                    prompt_tokens=args.prompt_tokens,
+                    capacity_prompt_tokens=capacity_prompt_tokens,
+                    top_k=args.top_k,
+                    num_experts=args.num_experts,
+                    pattern=pattern,
+                    grouped_experts_per_launch=args.grouped_experts_per_launch,
+                    repeats=args.repeats,
+                    seed=args.seed + stage_index * 10 + pattern_index,
+                )
+            )
+    print(
+        json.dumps(
+            {
+                "benchmark": "sm70_mxfp4_moe_grouped_prefill",
+                "device": torch.cuda.get_device_name(),
+                "results": results,
+            },
+            indent=2,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmarks/benchmark_sm70_mxfp4_moe_prefill.py
+++ b/benchmarks/benchmark_sm70_mxfp4_moe_prefill.py
@@ -34,10 +34,17 @@ STAGES = {
 }
 
 
-def _require_sm70() -> None:
-    if not torch.cuda.is_available():
+def _cuda_device_module():
+    if not torch.accelerator.is_available():
         raise RuntimeError("CUDA is required")
-    capability = torch.cuda.get_device_capability()
+    accelerator = torch.accelerator.current_accelerator()
+    if accelerator is None or accelerator.type != "cuda":
+        raise RuntimeError(f"CUDA is required, got {accelerator}")
+    return torch.get_device_module(accelerator)
+
+
+def _require_sm70() -> None:
+    capability = _cuda_device_module().get_device_capability()
     if capability != (7, 0):
         raise RuntimeError(f"This benchmark requires SM70, got SM{capability}")
     for op_name in (
@@ -115,14 +122,14 @@ def _offsets_from_counts(counts: list[int], device: torch.device) -> torch.Tenso
 def _measure(call, repeats: int) -> dict[str, object]:
     for _ in range(3):
         call()
-    torch.cuda.synchronize()
+    torch.accelerator.synchronize()
 
     gpu_ms: list[float] = []
     wall_ms: list[float] = []
     for _ in range(repeats):
-        start = torch.cuda.Event(enable_timing=True)
-        end = torch.cuda.Event(enable_timing=True)
-        torch.cuda.synchronize()
+        start = torch.Event(enable_timing=True)
+        end = torch.Event(enable_timing=True)
+        torch.accelerator.synchronize()
         wall_start = time.perf_counter()
         start.record()
         call()
@@ -227,20 +234,20 @@ def _run_stage(
         os.environ["VLLM_SM70_MXFP4_MOE_GROUPED_PREFILL"] = "0"
         output.fill_(7.0)
         call()
-        torch.cuda.synchronize()
+        torch.accelerator.synchronize()
         legacy_output = output.clone()
 
         os.environ["VLLM_SM70_MXFP4_MOE_GROUPED_PREFILL"] = "1"
         output.fill_(7.0)
         call()
-        torch.cuda.synchronize()
+        torch.accelerator.synchronize()
         grouped_output = output.clone()
         cross_route_equal = torch.equal(legacy_output, grouped_output)
         cross_route_max_abs = float((legacy_output - grouped_output).abs().max().item())
 
         output.fill_(7.0)
         call()
-        torch.cuda.synchronize()
+        torch.accelerator.synchronize()
         repeated_output = output
         repeat_equal = torch.equal(grouped_output, repeated_output)
         repeat_max_abs = float((grouped_output - repeated_output).abs().max().item())
@@ -289,7 +296,7 @@ def _run_stage(
     if not cross_route_equal or not repeat_equal:
         raise RuntimeError(f"Grouped MXFP4 prefill correctness gate failed: {result}")
 
-    torch.cuda.synchronize()
+    torch.accelerator.synchronize()
     del weights, scales
     return result
 
@@ -354,7 +361,7 @@ def main() -> int:
         json.dumps(
             {
                 "benchmark": "sm70_mxfp4_moe_grouped_prefill",
-                "device": torch.cuda.get_device_name(),
+                "device": _cuda_device_module().get_device_name(),
                 "results": results,
             },
             indent=2,

--- a/benchmarks/benchmark_sm70_mxfp4_moe_prefill.py
+++ b/benchmarks/benchmark_sm70_mxfp4_moe_prefill.py
@@ -10,11 +10,13 @@ fixed between routes so any drift is an operator correctness failure.
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import os
 import statistics
 import time
 from dataclasses import dataclass
+from pathlib import Path
 
 import torch
 
@@ -32,6 +34,11 @@ STAGES = {
     "w13": StageShape("w13", 4096, 512),
     "w2": StageShape("w2", 256, 4096),
 }
+
+
+def _digest(tensor: torch.Tensor) -> str:
+    raw = tensor.detach().cpu().contiguous().view(torch.uint8).numpy().tobytes()
+    return hashlib.sha256(raw).hexdigest()
 
 
 def _cuda_device_module():
@@ -194,6 +201,7 @@ def _run_stage(
     num_experts: int,
     pattern: str,
     grouped_experts_per_launch: int,
+    grouped_only: bool,
     repeats: int,
     seed: int,
 ) -> dict[str, object]:
@@ -229,21 +237,22 @@ def _run_stage(
     original = os.environ.get("VLLM_SM70_MXFP4_MOE_GROUPED_PREFILL")
     batch_env = "VLLM_SM70_MXFP4_MOE_GROUPED_PREFILL_EXPERTS_PER_LAUNCH"
     original_batch = os.environ.get(batch_env)
+    legacy_output = None
+    legacy_timing = None
     try:
         os.environ[batch_env] = str(grouped_experts_per_launch)
-        os.environ["VLLM_SM70_MXFP4_MOE_GROUPED_PREFILL"] = "0"
-        output.fill_(7.0)
-        call()
-        torch.accelerator.synchronize()
-        legacy_output = output.clone()
+        if not grouped_only:
+            os.environ["VLLM_SM70_MXFP4_MOE_GROUPED_PREFILL"] = "0"
+            output.fill_(7.0)
+            call()
+            torch.accelerator.synchronize()
+            legacy_output = output.clone()
 
         os.environ["VLLM_SM70_MXFP4_MOE_GROUPED_PREFILL"] = "1"
         output.fill_(7.0)
         call()
         torch.accelerator.synchronize()
         grouped_output = output.clone()
-        cross_route_equal = torch.equal(legacy_output, grouped_output)
-        cross_route_max_abs = float((legacy_output - grouped_output).abs().max().item())
 
         output.fill_(7.0)
         call()
@@ -252,8 +261,17 @@ def _run_stage(
         repeat_equal = torch.equal(grouped_output, repeated_output)
         repeat_max_abs = float((grouped_output - repeated_output).abs().max().item())
 
-        os.environ["VLLM_SM70_MXFP4_MOE_GROUPED_PREFILL"] = "0"
-        legacy_timing = _measure(call, repeats)
+        graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(graph):
+            call()
+        graph.replay()
+        torch.accelerator.synchronize()
+        graph_equal = torch.equal(grouped_output, output)
+        graph_max_abs = float((grouped_output - output).abs().max().item())
+
+        if not grouped_only:
+            os.environ["VLLM_SM70_MXFP4_MOE_GROUPED_PREFILL"] = "0"
+            legacy_timing = _measure(call, repeats)
         os.environ["VLLM_SM70_MXFP4_MOE_GROUPED_PREFILL"] = "1"
         grouped_timing = _measure(call, repeats)
     finally:
@@ -265,6 +283,15 @@ def _run_stage(
             os.environ.pop(batch_env, None)
         else:
             os.environ[batch_env] = original_batch
+
+    if legacy_output is None:
+        cross_route_equal = None
+        cross_route_max_abs = None
+        cross_route_diff = None
+    else:
+        cross_route_equal = torch.equal(legacy_output, grouped_output)
+        cross_route_max_abs = float((legacy_output - grouped_output).abs().max().item())
+        cross_route_diff = _diff_summary(legacy_output, grouped_output, counts)
 
     result = {
         "stage": shape.name,
@@ -279,21 +306,30 @@ def _run_stage(
         "routing_pattern": pattern,
         "active_experts": sum(count > 0 for count in counts),
         "grouped_experts_per_launch": grouped_experts_per_launch,
+        "grouped_only": grouped_only,
         "legacy": legacy_timing,
         "grouped": grouped_timing,
         "gpu_speedup": (
             legacy_timing["gpu_median_ms"] / grouped_timing["gpu_median_ms"]
+            if legacy_timing is not None
+            else None
         ),
         "wall_speedup": (
             legacy_timing["wall_median_ms"] / grouped_timing["wall_median_ms"]
+            if legacy_timing is not None
+            else None
         ),
         "cross_route_bitwise": cross_route_equal,
         "cross_route_max_abs": cross_route_max_abs,
-        "cross_route_diff": _diff_summary(legacy_output, grouped_output, counts),
+        "legacy_sha256": _digest(legacy_output) if legacy_output is not None else None,
+        "grouped_sha256": _digest(grouped_output),
+        "cross_route_diff": cross_route_diff,
         "grouped_repeat_bitwise": repeat_equal,
         "grouped_repeat_max_abs": repeat_max_abs,
+        "grouped_graph_bitwise": graph_equal,
+        "grouped_graph_max_abs": graph_max_abs,
     }
-    if not cross_route_equal or not repeat_equal:
+    if cross_route_equal is False or not repeat_equal or not graph_equal:
         raise RuntimeError(f"Grouped MXFP4 prefill correctness gate failed: {result}")
 
     torch.accelerator.synchronize()
@@ -323,6 +359,14 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument("--repeats", type=int, default=10)
     parser.add_argument("--seed", type=int, default=29)
+    parser.add_argument("--json-out", type=Path)
+    parser.add_argument(
+        "--grouped-only",
+        action="store_true",
+        help=(
+            "Skip the per-expert route so grouped first-dispatch selectors are tested."
+        ),
+    )
     return parser.parse_args()
 
 
@@ -353,20 +397,20 @@ def main() -> int:
                     num_experts=args.num_experts,
                     pattern=pattern,
                     grouped_experts_per_launch=args.grouped_experts_per_launch,
+                    grouped_only=args.grouped_only,
                     repeats=args.repeats,
                     seed=args.seed + stage_index * 10 + pattern_index,
                 )
             )
-    print(
-        json.dumps(
-            {
-                "benchmark": "sm70_mxfp4_moe_grouped_prefill",
-                "device": _cuda_device_module().get_device_name(),
-                "results": results,
-            },
-            indent=2,
-        )
-    )
+    payload = {
+        "benchmark": "sm70_mxfp4_moe_grouped_prefill",
+        "device": _cuda_device_module().get_device_name(),
+        "results": results,
+    }
+    if args.json_out is not None:
+        args.json_out.parent.mkdir(parents=True, exist_ok=True)
+        args.json_out.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    print(json.dumps(payload, indent=2))
     return 0
 
 

--- a/benchmarks/benchmark_sm70_openai_stream.py
+++ b/benchmarks/benchmark_sm70_openai_stream.py
@@ -35,7 +35,12 @@ def _percentile(values: list[float], fraction: float) -> float:
     return ordered[position]
 
 
-def _build_prompt_ids(base_url: str, model: str, input_len: int) -> list[int]:
+def _build_prompt_ids(
+    base_url: str,
+    model: str,
+    input_len: int,
+    context: str | None = None,
+) -> list[int]:
     prefix = (
         "你是一名负责大模型推理性能的工程师。请阅读材料，最后给出严谨的"
         "瓶颈分析和下一步优化建议。\n\n材料：\n"
@@ -51,12 +56,15 @@ def _build_prompt_ids(base_url: str, model: str, input_len: int) -> list[int]:
         "不会牺牲输出质量的优化顺序。"
     )
     prefix_ids = _tokenize(base_url, model, prefix)
-    context_ids = _tokenize(base_url, model, paragraph * 80)
+    context_text = paragraph * 80 if context is None else context
+    context_ids = _tokenize(base_url, model, context_text)
     suffix_ids = _tokenize(base_url, model, suffix)
     context_len = input_len - len(prefix_ids) - len(suffix_ids)
     if context_len < 0 or not context_ids:
         raise ValueError("Unable to construct the requested input length")
     if len(context_ids) < context_len:
+        if context is not None:
+            raise ValueError("The supplied context file is too short")
         repeats = (context_len + len(context_ids) - 1) // len(context_ids)
         context_ids *= repeats
     prompt_ids = prefix_ids + context_ids[:context_len] + suffix_ids
@@ -76,10 +84,21 @@ def main() -> int:
     parser.add_argument("--seed", type=int, default=4201)
     parser.add_argument("--temperature", type=float, default=1.0)
     parser.add_argument("--top-p", type=float, default=1.0)
+    parser.add_argument("--context-file", type=Path)
     parser.add_argument("--output", type=Path)
     args = parser.parse_args()
 
-    prompt_ids = _build_prompt_ids(args.base_url, args.model, args.input_len)
+    context = (
+        args.context_file.read_text(encoding="utf-8")
+        if args.context_file is not None
+        else None
+    )
+    prompt_ids = _build_prompt_ids(
+        args.base_url,
+        args.model,
+        args.input_len,
+        context,
+    )
     payload = {
         "model": args.model,
         "prompt": prompt_ids,

--- a/benchmarks/benchmark_sm70_openai_stream.py
+++ b/benchmarks/benchmark_sm70_openai_stream.py
@@ -54,8 +54,11 @@ def _build_prompt_ids(base_url: str, model: str, input_len: int) -> list[int]:
     context_ids = _tokenize(base_url, model, paragraph * 80)
     suffix_ids = _tokenize(base_url, model, suffix)
     context_len = input_len - len(prefix_ids) - len(suffix_ids)
-    if context_len < 0 or len(context_ids) < context_len:
+    if context_len < 0 or not context_ids:
         raise ValueError("Unable to construct the requested input length")
+    if len(context_ids) < context_len:
+        repeats = (context_len + len(context_ids) - 1) // len(context_ids)
+        context_ids *= repeats
     prompt_ids = prefix_ids + context_ids[:context_len] + suffix_ids
     if len(prompt_ids) != input_len:
         raise AssertionError(

--- a/csrc/deepseek_v4_sm70_sparse_attention.cu
+++ b/csrc/deepseek_v4_sm70_sparse_attention.cu
@@ -1,0 +1,320 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+ */
+
+#include <ATen/cuda/CUDAContext.h>
+#include <c10/cuda/CUDAGuard.h>
+#include <c10/cuda/CUDAException.h>
+#include <cuda_fp16.h>
+#include <cuda_runtime.h>
+#include <mma.h>
+#include <torch/all.h>
+
+#include <limits>
+
+namespace vllm::deepseek_v4_sm70_sparse {
+
+namespace {
+
+constexpr int kHeads = 8;
+constexpr int kHeadDim = 512;
+constexpr int kMaxIndexWidth = 640;
+constexpr int kKeysPerTile = 16;
+constexpr int kWarps = 8;
+constexpr int kThreads = kWarps * 32;
+constexpr int kDimsPerWarp = kHeadDim / kWarps;
+constexpr int kQTilesPerWarp = kDimsPerWarp / 16;
+constexpr int kKvStride = kHeadDim + 8;
+constexpr int kQStageStride = kDimsPerWarp + 8;
+constexpr int kScoreStride = 20;
+constexpr int kProbStride = 24;
+
+using half = __half;
+using half2 = __half2;
+namespace wmma = nvcuda::wmma;
+
+struct alignas(16) SharedStorage {
+  half kv[kKeysPerTile][kKvStride];
+  half q_stage[kWarps][16][kQStageStride];
+  union {
+    float qk[kWarps][16][kScoreStride];
+    float pv[kWarps][16][16];
+  } mma;
+  half probs[16][kProbStride];
+  float alpha[kHeads];
+  float final_scale[kHeads];
+  int slots[kKeysPerTile];
+  int valid[kKeysPerTile];
+};
+
+__device__ __forceinline__ float fast_exp(float value) { return __expf(value); }
+
+__global__ __launch_bounds__(kThreads, 2) void sparse_attention_hmma_kernel(
+    half const* __restrict__ q, half const* __restrict__ kv,
+    int const* __restrict__ indices, int const* __restrict__ lengths,
+    float const* __restrict__ sink, half* __restrict__ out,
+    int64_t q_stride_t, int64_t q_stride_h, int64_t kv_stride_n,
+    int64_t indices_stride_t, int64_t out_stride_t, int64_t out_stride_h,
+    int index_width, int num_kv, float scale) {
+  int const query_idx = blockIdx.x;
+  int const tid = threadIdx.x;
+  int const warp = tid / 32;
+  int const lane = tid % 32;
+  extern __shared__ __align__(16) unsigned char shared_bytes[];
+  auto& shared = *reinterpret_cast<SharedStorage*>(shared_bytes);
+
+  using MatrixA = wmma::fragment<wmma::matrix_a, 16, 16, 16, half,
+                                 wmma::row_major>;
+  using MatrixBCol = wmma::fragment<wmma::matrix_b, 16, 16, 16, half,
+                                    wmma::col_major>;
+  using MatrixBRow = wmma::fragment<wmma::matrix_b, 16, 16, 16, half,
+                                    wmma::row_major>;
+  using Accumulator = wmma::fragment<wmma::accumulator, 16, 16, 16, float>;
+
+  float output_acc[kQTilesPerWarp * 4];
+#pragma unroll
+  for (float& value : output_acc) {
+    value = 0.0f;
+  }
+  float running_max = -std::numeric_limits<float>::infinity();
+  float running_sum = 0.0f;
+  int const valid_len = lengths[query_idx];
+
+#pragma unroll
+  for (int pair = lane; pair < 16 * (kDimsPerWarp / 2); pair += 32) {
+    int const row = pair / (kDimsPerWarp / 2);
+    int const column_pair = pair % (kDimsPerWarp / 2);
+    int const dim = warp * kDimsPerWarp + column_pair * 2;
+    half2 value = __float2half2_rn(0.0f);
+    if (row < kHeads) {
+      auto const* q_row = reinterpret_cast<half2 const*>(
+          q + query_idx * q_stride_t + row * q_stride_h);
+      value = q_row[dim / 2];
+    }
+    auto* q_stage_row =
+        reinterpret_cast<half2*>(&shared.q_stage[warp][row][0]);
+    q_stage_row[column_pair] = value;
+  }
+  __syncwarp();
+
+  for (int key_start = 0; key_start < index_width;
+       key_start += kKeysPerTile) {
+    if (tid < kKeysPerTile) {
+      int const slot = indices[query_idx * indices_stride_t + key_start + tid];
+      bool const is_valid = key_start + tid < valid_len && slot >= 0 &&
+                            slot < num_kv;
+      shared.slots[tid] = is_valid ? slot : 0;
+      shared.valid[tid] = is_valid;
+    }
+    __syncthreads();
+
+#pragma unroll 1
+    for (int pair = tid; pair < kKeysPerTile * (kHeadDim / 2);
+         pair += kThreads) {
+      int const key = pair / (kHeadDim / 2);
+      int const dim_pair = pair % (kHeadDim / 2);
+      half2 value = __float2half2_rn(0.0f);
+      if (shared.valid[key]) {
+        auto const* kv_row = reinterpret_cast<half2 const*>(
+            kv + static_cast<int64_t>(shared.slots[key]) * kv_stride_n);
+        value = kv_row[dim_pair];
+      }
+      auto* shared_kv_row = reinterpret_cast<half2*>(&shared.kv[key][0]);
+      shared_kv_row[dim_pair] = value;
+    }
+    __syncthreads();
+
+    Accumulator score_fragment;
+    wmma::fill_fragment(score_fragment, 0.0f);
+#pragma unroll
+    for (int tile = 0; tile < kQTilesPerWarp; ++tile) {
+      MatrixA query_fragment;
+      MatrixBCol key_fragment;
+      wmma::load_matrix_sync(query_fragment,
+                             &shared.q_stage[warp][0][tile * 16],
+                             kQStageStride);
+      wmma::load_matrix_sync(
+          key_fragment,
+          &shared.kv[0][warp * kDimsPerWarp + tile * 16], kKvStride);
+      wmma::mma_sync(score_fragment, query_fragment, key_fragment,
+                     score_fragment);
+    }
+    wmma::store_matrix_sync(&shared.mma.qk[warp][0][0], score_fragment,
+                            kScoreStride, wmma::mem_row_major);
+    __syncthreads();
+
+    float score = -std::numeric_limits<float>::infinity();
+    if (lane < kKeysPerTile) {
+      score = shared.mma.qk[0][warp][lane];
+#pragma unroll
+      for (int partial = 1; partial < kWarps; ++partial) {
+        score += shared.mma.qk[partial][warp][lane];
+      }
+      score *= scale;
+    }
+
+    float block_max = -std::numeric_limits<float>::infinity();
+#pragma unroll
+    for (int key = 0; key < kKeysPerTile; ++key) {
+      float const key_score = __shfl_sync(0xffffffff, score, key);
+      if (lane == 0 && shared.valid[key]) {
+        block_max = fmaxf(block_max, key_score);
+      }
+    }
+
+    float new_max = 0.0f;
+    if (lane == 0) {
+      new_max = fmaxf(running_max, block_max);
+    }
+    new_max = __shfl_sync(0xffffffff, new_max, 0);
+    float probability = 0.0f;
+    if (lane < kKeysPerTile && shared.valid[lane]) {
+      probability = fast_exp(score - new_max);
+    }
+
+    float block_sum = 0.0f;
+#pragma unroll
+    for (int key = 0; key < kKeysPerTile; ++key) {
+      float const key_probability =
+          __shfl_sync(0xffffffff, probability, key);
+      if (lane == 0) {
+        block_sum += key_probability;
+      }
+    }
+
+    if (lane == 0) {
+      float const alpha = fast_exp(running_max - new_max);
+      running_sum = running_sum * alpha + block_sum;
+      running_max = new_max;
+      shared.alpha[warp] = alpha;
+    }
+    if (lane < kKeysPerTile) {
+      shared.probs[warp][lane] = __float2half_rn(probability);
+      shared.probs[kHeads + warp][lane] = __float2half(0.0f);
+    }
+    __syncthreads();
+
+    MatrixA probability_fragment;
+    wmma::load_matrix_sync(probability_fragment, &shared.probs[0][0],
+                           kProbStride);
+#pragma unroll
+    for (int tile = 0; tile < kQTilesPerWarp; ++tile) {
+      MatrixBRow value_fragment;
+      Accumulator output_fragment;
+      wmma::load_matrix_sync(
+          value_fragment,
+          &shared.kv[0][warp * kDimsPerWarp + tile * 16], kKvStride);
+      wmma::fill_fragment(output_fragment, 0.0f);
+      wmma::mma_sync(output_fragment, probability_fragment, value_fragment,
+                     output_fragment);
+      wmma::store_matrix_sync(&shared.mma.pv[warp][0][0], output_fragment, 16,
+                              wmma::mem_row_major);
+      __syncwarp();
+#pragma unroll
+      for (int element = 0; element < 4; ++element) {
+        int const linear = lane + element * 32;
+        int const head = linear / 16;
+        output_acc[tile * 4 + element] =
+            output_acc[tile * 4 + element] * shared.alpha[head] +
+            shared.mma.pv[warp][head][linear % 16];
+      }
+      __syncwarp();
+    }
+  }
+
+  if (lane == 0) {
+    float const final_max = fmaxf(running_max, sink[warp]);
+    float const alpha = fast_exp(running_max - final_max);
+    float const final_sum =
+        running_sum * alpha + fast_exp(sink[warp] - final_max);
+    shared.final_scale[warp] = alpha / fmaxf(final_sum, 1.0e-30f);
+  }
+  __syncthreads();
+
+#pragma unroll
+  for (int tile = 0; tile < kQTilesPerWarp; ++tile) {
+#pragma unroll
+    for (int element = 0; element < 4; ++element) {
+      int const linear = lane + element * 32;
+      int const head = linear / 16;
+      int const dim = warp * kDimsPerWarp + tile * 16 + linear % 16;
+      out[query_idx * out_stride_t + head * out_stride_h + dim] =
+          __float2half_rn(output_acc[tile * 4 + element] *
+                          shared.final_scale[head]);
+    }
+  }
+}
+
+}  // namespace
+
+void launch(torch::Tensor const& q, torch::Tensor const& kv,
+            torch::Tensor const& indices, torch::Tensor const& lengths,
+            torch::Tensor const& sink, torch::Tensor& out, double scale) {
+  TORCH_CHECK(q.is_cuda() && kv.is_cuda() && indices.is_cuda() &&
+                  lengths.is_cuda() && sink.is_cuda() && out.is_cuda(),
+              "all tensors must be CUDA tensors");
+  TORCH_CHECK(q.device() == kv.device() && q.device() == indices.device() &&
+                  q.device() == lengths.device() && q.device() == sink.device() &&
+                  q.device() == out.device(),
+              "all tensors must be on the same CUDA device");
+  at::cuda::OptionalCUDAGuard device_guard(device_of(q));
+  TORCH_CHECK(at::cuda::getCurrentDeviceProperties()->major == 7 &&
+                  at::cuda::getCurrentDeviceProperties()->minor == 0,
+              "sm70_deepseek_v4_sparse_attention_hmma requires SM70");
+  TORCH_CHECK(q.scalar_type() == torch::kFloat16 &&
+                  kv.scalar_type() == torch::kFloat16 &&
+                  out.scalar_type() == torch::kFloat16,
+              "q, kv, and out must be float16");
+  TORCH_CHECK(indices.scalar_type() == torch::kInt32 &&
+                  lengths.scalar_type() == torch::kInt32 &&
+                  sink.scalar_type() == torch::kFloat32,
+              "indices and lengths must be int32; sink must be float32");
+  TORCH_CHECK(q.dim() == 3 && q.size(1) == kHeads &&
+                  q.size(2) == kHeadDim,
+              "q must have shape [tokens, 8, 512]");
+  TORCH_CHECK(kv.dim() == 2 && kv.size(1) == kHeadDim,
+              "kv must have shape [tokens, 512]");
+  TORCH_CHECK(indices.dim() == 2 && indices.size(0) == q.size(0),
+              "indices must have one row per query token");
+  TORCH_CHECK(indices.size(1) == 128 || indices.size(1) == 256 ||
+                  indices.size(1) == kMaxIndexWidth,
+              "indices width must be 128, 256, or 640");
+  TORCH_CHECK(lengths.numel() == q.size(0),
+              "lengths must contain one entry per query token");
+  TORCH_CHECK(sink.numel() >= kHeads, "sink must contain at least 8 entries");
+  TORCH_CHECK(out.sizes() == q.sizes(), "out must match q shape");
+  TORCH_CHECK(q.stride(2) == 1 && kv.stride(1) == 1 &&
+                  indices.stride(1) == 1 && out.stride(2) == 1,
+              "innermost tensor dimensions must be contiguous");
+  TORCH_CHECK(lengths.is_contiguous() && sink.is_contiguous(),
+              "lengths and sink must be contiguous");
+  TORCH_CHECK(q.stride(0) % 2 == 0 && q.stride(1) % 2 == 0 &&
+                  kv.stride(0) % 2 == 0,
+              "q and kv row strides must be aligned for half2 loads");
+  if (q.size(0) == 0) {
+    return;
+  }
+
+  cudaStream_t stream = at::cuda::getCurrentCUDAStream();
+  sparse_attention_hmma_kernel<<<q.size(0), kThreads, sizeof(SharedStorage),
+                                 stream>>>(
+      reinterpret_cast<half const*>(q.data_ptr()),
+      reinterpret_cast<half const*>(kv.data_ptr()), indices.data_ptr<int>(),
+      lengths.data_ptr<int>(), sink.data_ptr<float>(),
+      reinterpret_cast<half*>(out.data_ptr()), q.stride(0), q.stride(1),
+      kv.stride(0), indices.stride(0), out.stride(0), out.stride(1),
+      static_cast<int>(indices.size(1)), static_cast<int>(kv.size(0)),
+      static_cast<float>(scale));
+  C10_CUDA_KERNEL_LAUNCH_CHECK();
+}
+
+}  // namespace vllm::deepseek_v4_sm70_sparse
+
+void sm70_deepseek_v4_sparse_attention_hmma(
+    torch::Tensor const& q, torch::Tensor const& kv,
+    torch::Tensor const& indices, torch::Tensor const& lengths,
+    torch::Tensor const& sink, torch::Tensor& out, double scale) {
+  vllm::deepseek_v4_sm70_sparse::launch(q, kv, indices, lengths, sink, out,
+                                        scale);
+}

--- a/csrc/moe/moe_ops.h
+++ b/csrc/moe/moe_ops.h
@@ -65,6 +65,15 @@ bool moe_permute_unpermute_supported();
 int64_t moe_permute_sort_workspace_size(int64_t num_expanded_rows,
                                         int64_t num_experts);
 
+void moe_permute_indexed_with_scratch(
+    const torch::Tensor& input, const torch::Tensor& topk_ids,
+    const torch::Tensor& token_expert_indices, int64_t n_expert,
+    int64_t n_local_expert, int64_t topk, torch::Tensor& permuted_input,
+    torch::Tensor& expert_first_token_offset, torch::Tensor& inv_permuted_idx,
+    torch::Tensor& permuted_idx, torch::Tensor& sort_workspace,
+    torch::Tensor& permuted_experts_id, torch::Tensor& sorted_row_idx,
+    torch::Tensor& topk_ids_for_sort);
+
 void shuffle_rows(const torch::Tensor& input_tensor,
                   const torch::Tensor& dst2src_map,
                   torch::Tensor& output_tensor);

--- a/csrc/moe/moe_permute_unpermute_op.cu
+++ b/csrc/moe/moe_permute_unpermute_op.cu
@@ -32,6 +32,37 @@ int64_t pad_to_multiple_of_16(int64_t value) {
   return (value + 15) / 16 * 16;
 }
 
+__global__ void prepareMoeIndexedRowsKernel(
+    int* expanded_dest_row_to_expanded_source_row,
+    int* expanded_source_row_to_expanded_dest_row, int* permuted_idx,
+    int64_t num_expanded_rows, int topk) {
+  const int64_t expanded_dest_row =
+      static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  if (expanded_dest_row >= num_expanded_rows) {
+    return;
+  }
+
+  const int expanded_source_row =
+      expanded_dest_row_to_expanded_source_row[expanded_dest_row];
+  expanded_source_row_to_expanded_dest_row[expanded_source_row] =
+      static_cast<int>(expanded_dest_row);
+  permuted_idx[expanded_dest_row] = expanded_source_row;
+  expanded_dest_row_to_expanded_source_row[expanded_dest_row] =
+      expanded_source_row / topk;
+}
+
+void prepareMoeIndexedRowsKernelLauncher(
+    int* expanded_dest_row_to_expanded_source_row,
+    int* expanded_source_row_to_expanded_dest_row, int* permuted_idx,
+    int64_t num_expanded_rows, int topk, cudaStream_t stream) {
+  constexpr int threads = 256;
+  const int blocks = static_cast<int>((num_expanded_rows + threads - 1) / threads);
+  prepareMoeIndexedRowsKernel<<<blocks, threads, 0, stream>>>(
+      expanded_dest_row_to_expanded_source_row,
+      expanded_source_row_to_expanded_dest_row, permuted_idx,
+      num_expanded_rows, topk);
+}
+
 }  // namespace
 
 int64_t moe_permute_sort_workspace_size(int64_t num_expanded_rows,
@@ -53,7 +84,8 @@ void moe_permute_impl(
     const std::optional<torch::Tensor>& maybe_sort_workspace,
     const std::optional<torch::Tensor>& maybe_permuted_experts_id,
     const std::optional<torch::Tensor>& maybe_sorted_row_idx,
-    const std::optional<torch::Tensor>& maybe_topk_ids_for_sort) {
+    const std::optional<torch::Tensor>& maybe_topk_ids_for_sort,
+    bool materialize_input) {
   TORCH_CHECK(expert_first_token_offset.scalar_type() == at::ScalarType::Long,
               "expert_first_token_offset must be int64");
   TORCH_CHECK(topk_ids.scalar_type() == at::ScalarType::Int,
@@ -72,7 +104,10 @@ void moe_permute_impl(
   auto expanded_rows = n_token * topk;
   auto stream = at::cuda::getCurrentCUDAStream().stream();
 
-  if (canUseSingleTokenMoePermuteFastPath(
+  TORCH_CHECK(materialize_input || !expert_map.has_value(),
+              "metadata-only MoE permute does not support expert parallelism");
+
+  if (materialize_input && canUseSingleTokenMoePermuteFastPath(
           n_token, topk, expert_map.has_value(), n_expert, n_local_expert)) {
     if (input.scalar_type() == at::ScalarType::Half) {
       singleTokenMoePermuteLauncher<half>(
@@ -139,6 +174,14 @@ void moe_permute_impl(
       get_ptr<int64_t>(expert_first_token_offset), n_token, n_expert,
       n_local_expert, topk, sorter, get_ptr<int>(sort_workspace), stream);
 
+  if (!materialize_input) {
+    prepareMoeIndexedRowsKernelLauncher(
+        get_ptr<int>(sorted_row_idx), get_ptr<int>(inv_permuted_idx),
+        get_ptr<int>(permuted_idx), expanded_rows, static_cast<int>(topk),
+        stream);
+    return;
+  }
+
   MOE_DISPATCH(input.scalar_type(), [&] {
     expandInputRowsKernelLauncher<scalar_t>(
         get_ptr<scalar_t>(input), get_ptr<scalar_t>(permuted_input),
@@ -161,7 +204,8 @@ void moe_permute(
   moe_permute_impl(input, topk_ids, token_expert_indices, expert_map, n_expert,
                    n_local_expert, topk, permuted_input,
                    expert_first_token_offset, inv_permuted_idx, permuted_idx,
-                   std::nullopt, std::nullopt, std::nullopt, std::nullopt);
+                   std::nullopt, std::nullopt, std::nullopt, std::nullopt,
+                   true);
 }
 
 void moe_permute_with_scratch(
@@ -177,7 +221,22 @@ void moe_permute_with_scratch(
                    n_local_expert, topk, permuted_input,
                    expert_first_token_offset, inv_permuted_idx, permuted_idx,
                    sort_workspace, permuted_experts_id, sorted_row_idx,
-                   topk_ids_for_sort);
+                   topk_ids_for_sort, true);
+}
+
+void moe_permute_indexed_with_scratch(
+    const torch::Tensor& input, const torch::Tensor& topk_ids,
+    const torch::Tensor& token_expert_indices, int64_t n_expert,
+    int64_t n_local_expert, int64_t topk, torch::Tensor& permuted_input,
+    torch::Tensor& expert_first_token_offset, torch::Tensor& inv_permuted_idx,
+    torch::Tensor& permuted_idx, torch::Tensor& sort_workspace,
+    torch::Tensor& permuted_experts_id, torch::Tensor& sorted_row_idx,
+    torch::Tensor& topk_ids_for_sort) {
+  moe_permute_impl(input, topk_ids, token_expert_indices, std::nullopt,
+                   n_expert, n_local_expert, topk, permuted_input,
+                   expert_first_token_offset, inv_permuted_idx, permuted_idx,
+                   sort_workspace, permuted_experts_id, sorted_row_idx,
+                   topk_ids_for_sort, false);
 }
 
 void moe_unpermute(
@@ -323,6 +382,19 @@ void moe_permute_with_scratch(
               "moe_permute_with_scratch is not supported on CUDA < 12.0");
 }
 
+void moe_permute_indexed_with_scratch(
+    const torch::Tensor& input, const torch::Tensor& topk_ids,
+    const torch::Tensor& token_expert_indices, int64_t n_expert,
+    int64_t n_local_expert, int64_t topk, torch::Tensor& permuted_input,
+    torch::Tensor& expert_first_token_offset, torch::Tensor& inv_permuted_idx,
+    torch::Tensor& permuted_idx, torch::Tensor& sort_workspace,
+    torch::Tensor& permuted_experts_id, torch::Tensor& sorted_row_idx,
+    torch::Tensor& topk_ids_for_sort) {
+  TORCH_CHECK(
+      false,
+      "moe_permute_indexed_with_scratch is not supported on CUDA < 12.0");
+}
+
 void moe_unpermute(
     const torch::Tensor& permuted_hidden_states,
     const torch::Tensor& topk_weights, const torch::Tensor& inv_permuted_idx,
@@ -344,5 +416,7 @@ bool moe_permute_unpermute_supported() {
 TORCH_LIBRARY_IMPL_EXPAND(TORCH_EXTENSION_NAME, CUDA, m) {
   m.impl("moe_permute", &moe_permute);
   m.impl("moe_permute_with_scratch", &moe_permute_with_scratch);
+  m.impl("moe_permute_indexed_with_scratch",
+         &moe_permute_indexed_with_scratch);
   m.impl("moe_unpermute", &moe_unpermute);
 }

--- a/csrc/moe/torch_bindings.cpp
+++ b/csrc/moe/torch_bindings.cpp
@@ -110,6 +110,14 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, m) {
       "Tensor! sorted_row_idx, Tensor! topk_ids_for_sort)->()");
 
   m.def(
+      "moe_permute_indexed_with_scratch(Tensor input, Tensor topk_ids,"
+      "Tensor token_expert_indices, int n_expert, int n_local_expert,"
+      "int topk, Tensor! permuted_input, Tensor! "
+      "expert_first_token_offset, Tensor! inv_permuted_idx, Tensor! "
+      "permuted_idx, Tensor! sort_workspace, Tensor! permuted_experts_id, "
+      "Tensor! sorted_row_idx, Tensor! topk_ids_for_sort)->()");
+
+  m.def(
       "moe_unpermute(Tensor permuted_hidden_states, Tensor topk_weights,"
       "Tensor inv_permuted_idx, Tensor? expert_first_token_offset, "
       "int topk, Tensor! hidden_states)->()");

--- a/csrc/ops.h
+++ b/csrc/ops.h
@@ -46,6 +46,13 @@ torch::Tensor fused_deepseek_v4_qnorm_rope_kv_rope_quant_insert(
     torch::Tensor const& cos_sin_cache, int64_t q_head_padded, double eps,
     int64_t cache_block_size);
 
+#ifndef USE_ROCM
+void sm70_deepseek_v4_sparse_attention_hmma(
+    torch::Tensor const& q, torch::Tensor const& kv,
+    torch::Tensor const& indices, torch::Tensor const& lengths,
+    torch::Tensor const& sink, torch::Tensor& out, double scale);
+#endif
+
 void silu_and_mul_per_block_quant(torch::Tensor& out,
                                   torch::Tensor const& input,
                                   torch::Tensor& scales, int64_t group_size,
@@ -499,6 +506,19 @@ void mxfp4_moe_dense_stage_sm70_out(torch::Tensor out,
                                     int64_t k,
                                     int64_t n,
                                     int64_t group_size);
+
+void mxfp4_moe_indexed_dense_stage_sm70_out(
+    torch::Tensor out,
+    torch::Tensor input,
+    torch::Tensor input_row_indices,
+    torch::Tensor expert_offsets,
+    torch::Tensor dense_expert_ids,
+    torch::Tensor ptrs_w,
+    torch::Tensor ptrs_s,
+    int64_t num_experts,
+    int64_t k,
+    int64_t n,
+    int64_t group_size);
 
 void mxfp4_moe_single_token_prepare_w13_sm70_out(
     torch::Tensor gate_up,

--- a/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/gemm.cu
+++ b/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/gemm.cu
@@ -81,6 +81,19 @@ bool Sm70AwqMtpM5FastSelectorEnabled()
     return !raw || std::atoi(raw) != 0;
 }
 
+bool Sm70Fp8PrefillFastSelectorEnabled()
+{
+    const char* raw = std::getenv("VLLM_SM70_FP8_PREFILL_FAST_SELECTOR");
+    return raw && std::atoi(raw) != 0;
+}
+
+bool Sm70Mxfp4MoePrefillFastSelectorEnabled()
+{
+    const char* raw     = std::getenv("VLLM_SM70_MXFP4_MOE_PREFILL_FAST_SELECTOR");
+    const char* grouped = std::getenv("VLLM_SM70_MXFP4_MOE_GROUPED_PREFILL");
+    return raw && std::atoi(raw) != 0 && grouped && std::atoi(grouped) != 0;
+}
+
 struct Sm70AwqTp2FastTarget {
     int  n;
     int  k;
@@ -157,12 +170,53 @@ std::optional<Sm70AwqTp2FastTarget> GetSm70AwqTp2EnvFastTarget(const GemmDesc&  
 
 std::optional<Sm70AwqTp2FastTarget> GetSm70AwqTp2FastTarget(const GemmDesc& desc)
 {
-    if (!Sm70AwqTp2FastSelectorEnabled()) {
+    const bool awq_enabled    = Sm70AwqTp2FastSelectorEnabled();
+    const bool fp8_enabled    = Sm70Fp8PrefillFastSelectorEnabled();
+    const bool mxfp4_enabled  = Sm70Mxfp4MoePrefillFastSelectorEnabled();
+    if (!awq_enabled && !fp8_enabled && !mxfp4_enabled) {
         return std::nullopt;
     }
     const std::string desc_str = to_string(desc);
-    if (auto target = GetSm70AwqTp2EnvFastTarget(desc, desc_str)) {
-        return target;
+    if (awq_enabled) {
+        if (auto target = GetSm70AwqTp2EnvFastTarget(desc, desc_str)) {
+            return target;
+        }
+    }
+    // Exact DeepSeek V4 TP8 group-64 W2 prefill. Swizzle 4 preserves the
+    // baseline output bit-for-bit and improves grouped dispatch, but regresses
+    // the per-expert route, so require grouped prefill as part of the gate.
+    if (mxfp4_enabled
+        && desc_str == "sm70_f16_e2m1k32_f16_tnt_bbb_49152x4096x256_1") {
+        return Sm70AwqTp2FastTarget{
+            desc.n, desc.k, 128, 128, 16, 1, 4, true, ""};
+    }
+    // These exact DeepSeek V4 TP8 prefill shapes preserve the baseline output
+    // bit-for-bit. Keep shared_gate_up on the baseline tactic: all faster
+    // candidates tested for that shape changed its FP16 output.
+    if (fp8_enabled) {
+        if (desc_str == "sm70_f16_e4m3k128_f16_tnt_fff_8192x1536x4096_1") {
+            return Sm70AwqTp2FastTarget{
+                desc.n, desc.k, 128, 128, 16, 1, 4, true, ""};
+        }
+        if (desc_str == "sm70_f16_e4m3k128_f16_tnt_fff_8192x4096x1024_1") {
+            return Sm70AwqTp2FastTarget{
+                desc.n, desc.k, 128, 128, 16, 1, 4, true, ""};
+        }
+        if (desc_str == "sm70_f16_e4m3k128_f16_tnt_fff_8192x1024x4096_1") {
+            return Sm70AwqTp2FastTarget{
+                desc.n, desc.k, 128, 128, 16, 1, 3, true, ""};
+        }
+        if (desc_str == "sm70_f16_e4m3k128_f16_tnt_fff_8192x4096x256_1") {
+            return Sm70AwqTp2FastTarget{
+                desc.n, desc.k, 128, 128, 16, 1, 4, true, ""};
+        }
+        if (desc_str == "sm70_f16_e4m3k128_f16_tnt_fff_8192x8192x1024_1") {
+            return Sm70AwqTp2FastTarget{
+                desc.n, desc.k, 64, 256, 16, 1, 2, true, ""};
+        }
+    }
+    if (!awq_enabled) {
+        return std::nullopt;
     }
     if (desc_str == "sm70_f16_u4k128_f16_tnt_fff_5x17408x5120_1") {
         return Sm70AwqTp2FastTarget{desc.n, desc.k, 8, 64, 64, 1, 0, false, ""};

--- a/csrc/sm70_turbomind/ops/awq_sm70_gemm.cu
+++ b/csrc/sm70_turbomind/ops/awq_sm70_gemm.cu
@@ -7124,7 +7124,8 @@ void mxfp4_moe_gemm_sm70_out_impl(
     torch::Tensor strided_ptrs_w, torch::Tensor strided_ptrs_s,
     int64_t num_experts, int64_t k, int64_t n, int64_t group_size,
     torch::Tensor b_group_indices, bool compact_grouped_rows = false,
-    bool preserve_per_expert_dispatch = false) {
+    bool preserve_per_expert_dispatch = false,
+    torch::Tensor input_row_indices = torch::Tensor()) {
   TORCH_CHECK(
       sorted_input.is_cuda() && sorted_input.scalar_type() == torch::kFloat16,
       "mxfp4_moe_gemm_sm70: input must be CUDA float16.");
@@ -7144,7 +7145,19 @@ void mxfp4_moe_gemm_sm70_out_impl(
               "mxfp4_moe_gemm_sm70: k must be divisible by group_size.");
   TORCH_CHECK(sorted_input.dim() == 2 && sorted_input.size(1) == k,
               "mxfp4_moe_gemm_sm70: input shape mismatch.");
-  TORCH_CHECK(out.dim() == 2 && out.size(0) == sorted_input.size(0) &&
+  const bool indexed_input = input_row_indices.defined();
+  if (indexed_input) {
+    TORCH_CHECK(input_row_indices.is_cuda() &&
+                    input_row_indices.scalar_type() == torch::kInt32 &&
+                    input_row_indices.is_contiguous(),
+                "mxfp4_moe_gemm_sm70: input row indices must be contiguous "
+                "CUDA int32.");
+    TORCH_CHECK(input_row_indices.numel() >= out.size(0),
+                "mxfp4_moe_gemm_sm70: input row indices are too small.");
+  }
+  const int64_t total_tokens =
+      indexed_input ? out.size(0) : sorted_input.size(0);
+  TORCH_CHECK(out.dim() == 2 && out.size(0) == total_tokens &&
                   out.size(1) == n && out.stride(1) == 1,
               "mxfp4_moe_gemm_sm70: output must be contiguous [tokens, n].");
   TORCH_CHECK(expert_offsets.numel() >= num_experts + 1,
@@ -7156,7 +7169,6 @@ void mxfp4_moe_gemm_sm70_out_impl(
               "mxfp4_moe_gemm_sm70: B group indices must be contiguous CUDA "
               "int32.");
 
-  const int64_t total_tokens = sorted_input.size(0);
   if (total_tokens == 0) {
     return;
   }
@@ -7181,6 +7193,8 @@ void mxfp4_moe_gemm_sm70_out_impl(
   };
   desc_A.num = static_cast<int>(num_experts);
   desc_A.offsets = expert_offsets.data_ptr<int>();
+  desc_A.idxs =
+      indexed_input ? input_row_indices.data_ptr<int>() : nullptr;
   turbomind::gemm::MatrixLayout desc_U{};
 
   const auto order_w = conv_w->order;
@@ -7270,11 +7284,11 @@ void mxfp4_moe_gemm_sm70_out_impl(
               ").");
 }
 
-void mxfp4_moe_dense_stage_sm70_out(
+void mxfp4_moe_dense_stage_sm70_out_impl(
     torch::Tensor out, torch::Tensor input, torch::Tensor expert_offsets,
     torch::Tensor dense_expert_ids, torch::Tensor ptrs_w,
     torch::Tensor ptrs_s, int64_t num_experts, int64_t k, int64_t n,
-    int64_t group_size) {
+    int64_t group_size, torch::Tensor input_row_indices) {
   TORCH_CHECK(
       input.is_cuda() && input.scalar_type() == torch::kFloat16,
       "mxfp4_moe_dense_stage_sm70_out: input must be CUDA float16.");
@@ -7299,8 +7313,17 @@ void mxfp4_moe_dense_stage_sm70_out(
               "supported.");
   TORCH_CHECK(input.dim() == 2 && input.size(1) == k,
               "mxfp4_moe_dense_stage_sm70_out: input shape mismatch.");
-  TORCH_CHECK(out.dim() == 2 && out.size(0) == input.size(0) &&
-                  out.size(1) == n,
+  const bool indexed_input = input_row_indices.defined();
+  if (indexed_input) {
+    TORCH_CHECK(input_row_indices.is_cuda() &&
+                    input_row_indices.scalar_type() == torch::kInt32 &&
+                    input_row_indices.is_contiguous() &&
+                    input_row_indices.numel() >= out.size(0),
+                "mxfp4_moe_dense_stage_sm70_out: indexed input requires "
+                "contiguous CUDA int32 row indices.");
+  }
+  const int64_t logical_rows = indexed_input ? out.size(0) : input.size(0);
+  TORCH_CHECK(out.dim() == 2 && out.size(0) == logical_rows && out.size(1) == n,
               "mxfp4_moe_dense_stage_sm70_out: out shape mismatch.");
   TORCH_CHECK(expert_offsets.numel() >= num_experts + 1,
               "mxfp4_moe_dense_stage_sm70_out: expert_offsets too small.");
@@ -7312,12 +7335,12 @@ void mxfp4_moe_dense_stage_sm70_out(
   maybe_log_sm70_moe_route_once(
       logged_mxfp4_dense_stage,
       "SM70 MXFP4 MoE CUDA-graph-safe dense-stage path enabled C++ op reached",
-      input, input.size(0), num_experts);
+      input, logical_rows, num_experts);
   constexpr int kDeepSeekV4Experts = 256;
   constexpr int kDeepSeekV4PrefillMinRows = 1024 * 6;
   if (vllm::awq_sm70::mxfp4_moe_grouped_prefill_enabled() &&
       num_experts == kDeepSeekV4Experts &&
-      input.size(0) >= kDeepSeekV4PrefillMinRows) {
+      logical_rows >= kDeepSeekV4PrefillMinRows) {
     static std::atomic<unsigned> logged_mxfp4_grouped_prefill{0u};
     maybe_log_sm70_moe_route_once(
         logged_mxfp4_grouped_prefill,
@@ -7336,12 +7359,12 @@ void mxfp4_moe_dense_stage_sm70_out(
           dense_expert_ids.narrow(0, expert, launch_experts);
       mxfp4_moe_gemm_sm70_out_impl(
           out, input, offsets, ptrs_w, ptrs_s, launch_experts, k, n,
-          group_size, expert_ids, false, true);
+          group_size, expert_ids, false, true, input_row_indices);
     }
     return;
   }
   const bool compact_decode_shape =
-      input.size(0) == num_experts && num_experts == 6 &&
+      !indexed_input && input.size(0) == num_experts && num_experts == 6 &&
       ((k == 4096 && n == 512) || (k == 256 && n == 4096));
   if (vllm::awq_sm70::mxfp4_moe_compact_grouped_decode_enabled() &&
       compact_decode_shape) {
@@ -7354,8 +7377,29 @@ void mxfp4_moe_dense_stage_sm70_out(
     torch::Tensor offsets = expert_offsets.narrow(0, expert, 2);
     torch::Tensor expert_idx = dense_expert_ids.narrow(0, expert, 1);
     mxfp4_moe_gemm_sm70_out_impl(out, input, offsets, ptrs_w, ptrs_s, 1, k,
-                                 n, group_size, expert_idx);
+                                 n, group_size, expert_idx, false, false,
+                                 input_row_indices);
   }
+}
+
+void mxfp4_moe_dense_stage_sm70_out(
+    torch::Tensor out, torch::Tensor input, torch::Tensor expert_offsets,
+    torch::Tensor dense_expert_ids, torch::Tensor ptrs_w,
+    torch::Tensor ptrs_s, int64_t num_experts, int64_t k, int64_t n,
+    int64_t group_size) {
+  mxfp4_moe_dense_stage_sm70_out_impl(
+      out, input, expert_offsets, dense_expert_ids, ptrs_w, ptrs_s,
+      num_experts, k, n, group_size, torch::Tensor());
+}
+
+void mxfp4_moe_indexed_dense_stage_sm70_out(
+    torch::Tensor out, torch::Tensor input, torch::Tensor input_row_indices,
+    torch::Tensor expert_offsets, torch::Tensor dense_expert_ids,
+    torch::Tensor ptrs_w, torch::Tensor ptrs_s, int64_t num_experts,
+    int64_t k, int64_t n, int64_t group_size) {
+  mxfp4_moe_dense_stage_sm70_out_impl(
+      out, input, expert_offsets, dense_expert_ids, ptrs_w, ptrs_s,
+      num_experts, k, n, group_size, input_row_indices);
 }
 
 void mxfp4_moe_single_token_prepare_w13_sm70_out(

--- a/csrc/sm70_turbomind/ops/awq_sm70_gemm.cu
+++ b/csrc/sm70_turbomind/ops/awq_sm70_gemm.cu
@@ -1067,6 +1067,17 @@ bool mxfp4_tune_small_shapes_enabled() {
   return raw == nullptr || std::atoi(raw) != 0;
 }
 
+bool mxfp4_moe_grouped_prefill_enabled() {
+  const char* raw = std::getenv("VLLM_SM70_MXFP4_MOE_GROUPED_PREFILL");
+  return raw != nullptr && std::atoi(raw) != 0;
+}
+
+int mxfp4_moe_grouped_prefill_experts_per_launch() {
+  const char* raw = std::getenv(
+      "VLLM_SM70_MXFP4_MOE_GROUPED_PREFILL_EXPERTS_PER_LAUNCH");
+  return raw != nullptr ? std::clamp(std::atoi(raw), 1, 64) : 64;
+}
+
 bool mxfp4_moe_compact_grouped_decode_enabled() {
   const char* raw =
       std::getenv("VLLM_SM70_MXFP4_MOE_COMPACT_GROUPED_DECODE");
@@ -7112,7 +7123,8 @@ void mxfp4_moe_gemm_sm70_out_impl(
     torch::Tensor out, torch::Tensor sorted_input, torch::Tensor expert_offsets,
     torch::Tensor strided_ptrs_w, torch::Tensor strided_ptrs_s,
     int64_t num_experts, int64_t k, int64_t n, int64_t group_size,
-    torch::Tensor b_group_indices, bool compact_grouped_rows = false) {
+    torch::Tensor b_group_indices, bool compact_grouped_rows = false,
+    bool preserve_per_expert_dispatch = false) {
   TORCH_CHECK(
       sorted_input.is_cuda() && sorted_input.scalar_type() == torch::kFloat16,
       "mxfp4_moe_gemm_sm70: input must be CUDA float16.");
@@ -7241,7 +7253,8 @@ void mxfp4_moe_gemm_sm70_out_impl(
   op.quant_a = {turbomind::gemm::QuantType::kNone, 0};
   op.quant_b = {turbomind::gemm::QuantType::kK, static_cast<int>(group_size)};
   op.batch_dim = 0;
-  op.dispatch_num_override = compact_grouped_rows ? 1 : 0;
+  op.dispatch_num_override =
+      compact_grouped_rows || preserve_per_expert_dispatch ? 1 : 0;
   op.active_group_count =
       compact_grouped_rows ? -static_cast<int>(num_experts) : 0;
 
@@ -7300,6 +7313,31 @@ void mxfp4_moe_dense_stage_sm70_out(
       logged_mxfp4_dense_stage,
       "SM70 MXFP4 MoE CUDA-graph-safe dense-stage path enabled C++ op reached",
       input, input.size(0), num_experts);
+  constexpr int kDeepSeekV4Experts = 256;
+  if (vllm::awq_sm70::mxfp4_moe_grouped_prefill_enabled() &&
+      num_experts == kDeepSeekV4Experts && input.size(0) >= num_experts) {
+    static std::atomic<unsigned> logged_mxfp4_grouped_prefill{0u};
+    maybe_log_sm70_moe_route_once(
+        logged_mxfp4_grouped_prefill,
+        "SM70 MXFP4 MoE grouped prefill path enabled C++ op reached", input,
+        input.size(0), num_experts);
+    const int experts_per_launch = std::min(
+        static_cast<int>(num_experts),
+        vllm::awq_sm70::mxfp4_moe_grouped_prefill_experts_per_launch());
+    for (int expert = 0; expert < static_cast<int>(num_experts);
+         expert += experts_per_launch) {
+      const int launch_experts = std::min(
+          experts_per_launch, static_cast<int>(num_experts) - expert);
+      torch::Tensor offsets =
+          expert_offsets.narrow(0, expert, launch_experts + 1);
+      torch::Tensor expert_ids =
+          dense_expert_ids.narrow(0, expert, launch_experts);
+      mxfp4_moe_gemm_sm70_out_impl(
+          out, input, offsets, ptrs_w, ptrs_s, launch_experts, k, n,
+          group_size, expert_ids, false, true);
+    }
+    return;
+  }
   const bool compact_decode_shape =
       input.size(0) == num_experts && num_experts == 6 &&
       ((k == 4096 && n == 512) || (k == 256 && n == 4096));

--- a/csrc/sm70_turbomind/ops/awq_sm70_gemm.cu
+++ b/csrc/sm70_turbomind/ops/awq_sm70_gemm.cu
@@ -7314,8 +7314,10 @@ void mxfp4_moe_dense_stage_sm70_out(
       "SM70 MXFP4 MoE CUDA-graph-safe dense-stage path enabled C++ op reached",
       input, input.size(0), num_experts);
   constexpr int kDeepSeekV4Experts = 256;
+  constexpr int kDeepSeekV4PrefillMinRows = 1024 * 6;
   if (vllm::awq_sm70::mxfp4_moe_grouped_prefill_enabled() &&
-      num_experts == kDeepSeekV4Experts && input.size(0) >= num_experts) {
+      num_experts == kDeepSeekV4Experts &&
+      input.size(0) >= kDeepSeekV4PrefillMinRows) {
     static std::atomic<unsigned> logged_mxfp4_grouped_prefill{0u};
     maybe_log_sm70_moe_route_once(
         logged_mxfp4_grouped_prefill,

--- a/csrc/torch_bindings.cpp
+++ b/csrc/torch_bindings.cpp
@@ -86,6 +86,13 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, ops) {
   // Quantization ops
 #ifndef USE_ROCM
 
+  ops.def(
+      "sm70_deepseek_v4_sparse_attention_hmma("
+      "Tensor q, Tensor kv, Tensor indices, Tensor lengths, Tensor sink, "
+      "Tensor! out, float scale) -> ()");
+  ops.impl("sm70_deepseek_v4_sparse_attention_hmma", torch::kCUDA,
+           &sm70_deepseek_v4_sparse_attention_hmma);
+
   // Note about marlin kernel 'workspace' arguments:
   // Technically these should be mutable since they are modified by the kernel.
   // But since they are set back to zero once the kernel is finished we can
@@ -480,6 +487,14 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, ops) {
       "int num_experts, int k, int n, int group_size) -> ()");
   ops.impl("mxfp4_moe_dense_stage_sm70_out", torch::kCUDA,
            &mxfp4_moe_dense_stage_sm70_out);
+
+  ops.def(
+      "mxfp4_moe_indexed_dense_stage_sm70_out("
+      "Tensor(a!) out, Tensor input, Tensor input_row_indices, "
+      "Tensor expert_offsets, Tensor dense_expert_ids, Tensor ptrs_w, "
+      "Tensor ptrs_s, int num_experts, int k, int n, int group_size) -> ()");
+  ops.impl("mxfp4_moe_indexed_dense_stage_sm70_out", torch::kCUDA,
+           &mxfp4_moe_indexed_dense_stage_sm70_out);
 
   ops.def(
       "mxfp4_moe_single_token_prepare_w13_sm70_out("

--- a/docs/design/sm70_deepseek_v4_prefill_optimization.md
+++ b/docs/design/sm70_deepseek_v4_prefill_optimization.md
@@ -309,6 +309,323 @@ The median is 1818.623 ms, or 563.06 prompt tok/s at request level. This is a
 reference rather than the final task-owned result because the requested
 prefill contract uses one output token.
 
+## Sparse-Prefill HMMA Candidate
+
+The exact TP8 8192-token Nsight Systems trace identified sparse gathered
+attention as the next dominant category: 1600.504 ms over 43 launches, or
+53.33% of critical-rank kernel service. The layer split was 25.593 ms for two
+SWA layers, 1142.831 ms for 21 C4 layers, and 432.080 ms for 20 C128 layers.
+The C4 mean of 54.421 ms was reproduced by the standalone exact-shape
+benchmark at about 54.2 ms, so the microbenchmark is representative of the
+model path.
+
+Nsight Compute rejected further Triton launch tuning as the primary route.
+The C4 kernel used 255 registers per thread and 49.15 KiB dynamic shared
+memory, reached 12.49% achieved occupancy, and had no eligible warp in 91.69%
+of scheduler cycles. DRAM throughput was only 5.09%, while L1/TEX throughput
+was 96.12%. It accumulated 4.868 billion shared bank conflicts and 6.235
+billion shared wavefronts; MIO throttle was the dominant issue stall. SASS
+contained no HMMA instructions and lowered the two `tl.dot` operations to
+shared-memory FFMA sequences.
+
+Shallow shape tuning did not repair the lowering. `BLOCK_H=4/2/1` and eight
+warps were slower. Padding the eight valid heads to `BLOCK_H=16` remained
+bitwise equal but measured 128.010 ms with eight warps and 1313.295 ms with
+four warps, versus about 63.6 ms for the control in that clock state. These
+variants are rejected.
+
+The candidate is a fused SM70 CUDA kernel with one CTA per query and eight
+warps:
+
+1. Eight warps split the 512-dimensional QK reduction into 64 dimensions each
+   and use Volta WMMA/HMMA. Each warp also owns 64 PV output dimensions.
+2. The CTA gathers each 16-key KV tile once with aligned `half2` loads and
+   reuses it for both QK and PV.
+3. Q is staged once per CTA instead of being copied again for every key tile.
+4. QK and probability rows use padded shared-memory strides. QK partial and PV
+   scratch storage overlap because their lifetimes do not.
+5. Online softmax keeps the original 16-key update order and converts
+   probabilities to FP16 before PV. The changed HMMA reduction tree is the
+   only intended numerical difference from the Triton path.
+
+The final object contains 128 static HMMA instructions, uses 110 registers per
+thread and 46.27 KiB dynamic shared memory, and has no local-memory spills. It
+supports all three gathered layouts used by the model. Same-process 8192-query
+microbenchmarks measured:
+
+| Layer pattern | Triton median | HMMA median | Speedup | Max abs error |
+| :--- | ---: | ---: | ---: | ---: |
+| C4, width 640 | 54.211 ms | 20.337 ms | 2.666x | 0.0009765625 |
+| C128, width 256 | 21.636 ms | 7.264 ms | 2.979x | 0.0009765625 |
+| SWA, width 128 | 10.918 ms | 4.401 ms | 2.481x | 0.0009765625 |
+
+All outputs were finite. GPU tests cover widths 128, 256, and 640 and accept at
+most one FP16 ULP. The candidate is not bitwise equal to the scalar-FFMA Triton
+route.
+
+The final C4 Nsight Compute profile measured 23.31 ms, 24.92% achieved
+occupancy, 98.16 GB/s memory throughput, 73.29% scheduler cycles with no
+eligible warp, 5.58 long-scoreboard cycles per issued instruction, and 0.99
+barrier cycles per issued instruction. The final warp-softmax implementation
+executes 2.549 billion instructions; its lower barrier cost is partly offset by
+shuffle instructions, so further softmax-only work is at marginal return.
+
+The source-level profile attributed 95.6% of the intermediate eight-warp
+kernel's long-scoreboard samples to the KV global-load-to-shared-store chain.
+Staging Q once and vectorizing KV movement removed 1.205 billion executed
+instructions from that intermediate version. The remaining 293.6 million
+excessive shared wavefronts are predominantly inside Volta WMMA fragment
+loads and stores. Bypassing those stores requires fixed SM70 fragment or SASS
+mapping and remains a separate high-risk experiment.
+
+The same-binary, default-off endpoint control measured 8K TTFT values of
+3030.361, 2993.855, 2997.582, 2991.335, and 2990.318 ms after cold JIT and two
+warmups. Its median is 2993.855 ms, or 2736.27 prompt token/s. The final HMMA
+candidate measured 1900.654, 1901.288, 1889.743, 1889.015, and 1891.466 ms.
+Its median is 1891.466 ms, or 4331.03 prompt token/s. TTFT falls by 1102.389 ms
+or 36.82%; request-level prompt throughput rises by 58.28%. These are
+unprofiled endpoint measurements rather than a service-time projection.
+
+### HMMA Quality Blocker
+
+The performance path remains default-off. Official-sampling tests use the
+model's `temperature=1.0`, `top_p=1.0`, and natural stopping. Both paths were
+coherent for the clean PagedAttention material at seed 9601, but the candidate
+leaked source text at seed 9602 while the repeated baseline stayed on topic.
+At the synthetic 8192/256 seed 9202 workload, two independent baseline starts
+produced coherent Chinese analyses; two candidate starts produced an English
+paper excerpt or prompt-template leakage. A one-ULP operator bound therefore
+does not close the model-quality gate.
+
+Raw artifacts are retained as:
+
+- `microbench-sparse-prefill-hmma-8warp-vectored-{c4,c128,swa}-q8192.json`
+- `ncu-hmma-vectored-c4-q8192.ncu-rep`
+- `hmma-vectored-candidate-seed970{3..7}-i8192-o1.json`
+- `hmma-{baseline-repeat,vectored-candidate}-quality-*.json`
+
+The release-guarded binary hash for these results is
+`ac8fd1f20d289e947517636310f2b5c10c72b11d3f6d31a204035121e38d7af2`.
+
+## mHC Prenorm Weight Reuse
+
+After the sparse-attention reduction, the exact 8K trace exposed mHC as the
+next target: 302.284 ms of critical-rank service, including 196.032 ms over 86
+launches of `hc_prenorm_gemm_block_m_tilelang_kernel`. Its baseline NCU report
+showed 85.75% L2 throughput, 91.43% L2 hit rate, only 22.14% DRAM throughput,
+and 18.26 long-scoreboard cycles per issued instruction. The repeated 1.5 MiB
+FP32 `fn` weight was being fetched from L2 once per two-token CTA block.
+
+The SM70 candidate changes the prenorm tile from `(block_m, tile_n)=(2,12)` to
+`(4,6)`. Both shapes keep 24 FP32 accumulators per thread and the same 8192 CTA
+count at M=8192, but the candidate reuses each weight load across four tokens.
+It is guarded by `VLLM_SM70_DSV4_MHC_PREFILL_WEIGHT_REUSE=1`, requires the
+DeepSeek V4 FP16 shape, and remains default-off until endpoint validation.
+
+Clean CUDA Graph microbenchmarks measured:
+
+| Tokens | Baseline `(2,12)` | Candidate `(4,6)` | Reduction | Speedup |
+| ---: | ---: | ---: | ---: | ---: |
+| 1024 | 0.3359 ms | 0.2422 ms | 27.91% | 1.387x |
+| 4096 | 1.1716 ms | 0.9071 ms | 22.57% | 1.292x |
+| 8192 | 2.3161 ms | 1.7876 ms | 22.82% | 1.296x |
+
+All candidate outputs were bitwise equal to both the runtime oracle and eager
+execution. The non-divisible M=1025 tail also passed bitwise. At M=8192, the
+86-launch model-forward projection falls from 199.186 to 153.732 ms, a 45.454
+ms saving; this is a projection, not an endpoint result.
+
+NCU confirms that the candidate reduces L2 work without sacrificing residency:
+
+| M=8192 metric | Baseline `(2,12)` | Candidate `(4,6)` |
+| :--- | ---: | ---: |
+| NCU duration | 2.85 ms | 1.89 ms |
+| Registers/thread | 55 | 56 |
+| Achieved occupancy | 49.35% | 48.71% |
+| L2 throughput | 85.75% | 86.36% |
+| L2 hit rate | 91.43% | 73.57% |
+| DRAM throughput | 22.14% | 63.93% |
+| Compute throughput | 26.68% | 39.44% |
+| Scheduler cycles with no eligible warp | 73.76% | 60.87% |
+
+Larger reuse blocks were rejected after clean reruns: `(5,5)` measured 2.009
+ms, `(6,4)` 2.204 ms, and `(8,3)` 3.109 ms. The first two already require 64
+registers per thread; added x rereads and dependency stalls outweigh further
+weight reuse even though they retain two CTAs per SM.
+
+### Remaining mHC Kernels
+
+The other two repeated mHC kernels account for another 104.653 ms in the 8K
+trace. `mhc_post_tilelang_kernel` reproduces at 0.7437 ms per call and reaches
+805.47 GB/s, or 89.71% DRAM throughput. Its mandatory 40 KiB input and 32 KiB
+output per token make standalone tuning a sub-10% opportunity, so it is not
+the next implementation target.
+
+`mhc_pre_big_fuse_with_norm_tilelang_kernel` accounts for 40.669 ms over 85
+calls. NCU measures 79.22% DRAM throughput, 103 registers per thread, 29.04
+KiB dynamic shared memory, and only 12.32% achieved occupancy. Its 1024-wide
+software-pipelined tile double-buffers residual and norm-weight staging.
+Temporary 512- and 256-wide benchmark variants measured only 0.36% and 1.69%
+faster, respectively, while both changed `layer_input` by up to 0.00012207.
+They are rejected and the production tile remains 1024.
+
+Raw artifacts are retained as:
+
+- `microbench-mhc-prenorm-m{1024,4096,8192}-idle-repeat-*.json`
+- `microbench-mhc-prenorm-m1025-tail-blockm4-tilen6.json`
+- `microbench-mhc-prenorm-m4096-production-dispatch-weight-reuse.json`
+- `ncu-mhc-prenorm-m8192-weight-reuse.ncu-rep`
+- `ncu-mhc-prenorm-m8192-blockm{5,6}-*-resources.ncu-rep`
+- `ncu-mhc-{post,pre-with-norm}-m8192-baseline.ncu-rep`
+
+## Indexed MXFP4 W13 Prefill
+
+The final 8K trace attributes 61.950 ms over 43 launches to
+`expandInputRowsKernel`, or 1.441 ms per MoE layer. It materializes a
+`[8192 * 6, 4096]` FP16 matrix before W13 even though every destination row is
+an unchanged source-token row. This is a routing algorithm cost rather than a
+GEMM tile-selection problem.
+
+TurboMind's existing SM70 grouped MXFP4 kernels already instantiate an
+indexed-A iterator. The candidate therefore keeps the same W13 kernel and
+arithmetic but supplies the sorted source-token row map directly:
+
+1. CUB still sorts the same expanded `(token, expert-slot)` IDs and produces
+   the same expert offsets.
+2. A 256-thread metadata kernel builds the existing forward and inverse
+   permutation maps and converts each sorted expanded ID to its source-token
+   row. It does not copy activation data.
+3. Grouped W13 reads `x[source_row, :]` through TurboMind's indexed-A iterator.
+4. SwiGLU, W2, weighted unpermute, FP16 accumulation order, and router weights
+   are unchanged.
+
+The route is guarded by `VLLM_SM70_MXFP4_MOE_INDEXED_PREFILL=1`, also requires
+grouped prefill, at least 1024 prompt tokens, top-k 6, and fully replicated 256
+experts. Expert-parallel and short/decode shapes remain on the materialized
+path. The switch remains default-off pending an unprofiled endpoint run.
+
+Clean full `permute + W13` microbenchmarks measured:
+
+| Prompt tokens | Materialized | Indexed | Speedup | 43-layer projected saving |
+| ---: | ---: | ---: | ---: | ---: |
+| 1024 | 3.258 ms | 3.065 ms | 1.063x | 8.319 ms |
+| 1025 tail | 3.213 ms | 3.052 ms | 1.053x | 6.921 ms |
+| 4096 | 3.817 ms | 3.119 ms | 1.224x | 30.000 ms |
+| 8192 | 7.395 ms | 6.001 ms | 1.232x | 59.928 ms |
+| 8192, second seed | 7.390 ms | 5.977 ms | 1.237x | 60.771 ms |
+
+All rows passed bitwise output equality, bitwise expert offsets, forward and
+inverse permutation equality, source-row-map equality, and bitwise CUDA Graph
+replay. The clean M=8192 result recovers about 96.7% of the 61.950 ms trace
+cost; indexed W13 adds only about 0.05 ms per layer relative to removing the
+copy in isolation.
+
+The validated extension hashes are:
+
+- `_C.abi3.so`: `fe03604ac5f681a9c4ca5be4443d271749c79dfcd67a8abd64bb3f363caafa77`
+- `_moe_C.abi3.so`: `45c69eba91875db122a61c371c35b6a840c566a4d170ffcaa1fd74ce5f42ee61`
+
+Raw artifacts are retained as
+`microbench-mxfp4-indexed-prefill-m*.json`,
+`indexed-prefill-*-peer-util.log`, and `build-indexed-prefill.log` under the
+task run directory. The next gate is a matched 8K TP8 endpoint comparison with
+the sparse-HMMA and mHC switches held fixed.
+
+## Exact MXFP4 W2 Prefill Selector
+
+The grouped MXFP4 stage was retuned only after the indexed-W13 change. Generic
+autotuning selected CTA 16x128x32 for W13, but grouped W13 regressed from 5.045
+to 5.261 ms, so that result is rejected. For W2, changing only the swizzle of
+the existing CTA 128x128x16, split-1 kernel from 0 to 4 is consistently faster.
+
+`VLLM_SM70_MXFP4_MOE_PREFILL_FAST_SELECTOR=1` enables the exact
+`49152x4096x256` TP8 descriptor only when group-64 prefill is also enabled.
+This combined gate matters because swizzle 4 improves grouped execution but
+regresses the per-expert route. All other shapes retain normal dispatch.
+
+Same-binary A/B/A grouped-only measurements produced:
+
+| Routing | Baseline mean | Swizzle 4 | Reduction | 43-layer saving |
+| :--- | ---: | ---: | ---: | ---: |
+| balanced | 3.578 ms | 3.138 ms | 12.29% | 18.91 ms |
+| random | 3.574 ms | 3.134 ms | 12.32% | 18.94 ms |
+| half-active | 2.974 ms | 2.469 ms | 17.00% | 21.74 ms |
+
+Every route matches the original tactic's cross-process output hash and is
+bitwise stable across direct repeats and CUDA Graph replay. The validated
+binary hash is
+`dba88d00245f6ace0d56fac66e1b8c54ac309512dd6649f812ada68390759c88`.
+Raw artifacts are retained as
+`microbench-mxfp4-w2-m8192-{grouped-only-baseline,grouped-only-baseline-repeat,grouped-only-fast-selector-graph}.json`.
+
+## Exact FP8 Dense Prefill Selector
+
+The 8K trace attributes 315.809 ms to dense FP8 GEMMs. A clean exhaustive
+tactic search found faster, bitwise-identical choices for five exact DeepSeek
+V4 TP8 shapes at M=8192. `VLLM_SM70_FP8_PREFILL_FAST_SELECTOR=1` selects only
+those descriptors; all other token counts and shapes retain the normal
+selector. The switch remains default-off until endpoint validation.
+
+| Projection | Exact tactic |
+| :--- | :--- |
+| fused WQA/WKV, 8192x1536x4096 | CTA 128x128x16, split 1, swizzle 4 |
+| WQ-B/WO-B, 8192x4096x1024 | CTA 128x128x16, split 1, swizzle 4 |
+| WO-A group, 8192x1024x4096 | CTA 128x128x16, split 1, swizzle 3 |
+| shared down, 8192x4096x256 | CTA 128x128x16, split 1, swizzle 4 |
+| C4 indexer WQ-B, 8192x8192x1024 | CTA 64x256x16, split 1, swizzle 2 |
+
+The shared gate/up shape is deliberately excluded. Its faster measured
+tactics changed the FP16 output hash, including CTA 64x256x16 and several
+128x128/96x128/64x128 alternatives. It therefore stays on the baseline CTA
+128x256x16, split-8 route.
+
+A same-binary A/B/A CUDA Graph run measured a 328.108 ms selector-off
+projection and 311.574/312.763 ms selector-on projections. The candidate mean
+is 312.168 ms, saving 15.939 ms or 4.86% of this dense substage. All six output
+hashes match the paired baseline, direct versus graph output is bitwise equal,
+and the other seven GPUs stayed idle during measurement. The final independent
+selector check used binary
+`dba88d00245f6ace0d56fac66e1b8c54ac309512dd6649f812ada68390759c88`.
+
+Raw artifacts are retained as
+`microbench-fp8-dense-m8192-{paired-baseline,fast-selector,fast-selector-repeat}.json`.
+
+## Bitwise-Safe Combined 8K Endpoint
+
+The final endpoint comparison keeps sparse HMMA disabled because its text gate
+is unresolved. Both routes use TP8, one 8192-token chunk, `fp8_ds_mla`, no
+prefix cache, no MTP, breakable CUDA Graph, group-64 MXFP4 prefill, official
+`temperature=1.0`/`top_p=1.0`, and one sampled output token. The candidate
+adds only mHC weight reuse, indexed W13, the exact W2 selector, and the exact
+FP8 dense selector.
+
+One cold request and two warmups precede five measured requests in each run:
+
+| Route | Median TTFT | Prompt throughput |
+| :--- | ---: | ---: |
+| selector-off control A | 2993.893 ms | 2736.24 token/s |
+| four-way candidate | 2858.855 ms | 2865.48 token/s |
+| selector-off control A repeat | 2996.340 ms | 2734.00 token/s |
+
+The candidate saves 135.038-137.485 ms against the two controls. TTFT falls by
+4.51-4.59%, and request-level prompt throughput rises by 4.72-4.81%. This is a
+measured endpoint result rather than a sum of microbenchmark projections. All
+eight paired one-token seeds returned the same token in control and candidate.
+
+The longer text gate does not support a stronger quality claim. At 8192/64,
+the candidate and control chose different continuations after the same first
+token. More importantly, the selector-off control itself produced different
+continuations for two repeated requests with the same seed. It remained
+non-reproducible with `temperature=0` and the same seed, and both control and
+candidate samples could leak prompt-like instructions or English text. The
+operator and first-token evidence shows no detected regression from these
+four changes, but the model's endpoint text-quality baseline is not closed.
+All four switches therefore remain default-off.
+
+Raw endpoint artifacts are retained as
+`final-safe-{baseline,baseline-repeat,combined}-seed*-i8192-o1.json` and
+`final-safe-{baseline-repeat,combined}-quality-seed8701-i8192-o64.json`.
+
 ## Rejected Evidence
 
 The earlier report

--- a/docs/design/sm70_deepseek_v4_prefill_optimization.md
+++ b/docs/design/sm70_deepseek_v4_prefill_optimization.md
@@ -45,14 +45,201 @@ prefill claim.
 
 ## Baseline
 
-The task-owned `1024/1` baseline and no-prefix trace are pending. Raw artifacts
-will be retained under
+The task-owned endpoint used TP8, `fp8_ds_mla`, prefix caching disabled,
+`max_model_len=2048`, `max_num_batched_tokens=2048`, no MTP, and CUDA Graph.
+The first cold request took 11681.327 ms and compiled eight prefill Triton
+kernels. It is retained as cold-start evidence and excluded from the warm
+baseline. Two additional warmups measured 1652.083 and 1653.033 ms.
+
+Five measured requests then produced:
+
+| Seed | TTFT (ms) | Prompt tokens | Completion tokens |
+| ---: | --------: | ------------: | ----------------: |
+| 6101 | 1651.805 | 1024 | 1 |
+| 6102 | 1651.730 | 1024 | 1 |
+| 6103 | 1651.969 | 1024 | 1 |
+| 6104 | 1654.750 | 1024 | 1 |
+| 6105 | 1649.518 | 1024 | 1 |
+
+The median is 1651.805 ms, the mean is 1651.954 ms, and the median effective
+request-level prompt throughput is 619.93 token/s. All samples used official
+`temperature=1.0` and `top_p=1.0` sampling. A separate 1024/64 smoke decoded
+readable text but drifted into an HTML fragment near its token-limit stop, so
+it is retained only as baseline text-health evidence, not as a full quality
+pass.
+
+Raw artifacts are retained under
 `/home/fudanwl/v100-worktrees/runs/dsv4-prefill-trace-20260803/`.
 
-As a same-source preliminary reference, the pre-existing no-MTP run used
-runtime source `6f946b603a`, TP8, `fp8_ds_mla`, prefix caching disabled,
-`max_model_len=2048`, and `max_num_batched_tokens=2048`. Its exact 1024-token
-prompt had these request TTFT values with 256 output tokens:
+## Nsight Systems Trace
+
+After the cold JITs and two profiler-server warmups, one exact 1024/1 request
+was captured with CUDA Graph node tracing. The profiled request had 1713.796
+ms TTFT. Its critical rank was device 5:
+
+| Same-request interval | Time (ms) | Share of request TTFT |
+| --- | ---: | ---: |
+| Critical-rank GPU envelope | 1686.097 | 98.38% |
+| GPU busy interval union | 1541.559 | 89.95% |
+| GPU idle/dependency gap | 144.538 | 8.43% |
+| Request residual outside GPU envelope | 27.699 | 1.62% |
+
+The second and third rows close the GPU envelope. The last row is only the
+same-profile request residual; it must not be interpreted as a pure scheduler
+measurement. Across all eight ranks, envelopes were tightly grouped from
+1685.221 to 1686.097 ms.
+
+Critical-rank kernel service was composed as follows. Percentages use total
+kernel service as their denominator and therefore do not close the GPU wall
+clock when streams overlap.
+
+| Category | Service (ms) | Service share | Launches |
+| --- | ---: | ---: | ---: |
+| TurboMind MXFP4 MoE GEMM | 1128.102 | 72.69% | 22016 |
+| SM70 sparse MLA/SWA attention | 212.538 | 13.69% | 43 |
+| NCCL collectives | 64.355 | 4.15% | 88 |
+| TurboMind FP8 dense GEMM | 48.321 | 3.11% | 258 |
+| mHC | 43.237 | 2.79% | 259 |
+| FP16/CUTLASS GEMM | 17.856 | 1.15% | 148 |
+| KV compression/indexer/rope | 17.060 | 1.10% | 346 |
+| MoE routing | 15.349 | 0.99% | 344 |
+| All remaining categories | 5.147 | 0.33% | 574 |
+
+The dominant MXFP4 service splits into exactly two repeated launch shapes:
+
+| Stage | Service (ms) | Launches | Mean launch | Launch geometry |
+| --- | ---: | ---: | ---: | --- |
+| W13 gate/up, local N=512 | 886.889 | 11008 | 80.57 us | `grid=(49,4,2)`, 128 threads, 255 registers, 32784 B dynamic shared memory |
+| W2 down, local N=4096 | 241.213 | 11008 | 21.91 us | `grid=(49,32,1)`, 128 threads, 255 registers, 32784 B dynamic shared memory |
+
+The count is structural: 43 MoE layers times 256 experts times two stages is
+22016 launches. `mxfp4_moe_dense_stage_sm70_out()` currently loops over every
+expert and invokes TurboMind with `num_experts=1`. This launch decomposition,
+not sparse attention, is the first prefill optimization target.
+
+The first candidate uses four 64-expert TurboMind dispatches per stage instead
+of 256 one-expert dispatches. PR #179 contained a default-off unvalidated sketch
+of this direction. The sketch was ported to the current integration base, but
+its unbounded 256-expert grouped call failed the numerical gate despite a large
+speedup:
+
+| Candidate | W13 legacy | W13 grouped | Speedup | Numerical result |
+| --- | ---: | ---: | ---: | --- |
+| 256 experts/launch | 29.66 ms | 1.299 ms | 22.83x | Rejected: max abs 0.00390625 |
+| 256 experts/launch, legacy dispatch policy | 28.95 ms | 2.074 ms | 13.96x | Rejected: same max abs 0.00390625 |
+
+The second failure used the exact same TurboMind kernel, split count, swizzle,
+CTA shape, and stages as the legacy loop. The difference therefore comes from
+the large grouped scheduler execution shape, not a quantization or dispatch
+policy change. It affected 2645 of 3145728 W13 elements across all 256 experts,
+with no sign flips or row-wise argmax changes. It is still rejected because
+the full-model effect of repeating the difference across 43 layers is not
+proven safe.
+
+Sweeping the number of experts handled per grouped launch found a strict
+bitwise boundary:
+
+| Experts/launch | W13 grouped GPU median | Speedup | Cross-route result |
+| ---: | ---: | ---: | --- |
+| 1 | 28.273 ms | 1.06x | bitwise |
+| 2 | 16.644 ms | 1.81x | bitwise |
+| 4 | 9.767 ms | 2.92x | bitwise |
+| 8 | 5.040 ms | 5.54x | bitwise |
+| 16 | 2.557 ms | 11.00x | bitwise |
+| 32 | 2.489 ms | 11.31x | bitwise |
+| 64 | 2.464 ms | 11.51x | bitwise |
+| 128 | 2.372 ms | 11.92x | rejected, max abs 0.00390625 |
+| 256 | 2.081 ms | 13.56x | rejected, max abs 0.00390625 |
+
+The candidate is therefore hard-limited to at most 64 experts per launch. At
+that width the 1024-token stage benchmark passed cross-route and repeated-run
+bitwise equality for W13 and W2, balanced routing and a half-active routing
+stress, across seeds 29, 101, and 202. Balanced-route W13 speedup ranged from
+10.14x to 12.40x; W2 ranged from 5.64x to 5.89x. The structural request count
+becomes 43 layers times two stages times four launches, or 344 launches instead
+of 22016.
+
+The original projection put MXFP4 service near 123 ms. The matched endpoint and
+post-candidate trace have now measured the result rather than relying on that
+projection.
+
+## Grouped-Prefill Candidate
+
+The candidate keeps the route default-off and hard-clamps the group width to
+64. Worker logs proved that a 1024-token API request reached the grouped C++
+path with a 12288-row internal staging shape. Decode graph capture remained on
+the existing dense-stage path with 12 rows and did not enter grouped prefill.
+
+After a cold request and two warmups, five unprofiled requests produced:
+
+| Seed | Candidate TTFT (ms) |
+| ---: | ---: |
+| 6601 | 567.607 |
+| 6602 | 533.535 |
+| 6603 | 531.873 |
+| 6604 | 531.416 |
+| 6605 | 568.867 |
+
+The candidate median is 533.535 ms and the mean is 546.660 ms. Relative to the
+same-contract 1651.805 ms baseline median, TTFT falls by 1118.270 ms or 67.70%,
+a 3.096x speedup. Effective request-level prompt throughput rises from 619.93
+to 1919.27 token/s. These are unprofiled endpoint measurements, not kernel
+service projections.
+
+The matched post-candidate Nsight request measured 596.478 ms TTFT. Device 5
+was again the critical rank:
+
+| Same-request interval | Time (ms) | Share of request TTFT |
+| --- | ---: | ---: |
+| Critical-rank GPU envelope | 572.791 | 96.03% |
+| GPU busy interval union | 545.071 | 91.38% |
+| GPU idle/dependency gap | 27.721 | 4.65% |
+| Request residual outside GPU envelope | 23.687 | 3.97% |
+
+The candidate busy interval and idle gap close the candidate GPU envelope.
+Critical-rank envelopes ranged from 572.114 to 572.791 ms across all ranks.
+Its service composition was:
+
+| Category | Service (ms) | Service share | Launches |
+| --- | ---: | ---: | ---: |
+| SM70 sparse MLA/SWA attention | 228.628 | 41.18% | 43 |
+| TurboMind MXFP4 MoE GEMM | 133.226 | 24.00% | 344 |
+| TurboMind FP8 dense GEMM | 50.828 | 9.16% | 258 |
+| mHC | 45.335 | 8.17% | 259 |
+| NCCL collectives | 39.792 | 7.17% | 88 |
+| KV compression/indexer/rope | 18.161 | 3.27% | 346 |
+| FP16/CUTLASS GEMM | 17.989 | 3.24% | 148 |
+| MoE routing | 15.729 | 2.83% | 344 |
+| All remaining categories | 5.467 | 0.98% | 574 |
+
+MXFP4 service therefore falls from 1128.102 to 133.226 ms, an 88.19%
+reduction, while its launch count falls exactly 64x from 22016 to 344. W13
+accounts for 86.319 ms and 172 launches; W2 accounts for 46.906 ms and 172
+launches. The new first optimization target is the 228.628 ms sparse MLA/SWA
+attention kernel, not further grouped-MoE launch reduction.
+
+### Numerical And Text Gates
+
+The operator oracle now covers the internal 2048-token execution shape seen in
+the route log: 12288 routed rows, all 256 experts active, random non-uniform
+expert counts, and the entire output buffer initialized with a sentinel. At
+64 experts per launch, both W13 and W2 match the legacy path bit-for-bit,
+including the full-buffer tail, and repeated grouped runs are bitwise stable.
+
+The candidate also completed repeated official-sampling 1024/64 requests with
+stable, readable text, no repeated-token collapse, and unchanged steady decode
+latency. A separate greedy cross-process comparison shared its first 25 output
+tokens with the default-off run and then selected a different valid
+continuation. Because that comparison crossed server restarts, it is not a
+valid operator-level numerical oracle; a second default-off restart intended
+to measure restart variance was blocked when an unrelated TP8 service acquired
+the GPUs. The feature therefore remains default-off until same-process model
+output or logit equality is closed. No quality-pass claim is made from the
+semantic smoke alone.
+
+As a same-source preliminary reference, an earlier no-MTP run used runtime
+source `6f946b603a`, the same TP8 and KV-cache configuration, and 256 output
+tokens. Its exact 1024-token prompt had these request TTFT values:
 
 | Seed | TTFT (ms) |
 | ---: | --------: |

--- a/docs/design/sm70_deepseek_v4_prefill_optimization.md
+++ b/docs/design/sm70_deepseek_v4_prefill_optimization.md
@@ -1,0 +1,35 @@
+# SM70 DeepSeek V4 Prefill Optimization
+
+## Scope
+
+- Integration base: `48e89751b4b98c18e1be6506dca15f015155d068`
+- Model: DeepSeek-V4-Flash, FP8 dense and MXFP4 routed experts
+- Hardware: TP8 on eight V100-SXM2-32GB GPUs
+- Quantization backend: TurboMind only; Marlin is out of scope
+- KV cache: `fp8_ds_mla`
+- Runtime: CUDA Graph enabled, no eager execution, no speculative decoding
+- Initial workload: exactly 1024 input tokens and one naturally sampled output
+- Sampling: official `temperature=1.0`, `top_p=1.0`
+
+The first gate is a same-source, unprofiled single-request prefill baseline.
+Report tokenized prompt length, request TTFT, worker prefill wall time, and
+prompt throughput separately. Decode timing must not be included in the
+prefill claim.
+
+## Measurement Order
+
+1. Verify worker logs select DeepSeek V4, TurboMind FP8/MXFP4, SM70 sparse
+   attention, FP8 MLA KV, TP8, and non-eager execution.
+2. Run warm and cold unprofiled 1024-token prefill samples and retain raw JSON.
+3. Capture one Nsight Systems request with CUDA Graph node and NVTX data.
+4. Split prefill GPU service into FP8 dense, MXFP4 MoE, sparse/SWA attention,
+   compressor and KV work, mHC, collectives, routing, and residual categories.
+5. Use Nsight Compute only on a confirmed dominant kernel and preserve an
+   explicit unattributed residual between GPU service and worker/request wall.
+6. Admit an optimization only after an exact-shape microbenchmark and numerical
+   oracle pass, then rerun the unprofiled endpoint and output-quality gates.
+
+## Baseline
+
+Pending. Raw artifacts will be retained under
+`/home/fudanwl/v100-worktrees/runs/dsv4-prefill-trace-20260803/`.

--- a/docs/design/sm70_deepseek_v4_prefill_optimization.md
+++ b/docs/design/sm70_deepseek_v4_prefill_optimization.md
@@ -165,10 +165,12 @@ projection.
 
 ## Grouped-Prefill Candidate
 
-The candidate keeps the route default-off and hard-clamps the group width to
-64. Worker logs proved that a 1024-token API request reached the grouped C++
-path with a 12288-row internal staging shape. Decode graph capture remained on
-the existing dense-stage path with 12 rows and did not enter grouped prefill.
+The candidate keeps the route default-off, requires at least 6144 routed rows
+(1024 tokens times top-k 6), and hard-clamps the group width to 64. This keeps
+unvalidated high-concurrency decode shapes out of the prefill route. Worker
+logs proved that a 1024-token API request reached the grouped C++ path with a
+12288-row internal staging shape. Decode graph capture remained on the existing
+dense-stage path with 12 rows and did not enter grouped prefill.
 
 After a cold request and two warmups, five unprofiled requests produced:
 

--- a/docs/design/sm70_deepseek_v4_prefill_optimization.md
+++ b/docs/design/sm70_deepseek_v4_prefill_optimization.md
@@ -239,6 +239,62 @@ the GPUs. The feature therefore remains default-off until same-process model
 output or logit equality is closed. No quality-pass claim is made from the
 semantic smoke alone.
 
+## Exact 8K Chunk Comparison
+
+The next workload uses exactly 8192 prompt tokens, one officially sampled
+output token, TP8, `fp8_ds_mla`, no prefix cache, no MTP, and non-eager
+breakable CUDA Graph execution. The benchmark prompt builder preserves its
+existing token prefix and repeats the already-tokenized context only when the
+requested length exceeds the original 80-paragraph fixture.
+
+The first 4096-token chunk request exposed a correctness bug before timing:
+the SM70 indexer dequantization kernel has a `uint8` AOT signature and performs
+software E4M3 decoding, but its runtime call passed the same storage with a
+native `float8_e4m3fn` type. Triton rejects that native FP8 type on SM70 before
+entering the kernel. Passing a zero-copy `uint8` view at the call boundary
+preserves every value and scale. A direct GPU oracle covering weighted-Q,
+software FP8 K dequantization, and FP16 HMMA was bitwise equal to the reference
+with zero mismatched elements.
+
+The endpoint comparison measured:
+
+| Chunk | Grouped prefill | Median TTFT | Mean TTFT | Prompt throughput |
+| ---: | :---: | ---: | ---: | ---: |
+| 4096 | off | 7458.383 ms | 7457.075 ms | 1098.36 token/s |
+| 4096 | group-64 | 3179.100 ms | 3178.883 ms | 2576.83 token/s |
+| 8192 | group-64 | 2997.086 ms | 2997.686 ms | 2733.32 token/s |
+
+Each row uses five measured requests after a cold request and two warmups. The
+4096 rows used `gpu_memory_utilization=0.90`. An 8192-token profile run leaves
+only 2.92 GiB for KV at that setting, below the 3.32 GiB startup admission
+requirement for `max_model_len=10240`, so the 8192 row used 0.95 and retained
+15,667 KV tokens. GPU memory utilization changes the allocated KV pool rather
+than the active 8192-token execution, but a strict 0.95-versus-0.95 endpoint
+repeat remains outstanding. Subject to that caveat, one 8192-token chunk is
+5.73% faster than two 4096-token chunks.
+
+The exact 8192-token, 49,152-routed-row operator gate passed before the model
+run. Group-64 W13 measured 5.124 ms versus 54.956 ms legacy (10.72x); W2
+measured 3.237 ms versus 14.504 ms (4.48x). Both stages were cross-route and
+repeated-run bitwise equal over the complete output buffer.
+
+An official-sampling 8192/64 request completed all 64 tokens with 20.330 ms
+mean decode interval, but its continuation ended in an unrelated TypeScript
+fragment. It is not a text-quality pass. The speed route remains experimental
+until the same prompt and seed are compared with the 4096-token chunk path and
+the broader model-quality investigation is closed.
+
+Raw artifacts include:
+
+- `baseline-c4096-seed820{1..5}-fixed-i8192-o1.json`
+- `group64-c4096-seed840{1..5}-i8192-o1.json`
+- `group64-c8192-u095-seed860{1..5}-i8192-o1.json`
+- `microbench-grouped-prefill-chunk8192-random-b64.log`
+- `group64-c8192-u095-quality-i8192-o64.json`
+
+They are retained in
+`/home/fudanwl/v100-worktrees/runs/dsv4-prefill-trace-20260803/`.
+
 As a same-source preliminary reference, an earlier no-MTP run used runtime
 source `6f946b603a`, the same TP8 and KV-cache configuration, and 256 output
 tokens. Its exact 1024-token prompt had these request TTFT values:

--- a/docs/design/sm70_deepseek_v4_prefill_optimization.md
+++ b/docs/design/sm70_deepseek_v4_prefill_optimization.md
@@ -16,6 +16,20 @@ Report tokenized prompt length, request TTFT, worker prefill wall time, and
 prompt throughput separately. Decode timing must not be included in the
 prefill claim.
 
+## Measurement Definitions
+
+- Request TTFT is measured by the streaming OpenAI client from request start
+  to the first non-empty text delta. Effective prompt throughput is
+  `1024 / TTFT`; it includes frontend, scheduling, LM-head, sampling, and
+  streaming overhead and is not pure GPU prefill throughput.
+- The Nsight GPU envelope is the interval from the first to the last CUDA
+  kernel on one rank during the captured request. The critical rank is the GPU
+  with the longest envelope.
+- GPU busy time is the interval union across streams. `envelope - busy` is the
+  explicit GPU idle/dependency gap and closes the per-rank wall clock.
+- Kernel and category service sums describe composition. They are kept
+  separate from the envelope because concurrent streams can overlap.
+
 ## Measurement Order
 
 1. Verify worker logs select DeepSeek V4, TurboMind FP8/MXFP4, SM70 sparse
@@ -31,5 +45,45 @@ prefill claim.
 
 ## Baseline
 
-Pending. Raw artifacts will be retained under
+The task-owned `1024/1` baseline and no-prefix trace are pending. Raw artifacts
+will be retained under
 `/home/fudanwl/v100-worktrees/runs/dsv4-prefill-trace-20260803/`.
+
+As a same-source preliminary reference, the pre-existing no-MTP run used
+runtime source `6f946b603a`, TP8, `fp8_ds_mla`, prefix caching disabled,
+`max_model_len=2048`, and `max_num_batched_tokens=2048`. Its exact 1024-token
+prompt had these request TTFT values with 256 output tokens:
+
+| Seed | TTFT (ms) |
+| ---: | --------: |
+| 4201 | 1818.623 |
+| 4202 | 1826.996 |
+| 4203 | 1817.802 |
+
+The median is 1818.623 ms, or 563.06 prompt tok/s at request level. This is a
+reference rather than the final task-owned result because the requested
+prefill contract uses one output token.
+
+## Rejected Evidence
+
+The earlier report
+`dsv4-combined-latest-graphtrace-20260803/graph_node_combined_i1024_o64`
+cannot serve as the full-prefill baseline. That server had prefix caching
+enabled, and the captured 1024-token request repeated the warmup prompt. The
+trace therefore measured a partial prefix hit: request TTFT was 1039.958 ms
+and the critical-rank GPU envelope was 1019.709 ms. Its kernel data remains
+useful only for validating the SQLite parser and category rules.
+
+The prefix-cache diagnosis is independently visible in same-source request
+results: a repeated 1024-token prompt with cache enabled measured about
+932.83-933.25 ms TTFT, while the no-prefix request measured 1872.07 ms. The
+new trace must therefore keep prefix caching disabled.
+
+## Runtime Setup Notes
+
+- A task-private empty TileLang cache exposed two startup prerequisites before
+  performance measurement: set `TILELANG_TARGET=cuda` (resolved as `sm_70`)
+  and point `CUDA_HOME` at the Conda CUDA 12.8 toolkit containing `nvcc`.
+- Two attempted launches correctly aborted when another registered TP8 task
+  acquired the GPUs first. These are ownership failures, not model startup or
+  performance regressions, and their logs are retained with the raw artifacts.

--- a/tests/kernels/test_deepseek_v4_sm70_sparse_prefill_hmma.py
+++ b/tests/kernels/test_deepseek_v4_sm70_sparse_prefill_hmma.py
@@ -1,0 +1,59 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from unittest.mock import patch
+
+import pytest
+import torch
+
+from vllm.models.deepseek_v4.sm70 import sparse_kernels
+
+
+def _is_sm70() -> bool:
+    return torch.cuda.is_available() and torch.cuda.get_device_capability() == (7, 0)
+
+
+@pytest.mark.skipif(not _is_sm70(), reason="requires NVIDIA V100/SM70")
+@pytest.mark.parametrize(
+    ("width", "compress_ratio"),
+    ((128, 1), (256, 128), (640, 4)),
+)
+def test_sm70_sparse_prefill_hmma_matches_triton(
+    width: int, compress_ratio: int
+) -> None:
+    torch.manual_seed(20260803 + width)
+    device = torch.device("cuda")
+    num_queries = 64
+    num_kv = 256
+    q = torch.randn((num_queries, 8, 512), dtype=torch.float16, device=device)
+    kv = torch.randn((num_kv, 512), dtype=torch.float16, device=device)
+    rows = torch.arange(num_queries, dtype=torch.int64, device=device)[:, None]
+    columns = torch.arange(width, dtype=torch.int64, device=device)[None, :]
+    compressed = torch.clamp(
+        (rows[:, 0] + 1) // compress_ratio,
+        max=max(0, width - 128),
+    )
+    if width == 128:
+        compressed.zero_()
+    lengths = (compressed + torch.clamp(rows[:, 0] + 1, max=128)).to(torch.int32)
+    indices = ((rows * 131 + columns * 67) % num_kv).to(torch.int32)
+    indices.masked_fill_(columns >= lengths[:, None], -1)
+    sink = torch.linspace(-4.0, -1.0, 8, dtype=torch.float32, device=device)
+    reference = torch.empty_like(q)
+    candidate = torch.empty_like(q)
+
+    with patch.object(
+        sparse_kernels.envs,
+        "VLLM_SM70_DSV4_SPARSE_PREFILL_HMMA",
+        False,
+    ):
+        sparse_kernels.sm70_sparse_attention_gathered(
+            q, kv, indices, lengths, 512**-0.5, sink, reference
+        )
+    sparse_kernels._sm70_sparse_attention_hmma(
+        q, kv, indices, lengths, sink, candidate, 512**-0.5
+    )
+    torch.accelerator.synchronize()
+
+    assert torch.isfinite(candidate).all()
+    torch.testing.assert_close(candidate, reference, rtol=0, atol=2**-9)

--- a/tests/kernels/test_mhc_sm70_fp16.py
+++ b/tests/kernels/test_mhc_sm70_fp16.py
@@ -3,6 +3,7 @@
 import pytest
 import torch
 
+from vllm import envs
 from vllm.model_executor.kernels.mhc import tilelang as mhc_tilelang
 from vllm.platforms.interface import DeviceCapability
 from vllm.utils.import_utils import has_tilelang
@@ -115,6 +116,32 @@ def test_mhc_fp16_fake_path_compiles_fullgraph() -> None:
     assert output[2].shape == (2, 128)
 
 
+@pytest.mark.parametrize(
+    ("weight_reuse", "expected_tile_n", "expected_block_m"),
+    [("0", 12, 2), ("1", 6, 4)],
+)
+def test_mhc_sm70_prefill_weight_reuse_dispatch(
+    monkeypatch: pytest.MonkeyPatch,
+    weight_reuse: str,
+    expected_tile_n: int,
+    expected_block_m: int,
+) -> None:
+    with monkeypatch.context() as patch:
+        patch.setenv("VLLM_SM70_DSV4_MHC_PREFILL_WEIGHT_REUSE", weight_reuse)
+        patch.setattr(mhc_tilelang, "current_platform", _FakeCudaPlatform(False))
+        envs.disable_envs_cache()
+        actual = mhc_tilelang._select_hc_prenorm_block_config(
+            torch.float16,
+            4096,
+            4,
+            24,
+            12,
+        )
+    envs.disable_envs_cache()
+
+    assert actual == (expected_tile_n, expected_block_m)
+
+
 @pytest.mark.skipif(
     not (mhc_tilelang.current_platform.is_cuda() and has_tilelang()),
     reason="CUDA and TileLang required",
@@ -143,6 +170,52 @@ def test_mhc_sm70_fp16_block_m_prenorm_keeps_rows_independent() -> None:
 
     torch.testing.assert_close(out, out_ref, rtol=0, atol=0)
     torch.testing.assert_close(sqrsum, sqrsum_ref, rtol=0, atol=0)
+
+
+@pytest.mark.skipif(
+    not (
+        mhc_tilelang.current_platform.is_cuda()
+        and has_tilelang()
+        and mhc_tilelang.current_platform.get_device_capability()
+        == DeviceCapability(7, 0)
+    ),
+    reason="NVIDIA V100/SM70 and TileLang required",
+)
+def test_mhc_sm70_prefill_weight_reuse_handles_tail(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    hidden_size = 4096
+    hc_mult = 4
+    num_tokens = 1025
+    hc_hidden_size = hc_mult * hidden_size
+    n_out = 2 * hc_mult + hc_mult * hc_mult
+    device = mhc_tilelang.current_platform.device_type
+
+    x = torch.ones((num_tokens, hc_hidden_size), dtype=torch.float16, device=device)
+    x[1::2].fill_(3)
+    fn = torch.ones((n_out, hc_hidden_size), dtype=torch.float32, device=device)
+    out = torch.empty((1, num_tokens, n_out), dtype=torch.float32, device=device)
+    sqrsum = torch.empty((1, num_tokens), dtype=torch.float32, device=device)
+
+    with monkeypatch.context() as patch:
+        patch.setenv("VLLM_SM70_DSV4_MHC_PREFILL_WEIGHT_REUSE", "1")
+        envs.disable_envs_cache()
+        mhc_tilelang._tilelang_hc_prenorm_gemm(
+            x,
+            fn,
+            out,
+            sqrsum,
+            hidden_size,
+            hc_mult,
+        )
+    envs.disable_envs_cache()
+
+    expected_out = torch.full_like(out, hc_hidden_size)
+    expected_out[:, 1::2].mul_(3)
+    expected_sqrsum = torch.full_like(sqrsum, hc_hidden_size)
+    expected_sqrsum[:, 1::2].mul_(9)
+    torch.testing.assert_close(out, expected_out, rtol=0, atol=0)
+    torch.testing.assert_close(sqrsum, expected_sqrsum, rtol=0, atol=0)
 
 
 @pytest.mark.skipif(

--- a/tests/models/test_deepseek_v4_sm70_routes.py
+++ b/tests/models/test_deepseek_v4_sm70_routes.py
@@ -103,6 +103,32 @@ def test_sm70_sparse_qk_dsplit_uses_graph_workspace():
     assert kwargs["partial_probs"].shape == (1, 8, 8, 16)
 
 
+def test_sm70_sparse_prefill_hmma_route_is_shape_gated():
+    from vllm.models.deepseek_v4.sm70 import sparse_kernels
+
+    q = torch.empty((4, 8, 512), dtype=torch.float16)
+    kv = torch.empty((8, 512), dtype=torch.float16)
+    sink = torch.zeros(8, dtype=torch.float32)
+    out = torch.empty_like(q)
+
+    with (
+        patch.object(
+            sparse_kernels.envs,
+            "VLLM_SM70_DSV4_SPARSE_PREFILL_HMMA",
+            True,
+        ),
+        patch.object(sparse_kernels, "_sm70_sparse_attention_hmma") as hmma,
+    ):
+        for width in (128, 256, 640):
+            indices = torch.zeros((4, width), dtype=torch.int32)
+            lengths = torch.full((4,), width, dtype=torch.int32)
+            sparse_kernels.sm70_sparse_attention_gathered(
+                q, kv, indices, lengths, 512**-0.5, sink, out
+            )
+
+    assert hmma.call_count == 3
+
+
 def test_sm75_does_not_select_sm70_impl():
     from vllm.models.deepseek_v4 import attention
     from vllm.models.deepseek_v4.nvidia.flashmla import (

--- a/tests/quantization/test_sm70_mxfp4_moe.py
+++ b/tests/quantization/test_sm70_mxfp4_moe.py
@@ -20,10 +20,36 @@ from vllm.model_executor.layers.quantization.mxfp4 import (
 )
 from vllm.model_executor.layers.quantization.mxfp4_sm70_moe import (
     Mxfp4SM70MoEMethod,
+    _mxfp4_indexed_prefill_enabled,
     _select_mxfp4_stage_dispatch,
     validate_mxfp4_sm70_moe_contract,
     validate_mxfp4_sm70_moe_weight_layout,
 )
+
+
+@pytest.mark.parametrize(
+    ("num_tokens", "fully_replicated", "grouped", "expected"),
+    [
+        (1024, True, True, True),
+        (8192, True, True, True),
+        (1023, True, True, False),
+        (1024, False, True, False),
+        (1024, True, False, False),
+    ],
+)
+def test_mxfp4_sm70_indexed_prefill_gate(
+    monkeypatch, num_tokens, fully_replicated, grouped, expected
+):
+    monkeypatch.setattr(envs, "VLLM_SM70_MXFP4_MOE_INDEXED_PREFILL", True)
+    monkeypatch.setattr(envs, "VLLM_SM70_MXFP4_MOE_GROUPED_PREFILL", grouped)
+
+    assert (
+        _mxfp4_indexed_prefill_enabled(
+            num_tokens=num_tokens,
+            fully_replicated_experts=fully_replicated,
+        )
+        is expected
+    )
 
 
 def _v4_flash_moe_config() -> FusedMoEConfig:

--- a/vllm/_sm70_ops.py
+++ b/vllm/_sm70_ops.py
@@ -452,6 +452,53 @@ if hasattr(torch.ops._C, "mxfp4_moe_dense_stage_sm70_out"):
         return None
 
 
+def mxfp4_moe_indexed_dense_stage_sm70_out(
+    out: torch.Tensor,
+    input: torch.Tensor,
+    input_row_indices: torch.Tensor,
+    expert_offsets: torch.Tensor,
+    dense_expert_ids: torch.Tensor,
+    ptrs_w: torch.Tensor,
+    ptrs_s: torch.Tensor,
+    num_experts: int,
+    k: int,
+    n: int,
+    group_size: int,
+) -> None:
+    _op("mxfp4_moe_indexed_dense_stage_sm70_out")(
+        out,
+        input,
+        input_row_indices,
+        expert_offsets,
+        dense_expert_ids,
+        ptrs_w,
+        ptrs_s,
+        num_experts,
+        k,
+        n,
+        group_size,
+    )
+
+
+if hasattr(torch.ops._C, "mxfp4_moe_indexed_dense_stage_sm70_out"):
+
+    @register_fake("_C::mxfp4_moe_indexed_dense_stage_sm70_out")
+    def _mxfp4_moe_indexed_dense_stage_sm70_out_fake(
+        out: torch.Tensor,
+        input: torch.Tensor,
+        input_row_indices: torch.Tensor,
+        expert_offsets: torch.Tensor,
+        dense_expert_ids: torch.Tensor,
+        ptrs_w: torch.Tensor,
+        ptrs_s: torch.Tensor,
+        num_experts: int,
+        k: int,
+        n: int,
+        group_size: int,
+    ) -> None:
+        return None
+
+
 def mxfp4_moe_single_token_prepare_w13_sm70_out(
     gate_up: torch.Tensor,
     compact_input: torch.Tensor,

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -196,6 +196,8 @@ if TYPE_CHECKING:
     VLLM_SM70_NVFP4_TURBOMIND: bool = True
     VLLM_SM70_MXFP4_TURBOMIND: bool = True
     VLLM_SM70_MXFP4_MOE_ACTIVE_EXPERT_B1: bool = False
+    VLLM_SM70_MXFP4_MOE_GROUPED_PREFILL: bool = False
+    VLLM_SM70_MXFP4_MOE_GROUPED_PREFILL_EXPERTS_PER_LAUNCH: int = 64
     VLLM_SM70_MXFP4_MOE_COMPACT_GROUPED_DECODE: bool = False
     VLLM_SM70_MXFP4_MOE_DIRECT_TOP6_DECODE: bool = False
     VLLM_SM70_DSV4_SPARSE_MLA_SPLITK_SWA: bool = False
@@ -1845,6 +1847,23 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # device tensors and can change between CUDA Graph replays.
     "VLLM_SM70_MXFP4_MOE_ACTIVE_EXPERT_B1": lambda: bool(
         int(os.getenv("VLLM_SM70_MXFP4_MOE_ACTIVE_EXPERT_B1", "0"))
+    ),
+    # Process populated prefill experts in bounded TurboMind grouped launches.
+    # Keep this opt-in until exact operator and endpoint quality gates pass.
+    "VLLM_SM70_MXFP4_MOE_GROUPED_PREFILL": lambda: bool(
+        int(os.getenv("VLLM_SM70_MXFP4_MOE_GROUPED_PREFILL", "0"))
+    ),
+    "VLLM_SM70_MXFP4_MOE_GROUPED_PREFILL_EXPERTS_PER_LAUNCH": lambda: max(
+        1,
+        min(
+            int(
+                os.getenv(
+                    "VLLM_SM70_MXFP4_MOE_GROUPED_PREFILL_EXPERTS_PER_LAUNCH",
+                    "64",
+                )
+            ),
+            64,
+        ),
     ),
     # Fuse the six one-row DeepSeek V4 MXFP4 decode experts into one
     # TurboMind launch. The C++ route reads this value directly as well.

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -166,6 +166,7 @@ if TYPE_CHECKING:
     VLLM_SM70_NVFP4_DENSE_TUNE_MAX_M: int = 16
     VLLM_SM70_DSV4_FP16_GEMV: bool = False
     VLLM_SM70_DSV4_MHC_FP32_STAGE: bool = True
+    VLLM_SM70_DSV4_MHC_PREFILL_WEIGHT_REUSE: bool = False
     VLLM_SM70_AWQ_MOE_TUNE_MAX_TOKENS: int = 128
     VLLM_SM70_ENABLE_DENSE_F16_FASTPATH: bool = False
     VLLM_SM70_ENABLE_LM_HEAD_FASTPATH: bool = False
@@ -193,17 +194,21 @@ if TYPE_CHECKING:
     VLLM_SM70_FP8_DEQUANT_FALLBACK: bool = True
     VLLM_SM70_FP8_TURBOMIND: bool = True
     VLLM_SM70_FP8_DENSE_GATED_SILU: bool = True
+    VLLM_SM70_FP8_PREFILL_FAST_SELECTOR: bool = False
     VLLM_SM70_NVFP4_TURBOMIND: bool = True
     VLLM_SM70_MXFP4_TURBOMIND: bool = True
     VLLM_SM70_MXFP4_MOE_ACTIVE_EXPERT_B1: bool = False
     VLLM_SM70_MXFP4_MOE_GROUPED_PREFILL: bool = False
     VLLM_SM70_MXFP4_MOE_GROUPED_PREFILL_EXPERTS_PER_LAUNCH: int = 64
+    VLLM_SM70_MXFP4_MOE_PREFILL_FAST_SELECTOR: bool = False
+    VLLM_SM70_MXFP4_MOE_INDEXED_PREFILL: bool = False
     VLLM_SM70_MXFP4_MOE_COMPACT_GROUPED_DECODE: bool = False
     VLLM_SM70_MXFP4_MOE_DIRECT_TOP6_DECODE: bool = False
     VLLM_SM70_DSV4_SPARSE_MLA_SPLITK_SWA: bool = False
     VLLM_SM70_DSV4_SPARSE_MLA_SPLITK_C4: bool = False
     VLLM_SM70_DSV4_SPARSE_MLA_SPLITK_C128: bool = False
     VLLM_SM70_DSV4_SPARSE_MLA_QK_DSPLIT: bool = False
+    VLLM_SM70_DSV4_SPARSE_PREFILL_HMMA: bool = False
     VLLM_SM70_FP8_MOE_DEQUANT_FALLBACK: bool = False
     VLLM_SM70_FP8_MOE_BATCHED_GEMM: bool = True
     VLLM_SM70_FP8_MOE_BATCHED_W13_PER_EXPERT_DISPATCH: bool = False
@@ -1655,6 +1660,9 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "VLLM_SM70_DSV4_MHC_FP32_STAGE": lambda: bool(
         int(os.getenv("VLLM_SM70_DSV4_MHC_FP32_STAGE", "1"))
     ),
+    "VLLM_SM70_DSV4_MHC_PREFILL_WEIGHT_REUSE": lambda: bool(
+        int(os.getenv("VLLM_SM70_DSV4_MHC_PREFILL_WEIGHT_REUSE", "0"))
+    ),
     "VLLM_SM70_AWQ_MOE_TUNE_MAX_TOKENS": lambda: int(
         os.getenv("VLLM_SM70_AWQ_MOE_TUNE_MAX_TOKENS", "128")
     ),
@@ -1775,6 +1783,9 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "VLLM_SM70_FP8_TURBOMIND": lambda: bool(
         int(os.getenv("VLLM_SM70_FP8_TURBOMIND", "1"))
     ),
+    "VLLM_SM70_FP8_PREFILL_FAST_SELECTOR": lambda: bool(
+        int(os.getenv("VLLM_SM70_FP8_PREFILL_FAST_SELECTOR", "0"))
+    ),
     # Fused gate_up_proj + SiluAndMul epilogue for SM70 dense FP8. It prepares
     # a single interleaved primary layout for gate_up_proj, avoiding the older
     # duplicate normal+gated layouts that cost about 5.4 GiB/rank on
@@ -1804,6 +1815,9 @@ environment_variables: dict[str, Callable[[], Any]] = {
     ),
     "VLLM_SM70_DSV4_SPARSE_MLA_QK_DSPLIT": lambda: bool(
         int(os.getenv("VLLM_SM70_DSV4_SPARSE_MLA_QK_DSPLIT", "0"))
+    ),
+    "VLLM_SM70_DSV4_SPARSE_PREFILL_HMMA": lambda: bool(
+        int(os.getenv("VLLM_SM70_DSV4_SPARSE_PREFILL_HMMA", "0"))
     ),
     # Diagnostic FP8 MoE fallback lane on V100. Dense FP8 linear can still use
     # TurboMind W8A16, but MoE expert weights are dequantized once to fp16 and
@@ -1864,6 +1878,16 @@ environment_variables: dict[str, Callable[[], Any]] = {
             ),
             64,
         ),
+    ),
+    # Exact TP8 M=8192 group-64 tactic overrides validated against the
+    # baseline output. The C++ selector also requires grouped prefill.
+    "VLLM_SM70_MXFP4_MOE_PREFILL_FAST_SELECTOR": lambda: bool(
+        int(os.getenv("VLLM_SM70_MXFP4_MOE_PREFILL_FAST_SELECTOR", "0"))
+    ),
+    # Let the grouped W13 GEMM gather source token rows directly instead of
+    # materializing the top-k expanded activation matrix.
+    "VLLM_SM70_MXFP4_MOE_INDEXED_PREFILL": lambda: bool(
+        int(os.getenv("VLLM_SM70_MXFP4_MOE_INDEXED_PREFILL", "0"))
     ),
     # Fuse the six one-row DeepSeek V4 MXFP4 decode experts into one
     # TurboMind launch. The C++ route reads this value directly as well.

--- a/vllm/model_executor/kernels/mhc/tilelang.py
+++ b/vllm/model_executor/kernels/mhc/tilelang.py
@@ -68,6 +68,30 @@ def _torch_hc_prenorm_gemm(
     sqrsum[0].copy_(x_float.square().sum(dim=-1))
 
 
+def _select_hc_prenorm_block_config(
+    activation_dtype: torch.dtype,
+    hidden_size: int,
+    hc_mult: int,
+    n_out: int,
+    default_tile_n: int,
+) -> tuple[int, int]:
+    capability = (
+        current_platform.get_device_capability() if current_platform.is_cuda() else None
+    )
+    use_sm70_weight_reuse = (
+        envs.VLLM_SM70_DSV4_MHC_PREFILL_WEIGHT_REUSE
+        and activation_dtype == torch.float16
+        and capability is not None
+        and capability.to_int() == 70
+        and hidden_size == 4096
+        and hc_mult == 4
+        and n_out == 24
+    )
+    if use_sm70_weight_reuse:
+        return 6, 4
+    return default_tile_n, 2
+
+
 def _tilelang_hc_prenorm_gemm(
     x: torch.Tensor,
     fn: torch.Tensor,
@@ -94,6 +118,15 @@ def _tilelang_hc_prenorm_gemm(
     assert (x.shape[1] // n_splits) % n_thr == 0
     use_default_config = tile_n == 12 and n_thr == 512
     if n_splits == 1 and use_default_config and x.shape[0] >= 1024:
+        block_tile_n, block_m = _select_hc_prenorm_block_config(
+            activation_dtype,
+            hidden_size,
+            hc_mult,
+            fn.shape[0],
+            tile_n,
+        )
+        if block_m == 4:
+            logger.info_once("SM70 DeepSeek V4 mHC prefill weight-reuse path enabled.")
         hc_prenorm_gemm_block_m_tilelang(
             x,
             fn,
@@ -103,8 +136,8 @@ def _tilelang_hc_prenorm_gemm(
             hc_mult,
             fn.shape[0],
             n_thr,
-            tile_n,
-            2,
+            block_tile_n,
+            block_m,
             use_fp16=use_fp16,
         )
         return

--- a/vllm/model_executor/layers/quantization/mxfp4_sm70_moe.py
+++ b/vllm/model_executor/layers/quantization/mxfp4_sm70_moe.py
@@ -40,6 +40,7 @@ _DEEPSEEK_V4_FLASH_INTERMEDIATE_SIZE: Final = 2048
 _DEEPSEEK_V4_FLASH_NUM_EXPERTS: Final = 256
 _DEEPSEEK_V4_FLASH_TOP_K: Final = 6
 _GRAPH_SAFE_MAX_TOKENS: Final = 1
+_INDEXED_PREFILL_MIN_TOKENS: Final = 1024
 
 
 def _mxfp4_active_expert_b1_enabled() -> bool:
@@ -47,6 +48,17 @@ def _mxfp4_active_expert_b1_enabled() -> bool:
         envs.VLLM_SM70_MXFP4_MOE_ACTIVE_EXPERT_B1
         and not envs.VLLM_SM70_MOE_SINGLE_TOKEN_FASTPATH
         and not envs.VLLM_SM70_MOE_SINGLE_TOKEN_PERMUTE_FASTPATH
+    )
+
+
+def _mxfp4_indexed_prefill_enabled(
+    *, num_tokens: int, fully_replicated_experts: bool
+) -> bool:
+    return bool(
+        envs.VLLM_SM70_MXFP4_MOE_INDEXED_PREFILL
+        and envs.VLLM_SM70_MXFP4_MOE_GROUPED_PREFILL
+        and num_tokens >= _INDEXED_PREFILL_MIN_TOKENS
+        and fully_replicated_experts
     )
 
 
@@ -228,6 +240,11 @@ class Mxfp4SM70MoEMethod(Mxfp4MoEMethod):
         )
         if envs.VLLM_SM70_MXFP4_MOE_DIRECT_TOP6_DECODE:
             required_ops += ("mxfp4_moe_single_token_prepare_w13_sm70_out",)
+        if (
+            envs.VLLM_SM70_MXFP4_MOE_INDEXED_PREFILL
+            and envs.VLLM_SM70_MXFP4_MOE_GROUPED_PREFILL
+        ):
+            required_ops += ("mxfp4_moe_indexed_dense_stage_sm70_out",)
         missing_ops = [name for name in required_ops if not hasattr(torch.ops._C, name)]
         if missing_ops:
             raise RuntimeError(
@@ -238,6 +255,15 @@ class Mxfp4SM70MoEMethod(Mxfp4MoEMethod):
             raise RuntimeError(
                 "DeepSeek-V4 MXFP4 MoE graph-safe B1 requires "
                 "_moe_C.moe_permute_with_scratch."
+            )
+        if (
+            envs.VLLM_SM70_MXFP4_MOE_INDEXED_PREFILL
+            and envs.VLLM_SM70_MXFP4_MOE_GROUPED_PREFILL
+            and not hasattr(torch.ops._moe_C, "moe_permute_indexed_with_scratch")
+        ):
+            raise RuntimeError(
+                "SM70 MXFP4 indexed prefill requires "
+                "_moe_C.moe_permute_indexed_with_scratch."
             )
         if self.moe.has_bias:
             raise NotImplementedError("SM70 MXFP4 MoE does not support expert bias.")
@@ -626,26 +652,53 @@ class Mxfp4SM70MoEMethod(Mxfp4MoEMethod):
         output.zero_()
 
         total_slots = num_tokens * _DEEPSEEK_V4_FLASH_TOP_K
+        fully_replicated_experts = (
+            layer.expert_map is None
+            and layer.local_num_experts == layer.global_num_experts
+        )
+        indexed_prefill = _mxfp4_indexed_prefill_enabled(
+            num_tokens=num_tokens,
+            fully_replicated_experts=fully_replicated_experts,
+        )
         topk_ids_i32 = buffers["topk_ids"]
         topk_ids_i32.copy_(topk_ids, non_blocking=True)
         buffers["permuted_idx"].fill_(total_slots)
-        torch.ops._moe_C.moe_permute_with_scratch(
-            x,
-            topk_ids_i32,
-            buffers["token_expert_indices"],
-            layer.expert_map,
-            layer.global_num_experts,
-            layer.local_num_experts,
-            _DEEPSEEK_V4_FLASH_TOP_K,
-            buffers["permuted_input"],
-            buffers["expert_offsets64"],
-            buffers["inv_permuted_idx"],
-            buffers["permuted_idx"],
-            buffers["sort_workspace"],
-            buffers["permuted_experts_id"],
-            buffers["sorted_row_idx"],
-            buffers["topk_ids_for_sort"],
-        )
+        if indexed_prefill:
+            logger.info_once("SM70 DeepSeek V4 MXFP4 indexed prefill path enabled.")
+            torch.ops._moe_C.moe_permute_indexed_with_scratch(
+                x,
+                topk_ids_i32,
+                buffers["token_expert_indices"],
+                layer.global_num_experts,
+                layer.local_num_experts,
+                _DEEPSEEK_V4_FLASH_TOP_K,
+                buffers["permuted_input"],
+                buffers["expert_offsets64"],
+                buffers["inv_permuted_idx"],
+                buffers["permuted_idx"],
+                buffers["sort_workspace"],
+                buffers["permuted_experts_id"],
+                buffers["sorted_row_idx"],
+                buffers["topk_ids_for_sort"],
+            )
+        else:
+            torch.ops._moe_C.moe_permute_with_scratch(
+                x,
+                topk_ids_i32,
+                buffers["token_expert_indices"],
+                layer.expert_map,
+                layer.global_num_experts,
+                layer.local_num_experts,
+                _DEEPSEEK_V4_FLASH_TOP_K,
+                buffers["permuted_input"],
+                buffers["expert_offsets64"],
+                buffers["inv_permuted_idx"],
+                buffers["permuted_idx"],
+                buffers["sort_workspace"],
+                buffers["permuted_experts_id"],
+                buffers["sorted_row_idx"],
+                buffers["topk_ids_for_sort"],
+            )
         buffers["expert_offsets"].copy_(buffers["expert_offsets64"], non_blocking=True)
 
         stage_offsets, stage_expert_ids, stage_expert_count = (
@@ -653,25 +706,37 @@ class Mxfp4SM70MoEMethod(Mxfp4MoEMethod):
                 buffers,
                 num_tokens=num_tokens,
                 num_experts=layer.sm70_mxfp4_num_experts,
-                fully_replicated_experts=(
-                    layer.expert_map is None
-                    and layer.local_num_experts == layer.global_num_experts
-                ),
+                fully_replicated_experts=fully_replicated_experts,
             )
         )
 
-        sm70_ops.mxfp4_moe_dense_stage_sm70_out(
-            buffers["gate_up"],
-            buffers["permuted_input"],
-            stage_offsets,
-            stage_expert_ids,
-            layer.w13_strided_ptrs_w,
-            layer.w13_strided_ptrs_s,
-            stage_expert_count,
-            layer.sm70_mxfp4_w13_k_dim,
-            layer.sm70_mxfp4_w13_n_dim,
-            layer.sm70_mxfp4_group_size,
-        )
+        if indexed_prefill:
+            sm70_ops.mxfp4_moe_indexed_dense_stage_sm70_out(
+                buffers["gate_up"],
+                x,
+                buffers["sorted_row_idx"].view(-1),
+                stage_offsets,
+                stage_expert_ids,
+                layer.w13_strided_ptrs_w,
+                layer.w13_strided_ptrs_s,
+                stage_expert_count,
+                layer.sm70_mxfp4_w13_k_dim,
+                layer.sm70_mxfp4_w13_n_dim,
+                layer.sm70_mxfp4_group_size,
+            )
+        else:
+            sm70_ops.mxfp4_moe_dense_stage_sm70_out(
+                buffers["gate_up"],
+                buffers["permuted_input"],
+                stage_offsets,
+                stage_expert_ids,
+                layer.w13_strided_ptrs_w,
+                layer.w13_strided_ptrs_s,
+                stage_expert_count,
+                layer.sm70_mxfp4_w13_k_dim,
+                layer.sm70_mxfp4_w13_n_dim,
+                layer.sm70_mxfp4_group_size,
+            )
         self._apply_swiglu(layer, buffers["intermediate"], buffers["gate_up"])
         sm70_ops.mxfp4_moe_dense_stage_sm70_out(
             buffers["sorted_output"],

--- a/vllm/models/deepseek_v4/sm70/indexer.py
+++ b/vllm/models/deepseek_v4/sm70/indexer.py
@@ -161,7 +161,7 @@ def sm70_indexer_prefill_logits(
     weighted_q = _combine_index_queries(q, weights)
     k_fp16 = torch.empty(k_quant.shape, dtype=torch.float16, device=k_quant.device)
     _dequant_contiguous_index_k_kernel[(k_quant.shape[0],)](
-        k_quant,
+        k_quant.view(torch.uint8),
         k_scales,
         k_fp16,
         k_quant.stride(0),

--- a/vllm/models/deepseek_v4/sm70/sparse_kernels.py
+++ b/vllm/models/deepseek_v4/sm70/sparse_kernels.py
@@ -5,6 +5,8 @@
 
 import torch
 
+import vllm.envs as envs
+from vllm.logger import init_logger
 from vllm.models.deepseek_v4.common.ops.fp8_software import (
     fp8_e4m3fn_bits_to_fp32,
     fp8_e4m3fn_bits_to_fp32_bitcast,
@@ -15,6 +17,21 @@ _HEAD_DIM = 512
 _NOPE_DIM = 448
 _ROPE_DIM = 64
 _SPLITK_BLOCK_K = 16
+logger = init_logger(__name__)
+
+
+def _sm70_sparse_attention_hmma(
+    q: torch.Tensor,
+    kv: torch.Tensor,
+    indices: torch.Tensor,
+    lengths: torch.Tensor,
+    sink: torch.Tensor,
+    out: torch.Tensor,
+    scale: float,
+) -> None:
+    torch.ops._C.sm70_deepseek_v4_sparse_attention_hmma(
+        q, kv, indices, lengths, sink, out, scale
+    )
 
 
 @triton.jit
@@ -846,6 +863,23 @@ def sm70_sparse_attention_gathered(
     indices_2d = indices.reshape(indices.shape[0], -1)
     lengths = lengths.reshape(-1).to(torch.int32)
     assert indices_2d.shape[0] == q.shape[0] == lengths.shape[0]
+
+    if (
+        envs.VLLM_SM70_DSV4_SPARSE_PREFILL_HMMA
+        and q.shape[1] == 8
+        and indices_2d.shape[1] in (128, 256, 640)
+    ):
+        logger.info_once("DeepSeek V4 SM70 sparse prefill HMMA route active.")
+        _sm70_sparse_attention_hmma(
+            q,
+            kv_2d,
+            indices_2d,
+            lengths,
+            attn_sink.contiguous(),
+            out,
+            float(scale),
+        )
+        return
 
     block_h = 8
     _sm70_sparse_gathered_kernel[(q.shape[0], triton.cdiv(q.shape[1], block_h))](


### PR DESCRIPTION
## Purpose

Profile DeepSeek-V4-Flash prefill on 8x V100-SXM2-32GB and reduce the traced
SM70 bottlenecks without enabling eager execution or changing quantization.

- Base SHA: `48e89751b4b98c18e1be6506dca15f015155d068`
- Head SHA: `9f3c66ca00ccfdb7c80f68be372eed6af3c86fbd`
- Backend: TurboMind FP8 dense + MXFP4 experts; Marlin is out of scope
- Runtime: TP8, `fp8_ds_mla`, CUDA Graph, no prefix cache, no MTP
- 8K contract: one 8192-token chunk, max length 10240, max seqs 1

## Implementation

- Group 256 per-expert MXFP4 launches into four bounded 64-expert launches.
- Add an indexed W13 route that gathers source rows in the existing
  TurboMind indexed-A iterator instead of materializing `[M * 6, 4096]`.
- Reuse mHC prenorm weights across four rows with exact `(block_m, tile_n) =
  (4, 6)` dispatch on the DeepSeek V4 SM70 shape.
- Add exact M=8192 selectors for five bitwise-safe FP8 dense shapes and the
  group-64 MXFP4 W2 swizzle-4 shape.
- Add an experimental Volta HMMA sparse-prefill kernel and keep it default-off
  because its endpoint text-quality gate failed.
- Extend exact-shape benchmarks, CUDA Graph checks, Nsight analysis, and the
  retained optimization worklog.

All newly added routes are default-off.

## Endpoint Results

### Initial group-64 result, exact 1024/1

| Metric | Per-expert baseline | Group-64 | Delta |
| --- | ---: | ---: | ---: |
| Median TTFT | 1651.805 ms | 533.535 ms | -67.70% |
| Prompt throughput | 619.93 tok/s | 1919.27 tok/s | 3.096x |
| MXFP4 service | 1128.102 ms | 133.226 ms | -88.19% |
| MXFP4 launches | 22016 | 344 | 64x fewer |

### Bitwise-safe combined result, exact 8192/1

Sparse HMMA is disabled in this comparison. The candidate adds only mHC
weight reuse, indexed W13, exact W2 selection, and exact FP8 selection.

| Route | Median TTFT | Prompt throughput |
| --- | ---: | ---: |
| Selector-off control A | 2993.893 ms | 2736.24 tok/s |
| Four-way candidate | 2858.855 ms | 2865.48 tok/s |
| Selector-off control A repeat | 2996.340 ms | 2734.00 tok/s |

The candidate saves 135.038-137.485 ms. TTFT falls 4.51-4.59%, while
request-level prompt throughput rises 4.72-4.81%.

## Microbenchmark Evidence

- Indexed W13, full permute + GEMM at M=8192: `7.395 -> 6.001 ms`, 1.232x,
  about 59.93 ms projected over 43 layers.
- mHC prenorm at M=8192: `2.316 -> 1.788 ms`, 1.296x, about 45.45 ms
  projected over 86 calls.
- MXFP4 W2 random routing: `3.574 -> 3.134 ms/layer`, -12.32%, about
  18.94 ms projected over 43 layers.
- FP8 dense six-shape projection: A/B/A candidate mean 312.168 ms versus
  328.108 ms control, -4.86% for the dense substage.

## Correctness And Quality Gates

Passed:

- Indexed W13 output, expert offsets, forward/inverse maps, source-row maps,
  repeat execution, and CUDA Graph replay are bitwise equal.
- mHC weight reuse is bitwise equal at M=1024/4096/8192 and the M=1025 tail.
- W2 balanced/random/half-active output hashes match the original tactic;
  direct repeats and CUDA Graph replay are bitwise equal.
- All six FP8 output hashes match the baseline; direct versus graph max error
  is zero. Faster shared gate/up tactics were rejected because hashes changed.
- Eight paired official-sampling 8192/1 seeds returned identical first tokens.

Open blockers:

- Sparse HMMA is 2.48-2.98x faster in operator tests and stays within one FP16
  ULP, but repeated endpoint text tests failed. It remains default-off.
- The selector-off 8192/64 model baseline is itself non-reproducible for the
  same seed under both official sampling and temperature zero, and can leak
  prompt-like or English text. The new exact routes show no detected operator
  regression, but full model text quality is not declared passed.

## Test Result

- `43 passed, 6 skipped` across the focused route, quantization, mHC, and
  sparse-prefill tests. GPU-only tests were skipped locally and run on V100.
- Full CUDA 12.8 SM70 build passed with all host cores.
- Focused Ruff check and format passed; `git diff --check` passed.
- Final `_C.abi3.so`:
  `dba88d00245f6ace0d56fac66e1b8c54ac309512dd6649f812ada68390759c88`
- Indexed `_moe_C.abi3.so`:
  `45c69eba91875db122a61c371c35b6a840c566a4d170ffcaa1fd74ce5f42ee61`

## Artifacts

Raw JSON, logs, Nsight Systems, and Nsight Compute reports remain outside the
repository under:

`/home/fudanwl/v100-worktrees/runs/dsv4-prefill-trace-20260803/`
