### PR TITLE
[Doc] Record rejected MTP prefill entry

### DIFF
--- a/docs/design/sm70_v100_migration_control.md
+++ b/docs/design/sm70_v100_migration_control.md
@@ -41287,3 +41287,33 @@ Interpretation:
   token 6377 predates the new E5M2 work and has no retained request seed. Keep
   it as an unmatched regression sample; do not attribute it to FP8 KV, XQA,
   MTP, or sampling without a matched reproduction.
+
+## 2026-08-16 Rejected MTP chunked-prefill compile entry
+
+- PR 213 proposed a second compiled Qwen target entry that bypassed the
+  automatic full-forward GDN guard only while every scheduled request was an
+  unfinished prefill chunk. Its 64K output was healthy, but its claimed
+  `22.5%-24.3%` prefill improvement compared against an older release artifact
+  rather than a same-source control.
+- A matched Qwen3.8-27B-FP8 TP4 control used MTP4, E5M2 KV, 65,517 prompt
+  tokens, 8,192-token prefill chunks, max length 262,144, seed 20260815,
+  official sampling, GPU memory utilization 0.88, and one warmup followed by
+  prefix/Mamba cache reset. The only changed setting was
+  `VLLM_SM70_MTP_PREFILL_STANDARD_GDN`.
+- The proposed entry took 24.428544 s for prefill. The disabled control took
+  24.284061 s, so enabling the entry added 0.144483 s (`+0.595%`) rather than
+  recovering the claimed release gap. Both lanes stopped naturally, retained
+  all three long-context sentinels, passed the corruption/repetition gate, and
+  reproduced their warmup text exactly. Cross-route token identity was not
+  required.
+- The additional entry also raised observed engine initialization from
+  117.93 s to 166.12 s because it compiled a second target graph. PR 213 was
+  closed without merge: the older comparison was confounded by other source
+  changes, while the matched result showed no runtime benefit to justify the
+  startup and maintenance cost.
+- Evidence is
+  `/data/minimax-h3/task-cache/qwen38-mtp-prefill-fastpath-20260816/results/qwen38-27b-fp8-mtp4-candidate-tp4-e5m2-64k-o512-warm.json`
+  and
+  `/data/minimax-h3/task-cache/qwen38-mtp-prefill-fastpath-20260816/results/qwen38-27b-fp8-mtp4-control-off-tp4-e5m2-64k-o512-warm.json`.
+  Do not repeat the older release-vs-candidate comparison as evidence for this
+  compile entry.


### PR DESCRIPTION
## Purpose

Record the matched audit that rejected #213, so the older release-vs-candidate comparison is not reused as evidence for the second Qwen target compile entry.

## Test Plan

- compare enabled and disabled lanes on the same implementation and runtime configuration
- require natural stop, sentinel retention, clean repetition/corruption metrics, and same-lane repeat determinism
- lint the updated control document

## Test Result

- enabled prefill: 24.428544 s
- disabled prefill: 24.284061 s
- enabled delta: +0.144483 s / +0.595%
- both outputs naturally stopped, retained every sentinel, passed quality gates, and reproduced warmup text exactly
- targeted markdownlint and whitespace checks passed

This documentation PR is stacked on #212; #213 was closed without merge.