### PR TITLE
[Bugfix][KV Offloading] Preserve MTP/Mamba state across external hits

### DIFF
--- a/tests/v1/core/test_prefix_caching.py
+++ b/tests/v1/core/test_prefix_caching.py
@@ -1009,6 +1009,98 @@ def test_prefill_hybrid_model_mamba_align():
     manager.free(req0)
 
 
+def test_mamba_align_offload_handoff_tracks_relocated_mtp_boundary():
+    """Expose the committed state block, not its stale logical position.
+
+    A large second prefill chunk relocates the four MTP scratch blocks. The
+    first scratch block moves from logical position 1 to position 5 and becomes
+    the state after token 24. An append-only connector mirror would still see
+    that physical block at position 1 and could save the token-24 state under
+    the token-8 key.
+    """
+    block_size = 4
+    kv_cache_config = KVCacheConfig(
+        num_blocks=64,
+        kv_cache_tensors=[],
+        kv_cache_groups=[
+            KVCacheGroupSpec(
+                ["full"],
+                FullAttentionSpec(
+                    block_size=block_size,
+                    num_kv_heads=1,
+                    head_size=1,
+                    dtype=torch.float32,
+                ),
+            ),
+            KVCacheGroupSpec(
+                ["mamba"],
+                MambaSpec(
+                    block_size=block_size,
+                    shapes=((1, 1),),
+                    dtypes=(torch.float32,),
+                    mamba_cache_mode="align",
+                    num_speculative_blocks=4,
+                ),
+            ),
+        ],
+    )
+    manager = KVCacheManager(
+        kv_cache_config,
+        max_model_len=8192,
+        enable_caching=True,
+        hash_block_size=block_size,
+    )
+    request = make_request("0", [0] * 24, block_size, sha256)
+    computed_blocks, num_computed_tokens = manager.get_computed_blocks(request)
+
+    assert (
+        manager.allocate_slots(
+            request,
+            num_new_tokens=4,
+            num_new_computed_tokens=num_computed_tokens,
+            new_computed_blocks=computed_blocks,
+        )
+        is not None
+    )
+    mamba_manager = manager.coordinator.single_type_managers[1]
+    mamba_blocks = mamba_manager.req_to_blocks[request.request_id]
+    first_boundary_block_id = mamba_blocks[0].block_id
+    first_scratch_block = mamba_blocks[1]
+
+    assert manager.take_boundary_state_offloads() == {
+        request.request_id: [(1, first_boundary_block_id, 4)]
+    }
+
+    request.num_computed_tokens = 4
+    assert manager.allocate_slots(request, num_new_tokens=20) is not None
+    mamba_blocks = mamba_manager.req_to_blocks[request.request_id]
+
+    assert mamba_blocks[1].is_null
+    assert mamba_blocks[5] is first_scratch_block
+    assert manager.take_boundary_state_offloads() == {
+        request.request_id: [(1, first_scratch_block.block_id, 24)]
+    }
+    assert manager.take_boundary_state_offloads() == {}
+
+    manager.free(request)
+
+    # A request freed before the scheduler drains its offer must not leave a
+    # block ID that can be recycled and later misidentified as its boundary.
+    freed_request = make_request("freed", [1] * 4, block_size, sha256)
+    computed_blocks, num_computed_tokens = manager.get_computed_blocks(freed_request)
+    assert (
+        manager.allocate_slots(
+            freed_request,
+            num_new_tokens=4,
+            num_new_computed_tokens=num_computed_tokens,
+            new_computed_blocks=computed_blocks,
+        )
+        is not None
+    )
+    manager.free(freed_request)
+    assert manager.take_boundary_state_offloads() == {}
+
+
 def test_prefill_plp():
     """Test prefill with APC and some prompt logprobs (plp) requests.
 

--- a/tests/v1/core/test_scheduler.py
+++ b/tests/v1/core/test_scheduler.py
@@ -23,6 +23,7 @@ from vllm.multimodal.inputs import (
 from vllm.sampling_params import SamplingParams, StructuredOutputsParams
 from vllm.utils.hashing import sha256
 from vllm.v1.core.encoder_cache_manager import EncoderCacheManager
+from vllm.v1.core.kv_cache_manager import KVCacheManager
 from vllm.v1.core.kv_cache_utils import get_request_block_hasher, init_none_hash
 from vllm.v1.core.sched.output import CachedRequestData, SchedulerOutput
 from vllm.v1.core.sched.scheduler import Scheduler
@@ -39,6 +40,46 @@ from vllm.v1.structured_output import StructuredOutputManager
 from .utils import EOS_TOKEN_ID, create_requests, create_scheduler, mock_kv
 
 pytestmark = pytest.mark.cpu_test
+
+
+@pytest.mark.parametrize(
+    "num_computed_tokens,expected_attention_ids",
+    [
+        (0, []),
+        (1, [10]),
+        (16, [10]),
+        (17, [10, 11]),
+        (64, [10, 11, 12, 13]),
+    ],
+)
+def test_block_ids_for_computed_tokens_exclude_attention_lookahead(
+    num_computed_tokens: int,
+    expected_attention_ids: list[int],
+):
+    """Only attention blocks beyond the computed-token frontier are clipped.
+
+    Non-attention state groups retain their allocator-defined block table.
+    """
+    manager = object.__new__(KVCacheManager)
+    attention_spec = FullAttentionSpec(
+        block_size=16,
+        num_kv_heads=1,
+        head_size=1,
+        dtype=torch.float32,
+    )
+    manager.kv_cache_config = Mock(
+        kv_cache_groups=[
+            Mock(kv_cache_spec=attention_spec),
+            Mock(kv_cache_spec=object()),
+        ]
+    )
+    manager.get_block_ids = Mock(return_value=([10, 11, 12, 13], [20, 21, 22]))
+
+    block_ids = manager.get_block_ids_for_computed_tokens(
+        "request", num_computed_tokens
+    )
+
+    assert block_ids == (expected_attention_ids, [20, 21, 22])
 
 
 def test_add_requests():

--- a/tests/v1/kv_connector/unit/offloading_connector/test_scheduler.py
+++ b/tests/v1/kv_connector/unit/offloading_connector/test_scheduler.py
@@ -806,6 +806,16 @@ def test_request_level_policy_stores_all_blocks(request_runner, async_scheduling
 # ---------------------------------------------------------------------------
 
 
+def test_pending_job_cleanup_deduplicates_block_ids():
+    """MTP lookahead may alias a physical block within one completed job."""
+    scheduler = object.__new__(OffloadingConnectorScheduler)
+    scheduler._block_id_to_pending_jobs = {7: {42}}
+
+    scheduler._remove_pending_job(42, [7, 7])
+
+    assert scheduler._block_id_to_pending_jobs == {}
+
+
 def test_loads_do_not_populate_fence_index(request_runner):
     """Loads don't populate _block_id_to_pending_jobs (protected by
     delay_free_blocks while in flight)."""
@@ -960,8 +970,8 @@ def test_max_offload_tokens_validation(request_runner, async_scheduling: bool):
             token_ids=[0] * offloaded_block_size * 3,
             kv_transfer_params={"max_offload_tokens": max_offload_tokens},
         )
-        r.manager.prepare_store.side_effect = (
-            lambda keys, req_context: generate_store_output(keys)
+        r.manager.prepare_store.side_effect = lambda keys, req_context: (
+            generate_store_output(keys)
         )
 
     # With sync scheduling, the connector flushes completed stores when the
@@ -1059,8 +1069,8 @@ def test_offload_prompt_only(request_runner, async_scheduling: bool):
         extra_config_overrides={"offload_prompt_only": True},
     )
 
-    runner.manager.prepare_store.side_effect = (
-        lambda keys, req_context: generate_store_output(keys)
+    runner.manager.prepare_store.side_effect = lambda keys, req_context: (
+        generate_store_output(keys)
     )
 
     runner.new_request(token_ids=[0] * offloaded_block_size * num_prompt_blocks)

--- a/tests/v1/kv_connector/unit/offloading_connector/test_scheduler.py
+++ b/tests/v1/kv_connector/unit/offloading_connector/test_scheduler.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 from collections.abc import Iterable
+from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import pytest
@@ -13,15 +14,21 @@ from tests.v1.kv_connector.unit.offloading_connector.utils import (
 from tests.v1.kv_connector.unit.utils import EOS_TOKEN_ID
 from vllm.distributed.kv_events import BlockRemoved, BlockStored
 from vllm.distributed.kv_transfer.kv_connector.v1.offloading.scheduler import (
+    GroupOffloadConfig,
     OffloadingConnectorScheduler,
+    RequestOffloadState,
+    SchedulerOffloadConfig,
 )
 from vllm.v1.core.kv_cache_utils import BlockHash
 from vllm.v1.kv_cache_interface import (
     FullAttentionSpec,
+    KVCacheConfig,
     KVCacheGroupSpec,
+    MambaSpec,
     SlidingWindowSpec,
 )
 from vllm.v1.kv_offload.base import (
+    GPULoadStoreSpec,
     OffloadingEvent,
     OffloadingManager,
     OffloadPolicy,
@@ -804,6 +811,182 @@ def test_request_level_policy_stores_all_blocks(request_runner, async_scheduling
 # ---------------------------------------------------------------------------
 # Tests for the per-job-store-completion design and fence invariants.
 # ---------------------------------------------------------------------------
+
+
+def _make_exact_boundary_scheduler() -> OffloadingConnectorScheduler:
+    scheduler = object.__new__(OffloadingConnectorScheduler)
+    scheduler.config = SchedulerOffloadConfig(
+        kv_group_configs=(
+            GroupOffloadConfig(
+                group_idx=0,
+                gpu_block_size=16,
+                offloaded_block_size=16,
+                hash_block_size_factor=4,
+                sliding_window_size_in_blocks=None,
+            ),
+            GroupOffloadConfig(
+                group_idx=1,
+                gpu_block_size=16,
+                offloaded_block_size=16,
+                hash_block_size_factor=4,
+                sliding_window_size_in_blocks=1,
+                requires_exact_boundary_source=True,
+            ),
+        ),
+        block_size_factor=1,
+        num_workers=1,
+        offload_prompt_only=False,
+    )
+    scheduler.manager = MagicMock(spec=OffloadingManager)
+    scheduler.manager.prepare_store.side_effect = lambda keys, req_context: (
+        generate_store_output(keys)
+    )
+    request = MagicMock()
+    request.request_id = "req"
+    request.kv_transfer_params = None
+    request.block_hashes = [BlockHash(f"h{i}".encode()) for i in range(4)]
+    request.num_computed_tokens = 0
+    request.num_prompt_tokens = 16
+    request.num_tokens = 16
+    request.is_finished.return_value = False
+    req_context = ReqContext(req_id=request.request_id)
+    req_status = RequestOffloadState(
+        config=scheduler.config,
+        req=request,
+        req_context=req_context,
+        offloading_context=RequestOffloadingContext(),
+    )
+    req_status.update_offload_keys()
+    req_status.group_states[0].block_ids[:] = [11]
+    # This is the connector's stale append-only view of the Mamba table.
+    req_status.group_states[1].block_ids[:] = [21]
+
+    scheduler._req_status = {request.request_id: req_status}
+    scheduler._current_batch_load_jobs = {}
+    scheduler._current_batch_jobs_to_flush = set()
+    scheduler._blocks_being_loaded = set()
+    scheduler._job_counter = 0
+    scheduler._stale_job_threshold = 0
+    scheduler._jobs = {}
+    scheduler._block_id_to_pending_jobs = {}
+    return scheduler
+
+
+def test_mamba_align_group_requires_exact_boundary_source():
+    block_size = 16
+    kv_cache_config = KVCacheConfig(
+        num_blocks=32,
+        kv_cache_tensors=[],
+        kv_cache_groups=[
+            KVCacheGroupSpec(
+                ["full"],
+                FullAttentionSpec(
+                    block_size=block_size,
+                    num_kv_heads=1,
+                    head_size=1,
+                    dtype=torch.float32,
+                ),
+            ),
+            KVCacheGroupSpec(
+                ["mamba"],
+                MambaSpec(
+                    block_size=block_size,
+                    shapes=((1, 1),),
+                    dtypes=(torch.float32,),
+                    mamba_cache_mode="align",
+                ),
+            ),
+        ],
+    )
+    spec = SimpleNamespace(
+        vllm_config=SimpleNamespace(parallel_config=SimpleNamespace(world_size=4)),
+        kv_cache_config=kv_cache_config,
+        gpu_block_size=(block_size, block_size),
+        block_size_factor=1,
+        hash_block_size=block_size,
+        offload_prompt_only=False,
+    )
+
+    config = SchedulerOffloadConfig.from_spec(spec)
+
+    assert not config.kv_group_configs[0].requires_exact_boundary_source
+    assert config.kv_group_configs[1].requires_exact_boundary_source
+
+
+def _empty_store_output(**overrides):
+    output = SimpleNamespace(
+        scheduled_new_reqs=[],
+        scheduled_cached_reqs=SimpleNamespace(
+            req_ids=[], new_block_ids=[], resumed_req_ids=set()
+        ),
+        num_scheduled_tokens={},
+        finished_req_ids=set(),
+        preempted_req_ids=set(),
+        boundary_state_offloads=None,
+    )
+    for name, value in overrides.items():
+        setattr(output, name, value)
+    return output
+
+
+def test_mamba_boundary_store_uses_exact_source_not_positional_mirror():
+    scheduler = _make_exact_boundary_scheduler()
+    output = _empty_store_output(
+        num_scheduled_tokens={"req": 16},
+        boundary_state_offloads={"req": [(1, 99, 16)]},
+    )
+
+    jobs = scheduler._build_boundary_state_store_jobs(output)
+
+    assert len(jobs) == 1
+    [job_id] = jobs
+    src_spec, _ = jobs[job_id].transfer_spec
+    assert isinstance(src_spec, GPULoadStoreSpec)
+    assert src_spec.block_ids.tolist() == [99]
+    assert src_spec.block_ids.tolist() != [21]
+    assert src_spec.group_sizes == [0, 1]
+    assert src_spec.block_indices == [0, 0]
+    assert scheduler._block_id_to_pending_jobs == {99: {job_id}}
+
+
+def test_normal_store_excludes_positional_mamba_align_source():
+    scheduler = _make_exact_boundary_scheduler()
+    output = _empty_store_output(
+        scheduled_new_reqs=[SimpleNamespace(req_id="req", block_ids=None)],
+        num_scheduled_tokens={"req": 16},
+    )
+
+    jobs = scheduler._build_store_jobs(output)
+
+    assert len(jobs) == 1
+    [job] = jobs.values()
+    src_spec, _ = job.transfer_spec
+    assert isinstance(src_spec, GPULoadStoreSpec)
+    assert src_spec.block_ids.tolist() == [11]
+    assert src_spec.group_sizes == [1, 0]
+    assert 21 not in src_spec.block_ids
+
+
+def test_mamba_boundary_store_flushes_before_source_block_reuse():
+    scheduler = _make_exact_boundary_scheduler()
+    first = _empty_store_output(
+        num_scheduled_tokens={"req": 16},
+        boundary_state_offloads={"req": [(1, 99, 16)]},
+    )
+    first_meta = scheduler.build_connector_meta(first)
+    [job_id] = first_meta.store_jobs
+
+    second = _empty_store_output(
+        scheduled_cached_reqs=SimpleNamespace(
+            req_ids=["req"],
+            new_block_ids=[([12], [99])],
+            resumed_req_ids=set(),
+        ),
+        num_scheduled_tokens={"req": 0},
+    )
+    second_meta = scheduler.build_connector_meta(second)
+
+    assert second_meta.jobs_to_flush == {job_id}
 
 
 def test_pending_job_cleanup_deduplicates_block_ids():

--- a/tests/v1/worker/test_gpu_model_runner.py
+++ b/tests/v1/worker/test_gpu_model_runner.py
@@ -795,6 +795,237 @@ def test_sample_passes_reordered_draft_probs_to_rejection_sampler():
     assert torch.equal(passed_draft_probs, expected_draft_probs)
 
 
+@pytest.mark.skip_global_cleanup
+def test_sync_mamba_accepted_token_state_tracks_request_ownership():
+    runner = object.__new__(GPUModelRunner)
+    move_state = object()
+    resumed_state = object()
+    replaced_old_state = object()
+    replaced_new_state = object()
+    runner._mamba_accepted_token_state_rows = {
+        "old": (0, object()),
+        "resumed": (1, resumed_state),
+        "move": (2, move_state),
+        "same-id": (3, replaced_old_state),
+    }
+    runner.num_accepted_tokens = SimpleNamespace(
+        np=np.array([5, 3, 4, 5, 0], dtype=np.int32)
+    )
+    runner.spec_state_slot_selectors = SimpleNamespace(
+        np=np.array([5, 4, 2, 5, 0], dtype=np.int32)
+    )
+    runner.input_batch = SimpleNamespace(
+        req_ids=["new", "move", "resumed", "same-id"],
+        num_accepted_tokens_cpu=np.full(5, 9, dtype=np.int32),
+        spec_num_accepted_tokens_cpu=np.full(5, 9, dtype=np.int32),
+    )
+    runner.requests = {
+        "new": object(),
+        "move": move_state,
+        "resumed": resumed_state,
+        "same-id": replaced_new_state,
+    }
+    scheduler_output = SimpleNamespace(
+        scheduled_new_reqs=[SimpleNamespace(req_id="new")],
+        scheduled_cached_reqs=SimpleNamespace(resumed_req_ids={"resumed"}),
+    )
+
+    GPUModelRunner._sync_mamba_accepted_token_state(
+        runner, scheduler_output, num_reqs=4
+    )
+
+    # Only the continuing request keeps its prior accepted-token state. A new
+    # request, a resumed request, and a replacement using the same request ID
+    # all start with zero speculative bias (the encoded value 1).
+    expected_counts = np.array([1, 4, 1, 1], dtype=np.int32)
+    expected_selectors = np.array([1, 2, 1, 1], dtype=np.int32)
+    np.testing.assert_array_equal(runner.num_accepted_tokens.np[:4], expected_counts)
+    np.testing.assert_array_equal(
+        runner.spec_state_slot_selectors.np[:4], expected_selectors
+    )
+    np.testing.assert_array_equal(
+        runner.input_batch.num_accepted_tokens_cpu[:4], expected_counts
+    )
+    np.testing.assert_array_equal(
+        runner.input_batch.spec_num_accepted_tokens_cpu[:4], expected_selectors
+    )
+
+
+@pytest.mark.skip_global_cleanup
+def test_mamba_align_postprocess_uses_runner_owned_d2h_buffers(monkeypatch):
+    runner = object.__new__(GPUModelRunner)
+    req_state = object()
+    runner.speculative_config = object()
+    runner.model_config = SimpleNamespace(is_hybrid=True)
+    runner.cache_config = SimpleNamespace(mamba_cache_mode="align")
+    runner.num_accepted_tokens = SimpleNamespace(
+        cpu=torch.zeros(1, dtype=torch.int32),
+        gpu=torch.zeros(1, dtype=torch.int32),
+    )
+    runner.spec_state_slot_selectors = SimpleNamespace(
+        cpu=torch.zeros(1, dtype=torch.int32),
+        gpu=torch.zeros(1, dtype=torch.int32),
+    )
+    runner.input_batch = SimpleNamespace(
+        req_ids=["req"],
+        num_accepted_tokens_cpu_tensor=torch.full((1,), 9, dtype=torch.int32),
+        spec_num_accepted_tokens_cpu_tensor=torch.full((1,), 9, dtype=torch.int32),
+    )
+    runner.requests = {"req": req_state}
+    runner._get_mamba_bufs = Mock(
+        return_value=SimpleNamespace(postprocess_align=object())
+    )
+    runner.kv_cache_config = object()
+    runner.compilation_config = SimpleNamespace(static_forward_context=object())
+    runner.model = SimpleNamespace(get_mamba_state_copy_func=Mock(return_value=()))
+    runner.mamba_state_idx = {}
+    runner.num_accepted_tokens_event = Mock()
+    postprocess = Mock()
+    monkeypatch.setattr(
+        gpu_model_runner_module.envs,
+        "VLLM_MAMBA_ALIGN_CPU_POSTPROCESS",
+        False,
+    )
+    monkeypatch.setattr(
+        gpu_model_runner_module.mamba_utils,
+        "stage_postprocess_inputs_to_gpu",
+        Mock(),
+    )
+    monkeypatch.setattr(
+        gpu_model_runner_module.mamba_utils,
+        "postprocess_mamba_align_gpu",
+        postprocess,
+    )
+
+    GPUModelRunner._update_states_after_model_execute(
+        runner,
+        output_token_ids=torch.tensor([[10, 11, -1]], dtype=torch.int32),
+        scheduler_output=SimpleNamespace(scheduled_ddtree_payloads={}),
+    )
+
+    kwargs = postprocess.call_args.kwargs
+    assert kwargs["num_accepted_tokens_cpu_tensor"] is runner.num_accepted_tokens.cpu
+    assert (
+        kwargs["spec_num_accepted_tokens_cpu_tensor"]
+        is runner.spec_state_slot_selectors.cpu
+    )
+    assert (
+        kwargs["num_accepted_tokens_cpu_tensor"]
+        is not runner.input_batch.num_accepted_tokens_cpu_tensor
+    )
+    assert (
+        kwargs["spec_num_accepted_tokens_cpu_tensor"]
+        is not runner.input_batch.spec_num_accepted_tokens_cpu_tensor
+    )
+    # The GPU path must not leave any asynchronous DMA targeting mutable
+    # InputBatch rows; both accepted-state arrays are remapped only after the
+    # event is synchronized in _prepare_inputs().
+    assert torch.equal(
+        runner.input_batch.num_accepted_tokens_cpu_tensor,
+        torch.full((1,), 9, dtype=torch.int32),
+    )
+    assert torch.equal(
+        runner.input_batch.spec_num_accepted_tokens_cpu_tensor,
+        torch.full((1,), 9, dtype=torch.int32),
+    )
+
+
+@pytest.mark.skip_global_cleanup
+def test_mamba_align_cpu_postprocess_mirrors_runner_owned_snapshot(monkeypatch):
+    runner = object.__new__(GPUModelRunner)
+    req_state = object()
+    runner.speculative_config = object()
+    runner.model_config = SimpleNamespace(is_hybrid=True)
+    runner.cache_config = SimpleNamespace(mamba_cache_mode="align")
+    runner.num_accepted_tokens = SimpleNamespace(
+        cpu=torch.zeros(1, dtype=torch.int32),
+        gpu=torch.zeros(1, dtype=torch.int32),
+    )
+    runner.spec_state_slot_selectors = SimpleNamespace(
+        cpu=torch.zeros(1, dtype=torch.int32),
+        gpu=torch.zeros(1, dtype=torch.int32),
+    )
+    runner.input_batch = SimpleNamespace(
+        req_ids=["req"],
+        num_accepted_tokens_cpu_tensor=torch.zeros(1, dtype=torch.int32),
+        spec_num_accepted_tokens_cpu_tensor=torch.zeros(1, dtype=torch.int32),
+    )
+    runner.requests = {"req": req_state}
+    runner._get_mamba_bufs = Mock(return_value=SimpleNamespace(preprocess=object()))
+    runner.kv_cache_config = object()
+    runner.compilation_config = SimpleNamespace(static_forward_context=object())
+    runner.model = SimpleNamespace(get_mamba_state_copy_func=Mock(return_value=()))
+    runner.mamba_state_idx = {}
+    runner.num_accepted_tokens_event = Mock()
+
+    def cpu_postprocess(*args, **kwargs):
+        runner.input_batch.num_accepted_tokens_cpu_tensor.fill_(3)
+        runner.input_batch.spec_num_accepted_tokens_cpu_tensor.fill_(2)
+
+    monkeypatch.setattr(
+        gpu_model_runner_module.envs,
+        "VLLM_MAMBA_ALIGN_CPU_POSTPROCESS",
+        True,
+    )
+    monkeypatch.setattr(
+        gpu_model_runner_module.mamba_utils,
+        "postprocess_mamba",
+        cpu_postprocess,
+    )
+
+    GPUModelRunner._update_states_after_model_execute(
+        runner,
+        output_token_ids=torch.tensor([[10, 11, -1]], dtype=torch.int32),
+        scheduler_output=SimpleNamespace(scheduled_ddtree_payloads={}),
+    )
+
+    assert runner.num_accepted_tokens.cpu.tolist() == [3]
+    assert runner.spec_state_slot_selectors.cpu.tolist() == [2]
+
+
+@pytest.mark.skip_global_cleanup
+def test_mamba_all_mode_uses_runner_owned_d2h_buffers(monkeypatch):
+    runner = object.__new__(GPUModelRunner)
+    req_state = object()
+    runner.speculative_config = object()
+    runner.model_config = SimpleNamespace(is_hybrid=True)
+    runner.cache_config = SimpleNamespace(mamba_cache_mode="all")
+    runner.num_spec_tokens = 4
+    runner.num_accepted_tokens = SimpleNamespace(
+        cpu=torch.zeros(1, dtype=torch.int32),
+        gpu=torch.zeros(1, dtype=torch.int32),
+    )
+    runner.spec_state_slot_selectors = SimpleNamespace(
+        cpu=torch.zeros(1, dtype=torch.int32),
+        gpu=torch.zeros(1, dtype=torch.int32),
+    )
+    runner.input_batch = SimpleNamespace(
+        req_ids=["req"],
+        num_accepted_tokens_cpu_tensor=torch.full((1,), 9, dtype=torch.int32),
+        spec_num_accepted_tokens_cpu_tensor=torch.full((1,), 9, dtype=torch.int32),
+    )
+    runner.requests = {"req": req_state}
+    runner.kv_cache_config = object()
+    runner.mamba_state_idx = {}
+    runner.num_accepted_tokens_event = Mock()
+    monkeypatch.setattr(
+        gpu_model_runner_module.mamba_utils,
+        "postprocess_mamba_all",
+        Mock(),
+    )
+
+    GPUModelRunner._update_states_after_model_execute(
+        runner,
+        output_token_ids=torch.tensor([[10, 11, -1]], dtype=torch.int32),
+        scheduler_output=SimpleNamespace(scheduled_ddtree_payloads={}),
+    )
+
+    assert runner.num_accepted_tokens.cpu.tolist() == [2]
+    assert runner.spec_state_slot_selectors.cpu.tolist() == [2]
+    assert runner.input_batch.num_accepted_tokens_cpu_tensor.tolist() == [9]
+    assert runner.input_batch.spec_num_accepted_tokens_cpu_tensor.tolist() == [9]
+
+
 def test_init_kv_cache_with_kv_sharing_invalid_target_layer_order(default_vllm_config):
     torch.set_default_dtype(torch.float16)
     layer_0 = "model.layers.0.self_attn.attn"

--- a/vllm/distributed/kv_transfer/kv_connector/v1/offloading/scheduler.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/offloading/scheduler.py
@@ -331,7 +331,10 @@ class OffloadingConnectorScheduler:
         return job_id
 
     def _remove_pending_job(self, job_id: int, block_ids: list[int] | None) -> None:
-        for bid in block_ids or ():
+        # Registration is idempotent because each block maps to a set of job IDs.
+        # MTP lookahead may report the same physical block ID more than once, so
+        # completion must use the same set semantics instead of removing twice.
+        for bid in set(block_ids or ()):
             pending = self._block_id_to_pending_jobs[bid]
             pending.remove(job_id)
             if not pending:

--- a/vllm/distributed/kv_transfer/kv_connector/v1/offloading/scheduler.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/offloading/scheduler.py
@@ -15,7 +15,7 @@ from vllm.distributed.kv_transfer.kv_connector.v1.offloading.common import (
     TransferJob,
 )
 from vllm.logger import init_logger
-from vllm.utils.math_utils import cdiv
+from vllm.utils.math_utils import cdiv, round_down
 from vllm.v1.core.kv_cache_manager import KVCacheBlocks
 from vllm.v1.core.sched.output import SchedulerOutput
 from vllm.v1.kv_cache_interface import (
@@ -88,6 +88,24 @@ def get_sliding_window_size_in_blocks(
 
     assert isinstance(kv_cache_spec, FullAttentionSpec)
     return None
+
+
+def resolve_mamba_align_size(spec: "OffloadingSpec") -> int | None:
+    """Scan all KV cache groups in *spec* and return the single mamba alignment
+    size, or None if no group requires mamba alignment.
+
+    For MambaSpec groups in "align" cache mode the hit window must be rounded
+    down to a multiple of the offloaded block size. Asserts that all such
+    groups agree on the same value.
+    """
+    mamba_align_size: int | None = None
+    for idx, gpu_block_size in enumerate(spec.gpu_block_size):
+        kv_spec = spec.kv_cache_config.kv_cache_groups[idx].kv_cache_spec
+        if isinstance(kv_spec, MambaSpec) and kv_spec.mamba_cache_mode == "align":
+            offload_block_size = gpu_block_size * spec.block_size_factor
+            assert mamba_align_size is None or mamba_align_size == offload_block_size
+            mamba_align_size = offload_block_size
+    return mamba_align_size
 
 
 class SchedulerOffloadConfig(NamedTuple):
@@ -282,6 +300,7 @@ class OffloadingConnectorScheduler:
         # used by _lookup
         self._sliding_window_groups: tuple[int, ...] = tuple(sliding_window_groups)
         self._lookup_groups = tuple(full_attention_groups) + self._sliding_window_groups
+        self._mamba_align_size: int | None = resolve_mamba_align_size(spec)
 
         self._req_status: dict[ReqId, RequestOffloadState] = {}
         self._current_batch_load_jobs: dict[int, TransferJob] = {}
@@ -398,6 +417,11 @@ class OffloadingConnectorScheduler:
             # for sliding window attention, we must reduce by 1 to make sure
             # we still have a hit after reduction
             max_hit_size_tokens -= 1
+            if self._mamba_align_size is not None:
+                # Constrain hit-window to the mamba block size.
+                max_hit_size_tokens = round_down(
+                    max_hit_size_tokens, self._mamba_align_size
+                )
         num_hit_tokens: int = 0
         defer_lookup = False
         lookup_groups = self._lookup_groups

--- a/vllm/distributed/kv_transfer/kv_connector/v1/offloading/scheduler.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/offloading/scheduler.py
@@ -73,6 +73,10 @@ class GroupOffloadConfig(NamedTuple):
     # than the MLA full-attention group).
     # None for full-attention groups or when the optimization doesn't apply.
     alignment_block_count: int | None = None
+    # Mamba ``align`` tables mutate existing logical positions. Such groups
+    # must be stored from exact core-provided boundary block IDs instead of the
+    # connector's append-only positional mirror.
+    requires_exact_boundary_source: bool = False
 
 
 def get_sliding_window_size_in_blocks(
@@ -151,6 +155,12 @@ class SchedulerOffloadConfig(NamedTuple):
                 return None
             return per_segment
 
+        def _requires_exact_boundary_source(group_idx: int) -> bool:
+            kv_spec = spec.kv_cache_config.kv_cache_groups[group_idx].kv_cache_spec
+            return (
+                isinstance(kv_spec, MambaSpec) and kv_spec.mamba_cache_mode == "align"
+            )
+
         return cls(
             num_workers=spec.vllm_config.parallel_config.world_size,
             kv_group_configs=tuple(
@@ -170,6 +180,9 @@ class SchedulerOffloadConfig(NamedTuple):
                     ),
                     alignment_block_count=_alignment_block_count(
                         gpu_block_size * spec.block_size_factor, sw
+                    ),
+                    requires_exact_boundary_source=(
+                        _requires_exact_boundary_source(idx)
                     ),
                 )
                 for idx, gpu_block_size in enumerate(spec.gpu_block_size)
@@ -754,6 +767,8 @@ class OffloadingConnectorScheduler:
             for group_config, group_state in zip(
                 self.config.kv_group_configs, req_status.group_states
             ):
+                if group_config.requires_exact_boundary_source:
+                    continue
                 num_blocks = num_offloadable_tokens // group_config.offloaded_block_size
                 start_block_idx = group_state.next_stored_block_idx
                 if num_blocks <= start_block_idx:
@@ -822,6 +837,10 @@ class OffloadingConnectorScheduler:
             for group_config, group_state in zip(
                 self.config.kv_group_configs, req_status.group_states
             ):
+                if group_config.requires_exact_boundary_source:
+                    group_sizes.append(0)
+                    block_indices.append(0)
+                    continue
                 is_sliding_window = (
                     group_config.sliding_window_size_in_blocks is not None
                 )
@@ -899,6 +918,99 @@ class OffloadingConnectorScheduler:
 
         return store_jobs
 
+    def _build_boundary_state_store_jobs(
+        self,
+        scheduler_output: SchedulerOutput,
+    ) -> dict[int, TransferJob]:
+        """Build stores from exact committed Mamba boundary-state blocks."""
+        handoffs = scheduler_output.boundary_state_offloads
+        if not handoffs:
+            return {}
+
+        store_jobs: dict[int, TransferJob] = {}
+        num_groups = len(self.config.kv_group_configs)
+        for req_id, entries in handoffs.items():
+            req_status = self._req_status.get(req_id)
+            if req_status is None:
+                continue
+            req_status.update_offload_keys()
+            req = req_status.req
+            num_scheduled_tokens = scheduler_output.num_scheduled_tokens.get(req_id, 0)
+            num_offloadable_tokens = min(
+                req.num_computed_tokens + num_scheduled_tokens,
+                req.num_tokens,
+            )
+            if req_status.max_offload_tokens is not None:
+                num_offloadable_tokens = min(
+                    num_offloadable_tokens, req_status.max_offload_tokens
+                )
+            if self.config.offload_prompt_only:
+                num_offloadable_tokens = min(
+                    num_offloadable_tokens, req.num_prompt_tokens
+                )
+
+            for group_idx, block_id, boundary_tokens in entries:
+                group_config = self.config.kv_group_configs[group_idx]
+                if not group_config.requires_exact_boundary_source:
+                    continue
+                if (
+                    block_id == 0
+                    or boundary_tokens > num_offloadable_tokens
+                    or boundary_tokens % group_config.offloaded_block_size != 0
+                ):
+                    continue
+
+                offload_block_idx = (
+                    boundary_tokens // group_config.offloaded_block_size - 1
+                )
+                group_state = req_status.group_states[group_idx]
+                if offload_block_idx >= len(group_state.offload_keys):
+                    continue
+                offload_key = group_state.offload_keys[offload_block_idx]
+                store_output = self.manager.prepare_store(
+                    [offload_key], req_status.req_context
+                )
+                if store_output is None:
+                    logger.warning(
+                        "Request %s: cannot store Mamba boundary at %d tokens",
+                        req_id,
+                        boundary_tokens,
+                    )
+                    continue
+                keys_to_store = set(store_output.keys_to_store)
+                if not keys_to_store:
+                    continue
+                assert keys_to_store == {offload_key}
+
+                job_id = self._generate_job_id()
+                req_status.transfer_jobs.add(job_id)
+                self._block_id_to_pending_jobs.setdefault(block_id, set()).add(job_id)
+                self._jobs[job_id] = TransferJobStatus(
+                    req_id=req_id,
+                    pending_count=self.config.num_workers,
+                    keys=keys_to_store,
+                    is_store=True,
+                    sliding_window_block_ids=[block_id],
+                )
+
+                group_sizes = [0] * num_groups
+                group_sizes[group_idx] = 1
+                block_indices = [0] * num_groups
+                block_indices[group_idx] = (
+                    boundary_tokens // group_config.gpu_block_size - 1
+                )
+                src_spec = GPULoadStoreSpec(
+                    [block_id],
+                    group_sizes=group_sizes,
+                    block_indices=block_indices,
+                )
+                store_jobs[job_id] = TransferJob(
+                    req_id=req_id,
+                    transfer_spec=(src_spec, store_output.store_spec),
+                )
+
+        return store_jobs
+
     def build_connector_meta(
         self, scheduler_output: SchedulerOutput
     ) -> KVConnectorMetadata:
@@ -918,9 +1030,11 @@ class OffloadingConnectorScheduler:
         ):
             self._current_batch_jobs_to_flush.update(self._jobs.keys())
 
+        boundary_store_jobs = self._build_boundary_state_store_jobs(scheduler_output)
+        normal_store_jobs = self._build_store_jobs(scheduler_output)
         meta = OffloadingConnectorMetadata(
             load_jobs=self._current_batch_load_jobs,
-            store_jobs=self._build_store_jobs(scheduler_output),
+            store_jobs=boundary_store_jobs | normal_store_jobs,
             jobs_to_flush=self._current_batch_jobs_to_flush,
         )
         self._current_batch_load_jobs = {}

--- a/vllm/v1/core/kv_cache_manager.py
+++ b/vllm/v1/core/kv_cache_manager.py
@@ -589,6 +589,28 @@ class KVCacheManager:
             ids.extend(mgr.take_new_block_ids())
         return ids
 
+    def take_boundary_state_offloads(
+        self,
+    ) -> dict[str, list[tuple[int, int, int]]]:
+        """Drain exact Mamba ``align`` state blocks for KV connectors.
+
+        Returns ``{request_id: [(group_id, block_id, boundary_tokens), ...]}``.
+        These scheduler-local handoffs avoid reconstructing mutable Mamba block
+        tables from a connector's append-only block-ID mirror.
+        """
+        offloads: dict[str, list[tuple[int, int, int]]] = {}
+        for mgr in self.coordinator.single_type_managers:
+            for (
+                request_id,
+                group_id,
+                block,
+                boundary_tokens,
+            ) in mgr.take_pending_boundary_state_offloads():
+                offloads.setdefault(request_id, []).append(
+                    (group_id, block.block_id, boundary_tokens)
+                )
+        return offloads
+
     def new_step_starts(self) -> None:
         """Called when a new step is started."""
         self.coordinator.new_step_starts()

--- a/vllm/v1/core/kv_cache_manager.py
+++ b/vllm/v1/core/kv_cache_manager.py
@@ -8,10 +8,14 @@ from typing import Literal, overload
 
 from vllm.distributed.kv_events import BlockStored, KVCacheEvent
 from vllm.logger import init_logger
+from vllm.utils.math_utils import cdiv
 from vllm.v1.core.kv_cache_coordinator import get_kv_cache_coordinator
 from vllm.v1.core.kv_cache_metrics import KVCacheMetricsCollector
 from vllm.v1.core.kv_cache_utils import KVCacheBlock
 from vllm.v1.kv_cache_interface import (
+    AttentionSpec,
+    CrossAttentionSpec,
+    EncoderOnlyAttentionSpec,
     KVCacheConfig,
     get_kv_cache_spec_kind,
     get_kv_cache_spec_sliding_window,
@@ -540,6 +544,26 @@ class KVCacheManager:
     def get_block_ids(self, request_id: str) -> tuple[list[int], ...]:
         """Get the block ids of a request."""
         return self.get_blocks(request_id).get_block_ids()
+
+    def get_block_ids_for_computed_tokens(
+        self,
+        request_id: str,
+        num_computed_tokens: int,
+    ) -> tuple[list[int], ...]:
+        """Get block ids covering the request's computed tokens."""
+        block_ids = self.get_block_ids(request_id)
+        clipped_block_ids: list[list[int]] = []
+        for group, ids in zip(self.kv_cache_config.kv_cache_groups, block_ids):
+            spec = group.kv_cache_spec
+            if not isinstance(spec, AttentionSpec) or isinstance(
+                spec, (CrossAttentionSpec, EncoderOnlyAttentionSpec)
+            ):
+                clipped_block_ids.append(ids)
+                continue
+
+            num_valid_blocks = cdiv(num_computed_tokens, spec.block_size)
+            clipped_block_ids.append(ids[:num_valid_blocks])
+        return tuple(clipped_block_ids)
 
     def cache_blocks(self, request: Request, num_computed_tokens: int) -> None:
         """Cache the blocks for the request, if enabled.

--- a/vllm/v1/core/sched/output.py
+++ b/vllm/v1/core/sched/output.py
@@ -246,6 +246,11 @@ class SchedulerOutput:
     # preventing stale NaN/data from corrupting attention or SSM computation.
     new_block_ids_to_zero: list[int] | None = None
 
+    # Exact Mamba ``align`` boundary-state sources offered to a KV connector:
+    # {request_id: [(group_id, block_id, boundary_tokens), ...]}.
+    # Scheduler-local; cleared after connector metadata is built.
+    boundary_state_offloads: dict[str, list[tuple[int, int, int]]] | None = None
+
     @classmethod
     def make_empty(cls) -> "SchedulerOutput":
         return cls(

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -2395,7 +2395,10 @@ class Scheduler(SchedulerInterface):
             total_computed_tokens=request.num_computed_tokens,
         )
 
-        block_ids = self.kv_cache_manager.get_block_ids(request.request_id)
+        block_ids = self.kv_cache_manager.get_block_ids_for_computed_tokens(
+            request_id=request.request_id,
+            num_computed_tokens=request.num_computed_tokens,
+        )
 
         if not isinstance(self.connector, SupportsHMA):
             # NOTE(Kuntai): We should deprecate this code path after we enforce

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -415,9 +415,6 @@ class Scheduler(SchedulerInterface):
         num_new_local_computed_tokens: int = 0,
         num_external_computed_tokens: int = 0,
     ) -> int:
-        assert num_external_computed_tokens == 0, (
-            "External KV connector is not verified yet"
-        )
         num_computed_tokens = (
             request.num_computed_tokens
             + num_new_local_computed_tokens
@@ -923,7 +920,8 @@ class Scheduler(SchedulerInterface):
                             # The request cannot be scheduled.
                             break
 
-                if self.need_mamba_block_aligned_split:
+                # Skip block alignment when setting up async receive (no local work).
+                if self.need_mamba_block_aligned_split and not load_kv_async:
                     num_new_tokens = self._mamba_block_aligned_split(
                         request,
                         num_new_tokens,

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -1118,6 +1118,9 @@ class Scheduler(SchedulerInterface):
             if self.needs_kv_cache_zeroing
             else None
         )
+        # A Mamba ``align`` table is not append-only. Drain exact committed
+        # boundary-state block IDs before the connector builds store jobs.
+        boundary_state_offloads = self.kv_cache_manager.take_boundary_state_offloads()
 
         scheduler_output = SchedulerOutput(
             scheduled_new_reqs=new_reqs_data,
@@ -1136,6 +1139,9 @@ class Scheduler(SchedulerInterface):
             finished_req_ids=self.finished_req_ids,
             free_encoder_mm_hashes=self.encoder_cache_manager.get_freed_mm_hashes(),
             new_block_ids_to_zero=new_block_ids_to_zero,
+            boundary_state_offloads=(
+                boundary_state_offloads if self.connector is not None else None
+            ),
         )
 
         # NOTE(Kuntai): this function is designed for multiple purposes:
@@ -1145,6 +1151,9 @@ class Scheduler(SchedulerInterface):
         if self.connector is not None:
             meta = self._build_kv_connector_meta(self.connector, scheduler_output)
             scheduler_output.kv_connector_metadata = meta
+
+        # Exact source IDs are scheduler-side connector inputs only.
+        scheduler_output.boundary_state_offloads = None
 
         # Build the connector meta for ECConnector
         if self.ec_connector is not None:

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -68,6 +68,14 @@ class SingleTypeKVCacheManager(ABC):
         self._max_admission_blocks_per_request = max_admission_blocks_per_request
         self.new_block_ids: list[int] = []
 
+        # Mamba ``align`` block tables are sparse and mutable: committed
+        # boundary states can be followed by speculative scratch blocks that
+        # are relocated in place. A connector therefore cannot recover an
+        # exact boundary-state source from an append-only block-ID mirror.
+        self._pending_boundary_state_offloads: list[
+            tuple[str, int, KVCacheBlock, int]
+        ] = []
+
         # Mapping from request ID to blocks to track the blocks allocated
         # for each request, so that we can free the blocks when the request
         # is finished.
@@ -81,6 +89,18 @@ class SingleTypeKVCacheManager(ABC):
 
         self.kv_cache_group_id = kv_cache_group_id
         self._null_block = block_pool.null_block
+
+    def take_pending_boundary_state_offloads(
+        self,
+    ) -> list[tuple[str, int, KVCacheBlock, int]]:
+        """Drain exact Mamba ``align`` boundary-state handoffs.
+
+        Entries are ``(request_id, group_id, block, boundary_tokens)``.
+        Non-Mamba managers leave the list empty.
+        """
+        pending = self._pending_boundary_state_offloads
+        self._pending_boundary_state_offloads = []
+        return pending
 
     @classmethod
     def _get_num_evictable_blocks(cls, blocks: Sequence[KVCacheBlock]):
@@ -1095,6 +1115,14 @@ class MambaManager(SingleTypeKVCacheManager):
         if self.mamba_cache_mode == "align":
             self._allocated_block_reqs.discard(request_id)
             self.last_state_block_idx.pop(request_id, None)
+            # A hand-off is valid only while its source still belongs to this
+            # request. Drop offers that have not reached the connector before
+            # returning the request's blocks to the pool.
+            self._pending_boundary_state_offloads = [
+                entry
+                for entry in self._pending_boundary_state_offloads
+                if entry[0] != request_id
+            ]
         super().free(request_id)
 
     def get_num_skipped_tokens(self, num_computed_tokens: int) -> int:
@@ -1115,13 +1143,22 @@ class MambaManager(SingleTypeKVCacheManager):
         super().cache_blocks(request, num_tokens, alignment_tokens=alignment_tokens)
         num_cached_blocks_after = self.num_cached_block.get(request.request_id, 0)
         if num_cached_blocks_after > num_cached_blocks_before:
-            for block in self.req_to_blocks[request.request_id][
-                num_cached_blocks_before:num_cached_blocks_after
-            ]:
+            blocks = self.req_to_blocks[request.request_id]
+            for block_idx in range(num_cached_blocks_before, num_cached_blocks_after):
+                block = blocks[block_idx]
                 if block.is_null:
                     continue
                 assert block.block_hash is not None
                 self.cached_blocks_this_step.add(block.block_hash)
+                if self.mamba_cache_mode == "align":
+                    self._pending_boundary_state_offloads.append(
+                        (
+                            request.request_id,
+                            self.kv_cache_group_id,
+                            block,
+                            (block_idx + 1) * self.block_size,
+                        )
+                    )
 
     def new_step_starts(self) -> None:
         self.cached_blocks_this_step.clear()

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -1808,6 +1808,12 @@ class GPUModelRunner(
         self.valid_sampled_token_count_cpu: torch.Tensor | None = None
         self.draft_token_ids_cpu: torch.Tensor | None = None
         self.num_accepted_tokens_event: torch.Event | None = None
+        # Row ownership for the runner-owned accepted-token D2H snapshots.
+        # Keep the request object as well as its ID so abort-and-resubmit with
+        # the same ID is still treated as a new request.
+        self._mamba_accepted_token_state_rows: dict[
+            str, tuple[int, CachedRequestState]
+        ] = {}
         if self.num_spec_tokens:
             self.draft_token_ids_event = torch.Event()
             self.num_accepted_tokens_event = torch.Event()
@@ -2589,6 +2595,10 @@ class GPUModelRunner(
         # Count only the contiguous accepted prefix. Values after the first -1
         # are rejected/padding slots and may contain stale token ids.
         num_reqs = output_token_ids.size(0)
+        self._mamba_accepted_token_state_rows = {
+            req_id: (i, self.requests[req_id])
+            for i, req_id in enumerate(self.input_batch.req_ids[:num_reqs])
+        }
         profile_count_t0 = time.perf_counter() if profile_enabled else 0.0
         sidecar_values = None
         if (
@@ -2715,19 +2725,16 @@ class GPUModelRunner(
                         else None
                     ),
                 )
+                # CPU postprocess updates InputBatch in place. Mirror its final
+                # values into the runner-owned snapshot used by the next step.
+                self.num_accepted_tokens.cpu[:num_reqs].copy_(
+                    self.input_batch.num_accepted_tokens_cpu_tensor[:num_reqs]
+                )
+                self.spec_state_slot_selectors.cpu[:num_reqs].copy_(
+                    self.input_batch.spec_num_accepted_tokens_cpu_tensor[:num_reqs]
+                )
             else:
                 profile_mamba_stage_t0 = time.perf_counter() if profile_enabled else 0.0
-                if spec_state_slot_selectors_cpu is not None:
-                    self.input_batch.spec_num_accepted_tokens_cpu_tensor[
-                        :num_reqs
-                    ].copy_(spec_state_slot_selectors_cpu)
-                else:
-                    self.input_batch.spec_num_accepted_tokens_cpu_tensor[
-                        :num_reqs
-                    ].copy_(
-                        self.spec_state_slot_selectors.gpu[:num_reqs],
-                        non_blocking=True,
-                    )
                 assert mamba_bufs.postprocess_align is not None
                 mamba_utils.stage_postprocess_inputs_to_gpu(
                     mamba_bufs.postprocess_align,
@@ -2749,11 +2756,9 @@ class GPUModelRunner(
                     num_reqs=num_reqs,
                     num_accepted_tokens_gpu=self.num_accepted_tokens.gpu,
                     spec_state_slot_selectors_gpu=(self.spec_state_slot_selectors.gpu),
-                    num_accepted_tokens_cpu_tensor=(
-                        self.input_batch.num_accepted_tokens_cpu_tensor
-                    ),
+                    num_accepted_tokens_cpu_tensor=self.num_accepted_tokens.cpu,
                     spec_num_accepted_tokens_cpu_tensor=(
-                        self.input_batch.spec_num_accepted_tokens_cpu_tensor
+                        self.spec_state_slot_selectors.cpu
                     ),
                     input_batch=self.input_batch,
                     kv_cache_config=self.kv_cache_config,
@@ -2786,10 +2791,10 @@ class GPUModelRunner(
                     spec_state_slot_selectors_cpu
                 )
             else:
-                self.input_batch.num_accepted_tokens_cpu_tensor[:num_reqs].copy_(
+                self.num_accepted_tokens.cpu[:num_reqs].copy_(
                     self.num_accepted_tokens.gpu[:num_reqs], non_blocking=True
                 )
-                self.input_batch.spec_num_accepted_tokens_cpu_tensor[:num_reqs].copy_(
+                self.spec_state_slot_selectors.cpu[:num_reqs].copy_(
                     self.spec_state_slot_selectors.gpu[:num_reqs],
                     non_blocking=True,
                 )
@@ -4658,6 +4663,45 @@ class GPUModelRunner(
 
         return encoder_seq_lens, encoder_seq_lens_cpu
 
+    def _sync_mamba_accepted_token_state(
+        self,
+        scheduler_output: "SchedulerOutput",
+        num_reqs: int,
+    ) -> None:
+        """Remap the previous step's accepted-token state by request.
+
+        The GPU postprocess copies into runner-owned CPU buffers. InputBatch
+        rows can be removed, reused, or condensed before this synchronization,
+        so row-for-row writeback is not safe even with synchronous scheduling.
+        """
+        previous_counts = self.num_accepted_tokens.np.copy()
+        previous_selectors = self.spec_state_slot_selectors.np.copy()
+        previous_rows = self._mamba_accepted_token_state_rows
+        reset_req_ids = set(scheduler_output.scheduled_cached_reqs.resumed_req_ids)
+        reset_req_ids.update(
+            req_data.req_id for req_data in scheduler_output.scheduled_new_reqs
+        )
+
+        current_counts = self.num_accepted_tokens.np[:num_reqs]
+        current_selectors = self.spec_state_slot_selectors.np[:num_reqs]
+        for current_idx, req_id in enumerate(self.input_batch.req_ids[:num_reqs]):
+            previous = previous_rows.get(req_id)
+            if (
+                previous is not None
+                and req_id not in reset_req_ids
+                and self.requests.get(req_id) is previous[1]
+            ):
+                previous_idx = previous[0]
+                current_counts[current_idx] = previous_counts[previous_idx]
+                current_selectors[current_idx] = previous_selectors[previous_idx]
+            else:
+                # A new/restored request has no accepted speculative prefix.
+                current_counts[current_idx] = 1
+                current_selectors[current_idx] = 1
+
+        self.input_batch.num_accepted_tokens_cpu[:num_reqs] = current_counts
+        self.input_batch.spec_num_accepted_tokens_cpu[:num_reqs] = current_selectors
+
     def _prepare_inputs(
         self,
         scheduler_output: "SchedulerOutput",
@@ -4869,32 +4913,7 @@ class GPUModelRunner(
                 self.num_accepted_tokens_event,
                 "GPUModelRunner.num_accepted_tokens_event.synchronize",
             )
-            # Async mode: condense() reordered indices, use prev_positions mapping
-            if self.use_async_scheduling and prev_req_id_to_index:
-                prev_idx = self.prev_positions.np[:num_reqs]
-                new_mask = prev_idx < 0
-                prev_idx_or_zero = np.where(new_mask, 0, prev_idx)
-                align_counts = self.input_batch.num_accepted_tokens_cpu[
-                    prev_idx_or_zero
-                ].copy()
-                align_counts[new_mask] = 1
-                self.input_batch.num_accepted_tokens_cpu[:num_reqs] = align_counts
-                spec_counts = self.input_batch.spec_num_accepted_tokens_cpu[
-                    prev_idx_or_zero
-                ]
-                spec_counts = spec_counts.copy()
-                spec_counts[new_mask] = 1
-                self.input_batch.spec_num_accepted_tokens_cpu[:num_reqs] = spec_counts
-                self.num_accepted_tokens.np[:num_reqs] = align_counts
-                self.spec_state_slot_selectors.np[:num_reqs] = spec_counts
-            else:
-                # Non-async mode: use values directly
-                self.num_accepted_tokens.np[:num_reqs] = (
-                    self.input_batch.num_accepted_tokens_cpu[:num_reqs]
-                )
-                self.spec_state_slot_selectors.np[:num_reqs] = (
-                    self.input_batch.spec_num_accepted_tokens_cpu[:num_reqs]
-                )
+            self._sync_mamba_accepted_token_state(scheduler_output, num_reqs)
             self.num_accepted_tokens.np[num_reqs:].fill(1)
             self.spec_state_slot_selectors.np[num_reqs:].fill(1)
             self._copy_buffer_to_gpu(self.num_accepted_tokens)


### PR DESCRIPTION
## Purpose

Fix incorrect native CPU KV offload restores for hybrid Mamba/GDN models when
MTP speculative decoding is enabled.

This PR **depends on 1Cat PR #247**. PR #247 removes the original external-KV
assertion and backports the Mamba boundary-alignment fixes from upstream vLLM,
but it does not cover MTP-owned accepted-token state or mutable Mamba `align`
source blocks. This branch is stacked on the fixed head of #247
(`c514f39e15ca74a1f51bb5270f0f4734d1da8bc7`) and will be rebased after #247
lands.

## Root cause

On a real external CPU-tier hit, MTP4 output consistently lost exactly four
tokens. The fixed loss matching the MTP width exposed two related ownership
bugs:

1. Asynchronous accepted-token D2H copies targeted mutable `InputBatch` rows.
   Rows can be removed, condensed, resumed, or reused before the event is
   consumed, so accepted-token state could be applied to the wrong request.
2. A Mamba `align` table is not append-only. MTP scratch blocks move to new
   logical positions when a boundary is committed, while the native connector's
   block mirror only appends. A positional store could therefore save a stale
   Mamba state under a valid prefix key.

## Changes

- Store accepted-token D2H results in runner-owned buffers and remap them by
  request identity after synchronization. New, resumed, or same-ID replacement
  requests reset their speculative state.
- Clip attention block tables at the computed-token frontier without clipping
  allocator-defined non-attention state groups.
- Emit exact core-selected Mamba `align` boundary block IDs to the connector.
- Exclude mutable Mamba groups from the normal positional store path and build
  their store jobs only from exact boundary handoffs.
- Keep the existing pending-job fence on each source block until the async
  store completes, including deduplication when MTP aliases one physical block.

## Scope and duplicate-work check

This is not duplicate work:

- 1Cat #247 is the required base fix; it does not address MTP state ownership
  or the exact external-hit corruption described here.
- Upstream vLLM
  [#51358](https://github.com/vllm-project/vllm/pull/51358) implements exact
  Mamba boundary persistence for Mooncake with its own pin/watermark protocol;
  this PR adapts the correctness invariant to the native `OffloadingConnector`
  and its per-job fence lifecycle.
- Upstream vLLM
  [#52771](https://github.com/vllm-project/vllm/pull/52771) fixes MTP/EAGLE
  lookups being reduced to zero. In this reproduction the external hit was
  already real; the restored recurrent state was wrong.
- Upstream vLLM
  [#52832](https://github.com/vllm-project/vllm/pull/52832) concerns
  Mooncake finish-time partial tails and does not cover this native exact-
  boundary path.

No open 1Cat PR or issue was found for this mechanism.

## Test Plan

```bash
.venv/bin/python -m pytest -q \
  tests/v1/core/test_prefix_caching.py \
  tests/v1/kv_connector/unit/offloading_connector/test_scheduler.py \
  tests/v1/core/test_scheduler.py

.venv/bin/python -m pytest -q tests/v1/worker/test_gpu_model_runner.py \
  -k 'sync_mamba_accepted_token_state_tracks_request_ownership or mamba_align_postprocess_uses_runner_owned_d2h_buffers or mamba_align_cpu_postprocess_mirrors_runner_owned_snapshot or mamba_all_mode_uses_runner_owned_d2h_buffers'

pre-commit run --from-ref upstream/pr-247 --to-ref HEAD
git diff --check upstream/pr-247..HEAD
```

## Test Result

- Core, scheduler, and native connector regression suite: **219 passed**.
- New worker state-ownership tests: **4 passed**.
- All pre-commit hooks for the ten changed files passed.
- `git diff --check` passed.
- An extended run including the entire worker file produced **251 passed, 3
  failed**. All three failures reproduce unchanged on the unmodified #247 base:
  one existing sampling mock lacks `drafter`, and two GPU/FLASHINFER assertions
  are not valid in the CPU-only test environment.
- Integrated 4 x Tesla V100 validation of the identical MTP diff, together with
  #247 and the separately submitted VMM-safe connector change in 1Cat #248,
  passed a
  39,999-token cold / external-hit / local-rehit sequence with byte- and
  SHA-identical output. Exact-boundary, mid-block, Responses API, tool-call, and
  follow-up cases passed; MTP reported 136 drafted / 135 accepted tokens, with
  no OOM, process restart, or EngineCore fatal error.

## AI assistance

AI assistance was used for implementation, test orchestration, root-cause
analysis, and drafting this PR. The human submitter has reviewed every changed line and is submitting this
PR for maintainer review.
