### PR TITLE
[Bugfix][KV Offloading] Allow native CPU offload with expandable_segments

### DIFF
--- a/tests/v1/kv_connector/unit/test_config.py
+++ b/tests/v1/kv_connector/unit/test_config.py
@@ -104,6 +104,16 @@ def test_kv_connector_rejects_expandable_segments(monkeypatch, kv_connector):
         _build_config(kv_connector=kv_connector)
 
 
+def test_native_offloading_allows_expandable_segments(monkeypatch):
+    """Native CPU offload resolves GPU virtual addresses for each CUDA copy
+    and explicitly opts into the VMM-safe transfer contract."""
+    monkeypatch.setenv("PYTORCH_CUDA_ALLOC_CONF", "expandable_segments:True")
+
+    cfg = _build_config(kv_connector="OffloadingConnector")
+
+    assert cfg._connector_supports_vmm_safe_transfers()
+
+
 def test_kv_connector_allows_expandable_segments_with_sleep_mode(monkeypatch):
     """Sleep mode routes KV allocations through CuMemAllocator's pool, which
     auto-disables expandable_segments (see #40812)."""

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -826,8 +826,8 @@ class VllmConfig:
         # producing RDMA failures like IBV_WC_REM_ACCESS_ERR /
         # NIXL_ERR_REMOTE_DISCONNECT at the first inter-node KV transfer.
         # We can't enumerate every in-tree and out-of-tree connector that
-        # pins memory, so we conservatively reject the combination whenever
-        # any KV connector is configured.
+        # pins memory, so we conservatively reject the combination unless the
+        # connector explicitly opts into the VMM-safe transfer contract.
         #
         # CuMem allocator is exempt: CuMemAllocator.use_memory_pool toggles
         # expandable_segments off around its pool (see #40812), so the KV
@@ -838,6 +838,14 @@ class VllmConfig:
         ):
             return
         if self.model_config is not None and (self.model_config.enable_cumem_allocator):
+            return
+        if self._connector_supports_vmm_safe_transfers():
+            logger.warning_once(
+                "Allowing KV connector %s with "
+                "PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True because "
+                "it implements SupportsVmmSafeTransfers.",
+                self.kv_transfer_config.kv_connector,
+            )
             return
 
         raise ValueError(
@@ -852,6 +860,25 @@ class VllmConfig:
             "routes KV allocations through CuMemAllocator's pool, where "
             "expandable_segments is automatically disabled)."
         )
+
+    def _connector_supports_vmm_safe_transfers(self) -> bool:
+        """Resolve the connector and check its explicit VMM-safety marker."""
+        from vllm.distributed.kv_transfer.kv_connector.factory import (
+            KVConnectorFactory,
+        )
+        from vllm.distributed.kv_transfer.kv_connector.v1 import (
+            supports_vmm_safe_transfers,
+        )
+
+        kv_transfer_config = self.kv_transfer_config
+        if kv_transfer_config is None:
+            return False
+
+        try:
+            connector_cls = KVConnectorFactory.get_connector_class(kv_transfer_config)
+            return supports_vmm_safe_transfers(connector_cls)
+        except (ValueError, AttributeError, ImportError, TypeError):
+            return False
 
     def __post_init__(self):
         """Verify configs are valid & consistent with each other."""

--- a/vllm/distributed/kv_transfer/kv_connector/v1/__init__.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/__init__.py
@@ -4,7 +4,9 @@ from vllm.distributed.kv_transfer.kv_connector.v1.base import (
     KVConnectorBase_V1,
     KVConnectorRole,
     SupportsHMA,
+    SupportsVmmSafeTransfers,
     supports_hma,
+    supports_vmm_safe_transfers,
 )
 from vllm.distributed.kv_transfer.kv_connector.v1.decode_bench_connector import (  # noqa: E501
     DecodeBenchConnector,
@@ -15,5 +17,7 @@ __all__ = [
     "KVConnectorBase_V1",
     "supports_hma",
     "SupportsHMA",
+    "SupportsVmmSafeTransfers",
+    "supports_vmm_safe_transfers",
     "DecodeBenchConnector",
 ]

--- a/vllm/distributed/kv_transfer/kv_connector/v1/base.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/base.py
@@ -121,6 +121,21 @@ def supports_hma(connector: Any) -> bool:
         return isinstance(connector, SupportsHMA)
 
 
+class SupportsVmmSafeTransfers(ABC):  # noqa: B024
+    """Marker for connectors safe under CUDA VMM remapping.
+
+    Implement this marker only when every KV transfer dereferences GPU
+    virtual addresses at transfer time (for example, cuMemcpy/cudaMemcpy),
+    and the connector never registers KV device memory with RDMA, GDS,
+    CUDA IPC, or another mechanism that depends on stable physical pages.
+    """
+
+
+def supports_vmm_safe_transfers(connector_cls: type) -> bool:
+    """Return whether a connector class explicitly declares VMM safety."""
+    return issubclass(connector_cls, SupportsVmmSafeTransfers)
+
+
 class KVConnectorRole(enum.Enum):
     # Connector running in the scheduler process
     SCHEDULER = 0

--- a/vllm/distributed/kv_transfer/kv_connector/v1/offloading_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/offloading_connector.py
@@ -11,6 +11,7 @@ from vllm.distributed.kv_transfer.kv_connector.v1 import (
     KVConnectorBase_V1,
     KVConnectorRole,
     SupportsHMA,
+    SupportsVmmSafeTransfers,
 )
 from vllm.distributed.kv_transfer.kv_connector.v1.base import KVConnectorMetadata
 from vllm.distributed.kv_transfer.kv_connector.v1.metrics import (
@@ -43,7 +44,15 @@ from vllm.v1.outputs import KVConnectorOutput
 from vllm.v1.request import Request
 
 
-class OffloadingConnector(KVConnectorBase_V1, SupportsHMA):
+class OffloadingConnector(KVConnectorBase_V1, SupportsHMA, SupportsVmmSafeTransfers):
+    """Native CPU KV offload connector.
+
+    Transfers resolve the current tensor virtual address for every operation
+    and use CUDA memcpy. The connector does not register or export GPU KV
+    memory through RDMA, GDS, or CUDA IPC, so it is safe under CUDA VMM
+    remapping.
+    """
+
     @property
     def prefer_cross_layer_blocks(self) -> bool:
         return True


### PR DESCRIPTION
## Purpose

Allow 1Cat's native `OffloadingConnector` to run with
`PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True` without weakening the
default safety check for other KV connectors.

The native CPU offload path resolves the current tensor virtual address for
every transfer and uses `cuMemcpyBatchAsync` / `cudaMemcpyAsync`. It does not
register or export vLLM KV device memory through RDMA, GDS, or CUDA IPC, so a
CUDA VMM physical-page remap does not invalidate its transfer state.

This change:

- adds an explicit `SupportsVmmSafeTransfers` connector capability;
- lets the config validator accept only connectors that opt into that
  capability; and
- marks the native `OffloadingConnector` as VMM-safe.

All unmarked connectors remain fail-closed exactly as before.

## Scope and duplicate-work check

This PR is intentionally limited to allocator/connector compatibility. It does
not include the separate MTP/Mamba external-hit correctness fix, submitted as
1Cat #249.

Upstream vLLM PR
[#42405](https://github.com/vllm-project/vllm/pull/42405) proposes the same
connector-declared marker for `SimpleCPUOffloadConnector`; PR
[#48243](https://github.com/vllm-project/vllm/pull/48243) proposes an
operator-level opt-out. Neither is merged, and no open 1Cat PR covers 1Cat's
native `OffloadingConnector`. This PR applies the fail-closed connector
capability design to that native path and includes 1Cat/V100 validation.

## Test Plan

```bash
.venv/bin/python -m pytest -q tests/v1/kv_connector/unit/test_config.py
pre-commit run --from-ref upstream/main --to-ref HEAD
git diff --check upstream/main..HEAD
```

## Test Result

- Config tests: **14 passed**.
- All pre-commit hooks for the five changed files passed.
- `git diff --check` passed.
- Integrated hardware validation used the identical five-file diff, layered
  with 1Cat PR #247, on 4 x Tesla V100 32 GB with native CPU KV offload and
  `expandable_segments:True`. PIECEWISE and FULL CUDA Graph capture completed;
  a cold A / cold B / external-hit A sequence completed with byte-identical A
  output and real GPU-to-CPU plus CPU-to-GPU transfers. The prior
  `static_cuda_launcher` / `CUDA driver error: invalid argument` failure did
  not recur.

## AI assistance

AI assistance was used for implementation, test orchestration, and drafting
this PR. The human submitter has reviewed every changed line and is submitting this
PR for maintainer review.
