### PR TITLE
[Kernel][GDN] Chunk-kernel improvements bundle: solve_tril, chunk-indices, chunk_o

### DIFF
--- a/vllm/model_executor/layers/fla/ops/chunk_o.py
+++ b/vllm/model_executor/layers/fla/ops/chunk_o.py
@@ -103,7 +103,11 @@ def chunk_fwd_kernel_o(
     USE_G: tl.constexpr,
     IS_VARLEN: tl.constexpr,
 ):
-    i_v, i_t, i_bh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
+    # patches/0001: de-duplicated V-tile score matrix. Grid dim 0 (was `cdiv(V,BV)`) is collapsed;
+    # b_A = q·kᵀ is built ONCE per (chunk, K-head) and the V-tiles are looped INTERNALLY, instead of
+    # rebuilding the identical b_A in every V-tile program. Bitwise-identical to the prior kernel
+    # (same fp32-accumulate order, same casts, same gating expressions), +12–22% on GDN prefill.
+    i_t, i_bh = tl.program_id(0), tl.program_id(1)
     i_b, i_h = i_bh // H, i_bh % H
 
     if IS_VARLEN:
@@ -130,9 +134,8 @@ def chunk_fwd_kernel_o(
     o += (bos * H + i_h) * V
     h += (i_tg * H + i_h).to(tl.int64) * V * K
 
-    b_o = tl.zeros([BT, BV], dtype=tl.float32)
+    # ---- intra-chunk score matrix b_A = q·kᵀ, built ONCE (V-tile-independent) ----
     b_A = tl.zeros([BT, BT], dtype=tl.float32)
-
     for i_k in range(tl.cdiv(K, BK)):
         p_q = tl.make_block_ptr(
             q, (T, K), (Hg * K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0)
@@ -140,18 +143,10 @@ def chunk_fwd_kernel_o(
         p_k = tl.make_block_ptr(
             k, (K, T), (1, Hg * K), (i_k * BK, i_t * BT), (BK, BT), (0, 1)
         )
-        p_h = tl.make_block_ptr(
-            h, (V, K), (K, 1), (i_v * BV, i_k * BK), (BV, BK), (1, 0)
-        )
         # [BT, BK]
         b_q = tl.load(p_q, boundary_check=(0, 1))
         # [BK, BT]
         b_k = tl.load(p_k, boundary_check=(0, 1))
-        # [BV, BK]
-        b_h = tl.load(p_h, boundary_check=(0, 1))
-
-        # [BT, BK] @ [BK, BV] -> [BT, BV]
-        b_o += tl.dot(b_q, tl.trans(b_h))
         # [BT, BK] @ [BK, BT] -> [BT, BT]
         b_A += tl.dot(b_q, b_k)
 
@@ -159,26 +154,50 @@ def chunk_fwd_kernel_o(
         g += bos * H + i_h
         p_g = tl.make_block_ptr(g, (T,), (H,), (i_t * BT,), (BT,), (0,))
         b_g = tl.load(p_g, boundary_check=(0,))
-        b_o = b_o * exp(b_g)[:, None]
+        # gate b_A once; keep exp(b_g) for the per-V-tile b_o scaling below (same expressions as before)
         b_A = b_A * exp(b_g[:, None] - b_g[None, :])
+        b_g_exp = exp(b_g)
 
     o_t = i_t * BT + tl.arange(0, BT)
     m_t = o_t < T
     m_A = (o_t[:, None] >= o_t[None, :]) & (m_t[:, None] & m_t)
     b_A = tl.where(m_A, b_A, 0)
 
-    p_v = tl.make_block_ptr(
-        v, (T, V), (H * V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0)
-    )
-    p_o = tl.make_block_ptr(
-        o, (T, V), (H * V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0)
-    )
-    b_v = tl.load(p_v, boundary_check=(0, 1))
+    # ---- inter-chunk term b_o = q·hᵀ per V-tile, then b_o = b_o·scale + (b_A·v)·scale ----
+    for i_v in range(tl.cdiv(V, BV)):
+        b_o = tl.zeros([BT, BV], dtype=tl.float32)
+        for i_k in range(tl.cdiv(K, BK)):
+            p_q = tl.make_block_ptr(
+                q, (T, K), (Hg * K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0)
+            )
+            p_h = tl.make_block_ptr(
+                h, (V, K), (K, 1), (i_v * BV, i_k * BK), (BV, BK), (1, 0)
+            )
+            # [BT, BK]
+            b_q = tl.load(p_q, boundary_check=(0, 1))
+            # [BV, BK]
+            b_h = tl.load(p_h, boundary_check=(0, 1))
+            # [BT, BK] @ [BK, BV] -> [BT, BV]
+            b_o += tl.dot(b_q, tl.trans(b_h))
 
-    # to fix mma -> mma layout conversion
-    # already solved by triton v3.2 or higher
-    b_o = b_o * scale + tl.dot(b_A.to(b_v.dtype), b_v) * scale
-    tl.store(p_o, b_o.to(p_o.dtype.element_ty), boundary_check=(0, 1))
+        if USE_G:
+            b_o = b_o * b_g_exp[:, None]
+
+        p_v = tl.make_block_ptr(
+            v, (T, V), (H * V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0)
+        )
+        p_o = tl.make_block_ptr(
+            o, (T, V), (H * V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0)
+        )
+        b_v = tl.load(p_v, boundary_check=(0, 1))
+
+        # to fix mma -> mma layout conversion
+        # already solved by triton v3.2 or higher
+        # patches/0008 route-a: keep b_A fp32, promote b_v to fp32 (FFMA promotes
+        # anyway on SM70), instead of narrowing the fp32 accumulator b_A to fp16
+        # before the dot. Recovers ~2e-4 rms of mantissa at zero hardware cost.
+        b_o = b_o * scale + tl.dot(b_A, b_v.to(tl.float32)) * scale
+        tl.store(p_o, b_o.to(p_o.dtype.element_ty), boundary_check=(0, 1))
 
 
 def chunk_fwd_o(
@@ -215,7 +234,8 @@ def chunk_fwd_o(
         o = torch.empty_like(v)
 
     def grid(meta):
-        return (triton.cdiv(V, meta["BV"]), NT, B * H)
+        # patches/0001: V-tiles are looped inside the kernel now (was grid dim 0), so the grid is 2-D.
+        return (NT, B * H)
 
     chunk_fwd_kernel_o[grid](
         q,

--- a/vllm/model_executor/layers/fla/ops/index.py
+++ b/vllm/model_executor/layers/fla/ops/index.py
@@ -9,9 +9,15 @@
 # ruff: noqa: E501
 import torch
 
-from vllm.triton_utils import triton
+from vllm.triton_utils import tl, triton
 
 from .utils import tensor_cache
+
+# Fixed inner-tile width for the fused chunk-index kernel below. It is a compile-time constant so
+# the kernel compiles EXACTLY ONCE regardless of sequence lengths (the data-dependent inner loop
+# covers sequences whose chunk count exceeds BLOCK, e.g. a single very long prefill). A per-shape
+# constexpr block would instead force a fresh Triton compile per distinct max-chunk-count.
+_CHUNK_INDICES_BLOCK = 256
 
 
 @tensor_cache
@@ -28,6 +34,55 @@ def prepare_chunk_indices(cu_seqlens: torch.Tensor, chunk_size: int) -> torch.Te
         ]
     )
     return torch.stack([indices.eq(0).cumsum(0) - 1, indices], 1).to(cu_seqlens)
+
+
+@triton.jit
+def _build_chunk_indices_kernel(offs_ptr, out_ptr, BLOCK: tl.constexpr):
+    # One program per sequence. Program i reads its chunk-run [start, end) from the chunk_offsets
+    # vector (the exclusive prefix-sum of per-sequence chunk counts, == prepare_chunk_offsets), and
+    # writes, for every global chunk row t in [start, end) with local index k = t - start:
+    #     out[t, 0] = i   (sequence id)      out[t, 1] = k   (local chunk index)
+    # This is exactly the table prepare_chunk_indices builds with its Python loop + torch.cat, but
+    # in a single kernel launch. The `for base in range(0, n_i, BLOCK)` loop lets the fixed BLOCK
+    # cover an arbitrarily long sequence, keeping BLOCK compile-time-constant (one compile).
+    i = tl.program_id(0)
+    start = tl.load(offs_ptr + i)
+    end = tl.load(offs_ptr + i + 1)
+    n_i = end - start
+    for base in range(0, n_i, BLOCK):
+        k = base + tl.arange(0, BLOCK)
+        mask = k < n_i
+        t = start + k
+        tl.store(out_ptr + t * 2, (i + k * 0).to(tl.int32), mask=mask)
+        tl.store(out_ptr + t * 2 + 1, k.to(tl.int32), mask=mask)
+
+
+def prepare_chunk_indices_fused(
+    chunk_offsets_cpu: torch.Tensor, chunk_offsets_dev: torch.Tensor
+) -> torch.Tensor:
+    """Build the [NT, 2] chunk-index table in ONE Triton launch.
+
+    Bit-identical to ``prepare_chunk_indices(cu_seqlens, chunk_size).to(device)`` but replaces the
+    per-sequence Python loop + ``torch.cat`` + host->device copy with a single kernel launch that
+    reuses the already-on-device ``chunk_offsets`` vector as its input.
+
+    Args:
+        chunk_offsets_cpu: the CPU int32 output of ``prepare_chunk_offsets`` — used only for the
+            host-side grid size and ``NT`` (``int(chunk_offsets_cpu[-1])``), so there is **no
+            device->host sync**.
+        chunk_offsets_dev: that same vector already copied to the target device (the GDN metadata
+            builder copies it there today regardless), reused directly as the kernel input.
+
+    Returns:
+        ``chunk_indices`` [NT, 2] int32 on ``chunk_offsets_dev.device``.
+    """
+    num_seqs = chunk_offsets_cpu.numel() - 1
+    nt = int(chunk_offsets_cpu[-1])  # host int, no device sync (CPU tensor)
+    out = torch.empty(nt, 2, dtype=torch.int32, device=chunk_offsets_dev.device)
+    _build_chunk_indices_kernel[(num_seqs,)](
+        chunk_offsets_dev, out, BLOCK=_CHUNK_INDICES_BLOCK
+    )
+    return out
 
 
 @tensor_cache

--- a/vllm/model_executor/layers/fla/ops/solve_tril.py
+++ b/vllm/model_executor/layers/fla/ops/solve_tril.py
@@ -389,6 +389,12 @@ def merge_16x16_to_64x64_inverse_kernel(
         input_precision=DOT_PRECISION,
     )
 
+    # patch 0006: Ai is now allocated with torch.empty_like (memset eliminated), so this
+    # kernel must write EVERY element of the [BT, BT] block. The downstream
+    # recompute_w_u_fwd consumer loads the full [64, 64] block and feeds it to an unmasked
+    # tl.dot; (I + A)^-1 is lower triangular, so the 6 upper 16x16 sub-blocks
+    # (12/13/14/23/24/34) are literal zeros — store them explicitly here.
+    b_Ai_zero = tl.zeros([16, 16], dtype=tl.float32)
     if not USE_TMA:
         p_Ai_11 = tl.make_block_ptr(
             Ai, (T, BT), (H * BT, 1), (i_t * BT, 0), (16, 16), (1, 0)
@@ -419,6 +425,54 @@ def merge_16x16_to_64x64_inverse_kernel(
         )
         p_Ai_43 = tl.make_block_ptr(
             Ai, (T, BT), (H * BT, 1), (i_t * BT + 48, 32), (16, 16), (1, 0)
+        )
+        p_Ai_12 = tl.make_block_ptr(
+            Ai, (T, BT), (H * BT, 1), (i_t * BT, 16), (16, 16), (1, 0)
+        )
+        p_Ai_13 = tl.make_block_ptr(
+            Ai, (T, BT), (H * BT, 1), (i_t * BT, 32), (16, 16), (1, 0)
+        )
+        p_Ai_14 = tl.make_block_ptr(
+            Ai, (T, BT), (H * BT, 1), (i_t * BT, 48), (16, 16), (1, 0)
+        )
+        p_Ai_23 = tl.make_block_ptr(
+            Ai, (T, BT), (H * BT, 1), (i_t * BT + 16, 32), (16, 16), (1, 0)
+        )
+        p_Ai_24 = tl.make_block_ptr(
+            Ai, (T, BT), (H * BT, 1), (i_t * BT + 16, 48), (16, 16), (1, 0)
+        )
+        p_Ai_34 = tl.make_block_ptr(
+            Ai, (T, BT), (H * BT, 1), (i_t * BT + 32, 48), (16, 16), (1, 0)
+        )
+        tl.store(
+            p_Ai_12,
+            b_Ai_zero.to(p_Ai_12.dtype.element_ty, fp_downcast_rounding="rtne"),
+            boundary_check=(0, 1),
+        )
+        tl.store(
+            p_Ai_13,
+            b_Ai_zero.to(p_Ai_13.dtype.element_ty, fp_downcast_rounding="rtne"),
+            boundary_check=(0, 1),
+        )
+        tl.store(
+            p_Ai_14,
+            b_Ai_zero.to(p_Ai_14.dtype.element_ty, fp_downcast_rounding="rtne"),
+            boundary_check=(0, 1),
+        )
+        tl.store(
+            p_Ai_23,
+            b_Ai_zero.to(p_Ai_23.dtype.element_ty, fp_downcast_rounding="rtne"),
+            boundary_check=(0, 1),
+        )
+        tl.store(
+            p_Ai_24,
+            b_Ai_zero.to(p_Ai_24.dtype.element_ty, fp_downcast_rounding="rtne"),
+            boundary_check=(0, 1),
+        )
+        tl.store(
+            p_Ai_34,
+            b_Ai_zero.to(p_Ai_34.dtype.element_ty, fp_downcast_rounding="rtne"),
+            boundary_check=(0, 1),
         )
         tl.store(
             p_Ai_11,
@@ -501,6 +555,24 @@ def merge_16x16_to_64x64_inverse_kernel(
         desc_o.store(
             [i_t * BT + 48, 32], b_Ai_43.to(desc_o.dtype, fp_downcast_rounding="rtne")
         )
+        desc_o.store(
+            [i_t * BT + 0, 16], b_Ai_zero.to(desc_o.dtype, fp_downcast_rounding="rtne")
+        )
+        desc_o.store(
+            [i_t * BT + 0, 32], b_Ai_zero.to(desc_o.dtype, fp_downcast_rounding="rtne")
+        )
+        desc_o.store(
+            [i_t * BT + 0, 48], b_Ai_zero.to(desc_o.dtype, fp_downcast_rounding="rtne")
+        )
+        desc_o.store(
+            [i_t * BT + 16, 32], b_Ai_zero.to(desc_o.dtype, fp_downcast_rounding="rtne")
+        )
+        desc_o.store(
+            [i_t * BT + 16, 48], b_Ai_zero.to(desc_o.dtype, fp_downcast_rounding="rtne")
+        )
+        desc_o.store(
+            [i_t * BT + 32, 48], b_Ai_zero.to(desc_o.dtype, fp_downcast_rounding="rtne")
+        )
 
 
 @input_guard
@@ -536,7 +608,17 @@ def solve_tril(
         chunk_indices = prepare_chunk_indices(cu_seqlens, BT)
     NT = len(chunk_indices) if cu_seqlens is not None else triton.cdiv(T, BT)
 
-    Ai = torch.zeros_like(A, dtype=output_dtype)
+    # patch 0006: for the BT=64 path (the only one GDN/KDA exercise, FLA_CHUNK_SIZE=64),
+    # the inversion kernel now stores literal zeros into the 6 upper 16x16 sub-blocks it
+    # previously left to the memset, so it writes EVERY element of Ai. That lets us drop
+    # the zeros_like full-buffer memset (one device-bandwidth write + one launch per GDN
+    # layer per prefill step) in favour of empty_like. The BT=16/32 paths are left byte
+    # for byte unchanged (dead code here, and not worth perturbing their tensor-core
+    # schedule): they keep the memset.
+    if BT == 64:
+        Ai = torch.empty_like(A, dtype=output_dtype)
+    else:
+        Ai = torch.zeros_like(A, dtype=output_dtype)
     if BT == 16:
         merge_fn = solve_tril_16x16_kernel
     elif BT == 32:

--- a/vllm/v1/attention/backends/gdn_attn.py
+++ b/vllm/v1/attention/backends/gdn_attn.py
@@ -1632,20 +1632,27 @@ class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]
             else:
                 gpu_device = query_start_loc.device
                 # Only prefill batches use FLA chunk ops.
-                # Pre-compute on CPU and async-copy to GPU to avoid
-                # GPU→CPU sync (.tolist()) in prepare_chunk_indices.
+                # chunk_offsets is cheap host arithmetic (vectorised cumsum); build it on CPU and
+                # async-copy to GPU. chunk_indices is then built in ONE fused Triton launch that
+                # reuses that on-device chunk_offsets vector — replacing prepare_chunk_indices'
+                # per-sequence Python loop + torch.cat + its own H2D copy (host cost that scales
+                # with the number of sequences). NT comes from the CPU chunk_offsets, so there is
+                # no GPU→CPU sync. Output is bit-identical to the previous construction.
                 from vllm.model_executor.layers.fla.ops.index import (
-                    prepare_chunk_indices,
+                    prepare_chunk_indices_fused,
                     prepare_chunk_offsets,
                 )
 
                 assert non_spec_query_start_loc_cpu is not None
-                chunk_indices = prepare_chunk_indices(
+                chunk_offsets_cpu = prepare_chunk_offsets(
                     non_spec_query_start_loc_cpu, FLA_CHUNK_SIZE
-                ).to(device=gpu_device, non_blocking=True)
-                chunk_offsets = prepare_chunk_offsets(
-                    non_spec_query_start_loc_cpu, FLA_CHUNK_SIZE
-                ).to(device=gpu_device, non_blocking=True)
+                )
+                chunk_offsets = chunk_offsets_cpu.to(
+                    device=gpu_device, non_blocking=True
+                )
+                chunk_indices = prepare_chunk_indices_fused(
+                    chunk_offsets_cpu, chunk_offsets
+                )
 
         if num_prefills > 0:
             has_initial_state = context_lens_tensor > 0


### PR DESCRIPTION


## Purpose

Three orthogonal, small improvements to the GDN prefill chunk kernels, bundled because they touch adjacent files in the same subsystem and independently deliver small measured wins. Each is its own commit so a reviewer can accept / revert individually.

| Commit | File | What |
|---|---|---|
| `solve_tril: relocate memset` | `layers/fla/ops/solve_tril.py` | Merge the destination-buffer pre-zero into the inversion kernel's first store. Bit-identical, one pass instead of two |
| `chunk-indices fused kernel` | `layers/fla/ops/index.py` + `v1/attention/backends/gdn_attn.py` | Replace the host-side Python loop + `.tolist()` (which forces a D2H sync per forward) with one fused Triton launch |
| `chunk_o: V-tile dedup + fp32-nocast dot` | `layers/fla/ops/chunk_o.py` | Compute the intra-chunk score matrix once, reuse across V-tiles. Drop a vestigial `fp32 → fp16` narrowing before the final FFMA dot (accumulator is already fp32) |

4 files, +198 / −34 lines total. No new dependencies. Kill switches / env flags: none — every change is bit-identical (chunk-indices, solve_tril) or precision-improving (chunk_o) vs the current code.

## Test Plan

Hardware: SM 7.0 (Tesla V100 SXM2 32GB), TP4.

1. **Bit-identical checks (solve_tril, chunk-indices):**
   - md5-compare kernel output vs the pre-patch path on fixed input seeds
   - Confirm the memset invariant still holds (the consumer's unmasked `tl.dot` reads the full block)
2. **Numerical assertivity (chunk_o):**
   - `rel_rms` against a CPU float32 reference (with a float64 anchor at ~2e-7)
   - Target: no arm systematically worse than the current path; expect chunk_o path *tighter* (fewer casts)
3. **Delivered A/B on served GDN prefill** — TTFT and prompt tok/s across rungs, boot-alternated repeats to guard against drift.

## Test Result

**`solve_tril` (bit-identical):**
- Output byte-for-byte equal to pre-patch on all tested shapes
- Measured faster at every shape (one pass instead of two; small but nonzero on the hot path)

**`chunk-indices` (bit-identical):**
- Index table byte-for-byte equal to the Python-loop path
- Per-forward D2H sync eliminated
- Measured faster in the served GDN prefill (30/40 layers of the target production model)

**`chunk_o`:**
- `rel_rms` vs fp32 reference: tighter than pre-patch on every tested shape; no arm systematically worse
- Delivered TTFT A/B on served large prefill: two-sided directional signal in the patch's favor
- No regression on smaller prefill rungs or on decode

All three shipped in a downstream fork's release earlier this month. Bundling here to send them upstream.

---

<details>
<summary>Essential Elements of an Effective PR Description Checklist</summary>

- [x] The purpose of the PR
- [x] The test plan
- [x] The test results
- [ ] (Optional) Documentation update — happy to add notes if reviewers want any
</details>