### PR TITLE
[Bugfix] Disable YaRN on DeepSeek-V4's sliding-window-only layers

### DIFF
--- a/tests/model_executor/test_deepseek_v4_swa_rope.py
+++ b/tests/model_executor/test_deepseek_v4_swa_rope.py
@@ -1,0 +1,137 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""YaRN must be off on DeepSeek-V4's sliding-window-only layers.
+
+For compress_ratio == 0 layers the reference passes original_seq_len=0 to
+precompute_freqs_cis (inference/model.py:481-486), which skips the correction
+range entirely and leaves plain rope at the base rope_theta. Swapping only
+rope_theta and leaving rope_type="deepseek_yarn" with factor=16 keeps the
+interpolation on for those layers.
+"""
+
+import math
+
+import pytest
+import torch
+
+from vllm.model_executor.layers.rotary_embedding import get_rope
+from vllm.platforms import current_platform
+
+# DeepSeek-V4-Flash config.json.
+_HEAD_SIZE = 512
+_ROPE_DIM = 64
+_MAX_POSITION = 262144  # served context; the model passes max_position_embeddings
+_ORIGINAL_MAX_POSITION = 65536
+_YARN_FACTOR = 16
+_ROPE_THETA = 10000  # SWA-only layers; compressing layers use 160000
+_SWA_WINDOW = 128
+
+
+@pytest.fixture(autouse=True)
+def _default_device():
+    """DeepseekV4ScalingRotaryEmbedding builds its position grid on
+    current_platform.device_type but its inv_freq on the default device, so it
+    only assembles under the device context the model loader already sets."""
+    with torch.device(current_platform.device_type):
+        yield
+
+
+def _rope_parameters(factor: int, original_max_position: int) -> dict:
+    """What DeepseekV4Attention hands get_rope for a compress_ratio<=1 layer."""
+    return {
+        "rope_type": "deepseek_yarn",
+        "beta_fast": 32,
+        "beta_slow": 1,
+        "factor": factor,
+        "original_max_position_embeddings": original_max_position,
+        "rope_theta": _ROPE_THETA,
+        "mscale": 0,
+        "mscale_all_dim": 0,
+        "is_deepseek_v4": True,
+        "rope_dim": _ROPE_DIM,
+    }
+
+
+def _get_rope(factor: int, original_max_position: int):
+    return get_rope(
+        _HEAD_SIZE,
+        max_position=_MAX_POSITION,
+        rope_parameters=_rope_parameters(factor, original_max_position),
+        is_neox_style=False,
+    )
+
+
+def _plain_inv_freq() -> torch.Tensor:
+    exponents = torch.arange(0, _ROPE_DIM, 2, dtype=torch.float32) / _ROPE_DIM
+    return 1.0 / (_ROPE_THETA**exponents)
+
+
+def test_factor_one_is_exactly_plain_rope(default_vllm_config) -> None:
+    """factor=1 collapses YaRN to an identity, so no class swap is needed.
+
+    DeepseekV4ScalingRotaryEmbedding is what the fused kernels expect: it
+    rotates the *last* rotary_dim and keeps cos/sin in fp32. Neither is true of
+    the base RotaryEmbedding, so "turn YaRN off" has to mean factor=1, not
+    rope_type="default".
+    """
+    swa = _get_rope(1, _MAX_POSITION)
+
+    assert swa.mscale == 1.0
+    # inv_freq_interpolation == inv_freq_extrapolation at factor=1, so the ramp
+    # blend `a * (1 - m) + a * m` is algebraically `a`; in fp32 it lands within
+    # a couple of ulp on the two pairs where the mask is neither 0 nor 1.
+    torch.testing.assert_close(
+        swa._compute_inv_freq(swa.scaling_factor),
+        _plain_inv_freq(),
+        rtol=1e-6,
+        atol=0,
+    )
+    # Cache length is original_max_position * factor, so original_max_position
+    # has to carry the full range once factor is 1.
+    assert swa.cos_sin_cache.shape[0] == _MAX_POSITION
+
+
+def test_yarn_config_still_interpolates_the_low_frequency_pairs(
+    default_vllm_config,
+) -> None:
+    """The unfixed config is a real divergence, not a no-op."""
+    yarn = _get_rope(_YARN_FACTOR, _ORIGINAL_MAX_POSITION)
+
+    yarn_inv_freq = yarn._compute_inv_freq(yarn.scaling_factor)
+    plain = _plain_inv_freq()
+    assert not torch.allclose(yarn_inv_freq, plain)
+
+    # Only the low-frequency pairs move: high-frequency pairs sit above the
+    # correction range and extrapolate unchanged.
+    moved = (yarn_inv_freq != plain).nonzero().flatten().tolist()
+    assert moved and min(moved) >= _ROPE_DIM // 4
+
+    # Accumulated rotation error across one 128-token SWA window.
+    worst_radians = ((plain - yarn_inv_freq).abs() * (_SWA_WINDOW - 1)).max().item()
+    assert 0.0 < math.degrees(worst_radians) < 5.0
+
+
+def test_shared_rope_parameters_dict_must_not_be_mutated(default_vllm_config) -> None:
+    """A shared rope_parameters dict must not be mutated in place.
+
+    DeepseekV4Attention reads config.rope_parameters itself, and every later
+    layer reads it back, so setting factor=1 in place would disable YaRN
+    model-wide.
+    """
+    shared = _rope_parameters(_YARN_FACTOR, _ORIGINAL_MAX_POSITION)
+    before = dict(shared)
+
+    swa_parameters = dict(shared)
+    swa_parameters["factor"] = 1
+    swa_parameters["original_max_position_embeddings"] = _MAX_POSITION
+    get_rope(
+        _HEAD_SIZE,
+        max_position=_MAX_POSITION,
+        rope_parameters=swa_parameters,
+        is_neox_style=False,
+    )
+
+    assert shared == before
+    compressing = _get_rope(_YARN_FACTOR, _ORIGINAL_MAX_POSITION)
+    assert compressing.scaling_factor == _YARN_FACTOR

--- a/vllm/models/deepseek_v4/nvidia/model.py
+++ b/vllm/models/deepseek_v4/nvidia/model.py
@@ -718,6 +718,27 @@ class DeepseekV4Attention(nn.Module):
         rope_parameters["mscale_all_dim"] = 0  # Disable mscale
         rope_parameters["is_deepseek_v4"] = True
         rope_parameters["rope_dim"] = self.rope_head_dim
+        if self.compress_ratio <= 1:
+            # The sliding-window-only layers get base rope_theta above, but the
+            # reference also turns YaRN itself off for them: it passes
+            # original_seq_len=0, and precompute_freqs_cis then skips the
+            # correction range entirely (inference/model.py:481-486, :227).
+            # Swapping only theta leaves the interpolation on, which shifts the
+            # low-frequency pairs by up to ~2 degrees across the 128-token
+            # window. factor=1 makes the interpolation an exact identity
+            # (inv_freq_interpolation == inv_freq_extrapolation) and mscale
+            # collapses to 1.0, so this is plain rope without swapping the
+            # class -- DeepseekV4ScalingRotaryEmbedding still rotates the last
+            # rotary_dim and keeps the cache in fp32, which the fused kernels
+            # require. Copy first: the dict is config.rope_parameters itself
+            # and every later layer reads it back.
+            rope_parameters = dict(rope_parameters)
+            rope_parameters["factor"] = 1
+            # Cache length is original_max_position * factor, so it has to
+            # carry the full position range now that factor is 1.
+            rope_parameters["original_max_position_embeddings"] = (
+                self.max_position_embeddings
+            )
         self.rotary_emb = get_rope(
             self.head_dim,
             max_position=self.max_position_embeddings,


### PR DESCRIPTION
## Purpose

`DeepseekV4Attention.__init__` switches the rope base for sliding-window-only layers but leaves YaRN itself on:

```python
rope_parameters["rope_theta"] = (
    config.compress_rope_theta if self.compress_ratio > 1 else config.rope_theta
)
```

The reference goes further. For `compress_ratio == 0` layers it passes `original_seq_len=0` to `precompute_freqs_cis` (`inference/model.py:481-486`), and `precompute_freqs_cis` then skips the correction range entirely (`:227`) — plain rope at the base `rope_theta`.

The engine swapped the theta but kept `rope_type="deepseek_yarn"` with `factor=16` and `original_max_position_embeddings=65536`, so the interpolation stayed on for those **5 of 46 layers**.

**Magnitude, stated honestly:** at most **2.12 degrees** of accumulated rotation across the 128-token window, on rope pairs 21–31 — precisely the low-frequency dims whose rotation over such a short window is tiny. This is a correctness/faithfulness fix, not a measurable quality win. It is a real divergence from the checkpoint, and it is 21 lines.

### Why `factor=1` and not `rope_type="default"`

`factor=1` makes `inv_freq_interpolation == inv_freq_extrapolation`, so the YaRN ramp blend `a*(1-m) + a*m` is algebraically the identity, and `yarn_get_mscale` collapses to 1.0. Crucially it keeps `DeepseekV4ScalingRotaryEmbedding`, which

- rotates the **last** `rotary_dim`, and
- holds its cos/sin cache in **fp32**,

both of which the fused kernels depend on and neither of which the base `RotaryEmbedding` provides. Swapping the class would be the larger, riskier change.

`original_max_position_embeddings` has to carry the full range, because the cache length is `original_max_position * factor` and factor is now 1.

**The dict is copied first.** `rope_parameters` *is* `config.rope_parameters`, and every later layer reads it back — mutating it in place would disable YaRN model-wide.

## Test Plan

```bash
pytest tests/model_executor/test_deepseek_v4_swa_rope.py -v
```

Three tests, using the real `DeepSeek-V4-Flash` config values (`rope_dim=64`, `rope_theta=10000`, `factor=16`, `original_max_position_embeddings=65536`, `beta_fast=32`, `beta_slow=1`):

- `test_factor_one_is_exactly_plain_rope` — `mscale == 1.0`, `inv_freq` equals plain `1/theta^(2i/d)`, and the cos/sin cache covers the full position range.
- `test_yarn_config_still_interpolates_the_low_frequency_pairs` — the *unfixed* configuration really does move `inv_freq`; only pairs at or above `rope_dim/4` move; the worst accumulated rotation across a 128-token window is under 5 degrees. This is the "is it actually a bug" check.
- `test_shared_rope_parameters_dict_must_not_be_mutated` — pins the copy-before-edit contract.

**Scope of the tests, stated plainly:** these pin the rope-level claims. They do not construct a `DeepseekV4Attention`, so they do not by themselves regression-test the *layer selection* (`compress_ratio <= 1`) — that needs a full `VllmConfig` plus distributed init, which would be a larger change than the fix. The layer wiring was verified end-to-end instead (below). Happy to extract the rope-parameter derivation into a testable helper if maintainers would prefer that.

## Test Result

Hardware: 8× Tesla V100-SXM2-32GB, CUDA 12.9, Python 3.12.

```
test_factor_one_is_exactly_plain_rope                          PASSED
test_yarn_config_still_interpolates_the_low_frequency_pairs    PASSED
test_shared_rope_parameters_dict_must_not_be_mutated           PASSED
3 passed in 1.75s
```

One nuance the tests surfaced and now document: the ramp blend is the identity *algebraically*, but in fp32 two of the 32 pairs land ~6e-8 relative away from plain rope (the pairs where the ramp mask is neither 0 nor 1). The test uses `rtol=1e-6, atol=0` rather than claiming bit-exactness.

End-to-end on `DeepSeek-V4-Flash-0731`, TP8, `max_model_len 262144`: needle-in-a-haystack **6/6 EXACT at 128k and 240k**, unchanged — as expected for a 2-degree correction on the low-frequency dims of a 128-token window.

Lint: `ruff 0.14.0` `check` and `format` clean.

## Notes

- **Not a duplicate.** `gh pr list --repo 1CatAI/1Cat-vLLM --state all --search "yarn"` / `"rope sliding window"` returns #241 (open, a patch-set replay that touches NTK in `vllm/config/`, `envs.py` and the entrypoints — not `models/deepseek_v4/`), #238 (closed) and #59 (closed, gemma-4). No open PR touches `vllm/models/deepseek_v4/nvidia/model.py`.
- **`amd/model.py:320` has the same divergence.** It is left alone here because there is no AMD hardware on this side to verify against; flagging it for whoever has one.
- **AI assistance was used** (Claude Opus 5) for the investigation, the patch and the tests. Every changed line has been reviewed by the submitter, and the commands and results above were run on the hardware described.
