### PR TITLE
[SM70][NVFP4] Add skinny dense small-M backend

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -401,6 +401,21 @@ if(VLLM_GPU_LANG STREQUAL "CUDA")
     set_gencode_flags_for_srcs(
       SRCS "${VLLM_SM70_TURBOMIND_SRCS}"
       CUDA_ARCHS "${SM70_TURBOMIND_ARCHS}")
+
+    # The skinny NVFP4 kernels are a small-M overlay on the SM70 TurboMind
+    # dense backend. Keep them in the same _C extension and compile this
+    # source for Volta only; unsupported dtypes/shapes fall back to TurboMind.
+    set(VLLM_SM70_SKINNY_NVFP4_SRC
+        "csrc/quantization/skinny_nvfp4/skinny_nvfp4.cu")
+    set_gencode_flags_for_srcs(
+      SRCS "${VLLM_SM70_SKINNY_NVFP4_SRC}"
+      CUDA_ARCHS "${SM70_TURBOMIND_ARCHS}")
+    set_property(
+      SOURCE "${VLLM_SM70_SKINNY_NVFP4_SRC}"
+      APPEND PROPERTY COMPILE_OPTIONS "--use_fast_math" "-lineinfo")
+    list(APPEND VLLM_SM70_TURBOMIND_SRCS
+         "${VLLM_SM70_SKINNY_NVFP4_SRC}")
+
     set_source_files_properties(
       csrc/torch_bindings.cpp
       PROPERTIES COMPILE_DEFINITIONS ENABLE_SM70_TURBOMIND=1)

--- a/csrc/quantization/skinny_nvfp4/LICENSE
+++ b/csrc/quantization/skinny_nvfp4/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 v100-skinny contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/csrc/quantization/skinny_nvfp4/README.md
+++ b/csrc/quantization/skinny_nvfp4/README.md
@@ -1,0 +1,20 @@
+# SM70 skinny NVFP4 kernels
+
+This directory contains the small-M production subset of the MIT-licensed
+[`v100-skinny`](https://github.com/Leonccaa/v100-skinny) CUDA kernels, pinned
+to commit `f8194f7c3c9269fa74ee70b5029d53c20098f4c8`.
+
+The extension consumes the checkpoint-native W4A16 NVFP4 layout: packed E2M1
+codes `[N, K / 2]`, FP8-E4M3 group-16 scales `[N, K / 16]`, and one
+multiplicative global scale. It provides two SM70-only operators:
+
+- SIMT for FP16 `M <= 3`.
+- QPN `mma.sync.m8n8k4` for FP16 `4 <= M <= 16`, using an offline
+  fragment-order prepack.
+
+The Python adapter owns runtime dispatch. BF16 is converted explicitly to
+FP16 at the adapter boundary and restored on output. Larger M, unsupported
+shapes, or a failed validation use the existing SM70 TurboMind kernel. The
+skinny backend is opt-in through `VLLM_SM70_QUANT_BACKEND=skinny`; it is not a
+global `--linear-backend` because mixed-format models still need their normal
+per-format backends.

--- a/csrc/quantization/skinny_nvfp4/skinny_nvfp4.cu
+++ b/csrc/quantization/skinny_nvfp4/skinny_nvfp4.cu
@@ -1,0 +1,516 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 v100-skinny contributors
+//
+// SM70 skinny NVFP4 dequant-GEMM: y[M,N] = x[M,K] @ W[K,N].
+//
+// This is the production small-M subset adapted from v100-skinny commit
+// f8194f7c3c9269fa74ee70b5029d53c20098f4c8. 1Cat dispatches FP16 M<=3
+// to SIMT and M=4..16 to QPN; the Python adapter explicitly converts BF16
+// activations to FP16, while TurboMind remains the fallback for unsupported
+// shapes and larger M.
+//
+// Packed format (0.5625 bytes/weight):
+//   codes  uint8 [N][K/2]   two E2M1 codes per byte, low nibble = even k
+//   scales uint8 [N][K/16]  FP8-E4M3 per 16-k group
+//   gscale float            global scale, applied in the kernel
+
+#include <ATen/cuda/CUDAContext.h>
+#include <c10/cuda/CUDAException.h>
+#include <cuda_fp16.h>
+#include <torch/all.h>
+#include <torch/library.h>
+
+#define DEV_INLINE __device__ __forceinline__
+
+// PRMT-LUT decoder (compile with -DSKINNY_LUT_CVT to select): loses
+// to the TurboMind-derived shift+rebias decoder below by ~28% at M=1
+// (504 vs 647 GB/s) and ~22% at M=16 - longer PRMT dependency chain
+// and more INT-pipe ops per value. Kept for A/B reference.
+// fp16 high bytes of the e2m1 magnitudes {0,.5,1,1.5} and {2,3,4,6};
+// the low bytes are all 0x00, so one PRMT yields two packed halves.
+constexpr unsigned LUT_LO = 0x3E3C3800u;
+constexpr unsigned LUT_HI = 0x46444240u;
+
+// Dequant one byte-pair position of an 8-code word. `q` holds 8 nibbles;
+// byte `pi` gives codes (2p, 2p+1) -> returns them as one half2.
+DEV_INLINE half2 dequant_pair(unsigned q, int pi, half2 sc2) {
+  const unsigned mq = (q & 0x77777777u) >> (8 * pi);
+  const unsigned sq = (q & 0x88888888u) >> (8 * pi);
+  unsigned sel = ((mq & 0x7u) << 4) | ((mq & 0x70u) << 8);
+  unsigned h = __byte_perm(LUT_LO, LUT_HI, sel);
+  h |= ((sq & 0x8u) << 12) | ((sq & 0x80u) << 24);
+  return __hmul2(*reinterpret_cast<half2*>(&h), sc2);
+}
+
+DEV_INLINE half2 fp8e4m3_to_half2(unsigned char b) {
+  const unsigned short hb =
+      (((unsigned short)b & 0x80u) << 8) | (((unsigned short)b & 0x7Fu) << 7);
+  const half hs =
+      __hmul(__ushort_as_half(hb), __ushort_as_half(0x5C00));  // *256
+  return __halves2half2(hs, hs);
+}
+
+// XOR swizzle on the low 3 bits of a k-pair index; conflict-free for the
+// simt read pattern (lane-groups sharing a bank base differ in p>>5).
+DEV_INLINE int swz(int p) { return (p & ~7) | ((p ^ (p >> 5)) & 7); }
+
+#ifndef SKINNY_LUT_CVT
+// Alternative e2m1 decoder derived from TurboMind's cvt_f16x8_e2m1
+// (Apache-2.0; 1Cat-vLLM csrc/sm70_turbomind/lmdeploy/src/turbomind/
+// kernels/attention/quantization.h). Shifts sign/EM bits into fp16
+// positions; the 2^14 exponent re-bias is folded into the caller's
+// scale, so no extra multiply. Output half2 pairing is INTERLEAVED:
+// out[i] holds codes (i, i+4) of the 8-code word.
+DEV_INLINE void dequant8_tm(unsigned q, half2 sc2p, half2 out[4]) {
+  constexpr unsigned S = 0x80008000u, EM = 0x0E000E00u;
+  unsigned v0 = ((q << 12) & S) | ((q << 9) & EM);
+  unsigned v1 = ((q << 8) & S) | ((q << 5) & EM);
+  unsigned v2 = ((q << 4) & S) | ((q << 1) & EM);
+  unsigned v3 = (q & S) | ((q >> 3) & EM);
+  out[0] = __hmul2(*reinterpret_cast<half2*>(&v0), sc2p);
+  out[1] = __hmul2(*reinterpret_cast<half2*>(&v1), sc2p);
+  out[2] = __hmul2(*reinterpret_cast<half2*>(&v2), sc2p);
+  out[3] = __hmul2(*reinterpret_cast<half2*>(&v3), sc2p);
+}
+#endif
+
+// Stage 8 contiguous activation halves as four half2 pairs. Default
+// pairing is adjacent-k; the TM decoder variant needs (k, k+4) pairs to
+// match dequant8_tm's interleaved output.
+DEV_INLINE void stage_pairs(half2* dst, int base_pair, const uint4& v) {
+#ifndef SKINNY_LUT_CVT
+  const unsigned* r = reinterpret_cast<const unsigned*>(&v);
+  unsigned o[4] = {
+      __byte_perm(r[0], r[2], 0x5410), __byte_perm(r[0], r[2], 0x7632),
+      __byte_perm(r[1], r[3], 0x5410), __byte_perm(r[1], r[3], 0x7632)};
+  #pragma unroll
+  for (int j = 0; j < 4; j++)
+    dst[swz(base_pair + j)] = *reinterpret_cast<half2*>(&o[j]);
+#else
+  const half2* hv = reinterpret_cast<const half2*>(&v);
+  #pragma unroll
+  for (int j = 0; j < 4; j++) dst[swz(base_pair + j)] = hv[j];
+#endif
+}
+
+// ---------------------------------------------------------------------------
+// SIMT kernel: 8 warps/block, one output row per warp.
+// ---------------------------------------------------------------------------
+template <int M, int KC, int R = 1, bool ARGMAX = false>
+__global__ void skinny_nvfp4_simt(const uint8_t* __restrict__ codes,
+                                  const uint8_t* __restrict__ scales,
+                                  const half* __restrict__ x,
+                                  half* __restrict__ y, int N, int K,
+                                  float gscale, half* __restrict__ bvals,
+                                  int* __restrict__ bidxs) {
+  extern __shared__ char smem_raw[];
+  half2* xs = reinterpret_cast<half2*>(smem_raw);  // [M][KC/2] swizzled
+  constexpr int P2 = KC / 2;
+
+  const int warp = threadIdx.x >> 5, lane = threadIdx.x & 31;
+  const int n = (blockIdx.x * 8 + warp) * R;
+  const uint8_t* crow[R];
+  const uint8_t* srow[R];
+#pragma unroll
+  for (int r = 0; r < R; r++) {
+    crow[r] = codes + (size_t)(n + r) * (K >> 1);
+    srow[r] = scales + (size_t)(n + r) * (K >> 4);
+  }
+  // Fold the global scale into the group scales so in-kernel weights sit
+  // at their true O(0.1) magnitudes; otherwise code*fp8scale reaches
+  // ~2.7e3 and fp16 products overflow on real activation outliers.
+#ifndef SKINNY_LUT_CVT
+  // dequant8_tm needs a 2^14 exponent re-bias; fold it here for free.
+  const half2 gm2 = __float2half2_rn(gscale * 16384.f);
+#else
+  const half2 gm2 = __float2half2_rn(gscale);
+#endif
+
+  float accf[R][M];
+#pragma unroll
+  for (int r = 0; r < R; r++)
+#pragma unroll
+    for (int m = 0; m < M; m++) accf[r][m] = 0.f;
+
+  int k0 = 0;
+  for (; k0 + KC <= K; k0 += KC) {
+    __syncthreads();
+    for (int idx = threadIdx.x; idx < M * (KC / 8); idx += blockDim.x) {
+      const int m = idx / (KC / 8), j4 = idx % (KC / 8);
+      const uint4 v =
+          *reinterpret_cast<const uint4*>(x + (size_t)m * K + k0 + j4 * 8);
+      stage_pairs(xs + m * P2, j4 * 4, v);
+    }
+    __syncthreads();
+
+#pragma unroll
+    for (int i = 0; i < KC / 512; i++) {
+      const int s = lane + 32 * i;  // 16-code segment == one scale group
+      uint2 q2[R];
+      half2 sc2[R];
+#pragma unroll
+      for (int r = 0; r < R; r++) {
+        q2[r] = *reinterpret_cast<const uint2*>(crow[r] + (k0 >> 1) + s * 8);
+        sc2[r] = __hmul2(fp8e4m3_to_half2(srow[r][(k0 >> 4) + s]), gm2);
+      }
+      // fp16 accumulation window is one 16-code segment (8 products per
+      // half2 lane); flushed to fp32 so real activation outliers cannot
+      // overflow half range.
+      half2 acch[R][M];
+#pragma unroll
+      for (int r = 0; r < R; r++)
+#pragma unroll
+        for (int m = 0; m < M; m++) acch[r][m] = __float2half2_rn(0.f);
+#pragma unroll
+      for (int w = 0; w < 2; w++) {
+        half2 w4[R][4];
+#pragma unroll
+        for (int r = 0; r < R; r++) {
+          const unsigned qw = w == 0 ? q2[r].x : q2[r].y;
+#ifndef SKINNY_LUT_CVT
+          dequant8_tm(qw, sc2[r], w4[r]);
+#else
+  #pragma unroll
+          for (int pi = 0; pi < 4; pi++)
+            w4[r][pi] = dequant_pair(qw, pi, sc2[r]);
+#endif
+        }
+#pragma unroll
+        for (int pi = 0; pi < 4; pi++) {
+          const int psw = swz(s * 8 + w * 4 + pi);
+#pragma unroll
+          for (int m = 0; m < M; m++) {
+            const half2 xv = xs[m * P2 + psw];
+#pragma unroll
+            for (int r = 0; r < R; r++)
+              acch[r][m] = __hfma2(w4[r][pi], xv, acch[r][m]);
+          }
+        }
+      }
+#pragma unroll
+      for (int r = 0; r < R; r++)
+#pragma unroll
+        for (int m = 0; m < M; m++) {
+          const float2 f = __half22float2(acch[r][m]);
+          accf[r][m] += f.x + f.y;
+        }
+    }
+  }
+
+  // Tail chunk: K % KC remainder (any multiple of 128). Same layout and
+  // swizzle, runtime segment bound with idle-lane guard.
+  const int tail = K - k0;
+  if (tail > 0) {
+    __syncthreads();
+    for (int idx = threadIdx.x; idx < M * (tail / 8); idx += blockDim.x) {
+      const int m = idx / (tail / 8), j4 = idx % (tail / 8);
+      const uint4 v =
+          *reinterpret_cast<const uint4*>(x + (size_t)m * K + k0 + j4 * 8);
+      stage_pairs(xs + m * P2, j4 * 4, v);
+    }
+    __syncthreads();
+    const int nseg = tail >> 4;
+    for (int s = lane; s < nseg; s += 32) {
+      uint2 q2[R];
+      half2 sc2[R];
+#pragma unroll
+      for (int r = 0; r < R; r++) {
+        q2[r] = *reinterpret_cast<const uint2*>(crow[r] + (k0 >> 1) + s * 8);
+        sc2[r] = __hmul2(fp8e4m3_to_half2(srow[r][(k0 >> 4) + s]), gm2);
+      }
+      half2 acch[R][M];
+#pragma unroll
+      for (int r = 0; r < R; r++)
+#pragma unroll
+        for (int m = 0; m < M; m++) acch[r][m] = __float2half2_rn(0.f);
+#pragma unroll
+      for (int w = 0; w < 2; w++) {
+        half2 w4[R][4];
+#pragma unroll
+        for (int r = 0; r < R; r++) {
+          const unsigned qw = w == 0 ? q2[r].x : q2[r].y;
+#ifndef SKINNY_LUT_CVT
+          dequant8_tm(qw, sc2[r], w4[r]);
+#else
+  #pragma unroll
+          for (int pi = 0; pi < 4; pi++)
+            w4[r][pi] = dequant_pair(qw, pi, sc2[r]);
+#endif
+        }
+#pragma unroll
+        for (int pi = 0; pi < 4; pi++) {
+          const int psw = swz(s * 8 + w * 4 + pi);
+#pragma unroll
+          for (int m = 0; m < M; m++) {
+            const half2 xv = xs[m * P2 + psw];
+#pragma unroll
+            for (int r = 0; r < R; r++)
+              acch[r][m] = __hfma2(w4[r][pi], xv, acch[r][m]);
+          }
+        }
+      }
+#pragma unroll
+      for (int r = 0; r < R; r++)
+#pragma unroll
+        for (int m = 0; m < M; m++) {
+          const float2 f = __half22float2(acch[r][m]);
+          accf[r][m] += f.x + f.y;
+        }
+    }
+  }
+
+  if constexpr (!ARGMAX) {
+#pragma unroll
+    for (int r = 0; r < R; r++)
+#pragma unroll
+      for (int m = 0; m < M; m++) {
+        float v = accf[r][m];
+#pragma unroll
+        for (int o = 16; o > 0; o >>= 1) v += __shfl_xor_sync(~0u, v, o);
+        if (lane == 0) y[(size_t)m * N + n + r] = __float2half(v);
+      }
+  } else {
+    // Fused greedy argmax (M=1): identical reduce, identical
+    // __float2half rounding, then compare halves with strict > so ties
+    // keep the LOWEST index — matching argmax-over-half semantics of
+    // the separate path. One (val, idx) pair per block; no logits hit
+    // HBM.
+    __shared__ half wval[8];
+    __shared__ int widx[8];
+    half best_h = __float2half(-3.0e38f);
+    int best_i = -1;
+#pragma unroll
+    for (int r = 0; r < R; r++) {
+      float v = accf[r][0];
+#pragma unroll
+      for (int o = 16; o > 0; o >>= 1) v += __shfl_xor_sync(~0u, v, o);
+      if (lane == 0) {
+        const half h = __float2half(v);
+        if (__hgt(h, best_h)) {
+          best_h = h;
+          best_i = n + r;
+        }
+      }
+    }
+    if (lane == 0) {
+      wval[warp] = best_h;
+      widx[warp] = best_i;
+    }
+    __syncthreads();
+    if (threadIdx.x == 0) {
+      half bh = wval[0];
+      int bi = widx[0];
+#pragma unroll
+      for (int w = 1; w < 8; w++)
+        if (__hgt(wval[w], bh)) {
+          bh = wval[w];
+          bi = widx[w];
+        }
+      bvals[blockIdx.x] = bh;
+      bidxs[blockIdx.x] = bi;
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Host dispatch
+// ---------------------------------------------------------------------------
+static void check_inputs(const torch::Tensor& x, const torch::Tensor& codes,
+                         const torch::Tensor& scales, int64_t& m, int64_t& n,
+                         int64_t& k) {
+  TORCH_CHECK(x.is_cuda() && x.dtype() == torch::kHalf && x.is_contiguous());
+  TORCH_CHECK(codes.is_cuda() && codes.dtype() == torch::kUInt8 &&
+              codes.is_contiguous());
+  TORCH_CHECK(scales.is_cuda() && scales.dtype() == torch::kUInt8 &&
+              scales.is_contiguous());
+  m = x.size(0);
+  k = x.size(1);
+  n = codes.size(0);
+  TORCH_CHECK(codes.size(1) * 2 == k, "codes/x K mismatch");
+  TORCH_CHECK(scales.size(0) == n && scales.size(1) * 16 == k);
+}
+torch::Tensor skinny_gemm_simt(torch::Tensor x, torch::Tensor codes,
+                               torch::Tensor scales, double gscale) {
+  int64_t m, n, k;
+  check_inputs(x, codes, scales, m, n, k);
+  constexpr int KC = 1024;
+  TORCH_CHECK(k % 128 == 0 && k >= 128, "K must be a multiple of 128");
+  TORCH_CHECK(n % 8 == 0, "N must be a multiple of 8");
+  auto y = torch::empty({m, n}, x.options());
+  // Short-K rows leave <2 weight loads in flight per thread; two rows
+  // per warp restores latency hiding (shape diagnostic: out_proj K=1536
+  // ran at 66% of flagship bandwidth with one row per warp).
+  const bool two_rows = (k <= 2048) && (n % 16 == 0);
+  const dim3 grid(two_rows ? n / 16 : n / 8), block(256);
+  auto stream = at::cuda::getCurrentCUDAStream();
+  const int smem = (int)m * (KC / 2) * sizeof(half2);
+
+#define LAUNCH_SIMT(MM)                                                  \
+  if (two_rows)                                                          \
+    skinny_nvfp4_simt<MM, KC, 2><<<grid, block, smem, stream>>>(         \
+        codes.data_ptr<uint8_t>(), scales.data_ptr<uint8_t>(),           \
+        reinterpret_cast<const half*>(x.data_ptr<at::Half>()),           \
+        reinterpret_cast<half*>(y.data_ptr<at::Half>()), (int)n, (int)k, \
+        (float)gscale, nullptr, nullptr);                                \
+  else                                                                   \
+    skinny_nvfp4_simt<MM, KC, 1><<<grid, block, smem, stream>>>(         \
+        codes.data_ptr<uint8_t>(), scales.data_ptr<uint8_t>(),           \
+        reinterpret_cast<const half*>(x.data_ptr<at::Half>()),           \
+        reinterpret_cast<half*>(y.data_ptr<at::Half>()), (int)n, (int)k, \
+        (float)gscale, nullptr, nullptr)
+
+  switch (m) {
+    case 1:
+      LAUNCH_SIMT(1);
+      break;
+    case 2:
+      LAUNCH_SIMT(2);
+      break;
+    case 3:
+      LAUNCH_SIMT(3);
+      break;
+    default:
+      TORCH_CHECK(false, "simt kernel supports M in 1..3, got ", m);
+  }
+#undef LAUNCH_SIMT
+  C10_CUDA_KERNEL_LAUNCH_CHECK();
+  return y;
+}
+// ---------------------------------------------------------------------------
+// QPN kernel: Volta-native four-quadpair mma.m8n8k4, M 4..16 band.
+//
+// The quadpairs split the N dimension: one warp instruction = four
+// independent 8x8x4 MMAs sharing a single 8x4 activation A tile (the A
+// fragment map depends only on lane-position inside the quadpair, so
+// QP-sibling lanes hold identical A registers). MT template = number of
+// 8-row A tiles (MT=2 decodes B once for M 9..16). Weights arrive
+// PREPACKED in fragment order ([tile N/32][group K/16][lane 32] x 8B,
+// nibbles pre-interleaved so dequant8_tm's (i, i+4) output IS the
+// adjacent-k B register pair) — built once at weight load by the Python
+// adapter; the checkpoint-native layout stays for the SIMT decode path.
+// No smem in the main loop, no barriers except the cross-warp K-reduce
+// at output (CTA = 4 warps splitting K to keep the grid at N/32).
+// Frontier (qpn_sweep_20260810): SIMT M<=3 and QPN M=4..16 —
+// 1.28x at M=5, 1.69x at M=8, 1.29x at M=11, 1.22x at M=16 vs the
+// prior best incumbent on the 5-shape production set.
+// ---------------------------------------------------------------------------
+#define MMA_8N8K4(C, A0, A1, B0, B1)                                \
+  asm volatile(                                                     \
+      "mma.sync.aligned.m8n8k4.row.col.f32.f16.f16.f32 "            \
+      "{%0,%1,%2,%3,%4,%5,%6,%7}, {%8,%9}, {%10,%11}, "             \
+      "{%0,%1,%2,%3,%4,%5,%6,%7};\n"                                \
+      : "+f"(C[0]), "+f"(C[1]), "+f"(C[2]), "+f"(C[3]), "+f"(C[4]), \
+        "+f"(C[5]), "+f"(C[6]), "+f"(C[7])                          \
+      : "r"(A0), "r"(A1), "r"(B0), "r"(B1))
+
+template <int MT>
+__global__ void skinny_nvfp4_qpn(const uint8_t* __restrict__ qcodes,
+                                 const uint8_t* __restrict__ qscales,
+                                 const half* __restrict__ x,
+                                 half* __restrict__ y, int N, int K, int M,
+                                 float gscale) {
+  constexpr int WARPS = 4;
+  __shared__ float cs[WARPS][MT * 256];
+
+  const int lane = threadIdx.x & 31, warp = threadIdx.x >> 5;
+  const int tile = blockIdx.x;
+  const int qp = (lane >> 2) & 3;
+  const int r = (lane & 3) + ((lane & 16) ? 4 : 0);  // A row & B local col
+  const int G = K >> 4, Gq = G / WARPS;
+  const int g0 = warp * Gq;
+  const uint2* cb =
+      reinterpret_cast<const uint2*>(qcodes) + (size_t)tile * G * 32 + lane;
+  const uint8_t* sb = qscales + (size_t)tile * G * 32 + lane;
+
+  const half2 gm2 = __float2half2_rn(gscale * 16384.f);
+  float c[MT][8];
+#pragma unroll
+  for (int t = 0; t < MT; t++)
+#pragma unroll
+    for (int i = 0; i < 8; i++) c[t][i] = 0.f;
+
+#pragma unroll 4
+  for (int g = g0; g < g0 + Gq; g++) {
+    const uint2 q2 = __ldcs(cb + (size_t)g * 32);
+    const half2 sc2 =
+        __hmul2(fp8e4m3_to_half2(__ldg(sb + (size_t)g * 32)), gm2);
+    half2 b[8];
+    dequant8_tm(q2.x, sc2, b + 0);  // slices 0,1 (k0..7 adjacent pairs)
+    dequant8_tm(q2.y, sc2, b + 4);  // slices 2,3 (k8..15)
+    const unsigned* B = reinterpret_cast<const unsigned*>(b);
+#pragma unroll
+    for (int t = 0; t < MT; t++) {
+      const int ar = t * 8 + r;
+      uint4 a01 = make_uint4(0, 0, 0, 0), a23 = make_uint4(0, 0, 0, 0);
+      if (ar < M) {
+        const half* xrow = x + (size_t)ar * K;
+        a01 = *reinterpret_cast<const uint4*>(xrow + g * 16);
+        a23 = *reinterpret_cast<const uint4*>(xrow + g * 16 + 8);
+      }
+      const unsigned* A0 = reinterpret_cast<const unsigned*>(&a01);
+      const unsigned* A1 = reinterpret_cast<const unsigned*>(&a23);
+      MMA_8N8K4(c[t], A0[0], A0[1], B[0], B[1]);
+      MMA_8N8K4(c[t], A0[2], A0[3], B[2], B[3]);
+      MMA_8N8K4(c[t], A1[0], A1[1], B[4], B[5]);
+      MMA_8N8K4(c[t], A1[2], A1[3], B[6], B[7]);
+    }
+  }
+
+  // C map (mma8_probe.cu, roles swapped): reg i of lane L ->
+  //   A-row (i&2)|((L&16)?4:0)|(L&1); B-col (i&1)|(((L>>1)&1)<<1)|((i>>2)<<2)
+#pragma unroll
+  for (int t = 0; t < MT; t++)
+#pragma unroll
+    for (int i = 0; i < 8; i++) {
+      const int row = (i & 2) | ((lane & 16) ? 4 : 0) | (lane & 1);
+      const int col = (i & 1) | (((lane >> 1) & 1) << 1) | ((i >> 2) << 2);
+      cs[warp][(t * 8 + row) * 32 + qp * 8 + col] = c[t][i];
+    }
+  __syncthreads();  // the only barrier: cross-warp K reduce
+  for (int e = threadIdx.x; e < MT * 256; e += blockDim.x) {
+    const float v = cs[0][e] + cs[1][e] + cs[2][e] + cs[3][e];
+    const int row = e >> 5, col = e & 31;
+    if (row < M) y[(size_t)row * N + (size_t)tile * 32 + col] = __float2half(v);
+  }
+}
+torch::Tensor skinny_gemm_qpn(torch::Tensor x, torch::Tensor qcodes,
+                              torch::Tensor qscales, double gscale, int64_t n) {
+  const int64_t m = x.size(0), k = x.size(1);
+  TORCH_CHECK(x.is_cuda() && x.dtype() == torch::kHalf && x.is_contiguous());
+  TORCH_CHECK(qcodes.is_cuda() && qcodes.dtype() == torch::kUInt8 &&
+              qcodes.is_contiguous());
+  TORCH_CHECK(qscales.is_cuda() && qscales.dtype() == torch::kUInt8 &&
+              qscales.is_contiguous());
+  TORCH_CHECK(m >= 4 && m <= 16, "qpn supports M 4..16, got ", m);
+  TORCH_CHECK(k % 64 == 0, "K % 64 (4-warp split of 16-k groups)");
+  TORCH_CHECK(n % 32 == 0, "N % 32");
+  TORCH_CHECK(qcodes.numel() == n * (k >> 1), "qpn codes size");
+  TORCH_CHECK(qscales.numel() == n * (k >> 4), "qpn scales size");
+  auto y = torch::empty({m, n}, x.options());
+  auto stream = at::cuda::getCurrentCUDAStream();
+  if (m <= 8)
+    skinny_nvfp4_qpn<1><<<dim3((int)(n / 32)), dim3(128), 0, stream>>>(
+        qcodes.data_ptr<uint8_t>(), qscales.data_ptr<uint8_t>(),
+        reinterpret_cast<const half*>(x.data_ptr<at::Half>()),
+        reinterpret_cast<half*>(y.data_ptr<at::Half>()), (int)n, (int)k, (int)m,
+        (float)gscale);
+  else
+    skinny_nvfp4_qpn<2><<<dim3((int)(n / 32)), dim3(128), 0, stream>>>(
+        qcodes.data_ptr<uint8_t>(), qscales.data_ptr<uint8_t>(),
+        reinterpret_cast<const half*>(x.data_ptr<at::Half>()),
+        reinterpret_cast<half*>(y.data_ptr<at::Half>()), (int)n, (int)k, (int)m,
+        (float)gscale);
+  C10_CUDA_KERNEL_LAUNCH_CHECK();
+  return y;
+}
+
+TORCH_LIBRARY_FRAGMENT(_C, ops) {
+  ops.def(
+      "skinny_nvfp4_gemm_simt(Tensor x, Tensor codes, Tensor scales, "
+      "float gscale) -> Tensor");
+  ops.impl("skinny_nvfp4_gemm_simt", torch::kCUDA, &skinny_gemm_simt);
+  ops.def(
+      "skinny_nvfp4_gemm_qpn(Tensor x, Tensor qcodes, Tensor qscales, "
+      "float gscale, int n) -> Tensor");
+  ops.impl("skinny_nvfp4_gemm_qpn", torch::kCUDA, &skinny_gemm_qpn);
+}

--- a/docs/design/sm70_skinny_nvfp4_backend.md
+++ b/docs/design/sm70_skinny_nvfp4_backend.md
@@ -1,0 +1,68 @@
+# SM70 skinny NVFP4 dense backend
+
+## Scope
+
+The skinny backend is an opt-in small-batch overlay for dense W4A16 NVFP4
+linear layers on exact SM70 GPUs. It is model-agnostic: selection depends on
+the quantization layout and GEMM shape, not on a Qwen model class.
+
+Enable it with:
+
+```bash
+VLLM_SM70_QUANT_BACKEND=skinny vllm serve ... --dtype half
+```
+
+`skinny` extends the existing unified SM70 backend selector. Other quantized
+formats continue to use TurboMind. NVFP4 uses this runtime frontier:
+
+| Condition | Route |
+| --- | --- |
+| FP16, `M <= 3`, `K % 128 == 0`, `N % 8 == 0` | skinny SIMT |
+| FP16, `4 <= M <= 16`, QPN-eligible shape | skinny QPN |
+| Larger M or unsupported shape | TurboMind |
+| BF16 activation | explicit FP16 conversion, selected route, BF16 output |
+
+The adapter runs one eager comparison against TurboMind for each unique
+`(N, K)` shape at load time. A non-finite result, exception, or relative error
+above `3e-2` disables the skinny routes for the worker; TurboMind remains
+available because its packed state is prepared unconditionally.
+
+## Checkpoint contract
+
+The backend consumes the standard native NVFP4 W4A16 representation:
+
+- packed E2M1 codes: `uint8 [N, K / 2]`;
+- FP8-E4M3 scales with group size 16: `[N, K / 16]`;
+- one multiplicative global weight scale.
+
+Both compressed-tensors and ModelOpt NVFP4 linear adapters can use the backend.
+W4A4 checkpoints use it as a weight-only W4A16 fallback on SM70; their
+activation scales are not consumed on Volta. A mixed ModelOpt checkpoint may
+still have a higher device-capability requirement because its non-NVFP4 layers
+need their own SM70 conversion or fallback. Converting such a checkpoint to an
+SM70-compatible compressed-tensors artifact remains a separate checkpoint-build
+step.
+
+## Memory and fallback
+
+For dense models the load-time representation contains:
+
+1. the checkpoint-native codes/scales for SIMT;
+2. one same-size fragment-order QPN copy;
+3. the existing TurboMind packed fallback.
+
+The native tensors are aliased before TurboMind preparation rather than
+cloned. QPN therefore adds one NVFP4-weight-sized copy, not two. This profile is
+appropriate for dense 27B-class models under tensor parallelism, but it must
+not be applied wholesale to a large MoE expert bank.
+
+MoE support should reuse the same CUDA operators and prepack ABI behind a
+separate expert adapter with a bounded or lazy QPN cache. That keeps this dense
+backend reusable while avoiding an unbounded duplicate of every expert.
+
+## Provenance
+
+The CUDA implementation is the production SIMT and QPN subset of the
+MIT-licensed `Leonccaa/v100-skinny` project at commit
+`f8194f7c3c9269fa74ee70b5029d53c20098f4c8`. Its license and pinned-source note
+live beside the source in `csrc/quantization/skinny_nvfp4/`.

--- a/tests/quantization/test_nvfp4_mxfp4_gating.py
+++ b/tests/quantization/test_nvfp4_mxfp4_gating.py
@@ -18,6 +18,9 @@ from vllm.model_executor.kernels.linear.nvfp4.flashinfer import (
 from vllm.model_executor.layers.quantization.compressed_tensors.schemes import (
     compressed_tensors_w4a4_mxfp4 as mxfp4_scheme,
 )
+from vllm.model_executor.layers.quantization.compressed_tensors.schemes import (
+    compressed_tensors_w4a4_nvfp4 as nvfp4_scheme,
+)
 from vllm.model_executor.layers.quantization.compressed_tensors.schemes.compressed_tensors_w4a4_mxfp4 import (  # noqa: E501
     CompressedTensorsW4A4Mxfp4,
 )
@@ -37,6 +40,10 @@ def test_sm70_quant_backend_auto_respects_route_default(monkeypatch):
 
     monkeypatch.setenv("VLLM_SM70_QUANT_BACKEND", "marlin")
     assert not envs.use_sm70_turbomind(True)
+
+    monkeypatch.setenv("VLLM_SM70_QUANT_BACKEND", "skinny")
+    assert envs.use_sm70_turbomind(False)
+    assert envs.use_sm70_skinny_nvfp4()
 
 
 def test_nvfp4_min_capability_honors_linear_backend_emulation(monkeypatch):
@@ -81,6 +88,50 @@ def test_nvfp4_min_capability_honors_legacy_emulation_env(monkeypatch):
         VllmConfig(kernel_config=KernelConfig(linear_backend="auto"))
     ):
         assert CompressedTensorsW4A4Fp4.get_min_capability() == 70
+
+
+def test_nvfp4_w4a4_skinny_route_precedes_turbomind(monkeypatch):
+    layer = torch.nn.Module()
+    layer.input_size_per_partition = 4
+    layer.output_size_per_partition = 2
+    layer.weight_packed = Parameter(
+        torch.tensor([[0x10, 0x32], [0x54, 0x76]], dtype=torch.uint8),
+        requires_grad=False,
+    )
+    layer.weight_scale = Parameter(
+        torch.ones((2, 1), dtype=torch.float8_e4m3fn), requires_grad=False
+    )
+    layer.weight_global_scale = Parameter(torch.tensor([2.0]), requires_grad=False)
+    layer.input_global_scale = Parameter(torch.tensor([4.0]), requires_grad=False)
+    calls = []
+
+    class FakeSkinnyKernel:
+        def process_weights_after_loading(self, loaded_layer):
+            calls.append("process")
+            loaded_layer.skinny_codes = loaded_layer.weight
+
+        def apply_weights(self, layer, x, bias=None):
+            calls.append("apply")
+            return torch.zeros((x.shape[0], 2), dtype=x.dtype) + (bias or 0)
+
+    monkeypatch.setattr(nvfp4_scheme.sm70_tm, "uses_skinny_nvfp4", lambda: True)
+    monkeypatch.setattr(
+        nvfp4_scheme.sm70_tm,
+        "prepare_nvfp4_linear",
+        lambda layer: (_ for _ in ()).throw(AssertionError("unexpected TurboMind")),
+    )
+    monkeypatch.setattr(
+        CompressedTensorsW4A4Fp4,
+        "_fallback_kernel",
+        lambda self: FakeSkinnyKernel(),
+    )
+    scheme = CompressedTensorsW4A4Fp4()
+
+    scheme.process_weights_after_loading(layer)
+    out = scheme.apply_weights(layer, torch.ones((1, 4), dtype=torch.float16))
+
+    assert calls == ["process", "apply"]
+    assert out.shape == (1, 2)
 
 
 def test_flashinfer_nvfp4_backends_reject_sm70():

--- a/tests/quantization/test_sm70_skinny_nvfp4.py
+++ b/tests/quantization/test_sm70_skinny_nvfp4.py
@@ -1,0 +1,152 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import torch
+
+from vllm import _sm70_ops
+from vllm.model_executor.kernels.linear.nvfp4 import skinny
+from vllm.model_executor.layers.quantization import modelopt
+
+
+def _unpack_nibble(codes: torch.Tensor, row: int, column: int) -> int:
+    packed = int(codes[row, column // 2])
+    return (packed >> (4 * (column & 1))) & 0xF
+
+
+def test_qpn_prepack_matches_fragment_order_reference():
+    n, k = 32, 64
+    codes = torch.arange(n * (k // 2), dtype=torch.int64)
+    codes = codes.remainder(256).to(torch.uint8).view(n, k // 2)
+    scales = torch.arange(n * (k // 16), dtype=torch.int64)
+    scales = scales.remainder(256).to(torch.uint8).view(n, k // 16)
+
+    actual_codes, actual_scales = skinny.qpn_prepack(codes, scales)
+
+    assert actual_codes is not None
+    assert actual_scales is not None
+    expected_codes: list[int] = []
+    expected_scales: list[int] = []
+    korder = [0, 2, 4, 6, 1, 3, 5, 7, 8, 10, 12, 14, 9, 11, 13, 15]
+    for group in range(k // 16):
+        for lane in range(32):
+            column = ((lane >> 2) & 3) * 8 + (lane & 3) + (4 if lane & 16 else 0)
+            selected = [
+                _unpack_nibble(codes, column, group * 16 + offset) for offset in korder
+            ]
+            expected_codes.extend(
+                selected[index] | (selected[index + 1] << 4)
+                for index in range(0, 16, 2)
+            )
+            expected_scales.append(int(scales[column, group]))
+
+    assert actual_codes.tolist() == expected_codes
+    assert actual_scales.tolist() == expected_scales
+
+
+def test_qpn_prepack_rejects_ineligible_shape_without_copy():
+    codes = torch.zeros((31, 32), dtype=torch.uint8)
+    scales = torch.zeros((31, 4), dtype=torch.uint8)
+
+    qcodes, qscales = skinny.qpn_prepack(codes, scales)
+
+    assert qcodes is None
+    assert qscales is None
+
+
+def _native_buffers(n: int, k: int):
+    codes = torch.zeros((n, k // 2), dtype=torch.uint8)
+    scales = torch.zeros((n, k // 16), dtype=torch.uint8)
+    qcodes = torch.zeros(n * (k // 2), dtype=torch.uint8)
+    qscales = torch.zeros(n * (k // 16), dtype=torch.uint8)
+    tm_weight = torch.empty(0, dtype=torch.int32)
+    tm_scales = torch.empty(0, dtype=torch.float16)
+    return codes, scales, qcodes, qscales, tm_weight, tm_scales
+
+
+def test_bf16_activation_is_explicitly_converted_and_restored(monkeypatch):
+    n, k = 32, 128
+    buffers = _native_buffers(n, k)
+    seen_dtypes = []
+
+    def fake_simt(input, codes, scales, global_scale):
+        del codes, scales, global_scale
+        seen_dtypes.append(input.dtype)
+        return input.sum(dim=1, keepdim=True).expand(-1, n).contiguous()
+
+    monkeypatch.setattr(_sm70_ops, "skinny_nvfp4_gemm_simt", fake_simt)
+    x = torch.ones((1, k), dtype=torch.bfloat16)
+
+    out = skinny._skinny_nvfp4_linear_impl(x, *buffers, 1.0, n, k, 16, 0, 0)
+
+    assert seen_dtypes == [torch.float16]
+    assert out.dtype == torch.bfloat16
+    assert out.shape == (1, n)
+
+
+def test_large_m_uses_turbomind_fallback(monkeypatch):
+    n, k, m = 32, 128, 17
+    buffers = _native_buffers(n, k)
+    calls = []
+
+    def fake_turbomind(
+        out, input, qweight, scales, group_size, k_ld, q_ld, gated_silu=False
+    ):
+        del qweight, scales, group_size, k_ld, q_ld, gated_silu
+        calls.append(input.dtype)
+        out.copy_(input.sum(dim=1, keepdim=True).expand(-1, n))
+
+    monkeypatch.setattr(_sm70_ops, "nvfp4_gemm_sm70_out", fake_turbomind)
+    x = torch.ones((m, k), dtype=torch.bfloat16)
+
+    out = skinny._skinny_nvfp4_linear_impl(x, *buffers, 1.0, n, k, 16, 0, 0)
+
+    assert calls == [torch.float16]
+    assert out.dtype == torch.bfloat16
+    assert out.shape == (m, n)
+
+
+def test_skinny_kernel_rejects_non_sm70():
+    supported, reason = skinny.SkinnyNvFp4LinearKernel.is_supported(80)
+
+    assert not supported
+    assert reason == "requires exact CUDA capability 7.0"
+
+
+def test_modelopt_nvfp4_min_capability_is_lowered_only_for_skinny(monkeypatch):
+    monkeypatch.delenv("VLLM_SM70_QUANT_BACKEND", raising=False)
+    assert modelopt.ModelOptNvFp4Config.get_min_capability() == 75
+
+    monkeypatch.setenv("VLLM_SM70_QUANT_BACKEND", "skinny")
+    assert modelopt.ModelOptNvFp4Config.get_min_capability() == 70
+
+
+def test_modelopt_w4a16_selects_generic_skinny_kernel(monkeypatch):
+    sentinel = object()
+    monkeypatch.setenv("VLLM_SM70_QUANT_BACKEND", "skinny")
+    monkeypatch.setattr(modelopt, "init_nvfp4_linear_kernel", lambda: sentinel)
+    config = modelopt.ModelOptNvFp4Config(
+        quant_method="W4A16_NVFP4",
+        is_checkpoint_nvfp4_serialized=True,
+        kv_cache_quant_algo=None,
+        exclude_modules=[],
+    )
+
+    method = modelopt.ModelOptNvFp4W4A16LinearMethod(config)
+
+    assert method.kernel is sentinel
+
+
+def test_modelopt_w4a4_selects_generic_skinny_kernel(monkeypatch):
+    sentinel = object()
+    monkeypatch.setenv("VLLM_SM70_QUANT_BACKEND", "skinny")
+    monkeypatch.setattr(modelopt, "init_nvfp4_linear_kernel", lambda: sentinel)
+    config = modelopt.ModelOptNvFp4Config(
+        quant_method="NVFP4",
+        is_checkpoint_nvfp4_serialized=True,
+        kv_cache_quant_algo=None,
+        exclude_modules=[],
+    )
+
+    method = modelopt.ModelOptNvFp4LinearMethod(config)
+
+    assert method.kernel is sentinel

--- a/tests/quantization/test_sm70_skinny_nvfp4_gpu.py
+++ b/tests/quantization/test_sm70_skinny_nvfp4_gpu.py
@@ -1,0 +1,111 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+import torch
+
+from vllm import _sm70_ops
+from vllm.model_executor.kernels.linear.nvfp4 import (
+    NvFp4LinearLayerConfig,
+    SkinnyNvFp4LinearKernel,
+    skinny,
+)
+
+
+def _is_exact_sm70() -> bool:
+    return torch.cuda.is_available() and torch.cuda.get_device_capability() == (7, 0)
+
+
+@pytest.mark.skipif(not _is_exact_sm70(), reason="requires an exact SM70 GPU")
+@torch.inference_mode()
+def test_sm70_skinny_adapter_routes_and_matches_turbomind(monkeypatch):
+    supported, reason = SkinnyNvFp4LinearKernel.is_supported()
+    if not supported:
+        pytest.skip(reason)
+
+    class FakeLayer(torch.nn.Module):
+        pass
+
+    torch.manual_seed(20260812)
+    device = torch.device("cuda:0")
+    n, k = 5120, 1536
+    layer = FakeLayer()
+    layer.input_size_per_partition = k
+    layer.output_size_per_partition = n
+    layer.weight = torch.nn.Parameter(
+        torch.randint(0, 256, (n, k // 2), dtype=torch.uint8, device=device),
+        requires_grad=False,
+    )
+    layer.weight_scale = torch.nn.Parameter(
+        (torch.rand(n, k // 16, device=device) * 400 + 8).to(torch.float8_e4m3fn),
+        requires_grad=False,
+    )
+    layer.weight_global_scale = torch.nn.Parameter(
+        torch.tensor(0.0021, dtype=torch.float32, device=device),
+        requires_grad=False,
+    )
+
+    kernel = SkinnyNvFp4LinearKernel(NvFp4LinearLayerConfig())
+    kernel.process_weights_after_loading(layer)
+    state = skinny.sm70_tm.get_prepared_linear_state(layer)
+    assert state.op_kind == "nvfp4"
+
+    route_calls = {"simt": 0, "qpn": 0}
+    original_simt = _sm70_ops.skinny_nvfp4_gemm_simt
+    original_qpn = _sm70_ops.skinny_nvfp4_gemm_qpn
+
+    def counted_simt(*args, **kwargs):
+        route_calls["simt"] += 1
+        return original_simt(*args, **kwargs)
+
+    def counted_qpn(*args, **kwargs):
+        route_calls["qpn"] += 1
+        return original_qpn(*args, **kwargs)
+
+    monkeypatch.setattr(_sm70_ops, "skinny_nvfp4_gemm_simt", counted_simt)
+    monkeypatch.setattr(_sm70_ops, "skinny_nvfp4_gemm_qpn", counted_qpn)
+
+    cases = [
+        (1, torch.float16, "simt"),
+        (3, torch.float16, "simt"),
+        (4, torch.float16, "qpn"),
+        (8, torch.float16, "qpn"),
+        (9, torch.float16, "qpn"),
+        (16, torch.float16, "qpn"),
+        (17, torch.float16, "turbomind"),
+        (2048, torch.float16, "turbomind"),
+        (1, torch.bfloat16, "simt"),
+        (8, torch.bfloat16, "qpn"),
+        (17, torch.bfloat16, "turbomind"),
+    ]
+    for m, dtype, expected_route in cases:
+        before = route_calls.copy()
+        x = (torch.randn(m, k, device=device) * 0.1).to(dtype)
+        actual = kernel.apply_weights(layer, x)
+        reference = skinny._turbomind_fallback(
+            x.to(torch.float16),
+            state.weight,
+            state.scales,
+            n,
+            state.group_size,
+            state.k_ld,
+            state.q_ld,
+        )
+        if dtype == torch.bfloat16:
+            reference = reference.to(torch.bfloat16)
+
+        denominator = reference.float().abs().max().clamp(min=1e-6)
+        relative_error = (
+            (actual.float() - reference.float()).abs().max() / denominator
+        ).item()
+        assert torch.isfinite(actual).all()
+        assert actual.dtype == dtype
+        assert relative_error < 3e-2
+        if expected_route == "simt":
+            assert route_calls["simt"] == before["simt"] + 1
+            assert route_calls["qpn"] == before["qpn"]
+        elif expected_route == "qpn":
+            assert route_calls["qpn"] == before["qpn"] + 1
+            assert route_calls["simt"] == before["simt"]
+        else:
+            assert route_calls == before

--- a/vllm/_sm70_ops.py
+++ b/vllm/_sm70_ops.py
@@ -536,6 +536,54 @@ if hasattr(torch.ops._C, "nvfp4_gemm_sm70_out"):
         return None
 
 
+def skinny_nvfp4_gemm_simt(
+    input: torch.Tensor,
+    codes: torch.Tensor,
+    scales: torch.Tensor,
+    global_scale: float,
+) -> torch.Tensor:
+    return _op("skinny_nvfp4_gemm_simt")(input, codes, scales, global_scale)
+
+
+if hasattr(torch.ops._C, "skinny_nvfp4_gemm_simt"):
+
+    @register_fake("_C::skinny_nvfp4_gemm_simt")
+    def _skinny_nvfp4_gemm_simt_fake(
+        input: torch.Tensor,
+        codes: torch.Tensor,
+        scales: torch.Tensor,
+        global_scale: float,
+    ) -> torch.Tensor:
+        del scales, global_scale
+        return input.new_empty((input.shape[0], codes.shape[0]))
+
+
+def skinny_nvfp4_gemm_qpn(
+    input: torch.Tensor,
+    qcodes: torch.Tensor,
+    qscales: torch.Tensor,
+    global_scale: float,
+    output_size: int,
+) -> torch.Tensor:
+    return _op("skinny_nvfp4_gemm_qpn")(
+        input, qcodes, qscales, global_scale, output_size
+    )
+
+
+if hasattr(torch.ops._C, "skinny_nvfp4_gemm_qpn"):
+
+    @register_fake("_C::skinny_nvfp4_gemm_qpn")
+    def _skinny_nvfp4_gemm_qpn_fake(
+        input: torch.Tensor,
+        qcodes: torch.Tensor,
+        qscales: torch.Tensor,
+        global_scale: float,
+        output_size: int,
+    ) -> torch.Tensor:
+        del qcodes, qscales, global_scale
+        return input.new_empty((input.shape[0], output_size))
+
+
 def nvfp4_gemv_sm70_raw_out(
     out: torch.Tensor,
     input: torch.Tensor,

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -112,7 +112,7 @@ if TYPE_CHECKING:
     VLLM_1CAT_ENABLE_QWEN35_MTP_DEFAULTS: bool = False
     VLLM_1CAT_DISABLE_SM70_MTP_DEFAULTS: bool = False
     VLLM_1CAT_DISABLE_QWEN35_MTP_DEFAULTS: bool = False
-    VLLM_SM70_QUANT_BACKEND: Literal["auto", "marlin", "turbomind"] = "auto"
+    VLLM_SM70_QUANT_BACKEND: Literal["auto", "marlin", "turbomind", "skinny"] = "auto"
     VLLM_SM70_AWQ_TURBOMIND: bool = True
     VLLM_SM70_GPTQ_TURBOMIND: bool = False
     VLLM_SM70_COMPRESSED_TENSORS_TURBOMIND: bool = False
@@ -770,15 +770,16 @@ def env_with_choices(
     return _get_validated_env
 
 
-SM70_QUANT_BACKENDS = ("auto", "marlin", "turbomind")
-SM70QuantBackend = Literal["auto", "marlin", "turbomind"]
+SM70_QUANT_BACKENDS = ("auto", "marlin", "turbomind", "skinny")
+SM70QuantBackend = Literal["auto", "marlin", "turbomind", "skinny"]
 
 
 def get_sm70_quant_backend() -> SM70QuantBackend:
     value = os.getenv("VLLM_SM70_QUANT_BACKEND", "auto").strip().lower()
     if value not in SM70_QUANT_BACKENDS:
         raise ValueError(
-            "VLLM_SM70_QUANT_BACKEND must be one of auto, marlin, turbomind; "
+            "VLLM_SM70_QUANT_BACKEND must be one of auto, marlin, "
+            "turbomind, skinny; "
             f"got {value!r}."
         )
     return cast(SM70QuantBackend, value)
@@ -788,13 +789,22 @@ def use_sm70_turbomind(default_enabled: bool) -> bool:
     backend = get_sm70_quant_backend()
     if backend == "marlin":
         return False
-    if backend == "turbomind":
+    if backend in ("turbomind", "skinny"):
         return True
     return bool(default_enabled)
 
 
 def force_sm70_marlin() -> bool:
     return get_sm70_quant_backend() == "marlin"
+
+
+def use_sm70_skinny_nvfp4() -> bool:
+    """Use the skinny small-M overlay for SM70 NVFP4 dense layers.
+
+    Other quantized formats continue to use TurboMind when the unified
+    backend is ``skinny``.
+    """
+    return get_sm70_quant_backend() == "skinny"
 
 
 def env_list_with_choices(
@@ -1470,7 +1480,9 @@ environment_variables: dict[str, Callable[[], Any]] = {
         int(os.getenv("VLLM_1CAT_DISABLE_QWEN35_MTP_DEFAULTS", "0"))
     ),
     # Unified V100/SM70 quantized linear backend selector. "auto" resolves to
-    # TurboMind for supported SM70 quant routes; only "marlin" forces Marlin.
+    # TurboMind for supported SM70 quant routes; "skinny" overlays the NVFP4
+    # dense small-M kernels while retaining TurboMind for all fallbacks and
+    # other formats. Only "marlin" forces Marlin.
     "VLLM_SM70_QUANT_BACKEND": get_sm70_quant_backend,
     # V100/SM70 AWQ dense path using the local TurboMind backend. This matches
     # the 0.0.3 route semantics: enable by default on SM70 and allow an explicit

--- a/vllm/model_executor/kernels/linear/__init__.py
+++ b/vllm/model_executor/kernels/linear/__init__.py
@@ -112,6 +112,9 @@ from vllm.model_executor.kernels.linear.nvfp4.flashinfer import (
 from vllm.model_executor.kernels.linear.nvfp4.marlin import (
     MarlinNvFp4LinearKernel,
 )
+from vllm.model_executor.kernels.linear.nvfp4.skinny import (
+    SkinnyNvFp4LinearKernel,
+)
 from vllm.model_executor.kernels.linear.scaled_mm import (
     Fp8BlockScaledMMLinearKernel,
     FP8ScaledMMLinearKernel,
@@ -830,6 +833,7 @@ _NVFP4_BACKEND_TO_KERNEL: dict[str, type[NvFp4LinearKernel]] = {
     "flashinfer-trtllm": FlashInferTrtllmNvFp4LinearKernel,
     "flashinfer-cudnn": FlashInferCudnnNvFp4LinearKernel,
     "emulation": EmulationNvFp4LinearKernel,
+    "skinny": SkinnyNvFp4LinearKernel,
 }
 
 
@@ -873,6 +877,14 @@ def init_nvfp4_linear_kernel() -> NvFp4LinearKernel:
                 reason,
             )
             force_kernel = EmulationNvFp4LinearKernel
+    elif envs.use_sm70_skinny_nvfp4():
+        if linear_backend != "auto":
+            logger.warning_once(
+                "VLLM_SM70_QUANT_BACKEND=skinny overrides "
+                "--linear-backend=%s for NVFP4 layers.",
+                linear_backend,
+            )
+        force_kernel = SkinnyNvFp4LinearKernel
     elif linear_backend == "auto":
         # Deprecated env-var overrides — only honoured when --linear-backend
         # is "auto". Deprecation warnings are emitted from vllm/envs.py.
@@ -1013,6 +1025,7 @@ __all__ = [
     "AiterPerTokenFp8ScaledMMLinearKernel",
     "NvFp4LinearKernel",
     "NvFp4LinearLayerConfig",
+    "SkinnyNvFp4LinearKernel",
     "AiterInt8ScaledMMLinearKernel",
     "CPUInt8ScaledMMLinearKernel",
     "CutlassFP8ScaledMMLinearKernel",

--- a/vllm/model_executor/kernels/linear/nvfp4/__init__.py
+++ b/vllm/model_executor/kernels/linear/nvfp4/__init__.py
@@ -5,8 +5,12 @@ from vllm.model_executor.kernels.linear.nvfp4.base import (
     NvFp4LinearKernel,
     NvFp4LinearLayerConfig,
 )
+from vllm.model_executor.kernels.linear.nvfp4.skinny import (
+    SkinnyNvFp4LinearKernel,
+)
 
 __all__ = [
     "NvFp4LinearKernel",
     "NvFp4LinearLayerConfig",
+    "SkinnyNvFp4LinearKernel",
 ]

--- a/vllm/model_executor/kernels/linear/nvfp4/skinny.py
+++ b/vllm/model_executor/kernels/linear/nvfp4/skinny.py
@@ -1,0 +1,423 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from __future__ import annotations
+
+import math
+
+import torch
+from torch.nn.parameter import Parameter
+
+from vllm.logger import init_logger
+from vllm.model_executor.layers.quantization import sm70_turbomind as sm70_tm
+from vllm.platforms import current_platform
+from vllm.utils.torch_utils import direct_register_custom_op
+
+from .base import NvFp4LinearKernel, NvFp4LinearLayerConfig
+
+logger = init_logger(__name__)
+
+_SELF_CHECK_TOL = 3e-2
+_runtime_ok = True
+_validated_shapes: set[tuple[int, int]] = set()
+_route_log_seen: set[tuple[str, int, torch.dtype]] = set()
+
+
+def qpn_prepack(
+    codes: torch.Tensor, scales: torch.Tensor
+) -> tuple[torch.Tensor | None, torch.Tensor | None]:
+    """Prepack checkpoint-native NVFP4 bytes for the QPN fragment map.
+
+    The result is a pure permutation of weight nibbles and scale bytes. It is
+    built once at weight load and consumed by the M=4..16 QPN kernel.
+    """
+    if codes.dim() != 2 or scales.dim() != 2:
+        raise ValueError("NVFP4 codes and scales must both be two-dimensional.")
+    if codes.dtype != torch.uint8 or scales.dtype != torch.uint8:
+        raise TypeError("QPN prepack expects uint8 views of NVFP4 codes and scales.")
+    if codes.device != scales.device:
+        raise ValueError("NVFP4 codes and scales must be on the same device.")
+
+    n, k2 = codes.shape
+    k = k2 * 2
+    if scales.shape != (n, k // 16):
+        raise ValueError(
+            "NVFP4 scale shape mismatch: expected "
+            f"{(n, k // 16)}, got {tuple(scales.shape)}."
+        )
+    if n % 32 or k % 64:
+        return None, None
+
+    device = codes.device
+    tiles, groups = n // 32, k // 16
+    lane = torch.arange(32, device=device)
+    col = ((lane >> 2) & 3) * 8 + (lane & 3) + ((lane & 16) > 0).long() * 4
+    korder = torch.tensor(
+        [0, 2, 4, 6, 1, 3, 5, 7, 8, 10, 12, 14, 9, 11, 13, 15],
+        device=device,
+    )
+    nibbles = torch.stack([codes & 0xF, codes >> 4], dim=-1).view(n, k)
+    group = torch.arange(groups, device=device)
+    kidx = group.view(groups, 1) * 16 + korder.view(1, 16)
+    qcodes = torch.empty(tiles, groups, 32, 8, dtype=torch.uint8, device=device)
+    qscales = torch.empty(tiles, groups, 32, dtype=torch.uint8, device=device)
+
+    # Broadcast indices are much larger than the payload. Bound temporary
+    # storage to roughly 300 MiB even for a large vocabulary projection.
+    tile_chunk = max(1, 36864 // groups)
+    for tile_start in range(0, tiles, tile_chunk):
+        tile_end = min(tile_start + tile_chunk, tiles)
+        tile_count = tile_end - tile_start
+        ncol = torch.arange(tile_start, tile_end, device=device).view(
+            tile_count, 1
+        ) * 32 + col.view(1, 32)
+        selected = nibbles[
+            ncol.view(tile_count, 1, 32, 1).expand(tile_count, groups, 32, 16),
+            kidx.view(1, groups, 1, 16).expand(tile_count, groups, 32, 16),
+        ]
+        qcodes[tile_start:tile_end] = selected[..., 0::2] | (selected[..., 1::2] << 4)
+        qscales[tile_start:tile_end] = scales[
+            ncol.view(tile_count, 1, 32).expand(tile_count, groups, 32),
+            group.view(1, groups, 1).expand(tile_count, groups, 32),
+        ]
+
+    return qcodes.view(-1).contiguous(), qscales.view(-1).contiguous()
+
+
+def _turbomind_fallback(
+    x: torch.Tensor,
+    tm_weight: torch.Tensor,
+    tm_scales: torch.Tensor,
+    n: int,
+    group_size: int,
+    k_ld: int,
+    q_ld: int,
+) -> torch.Tensor:
+    from vllm import _sm70_ops as sm70_ops
+
+    out = torch.empty((x.shape[0], n), dtype=x.dtype, device=x.device)
+    sm70_ops.nvfp4_gemm_sm70_out(
+        out,
+        x,
+        tm_weight,
+        tm_scales,
+        group_size,
+        k_ld,
+        q_ld,
+    )
+    return out
+
+
+def _skinny_nvfp4_linear_impl(
+    x: torch.Tensor,
+    codes: torch.Tensor,
+    scales: torch.Tensor,
+    qpn_codes: torch.Tensor,
+    qpn_scales: torch.Tensor,
+    tm_weight: torch.Tensor,
+    tm_scales: torch.Tensor,
+    global_scale: float,
+    n: int,
+    k: int,
+    group_size: int,
+    k_ld: int,
+    q_ld: int,
+) -> torch.Tensor:
+    global _runtime_ok
+
+    if x.dtype not in (torch.float16, torch.bfloat16):
+        raise TypeError(
+            f"SM70 skinny NVFP4 supports FP16 or BF16 activations, but got {x.dtype}."
+        )
+
+    # Both the small-M kernels and the existing TurboMind fallback execute in
+    # FP16 on Volta. For a BF16 model, make that conversion explicit at this
+    # adapter boundary and restore the public output dtype afterwards.
+    output_dtype = x.dtype
+    kernel_x = x if x.dtype == torch.float16 else x.to(torch.float16)
+    m = kernel_x.shape[0]
+
+    use_qpn = (
+        _runtime_ok
+        and 4 <= m <= 16
+        and k % 64 == 0
+        and n % 32 == 0
+        and qpn_codes.numel() == n * (k // 2)
+        and qpn_scales.numel() == n * (k // 16)
+    )
+    use_simt = (
+        _runtime_ok
+        and 1 <= m <= 3
+        and k % 128 == 0
+        and n % 8 == 0
+        and codes.numel() == n * (k // 2)
+        and scales.numel() == n * (k // 16)
+    )
+
+    if use_qpn:
+        route = "qpn"
+    elif use_simt:
+        route = "simt"
+    else:
+        route = "turbomind"
+    route_key = (route, m, output_dtype)
+    if route_key not in _route_log_seen:
+        _route_log_seen.add(route_key)
+        logger.info(
+            "SM70 skinny NVFP4 route: M=%d N=%d K=%d dtype=%s -> %s",
+            m,
+            n,
+            k,
+            output_dtype,
+            route,
+        )
+
+    from vllm import _sm70_ops as sm70_ops
+
+    if use_qpn:
+        out = sm70_ops.skinny_nvfp4_gemm_qpn(
+            kernel_x, qpn_codes, qpn_scales, global_scale, n
+        )
+    elif use_simt:
+        out = sm70_ops.skinny_nvfp4_gemm_simt(kernel_x, codes, scales, global_scale)
+    else:
+        out = _turbomind_fallback(
+            kernel_x, tm_weight, tm_scales, n, group_size, k_ld, q_ld
+        )
+
+    return out if output_dtype == torch.float16 else out.to(output_dtype)
+
+
+def _skinny_nvfp4_linear_fake(
+    x: torch.Tensor,
+    codes: torch.Tensor,
+    scales: torch.Tensor,
+    qpn_codes: torch.Tensor,
+    qpn_scales: torch.Tensor,
+    tm_weight: torch.Tensor,
+    tm_scales: torch.Tensor,
+    global_scale: float,
+    n: int,
+    k: int,
+    group_size: int,
+    k_ld: int,
+    q_ld: int,
+) -> torch.Tensor:
+    del (
+        codes,
+        scales,
+        qpn_codes,
+        qpn_scales,
+        tm_weight,
+        tm_scales,
+        global_scale,
+        k,
+        group_size,
+        k_ld,
+        q_ld,
+    )
+    return x.new_empty((x.shape[0], n))
+
+
+direct_register_custom_op(
+    op_name="sm70_skinny_nvfp4_linear",
+    op_func=_skinny_nvfp4_linear_impl,
+    fake_impl=_skinny_nvfp4_linear_fake,
+)
+
+
+def _relative_error(actual: torch.Tensor, expected: torch.Tensor) -> float:
+    denominator = expected.float().abs().max().clamp(min=1e-6)
+    error = (actual.float() - expected.float()).abs().max() / denominator
+    return float(error.item())
+
+
+class SkinnyNvFp4LinearKernel(NvFp4LinearKernel):
+    """SM70 small-M NVFP4 overlay with a TurboMind fallback."""
+
+    @classmethod
+    def is_supported(
+        cls, compute_capability: int | None = None
+    ) -> tuple[bool, str | None]:
+        if compute_capability is None:
+            if (
+                not current_platform.is_cuda()
+                or not current_platform.is_device_capability((7, 0))
+            ):
+                return False, "requires exact CUDA capability 7.0"
+        elif compute_capability != 70:
+            return False, "requires exact CUDA capability 7.0"
+
+        required_ops = (
+            "skinny_nvfp4_gemm_simt",
+            "skinny_nvfp4_gemm_qpn",
+            "nvfp4_sm70_prepare",
+            "nvfp4_gemm_sm70_out",
+        )
+        missing = [name for name in required_ops if not hasattr(torch.ops._C, name)]
+        if missing:
+            return False, "missing SM70 extension ops: " + ", ".join(missing)
+        return True, None
+
+    @classmethod
+    def can_implement(cls, config: NvFp4LinearLayerConfig) -> tuple[bool, str | None]:
+        del config
+        return True, None
+
+    def _validate_shape(self, layer: torch.nn.Module) -> None:
+        global _runtime_ok
+
+        n = layer.output_size_per_partition
+        k = layer.input_size_per_partition
+        shape = (n, k)
+        if not _runtime_ok or shape in _validated_shapes:
+            return
+
+        state = sm70_tm.get_prepared_linear_state(layer)
+        cases = [(1, "simt")]
+        if layer.skinny_qpn_codes.numel() > 0:
+            cases.append((8, "qpn"))
+
+        try:
+            for m, route in cases:
+                values = torch.arange(
+                    m * k, device=layer.skinny_codes.device, dtype=torch.int32
+                )
+                x = ((values.remainder(31) - 15).to(torch.float16) * 1e-3).view(m, k)
+                reference = _turbomind_fallback(
+                    x,
+                    state.weight,
+                    state.scales,
+                    n,
+                    state.group_size,
+                    state.k_ld,
+                    state.q_ld,
+                )
+                if route == "simt":
+                    actual = torch.ops._C.skinny_nvfp4_gemm_simt(
+                        x,
+                        layer.skinny_codes,
+                        layer.skinny_scales,
+                        layer.skinny_global_scale,
+                    )
+                else:
+                    actual = torch.ops._C.skinny_nvfp4_gemm_qpn(
+                        x,
+                        layer.skinny_qpn_codes,
+                        layer.skinny_qpn_scales,
+                        layer.skinny_global_scale,
+                        n,
+                    )
+                relative_error = _relative_error(actual, reference)
+                if (
+                    not math.isfinite(relative_error)
+                    or relative_error > _SELF_CHECK_TOL
+                ):
+                    raise RuntimeError(
+                        f"{route} relative error {relative_error:.3e} exceeds "
+                        f"{_SELF_CHECK_TOL:.3e}"
+                    )
+        except Exception:
+            _runtime_ok = False
+            logger.exception(
+                "SM70 skinny NVFP4 self-check failed for N=%d K=%d; "
+                "disabling skinny routes and retaining TurboMind.",
+                n,
+                k,
+            )
+            return
+
+        _validated_shapes.add(shape)
+        logger.info(
+            "SM70 skinny NVFP4 self-check passed for N=%d K=%d (%d route(s)).",
+            n,
+            k,
+            len(cases),
+        )
+
+    def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
+        if layer.weight.dtype != torch.uint8 or layer.weight.dim() != 2:
+            raise TypeError("Skinny NVFP4 expects native uint8 [N, K/2] weights.")
+
+        n = layer.output_size_per_partition
+        k = layer.input_size_per_partition
+        if layer.weight.shape != (n, k // 2):
+            raise ValueError(
+                f"Skinny NVFP4 expected weight shape {(n, k // 2)}, "
+                f"got {tuple(layer.weight.shape)}."
+            )
+
+        # Keep aliases of the checkpoint-native tensors; no clone is needed.
+        # TurboMind prepare only reads them before replacing layer.weight.
+        layer.register_parameter(
+            "skinny_codes", Parameter(layer.weight.data, requires_grad=False)
+        )
+        layer.register_parameter(
+            "skinny_scales",
+            Parameter(
+                layer.weight_scale.data.view(torch.uint8).contiguous(),
+                requires_grad=False,
+            ),
+        )
+        layer.skinny_global_scale = float(
+            layer.weight_global_scale.data.float().max().item()
+        )
+
+        qcodes, qscales = qpn_prepack(layer.skinny_codes.data, layer.skinny_scales.data)
+        empty = layer.skinny_codes.data.new_empty(0)
+        layer.register_parameter(
+            "skinny_qpn_codes",
+            Parameter(qcodes if qcodes is not None else empty, requires_grad=False),
+        )
+        layer.register_parameter(
+            "skinny_qpn_scales",
+            Parameter(qscales if qscales is not None else empty, requires_grad=False),
+        )
+
+        sm70_tm.prepare_nvfp4_linear(layer)
+        weight_device = layer.weight.device
+        scale_device = layer.weight_scale.device
+        scale_dtype = layer.weight_scale.dtype
+        layer.weight = Parameter(
+            torch.empty(0, dtype=torch.uint8, device=weight_device),
+            requires_grad=False,
+        )
+        layer.weight_scale = Parameter(
+            torch.empty(0, dtype=scale_dtype, device=scale_device),
+            requires_grad=False,
+        )
+
+        self._validate_shape(layer)
+        logger.info_once(
+            "SM70 skinny NVFP4 dense backend enabled: SIMT M<=3, "
+            "QPN M=4..16, TurboMind fallback."
+        )
+
+    def apply_weights(
+        self,
+        layer: torch.nn.Module,
+        x: torch.Tensor,
+        bias: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        state = sm70_tm.get_prepared_linear_state(layer)
+        k = layer.input_size_per_partition
+        n = layer.output_size_per_partition
+        reshaped_x = x.reshape(-1, k).contiguous()
+        out = torch.ops.vllm.sm70_skinny_nvfp4_linear(
+            reshaped_x,
+            layer.skinny_codes,
+            layer.skinny_scales,
+            layer.skinny_qpn_codes,
+            layer.skinny_qpn_scales,
+            state.weight,
+            state.scales,
+            layer.skinny_global_scale,
+            n,
+            k,
+            state.group_size,
+            state.k_ld,
+            state.q_ld,
+        )
+        if bias is not None:
+            out = out + bias
+        return out.reshape(x.shape[:-1] + (n,))

--- a/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_w4a16_nvfp4.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_w4a16_nvfp4.py
@@ -7,6 +7,10 @@ from torch.nn.parameter import Parameter
 
 from vllm import envs
 from vllm.logger import init_logger
+from vllm.model_executor.kernels.linear.nvfp4 import NvFp4LinearLayerConfig
+from vllm.model_executor.kernels.linear.nvfp4.skinny import (
+    SkinnyNvFp4LinearKernel,
+)
 from vllm.model_executor.layers.quantization import sm70_turbomind as sm70_tm
 from vllm.model_executor.layers.quantization.compressed_tensors.schemes import (
     CompressedTensorsScheme,
@@ -93,12 +97,22 @@ class CompressedTensorsW4A16Fp4(CompressedTensorsScheme):
             1.0 / layer.weight_global_scale.max().to(torch.float32), requires_grad=False
         )
 
+        if sm70_tm.uses_skinny_nvfp4():
+            supported, reason = SkinnyNvFp4LinearKernel.is_supported()
+            if not supported:
+                raise RuntimeError(
+                    "VLLM_SM70_QUANT_BACKEND=skinny was requested, but the "
+                    f"backend is unavailable: {reason}."
+                )
+            self.skinny_kernel = SkinnyNvFp4LinearKernel(NvFp4LinearLayerConfig())
+            self.skinny_kernel.process_weights_after_loading(layer)
+            return
+
         if sm70_tm.should_prepare_turbomind(
             layer.weight, envs.VLLM_SM70_NVFP4_TURBOMIND
         ):
             logger.info_once(
-                "SM70 compressed-tensors NVFP4 TurboMind W4A16 dense path "
-                "enabled."
+                "SM70 compressed-tensors NVFP4 TurboMind W4A16 dense path enabled."
             )
             sm70_tm.prepare_nvfp4_linear(layer)
             layer.weight = Parameter(
@@ -121,6 +135,8 @@ class CompressedTensorsW4A16Fp4(CompressedTensorsScheme):
         x: torch.Tensor,
         bias: torch.Tensor | None = None,
     ) -> torch.Tensor:
+        if hasattr(self, "skinny_kernel"):
+            return self.skinny_kernel.apply_weights(layer, x, bias)
         if sm70_tm.has_prepared_linear(layer):
             return sm70_tm.apply_prepared_linear(layer, x, bias)
         return apply_fp4_marlin_linear(

--- a/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_w4a4_nvfp4.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_w4a4_nvfp4.py
@@ -25,10 +25,7 @@ __all__ = ["CompressedTensorsW4A4Fp4"]
 
 
 def _explicit_nvfp4_emulation_requested() -> bool:
-    if (
-        envs.VLLM_USE_NVFP4_CT_EMULATIONS
-        or envs.VLLM_NVFP4_GEMM_BACKEND == "emulation"
-    ):
+    if envs.VLLM_USE_NVFP4_CT_EMULATIONS or envs.VLLM_NVFP4_GEMM_BACKEND == "emulation":
         return True
 
     from vllm.config import get_current_vllm_config_or_none
@@ -147,6 +144,14 @@ class CompressedTensorsW4A4Fp4(CompressedTensorsScheme):
             layer.input_global_scale * layer.weight_global_scale, requires_grad=False
         )
 
+        # Volta cannot execute the checkpoint's W4A4 path natively. The
+        # opt-in skinny backend consumes the same weights as W4A16, just like
+        # the existing TurboMind SM70 fallback, but preserves the native bytes
+        # for its small-M streaming kernels.
+        if sm70_tm.uses_skinny_nvfp4():
+            self._fallback_kernel().process_weights_after_loading(layer)
+            return
+
         if sm70_tm.should_prepare_turbomind(
             layer.weight, envs.VLLM_SM70_NVFP4_TURBOMIND
         ):
@@ -180,6 +185,8 @@ class CompressedTensorsW4A4Fp4(CompressedTensorsScheme):
         x: torch.Tensor,
         bias: torch.Tensor | None = None,
     ) -> torch.Tensor:
+        if hasattr(layer, "skinny_codes"):
+            return self._fallback_kernel().apply_weights(layer=layer, x=x, bias=bias)
         if sm70_tm.has_prepared_linear(layer):
             return sm70_tm.apply_prepared_linear(layer, x, bias)
         return self._fallback_kernel().apply_weights(layer=layer, x=x, bias=bias)

--- a/vllm/model_executor/layers/quantization/modelopt.py
+++ b/vllm/model_executor/layers/quantization/modelopt.py
@@ -8,6 +8,7 @@ import torch
 from torch.nn.parameter import Parameter
 
 import vllm.model_executor.layers.fused_moe.modular_kernel as mk
+from vllm import envs
 from vllm.config import get_current_vllm_config
 from vllm.logger import init_logger
 from vllm.model_executor.kernels.linear import (
@@ -1050,7 +1051,10 @@ class ModelOptNvFp4Config(ModelOptQuantConfigBase):
 
     @classmethod
     def get_min_capability(cls) -> int:
-        return 75
+        # The opt-in skinny backend consumes ModelOpt NVFP4 as W4A16 and has
+        # an exact-SM70 implementation. Other ModelOpt NVFP4 backends retain
+        # their upstream minimum.
+        return 70 if envs.use_sm70_skinny_nvfp4() else 75
 
     @classmethod
     def override_quantization_method(
@@ -1261,12 +1265,14 @@ class ModelOptNvFp4W4A16LinearMethod(LinearMethodBase):
         # backend == "marlin"; we don't set that since we pin the kernel
         # below, but we keep the attribute for shape parity.
         self.marlin_input_dtype = None
-        # Direct-instantiate the Marlin NVFP4 adapter rather than going through
-        # init_nvfp4_linear_kernel(): the latter's priority list returns a
-        # cutlass W4A4 kernel as first-pick on this hardware, which would
-        # silently try to quantize activations (we have no input_scale). For
-        # W4A16 there is exactly one valid kernel, so we pin it.
-        self.kernel = MarlinNvFp4LinearKernel(NvFp4LinearLayerConfig())
+        # W4A16 normally pins Marlin so the generic NVFP4 selector cannot pick
+        # an activation-quantizing W4A4 kernel. The explicit SM70 skinny mode
+        # is also weight-only and keeps TurboMind as its fallback, so it is the
+        # one safe exception.
+        if envs.use_sm70_skinny_nvfp4():
+            self.kernel = init_nvfp4_linear_kernel()
+        else:
+            self.kernel = MarlinNvFp4LinearKernel(NvFp4LinearLayerConfig())
 
     def create_weights(
         self,

--- a/vllm/model_executor/layers/quantization/sm70_turbomind.py
+++ b/vllm/model_executor/layers/quantization/sm70_turbomind.py
@@ -15,7 +15,7 @@ COMPRESSED_UINT4_GROUP_SIZES = (32, 128)
 MXFP4_GROUP_SIZE = 32
 NVFP4_GROUP_SIZE = 16
 STATE_ATTR = "_sm70_turbomind_linear"
-SM70QuantBackend = Literal["auto", "marlin", "turbomind"]
+SM70QuantBackend = Literal["auto", "marlin", "turbomind", "skinny"]
 
 
 @dataclass
@@ -39,6 +39,10 @@ def use_turbomind(default_enabled: bool) -> bool:
 
 def forces_marlin() -> bool:
     return envs.force_sm70_marlin()
+
+
+def uses_skinny_nvfp4() -> bool:
+    return envs.use_sm70_skinny_nvfp4()
 
 
 def is_exact_sm70_cuda(tensor: torch.Tensor, enabled: bool) -> bool:
@@ -153,6 +157,13 @@ def _store_state(
 
 def has_prepared_linear(layer: torch.nn.Module) -> bool:
     return getattr(layer, STATE_ATTR, None) is not None
+
+
+def get_prepared_linear_state(layer: torch.nn.Module) -> SM70TurboMindLinearState:
+    state = getattr(layer, STATE_ATTR, None)
+    if state is None:
+        raise RuntimeError("SM70 TurboMind linear state has not been prepared.")
+    return state
 
 
 def prepare_gptq_linear(


### PR DESCRIPTION
## Summary

Add an opt-in, model-agnostic SM70/V100 small-M backend for dense group-16
NVFP4 linear layers.

- compile the MIT-licensed `v100-skinny` SIMT and QPN production kernels into
  the existing SM70 `_C` extension;
- route FP16 `M <= 3` to SIMT, `M = 4..16` to QPN, and all larger or unsupported
  shapes to the existing TurboMind backend;
- make BF16 behavior explicit by converting to FP16 at the adapter boundary
  and restoring the public output dtype;
- prepack one fragment-order QPN copy at load time while retaining native
  codes/scales and a TurboMind fallback;
- integrate compressed-tensors W4A16/W4A4 and ModelOpt W4A16/W4A4 through the
  generic NVFP4 linear selector;
- compare each unique `(N, K)` shape against TurboMind at load time and disable
  skinny routes for the worker if validation fails;
- document the dispatch, memory profile, provenance, and dense-only scope.

Enable with `VLLM_SM70_QUANT_BACKEND=skinny`. The default behavior is unchanged.

## Why

V100 has no native FP4 tensor-core path, but dense decode and low-row-count
verification are dominated by streaming quantized weights. The added kernels
consume checkpoint-native NVFP4 in a fused load/decode/MAC dataflow and use an
offline fragment-order layout for QPN. Selection depends on the NVFP4 layout and
GEMM shape, not a model class, so the same backend can serve compatible dense
Qwen and other architectures.

This is intentionally a dense backend. Fused MoE experts remain on their
existing backend; applying QPN to a large expert bank needs a separate bounded
or lazy prepack cache.

## Relationship to #166

This is not a duplicate of #166. That PR covers ModelOpt SM70 admission,
TurboMind/dequant policy, scale conventions, MoE fallback, and operational
runbooks. This PR adds the actual small-M SIMT/QPN CUDA operators, QPN prepack,
generic selector overlay, and runtime correctness fallback. The adapter
touchpoints may need a small rebase if #166 lands first, but the kernel and
dispatch layer are independent.

## Validation

- staged repository `pre-commit`: all hooks passed, including Ruff,
  clang-format, mypy, Markdown lint, SPDX, and custom checks;
- targeted CPU tests: `10 passed, 6 deselected`;
- exact-SM70 AOT build: the final formatted CUDA source compiled and `_C.abi3.so`
  linked successfully;
- V100 route/correctness test: FP16 and BF16 SIMT/QPN/TurboMind routes all
  matched the expected frontier, produced finite outputs, and stayed below the
  `3e-2` relative-error gate versus TurboMind;
- TP4 mixed-MoE checkpoint gate: all real dense shapes passed load-time
  self-check while MoE remained on Marlin;
- eager and production CUDA-graph HTTP gates both returned 200, arithmetic
  returned `42`, and repeated decode outputs were identical.

The service run was an integration gate, not a performance claim. No production
default, model alias, or MoE backend is changed by this PR.

## Provenance

The CUDA subset is adapted from `Leonccaa/v100-skinny` at commit
`f8194f7c3c9269fa74ee70b5029d53c20098f4c8`. Its MIT license is included beside
the source.

## AI assistance

AI assistance was used to research, implement, and validate this change. Leon
must review every changed line and understand and defend the implementation
before this draft is marked ready for review.
