### PR TITLE
[Kernel][SM70] TRITON_MLA decode: clamp BLOCK to 16 for MLA-large (smem overflow fix)

### DIFF
--- a/vllm/v1/attention/ops/triton_decode_attention.py
+++ b/vllm/v1/attention/ops/triton_decode_attention.py
@@ -478,8 +478,21 @@ def _decode_grouped_att_m_fwd(
         BLOCK_DPE = 0
     BLOCK_DV = triton.next_power_of_2(Lv)
 
+    # Patch 0103: BLOCK=16 for HIP (original) and for MLA-large on SM70 (V100).
+    # On SM70 at BLOCK=32 the stage-1 kernel needs 102,400 B of smem (Triton
+    # stages dot operands as fp32 on sm70: peak = 4 B x [BLOCK_H*(BLOCK_DMODEL+
+    # BLOCK_DPE) + BLOCK*BLOCK_DMODEL]) against the 98,304 B hardware limit ->
+    # OutOfResources on the first decode. BLOCK=16 fits (69,632 B) and won the
+    # tiling bench vs BN32/BH8 (spill catastrophe) and BN16/BH8 (loses at
+    # saturated grids) at 128-user shapes. num_stages is a no-op here (no
+    # cp.async on sm70 - KV loads cannot be multi-buffered); leave it alone.
+    # Proof + bench: patches/0103-mla-triton-decode-smem/poc/.
     BLOCK = 32
-    if is_hip_:
+    if is_hip_ or (
+        is_mla
+        and BLOCK_DMODEL >= 512
+        and current_platform.get_device_capability()[0] == 7
+    ):
         BLOCK = 16
 
     batch, head_num = q.shape[0], q.shape[1]


### PR DESCRIPTION
Fixes a launch failure for MLA-large decode (GLM/DeepSeek latent Lk=576) on SM 7.0 (V100).

### Problem

The TRITON_MLA stage-1 kernel requests 102,400 B of shared memory for the GLM/DeepSeek latent (Lk=576 => BLOCK_DMODEL=512, BLOCK_DPE=64, BLOCK_N=32). V100's per-block smem limit is 98,304 B (96 KiB), so the kernel fails to launch on the very first decode:

```
OutOfResources: Required 102,400 B > Hardware limit 98,304 B
```

Reproduced exactly. A closed-form smem model — `4 B x [BLOCK_H*(BLOCK_DMODEL+BLOCK_DPE) + BLOCK*BLOCK_DMODEL]` — matches the compiler on all six probed configs. The dominant term is `BLOCK_N x BLOCK_DMODEL`; Triton stages dot operands as **fp32** on sm70 (not fp16, as an earlier 2-byte accounting assumed), so halving `BLOCK_N` 32->16 halves that term, saving 32,768 B and landing at 69,632 B — under the limit.

**Negative result worth recording:** forcing `num_stages=1` does NOT help. The MLA latent `c_kv` is loaded once, not double-buffered, so `num_stages` changes neither the reported smem (still 102,400 B) nor throughput. The lever is `BLOCK_N`, not `num_stages`.

### Fix

Extend the existing `is_hip_` `BLOCK=16` branch to also cover MLA-large on SM 7.0: `is_mla and BLOCK_DMODEL >= 512 and capability_major == 7`.

### Measured (V100-SXM2-32GB, op-level)

- **Capability: MEASURED.** Stock `BLOCK=32` fails to launch (reproduced exactly); `BLOCK=16` compiles and runs at 69,632 B. There is no prior-working baseline on MLA-large to regress — the patch unblocks the decode half of the GLM/DeepSeek MLA path (the prefill half is a separate, already-working code path).
- **Tiling selection** (median of 100 iters x 3 repeats, spread <0.2%): compared `BLOCK_N=16/BLOCK_H=16` (this fix) against `BLOCK_N=32/BLOCK_H=8` and `BLOCK_N=16/BLOCK_H=8` across batch 1..128 x kv_len 2048..32768. The 32/8 variant loses everywhere (1.8x-6.0x slower; ptxas spills it to 32 regs/thread, 1,452 spills). The 16/8 variant wins only at small batch (<=8: up to 28% faster) but loses 7-18% at saturated 128-batch shapes. 16/16 (this fix) is the best choice for the saturated/high-concurrency regime; 16/8 is a small-batch-only local optimum.
- **Assertivity: no measured loss.** `BLOCK=16` output vs an f32 CPU reference (f64-anchored): rms-rel 1.45e-4 (the f16 floor). `BLOCK=16`-vs-`32` tile-invariance at a smaller latent (Lk=288, where both fit): 8.6e-5 — pure reduction-order noise, no systematic bias.

### Downsides

None measured. The clamp only narrows the exact SM70 MLA-large configuration that cannot launch today, so there is no working path to regress. One examined nuance, not a loss: the `capability_major == 7` guard also matches SM75 (Turing), whose smem limit (64 KiB) would still overflow even at `BLOCK=16` (69,632 B) — this patch does not fully fix SM75, but SM75 already fails at `BLOCK=32` today, so the patch never makes any board worse. Noted so a future SM75-focused change doesn't inherit a silent assumption from here.

Composes with the existing SM70 GLM 256/256 dense MLA prefill route (a separate code path, not touched by this patch) to complete decode+prefill coverage for that geometry.

### Files

`vllm/v1/attention/ops/triton_decode_attention.py`