### PR TITLE
[Bugfix] Harden SM70 output quality gates

### DIFF
--- a/benchmarks/benchmark_sm70_serving_quality.py
+++ b/benchmarks/benchmark_sm70_serving_quality.py
@@ -32,6 +32,7 @@ from benchmark_sm70_model_tokens import (
     _sm70_turbomind_policy,
     _tracked_env,
 )
+from run_sm70_release_matrix import _fixed_quality_contract_failures
 
 DEFAULT_PROMPTS = [
     "Write one sentence about deterministic validation.",
@@ -51,10 +52,12 @@ def _load_prompts(args: argparse.Namespace) -> list[dict[str, str]]:
             )
         for index, item in enumerate(loaded):
             if isinstance(item, str):
-                prompts.append({
-                    "id": f"external_{index + 1:02d}",
-                    "content": item,
-                })
+                prompts.append(
+                    {
+                        "id": f"external_{index + 1:02d}",
+                        "content": item,
+                    }
+                )
             elif isinstance(item, dict):
                 raw_content = item.get("content", item.get("prompt"))
                 if not isinstance(raw_content, str):
@@ -62,10 +65,12 @@ def _load_prompts(args: argparse.Namespace) -> list[dict[str, str]]:
                         "--prompts-json dict entries require string "
                         "'content' or 'prompt'"
                     )
-                prompts.append({
-                    "id": str(item.get("id", f"external_{index + 1:02d}")),
-                    "content": raw_content,
-                })
+                prompts.append(
+                    {
+                        "id": str(item.get("id", f"external_{index + 1:02d}")),
+                        "content": raw_content,
+                    }
+                )
             else:
                 raise TypeError("--prompts-json entries must be strings or objects")
     if not prompts:
@@ -147,27 +152,24 @@ def _collect_serving_counters(metrics_text: str) -> dict[str, float]:
     return counters
 
 
-def _metrics_snapshot(metrics_url: str | None,
-                      timeout: float) -> dict[str, float] | None:
+def _metrics_snapshot(
+    metrics_url: str | None, timeout: float
+) -> dict[str, float] | None:
     if metrics_url is None:
         return None
     return _collect_serving_counters(_get_text(metrics_url, timeout))
 
 
-def _counter_delta(before: dict[str, float] | None,
-                   after: dict[str, float] | None) -> dict[str, Any] | None:
+def _counter_delta(
+    before: dict[str, float] | None, after: dict[str, float] | None
+) -> dict[str, Any] | None:
     if before is None or after is None:
         return None
     keys = sorted(set(before) | set(after))
-    delta = {
-        key: after.get(key, 0.0) - before.get(key, 0.0)
-        for key in keys
-    }
+    delta = {key: after.get(key, 0.0) - before.get(key, 0.0) for key in keys}
     drafts = delta.get("vllm:spec_decode_num_drafts_total", 0.0)
     draft_tokens = delta.get("vllm:spec_decode_num_draft_tokens_total", 0.0)
-    accepted_tokens = delta.get(
-        "vllm:spec_decode_num_accepted_tokens_total", 0.0
-    )
+    accepted_tokens = delta.get("vllm:spec_decode_num_accepted_tokens_total", 0.0)
     generation_tokens = delta.get("vllm:generation_tokens_total", 0.0)
     prompt_tokens = delta.get("vllm:prompt_tokens_total", 0.0)
     per_position = [
@@ -275,8 +277,14 @@ def _max_repeated_window(text: str, width: int) -> int:
         return 0
     counts: dict[str, int] = {}
     for idx in range(0, len(normalized) - width + 1):
-        window = normalized[idx:idx + width]
+        window = normalized[idx : idx + width]
         if len(window.strip()) < width // 2:
+            continue
+        # Homogeneous runs are checked independently by
+        # _longest_same_char_run. Counting their overlapping windows makes
+        # ordinary code separators such as "=====" look quadratically
+        # repetitive.
+        if len(set(window)) == 1:
             continue
         counts[window] = counts.get(window, 0) + 1
     return max(counts.values(), default=0)
@@ -299,9 +307,9 @@ def _max_same_line_run(text: str) -> int:
     return best
 
 
-def _quality_metrics(text: str | None,
-                     raw_token_ids: Any,
-                     completion_tokens: Any = None) -> dict[str, Any]:
+def _quality_metrics(
+    text: str | None, raw_token_ids: Any, completion_tokens: Any = None
+) -> dict[str, Any]:
     text = text or ""
     token_ids = [int(token_id) for token_id in (raw_token_ids or [])]
     if token_ids:
@@ -361,8 +369,9 @@ def _quality_metrics(text: str | None,
     return metrics
 
 
-def _summarize_tps(records: list[dict[str, Any]],
-                   elapsed_seconds: float) -> dict[str, Any]:
+def _summarize_tps(
+    records: list[dict[str, Any]], elapsed_seconds: float
+) -> dict[str, Any]:
     completion_tokens = [
         int(record["timing"]["completion_tokens"]) for record in records
     ]
@@ -381,27 +390,28 @@ def _summarize_tps(records: list[dict[str, Any]],
     if request_tps:
         sorted_tps = sorted(request_tps)
         p90_index = min(len(sorted_tps) - 1, math.ceil(0.9 * len(sorted_tps)) - 1)
-        summary.update({
-            "request_tps_min": min(request_tps),
-            "request_tps_mean": statistics.fmean(request_tps),
-            "request_tps_median": statistics.median(request_tps),
-            "request_tps_p90": sorted_tps[p90_index],
-            "request_tps_max": max(request_tps),
-        })
+        summary.update(
+            {
+                "request_tps_min": min(request_tps),
+                "request_tps_mean": statistics.fmean(request_tps),
+                "request_tps_median": statistics.median(request_tps),
+                "request_tps_p90": sorted_tps[p90_index],
+                "request_tps_max": max(request_tps),
+            }
+        )
     return summary
 
 
 def _summarize_spec_metrics(records: list[dict[str, Any]]) -> dict[str, Any] | None:
     per_request = [
-        record.get("serving_metrics_delta") for record in records
+        record.get("serving_metrics_delta")
+        for record in records
         if record.get("serving_metrics_delta") is not None
     ]
     if not per_request:
         return None
     total_drafts = sum(float(item["num_drafts"]) for item in per_request)
-    total_draft_tokens = sum(
-        float(item["num_draft_tokens"]) for item in per_request
-    )
+    total_draft_tokens = sum(float(item["num_draft_tokens"]) for item in per_request)
     total_accepted_tokens = sum(
         float(item["num_accepted_tokens"]) for item in per_request
     )
@@ -417,17 +427,16 @@ def _summarize_spec_metrics(records: list[dict[str, Any]]) -> dict[str, Any] | N
             total_accepted_tokens / total_drafts if total_drafts > 0 else None
         ),
         "mean_acceptance_length": (
-            1.0 + total_accepted_tokens / total_drafts
-            if total_drafts > 0 else None
+            1.0 + total_accepted_tokens / total_drafts if total_drafts > 0 else None
         ),
         "draft_acceptance_rate": (
             total_accepted_tokens / total_draft_tokens
-            if total_draft_tokens > 0 else None
+            if total_draft_tokens > 0
+            else None
         ),
         "accepted_tokens_per_pos": per_position,
         "per_position_acceptance_rate": [
-            value / total_drafts if total_drafts > 0 else None
-            for value in per_position
+            value / total_drafts if total_drafts > 0 else None for value in per_position
         ],
     }
 
@@ -456,18 +465,22 @@ def _dump(args: argparse.Namespace) -> int:
             "stream": False,
         }
         if args.endpoint == "chat":
-            payload["messages"] = [{
-                "role": "user",
-                "content": prompt["content"],
-            }]
+            payload["messages"] = [
+                {
+                    "role": "user",
+                    "content": prompt["content"],
+                }
+            ]
         else:
-            payload.update({
-                "prompt": prompt["content"],
-                "logprobs": args.logprobs,
-                "return_token_ids": True,
-                "return_tokens_as_token_ids": True,
-                "prompt_logprobs": args.prompt_logprobs,
-            })
+            payload.update(
+                {
+                    "prompt": prompt["content"],
+                    "logprobs": args.logprobs,
+                    "return_token_ids": True,
+                    "return_tokens_as_token_ids": True,
+                    "prompt_logprobs": args.prompt_logprobs,
+                }
+            )
         if args.seed is not None:
             payload["seed"] = args.seed
         if args.top_k is not None:
@@ -482,35 +495,49 @@ def _dump(args: argparse.Namespace) -> int:
         choice = _extract_choice(response)
         usage = response.get("usage") or {}
         completion_tokens = int(
-            usage.get("completion_tokens")
-            or len(choice.get("token_ids") or [])
+            usage.get("completion_tokens") or len(choice.get("token_ids") or [])
         )
         prompt_tokens = usage.get("prompt_tokens")
         total_tokens = usage.get("total_tokens")
         completion_tps = (
             completion_tokens / request_elapsed if request_elapsed > 0 else None
         )
-        records.append({
-            "index": index,
-            "id": prompt["id"],
-            "prompt": prompt["content"],
-            "request": payload,
-            "response": response,
-            "choice": choice,
-            "timing": {
-                "elapsed_seconds": request_elapsed,
-                "completion_tokens": completion_tokens,
-                "prompt_tokens": prompt_tokens,
-                "total_tokens": total_tokens,
-                "completion_tokens_per_second": completion_tps,
-            },
-            "serving_metrics_delta": _counter_delta(metrics_before, metrics_after),
-            "metrics": _quality_metrics(
-                choice.get("text"),
-                choice.get("token_ids"),
-                completion_tokens,
-            ),
-        })
+        quality_metrics = _quality_metrics(
+            choice.get("text"),
+            choice.get("token_ids"),
+            completion_tokens,
+        )
+        if args.require_fixed_quality_contract:
+            quality_metrics["failures"].extend(
+                _fixed_quality_contract_failures(
+                    prompt["id"],
+                    choice.get("text") or "",
+                    choice.get("finish_reason") or "",
+                )
+            )
+            quality_metrics["failures"] = list(
+                dict.fromkeys(quality_metrics["failures"])
+            )
+            quality_metrics["passed"] = not quality_metrics["failures"]
+        records.append(
+            {
+                "index": index,
+                "id": prompt["id"],
+                "prompt": prompt["content"],
+                "request": payload,
+                "response": response,
+                "choice": choice,
+                "timing": {
+                    "elapsed_seconds": request_elapsed,
+                    "completion_tokens": completion_tokens,
+                    "prompt_tokens": prompt_tokens,
+                    "total_tokens": total_tokens,
+                    "completion_tokens_per_second": completion_tps,
+                },
+                "serving_metrics_delta": _counter_delta(metrics_before, metrics_after),
+                "metrics": quality_metrics,
+            }
+        )
     elapsed = time.perf_counter() - start
     quality_passed = all(record["metrics"]["passed"] for record in records)
     throughput_summary = _summarize_tps(records, elapsed)
@@ -561,10 +588,15 @@ def _dump(args: argparse.Namespace) -> int:
         "records": records,
     }
     args.out.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
-    print(json.dumps({k: v for k, v in payload.items() if k != "records"},
-                     indent=2,
-                     sort_keys=True))
-    return 0 if quality_passed or not args.require_quality_gate else 2
+    print(
+        json.dumps(
+            {k: v for k, v in payload.items() if k != "records"},
+            indent=2,
+            sort_keys=True,
+        )
+    )
+    quality_required = args.require_quality_gate or args.require_fixed_quality_contract
+    return 0 if quality_passed or not quality_required else 2
 
 
 def _logprob_value(value: Any) -> float | None:
@@ -626,7 +658,7 @@ def _token_logprobs(choice: dict[str, Any]) -> list[float | None]:
 def _normal_logprob_key(key: Any) -> str:
     text = str(key)
     if text.startswith("token_id:"):
-        return text[len("token_id:"):]
+        return text[len("token_id:") :]
     return text
 
 
@@ -678,8 +710,7 @@ def _diff_top_logprob_maps(
     }
 
 
-def _diff_values(left: list[float | None],
-                 right: list[float | None]) -> dict[str, Any]:
+def _diff_values(left: list[float | None], right: list[float | None]) -> dict[str, Any]:
     diffs: list[float] = []
     same_count = len(left) == len(right)
     for left_value, right_value in zip(left, right, strict=False):
@@ -695,8 +726,9 @@ def _diff_values(left: list[float | None],
     }
 
 
-def _first_mismatch(left: list[int] | None,
-                    right: list[int] | None) -> dict[str, Any] | None:
+def _first_mismatch(
+    left: list[int] | None, right: list[int] | None
+) -> dict[str, Any] | None:
     if left is None or right is None:
         return None if left == right else {"index": 0, "left": left, "right": right}
     for index, (left_id, right_id) in enumerate(zip(left, right, strict=False)):
@@ -719,22 +751,26 @@ def _load_logits_dumps(path: Path) -> list[dict[str, Any]]:
     for file_path in sorted(path.glob("sampler_logits_*.pt")):
         payload = torch.load(file_path, map_location="cpu", weights_only=False)
         logits = payload["logits"].float()
-        entries.append({
-            "path": str(file_path),
-            "step": int(payload["step"]),
-            "pid": payload.get("pid"),
-            "stage": payload.get("stage"),
-            "shape": list(payload.get("shape", tuple(logits.shape))),
-            "dtype": payload.get("dtype"),
-            "all_greedy": bool(payload.get("all_greedy")),
-            "output_token_ids": payload.get("output_token_ids"),
-            "logits": logits,
-        })
-    entries.sort(key=lambda item: (
-        int(item["step"]),
-        str(item.get("stage")),
-        str(item["path"]),
-    ))
+        entries.append(
+            {
+                "path": str(file_path),
+                "step": int(payload["step"]),
+                "pid": payload.get("pid"),
+                "stage": payload.get("stage"),
+                "shape": list(payload.get("shape", tuple(logits.shape))),
+                "dtype": payload.get("dtype"),
+                "all_greedy": bool(payload.get("all_greedy")),
+                "output_token_ids": payload.get("output_token_ids"),
+                "logits": logits,
+            }
+        )
+    entries.sort(
+        key=lambda item: (
+            int(item["step"]),
+            str(item.get("stage")),
+            str(item["path"]),
+        )
+    )
     return entries
 
 
@@ -753,7 +789,8 @@ def _compare_logits_dirs(left_dir: Path, right_dir: Path) -> dict[str, Any]:
     num_argmax_mismatch = 0
     first_argmax_mismatch = None
     for index, (left, right) in enumerate(
-            zip(left_entries, right_entries, strict=False)):
+        zip(left_entries, right_entries, strict=False)
+    ):
         shape_equal = tuple(left["logits"].shape) == tuple(right["logits"].shape)
         all_shape_equal = all_shape_equal and shape_equal
         payload = {
@@ -787,15 +824,17 @@ def _compare_logits_dirs(left_dir: Path, right_dir: Path) -> dict[str, Any]:
             global_max = max(global_max, max_diff)
             total_sum += float(diff.sum().item())
             total_count += int(diff.numel())
-            payload.update({
-                "max_abs_diff": max_diff,
-                "mean_abs_diff": mean_diff,
-                "argmax_equal": argmax_equal,
-                "argmax_first_mismatch": _first_mismatch(
-                    left_argmax.reshape(-1).tolist(),
-                    right_argmax.reshape(-1).tolist(),
-                ),
-            })
+            payload.update(
+                {
+                    "max_abs_diff": max_diff,
+                    "mean_abs_diff": mean_diff,
+                    "argmax_equal": argmax_equal,
+                    "argmax_first_mismatch": _first_mismatch(
+                        left_argmax.reshape(-1).tolist(),
+                        right_argmax.reshape(-1).tolist(),
+                    ),
+                }
+            )
         else:
             all_argmax_equal = False
         comparisons.append(payload)
@@ -831,11 +870,12 @@ def _compare(args: argparse.Namespace) -> int:
     output_top_logprob_diffs: list[float] = []
     prompt_perplexity_diffs: list[float] = []
     for index, (left_record, right_record) in enumerate(
-            zip(left["records"], right["records"], strict=False)):
+        zip(left["records"], right["records"], strict=False)
+    ):
         left_choice = left_record["choice"]
         right_choice = right_record["choice"]
-        prompt_equal = (
-            left_choice.get("prompt_token_ids") == right_choice.get("prompt_token_ids")
+        prompt_equal = left_choice.get("prompt_token_ids") == right_choice.get(
+            "prompt_token_ids"
         )
         output_equal = left_choice.get("token_ids") == right_choice.get("token_ids")
         text_equal = left_choice.get("text") == right_choice.get("text")
@@ -870,32 +910,35 @@ def _compare(args: argparse.Namespace) -> int:
         left_ppl_value = left_ppl["perplexity"]
         right_ppl_value = right_ppl["perplexity"]
         prompt_perplexity_abs_diff = (
-            None if left_ppl_value is None or right_ppl_value is None else
-            abs(float(left_ppl_value) - float(right_ppl_value))
+            None
+            if left_ppl_value is None or right_ppl_value is None
+            else abs(float(left_ppl_value) - float(right_ppl_value))
         )
         if prompt_perplexity_abs_diff is not None:
             prompt_perplexity_diffs.append(prompt_perplexity_abs_diff)
-        pairs.append({
-            "index": index,
-            "prompt_equal": prompt_equal,
-            "output_equal": output_equal,
-            "text_equal": text_equal,
-            "prompt_first_mismatch": _first_mismatch(
-                left_choice.get("prompt_token_ids"),
-                right_choice.get("prompt_token_ids"),
-            ),
-            "output_first_mismatch": _first_mismatch(
-                left_choice.get("token_ids"),
-                right_choice.get("token_ids"),
-            ),
-            "prompt_logprob_diff": prompt_diff,
-            "output_logprob_diff": output_diff,
-            "prompt_top_logprob_diff": prompt_top_diff,
-            "output_top_logprob_diff": output_top_diff,
-            "left_prompt_perplexity": left_ppl,
-            "right_prompt_perplexity": right_ppl,
-            "prompt_perplexity_abs_diff": prompt_perplexity_abs_diff,
-        })
+        pairs.append(
+            {
+                "index": index,
+                "prompt_equal": prompt_equal,
+                "output_equal": output_equal,
+                "text_equal": text_equal,
+                "prompt_first_mismatch": _first_mismatch(
+                    left_choice.get("prompt_token_ids"),
+                    right_choice.get("prompt_token_ids"),
+                ),
+                "output_first_mismatch": _first_mismatch(
+                    left_choice.get("token_ids"),
+                    right_choice.get("token_ids"),
+                ),
+                "prompt_logprob_diff": prompt_diff,
+                "output_logprob_diff": output_diff,
+                "prompt_top_logprob_diff": prompt_top_diff,
+                "output_top_logprob_diff": output_top_diff,
+                "left_prompt_perplexity": left_ppl,
+                "right_prompt_perplexity": right_ppl,
+                "prompt_perplexity_abs_diff": prompt_perplexity_abs_diff,
+            }
+        )
 
     sampler_logits_diff = (
         _compare_logits_dirs(args.left_logits_dir, args.right_logits_dir)
@@ -962,15 +1005,9 @@ def _model_quality_gate(
         "token_equal": token_equal,
         "prompt_logprob_max_abs_diff": result.get("max_prompt_logprob_diff"),
         "output_logprob_max_abs_diff": result.get("max_output_logprob_diff"),
-        "prompt_top_logprob_max_abs_diff": result.get(
-            "max_prompt_top_logprob_diff"
-        ),
-        "output_top_logprob_max_abs_diff": result.get(
-            "max_output_top_logprob_diff"
-        ),
-        "prompt_perplexity_max_abs_diff": result.get(
-            "max_prompt_perplexity_abs_diff"
-        ),
+        "prompt_top_logprob_max_abs_diff": result.get("max_prompt_top_logprob_diff"),
+        "output_top_logprob_max_abs_diff": result.get("max_output_top_logprob_diff"),
+        "prompt_perplexity_max_abs_diff": result.get("max_prompt_perplexity_abs_diff"),
         "sampler_logits_max_abs_diff": None
         if sampler_logits_diff is None
         else sampler_logits_diff.get("max_abs_diff"),
@@ -1138,6 +1175,15 @@ def _parse_args() -> argparse.Namespace:
         "--require-quality-gate",
         action="store_true",
         help="Fail dump mode if any prompt trips the local repetition/corruption gate.",
+    )
+    parser.add_argument(
+        "--require-fixed-quality-contract",
+        action="store_true",
+        help=(
+            "Fail dump mode unless every prompt stops naturally and any known "
+            "prompt-specific structural contract also passes. The macos_6k_code "
+            "contract requires complete HTML/CSS/JavaScript and closed code fences."
+        ),
     )
     parser.add_argument("--timeout", type=float, default=600.0)
     parser.add_argument(

--- a/benchmarks/run_sm70_quality_speed_matrix.py
+++ b/benchmarks/run_sm70_quality_speed_matrix.py
@@ -300,6 +300,12 @@ def _max_repeated_window(text: str, width: int) -> int:
         window = normalized[idx : idx + width]
         if len(window.strip()) < width // 2:
             continue
+        # Homogeneous runs are checked independently by
+        # _longest_same_char_run. Counting their overlapping windows makes
+        # ordinary code separators such as "=====" look quadratically
+        # repetitive.
+        if len(set(window)) == 1:
+            continue
         counts[window] = counts.get(window, 0) + 1
     return max(counts.values(), default=0)
 

--- a/benchmarks/run_sm70_release_matrix.py
+++ b/benchmarks/run_sm70_release_matrix.py
@@ -900,6 +900,12 @@ def _max_repeated_window(text: str, width: int) -> int:
         window = normalized[idx : idx + width]
         if len(window.strip()) < width // 2:
             continue
+        # Homogeneous runs are checked independently by
+        # _longest_same_char_run. Counting their overlapping windows makes
+        # ordinary code separators such as "=====" look quadratically
+        # repetitive.
+        if len(set(window)) == 1:
+            continue
         counts[window] = counts.get(window, 0) + 1
     return max(counts.values(), default=0)
 

--- a/docs/design/sm70_qwen38_130_acceptance.md
+++ b/docs/design/sm70_qwen38_130_acceptance.md
@@ -100,10 +100,30 @@ issue, not an idle-GPU or missing graph-shape issue.
   all token IDs are legal, `is_corrupted=false`, and acceptance length is 4.0.
 - Tool-call JSON and streaming tool calls parse correctly. A repeated 3136-token
   prefix records a cache hit and reduces request latency from 1.965 to 1.152 s.
-- HTML/JavaScript quality prompts pass structural checks, natural-stop checks,
-  and `node --check`. One long stochastic seed repeated after about 6377 tokens;
-  another bounded run naturally stopped at 7894 tokens. Treat this as a model
-  sampling risk, not deterministic token or HTML-tag corruption.
+- The original acceptance run contains one unmatched no-MTP/FP16-KV sample
+  that reached the 8192-token request limit and began repeating after about
+  6377 tokens. Its request seed was not retained, so that artifact is neither
+  proof of a deterministic kernel defect nor sufficient evidence to dismiss
+  the failure as sampling variance.
+- A matched audit at source `7f409a7727` used the 74-token macOS prompt,
+  seed `20260620`, `temperature=1.0`, `top_p=0.95`, `top_k=20`, and a
+  32600-token output allowance. All four production combinations stopped
+  naturally with complete HTML/CSS/JavaScript and closed code fences:
+
+  | MTP | KV cache | Output tokens | Decode tok/s | Result |
+  | --- | --- | ---: | ---: | --- |
+  | off | FP16 | 24,441 | 61.63 | pass |
+  | off | E5M2 | 25,055 | 61.71 | pass |
+  | MTP4 | FP16 | 25,753 | 75.21 | pass |
+  | MTP4 | E5M2 | 18,642 | 81.82 | pass |
+
+  Repeated same-seed requests were byte-identical in every combination.
+  Prefix-cache-hit probes were also byte-identical for no-MTP/FP16,
+  MTP4/FP16, and MTP4/E5M2. The MTP4/E5M2 sample initially tripped the local
+  repeated-window heuristic because fourteen decorative `=====` section
+  separators contributed overlapping single-character windows; 200-character
+  windows did not repeat. The gate now leaves homogeneous runs to its separate
+  same-character-run check.
 - The corrected FP8 workspace ABI passes a 6278-token natural prompt: it
   follows the final four-line instruction, emits no replacement characters,
   and stops naturally after 47 tokens.

--- a/docs/design/sm70_v100_migration_control.md
+++ b/docs/design/sm70_v100_migration_control.md
@@ -41256,3 +41256,34 @@ Interpretation:
   290 MiB/rank extra workspace, and non-bitwise output.
 - Detailed route gates, full sweep, tests, rejected paths, and artifacts are
   in `docs/design/sm70_fp8_long_prefill_exact_dense.md`.
+
+## 2026-08-16 Qwen3.8 output-quality audit
+
+- Audited PR 212 head `7f409a7727` on Qwen3.8-27B-FP8, TP4 V100, max length
+  32768, official sampling, and the fixed 74-token macOS code prompt. Do not
+  repeat the earlier 1K/8K smokes as long-form quality evidence.
+- Natural-stop output gates passed no-MTP/FP16 KV (24,441 tokens),
+  no-MTP/E5M2 KV (25,055), MTP4/FP16 KV (25,753), and MTP4/E5M2 KV (18,642).
+  Every output contains complete HTML/CSS/JavaScript, closed tags and code
+  fences, no replacement characters, and no semantic long-block repetition.
+- Same-seed duplicate requests were byte-identical for all four paths. Long
+  prefix-cache probes remained byte-identical after 4,704, 4,896, and 6,464
+  cached tokens in the no-MTP/FP16, MTP4/FP16, and MTP4/E5M2 lanes.
+- Qwen3.8 TP4 XQA-vs-scalar operator checks at the 4095/4096/4097 boundary,
+  6272, 8192, and 16384 stayed within `6.1035e-5` maximum absolute difference
+  for FP16 and E5M2 KV. The MTP five-row, partition-1024 checks have the same
+  bound. The full MTP services logged the automatic GDN full-forward quality
+  guard and actual route hit.
+- A no-MTP-vs-MTP FP16 greedy comparison first diverges at output index 179.
+  The no-MTP top two tokens are tied at returned precision; the MTP target
+  top-1 leads by only 0.015625 and the verifier selects that target top-1.
+  This is a low-margin M=1/M=5 floating-point-order flip, not evidence that MTP
+  accepted a non-target draft token.
+- The serving/release gates falsely counted each overlapping 20/50-character
+  window inside decorative `=====` comments. On the MTP4/E5M2 output this
+  produced `repeat20=1064` and `repeat50=224`; excluding homogeneous windows
+  yields 28/28 while the independent same-character-run gate remains active.
+- The historical 8192-token no-MTP/FP16 artifact that degenerates after about
+  token 6377 predates the new E5M2 work and has no retained request seed. Keep
+  it as an unmatched regression sample; do not attribute it to FP8 KV, XQA,
+  MTP, or sampling without a matched reproduction.

--- a/tests/benchmarks/test_sm70_release_quality_gate.py
+++ b/tests/benchmarks/test_sm70_release_quality_gate.py
@@ -77,6 +77,25 @@ def test_quality_metrics_still_reject_degenerate_repetition():
     assert "same_token_run" in metrics["failures"]
 
 
+def test_quality_metrics_allow_decorative_character_separators():
+    separator = "/* " + "=" * 57 + " */"
+    text = "\n".join(f"{separator}\nconst section_{idx} = {idx};" for idx in range(30))
+
+    metrics = _quality_metrics(text, list(range(64)))
+
+    assert metrics["max_same_char_run"] == 57
+    assert metrics["repeat20"] <= metrics["repeat20_limit"]
+    assert metrics["repeat50"] <= 40
+    assert metrics["passed"]
+
+
+def test_quality_metrics_still_reject_long_homogeneous_run():
+    metrics = _quality_metrics("=" * 121, list(range(64)))
+
+    assert metrics["max_same_char_run"] == 121
+    assert "same_char_run" in metrics["failures"]
+
+
 def test_release_matrix_includes_fp8_weight_fp8_kv_mtp_by_default():
     cases = _make_cases(
         backends=("turbomind",),

--- a/tests/test_envs.py
+++ b/tests/test_envs.py
@@ -104,16 +104,21 @@ def test_is_envs_cache_enabled() -> None:
 
 
 def test_precompiled_install_flags_are_orthogonal() -> None:
-    with patch.dict(
-        os.environ,
-        {
-            "VLLM_PRECOMPILED_WHEEL_LOCATION": "/tmp/vllm.whl",
-            "VLLM_USE_PRECOMPILED_RUST": "1",
-        },
-        clear=False,
-    ):
+    # The Rust frontend flag must not implicitly enable the precompiled C
+    # extensions.
+    with patch.dict(os.environ, {"VLLM_USE_PRECOMPILED_RUST": "1"}, clear=True):
         assert environment_variables["VLLM_USE_PRECOMPILED"]() is False
         assert environment_variables["VLLM_USE_PRECOMPILED_RUST"]() is True
+
+    # A wheel location still selects precompiled C extensions without
+    # implicitly enabling the Rust frontend.
+    with patch.dict(
+        os.environ,
+        {"VLLM_PRECOMPILED_WHEEL_LOCATION": "/tmp/vllm.whl"},
+        clear=True,
+    ):
+        assert environment_variables["VLLM_USE_PRECOMPILED"]() is True
+        assert environment_variables["VLLM_USE_PRECOMPILED_RUST"]() is False
 
 
 def test_flash_v100_g6_sawtooth_pipeline_envs(

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -1024,10 +1024,10 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # If set, `MAX_JOBS` will be reduced to avoid oversubscribing the CPU.
     "NVCC_THREADS": lambda: os.getenv("NVCC_THREADS", None),
     # If set, vllm will use precompiled native binaries (*.so and vllm-rs).
-    "VLLM_USE_PRECOMPILED": lambda: os.environ.get("VLLM_USE_PRECOMPILED", "")
-    .strip()
-    .lower()
-    in ("1", "true"),
+    "VLLM_USE_PRECOMPILED": lambda: (
+        os.environ.get("VLLM_USE_PRECOMPILED", "").strip().lower() in ("1", "true")
+        or bool(os.environ.get("VLLM_PRECOMPILED_WHEEL_LOCATION"))
+    ),
     # If set, vllm will use the precompiled Rust frontend binary (vllm-rs).
     "VLLM_USE_PRECOMPILED_RUST": lambda: (
         os.environ.get("VLLM_USE_PRECOMPILED_RUST", "").strip().lower() in ("1", "true")


### PR DESCRIPTION
## Purpose

- stop treating overlapping windows inside decorative homogeneous separators as semantic repetition while retaining the independent long-character-run guard
- optionally require natural stop plus prompt-specific structure in serving-quality dumps, so truncated macOS HTML cannot pass a release-quality claim
- restore `VLLM_PRECOMPILED_WHEEL_LOCATION` as a selector for precompiled native extensions
- record the matched Qwen3.8 27B FP16/E5M2, MTP/no-MTP output-quality audit

This PR is intentionally stacked on #212.

## Test Plan

- replay the four long-form quality artifacts through all three local gates
- validate same-path determinism, prefix-cache hits, FP8 scalar/XQA boundaries, and MTP route/acceptance state
- run focused quality-gate and environment tests
- run the affected CPU/control and GPU operator suites

## Test Result

- four 18.6K-25.8K token production-path samples naturally stopped with complete HTML/CSS/JavaScript
- same-seed duplicate requests were byte-identical in all four FP16/E5M2, MTP/no-MTP combinations
- prefix-cache probes were byte-identical on no-MTP/FP16, MTP/FP16, and MTP/E5M2
- TP4 scalar/XQA FP16 and E5M2 boundary checks stayed within 6.1035e-5 max absolute difference through 16K context, including five-row MTP
- 225 affected CPU/control tests passed
- 26 targeted GPU/operator tests passed
- focused environment and release-quality tests passed under Python 3.12 / Torch 2.10
- Ruff check, Ruff format check, and `git diff --check` passed

FP8 KV and FP16 greedy token identity is deliberately not an acceptance condition; quantization may change low-margin token choices. The audit instead gates unexpected corruption, repetition, truncation, nondeterminism, cache-state contamination, route inconsistency, and verifier errors.