### PR TITLE
[Bugfix] Align SM70 paged prefill accumulators

### DIFF
--- a/flash-attention-v100/kernel/fused_mha_forward_paged.cu
+++ b/flash-attention-v100/kernel/fused_mha_forward_paged.cu
@@ -3,6 +3,7 @@
 #include <cuda_fp16.h>
 #include <torch/extension.h>
 #include <algorithm>
+#include <cstddef>
 #include <cstdlib>
 #include <cstring>
 #include <string>
@@ -135,7 +136,8 @@ struct KernelConfig {
         alignas(16) float  pipeline_s[PIPELINE_S_ELEMENTS];
         alignas(16) int    pipeline_page_idx[PIPELINE_PAGE_ELEMENTS];
         alignas(16) int    pipeline_page_offset[PIPELINE_PAGE_ELEMENTS];
-        alignas(16) float  o      [BLOCK_M * O_STRIDE];
+        // WMMA accumulator loads and stores require 256-bit alignment.
+        alignas(32) float  o      [BLOCK_M * O_STRIDE];
         alignas(16) float  row_max[BLOCK_M];
         alignas(16) float  row_sum[BLOCK_M];
         alignas(16) int    page_idx[LOW_SMEM_PAGE_COUNT];
@@ -143,6 +145,8 @@ struct KernelConfig {
     };
 
     static constexpr size_t TOTAL_SMEM = ((sizeof(SmemLayout) + 127) & ~size_t(127));
+    static_assert(offsetof(SmemLayout, o) % 32 == 0,
+                  "WMMA accumulator storage must be 256-bit aligned");
 };
 
 template<typename Config>
@@ -480,7 +484,7 @@ flash_attention_forward_kernel_paged(
     const int64_t k_row_stride = k_token_stride;
     const int64_t v_row_stride = v_token_stride;
 
-    extern __shared__ char smem_raw[];
+    extern __shared__ __align__(128) char smem_raw[];
     init_smem<Config>(smem_raw);
     auto& smem = *reinterpret_cast<typename Config::SmemLayout*>(smem_raw);
 

--- a/tests/kernels/attention/test_sm70_flash_v100_paged_prefill_determinism.py
+++ b/tests/kernels/attention/test_sm70_flash_v100_paged_prefill_determinism.py
@@ -1,0 +1,129 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+
+def _make_paged_inputs(
+    *,
+    seq_len: int,
+    block_size: int,
+) -> tuple[
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+]:
+    num_query_heads = 12
+    num_kv_heads = 2
+    head_dim = 128
+    num_blocks = (seq_len + block_size - 1) // block_size
+
+    query = torch.randn(
+        1,
+        seq_len,
+        num_query_heads,
+        head_dim,
+        dtype=torch.float16,
+        device="cuda",
+    )
+    key_cache = torch.full(
+        (num_blocks, block_size, num_kv_heads, head_dim),
+        100.0,
+        dtype=torch.float16,
+        device="cuda",
+    )
+    value_cache = key_cache.clone()
+    key = torch.randn(
+        seq_len,
+        num_kv_heads,
+        head_dim,
+        dtype=torch.float16,
+        device="cuda",
+    )
+    value = torch.randn_like(key)
+
+    for token_idx in range(seq_len):
+        block_idx, block_offset = divmod(token_idx, block_size)
+        key_cache[block_idx, block_offset] = key[token_idx]
+        value_cache[block_idx, block_offset] = value[token_idx]
+
+    block_table = torch.arange(num_blocks, dtype=torch.int32, device="cuda").unsqueeze(
+        0
+    )
+    seq_lens = torch.tensor([seq_len], dtype=torch.int32, device="cuda")
+    return query, key_cache, value_cache, block_table, seq_lens
+
+
+def _assert_bit_exact_replays(outputs: list[torch.Tensor], label: str) -> None:
+    reference = outputs[0]
+    max_diff = max((reference - output).abs().max().item() for output in outputs[1:])
+    assert all(torch.equal(reference, output) for output in outputs[1:]), (
+        f"{label} replay changed; max_abs_diff={max_diff}"
+    )
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
+@pytest.mark.parametrize("seq_len", [300, 512])
+@torch.inference_mode()
+def test_sm70_flash_v100_paged_prefill_d128_replay_is_bit_exact(
+    seq_len: int,
+) -> None:
+    """Guard the physical-V100 regression reported in #98.
+
+    The direct extension replay separates a kernel error from the public API's
+    BMHD-to-BHMD conversion and output copy. Synchronizing each launch makes
+    this a strict deterministic-replay test rather than a stream-order test.
+    """
+    if torch.cuda.get_device_capability() != (7, 0):
+        pytest.skip("FlashAttention-V100 regression is SM70/V100 only")
+
+    flash_attn_v100 = pytest.importorskip("flash_attn_v100")
+    from flash_attn_v100 import flash_attn_interface
+
+    torch.manual_seed(0)
+    query, key_cache, value_cache, block_table, seq_lens = _make_paged_inputs(
+        seq_len=seq_len,
+        block_size=256,
+    )
+    query_bhmd = query.permute(0, 2, 1, 3).contiguous()
+    direct_outputs: list[torch.Tensor] = []
+    public_outputs: list[torch.Tensor] = []
+
+    for _ in range(6):
+        direct_output = flash_attn_interface.flash_attn_v100_cuda.prefill_paged_fwd(
+            query_bhmd,
+            key_cache,
+            value_cache,
+            None,
+            block_table,
+            seq_lens,
+            query.shape[-1] ** -0.5,
+            "auto",
+            1.0,
+            1.0,
+            True,
+            -1,
+            -1,
+        )
+        torch.accelerator.synchronize()
+        direct_outputs.append(direct_output)
+
+        public_output = flash_attn_v100.flash_attn_prefill_paged(
+            query,
+            key_cache,
+            value_cache,
+            block_table,
+            seq_lens,
+            causal=True,
+        )
+        torch.accelerator.synchronize()
+        public_outputs.append(public_output)
+
+    _assert_bit_exact_replays(direct_outputs, "prefill_paged_fwd")
+    _assert_bit_exact_replays(public_outputs, "flash_attn_prefill_paged")
+    assert torch.equal(direct_outputs[0].permute(0, 2, 1, 3), public_outputs[0])


### PR DESCRIPTION
## Purpose

Port and complete the hardware gate for #123 / #98 on current main. The D=128 paged-prefill FP32 WMMA accumulator buffer started at a 16-byte boundary, while WMMA matrix load/store requires 256-bit (32-byte) alignment. The resulting undefined behavior was observed as run-to-run prefill jitter and could fork greedy output after server restart.

## Change

- Align the accumulator buffer to 32 bytes.
- Explicitly align the dynamic shared-memory base and assert the accumulator offset at compile time.
- Add the six-replay physical-SM70 regression from #123, updated to the current accelerator synchronization API.

## Test Plan

- Build the bundled Flash-V100 extension from this branch for `sm_70`.
- On a physical V100, run direct-extension and public-wrapper D=128 paged prefill six times for L=300 and L=512 and require bitwise equality.
- Compare both shapes against an independent FP32 causal-GQA reference.
- Run focused Ruff and diff checks.

## Test Result

- CUDA 12.8 / Torch 2.9.1, V100-SXM2-16GB: extension build passed.
- `pytest --confcutdir=tests/kernels/attention tests/kernels/attention/test_sm70_flash_v100_paged_prefill_determinism.py`: **2 passed**.
- All six direct and public replays were bit-exact for both L=300 and L=512.
- FP32 reference:
  - L=300: finite, max abs error `0.00086688995`, mean abs error `3.2426e-05`, cosine `0.9999999404`.
  - L=512: finite, max abs error `0.00109624863`, mean abs error `2.6168e-05`, cosine `1.0`.
- Ruff check and format check passed; `git diff --check` passed.

Supersedes #123 without changing the kernel algorithm or dispatch.
