### PR TITLE
[Core][Kernel] Complete Qwen3.8 SM70 FP8 release paths

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,7 +63,7 @@ endif()
 # requirements.txt files and should be kept consistent.  The ROCm torch
 # versions are derived from docker/Dockerfile.rocm
 #
-set(TORCH_SUPPORTED_VERSION_CUDA "2.11.0")
+set(TORCH_SUPPORTED_VERSION_CUDA "2.10.0")
 set(TORCH_SUPPORTED_VERSION_ROCM "2.11.0")
 
 #

--- a/SM70_MTP_OUTPUT_QUALITY_AUDIT_20260616.md
+++ b/SM70_MTP_OUTPUT_QUALITY_AUDIT_20260616.md
@@ -251,7 +251,7 @@ generic MTP, Flash attention, or sampling parameters.
     `num_accepted_tokens`, `num_computed_tokens`, and block rollover behavior
     around the first corrupted-token region.
 
-## Do Not Repeat
+## Initial Do Not Repeat
 
 - Do not rerun the exact-CPU `seq_lens_cpu_upper_bound` A/B unless the related
   code changes. It failed and is not sufficient root.

--- a/benchmarks/benchmark_sm70_decode.py
+++ b/benchmarks/benchmark_sm70_decode.py
@@ -585,6 +585,14 @@ def _sm70_attention_policy(kv_cache_dtype: Any) -> dict[str, Any]:
         "VLLM_FLASH_V100_XQA_MTP5_PARTITION_SIZE",
         1024,
     )
+    g6_qk_pipeline = _env_bool(
+        "VLLM_FLASH_V100_XQA_G6_QK_PIPELINE",
+        True,
+    )
+    g6_qk_pipeline_warps = _env_int(
+        "VLLM_FLASH_V100_XQA_G6_QK_PIPELINE_WARPS",
+        8,
+    )
     decode_dynamic_partitions = _env_bool(
         "VLLM_FLASH_V100_DECODE_DYNAMIC_PARTITIONS",
         True,
@@ -660,6 +668,17 @@ def _sm70_attention_policy(kv_cache_dtype: Any) -> dict[str, Any]:
             "VLLM_FLASH_V100_XQA_MTP5_PARTITION_SIZE"
         ),
         "mtp5_xqa_partition_size_effective": mtp5_xqa_partition_size,
+        "VLLM_FLASH_V100_XQA_G6_QK_PIPELINE": os.environ.get(
+            "VLLM_FLASH_V100_XQA_G6_QK_PIPELINE"
+        ),
+        "g6_qk_pipeline_effective": g6_qk_pipeline,
+        "VLLM_FLASH_V100_XQA_G6_QK_PIPELINE_WARPS": os.environ.get(
+            "VLLM_FLASH_V100_XQA_G6_QK_PIPELINE_WARPS"
+        ),
+        "g6_qk_pipeline_warps_effective": g6_qk_pipeline_warps,
+        "g6_qk_pipeline_mid_only_policy": (
+            g6_qk_pipeline and g6_qk_pipeline_warps == 8
+        ),
         "exact_mtp5_fp8_p1024_dual_cta_policy": (
             smallq_decode_use_xqa
             and mtp5_xqa_dual_cta
@@ -1201,6 +1220,7 @@ def _enable_diagnostics_after_load() -> None:
 def _make_prompt_token_ids(
     tokenizer: Any,
     prompt_base: str,
+    prompt_suffix: str,
     input_len: int,
 ) -> list[int]:
     if input_len <= 0:
@@ -1209,11 +1229,15 @@ def _make_prompt_token_ids(
     chunk = tokenizer.encode(prompt_base, add_special_tokens=False)
     if not chunk:
         raise ValueError("--prompt-base produced no tokens")
+    suffix = tokenizer.encode(prompt_suffix, add_special_tokens=False)
+    if len(suffix) > input_len:
+        raise ValueError("--prompt-suffix is longer than --input-len")
 
     repeated: list[int] = []
-    while len(repeated) < input_len:
+    prefix_len = input_len - len(suffix)
+    while len(repeated) < prefix_len:
         repeated.extend(chunk)
-    return repeated[:input_len]
+    return repeated[:prefix_len] + suffix
 
 
 def _load_cases(args: argparse.Namespace) -> list[dict[str, Any]]:
@@ -1224,6 +1248,9 @@ def _load_cases(args: argparse.Namespace) -> list[dict[str, Any]]:
                 "input_len": args.input_len,
                 "output_len": args.output_len,
                 "prompt_base": args.prompt_base,
+                "prompt_suffix": args.prompt_suffix,
+                "warmup": args.warmup,
+                "repeat": args.repeat,
             }
         ]
 
@@ -1237,14 +1264,24 @@ def _load_cases(args: argparse.Namespace) -> list[dict[str, Any]]:
             raise ValueError(f"case {index} must be an object")
         input_len = int(raw_case.get("input_len", args.input_len))
         output_len = int(raw_case.get("output_len", args.output_len))
+        warmup = int(raw_case.get("warmup", args.warmup))
+        repeat = int(raw_case.get("repeat", args.repeat))
+        if warmup < 0:
+            raise ValueError(f"case {index} warmup must be non-negative")
+        if repeat <= 0:
+            raise ValueError(f"case {index} repeat must be positive")
         name = str(raw_case.get("name", f"case_{index}"))
         prompt_base = str(raw_case.get("prompt_base", args.prompt_base))
+        prompt_suffix = str(raw_case.get("prompt_suffix", args.prompt_suffix))
         cases.append(
             {
                 "name": name,
                 "input_len": input_len,
                 "output_len": output_len,
                 "prompt_base": prompt_base,
+                "prompt_suffix": prompt_suffix,
+                "warmup": warmup,
+                "repeat": repeat,
             }
         )
     return cases
@@ -1398,7 +1435,15 @@ def _diff_spec_metrics(
     )
 
 
-def _run_once(llm: Any, prompt: dict[str, list[int]], sampling_params: Any) -> dict:
+def _run_once(
+    llm: Any,
+    prompt: dict[str, list[int]],
+    sampling_params: Any,
+    *,
+    reset_prefix_cache: bool = False,
+) -> dict:
+    if reset_prefix_cache and not llm.reset_prefix_cache():
+        raise RuntimeError("Failed to reset the prefix cache before measurement.")
     request_prompt = {"prompt_token_ids": list(prompt["prompt_token_ids"])}
     spec_metrics_before = _spec_metrics_snapshot(llm)
     start = time.perf_counter()
@@ -1507,6 +1552,8 @@ def _write_results(
         "engine_kwargs": llm_kwargs,
         "sampling_params": first_case["sampling_params"],
         "cuda_profile_repeat": args.cuda_profile_repeat,
+        "reset_prefix_cache_before_case": args.reset_prefix_cache_before_case,
+        "reset_prefix_cache_between_runs": args.reset_prefix_cache_between_runs,
         "prompt": first_case["prompt"],
         "load_seconds": load_seconds,
         "warmups": first_case["warmups"],
@@ -1531,7 +1578,8 @@ def _parse_args() -> argparse.Namespace:
         type=Path,
         help=(
             "Optional JSON list of cases with name/input_len/output_len/"
-            "prompt_base. Loads the model once and runs every case."
+            "prompt_base/prompt_suffix/warmup/repeat. Loads the model once and "
+            "runs every case."
         ),
     )
     parser.add_argument("--warmup", type=int, default=1)
@@ -1545,10 +1593,36 @@ def _parse_args() -> argparse.Namespace:
         ),
     )
     parser.add_argument(
+        "--reset-prefix-cache-before-case",
+        action="store_true",
+        help=(
+            "Reset prefix and Mamba caches once before each case. Warmups are "
+            "cold, while measured repeats may reuse that case's prefix."
+        ),
+    )
+    parser.add_argument(
+        "--reset-prefix-cache-between-runs",
+        action="store_true",
+        help=(
+            "Reset prefix and Mamba caches before every warmup and measured "
+            "request. This preserves production Mamba align mode without "
+            "turning repeated benchmark prompts into prefix-cache hits."
+        ),
+    )
+    parser.add_argument(
         "--prompt-base",
         default=(
             "This fixed benchmark prompt is used to create a deterministic "
             "tokenized input for single-request decode measurement. "
+        ),
+    )
+    parser.add_argument(
+        "--prompt-suffix",
+        default="",
+        help=(
+            "Text kept at the end of every exact-length prompt. Use this for "
+            "a stable generation instruction while --prompt-base pads the "
+            "preceding context."
         ),
     )
     parser.add_argument("--temperature", type=float, default=0.0)
@@ -1615,6 +1689,10 @@ def main() -> int:
         raise ValueError("--repeat must be positive")
     if args.warmup < 0:
         raise ValueError("--warmup must be non-negative")
+    if args.reset_prefix_cache_before_case and args.reset_prefix_cache_between_runs:
+        raise ValueError(
+            "Choose only one prefix-cache reset mode: before-case or between-runs."
+        )
 
     import torch
     from transformers import AutoTokenizer
@@ -1632,6 +1710,7 @@ def main() -> int:
         prompt_token_ids = _make_prompt_token_ids(
             tokenizer,
             raw_case["prompt_base"],
+            raw_case["prompt_suffix"],
             raw_case["input_len"],
         )
         cases.append(
@@ -1682,10 +1761,6 @@ def main() -> int:
 
     case_results = []
     for case in cases:
-        warmups = [
-            _run_once(llm, case["prompt"], case["sampling_params"])
-            for _ in range(args.warmup)
-        ]
         case_results.append(
             {
                 "name": case["name"],
@@ -1705,13 +1780,30 @@ def main() -> int:
                     "logprobs": args.logprobs if args.logprobs != 0 else None,
                     "seed": args.seed,
                 },
-                "warmups": warmups,
+                "requested_warmups": case["warmup"],
+                "requested_repeats": case["repeat"],
+                "warmups": [],
                 "repeats": [],
                 "summary": {},
             }
         )
 
     if args.cuda_profile_repeat:
+        # Warm every case before starting the profiler so the capture contains
+        # measured repeats only. Normal sweeps warm each case immediately
+        # before measuring it, allowing checkpoints to be written promptly.
+        for case, result in zip(cases, case_results):
+            if args.reset_prefix_cache_before_case and not llm.reset_prefix_cache():
+                raise RuntimeError("Failed to reset the prefix cache before case.")
+            result["warmups"] = [
+                _run_once(
+                    llm,
+                    case["prompt"],
+                    case["sampling_params"],
+                    reset_prefix_cache=args.reset_prefix_cache_between_runs,
+                )
+                for _ in range(case["warmup"])
+            ]
         try:
             llm.start_profile()
         except Exception as exc:
@@ -1723,9 +1815,26 @@ def main() -> int:
             ) from exc
     try:
         for case, result in zip(cases, case_results):
+            if not args.cuda_profile_repeat:
+                if args.reset_prefix_cache_before_case and not llm.reset_prefix_cache():
+                    raise RuntimeError("Failed to reset the prefix cache before case.")
+                result["warmups"] = [
+                    _run_once(
+                        llm,
+                        case["prompt"],
+                        case["sampling_params"],
+                        reset_prefix_cache=args.reset_prefix_cache_between_runs,
+                    )
+                    for _ in range(case["warmup"])
+                ]
             repeats = [
-                _run_once(llm, case["prompt"], case["sampling_params"])
-                for _ in range(args.repeat)
+                _run_once(
+                    llm,
+                    case["prompt"],
+                    case["sampling_params"],
+                    reset_prefix_cache=args.reset_prefix_cache_between_runs,
+                )
+                for _ in range(case["repeat"])
             ]
             result["repeats"] = repeats
             result["summary"] = _summarize(repeats)

--- a/benchmarks/benchmark_sm70_decode.py
+++ b/benchmarks/benchmark_sm70_decode.py
@@ -9,11 +9,33 @@ and SM70 gates so old-vs-latest no-MTP decode comparisons are reproducible.
 
 import argparse
 import hashlib
+import importlib.util
 import json
 import os
+import sys
 import time
 from pathlib import Path
 from typing import Any
+
+SOURCE_ROOT = Path(__file__).resolve().parents[1]
+FLASH_V100_ROOT = SOURCE_ROOT / "flash-attention-v100"
+for source_path in (FLASH_V100_ROOT, SOURCE_ROOT):
+    source_path_str = str(source_path)
+    if source_path_str not in sys.path:
+        sys.path.insert(0, source_path_str)
+
+
+def _module_file(module_name: str) -> str | None:
+    module = sys.modules.get(module_name)
+    if module is not None:
+        return getattr(module, "__file__", None)
+    spec = importlib.util.find_spec(module_name)
+    return spec.origin if spec is not None else None
+
+
+def _module_realpath(module_name: str) -> str | None:
+    module_file = _module_file(module_name)
+    return str(Path(module_file).resolve()) if module_file is not None else None
 
 
 def _parse_scalar(value: str) -> Any:
@@ -388,6 +410,13 @@ def _sm70_turbomind_policy() -> dict[str, Any]:
         "awq_moe_safe_default_selector_effective": (awq_moe_safe_default_selector),
         "VLLM_SM70_FP8_TUNE_SMALL_SHAPES": fp8_tune_raw,
         "fp8_safe_default_selector_effective": fp8_safe_default_selector,
+        "VLLM_SM70_FP8_COORDINATED_TUNING": os.environ.get(
+            "VLLM_SM70_FP8_COORDINATED_TUNING"
+        ),
+        "fp8_coordinated_tuning_effective": _env_bool(
+            "VLLM_SM70_FP8_COORDINATED_TUNING",
+            True,
+        ),
         "VLLM_SM70_FP8_SAFE_FAST_SELECTOR": os.environ.get(
             "VLLM_SM70_FP8_SAFE_FAST_SELECTOR"
         ),
@@ -593,6 +622,22 @@ def _sm70_attention_policy(kv_cache_dtype: Any) -> dict[str, Any]:
         "VLLM_FLASH_V100_XQA_G6_QK_PIPELINE_WARPS",
         8,
     )
+    e5m2_g6_dual_cta = _env_bool(
+        "VLLM_FLASH_V100_XQA_E5M2_G6_DUAL_CTA",
+        True,
+    )
+    e5m2_g6_split_reduce = _env_bool(
+        "VLLM_FLASH_V100_XQA_E5M2_G6_SPLIT_REDUCE",
+        True,
+    )
+    e5m2_partition_page_ids = _env_bool(
+        "VLLM_FLASH_V100_XQA_E5M2_PARTITION_PAGE_IDS",
+        True,
+    )
+    e5m2_pair_load = _env_bool(
+        "VLLM_FLASH_V100_XQA_E5M2_PAIR_LOAD",
+        True,
+    )
     decode_dynamic_partitions = _env_bool(
         "VLLM_FLASH_V100_DECODE_DYNAMIC_PARTITIONS",
         True,
@@ -607,7 +652,11 @@ def _sm70_attention_policy(kv_cache_dtype: Any) -> dict[str, Any]:
     )
     decode_fp8_xqa_min_seq_len = _env_int(
         "VLLM_FLASH_V100_DECODE_FP8_XQA_MIN_SEQ_LEN",
-        8192,
+        16384,
+    )
+    e5m2_p1024_begin = _env_int(
+        "VLLM_FLASH_V100_XQA_E5M2_P1024_BEGIN",
+        61633,
     )
     if selector_enabled:
         expected_sm70_priority = [
@@ -625,6 +674,11 @@ def _sm70_attention_policy(kv_cache_dtype: Any) -> dict[str, Any]:
             "TURBOQUANT",
         ]
     kv_cache_dtype_str = kv_cache_dtype if isinstance(kv_cache_dtype, str) else None
+    expected_kv_cache_dtype = (
+        "fp8_e5m2"
+        if selector_enabled and kv_cache_dtype_str == "fp8"
+        else kv_cache_dtype_str
+    )
     fp8_kv_cache_requested = _is_fp8_kv_cache_dtype(kv_cache_dtype_str)
     full_flash_default_policy = (
         selector_enabled
@@ -679,6 +733,26 @@ def _sm70_attention_policy(kv_cache_dtype: Any) -> dict[str, Any]:
         "g6_qk_pipeline_mid_only_policy": (
             g6_qk_pipeline and g6_qk_pipeline_warps == 8
         ),
+        "VLLM_FLASH_V100_XQA_E5M2_G6_DUAL_CTA": os.environ.get(
+            "VLLM_FLASH_V100_XQA_E5M2_G6_DUAL_CTA"
+        ),
+        "e5m2_g6_dual_cta_effective": e5m2_g6_dual_cta,
+        "VLLM_FLASH_V100_XQA_E5M2_G6_SPLIT_REDUCE": os.environ.get(
+            "VLLM_FLASH_V100_XQA_E5M2_G6_SPLIT_REDUCE"
+        ),
+        "e5m2_g6_split_reduce_effective": e5m2_g6_split_reduce,
+        "VLLM_FLASH_V100_XQA_E5M2_P1024_BEGIN": os.environ.get(
+            "VLLM_FLASH_V100_XQA_E5M2_P1024_BEGIN"
+        ),
+        "e5m2_p1024_begin_effective": e5m2_p1024_begin,
+        "VLLM_FLASH_V100_XQA_E5M2_PARTITION_PAGE_IDS": os.environ.get(
+            "VLLM_FLASH_V100_XQA_E5M2_PARTITION_PAGE_IDS"
+        ),
+        "e5m2_partition_page_ids_effective": e5m2_partition_page_ids,
+        "VLLM_FLASH_V100_XQA_E5M2_PAIR_LOAD": os.environ.get(
+            "VLLM_FLASH_V100_XQA_E5M2_PAIR_LOAD"
+        ),
+        "e5m2_pair_load_effective": e5m2_pair_load,
         "exact_mtp5_fp8_p1024_dual_cta_policy": (
             smallq_decode_use_xqa
             and mtp5_xqa_dual_cta
@@ -708,6 +782,8 @@ def _sm70_attention_policy(kv_cache_dtype: Any) -> dict[str, Any]:
         "decode_fp8_xqa_min_seq_len_effective": decode_fp8_xqa_min_seq_len,
         "full_flash_default_policy": full_flash_default_policy,
         "kv_cache_dtype": kv_cache_dtype_str,
+        "kv_cache_dtype_requested": kv_cache_dtype_str,
+        "kv_cache_dtype_expected_after_sm70_alias": expected_kv_cache_dtype,
         "fp8_kv_cache_requested_effective": fp8_kv_cache_requested,
         "fp8_kv_cache_full_flash_policy": (
             full_flash_default_policy and fp8_kv_cache_requested
@@ -1528,6 +1604,11 @@ def _write_results(
         "vllm": {
             "version": getattr(vllm, "__version__", None),
             "file": getattr(vllm, "__file__", None),
+        },
+        "flash_attn_v100": {
+            "python_file": _module_file("flash_attn_v100"),
+            "cuda_extension_file": _module_file("flash_attn_v100_cuda"),
+            "cuda_extension_realpath": _module_realpath("flash_attn_v100_cuda"),
         },
         "torch": {
             "version": torch.__version__,

--- a/benchmarks/benchmark_sm70_model_tokens.py
+++ b/benchmarks/benchmark_sm70_model_tokens.py
@@ -793,6 +793,14 @@ def _sm70_attention_policy(kv_cache_dtype: Any) -> dict[str, Any]:
         "VLLM_FLASH_V100_XQA_MTP5_PARTITION_SIZE",
         1024,
     )
+    g6_qk_pipeline = _env_bool(
+        "VLLM_FLASH_V100_XQA_G6_QK_PIPELINE",
+        True,
+    )
+    g6_qk_pipeline_warps = _env_int(
+        "VLLM_FLASH_V100_XQA_G6_QK_PIPELINE_WARPS",
+        8,
+    )
     prefill_d256_output_stride_268 = _env_bool(
         "VLLM_FLASH_V100_PREFILL_D256_OUTPUT_STRIDE_268",
         True,
@@ -860,6 +868,17 @@ def _sm70_attention_policy(kv_cache_dtype: Any) -> dict[str, Any]:
             "VLLM_FLASH_V100_XQA_MTP5_PARTITION_SIZE"
         ),
         "mtp5_xqa_partition_size_effective": mtp5_xqa_partition_size,
+        "VLLM_FLASH_V100_XQA_G6_QK_PIPELINE": os.environ.get(
+            "VLLM_FLASH_V100_XQA_G6_QK_PIPELINE"
+        ),
+        "g6_qk_pipeline_effective": g6_qk_pipeline,
+        "VLLM_FLASH_V100_XQA_G6_QK_PIPELINE_WARPS": os.environ.get(
+            "VLLM_FLASH_V100_XQA_G6_QK_PIPELINE_WARPS"
+        ),
+        "g6_qk_pipeline_warps_effective": g6_qk_pipeline_warps,
+        "g6_qk_pipeline_mid_only_policy": (
+            g6_qk_pipeline and g6_qk_pipeline_warps == 8
+        ),
         "exact_mtp5_fp8_p1024_dual_cta_policy": (
             smallq_decode_use_xqa
             and mtp5_xqa_dual_cta

--- a/benchmarks/benchmark_sm70_model_tokens.py
+++ b/benchmarks/benchmark_sm70_model_tokens.py
@@ -9,13 +9,36 @@ produces identical deterministic token IDs.
 
 import argparse
 import hashlib
+import importlib.util
 import json
 import math
 import os
+import sys
 import time
 from dataclasses import asdict, is_dataclass
 from pathlib import Path
 from typing import Any
+
+SOURCE_ROOT = Path(__file__).resolve().parents[1]
+FLASH_V100_ROOT = SOURCE_ROOT / "flash-attention-v100"
+for source_path in (FLASH_V100_ROOT, SOURCE_ROOT):
+    source_path_str = str(source_path)
+    if source_path_str not in sys.path:
+        sys.path.insert(0, source_path_str)
+
+
+def _module_file(module_name: str) -> str | None:
+    module = sys.modules.get(module_name)
+    if module is not None:
+        return getattr(module, "__file__", None)
+    spec = importlib.util.find_spec(module_name)
+    return spec.origin if spec is not None else None
+
+
+def _module_realpath(module_name: str) -> str | None:
+    module_file = _module_file(module_name)
+    return str(Path(module_file).resolve()) if module_file is not None else None
+
 
 DEFAULT_PROMPTS = [
     "Write a concise explanation of why deterministic validation matters.",
@@ -96,11 +119,18 @@ def _make_prompt_token_ids(
 
 
 def _prompt_generation_metadata(args: argparse.Namespace) -> dict[str, Any]:
-    metadata: dict[str, Any] = {
-        "input_len": args.input_len,
-        "uses_repeated_prompt_base": args.input_len is not None,
-    }
-    if args.input_len is None:
+    input_lens = args.input_lens
+    if input_lens is not None:
+        metadata: dict[str, Any] = {
+            "input_lens": input_lens,
+            "uses_repeated_prompt_base": True,
+        }
+    else:
+        metadata = {
+            "input_len": args.input_len,
+            "uses_repeated_prompt_base": args.input_len is not None,
+        }
+    if args.input_len is None and input_lens is None:
         return metadata
 
     from transformers import AutoTokenizer
@@ -209,6 +239,29 @@ def _spec_decoding_summary(
 
 
 def _load_prompts(args: argparse.Namespace) -> list[Any]:
+    if args.input_lens is not None:
+        if args.input_len is not None or args.prompt or args.prompts_json is not None:
+            raise ValueError(
+                "--input-lens cannot be mixed with --input-len or text prompts"
+            )
+        if not args.input_lens or any(length <= 0 for length in args.input_lens):
+            raise ValueError("--input-lens values must be positive")
+        from transformers import AutoTokenizer
+
+        tokenizer = AutoTokenizer.from_pretrained(
+            str(args.model),
+            trust_remote_code=args.trust_remote_code,
+        )
+        return [
+            {
+                "prompt_token_ids": _make_prompt_token_ids(
+                    tokenizer,
+                    args.prompt_base,
+                    input_len,
+                )
+            }
+            for input_len in args.input_lens
+        ]
     if args.input_len is not None:
         if args.prompt or args.prompts_json is not None:
             raise ValueError(
@@ -600,6 +653,13 @@ def _sm70_turbomind_policy() -> dict[str, Any]:
         "awq_moe_safe_default_selector_effective": (awq_moe_safe_default_selector),
         "VLLM_SM70_FP8_TUNE_SMALL_SHAPES": fp8_tune_raw,
         "fp8_safe_default_selector_effective": fp8_safe_default_selector,
+        "VLLM_SM70_FP8_COORDINATED_TUNING": os.environ.get(
+            "VLLM_SM70_FP8_COORDINATED_TUNING"
+        ),
+        "fp8_coordinated_tuning_effective": _env_bool(
+            "VLLM_SM70_FP8_COORDINATED_TUNING",
+            True,
+        ),
         "VLLM_SM70_FP8_SAFE_FAST_SELECTOR": os.environ.get(
             "VLLM_SM70_FP8_SAFE_FAST_SELECTOR"
         ),
@@ -809,6 +869,30 @@ def _sm70_attention_policy(kv_cache_dtype: Any) -> dict[str, Any]:
         "VLLM_FLASH_V100_XQA_G6_QK_PIPELINE_WARPS",
         8,
     )
+    e5m2_g6_dual_cta = _env_bool(
+        "VLLM_FLASH_V100_XQA_E5M2_G6_DUAL_CTA",
+        True,
+    )
+    e5m2_g6_split_reduce = _env_bool(
+        "VLLM_FLASH_V100_XQA_E5M2_G6_SPLIT_REDUCE",
+        True,
+    )
+    e5m2_partition_page_ids = _env_bool(
+        "VLLM_FLASH_V100_XQA_E5M2_PARTITION_PAGE_IDS",
+        True,
+    )
+    e5m2_pair_load = _env_bool(
+        "VLLM_FLASH_V100_XQA_E5M2_PAIR_LOAD",
+        True,
+    )
+    decode_fp8_xqa_min_seq_len = _env_int(
+        "VLLM_FLASH_V100_DECODE_FP8_XQA_MIN_SEQ_LEN",
+        16384,
+    )
+    e5m2_p1024_begin = _env_int(
+        "VLLM_FLASH_V100_XQA_E5M2_P1024_BEGIN",
+        61633,
+    )
     prefill_d256_output_stride_268 = _env_bool(
         "VLLM_FLASH_V100_PREFILL_D256_OUTPUT_STRIDE_268",
         True,
@@ -837,6 +921,11 @@ def _sm70_attention_policy(kv_cache_dtype: Any) -> dict[str, Any]:
             "TURBOQUANT",
         ]
     kv_cache_dtype_str = kv_cache_dtype if isinstance(kv_cache_dtype, str) else None
+    expected_kv_cache_dtype = (
+        "fp8_e5m2"
+        if selector_enabled and kv_cache_dtype_str == "fp8"
+        else kv_cache_dtype_str
+    )
     fp8_kv_cache_requested = _is_fp8_kv_cache_dtype(kv_cache_dtype_str)
     full_flash_default_policy = (
         selector_enabled
@@ -887,6 +976,30 @@ def _sm70_attention_policy(kv_cache_dtype: Any) -> dict[str, Any]:
         "g6_qk_pipeline_mid_only_policy": (
             g6_qk_pipeline and g6_qk_pipeline_warps == 8
         ),
+        "VLLM_FLASH_V100_XQA_E5M2_G6_DUAL_CTA": os.environ.get(
+            "VLLM_FLASH_V100_XQA_E5M2_G6_DUAL_CTA"
+        ),
+        "e5m2_g6_dual_cta_effective": e5m2_g6_dual_cta,
+        "VLLM_FLASH_V100_XQA_E5M2_G6_SPLIT_REDUCE": os.environ.get(
+            "VLLM_FLASH_V100_XQA_E5M2_G6_SPLIT_REDUCE"
+        ),
+        "e5m2_g6_split_reduce_effective": e5m2_g6_split_reduce,
+        "VLLM_FLASH_V100_XQA_E5M2_P1024_BEGIN": os.environ.get(
+            "VLLM_FLASH_V100_XQA_E5M2_P1024_BEGIN"
+        ),
+        "e5m2_p1024_begin_effective": e5m2_p1024_begin,
+        "VLLM_FLASH_V100_XQA_E5M2_PARTITION_PAGE_IDS": os.environ.get(
+            "VLLM_FLASH_V100_XQA_E5M2_PARTITION_PAGE_IDS"
+        ),
+        "e5m2_partition_page_ids_effective": e5m2_partition_page_ids,
+        "VLLM_FLASH_V100_XQA_E5M2_PAIR_LOAD": os.environ.get(
+            "VLLM_FLASH_V100_XQA_E5M2_PAIR_LOAD"
+        ),
+        "e5m2_pair_load_effective": e5m2_pair_load,
+        "VLLM_FLASH_V100_DECODE_FP8_XQA_MIN_SEQ_LEN": os.environ.get(
+            "VLLM_FLASH_V100_DECODE_FP8_XQA_MIN_SEQ_LEN"
+        ),
+        "decode_fp8_xqa_min_seq_len_effective": decode_fp8_xqa_min_seq_len,
         "exact_mtp5_fp8_p1024_dual_cta_policy": (
             smallq_decode_use_xqa
             and mtp5_xqa_dual_cta
@@ -906,6 +1019,8 @@ def _sm70_attention_policy(kv_cache_dtype: Any) -> dict[str, Any]:
         "prefill_d256_sw_pipeline_pv_effective": prefill_d256_sw_pipeline_pv,
         "full_flash_default_policy": full_flash_default_policy,
         "kv_cache_dtype": kv_cache_dtype_str,
+        "kv_cache_dtype_requested": kv_cache_dtype_str,
+        "kv_cache_dtype_expected_after_sm70_alias": expected_kv_cache_dtype,
         "fp8_kv_cache_requested_effective": fp8_kv_cache_requested,
         "fp8_kv_cache_full_flash_policy": (
             full_flash_default_policy and fp8_kv_cache_requested
@@ -1615,6 +1730,11 @@ def _dump(args: argparse.Namespace) -> int:
         "vllm": {
             "version": getattr(vllm, "__version__", None),
             "file": getattr(vllm, "__file__", None),
+        },
+        "flash_attn_v100": {
+            "python_file": _module_file("flash_attn_v100"),
+            "cuda_extension_file": _module_file("flash_attn_v100_cuda"),
+            "cuda_extension_realpath": _module_realpath("flash_attn_v100_cuda"),
         },
         "torch": {
             "version": torch.__version__,
@@ -2371,6 +2491,15 @@ def _parse_args() -> argparse.Namespace:
         help=(
             "Create a tokenized prompt by repeating --prompt-base to exactly "
             "this many tokens. This matches benchmark_sm70_decode.py."
+        ),
+    )
+    parser.add_argument(
+        "--input-lens",
+        type=int,
+        nargs="+",
+        help=(
+            "Create several exact-length repeated prompts in one engine "
+            "startup. Use with --sequential-prompts for isolated latency."
         ),
     )
     parser.add_argument(

--- a/benchmarks/benchmark_sm70_model_tokens.py
+++ b/benchmarks/benchmark_sm70_model_tokens.py
@@ -464,6 +464,10 @@ def _sm70_turbomind_policy() -> dict[str, Any]:
         "VLLM_SM70_FP8_DENSE_GATED_SILU",
         True,
     )
+    fp8_prefill_exact_dense = _env_bool(
+        "VLLM_SM70_FP8_PREFILL_EXACT_DENSE",
+        True,
+    )
     nvfp4_turbomind = _env_bool("VLLM_SM70_NVFP4_TURBOMIND", False)
     mxfp4_turbomind = _env_bool("VLLM_SM70_MXFP4_TURBOMIND", False)
     fp8_dequant_fallback = _env_bool("VLLM_SM70_FP8_DEQUANT_FALLBACK", True)
@@ -516,6 +520,10 @@ def _sm70_turbomind_policy() -> dict[str, Any]:
             "VLLM_SM70_FP8_DENSE_GATED_SILU"
         ),
         "fp8_dense_gated_silu_effective": fp8_dense_gated_silu,
+        "VLLM_SM70_FP8_PREFILL_EXACT_DENSE": os.environ.get(
+            "VLLM_SM70_FP8_PREFILL_EXACT_DENSE"
+        ),
+        "fp8_prefill_exact_dense_effective": fp8_prefill_exact_dense,
         "VLLM_SM70_NVFP4_TURBOMIND": os.environ.get("VLLM_SM70_NVFP4_TURBOMIND"),
         "nvfp4_turbomind_effective": nvfp4_turbomind,
         "VLLM_SM70_MXFP4_TURBOMIND": os.environ.get("VLLM_SM70_MXFP4_TURBOMIND"),

--- a/benchmarks/benchmark_sm70_serving_quality.py
+++ b/benchmarks/benchmark_sm70_serving_quality.py
@@ -32,6 +32,7 @@ from benchmark_sm70_model_tokens import (
     _sm70_turbomind_policy,
     _tracked_env,
 )
+from run_sm70_release_matrix import _fixed_quality_contract_failures
 
 DEFAULT_PROMPTS = [
     "Write one sentence about deterministic validation.",
@@ -51,10 +52,12 @@ def _load_prompts(args: argparse.Namespace) -> list[dict[str, str]]:
             )
         for index, item in enumerate(loaded):
             if isinstance(item, str):
-                prompts.append({
-                    "id": f"external_{index + 1:02d}",
-                    "content": item,
-                })
+                prompts.append(
+                    {
+                        "id": f"external_{index + 1:02d}",
+                        "content": item,
+                    }
+                )
             elif isinstance(item, dict):
                 raw_content = item.get("content", item.get("prompt"))
                 if not isinstance(raw_content, str):
@@ -62,10 +65,12 @@ def _load_prompts(args: argparse.Namespace) -> list[dict[str, str]]:
                         "--prompts-json dict entries require string "
                         "'content' or 'prompt'"
                     )
-                prompts.append({
-                    "id": str(item.get("id", f"external_{index + 1:02d}")),
-                    "content": raw_content,
-                })
+                prompts.append(
+                    {
+                        "id": str(item.get("id", f"external_{index + 1:02d}")),
+                        "content": raw_content,
+                    }
+                )
             else:
                 raise TypeError("--prompts-json entries must be strings or objects")
     if not prompts:
@@ -147,27 +152,24 @@ def _collect_serving_counters(metrics_text: str) -> dict[str, float]:
     return counters
 
 
-def _metrics_snapshot(metrics_url: str | None,
-                      timeout: float) -> dict[str, float] | None:
+def _metrics_snapshot(
+    metrics_url: str | None, timeout: float
+) -> dict[str, float] | None:
     if metrics_url is None:
         return None
     return _collect_serving_counters(_get_text(metrics_url, timeout))
 
 
-def _counter_delta(before: dict[str, float] | None,
-                   after: dict[str, float] | None) -> dict[str, Any] | None:
+def _counter_delta(
+    before: dict[str, float] | None, after: dict[str, float] | None
+) -> dict[str, Any] | None:
     if before is None or after is None:
         return None
     keys = sorted(set(before) | set(after))
-    delta = {
-        key: after.get(key, 0.0) - before.get(key, 0.0)
-        for key in keys
-    }
+    delta = {key: after.get(key, 0.0) - before.get(key, 0.0) for key in keys}
     drafts = delta.get("vllm:spec_decode_num_drafts_total", 0.0)
     draft_tokens = delta.get("vllm:spec_decode_num_draft_tokens_total", 0.0)
-    accepted_tokens = delta.get(
-        "vllm:spec_decode_num_accepted_tokens_total", 0.0
-    )
+    accepted_tokens = delta.get("vllm:spec_decode_num_accepted_tokens_total", 0.0)
     generation_tokens = delta.get("vllm:generation_tokens_total", 0.0)
     prompt_tokens = delta.get("vllm:prompt_tokens_total", 0.0)
     per_position = [
@@ -275,8 +277,14 @@ def _max_repeated_window(text: str, width: int) -> int:
         return 0
     counts: dict[str, int] = {}
     for idx in range(0, len(normalized) - width + 1):
-        window = normalized[idx:idx + width]
+        window = normalized[idx : idx + width]
         if len(window.strip()) < width // 2:
+            continue
+        # Homogeneous runs are checked independently by
+        # _longest_same_char_run. Counting their overlapping windows makes
+        # ordinary code separators such as "=====" look quadratically
+        # repetitive.
+        if len(set(window)) == 1:
             continue
         counts[window] = counts.get(window, 0) + 1
     return max(counts.values(), default=0)
@@ -299,9 +307,9 @@ def _max_same_line_run(text: str) -> int:
     return best
 
 
-def _quality_metrics(text: str | None,
-                     raw_token_ids: Any,
-                     completion_tokens: Any = None) -> dict[str, Any]:
+def _quality_metrics(
+    text: str | None, raw_token_ids: Any, completion_tokens: Any = None
+) -> dict[str, Any]:
     text = text or ""
     token_ids = [int(token_id) for token_id in (raw_token_ids or [])]
     if token_ids:
@@ -361,8 +369,9 @@ def _quality_metrics(text: str | None,
     return metrics
 
 
-def _summarize_tps(records: list[dict[str, Any]],
-                   elapsed_seconds: float) -> dict[str, Any]:
+def _summarize_tps(
+    records: list[dict[str, Any]], elapsed_seconds: float
+) -> dict[str, Any]:
     completion_tokens = [
         int(record["timing"]["completion_tokens"]) for record in records
     ]
@@ -381,27 +390,28 @@ def _summarize_tps(records: list[dict[str, Any]],
     if request_tps:
         sorted_tps = sorted(request_tps)
         p90_index = min(len(sorted_tps) - 1, math.ceil(0.9 * len(sorted_tps)) - 1)
-        summary.update({
-            "request_tps_min": min(request_tps),
-            "request_tps_mean": statistics.fmean(request_tps),
-            "request_tps_median": statistics.median(request_tps),
-            "request_tps_p90": sorted_tps[p90_index],
-            "request_tps_max": max(request_tps),
-        })
+        summary.update(
+            {
+                "request_tps_min": min(request_tps),
+                "request_tps_mean": statistics.fmean(request_tps),
+                "request_tps_median": statistics.median(request_tps),
+                "request_tps_p90": sorted_tps[p90_index],
+                "request_tps_max": max(request_tps),
+            }
+        )
     return summary
 
 
 def _summarize_spec_metrics(records: list[dict[str, Any]]) -> dict[str, Any] | None:
     per_request = [
-        record.get("serving_metrics_delta") for record in records
+        record.get("serving_metrics_delta")
+        for record in records
         if record.get("serving_metrics_delta") is not None
     ]
     if not per_request:
         return None
     total_drafts = sum(float(item["num_drafts"]) for item in per_request)
-    total_draft_tokens = sum(
-        float(item["num_draft_tokens"]) for item in per_request
-    )
+    total_draft_tokens = sum(float(item["num_draft_tokens"]) for item in per_request)
     total_accepted_tokens = sum(
         float(item["num_accepted_tokens"]) for item in per_request
     )
@@ -417,17 +427,16 @@ def _summarize_spec_metrics(records: list[dict[str, Any]]) -> dict[str, Any] | N
             total_accepted_tokens / total_drafts if total_drafts > 0 else None
         ),
         "mean_acceptance_length": (
-            1.0 + total_accepted_tokens / total_drafts
-            if total_drafts > 0 else None
+            1.0 + total_accepted_tokens / total_drafts if total_drafts > 0 else None
         ),
         "draft_acceptance_rate": (
             total_accepted_tokens / total_draft_tokens
-            if total_draft_tokens > 0 else None
+            if total_draft_tokens > 0
+            else None
         ),
         "accepted_tokens_per_pos": per_position,
         "per_position_acceptance_rate": [
-            value / total_drafts if total_drafts > 0 else None
-            for value in per_position
+            value / total_drafts if total_drafts > 0 else None for value in per_position
         ],
     }
 
@@ -456,18 +465,22 @@ def _dump(args: argparse.Namespace) -> int:
             "stream": False,
         }
         if args.endpoint == "chat":
-            payload["messages"] = [{
-                "role": "user",
-                "content": prompt["content"],
-            }]
+            payload["messages"] = [
+                {
+                    "role": "user",
+                    "content": prompt["content"],
+                }
+            ]
         else:
-            payload.update({
-                "prompt": prompt["content"],
-                "logprobs": args.logprobs,
-                "return_token_ids": True,
-                "return_tokens_as_token_ids": True,
-                "prompt_logprobs": args.prompt_logprobs,
-            })
+            payload.update(
+                {
+                    "prompt": prompt["content"],
+                    "logprobs": args.logprobs,
+                    "return_token_ids": True,
+                    "return_tokens_as_token_ids": True,
+                    "prompt_logprobs": args.prompt_logprobs,
+                }
+            )
         if args.seed is not None:
             payload["seed"] = args.seed
         if args.top_k is not None:
@@ -482,35 +495,49 @@ def _dump(args: argparse.Namespace) -> int:
         choice = _extract_choice(response)
         usage = response.get("usage") or {}
         completion_tokens = int(
-            usage.get("completion_tokens")
-            or len(choice.get("token_ids") or [])
+            usage.get("completion_tokens") or len(choice.get("token_ids") or [])
         )
         prompt_tokens = usage.get("prompt_tokens")
         total_tokens = usage.get("total_tokens")
         completion_tps = (
             completion_tokens / request_elapsed if request_elapsed > 0 else None
         )
-        records.append({
-            "index": index,
-            "id": prompt["id"],
-            "prompt": prompt["content"],
-            "request": payload,
-            "response": response,
-            "choice": choice,
-            "timing": {
-                "elapsed_seconds": request_elapsed,
-                "completion_tokens": completion_tokens,
-                "prompt_tokens": prompt_tokens,
-                "total_tokens": total_tokens,
-                "completion_tokens_per_second": completion_tps,
-            },
-            "serving_metrics_delta": _counter_delta(metrics_before, metrics_after),
-            "metrics": _quality_metrics(
-                choice.get("text"),
-                choice.get("token_ids"),
-                completion_tokens,
-            ),
-        })
+        quality_metrics = _quality_metrics(
+            choice.get("text"),
+            choice.get("token_ids"),
+            completion_tokens,
+        )
+        if args.require_fixed_quality_contract:
+            quality_metrics["failures"].extend(
+                _fixed_quality_contract_failures(
+                    prompt["id"],
+                    choice.get("text") or "",
+                    choice.get("finish_reason") or "",
+                )
+            )
+            quality_metrics["failures"] = list(
+                dict.fromkeys(quality_metrics["failures"])
+            )
+            quality_metrics["passed"] = not quality_metrics["failures"]
+        records.append(
+            {
+                "index": index,
+                "id": prompt["id"],
+                "prompt": prompt["content"],
+                "request": payload,
+                "response": response,
+                "choice": choice,
+                "timing": {
+                    "elapsed_seconds": request_elapsed,
+                    "completion_tokens": completion_tokens,
+                    "prompt_tokens": prompt_tokens,
+                    "total_tokens": total_tokens,
+                    "completion_tokens_per_second": completion_tps,
+                },
+                "serving_metrics_delta": _counter_delta(metrics_before, metrics_after),
+                "metrics": quality_metrics,
+            }
+        )
     elapsed = time.perf_counter() - start
     quality_passed = all(record["metrics"]["passed"] for record in records)
     throughput_summary = _summarize_tps(records, elapsed)
@@ -561,10 +588,15 @@ def _dump(args: argparse.Namespace) -> int:
         "records": records,
     }
     args.out.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
-    print(json.dumps({k: v for k, v in payload.items() if k != "records"},
-                     indent=2,
-                     sort_keys=True))
-    return 0 if quality_passed or not args.require_quality_gate else 2
+    print(
+        json.dumps(
+            {k: v for k, v in payload.items() if k != "records"},
+            indent=2,
+            sort_keys=True,
+        )
+    )
+    quality_required = args.require_quality_gate or args.require_fixed_quality_contract
+    return 0 if quality_passed or not quality_required else 2
 
 
 def _logprob_value(value: Any) -> float | None:
@@ -626,7 +658,7 @@ def _token_logprobs(choice: dict[str, Any]) -> list[float | None]:
 def _normal_logprob_key(key: Any) -> str:
     text = str(key)
     if text.startswith("token_id:"):
-        return text[len("token_id:"):]
+        return text[len("token_id:") :]
     return text
 
 
@@ -678,8 +710,7 @@ def _diff_top_logprob_maps(
     }
 
 
-def _diff_values(left: list[float | None],
-                 right: list[float | None]) -> dict[str, Any]:
+def _diff_values(left: list[float | None], right: list[float | None]) -> dict[str, Any]:
     diffs: list[float] = []
     same_count = len(left) == len(right)
     for left_value, right_value in zip(left, right, strict=False):
@@ -695,8 +726,9 @@ def _diff_values(left: list[float | None],
     }
 
 
-def _first_mismatch(left: list[int] | None,
-                    right: list[int] | None) -> dict[str, Any] | None:
+def _first_mismatch(
+    left: list[int] | None, right: list[int] | None
+) -> dict[str, Any] | None:
     if left is None or right is None:
         return None if left == right else {"index": 0, "left": left, "right": right}
     for index, (left_id, right_id) in enumerate(zip(left, right, strict=False)):
@@ -719,22 +751,26 @@ def _load_logits_dumps(path: Path) -> list[dict[str, Any]]:
     for file_path in sorted(path.glob("sampler_logits_*.pt")):
         payload = torch.load(file_path, map_location="cpu", weights_only=False)
         logits = payload["logits"].float()
-        entries.append({
-            "path": str(file_path),
-            "step": int(payload["step"]),
-            "pid": payload.get("pid"),
-            "stage": payload.get("stage"),
-            "shape": list(payload.get("shape", tuple(logits.shape))),
-            "dtype": payload.get("dtype"),
-            "all_greedy": bool(payload.get("all_greedy")),
-            "output_token_ids": payload.get("output_token_ids"),
-            "logits": logits,
-        })
-    entries.sort(key=lambda item: (
-        int(item["step"]),
-        str(item.get("stage")),
-        str(item["path"]),
-    ))
+        entries.append(
+            {
+                "path": str(file_path),
+                "step": int(payload["step"]),
+                "pid": payload.get("pid"),
+                "stage": payload.get("stage"),
+                "shape": list(payload.get("shape", tuple(logits.shape))),
+                "dtype": payload.get("dtype"),
+                "all_greedy": bool(payload.get("all_greedy")),
+                "output_token_ids": payload.get("output_token_ids"),
+                "logits": logits,
+            }
+        )
+    entries.sort(
+        key=lambda item: (
+            int(item["step"]),
+            str(item.get("stage")),
+            str(item["path"]),
+        )
+    )
     return entries
 
 
@@ -753,7 +789,8 @@ def _compare_logits_dirs(left_dir: Path, right_dir: Path) -> dict[str, Any]:
     num_argmax_mismatch = 0
     first_argmax_mismatch = None
     for index, (left, right) in enumerate(
-            zip(left_entries, right_entries, strict=False)):
+        zip(left_entries, right_entries, strict=False)
+    ):
         shape_equal = tuple(left["logits"].shape) == tuple(right["logits"].shape)
         all_shape_equal = all_shape_equal and shape_equal
         payload = {
@@ -787,15 +824,17 @@ def _compare_logits_dirs(left_dir: Path, right_dir: Path) -> dict[str, Any]:
             global_max = max(global_max, max_diff)
             total_sum += float(diff.sum().item())
             total_count += int(diff.numel())
-            payload.update({
-                "max_abs_diff": max_diff,
-                "mean_abs_diff": mean_diff,
-                "argmax_equal": argmax_equal,
-                "argmax_first_mismatch": _first_mismatch(
-                    left_argmax.reshape(-1).tolist(),
-                    right_argmax.reshape(-1).tolist(),
-                ),
-            })
+            payload.update(
+                {
+                    "max_abs_diff": max_diff,
+                    "mean_abs_diff": mean_diff,
+                    "argmax_equal": argmax_equal,
+                    "argmax_first_mismatch": _first_mismatch(
+                        left_argmax.reshape(-1).tolist(),
+                        right_argmax.reshape(-1).tolist(),
+                    ),
+                }
+            )
         else:
             all_argmax_equal = False
         comparisons.append(payload)
@@ -831,11 +870,12 @@ def _compare(args: argparse.Namespace) -> int:
     output_top_logprob_diffs: list[float] = []
     prompt_perplexity_diffs: list[float] = []
     for index, (left_record, right_record) in enumerate(
-            zip(left["records"], right["records"], strict=False)):
+        zip(left["records"], right["records"], strict=False)
+    ):
         left_choice = left_record["choice"]
         right_choice = right_record["choice"]
-        prompt_equal = (
-            left_choice.get("prompt_token_ids") == right_choice.get("prompt_token_ids")
+        prompt_equal = left_choice.get("prompt_token_ids") == right_choice.get(
+            "prompt_token_ids"
         )
         output_equal = left_choice.get("token_ids") == right_choice.get("token_ids")
         text_equal = left_choice.get("text") == right_choice.get("text")
@@ -870,32 +910,35 @@ def _compare(args: argparse.Namespace) -> int:
         left_ppl_value = left_ppl["perplexity"]
         right_ppl_value = right_ppl["perplexity"]
         prompt_perplexity_abs_diff = (
-            None if left_ppl_value is None or right_ppl_value is None else
-            abs(float(left_ppl_value) - float(right_ppl_value))
+            None
+            if left_ppl_value is None or right_ppl_value is None
+            else abs(float(left_ppl_value) - float(right_ppl_value))
         )
         if prompt_perplexity_abs_diff is not None:
             prompt_perplexity_diffs.append(prompt_perplexity_abs_diff)
-        pairs.append({
-            "index": index,
-            "prompt_equal": prompt_equal,
-            "output_equal": output_equal,
-            "text_equal": text_equal,
-            "prompt_first_mismatch": _first_mismatch(
-                left_choice.get("prompt_token_ids"),
-                right_choice.get("prompt_token_ids"),
-            ),
-            "output_first_mismatch": _first_mismatch(
-                left_choice.get("token_ids"),
-                right_choice.get("token_ids"),
-            ),
-            "prompt_logprob_diff": prompt_diff,
-            "output_logprob_diff": output_diff,
-            "prompt_top_logprob_diff": prompt_top_diff,
-            "output_top_logprob_diff": output_top_diff,
-            "left_prompt_perplexity": left_ppl,
-            "right_prompt_perplexity": right_ppl,
-            "prompt_perplexity_abs_diff": prompt_perplexity_abs_diff,
-        })
+        pairs.append(
+            {
+                "index": index,
+                "prompt_equal": prompt_equal,
+                "output_equal": output_equal,
+                "text_equal": text_equal,
+                "prompt_first_mismatch": _first_mismatch(
+                    left_choice.get("prompt_token_ids"),
+                    right_choice.get("prompt_token_ids"),
+                ),
+                "output_first_mismatch": _first_mismatch(
+                    left_choice.get("token_ids"),
+                    right_choice.get("token_ids"),
+                ),
+                "prompt_logprob_diff": prompt_diff,
+                "output_logprob_diff": output_diff,
+                "prompt_top_logprob_diff": prompt_top_diff,
+                "output_top_logprob_diff": output_top_diff,
+                "left_prompt_perplexity": left_ppl,
+                "right_prompt_perplexity": right_ppl,
+                "prompt_perplexity_abs_diff": prompt_perplexity_abs_diff,
+            }
+        )
 
     sampler_logits_diff = (
         _compare_logits_dirs(args.left_logits_dir, args.right_logits_dir)
@@ -962,15 +1005,9 @@ def _model_quality_gate(
         "token_equal": token_equal,
         "prompt_logprob_max_abs_diff": result.get("max_prompt_logprob_diff"),
         "output_logprob_max_abs_diff": result.get("max_output_logprob_diff"),
-        "prompt_top_logprob_max_abs_diff": result.get(
-            "max_prompt_top_logprob_diff"
-        ),
-        "output_top_logprob_max_abs_diff": result.get(
-            "max_output_top_logprob_diff"
-        ),
-        "prompt_perplexity_max_abs_diff": result.get(
-            "max_prompt_perplexity_abs_diff"
-        ),
+        "prompt_top_logprob_max_abs_diff": result.get("max_prompt_top_logprob_diff"),
+        "output_top_logprob_max_abs_diff": result.get("max_output_top_logprob_diff"),
+        "prompt_perplexity_max_abs_diff": result.get("max_prompt_perplexity_abs_diff"),
         "sampler_logits_max_abs_diff": None
         if sampler_logits_diff is None
         else sampler_logits_diff.get("max_abs_diff"),
@@ -1138,6 +1175,15 @@ def _parse_args() -> argparse.Namespace:
         "--require-quality-gate",
         action="store_true",
         help="Fail dump mode if any prompt trips the local repetition/corruption gate.",
+    )
+    parser.add_argument(
+        "--require-fixed-quality-contract",
+        action="store_true",
+        help=(
+            "Fail dump mode unless every prompt stops naturally and any known "
+            "prompt-specific structural contract also passes. The macos_6k_code "
+            "contract requires complete HTML/CSS/JavaScript and closed code fences."
+        ),
     )
     parser.add_argument("--timeout", type=float, default=600.0)
     parser.add_argument(

--- a/benchmarks/kernels/benchmark_flash_v100_fp8_kv.py
+++ b/benchmarks/kernels/benchmark_flash_v100_fp8_kv.py
@@ -45,9 +45,11 @@ PREFILL_VARIANTS = (
 DECODE_VARIANTS = (
     "fp16_b784_xqa",
     "fp16_b784_scalar",
+    "fp16_b1568_xqa",
     "fp16_b1568_scalar",
     "fp16_b1616_xqa",
     "fp16_b1616_scalar",
+    "fp8_b16_xqa",
     "fp8_b784_xqa",
     "fp8_b784_scalar",
     "fp8_b1568_xqa",

--- a/benchmarks/kernels/benchmark_sm70_fp8_e5m2_cache_write.py
+++ b/benchmarks/kernels/benchmark_sm70_fp8_e5m2_cache_write.py
@@ -1,0 +1,137 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""Benchmark the native E5M2 reshape-and-cache writer on SM70."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import statistics
+from pathlib import Path
+
+import torch
+
+
+def _measure(run, warmup: int, reps: int, inner_reps: int) -> dict[str, float]:
+    for _ in range(warmup):
+        run()
+    torch.accelerator.synchronize()
+
+    samples = []
+    for _ in range(reps):
+        start = torch.cuda.Event(enable_timing=True)
+        end = torch.cuda.Event(enable_timing=True)
+        start.record()
+        run()
+        end.record()
+        end.synchronize()
+        samples.append(start.elapsed_time(end) * 1000.0 / inner_reps)
+    return {
+        "median_us": statistics.median(samples),
+        "mean_us": statistics.mean(samples),
+        "min_us": min(samples),
+        "max_us": max(samples),
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--library", type=Path, required=True)
+    parser.add_argument("--num-tokens", type=int, default=1)
+    parser.add_argument("--num-heads", type=int, default=1)
+    parser.add_argument("--head-size", type=int, default=256)
+    parser.add_argument("--block-size", type=int, default=256)
+    parser.add_argument("--num-blocks", type=int, default=1024)
+    parser.add_argument("--layout", choices=("NHD", "HND"), default="NHD")
+    parser.add_argument("--scale", type=float, default=1.0)
+    parser.add_argument("--warmup", type=int, default=200)
+    parser.add_argument("--reps", type=int, default=1000)
+    parser.add_argument("--inner-reps", type=int, default=1)
+    parser.add_argument("--cuda-graph", action="store_true")
+    parser.add_argument("--output", type=Path)
+    args = parser.parse_args()
+
+    torch.ops.load_library(str(args.library.resolve()))
+    device = torch.device("cuda")
+    key = torch.randn(
+        args.num_tokens,
+        args.num_heads,
+        args.head_size,
+        device=device,
+        dtype=torch.float16,
+    )
+    value = torch.randn_like(key)
+    logical_shape = (
+        args.num_blocks,
+        args.block_size,
+        args.num_heads,
+        args.head_size,
+    )
+    if args.layout == "NHD":
+        key_cache = torch.zeros(logical_shape, device=device, dtype=torch.uint8)
+        value_cache = torch.zeros_like(key_cache)
+    else:
+        physical_shape = (
+            args.num_blocks,
+            args.num_heads,
+            args.block_size,
+            args.head_size,
+        )
+        key_cache = torch.zeros(
+            physical_shape, device=device, dtype=torch.uint8
+        ).permute(0, 2, 1, 3)
+        value_cache = torch.zeros(
+            physical_shape, device=device, dtype=torch.uint8
+        ).permute(0, 2, 1, 3)
+    slot_mapping = torch.arange(args.num_tokens, device=device, dtype=torch.int64)
+    scale = torch.full((1,), args.scale, device=device, dtype=torch.float32)
+
+    def launch() -> None:
+        torch.ops._C_cache_ops.reshape_and_cache_flash(
+            key,
+            value,
+            key_cache,
+            value_cache,
+            slot_mapping,
+            "fp8_e5m2",
+            scale,
+            scale,
+        )
+
+    def run_many() -> None:
+        for _ in range(args.inner_reps):
+            launch()
+
+    if args.cuda_graph:
+        for _ in range(3):
+            run_many()
+        graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(graph):
+            run_many()
+        run = graph.replay
+    else:
+        run = run_many
+
+    result = {
+        "library": str(args.library.resolve()),
+        "device": torch.cuda.get_device_name(),
+        "num_tokens": args.num_tokens,
+        "num_heads": args.num_heads,
+        "head_size": args.head_size,
+        "block_size": args.block_size,
+        "layout": args.layout,
+        "scale": args.scale,
+        "cuda_graph": args.cuda_graph,
+        "inner_reps": args.inner_reps,
+        **_measure(run, args.warmup, args.reps, args.inner_reps),
+    }
+    text = json.dumps(result, indent=2, sort_keys=True)
+    print(text)
+    if args.output is not None:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(text + "\n", encoding="utf-8")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/run_sm70_quality_speed_matrix.py
+++ b/benchmarks/run_sm70_quality_speed_matrix.py
@@ -300,6 +300,12 @@ def _max_repeated_window(text: str, width: int) -> int:
         window = normalized[idx : idx + width]
         if len(window.strip()) < width // 2:
             continue
+        # Homogeneous runs are checked independently by
+        # _longest_same_char_run. Counting their overlapping windows makes
+        # ordinary code separators such as "=====" look quadratically
+        # repetitive.
+        if len(set(window)) == 1:
+            continue
         counts[window] = counts.get(window, 0) + 1
     return max(counts.values(), default=0)
 

--- a/benchmarks/run_sm70_release_matrix.py
+++ b/benchmarks/run_sm70_release_matrix.py
@@ -900,6 +900,12 @@ def _max_repeated_window(text: str, width: int) -> int:
         window = normalized[idx : idx + width]
         if len(window.strip()) < width // 2:
             continue
+        # Homogeneous runs are checked independently by
+        # _longest_same_char_run. Counting their overlapping windows makes
+        # ordinary code separators such as "=====" look quadratically
+        # repetitive.
+        if len(set(window)) == 1:
+            continue
         counts[window] = counts.get(window, 0) + 1
     return max(counts.values(), default=0)
 

--- a/csrc/libtorch_stable/cache_kernels.cu
+++ b/csrc/libtorch_stable/cache_kernels.cu
@@ -246,6 +246,33 @@ struct CopyWithScaleOp {
   }
 };
 
+__device__ __forceinline__ uint8_t
+fp16_bits_to_e5m2_satfinite_rn(const uint16_t bits) {
+  const uint16_t sign = (bits >> 8) & 0x80u;
+  const uint16_t magnitude = bits & 0x7fffu;
+  const uint16_t exponent = magnitude >> 10;
+  const uint16_t mantissa = magnitude & 0x03ffu;
+
+  if (exponent == 0x1fu) {
+    // Match CUDA's __NV_SATFINITE behavior: infinities clamp to max finite,
+    // while every NaN payload and sign canonicalizes to positive E5M2 NaN.
+    return mantissa == 0 ? static_cast<uint8_t>(sign | 0x7bu) : 0x7fu;
+  }
+
+  uint16_t rounded = magnitude >> 8;
+  const uint16_t remainder = magnitude & 0x00ffu;
+  rounded += remainder > 0x80u || (remainder == 0x80u && (rounded & 1u) != 0u);
+  rounded = rounded > 0x7bu ? 0x7bu : rounded;
+  return static_cast<uint8_t>(sign | rounded);
+}
+
+struct CopyFp16ToE5M2UnitScaleOp {
+  __device__ __forceinline__ void operator()(uint8_t& dst,
+                                             const uint16_t src) const {
+    dst = fp16_bits_to_e5m2_satfinite_rn(src);
+  }
+};
+
 template <typename scalar_t, typename cache_t, Fp8KVCacheDataType kv_dt>
 __global__ void reshape_and_cache_kernel(
     const scalar_t* __restrict__ key,    // [num_tokens, num_heads, head_size]
@@ -349,13 +376,36 @@ __global__ void reshape_and_cache_flash_kernel(
     float k_scale_val = (kv_dt == Fp8KVCacheDataType::kAuto) ? 0.f : *k_scale;
     float v_scale_val = (kv_dt == Fp8KVCacheDataType::kAuto) ? 0.f : *v_scale;
 
-    CopyWithScaleOp<cache_t, scalar_t, kv_dt> k_op{k_scale_val};
-    CopyWithScaleOp<cache_t, scalar_t, kv_dt> v_op{v_scale_val};
+    if constexpr (kv_dt == Fp8KVCacheDataType::kFp8E5M2 &&
+                  std::is_same_v<scalar_t, uint16_t> &&
+                  std::is_same_v<cache_t, uint8_t>) {
+      if (k_scale_val == 1.f) {
+        vectorize_with_alignment<VEC_SIZE>(key_src, key_dst, n_elems,
+                                           threadIdx.x, blockDim.x,
+                                           CopyFp16ToE5M2UnitScaleOp{});
+      } else {
+        CopyWithScaleOp<cache_t, scalar_t, kv_dt> k_op{k_scale_val};
+        vectorize_with_alignment<VEC_SIZE>(key_src, key_dst, n_elems,
+                                           threadIdx.x, blockDim.x, k_op);
+      }
+      if (v_scale_val == 1.f) {
+        vectorize_with_alignment<VEC_SIZE>(value_src, value_dst, n_elems,
+                                           threadIdx.x, blockDim.x,
+                                           CopyFp16ToE5M2UnitScaleOp{});
+      } else {
+        CopyWithScaleOp<cache_t, scalar_t, kv_dt> v_op{v_scale_val};
+        vectorize_with_alignment<VEC_SIZE>(value_src, value_dst, n_elems,
+                                           threadIdx.x, blockDim.x, v_op);
+      }
+    } else {
+      CopyWithScaleOp<cache_t, scalar_t, kv_dt> k_op{k_scale_val};
+      CopyWithScaleOp<cache_t, scalar_t, kv_dt> v_op{v_scale_val};
 
-    vectorize_with_alignment<VEC_SIZE>(key_src, key_dst, n_elems, threadIdx.x,
-                                       blockDim.x, k_op);
-    vectorize_with_alignment<VEC_SIZE>(value_src, value_dst, n_elems,
-                                       threadIdx.x, blockDim.x, v_op);
+      vectorize_with_alignment<VEC_SIZE>(key_src, key_dst, n_elems, threadIdx.x,
+                                         blockDim.x, k_op);
+      vectorize_with_alignment<VEC_SIZE>(value_src, value_dst, n_elems,
+                                         threadIdx.x, blockDim.x, v_op);
+    }
   } else {
     // HND layout OR k/v_scales are [num_heads] (i.e. per-attn-head)
     // HND layout: heads are strided, but each head_size segment is contiguous
@@ -380,16 +430,35 @@ __global__ void reshape_and_cache_flash_kernel(
                               ? 0.f
                               : v_scale[head * kv_scale_stride];
 
-      CopyWithScaleOp<cache_t, scalar_t, kv_dt> k_op{k_scale_val};
-      CopyWithScaleOp<cache_t, scalar_t, kv_dt> v_op{v_scale_val};
+      if constexpr (kv_dt == Fp8KVCacheDataType::kFp8E5M2 &&
+                    std::is_same_v<scalar_t, uint16_t> &&
+                    std::is_same_v<cache_t, uint8_t>) {
+        if (k_scale_val == 1.f) {
+          vectorize_with_alignment<VEC_SIZE>(k_src_h, k_dst_h, head_size, lane,
+                                             32, CopyFp16ToE5M2UnitScaleOp{});
+        } else {
+          CopyWithScaleOp<cache_t, scalar_t, kv_dt> k_op{k_scale_val};
+          vectorize_with_alignment<VEC_SIZE>(k_src_h, k_dst_h, head_size, lane,
+                                             32, k_op);
+        }
+        if (v_scale_val == 1.f) {
+          vectorize_with_alignment<VEC_SIZE>(v_src_h, v_dst_h, head_size, lane,
+                                             32, CopyFp16ToE5M2UnitScaleOp{});
+        } else {
+          CopyWithScaleOp<cache_t, scalar_t, kv_dt> v_op{v_scale_val};
+          vectorize_with_alignment<VEC_SIZE>(v_src_h, v_dst_h, head_size, lane,
+                                             32, v_op);
+        }
+      } else {
+        CopyWithScaleOp<cache_t, scalar_t, kv_dt> k_op{k_scale_val};
+        CopyWithScaleOp<cache_t, scalar_t, kv_dt> v_op{v_scale_val};
 
-      // within each head, let the 32 threads of the warp perform the vector
-      // copy
-      vectorize_with_alignment<VEC_SIZE>(k_src_h, k_dst_h, head_size, lane, 32,
-                                         k_op);
-
-      vectorize_with_alignment<VEC_SIZE>(v_src_h, v_dst_h, head_size, lane, 32,
-                                         v_op);
+        // Within each head, let one warp perform the vector copy.
+        vectorize_with_alignment<VEC_SIZE>(k_src_h, k_dst_h, head_size, lane,
+                                           32, k_op);
+        vectorize_with_alignment<VEC_SIZE>(v_src_h, v_dst_h, head_size, lane,
+                                           32, v_op);
+      }
     }
   }
 }
@@ -804,7 +873,19 @@ void reshape_and_cache_flash(
   int kv_scale_stride = (k_scale.numel() > 1) ? 1 : 0;
 
   dim3 grid(num_tokens);
-  dim3 block(std::min(num_heads * head_size, 512));
+  int num_threads = std::min(num_heads * head_size, 512);
+  if (head_stride == head_size && kv_scale_stride == 0) {
+    // The contiguous path assigns one thread per vector, not one thread per
+    // scalar. Avoid launching idle warps for small-GQA decode shapes such as
+    // Hkv=1, D=256, where 32 threads process all 32 FP16 vectors.
+    const int vec_size = key.element_size() == 2 ? 8 : 4;
+    const int num_vectors = (num_heads * head_size + vec_size - 1) / vec_size;
+    num_threads = std::min(((num_vectors + 31) / 32) * 32, 512);
+  } else {
+    // The strided-head path assigns one warp per KV head.
+    num_threads = std::min(std::max(num_heads, 1) * 32, 512);
+  }
+  dim3 block(num_threads);
 
   DISPATCH_BY_KV_CACHE_DTYPE(key.scalar_type(), kv_cache_dtype,
                              CALL_RESHAPE_AND_CACHE_FLASH);

--- a/csrc/ops.h
+++ b/csrc/ops.h
@@ -174,16 +174,10 @@ void fp8_gemm_sm70_out(torch::Tensor out,
                        int64_t q_ld,
                        bool gated_silu);
 
-void fp8_gemm_sm70_prefill_dispatch_out(torch::Tensor out,
-                                        torch::Tensor dense_weight,
-                                        torch::Tensor _in_feats,
-                                        torch::Tensor _kernel,
-                                        torch::Tensor _scaling_factors,
-                                        int64_t group_size,
-                                        int64_t k_ld,
-                                        int64_t q_ld,
-                                        bool gated_silu,
-                                        int64_t min_prefill_m);
+void fp8_gemm_sm70_prefill_dispatch_out(
+    torch::Tensor out, int64_t dense_weight_ptr, torch::Tensor _in_feats,
+    torch::Tensor _kernel, torch::Tensor _scaling_factors, int64_t group_size,
+    int64_t k_ld, int64_t q_ld, bool gated_silu, int64_t min_prefill_m);
 
 void mxfp4_gemm_sm70_out(torch::Tensor out,
                          torch::Tensor _in_feats,

--- a/csrc/ops.h
+++ b/csrc/ops.h
@@ -116,6 +116,11 @@ std::vector<torch::Tensor> fp8_sm70_prepare(torch::Tensor _kernel,
                                             int64_t group_size,
                                             bool interleave_gated_silu);
 
+void fp8_sm70_dequantize_out(torch::Tensor out,
+                             torch::Tensor _kernel,
+                             torch::Tensor _scaling_factors,
+                             int64_t group_size);
+
 std::vector<torch::Tensor> mxfp4_sm70_prepare(torch::Tensor _kernel,
                                               torch::Tensor _scaling_factors,
                                               int64_t group_size,
@@ -168,6 +173,17 @@ void fp8_gemm_sm70_out(torch::Tensor out,
                        int64_t k_ld,
                        int64_t q_ld,
                        bool gated_silu);
+
+void fp8_gemm_sm70_prefill_dispatch_out(torch::Tensor out,
+                                        torch::Tensor dense_weight,
+                                        torch::Tensor _in_feats,
+                                        torch::Tensor _kernel,
+                                        torch::Tensor _scaling_factors,
+                                        int64_t group_size,
+                                        int64_t k_ld,
+                                        int64_t q_ld,
+                                        bool gated_silu,
+                                        int64_t min_prefill_m);
 
 void mxfp4_gemm_sm70_out(torch::Tensor out,
                          torch::Tensor _in_feats,

--- a/csrc/sm70_turbomind/ops/awq_sm70_gemm.cu
+++ b/csrc/sm70_turbomind/ops/awq_sm70_gemm.cu
@@ -3519,7 +3519,7 @@ void fp8_gemm_sm70_out(torch::Tensor out, torch::Tensor in_feats,
 }
 
 void fp8_gemm_sm70_prefill_dispatch_out(
-    torch::Tensor out, torch::Tensor dense_weight, torch::Tensor in_feats,
+    torch::Tensor out, int64_t dense_weight_ptr, torch::Tensor in_feats,
     torch::Tensor tm_weight, torch::Tensor tm_scales, int64_t group_size,
     int64_t k_ld, int64_t q_ld, bool gated_silu, int64_t min_prefill_m) {
   if (in_feats.size(0) < min_prefill_m) {
@@ -3528,11 +3528,11 @@ void fp8_gemm_sm70_prefill_dispatch_out(
     return;
   }
 
-  TORCH_CHECK(in_feats.dim() == 2 && dense_weight.dim() == 2,
+  TORCH_CHECK(in_feats.dim() == 2 && dense_weight_ptr != 0,
               "SM70 FP8 prefill dispatch expects rank-2 input and workspace.");
-  TORCH_CHECK(dense_weight.size(0) == in_feats.size(1) &&
-                  dense_weight.size(1) == tm_weight.size(1),
-              "SM70 FP8 prefill dispatch workspace shape mismatch.");
+  auto dense_weight = torch::from_blob(
+      reinterpret_cast<void*>(dense_weight_ptr),
+      {in_feats.size(1), tm_weight.size(1)}, in_feats.options());
   fp8_sm70_dequantize_out(dense_weight, tm_weight, tm_scales, group_size);
   if (gated_silu) {
     auto gate_up = at::mm(in_feats, dense_weight);
@@ -4876,12 +4876,12 @@ void fp8_gemm_sm70_out(torch::Tensor out, torch::Tensor _in_feats,
 }
 
 void fp8_gemm_sm70_prefill_dispatch_out(
-    torch::Tensor out, torch::Tensor dense_weight, torch::Tensor _in_feats,
+    torch::Tensor out, int64_t dense_weight_ptr, torch::Tensor _in_feats,
     torch::Tensor _kernel, torch::Tensor _scaling_factors, int64_t group_size,
     int64_t k_ld, int64_t q_ld, bool gated_silu, int64_t min_prefill_m) {
   vllm::awq_sm70::fp8_gemm_sm70_prefill_dispatch_out(
-      out, dense_weight, _in_feats, _kernel, _scaling_factors, group_size, k_ld,
-      q_ld, gated_silu, min_prefill_m);
+      out, dense_weight_ptr, _in_feats, _kernel, _scaling_factors, group_size,
+      k_ld, q_ld, gated_silu, min_prefill_m);
 }
 
 void mxfp4_gemm_sm70_out(torch::Tensor out, torch::Tensor _in_feats,

--- a/csrc/sm70_turbomind/ops/awq_sm70_gemm.cu
+++ b/csrc/sm70_turbomind/ops/awq_sm70_gemm.cu
@@ -2368,6 +2368,109 @@ void awq_sm70_dequantize_out(torch::Tensor output, torch::Tensor packed_weight,
   C10_CUDA_KERNEL_LAUNCH_CHECK();
 }
 
+constexpr int kFp8PrefillDequantThreads = 256;
+constexpr int kFp8QuantValuesPerWord = 8;
+constexpr int kFp8OutputColumnsPerTile = 32;
+
+__global__ void fp8_sm70_dequantize_kernel(
+    __half* __restrict__ output, const uint8_t* __restrict__ packed_weight,
+    const __half* __restrict__ packed_scales, int k, int n, int group_size) {
+  const int64_t word_index =
+      static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  const int64_t word_count =
+      static_cast<int64_t>(k) * n / kFp8QuantValuesPerWord;
+  if (word_index >= word_count) {
+    return;
+  }
+
+  const int words_per_n_tile = k / kFp8QuantValuesPerWord;
+  const int n_in_tile =
+      static_cast<int>(word_index % kFp8OutputColumnsPerTile);
+  const int64_t tile_word = word_index / kFp8OutputColumnsPerTile;
+  const int k_word = static_cast<int>(tile_word % words_per_n_tile);
+  const int n_tile = static_cast<int>(tile_word / words_per_n_tile);
+  const int col = n_tile * kFp8OutputColumnsPerTile + n_in_tile;
+  const int k_base = k_word * kFp8QuantValuesPerWord;
+  const int group = k_base / group_size;
+
+  const uint2 quant = reinterpret_cast<const uint2*>(packed_weight)[word_index];
+  const auto& quant_lo = reinterpret_cast<
+      const turbomind::Array<turbomind::fp8_e4m3_t, 4>&>(quant.x);
+  const auto& quant_hi = reinterpret_cast<
+      const turbomind::Array<turbomind::fp8_e4m3_t, 4>&>(quant.y);
+  const auto half_lo = turbomind::cvt_f16x4_e4m3(quant_lo);
+  const auto half_hi = turbomind::cvt_f16x4_e4m3(quant_hi);
+  const __half scale = packed_scales[static_cast<int64_t>(group) * n + col];
+
+  // cvt_f16x4_e4m3 reverses the converter's physical [0, 2, 1, 3]
+  // byte order and returns each logical K4 in-order.
+  output[static_cast<int64_t>(k_base + 0) * n + col] =
+      __hmul(half_lo[0], scale);
+  output[static_cast<int64_t>(k_base + 1) * n + col] =
+      __hmul(half_lo[1], scale);
+  output[static_cast<int64_t>(k_base + 2) * n + col] =
+      __hmul(half_lo[2], scale);
+  output[static_cast<int64_t>(k_base + 3) * n + col] =
+      __hmul(half_lo[3], scale);
+  output[static_cast<int64_t>(k_base + 4) * n + col] =
+      __hmul(half_hi[0], scale);
+  output[static_cast<int64_t>(k_base + 5) * n + col] =
+      __hmul(half_hi[1], scale);
+  output[static_cast<int64_t>(k_base + 6) * n + col] =
+      __hmul(half_hi[2], scale);
+  output[static_cast<int64_t>(k_base + 7) * n + col] =
+      __hmul(half_hi[3], scale);
+}
+
+void fp8_sm70_dequantize_out(torch::Tensor output,
+                             torch::Tensor packed_weight,
+                             torch::Tensor packed_scales,
+                             int64_t group_size) {
+  TORCH_CHECK(
+      output.is_cuda() && packed_weight.is_cuda() && packed_scales.is_cuda(),
+      "SM70 FP8 prefill dequant expects CUDA tensors.");
+  TORCH_CHECK(output.scalar_type() == torch::kFloat16 &&
+                  packed_weight.scalar_type() == torch::kUInt8 &&
+                  packed_scales.scalar_type() == torch::kFloat16,
+              "SM70 FP8 prefill dequant dtype mismatch.");
+  TORCH_CHECK(
+      output.dim() == 2 && packed_weight.dim() == 2 && packed_scales.dim() == 2,
+      "SM70 FP8 prefill dequant expects rank-2 tensors.");
+  TORCH_CHECK(output.is_contiguous() && packed_weight.is_contiguous() &&
+                  packed_scales.is_contiguous(),
+              "SM70 FP8 prefill dequant expects contiguous tensors.");
+  TORCH_CHECK(group_size == 128,
+              "SM70 FP8 prefill dequant requires group_size=128.");
+
+  const at::cuda::OptionalCUDAGuard device_guard(device_of(output));
+  const int64_t k = output.size(0);
+  const int64_t n = output.size(1);
+  TORCH_CHECK(k % group_size == 0 &&
+                  k % kFp8QuantValuesPerWord == 0 &&
+                  n % kFp8OutputColumnsPerTile == 0,
+              "SM70 FP8 prefill dequant shape alignment mismatch.");
+  TORCH_CHECK(packed_weight.numel() == k * n,
+              "SM70 FP8 prefill packed-weight shape mismatch.");
+  TORCH_CHECK(
+      packed_scales.size(0) == k / group_size && packed_scales.size(1) == n,
+      "SM70 FP8 prefill packed-scale shape mismatch.");
+  TORCH_CHECK(output.device() == packed_weight.device() &&
+                  output.device() == packed_scales.device(),
+              "SM70 FP8 prefill tensors must share a device.");
+
+  const int64_t words = packed_weight.numel() / kFp8QuantValuesPerWord;
+  const int blocks = static_cast<int>(
+      (words + kFp8PrefillDequantThreads - 1) / kFp8PrefillDequantThreads);
+  fp8_sm70_dequantize_kernel<<<blocks, kFp8PrefillDequantThreads, 0,
+                               at::cuda::getCurrentCUDAStream()>>>(
+      reinterpret_cast<__half*>(output.data_ptr<at::Half>()),
+      packed_weight.data_ptr<uint8_t>(),
+      reinterpret_cast<const __half*>(packed_scales.data_ptr<at::Half>()),
+      static_cast<int>(k), static_cast<int>(n),
+      static_cast<int>(group_size));
+  C10_CUDA_KERNEL_LAUNCH_CHECK();
+}
+
 torch::Tensor interleave_gated_silu_cols(torch::Tensor tensor) {
   const int64_t n = tensor.size(-1);
   TORCH_CHECK((n % 2) == 0,
@@ -3413,6 +3516,31 @@ void fp8_gemm_sm70_out(torch::Tensor out, torch::Tensor in_feats,
                           desc_V, 0.f, out.data_ptr(), desc_D, out.data_ptr(),
                           desc_D, workspace_holder.workspace, stream);
   TORCH_CHECK(ec == 0, "fp8_gemm_sm70: TurboMind GEMM failed.");
+}
+
+void fp8_gemm_sm70_prefill_dispatch_out(
+    torch::Tensor out, torch::Tensor dense_weight, torch::Tensor in_feats,
+    torch::Tensor tm_weight, torch::Tensor tm_scales, int64_t group_size,
+    int64_t k_ld, int64_t q_ld, bool gated_silu, int64_t min_prefill_m) {
+  if (in_feats.size(0) < min_prefill_m) {
+    fp8_gemm_sm70_out(out, in_feats, tm_weight, tm_scales, group_size, k_ld,
+                      q_ld, gated_silu);
+    return;
+  }
+
+  TORCH_CHECK(in_feats.dim() == 2 && dense_weight.dim() == 2,
+              "SM70 FP8 prefill dispatch expects rank-2 input and workspace.");
+  TORCH_CHECK(dense_weight.size(0) == in_feats.size(1) &&
+                  dense_weight.size(1) == tm_weight.size(1),
+              "SM70 FP8 prefill dispatch workspace shape mismatch.");
+  fp8_sm70_dequantize_out(dense_weight, tm_weight, tm_scales, group_size);
+  if (gated_silu) {
+    auto gate_up = at::mm(in_feats, dense_weight);
+    sm70_silu_and_mul_interleaved_fp16_out(out, gate_up);
+    C10_CUDA_KERNEL_LAUNCH_CHECK();
+    return;
+  }
+  at::mm_out(out, in_feats, dense_weight);
 }
 
 void mxfp4_gemm_sm70_out(torch::Tensor out, torch::Tensor in_feats,
@@ -4678,6 +4806,13 @@ std::vector<torch::Tensor> fp8_sm70_prepare(torch::Tensor _kernel,
                                           interleave_gated_silu);
 }
 
+void fp8_sm70_dequantize_out(torch::Tensor out, torch::Tensor _kernel,
+                             torch::Tensor _scaling_factors,
+                             int64_t group_size) {
+  vllm::awq_sm70::fp8_sm70_dequantize_out(out, _kernel, _scaling_factors,
+                                          group_size);
+}
+
 std::vector<torch::Tensor> mxfp4_sm70_prepare(torch::Tensor _kernel,
                                               torch::Tensor _scaling_factors,
                                               int64_t group_size,
@@ -4738,6 +4873,15 @@ void fp8_gemm_sm70_out(torch::Tensor out, torch::Tensor _in_feats,
                        bool gated_silu) {
   vllm::awq_sm70::fp8_gemm_sm70_out(out, _in_feats, _kernel, _scaling_factors,
                                     group_size, k_ld, q_ld, gated_silu);
+}
+
+void fp8_gemm_sm70_prefill_dispatch_out(
+    torch::Tensor out, torch::Tensor dense_weight, torch::Tensor _in_feats,
+    torch::Tensor _kernel, torch::Tensor _scaling_factors, int64_t group_size,
+    int64_t k_ld, int64_t q_ld, bool gated_silu, int64_t min_prefill_m) {
+  vllm::awq_sm70::fp8_gemm_sm70_prefill_dispatch_out(
+      out, dense_weight, _in_feats, _kernel, _scaling_factors, group_size, k_ld,
+      q_ld, gated_silu, min_prefill_m);
 }
 
 void mxfp4_gemm_sm70_out(torch::Tensor out, torch::Tensor _in_feats,

--- a/csrc/torch_bindings.cpp
+++ b/csrc/torch_bindings.cpp
@@ -191,6 +191,12 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, ops) {
   ops.impl("fp8_sm70_prepare", torch::kCUDA, &fp8_sm70_prepare);
 
   ops.def(
+      "fp8_sm70_dequantize_out(Tensor(a!) out, Tensor _kernel, "
+      "Tensor _scaling_factors, int group_size) -> ()");
+  ops.impl("fp8_sm70_dequantize_out", torch::kCUDA,
+           &fp8_sm70_dequantize_out);
+
+  ops.def(
       "mxfp4_sm70_prepare(Tensor _kernel, Tensor _scaling_factors, "
       "int group_size, bool interleave_gated_silu) -> Tensor[]");
   ops.impl("mxfp4_sm70_prepare", torch::kCUDA, &mxfp4_sm70_prepare);
@@ -230,6 +236,14 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, ops) {
       "Tensor _scaling_factors, int group_size, int k_ld, int q_ld, "
       "bool gated_silu) -> ()");
   ops.impl("fp8_gemm_sm70_out", torch::kCUDA, &fp8_gemm_sm70_out);
+
+  ops.def(
+      "fp8_gemm_sm70_prefill_dispatch_out(Tensor(a!) out, "
+      "Tensor(b!) dense_weight, Tensor _in_feats, Tensor _kernel, "
+      "Tensor _scaling_factors, int group_size, int k_ld, int q_ld, "
+      "bool gated_silu, int min_prefill_m) -> ()");
+  ops.impl("fp8_gemm_sm70_prefill_dispatch_out", torch::kCUDA,
+           &fp8_gemm_sm70_prefill_dispatch_out);
 
   ops.def(
       "mxfp4_gemm_sm70_out(Tensor(a!) out, Tensor _in_feats, Tensor _kernel, "

--- a/csrc/torch_bindings.cpp
+++ b/csrc/torch_bindings.cpp
@@ -239,7 +239,7 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, ops) {
 
   ops.def(
       "fp8_gemm_sm70_prefill_dispatch_out(Tensor(a!) out, "
-      "Tensor(b!) dense_weight, Tensor _in_feats, Tensor _kernel, "
+      "int dense_weight_ptr, Tensor _in_feats, Tensor _kernel, "
       "Tensor _scaling_factors, int group_size, int k_ld, int q_ld, "
       "bool gated_silu, int min_prefill_m) -> ()");
   ops.impl("fp8_gemm_sm70_prefill_dispatch_out", torch::kCUDA,

--- a/docs/design/sm70_fp8_long_prefill_exact_dense.md
+++ b/docs/design/sm70_fp8_long_prefill_exact_dense.md
@@ -23,6 +23,15 @@ The accepted implementation places the M decision in the opaque CUDA op
 layout into one shared 85 MiB FP16 KxN workspace, then uses `mm_out` or the
 exact gated-SiLU epilogue. M below 3920 stays in TurboMind.
 
+The first implementation passed a view of that workspace as a Tensor argument.
+Inductor lifted the large Tensor into the compiled graph and CUDA graph input
+handling reduced 1K/256 single-request throughput from about 60 to 19 tok/s;
+graph memory also grew from 0.26 to about 0.42 GiB/rank. The corrected ABI
+passes the stable CUDA address as an integer. A process-global strong reference
+keeps one workspace alive per device, and the C++ op only wraps that address for
+M at or above the threshold. Small-M decode returns to TurboMind before the
+workspace is wrapped.
+
 The default allowlist is TP4 plus the exact `(K,N)` shape for
 `gate_up_proj`, `down_proj`, `out_proj`, and `o_proj`. `qkv_proj` and
 `in_proj_qkvz` remain excluded because direct dense evaluation changed FP16
@@ -52,6 +61,19 @@ Matched chunk-15680 control and candidate requests preserve output hashes.
 | 128K | 53.575 s | 2446.5 |
 | 256K* | 163.472 s | 1602.0 |
 
+The corrected pointer ABI preserves decode and concurrency performance. These
+results use 64 independent 1K/256 requests per row and official sampling. Each
+row completed 64/64 requests; concurrency 4 was repeated because its first run
+measured 188.68 tok/s.
+
+| Concurrency | Output tok/s | Scale vs C1 | Parallel efficiency | Mean TPOT | P99 TPOT |
+|---:|---:|---:|---:|---:|---:|
+| 1 | 60.44 | 1.00x | 100.0% | 15.16 ms | 15.32 ms |
+| 2 | 108.72 | 1.80x | 89.9% | 16.29 ms | 17.13 ms |
+| 4 | 192.39 | 3.18x | 79.6% | 16.88 ms | 19.58 ms |
+| 8 | 309.70 | 5.12x | 64.0% | 18.16 ms | 24.55 ms |
+| 16 | 412.35 | 6.82x | 42.6% | 23.03 ms | 38.57 ms |
+
 The remembered 128K/256K reference was Qwen3.6-27B-AWQ without prefix
 caching: 2517.6/1655.0 tok/s, not a same-model Qwen3.8-FP8 result. The current
 Qwen3.8 production contract is within 2.8%/3.2% of that cross-model reference.
@@ -62,8 +84,15 @@ Qwen3.8 production contract is within 2.8%/3.2% of that cross-model reference.
   projections.
 - 32K, 128K, and 256K candidate output hashes exactly match their controls.
   All short-sweep repeats also have stable hashes and `is_corrupted=false`.
+- The pointer-ABI microbenchmark is bitwise equal at M=1 and M=3920. M=1 is
+  0.01636 ms direct versus 0.01666 ms through dispatch; M=3920 is 1.062 ms
+  direct versus 0.800 ms through dispatch (1.33x).
+- A 6278-token natural prompt follows its final instruction, emits coherent
+  text, and stops naturally after 47 tokens on the corrected full-graph path.
 - Model residency is 7.57 GiB/rank. The 85 MiB shared workspace leaves
   19.18 GiB/rank for KV and an estimated 4.70x 256K cache capacity.
+- CUDA graph capture uses 0.26 GiB/rank after the pointer fix, matching the
+  exact-dense-off control instead of the regressed 0.42 GiB/rank path.
 - Compiled microbenchmarks prove both M=784 and M=3920 reach the same runtime
   dispatch op. M3920 and M7840 improve 1.31x and 1.46x with zero mismatch.
 
@@ -81,3 +110,4 @@ Qwen3.8 production contract is within 2.8%/3.2% of that cross-model reference.
 - Candidate short sweep: `/data/minimax-h3/task-cache/qwen38-130-prefill-recovery-20260815/candidate-dispatch/results/short-1k-64k.json`
 - Candidate long sweep: `/data/minimax-h3/task-cache/qwen38-130-prefill-recovery-20260815/candidate-dispatch/results/long-128k-256k.json`
 - Route trace: `/data/minimax-h3/task-cache/qwen38-130-prefill-recovery-20260815/candidate-dispatch/nsys/qwen38_fp8_dispatch_tp4_i32k_r2.nsys-rep`
+- Decode/concurrency regression fix: `/data/minimax-h3/task-cache/qwen38-130-concurrency-latest-20260815`

--- a/docs/design/sm70_fp8_long_prefill_exact_dense.md
+++ b/docs/design/sm70_fp8_long_prefill_exact_dense.md
@@ -1,0 +1,83 @@
+# SM70 FP8 Long-Prefill Exact-Dense Projections
+
+Date: 2026-08-15
+
+## Scope
+
+This route accelerates Qwen3.8-27B-FP8 TP4 prefill on four V100-32GB GPUs.
+The accepted contract uses Python 3.12, Torch 2.10.0+cu128, FP16 KV,
+Flash-V100, prefix caching with Mamba align, CUDA graphs, no MTP, and
+`max_num_batched_tokens=15680`.
+
+## Root Cause
+
+The earlier Flash-V100 gather/exact-D256 attention route was active. The
+missing gain was in large-M FP8 projections: TurboMind's W8A16 kernel is the
+correct decode and tail path, but the 32K Nsight trace attributed 68.4% of
+summed FP8 projection time to it. A first Python `M >= 3920` branch was also
+invalid because the dynamic compile range folded the branch during tracing;
+the measured request still launched 3648 TurboMind calls and no dense GEMM.
+
+The accepted implementation places the M decision in the opaque CUDA op
+`fp8_gemm_sm70_prefill_dispatch_out`. It reconstructs TurboMind's K8/N32 FP8
+layout into one shared 85 MiB FP16 KxN workspace, then uses `mm_out` or the
+exact gated-SiLU epilogue. M below 3920 stays in TurboMind.
+
+The default allowlist is TP4 plus the exact `(K,N)` shape for
+`gate_up_proj`, `down_proj`, `out_proj`, and `o_proj`. `qkv_proj` and
+`in_proj_qkvz` remain excluded because direct dense evaluation changed FP16
+outputs. The environment rollback is
+`VLLM_SM70_FP8_PREFILL_EXACT_DENSE=0`.
+
+## Performance
+
+Matched chunk-15680 control and candidate requests preserve output hashes.
+
+| Input | Control prefill | Candidate prefill | Control tok/s | Candidate tok/s | Throughput gain |
+|---:|---:|---:|---:|---:|---:|
+| 32K | 11.024 s | 9.010 s | 2972.3 | 3636.7 | 22.36% |
+| 128K | 60.507 s | 53.575 s | 2166.2 | 2446.5 | 12.94% |
+| 256K* | 175.323 s | 163.472 s | 1493.7 | 1602.0 | 7.25% |
+
+`256K*` uses 261888 prompt tokens. The final sustained sweep is:
+
+| Input | Mean prefill | Prompt tok/s |
+|---:|---:|---:|
+| 1K | 0.407 s | 2515.1 |
+| 4K | 1.065 s | 3847.8 |
+| 8K | 2.199 s | 3725.4 |
+| 16K | 4.199 s | 3901.6 |
+| 32K | 9.533 s | 3437.2 |
+| 64K | 22.981 s | 2851.7 |
+| 128K | 53.575 s | 2446.5 |
+| 256K* | 163.472 s | 1602.0 |
+
+The remembered 128K/256K reference was Qwen3.6-27B-AWQ without prefix
+caching: 2517.6/1655.0 tok/s, not a same-model Qwen3.8-FP8 result. The current
+Qwen3.8 production contract is within 2.8%/3.2% of that cross-model reference.
+
+## Correctness And Memory
+
+- 72 real-weight rank/shape/M checks are bitwise equal for all admitted
+  projections.
+- 32K, 128K, and 256K candidate output hashes exactly match their controls.
+  All short-sweep repeats also have stable hashes and `is_corrupted=false`.
+- Model residency is 7.57 GiB/rank. The 85 MiB shared workspace leaves
+  19.18 GiB/rank for KV and an estimated 4.70x 256K cache capacity.
+- Compiled microbenchmarks prove both M=784 and M=3920 reach the same runtime
+  dispatch op. M3920 and M7840 improve 1.31x and 1.46x with zero mismatch.
+
+## Closed Paths
+
+- Do not restore a Python dynamic-M branch; `torch.compile` can fold it.
+- Do not include QKV shapes without a new bitwise proof.
+- Extending dense split-KV3 from Q4096 to Q15680 gives only 0.85%-1.80%
+  attention-kernel gain, needs about 290 MiB/rank of FP32 workspace, and is
+  not bitwise. It is not promoted.
+
+## Evidence
+
+- Control: `/data/minimax-h3/task-cache/qwen38-130-prefill-recovery-20260815/results/chunk15680-long-sweep.json`
+- Candidate short sweep: `/data/minimax-h3/task-cache/qwen38-130-prefill-recovery-20260815/candidate-dispatch/results/short-1k-64k.json`
+- Candidate long sweep: `/data/minimax-h3/task-cache/qwen38-130-prefill-recovery-20260815/candidate-dispatch/results/long-128k-256k.json`
+- Route trace: `/data/minimax-h3/task-cache/qwen38-130-prefill-recovery-20260815/candidate-dispatch/nsys/qwen38_fp8_dispatch_tp4_i32k_r2.nsys-rep`

--- a/docs/design/sm70_qwen38_130_acceptance.md
+++ b/docs/design/sm70_qwen38_130_acceptance.md
@@ -30,22 +30,27 @@ Date: 2026-08-15
 - The benchmark harness records official sampling, generated-token count,
   natural-stop state, TTFT/prefill, pure decode TPOT, acceptance length, route
   policy, and token hashes.
+- Large-M TP4 FP8 gate/up/down/output projections now use a compile-safe
+  runtime exact-dense dispatch with one shared 85 MiB workspace. Decode,
+  tails, and numerically unsafe QKV shapes retain TurboMind.
 
 ## No-MTP Long Context
 
-The FP16-KV production sweep uses repeated official-sampling requests. The
-FP8-KV sweep uses a generation suffix and produces 256 tokens at every point.
+The FP16-KV prefill column is the final no-MTP chunk-15680 route. The 1K-64K
+rows are two-repeat cold-cache means; 128K and 256K are one cold-cache request.
+Decode columns retain the official-sampling release sweep. The FP8-KV sweep
+uses a generation suffix and produces 256 tokens at every point.
 
 | Context | FP16 KV prefill tok/s | FP16 KV decode tok/s | FP8 KV prefill tok/s | FP8 KV decode tok/s |
 |---:|---:|---:|---:|---:|
-| 1K | 2550.2 | 65.05 | 3430.8 | 66.36 |
-| 4K | 3093.7 | 63.35 | 3591.3 | 65.61 |
-| 8K | 2884.0 | 64.04 | 2995.9 | 65.50 |
-| 16K | 2677.8 | 63.90 | 2797.0 | 65.36 |
-| 32K | 2341.9 | 60.07* | 2516.2 | 59.97 |
-| 64K | 1995.8 | 58.44* | 2063.4 | 52.30 |
-| 128K | 1501.6 | 46.95 | 1519.6 | 42.35 |
-| 256K | 1004.7 | 36.96 | 1007.1 | 31.49 |
+| 1K | 2515.1 | 65.05 | 3430.8 | 66.36 |
+| 4K | 3847.8 | 63.35 | 3591.3 | 65.61 |
+| 8K | 3725.4 | 64.04 | 2995.9 | 65.50 |
+| 16K | 3901.6 | 63.90 | 2797.0 | 65.36 |
+| 32K | 3437.2 | 60.07* | 2516.2 | 59.97 |
+| 64K | 2851.7 | 58.44* | 2063.4 | 52.30 |
+| 128K | 2446.5 | 46.95 | 1519.6 | 42.35 |
+| 256K | 1602.0 | 36.96 | 1007.1 | 31.49 |
 
 `*` The FP16-KV 32K and 64K requests naturally stopped after 2 and 17 output
 tokens. Keep those rows as route checks, not high-confidence decode means.
@@ -117,3 +122,6 @@ Artifacts are rooted at
 `/data/minimax-h3/task-cache/qwen38-130-acceptance-20260815`. Retained groups
 are `context/`, `concurrency/`, `mtp/`, `correctness/`, `profiles/nsys/`,
 `compat/`, `build/final-wheel/`, and `logs/`.
+
+The corrected FP8 prefill implementation, A/B results, and retained profiles
+are documented in `docs/design/sm70_fp8_long_prefill_exact_dense.md`.

--- a/docs/design/sm70_qwen38_130_acceptance.md
+++ b/docs/design/sm70_qwen38_130_acceptance.md
@@ -31,8 +31,9 @@ Date: 2026-08-15
   natural-stop state, TTFT/prefill, pure decode TPOT, acceptance length, route
   policy, and token hashes.
 - Large-M TP4 FP8 gate/up/down/output projections now use a compile-safe
-  runtime exact-dense dispatch with one shared 85 MiB workspace. Decode,
-  tails, and numerically unsafe QKV shapes retain TurboMind.
+  runtime exact-dense dispatch with one shared 85 MiB workspace. The workspace
+  address is passed as an integer so it is not copied into compiled graph
+  inputs. Decode, tails, and numerically unsafe QKV shapes retain TurboMind.
 
 ## No-MTP Long Context
 
@@ -71,19 +72,23 @@ no counter-derived bottleneck claim is made for this release.
 ## Concurrency
 
 All rows use 64 requests of exact 1K input and 256 output tokens with official
-sampling. Every request completed successfully.
+sampling. Prompt seeds differ between rows to prevent cross-row prefix-cache
+reuse. Every request completed successfully.
 
-| Concurrency | Old output tok/s | Accepted output tok/s | Gain | Mean TPOT |
-|---:|---:|---:|---:|---:|
-| 1 | 59.90 | 60.06 | +0.27% | 15.24 ms |
-| 2 | 107.13 | 107.00 | -0.12% | 16.47 ms |
-| 4 | 51.08 | 193.66 | +279.15% | 16.79 ms |
-| 8 | 95.60 | 296.35 | +209.99% | 18.48 ms |
-| 16 | 167.49 | 383.00 | +128.68% | 26.90 ms |
+| Concurrency | Prior accepted tok/s | Current tok/s | Change | Scale | Efficiency | Mean / P99 TPOT |
+|---:|---:|---:|---:|---:|---:|---:|
+| 1 | 60.06 | 60.44 | +0.63% | 1.00x | 100.0% | 15.16 / 15.32 ms |
+| 2 | 107.00 | 108.72 | +1.61% | 1.80x | 89.9% | 16.29 / 17.13 ms |
+| 4 | 193.66 | 192.39 | -0.65% | 3.18x | 79.6% | 16.88 / 19.58 ms |
+| 8 | 296.35 | 309.70 | +4.50% | 5.12x | 64.0% | 18.16 / 24.55 ms |
+| 16 | 383.00 | 412.35 | +7.66% | 6.82x | 42.6% | 23.03 / 38.57 ms |
 
-At concurrency 16 all four GPUs remain at 100% SM busy and about 51-52%
-memory busy. Remaining non-linear scaling is a saturated high-M kernel issue,
-not an idle-GPU or missing graph-shape issue.
+The first concurrency-4 run measured 188.68 tok/s; its independent repeat
+measured 192.39 tok/s and is reported above. Across the timed intervals all
+four V100s average 98.0-99.8% SM busy. Average memory busy falls from 50.7% at
+concurrency 1 to 38.3% at concurrency 16 while power rises from 194.7 to
+229.8 W/GPU. Remaining non-linear scaling is a high-M execution-efficiency
+issue, not an idle-GPU or missing graph-shape issue.
 
 ## MTP And Quality
 
@@ -99,6 +104,9 @@ not an idle-GPU or missing graph-shape issue.
   and `node --check`. One long stochastic seed repeated after about 6377 tokens;
   another bounded run naturally stopped at 7894 tokens. Treat this as a model
   sampling risk, not deterministic token or HTML-tag corruption.
+- The corrected FP8 workspace ABI passes a 6278-token natural prompt: it
+  follows the final four-line instruction, emits no replacement characters,
+  and stops naturally after 47 tokens.
 
 ## Wheel And Compatibility
 
@@ -125,3 +133,5 @@ are `context/`, `concurrency/`, `mtp/`, `correctness/`, `profiles/nsys/`,
 
 The corrected FP8 prefill implementation, A/B results, and retained profiles
 are documented in `docs/design/sm70_fp8_long_prefill_exact_dense.md`.
+The pointer-fix and concurrency artifacts are rooted at
+`/data/minimax-h3/task-cache/qwen38-130-concurrency-latest-20260815`.

--- a/docs/design/sm70_qwen38_130_acceptance.md
+++ b/docs/design/sm70_qwen38_130_acceptance.md
@@ -1,0 +1,119 @@
+# SM70 Qwen3.8-27B 1.3.0 Acceptance
+
+Date: 2026-08-15
+
+## Contract
+
+- Model: `Qwen3.8-27B-FP8`, TP4 on four V100-32GB GPUs.
+- Runtime: Python 3.12, Torch 2.10.0+cu128, CUDA 12.8, CUDA graphs enabled.
+- Production attention: `FLASH_ATTN_V100`; no eager or Marlin performance
+  evidence is accepted.
+- Official sampling is `temperature=1.0`, `top_p=0.95`, `top_k=20`.
+- Main long-context configuration uses 262144 tokens, chunked prefill, Mamba
+  align mode, and prefix caching. Speed tables use no MTP unless stated.
+
+## Accepted Changes
+
+- The G6 XQA QK producer/consumer pipeline is default-on only for the proven
+  111104-147840 token range. The final range keeps the prior kernel. At 128K,
+  full-model TPOT improves from 21.292 to 20.293 ms (-4.69%) with the same
+  token hash; the 256K route is neutral within 0.16%.
+- No-MTP CUDA graph capture now covers request shapes 1, 2, 4, 8, and 16,
+  bounded by `max_num_seqs`. This fixes the severe eager fallback above two
+  concurrent requests for 0.07 GiB/rank additional graph memory.
+- Qwen3.8 does not reuse the Qwen3.6 dynamic-draft-vocabulary asset. The
+  implicit asset is now restricted to model paths containing `qwen3.6-27b`;
+  Qwen3.8 MTP therefore fails closed to the full vocabulary.
+- FlashQLA SM70 is compiled into the wheel. Runtime first tries the packaged
+  extension and only source installs may fall back to JIT, with fixed SM70/75
+  gencode and retained first-error diagnostics.
+- The benchmark harness records official sampling, generated-token count,
+  natural-stop state, TTFT/prefill, pure decode TPOT, acceptance length, route
+  policy, and token hashes.
+
+## No-MTP Long Context
+
+The FP16-KV production sweep uses repeated official-sampling requests. The
+FP8-KV sweep uses a generation suffix and produces 256 tokens at every point.
+
+| Context | FP16 KV prefill tok/s | FP16 KV decode tok/s | FP8 KV prefill tok/s | FP8 KV decode tok/s |
+|---:|---:|---:|---:|---:|
+| 1K | 2550.2 | 65.05 | 3430.8 | 66.36 |
+| 4K | 3093.7 | 63.35 | 3591.3 | 65.61 |
+| 8K | 2884.0 | 64.04 | 2995.9 | 65.50 |
+| 16K | 2677.8 | 63.90 | 2797.0 | 65.36 |
+| 32K | 2341.9 | 60.07* | 2516.2 | 59.97 |
+| 64K | 1995.8 | 58.44* | 2063.4 | 52.30 |
+| 128K | 1501.6 | 46.95 | 1519.6 | 42.35 |
+| 256K | 1004.7 | 36.96 | 1007.1 | 31.49 |
+
+`*` The FP16-KV 32K and 64K requests naturally stopped after 2 and 17 output
+tokens. Keep those rows as route checks, not high-confidence decode means.
+
+The 128K Nsight Systems graph-node trace attributes 21.30 ms TPOT to:
+
+| Category | Time | Share |
+|---|---:|---:|
+| FP8 TurboMind dense GEMM | 8.946 ms | 42.1% |
+| Flash-V100 q=1 XQA | 5.274 ms | 25.2% |
+| TP all-reduce | 1.874 ms | 8.6% |
+| LM head, sample, and gather | 1.301 ms | 6.2% |
+| Other graph work and gaps | about 3.6 ms | 17.9% |
+
+NCU counter collection is unavailable on this host (`ERR_NVGPUCTRPERM`), so
+no counter-derived bottleneck claim is made for this release.
+
+## Concurrency
+
+All rows use 64 requests of exact 1K input and 256 output tokens with official
+sampling. Every request completed successfully.
+
+| Concurrency | Old output tok/s | Accepted output tok/s | Gain | Mean TPOT |
+|---:|---:|---:|---:|---:|
+| 1 | 59.90 | 60.06 | +0.27% | 15.24 ms |
+| 2 | 107.13 | 107.00 | -0.12% | 16.47 ms |
+| 4 | 51.08 | 193.66 | +279.15% | 16.79 ms |
+| 8 | 95.60 | 296.35 | +209.99% | 18.48 ms |
+| 16 | 167.49 | 383.00 | +128.68% | 26.90 ms |
+
+At concurrency 16 all four GPUs remain at 100% SM busy and about 51-52%
+memory busy. Remaining non-linear scaling is a saturated high-M kernel issue,
+not an idle-GPU or missing graph-shape issue.
+
+## MTP And Quality
+
+- Full-vocabulary MTP4, FP8 KV, 128K: 58.25 tok/s, 17.168 ms TPOT,
+  acceptance length 3.866, 256 valid output tokens.
+- Full-vocabulary MTP4, FP16 KV, 128K: 55.40 tok/s, 18.051 ms TPOT,
+  acceptance length 4.031, 256 valid output tokens.
+- Exact 256K boundary (`input_len=262120`, 24 outputs), MTP4 plus FP8 KV:
+  all token IDs are legal, `is_corrupted=false`, and acceptance length is 4.0.
+- Tool-call JSON and streaming tool calls parse correctly. A repeated 3136-token
+  prefix records a cache hit and reduces request latency from 1.965 to 1.152 s.
+- HTML/JavaScript quality prompts pass structural checks, natural-stop checks,
+  and `node --check`. One long stochastic seed repeated after about 6377 tokens;
+  another bounded run naturally stopped at 7894 tokens. Treat this as a model
+  sampling risk, not deterministic token or HTML-tag corruption.
+
+## Wheel And Compatibility
+
+- Wheel: `1cat_vllm-1.3.0-cp312-cp312-linux_x86_64.whl`.
+- SHA256: `df4275918461c67cb8af2c489a097cf5c7424e37706396267690094007eafdab`.
+- A cloned environment imports vLLM 1.3.0 from site-packages with Torch
+  2.10.0+cu128. `_moe_C.moe_permute_sort_workspace_size` is present.
+- The wheel contains `_C`, `_C_stable_libtorch`, `_moe_C`, Flash-V100,
+  vLLM FA2, and `flash_qla_sm70_gdn_strided.so`.
+- A clean-cache MTP4 plus FP8-KV boundary run does not create
+  `TORCH_EXTENSIONS_DIR`, proving FlashQLA does not invoke NVCC at runtime.
+- Qwen3.6-35B-A3B-AWQ TP2 final-wheel checks pass. Official 1K/256 and
+  4K/1024 pure decode are 95.63 and 95.29 tok/s (10.457 and 10.494 ms TPOT),
+  with complete, non-corrupted outputs and the TurboMind AWQ MoE route.
+- No Qwen3.6-35B-A3B-FP8 checkpoint is available on this host. FP8 35B speed
+  remains unmeasured and must not be inferred from AWQ or 27B results.
+
+## Evidence
+
+Artifacts are rooted at
+`/data/minimax-h3/task-cache/qwen38-130-acceptance-20260815`. Retained groups
+are `context/`, `concurrency/`, `mtp/`, `correctness/`, `profiles/nsys/`,
+`compat/`, `build/final-wheel/`, and `logs/`.

--- a/docs/design/sm70_qwen38_130_acceptance.md
+++ b/docs/design/sm70_qwen38_130_acceptance.md
@@ -100,10 +100,30 @@ issue, not an idle-GPU or missing graph-shape issue.
   all token IDs are legal, `is_corrupted=false`, and acceptance length is 4.0.
 - Tool-call JSON and streaming tool calls parse correctly. A repeated 3136-token
   prefix records a cache hit and reduces request latency from 1.965 to 1.152 s.
-- HTML/JavaScript quality prompts pass structural checks, natural-stop checks,
-  and `node --check`. One long stochastic seed repeated after about 6377 tokens;
-  another bounded run naturally stopped at 7894 tokens. Treat this as a model
-  sampling risk, not deterministic token or HTML-tag corruption.
+- The original acceptance run contains one unmatched no-MTP/FP16-KV sample
+  that reached the 8192-token request limit and began repeating after about
+  6377 tokens. Its request seed was not retained, so that artifact is neither
+  proof of a deterministic kernel defect nor sufficient evidence to dismiss
+  the failure as sampling variance.
+- A matched audit at source `7f409a7727` used the 74-token macOS prompt,
+  seed `20260620`, `temperature=1.0`, `top_p=0.95`, `top_k=20`, and a
+  32600-token output allowance. All four production combinations stopped
+  naturally with complete HTML/CSS/JavaScript and closed code fences:
+
+  | MTP | KV cache | Output tokens | Decode tok/s | Result |
+  | --- | --- | ---: | ---: | --- |
+  | off | FP16 | 24,441 | 61.63 | pass |
+  | off | E5M2 | 25,055 | 61.71 | pass |
+  | MTP4 | FP16 | 25,753 | 75.21 | pass |
+  | MTP4 | E5M2 | 18,642 | 81.82 | pass |
+
+  Repeated same-seed requests were byte-identical in every combination.
+  Prefix-cache-hit probes were also byte-identical for no-MTP/FP16,
+  MTP4/FP16, and MTP4/E5M2. The MTP4/E5M2 sample initially tripped the local
+  repeated-window heuristic because fourteen decorative `=====` section
+  separators contributed overlapping single-character windows; 200-character
+  windows did not repeat. The gate now leaves homogeneous runs to its separate
+  same-character-run check.
 - The corrected FP8 workspace ABI passes a 6278-token natural prompt: it
   follows the final four-line instruction, emits no replacement characters,
   and stops naturally after 47 tokens.

--- a/docs/design/sm70_qwen38_fp8_prefill_decay.md
+++ b/docs/design/sm70_qwen38_fp8_prefill_decay.md
@@ -1,0 +1,136 @@
+# SM70 Qwen3.8 FP8 Prefill Decay
+
+Date: 2026-08-15
+
+## Contract
+
+- Source base: `87ac589295ba64399695ef2237c37cffc0d8b71b`.
+- Model: Qwen3.8-27B-FP8 local checkpoint.
+- Model weights: FP8 E4M3. This is independent from the KV-cache dtype.
+- FP8 KV cache on SM70/Flash-V100: FP8 E5M2. The `fp8` CLI shorthand
+  resolves to E5M2 on this route; explicit E4M3 remains explicit E4M3.
+- Hardware: TP4 on V100-SXM2-16GB GPUs 0-3.
+- Runtime: Python 3.12, Torch 2.10.0+cu128, `FLASH_ATTN_V100`, prefix
+  caching with Mamba align, CUDA graphs, and no MTP. The chunk baseline and
+  128K trace use FP16 KV; the later regression and fixed-route sections use
+  the explicitly stated FP8 KV dtype.
+- Sampling: temperature 1.0, top-p 0.95, top-k 20, seed 20260815.
+
+## Chunk Baseline
+
+Every request resets the prefix cache and emits 32 tokens. Output hashes are
+stable and identical between the two chunk configurations.
+
+| Input | Chunk 15680 | Chunk 4096 | Chunk 15680 gain |
+|---:|---:|---:|---:|
+| 4K | 4160.0 tok/s | 4146.1 tok/s | 0.33% |
+| 16K | 4290.1 tok/s | 3841.2 tok/s | 11.69% |
+| 64K | 3420.2 tok/s | 2778.9 tok/s | 23.07% |
+| 128K | 2702.9 tok/s | 2020.5 tok/s | 33.77% |
+
+Chunk 15680 is retained. The greater-than-4K peak is present on the current
+machine; the unresolved issue is long-context decay, not a missing dispatch.
+
+## 128K Critical-Rank Trace
+
+The profiled prefill wall is 49.821 seconds versus 48.492 seconds unprofiled.
+Critical-rank kernel attribution is:
+
+| Category | Kernel time | Profiled wall share |
+|---|---:|---:|
+| D256 exact-dense attention | 17.710 s | 35.55% |
+| D256 direct-paged attention | 3.099 s | 6.22% |
+| FP8 exact-dense projections | 12.787 s | 25.67% |
+| TurboMind FP8 projections | 5.551 s | 11.14% |
+| TP communication | 4.895 s | 9.82% |
+| GDN / linear attention | 1.640 s | 3.29% |
+| Other FP16 GEMM | 1.547 s | 3.11% |
+| Norm / elementwise / sampling | 1.240 s | 2.49% |
+| KV cache and gather | 0.042 s | 0.08% |
+| Host and unattributed residual | 1.309 s | 2.63% |
+
+The 128 exact-dense calls are eight full chunks times 16 full-attention
+layers. Mean per-layer latency grows from 18.50 ms in the first group to
+256.59 ms in the eighth group.
+
+## Exact-Shape NCU
+
+The isolated shape is `Q=15680, KV=125440, Hq=6, Hkv=1, D=256`. The
+unprofiled accepted operator is 242.954 ms median, 46.63 causal TFLOP/s, and
+has output SHA256
+`71653010ebcad1ff38a231ad92cc970fe47491f14d570f29b81f963c3b794862`.
+
+- 253-254 registers/thread, 45.57 KiB dynamic shared memory, one CTA/SM,
+  12.5% occupancy, and 18.38 waves.
+- Tensor pipe active: 38.67%; issue active: 36.75%.
+- Schedulers have no eligible warp for 62.14% of cycles.
+- DRAM throughput is only 9.06% (81.65 GB/s); L2 hit rate is 88.51%.
+- MIO throttle is the largest per-issue stall. Eight P-operand `LDS.128`
+  instructions each account for about 172.9 million excessive shared
+  wavefronts.
+- The dominant long-scoreboard PC is the next-K shared publication waiting
+  for its global register load. Earlier publication is already a closed
+  regression because it extends the fragment across the register-dense loop.
+
+This is a CTA-local shared-memory and dependency problem, not an HBM or grid
+parallelism limit.
+
+## Rejected Pre-Fix FP8-Alias Run
+
+The same TP4, no-MTP contract was rerun with `kv_cache_dtype=fp8` and
+`max_num_batched_tokens=8192`. At that point, the generic `fp8` alias was
+incorrectly left as E4M3. These numbers describe the bug and are not an E5M2
+baseline.
+
+| Input | Prefill | FP16 KV/chunk 15680 | Relative | Decode |
+|---:|---:|---:|---:|---:|
+| 4K | 3529.8 tok/s | 4160.0 tok/s | -15.1% | 53.57 tok/s |
+| 16K | 2479.0 tok/s | 4290.1 tok/s | -42.2% | 52.27 tok/s |
+| 64K | 859.3 tok/s | 3420.2 tok/s | -74.9% | 32.55 tok/s |
+| 128K | 460.3 tok/s | 2702.9 tok/s | -83.0% | 22.91 tok/s |
+
+The configuration provides 685,491 KV tokens and 2.61x nominal 256K request
+capacity, versus 294,431 tokens and 1.12x for FP16 KV/chunk 15680. The severe
+regression came from selecting the wrong KV format and therefore missing every
+SM70 E5M2 fast path:
+
+- E4M3 prefix chunks cannot enter the D256 exact-dense path because that path
+  currently requires FP16 K/V cache tensors.
+- The existing one-pass FP8-to-FP16 bridge supports E5M2 only. E4M3 therefore
+  uses direct paged prefill with software dequantization in the attention loop.
+- Decode selects the scalar-paged E4M3 route instead of XQA, causing additional
+  long-context decay.
+- Model E4M3 weights do not imply an E4M3 KV cache. Weight quantization must
+  never be used as a KV dispatch condition.
+
+The fix resolves the SM70/Flash-V100 `fp8` alias to E5M2 while preserving an
+explicit `fp8_e4m3` request. E5M2 then enters the exact-dense prefill bridge,
+native cache writer, and scalar/XQA decode routes. Current E5M2 decode has a
+lower long-context slope than FP16 and is faster at 128K and 256K; the final
+matched prefill/decode table is recorded after the full acceptance sweep.
+
+## Rejected Candidate
+
+The first candidate reused the conflict-free native PV matrix-A layout but
+kept direct logical stores from the QK accumulator, avoiding the previously
+rejected shuffle/repack function.
+
+- PTXAS: 253 registers/thread, zero stack, zero spill, unchanged shared size.
+- Quality: exact output hash.
+- Wall: 242.954 ms control to 254.450 ms candidate, a 4.73% regression.
+
+The extra address-generation/scalar-publication issue cost exceeds the saved
+P-load replay. Do not retry this layout spelling or the earlier
+shuffle/repack form.
+
+## Artifacts
+
+- Root: task-local `qwen38-fp8-prefill-decay-20260815` artifact directory.
+- Nsight Systems:
+  `profiles/qwen38-fp8-tp4-i128k-chunk15680-r2.nsys-rep`.
+- Nsight Compute:
+  `profiles/ncu-d256-exact-q15680-kv125440-baseline.ncu-rep`.
+- Candidate binary:
+  `experiments/p-scalar-native-build-r3/_vllm_fa2_C.abi3.so`.
+- FP8 KV/chunk 8192 result:
+  `results/fp8kv-chunk8192-tp4.json`.

--- a/docs/design/sm70_v100_migration_control.md
+++ b/docs/design/sm70_v100_migration_control.md
@@ -41229,3 +41229,16 @@ Interpretation:
 - Evidence is under `workspace-production/` in the retained task artifact
   directory. The rollback remains
   `VLLM_SM70_AWQ_PREFILL_EXACT_DENSE=0`.
+
+## 2026-08-15 Qwen3.8-27B 1.3.0 release acceptance
+
+- Accepted Qwen3.8-27B-FP8 TP4 no-MTP long-context, concurrency, MTP4,
+  FP8-KV, exact-256K-boundary, API quality, and final-wheel gates.
+- Defaulted the proven mid-range G6 XQA QK pipeline, extended no-MTP graph
+  request shapes through 16, restricted the Qwen3.6 draft-vocabulary asset so
+  Qwen3.8 uses full vocabulary, and bundled FlashQLA SM70 into the wheel.
+- Qwen3.6-35B-A3B-AWQ TP2 loads from the final wheel and passes official
+  1K/256 and 4K/1024 checks. No 35B FP8 checkpoint is available, so that speed
+  target remains explicitly unmeasured.
+- Full configuration, performance tables, quality evidence, limitations, and
+  artifact paths are in `docs/design/sm70_qwen38_130_acceptance.md`.

--- a/docs/design/sm70_v100_migration_control.md
+++ b/docs/design/sm70_v100_migration_control.md
@@ -41287,3 +41287,33 @@ Interpretation:
   token 6377 predates the new E5M2 work and has no retained request seed. Keep
   it as an unmatched regression sample; do not attribute it to FP8 KV, XQA,
   MTP, or sampling without a matched reproduction.
+
+## 2026-08-16 Rejected MTP chunked-prefill compile entry
+
+- PR 213 proposed a second compiled Qwen target entry that bypassed the
+  automatic full-forward GDN guard only while every scheduled request was an
+  unfinished prefill chunk. Its 64K output was healthy, but its claimed
+  `22.5%-24.3%` prefill improvement compared against an older release artifact
+  rather than a same-source control.
+- A matched Qwen3.8-27B-FP8 TP4 control used MTP4, E5M2 KV, 65,517 prompt
+  tokens, 8,192-token prefill chunks, max length 262,144, seed 20260815,
+  official sampling, GPU memory utilization 0.88, and one warmup followed by
+  prefix/Mamba cache reset. The only changed setting was
+  `VLLM_SM70_MTP_PREFILL_STANDARD_GDN`.
+- The proposed entry took 24.428544 s for prefill. The disabled control took
+  24.284061 s, so enabling the entry added 0.144483 s (`+0.595%`) rather than
+  recovering the claimed release gap. Both lanes stopped naturally, retained
+  all three long-context sentinels, passed the corruption/repetition gate, and
+  reproduced their warmup text exactly. Cross-route token identity was not
+  required.
+- The additional entry also raised observed engine initialization from
+  117.93 s to 166.12 s because it compiled a second target graph. PR 213 was
+  closed without merge: the older comparison was confounded by other source
+  changes, while the matched result showed no runtime benefit to justify the
+  startup and maintenance cost.
+- Evidence is
+  `/data/minimax-h3/task-cache/qwen38-mtp-prefill-fastpath-20260816/results/qwen38-27b-fp8-mtp4-candidate-tp4-e5m2-64k-o512-warm.json`
+  and
+  `/data/minimax-h3/task-cache/qwen38-mtp-prefill-fastpath-20260816/results/qwen38-27b-fp8-mtp4-control-off-tp4-e5m2-64k-o512-warm.json`.
+  Do not repeat the older release-vs-candidate comparison as evidence for this
+  compile entry.

--- a/docs/design/sm70_v100_migration_control.md
+++ b/docs/design/sm70_v100_migration_control.md
@@ -41256,3 +41256,34 @@ Interpretation:
   290 MiB/rank extra workspace, and non-bitwise output.
 - Detailed route gates, full sweep, tests, rejected paths, and artifacts are
   in `docs/design/sm70_fp8_long_prefill_exact_dense.md`.
+
+## 2026-08-16 Qwen3.8 output-quality audit
+
+- Audited PR 212 head `7f409a7727` on Qwen3.8-27B-FP8, TP4 V100, max length
+  32768, official sampling, and the fixed 74-token macOS code prompt. Do not
+  repeat the earlier 1K/8K smokes as long-form quality evidence.
+- Natural-stop output gates passed no-MTP/FP16 KV (24,441 tokens),
+  no-MTP/E5M2 KV (25,055), MTP4/FP16 KV (25,753), and MTP4/E5M2 KV (18,642).
+  Every output contains complete HTML/CSS/JavaScript, closed tags and code
+  fences, no replacement characters, and no semantic long-block repetition.
+- Same-seed duplicate requests were byte-identical for all four paths. Long
+  prefix-cache probes remained byte-identical after 4,704, 4,896, and 6,464
+  cached tokens in the no-MTP/FP16, MTP4/FP16, and MTP4/E5M2 lanes.
+- Qwen3.8 TP4 XQA-vs-scalar operator checks at the 4095/4096/4097 boundary,
+  6272, 8192, and 16384 stayed within `6.1035e-5` maximum absolute difference
+  for FP16 and E5M2 KV. The MTP five-row, partition-1024 checks have the same
+  bound. The full MTP services logged the automatic GDN full-forward quality
+  guard and actual route hit.
+- A no-MTP-vs-MTP FP16 greedy comparison first diverges at output index 179.
+  The no-MTP top two tokens are tied at returned precision; the MTP target
+  top-1 leads by only 0.015625 and the verifier selects that target top-1.
+  This is a low-margin M=1/M=5 floating-point-order flip, not evidence that MTP
+  accepted a non-target draft token.
+- The serving/release gates falsely counted each overlapping 20/50-character
+  window inside decorative `=====` comments. On the MTP4/E5M2 output this
+  produced `repeat20=1064` and `repeat50=224`; excluding homogeneous windows
+  yields 28/28 while the independent same-character-run gate remains active.
+- The historical 8192-token no-MTP/FP16 artifact that degenerates after about
+  token 6377 predates the new E5M2 work and has no retained request seed. Keep
+  it as an unmatched regression sample; do not attribute it to FP8 KV, XQA,
+  MTP, or sampling without a matched reproduction.

--- a/docs/design/sm70_v100_migration_control.md
+++ b/docs/design/sm70_v100_migration_control.md
@@ -41242,3 +41242,17 @@ Interpretation:
   target remains explicitly unmeasured.
 - Full configuration, performance tables, quality evidence, limitations, and
   artifact paths are in `docs/design/sm70_qwen38_130_acceptance.md`.
+
+## 2026-08-15 Qwen3.8 FP8 compile-safe long-prefill projections
+
+- Fixed a false route hit where `torch.compile` folded a Python large-M
+  branch and left every measured FP8 projection on TurboMind. The accepted
+  opaque CUDA op selects TurboMind below M3920 and exact dense above it.
+- The default is restricted to TP4 gate/up/down/output shapes. It uses one
+  shared 85 MiB FP16 workspace; QKV, decode, and tails remain unchanged.
+- Matched 32K/128K/256K throughput improves 22.36%/12.94%/7.25% with exact
+  control output hashes. Final 128K/256K prefill is 2446.5/1602.0 tok/s.
+- Q15680 split-KV3 was rejected: only 0.85%-1.80% attention gain, about
+  290 MiB/rank extra workspace, and non-bitwise output.
+- Detailed route gates, full sweep, tests, rejected paths, and artifacts are
+  in `docs/design/sm70_fp8_long_prefill_exact_dense.md`.

--- a/flash-attention-v100/kernel/flash_decode_paged.cu
+++ b/flash-attention-v100/kernel/flash_decode_paged.cu
@@ -145,6 +145,46 @@ bool xqa_g6_dual_cta_enabled() {
   return value != nullptr && value[0] == '1';
 }
 
+bool xqa_e5m2_g6_dual_cta_enabled() {
+  const char* value = std::getenv("VLLM_FLASH_V100_XQA_E5M2_G6_DUAL_CTA");
+  return value == nullptr || value[0] != '0';
+}
+
+bool xqa_e5m2_g6_split_reduce_enabled() {
+  const char* value = std::getenv("VLLM_FLASH_V100_XQA_E5M2_G6_SPLIT_REDUCE");
+  return value == nullptr || value[0] != '0';
+}
+
+bool xqa_e5m2_partition_page_ids_enabled() {
+  const char* value =
+      std::getenv("VLLM_FLASH_V100_XQA_E5M2_PARTITION_PAGE_IDS");
+  return value == nullptr || value[0] != '0';
+}
+
+bool xqa_e5m2_pair_load_enabled() {
+  const char* value = std::getenv("VLLM_FLASH_V100_XQA_E5M2_PAIR_LOAD");
+  return value == nullptr || value[0] != '0';
+}
+
+int xqa_e5m2_p1024_begin() {
+  const char* value = std::getenv("VLLM_FLASH_V100_XQA_E5M2_P1024_BEGIN");
+  return value == nullptr ? 61633 : std::max(1, std::atoi(value));
+}
+
+int xqa_e5m2_scalar_xqa_seq_len() {
+  const char* value = std::getenv("VLLM_FLASH_V100_DECODE_FP8_XQA_MIN_SEQ_LEN");
+  return value == nullptr ? 16384 : std::max(1, std::atoi(value));
+}
+
+bool xqa_e5m2_g6_dual_cta_trace_enabled() {
+  static const bool enabled = [] {
+    const char* value =
+        std::getenv("VLLM_FLASH_V100_XQA_E5M2_G6_DUAL_CTA_TRACE");
+    return value != nullptr && value[0] == '1';
+  }();
+  return enabled;
+}
+
 bool xqa_mtp5_dual_cta_enabled() {
   const char* value = std::getenv("VLLM_FLASH_V100_XQA_MTP5_DUAL_CTA");
   return value == nullptr || value[0] == '1';
@@ -449,7 +489,8 @@ __device__ __forceinline__ uint4 load_xqa_tc_kv_vector(
 }
 
 template <int BLOCK_SIZE, bool CONTIGUOUS_HKV1_LAYOUT, int NUM_THREADS,
-          int KV_DTYPE = flash_v100::KV_CACHE_DTYPE_FP16>
+          int KV_DTYPE = flash_v100::KV_CACHE_DTYPE_FP16,
+          bool E5M2_PAIR_LOAD = false>
 __device__ __forceinline__ void load_xqa_tc_kv_panel(
     __half* __restrict__ shared_kv, const void* __restrict__ kv_cache,
     const int* __restrict__ page_ids, const int valid_kv_tile_rows,
@@ -458,17 +499,65 @@ __device__ __forceinline__ void load_xqa_tc_kv_panel(
     const int kv_head_idx, const int64_t block_stride,
     const int64_t token_stride, const int64_t head_stride,
     const int panel_offset, const int copy_thread_idx = threadIdx.x) {
-  const int copy_count = valid_kv_tile_rows * panel_d_stride_uint4;
   uint4* shared_vec = reinterpret_cast<uint4*>(shared_kv);
-  for (int copy_idx = copy_thread_idx; copy_idx < copy_count;
-       copy_idx += NUM_THREADS) {
-    const int row = copy_idx / panel_d_stride_uint4;
-    const int vec_col = copy_idx % panel_d_stride_uint4;
-    shared_vec[row * kv_smem_stride_uint4 + vec_col] =
-        load_xqa_tc_kv_vector<BLOCK_SIZE, CONTIGUOUS_HKV1_LAYOUT, KV_DTYPE>(
-            kv_cache, page_ids, copy_idx, panel_d_stride_uint4,
-            tile_page_offset, kv_tile_start, block_size, kv_head_idx,
-            block_stride, token_stride, head_stride, panel_offset);
+  if constexpr (E5M2_PAIR_LOAD) {
+    static_assert(KV_DTYPE == flash_v100::KV_CACHE_DTYPE_FP8_E5M2,
+                  "Paired XQA loads are only valid for FP8 E5M2 KV");
+    const int pair_stride = panel_d_stride_uint4 / 2;
+    const int pair_count = valid_kv_tile_rows * pair_stride;
+    for (int pair_idx = copy_thread_idx; pair_idx < pair_count;
+         pair_idx += NUM_THREADS) {
+      const int row = pair_idx / pair_stride;
+      const int vec_pair = pair_idx % pair_stride;
+      const int token_offset = tile_page_offset + kv_tile_start + row;
+      int logical_block;
+      int block_offset;
+      if constexpr (BLOCK_SIZE == 16) {
+        logical_block = token_offset >> 4;
+        block_offset = token_offset & 15;
+      } else if constexpr (BLOCK_SIZE == 784) {
+        logical_block = token_offset / 784;
+        block_offset = token_offset - logical_block * 784;
+      } else {
+        logical_block = token_offset / block_size;
+        block_offset = token_offset % block_size;
+      }
+      const int physical_block = page_ids[logical_block];
+      int64_t physical_offset;
+      if constexpr (CONTIGUOUS_HKV1_LAYOUT) {
+        constexpr int kHeadDim = 256;
+        constexpr int kBlockStride = 16 * kHeadDim;
+        physical_offset = static_cast<int64_t>(physical_block) * kBlockStride +
+                          static_cast<int64_t>(block_offset) * kHeadDim +
+                          panel_offset;
+      } else {
+        physical_offset = static_cast<int64_t>(physical_block) * block_stride +
+                          static_cast<int64_t>(block_offset) * token_stride +
+                          static_cast<int64_t>(kv_head_idx) * head_stride +
+                          panel_offset;
+      }
+      const uint4 raw = __ldg(reinterpret_cast<const uint4*>(kv_cache) +
+                              physical_offset / 16 + vec_pair);
+      const int shared_offset = row * kv_smem_stride_uint4 + vec_pair * 2;
+      const uint64_t raw_lo =
+          static_cast<uint64_t>(raw.x) | (static_cast<uint64_t>(raw.y) << 32);
+      shared_vec[shared_offset] = fp8_e5m2_vector_to_half8(raw_lo);
+      const uint64_t raw_hi =
+          static_cast<uint64_t>(raw.z) | (static_cast<uint64_t>(raw.w) << 32);
+      shared_vec[shared_offset + 1] = fp8_e5m2_vector_to_half8(raw_hi);
+    }
+  } else {
+    const int copy_count = valid_kv_tile_rows * panel_d_stride_uint4;
+    for (int copy_idx = copy_thread_idx; copy_idx < copy_count;
+         copy_idx += NUM_THREADS) {
+      const int row = copy_idx / panel_d_stride_uint4;
+      const int vec_col = copy_idx % panel_d_stride_uint4;
+      shared_vec[row * kv_smem_stride_uint4 + vec_col] =
+          load_xqa_tc_kv_vector<BLOCK_SIZE, CONTIGUOUS_HKV1_LAYOUT, KV_DTYPE>(
+              kv_cache, page_ids, copy_idx, panel_d_stride_uint4,
+              tile_page_offset, kv_tile_start, block_size, kv_head_idx,
+              block_stride, token_stride, head_stride, panel_offset);
+    }
   }
 }
 
@@ -573,7 +662,8 @@ __device__ __forceinline__ float dot_qk_cache(const __half* __restrict__ q_ptr,
   }
 }
 
-template <int D, int PARTITION_SIZE, int KV_DTYPE>
+template <int D, int PARTITION_SIZE, int KV_DTYPE,
+          int SEQ_LEN_ROUTE = kXQARouteAllSeqLens>
 __global__ void flash_attention_decode_partition_kernel(
     const __half* __restrict__ q, const void* __restrict__ k_cache,
     const void* __restrict__ v_cache, __half* __restrict__ tmp_out,
@@ -590,7 +680,8 @@ __global__ void flash_attention_decode_partition_kernel(
     const int64_t v_block_stride, const int64_t v_token_stride,
     const int64_t v_head_stride, const float softmax_scale, const float k_scale,
     const float v_scale, const int window_size_left,
-    const int window_size_right) {
+    const int window_size_right, const int route_seq_len_begin,
+    const int route_seq_len_end, const int route_seq_len_final) {
   const int batch_idx = blockIdx.x;
   const int head_idx = blockIdx.y;
   const int partition_idx = blockIdx.z;
@@ -601,6 +692,11 @@ __global__ void flash_attention_decode_partition_kernel(
   }
 
   const int seq_len = seq_lens[batch_idx];
+  if (!xqa_seq_len_route_active<SEQ_LEN_ROUTE>(seq_len, route_seq_len_begin,
+                                               route_seq_len_end,
+                                               route_seq_len_final)) {
+    return;
+  }
   const int start_token_idx = partition_idx * PARTITION_SIZE;
   if (seq_len <= 0 || start_token_idx >= seq_len) {
     return;
@@ -730,7 +826,8 @@ __global__ void flash_attention_decode_partition_kernel(
 template <int PARTITION_SIZE, int GROUP_SIZE, bool PADDED_SMEM, int NUM_THREADS,
           int MIN_BLOCKS_PER_SM, int BLOCK_SIZE, bool CONTIGUOUS_HKV1_LAYOUT,
           bool ALIGNED_PADDED_SMEM, int KV_DTYPE,
-          int SEQ_LEN_ROUTE = kXQARouteAllSeqLens, bool QK_SW_PIPELINE = false>
+          int SEQ_LEN_ROUTE = kXQARouteAllSeqLens, bool QK_SW_PIPELINE = false,
+          bool PARTITION_PAGE_IDS = false, bool E5M2_PAIR_LOAD = false>
 __global__ void __launch_bounds__(NUM_THREADS, MIN_BLOCKS_PER_SM)
     flash_attention_decode_xqa_tc_partition_kernel_256_wide(
         const __half* __restrict__ q, const void* __restrict__ k_cache,
@@ -779,7 +876,6 @@ __global__ void __launch_bounds__(NUM_THREADS, MIN_BLOCKS_PER_SM)
                                               NUM_THREADS == 8 * kWarpSize)),
       "The QK software pipeline requires a six- or eight-warp G6 "
       "kernel");
-
   const int batch_idx = blockIdx.x;
   const int kv_head_idx = blockIdx.y;
   const int partition_idx = blockIdx.z;
@@ -856,14 +952,29 @@ __global__ void __launch_bounds__(NUM_THREADS, MIN_BLOCKS_PER_SM)
   }
   __syncthreads();
 
+  int partition_start_page = 0;
+  int partition_page_offset = 0;
+  if constexpr (PARTITION_PAGE_IDS) {
+    partition_start_page = start_token_idx / block_size;
+    partition_page_offset = start_token_idx - partition_start_page * block_size;
+    const int partition_page_count =
+        (partition_page_offset + part_tokens + block_size - 1) / block_size;
+    for (int idx = tid; idx < partition_page_count; idx += NUM_THREADS) {
+      smem.page_ids[idx] = __ldg(&block_table_seq[partition_start_page + idx]);
+    }
+    __syncthreads();
+  }
+
   for (int block_n = 0; block_n < num_k_tiles; ++block_n) {
     const int tile_token_start = start_token_idx + block_n * kXQATCBlockN;
     const int valid_k_rows =
         min(kXQATCBlockN, part_tokens - block_n * kXQATCBlockN);
-    int start_page;
+    int start_page = partition_start_page;
     int tile_page_offset;
-    int page_count;
-    if constexpr (BLOCK_SIZE == 16) {
+    int page_count = 0;
+    if constexpr (PARTITION_PAGE_IDS) {
+      tile_page_offset = partition_page_offset + block_n * kXQATCBlockN;
+    } else if constexpr (BLOCK_SIZE == 16) {
       start_page = tile_token_start >> 4;
       tile_page_offset = tile_token_start & 15;
       page_count = (tile_page_offset + valid_k_rows + 15) >> 4;
@@ -878,10 +989,12 @@ __global__ void __launch_bounds__(NUM_THREADS, MIN_BLOCKS_PER_SM)
           (tile_page_offset + valid_k_rows + block_size - 1) / block_size;
     }
 
-    for (int idx = tid; idx < page_count; idx += NUM_THREADS) {
-      smem.page_ids[idx] = __ldg(&block_table_seq[start_page + idx]);
+    if constexpr (!PARTITION_PAGE_IDS) {
+      for (int idx = tid; idx < page_count; idx += NUM_THREADS) {
+        smem.page_ids[idx] = __ldg(&block_table_seq[start_page + idx]);
+      }
+      __syncthreads();
     }
-    __syncthreads();
 
     for (int kv_tile_start = 0; kv_tile_start < valid_k_rows;
          kv_tile_start += kXQATCBlockN) {
@@ -950,7 +1063,7 @@ __global__ void __launch_bounds__(NUM_THREADS, MIN_BLOCKS_PER_SM)
         for (int panel_idx = 0; panel_idx < kNumQKPanels; ++panel_idx) {
           const int panel_offset = panel_idx * kQKPanelDim;
           load_xqa_tc_kv_panel<BLOCK_SIZE, CONTIGUOUS_HKV1_LAYOUT, NUM_THREADS,
-                               KV_DTYPE>(
+                               KV_DTYPE, E5M2_PAIR_LOAD>(
               sK, k_cache, smem.page_ids, valid_kv_tile_rows,
               qk_panel_d_stride_uint4, qk_smem_stride_uint4, tile_page_offset,
               kv_tile_start, block_size, kv_head_idx, k_block_stride,
@@ -1087,7 +1200,7 @@ __global__ void __launch_bounds__(NUM_THREADS, MIN_BLOCKS_PER_SM)
         const int valid_kv_tile_rows =
             min(kXQATCBlockN, valid_k_rows - kv_tile_start);
         load_xqa_tc_kv_panel<BLOCK_SIZE, CONTIGUOUS_HKV1_LAYOUT, NUM_THREADS,
-                             KV_DTYPE>(
+                             KV_DTYPE, E5M2_PAIR_LOAD>(
             sV, v_cache, smem.page_ids, valid_kv_tile_rows,
             pv_panel_d_stride_uint4, kv_smem_stride_uint4, tile_page_offset,
             kv_tile_start, block_size, kv_head_idx, v_block_stride,
@@ -1899,7 +2012,8 @@ __global__ void flash_attention_decode_qk_scores_kernel(
   }
 }
 
-template <int D, int PARTITION_SIZE, int KV_DTYPE>
+template <int D, int PARTITION_SIZE, int KV_DTYPE,
+          int SEQ_LEN_ROUTE = kXQARouteAllSeqLens>
 void launch_flash_attention_decode_paged(
     const at::Tensor& q, const at::Tensor& k_cache, const at::Tensor& v_cache,
     at::Tensor& out, const at::Tensor& block_table, const at::Tensor& seq_lens,
@@ -1907,7 +2021,9 @@ void launch_flash_attention_decode_paged(
     const at::Tensor& active_num_partitions, const float softmax_scale,
     const int launch_num_partitions, const float k_scale, const float v_scale,
     const int window_size_left, const int window_size_right,
-    cudaStream_t stream) {
+    cudaStream_t stream, const int route_seq_len_begin = 0,
+    const int route_seq_len_end = 0, const int route_seq_len_final = 0,
+    const bool launch_reduce = true) {
   const int batch_size = q.size(0);
   const int num_heads_q = q.size(1);
   const int num_heads_kv = k_cache.size(2);
@@ -1921,7 +2037,8 @@ void launch_flash_attention_decode_paged(
   const size_t reduce_shared_mem =
       static_cast<size_t>(2 * max_num_partitions) * sizeof(float);
 
-  flash_attention_decode_partition_kernel<D, PARTITION_SIZE, KV_DTYPE>
+  flash_attention_decode_partition_kernel<D, PARTITION_SIZE, KV_DTYPE,
+                                          SEQ_LEN_ROUTE>
       <<<partition_grid, block, 0, stream>>>(
           reinterpret_cast<const __half*>(q.data_ptr<at::Half>()),
           k_cache.data_ptr(), v_cache.data_ptr(),
@@ -1934,7 +2051,12 @@ void launch_flash_attention_decode_paged(
           tmp_out.stride(2), max_logits.stride(0), max_logits.stride(1),
           k_cache.stride(0), k_cache.stride(1), k_cache.stride(2),
           v_cache.stride(0), v_cache.stride(1), v_cache.stride(2),
-          softmax_scale, k_scale, v_scale, window_size_left, window_size_right);
+          softmax_scale, k_scale, v_scale, window_size_left, window_size_right,
+          route_seq_len_begin, route_seq_len_end, route_seq_len_final);
+
+  if (!launch_reduce) {
+    return;
+  }
 
   flash_attention_decode_reduce_kernel<D, PARTITION_SIZE>
       <<<reduce_grid, block, reduce_shared_mem, stream>>>(
@@ -2005,7 +2127,8 @@ template <int PARTITION_SIZE, int GROUP_SIZE, bool PADDED_SMEM,
           int NUM_THREADS = kXQATC256WideThreads, int MIN_BLOCKS_PER_SM = 1,
           int BLOCK_SIZE = 0, bool CONTIGUOUS_HKV1_LAYOUT = false,
           bool ALIGNED_PADDED_SMEM = false,
-          int SEQ_LEN_ROUTE = kXQARouteAllSeqLens, bool QK_SW_PIPELINE = false>
+          int SEQ_LEN_ROUTE = kXQARouteAllSeqLens, bool QK_SW_PIPELINE = false,
+          bool PARTITION_PAGE_IDS = false, bool E5M2_PAIR_LOAD = false>
 void launch_flash_attention_decode_paged_xqa_tc_256_wide(
     const at::Tensor& q, const at::Tensor& k_cache, const at::Tensor& v_cache,
     at::Tensor& out, const at::Tensor& block_table, const at::Tensor& seq_lens,
@@ -2032,7 +2155,8 @@ void launch_flash_attention_decode_paged_xqa_tc_256_wide(
         (void*)flash_attention_decode_xqa_tc_partition_kernel_256_wide<        \
             PARTITION_SIZE, GROUP_SIZE, PADDED_SMEM, NUM_THREADS,              \
             MIN_BLOCKS_PER_SM, BLOCK_SIZE, CONTIGUOUS_HKV1_LAYOUT,             \
-            ALIGNED_PADDED_SMEM, KV_DTYPE, SEQ_LEN_ROUTE, QK_SW_PIPELINE>;     \
+            ALIGNED_PADDED_SMEM, KV_DTYPE, SEQ_LEN_ROUTE, QK_SW_PIPELINE,      \
+            PARTITION_PAGE_IDS, E5M2_PAIR_LOAD>;                               \
     cudaFuncSetAttribute(partition_kernel,                                     \
                          cudaFuncAttributeMaxDynamicSharedMemorySize,          \
                          shared_mem);                                          \
@@ -2044,7 +2168,8 @@ void launch_flash_attention_decode_paged_xqa_tc_256_wide(
     flash_attention_decode_xqa_tc_partition_kernel_256_wide<                   \
         PARTITION_SIZE, GROUP_SIZE, PADDED_SMEM, NUM_THREADS,                  \
         MIN_BLOCKS_PER_SM, BLOCK_SIZE, CONTIGUOUS_HKV1_LAYOUT,                 \
-        ALIGNED_PADDED_SMEM, KV_DTYPE, SEQ_LEN_ROUTE, QK_SW_PIPELINE>          \
+        ALIGNED_PADDED_SMEM, KV_DTYPE, SEQ_LEN_ROUTE, QK_SW_PIPELINE,          \
+        PARTITION_PAGE_IDS, E5M2_PAIR_LOAD>                                    \
         <<<partition_grid, NUM_THREADS, shared_mem, stream>>>(                 \
             reinterpret_cast<const __half*>(q.data_ptr<at::Half>()),           \
             k_cache.data_ptr(), v_cache.data_ptr(),                            \
@@ -2061,7 +2186,11 @@ void launch_flash_attention_decode_paged_xqa_tc_256_wide(
             route_seq_len_end, route_seq_len_final);                           \
   } while (0)
 
-  if (k_cache.scalar_type() == at::kByte) {
+  if constexpr (E5M2_PAIR_LOAD) {
+    TORCH_CHECK(k_cache.scalar_type() == at::kByte,
+                "Paired XQA loads require FP8 E5M2 KV cache");
+    LAUNCH_XQA_PARTITION(flash_v100::KV_CACHE_DTYPE_FP8_E5M2);
+  } else if (k_cache.scalar_type() == at::kByte) {
     LAUNCH_XQA_PARTITION(flash_v100::KV_CACHE_DTYPE_FP8_E5M2);
   } else {
     LAUNCH_XQA_PARTITION(flash_v100::KV_CACHE_DTYPE_FP16);
@@ -2544,10 +2673,46 @@ at::Tensor flash_attention_decode_paged_xqa(
       k_cache.size(2) > 0 &&
       kv_dtype_code == flash_v100::KV_CACHE_DTYPE_FP8_E5M2 &&
       xqa_mtp5_dual_cta_enabled();
+  const bool use_e5m2_g6_dual_cta =
+      q.size(0) == 1 && q_per_kv == 6 && partition_size == 256 &&
+      k_cache.size(1) >= 256 && k_cache.size(1) % 16 == 0 &&
+      k_cache.size(2) == 1 && k_cache.scalar_type() == at::kByte &&
+      kv_dtype_code == flash_v100::KV_CACHE_DTYPE_FP8_E5M2 &&
+      !decode_partition_size_overridden() && xqa_e5m2_g6_dual_cta_enabled() &&
+      xqa_e5m2_g6_split_reduce_enabled();
+  const int e5m2_g6_dual_cta_seq_len =
+      use_e5m2_g6_dual_cta
+          ? at::cuda::getDeviceProperties(q.get_device())->multiProcessorCount *
+                    1024 +
+                1
+          : 0;
+  const int e5m2_p1024_begin =
+      use_e5m2_g6_dual_cta ? xqa_e5m2_p1024_begin() : 0;
+  const int e5m2_scalar_xqa_seq_len =
+      use_e5m2_g6_dual_cta
+          ? std::min(xqa_e5m2_scalar_xqa_seq_len(), e5m2_p1024_begin)
+          : 0;
+  TORCH_CHECK(
+      !use_e5m2_g6_dual_cta || e5m2_p1024_begin < e5m2_g6_dual_cta_seq_len,
+      "Invalid E5M2 G6 partition thresholds: ", e5m2_p1024_begin, ", ",
+      e5m2_g6_dual_cta_seq_len);
+  const int e5m2_p1024_launch_num_partitions = (launch_num_partitions + 3) / 4;
+  const int e5m2_p1024_one_cta_launch_num_partitions =
+      use_e5m2_g6_dual_cta
+          ? std::min(e5m2_p1024_launch_num_partitions,
+                     at::cuda::getDeviceProperties(q.get_device())
+                         ->multiProcessorCount)
+          : 0;
+  const bool use_e5m2_partition_page_ids =
+      use_e5m2_g6_dual_cta && xqa_e5m2_partition_page_ids_enabled();
+  const bool use_e5m2_pair_load =
+      use_e5m2_partition_page_ids && xqa_e5m2_pair_load_enabled();
   const bool use_g6_dual_cta =
       use_g6_p1024_auto || use_g6_p1024_sawtooth || use_mtp5_dual_cta ||
+      use_e5m2_g6_dual_cta ||
       (xqa_g6_dual_cta_enabled() && (use_padded_smem || use_g6_dual_cta_dense));
   const bool use_split_reduce = use_g6_p1024_auto || use_g6_p1024_sawtooth ||
+                                use_e5m2_g6_dual_cta ||
                                 (use_g6_dual_cta && xqa_split_reduce_enabled());
   const bool supports_block16_index = use_g6_dual_cta && k_cache.size(1) == 16;
   const bool supports_block16_contiguous_layout =
@@ -2620,6 +2785,20 @@ at::Tensor flash_attention_decode_paged_xqa(
         g6_qk_pipeline_warps);
     traced_g6_qk_pipeline = true;
   }
+  static bool traced_e5m2_g6_dual_cta = false;
+  if (xqa_e5m2_g6_dual_cta_trace_enabled() && use_e5m2_g6_dual_cta &&
+      !traced_e5m2_g6_dual_cta) {
+    TORCH_WARN(
+        "Flash-V100 XQA E5M2 G6 device-side p256/p1024 route active; "
+        "thresholds=",
+        e5m2_p1024_begin, ", ", e5m2_g6_dual_cta_seq_len, ", KV shape [blocks,",
+        k_cache.size(1), ",", k_cache.size(2), ",", k_cache.size(3),
+        "], split_reduce=", use_split_reduce,
+        ", partition_page_ids=", use_e5m2_partition_page_ids,
+        ", pair_load=", use_e5m2_pair_load,
+        ", scalar_xqa_seq_len=", e5m2_scalar_xqa_seq_len);
+    traced_e5m2_g6_dual_cta = true;
+  }
   static bool traced_aligned_padded_smem = false;
   if (xqa_aligned_padded_smem_trace_enabled() && use_aligned_padded_smem &&
       !traced_aligned_padded_smem) {
@@ -2663,7 +2842,96 @@ at::Tensor flash_attention_decode_paged_xqa(
     }                                                                    \
   } while (0)
 
-  if (use_g6_p1024_sawtooth) {
+  if (use_e5m2_g6_dual_cta) {
+    launch_flash_attention_decode_paged<
+        256, 256, flash_v100::KV_CACHE_DTYPE_FP8_E5M2, kXQARouteShortSeqLens>(
+        q, k_cache, v_cache, out, block_table, seq_lens, tmp_out, max_logits,
+        exp_sums, active_num_partitions, softmax_scale, launch_num_partitions,
+        k_scale, v_scale, window_size_left, window_size_right, stream,
+        e5m2_scalar_xqa_seq_len, 0, 0, false);
+    if (use_e5m2_pair_load) {
+      launch_flash_attention_decode_paged_xqa_tc_256_wide<
+          256, 6, true, kXQATC256WideThreads, 1, 0, false, false,
+          kXQARouteP1024SawtoothMid, false, true, true>(
+          q, k_cache, v_cache, out, block_table, seq_lens, tmp_out, max_logits,
+          exp_sums, active_num_partitions, softmax_scale, k_scale, v_scale,
+          launch_num_partitions, false, split_reduce_dim_tile, stream,
+          e5m2_scalar_xqa_seq_len, e5m2_p1024_begin, 0, false);
+    } else if (use_e5m2_partition_page_ids) {
+      launch_flash_attention_decode_paged_xqa_tc_256_wide<
+          256, 6, true, kXQATC256WideThreads, 1, 0, false, false,
+          kXQARouteP1024SawtoothMid, false, true>(
+          q, k_cache, v_cache, out, block_table, seq_lens, tmp_out, max_logits,
+          exp_sums, active_num_partitions, softmax_scale, k_scale, v_scale,
+          launch_num_partitions, false, split_reduce_dim_tile, stream,
+          e5m2_scalar_xqa_seq_len, e5m2_p1024_begin, 0, false);
+    } else {
+      launch_flash_attention_decode_paged_xqa_tc_256_wide<
+          256, 6, true, kXQATC256WideThreads, 1, 0, false, false,
+          kXQARouteP1024SawtoothMid>(
+          q, k_cache, v_cache, out, block_table, seq_lens, tmp_out, max_logits,
+          exp_sums, active_num_partitions, softmax_scale, k_scale, v_scale,
+          launch_num_partitions, false, split_reduce_dim_tile, stream,
+          e5m2_scalar_xqa_seq_len, e5m2_p1024_begin, 0, false);
+    }
+    if (use_e5m2_partition_page_ids) {
+      if (use_e5m2_pair_load) {
+        launch_flash_attention_decode_paged_xqa_tc_256_wide<
+            1024, 6, false, kXQATC256WideThreads, 1, 0, false, false,
+            kXQARouteP1024SawtoothMid, false, true, true>(
+            q, k_cache, v_cache, out, block_table, seq_lens, tmp_out,
+            max_logits, exp_sums, active_num_partitions, softmax_scale, k_scale,
+            v_scale, e5m2_p1024_one_cta_launch_num_partitions, false,
+            split_reduce_dim_tile, stream, e5m2_p1024_begin,
+            e5m2_g6_dual_cta_seq_len, 0, false);
+        launch_flash_attention_decode_paged_xqa_tc_256_wide<
+            1024, 6, false, kXQATCG6DualCtaThreads, 2, 0, false, false,
+            kXQARouteLongSeqLens, false, true, true>(
+            q, k_cache, v_cache, out, block_table, seq_lens, tmp_out,
+            max_logits, exp_sums, active_num_partitions, softmax_scale, k_scale,
+            v_scale, e5m2_p1024_launch_num_partitions, false,
+            split_reduce_dim_tile, stream, e5m2_g6_dual_cta_seq_len, 0, 0,
+            false);
+      } else {
+        launch_flash_attention_decode_paged_xqa_tc_256_wide<
+            1024, 6, false, kXQATC256WideThreads, 1, 0, false, false,
+            kXQARouteP1024SawtoothMid, false, true>(
+            q, k_cache, v_cache, out, block_table, seq_lens, tmp_out,
+            max_logits, exp_sums, active_num_partitions, softmax_scale, k_scale,
+            v_scale, e5m2_p1024_one_cta_launch_num_partitions, false,
+            split_reduce_dim_tile, stream, e5m2_p1024_begin,
+            e5m2_g6_dual_cta_seq_len, 0, false);
+        launch_flash_attention_decode_paged_xqa_tc_256_wide<
+            1024, 6, false, kXQATCG6DualCtaThreads, 2, 0, false, false,
+            kXQARouteLongSeqLens, false, true>(
+            q, k_cache, v_cache, out, block_table, seq_lens, tmp_out,
+            max_logits, exp_sums, active_num_partitions, softmax_scale, k_scale,
+            v_scale, e5m2_p1024_launch_num_partitions, false,
+            split_reduce_dim_tile, stream, e5m2_g6_dual_cta_seq_len, 0, 0,
+            false);
+      }
+    } else {
+      launch_flash_attention_decode_paged_xqa_tc_256_wide<
+          1024, 6, false, kXQATC256WideThreads, 1, 0, false, false,
+          kXQARouteP1024SawtoothMid>(
+          q, k_cache, v_cache, out, block_table, seq_lens, tmp_out, max_logits,
+          exp_sums, active_num_partitions, softmax_scale, k_scale, v_scale,
+          e5m2_p1024_one_cta_launch_num_partitions, false,
+          split_reduce_dim_tile, stream, e5m2_p1024_begin,
+          e5m2_g6_dual_cta_seq_len, 0, false);
+      launch_flash_attention_decode_paged_xqa_tc_256_wide<
+          1024, 6, false, kXQATCG6DualCtaThreads, 2, 0, false, false,
+          kXQARouteLongSeqLens>(
+          q, k_cache, v_cache, out, block_table, seq_lens, tmp_out, max_logits,
+          exp_sums, active_num_partitions, softmax_scale, k_scale, v_scale,
+          e5m2_p1024_launch_num_partitions, false, split_reduce_dim_tile,
+          stream, e5m2_g6_dual_cta_seq_len, 0, 0, false);
+    }
+    launch_flash_attention_decode_xqa_split_reduce<0>(
+        out, seq_lens, tmp_out, max_logits, exp_sums, launch_num_partitions,
+        split_reduce_dim_tile, stream, e5m2_p1024_begin,
+        e5m2_g6_dual_cta_seq_len, e5m2_g6_dual_cta_seq_len);
+  } else if (use_g6_p1024_sawtooth) {
     const int p1024_launch_num_partitions = (launch_num_partitions + 3) / 4;
     if (use_g6_qk_pipeline) {
       if (g6_qk_pipeline_warps == 8) {

--- a/flash-attention-v100/kernel/flash_decode_paged.cu
+++ b/flash-attention-v100/kernel/flash_decode_paged.cu
@@ -47,6 +47,8 @@ constexpr int kXQARouteShortSeqLens = -1;
 constexpr int kXQARouteLongSeqLens = 1;
 constexpr int kXQARouteP1024Sawtooth = 4;
 constexpr int kXQARouteP256Sawtooth = 5;
+constexpr int kXQARouteP1024SawtoothMid = 6;
+constexpr int kXQARouteP1024SawtoothFinal = 7;
 // The dense 256/128-half strides alias Volta shared-memory banks in the
 // WMMA A/B fragment loads. Both padded strides remain 16-byte aligned.
 constexpr int kXQATC256WidePaddedQStride = 264;
@@ -177,7 +179,7 @@ bool decode_partition_size_overridden() {
 
 bool xqa_g6_qk_pipeline_enabled() {
   const char* value = std::getenv("VLLM_FLASH_V100_XQA_G6_QK_PIPELINE");
-  return value != nullptr && value[0] == '1';
+  return value == nullptr || value[0] != '0';
 }
 
 int xqa_g6_qk_pipeline_warps() {
@@ -297,6 +299,10 @@ __device__ __forceinline__ bool xqa_seq_len_route_active(
   } else if constexpr (SEQ_LEN_ROUTE == kXQARouteP256Sawtooth) {
     return seq_len < route_seq_len_begin ||
            (seq_len >= route_seq_len_end && seq_len < route_seq_len_final);
+  } else if constexpr (SEQ_LEN_ROUTE == kXQARouteP1024SawtoothMid) {
+    return seq_len >= route_seq_len_begin && seq_len < route_seq_len_end;
+  } else if constexpr (SEQ_LEN_ROUTE == kXQARouteP1024SawtoothFinal) {
+    return seq_len >= route_seq_len_final;
   }
   return true;
 }
@@ -2609,7 +2615,8 @@ at::Tensor flash_attention_decode_paged_xqa(
       !traced_g6_qk_pipeline) {
     TORCH_WARN(
         "Flash-V100 XQA G6 fp16-KV QK K64 producer/consumer "
-        "pipeline active; warps=",
+        "pipeline active for the mid p1024 range with baseline final-range "
+        "fallback; warps=",
         g6_qk_pipeline_warps);
     traced_g6_qk_pipeline = true;
   }
@@ -2662,7 +2669,7 @@ at::Tensor flash_attention_decode_paged_xqa(
       if (g6_qk_pipeline_warps == 8) {
         launch_flash_attention_decode_paged_xqa_tc_256_wide<
             1024, 6, false, kXQATCG6Pipeline8WarpThreads, 2, 784, false, false,
-            kXQARouteP1024Sawtooth, true>(
+            kXQARouteP1024SawtoothMid, true>(
             q, k_cache, v_cache, out, block_table, seq_lens, tmp_out,
             max_logits, exp_sums, active_num_partitions, softmax_scale, k_scale,
             v_scale, p1024_launch_num_partitions, false, split_reduce_dim_tile,
@@ -2672,7 +2679,7 @@ at::Tensor flash_attention_decode_paged_xqa(
       } else {
         launch_flash_attention_decode_paged_xqa_tc_256_wide<
             1024, 6, false, kXQATCG6DualCtaThreads, 2, 784, false, false,
-            kXQARouteP1024Sawtooth, true>(
+            kXQARouteP1024SawtoothMid, true>(
             q, k_cache, v_cache, out, block_table, seq_lens, tmp_out,
             max_logits, exp_sums, active_num_partitions, softmax_scale, k_scale,
             v_scale, p1024_launch_num_partitions, false, split_reduce_dim_tile,
@@ -2680,6 +2687,15 @@ at::Tensor flash_attention_decode_paged_xqa(
             g6_p1024_sawtooth_p256_long_seq_len,
             g6_p1024_sawtooth_p1024_final_seq_len, false);
       }
+      launch_flash_attention_decode_paged_xqa_tc_256_wide<
+          1024, 6, false, kXQATCG6DualCtaThreads, 2, 784, false, false,
+          kXQARouteP1024SawtoothFinal>(
+          q, k_cache, v_cache, out, block_table, seq_lens, tmp_out, max_logits,
+          exp_sums, active_num_partitions, softmax_scale, k_scale, v_scale,
+          p1024_launch_num_partitions, false, split_reduce_dim_tile, stream,
+          g6_p1024_sawtooth_p1024_mid_seq_len,
+          g6_p1024_sawtooth_p256_long_seq_len,
+          g6_p1024_sawtooth_p1024_final_seq_len, false);
     } else {
       launch_flash_attention_decode_paged_xqa_tc_256_wide<
           1024, 6, false, kXQATCG6DualCtaThreads, 2, 784, false, false,

--- a/flash_qla/ops/gated_delta_rule/chunk/sm70/fused_fwd.py
+++ b/flash_qla/ops/gated_delta_rule/chunk/sm70/fused_fwd.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import importlib
 import os
 from pathlib import Path
 
@@ -10,24 +11,61 @@ import torch
 from torch.utils.cpp_extension import load
 
 _EXT = None
+_EXT_LOAD_ERROR: Exception | None = None
+_PREBUILT_EXTENSION = (
+    "flash_qla.ops.gated_delta_rule.chunk.sm70.flash_qla_sm70_gdn_strided"
+)
+
+# Avoid CUDA-device auto-detection while distributed workers are initializing.
+# The fallback JIT supports both architectures implemented by this source file.
+_SM70_GENCODE_FLAGS = [
+    "-gencode=arch=compute_70,code=sm_70",
+    "-gencode=arch=compute_75,code=sm_75",
+]
 
 
 def _load_ext():
-    global _EXT
+    global _EXT, _EXT_LOAD_ERROR
     if _EXT is not None:
         return _EXT
+    if _EXT_LOAD_ERROR is not None:
+        raise RuntimeError(
+            "SM70 FlashQLA extension initialization previously failed. "
+            "The original loader or compiler error is chained below."
+        ) from _EXT_LOAD_ERROR
     if not torch.cuda.is_available():
         raise RuntimeError("SM70 FlashQLA backend requires CUDA.")
 
-    os.environ.setdefault("TORCH_CUDA_ARCH_LIST", "7.0;7.5")
+    try:
+        _EXT = importlib.import_module(_PREBUILT_EXTENSION)
+        return _EXT
+    except ModuleNotFoundError as exc:
+        if exc.name != _PREBUILT_EXTENSION:
+            _EXT_LOAD_ERROR = exc
+            raise RuntimeError(
+                "Bundled SM70 FlashQLA extension has a missing dependency."
+            ) from exc
+    except Exception as exc:
+        _EXT_LOAD_ERROR = exc
+        raise RuntimeError(
+            "Bundled SM70 FlashQLA extension failed to load. Reinstall a wheel "
+            "built for the active CUDA and PyTorch versions."
+        ) from exc
+
     src = Path(__file__).with_name("csrc") / "gdn_forward.cu"
-    _EXT = load(
-        name="flash_qla_sm70_gdn_strided",
-        sources=[str(src)],
-        extra_cuda_cflags=["-O3"],
-        extra_cflags=["-O3"],
-        verbose=bool(int(os.environ.get("FLASH_QLA_SM70_VERBOSE_BUILD", "0"))),
-    )
+    try:
+        _EXT = load(
+            name="flash_qla_sm70_gdn_strided",
+            sources=[str(src)],
+            extra_cuda_cflags=["-O3", *_SM70_GENCODE_FLAGS],
+            extra_cflags=["-O3"],
+            verbose=bool(int(os.environ.get("FLASH_QLA_SM70_VERBOSE_BUILD", "0"))),
+        )
+    except Exception as exc:
+        # PyTorch's process-local extension versioner may skip a retry after a
+        # failed build and only report a missing .so. Preserve the first error.
+        _EXT_LOAD_ERROR = exc
+        raise
     return _EXT
 
 

--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,9 @@ logger = logging.getLogger(__name__)
 PRECOMPILED_RUST_FRONTEND_PATH = ROOT_DIR / "vllm" / "vllm-rs"
 FLASH_ATTN_V100_ROOT = ROOT_DIR / "flash-attention-v100"
 FLASH_ATTN_V100_PACKAGE = FLASH_ATTN_V100_ROOT / "flash_attn_v100"
+FLASH_QLA_SM70_ROOT = (
+    ROOT_DIR / "flash_qla" / "ops" / "gated_delta_rule" / "chunk" / "sm70"
+)
 ONECAT_TORCH_CU128_URLS = {
     "torch==2.10.0": (
         "torch @ https://download.pytorch.org/whl/cu128/"
@@ -205,6 +208,50 @@ def bundle_flash_attn_v100(build_lib: str) -> None:
         dst_ext = dst_pkg / matches[-1].name
         shutil.copy2(matches[-1], dst_ext)
         remove_rpath(dst_ext)
+
+
+def bundle_flash_qla_sm70(build_lib: str, build_temp: str) -> None:
+    """Precompile the SM70 GDN extension so runtime never requires NVCC."""
+    if not _cuda_arch_contains(7, 0):
+        return
+
+    src = FLASH_QLA_SM70_ROOT / "csrc" / "gdn_forward.cu"
+    if not src.exists():
+        raise RuntimeError(f"SM70 FlashQLA source is missing: {src}")
+
+    from torch.utils.cpp_extension import load as load_torch_extension
+
+    extension_build_dir = Path(build_temp) / "flash_qla_sm70_gdn_strided"
+    extension_build_dir.mkdir(parents=True, exist_ok=True)
+    previous_arch_list = os.environ.get("TORCH_CUDA_ARCH_LIST")
+    os.environ["TORCH_CUDA_ARCH_LIST"] = "7.0"
+    try:
+        extension = load_torch_extension(
+            name="flash_qla_sm70_gdn_strided",
+            sources=[str(src)],
+            build_directory=str(extension_build_dir),
+            extra_cuda_cflags=[
+                "-O3",
+                "-gencode=arch=compute_70,code=sm_70",
+            ],
+            extra_cflags=["-O3"],
+            with_cuda=True,
+            verbose=bool(int(os.environ.get("FLASH_QLA_SM70_VERBOSE_BUILD", "0"))),
+        )
+    finally:
+        if previous_arch_list is None:
+            os.environ.pop("TORCH_CUDA_ARCH_LIST", None)
+        else:
+            os.environ["TORCH_CUDA_ARCH_LIST"] = previous_arch_list
+
+    dst_pkg = (
+        Path(build_lib) / "flash_qla" / "ops" / "gated_delta_rule" / "chunk" / "sm70"
+    )
+    dst_pkg.mkdir(parents=True, exist_ok=True)
+    dst_ext = dst_pkg / Path(extension.__file__).name
+    shutil.copy2(extension.__file__, dst_ext)
+    remove_rpath(dst_ext)
+    logger.info("Bundled SM70 FlashQLA extension into wheel: %s", dst_ext)
 
 
 def remove_rpath(path: Path) -> None:
@@ -424,6 +471,7 @@ class cmake_build_ext(build_ext):
 
         if _is_cuda():
             bundle_flash_attn_v100(self.build_lib)
+            bundle_flash_qla_sm70(self.build_lib, self.build_temp)
 
         # copy vllm/vllm_flash_attn/**/*.py from self.build_lib to current
         # directory so that they can be included in the editable build
@@ -1224,6 +1272,7 @@ package_data = {
     "flash_qla": [
         "LICENSE",
         "ops/gated_delta_rule/chunk/sm70/csrc/*.cu",
+        "ops/gated_delta_rule/chunk/sm70/*.so",
     ],
     "flash_attn_v100": [
         "*.so",

--- a/tests/benchmarks/test_sm70_release_quality_gate.py
+++ b/tests/benchmarks/test_sm70_release_quality_gate.py
@@ -77,6 +77,25 @@ def test_quality_metrics_still_reject_degenerate_repetition():
     assert "same_token_run" in metrics["failures"]
 
 
+def test_quality_metrics_allow_decorative_character_separators():
+    separator = "/* " + "=" * 57 + " */"
+    text = "\n".join(f"{separator}\nconst section_{idx} = {idx};" for idx in range(30))
+
+    metrics = _quality_metrics(text, list(range(64)))
+
+    assert metrics["max_same_char_run"] == 57
+    assert metrics["repeat20"] <= metrics["repeat20_limit"]
+    assert metrics["repeat50"] <= 40
+    assert metrics["passed"]
+
+
+def test_quality_metrics_still_reject_long_homogeneous_run():
+    metrics = _quality_metrics("=" * 121, list(range(64)))
+
+    assert metrics["max_same_char_run"] == 121
+    assert "same_char_run" in metrics["failures"]
+
+
 def test_release_matrix_includes_fp8_weight_fp8_kv_mtp_by_default():
     cases = _make_cases(
         backends=("turbomind",),

--- a/tests/entrypoints/test_cli.py
+++ b/tests/entrypoints/test_cli.py
@@ -1,0 +1,18 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import subprocess
+import sys
+
+from vllm.version import __version__
+
+
+def test_cli_version_uses_package_version():
+    result = subprocess.run(
+        [sys.executable, "-m", "vllm.entrypoints.cli.main", "--version"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.stdout.strip() == __version__

--- a/tests/kernels/attention/test_cache.py
+++ b/tests/kernels/attention/test_cache.py
@@ -703,9 +703,59 @@ def test_reshape_and_cache_flash_fp8_e5m2_smoke(
             expected_key[block_idx, :, block_offset, :] = key[i]
             expected_value[block_idx, :, block_offset, :] = value[i]
 
-    torch.cuda.synchronize()
+    torch.accelerator.synchronize()
     assert torch.equal(dequant(key_cache), expected_key)
     assert torch.equal(dequant(value_cache), expected_value)
+
+
+@torch.inference_mode()
+def test_reshape_and_cache_flash_fp8_e5m2_unit_scale_all_fp16_bits() -> None:
+    if torch.accelerator.device_count() == 0:
+        pytest.skip("CUDA is required for FP8 KV cache reshape")
+
+    device = "cuda:0"
+    bits = torch.arange(65536, device=device, dtype=torch.int32).to(torch.int16)
+    key = bits.view(torch.float16).reshape(-1, 1, 1).contiguous()
+    value = key.clone()
+    block_size = 16
+    cache = torch.empty(
+        (2, 65536 // block_size, block_size, 1, 1),
+        device=device,
+        dtype=torch.uint8,
+    )
+    slots = torch.arange(65536, device=device, dtype=torch.int64)
+    scale = torch.ones(1, device=device, dtype=torch.float32)
+
+    ops.reshape_and_cache_flash(
+        key,
+        value,
+        cache[0],
+        cache[1],
+        slots,
+        "fp8_e5m2",
+        scale,
+        scale,
+    )
+
+    bits_i32 = bits.to(torch.int32) & 0xFFFF
+    sign = (bits_i32 >> 8) & 0x80
+    magnitude = bits_i32 & 0x7FFF
+    exponent = magnitude >> 10
+    mantissa = magnitude & 0x3FF
+    truncated = magnitude >> 8
+    remainder = magnitude & 0xFF
+    rounded = truncated + (
+        (remainder > 0x80) | ((remainder == 0x80) & ((truncated & 1) != 0))
+    ).to(torch.int32)
+    finite = torch.minimum(rounded, torch.full_like(rounded, 0x7B)) | sign
+    expected = torch.where(
+        exponent == 0x1F,
+        torch.where(mantissa != 0, torch.full_like(sign, 0x7F), sign | 0x7B),
+        finite,
+    ).to(torch.uint8)
+
+    assert torch.equal(cache[0].flatten(), expected)
+    assert torch.equal(cache[1].flatten(), expected)
 
 
 def _create_mla_cache(

--- a/tests/kernels/core/test_layernorm.py
+++ b/tests/kernels/core/test_layernorm.py
@@ -234,3 +234,37 @@ def test_sm70_gemma_long_prefill_fused_add_rms_norm_exact(
 
     assert torch.equal(normalized, expected_normalized)
     assert torch.equal(residual_out, expected_residual)
+
+
+@pytest.mark.parametrize("num_tokens", [1, 5, 18])
+@pytest.mark.parametrize("weight_dtype", [torch.float16, torch.bfloat16, torch.float32])
+@torch.inference_mode()
+def test_sm70_gemma_long_prefill_op_small_shape_fallback_exact(
+    num_tokens: int,
+    weight_dtype: torch.dtype,
+) -> None:
+    if not torch.cuda.is_available() or torch.cuda.get_device_capability() != (7, 0):
+        pytest.skip("SM70 CUDA device required")
+
+    torch.manual_seed(20260814)
+    x = torch.randn(num_tokens, 5120, device="cuda", dtype=torch.float16).mul_(0.125)
+    residual = torch.randn(num_tokens, 5120, device="cuda", dtype=torch.float32).mul_(
+        0.125
+    )
+    weight = torch.randn(5120, device="cuda", dtype=torch.float32).mul_(0.05)
+    weight = weight.to(weight_dtype)
+
+    expected_normalized, expected_residual = GemmaRMSNorm._forward_static_with_residual(
+        weight, 1e-6, x, residual
+    )
+    normalized, residual_out = (
+        torch.ops.vllm.sm70_gemma_long_prefill_fused_add_rms_norm(
+            x,
+            residual,
+            weight,
+            1e-6,
+        )
+    )
+
+    assert torch.equal(normalized, expected_normalized)
+    assert torch.equal(residual_out, expected_residual)

--- a/tests/kernels/mamba/test_sm70_flashqla_extension.py
+++ b/tests/kernels/mamba/test_sm70_flashqla_extension.py
@@ -1,0 +1,80 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Unit tests for the SM70 FlashQLA extension loader."""
+
+from __future__ import annotations
+
+from types import ModuleType
+
+import pytest
+
+from flash_qla.ops.gated_delta_rule.chunk.sm70 import fused_fwd
+
+
+@pytest.fixture(autouse=True)
+def reset_extension_load_state(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(fused_fwd, "_EXT", None)
+    monkeypatch.setattr(fused_fwd, "_EXT_LOAD_ERROR", None)
+    monkeypatch.setattr(fused_fwd.torch.cuda, "is_available", lambda: True)
+
+
+def test_sm70_flashqla_prefers_bundled_extension(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    bundled = ModuleType("flash_qla_sm70_gdn_strided")
+    monkeypatch.setattr(fused_fwd.importlib, "import_module", lambda name: bundled)
+    monkeypatch.setattr(
+        fused_fwd,
+        "load",
+        lambda **kwargs: pytest.fail("JIT fallback must not run"),
+    )
+
+    assert fused_fwd._load_ext() is bundled
+
+
+def test_sm70_flashqla_jit_fallback_uses_fixed_arches(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    loaded = ModuleType("flash_qla_sm70_gdn_strided")
+    load_kwargs = {}
+
+    def missing_bundled(name: str):
+        error = ModuleNotFoundError(name=name)
+        raise error
+
+    def fake_load(**kwargs):
+        load_kwargs.update(kwargs)
+        return loaded
+
+    monkeypatch.setattr(fused_fwd.importlib, "import_module", missing_bundled)
+    monkeypatch.setattr(fused_fwd, "load", fake_load)
+
+    assert fused_fwd._load_ext() is loaded
+    assert load_kwargs["extra_cuda_cflags"] == [
+        "-O3",
+        "-gencode=arch=compute_70,code=sm_70",
+        "-gencode=arch=compute_75,code=sm_75",
+    ]
+
+
+def test_sm70_flashqla_retains_bundled_loader_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    initial_error = OSError("undefined symbol")
+    import_calls = 0
+
+    def failing_import(name: str):
+        nonlocal import_calls
+        import_calls += 1
+        raise initial_error
+
+    monkeypatch.setattr(fused_fwd.importlib, "import_module", failing_import)
+
+    with pytest.raises(RuntimeError, match="failed to load") as first_error:
+        fused_fwd._load_ext()
+    assert first_error.value.__cause__ is initial_error
+
+    with pytest.raises(RuntimeError, match="previously failed") as retry_error:
+        fused_fwd._load_ext()
+    assert retry_error.value.__cause__ is initial_error
+    assert import_calls == 1

--- a/tests/model_executor/test_qwen3_5_quantization.py
+++ b/tests/model_executor/test_qwen3_5_quantization.py
@@ -5,7 +5,9 @@ from unittest.mock import Mock, patch
 
 
 class _QuantConfig:
-    pass
+    def __init__(self) -> None:
+        self.ignore: list[str] = []
+        self.config: dict[str, object] = {}
 
 
 def test_qwen3_5_split_gdn_detects_compressed_tensors_ignore():

--- a/tests/quantization/test_sm70_fp8_prefill_exact_dense.py
+++ b/tests/quantization/test_sm70_fp8_prefill_exact_dense.py
@@ -80,7 +80,7 @@ def test_fp8_prefill_dispatch_reaches_runtime_op_for_small_and_large_m(monkeypat
 
     def fake_dispatch(
         out,
-        dense_weight,
+        dense_weight_ptr,
         input,
         qweight,
         scales,
@@ -90,6 +90,7 @@ def test_fp8_prefill_dispatch_reaches_runtime_op_for_small_and_large_m(monkeypat
         gated_silu,
         min_prefill_m,
     ):
+        assert dense_weight_ptr == 42
         calls.append((input.shape[0], min_prefill_m, gated_silu))
         out.zero_()
 
@@ -106,7 +107,7 @@ def test_fp8_prefill_dispatch_reaches_runtime_op_for_small_and_large_m(monkeypat
         weight_scale_inv=torch.empty((1, 6), dtype=torch.float16),
         sm70_fp8_k_ld=4,
         sm70_fp8_q_ld=6,
-        _sm70_fp8_prefill_exact_dense_workspace=torch.empty(24, dtype=torch.float16),
+        sm70_fp8_prefill_exact_dense_workspace_ptr=42,
     )
     method = SimpleNamespace()
 

--- a/tests/quantization/test_sm70_fp8_prefill_exact_dense.py
+++ b/tests/quantization/test_sm70_fp8_prefill_exact_dense.py
@@ -1,0 +1,126 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+
+import torch
+
+import vllm.envs as envs
+from vllm.model_executor.layers.quantization.fp8 import (
+    _SM70_FP8_PREFILL_DENSE_MIN_M,
+    _SM70_FP8_PREFILL_DENSE_WORKSPACE_BYTES,
+    Fp8LinearMethod,
+    _get_sm70_fp8_prefill_exact_dense_workspace,
+    _is_sm70_fp8_prefill_exact_dense_layer,
+    _sm70_fp8_prefill_dense_workspaces,
+)
+
+
+def test_fp8_prefill_exact_dense_is_default_on(monkeypatch):
+    monkeypatch.delenv("VLLM_SM70_FP8_PREFILL_EXACT_DENSE", raising=False)
+    envs.disable_envs_cache()
+    try:
+        assert envs.VLLM_SM70_FP8_PREFILL_EXACT_DENSE
+    finally:
+        envs.disable_envs_cache()
+
+
+def test_fp8_prefill_exact_dense_shape_gate_is_narrow():
+    layer = SimpleNamespace(
+        tp_size=4,
+        prefix="model.language_model.layers.1.mlp.gate_up_proj",
+        weight=SimpleNamespace(shape=(5120, 8704)),
+    )
+
+    assert _is_sm70_fp8_prefill_exact_dense_layer(layer)
+
+    layer.tp_size = 2
+    assert not _is_sm70_fp8_prefill_exact_dense_layer(layer)
+    layer.tp_size = 4
+    layer.prefix = "model.language_model.layers.1.self_attn.qkv_proj"
+    layer.weight = SimpleNamespace(shape=(5120, 3584))
+    assert not _is_sm70_fp8_prefill_exact_dense_layer(layer)
+    layer.prefix = "model.language_model.layers.1.linear_attn.in_proj_qkvz"
+    layer.weight = SimpleNamespace(shape=(5120, 4096))
+    assert not _is_sm70_fp8_prefill_exact_dense_layer(layer)
+    layer.prefix = "model.language_model.layers.1.mlp.gate_up_proj"
+    layer.weight = SimpleNamespace(shape=(5120, 8192))
+    assert not _is_sm70_fp8_prefill_exact_dense_layer(layer)
+
+
+def test_fp8_prefill_exact_dense_workspace_is_bounded():
+    assert _SM70_FP8_PREFILL_DENSE_WORKSPACE_BYTES == 85 * 1024**2
+
+
+def test_fp8_prefill_exact_dense_workspace_is_reused(monkeypatch):
+    workspace = torch.empty(1, dtype=torch.float16)
+    allocations = []
+
+    def fake_empty(shape, *, dtype, device):
+        allocations.append((shape, dtype, device))
+        return workspace
+
+    _sm70_fp8_prefill_dense_workspaces.clear()
+    monkeypatch.setattr(torch, "empty", fake_empty)
+    weight = SimpleNamespace(device=torch.device("cuda:0"))
+
+    try:
+        first = _get_sm70_fp8_prefill_exact_dense_workspace(weight)
+        second = _get_sm70_fp8_prefill_exact_dense_workspace(weight)
+
+        assert first is workspace
+        assert second is workspace
+        assert len(allocations) == 1
+    finally:
+        _sm70_fp8_prefill_dense_workspaces.clear()
+
+
+def test_fp8_prefill_dispatch_reaches_runtime_op_for_small_and_large_m(monkeypatch):
+    calls = []
+
+    def fake_dispatch(
+        out,
+        dense_weight,
+        input,
+        qweight,
+        scales,
+        group_size,
+        k_ld,
+        q_ld,
+        gated_silu,
+        min_prefill_m,
+    ):
+        calls.append((input.shape[0], min_prefill_m, gated_silu))
+        out.zero_()
+
+    monkeypatch.setattr(
+        "vllm.model_executor.layers.quantization.fp8.sm70_ops."
+        "fp8_gemm_sm70_prefill_dispatch_out",
+        fake_dispatch,
+    )
+    layer = SimpleNamespace(
+        sm70_fp8_turbomind=True,
+        sm70_fp8_bmm=False,
+        output_size_per_partition=6,
+        weight=torch.empty((4, 6), dtype=torch.uint8),
+        weight_scale_inv=torch.empty((1, 6), dtype=torch.float16),
+        sm70_fp8_k_ld=4,
+        sm70_fp8_q_ld=6,
+        _sm70_fp8_prefill_exact_dense_workspace=torch.empty(24, dtype=torch.float16),
+    )
+    method = SimpleNamespace()
+
+    for m in (1, _SM70_FP8_PREFILL_DENSE_MIN_M):
+        output = Fp8LinearMethod.apply(
+            method, layer, torch.empty((m, 4), dtype=torch.float16)
+        )
+        assert output.shape == (m, 6)
+
+    assert calls == [
+        (1, _SM70_FP8_PREFILL_DENSE_MIN_M, False),
+        (
+            _SM70_FP8_PREFILL_DENSE_MIN_M,
+            _SM70_FP8_PREFILL_DENSE_MIN_M,
+            False,
+        ),
+    ]

--- a/tests/quantization/test_sm70_warmup.py
+++ b/tests/quantization/test_sm70_warmup.py
@@ -66,3 +66,133 @@ def test_fp8_warmup_matches_grouped_bmm_runtime_slice(monkeypatch):
     assert all(call.group_size == 128 for call in calls)
     assert all(call.k_ld == 128 and call.q_ld == 64 for call in calls)
     assert all(not call.gated_silu for call in calls)
+
+
+def test_fp8_coordinated_warmup_leader_broadcasts_rank0_lut(monkeypatch):
+    import vllm.distributed.parallel_state as parallel_state
+
+    calls = []
+    broadcasts = []
+    barriers = []
+
+    def broadcast_object(payload, src):
+        broadcasts.append((payload, src))
+        return payload
+
+    def warmup_layers(layers, m_values):
+        calls.append((layers, m_values))
+        return 5
+
+    tp_group = SimpleNamespace(
+        world_size=4,
+        rank_in_group=0,
+        broadcast_object=broadcast_object,
+        barrier=lambda: barriers.append(True),
+    )
+    monkeypatch.setenv("VLLM_SM70_FP8_TUNE_SMALL_SHAPES", "1")
+    monkeypatch.setenv("VLLM_SM70_FP8_COORDINATED_TUNING", "1")
+    warmup.envs.disable_envs_cache()
+    monkeypatch.setattr(parallel_state, "get_tp_group", lambda: tp_group)
+    monkeypatch.setattr(
+        warmup,
+        "_warmup_fp8_dense_layers",
+        warmup_layers,
+    )
+    monkeypatch.setattr(warmup, "_export_lut_bytes", lambda device: (b"lut", 7))
+    monkeypatch.setattr(
+        warmup,
+        "_import_lut_bytes",
+        lambda device, payload: (_ for _ in ()).throw(AssertionError()),
+    )
+    monkeypatch.setattr(torch.accelerator, "synchronize", lambda device: None)
+
+    layers = [(nn.Module(), False)]
+    count = warmup._warmup_fp8_dense_layers_coordinated(
+        layers,
+        [1, 4],
+        torch.device("cuda:0"),
+    )
+
+    assert count == 5
+    assert calls == [(layers, [1, 4]), (layers, [1, 4])]
+    assert broadcasts == [(b"lut", 0)]
+    assert barriers == [True]
+
+
+def test_fp8_coordinated_warmup_follower_imports_rank0_lut(monkeypatch):
+    import vllm.distributed.parallel_state as parallel_state
+
+    calls = []
+    imports = []
+    barriers = []
+
+    def warmup_layers(layers, m_values):
+        calls.append((layers, m_values))
+        return 5
+
+    def import_lut(device, payload):
+        imports.append((device, payload))
+        return 7
+
+    tp_group = SimpleNamespace(
+        world_size=4,
+        rank_in_group=2,
+        broadcast_object=lambda payload, src: b"lut",
+        barrier=lambda: barriers.append(True),
+    )
+    monkeypatch.setenv("VLLM_SM70_FP8_TUNE_SMALL_SHAPES", "1")
+    monkeypatch.setenv("VLLM_SM70_FP8_COORDINATED_TUNING", "1")
+    warmup.envs.disable_envs_cache()
+    monkeypatch.setattr(parallel_state, "get_tp_group", lambda: tp_group)
+    monkeypatch.setattr(
+        warmup,
+        "_warmup_fp8_dense_layers",
+        warmup_layers,
+    )
+    monkeypatch.setattr(
+        warmup,
+        "_export_lut_bytes",
+        lambda device: (_ for _ in ()).throw(AssertionError()),
+    )
+    monkeypatch.setattr(
+        warmup,
+        "_import_lut_bytes",
+        import_lut,
+    )
+    monkeypatch.setattr(torch.accelerator, "synchronize", lambda device: None)
+
+    layers = [(nn.Module(), False)]
+    count = warmup._warmup_fp8_dense_layers_coordinated(
+        layers,
+        [1, 4],
+        torch.device("cuda:2"),
+    )
+
+    assert count == 5
+    assert calls == [(layers, [1, 4])]
+    assert imports == [(torch.device("cuda:2"), b"lut")]
+    assert barriers == [True]
+
+
+def test_fp8_explicit_lut_reuse_allows_dynamic_cache_import(monkeypatch):
+    monkeypatch.setenv("VLLM_SM70_FP8_TUNE_SMALL_SHAPES", "1")
+    monkeypatch.setenv("VLLM_SM70_FP8_REUSE_IMPORTED_CACHE", "1")
+    warmup.envs.disable_envs_cache()
+
+    assert not warmup._lut_cache_disabled_for_dynamic_quant_dispatch(
+        has_awq_dense=False,
+        has_fp8_dense=True,
+        fp4_kinds=set(),
+    )
+
+
+def test_fp8_dynamic_tuning_skips_stale_lut_by_default(monkeypatch):
+    monkeypatch.setenv("VLLM_SM70_FP8_TUNE_SMALL_SHAPES", "1")
+    monkeypatch.delenv("VLLM_SM70_FP8_REUSE_IMPORTED_CACHE", raising=False)
+    warmup.envs.disable_envs_cache()
+
+    assert warmup._lut_cache_disabled_for_dynamic_quant_dispatch(
+        has_awq_dense=False,
+        has_fp8_dense=True,
+        fp4_kinds=set(),
+    )

--- a/tests/test_envs.py
+++ b/tests/test_envs.py
@@ -122,7 +122,7 @@ def test_flash_v100_g6_sawtooth_pipeline_envs(
     bool_defaults = {
         "VLLM_FLASH_V100_XQA_G6_P1024_SAWTOOTH": True,
         "VLLM_FLASH_V100_XQA_G6_P1024_SAWTOOTH_TRACE": False,
-        "VLLM_FLASH_V100_XQA_G6_QK_PIPELINE": False,
+        "VLLM_FLASH_V100_XQA_G6_QK_PIPELINE": True,
         "VLLM_FLASH_V100_XQA_G6_QK_PIPELINE_TRACE": False,
     }
     int_defaults = {

--- a/tests/test_envs.py
+++ b/tests/test_envs.py
@@ -104,16 +104,21 @@ def test_is_envs_cache_enabled() -> None:
 
 
 def test_precompiled_install_flags_are_orthogonal() -> None:
-    with patch.dict(
-        os.environ,
-        {
-            "VLLM_PRECOMPILED_WHEEL_LOCATION": "/tmp/vllm.whl",
-            "VLLM_USE_PRECOMPILED_RUST": "1",
-        },
-        clear=False,
-    ):
+    # The Rust frontend flag must not implicitly enable the precompiled C
+    # extensions.
+    with patch.dict(os.environ, {"VLLM_USE_PRECOMPILED_RUST": "1"}, clear=True):
         assert environment_variables["VLLM_USE_PRECOMPILED"]() is False
         assert environment_variables["VLLM_USE_PRECOMPILED_RUST"]() is True
+
+    # A wheel location still selects precompiled C extensions without
+    # implicitly enabling the Rust frontend.
+    with patch.dict(
+        os.environ,
+        {"VLLM_PRECOMPILED_WHEEL_LOCATION": "/tmp/vllm.whl"},
+        clear=True,
+    ):
+        assert environment_variables["VLLM_USE_PRECOMPILED"]() is True
+        assert environment_variables["VLLM_USE_PRECOMPILED_RUST"]() is False
 
 
 def test_flash_v100_g6_sawtooth_pipeline_envs(

--- a/tests/v1/attention/test_sm70_flash_v100_policy.py
+++ b/tests/v1/attention/test_sm70_flash_v100_policy.py
@@ -241,6 +241,29 @@ def test_prefill_gather_dense_does_not_require_generic_dense_op(monkeypatch):
     assert impl.use_flash_v100_prefill_gather_dense is True
 
 
+def test_flash_v100_normalizes_resolved_float16_cache_dtype(monkeypatch):
+    import vllm.v1.attention.backends.flash_attn_v100 as flash_v100
+
+    monkeypatch.setattr(flash_v100, "_get_flash_ops", lambda: (None,) * 9)
+    monkeypatch.setattr(
+        flash_v100,
+        "_get_fp8_e5m2_paged_kv_bridge_op",
+        lambda: None,
+    )
+
+    impl = flash_v100.FlashAttnV100Impl(
+        num_heads=4,
+        head_size=256,
+        scale=1.0,
+        num_kv_heads=1,
+        alibi_slopes=None,
+        sliding_window=None,
+        kv_cache_dtype="float16",
+    )
+
+    assert impl.kv_cache_dtype == "auto"
+
+
 def test_prefill_gather_dense_reorders_random_pages_and_reuses_workspace(
     monkeypatch,
 ):

--- a/tests/v1/attention/test_sm70_flash_v100_policy.py
+++ b/tests/v1/attention/test_sm70_flash_v100_policy.py
@@ -853,7 +853,11 @@ def test_flash_v100_smallq_cudagraph_metadata_uses_persistent_buffers(
 
     assert torch.equal(
         capture_metadata.smallq_decode_seq_lens,
-        torch.tensor([1, 2, 3, 4], dtype=torch.int32),
+        torch.tensor(
+            [1, 2, 3, 4],
+            dtype=torch.int32,
+            device=capture_metadata.smallq_decode_seq_lens.device,
+        ),
     )
 
     runtime_common = create_common_attn_metadata(
@@ -1010,7 +1014,11 @@ def test_flash_v100_smallq_metadata_masks_cudagraph_padding(
 
     assert torch.equal(
         attn_metadata.smallq_decode_seq_lens,
-        torch.tensor([6, 7, 8, 6, 7, 0], dtype=torch.int32),
+        torch.tensor(
+            [6, 7, 8, 6, 7, 0],
+            dtype=torch.int32,
+            device=attn_metadata.smallq_decode_seq_lens.device,
+        ),
     )
     assert torch.equal(
         attn_metadata.smallq_decode_block_table[-1],
@@ -1064,6 +1072,28 @@ def test_flash_v100_smallq_replay_shape_overflow_fails_fast(
 
     with pytest.raises(RuntimeError, match="persistent buffer capacity"):
         builder.build(0, runtime_common)
+
+
+@pytest.mark.parametrize(
+    ("max_num_seqs", "expected"),
+    [
+        (1, [1, 2]),
+        (2, [1, 2]),
+        (3, [1, 2, 3]),
+        (4, [1, 2, 4]),
+        (8, [1, 2, 4, 8]),
+        (12, [1, 2, 4, 8, 12]),
+        (16, [1, 2, 4, 8, 16]),
+        (256, [1, 2, 4, 8, 16]),
+    ],
+)
+def test_sm70_nomtp_cudagraph_capture_sizes_cover_concurrency(
+    max_num_seqs: int,
+    expected: list[int],
+):
+    from vllm.config.vllm import _sm70_nomtp_cudagraph_capture_sizes
+
+    assert _sm70_nomtp_cudagraph_capture_sizes(max_num_seqs) == expected
 
 
 def test_flash_v100_decode_query_does_not_attach_smallq_metadata(

--- a/tests/v1/attention/test_sm70_flash_v100_policy.py
+++ b/tests/v1/attention/test_sm70_flash_v100_policy.py
@@ -150,6 +150,111 @@ def test_sm70_fa2_d256_prefill_env_is_default_on(monkeypatch):
     assert envs.VLLM_FLASH_V100_FA2_D256_PREFILL is False
 
 
+def test_sm70_e5m2_decode_fast_route_envs_are_default_on(monkeypatch):
+    import vllm.envs as envs
+
+    names = (
+        "VLLM_FLASH_V100_XQA_E5M2_G6_DUAL_CTA",
+        "VLLM_FLASH_V100_XQA_E5M2_G6_SPLIT_REDUCE",
+        "VLLM_FLASH_V100_XQA_E5M2_PARTITION_PAGE_IDS",
+        "VLLM_FLASH_V100_XQA_E5M2_PAIR_LOAD",
+    )
+    for name in names:
+        monkeypatch.delenv(name, raising=False)
+    monkeypatch.delenv("VLLM_FLASH_V100_XQA_E5M2_P1024_BEGIN", raising=False)
+    envs.disable_envs_cache()
+    assert envs.VLLM_FLASH_V100_XQA_E5M2_G6_DUAL_CTA is True
+    assert envs.VLLM_FLASH_V100_XQA_E5M2_G6_SPLIT_REDUCE is True
+    assert envs.VLLM_FLASH_V100_XQA_E5M2_PARTITION_PAGE_IDS is True
+    assert envs.VLLM_FLASH_V100_XQA_E5M2_PAIR_LOAD is True
+    assert envs.VLLM_FLASH_V100_XQA_E5M2_P1024_BEGIN == 61633
+
+    for name in names:
+        monkeypatch.setenv(name, "0")
+    envs.disable_envs_cache()
+    assert envs.VLLM_FLASH_V100_XQA_E5M2_G6_DUAL_CTA is False
+    assert envs.VLLM_FLASH_V100_XQA_E5M2_G6_SPLIT_REDUCE is False
+    assert envs.VLLM_FLASH_V100_XQA_E5M2_PARTITION_PAGE_IDS is False
+    assert envs.VLLM_FLASH_V100_XQA_E5M2_PAIR_LOAD is False
+
+    monkeypatch.setenv("VLLM_FLASH_V100_XQA_E5M2_P1024_BEGIN", "49152")
+    envs.disable_envs_cache()
+    assert envs.VLLM_FLASH_V100_XQA_E5M2_P1024_BEGIN == 49152
+
+
+def test_sm70_flash_v100_fp8_alias_resolves_to_e5m2(monkeypatch):
+    import vllm.engine.arg_utils as arg_utils
+    import vllm.envs as envs
+
+    monkeypatch.delenv("VLLM_SM70_FLASH_ATTN_V100", raising=False)
+    envs.disable_envs_cache()
+    monkeypatch.setattr(
+        arg_utils,
+        "current_platform",
+        SimpleNamespace(
+            is_cuda=lambda: True,
+            get_device_capability=lambda: SimpleNamespace(major=7, minor=0),
+        ),
+    )
+
+    assert (
+        arg_utils._resolve_sm70_flash_v100_kv_cache_dtype_alias("fp8", "fp8")
+        == "fp8_e5m2"
+    )
+    assert (
+        arg_utils._resolve_sm70_flash_v100_kv_cache_dtype_alias("fp8_e4m3", "fp8_e4m3")
+        == "fp8_e4m3"
+    )
+    assert (
+        arg_utils._resolve_sm70_flash_v100_kv_cache_dtype_alias("auto", "fp8_e4m3")
+        == "fp8_e4m3"
+    )
+
+
+def test_fp8_alias_keeps_upstream_e4m3_semantics_without_sm70_flash(
+    monkeypatch,
+):
+    import vllm.engine.arg_utils as arg_utils
+    import vllm.envs as envs
+
+    monkeypatch.setenv("VLLM_SM70_FLASH_ATTN_V100", "0")
+    envs.disable_envs_cache()
+    monkeypatch.setattr(
+        arg_utils,
+        "current_platform",
+        SimpleNamespace(
+            is_cuda=lambda: True,
+            get_device_capability=lambda: SimpleNamespace(major=7, minor=0),
+        ),
+    )
+
+    assert (
+        arg_utils._resolve_sm70_flash_v100_kv_cache_dtype_alias("fp8", "fp8") == "fp8"
+    )
+
+
+def test_fp8_alias_is_not_rewritten_outside_nvidia_cuda(monkeypatch):
+    import vllm.engine.arg_utils as arg_utils
+    import vllm.envs as envs
+
+    monkeypatch.delenv("VLLM_SM70_FLASH_ATTN_V100", raising=False)
+    envs.disable_envs_cache()
+    monkeypatch.setattr(
+        arg_utils,
+        "current_platform",
+        SimpleNamespace(
+            is_cuda=lambda: False,
+            get_device_capability=lambda: pytest.fail(
+                "non-CUDA platforms must not query an NVIDIA capability"
+            ),
+        ),
+    )
+
+    assert (
+        arg_utils._resolve_sm70_flash_v100_kv_cache_dtype_alias("fp8", "fp8") == "fp8"
+    )
+
+
 def test_sm70_prefill_gather_dense_env_is_default_on(monkeypatch):
     import vllm.envs as envs
 
@@ -1320,7 +1425,9 @@ def test_flash_v100_decode_uses_xqa_by_default_when_shape_supported(monkeypatch)
     ("num_heads", "seq_len", "expected_route"),
     (
         (6, 4096, "scalar"),
-        (6, 8192, "xqa"),
+        (6, 8192, "scalar"),
+        (6, 16383, "scalar"),
+        (6, 16384, "xqa"),
         (4, 65536, "scalar"),
         (8, 65536, "xqa"),
     ),
@@ -1402,18 +1509,123 @@ def test_flash_v100_fp8_prefill_bridge_accepts_mtp_aligned_tail():
     )
 
 
-def test_flash_v100_fp8_xqa_graph_capture_marker_forces_xqa(monkeypatch):
+def test_flash_v100_fp8_prefill_bridge_prefers_logical_dense_exact(monkeypatch):
+    from vllm.v1.attention.backends import flash_attn_v100 as mod
+    from vllm.v1.attention.backends.flash_attn_v100 import FlashAttnV100Impl
+
+    impl = object.__new__(FlashAttnV100Impl)
+    impl.scale = 256**-0.5
+    bridge_calls = []
+    exact_calls = []
+
+    def bridge_op(*args):
+        bridge_calls.append(args)
+
+    def exact_op(query, key, value, **kwargs):
+        exact_calls.append((query, key, value, kwargs))
+        kwargs["out"].fill_(3)
+        return kwargs["out"]
+
+    impl.fp8_e5m2_paged_kv_to_fp16 = bridge_op
+    impl.flash_attn_prefill_paged = lambda *args, **kwargs: pytest.fail(
+        "dense exact path unexpectedly fell back to paged prefill"
+    )
+    key_workspace = torch.empty((1, 784, 1, 256), dtype=torch.float16)
+    value_workspace = torch.empty_like(key_workspace)
+    output_block_table = torch.zeros((1, 1), dtype=torch.int32)
+    monkeypatch.setattr(
+        mod,
+        "_get_fp8_prefill_bridge_workspace",
+        lambda key_cache, required_blocks: (
+            key_workspace,
+            value_workspace,
+            output_block_table,
+        ),
+    )
+    monkeypatch.setattr(
+        mod,
+        "_uniform_cu_seqlens",
+        lambda *args, **kwargs: (
+            torch.tensor([0, 64], dtype=torch.int32),
+            torch.tensor([0, 64], dtype=torch.int32),
+        ),
+    )
+    monkeypatch.setattr(mod, "_try_sm70_fa2_d256_prefill", exact_op)
+
+    query = torch.zeros((1, 64, 6, 256), dtype=torch.float16)
+    key_cache = torch.zeros((1, 64, 1, 256), dtype=torch.uint8)
+    value_cache = torch.zeros_like(key_cache)
+    block_table = torch.tensor([[0]], dtype=torch.int32)
+    seq_lens = torch.tensor([64], dtype=torch.int32)
+    out = torch.zeros_like(query)
+
+    result = impl._run_fp8_prefill_bridge(
+        query=query,
+        key_cache=key_cache,
+        value_cache=value_cache,
+        block_table=block_table,
+        seq_lens=seq_lens,
+        seq_len=64,
+        k_scale=1.0,
+        v_scale=1.0,
+        causal=True,
+        window_size=(-1, -1),
+        out=out,
+    )
+
+    assert result is not None
+    assert result[0] is out
+    assert result[1] is True
+    assert len(bridge_calls) == 1
+    assert len(exact_calls) == 1
+    _, dense_key, dense_value, kwargs = exact_calls[0]
+    assert dense_key.shape == (1, 64, 1, 256)
+    assert dense_value.shape == dense_key.shape
+    assert dense_key.is_contiguous()
+    assert dense_value.is_contiguous()
+    assert kwargs["cu_seqlens_k"] is not None
+    assert kwargs.get("block_table") is None
+    assert torch.all(out == 3)
+
+
+def test_flash_v100_fp8_prefill_bridge_workspace_oom_falls_back(monkeypatch):
+    from vllm.v1.attention.backends import flash_attn_v100 as mod
+
+    key_cache = torch.zeros((1, 1568, 1, 33), dtype=torch.uint8)
+    mod._fp8_prefill_bridge_workspaces.clear()
+    monkeypatch.setattr(
+        torch.cuda,
+        "current_stream",
+        lambda device: SimpleNamespace(cuda_stream=17),
+    )
+    monkeypatch.setattr(torch.accelerator, "current_device_index", lambda: 0)
+    monkeypatch.setattr(
+        torch,
+        "empty",
+        lambda *args, **kwargs: (_ for _ in ()).throw(torch.OutOfMemoryError()),
+    )
+
+    assert mod._get_fp8_prefill_bridge_workspace(key_cache, 2) is None
+
+
+@pytest.mark.parametrize(
+    ("static_seq_hint", "expected"),
+    ((8192, False), (16384, True), (262144, True)),
+)
+def test_flash_v100_fp8_xqa_graph_capture_uses_static_context_hint(
+    monkeypatch, static_seq_hint, expected
+):
     from vllm.v1.attention.backends import flash_attn_v100 as mod
 
     monkeypatch.setattr(mod, "_is_cuda_graph_capturing", lambda query: False)
     metadata = SimpleNamespace(
         flash_v100_cudagraph_capture=True,
         flash_v100_decode_max_seq_len_hint=1,
-        flash_v100_static_decode_seq_hint=262144,
-        flash_v100_decode_workspace_seq_capacity_hint=262144,
+        flash_v100_static_decode_seq_hint=static_seq_hint,
+        flash_v100_decode_workspace_seq_capacity_hint=static_seq_hint,
     )
 
-    assert mod._decode_fp8_xqa_allowed(metadata, torch.empty(1))
+    assert mod._decode_fp8_xqa_allowed(metadata, torch.empty(1)) is expected
 
 
 def test_flash_v100_mtp5_dual_cta_partition_policy(monkeypatch):
@@ -1677,7 +1889,7 @@ def test_flash_v100_decode_sawtooth_rollback_preserves_default_planner(
     monkeypatch,
 ):
     from vllm.v1.attention.backends.flash_attn_v100 import (
-        _g6_page784_sawtooth_partition_size_hint,
+        _g6_aligned_page_partition_size_hint,
     )
 
     monkeypatch.delenv("VLLM_FLASH_V100_DECODE_PARTITION_SIZE", raising=False)
@@ -1685,14 +1897,17 @@ def test_flash_v100_decode_sawtooth_rollback_preserves_default_planner(
     query = torch.zeros((1, 6, 256), dtype=torch.float16)
     key_cache = torch.zeros((1, 784, 1, 256), dtype=torch.float16)
 
-    assert _g6_page784_sawtooth_partition_size_hint(query, key_cache, key_cache) is None
+    assert (
+        _g6_aligned_page_partition_size_hint(query, key_cache, key_cache, "auto")
+        is None
+    )
 
 
 def test_flash_v100_decode_sawtooth_preserves_explicit_partition_override(
     monkeypatch,
 ):
     from vllm.v1.attention.backends.flash_attn_v100 import (
-        _g6_page784_sawtooth_partition_size_hint,
+        _g6_aligned_page_partition_size_hint,
     )
 
     monkeypatch.setenv("VLLM_FLASH_V100_DECODE_PARTITION_SIZE", "256")
@@ -1700,20 +1915,89 @@ def test_flash_v100_decode_sawtooth_preserves_explicit_partition_override(
     query = torch.zeros((1, 6, 256), dtype=torch.float16)
     key_cache = torch.zeros((1, 784, 1, 256), dtype=torch.float16)
 
-    assert _g6_page784_sawtooth_partition_size_hint(query, key_cache, key_cache) is None
+    assert (
+        _g6_aligned_page_partition_size_hint(query, key_cache, key_cache, "auto")
+        is None
+    )
 
 
 def test_flash_v100_decode_sawtooth_workspace_supports_fp8_kv(monkeypatch):
     from vllm.v1.attention.backends.flash_attn_v100 import (
-        _g6_page784_sawtooth_partition_size_hint,
+        _g6_aligned_page_partition_size_hint,
     )
 
     monkeypatch.delenv("VLLM_FLASH_V100_DECODE_PARTITION_SIZE", raising=False)
     monkeypatch.delenv("VLLM_FLASH_V100_XQA_G6_P1024_SAWTOOTH", raising=False)
     query = torch.zeros((1, 6, 256), dtype=torch.float16)
-    key_cache = torch.zeros((1, 784, 1, 256), dtype=torch.uint8)
+    key_cache = torch.zeros((1, 784, 1, 256), dtype=torch.float16)
 
-    assert _g6_page784_sawtooth_partition_size_hint(query, key_cache, key_cache) == 256
+    assert (
+        _g6_aligned_page_partition_size_hint(query, key_cache, key_cache, "auto") == 256
+    )
+
+
+def test_flash_v100_decode_e5m2_aligned_page_plans_p256_workspace(monkeypatch):
+    from vllm.v1.attention.backends.flash_attn_v100 import (
+        _g6_aligned_page_partition_size_hint,
+    )
+
+    monkeypatch.delenv("VLLM_FLASH_V100_DECODE_PARTITION_SIZE", raising=False)
+    monkeypatch.delenv("VLLM_FLASH_V100_XQA_G6_P1024_SAWTOOTH", raising=False)
+    query = torch.zeros((1, 6, 256), dtype=torch.float16)
+    key_cache = torch.zeros((1, 1568, 1, 256), dtype=torch.uint8)
+
+    assert (
+        _g6_aligned_page_partition_size_hint(query, key_cache, key_cache, "fp8_e5m2")
+        == 256
+    )
+
+
+def test_flash_v100_decode_e5m2_partition_hint_is_page_size_generic(monkeypatch):
+    from vllm.v1.attention.backends.flash_attn_v100 import (
+        _g6_aligned_page_partition_size_hint,
+    )
+
+    monkeypatch.delenv("VLLM_FLASH_V100_DECODE_PARTITION_SIZE", raising=False)
+    monkeypatch.delenv("VLLM_FLASH_V100_XQA_G6_P1024_SAWTOOTH", raising=False)
+    query = torch.zeros((1, 6, 256), dtype=torch.float16)
+    key_cache = torch.zeros((1, 1616, 1, 256), dtype=torch.uint8)
+
+    assert (
+        _g6_aligned_page_partition_size_hint(query, key_cache, key_cache, "fp8_e5m2")
+        == 256
+    )
+
+
+def test_flash_v100_decode_e5m2_keeps_small_pages_on_default_planner(monkeypatch):
+    from vllm.v1.attention.backends.flash_attn_v100 import (
+        _g6_aligned_page_partition_size_hint,
+    )
+
+    monkeypatch.delenv("VLLM_FLASH_V100_DECODE_PARTITION_SIZE", raising=False)
+    monkeypatch.delenv("VLLM_FLASH_V100_XQA_G6_P1024_SAWTOOTH", raising=False)
+    query = torch.zeros((1, 6, 256), dtype=torch.float16)
+    key_cache = torch.zeros((1, 16, 1, 256), dtype=torch.uint8)
+
+    assert (
+        _g6_aligned_page_partition_size_hint(query, key_cache, key_cache, "fp8_e5m2")
+        is None
+    )
+
+
+def test_flash_v100_decode_e4m3_does_not_use_e5m2_partition_hint(monkeypatch):
+    from vllm.v1.attention.backends.flash_attn_v100 import (
+        _g6_aligned_page_partition_size_hint,
+    )
+
+    monkeypatch.delenv("VLLM_FLASH_V100_DECODE_PARTITION_SIZE", raising=False)
+    monkeypatch.delenv("VLLM_FLASH_V100_XQA_G6_P1024_SAWTOOTH", raising=False)
+    query = torch.zeros((1, 6, 256), dtype=torch.float16)
+    key_cache = torch.zeros((1, 1568, 1, 256), dtype=torch.uint8)
+
+    assert (
+        _g6_aligned_page_partition_size_hint(query, key_cache, key_cache, "fp8_e4m3")
+        is None
+    )
 
 
 def test_flash_v100_decode_keeps_qwen35_tp4_short_context_on_scalar(monkeypatch):

--- a/tests/v1/attention/test_sm70_flashinfer_backend.py
+++ b/tests/v1/attention/test_sm70_flashinfer_backend.py
@@ -95,9 +95,7 @@ def _make_fixed_prefill_impl(fixed_entry, splitkv3_entry=None):
     impl.logits_soft_cap = 0.0
     impl.sinks = None
     impl.flash_attn_prefill_paged_d256_bm32_allp_pair_scratch = fixed_entry
-    impl.flash_attn_prefill_paged_d256_bm32_allp_pair_scratch_splitkv3 = (
-        splitkv3_entry
-    )
+    impl.flash_attn_prefill_paged_d256_bm32_allp_pair_scratch_splitkv3 = splitkv3_entry
     impl.last_route_proof = None
     impl._flashinfer_sm70_active_metadata = None
     return impl
@@ -247,7 +245,7 @@ def test_eligible_fixed_prefill_bypasses_parent_and_records_runtime_proof(
 ) -> None:
     decision, metadata, query, kv_cache, output = _make_fixed_prefill_case()
     calls = []
-    route_calls = []
+    route_calls: list[str] = []
 
     def fixed_entry(
         query_bhmd,
@@ -351,7 +349,7 @@ def test_promoted_splitkv3_bypasses_fixed_entry_and_records_actual_n(
 ) -> None:
     decision, metadata, query, kv_cache, output = _make_fixed_prefill_case()
     calls = []
-    route_calls = []
+    route_calls: list[str] = []
 
     def splitkv3_entry(
         query_bhmd,
@@ -541,7 +539,7 @@ def test_fixed_prefill_entry_error_is_fail_closed(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     _, metadata, query, kv_cache, output = _make_fixed_prefill_case()
-    route_calls = []
+    route_calls: list[str] = []
 
     def failed_fixed_entry(*args, **kwargs):
         raise RuntimeError("fixed entry failed")

--- a/tests/v1/cudagraph/test_cudagraph_dispatch.py
+++ b/tests/v1/cudagraph/test_cudagraph_dispatch.py
@@ -401,6 +401,94 @@ class TestCudagraphDispatcher:
         disabled = CudagraphDispatcher(config)
         assert not disabled.sm70_dsv4_decode_context_buckets
 
+    def test_fp8_e5m2_decode_context_bucket_is_shape_derived_on_sm70(self, monkeypatch):
+        monkeypatch.delenv("VLLM_SM70_FP8_KV_DECODE_CONTEXT_BUCKETS", raising=False)
+        comp_config = CompilationConfig(
+            cudagraph_mode="FULL_DECODE_ONLY",
+            mode=CompilationMode.NONE,
+            cudagraph_capture_sizes=[1, 2],
+        )
+        config = _create_vllm_config(comp_config, max_num_seqs=2)
+        config.cache_config.cache_dtype = "fp8_e5m2"
+        config.attention_config.backend = None
+        config.model_config.max_model_len = 262144
+        config.model_config.hf_text_config.num_attention_heads = 24
+        config.model_config.hf_text_config.num_key_value_heads = 4
+        config.model_config.hf_text_config.head_dim = 256
+
+        with (
+            patch.object(current_platform, "is_cuda", return_value=True),
+            patch.object(current_platform, "is_device_capability", return_value=True),
+            patch("vllm.v1.cudagraph_dispatcher.envs") as mock_envs,
+        ):
+            mock_envs.VLLM_SM70_FLASH_ATTN_V100 = True
+            dispatcher = CudagraphDispatcher(config)
+        dispatcher.initialize_cudagraph_keys(
+            cudagraph_mode=comp_config.cudagraph_mode,
+            uniform_decode_query_len=1,
+        )
+
+        assert dispatcher.sm70_fp8_kv_decode_context_buckets == (8192,)
+        bounded = BatchDescriptor(
+            num_tokens=1,
+            num_reqs=1,
+            uniform=True,
+            attention_context_bucket=8192,
+        )
+        assert bounded in dispatcher.cudagraph_keys[CUDAGraphMode.FULL]
+
+        mode, desc = dispatcher.dispatch(
+            num_tokens=1,
+            uniform_decode=True,
+            attention_context_len=8192,
+        )
+        assert mode == CUDAGraphMode.FULL
+        assert desc == bounded
+
+        mode, desc = dispatcher.dispatch(
+            num_tokens=1,
+            uniform_decode=True,
+            attention_context_len=8193,
+        )
+        assert mode == CUDAGraphMode.FULL
+        assert desc == BatchDescriptor(num_tokens=1, num_reqs=1, uniform=True)
+
+    @pytest.mark.parametrize("cache_dtype", ("auto", "fp8_e4m3"))
+    def test_fp8_e5m2_decode_context_bucket_does_not_match_other_cache_dtypes(
+        self, monkeypatch, cache_dtype
+    ):
+        monkeypatch.delenv("VLLM_SM70_FP8_KV_DECODE_CONTEXT_BUCKETS", raising=False)
+        comp_config = CompilationConfig(
+            cudagraph_mode="FULL_DECODE_ONLY",
+            mode=CompilationMode.NONE,
+            cudagraph_capture_sizes=[1, 2],
+        )
+        config = _create_vllm_config(comp_config, max_num_seqs=2)
+        config.cache_config.cache_dtype = cache_dtype
+        config.model_config.max_model_len = 262144
+
+        with (
+            patch.object(current_platform, "is_cuda", return_value=True),
+            patch.object(current_platform, "is_device_capability", return_value=True),
+        ):
+            dispatcher = CudagraphDispatcher(config)
+
+        assert not dispatcher.sm70_fp8_kv_decode_context_buckets
+
+    def test_fp8_e5m2_decode_context_bucket_explicit_empty_disables(self, monkeypatch):
+        monkeypatch.setenv("VLLM_SM70_FP8_KV_DECODE_CONTEXT_BUCKETS", "")
+        comp_config = CompilationConfig(
+            cudagraph_mode="FULL_DECODE_ONLY",
+            mode=CompilationMode.NONE,
+            cudagraph_capture_sizes=[1, 2],
+        )
+        config = _create_vllm_config(comp_config, max_num_seqs=2)
+        config.cache_config.cache_dtype = "fp8_e5m2"
+
+        dispatcher = CudagraphDispatcher(config)
+
+        assert not dispatcher.sm70_fp8_kv_decode_context_buckets
+
 
 @pytest.mark.skipif(not current_platform.is_cuda(), reason="Skip if not cuda")
 class TestCUDAGraphWrapper:

--- a/tests/v1/spec_decode/test_ddtree_sampler.py
+++ b/tests/v1/spec_decode/test_ddtree_sampler.py
@@ -3,7 +3,7 @@
 
 import torch
 
-from vllm.v1.spec_decode.ddtree_payload import payload_from_tree
+from vllm.v1.spec_decode.ddtree_payload import DDTreeDraftPayload, payload_from_tree
 from vllm.v1.spec_decode.ddtree_sampler import (
     greedy_sample_ddtree_payloads,
     greedy_sample_ddtree_payloads_from_top_tokens,
@@ -12,7 +12,7 @@ from vllm.v1.spec_decode.ddtree_sampler import (
 from vllm.v1.spec_decode.ddtree_tree import build_ddtree
 
 
-def _payload() -> object:
+def _payload() -> DDTreeDraftPayload:
     tree = build_ddtree(
         [
             [(11, 0.0), (12, -0.1)],

--- a/tests/v1/spec_decode/test_ddtree_scheduler.py
+++ b/tests/v1/spec_decode/test_ddtree_scheduler.py
@@ -14,7 +14,7 @@ class _Request:
         self.request_id = "r0"
         self.is_prefill_chunk = is_prefill_chunk
         self.spec_token_ids: list[int] = []
-        self.structured_output_request = None
+        self.structured_output_request: object | None = None
         self.max_tokens = 8
         self._output_token_ids: list[int] = []
         self.num_output_placeholders = 0
@@ -123,9 +123,7 @@ def test_update_draft_token_ids_caches_matching_ddtree_payload() -> None:
     scheduler = _scheduler(request)
     payload = _payload()
 
-    scheduler.update_draft_token_ids(
-        DraftTokenIds(["r0"], [[11, 21, 31]], [payload])
-    )
+    scheduler.update_draft_token_ids(DraftTokenIds(["r0"], [[11, 21, 31]], [payload]))
 
     assert request.spec_token_ids == [11, 21, 31]
     assert scheduler.ddtree_payloads_by_req_id == {"r0": payload}
@@ -137,9 +135,7 @@ def test_update_draft_token_ids_drops_payload_after_grammar_trim() -> None:
     scheduler = _scheduler(request, advance=True)
     payload = _payload()
 
-    scheduler.update_draft_token_ids(
-        DraftTokenIds(["r0"], [[11, 21, 31]], [payload])
-    )
+    scheduler.update_draft_token_ids(DraftTokenIds(["r0"], [[11, 21, 31]], [payload]))
 
     assert request.spec_token_ids == [11, 21]
     assert scheduler.ddtree_payloads_by_req_id == {}
@@ -152,9 +148,7 @@ def test_update_draft_token_ids_drops_payload_for_prefill_chunk() -> None:
     payload = _payload()
     scheduler.ddtree_payloads_by_req_id = {"r0": payload}
 
-    scheduler.update_draft_token_ids(
-        DraftTokenIds(["r0"], [[11, 21, 31]], [payload])
-    )
+    scheduler.update_draft_token_ids(DraftTokenIds(["r0"], [[11, 21, 31]], [payload]))
 
     assert request.spec_token_ids == []
     assert scheduler.ddtree_payloads_by_req_id == {}

--- a/tests/v1/spec_decode/test_static_draft_vocab.py
+++ b/tests/v1/spec_decode/test_static_draft_vocab.py
@@ -36,7 +36,9 @@ def test_dynamic_draft_vocab_is_the_default_mtp_route(monkeypatch) -> None:
     monkeypatch.setenv("VLLM_SM70_MTP_DYNAMIC_DRAFT_VOCAB_DEFAULT", "1")
 
     config = resolve_mtp_draft_vocab_config(
-        "mtp", model_architecture="Qwen3_5ForConditionalGeneration"
+        "mtp",
+        model_architecture="Qwen3_5ForConditionalGeneration",
+        model_name_or_path="Qwen/Qwen3.6-27B",
     )
 
     assert config.using_defaults
@@ -67,6 +69,7 @@ def test_dynamic_draft_vocab_default_selects_tp4_asset(monkeypatch) -> None:
         "mtp",
         tensor_parallel_size=4,
         model_architecture="Qwen3_5ForConditionalGeneration",
+        model_name_or_path="/models/Qwen3.6-27B-AWQ",
     )
 
     assert config.using_defaults
@@ -87,15 +90,20 @@ def test_dynamic_draft_vocab_default_can_be_disabled(monkeypatch) -> None:
 
 
 @pytest.mark.parametrize(
-    ("model_architecture", "tensor_parallel_size"),
+    ("model_architecture", "tensor_parallel_size", "model_name_or_path"),
     [
-        ("DeepseekV4ForCausalLM", 8),
-        ("Qwen3_5ForConditionalGeneration", 8),
-        ("Qwen3_5MoeForConditionalGeneration", 4),
+        ("DeepseekV4ForCausalLM", 8, "deepseek-ai/DeepSeek-V4"),
+        ("Qwen3_5ForConditionalGeneration", 8, "Qwen/Qwen3.6-27B"),
+        ("Qwen3_5MoeForConditionalGeneration", 4, "Qwen/Qwen3.6-35B-A3B"),
+        ("Qwen3_5ForConditionalGeneration", 4, "Qwen/Qwen3.8-27B"),
+        ("Qwen3_5ForConditionalGeneration", 4, None),
     ],
 )
 def test_dynamic_draft_vocab_default_is_model_and_tp_specific(
-    monkeypatch, model_architecture: str, tensor_parallel_size: int
+    monkeypatch,
+    model_architecture: str,
+    tensor_parallel_size: int,
+    model_name_or_path: str | None,
 ) -> None:
     monkeypatch.setenv("VLLM_SM70_MTP_DYNAMIC_DRAFT_VOCAB_DEFAULT", "1")
 
@@ -103,6 +111,7 @@ def test_dynamic_draft_vocab_default_is_model_and_tp_specific(
         "mtp",
         tensor_parallel_size=tensor_parallel_size,
         model_architecture=model_architecture,
+        model_name_or_path=model_name_or_path,
     )
 
     assert not config.using_defaults

--- a/vllm/_sm70_ops.py
+++ b/vllm/_sm70_ops.py
@@ -423,7 +423,7 @@ if hasattr(torch.ops._C, "fp8_gemm_sm70_out"):
 
 def fp8_gemm_sm70_prefill_dispatch_out(
     out: torch.Tensor,
-    dense_weight: torch.Tensor,
+    dense_weight_ptr: int,
     input: torch.Tensor,
     qweight: torch.Tensor,
     scales: torch.Tensor,
@@ -435,7 +435,7 @@ def fp8_gemm_sm70_prefill_dispatch_out(
 ) -> None:
     _op("fp8_gemm_sm70_prefill_dispatch_out")(
         out,
-        dense_weight,
+        dense_weight_ptr,
         input,
         qweight,
         scales,
@@ -452,7 +452,7 @@ if hasattr(torch.ops._C, "fp8_gemm_sm70_prefill_dispatch_out"):
     @register_fake("_C::fp8_gemm_sm70_prefill_dispatch_out")
     def _fp8_gemm_sm70_prefill_dispatch_out_fake(
         out: torch.Tensor,
-        dense_weight: torch.Tensor,
+        dense_weight_ptr: int,
         input: torch.Tensor,
         qweight: torch.Tensor,
         scales: torch.Tensor,
@@ -462,6 +462,7 @@ if hasattr(torch.ops._C, "fp8_gemm_sm70_prefill_dispatch_out"):
         gated_silu: bool,
         min_prefill_m: int,
     ) -> None:
+        del dense_weight_ptr
         return None
 
 

--- a/vllm/_sm70_ops.py
+++ b/vllm/_sm70_ops.py
@@ -170,6 +170,28 @@ if hasattr(torch.ops._C, "fp8_sm70_prepare"):
         return [tm_weight, tm_scales, meta]
 
 
+def fp8_sm70_dequantize_out(
+    out: torch.Tensor,
+    qweight: torch.Tensor,
+    scales: torch.Tensor,
+    group_size: int,
+) -> None:
+    _op("fp8_sm70_dequantize_out")(out, qweight, scales, group_size)
+
+
+if hasattr(torch.ops._C, "fp8_sm70_dequantize_out"):
+
+    @register_fake("_C::fp8_sm70_dequantize_out")
+    def _fp8_sm70_dequantize_out_fake(
+        out: torch.Tensor,
+        qweight: torch.Tensor,
+        scales: torch.Tensor,
+        group_size: int,
+    ) -> None:
+        del out, qweight, scales, group_size
+        return None
+
+
 def mxfp4_sm70_prepare(
     qweight: torch.Tensor,
     scales: torch.Tensor,
@@ -395,6 +417,50 @@ if hasattr(torch.ops._C, "fp8_gemm_sm70_out"):
         k_ld: int,
         q_ld: int,
         gated_silu: bool,
+    ) -> None:
+        return None
+
+
+def fp8_gemm_sm70_prefill_dispatch_out(
+    out: torch.Tensor,
+    dense_weight: torch.Tensor,
+    input: torch.Tensor,
+    qweight: torch.Tensor,
+    scales: torch.Tensor,
+    group_size: int,
+    k_ld: int,
+    q_ld: int,
+    gated_silu: bool,
+    min_prefill_m: int,
+) -> None:
+    _op("fp8_gemm_sm70_prefill_dispatch_out")(
+        out,
+        dense_weight,
+        input,
+        qweight,
+        scales,
+        group_size,
+        k_ld,
+        q_ld,
+        gated_silu,
+        min_prefill_m,
+    )
+
+
+if hasattr(torch.ops._C, "fp8_gemm_sm70_prefill_dispatch_out"):
+
+    @register_fake("_C::fp8_gemm_sm70_prefill_dispatch_out")
+    def _fp8_gemm_sm70_prefill_dispatch_out_fake(
+        out: torch.Tensor,
+        dense_weight: torch.Tensor,
+        input: torch.Tensor,
+        qweight: torch.Tensor,
+        scales: torch.Tensor,
+        group_size: int,
+        k_ld: int,
+        q_ld: int,
+        gated_silu: bool,
+        min_prefill_m: int,
     ) -> None:
         return None
 

--- a/vllm/config/cache.py
+++ b/vllm/config/cache.py
@@ -76,6 +76,9 @@ class CacheConfig:
     """Data type for kv cache storage. If "auto", will use model data type.
     CUDA 11.8+ supports fp8 (=fp8_e4m3) and fp8_e5m2. ROCm (AMD GPU) supports
     fp8 (=fp8_e4m3). Intel Gaudi (HPU) supports fp8 (using fp8_inc).
+    On SM70 with the 1Cat Flash-V100 backend enabled, the user-facing ``fp8``
+    shorthand resolves to fp8_e5m2 for compatibility with its optimized KV
+    path; explicit fp8_e4m3 keeps the upstream E4M3 behavior.
     Some models (namely DeepSeekV3.2) default to fp8, set to bfloat16 to use
     bfloat16 instead, this is an invalid option for models that do not default
     to fp8.
@@ -261,14 +264,16 @@ class CacheConfig:
         if kv_cache_uses_per_token_head_scales(cache_dtype):
             logger.info(
                 "Using %s data type to store kv cache. It reduces the GPU "
-                "memory footprint and boosts the performance. "
+                "memory footprint; performance depends on backend and "
+                "hardware support. "
                 "Dynamic per-token-head scales will be computed at runtime.",
                 str(cache_dtype),
             )
         elif is_quantized_kv_cache(cache_dtype):
             logger.info(
                 "Using %s data type to store kv cache. It reduces the GPU "
-                "memory footprint and boosts the performance. "
+                "memory footprint; performance depends on backend and "
+                "hardware support. "
                 "Meanwhile, it may cause accuracy drop without a proper "
                 "scaling factor",
                 str(cache_dtype),

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -67,6 +67,16 @@ else:
 logger = init_logger(__name__)
 
 DEFAULT_V2_MODEL_RUNNER_ARCHITECTURES = frozenset({"Qwen3ForCausalLM"})
+_SM70_NOMTP_CUDAGRAPH_CAPTURE_SIZES = (1, 2, 4, 8, 16)
+
+
+def _sm70_nomtp_cudagraph_capture_sizes(max_num_seqs: int) -> list[int]:
+    max_graph_reqs = min(max(int(max_num_seqs), 1), 16)
+    capture_sizes = {
+        size for size in _SM70_NOMTP_CUDAGRAPH_CAPTURE_SIZES if size <= max_graph_reqs
+    }
+    capture_sizes.update((1, 2, max_graph_reqs))
+    return sorted(capture_sizes)
 
 
 class OptimizationLevel(IntEnum):
@@ -1324,7 +1334,9 @@ class VllmConfig:
                     CUDAGraphMode.FULL_AND_PIECEWISE
                 )
                 if self.compilation_config.cudagraph_capture_sizes is None:
-                    cudagraph_capture_sizes = [1, 2]
+                    cudagraph_capture_sizes = _sm70_nomtp_cudagraph_capture_sizes(
+                        self.scheduler_config.max_num_seqs
+                    )
                     if (
                         self.speculative_config is not None
                         and self.speculative_config.num_speculative_tokens
@@ -1370,6 +1382,11 @@ class VllmConfig:
                             "%sx1..%s for Flash-V100 compile graph.",
                             decode_query_len,
                             max_graph_reqs,
+                        )
+                    elif cudagraph_capture_sizes != [1, 2]:
+                        logger.info_once(
+                            "Using SM70 no-MTP decode cudagraph request shapes %s.",
+                            tuple(cudagraph_capture_sizes),
                         )
                     self.compilation_config.cudagraph_capture_sizes = (
                         cudagraph_capture_sizes

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -132,6 +132,34 @@ else:
 
 logger = init_logger(__name__)
 
+
+def _resolve_sm70_flash_v100_kv_cache_dtype_alias(
+    requested_dtype: str,
+    resolved_dtype: str,
+) -> str:
+    """Preserve the historical 1Cat V100 meaning of the ``fp8`` alias."""
+    if (
+        requested_dtype != "fp8"
+        or resolved_dtype != "fp8"
+        or not envs.VLLM_SM70_FLASH_ATTN_V100
+        or not current_platform.is_cuda()
+    ):
+        return resolved_dtype
+    try:
+        capability = current_platform.get_device_capability()
+    except Exception:
+        return resolved_dtype
+    if capability is None or (capability.major, capability.minor) != (7, 0):
+        return resolved_dtype
+    logger.warning_once(
+        "On SM70 Flash-V100, --kv-cache-dtype fp8 resolves to fp8_e5m2 "
+        "for compatibility with the optimized 1Cat V100 KV-cache path. "
+        "Use explicit fp8_e4m3 to request E4M3 KV storage. Model weight "
+        "quantization is configured independently."
+    )
+    return "fp8_e5m2"
+
+
 # object is used to allow for special typing forms
 T = TypeVar("T")
 TypeHint: TypeAlias = type[Any] | object
@@ -1937,6 +1965,10 @@ class EngineArgs:
         # Resolve "auto" kv_cache_dtype to actual value from model config
         resolved_cache_dtype = resolve_kv_cache_dtype_string(
             self.kv_cache_dtype, model_config
+        )
+        resolved_cache_dtype = _resolve_sm70_flash_v100_kv_cache_dtype_alias(
+            self.kv_cache_dtype,
+            resolved_cache_dtype,
         )
 
         assert self.enable_prefix_caching is not None, (

--- a/vllm/entrypoints/cli/main.py
+++ b/vllm/entrypoints/cli/main.py
@@ -5,11 +5,11 @@
 Note that all future modules must be lazily loaded within main
 to avoid certain eager import breakage."""
 
-import importlib.metadata
 import sys
 from importlib.util import find_spec
 
 from vllm.logger import init_logger
+from vllm.version import __version__ as VLLM_VERSION
 
 logger = init_logger(__name__)
 
@@ -75,7 +75,7 @@ def main():
             "-v",
             "--version",
             action="version",
-            version=importlib.metadata.version("vllm"),
+            version=VLLM_VERSION,
         )
         subparsers = parser.add_subparsers(required=False, dest="subparser")
         cmds = {}

--- a/vllm/entrypoints/cli/run_batch.py
+++ b/vllm/entrypoints/cli/run_batch.py
@@ -3,12 +3,12 @@
 
 import argparse
 import asyncio
-import importlib.metadata
 import typing
 
 from vllm.entrypoints.cli.types import CLISubcommand
 from vllm.entrypoints.utils import VLLM_SUBCMD_PARSER_EPILOG
 from vllm.logger import init_logger
+from vllm.version import __version__ as VLLM_VERSION
 
 if typing.TYPE_CHECKING:
     from vllm.utils.argparse_utils import FlexibleArgumentParser
@@ -27,9 +27,7 @@ class RunBatchSubcommand(CLISubcommand):
     def cmd(args: argparse.Namespace) -> None:
         from vllm.entrypoints.openai.run_batch import main as run_batch_main
 
-        logger.info(
-            "vLLM batch processing API version %s", importlib.metadata.version("vllm")
-        )
+        logger.info("vLLM batch processing API version %s", VLLM_VERSION)
         logger.info("args: %s", args)
 
         # Start the Prometheus metrics server.

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -150,6 +150,8 @@ if TYPE_CHECKING:
     VLLM_SM70_AWQ_MLP_DOWN_TILE_OVERLAP_REDUCER_BLOCKS: int = 4
     VLLM_SM70_AWQ_MLP_DOWN_TILE_OVERLAP_KERNEL_REDUCER_BLOCKS: int = 0
     VLLM_SM70_FP8_TUNE_SMALL_SHAPES: bool = True
+    VLLM_SM70_FP8_COORDINATED_TUNING: bool = True
+    VLLM_SM70_FP8_REUSE_IMPORTED_CACHE: bool = False
     VLLM_SM70_FP8_SAFE_FAST_SELECTOR: bool = False
     VLLM_SM70_FP8_PRESERVE_DEFAULT_SPLITS: bool = True
     VLLM_SM70_FP8_PRESERVE_DEFAULT_SPLITS_ONLY: bool = False
@@ -273,7 +275,7 @@ if TYPE_CHECKING:
     VLLM_SM70_DECODE_TILE_PROFILE: bool = False
     VLLM_FLASH_V100_ROUTE_SUMMARY: bool = False
     VLLM_FLASH_V100_FP8_PREFILL_BRIDGE: bool = True
-    VLLM_FLASH_V100_DECODE_FP8_XQA_MIN_SEQ_LEN: int = 8192
+    VLLM_FLASH_V100_DECODE_FP8_XQA_MIN_SEQ_LEN: int = 16384
     VLLM_FLASH_V100_KERNEL_BLOCK_SIZE16: bool = False
     VLLM_FLASH_V100_DENSE_D256_LOW_SMEM: bool = False
     VLLM_FLASH_V100_DENSE_D256_WMMA_QK: bool = True
@@ -342,6 +344,12 @@ if TYPE_CHECKING:
     VLLM_FLASH_V100_XQA_G6_QK_PIPELINE: bool = True
     VLLM_FLASH_V100_XQA_G6_QK_PIPELINE_WARPS: int = 8
     VLLM_FLASH_V100_XQA_G6_QK_PIPELINE_TRACE: bool = False
+    VLLM_FLASH_V100_XQA_E5M2_G6_DUAL_CTA: bool = True
+    VLLM_FLASH_V100_XQA_E5M2_G6_SPLIT_REDUCE: bool = True
+    VLLM_FLASH_V100_XQA_E5M2_P1024_BEGIN: int = 61633
+    VLLM_FLASH_V100_XQA_E5M2_PARTITION_PAGE_IDS: bool = True
+    VLLM_FLASH_V100_XQA_E5M2_PAIR_LOAD: bool = True
+    VLLM_FLASH_V100_XQA_E5M2_G6_DUAL_CTA_TRACE: bool = False
     VLLM_FLASH_V100_TRACE_DECODE_ACTIVE: bool = False
     VLLM_FLASH_V100_DECODE_USE_SCALAR_PAGED: bool = True
     VLLM_FLASH_V100_COMPARE_BHMD_OUT_DIR: str | None = None
@@ -1635,6 +1643,12 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "VLLM_SM70_FP8_TUNE_SMALL_SHAPES": lambda: bool(
         int(os.getenv("VLLM_SM70_FP8_TUNE_SMALL_SHAPES", "1"))
     ),
+    "VLLM_SM70_FP8_COORDINATED_TUNING": lambda: bool(
+        int(os.getenv("VLLM_SM70_FP8_COORDINATED_TUNING", "1"))
+    ),
+    "VLLM_SM70_FP8_REUSE_IMPORTED_CACHE": lambda: bool(
+        int(os.getenv("VLLM_SM70_FP8_REUSE_IMPORTED_CACHE", "0"))
+    ),
     "VLLM_SM70_FP8_SAFE_FAST_SELECTOR": lambda: bool(
         int(os.getenv("VLLM_SM70_FP8_SAFE_FAST_SELECTOR", "0"))
     ),
@@ -2087,7 +2101,7 @@ environment_variables: dict[str, Callable[[], Any]] = {
         int(os.getenv("VLLM_FLASH_V100_FP8_PREFILL_BRIDGE", "1"))
     ),
     "VLLM_FLASH_V100_DECODE_FP8_XQA_MIN_SEQ_LEN": lambda: int(
-        os.getenv("VLLM_FLASH_V100_DECODE_FP8_XQA_MIN_SEQ_LEN", "8192")
+        os.getenv("VLLM_FLASH_V100_DECODE_FP8_XQA_MIN_SEQ_LEN", "16384")
     ),
     "VLLM_FLASH_V100_KERNEL_BLOCK_SIZE16": lambda: bool(
         int(os.getenv("VLLM_FLASH_V100_KERNEL_BLOCK_SIZE16", "0"))
@@ -2312,6 +2326,24 @@ environment_variables: dict[str, Callable[[], Any]] = {
     ),
     "VLLM_FLASH_V100_XQA_G6_QK_PIPELINE_TRACE": lambda: bool(
         int(os.getenv("VLLM_FLASH_V100_XQA_G6_QK_PIPELINE_TRACE", "0"))
+    ),
+    "VLLM_FLASH_V100_XQA_E5M2_G6_DUAL_CTA": lambda: bool(
+        int(os.getenv("VLLM_FLASH_V100_XQA_E5M2_G6_DUAL_CTA", "1"))
+    ),
+    "VLLM_FLASH_V100_XQA_E5M2_G6_SPLIT_REDUCE": lambda: bool(
+        int(os.getenv("VLLM_FLASH_V100_XQA_E5M2_G6_SPLIT_REDUCE", "1"))
+    ),
+    "VLLM_FLASH_V100_XQA_E5M2_P1024_BEGIN": lambda: int(
+        os.getenv("VLLM_FLASH_V100_XQA_E5M2_P1024_BEGIN", "61633")
+    ),
+    "VLLM_FLASH_V100_XQA_E5M2_PARTITION_PAGE_IDS": lambda: bool(
+        int(os.getenv("VLLM_FLASH_V100_XQA_E5M2_PARTITION_PAGE_IDS", "1"))
+    ),
+    "VLLM_FLASH_V100_XQA_E5M2_PAIR_LOAD": lambda: bool(
+        int(os.getenv("VLLM_FLASH_V100_XQA_E5M2_PAIR_LOAD", "1"))
+    ),
+    "VLLM_FLASH_V100_XQA_E5M2_G6_DUAL_CTA_TRACE": lambda: bool(
+        int(os.getenv("VLLM_FLASH_V100_XQA_E5M2_G6_DUAL_CTA_TRACE", "0"))
     ),
     "VLLM_FLASH_V100_TRACE_DECODE_ACTIVE": lambda: bool(
         int(os.getenv("VLLM_FLASH_V100_TRACE_DECODE_ACTIVE", "0"))

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -338,7 +338,7 @@ if TYPE_CHECKING:
     VLLM_FLASH_V100_XQA_G6_P1024_SAWTOOTH_P1024_MID_SEQ_LEN: int = 111104
     VLLM_FLASH_V100_XQA_G6_P1024_SAWTOOTH_P256_LONG_SEQ_LEN: int = 147841
     VLLM_FLASH_V100_XQA_G6_P1024_SAWTOOTH_P1024_FINAL_SEQ_LEN: int = 258176
-    VLLM_FLASH_V100_XQA_G6_QK_PIPELINE: bool = False
+    VLLM_FLASH_V100_XQA_G6_QK_PIPELINE: bool = True
     VLLM_FLASH_V100_XQA_G6_QK_PIPELINE_WARPS: int = 8
     VLLM_FLASH_V100_XQA_G6_QK_PIPELINE_TRACE: bool = False
     VLLM_FLASH_V100_TRACE_DECODE_ACTIVE: bool = False
@@ -1015,10 +1015,10 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # If set, `MAX_JOBS` will be reduced to avoid oversubscribing the CPU.
     "NVCC_THREADS": lambda: os.getenv("NVCC_THREADS", None),
     # If set, vllm will use precompiled native binaries (*.so and vllm-rs).
-    "VLLM_USE_PRECOMPILED": lambda: (
-        os.environ.get("VLLM_USE_PRECOMPILED", "").strip().lower() in ("1", "true")
-        or bool(os.environ.get("VLLM_PRECOMPILED_WHEEL_LOCATION"))
-    ),
+    "VLLM_USE_PRECOMPILED": lambda: os.environ.get("VLLM_USE_PRECOMPILED", "")
+    .strip()
+    .lower()
+    in ("1", "true"),
     # If set, vllm will use the precompiled Rust frontend binary (vllm-rs).
     "VLLM_USE_PRECOMPILED_RUST": lambda: (
         os.environ.get("VLLM_USE_PRECOMPILED_RUST", "").strip().lower() in ("1", "true")
@@ -2298,7 +2298,7 @@ environment_variables: dict[str, Callable[[], Any]] = {
         )
     ),
     "VLLM_FLASH_V100_XQA_G6_QK_PIPELINE": lambda: bool(
-        int(os.getenv("VLLM_FLASH_V100_XQA_G6_QK_PIPELINE", "0"))
+        int(os.getenv("VLLM_FLASH_V100_XQA_G6_QK_PIPELINE", "1"))
     ),
     "VLLM_FLASH_V100_XQA_G6_QK_PIPELINE_WARPS": lambda: int(
         os.getenv("VLLM_FLASH_V100_XQA_G6_QK_PIPELINE_WARPS", "8")

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -1024,10 +1024,10 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # If set, `MAX_JOBS` will be reduced to avoid oversubscribing the CPU.
     "NVCC_THREADS": lambda: os.getenv("NVCC_THREADS", None),
     # If set, vllm will use precompiled native binaries (*.so and vllm-rs).
-    "VLLM_USE_PRECOMPILED": lambda: os.environ.get("VLLM_USE_PRECOMPILED", "")
-    .strip()
-    .lower()
-    in ("1", "true"),
+    "VLLM_USE_PRECOMPILED": lambda: (
+        os.environ.get("VLLM_USE_PRECOMPILED", "").strip().lower() in ("1", "true")
+        or bool(os.environ.get("VLLM_PRECOMPILED_WHEEL_LOCATION"))
+    ),
     # If set, vllm will use the precompiled Rust frontend binary (vllm-rs).
     "VLLM_USE_PRECOMPILED_RUST": lambda: (
         os.environ.get("VLLM_USE_PRECOMPILED_RUST", "").strip().lower() in ("1", "true")

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -153,6 +153,7 @@ if TYPE_CHECKING:
     VLLM_SM70_FP8_SAFE_FAST_SELECTOR: bool = False
     VLLM_SM70_FP8_PRESERVE_DEFAULT_SPLITS: bool = True
     VLLM_SM70_FP8_PRESERVE_DEFAULT_SPLITS_ONLY: bool = False
+    VLLM_SM70_FP8_PREFILL_EXACT_DENSE: bool = True
     VLLM_SM70_MXFP4_TUNE_SMALL_SHAPES: bool = True
     VLLM_SM70_NVFP4_TUNE_SMALL_SHAPES: bool = True
     VLLM_SM70_AWQ_REUSE_IMPORTED_CACHE: bool = False
@@ -1585,6 +1586,12 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # bounded FP16 workspace before their exact dense GEMM.
     "VLLM_SM70_AWQ_PREFILL_EXACT_DENSE": lambda: bool(
         int(os.getenv("VLLM_SM70_AWQ_PREFILL_EXACT_DENSE", "1"))
+    ),
+    # Expand selected large-M TP4 FP8 projections into one reusable bounded
+    # FP16 workspace before their exact dense GEMM. The allowlist and M gate
+    # keep decode, tails, and numerically unsafe QKV projections on TurboMind.
+    "VLLM_SM70_FP8_PREFILL_EXACT_DENSE": lambda: bool(
+        int(os.getenv("VLLM_SM70_FP8_PREFILL_EXACT_DENSE", "1"))
     ),
     # Experimental TileRT-inspired down-proj lane: after the row-parallel AWQ
     # GEMM, use the local tile-runtime TP2 all-reduce substrate for the MLP

--- a/vllm/model_executor/layers/fused_moe/runner/moe_runner.py
+++ b/vllm/model_executor/layers/fused_moe/runner/moe_runner.py
@@ -190,7 +190,8 @@ def dump_sm70_moe_runner_graph_buffers(step: int, stage: str) -> None:
         meta = _SM70_MOE_RUNNER_DUMP_META.get(key, {})
         label = str(meta.get("label", "unknown")).replace("/", "_").replace(".", "_")
         layer_type = str(meta.get("layer_type", "moe_runner"))
-        layer_idx = int(meta.get("layer_idx", -1))
+        layer_idx_value = meta.get("layer_idx", -1)
+        layer_idx = layer_idx_value if isinstance(layer_idx_value, int) else -1
         shape = "x".join(str(dim) for dim in tuple(buffer.shape))
         path = os.path.join(
             dump_dir,

--- a/vllm/model_executor/layers/layernorm.py
+++ b/vllm/model_executor/layers/layernorm.py
@@ -95,6 +95,18 @@ def _sm70_gemma_long_prefill_fused_add_rms_norm(
 ) -> tuple[torch.Tensor, torch.Tensor]:
     from vllm import _custom_ops as ops
 
+    # A long-prefill example can select this custom op while torch.compile is
+    # tracing a dynamic graph that is later reused for small CUDA Graph capture
+    # sizes. Preserve the normal exact path for those runtime shapes instead of
+    # dispatching the long-prefill kernel below its numerical contract.
+    if x.shape[0] < 256:
+        return _sm70_gemma_fused_add_rms_norm_eager(
+            x,
+            residual,
+            weight,
+            variance_epsilon,
+        )
+
     normalized_out = torch.empty_like(x)
     residual_out = torch.empty_like(residual)
     ops.sm70_gemma_long_prefill_fused_add_rms_norm(

--- a/vllm/model_executor/layers/quantization/__init__.py
+++ b/vllm/model_executor/layers/quantization/__init__.py
@@ -110,13 +110,16 @@ def get_quantization_config(quantization: str) -> type[QuantizationConfig]:
 
     # lazy import to avoid triggering `torch.compile` too early
     if quantization == "humming":
+        humming_config_cls: type[QuantizationConfig]
         try:
             from .humming import HummingConfig
+
+            humming_config_cls = HummingConfig
         except ModuleNotFoundError as exc:
             if exc.name != "humming":
                 raise
 
-            class HummingConfig(QuantizationConfig):
+            class MissingHummingConfig(QuantizationConfig):
                 """Placeholder used when the optional humming package is absent."""
 
                 def get_name(self) -> QuantizationMethods:
@@ -134,7 +137,7 @@ def get_quantization_config(quantization: str) -> type[QuantizationConfig]:
                     return []
 
                 @classmethod
-                def from_config(cls, config: dict) -> "HummingConfig":
+                def from_config(cls, config: dict) -> "MissingHummingConfig":
                     del config
                     raise ModuleNotFoundError(
                         "The optional 'humming' package is required for "
@@ -160,7 +163,9 @@ def get_quantization_config(quantization: str) -> type[QuantizationConfig]:
                         "quantization='humming'."
                     )
 
-        return HummingConfig
+            humming_config_cls = MissingHummingConfig
+
+        return humming_config_cls
 
     from vllm.config.quantization import _ONLINE_SHORTHANDS
     from vllm.model_executor.layers.quantization.quark.quark import QuarkConfig

--- a/vllm/model_executor/layers/quantization/fp8.py
+++ b/vllm/model_executor/layers/quantization/fp8.py
@@ -1240,9 +1240,11 @@ class Fp8MoEMethod(FusedMoEMethodBase):
         w13_input_scale: torch.Tensor | None,
         w2_input_scale: torch.Tensor | None,
     ) -> None:
+        fp8_backend = self.fp8_backend
+        assert fp8_backend is not None
         # Shuffle weights to runtime format.
         w13, w2, w13_scale, w2_scale = convert_to_fp8_moe_kernel_format(
-            fp8_backend=self.fp8_backend,
+            fp8_backend=fp8_backend,
             layer=layer,
             w13=w13,
             w2=w2,
@@ -1260,7 +1262,7 @@ class Fp8MoEMethod(FusedMoEMethodBase):
         replace_parameter(layer, f"w2_{self.weight_scale_name}", w2_scale)
 
         # AITER backend requires weights to be marked as shuffled.
-        if self.fp8_backend == Fp8MoeBackend.AITER:
+        if fp8_backend == Fp8MoeBackend.AITER:
             layer.w13_weight.is_shuffled = True
             layer.w2_weight.is_shuffled = True
 
@@ -1270,7 +1272,7 @@ class Fp8MoEMethod(FusedMoEMethodBase):
             self.moe_kernel = make_fp8_moe_kernel(
                 moe_quant_config=self.moe_quant_config,
                 moe_config=self.moe,
-                fp8_backend=self.fp8_backend,
+                fp8_backend=fp8_backend,
                 experts_cls=self.experts_cls,
                 routing_tables=layer._expert_routing_tables(),
             )
@@ -1408,13 +1410,15 @@ class Fp8MoEMethod(FusedMoEMethodBase):
         )
 
     def get_fused_moe_quant_config(self, layer: RoutedExperts) -> FusedMoEQuantConfig:
+        fp8_backend = self.fp8_backend
+        assert fp8_backend is not None
         w1_scale = getattr(layer, f"w13_{self.weight_scale_name}")
         w2_scale = getattr(layer, f"w2_{self.weight_scale_name}")
         a1_scale = layer.w13_input_scale
         a2_scale = layer.w2_input_scale
 
         quant_config = make_fp8_moe_quant_config(
-            fp8_backend=self.fp8_backend,
+            fp8_backend=fp8_backend,
             w1_scale=w1_scale,
             w2_scale=w2_scale,
             a1_scale=a1_scale,

--- a/vllm/model_executor/layers/quantization/fp8.py
+++ b/vllm/model_executor/layers/quantization/fp8.py
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
-import weakref
 from typing import TYPE_CHECKING, Any
 
 import torch
@@ -113,9 +112,8 @@ _SM70_FP8_PREFILL_DENSE_WORKSPACE_ELEMENTS = max(
 _SM70_FP8_PREFILL_DENSE_WORKSPACE_BYTES = (
     _SM70_FP8_PREFILL_DENSE_WORKSPACE_ELEMENTS * torch.float16.itemsize
 )
-_sm70_fp8_prefill_dense_workspaces: weakref.WeakValueDictionary[
-    tuple[int, torch.dtype], torch.Tensor
-] = weakref.WeakValueDictionary()
+# Layers retain only data_ptr(), so this cache owns each allocation's lifetime.
+_sm70_fp8_prefill_dense_workspaces: dict[tuple[int, torch.dtype], torch.Tensor] = {}
 
 
 def _is_sm70_fp8_prefill_exact_dense_layer(layer: torch.nn.Module) -> bool:
@@ -638,7 +636,9 @@ class Fp8LinearMethod(LinearMethodBase):
             ):
                 workspace = _get_sm70_fp8_prefill_exact_dense_workspace(tm_weight)
                 if workspace is not None:
-                    layer._sm70_fp8_prefill_exact_dense_workspace = workspace
+                    layer.sm70_fp8_prefill_exact_dense_workspace_ptr = (
+                        workspace.data_ptr()
+                    )
                     logger.info_once(
                         "SM70 FP8 exact-dense prefill path enabled with a bounded "
                         "85 MiB workspace."
@@ -800,16 +800,13 @@ class Fp8LinearMethod(LinearMethodBase):
                 device=x.device,
                 dtype=x.dtype,
             )
-            prefill_workspace = getattr(
-                layer, "_sm70_fp8_prefill_exact_dense_workspace", None
+            prefill_workspace_ptr = getattr(
+                layer, "sm70_fp8_prefill_exact_dense_workspace_ptr", None
             )
-            if prefill_workspace is not None and x_2d.dtype == torch.float16:
-                k = x_2d.shape[1]
-                n = layer.output_size_per_partition
-                prefill_weight = prefill_workspace[: k * n].view(k, n)
+            if prefill_workspace_ptr is not None and x_2d.dtype == torch.float16:
                 sm70_ops.fp8_gemm_sm70_prefill_dispatch_out(
                     out_2d,
-                    prefill_weight,
+                    prefill_workspace_ptr,
                     x_2d,
                     layer.weight,
                     layer.weight_scale_inv,
@@ -916,17 +913,13 @@ class Fp8LinearMethod(LinearMethodBase):
             scales = layer.sm70_fp8_gated_silu_scales
             k_ld = int(layer.sm70_fp8_gated_silu_k_ld)
             q_ld = int(layer.sm70_fp8_gated_silu_q_ld)
-        prefill_workspace = getattr(
-            layer, "_sm70_fp8_prefill_exact_dense_workspace", None
+        prefill_workspace_ptr = getattr(
+            layer, "sm70_fp8_prefill_exact_dense_workspace_ptr", None
         )
-        if prefill_workspace is not None and x_2d.dtype == torch.float16:
-            n = layer.output_size_per_partition
-            prefill_weight = prefill_workspace[: x_2d.shape[1] * n].view(
-                x_2d.shape[1], n
-            )
+        if prefill_workspace_ptr is not None and x_2d.dtype == torch.float16:
             sm70_ops.fp8_gemm_sm70_prefill_dispatch_out(
                 out_2d,
-                prefill_weight,
+                prefill_workspace_ptr,
                 x_2d,
                 weight,
                 scales,

--- a/vllm/model_executor/layers/quantization/fp8.py
+++ b/vllm/model_executor/layers/quantization/fp8.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import weakref
 from typing import TYPE_CHECKING, Any
 
 import torch
@@ -98,6 +99,59 @@ if TYPE_CHECKING:
 ACTIVATION_SCHEMES = ["static", "dynamic"]
 
 logger = init_logger(__name__)
+
+_SM70_FP8_PREFILL_DENSE_MIN_M = 3920
+_SM70_FP8_PREFILL_DENSE_SHAPES = {
+    "gate_up_proj": (5120, 8704),
+    "down_proj": (4352, 5120),
+    "out_proj": (1536, 5120),
+    "o_proj": (1536, 5120),
+}
+_SM70_FP8_PREFILL_DENSE_WORKSPACE_ELEMENTS = max(
+    k * n for k, n in _SM70_FP8_PREFILL_DENSE_SHAPES.values()
+)
+_SM70_FP8_PREFILL_DENSE_WORKSPACE_BYTES = (
+    _SM70_FP8_PREFILL_DENSE_WORKSPACE_ELEMENTS * torch.float16.itemsize
+)
+_sm70_fp8_prefill_dense_workspaces: weakref.WeakValueDictionary[
+    tuple[int, torch.dtype], torch.Tensor
+] = weakref.WeakValueDictionary()
+
+
+def _is_sm70_fp8_prefill_exact_dense_layer(layer: torch.nn.Module) -> bool:
+    if getattr(layer, "tp_size", 1) != 4:
+        return False
+    suffix = getattr(layer, "prefix", "").rsplit(".", 1)[-1]
+    expected = _SM70_FP8_PREFILL_DENSE_SHAPES.get(suffix)
+    if expected is None:
+        return False
+    return tuple(layer.weight.shape) == expected
+
+
+def _get_sm70_fp8_prefill_exact_dense_workspace(
+    weight: torch.Tensor,
+) -> torch.Tensor | None:
+    device_index = weight.device.index
+    if device_index is None:
+        device_index = torch.accelerator.current_device_index()
+    cache_key = (device_index, torch.float16)
+    workspace = _sm70_fp8_prefill_dense_workspaces.get(cache_key)
+    if workspace is not None:
+        return workspace
+    try:
+        workspace = torch.empty(
+            (_SM70_FP8_PREFILL_DENSE_WORKSPACE_ELEMENTS,),
+            dtype=torch.float16,
+            device=weight.device,
+        )
+    except torch.OutOfMemoryError:
+        logger.warning_once(
+            "Insufficient memory for the bounded SM70 FP8 prefill workspace; "
+            "falling back to TurboMind FP8."
+        )
+        return None
+    _sm70_fp8_prefill_dense_workspaces[cache_key] = workspace
+    return workspace
 
 
 class Fp8Config(QuantizationConfig):
@@ -577,6 +631,18 @@ class Fp8LinearMethod(LinearMethodBase):
             layer.register_buffer("sm70_fp8_meta", meta, persistent=False)
             layer.sm70_fp8_k_ld = int(meta[0].item())
             layer.sm70_fp8_q_ld = int(meta[1].item())
+            if (
+                envs.VLLM_SM70_FP8_PREFILL_EXACT_DENSE
+                and hasattr(torch.ops._C, "fp8_gemm_sm70_prefill_dispatch_out")
+                and _is_sm70_fp8_prefill_exact_dense_layer(layer)
+            ):
+                workspace = _get_sm70_fp8_prefill_exact_dense_workspace(tm_weight)
+                if workspace is not None:
+                    layer._sm70_fp8_prefill_exact_dense_workspace = workspace
+                    logger.info_once(
+                        "SM70 FP8 exact-dense prefill path enabled with a bounded "
+                        "85 MiB workspace."
+                    )
             logger.info_once("SM70 FP8 TurboMind W8A16 dense path enabled.")
             return
 
@@ -734,16 +800,36 @@ class Fp8LinearMethod(LinearMethodBase):
                 device=x.device,
                 dtype=x.dtype,
             )
-            sm70_ops.fp8_gemm_sm70_out(
-                out_2d,
-                x_2d,
-                layer.weight,
-                layer.weight_scale_inv,
-                128,
-                layer.sm70_fp8_k_ld,
-                layer.sm70_fp8_q_ld,
-                False,
+            prefill_workspace = getattr(
+                layer, "_sm70_fp8_prefill_exact_dense_workspace", None
             )
+            if prefill_workspace is not None and x_2d.dtype == torch.float16:
+                k = x_2d.shape[1]
+                n = layer.output_size_per_partition
+                prefill_weight = prefill_workspace[: k * n].view(k, n)
+                sm70_ops.fp8_gemm_sm70_prefill_dispatch_out(
+                    out_2d,
+                    prefill_weight,
+                    x_2d,
+                    layer.weight,
+                    layer.weight_scale_inv,
+                    128,
+                    layer.sm70_fp8_k_ld,
+                    layer.sm70_fp8_q_ld,
+                    False,
+                    _SM70_FP8_PREFILL_DENSE_MIN_M,
+                )
+            else:
+                sm70_ops.fp8_gemm_sm70_out(
+                    out_2d,
+                    x_2d,
+                    layer.weight,
+                    layer.weight_scale_inv,
+                    128,
+                    layer.sm70_fp8_k_ld,
+                    layer.sm70_fp8_q_ld,
+                    False,
+                )
             if getattr(layer, "sm70_fp8_gated_silu_primary", False):
                 out_features = layer.output_size_per_partition // 2
                 out_2d = (
@@ -830,6 +916,27 @@ class Fp8LinearMethod(LinearMethodBase):
             scales = layer.sm70_fp8_gated_silu_scales
             k_ld = int(layer.sm70_fp8_gated_silu_k_ld)
             q_ld = int(layer.sm70_fp8_gated_silu_q_ld)
+        prefill_workspace = getattr(
+            layer, "_sm70_fp8_prefill_exact_dense_workspace", None
+        )
+        if prefill_workspace is not None and x_2d.dtype == torch.float16:
+            n = layer.output_size_per_partition
+            prefill_weight = prefill_workspace[: x_2d.shape[1] * n].view(
+                x_2d.shape[1], n
+            )
+            sm70_ops.fp8_gemm_sm70_prefill_dispatch_out(
+                out_2d,
+                prefill_weight,
+                x_2d,
+                weight,
+                scales,
+                128,
+                k_ld,
+                q_ld,
+                True,
+                _SM70_FP8_PREFILL_DENSE_MIN_M,
+            )
+            return out_2d.reshape(*x.shape[:-1], out_features)
         sm70_ops.fp8_gemm_sm70_out(
             out_2d,
             x_2d,

--- a/vllm/model_executor/warmup/awq_sm70_warmup.py
+++ b/vllm/model_executor/warmup/awq_sm70_warmup.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+import tempfile
 from collections.abc import Iterable
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -50,7 +51,11 @@ def _lut_cache_disabled_for_dynamic_quant_dispatch(
         and not envs.VLLM_SM70_AWQ_PRESERVE_DEFAULT_SPLITS
         and not envs.VLLM_SM70_AWQ_PRESERVE_DEFAULT_SPLITS_ONLY
     )
-    fp8_dynamic = has_fp8_dense and envs.VLLM_SM70_FP8_TUNE_SMALL_SHAPES
+    fp8_dynamic = (
+        has_fp8_dense
+        and envs.VLLM_SM70_FP8_TUNE_SMALL_SHAPES
+        and not envs.VLLM_SM70_FP8_REUSE_IMPORTED_CACHE
+    )
     mxfp4_dynamic = (
         "mxfp4" in fp4_kinds or has_mxfp4_moe
     ) and envs.VLLM_SM70_MXFP4_TUNE_SMALL_SHAPES
@@ -100,6 +105,79 @@ def _save_lut_cache(device: torch.device, skip_export: bool = False) -> int:
     except Exception as exc:
         logger.warning("SM70 GEMM LUT export failed to %s (%s).", path, exc)
         return 0
+
+
+def _export_lut_bytes(device: torch.device) -> tuple[bytes | None, int]:
+    if not hasattr(torch.ops._C, "sm70_gemm_export_cache"):
+        return None, 0
+    device_hint = torch.empty(0, dtype=torch.uint8, device=device)
+    with tempfile.TemporaryDirectory(prefix="vllm-sm70-gemm-export-") as tmpdir:
+        path = Path(tmpdir) / "gemm-lut.bin"
+        records = int(sm70_ops.sm70_gemm_export_cache(device_hint, str(path)))
+        if records <= 0 or not path.exists():
+            return None, records
+        return path.read_bytes(), records
+
+
+def _import_lut_bytes(device: torch.device, payload: bytes) -> int:
+    if not hasattr(torch.ops._C, "sm70_gemm_import_cache"):
+        return 0
+    device_hint = torch.empty(0, dtype=torch.uint8, device=device)
+    with tempfile.TemporaryDirectory(prefix="vllm-sm70-gemm-import-") as tmpdir:
+        path = Path(tmpdir) / "gemm-lut.bin"
+        path.write_bytes(payload)
+        return int(sm70_ops.sm70_gemm_import_cache(device_hint, str(path)))
+
+
+def _warmup_fp8_dense_layers_coordinated(
+    layers: list[tuple[torch.nn.Module, bool]],
+    m_values: list[int],
+    device: torch.device,
+) -> int:
+    if not layers:
+        return 0
+    if (
+        not envs.VLLM_SM70_FP8_TUNE_SMALL_SHAPES
+        or not envs.VLLM_SM70_FP8_COORDINATED_TUNING
+    ):
+        return _warmup_fp8_dense_layers(layers, m_values)
+
+    from vllm.distributed.parallel_state import get_tp_group
+
+    tp_group = get_tp_group()
+    if tp_group.world_size <= 1:
+        return _warmup_fp8_dense_layers(layers, m_values)
+
+    is_leader = tp_group.rank_in_group == 0
+    if is_leader:
+        _warmup_fp8_dense_layers(layers, m_values)
+        torch.accelerator.synchronize(device)
+        payload, exported_records = _export_lut_bytes(device)
+    else:
+        payload = None
+        exported_records = 0
+
+    payload = tp_group.broadcast_object(payload, src=0)
+    if payload is None:
+        logger.warning(
+            "SM70 FP8 coordinated tuning produced no LUT; rank %d is "
+            "falling back to local tuning.",
+            tp_group.rank_in_group,
+        )
+        return _warmup_fp8_dense_layers(layers, m_values)
+
+    imported_records = (
+        exported_records if is_leader else _import_lut_bytes(device, payload)
+    )
+    tp_group.barrier()
+    calls = _warmup_fp8_dense_layers(layers, m_values)
+    torch.accelerator.synchronize(device)
+    logger.info(
+        "SM70 FP8 coordinated tuning loaded %d rank0 LUT records on rank %d.",
+        imported_records,
+        tp_group.rank_in_group,
+    )
+    return calls
 
 
 def _silu_and_mul_w13(
@@ -708,7 +786,9 @@ def sm70_awq_warmup(worker: Worker) -> None:
         return
 
     device = worker.device
-    if device.type != "cuda" or torch.cuda.get_device_capability(device) != (7, 0):
+    if device is None or device.type != "cuda":
+        return
+    if torch.cuda.get_device_capability(device) != (7, 0):
         return
 
     model = worker.get_model()
@@ -761,12 +841,16 @@ def sm70_awq_warmup(worker: Worker) -> None:
     )
     with torch.inference_mode():
         dense_calls = _warmup_dense_layers(dense_layers, m_values)
-        fp8_dense_calls = _warmup_fp8_dense_layers(fp8_dense_layers, m_values)
+        fp8_dense_calls = _warmup_fp8_dense_layers_coordinated(
+            fp8_dense_layers,
+            m_values,
+            device,
+        )
         fp4_dense_calls = _warmup_fp4_dense_layers(fp4_dense_layers, m_values)
         moe_stage_calls = _warmup_moe_dense_stage_layers(moe_layers, moe_token_counts)
         single_token_calls = _warmup_moe_single_token_layers(moe_layers)
         mxfp4_moe_stage_calls = _warmup_mxfp4_moe_b1_layers(mxfp4_moe_layers)
-    torch.cuda.synchronize(device)
+    torch.accelerator.synchronize(device)
     logger.info(
         "SM70 TurboMind warmup finished (%d AWQ dense calls, %d FP8 dense "
         "calls, %d FP4 dense calls, %d MoE stage calls, "

--- a/vllm/models/deepseek_v4/nvidia/dspark.py
+++ b/vllm/models/deepseek_v4/nvidia/dspark.py
@@ -385,12 +385,12 @@ class DSparkDeepseekV4ForCausalLM(nn.Module):
                 continue
 
             is_layer_param = name.startswith("model.layers.")
-            for param_name, weight_name, shard_id in stacked_params_mapping:
+            for param_name, weight_name, stacked_shard_id in stacked_params_mapping:
                 if not is_layer_param or weight_name not in name:
                     continue
                 name = name.replace(weight_name, param_name)
                 param = params_dict[name]
-                param.weight_loader(param, loaded_weight, shard_id)
+                param.weight_loader(param, loaded_weight, stacked_shard_id)
                 loaded_params.add(name)
                 break
             else:
@@ -408,8 +408,10 @@ class DSparkDeepseekV4ForCausalLM(nn.Module):
                         ".ffn.gate.bias", ".ffn.gate.e_score_correction_bias"
                     )
                 param = params_dict[name]
-                loader = getattr(param, "weight_loader", default_weight_loader)
-                loader(param, loaded_weight)
+                weight_loader: Callable[..., object] = (
+                    getattr(param, "weight_loader", None) or default_weight_loader
+                )
+                weight_loader(param, loaded_weight)
                 loaded_params.add(name)
 
         for layer in self.model.layers:

--- a/vllm/v1/attention/backends/flash_attn_v100.py
+++ b/vllm/v1/attention/backends/flash_attn_v100.py
@@ -150,6 +150,12 @@ _prefill_dense_splitkv3_workspaces: dict[
 ] = {}
 
 
+def _normalize_flash_v100_kv_cache_dtype(kv_cache_dtype: str) -> str:
+    # Newer vLLM resolves an explicit FP16 cache to "float16". The vendored
+    # Flash-V100 extension uses "auto" for the same unquantized FP16 layout.
+    return "auto" if kv_cache_dtype == "float16" else kv_cache_dtype
+
+
 def _split_paged_kv_cache(
     kv_cache: torch.Tensor | tuple[torch.Tensor, torch.Tensor] | list[torch.Tensor],
 ) -> tuple[torch.Tensor, torch.Tensor]:
@@ -3095,6 +3101,7 @@ class FlashAttnV100Impl(TritonAttentionImpl):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+        self.kv_cache_dtype = _normalize_flash_v100_kv_cache_dtype(self.kv_cache_dtype)
         (
             self.flash_attn_func,
             self.flash_attn_bhmd_func,

--- a/vllm/v1/attention/backends/flash_attn_v100.py
+++ b/vllm/v1/attention/backends/flash_attn_v100.py
@@ -4133,7 +4133,7 @@ class FlashAttnV100Impl(TritonAttentionImpl):
         key: torch.Tensor,
         value: torch.Tensor,
         kv_cache: torch.Tensor,
-        attn_metadata: TritonAttentionMetadata,
+        attn_metadata: TritonAttentionMetadata | None,
         output: torch.Tensor | None = None,
         output_scale: torch.Tensor | None = None,
         output_block_scale: torch.Tensor | None = None,

--- a/vllm/v1/attention/backends/flash_attn_v100.py
+++ b/vllm/v1/attention/backends/flash_attn_v100.py
@@ -127,6 +127,7 @@ _logged_dflash_prefix_dump = False
 _logged_prefill_ddtree_dense = False
 _logged_prefill_ddtree_triton = False
 _logged_prefill_ddtree_triton_fallback = False
+_logged_kv_dtype_contracts: set[str] = set()
 _route_summary_registered = False
 _route_counts: dict[str, int] = {}
 _decode_active_trace_signatures: set[tuple[object, ...]] = set()
@@ -134,11 +135,15 @@ _draft_graph_debug_counts: dict[str, int] = {}
 _DEFAULT_DECODE_PARTITION_SIZE = 256
 _VALID_DECODE_PARTITION_SIZES = (256, 512, 1024)
 _DEFAULT_Q4_XQA_MIN_SEQ_LEN = 32768
-_DEFAULT_FP8_XQA_MIN_SEQ_LEN = 8192
+_DEFAULT_FP8_XQA_MIN_SEQ_LEN = 16384
 _FP8_PREFILL_BRIDGE_PAGE_SIZE = 784
 _fp8_prefill_bridge_workspaces: dict[
     tuple[int, int, int, int],
     tuple[torch.Tensor, torch.Tensor, torch.Tensor],
+] = {}
+_fp8_prefill_bridge_tail_workspaces: dict[
+    tuple[int, int, torch.dtype, int, int],
+    tuple[torch.Tensor, torch.Tensor],
 ] = {}
 _prefill_gather_dense_workspaces: dict[
     tuple[int, int, torch.dtype, int, int, int],
@@ -290,28 +295,68 @@ def _decode_partition_size_for_metadata(
     return value
 
 
-def _g6_page784_sawtooth_partition_size_hint(
+def _g6_aligned_page_partition_size_hint(
     query: torch.Tensor,
     key_cache: torch.Tensor,
     value_cache: torch.Tensor,
+    kv_cache_dtype: str,
 ) -> int | None:
     if os.getenv("VLLM_FLASH_V100_DECODE_PARTITION_SIZE") is not None:
         return None
     if os.getenv("VLLM_FLASH_V100_XQA_G6_P1024_SAWTOOTH", "1") == "0":
         return None
-    if (
-        query.shape[0] == 1
-        and query.shape[1] == 6
-        and query.shape[2] == 256
-        and key_cache.shape[1] == 784
-        and key_cache.shape[2] == 1
-        and key_cache.shape[3] == 256
+    if not (
+        query.shape == (1, 6, 256)
+        and key_cache.ndim == 4
+        and key_cache.shape[1] >= _DEFAULT_DECODE_PARTITION_SIZE
+        and key_cache.shape[1] % 16 == 0
+        and key_cache.shape[2:] == (1, 256)
         and value_cache.shape == key_cache.shape
+        and value_cache.dtype == key_cache.dtype
     ):
-        # The CUDA graph contains p256 and p1024 nodes and selects between them
-        # from device seq_lens. Plan the larger p256 workspace envelope once.
+        return None
+    if (
+        kv_cache_dtype in ("auto", "bfloat16")
+        and key_cache.dtype == torch.float16
+        and key_cache.shape[1] == 784
+    ):
+        # The exact FP16 page-784 graph contains p256 and p1024 nodes and
+        # selects between them from device seq_lens. Plan the p256 workspace
+        # envelope once.
+        return 256
+    if kv_cache_dtype == "fp8_e5m2" and key_cache.dtype == torch.uint8:
+        # Plan the largest p256 workspace once. The extension selects p256 or
+        # p1024 from device seq_lens, so CUDA graph replay keeps one
+        # captured shape while short and long contexts use different kernels.
+        # Keep this layout-driven rather than using model-name allowlists.
         return 256
     return None
+
+
+def _log_kv_dtype_contract(kv_cache_dtype: str) -> None:
+    if kv_cache_dtype in _logged_kv_dtype_contracts:
+        return
+    _logged_kv_dtype_contracts.add(kv_cache_dtype)
+    if kv_cache_dtype == "fp8":
+        logger.warning(
+            "SM70 Flash-V100 received an unresolved `fp8` KV-cache dtype and "
+            "will interpret it as upstream E4M3. Normal EngineArgs processing "
+            "rewrites the SM70 `fp8` shorthand to `fp8_e5m2`; this warning "
+            "usually means the backend was constructed directly. KV-cache "
+            "dtype is independent of model weight quantization."
+        )
+    elif kv_cache_dtype == "fp8_e4m3":
+        logger.warning(
+            "SM70 Flash-V100 is using explicitly requested E4M3 KV cache. "
+            "The optimized V100 quantized-KV route uses E5M2. KV-cache dtype "
+            "is independent of model weight quantization."
+        )
+    elif kv_cache_dtype == "fp8_e5m2":
+        logger.info(
+            "SM70 Flash-V100 is using explicit E5M2 KV cache. This controls "
+            "KV storage only; model weight quantization is configured "
+            "separately."
+        )
 
 
 def _mtp_context_bucket_partition_size_hint() -> int | None:
@@ -393,9 +438,10 @@ def _decode_fp8_xqa_allowed(
     attn_metadata: TritonAttentionMetadata,
     query: torch.Tensor,
 ) -> bool:
-    if bool(getattr(attn_metadata, "flash_v100_cudagraph_capture", False)):
-        return True
-    if _is_cuda_graph_capturing(query):
+    graph_capture = bool(
+        getattr(attn_metadata, "flash_v100_cudagraph_capture", False)
+    ) or _is_cuda_graph_capturing(query)
+    if graph_capture:
         hint_names = (
             "flash_v100_static_decode_seq_hint",
             "flash_v100_decode_workspace_seq_capacity_hint",
@@ -976,7 +1022,7 @@ def _try_sm70_fa2_d256_prefill(
         and query.ndim == 4
         and query.shape[1] == max_seqlen_q
         and max_seqlen_q % 64 == 0
-        and max_seqlen_k % 64 == 0
+        and max_seqlen_k % 32 == 0
     )
     if splitd_eligible:
         dense_op, paged_op, splitkv3_op = splitd_ops
@@ -1102,13 +1148,16 @@ def _get_fp8_prefill_bridge_workspace(
         key_cache.shape[2],
         key_cache.shape[3],
     )
-    key_out = torch.empty(shape, dtype=torch.float16, device=key_cache.device)
-    value_out = torch.empty_like(key_out)
-    block_table = torch.arange(
-        capacity,
-        dtype=torch.int32,
-        device=key_cache.device,
-    ).unsqueeze(0)
+    try:
+        key_out = torch.empty(shape, dtype=torch.float16, device=key_cache.device)
+        value_out = torch.empty_like(key_out)
+        block_table = torch.arange(
+            capacity,
+            dtype=torch.int32,
+            device=key_cache.device,
+        ).unsqueeze(0)
+    except torch.OutOfMemoryError:
+        return None
     _fp8_prefill_bridge_workspaces[cache_key] = (
         key_out,
         value_out,
@@ -1118,6 +1167,51 @@ def _get_fp8_prefill_bridge_workspace(
         key_out[:required_blocks],
         value_out[:required_blocks],
         block_table[:, :required_blocks],
+    )
+
+
+def _get_fp8_prefill_bridge_tail_workspace(
+    query: torch.Tensor,
+    padded_query_len: int,
+) -> tuple[torch.Tensor, torch.Tensor] | None:
+    device_index = (
+        query.device.index
+        if query.device.index is not None
+        else torch.accelerator.current_device_index()
+    )
+    stream_id = int(torch.cuda.current_stream(query.device).cuda_stream)
+    cache_key = (
+        device_index,
+        stream_id,
+        query.dtype,
+        int(query.shape[2]),
+        int(query.shape[3]),
+    )
+    workspace = _fp8_prefill_bridge_tail_workspaces.get(cache_key)
+    if workspace is not None and workspace[0].shape[1] >= padded_query_len:
+        return (
+            workspace[0][:, :padded_query_len],
+            workspace[1][:, :padded_query_len],
+        )
+
+    if torch.cuda.is_current_stream_capturing():
+        return None
+
+    previous_capacity = workspace[0].shape[1] if workspace is not None else 0
+    capacity = max(padded_query_len, previous_capacity * 2)
+    shape = (1, capacity, query.shape[2], query.shape[3])
+    try:
+        padded_query = torch.empty(shape, dtype=query.dtype, device=query.device)
+        padded_output = torch.empty_like(padded_query)
+    except torch.OutOfMemoryError:
+        return None
+    _fp8_prefill_bridge_tail_workspaces[cache_key] = (
+        padded_query,
+        padded_output,
+    )
+    return (
+        padded_query[:, :padded_query_len],
+        padded_output[:, :padded_query_len],
     )
 
 
@@ -3102,6 +3196,7 @@ class FlashAttnV100Impl(TritonAttentionImpl):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.kv_cache_dtype = _normalize_flash_v100_kv_cache_dtype(self.kv_cache_dtype)
+        _log_kv_dtype_contract(self.kv_cache_dtype)
         (
             self.flash_attn_func,
             self.flash_attn_bhmd_func,
@@ -5084,11 +5179,16 @@ class FlashAttnV100Impl(TritonAttentionImpl):
                 attn_metadata=attn_metadata,
                 window_size=window_size,
             )
-            partition_size_hint = _g6_page784_sawtooth_partition_size_hint(
+            partition_size_hint = _g6_aligned_page_partition_size_hint(
                 query,
                 key_cache,
                 value_cache,
+                self.kv_cache_dtype,
             )
+            if partition_size_hint is not None:
+                _record_route(
+                    f"decode_xqa_p{partition_size_hint}_page{key_cache.shape[1]}"
+                )
             self.flash_attn_decode_paged_xqa(
                 query,
                 key_cache,
@@ -5724,14 +5824,24 @@ class FlashAttnV100Impl(TritonAttentionImpl):
         value_cache: torch.Tensor,
         block_table: torch.Tensor,
         seq_lens: torch.Tensor,
+        seq_len: int,
         k_scale: float,
         v_scale: float,
         causal: bool,
         window_size: tuple[int, int],
-    ) -> torch.Tensor | None:
+        out: torch.Tensor,
+    ) -> tuple[torch.Tensor, bool] | None:
         if block_table.shape[0] != 1:
             return None
-        input_capacity = int(block_table.shape[1]) * int(key_cache.shape[1])
+        input_block_size = int(key_cache.shape[1])
+        active_input_blocks = min(
+            int(block_table.shape[1]),
+            _cdiv_int(seq_len, input_block_size),
+        )
+        if active_input_blocks <= 0:
+            return None
+        active_block_table = block_table[:, :active_input_blocks]
+        input_capacity = active_input_blocks * input_block_size
         required_blocks = _cdiv_int(
             input_capacity,
             _FP8_PREFILL_BRIDGE_PAGE_SIZE,
@@ -5746,14 +5856,80 @@ class FlashAttnV100Impl(TritonAttentionImpl):
         self.fp8_e5m2_paged_kv_to_fp16(
             key_cache,
             value_cache,
-            block_table,
+            active_block_table,
             seq_lens,
             key_out,
             value_out,
             k_scale,
             v_scale,
         )
-        return self.flash_attn_prefill_paged(
+        q_len = int(query.shape[1])
+        exact_query = query
+        exact_out = out
+        tail_prefix = 0
+        if q_len % 64 != 0 and seq_len % 32 == 0:
+            padded_q_len = _cdiv_int(q_len, 64) * 64
+            if padded_q_len <= seq_len:
+                tail_workspace = _get_fp8_prefill_bridge_tail_workspace(
+                    query,
+                    padded_q_len,
+                )
+                if tail_workspace is not None:
+                    exact_query, exact_out = tail_workspace
+                    tail_prefix = padded_q_len - q_len
+                    exact_query[:, :tail_prefix].zero_()
+                    exact_query[:, tail_prefix:].copy_(query)
+        cu_q, cu_k = _uniform_cu_seqlens(
+            exact_query,
+            batch_size=1,
+            query_len=int(exact_query.shape[1]),
+            kv_len=seq_len,
+        )
+        key_dense = key_out.flatten(0, 1)[:seq_len].unsqueeze(0)
+        value_dense = value_out.flatten(0, 1)[:seq_len].unsqueeze(0)
+        exact_result = _try_sm70_fa2_d256_prefill(
+            exact_query,
+            key_dense,
+            value_dense,
+            cu_seqlens_q=cu_q,
+            cu_seqlens_k=cu_k,
+            max_seqlen_q=int(exact_query.shape[1]),
+            max_seqlen_k=seq_len,
+            softmax_scale=self.scale,
+            causal=causal,
+            window_size=window_size,
+            out=exact_out,
+        )
+        if exact_result is not None:
+            if tail_prefix:
+                out.copy_(exact_result[:, tail_prefix:])
+                _record_route("prefill_prefix_fp8_bridge_exact_dense_d256_tailpad")
+                return out, True
+            _record_route("prefill_prefix_fp8_bridge_exact_dense_d256")
+            return exact_result, True
+        exact_result = _try_sm70_fa2_d256_prefill(
+            exact_query,
+            key_out,
+            value_out,
+            cu_seqlens_q=cu_q,
+            cu_seqlens_k=None,
+            max_seqlen_q=int(exact_query.shape[1]),
+            max_seqlen_k=seq_len,
+            softmax_scale=self.scale,
+            causal=causal,
+            window_size=window_size,
+            out=exact_out,
+            seqused_k=seq_lens,
+            block_table=output_block_table,
+        )
+        if exact_result is not None:
+            if tail_prefix:
+                out.copy_(exact_result[:, tail_prefix:])
+                _record_route("prefill_prefix_fp8_bridge_exact_d256_tailpad")
+                return out, True
+            _record_route("prefill_prefix_fp8_bridge_exact_d256")
+            return exact_result, True
+        paged_result = self.flash_attn_prefill_paged(
             query,
             key_out,
             value_out,
@@ -5766,6 +5942,7 @@ class FlashAttnV100Impl(TritonAttentionImpl):
             causal=causal,
             window_size=window_size,
         )
+        return paged_result, False
 
     def _should_use_prefill_splitkv(
         self,
@@ -6390,18 +6567,21 @@ class FlashAttnV100Impl(TritonAttentionImpl):
                             ),
                         )
                 elif use_fp8_bridge:
-                    out_seq = self._run_fp8_prefill_bridge(
+                    bridge_result = self._run_fp8_prefill_bridge(
                         query=q_seq,
                         key_cache=key_cache,
                         value_cache=value_cache,
                         block_table=attn_metadata.block_table[i : i + 1],
                         seq_lens=attn_metadata.seq_lens[i : i + 1],
+                        seq_len=seq_len,
                         k_scale=float(layer._k_scale_float),
                         v_scale=float(layer._v_scale_float),
                         causal=causal,
                         window_size=window_size,
+                        out=out_view[start:end].unsqueeze(0),
                     )
-                    if out_seq is not None:
+                    if bridge_result is not None:
+                        out_seq, out_is_destination = bridge_result
                         if not _logged_fp8_prefill_bridge:
                             logger.info(
                                 "FLASH_ATTN_V100 FP8 E5M2 prefill bridge "

--- a/vllm/v1/attention/backends/flex_attention.py
+++ b/vllm/v1/attention/backends/flex_attention.py
@@ -490,7 +490,8 @@ class FlexAttentionMetadata:
         mask_mod functions. This allows mask mod functions to be agnostic to
         layout of the query and key/value tensors.
         """
-        assert self.doc_ids is not None
+        doc_ids = self.doc_ids
+        assert doc_ids is not None
 
         def final_mask_mod(
             b: torch.Tensor,
@@ -499,14 +500,14 @@ class FlexAttentionMetadata:
             physical_kv_idx: torch.Tensor,
         ) -> torch.Tensor:
             (is_valid, logical_q_idx, logical_kv_idx) = (
-                self._convert_physical_to_logical(self.doc_ids, q_idx, physical_kv_idx)
+                self._convert_physical_to_logical(doc_ids, q_idx, physical_kv_idx)
             )
             base_mask = self.logical_mask_mod(b, h, logical_q_idx, logical_kv_idx)
             if (
                 self.ddtree_parent_ids is not None
                 and self.ddtree_num_tree_tokens is not None
             ):
-                q_req = self.doc_ids[q_idx]
+                q_req = doc_ids[q_idx]
                 base_mask = ddtree_logical_mask(
                     base_mask=base_mask,
                     q_req=q_req,
@@ -904,9 +905,10 @@ class FlexAttentionMetadataBuilder(AttentionMetadataBuilder[FlexAttentionMetadat
         self,
         common_prefix_len: int,
         common_attn_metadata: CommonAttentionMetadata,
+        fast_build: bool = False,
+        *,
         ddtree_parent_ids: torch.Tensor | None = None,
         ddtree_num_tree_tokens_cpu: torch.Tensor | None = None,
-        fast_build: bool = False,
     ) -> FlexAttentionMetadata:
         num_reqs = common_attn_metadata.num_reqs
         num_actual_tokens = common_attn_metadata.num_actual_tokens

--- a/vllm/v1/attention/backends/mla/sparse_swa.py
+++ b/vllm/v1/attention/backends/mla/sparse_swa.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 from dataclasses import dataclass
-from typing import ClassVar, cast
+from typing import ClassVar, TypedDict, cast
 
 import torch
 
@@ -32,6 +32,16 @@ from vllm.v1.kv_cache_interface import (
 _LAYER_TYPE_SWAONLY = "swaonly"
 _LAYER_TYPE_C4A = "c4a"
 _LAYER_TYPE_C128A = "c128a"
+
+
+class _DeepseekV4MetadataFields(TypedDict, total=False):
+    prefill_seq_lens: torch.Tensor
+    prefill_seq_lens_cpu: torch.Tensor
+    prefill_gather_lens: torch.Tensor
+    prefill_query_lens_cpu: torch.Tensor
+    prefill_window_size: int
+    prefill_max_model_len: int
+    prefill_max_num_batched_tokens: int
 
 
 def _layer_type_for(compress_ratio: int) -> str:
@@ -506,7 +516,7 @@ class DeepseekSparseSWAMetadataBuilder(AttentionMetadataBuilder):
         seq_lens_cpu: torch.Tensor | None,
         query_start_loc: torch.Tensor,
         query_start_loc_cpu: torch.Tensor,
-    ) -> dict[str, torch.Tensor | int | None]:
+    ) -> _DeepseekV4MetadataFields:
         """Pre-compute DeepseekV4 prefill metadata during the metadata build phase.
 
         Returns a dict of keyword arguments to pass to the
@@ -515,7 +525,7 @@ class DeepseekSparseSWAMetadataBuilder(AttentionMetadataBuilder):
         Note: C128A topk indices are computed by the FlashMLASparse builder
         (which owns the C128A block_table), not here.
         """
-        result: dict[str, torch.Tensor | int | None] = {}
+        result: _DeepseekV4MetadataFields = {}
 
         # --- Prefill query metadata (single Triton kernel + CPU slicing) ---
         if num_prefills > 0:

--- a/vllm/v1/cudagraph_dispatcher.py
+++ b/vllm/v1/cudagraph_dispatcher.py
@@ -79,6 +79,65 @@ def _get_sm70_dsv4_decode_context_buckets(
     return (bucket,)
 
 
+def _get_sm70_fp8_kv_decode_context_buckets(
+    vllm_config: VllmConfig,
+) -> tuple[int, ...]:
+    """Select a scalar-only short graph for the SM70 E5M2 D256 route."""
+    env_name = "VLLM_SM70_FP8_KV_DECODE_CONTEXT_BUCKETS"
+    if env_name in os.environ:
+        return _get_sm70_context_buckets(env_name)
+    if vllm_config.speculative_config is not None:
+        return ()
+    if not (
+        current_platform.is_cuda() and current_platform.is_device_capability((7, 0))
+    ):
+        return ()
+    if not envs.VLLM_SM70_FLASH_ATTN_V100:
+        return ()
+
+    cache_config = getattr(vllm_config, "cache_config", None)
+    if getattr(cache_config, "cache_dtype", None) != "fp8_e5m2":
+        return ()
+
+    attention_config = getattr(vllm_config, "attention_config", None)
+    attention_backend = getattr(attention_config, "backend", None)
+    attention_backend_name = getattr(attention_backend, "name", attention_backend)
+    if attention_backend is not None and attention_backend_name not in (
+        "FLASH_ATTN_V100",
+        "FLASHINFER_SM70",
+    ):
+        return ()
+
+    model_config = vllm_config.model_config
+    hf_text_config = getattr(model_config, "hf_text_config", None)
+    num_attention_heads = getattr(hf_text_config, "num_attention_heads", None)
+    num_key_value_heads = getattr(hf_text_config, "num_key_value_heads", None)
+    head_dim = getattr(hf_text_config, "head_dim", None)
+    if not (
+        isinstance(num_attention_heads, int)
+        and isinstance(num_key_value_heads, int)
+        and num_key_value_heads > 0
+        and num_attention_heads % num_key_value_heads == 0
+        and num_attention_heads // num_key_value_heads in (6, 8)
+        and head_dim == 256
+    ):
+        return ()
+
+    bucket = 8192
+    max_model_len = getattr(model_config, "max_model_len", None)
+    if not isinstance(max_model_len, int) or max_model_len <= bucket:
+        return ()
+    logger.info_once(
+        "Auto-enabling the SM70 E5M2 KV short-context decode CUDA graph "
+        "at %d tokens. This keeps the short D256 GQA graph scalar-only while "
+        "the unbounded graph retains the long-context XQA routes. Set %s "
+        "explicitly to override or to an empty value to disable.",
+        bucket,
+        env_name,
+    )
+    return (bucket,)
+
+
 class CudagraphDispatcher:
     """
     Runtime cudagraph dispatcher to dispatch keys for multiple set of
@@ -111,6 +170,9 @@ class CudagraphDispatcher:
         )
         self.sm70_dsv4_decode_context_buckets = _get_sm70_dsv4_decode_context_buckets(
             vllm_config
+        )
+        self.sm70_fp8_kv_decode_context_buckets = (
+            _get_sm70_fp8_kv_decode_context_buckets(vllm_config)
         )
         self._logged_sm70_context_bucket = False
 
@@ -248,7 +310,12 @@ class CudagraphDispatcher:
     def _active_context_buckets(self) -> tuple[int, ...]:
         if self.uniform_decode_query_len > 1:
             return self.sm70_mtp_context_buckets
-        return self.sm70_dsv4_decode_context_buckets
+        return tuple(
+            sorted(
+                set(self.sm70_dsv4_decode_context_buckets)
+                | set(self.sm70_fp8_kv_decode_context_buckets)
+            )
+        )
 
     @property
     def has_attention_context_buckets(self) -> bool:

--- a/vllm/v1/spec_decode/draft_prob_alignment.py
+++ b/vllm/v1/spec_decode/draft_prob_alignment.py
@@ -2,12 +2,13 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 from collections.abc import Sequence
+from typing import TypeAlias
 
 import torch
 
 from vllm.v1.spec_decode.metadata import SpecDecodeMetadata
 
-DraftProbTokenIds = Sequence[Sequence[int]] | torch.Tensor
+DraftProbTokenIds: TypeAlias = Sequence[Sequence[int]] | torch.Tensor
 
 
 def _assert_cached_tokens_match(
@@ -38,7 +39,7 @@ def _assert_cached_tokens_match(
 def clone_draft_prob_token_ids(
     draft_token_ids: Sequence[Sequence[int]] | torch.Tensor,
 ) -> DraftProbTokenIds:
-    if torch.is_tensor(draft_token_ids):
+    if isinstance(draft_token_ids, torch.Tensor):
         return draft_token_ids.detach().clone()
     return [list(token_ids) for token_ids in draft_token_ids]
 
@@ -70,7 +71,7 @@ def get_aligned_draft_probs(
             "Cached draft probability row count does not match request ids: "
             f"rows={draft_probs.shape[0]}, req_ids={len(draft_prob_req_ids)}."
         )
-    if torch.is_tensor(draft_prob_token_ids):
+    if isinstance(draft_prob_token_ids, torch.Tensor):
         if draft_prob_token_ids.ndim != 2:
             raise RuntimeError(
                 "Cached draft probability token ids must have shape "
@@ -126,7 +127,7 @@ def get_aligned_draft_probs(
         expected_tokens = spec_decode_metadata.draft_token_ids[
             draft_token_offset : draft_token_offset + num_draft
         ]
-        if torch.is_tensor(draft_prob_token_ids):
+        if isinstance(draft_prob_token_ids, torch.Tensor):
             if draft_prob_token_ids.shape[1] < num_draft:
                 raise RuntimeError(
                     "Cached draft probability token ids do not have enough "

--- a/vllm/v1/spec_decode/gemma4.py
+++ b/vllm/v1/spec_decode/gemma4.py
@@ -96,7 +96,9 @@ class Gemma4Proposer(SpecDecodeBaseProposer):
                 per_layer_attn_metadata[layer_name] = attn_metadata
         return per_group_attn_metadata, per_layer_attn_metadata
 
-    def _greedy_sample(self, hidden_states: torch.Tensor) -> torch.Tensor:
+    def _greedy_sample(
+        self, hidden_states: torch.Tensor, spec_step_idx: int = 0
+    ) -> torch.Tensor:
         if self._centroids_sizes:
             T = hidden_states.shape[0]
             for size in self._centroids_sizes:
@@ -105,7 +107,7 @@ class Gemma4Proposer(SpecDecodeBaseProposer):
                     self._centroids_graphs[size].replay()
                     return self._centroids_outputs[size][:T].clone()
             return self.model.get_top_tokens(hidden_states)
-        return super()._greedy_sample(hidden_states)
+        return super()._greedy_sample(hidden_states, spec_step_idx)
 
     def _setup_centroids_cuda_graphs(self) -> None:
         """Capture CUDA graphs for centroids get_top_tokens at key sizes."""

--- a/vllm/v1/spec_decode/llm_base_proposer.py
+++ b/vllm/v1/spec_decode/llm_base_proposer.py
@@ -236,6 +236,7 @@ class SpecDecodeBaseProposer:
             self.method,
             vllm_config.parallel_config.tensor_parallel_size,
             vllm_config.model_config.architecture,
+            vllm_config.model_config.model,
         )
         if draft_vocab_config.gpu_lru_enabled:
             if self.max_batch_size != 1:
@@ -2254,6 +2255,7 @@ class SpecDecodeBaseProposer:
             self.method,
             self.vllm_config.parallel_config.tensor_parallel_size,
             self.vllm_config.model_config.architecture,
+            self.vllm_config.model_config.model,
         )
         ranking_path = vocab_config.ranking_path
         shortlist_size = vocab_config.shortlist_size

--- a/vllm/v1/spec_decode/llm_base_proposer.py
+++ b/vllm/v1/spec_decode/llm_base_proposer.py
@@ -176,7 +176,9 @@ class SpecDecodeBaseProposer:
         assert vllm_config.speculative_config is not None
         self.speculative_config = vllm_config.speculative_config
         self.draft_model_config = self.speculative_config.draft_model_config
-        self.method = self.speculative_config.method
+        method = self.speculative_config.method
+        assert method is not None
+        self.method: str = method
         self.pass_hidden_states_to_model = pass_hidden_states_to_model
 
         self.device = device
@@ -357,9 +359,7 @@ class SpecDecodeBaseProposer:
             and self.speculative_config.draft_sample_method == "probabilistic"
         )
         self._last_draft_probs: torch.Tensor | None = None
-        self._static_draft_vocab: (
-            StaticDraftVocabRuntime | DynamicDraftVocabRuntime | None
-        ) = None
+        self._static_draft_vocab: StaticDraftVocabRuntime | None = None
 
         self._slot_mapping_buffer = torch.zeros(
             self.max_positions,
@@ -998,7 +998,9 @@ class SpecDecodeBaseProposer:
             self._static_draft_vocab.begin_proposal()
         batch_size = common_attn_metadata.batch_size()
         common_attn_metadata = _clone_drafter_mutable_metadata(common_attn_metadata)
-        profile_events = [] if self._sm70_mtp_profile_enabled() else None
+        profile_events: list[tuple[str, torch.cuda.Event, torch.cuda.Event]] | None = (
+            [] if self._sm70_mtp_profile_enabled() else None
+        )
         profile_cpu_ms: dict[str, float] = {}
         profile_wall_start = time.perf_counter() if profile_events is not None else 0.0
         profile_total_start = self._sm70_mtp_profile_start(profile_events)
@@ -2319,6 +2321,7 @@ class SpecDecodeBaseProposer:
         if target_lm_head is None or not hasattr(target_lm_head, "weight"):
             raise ValueError("MTP model does not expose a shared target LM-head.")
 
+        runtime: StaticDraftVocabRuntime
         if dynamic_tail_size:
             runtime = initialize_dynamic_draft_vocab(
                 target_lm_head,
@@ -2690,6 +2693,7 @@ def compute_probs_and_sample_next_token(
         top_k,
         top_p,
     ):
+        assert sampling_metadata.top_k_cpu is not None
         return _compute_sparse_topk_draft_probs_and_sample_next_token(
             logits,
             sampling_metadata,

--- a/vllm/v1/spec_decode/static_draft_vocab.py
+++ b/vllm/v1/spec_decode/static_draft_vocab.py
@@ -406,6 +406,17 @@ class DynamicDraftVocabRuntime(StaticDraftVocabRuntime):
         )
         if self.tp_group is None or any(tensor is None for tensor in tensors):
             raise RuntimeError("Dynamic fused proposal buffers are not initialized.")
+        assert self.prepared_base_weight is not None
+        assert self.fused_base_values is not None
+        assert self.fused_base_ids is not None
+        assert self.fused_tail_logits is not None
+        assert self.fused_local_pairs is not None
+        assert self.fused_gathered_pairs is not None
+        assert self.fused_sampled_tokens is not None
+        assert self.fused_sparse_ids is not None
+        assert self.fused_sparse_probs is not None
+        assert self.fused_exponentials is not None
+        assert self.fused_dense_probs is not None
 
         sm70_ops = _get_sm70_ops()
         sm70_ops.sm70_f16_lm_head_top20_tc_out(
@@ -801,7 +812,7 @@ def initialize_static_draft_vocab(
             input_split_sizes=input_splits,
             group=tp_group.device_group,
         )
-    torch.cuda.synchronize(device)
+    torch.accelerator.synchronize(device)
 
     fingerprints = payload.get("fingerprints")
     ranking_fingerprint = None
@@ -1063,5 +1074,5 @@ def initialize_dynamic_draft_vocab(
         )
     else:
         runtime._refresh_tail()
-    torch.cuda.synchronize(device)
+    torch.accelerator.synchronize(device)
     return runtime

--- a/vllm/v1/spec_decode/static_draft_vocab.py
+++ b/vllm/v1/spec_decode/static_draft_vocab.py
@@ -48,12 +48,23 @@ class MTPDraftVocabConfig:
 
 _DEFAULT_DYNAMIC_DRAFT_VOCAB_ARCHITECTURE = "Qwen3_5ForConditionalGeneration"
 _DEFAULT_DYNAMIC_DRAFT_VOCAB_TP_SIZES = frozenset((2, 4))
+_DEFAULT_DYNAMIC_DRAFT_VOCAB_MODEL_MARKER = "qwen3.6-27b"
+
+
+def _matches_default_dynamic_draft_vocab_model(
+    model_name_or_path: str | None,
+) -> bool:
+    if model_name_or_path is None:
+        return False
+    normalized = model_name_or_path.casefold().replace("_", "-")
+    return _DEFAULT_DYNAMIC_DRAFT_VOCAB_MODEL_MARKER in normalized
 
 
 def resolve_mtp_draft_vocab_config(
     method: str,
     tensor_parallel_size: int = 2,
     model_architecture: str | None = None,
+    model_name_or_path: str | None = None,
 ) -> MTPDraftVocabConfig:
     """Resolve explicit controls or the model-specific default MTP vocabulary."""
     config = MTPDraftVocabConfig(
@@ -84,6 +95,7 @@ def resolve_mtp_draft_vocab_config(
         or explicit_config
         or model_architecture != _DEFAULT_DYNAMIC_DRAFT_VOCAB_ARCHITECTURE
         or tensor_parallel_size not in _DEFAULT_DYNAMIC_DRAFT_VOCAB_TP_SIZES
+        or not _matches_default_dynamic_draft_vocab_model(model_name_or_path)
     ):
         return config
 

--- a/vllm/v1/spec_decode/step3p5.py
+++ b/vllm/v1/spec_decode/step3p5.py
@@ -305,9 +305,12 @@ class Step3p5MTPProposer(EagleProposer):
             self.build_per_group_and_layer_attn_metadata(common_attn_metadata)
         )
 
-        cudagraph_runtime_mode, num_input_tokens, num_tokens_across_dp = (
-            self._determine_batch_execution_and_padding(num_tokens)
-        )
+        (
+            cudagraph_runtime_mode,
+            num_input_tokens,
+            num_tokens_across_dp,
+            batch_descriptor,
+        ) = self._determine_batch_execution_and_padding(num_tokens)
 
         model_kwargs, slot_mapping_size = self.build_model_inputs_first_pass(
             num_tokens, num_input_tokens, mm_embed_inputs
@@ -320,6 +323,7 @@ class Step3p5MTPProposer(EagleProposer):
             num_tokens=num_input_tokens,
             num_tokens_across_dp=num_tokens_across_dp,
             cudagraph_runtime_mode=cudagraph_runtime_mode,
+            batch_descriptor=self._batch_descriptor_for_spec_step(batch_descriptor, 0),
             slot_mapping=self._get_slot_mapping(
                 slot_mapping_size, common_attn_metadata.slot_mapping
             ),
@@ -369,9 +373,12 @@ class Step3p5MTPProposer(EagleProposer):
 
         draft_token_ids_list = [draft_token_ids]
 
-        cudagraph_runtime_mode, input_batch_size, batch_size_across_dp = (
-            self._determine_batch_execution_and_padding(batch_size)
-        )
+        (
+            cudagraph_runtime_mode,
+            input_batch_size,
+            batch_size_across_dp,
+            batch_descriptor,
+        ) = self._determine_batch_execution_and_padding(batch_size)
 
         common_attn_metadata.num_actual_tokens = batch_size
         common_attn_metadata.max_query_len = 1
@@ -433,6 +440,9 @@ class Step3p5MTPProposer(EagleProposer):
                 num_tokens=input_batch_size,
                 num_tokens_across_dp=batch_size_across_dp,
                 cudagraph_runtime_mode=cudagraph_runtime_mode,
+                batch_descriptor=self._batch_descriptor_for_spec_step(
+                    batch_descriptor, spec_step_idx
+                ),
                 slot_mapping=self._get_slot_mapping(input_batch_size),
             ):
                 ret_hidden_states = self.model(**model_kwargs)

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -1363,6 +1363,7 @@ class GPUModelRunner(
             (self.speculative_config.method or "") if self.speculative_config else "",
             self.parallel_config.tensor_parallel_size,
             self.model_config.architecture,
+            self.model_config.model,
         )
         self.dynamic_draft_vocab_prefill_topk = draft_vocab_config.prefill_topk
         validate_dynamic_draft_vocab_prefill_topk(


### PR DESCRIPTION
## Purpose

Deliver one reviewable Qwen3.8-27B-FP8 SM70 release candidate against `main`. This supersedes #209 and contains both its complete adaptation stack and the later FP8-KV long-context work, so review does not depend on an unpushed worktree.

- Base SHA: `af7708366a0be39e4154a59c31f18f9c75ad7dd7`
- Head SHA: `7f409a772746ca083b51696e20c4a58d540e0298`
- Target: Python 3.12, Torch 2.10.0+cu128, CUDA 12.8, V100/SM70, TP4, CUDA graphs, Flash-V100 and TurboMind.

## Complete Change Set

- Keep CUDA builds on Torch 2.10 and report the 1Cat package version correctly from the CLI.
- Admit Qwen3.8 release paths, stabilize SM70 CUDA-graph startup, isolate its static draft vocabulary, and package FlashQLA so wheel users do not require a runtime NVCC build.
- Recover long-prefill FP8 projection throughput with bounded exact-dense SM70 dispatch and graph-safe reusable workspaces.
- Preserve the historical V100 contract that user-facing `--kv-cache-dtype fp8` means E5M2 on SM70 Flash-V100; explicit `fp8_e4m3` remains E4M3. Weight quantization and KV dtype remain independent.
- Add an exact native FP16-to-E5M2 unit-scale cache writer and right-size its launch for small GQA decode shapes.
- Route E5M2 prefix prefill through one-pass dequantization plus the exact D256 dense attention path, including aligned tail padding and OOM fallback.
- Add the shape-derived E5M2 G6 decode route: short scalar boundary, p256/p1024 device-side selection, partition-page reuse, paired E5M2 loads, split reduction, and a short-context CUDA-graph bucket.
- Coordinate FP8 tuning across TP ranks by exporting rank 0's shape LUT and importing it before each rank's execution warmup.
- Extend benchmark provenance, multi-length prompt sweeps, FP8 route coverage, cache-write microbenchmarks, policy tests, and the retained optimization record.

## Test Plan

- Run all pre-commit hooks over the 17-file FP8-KV follow-up set.
- Run focused policy, CUDA graph, coordinated warmup, and exhaustive E5M2 conversion tests.
- Compare E5M2 XQA against scalar decode at every route boundary through 256K.
- Preserve the full-model Qwen3.8 acceptance gates from #209: no-MTP, MTP4, FP16/FP8 KV, exact 256K, tool calls, prefix caching, long output, and concurrency 1/2/4/8/16.
- Review the remaining MTP-prefill overhead separately; this PR does not claim that later optimization is solved.

## Test Result

- Changed-file pre-commit: all hooks passed, including Ruff, clang-format, Markdown, mypy, SPDX, config validation, and the accelerator-API gate.
- Focused pytest: `107 passed` for SM70 attention policy, CUDA-graph dispatch, and coordinated warmup.
- Exhaustive native cache conversion: `1 passed`; all 65,536 FP16 bit patterns match the E5M2 SATFINITE round-to-nearest-even oracle.
- E5M2 G6 XQA/scalar boundary sweep passed at 8,192, 16,384, 61,632, 61,633, 81,920, 131,072, and 262,144 tokens. Maximum absolute difference was `3.0517578125e-05`; all later long-context rows were at or below `1.52587890625e-05`.
- Latest same-source no-MTP E5M2 sweep with chunk 8,192: prefill `3654/4680/4718/4509/4176/3631/2883/2056 tok/s` at 1K/4K/8K/16K/32K/64K/128K/256K; valid measured decode rows were `62.40/63.14/62.80/62.04/54.83/50.68/41.11 tok/s` (32K stopped after two official-sampling tokens and is not used as a decode baseline).
- Previously accepted exact-dense projection gains retained from #209: +22.36% at 32K, +12.94% at 128K, and +7.25% at 256K with matching output hashes.
- Previously accepted concurrency retained from #209: C1/C2/C4/C8/C16 output throughput `60.44/108.72/192.39/309.70/412.35 tok/s`, with all 64 requests successful per row.

## Quality And Risk

- Official model sampling is used for full-model acceptance; short natural EOS rows are marked invalid instead of using `ignore_eos`.
- E5M2 decode defaults are constrained by SM70, D256, GQA group 6/8, KV dtype, page layout, and environment rollback gates.
- The prefix bridge returns to the paged implementation when its reusable workspace cannot be allocated.
- MTP4 decode remains accepted, but MTP causes additional chunked-prefill overhead. The current root-cause trace points to the target GDN verifier boundary and repeated MTP prefill work; that follow-up is intentionally not hidden in this PR.
- Qwen3.6-35B-A3B-AWQ TP2 compatibility from #209 remains `95.63 tok/s` at 1K/256 and `95.29 tok/s` at 4K/1024. No local 35B FP8 checkpoint was available for that required speed gate.

## Evidence

- `docs/design/sm70_qwen38_130_acceptance.md`
- `docs/design/sm70_fp8_long_prefill_exact_dense.md`
- `docs/design/sm70_qwen38_fp8_prefill_decay.md`
- Retained boundary artifact: `pr-audit-e5m2-xqa-boundaries.json` in the task-local result directory.

Supersedes #209.