### PR TITLE
[Kernel] Audit SM70 AWQ fallback and Marlin split-K quality

### DIFF
--- a/csrc/quantization/marlin/sm70_marlin_fp8_gemm.cu
+++ b/csrc/quantization/marlin/sm70_marlin_fp8_gemm.cu
@@ -22,6 +22,8 @@
 
 using marlin::sm70::Sm70CtaGeometry;
 using marlin::sm70::Sm70AtomicFp16Epilogue;
+using marlin::sm70::Sm70AtomicFp32Epilogue;
+using marlin::sm70::sm70_marlin_narrow_f32_to_f16;
 using marlin::sm70::Sm70MarlinGemmTraits;
 using marlin::sm70::Sm70SplitKPartition;
 using marlin::sm70::validate_sm70_marlin_dense_cta_geometry_supported;
@@ -466,12 +468,12 @@ void sm70_marlin_fp8_gemm_splitk_kernel(
     cutlass::half_t const* __restrict__ a,
     uint32_t const* __restrict__ b_q_weight,
     cutlass::half_t const* __restrict__ b_scales,
-    cutlass::half_t* __restrict__ c, int m, int n, int k, int lda, int requested_split_k) {
+    cutlass::half_t* __restrict__ c, float* __restrict__ c32, int m, int n, int k, int lda, int requested_split_k) {
   using Traits = Sm70Fp8GemmTraits<CtaM, CtaN, CtaK, Warps, WarpM, WarpN,
                                    WarpK, GroupSize, PackedMacroN,
                                    UseMetadataVectorWords>;
   using Mma = typename Traits::Mma;
-  using AtomicEpilogue = Sm70AtomicFp16Epilogue<Traits>;
+  using AtomicEpilogue = Sm70AtomicFp32Epilogue<Traits>;
 
   extern __shared__ char smem[];
   auto& shared_storage =
@@ -518,7 +520,7 @@ void sm70_marlin_fp8_gemm_splitk_kernel(
 
   AtomicEpilogue epilogue(shared_storage.epilogue, thread_idx, warp_idx,
                           lane_idx);
-  epilogue(iterator_D, accumulators, c, n);
+  epilogue(iterator_D, accumulators, c32, n);
 }
 
 }  // namespace
@@ -568,9 +570,11 @@ torch::Tensor launch_sm70_marlin_fp8_gemm(
   smem_bytes = configure_sm70_dynamic_smem<SharedStorage>(split_kernel);
 
   int64_t const numel = size_m * size_n;
-  C10_CUDA_CHECK(cudaMemsetAsync(
-      c.data_ptr<at::Half>(), 0,
-      static_cast<size_t>(numel) * sizeof(at::Half), stream));
+  // 0009: fp32 split-K scratch (zeroed for the fp32 atomicAdd), M*N floats.
+  // Only allocated on the split_k>1 path, which the auto-selector uses ONLY at
+  // low batch (M<128), so the scratch is bounded and small.
+  auto c32 = torch::zeros({size_m, size_n},
+                          a.options().dtype(at::kFloat));
 
   dim3 grid = sm70_marlin_cta_grid(size_m, size_n, CtaM, CtaN);
   int const active_split_k =
@@ -581,8 +585,18 @@ torch::Tensor launch_sm70_marlin_fp8_gemm(
       reinterpret_cast<uint32_t const*>(b_q_weight.data_ptr<int32_t>()),
       reinterpret_cast<cutlass::half_t const*>(b_scales.data_ptr<at::Half>()),
       reinterpret_cast<cutlass::half_t*>(c.data_ptr<at::Half>()),
+      c32.data_ptr<float>(),
       static_cast<int>(size_m), static_cast<int>(size_n),
       static_cast<int>(size_k), static_cast<int>(a.stride(0)), requested_split_k);
+  C10_CUDA_KERNEL_LAUNCH_CHECK();
+
+  // 0009: single deterministic-width fp32->fp16 narrow of the scratch.
+  int const narrow_block = 256;
+  int const narrow_grid =
+      static_cast<int>((numel + narrow_block - 1) / narrow_block);
+  sm70_marlin_narrow_f32_to_f16<256><<<narrow_grid, narrow_block, 0, stream>>>(
+      c32.data_ptr<float>(),
+      reinterpret_cast<half*>(c.data_ptr<at::Half>()), numel);
   C10_CUDA_KERNEL_LAUNCH_CHECK();
 
   return c;

--- a/csrc/quantization/marlin/sm70_marlin_mxfp4_gemm.cu
+++ b/csrc/quantization/marlin/sm70_marlin_mxfp4_gemm.cu
@@ -23,6 +23,8 @@
 
 using marlin::sm70::Sm70CtaGeometry;
 using marlin::sm70::Sm70AtomicFp16Epilogue;
+using marlin::sm70::Sm70AtomicFp32Epilogue;
+using marlin::sm70::sm70_marlin_narrow_f32_to_f16;
 using marlin::sm70::Sm70MarlinGemmTraits;
 using marlin::sm70::Sm70SplitKPartition;
 using marlin::sm70::validate_sm70_marlin_dense_cta_geometry_supported;
@@ -439,11 +441,11 @@ void sm70_marlin_mxfp4_gemm_splitk_kernel(
     cutlass::half_t const* __restrict__ a,
     uint32_t const* __restrict__ b_q_weight,
     uint8_t const* __restrict__ b_scales,
-    cutlass::half_t* __restrict__ c, int m, int n, int k, int lda, int requested_split_k) {
+    cutlass::half_t* __restrict__ c, float* __restrict__ c32, int m, int n, int k, int lda, int requested_split_k) {
   using Traits = Sm70Mxfp4GemmTraits<CtaM, CtaN, CtaK, Warps, WarpM,
                                   WarpN, WarpK, GroupSize, PackedMacroN>;
   using Mma = typename Traits::Mma;
-  using AtomicEpilogue = Sm70AtomicFp16Epilogue<Traits>;
+  using AtomicEpilogue = Sm70AtomicFp32Epilogue<Traits>;
 
   extern __shared__ char smem[];
   auto& shared_storage =
@@ -490,7 +492,7 @@ void sm70_marlin_mxfp4_gemm_splitk_kernel(
 
   AtomicEpilogue epilogue(shared_storage.epilogue, thread_idx, warp_idx,
                           lane_idx);
-  epilogue(iterator_D, accumulators, c, n);
+  epilogue(iterator_D, accumulators, c32, n);
 }
 
 }  // namespace
@@ -536,9 +538,11 @@ torch::Tensor launch_sm70_marlin_mxfp4_gemm(
   smem_bytes = configure_sm70_dynamic_smem<SharedStorage>(split_kernel);
 
   int64_t const numel = size_m * size_n;
-  C10_CUDA_CHECK(cudaMemsetAsync(
-      c.data_ptr<at::Half>(), 0,
-      static_cast<size_t>(numel) * sizeof(at::Half), stream));
+  // 0009: fp32 split-K scratch (zeroed for the fp32 atomicAdd), M*N floats.
+  // Only allocated on the split_k>1 path, which the auto-selector uses ONLY at
+  // low batch (M<128), so the scratch is bounded and small.
+  auto c32 = torch::zeros({size_m, size_n},
+                          a.options().dtype(at::kFloat));
 
   dim3 grid = sm70_marlin_cta_grid(size_m, size_n, CtaM, CtaN);
   int const active_split_k =
@@ -549,8 +553,18 @@ torch::Tensor launch_sm70_marlin_mxfp4_gemm(
       reinterpret_cast<uint32_t const*>(b_q_weight.data_ptr<int32_t>()),
       reinterpret_cast<uint8_t const*>(b_scales.data_ptr()),
       reinterpret_cast<cutlass::half_t*>(c.data_ptr<at::Half>()),
+      c32.data_ptr<float>(),
       static_cast<int>(size_m), static_cast<int>(size_n),
       static_cast<int>(size_k), static_cast<int>(a.stride(0)), requested_split_k);
+  C10_CUDA_KERNEL_LAUNCH_CHECK();
+
+  // 0009: single deterministic-width fp32->fp16 narrow of the scratch.
+  int const narrow_block = 256;
+  int const narrow_grid =
+      static_cast<int>((numel + narrow_block - 1) / narrow_block);
+  sm70_marlin_narrow_f32_to_f16<256><<<narrow_grid, narrow_block, 0, stream>>>(
+      c32.data_ptr<float>(),
+      reinterpret_cast<half*>(c.data_ptr<at::Half>()), numel);
   C10_CUDA_KERNEL_LAUNCH_CHECK();
 
   return c;

--- a/csrc/quantization/marlin/sm70_marlin_nvfp4_gemm.cu
+++ b/csrc/quantization/marlin/sm70_marlin_nvfp4_gemm.cu
@@ -23,6 +23,8 @@
 
 using marlin::sm70::Sm70CtaGeometry;
 using marlin::sm70::Sm70AtomicFp16Epilogue;
+using marlin::sm70::Sm70AtomicFp32Epilogue;
+using marlin::sm70::sm70_marlin_narrow_f32_to_f16;
 using marlin::sm70::Sm70MarlinGemmTraits;
 using marlin::sm70::Sm70SplitKPartition;
 using marlin::sm70::validate_sm70_marlin_dense_cta_geometry_supported;
@@ -414,11 +416,11 @@ void sm70_marlin_nvfp4_gemm_splitk_kernel(
     uint32_t const* __restrict__ b_q_weight,
     uint8_t const* __restrict__ b_scales,
     float const* __restrict__ global_scale,
-    cutlass::half_t* __restrict__ c, int m, int n, int k, int lda, int requested_split_k) {
+    cutlass::half_t* __restrict__ c, float* __restrict__ c32, int m, int n, int k, int lda, int requested_split_k) {
   using Traits = Sm70Nvfp4GemmTraits<CtaM, CtaN, CtaK, Warps, WarpM,
                                   WarpN, WarpK, GroupSize, PackedMacroN>;
   using Mma = typename Traits::Mma;
-  using AtomicEpilogue = Sm70AtomicFp16Epilogue<Traits>;
+  using AtomicEpilogue = Sm70AtomicFp32Epilogue<Traits>;
 
   extern __shared__ char smem[];
   auto& shared_storage =
@@ -467,7 +469,7 @@ void sm70_marlin_nvfp4_gemm_splitk_kernel(
 
   AtomicEpilogue epilogue(shared_storage.epilogue, thread_idx, warp_idx,
                           lane_idx);
-  epilogue(iterator_D, accumulators, c, n);
+  epilogue(iterator_D, accumulators, c32, n);
 }
 
 }  // namespace
@@ -514,9 +516,11 @@ torch::Tensor launch_sm70_marlin_nvfp4_gemm(
   smem_bytes = configure_sm70_dynamic_smem<SharedStorage>(split_kernel);
 
   int64_t const numel = size_m * size_n;
-  C10_CUDA_CHECK(cudaMemsetAsync(
-      c.data_ptr<at::Half>(), 0,
-      static_cast<size_t>(numel) * sizeof(at::Half), stream));
+  // 0009: fp32 split-K scratch (zeroed for the fp32 atomicAdd), M*N floats.
+  // Only allocated on the split_k>1 path, which the auto-selector uses ONLY at
+  // low batch (M<128), so the scratch is bounded and small.
+  auto c32 = torch::zeros({size_m, size_n},
+                          a.options().dtype(at::kFloat));
 
   dim3 grid = sm70_marlin_cta_grid(size_m, size_n, CtaM, CtaN);
   int const active_split_k =
@@ -528,8 +532,18 @@ torch::Tensor launch_sm70_marlin_nvfp4_gemm(
       reinterpret_cast<uint8_t const*>(b_scales.data_ptr()),
       reinterpret_cast<float const*>(global_scale.data_ptr<float>()),
       reinterpret_cast<cutlass::half_t*>(c.data_ptr<at::Half>()),
+      c32.data_ptr<float>(),
       static_cast<int>(size_m), static_cast<int>(size_n),
       static_cast<int>(size_k), static_cast<int>(a.stride(0)), requested_split_k);
+  C10_CUDA_KERNEL_LAUNCH_CHECK();
+
+  // 0009: single deterministic-width fp32->fp16 narrow of the scratch.
+  int const narrow_block = 256;
+  int const narrow_grid =
+      static_cast<int>((numel + narrow_block - 1) / narrow_block);
+  sm70_marlin_narrow_f32_to_f16<256><<<narrow_grid, narrow_block, 0, stream>>>(
+      c32.data_ptr<float>(),
+      reinterpret_cast<half*>(c.data_ptr<at::Half>()), numel);
   C10_CUDA_KERNEL_LAUNCH_CHECK();
 
   return c;

--- a/csrc/quantization/marlin/sm70_marlin_splitk.cuh
+++ b/csrc/quantization/marlin/sm70_marlin_splitk.cuh
@@ -227,4 +227,143 @@ class Sm70AtomicFp16Epilogue {
   }
 };
 
+template <typename Traits>
+class Sm70AtomicFp32Epilogue {
+ public:
+  using CutlassEpilogue = typename Traits::Epilogue;
+  using SharedStorage = typename CutlassEpilogue::Base::SharedStorage;
+  using AccumulatorTile = typename CutlassEpilogue::AccumulatorTile;
+  using AccumulatorFragmentIterator =
+      typename CutlassEpilogue::AccumulatorFragmentIterator;
+  using WarpTileIterator = typename CutlassEpilogue::WarpTileIterator;
+  using SharedLoadIterator = typename CutlassEpilogue::SharedLoadIterator;
+  using OutputTileIterator = typename CutlassEpilogue::OutputTileIterator;
+  using ThreadMap = typename OutputTileIterator::ThreadMap;
+
+ private:
+  WarpTileIterator warp_tile_iterator_;
+  SharedLoadIterator shared_load_iterator_;
+
+  CUTLASS_DEVICE
+  void atomic_store_fragment(OutputTileIterator const& destination_iterator,
+                             typename SharedLoadIterator::Fragment const& frag,
+                             float* __restrict__ c, int n) const {
+    float const* frag_ptr = reinterpret_cast<float const*>(&frag);
+    int const thread_start_row = destination_iterator.thread_start_row();
+    int const thread_start_column = destination_iterator.thread_start_column();
+    int const extent_row = destination_iterator.extent_row();
+
+    CUTLASS_PRAGMA_UNROLL
+    for (int cluster = 0; cluster < ThreadMap::Iterations::kCluster;
+         ++cluster) {
+      CUTLASS_PRAGMA_UNROLL
+      for (int group = 0; group < ThreadMap::Iterations::kGroup; ++group) {
+        CUTLASS_PRAGMA_UNROLL
+        for (int row = 0; row < ThreadMap::Iterations::kRow; ++row) {
+          int const frag_row_idx =
+              row + ThreadMap::Iterations::kRow *
+                        (group + ThreadMap::Iterations::kGroup * cluster);
+          int const row_offset =
+              row * ThreadMap::Delta::kRow +
+              group * ThreadMap::Delta::kGroup +
+              cluster * ThreadMap::Delta::kCluster;
+          int const logical_row = thread_start_row + row_offset;
+
+          CUTLASS_PRAGMA_UNROLL
+          for (int column = 0; column < ThreadMap::Iterations::kColumn;
+               ++column) {
+            int const logical_column_base =
+                thread_start_column + column * ThreadMap::Delta::kColumn;
+            int const frag_base =
+                (frag_row_idx * ThreadMap::Iterations::kColumn + column) *
+                ThreadMap::kElementsPerAccess;
+
+            if (logical_row < extent_row) {
+              CUTLASS_PRAGMA_UNROLL
+              for (int e = 0; e < ThreadMap::kElementsPerAccess; ++e) {
+                int64_t const offset =
+                    int64_t(logical_row) * n + logical_column_base + e;
+                atomicAdd(c + offset, frag_ptr[frag_base + e]);
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+ public:
+  CUTLASS_DEVICE
+  Sm70AtomicFp32Epilogue(SharedStorage& shared_storage, int thread_idx,
+                              int warp_idx, int lane_idx)
+      : warp_tile_iterator_(shared_storage.reference(), lane_idx),
+        shared_load_iterator_(shared_storage.reference(), thread_idx) {
+    using WarpCount = typename CutlassEpilogue::WarpCount;
+    int const warp_k = warp_idx / (WarpCount::kM * WarpCount::kN);
+    int const warp_mn = warp_idx % (WarpCount::kM * WarpCount::kN);
+    int const warp_m = warp_mn % WarpCount::kM;
+    int const warp_n = warp_mn / WarpCount::kM;
+
+    cutlass::MatrixCoord warp_offset{warp_k * WarpCount::kM + warp_m,
+                                     warp_n};
+    warp_tile_iterator_.add_tile_offset(warp_offset);
+  }
+
+  CUTLASS_DEVICE
+  void operator()(OutputTileIterator destination_iterator,
+                  AccumulatorTile const& accumulators,
+                  float* __restrict__ c, int n) {
+    AccumulatorFragmentIterator accum_fragment_iterator(accumulators);
+
+    CUTLASS_PRAGMA_UNROLL
+    for (int iter = 0; iter < OutputTileIterator::kIterations; ++iter) {
+      __syncthreads();
+
+      typename AccumulatorFragmentIterator::Fragment accum_fragment;
+      accum_fragment_iterator.load(accum_fragment);
+      ++accum_fragment_iterator;
+      warp_tile_iterator_.store(accum_fragment);
+
+      __syncthreads();
+
+      typename SharedLoadIterator::Fragment aligned_accum_fragment;
+      shared_load_iterator_.load(aligned_accum_fragment);
+
+      if (CutlassEpilogue::kPartitionsK > 1) {
+        cutlass::plus<typename SharedLoadIterator::Fragment> add_fragments;
+
+        CUTLASS_PRAGMA_UNROLL
+        for (int i = 1; i < CutlassEpilogue::kPartitionsK; ++i) {
+          typename SharedLoadIterator::Fragment aligned_addend_fragment;
+          shared_load_iterator_.add_pointer_offset(
+              CutlassEpilogue::kSmemPointerOffset);
+          shared_load_iterator_.load(aligned_addend_fragment);
+          aligned_accum_fragment =
+              add_fragments(aligned_accum_fragment, aligned_addend_fragment);
+        }
+
+        shared_load_iterator_.add_pointer_offset(
+            (1 - CutlassEpilogue::kPartitionsK) *
+            CutlassEpilogue::kSmemPointerOffset);
+      }
+
+      atomic_store_fragment(destination_iterator, aligned_accum_fragment, c,
+                            n);
+      ++destination_iterator;
+    }
+  }
+};
+
+
+// 0009: single fp32->fp16 narrow of the split-K scratch (replaces the per-partial
+// __float2half_rn narrow the fp16-atomic epilogue did S times). Templated so the
+// symbol has vague linkage across the 7 gemm TUs that include this header.
+template <int BlockSize = 256>
+__global__ void sm70_marlin_narrow_f32_to_f16(const float* __restrict__ src,
+                                              half* __restrict__ dst,
+                                              int64_t numel) {
+  int64_t i = int64_t(blockIdx.x) * BlockSize + threadIdx.x;
+  if (i < numel) dst[i] = __float2half_rn(src[i]);
+}
+
 }  // namespace marlin::sm70

--- a/csrc/quantization/marlin/sm70_marlin_u4_gemm.cu
+++ b/csrc/quantization/marlin/sm70_marlin_u4_gemm.cu
@@ -22,6 +22,8 @@
 
 using marlin::sm70::Sm70CtaGeometry;
 using marlin::sm70::Sm70AtomicFp16Epilogue;
+using marlin::sm70::Sm70AtomicFp32Epilogue;
+using marlin::sm70::sm70_marlin_narrow_f32_to_f16;
 using marlin::sm70::Sm70MarlinGemmTraits;
 using marlin::sm70::Sm70SplitKPartition;
 using marlin::sm70::validate_sm70_marlin_dense_cta_geometry_supported;
@@ -476,12 +478,12 @@ void sm70_marlin_u4_gemm_splitk_kernel(
     uint32_t const* __restrict__ b_q_weight,
     cutlass::half_t const* __restrict__ b_scales,
     cutlass::half_t const* __restrict__ b_zeros,
-    cutlass::half_t* __restrict__ c, int m, int n, int k, int lda, int requested_split_k) {
+    cutlass::half_t* __restrict__ c, float* __restrict__ c32, int m, int n, int k, int lda, int requested_split_k) {
   using Traits = Sm70U4ZpGemmTraits<CtaM, CtaN, CtaK, Warps, WarpM,
                                     WarpN, WarpK, GroupSize, PackedMacroN,
                                     UseMetadataVectorWords>;
   using Mma = typename Traits::Mma;
-  using AtomicEpilogue = Sm70AtomicFp16Epilogue<Traits>;
+  using AtomicEpilogue = Sm70AtomicFp32Epilogue<Traits>;
 
   extern __shared__ char smem[];
   auto& shared_storage =
@@ -529,7 +531,7 @@ void sm70_marlin_u4_gemm_splitk_kernel(
 
   AtomicEpilogue epilogue(shared_storage.epilogue, thread_idx, warp_idx,
                           lane_idx);
-  epilogue(iterator_D, accumulators, c, n);
+  epilogue(iterator_D, accumulators, c32, n);
 }
 
 }  // namespace
@@ -578,9 +580,11 @@ torch::Tensor launch_sm70_marlin_u4_gemm(
   smem_bytes = configure_sm70_dynamic_smem<SharedStorage>(split_kernel);
 
   int64_t const numel = size_m * size_n;
-  C10_CUDA_CHECK(cudaMemsetAsync(
-      c.data_ptr<at::Half>(), 0,
-      static_cast<size_t>(numel) * sizeof(at::Half), stream));
+  // 0009: fp32 split-K scratch (zeroed for the fp32 atomicAdd), M*N floats.
+  // Only allocated on the split_k>1 path, which the auto-selector uses ONLY at
+  // low batch (M<128), so the scratch is bounded and small.
+  auto c32 = torch::zeros({size_m, size_n},
+                          a.options().dtype(at::kFloat));
 
   dim3 grid = sm70_marlin_cta_grid(size_m, size_n, CtaM, CtaN);
   int const active_split_k =
@@ -592,8 +596,18 @@ torch::Tensor launch_sm70_marlin_u4_gemm(
       reinterpret_cast<cutlass::half_t const*>(b_scales.data_ptr<at::Half>()),
       reinterpret_cast<cutlass::half_t const*>(b_zeros.data_ptr<at::Half>()),
       reinterpret_cast<cutlass::half_t*>(c.data_ptr<at::Half>()),
+      c32.data_ptr<float>(),
       static_cast<int>(size_m), static_cast<int>(size_n),
       static_cast<int>(size_k), static_cast<int>(a.stride(0)), requested_split_k);
+  C10_CUDA_KERNEL_LAUNCH_CHECK();
+
+  // 0009: single deterministic-width fp32->fp16 narrow of the scratch.
+  int const narrow_block = 256;
+  int const narrow_grid =
+      static_cast<int>((numel + narrow_block - 1) / narrow_block);
+  sm70_marlin_narrow_f32_to_f16<256><<<narrow_grid, narrow_block, 0, stream>>>(
+      c32.data_ptr<float>(),
+      reinterpret_cast<half*>(c.data_ptr<at::Half>()), numel);
   C10_CUDA_KERNEL_LAUNCH_CHECK();
 
   return c;

--- a/csrc/quantization/marlin/sm70_marlin_u4b8_gemm.cu
+++ b/csrc/quantization/marlin/sm70_marlin_u4b8_gemm.cu
@@ -22,6 +22,8 @@
 
 using marlin::sm70::Sm70CtaGeometry;
 using marlin::sm70::Sm70AtomicFp16Epilogue;
+using marlin::sm70::Sm70AtomicFp32Epilogue;
+using marlin::sm70::sm70_marlin_narrow_f32_to_f16;
 using marlin::sm70::Sm70MarlinGemmTraits;
 using marlin::sm70::Sm70SplitKPartition;
 using marlin::sm70::validate_sm70_marlin_dense_cta_geometry_supported;
@@ -439,12 +441,12 @@ void sm70_marlin_u4b8_gemm_splitk_kernel(
     cutlass::half_t const* __restrict__ a,
     uint32_t const* __restrict__ b_q_weight,
     cutlass::half_t const* __restrict__ b_scales,
-    cutlass::half_t* __restrict__ c, int m, int n, int k, int lda, int requested_split_k) {
+    cutlass::half_t* __restrict__ c, float* __restrict__ c32, int m, int n, int k, int lda, int requested_split_k) {
   using Traits = Sm70U4B8GemmTraits<CtaM, CtaN, CtaK, Warps, WarpM,
                                     WarpN, WarpK, GroupSize, PackedMacroN,
                                     UseMetadataVectorWords>;
   using Mma = typename Traits::Mma;
-  using AtomicEpilogue = Sm70AtomicFp16Epilogue<Traits>;
+  using AtomicEpilogue = Sm70AtomicFp32Epilogue<Traits>;
 
   extern __shared__ char smem[];
   auto& shared_storage =
@@ -491,7 +493,7 @@ void sm70_marlin_u4b8_gemm_splitk_kernel(
 
   AtomicEpilogue epilogue(shared_storage.epilogue, thread_idx, warp_idx,
                           lane_idx);
-  epilogue(iterator_D, accumulators, c, n);
+  epilogue(iterator_D, accumulators, c32, n);
 }
 
 }  // namespace
@@ -541,9 +543,11 @@ torch::Tensor launch_sm70_marlin_u4b8_gemm(
   smem_bytes = configure_sm70_dynamic_smem<SharedStorage>(split_kernel);
 
   int64_t const numel = size_m * size_n;
-  C10_CUDA_CHECK(cudaMemsetAsync(
-      c.data_ptr<at::Half>(), 0,
-      static_cast<size_t>(numel) * sizeof(at::Half), stream));
+  // 0009: fp32 split-K scratch (zeroed for the fp32 atomicAdd), M*N floats.
+  // Only allocated on the split_k>1 path, which the auto-selector uses ONLY at
+  // low batch (M<128), so the scratch is bounded and small.
+  auto c32 = torch::zeros({size_m, size_n},
+                          a.options().dtype(at::kFloat));
 
   dim3 grid = sm70_marlin_cta_grid(size_m, size_n, CtaM, CtaN);
   int const active_split_k =
@@ -554,8 +558,18 @@ torch::Tensor launch_sm70_marlin_u4b8_gemm(
       reinterpret_cast<uint32_t const*>(b_q_weight.data_ptr<int32_t>()),
       reinterpret_cast<cutlass::half_t const*>(b_scales.data_ptr<at::Half>()),
       reinterpret_cast<cutlass::half_t*>(c.data_ptr<at::Half>()),
+      c32.data_ptr<float>(),
       static_cast<int>(size_m), static_cast<int>(size_n),
       static_cast<int>(size_k), static_cast<int>(a.stride(0)), requested_split_k);
+  C10_CUDA_KERNEL_LAUNCH_CHECK();
+
+  // 0009: single deterministic-width fp32->fp16 narrow of the scratch.
+  int const narrow_block = 256;
+  int const narrow_grid =
+      static_cast<int>((numel + narrow_block - 1) / narrow_block);
+  sm70_marlin_narrow_f32_to_f16<256><<<narrow_grid, narrow_block, 0, stream>>>(
+      c32.data_ptr<float>(),
+      reinterpret_cast<half*>(c.data_ptr<at::Half>()), numel);
   C10_CUDA_KERNEL_LAUNCH_CHECK();
 
   return c;

--- a/csrc/quantization/marlin/sm70_marlin_u8_gemm.cu
+++ b/csrc/quantization/marlin/sm70_marlin_u8_gemm.cu
@@ -22,6 +22,8 @@
 
 using marlin::sm70::Sm70CtaGeometry;
 using marlin::sm70::Sm70AtomicFp16Epilogue;
+using marlin::sm70::Sm70AtomicFp32Epilogue;
+using marlin::sm70::sm70_marlin_narrow_f32_to_f16;
 using marlin::sm70::Sm70MarlinGemmTraits;
 using marlin::sm70::Sm70SplitKPartition;
 using marlin::sm70::validate_sm70_marlin_dense_cta_geometry_supported;
@@ -503,12 +505,12 @@ void sm70_marlin_u8_gemm_splitk_kernel(
     uint32_t const* __restrict__ b_q_weight,
     cutlass::half_t const* __restrict__ b_scales,
     cutlass::half_t const* __restrict__ b_zeros,
-    cutlass::half_t* __restrict__ c, int m, int n, int k, int lda, int requested_split_k) {
+    cutlass::half_t* __restrict__ c, float* __restrict__ c32, int m, int n, int k, int lda, int requested_split_k) {
   using Traits = Sm70U8ZpGemmTraits<CtaM, CtaN, CtaK, Warps, WarpM,
                                     WarpN, WarpK, GroupSize, PackedMacroN,
                                     UseMetadataVectorWords>;
   using Mma = typename Traits::Mma;
-  using AtomicEpilogue = Sm70AtomicFp16Epilogue<Traits>;
+  using AtomicEpilogue = Sm70AtomicFp32Epilogue<Traits>;
 
   extern __shared__ char smem[];
   auto& shared_storage =
@@ -556,7 +558,7 @@ void sm70_marlin_u8_gemm_splitk_kernel(
 
   AtomicEpilogue epilogue(shared_storage.epilogue, thread_idx, warp_idx,
                           lane_idx);
-  epilogue(iterator_D, accumulators, c, n);
+  epilogue(iterator_D, accumulators, c32, n);
 }
 
 }  // namespace
@@ -606,9 +608,11 @@ torch::Tensor launch_sm70_marlin_u8_gemm(
   smem_bytes = configure_sm70_dynamic_smem<SharedStorage>(split_kernel);
 
   int64_t const numel = size_m * size_n;
-  C10_CUDA_CHECK(cudaMemsetAsync(
-      c.data_ptr<at::Half>(), 0,
-      static_cast<size_t>(numel) * sizeof(at::Half), stream));
+  // 0009: fp32 split-K scratch (zeroed for the fp32 atomicAdd), M*N floats.
+  // Only allocated on the split_k>1 path, which the auto-selector uses ONLY at
+  // low batch (M<128), so the scratch is bounded and small.
+  auto c32 = torch::zeros({size_m, size_n},
+                          a.options().dtype(at::kFloat));
 
   dim3 grid = sm70_marlin_cta_grid(size_m, size_n, CtaM, CtaN);
   int const active_split_k =
@@ -620,8 +624,18 @@ torch::Tensor launch_sm70_marlin_u8_gemm(
       reinterpret_cast<cutlass::half_t const*>(b_scales.data_ptr<at::Half>()),
       reinterpret_cast<cutlass::half_t const*>(b_zeros.data_ptr<at::Half>()),
       reinterpret_cast<cutlass::half_t*>(c.data_ptr<at::Half>()),
+      c32.data_ptr<float>(),
       static_cast<int>(size_m), static_cast<int>(size_n),
       static_cast<int>(size_k), static_cast<int>(a.stride(0)), requested_split_k);
+  C10_CUDA_KERNEL_LAUNCH_CHECK();
+
+  // 0009: single deterministic-width fp32->fp16 narrow of the scratch.
+  int const narrow_block = 256;
+  int const narrow_grid =
+      static_cast<int>((numel + narrow_block - 1) / narrow_block);
+  sm70_marlin_narrow_f32_to_f16<256><<<narrow_grid, narrow_block, 0, stream>>>(
+      c32.data_ptr<float>(),
+      reinterpret_cast<half*>(c.data_ptr<at::Half>()), numel);
   C10_CUDA_KERNEL_LAUNCH_CHECK();
 
   return c;

--- a/csrc/quantization/marlin/sm70_marlin_u8b128_gemm.cu
+++ b/csrc/quantization/marlin/sm70_marlin_u8b128_gemm.cu
@@ -22,6 +22,8 @@
 
 using marlin::sm70::Sm70CtaGeometry;
 using marlin::sm70::Sm70AtomicFp16Epilogue;
+using marlin::sm70::Sm70AtomicFp32Epilogue;
+using marlin::sm70::sm70_marlin_narrow_f32_to_f16;
 using marlin::sm70::Sm70MarlinGemmTraits;
 using marlin::sm70::Sm70SplitKPartition;
 using marlin::sm70::validate_sm70_marlin_dense_cta_geometry_supported;
@@ -468,12 +470,12 @@ void sm70_marlin_u8b128_gemm_splitk_kernel(
     cutlass::half_t const* __restrict__ a,
     uint32_t const* __restrict__ b_q_weight,
     cutlass::half_t const* __restrict__ b_scales,
-    cutlass::half_t* __restrict__ c, int m, int n, int k, int lda, int requested_split_k) {
+    cutlass::half_t* __restrict__ c, float* __restrict__ c32, int m, int n, int k, int lda, int requested_split_k) {
   using Traits = Sm70U8B128GemmTraits<CtaM, CtaN, CtaK, Warps, WarpM,
                                       WarpN, WarpK, GroupSize, PackedMacroN,
                                       UseMetadataVectorWords>;
   using Mma = typename Traits::Mma;
-  using AtomicEpilogue = Sm70AtomicFp16Epilogue<Traits>;
+  using AtomicEpilogue = Sm70AtomicFp32Epilogue<Traits>;
 
   extern __shared__ char smem[];
   auto& shared_storage =
@@ -520,7 +522,7 @@ void sm70_marlin_u8b128_gemm_splitk_kernel(
 
   AtomicEpilogue epilogue(shared_storage.epilogue, thread_idx, warp_idx,
                           lane_idx);
-  epilogue(iterator_D, accumulators, c, n);
+  epilogue(iterator_D, accumulators, c32, n);
 }
 
 }  // namespace
@@ -570,9 +572,11 @@ torch::Tensor launch_sm70_marlin_u8b128_gemm(
   smem_bytes = configure_sm70_dynamic_smem<SharedStorage>(split_kernel);
 
   int64_t const numel = size_m * size_n;
-  C10_CUDA_CHECK(cudaMemsetAsync(
-      c.data_ptr<at::Half>(), 0,
-      static_cast<size_t>(numel) * sizeof(at::Half), stream));
+  // 0009: fp32 split-K scratch (zeroed for the fp32 atomicAdd), M*N floats.
+  // Only allocated on the split_k>1 path, which the auto-selector uses ONLY at
+  // low batch (M<128), so the scratch is bounded and small.
+  auto c32 = torch::zeros({size_m, size_n},
+                          a.options().dtype(at::kFloat));
 
   dim3 grid = sm70_marlin_cta_grid(size_m, size_n, CtaM, CtaN);
   int const active_split_k =
@@ -583,8 +587,18 @@ torch::Tensor launch_sm70_marlin_u8b128_gemm(
       reinterpret_cast<uint32_t const*>(b_q_weight.data_ptr<int32_t>()),
       reinterpret_cast<cutlass::half_t const*>(b_scales.data_ptr<at::Half>()),
       reinterpret_cast<cutlass::half_t*>(c.data_ptr<at::Half>()),
+      c32.data_ptr<float>(),
       static_cast<int>(size_m), static_cast<int>(size_n),
       static_cast<int>(size_k), static_cast<int>(a.stride(0)), requested_split_k);
+  C10_CUDA_KERNEL_LAUNCH_CHECK();
+
+  // 0009: single deterministic-width fp32->fp16 narrow of the scratch.
+  int const narrow_block = 256;
+  int const narrow_grid =
+      static_cast<int>((numel + narrow_block - 1) / narrow_block);
+  sm70_marlin_narrow_f32_to_f16<256><<<narrow_grid, narrow_block, 0, stream>>>(
+      c32.data_ptr<float>(),
+      reinterpret_cast<half*>(c.data_ptr<at::Half>()), numel);
   C10_CUDA_KERNEL_LAUNCH_CHECK();
 
   return c;

--- a/docs/design/sm70_v100_migration_control.md
+++ b/docs/design/sm70_v100_migration_control.md
@@ -41347,3 +41347,52 @@ Interpretation:
   full-model FP8-vs-FP16 greedy equality for this change: the E5M2 binary path
   is compile-time unchanged and has already passed the stronger same-cache
   bitwise A/B gate.
+
+## 2026-08-16 AWQ fallback and Marlin split-K quality audit
+
+- Audited PR 204 on current main `d879e2580a` with CUDA 12.8, Torch
+  2.10.0+cu128, and V100 SM70. The AWQ fallback and Marlin split-K changes
+  were treated as separate quality fixes even though they arrived in one PR.
+- The classic AWQ fallback is genuinely broken on SM70, not merely different
+  from an FP16 greedy reference. Its M=1 GEMM returned finite but uninitialized
+  values with alternating hashes and about 3.2 RMS error; its M=300 dequantize
+  path produced 19,200 NaNs in 38,400 output elements. Triton dequantize plus
+  matmul was finite, repeat-bit-exact, and had 0/`8.14e-5` RMS error at M=1/300
+  against the matching half reference. The fallback is restricted to exact
+  CUDA capability 7.0; CUDA SM60/SM75 and non-CUDA platforms retain their
+  existing route. Five platform-dispatch regression cases cover this gate.
+- The Marlin candidate/control binaries differ only in the seven dense SM70
+  launchers and shared split-K epilogue. Their SHA256 values are
+  `92c267fe...392` and `d8dcbf50...96ff`. Production Qwen AWQ
+  `M={1,16,48,96,128}, N=4352, K=5120, group=128` used the same packed weight,
+  activation, CTA geometry, metadata layout, and FP32 reference in both
+  processes. Split-1 output was bitwise identical between binaries.
+- Candidate/control split-K RMS ratios at M=1/16/48/96 were
+  0.750/0.760/0.849/0.853, reducing error by 14.7%-25.0% and bringing it back
+  to the split-1 floor. Across 50 eager repeats, the maximum output spread fell
+  from `0.0039-0.0059` to `0.00024-0.00195`. FP32 atomic order is still not
+  bitwise deterministic, but both error and instability are strictly smaller
+  than the existing FP16 atomic route.
+- Independent split-8 gates for uint4b8, uint8b128, uint8, FP8, and NVFP4 all
+  passed. Candidate RMS was 22.5%-59.9% lower than control, remained within the
+  corresponding split-1 numerical floor, and reduced maximum repeat spread
+  from about `0.0039-0.0059` to `3.05e-5-9.77e-4`. CUDA Graph capture/replay
+  passed for every valid format and for production AWQ M=1/M=48.
+- Swapped-GPU concurrent M=48 timing was candidate `0.12716/0.12726 ms` versus
+  control `0.13175/0.13144 ms`; graph replay was `0.12299/0.12296 ms` versus
+  `0.12771/0.12781 ms`. Thus the quality fix is about 3%-4% faster in this
+  matched gate, not a performance regression. Production M=1/M=48 split
+  kernels retain 128 registers/thread and zero local spill; split-1 resources
+  are unchanged. The narrow kernel uses 12 registers/thread.
+- A new SM70 regression test passes on the candidate and fails on the exact
+  control because control split-8 RMS is more than twice the split-1 floor.
+  Raw binaries, fixed inputs, outputs, JSON, resource tables, build logs, and
+  audit harnesses are retained under
+  `/data/minimax-h3/task-cache/pr204-awq-marlin-audit-20260816/`.
+- This audit also exposed an independent pre-existing MXFP4 coverage defect.
+  The SM70 dispatcher accepts only FP16 activation/output, while the generic
+  test matrix admits MXFP4 only with BF16, which the dispatcher rejects. Under
+  FP16, E8M0 scale bytes at or below 112 are currently clamped to zero by the
+  SM70 fast decoder and can produce severe reference error. This invalid path
+  was excluded from PR 204 acceptance and requires a separate fix and PR; do
+  not cite the rejected BF16 run or the invalid FP16 result as split-K evidence.

--- a/tests/kernels/quantization/test_sm70_marlin_splitk.py
+++ b/tests/kernels/quantization/test_sm70_marlin_splitk.py
@@ -1,0 +1,132 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import math
+
+import pytest
+import torch
+
+from vllm import _custom_ops as ops
+from vllm.model_executor.layers.quantization.utils.marlin_utils import (
+    marlin_make_workspace_new,
+    marlin_permute_scales,
+)
+from vllm.model_executor.layers.quantization.utils.quant_utils import (
+    gptq_pack,
+    gptq_quantize_weights,
+)
+from vllm.platforms import current_platform
+from vllm.scalar_type import scalar_types
+
+pytestmark = pytest.mark.skipif(
+    not current_platform.is_device_capability(70),
+    reason="The split-K FP32 reduction is specific to SM70.",
+)
+
+
+def test_sm70_marlin_splitk_fp32_reduction(monkeypatch: pytest.MonkeyPatch) -> None:
+    torch.manual_seed(20260816)
+    size_m, size_n, size_k = 1, 512, 1024
+    group_size = 128
+    quant_type = scalar_types.uint4b8
+    device = torch.device("cuda")
+
+    activation = torch.randn((size_m, size_k), dtype=torch.float16, device=device)
+    weight = torch.randn(
+        (size_k, size_n), dtype=torch.float16, device=device
+    ) / math.sqrt(size_k)
+    weight_ref, qweight, scales, _, _ = gptq_quantize_weights(
+        weight, quant_type, group_size, False
+    )
+    packed_weight = gptq_pack(qweight, quant_type.size_bits, size_k, size_n)
+    marlin_weight = ops.gptq_marlin_repack(
+        packed_weight,
+        torch.empty(0, dtype=torch.int32, device=device),
+        size_k,
+        size_n,
+        quant_type.size_bits,
+        False,
+    )
+    marlin_scales = marlin_permute_scales(scales, size_k, size_n, group_size)
+    workspace = marlin_make_workspace_new(device)
+    output = torch.empty((size_m, size_n), dtype=torch.float16, device=device)
+
+    monkeypatch.setenv("SM70_MARLIN_DENSE_CTA_GEOMETRY", "32x128x32x4x32x32x32")
+    monkeypatch.setenv("SM70_MARLIN_DENSE_METADATA_CACHE", "vector_words")
+
+    def run(split_k: int) -> torch.Tensor:
+        monkeypatch.setenv("SM70_MARLIN_DENSE_SPLIT_K", str(split_k))
+        return ops.marlin_gemm(
+            activation,
+            output,
+            marlin_weight,
+            None,
+            marlin_scales,
+            None,
+            None,
+            None,
+            None,
+            None,
+            workspace,
+            quant_type,
+            size_m,
+            size_n,
+            size_k,
+            is_k_full=True,
+            use_atomic_add=False,
+            use_fp32_reduce=True,
+            is_zp_float=False,
+        ).clone()
+
+    reference = torch.matmul(activation.float(), weight_ref.float())
+    split1 = run(1)
+    split8_outputs = [run(8) for _ in range(20)]
+    torch.cuda.synchronize()
+
+    split1_rms = torch.sqrt(torch.mean((split1.float() - reference).square()))
+    split8_rms = torch.sqrt(
+        torch.mean((split8_outputs[0].float() - reference).square())
+    )
+    max_eager_spread = max(
+        (item.float() - split8_outputs[0].float()).abs().max().item()
+        for item in split8_outputs
+    )
+    assert torch.isfinite(split8_outputs[0]).all()
+    assert split8_rms <= split1_rms * 1.05
+    assert max_eager_spread <= 0.001953125
+
+    graph = torch.cuda.CUDAGraph()
+    run(8)
+    torch.cuda.synchronize()
+    with torch.cuda.graph(graph):
+        ops.marlin_gemm(
+            activation,
+            output,
+            marlin_weight,
+            None,
+            marlin_scales,
+            None,
+            None,
+            None,
+            None,
+            None,
+            workspace,
+            quant_type,
+            size_m,
+            size_n,
+            size_k,
+            is_k_full=True,
+            use_atomic_add=False,
+            use_fp32_reduce=True,
+            is_zp_float=False,
+        )
+    graph_outputs = []
+    for _ in range(20):
+        graph.replay()
+        graph_outputs.append(output.clone())
+    torch.cuda.synchronize()
+    max_graph_spread = max(
+        (item.float() - graph_outputs[0].float()).abs().max().item()
+        for item in graph_outputs
+    )
+    assert max_graph_spread <= 0.001953125

--- a/tests/quantization/test_awq_sm70_fallback.py
+++ b/tests/quantization/test_awq_sm70_fallback.py
@@ -1,0 +1,67 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+import vllm.model_executor.layers.quantization.awq as awq_module
+import vllm.model_executor.layers.quantization.awq_triton as awq_triton
+from vllm.model_executor.layers.quantization.awq import AWQConfig, AWQLinearMethod
+
+
+class _FakePlatform:
+    def __init__(self, *, is_cuda: bool, capability: int | None):
+        self._is_cuda = is_cuda
+        self._capability = capability
+
+    def is_cuda(self) -> bool:
+        return self._is_cuda
+
+    def is_device_capability(self, capability: int) -> bool:
+        return self._capability == capability
+
+
+@pytest.mark.parametrize(
+    ("platform", "expected_route"),
+    [
+        (_FakePlatform(is_cuda=True, capability=70), "triton"),
+        (_FakePlatform(is_cuda=True, capability=60), "classic"),
+        (_FakePlatform(is_cuda=True, capability=75), "classic"),
+        (_FakePlatform(is_cuda=False, capability=70), "classic"),
+        (_FakePlatform(is_cuda=False, capability=None), "classic"),
+    ],
+)
+def test_awq_fallback_uses_triton_only_on_sm70(
+    monkeypatch: pytest.MonkeyPatch,
+    platform: _FakePlatform,
+    expected_route: str,
+) -> None:
+    calls: list[str] = []
+    weight = torch.arange(16, dtype=torch.float32).reshape(2, 8)
+
+    def triton_dequantize(*_args):
+        calls.append("triton")
+        return weight
+
+    def classic_gemm(x, *_args):
+        calls.append("classic")
+        return torch.matmul(x, weight)
+
+    monkeypatch.setattr(awq_module, "current_platform", platform)
+    monkeypatch.setattr(awq_triton, "awq_dequantize_triton", triton_dequantize)
+    monkeypatch.setattr(awq_module.ops, "awq_gemm", classic_gemm)
+
+    method = AWQLinearMethod(AWQConfig(4, 128, True))
+    layer = SimpleNamespace(
+        qweight=torch.empty((2, 1), dtype=torch.int32),
+        scales=torch.empty((1, 8), dtype=torch.float32),
+        qzeros=torch.empty((1, 1), dtype=torch.int32),
+    )
+    x = torch.ones((1, 2), dtype=torch.float32)
+
+    output = method.apply(layer, x)
+
+    assert calls == [expected_route]
+    torch.testing.assert_close(output, torch.matmul(x, weight))

--- a/vllm/model_executor/layers/quantization/awq.py
+++ b/vllm/model_executor/layers/quantization/awq.py
@@ -631,18 +631,10 @@ class AWQLinearMethod(LinearMethodBase):
                     .transpose(1, 2)
                     .reshape(reshaped_x.shape[0], out_shape[-1])
                 )
-        elif not current_platform.has_device_capability(75):
-            # SM70 (V100): both classic AWQ kernels are silently broken here.
-            # ops.awq_gemm's kernel is `#if __CUDA_ARCH__ < 750 assert(false)`;
-            # in a release (NDEBUG) build the assert is compiled out, leaving an
-            # EMPTY kernel that writes nothing and returns uninitialised memory.
-            # ops.awq_dequantize (dequantize_weights) has no arch guard but still
-            # returns NaN on SM70 (measured: all-zero input yields [nan,0,...]).
-            # This path is reached when VLLM_SM70_QUANT_BACKEND=marlin forces the
-            # Marlin backend (so the layer loads and turbomind is off) but a layer
-            # is Marlin-ineligible and falls back to AWQLinearMethod. Route it
-            # through the arch-agnostic triton dequant, which is present on every
-            # build and numerically matches an fp32 reference on SM70. (patch 0040)
+        elif current_platform.is_cuda() and current_platform.is_device_capability(70):
+            # The classic AWQ GEMM is unsupported on SM70, while its dequantize
+            # fallback can produce NaNs there. Use the architecture-independent
+            # Triton dequantizer for Marlin-ineligible V100 layers.
             from vllm.model_executor.layers.quantization.awq_triton import (
                 awq_dequantize_triton,
             )

--- a/vllm/model_executor/layers/quantization/awq.py
+++ b/vllm/model_executor/layers/quantization/awq.py
@@ -494,6 +494,25 @@ class AWQLinearMethod(LinearMethodBase):
                     .transpose(1, 2)
                     .reshape(reshaped_x.shape[0], out_shape[-1])
                 )
+        elif not current_platform.has_device_capability(75):
+            # SM70 (V100): both classic AWQ kernels are silently broken here.
+            # ops.awq_gemm's kernel is `#if __CUDA_ARCH__ < 750 assert(false)`;
+            # in a release (NDEBUG) build the assert is compiled out, leaving an
+            # EMPTY kernel that writes nothing and returns uninitialised memory.
+            # ops.awq_dequantize (dequantize_weights) has no arch guard but still
+            # returns NaN on SM70 (measured: all-zero input yields [nan,0,...]).
+            # This path is reached when VLLM_SM70_QUANT_BACKEND=marlin forces the
+            # Marlin backend (so the layer loads and turbomind is off) but a layer
+            # is Marlin-ineligible and falls back to AWQLinearMethod. Route it
+            # through the arch-agnostic triton dequant, which is present on every
+            # build and numerically matches an fp32 reference on SM70. (patch 0040)
+            from vllm.model_executor.layers.quantization.awq_triton import (
+                awq_dequantize_triton,
+            )
+
+            out_shape = x.shape[:-1] + (qweight.shape[-1] * pack_factor,)
+            out = awq_dequantize_triton(qweight, scales, qzeros)
+            out = torch.matmul(reshaped_x, out)
         elif FP16_MATMUL_HEURISTIC_CONDITION or envs.VLLM_BATCH_INVARIANT:
             # Batch invariant mode requires torch.matmul path for Triton override.
             out_shape = x.shape[:-1] + (qweight.shape[-1] * pack_factor,)


### PR DESCRIPTION
## Purpose

Audit and harden PR #204 before integration. This branch preserves both original commits, scopes the AWQ fallback to exact CUDA SM70, adds regression coverage, and records matched V100 quality/performance evidence.

Base: `d879e2580aac4b8b85641cf30ff94180dbdcf0d9`
Head: `79fbaec72866eee8d59d313dd26d70f287778c8f`
Supersedes: #204

## Findings and implementation

- Classic AWQ GEMM on SM70 returned uninitialized, non-repeatable values; classic AWQ dequant produced 19,200 NaNs in 38,400 M=300 outputs.
- Route Marlin-ineligible V100 AWQ layers through Triton dequant plus matmul only on exact CUDA capability 7.0. SM60, SM75, and non-CUDA dispatch regression cases retain their previous route.
- Preserve the original Marlin change: split-K partitions accumulate into FP32 scratch and narrow once to FP16. Split-1 is unchanged.
- Add a V100 regression that passes on the candidate and fails on exact main because control split-8 RMS is more than twice the split-1 floor.

## Test plan and result

- `pytest` scoped AWQ dispatch plus SM70 Marlin: 6 passed.
- AWQ Triton M=1/M=300: finite, repeat-bit-exact, RMS 0 / 8.14e-5 against matching half reference.
- Production AWQ `M={1,16,48,96,128},N=4352,K=5120,group=128`: split-1 candidate/control bitwise identical; split-K RMS reduced 14.7%-25.0%; 50-run maximum spread reduced from 0.0039-0.0059 to 0.00024-0.00195.
- uint4b8, uint8b128, uint8, FP8, and NVFP4 split-8: candidate RMS reduced 22.5%-59.9% and remained at the split-1 numerical floor.
- CUDA Graph capture/replay passed for all valid formats and production AWQ M=1/M=48.
- Swapped-GPU M=48 candidate/control: 0.12716/0.13175 ms and 0.12726/0.13144 ms; graph 0.12299/0.12771 ms and 0.12296/0.12781 ms.
- Production split kernels retain 128 registers/thread and zero local spill; split-1 resources are unchanged.
- Scoped ruff, markdownlint, typos, and diff checks passed. The repository-wide formatter has known baseline debt unrelated to this diff.

## Artifacts

`/data/minimax-h3/task-cache/pr204-awq-marlin-audit-20260816/` contains fixed inputs, candidate/control binaries, hashes, JSON outputs, resource tables, build logs, and standalone harnesses.

## Risks and rollback

FP32 atomics remain order-dependent, but measured output spread is strictly smaller than the existing FP16 atomic route. The independent pre-existing MXFP4 FP16/E8M0 scale defect is excluded from this PR and recorded for a separate fix. Rollback is reverting the two preserved #204 commits; default TurboMind routing remains unchanged.