### PR TITLE
[Bugfix] Support probabilistic DeepSeek V4 DSpark drafting

### DIFF
--- a/docs/design/sm70_deepseek_v4_dspark_acceptance.md
+++ b/docs/design/sm70_deepseek_v4_dspark_acceptance.md
@@ -1,0 +1,134 @@
+# DeepSeek V4 DSpark Acceptance on SM70
+
+## Scope
+
+This investigation fixes the low DSpark acceptance observed with
+`DeepSeek-V4-Flash` on eight V100-SXM2-32GB GPUs. The acceptance contract uses
+the target model's official `temperature=1.0, top_p=1.0` sampling and standard
+lossless rejection sampling. Output quality must match the target model; draft
+acceptance may not be improved by changing target sampling or accepting biased
+tokens.
+
+- Integration base: `onecat/main`
+- Base SHA: `48e89751b4b98c18e1be6506dca15f015155d068`
+- Branch: `agent/v100-dsv4-dspark-acceptance-20260803-133931`
+- Model: `/home/fudanwl/Desktop/dir`
+- Runtime: TP8, FP8 DS MLA KV, CUDA Graph enabled, non-eager
+- Workload: raw 1024-token report prompts plus natural chat, math, and code
+
+## Sampling Contracts
+
+Three configurations must not be conflated:
+
+1. The public [DeepSeek V4 model card][v4-model-card] command uses seven greedy
+   draft tokens. In standard rejection sampling this makes the draft
+   distribution one-hot.
+2. The [DSpark paper][dspark-paper] and [DeepSpec][deepspec] evaluation code
+   sample from the complete draft distribution at `temperature=1.0` and verify
+   with the `min(1, p/q)` probability-ratio test. The paper's offline N=7 table
+   covers Qwen3 and Gemma4 checkpoints, not DeepSeek V4.
+3. The paper's production section uses DeepSeek V4 with a maximum block size
+   of five and a confidence scheduler. The released V4 checkpoint agrees:
+   `dspark_block_size=5` and a `[1, 4352]` confidence projection for a 4096-wide
+   hidden state plus the 256-wide Markov embedding.
+
+The old 1Cat proposer rejected probabilistic draft sampling and always returned
+`draft_probs=None`. Under a stochastic target this treated every proposal as a
+one-hot distribution and made acceptance depend on the target probability of
+the greedy token. It was not comparable to the paper's probabilistic results.
+
+## Fix
+
+The proposer now applies the trained Markov correction and samples each
+position sequentially through the existing probabilistic sampling helper. It
+returns each full draft distribution in request-major position order so the
+standard rejection sampler can perform exact probability-ratio verification.
+Greedy requests and the default greedy configuration retain the previous
+one-hot path.
+
+Use the paper-consistent route explicitly:
+
+```text
+--speculative-config '{"method":"dspark","num_speculative_tokens":7,"draft_sample_method":"probabilistic"}'
+```
+
+## Acceptance Results
+
+The matched raw-report suite uses seeds 4210-4219, 1024 prompt tokens, at most
+256 output tokens, and identical target sampling.
+
+| Route | Rounds | Accepted / proposed | Mean emitted length | Per-position unconditional acceptance |
+| --- | ---: | ---: | ---: | --- |
+| N=5 greedy | 1420 | 1139 / 7100 (16.04%) | 1.802 | 38.73%, 18.80%, 11.06%, 6.62%, 5.00% |
+| N=5 probabilistic | 1071 | 1493 / 5355 (27.88%) | 2.394 | 64.43%, 37.16%, 21.10%, 11.30%, 5.42% |
+| N=7 probabilistic | 1098 | 1459 / 7686 (18.98%) | 2.329 | 62.57%, 34.88%, 19.13%, 9.56%, 4.74%, 1.46%, 0.55% |
+
+Acceptance is workload-dependent. A separate N=5 domain smoke produced:
+
+| Domain | Mean emitted length | Accepted draft tokens |
+| --- | ---: | ---: |
+| Math prompt 1 / 2 | 4.394 / 4.691 | 67.88% / 73.82% |
+| Python prompt 1 / 2 | 3.794 / 4.655 | 55.88% / 73.09% |
+| Open chat prompt 1 / 2 | 2.500 / 2.590 | 30.00% / 31.80% |
+
+An N=7 open-chat rerun generated coherent output and measured 2.771 mean
+emitted length over 35 rounds. Its unconditional acceptance was 74.29%,
+48.57%, 28.57%, 11.43%, 8.57%, 2.86%, and 2.86% by position. The raw report
+prompt is therefore a high-entropy stress case, not a universal acceptance
+baseline.
+
+## Root-Cause Checks
+
+- Position cross-correlation found no token-row or verifier-logit shift. Draft
+  row `i` aligns best with target row `i`.
+- A byte-level FP8 attention oracle from the earlier bring-up already measured
+  cosine above 0.999999 for all three draft layers. Attention metadata and
+  non-causal visibility are not the acceptance limiter.
+- Markov bias is beneficial and correctly scaled. On 12 captured open-chat
+  rounds, removing it reduced expected emitted length from 2.542 to 1.513.
+  Scaling it by 0.75 or 1.25 produced 2.514 and 2.426 respectively; 1.0 was
+  best.
+- Global draft-temperature scaling cannot repair the suffix. The best tested
+  scale, 0.9, changed predicted length by only +0.004 token.
+- The checkpoint confidence head correlates with exact target/draft overlap
+  (Pearson 0.712 in the diagnostic sample). Fixed N=7 spends two verifier rows
+  on a suffix with little expected return. Confidence scheduling is a separate
+  change because this runner still needs efficient variable M=2-6 verifier
+  graphs; merely loading the unused head would not improve acceptance or speed.
+
+## Quality And Performance Gates
+
+- A natural-stop Chinese quality prompt remained coherent and completed in 45
+  tokens.
+- A deterministic 256-token control exactly matched the prior token SHA256
+  `63254475cd7fef9b04e338dc709f8eee4cc51803ac0d1632f178598362d93a52`.
+- Probabilistic sampling currently materializes and samples seven full-vocab
+  distributions. It fixes the acceptance contract but is not yet a speed win
+  on SM70. The next performance change must fuse or port the Gumbel draft
+  sampler before making an end-to-end acceleration claim.
+
+## Decisions
+
+1. Keep target sampling unchanged and retain standard lossless rejection.
+2. Land probabilistic DSpark support without changing the global greedy
+   default.
+3. Do not tune Markov scale, draft temperature, or attention again without new
+   contradictory evidence.
+4. Treat five as the checkpoint-native V4 width. Before changing the release
+   default from model-card N=7, optimize and benchmark the M=6 verifier path.
+5. Implement confidence scheduling only together with variable-width verifier
+   dispatch and measure accepted tokens, verifier rows, output quality, and
+   end-to-end TPOT.
+
+## Artifacts
+
+- Remote run root:
+  `/home/fudanwl/v100-worktrees/runs/dsv4-dspark-acceptance-20260803`
+- N=5/N=7 acceptance runs: `n5-prob`, `n7-prob`
+- Confidence and Markov diagnostics: `n7-confidence-calibration`
+- Main analyses: `confidence-analysis.json`, `markov-scale-analysis.json`, and
+  `temperature-overlap.json`
+
+[deepspec]: https://github.com/deepseek-ai/DeepSpec
+[dspark-paper]: https://arxiv.org/abs/2607.05147
+[v4-model-card]: https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash-DSpark

--- a/docs/design/sm70_deepseek_v4_dspark_optimization.md
+++ b/docs/design/sm70_deepseek_v4_dspark_optimization.md
@@ -25,8 +25,10 @@ execution, Marlin, altered model weights, or reduced-precision shortcuts.
   Markov samples, verifier width `N + 1`
 - Drafter attention: DeepSeek V4 SM70 sparse SWA with DSpark non-causal indices
 - Initial workload: exactly 1024 prompt tokens and at most 256 output tokens
-- Sampling: official target `temperature=1.0`, `top_p=1.0` for non-agentic
-  workloads; official DSpark draft sampling is greedy; natural EOS is preserved
+- Sampling: target `temperature=1.0`, `top_p=1.0` for non-agentic workloads;
+  the public V4 model-card route uses greedy drafts, while paper-comparable
+  acceptance uses probabilistic drafts and standard rejection sampling;
+  natural EOS is preserved
 - Bring-up context limit and token budget: 2048, sufficient for the exact
   1024-token prompt plus 256-token decode workload
 - Active-expert candidate: disabled during the first MTP/no-MTP comparison
@@ -51,12 +53,13 @@ namespace, not evidence that the ordinary vLLM MTP architecture applies.
 
 ## Speculative Width
 
-The checkpoint stores `dspark_block_size=5`, and its bundled reference runner
-generates five draft tokens. The official DeepSeek model-card vLLM command uses
-`N=7` with greedy draft sampling, and the released DeepSpec checkpoints use
-block seven. Therefore `N=7` is fixed for this route. The earlier `N=4` and
-`N=5` runs remain diagnostics only; do not spend another model startup on
-`N=16` without new acceptance evidence that can repay its wider verifier.
+The checkpoint stores `dspark_block_size=5`, and the DSpark paper's V4
+production route uses a maximum width of five with confidence scheduling. The
+public DeepSeek model-card vLLM command instead uses `N=7` with greedy draft
+sampling. Keep `N=7` as the current model-card deployment baseline, but do not
+treat it as the paper's V4 production contract. See
+`sm70_deepseek_v4_dspark_acceptance.md` before running another width or
+acceptance experiment.
 
 ## Measurement Order
 

--- a/tests/v1/spec_decode/test_dspark.py
+++ b/tests/v1/spec_decode/test_dspark.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+from types import MethodType, SimpleNamespace
+
 import pytest
 import torch
 import torch.nn as nn
@@ -57,6 +59,8 @@ def test_dspark_markov_sampling_is_sequential(
     proposer = object.__new__(DSparkProposer)
     proposer.num_speculative_tokens = num_speculative_tokens
     proposer.model = _FakeDSparkModel()
+    proposer._enable_probabilistic_draft_probs = False
+    proposer._static_draft_vocab = None
     proposer.input_ids = torch.zeros(2 * num_speculative_tokens, dtype=torch.int32)
     proposer.input_ids[0] = 1
     proposer.input_ids[num_speculative_tokens] = 4
@@ -71,6 +75,55 @@ def test_dspark_markov_sampling_is_sequential(
     )
 
     assert draft_probs is None
+    expected = [
+        [
+            (anchor + step + 1) % _FakeDSparkModel.vocab_size
+            for step in range(num_speculative_tokens)
+        ]
+        for anchor in (1, 4)
+    ]
+    assert output.view(2, num_speculative_tokens).tolist() == expected
+
+
+@pytest.mark.parametrize("num_speculative_tokens", [5, 7])
+def test_dspark_probabilistic_sampling_returns_sequential_probs(
+    num_speculative_tokens: int,
+) -> None:
+    proposer = object.__new__(DSparkProposer)
+    proposer.num_speculative_tokens = num_speculative_tokens
+    proposer.model = _FakeDSparkModel()
+    proposer._enable_probabilistic_draft_probs = True
+    proposer._static_draft_vocab = None
+    proposer.input_ids = torch.zeros(2 * num_speculative_tokens, dtype=torch.int32)
+    proposer.input_ids[0] = 1
+    proposer.input_ids[num_speculative_tokens] = 4
+    proposer._anchor_indices = torch.tensor(
+        [0, num_speculative_tokens], dtype=torch.int64
+    )
+
+    def sample_from_logits(
+        self: DSparkProposer,
+        logits: torch.Tensor,
+        sampling_metadata: object,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        del self, sampling_metadata
+        return logits.argmax(dim=-1), logits.softmax(dim=-1)
+
+    proposer._sample_from_logits = MethodType(sample_from_logits, proposer)
+    hidden_states = torch.zeros(2 * num_speculative_tokens, 2)
+    metadata = SimpleNamespace(all_greedy=False)
+
+    output, draft_probs = proposer._sample_draft_tokens(
+        hidden_states,
+        sampling_metadata=metadata,  # type: ignore[arg-type]
+    )
+
+    assert draft_probs is not None
+    assert draft_probs.shape == (
+        2 * num_speculative_tokens,
+        _FakeDSparkModel.vocab_size,
+    )
+    assert torch.equal(draft_probs.argmax(dim=-1), output)
     expected = [
         [
             (anchor + step + 1) % _FakeDSparkModel.vocab_size

--- a/vllm/v1/spec_decode/dspark.py
+++ b/vllm/v1/spec_decode/dspark.py
@@ -18,11 +18,6 @@ class DSparkProposer(DFlashProposer):
         runner=None,
     ) -> None:
         super().__init__(vllm_config, device, runner)
-        if self.speculative_config.draft_sample_method != "greedy":
-            raise ValueError(
-                "DeepSeek V4 DSpark currently requires the official greedy "
-                "draft sampling mode."
-            )
         if self.use_local_argmax_reduction:
             raise ValueError(
                 "DSpark cannot use local argmax reduction because its replicated "
@@ -40,8 +35,8 @@ class DSparkProposer(DFlashProposer):
         sampling_metadata: SamplingMetadata,
         logits: torch.Tensor | None = None,
         spec_step_idx: int = 0,
-    ) -> tuple[torch.Tensor, None]:
-        del sampling_metadata, spec_step_idx
+    ) -> tuple[torch.Tensor, torch.Tensor | None]:
+        del spec_step_idx
 
         num_rows = hidden_states.shape[0]
         batch_size, remainder = divmod(num_rows, self.num_speculative_tokens)
@@ -59,9 +54,25 @@ class DSparkProposer(DFlashProposer):
         # contents across asynchronous scheduling and CUDA Graph replay.
         prev = self.input_ids[self._anchor_indices[:batch_size]].to(torch.long)
         draft_tokens: list[torch.Tensor] = []
+        draft_probs: list[torch.Tensor] | None = None
         for step in range(self.num_speculative_tokens):
             markov_embed = self.model.markov_embed(prev)
             step_logits = base_logits[:, step] + self.model.markov_bias(markov_embed)
-            prev = self.model.map_draft_to_target(step_logits.argmax(dim=-1))
+            sampled, step_probs = self._sample_from_logits(
+                step_logits,
+                sampling_metadata,
+            )
+            prev = self.model.map_draft_to_target(sampled)
             draft_tokens.append(prev)
-        return torch.stack(draft_tokens, dim=1).reshape(-1), None
+            if step_probs is not None:
+                if draft_probs is None:
+                    draft_probs = []
+                draft_probs.append(step_probs)
+
+        flat_tokens = torch.stack(draft_tokens, dim=1).reshape(-1)
+        if draft_probs is None:
+            return flat_tokens, None
+        if len(draft_probs) != self.num_speculative_tokens:
+            raise RuntimeError("DSpark produced incomplete draft probabilities.")
+        flat_probs = torch.stack(draft_probs, dim=1).flatten(0, 1).contiguous()
+        return flat_tokens, flat_probs


### PR DESCRIPTION
## Purpose

- allow DeepSeek V4 DSpark to use the existing probabilistic draft-sampling contract
- sample the Markov-corrected block sequentially and return request-major full draft probabilities for standard lossless rejection
- retain the existing greedy one-hot path and global default
- document the distinct model-card N=7, paper benchmark, and V4 production max-gamma=5 contracts

## Test Plan

- run focused DSpark proposer tests locally and on remote Python 3.12
- run Ruff and git diff checks
- validate TP8 V100 non-eager CUDA Graph execution with FP8 DS MLA KV
- compare matched greedy/probabilistic acceptance and run deterministic plus natural-stop quality gates

## Test Result

- local: tests/v1/spec_decode/test_dspark.py: 6 passed
- remote Python 3.12: tests/v1/spec_decode/test_dspark.py: 6 passed
- Ruff: passed
- git diff --check: passed
- matched raw N=5: mean emitted length 1.802 greedy to 2.394 probabilistic
- matched raw N=7 probabilistic: mean emitted length 2.329
- N=7 open chat: mean emitted length 2.771; coherent output
- deterministic 256-token output retained SHA256 63254475cd7fef9b04e338dc709f8eee4cc51803ac0d1632f178598362d93a52

## Notes

This PR fixes the acceptance contract, not probabilistic-sampling latency. Full-vocabulary sequential sampling remains a separate SM70 performance target. The confidence-head and full-probability diagnostics used for root-cause analysis are not included in the source diff.