### PR TITLE
[Kernel] Make SM70 AWQ compact reduce deterministic

### DIFF
--- a/benchmarks/run_sm70_quality_speed_matrix.py
+++ b/benchmarks/run_sm70_quality_speed_matrix.py
@@ -499,6 +499,7 @@ def _run_worker(args: argparse.Namespace) -> int:
                     "finish_reason": q_finish_reason,
                     "stop_reason": q_stop_reason,
                     "prompt_tokens": len(request.prompt_token_ids or []),
+                    "token_ids": token_ids,
                     "metrics": _quality_metrics(text, token_ids),
                     "preview": text[:1000],
                     "tail": text[-1000:],
@@ -517,7 +518,7 @@ def _run_worker(args: argparse.Namespace) -> int:
         top_k=-1,
         skip_special_tokens=False,
     )
-    det_outputs = [llm.generate([det_prompt], det_sampling)[0] for _ in range(2)]
+    det_outputs = [llm.generate([det_prompt], det_sampling)[0] for _ in range(3)]
     det_records = []
     for output in det_outputs:
         text, token_ids, det_finish_reason, det_stop_reason = _output_record(output)
@@ -525,14 +526,14 @@ def _run_worker(args: argparse.Namespace) -> int:
             {
                 "finish_reason": det_finish_reason,
                 "stop_reason": det_stop_reason,
+                "token_ids": token_ids,
                 "metrics": _quality_metrics(text, token_ids),
                 "preview": text[:800],
             }
         )
-    deterministic_exact = (
-        det_records[0]["metrics"]["token_hash"]
-        == det_records[1]["metrics"]["token_hash"]
-    )
+    det_hashes = [record["metrics"]["token_hash"] for record in det_records]
+    deterministic_exact = len(set(det_hashes)) == 1
+    deterministic_steady_state_exact = det_hashes[-2] == det_hashes[-1]
 
     case_quality_passed = (
         all(record["metrics"]["passed"] for record in quality_records)
@@ -587,6 +588,7 @@ def _run_worker(args: argparse.Namespace) -> int:
             "records": quality_records,
             "determinism": {
                 "exact_token_match": deterministic_exact,
+                "steady_state_exact_token_match": deterministic_steady_state_exact,
                 "records": det_records,
             },
             "passed": case_quality_passed,

--- a/csrc/sm70_turbomind/ops/awq_sm70_gemm.cu
+++ b/csrc/sm70_turbomind/ops/awq_sm70_gemm.cu
@@ -6216,14 +6216,11 @@ void awq_moe_single_token_sm70_out(
   awq_moe_gemm_sm70_per_expert_dispatch_out(
       intermediate, compact_input, expert_offsets, dst_w13_ptrs_w_rows,
       dst_w13_ptrs_s_rows, top_k, w13_k, w13_n, group_size, true);
-  const bool use_weighted_reduce_epilogue = out.size(1) == w2_n;
-  if (use_weighted_reduce_epilogue) {
-    awq_moe_gemm_sm70_out_impl(sorted_output, intermediate, expert_offsets,
-                               dst_w2_ptrs_w_rows, dst_w2_ptrs_s_rows, top_k,
-                               w2_k, w2_n, group_size, false, torch::Tensor(),
-                               true, out, sorted_weights, true);
-    return;
-  }
+  // The weighted-reduce GEMM epilogue accumulates expert CTAs into the same
+  // FP16 output with atomicAdd. CTA arrival order is not deterministic, so
+  // repeated greedy requests can drift even with identical inputs. Materialize
+  // the eight expert rows and reduce them below in a fixed route order with
+  // FP32 FMA accumulation.
   awq_moe_gemm_sm70_per_expert_dispatch_out(
       sorted_output, intermediate, expert_offsets, dst_w2_ptrs_w_rows,
       dst_w2_ptrs_s_rows, top_k, w2_k, w2_n, group_size, false);

--- a/docs/design/sm70_v100_migration_control.md
+++ b/docs/design/sm70_v100_migration_control.md
@@ -41507,3 +41507,53 @@ Interpretation:
   `MagicMock` during lazy custom-op import, followed by duplicate Torch-op
   registration; its other 10 tests pass. Do not treat those import-pollution
   failures as MLA numerical evidence.
+
+## 2026-08-16 Qwen3.6 35B AWQ compact-reduce determinism repair
+
+- Reproduced a real no-MTP output-quality defect on Qwen3.6-35B-A3B-AWQ,
+  TP2 V100, FP16 KV, greedy decoding, and the accepted Flash-V100/compile-graph
+  route. Identical requests could agree twice and then diverge on the third
+  request, typically after 156-226 output tokens. This is not the expected
+  numerical difference between FP8 KV and FP16 KV: FP8 KV was not used in this
+  reproduction.
+- Focused exclusions showed that the instability remained with CUDA Graph and
+  compile disabled, asynchronous scheduling disabled, custom all-reduce
+  disabled, TRITON_ATTN selected, and FlashQLA GDN decode disabled. Disabling
+  only `VLLM_SM70_AWQ_MOE_LEGACY_SINGLE_TOKEN_COMPACT` restored three-request
+  token identity, but reduced the diagnostic short-request decode result from
+  about 97-98 to 83.09 tok/s. Keep that switch as an isolation control, not as
+  the production repair.
+- The compact W2 path used `StoreMoeWeightedReduce`, where eight expert CTAs
+  independently performed FP16 `atomicAdd` operations into the same output
+  row. CTA arrival order is unspecified, and rounding after each FP16 atomic
+  made the result depend on scheduling. The small per-layer drift accumulated
+  until a low-margin greedy token flipped.
+- The repair retains compact W13 and W2 GEMMs, materializes the eight sorted
+  expert rows, and invokes the existing fixed route-order half2 reduction with
+  FP32 FMA accumulation. It removes only the early weighted atomic epilogue;
+  attention, GDN, routing weights, quantized weights, and FP16 KV math are
+  unchanged.
+- Operator checks at layers 1, 20, and 39 covered round-robin routing and
+  single experts 0, 17, and 255. All 24 fused-W13/SILU and final-weighted-output
+  reports were bitwise exact against the ordered reference, with no NaNs and no
+  nonzero elements. Evidence is
+  `/data/minimax-h3/task-cache/awq-deterministic-reduce-20260816/op-layers1-20-39-patterns.json`.
+- The exact control and repaired `_C` binaries have SHA256
+  `8df401ad...d3e9` and `c81a45e8...2127`. With compact, Flash-V100,
+  compile/CUDA Graph, custom all-reduce, and asynchronous scheduling all left
+  enabled, the control produced three different 256-token greedy hashes:
+  `7f235c1e...1211`, `83f78a66...f7aa`, and `9b907780...ecc9`. The repaired
+  binary produced `e385f7e8...90dd` three times and passed both full and
+  steady-state exact-token gates.
+- A matched 512-input/256-output performance request reported 255 steady decode
+  tokens. Pure decode was 97.262188 tok/s for the atomic control and 97.691431
+  tok/s for the ordered repair (`+0.441%`, neutral noise rather than a
+  regression). Prefill/TTFT were not included in that comparison. Artifacts
+  are `fullmodel-atomic-speed256.json` and `fullmodel-fixed-speed256.json`
+  under
+  `/data/minimax-h3/task-cache/awq-deterministic-reduce-20260816/`.
+- Hardened `run_sm70_quality_speed_matrix.py` to retain output token IDs and
+  require three same-process greedy requests instead of two. It also reports
+  the last-two-request steady-state result separately. The earlier two-request
+  gate could miss this scheduler-order defect and must not be cited as
+  sufficient evidence for the compact route.


### PR DESCRIPTION
## Purpose

- Remove the nondeterministic FP16 atomic weighted epilogue from the SM70 AWQ single-token compact W2 route.
- Preserve compact W13/W2 GEMMs and reduce the eight expert rows in fixed route order with FP32 FMA.
- Harden the quality matrix to retain token IDs and require three same-process greedy requests.

## Test Plan

- Build the exact CUDA 12.8 / Torch 2.10 / SM70 `_C` extension.
- Compare compact output with the ordered reference across representative Qwen3.6-35B-A3B-AWQ layers and routing patterns.
- Run matched TP2 V100 full-model control/candidate quality and pure-decode gates with FP16 KV, no MTP, Flash-V100, compile/CUDA Graph, async scheduling, and custom all-reduce enabled.

## Test Result

- Exact `_C` build passed.
- 24/24 operator reports were bitwise exact with no NaNs or nonzero differences.
- Atomic control: three different 256-token greedy hashes; quality failed.
- Ordered repair: one identical hash across all three requests; full and steady-state determinism passed.
- Matched 512-input/256-output pure decode: 97.262188 tok/s control vs 97.691431 tok/s repair (+0.441%, neutral noise/no regression).
- `python -m py_compile`, `ruff check`, `ruff format --check`, and `git diff --check` passed.