### PR TITLE
[Core] Accept Qwen3.8 SM70 release paths

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,7 +63,7 @@ endif()
 # requirements.txt files and should be kept consistent.  The ROCm torch
 # versions are derived from docker/Dockerfile.rocm
 #
-set(TORCH_SUPPORTED_VERSION_CUDA "2.11.0")
+set(TORCH_SUPPORTED_VERSION_CUDA "2.10.0")
 set(TORCH_SUPPORTED_VERSION_ROCM "2.11.0")
 
 #

--- a/benchmarks/benchmark_sm70_decode.py
+++ b/benchmarks/benchmark_sm70_decode.py
@@ -585,6 +585,14 @@ def _sm70_attention_policy(kv_cache_dtype: Any) -> dict[str, Any]:
         "VLLM_FLASH_V100_XQA_MTP5_PARTITION_SIZE",
         1024,
     )
+    g6_qk_pipeline = _env_bool(
+        "VLLM_FLASH_V100_XQA_G6_QK_PIPELINE",
+        True,
+    )
+    g6_qk_pipeline_warps = _env_int(
+        "VLLM_FLASH_V100_XQA_G6_QK_PIPELINE_WARPS",
+        8,
+    )
     decode_dynamic_partitions = _env_bool(
         "VLLM_FLASH_V100_DECODE_DYNAMIC_PARTITIONS",
         True,
@@ -660,6 +668,17 @@ def _sm70_attention_policy(kv_cache_dtype: Any) -> dict[str, Any]:
             "VLLM_FLASH_V100_XQA_MTP5_PARTITION_SIZE"
         ),
         "mtp5_xqa_partition_size_effective": mtp5_xqa_partition_size,
+        "VLLM_FLASH_V100_XQA_G6_QK_PIPELINE": os.environ.get(
+            "VLLM_FLASH_V100_XQA_G6_QK_PIPELINE"
+        ),
+        "g6_qk_pipeline_effective": g6_qk_pipeline,
+        "VLLM_FLASH_V100_XQA_G6_QK_PIPELINE_WARPS": os.environ.get(
+            "VLLM_FLASH_V100_XQA_G6_QK_PIPELINE_WARPS"
+        ),
+        "g6_qk_pipeline_warps_effective": g6_qk_pipeline_warps,
+        "g6_qk_pipeline_mid_only_policy": (
+            g6_qk_pipeline and g6_qk_pipeline_warps == 8
+        ),
         "exact_mtp5_fp8_p1024_dual_cta_policy": (
             smallq_decode_use_xqa
             and mtp5_xqa_dual_cta
@@ -1201,6 +1220,7 @@ def _enable_diagnostics_after_load() -> None:
 def _make_prompt_token_ids(
     tokenizer: Any,
     prompt_base: str,
+    prompt_suffix: str,
     input_len: int,
 ) -> list[int]:
     if input_len <= 0:
@@ -1209,11 +1229,15 @@ def _make_prompt_token_ids(
     chunk = tokenizer.encode(prompt_base, add_special_tokens=False)
     if not chunk:
         raise ValueError("--prompt-base produced no tokens")
+    suffix = tokenizer.encode(prompt_suffix, add_special_tokens=False)
+    if len(suffix) > input_len:
+        raise ValueError("--prompt-suffix is longer than --input-len")
 
     repeated: list[int] = []
-    while len(repeated) < input_len:
+    prefix_len = input_len - len(suffix)
+    while len(repeated) < prefix_len:
         repeated.extend(chunk)
-    return repeated[:input_len]
+    return repeated[:prefix_len] + suffix
 
 
 def _load_cases(args: argparse.Namespace) -> list[dict[str, Any]]:
@@ -1224,6 +1248,9 @@ def _load_cases(args: argparse.Namespace) -> list[dict[str, Any]]:
                 "input_len": args.input_len,
                 "output_len": args.output_len,
                 "prompt_base": args.prompt_base,
+                "prompt_suffix": args.prompt_suffix,
+                "warmup": args.warmup,
+                "repeat": args.repeat,
             }
         ]
 
@@ -1237,14 +1264,24 @@ def _load_cases(args: argparse.Namespace) -> list[dict[str, Any]]:
             raise ValueError(f"case {index} must be an object")
         input_len = int(raw_case.get("input_len", args.input_len))
         output_len = int(raw_case.get("output_len", args.output_len))
+        warmup = int(raw_case.get("warmup", args.warmup))
+        repeat = int(raw_case.get("repeat", args.repeat))
+        if warmup < 0:
+            raise ValueError(f"case {index} warmup must be non-negative")
+        if repeat <= 0:
+            raise ValueError(f"case {index} repeat must be positive")
         name = str(raw_case.get("name", f"case_{index}"))
         prompt_base = str(raw_case.get("prompt_base", args.prompt_base))
+        prompt_suffix = str(raw_case.get("prompt_suffix", args.prompt_suffix))
         cases.append(
             {
                 "name": name,
                 "input_len": input_len,
                 "output_len": output_len,
                 "prompt_base": prompt_base,
+                "prompt_suffix": prompt_suffix,
+                "warmup": warmup,
+                "repeat": repeat,
             }
         )
     return cases
@@ -1398,7 +1435,15 @@ def _diff_spec_metrics(
     )
 
 
-def _run_once(llm: Any, prompt: dict[str, list[int]], sampling_params: Any) -> dict:
+def _run_once(
+    llm: Any,
+    prompt: dict[str, list[int]],
+    sampling_params: Any,
+    *,
+    reset_prefix_cache: bool = False,
+) -> dict:
+    if reset_prefix_cache and not llm.reset_prefix_cache():
+        raise RuntimeError("Failed to reset the prefix cache before measurement.")
     request_prompt = {"prompt_token_ids": list(prompt["prompt_token_ids"])}
     spec_metrics_before = _spec_metrics_snapshot(llm)
     start = time.perf_counter()
@@ -1507,6 +1552,8 @@ def _write_results(
         "engine_kwargs": llm_kwargs,
         "sampling_params": first_case["sampling_params"],
         "cuda_profile_repeat": args.cuda_profile_repeat,
+        "reset_prefix_cache_before_case": args.reset_prefix_cache_before_case,
+        "reset_prefix_cache_between_runs": args.reset_prefix_cache_between_runs,
         "prompt": first_case["prompt"],
         "load_seconds": load_seconds,
         "warmups": first_case["warmups"],
@@ -1531,7 +1578,8 @@ def _parse_args() -> argparse.Namespace:
         type=Path,
         help=(
             "Optional JSON list of cases with name/input_len/output_len/"
-            "prompt_base. Loads the model once and runs every case."
+            "prompt_base/prompt_suffix/warmup/repeat. Loads the model once and "
+            "runs every case."
         ),
     )
     parser.add_argument("--warmup", type=int, default=1)
@@ -1545,10 +1593,36 @@ def _parse_args() -> argparse.Namespace:
         ),
     )
     parser.add_argument(
+        "--reset-prefix-cache-before-case",
+        action="store_true",
+        help=(
+            "Reset prefix and Mamba caches once before each case. Warmups are "
+            "cold, while measured repeats may reuse that case's prefix."
+        ),
+    )
+    parser.add_argument(
+        "--reset-prefix-cache-between-runs",
+        action="store_true",
+        help=(
+            "Reset prefix and Mamba caches before every warmup and measured "
+            "request. This preserves production Mamba align mode without "
+            "turning repeated benchmark prompts into prefix-cache hits."
+        ),
+    )
+    parser.add_argument(
         "--prompt-base",
         default=(
             "This fixed benchmark prompt is used to create a deterministic "
             "tokenized input for single-request decode measurement. "
+        ),
+    )
+    parser.add_argument(
+        "--prompt-suffix",
+        default="",
+        help=(
+            "Text kept at the end of every exact-length prompt. Use this for "
+            "a stable generation instruction while --prompt-base pads the "
+            "preceding context."
         ),
     )
     parser.add_argument("--temperature", type=float, default=0.0)
@@ -1615,6 +1689,10 @@ def main() -> int:
         raise ValueError("--repeat must be positive")
     if args.warmup < 0:
         raise ValueError("--warmup must be non-negative")
+    if args.reset_prefix_cache_before_case and args.reset_prefix_cache_between_runs:
+        raise ValueError(
+            "Choose only one prefix-cache reset mode: before-case or between-runs."
+        )
 
     import torch
     from transformers import AutoTokenizer
@@ -1632,6 +1710,7 @@ def main() -> int:
         prompt_token_ids = _make_prompt_token_ids(
             tokenizer,
             raw_case["prompt_base"],
+            raw_case["prompt_suffix"],
             raw_case["input_len"],
         )
         cases.append(
@@ -1682,10 +1761,6 @@ def main() -> int:
 
     case_results = []
     for case in cases:
-        warmups = [
-            _run_once(llm, case["prompt"], case["sampling_params"])
-            for _ in range(args.warmup)
-        ]
         case_results.append(
             {
                 "name": case["name"],
@@ -1705,13 +1780,30 @@ def main() -> int:
                     "logprobs": args.logprobs if args.logprobs != 0 else None,
                     "seed": args.seed,
                 },
-                "warmups": warmups,
+                "requested_warmups": case["warmup"],
+                "requested_repeats": case["repeat"],
+                "warmups": [],
                 "repeats": [],
                 "summary": {},
             }
         )
 
     if args.cuda_profile_repeat:
+        # Warm every case before starting the profiler so the capture contains
+        # measured repeats only. Normal sweeps warm each case immediately
+        # before measuring it, allowing checkpoints to be written promptly.
+        for case, result in zip(cases, case_results):
+            if args.reset_prefix_cache_before_case and not llm.reset_prefix_cache():
+                raise RuntimeError("Failed to reset the prefix cache before case.")
+            result["warmups"] = [
+                _run_once(
+                    llm,
+                    case["prompt"],
+                    case["sampling_params"],
+                    reset_prefix_cache=args.reset_prefix_cache_between_runs,
+                )
+                for _ in range(case["warmup"])
+            ]
         try:
             llm.start_profile()
         except Exception as exc:
@@ -1723,9 +1815,26 @@ def main() -> int:
             ) from exc
     try:
         for case, result in zip(cases, case_results):
+            if not args.cuda_profile_repeat:
+                if args.reset_prefix_cache_before_case and not llm.reset_prefix_cache():
+                    raise RuntimeError("Failed to reset the prefix cache before case.")
+                result["warmups"] = [
+                    _run_once(
+                        llm,
+                        case["prompt"],
+                        case["sampling_params"],
+                        reset_prefix_cache=args.reset_prefix_cache_between_runs,
+                    )
+                    for _ in range(case["warmup"])
+                ]
             repeats = [
-                _run_once(llm, case["prompt"], case["sampling_params"])
-                for _ in range(args.repeat)
+                _run_once(
+                    llm,
+                    case["prompt"],
+                    case["sampling_params"],
+                    reset_prefix_cache=args.reset_prefix_cache_between_runs,
+                )
+                for _ in range(case["repeat"])
             ]
             result["repeats"] = repeats
             result["summary"] = _summarize(repeats)

--- a/benchmarks/benchmark_sm70_model_tokens.py
+++ b/benchmarks/benchmark_sm70_model_tokens.py
@@ -793,6 +793,14 @@ def _sm70_attention_policy(kv_cache_dtype: Any) -> dict[str, Any]:
         "VLLM_FLASH_V100_XQA_MTP5_PARTITION_SIZE",
         1024,
     )
+    g6_qk_pipeline = _env_bool(
+        "VLLM_FLASH_V100_XQA_G6_QK_PIPELINE",
+        True,
+    )
+    g6_qk_pipeline_warps = _env_int(
+        "VLLM_FLASH_V100_XQA_G6_QK_PIPELINE_WARPS",
+        8,
+    )
     prefill_d256_output_stride_268 = _env_bool(
         "VLLM_FLASH_V100_PREFILL_D256_OUTPUT_STRIDE_268",
         True,
@@ -860,6 +868,17 @@ def _sm70_attention_policy(kv_cache_dtype: Any) -> dict[str, Any]:
             "VLLM_FLASH_V100_XQA_MTP5_PARTITION_SIZE"
         ),
         "mtp5_xqa_partition_size_effective": mtp5_xqa_partition_size,
+        "VLLM_FLASH_V100_XQA_G6_QK_PIPELINE": os.environ.get(
+            "VLLM_FLASH_V100_XQA_G6_QK_PIPELINE"
+        ),
+        "g6_qk_pipeline_effective": g6_qk_pipeline,
+        "VLLM_FLASH_V100_XQA_G6_QK_PIPELINE_WARPS": os.environ.get(
+            "VLLM_FLASH_V100_XQA_G6_QK_PIPELINE_WARPS"
+        ),
+        "g6_qk_pipeline_warps_effective": g6_qk_pipeline_warps,
+        "g6_qk_pipeline_mid_only_policy": (
+            g6_qk_pipeline and g6_qk_pipeline_warps == 8
+        ),
         "exact_mtp5_fp8_p1024_dual_cta_policy": (
             smallq_decode_use_xqa
             and mtp5_xqa_dual_cta

--- a/benchmarks/benchmark_sm70_model_tokens.py
+++ b/benchmarks/benchmark_sm70_model_tokens.py
@@ -464,6 +464,10 @@ def _sm70_turbomind_policy() -> dict[str, Any]:
         "VLLM_SM70_FP8_DENSE_GATED_SILU",
         True,
     )
+    fp8_prefill_exact_dense = _env_bool(
+        "VLLM_SM70_FP8_PREFILL_EXACT_DENSE",
+        True,
+    )
     nvfp4_turbomind = _env_bool("VLLM_SM70_NVFP4_TURBOMIND", False)
     mxfp4_turbomind = _env_bool("VLLM_SM70_MXFP4_TURBOMIND", False)
     fp8_dequant_fallback = _env_bool("VLLM_SM70_FP8_DEQUANT_FALLBACK", True)
@@ -516,6 +520,10 @@ def _sm70_turbomind_policy() -> dict[str, Any]:
             "VLLM_SM70_FP8_DENSE_GATED_SILU"
         ),
         "fp8_dense_gated_silu_effective": fp8_dense_gated_silu,
+        "VLLM_SM70_FP8_PREFILL_EXACT_DENSE": os.environ.get(
+            "VLLM_SM70_FP8_PREFILL_EXACT_DENSE"
+        ),
+        "fp8_prefill_exact_dense_effective": fp8_prefill_exact_dense,
         "VLLM_SM70_NVFP4_TURBOMIND": os.environ.get("VLLM_SM70_NVFP4_TURBOMIND"),
         "nvfp4_turbomind_effective": nvfp4_turbomind,
         "VLLM_SM70_MXFP4_TURBOMIND": os.environ.get("VLLM_SM70_MXFP4_TURBOMIND"),

--- a/csrc/ops.h
+++ b/csrc/ops.h
@@ -174,16 +174,10 @@ void fp8_gemm_sm70_out(torch::Tensor out,
                        int64_t q_ld,
                        bool gated_silu);
 
-void fp8_gemm_sm70_prefill_dispatch_out(torch::Tensor out,
-                                        torch::Tensor dense_weight,
-                                        torch::Tensor _in_feats,
-                                        torch::Tensor _kernel,
-                                        torch::Tensor _scaling_factors,
-                                        int64_t group_size,
-                                        int64_t k_ld,
-                                        int64_t q_ld,
-                                        bool gated_silu,
-                                        int64_t min_prefill_m);
+void fp8_gemm_sm70_prefill_dispatch_out(
+    torch::Tensor out, int64_t dense_weight_ptr, torch::Tensor _in_feats,
+    torch::Tensor _kernel, torch::Tensor _scaling_factors, int64_t group_size,
+    int64_t k_ld, int64_t q_ld, bool gated_silu, int64_t min_prefill_m);
 
 void mxfp4_gemm_sm70_out(torch::Tensor out,
                          torch::Tensor _in_feats,

--- a/csrc/ops.h
+++ b/csrc/ops.h
@@ -116,6 +116,11 @@ std::vector<torch::Tensor> fp8_sm70_prepare(torch::Tensor _kernel,
                                             int64_t group_size,
                                             bool interleave_gated_silu);
 
+void fp8_sm70_dequantize_out(torch::Tensor out,
+                             torch::Tensor _kernel,
+                             torch::Tensor _scaling_factors,
+                             int64_t group_size);
+
 std::vector<torch::Tensor> mxfp4_sm70_prepare(torch::Tensor _kernel,
                                               torch::Tensor _scaling_factors,
                                               int64_t group_size,
@@ -168,6 +173,17 @@ void fp8_gemm_sm70_out(torch::Tensor out,
                        int64_t k_ld,
                        int64_t q_ld,
                        bool gated_silu);
+
+void fp8_gemm_sm70_prefill_dispatch_out(torch::Tensor out,
+                                        torch::Tensor dense_weight,
+                                        torch::Tensor _in_feats,
+                                        torch::Tensor _kernel,
+                                        torch::Tensor _scaling_factors,
+                                        int64_t group_size,
+                                        int64_t k_ld,
+                                        int64_t q_ld,
+                                        bool gated_silu,
+                                        int64_t min_prefill_m);
 
 void mxfp4_gemm_sm70_out(torch::Tensor out,
                          torch::Tensor _in_feats,

--- a/csrc/sm70_turbomind/ops/awq_sm70_gemm.cu
+++ b/csrc/sm70_turbomind/ops/awq_sm70_gemm.cu
@@ -3519,7 +3519,7 @@ void fp8_gemm_sm70_out(torch::Tensor out, torch::Tensor in_feats,
 }
 
 void fp8_gemm_sm70_prefill_dispatch_out(
-    torch::Tensor out, torch::Tensor dense_weight, torch::Tensor in_feats,
+    torch::Tensor out, int64_t dense_weight_ptr, torch::Tensor in_feats,
     torch::Tensor tm_weight, torch::Tensor tm_scales, int64_t group_size,
     int64_t k_ld, int64_t q_ld, bool gated_silu, int64_t min_prefill_m) {
   if (in_feats.size(0) < min_prefill_m) {
@@ -3528,11 +3528,11 @@ void fp8_gemm_sm70_prefill_dispatch_out(
     return;
   }
 
-  TORCH_CHECK(in_feats.dim() == 2 && dense_weight.dim() == 2,
+  TORCH_CHECK(in_feats.dim() == 2 && dense_weight_ptr != 0,
               "SM70 FP8 prefill dispatch expects rank-2 input and workspace.");
-  TORCH_CHECK(dense_weight.size(0) == in_feats.size(1) &&
-                  dense_weight.size(1) == tm_weight.size(1),
-              "SM70 FP8 prefill dispatch workspace shape mismatch.");
+  auto dense_weight = torch::from_blob(
+      reinterpret_cast<void*>(dense_weight_ptr),
+      {in_feats.size(1), tm_weight.size(1)}, in_feats.options());
   fp8_sm70_dequantize_out(dense_weight, tm_weight, tm_scales, group_size);
   if (gated_silu) {
     auto gate_up = at::mm(in_feats, dense_weight);
@@ -4876,12 +4876,12 @@ void fp8_gemm_sm70_out(torch::Tensor out, torch::Tensor _in_feats,
 }
 
 void fp8_gemm_sm70_prefill_dispatch_out(
-    torch::Tensor out, torch::Tensor dense_weight, torch::Tensor _in_feats,
+    torch::Tensor out, int64_t dense_weight_ptr, torch::Tensor _in_feats,
     torch::Tensor _kernel, torch::Tensor _scaling_factors, int64_t group_size,
     int64_t k_ld, int64_t q_ld, bool gated_silu, int64_t min_prefill_m) {
   vllm::awq_sm70::fp8_gemm_sm70_prefill_dispatch_out(
-      out, dense_weight, _in_feats, _kernel, _scaling_factors, group_size, k_ld,
-      q_ld, gated_silu, min_prefill_m);
+      out, dense_weight_ptr, _in_feats, _kernel, _scaling_factors, group_size,
+      k_ld, q_ld, gated_silu, min_prefill_m);
 }
 
 void mxfp4_gemm_sm70_out(torch::Tensor out, torch::Tensor _in_feats,

--- a/csrc/sm70_turbomind/ops/awq_sm70_gemm.cu
+++ b/csrc/sm70_turbomind/ops/awq_sm70_gemm.cu
@@ -2368,6 +2368,109 @@ void awq_sm70_dequantize_out(torch::Tensor output, torch::Tensor packed_weight,
   C10_CUDA_KERNEL_LAUNCH_CHECK();
 }
 
+constexpr int kFp8PrefillDequantThreads = 256;
+constexpr int kFp8QuantValuesPerWord = 8;
+constexpr int kFp8OutputColumnsPerTile = 32;
+
+__global__ void fp8_sm70_dequantize_kernel(
+    __half* __restrict__ output, const uint8_t* __restrict__ packed_weight,
+    const __half* __restrict__ packed_scales, int k, int n, int group_size) {
+  const int64_t word_index =
+      static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  const int64_t word_count =
+      static_cast<int64_t>(k) * n / kFp8QuantValuesPerWord;
+  if (word_index >= word_count) {
+    return;
+  }
+
+  const int words_per_n_tile = k / kFp8QuantValuesPerWord;
+  const int n_in_tile =
+      static_cast<int>(word_index % kFp8OutputColumnsPerTile);
+  const int64_t tile_word = word_index / kFp8OutputColumnsPerTile;
+  const int k_word = static_cast<int>(tile_word % words_per_n_tile);
+  const int n_tile = static_cast<int>(tile_word / words_per_n_tile);
+  const int col = n_tile * kFp8OutputColumnsPerTile + n_in_tile;
+  const int k_base = k_word * kFp8QuantValuesPerWord;
+  const int group = k_base / group_size;
+
+  const uint2 quant = reinterpret_cast<const uint2*>(packed_weight)[word_index];
+  const auto& quant_lo = reinterpret_cast<
+      const turbomind::Array<turbomind::fp8_e4m3_t, 4>&>(quant.x);
+  const auto& quant_hi = reinterpret_cast<
+      const turbomind::Array<turbomind::fp8_e4m3_t, 4>&>(quant.y);
+  const auto half_lo = turbomind::cvt_f16x4_e4m3(quant_lo);
+  const auto half_hi = turbomind::cvt_f16x4_e4m3(quant_hi);
+  const __half scale = packed_scales[static_cast<int64_t>(group) * n + col];
+
+  // cvt_f16x4_e4m3 reverses the converter's physical [0, 2, 1, 3]
+  // byte order and returns each logical K4 in-order.
+  output[static_cast<int64_t>(k_base + 0) * n + col] =
+      __hmul(half_lo[0], scale);
+  output[static_cast<int64_t>(k_base + 1) * n + col] =
+      __hmul(half_lo[1], scale);
+  output[static_cast<int64_t>(k_base + 2) * n + col] =
+      __hmul(half_lo[2], scale);
+  output[static_cast<int64_t>(k_base + 3) * n + col] =
+      __hmul(half_lo[3], scale);
+  output[static_cast<int64_t>(k_base + 4) * n + col] =
+      __hmul(half_hi[0], scale);
+  output[static_cast<int64_t>(k_base + 5) * n + col] =
+      __hmul(half_hi[1], scale);
+  output[static_cast<int64_t>(k_base + 6) * n + col] =
+      __hmul(half_hi[2], scale);
+  output[static_cast<int64_t>(k_base + 7) * n + col] =
+      __hmul(half_hi[3], scale);
+}
+
+void fp8_sm70_dequantize_out(torch::Tensor output,
+                             torch::Tensor packed_weight,
+                             torch::Tensor packed_scales,
+                             int64_t group_size) {
+  TORCH_CHECK(
+      output.is_cuda() && packed_weight.is_cuda() && packed_scales.is_cuda(),
+      "SM70 FP8 prefill dequant expects CUDA tensors.");
+  TORCH_CHECK(output.scalar_type() == torch::kFloat16 &&
+                  packed_weight.scalar_type() == torch::kUInt8 &&
+                  packed_scales.scalar_type() == torch::kFloat16,
+              "SM70 FP8 prefill dequant dtype mismatch.");
+  TORCH_CHECK(
+      output.dim() == 2 && packed_weight.dim() == 2 && packed_scales.dim() == 2,
+      "SM70 FP8 prefill dequant expects rank-2 tensors.");
+  TORCH_CHECK(output.is_contiguous() && packed_weight.is_contiguous() &&
+                  packed_scales.is_contiguous(),
+              "SM70 FP8 prefill dequant expects contiguous tensors.");
+  TORCH_CHECK(group_size == 128,
+              "SM70 FP8 prefill dequant requires group_size=128.");
+
+  const at::cuda::OptionalCUDAGuard device_guard(device_of(output));
+  const int64_t k = output.size(0);
+  const int64_t n = output.size(1);
+  TORCH_CHECK(k % group_size == 0 &&
+                  k % kFp8QuantValuesPerWord == 0 &&
+                  n % kFp8OutputColumnsPerTile == 0,
+              "SM70 FP8 prefill dequant shape alignment mismatch.");
+  TORCH_CHECK(packed_weight.numel() == k * n,
+              "SM70 FP8 prefill packed-weight shape mismatch.");
+  TORCH_CHECK(
+      packed_scales.size(0) == k / group_size && packed_scales.size(1) == n,
+      "SM70 FP8 prefill packed-scale shape mismatch.");
+  TORCH_CHECK(output.device() == packed_weight.device() &&
+                  output.device() == packed_scales.device(),
+              "SM70 FP8 prefill tensors must share a device.");
+
+  const int64_t words = packed_weight.numel() / kFp8QuantValuesPerWord;
+  const int blocks = static_cast<int>(
+      (words + kFp8PrefillDequantThreads - 1) / kFp8PrefillDequantThreads);
+  fp8_sm70_dequantize_kernel<<<blocks, kFp8PrefillDequantThreads, 0,
+                               at::cuda::getCurrentCUDAStream()>>>(
+      reinterpret_cast<__half*>(output.data_ptr<at::Half>()),
+      packed_weight.data_ptr<uint8_t>(),
+      reinterpret_cast<const __half*>(packed_scales.data_ptr<at::Half>()),
+      static_cast<int>(k), static_cast<int>(n),
+      static_cast<int>(group_size));
+  C10_CUDA_KERNEL_LAUNCH_CHECK();
+}
+
 torch::Tensor interleave_gated_silu_cols(torch::Tensor tensor) {
   const int64_t n = tensor.size(-1);
   TORCH_CHECK((n % 2) == 0,
@@ -3413,6 +3516,31 @@ void fp8_gemm_sm70_out(torch::Tensor out, torch::Tensor in_feats,
                           desc_V, 0.f, out.data_ptr(), desc_D, out.data_ptr(),
                           desc_D, workspace_holder.workspace, stream);
   TORCH_CHECK(ec == 0, "fp8_gemm_sm70: TurboMind GEMM failed.");
+}
+
+void fp8_gemm_sm70_prefill_dispatch_out(
+    torch::Tensor out, torch::Tensor dense_weight, torch::Tensor in_feats,
+    torch::Tensor tm_weight, torch::Tensor tm_scales, int64_t group_size,
+    int64_t k_ld, int64_t q_ld, bool gated_silu, int64_t min_prefill_m) {
+  if (in_feats.size(0) < min_prefill_m) {
+    fp8_gemm_sm70_out(out, in_feats, tm_weight, tm_scales, group_size, k_ld,
+                      q_ld, gated_silu);
+    return;
+  }
+
+  TORCH_CHECK(in_feats.dim() == 2 && dense_weight.dim() == 2,
+              "SM70 FP8 prefill dispatch expects rank-2 input and workspace.");
+  TORCH_CHECK(dense_weight.size(0) == in_feats.size(1) &&
+                  dense_weight.size(1) == tm_weight.size(1),
+              "SM70 FP8 prefill dispatch workspace shape mismatch.");
+  fp8_sm70_dequantize_out(dense_weight, tm_weight, tm_scales, group_size);
+  if (gated_silu) {
+    auto gate_up = at::mm(in_feats, dense_weight);
+    sm70_silu_and_mul_interleaved_fp16_out(out, gate_up);
+    C10_CUDA_KERNEL_LAUNCH_CHECK();
+    return;
+  }
+  at::mm_out(out, in_feats, dense_weight);
 }
 
 void mxfp4_gemm_sm70_out(torch::Tensor out, torch::Tensor in_feats,
@@ -4678,6 +4806,13 @@ std::vector<torch::Tensor> fp8_sm70_prepare(torch::Tensor _kernel,
                                           interleave_gated_silu);
 }
 
+void fp8_sm70_dequantize_out(torch::Tensor out, torch::Tensor _kernel,
+                             torch::Tensor _scaling_factors,
+                             int64_t group_size) {
+  vllm::awq_sm70::fp8_sm70_dequantize_out(out, _kernel, _scaling_factors,
+                                          group_size);
+}
+
 std::vector<torch::Tensor> mxfp4_sm70_prepare(torch::Tensor _kernel,
                                               torch::Tensor _scaling_factors,
                                               int64_t group_size,
@@ -4738,6 +4873,15 @@ void fp8_gemm_sm70_out(torch::Tensor out, torch::Tensor _in_feats,
                        bool gated_silu) {
   vllm::awq_sm70::fp8_gemm_sm70_out(out, _in_feats, _kernel, _scaling_factors,
                                     group_size, k_ld, q_ld, gated_silu);
+}
+
+void fp8_gemm_sm70_prefill_dispatch_out(
+    torch::Tensor out, torch::Tensor dense_weight, torch::Tensor _in_feats,
+    torch::Tensor _kernel, torch::Tensor _scaling_factors, int64_t group_size,
+    int64_t k_ld, int64_t q_ld, bool gated_silu, int64_t min_prefill_m) {
+  vllm::awq_sm70::fp8_gemm_sm70_prefill_dispatch_out(
+      out, dense_weight, _in_feats, _kernel, _scaling_factors, group_size, k_ld,
+      q_ld, gated_silu, min_prefill_m);
 }
 
 void mxfp4_gemm_sm70_out(torch::Tensor out, torch::Tensor _in_feats,

--- a/csrc/torch_bindings.cpp
+++ b/csrc/torch_bindings.cpp
@@ -191,6 +191,12 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, ops) {
   ops.impl("fp8_sm70_prepare", torch::kCUDA, &fp8_sm70_prepare);
 
   ops.def(
+      "fp8_sm70_dequantize_out(Tensor(a!) out, Tensor _kernel, "
+      "Tensor _scaling_factors, int group_size) -> ()");
+  ops.impl("fp8_sm70_dequantize_out", torch::kCUDA,
+           &fp8_sm70_dequantize_out);
+
+  ops.def(
       "mxfp4_sm70_prepare(Tensor _kernel, Tensor _scaling_factors, "
       "int group_size, bool interleave_gated_silu) -> Tensor[]");
   ops.impl("mxfp4_sm70_prepare", torch::kCUDA, &mxfp4_sm70_prepare);
@@ -230,6 +236,14 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, ops) {
       "Tensor _scaling_factors, int group_size, int k_ld, int q_ld, "
       "bool gated_silu) -> ()");
   ops.impl("fp8_gemm_sm70_out", torch::kCUDA, &fp8_gemm_sm70_out);
+
+  ops.def(
+      "fp8_gemm_sm70_prefill_dispatch_out(Tensor(a!) out, "
+      "Tensor(b!) dense_weight, Tensor _in_feats, Tensor _kernel, "
+      "Tensor _scaling_factors, int group_size, int k_ld, int q_ld, "
+      "bool gated_silu, int min_prefill_m) -> ()");
+  ops.impl("fp8_gemm_sm70_prefill_dispatch_out", torch::kCUDA,
+           &fp8_gemm_sm70_prefill_dispatch_out);
 
   ops.def(
       "mxfp4_gemm_sm70_out(Tensor(a!) out, Tensor _in_feats, Tensor _kernel, "

--- a/csrc/torch_bindings.cpp
+++ b/csrc/torch_bindings.cpp
@@ -239,7 +239,7 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, ops) {
 
   ops.def(
       "fp8_gemm_sm70_prefill_dispatch_out(Tensor(a!) out, "
-      "Tensor(b!) dense_weight, Tensor _in_feats, Tensor _kernel, "
+      "int dense_weight_ptr, Tensor _in_feats, Tensor _kernel, "
       "Tensor _scaling_factors, int group_size, int k_ld, int q_ld, "
       "bool gated_silu, int min_prefill_m) -> ()");
   ops.impl("fp8_gemm_sm70_prefill_dispatch_out", torch::kCUDA,

--- a/docs/design/sm70_fp8_long_prefill_exact_dense.md
+++ b/docs/design/sm70_fp8_long_prefill_exact_dense.md
@@ -23,6 +23,15 @@ The accepted implementation places the M decision in the opaque CUDA op
 layout into one shared 85 MiB FP16 KxN workspace, then uses `mm_out` or the
 exact gated-SiLU epilogue. M below 3920 stays in TurboMind.
 
+The first implementation passed a view of that workspace as a Tensor argument.
+Inductor lifted the large Tensor into the compiled graph and CUDA graph input
+handling reduced 1K/256 single-request throughput from about 60 to 19 tok/s;
+graph memory also grew from 0.26 to about 0.42 GiB/rank. The corrected ABI
+passes the stable CUDA address as an integer. A process-global strong reference
+keeps one workspace alive per device, and the C++ op only wraps that address for
+M at or above the threshold. Small-M decode returns to TurboMind before the
+workspace is wrapped.
+
 The default allowlist is TP4 plus the exact `(K,N)` shape for
 `gate_up_proj`, `down_proj`, `out_proj`, and `o_proj`. `qkv_proj` and
 `in_proj_qkvz` remain excluded because direct dense evaluation changed FP16
@@ -52,6 +61,19 @@ Matched chunk-15680 control and candidate requests preserve output hashes.
 | 128K | 53.575 s | 2446.5 |
 | 256K* | 163.472 s | 1602.0 |
 
+The corrected pointer ABI preserves decode and concurrency performance. These
+results use 64 independent 1K/256 requests per row and official sampling. Each
+row completed 64/64 requests; concurrency 4 was repeated because its first run
+measured 188.68 tok/s.
+
+| Concurrency | Output tok/s | Scale vs C1 | Parallel efficiency | Mean TPOT | P99 TPOT |
+|---:|---:|---:|---:|---:|---:|
+| 1 | 60.44 | 1.00x | 100.0% | 15.16 ms | 15.32 ms |
+| 2 | 108.72 | 1.80x | 89.9% | 16.29 ms | 17.13 ms |
+| 4 | 192.39 | 3.18x | 79.6% | 16.88 ms | 19.58 ms |
+| 8 | 309.70 | 5.12x | 64.0% | 18.16 ms | 24.55 ms |
+| 16 | 412.35 | 6.82x | 42.6% | 23.03 ms | 38.57 ms |
+
 The remembered 128K/256K reference was Qwen3.6-27B-AWQ without prefix
 caching: 2517.6/1655.0 tok/s, not a same-model Qwen3.8-FP8 result. The current
 Qwen3.8 production contract is within 2.8%/3.2% of that cross-model reference.
@@ -62,8 +84,15 @@ Qwen3.8 production contract is within 2.8%/3.2% of that cross-model reference.
   projections.
 - 32K, 128K, and 256K candidate output hashes exactly match their controls.
   All short-sweep repeats also have stable hashes and `is_corrupted=false`.
+- The pointer-ABI microbenchmark is bitwise equal at M=1 and M=3920. M=1 is
+  0.01636 ms direct versus 0.01666 ms through dispatch; M=3920 is 1.062 ms
+  direct versus 0.800 ms through dispatch (1.33x).
+- A 6278-token natural prompt follows its final instruction, emits coherent
+  text, and stops naturally after 47 tokens on the corrected full-graph path.
 - Model residency is 7.57 GiB/rank. The 85 MiB shared workspace leaves
   19.18 GiB/rank for KV and an estimated 4.70x 256K cache capacity.
+- CUDA graph capture uses 0.26 GiB/rank after the pointer fix, matching the
+  exact-dense-off control instead of the regressed 0.42 GiB/rank path.
 - Compiled microbenchmarks prove both M=784 and M=3920 reach the same runtime
   dispatch op. M3920 and M7840 improve 1.31x and 1.46x with zero mismatch.
 
@@ -81,3 +110,4 @@ Qwen3.8 production contract is within 2.8%/3.2% of that cross-model reference.
 - Candidate short sweep: `/data/minimax-h3/task-cache/qwen38-130-prefill-recovery-20260815/candidate-dispatch/results/short-1k-64k.json`
 - Candidate long sweep: `/data/minimax-h3/task-cache/qwen38-130-prefill-recovery-20260815/candidate-dispatch/results/long-128k-256k.json`
 - Route trace: `/data/minimax-h3/task-cache/qwen38-130-prefill-recovery-20260815/candidate-dispatch/nsys/qwen38_fp8_dispatch_tp4_i32k_r2.nsys-rep`
+- Decode/concurrency regression fix: `/data/minimax-h3/task-cache/qwen38-130-concurrency-latest-20260815`

--- a/docs/design/sm70_fp8_long_prefill_exact_dense.md
+++ b/docs/design/sm70_fp8_long_prefill_exact_dense.md
@@ -1,0 +1,83 @@
+# SM70 FP8 Long-Prefill Exact-Dense Projections
+
+Date: 2026-08-15
+
+## Scope
+
+This route accelerates Qwen3.8-27B-FP8 TP4 prefill on four V100-32GB GPUs.
+The accepted contract uses Python 3.12, Torch 2.10.0+cu128, FP16 KV,
+Flash-V100, prefix caching with Mamba align, CUDA graphs, no MTP, and
+`max_num_batched_tokens=15680`.
+
+## Root Cause
+
+The earlier Flash-V100 gather/exact-D256 attention route was active. The
+missing gain was in large-M FP8 projections: TurboMind's W8A16 kernel is the
+correct decode and tail path, but the 32K Nsight trace attributed 68.4% of
+summed FP8 projection time to it. A first Python `M >= 3920` branch was also
+invalid because the dynamic compile range folded the branch during tracing;
+the measured request still launched 3648 TurboMind calls and no dense GEMM.
+
+The accepted implementation places the M decision in the opaque CUDA op
+`fp8_gemm_sm70_prefill_dispatch_out`. It reconstructs TurboMind's K8/N32 FP8
+layout into one shared 85 MiB FP16 KxN workspace, then uses `mm_out` or the
+exact gated-SiLU epilogue. M below 3920 stays in TurboMind.
+
+The default allowlist is TP4 plus the exact `(K,N)` shape for
+`gate_up_proj`, `down_proj`, `out_proj`, and `o_proj`. `qkv_proj` and
+`in_proj_qkvz` remain excluded because direct dense evaluation changed FP16
+outputs. The environment rollback is
+`VLLM_SM70_FP8_PREFILL_EXACT_DENSE=0`.
+
+## Performance
+
+Matched chunk-15680 control and candidate requests preserve output hashes.
+
+| Input | Control prefill | Candidate prefill | Control tok/s | Candidate tok/s | Throughput gain |
+|---:|---:|---:|---:|---:|---:|
+| 32K | 11.024 s | 9.010 s | 2972.3 | 3636.7 | 22.36% |
+| 128K | 60.507 s | 53.575 s | 2166.2 | 2446.5 | 12.94% |
+| 256K* | 175.323 s | 163.472 s | 1493.7 | 1602.0 | 7.25% |
+
+`256K*` uses 261888 prompt tokens. The final sustained sweep is:
+
+| Input | Mean prefill | Prompt tok/s |
+|---:|---:|---:|
+| 1K | 0.407 s | 2515.1 |
+| 4K | 1.065 s | 3847.8 |
+| 8K | 2.199 s | 3725.4 |
+| 16K | 4.199 s | 3901.6 |
+| 32K | 9.533 s | 3437.2 |
+| 64K | 22.981 s | 2851.7 |
+| 128K | 53.575 s | 2446.5 |
+| 256K* | 163.472 s | 1602.0 |
+
+The remembered 128K/256K reference was Qwen3.6-27B-AWQ without prefix
+caching: 2517.6/1655.0 tok/s, not a same-model Qwen3.8-FP8 result. The current
+Qwen3.8 production contract is within 2.8%/3.2% of that cross-model reference.
+
+## Correctness And Memory
+
+- 72 real-weight rank/shape/M checks are bitwise equal for all admitted
+  projections.
+- 32K, 128K, and 256K candidate output hashes exactly match their controls.
+  All short-sweep repeats also have stable hashes and `is_corrupted=false`.
+- Model residency is 7.57 GiB/rank. The 85 MiB shared workspace leaves
+  19.18 GiB/rank for KV and an estimated 4.70x 256K cache capacity.
+- Compiled microbenchmarks prove both M=784 and M=3920 reach the same runtime
+  dispatch op. M3920 and M7840 improve 1.31x and 1.46x with zero mismatch.
+
+## Closed Paths
+
+- Do not restore a Python dynamic-M branch; `torch.compile` can fold it.
+- Do not include QKV shapes without a new bitwise proof.
+- Extending dense split-KV3 from Q4096 to Q15680 gives only 0.85%-1.80%
+  attention-kernel gain, needs about 290 MiB/rank of FP32 workspace, and is
+  not bitwise. It is not promoted.
+
+## Evidence
+
+- Control: `/data/minimax-h3/task-cache/qwen38-130-prefill-recovery-20260815/results/chunk15680-long-sweep.json`
+- Candidate short sweep: `/data/minimax-h3/task-cache/qwen38-130-prefill-recovery-20260815/candidate-dispatch/results/short-1k-64k.json`
+- Candidate long sweep: `/data/minimax-h3/task-cache/qwen38-130-prefill-recovery-20260815/candidate-dispatch/results/long-128k-256k.json`
+- Route trace: `/data/minimax-h3/task-cache/qwen38-130-prefill-recovery-20260815/candidate-dispatch/nsys/qwen38_fp8_dispatch_tp4_i32k_r2.nsys-rep`

--- a/docs/design/sm70_qwen38_130_acceptance.md
+++ b/docs/design/sm70_qwen38_130_acceptance.md
@@ -30,22 +30,27 @@ Date: 2026-08-15
 - The benchmark harness records official sampling, generated-token count,
   natural-stop state, TTFT/prefill, pure decode TPOT, acceptance length, route
   policy, and token hashes.
+- Large-M TP4 FP8 gate/up/down/output projections now use a compile-safe
+  runtime exact-dense dispatch with one shared 85 MiB workspace. Decode,
+  tails, and numerically unsafe QKV shapes retain TurboMind.
 
 ## No-MTP Long Context
 
-The FP16-KV production sweep uses repeated official-sampling requests. The
-FP8-KV sweep uses a generation suffix and produces 256 tokens at every point.
+The FP16-KV prefill column is the final no-MTP chunk-15680 route. The 1K-64K
+rows are two-repeat cold-cache means; 128K and 256K are one cold-cache request.
+Decode columns retain the official-sampling release sweep. The FP8-KV sweep
+uses a generation suffix and produces 256 tokens at every point.
 
 | Context | FP16 KV prefill tok/s | FP16 KV decode tok/s | FP8 KV prefill tok/s | FP8 KV decode tok/s |
 |---:|---:|---:|---:|---:|
-| 1K | 2550.2 | 65.05 | 3430.8 | 66.36 |
-| 4K | 3093.7 | 63.35 | 3591.3 | 65.61 |
-| 8K | 2884.0 | 64.04 | 2995.9 | 65.50 |
-| 16K | 2677.8 | 63.90 | 2797.0 | 65.36 |
-| 32K | 2341.9 | 60.07* | 2516.2 | 59.97 |
-| 64K | 1995.8 | 58.44* | 2063.4 | 52.30 |
-| 128K | 1501.6 | 46.95 | 1519.6 | 42.35 |
-| 256K | 1004.7 | 36.96 | 1007.1 | 31.49 |
+| 1K | 2515.1 | 65.05 | 3430.8 | 66.36 |
+| 4K | 3847.8 | 63.35 | 3591.3 | 65.61 |
+| 8K | 3725.4 | 64.04 | 2995.9 | 65.50 |
+| 16K | 3901.6 | 63.90 | 2797.0 | 65.36 |
+| 32K | 3437.2 | 60.07* | 2516.2 | 59.97 |
+| 64K | 2851.7 | 58.44* | 2063.4 | 52.30 |
+| 128K | 2446.5 | 46.95 | 1519.6 | 42.35 |
+| 256K | 1602.0 | 36.96 | 1007.1 | 31.49 |
 
 `*` The FP16-KV 32K and 64K requests naturally stopped after 2 and 17 output
 tokens. Keep those rows as route checks, not high-confidence decode means.
@@ -117,3 +122,6 @@ Artifacts are rooted at
 `/data/minimax-h3/task-cache/qwen38-130-acceptance-20260815`. Retained groups
 are `context/`, `concurrency/`, `mtp/`, `correctness/`, `profiles/nsys/`,
 `compat/`, `build/final-wheel/`, and `logs/`.
+
+The corrected FP8 prefill implementation, A/B results, and retained profiles
+are documented in `docs/design/sm70_fp8_long_prefill_exact_dense.md`.

--- a/docs/design/sm70_qwen38_130_acceptance.md
+++ b/docs/design/sm70_qwen38_130_acceptance.md
@@ -31,8 +31,9 @@ Date: 2026-08-15
   natural-stop state, TTFT/prefill, pure decode TPOT, acceptance length, route
   policy, and token hashes.
 - Large-M TP4 FP8 gate/up/down/output projections now use a compile-safe
-  runtime exact-dense dispatch with one shared 85 MiB workspace. Decode,
-  tails, and numerically unsafe QKV shapes retain TurboMind.
+  runtime exact-dense dispatch with one shared 85 MiB workspace. The workspace
+  address is passed as an integer so it is not copied into compiled graph
+  inputs. Decode, tails, and numerically unsafe QKV shapes retain TurboMind.
 
 ## No-MTP Long Context
 
@@ -71,19 +72,23 @@ no counter-derived bottleneck claim is made for this release.
 ## Concurrency
 
 All rows use 64 requests of exact 1K input and 256 output tokens with official
-sampling. Every request completed successfully.
+sampling. Prompt seeds differ between rows to prevent cross-row prefix-cache
+reuse. Every request completed successfully.
 
-| Concurrency | Old output tok/s | Accepted output tok/s | Gain | Mean TPOT |
-|---:|---:|---:|---:|---:|
-| 1 | 59.90 | 60.06 | +0.27% | 15.24 ms |
-| 2 | 107.13 | 107.00 | -0.12% | 16.47 ms |
-| 4 | 51.08 | 193.66 | +279.15% | 16.79 ms |
-| 8 | 95.60 | 296.35 | +209.99% | 18.48 ms |
-| 16 | 167.49 | 383.00 | +128.68% | 26.90 ms |
+| Concurrency | Prior accepted tok/s | Current tok/s | Change | Scale | Efficiency | Mean / P99 TPOT |
+|---:|---:|---:|---:|---:|---:|---:|
+| 1 | 60.06 | 60.44 | +0.63% | 1.00x | 100.0% | 15.16 / 15.32 ms |
+| 2 | 107.00 | 108.72 | +1.61% | 1.80x | 89.9% | 16.29 / 17.13 ms |
+| 4 | 193.66 | 192.39 | -0.65% | 3.18x | 79.6% | 16.88 / 19.58 ms |
+| 8 | 296.35 | 309.70 | +4.50% | 5.12x | 64.0% | 18.16 / 24.55 ms |
+| 16 | 383.00 | 412.35 | +7.66% | 6.82x | 42.6% | 23.03 / 38.57 ms |
 
-At concurrency 16 all four GPUs remain at 100% SM busy and about 51-52%
-memory busy. Remaining non-linear scaling is a saturated high-M kernel issue,
-not an idle-GPU or missing graph-shape issue.
+The first concurrency-4 run measured 188.68 tok/s; its independent repeat
+measured 192.39 tok/s and is reported above. Across the timed intervals all
+four V100s average 98.0-99.8% SM busy. Average memory busy falls from 50.7% at
+concurrency 1 to 38.3% at concurrency 16 while power rises from 194.7 to
+229.8 W/GPU. Remaining non-linear scaling is a high-M execution-efficiency
+issue, not an idle-GPU or missing graph-shape issue.
 
 ## MTP And Quality
 
@@ -99,6 +104,9 @@ not an idle-GPU or missing graph-shape issue.
   and `node --check`. One long stochastic seed repeated after about 6377 tokens;
   another bounded run naturally stopped at 7894 tokens. Treat this as a model
   sampling risk, not deterministic token or HTML-tag corruption.
+- The corrected FP8 workspace ABI passes a 6278-token natural prompt: it
+  follows the final four-line instruction, emits no replacement characters,
+  and stops naturally after 47 tokens.
 
 ## Wheel And Compatibility
 
@@ -125,3 +133,5 @@ are `context/`, `concurrency/`, `mtp/`, `correctness/`, `profiles/nsys/`,
 
 The corrected FP8 prefill implementation, A/B results, and retained profiles
 are documented in `docs/design/sm70_fp8_long_prefill_exact_dense.md`.
+The pointer-fix and concurrency artifacts are rooted at
+`/data/minimax-h3/task-cache/qwen38-130-concurrency-latest-20260815`.

--- a/docs/design/sm70_qwen38_130_acceptance.md
+++ b/docs/design/sm70_qwen38_130_acceptance.md
@@ -1,0 +1,119 @@
+# SM70 Qwen3.8-27B 1.3.0 Acceptance
+
+Date: 2026-08-15
+
+## Contract
+
+- Model: `Qwen3.8-27B-FP8`, TP4 on four V100-32GB GPUs.
+- Runtime: Python 3.12, Torch 2.10.0+cu128, CUDA 12.8, CUDA graphs enabled.
+- Production attention: `FLASH_ATTN_V100`; no eager or Marlin performance
+  evidence is accepted.
+- Official sampling is `temperature=1.0`, `top_p=0.95`, `top_k=20`.
+- Main long-context configuration uses 262144 tokens, chunked prefill, Mamba
+  align mode, and prefix caching. Speed tables use no MTP unless stated.
+
+## Accepted Changes
+
+- The G6 XQA QK producer/consumer pipeline is default-on only for the proven
+  111104-147840 token range. The final range keeps the prior kernel. At 128K,
+  full-model TPOT improves from 21.292 to 20.293 ms (-4.69%) with the same
+  token hash; the 256K route is neutral within 0.16%.
+- No-MTP CUDA graph capture now covers request shapes 1, 2, 4, 8, and 16,
+  bounded by `max_num_seqs`. This fixes the severe eager fallback above two
+  concurrent requests for 0.07 GiB/rank additional graph memory.
+- Qwen3.8 does not reuse the Qwen3.6 dynamic-draft-vocabulary asset. The
+  implicit asset is now restricted to model paths containing `qwen3.6-27b`;
+  Qwen3.8 MTP therefore fails closed to the full vocabulary.
+- FlashQLA SM70 is compiled into the wheel. Runtime first tries the packaged
+  extension and only source installs may fall back to JIT, with fixed SM70/75
+  gencode and retained first-error diagnostics.
+- The benchmark harness records official sampling, generated-token count,
+  natural-stop state, TTFT/prefill, pure decode TPOT, acceptance length, route
+  policy, and token hashes.
+
+## No-MTP Long Context
+
+The FP16-KV production sweep uses repeated official-sampling requests. The
+FP8-KV sweep uses a generation suffix and produces 256 tokens at every point.
+
+| Context | FP16 KV prefill tok/s | FP16 KV decode tok/s | FP8 KV prefill tok/s | FP8 KV decode tok/s |
+|---:|---:|---:|---:|---:|
+| 1K | 2550.2 | 65.05 | 3430.8 | 66.36 |
+| 4K | 3093.7 | 63.35 | 3591.3 | 65.61 |
+| 8K | 2884.0 | 64.04 | 2995.9 | 65.50 |
+| 16K | 2677.8 | 63.90 | 2797.0 | 65.36 |
+| 32K | 2341.9 | 60.07* | 2516.2 | 59.97 |
+| 64K | 1995.8 | 58.44* | 2063.4 | 52.30 |
+| 128K | 1501.6 | 46.95 | 1519.6 | 42.35 |
+| 256K | 1004.7 | 36.96 | 1007.1 | 31.49 |
+
+`*` The FP16-KV 32K and 64K requests naturally stopped after 2 and 17 output
+tokens. Keep those rows as route checks, not high-confidence decode means.
+
+The 128K Nsight Systems graph-node trace attributes 21.30 ms TPOT to:
+
+| Category | Time | Share |
+|---|---:|---:|
+| FP8 TurboMind dense GEMM | 8.946 ms | 42.1% |
+| Flash-V100 q=1 XQA | 5.274 ms | 25.2% |
+| TP all-reduce | 1.874 ms | 8.6% |
+| LM head, sample, and gather | 1.301 ms | 6.2% |
+| Other graph work and gaps | about 3.6 ms | 17.9% |
+
+NCU counter collection is unavailable on this host (`ERR_NVGPUCTRPERM`), so
+no counter-derived bottleneck claim is made for this release.
+
+## Concurrency
+
+All rows use 64 requests of exact 1K input and 256 output tokens with official
+sampling. Every request completed successfully.
+
+| Concurrency | Old output tok/s | Accepted output tok/s | Gain | Mean TPOT |
+|---:|---:|---:|---:|---:|
+| 1 | 59.90 | 60.06 | +0.27% | 15.24 ms |
+| 2 | 107.13 | 107.00 | -0.12% | 16.47 ms |
+| 4 | 51.08 | 193.66 | +279.15% | 16.79 ms |
+| 8 | 95.60 | 296.35 | +209.99% | 18.48 ms |
+| 16 | 167.49 | 383.00 | +128.68% | 26.90 ms |
+
+At concurrency 16 all four GPUs remain at 100% SM busy and about 51-52%
+memory busy. Remaining non-linear scaling is a saturated high-M kernel issue,
+not an idle-GPU or missing graph-shape issue.
+
+## MTP And Quality
+
+- Full-vocabulary MTP4, FP8 KV, 128K: 58.25 tok/s, 17.168 ms TPOT,
+  acceptance length 3.866, 256 valid output tokens.
+- Full-vocabulary MTP4, FP16 KV, 128K: 55.40 tok/s, 18.051 ms TPOT,
+  acceptance length 4.031, 256 valid output tokens.
+- Exact 256K boundary (`input_len=262120`, 24 outputs), MTP4 plus FP8 KV:
+  all token IDs are legal, `is_corrupted=false`, and acceptance length is 4.0.
+- Tool-call JSON and streaming tool calls parse correctly. A repeated 3136-token
+  prefix records a cache hit and reduces request latency from 1.965 to 1.152 s.
+- HTML/JavaScript quality prompts pass structural checks, natural-stop checks,
+  and `node --check`. One long stochastic seed repeated after about 6377 tokens;
+  another bounded run naturally stopped at 7894 tokens. Treat this as a model
+  sampling risk, not deterministic token or HTML-tag corruption.
+
+## Wheel And Compatibility
+
+- Wheel: `1cat_vllm-1.3.0-cp312-cp312-linux_x86_64.whl`.
+- SHA256: `df4275918461c67cb8af2c489a097cf5c7424e37706396267690094007eafdab`.
+- A cloned environment imports vLLM 1.3.0 from site-packages with Torch
+  2.10.0+cu128. `_moe_C.moe_permute_sort_workspace_size` is present.
+- The wheel contains `_C`, `_C_stable_libtorch`, `_moe_C`, Flash-V100,
+  vLLM FA2, and `flash_qla_sm70_gdn_strided.so`.
+- A clean-cache MTP4 plus FP8-KV boundary run does not create
+  `TORCH_EXTENSIONS_DIR`, proving FlashQLA does not invoke NVCC at runtime.
+- Qwen3.6-35B-A3B-AWQ TP2 final-wheel checks pass. Official 1K/256 and
+  4K/1024 pure decode are 95.63 and 95.29 tok/s (10.457 and 10.494 ms TPOT),
+  with complete, non-corrupted outputs and the TurboMind AWQ MoE route.
+- No Qwen3.6-35B-A3B-FP8 checkpoint is available on this host. FP8 35B speed
+  remains unmeasured and must not be inferred from AWQ or 27B results.
+
+## Evidence
+
+Artifacts are rooted at
+`/data/minimax-h3/task-cache/qwen38-130-acceptance-20260815`. Retained groups
+are `context/`, `concurrency/`, `mtp/`, `correctness/`, `profiles/nsys/`,
+`compat/`, `build/final-wheel/`, and `logs/`.

--- a/docs/design/sm70_v100_migration_control.md
+++ b/docs/design/sm70_v100_migration_control.md
@@ -41229,3 +41229,16 @@ Interpretation:
 - Evidence is under `workspace-production/` in the retained task artifact
   directory. The rollback remains
   `VLLM_SM70_AWQ_PREFILL_EXACT_DENSE=0`.
+
+## 2026-08-15 Qwen3.8-27B 1.3.0 release acceptance
+
+- Accepted Qwen3.8-27B-FP8 TP4 no-MTP long-context, concurrency, MTP4,
+  FP8-KV, exact-256K-boundary, API quality, and final-wheel gates.
+- Defaulted the proven mid-range G6 XQA QK pipeline, extended no-MTP graph
+  request shapes through 16, restricted the Qwen3.6 draft-vocabulary asset so
+  Qwen3.8 uses full vocabulary, and bundled FlashQLA SM70 into the wheel.
+- Qwen3.6-35B-A3B-AWQ TP2 loads from the final wheel and passes official
+  1K/256 and 4K/1024 checks. No 35B FP8 checkpoint is available, so that speed
+  target remains explicitly unmeasured.
+- Full configuration, performance tables, quality evidence, limitations, and
+  artifact paths are in `docs/design/sm70_qwen38_130_acceptance.md`.

--- a/docs/design/sm70_v100_migration_control.md
+++ b/docs/design/sm70_v100_migration_control.md
@@ -41242,3 +41242,17 @@ Interpretation:
   target remains explicitly unmeasured.
 - Full configuration, performance tables, quality evidence, limitations, and
   artifact paths are in `docs/design/sm70_qwen38_130_acceptance.md`.
+
+## 2026-08-15 Qwen3.8 FP8 compile-safe long-prefill projections
+
+- Fixed a false route hit where `torch.compile` folded a Python large-M
+  branch and left every measured FP8 projection on TurboMind. The accepted
+  opaque CUDA op selects TurboMind below M3920 and exact dense above it.
+- The default is restricted to TP4 gate/up/down/output shapes. It uses one
+  shared 85 MiB FP16 workspace; QKV, decode, and tails remain unchanged.
+- Matched 32K/128K/256K throughput improves 22.36%/12.94%/7.25% with exact
+  control output hashes. Final 128K/256K prefill is 2446.5/1602.0 tok/s.
+- Q15680 split-KV3 was rejected: only 0.85%-1.80% attention gain, about
+  290 MiB/rank extra workspace, and non-bitwise output.
+- Detailed route gates, full sweep, tests, rejected paths, and artifacts are
+  in `docs/design/sm70_fp8_long_prefill_exact_dense.md`.

--- a/flash-attention-v100/kernel/flash_decode_paged.cu
+++ b/flash-attention-v100/kernel/flash_decode_paged.cu
@@ -47,6 +47,8 @@ constexpr int kXQARouteShortSeqLens = -1;
 constexpr int kXQARouteLongSeqLens = 1;
 constexpr int kXQARouteP1024Sawtooth = 4;
 constexpr int kXQARouteP256Sawtooth = 5;
+constexpr int kXQARouteP1024SawtoothMid = 6;
+constexpr int kXQARouteP1024SawtoothFinal = 7;
 // The dense 256/128-half strides alias Volta shared-memory banks in the
 // WMMA A/B fragment loads. Both padded strides remain 16-byte aligned.
 constexpr int kXQATC256WidePaddedQStride = 264;
@@ -177,7 +179,7 @@ bool decode_partition_size_overridden() {
 
 bool xqa_g6_qk_pipeline_enabled() {
   const char* value = std::getenv("VLLM_FLASH_V100_XQA_G6_QK_PIPELINE");
-  return value != nullptr && value[0] == '1';
+  return value == nullptr || value[0] != '0';
 }
 
 int xqa_g6_qk_pipeline_warps() {
@@ -297,6 +299,10 @@ __device__ __forceinline__ bool xqa_seq_len_route_active(
   } else if constexpr (SEQ_LEN_ROUTE == kXQARouteP256Sawtooth) {
     return seq_len < route_seq_len_begin ||
            (seq_len >= route_seq_len_end && seq_len < route_seq_len_final);
+  } else if constexpr (SEQ_LEN_ROUTE == kXQARouteP1024SawtoothMid) {
+    return seq_len >= route_seq_len_begin && seq_len < route_seq_len_end;
+  } else if constexpr (SEQ_LEN_ROUTE == kXQARouteP1024SawtoothFinal) {
+    return seq_len >= route_seq_len_final;
   }
   return true;
 }
@@ -2609,7 +2615,8 @@ at::Tensor flash_attention_decode_paged_xqa(
       !traced_g6_qk_pipeline) {
     TORCH_WARN(
         "Flash-V100 XQA G6 fp16-KV QK K64 producer/consumer "
-        "pipeline active; warps=",
+        "pipeline active for the mid p1024 range with baseline final-range "
+        "fallback; warps=",
         g6_qk_pipeline_warps);
     traced_g6_qk_pipeline = true;
   }
@@ -2662,7 +2669,7 @@ at::Tensor flash_attention_decode_paged_xqa(
       if (g6_qk_pipeline_warps == 8) {
         launch_flash_attention_decode_paged_xqa_tc_256_wide<
             1024, 6, false, kXQATCG6Pipeline8WarpThreads, 2, 784, false, false,
-            kXQARouteP1024Sawtooth, true>(
+            kXQARouteP1024SawtoothMid, true>(
             q, k_cache, v_cache, out, block_table, seq_lens, tmp_out,
             max_logits, exp_sums, active_num_partitions, softmax_scale, k_scale,
             v_scale, p1024_launch_num_partitions, false, split_reduce_dim_tile,
@@ -2672,7 +2679,7 @@ at::Tensor flash_attention_decode_paged_xqa(
       } else {
         launch_flash_attention_decode_paged_xqa_tc_256_wide<
             1024, 6, false, kXQATCG6DualCtaThreads, 2, 784, false, false,
-            kXQARouteP1024Sawtooth, true>(
+            kXQARouteP1024SawtoothMid, true>(
             q, k_cache, v_cache, out, block_table, seq_lens, tmp_out,
             max_logits, exp_sums, active_num_partitions, softmax_scale, k_scale,
             v_scale, p1024_launch_num_partitions, false, split_reduce_dim_tile,
@@ -2680,6 +2687,15 @@ at::Tensor flash_attention_decode_paged_xqa(
             g6_p1024_sawtooth_p256_long_seq_len,
             g6_p1024_sawtooth_p1024_final_seq_len, false);
       }
+      launch_flash_attention_decode_paged_xqa_tc_256_wide<
+          1024, 6, false, kXQATCG6DualCtaThreads, 2, 784, false, false,
+          kXQARouteP1024SawtoothFinal>(
+          q, k_cache, v_cache, out, block_table, seq_lens, tmp_out, max_logits,
+          exp_sums, active_num_partitions, softmax_scale, k_scale, v_scale,
+          p1024_launch_num_partitions, false, split_reduce_dim_tile, stream,
+          g6_p1024_sawtooth_p1024_mid_seq_len,
+          g6_p1024_sawtooth_p256_long_seq_len,
+          g6_p1024_sawtooth_p1024_final_seq_len, false);
     } else {
       launch_flash_attention_decode_paged_xqa_tc_256_wide<
           1024, 6, false, kXQATCG6DualCtaThreads, 2, 784, false, false,

--- a/flash_qla/ops/gated_delta_rule/chunk/sm70/fused_fwd.py
+++ b/flash_qla/ops/gated_delta_rule/chunk/sm70/fused_fwd.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import importlib
 import os
 from pathlib import Path
 
@@ -10,24 +11,61 @@ import torch
 from torch.utils.cpp_extension import load
 
 _EXT = None
+_EXT_LOAD_ERROR: Exception | None = None
+_PREBUILT_EXTENSION = (
+    "flash_qla.ops.gated_delta_rule.chunk.sm70.flash_qla_sm70_gdn_strided"
+)
+
+# Avoid CUDA-device auto-detection while distributed workers are initializing.
+# The fallback JIT supports both architectures implemented by this source file.
+_SM70_GENCODE_FLAGS = [
+    "-gencode=arch=compute_70,code=sm_70",
+    "-gencode=arch=compute_75,code=sm_75",
+]
 
 
 def _load_ext():
-    global _EXT
+    global _EXT, _EXT_LOAD_ERROR
     if _EXT is not None:
         return _EXT
+    if _EXT_LOAD_ERROR is not None:
+        raise RuntimeError(
+            "SM70 FlashQLA extension initialization previously failed. "
+            "The original loader or compiler error is chained below."
+        ) from _EXT_LOAD_ERROR
     if not torch.cuda.is_available():
         raise RuntimeError("SM70 FlashQLA backend requires CUDA.")
 
-    os.environ.setdefault("TORCH_CUDA_ARCH_LIST", "7.0;7.5")
+    try:
+        _EXT = importlib.import_module(_PREBUILT_EXTENSION)
+        return _EXT
+    except ModuleNotFoundError as exc:
+        if exc.name != _PREBUILT_EXTENSION:
+            _EXT_LOAD_ERROR = exc
+            raise RuntimeError(
+                "Bundled SM70 FlashQLA extension has a missing dependency."
+            ) from exc
+    except Exception as exc:
+        _EXT_LOAD_ERROR = exc
+        raise RuntimeError(
+            "Bundled SM70 FlashQLA extension failed to load. Reinstall a wheel "
+            "built for the active CUDA and PyTorch versions."
+        ) from exc
+
     src = Path(__file__).with_name("csrc") / "gdn_forward.cu"
-    _EXT = load(
-        name="flash_qla_sm70_gdn_strided",
-        sources=[str(src)],
-        extra_cuda_cflags=["-O3"],
-        extra_cflags=["-O3"],
-        verbose=bool(int(os.environ.get("FLASH_QLA_SM70_VERBOSE_BUILD", "0"))),
-    )
+    try:
+        _EXT = load(
+            name="flash_qla_sm70_gdn_strided",
+            sources=[str(src)],
+            extra_cuda_cflags=["-O3", *_SM70_GENCODE_FLAGS],
+            extra_cflags=["-O3"],
+            verbose=bool(int(os.environ.get("FLASH_QLA_SM70_VERBOSE_BUILD", "0"))),
+        )
+    except Exception as exc:
+        # PyTorch's process-local extension versioner may skip a retry after a
+        # failed build and only report a missing .so. Preserve the first error.
+        _EXT_LOAD_ERROR = exc
+        raise
     return _EXT
 
 

--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,9 @@ logger = logging.getLogger(__name__)
 PRECOMPILED_RUST_FRONTEND_PATH = ROOT_DIR / "vllm" / "vllm-rs"
 FLASH_ATTN_V100_ROOT = ROOT_DIR / "flash-attention-v100"
 FLASH_ATTN_V100_PACKAGE = FLASH_ATTN_V100_ROOT / "flash_attn_v100"
+FLASH_QLA_SM70_ROOT = (
+    ROOT_DIR / "flash_qla" / "ops" / "gated_delta_rule" / "chunk" / "sm70"
+)
 ONECAT_TORCH_CU128_URLS = {
     "torch==2.10.0": (
         "torch @ https://download.pytorch.org/whl/cu128/"
@@ -205,6 +208,50 @@ def bundle_flash_attn_v100(build_lib: str) -> None:
         dst_ext = dst_pkg / matches[-1].name
         shutil.copy2(matches[-1], dst_ext)
         remove_rpath(dst_ext)
+
+
+def bundle_flash_qla_sm70(build_lib: str, build_temp: str) -> None:
+    """Precompile the SM70 GDN extension so runtime never requires NVCC."""
+    if not _cuda_arch_contains(7, 0):
+        return
+
+    src = FLASH_QLA_SM70_ROOT / "csrc" / "gdn_forward.cu"
+    if not src.exists():
+        raise RuntimeError(f"SM70 FlashQLA source is missing: {src}")
+
+    from torch.utils.cpp_extension import load as load_torch_extension
+
+    extension_build_dir = Path(build_temp) / "flash_qla_sm70_gdn_strided"
+    extension_build_dir.mkdir(parents=True, exist_ok=True)
+    previous_arch_list = os.environ.get("TORCH_CUDA_ARCH_LIST")
+    os.environ["TORCH_CUDA_ARCH_LIST"] = "7.0"
+    try:
+        extension = load_torch_extension(
+            name="flash_qla_sm70_gdn_strided",
+            sources=[str(src)],
+            build_directory=str(extension_build_dir),
+            extra_cuda_cflags=[
+                "-O3",
+                "-gencode=arch=compute_70,code=sm_70",
+            ],
+            extra_cflags=["-O3"],
+            with_cuda=True,
+            verbose=bool(int(os.environ.get("FLASH_QLA_SM70_VERBOSE_BUILD", "0"))),
+        )
+    finally:
+        if previous_arch_list is None:
+            os.environ.pop("TORCH_CUDA_ARCH_LIST", None)
+        else:
+            os.environ["TORCH_CUDA_ARCH_LIST"] = previous_arch_list
+
+    dst_pkg = (
+        Path(build_lib) / "flash_qla" / "ops" / "gated_delta_rule" / "chunk" / "sm70"
+    )
+    dst_pkg.mkdir(parents=True, exist_ok=True)
+    dst_ext = dst_pkg / Path(extension.__file__).name
+    shutil.copy2(extension.__file__, dst_ext)
+    remove_rpath(dst_ext)
+    logger.info("Bundled SM70 FlashQLA extension into wheel: %s", dst_ext)
 
 
 def remove_rpath(path: Path) -> None:
@@ -424,6 +471,7 @@ class cmake_build_ext(build_ext):
 
         if _is_cuda():
             bundle_flash_attn_v100(self.build_lib)
+            bundle_flash_qla_sm70(self.build_lib, self.build_temp)
 
         # copy vllm/vllm_flash_attn/**/*.py from self.build_lib to current
         # directory so that they can be included in the editable build
@@ -1224,6 +1272,7 @@ package_data = {
     "flash_qla": [
         "LICENSE",
         "ops/gated_delta_rule/chunk/sm70/csrc/*.cu",
+        "ops/gated_delta_rule/chunk/sm70/*.so",
     ],
     "flash_attn_v100": [
         "*.so",

--- a/tests/entrypoints/test_cli.py
+++ b/tests/entrypoints/test_cli.py
@@ -1,0 +1,18 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import subprocess
+import sys
+
+from vllm.version import __version__
+
+
+def test_cli_version_uses_package_version():
+    result = subprocess.run(
+        [sys.executable, "-m", "vllm.entrypoints.cli.main", "--version"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.stdout.strip() == __version__

--- a/tests/kernels/core/test_layernorm.py
+++ b/tests/kernels/core/test_layernorm.py
@@ -234,3 +234,37 @@ def test_sm70_gemma_long_prefill_fused_add_rms_norm_exact(
 
     assert torch.equal(normalized, expected_normalized)
     assert torch.equal(residual_out, expected_residual)
+
+
+@pytest.mark.parametrize("num_tokens", [1, 5, 18])
+@pytest.mark.parametrize("weight_dtype", [torch.float16, torch.bfloat16, torch.float32])
+@torch.inference_mode()
+def test_sm70_gemma_long_prefill_op_small_shape_fallback_exact(
+    num_tokens: int,
+    weight_dtype: torch.dtype,
+) -> None:
+    if not torch.cuda.is_available() or torch.cuda.get_device_capability() != (7, 0):
+        pytest.skip("SM70 CUDA device required")
+
+    torch.manual_seed(20260814)
+    x = torch.randn(num_tokens, 5120, device="cuda", dtype=torch.float16).mul_(0.125)
+    residual = torch.randn(num_tokens, 5120, device="cuda", dtype=torch.float32).mul_(
+        0.125
+    )
+    weight = torch.randn(5120, device="cuda", dtype=torch.float32).mul_(0.05)
+    weight = weight.to(weight_dtype)
+
+    expected_normalized, expected_residual = GemmaRMSNorm._forward_static_with_residual(
+        weight, 1e-6, x, residual
+    )
+    normalized, residual_out = (
+        torch.ops.vllm.sm70_gemma_long_prefill_fused_add_rms_norm(
+            x,
+            residual,
+            weight,
+            1e-6,
+        )
+    )
+
+    assert torch.equal(normalized, expected_normalized)
+    assert torch.equal(residual_out, expected_residual)

--- a/tests/kernels/mamba/test_sm70_flashqla_extension.py
+++ b/tests/kernels/mamba/test_sm70_flashqla_extension.py
@@ -1,0 +1,80 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Unit tests for the SM70 FlashQLA extension loader."""
+
+from __future__ import annotations
+
+from types import ModuleType
+
+import pytest
+
+from flash_qla.ops.gated_delta_rule.chunk.sm70 import fused_fwd
+
+
+@pytest.fixture(autouse=True)
+def reset_extension_load_state(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(fused_fwd, "_EXT", None)
+    monkeypatch.setattr(fused_fwd, "_EXT_LOAD_ERROR", None)
+    monkeypatch.setattr(fused_fwd.torch.cuda, "is_available", lambda: True)
+
+
+def test_sm70_flashqla_prefers_bundled_extension(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    bundled = ModuleType("flash_qla_sm70_gdn_strided")
+    monkeypatch.setattr(fused_fwd.importlib, "import_module", lambda name: bundled)
+    monkeypatch.setattr(
+        fused_fwd,
+        "load",
+        lambda **kwargs: pytest.fail("JIT fallback must not run"),
+    )
+
+    assert fused_fwd._load_ext() is bundled
+
+
+def test_sm70_flashqla_jit_fallback_uses_fixed_arches(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    loaded = ModuleType("flash_qla_sm70_gdn_strided")
+    load_kwargs = {}
+
+    def missing_bundled(name: str):
+        error = ModuleNotFoundError(name=name)
+        raise error
+
+    def fake_load(**kwargs):
+        load_kwargs.update(kwargs)
+        return loaded
+
+    monkeypatch.setattr(fused_fwd.importlib, "import_module", missing_bundled)
+    monkeypatch.setattr(fused_fwd, "load", fake_load)
+
+    assert fused_fwd._load_ext() is loaded
+    assert load_kwargs["extra_cuda_cflags"] == [
+        "-O3",
+        "-gencode=arch=compute_70,code=sm_70",
+        "-gencode=arch=compute_75,code=sm_75",
+    ]
+
+
+def test_sm70_flashqla_retains_bundled_loader_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    initial_error = OSError("undefined symbol")
+    import_calls = 0
+
+    def failing_import(name: str):
+        nonlocal import_calls
+        import_calls += 1
+        raise initial_error
+
+    monkeypatch.setattr(fused_fwd.importlib, "import_module", failing_import)
+
+    with pytest.raises(RuntimeError, match="failed to load") as first_error:
+        fused_fwd._load_ext()
+    assert first_error.value.__cause__ is initial_error
+
+    with pytest.raises(RuntimeError, match="previously failed") as retry_error:
+        fused_fwd._load_ext()
+    assert retry_error.value.__cause__ is initial_error
+    assert import_calls == 1

--- a/tests/quantization/test_sm70_fp8_prefill_exact_dense.py
+++ b/tests/quantization/test_sm70_fp8_prefill_exact_dense.py
@@ -80,7 +80,7 @@ def test_fp8_prefill_dispatch_reaches_runtime_op_for_small_and_large_m(monkeypat
 
     def fake_dispatch(
         out,
-        dense_weight,
+        dense_weight_ptr,
         input,
         qweight,
         scales,
@@ -90,6 +90,7 @@ def test_fp8_prefill_dispatch_reaches_runtime_op_for_small_and_large_m(monkeypat
         gated_silu,
         min_prefill_m,
     ):
+        assert dense_weight_ptr == 42
         calls.append((input.shape[0], min_prefill_m, gated_silu))
         out.zero_()
 
@@ -106,7 +107,7 @@ def test_fp8_prefill_dispatch_reaches_runtime_op_for_small_and_large_m(monkeypat
         weight_scale_inv=torch.empty((1, 6), dtype=torch.float16),
         sm70_fp8_k_ld=4,
         sm70_fp8_q_ld=6,
-        _sm70_fp8_prefill_exact_dense_workspace=torch.empty(24, dtype=torch.float16),
+        sm70_fp8_prefill_exact_dense_workspace_ptr=42,
     )
     method = SimpleNamespace()
 

--- a/tests/quantization/test_sm70_fp8_prefill_exact_dense.py
+++ b/tests/quantization/test_sm70_fp8_prefill_exact_dense.py
@@ -1,0 +1,126 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+
+import torch
+
+import vllm.envs as envs
+from vllm.model_executor.layers.quantization.fp8 import (
+    _SM70_FP8_PREFILL_DENSE_MIN_M,
+    _SM70_FP8_PREFILL_DENSE_WORKSPACE_BYTES,
+    Fp8LinearMethod,
+    _get_sm70_fp8_prefill_exact_dense_workspace,
+    _is_sm70_fp8_prefill_exact_dense_layer,
+    _sm70_fp8_prefill_dense_workspaces,
+)
+
+
+def test_fp8_prefill_exact_dense_is_default_on(monkeypatch):
+    monkeypatch.delenv("VLLM_SM70_FP8_PREFILL_EXACT_DENSE", raising=False)
+    envs.disable_envs_cache()
+    try:
+        assert envs.VLLM_SM70_FP8_PREFILL_EXACT_DENSE
+    finally:
+        envs.disable_envs_cache()
+
+
+def test_fp8_prefill_exact_dense_shape_gate_is_narrow():
+    layer = SimpleNamespace(
+        tp_size=4,
+        prefix="model.language_model.layers.1.mlp.gate_up_proj",
+        weight=SimpleNamespace(shape=(5120, 8704)),
+    )
+
+    assert _is_sm70_fp8_prefill_exact_dense_layer(layer)
+
+    layer.tp_size = 2
+    assert not _is_sm70_fp8_prefill_exact_dense_layer(layer)
+    layer.tp_size = 4
+    layer.prefix = "model.language_model.layers.1.self_attn.qkv_proj"
+    layer.weight = SimpleNamespace(shape=(5120, 3584))
+    assert not _is_sm70_fp8_prefill_exact_dense_layer(layer)
+    layer.prefix = "model.language_model.layers.1.linear_attn.in_proj_qkvz"
+    layer.weight = SimpleNamespace(shape=(5120, 4096))
+    assert not _is_sm70_fp8_prefill_exact_dense_layer(layer)
+    layer.prefix = "model.language_model.layers.1.mlp.gate_up_proj"
+    layer.weight = SimpleNamespace(shape=(5120, 8192))
+    assert not _is_sm70_fp8_prefill_exact_dense_layer(layer)
+
+
+def test_fp8_prefill_exact_dense_workspace_is_bounded():
+    assert _SM70_FP8_PREFILL_DENSE_WORKSPACE_BYTES == 85 * 1024**2
+
+
+def test_fp8_prefill_exact_dense_workspace_is_reused(monkeypatch):
+    workspace = torch.empty(1, dtype=torch.float16)
+    allocations = []
+
+    def fake_empty(shape, *, dtype, device):
+        allocations.append((shape, dtype, device))
+        return workspace
+
+    _sm70_fp8_prefill_dense_workspaces.clear()
+    monkeypatch.setattr(torch, "empty", fake_empty)
+    weight = SimpleNamespace(device=torch.device("cuda:0"))
+
+    try:
+        first = _get_sm70_fp8_prefill_exact_dense_workspace(weight)
+        second = _get_sm70_fp8_prefill_exact_dense_workspace(weight)
+
+        assert first is workspace
+        assert second is workspace
+        assert len(allocations) == 1
+    finally:
+        _sm70_fp8_prefill_dense_workspaces.clear()
+
+
+def test_fp8_prefill_dispatch_reaches_runtime_op_for_small_and_large_m(monkeypatch):
+    calls = []
+
+    def fake_dispatch(
+        out,
+        dense_weight,
+        input,
+        qweight,
+        scales,
+        group_size,
+        k_ld,
+        q_ld,
+        gated_silu,
+        min_prefill_m,
+    ):
+        calls.append((input.shape[0], min_prefill_m, gated_silu))
+        out.zero_()
+
+    monkeypatch.setattr(
+        "vllm.model_executor.layers.quantization.fp8.sm70_ops."
+        "fp8_gemm_sm70_prefill_dispatch_out",
+        fake_dispatch,
+    )
+    layer = SimpleNamespace(
+        sm70_fp8_turbomind=True,
+        sm70_fp8_bmm=False,
+        output_size_per_partition=6,
+        weight=torch.empty((4, 6), dtype=torch.uint8),
+        weight_scale_inv=torch.empty((1, 6), dtype=torch.float16),
+        sm70_fp8_k_ld=4,
+        sm70_fp8_q_ld=6,
+        _sm70_fp8_prefill_exact_dense_workspace=torch.empty(24, dtype=torch.float16),
+    )
+    method = SimpleNamespace()
+
+    for m in (1, _SM70_FP8_PREFILL_DENSE_MIN_M):
+        output = Fp8LinearMethod.apply(
+            method, layer, torch.empty((m, 4), dtype=torch.float16)
+        )
+        assert output.shape == (m, 6)
+
+    assert calls == [
+        (1, _SM70_FP8_PREFILL_DENSE_MIN_M, False),
+        (
+            _SM70_FP8_PREFILL_DENSE_MIN_M,
+            _SM70_FP8_PREFILL_DENSE_MIN_M,
+            False,
+        ),
+    ]

--- a/tests/test_envs.py
+++ b/tests/test_envs.py
@@ -122,7 +122,7 @@ def test_flash_v100_g6_sawtooth_pipeline_envs(
     bool_defaults = {
         "VLLM_FLASH_V100_XQA_G6_P1024_SAWTOOTH": True,
         "VLLM_FLASH_V100_XQA_G6_P1024_SAWTOOTH_TRACE": False,
-        "VLLM_FLASH_V100_XQA_G6_QK_PIPELINE": False,
+        "VLLM_FLASH_V100_XQA_G6_QK_PIPELINE": True,
         "VLLM_FLASH_V100_XQA_G6_QK_PIPELINE_TRACE": False,
     }
     int_defaults = {

--- a/tests/v1/attention/test_sm70_flash_v100_policy.py
+++ b/tests/v1/attention/test_sm70_flash_v100_policy.py
@@ -241,6 +241,29 @@ def test_prefill_gather_dense_does_not_require_generic_dense_op(monkeypatch):
     assert impl.use_flash_v100_prefill_gather_dense is True
 
 
+def test_flash_v100_normalizes_resolved_float16_cache_dtype(monkeypatch):
+    import vllm.v1.attention.backends.flash_attn_v100 as flash_v100
+
+    monkeypatch.setattr(flash_v100, "_get_flash_ops", lambda: (None,) * 9)
+    monkeypatch.setattr(
+        flash_v100,
+        "_get_fp8_e5m2_paged_kv_bridge_op",
+        lambda: None,
+    )
+
+    impl = flash_v100.FlashAttnV100Impl(
+        num_heads=4,
+        head_size=256,
+        scale=1.0,
+        num_kv_heads=1,
+        alibi_slopes=None,
+        sliding_window=None,
+        kv_cache_dtype="float16",
+    )
+
+    assert impl.kv_cache_dtype == "auto"
+
+
 def test_prefill_gather_dense_reorders_random_pages_and_reuses_workspace(
     monkeypatch,
 ):

--- a/tests/v1/attention/test_sm70_flash_v100_policy.py
+++ b/tests/v1/attention/test_sm70_flash_v100_policy.py
@@ -853,7 +853,11 @@ def test_flash_v100_smallq_cudagraph_metadata_uses_persistent_buffers(
 
     assert torch.equal(
         capture_metadata.smallq_decode_seq_lens,
-        torch.tensor([1, 2, 3, 4], dtype=torch.int32),
+        torch.tensor(
+            [1, 2, 3, 4],
+            dtype=torch.int32,
+            device=capture_metadata.smallq_decode_seq_lens.device,
+        ),
     )
 
     runtime_common = create_common_attn_metadata(
@@ -1010,7 +1014,11 @@ def test_flash_v100_smallq_metadata_masks_cudagraph_padding(
 
     assert torch.equal(
         attn_metadata.smallq_decode_seq_lens,
-        torch.tensor([6, 7, 8, 6, 7, 0], dtype=torch.int32),
+        torch.tensor(
+            [6, 7, 8, 6, 7, 0],
+            dtype=torch.int32,
+            device=attn_metadata.smallq_decode_seq_lens.device,
+        ),
     )
     assert torch.equal(
         attn_metadata.smallq_decode_block_table[-1],
@@ -1064,6 +1072,28 @@ def test_flash_v100_smallq_replay_shape_overflow_fails_fast(
 
     with pytest.raises(RuntimeError, match="persistent buffer capacity"):
         builder.build(0, runtime_common)
+
+
+@pytest.mark.parametrize(
+    ("max_num_seqs", "expected"),
+    [
+        (1, [1, 2]),
+        (2, [1, 2]),
+        (3, [1, 2, 3]),
+        (4, [1, 2, 4]),
+        (8, [1, 2, 4, 8]),
+        (12, [1, 2, 4, 8, 12]),
+        (16, [1, 2, 4, 8, 16]),
+        (256, [1, 2, 4, 8, 16]),
+    ],
+)
+def test_sm70_nomtp_cudagraph_capture_sizes_cover_concurrency(
+    max_num_seqs: int,
+    expected: list[int],
+):
+    from vllm.config.vllm import _sm70_nomtp_cudagraph_capture_sizes
+
+    assert _sm70_nomtp_cudagraph_capture_sizes(max_num_seqs) == expected
 
 
 def test_flash_v100_decode_query_does_not_attach_smallq_metadata(

--- a/tests/v1/spec_decode/test_static_draft_vocab.py
+++ b/tests/v1/spec_decode/test_static_draft_vocab.py
@@ -36,7 +36,9 @@ def test_dynamic_draft_vocab_is_the_default_mtp_route(monkeypatch) -> None:
     monkeypatch.setenv("VLLM_SM70_MTP_DYNAMIC_DRAFT_VOCAB_DEFAULT", "1")
 
     config = resolve_mtp_draft_vocab_config(
-        "mtp", model_architecture="Qwen3_5ForConditionalGeneration"
+        "mtp",
+        model_architecture="Qwen3_5ForConditionalGeneration",
+        model_name_or_path="Qwen/Qwen3.6-27B",
     )
 
     assert config.using_defaults
@@ -67,6 +69,7 @@ def test_dynamic_draft_vocab_default_selects_tp4_asset(monkeypatch) -> None:
         "mtp",
         tensor_parallel_size=4,
         model_architecture="Qwen3_5ForConditionalGeneration",
+        model_name_or_path="/models/Qwen3.6-27B-AWQ",
     )
 
     assert config.using_defaults
@@ -87,15 +90,20 @@ def test_dynamic_draft_vocab_default_can_be_disabled(monkeypatch) -> None:
 
 
 @pytest.mark.parametrize(
-    ("model_architecture", "tensor_parallel_size"),
+    ("model_architecture", "tensor_parallel_size", "model_name_or_path"),
     [
-        ("DeepseekV4ForCausalLM", 8),
-        ("Qwen3_5ForConditionalGeneration", 8),
-        ("Qwen3_5MoeForConditionalGeneration", 4),
+        ("DeepseekV4ForCausalLM", 8, "deepseek-ai/DeepSeek-V4"),
+        ("Qwen3_5ForConditionalGeneration", 8, "Qwen/Qwen3.6-27B"),
+        ("Qwen3_5MoeForConditionalGeneration", 4, "Qwen/Qwen3.6-35B-A3B"),
+        ("Qwen3_5ForConditionalGeneration", 4, "Qwen/Qwen3.8-27B"),
+        ("Qwen3_5ForConditionalGeneration", 4, None),
     ],
 )
 def test_dynamic_draft_vocab_default_is_model_and_tp_specific(
-    monkeypatch, model_architecture: str, tensor_parallel_size: int
+    monkeypatch,
+    model_architecture: str,
+    tensor_parallel_size: int,
+    model_name_or_path: str | None,
 ) -> None:
     monkeypatch.setenv("VLLM_SM70_MTP_DYNAMIC_DRAFT_VOCAB_DEFAULT", "1")
 
@@ -103,6 +111,7 @@ def test_dynamic_draft_vocab_default_is_model_and_tp_specific(
         "mtp",
         tensor_parallel_size=tensor_parallel_size,
         model_architecture=model_architecture,
+        model_name_or_path=model_name_or_path,
     )
 
     assert not config.using_defaults

--- a/vllm/_sm70_ops.py
+++ b/vllm/_sm70_ops.py
@@ -423,7 +423,7 @@ if hasattr(torch.ops._C, "fp8_gemm_sm70_out"):
 
 def fp8_gemm_sm70_prefill_dispatch_out(
     out: torch.Tensor,
-    dense_weight: torch.Tensor,
+    dense_weight_ptr: int,
     input: torch.Tensor,
     qweight: torch.Tensor,
     scales: torch.Tensor,
@@ -435,7 +435,7 @@ def fp8_gemm_sm70_prefill_dispatch_out(
 ) -> None:
     _op("fp8_gemm_sm70_prefill_dispatch_out")(
         out,
-        dense_weight,
+        dense_weight_ptr,
         input,
         qweight,
         scales,
@@ -452,7 +452,7 @@ if hasattr(torch.ops._C, "fp8_gemm_sm70_prefill_dispatch_out"):
     @register_fake("_C::fp8_gemm_sm70_prefill_dispatch_out")
     def _fp8_gemm_sm70_prefill_dispatch_out_fake(
         out: torch.Tensor,
-        dense_weight: torch.Tensor,
+        dense_weight_ptr: int,
         input: torch.Tensor,
         qweight: torch.Tensor,
         scales: torch.Tensor,
@@ -462,6 +462,7 @@ if hasattr(torch.ops._C, "fp8_gemm_sm70_prefill_dispatch_out"):
         gated_silu: bool,
         min_prefill_m: int,
     ) -> None:
+        del dense_weight_ptr
         return None
 
 

--- a/vllm/_sm70_ops.py
+++ b/vllm/_sm70_ops.py
@@ -170,6 +170,28 @@ if hasattr(torch.ops._C, "fp8_sm70_prepare"):
         return [tm_weight, tm_scales, meta]
 
 
+def fp8_sm70_dequantize_out(
+    out: torch.Tensor,
+    qweight: torch.Tensor,
+    scales: torch.Tensor,
+    group_size: int,
+) -> None:
+    _op("fp8_sm70_dequantize_out")(out, qweight, scales, group_size)
+
+
+if hasattr(torch.ops._C, "fp8_sm70_dequantize_out"):
+
+    @register_fake("_C::fp8_sm70_dequantize_out")
+    def _fp8_sm70_dequantize_out_fake(
+        out: torch.Tensor,
+        qweight: torch.Tensor,
+        scales: torch.Tensor,
+        group_size: int,
+    ) -> None:
+        del out, qweight, scales, group_size
+        return None
+
+
 def mxfp4_sm70_prepare(
     qweight: torch.Tensor,
     scales: torch.Tensor,
@@ -395,6 +417,50 @@ if hasattr(torch.ops._C, "fp8_gemm_sm70_out"):
         k_ld: int,
         q_ld: int,
         gated_silu: bool,
+    ) -> None:
+        return None
+
+
+def fp8_gemm_sm70_prefill_dispatch_out(
+    out: torch.Tensor,
+    dense_weight: torch.Tensor,
+    input: torch.Tensor,
+    qweight: torch.Tensor,
+    scales: torch.Tensor,
+    group_size: int,
+    k_ld: int,
+    q_ld: int,
+    gated_silu: bool,
+    min_prefill_m: int,
+) -> None:
+    _op("fp8_gemm_sm70_prefill_dispatch_out")(
+        out,
+        dense_weight,
+        input,
+        qweight,
+        scales,
+        group_size,
+        k_ld,
+        q_ld,
+        gated_silu,
+        min_prefill_m,
+    )
+
+
+if hasattr(torch.ops._C, "fp8_gemm_sm70_prefill_dispatch_out"):
+
+    @register_fake("_C::fp8_gemm_sm70_prefill_dispatch_out")
+    def _fp8_gemm_sm70_prefill_dispatch_out_fake(
+        out: torch.Tensor,
+        dense_weight: torch.Tensor,
+        input: torch.Tensor,
+        qweight: torch.Tensor,
+        scales: torch.Tensor,
+        group_size: int,
+        k_ld: int,
+        q_ld: int,
+        gated_silu: bool,
+        min_prefill_m: int,
     ) -> None:
         return None
 

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -67,6 +67,16 @@ else:
 logger = init_logger(__name__)
 
 DEFAULT_V2_MODEL_RUNNER_ARCHITECTURES = frozenset({"Qwen3ForCausalLM"})
+_SM70_NOMTP_CUDAGRAPH_CAPTURE_SIZES = (1, 2, 4, 8, 16)
+
+
+def _sm70_nomtp_cudagraph_capture_sizes(max_num_seqs: int) -> list[int]:
+    max_graph_reqs = min(max(int(max_num_seqs), 1), 16)
+    capture_sizes = {
+        size for size in _SM70_NOMTP_CUDAGRAPH_CAPTURE_SIZES if size <= max_graph_reqs
+    }
+    capture_sizes.update((1, 2, max_graph_reqs))
+    return sorted(capture_sizes)
 
 
 class OptimizationLevel(IntEnum):
@@ -1324,7 +1334,9 @@ class VllmConfig:
                     CUDAGraphMode.FULL_AND_PIECEWISE
                 )
                 if self.compilation_config.cudagraph_capture_sizes is None:
-                    cudagraph_capture_sizes = [1, 2]
+                    cudagraph_capture_sizes = _sm70_nomtp_cudagraph_capture_sizes(
+                        self.scheduler_config.max_num_seqs
+                    )
                     if (
                         self.speculative_config is not None
                         and self.speculative_config.num_speculative_tokens
@@ -1370,6 +1382,11 @@ class VllmConfig:
                             "%sx1..%s for Flash-V100 compile graph.",
                             decode_query_len,
                             max_graph_reqs,
+                        )
+                    elif cudagraph_capture_sizes != [1, 2]:
+                        logger.info_once(
+                            "Using SM70 no-MTP decode cudagraph request shapes %s.",
+                            tuple(cudagraph_capture_sizes),
                         )
                     self.compilation_config.cudagraph_capture_sizes = (
                         cudagraph_capture_sizes

--- a/vllm/entrypoints/cli/main.py
+++ b/vllm/entrypoints/cli/main.py
@@ -5,11 +5,11 @@
 Note that all future modules must be lazily loaded within main
 to avoid certain eager import breakage."""
 
-import importlib.metadata
 import sys
 from importlib.util import find_spec
 
 from vllm.logger import init_logger
+from vllm.version import __version__ as VLLM_VERSION
 
 logger = init_logger(__name__)
 
@@ -75,7 +75,7 @@ def main():
             "-v",
             "--version",
             action="version",
-            version=importlib.metadata.version("vllm"),
+            version=VLLM_VERSION,
         )
         subparsers = parser.add_subparsers(required=False, dest="subparser")
         cmds = {}

--- a/vllm/entrypoints/cli/run_batch.py
+++ b/vllm/entrypoints/cli/run_batch.py
@@ -3,12 +3,12 @@
 
 import argparse
 import asyncio
-import importlib.metadata
 import typing
 
 from vllm.entrypoints.cli.types import CLISubcommand
 from vllm.entrypoints.utils import VLLM_SUBCMD_PARSER_EPILOG
 from vllm.logger import init_logger
+from vllm.version import __version__ as VLLM_VERSION
 
 if typing.TYPE_CHECKING:
     from vllm.utils.argparse_utils import FlexibleArgumentParser
@@ -27,9 +27,7 @@ class RunBatchSubcommand(CLISubcommand):
     def cmd(args: argparse.Namespace) -> None:
         from vllm.entrypoints.openai.run_batch import main as run_batch_main
 
-        logger.info(
-            "vLLM batch processing API version %s", importlib.metadata.version("vllm")
-        )
+        logger.info("vLLM batch processing API version %s", VLLM_VERSION)
         logger.info("args: %s", args)
 
         # Start the Prometheus metrics server.

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -338,7 +338,7 @@ if TYPE_CHECKING:
     VLLM_FLASH_V100_XQA_G6_P1024_SAWTOOTH_P1024_MID_SEQ_LEN: int = 111104
     VLLM_FLASH_V100_XQA_G6_P1024_SAWTOOTH_P256_LONG_SEQ_LEN: int = 147841
     VLLM_FLASH_V100_XQA_G6_P1024_SAWTOOTH_P1024_FINAL_SEQ_LEN: int = 258176
-    VLLM_FLASH_V100_XQA_G6_QK_PIPELINE: bool = False
+    VLLM_FLASH_V100_XQA_G6_QK_PIPELINE: bool = True
     VLLM_FLASH_V100_XQA_G6_QK_PIPELINE_WARPS: int = 8
     VLLM_FLASH_V100_XQA_G6_QK_PIPELINE_TRACE: bool = False
     VLLM_FLASH_V100_TRACE_DECODE_ACTIVE: bool = False
@@ -1015,10 +1015,10 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # If set, `MAX_JOBS` will be reduced to avoid oversubscribing the CPU.
     "NVCC_THREADS": lambda: os.getenv("NVCC_THREADS", None),
     # If set, vllm will use precompiled native binaries (*.so and vllm-rs).
-    "VLLM_USE_PRECOMPILED": lambda: (
-        os.environ.get("VLLM_USE_PRECOMPILED", "").strip().lower() in ("1", "true")
-        or bool(os.environ.get("VLLM_PRECOMPILED_WHEEL_LOCATION"))
-    ),
+    "VLLM_USE_PRECOMPILED": lambda: os.environ.get("VLLM_USE_PRECOMPILED", "")
+    .strip()
+    .lower()
+    in ("1", "true"),
     # If set, vllm will use the precompiled Rust frontend binary (vllm-rs).
     "VLLM_USE_PRECOMPILED_RUST": lambda: (
         os.environ.get("VLLM_USE_PRECOMPILED_RUST", "").strip().lower() in ("1", "true")
@@ -2298,7 +2298,7 @@ environment_variables: dict[str, Callable[[], Any]] = {
         )
     ),
     "VLLM_FLASH_V100_XQA_G6_QK_PIPELINE": lambda: bool(
-        int(os.getenv("VLLM_FLASH_V100_XQA_G6_QK_PIPELINE", "0"))
+        int(os.getenv("VLLM_FLASH_V100_XQA_G6_QK_PIPELINE", "1"))
     ),
     "VLLM_FLASH_V100_XQA_G6_QK_PIPELINE_WARPS": lambda: int(
         os.getenv("VLLM_FLASH_V100_XQA_G6_QK_PIPELINE_WARPS", "8")

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -153,6 +153,7 @@ if TYPE_CHECKING:
     VLLM_SM70_FP8_SAFE_FAST_SELECTOR: bool = False
     VLLM_SM70_FP8_PRESERVE_DEFAULT_SPLITS: bool = True
     VLLM_SM70_FP8_PRESERVE_DEFAULT_SPLITS_ONLY: bool = False
+    VLLM_SM70_FP8_PREFILL_EXACT_DENSE: bool = True
     VLLM_SM70_MXFP4_TUNE_SMALL_SHAPES: bool = True
     VLLM_SM70_NVFP4_TUNE_SMALL_SHAPES: bool = True
     VLLM_SM70_AWQ_REUSE_IMPORTED_CACHE: bool = False
@@ -1585,6 +1586,12 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # bounded FP16 workspace before their exact dense GEMM.
     "VLLM_SM70_AWQ_PREFILL_EXACT_DENSE": lambda: bool(
         int(os.getenv("VLLM_SM70_AWQ_PREFILL_EXACT_DENSE", "1"))
+    ),
+    # Expand selected large-M TP4 FP8 projections into one reusable bounded
+    # FP16 workspace before their exact dense GEMM. The allowlist and M gate
+    # keep decode, tails, and numerically unsafe QKV projections on TurboMind.
+    "VLLM_SM70_FP8_PREFILL_EXACT_DENSE": lambda: bool(
+        int(os.getenv("VLLM_SM70_FP8_PREFILL_EXACT_DENSE", "1"))
     ),
     # Experimental TileRT-inspired down-proj lane: after the row-parallel AWQ
     # GEMM, use the local tile-runtime TP2 all-reduce substrate for the MLP

--- a/vllm/model_executor/layers/layernorm.py
+++ b/vllm/model_executor/layers/layernorm.py
@@ -95,6 +95,18 @@ def _sm70_gemma_long_prefill_fused_add_rms_norm(
 ) -> tuple[torch.Tensor, torch.Tensor]:
     from vllm import _custom_ops as ops
 
+    # A long-prefill example can select this custom op while torch.compile is
+    # tracing a dynamic graph that is later reused for small CUDA Graph capture
+    # sizes. Preserve the normal exact path for those runtime shapes instead of
+    # dispatching the long-prefill kernel below its numerical contract.
+    if x.shape[0] < 256:
+        return _sm70_gemma_fused_add_rms_norm_eager(
+            x,
+            residual,
+            weight,
+            variance_epsilon,
+        )
+
     normalized_out = torch.empty_like(x)
     residual_out = torch.empty_like(residual)
     ops.sm70_gemma_long_prefill_fused_add_rms_norm(

--- a/vllm/model_executor/layers/quantization/fp8.py
+++ b/vllm/model_executor/layers/quantization/fp8.py
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
-import weakref
 from typing import TYPE_CHECKING, Any
 
 import torch
@@ -113,9 +112,8 @@ _SM70_FP8_PREFILL_DENSE_WORKSPACE_ELEMENTS = max(
 _SM70_FP8_PREFILL_DENSE_WORKSPACE_BYTES = (
     _SM70_FP8_PREFILL_DENSE_WORKSPACE_ELEMENTS * torch.float16.itemsize
 )
-_sm70_fp8_prefill_dense_workspaces: weakref.WeakValueDictionary[
-    tuple[int, torch.dtype], torch.Tensor
-] = weakref.WeakValueDictionary()
+# Layers retain only data_ptr(), so this cache owns each allocation's lifetime.
+_sm70_fp8_prefill_dense_workspaces: dict[tuple[int, torch.dtype], torch.Tensor] = {}
 
 
 def _is_sm70_fp8_prefill_exact_dense_layer(layer: torch.nn.Module) -> bool:
@@ -638,7 +636,9 @@ class Fp8LinearMethod(LinearMethodBase):
             ):
                 workspace = _get_sm70_fp8_prefill_exact_dense_workspace(tm_weight)
                 if workspace is not None:
-                    layer._sm70_fp8_prefill_exact_dense_workspace = workspace
+                    layer.sm70_fp8_prefill_exact_dense_workspace_ptr = (
+                        workspace.data_ptr()
+                    )
                     logger.info_once(
                         "SM70 FP8 exact-dense prefill path enabled with a bounded "
                         "85 MiB workspace."
@@ -800,16 +800,13 @@ class Fp8LinearMethod(LinearMethodBase):
                 device=x.device,
                 dtype=x.dtype,
             )
-            prefill_workspace = getattr(
-                layer, "_sm70_fp8_prefill_exact_dense_workspace", None
+            prefill_workspace_ptr = getattr(
+                layer, "sm70_fp8_prefill_exact_dense_workspace_ptr", None
             )
-            if prefill_workspace is not None and x_2d.dtype == torch.float16:
-                k = x_2d.shape[1]
-                n = layer.output_size_per_partition
-                prefill_weight = prefill_workspace[: k * n].view(k, n)
+            if prefill_workspace_ptr is not None and x_2d.dtype == torch.float16:
                 sm70_ops.fp8_gemm_sm70_prefill_dispatch_out(
                     out_2d,
-                    prefill_weight,
+                    prefill_workspace_ptr,
                     x_2d,
                     layer.weight,
                     layer.weight_scale_inv,
@@ -916,17 +913,13 @@ class Fp8LinearMethod(LinearMethodBase):
             scales = layer.sm70_fp8_gated_silu_scales
             k_ld = int(layer.sm70_fp8_gated_silu_k_ld)
             q_ld = int(layer.sm70_fp8_gated_silu_q_ld)
-        prefill_workspace = getattr(
-            layer, "_sm70_fp8_prefill_exact_dense_workspace", None
+        prefill_workspace_ptr = getattr(
+            layer, "sm70_fp8_prefill_exact_dense_workspace_ptr", None
         )
-        if prefill_workspace is not None and x_2d.dtype == torch.float16:
-            n = layer.output_size_per_partition
-            prefill_weight = prefill_workspace[: x_2d.shape[1] * n].view(
-                x_2d.shape[1], n
-            )
+        if prefill_workspace_ptr is not None and x_2d.dtype == torch.float16:
             sm70_ops.fp8_gemm_sm70_prefill_dispatch_out(
                 out_2d,
-                prefill_weight,
+                prefill_workspace_ptr,
                 x_2d,
                 weight,
                 scales,

--- a/vllm/model_executor/layers/quantization/fp8.py
+++ b/vllm/model_executor/layers/quantization/fp8.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import weakref
 from typing import TYPE_CHECKING, Any
 
 import torch
@@ -98,6 +99,59 @@ if TYPE_CHECKING:
 ACTIVATION_SCHEMES = ["static", "dynamic"]
 
 logger = init_logger(__name__)
+
+_SM70_FP8_PREFILL_DENSE_MIN_M = 3920
+_SM70_FP8_PREFILL_DENSE_SHAPES = {
+    "gate_up_proj": (5120, 8704),
+    "down_proj": (4352, 5120),
+    "out_proj": (1536, 5120),
+    "o_proj": (1536, 5120),
+}
+_SM70_FP8_PREFILL_DENSE_WORKSPACE_ELEMENTS = max(
+    k * n for k, n in _SM70_FP8_PREFILL_DENSE_SHAPES.values()
+)
+_SM70_FP8_PREFILL_DENSE_WORKSPACE_BYTES = (
+    _SM70_FP8_PREFILL_DENSE_WORKSPACE_ELEMENTS * torch.float16.itemsize
+)
+_sm70_fp8_prefill_dense_workspaces: weakref.WeakValueDictionary[
+    tuple[int, torch.dtype], torch.Tensor
+] = weakref.WeakValueDictionary()
+
+
+def _is_sm70_fp8_prefill_exact_dense_layer(layer: torch.nn.Module) -> bool:
+    if getattr(layer, "tp_size", 1) != 4:
+        return False
+    suffix = getattr(layer, "prefix", "").rsplit(".", 1)[-1]
+    expected = _SM70_FP8_PREFILL_DENSE_SHAPES.get(suffix)
+    if expected is None:
+        return False
+    return tuple(layer.weight.shape) == expected
+
+
+def _get_sm70_fp8_prefill_exact_dense_workspace(
+    weight: torch.Tensor,
+) -> torch.Tensor | None:
+    device_index = weight.device.index
+    if device_index is None:
+        device_index = torch.accelerator.current_device_index()
+    cache_key = (device_index, torch.float16)
+    workspace = _sm70_fp8_prefill_dense_workspaces.get(cache_key)
+    if workspace is not None:
+        return workspace
+    try:
+        workspace = torch.empty(
+            (_SM70_FP8_PREFILL_DENSE_WORKSPACE_ELEMENTS,),
+            dtype=torch.float16,
+            device=weight.device,
+        )
+    except torch.OutOfMemoryError:
+        logger.warning_once(
+            "Insufficient memory for the bounded SM70 FP8 prefill workspace; "
+            "falling back to TurboMind FP8."
+        )
+        return None
+    _sm70_fp8_prefill_dense_workspaces[cache_key] = workspace
+    return workspace
 
 
 class Fp8Config(QuantizationConfig):
@@ -577,6 +631,18 @@ class Fp8LinearMethod(LinearMethodBase):
             layer.register_buffer("sm70_fp8_meta", meta, persistent=False)
             layer.sm70_fp8_k_ld = int(meta[0].item())
             layer.sm70_fp8_q_ld = int(meta[1].item())
+            if (
+                envs.VLLM_SM70_FP8_PREFILL_EXACT_DENSE
+                and hasattr(torch.ops._C, "fp8_gemm_sm70_prefill_dispatch_out")
+                and _is_sm70_fp8_prefill_exact_dense_layer(layer)
+            ):
+                workspace = _get_sm70_fp8_prefill_exact_dense_workspace(tm_weight)
+                if workspace is not None:
+                    layer._sm70_fp8_prefill_exact_dense_workspace = workspace
+                    logger.info_once(
+                        "SM70 FP8 exact-dense prefill path enabled with a bounded "
+                        "85 MiB workspace."
+                    )
             logger.info_once("SM70 FP8 TurboMind W8A16 dense path enabled.")
             return
 
@@ -734,16 +800,36 @@ class Fp8LinearMethod(LinearMethodBase):
                 device=x.device,
                 dtype=x.dtype,
             )
-            sm70_ops.fp8_gemm_sm70_out(
-                out_2d,
-                x_2d,
-                layer.weight,
-                layer.weight_scale_inv,
-                128,
-                layer.sm70_fp8_k_ld,
-                layer.sm70_fp8_q_ld,
-                False,
+            prefill_workspace = getattr(
+                layer, "_sm70_fp8_prefill_exact_dense_workspace", None
             )
+            if prefill_workspace is not None and x_2d.dtype == torch.float16:
+                k = x_2d.shape[1]
+                n = layer.output_size_per_partition
+                prefill_weight = prefill_workspace[: k * n].view(k, n)
+                sm70_ops.fp8_gemm_sm70_prefill_dispatch_out(
+                    out_2d,
+                    prefill_weight,
+                    x_2d,
+                    layer.weight,
+                    layer.weight_scale_inv,
+                    128,
+                    layer.sm70_fp8_k_ld,
+                    layer.sm70_fp8_q_ld,
+                    False,
+                    _SM70_FP8_PREFILL_DENSE_MIN_M,
+                )
+            else:
+                sm70_ops.fp8_gemm_sm70_out(
+                    out_2d,
+                    x_2d,
+                    layer.weight,
+                    layer.weight_scale_inv,
+                    128,
+                    layer.sm70_fp8_k_ld,
+                    layer.sm70_fp8_q_ld,
+                    False,
+                )
             if getattr(layer, "sm70_fp8_gated_silu_primary", False):
                 out_features = layer.output_size_per_partition // 2
                 out_2d = (
@@ -830,6 +916,27 @@ class Fp8LinearMethod(LinearMethodBase):
             scales = layer.sm70_fp8_gated_silu_scales
             k_ld = int(layer.sm70_fp8_gated_silu_k_ld)
             q_ld = int(layer.sm70_fp8_gated_silu_q_ld)
+        prefill_workspace = getattr(
+            layer, "_sm70_fp8_prefill_exact_dense_workspace", None
+        )
+        if prefill_workspace is not None and x_2d.dtype == torch.float16:
+            n = layer.output_size_per_partition
+            prefill_weight = prefill_workspace[: x_2d.shape[1] * n].view(
+                x_2d.shape[1], n
+            )
+            sm70_ops.fp8_gemm_sm70_prefill_dispatch_out(
+                out_2d,
+                prefill_weight,
+                x_2d,
+                weight,
+                scales,
+                128,
+                k_ld,
+                q_ld,
+                True,
+                _SM70_FP8_PREFILL_DENSE_MIN_M,
+            )
+            return out_2d.reshape(*x.shape[:-1], out_features)
         sm70_ops.fp8_gemm_sm70_out(
             out_2d,
             x_2d,

--- a/vllm/v1/attention/backends/flash_attn_v100.py
+++ b/vllm/v1/attention/backends/flash_attn_v100.py
@@ -150,6 +150,12 @@ _prefill_dense_splitkv3_workspaces: dict[
 ] = {}
 
 
+def _normalize_flash_v100_kv_cache_dtype(kv_cache_dtype: str) -> str:
+    # Newer vLLM resolves an explicit FP16 cache to "float16". The vendored
+    # Flash-V100 extension uses "auto" for the same unquantized FP16 layout.
+    return "auto" if kv_cache_dtype == "float16" else kv_cache_dtype
+
+
 def _split_paged_kv_cache(
     kv_cache: torch.Tensor | tuple[torch.Tensor, torch.Tensor] | list[torch.Tensor],
 ) -> tuple[torch.Tensor, torch.Tensor]:
@@ -3095,6 +3101,7 @@ class FlashAttnV100Impl(TritonAttentionImpl):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+        self.kv_cache_dtype = _normalize_flash_v100_kv_cache_dtype(self.kv_cache_dtype)
         (
             self.flash_attn_func,
             self.flash_attn_bhmd_func,

--- a/vllm/v1/spec_decode/llm_base_proposer.py
+++ b/vllm/v1/spec_decode/llm_base_proposer.py
@@ -236,6 +236,7 @@ class SpecDecodeBaseProposer:
             self.method,
             vllm_config.parallel_config.tensor_parallel_size,
             vllm_config.model_config.architecture,
+            vllm_config.model_config.model,
         )
         if draft_vocab_config.gpu_lru_enabled:
             if self.max_batch_size != 1:
@@ -2254,6 +2255,7 @@ class SpecDecodeBaseProposer:
             self.method,
             self.vllm_config.parallel_config.tensor_parallel_size,
             self.vllm_config.model_config.architecture,
+            self.vllm_config.model_config.model,
         )
         ranking_path = vocab_config.ranking_path
         shortlist_size = vocab_config.shortlist_size

--- a/vllm/v1/spec_decode/static_draft_vocab.py
+++ b/vllm/v1/spec_decode/static_draft_vocab.py
@@ -48,12 +48,23 @@ class MTPDraftVocabConfig:
 
 _DEFAULT_DYNAMIC_DRAFT_VOCAB_ARCHITECTURE = "Qwen3_5ForConditionalGeneration"
 _DEFAULT_DYNAMIC_DRAFT_VOCAB_TP_SIZES = frozenset((2, 4))
+_DEFAULT_DYNAMIC_DRAFT_VOCAB_MODEL_MARKER = "qwen3.6-27b"
+
+
+def _matches_default_dynamic_draft_vocab_model(
+    model_name_or_path: str | None,
+) -> bool:
+    if model_name_or_path is None:
+        return False
+    normalized = model_name_or_path.casefold().replace("_", "-")
+    return _DEFAULT_DYNAMIC_DRAFT_VOCAB_MODEL_MARKER in normalized
 
 
 def resolve_mtp_draft_vocab_config(
     method: str,
     tensor_parallel_size: int = 2,
     model_architecture: str | None = None,
+    model_name_or_path: str | None = None,
 ) -> MTPDraftVocabConfig:
     """Resolve explicit controls or the model-specific default MTP vocabulary."""
     config = MTPDraftVocabConfig(
@@ -84,6 +95,7 @@ def resolve_mtp_draft_vocab_config(
         or explicit_config
         or model_architecture != _DEFAULT_DYNAMIC_DRAFT_VOCAB_ARCHITECTURE
         or tensor_parallel_size not in _DEFAULT_DYNAMIC_DRAFT_VOCAB_TP_SIZES
+        or not _matches_default_dynamic_draft_vocab_model(model_name_or_path)
     ):
         return config
 

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -1363,6 +1363,7 @@ class GPUModelRunner(
             (self.speculative_config.method or "") if self.speculative_config else "",
             self.parallel_config.tensor_parallel_size,
             self.model_config.architecture,
+            self.model_config.model,
         )
         self.dynamic_draft_vocab_prefill_topk = draft_vocab_config.prefill_topk
         validate_dynamic_draft_vocab_prefill_topk(


### PR DESCRIPTION
## Purpose

Prepare the CUDA 12.8 / Torch 2.10 SM70 release and accept Qwen3.8-27B-FP8 on four V100-32GB GPUs.

- Keep wheel metadata and CLI versioning consistent under `1cat-vllm==1.3.0`.
- Enable the proven mid-range G6 XQA QK pipeline for long decode.
- Capture no-MTP CUDA graph request shapes through concurrency 16.
- Prevent Qwen3.8 from reusing the Qwen3.6 dynamic-vocabulary asset.
- Bundle FlashQLA SM70 so installed wheels do not require NVCC at runtime.
- Extend the SM70 benchmark harness for exact prompts, cold-cache sweeps, official sampling, and checkpointed cases.
- Recover Qwen3.8-FP8 long-prefill projection throughput with a compile-safe, bounded-memory TP4 exact-dense dispatch.

Target: Python 3.12, Torch 2.10.0+cu128, CUDA 12.8, SM70, TurboMind and Flash-V100, CUDA graphs enabled.

## Test Plan

- Build and install a clean `1cat-vllm==1.3.0` SM70 wheel.
- Import every required native extension from site-packages with an empty Torch extension cache.
- Run Qwen3.8 no-MTP long-context prefill/decode, MTP4, FP8 KV, exact-256K-boundary, API quality, and 1/2/4/8/16 concurrency gates.
- Profile 128K decode with Nsight Systems graph-node tracing.
- Run Qwen3.6-35B-A3B-AWQ TP2 compatibility and speed checks.
- Run matched 32K/128K/256K FP8 projection A/B checks, a 1K-256K prefill sweep, output-hash gates, and an Nsight route trace.
- Run focused Ruff, format, py_compile, and pytest gates.

## Test Result

- Ruff check/format and py_compile passed for all changed Python files.
- Focused pytest: `144 passed`.
- FP8 exact-dense focused pytest: `5 passed`; the SM70 `_C` target rebuild is clean.
- Matched chunk-15680 FP8 prefill improves 32K `2972.3 -> 3636.7` tok/s (+22.36%), 128K `2166.2 -> 2446.5` (+12.94%), and 256K `1493.7 -> 1602.0` (+7.25%), with exact control output hashes.
- Final FP16-KV/no-MTP prefill sweep is 2515.1/3847.8/3725.4/3901.6/3437.2/2851.7/2446.5/1602.0 tok/s at 1K/4K/8K/16K/32K/64K/128K/256K. Every repeated row has one stable hash and `is_corrupted=false`.
- Nsight proves the measured 32K request executes 1536 selected exact-dense projection calls. The route uses one shared 85 MiB/rank workspace and leaves 19.18 GiB/rank for KV (4.70x estimated 256K cache capacity).
- Qwen3.8 final-wheel no-MTP 1K/256: 65.92 tok/s pure decode, 15.170 ms TPOT, valid natural stop.
- Qwen3.8 no-MTP FP16-KV pure decode: 65.05 tok/s at 1K, 46.95 at 128K, and 36.96 at 256K.
- Qwen3.8 no-MTP FP8-KV pure decode: 66.36 tok/s at 1K, 42.35 at 128K, and 31.49 at 256K.
- 128K G6 QK pipeline: 21.292 -> 20.293 ms TPOT (-4.69%) with the same token hash; 256K is neutral within 0.16%.
- Corrected exact-dense pointer ABI keeps CUDA graph memory at 0.26 GiB/rank and restores C1 decode from the regressed ~19 tok/s path to 60.44 tok/s.
- Latest concurrency output throughput: C1 60.44, C2 108.72, C4 192.39, C8 309.70, C16 412.35 tok/s; 64/64 requests passed per row. C4 repeated at 188.68-192.39 tok/s.
- Full-vocabulary MTP4 at 128K: FP8 KV 58.25 tok/s and acceptance length 3.866; FP16 KV 55.40 tok/s and acceptance length 4.031.
- Exact 256K MTP4 + FP8-KV boundary produced 24 legal tokens with `is_corrupted=false`; acceptance length 4.0.
- Tool-call JSON, streaming tools, prefix-cache reuse, and HTML/JavaScript quality checks passed.
- Qwen3.6-35B-A3B-AWQ TP2 final-wheel official sampling: 95.63 tok/s at 1K/256 and 95.29 tok/s at 4K/1024, both complete and non-corrupted.
- No Qwen3.6-35B-A3B-FP8 checkpoint is available on this host; that speed target remains unmeasured.

## Wheel

- `1cat_vllm-1.3.0-cp312-cp312-linux_x86_64.whl`
- SHA256: `df4275918461c67cb8af2c489a097cf5c7424e37706396267690094007eafdab`
- Includes `_C`, `_C_stable_libtorch`, `_moe_C`, Flash-V100, FA2 SM70, and packaged `flash_qla_sm70_gdn_strided.so`.
- Clean-cache MTP4 inference did not create `TORCH_EXTENSIONS_DIR`; no FlashQLA runtime JIT occurred.
- This wheel predates commit `4d0fcdf7ba`; rebuild the release wheel after this PR is accepted so the FP8 long-prefill path is included.

## Evidence

- Acceptance report: `docs/design/sm70_qwen38_130_acceptance.md`
- FP8 long-prefill report: `docs/design/sm70_fp8_long_prefill_exact_dense.md`
- Artifacts: `/data/minimax-h3/task-cache/qwen38-130-acceptance-20260815`
- FP8 prefill artifacts: `/data/minimax-h3/task-cache/qwen38-130-prefill-recovery-20260815`
- Pointer-fix and concurrency artifacts: `/data/minimax-h3/task-cache/qwen38-130-concurrency-latest-20260815`

## Risk

- The new QK pipeline is restricted to the measured 111104-147840 token range and has an environment rollback.
- One long stochastic HTML seed repeated late while another naturally stopped correctly; no deterministic token corruption was reproduced.
- NCU counters are unavailable on this host (`ERR_NVGPUCTRPERM`); kernel attribution uses Nsight Systems rather than counter-derived claims.
- The FP8 path is default-on only for four exact TP4 projection shapes at M>=3920; decode, tails, and QKV retain TurboMind. Rollback is `VLLM_SM70_FP8_PREFILL_EXACT_DENSE=0`.