### PR TITLE
[Doc] Prepare 1.3.0 release notes

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -57,6 +57,7 @@ TP2 FP8-weight baseline by `+22.24%` to `53.693 tok/s` at 128K.
 | Qwen3.6-27B | FP8 | 2/4 | supported | supported |
 | Qwen3.6-35B-A3B | AWQ | 2/4 | supported | supported fallback |
 | Qwen3.6-35B-A3B | FP8 | 2/4 | supported | supported fallback |
+| Qwen3.8-27B | FP8 | 4 | supported | supported |
 | Qwen3.5-27B | NVFP4 | 4 | supported | no valid MTP weights |
 
 FP8 KV decode overhead at 64K is within 0.49%-1.16% of matched FP16 KV across

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -67,8 +67,10 @@ the accepted matrix. TurboMind remains the production SM70 quantization path.
 
 - The wheel now includes Flash-V100, paged-KV utilities, vLLM CUDA extensions,
   TurboMind SM70 kernels, and the complete FlashQLA Python/CUDA source package.
-- FlashQLA no longer requires an external source checkout. Its first JIT build
-  still requires a compatible CUDA toolkit and C++ compiler.
+- The wheel bundles the precompiled SM70 FlashQLA extension, so a supported
+  wheel install does not invoke NVCC at runtime. Editable/source installs may
+  use the explicit FlashQLA JIT fallback and therefore require a compatible
+  CUDA toolkit and C++ compiler.
 - All tracked Python files pass Ruff. The release change set also passes
   formatting, typos, mypy, SPDX, configuration, and backend documentation
   checks.
@@ -80,6 +82,12 @@ the accepted matrix. TurboMind remains the production SM70 quantization path.
 - The exact dual-CTA verifier currently targets the G6 FP8-KV shape; other
   shapes use exact fallbacks.
 - `FLASHINFER_SM70` and BFLA sparse prefill remain explicit experimental paths.
+- SM70 Flash-V100 disables saved AOT graph-cache reload by default because a
+  cached-artifact reload can cause deterministic greedy-token drift. This
+  preserves output quality but increases cold-start compilation time.
+- MTP is opt-in. Its first request can compile Triton helper kernels for a
+  previously unseen shape, causing a cold latency spike; warm it before
+  accepting production traffic.
 
 ## Build Target
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,7 +1,8 @@
-# 1Cat-vLLM 1.2.2
+# 1Cat-vLLM 1.3.0
 
-1Cat-vLLM 1.2.2 improves V100/SM70 long-context attention, FP8 KV cache,
-and Qwen3.6 MTP4 performance. It supersedes 1.2.1.
+1Cat-vLLM 1.3.0 improves V100/SM70 long-context attention, FP8 KV cache,
+Qwen3.6 MTP4 performance, and adds validated Qwen3.8-27B FP8 support. It
+supersedes 1.2.2.
 
 ## Highlights
 
@@ -14,7 +15,7 @@ and Qwen3.6 MTP4 performance. It supersedes 1.2.1.
   exact output on the accepted prefill paths.
 - Fixed stale CUDA Graph partition metadata so decode scans the live KV length.
 
-| Matched path | Before | 1.2.2 | Change |
+| Matched path | Before | 1.3.0 | Change |
 | --- | ---: | ---: | ---: |
 | FP16 paged-prefill operator, 64K | `43.605 ms` | `31.717 ms` | `-27.26%` |
 | 27B-AWQ TP4 full-model prefill, 64K | `47.9785 s` | `33.0984 s` | `-31.01%` |

--- a/docs/design/sm70_qwen38_130_acceptance.md
+++ b/docs/design/sm70_qwen38_130_acceptance.md
@@ -131,13 +131,20 @@ issue, not an idle-GPU or missing graph-shape issue.
 ## Wheel And Compatibility
 
 - Wheel: `1cat_vllm-1.3.0-cp312-cp312-linux_x86_64.whl`.
-- SHA256: `df4275918461c67cb8af2c489a097cf5c7424e37706396267690094007eafdab`.
+- SHA256: `38d894460540b42dc480fed2a3c3fbb6600ecc1d3fe3e6e32054d4a766a03ff4`.
 - A cloned environment imports vLLM 1.3.0 from site-packages with Torch
   2.10.0+cu128. `_moe_C.moe_permute_sort_workspace_size` is present.
 - The wheel contains `_C`, `_C_stable_libtorch`, `_moe_C`, Flash-V100,
   vLLM FA2, and `flash_qla_sm70_gdn_strided.so`.
 - A clean-cache MTP4 plus FP8-KV boundary run does not create
   `TORCH_EXTENSIONS_DIR`, proving FlashQLA does not invoke NVCC at runtime.
+- The 2026-08-17 release candidate was rebuilt from the accepted SM70 source,
+  installed into a fresh Python 3.12 environment, and served Qwen3.8-27B-FP8
+  TP4 with the `fp8` shorthand resolving to E5M2. In both no-MTP and MTP4
+  lanes, repeated fixed-seed greedy responses were byte-identical and official
+  sampling stopped naturally without replacement characters. MTP's first
+  request may still JIT Triton helper kernels; this is a cold-latency concern,
+  not a numerical-output difference.
 - Qwen3.6-35B-A3B-AWQ TP2 final-wheel checks pass. Official 1K/256 and
   4K/1024 pure decode are 95.63 and 95.29 tok/s (10.457 and 10.494 ms TPOT),
   with complete, non-corrupted outputs and the TurboMind AWQ MoE route.

--- a/docs/design/sm70_qwen38_130_acceptance.md
+++ b/docs/design/sm70_qwen38_130_acceptance.md
@@ -4,7 +4,7 @@ Date: 2026-08-15
 
 ## Contract
 
-- Model: `Qwen3.8-27B-FP8`, TP4 on four V100-32GB GPUs.
+- Model: `Qwen3.8-27B-FP8`, TP4 on four V100-SXM2-16GB GPUs.
 - Runtime: Python 3.12, Torch 2.10.0+cu128, CUDA 12.8, CUDA graphs enabled.
 - Production attention: `FLASH_ATTN_V100`; no eager or Marlin performance
   evidence is accepted.


### PR DESCRIPTION
## Purpose

Prepare the 1.3.0 release notes and record the final wheel acceptance result.

- Promote the top-level release note from 1.2.2 to 1.3.0 and add Qwen3.8-27B FP8 support.
- Correct the Qwen3.8 acceptance hardware contract to the tested 4x V100-SXM2-16GB topology.
- Correct the FlashQLA wheel-install statement and disclose the SM70 AOT-cache and MTP cold-start limits.

## Base

- Runtime base SHA: `2dec067954e38d8e8082489398d0fee57148ef9d`

## Validation

- SM70 static quality and routing gates: 92 passed.
- Exact-main Qwen3.8 FP8 E5M2 1K-256K artifact verifier: passed.
- Fresh wheel: `1cat_vllm-1.3.0-cp312-cp312-linux_x86_64.whl`.
- SHA256: `38d894460540b42dc480fed2a3c3fbb6600ecc1d3fe3e6e32054d4a766a03ff4`.
- `unzip -t`, SM70 cubin inspection, clean Python 3.12 install/import, and prebuilt FlashQLA load passed without runtime NVCC.
- Fresh Qwen3.8-27B-FP8 TP4 wheel services passed deterministic greedy-repeat and natural-stop sampling smoke for both no-MTP and MTP4 with FP8 E5M2 KV.

## Scope

Documentation only; no runtime code or kernel behavior changes.