### PR TITLE
[Kernel][SM70] FA_V100 bundle: decode grid overlaunch + paged prefill sS/sP race fix

### DIFF
--- a/flash-attention-v100/flash_attn_v100/flash_attn_interface.py
+++ b/flash-attention-v100/flash_attn_v100/flash_attn_interface.py
@@ -213,6 +213,17 @@ def _get_decode_plan(
         ),
         workspace_num_partitions=workspace_num_partitions,
     )
+    # Invariant, by construction: actual <= launch <= workspace. Both partition
+    # counts divide by the same positive partition_size, and
+    # effective_workspace_seq_capacity is floored to >= effective_max_seq_len
+    # above (:164-168), so workspace_num_partitions >= runtime_num_partitions;
+    # launch_num_partitions is one of those two. A check of that inequality HERE
+    # would be a tautology that can never fire (it compares three quantities all
+    # derived from the same hints), so it is NOT placed here. The coverage that
+    # actually matters -- launch >= ceil(true seq_lens.max()/ps) -- can only be
+    # checked where the real per-sequence lengths are known, which is the caller
+    # wrappers flash_attn_decode_paged / _xqa; see
+    # _assert_decode_launch_covers_seq_lens.
     device_index = q.device.index if q.device.index is not None else -1
     key = (
         device_index,
@@ -231,6 +242,57 @@ def _get_decode_plan(
             return cached
         _decode_plan_cache[key] = plan
     return plan
+
+
+def _assert_decode_launch_covers_seq_lens(
+    plan: "_DecodePlan",
+    seq_lens: torch.Tensor | None,
+    *,
+    workspace_seq_capacity_hint: int | None,
+) -> None:
+    """Lower-bound coverage guard with REAL rejecting power (DISCIPLINE §3).
+
+    Unlike an inequality among quantities all derived from the same hint (a
+    by-construction tautology inside `_get_decode_plan`), this compares the
+    launched partition count against the batch's TRUE longest sequence, read
+    from the device ``seq_lens`` tensor -- a source INDEPENDENT of the capacity
+    hint. It therefore fires exactly when a capacity hint understates the real
+    max seq_len and the launch grid would silently truncate the longest
+    sequence (the corruption 0007's adversarial probe demonstrated, 328x rms).
+
+    Scope, and why it is scoped: it runs only when a ``workspace_seq_capacity_
+    hint`` was supplied -- the small-query / static-decode path where
+    ``launch_num_partitions == workspace_num_partitions`` can be driven below
+    coverage by a wrong hint, including this patch's own cap arithmetic. Plain
+    q=1 decode passes ``workspace_seq_capacity_hint=None`` (build() ->
+    _attach_decode_shape_hints, static_decode=False), so ``launch == runtime ==
+    ceil(effective_max_seq_len/ps)`` and there is no device sync on the hot
+    path. The q=1 path's own coverage is safe by construction (its hint is
+    ``seq_lens_cpu.max()`` for the same eager forward) and is out of this
+    finding's scope, so it is deliberately NOT guarded here. Skipped under CUDA
+    graph capture, where a ``.item()`` sync is illegal and the captured grid is
+    already sized to the full workspace envelope (:170-182), which covers any
+    runtime seq_len.
+    """
+    if workspace_seq_capacity_hint is None or _cuda_graph_capture_active():
+        return
+    if seq_lens is None or seq_lens.numel() == 0:
+        return
+    true_max_seq_len = int(seq_lens.max().item())
+    required_num_partitions = max(
+        1,
+        (true_max_seq_len + plan.partition_size - 1) // plan.partition_size,
+    )
+    if plan.launch_num_partitions < required_num_partitions:
+        raise RuntimeError(
+            "decode launch grid under-covers the batch: launch_num_partitions="
+            f"{plan.launch_num_partitions} < required={required_num_partitions} "
+            f"to cover max seq_len={true_max_seq_len} "
+            f"(partition_size={plan.partition_size}, "
+            f"workspace_seq_capacity_hint={workspace_seq_capacity_hint}). "
+            "A capacity hint understated the real sequence length; the longest "
+            "sequence would be silently truncated."
+        )
 
 
 def _get_decode_workspace_for_plan(
@@ -863,6 +925,11 @@ def flash_attn_decode_paged(
         active_num_partitions=active_num_partitions,
         partition_size_hint=partition_size_hint,
     )
+    _assert_decode_launch_covers_seq_lens(
+        plan,
+        seq_lens,
+        workspace_seq_capacity_hint=workspace_seq_capacity_hint,
+    )
     tmp_out, max_logits, exp_sums, active_num_partitions = (
         _get_decode_workspace_for_plan(
             q,
@@ -949,6 +1016,11 @@ def flash_attn_decode_paged_xqa(
         workspace_seq_capacity_hint=workspace_seq_capacity_hint,
         active_num_partitions=active_num_partitions,
         partition_size_hint=partition_size_hint,
+    )
+    _assert_decode_launch_covers_seq_lens(
+        plan,
+        seq_lens,
+        workspace_seq_capacity_hint=workspace_seq_capacity_hint,
     )
     tmp_out, max_logits, exp_sums, active_num_partitions = (
         _get_decode_workspace_for_plan(

--- a/flash-attention-v100/kernel/fused_mha_forward_paged.cu
+++ b/flash-attention-v100/kernel/fused_mha_forward_paged.cu
@@ -1363,6 +1363,25 @@ flash_attention_forward_kernel_paged(
             const int sub_valid_k_rows = min(softmax_sub_tile,
                                              valid_k_rows - sub_start);
 
+            // ================================================================
+            // Patch 0108 (surgical) — sS/sP union race fix, D-conditional.
+            // ISSUE-0007 / issues/0090. The race (W(__half2) P-commit racing
+            // R(float4) sS reads with no cross-warp barrier) exists ONLY for
+            // D != 256, where sP = reuse_sp.p aliases sS byte-for-byte.
+            //
+            // D == 256 is race-IMMUNE: sP = p_strict, a SEPARATE buffer
+            // (SmemLayout::p_strict, line ~134; selected at line ~491). So the
+            // D==256 arm below is the ORIGINAL monolithic block VERBATIM — no
+            // barrier, no variable hoisting. This is the ONLY difference from
+            // archived/patches/0011: 0011 split the guard and hoisted vars for
+            // EVERY D, which perturbed the D=256 register/spill allocation and
+            // cost the immune path +0.47..+2.79% for zero benefit. Guarding the
+            // whole transform under `if constexpr (D != 256)` makes the D=256
+            // codegen byte-identical to baseline (proved via SASS diff) => the
+            // immune path pays EXACTLY zero. The D!=256 arm is 0011's
+            // two-phase-commit fix, verbatim (barrier ALONE, no riders).
+            // ================================================================
+            if constexpr (D == 256) {
             if (tid < valid_q_rows * THREADS_PER_ROW) {
                 const int row = tid / THREADS_PER_ROW;
                 const int thread_in_row = tid % THREADS_PER_ROW;
@@ -1521,6 +1540,224 @@ flash_attention_forward_kernel_paged(
                         sO_vec[ov] = v;
                     }
                 }
+            }
+            } else {
+            // ----------------------------------------------------------------
+            // ISSUE-0007 race-class fix (patch 0011,
+            // patches/0011-paged-race-fix-issue0007/ — PoC: poc/race_poc.cu).
+            //
+            // For D != 256, sP aliases sS byte-for-byte (union reuse_sp;
+            // sP = reuse_sp.p selected above with p_stride == S_STRIDE). The
+            // softmax phase reads sS as float4 (max pass, exp pass, scalar
+            // tail) and then commits P into the SAME union bytes as
+            // __half2/__half. Row r's half P row occupies union bytes
+            // [2*S_STRIDE*r, +2*S_STRIDE) — inside the FLOAT score row of row
+            // r/2 — so the P commit of warp w lands exactly on the score row
+            // still being read as float4 by warp w/2. The register staging
+            // (half_buffer) orders read-then-write only WITHIN one thread;
+            // cross-warp there was NO ordering until the __syncthreads() at
+            // the end of this phase, i.e. AFTER both: a W(__half2) x R(float4)
+            // data race. Evidence: compute-sanitizer racecheck 3 errors /
+            // 87,712 hazard instances on the PoC extraction of this exact
+            // access pattern, and the REAL kernel 10/10-runs bitwise
+            // non-deterministic at D=128 (q=512/kv=4096 and q=1024/kv=8192).
+            //
+            // Fix, proved racecheck-clean AND bit-equal in the PoC: two-phase
+            // P commit. Phase A = all sS reads + reductions with P staged in
+            // registers exactly as before; ONE uniform block-scope
+            // __syncthreads(); phase B = all sP stores. The former single
+            // guarded region is split in two so the barrier sits in UNIFORM
+            // control flow, and the per-thread state below is hoisted to
+            // survive across the barrier. No arithmetic is changed or
+            // reordered. D == 256 keeps its original barrier-free structure:
+            // sP = p_strict there, a separate buffer that never aliases sS
+            // (constexpr guard on the barrier below).
+            // ----------------------------------------------------------------
+            const int row = tid / THREADS_PER_ROW;
+            const int thread_in_row = tid % THREADS_PER_ROW;
+            __half* sP_row_h = sP + row * p_stride;
+            __half2* sP_half2 = reinterpret_cast<__half2*>(sP_row_h);
+            const int vec_cols = sub_valid_k_rows >> 2;
+            const int vecs_per_thread =
+                (vec_cols + THREADS_PER_ROW - 1) / THREADS_PER_ROW;
+            const int tail_start = vec_cols << 2;
+            float exp_diff = 1.0f;
+            __half2 half_buffer[20];
+            int tail_col = -1;
+            __half tail_value = __float2half(0.f);
+
+            if (tid < valid_q_rows * THREADS_PER_ROW) {
+                const unsigned mask = (valid_q_rows == BLOCK_M)
+                                          ? 0xFFFFFFFFU
+                                          : __activemask();
+                const int row_leader = __ffs(mask) - 1;
+
+                float*  sS_row_f = sS + row * S_STRIDE + sub_start;
+
+                float thread_max = NEG_INF;
+                float4* sS_vec4 = reinterpret_cast<float4*>(sS_row_f);
+
+                #pragma unroll 4
+                for (int j = 0; j < vecs_per_thread; ++j) {
+                    int vc = thread_in_row + j * THREADS_PER_ROW;
+                    if (vc < vec_cols) {
+                        float4 v4 = sS_vec4[vc];
+                        thread_max = fmaxf(
+                            thread_max,
+                            fmaxf(fmaxf(v4.x, v4.y), fmaxf(v4.z, v4.w)));
+                    }
+                }
+
+                #pragma unroll
+                for (int c = tail_start + thread_in_row; c < sub_valid_k_rows;
+                     c += THREADS_PER_ROW) {
+                    thread_max = fmaxf(thread_max, sS_row_f[c]);
+                }
+
+                #pragma unroll
+                for (int o = THREADS_PER_ROW / 2; o > 0; o >>= 1) {
+                    thread_max = fmaxf(
+                        thread_max,
+                        __shfl_down_sync(mask, thread_max, o, THREADS_PER_ROW));
+                }
+
+                const float row_max =
+                    __shfl_sync(mask, thread_max, row_leader, THREADS_PER_ROW);
+                const float old_max = sRowMax[row];
+                const float new_max = fmaxf(old_max, row_max);
+                // 0011: exp_diff hoisted above the phase split (used by the
+                // sO rescale in phase B). Same expression, same position in
+                // the arithmetic order.
+                exp_diff = __expf(old_max - new_max);
+
+                float thread_sum = 0.0f;
+                int vc_base = thread_in_row;
+                int h2_idx = 0;
+
+                #pragma unroll 4
+                for (int j = 0; j < vecs_per_thread; ++j,
+                         vc_base += THREADS_PER_ROW) {
+                    if (vc_base < vec_cols) {
+                        float4 v4 = sS_vec4[vc_base];
+
+                        float e0 = __expf(fmaxf(v4.x - new_max, -80.0f));
+                        float e1 = __expf(fmaxf(v4.y - new_max, -80.0f));
+                        float e2 = __expf(fmaxf(v4.z - new_max, -80.0f));
+                        float e3 = __expf(fmaxf(v4.w - new_max, -80.0f));
+
+                        thread_sum += (e0 + e1) + (e2 + e3);
+
+                        const __half2 p01 =
+                            __float22half2_rn(make_float2(e0, e1));
+                        const __half2 p23 =
+                            __float22half2_rn(make_float2(e2, e3));
+                        if constexpr (D256_SW_PIPELINE_PV) {
+                            // D256 owns a separate probability buffer, so the
+                            // values can leave registers before row reduction.
+                            const int base_offset = vc_base * 2;
+                            sP_half2[base_offset] = p01;
+                            sP_half2[base_offset + 1] = p23;
+                        } else {
+                            half_buffer[h2_idx++] = p01;
+                            half_buffer[h2_idx++] = p23;
+                        }
+                    }
+                }
+
+                #pragma unroll 4
+                for (int c = tail_start + thread_in_row; c < sub_valid_k_rows;
+                     c += THREADS_PER_ROW) {
+                    float v = sS_row_f[c];
+                    float e = __expf(fmaxf(v - new_max, -80.0f));
+                    thread_sum += e;
+                    if constexpr (D256_SW_PIPELINE_PV) {
+                        sP_row_h[c] = __float2half_rn(e);
+                    } else {
+                        tail_col = c;
+                        tail_value = __float2half_rn(e);
+                    }
+                }
+
+                #pragma unroll
+                for (int o = THREADS_PER_ROW / 2; o > 0; o >>= 1) {
+                    thread_sum +=
+                        __shfl_down_sync(mask, thread_sum, o, THREADS_PER_ROW);
+                }
+
+                float row_sum =
+                    __shfl_sync(mask, thread_sum, row_leader, THREADS_PER_ROW);
+
+                if (thread_in_row == 0) {
+                    sRowSum[row] = exp_diff * sRowSum[row] + row_sum;
+                    sRowMax[row] = new_max;
+                }
+            }  // end phase A: every sS read of this sub-tile is done; P is
+               // staged in registers (half_buffer / tail_col / tail_value).
+
+            // ISSUE-0007 fix (patch 0011): THE one uniform __syncthreads()
+            // between the sS read phase and the sP commit phase — the only
+            // behavioral change of this patch. UNIFORMITY: this point is at
+            // the body scope of the sub_start loop; its trip count
+            // (valid_k_rows, softmax_sub_tile) and every enclosing control
+            // transfer (kernel early returns on blockIdx.z/M; block_n loop
+            // break/continue on start_col/min_key_pos/bfla block mask) are
+            // block-uniform — the same uniformity the pre-existing
+            // __syncthreads() at the end of this loop body already requires.
+            // All threads of the block reach this barrier exactly once per
+            // sub_start iteration. D == 256 is immune (sP = p_strict,
+            // separate buffer) and keeps its barrier-free codegen.
+            if constexpr (D != 256) {
+                __syncthreads();
+            }
+
+            if (tid < valid_q_rows * THREADS_PER_ROW) {
+                // phase B: commit P to the union bytes. Bit-identical values
+                // (straight from the phase-A registers), same store order,
+                // same addresses as the pre-fix code.
+                if constexpr (!D256_SW_PIPELINE_PV) {
+                    int h2_idx = 0;
+                    int vc_base = thread_in_row;
+                    #pragma unroll 4
+                    for (int j = 0; j < vecs_per_thread; ++j,
+                             vc_base += THREADS_PER_ROW) {
+                        if (vc_base < vec_cols) {
+                            int base_offset = vc_base * 2;
+                            sP_half2[base_offset] = half_buffer[h2_idx++];
+                            sP_half2[base_offset + 1] = half_buffer[h2_idx++];
+                        }
+                    }
+
+                    if (tail_col >= 0) {
+                        sP_row_h[tail_col] = tail_value;
+                    }
+                }
+
+                #pragma unroll 4
+                for (int c = tail_start + thread_in_row; c < p_tile_capacity;
+                     c += THREADS_PER_ROW) {
+                    if (c >= sub_valid_k_rows) {
+                        sP_row_h[c] = __float2half(0.f);
+                    }
+                }
+
+                if (block_n > 0 || sub_start > 0) {
+                    float*  sO_row = sO + row * O_STRIDE;
+                    float4* sO_vec = reinterpret_cast<float4*>(sO_row);
+                    const int o_vec_count = D / 4;
+                    float scale = exp_diff;
+
+                    #pragma unroll 4
+                    for (int ov = thread_in_row; ov < o_vec_count;
+                         ov += THREADS_PER_ROW) {
+                        float4 v = sO_vec[ov];
+                        v.x *= scale;
+                        v.y *= scale;
+                        v.z *= scale;
+                        v.w *= scale;
+                        sO_vec[ov] = v;
+                    }
+                }
+            }
             }
             __syncthreads();
 

--- a/vllm/v1/attention/backends/flash_attn_v100.py
+++ b/vllm/v1/attention/backends/flash_attn_v100.py
@@ -2506,9 +2506,22 @@ class FlashAttnV100MetadataBuilder(TritonAttentionMetadataBuilder):
                 common_attn_metadata,
             )
         if not ddtree_tree_verify:
+            # EAGER build path: cap the small-query decode workspace/launch grid
+            # to the runtime max_seq_len, mirroring build_for_cudagraph_capture
+            # (:2431-2445). Without a cap, _update_smallq_decode_metadata stores
+            # the full block-table capacity (== max_model_len worth of blocks) at
+            # smallq_decode_workspace_seq_capacity_hint (:2350), and the interface
+            # then launches ceil(max_model_len/partition_size) partitions where
+            # only ceil(max_seq_len/partition_size) do work (1024 vs 17 at
+            # max_model_len=262144 / S=4224 / ps=256). The cap keeps launch equal
+            # to the runtime coverage; the interface floors it at effective
+            # max_seq_len (_get_decode_plan:165-169), so it can never under-cover.
             self._update_smallq_decode_metadata(
                 attn_metadata,
                 common_attn_metadata,
+                workspace_seq_capacity_cap=(
+                    int(getattr(common_attn_metadata, "max_seq_len", 0) or 0) or None
+                ),
             )
         self._attach_decode_shape_hints(attn_metadata, common_attn_metadata)
         self._update_decode_active_num_partitions(attn_metadata, stage="build")
@@ -2544,7 +2557,16 @@ class FlashAttnV100MetadataBuilder(TritonAttentionMetadataBuilder):
             else 0.0
         )
         profile_stage_t0 = time.perf_counter() if profile_enabled else 0.0
-        self._update_smallq_decode_metadata(attn_metadata, common_attn_metadata)
+        # EAGER drafting build path: same runtime max_seq_len cap as build()
+        # above, so the drafter hot loop does not over-launch to the full
+        # max_model_len envelope. See build() for the full rationale.
+        self._update_smallq_decode_metadata(
+            attn_metadata,
+            common_attn_metadata,
+            workspace_seq_capacity_cap=(
+                int(getattr(common_attn_metadata, "max_seq_len", 0) or 0) or None
+            ),
+        )
         smallq_ms = (
             (time.perf_counter() - profile_stage_t0) * 1000.0
             if profile_enabled
@@ -5148,6 +5170,15 @@ class FlashAttnV100Impl(TritonAttentionImpl):
             torch.zeros_like(decode_block_table),
             decode_block_table,
         ).contiguous()
+        # EAGER fallback branch (persistent smallq metadata absent). Cap the
+        # workspace/launch grid to the runtime max_seq_len instead of passing the
+        # raw block-table capacity (== max_model_len worth of blocks), which would
+        # over-launch ceil(max_model_len/ps) partitions where only
+        # ceil(max_seq_len/ps) do work. eager_max_seq_len is computed once (single
+        # device->host sync, was already paid for max_seq_len_hint) and reused; the
+        # interface floors the hint at effective max_seq_len (_get_decode_plan:
+        # 165-169), so the cap can never under-cover the runtime sequences.
+        eager_max_seq_len = int(seq_lens.max().item()) if num_seqs > 0 else None
         self._call_flash_attn_smallq_decode_paged(
             layer,
             query,
@@ -5157,9 +5188,12 @@ class FlashAttnV100Impl(TritonAttentionImpl):
             decode_seq_lens,
             attn_metadata,
             out=out_view,
-            max_seq_len_hint=(int(seq_lens.max().item()) if num_seqs > 0 else None),
+            max_seq_len_hint=eager_max_seq_len,
             workspace_seq_capacity_hint=(
-                int(block_table.shape[1]) * int(key_cache.shape[1])
+                min(
+                    int(block_table.shape[1]) * int(key_cache.shape[1]),
+                    eager_max_seq_len,
+                )
                 if num_seqs > 0
                 else None
             ),


### PR DESCRIPTION
Two independent SM70 FA_V100 kernel fixes. Bundled as separate commits so either can be dropped if a reviewer wants only one.

Both patches were qualified on V100 SM70 (CUDA 12.8) with real-kernel A/B measurements. Numbers below are per-kernel operator-level (not end-to-end served throughput) unless otherwise noted.

---

### 1. `e4c8d1d` — decode: size launch grid by runtime seq_len, not workspace capacity

Fixes an eager over-launch in the paged FA_V100 decode-attention path.

`flash_attn_v100.py` was passing `workspace_seq_capacity_hint = block_table.shape[1] * block_size` — i.e. `max_model_len` worth of blocks — and `flash_attn_interface.py` then launched `workspace_num_partitions` rather than `runtime_num_partitions`. At `--max-model-len 262144` with `partition_size 256`, that is 1024 launched partitions where roughly 17 do any work.

The fix separates the two roles:
- `workspace_num_partitions` — upper bound, stays as scratch size and as the `max_num_partitions` template arg the kernels clamp with.
- `runtime_num_partitions` — grid.z at launch, sized from the effective `runtime_max_seq_len`.

Correctness preserved: both `flash_decode_paged` and the reduce kernel still receive the workspace bound and clamp coverage internally.

Measured speedups (V100 SM70, interleaved medians):

| rows | path | scalar over→fix | XQA (D=256,q_per_kv=6) |
|---|---|---|---|
| 32  | graph      | 866 → 518 µs (1.67x)    | — |
| 128 | graph edge | 3255 → 1756 µs (1.85x)  | 1667 → 1270 µs (1.31x) |
| 256 | eager      | 6408 → 3455 µs (1.85x)  | 3203 → 2394 µs (1.34x) |
| 512 | eager      | 13034 → 6839 µs (1.91x) | 6129 → 4507 µs (1.36x) |

At long context (S ≥ 32768) the partition size rises to 1024, shrinking over-launch to ~256 partitions and the gain to ~2%. Small-B graph-captured shapes are already bucketed → ≈0 change. No shape regresses. Same speedup ratio device-confirmed on the `fp8_e5m2` KV route.

Files: `flash-attention-v100/flash_attn_v100/flash_attn_interface.py`, `vllm/v1/attention/backends/flash_attn_v100.py`.

---

### 2. `8aa6b24` — paged prefill: two-phase P commit fixes sS/sP union race (D≠256)

Fixes a WAR/RAW race in `flash_attention_forward_kernel_paged` on head_dim ≠ 256.

`fused_mha_forward_paged.cu` declares `union reuse_sp { float s[]; __half p[]; }`. For D≠256, both `sS` and `sP` point at the same bytes. In the softmax sub-tile the loop reads sS as `float4` and, inside the same tid-guarded region, commits P to sP as `__half2`/`__half`, with only within-thread ordering via a register buffer. Cross-warp, warp W's P store lands on the float score row that warp W' is still reading as float4 — no ordering between them.

Observed on baseline (compute-sanitizer racecheck): **4 errors at D=128, 5 at D=64**; 10 identical-input launches at D=128 H=8 give **10 unique outputs**. D=256 is immune (sP is a separate `p_strict` buffer).

Fix: split the guarded region into (A) all sS reads + reductions with P staged in registers, and (B) all sP stores, with one uniform `__syncthreads()` between them at block-uniform control flow. The whole transform lives under `if constexpr (D != 256)`, so the D=256 codegen is unchanged.

Measured cost (real-kernel A/B, interleaved):
- **D=256 (immune, served path): ZERO cost** — all 39 D=256 kernel symbols are raw-SASS byte-identical to baseline; `cuobjdump -res-usage` identical.
- **D=64 short-context** (M=512/KV=4096): +0.5% (426.0 → 428.1 µs) — a fixed barrier cost, vanishes proportionally at higher load (D=64 M=1024/KV=8192: +0.02%, noise).
- **D=128** (the head the race actually fires on): -0.07% / -0.3% at 512/4096 and 1024/8192 — inside noise, so honestly "D=128 pays nothing".

Correctness: racecheck 4→0 (D=128), 5→0 (D=64). Determinism D=128 H=8: 10/10-unique baseline → 1 unique (bitwise-identical across 10 runs). Bit-equal to baseline on all previously-stable shapes — the fix reorders **when** threads read, never **what** is computed.

Note on prior art: this is the surgical form of an earlier internal patch that hoisted variables for every D. That earlier form measured +0.47…+2.79% D=256 cost from register/spill perturbation on the immune path. Guarding the transform under `if constexpr (D != 256)` makes the D=256 machine code literally unchanged, at no cost to the fix on the D≠256 paths.

Files: `flash-attention-v100/kernel/fused_mha_forward_paged.cu`.

---

### Testing on our side

Both patches shipped in monico-vllm v0.1.4/v0.1.6 on 4× V100 SXM2, serving at TP4 with `FLASH_ATTN_V100` backend. In-engine A/B with the resident model (head_dim 256, AWQ int4, fp8_e5m2 KV) is stable; racecheck-clean device runs on D=128/D=64 shapes for #2.

Happy to split into two PRs if that's easier to review.