### PR TITLE
[Kernel] Audit SM70 MLA prefill routing

### DIFF
--- a/docs/design/sm70_v100_migration_control.md
+++ b/docs/design/sm70_v100_migration_control.md
@@ -41442,3 +41442,68 @@ Interpretation:
   pytest logs, swapped-GPU JSON, and standalone audit harnesses are retained
   under
   `/data/minimax-h3/task-cache/mxfp4-e8m0-subnormal-20260816/`.
+
+## 2026-08-16 FP8 E5M2 KV scale and decode-quality follow-up
+
+- The quality contract remains quantization-aware: FP8 KV and FP16 KV greedy
+  token identity is not required. The decisive checks are correct E5M2 byte
+  storage and scale semantics, finite output, repeat stability, bounded
+  independent-reader differences, and comparison with an FP64 oracle.
+- `reshape_and_cache_flash` was checked with non-unit tensor scales and
+  per-head scales. The stored E5M2 bytes were bitwise identical to the
+  PyTorch quantization reference in every case; no scale inversion, omitted
+  scale, head-indexing error, or byte-layout mismatch was found.
+- Scalar and XQA readers were checked at G6/D256, block 1616, and sequence
+  length 16385. With K/V scales 0.75/1.25, both routes were finite and
+  bitwise repeatable; their maximum difference was `3.0518e-5`, while maximum
+  FP64 errors were `1.8593e-5` (scalar) and `1.7135e-5` (XQA). With scales
+  0.015625/0.03125, the route difference was `4.7684e-7` and FP64 error was
+  about `3.44e-7`.
+- A wider pre-existing G6/block-1568/sequence-2049 test produced one scalar/XQA
+  difference of `1.2207e-4`. This is exactly one adjacent FP16 output step at
+  that magnitude: scalar was `-0.1254883`, XQA was `-0.1256104`, and the FP64
+  reference was `-0.1255173`. Relative RMS errors were `2.93e-4` and
+  `3.50e-4`; neither path showed corruption. The regression gate now retains
+  its `1e-4` absolute tolerance near zero but permits one representable FP16
+  output ULP, while retaining the independent mean-error bound.
+- Combined with the four long-output no-MTP/MTP x FP16/E5M2 lanes above, this
+  audit found no unexpected FP8 KV quality bug. Do not reopen an issue solely
+  because an FP8-KV greedy stream differs from FP16-KV; require a matched
+  violation of one of the numerical or stability gates.
+
+## 2026-08-16 PR 200 SM70 MLA prefill audit
+
+- PR 200's availability goal is valid, but its original load-time guard was
+  ineffective on the real V100 build. `is_flash_attn_varlen_func_available()`
+  returned true whenever the platform was CUDA even when importing
+  `vllm_flash_attn` had failed and the exported function was only an
+  always-raising stub. Consequently 192/128 asymmetric MLA, uncompiled head
+  dim 80, and BF16 configurations returned no rejection reasons and would
+  fail only at first prefill.
+- The audited route now detects exact SM70 explicitly, bases availability on
+  the Flash-V100 dense-LSE entry, and always applies the FP16, uniform-head,
+  and compiled-tile checks during selection. On a real V100, 256/256 FP16 is
+  accepted; 192/128 FP16, 80/80 FP16, and 256/256 BF16 are rejected at load
+  time with specific reasons.
+- The original causal dispatch also used Python object identity for the Q/K
+  cumulative-offset tensors. Independent tensors containing identical
+  offsets therefore fell through to the unavailable FA2 stub. The SM70 path
+  is now selected explicitly and validates offset values; it no longer relies
+  on tensor identity.
+- The dense-LSE driver validates dtype, packed layout, devices, head mapping,
+  complete monotonic Q/K metadata, output and LSE buffers, and unsupported
+  attention options. Empty-key rows are written as zero output with `-inf`
+  LSE so they are neutral in `merge_attn_states`; no uninitialized row is
+  allowed to reach the merge.
+- V100 context-chunk coverage used independent query lengths 3/2/4 and key
+  lengths 5/0/3 at GQA Hq4/Hkv2/D256. Output was repeat-bitwise-exact, the
+  empty-key request was exactly zero/`-inf`, relative RMS versus FP64 was
+  `1.3478e-4`, and finite LSE maximum error was `1.286e-6`. Causal packed
+  lengths 1/3/5 had output RMS `1.3075e-4` and LSE maximum error
+  `1.519e-6` versus FP64.
+- The complete SM70 policy suite passes 82/82 and the complete varlen/layout
+  GPU suite passes 20/20. The general MLA selector suite has three unrelated
+  V100 test-harness failures caused by patching `current_platform` with a
+  `MagicMock` during lazy custom-op import, followed by duplicate Torch-op
+  registration; its other 10 tests pass. Do not treat those import-pollution
+  failures as MLA numerical evidence.

--- a/tests/kernels/attention/test_sm70_flash_v100_varlen_layout.py
+++ b/tests/kernels/attention/test_sm70_flash_v100_varlen_layout.py
@@ -145,6 +145,208 @@ def test_sm70_flash_v100_fp8_e5m2_paged_kv_read_exact():
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
 @torch.inference_mode()
+def test_sm70_flash_v100_mla_context_lse_matches_fp64():
+    if torch.cuda.get_device_capability() != (7, 0):
+        pytest.skip("FlashAttention-V100 regression is SM70/V100 only")
+
+    pytest.importorskip("flash_attn_v100")
+    from vllm.v1.attention.backends.flash_attn_v100 import (
+        flash_v100_dense_prefill_lse,
+    )
+
+    torch.manual_seed(200001)
+    query_lens = [3, 2, 4]
+    key_lens = [5, 0, 3]
+    num_q_heads = 4
+    num_kv_heads = 2
+    head_dim = 256
+    softmax_scale = head_dim**-0.5
+    query = torch.randn(
+        sum(query_lens),
+        num_q_heads,
+        head_dim,
+        dtype=torch.float16,
+        device="cuda",
+    )
+    key = torch.randn(
+        sum(key_lens),
+        num_kv_heads,
+        head_dim,
+        dtype=torch.float16,
+        device="cuda",
+    )
+    value = torch.randn_like(key)
+    cu_q = torch.tensor(
+        [0, *torch.tensor(query_lens).cumsum(0).tolist()],
+        dtype=torch.int32,
+        device="cuda",
+    )
+    cu_k = torch.tensor(
+        [0, *torch.tensor(key_lens).cumsum(0).tolist()],
+        dtype=torch.int32,
+        device="cuda",
+    )
+
+    def run():
+        output = torch.empty_like(query)
+        lse = torch.empty(
+            (num_q_heads, query.shape[0]), dtype=torch.float32, device="cuda"
+        )
+        return flash_v100_dense_prefill_lse(
+            query,
+            key,
+            value,
+            output,
+            lse,
+            cu_q,
+            cu_k,
+            query.shape[0],
+            softmax_scale,
+        )
+
+    output, lse = run()
+    output_repeat, lse_repeat = run()
+
+    kv_head_for_q = torch.arange(num_q_heads, device="cuda") // (
+        num_q_heads // num_kv_heads
+    )
+    output_refs = []
+    lse_refs = []
+    query_offset = 0
+    key_offset = 0
+    for query_len, key_len in zip(query_lens, key_lens):
+        if key_len == 0:
+            output_refs.append(
+                torch.zeros(
+                    (query_len, num_q_heads, head_dim),
+                    dtype=torch.float64,
+                    device="cuda",
+                )
+            )
+            lse_refs.append(
+                torch.full(
+                    (num_q_heads, query_len),
+                    -torch.inf,
+                    dtype=torch.float64,
+                    device="cuda",
+                )
+            )
+        else:
+            q_seq = query[query_offset : query_offset + query_len].double()
+            k_seq = key[key_offset : key_offset + key_len, kv_head_for_q].double()
+            v_seq = value[key_offset : key_offset + key_len, kv_head_for_q].double()
+            scores = torch.einsum("qhd,khd->hqk", q_seq, k_seq) * softmax_scale
+            probabilities = torch.softmax(scores, dim=-1)
+            output_refs.append(torch.einsum("hqk,khd->qhd", probabilities, v_seq))
+            lse_refs.append(torch.logsumexp(scores, dim=-1))
+        query_offset += query_len
+        key_offset += key_len
+
+    output_ref = torch.cat(output_refs)
+    lse_ref = torch.cat(lse_refs, dim=1)
+    torch.accelerator.synchronize()
+
+    assert torch.equal(output, output_repeat)
+    assert torch.equal(lse, lse_repeat)
+    empty_start = query_lens[0]
+    empty_end = empty_start + query_lens[1]
+    assert torch.count_nonzero(output[empty_start:empty_end]) == 0
+    assert torch.isneginf(lse[:, empty_start:empty_end]).all()
+    output_error = output.double() - output_ref
+    relative_rms = torch.sqrt(torch.mean(output_error.square())) / torch.sqrt(
+        torch.mean(output_ref.square())
+    )
+    assert float(relative_rms) < 5e-4
+    finite_lse = torch.isfinite(lse_ref)
+    assert float((lse.double()[finite_lse] - lse_ref[finite_lse]).abs().max()) < 2e-5
+
+    bad_cu_q = cu_q.clone()
+    bad_cu_q[-1] -= 1
+    with pytest.raises(ValueError, match="cover every actual query token"):
+        flash_v100_dense_prefill_lse(
+            query,
+            key,
+            value,
+            torch.empty_like(query),
+            torch.empty_like(lse),
+            bad_cu_q,
+            cu_k,
+            query.shape[0],
+            softmax_scale,
+        )
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
+@torch.inference_mode()
+def test_sm70_flash_v100_mla_causal_lse_matches_fp64():
+    if torch.cuda.get_device_capability() != (7, 0):
+        pytest.skip("FlashAttention-V100 regression is SM70/V100 only")
+
+    pytest.importorskip("flash_attn_v100")
+    from vllm.v1.attention.backends.flash_attn_v100 import (
+        flash_v100_dense_prefill_lse,
+    )
+
+    torch.manual_seed(200002)
+    seq_lens = [1, 3, 5]
+    num_heads = 2
+    head_dim = 256
+    softmax_scale = head_dim**-0.5
+    shape = (sum(seq_lens), num_heads, head_dim)
+    query = torch.randn(shape, dtype=torch.float16, device="cuda")
+    key = torch.randn_like(query)
+    value = torch.randn_like(query)
+    cu_seq_lens = torch.tensor(
+        [0, *torch.tensor(seq_lens).cumsum(0).tolist()],
+        dtype=torch.int32,
+        device="cuda",
+    )
+    output = torch.empty_like(query)
+    lse = torch.empty((num_heads, query.shape[0]), dtype=torch.float32, device="cuda")
+
+    flash_v100_dense_prefill_lse(
+        query,
+        key,
+        value,
+        output,
+        lse,
+        cu_seq_lens,
+        cu_seq_lens.clone(),
+        query.shape[0],
+        softmax_scale,
+        causal=True,
+    )
+
+    output_refs = []
+    lse_refs = []
+    offset = 0
+    for seq_len in seq_lens:
+        q_seq = query[offset : offset + seq_len].double()
+        k_seq = key[offset : offset + seq_len].double()
+        v_seq = value[offset : offset + seq_len].double()
+        scores = torch.einsum("qhd,khd->hqk", q_seq, k_seq) * softmax_scale
+        causal_mask = torch.ones(
+            (seq_len, seq_len), dtype=torch.bool, device="cuda"
+        ).triu(1)
+        scores.masked_fill_(causal_mask, -torch.inf)
+        probabilities = torch.softmax(scores, dim=-1)
+        output_refs.append(torch.einsum("hqk,khd->qhd", probabilities, v_seq))
+        lse_refs.append(torch.logsumexp(scores, dim=-1))
+        offset += seq_len
+
+    output_ref = torch.cat(output_refs)
+    lse_ref = torch.cat(lse_refs, dim=1)
+    torch.accelerator.synchronize()
+    output_error = output.double() - output_ref
+    relative_rms = torch.sqrt(torch.mean(output_error.square())) / torch.sqrt(
+        torch.mean(output_ref.square())
+    )
+    assert float(relative_rms) < 5e-4
+    assert float((lse.double() - lse_ref).abs().max()) < 2e-5
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
+@torch.inference_mode()
 def test_sm70_flash_v100_bm32_phase_multi_kv_stride_exact(monkeypatch):
     if torch.cuda.get_device_capability() != (7, 0):
         pytest.skip("FlashAttention-V100 regression is SM70/V100 only")
@@ -412,5 +614,13 @@ def test_sm70_flash_v100_fp8_e5m2_xqa_decode_matches_scalar(
 
     torch.accelerator.synchronize()
     delta = (actual.float() - expected.float()).abs()
-    assert float(delta.max()) <= 1e-4
+    # The two reductions may round to adjacent fp16 outputs. Preserve the
+    # original absolute gate near zero, but do not set it below one output ULP.
+    positive = torch.full_like(expected, torch.inf)
+    negative = torch.full_like(expected, -torch.inf)
+    one_ulp = torch.maximum(
+        (torch.nextafter(expected, positive) - expected).abs(),
+        (torch.nextafter(expected, negative) - expected).abs(),
+    ).float()
+    assert torch.all(delta <= torch.maximum(one_ulp, torch.full_like(delta, 1e-4)))
     assert float(delta.mean()) <= 1e-5

--- a/tests/v1/attention/test_sm70_flash_v100_policy.py
+++ b/tests/v1/attention/test_sm70_flash_v100_policy.py
@@ -104,6 +104,93 @@ def test_split_paged_kv_cache_prefers_standard_axis_for_two_blocks():
     assert torch.equal(value_cache, kv_cache[:, 1])
 
 
+def test_sm70_mla_prefill_rejects_unsupported_configs(monkeypatch):
+    from vllm.v1.attention.backends.mla.prefill import flash_attn as mod
+
+    monkeypatch.setattr(mod, "_is_sm70_flash_v100_platform", lambda: True)
+    monkeypatch.setattr(mod, "_flash_v100_dense_prefill_lse_usable", lambda: True)
+    # The generic CUDA predicate can report a stub as available. SM70 selection
+    # must remain independent of it.
+    monkeypatch.setattr(mod, "is_flash_attn_varlen_func_available", lambda: True)
+    capability = SimpleNamespace(major=7, minor=0)
+
+    def reasons(dtype=torch.float16, qk_head_dim=256, v_head_dim=256):
+        config = SimpleNamespace(
+            dtype=dtype,
+            is_r1_compatible=False,
+            qk_head_dim=qk_head_dim,
+            v_head_dim=v_head_dim,
+        )
+        return mod.FlashAttnPrefillBackend.validate_configuration(capability, config)
+
+    assert reasons() == []
+    assert any(
+        "uniform" in reason for reason in reasons(qk_head_dim=192, v_head_dim=128)
+    )
+    assert any(
+        "no compiled kernel" in reason
+        for reason in reasons(qk_head_dim=80, v_head_dim=80)
+    )
+    assert any("requires float16" in reason for reason in reasons(dtype=torch.bfloat16))
+
+
+def test_sm70_mla_selector_extracts_uniform_head_dims():
+    from vllm.v1.attention.backends.mla.prefill.selector import _mla_head_dims
+
+    hf_text_config = SimpleNamespace(
+        qk_nope_head_dim=192,
+        qk_rope_head_dim=64,
+        v_head_dim=256,
+    )
+    vllm_config = SimpleNamespace(
+        model_config=SimpleNamespace(hf_text_config=hf_text_config)
+    )
+
+    assert _mla_head_dims(vllm_config) == (256, 256)
+
+
+def test_sm70_mla_prefill_accepts_equal_independent_causal_metadata(monkeypatch):
+    from vllm.v1.attention.backends import flash_attn_v100 as flash_mod
+    from vllm.v1.attention.backends.mla.prefill import flash_attn as mod
+
+    monkeypatch.setattr(mod, "_is_sm70_flash_v100_platform", lambda: True)
+    monkeypatch.setattr(mod, "_flash_v100_dense_prefill_lse_usable", lambda: True)
+
+    calls = []
+
+    def dense_lse(query, key, value, output, softmax_lse, *args, **kwargs):
+        calls.append((args, kwargs))
+        output.copy_(value.expand_as(output))
+        softmax_lse.zero_()
+        return output, softmax_lse
+
+    monkeypatch.setattr(flash_mod, "flash_v100_dense_prefill_lse", dense_lse)
+    impl = object.__new__(mod.FlashAttnPrefillBackend)
+    impl.flash_attn_varlen_func = lambda *args, **kwargs: pytest.fail(
+        "SM70 MLA prefill fell through to the unsupported FA2 stub"
+    )
+
+    query = torch.zeros((3, 1, 256), dtype=torch.float16)
+    key = torch.zeros_like(query)
+    value = torch.ones_like(query)
+    cu_q = torch.tensor([0, 3], dtype=torch.int32)
+    cu_k = cu_q.clone()
+
+    output, lse = impl._flash_attn_varlen_diff_headdims(
+        query,
+        key,
+        value,
+        cu_seqlens_q=cu_q,
+        cu_seqlens_k=cu_k,
+        causal=True,
+        return_softmax_lse=True,
+    )
+
+    assert len(calls) == 1
+    assert torch.equal(output, value)
+    assert torch.count_nonzero(lse) == 0
+
+
 def test_sm70_flash_v100_priority_can_be_disabled(monkeypatch):
     monkeypatch.setenv("VLLM_SM70_FLASH_ATTN_V100", "0")
     _get_backend_priorities, DeviceCapability, AttentionBackendEnum = _load_selector()

--- a/vllm/v1/attention/backends/flash_attn_v100.py
+++ b/vllm/v1/attention/backends/flash_attn_v100.py
@@ -1329,6 +1329,188 @@ def flash_v100_dense_prefill(
     return output
 
 
+# MLA context-chunk prefill needs the LSE that the dense SM70 kernel already
+# computes, plus independent Q and K sequence metadata for M != N attention.
+_flash_attn_forward_lse: Callable[..., tuple[torch.Tensor, ...]] | None = None
+_flash_attn_forward_lse_checked = False
+
+
+def _get_flash_dense_forward() -> Callable[..., tuple[torch.Tensor, ...]] | None:
+    """Lazy-load the private LSE-capable forward entry of the FA-V100 wheel."""
+    global _flash_attn_forward_lse, _flash_attn_forward_lse_checked
+    if not _flash_attn_forward_lse_checked:
+        _flash_attn_forward_lse_checked = True
+        try:
+            from flash_attn_v100.flash_attn_interface import _flash_attn_forward
+
+            _flash_attn_forward_lse = _flash_attn_forward
+        except (ImportError, AttributeError):
+            _flash_attn_forward_lse = None
+    return _flash_attn_forward_lse
+
+
+def flash_v100_dense_prefill_lse_available() -> bool:
+    return _get_flash_dense_forward() is not None
+
+
+def flash_v100_dense_prefill_lse(
+    query: torch.Tensor,
+    key: torch.Tensor,
+    value: torch.Tensor,
+    output: torch.Tensor,
+    softmax_lse: torch.Tensor,
+    cu_seqlens_q: torch.Tensor,
+    cu_seqlens_k: torch.Tensor,
+    num_actual_tokens: int,
+    softmax_scale: float,
+    causal: bool = False,
+    window_size: tuple[int, int] = (-1, -1),
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Flash-V100 dense varlen prefill that also emits the softmax LSE.
+
+    Inputs use packed ``[tokens, heads, dim]`` layout and ``softmax_lse`` uses
+    the FA2 ``[query_heads, total_query_tokens]`` convention. Empty key segments
+    produce zero output and ``-inf`` LSE, making them neutral when attention
+    states are merged. Causal calls require equal Q/K lengths for every sequence.
+    """
+    fwd = _get_flash_dense_forward()
+    if fwd is None:
+        raise RuntimeError("flash_attn_v100 dense LSE prefill op is unavailable")
+    if query.ndim != 3 or key.ndim != 3 or value.ndim != 3:
+        raise ValueError("dense LSE prefill expects packed [T, H, D] Q/K/V")
+    if (
+        query.dtype != torch.float16
+        or key.dtype != query.dtype
+        or value.dtype != query.dtype
+    ):
+        raise TypeError("dense LSE prefill requires fp16 Q/K/V")
+    if query.device != key.device or query.device != value.device:
+        raise ValueError("dense LSE prefill Q/K/V must share a device")
+    if key.shape != value.shape:
+        raise ValueError("dense LSE prefill K/V shapes must match")
+    if query.shape[2] != key.shape[2]:
+        raise ValueError("dense LSE prefill Q/K/V head dimensions must match")
+    if key.shape[1] <= 0 or query.shape[1] % key.shape[1] != 0:
+        raise ValueError("dense LSE prefill has an invalid Q/K head mapping")
+    if output.shape != query.shape or output.dtype != query.dtype:
+        raise ValueError("dense LSE prefill output must match the query")
+    if output.device != query.device:
+        raise ValueError("dense LSE prefill output must share the query device")
+    if softmax_lse.shape != (query.shape[1], query.shape[0]):
+        raise ValueError("dense LSE prefill LSE must have shape [Hq, Tq]")
+    if softmax_lse.dtype != torch.float32 or softmax_lse.device != query.device:
+        raise ValueError("dense LSE prefill LSE must be fp32 on the query device")
+    if cu_seqlens_q.ndim != 1 or cu_seqlens_k.ndim != 1:
+        raise ValueError("dense LSE prefill sequence metadata must be one-dimensional")
+    if cu_seqlens_q.numel() != cu_seqlens_k.numel():
+        raise ValueError("Q/K sequence metadata must describe the same batch")
+    if num_actual_tokens < 0 or num_actual_tokens > query.shape[0]:
+        raise ValueError("num_actual_tokens is outside the query bounds")
+
+    # A single device-to-host transfer replaces per-sequence scalar syncs.
+    q_off = cu_seqlens_q.tolist()
+    k_off = cu_seqlens_k.tolist()
+    if not q_off or q_off[0] != 0 or k_off[0] != 0:
+        raise ValueError("Q/K sequence offsets must start at zero")
+    if any(a > b for a, b in zip(q_off, q_off[1:])) or any(
+        a > b for a, b in zip(k_off, k_off[1:])
+    ):
+        raise ValueError("Q/K sequence offsets must be nondecreasing")
+    if q_off[-1] != num_actual_tokens:
+        raise ValueError("Q sequence offsets must cover every actual query token")
+    if k_off[-1] != key.shape[0]:
+        raise ValueError("K sequence offsets must cover every packed key/value token")
+
+    query = query[:num_actual_tokens]
+    out_view = output[:num_actual_tokens]
+    lse_view = softmax_lse[:, :num_actual_tokens]
+    num_seqs = len(q_off) - 1
+    if num_seqs == 0:
+        return output, softmax_lse
+
+    window_size_left, window_size_right = window_size
+    num_q_heads, head_dim = query.shape[1], query.shape[2]
+    num_kv_heads = key.shape[1]
+
+    run_start = 0
+    while run_start < num_seqs:
+        q_len = q_off[run_start + 1] - q_off[run_start]
+        k_len = k_off[run_start + 1] - k_off[run_start]
+        # Batch the maximal run sharing BOTH lengths — the kernel takes a
+        # rectangular [B,H,M,D] x [B,H,N,D] batch.
+        run_end = run_start + 1
+        while (
+            run_end < num_seqs
+            and q_off[run_end + 1] - q_off[run_end] == q_len
+            and k_off[run_end + 1] - k_off[run_end] == k_len
+        ):
+            run_end += 1
+
+        if q_len > 0:
+            qt0, qt1 = q_off[run_start], q_off[run_end]
+            batch_size = run_end - run_start
+
+            if k_len == 0:
+                # This is the neutral element expected by merge_attn_states.
+                out_view[qt0:qt1].zero_()
+                lse_view[:, qt0:qt1].fill_(float("-inf"))
+            else:
+                if causal and q_len != k_len:
+                    raise RuntimeError(
+                        "flash_v100_dense_prefill_lse: causal=True requires "
+                        f"q_len == k_len (got {q_len} vs {k_len})"
+                    )
+                kt0, kt1 = k_off[run_start], k_off[run_end]
+
+                # [T,H,D] -> [B,M,H,D] -> [B,H,M,D].
+                q_batch = (
+                    query[qt0:qt1]
+                    .view(batch_size, q_len, num_q_heads, head_dim)
+                    .permute(0, 2, 1, 3)
+                    .contiguous()
+                )
+                k_batch = (
+                    key[kt0:kt1]
+                    .view(batch_size, k_len, num_kv_heads, head_dim)
+                    .permute(0, 2, 1, 3)
+                    .contiguous()
+                )
+                v_batch = (
+                    value[kt0:kt1]
+                    .view(batch_size, k_len, num_kv_heads, head_dim)
+                    .permute(0, 2, 1, 3)
+                    .contiguous()
+                )
+
+                out_batch, lse_batch, _, _ = fwd(
+                    q_batch,
+                    k_batch,
+                    v_batch,
+                    None,
+                    0.0,
+                    softmax_scale,
+                    causal,
+                    window_size_left,
+                    window_size_right,
+                    0.0,
+                    None,
+                    False,
+                )
+
+                # [B,H,M,D] -> [B,M,H,D] -> packed [B*M,H,D].
+                out_view[qt0:qt1].copy_(
+                    out_batch.permute(0, 2, 1, 3).reshape(-1, num_q_heads, head_dim)
+                )
+                # [B,H,M] -> [H,B*M], matching FA2's [num_heads, total_q].
+                lse_view[:, qt0:qt1].copy_(
+                    lse_batch.permute(1, 0, 2).reshape(num_q_heads, -1)
+                )
+
+        run_start = run_end
+
+    return output, softmax_lse
+
+
 def _get_flash_turboquant_decode_op():
     """Lazy-load the optional TurboQuant decode op without touching base ops."""
     global _flash_attn_turboquant_decode_checked

--- a/vllm/v1/attention/backends/flash_attn_v100.py
+++ b/vllm/v1/attention/backends/flash_attn_v100.py
@@ -854,6 +854,195 @@ def flash_v100_dense_prefill(
     return output
 
 
+# 0014: LSE-emitting dense varlen prefill (revives archived 0043 + discharges 0044)
+# ----------------------------------------------------------------------------
+# The SM70 kernel ALWAYS computes the softmax log-sum-exp
+# (flash-attention-v100/kernel/fused_mha_forward.cu:688-692 writes rowmax+log(rowsum),
+# :1149 returns it as outputs[1]). What flash_v100_dense_prefill drops is that LSE,
+# which the MLA context-chunk / prefix-cache merge needs (mla_attention.py:2109-2136,
+# :2305-2312). This op exposes it and additionally accepts an INDEPENDENT cu_seqlens_k,
+# so the cross-attention shape of run_prefill_context_chunk (M new-token queries vs N
+# gathered context keys, M != N, unmasked) is expressible.
+_flash_attn_forward_lse = None
+_flash_attn_forward_lse_checked = False
+
+
+def _get_flash_dense_forward():
+    """Lazy-load the private LSE-capable forward entry of the FA-V100 wheel."""
+    global _flash_attn_forward_lse, _flash_attn_forward_lse_checked
+    if not _flash_attn_forward_lse_checked:
+        _flash_attn_forward_lse_checked = True
+        try:
+            from flash_attn_v100.flash_attn_interface import _flash_attn_forward
+
+            _flash_attn_forward_lse = _flash_attn_forward
+        except (ImportError, AttributeError):
+            _flash_attn_forward_lse = None
+    return _flash_attn_forward_lse
+
+
+def flash_v100_dense_prefill_lse_available() -> bool:
+    return _get_flash_dense_forward() is not None
+
+
+def flash_v100_dense_prefill_lse(
+    query: torch.Tensor,
+    key: torch.Tensor,
+    value: torch.Tensor,
+    output: torch.Tensor,
+    softmax_lse: torch.Tensor,
+    cu_seqlens_q: torch.Tensor,
+    cu_seqlens_k: torch.Tensor,
+    num_actual_tokens: int,
+    softmax_scale: float,
+    causal: bool = False,
+    window_size: tuple[int, int] = (-1, -1),
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Flash-V100 dense varlen prefill that also emits the softmax LSE.
+
+    Layouts:
+      query  [T_q, H, D] fp16      output      [T_q, H, D] fp16 (written)
+      key    [T_k, H_kv, D] fp16   softmax_lse [H, T_q] fp32   (written)
+      value  [T_k, H_kv, D] fp16
+    softmax_lse uses FA2's varlen convention [num_heads, total_q] — exactly what
+    merge_attn_states reads (merge_attn_states.py:32-37).
+
+    ===== 0044 DISCHARGE — OPTION (a), applied AT THE BACKEND =====
+    A query row whose key run is EMPTY for this chunk (a sequence contributing no
+    tokens to a later context chunk, or a request with context_len==0 in a batch
+    where others carry context) has no attention result. This op WRITES EVERY
+    query row of output[:num_actual_tokens] — either the kernel result (k_len>0)
+    or an explicit ZERO (k_len==0) — and sets softmax_lse=-inf for the empty rows.
+    No uninitialised/scratch value ever reaches merge_attn_states, so all three
+    corners the merge kernel leaves open are closed AT THE SOURCE:
+      * fall-through (prefix finite, suffix empty): suffix row is 0, not scratch,
+        so merge_attn_states.cu:162 computes p_out*1 + 0*0 = p_out (no NaN*0=NaN);
+      * both-empty guard (:109-131 stores prefix verbatim "expected all zeros"):
+        the prefix WAS zeroed here, so the assumption holds;
+      * symmetric / chunk-0 direct-assign (mla_attention.py:2118-2120) and
+        num_chunks==1: the accumulator row is 0/-inf, not scratch.
+    -inf (not -1e30) is used so the sentinel matches the FA2 varlen contract the
+    merge guard was written against (its isinf checks at merge_attn_states.cu:96-109
+    fire BEFORE any -inf subtraction, and the causal new-tokens LSE it is finally
+    merged against is always finite). Because the empty ROWS are zeroed regardless,
+    the sentinel value cannot reintroduce a NaN on our path — verified on real SM70
+    (patches/0014/poc/mla_merge_corner_gate.py: unmasked leaves NaN in 2/3 requests
+    through the real merge CUDA op; this option-(a) path reconstructs the true
+    attention at rel_rms 2.4e-4 vs the f32 oracle; a negative control that keeps the
+    zeros but drops the -inf sentinel deviates 0.41 and is correctly rejected).
+
+    causal=True is only valid when every sequence has q_len == k_len (self-attn):
+    the SM70 kernel's causal masking for M != N has no validated alignment
+    convention here, so the mismatch is rejected loudly rather than mis-masked.
+    """
+    fwd = _get_flash_dense_forward()
+    if fwd is None:
+        raise RuntimeError("flash_attn_v100 dense LSE prefill op is unavailable")
+
+    query = query[:num_actual_tokens]
+    out_view = output[:num_actual_tokens]
+    lse_view = softmax_lse[:, :num_actual_tokens]
+
+    num_seqs = len(cu_seqlens_q) - 1
+    if num_seqs == 0:
+        return output, softmax_lse
+    if len(cu_seqlens_k) - 1 != num_seqs:
+        raise RuntimeError(
+            "cu_seqlens_q and cu_seqlens_k must describe the same batch: "
+            f"{num_seqs} vs {len(cu_seqlens_k) - 1}"
+        )
+
+    # One host sync for the whole call (0020 synced per sequence inside the loop;
+    # on the 128-user axis that host cost is paid per layer per step).
+    q_off = cu_seqlens_q.tolist()
+    k_off = cu_seqlens_k.tolist()
+
+    window_size_left, window_size_right = window_size
+    num_q_heads, head_dim = query.shape[1], query.shape[2]
+    num_kv_heads = key.shape[1]
+
+    run_start = 0
+    while run_start < num_seqs:
+        q_len = q_off[run_start + 1] - q_off[run_start]
+        k_len = k_off[run_start + 1] - k_off[run_start]
+        # Batch the maximal run sharing BOTH lengths — the kernel takes a
+        # rectangular [B,H,M,D] x [B,H,N,D] batch.
+        run_end = run_start + 1
+        while (
+            run_end < num_seqs
+            and q_off[run_end + 1] - q_off[run_end] == q_len
+            and k_off[run_end + 1] - k_off[run_end] == k_len
+        ):
+            run_end += 1
+
+        if q_len > 0:
+            qt0, qt1 = q_off[run_start], q_off[run_end]
+            batch_size = run_end - run_start
+
+            if k_len == 0:
+                # 0044 option (a): empty key run -> zero output, -inf LSE, so
+                # merge_attn_states ignores this chunk with no scratch.
+                out_view[qt0:qt1].zero_()
+                lse_view[:, qt0:qt1].fill_(float("-inf"))
+            else:
+                if causal and q_len != k_len:
+                    raise RuntimeError(
+                        "flash_v100_dense_prefill_lse: causal=True requires "
+                        f"q_len == k_len (got {q_len} vs {k_len})"
+                    )
+                kt0, kt1 = k_off[run_start], k_off[run_end]
+
+                # [T,H,D] -> [B,M,H,D] -> [B,H,M,D]: the SM70 fwd reads (B,H,M,D)
+                # (fused_mha_forward.cu:1113) and needs the last dim contiguous.
+                q_batch = (
+                    query[qt0:qt1]
+                    .view(batch_size, q_len, num_q_heads, head_dim)
+                    .permute(0, 2, 1, 3)
+                    .contiguous()
+                )
+                k_batch = (
+                    key[kt0:kt1]
+                    .view(batch_size, k_len, num_kv_heads, head_dim)
+                    .permute(0, 2, 1, 3)
+                    .contiguous()
+                )
+                v_batch = (
+                    value[kt0:kt1]
+                    .view(batch_size, k_len, num_kv_heads, head_dim)
+                    .permute(0, 2, 1, 3)
+                    .contiguous()
+                )
+
+                out_batch, lse_batch, _, _ = fwd(
+                    q_batch,
+                    k_batch,
+                    v_batch,
+                    None,
+                    0.0,
+                    softmax_scale,
+                    causal,
+                    window_size_left,
+                    window_size_right,
+                    0.0,
+                    None,
+                    False,  # NOT the P-matrix flag (kernel refuses it); LSE comes
+                    # back as outputs[1] regardless.
+                )
+
+                # [B,H,M,D] -> [B,M,H,D] -> packed [B*M,H,D].
+                out_view[qt0:qt1].copy_(
+                    out_batch.permute(0, 2, 1, 3).reshape(-1, num_q_heads, head_dim)
+                )
+                # [B,H,M] -> [H,B*M], matching FA2's [num_heads, total_q].
+                lse_view[:, qt0:qt1].copy_(
+                    lse_batch.permute(1, 0, 2).reshape(num_q_heads, -1)
+                )
+
+        run_start = run_end
+
+    return output, softmax_lse
+
+
 def _get_flash_turboquant_decode_op():
     """Lazy-load the optional TurboQuant decode op without touching base ops."""
     global _flash_attn_turboquant_decode_checked

--- a/vllm/v1/attention/backends/mla/prefill/flash_attn.py
+++ b/vllm/v1/attention/backends/mla/prefill/flash_attn.py
@@ -24,6 +24,33 @@ else:
     flash_attn_varlen_func = None  # type: ignore[assignment]
 
 
+def _is_sm70_flash_v100_platform() -> bool:
+    """Return whether this process is running on an exact SM70 CUDA device."""
+    if not current_platform.is_cuda():
+        return False
+    capability = current_platform.get_device_capability()
+    return capability is not None and tuple(capability) == (7, 0)
+
+
+@functools.cache
+def _flash_v100_dense_prefill_lse_usable() -> bool:
+    """Return whether the SM70 dense prefill entry can emit softmax LSE."""
+    if not _is_sm70_flash_v100_platform():
+        return False
+    try:
+        from vllm.v1.attention.backends.flash_attn_v100 import (
+            flash_v100_dense_prefill_lse_available,
+        )
+    except ImportError:
+        return False
+    return flash_v100_dense_prefill_lse_available()
+
+
+# Head dimensions instantiated by fused_mha_forward.cu. Keep this in sync with
+# the kernel dispatch switch so unsupported models are rejected during selection.
+_SM70_DENSE_PREFILL_HEAD_DIMS = frozenset({16, 32, 64, 128, 256})
+
+
 class FlashAttnPrefillBackend(MLAPrefillBackend):
     """FlashAttention backend for MLA prefill."""
 
@@ -33,7 +60,37 @@ class FlashAttnPrefillBackend(MLAPrefillBackend):
 
     @classmethod
     def is_available(cls) -> bool:
+        # The generic CUDA availability predicate can be true on V100 even when
+        # it resolves to an unsupported FA2 stub. Select the in-tree implementation
+        # explicitly on SM70 and retain the normal FA2/FA3 behavior elsewhere.
+        if _is_sm70_flash_v100_platform():
+            return _flash_v100_dense_prefill_lse_usable()
         return is_flash_attn_varlen_func_available()
+
+    @classmethod
+    def validate_configuration(cls, device_capability, selector_config) -> list[str]:
+        invalid_reasons = super().validate_configuration(
+            device_capability, selector_config
+        )
+        if _is_sm70_flash_v100_platform():
+            if selector_config.dtype != torch.float16:
+                invalid_reasons.append(
+                    "SM70 Flash-V100 MLA prefill route requires float16 "
+                    f"(got {selector_config.dtype})"
+                )
+            if selector_config.qk_head_dim != selector_config.v_head_dim:
+                invalid_reasons.append(
+                    "SM70 Flash-V100 MLA prefill route requires uniform qk/v head "
+                    f"dims (got qk={selector_config.qk_head_dim}, "
+                    f"v={selector_config.v_head_dim})"
+                )
+            elif selector_config.qk_head_dim not in _SM70_DENSE_PREFILL_HEAD_DIMS:
+                invalid_reasons.append(
+                    "SM70 Flash-V100 MLA prefill route has no compiled kernel tile "
+                    f"for head dim {selector_config.qk_head_dim} "
+                    f"(compiled: {sorted(_SM70_DENSE_PREFILL_HEAD_DIMS)})"
+                )
+        return invalid_reasons
 
     def __init__(
         self,
@@ -55,12 +112,24 @@ class FlashAttnPrefillBackend(MLAPrefillBackend):
             vllm_config=vllm_config,
         )
 
+        if _is_sm70_flash_v100_platform():
+            assert _flash_v100_dense_prefill_lse_usable(), (
+                "The SM70 FlashAttention MLA prefill route requires the "
+                "Flash-V100 dense LSE entry."
+            )
+            self.flash_attn_varlen_func = None
+            self.vllm_flash_attn_version = None
+            self.requires_v_padding = False
+            self._is_vllm_fa = True
+            return
+
         # Handle the differences between the flash_attn_varlen from
-        # flash_attn and the one from vllm_flash_attn
+        # flash_attn and the one from vllm_flash_attn.
         assert flash_attn_varlen_func is not None, (
             "FlashAttnPrefillBackend requires flash_attn_varlen_func. "
             "Ensure FlashAttnPrefillBackend.is_available() is checked first."
         )
+
         qk_head_dim = qk_nope_head_dim + qk_rope_head_dim
         self.flash_attn_varlen_func = flash_attn_varlen_func
         self.vllm_flash_attn_version = get_flash_attn_version(head_size=qk_head_dim)
@@ -96,6 +165,66 @@ class FlashAttnPrefillBackend(MLAPrefillBackend):
         softmax_scale: float | None = None,
         **kwargs,
     ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
+        if _is_sm70_flash_v100_platform():
+            cu_q = kwargs.get("cu_seqlens_q")
+            cu_k = kwargs.get("cu_seqlens_k")
+            causal = bool(kwargs.get("causal", False))
+            window_size = tuple(kwargs.get("window_size", (-1, -1)))
+            if not _flash_v100_dense_prefill_lse_usable():
+                raise RuntimeError("Flash-V100 dense LSE prefill is unavailable")
+            if q.dtype != torch.float16 or k.dtype != q.dtype or v.dtype != q.dtype:
+                raise TypeError("SM70 Flash-V100 MLA prefill requires fp16 Q/K/V")
+            if q.ndim != 3 or k.ndim != 3 or v.ndim != 3:
+                raise ValueError("SM70 Flash-V100 MLA prefill expects [T, H, D] Q/K/V")
+            if q.shape[-1] != k.shape[-1] or q.shape[-1] != v.shape[-1]:
+                raise ValueError(
+                    "SM70 Flash-V100 MLA prefill requires uniform Q/K/V head dims"
+                )
+            if k.shape[1] != v.shape[1] or q.shape[1] % k.shape[1] != 0:
+                raise ValueError(
+                    "SM70 Flash-V100 MLA prefill has invalid Q/K/V head mapping"
+                )
+            if cu_q is None or cu_k is None or cu_q.numel() != cu_k.numel():
+                raise ValueError(
+                    "SM70 Flash-V100 MLA prefill requires matching Q/K metadata"
+                )
+            if float(kwargs.get("dropout_p", 0.0)) != 0.0:
+                raise ValueError("SM70 Flash-V100 MLA prefill does not support dropout")
+            if kwargs.get("alibi_slopes") is not None:
+                raise ValueError("SM70 Flash-V100 MLA prefill does not support ALiBi")
+            if float(kwargs.get("softcap", 0.0)) != 0.0:
+                raise ValueError("SM70 Flash-V100 MLA prefill does not support softcap")
+
+            from vllm.v1.attention.backends.flash_attn_v100 import (
+                flash_v100_dense_prefill_lse,
+            )
+
+            q_c = q.contiguous()
+            out = torch.empty_like(q_c)
+            lse = torch.empty(
+                (q_c.shape[1], q_c.shape[0]),
+                dtype=torch.float32,
+                device=q_c.device,
+            )
+            flash_v100_dense_prefill_lse(
+                q_c,
+                k.contiguous(),
+                v.contiguous(),
+                out,
+                lse,
+                cu_q,
+                cu_k,
+                q_c.shape[0],
+                float(softmax_scale)
+                if softmax_scale is not None
+                else q.shape[-1] ** -0.5,
+                causal=causal,
+                window_size=window_size,
+            )
+            if return_softmax_lse:
+                return out, lse
+            return out
+
         maybe_padded_v = v
         if self.requires_v_padding:
             maybe_padded_v = torch.nn.functional.pad(
@@ -111,7 +240,9 @@ class FlashAttnPrefillBackend(MLAPrefillBackend):
         if envs.VLLM_BATCH_INVARIANT:
             kwargs["num_splits"] = 1
 
-        attn_out = self.flash_attn_varlen_func(
+        flash_attn_varlen_func = self.flash_attn_varlen_func
+        assert flash_attn_varlen_func is not None
+        attn_out = flash_attn_varlen_func(
             q=q,
             k=k,
             v=maybe_padded_v,

--- a/vllm/v1/attention/backends/mla/prefill/flash_attn.py
+++ b/vllm/v1/attention/backends/mla/prefill/flash_attn.py
@@ -24,6 +24,54 @@ else:
     flash_attn_varlen_func = None  # type: ignore[assignment]
 
 
+@functools.cache
+def _flash_v100_dense_prefill_usable() -> bool:
+    """0014: True iff this device is SM70 with the in-tree Flash-V100 dense
+    prefill op available. On SM70 the vendored FA2 called below can never run
+    (fa_utils stub raises ImportError on first prefill), so this predicate gates
+    an automatic route to the in-tree op. Exact (7,0) match: the flash_attn_v100
+    kernel TORCH_CHECKs sm70 itself. Cached: device + op availability are
+    process-invariant."""
+    if not current_platform.is_cuda():
+        return False
+    capability = current_platform.get_device_capability()
+    if capability is None or capability[0] != 7 or capability[1] != 0:
+        return False
+    try:
+        from vllm.v1.attention.backends.flash_attn_v100 import (
+            flash_v100_dense_prefill_available,
+        )
+    except ImportError:
+        return False
+    return flash_v100_dense_prefill_available()
+
+
+@functools.cache
+def _flash_v100_dense_prefill_lse_usable() -> bool:
+    """0014: True iff the in-tree Flash-V100 dense op can also emit the LSE.
+    Same SM70 gate as above plus availability of the LSE-capable forward entry.
+    Separate predicate so an older wheel degrades to no-LSE coverage instead of
+    failing the whole route."""
+    if not _flash_v100_dense_prefill_usable():
+        return False
+    try:
+        from vllm.v1.attention.backends.flash_attn_v100 import (
+            flash_v100_dense_prefill_lse_available,
+        )
+    except ImportError:
+        return False
+    return flash_v100_dense_prefill_lse_available()
+
+
+# 0014: head-dim tiles the in-tree Flash-V100 dense prefill kernel instantiates
+# (flash-attention-v100/kernel/fused_mha_forward.cu:1136-1142 `switch (D)`; anything
+# else hits `default: TORCH_CHECK(false, "Unsupported D")`). A uniform MLA head dim
+# outside this set would crash the kernel at runtime, so the SM70 route must not be
+# offered for it. Kept beside the gate that reads it; update in lockstep with the
+# kernel switch (adding `case 192:` for the DeepSeek slice would add 192 here too).
+_SM70_DENSE_PREFILL_HEAD_DIMS = frozenset({16, 32, 64, 128, 256})
+
+
 class FlashAttnPrefillBackend(MLAPrefillBackend):
     """FlashAttention backend for MLA prefill."""
 
@@ -33,7 +81,55 @@ class FlashAttnPrefillBackend(MLAPrefillBackend):
 
     @classmethod
     def is_available(cls) -> bool:
-        return is_flash_attn_varlen_func_available()
+        # SM80+ builds: the vendored FA2/FA3 varlen extension.
+        # SM70/V100 builds are compiled WITHOUT that extension (0013 makes
+        # is_flash_attn_varlen_func_available() honestly False there); on SM70 this
+        # backend serves MLA prefill through the in-tree Flash-V100 dense op instead
+        # (0014, routed in _flash_attn_varlen_diff_headdims). Either presence means a
+        # working MLA-prefill implementation exists. The SM70 route's shape/dtype
+        # constraints are per-config, not device-global, so they are enforced in
+        # validate_configuration (which sees the model's head dims and dtype), not
+        # here.
+        return (
+            is_flash_attn_varlen_func_available()
+            or _flash_v100_dense_prefill_lse_usable()
+        )
+
+    @classmethod
+    def validate_configuration(cls, device_capability, selector_config) -> list[str]:
+        invalid_reasons = super().validate_configuration(
+            device_capability, selector_config
+        )
+        # 0014: when the ONLY available implementation is the SM70 in-tree dense
+        # route (FA2 varlen absent, Flash-V100 dense op present), that route computes
+        # only the uniform-head-dim, fp16 slice. Reject anything it cannot run here,
+        # AT SELECTION TIME, so a config the route would fall through on gets a clean
+        # load-time error (0013's guarantee) instead of loading and then crashing at
+        # the first prefill in the raising FA2 stub. On SM80+ this block is inert
+        # (is_flash_attn_varlen_func_available() is True).
+        if (
+            not is_flash_attn_varlen_func_available()
+            and _flash_v100_dense_prefill_lse_usable()
+        ):
+            if selector_config.dtype != torch.float16:
+                invalid_reasons.append(
+                    "SM70 Flash-V100 MLA prefill route requires float16 "
+                    f"(got {selector_config.dtype})"
+                )
+            if selector_config.qk_head_dim != selector_config.v_head_dim:
+                invalid_reasons.append(
+                    "SM70 Flash-V100 MLA prefill route requires uniform qk/v head "
+                    f"dims (got qk={selector_config.qk_head_dim}, "
+                    f"v={selector_config.v_head_dim}); DeepSeek-style asymmetric "
+                    "MLA (qk=192/v=128) is 0014's deferred slice"
+                )
+            elif selector_config.qk_head_dim not in _SM70_DENSE_PREFILL_HEAD_DIMS:
+                invalid_reasons.append(
+                    "SM70 Flash-V100 MLA prefill route has no compiled kernel tile "
+                    f"for head dim {selector_config.qk_head_dim} "
+                    f"(compiled: {sorted(_SM70_DENSE_PREFILL_HEAD_DIMS)})"
+                )
+        return invalid_reasons
 
     def __init__(
         self,
@@ -57,10 +153,26 @@ class FlashAttnPrefillBackend(MLAPrefillBackend):
 
         # Handle the differences between the flash_attn_varlen from
         # flash_attn and the one from vllm_flash_attn
-        assert flash_attn_varlen_func is not None, (
-            "FlashAttnPrefillBackend requires flash_attn_varlen_func. "
-            "Ensure FlashAttnPrefillBackend.is_available() is checked first."
-        )
+        if flash_attn_varlen_func is None:
+            # 0014: SM70/V100 build without the FA2 varlen extension. This backend
+            # serves MLA prefill through the in-tree Flash-V100 dense op instead
+            # (routed at the top of _flash_attn_varlen_diff_headdims), so no FA2
+            # setup is needed. validate_configuration has already guaranteed the
+            # SM70 route is present and shape/dtype-valid for this model; a genuinely
+            # absent op still fails loudly here rather than silently mis-routing.
+            assert _flash_v100_dense_prefill_lse_usable(), (
+                "FlashAttnPrefillBackend requires either flash_attn_varlen_func or "
+                "the SM70 Flash-V100 dense prefill op. Ensure "
+                "FlashAttnPrefillBackend.is_available() is checked first."
+            )
+            self.flash_attn_varlen_func = None
+            self.vllm_flash_attn_version = None
+            # Uniform head dims on this route (validate_configuration enforced qk==v),
+            # so V never needs padding — and the route intercepts before the pad path.
+            self.requires_v_padding = False
+            self._is_vllm_fa = current_platform.is_cuda()
+            return
+
         qk_head_dim = qk_nope_head_dim + qk_rope_head_dim
         self.flash_attn_varlen_func = flash_attn_varlen_func
         self.vllm_flash_attn_version = get_flash_attn_version(head_size=qk_head_dim)
@@ -96,6 +208,97 @@ class FlashAttnPrefillBackend(MLAPrefillBackend):
         softmax_scale: float | None = None,
         **kwargs,
     ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
+        # ------------------------------------------------------------------
+        # 0014: V100 (SM70) MLA prefill route (revives archived 0020 + 0043).
+        # On SM70 the vendored FA2 call below is a guaranteed ImportError
+        # (fa_utils stub), so when the in-tree Flash-V100 dense op can faithfully
+        # compute this exact call we route to it. Guard sets are EXACT — any call
+        # outside them falls through to the FA2 call, which FAILS LOUDLY on SM70
+        # rather than silently computing wrong values.
+        #
+        # This slice covers the UNIFORM head-dim case (GLM-MoE-Lite MLA: qk==v,
+        # e.g. 256==256). DeepSeek-style diff head dims (qk 192 / v 128) still
+        # fall through and crash on SM70 — that case additionally needs the
+        # FA_V100 `case 192:` build + a pad-V driver and is 0014's deferred slice.
+        cu_q = kwargs.get("cu_seqlens_q")
+        cu_k = kwargs.get("cu_seqlens_k")
+        causal = bool(kwargs.get("causal", False))
+
+        # (0043) LSE-emitting route — the context-chunk / prefix-cache path that
+        # needs the softmax LSE and an INDEPENDENT cu_seqlens_k. Guard: LSE-capable
+        # wheel, fp16, uniform head dims, both cu_seqlens present and same batch,
+        # and causal only with cu_k IS cu_q (masking for M!=N is unvalidated here).
+        if (
+            _flash_v100_dense_prefill_lse_usable()
+            and q.dtype == torch.float16
+            and k.dtype == torch.float16
+            and v.dtype == torch.float16
+            and q.shape[-1] == v.shape[-1]
+            and cu_q is not None
+            and cu_k is not None
+            and cu_q.numel() == cu_k.numel()
+            and (cu_k is cu_q or not causal)
+        ):
+            from vllm.v1.attention.backends.flash_attn_v100 import (
+                flash_v100_dense_prefill_lse,
+            )
+
+            q_c = q.contiguous()
+            out = torch.empty_like(q_c)
+            lse = torch.empty(
+                (q_c.shape[1], q_c.shape[0]),
+                dtype=torch.float32,
+                device=q_c.device,
+            )
+            flash_v100_dense_prefill_lse(
+                q_c,
+                k.contiguous(),
+                v.contiguous(),
+                out,
+                lse,
+                cu_q,
+                cu_k,
+                q_c.shape[0],
+                float(softmax_scale)
+                if softmax_scale is not None
+                else q.shape[-1] ** -0.5,
+                causal=causal,
+            )
+            if return_softmax_lse:
+                return out, lse
+            return out
+
+        # (0020) no-LSE route — the new-tokens self-attention path on wheels that
+        # predate the LSE entry. Requires cu_k IS cu_q and no LSE requested.
+        if (
+            _flash_v100_dense_prefill_usable()
+            and not return_softmax_lse
+            and q.dtype == torch.float16
+            and q.shape[-1] == v.shape[-1]
+            and cu_q is not None
+            and cu_k is cu_q
+        ):
+            from vllm.v1.attention.backends.flash_attn_v100 import (
+                flash_v100_dense_prefill,
+            )
+
+            q_c = q.contiguous()
+            out = torch.empty_like(q_c)
+            flash_v100_dense_prefill(
+                q_c,
+                k.contiguous(),
+                v.contiguous(),
+                out,
+                cu_q,
+                q_c.shape[0],
+                float(softmax_scale)
+                if softmax_scale is not None
+                else q.shape[-1] ** -0.5,
+                causal=causal,
+            )
+            return out
+        # --- end 0014 route -----------------------------------------------
+
         maybe_padded_v = v
         if self.requires_v_padding:
             maybe_padded_v = torch.nn.functional.pad(

--- a/vllm/v1/attention/backends/mla/prefill/selector.py
+++ b/vllm/v1/attention/backends/mla/prefill/selector.py
@@ -32,6 +32,27 @@ class MLAPrefillSelectorConfig(NamedTuple):
 
     dtype: torch.dtype
     is_r1_compatible: bool
+    # These remain plain integers so the selector configuration is hashable.
+    qk_head_dim: int = 0
+    v_head_dim: int = 0
+
+
+def _mla_head_dims(vllm_config: "VllmConfig") -> tuple[int, int]:
+    """Return (qk_head_dim, v_head_dim) for MLA backend selection.
+
+    qk_head_dim = qk_nope_head_dim + qk_rope_head_dim, matching
+    deepseek_v2.py:428-431 and the query head dim the prefill kernel dispatches
+    on. Returns (0, 0) when the config exposes no MLA dims — the value is only
+    consulted by backends that gate on it (the SM70 route), for which 0 head dims
+    never satisfy the uniform-and-compiled-tile check.
+    """
+    if vllm_config.model_config is None:
+        return 0, 0
+    hf_text_config = vllm_config.model_config.hf_text_config
+    qk_nope_head_dim = int(getattr(hf_text_config, "qk_nope_head_dim", 0) or 0)
+    qk_rope_head_dim = int(getattr(hf_text_config, "qk_rope_head_dim", 0) or 0)
+    v_head_dim = int(getattr(hf_text_config, "v_head_dim", 0) or 0)
+    return qk_nope_head_dim + qk_rope_head_dim, v_head_dim
 
 
 def is_deepseek_r1_mla_compatible(vllm_config: "VllmConfig") -> bool:
@@ -101,9 +122,12 @@ def get_mla_prefill_backend(
 
     attention_config = vllm_config.attention_config
 
+    qk_head_dim, v_head_dim = _mla_head_dims(vllm_config)
     selector_config = MLAPrefillSelectorConfig(
         dtype=vllm_config.model_config.dtype,
         is_r1_compatible=is_deepseek_r1_mla_compatible(vllm_config),
+        qk_head_dim=qk_head_dim,
+        v_head_dim=v_head_dim,
     )
 
     if attention_config.mla_prefill_backend is not None:

--- a/vllm/v1/attention/backends/mla/prefill/selector.py
+++ b/vllm/v1/attention/backends/mla/prefill/selector.py
@@ -32,6 +32,31 @@ class MLAPrefillSelectorConfig(NamedTuple):
 
     dtype: torch.dtype
     is_r1_compatible: bool
+    # 0014: MLA head dims, so a backend can reject a shape it cannot serve AT
+    # SELECTION time (the SM70 Flash-V100 dense route only runs uniform qk==v).
+    # Defaulted so non-MLA / older construction sites stay valid; the real MLA
+    # selection site below populates them. Both ints, so the NamedTuple stays
+    # hashable for the @cache on _auto_select_mla_prefill_backend.
+    qk_head_dim: int = 0
+    v_head_dim: int = 0
+
+
+def _mla_head_dims(vllm_config: "VllmConfig") -> tuple[int, int]:
+    """Return (qk_head_dim, v_head_dim) for MLA backend selection.
+
+    qk_head_dim = qk_nope_head_dim + qk_rope_head_dim, matching
+    deepseek_v2.py:428-431 and the query head dim the prefill kernel dispatches
+    on. Returns (0, 0) when the config exposes no MLA dims — the value is only
+    consulted by backends that gate on it (the SM70 route), for which 0 head dims
+    never satisfy the uniform-and-compiled-tile check.
+    """
+    if vllm_config.model_config is None:
+        return 0, 0
+    hf_text_config = vllm_config.model_config.hf_text_config
+    qk_nope_head_dim = getattr(hf_text_config, "qk_nope_head_dim", 0)
+    qk_rope_head_dim = getattr(hf_text_config, "qk_rope_head_dim", 0)
+    v_head_dim = getattr(hf_text_config, "v_head_dim", 0)
+    return qk_nope_head_dim + qk_rope_head_dim, v_head_dim
 
 
 def is_deepseek_r1_mla_compatible(vllm_config: "VllmConfig") -> bool:
@@ -101,9 +126,12 @@ def get_mla_prefill_backend(
 
     attention_config = vllm_config.attention_config
 
+    qk_head_dim, v_head_dim = _mla_head_dims(vllm_config)
     selector_config = MLAPrefillSelectorConfig(
         dtype=vllm_config.model_config.dtype,
         is_r1_compatible=is_deepseek_r1_mla_compatible(vllm_config),
+        qk_head_dim=qk_head_dim,
+        v_head_dim=v_head_dim,
     )
 
     if attention_config.mla_prefill_backend is not None:


### PR DESCRIPTION
## Purpose

Supersede and preserve PR #200 after a V100 quality audit. The original availability goal is valid, but the proposed load-time guard trusted a CUDA availability predicate that returns true even when FlashAttention is only an always-raising stub. Unsupported MLA configurations therefore loaded and failed at first prefill.

This audited merge:

- selects the in-tree dense-LSE route explicitly on exact SM70;
- rejects BF16, asymmetric qk/v dimensions, and uncompiled dimensions at model selection time;
- accepts independent but equal causal Q/K offset tensors instead of relying on Python object identity;
- validates complete packed metadata and writes zero output plus negative-infinity LSE for empty-key rows;
- adds FP64 context and causal numerical gates, selector policy tests, and a quantization-aware one-ULP FP8 XQA/scalar regression gate;
- records the FP8 KV and MLA quality audit in the migration control document.

The commit is a two-parent merge, so the original PR #200 contribution and authorship remain in history.

## Test Plan

Hardware: Tesla V100 SM70, CUDA 12.8, Torch 2.10.0+cu128.

- Run the full SM70 policy suite.
- Run the full Flash-V100 varlen/layout GPU suite.
- Compare context-chunk and causal packed outputs plus LSE against FP64 references.
- Validate real-device selection for supported 256/256 FP16 and rejection for 192/128 FP16, 80/80 FP16, and 256/256 BF16.
- Run all pre-commit hooks scoped to changed files.

## Test Result

- SM70 policy: 82 passed.
- Flash-V100 varlen/layout GPU suite: 20 passed.
- Context Q lengths 3/2/4 and K lengths 5/0/3: repeat exact; empty-key rows exactly zero/negative-infinity; relative RMS 1.3478e-4; finite LSE max error 1.286e-6 versus FP64.
- Causal packed lengths 1/3/5: relative RMS 1.3075e-4; LSE max error 1.519e-6 versus FP64.
- Changed-file pre-commit: ruff, formatting, typos, markdownlint, Python 3.10 mypy, SPDX, import policy, and CUDA API policy all passed.
- General MLA selector suite: 10 passed and 3 pre-existing V100 test-harness failures caused by current_platform MagicMock import pollution and duplicate Torch custom-op registration; these failures are unrelated to this numerical path.

The FP8 audit does not require FP8 KV greedy identity with FP16 KV. Non-unit and per-head scale storage was byte-exact, scalar/XQA routes were finite and repeat exact, and the observed wider-case 1.2207e-4 difference was one adjacent FP16 output step with both paths bounded against FP64.