### PR TITLE
[Bugfix][SM70] Preserve FlashQLA in precompiled wheels

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -888,6 +888,9 @@ class precompiled_wheel_utils:
                     r"flash_attn_v100/"
                     r"(?:flash_attn_v100_cuda|paged_kv_utils).*\.so"
                 )
+                flash_qla_sm70_ext_regex = re.compile(
+                    r"flash_qla/ops/gated_delta_rule/chunk/sm70/[^/]+\.so"
+                )
                 file_members = []
                 for member in wheel.filelist:
                     if member.filename in exact_members:
@@ -906,6 +909,7 @@ class precompiled_wheel_utils:
                         or flashmla_regex.match(member.filename)
                         or deep_gemm_regex.match(member.filename)
                         or flash_attn_v100_ext_regex.match(member.filename)
+                        or flash_qla_sm70_ext_regex.match(member.filename)
                     ):
                         file_members.append(member)
 


### PR DESCRIPTION
## Purpose
Fix the CUDA precompiled-wheel repackage path so it retains the packaged SM70 FlashQLA extension (`flash_qla_sm70_gdn_strided.so`).

## Base
- Base SHA: `2f5c642897c0198d3d45766123165ea4b0e43e11`

## Change
- Include the packaged FlashQLA SM70 shared object when extracting a precompiled 1Cat wheel before building a replacement wheel.

## Validation
- `pre-commit run --files setup.py`
- Actual `VLLM_USE_PRECOMPILED=1` repackage from the previously accepted SM70 wheel.
- ZIP integrity and 2,443 RECORD hashes.
- Every `.so` and `vllm-rs` member is byte-identical to the accepted input wheel.
- Isolated imports plus direct `torch.ops.load_library` of packaged FlashQLA.
- `test_sm70_mtp_probabilistic_mixed_batch_guard.py` and `test_sm70_flash_v100_policy.py`: 87 passed.
- Flash-V100, FlashQLA, and `_C` contain SM70 cubins and have no RPATH.

## Scope / risk
- Packaging-only correction; no runtime, kernel, quality, attention, or sampling changes.