### PR TITLE
[SM70][MTP] Do not kill the engine when a sampled request joins an all-greedy probabilistic-draft batch

### DIFF
--- a/tests/v1/spec_decode/test_sm70_mtp_probabilistic_mixed_batch_guard.py
+++ b/tests/v1/spec_decode/test_sm70_mtp_probabilistic_mixed_batch_guard.py
@@ -1,0 +1,54 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""MTP probabilistic-draft guard: only reject when a non-greedy row carries drafts.
+
+Draft tokens are proposed one step ahead with the previous batch's sampling
+metadata. When that batch was all-greedy the proposer legitimately returns no
+draft probabilities. If a sampled request joins on the next step it has zero
+draft tokens, so the verify step must not be rejected (that rejection killed
+the engine on every greedy->mixed batch transition).
+"""
+
+from types import SimpleNamespace
+
+import torch
+
+from vllm.v1.sample.rejection_sampler import GREEDY_TEMPERATURE
+from vllm.v1.worker.gpu_model_runner import _non_greedy_rows_carry_drafts
+
+
+def _meta(temperatures, num_draft_tokens):
+    sampling = SimpleNamespace(
+        temperature=None
+        if temperatures is None
+        else torch.tensor(temperatures, dtype=torch.float32)
+    )
+    spec = SimpleNamespace(num_draft_tokens=list(num_draft_tokens))
+    return sampling, spec
+
+
+def test_all_greedy_rows_with_drafts_do_not_need_probs():
+    sampling, spec = _meta([GREEDY_TEMPERATURE, GREEDY_TEMPERATURE], [2, 2])
+    assert _non_greedy_rows_carry_drafts(sampling, spec) is False
+
+
+def test_sampled_request_joining_greedy_batch_has_no_drafts_yet():
+    # Row 0: running greedy decode with 2 drafts proposed last step (argmax path).
+    # Row 1: new temperature=1.0 request on its first verify step, 0 drafts.
+    sampling, spec = _meta([GREEDY_TEMPERATURE, 1.0], [2, 0])
+    assert _non_greedy_rows_carry_drafts(sampling, spec) is False
+
+
+def test_non_greedy_row_with_drafts_requires_probs():
+    sampling, spec = _meta([GREEDY_TEMPERATURE, 1.0], [2, 2])
+    assert _non_greedy_rows_carry_drafts(sampling, spec) is True
+
+
+def test_no_drafts_anywhere_never_requires_probs():
+    sampling, spec = _meta([0.7, 1.0], [0, 0])
+    assert _non_greedy_rows_carry_drafts(sampling, spec) is False
+
+
+def test_missing_temperature_tensor_means_all_greedy():
+    sampling, spec = _meta(None, [2, 2])
+    assert _non_greedy_rows_carry_drafts(sampling, spec) is False

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -182,7 +182,7 @@ from vllm.v1.pool.metadata import PoolingMetadata, PoolingStates
 from vllm.v1.sample.logits_processor import LogitsProcessors, build_logitsprocs
 from vllm.v1.sample.logits_processor.interface import LogitsProcessor
 from vllm.v1.sample.metadata import SamplingMetadata
-from vllm.v1.sample.rejection_sampler import RejectionSampler
+from vllm.v1.sample.rejection_sampler import GREEDY_TEMPERATURE, RejectionSampler
 from vllm.v1.sample.sampler import Sampler
 from vllm.v1.spec_decode.custom_class_proposer import create_custom_proposer
 from vllm.v1.spec_decode.ddtree_parent_metadata import (
@@ -1059,6 +1059,33 @@ class DDTreeMambaCopyRecord(TypedDict):
     dst_block_idx: int
     src_block_id: int
     dst_block_id: int
+
+
+def _non_greedy_rows_carry_drafts(
+    sampling_metadata: SamplingMetadata,
+    spec_decode_metadata: SpecDecodeMetadata,
+) -> bool:
+    """Whether any non-greedy request in this verify step carries draft tokens.
+
+    Draft tokens are proposed one step ahead with the *previous* batch's
+    sampling metadata. When that batch was all-greedy the proposer takes the
+    argmax fast path and legitimately returns no draft probabilities. If a
+    sampled (non-greedy) request joins the batch on the next step it has zero
+    draft tokens at that step, so no probability rows are needed for it, and
+    the greedy rows are verified by argmax without probabilities. Only a
+    non-greedy row that actually carries draft tokens needs ``draft_probs``;
+    that is the case the missing-probability guard must reject.
+    """
+    num_draft_tokens = spec_decode_metadata.num_draft_tokens
+    if not any(num_draft_tokens):
+        return False
+    temperature = sampling_metadata.temperature
+    if temperature is None:
+        return False
+    # Exceptional path only (probabilistic MTP, mixed batch, no probs), so the
+    # small device-to-host copy here does not sit on the steady-state step.
+    is_greedy = (temperature[: len(num_draft_tokens)] == GREEDY_TEMPERATURE).tolist()
+    return any(n > 0 and not greedy for n, greedy in zip(num_draft_tokens, is_greedy))
 
 
 class GPUModelRunner(
@@ -7299,6 +7326,7 @@ class GPUModelRunner(
             and self.speculative_config.draft_sample_method == "probabilistic"
             and not sampling_metadata.all_greedy
             and draft_probs is None
+            and _non_greedy_rows_carry_drafts(sampling_metadata, spec_decode_metadata)
         ):
             raise RuntimeError(
                 "MTP probabilistic draft sampling requires draft probability "


### PR DESCRIPTION
## Purpose

Stop `GPUModelRunner._sample` from terminating the EngineCore when a sampled (temperature>0) request joins a batch whose drafts were proposed while the batch was all-greedy, under `draft_sample_method=probabilistic` — which `arg_utils` applies by default to an explicit `{"method": "mtp", ...}` config on SM70.

## Root cause

Draft tokens for verify step N are sampled at step N−1 with step N−1's `SamplingMetadata`. `LLMBaseProposer._sample_draft_tokens` returns `(ids, None)` when that batch is all-greedy (argmax fast path). If a non-greedy request is admitted at step N, the guard at `_sample` sees `all_greedy=False` and `draft_probs is None` and raises `RuntimeError("MTP probabilistic draft sampling requires draft probability rows ...")`. The worker busy-loop dies; every subsequent request returns 500.

At that step the newly joined row has **zero draft tokens** (`rejection_sample_kernel` makes no acceptance decision for it) and the greedy rows are verified by `rejection_greedy_sample_kernel` without probabilities, so no `draft_probs` are needed. Only a non-greedy row that actually carries draft tokens needs them.

## Change

- `_non_greedy_rows_carry_drafts(sampling_metadata, spec_decode_metadata)`: true iff some row with `temperature != GREEDY_TEMPERATURE` has `num_draft_tokens > 0`. Added as the last conjunct of the guard, so all-greedy batches never evaluate it and the raise is kept for the genuinely invalid case (non-greedy row with drafts, no probs). The one small D2H copy is on the exceptional path only.
- `tests/v1/spec_decode/test_sm70_mtp_probabilistic_mixed_batch_guard.py` (5 cases: all-greedy with drafts; sampled row joining with 0 drafts; non-greedy row with drafts → must raise; no drafts; `temperature is None`).

## Repro and verification (2× Tesla V100-PCIE-32GB, main `2dec067` build, TP2, `FLASH_ATTN_V100`, `fp8_e5m2` KV)

Model: `philbert440/Qwen3.8-27B-NVFP4` (compressed-tensors, SM70 TurboMind path). Serve with `--speculative-config '{"method":"mtp","num_speculative_tokens":2,"attention_backend":"FLASH_ATTN_V100","draft_sample_method":"probabilistic"}'`.

| step | pristine main | with this fix |
|---|---|---|
| A) one `temperature=1` request alone | ok | ok |
| B) one `temperature=0` request alone | ok | ok |
| C) `temperature=1` request sent while a `temperature=0` request is decoding | **500; `RuntimeError: MTP probabilistic draft sampling requires draft probability rows`; engine dead; every later request 500** | ok |
| E) `temperature=0` request sent while a `temperature=1` request is decoding | (engine already dead) | ok |
| F) 8-way burst mixing `temperature ∈ {0, 0.7, 1.0}` and `max_tokens ∈ {2..200}` | 0/8 | 8/8 |
| guard raises in log | 9 | 0 |

Quality after the fix on the same serve: same-process greedy determinism 10/10 prompt-sets across 3 runs; Paris / no-think leak / gsm8k 3/3 / long-gen all pass. Greedy single-stream outputs vs pristine: 9/10 prompts token-identical; the remaining one flips at an exact fp16 tie (`' colors'` −0.694 vs `' visible'` −0.694 at token 39/211) — argmax tie order, not a semantic change (the helper cannot execute for all-greedy batches).

## Test plan
- [x] `pytest tests/v1/spec_decode/test_sm70_mtp_probabilistic_mixed_batch_guard.py` → 5 passed
- [x] `ruff check` / `ruff format --check` clean on both files
- [x] V100 repro A/B/C/E/F before and after (above)

Not a duplicate: no open PR touches this guard (open-PR inventory checked today). Related history: #174 (closed as superseded) addressed a different default; this PR does not change any default or the dynamic draft vocab.

*Disclosure per AGENTS.md: AI assistance (Rivet agents on this account) was used; the human owner of this account is responsible for the change.*
