### PR TITLE
[Kernel+Bugfix][SM70] Marlin split-K fp32 reduce + AWQ non-turbomind SM70 route

### DIFF
--- a/csrc/quantization/marlin/sm70_marlin_fp8_gemm.cu
+++ b/csrc/quantization/marlin/sm70_marlin_fp8_gemm.cu
@@ -22,6 +22,8 @@
 
 using marlin::sm70::Sm70CtaGeometry;
 using marlin::sm70::Sm70AtomicFp16Epilogue;
+using marlin::sm70::Sm70AtomicFp32Epilogue;
+using marlin::sm70::sm70_marlin_narrow_f32_to_f16;
 using marlin::sm70::Sm70MarlinGemmTraits;
 using marlin::sm70::Sm70SplitKPartition;
 using marlin::sm70::validate_sm70_marlin_dense_cta_geometry_supported;
@@ -466,12 +468,12 @@ void sm70_marlin_fp8_gemm_splitk_kernel(
     cutlass::half_t const* __restrict__ a,
     uint32_t const* __restrict__ b_q_weight,
     cutlass::half_t const* __restrict__ b_scales,
-    cutlass::half_t* __restrict__ c, int m, int n, int k, int lda, int requested_split_k) {
+    cutlass::half_t* __restrict__ c, float* __restrict__ c32, int m, int n, int k, int lda, int requested_split_k) {
   using Traits = Sm70Fp8GemmTraits<CtaM, CtaN, CtaK, Warps, WarpM, WarpN,
                                    WarpK, GroupSize, PackedMacroN,
                                    UseMetadataVectorWords>;
   using Mma = typename Traits::Mma;
-  using AtomicEpilogue = Sm70AtomicFp16Epilogue<Traits>;
+  using AtomicEpilogue = Sm70AtomicFp32Epilogue<Traits>;
 
   extern __shared__ char smem[];
   auto& shared_storage =
@@ -518,7 +520,7 @@ void sm70_marlin_fp8_gemm_splitk_kernel(
 
   AtomicEpilogue epilogue(shared_storage.epilogue, thread_idx, warp_idx,
                           lane_idx);
-  epilogue(iterator_D, accumulators, c, n);
+  epilogue(iterator_D, accumulators, c32, n);
 }
 
 }  // namespace
@@ -568,9 +570,11 @@ torch::Tensor launch_sm70_marlin_fp8_gemm(
   smem_bytes = configure_sm70_dynamic_smem<SharedStorage>(split_kernel);
 
   int64_t const numel = size_m * size_n;
-  C10_CUDA_CHECK(cudaMemsetAsync(
-      c.data_ptr<at::Half>(), 0,
-      static_cast<size_t>(numel) * sizeof(at::Half), stream));
+  // 0009: fp32 split-K scratch (zeroed for the fp32 atomicAdd), M*N floats.
+  // Only allocated on the split_k>1 path, which the auto-selector uses ONLY at
+  // low batch (M<128), so the scratch is bounded and small.
+  auto c32 = torch::zeros({size_m, size_n},
+                          a.options().dtype(at::kFloat));
 
   dim3 grid = sm70_marlin_cta_grid(size_m, size_n, CtaM, CtaN);
   int const active_split_k =
@@ -581,8 +585,18 @@ torch::Tensor launch_sm70_marlin_fp8_gemm(
       reinterpret_cast<uint32_t const*>(b_q_weight.data_ptr<int32_t>()),
       reinterpret_cast<cutlass::half_t const*>(b_scales.data_ptr<at::Half>()),
       reinterpret_cast<cutlass::half_t*>(c.data_ptr<at::Half>()),
+      c32.data_ptr<float>(),
       static_cast<int>(size_m), static_cast<int>(size_n),
       static_cast<int>(size_k), static_cast<int>(a.stride(0)), requested_split_k);
+  C10_CUDA_KERNEL_LAUNCH_CHECK();
+
+  // 0009: single deterministic-width fp32->fp16 narrow of the scratch.
+  int const narrow_block = 256;
+  int const narrow_grid =
+      static_cast<int>((numel + narrow_block - 1) / narrow_block);
+  sm70_marlin_narrow_f32_to_f16<256><<<narrow_grid, narrow_block, 0, stream>>>(
+      c32.data_ptr<float>(),
+      reinterpret_cast<half*>(c.data_ptr<at::Half>()), numel);
   C10_CUDA_KERNEL_LAUNCH_CHECK();
 
   return c;

--- a/csrc/quantization/marlin/sm70_marlin_mxfp4_gemm.cu
+++ b/csrc/quantization/marlin/sm70_marlin_mxfp4_gemm.cu
@@ -23,6 +23,8 @@
 
 using marlin::sm70::Sm70CtaGeometry;
 using marlin::sm70::Sm70AtomicFp16Epilogue;
+using marlin::sm70::Sm70AtomicFp32Epilogue;
+using marlin::sm70::sm70_marlin_narrow_f32_to_f16;
 using marlin::sm70::Sm70MarlinGemmTraits;
 using marlin::sm70::Sm70SplitKPartition;
 using marlin::sm70::validate_sm70_marlin_dense_cta_geometry_supported;
@@ -439,11 +441,11 @@ void sm70_marlin_mxfp4_gemm_splitk_kernel(
     cutlass::half_t const* __restrict__ a,
     uint32_t const* __restrict__ b_q_weight,
     uint8_t const* __restrict__ b_scales,
-    cutlass::half_t* __restrict__ c, int m, int n, int k, int lda, int requested_split_k) {
+    cutlass::half_t* __restrict__ c, float* __restrict__ c32, int m, int n, int k, int lda, int requested_split_k) {
   using Traits = Sm70Mxfp4GemmTraits<CtaM, CtaN, CtaK, Warps, WarpM,
                                   WarpN, WarpK, GroupSize, PackedMacroN>;
   using Mma = typename Traits::Mma;
-  using AtomicEpilogue = Sm70AtomicFp16Epilogue<Traits>;
+  using AtomicEpilogue = Sm70AtomicFp32Epilogue<Traits>;
 
   extern __shared__ char smem[];
   auto& shared_storage =
@@ -490,7 +492,7 @@ void sm70_marlin_mxfp4_gemm_splitk_kernel(
 
   AtomicEpilogue epilogue(shared_storage.epilogue, thread_idx, warp_idx,
                           lane_idx);
-  epilogue(iterator_D, accumulators, c, n);
+  epilogue(iterator_D, accumulators, c32, n);
 }
 
 }  // namespace
@@ -536,9 +538,11 @@ torch::Tensor launch_sm70_marlin_mxfp4_gemm(
   smem_bytes = configure_sm70_dynamic_smem<SharedStorage>(split_kernel);
 
   int64_t const numel = size_m * size_n;
-  C10_CUDA_CHECK(cudaMemsetAsync(
-      c.data_ptr<at::Half>(), 0,
-      static_cast<size_t>(numel) * sizeof(at::Half), stream));
+  // 0009: fp32 split-K scratch (zeroed for the fp32 atomicAdd), M*N floats.
+  // Only allocated on the split_k>1 path, which the auto-selector uses ONLY at
+  // low batch (M<128), so the scratch is bounded and small.
+  auto c32 = torch::zeros({size_m, size_n},
+                          a.options().dtype(at::kFloat));
 
   dim3 grid = sm70_marlin_cta_grid(size_m, size_n, CtaM, CtaN);
   int const active_split_k =
@@ -549,8 +553,18 @@ torch::Tensor launch_sm70_marlin_mxfp4_gemm(
       reinterpret_cast<uint32_t const*>(b_q_weight.data_ptr<int32_t>()),
       reinterpret_cast<uint8_t const*>(b_scales.data_ptr()),
       reinterpret_cast<cutlass::half_t*>(c.data_ptr<at::Half>()),
+      c32.data_ptr<float>(),
       static_cast<int>(size_m), static_cast<int>(size_n),
       static_cast<int>(size_k), static_cast<int>(a.stride(0)), requested_split_k);
+  C10_CUDA_KERNEL_LAUNCH_CHECK();
+
+  // 0009: single deterministic-width fp32->fp16 narrow of the scratch.
+  int const narrow_block = 256;
+  int const narrow_grid =
+      static_cast<int>((numel + narrow_block - 1) / narrow_block);
+  sm70_marlin_narrow_f32_to_f16<256><<<narrow_grid, narrow_block, 0, stream>>>(
+      c32.data_ptr<float>(),
+      reinterpret_cast<half*>(c.data_ptr<at::Half>()), numel);
   C10_CUDA_KERNEL_LAUNCH_CHECK();
 
   return c;

--- a/csrc/quantization/marlin/sm70_marlin_nvfp4_gemm.cu
+++ b/csrc/quantization/marlin/sm70_marlin_nvfp4_gemm.cu
@@ -23,6 +23,8 @@
 
 using marlin::sm70::Sm70CtaGeometry;
 using marlin::sm70::Sm70AtomicFp16Epilogue;
+using marlin::sm70::Sm70AtomicFp32Epilogue;
+using marlin::sm70::sm70_marlin_narrow_f32_to_f16;
 using marlin::sm70::Sm70MarlinGemmTraits;
 using marlin::sm70::Sm70SplitKPartition;
 using marlin::sm70::validate_sm70_marlin_dense_cta_geometry_supported;
@@ -414,11 +416,11 @@ void sm70_marlin_nvfp4_gemm_splitk_kernel(
     uint32_t const* __restrict__ b_q_weight,
     uint8_t const* __restrict__ b_scales,
     float const* __restrict__ global_scale,
-    cutlass::half_t* __restrict__ c, int m, int n, int k, int lda, int requested_split_k) {
+    cutlass::half_t* __restrict__ c, float* __restrict__ c32, int m, int n, int k, int lda, int requested_split_k) {
   using Traits = Sm70Nvfp4GemmTraits<CtaM, CtaN, CtaK, Warps, WarpM,
                                   WarpN, WarpK, GroupSize, PackedMacroN>;
   using Mma = typename Traits::Mma;
-  using AtomicEpilogue = Sm70AtomicFp16Epilogue<Traits>;
+  using AtomicEpilogue = Sm70AtomicFp32Epilogue<Traits>;
 
   extern __shared__ char smem[];
   auto& shared_storage =
@@ -467,7 +469,7 @@ void sm70_marlin_nvfp4_gemm_splitk_kernel(
 
   AtomicEpilogue epilogue(shared_storage.epilogue, thread_idx, warp_idx,
                           lane_idx);
-  epilogue(iterator_D, accumulators, c, n);
+  epilogue(iterator_D, accumulators, c32, n);
 }
 
 }  // namespace
@@ -514,9 +516,11 @@ torch::Tensor launch_sm70_marlin_nvfp4_gemm(
   smem_bytes = configure_sm70_dynamic_smem<SharedStorage>(split_kernel);
 
   int64_t const numel = size_m * size_n;
-  C10_CUDA_CHECK(cudaMemsetAsync(
-      c.data_ptr<at::Half>(), 0,
-      static_cast<size_t>(numel) * sizeof(at::Half), stream));
+  // 0009: fp32 split-K scratch (zeroed for the fp32 atomicAdd), M*N floats.
+  // Only allocated on the split_k>1 path, which the auto-selector uses ONLY at
+  // low batch (M<128), so the scratch is bounded and small.
+  auto c32 = torch::zeros({size_m, size_n},
+                          a.options().dtype(at::kFloat));
 
   dim3 grid = sm70_marlin_cta_grid(size_m, size_n, CtaM, CtaN);
   int const active_split_k =
@@ -528,8 +532,18 @@ torch::Tensor launch_sm70_marlin_nvfp4_gemm(
       reinterpret_cast<uint8_t const*>(b_scales.data_ptr()),
       reinterpret_cast<float const*>(global_scale.data_ptr<float>()),
       reinterpret_cast<cutlass::half_t*>(c.data_ptr<at::Half>()),
+      c32.data_ptr<float>(),
       static_cast<int>(size_m), static_cast<int>(size_n),
       static_cast<int>(size_k), static_cast<int>(a.stride(0)), requested_split_k);
+  C10_CUDA_KERNEL_LAUNCH_CHECK();
+
+  // 0009: single deterministic-width fp32->fp16 narrow of the scratch.
+  int const narrow_block = 256;
+  int const narrow_grid =
+      static_cast<int>((numel + narrow_block - 1) / narrow_block);
+  sm70_marlin_narrow_f32_to_f16<256><<<narrow_grid, narrow_block, 0, stream>>>(
+      c32.data_ptr<float>(),
+      reinterpret_cast<half*>(c.data_ptr<at::Half>()), numel);
   C10_CUDA_KERNEL_LAUNCH_CHECK();
 
   return c;

--- a/csrc/quantization/marlin/sm70_marlin_splitk.cuh
+++ b/csrc/quantization/marlin/sm70_marlin_splitk.cuh
@@ -227,4 +227,143 @@ class Sm70AtomicFp16Epilogue {
   }
 };
 
+template <typename Traits>
+class Sm70AtomicFp32Epilogue {
+ public:
+  using CutlassEpilogue = typename Traits::Epilogue;
+  using SharedStorage = typename CutlassEpilogue::Base::SharedStorage;
+  using AccumulatorTile = typename CutlassEpilogue::AccumulatorTile;
+  using AccumulatorFragmentIterator =
+      typename CutlassEpilogue::AccumulatorFragmentIterator;
+  using WarpTileIterator = typename CutlassEpilogue::WarpTileIterator;
+  using SharedLoadIterator = typename CutlassEpilogue::SharedLoadIterator;
+  using OutputTileIterator = typename CutlassEpilogue::OutputTileIterator;
+  using ThreadMap = typename OutputTileIterator::ThreadMap;
+
+ private:
+  WarpTileIterator warp_tile_iterator_;
+  SharedLoadIterator shared_load_iterator_;
+
+  CUTLASS_DEVICE
+  void atomic_store_fragment(OutputTileIterator const& destination_iterator,
+                             typename SharedLoadIterator::Fragment const& frag,
+                             float* __restrict__ c, int n) const {
+    float const* frag_ptr = reinterpret_cast<float const*>(&frag);
+    int const thread_start_row = destination_iterator.thread_start_row();
+    int const thread_start_column = destination_iterator.thread_start_column();
+    int const extent_row = destination_iterator.extent_row();
+
+    CUTLASS_PRAGMA_UNROLL
+    for (int cluster = 0; cluster < ThreadMap::Iterations::kCluster;
+         ++cluster) {
+      CUTLASS_PRAGMA_UNROLL
+      for (int group = 0; group < ThreadMap::Iterations::kGroup; ++group) {
+        CUTLASS_PRAGMA_UNROLL
+        for (int row = 0; row < ThreadMap::Iterations::kRow; ++row) {
+          int const frag_row_idx =
+              row + ThreadMap::Iterations::kRow *
+                        (group + ThreadMap::Iterations::kGroup * cluster);
+          int const row_offset =
+              row * ThreadMap::Delta::kRow +
+              group * ThreadMap::Delta::kGroup +
+              cluster * ThreadMap::Delta::kCluster;
+          int const logical_row = thread_start_row + row_offset;
+
+          CUTLASS_PRAGMA_UNROLL
+          for (int column = 0; column < ThreadMap::Iterations::kColumn;
+               ++column) {
+            int const logical_column_base =
+                thread_start_column + column * ThreadMap::Delta::kColumn;
+            int const frag_base =
+                (frag_row_idx * ThreadMap::Iterations::kColumn + column) *
+                ThreadMap::kElementsPerAccess;
+
+            if (logical_row < extent_row) {
+              CUTLASS_PRAGMA_UNROLL
+              for (int e = 0; e < ThreadMap::kElementsPerAccess; ++e) {
+                int64_t const offset =
+                    int64_t(logical_row) * n + logical_column_base + e;
+                atomicAdd(c + offset, frag_ptr[frag_base + e]);
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+ public:
+  CUTLASS_DEVICE
+  Sm70AtomicFp32Epilogue(SharedStorage& shared_storage, int thread_idx,
+                              int warp_idx, int lane_idx)
+      : warp_tile_iterator_(shared_storage.reference(), lane_idx),
+        shared_load_iterator_(shared_storage.reference(), thread_idx) {
+    using WarpCount = typename CutlassEpilogue::WarpCount;
+    int const warp_k = warp_idx / (WarpCount::kM * WarpCount::kN);
+    int const warp_mn = warp_idx % (WarpCount::kM * WarpCount::kN);
+    int const warp_m = warp_mn % WarpCount::kM;
+    int const warp_n = warp_mn / WarpCount::kM;
+
+    cutlass::MatrixCoord warp_offset{warp_k * WarpCount::kM + warp_m,
+                                     warp_n};
+    warp_tile_iterator_.add_tile_offset(warp_offset);
+  }
+
+  CUTLASS_DEVICE
+  void operator()(OutputTileIterator destination_iterator,
+                  AccumulatorTile const& accumulators,
+                  float* __restrict__ c, int n) {
+    AccumulatorFragmentIterator accum_fragment_iterator(accumulators);
+
+    CUTLASS_PRAGMA_UNROLL
+    for (int iter = 0; iter < OutputTileIterator::kIterations; ++iter) {
+      __syncthreads();
+
+      typename AccumulatorFragmentIterator::Fragment accum_fragment;
+      accum_fragment_iterator.load(accum_fragment);
+      ++accum_fragment_iterator;
+      warp_tile_iterator_.store(accum_fragment);
+
+      __syncthreads();
+
+      typename SharedLoadIterator::Fragment aligned_accum_fragment;
+      shared_load_iterator_.load(aligned_accum_fragment);
+
+      if (CutlassEpilogue::kPartitionsK > 1) {
+        cutlass::plus<typename SharedLoadIterator::Fragment> add_fragments;
+
+        CUTLASS_PRAGMA_UNROLL
+        for (int i = 1; i < CutlassEpilogue::kPartitionsK; ++i) {
+          typename SharedLoadIterator::Fragment aligned_addend_fragment;
+          shared_load_iterator_.add_pointer_offset(
+              CutlassEpilogue::kSmemPointerOffset);
+          shared_load_iterator_.load(aligned_addend_fragment);
+          aligned_accum_fragment =
+              add_fragments(aligned_accum_fragment, aligned_addend_fragment);
+        }
+
+        shared_load_iterator_.add_pointer_offset(
+            (1 - CutlassEpilogue::kPartitionsK) *
+            CutlassEpilogue::kSmemPointerOffset);
+      }
+
+      atomic_store_fragment(destination_iterator, aligned_accum_fragment, c,
+                            n);
+      ++destination_iterator;
+    }
+  }
+};
+
+
+// 0009: single fp32->fp16 narrow of the split-K scratch (replaces the per-partial
+// __float2half_rn narrow the fp16-atomic epilogue did S times). Templated so the
+// symbol has vague linkage across the 7 gemm TUs that include this header.
+template <int BlockSize = 256>
+__global__ void sm70_marlin_narrow_f32_to_f16(const float* __restrict__ src,
+                                              half* __restrict__ dst,
+                                              int64_t numel) {
+  int64_t i = int64_t(blockIdx.x) * BlockSize + threadIdx.x;
+  if (i < numel) dst[i] = __float2half_rn(src[i]);
+}
+
 }  // namespace marlin::sm70

--- a/csrc/quantization/marlin/sm70_marlin_u4_gemm.cu
+++ b/csrc/quantization/marlin/sm70_marlin_u4_gemm.cu
@@ -22,6 +22,8 @@
 
 using marlin::sm70::Sm70CtaGeometry;
 using marlin::sm70::Sm70AtomicFp16Epilogue;
+using marlin::sm70::Sm70AtomicFp32Epilogue;
+using marlin::sm70::sm70_marlin_narrow_f32_to_f16;
 using marlin::sm70::Sm70MarlinGemmTraits;
 using marlin::sm70::Sm70SplitKPartition;
 using marlin::sm70::validate_sm70_marlin_dense_cta_geometry_supported;
@@ -476,12 +478,12 @@ void sm70_marlin_u4_gemm_splitk_kernel(
     uint32_t const* __restrict__ b_q_weight,
     cutlass::half_t const* __restrict__ b_scales,
     cutlass::half_t const* __restrict__ b_zeros,
-    cutlass::half_t* __restrict__ c, int m, int n, int k, int lda, int requested_split_k) {
+    cutlass::half_t* __restrict__ c, float* __restrict__ c32, int m, int n, int k, int lda, int requested_split_k) {
   using Traits = Sm70U4ZpGemmTraits<CtaM, CtaN, CtaK, Warps, WarpM,
                                     WarpN, WarpK, GroupSize, PackedMacroN,
                                     UseMetadataVectorWords>;
   using Mma = typename Traits::Mma;
-  using AtomicEpilogue = Sm70AtomicFp16Epilogue<Traits>;
+  using AtomicEpilogue = Sm70AtomicFp32Epilogue<Traits>;
 
   extern __shared__ char smem[];
   auto& shared_storage =
@@ -529,7 +531,7 @@ void sm70_marlin_u4_gemm_splitk_kernel(
 
   AtomicEpilogue epilogue(shared_storage.epilogue, thread_idx, warp_idx,
                           lane_idx);
-  epilogue(iterator_D, accumulators, c, n);
+  epilogue(iterator_D, accumulators, c32, n);
 }
 
 }  // namespace
@@ -578,9 +580,11 @@ torch::Tensor launch_sm70_marlin_u4_gemm(
   smem_bytes = configure_sm70_dynamic_smem<SharedStorage>(split_kernel);
 
   int64_t const numel = size_m * size_n;
-  C10_CUDA_CHECK(cudaMemsetAsync(
-      c.data_ptr<at::Half>(), 0,
-      static_cast<size_t>(numel) * sizeof(at::Half), stream));
+  // 0009: fp32 split-K scratch (zeroed for the fp32 atomicAdd), M*N floats.
+  // Only allocated on the split_k>1 path, which the auto-selector uses ONLY at
+  // low batch (M<128), so the scratch is bounded and small.
+  auto c32 = torch::zeros({size_m, size_n},
+                          a.options().dtype(at::kFloat));
 
   dim3 grid = sm70_marlin_cta_grid(size_m, size_n, CtaM, CtaN);
   int const active_split_k =
@@ -592,8 +596,18 @@ torch::Tensor launch_sm70_marlin_u4_gemm(
       reinterpret_cast<cutlass::half_t const*>(b_scales.data_ptr<at::Half>()),
       reinterpret_cast<cutlass::half_t const*>(b_zeros.data_ptr<at::Half>()),
       reinterpret_cast<cutlass::half_t*>(c.data_ptr<at::Half>()),
+      c32.data_ptr<float>(),
       static_cast<int>(size_m), static_cast<int>(size_n),
       static_cast<int>(size_k), static_cast<int>(a.stride(0)), requested_split_k);
+  C10_CUDA_KERNEL_LAUNCH_CHECK();
+
+  // 0009: single deterministic-width fp32->fp16 narrow of the scratch.
+  int const narrow_block = 256;
+  int const narrow_grid =
+      static_cast<int>((numel + narrow_block - 1) / narrow_block);
+  sm70_marlin_narrow_f32_to_f16<256><<<narrow_grid, narrow_block, 0, stream>>>(
+      c32.data_ptr<float>(),
+      reinterpret_cast<half*>(c.data_ptr<at::Half>()), numel);
   C10_CUDA_KERNEL_LAUNCH_CHECK();
 
   return c;

--- a/csrc/quantization/marlin/sm70_marlin_u4b8_gemm.cu
+++ b/csrc/quantization/marlin/sm70_marlin_u4b8_gemm.cu
@@ -22,6 +22,8 @@
 
 using marlin::sm70::Sm70CtaGeometry;
 using marlin::sm70::Sm70AtomicFp16Epilogue;
+using marlin::sm70::Sm70AtomicFp32Epilogue;
+using marlin::sm70::sm70_marlin_narrow_f32_to_f16;
 using marlin::sm70::Sm70MarlinGemmTraits;
 using marlin::sm70::Sm70SplitKPartition;
 using marlin::sm70::validate_sm70_marlin_dense_cta_geometry_supported;
@@ -439,12 +441,12 @@ void sm70_marlin_u4b8_gemm_splitk_kernel(
     cutlass::half_t const* __restrict__ a,
     uint32_t const* __restrict__ b_q_weight,
     cutlass::half_t const* __restrict__ b_scales,
-    cutlass::half_t* __restrict__ c, int m, int n, int k, int lda, int requested_split_k) {
+    cutlass::half_t* __restrict__ c, float* __restrict__ c32, int m, int n, int k, int lda, int requested_split_k) {
   using Traits = Sm70U4B8GemmTraits<CtaM, CtaN, CtaK, Warps, WarpM,
                                     WarpN, WarpK, GroupSize, PackedMacroN,
                                     UseMetadataVectorWords>;
   using Mma = typename Traits::Mma;
-  using AtomicEpilogue = Sm70AtomicFp16Epilogue<Traits>;
+  using AtomicEpilogue = Sm70AtomicFp32Epilogue<Traits>;
 
   extern __shared__ char smem[];
   auto& shared_storage =
@@ -491,7 +493,7 @@ void sm70_marlin_u4b8_gemm_splitk_kernel(
 
   AtomicEpilogue epilogue(shared_storage.epilogue, thread_idx, warp_idx,
                           lane_idx);
-  epilogue(iterator_D, accumulators, c, n);
+  epilogue(iterator_D, accumulators, c32, n);
 }
 
 }  // namespace
@@ -541,9 +543,11 @@ torch::Tensor launch_sm70_marlin_u4b8_gemm(
   smem_bytes = configure_sm70_dynamic_smem<SharedStorage>(split_kernel);
 
   int64_t const numel = size_m * size_n;
-  C10_CUDA_CHECK(cudaMemsetAsync(
-      c.data_ptr<at::Half>(), 0,
-      static_cast<size_t>(numel) * sizeof(at::Half), stream));
+  // 0009: fp32 split-K scratch (zeroed for the fp32 atomicAdd), M*N floats.
+  // Only allocated on the split_k>1 path, which the auto-selector uses ONLY at
+  // low batch (M<128), so the scratch is bounded and small.
+  auto c32 = torch::zeros({size_m, size_n},
+                          a.options().dtype(at::kFloat));
 
   dim3 grid = sm70_marlin_cta_grid(size_m, size_n, CtaM, CtaN);
   int const active_split_k =
@@ -554,8 +558,18 @@ torch::Tensor launch_sm70_marlin_u4b8_gemm(
       reinterpret_cast<uint32_t const*>(b_q_weight.data_ptr<int32_t>()),
       reinterpret_cast<cutlass::half_t const*>(b_scales.data_ptr<at::Half>()),
       reinterpret_cast<cutlass::half_t*>(c.data_ptr<at::Half>()),
+      c32.data_ptr<float>(),
       static_cast<int>(size_m), static_cast<int>(size_n),
       static_cast<int>(size_k), static_cast<int>(a.stride(0)), requested_split_k);
+  C10_CUDA_KERNEL_LAUNCH_CHECK();
+
+  // 0009: single deterministic-width fp32->fp16 narrow of the scratch.
+  int const narrow_block = 256;
+  int const narrow_grid =
+      static_cast<int>((numel + narrow_block - 1) / narrow_block);
+  sm70_marlin_narrow_f32_to_f16<256><<<narrow_grid, narrow_block, 0, stream>>>(
+      c32.data_ptr<float>(),
+      reinterpret_cast<half*>(c.data_ptr<at::Half>()), numel);
   C10_CUDA_KERNEL_LAUNCH_CHECK();
 
   return c;

--- a/csrc/quantization/marlin/sm70_marlin_u8_gemm.cu
+++ b/csrc/quantization/marlin/sm70_marlin_u8_gemm.cu
@@ -22,6 +22,8 @@
 
 using marlin::sm70::Sm70CtaGeometry;
 using marlin::sm70::Sm70AtomicFp16Epilogue;
+using marlin::sm70::Sm70AtomicFp32Epilogue;
+using marlin::sm70::sm70_marlin_narrow_f32_to_f16;
 using marlin::sm70::Sm70MarlinGemmTraits;
 using marlin::sm70::Sm70SplitKPartition;
 using marlin::sm70::validate_sm70_marlin_dense_cta_geometry_supported;
@@ -503,12 +505,12 @@ void sm70_marlin_u8_gemm_splitk_kernel(
     uint32_t const* __restrict__ b_q_weight,
     cutlass::half_t const* __restrict__ b_scales,
     cutlass::half_t const* __restrict__ b_zeros,
-    cutlass::half_t* __restrict__ c, int m, int n, int k, int lda, int requested_split_k) {
+    cutlass::half_t* __restrict__ c, float* __restrict__ c32, int m, int n, int k, int lda, int requested_split_k) {
   using Traits = Sm70U8ZpGemmTraits<CtaM, CtaN, CtaK, Warps, WarpM,
                                     WarpN, WarpK, GroupSize, PackedMacroN,
                                     UseMetadataVectorWords>;
   using Mma = typename Traits::Mma;
-  using AtomicEpilogue = Sm70AtomicFp16Epilogue<Traits>;
+  using AtomicEpilogue = Sm70AtomicFp32Epilogue<Traits>;
 
   extern __shared__ char smem[];
   auto& shared_storage =
@@ -556,7 +558,7 @@ void sm70_marlin_u8_gemm_splitk_kernel(
 
   AtomicEpilogue epilogue(shared_storage.epilogue, thread_idx, warp_idx,
                           lane_idx);
-  epilogue(iterator_D, accumulators, c, n);
+  epilogue(iterator_D, accumulators, c32, n);
 }
 
 }  // namespace
@@ -606,9 +608,11 @@ torch::Tensor launch_sm70_marlin_u8_gemm(
   smem_bytes = configure_sm70_dynamic_smem<SharedStorage>(split_kernel);
 
   int64_t const numel = size_m * size_n;
-  C10_CUDA_CHECK(cudaMemsetAsync(
-      c.data_ptr<at::Half>(), 0,
-      static_cast<size_t>(numel) * sizeof(at::Half), stream));
+  // 0009: fp32 split-K scratch (zeroed for the fp32 atomicAdd), M*N floats.
+  // Only allocated on the split_k>1 path, which the auto-selector uses ONLY at
+  // low batch (M<128), so the scratch is bounded and small.
+  auto c32 = torch::zeros({size_m, size_n},
+                          a.options().dtype(at::kFloat));
 
   dim3 grid = sm70_marlin_cta_grid(size_m, size_n, CtaM, CtaN);
   int const active_split_k =
@@ -620,8 +624,18 @@ torch::Tensor launch_sm70_marlin_u8_gemm(
       reinterpret_cast<cutlass::half_t const*>(b_scales.data_ptr<at::Half>()),
       reinterpret_cast<cutlass::half_t const*>(b_zeros.data_ptr<at::Half>()),
       reinterpret_cast<cutlass::half_t*>(c.data_ptr<at::Half>()),
+      c32.data_ptr<float>(),
       static_cast<int>(size_m), static_cast<int>(size_n),
       static_cast<int>(size_k), static_cast<int>(a.stride(0)), requested_split_k);
+  C10_CUDA_KERNEL_LAUNCH_CHECK();
+
+  // 0009: single deterministic-width fp32->fp16 narrow of the scratch.
+  int const narrow_block = 256;
+  int const narrow_grid =
+      static_cast<int>((numel + narrow_block - 1) / narrow_block);
+  sm70_marlin_narrow_f32_to_f16<256><<<narrow_grid, narrow_block, 0, stream>>>(
+      c32.data_ptr<float>(),
+      reinterpret_cast<half*>(c.data_ptr<at::Half>()), numel);
   C10_CUDA_KERNEL_LAUNCH_CHECK();
 
   return c;

--- a/csrc/quantization/marlin/sm70_marlin_u8b128_gemm.cu
+++ b/csrc/quantization/marlin/sm70_marlin_u8b128_gemm.cu
@@ -22,6 +22,8 @@
 
 using marlin::sm70::Sm70CtaGeometry;
 using marlin::sm70::Sm70AtomicFp16Epilogue;
+using marlin::sm70::Sm70AtomicFp32Epilogue;
+using marlin::sm70::sm70_marlin_narrow_f32_to_f16;
 using marlin::sm70::Sm70MarlinGemmTraits;
 using marlin::sm70::Sm70SplitKPartition;
 using marlin::sm70::validate_sm70_marlin_dense_cta_geometry_supported;
@@ -468,12 +470,12 @@ void sm70_marlin_u8b128_gemm_splitk_kernel(
     cutlass::half_t const* __restrict__ a,
     uint32_t const* __restrict__ b_q_weight,
     cutlass::half_t const* __restrict__ b_scales,
-    cutlass::half_t* __restrict__ c, int m, int n, int k, int lda, int requested_split_k) {
+    cutlass::half_t* __restrict__ c, float* __restrict__ c32, int m, int n, int k, int lda, int requested_split_k) {
   using Traits = Sm70U8B128GemmTraits<CtaM, CtaN, CtaK, Warps, WarpM,
                                       WarpN, WarpK, GroupSize, PackedMacroN,
                                       UseMetadataVectorWords>;
   using Mma = typename Traits::Mma;
-  using AtomicEpilogue = Sm70AtomicFp16Epilogue<Traits>;
+  using AtomicEpilogue = Sm70AtomicFp32Epilogue<Traits>;
 
   extern __shared__ char smem[];
   auto& shared_storage =
@@ -520,7 +522,7 @@ void sm70_marlin_u8b128_gemm_splitk_kernel(
 
   AtomicEpilogue epilogue(shared_storage.epilogue, thread_idx, warp_idx,
                           lane_idx);
-  epilogue(iterator_D, accumulators, c, n);
+  epilogue(iterator_D, accumulators, c32, n);
 }
 
 }  // namespace
@@ -570,9 +572,11 @@ torch::Tensor launch_sm70_marlin_u8b128_gemm(
   smem_bytes = configure_sm70_dynamic_smem<SharedStorage>(split_kernel);
 
   int64_t const numel = size_m * size_n;
-  C10_CUDA_CHECK(cudaMemsetAsync(
-      c.data_ptr<at::Half>(), 0,
-      static_cast<size_t>(numel) * sizeof(at::Half), stream));
+  // 0009: fp32 split-K scratch (zeroed for the fp32 atomicAdd), M*N floats.
+  // Only allocated on the split_k>1 path, which the auto-selector uses ONLY at
+  // low batch (M<128), so the scratch is bounded and small.
+  auto c32 = torch::zeros({size_m, size_n},
+                          a.options().dtype(at::kFloat));
 
   dim3 grid = sm70_marlin_cta_grid(size_m, size_n, CtaM, CtaN);
   int const active_split_k =
@@ -583,8 +587,18 @@ torch::Tensor launch_sm70_marlin_u8b128_gemm(
       reinterpret_cast<uint32_t const*>(b_q_weight.data_ptr<int32_t>()),
       reinterpret_cast<cutlass::half_t const*>(b_scales.data_ptr<at::Half>()),
       reinterpret_cast<cutlass::half_t*>(c.data_ptr<at::Half>()),
+      c32.data_ptr<float>(),
       static_cast<int>(size_m), static_cast<int>(size_n),
       static_cast<int>(size_k), static_cast<int>(a.stride(0)), requested_split_k);
+  C10_CUDA_KERNEL_LAUNCH_CHECK();
+
+  // 0009: single deterministic-width fp32->fp16 narrow of the scratch.
+  int const narrow_block = 256;
+  int const narrow_grid =
+      static_cast<int>((numel + narrow_block - 1) / narrow_block);
+  sm70_marlin_narrow_f32_to_f16<256><<<narrow_grid, narrow_block, 0, stream>>>(
+      c32.data_ptr<float>(),
+      reinterpret_cast<half*>(c.data_ptr<at::Half>()), numel);
   C10_CUDA_KERNEL_LAUNCH_CHECK();
 
   return c;

--- a/vllm/model_executor/layers/quantization/awq.py
+++ b/vllm/model_executor/layers/quantization/awq.py
@@ -494,6 +494,25 @@ class AWQLinearMethod(LinearMethodBase):
                     .transpose(1, 2)
                     .reshape(reshaped_x.shape[0], out_shape[-1])
                 )
+        elif not current_platform.has_device_capability(75):
+            # SM70 (V100): both classic AWQ kernels are silently broken here.
+            # ops.awq_gemm's kernel is `#if __CUDA_ARCH__ < 750 assert(false)`;
+            # in a release (NDEBUG) build the assert is compiled out, leaving an
+            # EMPTY kernel that writes nothing and returns uninitialised memory.
+            # ops.awq_dequantize (dequantize_weights) has no arch guard but still
+            # returns NaN on SM70 (measured: all-zero input yields [nan,0,...]).
+            # This path is reached when VLLM_SM70_QUANT_BACKEND=marlin forces the
+            # Marlin backend (so the layer loads and turbomind is off) but a layer
+            # is Marlin-ineligible and falls back to AWQLinearMethod. Route it
+            # through the arch-agnostic triton dequant, which is present on every
+            # build and numerically matches an fp32 reference on SM70. (patch 0040)
+            from vllm.model_executor.layers.quantization.awq_triton import (
+                awq_dequantize_triton,
+            )
+
+            out_shape = x.shape[:-1] + (qweight.shape[-1] * pack_factor,)
+            out = awq_dequantize_triton(qweight, scales, qzeros)
+            out = torch.matmul(reshaped_x, out)
         elif FP16_MATMUL_HEURISTIC_CONDITION or envs.VLLM_BATCH_INVARIANT:
             # Batch invariant mode requires torch.matmul path for Triton override.
             out_shape = x.shape[:-1] + (qweight.shape[-1] * pack_factor,)


### PR DESCRIPTION
Two independent SM70 fixes. Bundled as separate commits — either can be dropped.

---

### 1. `9550d11` — Marlin split-K: fp32 atomic reduction + one narrow at the end

Recovers the fp16 accuracy floor for the SM70 Marlin split-K cross-CTA reduce and adds low-batch determinism, without regressing any measured shape.

**Problem.** Intra-tile / intra-CTA accumulation is already fp32. The problem is the CROSS-CTA grid split-K reduction: `Sm70AtomicFp16Epilogue` narrows each fp32 partition with `__float2half_rn` and does a native fp16 `atomicAdd` into a zeroed fp16 output (`sm70_marlin_splitk.cuh:158-159`). Up to `active_split_k` (2/4/8) fp16 partials land in one cell, in nondeterministic block-completion order. Chain error: summing S fp16 partials in fp16 accrues ~√S ulps of extra rounding vs one fp32 reduce narrowed once. The auto-selector routes `split_k=8` → M ≤ 16 and `split_k=4` → M ≤ 48 / M < 128 → **loss concentrated at low batch / decode (B=1)**. AWQ TurboMind's `Reduce` accumulates in fp32 — Marlin was the outlier.

**Fix.** New fp32-atomic epilogue + a single fp32→fp16 narrow pass at the end, mirroring the split_k==1 fp32 reduce. Shared header + 7 per-bit-width launchers (identical transform). Fresh fp32 scratch (M×N×4) allocated ONLY on `requested_split_k > 1` (sk=1 keeps its zero-scratch path).

**Numbers.** rms_rel vs fp64 CPU reference (split_k=1 as control):

| M | split_k | current | patched (floor) | improvement |
|---|---|---|---|---|
|   1 | 8 | 5.05e-4 | 2.10e-4 | **2.40x** |
|  16 | 8 | 5.07e-4 | 2.07e-4 | 2.45x |
|  48 | 4 | 3.94e-4 | 2.08e-4 | 1.90x |
| 128 | 1 | 2.08e-4 | 2.08e-4 | 1.00x (control) |

Real-kernel A/B on CUDA-graph replay: no perf LOSS at any shape. sk=1 exact no-op. One clean win at n=1792/sk=8 (**0.843x**, tight); mid-batch trends faster but with 10-20% DVFS spread on unpaired A/B (directional). Scratch bound: enumerated across all 228 selector entries — worst co-occurring is **N=4352, M=127, sk=4 → 2.108 MiB** per rank.

Delivered vs prior release on the served AWQ + fp8_e5m2 KV config: flat within noise — the suite's job here was NO REGRESSION on the config that barely touches Marlin's hot path. Ships as monico-vllm v0.1.4.

Files: `csrc/quantization/marlin/sm70_marlin_splitk.cuh` and per-bit-width launchers (`sm70_marlin_{u4,u4b8,u8,u8b128,fp8,mxfp4,nvfp4}_gemm.cu`).

---

### 2. `5c8da86` — AWQ non-turbomind fallback: route to triton dequant on SM70

Fixes silent garbage / NaN output for AWQ layers that fall back to `AWQLinearMethod` on V100 when `VLLM_SM70_QUANT_BACKEND=marlin` forces the Marlin backend and at least one linear layer is Marlin-INELIGIBLE.

**Problem.** `AWQLinearMethod.apply()` dispatches the non-TurboMind path on token count (threshold 256):
- `< 256` tokens → `ops.awq_gemm`
- `>= 256` tokens → `ops.awq_dequantize` + `torch.matmul`

Both classic kernels are broken on SM70, silently:
- `gemm_forward_4bit_cuda_m16nXk32` is `#if __CUDA_ARCH__ < 750 assert(false); #else <mma code> #endif`. In a **release (NDEBUG) build** the `assert` is compiled out, leaving an EMPTY kernel body on SM70. It launches, writes nothing, returns uninitialised memory (measured: nondeterministic — zeros one run, NaN the next).
- `dequantize_weights` has no arch guard but is ALSO broken on SM70: for an all-zero input it returns `[nan, 0, nan, 0, ...]` — half NaN.

Path is reachable **by design** — vLLM emits `warning_once("... Falling back to AWQ")` for exactly this fallback.

**Fix.** SM70-only branch in `apply()` routes through the arch-agnostic Triton dequant + matmul when `!current_platform.has_device_capability(75)`. SM75+ path byte-identical.

**Numbers.** rms(diff)/rms(ref) vs fp32 CPU reference on V100:

| M | path | unpatched | patched |
|---|---|---|---|
|   1 | else → awq_gemm | nan (nondeterministic) | 2.965e-04 |
| 300 | elif → awq_dequantize + matmul | nan | 2.804e-04 |

Both patched deviations are fp16-class error vs fp32 — i.e. correct. Delivered vs v0.1.1: prefill prompt tok/s **+2.87..+5.35%** at every rung, prefill TTFT p99 **-4.7..-13.4%** at every rung, decode throughput and TPOT improved at all seven measured rungs, nothing regressed. Ships as monico-vllm v0.1.3.

Cost: triton first-call warmup (one-time, maskable). SM75+ unaffected.

Files: `vllm/model_executor/layers/quantization/awq.py`.

---

Happy to split into two PRs if that's easier to review.