### PR TITLE
[Bugfix][KV Offloading] Backport mamba/GDN CPU offloading fixes (upstream vllm#42554 + vllm#44599)

### DIFF
--- a/vllm/distributed/kv_transfer/kv_connector/v1/offloading/scheduler.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/offloading/scheduler.py
@@ -15,7 +15,7 @@ from vllm.distributed.kv_transfer.kv_connector.v1.offloading.common import (
     TransferJob,
 )
 from vllm.logger import init_logger
-from vllm.utils.math_utils import cdiv
+from vllm.utils.math_utils import cdiv, round_down
 from vllm.v1.core.kv_cache_manager import KVCacheBlocks
 from vllm.v1.core.sched.output import SchedulerOutput
 from vllm.v1.kv_cache_interface import (
@@ -88,6 +88,24 @@ def get_sliding_window_size_in_blocks(
 
     assert isinstance(kv_cache_spec, FullAttentionSpec)
     return None
+
+
+def resolve_mamba_align_size(spec: "OffloadingSpec") -> int | None:
+    """Scan all KV cache groups in *spec* and return the single mamba alignment
+    size, or None if no group requires mamba alignment.
+
+    For MambaSpec groups in "align" cache mode the hit window must be rounded
+    down to a multiple of the offloaded block size. Asserts that all such
+    groups agree on the same value.
+    """
+    mamba_align_size: int | None = None
+    for idx, gpu_block_size in enumerate(spec.gpu_block_size):
+        kv_spec = spec.kv_cache_config.kv_cache_groups[idx].kv_cache_spec
+        if isinstance(kv_spec, MambaSpec) and kv_spec.mamba_cache_mode == "align":
+            offload_block_size = gpu_block_size * spec.block_size_factor
+            assert mamba_align_size is None or mamba_align_size == offload_block_size
+            mamba_align_size = offload_block_size
+    return mamba_align_size
 
 
 class SchedulerOffloadConfig(NamedTuple):
@@ -282,6 +300,7 @@ class OffloadingConnectorScheduler:
         # used by _lookup
         self._sliding_window_groups: tuple[int, ...] = tuple(sliding_window_groups)
         self._lookup_groups = tuple(full_attention_groups) + self._sliding_window_groups
+        self._mamba_align_size: int | None = resolve_mamba_align_size(spec)
 
         self._req_status: dict[ReqId, RequestOffloadState] = {}
         self._current_batch_load_jobs: dict[int, TransferJob] = {}
@@ -398,6 +417,11 @@ class OffloadingConnectorScheduler:
             # for sliding window attention, we must reduce by 1 to make sure
             # we still have a hit after reduction
             max_hit_size_tokens -= 1
+            if self._mamba_align_size is not None:
+                # Constrain hit-window to the mamba block size.
+                max_hit_size_tokens = round_down(
+                    max_hit_size_tokens, self._mamba_align_size
+                )
         num_hit_tokens: int = 0
         defer_lookup = False
         lookup_groups = self._lookup_groups

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -415,9 +415,6 @@ class Scheduler(SchedulerInterface):
         num_new_local_computed_tokens: int = 0,
         num_external_computed_tokens: int = 0,
     ) -> int:
-        assert num_external_computed_tokens == 0, (
-            "External KV connector is not verified yet"
-        )
         num_computed_tokens = (
             request.num_computed_tokens
             + num_new_local_computed_tokens
@@ -923,7 +920,8 @@ class Scheduler(SchedulerInterface):
                             # The request cannot be scheduled.
                             break
 
-                if self.need_mamba_block_aligned_split:
+                # Skip block alignment when setting up async receive (no local work).
+                if self.need_mamba_block_aligned_split and not load_kv_async:
                     num_new_tokens = self._mamba_block_aligned_split(
                         request,
                         num_new_tokens,


### PR DESCRIPTION
# [Bugfix][KV Offloading] Backport mamba/GDN CPU offloading fixes (upstream vllm#42554 + vllm#44599)

## Purpose

Hybrid GDN models (Qwen3.8 / Qwen3-Next family, `linear_attention` + periodic
`full_attention` layers) are broken with the native CPU KV offloading connector
(`--kv-offloading-size N --kv-offloading-backend native`) as soon as any prefix
is repeated:

1. **Engine crash on offload hit.** `Scheduler._mamba_block_aligned_split`
   asserted `num_external_computed_tokens == 0` ("External KV connector is not
   verified yet"). With offloading enabled, any request whose prefix hits the
   CPU offload pool reaches the scheduler with external computed tokens and
   immediately kills the engine.
2. **Misaligned hit windows.** `OffloadingConnectorScheduler` treated
   `MambaSpec` groups like sliding-window attention when computing hit windows.
   In `align` cache mode a mamba group keeps a single state per block, so a hit
   window that is not a multiple of the offloaded block size is incorrect.

This PR backports the two upstream fixes:

- [vllm-project/vllm#42554](https://github.com/vllm-project/vllm/pull/42554)
  (merged upstream as `68f5e565`): drop the assertion; skip the mamba-aligned
  split when `load_kv_async` (async receive setup does no local work).
- [vllm-project/vllm#44599](https://github.com/vllm-project/vllm/pull/44599)
  (merged upstream as `b927004c`): add `resolve_mamba_align_size()` and round
  the hit window down to the mamba-aligned offloaded block size.

**Drop this commit when rebasing onto an upstream base that contains both PRs.**

## Test Plan / Result

`tests/test_gdn_offload.py` (1Cat workspace) on Qwen3.8-27B-FP8, 8xV100, TP4,
`--kv-offloading-size 64 --kv-offloading-backend native`:

| step | result |
|---|---|
| cold request (long shared prefix) | 10.7s TTFT |
| reset prefix cache, same prefix via CPU offload hit | **2.2s TTFT** |
| greedy outputs cold vs offload-hit | **byte-identical** |
| follow-up distinct requests | engine healthy |

Without the patch, step 2 crashes the engine at the scheduler assertion.
