### PR TITLE
[Kernel][SM70] Preserve MXFP4 E8M0 subnormal scales

### DIFF
--- a/csrc/moe/marlin_moe_wna16/sm70_marlin_mxfp4_gemm.cu
+++ b/csrc/moe/marlin_moe_wna16/sm70_marlin_mxfp4_gemm.cu
@@ -28,17 +28,12 @@ constexpr int kMxfp4ValuesPerWord = 8;
 
 CUTLASS_DEVICE
 __half2 e8m0x2_to_half2_fast(uint16_t e8m0_x2) {
-  int v0 = e8m0_x2 & 0xFF;
-  int v1 = e8m0_x2 >> 8;
-
-  int e0 = v0 - 112;
-  e0 = e0 < 0 ? 0 : (e0 > 31 ? 31 : e0);
-
-  int e1 = v1 - 112;
-  e1 = e1 < 0 ? 0 : (e1 > 31 ? 31 : e1);
-
-  uint32_t res = ((e1 << 10) << 16) | (e0 << 10);
-  return *reinterpret_cast<__half2*>(&res);
+  // Finite nonzero E8M0 bytes are IEEE FP32 exponent fields for
+  // 2^(value - 127); byte zero also rounds to FP16 zero. Let the hardware
+  // conversion preserve subnormals and apply round-to-nearest-even.
+  uint32_t const bits0 = static_cast<uint32_t>(e8m0_x2 & 0xFF) << 23;
+  uint32_t const bits1 = static_cast<uint32_t>(e8m0_x2 >> 8) << 23;
+  return __floats2half2_rn(__uint_as_float(bits0), __uint_as_float(bits1));
 }
 
 CUTLASS_DEVICE

--- a/csrc/quantization/marlin/sm70_marlin_mxfp4_gemm.cu
+++ b/csrc/quantization/marlin/sm70_marlin_mxfp4_gemm.cu
@@ -47,18 +47,12 @@ constexpr int kMxfp4ValuesPerWord = 8;
 
 CUTLASS_DEVICE
 __half2 e8m0x2_to_half2_fast(uint16_t e8m0_x2) {
-  int v0 = e8m0_x2 & 0xFF;
-  int v1 = e8m0_x2 >> 8;
-
-  int e0 = v0 - 112;
-  e0 = e0 < 0 ? 0 : (e0 > 31 ? 31 : e0);
-
-  int e1 = v1 - 112;
-  e1 = e1 < 0 ? 0 : (e1 > 31 ? 31 : e1);
-
-  uint32_t res = ((e1 << 10) << 16) | (e0 << 10);
-
-  return *reinterpret_cast<__half2*>(&res);
+  // Finite nonzero E8M0 bytes are IEEE FP32 exponent fields for
+  // 2^(value - 127); byte zero also rounds to FP16 zero. Let the hardware
+  // conversion preserve subnormals and apply round-to-nearest-even.
+  uint32_t const bits0 = static_cast<uint32_t>(e8m0_x2 & 0xFF) << 23;
+  uint32_t const bits1 = static_cast<uint32_t>(e8m0_x2 >> 8) << 23;
+  return __floats2half2_rn(__uint_as_float(bits0), __uint_as_float(bits1));
 }
 
 CUTLASS_DEVICE

--- a/docs/design/sm70_v100_migration_control.md
+++ b/docs/design/sm70_v100_migration_control.md
@@ -41396,3 +41396,49 @@ Interpretation:
   SM70 fast decoder and can produce severe reference error. This invalid path
   was excluded from PR 204 acceptance and requires a separate fix and PR; do
   not cite the rejected BF16 run or the invalid FP16 result as split-K evidence.
+
+## 2026-08-16 SM70 MXFP4 E8M0 subnormal quality repair
+
+- Reproduced the independent MXFP4 defect from the PR 204 audit on main
+  `064b8044bf` with CUDA 12.8, Torch 2.10.0+cu128, and V100 SM70. This is a
+  Marlin weight-scale decoder bug and is unrelated to the accepted numerical
+  difference between FP8 KV cache and FP16 KV cache.
+- An E8M0 byte represents `2^(byte - 127)`. Bytes 103-112 therefore map to
+  representable FP16 subnormals `2^-24` through `2^-15`; byte 102 is the
+  round-to-nearest-even tie below the minimum subnormal and must become zero.
+  Both dense and MoE decoders instead clamped every byte through 112 to zero.
+- Fixed-byte `M=1,N=512,K=1024,group=32` controls produced zero output for
+  bytes 103-112 while 510-511 of 512 FP16-reference elements were nonzero.
+  Relative RMS error was exactly 1.0 in both dense and MoE paths. Bytes 100,
+  102, 113, and 120 behaved as expected, isolating the decoder boundary.
+- The accepted implementation treats each E8M0 byte as an IEEE FP32 exponent
+  field and uses the SM70 FP32-to-FP16 round-to-nearest-even conversion. It
+  preserves FP16 subnormals without changing FP4 dequantization, HMMA, or FP32
+  accumulation order. Dense and MoE candidate binaries are
+  `488c8d1c...585d` and `059b1357...93d`; controls are
+  `92c267fe...392` and `f4dfacf1...fe0`.
+- Sixteen focused candidate regressions cover dense/MoE, split-K 1/8, and
+  E8M0 bytes 102/103/112/113. All pass bitwise against the matching FP16
+  reference. A wider fixed-byte sweep over 100/102/103/104/111/112/113/120
+  is also bitwise exact for dense and MoE at split-K 1 and 8. The exact control
+  fails both paths at bytes 103 and 112.
+- CUDA Graph replay is valid for the normal production-scale benchmark. In
+  swapped-GPU tests at byte 120, dense `M=1,N=4096,K=4096` eager medians improve
+  from `0.269427/0.269308` to `0.211488/0.211551 ms`; graph medians improve from
+  `0.268847/0.268723` to `0.210803/0.211058 ms` (about 21%). MoE
+  `M=1,N=512,K=4096` eager medians improve from `0.380061/0.379988` to
+  `0.276103/0.276185 ms`; graph medians improve from
+  `0.379811/0.379772` to `0.275853/0.275913 ms` (about 27%).
+- The representative dense non-split/split kernels move from 175/183 to
+  194/193 registers/thread; representative MoE variants move from 192/194 to
+  213/214. These shapes retain two resident CTAs and have no local spill. The
+  measured speedup confirms the hardware conversion removes more integer
+  decoder work than the added registers cost.
+- Rejected two explicit integer branch/shift variants. Although both repaired
+  quality, the better of them regressed dense `0.269 -> 0.554 ms` and MoE
+  `0.380 -> 0.648 ms` at the same normal-scale contract. Do not reintroduce a
+  dynamic subnormal shift into the metadata hot loop.
+- Source binaries, control/candidate outputs, build logs, resource tables,
+  pytest logs, swapped-GPU JSON, and standalone audit harnesses are retained
+  under
+  `/data/minimax-h3/task-cache/mxfp4-e8m0-subnormal-20260816/`.

--- a/tests/kernels/quantization/test_sm70_mxfp4_e8m0.py
+++ b/tests/kernels/quantization/test_sm70_mxfp4_e8m0.py
@@ -1,0 +1,145 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+import torch
+
+from vllm import _custom_ops as ops
+from vllm.model_executor.layers.fused_moe.moe_align_block_size import (
+    moe_align_block_size,
+)
+from vllm.model_executor.layers.quantization.utils.marlin_utils import (
+    marlin_make_workspace_new,
+)
+from vllm.model_executor.layers.quantization.utils.marlin_utils_fp4 import (
+    rand_marlin_weight_mxfp4_like,
+)
+from vllm.platforms import current_platform
+from vllm.scalar_type import scalar_types
+
+pytestmark = pytest.mark.skipif(
+    not current_platform.is_device_capability(70),
+    reason="The FP16 MXFP4 kernels under test are specific to SM70.",
+)
+
+_M = 1
+_N = 512
+_K = 1024
+_GROUP_SIZE = 32
+
+
+def _make_fixed_e8m0_case(
+    monkeypatch: pytest.MonkeyPatch, exponent: int
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    torch.manual_seed(20260816)
+    original_randint = torch.randint
+
+    def fixed_randint(low, high, size, **kwargs):
+        if low == 110 and high == 120 and kwargs.get("dtype") == torch.uint8:
+            return torch.full(
+                size,
+                exponent,
+                dtype=torch.uint8,
+                device=kwargs.get("device"),
+            )
+        return original_randint(low, high, size, **kwargs)
+
+    shape_only_weight = torch.empty((_N, _K), dtype=torch.float16, device="cuda")
+    with monkeypatch.context() as context:
+        context.setattr(torch, "randint", fixed_randint)
+        weight_ref, qweight, scales = rand_marlin_weight_mxfp4_like(
+            shape_only_weight, _GROUP_SIZE
+        )
+
+    activation = torch.ones((_M, _K), dtype=torch.float16, device="cuda")
+    reference = torch.matmul(activation.float(), weight_ref.float()).half()
+    return activation, qweight, scales, reference
+
+
+def _assert_matches_reference(output: torch.Tensor, reference: torch.Tensor) -> None:
+    if torch.count_nonzero(reference).item() == 0:
+        assert torch.count_nonzero(output).item() == 0
+        return
+    torch.testing.assert_close(output, reference, rtol=0, atol=0)
+
+
+@pytest.mark.parametrize("exponent", [102, 103, 112, 113])
+@pytest.mark.parametrize("split_k", [1, 8])
+def test_sm70_dense_mxfp4_preserves_e8m0_subnormals(
+    monkeypatch: pytest.MonkeyPatch, exponent: int, split_k: int
+) -> None:
+    activation, qweight, scales, reference = _make_fixed_e8m0_case(
+        monkeypatch, exponent
+    )
+    workspace = marlin_make_workspace_new(activation.device)
+    output = torch.empty((_M, _N), dtype=torch.float16, device="cuda")
+    monkeypatch.setenv("SM70_MARLIN_DENSE_SPLIT_K", str(split_k))
+
+    result = ops.marlin_gemm(
+        activation,
+        output,
+        qweight,
+        None,
+        scales,
+        None,
+        None,
+        None,
+        None,
+        None,
+        workspace,
+        scalar_types.float4_e2m1f,
+        _M,
+        _N,
+        _K,
+        is_k_full=True,
+        use_atomic_add=False,
+        use_fp32_reduce=True,
+        is_zp_float=False,
+    )
+    _assert_matches_reference(result, reference)
+
+
+@pytest.mark.parametrize("exponent", [102, 103, 112, 113])
+@pytest.mark.parametrize("split_k", [1, 8])
+def test_sm70_moe_mxfp4_preserves_e8m0_subnormals(
+    monkeypatch: pytest.MonkeyPatch, exponent: int, split_k: int
+) -> None:
+    activation, qweight, scales, reference = _make_fixed_e8m0_case(
+        monkeypatch, exponent
+    )
+    topk_ids = torch.zeros((_M, 1), dtype=torch.int64, device="cuda")
+    sorted_ids, expert_ids, padded = moe_align_block_size(topk_ids, 8, 1)
+    topk_weights = torch.ones((_M, 1), dtype=torch.float32, device="cuda")
+    workspace = marlin_make_workspace_new(activation.device, 4)
+    output = torch.empty((_M, _N), dtype=torch.float16, device="cuda")
+    monkeypatch.setenv("SM70_MARLIN_MOE_SPLIT_K", str(split_k))
+
+    result = ops.moe_wna16_marlin_gemm(
+        activation,
+        output,
+        qweight.unsqueeze(0),
+        None,
+        scales.unsqueeze(0),
+        None,
+        None,
+        None,
+        None,
+        None,
+        workspace,
+        sorted_ids,
+        expert_ids,
+        padded,
+        topk_weights,
+        8,
+        1,
+        False,
+        scalar_types.float4_e2m1f,
+        _M,
+        _N,
+        _K,
+        True,
+        False,
+        True,
+        False,
+    )
+    _assert_matches_reference(result, reference)


### PR DESCRIPTION
## Objective

Fix the SM70 Marlin dense and MoE MXFP4 E8M0 decoder so FP16-representable
subnormal scales are not flushed to zero.

Base: `064b8044bf3821ee10fc47458ec686d0b6f312df`

Head: `2f0a5056f9`

## Implementation and dispatch gates

- Decode finite nonzero E8M0 bytes through their IEEE FP32 exponent fields and
  use the SM70 FP32-to-FP16 round-to-nearest-even conversion.
- Apply the same correction to dense and MoE Marlin MXFP4 iterators.
- Do not change FP4 dequantization, HMMA, FP32 accumulation, dispatch, or
  non-SM70 routes.

## Quality and tests

- Exact main control flushes bytes 103-112 to zero in both dense and MoE;
  fixed-byte relative RMS error is 1.0.
- Candidate is bitwise equal to the matching FP16 reference for bytes
  100/102/103/104/111/112/113/120 at split-K 1 and 8.
- `16 passed` in
  `tests/kernels/quantization/test_sm70_mxfp4_e8m0.py` on V100 SM70.
- CUDA Graph replay passes the normal-scale dense and MoE benchmark.
- Ruff, scoped clang-format, typos, markdownlint, and `git diff --check` pass.

## Performance

CUDA 12.8, Torch 2.10.0+cu128, V100 SM70, E8M0 byte 120, swapped GPUs:

- Dense `M=1,N=4096,K=4096`: eager
  `0.269427/0.269308 -> 0.211488/0.211551 ms`; graph
  `0.268847/0.268723 -> 0.210803/0.211058 ms` (about 21% faster).
- MoE `M=1,N=512,K=4096`: eager
  `0.380061/0.379988 -> 0.276103/0.276185 ms`; graph
  `0.379811/0.379772 -> 0.275853/0.275913 ms` (about 27% faster).

Representative shapes keep the same two-CTA register occupancy and have no
local spill.

## Rejected variants and risks

- Rejected two integer branch/dynamic-shift implementations: both fixed
  quality but regressed dense `0.269 -> 0.554 ms` and MoE
  `0.380 -> 0.648 ms`.
- This repairs Marlin weight-scale decoding. It is unrelated to, and makes no
  FP8-KV-vs-FP16 greedy-equality claim.
- Generic all-files formatting debt remains pre-existing and is not expanded
  here.

## Artifacts

Builds, binary hashes, control/candidate outputs, resource reports, test logs,
swapped-GPU JSON, and audit harnesses:

`/data/minimax-h3/task-cache/mxfp4-e8m0-subnormal-20260816/`
