### PR TITLE
[SM70][NVFP4] Admit ModelOpt on exact SM70 via proven backends

### DIFF
--- a/tests/quantization/test_sm70_modelopt_nvfp4.py
+++ b/tests/quantization/test_sm70_modelopt_nvfp4.py
@@ -92,7 +92,7 @@ def test_modelopt_scale_provenance_is_not_the_pr166_heuristic():
     # ModelOpt provenance is explicit: global is already amax/2688.
     # Same numeric tensors must keep the on-disk global (no rewrite).
     modelopt_global = 100.0
-    assert _modelopt_dequant_oracle(nibble, block, modelopt_global) == 200.0
+    assert _modelopt_dequant_oracle(nibble, block, modelopt_global) == 100.0
     assert abs(block) < 1
     assert _modelopt_dequant_oracle(nibble, block, modelopt_global) != 1.0
 

--- a/tests/quantization/test_sm70_modelopt_nvfp4.py
+++ b/tests/quantization/test_sm70_modelopt_nvfp4.py
@@ -1,0 +1,255 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Exact-SM70 ModelOpt NVFP4 admission: capability, provenance, routing.
+
+These tests exist so PR 114/166 cannot recur:
+- the class-wide gate is not blindly lowered to 70
+- scale convention is ModelOpt provenance (amax/2688), never max(|scale|) < 1
+- TurboMind prepare is exact SM70 only
+"""
+
+from unittest.mock import MagicMock, patch
+
+import torch
+from torch.nn.parameter import Parameter
+
+from vllm.config import KernelConfig, VllmConfig, set_current_vllm_config
+from vllm.model_executor.layers.quantization import sm70_turbomind as sm70_tm
+from vllm.model_executor.layers.quantization.modelopt import (
+    ModelOptNvFp4Config,
+    ModelOptNvFp4LinearMethod,
+    ModelOptNvFp4W4A16LinearMethod,
+)
+
+
+def _modelopt_dequant_oracle(
+    packed_nibble: float, block_scale: float, weight_global_scale: float
+) -> float:
+    """Independent ModelOpt NVFP4 dequant: nibble * block * (amax/2688)."""
+    return packed_nibble * block_scale * weight_global_scale
+
+
+def _ct_dequant_oracle(
+    packed_nibble: float, block_scale: float, disk_global: float
+) -> float:
+    """Independent CT NVFP4 dequant: nibble * block / disk_global."""
+    return packed_nibble * block_scale / disk_global
+
+
+def _rejected_magnitude_heuristic_dequant(
+    packed_nibble: float, block_scale: float, disk_global: float
+) -> float:
+    """PR 166 heuristic: max(|block|) < 1 => drop the global factor."""
+    global_scale = 1.0 if abs(block_scale) < 1 else 1.0 / disk_global
+    return packed_nibble * block_scale * global_scale
+
+
+def test_modelopt_nvfp4_min_capability_requires_proven_backend(monkeypatch):
+    monkeypatch.delenv("VLLM_USE_NVFP4_CT_EMULATIONS", raising=False)
+    monkeypatch.delenv("VLLM_NVFP4_GEMM_BACKEND", raising=False)
+    monkeypatch.delenv("VLLM_SM70_QUANT_BACKEND", raising=False)
+
+    with set_current_vllm_config(
+        VllmConfig(kernel_config=KernelConfig(linear_backend="auto"))
+    ):
+        assert ModelOptNvFp4Config.get_min_capability() == 70
+
+    monkeypatch.setenv("VLLM_SM70_NVFP4_TURBOMIND", "0")
+    with set_current_vllm_config(
+        VllmConfig(kernel_config=KernelConfig(linear_backend="auto"))
+    ):
+        assert ModelOptNvFp4Config.get_min_capability() == 75
+
+    monkeypatch.delenv("VLLM_SM70_NVFP4_TURBOMIND", raising=False)
+    monkeypatch.setenv("VLLM_SM70_QUANT_BACKEND", "marlin")
+    with set_current_vllm_config(
+        VllmConfig(kernel_config=KernelConfig(linear_backend="auto"))
+    ):
+        assert ModelOptNvFp4Config.get_min_capability() == 70
+
+    monkeypatch.setenv("VLLM_SM70_QUANT_BACKEND", "turbomind")
+    with set_current_vllm_config(
+        VllmConfig(kernel_config=KernelConfig(linear_backend="auto"))
+    ):
+        assert ModelOptNvFp4Config.get_min_capability() == 70
+
+    monkeypatch.setenv("VLLM_SM70_NVFP4_TURBOMIND", "0")
+    monkeypatch.setenv("VLLM_SM70_QUANT_BACKEND", "auto")
+    with set_current_vllm_config(
+        VllmConfig(kernel_config=KernelConfig(linear_backend="emulation"))
+    ):
+        assert ModelOptNvFp4Config.get_min_capability() == 70
+
+
+def test_modelopt_scale_provenance_is_not_the_pr166_heuristic():
+    # yangzhuxinyzx 100x counterexample: valid CT encoding, FP8 block 0.5,
+    # disk global 100, nibble 2. Correct CT dequant is 0.01. The rejected
+    # magnitude rule rewrites it to 1.0.
+    nibble, block, disk_global = 2.0, 0.5, 100.0
+    assert _ct_dequant_oracle(nibble, block, disk_global) == 0.01
+    assert _rejected_magnitude_heuristic_dequant(nibble, block, disk_global) == 1.0
+
+    # ModelOpt provenance is explicit: global is already amax/2688.
+    # Same numeric tensors must keep the on-disk global (no rewrite).
+    modelopt_global = 100.0
+    assert _modelopt_dequant_oracle(nibble, block, modelopt_global) == 200.0
+    assert abs(block) < 1
+    assert _modelopt_dequant_oracle(nibble, block, modelopt_global) != 1.0
+
+
+def _w4a16_layer(global_scale: float, block_scale: float) -> torch.nn.Module:
+    layer = torch.nn.Module()
+    layer.weight = Parameter(
+        torch.zeros((16, 8), dtype=torch.uint8),
+        requires_grad=False,
+    )
+    layer.weight_scale = Parameter(
+        torch.full((16, 1), block_scale, dtype=torch.float8_e4m3fn),
+        requires_grad=False,
+    )
+    layer.weight_scale_2 = Parameter(
+        torch.tensor([global_scale], dtype=torch.float32),
+        requires_grad=False,
+    )
+    layer.input_scale = Parameter(
+        torch.tensor([1.0], dtype=torch.float32),
+        requires_grad=False,
+    )
+    return layer
+
+
+def test_w4a16_keeps_modelopt_global_scale_without_reciprocation_or_heuristic():
+    layer = _w4a16_layer(global_scale=100.0, block_scale=0.5)
+    fake_kernel = MagicMock()
+
+    with patch(
+        "vllm.model_executor.layers.quantization.modelopt.MarlinNvFp4LinearKernel",
+        return_value=fake_kernel,
+    ):
+        method = ModelOptNvFp4W4A16LinearMethod(
+            ModelOptNvFp4Config(
+                quant_method="W4A16_NVFP4",
+                is_checkpoint_nvfp4_serialized=True,
+            )
+        )
+
+    with (
+        patch.object(sm70_tm, "should_prepare_turbomind", return_value=False),
+        patch.object(
+            sm70_tm,
+            "prepare_nvfp4_linear",
+            side_effect=AssertionError("prepare must not run"),
+        ),
+    ):
+        method.process_weights_after_loading(layer)
+
+    # Provenance: keep on-disk ModelOpt global. Do not invert. Do not
+    # force 1.0 because max(|weight_scale|) < 1.
+    assert torch.equal(layer.weight_global_scale.cpu(), torch.tensor(100.0))
+    assert not hasattr(layer, "weight_scale_2")
+    fake_kernel.process_weights_after_loading.assert_called_once_with(layer)
+
+
+def test_w4a16_turbomind_prepare_only_on_exact_sm70():
+    layer = _w4a16_layer(global_scale=0.25, block_scale=1.0)
+    fake_kernel = MagicMock()
+
+    with patch(
+        "vllm.model_executor.layers.quantization.modelopt.MarlinNvFp4LinearKernel",
+        return_value=fake_kernel,
+    ):
+        method = ModelOptNvFp4W4A16LinearMethod(
+            ModelOptNvFp4Config(
+                quant_method="W4A16_NVFP4",
+                is_checkpoint_nvfp4_serialized=True,
+            )
+        )
+
+    def fake_prepare(prepared: torch.nn.Module) -> None:
+        setattr(prepared, sm70_tm.STATE_ATTR, object())
+
+    with (
+        patch.object(sm70_tm, "should_prepare_turbomind", return_value=True),
+        patch.object(sm70_tm, "prepare_nvfp4_linear", side_effect=fake_prepare),
+    ):
+        method.process_weights_after_loading(layer)
+
+    assert sm70_tm.has_prepared_linear(layer)
+    assert layer.weight.numel() == 0
+    assert layer.weight_scale.numel() == 0
+    fake_kernel.process_weights_after_loading.assert_not_called()
+
+
+def test_w4a4_turbomind_prepare_skipped_off_sm70():
+    layer = torch.nn.Module()
+    layer.input_scale = Parameter(
+        torch.ones(1, dtype=torch.float32),
+        requires_grad=False,
+    )
+    layer.weight_scale_2 = Parameter(
+        torch.tensor([0.25], dtype=torch.float32),
+        requires_grad=False,
+    )
+    layer.weight = Parameter(
+        torch.zeros((16, 8), dtype=torch.uint8),
+        requires_grad=False,
+    )
+    layer.weight_scale = Parameter(
+        torch.ones((16, 1), dtype=torch.float8_e4m3fn),
+        requires_grad=False,
+    )
+    fake_kernel = MagicMock()
+
+    with patch(
+        "vllm.model_executor.layers.quantization.modelopt.init_nvfp4_linear_kernel",
+        return_value=fake_kernel,
+    ):
+        method = ModelOptNvFp4LinearMethod(
+            ModelOptNvFp4Config(
+                quant_method="NVFP4",
+                is_checkpoint_nvfp4_serialized=True,
+            )
+        )
+
+    with (
+        patch.object(sm70_tm, "should_prepare_turbomind", return_value=False),
+        patch.object(
+            sm70_tm,
+            "prepare_nvfp4_linear",
+            side_effect=AssertionError("prepare must not run off SM70"),
+        ),
+    ):
+        method.process_weights_after_loading(layer)
+
+    fake_kernel.process_weights_after_loading.assert_called_once_with(layer)
+    assert not sm70_tm.has_prepared_linear(layer)
+
+
+def test_apply_uses_prepared_turbomind_path():
+    layer = torch.nn.Module()
+    fake_kernel = MagicMock()
+    fake_out = torch.zeros((1, 4), dtype=torch.float16)
+
+    with patch(
+        "vllm.model_executor.layers.quantization.modelopt.MarlinNvFp4LinearKernel",
+        return_value=fake_kernel,
+    ):
+        method = ModelOptNvFp4W4A16LinearMethod(
+            ModelOptNvFp4Config(
+                quant_method="W4A16_NVFP4",
+                is_checkpoint_nvfp4_serialized=True,
+            )
+        )
+
+    x = torch.ones((1, 16), dtype=torch.float16)
+    with (
+        patch.object(sm70_tm, "has_prepared_linear", return_value=True),
+        patch.object(
+            sm70_tm, "apply_prepared_linear", return_value=fake_out
+        ) as apply_tm,
+    ):
+        out = method.apply(layer, x)
+
+    assert out is fake_out
+    apply_tm.assert_called_once()
+    fake_kernel.apply_weights.assert_not_called()

--- a/tests/quantization/test_sm70_modelopt_nvfp4_kernel_oracle.py
+++ b/tests/quantization/test_sm70_modelopt_nvfp4_kernel_oracle.py
@@ -1,0 +1,148 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Exact-SM70 ModelOpt NVFP4: real kernel path vs an independent fp32 reference.
+
+Runs only on a Volta (7,0) CUDA device. Builds a synthetic linear in the exact
+on-disk ModelOpt layout (``weight`` uint8 E2M1 pairs, ``weight_scale`` fp8 e4m3
+per 16-group, ``weight_scale_2`` fp32 = amax/(6*448)), loads it through the real
+ModelOpt W4A4 / W4A16 quant methods (so the SM70 TurboMind prepare/apply route is
+exercised end to end), and compares against a pure-torch dequant + fp32 GEMM that
+shares no code with vLLM's scale handling. A convention error (reciprocated or
+dropped global, PR 166 class) shows up as an output-norm ratio of ~2688x or
+~1/2688x and fails loudly; kernel arithmetic error shows up as low cosine.
+"""
+
+import os
+
+import pytest
+import torch
+
+from vllm.config import VllmConfig, set_current_vllm_config
+from vllm.distributed import (
+    ensure_model_parallel_initialized,
+    init_distributed_environment,
+)
+from vllm.model_executor.layers.linear import ReplicatedLinear
+from vllm.model_executor.layers.quantization import sm70_turbomind as sm70_tm
+from vllm.model_executor.layers.quantization.modelopt import ModelOptNvFp4Config
+
+E2M1 = torch.tensor([0.0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0], dtype=torch.float32)
+
+
+def _is_exact_sm70() -> bool:
+    return torch.cuda.is_available() and torch.cuda.get_device_capability(0) == (7, 0)
+
+
+pytestmark = pytest.mark.skipif(
+    not _is_exact_sm70(), reason="requires an exact SM70 (Volta) CUDA device"
+)
+
+
+def _decode_e2m1(packed: torch.Tensor) -> torch.Tensor:
+    lo = packed & 0x0F
+    hi = (packed >> 4) & 0x0F
+    nib = torch.stack([lo, hi], dim=-1).reshape(packed.shape[0], -1).long()
+    return E2M1[nib & 0x7] * torch.where((nib & 0x8) != 0, -1.0, 1.0)
+
+
+def _make_modelopt_layer(n: int, k: int, seed: int):
+    """Synthetic ModelOpt NVFP4 tensors: nibbles, fp8 block scales, amax global."""
+    g = torch.Generator().manual_seed(seed)
+    packed = torch.randint(0, 256, (n, k // 2), generator=g, dtype=torch.uint8)
+    amax = 0.35
+    weight_scale_2 = torch.tensor(amax / (6.0 * 448.0), dtype=torch.float32)
+    # block scales in fp8: values so that block*global lands in a realistic weight range
+    block = torch.rand(n, k // 16, generator=g) * 400.0 + 20.0
+    weight_scale = block.to(torch.float8_e4m3fn)
+    w_ref = (
+        _decode_e2m1(packed)
+        * weight_scale.to(torch.float32).repeat_interleave(16, dim=1)
+        * weight_scale_2
+    )
+    return packed, weight_scale, weight_scale_2, w_ref
+
+
+def _build_layer(quant_method: str, n: int, k: int, tensors, device):
+    packed, weight_scale, weight_scale_2, _ = tensors
+    os.environ.setdefault("MASTER_ADDR", "127.0.0.1")
+    os.environ.setdefault("MASTER_PORT", "29581")
+    with set_current_vllm_config(VllmConfig()):
+        try:
+            init_distributed_environment(
+                world_size=1,
+                rank=0,
+                local_rank=0,
+                distributed_init_method="env://",
+                backend="gloo",
+            )
+            ensure_model_parallel_initialized(1, 1)
+        except Exception:
+            pass  # already initialised by an earlier test in this process
+        qc = ModelOptNvFp4Config(
+            is_checkpoint_nvfp4_serialized=True,
+            kv_cache_quant_algo=None,
+            exclude_modules=[],
+            group_size=16,
+            quant_method=quant_method,
+        )
+        lin = ReplicatedLinear(
+            k,
+            n,
+            bias=False,
+            quant_config=qc,
+            prefix="oracle",
+            params_dtype=torch.float16,
+        ).to(device)
+        for pname, param in lin.named_parameters():
+            src = {
+                "weight": packed,
+                "weight_scale": weight_scale,
+                "weight_scale_2": weight_scale_2.reshape(1),
+                "input_scale": torch.tensor([1.0]),
+            }.get(pname)
+            if src is None:
+                continue
+            loader = getattr(param, "weight_loader", None)
+            if loader is not None:
+                loader(
+                    param, src if param.dtype == torch.uint8 else src.to(param.dtype)
+                )
+            else:
+                param.data.copy_(src.reshape(param.shape))
+        lin.quant_method.process_weights_after_loading(lin)
+        return lin
+
+
+@pytest.mark.parametrize("quant_method", ["NVFP4", "W4A16_NVFP4"])
+@pytest.mark.parametrize("n,k", [(512, 1024), (1024, 512)])
+def test_sm70_modelopt_nvfp4_kernel_matches_independent_reference(
+    monkeypatch, quant_method, n, k
+):
+    monkeypatch.setenv("VLLM_SM70_NVFP4_TURBOMIND", "1")
+    monkeypatch.delenv("VLLM_SM70_QUANT_BACKEND", raising=False)
+    assert ModelOptNvFp4Config.get_min_capability() == 70
+
+    device = torch.device("cuda:0")
+    tensors = _make_modelopt_layer(n, k, seed=n + k)
+    w_ref = tensors[3]
+    lin = _build_layer(quant_method, n, k, tensors, device)
+    assert sm70_tm.has_prepared_linear(lin), "expected the exact-SM70 TurboMind route"
+
+    torch.manual_seed(0)
+    x = (torch.randn(64, k) * 0.5).to(torch.float16)
+    y_ref = x.float() @ w_ref.T  # independent fp32 reference
+    y_floor = (x @ w_ref.to(torch.float16).T).float()  # fp16 accumulation floor
+    with torch.no_grad():
+        y_dut, _ = lin(x.to(device))
+    y_dut = y_dut.float().cpu()
+
+    ratio = float(y_dut.norm() / y_ref.norm())
+    cos = float(
+        torch.nn.functional.cosine_similarity(y_dut.flatten(), y_ref.flatten(), dim=0)
+    )
+    rel = float((y_dut - y_ref).norm() / y_ref.norm())
+    rel_floor = float((y_floor - y_ref).norm() / y_ref.norm())
+    # A reciprocated/dropped global would put ratio at ~2688 or ~1/2688.
+    assert abs(ratio - 1.0) < 0.02, f"output scale ratio {ratio} (convention error?)"
+    assert cos > 0.999, f"cosine {cos} (kernel arithmetic error?)"
+    assert rel < max(5.0 * rel_floor, 5e-3), f"rel err {rel} vs fp16 floor {rel_floor}"

--- a/vllm/model_executor/layers/quantization/modelopt.py
+++ b/vllm/model_executor/layers/quantization/modelopt.py
@@ -8,6 +8,7 @@ import torch
 from torch.nn.parameter import Parameter
 
 import vllm.model_executor.layers.fused_moe.modular_kernel as mk
+from vllm import envs
 from vllm.config import get_current_vllm_config
 from vllm.logger import init_logger
 from vllm.model_executor.kernels.linear import (
@@ -48,6 +49,7 @@ from vllm.model_executor.layers.linear import (
     UnquantizedLinearMethod,
 )
 from vllm.model_executor.layers.quantization import QuantizationMethods
+from vllm.model_executor.layers.quantization import sm70_turbomind as sm70_tm
 from vllm.model_executor.layers.quantization.base_config import (
     QuantizationConfig,
     QuantizeMethodBase,
@@ -1002,6 +1004,51 @@ ModelOptFp8Config.FusedMoEMethodCls = ModelOptFp8MoEMethod
 ModelOptFp8Config.KVCacheMethodCls = ModelOptKVCacheMethod
 
 
+def _explicit_nvfp4_emulation_requested() -> bool:
+    """True when an explicit NVFP4 software-emulation backend is selected.
+
+    Matches compressed-tensors W4A4 NVFP4: emulation is a proven software
+    path, so SM70 may load. Cutlass/FlashInfer are not.
+    """
+    if envs.VLLM_USE_NVFP4_CT_EMULATIONS or envs.VLLM_NVFP4_GEMM_BACKEND == "emulation":
+        return True
+
+    from vllm.config import get_current_vllm_config_or_none
+
+    vllm_config = get_current_vllm_config_or_none()
+    return (
+        vllm_config is not None
+        and vllm_config.kernel_config.linear_backend == "emulation"
+    )
+
+
+def _try_prepare_sm70_modelopt_nvfp4(layer: torch.nn.Module) -> bool:
+    """Prepare exact-SM70 TurboMind NVFP4 weights for a ModelOpt linear.
+
+    ModelOpt stores ``weight_scale_2`` / ``weight_global_scale`` as
+    ``amax / (6 * 448)`` (the Marlin multiplier). TurboMind combine is
+    ``block * global``. Do not infer convention from scale magnitude.
+    """
+    if not sm70_tm.should_prepare_turbomind(
+        layer.weight, envs.VLLM_SM70_NVFP4_TURBOMIND
+    ):
+        return False
+    logger.info_once(
+        "SM70 ModelOpt NVFP4 TurboMind dense path enabled "
+        "(weight-only; activations remain half)."
+    )
+    sm70_tm.prepare_nvfp4_linear(layer)
+    layer.weight = Parameter(
+        torch.empty(0, dtype=torch.uint8, device=layer.weight.device),
+        requires_grad=False,
+    )
+    layer.weight_scale = Parameter(
+        torch.empty(0, dtype=torch.float8_e4m3fn, device=layer.weight_scale.device),
+        requires_grad=False,
+    )
+    return True
+
+
 class ModelOptNvFp4Config(ModelOptQuantConfigBase):
     """Config class for ModelOpt FP4."""
 
@@ -1050,6 +1097,18 @@ class ModelOptNvFp4Config(ModelOptQuantConfigBase):
 
     @classmethod
     def get_min_capability(cls) -> int:
+        # Do not unconditionally lower the class-wide gate to 70. W4A4
+        # (quant_algo=NVFP4) and W4A16_NVFP4 share this config; SM70 is
+        # admitted only when a proven software backend is selected.
+        # Exact-device routing still happens later via
+        # sm70_tm.should_prepare_turbomind (capability == (7, 0)).
+        if (
+            sm70_tm.use_turbomind(envs.VLLM_SM70_NVFP4_TURBOMIND)
+            or sm70_tm.forces_marlin()
+        ):
+            return 70
+        if _explicit_nvfp4_emulation_requested():
+            return 70
         return 75
 
     @classmethod
@@ -1220,6 +1279,9 @@ class ModelOptNvFp4LinearMethod(LinearMethodBase):
             (1.0 / layer.input_global_scale).to(torch.float32), requires_grad=False
         )
 
+        if _try_prepare_sm70_modelopt_nvfp4(layer):
+            return
+
         # Convert layer to NVFP4 linear kernel format
         self.kernel.process_weights_after_loading(layer)
 
@@ -1229,6 +1291,8 @@ class ModelOptNvFp4LinearMethod(LinearMethodBase):
         x: torch.Tensor,
         bias: torch.Tensor | None = None,
     ) -> torch.Tensor:
+        if sm70_tm.has_prepared_linear(layer):
+            return sm70_tm.apply_prepared_linear(layer, x, bias)
         return self.kernel.apply_weights(layer=layer, x=x, bias=bias)
 
 
@@ -1360,12 +1424,15 @@ class ModelOptNvFp4W4A16LinearMethod(LinearMethodBase):
 
         # Rename weight_scale_2 -> weight_global_scale. NO reciprocation:
         # ModelOpt already stores amax/2688, which is exactly what Marlin
-        # consumes via nvfp4_marlin_process_global_scale (called inside the
-        # Marlin adapter's process_weights_after_loading).
+        # and SM70 TurboMind consume. This is checkpoint-format provenance,
+        # not a magnitude heuristic (see PR 166 rejection).
         layer.weight_global_scale = Parameter(
             layer.weight_scale_2.max().to(torch.float32), requires_grad=False
         )
         del layer.weight_scale_2
+
+        if _try_prepare_sm70_modelopt_nvfp4(layer):
+            return
 
         self.kernel.process_weights_after_loading(layer)
 
@@ -1375,6 +1442,8 @@ class ModelOptNvFp4W4A16LinearMethod(LinearMethodBase):
         x: torch.Tensor,
         bias: torch.Tensor | None = None,
     ) -> torch.Tensor:
+        if sm70_tm.has_prepared_linear(layer):
+            return sm70_tm.apply_prepared_linear(layer, x, bias)
         return self.kernel.apply_weights(layer=layer, x=x, bias=bias)
 
 


### PR DESCRIPTION
## Summary

Narrow resubmit of the **only leftover** from closed [#166](https://github.com/1CatAI/1Cat-vLLM/pull/166) / [#114](https://github.com/1CatAI/1Cat-vLLM/pull/114): admit **ModelOpt NVFP4** on exact SM70.

This is **not** the #166 kitchen-sink. There is **no** `max(|weight_scale|) < 1` rewrite and **no** change to compressed-tensors scale handling.

## What changed

1. **`ModelOptNvFp4Config.get_min_capability`** is no longer a blind `75 → 70`. It returns 70 only when a proven software backend is selected, matching current-main CT W4A4:
   - `VLLM_SM70_NVFP4_TURBOMIND` / `use_sm70_turbomind`
   - forced Marlin (`VLLM_SM70_QUANT_BACKEND=marlin`)
   - explicit emulation (`linear_backend=emulation` / legacy env)
   - otherwise **75** — support is not claimed when those backends are off (the #114 close reason).
2. **Exact-SM70 routing** uses existing `sm70_tm.should_prepare_turbomind` (`device capability == (7, 0)`). SM75+ ModelOpt paths are unchanged.
3. **ModelOpt W4A16 and W4A4** linears hook the already-merged TurboMind `prepare_nvfp4_linear` / `apply_prepared_linear` path. W4A4 on SM70 is weight-only (activations stay half), same honesty as current-main CT W4A4.
4. **Scale convention is checkpoint provenance**, not a magnitude heuristic. ModelOpt stores `weight_scale_2 = amax / (6 * 448)`. We still rename to `weight_global_scale` **without reciprocation**. TurboMind combine is `block * global`. The #166 100x CT counterexample (`block=0.5`, `disk_global=100`) is a unit-test fixture and is **not** rewritten.

## Out of scope (intentionally)

- Any `normalize_nvfp4_global_scale_for_sm70` / `max(|scale|) < 1` rewrite
- Hybrid GDN `linear_attn` policy / checkpoint stamps
- MoE Marlin/EMULATION selection (already on main)
- Graph/MTP serve scripts and Paris/323 smokes as merge evidence
- Changing CT export convention at source

## Tests

`tests/quantization/test_sm70_modelopt_nvfp4.py`

- capability gate: TM / Marlin / emulation / off
- independent ModelOpt vs CT vs rejected-heuristic dequant oracle, including the 100x counterexample
- W4A16 keeps on-disk global (no recip, no force-`1.0`)
- TurboMind prepare only when `should_prepare_turbomind` is true; skipped off-SM70
- apply uses the prepared TM path when present

## Remaining V100 gates (required before merge)

These match the #166 close bar. Attached in the evidence comment below (current main `2dec067`, 2× V100).

- **(c)** Real-layer dequant/logit vs an independent reference on a ModelOpt NVFP4 checkpoint (not a self-consistent unit fixture).
- **(d)** Current-main CUDA-graph no-MTP and MTP output-quality coverage on exact SM70, as applicable.

I will attach those artifacts on this PR rather than citing #166 Paris/323.

## Test plan

- [x] Unit: capability / provenance / exact-SM70 routing
- [x] Focused pytest on current main tree (10 passed on V100, `54105a0`)
- [x] V100 ModelOpt load + real-layer dequant/logit vs reference (see evidence comment)
- [x] V100 CUDA-graph no-MTP / MTP quality gate (see evidence comment)
