### PR TITLE
[Kernel][SM70] Clamp MLA-large decode to fit V100

### DIFF
--- a/tests/kernels/attention/test_triton_decode_attention.py
+++ b/tests/kernels/attention/test_triton_decode_attention.py
@@ -6,9 +6,40 @@ import torch
 
 from vllm.platforms import current_platform
 from vllm.utils.math_utils import cdiv
-from vllm.v1.attention.ops.triton_decode_attention import decode_attention_fwd
+from vllm.v1.attention.ops.triton_decode_attention import (
+    _decode_grouped_block_size,
+    decode_attention_fwd,
+)
 
 DEVICE_TYPE = current_platform.device_type
+
+
+@pytest.mark.parametrize(
+    ("is_hip", "is_mla", "block_dmodel", "is_sm70", "expected"),
+    [
+        (True, False, 128, False, 16),
+        (False, True, 512, True, 16),
+        (False, True, 512, False, 32),
+        (False, True, 256, True, 32),
+        (False, False, 512, True, 32),
+    ],
+)
+def test_decode_grouped_block_size_is_sm70_scoped(
+    is_hip,
+    is_mla,
+    block_dmodel,
+    is_sm70,
+    expected,
+):
+    assert (
+        _decode_grouped_block_size(
+            is_hip=is_hip,
+            is_mla=is_mla,
+            block_dmodel=block_dmodel,
+            is_sm70=is_sm70,
+        )
+        == expected
+    )
 
 
 @pytest.mark.parametrize("B", [3, 5])

--- a/vllm/v1/attention/ops/triton_decode_attention.py
+++ b/vllm/v1/attention/ops/triton_decode_attention.py
@@ -39,6 +39,19 @@ from vllm.triton_utils import tl, triton
 
 is_hip_ = current_platform.is_rocm()
 
+
+def _decode_grouped_block_size(
+    *,
+    is_hip: bool,
+    is_mla: bool,
+    block_dmodel: int,
+    is_sm70: bool,
+) -> int:
+    if is_hip or (is_mla and block_dmodel >= 512 and is_sm70):
+        return 16
+    return 32
+
+
 logger = logging.getLogger(__name__)
 
 # Only print the following warnings when triton version < 3.2.0.
@@ -487,13 +500,12 @@ def _decode_grouped_att_m_fwd(
     # saturated grids) at 128-user shapes. num_stages is a no-op here (no
     # cp.async on sm70 - KV loads cannot be multi-buffered); leave it alone.
     # Proof + bench: patches/0103-mla-triton-decode-smem/poc/.
-    BLOCK = 32
-    if is_hip_ or (
-        is_mla
-        and BLOCK_DMODEL >= 512
-        and current_platform.get_device_capability()[0] == 7
-    ):
-        BLOCK = 16
+    BLOCK = _decode_grouped_block_size(
+        is_hip=is_hip_,
+        is_mla=is_mla,
+        block_dmodel=BLOCK_DMODEL,
+        is_sm70=current_platform.is_device_capability(70),
+    )
 
     batch, head_num = q.shape[0], q.shape[1]
     kv_group_num = q.shape[1] // k_buffer.shape[-2]

--- a/vllm/v1/attention/ops/triton_decode_attention.py
+++ b/vllm/v1/attention/ops/triton_decode_attention.py
@@ -478,8 +478,21 @@ def _decode_grouped_att_m_fwd(
         BLOCK_DPE = 0
     BLOCK_DV = triton.next_power_of_2(Lv)
 
+    # Patch 0103: BLOCK=16 for HIP (original) and for MLA-large on SM70 (V100).
+    # On SM70 at BLOCK=32 the stage-1 kernel needs 102,400 B of smem (Triton
+    # stages dot operands as fp32 on sm70: peak = 4 B x [BLOCK_H*(BLOCK_DMODEL+
+    # BLOCK_DPE) + BLOCK*BLOCK_DMODEL]) against the 98,304 B hardware limit ->
+    # OutOfResources on the first decode. BLOCK=16 fits (69,632 B) and won the
+    # tiling bench vs BN32/BH8 (spill catastrophe) and BN16/BH8 (loses at
+    # saturated grids) at 128-user shapes. num_stages is a no-op here (no
+    # cp.async on sm70 - KV loads cannot be multi-buffered); leave it alone.
+    # Proof + bench: patches/0103-mla-triton-decode-smem/poc/.
     BLOCK = 32
-    if is_hip_:
+    if is_hip_ or (
+        is_mla
+        and BLOCK_DMODEL >= 512
+        and current_platform.get_device_capability()[0] == 7
+    ):
         BLOCK = 16
 
     batch, head_num = q.shape[0], q.shape[1]


### PR DESCRIPTION
## Purpose

Integrate #211 and tighten its architecture gate so the 69,632-byte BLOCK=16 route is selected on SM70/V100, not on SM75 where it still exceeds the 64 KiB block limit.

## Test Plan

- cover HIP, SM70 MLA-large, SM75/non-SM70, small MLA, and non-MLA block selection
- launch the real MLA-large Lk=576/Lv=512 grouped decode path on V100
- compare output against the FP32 MLA c_kv oracle
- run changed-file Ruff/format/whitespace checks

## Test Result

- route selection: 5 passed
- V100 MLA-large B1/Hq16/Hkv1/L2048/Dqk576/Dv512 launched successfully
- output finite; max absolute difference 3.7383e-6; RMS-relative error 2.5177e-4 versus FP32 oracle
- Ruff, format, and whitespace checks passed

This supersedes #211 because the original capability-major gate also selected unsupported SM75.