### PR TITLE
[Core] Backport DFlash2 with SM70 correctness

### DIFF
--- a/docs/design/sm70_v100_migration_control.md
+++ b/docs/design/sm70_v100_migration_control.md
@@ -42,8 +42,88 @@ Goal:
   DFlash input-preparation test passes on V100 after supplying the KV-group
   initialization contract used in production. Two unrelated DDTree metadata
   assertions fail identically on the frozen base and are recorded as pre-existing.
-- No speed or acceptance claim is made until DFlash2 eager correctness, graph
-  equivalence, and same-stack dense-selector baselines pass.
+- Draft PR #253 is the PR2 review scope on
+  `codex/v100-dflash2-sm70-20260820-044011`, based only on PR1. Its worktree is
+  `/home/ymzx/桌面/1cat-vllm/worktrees/v100-dflash2-sm70-20260820-044011`.
+
+### PR2 DFlash2 correctness evidence, 2026-08-20
+
+- Checkpoint contract is frozen at
+  `incoai/Qwen3.8-27B-DFlash2@dedf8df68adfb1afeaf7b7480c0a0243108177b4`.
+  The retained local `model.safetensors` SHA256 is
+  `67fc76d68dc5a9415511a4f394ef744d67510cd20e93b37cc2cc7d28e4bab65c`.
+  Its architecture is `DFlash2DraftModel`, selector K is 16, block size is 8,
+  attention is non-causal with sliding window 2048, and checkpoint layer IDs
+  `[5,19,33,47,61]` map to target hidden boundaries `[6,20,34,48,62]`.
+- The dependency closure now contains the official grouped convolution,
+  selector codebooks, TP-aware candidate top-K, DFlash2 MRV2 walk/cache, FP32
+  proposal scores, rejection `log1p`, and a separate selector compile-cache
+  tag. FlashInfer top-K is capability-gated and is never called on SM70.
+- The SM70-only numeric adaptation keeps FP32 residual state, explicit BF16
+  round-to-nearest-even points, scaled FP16 attention and gate-up projections,
+  and per-row power-of-two SwiGLU transport. The seventh selector slot uses a
+  separate Volta tail kernel; other architectures retain the upstream walk.
+- Flash-V100 graph capture now binds DFlash's K+1 non-causal query directly to
+  persistent paged-prefix metadata. The causal small-query decode branch is
+  unavailable to a non-causal draft. Target E5M2 and draft FP16 KV pages are
+  unified without truncating hybrid Mamba physical padding.
+- Single-request eager and CUDA Graph runs produced the exact same 16 token IDs,
+  hash `6de4c3f326c76ecc1b31b8026501ddf22f73a34b53b2fc46c622dee6b4a2d995`,
+  candidate lattice, acceptance trace, and draft KV. The graph artifact is
+  `/data/minimax-h3/task-cache/v100-dflash2-20260820/pr2/dflash2-graph-greedy16-fixed.json`;
+  the matched eager artifact is `dflash2-eager-noncausal-fixed16.json`.
+- Matched batch-2 eager/graph runs generated 96 and 61 tokens with identical
+  hashes and all acceptance counters. CUDA Graph batch-4 generated mixed
+  lengths 64/61/64/64 without OOB, stale-buffer, NaN, or replay corruption;
+  each result matched the corresponding eager prefix. Retained artifacts are
+  `dflash2-{eager,graph}-gsm8k-mixed-b2-2x96-greedy.json` and
+  `dflash2-graph-gsm8k-mixed-b4-4x64-greedy.json` under the PR2 cache directory.
+- On four fixed GSM8K prompts with the Qwen3.8 xhigh chat template and official
+  target sampling, greedy drafting emitted 421 tokens with mean accepted length
+  4.1068 and per-position acceptance
+  `[.8544,.6505,.4854,.4175,.3301,.2233,.1456]`. Probabilistic drafting emitted
+  452 tokens with mean 4.2407. These short V100/FP8 results are correctness and
+  sampling diagnostics, not a like-for-like replacement for the published
+  H200/BF16 acceptance figures.
+- The fixed 32-to-16 graph diagnostic reported 80.11 steady decode tok/s versus
+  18.72 eager with exact token/acceptance equality. The matched batch-2 run was
+  116.67 tok/s graph versus 43.53 eager. These are short diagnostic shapes and
+  are not a target-only or dense-selector paired performance gate.
+- DFlash1 remains on the official MRV2 speculator for the local 9B, 27B, and
+  35B-A3B checkpoints. A real 9B-AWQ/FP16-draft eager smoke produced eight
+  tokens, hash `2a205303e4c2b54b62d7562643abcaa425952d7dbcf3f3c1a4b6a4e3e3634be9`,
+  accepted length 3.5, and confirmed Flash-V100 routing. The artifact is
+  `/data/minimax-h3/task-cache/v100-dflash2-20260820/pr2/dflash1-9b-awq-mrv2-eager-route.json`.
+- Existing MTP was not replaced. A real Qwen3.8 TP4 MTP4 probabilistic smoke
+  confirmed native MTP, local argmax, Flash-V100, and E5M2 routes; it emitted 32
+  tokens with accepted length 4.25 and per-position acceptance
+  `[1.0,1.0,.75,.5]`. The artifact is
+  `/data/minimax-h3/task-cache/v100-dflash2-20260820/pr2/dflash2-mtp4-qwen38-regression-eager.json`.
+- Focused results: DFlash2/config/SM70 CPU matrix `107 passed, 1 skipped`;
+  DFlash MRV2 config `7 passed`; V100 rejection sampling `14 passed`; V100
+  probabilistic selector score-cache `1 passed`; Ruff passed on every changed
+  Python file. The DDTree targeted matrix remains `71 passed, 1 failed`, with
+  the one shared-storage assertion reproduced identically on PR1. Three stale
+  MTP step-index helper failures also reproduce on PR1; their 19 unaffected
+  cases pass. Four Eagle tests that require the gated Llama-3.1 config stop at
+  Hugging Face 401 on both PR1 and PR2; the local DFlash/Eagle compatibility
+  test itself passes.
+- Qwen3.8 exposes only hybrid `align` prefix caching, while the current MRV2
+  runner has no align-state preprocessing. SM70 server defaults therefore set
+  prefix caching off for explicit DFlash, and an explicit DFlash+hybrid-prefix
+  request now fails early with a precise error. Target-prefix hit plus draft-KV
+  rebuild remains an open PR2 dependency; no cross-request prefix claim is made.
+- Numeric classification for the DFlash non-causal paged attention route is
+  still `B-pending`, not silently accepted. Aligned DFlash shapes at sequence
+  lengths 8/69/512/2048 show semantic-boundary paged-vs-dense maxima
+  `0/2.44e-4/1.22e-4/6.10e-5`, all below the FP16 `2e-3` bound and not growing
+  with length. Scaling V by 256 reproduces raw differences up to 0.0625, which
+  become at most 2.44e-4 after the model's required `/256` range restoration.
+  The retained evidence is
+  `/data/minimax-h3/task-cache/v100-dflash2-20260820/pr2/dflash2-noncausal-paged-attention-exactness.json`.
+  Same-tile basis probes do not yet reduce every key to exact zero, so the
+  mechanical reduction-order proof remains open and PR3 default enablement is
+  blocked on it.
 
 Main implementation priority:
 

--- a/docs/design/sm70_v100_migration_control.md
+++ b/docs/design/sm70_v100_migration_control.md
@@ -99,31 +99,62 @@ Goal:
   tokens with accepted length 4.25 and per-position acceptance
   `[1.0,1.0,.75,.5]`. The artifact is
   `/data/minimax-h3/task-cache/v100-dflash2-20260820/pr2/dflash2-mtp4-qwen38-regression-eager.json`.
-- Focused results: DFlash2/config/SM70 CPU matrix `107 passed, 1 skipped`;
-  DFlash MRV2 config `7 passed`; V100 rejection sampling `14 passed`; V100
-  probabilistic selector score-cache `1 passed`; Ruff passed on every changed
-  Python file. The DDTree targeted matrix remains `71 passed, 1 failed`, with
+- Final changed-path gate: SM70 arguments plus KV layout, DFlash2/MRV2 routing,
+  and warmup reservation total `113 passed, 1 skipped` on CPU; the dedicated
+  V100 Mamba align kernels add `5 passed`. The new warmup matrix covers MRV2
+  DFlash K+1, DDTree tree-budget lookahead, unchanged Eagle/MTP/DSpark values,
+  and align/non-align Mamba speculative tails. Earlier V100 rejection sampling
+  remains `14 passed` and probabilistic selector score-cache `1 passed`; Ruff
+  passes every changed Python file. The DDTree targeted matrix remains
+  `71 passed, 1 failed`, with
   the one shared-storage assertion reproduced identically on PR1. Three stale
   MTP step-index helper failures also reproduce on PR1; their 19 unaffected
   cases pass. Four Eagle tests that require the gated Llama-3.1 config stop at
   Hugging Face 401 on both PR1 and PR2; the local DFlash/Eagle compatibility
   test itself passes.
-- Qwen3.8 exposes only hybrid `align` prefix caching, while the current MRV2
-  runner has no align-state preprocessing. SM70 server defaults therefore set
-  prefix caching off for explicit DFlash, and an explicit DFlash+hybrid-prefix
-  request now fails early with a precise error. Target-prefix hit plus draft-KV
-  rebuild remains an open PR2 dependency; no cross-request prefix claim is made.
+- MRV2 now implements the upstream hybrid Mamba `align` state migration on the
+  GPU without changing the V1 DDTree state-selection path. The new-request
+  state column is seeded from the resolved `MambaSpec.block_size`, not the
+  smaller global cache block size; this is required when E5M2 target pages and
+  FP16 DFlash pages share a hybrid pool. Upstream hash-layout fix #51180 is also
+  included so aligned Mamba groups retain the finest divisible hash unit.
+- Prefix correctness is accepted for the real Qwen3.8-27B-FP8 TP4 route. With
+  the resolved target Full/Mamba block size 3296 and draft SWA block size 1648,
+  a 3505-token prompt produced a 3296-token hit on the second request. Eager
+  kept the exact 16-token hash `a2c583fc17c7...`, accepted length 6.6667, and
+  per-position counts `[3,3,3,2,2,2,2]`; TTFT changed from 1.117s to 0.303s.
+  CUDA Graph kept the same token and acceptance trace with TTFT
+  1.119s to 0.174s. Artifacts are `dflash2-prefix-tp4-{eager,graph}-4k.json`
+  under the PR2 cache directory.
+- A paired target-only TP4 probe hit 3136 tokens with exact output and TTFT
+  1.010s to 0.167s (`qwen38-prefix-tp4-target-only-eager-4k.json`). This
+  separates target Mamba-state restoration from DFlash proposal correctness.
+  No separate cross-request draft-prefix index or persistence layer was added;
+  the accepted same-process path uses the existing unified hybrid block cache,
+  while an ordinary miss rebuilds draft context KV during DFlash proposal.
 - Numeric classification for the DFlash non-causal paged attention route is
-  still `B-pending`, not silently accepted. Aligned DFlash shapes at sequence
-  lengths 8/69/512/2048 show semantic-boundary paged-vs-dense maxima
+  `B-accept`, with its layout component separately passing Type A. Aligned
+  DFlash shapes at sequence lengths 8/69/512/2048 show semantic-boundary
+  paged-vs-dense maxima
   `0/2.44e-4/1.22e-4/6.10e-5`, all below the FP16 `2e-3` bound and not growing
   with length. Scaling V by 256 reproduces raw differences up to 0.0625, which
   become at most 2.44e-4 after the model's required `/256` range restoration.
+  Reversing every physical KV page and applying the matching block-table
+  permutation is bitwise exact for every shape, proving page addressing,
+  layout, mask, and KV-source alignment. The bounded cross-kernel residual is
+  mechanically explained by the source arithmetic: for D != 256, dense
+  Flash-V100 scales QK by `log2(e)` and evaluates `exp2f`, whereas paged
+  Flash-V100 retains natural-log scores and evaluates `expf`. These are
+  mathematically equivalent reductions with different FP16 rounding. The
+  release extension was built from paged-kernel source SHA256
+  `9be6b237fcd1c89653c26460054c1c25edd6e7d8f9685f7b9f4b83a2f1ba5e58`,
+  identical to the integration source; an older independently built extension
+  produced the same case-by-case results.
   The retained evidence is
   `/data/minimax-h3/task-cache/v100-dflash2-20260820/pr2/dflash2-noncausal-paged-attention-exactness.json`.
-  Same-tile basis probes do not yet reduce every key to exact zero, so the
-  mechanical reduction-order proof remains open and PR3 default enablement is
-  blocked on it.
+  Together with exact eager/graph model tokens, candidates, acceptance trace,
+  and draft KV, the attention numeric gate no longer blocks PR3. This does not
+  relax the separate fused-selector performance and exact-token gates.
 
 Main implementation priority:
 

--- a/tests/engine/test_arg_utils.py
+++ b/tests/engine/test_arg_utils.py
@@ -237,7 +237,13 @@ def _fake_qwen_hybrid_model_config():
     )
 
 
-def _apply_sm70_defaults(monkeypatch, *, env=None, speculative_config=None):
+def _apply_sm70_defaults(
+    monkeypatch,
+    *,
+    env=None,
+    speculative_config=None,
+    enable_prefix_caching=None,
+):
     for key in (
         "VLLM_1CAT_ENABLE_SM70_MTP_DEFAULTS",
         "VLLM_1CAT_ENABLE_QWEN35_MTP_DEFAULTS",
@@ -249,7 +255,11 @@ def _apply_sm70_defaults(monkeypatch, *, env=None, speculative_config=None):
         monkeypatch.setenv(key, value)
     monkeypatch.setattr("vllm.engine.arg_utils.current_platform", _FakeSM70Platform())
 
-    args = EngineArgs(model="dummy", tensor_parallel_size=4)
+    args = EngineArgs(
+        model="dummy",
+        tensor_parallel_size=4,
+        enable_prefix_caching=enable_prefix_caching,
+    )
     args.speculative_config = speculative_config
     args._maybe_apply_sm70_mtp_defaults(
         UsageContext.OPENAI_API_SERVER,
@@ -337,6 +347,32 @@ def test_sm70_explicit_mtp_still_gets_safe_defaults(monkeypatch):
     assert args.enable_prefix_caching is True
     assert args.mamba_cache_mode == "align"
     assert args.max_num_seqs == 4
+
+
+def test_sm70_explicit_dflash_uses_greedy_without_unsupported_prefix_cache(
+    monkeypatch,
+):
+    args = _apply_sm70_defaults(
+        monkeypatch,
+        speculative_config={"method": "dflash", "num_speculative_tokens": 7},
+    )
+
+    assert args.speculative_config == {
+        "method": "dflash",
+        "num_speculative_tokens": 7,
+        "draft_sample_method": "greedy",
+    }
+    assert args.enable_prefix_caching is False
+    assert args.mamba_cache_mode == "none"
+
+
+def test_sm70_explicit_dflash_rejects_hybrid_prefix_cache(monkeypatch):
+    with pytest.raises(ValueError, match="align-mode prefix cache"):
+        _apply_sm70_defaults(
+            monkeypatch,
+            speculative_config={"method": "dflash", "num_speculative_tokens": 7},
+            enable_prefix_caching=True,
+        )
 
 
 @pytest.mark.parametrize(

--- a/tests/engine/test_arg_utils.py
+++ b/tests/engine/test_arg_utils.py
@@ -254,6 +254,9 @@ def _apply_sm70_defaults(
     for key, value in (env or {}).items():
         monkeypatch.setenv(key, value)
     monkeypatch.setattr("vllm.engine.arg_utils.current_platform", _FakeSM70Platform())
+    monkeypatch.setattr(
+        "vllm.engine.arg_utils.get_model_path", lambda model, revision: model
+    )
 
     args = EngineArgs(
         model="dummy",
@@ -349,9 +352,7 @@ def test_sm70_explicit_mtp_still_gets_safe_defaults(monkeypatch):
     assert args.max_num_seqs == 4
 
 
-def test_sm70_explicit_dflash_uses_greedy_without_unsupported_prefix_cache(
-    monkeypatch,
-):
+def test_sm70_explicit_dflash_uses_greedy_with_align_prefix_cache(monkeypatch):
     args = _apply_sm70_defaults(
         monkeypatch,
         speculative_config={"method": "dflash", "num_speculative_tokens": 7},
@@ -362,17 +363,19 @@ def test_sm70_explicit_dflash_uses_greedy_without_unsupported_prefix_cache(
         "num_speculative_tokens": 7,
         "draft_sample_method": "greedy",
     }
-    assert args.enable_prefix_caching is False
-    assert args.mamba_cache_mode == "none"
+    assert args.enable_prefix_caching is True
+    assert args.mamba_cache_mode == "align"
 
 
-def test_sm70_explicit_dflash_rejects_hybrid_prefix_cache(monkeypatch):
-    with pytest.raises(ValueError, match="align-mode prefix cache"):
-        _apply_sm70_defaults(
-            monkeypatch,
-            speculative_config={"method": "dflash", "num_speculative_tokens": 7},
-            enable_prefix_caching=True,
-        )
+def test_sm70_explicit_dflash_accepts_explicit_hybrid_prefix_cache(monkeypatch):
+    args = _apply_sm70_defaults(
+        monkeypatch,
+        speculative_config={"method": "dflash", "num_speculative_tokens": 7},
+        enable_prefix_caching=True,
+    )
+
+    assert args.enable_prefix_caching is True
+    assert args.mamba_cache_mode == "align"
 
 
 @pytest.mark.parametrize(

--- a/tests/engine/test_arg_utils.py
+++ b/tests/engine/test_arg_utils.py
@@ -352,7 +352,7 @@ def test_sm70_explicit_mtp_still_gets_safe_defaults(monkeypatch):
     assert args.max_num_seqs == 4
 
 
-def test_sm70_explicit_dflash_uses_greedy_with_align_prefix_cache(monkeypatch):
+def test_sm70_explicit_dflash_preserves_probabilistic_default(monkeypatch):
     args = _apply_sm70_defaults(
         monkeypatch,
         speculative_config={"method": "dflash", "num_speculative_tokens": 7},
@@ -361,19 +361,24 @@ def test_sm70_explicit_dflash_uses_greedy_with_align_prefix_cache(monkeypatch):
     assert args.speculative_config == {
         "method": "dflash",
         "num_speculative_tokens": 7,
-        "draft_sample_method": "greedy",
+        "draft_sample_method": "probabilistic",
     }
     assert args.enable_prefix_caching is True
     assert args.mamba_cache_mode == "align"
 
 
-def test_sm70_explicit_dflash_accepts_explicit_hybrid_prefix_cache(monkeypatch):
+def test_sm70_explicit_dflash_accepts_explicit_greedy(monkeypatch):
     args = _apply_sm70_defaults(
         monkeypatch,
-        speculative_config={"method": "dflash", "num_speculative_tokens": 7},
+        speculative_config={
+            "method": "dflash",
+            "num_speculative_tokens": 7,
+            "draft_sample_method": "greedy",
+        },
         enable_prefix_caching=True,
     )
 
+    assert args.speculative_config["draft_sample_method"] == "greedy"
     assert args.enable_prefix_caching is True
     assert args.mamba_cache_mode == "align"
 

--- a/tests/kernels/mamba/test_mrv2_mamba_align.py
+++ b/tests/kernels/mamba/test_mrv2_mamba_align.py
@@ -1,0 +1,196 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from vllm.platforms import current_platform
+from vllm.triton_utils import triton
+from vllm.v1.worker.gpu.mamba_align import (
+    preprocess_mamba_align_fused_kernel,
+    run_mamba_align_postprocess,
+    run_mamba_align_precopy,
+)
+
+pytestmark = pytest.mark.skipif(
+    not current_platform.is_cuda(), reason="MRV2 Mamba align needs CUDA/Triton"
+)
+
+
+def _make_context(
+    conv: torch.Tensor,
+    temporal: torch.Tensor,
+    block_table: torch.Tensor,
+    *,
+    block_size: int = 4,
+    max_num_reqs: int | None = None,
+) -> SimpleNamespace:
+    states = (conv, temporal)
+    device = block_table.device
+    return SimpleNamespace(
+        is_initialized=True,
+        num_layers=1,
+        num_state_types=2,
+        block_table_ptrs=torch.tensor(
+            [block_table.data_ptr()], dtype=torch.int64, device=device
+        ),
+        block_table_stride_req=block_table.stride(0),
+        state_base_addrs=torch.tensor(
+            [state.data_ptr() for state in states],
+            dtype=torch.int64,
+            device=device,
+        ),
+        state_block_strides=torch.tensor(
+            [state.stride(0) * state.element_size() for state in states],
+            dtype=torch.int64,
+            device=device,
+        ),
+        state_elem_sizes=torch.tensor(
+            [state.element_size() for state in states],
+            dtype=torch.int32,
+            device=device,
+        ),
+        state_inner_sizes=torch.tensor(
+            [conv.stride(1), temporal[0].numel()],
+            dtype=torch.int64,
+            device=device,
+        ),
+        state_conv_widths=torch.tensor(
+            [conv.size(1), 0], dtype=torch.int32, device=device
+        ),
+        state_group_indices=torch.zeros(2, dtype=torch.int32, device=device),
+        block_size=block_size,
+        num_accepted_tokens_out=torch.empty(
+            max_num_reqs or block_table.shape[0],
+            dtype=torch.int32,
+            device=device,
+        ),
+    )
+
+
+def test_mrv2_align_prefix_seed_uses_resolved_mamba_block_size() -> None:
+    device = torch.device("cuda")
+    # Batch order is intentionally different from persistent request-slot order.
+    idx_mapping = torch.tensor([1, 0], dtype=torch.int32, device=device)
+    state_idx = torch.full((2,), -2, dtype=torch.int32, device=device)
+    num_computed = torch.tensor([8, 0], dtype=torch.int32, device=device)
+    query_start_loc = torch.tensor([0, 1, 2], dtype=torch.int32, device=device)
+    num_accepted = torch.ones(2, dtype=torch.int32, device=device)
+    src_col = torch.empty(2, dtype=torch.int32, device=device)
+    token_bias = torch.empty(2, dtype=torch.int32, device=device)
+
+    preprocess_mamba_align_fused_kernel[(1,)](
+        idx_mapping,
+        state_idx,
+        num_computed,
+        query_start_loc,
+        num_accepted,
+        src_col,
+        token_bias,
+        2,
+        BLOCK_SIZE=triton.next_power_of_2(2),
+        MAMBA_BLOCK_SIZE=8,
+    )
+    torch.accelerator.synchronize()
+
+    # req0 resumes after one complete Mamba block and crosses into column 1;
+    # req1 is fresh and has no source state before entering column 0.
+    assert src_col.cpu().tolist() == [0, -1]
+    assert state_idx.cpu().tolist() == [1, 0]
+    assert token_bias.cpu().tolist() == [0, 0]
+
+
+@pytest.mark.parametrize("token_bias", [0, 1, 2])
+def test_mrv2_align_precopy_matches_v1_sd_semantics(token_bias: int) -> None:
+    torch.manual_seed(42)
+    device = torch.device("cuda")
+    num_reqs, num_cols = 4, 6
+    conv_width, conv_dim = 6, 128
+    num_blocks = num_reqs * num_cols + 1
+    block_table = torch.arange(1, num_blocks, dtype=torch.int32, device=device).reshape(
+        num_reqs, num_cols
+    )
+    conv = torch.randn(
+        num_blocks, conv_width, conv_dim, dtype=torch.float16, device=device
+    )
+    temporal = torch.randn(num_blocks, 4, 16, 16, dtype=torch.float32, device=device)
+    conv_before = conv.clone()
+    temporal_before = temporal.clone()
+
+    # State arrays use persistent request-slot order; block-table rows use
+    # current batch order. The non-identity mapping proves the two are not mixed.
+    src_col = torch.tensor([-1, 1, 1, 2], dtype=torch.int32, device=device)
+    dst_col = torch.tensor([0, 1, 2, 0], dtype=torch.int32, device=device)
+    bias = torch.tensor(
+        [0, 0, token_bias, token_bias], dtype=torch.int32, device=device
+    )
+    idx_mapping = torch.tensor([2, 0, 3, 1], dtype=torch.int32, device=device)
+
+    run_mamba_align_precopy(
+        _make_context(conv, temporal, block_table),
+        num_reqs,
+        dst_col,
+        src_col,
+        bias,
+        idx_mapping,
+    )
+    torch.accelerator.synchronize()
+
+    conv_ref = conv_before.clone()
+    temporal_ref = temporal_before.clone()
+    for batch_idx, req_idx in enumerate(idx_mapping.cpu().tolist()):
+        src = int(src_col[req_idx])
+        dst = int(dst_col[req_idx])
+        accepted_bias = int(bias[req_idx])
+        if src < 0 or src == dst:
+            continue
+        src_block = int(block_table[batch_idx, src])
+        dst_block = int(block_table[batch_idx, dst])
+        temporal_block = int(block_table[batch_idx, src + accepted_bias])
+        conv_ref[dst_block, : conv_width - accepted_bias] = conv_before[
+            src_block, accepted_bias:
+        ]
+        temporal_ref[dst_block] = temporal_before[temporal_block]
+
+    torch.testing.assert_close(conv, conv_ref, rtol=0, atol=0)
+    torch.testing.assert_close(temporal, temporal_ref, rtol=0, atol=0)
+
+
+def test_mrv2_align_postprocess_same_block_shift_is_exact() -> None:
+    torch.manual_seed(43)
+    device = torch.device("cuda")
+    conv_width, conv_dim = 6, 128
+    block_table = torch.tensor([[1, 2, 3, 4, 5]], dtype=torch.int32, device=device)
+    conv = torch.randn(6, conv_width, conv_dim, dtype=torch.float16, device=device)
+    temporal = torch.randn(6, 4, 16, 16, dtype=torch.float32, device=device)
+    conv_before = conv.clone()
+    temporal_before = temporal.clone()
+
+    # accepted=3 and new_computed=8 means running=6, aligned=8, bias=2.
+    # src_col == dst_col == 1 exercises the overlapping conv memmove.
+    accepted = torch.tensor([3, 1, 1, 1], dtype=torch.int32, device=device)
+    state_idx = torch.tensor([1, 0, 0, 0], dtype=torch.int32, device=device)
+    new_computed = torch.tensor([8, 0, 0, 0], dtype=torch.int32, device=device)
+    idx_mapping = torch.tensor([0], dtype=torch.int32, device=device)
+    run_mamba_align_postprocess(
+        _make_context(
+            conv, temporal, block_table, block_size=4, max_num_reqs=accepted.numel()
+        ),
+        1,
+        accepted,
+        state_idx,
+        new_computed,
+        idx_mapping,
+    )
+    torch.accelerator.synchronize()
+
+    dst_block = int(block_table[0, 1])
+    temporal_src_block = int(block_table[0, 3])
+    conv_ref = conv_before.clone()
+    temporal_ref = temporal_before.clone()
+    conv_ref[dst_block, : conv_width - 2] = conv_before[dst_block, 2:]
+    temporal_ref[dst_block] = temporal_before[temporal_src_block]
+    torch.testing.assert_close(conv, conv_ref, rtol=0, atol=0)
+    torch.testing.assert_close(temporal, temporal_ref, rtol=0, atol=0)
+    assert int(accepted[0]) == 1

--- a/tests/v1/core/test_kv_cache_utils.py
+++ b/tests/v1/core/test_kv_cache_utils.py
@@ -3,6 +3,7 @@
 import hashlib
 import importlib
 from collections.abc import Callable
+from types import SimpleNamespace
 from typing import Any
 
 import pytest
@@ -180,6 +181,37 @@ def new_mamba_spec(
         mamba_cache_mode=mamba_cache_mode,
         num_speculative_blocks=num_speculative_blocks,
     )
+
+
+def test_resolve_kv_cache_block_sizes_for_aligned_mamba_group():
+    """Aligned Mamba keeps fine-grained hashes after page-size unification."""
+    kv_cache_config = KVCacheConfig(
+        num_blocks=1,
+        kv_cache_tensors=[],
+        kv_cache_groups=[
+            KVCacheGroupSpec(["attention"], new_kv_cache_spec(block_size=16)),
+            KVCacheGroupSpec(
+                ["mamba"],
+                new_mamba_spec(block_size=1648, mamba_cache_mode="align"),
+            ),
+        ],
+    )
+    vllm_config = SimpleNamespace(
+        cache_config=SimpleNamespace(
+            block_size=16,
+            enable_prefix_caching=True,
+            hash_block_size=None,
+        ),
+        parallel_config=SimpleNamespace(
+            decode_context_parallel_size=1,
+            prefill_context_parallel_size=1,
+        ),
+        kv_transfer_config=None,
+    )
+
+    assert kv_cache_utils.resolve_kv_cache_block_sizes(
+        kv_cache_config, vllm_config
+    ) == (1648, 16)
 
 
 @pytest.mark.parametrize("hash_fn", [sha256, sha256_cbor])

--- a/tests/v1/spec_decode/test_dflash2.py
+++ b/tests/v1/spec_decode/test_dflash2.py
@@ -11,6 +11,7 @@ import vllm.model_executor.models.qwen3_dflash2 as dflash2_model
 import vllm.v1.attention.backends.flash_attn_v100 as flash_v100
 import vllm.v1.worker.gpu.attn_utils as attn_utils
 import vllm.v1.worker.gpu.spec_decode.dflash.speculator as dflash_speculator
+from vllm.config.speculative import SpeculativeConfig
 from vllm.model_executor.models.dflash_sm70 import (
     DFLASH_SM70_GATE_UP_INPUT_SCALE,
     DFLASH_SM70_WIDE_OUTPUT_SCALE,
@@ -221,6 +222,24 @@ def test_dflash1_architecture_stays_on_official_mrv2_speculator(monkeypatch):
         )
     )
     assert isinstance(init_speculator(config, torch.device("cpu")), DFlashSpeculator)
+
+
+@pytest.mark.parametrize(
+    ("method", "expected"),
+    [
+        ("dflash", False),
+        ("dflash_ddtree", True),
+        ("eagle3", True),
+        ("mtp", True),
+    ],
+)
+def test_only_mrv2_dflash_skips_eagle_prefix_block_drop(method, expected):
+    config = SimpleNamespace(
+        method=method,
+        use_eagle=lambda: True,
+        use_dflash=lambda: method == "dflash",
+    )
+    assert SpeculativeConfig.use_eagle_kv_cache(config) is expected
 
 
 @pytest.mark.parametrize("method", ["eagle3", "mtp"])

--- a/tests/v1/spec_decode/test_dflash2.py
+++ b/tests/v1/spec_decode/test_dflash2.py
@@ -1,0 +1,487 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+import torch
+
+import vllm.model_executor.models.qwen3_dflash2 as dflash2_model
+import vllm.v1.attention.backends.flash_attn_v100 as flash_v100
+import vllm.v1.worker.gpu.attn_utils as attn_utils
+import vllm.v1.worker.gpu.spec_decode.dflash.speculator as dflash_speculator
+from vllm.model_executor.models.dflash_sm70 import (
+    DFLASH_SM70_GATE_UP_INPUT_SCALE,
+    DFLASH_SM70_WIDE_OUTPUT_SCALE,
+    DFlashSM70RMSNorm,
+    dflash_scale_output_sm70,
+    dflash_silu_and_mul_sm70,
+)
+from vllm.model_executor.models.qwen3_dflash import (
+    DFlashQwen3ForCausalLM,
+    _dflash_layer_causal,
+)
+from vllm.model_executor.models.qwen3_dflash2 import _grouped_conv, _score_edges
+from vllm.v1.attention.backends.flash_attn_v100 import FlashAttnV100Impl
+from vllm.v1.core.kv_cache_utils import unify_kv_cache_spec_page_size
+from vllm.v1.kv_cache_interface import FullAttentionSpec, MambaSpec
+from vllm.v1.worker.gpu.spec_decode import init_speculator
+from vllm.v1.worker.gpu.spec_decode.dflash.speculator import DFlashSpeculator
+from vllm.v1.worker.gpu.spec_decode.dflash2.speculator import (
+    DFlash2Speculator,
+    _requires_sm70_tail,
+    _selector_walk_kernel,
+)
+
+
+@pytest.mark.parametrize("block_size", [4, 6, 8])
+def test_grouped_conv_matches_reference(block_size: int):
+    torch.manual_seed(0)
+    batch, taps, num_groups, group_size = 3, 3, 4, 2
+    hidden = torch.randn(batch * block_size, num_groups * group_size)
+    delta = torch.randn(batch * block_size, taps, num_groups)
+    base = torch.randn(taps, num_groups * group_size)
+
+    actual = _grouped_conv(
+        hidden, delta, base, block_size, num_groups, group_size, taps
+    )
+    hidden_blocks = hidden.view(batch, block_size, num_groups, group_size)
+    expected = torch.zeros_like(hidden_blocks)
+    base = base.view(taps, num_groups, group_size)
+    delta = delta.view(batch, block_size, taps, num_groups)
+    for position in range(block_size):
+        for tap in range(min(taps, position + 1)):
+            expected[:, position] += (
+                base[tap] + delta[:, position, tap, :, None]
+            ) * hidden_blocks[:, position - tap]
+
+    torch.testing.assert_close(actual, expected.flatten(0, 1).flatten(-2))
+
+
+def test_selector_edges_match_sequential_reference():
+    torch.manual_seed(1)
+    batch, steps, top_k, rank = 2, 4, 3, 5
+    vocab = 17
+    predecessors = torch.randn(vocab, rank)
+    successors = torch.randn(vocab, rank)
+    candidate_ids = torch.randint(vocab, (batch, steps, top_k))
+    unary = torch.randn(batch, steps, top_k)
+    hidden = torch.randn(batch, steps, rank)
+    anchors = torch.randint(vocab, (batch,))
+
+    actual = _score_edges(
+        predecessors,
+        successors,
+        candidate_ids,
+        unary,
+        hidden,
+        anchors,
+        top_k,
+    )
+    expected = torch.empty_like(actual)
+    for step in range(steps):
+        pred = (
+            anchors[:, None].expand(-1, top_k)
+            if step == 0
+            else candidate_ids[:, step - 1]
+        )
+        expected[:, step] = unary[:, step, None] + torch.einsum(
+            "bpr,bcr->bpc",
+            predecessors[pred] * hidden[:, step, None],
+            successors[candidate_ids[:, step]],
+        )
+
+    torch.testing.assert_close(actual, expected)
+
+
+def _stub_base(monkeypatch: pytest.MonkeyPatch, draft_logits):
+    def init_base(self, _vllm_config, device):
+        self.draft_model_config = SimpleNamespace(
+            hf_config=SimpleNamespace(dflash_config={"selector_top_k": 16})
+        )
+        self.max_num_reqs = 2
+        self.num_query_per_req = 8
+        self.num_speculative_steps = 7
+        self.vocab_size = 31
+        self.draft_tokens = torch.empty((2, 7), dtype=torch.int64, device=device)
+        self.draft_logits = draft_logits
+
+    monkeypatch.setattr(DFlashSpeculator, "__init__", init_base)
+
+
+def test_selector_leaves_greedy_without_proposal_logits(monkeypatch):
+    _stub_base(monkeypatch, None)
+    speculator = DFlash2Speculator(None, torch.device("cpu"))
+    assert speculator.draft_logits is None
+
+
+def test_selector_initializes_probabilistic_cache_to_negative_infinity(monkeypatch):
+    allocated = torch.zeros((2, 7, 31), dtype=torch.float32)
+    _stub_base(monkeypatch, allocated)
+    speculator = DFlash2Speculator(None, torch.device("cpu"))
+    assert speculator.draft_logits is allocated
+    assert torch.isneginf(speculator.draft_logits).all()
+
+
+def test_selector_uses_checkpoint_top16_and_fp32_proposal_cache(monkeypatch):
+    _stub_base(monkeypatch, None)
+    speculator = DFlash2Speculator(None, torch.device("cpu"))
+    dtype, fill = DFlash2Speculator.draft_logits_spec(None, None)
+    assert speculator.selector_top_k == 16
+    assert dtype is torch.float32
+    assert fill == float("-inf")
+
+
+def test_probabilistic_selector_caches_temperature_applied_scores():
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA is required for the DFlash2 selector kernel")
+
+    device = torch.device("cuda")
+    num_steps, top_k = 2, 4
+    scores = torch.tensor(
+        [
+            [
+                [
+                    [0.0, 0.5, 1.0, 1.5],
+                    [2.0, 2.5, 3.0, 3.5],
+                    [4.0, 4.5, 5.0, 5.5],
+                    [6.0, 6.5, 7.0, 7.5],
+                ],
+                [
+                    [8.0, 8.5, 9.0, 9.5],
+                    [10.0, 10.5, 11.0, 11.5],
+                    [12.0, 12.5, 13.0, 13.5],
+                    [14.0, 14.5, 15.0, 15.5],
+                ],
+            ]
+        ],
+        dtype=torch.float32,
+        device=device,
+    )
+    candidates = torch.arange(top_k, dtype=torch.int64, device=device).repeat(
+        1, num_steps, 1
+    )
+    sample_pos = torch.tensor([10, 11], dtype=torch.int64, device=device)
+    req_state = torch.zeros(num_steps, dtype=torch.int32, device=device)
+    temperature = torch.tensor([0.5], dtype=torch.float32, device=device)
+    seeds = torch.tensor([123], dtype=torch.int64, device=device)
+    tokens = torch.full((num_steps,), -1, dtype=torch.int64, device=device)
+    realized = torch.full(
+        (1, num_steps, top_k),
+        float("nan"),
+        dtype=torch.float32,
+        device=device,
+    )
+    path_state = torch.empty(1, dtype=torch.int32, device=device)
+
+    _selector_walk_kernel[(1,)](
+        scores,
+        candidates,
+        sample_pos,
+        req_state,
+        temperature,
+        seeds,
+        tokens,
+        realized,
+        path_state,
+        num_steps=num_steps,
+        walk_steps=num_steps,
+        top_k=top_k,
+        BLOCK_K=top_k,
+        SAMPLE_PROBABILISTIC=True,
+        USE_FP64=False,
+        num_warps=1,
+    )
+
+    first_index = int(tokens[0].item())
+    torch.testing.assert_close(realized[0, 0], scores[0, 0, 0] / temperature[0])
+    torch.testing.assert_close(
+        realized[0, 1], scores[0, 1, first_index] / temperature[0]
+    )
+
+
+def test_dflash2_architecture_dispatches_to_mrv2(monkeypatch):
+    monkeypatch.setattr(DFlash2Speculator, "__init__", lambda self, *_args: None)
+    config = SimpleNamespace(
+        speculative_config=SimpleNamespace(
+            method="dflash",
+            draft_model_config=SimpleNamespace(architectures=["DFlash2DraftModel"]),
+        )
+    )
+    assert isinstance(init_speculator(config, torch.device("cpu")), DFlash2Speculator)
+
+
+def test_dflash1_architecture_stays_on_official_mrv2_speculator(monkeypatch):
+    monkeypatch.setattr(DFlashSpeculator, "__init__", lambda self, *_args: None)
+    config = SimpleNamespace(
+        speculative_config=SimpleNamespace(
+            method="dflash",
+            draft_model_config=SimpleNamespace(architectures=["DFlashDraftModel"]),
+        )
+    )
+    assert isinstance(init_speculator(config, torch.device("cpu")), DFlashSpeculator)
+
+
+@pytest.mark.parametrize("method", ["eagle3", "mtp"])
+def test_non_dflash_speculators_keep_eagle_dispatch(monkeypatch, method):
+    from vllm.v1.worker.gpu.spec_decode.eagle.speculator import EagleSpeculator
+
+    monkeypatch.setattr(EagleSpeculator, "__init__", lambda self, *_args: None)
+    config = SimpleNamespace(
+        speculative_config=SimpleNamespace(
+            method=method,
+            use_eagle=lambda: True,
+        )
+    )
+    assert isinstance(init_speculator(config, torch.device("cpu")), EagleSpeculator)
+
+
+def test_top_level_noncausal_override_wins_over_sliding_layer_default():
+    config = SimpleNamespace(
+        is_causal=False,
+        dflash_config={},
+        layer_types=["sliding_attention"],
+    )
+    assert _dflash_layer_causal(config, 0) is False
+
+
+def test_aux_hidden_states_follow_loaded_draft_projection_dtype():
+    fc = torch.nn.Linear(10, 2, bias=False, dtype=torch.float16)
+    fc.input_size = 10
+    model = SimpleNamespace(use_aux_hidden_state=True, fc=fc)
+    outer = SimpleNamespace(model=model)
+    hidden_states = torch.randn(3, 10, dtype=torch.float32)
+
+    output = DFlashQwen3ForCausalLM.combine_hidden_states(outer, hidden_states)
+
+    assert output.dtype is torch.float16
+
+
+@pytest.mark.parametrize("mamba_page_size_padded", [None, 16 * 512])
+def test_fp16_draft_cache_grows_padded_fp8_hybrid_pages(
+    mamba_page_size_padded: int | None,
+):
+    block_size = 16
+    target_page_size = 16 * 512
+    specs = {
+        "target.attn": FullAttentionSpec(
+            block_size=block_size,
+            num_kv_heads=1,
+            head_size=256,
+            dtype=torch.float8_e5m2,
+        ),
+        "target.mamba": MambaSpec(
+            block_size=block_size,
+            shapes=((target_page_size,),),
+            dtypes=(torch.uint8,),
+            page_size_padded=mamba_page_size_padded,
+        ),
+        "draft.attn": FullAttentionSpec(
+            block_size=block_size,
+            num_kv_heads=2,
+            head_size=128,
+            dtype=torch.float16,
+        ),
+    }
+
+    unified = unify_kv_cache_spec_page_size(specs)
+
+    expected_page_size = specs["draft.attn"].page_size_bytes
+    assert {spec.page_size_bytes for spec in unified.values()} == {expected_page_size}
+    assert unified["target.attn"].block_size == 2 * block_size
+    assert unified["target.mamba"].block_size == 2 * block_size
+    assert unified["target.mamba"].page_size_padded == expected_page_size
+
+
+def test_flashinfer_topk_is_capability_gated_on_sm70(monkeypatch):
+    dflash2_model._flashinfer_topk.cache_clear()
+    monkeypatch.setattr(dflash2_model.current_platform, "is_cuda", lambda: True)
+    monkeypatch.setattr(
+        dflash2_model.current_platform,
+        "has_device_capability",
+        lambda capability: capability <= 70,
+    )
+    monkeypatch.setattr(dflash2_model, "has_flashinfer", lambda: True)
+    assert dflash2_model._flashinfer_topk() is None
+    dflash2_model._flashinfer_topk.cache_clear()
+
+
+@pytest.mark.parametrize(
+    ("capability", "num_steps", "expected"),
+    [((7, 0), 7, True), ((7, 0), 1, False), ((8, 0), 7, False)],
+)
+def test_selector_tail_split_is_sm70_only(monkeypatch, capability, num_steps, expected):
+    monkeypatch.setattr(torch.cuda, "get_device_capability", lambda _device: capability)
+    assert _requires_sm70_tail(torch.device("cuda:0"), num_steps) is expected
+
+
+def test_noncausal_draft_cannot_enter_flash_v100_small_query_fast_path():
+    impl = SimpleNamespace(
+        use_flash_v100_decode=True,
+        smallq_decode_max_query_len=8,
+        smallq_decode_max_model_len=4096,
+    )
+    metadata = SimpleNamespace(
+        causal=False,
+        query_start_loc=torch.tensor([0, 8], dtype=torch.int32),
+        max_model_len=128,
+    )
+    assert not FlashAttnV100Impl._small_query_decode_enabled(impl, metadata)
+
+
+def test_dflash_attention_builders_receive_the_draft_model_config(monkeypatch):
+    def fake_replace(config, **updates):
+        return SimpleNamespace(source=config, **updates)
+
+    monkeypatch.setattr(dflash_speculator, "replace", fake_replace)
+    target_model_config = object()
+    draft_model_config = object()
+    attention_config = object()
+    speculator = SimpleNamespace(
+        vllm_config=SimpleNamespace(
+            model_config=target_model_config,
+            attention_config=attention_config,
+        ),
+        draft_model_config=draft_model_config,
+        requires_non_causal=True,
+    )
+
+    config = DFlashSpeculator.attn_vllm_config.fget(speculator)
+
+    assert config.model_config is draft_model_config
+    assert config.attention_config.source is attention_config
+    assert config.attention_config.use_non_causal is True
+
+
+def test_noncausal_dflash_capture_binds_paged_prefix_attention(monkeypatch):
+    monkeypatch.setattr(flash_v100, "_is_cuda_graph_capturing", lambda _query: True)
+    output = torch.empty(8, 1, 1)
+    paged_prefix = Mock(return_value=output)
+    impl = SimpleNamespace(
+        _supports_flash_v100_path=lambda: True,
+        _layer_debug_info=lambda _layer: {
+            "layer_name": "draft",
+            "is_dflash_draft_attn": True,
+        },
+        use_triton_prefill=False,
+        use_decode_scalar_paged=True,
+        use_decode_paged_prefill=False,
+        use_flash_v100_prefill_paged=True,
+        _small_query_decode_enabled=lambda _metadata: False,
+        _flash_v100_prefill_with_prefix=paged_prefix,
+    )
+    metadata = SimpleNamespace(
+        max_query_len=8,
+        max_seq_len=1024,
+        num_actual_tokens=8,
+        causal=False,
+        query_start_loc=torch.tensor([0, 8], dtype=torch.int32),
+        query_start_loc_cpu=torch.tensor([0, 8], dtype=torch.int32),
+        # Capture-time CPU metadata looks like no-prefix prefill, while the
+        # persistent device metadata is updated before replay.
+        seq_lens=torch.tensor([17], dtype=torch.int32),
+        seq_lens_cpu=torch.tensor([8], dtype=torch.int32),
+        block_table=torch.tensor([[0]], dtype=torch.int32),
+    )
+    query = torch.empty(8, 1, 1)
+    layer = SimpleNamespace(is_dflash_draft_attn=True)
+
+    result = FlashAttnV100Impl.forward(
+        impl,
+        layer,
+        query,
+        query,
+        query,
+        torch.empty(1),
+        metadata,
+        output,
+    )
+
+    assert result is output
+    paged_prefix.assert_called_once()
+
+
+def test_draft_attention_causality_is_resolved_per_kv_group(monkeypatch):
+    observed_causality = []
+
+    class CapturedCommonAttentionMetadata:
+        def __init__(self, **kwargs):
+            observed_causality.append(kwargs["causal"])
+
+    monkeypatch.setattr(
+        attn_utils,
+        "CommonAttentionMetadata",
+        CapturedCommonAttentionMetadata,
+    )
+    kv_cache_config = SimpleNamespace(
+        kv_cache_groups=[SimpleNamespace(), SimpleNamespace()]
+    )
+    attn_utils.build_attn_metadata(
+        attn_groups=[[], []],
+        num_reqs=1,
+        num_tokens=8,
+        query_start_loc_gpu=torch.tensor([0, 8], dtype=torch.int32),
+        query_start_loc_cpu=torch.tensor([0, 8], dtype=torch.int32),
+        max_query_len=8,
+        seq_lens=torch.tensor([8], dtype=torch.int32),
+        max_seq_len=8,
+        block_tables=[
+            torch.zeros((1, 1), dtype=torch.int32),
+            torch.zeros((1, 1), dtype=torch.int32),
+        ],
+        slot_mappings=torch.zeros((2, 8), dtype=torch.int64),
+        kv_cache_config=kv_cache_config,
+        causal={0: False, 1: True},
+    )
+
+    assert observed_causality == [False, True]
+
+
+def test_sm70_rmsnorm_keeps_bf16_residual_in_fp32():
+    norm = DFlashSM70RMSNorm(8, 1e-6, torch.float16)
+    norm.weight.data.copy_(torch.linspace(0.5, 1.5, 8, dtype=torch.float16))
+    x = torch.full((2, 8), 300.0, dtype=torch.float16)
+    residual = torch.full((2, 8), 70000.0, dtype=torch.float32)
+
+    output, residual_output = norm(x, residual)
+    expected_residual = (
+        (x.float() * DFLASH_SM70_WIDE_OUTPUT_SCALE + residual)
+        .to(torch.bfloat16)
+        .float()
+    )
+
+    assert residual_output.dtype is torch.float32
+    assert torch.isfinite(output).all()
+    assert residual_output.max() > torch.finfo(torch.float16).max
+    torch.testing.assert_close(residual_output, expected_residual, rtol=0, atol=0)
+
+
+def test_sm70_swiglu_uses_power_of_two_row_scale():
+    gate_up = (
+        torch.tensor(
+            [
+                [2000.0, -1500.0, 1000.0, 800.0, 1800.0, 900.0, -700.0, 600.0],
+                [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0],
+            ],
+            dtype=torch.float16,
+        )
+        / DFLASH_SM70_GATE_UP_INPUT_SCALE
+    )
+    transported, row_scales = dflash_silu_and_mul_sm70(gate_up)
+
+    assert torch.all(row_scales >= 1)
+    torch.testing.assert_close(
+        torch.log2(row_scales),
+        torch.log2(row_scales).round(),
+        rtol=0,
+        atol=0,
+    )
+    assert torch.isfinite(transported).all()
+
+    down = torch.ones((2, 8), dtype=torch.float16)
+    restored = dflash_scale_output_sm70(down, row_scales)
+    expected = (
+        down.float() * (row_scales[:, None] / DFLASH_SM70_WIDE_OUTPUT_SCALE)
+    ).half()
+    torch.testing.assert_close(restored, expected, rtol=0, atol=0)

--- a/tests/v1/spec_decode/test_dflash2.py
+++ b/tests/v1/spec_decode/test_dflash2.py
@@ -27,6 +27,7 @@ from vllm.model_executor.models.qwen3_dflash2 import _grouped_conv, _score_edges
 from vllm.v1.attention.backends.flash_attn_v100 import FlashAttnV100Impl
 from vllm.v1.core.kv_cache_utils import unify_kv_cache_spec_page_size
 from vllm.v1.kv_cache_interface import FullAttentionSpec, MambaSpec
+from vllm.v1.worker.gpu.sample.gumbel import gumbel_sample
 from vllm.v1.worker.gpu.spec_decode import init_speculator
 from vllm.v1.worker.gpu.spec_decode.dflash.speculator import DFlashSpeculator
 from vllm.v1.worker.gpu.spec_decode.dflash2.speculator import (
@@ -200,6 +201,38 @@ def test_probabilistic_selector_caches_temperature_applied_scores():
     torch.testing.assert_close(
         realized[0, 1], scores[0, 1, first_index] / temperature[0]
     )
+
+
+def test_probabilistic_cache_respects_column_stride():
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA is required for the Gumbel kernel")
+
+    device = torch.device("cuda")
+    vocab_size = 17
+    padded_vocab_size = 23
+    logits = torch.arange(vocab_size, dtype=torch.float32, device=device)[None]
+    storage = torch.full(
+        (1, 2, padded_vocab_size),
+        float("nan"),
+        dtype=torch.float32,
+        device=device,
+    )
+    cache = storage[:, :, :vocab_size]
+
+    gumbel_sample(
+        logits,
+        expanded_idx_mapping=torch.tensor([0], dtype=torch.int32, device=device),
+        temperature=torch.tensor([1.0], dtype=torch.float32, device=device),
+        seed=torch.tensor([123], dtype=torch.int64, device=device),
+        pos=torch.tensor([7], dtype=torch.int64, device=device),
+        apply_temperature=True,
+        output_processed_logits=cache,
+        output_processed_logits_col=torch.tensor(1, device=device),
+    )
+
+    assert torch.isnan(cache[0, 0]).all()
+    torch.testing.assert_close(cache[0, 1], logits[0])
+    assert torch.isnan(storage[:, :, vocab_size:]).all()
 
 
 def test_dflash2_architecture_dispatches_to_mrv2(monkeypatch):

--- a/tests/v1/worker/test_gpu_warmup_blocks.py
+++ b/tests/v1/worker/test_gpu_warmup_blocks.py
@@ -1,0 +1,98 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""MRV2 warmup must reserve the same speculative KV tail as the scheduler."""
+
+import pytest
+import torch
+
+from vllm.config.speculative import SpeculativeConfig
+from vllm.config.vllm import VllmConfig
+from vllm.v1.kv_cache_interface import FullAttentionSpec, MambaSpec
+from vllm.v1.worker.gpu.warmup import _reserved_block_count
+
+BLOCK_SIZE = 16
+MAX_MODEL_LEN = 1024
+NUM_SPEC_TOKENS = 7
+
+
+def _speculative_config(method: str) -> SpeculativeConfig:
+    config = object.__new__(SpeculativeConfig)
+    object.__setattr__(config, "method", method)
+    object.__setattr__(config, "num_speculative_tokens", NUM_SPEC_TOKENS)
+    object.__setattr__(config, "ddtree_disable_tree_verify", False)
+    object.__setattr__(config, "ddtree_budget", 24)
+    return config
+
+
+class _Config:
+    speculative_config: SpeculativeConfig | None = None
+    diffusion_config = None
+    num_speculative_tokens = VllmConfig.num_speculative_tokens
+    num_lookahead_tokens = VllmConfig.num_lookahead_tokens
+
+
+@pytest.mark.parametrize(
+    ("method", "expected"),
+    [
+        ("dflash", NUM_SPEC_TOKENS + 1),
+        ("dflash_ddtree", 25),
+        ("eagle3", NUM_SPEC_TOKENS),
+        ("mtp", NUM_SPEC_TOKENS),
+        ("dspark", NUM_SPEC_TOKENS),
+        ("draft_model", NUM_SPEC_TOKENS),
+        ("ngram", 0),
+    ],
+)
+def test_num_lookahead_tokens_per_method(method: str, expected: int) -> None:
+    config = _Config()
+    config.speculative_config = _speculative_config(method)
+
+    assert config.num_lookahead_tokens == expected
+
+
+def test_num_lookahead_tokens_without_speculation() -> None:
+    assert _Config().num_lookahead_tokens == 0
+
+
+def _full_attention_spec() -> FullAttentionSpec:
+    return FullAttentionSpec(
+        block_size=BLOCK_SIZE,
+        num_kv_heads=1,
+        head_size=1,
+        dtype=torch.float16,
+    )
+
+
+def _mamba_spec(mode: str) -> MambaSpec:
+    return MambaSpec(
+        block_size=BLOCK_SIZE,
+        shapes=((1,),),
+        dtypes=(torch.float16,),
+        mamba_cache_mode=mode,
+        num_speculative_blocks=NUM_SPEC_TOKENS,
+    )
+
+
+@pytest.mark.parametrize(
+    ("spec", "expected"),
+    [
+        (_full_attention_spec(), 2),
+        (_mamba_spec("align"), 8),
+        (_mamba_spec("none"), 9),
+        (_mamba_spec("all"), 9),
+    ],
+)
+def test_reserved_block_count_matches_speculative_tail(spec, expected) -> None:
+    # 14 scheduled tokens plus DFlash's eight lookahead positions crosses the
+    # second attention block. Align-mode Mamba excludes lookahead from its
+    # token range but always retains seven speculative state blocks.
+    assert (
+        _reserved_block_count(
+            14,
+            spec,
+            num_lookahead_tokens=NUM_SPEC_TOKENS + 1,
+            max_model_len=MAX_MODEL_LEN,
+            max_encoder_len=0,
+        )
+        == expected
+    )

--- a/vllm/config/speculative.py
+++ b/vllm/config/speculative.py
@@ -1183,6 +1183,15 @@ class SpeculativeConfig:
             or self.use_dspark()
         )
 
+    def use_eagle_kv_cache(self) -> bool:
+        """Whether prefix hits need Eagle's final target-block recompute."""
+        # MRV2 DFlash caches its projected draft context KV alongside the
+        # target KV. It only needs target hidden states for the uncached suffix,
+        # so dropping an additional target block is both unnecessary and can
+        # eliminate all prefix hits when hybrid page unification makes blocks
+        # large. Keep DDTree and DSpark on their established V1 semantics.
+        return self.use_eagle() and not self.use_dflash()
+
     def use_dflash(self) -> bool:
         return self.method == "dflash"
 

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -521,6 +521,19 @@ class VllmConfig:
         return 0
 
     @property
+    def num_lookahead_tokens(self) -> int:
+        """KV positions reserved beyond the target model's scheduled query."""
+        speculative_config = self.speculative_config
+        if speculative_config is None:
+            return 0
+        if speculative_config.use_dflash_family():
+            # DFlash has one anchor query plus the checkpoint-owned draft state.
+            return speculative_config.num_speculative_state_tokens() + 1
+        if speculative_config.use_eagle() or speculative_config.uses_draft_model():
+            return self.num_speculative_tokens
+        return 0
+
+    @property
     def use_v2_model_runner(self) -> bool:
         use_v2_model_runner = envs.VLLM_USE_V2_MODEL_RUNNER
         is_mrv2_dflash = (
@@ -2496,13 +2509,6 @@ class VllmConfig:
         model_config = self.model_config
         speculative_config = self.speculative_config
 
-        if (
-            model_config is not None
-            and model_config.has_inner_state
-            and self.cache_config.mamba_cache_mode == "align"
-        ):
-            unsupported.append("hybrid/mamba models with align cache mode")
-
         if self.parallel_config.prefill_context_parallel_size > 1:
             unsupported.append("prefill context parallelism")
 
@@ -2645,10 +2651,6 @@ class VllmConfig:
                 "Chunked MM input is required because we need the flexibility "
                 "to schedule a multiple of block_size tokens even if they are "
                 "in the middle of a mm input"
-            )
-            # TODO: support align mamba cache mode for model runner v2
-            assert not envs.VLLM_USE_V2_MODEL_RUNNER, (
-                "Model Runner V2 has not yet supported mamba_cache_mode='align'. "
             )
 
     @model_validator(mode="after")

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -1765,30 +1765,10 @@ class EngineArgs:
         has_linear_attention = any(
             layer_type == "linear_attention" for layer_type in layer_types
         )
-        explicit_spec_method = (
-            self.speculative_config.get("method")
-            if isinstance(self.speculative_config, dict)
-            else None
-        )
-
         if is_server and self.enable_prefix_caching is None and has_linear_attention:
-            # Qwen3.5/3.8 exposes only align-mode prefix caching, while MRV2
-            # does not yet implement align-state preprocessing. Keep the
-            # recommended DFlash server configuration bootable and require an
-            # explicit future opt-in once that dependency is backported.
-            self.enable_prefix_caching = explicit_spec_method != "dflash"
+            self.enable_prefix_caching = True
             profile_updates.append(
                 f"enable_prefix_caching={self.enable_prefix_caching}"
-            )
-        if (
-            explicit_spec_method == "dflash"
-            and self.enable_prefix_caching
-            and has_linear_attention
-        ):
-            raise ValueError(
-                "MRV2 DFlash does not yet support Qwen hybrid align-mode prefix "
-                "cache preprocessing. Set enable_prefix_caching=False; target-prefix "
-                "hits with draft-KV rebuild require a later dependency backport."
             )
         if (
             self.enable_prefix_caching

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -1815,10 +1815,10 @@ class EngineArgs:
             return
 
         if "draft_sample_method" not in self.speculative_config:
-            # Native MTP keeps its validated probabilistic default. DFlash2's
-            # published/default performance lane is greedy; probabilistic
-            # drafting remains available when explicitly requested.
-            draft_sample_method = "probabilistic" if spec_method == "mtp" else "greedy"
+            # Preserve the validated probabilistic default for MTP and the
+            # DFlash family. DFlash2's greedy performance lane remains
+            # available when explicitly requested, without changing DFlash1.
+            draft_sample_method = "probabilistic"
             self.speculative_config["draft_sample_method"] = draft_sample_method
             profile_updates.append(
                 f"speculative_config.draft_sample_method={draft_sample_method}"

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -1765,10 +1765,31 @@ class EngineArgs:
         has_linear_attention = any(
             layer_type == "linear_attention" for layer_type in layer_types
         )
+        explicit_spec_method = (
+            self.speculative_config.get("method")
+            if isinstance(self.speculative_config, dict)
+            else None
+        )
 
         if is_server and self.enable_prefix_caching is None and has_linear_attention:
-            self.enable_prefix_caching = True
-            profile_updates.append("enable_prefix_caching=True")
+            # Qwen3.5/3.8 exposes only align-mode prefix caching, while MRV2
+            # does not yet implement align-state preprocessing. Keep the
+            # recommended DFlash server configuration bootable and require an
+            # explicit future opt-in once that dependency is backported.
+            self.enable_prefix_caching = explicit_spec_method != "dflash"
+            profile_updates.append(
+                f"enable_prefix_caching={self.enable_prefix_caching}"
+            )
+        if (
+            explicit_spec_method == "dflash"
+            and self.enable_prefix_caching
+            and has_linear_attention
+        ):
+            raise ValueError(
+                "MRV2 DFlash does not yet support Qwen hybrid align-mode prefix "
+                "cache preprocessing. Set enable_prefix_caching=False; target-prefix "
+                "hits with draft-KV rebuild require a later dependency backport."
+            )
         if (
             self.enable_prefix_caching
             and has_linear_attention
@@ -1814,13 +1835,10 @@ class EngineArgs:
             return
 
         if "draft_sample_method" not in self.speculative_config:
-            # For SM70 native MTP, official Qwen sampling is non-greedy
-            # (temperature=1.0/top_p=0.95/top_k=20). Probabilistic draft
-            # sampling provides draft_probs for standard rejection sampling and
-            # is the validated high-acceptance path. Greedy requests still take
-            # the argmax fast path inside the proposer when sampling metadata is
-            # all-greedy, so this default does not penalize deterministic runs.
-            draft_sample_method = "probabilistic"
+            # Native MTP keeps its validated probabilistic default. DFlash2's
+            # published/default performance lane is greedy; probabilistic
+            # drafting remains available when explicitly requested.
+            draft_sample_method = "probabilistic" if spec_method == "mtp" else "greedy"
             self.speculative_config["draft_sample_method"] = draft_sample_method
             profile_updates.append(
                 f"speculative_config.draft_sample_method={draft_sample_method}"

--- a/vllm/model_executor/models/dflash_sm70.py
+++ b/vllm/model_executor/models/dflash_sm70.py
@@ -1,0 +1,300 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Range-preserving BF16 arithmetic for DFlash2 drafts on SM70.
+
+The checkpoint was trained with BF16 activations, but Volta executes its dense
+GEMMs in FP16. These kernels retain FP16 Tensor Core transport while preserving
+BF16 residual range and rounding at the model's trained rounding points.
+
+Adapted from haohervchb/sglang-V100@5526ef1c6a82.
+"""
+
+from __future__ import annotations
+
+import torch
+from torch import nn
+
+from vllm.triton_utils import tl, triton
+
+DFLASH_SM70_GATE_UP_INPUT_SCALE = 32.0
+DFLASH_SM70_WIDE_OUTPUT_SCALE = 256.0
+
+
+@triton.jit
+def _round_fp32_to_bf16_rne(value):
+    """Round FP32 to BF16 RNE and keep the result represented as FP32."""
+    bits = value.to(tl.uint32, bitcast=True)
+    rounded_bits = (bits + 0x7FFF + ((bits >> 16) & 1)) & 0xFFFF0000
+    return rounded_bits.to(tl.float32, bitcast=True)
+
+
+@triton.jit
+def _dflash_silu_and_mul_sm70_kernel(
+    output_ptr,
+    output_scales_ptr,
+    gate_up_ptr,
+    n_cols: tl.constexpr,
+    gate_up_scale: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+):
+    row = tl.program_id(0).to(tl.int64)
+    offsets = tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_cols
+    input_offsets = row * 2 * n_cols + offsets
+    output_offsets = row * n_cols + offsets
+
+    gate = tl.load(gate_up_ptr + input_offsets, mask=mask, other=0.0).to(tl.float32)
+    up = tl.load(gate_up_ptr + input_offsets + n_cols, mask=mask, other=0.0).to(
+        tl.float32
+    )
+    gate = _round_fp32_to_bf16_rne(gate * gate_up_scale)
+    up = _round_fp32_to_bf16_rne(up * gate_up_scale)
+    activated_gate = _round_fp32_to_bf16_rne(gate * tl.sigmoid(gate))
+    output = _round_fp32_to_bf16_rne(activated_gate * up)
+
+    # A per-row power-of-two divisor retains exact transport scaling.
+    max_abs = tl.max(tl.abs(output), axis=0)
+    output_scale = tl.maximum(max_abs / 32752.0, 1.0)
+    output_scale = tl.exp2(tl.ceil(tl.log2(output_scale)))
+    tl.store(output_scales_ptr + row, output_scale)
+    tl.store(output_ptr + output_offsets, output / output_scale, mask=mask)
+
+
+@triton.jit
+def _dflash_scale_output_sm70_kernel(
+    output_ptr,
+    row_scales_ptr,
+    n_cols: tl.constexpr,
+    residual_scale: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+):
+    row = tl.program_id(0).to(tl.int64)
+    offsets = tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_cols
+    row_offsets = row * n_cols + offsets
+    value = tl.load(output_ptr + row_offsets, mask=mask, other=0.0).to(tl.float32)
+    row_scale = tl.load(row_scales_ptr + row).to(tl.float32)
+    tl.store(
+        output_ptr + row_offsets,
+        value * (row_scale / residual_scale),
+        mask=mask,
+    )
+
+
+@triton.jit
+def _dflash_rmsnorm_sm70_kernel(
+    output_ptr,
+    residual_output_ptr,
+    x_ptr,
+    residual_ptr,
+    weight_ptr,
+    n_cols: tl.constexpr,
+    eps: tl.constexpr,
+    residual_scale: tl.constexpr,
+    HAS_RESIDUAL: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+):
+    row = tl.program_id(0).to(tl.int64)
+    offsets = tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_cols
+    row_offsets = row * n_cols + offsets
+
+    value = tl.load(x_ptr + row_offsets, mask=mask, other=0.0).to(tl.float32)
+    if HAS_RESIDUAL:
+        residual = tl.load(residual_ptr + row_offsets, mask=mask, other=0.0).to(
+            tl.float32
+        )
+        value = _round_fp32_to_bf16_rne(value * residual_scale + residual)
+        tl.store(residual_output_ptr + row_offsets, value, mask=mask)
+
+    variance = tl.sum(value * value, axis=0) / n_cols
+    normalized = value * tl.rsqrt(variance + eps)
+    weight = tl.load(weight_ptr + offsets, mask=mask, other=0.0).to(tl.float32)
+    weight = _round_fp32_to_bf16_rne(weight)
+    output = _round_fp32_to_bf16_rne(normalized * weight)
+    tl.store(output_ptr + row_offsets, output, mask=mask)
+
+
+def _num_warps(n_cols: int) -> int:
+    return max(min(triton.next_power_of_2(triton.cdiv(n_cols, 256)), 16), 4)
+
+
+def _silu_and_mul_reference(
+    gate_up: torch.Tensor, gate_up_scale: float
+) -> tuple[torch.Tensor, torch.Tensor]:
+    gate, up = gate_up.float().chunk(2, dim=-1)
+    gate = (gate * gate_up_scale).to(torch.bfloat16).float()
+    up = (up * gate_up_scale).to(torch.bfloat16).float()
+    activated = (gate * torch.sigmoid(gate)).to(torch.bfloat16).float()
+    output = (activated * up).to(torch.bfloat16).float()
+    max_abs = output.abs().amax(dim=-1)
+    row_scales = torch.maximum(max_abs / 32752.0, torch.ones_like(max_abs))
+    row_scales = torch.pow(2.0, torch.ceil(torch.log2(row_scales)))
+    return (output / row_scales.unsqueeze(-1)).to(gate_up.dtype), row_scales
+
+
+def dflash_silu_and_mul_sm70(
+    gate_up: torch.Tensor,
+    gate_up_scale: float = DFLASH_SM70_GATE_UP_INPUT_SCALE,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    if gate_up.ndim < 2 or gate_up.shape[-1] % 2:
+        raise ValueError(
+            "DFlash SM70 SwiGLU expects [..., 2 * intermediate_size], "
+            f"got {tuple(gate_up.shape)}."
+        )
+    if gate_up_scale <= 0:
+        raise ValueError(f"gate_up_scale must be positive, got {gate_up_scale}.")
+    if not gate_up.is_cuda:
+        return _silu_and_mul_reference(gate_up, gate_up_scale)
+    if gate_up.dtype != torch.float16:
+        raise ValueError(
+            f"DFlash SM70 SwiGLU requires FP16 CUDA transport, got {gate_up.dtype}."
+        )
+    if not gate_up.is_contiguous():
+        gate_up = gate_up.contiguous()
+
+    n_cols = gate_up.shape[-1] // 2
+    n_rows = gate_up.numel() // (2 * n_cols)
+    output = torch.empty(
+        (*gate_up.shape[:-1], n_cols),
+        dtype=gate_up.dtype,
+        device=gate_up.device,
+    )
+    output_scales = torch.empty(n_rows, dtype=torch.float32, device=gate_up.device)
+    block_size = triton.next_power_of_2(n_cols)
+    _dflash_silu_and_mul_sm70_kernel[(n_rows,)](
+        output,
+        output_scales,
+        gate_up,
+        n_cols=n_cols,
+        gate_up_scale=gate_up_scale,
+        BLOCK_SIZE=block_size,
+        num_warps=_num_warps(n_cols),
+    )
+    return output, output_scales
+
+
+def dflash_scale_output_sm70(
+    output: torch.Tensor,
+    row_scales: torch.Tensor,
+    residual_scale: float = DFLASH_SM70_WIDE_OUTPUT_SCALE,
+) -> torch.Tensor:
+    if output.ndim < 2:
+        raise ValueError(f"DFlash SM70 output must have ndim >= 2, got {output.ndim}.")
+    if residual_scale <= 0:
+        raise ValueError(f"residual_scale must be positive, got {residual_scale}.")
+    n_cols = output.shape[-1]
+    n_rows = output.numel() // n_cols
+    if row_scales.numel() != n_rows:
+        raise ValueError(
+            f"DFlash SM70 row-scale mismatch: rows={n_rows}, "
+            f"scales={row_scales.numel()}."
+        )
+    if not output.is_cuda:
+        return (output.float() * (row_scales.reshape(-1, 1) / residual_scale)).to(
+            output.dtype
+        )
+    if output.dtype != torch.float16 or not output.is_contiguous():
+        raise ValueError("DFlash SM70 W2 scaling requires contiguous CUDA FP16 output.")
+    block_size = triton.next_power_of_2(n_cols)
+    _dflash_scale_output_sm70_kernel[(n_rows,)](
+        output,
+        row_scales,
+        n_cols=n_cols,
+        residual_scale=residual_scale,
+        BLOCK_SIZE=block_size,
+        num_warps=_num_warps(n_cols),
+    )
+    return output
+
+
+class DFlashSM70RMSNorm(nn.Module):
+    """RMSNorm with FP32 residual transport and explicit BF16 RNE."""
+
+    def __init__(
+        self,
+        hidden_size: int,
+        eps: float,
+        dtype: torch.dtype,
+        residual_scale: float = DFLASH_SM70_WIDE_OUTPUT_SCALE,
+    ) -> None:
+        super().__init__()
+        self.hidden_size = hidden_size
+        self.variance_epsilon = eps
+        self.residual_scale = residual_scale
+        self.weight = nn.Parameter(torch.ones(hidden_size, dtype=dtype))
+
+    def _reference(
+        self, x: torch.Tensor, residual: torch.Tensor | None
+    ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
+        orig_dtype = x.dtype
+        value = x.float()
+        residual_output = None
+        if residual is not None:
+            value = (
+                (value * self.residual_scale + residual.float())
+                .to(torch.bfloat16)
+                .float()
+            )
+            residual_output = value
+        variance = value.square().mean(dim=-1, keepdim=True)
+        normalized = value * torch.rsqrt(variance + self.variance_epsilon)
+        weight = self.weight.float().to(torch.bfloat16).float()
+        output = (normalized * weight).to(torch.bfloat16).to(orig_dtype)
+        if residual_output is None:
+            return output
+        return output, residual_output
+
+    def forward(
+        self, x: torch.Tensor, residual: torch.Tensor | None = None
+    ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
+        if not x.is_cuda:
+            return self._reference(x, residual)
+        if x.dtype != torch.float16:
+            raise ValueError(
+                f"DFlash SM70 RMSNorm requires FP16 CUDA transport, got {x.dtype}."
+            )
+        if not x.is_contiguous():
+            x = x.contiguous()
+        if residual is not None and not residual.is_contiguous():
+            residual = residual.contiguous()
+
+        n_rows = x.numel() // self.hidden_size
+        output = torch.empty_like(x)
+        has_residual = residual is not None
+        residual_output = (
+            torch.empty_like(x, dtype=torch.float32) if has_residual else output
+        )
+        residual_ptr = residual if residual is not None else x
+        block_size = triton.next_power_of_2(self.hidden_size)
+        _dflash_rmsnorm_sm70_kernel[(n_rows,)](
+            output,
+            residual_output,
+            x,
+            residual_ptr,
+            self.weight,
+            n_cols=self.hidden_size,
+            eps=self.variance_epsilon,
+            residual_scale=self.residual_scale,
+            HAS_RESIDUAL=has_residual,
+            BLOCK_SIZE=block_size,
+            num_warps=_num_warps(self.hidden_size),
+        )
+        if has_residual:
+            return output, residual_output
+        return output
+
+
+class DFlashSM70MLP(nn.Module):
+    """Wrap the official Qwen MLP with overflow-safe BF16-equivalent math."""
+
+    def __init__(self, mlp: nn.Module) -> None:
+        super().__init__()
+        self.gate_up_proj = mlp.gate_up_proj
+        self.down_proj = mlp.down_proj
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        gate_up, _ = self.gate_up_proj(x / DFLASH_SM70_GATE_UP_INPUT_SCALE)
+        x, row_scales = dflash_silu_and_mul_sm70(gate_up)
+        x, _ = self.down_proj(x)
+        return dflash_scale_output_sm70(x, row_scales)

--- a/vllm/model_executor/models/qwen3_dflash.py
+++ b/vllm/model_executor/models/qwen3_dflash.py
@@ -60,10 +60,13 @@ _SLIDING_ATTENTION = "sliding_attention"
 
 
 def _dflash_layer_causal(config: Qwen3Config, layer_idx: int) -> bool:
-    """``dflash_config.causal`` overrides all layers; else only SWA layers causal."""
+    """Resolve explicit causality before falling back to legacy layer defaults."""
+    is_causal = getattr(config, "is_causal", None)
+    if is_causal is not None:
+        return bool(is_causal)
     override = (getattr(config, "dflash_config", None) or {}).get("causal")
     if override is not None:
-        return override
+        return bool(override)
     layer_types = getattr(config, "layer_types", None)
     return bool(layer_types) and layer_types[layer_idx] == _SLIDING_ATTENTION
 
@@ -288,11 +291,16 @@ class DFlashQwen3Attention(nn.Module):
         q, k = self.rotary_emb(positions, q, k)
 
         attn_output = self.attn(q, k, v)
+        output_input_scale = getattr(self, "output_input_scale", 1.0)
+        if output_input_scale != 1.0:
+            attn_output = attn_output / output_input_scale
         output, _ = self.o_proj(attn_output)
         return output
 
 
 class DFlashQwen3DecoderLayer(nn.Module):
+    attention_cls = DFlashQwen3Attention
+
     def __init__(
         self,
         vllm_config: VllmConfig,
@@ -327,7 +335,7 @@ class DFlashQwen3DecoderLayer(nn.Module):
         # collapses with no error raised.
         is_neox_style = getattr(config, "is_neox_style", True)
 
-        self.self_attn = DFlashQwen3Attention(
+        self.self_attn = self.attention_cls(
             hidden_size=self.hidden_size,
             num_heads=config.num_attention_heads,
             max_position=config.max_position_embeddings,
@@ -381,6 +389,8 @@ class DFlashQwen3DecoderLayer(nn.Module):
 
 @support_torch_compile
 class DFlashQwen3Model(nn.Module):
+    decoder_layer_cls = DFlashQwen3DecoderLayer
+
     hf_to_vllm_mapper = WeightsMapper(
         orig_to_new_substr={
             "midlayer.": "layers.0.",
@@ -434,7 +444,7 @@ class DFlashQwen3Model(nn.Module):
 
         self.layers = nn.ModuleList(
             [
-                DFlashQwen3DecoderLayer(
+                self.decoder_layer_cls(
                     current_vllm_config,
                     config=self.config,
                     layer_idx=layer_idx,
@@ -548,13 +558,7 @@ class DFlashQwen3Model(nn.Module):
         head_dim: int,
     ) -> tuple[torch.Tensor, torch.Tensor]:
         # --- Fused KV projection (one GEMM for all layers) ---
-        normed_context_states = torch.empty_like(context_states)
-        ops.rms_norm(
-            normed_context_states,
-            context_states,
-            self._hidden_norm_weight,
-            self._rms_norm_eps,
-        )
+        normed_context_states = self._normalize_context_states(context_states)
         all_kv_flat = F.linear(
             normed_context_states, self._fused_kv_weight, self._fused_kv_bias
         )
@@ -569,6 +573,16 @@ class DFlashQwen3Model(nn.Module):
         all_k = all_kv[0]  # [L, num_ctx, nkv, hd], contiguous
         all_v = all_kv[1]  # [L, num_ctx, nkv, hd], contiguous
         return all_k, all_v
+
+    def _normalize_context_states(self, context_states: torch.Tensor) -> torch.Tensor:
+        normed_context_states = torch.empty_like(context_states)
+        ops.rms_norm(
+            normed_context_states,
+            context_states,
+            self._hidden_norm_weight,
+            self._rms_norm_eps,
+        )
+        return normed_context_states
 
     def _normalize_context_k(self, all_k: torch.Tensor) -> torch.Tensor:
         # --- Grouped RMSNorm K across all layers ([L, num_ctx, nkv, hd]) ---
@@ -740,6 +754,8 @@ class DFlashQwen3Model(nn.Module):
 
 
 class DFlashQwen3ForCausalLM(Qwen3ForCausalLM):
+    model_cls = DFlashQwen3Model
+
     def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):
         nn.Module.__init__(self)
         self.draft_model_config = vllm_config.speculative_config.draft_model_config
@@ -749,7 +765,7 @@ class DFlashQwen3ForCausalLM(Qwen3ForCausalLM):
         target_layer_num = vllm_config.model_config.get_num_layers(
             vllm_config.parallel_config
         )
-        self.model = DFlashQwen3Model(
+        self.model = self.model_cls(
             vllm_config=vllm_config,
             prefix=maybe_prefix(prefix, "model"),
             start_layer_id=target_layer_num,

--- a/vllm/model_executor/models/qwen3_dflash2.py
+++ b/vllm/model_executor/models/qwen3_dflash2.py
@@ -1,0 +1,426 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from collections.abc import Callable
+from functools import cache
+
+import torch
+import torch.nn.functional as F
+from torch import nn
+
+from vllm.compilation.backends import set_model_tag
+from vllm.compilation.decorators import support_torch_compile
+from vllm.config import CacheConfig, VllmConfig
+from vllm.distributed import (
+    get_tensor_model_parallel_world_size,
+    tensor_model_parallel_all_gather,
+)
+from vllm.logger import init_logger
+from vllm.model_executor.layers.linear import (
+    ReplicatedLinear,
+    UnquantizedLinearMethod,
+)
+from vllm.model_executor.layers.quantization.base_config import QuantizationConfig
+from vllm.model_executor.layers.vocab_parallel_embedding import (
+    UnquantizedEmbeddingMethod,
+)
+from vllm.platforms import current_platform
+from vllm.utils.flashinfer import has_flashinfer
+
+from .dflash_sm70 import (
+    DFLASH_SM70_WIDE_OUTPUT_SCALE,
+    DFlashSM70MLP,
+    DFlashSM70RMSNorm,
+)
+from .qwen3_dflash import (
+    DFlashQwen3DecoderLayer,
+    DFlashQwen3ForCausalLM,
+    DFlashQwen3Model,
+)
+from .utils import maybe_prefix
+
+logger = init_logger(__name__)
+
+
+def _use_sm70_bf16_emulation(config) -> bool:
+    declared_dtype = getattr(config, "dtype", None)
+    if declared_dtype is None:
+        declared_dtype = getattr(config, "torch_dtype", None)
+    is_bf16 = declared_dtype is torch.bfloat16 or str(declared_dtype).lower() in {
+        "bfloat16",
+        "bf16",
+        "torch.bfloat16",
+    }
+    return (
+        is_bf16
+        and current_platform.is_cuda()
+        and current_platform.is_device_capability(70)
+    )
+
+
+@cache
+def _flashinfer_topk() -> Callable[..., tuple[torch.Tensor, torch.Tensor]] | None:
+    """Return FlashInfer radix top-k only where the installed kernel can run.
+
+    Presence is not a sufficient capability check: FlashInfer can be installed
+    in the V100 environment while its radix top-k has no SM70 implementation.
+    """
+    if not current_platform.is_cuda():
+        return None
+    if not current_platform.has_device_capability(80):
+        logger.info_once(
+            "DFlash2 disables FlashInfer top-k below SM80; using torch.topk."
+        )
+        return None
+    if not has_flashinfer():
+        logger.info_once(
+            "FlashInfer is unavailable; the DFlash2 selector uses torch.topk."
+        )
+        return None
+    from flashinfer import top_k
+
+    return top_k
+
+
+def _topk(scores: torch.Tensor, k: int) -> tuple[torch.Tensor, torch.Tensor]:
+    impl = _flashinfer_topk()
+    if impl is None or not scores.is_cuda:
+        return torch.topk(scores, k, dim=-1)
+    return impl(scores, k, sorted=True, deterministic=True)
+
+
+def _grouped_conv(
+    hidden_states: torch.Tensor,
+    delta: torch.Tensor,
+    base: torch.Tensor,
+    block_size: int,
+    num_groups: int,
+    group_size: int,
+    taps: int,
+) -> torch.Tensor:
+    blocks = hidden_states.unflatten(-1, (num_groups, group_size))
+    coefficients = base.view(1, taps, num_groups, group_size) + delta.unsqueeze(-1)
+    output = coefficients[:, 0] * blocks
+    position = torch.arange(hidden_states.shape[0], device=hidden_states.device)
+    if block_size & (block_size - 1) == 0:
+        position = position & (block_size - 1)
+    else:
+        position = position % block_size
+    for tap in range(1, taps):
+        shifted = F.pad(blocks[:-tap], (0, 0, 0, 0, tap, 0))
+        output += coefficients[:, tap] * shifted * (position >= tap).view(-1, 1, 1)
+    return output.flatten(-2)
+
+
+class DFlashGroupedConv(nn.Module):
+    def __init__(
+        self,
+        hidden_size: int,
+        taps: int,
+        group_size: int,
+        block_size: int,
+        params_dtype: torch.dtype,
+        prefix: str,
+    ) -> None:
+        super().__init__()
+        if hidden_size % group_size:
+            raise ValueError(
+                f"conv_group_size={group_size} must divide hidden_size={hidden_size}."
+            )
+        self.block_size = block_size
+        self.taps = taps
+        self.group_size = group_size
+        self.num_groups = hidden_size // group_size
+        self.base_kernel = nn.Parameter(
+            torch.empty(2, taps, hidden_size, dtype=params_dtype),
+            requires_grad=False,
+        )
+        self.kernel_projection = ReplicatedLinear(
+            hidden_size,
+            2 * taps * self.num_groups,
+            bias=False,
+            params_dtype=params_dtype,
+            quant_config=None,
+            prefix=maybe_prefix(prefix, "kernel_projection"),
+            return_bias=False,
+        )
+
+    def _convolve(
+        self, hidden_states: torch.Tensor, delta: torch.Tensor, side: int
+    ) -> torch.Tensor:
+        return _grouped_conv(
+            hidden_states,
+            delta,
+            self.base_kernel[side],
+            self.block_size,
+            self.num_groups,
+            self.group_size,
+            self.taps,
+        )
+
+    def prepare(self, hidden_states: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+        coefficients = self.kernel_projection(hidden_states).reshape(
+            hidden_states.shape[0], 2, self.taps, self.num_groups
+        )
+        return self._convolve(hidden_states, coefficients[:, 0], 0), coefficients[:, 1]
+
+    def finish(
+        self, hidden_states: torch.Tensor, coefficients: torch.Tensor
+    ) -> torch.Tensor:
+        return self._convolve(hidden_states, coefficients, 1)
+
+
+class DFlash2Qwen3DecoderLayer(DFlashQwen3DecoderLayer):
+    def __init__(
+        self,
+        vllm_config: VllmConfig,
+        *,
+        config,
+        layer_idx: int,
+        cache_config: CacheConfig | None = None,
+        quant_config: QuantizationConfig | None = None,
+        prefix: str = "",
+    ) -> None:
+        super().__init__(
+            vllm_config,
+            config=config,
+            layer_idx=layer_idx,
+            cache_config=cache_config,
+            quant_config=quant_config,
+            prefix=prefix,
+        )
+        self.use_sm70_bf16_emulation = _use_sm70_bf16_emulation(config)
+        if self.use_sm70_bf16_emulation:
+            runtime_dtype = vllm_config.model_config.dtype
+            if runtime_dtype != torch.float16:
+                raise ValueError(
+                    "BF16 DFlash2 on SM70 requires FP16 runtime transport; "
+                    f"got runtime dtype {runtime_dtype}."
+                )
+            self.self_attn.output_input_scale = DFLASH_SM70_WIDE_OUTPUT_SCALE
+            self.mlp = DFlashSM70MLP(self.mlp)
+            self.input_layernorm = DFlashSM70RMSNorm(
+                config.hidden_size,
+                config.rms_norm_eps,
+                runtime_dtype,
+            )
+            self.post_attention_layernorm = DFlashSM70RMSNorm(
+                config.hidden_size,
+                config.rms_norm_eps,
+                runtime_dtype,
+            )
+        draft_config = config.dflash_config
+        speculative_config = vllm_config.speculative_config
+        assert speculative_config is not None
+        conv_args = dict(
+            hidden_size=config.hidden_size,
+            taps=int(draft_config["conv_kernel_size"]),
+            group_size=int(draft_config["conv_group_size"]),
+            # Query tokens per request: the bonus token plus the mask tokens.
+            block_size=1 + speculative_config.num_speculative_tokens,
+            params_dtype=vllm_config.model_config.dtype,
+        )
+        self.attention_conv = DFlashGroupedConv(
+            **conv_args, prefix=maybe_prefix(prefix, "attention_conv")
+        )
+        self.mlp_conv = DFlashGroupedConv(
+            **conv_args, prefix=maybe_prefix(prefix, "mlp_conv")
+        )
+
+    def forward(
+        self,
+        positions: torch.Tensor,
+        hidden_states: torch.Tensor,
+        residual: torch.Tensor | None,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        if residual is None:
+            residual = hidden_states
+            hidden_states = self.input_layernorm(hidden_states)
+        else:
+            hidden_states, residual = self.input_layernorm(hidden_states, residual)
+
+        hidden_states, coefficients = self.attention_conv.prepare(hidden_states)
+        hidden_states = self.self_attn(positions=positions, hidden_states=hidden_states)
+        hidden_states = self.attention_conv.finish(hidden_states, coefficients)
+
+        hidden_states, residual = self.post_attention_layernorm(hidden_states, residual)
+        hidden_states, coefficients = self.mlp_conv.prepare(hidden_states)
+        hidden_states = self.mlp(hidden_states)
+        hidden_states = self.mlp_conv.finish(hidden_states, coefficients)
+        return hidden_states, residual
+
+
+def _score_edges(
+    predecessor_table: torch.Tensor,
+    successor_table: torch.Tensor,
+    candidate_ids: torch.Tensor,
+    unary_logits: torch.Tensor,
+    hidden: torch.Tensor,
+    anchor_token_ids: torch.Tensor,
+    top_k: int,
+) -> torch.Tensor:
+    successors = successor_table[candidate_ids]
+    predecessor_ids = torch.cat(
+        (
+            anchor_token_ids[:, None, None].expand(-1, 1, top_k),
+            candidate_ids[:, :-1],
+        ),
+        dim=1,
+    )
+    predecessors = predecessor_table[predecessor_ids]
+    return unary_logits[:, :, None] + torch.einsum(
+        "blpr,blcr->blpc", predecessors * hidden[:, :, None], successors
+    )
+
+
+@support_torch_compile
+class CandidateSelector(nn.Module):
+    def __init__(
+        self,
+        hidden_size: int,
+        vocab_size: int,
+        rank: int,
+        top_k: int,
+        params_dtype: torch.dtype,
+        prefix: str,
+    ) -> None:
+        super().__init__()
+        self.top_k = top_k
+        self.predecessor_codebook = nn.Parameter(
+            torch.empty(vocab_size, rank, dtype=params_dtype), requires_grad=False
+        )
+        self.successor_codebook = nn.Parameter(
+            torch.empty(vocab_size, rank, dtype=params_dtype), requires_grad=False
+        )
+        self.hidden_projection = ReplicatedLinear(
+            hidden_size,
+            rank,
+            bias=False,
+            params_dtype=params_dtype,
+            quant_config=None,
+            prefix=maybe_prefix(prefix, "hidden_projection"),
+            return_bias=False,
+        )
+
+    def forward(
+        self,
+        candidate_ids: torch.Tensor,
+        unary_logits: torch.Tensor,
+        hidden_states: torch.Tensor,
+        anchor_token_ids: torch.Tensor,
+    ) -> torch.Tensor:
+        hidden = self.hidden_projection(hidden_states)
+        return _score_edges(
+            self.predecessor_codebook,
+            self.successor_codebook,
+            candidate_ids,
+            unary_logits,
+            hidden,
+            anchor_token_ids,
+            self.top_k,
+        )
+
+
+class DFlash2Qwen3Model(DFlashQwen3Model):
+    decoder_layer_cls = DFlash2Qwen3DecoderLayer
+
+    def __init__(
+        self,
+        *,
+        vllm_config: VllmConfig,
+        start_layer_id: int = 0,
+        prefix: str = "",
+    ) -> None:
+        super().__init__(
+            vllm_config=vllm_config,
+            start_layer_id=start_layer_id,
+            prefix=prefix,
+        )
+        draft_config = self.config.dflash_config
+        self.use_sm70_bf16_emulation = _use_sm70_bf16_emulation(self.config)
+        if self.use_sm70_bf16_emulation:
+            runtime_dtype = vllm_config.model_config.dtype
+            self.hidden_norm = DFlashSM70RMSNorm(
+                self.config.hidden_size,
+                self.config.rms_norm_eps,
+                runtime_dtype,
+                residual_scale=1.0,
+            )
+            self.norm = DFlashSM70RMSNorm(
+                self.config.hidden_size,
+                self.config.rms_norm_eps,
+                runtime_dtype,
+            )
+            logger.info_once(
+                "Using range-preserving BF16 DFlash2 arithmetic on SM70 "
+                "(FP32 residual, BF16 RNE, scaled FP16 projections)."
+            )
+        self.input_embedding_scale = float(
+            draft_config.get("input_embedding_scale", 1.0)
+        )
+        # The selector is compiled separately from the draft backbone. A unique
+        # model tag prevents the two incompatible input signatures from sharing
+        # a persistent compile-cache namespace.
+        with set_model_tag("dflash2_candidate_selector"):
+            self.candidate_selector = CandidateSelector(
+                hidden_size=self.config.hidden_size,
+                vocab_size=self.config.vocab_size,
+                rank=int(draft_config["selector_rank"]),
+                top_k=int(draft_config["selector_top_k"]),
+                params_dtype=vllm_config.model_config.dtype,
+                prefix=maybe_prefix(prefix, "candidate_selector"),
+            )
+
+    def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
+        return super().embed_input_ids(input_ids) * self.input_embedding_scale
+
+    def _normalize_context_states(self, context_states: torch.Tensor) -> torch.Tensor:
+        if self.use_sm70_bf16_emulation:
+            return self.hidden_norm(context_states)
+        return super()._normalize_context_states(context_states)
+
+
+class DFlash2Qwen3ForCausalLM(DFlashQwen3ForCausalLM):
+    model_cls = DFlash2Qwen3Model
+
+    def __init__(self, *, vllm_config: VllmConfig, prefix: str = "") -> None:
+        super().__init__(vllm_config=vllm_config, prefix=prefix)
+        draft_config = self.config.dflash_config
+        self.output_multiplier = float(draft_config.get("output_multiplier", 1.0))
+        softcap = float(draft_config.get("final_logit_softcapping") or 0.0)
+        self.final_logit_softcapping = softcap if softcap > 0 else None
+
+    def compute_candidates(
+        self, hidden_states: torch.Tensor
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        if not isinstance(
+            self.lm_head.quant_method,
+            (UnquantizedEmbeddingMethod, UnquantizedLinearMethod),
+        ):
+            raise ValueError(
+                "DFlash2 requires an unquantized target LM head for candidate TopK; "
+                f"got {type(self.lm_head.quant_method).__name__}."
+            )
+
+        selector = self.model.candidate_selector
+        logits = self.lm_head.quant_method.apply(self.lm_head, hidden_states, bias=None)
+        num_pad = self.lm_head.shard_indices.num_org_vocab_padding
+        if num_pad > 0:
+            logits[..., -num_pad:] = -float("inf")
+        values, ids = _topk(logits, selector.top_k)
+        ids = ids.to(torch.int64) + self.lm_head.shard_indices.org_vocab_start_index
+
+        if get_tensor_model_parallel_world_size() > 1:
+            values = tensor_model_parallel_all_gather(values, dim=-1)
+            ids = tensor_model_parallel_all_gather(ids, dim=-1)
+            values, selected = _topk(values, selector.top_k)
+            ids = ids.gather(-1, selected)
+
+        values = values.float() * self.output_multiplier
+        if self.final_logit_softcapping is not None:
+            cap = self.final_logit_softcapping
+            values = torch.tanh(values / cap) * cap
+        return ids, values
+
+
+EntryClass = DFlash2Qwen3ForCausalLM

--- a/vllm/model_executor/models/registry.py
+++ b/vllm/model_executor/models/registry.py
@@ -598,6 +598,7 @@ _SPECULATIVE_DECODING_MODELS = {
     "EagleLlama4ForCausalLM": ("llama4_eagle", "EagleLlama4ForCausalLM"),
     "EagleMiniCPMForCausalLM": ("minicpm_eagle", "EagleMiniCPMForCausalLM"),
     "DFlashDraftModel": ("qwen3_dflash", "DFlashQwen3ForCausalLM"),
+    "DFlash2DraftModel": ("qwen3_dflash2", "DFlash2Qwen3ForCausalLM"),
     "DSparkDraftModel": (
         "vllm.models.deepseek_v4",
         "DSparkDeepseekV4ForCausalLM",

--- a/vllm/v1/attention/backends/flash_attn_v100.py
+++ b/vllm/v1/attention/backends/flash_attn_v100.py
@@ -799,7 +799,12 @@ def _get_flash_ops():
                 _flash_attn_prefill_paged_splitkv = flash_attn_prefill_paged_splitkv
             except ImportError:
                 _flash_attn_prefill_paged_splitkv = None
-        except ImportError:
+        except ImportError as exc:
+            logger.warning_once(
+                "Flash-V100 Python operators could not be imported (%s: %s).",
+                type(exc).__name__,
+                exc,
+            )
             _flash_attn_func = None
             _flash_attn_bhmd_func = None
             _flash_attn_decode_paged = None
@@ -2506,6 +2511,9 @@ class FlashAttnV100MetadataBuilder(TritonAttentionMetadataBuilder):
             and getattr(cache_config, "cache_dtype", None) == "fp8_e5m2"
             and batch_context_shape_supported
         )
+        self._is_dflash_draft_model = self._is_speculative_draft_model and (
+            getattr(spec_config, "method", None) == "dflash"
+        )
         self._draft_block_table: torch.Tensor | None = None
         self._draft_seq_lens: torch.Tensor | None = None
         self._draft_query_start_loc: torch.Tensor | None = None
@@ -3249,12 +3257,13 @@ class FlashAttnV100MetadataBuilder(TritonAttentionMetadataBuilder):
                 workspace_seq_capacity_cap=workspace_seq_capacity_cap,
                 partition_size_hint=partition_size_hint,
             )
-        else:
+        if max_query_len == 1 or self._is_dflash_draft_model:
             # PIECEWISE graph replay captures the q=1 decode kernel arguments
             # during metadata warmup. Runtime drafting updates the persistent
-            # draft metadata buffers in build_for_drafting(), so capture must
-            # bind the graph to the same buffers instead of transient dummy
-            # capture tensors.
+            # draft metadata buffers, so capture must bind the graph to the
+            # same buffers instead of transient dummy capture tensors. DFlash
+            # parallel drafting has q=K+1; its non-causal paged-prefill graph
+            # consumes the same dynamic block table and sequence lengths.
             self._stabilize_draft_graph_metadata(
                 attn_metadata,
                 common_attn_metadata,
@@ -3298,13 +3307,14 @@ class FlashAttnV100MetadataBuilder(TritonAttentionMetadataBuilder):
             and getattr(attn_metadata, "max_query_len", 1) > 1
             and bool(torch.any(ddtree_num_tree_tokens_cpu[:num_reqs] > 0).item())
         )
-        if (
+        if self._flash_draft_buffer_shape is not None and (
             getattr(attn_metadata, "max_query_len", 1) == 1
-            and self._flash_draft_buffer_shape is not None
+            or self._is_dflash_draft_model
         ):
             # FULL graph capture binds q=1 decode to these persistent buffers.
-            # Refresh them on every runtime decode step so replay sees the
-            # current request's block table and sequence metadata.
+            # DFlash binds its q=K+1 paged-prefill graph to the same buffers.
+            # Refresh them on every runtime step so replay sees the current
+            # request's block table and sequence metadata.
             self._stabilize_draft_graph_metadata(
                 attn_metadata,
                 common_attn_metadata,
@@ -4403,7 +4413,14 @@ class FlashAttnV100Impl(TritonAttentionImpl):
                 "Flash op is unavailable or the attention features/KV cache dtype "
                 "are unsupported. Select TRITON_ATTN for a full Triton route, or "
                 "set VLLM_FLASH_V100_ALLOW_TRITON_FALLBACK=1 for explicit "
-                "diagnostic fallback."
+                "diagnostic fallback. "
+                f"Details: layer={layer_info.get('layer_name')!r}, "
+                f"flash_ops_available={self.use_flash_v100}, "
+                f"attn_type={self.attn_type!r}, "
+                f"has_alibi={self.alibi_slopes is not None}, "
+                f"logits_soft_cap={self.logits_soft_cap!r}, "
+                f"has_sinks={self.sinks is not None}, "
+                f"kv_cache_dtype={self.kv_cache_dtype!r}."
             )
             if not (self.allow_triton_fallback or is_dflash_draft_attn):
                 raise RuntimeError(message)
@@ -4534,6 +4551,26 @@ class FlashAttnV100Impl(TritonAttentionImpl):
                 # look like no-prefix prefill, while replayed MTP verification
                 # is a uniform small-query decode over an existing KV prefix.
                 # Capture the same small-query kernel branch that replay needs.
+                is_dflash_non_causal = bool(
+                    getattr(layer, "is_dflash_draft_attn", False)
+                ) and not bool(getattr(attn_metadata, "causal", True))
+                if is_dflash_non_causal:
+                    # DFlash pre-inserts target context K/V before replay. Its
+                    # dummy capture has seq_len == query_len and would
+                    # otherwise freeze the no-prefix dense branch into the
+                    # graph. Bind directly to the non-causal paged-prefix
+                    # kernel; runtime updates its persistent sequence and
+                    # block-table buffers before every replay.
+                    _record_route("prefill_capture_dflash_noncausal_paged")
+                    return self._flash_v100_prefill_with_prefix(
+                        layer,
+                        query,
+                        key,
+                        value,
+                        kv_cache,
+                        attn_metadata,
+                        output,
+                    )
                 smallq_decode = self._small_query_decode_enabled(attn_metadata)
                 if smallq_decode:
                     if _draft_graph_debug_enabled():

--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -1043,8 +1043,23 @@ def unify_kv_cache_spec_page_size(
                 )
             ratio = max_page_size // layer_page_size
             new_block_size = layer_spec.block_size * ratio
-            new_spec = replace(layer_spec, block_size=new_block_size)
-            assert new_spec.page_size_bytes == max_page_size
+            replace_args = {"block_size": new_block_size}
+            # A padded page does not grow when only block_size changes. This
+            # happens for hybrid Mamba targets when a higher-precision draft
+            # cache has a larger page than the target cache. Keep the logical
+            # block-size adjustment and grow the physical padding with it.
+            if (
+                isinstance(layer_spec, MambaSpec)
+                or getattr(layer_spec, "page_size_padded", None) is not None
+            ):
+                replace_args["page_size_padded"] = max_page_size
+            new_spec = replace(layer_spec, **replace_args)
+            assert new_spec.page_size_bytes == max_page_size, (
+                f"Failed to unify KV page for {layer_name}: "
+                f"spec={layer_spec!r}, old_page={layer_page_size}, "
+                f"target_page={max_page_size}, replacement={replace_args!r}, "
+                f"new_page={new_spec.page_size_bytes}"
+            )
             new_kv_cache_spec[layer_name] = new_spec
     return new_kv_cache_spec
 

--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -611,12 +611,12 @@ def resolve_kv_cache_block_sizes(
     if not (cache_config.enable_prefix_caching or connector_enabled):
         return scheduler_block_size, scheduler_block_size
 
-    # Mamba groups with block_size != cache_config.block_size
-    # (mamba_cache_mode != "align") break divisibility; back off to the
-    # scheduler block size.
+    # Mamba groups outside align mode break divisibility; back off to the
+    # scheduler block size. Read the mode from the resolved group spec because
+    # its block size may have been updated independently of cache_config.
     if any(
         isinstance(g.kv_cache_spec, MambaSpec)
-        and g.kv_cache_spec.block_size != cache_config.block_size
+        and g.kv_cache_spec.mamba_cache_mode != "align"
         for g in groups
     ):
         return scheduler_block_size, scheduler_block_size

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -247,25 +247,10 @@ class Scheduler(SchedulerInterface):
         )
 
         self.use_eagle = False
-        self.num_spec_tokens = self.num_lookahead_tokens = 0
-        if speculative_config:
-            self.num_spec_tokens = speculative_config.num_speculative_tokens
-            if speculative_config.use_eagle():
-                self.use_eagle = True
-                self.num_lookahead_tokens = self.num_spec_tokens
-            if speculative_config.uses_draft_model():
-                self.num_lookahead_tokens = self.num_spec_tokens
-            if speculative_config.use_dflash_family():
-                # DFlash requires an extra lookahead slot since it uses in-fill-style
-                # decoding instead of standard next-token sampling, so it has a query
-                # for the last sampled token plus queries for each draft token.
-                self.num_lookahead_tokens = (
-                    speculative_config.num_speculative_state_tokens() + 1
-                )
-            if speculative_config.use_dspark():
-                # The anchor itself is the first prediction position, with no
-                # separate bonus query, so DSpark needs exactly N slots.
-                self.num_lookahead_tokens = self.num_spec_tokens
+        self.num_spec_tokens = vllm_config.num_speculative_tokens
+        self.num_lookahead_tokens = vllm_config.num_lookahead_tokens
+        if speculative_config and speculative_config.use_eagle_kv_cache():
+            self.use_eagle = True
 
         # Create the KV cache manager.
         if hash_block_size is None:

--- a/vllm/v1/worker/gpu/attn_utils.py
+++ b/vllm/v1/worker/gpu/attn_utils.py
@@ -389,7 +389,7 @@ def build_attn_metadata(
     positions: torch.Tensor | None = None,
     model_specific_attn_metadata: ModelSpecificAttnMetadata | None = None,
     for_cudagraph_capture: bool = False,
-    causal: bool | Mapping[int, bool] = True,
+    causal: bool | torch.Tensor | Mapping[int, bool] = True,
 ) -> dict[str, Any]:
     seq_lens = seq_lens[:num_reqs]
     if dcp_local_seq_lens is not None:
@@ -402,7 +402,12 @@ def build_attn_metadata(
     for i in range(num_kv_cache_groups):
         block_table = block_tables[i]
         slot_mapping = slot_mappings[i]
-        group_causal = causal if isinstance(causal, bool) else causal.get(i, True)
+        # Hybrid drafters can assign different causality to each KV group.
+        # A Mapping must be resolved here; passing the dict itself into the
+        # backend metadata makes it truthy and silently selects causal kernels.
+        group_causal = (
+            causal if isinstance(causal, (bool, torch.Tensor)) else causal.get(i, True)
+        )
 
         common_attn_metadata_extra_kwargs = (
             model_specific_attn_metadata.get_extra_common_attn_kwargs(i, num_reqs)

--- a/vllm/v1/worker/gpu/mamba_align.py
+++ b/vllm/v1/worker/gpu/mamba_align.py
@@ -1,0 +1,319 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""MRV2 GPU state migration for hybrid Mamba ``align`` prefix caching.
+
+This is the narrow Model Runner V2 portion of upstream vLLM PR #42406.  It is
+kept separate from :mod:`vllm.v1.worker.mamba_utils` because that module also
+owns this tree's V1 DDTree state-selection compatibility path.
+"""
+
+import torch
+
+from vllm.triton_utils import tl, triton
+from vllm.v1.worker.mamba_utils import MambaSpecDecodeGPUContext
+
+# Temporal states are much larger than conv states. Splitting their byte range
+# keeps block-boundary copies from serializing on one CTA at small batch sizes.
+_TEMPORAL_TILES = 16
+
+
+@triton.jit
+def _copy_mamba_state_block(
+    state_idx,
+    block_table_row,
+    src_col,
+    dst_col,
+    token_bias,
+    block_table_ptrs_ptr,
+    block_table_stride_req,
+    state_base_addrs_ptr,
+    state_block_strides_ptr,
+    state_elem_sizes_ptr,
+    state_inner_sizes_ptr,
+    state_conv_widths_ptr,
+    state_group_indices_ptr,
+    tile_idx,
+    COPY_BLOCK_SIZE: tl.constexpr,
+    TEMPORAL_TILES: tl.constexpr,
+):
+    """Copy one SD-layout conv or temporal state using V1 align semantics."""
+    state_base_addr = tl.load(state_base_addrs_ptr + state_idx)
+    state_block_stride = tl.load(state_block_strides_ptr + state_idx)
+    state_elem_size = tl.load(state_elem_sizes_ptr + state_idx).to(tl.int64)
+    state_inner_size = tl.load(state_inner_sizes_ptr + state_idx).to(tl.int64)
+    conv_width = tl.load(state_conv_widths_ptr + state_idx)
+
+    group_idx = tl.load(state_group_indices_ptr + state_idx).to(tl.int64)
+    group_base_addr = tl.load(block_table_ptrs_ptr + group_idx)
+    block_table = group_base_addr.to(tl.pointer_type(tl.int32))
+    block_table += block_table_row * block_table_stride_req
+
+    dst_block_id = tl.load(block_table + dst_col).to(tl.int64)
+    dst_addr = state_base_addr + dst_block_id * state_block_stride
+    is_conv_state = conv_width > 0
+
+    if is_conv_state:
+        # Conv states are small and may be shifted left within the same block.
+        # One CTA owns the copy so a block-local barrier can make each chunk
+        # memmove-safe before lower addresses overwrite overlapping input.
+        if tile_idx > 0:
+            return
+        src_block_id = tl.load(block_table + src_col).to(tl.int64)
+        token_bytes = state_inner_size * state_elem_size
+        src_addr = (
+            state_base_addr
+            + src_block_id * state_block_stride
+            + token_bias.to(tl.int64) * token_bytes
+        )
+        copy_size = (conv_width - token_bias).to(tl.int64) * token_bytes
+        tile_start = copy_size * 0
+        tile_end = copy_size
+        is_left_overlap = (dst_addr < src_addr) & (dst_addr + copy_size > src_addr)
+    else:
+        # Temporal state chooses the accepted speculative column.
+        src_block_id = tl.load(block_table + src_col + token_bias).to(tl.int64)
+        src_addr = state_base_addr + src_block_id * state_block_stride
+        copy_size = state_inner_size * state_elem_size
+        bytes_per_tile = (copy_size + TEMPORAL_TILES - 1) // TEMPORAL_TILES
+        tile_start = tile_idx.to(tl.int64) * bytes_per_tile
+        tile_end = tl.minimum(tile_start + bytes_per_tile, copy_size)
+        is_left_overlap = False
+
+    offsets = tl.arange(0, COPY_BLOCK_SIZE)
+    for chunk_start in range(tile_start, tile_end, COPY_BLOCK_SIZE):
+        byte_offsets = chunk_start + offsets
+        mask = byte_offsets < tile_end
+        src = (src_addr + byte_offsets).to(tl.pointer_type(tl.uint8))
+        dst = (dst_addr + byte_offsets).to(tl.pointer_type(tl.uint8))
+        data = tl.load(src, mask=mask)
+        if is_left_overlap:
+            tl.debug_barrier()
+        tl.store(dst, data, mask=mask)
+
+
+@triton.jit
+def preprocess_mamba_align_fused_kernel(
+    idx_mapping_ptr,
+    state_idx_ptr,
+    num_computed_tokens_ptr,
+    query_start_loc_ptr,
+    num_accepted_tokens_ptr,
+    src_col_ptr,
+    token_bias_ptr,
+    num_reqs,
+    BLOCK_SIZE: tl.constexpr,
+    MAMBA_BLOCK_SIZE: tl.constexpr,
+):
+    """Advance running state columns and emit any required pre-copy inputs."""
+    rows = tl.program_id(0) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    mask = rows < num_reqs
+    req_indices = tl.load(idx_mapping_ptr + rows, mask=mask, other=0)
+
+    state_idx = tl.load(state_idx_ptr + req_indices, mask=mask, other=-1)
+    num_computed = tl.load(num_computed_tokens_ptr + req_indices, mask=mask, other=0)
+    # A new request is seeded here, after the resolved MambaSpec is available.
+    # cache_config.block_size can be smaller than the actual Mamba block when
+    # an FP16 DFlash cache shares the hybrid page pool, so add_request cannot
+    # derive the state column from the global cache block size.
+    seeded_state_idx = (num_computed + MAMBA_BLOCK_SIZE - 1) // MAMBA_BLOCK_SIZE - 1
+    state_idx = tl.where(state_idx == -2, seeded_state_idx, state_idx)
+    num_accepted = tl.load(num_accepted_tokens_ptr + req_indices, mask=mask, other=1)
+    token_bias = tl.maximum(num_accepted - 1, 0)
+    tl.store(src_col_ptr + req_indices, state_idx, mask=mask)
+    tl.store(token_bias_ptr + req_indices, token_bias, mask=mask)
+
+    query_start = tl.load(query_start_loc_ptr + rows, mask=mask, other=0)
+    query_end = tl.load(query_start_loc_ptr + rows + 1, mask=mask, other=0)
+    computed_after = num_computed + query_end - query_start
+    new_state_idx = (computed_after + MAMBA_BLOCK_SIZE - 1) // MAMBA_BLOCK_SIZE - 1
+    tl.store(state_idx_ptr + req_indices, new_state_idx, mask=mask)
+    crossed_boundary = (state_idx >= 0) & (state_idx != new_state_idx)
+    tl.store(
+        num_accepted_tokens_ptr + req_indices,
+        1,
+        mask=mask & crossed_boundary,
+    )
+
+
+@triton.jit
+def _precopy_mamba_align_kernel(
+    state_idx_ptr,
+    src_col_ptr,
+    token_bias_ptr,
+    block_table_ptrs_ptr,
+    block_table_stride_req,
+    state_base_addrs_ptr,
+    state_block_strides_ptr,
+    state_elem_sizes_ptr,
+    state_inner_sizes_ptr,
+    state_conv_widths_ptr,
+    state_group_indices_ptr,
+    idx_mapping_ptr,
+    num_reqs,
+    COPY_BLOCK_SIZE: tl.constexpr,
+    TEMPORAL_TILES: tl.constexpr,
+):
+    batch_idx = tl.program_id(0)
+    state_idx = tl.program_id(1)
+    tile_idx = tl.program_id(2)
+    if batch_idx >= num_reqs:
+        return
+    req_idx = tl.load(idx_mapping_ptr + batch_idx)
+    if req_idx < 0:
+        return
+
+    src_col = tl.load(src_col_ptr + req_idx)
+    dst_col = tl.load(state_idx_ptr + req_idx)
+    if src_col < 0 or src_col == dst_col:
+        return
+    token_bias = tl.load(token_bias_ptr + req_idx)
+    _copy_mamba_state_block(
+        state_idx,
+        batch_idx,
+        src_col,
+        dst_col,
+        token_bias,
+        block_table_ptrs_ptr,
+        block_table_stride_req,
+        state_base_addrs_ptr,
+        state_block_strides_ptr,
+        state_elem_sizes_ptr,
+        state_inner_sizes_ptr,
+        state_conv_widths_ptr,
+        state_group_indices_ptr,
+        tile_idx,
+        COPY_BLOCK_SIZE,
+        TEMPORAL_TILES,
+    )
+
+
+@triton.jit
+def _postprocess_mamba_align_kernel(
+    num_accepted_snapshot_ptr,
+    num_accepted_out_ptr,
+    state_idx_ptr,
+    new_num_computed_tokens_ptr,
+    block_table_ptrs_ptr,
+    block_table_stride_req,
+    state_base_addrs_ptr,
+    state_block_strides_ptr,
+    state_elem_sizes_ptr,
+    state_inner_sizes_ptr,
+    state_conv_widths_ptr,
+    state_group_indices_ptr,
+    idx_mapping_ptr,
+    num_reqs,
+    MAMBA_BLOCK_SIZE: tl.constexpr,
+    COPY_BLOCK_SIZE: tl.constexpr,
+    TEMPORAL_TILES: tl.constexpr,
+):
+    batch_idx = tl.program_id(0)
+    state_meta_idx = tl.program_id(1)
+    tile_idx = tl.program_id(2)
+    if batch_idx >= num_reqs:
+        return
+    req_idx = tl.load(idx_mapping_ptr + batch_idx)
+    if req_idx < 0:
+        return
+
+    num_accepted = tl.load(num_accepted_snapshot_ptr + req_idx)
+    src_col = tl.load(state_idx_ptr + req_idx)
+    new_num_computed = tl.load(new_num_computed_tokens_ptr + req_idx)
+    num_tokens_running_state = new_num_computed - num_accepted + 1
+    aligned_new_computed = (new_num_computed // MAMBA_BLOCK_SIZE) * MAMBA_BLOCK_SIZE
+    if aligned_new_computed < num_tokens_running_state:
+        return
+
+    token_bias = aligned_new_computed - num_tokens_running_state
+    dst_col = aligned_new_computed // MAMBA_BLOCK_SIZE - 1
+    if src_col == dst_col and state_meta_idx == 0 and tile_idx == 0:
+        tl.store(num_accepted_out_ptr + req_idx, 1)
+    if src_col == dst_col and token_bias == 0:
+        return
+
+    _copy_mamba_state_block(
+        state_meta_idx,
+        batch_idx,
+        src_col,
+        dst_col,
+        token_bias,
+        block_table_ptrs_ptr,
+        block_table_stride_req,
+        state_base_addrs_ptr,
+        state_block_strides_ptr,
+        state_elem_sizes_ptr,
+        state_inner_sizes_ptr,
+        state_conv_widths_ptr,
+        state_group_indices_ptr,
+        tile_idx,
+        COPY_BLOCK_SIZE,
+        TEMPORAL_TILES,
+    )
+
+
+def run_mamba_align_precopy(
+    ctx: MambaSpecDecodeGPUContext,
+    num_reqs: int,
+    state_idx: torch.Tensor,
+    src_col: torch.Tensor,
+    token_bias: torch.Tensor,
+    idx_mapping: torch.Tensor,
+) -> None:
+    if num_reqs == 0 or not ctx.is_initialized:
+        return
+    total_states = ctx.num_layers * ctx.num_state_types
+    grid = (num_reqs, total_states, _TEMPORAL_TILES)
+    _precopy_mamba_align_kernel[grid](
+        state_idx,
+        src_col,
+        token_bias,
+        ctx.block_table_ptrs,
+        ctx.block_table_stride_req,
+        ctx.state_base_addrs,
+        ctx.state_block_strides,
+        ctx.state_elem_sizes,
+        ctx.state_inner_sizes,
+        ctx.state_conv_widths,
+        ctx.state_group_indices,
+        idx_mapping,
+        num_reqs,
+        COPY_BLOCK_SIZE=1024,
+        TEMPORAL_TILES=_TEMPORAL_TILES,
+    )
+
+
+def run_mamba_align_postprocess(
+    ctx: MambaSpecDecodeGPUContext,
+    num_reqs: int,
+    num_accepted_tokens: torch.Tensor,
+    state_idx: torch.Tensor,
+    new_num_computed_tokens: torch.Tensor,
+    idx_mapping: torch.Tensor,
+) -> None:
+    if num_reqs == 0 or not ctx.is_initialized:
+        return
+    # Snapshot the decision array because one program may reset a request's
+    # output count while programs copying other state tensors still read it.
+    snapshot = ctx.num_accepted_tokens_out
+    snapshot.copy_(num_accepted_tokens)
+    total_states = ctx.num_layers * ctx.num_state_types
+    grid = (num_reqs, total_states, _TEMPORAL_TILES)
+    _postprocess_mamba_align_kernel[grid](
+        snapshot,
+        num_accepted_tokens,
+        state_idx,
+        new_num_computed_tokens,
+        ctx.block_table_ptrs,
+        ctx.block_table_stride_req,
+        ctx.state_base_addrs,
+        ctx.state_block_strides,
+        ctx.state_elem_sizes,
+        ctx.state_inner_sizes,
+        ctx.state_conv_widths,
+        ctx.state_group_indices,
+        idx_mapping,
+        num_reqs,
+        MAMBA_BLOCK_SIZE=ctx.block_size,
+        COPY_BLOCK_SIZE=1024,
+        TEMPORAL_TILES=_TEMPORAL_TILES,
+    )

--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -1019,7 +1019,11 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             self.req_states.total_len.gpu,
         )
 
-        self.model_state.postprocess_state(input_batch, num_sampled)
+        self.model_state.postprocess_state(
+            input_batch,
+            num_sampled,
+            self.req_states.num_computed_tokens.gpu,
+        )
 
     @torch.inference_mode()
     def execute_model(
@@ -1075,6 +1079,14 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             # Prepare all the inputs and copy to the input buffers.
             input_batch = self.prepare_inputs(scheduler_output, batch_desc)
             block_tables, slot_mappings = self.prepare_attn(input_batch)
+            # Hybrid Mamba align-mode prefix caching migrates recurrent state
+            # across block boundaries before attention metadata consumes it.
+            self.model_state.preprocess_state(
+                input_batch,
+                block_tables,
+                self.kv_cache_config,
+                self.req_states.num_computed_tokens.gpu,
+            )
 
             if self.lora_config:
                 # Activate LoRA adapters.

--- a/vllm/v1/worker/gpu/model_states/interface.py
+++ b/vllm/v1/worker/gpu/model_states/interface.py
@@ -56,10 +56,21 @@ class ModelState(ABC):
     def apply_staged_writes(self) -> None:
         return None
 
+    def preprocess_state(
+        self,
+        input_batch: InputBatch,
+        block_tables: tuple[torch.Tensor, ...],
+        kv_cache_config: KVCacheConfig,
+        num_computed_tokens: torch.Tensor,
+    ) -> None:
+        """Hook for model-specific state movement before a real forward."""
+        return None
+
     def postprocess_state(
         self,
         input_batch: InputBatch,
         num_sampled: torch.Tensor,
+        num_computed_tokens: torch.Tensor | None = None,
     ) -> None:
         return None
 

--- a/vllm/v1/worker/gpu/model_states/mamba_hybrid.py
+++ b/vllm/v1/worker/gpu/model_states/mamba_hybrid.py
@@ -9,14 +9,28 @@ import torch.nn as nn
 
 from vllm.config import VllmConfig
 from vllm.config.compilation import CUDAGraphMode
+from vllm.model_executor.layers.mamba.mamba_utils import (
+    get_conv_copy_spec,
+    is_conv_state_dim_first,
+)
+from vllm.triton_utils import triton
+from vllm.utils.platform_utils import is_pin_memory_available
 from vllm.v1.attention.backends.gdn_attn import GDNAttentionMetadataBuilder
 from vllm.v1.attention.backends.mamba2_attn import Mamba2AttentionMetadataBuilder
-from vllm.v1.kv_cache_interface import KVCacheConfig
+from vllm.v1.core.sched.output import NewRequestData
+from vllm.v1.kv_cache_interface import KVCacheConfig, MambaSpec
+from vllm.v1.utils import CpuGpuBuffer
 from vllm.v1.worker.gpu.attn_utils import build_attn_metadata
 from vllm.v1.worker.gpu.input_batch import InputBatch
+from vllm.v1.worker.gpu.mamba_align import (
+    preprocess_mamba_align_fused_kernel,
+    run_mamba_align_postprocess,
+    run_mamba_align_precopy,
+)
 from vllm.v1.worker.gpu.mm.encoder_cache import EncoderCache
 from vllm.v1.worker.gpu.model_states.default import DefaultModelState
 from vllm.v1.worker.gpu.model_states.interface import ModelSpecificAttnMetadata
+from vllm.v1.worker.mamba_utils import MambaSpecDecodeGPUContext
 from vllm.v1.worker.utils import AttentionGroup
 
 
@@ -64,8 +78,126 @@ class MambaHybridModelState(DefaultModelState):
         device: torch.device,
     ) -> None:
         super().__init__(vllm_config, model, encoder_cache, device)
+        self.cache_config = vllm_config.cache_config
         self.num_accepted_tokens_gpu = torch.ones(
             self.max_num_reqs, dtype=torch.int32, device=self.device
+        )
+        self._align_mode = self.cache_config.mamba_cache_mode == "align"
+        if self._align_mode:
+            self._mamba_state_idx_gpu = torch.full(
+                (self.max_num_reqs,), -2, dtype=torch.int32, device=self.device
+            )
+            self._mamba_src_col_gpu = torch.full(
+                (self.max_num_reqs,), -1, dtype=torch.int32, device=self.device
+            )
+            self._mamba_token_bias_gpu = torch.zeros(
+                self.max_num_reqs, dtype=torch.int32, device=self.device
+            )
+            self._mamba_ctx: MambaSpecDecodeGPUContext | None = None
+            self._mamba_group_ids: list[int] = []
+            self._mamba_spec: MambaSpec | None = None
+
+    def add_request(self, req_index: int, new_req_data: NewRequestData) -> None:
+        super().add_request(req_index, new_req_data)
+        # A recycled request slot may contain the previous request's accepted
+        # count. The neutral value is required in both align and non-align mode.
+        self.num_accepted_tokens_gpu[req_index].fill_(1)
+        if self._align_mode:
+            # Delay state-column seeding until preprocess_state has the
+            # resolved MambaSpec block size. -2 is distinct from -1 (fresh
+            # request with no computed state).
+            self._mamba_state_idx_gpu[req_index].fill_(-2)
+
+    def _get_mamba_group_info(
+        self, kv_cache_config: KVCacheConfig
+    ) -> tuple[list[int], MambaSpec]:
+        if self._mamba_spec is None:
+            group_ids: list[int] = []
+            specs: list[MambaSpec] = []
+            for group_id, group in enumerate(kv_cache_config.kv_cache_groups):
+                if isinstance(group.kv_cache_spec, MambaSpec):
+                    group_ids.append(group_id)
+                    specs.append(group.kv_cache_spec)
+            assert specs, "no mamba layers in the model"
+            assert all(specs[0] == spec for spec in specs)
+            self._mamba_group_ids = group_ids
+            self._mamba_spec = specs[0]
+        return self._mamba_group_ids, self._mamba_spec
+
+    def _ensure_align_ctx(
+        self,
+        kv_cache_config: KVCacheConfig,
+        mamba_group_ids: list[int],
+        block_tables: tuple[torch.Tensor, ...],
+    ) -> MambaSpecDecodeGPUContext:
+        if self._mamba_ctx is None:
+            copy_funcs = self.model.get_mamba_state_copy_func()
+            # This V100 closure intentionally retains the tree's default SD
+            # layout. The official DS-row extension is unrelated to Qwen3.8's
+            # configured path and would expand the DDTree-sensitive closure.
+            if get_conv_copy_spec in copy_funcs and is_conv_state_dim_first():
+                raise ValueError(
+                    "MRV2 align prefix caching with speculative decoding requires "
+                    "the default SD Mamba conv-state layout on this V100 path."
+                )
+            self._mamba_ctx = MambaSpecDecodeGPUContext.create(
+                max_num_reqs=self.max_num_reqs,
+                kv_cache_config=kv_cache_config,
+                num_state_types=len(copy_funcs),
+                device=self.device,
+                make_buffer=lambda n, dtype: CpuGpuBuffer(
+                    n,
+                    dtype=dtype,
+                    device=self.device,
+                    pin_memory=is_pin_memory_available(),
+                ),
+            )
+        ctx = self._mamba_ctx
+        if not ctx.is_initialized:
+            forward_context = self.vllm_config.compilation_config.static_forward_context
+            ctx.initialize_from_forward_context(
+                kv_cache_config,
+                forward_context,
+                self.model.get_mamba_state_copy_func(),
+                [block_tables[group_id] for group_id in mamba_group_ids],
+            )
+        return ctx
+
+    def preprocess_state(
+        self,
+        input_batch: InputBatch,
+        block_tables: tuple[torch.Tensor, ...],
+        kv_cache_config: KVCacheConfig,
+        num_computed_tokens: torch.Tensor,
+    ) -> None:
+        """Move align-mode recurrent state before a real MRV2 forward."""
+        if not self._align_mode or input_batch.num_reqs == 0:
+            return
+        mamba_group_ids, mamba_spec = self._get_mamba_group_info(kv_cache_config)
+        ctx = self._ensure_align_ctx(kv_cache_config, mamba_group_ids, block_tables)
+
+        block = 256
+        preprocess_mamba_align_fused_kernel[
+            (triton.cdiv(input_batch.num_reqs, block),)
+        ](
+            input_batch.idx_mapping,
+            self._mamba_state_idx_gpu,
+            num_computed_tokens,
+            input_batch.query_start_loc,
+            self.num_accepted_tokens_gpu,
+            self._mamba_src_col_gpu,
+            self._mamba_token_bias_gpu,
+            input_batch.num_reqs,
+            BLOCK_SIZE=block,
+            MAMBA_BLOCK_SIZE=mamba_spec.block_size,
+        )
+        run_mamba_align_precopy(
+            ctx,
+            input_batch.num_reqs,
+            self._mamba_state_idx_gpu,
+            self._mamba_src_col_gpu,
+            self._mamba_token_bias_gpu,
+            input_batch.idx_mapping,
         )
 
     def prepare_attn(
@@ -142,9 +274,24 @@ class MambaHybridModelState(DefaultModelState):
         self,
         input_batch: InputBatch,
         num_sampled: torch.Tensor,
+        num_computed_tokens: torch.Tensor | None = None,
     ) -> None:
         # Chunked prefill does not sample a token, so num_sampled can be 0.
         # Mamba treats num_accepted_tokens=1 as the neutral non-spec value.
         self.num_accepted_tokens_gpu[input_batch.idx_mapping] = torch.clamp(
             num_sampled, min=1
         )
+        if (
+            self._align_mode
+            and num_computed_tokens is not None
+            and self._mamba_ctx is not None
+            and input_batch.num_reqs > 0
+        ):
+            run_mamba_align_postprocess(
+                self._mamba_ctx,
+                input_batch.num_reqs,
+                self.num_accepted_tokens_gpu,
+                self._mamba_state_idx_gpu,
+                num_computed_tokens,
+                input_batch.idx_mapping,
+            )

--- a/vllm/v1/worker/gpu/sample/gumbel.py
+++ b/vllm/v1/worker/gpu/sample/gumbel.py
@@ -2,18 +2,16 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 import torch
 
-from vllm.triton_utils import HAS_TRITON, tl, triton
+from vllm.triton_utils import HAS_TRITON, tl, tldevice, triton
 
-# Smallest positive normal fp32 value. Used to clamp the uniform draw so that
-# `log(u)` cannot produce -inf (and thus `-log(-log(u))` stays finite).
+# Smallest positive value produced by Triton's fp32 `tl.rand`. Used to clamp
+# zero draws before the flipped Gumbel transform below.
 #
 # Triton requires globals accessed from `@triton.jit` functions to be wrapped
 # in `tl.constexpr(...)`. We can only do that when Triton is actually
 # available — on the CPU worker path `tl` is a placeholder whose `constexpr`
 # attribute is `None`, and `tl.constexpr(...)` would crash at import time.
-_FP32_TINY = (
-    tl.constexpr(float.fromhex("0x1p-126")) if HAS_TRITON else float.fromhex("0x1p-126")
-)
+_TL_RAND_MIN = tl.constexpr(4.6566127342e-10) if HAS_TRITON else 4.6566127342e-10
 
 
 @triton.jit
@@ -76,6 +74,46 @@ def tl_rand64(seed, offset, includes_zero: tl.constexpr):
 
 
 @triton.jit
+def tl_rand32(seed, offset, includes_zero: tl.constexpr):
+    u = tl.rand(seed, offset)
+    if not includes_zero:
+        u = tl.maximum(u, _TL_RAND_MIN)
+    return u
+
+
+@triton.jit
+def gumbel_noised_argmax(
+    logits,
+    keys,
+    mask,
+    seed,
+    pos,
+    temp,
+    USE_FP64: tl.constexpr,
+    APPLY_TEMPERATURE: tl.constexpr = True,
+):
+    """Argmax under token-keyed Gumbel noise, or plain argmax at temp zero."""
+    if temp != 0.0 and APPLY_TEMPERATURE:
+        logits = logits / temp
+
+    if USE_FP64:
+        logits = logits.to(tl.float64)
+    if temp != 0.0:
+        gumbel_seed = tl.randint(seed, pos)
+        if USE_FP64:
+            u = tl_rand64(gumbel_seed, keys, includes_zero=False)
+            gumbel_noise = -tl.log(-tl.log(u))
+        else:
+            u = tl_rand32(gumbel_seed, keys, includes_zero=False)
+            # Flip the transform so the deciding tail lies near zero, where
+            # fp32 uniforms retain resolution. `log1p` avoids cancellation.
+            gumbel_noise = -tl.log(-tldevice.log1p(-u))
+        logits = tl.where(mask, logits + gumbel_noise, float("-inf"))
+
+    return tl.max(logits, axis=0, return_indices=True)
+
+
+@triton.jit
 def gumbel_block_argmax(
     logits,
     block,
@@ -92,16 +130,18 @@ def gumbel_block_argmax(
     APPLY_TEMPERATURE: tl.constexpr,
     USE_FP64: tl.constexpr,
 ):
-    req_state_idx = tl.load(expanded_idx_mapping_ptr + token_idx)
-    temp = tl.load(temp_ptr + req_state_idx).to(tl.float32)
+    req_state_idx = tl.load(expanded_idx_mapping_ptr + token_idx).to(tl.int64)
+    is_valid_req = req_state_idx >= 0
+    temp = tl.load(temp_ptr + req_state_idx, mask=is_valid_req, other=0.0).to(
+        tl.float32
+    )
     if temp != 0.0 and APPLY_TEMPERATURE:
-        # Apply temperature.
-        # NOTE(woosuk): Match the behavior of _temperature_kernel.
-        # E.g., if the kernel uses tl.div_rn, we should use tl.div_rn here too.
+        # Preserve the established MRV2 contract: proposal logits handed to
+        # rejection sampling have already had request temperature applied.
         logits = logits / temp
 
     if processed_logits_ptr is not None:
-        # Store the temperature-applied logits.
+        # Store the temperature-applied proposal distribution.
         if processed_logits_col_ptr is not None:
             col = tl.load(processed_logits_col_ptr)
         else:
@@ -112,31 +152,21 @@ def gumbel_block_argmax(
             + col * vocab_size
             + block,
             logits,
-            mask=mask,
+            mask=mask & is_valid_req,
         )
 
-    # fp32 is the default reduction dtype; fp64 is ~1/32–1/64x the throughput
-    # on H100/Ada/Blackwell and empirically indistinguishable for Gumbel-max.
-    if USE_FP64:
-        logits = logits.to(tl.float64)
-    if temp != 0.0:
-        # Calculate the seed for gumbel noise.
-        seed = tl.load(seeds_ptr + req_state_idx)
-        pos = tl.load(pos_ptr + token_idx)
-        gumbel_seed = tl.randint(seed, pos)
-
-        if USE_FP64:
-            u = tl_rand64(gumbel_seed, block, includes_zero=False)
-        else:
-            u = tl.rand(gumbel_seed, block)
-            u = tl.maximum(u, _FP32_TINY)
-        gumbel_noise = -tl.log(-tl.log(u))
-
-        # Apply gumbel noise.
-        logits = tl.where(mask, logits + gumbel_noise, float("-inf"))
-
-    value, idx = tl.max(logits, axis=0, return_indices=True)
-    return value, idx
+    seed = tl.load(seeds_ptr + req_state_idx, mask=is_valid_req, other=0)
+    pos = tl.load(pos_ptr + token_idx)
+    return gumbel_noised_argmax(
+        logits,
+        block,
+        mask & is_valid_req,
+        seed,
+        pos,
+        temp,
+        USE_FP64=USE_FP64,
+        APPLY_TEMPERATURE=False,
+    )
 
 
 @triton.jit

--- a/vllm/v1/worker/gpu/sample/gumbel.py
+++ b/vllm/v1/worker/gpu/sample/gumbel.py
@@ -125,6 +125,7 @@ def gumbel_block_argmax(
     pos_ptr,
     processed_logits_ptr,
     processed_logits_stride,
+    processed_logits_col_stride,
     processed_logits_col_ptr,
     vocab_size,
     APPLY_TEMPERATURE: tl.constexpr,
@@ -149,7 +150,7 @@ def gumbel_block_argmax(
         tl.store(
             processed_logits_ptr
             + req_state_idx * processed_logits_stride
-            + col * vocab_size
+            + col * processed_logits_col_stride
             + block,
             logits,
             mask=mask & is_valid_req,
@@ -177,6 +178,7 @@ def _gumbel_sample_kernel(
     local_max_stride,
     processed_logits_ptr,
     processed_logits_stride,
+    processed_logits_col_stride,
     processed_logits_col_ptr,
     logits_ptr,
     logits_stride,
@@ -211,6 +213,7 @@ def _gumbel_sample_kernel(
         pos_ptr,
         processed_logits_ptr,
         processed_logits_stride,
+        processed_logits_col_stride,
         processed_logits_col_ptr,
         vocab_size,
         APPLY_TEMPERATURE=APPLY_TEMPERATURE,
@@ -245,6 +248,7 @@ def gumbel_sample(
         local_max.stride(0),
         output_processed_logits,
         output_processed_logits.stride(0) if output_processed_logits is not None else 0,
+        output_processed_logits.stride(1) if output_processed_logits is not None else 0,
         output_processed_logits_col,
         logits,
         logits.stride(0),

--- a/vllm/v1/worker/gpu/spec_decode/__init__.py
+++ b/vllm/v1/worker/gpu/spec_decode/__init__.py
@@ -13,10 +13,11 @@ def init_speculator(vllm_config: VllmConfig, device: torch.device):
         if draft_config is None:
             raise ValueError("method='dflash' requires a draft model config")
         if "DFlash2DraftModel" in (draft_config.architectures or []):
-            raise ValueError(
-                "DFlash2 requires the MRV2 DFlash2 speculator, which is not "
-                "available in this base backport stage."
+            from vllm.v1.worker.gpu.spec_decode.dflash2.speculator import (
+                DFlash2Speculator,
             )
+
+            return DFlash2Speculator(vllm_config, device)
         from vllm.v1.worker.gpu.spec_decode.dflash.speculator import DFlashSpeculator
 
         return DFlashSpeculator(vllm_config, device)

--- a/vllm/v1/worker/gpu/spec_decode/dflash/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/dflash/speculator.py
@@ -105,6 +105,7 @@ class DFlashSpeculator(DraftModelSpeculator):
         # The draft's attention differs from the target's in causality.
         return replace(
             self.vllm_config,
+            model_config=self.draft_model_config,
             attention_config=replace(
                 self.vllm_config.attention_config,
                 use_non_causal=self.requires_non_causal,

--- a/vllm/v1/worker/gpu/spec_decode/dflash2/__init__.py
+++ b/vllm/v1/worker/gpu/spec_decode/dflash2/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project

--- a/vllm/v1/worker/gpu/spec_decode/dflash2/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/dflash2/speculator.py
@@ -1,0 +1,339 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from typing import Any
+
+import torch
+
+from vllm.config import VllmConfig
+from vllm.config.compilation import CUDAGraphMode
+from vllm.triton_utils import tl, triton
+from vllm.v1.worker.gpu.sample.gumbel import gumbel_noised_argmax
+from vllm.v1.worker.gpu.spec_decode.dflash.speculator import DFlashSpeculator
+
+
+def _requires_sm70_tail(device: torch.device, num_steps: int) -> bool:
+    """Whether the final dependent selector slot needs its own kernel."""
+    return (
+        device.type == "cuda"
+        and num_steps > 1
+        and torch.cuda.get_device_capability(device) == (7, 0)
+    )
+
+
+@triton.jit
+def _selector_walk_kernel(
+    scores_ptr,
+    candidate_ptr,
+    sample_pos_ptr,
+    req_state_ptr,
+    temperature_ptr,
+    seeds_ptr,
+    tokens_ptr,
+    realized_scores_ptr,
+    path_state_ptr,
+    num_steps: tl.constexpr,
+    walk_steps: tl.constexpr,
+    top_k: tl.constexpr,
+    BLOCK_K: tl.constexpr,
+    SAMPLE_PROBABILISTIC: tl.constexpr,
+    USE_FP64: tl.constexpr,
+):
+    row = tl.program_id(0)
+    offsets = tl.arange(0, BLOCK_K)
+    mask = offsets < top_k
+    req_state = tl.load(req_state_ptr + row * num_steps)
+    valid = req_state >= 0
+    temperature = tl.load(temperature_ptr + req_state, mask=valid, other=0.0)
+    seed = tl.load(seeds_ptr + req_state, mask=valid, other=0)
+    previous = 0
+    for step in range(walk_steps):
+        flat = row * num_steps + step
+        score_base = (flat * top_k + previous) * top_k
+        scores = tl.load(
+            scores_ptr + score_base + offsets,
+            mask=mask & valid,
+            other=float("-inf"),
+        ).to(tl.float64 if USE_FP64 else tl.float32)
+        if SAMPLE_PROBABILISTIC and temperature != 0.0:
+            # Cache the exact temperature-applied proposal scores expected by
+            # the shared rejection sampler. This keeps Eagle/MTP's established
+            # contract unchanged while matching the DFlash2 selector draw.
+            scores = scores / temperature
+        candidate_base = flat * top_k
+        candidates = tl.load(
+            candidate_ptr + candidate_base + offsets,
+            mask=mask & valid,
+            other=0,
+        )
+
+        # Candidate token IDs key the noise, matching the target sampler.
+        position = tl.load(sample_pos_ptr + flat) - 1
+        _, index = gumbel_noised_argmax(
+            scores,
+            candidates,
+            mask & valid,
+            seed,
+            position,
+            temperature if SAMPLE_PROBABILISTIC else 0.0,
+            USE_FP64=USE_FP64,
+            APPLY_TEMPERATURE=False,
+        )
+
+        tl.store(
+            realized_scores_ptr + candidate_base + offsets,
+            scores,
+            mask=mask & valid,
+        )
+        token = tl.load(candidate_ptr + candidate_base + index, mask=valid, other=0)
+        tl.store(tokens_ptr + flat, token, mask=valid)
+        previous = index
+
+    if walk_steps < num_steps:
+        tl.store(path_state_ptr + row, previous, mask=valid)
+
+
+@triton.jit
+def _selector_walk_tail_kernel(
+    scores_ptr,
+    candidate_ptr,
+    sample_pos_ptr,
+    req_state_ptr,
+    temperature_ptr,
+    seeds_ptr,
+    tokens_ptr,
+    realized_scores_ptr,
+    path_state_ptr,
+    num_steps: tl.constexpr,
+    top_k: tl.constexpr,
+    BLOCK_K: tl.constexpr,
+    SAMPLE_PROBABILISTIC: tl.constexpr,
+    USE_FP64: tl.constexpr,
+):
+    """Write the final dependent slot separately on SM70.
+
+    Triton can drop the seventh store of a fully unrolled selector walk during
+    CUDA Graph replay on Volta. The first six slots remain fused; this tiny tail
+    consumes their persistent path state and guarantees the seventh write.
+    """
+    row = tl.program_id(0)
+    offsets = tl.arange(0, BLOCK_K)
+    mask = offsets < top_k
+    req_state = tl.load(req_state_ptr + row * num_steps)
+    valid = req_state >= 0
+    temperature = tl.load(temperature_ptr + req_state, mask=valid, other=0.0)
+    seed = tl.load(seeds_ptr + req_state, mask=valid, other=0)
+    previous = tl.load(path_state_ptr + row, mask=valid, other=0)
+    step: tl.constexpr = num_steps - 1
+    flat = row * num_steps + step
+    score_base = (flat * top_k + previous) * top_k
+    scores = tl.load(
+        scores_ptr + score_base + offsets,
+        mask=mask & valid,
+        other=float("-inf"),
+    ).to(tl.float64 if USE_FP64 else tl.float32)
+    if SAMPLE_PROBABILISTIC and temperature != 0.0:
+        scores = scores / temperature
+    candidate_base = flat * top_k
+    candidates = tl.load(
+        candidate_ptr + candidate_base + offsets,
+        mask=mask & valid,
+        other=0,
+    )
+    position = tl.load(sample_pos_ptr + flat) - 1
+    _, index = gumbel_noised_argmax(
+        scores,
+        candidates,
+        mask & valid,
+        seed,
+        position,
+        temperature if SAMPLE_PROBABILISTIC else 0.0,
+        USE_FP64=USE_FP64,
+        APPLY_TEMPERATURE=False,
+    )
+    tl.store(
+        realized_scores_ptr + candidate_base + offsets,
+        scores,
+        mask=mask & valid,
+    )
+    token = tl.load(candidate_ptr + candidate_base + index, mask=valid, other=0)
+    tl.store(tokens_ptr + flat, token, mask=valid)
+
+
+@triton.jit
+def _cache_draft_logits_kernel(
+    draft_logits_ptr,
+    cached_candidate_ptr,
+    candidate_ptr,
+    scores_ptr,
+    req_state_ptr,
+    draft_logits_stride_0,
+    draft_logits_stride_1,
+    num_steps: tl.constexpr,
+    top_k: tl.constexpr,
+    BLOCK_K: tl.constexpr,
+):
+    flat = tl.program_id(0)
+    req_state = tl.load(req_state_ptr + flat)
+    step = flat % num_steps
+    offsets = tl.arange(0, BLOCK_K)
+    mask = (req_state >= 0) & (offsets < top_k)
+    candidate_base = flat * top_k
+    cache_base = (req_state * num_steps + step) * top_k
+    old_token_ids = tl.load(cached_candidate_ptr + cache_base + offsets, mask=mask)
+    logits_base = (
+        draft_logits_ptr
+        + req_state * draft_logits_stride_0
+        + step * draft_logits_stride_1
+    )
+    tl.store(logits_base + old_token_ids, -float("inf"), mask=mask)
+    token_ids = tl.load(candidate_ptr + candidate_base + offsets, mask=mask)
+    scores = tl.load(scores_ptr + candidate_base + offsets, mask=mask)
+    tl.store(logits_base + token_ids, scores, mask=mask)
+    tl.store(cached_candidate_ptr + cache_base + offsets, token_ids, mask=mask)
+
+
+class DFlash2Speculator(DFlashSpeculator):
+    _speculator_name = "DFlash2"
+
+    def __init__(self, vllm_config: VllmConfig, device: torch.device):
+        super().__init__(vllm_config, device)
+        draft_config = self.draft_model_config.hf_config.dflash_config
+        self.selector_top_k = int(draft_config["selector_top_k"])
+        self._anchor_indices = (
+            torch.arange(self.max_num_reqs, dtype=torch.int64, device=device)
+            * self.num_query_per_req
+        )
+        self._selector_scores = torch.empty(
+            self.max_num_reqs,
+            self.num_speculative_steps,
+            self.selector_top_k,
+            dtype=torch.float32,
+            device=device,
+        )
+        self._cached_candidate_ids = torch.zeros(
+            self._selector_scores.shape, dtype=torch.int64, device=device
+        )
+        self._selector_path_state = torch.empty(
+            self.max_num_reqs, dtype=torch.int32, device=device
+        )
+        self._use_sm70_tail = _requires_sm70_tail(device, self.num_speculative_steps)
+        if self.draft_logits is not None:
+            # The cache kernel writes only K columns; all other vocabulary
+            # columns must remain impossible.
+            self.draft_logits.fill_(-float("inf"))
+
+    def draft_logits_spec(self, vllm_config: VllmConfig) -> tuple[torch.dtype, float]:
+        # The selector walk and rejection sampler must consume identical scores.
+        # BF16 rounding measurably changes candidate order, so keep this FP32.
+        return torch.float32, -float("inf")
+
+    def _sample_path(
+        self,
+        candidate_ids: torch.Tensor,
+        scores: torch.Tensor,
+        num_reqs: int,
+    ) -> None:
+        # The SM70 tail must consume the exact same packed lattice as the
+        # prefix walk. Keep one persistent view instead of creating temporary
+        # contiguous inputs only for the first launch.
+        scores = scores.contiguous()
+        candidate_ids = candidate_ids.contiguous()
+        block_k = triton.next_power_of_2(self.selector_top_k)
+        walk_steps = (
+            self.num_speculative_steps - 1
+            if self._use_sm70_tail
+            else self.num_speculative_steps
+        )
+        _selector_walk_kernel[(num_reqs,)](
+            scores,
+            candidate_ids,
+            self.sample_pos,
+            self.sample_idx_mapping,
+            self.temperature,
+            self.seeds,
+            self.draft_tokens,
+            self._selector_scores,
+            self._selector_path_state,
+            num_steps=self.num_speculative_steps,
+            walk_steps=walk_steps,
+            top_k=self.selector_top_k,
+            BLOCK_K=block_k,
+            SAMPLE_PROBABILISTIC=self.draft_logits is not None,
+            USE_FP64=self.use_fp64_gumbel,
+            num_warps=1,
+        )
+        if self._use_sm70_tail:
+            _selector_walk_tail_kernel[(num_reqs,)](
+                scores,
+                candidate_ids,
+                self.sample_pos,
+                self.sample_idx_mapping,
+                self.temperature,
+                self.seeds,
+                self.draft_tokens,
+                self._selector_scores,
+                self._selector_path_state,
+                num_steps=self.num_speculative_steps,
+                top_k=self.selector_top_k,
+                BLOCK_K=block_k,
+                SAMPLE_PROBABILISTIC=self.draft_logits is not None,
+                USE_FP64=self.use_fp64_gumbel,
+                num_warps=1,
+            )
+
+    def _cache_draft_logits(self, candidate_ids: torch.Tensor, num_sample: int) -> None:
+        draft_logits = self.draft_logits
+        assert draft_logits is not None
+        block_k = triton.next_power_of_2(self.selector_top_k)
+        _cache_draft_logits_kernel[(num_sample,)](
+            draft_logits,
+            self._cached_candidate_ids,
+            candidate_ids,
+            self._selector_scores,
+            self.sample_idx_mapping,
+            draft_logits.stride(0),
+            draft_logits.stride(1),
+            num_steps=self.num_speculative_steps,
+            top_k=self.selector_top_k,
+            BLOCK_K=block_k,
+            num_warps=1,
+        )
+
+    def _generate_draft(
+        self,
+        num_reqs: int,
+        num_tokens_padded: int,
+        attn_metadata: dict[str, Any] | None,
+        slot_mappings: dict[str, torch.Tensor] | None,
+        num_tokens_across_dp: torch.Tensor | None,
+        cudagraph_runtime_mode: CUDAGraphMode = CUDAGraphMode.NONE,
+    ) -> None:
+        last_hidden_states = self._run_model(
+            num_tokens_padded,
+            attn_metadata,
+            slot_mappings,
+            num_tokens_across_dp,
+            cudagraph_runtime_mode,
+        )
+        num_sample = num_reqs * self.num_speculative_steps
+        hidden_states = last_hidden_states[self.sample_indices[:num_sample]].view(
+            num_reqs, self.num_speculative_steps, -1
+        )
+        candidate_ids, unary_logits = self.model.compute_candidates(
+            hidden_states.flatten(0, 1)
+        )
+        candidate_ids = candidate_ids.view(
+            num_reqs, self.num_speculative_steps, self.selector_top_k
+        )
+        unary_logits = unary_logits.view_as(candidate_ids)
+        anchor_token_ids = self.input_buffers.input_ids[self._anchor_indices[:num_reqs]]
+        scores = self.model.model.candidate_selector(
+            candidate_ids,
+            unary_logits,
+            hidden_states,
+            anchor_token_ids,
+        )
+        self._sample_path(candidate_ids, scores, num_reqs)
+        if self.draft_logits is not None:
+            self._cache_draft_logits(candidate_ids, num_sample)

--- a/vllm/v1/worker/gpu/spec_decode/rejection_sampler_utils.py
+++ b/vllm/v1/worker/gpu/spec_decode/rejection_sampler_utils.py
@@ -413,6 +413,7 @@ def _resample_kernel(
         pos_ptr,
         None,  # processed_logits_ptr
         0,  # processed_logits_stride
+        0,  # processed_logits_col_stride
         None,  # processed_logits_col_ptr
         vocab_size,
         APPLY_TEMPERATURE=False,

--- a/vllm/v1/worker/gpu/spec_decode/rejection_sampler_utils.py
+++ b/vllm/v1/worker/gpu/spec_decode/rejection_sampler_utils.py
@@ -2,8 +2,8 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 import torch
 
-from vllm.triton_utils import tl, triton
-from vllm.v1.worker.gpu.sample.gumbel import gumbel_block_argmax, tl_rand64
+from vllm.triton_utils import tl, tldevice, triton
+from vllm.v1.worker.gpu.sample.gumbel import gumbel_block_argmax, tl_rand32
 
 
 @triton.jit
@@ -243,7 +243,7 @@ def _rejection_kernel(
 
                 if SYNTHETIC_MODE:
                     pos = tl.load(pos_ptr + logit_idx)
-                    u = tl_rand64(seed, pos, includes_zero=False)
+                    u = tl_rand32(seed, pos, includes_zero=False)
                     rate = tl.load(synthetic_conditional_rates_ptr + i)
                     accepted &= u < rate
                 else:
@@ -267,7 +267,7 @@ def _rejection_kernel(
                 )
                 target_log_prob = target_logit - target_lse
                 pos = tl.load(pos_ptr + logit_idx)
-                u = tl_rand64(seed, pos, includes_zero=False)
+                u = tl_rand32(seed, pos, includes_zero=False)
                 if HAS_DRAFT_LOGITS:
                     draft_logit = tl.load(
                         draft_logits_ptr
@@ -388,7 +388,7 @@ def _resample_kernel(
         ratio = tl.exp(draft_log_probs - target_log_probs)
         residual_logits = tl.where(
             ratio < 1.0,
-            target_log_probs + tl.log(1 - ratio),
+            target_log_probs + tldevice.log1p(-ratio),
             float("-inf"),
         ).to(tl.float32)
     else:

--- a/vllm/v1/worker/gpu/spec_decode/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/speculator.py
@@ -128,12 +128,16 @@ class DraftModelSpeculator(BaseSpeculator):
 
         self.draft_logits: torch.Tensor | None = None
         if self.speculative_config.draft_sample_method == "probabilistic":
-            # Pre-temperature logits, cached from the previous decode step.
-            self.draft_logits = torch.zeros(
-                self.max_num_reqs,
-                self.num_speculative_steps,
-                self.vocab_size,
-                dtype=vllm_config.model_config.head_dtype,
+            # Temperature-applied logits, cached from the previous decode step.
+            dtype, fill = self.draft_logits_spec(vllm_config)
+            self.draft_logits = torch.full(
+                (
+                    self.max_num_reqs,
+                    self.num_speculative_steps,
+                    self.vocab_size,
+                ),
+                fill,
+                dtype=dtype,
                 device=device,
             )
 
@@ -277,6 +281,15 @@ class DraftModelSpeculator(BaseSpeculator):
             seq_lens_cpu_upper_bound=draft_seq_lens_cpu_upper_bound,
         )
         return attn_metadata
+
+    def draft_logits_spec(self, vllm_config: VllmConfig) -> tuple[torch.dtype, float]:
+        """Dtype and initial value for the cached proposal distribution.
+
+        Most speculators overwrite every vocabulary column and use the target
+        head dtype. DFlash2 overrides this because it writes only K candidates
+        and its selector/rejection path must share FP32 scores exactly.
+        """
+        return vllm_config.model_config.head_dtype, 0.0
 
     def _validate_local_argmax_reduction(self) -> None:
         if not self.use_local_argmax_reduction:

--- a/vllm/v1/worker/gpu/warmup.py
+++ b/vllm/v1/worker/gpu/warmup.py
@@ -15,8 +15,44 @@ from vllm.v1.core.sched.output import (
     NewRequestData,
     SchedulerOutput,
 )
+from vllm.v1.kv_cache_interface import CrossAttentionSpec, KVCacheSpec, MambaSpec
 from vllm.v1.request import Request
 from vllm.v1.worker.gpu.model_runner import GPUModelRunner
+
+
+def _reserved_block_count(
+    num_tokens: int,
+    kv_cache_spec: KVCacheSpec,
+    *,
+    num_lookahead_tokens: int,
+    max_model_len: int,
+    max_encoder_len: int,
+) -> int:
+    """Match the scheduler's block reservation in hand-built warmup batches."""
+    if isinstance(kv_cache_spec, CrossAttentionSpec):
+        return cdiv(max_encoder_len, kv_cache_spec.block_size)
+    num_speculative_blocks = 0
+    if isinstance(kv_cache_spec, MambaSpec):
+        num_speculative_blocks = kv_cache_spec.num_speculative_blocks
+        if kv_cache_spec.mamba_cache_mode == "align":
+            return cdiv(num_tokens, kv_cache_spec.block_size) + num_speculative_blocks
+    num_tokens = min(num_tokens + num_lookahead_tokens, max_model_len)
+    return cdiv(num_tokens, kv_cache_spec.block_size) + num_speculative_blocks
+
+
+def _warmup_block_counter(
+    model_runner: GPUModelRunner,
+) -> Callable[[int, KVCacheSpec], int]:
+    def block_count(num_tokens: int, kv_cache_spec: KVCacheSpec) -> int:
+        return _reserved_block_count(
+            num_tokens,
+            kv_cache_spec,
+            num_lookahead_tokens=model_runner.vllm_config.num_lookahead_tokens,
+            max_model_len=model_runner.max_model_len,
+            max_encoder_len=getattr(model_runner.model_state, "max_encoder_len", 0),
+        )
+
+    return block_count
 
 
 @torch.inference_mode()
@@ -46,9 +82,10 @@ def warmup_kernels(
     num_kv_cache_groups = len(kv_cache_groups)
 
     # Compute per-request block counts for each KV cache group.
-    group_block_sizes = [g.kv_cache_spec.block_size for g in kv_cache_groups]
-    prefill_block_counts = [cdiv(prompt_len, bs) for bs in group_block_sizes]
-    decode_block_counts = [cdiv(decode_len, bs) for bs in group_block_sizes]
+    block_count = _warmup_block_counter(model_runner)
+    kv_cache_specs = [group.kv_cache_spec for group in kv_cache_groups]
+    prefill_block_counts = [block_count(prompt_len, spec) for spec in kv_cache_specs]
+    decode_block_counts = [block_count(decode_len, spec) for spec in kv_cache_specs]
     decode_block_deltas = [
         d - p for d, p in zip(decode_block_counts, prefill_block_counts)
     ]


### PR DESCRIPTION
## Purpose

Stack on PR #252 and backport the pinned vLLM DFlash2 implementation plus only its correctness dependency closure.

Scope:
- Official Qwen3 DFlash2 grouped-convolution model, checkpoint-owned top-16 selector, and MRV2 speculator.
- Rejection-sampling fixes, Qwen3.8 target hidden capture at [6, 20, 34, 48, 62], and independent draft KV dtype.
- Non-causal sliding-window draft attention through Flash-V100.
- SM70 BF16-range preservation and the Volta selector tail-slot kernel.
- Capability-gated FlashInfer use; SM70 uses dense LM-head plus torch.topk.
- Hybrid Mamba align-state migration required for correct target/draft prefix-cache hits.
- Eager correctness before selector/draft CUDA Graph capture.

Explicitly out of scope:
- Eagle, MTP, and DDTree replacement.
- Fused TurboMind selector optimization; that is stacked PR 3.

## Test Plan

- Run route/config, K/K+1 reservation, rejection-sampling, selector, attention, hybrid-cache, and SM70-tail unit tests.
- Compare eager and CUDA Graph token IDs, candidate lattices, acceptance traces, and draft KV on V100.
- Run mixed batch 1/2/4 stability and real DFlash1, DFlash2, MTP, and prefix-cache smokes.
- Classify Flash-V100 paged-vs-dense non-causal numerics before accepting the backend.

## Test Result

- Final changed-path CPU gate: 113 passed, 1 skipped.
- Dedicated V100 Mamba align kernels: 5 passed.
- V100 rejection sampling: 14 passed; probabilistic selector cache: 1 passed.
- Qwen3.8-27B-FP8 TP4 eager and CUDA Graph produced identical token IDs, candidates, acceptance traces, and draft KV. Batch 2 and mixed batch 4 remained exact and free of OOB/stale replay errors.
- Four-prompt GSM8K diagnostic: greedy mean accepted length 4.1068; probabilistic 4.2407.
- Prefix cache, 3505-token prompt: second request hit 3296 tokens. Eager TTFT 1.117s to 0.303s; graph TTFT 1.119s to 0.174s, with exact 16-token output and acceptance trace.
- Flash-V100 non-causal paged attention classified B-accept: semantic max error at lengths 8/69/512/2048 was 0/2.44e-4/1.22e-4/6.10e-5, below the FP16 2e-3 gate; physical-page permutation was bitwise exact.
- DFlash1 9B real route smoke and Qwen3.8 TP4 MTP4 regression smoke passed without replacing their existing implementations.
- Ruff, formatting, py_compile, and diff checks passed.
- Known baseline-only limitations remain documented in the migration control file: one DDTree shared-storage assertion, three stale MTP helper assertions, and four gated Llama config tests unavailable without Hugging Face access.

## Acceptance root-cause correction (2026-08-22)

- The earlier four-prompt 4.1068/4.2407 values predate the batched-weight RMSNorm repair and are retained only as historical route diagnostics; they must not be cited as DFlash2 acceptance baselines.
- Root cause: the model backport used grouped per-layer K normalization, but the stable kernel dependency that selects `weight[layer_idx]` was omitted, so every draft layer used K-norm row zero. SGLang-V100 correctly indexes each layer in both its sequential and fused materialization paths.
- Final TP4 V100, single sequential request, CUDA Graph, FP8 target, E5M2 target KV, FP16/auto draft KV, Flash-V100, selector K=16, seven draft tokens, official probabilistic GSM8K sampling: 64-prompt per-request mean 5.3888, pooled 4.5644, versus 5.2489/4.3571 on the matched SGLang-V100 run and public official mean 5.46.
- Repaired per-position acceptance is 85.833/70.569/57.920/46.887/38.032/31.342/25.861%. The 13-case V100 batched-weight RMSNorm gate passes bitwise against a per-layer reference.


## Maintainer audit (2026-08-24)

- Rebased the PR-only DFlash2 delta onto current main after parent PR #252 merged; current audited head is 5745c1ffc.
- Preserved DFlash1/MTP probabilistic defaults; DFlash2 greedy remains an explicit supported lane.
- Fixed processed-logit cache writes to honor the actual column stride, with a padded-cache Triton regression test.
- Resolved the Flash-V100 metadata integration by retaining both the current main batch-context route and the DFlash draft marker.
- DFlash2 plus SM70-default tests: 33 passed on V100 GPU 7; changed-file pre-commit and diff checks passed.
- No full-model E2E was repeated; the promotion decision uses the existing matched TP4 correctness, prefix-cache, and 64-prompt acceptance evidence above.