### PR TITLE
[Bugfix][SM70] Fix the DeepSeek-V4 indexer cache layout and restore the ReLU

### DIFF
--- a/tests/kernels/test_deepseek_v4_sm70_indexer.py
+++ b/tests/kernels/test_deepseek_v4_sm70_indexer.py
@@ -4,33 +4,189 @@
 import pytest
 import torch
 
-from vllm.models.deepseek_v4.sm70.indexer import sm70_indexer_prefill_logits
+from vllm.models.deepseek_v4.sm70 import indexer as sm70_indexer
+from vllm.models.deepseek_v4.sm70.indexer import (
+    sm70_indexer_decode_logits,
+    sm70_indexer_prefill_logits,
+)
 
-
-@pytest.mark.skipif(
+requires_sm70 = pytest.mark.skipif(
     not torch.cuda.is_available() or torch.cuda.get_device_capability() != (7, 0),
     reason="requires NVIDIA V100/SM70",
 )
-def test_sm70_indexer_prefill_dequantizes_fp8_storage_as_uint8() -> None:
-    torch.manual_seed(20260803)
-    num_queries = 3
-    num_heads = 4
-    num_keys = 7
-    head_dim = 128
 
-    q = torch.randn(
-        (num_queries, num_heads, head_dim), device="cuda", dtype=torch.float16
+_HEAD_DIM = 128
+_BLOCK_SIZE = 64
+
+# E4M3FN bit patterns with exact values. Building keys from a palette keeps the
+# reference bit-exact and needs no native FP8 conversion, which SM70 lacks.
+_FP8_BITS = torch.tensor([0x00, 0x30, 0x38, 0x3C, 0x40, 0xB0, 0xB8, 0xC0])
+_FP8_VALUES = torch.tensor([0.0, 0.5, 1.0, 1.5, 2.0, -0.5, -1.0, -2.0])
+
+
+def _random_fp8_keys(num_keys: int, generator: torch.Generator):
+    """Return (uint8 bit patterns, exact fp32 values) for `num_keys` keys."""
+    picks = torch.randint(len(_FP8_BITS), (num_keys, _HEAD_DIM), generator=generator)
+    return _FP8_BITS[picks].to(torch.uint8).cuda(), _FP8_VALUES[picks].cuda()
+
+
+def _reference_index_logits(
+    q: torch.Tensor, weights: torch.Tensor, k: torch.Tensor
+) -> torch.Tensor:
+    """I[t, s] = sum_h weights[t, h] * relu(q[t, h] . k[s]).
+
+    The model's actual indexer scoring function (reference `Indexer.forward`,
+    inference/model.py:427; the in-repo `fp8_mqa_logits` reference at
+    v1/attention/ops/rocm_aiter_mla_sparse.py:510 applies the same relu). It
+    does NOT factor to (sum_h weights[t, h] * q[t, h]) . k[s] - the relu sits
+    between the weighting and the head sum.
+    """
+    per_head = torch.einsum("thd,sd->ths", q.float(), k.float())
+    return torch.einsum("ths,th->ts", torch.relu(per_head), weights.float())
+
+
+def _reference_factored_logits(
+    q: torch.Tensor, weights: torch.Tensor, k: torch.Tensor
+) -> torch.Tensor:
+    """The relu-free form, kept reachable via VLLM_SM70_INDEXER_RELU=0."""
+    weighted_q = torch.einsum("thd,th->td", q.float(), weights.float())
+    return weighted_q @ k.float().T
+
+
+def _build_paged_index_cache(
+    value_bits: torch.Tensor, scales: torch.Tensor
+) -> torch.Tensor:
+    """Pack keys into the block-major layout the C++ cache kernels write.
+
+    `indexer_k_quant_and_cache` / `cp_gather_indexer_k_quant_cache`
+    (csrc/libtorch_stable/cache_kernels.cu) store, per block, all `block_size`
+    rows of 128 FP8 values first and only then that block's FP32 scales:
+
+        value: block_base + pos_in_block * 128 + d
+        scale: block_base + block_size * 128 + pos_in_block * 4
+
+    It is NOT a per-token [128 values][4 scale] record, which is why only
+    token 0 of each block used to read back correctly.
+    """
+    num_blocks, block_size, head_dim = value_bits.shape
+    assert scales.shape == (num_blocks, block_size)
+    value_bytes = value_bits.reshape(num_blocks, block_size * head_dim)
+    scale_bytes = scales.contiguous().view(torch.uint8)
+    return (
+        torch.cat([value_bytes, scale_bytes], dim=1)
+        .reshape(num_blocks, block_size, head_dim + 4)
+        .contiguous()
     )
-    weights = torch.randn((num_queries, num_heads), device="cuda", dtype=torch.float32)
-    # E4M3FN bit pattern 0x38 is exactly 1.0. Constructing the tensor through
-    # uint8 also avoids requiring native FP8 conversion support on SM70.
-    k_bits = torch.full((num_keys, head_dim), 0x38, device="cuda", dtype=torch.uint8)
-    k_quant = k_bits.view(torch.float8_e4m3fn)
+
+
+def _make_queries(rows: int, num_heads: int):
+    q = (
+        torch.randn((rows, num_heads, _HEAD_DIM), device="cuda", dtype=torch.float16)
+        * 0.25
+    )
+    weights = torch.randn((rows, num_heads), device="cuda", dtype=torch.float32)
+    return q, weights
+
+
+@requires_sm70
+@pytest.mark.parametrize("use_cublas", [True, False])
+def test_prefill_matches_the_reference_scoring_function(monkeypatch, use_cublas):
+    torch.manual_seed(20260819)
+    generator = torch.Generator().manual_seed(20260819)
+    num_queries, num_heads, num_keys = 5, 8, 37
+    monkeypatch.setattr(sm70_indexer, "_PREFILL_CUBLAS", use_cublas)
+
+    q, weights = _make_queries(num_queries, num_heads)
+    bits, values = _random_fp8_keys(num_keys, generator)
+    scales = torch.linspace(0.5, 2.0, num_keys, device="cuda", dtype=torch.float32)
+    k = values * scales[:, None]
+
+    actual = sm70_indexer_prefill_logits(
+        q, bits.view(torch.float8_e4m3fn), scales, weights
+    )
+    expected = _reference_index_logits(q, weights, k)
+    torch.testing.assert_close(actual, expected, rtol=1e-2, atol=1e-2)
+
+    # The relu is not a rounding detail: without it the scoring is a different
+    # function, which is what broke long-context top-k selection.
+    factored = _reference_factored_logits(q, weights, k)
+    assert not torch.allclose(expected, factored, rtol=1e-2, atol=1e-2)
+
+
+@requires_sm70
+def test_prefill_relu_off_restores_the_factored_form(monkeypatch):
+    """VLLM_SM70_INDEXER_RELU=0 keeps the old scoring reachable for A/B."""
+    torch.manual_seed(20260819)
+    generator = torch.Generator().manual_seed(20260819)
+    num_queries, num_heads, num_keys = 4, 8, 23
+    monkeypatch.setattr(sm70_indexer, "_RELU_LOGITS", False)
+
+    q, weights = _make_queries(num_queries, num_heads)
+    bits, values = _random_fp8_keys(num_keys, generator)
     scales = torch.linspace(0.5, 2.0, num_keys, device="cuda", dtype=torch.float32)
 
-    actual = sm70_indexer_prefill_logits(q, k_quant, scales, weights)
+    actual = sm70_indexer_prefill_logits(
+        q, bits.view(torch.float8_e4m3fn), scales, weights
+    )
+    expected = _reference_factored_logits(q, weights, values * scales[:, None])
+    torch.testing.assert_close(actual, expected, rtol=1e-2, atol=1e-2)
 
-    weighted_q = torch.sum(q.float() * weights[:, :, None], dim=1).half()
-    k_reference = scales[:, None].expand(num_keys, head_dim).half()
-    expected = torch.mm(weighted_q, k_reference.T, out_dtype=torch.float32)
-    torch.testing.assert_close(actual, expected, rtol=2e-3, atol=2e-3)
+
+@requires_sm70
+@pytest.mark.parametrize(
+    "relu,fused",
+    [
+        pytest.param(True, True, id="relu"),
+        pytest.param(False, True, id="factored-fused"),
+        pytest.param(False, False, id="factored-gather"),
+    ],
+)
+def test_decode_reads_the_block_major_paged_cache(monkeypatch, relu, fused):
+    """Every decode path must address values and scales the way the cache is
+    written. Reading a token as a [128 values][4 scale] record lands on the
+    wrong bytes for every token but the first of each block, and reinterprets
+    four FP8 value bytes as the FP32 scale.
+    """
+    torch.manual_seed(20260819)
+    generator = torch.Generator().manual_seed(20260819)
+    monkeypatch.setattr(sm70_indexer, "_RELU_LOGITS", relu)
+    monkeypatch.setattr(sm70_indexer, "_FUSED_DECODE_LOGITS", fused)
+
+    num_heads = 8
+    seq_lens_list = [1, _BLOCK_SIZE + 1, 3 * _BLOCK_SIZE - 5]
+    rows = len(seq_lens_list)
+    max_seq_len = max(seq_lens_list)
+    blocks_per_row = (max_seq_len + _BLOCK_SIZE - 1) // _BLOCK_SIZE
+    num_blocks = rows * blocks_per_row + 2  # +2 so no row can start at block 0
+
+    bits, values = _random_fp8_keys(num_blocks * _BLOCK_SIZE, generator)
+    value_bits = bits.reshape(num_blocks, _BLOCK_SIZE, _HEAD_DIM)
+    block_values = values.reshape(num_blocks, _BLOCK_SIZE, _HEAD_DIM)
+    # Distinct per-token scales inside every block: with one scale per block
+    # the layout bug is invisible.
+    scales = torch.rand((num_blocks, _BLOCK_SIZE), generator=generator).cuda() + 0.5
+    cache = _build_paged_index_cache(value_bits, scales)
+
+    # Shuffled, non-identity mapping so a wrong block stride cannot pass.
+    perm = torch.randperm(num_blocks, generator=generator)[: rows * blocks_per_row]
+    block_table = perm.to(torch.int32).cuda().reshape(rows, blocks_per_row)
+    seq_lens = torch.tensor(seq_lens_list, device="cuda", dtype=torch.int32)
+    q, weights = _make_queries(rows, num_heads)
+
+    actual = sm70_indexer_decode_logits(
+        q, cache, weights, seq_lens, block_table, max_seq_len
+    )
+
+    reference = _reference_index_logits if relu else _reference_factored_logits
+    for row, seq_len in enumerate(seq_lens_list):
+        positions = torch.arange(seq_len, device="cuda")
+        physical = block_table[row][positions // _BLOCK_SIZE].long()
+        pos_in_block = positions % _BLOCK_SIZE
+        k = (
+            block_values[physical, pos_in_block]
+            * scales[physical, pos_in_block][:, None]
+        )
+        expected = reference(q[row : row + 1], weights[row : row + 1], k)
+        torch.testing.assert_close(
+            actual[row, :seq_len].unsqueeze(0), expected, rtol=1e-2, atol=1e-2
+        )

--- a/vllm/models/deepseek_v4/sm70/indexer.py
+++ b/vllm/models/deepseek_v4/sm70/indexer.py
@@ -3,6 +3,8 @@
 
 """DeepSeek V4 C4 indexer fallback using FP16 HMMA on SM70."""
 
+import os
+
 import torch
 
 from vllm.models.deepseek_v4.common.ops.fp8_software import (
@@ -12,6 +14,74 @@ from vllm.triton_utils import tl, triton
 
 _INDEX_HEAD_DIM = 128
 _INDEX_CACHE_BYTES = _INDEX_HEAD_DIM + 4
+
+# Fuse dequant+scoring into one paged kernel instead of materialising
+# [rows, max_seq_len, 128] fp16 and running a dense bmm. Set to 0 to get the
+# old gather+bmm path back for an A/B. Only affects decode; prefill scores a
+# contiguous chunk whose width is the real chunk length already.
+_FUSED_DECODE_LOGITS = os.getenv("VLLM_SM70_INDEXER_FUSED_LOGITS", "1") == "1"
+
+# Score with the model's actual indexer function,
+#     I[t, s] = sum_h weights[t, h] * relu(q[t, h] . k[s]),
+# instead of the cheaper (sum_h weights[t, h] * q[t, h]) . k[s]. Those are
+# equal only without the relu, and the relu is not optional: it is what the
+# checkpoint was trained with (reference `Indexer.forward`,
+# inference/model.py:427, and the in-repo `fp8_mqa_logits` reference at
+# v1/attention/ops/rocm_aiter_mla_sparse.py:510 -- every non-SM70 backend
+# applies it inside its logits kernel). Dropping it costs 64x fewer flops and
+# ranks the wrong keys, which only shows up once top-k is actually selective.
+# Set 0 to restore the factored form for an A/B.
+_RELU_LOGITS = os.getenv("VLLM_SM70_INDEXER_RELU", "1") == "1"
+
+# Key-axis splits are chosen so the launch is roughly this many blocks, which
+# keeps all 80 SMs busy at long context without paying for thousands of
+# no-op programs at short context.
+_LOGITS_TARGET_BLOCKS = 512
+_LOGITS_BLOCK_N = 32
+# The relu path multiplies q against k with an MMA instead of a broadcast
+# multiply, so the key tile has to be at least one 16x16x16 HMMA fragment
+# wide; 64 keeps the [64 heads, 128] x [128, N] shape efficient.
+_RELU_BLOCK_N = 64
+_RELU_BLOCK_M = 32
+
+# Route prefill scoring through cuBLAS instead of the Triton MMA. Set 0 for an
+# A/B against the Triton kernel above (which stays as the reference shape and
+# is what the decode path still uses, since decode gathers from a paged cache).
+_PREFILL_CUBLAS = os.getenv("VLLM_SM70_INDEXER_PREFILL_CUBLAS", "1") == "1"
+# Cap (MiB) on the [tokens*heads, key_tile] fp16 score tile. At the default
+# 2048-token prefill chunk and 64 heads this is 128 KiB per key, so the tile
+# is what keeps a long-context chunk from asking for gigabytes in one go.
+_PREFILL_TILE_MB = int(os.getenv("VLLM_SM70_INDEXER_PREFILL_TILE_MB", "192"))
+_EPILOGUE_BLOCK_K = 256
+_EPILOGUE_BLOCK_H = 8
+
+
+@triton.jit
+def _index_cache_ptrs(
+    cache_ptr,
+    physical_block,
+    pos_in_block,
+    block_stride,
+    cache_block_size,
+    head_dim: tl.constexpr,
+):
+    """Value and scale pointers for one token of the paged indexer cache.
+
+    The layout is block-major, NOT token-interleaved: within a block come all
+    `cache_block_size` rows of FP8 values, and only then the FP32 scales, one
+    per token (csrc/libtorch_stable/cache_kernels.cu, the
+    `indexer_k_quant_and_cache` store and the `cp_gather_indexer_k_quant_cache`
+    load both address it this way). Reading a token as
+    `[128 values][4 scale]` at `pos * cache.stride(1)` therefore lands on the
+    wrong bytes for every token but the first of each block, and the "scale"
+    it picks up is really four FP8 value bytes.
+    """
+    base = cache_ptr + physical_block.to(tl.int64) * block_stride
+    value_ptr = base + pos_in_block.to(tl.int64) * head_dim
+    scale_ptr = (base + cache_block_size * head_dim + pos_in_block * 4).to(
+        tl.pointer_type(tl.float32)
+    )
+    return value_ptr, scale_ptr
 
 
 @triton.jit
@@ -79,7 +149,6 @@ def _dequant_paged_index_k_kernel(
     seq_lens_ptr,
     out_ptr,
     cache_stride0,
-    cache_stride1,
     block_table_stride0,
     out_stride0,
     out_stride1,
@@ -100,10 +169,13 @@ def _dequant_paged_index_k_kernel(
         mask=valid,
         other=0,
     )
-    token_ptr = (
-        cache_ptr
-        + physical_block.to(tl.int64) * cache_stride0
-        + pos_in_block * cache_stride1
+    token_ptr, scale_ptr = _index_cache_ptrs(
+        cache_ptr,
+        physical_block,
+        pos_in_block,
+        cache_stride0,
+        cache_block_size,
+        head_dim,
     )
     packed = tl.load(
         token_ptr[:, None] + dim_offsets[None, :],
@@ -111,7 +183,6 @@ def _dequant_paged_index_k_kernel(
         other=0,
     )
     fp8 = fp8_e4m3fn_bits_to_fp32(packed)
-    scale_ptr = (token_ptr + head_dim).to(tl.pointer_type(tl.float32))
     scale = tl.load(scale_ptr, mask=valid, other=0.0).to(tl.float32)
     dequant = fp8 * scale[:, None]
     tl.store(
@@ -122,6 +193,220 @@ def _dequant_paged_index_k_kernel(
         dequant.to(out_ptr.type.element_ty),
         mask=valid[:, None],
     )
+
+
+@triton.jit
+def _paged_index_logits_kernel(
+    q_ptr,
+    cache_ptr,
+    block_table_ptr,
+    seq_lens_ptr,
+    out_ptr,
+    q_stride0,
+    cache_stride0,
+    block_table_stride0,
+    out_stride0,
+    cache_block_size,
+    head_dim: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    NUM_SPLITS: tl.constexpr,
+):
+    """Index logits straight out of the paged FP8 cache, no gather buffer.
+
+    `_dequant_paged_index_k_kernel` + bmm has a grid and a GEMM shape derived
+    from `max_seq_len`, and under a captured decode CUDA Graph that is frozen
+    at `max_model_len` forever. Here the grid is static -- (rows, NUM_SPLITS),
+    sized from `max_seq_len` on the host -- and only each program's trip count
+    follows the live `seq_len`, so one captured graph serves any context while
+    a short context costs almost nothing.
+    """
+    row_idx = tl.program_id(0)
+    split_id = tl.program_id(1)
+    dim_offsets = tl.arange(0, head_dim)
+    q = tl.load(q_ptr + row_idx * q_stride0 + dim_offsets).to(tl.float32)
+
+    seq_len = tl.load(seq_lens_ptr + row_idx)
+    chunks = (seq_len + BLOCK_N - 1) // BLOCK_N
+    chunks_per_split = (chunks + NUM_SPLITS - 1) // NUM_SPLITS
+    lo = split_id * chunks_per_split * BLOCK_N
+    hi = tl.minimum(lo + chunks_per_split * BLOCK_N, seq_len)
+
+    for start in range(lo, hi, BLOCK_N):
+        key_offsets = start + tl.arange(0, BLOCK_N)
+        valid = key_offsets < seq_len
+        block_in_seq = key_offsets // cache_block_size
+        pos_in_block = key_offsets % cache_block_size
+        physical_block = tl.load(
+            block_table_ptr + row_idx * block_table_stride0 + block_in_seq,
+            mask=valid,
+            other=0,
+        )
+        token_ptr, scale_ptr = _index_cache_ptrs(
+            cache_ptr,
+            physical_block,
+            pos_in_block,
+            cache_stride0,
+            cache_block_size,
+            head_dim,
+        )
+        packed = tl.load(
+            token_ptr[:, None] + dim_offsets[None, :],
+            mask=valid[:, None],
+            other=0,
+        )
+        fp8 = fp8_e4m3fn_bits_to_fp32(packed)
+        scale = tl.load(scale_ptr, mask=valid, other=0.0).to(tl.float32)
+        # Per-token scale factors out of the dot product.
+        logits = tl.sum(fp8 * q[None, :], axis=1) * scale
+        tl.store(out_ptr + row_idx * out_stride0 + key_offsets, logits, mask=valid)
+
+
+@triton.jit
+def _contiguous_index_logits_relu_kernel(
+    q_ptr,
+    w_ptr,
+    k_ptr,
+    k_scale_ptr,
+    out_ptr,
+    q_stride0,
+    q_stride1,
+    w_stride0,
+    k_stride0,
+    out_stride0,
+    num_q,
+    num_k,
+    num_heads,
+    head_dim: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    """Prefill index scores, per head, with the relu inside the head sum.
+
+    Reference shape for the scoring, and the A/B fallback for the cuBLAS path
+    (`VLLM_SM70_INDEXER_PREFILL_CUBLAS=0`). It is not the fast path: Triton's
+    `tl.dot` does not reach Volta's tensor cores, so this tops out near 3.3
+    TFLOP/s no matter how the tile is shaped -- folding heads into the M
+    dimension to get a [256, 128] x [128, 64] MMA instead of a per-head
+    [32, 128] x [128, 64] one measured 3.34 vs 3.39 TFLOP/s, i.e. nothing.
+    cuBLAS does the same shape at 54.
+
+    The key tile is loaded once and reused by every head (the indexer is MQA).
+    FP8 keys are widened to FP16 *unscaled* -- e4m3 maxes out at 448, which
+    fp16 holds exactly -- and the per-key scale is applied to the finished
+    accumulator. That keeps `k * scale` out of fp16 entirely, where a large
+    ue8m0 scale could otherwise overflow.
+    """
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+    offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    offs_n = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+    dim_offsets = tl.arange(0, head_dim)
+    m_valid = offs_m < num_q
+    n_valid = offs_n < num_k
+
+    packed = tl.load(
+        k_ptr + offs_n[:, None] * k_stride0 + dim_offsets[None, :],
+        mask=n_valid[:, None],
+        other=0,
+    )
+    k_t = tl.trans(fp8_e4m3fn_bits_to_fp32(packed).to(tl.float16))
+    scale = tl.load(k_scale_ptr + offs_n, mask=n_valid, other=0.0).to(tl.float32)
+
+    acc = tl.zeros((BLOCK_M, BLOCK_N), dtype=tl.float32)
+    for head in range(num_heads):
+        q = tl.load(
+            q_ptr
+            + offs_m[:, None] * q_stride0
+            + head * q_stride1
+            + dim_offsets[None, :],
+            mask=m_valid[:, None],
+            other=0.0,
+        )
+        w = tl.load(w_ptr + offs_m * w_stride0 + head, mask=m_valid, other=0.0)
+        acc += tl.maximum(tl.dot(q, k_t), 0.0) * w[:, None].to(tl.float32)
+
+    tl.store(
+        out_ptr + offs_m[:, None] * out_stride0 + offs_n[None, :],
+        acc * scale[None, :],
+        mask=m_valid[:, None] & n_valid[None, :],
+    )
+
+
+@triton.jit
+def _paged_index_logits_relu_kernel(
+    q_ptr,
+    w_ptr,
+    cache_ptr,
+    block_table_ptr,
+    seq_lens_ptr,
+    out_ptr,
+    q_stride0,
+    q_stride1,
+    w_stride0,
+    cache_stride0,
+    block_table_stride0,
+    out_stride0,
+    cache_block_size,
+    head_dim: tl.constexpr,
+    NUM_HEADS: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    NUM_SPLITS: tl.constexpr,
+):
+    """Decode counterpart of `_contiguous_index_logits_relu_kernel`.
+
+    Same static-grid property as `_paged_index_logits_kernel`: the grid is
+    (rows, NUM_SPLITS) and only the trip count follows the live `seq_len`, so
+    one captured CUDA graph serves any context length.
+    """
+    row_idx = tl.program_id(0)
+    split_id = tl.program_id(1)
+    head_offsets = tl.arange(0, NUM_HEADS)
+    dim_offsets = tl.arange(0, head_dim)
+    q = tl.load(
+        q_ptr
+        + row_idx * q_stride0
+        + head_offsets[:, None] * q_stride1
+        + dim_offsets[None, :]
+    )
+    w = tl.load(w_ptr + row_idx * w_stride0 + head_offsets).to(tl.float32)
+
+    seq_len = tl.load(seq_lens_ptr + row_idx)
+    chunks = (seq_len + BLOCK_N - 1) // BLOCK_N
+    chunks_per_split = (chunks + NUM_SPLITS - 1) // NUM_SPLITS
+    lo = split_id * chunks_per_split * BLOCK_N
+    hi = tl.minimum(lo + chunks_per_split * BLOCK_N, seq_len)
+
+    for start in range(lo, hi, BLOCK_N):
+        key_offsets = start + tl.arange(0, BLOCK_N)
+        valid = key_offsets < seq_len
+        block_in_seq = key_offsets // cache_block_size
+        pos_in_block = key_offsets % cache_block_size
+        physical_block = tl.load(
+            block_table_ptr + row_idx * block_table_stride0 + block_in_seq,
+            mask=valid,
+            other=0,
+        )
+        token_ptr, scale_ptr = _index_cache_ptrs(
+            cache_ptr,
+            physical_block,
+            pos_in_block,
+            cache_stride0,
+            cache_block_size,
+            head_dim,
+        )
+        packed = tl.load(
+            token_ptr[:, None] + dim_offsets[None, :],
+            mask=valid[:, None],
+            other=0,
+        )
+        k_t = tl.trans(fp8_e4m3fn_bits_to_fp32(packed).to(tl.float16))
+        scale = tl.load(scale_ptr, mask=valid, other=0.0).to(tl.float32)
+        # relu(q_h . k) is per head; only then does the weighted head sum
+        # collapse it to one logit. The per-key scale is positive, so pulling
+        # it out past the relu and the sum is exact.
+        scores = tl.maximum(tl.dot(q, k_t), 0.0) * w[:, None]
+        logits = tl.sum(scores, axis=0) * scale
+        tl.store(out_ptr + row_idx * out_stride0 + key_offsets, logits, mask=valid)
 
 
 def _combine_index_queries(q: torch.Tensor, weights: torch.Tensor) -> torch.Tensor:
@@ -146,6 +431,134 @@ def _combine_index_queries(q: torch.Tensor, weights: torch.Tensor) -> torch.Tens
     return out
 
 
+@triton.jit
+def _relu_weight_headsum_kernel(
+    s_ptr,
+    w_ptr,
+    scale_ptr,
+    out_ptr,
+    s_stride0,
+    s_stride1,
+    w_stride0,
+    out_stride0,
+    num_k,
+    num_heads: tl.constexpr,
+    BLOCK_K: tl.constexpr,
+    BLOCK_H: tl.constexpr,
+):
+    """relu -> weight -> head sum -> key scale, in a single pass over scores.
+
+    Epilogue for the cuBLAS prefill path. Doing it as torch ops instead costs
+    three extra round trips through the [tokens, heads, keys] score tile, which
+    is the largest tensor in the whole indexer; fusing them measured 13 -> 26
+    TFLOP/s end to end.
+    """
+    token = tl.program_id(0)
+    k_base = tl.program_id(1) * BLOCK_K
+    k_offsets = k_base + tl.arange(0, BLOCK_K)
+    k_valid = k_offsets < num_k
+
+    acc = tl.zeros((BLOCK_K,), dtype=tl.float32)
+    for head in range(0, num_heads, BLOCK_H):
+        h_offsets = head + tl.arange(0, BLOCK_H)
+        s = tl.load(
+            s_ptr
+            + token * s_stride0
+            + h_offsets[:, None] * s_stride1
+            + k_offsets[None, :],
+            mask=k_valid[None, :],
+            other=0.0,
+        ).to(tl.float32)
+        w = tl.load(w_ptr + token * w_stride0 + h_offsets).to(tl.float32)
+        acc += tl.sum(tl.maximum(s, 0.0) * w[:, None], axis=0)
+
+    scale = tl.load(scale_ptr + k_offsets, mask=k_valid, other=0.0).to(tl.float32)
+    tl.store(out_ptr + token * out_stride0 + k_offsets, acc * scale, mask=k_valid)
+
+
+@triton.jit
+def _dequant_index_k_unscaled_kernel(
+    k_ptr,
+    out_ptr,
+    k_stride0,
+    out_stride0,
+    head_dim: tl.constexpr,
+):
+    """Widen FP8 index keys to FP16 without applying the per-key scale.
+
+    e4m3 tops out at 448 and the scale is folded into the epilogue instead, so
+    the GEMM never sees `k * scale` -- a large ue8m0 scale would otherwise
+    overflow fp16 on the way in.
+    """
+    row_idx = tl.program_id(0)
+    offsets = tl.arange(0, head_dim)
+    values = tl.load(
+        k_ptr.to(tl.pointer_type(tl.uint8)) + row_idx * k_stride0 + offsets
+    )
+    tl.store(
+        out_ptr + row_idx * out_stride0 + offsets,
+        fp8_e4m3fn_bits_to_fp32(values).to(tl.float16),
+    )
+
+
+def _prefill_logits_cublas(q, k_quant, k_scales, weights):
+    """Prefill index scores through cuBLAS, with the relu inside the head sum.
+
+    Triton's `tl.dot` does not reach Volta's tensor cores: on the exact shape
+    this needs it measures 3.3 TFLOP/s, against 54 TFLOP/s for cuBLAS fp16 and
+    13 TFLOP/s for plain fp32 CUDA cores. The relu blocks the one-GEMM
+    factorisation, but it does not block cuBLAS -- stacking heads into the M
+    dimension turns the scoring into a single [tokens*heads, 128] x [128, keys]
+    GEMM whose output is reduced over heads afterwards. Keys are tiled so that
+    intermediate stays bounded; it is the largest allocation in the indexer.
+    """
+    num_q, num_heads, head_dim = q.shape
+    num_k = k_quant.shape[0]
+    out = torch.empty((num_q, num_k), dtype=torch.float32, device=q.device)
+
+    k_fp16 = torch.empty((num_k, head_dim), dtype=torch.float16, device=q.device)
+    _dequant_index_k_unscaled_kernel[(num_k,)](
+        k_quant.view(torch.uint8),
+        k_fp16,
+        k_quant.stride(0),
+        k_fp16.stride(0),
+        head_dim=head_dim,
+        num_warps=4,
+    )
+
+    q2 = q.reshape(num_q * num_heads, head_dim)
+    if not q2.is_contiguous():
+        q2 = q2.contiguous()
+
+    rows = num_q * num_heads
+    budget = max(1, _PREFILL_TILE_MB * 2**20 // max(1, rows * 2))
+    k_tile = max(_RELU_BLOCK_N, min(num_k, budget // _RELU_BLOCK_N * _RELU_BLOCK_N))
+
+    for start in range(0, num_k, k_tile):
+        stop = min(start + k_tile, num_k)
+        width = stop - start
+        # fp16 out with fp32 accumulate: the epilogue reduces in fp32 and only
+        # the top-k *set* is consumed downstream, so the 5e-4 rounding here is
+        # far below the gap between neighbouring index scores.
+        scores = torch.mm(q2, k_fp16[start:stop].t())
+        _relu_weight_headsum_kernel[(num_q, triton.cdiv(width, _EPILOGUE_BLOCK_K))](
+            scores,
+            weights,
+            k_scales[start:stop],
+            out[:, start:stop],
+            scores.stride(0) * num_heads,
+            scores.stride(0),
+            weights.stride(0),
+            out.stride(0),
+            width,
+            num_heads=num_heads,
+            BLOCK_K=_EPILOGUE_BLOCK_K,
+            BLOCK_H=_EPILOGUE_BLOCK_H,
+            num_warps=4,
+        )
+    return out
+
+
 def sm70_indexer_prefill_logits(
     q: torch.Tensor,
     k_quant: torch.Tensor,
@@ -157,6 +570,37 @@ def sm70_indexer_prefill_logits(
     assert k_quant.ndim == 2 and k_quant.shape[1] == _INDEX_HEAD_DIM
     k_scales = k_scale_storage.view(torch.float32).reshape(-1)
     assert k_scales.shape[0] == k_quant.shape[0]
+
+    if _RELU_LOGITS and _PREFILL_CUBLAS:
+        return _prefill_logits_cublas(q, k_quant, k_scales, weights)
+
+    if _RELU_LOGITS:
+        num_q, num_heads, _ = q.shape
+        num_k = k_quant.shape[0]
+        out = torch.empty((num_q, num_k), dtype=torch.float32, device=q.device)
+        block_m, block_n = _RELU_BLOCK_M, _RELU_BLOCK_N
+        _contiguous_index_logits_relu_kernel[
+            (triton.cdiv(num_q, block_m), triton.cdiv(num_k, block_n))
+        ](
+            q,
+            weights,
+            k_quant.view(torch.uint8),
+            k_scales,
+            out,
+            q.stride(0),
+            q.stride(1),
+            weights.stride(0),
+            k_quant.stride(0),
+            out.stride(0),
+            num_q,
+            num_k,
+            num_heads,
+            head_dim=_INDEX_HEAD_DIM,
+            BLOCK_M=block_m,
+            BLOCK_N=block_n,
+            num_warps=8,
+        )
+        return out
 
     weighted_q = _combine_index_queries(q, weights)
     k_fp16 = torch.empty(k_quant.shape, dtype=torch.float16, device=k_quant.device)
@@ -183,7 +627,9 @@ def sm70_indexer_decode_logits(
     """Gather paged FP8 index keys and compute batched decode scores."""
     assert cache.dtype == torch.uint8 and cache.ndim == 3
     assert cache.shape[-1] >= _INDEX_CACHE_BYTES
-    weighted_q = _combine_index_queries(q, weights)
+    # The relu path scores per head, so it needs q as [rows, heads, dim]; the
+    # factored path collapses the head axis up front.
+    weighted_q = q if _RELU_LOGITS else _combine_index_queries(q, weights)
 
     if seq_lens.ndim == 2:
         next_n = seq_lens.shape[1]
@@ -195,21 +641,77 @@ def sm70_indexer_decode_logits(
     assert block_table.shape[0] == weighted_q.shape[0]
 
     max_seq_len = max(1, int(max_seq_len))
+    total_rows = weighted_q.shape[0]
+
+    if _RELU_LOGITS:
+        out = torch.empty(
+            (total_rows, max_seq_len), dtype=torch.float32, device=q.device
+        )
+        max_chunks = triton.cdiv(max_seq_len, _RELU_BLOCK_N)
+        splits = max(1, min(max_chunks, _LOGITS_TARGET_BLOCKS // total_rows))
+        _paged_index_logits_relu_kernel[(total_rows, splits)](
+            q,
+            weights,
+            cache,
+            block_table,
+            flat_lens,
+            out,
+            q.stride(0),
+            q.stride(1),
+            weights.stride(0),
+            cache.stride(0),
+            block_table.stride(0),
+            out.stride(0),
+            cache.shape[1],
+            head_dim=_INDEX_HEAD_DIM,
+            NUM_HEADS=q.shape[1],
+            BLOCK_N=_RELU_BLOCK_N,
+            NUM_SPLITS=splits,
+            num_warps=8,
+        )
+        # Positions >= seq_len are left uninitialised; every consumer masks by
+        # seq_lens (see the note on the factored path below).
+        return out
+
+    if _FUSED_DECODE_LOGITS:
+        out = torch.empty(
+            (total_rows, max_seq_len), dtype=torch.float32, device=q.device
+        )
+        max_chunks = triton.cdiv(max_seq_len, _LOGITS_BLOCK_N)
+        splits = max(1, min(max_chunks, _LOGITS_TARGET_BLOCKS // total_rows))
+        _paged_index_logits_kernel[(total_rows, splits)](
+            weighted_q,
+            cache,
+            block_table,
+            flat_lens,
+            out,
+            weighted_q.stride(0),
+            cache.stride(0),
+            block_table.stride(0),
+            out.stride(0),
+            cache.shape[1],
+            head_dim=_INDEX_HEAD_DIM,
+            BLOCK_N=_LOGITS_BLOCK_N,
+            NUM_SPLITS=splits,
+            num_warps=4,
+        )
+        # Positions >= seq_len are left uninitialised, exactly as the
+        # single-chunk gather path leaves them; every consumer masks by
+        # seq_lens.
+        return out
+
+    block_n = 16
     gathered_k = torch.empty(
-        (weighted_q.shape[0], max_seq_len, _INDEX_HEAD_DIM),
+        (total_rows, max_seq_len, _INDEX_HEAD_DIM),
         dtype=torch.float16,
         device=q.device,
     )
-    block_n = 16
-    _dequant_paged_index_k_kernel[
-        (weighted_q.shape[0], triton.cdiv(max_seq_len, block_n))
-    ](
+    _dequant_paged_index_k_kernel[(total_rows, triton.cdiv(max_seq_len, block_n))](
         cache,
         block_table,
         flat_lens,
         gathered_k,
         cache.stride(0),
-        cache.stride(1),
         block_table.stride(0),
         gathered_k.stride(0),
         gathered_k.stride(1),


### PR DESCRIPTION
## Purpose

Two independent defects in the SM70 lightning-indexer path. Both only bite once top-k is actually selective, i.e. at long context — which is why the 8k bring-up (#184, #159) looked clean.

### 1. The paged decode kernels read a block-major cache as token-interleaved

`indexer_k_quant_and_cache` / `cp_gather_indexer_k_quant_cache` (`csrc/libtorch_stable/cache_kernels.cu`) store, **per block**, all `block_size` rows of 128 FP8 values first and only then that block's FP32 scales:

```
value: block_base + pos_in_block * 128 + d
scale: block_base + block_size * 128 + pos_in_block * 4
```

Every Triton kernel in `sm70/indexer.py` instead assumed a per-token `[128 values][4-byte scale]` record at `pos_in_block * cache.stride(1)`:

```python
token_ptr = cache_ptr + physical_block.to(tl.int64) * cache_stride0 \
                      + pos_in_block * cache_stride1
scale_ptr = (token_ptr + head_dim).to(tl.pointer_type(tl.float32))
```

Only token 0 of each block read the right *values*, and **no** token read the right scale — what it picked up was four FP8 value bytes reinterpreted as FP32. Measured in situ: 6943 of 13802 scales negative, spanning ±1e36..1e38.

Prefill was unaffected because it gathers through the layout-aware C++ kernel, so retrieval looked perfect there (needle at rank 0–16 of 13801) while decode was broken (rank 43–3323, **0 of 8** needle keys kept). That asymmetry is what made this look like "long-context quality decay" rather than a bug.

Fixed with a shared `_index_cache_ptrs()` helper so the layout is stated once.

### 2. The scoring function dropped the per-head ReLU

The model computes

```
I[t, s] = sum_h weights[t, h] * relu(q[t, h] . k[s])
```

(reference `Indexer.forward`, `inference/model.py:427`; the in-repo `fp8_mqa_logits` reference at `v1/attention/ops/rocm_aiter_mla_sparse.py:510` applies the same ReLU, and every non-SM70 backend applies it inside its logits kernel). SM70 computed

```
(sum_h weights[t, h] * q[t, h]) . k[s]
```

folding the weights out through a nonlinearity. That is 64× cheaper and a different function: on random data the induced top-512 sets agree only 51–66%.

### Result

Needle-in-a-haystack, ctx {4k, 16k, 64k} × depth {0.25, 0.5, 0.75}: **5/9 → 9/9 EXACT**. Extending the grid to ctx {128k, 240k} × the same depths gives a further **6/6 EXACT** after the fix (207,202-token prompts); no pre-fix baseline was taken at those two lengths, so that half is an after-only result. 15/15 EXACT from 4k to 207k with the fix in place.

### Making the ReLU affordable

The correct form is 64× the flops of the factored one, and Triton's `tl.dot` does not reach Volta's tensor cores: on this shape it measures **3.3 TFLOP/s** against **54** for cuBLAS fp16 and **13** for plain fp32 CUDA cores. No tiling fixes it — folding heads into M to get a `[256,128]x[128,64]` MMA measured 3.34. Prefill scoring therefore goes through `torch.mm` as one `[tokens*heads, 128] x [128, key_tile]` GEMM with a fused Triton `relu → weight → head-sum → key-scale` epilogue; keys are tiled to bound the score tile.

- Standalone: **3.39 → 18.1 TFLOP/s**
- In-engine 207k-token prefill: **768 s → 350 s** (128k: 268 → 148 s)
- Retrieval unchanged at 6/6 EXACT

Both scoring paths stay available for A/B: `VLLM_SM70_INDEXER_RELU=0` restores the factored form, `VLLM_SM70_INDEXER_PREFILL_CUBLAS=0` the Triton MMA.

## Test Plan

```bash
pytest tests/kernels/test_deepseek_v4_sm70_indexer.py -v
```

**`test_sm70_indexer_prefill_dequantizes_fp8_storage_as_uint8` had to be replaced, not extended.** Its expected value *was* the factored form:

```python
weighted_q = torch.sum(q.float() * weights[:, :, None], dim=1).half()
expected = torch.mm(weighted_q, k_reference.T, out_dtype=torch.float32)
```

i.e. the test encoded defect 2 as its reference, so restoring the ReLU necessarily turns it red. The replacement scores against `sum_h w * relu(q . k)` directly. It also keeps FP8 keys as exact bit patterns (a small palette: `0x38 = 1.0`, `0xB8 = -1.0`, …) so the reference needs no native FP8 conversion, which SM70 lacks — the property the old test was written for is preserved.

Six tests, all on the SM70 gate already used by this file:

| test | pins |
|---|---|
| `test_prefill_matches_the_reference_scoring_function[True/False]` | both prefill paths (cuBLAS and Triton MMA) against `sum_h w·relu(q·k)`; also asserts the factored form is *not* within tolerance, so the ReLU cannot be silently dropped again |
| `test_prefill_relu_off_restores_the_factored_form` | the `VLLM_SM70_INDEXER_RELU=0` A/B escape hatch still works |
| `test_decode_reads_the_block_major_paged_cache[relu / factored-fused / factored-gather]` | all three decode paths, against a cache built in the **real** block-major layout with **distinct per-token scales** and a shuffled block table |

The decode test is what pins defect 1: with one scale per block, or an identity block table, the layout bug is invisible.

## Test Result

Hardware: 8× Tesla V100-SXM2-32GB (DGX-1), CUDA 12.9, Python 3.12. One GPU.

```
test_prefill_matches_the_reference_scoring_function[True]      PASSED
test_prefill_matches_the_reference_scoring_function[False]     PASSED
test_prefill_relu_off_restores_the_factored_form               PASSED
test_decode_reads_the_block_major_paged_cache[relu]            PASSED
test_decode_reads_the_block_major_paged_cache[factored-fused]  PASSED
test_decode_reads_the_block_major_paged_cache[factored-gather] PASSED
6 passed in 5.34s
```

Against the pre-fix decode kernel, the same inputs give (per row, vs the factored reference so the ReLU is not the variable):

```
row 0 seq_len=  1  token0_ok=False  max_abs_err=5.985  ref_absmax=5.985  within_1pct=0/1
row 1 seq_len= 65  token0_ok=False  max_abs_err=774.4  ref_absmax=36.43  within_1pct=0/65
row 2 seq_len=187  token0_ok=False  max_abs_err=nan    ref_absmax=25.99  within_1pct=1/187
```

The `nan` is a misread scale: four FP8 value bytes reinterpreted as FP32 overflow the fp16 gather.

End-to-end, on `DeepSeek-V4-Flash-0731`, TP8, `max_model_len 262144`:

| | needle 4k–64k (9 pts) | needle 128k/240k (6 pts) | 207k prefill | 128k prefill |
|---|---|---|---|---|
| before | 5/9 EXACT | not measured | 768 s | 268 s |
| after | **9/9 EXACT** | **6/6 EXACT** | **350 s** | **148 s** |

The prefill timings are a single run each; local run-to-run noise on this box is around ±11%, so treat the magnitude as approximate — the direction is well outside it.

Also ran the rest of the SM70 DeepSeek-V4 kernel tests. **20 failures in `tests/kernels/test_fused_indexer_q_rope_quant.py` are pre-existing on `main` @ `7aede2cf01`** — verified by running that file on a clean checkout of `main` in the same environment (20 failed there too). Nothing in this PR changes them.

Lint: `ruff 0.14.0` `check` and `format` clean.

## Notes

- **Not a duplicate.** `gh pr list --repo 1CatAI/1Cat-vLLM --state all --search "indexer relu"` / `"sparse indexer"` returns only #184 (CLOSED) and #159 (MERGED), both 8k bring-up / long-context work that predates this path. No open PR touches `vllm/models/deepseek_v4/sm70/indexer.py`. Both defects are live on `main` today.
- **AI assistance was used** (Claude Opus 5) for the investigation, the patch and the tests. Every changed line has been reviewed by the submitter, and the commands and results above were run on the hardware described.
