### PR TITLE
[Kernel][SM70] Keep XQA softmax probabilities in FP32 for FP16 KV

### DIFF
--- a/docs/design/sm70_v100_migration_control.md
+++ b/docs/design/sm70_v100_migration_control.md
@@ -41317,3 +41317,33 @@ Interpretation:
   `/data/minimax-h3/task-cache/qwen38-mtp-prefill-fastpath-20260816/results/qwen38-27b-fp8-mtp4-control-off-tp4-e5m2-64k-o512-warm.json`.
   Do not repeat the older release-vs-candidate comparison as evidence for this
   compile entry.
+
+## 2026-08-16 XQA FP16 probability-handoff audit
+
+- Audited PR 210 on current main `4ba41b32ac`. The change keeps softmax
+  probabilities in FP32 through the scalar PV loop only for FP16 KV. The
+  FP8-E5M2 instantiations retain the existing FP16 probability handoff.
+- The quality contract does not require FP8-KV greedy output to equal FP16-KV
+  greedy output. The relevant gates here were same-build repeat stability,
+  same-quantized-cache candidate/control equality, finite output, bounded
+  scalar/XQA differences, and error against an FP64 attention oracle.
+- Five controlled FP16 shapes covered G4/G6/G8, partitions 256/512/1024,
+  partial tiles, block sizes 16/784/1616, and a five-row MTP-verifier shape.
+  Candidate/control FP64 RMS ratios were 0.835, 0.862, 0.850, 0.868, and
+  0.856. Two default-production G6/block784 shapes at 16K and 64K had ratios
+  0.863 and 0.874. Thus every tested FP16 shape improved by 12.6%-16.5%.
+- Four controlled and two default-production E5M2 shapes were bitwise
+  identical between candidate and control across all 15,360 output elements.
+  All 13 FP16/E5M2 cases were finite and bitwise repeatable across four runs.
+  Resource usage was identical for every compiled kernel instantiation.
+- Swapped-GPU concurrent A/B timing at FP16 G6/block784/65,539, 500 measured
+  calls per lane, produced candidate/control medians of 0.294912/0.296960 ms,
+  0.295936/0.295936 ms, and 0.299008/0.295936 ms. The observed range
+  (-0.7% to +1.0%) is neutral measurement noise; no decode regression was
+  established.
+- Raw builds, outputs, JSON, logs, resource tables, and the standalone audit
+  harness are retained under
+  `/data/minimax-h3/task-cache/pr210-xqa-fp32-p-audit-20260816/`. Do not rerun
+  full-model FP8-vs-FP16 greedy equality for this change: the E5M2 binary path
+  is compile-time unchanged and has already passed the stronger same-cache
+  bitwise A/B gate.

--- a/flash-attention-v100/kernel/flash_decode_paged.cu
+++ b/flash-attention-v100/kernel/flash_decode_paged.cu
@@ -756,6 +756,11 @@ __global__ void __launch_bounds__(NUM_THREADS, MIN_BLOCKS_PER_SM)
       QK_SW_PIPELINE,
       XQATCQKPipelineSmem256WideLayout<PADDED_SMEM, ALIGNED_PADDED_SMEM>,
       XQATCSmem256WideLayout<PADDED_SMEM, ALIGNED_PADDED_SMEM>>;
+  // Keep the softmax P matrix in fp32 through the PV stage when KV precision
+  // is high enough that the fp16 round-trip rounding dominates (fp16 KV). On
+  // fp8_e5m2 KV the ~10-12% KV-quant error swamps it, so keep the original
+  // fp16-P store bit-exact there (the else arms below). Compile-time only.
+  constexpr bool kKeepPfp32 = (KV_DTYPE == flash_v100::KV_CACHE_DTYPE_FP16);
   constexpr int q_global_stride_uint4 = D / 8;
   constexpr int q_smem_stride_uint4 = SmemLayout::kQStride / 8;
   constexpr int kv_smem_stride_uint4 = SmemLayout::kKVStride / 8;
@@ -996,6 +1001,7 @@ __global__ void __launch_bounds__(NUM_THREADS, MIN_BLOCKS_PER_SM)
       const unsigned mask = 0xffffffffu;
       float* sS_row_f = sS + row * kXQATCBlockN;
       __half* sP_row_h = sP + row * kXQATCBlockN;
+      float* sP_row_f = sS + row * kXQATCBlockN;  // 0012: fp32 P alias (fp16-KV)
       const int vec_cols = valid_k_rows >> 2;
       const int tail_start = vec_cols << 2;
       const int vec_col = thread_in_row;
@@ -1032,8 +1038,12 @@ __global__ void __launch_bounds__(NUM_THREADS, MIN_BLOCKS_PER_SM)
         const float e2 = __expf(fmaxf(v4.z - new_max, -80.0f));
         const float e3 = __expf(fmaxf(v4.w - new_max, -80.0f));
         thread_sum += (e0 + e1) + (e2 + e3);
-        packed_exp0 = __float22half2_rn(make_float2(e0, e1));
-        packed_exp1 = __float22half2_rn(make_float2(e2, e3));
+        if constexpr (kKeepPfp32) {
+          reinterpret_cast<float4*>(sP_row_f)[vec_col] = make_float4(e0, e1, e2, e3);
+        } else {
+          packed_exp0 = __float22half2_rn(make_float2(e0, e1));
+          packed_exp1 = __float22half2_rn(make_float2(e2, e3));
+        }
       }
 
 #pragma unroll
@@ -1042,8 +1052,12 @@ __global__ void __launch_bounds__(NUM_THREADS, MIN_BLOCKS_PER_SM)
         const float v = (c < valid_k_rows) ? sS_row_f[c] : kXQANegInf;
         const float e = __expf(fmaxf(v - new_max, -80.0f));
         thread_sum += (c < valid_k_rows) ? e : 0.0f;
-        sP_row_h[c] =
-            (c < valid_k_rows) ? __float2half_rn(e) : __float2half(0.f);
+        if constexpr (kKeepPfp32) {
+          sP_row_f[c] = (c < valid_k_rows) ? e : 0.0f;
+        } else {
+          sP_row_h[c] =
+              (c < valid_k_rows) ? __float2half_rn(e) : __float2half(0.f);
+        }
       }
 
 #pragma unroll
@@ -1058,12 +1072,15 @@ __global__ void __launch_bounds__(NUM_THREADS, MIN_BLOCKS_PER_SM)
         row_sum_reg = exp_diff * old_sum + row_sum;
         row_max_reg = new_max;
       }
-      __half2* sP_half2 = reinterpret_cast<__half2*>(sP_row_h);
-      if (vec_col < vec_cols) {
-        const int base_offset = vec_col * 2;
-        sP_half2[base_offset] = packed_exp0;
-        sP_half2[base_offset + 1] = packed_exp1;
+      if constexpr (!kKeepPfp32) {
+        __half2* sP_half2 = reinterpret_cast<__half2*>(sP_row_h);
+        if (vec_col < vec_cols) {
+          const int base_offset = vec_col * 2;
+          sP_half2[base_offset] = packed_exp0;
+          sP_half2[base_offset + 1] = packed_exp1;
+        }
       }
+      // 0012 (fp16 KV): vec P store folded into the exp block above (fp32 float4)
 
       if (block_n > 0) {
 #pragma unroll
@@ -1098,12 +1115,18 @@ __global__ void __launch_bounds__(NUM_THREADS, MIN_BLOCKS_PER_SM)
         if (tid < GROUP_SIZE * kXQATC256WideThreadsPerRow) {
           const int row = tid / kXQATC256WideThreadsPerRow;
           const __half* sP_row = sP + row * kXQATCBlockN + kv_tile_start;
+          const float* sP_row_f = sS + row * kXQATCBlockN + kv_tile_start;
 #pragma unroll
           for (int token = 0; token < kXQATCBlockN; ++token) {
             if (token >= valid_kv_tile_rows) {
               break;
             }
-            const float prob = __half2float(sP_row[token]);
+            float prob;
+            if constexpr (kKeepPfp32) {
+              prob = sP_row_f[token];
+            } else {
+              prob = __half2float(sP_row[token]);
+            }
             const __half* sV_row = sV + token * SmemLayout::kKVStride;
 #pragma unroll
             for (int d_iter = 0; d_iter < (kPVPanelDim / kWarpSize); ++d_iter) {

--- a/flash-attention-v100/kernel/flash_decode_paged.cu
+++ b/flash-attention-v100/kernel/flash_decode_paged.cu
@@ -859,10 +859,9 @@ __global__ void __launch_bounds__(NUM_THREADS, MIN_BLOCKS_PER_SM)
       QK_SW_PIPELINE,
       XQATCQKPipelineSmem256WideLayout<PADDED_SMEM, ALIGNED_PADDED_SMEM>,
       XQATCSmem256WideLayout<PADDED_SMEM, ALIGNED_PADDED_SMEM>>;
-  // Keep the softmax P matrix in fp32 through the PV stage when KV precision
-  // is high enough that the fp16 round-trip rounding dominates (fp16 KV). On
-  // fp8_e5m2 KV the ~10-12% KV-quant error swamps it, so keep the original
-  // fp16-P store bit-exact there (the else arms below). Compile-time only.
+  // Keep softmax P in fp32 through PV for fp16 KV, avoiding a half round-trip.
+  // Preserve the half-P path for fp8_e5m2 so quantized-cache behavior remains
+  // bit-exact. This branch is resolved entirely at compile time.
   constexpr bool kKeepPfp32 = (KV_DTYPE == flash_v100::KV_CACHE_DTYPE_FP16);
   constexpr int q_global_stride_uint4 = D / 8;
   constexpr int q_smem_stride_uint4 = SmemLayout::kQStride / 8;
@@ -1120,7 +1119,7 @@ __global__ void __launch_bounds__(NUM_THREADS, MIN_BLOCKS_PER_SM)
       const unsigned mask = 0xffffffffu;
       float* sS_row_f = sS + row * kXQATCBlockN;
       __half* sP_row_h = sP + row * kXQATCBlockN;
-      float* sP_row_f = sS + row * kXQATCBlockN;  // 0012: fp32 P alias (fp16-KV)
+      float* sP_row_f = sS + row * kXQATCBlockN;
       const int vec_cols = valid_k_rows >> 2;
       const int tail_start = vec_cols << 2;
       const int vec_col = thread_in_row;
@@ -1158,7 +1157,8 @@ __global__ void __launch_bounds__(NUM_THREADS, MIN_BLOCKS_PER_SM)
         const float e3 = __expf(fmaxf(v4.w - new_max, -80.0f));
         thread_sum += (e0 + e1) + (e2 + e3);
         if constexpr (kKeepPfp32) {
-          reinterpret_cast<float4*>(sP_row_f)[vec_col] = make_float4(e0, e1, e2, e3);
+          reinterpret_cast<float4*>(sP_row_f)[vec_col] =
+              make_float4(e0, e1, e2, e3);
         } else {
           packed_exp0 = __float22half2_rn(make_float2(e0, e1));
           packed_exp1 = __float22half2_rn(make_float2(e2, e3));
@@ -1199,7 +1199,6 @@ __global__ void __launch_bounds__(NUM_THREADS, MIN_BLOCKS_PER_SM)
           sP_half2[base_offset + 1] = packed_exp1;
         }
       }
-      // 0012 (fp16 KV): vec P store folded into the exp block above (fp32 float4)
 
       if (block_n > 0) {
 #pragma unroll


### PR DESCRIPTION
## Purpose

Audit and integrate PR #210 on the current SM70 mainline. The XQA partition kernel used to round softmax probabilities to FP16 and immediately widen them for scalar FP32 PV accumulation. This keeps the handoff in FP32 only for FP16 KV while preserving the existing E5M2 code path.

Integration base: `4ba41b32ac8bc06a3117f42007434d3a1e4e367c`
Audited external head: `21174ccd686b46d257a7dbfe3d6bcb7fe1ebe305`
Current head: `08ad6f89c791b784351a990eca9b7927f9959cc3`

## Quality contract

FP8-KV output is not required to match FP16-KV greedy output. This audit instead requires:

- finite, repeat-stable output within each route;
- bitwise candidate/control equality for the unchanged E5M2 instantiations;
- bounded scalar/XQA differences on the same cache;
- lower delivered FP16 error against an FP64 attention oracle;
- no default-route or MTP-verifier regression.

## Test plan and result

Built candidate and same-source control with CUDA 12.8, Torch 2.9.1+cu128, `sm_70`, on V100-SXM2. The only control difference was the 43-line FP32-P change.

- Five controlled FP16 shapes covered G4/G6/G8, partitions 256/512/1024, partial tiles, block sizes 16/784/1616, and a five-row MTP-verifier shape. Candidate/control FP64 RMS ratios: `0.835`, `0.862`, `0.850`, `0.868`, `0.856` (12.6%-16.5% lower RMS error in every case).
- Default-production G6/block784 at 16K and 64K: RMS ratios `0.863` and `0.874`.
- Four controlled plus two default-production E5M2 shapes: bitwise identical candidate/control across all 15,360 output elements.
- All 13 FP16/E5M2 cases: finite and bitwise repeatable across four runs.
- Compiled resource table: identical registers, stack, shared memory, and local memory for every kernel instantiation.
- `pre-commit` scoped checks: clang-format, markdownlint-cli2, typos passed; `git diff --check` passed.
- The repository pytest entry could not collect in this source-only worktree because `vllm._C` is not built. The standalone audit loaded the freshly built Flash-V100 CUDA extension and exercised the real GPU kernels directly.

## Performance

Swapped-GPU concurrent A/B, FP16 G6/block784/65,539, 500 measured calls per lane:

- candidate/control `0.294912 / 0.296960 ms`
- candidate/control `0.295936 / 0.295936 ms`
- candidate/control `0.299008 / 0.295936 ms`

Range is -0.7% to +1.0%, so no measurable decode regression was established.

## Artifacts

All builds, output tensors, JSON results, logs, resource tables, and the standalone harness are retained at:

`/data/minimax-h3/task-cache/pr210-xqa-fp32-p-audit-20260816/`

## Risk and rollback

The choice is compile-time. E5M2 retains the prior generated behavior; only FP16 XQA probability storage/load changes. Reverting the external commit restores the previous FP16 half-P handoff.
