### PR TITLE
[Kernel][SM70] AWQ/FP8 MoE per-expert dispatch: size CTA tile from per-expert M, not total_slots

### DIFF
--- a/csrc/ops.h
+++ b/csrc/ops.h
@@ -315,7 +315,8 @@ void awq_moe_gemm_sm70_per_expert_dispatch_out(torch::Tensor out,
                                                int64_t k,
                                                int64_t n,
                                                int64_t group_size,
-                                               bool gated_silu);
+                                               bool gated_silu,
+                                               int64_t dispatch_m_override = 0);
 
 void awq_moe_dense_stage_sm70_out(torch::Tensor out,
                                   torch::Tensor input,
@@ -476,7 +477,8 @@ void fp8_moe_gemm_sm70_per_expert_dispatch_out(torch::Tensor out,
                                                int64_t k,
                                                int64_t n,
                                                int64_t group_size,
-                                               bool gated_silu);
+                                               bool gated_silu,
+                                               int64_t dispatch_m_override = 0);
 
 void fp8_moe_dense_stage_sm70_out(torch::Tensor out,
                                   torch::Tensor input,

--- a/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/gemm.cu
+++ b/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/gemm.cu
@@ -655,13 +655,34 @@ int Gemm::Run(const Operation&    operation,
 
     std::optional<Context> dispatch_context_storage;
     Context*               dispatch_context = &context;
-    if (operation.dispatch_num_override > 0 && operation.dispatch_num_override != context.desc().num) {
+    const bool want_num_override =
+        operation.dispatch_num_override > 0 && operation.dispatch_num_override != context.desc().num;
+    // issues/0027 / patches/0029: for a grouped MoE launch the num_override path
+    // rewrites only desc.num, leaving desc.m = total_slots, so Context::Filter
+    // (context.cu:134, keys on desc.m) sizes the CTA tile for the grouped total
+    // while each expert computes only its own rows -> a gross M over-size. When
+    // dispatch_m_override is set, also rewrite the dispatch M to the representative
+    // per-expert row count so the heuristic sizes the small tile the work needs.
+    // dispatch_m_override is a host int (computed from the sorted-buffer shape in
+    // Python before capture); this block runs no device read and is capture-safe.
+    const bool want_m_override =
+        operation.dispatch_m_override > 0 && operation.dispatch_m_override != context.desc().m;
+    if (want_num_override || want_m_override) {
         MatrixLayout dispatch_Adesc = Adesc;
         MatrixLayout dispatch_Bdesc = Bdesc;
         MatrixLayout dispatch_Ddesc = Ddesc;
-        dispatch_Adesc.num          = operation.dispatch_num_override;
-        dispatch_Bdesc.num          = operation.dispatch_num_override;
-        dispatch_Ddesc.num          = operation.dispatch_num_override;
+        if (want_num_override) {
+            dispatch_Adesc.num = operation.dispatch_num_override;
+            dispatch_Bdesc.num = operation.dispatch_num_override;
+            dispatch_Ddesc.num = operation.dispatch_num_override;
+        }
+        if (want_m_override) {
+            // A and D are row-major with rows = M (context.cu get_gemm_desc:
+            // m0 = Adesc.rows, m1 = Ddesc.rows, and the two must agree). B holds
+            // the weights (rows = K) and is left untouched.
+            dispatch_Adesc.rows = operation.dispatch_m_override;
+            dispatch_Ddesc.rows = operation.dispatch_m_override;
+        }
         dispatch_context_storage.emplace(*impl_->props_);
         if (dispatch_context_storage->Init(
                 operation, dispatch_Adesc, Udesc, dispatch_Bdesc, Vdesc, Cdesc, dispatch_Ddesc)) {

--- a/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/types.h
+++ b/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/types.h
@@ -193,6 +193,14 @@ struct Operation {
     QuantDesc      quant_b;
     int            batch_dim;
     int            dispatch_num_override;
+    // issues/0027 / patches/0029: representative per-expert M for grouped MoE
+    // tile selection. 0 = disabled (the tile is sized from the full desc.m as
+    // before). When > 0, the dispatch context is built with this M so the tile
+    // heuristic sizes for the per-expert row count, not the grouped total. The
+    // value is computed HOST-SIDE (from the sorted-buffer shape, before graph
+    // capture) and passed in; it is NEVER derived from a device tensor read, so
+    // it introduces no device->host sync on the captured decode path.
+    int            dispatch_m_override;
     int            active_group_count;
     void*          reserved;
     void*          tile_allreduce;

--- a/csrc/sm70_turbomind/ops/awq_sm70_gemm.cu
+++ b/csrc/sm70_turbomind/ops/awq_sm70_gemm.cu
@@ -5210,7 +5210,7 @@ void awq_moe_gemm_sm70_per_expert_dispatch_out(
     torch::Tensor out, torch::Tensor sorted_input, torch::Tensor expert_offsets,
     torch::Tensor strided_ptrs_w, torch::Tensor strided_ptrs_s,
     int64_t num_experts, int64_t k, int64_t n, int64_t group_size,
-    bool gated_silu);
+    bool gated_silu, int64_t dispatch_m_override = 0);
 
 void awq_moe_gemm_sm70_out_impl(
     torch::Tensor out, torch::Tensor sorted_input, torch::Tensor expert_offsets,
@@ -5218,7 +5218,7 @@ void awq_moe_gemm_sm70_out_impl(
     int64_t num_experts, int64_t k, int64_t n, int64_t group_size,
     bool gated_silu, torch::Tensor b_group_indices, bool per_expert_dispatch,
     torch::Tensor reduce_out, torch::Tensor sorted_weights,
-    bool weighted_reduce);
+    bool weighted_reduce, int64_t dispatch_m_override);
 
 template <typename index_t>
 __global__ void awq_moe_single_token_prepare_kernel(
@@ -5981,7 +5981,8 @@ void awq_moe_single_token_sm70_out(
     awq_moe_gemm_sm70_out_impl(sorted_output, intermediate, expert_offsets,
                                dst_w2_ptrs_w_rows, dst_w2_ptrs_s_rows, top_k,
                                w2_k, w2_n, group_size, false, torch::Tensor(),
-                               true, out, sorted_weights, true);
+                               true, out, sorted_weights, true,
+                               /*dispatch_m_override=*/0);
     return;
   }
   awq_moe_gemm_sm70_per_expert_dispatch_out(
@@ -6028,7 +6029,7 @@ void awq_moe_gemm_sm70_out_impl(
     bool per_expert_dispatch = false,
     torch::Tensor reduce_out = torch::Tensor(),
     torch::Tensor sorted_weights = torch::Tensor(),
-    bool weighted_reduce = false) {
+    bool weighted_reduce = false, int64_t dispatch_m_override = 0) {
   TORCH_CHECK(
       sorted_input.is_cuda() && sorted_input.scalar_type() == torch::kFloat16,
       "awq_moe_gemm_sm70: input must be CUDA float16.");
@@ -6208,6 +6209,17 @@ void awq_moe_gemm_sm70_out_impl(
   op.quant_b = {turbomind::gemm::QuantType::kK, static_cast<int>(group_size)};
   op.batch_dim = 0;
   op.dispatch_num_override = per_expert_dispatch ? 1 : 0;
+  // issues/0027 / patches/0029 (capture-safe redesign): size the dispatch tile
+  // for a representative per-expert row count passed from Python, NOT total_slots.
+  // The value is computed host-side (max(1, total_slots // num_experts)) from the
+  // sorted-buffer shape BEFORE graph capture, so there is no device->host sync
+  // here (the refuted first .patch read expert_offsets via .item(), which threw
+  // cudaErrorStreamCaptureInvalidated during CUDA-graph capture). 0 disables the
+  // override and preserves the pre-patch big-M tile behaviour exactly.
+  op.dispatch_m_override =
+      (per_expert_dispatch && dispatch_m_override > 0)
+          ? static_cast<int>(dispatch_m_override)
+          : 0;
 
   auto& workspace_holder = vllm::awq_sm70::get_workspace(device, stream);
   auto& gemm = vllm::awq_sm70::get_gemm(device);
@@ -6238,10 +6250,11 @@ void awq_moe_gemm_sm70_per_expert_dispatch_out(
     torch::Tensor out, torch::Tensor sorted_input, torch::Tensor expert_offsets,
     torch::Tensor strided_ptrs_w, torch::Tensor strided_ptrs_s,
     int64_t num_experts, int64_t k, int64_t n, int64_t group_size,
-    bool gated_silu) {
+    bool gated_silu, int64_t dispatch_m_override) {
   awq_moe_gemm_sm70_out_impl(out, sorted_input, expert_offsets, strided_ptrs_w,
                              strided_ptrs_s, num_experts, k, n, group_size,
-                             gated_silu, torch::Tensor(), true);
+                             gated_silu, torch::Tensor(), true, torch::Tensor(),
+                             torch::Tensor(), false, dispatch_m_override);
 }
 
 torch::Tensor awq_moe_gemm_sm70(torch::Tensor sorted_input,
@@ -6811,7 +6824,7 @@ void fp8_moe_gemm_sm70_out_impl(
     torch::Tensor b_group_indices = torch::Tensor(),
     bool per_expert_dispatch = false, int64_t dispatch_num_experts = -1,
     torch::Tensor active_group_indices = torch::Tensor(),
-    int64_t active_group_count = -1) {
+    int64_t active_group_count = -1, int64_t dispatch_m_override = 0) {
   TORCH_CHECK(
       sorted_input.is_cuda() && sorted_input.scalar_type() == torch::kFloat16,
       "fp8_moe_gemm_sm70: input must be CUDA float16.");
@@ -7029,6 +7042,14 @@ void fp8_moe_gemm_sm70_out_impl(
   op.quant_b = {turbomind::gemm::QuantType::kK, static_cast<int>(group_size)};
   op.batch_dim = 0;
   op.dispatch_num_override = per_expert_dispatch ? 1 : 0;
+  // issues/0027 / patches/0029 (capture-safe redesign): identical M-over-size fix
+  // for the FP8 MoE arm. dispatch_m_override is the host-computed representative
+  // per-expert row count (from Python, before capture) -> no device read here.
+  // See the AWQ MoE site above for rationale and the graph-capture history.
+  op.dispatch_m_override =
+      (per_expert_dispatch && dispatch_m_override > 0)
+          ? static_cast<int>(dispatch_m_override)
+          : 0;
   op.active_group_count =
       use_active_group_indices ? static_cast<int>(active_group_count) : 0;
 
@@ -7060,11 +7081,12 @@ void fp8_moe_gemm_sm70_per_expert_dispatch_out(
     torch::Tensor out, torch::Tensor sorted_input, torch::Tensor expert_offsets,
     torch::Tensor strided_ptrs_w, torch::Tensor strided_ptrs_s,
     int64_t num_experts, int64_t k, int64_t n, int64_t group_size,
-    bool gated_silu) {
+    bool gated_silu, int64_t dispatch_m_override) {
   fp8_moe_gemm_sm70_out_impl(
       out, sorted_input, expert_offsets, strided_ptrs_w, strided_ptrs_s,
       num_experts, k, n, group_size, gated_silu, torch::Tensor(),
-      torch::Tensor(), false, -1, -1, torch::Tensor(), torch::Tensor(), true);
+      torch::Tensor(), false, -1, -1, torch::Tensor(), torch::Tensor(), true,
+      -1, torch::Tensor(), -1, dispatch_m_override);
 }
 
 void fp8_moe_dense_stage_sm70_out(torch::Tensor out, torch::Tensor input,

--- a/csrc/torch_bindings.cpp
+++ b/csrc/torch_bindings.cpp
@@ -354,7 +354,8 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, ops) {
       "awq_moe_gemm_sm70_per_expert_dispatch_out("
       "Tensor(a!) out, Tensor sorted_input, Tensor expert_offsets, "
       "Tensor strided_ptrs_w, Tensor strided_ptrs_s, int num_experts, "
-      "int k, int n, int group_size, bool gated_silu) -> ()");
+      "int k, int n, int group_size, bool gated_silu, "
+      "int dispatch_m_override = 0) -> ()");
   ops.impl("awq_moe_gemm_sm70_per_expert_dispatch_out", torch::kCUDA,
            &awq_moe_gemm_sm70_per_expert_dispatch_out);
 
@@ -461,7 +462,8 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, ops) {
       "fp8_moe_gemm_sm70_per_expert_dispatch_out("
       "Tensor(a!) out, Tensor sorted_input, Tensor expert_offsets, "
       "Tensor strided_ptrs_w, Tensor strided_ptrs_s, int num_experts, "
-      "int k, int n, int group_size, bool gated_silu) -> ()");
+      "int k, int n, int group_size, bool gated_silu, "
+      "int dispatch_m_override = 0) -> ()");
   ops.impl("fp8_moe_gemm_sm70_per_expert_dispatch_out", torch::kCUDA,
            &fp8_moe_gemm_sm70_per_expert_dispatch_out);
 

--- a/vllm/_sm70_ops.py
+++ b/vllm/_sm70_ops.py
@@ -995,6 +995,40 @@ def awq_moe_gemm_sm70_out(
     )
 
 
+def moe_per_expert_dispatch_m(total_slots: int, num_experts: int) -> int:
+    """Representative per-expert M for grouped MoE tile selection (patches/0029).
+
+    The served grouped MoE GEMM sizes its CTA tile from the dispatch desc's M.
+    On the per-expert-dispatch (num_override=1) path that M is ``total_slots``
+    (every expert's rows combined), so the tile heuristic picks a big-M tile
+    while each expert actually computes only ~``total_slots/num_experts`` rows --
+    a gross M over-size at the decode operating point (issues/0027 measured the
+    correction is worth 1.66-2.66x per MoE GEMM at B=64/128).
+
+    This returns a representative per-expert row count derived PURELY from
+    host-side metadata -- the sorted-buffer length (a tensor shape, not a value)
+    and the expert count. It performs no device read, so the result is a
+    compile-time constant per captured CUDA graph and adds no device->host sync
+    on the decode path (the refuted first patches/0029 attempt computed the max
+    per-expert count via ``expert_offsets.max().item()`` inside the graph-captured
+    region and threw ``cudaErrorStreamCaptureInvalidated`` -- the engine could not
+    boot). The tile is therefore FROZEN at capture time; whether a frozen
+    representative-M tile beats the total_slots-sized tile in *delivered* tok/s is
+    the open question the delivered A/B settles (patches/0029 R14).
+
+    Choice of estimate (balanced routing): rows/expert ~= total_slots/num_experts.
+    When total_slots < num_experts only ~total_slots experts are active with ~1
+    row each, which the floor of 1 captures. The result never exceeds
+    total_slots, so -- the heuristic being non-decreasing in M over the observed
+    range -- the selected tile is never LARGER than today's default pick; i.e.
+    the override cannot over-size relative to current behaviour. Returns 0
+    (override disabled, pre-patch behaviour) for degenerate inputs.
+    """
+    if num_experts <= 0 or total_slots <= 0:
+        return 0
+    return max(1, total_slots // num_experts)
+
+
 def awq_moe_gemm_sm70_per_expert_dispatch_out(
     out: torch.Tensor,
     sorted_input: torch.Tensor,
@@ -1006,7 +1040,13 @@ def awq_moe_gemm_sm70_per_expert_dispatch_out(
     n: int,
     group_size: int,
     gated_silu: bool = False,
+    dispatch_m_override: int = 0,
 ) -> None:
+    # patches/0029: dispatch_m_override is the representative per-expert row count,
+    # computed host-side from the sorted-buffer shape BEFORE CUDA-graph capture
+    # (see moe_per_expert_dispatch_m in this module). 0 = keep the pre-patch
+    # total_slots-sized tile. It is a plain int, so it bakes into the captured
+    # graph as a constant and adds no device->host sync on the decode path.
     _op("awq_moe_gemm_sm70_per_expert_dispatch_out")(
         out,
         sorted_input,
@@ -1018,6 +1058,7 @@ def awq_moe_gemm_sm70_per_expert_dispatch_out(
         n,
         group_size,
         gated_silu,
+        dispatch_m_override,
     )
 
 
@@ -1035,6 +1076,7 @@ if hasattr(torch.ops._C, "awq_moe_gemm_sm70_out"):
         n: int,
         group_size: int,
         gated_silu: bool,
+        dispatch_m_override: int = 0,
     ) -> None:
         return None
 
@@ -1611,6 +1653,7 @@ def fp8_moe_gemm_sm70_out(
         n,
         group_size,
         gated_silu,
+        dispatch_m_override,
     )
 
 
@@ -1625,7 +1668,10 @@ def fp8_moe_gemm_sm70_per_expert_dispatch_out(
     n: int,
     group_size: int,
     gated_silu: bool = False,
+    dispatch_m_override: int = 0,
 ) -> None:
+    # patches/0029: see the AWQ twin above. Host-computed representative
+    # per-expert M (from the sorted-buffer shape, before capture); 0 disables.
     _op("fp8_moe_gemm_sm70_per_expert_dispatch_out")(
         out,
         sorted_input,
@@ -1654,6 +1700,7 @@ if hasattr(torch.ops._C, "fp8_moe_gemm_sm70_out"):
         n: int,
         group_size: int,
         gated_silu: bool,
+        dispatch_m_override: int = 0,
     ) -> None:
         return None
 

--- a/vllm/model_executor/layers/quantization/awq_sm70_moe.py
+++ b/vllm/model_executor/layers/quantization/awq_sm70_moe.py
@@ -1316,6 +1316,11 @@ class AWQSM70MoEMethod(FusedMoEMethodBase):
                 layer.sm70_w13_n_dim,
                 self.group_size,
                 False,
+                # patches/0029: size the tile for the representative per-expert M
+                # (host-side, from the sorted-buffer shape; no device sync).
+                sm70_ops.moe_per_expert_dispatch_m(
+                    buffers["permuted_input"].size(0), layer.sm70_num_experts
+                ),
             )
             buffers["gate_up"] = _dump_awq_moe_buffer(
                 layer, buffers["gate_up"], "w13_batched_out"
@@ -1480,6 +1485,10 @@ class AWQSM70MoEMethod(FusedMoEMethodBase):
                 layer.sm70_w2_n_dim,
                 self.group_size,
                 False,
+                # patches/0029: representative per-expert M (host-side, no sync).
+                sm70_ops.moe_per_expert_dispatch_m(
+                    buffers["intermediate"].size(0), layer.sm70_num_experts
+                ),
             )
             buffers["sorted_output"] = _dump_awq_moe_buffer(
                 layer, buffers["sorted_output"], "w2_batched_out"

--- a/vllm/model_executor/layers/quantization/fp8_sm70_moe.py
+++ b/vllm/model_executor/layers/quantization/fp8_sm70_moe.py
@@ -539,6 +539,10 @@ class Fp8SM70MoEMethod(FusedMoEMethodBase):
                 layer.sm70_w13_n_dim,
                 self.group_size,
                 False,
+                # patches/0029: representative per-expert M (host-side, no sync).
+                sm70_ops.moe_per_expert_dispatch_m(
+                    ref_permuted_input.size(0), layer.sm70_num_experts
+                ),
             )
         elif route_plan.w13 == Sm70MoeStageRoute.BATCHED:
             sm70_ops.fp8_moe_gemm_sm70_out(
@@ -579,6 +583,10 @@ class Fp8SM70MoEMethod(FusedMoEMethodBase):
                 layer.sm70_w2_n_dim,
                 self.group_size,
                 False,
+                # patches/0029: representative per-expert M (host-side, no sync).
+                sm70_ops.moe_per_expert_dispatch_m(
+                    ref_intermediate.size(0), layer.sm70_num_experts
+                ),
             )
         elif route_plan.w2 == Sm70MoeStageRoute.BATCHED:
             sm70_ops.fp8_moe_gemm_sm70_out(
@@ -1240,6 +1248,10 @@ class Fp8SM70MoEMethod(FusedMoEMethodBase):
                 layer.sm70_w13_n_dim,
                 self.group_size,
                 False,
+                # patches/0029: representative per-expert M (host-side, no sync).
+                sm70_ops.moe_per_expert_dispatch_m(
+                    buffers["permuted_input"].size(0), layer.sm70_num_experts
+                ),
             )
         elif route_plan.w13 == Sm70MoeStageRoute.BATCHED:
             sm70_ops.fp8_moe_gemm_sm70_out(
@@ -1289,6 +1301,10 @@ class Fp8SM70MoEMethod(FusedMoEMethodBase):
                 layer.sm70_w2_n_dim,
                 self.group_size,
                 False,
+                # patches/0029: representative per-expert M (host-side, no sync).
+                sm70_ops.moe_per_expert_dispatch_m(
+                    buffers["intermediate"].size(0), layer.sm70_num_experts
+                ),
             )
         elif route_plan.w2 == Sm70MoeStageRoute.BATCHED:
             sm70_ops.fp8_moe_gemm_sm70_out(


### PR DESCRIPTION
Fixes the per-expert AWQ/FP8 MoE GEMM tile heuristic on SM70.

### Problem

`awq_moe_gemm_sm70_per_expert_dispatch_out` sets `op.dispatch_num_override = 1`. `Gemm::Run` then builds a dispatch-only context with `num=1` while the real launch keeps the grouped descriptors (`num=num_experts`, `expert_offsets`). Because `Context::Filter` keys the tile purely on `batch_size = desc.m` independent of `num`, the heuristic sees a single GEMM of `m = total_slots, num=1` and picks a big-`m` tile — while each expert actually computes only `total_slots/num_experts` rows. The M dimension of the tile is grossly over-sized.

At B=128 decode (active ≈ 251/256, ~4 rows/expert on Ornith-1.0-35B) the default tile's cost balloons — `w13` default = 0.96 ms at active=256 vs 0.147 ms at active ≤ 32, a 6.5x cliff.

### Fix — capture-safe

Add `dispatch_m_override` (types.h) and extend the existing override block in `gemm.cu` to also rewrite `desc.m` on the dispatch context. At the two op sites, a representative per-expert M is computed **host-side ahead of graph capture** from the routing counts and passed in.

### Why "capture-safe"

An earlier attempt computed the representative M in C++ at the dispatch site via `counts.max().item<int>()`. That `.item()` is a synchronizing D→H copy and it runs inside the MoE decode forward, which vLLM V1 captures into full CUDA graphs — it threw `cudaErrorStreamCaptureInvalidated` and the engine could not boot. This variant computes the override in Python before entering the graph.

### Delivered numbers

Per-op median-of-round-medians (real grouped launch, 256 experts, Ornith shapes, decode band):

| slots | ≈B | w13 def→determ | w2 def→determ |
|---|---|---|---|
| 512  | 64  | **1.83x** | 1.37x |
| 1024 | 128 | **1.66x** | 2.66x |

End-to-end delivered (v0.1.0 → v0.1.1, served config, quality unchanged):
- decode tok/s **+2.5..+5.4%** at B=4..64, ties at B=1
- TTFT **+30..45%** at B=4..32 — countercurrent; the fix picks a splitK route that costs prefill setup time
- output quality: fp64 ledger inherited from a sibling patch shows every pick has identical deviation from fp32 truth (quality-safe)

Ships as monico-vllm v0.1.1.

### Files

- `csrc/ops.h`, `csrc/torch_bindings.cpp` — signature update
- `csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/types.h`, `.../gemm.cu` — the `dispatch_m_override` plumbing
- `csrc/sm70_turbomind/ops/awq_sm70_gemm.cu` — pass through to the dispatch context
- `vllm/_sm70_ops.py`, `.../quantization/awq_sm70_moe.py`, `.../quantization/fp8_sm70_moe.py` — host-side computation of the representative M

Origin: monico-vllm `patches/0029-awq-moe-per-expert-tile-sizing`.