### PR TITLE
[Bugfix] Expose missing SM70 D256 prefill ops

### DIFF
--- a/benchmarks/benchmark_sm70_decode.py
+++ b/benchmarks/benchmark_sm70_decode.py
@@ -9,6 +9,7 @@ and SM70 gates so old-vs-latest no-MTP decode comparisons are reproducible.
 
 import argparse
 import hashlib
+import importlib
 import importlib.util
 import json
 import os
@@ -36,6 +37,50 @@ def _module_file(module_name: str) -> str | None:
 def _module_realpath(module_name: str) -> str | None:
     module_file = _module_file(module_name)
     return str(Path(module_file).resolve()) if module_file is not None else None
+
+
+def _sm70_fa2_d256_prefill_status(torch: Any) -> dict[str, Any]:
+    """Report whether the vendored FA2 library exposes exact SM70 D256 ops."""
+    required_ops = (
+        "sm70_d256_splitd_n32_dense_fwd",
+        "sm70_d256_splitd_n32_paged_fwd",
+    )
+    optional_ops = ("sm70_d256_splitd_n32_dense_splitkv3_fwd",)
+    try:
+        importlib.import_module("vllm.vllm_flash_attn.flash_attn_interface")
+    except (AttributeError, ImportError, RuntimeError) as exc:
+        return {
+            "available": False,
+            "error": f"{type(exc).__name__}: {exc}",
+            "extension_file": None,
+            "extension_realpath": None,
+            "required_ops": {name: False for name in required_ops},
+            "optional_ops": {name: False for name in optional_ops},
+        }
+
+    extension_file = _module_file("vllm.vllm_flash_attn._vllm_fa2_C")
+    namespace = getattr(torch.ops, "_vllm_fa2_C", None)
+    required_status = {
+        name: namespace is not None and hasattr(namespace, name)
+        for name in required_ops
+    }
+    optional_status = {
+        name: namespace is not None and hasattr(namespace, name)
+        for name in optional_ops
+    }
+    missing_ops = [name for name, present in required_status.items() if not present]
+    return {
+        "available": not missing_ops,
+        "error": None
+        if not missing_ops
+        else "missing required operators: " + ", ".join(missing_ops),
+        "extension_file": extension_file,
+        "extension_realpath": (
+            str(Path(extension_file).resolve()) if extension_file is not None else None
+        ),
+        "required_ops": required_status,
+        "optional_ops": optional_status,
+    }
 
 
 def _parse_scalar(value: str) -> Any:
@@ -1609,6 +1654,7 @@ def _write_results(
             "python_file": _module_file("flash_attn_v100"),
             "cuda_extension_file": _module_file("flash_attn_v100_cuda"),
             "cuda_extension_realpath": _module_realpath("flash_attn_v100_cuda"),
+            "fa2_d256_prefill": _sm70_fa2_d256_prefill_status(torch),
         },
         "torch": {
             "version": torch.__version__,
@@ -1760,6 +1806,14 @@ def _parse_args() -> argparse.Namespace:
         action="store_true",
         help="Wrap only measured repeats in cudaProfilerStart/Stop.",
     )
+    parser.add_argument(
+        "--require-sm70-fa2-d256-prefill",
+        action="store_true",
+        help=(
+            "Fail before model loading unless the active vendored FA2 extension "
+            "exports the exact SM70 D256 dense and paged prefill operators."
+        ),
+    )
     parser.add_argument("--engine-arg", action="append", default=[])
     return parser.parse_args()
 
@@ -1780,6 +1834,14 @@ def main() -> int:
 
     import vllm
     from vllm import LLM, SamplingParams
+
+    if args.require_sm70_fa2_d256_prefill:
+        fa2_status = _sm70_fa2_d256_prefill_status(torch)
+        if not fa2_status["available"]:
+            raise RuntimeError(
+                "Required SM70 FA2 D256 prefill route is unavailable: "
+                f"{fa2_status['error']}"
+            )
 
     tokenizer = AutoTokenizer.from_pretrained(
         str(args.model),

--- a/docs/design/sm70_qwen38_fp8_prefill_decay.md
+++ b/docs/design/sm70_qwen38_fp8_prefill_decay.md
@@ -134,3 +134,43 @@ shuffle/repack form.
   `experiments/p-scalar-native-build-r3/_vllm_fa2_C.abi3.so`.
 - FP8 KV/chunk 8192 result:
   `results/fp8kv-chunk8192-tp4.json`.
+
+## 2026-08-16 source-worktree FA2 route audit
+
+A later Qwen3.8 MTP-prefill investigation initially measured only 2798.6
+tok/s without MTP and 2702.6 tok/s with MTP4 at 64K. Those values are invalid
+as optimized-route baselines. The source worktree shadowed the installed vLLM
+package but did not contain `_vllm_fa2_C.abi3.so`; the optional operator
+loader swallowed the resulting import error and silently disabled the exact
+SM70 D256 prefill route.
+
+Restoring the same vendored FA2 binary used by the accepted build made the
+required dense, paged, and split-KV3 operators visible. Under the matched TP4,
+E5M2 KV, chunk-8192, prefix-cache/Mamba-align, CUDA-graph, official-sampling,
+64K-input/256-output contract, the corrected results are:
+
+| Mode | Prefill | Throughput | Relative to retained table |
+|---|---:|---:|---:|
+| no-MTP | 18.743949 s | 3496.4 tok/s | -3.7% vs. 3630.6 |
+| MTP4 | 22.308881 s | 2937.7 tok/s | -0.4% vs. 2950.5 |
+
+The no-MTP worker recorded 288 hits on
+`prefill_prefix_fp8_bridge_exact_dense_d256_tailpad`. Both modes emitted 256
+coherent tokens with stable warmup/measurement hashes. The remaining matched
+MTP prefill overhead is 3.564932 seconds (+19.0% latency, -16.0% throughput),
+which is now the optimization target. Raw results and logs are retained under
+`/data/minimax-h3/task-cache/qwen38-mtp-fp8kv-prefill-20260816/`.
+
+Synchronized interval profiling attributes 21.281 seconds to the MTP target
+forward and 0.864 seconds to the four-step drafter GPU timeline. The target
+forward is therefore the dominant prefill cost; removing drafter sampling or
+the three dependent draft loops cannot recover the full MTP penalty.
+
+A state-only prefill candidate kept the first draft forward/KV update but
+skipped prefill draft sampling and the three dependent loops. It was rejected:
+prefill changed from 22.308881 to 22.330927 seconds (+0.10%), while accepted
+length fell from 3.779 to 3.253 and decode throughput fell from 60.86 to 58.79
+tok/s. The 256-token output remained coherent, but changing the draft RNG
+sequence made this route unsuitable even apart from the lack of speedup. The
+candidate was removed; its raw result is
+`results/mtp4-e5m2-64k-o256-prefill-state-only-r1.json` under the artifact root.

--- a/tests/benchmarks/test_benchmark_sm70_decode.py
+++ b/tests/benchmarks/test_benchmark_sm70_decode.py
@@ -1,0 +1,48 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import types
+
+from benchmarks import benchmark_sm70_decode
+
+
+def test_sm70_fa2_d256_prefill_status_reports_import_error(monkeypatch):
+    def fail_import(_name):
+        raise ImportError("missing vendored extension")
+
+    monkeypatch.setattr(benchmark_sm70_decode.importlib, "import_module", fail_import)
+
+    status = benchmark_sm70_decode._sm70_fa2_d256_prefill_status(
+        types.SimpleNamespace(ops=types.SimpleNamespace())
+    )
+
+    assert status["available"] is False
+    assert status["error"] == "ImportError: missing vendored extension"
+    assert not any(status["required_ops"].values())
+
+
+def test_sm70_fa2_d256_prefill_status_requires_dense_and_paged_ops(monkeypatch):
+    monkeypatch.setattr(
+        benchmark_sm70_decode.importlib,
+        "import_module",
+        lambda _name: types.SimpleNamespace(),
+    )
+    namespace = types.SimpleNamespace(
+        sm70_d256_splitd_n32_dense_fwd=object(),
+        sm70_d256_splitd_n32_paged_fwd=object(),
+        sm70_d256_splitd_n32_dense_splitkv3_fwd=object(),
+    )
+    fake_torch = types.SimpleNamespace(ops=types.SimpleNamespace(_vllm_fa2_C=namespace))
+    fake_extension = types.SimpleNamespace(__file__="/tmp/_vllm_fa2_C.abi3.so")
+    monkeypatch.setitem(
+        benchmark_sm70_decode.sys.modules,
+        "vllm.vllm_flash_attn._vllm_fa2_C",
+        fake_extension,
+    )
+
+    status = benchmark_sm70_decode._sm70_fa2_d256_prefill_status(fake_torch)
+
+    assert status["available"] is True
+    assert status["error"] is None
+    assert all(status["required_ops"].values())
+    assert all(status["optional_ops"].values())

--- a/tests/v1/attention/test_sm70_flash_v100_policy.py
+++ b/tests/v1/attention/test_sm70_flash_v100_policy.py
@@ -674,10 +674,18 @@ def test_sm70_splitd_d256_loader_requires_exact_ops(monkeypatch):
     )
 
     fake_ops = SimpleNamespace(_vllm_fa2_C=SimpleNamespace())
+    warnings: list[str] = []
     monkeypatch.setattr(flash_v100, "torch", SimpleNamespace(ops=fake_ops))
+    monkeypatch.setattr(
+        flash_v100.logger,
+        "warning_once",
+        lambda message, *args: warnings.append(message % args),
+    )
     monkeypatch.setattr(flash_v100, "_sm70_splitd_d256_ops_checked", False)
     monkeypatch.setattr(flash_v100, "_sm70_splitd_d256_ops", None)
     assert flash_v100._get_sm70_splitd_d256_ops() is None
+    assert len(warnings) == 1
+    assert "sm70_d256_splitd_n32_dense_fwd" in warnings[0]
 
     dense = object()
     paged = object()

--- a/vllm/v1/attention/backends/flash_attn_v100.py
+++ b/vllm/v1/attention/backends/flash_attn_v100.py
@@ -828,8 +828,17 @@ def _get_sm70_splitd_d256_ops():
             None,
         )
         _sm70_splitd_d256_ops = (dense, paged, splitkv3)
-    except (AttributeError, ImportError, RuntimeError):
+    except (AttributeError, ImportError, RuntimeError) as exc:
         _sm70_splitd_d256_ops = None
+        logger.warning_once(
+            "SM70 D256 exact-prefill operators are unavailable (%s: %s). "
+            "Long prefill will use a slower fallback. Verify that the active "
+            "vllm package contains a loadable _vllm_fa2_C extension with the "
+            "sm70_d256_splitd_n32_dense_fwd and "
+            "sm70_d256_splitd_n32_paged_fwd operators.",
+            type(exc).__name__,
+            exc,
+        )
     return _sm70_splitd_d256_ops
 
 


### PR DESCRIPTION
## Purpose
Prevent an unbuilt or missing vendored FA2 extension from silently disabling the SM70 D256 exact-prefill route and producing misleading long-prefill baselines.

Base SHA: `1bd2ed5726`
Head SHA: `9c6e8a199e`

## Changes
- Warn once with the exact import/operator failure when SM70 D256 exact-prefill operators are unavailable.
- Record required/optional FA2 D256 operator availability and the resolved extension path in `benchmark_sm70_decode.py`.
- Add `--require-sm70-fa2-d256-prefill` to fail before model loading instead of benchmarking the fallback.
- Add focused tests and retain the Qwen3.8 FP8-KV/MTP investigation, including the rejected state-only candidate.

## Test Plan
- Python 3.12, Torch 2.10.0+cu128.
- `pytest -q tests/benchmarks/test_benchmark_sm70_decode.py tests/v1/attention/test_sm70_flash_v100_policy.py`
- Ruff check and format check on all changed Python files.
- Runtime operator audit against vendored FA2 binary SHA256 `98dd26ec09c1f9bbd2d2dda3bbb08c91d91308dc8e68398f9b984c44deee3214`.

## Test Result
- 81 tests passed.
- Ruff and format checks passed.
- Required dense/paged and optional split-KV3 operators all visible.
- Qwen3.8-27B-FP8, TP4, E5M2 KV, chunk 8192, 64K input/256 output:
  - missing extension fallback, no-MTP: 23.417800 s, 2798.6 tok/s
  - restored route, no-MTP: 18.743949 s, 3496.4 tok/s (+24.9%)
  - restored route, MTP4: 22.308881 s, 2937.7 tok/s
- Both restored-route runs emitted 256 coherent tokens with stable warmup/measurement hashes.
- Rejected state-only MTP prefill candidate: +0.10% prefill latency, accepted length 3.779 -> 3.253; implementation removed.

Artifacts: `/data/minimax-h3/task-cache/qwen38-mtp-fp8kv-prefill-20260816/`

## Risk
This PR does not change the accepted attention math or dispatch policy. It makes a previously silent optional-extension fallback observable and optionally fatal in the benchmark.