### PR TITLE
[Frontend][Model] Per-model serving defaults, DeepSeek-OCR resolution modes, and SWA async-eviction fix (SM70)

### DIFF
--- a/flash-attention-v100/flash_attn_v100/flash_attn_interface.py
+++ b/flash-attention-v100/flash_attn_v100/flash_attn_interface.py
@@ -897,6 +897,8 @@ def flash_attn_decode_paged(
     workspace_seq_capacity_hint: int | None = None,
     active_num_partitions: torch.Tensor | None = None,
     partition_size_hint: int | None = None,
+    anchor_lens: torch.Tensor | None = None,
+    anchored_window: int = 0,
 ):
     if softmax_scale is None:
         softmax_scale = q.shape[-1] ** -0.5
@@ -905,9 +907,12 @@ def flash_attn_decode_paged(
     block_table = maybe_contiguous(block_table)
     seq_lens = maybe_contiguous(seq_lens)
     out = maybe_contiguous(out)
+    anchor_lens = maybe_contiguous(anchor_lens)
     window_size_left, window_size_right = window_size
     if window_size_left < -1 or window_size_right < -1:
         raise ValueError(f"Invalid window_size={window_size}; values must be >= -1")
+    if anchored_window > 0 and anchor_lens is None:
+        raise ValueError("anchored_window requires anchor_lens")
     batch_capacity = q.shape[0]
     num_heads = q.shape[1]
     head_dim = q.shape[2]
@@ -960,6 +965,8 @@ def flash_attn_decode_paged(
         float(v_scale),
         int(window_size_left),
         int(window_size_right),
+        anchor_lens,
+        int(anchored_window),
     )
 
 
@@ -1232,6 +1239,8 @@ def flash_attn_prefill_paged(
     v_scale: float = 1.0,
     causal: bool = True,
     window_size: tuple = (-1, -1),
+    anchor_lens: torch.Tensor | None = None,
+    anchored_window: int = 0,
 ):
     if softmax_scale is None:
         softmax_scale = q.shape[-1] ** -0.5
@@ -1241,9 +1250,12 @@ def flash_attn_prefill_paged(
     block_table = maybe_contiguous(block_table)
     seq_lens = maybe_contiguous(seq_lens)
     out = maybe_contiguous(out)
+    anchor_lens = maybe_contiguous(anchor_lens)
     window_size_left, window_size_right = window_size
     if window_size_left < -1 or window_size_right < -1:
         raise ValueError(f"Invalid window_size={window_size}; values must be >= -1")
+    if anchored_window > 0 and anchor_lens is None:
+        raise ValueError("anchored_window requires anchor_lens")
 
     q_ = q.permute(0, 2, 1, 3).contiguous()
     out_ = out.permute(0, 2, 1, 3).contiguous() if out is not None else None
@@ -1262,6 +1274,8 @@ def flash_attn_prefill_paged(
         causal,
         int(window_size_left),
         int(window_size_right),
+        anchor_lens,
+        int(anchored_window),
     )
     return _copy_bhmd_to_bmhd_out(out_, out_original)
 
@@ -1433,6 +1447,8 @@ def flash_attn_prefill_paged_bhmd(
         causal,
         int(window_size_left),
         int(window_size_right),
+        None,
+        0,
     )
 
 

--- a/flash-attention-v100/include/fused_mha.h
+++ b/flash-attention-v100/include/fused_mha.h
@@ -48,7 +48,9 @@ at::Tensor flash_attention_decode_paged(
     const float k_scale,
     const float v_scale,
     const int window_size_left,
-    const int window_size_right
+    const int window_size_right,
+    const std::optional<at::Tensor>& anchor_lens,
+    const int64_t anchored_window
 );
 
 at::Tensor flash_attention_decode_paged_xqa(
@@ -148,7 +150,9 @@ at::Tensor flash_attention_prefill_paged(
     const float v_scale,
     const bool is_causal,
     const int window_size_left,
-    const int window_size_right
+    const int window_size_right,
+    const std::optional<at::Tensor>& anchor_lens,
+    const int64_t anchored_window
 );
 
 std::vector<at::Tensor>

--- a/flash-attention-v100/kernel/flash_decode_paged.cu
+++ b/flash-attention-v100/kernel/flash_decode_paged.cu
@@ -663,7 +663,7 @@ __device__ __forceinline__ float dot_qk_cache(const __half* __restrict__ q_ptr,
 }
 
 template <int D, int PARTITION_SIZE, int KV_DTYPE,
-          int SEQ_LEN_ROUTE = kXQARouteAllSeqLens>
+          int SEQ_LEN_ROUTE = kXQARouteAllSeqLens, bool ANCHORED_SWA = false>
 __global__ void flash_attention_decode_partition_kernel(
     const __half* __restrict__ q, const void* __restrict__ k_cache,
     const void* __restrict__ v_cache, __half* __restrict__ tmp_out,
@@ -681,7 +681,12 @@ __global__ void flash_attention_decode_partition_kernel(
     const int64_t v_head_stride, const float softmax_scale, const float k_scale,
     const float v_scale, const int window_size_left,
     const int window_size_right, const int route_seq_len_begin,
-    const int route_seq_len_end, const int route_seq_len_final) {
+    const int route_seq_len_end, const int route_seq_len_final,
+    const int* __restrict__ anchor_lens, const int anchored_window) {
+  // The anchored decode-window mask variant is only generated for the fp16-KV
+  // configuration; every other instantiation keeps its original code path.
+  static_assert(!ANCHORED_SWA || KV_DTYPE == flash_v100::KV_CACHE_DTYPE_FP16,
+                "ANCHORED_SWA requires an fp16 KV cache");
   const int batch_idx = blockIdx.x;
   const int head_idx = blockIdx.y;
   const int partition_idx = blockIdx.z;
@@ -718,6 +723,17 @@ __global__ void flash_attention_decode_partition_kernel(
                              : seq_len - 1;
   const int part_start = max(start_token_idx, min_token_idx);
   const int part_end = min(start_token_idx + PARTITION_SIZE, max_token_idx + 1);
+
+  // Anchored decode window: keys below the per-request prompt length stay
+  // globally visible; later (generated) keys must fall inside the sliding
+  // window over generated positions. Keys inside [gap_lo, gap_hi) are masked.
+  int gap_lo = seq_len;
+  int gap_hi = seq_len;
+  if constexpr (ANCHORED_SWA) {
+    const int anchor_len = anchor_lens[batch_idx];
+    gap_lo = anchor_len;
+    gap_hi = max(anchor_len, query_pos - anchored_window + 1);
+  }
   const int q_per_kv = num_heads_q / num_heads_kv;
   const int kv_head_idx = head_idx / q_per_kv;
   const int lane = threadIdx.x % kWarpSize;
@@ -777,9 +793,21 @@ __global__ void flash_attention_decode_partition_kernel(
 
     float score = dot_qk_cache<D, KV_DTYPE>(q_shared, k_cache, k_index, lane);
     if (lane == 0) {
-      score *= score_scale;
-      scores_shared[token_local] = score;
-      local_max = fmaxf(local_max, score);
+      if constexpr (ANCHORED_SWA) {
+        const int token_idx = part_start + token_local;
+        if (token_idx >= gap_lo && token_idx < gap_hi) {
+          // Masked gap key: never contributes (nulled gap blocks included).
+          scores_shared[token_local] = -1.0e30f;
+        } else {
+          score *= score_scale;
+          scores_shared[token_local] = score;
+          local_max = fmaxf(local_max, score);
+        }
+      } else {
+        score *= score_scale;
+        scores_shared[token_local] = score;
+        local_max = fmaxf(local_max, score);
+      }
     }
   }
 
@@ -787,6 +815,14 @@ __global__ void flash_attention_decode_partition_kernel(
 
   float local_sum = 0.f;
   for (int i = threadIdx.x; i < part_tokens; i += blockDim.x) {
+    if constexpr (ANCHORED_SWA) {
+      const int token_idx = part_start + i;
+      if (token_idx >= gap_lo && token_idx < gap_hi) {
+        // Exact zero weight for masked keys (no reliance on expf underflow).
+        scores_shared[i] = 0.f;
+        continue;
+      }
+    }
     const float p = __expf(scores_shared[i] - part_max);
     scores_shared[i] = p;
     local_sum += p;
@@ -2045,7 +2081,8 @@ void launch_flash_attention_decode_paged(
     const int window_size_left, const int window_size_right,
     cudaStream_t stream, const int route_seq_len_begin = 0,
     const int route_seq_len_end = 0, const int route_seq_len_final = 0,
-    const bool launch_reduce = true) {
+    const bool launch_reduce = true, const int* anchor_lens = nullptr,
+    const int anchored_window = 0) {
   const int batch_size = q.size(0);
   const int num_heads_q = q.size(1);
   const int num_heads_kv = k_cache.size(2);
@@ -2059,22 +2096,41 @@ void launch_flash_attention_decode_paged(
   const size_t reduce_shared_mem =
       static_cast<size_t>(2 * max_num_partitions) * sizeof(float);
 
-  flash_attention_decode_partition_kernel<D, PARTITION_SIZE, KV_DTYPE,
-                                          SEQ_LEN_ROUTE>
-      <<<partition_grid, block, 0, stream>>>(
-          reinterpret_cast<const __half*>(q.data_ptr<at::Half>()),
-          k_cache.data_ptr(), v_cache.data_ptr(),
-          reinterpret_cast<__half*>(tmp_out.data_ptr<at::Half>()),
-          max_logits.data_ptr<float>(), exp_sums.data_ptr<float>(),
-          block_table.data_ptr<int>(), seq_lens.data_ptr<int>(),
-          active_num_partitions.data_ptr<int>(), batch_size, max_num_blocks,
-          max_num_partitions, num_heads_q, num_heads_kv, block_size,
-          q.stride(0), q.stride(1), tmp_out.stride(0), tmp_out.stride(1),
-          tmp_out.stride(2), max_logits.stride(0), max_logits.stride(1),
-          k_cache.stride(0), k_cache.stride(1), k_cache.stride(2),
-          v_cache.stride(0), v_cache.stride(1), v_cache.stride(2),
-          softmax_scale, k_scale, v_scale, window_size_left, window_size_right,
-          route_seq_len_begin, route_seq_len_end, route_seq_len_final);
+  const bool use_anchored = anchor_lens != nullptr && anchored_window > 0;
+  // Second kernel version: the anchored decode-window mask is a separate
+  // template instantiation, generated only for the fp16-KV configuration;
+  // the non-anchored instantiations stay untouched.
+  const auto launch_partition = [&](auto anchored_tag) {
+    constexpr bool kAnchored = decltype(anchored_tag)::value;
+    flash_attention_decode_partition_kernel<D, PARTITION_SIZE, KV_DTYPE,
+                                            SEQ_LEN_ROUTE, kAnchored>
+        <<<partition_grid, block, 0, stream>>>(
+            reinterpret_cast<const __half*>(q.data_ptr<at::Half>()),
+            k_cache.data_ptr(), v_cache.data_ptr(),
+            reinterpret_cast<__half*>(tmp_out.data_ptr<at::Half>()),
+            max_logits.data_ptr<float>(), exp_sums.data_ptr<float>(),
+            block_table.data_ptr<int>(), seq_lens.data_ptr<int>(),
+            active_num_partitions.data_ptr<int>(), batch_size, max_num_blocks,
+            max_num_partitions, num_heads_q, num_heads_kv, block_size,
+            q.stride(0), q.stride(1), tmp_out.stride(0), tmp_out.stride(1),
+            tmp_out.stride(2), max_logits.stride(0), max_logits.stride(1),
+            k_cache.stride(0), k_cache.stride(1), k_cache.stride(2),
+            v_cache.stride(0), v_cache.stride(1), v_cache.stride(2),
+            softmax_scale, k_scale, v_scale, window_size_left,
+            window_size_right, route_seq_len_begin, route_seq_len_end,
+            route_seq_len_final, anchor_lens, anchored_window);
+  };
+  if constexpr (KV_DTYPE == flash_v100::KV_CACHE_DTYPE_FP16) {
+    if (use_anchored) {
+      launch_partition(std::true_type{});
+    } else {
+      launch_partition(std::false_type{});
+    }
+  } else {
+    TORCH_CHECK(!use_anchored,
+                "anchored decode window requires an fp16 KV cache");
+    launch_partition(std::false_type{});
+  }
 
   if (!launch_reduce) {
     return;
@@ -2388,7 +2444,9 @@ at::Tensor flash_attention_decode_paged(
     const float softmax_scale, const int partition_size,
     const int launch_num_partitions, const std::string& kv_cache_dtype,
     const float k_scale, const float v_scale, const int window_size_left,
-    const int window_size_right) {
+    const int window_size_right,
+    const std::optional<at::Tensor>& anchor_lens,
+    const int64_t anchored_window) {
   TORCH_CHECK(q.is_cuda(), "q must be on CUDA");
   TORCH_CHECK(k_cache.is_cuda() && v_cache.is_cuda(),
               "k/v cache must be on CUDA");
@@ -2474,6 +2532,23 @@ at::Tensor flash_attention_decode_paged(
   TORCH_CHECK(window_size_left >= -1 && window_size_right >= -1,
               "window sizes must be >= -1");
 
+  const bool use_anchored = anchor_lens.has_value() && anchored_window > 0;
+  const int* anchor_lens_ptr = nullptr;
+  if (use_anchored) {
+    const at::Tensor& anchors = anchor_lens.value();
+    TORCH_CHECK(anchors.is_cuda(), "anchor_lens must be on CUDA");
+    TORCH_CHECK(anchors.dtype() == torch::kInt32, "anchor_lens must be int32");
+    TORCH_CHECK(anchors.dim() == 1 && anchors.size(0) >= batch_size,
+                "anchor_lens must have shape [B]");
+    TORCH_CHECK(anchors.stride(0) == 1, "anchor_lens must be contiguous");
+    TORCH_CHECK(kv_dtype_code == flash_v100::KV_CACHE_DTYPE_FP16,
+                "anchored decode window requires an fp16 KV cache");
+    TORCH_CHECK(window_size_left == -1 && window_size_right == -1,
+                "anchored decode window cannot be combined with "
+                "sliding-window attention");
+    anchor_lens_ptr = anchors.data_ptr<int>();
+  }
+
   at::Tensor out = out_.has_value() ? out_.value() : torch::empty_like(q);
   TORCH_CHECK(out.is_cuda(), "out must be on CUDA");
   TORCH_CHECK(out.dtype() == torch::kFloat16, "out must be fp16");
@@ -2487,7 +2562,8 @@ at::Tensor flash_attention_decode_paged(
   launch_flash_attention_decode_paged<HDIM, PARTITION, KV_DTYPE_CODE>(       \
       q, k_cache, v_cache, out, block_table, seq_lens, tmp_out, max_logits,  \
       exp_sums, active_num_partitions, softmax_scale, launch_num_partitions, \
-      k_scale, v_scale, window_size_left, window_size_right, stream)
+      k_scale, v_scale, window_size_left, window_size_right, stream, 0, 0,   \
+      0, true, anchor_lens_ptr, static_cast<int>(anchored_window))
 
 #define LAUNCH_BY_KV_DTYPE(HDIM, PARTITION)                                 \
   do {                                                                      \

--- a/flash-attention-v100/kernel/flash_decode_paged.cu
+++ b/flash-attention-v100/kernel/flash_decode_paged.cu
@@ -2444,8 +2444,7 @@ at::Tensor flash_attention_decode_paged(
     const float softmax_scale, const int partition_size,
     const int launch_num_partitions, const std::string& kv_cache_dtype,
     const float k_scale, const float v_scale, const int window_size_left,
-    const int window_size_right,
-    const std::optional<at::Tensor>& anchor_lens,
+    const int window_size_right, const std::optional<at::Tensor>& anchor_lens,
     const int64_t anchored_window) {
   TORCH_CHECK(q.is_cuda(), "q must be on CUDA");
   TORCH_CHECK(k_cache.is_cuda() && v_cache.is_cuda(),
@@ -2558,12 +2557,12 @@ at::Tensor flash_attention_decode_paged(
   auto stream = at::cuda::getCurrentCUDAStream().stream();
   c10::cuda::CUDAGuard device_guard(q.device());
 
-#define LAUNCH_TYPED(HDIM, PARTITION, KV_DTYPE_CODE)                         \
-  launch_flash_attention_decode_paged<HDIM, PARTITION, KV_DTYPE_CODE>(       \
-      q, k_cache, v_cache, out, block_table, seq_lens, tmp_out, max_logits,  \
-      exp_sums, active_num_partitions, softmax_scale, launch_num_partitions, \
-      k_scale, v_scale, window_size_left, window_size_right, stream, 0, 0,   \
-      0, true, anchor_lens_ptr, static_cast<int>(anchored_window))
+#define LAUNCH_TYPED(HDIM, PARTITION, KV_DTYPE_CODE)                          \
+  launch_flash_attention_decode_paged<HDIM, PARTITION, KV_DTYPE_CODE>(        \
+      q, k_cache, v_cache, out, block_table, seq_lens, tmp_out, max_logits,   \
+      exp_sums, active_num_partitions, softmax_scale, launch_num_partitions,  \
+      k_scale, v_scale, window_size_left, window_size_right, stream, 0, 0, 0, \
+      true, anchor_lens_ptr, static_cast<int>(anchored_window))
 
 #define LAUNCH_BY_KV_DTYPE(HDIM, PARTITION)                                 \
   do {                                                                      \

--- a/flash-attention-v100/kernel/fused_mha_forward_paged.cu
+++ b/flash-attention-v100/kernel/fused_mha_forward_paged.cu
@@ -205,7 +205,7 @@ __device__ __forceinline__ void load_pipeline_swizzled_matrix_a_fragment(
 }
 
 template<int Q_STRIDE, int S_STRIDE, int K_TILES, bool IS_CAUSAL,
-         bool SWIZZLED_Q = false>
+         bool SWIZZLED_Q = false, bool ANCHORED_SWA = false>
 __device__ __forceinline__ void pipeline_qk_slice(
     const __half* __restrict__ sQ,
     float* __restrict__ score,
@@ -228,7 +228,9 @@ __device__ __forceinline__ void pipeline_qk_slice(
     float softmax_scale,
     int window_size_left,
     int window_size_right,
-    float neg_inf) {
+    float neg_inf,
+    int anchor_len = 0,
+    int anchored_window = 0) {
     if (tile_n >= valid_k_rows) {
         return;
     }
@@ -299,8 +301,18 @@ __device__ __forceinline__ void pipeline_qk_slice(
                     is_window_valid
                     && global_n <= global_q_pos + window_size_right;
             }
+            // Anchored decode window: keys inside the prompt/prefix stay
+            // globally visible; later (generated) keys must fall inside the
+            // sliding window over generated positions.
+            bool is_anchor_valid = true;
+            if constexpr (ANCHORED_SWA) {
+                is_anchor_valid =
+                    (global_n < anchor_len)
+                    || (global_q_pos - global_n < anchored_window);
+            }
             acc_frag.x[i] =
-                (is_valid && is_causal_valid && is_window_valid)
+                (is_valid && is_causal_valid && is_window_valid
+                 && is_anchor_valid)
                     ? acc_frag.x[i] * softmax_scale
                     : neg_inf;
         }
@@ -360,7 +372,7 @@ template<int D, bool LOW_SMEM, bool LOW_SMEM_CONTIG_FAST,
          bool LOW_SMEM_SCALAR_QK, bool LOW_SMEM_BM32, bool SPLIT_KV,
          bool IS_CAUSAL, int KV_DTYPE, bool D256_OUTPUT_STRIDE_268 = false,
          bool D256_SW_PIPELINE_QK = false,
-         bool D256_SW_PIPELINE_PV = false>
+         bool D256_SW_PIPELINE_PV = false, bool ANCHORED_SWA = false>
 __global__ void __launch_bounds__(
     KernelConfig<D, LOW_SMEM, LOW_SMEM_SCALAR_QK,
                  LOW_SMEM_BM32,
@@ -401,8 +413,17 @@ flash_attention_forward_kernel_paged(
           float* __restrict__ split_tmp_out,
           float* __restrict__ split_tmp_row_max,
           float* __restrict__ split_tmp_row_sum,
-    const int split_kv_tiles
+    const int split_kv_tiles,
+    const int* __restrict__ anchor_lens,
+    const int anchored_window
 ) {
+    // The anchored decode-window mask variant is only generated for the
+    // causal fp16-KV configuration; every other instantiation keeps its
+    // original code path.
+    static_assert(!ANCHORED_SWA
+                      || (IS_CAUSAL
+                          && KV_DTYPE == flash_v100::KV_CACHE_DTYPE_FP16),
+                  "ANCHORED_SWA requires IS_CAUSAL and fp16 KV cache");
     using Config = KernelConfig<D, LOW_SMEM, LOW_SMEM_SCALAR_QK,
                                 LOW_SMEM_BM32, D256_OUTPUT_STRIDE_268,
                                 D256_SW_PIPELINE_QK,
@@ -448,6 +469,14 @@ flash_attention_forward_kernel_paged(
     int num_n_tiles = (actual_N + BLOCK_N - 1) / BLOCK_N;
     const int valid_q_rows = min(BLOCK_M, M - start_row);
     const int causal_q_offset = max(actual_N - M, 0);
+
+    // Per-request prompt length for the anchored decode-window mask. Keys
+    // below anchor_len are globally visible; later keys must additionally
+    // fall inside the sliding window over generated positions.
+    int anchor_len = 0;
+    if constexpr (ANCHORED_SWA) {
+        anchor_len = anchor_lens[batch_id];
+    }
 
     int max_key_pos = actual_N - 1;
     if constexpr (IS_CAUSAL) {
@@ -570,13 +599,13 @@ flash_attention_forward_kernel_paged(
             if (warp_id < BLOCK_N / WMMA_N) {
                 const int valid_k_rows = min(BLOCK_N, actual_N);
                 pipeline_qk_slice<Q_STRIDE, S_STRIDE, D / WMMA_K,
-                                  IS_CAUSAL, true>(
+                                  IS_CAUSAL, true, ANCHORED_SWA>(
                     sQ, sS, k_cache_h, sPageIdx, sPageOffset,
                     k_block_stride, k_token_stride,
                     k_head_stride, kv_head_id, 0, valid_k_rows, start_row,
                     valid_q_rows, causal_q_offset, warp_id * WMMA_N, 0, false,
                     true, softmax_scale, window_size_left, window_size_right,
-                    NEG_INF);
+                    NEG_INF, anchor_len, anchored_window);
             }
             __syncthreads();
 
@@ -743,7 +772,7 @@ flash_attention_forward_kernel_paged(
                         if (warp_id < BLOCK_N / WMMA_N) {
                             pipeline_qk_slice<
                                 Q_STRIDE, S_STRIDE, D / WMMA_K, IS_CAUSAL,
-                                true>(
+                                true, ANCHORED_SWA>(
                                 sQ, score_next, k_cache_h, page_idx_next,
                                 page_offset_next, k_block_stride,
                                 k_token_stride, k_head_stride, kv_head_id,
@@ -751,7 +780,8 @@ flash_attention_forward_kernel_paged(
                                 valid_q_rows, causal_q_offset,
                                 warp_id * WMMA_N, 0, false, true,
                                 softmax_scale, window_size_left,
-                                window_size_right, NEG_INF);
+                                window_size_right, NEG_INF, anchor_len,
+                                anchored_window);
                         } else {
                             const int pv_warp =
                                 warp_id - BLOCK_N / WMMA_N;
@@ -975,6 +1005,13 @@ flash_attention_forward_kernel_paged(
                             is_valid
                             && global_n <= global_q_pos + window_size_right;
                     }
+                    if constexpr (ANCHORED_SWA) {
+                        is_valid =
+                            is_valid
+                            && ((global_n < anchor_len)
+                                || (global_q_pos - global_n
+                                    < anchored_window));
+                    }
 
                     float acc = 0.0f;
                     if (is_valid) {
@@ -999,13 +1036,15 @@ flash_attention_forward_kernel_paged(
                 constexpr int QK_TILES = BLOCK_N / WMMA_N;
                 if (warp_id < QK_TILES) {
                     pipeline_qk_slice<Q_STRIDE, S_STRIDE, D / WMMA_K,
-                                      IS_CAUSAL, D256_SW_PIPELINE_PV>(
+                                      IS_CAUSAL, D256_SW_PIPELINE_PV,
+                                      ANCHORED_SWA>(
                         sQ, sS, K_cache_h, sPageIdx, sPageOffset,
                         k_block_stride, k_token_stride, k_head_stride,
                         kv_head_id, start_col, valid_k_rows, start_row,
                         valid_q_rows, causal_q_offset, warp_id * WMMA_N, 0,
                         false, true, softmax_scale, window_size_left,
-                        window_size_right, NEG_INF);
+                        window_size_right, NEG_INF, anchor_len,
+                        anchored_window);
                 }
             } else {
                 const int num_tiles_m_qk = (BLOCK_M + WMMA_M - 1) / WMMA_M;
@@ -1119,9 +1158,17 @@ flash_attention_forward_kernel_paged(
                                 && global_n
                                        <= global_q_pos + window_size_right;
                         }
+                        bool is_anchor_valid = true;
+                        if constexpr (ANCHORED_SWA) {
+                            is_anchor_valid =
+                                (global_n < anchor_len)
+                                || (global_q_pos - global_n
+                                    < anchored_window);
+                        }
 
                         acc_frag.x[i] =
-                            (is_valid && is_causal_valid && is_window_valid)
+                            (is_valid && is_causal_valid && is_window_valid
+                             && is_anchor_valid)
                                 ? acc_frag.x[i] * softmax_scale
                                 : NEG_INF;
                     }
@@ -1266,8 +1313,15 @@ flash_attention_forward_kernel_paged(
                     is_window_valid = is_window_valid &&
                                       global_n <= global_q_pos + window_size_right;
                 }
+                bool is_anchor_valid = true;
+                if constexpr (ANCHORED_SWA) {
+                    is_anchor_valid =
+                        (global_n < anchor_len)
+                        || (global_q_pos - global_n < anchored_window);
+                }
 
-                acc_frag.x[i] = (is_valid && is_causal_valid && is_window_valid)
+                acc_frag.x[i] = (is_valid && is_causal_valid && is_window_valid
+                                 && is_anchor_valid)
                     ? acc_frag.x[i] * softmax_scale
                     : NEG_INF;
             }
@@ -1933,7 +1987,9 @@ void launcher_flash_attention_forward_paged_impl(
     float v_scale,
     int window_size_left,
     int window_size_right,
-    cudaStream_t stream
+    cudaStream_t stream,
+    const int* anchor_lens = nullptr,
+    int anchored_window = 0
 ) {
     using Config = KernelConfig<D, LOW_SMEM, LOW_SMEM_SCALAR_QK,
                                 LOW_SMEM_BM32, D256_OUTPUT_STRIDE_268,
@@ -1961,6 +2017,66 @@ void launcher_flash_attention_forward_paged_impl(
 
     TORCH_CHECK(smem <= MAX_SMEM_PER_SM, "Shared memory exceeds 96KB: ", smem,
                 " bytes");
+
+    const bool use_anchored = anchor_lens != nullptr && anchored_window > 0;
+    TORCH_CHECK(!use_anchored || is_causal,
+                "anchored decode window requires causal attention");
+    // Second kernel version: the anchored decode-window mask is a separate
+    // template instantiation, generated only for the causal fp16-KV
+    // configuration; the non-anchored instantiations stay untouched.
+    if constexpr (KV_DTYPE == flash_v100::KV_CACHE_DTYPE_FP16) {
+        if (use_anchored) {
+            auto anchored_kernel = flash_attention_forward_kernel_paged<
+                D, LOW_SMEM, LOW_SMEM_CONTIG_FAST, LOW_SMEM_SCALAR_QK,
+                LOW_SMEM_BM32, false, true, KV_DTYPE, D256_OUTPUT_STRIDE_268,
+                D256_SW_PIPELINE_QK, D256_SW_PIPELINE_PV, true>;
+            cudaFuncSetAttribute((void*)anchored_kernel,
+                                 cudaFuncAttributeMaxDynamicSharedMemorySize,
+                                 smem);
+            anchored_kernel<<<grid, block, smem, stream>>>(
+                reinterpret_cast<const __half*>(Q.data_ptr()),
+                K_cache.data_ptr(),
+                V_cache.data_ptr(),
+                reinterpret_cast<__half*>(Out.data_ptr()),
+                softmax_lse.data_ptr<float>(),
+                block_table.data_ptr<int>(),
+                seq_lens.data_ptr<int>(),
+                B,
+                H,
+                M,
+                N,
+                bfla_mask_ptr,
+                bfla_mask_block_n,
+                bfla_mask_stride_b,
+                bfla_mask_stride_h,
+                bfla_mask_stride_q,
+                bfla_mask_stride_k,
+                page_block_size,
+                num_kv_heads,
+                k_block_stride,
+                k_token_stride,
+                k_head_stride,
+                v_block_stride,
+                v_token_stride,
+                v_head_stride,
+                softmax_scale,
+                k_scale,
+                v_scale,
+                window_size_left,
+                window_size_right,
+                nullptr,
+                nullptr,
+                nullptr,
+                0,
+                anchor_lens,
+                anchored_window
+            );
+            return;
+        }
+    } else {
+        TORCH_CHECK(!use_anchored,
+                    "anchored decode window requires an fp16 KV cache");
+    }
 
     auto kernel = is_causal
                       ? (void*)flash_attention_forward_kernel_paged<
@@ -2015,6 +2131,8 @@ void launcher_flash_attention_forward_paged_impl(
             nullptr,
             nullptr,
             nullptr,
+            0,
+            nullptr,
             0
         );
     } else {
@@ -2055,6 +2173,8 @@ void launcher_flash_attention_forward_paged_impl(
             window_size_right,
             nullptr,
             nullptr,
+            nullptr,
+            0,
             nullptr,
             0
         );
@@ -2256,7 +2376,9 @@ void launcher_flash_attention_forward_paged_splitkv_impl(
             split_tmp_out.data_ptr<float>(),
             split_tmp_row_max.data_ptr<float>(),
             split_tmp_row_sum.data_ptr<float>(),
-            split_kv_tiles
+            split_kv_tiles,
+            nullptr,
+            0
         );
     } else {
         flash_attention_forward_kernel_paged<
@@ -2296,7 +2418,9 @@ void launcher_flash_attention_forward_paged_splitkv_impl(
             split_tmp_out.data_ptr<float>(),
             split_tmp_row_max.data_ptr<float>(),
             split_tmp_row_sum.data_ptr<float>(),
-            split_kv_tiles
+            split_kv_tiles,
+            nullptr,
+            0
         );
     }
 
@@ -3609,8 +3733,34 @@ void launcher_flash_attention_forward_paged(
     int64_t bfla_mask_stride_b = 0,
     int64_t bfla_mask_stride_h = 0,
     int64_t bfla_mask_stride_q = 0,
-    int64_t bfla_mask_stride_k = 0
+    int64_t bfla_mask_stride_k = 0,
+    const int* anchor_lens = nullptr,
+    int anchored_window = 0
 ) {
+    if (anchor_lens != nullptr && anchored_window > 0) {
+        // Anchored decode-window mask: dispatch to the dedicated masked
+        // instantiation through the baseline kernel configuration. The
+        // D256 fast-path variants are intentionally not generated for the
+        // masked version.
+        TORCH_CHECK(KV_DTYPE == flash_v100::KV_CACHE_DTYPE_FP16,
+                    "anchored decode window requires an fp16 KV cache");
+        TORCH_CHECK(is_causal,
+                    "anchored decode window requires causal attention");
+        TORCH_CHECK(window_size_left < 0 && window_size_right < 0,
+                    "anchored decode window cannot be combined with "
+                    "sliding-window attention");
+        TORCH_CHECK(bfla_mask_ptr == nullptr,
+                    "anchored decode window cannot be combined with a "
+                    "block sparsity mask");
+        launcher_flash_attention_forward_paged_impl<
+            D, KV_DTYPE, false, false, false, false>(
+            Q, K_cache, V_cache, Out, softmax_lse, block_table, seq_lens,
+            bfla_mask_ptr, bfla_mask_block_n, bfla_mask_stride_b,
+            bfla_mask_stride_h, bfla_mask_stride_q, bfla_mask_stride_k,
+            softmax_scale, is_causal, k_scale, v_scale, window_size_left,
+            window_size_right, stream, anchor_lens, anchored_window);
+        return;
+    }
     if constexpr (D == 256 && KV_DTYPE == flash_v100::KV_CACHE_DTYPE_FP16) {
         const int M = Q.size(2);
         const int page_block_size = K_cache.size(1);
@@ -3966,7 +4116,9 @@ at::Tensor flash_attention_prefill_paged(
     const float v_scale,
     const bool is_causal,
     const int window_size_left,
-    const int window_size_right
+    const int window_size_right,
+    const std::optional<at::Tensor>& anchor_lens,
+    const int64_t anchored_window
 ) {
     TORCH_CHECK(q.dtype() == torch::kFloat16, "q must be fp16");
     const int kv_dtype_code = kv_cache_dtype_code_from_string(kv_cache_dtype);
@@ -4006,6 +4158,26 @@ at::Tensor flash_attention_prefill_paged(
     TORCH_CHECK(window_size_left >= -1 && window_size_right >= -1,
                 "window sizes must be >= -1");
 
+    const bool use_anchored = anchor_lens.has_value() && anchored_window > 0;
+    const int* anchor_lens_ptr = nullptr;
+    if (use_anchored) {
+        const at::Tensor& anchors = anchor_lens.value();
+        TORCH_CHECK(anchors.is_cuda(), "anchor_lens must be on CUDA");
+        TORCH_CHECK(anchors.dtype() == torch::kInt32,
+                    "anchor_lens must be int32");
+        TORCH_CHECK(anchors.dim() == 1 && anchors.size(0) >= B,
+                    "anchor_lens must have shape [B]");
+        TORCH_CHECK(anchors.stride(0) == 1, "anchor_lens must be contiguous");
+        TORCH_CHECK(kv_dtype_code == flash_v100::KV_CACHE_DTYPE_FP16,
+                    "anchored decode window requires an fp16 KV cache");
+        TORCH_CHECK(is_causal,
+                    "anchored decode window requires causal attention");
+        TORCH_CHECK(window_size_left == -1 && window_size_right == -1,
+                    "anchored decode window cannot be combined with "
+                    "sliding-window attention");
+        anchor_lens_ptr = anchors.data_ptr<int>();
+    }
+
     at::Tensor out_fp16 = out_.has_value() ? out_.value() : torch::zeros_like(q);
     auto softmax_lse = torch::zeros({B, H, M},
                                     torch::dtype(torch::kFloat32).device(q.device()));
@@ -4019,7 +4191,8 @@ at::Tensor flash_attention_prefill_paged(
         launcher_flash_attention_forward_paged<HDIM, KV_DTYPE_CODE>(            \
             q, k_cache, v_cache, out_fp16, softmax_lse, block_table, seq_lens,  \
             softmax_scale, is_causal, k_scale, v_scale, window_size_left,       \
-            window_size_right, stream)
+            window_size_right, stream, nullptr, 0, 0, 0, 0, 0,                  \
+            anchor_lens_ptr, static_cast<int>(anchored_window))
 
     #define LAUNCH_PAGED_BY_KV(HDIM)                                            \
         do {                                                                    \

--- a/tests/kernels/attention/test_sm70_flash_v100_anchored_swa.py
+++ b/tests/kernels/attention/test_sm70_flash_v100_anchored_swa.py
@@ -1,0 +1,204 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""SM70 Flash-V100 anchored decode-window mask kernel tests.
+
+Validates the masked (second) kernel instantiations of the paged decode and
+paged prefill kernels against a plain torch reference:
+``causal AND (kv < anchor_len OR q_abs - kv < window)``, element-wise.
+
+Requires a CUDA device and the flash_attn_v100 extension built with the
+anchored kernel arguments; skipped otherwise.
+"""
+
+import pytest
+import torch
+
+cuda_available = torch.cuda.is_available()
+flash_ops = None
+if cuda_available:
+    try:
+        from flash_attn_v100 import (
+            flash_attn_decode_paged,
+            flash_attn_prefill_paged,
+        )
+
+        flash_ops = (flash_attn_decode_paged, flash_attn_prefill_paged)
+    except ImportError:
+        flash_ops = None
+
+pytestmark = pytest.mark.skipif(
+    not cuda_available or flash_ops is None,
+    reason="requires CUDA and the flash_attn_v100 extension",
+)
+
+
+def _anchored_mask(
+    q_positions: torch.Tensor,
+    kv_len: int,
+    anchor_len: int,
+    window: int,
+    device: str,
+) -> torch.Tensor:
+    """Boolean keep-mask [num_q, kv_len]; True = attend."""
+    kv = torch.arange(kv_len, device=device)[None, :]
+    q = q_positions[:, None]
+    causal = kv <= q
+    in_prefix = kv < anchor_len
+    in_window = (q - kv) < window
+    return causal & (in_prefix | in_window)
+
+
+def _ref_attention(
+    q: torch.Tensor,  # [num_q, H, D]
+    k: torch.Tensor,  # [kv_len, H_kv, D]
+    v: torch.Tensor,
+    mask: torch.Tensor,  # [num_q, kv_len]
+    scale: float,
+) -> torch.Tensor:
+    group = q.shape[1] // k.shape[1]
+    k_exp = k.repeat_interleave(group, dim=1)
+    v_exp = v.repeat_interleave(group, dim=1)
+    scores = torch.einsum("qhd,khd->hqk", q.float(), k_exp.float()) * scale
+    scores = scores.masked_fill(~mask[None], float("-inf"))
+    probs = torch.softmax(scores, dim=-1)
+    return torch.einsum("hqk,khd->qhd", probs, v_exp.float())
+
+
+def _build_paged_kv(
+    kv_len: int,
+    block_size: int,
+    num_kv_heads: int,
+    head_dim: int,
+    device: str,
+    dtype: torch.dtype,
+    seed: int,
+):
+    torch.manual_seed(seed)
+    num_blocks = (kv_len + block_size - 1) // block_size + 2
+    k_cache = torch.randn(
+        num_blocks, block_size, num_kv_heads, head_dim, device=device, dtype=dtype
+    )
+    v_cache = torch.randn_like(k_cache)
+    block_table = torch.arange(
+        num_blocks, dtype=torch.int32, device=device
+    ).unsqueeze(0)
+    k_lin = k_cache.reshape(-1, num_kv_heads, head_dim)[:kv_len]
+    v_lin = v_cache.reshape(-1, num_kv_heads, head_dim)[:kv_len]
+    return k_cache, v_cache, block_table, k_lin, v_lin
+
+
+@pytest.mark.parametrize(
+    "head_dim,num_heads,num_kv_heads",
+    [(128, 8, 8), (128, 8, 4), (64, 4, 4)],
+)
+# kv_len=1100 spans three 512-token partitions with the middle partition
+# entirely inside the masked gap (exercises the neutral-stats path).
+@pytest.mark.parametrize(
+    "anchor,window,kv_len", [(32, 16, 96), (16, 8, 40), (32, 16, 1100)]
+)
+def test_decode_paged_anchored_matches_reference(
+    head_dim, num_heads, num_kv_heads, anchor, window, kv_len
+):
+    device = "cuda"
+    dtype = torch.float16
+    block_size = 16
+    scale = head_dim**-0.5
+
+    k_cache, v_cache, block_table, k_lin, v_lin = _build_paged_kv(
+        kv_len, block_size, num_kv_heads, head_dim, device, dtype, seed=0
+    )
+    q = torch.randn(1, num_heads, head_dim, device=device, dtype=dtype)
+    seq_lens = torch.tensor([kv_len], dtype=torch.int32, device=device)
+    anchor_lens = torch.tensor([anchor], dtype=torch.int32, device=device)
+
+    out = torch.empty_like(q)
+    flash_ops[0](
+        q,
+        k_cache,
+        v_cache,
+        block_table,
+        seq_lens,
+        softmax_scale=scale,
+        out=out,
+        anchor_lens=anchor_lens,
+        anchored_window=window,
+    )
+
+    q_pos = torch.tensor([kv_len - 1], device=device)
+    mask = _anchored_mask(q_pos, kv_len, anchor, window, device)
+    assert not mask[0].all(), "test must exercise a non-trivial gap"
+    ref = _ref_attention(q[0].unsqueeze(0), k_lin, v_lin, mask, scale)
+    torch.testing.assert_close(
+        out[0].float(), ref[0], atol=2e-2, rtol=2e-2
+    )
+
+
+def test_decode_paged_anchored_off_path_unchanged():
+    """Without anchor arguments the decode op matches its own baseline."""
+    device = "cuda"
+    dtype = torch.float16
+    head_dim, num_heads, num_kv_heads = 128, 8, 8
+    kv_len, block_size = 96, 16
+    scale = head_dim**-0.5
+
+    k_cache, v_cache, block_table, k_lin, v_lin = _build_paged_kv(
+        kv_len, block_size, num_kv_heads, head_dim, device, dtype, seed=1
+    )
+    q = torch.randn(1, num_heads, head_dim, device=device, dtype=dtype)
+    seq_lens = torch.tensor([kv_len], dtype=torch.int32, device=device)
+
+    out = torch.empty_like(q)
+    flash_ops[0](
+        q, k_cache, v_cache, block_table, seq_lens, softmax_scale=scale, out=out
+    )
+    q_pos = torch.tensor([kv_len - 1], device=device)
+    causal = _anchored_mask(q_pos, kv_len, kv_len, kv_len, device)
+    assert causal[0].all()
+    ref = _ref_attention(q[0].unsqueeze(0), k_lin, v_lin, causal, scale)
+    torch.testing.assert_close(out[0].float(), ref[0], atol=2e-2, rtol=2e-2)
+
+
+@pytest.mark.parametrize("head_dim,num_heads,num_kv_heads", [(128, 8, 4)])
+@pytest.mark.parametrize(
+    "anchor,window,kv_len,q_len", [(32, 16, 96, 8), (16, 8, 48, 48)]
+)
+def test_prefill_paged_anchored_matches_reference(
+    head_dim, num_heads, num_kv_heads, anchor, window, kv_len, q_len
+):
+    """Masked paged prefill vs torch reference.
+
+    Covers both the chunked-continuation shape (q_len < kv_len, queries in
+    the decode region) and the full-sequence shape (q_len == kv_len, where
+    prompt-region queries must stay purely causal).
+    """
+    device = "cuda"
+    dtype = torch.float16
+    block_size = 16
+    scale = head_dim**-0.5
+
+    k_cache, v_cache, block_table, k_lin, v_lin = _build_paged_kv(
+        kv_len, block_size, num_kv_heads, head_dim, device, dtype, seed=2
+    )
+    q = torch.randn(1, q_len, num_heads, head_dim, device=device, dtype=dtype)
+    seq_lens = torch.tensor([kv_len], dtype=torch.int32, device=device)
+    anchor_lens = torch.tensor([anchor], dtype=torch.int32, device=device)
+
+    out = flash_ops[1](
+        q,
+        k_cache,
+        v_cache,
+        block_table,
+        seq_lens,
+        softmax_scale=scale,
+        causal=True,
+        anchor_lens=anchor_lens,
+        anchored_window=window,
+    )
+
+    # Query absolute positions: the last q_len positions of the sequence.
+    q_pos = torch.arange(kv_len - q_len, kv_len, device=device)
+    mask = _anchored_mask(q_pos, kv_len, anchor, window, device)
+    ref = _ref_attention(q[0], k_lin, v_lin, mask, scale)
+    torch.testing.assert_close(
+        out[0].float(), ref.float(), atol=2e-2, rtol=2e-2
+    )

--- a/tests/kernels/attention/test_sm70_flash_v100_anchored_swa.py
+++ b/tests/kernels/attention/test_sm70_flash_v100_anchored_swa.py
@@ -10,11 +10,14 @@ Requires a CUDA device and the flash_attn_v100 extension built with the
 anchored kernel arguments; skipped otherwise.
 """
 
+from collections.abc import Callable
+from typing import Any
+
 import pytest
 import torch
 
 cuda_available = torch.cuda.is_available()
-flash_ops = None
+flash_ops: tuple[Callable[..., Any], Callable[..., Any]] | None = None
 if cuda_available:
     try:
         from flash_attn_v100 import (
@@ -30,6 +33,11 @@ pytestmark = pytest.mark.skipif(
     not cuda_available or flash_ops is None,
     reason="requires CUDA and the flash_attn_v100 extension",
 )
+
+
+def _require_flash_ops() -> tuple[Callable[..., Any], Callable[..., Any]]:
+    assert flash_ops is not None
+    return flash_ops
 
 
 def _anchored_mask(
@@ -79,9 +87,9 @@ def _build_paged_kv(
         num_blocks, block_size, num_kv_heads, head_dim, device=device, dtype=dtype
     )
     v_cache = torch.randn_like(k_cache)
-    block_table = torch.arange(
-        num_blocks, dtype=torch.int32, device=device
-    ).unsqueeze(0)
+    block_table = torch.arange(num_blocks, dtype=torch.int32, device=device).unsqueeze(
+        0
+    )
     k_lin = k_cache.reshape(-1, num_kv_heads, head_dim)[:kv_len]
     v_lin = v_cache.reshape(-1, num_kv_heads, head_dim)[:kv_len]
     return k_cache, v_cache, block_table, k_lin, v_lin
@@ -111,8 +119,9 @@ def test_decode_paged_anchored_matches_reference(
     seq_lens = torch.tensor([kv_len], dtype=torch.int32, device=device)
     anchor_lens = torch.tensor([anchor], dtype=torch.int32, device=device)
 
+    decode_paged, _ = _require_flash_ops()
     out = torch.empty_like(q)
-    flash_ops[0](
+    decode_paged(
         q,
         k_cache,
         v_cache,
@@ -128,9 +137,7 @@ def test_decode_paged_anchored_matches_reference(
     mask = _anchored_mask(q_pos, kv_len, anchor, window, device)
     assert not mask[0].all(), "test must exercise a non-trivial gap"
     ref = _ref_attention(q[0].unsqueeze(0), k_lin, v_lin, mask, scale)
-    torch.testing.assert_close(
-        out[0].float(), ref[0], atol=2e-2, rtol=2e-2
-    )
+    torch.testing.assert_close(out[0].float(), ref[0], atol=2e-2, rtol=2e-2)
 
 
 def test_decode_paged_anchored_off_path_unchanged():
@@ -147,8 +154,9 @@ def test_decode_paged_anchored_off_path_unchanged():
     q = torch.randn(1, num_heads, head_dim, device=device, dtype=dtype)
     seq_lens = torch.tensor([kv_len], dtype=torch.int32, device=device)
 
+    decode_paged, _ = _require_flash_ops()
     out = torch.empty_like(q)
-    flash_ops[0](
+    decode_paged(
         q, k_cache, v_cache, block_table, seq_lens, softmax_scale=scale, out=out
     )
     q_pos = torch.tensor([kv_len - 1], device=device)
@@ -183,7 +191,8 @@ def test_prefill_paged_anchored_matches_reference(
     seq_lens = torch.tensor([kv_len], dtype=torch.int32, device=device)
     anchor_lens = torch.tensor([anchor], dtype=torch.int32, device=device)
 
-    out = flash_ops[1](
+    _, prefill_paged = _require_flash_ops()
+    out = prefill_paged(
         q,
         k_cache,
         v_cache,
@@ -199,6 +208,4 @@ def test_prefill_paged_anchored_matches_reference(
     q_pos = torch.arange(kv_len - q_len, kv_len, device=device)
     mask = _anchored_mask(q_pos, kv_len, anchor, window, device)
     ref = _ref_attention(q[0], k_lin, v_lin, mask, scale)
-    torch.testing.assert_close(
-        out[0].float(), ref.float(), atol=2e-2, rtol=2e-2
-    )
+    torch.testing.assert_close(out[0].float(), ref.float(), atol=2e-2, rtol=2e-2)

--- a/tests/v1/attention/test_prefix_anchored_swa_mask.py
+++ b/tests/v1/attention/test_prefix_anchored_swa_mask.py
@@ -1,0 +1,104 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Tests for the prefix-anchored sliding-window attention mask.
+
+Semantics under test: keys inside the prompt/prefix (``kv < anchor_len``)
+stay globally visible; generated keys are additionally restricted to a
+sliding window (``q_abs - kv < window``); everything is AND-ed with the
+causal mask.
+
+The CPU tests validate the mask formula (the same one the masked kernels
+implement) against plain causal attention with a torch reference.
+"""
+
+import pytest
+import torch
+
+
+def anchored_swa_mask(
+    seq_len: int, anchor_len: int, window: int, device: str = "cpu"
+) -> torch.Tensor:
+    """Boolean keep-mask [seq_len, seq_len]; True = attend.
+
+    Mirrors the kernel formula:
+    ``causal AND (kv < anchor_len OR q_abs - kv < window)``.
+    """
+    q = torch.arange(seq_len, device=device)[:, None]
+    kv = torch.arange(seq_len, device=device)[None, :]
+    causal = kv <= q
+    in_prefix = kv < anchor_len
+    in_window = (q - kv) < window
+    return causal & (in_prefix | in_window)
+
+
+def causal_mask(seq_len: int, device: str = "cpu") -> torch.Tensor:
+    q = torch.arange(seq_len, device=device)[:, None]
+    kv = torch.arange(seq_len, device=device)[None, :]
+    return kv <= q
+
+
+def ref_attention(
+    q: torch.Tensor, k: torch.Tensor, v: torch.Tensor, mask: torch.Tensor
+) -> torch.Tensor:
+    """Plain fp32 reference attention. q/k/v: [heads, seq, dim]."""
+    scale = q.shape[-1] ** -0.5
+    scores = torch.einsum("hqd,hkd->hqk", q.float(), k.float()) * scale
+    scores = scores.masked_fill(~mask[None], float("-inf"))
+    probs = torch.softmax(scores, dim=-1)
+    return torch.einsum("hqk,hkd->hqd", probs, v.float())
+
+
+@pytest.mark.cpu_test
+def test_mask_equals_causal_while_within_window():
+    # While the number of generated tokens is <= window, no key falls in the
+    # gap, so the mask must be exactly the causal mask.
+    anchor, window = 6, 8
+    for seq_len in range(1, anchor + window + 1):
+        assert torch.equal(
+            anchored_swa_mask(seq_len, anchor, window),
+            causal_mask(seq_len),
+        ), f"seq_len={seq_len}"
+
+
+@pytest.mark.cpu_test
+def test_mask_prunes_gap_beyond_window():
+    anchor, window = 6, 8
+    seq_len = anchor + window + 3  # 3 generated keys fall out of the window
+    mask = anchored_swa_mask(seq_len, anchor, window)
+    causal = causal_mask(seq_len)
+    assert not torch.equal(mask, causal)
+    # The last query keeps: the full prefix and the window of recent keys...
+    last = mask[-1]
+    assert last[:anchor].all(), "prefix must stay globally visible"
+    assert last[seq_len - window :].all(), "recent window must be visible"
+    # ...and drops exactly the gap keys in between.
+    gap = last[anchor : seq_len - window]
+    assert not gap.any(), "gap keys must be masked"
+    # Prefix queries (inside the prompt) are never affected.
+    assert torch.equal(mask[: anchor + window], causal[: anchor + window])
+
+
+@pytest.mark.cpu_test
+def test_attention_output_equivalence_and_divergence():
+    torch.manual_seed(0)
+    heads, dim = 2, 32
+    anchor, window = 6, 8
+
+    # Within the window: identical outputs.
+    seq_len = anchor + window
+    q, k, v = (torch.randn(heads, seq_len, dim) for _ in range(3))
+    out_anchored = ref_attention(q, k, v, anchored_swa_mask(seq_len, anchor, window))
+    out_causal = ref_attention(q, k, v, causal_mask(seq_len))
+    torch.testing.assert_close(out_anchored, out_causal)
+
+    # Beyond the window: the late queries must diverge from full attention
+    # (negative control proving the mask actually removes information).
+    seq_len = anchor + 2 * window
+    q, k, v = (torch.randn(heads, seq_len, dim) for _ in range(3))
+    out_anchored = ref_attention(q, k, v, anchored_swa_mask(seq_len, anchor, window))
+    out_causal = ref_attention(q, k, v, causal_mask(seq_len))
+    assert not torch.allclose(out_anchored[:, -1], out_causal[:, -1])
+    # Queries that see no gap still match exactly.
+    torch.testing.assert_close(
+        out_anchored[:, : anchor + window], out_causal[:, : anchor + window]
+    )

--- a/tests/v1/core/test_single_type_kv_cache_manager.py
+++ b/tests/v1/core/test_single_type_kv_cache_manager.py
@@ -14,9 +14,14 @@ from vllm.v1.core.kv_cache_utils import (
 )
 from vllm.v1.core.single_type_kv_cache_manager import (
     ChunkedLocalAttentionManager,
+    PrefixAnchoredSWAManager,
     SlidingWindowManager,
 )
-from vllm.v1.kv_cache_interface import ChunkedLocalAttentionSpec, SlidingWindowSpec
+from vllm.v1.kv_cache_interface import (
+    ChunkedLocalAttentionSpec,
+    PrefixAnchoredSWASpec,
+    SlidingWindowSpec,
+)
 
 pytestmark = pytest.mark.cpu_test
 
@@ -481,3 +486,103 @@ def test_predictor_matches_allocator_blocks_calculation_with_admission_cap():
             f"but allocator pulled {len(new_blocks)}"
         )
         total_computed = num_tokens
+
+
+def test_prefix_anchored_swa_remove_skipped_blocks_gap_range():
+    block_size = 4
+    spec = PrefixAnchoredSWASpec(
+        block_size=block_size,
+        num_kv_heads=1,
+        head_size=1,
+        dtype=torch.float32,
+        decode_sliding_window=8,
+    )
+    block_pool = BlockPool(
+        num_gpu_blocks=2000, enable_caching=True, hash_block_size=block_size
+    )
+    manager = PrefixAnchoredSWAManager(
+        spec,
+        block_pool=block_pool,
+        enable_caching=True,
+        kv_cache_group_id=0,
+    )
+
+    null_block_id = block_pool.null_block.block_id
+    original_block_ids = list(range(1000, 1010))
+    block_table = [KVCacheBlock(id_) for id_ in original_block_ids]
+    manager.req_to_blocks["test"] = block_table
+
+    prefix_len = 16
+
+    # Without num_prompt_tokens, gap blocks are not evicted (full-attention
+    # default path).
+    manager.remove_skipped_blocks("test", 28)
+    assert [b.block_id for b in block_table] == original_block_ids
+
+    # Gap = block 4 only (tokens [16, 20) fall in the gap).
+    manager.remove_skipped_blocks("test", 28, num_prompt_tokens=prefix_len)
+    expected = original_block_ids.copy()
+    expected[4] = null_block_id
+    assert [b.block_id for b in block_table] == expected
+
+    # Window moves: blocks 5 and 6 also enter the gap; block 4 is already
+    # null and stays null.
+    manager.remove_skipped_blocks("test", 36, num_prompt_tokens=prefix_len)
+    expected[5] = null_block_id
+    expected[6] = null_block_id
+    assert [b.block_id for b in block_table] == expected
+
+    # Blocks holding the prefix and the live decode window are never touched.
+    assert [b.block_id for b in block_table[:4]] == original_block_ids[:4]
+    assert [b.block_id for b in block_table[7:]] == original_block_ids[7:]
+
+
+def test_prefix_anchored_swa_spec_merge():
+    def make_spec(window: int) -> PrefixAnchoredSWASpec:
+        return PrefixAnchoredSWASpec(
+            block_size=16,
+            num_kv_heads=2,
+            head_size=64,
+            dtype=torch.float16,
+            decode_sliding_window=window,
+        )
+
+    merged = PrefixAnchoredSWASpec.merge([make_spec(128), make_spec(128)])
+    assert isinstance(merged, PrefixAnchoredSWASpec)
+    assert merged.decode_sliding_window == 128
+    assert merged.block_size == 16
+    assert merged.num_kv_heads == 2
+    assert merged.head_size == 64
+    assert merged.head_size_v == 64
+    assert merged.dtype == torch.float16
+
+    with pytest.raises(AssertionError):
+        PrefixAnchoredSWASpec.merge([make_spec(128), make_spec(64)])
+
+
+def test_prefix_anchored_swa_manager_registered():
+    from vllm.v1.core.single_type_kv_cache_manager import (
+        get_manager_for_kv_cache_spec,
+        spec_manager_map,
+    )
+
+    assert spec_manager_map[PrefixAnchoredSWASpec] is PrefixAnchoredSWAManager
+
+    spec = PrefixAnchoredSWASpec(
+        block_size=16,
+        num_kv_heads=1,
+        head_size=64,
+        dtype=torch.float16,
+        decode_sliding_window=128,
+    )
+    block_pool = BlockPool(num_gpu_blocks=100, enable_caching=False, hash_block_size=16)
+    manager = get_manager_for_kv_cache_spec(
+        spec,
+        max_num_batched_tokens=1024,
+        max_model_len=4096,
+        block_pool=block_pool,
+        enable_caching=False,
+        kv_cache_group_id=0,
+    )
+    assert isinstance(manager, PrefixAnchoredSWAManager)
+    assert manager.decode_sliding_window == 128

--- a/vllm/config/model.py
+++ b/vllm/config/model.py
@@ -1280,6 +1280,14 @@ class ModelConfig:
     def is_mm_prefix_lm(self) -> bool:
         return self.model_arch_config.is_mm_prefix_lm
 
+    @property
+    def decode_sliding_window(self) -> int | None:
+        """Prefix-anchored sliding-window size over generated tokens.
+
+        The prompt/prefix stays globally attended; ``None`` disables it.
+        """
+        return self.model_arch_config.decode_sliding_window
+
     def get_head_size(self) -> int:
         return self.model_arch_config.head_size
 

--- a/vllm/config/model_arch.py
+++ b/vllm/config/model_arch.py
@@ -58,3 +58,7 @@ class ModelArchitectureConfig:
 
     derived_max_model_len_and_key: tuple[float, str | None]
     """Derived maximum model length and key from the hf config."""
+
+    decode_sliding_window: int | None = None
+    """Prefix-anchored sliding-window size applied to generated tokens
+    (the prompt/prefix stays globally attended). None disables it."""

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -222,10 +222,11 @@ def apply_decode_sliding_window_constraints(
     """Enforce prefix-anchored sliding-window attention constraints.
 
     Only the FLASH_ATTN_V100 kernels (masked template instantiations)
-    apply the anchored decode-window mask, so any other backend would silently skip the mask while the KV
-    cache manager evicts gap blocks. And a decode token's KV under that mask
-    is not a pure causal function of the prefix, so it must never be reused
-    across requests via prefix caching.
+    apply the anchored decode-window mask, so any other backend would
+    silently skip the mask while the KV cache manager evicts gap blocks.
+    And a decode token's KV under that mask is not a pure causal function
+    of the prefix, so it must never be reused across requests via prefix
+    caching.
     """
     if getattr(model_config, "decode_sliding_window", None) is None:
         return

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -216,6 +216,46 @@ def enable_mla_dual_rms_norm_fusion(cfg: "VllmConfig") -> bool:
     return rocm_aiter_ops.is_enabled() and check_aiter_fused_qk_rmsnorm()
 
 
+def apply_decode_sliding_window_constraints(
+    model_config, attention_config, cache_config
+) -> None:
+    """Enforce prefix-anchored sliding-window attention constraints.
+
+    Only the FLASH_ATTN_V100 kernels (masked template instantiations)
+    apply the anchored decode-window mask, so any other backend would silently skip the mask while the KV
+    cache manager evicts gap blocks. And a decode token's KV under that mask
+    is not a pure causal function of the prefix, so it must never be reused
+    across requests via prefix caching.
+    """
+    if getattr(model_config, "decode_sliding_window", None) is None:
+        return
+
+    from vllm.v1.attention.backends.registry import AttentionBackendEnum
+
+    supported_backends = (AttentionBackendEnum.FLASH_ATTN_V100,)
+    backend = attention_config.backend
+    if backend is None:
+        attention_config.backend = AttentionBackendEnum.FLASH_ATTN_V100
+        logger.info(
+            "Prefix-anchored sliding-window attention: auto-selecting the "
+            "FLASH_ATTN_V100 backend (SM70-native kernels with the "
+            "anchored decode-window mask)."
+        )
+    elif backend not in supported_backends:
+        raise ValueError(
+            "decode_sliding_window (prefix-anchored sliding-window "
+            f"attention) is not supported by attention backend "
+            f"{backend.name}; it requires FLASH_ATTN_V100. "
+            "Use one of those backends or unset decode_sliding_window."
+        )
+    if cache_config.enable_prefix_caching:
+        cache_config.enable_prefix_caching = False
+        logger.info(
+            "Prefix-anchored sliding-window attention: disabling prefix "
+            "caching (windowed decode KV is not reusable across requests)."
+        )
+
+
 OPTIMIZATION_LEVEL_00 = {
     "compilation_config": {
         "pass_config": {
@@ -896,6 +936,11 @@ class VllmConfig:
 
         if self.lora_config is not None:
             self.lora_config.verify_with_model_config(self.model_config)
+
+        if self.model_config is not None:
+            apply_decode_sliding_window_constraints(
+                self.model_config, self.attention_config, self.cache_config
+            )
 
         if (
             self.mamba_config.enable_stochastic_rounding
@@ -1688,6 +1733,23 @@ class VllmConfig:
                     self.compilation_config.cudagraph_mode = (
                         CUDAGraphMode.FULL_DECODE_ONLY
                     )
+
+            # Prefix-anchored sliding-window attention: full-graph capture
+            # bakes attention metadata that carries no per-request anchor
+            # lengths, so the anchored decode-window mask cannot run inside a
+            # full cudagraph. Piecewise graphs keep attention outside capture.
+            if (
+                self.model_config is not None
+                and self.model_config.decode_sliding_window is not None
+                and self.compilation_config.cudagraph_mode.has_full_cudagraphs()
+            ):
+                logger.info(
+                    "Prefix-anchored sliding-window attention does not "
+                    "support full cudagraphs. Overriding cudagraph_mode "
+                    "from %s to PIECEWISE.",
+                    self.compilation_config.cudagraph_mode.name,
+                )
+                self.compilation_config.cudagraph_mode = CUDAGraphMode.PIECEWISE
 
             # Check if KV connector requires PIECEWISE mode for CUDA graphs
             if (

--- a/vllm/model_executor/layers/attention/__init__.py
+++ b/vllm/model_executor/layers/attention/__init__.py
@@ -11,6 +11,9 @@ from vllm.model_executor.layers.attention.encoder_only_attention import (
 )
 from vllm.model_executor.layers.attention.mla_attention import MLAAttention
 from vllm.model_executor.layers.attention.mm_encoder_attention import MMEncoderAttention
+from vllm.model_executor.layers.attention.prefix_anchored_swa_attention import (
+    PrefixAnchoredSWAAttention,
+)
 from vllm.model_executor.layers.attention.static_sink_attention import (
     StaticSinkAttention,
 )
@@ -22,5 +25,6 @@ __all__ = [
     "EncoderOnlyAttention",
     "MLAAttention",
     "MMEncoderAttention",
+    "PrefixAnchoredSWAAttention",
     "StaticSinkAttention",
 ]

--- a/vllm/model_executor/layers/attention/prefix_anchored_swa_attention.py
+++ b/vllm/model_executor/layers/attention/prefix_anchored_swa_attention.py
@@ -1,0 +1,47 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from vllm.config.vllm import VllmConfig
+from vllm.model_executor.layers.attention.attention import Attention
+from vllm.v1.kv_cache_interface import (
+    KVCacheSpec,
+    PrefixAnchoredSWASpec,
+    get_kv_quant_mode,
+)
+
+
+class PrefixAnchoredSWAAttention(Attention):
+    """Attention layer that reports ``PrefixAnchoredSWASpec`` as its KV spec.
+
+    Drop-in replacement for the standard ``Attention`` layer when the model
+    is configured with prefix-anchored sliding-window attention
+    (``decode_sliding_window > 0``): the prompt/prefix stays globally
+    attended while generated tokens additionally attend only a fixed window
+    of recent tokens. The actual masking logic lives in the attention
+    backend; this layer only overrides ``get_kv_cache_spec`` so the KV cache
+    manager instantiates ``PrefixAnchoredSWAManager`` (instead of
+    ``FullAttentionManager``) and can therefore evict "gap" blocks to keep
+    per-request KV memory bounded at O(prefix + window).
+    """
+
+    def __init__(self, *args, decode_sliding_window: int, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self._decode_sliding_window = decode_sliding_window
+
+    def get_kv_cache_spec(self, vllm_config: VllmConfig) -> KVCacheSpec | None:
+        spec = super().get_kv_cache_spec(vllm_config)
+        if spec is None:
+            return None
+        assert self.sliding_window is None, (
+            "Prefix-anchored SWA cannot be combined with a uniform "
+            "per-layer sliding window."
+        )
+        return PrefixAnchoredSWASpec(
+            block_size=vllm_config.cache_config.block_size,
+            num_kv_heads=self.num_kv_heads,
+            head_size=self.head_size,
+            head_size_v=self.head_size_v,
+            dtype=self.kv_cache_torch_dtype,
+            kv_quant_mode=get_kv_quant_mode(self.kv_cache_dtype),
+            decode_sliding_window=self._decode_sliding_window,
+        )

--- a/vllm/model_executor/models/deepseek_ocr.py
+++ b/vllm/model_executor/models/deepseek_ocr.py
@@ -428,6 +428,13 @@ class DeepseekOCRForCausalLM(nn.Module, SupportsMultiModal, SupportsPP, Supports
                     f"Only 2D tile_tag is supported currently, got: {self.tile_tag}"
                 )
 
+        # Prefix-anchored SWA: the language model reads
+        # ``decode_sliding_window`` from its own (text) config, so propagate
+        # the top-level setting before building it.
+        decode_sliding_window = getattr(config, "decode_sliding_window", None)
+        if decode_sliding_window is not None:
+            self.text_config.decode_sliding_window = decode_sliding_window
+
         with self._mark_language_model(vllm_config):
             self.language_model = init_vllm_registered_model(
                 vllm_config=vllm_config,

--- a/vllm/model_executor/models/deepseek_v2.py
+++ b/vllm/model_executor/models/deepseek_v2.py
@@ -45,7 +45,7 @@ from vllm.distributed import (
 )
 from vllm.logger import init_logger
 from vllm.model_executor.layers.activation import SiluAndMul
-from vllm.model_executor.layers.attention import Attention
+from vllm.model_executor.layers.attention import Attention, PrefixAnchoredSWAAttention
 from vllm.model_executor.layers.attention_layer_base import AttentionLayerBase
 from vllm.model_executor.layers.fused_moe import (
     FusedMoE,
@@ -172,15 +172,33 @@ class DeepseekAttention(nn.Module):
             max_position=max_position_embeddings,
             rope_parameters=config.rope_parameters,
         )
-        self.attn = Attention(
-            self.num_heads,
-            self.head_dim,
-            self.scaling,
-            num_kv_heads=self.num_kv_heads,
-            cache_config=cache_config,
-            quant_config=quant_config,
-            prefix=f"{prefix}.attn",
+        # Prefix-anchored sliding-window attention: enabled when the model's
+        # HF config carries ``decode_sliding_window`` (validated on the
+        # DeepSeek-OCR family). Off by default; plain attention otherwise.
+        decode_sliding_window = getattr(
+            vllm_config.model_config.hf_config, "decode_sliding_window", None
         )
+        if decode_sliding_window is not None:
+            self.attn = PrefixAnchoredSWAAttention(
+                self.num_heads,
+                self.head_dim,
+                self.scaling,
+                num_kv_heads=self.num_kv_heads,
+                cache_config=cache_config,
+                quant_config=quant_config,
+                prefix=f"{prefix}.attn",
+                decode_sliding_window=decode_sliding_window,
+            )
+        else:
+            self.attn = Attention(
+                self.num_heads,
+                self.head_dim,
+                self.scaling,
+                num_kv_heads=self.num_kv_heads,
+                cache_config=cache_config,
+                quant_config=quant_config,
+                prefix=f"{prefix}.attn",
+            )
 
     def forward(
         self,

--- a/vllm/transformers_utils/model_arch_config_convertor.py
+++ b/vllm/transformers_utils/model_arch_config_convertor.py
@@ -275,6 +275,12 @@ class ModelArchConfigConvertorBase:
             return False
         return self.hf_config.model_type in MM_PREFIX_LM_MODELS
 
+    def decode_sliding_window(self) -> int | None:
+        value = getattr(self.hf_config, "decode_sliding_window", None)
+        if value is None:
+            return None
+        return int(value)
+
     def derive_max_model_len_and_key(self) -> tuple[float, str | None]:
         derived_max_model_len = float("inf")
         possible_keys = [
@@ -326,6 +332,7 @@ class ModelArchConfigConvertorBase:
             is_deepseek_mla=self.is_deepseek_mla(),
             is_mm_prefix_lm=self.is_mm_prefix_lm(),
             derived_max_model_len_and_key=self.derive_max_model_len_and_key(),
+            decode_sliding_window=self.decode_sliding_window(),
         )
 
         return model_arch_config

--- a/vllm/v1/attention/backend.py
+++ b/vllm/v1/attention/backend.py
@@ -416,6 +416,14 @@ class CommonAttentionMetadata:
     decode rows (assumes every draft was accepted). Not safe for kernels
     that need exact per-row context lengths on decode rows."""
 
+    prefix_anchor_lens: torch.Tensor | None = None
+    """(batch_size,) per-request prefix length (prompt token count) for
+    prefix-anchored sliding-window attention. Tokens with logical index below
+    this stay globally visible; later (generated) tokens additionally see a
+    fixed sliding window. None disables the mechanism. The attention backend
+    copies this into its own persistent buffer and reads the window size from
+    ``model_config.decode_sliding_window``."""
+
     # WARNING: Deprecated fields. Will be removed in a future release (v0.15.0)
     _seq_lens_cpu: torch.Tensor | None = None
     _num_computed_tokens_cpu: torch.Tensor | None = None
@@ -523,6 +531,7 @@ class CommonAttentionMetadata:
             dcp_local_seq_lens=maybe_slice_reqs(self.dcp_local_seq_lens),
             dcp_local_seq_lens_cpu=maybe_slice_reqs(self.dcp_local_seq_lens_cpu),
             is_prefilling=maybe_slice_reqs(self.is_prefilling),
+            prefix_anchor_lens=maybe_slice_reqs(self.prefix_anchor_lens),
         )
 
 

--- a/vllm/v1/attention/backends/flash_attn_v100.py
+++ b/vllm/v1/attention/backends/flash_attn_v100.py
@@ -3186,6 +3186,7 @@ class FlashAttnV100MetadataBuilder(TritonAttentionMetadataBuilder):
         )
         attn_metadata = super().build_for_cudagraph_capture(common_attn_metadata)
         self._attach_common_flash_metadata(attn_metadata, common_attn_metadata)
+        flash_metadata = _as_flash_v100_metadata(attn_metadata)
         prefix_anchor_lens = common_attn_metadata.prefix_anchor_lens
         if self.decode_sliding_window is not None and prefix_anchor_lens is not None:
             assert self.persistent_prefix_anchor_lens is not None
@@ -3195,9 +3196,8 @@ class FlashAttnV100MetadataBuilder(TritonAttentionMetadataBuilder):
             )
             persistent_anchor_lens = self.persistent_prefix_anchor_lens[:anchor_reqs]
             persistent_anchor_lens.copy_(prefix_anchor_lens[:anchor_reqs])
-            attn_metadata.prefix_anchor_lens = persistent_anchor_lens
-            attn_metadata.decode_sliding_window = self.decode_sliding_window
-        flash_metadata = _as_flash_v100_metadata(attn_metadata)
+            flash_metadata.prefix_anchor_lens = persistent_anchor_lens
+            flash_metadata.decode_sliding_window = self.decode_sliding_window
         flash_metadata.seq_lens_cpu = capture_seq_lens_cpu
 
         # The Triton builder shortens capture seq_lens to 1 so full graph
@@ -3444,9 +3444,7 @@ class FlashAttnV100Impl(TritonAttentionImpl):
         }
         self._flash_prefill_paged_supports_anchor = (
             self.flash_attn_prefill_paged is not None
-            and _callable_accepts_keyword(
-                self.flash_attn_prefill_paged, "anchor_lens"
-            )
+            and _callable_accepts_keyword(self.flash_attn_prefill_paged, "anchor_lens")
         )
         paged_prefill_enable = os.getenv("VLLM_FLASH_V100_ENABLE_PAGED_PREFILL")
         paged_prefill_disable = (
@@ -4783,9 +4781,7 @@ class FlashAttnV100Impl(TritonAttentionImpl):
         # Anchored decode-window mask: only the scalar paged decode route and
         # the direct paged prefill route carry the masked kernel; diagnostic
         # decode bridges are bypassed while the mask is active.
-        anchored_swa_active = (
-            self._anchored_swa_params(attn_metadata)[0] is not None
-        )
+        anchored_swa_active = self._anchored_swa_params(attn_metadata)[0] is not None
         if (
             self.use_decode_paged_prefill
             and self.use_flash_v100_prefill_paged
@@ -4820,11 +4816,7 @@ class FlashAttnV100Impl(TritonAttentionImpl):
             )
             _record_route("decode_paged_prefill")
             return result
-        if (
-            self.use_decode_dense_cache
-            and not is_capturing
-            and not anchored_swa_active
-        ):
+        if self.use_decode_dense_cache and not is_capturing and not anchored_swa_active:
             _log_fp8_kv_cache_route("decode", self.kv_cache_dtype, "dense_cache_bridge")
             _sm70_profile_trace(
                 "forward branch=decode_dense_cache layer=%s",

--- a/vllm/v1/attention/backends/flash_attn_v100.py
+++ b/vllm/v1/attention/backends/flash_attn_v100.py
@@ -44,6 +44,8 @@ class FlashAttnV100Metadata(TritonAttentionMetadata):
     max_model_len: int
     flash_v100_cudagraph_capture: bool
     flash_v100_contig_dense_cache: dict[tuple[int, int, int, int, int], int]
+    prefix_anchor_lens: torch.Tensor | None = None
+    decode_sliding_window: int | None = None
     flash_v100_decode_max_seq_len_hint: int | None
     flash_v100_decode_workspace_seq_capacity_hint: int | None
     flash_v100_static_decode_seq_hint: int | None
@@ -2468,6 +2470,16 @@ class FlashAttnV100MetadataBuilder(TritonAttentionMetadataBuilder):
         )
         self._draft_block_table: torch.Tensor | None = None
         self._draft_seq_lens: torch.Tensor | None = None
+        # Prefix-anchored SWA: persistent per-request prompt-length buffer so
+        # the device address stays stable across steps.
+        self.decode_sliding_window = self.vllm_config.model_config.decode_sliding_window
+        self.persistent_prefix_anchor_lens: torch.Tensor | None = None
+        if self.decode_sliding_window is not None:
+            self.persistent_prefix_anchor_lens = torch.empty(
+                self.vllm_config.scheduler_config.max_num_seqs,
+                dtype=torch.int32,
+                device=self.device,
+            )
         self._draft_query_start_loc: torch.Tensor | None = None
         self._flash_draft_buffer_shape: tuple[int, int] | None = None
         self._smallq_decode_block_table: torch.Tensor | None = None
@@ -3174,6 +3186,17 @@ class FlashAttnV100MetadataBuilder(TritonAttentionMetadataBuilder):
         )
         attn_metadata = super().build_for_cudagraph_capture(common_attn_metadata)
         self._attach_common_flash_metadata(attn_metadata, common_attn_metadata)
+        prefix_anchor_lens = common_attn_metadata.prefix_anchor_lens
+        if self.decode_sliding_window is not None and prefix_anchor_lens is not None:
+            assert self.persistent_prefix_anchor_lens is not None
+            anchor_reqs = common_attn_metadata.num_reqs
+            prefix_anchor_lens = prefix_anchor_lens.to(
+                device=self.device, dtype=torch.int32, non_blocking=True
+            )
+            persistent_anchor_lens = self.persistent_prefix_anchor_lens[:anchor_reqs]
+            persistent_anchor_lens.copy_(prefix_anchor_lens[:anchor_reqs])
+            attn_metadata.prefix_anchor_lens = persistent_anchor_lens
+            attn_metadata.decode_sliding_window = self.decode_sliding_window
         flash_metadata = _as_flash_v100_metadata(attn_metadata)
         flash_metadata.seq_lens_cpu = capture_seq_lens_cpu
 
@@ -3413,10 +3436,18 @@ class FlashAttnV100Impl(TritonAttentionImpl):
                 "workspace_seq_capacity_hint",
                 "active_num_partitions",
                 "partition_size_hint",
+                "anchor_lens",
+                "anchored_window",
             )
             if self.flash_attn_decode_paged is not None
             and _callable_accepts_keyword(self.flash_attn_decode_paged, name)
         }
+        self._flash_prefill_paged_supports_anchor = (
+            self.flash_attn_prefill_paged is not None
+            and _callable_accepts_keyword(
+                self.flash_attn_prefill_paged, "anchor_lens"
+            )
+        )
         paged_prefill_enable = os.getenv("VLLM_FLASH_V100_ENABLE_PAGED_PREFILL")
         paged_prefill_disable = (
             os.getenv("VLLM_FLASH_V100_DISABLE_PAGED_PREFILL", "0") == "1"
@@ -4108,6 +4139,8 @@ class FlashAttnV100Impl(TritonAttentionImpl):
         workspace_seq_capacity_hint: int | None = None,
         active_num_partitions: int | None = None,
         partition_size_hint: int | None = None,
+        anchor_lens: torch.Tensor | None = None,
+        anchored_window: int = 0,
     ) -> None:
         kwargs: dict[str, object] = {
             "softmax_scale": softmax_scale,
@@ -4123,6 +4156,15 @@ class FlashAttnV100Impl(TritonAttentionImpl):
                 "FLASH_ATTN_V100 decode op does not support sliding-window "
                 "attention with this extension build."
             )
+        if anchor_lens is not None and anchored_window > 0:
+            if "anchor_lens" not in self._flash_decode_paged_kwargs:
+                raise RuntimeError(
+                    "FLASH_ATTN_V100 decode op does not support the anchored "
+                    "decode-window mask with this extension build; rebuild "
+                    "flash_attn_v100."
+                )
+            kwargs["anchor_lens"] = anchor_lens
+            kwargs["anchored_window"] = anchored_window
         optional_kwargs = {
             "max_seq_len_hint": max_seq_len_hint,
             "workspace_seq_capacity_hint": workspace_seq_capacity_hint,
@@ -4288,6 +4330,23 @@ class FlashAttnV100Impl(TritonAttentionImpl):
         )
         _record_route("prefill_smallq_decode_scalar")
 
+    def _anchored_swa_params(
+        self,
+        attn_metadata: TritonAttentionMetadata,
+    ) -> tuple[torch.Tensor | None, int]:
+        """Anchored decode-window mask parameters, when active.
+
+        Returns ``(prefix_anchor_lens, decode_sliding_window)`` when the model
+        is configured with a prefix-anchored sliding window over generated
+        tokens and the metadata carries per-request prompt lengths; otherwise
+        ``(None, 0)``.
+        """
+        window = getattr(attn_metadata, "decode_sliding_window", None)
+        anchor_lens = getattr(attn_metadata, "prefix_anchor_lens", None)
+        if window is None or int(window) <= 0 or anchor_lens is None:
+            return None, 0
+        return anchor_lens, int(window)
+
     def _small_query_decode_enabled(
         self,
         attn_metadata: TritonAttentionMetadata,
@@ -4297,6 +4356,11 @@ class FlashAttnV100Impl(TritonAttentionImpl):
             or not self.use_flash_v100_decode
             or self.smallq_decode_max_query_len <= 0
         ):
+            return False
+        # Anchored decode-window mask: the small-query re-expansion path does
+        # not carry per-row anchor lengths; use the masked paged prefill
+        # kernel instead.
+        if self._anchored_swa_params(attn_metadata)[0] is not None:
             return False
 
         query_start_loc_cpu = getattr(attn_metadata, "query_start_loc_cpu", None)
@@ -4716,10 +4780,17 @@ class FlashAttnV100Impl(TritonAttentionImpl):
                 output_block_scale,
             )
 
+        # Anchored decode-window mask: only the scalar paged decode route and
+        # the direct paged prefill route carry the masked kernel; diagnostic
+        # decode bridges are bypassed while the mask is active.
+        anchored_swa_active = (
+            self._anchored_swa_params(attn_metadata)[0] is not None
+        )
         if (
             self.use_decode_paged_prefill
             and self.use_flash_v100_prefill_paged
             and not is_capturing
+            and not anchored_swa_active
         ):
             _log_fp8_kv_cache_route(
                 "decode", self.kv_cache_dtype, "decode_as_paged_prefill"
@@ -4749,7 +4820,11 @@ class FlashAttnV100Impl(TritonAttentionImpl):
             )
             _record_route("decode_paged_prefill")
             return result
-        if self.use_decode_dense_cache and not is_capturing:
+        if (
+            self.use_decode_dense_cache
+            and not is_capturing
+            and not anchored_swa_active
+        ):
             _log_fp8_kv_cache_route("decode", self.kv_cache_dtype, "dense_cache_bridge")
             _sm70_profile_trace(
                 "forward branch=decode_dense_cache layer=%s",
@@ -4778,7 +4853,11 @@ class FlashAttnV100Impl(TritonAttentionImpl):
             )
             _record_route("decode_dense_cache")
             return result
-        if self.use_decode_dense_reference and not is_capturing:
+        if (
+            self.use_decode_dense_reference
+            and not is_capturing
+            and not anchored_swa_active
+        ):
             _log_fp8_kv_cache_route(
                 "decode", self.kv_cache_dtype, "dense_reference_bridge"
             )
@@ -5321,6 +5400,7 @@ class FlashAttnV100Impl(TritonAttentionImpl):
     ) -> torch.Tensor:
         """Decode path using Flash V100 directly over paged KV cache."""
         window_size = self._flash_v100_window_size(causal=True)
+        anchor_lens, anchored_window = self._anchored_swa_params(attn_metadata)
         num_actual_tokens = attn_metadata.num_actual_tokens
         query = query[:num_actual_tokens]
         out_view = output[:num_actual_tokens]
@@ -5360,6 +5440,9 @@ class FlashAttnV100Impl(TritonAttentionImpl):
                 or (q_per_kv != 4 and _decode_fp8_xqa_allowed(attn_metadata, query))
             )
             and window_size == (-1, -1)
+            # Anchored decode-window mask: only the scalar paged decode kernel
+            # carries the masked instantiation.
+            and anchor_lens is None
         ):
             _log_fp8_kv_cache_route("decode", self.kv_cache_dtype, "xqa_paged")
             _trace_decode_active(
@@ -5448,6 +5531,8 @@ class FlashAttnV100Impl(TritonAttentionImpl):
                 "flash_v100_decode_active_num_partitions",
                 None,
             ),
+            anchor_lens=anchor_lens,
+            anchored_window=anchored_window,
         )
         _record_route("decode_scalar_paged")
         return output
@@ -6316,6 +6401,22 @@ class FlashAttnV100Impl(TritonAttentionImpl):
         global _logged_prefill_compare, _logged_prefill_smallq_decode
         causal = getattr(attn_metadata, "causal", True)
         window_size = self._flash_v100_window_size(causal)
+        anchor_lens, anchored_window = self._anchored_swa_params(attn_metadata)
+        if anchor_lens is not None:
+            # Fail closed: with the anchored decode-window mask active the
+            # KV cache manager evicts gap blocks, so running any unmasked
+            # prefill route would silently produce wrong output.
+            if not self.use_flash_v100_prefill_paged:
+                raise RuntimeError(
+                    "FLASH_ATTN_V100 anchored decode-window mask requires "
+                    "the paged prefill kernel; it is disabled or unavailable."
+                )
+            if not self._flash_prefill_paged_supports_anchor:
+                raise RuntimeError(
+                    "FLASH_ATTN_V100 prefill op does not support the "
+                    "anchored decode-window mask with this extension build; "
+                    "rebuild flash_attn_v100."
+                )
         num_actual_tokens = attn_metadata.num_actual_tokens
         query = query[:num_actual_tokens]
         out_view = output[:num_actual_tokens]
@@ -6351,6 +6452,11 @@ class FlashAttnV100Impl(TritonAttentionImpl):
             attn_metadata,
             query_start_loc,
         ):
+            if anchor_lens is not None:
+                raise RuntimeError(
+                    "FLASH_ATTN_V100 anchored decode-window mask does not "
+                    "support ddtree drafting metadata."
+                )
             return self._flash_v100_ddtree_small_query_prefill_dense(
                 layer,
                 query,
@@ -6366,6 +6472,7 @@ class FlashAttnV100Impl(TritonAttentionImpl):
 
         if (
             causal
+            and anchor_lens is None
             and self.use_flash_v100_decode
             and self.smallq_decode_max_query_len > 0
             and max_query_len <= self.smallq_decode_max_query_len
@@ -6405,6 +6512,36 @@ class FlashAttnV100Impl(TritonAttentionImpl):
                 q_len = end - start
                 seq_len = int(seq_lens[i].item())
                 q_seq = query[start:end].unsqueeze(0)
+                if anchor_lens is not None:
+                    # Anchored decode-window mask: single masked paged
+                    # prefill route; every unmasked fast path is bypassed.
+                    _record_route("prefill_prefix_paged_anchored")
+                    out_seq = self._run_prefill_paged_call(
+                        route="prefill_prefix_paged_anchored",
+                        q_len=q_len,
+                        seq_len=seq_len,
+                        heads_q=query.shape[1],
+                        heads_kv=num_kv_heads,
+                        head_dim=head_dim,
+                        block_size=block_size,
+                        fn=lambda q_seq=q_seq, i=i: self.flash_attn_prefill_paged(  # type: ignore[misc]
+                            q_seq,
+                            key_cache,
+                            value_cache,
+                            attn_metadata.block_table[i : i + 1],
+                            attn_metadata.seq_lens[i : i + 1],
+                            softmax_scale=self.scale,
+                            kv_cache_dtype=self.kv_cache_dtype,
+                            k_scale=float(layer._k_scale_float),
+                            v_scale=float(layer._v_scale_float),
+                            causal=causal,
+                            window_size=window_size,
+                            anchor_lens=anchor_lens[i : i + 1],
+                            anchored_window=anchored_window,
+                        ),
+                    )
+                    out_view[start:end].copy_(out_seq.squeeze(0))
+                    continue
                 bfla_block_mask = None
                 use_bfla = self._should_use_prefill_bfla(
                     q_len=q_len,

--- a/vllm/v1/core/kv_cache_coordinator.py
+++ b/vllm/v1/core/kv_cache_coordinator.py
@@ -236,7 +236,10 @@ class KVCacheCoordinator(ABC):
         ]
 
     def remove_skipped_blocks(
-        self, request_id: str, total_computed_tokens: int
+        self,
+        request_id: str,
+        total_computed_tokens: int,
+        num_prompt_tokens: int | None = None,
     ) -> None:
         """
         Remove the blocks that are no longer needed from `blocks` and replace
@@ -246,9 +249,14 @@ class KVCacheCoordinator(ABC):
             request_id: The request ID.
             total_computed_tokens: The total number of computed tokens, including
                 local computed tokens and external computed tokens.
+            num_prompt_tokens: Optional prompt length. Prefix-anchored SWA
+                managers use this to free gap blocks between the prefill tail
+                and the decode window; other manager types ignore it.
         """
         for manager in self.single_type_managers:
-            manager.remove_skipped_blocks(request_id, total_computed_tokens)
+            manager.remove_skipped_blocks(
+                request_id, total_computed_tokens, num_prompt_tokens
+            )
 
     def get_blocks(self, request_id: str) -> tuple[list[KVCacheBlock], ...]:
         """

--- a/vllm/v1/core/kv_cache_manager.py
+++ b/vllm/v1/core/kv_cache_manager.py
@@ -371,7 +371,9 @@ class KVCacheManager:
         # Should call this function before allocating new blocks to reduce
         # the number of evicted blocks.
         self.coordinator.remove_skipped_blocks(
-            request.request_id, total_computed_tokens
+            request.request_id,
+            total_computed_tokens,
+            num_prompt_tokens=request.num_prompt_tokens,
         )
 
         num_blocks_to_allocate = self.coordinator.get_num_blocks_to_allocate(
@@ -437,7 +439,10 @@ class KVCacheManager:
         self.coordinator.free(request.request_id)
 
     def remove_skipped_blocks(
-        self, request_id: str, total_computed_tokens: int
+        self,
+        request_id: str,
+        total_computed_tokens: int,
+        num_prompt_tokens: int | None = None,
     ) -> None:
         """Remove the blocks that are no longer needed from `blocks` and replace
         the removed blocks with null_block.
@@ -446,8 +451,12 @@ class KVCacheManager:
             request_id: The request ID.
             total_computed_tokens: The total number of computed tokens, including
                 local computed tokens and external computed tokens.
+            num_prompt_tokens: Optional prompt length for prefix-anchored SWA
+                gap eviction.
         """
-        self.coordinator.remove_skipped_blocks(request_id, total_computed_tokens)
+        self.coordinator.remove_skipped_blocks(
+            request_id, total_computed_tokens, num_prompt_tokens
+        )
 
     def evict_blocks(self, block_ids: set[int]) -> None:
         """evict blocks from the prefix cache by their block IDs.

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -2395,6 +2395,7 @@ class Scheduler(SchedulerInterface):
         self.kv_cache_manager.remove_skipped_blocks(
             request_id=request.request_id,
             total_computed_tokens=request.num_computed_tokens,
+            num_prompt_tokens=request.num_prompt_tokens,
         )
 
         block_ids = self.kv_cache_manager.get_block_ids(request.request_id)

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -20,6 +20,7 @@ from vllm.v1.kv_cache_interface import (
     KVCacheSpec,
     MambaSpec,
     MLAAttentionSpec,
+    PrefixAnchoredSWASpec,
     SinkFullAttentionSpec,
     SlidingWindowMLASpec,
     SlidingWindowSpec,
@@ -425,8 +426,41 @@ class SingleTypeKVCacheManager(ABC):
 
         raise NotImplementedError
 
+    def _remove_blocks_in_range(
+        self,
+        request_id: str,
+        first_block: int,
+        last_block: int,
+    ) -> None:
+        """Free blocks in ``[first_block, last_block)`` and replace with null_block.
+
+        Iterates backward so newly-evictable tail blocks are reached even after
+        earlier blocks in the range were nulled in a prior call.
+        """
+        if request_id not in self.req_to_blocks:
+            return
+        if first_block >= last_block:
+            return
+        blocks = self.req_to_blocks[request_id]
+        last_block = min(last_block, len(blocks))
+
+        freed: list[KVCacheBlock] = []
+        for i in range(last_block - 1, first_block - 1, -1):
+            if blocks[i] == self._null_block:
+                # If the block is already a null block, the blocks before it
+                # should also have been set to null blocks by the previous calls
+                # to this function.
+                break
+            freed.append(blocks[i])
+            blocks[i] = self._null_block
+        if freed:
+            self.block_pool.free_blocks(freed)
+
     def remove_skipped_blocks(
-        self, request_id: str, total_computed_tokens: int
+        self,
+        request_id: str,
+        total_computed_tokens: int,
+        num_prompt_tokens: int | None = None,
     ) -> None:
         """
         Remove and free the blocks that are no longer needed for attention computation.
@@ -439,7 +473,11 @@ class SingleTypeKVCacheManager(ABC):
             request_id: The request ID.
             total_computed_tokens: The total number of computed tokens, including
                 local computed tokens and external computed tokens.
+            num_prompt_tokens: Optional prompt length for attention types (e.g.
+                prefix-anchored SWA) that evict a middle gap rather than a head
+                prefix. Ignored by the default implementation.
         """
+        del num_prompt_tokens
         # Remove the blocks that will be skipped during attention computation.
         num_skipped_tokens = self.get_num_skipped_tokens(total_computed_tokens)
         if num_skipped_tokens <= 0:
@@ -448,25 +486,12 @@ class SingleTypeKVCacheManager(ABC):
             # A typical case is full attention that we never free any token
             # before the request is finished.
             return
-        blocks = self.req_to_blocks[request_id]
         num_skipped_blocks = num_skipped_tokens // self.block_size
         # `num_skipped_tokens` may include tokens that haven't been allocated yet
         # (e.g., when the attention window moves into the external computed tokens
-        # range), so we must cap to the number of blocks that currently exist for
-        # this request.
-        num_skipped_blocks = min(num_skipped_blocks, len(blocks))
-        removed_blocks: list[KVCacheBlock] = []
-        # Because the block starts from index 0, the num_skipped_block-th block
-        # corresponds to index num_skipped_blocks - 1.
-        for i in range(num_skipped_blocks - 1, -1, -1):
-            if blocks[i] == self._null_block:
-                # If the block is already a null block, the blocks before it
-                # should also have been set to null blocks by the previous calls
-                # to this function.
-                break
-            removed_blocks.append(blocks[i])
-            blocks[i] = self._null_block
-        self.block_pool.free_blocks(removed_blocks)
+        # range); `_remove_blocks_in_range` caps to the number of blocks that
+        # currently exist for this request.
+        self._remove_blocks_in_range(request_id, 0, num_skipped_blocks)
 
     def get_num_skipped_tokens(self, num_computed_tokens: int) -> int:
         """
@@ -545,6 +570,53 @@ class FullAttentionManager(SingleTypeKVCacheManager):
             else:
                 break
         return num_common_blocks
+
+
+class PrefixAnchoredSWAManager(FullAttentionManager):
+    """KV cache manager for prefix-anchored sliding-window attention.
+
+    When ``num_prompt_tokens`` is supplied to ``remove_skipped_blocks``, frees
+    gap blocks between the prefill tail and the current decode window.  This
+    bounds per-request KV memory at O(prefix_len + decode_sliding_window)
+    instead of growing linearly with decode length.
+    """
+
+    def __init__(self, kv_cache_spec: PrefixAnchoredSWASpec, **kwargs) -> None:
+        super().__init__(kv_cache_spec, **kwargs)
+        self.decode_sliding_window: int = kv_cache_spec.decode_sliding_window
+
+    def remove_skipped_blocks(
+        self,
+        request_id: str,
+        total_computed_tokens: int,
+        num_prompt_tokens: int | None = None,
+    ) -> None:
+        """Free gap blocks that are no longer needed for attention.
+
+        Gap = blocks entirely within
+            [ceil(prefix_len / block_size) * block_size,
+             max(prefix_len, total_computed_tokens - decode_sliding_window))
+
+        Freed blocks are replaced with null_block in req_to_blocks so the
+        block_table handed to the attention backend stays valid (null_block
+        KV is all-zero; the backend mask marks gap positions as non-visible
+        so they never contribute to the output).
+        """
+        if num_prompt_tokens is None:
+            super().remove_skipped_blocks(
+                request_id, total_computed_tokens, num_prompt_tokens
+            )
+            return
+
+        bs = self.block_size
+        # First block fully after the prefill boundary.
+        first_gap_block = cdiv(num_prompt_tokens, bs)
+        # Decode window start position; blocks before this are evictable.
+        window_start = max(
+            num_prompt_tokens, total_computed_tokens - self.decode_sliding_window
+        )
+        last_gap_block = window_start // bs  # exclusive upper bound
+        self._remove_blocks_in_range(request_id, first_gap_block, last_gap_block)
 
 
 class SlidingWindowManager(SingleTypeKVCacheManager):
@@ -910,7 +982,12 @@ class MambaManager(SingleTypeKVCacheManager):
 
         return computed_blocks
 
-    def remove_skipped_blocks(self, request_id: str, num_computed_tokens: int) -> None:
+    def remove_skipped_blocks(
+        self,
+        request_id: str,
+        num_computed_tokens: int,
+        num_prompt_tokens: int | None = None,
+    ) -> None:
         assert isinstance(self.kv_cache_spec, MambaSpec)
 
         # NOTE (tdoublep) with async scheduling, the num_computed_tokens can contain
@@ -920,7 +997,9 @@ class MambaManager(SingleTypeKVCacheManager):
         # that we might actually need.
         num_computed_tokens = max(0, num_computed_tokens - self.num_speculative_blocks)
 
-        super().remove_skipped_blocks(request_id, num_computed_tokens)
+        super().remove_skipped_blocks(
+            request_id, num_computed_tokens, num_prompt_tokens
+        )
         if self.mamba_cache_mode == "align":
             # `last_state_block_idx` refers to the block index allocated two steps ago.
             # The block allocated in the previous step is used to copy Mamba states
@@ -1210,6 +1289,7 @@ spec_manager_map: dict[type[KVCacheSpec], type[SingleTypeKVCacheManager]] = {
     TQFullAttentionSpec: FullAttentionManager,
     MLAAttentionSpec: FullAttentionManager,
     HiddenStateCacheSpec: FullAttentionManager,
+    PrefixAnchoredSWASpec: PrefixAnchoredSWAManager,
     SlidingWindowSpec: SlidingWindowManager,
     SlidingWindowMLASpec: SlidingWindowManager,
     ChunkedLocalAttentionSpec: ChunkedLocalAttentionManager,

--- a/vllm/v1/kv_cache_interface.py
+++ b/vllm/v1/kv_cache_interface.py
@@ -404,6 +404,47 @@ class HiddenStateCacheSpec(MLAAttentionSpec):
 
 
 @dataclass(frozen=True, kw_only=True)
+class PrefixAnchoredSWASpec(FullAttentionSpec):
+    """KV cache spec for prefix-anchored sliding-window attention.
+
+    Prefill (prompt/prefix) tokens are always globally visible.
+    Only the last ``decode_sliding_window`` generated tokens are kept in the
+    KV cache; gap blocks (between the prefill tail and the current decode
+    window) are evicted during each decode step to bound per-request memory
+    at O(prefix_blocks + window_blocks).
+    """
+
+    decode_sliding_window: int
+
+    @classmethod
+    def merge(cls, specs: list[Self]) -> Self:
+        assert all(isinstance(spec, PrefixAnchoredSWASpec) for spec in specs), (
+            "All attention layers in the same KV cache group must be "
+            "PrefixAnchoredSWASpec."
+        )
+        windows = {spec.decode_sliding_window for spec in specs}
+        assert len(windows) == 1, (
+            "All prefix-anchored SWA layers must share the same "
+            f"decode_sliding_window, got {windows}"
+        )
+        # Delegate common field merging to the parent, then reattach the
+        # decode window.
+        base = FullAttentionSpec.merge(specs)  # type: ignore[arg-type]
+        return cls(
+            block_size=base.block_size,
+            num_kv_heads=base.num_kv_heads,
+            head_size=base.head_size,
+            head_size_v=base.head_size_v,
+            dtype=base.dtype,
+            kv_quant_mode=base.kv_quant_mode,
+            page_size_padded=base.page_size_padded,
+            sliding_window=base.sliding_window,
+            attention_chunk_size=base.attention_chunk_size,
+            decode_sliding_window=windows.pop(),
+        )
+
+
+@dataclass(frozen=True, kw_only=True)
 class ChunkedLocalAttentionSpec(AttentionSpec):
     attention_chunk_size: int
 

--- a/vllm/v1/worker/gpu/attn_utils.py
+++ b/vllm/v1/worker/gpu/attn_utils.py
@@ -389,6 +389,7 @@ def build_attn_metadata(
     positions: torch.Tensor | None = None,
     model_specific_attn_metadata: ModelSpecificAttnMetadata | None = None,
     for_cudagraph_capture: bool = False,
+    prefix_anchor_lens: torch.Tensor | None = None,
 ) -> dict[str, Any]:
     seq_lens = seq_lens[:num_reqs]
     if dcp_local_seq_lens is not None:
@@ -421,6 +422,7 @@ def build_attn_metadata(
             causal=True,
             dcp_local_seq_lens=dcp_local_seq_lens,
             positions=positions,
+            prefix_anchor_lens=prefix_anchor_lens,
             **common_attn_metadata_extra_kwargs,
         )
 

--- a/vllm/v1/worker/gpu/input_batch.py
+++ b/vllm/v1/worker/gpu/input_batch.py
@@ -84,6 +84,10 @@ class InputBatch:
     # Whether any requests in batch use structured output.
     has_structured_output_reqs: bool
 
+    # [num_reqs_after_padding] per-request prompt length for prefix-anchored
+    # sliding-window attention (optional).
+    prefix_anchor_lens: torch.Tensor | None = None
+
     @classmethod
     def make_dummy(
         cls,

--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -203,6 +203,13 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             max_num_tokens=self.max_num_tokens,
             device=self.device,
         )
+        # Prefix-anchored SWA: persistent GPU buffer for per-request prompt
+        # lengths (stable device address across steps).
+        self.prefix_anchor_lens_buffer: torch.Tensor | None = None
+        if self.model_config.decode_sliding_window is not None:
+            self.prefix_anchor_lens_buffer = torch.zeros(
+                self.max_num_reqs, dtype=torch.int32, device=self.device
+            )
 
         self.sampler: Sampler | None = None
         self.rejection_sampler: RejectionSampler | None = None
@@ -878,6 +885,16 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             out=seq_lens_cpu_upper_bound_np[:num_reqs],
         )
         seq_lens_cpu_upper_bound = torch.from_numpy(seq_lens_cpu_upper_bound_np)
+
+        prefix_anchor_lens = None
+        if self.prefix_anchor_lens_buffer is not None:
+            prefix_anchor_lens = self.prefix_anchor_lens_buffer[:num_reqs_padded]
+            prefix_anchor_lens[:num_reqs] = self.req_states.prompt_len.gpu[
+                idx_mapping[:num_reqs]
+            ]
+            if num_reqs_padded > num_reqs:
+                prefix_anchor_lens[num_reqs:].zero_()
+
         return InputBatch(
             req_ids=req_ids,
             num_reqs=num_reqs,
@@ -903,6 +920,7 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             cu_num_logits=cu_num_logits,
             cu_num_logits_np=cu_num_logits_np,
             has_structured_output_reqs=scheduler_output.has_structured_output_requests,
+            prefix_anchor_lens=prefix_anchor_lens,
         )
 
     def prepare_attn(

--- a/vllm/v1/worker/gpu/model_states/default.py
+++ b/vllm/v1/worker/gpu/model_states/default.py
@@ -195,5 +195,6 @@ class DefaultModelState(ModelState):
             dcp_local_seq_lens=input_batch.dcp_local_seq_lens,
             positions=input_batch.positions,
             for_cudagraph_capture=for_capture,
+            prefix_anchor_lens=input_batch.prefix_anchor_lens,
         )
         return attn_metadata

--- a/vllm/v1/worker/gpu/model_states/mamba_hybrid.py
+++ b/vllm/v1/worker/gpu/model_states/mamba_hybrid.py
@@ -136,6 +136,7 @@ class MambaHybridModelState(DefaultModelState):
             dcp_local_seq_lens=input_batch.dcp_local_seq_lens,
             model_specific_attn_metadata=mamba_attn_metadata,
             for_cudagraph_capture=for_capture,
+            prefix_anchor_lens=input_batch.prefix_anchor_lens,
         )
 
     def postprocess_state(

--- a/vllm/v1/worker/gpu/model_states/whisper.py
+++ b/vllm/v1/worker/gpu/model_states/whisper.py
@@ -161,6 +161,7 @@ class WhisperModelState(ModelState):
             dcp_local_seq_lens=input_batch.dcp_local_seq_lens,
             model_specific_attn_metadata=whisper_attn_metadata,
             for_cudagraph_capture=for_capture,
+            prefix_anchor_lens=input_batch.prefix_anchor_lens,
         )
         return attn_metadata
 

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -5257,6 +5257,13 @@ class GPUModelRunner(
             seq_lens_cpu = None
             num_computed_tokens_cpu = None
 
+        # Prefix-anchored SWA: pass per-request prompt lengths so the
+        # attention backend can keep the prefix globally visible. The backend
+        # owns the persistent device buffer.
+        prefix_anchor_lens = None
+        if self.model_config.decode_sliding_window is not None:
+            prefix_anchor_lens = num_prompt_tokens_cpu
+
         cm_base = CommonAttentionMetadata(
             query_start_loc=self.query_start_loc.gpu[: num_reqs_padded + 1],
             query_start_loc_cpu=self.query_start_loc.cpu[: num_reqs_padded + 1],
@@ -5273,6 +5280,7 @@ class GPUModelRunner(
             causal=True,
             is_prefilling=is_prefilling,
             positions=self.positions[:num_tokens_padded],
+            prefix_anchor_lens=prefix_anchor_lens,
         )
 
         current_mamba_state_block_ids_by_gid: dict[int, torch.Tensor] = {}


### PR DESCRIPTION
## What

Serving-quality improvements for long-generation OCR workloads, plus a
correctness fix for the prefix-anchored SWA capability merged in #281:

1. **Bugfix (SWA/#281):** out-of-window gap blocks were freed on the
   scheduled-token basis; under async scheduling this can free blocks the
   worker has not yet computed past. Free on the processed-token basis
   instead. Regression tests simulate the async gap.
2. **Per-model serving defaults with request-override bounds:** an
   architecture-keyed registry applied at the chat endpoint. A model can
   declare its recommended sampling/extra-args recipe; requests may
   override within declared bounds. DeepSeek-OCR registers its checkpoint
   README recipe (n-gram blocker 30/90 with whitelist tokens, temperature
   0, max_tokens 8192) so an unconfigured client gets the model's intended
   behavior via plain chat completions.
3. **Architecture-keyed chat template fallbacks:** DeepSeek-OCR's
   model_type previously fell through to the DeepSeek-VL2 template, which
   injects role markers the OCR checkpoint was not trained with; the
   fallback now pins the raw-concatenation prompt (golden test included).
4. **Repetition-detection default** for OCR serving: a bounded
   exact-pattern detector as a safety net for degenerate table pages,
   request-overridable.
5. **Per-request DeepSeek-OCR resolution modes:** the checkpoint's five
   official modes (tiny/small/base/large/gundam) selectable via
   `mm_processor_kwargs: {"image_mode": ...}`; multi-image serving
   profile; `max_crops` plumbing. The serving default remains the
   checkpoint's gundam configuration.

## Why

On document OCR, the model's own recipe is load-bearing: without the
n-gram blocker and the correct raw prompt, long pages degenerate into
loops. These changes make the endpoint serve the checkpoint's intended
recipe by default while keeping every knob per-request-overridable within
bounds. The SWA fix closes an async-scheduling correctness gap in the
capability added by #281.

## Validation

All device work on Tesla V100-SXM2 32 GB (sm_70), fp16, on current main.

- 195 CPU tests green, including #281's admission/mask/manager suites
  (proves coexistence with the merged SWA capability), the new
  eviction-basis regression tests, resolution-mode suite, template golden,
  defaults/bounds and repetition-detection suites.
- Endpoint (serve) on V100: deterministic 3× byte-identical generations;
  resolution-mode discrimination (default ≡ gundam as identity control;
  base/large produce distinct image-token counts); document-page scoring
  against known ground truth (per-mode table in tests receipt).

## Serving DeepSeek-OCR (validated configuration)

Launch line used for every endpoint validation in this PR (Tesla
V100-SXM2 32 GB, fp16):

```bash
vllm serve /path/to/DeepSeek-OCR \
  --dtype float16 \
  --max-model-len 8192 \
  --gpu-memory-utilization 0.85 \
  --enforce-eager \
  --no-enable-prefix-caching \
  --mm-processor-cache-gb 0 \
  --logits-processors vllm.model_executor.models.deepseek_ocr:NGramPerReqLogitsProcessor
```

- `--logits-processors` loads the n-gram blocker class; the serving-defaults
  registry supplies its per-request parameters and **fails startup with the
  exact flag text if the class is missing** (never silent looping).
- `--no-enable-prefix-caching` / `--mm-processor-cache-gb 0` are the
  checkpoint recipe's engine flags.
- For multi-image requests add `--limit-mm-per-prompt '{"image":8}'`
  (the SM70 baseline defaults to 1 image per prompt).
- `--enforce-eager` is the validated configuration; CUDA graphs measured
  ~4x faster decode at ~1% window cost and can be enabled after a
  graph-mode validation pass.
- Tensor parallelism: the checkpoint has 10 attention heads, so
  `--tensor-parallel-size` must divide 10 (1 or 2 on a 4-GPU host); 4
  fails at startup with the head-divisibility error.

## Merge base

Branch applies and merges cleanly onto current `main` at `34403018d`
([Kernel][SM70] Optimize E4M3 page800 long decode, #290); all validation in
this PR ran on that base.
