### PR TITLE
[Bugfix][SM70] Preserve Flash-V100 in precompiled wheels

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -210,6 +210,29 @@ def bundle_flash_attn_v100(build_lib: str) -> None:
         remove_rpath(dst_ext)
 
 
+def bundle_precompiled_flash_attn_v100(build_lib: str) -> None:
+    """Embed Flash-V100 files extracted from a precompiled 1Cat wheel."""
+    extracted_pkg = ROOT_DIR / "flash_attn_v100"
+    ext_suffix = sysconfig.get_config_var("EXT_SUFFIX") or ".so"
+    extensions: list[Path] = []
+    for ext_name in ("flash_attn_v100_cuda", "paged_kv_utils"):
+        matches = sorted(extracted_pkg.glob(f"{ext_name}*{ext_suffix}"))
+        if not matches:
+            matches = sorted(extracted_pkg.glob(f"{ext_name}*.so"))
+        if not matches:
+            return
+        extensions.append(matches[-1])
+
+    dst_pkg = Path(build_lib) / "flash_attn_v100"
+    dst_pkg.mkdir(parents=True, exist_ok=True)
+    for py_file in FLASH_ATTN_V100_PACKAGE.glob("*.py"):
+        shutil.copy2(py_file, dst_pkg / py_file.name)
+    for extension in extensions:
+        dst_ext = dst_pkg / extension.name
+        shutil.copy2(extension, dst_ext)
+        remove_rpath(dst_ext)
+
+
 def bundle_flash_qla_sm70(build_lib: str, build_temp: str) -> None:
     """Precompile the SM70 GDN extension so runtime never requires NVCC."""
     if not _cuda_arch_contains(7, 0):
@@ -522,7 +545,8 @@ class precompiled_build_ext(build_ext):
     """Disables extension building when using precompiled binaries."""
 
     def run(self) -> None:
-        return
+        if _is_cuda():
+            bundle_precompiled_flash_attn_v100(self.build_lib)
 
     def build_extensions(self) -> None:
         print("Skipping build_ext: using precompiled extensions.")


### PR DESCRIPTION
## Purpose
Fix the CUDA precompiled-wheel repackage path, which extracted Flash-V100 extensions but emitted a wheel without the Flash-V100 Python package or extensions.

## Base
- Base SHA: `c82f26f79e190efd88c51bfd2c5e115bca86813c`

## Change
- When CUDA precompiled artifacts include both Flash-V100 extensions, copy their source-controlled Python files and extracted `.so` files into `build_lib` before wheel assembly.
- Preserve the existing no-op behavior when either extension is absent.

## Validation
- `pre-commit run --files setup.py`
- Actual `VLLM_USE_PRECOMPILED=1` repackage using the previously accepted SM70 wheel.
- ZIP integrity; 2,442 RECORD hashes; required Flash-V100 members; isolated `vllm`, Flash-V100 and FA2 native imports.
- `tests/v1/spec_decode/test_sm70_mtp_probabilistic_mixed_batch_guard.py`: 5 passed from the isolated rebuilt wheel.

## Scope / risk
- Packaging only; no model, attention, sampling, CUDA kernel, or runtime-dispatch code changes.
- The release wheel remains separately subject to the full source-build acceptance gate.