### PR TITLE
[Kernel][SM70] MLA prefill: selectable Flash-V100 route for uniform 256/256 head dims

### DIFF
--- a/vllm/v1/attention/backends/flash_attn_v100.py
+++ b/vllm/v1/attention/backends/flash_attn_v100.py
@@ -854,6 +854,195 @@ def flash_v100_dense_prefill(
     return output
 
 
+# 0014: LSE-emitting dense varlen prefill (revives archived 0043 + discharges 0044)
+# ----------------------------------------------------------------------------
+# The SM70 kernel ALWAYS computes the softmax log-sum-exp
+# (flash-attention-v100/kernel/fused_mha_forward.cu:688-692 writes rowmax+log(rowsum),
+# :1149 returns it as outputs[1]). What flash_v100_dense_prefill drops is that LSE,
+# which the MLA context-chunk / prefix-cache merge needs (mla_attention.py:2109-2136,
+# :2305-2312). This op exposes it and additionally accepts an INDEPENDENT cu_seqlens_k,
+# so the cross-attention shape of run_prefill_context_chunk (M new-token queries vs N
+# gathered context keys, M != N, unmasked) is expressible.
+_flash_attn_forward_lse = None
+_flash_attn_forward_lse_checked = False
+
+
+def _get_flash_dense_forward():
+    """Lazy-load the private LSE-capable forward entry of the FA-V100 wheel."""
+    global _flash_attn_forward_lse, _flash_attn_forward_lse_checked
+    if not _flash_attn_forward_lse_checked:
+        _flash_attn_forward_lse_checked = True
+        try:
+            from flash_attn_v100.flash_attn_interface import _flash_attn_forward
+
+            _flash_attn_forward_lse = _flash_attn_forward
+        except (ImportError, AttributeError):
+            _flash_attn_forward_lse = None
+    return _flash_attn_forward_lse
+
+
+def flash_v100_dense_prefill_lse_available() -> bool:
+    return _get_flash_dense_forward() is not None
+
+
+def flash_v100_dense_prefill_lse(
+    query: torch.Tensor,
+    key: torch.Tensor,
+    value: torch.Tensor,
+    output: torch.Tensor,
+    softmax_lse: torch.Tensor,
+    cu_seqlens_q: torch.Tensor,
+    cu_seqlens_k: torch.Tensor,
+    num_actual_tokens: int,
+    softmax_scale: float,
+    causal: bool = False,
+    window_size: tuple[int, int] = (-1, -1),
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Flash-V100 dense varlen prefill that also emits the softmax LSE.
+
+    Layouts:
+      query  [T_q, H, D] fp16      output      [T_q, H, D] fp16 (written)
+      key    [T_k, H_kv, D] fp16   softmax_lse [H, T_q] fp32   (written)
+      value  [T_k, H_kv, D] fp16
+    softmax_lse uses FA2's varlen convention [num_heads, total_q] — exactly what
+    merge_attn_states reads (merge_attn_states.py:32-37).
+
+    ===== 0044 DISCHARGE — OPTION (a), applied AT THE BACKEND =====
+    A query row whose key run is EMPTY for this chunk (a sequence contributing no
+    tokens to a later context chunk, or a request with context_len==0 in a batch
+    where others carry context) has no attention result. This op WRITES EVERY
+    query row of output[:num_actual_tokens] — either the kernel result (k_len>0)
+    or an explicit ZERO (k_len==0) — and sets softmax_lse=-inf for the empty rows.
+    No uninitialised/scratch value ever reaches merge_attn_states, so all three
+    corners the merge kernel leaves open are closed AT THE SOURCE:
+      * fall-through (prefix finite, suffix empty): suffix row is 0, not scratch,
+        so merge_attn_states.cu:162 computes p_out*1 + 0*0 = p_out (no NaN*0=NaN);
+      * both-empty guard (:109-131 stores prefix verbatim "expected all zeros"):
+        the prefix WAS zeroed here, so the assumption holds;
+      * symmetric / chunk-0 direct-assign (mla_attention.py:2118-2120) and
+        num_chunks==1: the accumulator row is 0/-inf, not scratch.
+    -inf (not -1e30) is used so the sentinel matches the FA2 varlen contract the
+    merge guard was written against (its isinf checks at merge_attn_states.cu:96-109
+    fire BEFORE any -inf subtraction, and the causal new-tokens LSE it is finally
+    merged against is always finite). Because the empty ROWS are zeroed regardless,
+    the sentinel value cannot reintroduce a NaN on our path — verified on real SM70
+    (patches/0014/poc/mla_merge_corner_gate.py: unmasked leaves NaN in 2/3 requests
+    through the real merge CUDA op; this option-(a) path reconstructs the true
+    attention at rel_rms 2.4e-4 vs the f32 oracle; a negative control that keeps the
+    zeros but drops the -inf sentinel deviates 0.41 and is correctly rejected).
+
+    causal=True is only valid when every sequence has q_len == k_len (self-attn):
+    the SM70 kernel's causal masking for M != N has no validated alignment
+    convention here, so the mismatch is rejected loudly rather than mis-masked.
+    """
+    fwd = _get_flash_dense_forward()
+    if fwd is None:
+        raise RuntimeError("flash_attn_v100 dense LSE prefill op is unavailable")
+
+    query = query[:num_actual_tokens]
+    out_view = output[:num_actual_tokens]
+    lse_view = softmax_lse[:, :num_actual_tokens]
+
+    num_seqs = len(cu_seqlens_q) - 1
+    if num_seqs == 0:
+        return output, softmax_lse
+    if len(cu_seqlens_k) - 1 != num_seqs:
+        raise RuntimeError(
+            "cu_seqlens_q and cu_seqlens_k must describe the same batch: "
+            f"{num_seqs} vs {len(cu_seqlens_k) - 1}"
+        )
+
+    # One host sync for the whole call (0020 synced per sequence inside the loop;
+    # on the 128-user axis that host cost is paid per layer per step).
+    q_off = cu_seqlens_q.tolist()
+    k_off = cu_seqlens_k.tolist()
+
+    window_size_left, window_size_right = window_size
+    num_q_heads, head_dim = query.shape[1], query.shape[2]
+    num_kv_heads = key.shape[1]
+
+    run_start = 0
+    while run_start < num_seqs:
+        q_len = q_off[run_start + 1] - q_off[run_start]
+        k_len = k_off[run_start + 1] - k_off[run_start]
+        # Batch the maximal run sharing BOTH lengths — the kernel takes a
+        # rectangular [B,H,M,D] x [B,H,N,D] batch.
+        run_end = run_start + 1
+        while (
+            run_end < num_seqs
+            and q_off[run_end + 1] - q_off[run_end] == q_len
+            and k_off[run_end + 1] - k_off[run_end] == k_len
+        ):
+            run_end += 1
+
+        if q_len > 0:
+            qt0, qt1 = q_off[run_start], q_off[run_end]
+            batch_size = run_end - run_start
+
+            if k_len == 0:
+                # 0044 option (a): empty key run -> zero output, -inf LSE, so
+                # merge_attn_states ignores this chunk with no scratch.
+                out_view[qt0:qt1].zero_()
+                lse_view[:, qt0:qt1].fill_(float("-inf"))
+            else:
+                if causal and q_len != k_len:
+                    raise RuntimeError(
+                        "flash_v100_dense_prefill_lse: causal=True requires "
+                        f"q_len == k_len (got {q_len} vs {k_len})"
+                    )
+                kt0, kt1 = k_off[run_start], k_off[run_end]
+
+                # [T,H,D] -> [B,M,H,D] -> [B,H,M,D]: the SM70 fwd reads (B,H,M,D)
+                # (fused_mha_forward.cu:1113) and needs the last dim contiguous.
+                q_batch = (
+                    query[qt0:qt1]
+                    .view(batch_size, q_len, num_q_heads, head_dim)
+                    .permute(0, 2, 1, 3)
+                    .contiguous()
+                )
+                k_batch = (
+                    key[kt0:kt1]
+                    .view(batch_size, k_len, num_kv_heads, head_dim)
+                    .permute(0, 2, 1, 3)
+                    .contiguous()
+                )
+                v_batch = (
+                    value[kt0:kt1]
+                    .view(batch_size, k_len, num_kv_heads, head_dim)
+                    .permute(0, 2, 1, 3)
+                    .contiguous()
+                )
+
+                out_batch, lse_batch, _, _ = fwd(
+                    q_batch,
+                    k_batch,
+                    v_batch,
+                    None,
+                    0.0,
+                    softmax_scale,
+                    causal,
+                    window_size_left,
+                    window_size_right,
+                    0.0,
+                    None,
+                    False,  # NOT the P-matrix flag (kernel refuses it); LSE comes
+                    # back as outputs[1] regardless.
+                )
+
+                # [B,H,M,D] -> [B,M,H,D] -> packed [B*M,H,D].
+                out_view[qt0:qt1].copy_(
+                    out_batch.permute(0, 2, 1, 3).reshape(-1, num_q_heads, head_dim)
+                )
+                # [B,H,M] -> [H,B*M], matching FA2's [num_heads, total_q].
+                lse_view[:, qt0:qt1].copy_(
+                    lse_batch.permute(1, 0, 2).reshape(num_q_heads, -1)
+                )
+
+        run_start = run_end
+
+    return output, softmax_lse
+
+
 def _get_flash_turboquant_decode_op():
     """Lazy-load the optional TurboQuant decode op without touching base ops."""
     global _flash_attn_turboquant_decode_checked

--- a/vllm/v1/attention/backends/mla/prefill/flash_attn.py
+++ b/vllm/v1/attention/backends/mla/prefill/flash_attn.py
@@ -24,6 +24,54 @@ else:
     flash_attn_varlen_func = None  # type: ignore[assignment]
 
 
+@functools.cache
+def _flash_v100_dense_prefill_usable() -> bool:
+    """0014: True iff this device is SM70 with the in-tree Flash-V100 dense
+    prefill op available. On SM70 the vendored FA2 called below can never run
+    (fa_utils stub raises ImportError on first prefill), so this predicate gates
+    an automatic route to the in-tree op. Exact (7,0) match: the flash_attn_v100
+    kernel TORCH_CHECKs sm70 itself. Cached: device + op availability are
+    process-invariant."""
+    if not current_platform.is_cuda():
+        return False
+    capability = current_platform.get_device_capability()
+    if capability is None or capability[0] != 7 or capability[1] != 0:
+        return False
+    try:
+        from vllm.v1.attention.backends.flash_attn_v100 import (
+            flash_v100_dense_prefill_available,
+        )
+    except ImportError:
+        return False
+    return flash_v100_dense_prefill_available()
+
+
+@functools.cache
+def _flash_v100_dense_prefill_lse_usable() -> bool:
+    """0014: True iff the in-tree Flash-V100 dense op can also emit the LSE.
+    Same SM70 gate as above plus availability of the LSE-capable forward entry.
+    Separate predicate so an older wheel degrades to no-LSE coverage instead of
+    failing the whole route."""
+    if not _flash_v100_dense_prefill_usable():
+        return False
+    try:
+        from vllm.v1.attention.backends.flash_attn_v100 import (
+            flash_v100_dense_prefill_lse_available,
+        )
+    except ImportError:
+        return False
+    return flash_v100_dense_prefill_lse_available()
+
+
+# 0014: head-dim tiles the in-tree Flash-V100 dense prefill kernel instantiates
+# (flash-attention-v100/kernel/fused_mha_forward.cu:1136-1142 `switch (D)`; anything
+# else hits `default: TORCH_CHECK(false, "Unsupported D")`). A uniform MLA head dim
+# outside this set would crash the kernel at runtime, so the SM70 route must not be
+# offered for it. Kept beside the gate that reads it; update in lockstep with the
+# kernel switch (adding `case 192:` for the DeepSeek slice would add 192 here too).
+_SM70_DENSE_PREFILL_HEAD_DIMS = frozenset({16, 32, 64, 128, 256})
+
+
 class FlashAttnPrefillBackend(MLAPrefillBackend):
     """FlashAttention backend for MLA prefill."""
 
@@ -33,7 +81,55 @@ class FlashAttnPrefillBackend(MLAPrefillBackend):
 
     @classmethod
     def is_available(cls) -> bool:
-        return is_flash_attn_varlen_func_available()
+        # SM80+ builds: the vendored FA2/FA3 varlen extension.
+        # SM70/V100 builds are compiled WITHOUT that extension (0013 makes
+        # is_flash_attn_varlen_func_available() honestly False there); on SM70 this
+        # backend serves MLA prefill through the in-tree Flash-V100 dense op instead
+        # (0014, routed in _flash_attn_varlen_diff_headdims). Either presence means a
+        # working MLA-prefill implementation exists. The SM70 route's shape/dtype
+        # constraints are per-config, not device-global, so they are enforced in
+        # validate_configuration (which sees the model's head dims and dtype), not
+        # here.
+        return (
+            is_flash_attn_varlen_func_available()
+            or _flash_v100_dense_prefill_lse_usable()
+        )
+
+    @classmethod
+    def validate_configuration(cls, device_capability, selector_config) -> list[str]:
+        invalid_reasons = super().validate_configuration(
+            device_capability, selector_config
+        )
+        # 0014: when the ONLY available implementation is the SM70 in-tree dense
+        # route (FA2 varlen absent, Flash-V100 dense op present), that route computes
+        # only the uniform-head-dim, fp16 slice. Reject anything it cannot run here,
+        # AT SELECTION TIME, so a config the route would fall through on gets a clean
+        # load-time error (0013's guarantee) instead of loading and then crashing at
+        # the first prefill in the raising FA2 stub. On SM80+ this block is inert
+        # (is_flash_attn_varlen_func_available() is True).
+        if (
+            not is_flash_attn_varlen_func_available()
+            and _flash_v100_dense_prefill_lse_usable()
+        ):
+            if selector_config.dtype != torch.float16:
+                invalid_reasons.append(
+                    "SM70 Flash-V100 MLA prefill route requires float16 "
+                    f"(got {selector_config.dtype})"
+                )
+            if selector_config.qk_head_dim != selector_config.v_head_dim:
+                invalid_reasons.append(
+                    "SM70 Flash-V100 MLA prefill route requires uniform qk/v head "
+                    f"dims (got qk={selector_config.qk_head_dim}, "
+                    f"v={selector_config.v_head_dim}); DeepSeek-style asymmetric "
+                    "MLA (qk=192/v=128) is 0014's deferred slice"
+                )
+            elif selector_config.qk_head_dim not in _SM70_DENSE_PREFILL_HEAD_DIMS:
+                invalid_reasons.append(
+                    "SM70 Flash-V100 MLA prefill route has no compiled kernel tile "
+                    f"for head dim {selector_config.qk_head_dim} "
+                    f"(compiled: {sorted(_SM70_DENSE_PREFILL_HEAD_DIMS)})"
+                )
+        return invalid_reasons
 
     def __init__(
         self,
@@ -57,10 +153,26 @@ class FlashAttnPrefillBackend(MLAPrefillBackend):
 
         # Handle the differences between the flash_attn_varlen from
         # flash_attn and the one from vllm_flash_attn
-        assert flash_attn_varlen_func is not None, (
-            "FlashAttnPrefillBackend requires flash_attn_varlen_func. "
-            "Ensure FlashAttnPrefillBackend.is_available() is checked first."
-        )
+        if flash_attn_varlen_func is None:
+            # 0014: SM70/V100 build without the FA2 varlen extension. This backend
+            # serves MLA prefill through the in-tree Flash-V100 dense op instead
+            # (routed at the top of _flash_attn_varlen_diff_headdims), so no FA2
+            # setup is needed. validate_configuration has already guaranteed the
+            # SM70 route is present and shape/dtype-valid for this model; a genuinely
+            # absent op still fails loudly here rather than silently mis-routing.
+            assert _flash_v100_dense_prefill_lse_usable(), (
+                "FlashAttnPrefillBackend requires either flash_attn_varlen_func or "
+                "the SM70 Flash-V100 dense prefill op. Ensure "
+                "FlashAttnPrefillBackend.is_available() is checked first."
+            )
+            self.flash_attn_varlen_func = None
+            self.vllm_flash_attn_version = None
+            # Uniform head dims on this route (validate_configuration enforced qk==v),
+            # so V never needs padding — and the route intercepts before the pad path.
+            self.requires_v_padding = False
+            self._is_vllm_fa = current_platform.is_cuda()
+            return
+
         qk_head_dim = qk_nope_head_dim + qk_rope_head_dim
         self.flash_attn_varlen_func = flash_attn_varlen_func
         self.vllm_flash_attn_version = get_flash_attn_version(head_size=qk_head_dim)
@@ -96,6 +208,97 @@ class FlashAttnPrefillBackend(MLAPrefillBackend):
         softmax_scale: float | None = None,
         **kwargs,
     ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
+        # ------------------------------------------------------------------
+        # 0014: V100 (SM70) MLA prefill route (revives archived 0020 + 0043).
+        # On SM70 the vendored FA2 call below is a guaranteed ImportError
+        # (fa_utils stub), so when the in-tree Flash-V100 dense op can faithfully
+        # compute this exact call we route to it. Guard sets are EXACT — any call
+        # outside them falls through to the FA2 call, which FAILS LOUDLY on SM70
+        # rather than silently computing wrong values.
+        #
+        # This slice covers the UNIFORM head-dim case (GLM-MoE-Lite MLA: qk==v,
+        # e.g. 256==256). DeepSeek-style diff head dims (qk 192 / v 128) still
+        # fall through and crash on SM70 — that case additionally needs the
+        # FA_V100 `case 192:` build + a pad-V driver and is 0014's deferred slice.
+        cu_q = kwargs.get("cu_seqlens_q")
+        cu_k = kwargs.get("cu_seqlens_k")
+        causal = bool(kwargs.get("causal", False))
+
+        # (0043) LSE-emitting route — the context-chunk / prefix-cache path that
+        # needs the softmax LSE and an INDEPENDENT cu_seqlens_k. Guard: LSE-capable
+        # wheel, fp16, uniform head dims, both cu_seqlens present and same batch,
+        # and causal only with cu_k IS cu_q (masking for M!=N is unvalidated here).
+        if (
+            _flash_v100_dense_prefill_lse_usable()
+            and q.dtype == torch.float16
+            and k.dtype == torch.float16
+            and v.dtype == torch.float16
+            and q.shape[-1] == v.shape[-1]
+            and cu_q is not None
+            and cu_k is not None
+            and cu_q.numel() == cu_k.numel()
+            and (cu_k is cu_q or not causal)
+        ):
+            from vllm.v1.attention.backends.flash_attn_v100 import (
+                flash_v100_dense_prefill_lse,
+            )
+
+            q_c = q.contiguous()
+            out = torch.empty_like(q_c)
+            lse = torch.empty(
+                (q_c.shape[1], q_c.shape[0]),
+                dtype=torch.float32,
+                device=q_c.device,
+            )
+            flash_v100_dense_prefill_lse(
+                q_c,
+                k.contiguous(),
+                v.contiguous(),
+                out,
+                lse,
+                cu_q,
+                cu_k,
+                q_c.shape[0],
+                float(softmax_scale)
+                if softmax_scale is not None
+                else q.shape[-1] ** -0.5,
+                causal=causal,
+            )
+            if return_softmax_lse:
+                return out, lse
+            return out
+
+        # (0020) no-LSE route — the new-tokens self-attention path on wheels that
+        # predate the LSE entry. Requires cu_k IS cu_q and no LSE requested.
+        if (
+            _flash_v100_dense_prefill_usable()
+            and not return_softmax_lse
+            and q.dtype == torch.float16
+            and q.shape[-1] == v.shape[-1]
+            and cu_q is not None
+            and cu_k is cu_q
+        ):
+            from vllm.v1.attention.backends.flash_attn_v100 import (
+                flash_v100_dense_prefill,
+            )
+
+            q_c = q.contiguous()
+            out = torch.empty_like(q_c)
+            flash_v100_dense_prefill(
+                q_c,
+                k.contiguous(),
+                v.contiguous(),
+                out,
+                cu_q,
+                q_c.shape[0],
+                float(softmax_scale)
+                if softmax_scale is not None
+                else q.shape[-1] ** -0.5,
+                causal=causal,
+            )
+            return out
+        # --- end 0014 route -----------------------------------------------
+
         maybe_padded_v = v
         if self.requires_v_padding:
             maybe_padded_v = torch.nn.functional.pad(

--- a/vllm/v1/attention/backends/mla/prefill/selector.py
+++ b/vllm/v1/attention/backends/mla/prefill/selector.py
@@ -32,6 +32,31 @@ class MLAPrefillSelectorConfig(NamedTuple):
 
     dtype: torch.dtype
     is_r1_compatible: bool
+    # 0014: MLA head dims, so a backend can reject a shape it cannot serve AT
+    # SELECTION time (the SM70 Flash-V100 dense route only runs uniform qk==v).
+    # Defaulted so non-MLA / older construction sites stay valid; the real MLA
+    # selection site below populates them. Both ints, so the NamedTuple stays
+    # hashable for the @cache on _auto_select_mla_prefill_backend.
+    qk_head_dim: int = 0
+    v_head_dim: int = 0
+
+
+def _mla_head_dims(vllm_config: "VllmConfig") -> tuple[int, int]:
+    """Return (qk_head_dim, v_head_dim) for MLA backend selection.
+
+    qk_head_dim = qk_nope_head_dim + qk_rope_head_dim, matching
+    deepseek_v2.py:428-431 and the query head dim the prefill kernel dispatches
+    on. Returns (0, 0) when the config exposes no MLA dims — the value is only
+    consulted by backends that gate on it (the SM70 route), for which 0 head dims
+    never satisfy the uniform-and-compiled-tile check.
+    """
+    if vllm_config.model_config is None:
+        return 0, 0
+    hf_text_config = vllm_config.model_config.hf_text_config
+    qk_nope_head_dim = getattr(hf_text_config, "qk_nope_head_dim", 0)
+    qk_rope_head_dim = getattr(hf_text_config, "qk_rope_head_dim", 0)
+    v_head_dim = getattr(hf_text_config, "v_head_dim", 0)
+    return qk_nope_head_dim + qk_rope_head_dim, v_head_dim
 
 
 def is_deepseek_r1_mla_compatible(vllm_config: "VllmConfig") -> bool:
@@ -101,9 +126,12 @@ def get_mla_prefill_backend(
 
     attention_config = vllm_config.attention_config
 
+    qk_head_dim, v_head_dim = _mla_head_dims(vllm_config)
     selector_config = MLAPrefillSelectorConfig(
         dtype=vllm_config.model_config.dtype,
         is_r1_compatible=is_deepseek_r1_mla_compatible(vllm_config),
+        qk_head_dim=qk_head_dim,
+        v_head_dim=v_head_dim,
     )
 
     if attention_config.mla_prefill_backend is not None:


### PR DESCRIPTION


## Purpose

Make FlashAttention MLA prefill **selectable on SM 7.0** so models with uniform 256/256 head dims (e.g. GLM-MoE-Lite) can pick FLASH_ATTN prefill instead of failing at engine init with:

```
No valid MLA prefill backend found ... {FLASH_ATTN: [required dependencies not available]}
```

Before this PR, the FlashAttention MLA prefill selector gates itself off on Volta, and there is no fallback that can serve MLA prefill there. This PR wires the SM70 route (via the in-tree Flash-V100 dense-LSE op) into the selector, and keeps non-selectable configs REJECTED at load time — so the clean-error guarantee for anything the SM70 route cannot serve is preserved.

Three edits close the selectability gap:

1. `is_available()` returns True on SM 7.0 when the in-tree Flash-V100 dense-LSE op is usable.
2. `validate_configuration()` override rejects any config the SM70 route cannot run: non-fp16 dtype, non-uniform head dims (e.g. DeepSeek 192/128 asymmetric qk/v), or a non-compiled head-dim tile.
3. `__init__` assert relaxed on the SM70 route.

Load-time rejection preserves clean-error behavior: a config the backend can't serve is refused up front, never selected-then-crashed.

Files: `vllm/v1/attention/backends/flash_attn_v100.py`, `vllm/v1/attention/backends/mla/prefill/flash_attn.py`, `vllm/v1/attention/backends/mla/prefill/selector.py`. 3 files, +425 / −5 lines.

**Deferred (not in this PR):** the DeepSeek 192/128 asymmetric slice is provably held out by the selector at load time. A follow-up PR covers that.

## Test Plan

Hardware: SM 7.0 (Tesla V100 SXM2 32GB), TP4.

1. **Op-level numerics** — three-arm merge-corner gate on the SM70 route:
   - Unmasked driver (negative control) — expect NaN poisoning
   - Fixed masked driver — expect attention reconstruction within fp16 noise
   - Random negative control — expect large error
2. **Engine selectability** — load a model with uniform 256/256 MLA head dims (e.g. `rt-base-w4g128`, GLM-MoE-Lite lineage) on SM70 TP4 and confirm the selector picks `FLASH_ATTN` MLA prefill without crashing.
3. **End-to-end coherence** — greedy answers on canonical prompts (capital of France, arithmetic, a short story) — verify correctness, not just non-crash.
4. **Regression suite** — a delivered A/B against the prior release version on the same served config, covering decode tok/s, prefill prompt tok/s, TPOT, and HumanEval mean.

## Test Result

**Op-level numerics (real SM70, three-arm merge-corner gate):**

| Arm | Result |
|---|---|
| Unmasked driver | NaN-frac 0.667 (2/3 requests poisoned) — REJECTED |
| Fixed masked driver | Attention reconstructed at `rel_rms 2.42e-4` vs fp32 oracle |
| Random negative control | rel_rms 0.41 — REJECTED |

**Live engine boot (rt-base-w4g128 on V100 TP4):**

```
selector.py:191 Using FLASH_ATTN MLA prefill backend
Using TRITON_MLA attention backend
```

Greedy answers on the loaded engine:
- "The capital of France is Paris… London" — correct
- "17 plus 26 equals 43" — correct
- Fluent short-story generation

Before this PR: engine init raised at the selector, no MLA prefill backend available on SM 7.0.

**Delivered A/B (against prior release version, same served config):**

| Metric | Delta | Interpretation |
|---|---|---|
| Decode tok/s | −1.8…+0.1% | inside spread |
| Prefill prompt tok/s | −1.0…+0.2% | inside spread |
| TPOT | +0.5…+1.1% | inside spread |
| HumanEval mean | inside own spread | no regression |

Flat is the predicted result: against the deployed served config (AWQ, fp8_e5m2 KV, no speculative decoding) this patch set barely touches the served hot path. The suite's job was to prove no regression, which it does. The AVAILABILITY win — MLA prefill from "unselectable / crashes" to "engine-selectable and correct" — is the value here.

---

<details>
<summary>Essential Elements of an Effective PR Description Checklist</summary>

- [x] The purpose of the PR
- [x] The test plan
- [x] The test results
- [ ] (Optional) Documentation update — happy to add supported-models note if reviewers want one
</details>