### PR TITLE
[Rejected] Qwen MTP chunked prefill fusion

### DIFF
--- a/docs/design/sm70_qwen38_130_acceptance.md
+++ b/docs/design/sm70_qwen38_130_acceptance.md
@@ -108,6 +108,40 @@ issue, not an idle-GPU or missing graph-shape issue.
   follows the final four-line instruction, emits no replacement characters,
   and stops naturally after 47 tokens.
 
+## MTP Chunked-Prefill Recovery
+
+The 2026-08-16 follow-up keeps the opaque GDN full-forward boundary for the
+MTP verifier and decode, but gives unfinished chunked-prefill batches a
+separate compiled standard-GDN entry. This lets MTP prefill use the later FP8
+exact-dense projection route without specializing the verifier graph on a
+Python route flag. The default can be disabled with
+`VLLM_SM70_MTP_PREFILL_STANDARD_GDN=0`.
+
+The release MTP4 FP8-KV 64K cold request took 32.269 s, or about 2031 prompt
+tok/s. On the current TP4 candidate, a 65517-token official-chat request took
+25.008 s while paying the first `postprocess_mamba_fused_kernel` JIT. After one
+warmup and a successful prefix/Mamba cache reset, measured prefill was
+24.429 s, or 2682 prompt tok/s. This is 22.5%-24.3% lower prefill latency and
+29.0%-32.1% higher throughput than the retained release MTP cold request. It
+also exceeds the retained 64K no-MTP FP8-KV result of 2063.4 tok/s by 30.0%.
+
+Runtime logs confirm the standard-GDN entry only for discarded partial
+prefill chunks, the full-forward route for verifier/decode, FP8 exact-dense
+prefill, Flash-V100 E5M2 prefill/decode, and MTP4 XQA. The measured request
+naturally stopped after 406 tokens under official sampling. Its complete text
+is coherent, contains all three long-context sentinel values, has no repeated
+or malformed spans, and exactly matches the warmup output. Acceptance length
+was 2.632 for this prompt; it is content-specific and is not compared with the
+older synthetic long-sweep acceptance result.
+
+Candidate artifacts are under
+`/data/minimax-h3/task-cache/qwen38-mtp-prefill-fastpath-20260816/`; the
+measured JSON is
+`results/qwen38-27b-fp8-mtp4-candidate-tp4-e5m2-64k-o512-warm.json` and the
+full route log is the corresponding file under `logs/`. The retained release
+control is `mtp/mtp4-dynamic-fp8kv-long-sweep.json` under the 1.3.0 acceptance
+artifact root.
+
 ## Wheel And Compatibility
 
 - Wheel: `1cat_vllm-1.3.0-cp312-cp312-linux_x86_64.whl`.

--- a/tests/model_executor/test_qwen3_5_quantization.py
+++ b/tests/model_executor/test_qwen3_5_quantization.py
@@ -3,11 +3,32 @@
 
 from unittest.mock import Mock, patch
 
+from torch import nn
+
 
 class _QuantConfig:
     def __init__(self) -> None:
         self.ignore: list[str] = []
         self.config: dict[str, object] = {}
+
+
+def test_qwen3_5_mtp_prefill_model_selection_is_explicit():
+    from vllm.model_executor.models.qwen3_5 import (
+        _select_sm70_mtp_prefill_model,
+    )
+
+    default_model = nn.Identity()
+    prefill_model = nn.ReLU()
+
+    assert (
+        _select_sm70_mtp_prefill_model(default_model, prefill_model, True)
+        is prefill_model
+    )
+    assert (
+        _select_sm70_mtp_prefill_model(default_model, prefill_model, False)
+        is default_model
+    )
+    assert _select_sm70_mtp_prefill_model(default_model, None, True) is default_model
 
 
 def test_qwen3_5_split_gdn_detects_compressed_tensors_ignore():

--- a/tests/v1/attention/test_gdn_metadata_builder.py
+++ b/tests/v1/attention/test_gdn_metadata_builder.py
@@ -1008,6 +1008,86 @@ def test_sm70_qwen_gdn_full_forward_auto_is_mtp_engine_scoped(
 
 
 @pytest.mark.parametrize(
+    ("requested", "force_full_forward", "auto_full_forward", "expected"),
+    [
+        (True, False, True, True),
+        (False, False, True, False),
+        (True, True, True, False),
+        (True, False, False, False),
+    ],
+)
+def test_sm70_qwen_gdn_standard_prefill_only_bypasses_auto_guard(
+    requested,
+    force_full_forward,
+    auto_full_forward,
+    expected,
+):
+    assert (
+        qwen_gdn._sm70_qwen_gdn_standard_prefill_enabled(
+            requested=requested,
+            force_full_forward=force_full_forward,
+            auto_full_forward=auto_full_forward,
+        )
+        is expected
+    )
+
+
+@pytest.mark.parametrize(
+    ("requested", "force_full_forward", "expected_route"),
+    [
+        (True, False, "standard"),
+        (False, False, "full"),
+        (True, True, "full"),
+    ],
+)
+def test_sm70_qwen_gdn_standard_prefill_forward_route(
+    monkeypatch,
+    requested,
+    force_full_forward,
+    expected_route,
+):
+    calls: list[str] = []
+
+    class FakeAttention:
+        prefix = "layer.0.linear_attn"
+        maybe_sm70_qwen_gdn_full_forward = True
+        disable_sm70_qwen_gdn_full_forward = False
+        auto_sm70_qwen_gdn_full_forward = True
+        force_sm70_qwen_gdn_full_forward = force_full_forward
+
+        def _forward_method(self, hidden_states, output):
+            del hidden_states, output
+            calls.append("standard")
+
+    empty_cache = torch.empty(0)
+    monkeypatch.setattr(
+        qwen_gdn,
+        "_resolve_qwen_gdn_kv_cache_args",
+        lambda *args, **kwargs: (empty_cache, empty_cache),
+    )
+
+    def fake_full_forward(*args, **kwargs):
+        del args, kwargs
+        calls.append("full")
+
+    monkeypatch.setattr(
+        torch.ops.vllm,
+        "qwen_gdn_full_forward",
+        fake_full_forward,
+        raising=False,
+    )
+
+    qwen_gdn.QwenGatedDeltaNetAttention.forward(
+        FakeAttention(),
+        torch.zeros(2, 4),
+        torch.empty(2, 4),
+        sm70_mtp_prefill_standard_gdn=requested,
+    )
+
+    assert calls == [expected_route]
+
+
+@pytest.mark.parametrize(
     ("method", "num_speculative_tokens", "expected"),
     [
         ("mtp", 2, False),

--- a/tests/v1/worker/test_gpu_model_runner.py
+++ b/tests/v1/worker/test_gpu_model_runner.py
@@ -51,6 +51,39 @@ NUM_BLOCKS = 10
 DEVICE_TYPE = current_platform.device_type
 
 
+@pytest.mark.parametrize(
+    ("enabled", "has_spec", "model_supports", "partial_prefill", "expected"),
+    [
+        (True, True, True, True, True),
+        (False, True, True, True, False),
+        (True, False, True, True, False),
+        (True, True, False, True, False),
+        (True, True, True, False, False),
+    ],
+)
+def test_sm70_mtp_standard_gdn_requires_pure_partial_prefill(
+    monkeypatch,
+    enabled,
+    has_spec,
+    model_supports,
+    partial_prefill,
+    expected,
+):
+    monkeypatch.setattr(
+        gpu_model_runner_module.envs,
+        "VLLM_SM70_MTP_PREFILL_STANDARD_GDN",
+        enabled,
+        raising=False,
+    )
+    runner = SimpleNamespace(
+        speculative_config=object() if has_spec else None,
+        model=SimpleNamespace(supports_sm70_mtp_prefill_standard_gdn=model_supports),
+        _is_all_reqs_chunked_prefill=lambda: partial_prefill,
+    )
+
+    assert GPUModelRunner._use_sm70_mtp_prefill_standard_gdn(runner) is expected
+
+
 def initialize_kv_cache(runner: GPUModelRunner):
     """
     Only perform necessary steps in GPUModelRunner.initialize_kv_cache()

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -435,6 +435,7 @@ if TYPE_CHECKING:
     VLLM_SM70_QWEN_GDN_CONTEXT_CORE: bool = False
     VLLM_SM70_QWEN_GDN_FULL_FORWARD: bool = False
     VLLM_SM70_QWEN_GDN_DISABLE_FULL_FORWARD: bool = False
+    VLLM_SM70_MTP_PREFILL_STANDARD_GDN: bool = True
     VLLM_SM70_QWEN_GDN_SPEC_DECODE_PIECEWISE: bool = False
     VLLM_SM70_QWEN_GDN_SPEC_CORE_OP: bool = False
     VLLM_SM70_QWEN_GDN_003_SPEC_CORE_OP: bool = False
@@ -2625,6 +2626,13 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # boundary against the default full-forward quality guard.
     "VLLM_SM70_QWEN_GDN_DISABLE_FULL_FORWARD": lambda: bool(
         int(os.getenv("VLLM_SM70_QWEN_GDN_DISABLE_FULL_FORWARD", "0"))
+    ),
+    # Keep the opaque full-forward boundary for MTP verifier/decode quality,
+    # but let unfinished chunked-prefill batches use the regular compiled GDN
+    # path. Their sampled output is discarded and they have no active spec
+    # rows, so the verifier-specific boundary only blocks prefill fusion.
+    "VLLM_SM70_MTP_PREFILL_STANDARD_GDN": lambda: bool(
+        int(os.getenv("VLLM_SM70_MTP_PREFILL_STANDARD_GDN", "1"))
     ),
     # Experimental active-MTP quality/speed lane: keep the SM70 0.0.3
     # FULL_AND_PIECEWISE compile policy, but skip FULL cudagraph replay for

--- a/vllm/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py
+++ b/vllm/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py
@@ -612,6 +612,20 @@ def _sm70_qwen_gdn_full_forward_enabled(
     return auto_enabled
 
 
+def _sm70_qwen_gdn_standard_prefill_enabled(
+    *,
+    requested: bool,
+    force_full_forward: bool,
+    auto_full_forward: bool,
+) -> bool:
+    """Allow pure partial prefill to bypass the automatic MTP guard.
+
+    An explicit full-forward request remains authoritative. The bypass is only
+    meaningful when speculative decoding automatically armed the guard.
+    """
+    return requested and auto_full_forward and not force_full_forward
+
+
 def _sm70_qwen_gdn_input_core_boundary_enabled() -> bool:
     if envs.VLLM_SM70_QWEN_GDN_DISABLE_INPUT_CORE_OP:
         return False
@@ -3561,8 +3575,14 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
         self,
         hidden_states: torch.Tensor,
         output: torch.Tensor,
+        sm70_mtp_prefill_standard_gdn: bool = False,
     ):
-        if self.maybe_sm70_qwen_gdn_full_forward:
+        use_standard_prefill = _sm70_qwen_gdn_standard_prefill_enabled(
+            requested=sm70_mtp_prefill_standard_gdn,
+            force_full_forward=self.force_sm70_qwen_gdn_full_forward,
+            auto_full_forward=self.auto_sm70_qwen_gdn_full_forward,
+        )
+        if self.maybe_sm70_qwen_gdn_full_forward and not use_standard_prefill:
             layer_name = _encode_layer_name(self.prefix)
             if _sm70_qwen_gdn_full_forward_enabled(
                 layer_name,

--- a/vllm/model_executor/models/qwen3_5.py
+++ b/vllm/model_executor/models/qwen3_5.py
@@ -655,6 +655,54 @@ class Qwen3_5Model(Qwen3NextModel):
         return loaded_params
 
 
+@support_torch_compile(
+    dynamic_arg_dims={
+        "input_ids": 0,
+        "positions": -1,
+        "intermediate_tensors": 0,
+        "inputs_embeds": 0,
+    }
+)
+class _Qwen3_5MTPPrefillModel(nn.Module):
+    """Second compile entry sharing the target model's modules and caches."""
+
+    def __init__(
+        self,
+        model: Qwen3_5Model,
+        *,
+        vllm_config: VllmConfig,
+        prefix: str = "",
+    ) -> None:
+        super().__init__()
+        del vllm_config, prefix
+        self.shared_model = model
+
+    def forward(
+        self,
+        input_ids: torch.Tensor | None,
+        positions: torch.Tensor,
+        intermediate_tensors: IntermediateTensors | None = None,
+        inputs_embeds: torch.Tensor | None = None,
+    ) -> torch.Tensor | IntermediateTensors | tuple[torch.Tensor, list[torch.Tensor]]:
+        return self.shared_model.forward(
+            input_ids=input_ids,
+            positions=positions,
+            intermediate_tensors=intermediate_tensors,
+            inputs_embeds=inputs_embeds,
+            sm70_mtp_prefill_standard_gdn=True,
+        )
+
+
+def _select_sm70_mtp_prefill_model(
+    default_model: nn.Module,
+    prefill_model: nn.Module | None,
+    requested: bool,
+) -> nn.Module:
+    if requested and prefill_model is not None:
+        return prefill_model
+    return default_model
+
+
 class Qwen3_5ForCausalLMBase(
     nn.Module,
     HasInnerState,
@@ -694,6 +742,28 @@ class Qwen3_5ForCausalLMBase(
         self.model = Qwen3_5Model(
             vllm_config=vllm_config, prefix=maybe_prefix(prefix, "model")
         )
+        prefill_model = None
+        if (
+            envs.VLLM_SM70_MTP_PREFILL_STANDARD_GDN
+            and not envs.VLLM_SM70_QWEN_GDN_FULL_FORWARD
+            and not envs.VLLM_SM70_QWEN_GDN_DISABLE_FULL_FORWARD
+            and vllm_config.speculative_config is not None
+            and envs.VLLM_SM70_FLASH_V100_0DOT3_COMPILE_GRAPH
+        ):
+            prefill_model = _Qwen3_5MTPPrefillModel(
+                self.model,
+                vllm_config=vllm_config,
+                prefix=maybe_prefix(prefix, "mtp_prefill_model"),
+            )
+        # Keep the shared compile entry out of the module tree so state_dict and
+        # weight loading visit the target parameters exactly once.
+        object.__setattr__(self, "_sm70_mtp_prefill_model", prefill_model)
+        self.supports_sm70_mtp_prefill_standard_gdn = prefill_model is not None
+        if prefill_model is not None:
+            logger.info_once(
+                "SM70 MTP target has a separate compiled standard-GDN "
+                "entry for unfinished chunked prefill."
+            )
 
         if get_pp_group().is_last_rank:
             if config.tie_word_embeddings:
@@ -731,7 +801,13 @@ class Qwen3_5ForCausalLMBase(
         inputs_embeds: torch.Tensor | None = None,
         **kwargs: object,
     ):
-        hidden_states = self.model(
+        use_standard_prefill = bool(kwargs.pop("sm70_mtp_prefill_standard_gdn", False))
+        model = _select_sm70_mtp_prefill_model(
+            self.model,
+            self._sm70_mtp_prefill_model,
+            use_standard_prefill,
+        )
+        hidden_states = model(
             input_ids,
             positions,
             intermediate_tensors,
@@ -851,6 +927,9 @@ class Qwen3_5ForConditionalGeneration(Qwen3VLForConditionalGeneration, IsHybrid)
             self.language_model = Qwen3_5ForCausalLM(
                 vllm_config=vllm_config, prefix=maybe_prefix(prefix, "language_model")
             )
+        self.supports_sm70_mtp_prefill_standard_gdn = (
+            self.language_model.supports_sm70_mtp_prefill_standard_gdn
+        )
 
         self.make_empty_intermediate_tensors = (
             self.language_model.make_empty_intermediate_tensors
@@ -923,7 +1002,13 @@ class Qwen3_5ForConditionalGeneration(Qwen3VLForConditionalGeneration, IsHybrid)
         if intermediate_tensors is not None:
             inputs_embeds = None
 
-        hidden_states = self.language_model.model(
+        use_standard_prefill = bool(kwargs.pop("sm70_mtp_prefill_standard_gdn", False))
+        model = _select_sm70_mtp_prefill_model(
+            self.language_model.model,
+            self.language_model._sm70_mtp_prefill_model,
+            use_standard_prefill,
+        )
+        hidden_states = model(
             input_ids=input_ids,
             positions=positions,
             intermediate_tensors=intermediate_tensors,

--- a/vllm/model_executor/models/qwen3_next.py
+++ b/vllm/model_executor/models/qwen3_next.py
@@ -749,6 +749,9 @@ class Qwen3NextDecoderLayer(nn.Module):
             self.linear_attn(
                 hidden_states=hidden_states,
                 output=self_attention_output,
+                sm70_mtp_prefill_standard_gdn=bool(
+                    kwargs.get("sm70_mtp_prefill_standard_gdn", False)
+                ),
             )
         elif self.layer_type == "full_attention":
             self.self_attn(
@@ -866,6 +869,7 @@ class Qwen3NextModel(nn.Module, EagleModelMixin):
         positions: torch.Tensor,
         intermediate_tensors: IntermediateTensors | None = None,
         inputs_embeds: torch.Tensor | None = None,
+        sm70_mtp_prefill_standard_gdn: bool = False,
     ) -> torch.Tensor | IntermediateTensors | tuple[torch.Tensor, list[torch.Tensor]]:
         if self.is_pp_first_rank:
             if inputs_embeds is not None:
@@ -904,6 +908,7 @@ class Qwen3NextModel(nn.Module, EagleModelMixin):
                 positions=positions,
                 hidden_states=hidden_states,
                 residual=residual,
+                sm70_mtp_prefill_standard_gdn=sm70_mtp_prefill_standard_gdn,
             )
             if trace_enabled:
                 _sm70_profile_trace(

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -56,6 +56,7 @@ from vllm.distributed.parallel_state import (
 )
 from vllm.forward_context import (
     BatchDescriptor,
+    get_forward_context,
     set_forward_context,
 )
 from vllm.logger import init_logger
@@ -8000,6 +8001,20 @@ class GPUModelRunner(
         num_reqs = self.input_batch.num_reqs
         return bool(self.discard_request_mask.np[:num_reqs].all())
 
+    def _use_sm70_mtp_prefill_standard_gdn(self) -> bool:
+        enabled = bool(
+            envs.VLLM_SM70_MTP_PREFILL_STANDARD_GDN
+            and self.speculative_config is not None
+            and getattr(self.model, "supports_sm70_mtp_prefill_standard_gdn", False)
+            and self._is_all_reqs_chunked_prefill()
+        )
+        if enabled:
+            logger.info_once(
+                "SM70 MTP target is using the standard-GDN compile entry for "
+                "unfinished chunked prefill."
+            )
+        return enabled
+
     @torch.inference_mode()
     def execute_model(
         self,
@@ -8288,6 +8303,10 @@ class GPUModelRunner(
             ) = self._preprocess(
                 scheduler_output, num_tokens_padded, intermediate_tensors
             )
+            if getattr(self.model, "supports_sm70_mtp_prefill_standard_gdn", False):
+                model_kwargs["sm70_mtp_prefill_standard_gdn"] = (
+                    self._use_sm70_mtp_prefill_standard_gdn()
+                )
             if trace_log:
                 trace_model_preprocess_ms = (
                     time.perf_counter() - trace_model_preprocess_t0
@@ -10573,6 +10592,35 @@ class GPUModelRunner(
                     type(attn_metadata).__name__ if attn_metadata is not None else None,
                     skip_compiled_profile,
                 )
+                if (
+                    is_profile
+                    and getattr(
+                        self.model,
+                        "supports_sm70_mtp_prefill_standard_gdn",
+                        False,
+                    )
+                    and envs.VLLM_SM70_MTP_PREFILL_STANDARD_GDN
+                ):
+                    logger.info_once(
+                        "Compiling the SM70 MTP standard-GDN prefill entry "
+                        "during memory profiling."
+                    )
+                    model_kwargs["sm70_mtp_prefill_standard_gdn"] = True
+                    forward_context = get_forward_context()
+                    previous_skip_compiled = forward_context.skip_compiled
+                    forward_context.skip_compiled = False
+                    try:
+                        prefill_outputs = self.model(
+                            input_ids=input_ids,
+                            positions=positions,
+                            intermediate_tensors=intermediate_tensors,
+                            inputs_embeds=inputs_embeds,
+                            **model_kwargs,
+                        )
+                    finally:
+                        forward_context.skip_compiled = previous_skip_compiled
+                    del prefill_outputs
+                    model_kwargs.pop("sm70_mtp_prefill_standard_gdn")
                 outputs = self.model(
                     input_ids=input_ids,
                     positions=positions,


### PR DESCRIPTION
## Status

**Closed and reverted.** The original performance conclusion was invalid because it compared the candidate with a stale release cold-path artifact instead of the retained current-task MTP baseline.

## Corrected Evidence

Contract: Qwen3.8-27B-FP8, TP4, FP8 E5M2 KV, chunk 8192, Flash-V100, prefix cache reset between measured cases.

- Retained no-MTP chunk-8192 artifact:
  - 4K: 3858.37 prompt tok/s
  - 16K: 4068.07 prompt tok/s
  - 64K: 3368.33 prompt tok/s
  - 128K: 2632.44 prompt tok/s
  - Artifact: /data/minimax-h3/task-cache/qwen38-fp8-prefill-decay-20260815/results/e5m2-kv-chunk8192-tp4.json
- Retained MTP4 artifact:
  - 4K: 3592.72 prompt tok/s
  - 16K: 3691.16 prompt tok/s
  - 64K: 2950.55 prompt tok/s
  - Independent 64K profile: 2945.25 prompt tok/s
  - Artifacts:
    - /data/minimax-h3/task-cache/qwen38-fp8-prefill-decay-20260815/results/mtp4-latest-r6-e5m2-tp4-1k-256k-o128-quality.json
    - /data/minimax-h3/task-cache/qwen38-fp8-prefill-decay-20260815/results/mtp4-prefill-profile-e5m2-tp4-8k-64k.json

The candidate measured 2682 prompt tok/s at about 64K. That is about 9.1% below the retained 2950.55 tok/s MTP4 result, so it does not establish a speedup. The prior claim of +29.0% to +32.1% is retracted.

The historical artifacts did not capture an immutable source SHA, so they are valid for recovering the previous reported baseline but not for attributing an isolated source-code delta. A future optimization must use a same-SHA A/B or explicitly recorded control SHA.

## Validation Retained

The candidate route and output-quality checks passed, but route correctness is not a performance win. The implementation and documentation commits were reverted in 24e779d90e and 60648b36a1.