### PR TITLE
[Core][SM70] Split MTP verifier and drafter CUDA Graph shapes

### DIFF
--- a/tests/engine/test_arg_utils.py
+++ b/tests/engine/test_arg_utils.py
@@ -299,18 +299,6 @@ def test_sm70_mtp_defaults_require_env_opt_in(monkeypatch):
     assert args.enable_prefix_caching is True
     assert args.mamba_cache_mode == "align"
     assert args.max_num_seqs == 4
-    assert args.compilation_config.cudagraph_capture_sizes == [5, 10, 20]
-
-
-def test_sm70_mtp_split_cudagraphs_can_roll_back(monkeypatch):
-    args = _apply_sm70_defaults(
-        monkeypatch,
-        env={
-            "VLLM_1CAT_ENABLE_SM70_MTP_DEFAULTS": "1",
-            "VLLM_SM70_MTP_SPLIT_DRAFT_CUDAGRAPHS": "0",
-        },
-    )
-
     assert args.compilation_config.cudagraph_capture_sizes == [
         1,
         2,
@@ -325,10 +313,25 @@ def test_sm70_mtp_split_cudagraphs_can_roll_back(monkeypatch):
     ]
 
 
+def test_sm70_mtp_split_cudagraphs_are_opt_in(monkeypatch):
+    args = _apply_sm70_defaults(
+        monkeypatch,
+        env={
+            "VLLM_1CAT_ENABLE_SM70_MTP_DEFAULTS": "1",
+            "VLLM_SM70_MTP_SPLIT_DRAFT_CUDAGRAPHS": "1",
+        },
+    )
+
+    assert args.compilation_config.cudagraph_capture_sizes == [5, 10, 20]
+
+
 def test_sm70_mtp_split_cudagraphs_cover_production_batches(monkeypatch):
     args = _apply_sm70_defaults(
         monkeypatch,
-        env={"VLLM_1CAT_ENABLE_SM70_MTP_DEFAULTS": "1"},
+        env={
+            "VLLM_1CAT_ENABLE_SM70_MTP_DEFAULTS": "1",
+            "VLLM_SM70_MTP_SPLIT_DRAFT_CUDAGRAPHS": "1",
+        },
         max_num_seqs=16,
     )
 

--- a/tests/engine/test_arg_utils.py
+++ b/tests/engine/test_arg_utils.py
@@ -243,12 +243,14 @@ def _apply_sm70_defaults(
     env=None,
     speculative_config=None,
     enable_prefix_caching=None,
+    max_num_seqs=None,
 ):
     for key in (
         "VLLM_1CAT_ENABLE_SM70_MTP_DEFAULTS",
         "VLLM_1CAT_ENABLE_QWEN35_MTP_DEFAULTS",
         "VLLM_1CAT_DISABLE_SM70_MTP_DEFAULTS",
         "VLLM_1CAT_DISABLE_QWEN35_MTP_DEFAULTS",
+        "VLLM_SM70_MTP_SPLIT_DRAFT_CUDAGRAPHS",
     ):
         monkeypatch.delenv(key, raising=False)
     for key, value in (env or {}).items():
@@ -262,6 +264,7 @@ def _apply_sm70_defaults(
         model="dummy",
         tensor_parallel_size=4,
         enable_prefix_caching=enable_prefix_caching,
+        max_num_seqs=max_num_seqs,
     )
     args.speculative_config = speculative_config
     args._maybe_apply_sm70_mtp_defaults(
@@ -296,6 +299,18 @@ def test_sm70_mtp_defaults_require_env_opt_in(monkeypatch):
     assert args.enable_prefix_caching is True
     assert args.mamba_cache_mode == "align"
     assert args.max_num_seqs == 4
+    assert args.compilation_config.cudagraph_capture_sizes == [5, 10, 20]
+
+
+def test_sm70_mtp_split_cudagraphs_can_roll_back(monkeypatch):
+    args = _apply_sm70_defaults(
+        monkeypatch,
+        env={
+            "VLLM_1CAT_ENABLE_SM70_MTP_DEFAULTS": "1",
+            "VLLM_SM70_MTP_SPLIT_DRAFT_CUDAGRAPHS": "0",
+        },
+    )
+
     assert args.compilation_config.cudagraph_capture_sizes == [
         1,
         2,
@@ -307,6 +322,24 @@ def test_sm70_mtp_defaults_require_env_opt_in(monkeypatch):
         15,
         18,
         20,
+    ]
+
+
+def test_sm70_mtp_split_cudagraphs_cover_production_batches(monkeypatch):
+    args = _apply_sm70_defaults(
+        monkeypatch,
+        env={"VLLM_1CAT_ENABLE_SM70_MTP_DEFAULTS": "1"},
+        max_num_seqs=16,
+    )
+
+    assert args.compilation_config.cudagraph_capture_sizes == [
+        5,
+        10,
+        20,
+        30,
+        40,
+        60,
+        80,
     ]
 
 

--- a/tests/v1/attention/test_sm70_flash_v100_policy.py
+++ b/tests/v1/attention/test_sm70_flash_v100_policy.py
@@ -1330,6 +1330,27 @@ def test_sm70_nomtp_cudagraph_capture_sizes_cover_concurrency(
     assert _sm70_nomtp_cudagraph_capture_sizes(max_num_seqs) == expected
 
 
+@pytest.mark.parametrize(
+    ("max_num_seqs", "expected"),
+    [
+        (1, [5]),
+        (2, [5, 10]),
+        (4, [5, 10, 20]),
+        (6, [5, 10, 20, 30]),
+        (12, [5, 10, 20, 30, 40, 60]),
+        (16, [5, 10, 20, 30, 40, 60, 80]),
+        (32, [5, 10, 20, 30, 40, 60, 80]),
+    ],
+)
+def test_sm70_mtp_cudagraph_capture_sizes_cover_production_concurrency(
+    max_num_seqs: int,
+    expected: list[int],
+):
+    from vllm.config.vllm import _sm70_mtp_cudagraph_capture_sizes
+
+    assert _sm70_mtp_cudagraph_capture_sizes(max_num_seqs, 5) == expected
+
+
 def test_flash_v100_decode_query_does_not_attach_smallq_metadata(
     monkeypatch,
     local_flash_v100_model,

--- a/tests/v1/cudagraph/test_sm70_mtp_split_cudagraphs.py
+++ b/tests/v1/cudagraph/test_sm70_mtp_split_cudagraphs.py
@@ -1,0 +1,96 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+import torch
+
+from vllm.config import CompilationConfig, CUDAGraphMode
+from vllm.v1.worker.gpu.cudagraph_utils import CudaGraphManager
+
+
+def _make_config(max_num_seqs: int, verifier_sizes: list[int]):
+    speculative_config = SimpleNamespace(
+        method="mtp",
+        num_speculative_state_tokens=lambda: 4,
+    )
+    return SimpleNamespace(
+        scheduler_config=SimpleNamespace(max_num_seqs=max_num_seqs),
+        parallel_config=SimpleNamespace(
+            tensor_parallel_size=4,
+            data_parallel_size=1,
+        ),
+        compilation_config=CompilationConfig(
+            cudagraph_mode=CUDAGraphMode.FULL_AND_PIECEWISE,
+            cudagraph_capture_sizes=verifier_sizes.copy(),
+            max_cudagraph_capture_size=max(verifier_sizes),
+        ),
+        speculative_config=speculative_config,
+    )
+
+
+@pytest.mark.parametrize(
+    ("max_num_seqs", "request_sizes", "verifier_sizes"),
+    [
+        (16, [1, 2, 4, 6, 8, 12, 16], [5, 10, 20, 30, 40, 60, 80]),
+        (32, [1, 2, 4, 6, 8, 12, 16, 32], [5, 10, 20, 30, 40, 60, 80, 160]),
+    ],
+)
+def test_split_managers_keep_exact_full_graph_shapes(
+    monkeypatch,
+    max_num_seqs: int,
+    request_sizes: list[int],
+    verifier_sizes: list[int],
+):
+    monkeypatch.setenv("VLLM_SM70_MTP_SPLIT_DRAFT_CUDAGRAPHS", "1")
+    monkeypatch.setattr(
+        "vllm.v1.worker.gpu.cudagraph_utils.current_platform.is_cuda",
+        lambda: True,
+    )
+    monkeypatch.setattr(
+        "vllm.v1.worker.gpu.cudagraph_utils.current_platform.is_device_capability",
+        lambda capability: capability == (7, 0),
+    )
+    monkeypatch.setattr(
+        "vllm.v1.worker.gpu.cudagraph_utils.current_platform.get_global_graph_pool",
+        lambda: None,
+    )
+    monkeypatch.setattr(
+        "vllm.v1.worker.gpu.cudagraph_utils.get_pp_group",
+        lambda: MagicMock(is_first_rank=True, is_last_rank=True),
+    )
+
+    config = _make_config(max_num_seqs, verifier_sizes)
+    shared_sizes = config.compilation_config.cudagraph_capture_sizes.copy()
+    shared_max_size = config.compilation_config.max_cudagraph_capture_size
+    target = CudaGraphManager(
+        config,
+        torch.device("cpu"),
+        CUDAGraphMode.FULL_DECODE_ONLY,
+        decode_query_len=5,
+    )
+    draft = CudaGraphManager(
+        config,
+        torch.device("cpu"),
+        CUDAGraphMode.FULL_DECODE_ONLY,
+        decode_query_len=1,
+    )
+
+    assert target._capture_sizes == verifier_sizes
+    assert draft._capture_sizes == request_sizes
+    assert config.compilation_config.cudagraph_capture_sizes == shared_sizes
+    assert config.compilation_config.max_cudagraph_capture_size == shared_max_size
+
+    target._graphs_captured = True
+    draft._graphs_captured = True
+    for batch_size in request_sizes:
+        target_desc = target.dispatch(batch_size, batch_size * 5, 5)
+        draft_desc = draft.dispatch(batch_size, batch_size, 1)
+        assert target_desc.cg_mode == CUDAGraphMode.FULL
+        assert target_desc.num_tokens == batch_size * 5
+        assert target_desc.num_reqs == batch_size
+        assert draft_desc.cg_mode == CUDAGraphMode.FULL
+        assert draft_desc.num_tokens == batch_size
+        assert draft_desc.num_reqs == batch_size

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -68,6 +68,7 @@ logger = init_logger(__name__)
 
 DEFAULT_V2_MODEL_RUNNER_ARCHITECTURES = frozenset({"Qwen3ForCausalLM"})
 _SM70_NOMTP_CUDAGRAPH_CAPTURE_SIZES = (1, 2, 4, 8, 16)
+_SM70_MTP_CUDAGRAPH_REQUEST_SIZES = (1, 2, 4, 6, 8, 12, 16)
 
 
 def _sm70_nomtp_cudagraph_capture_sizes(max_num_seqs: int) -> list[int]:
@@ -77,6 +78,19 @@ def _sm70_nomtp_cudagraph_capture_sizes(max_num_seqs: int) -> list[int]:
     }
     capture_sizes.update((1, 2, max_graph_reqs))
     return sorted(capture_sizes)
+
+
+def _sm70_mtp_cudagraph_capture_sizes(
+    max_num_seqs: int,
+    decode_query_len: int,
+) -> list[int]:
+    """Return exact SM70 MTP verifier token shapes for production requests."""
+    max_graph_reqs = min(max(int(max_num_seqs), 1), 16)
+    request_sizes = {
+        size for size in _SM70_MTP_CUDAGRAPH_REQUEST_SIZES if size <= max_graph_reqs
+    }
+    request_sizes.add(max_graph_reqs)
+    return [decode_query_len * size for size in sorted(request_sizes)]
 
 
 class OptimizationLevel(IntEnum):
@@ -1395,11 +1409,6 @@ class VllmConfig:
                         self.speculative_config is not None
                         and self.speculative_config.num_speculative_tokens
                     ):
-                        cudagraph_capture_sizes = (
-                            [1, 2, 4, 8, 9, 18]
-                            if self.parallel_config.tensor_parallel_size >= 4
-                            else [1, 2, 4, 8, 9]
-                        )
                         decode_query_len = (
                             self.speculative_config.num_speculative_state_tokens() + 1
                         )
@@ -1417,26 +1426,47 @@ class VllmConfig:
                                 smallq_env,
                                 decode_query_len,
                             )
-                        max_graph_reqs = (
-                            4 if self.parallel_config.tensor_parallel_size >= 4 else 1
-                        )
-                        max_graph_reqs = min(
-                            max(int(self.scheduler_config.max_num_seqs), 1),
-                            max_graph_reqs,
-                        )
-                        cudagraph_capture_sizes = sorted(
-                            set(cudagraph_capture_sizes)
-                            | {
-                                decode_query_len * num_reqs
-                                for num_reqs in range(1, max_graph_reqs + 1)
-                            }
-                        )
-                        logger.info_once(
-                            "Using SM70 speculative verifier cudagraph shapes "
-                            "%sx1..%s for Flash-V100 compile graph.",
-                            decode_query_len,
-                            max_graph_reqs,
-                        )
+                        if (
+                            envs.VLLM_SM70_MTP_SPLIT_DRAFT_CUDAGRAPHS
+                            and self.speculative_config.method == "mtp"
+                        ):
+                            cudagraph_capture_sizes = _sm70_mtp_cudagraph_capture_sizes(
+                                self.scheduler_config.max_num_seqs,
+                                decode_query_len,
+                            )
+                            logger.info_once(
+                                "Using split SM70 MTP verifier cudagraph token "
+                                "shapes %s for Flash-V100 compile graph.",
+                                tuple(cudagraph_capture_sizes),
+                            )
+                        else:
+                            cudagraph_capture_sizes = (
+                                [1, 2, 4, 8, 9, 18]
+                                if self.parallel_config.tensor_parallel_size >= 4
+                                else [1, 2, 4, 8, 9]
+                            )
+                            max_graph_reqs = (
+                                4
+                                if self.parallel_config.tensor_parallel_size >= 4
+                                else 1
+                            )
+                            max_graph_reqs = min(
+                                max(int(self.scheduler_config.max_num_seqs), 1),
+                                max_graph_reqs,
+                            )
+                            cudagraph_capture_sizes = sorted(
+                                set(cudagraph_capture_sizes)
+                                | {
+                                    decode_query_len * num_reqs
+                                    for num_reqs in range(1, max_graph_reqs + 1)
+                                }
+                            )
+                            logger.info_once(
+                                "Using SM70 speculative verifier cudagraph shapes "
+                                "%sx1..%s for Flash-V100 compile graph.",
+                                decode_query_len,
+                                max_graph_reqs,
+                            )
                     elif cudagraph_capture_sizes != [1, 2]:
                         logger.info_once(
                             "Using SM70 no-MTP decode cudagraph request shapes %s.",

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -93,7 +93,11 @@ from vllm.config.parallel import (
 )
 from vllm.config.scheduler import SchedulerPolicy
 from vllm.config.utils import get_field
-from vllm.config.vllm import OptimizationLevel, PerformanceMode
+from vllm.config.vllm import (
+    OptimizationLevel,
+    PerformanceMode,
+    _sm70_mtp_cudagraph_capture_sizes,
+)
 from vllm.logger import init_logger, suppress_logging
 from vllm.platforms import CpuArchEnum, current_platform
 from vllm.plugins import load_general_plugins
@@ -1858,11 +1862,6 @@ class EngineArgs:
             and self.compilation_config.cudagraph_capture_sizes is None
             and self.compilation_config.max_cudagraph_capture_size is None
         ):
-            cudagraph_capture_sizes = (
-                [1, 2, 4, 8, 9, 18]
-                if self.tensor_parallel_size >= 4
-                else [1, 2, 4, 8, 9]
-            )
             num_speculative_tokens = int(
                 self.speculative_config.get("num_speculative_tokens") or 0
             )
@@ -1879,9 +1878,22 @@ class EngineArgs:
                 num_speculative_state_tokens = max(
                     num_speculative_tokens, ddtree_budget
                 )
-            if num_speculative_state_tokens > 0:
-                decode_query_len = num_speculative_state_tokens + 1
-                max_num_seqs = max(int(self.max_num_seqs or 1), 1)
+            decode_query_len = num_speculative_state_tokens + 1
+            max_num_seqs = max(int(self.max_num_seqs or 1), 1)
+            if envs.VLLM_SM70_MTP_SPLIT_DRAFT_CUDAGRAPHS and spec_method == "mtp":
+                cudagraph_capture_sizes = _sm70_mtp_cudagraph_capture_sizes(
+                    max_num_seqs,
+                    decode_query_len,
+                )
+                profile_updates.append(
+                    f"mtp_split_verifier_cudagraph_shapes={cudagraph_capture_sizes}"
+                )
+            else:
+                cudagraph_capture_sizes = (
+                    [1, 2, 4, 8, 9, 18]
+                    if self.tensor_parallel_size >= 4
+                    else [1, 2, 4, 8, 9]
+                )
                 cudagraph_capture_sizes = sorted(
                     set(cudagraph_capture_sizes)
                     | {

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -238,6 +238,7 @@ if TYPE_CHECKING:
     VLLM_SM70_DECODE_EVENT_TRACE_EVERY: int = 16
     VLLM_SM70_MTP_PROFILE: bool = False
     VLLM_SM70_MTP_PROFILE_INTERVAL: int = 16
+    VLLM_SM70_MTP_SPLIT_DRAFT_CUDAGRAPHS: bool = True
     VLLM_SM70_MTP_CONTEXT_BUCKETS: str | None = None
     VLLM_SM70_DSV4_DECODE_CONTEXT_BUCKETS: str | None = None
     VLLM_SM70_FP8_KV_DECODE_CONTEXT_BUCKETS: str | None = None
@@ -2018,6 +2019,9 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "VLLM_SM70_MTP_PROFILE": lambda: bool(int(os.getenv("VLLM_SM70_MTP_PROFILE", "0"))),
     "VLLM_SM70_MTP_PROFILE_INTERVAL": lambda: max(
         1, int(os.getenv("VLLM_SM70_MTP_PROFILE_INTERVAL", "16"))
+    ),
+    "VLLM_SM70_MTP_SPLIT_DRAFT_CUDAGRAPHS": lambda: bool(
+        int(os.getenv("VLLM_SM70_MTP_SPLIT_DRAFT_CUDAGRAPHS", "1"))
     ),
     "VLLM_SM70_MTP_CONTEXT_BUCKETS": lambda: os.getenv("VLLM_SM70_MTP_CONTEXT_BUCKETS"),
     "VLLM_SM70_DSV4_DECODE_CONTEXT_BUCKETS": lambda: os.getenv(

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -238,7 +238,7 @@ if TYPE_CHECKING:
     VLLM_SM70_DECODE_EVENT_TRACE_EVERY: int = 16
     VLLM_SM70_MTP_PROFILE: bool = False
     VLLM_SM70_MTP_PROFILE_INTERVAL: int = 16
-    VLLM_SM70_MTP_SPLIT_DRAFT_CUDAGRAPHS: bool = True
+    VLLM_SM70_MTP_SPLIT_DRAFT_CUDAGRAPHS: bool = False
     VLLM_SM70_MTP_CONTEXT_BUCKETS: str | None = None
     VLLM_SM70_DSV4_DECODE_CONTEXT_BUCKETS: str | None = None
     VLLM_SM70_FP8_KV_DECODE_CONTEXT_BUCKETS: str | None = None
@@ -2021,7 +2021,7 @@ environment_variables: dict[str, Callable[[], Any]] = {
         1, int(os.getenv("VLLM_SM70_MTP_PROFILE_INTERVAL", "16"))
     ),
     "VLLM_SM70_MTP_SPLIT_DRAFT_CUDAGRAPHS": lambda: bool(
-        int(os.getenv("VLLM_SM70_MTP_SPLIT_DRAFT_CUDAGRAPHS", "1"))
+        int(os.getenv("VLLM_SM70_MTP_SPLIT_DRAFT_CUDAGRAPHS", "0"))
     ),
     "VLLM_SM70_MTP_CONTEXT_BUCKETS": lambda: os.getenv("VLLM_SM70_MTP_CONTEXT_BUCKETS"),
     "VLLM_SM70_DSV4_DECODE_CONTEXT_BUCKETS": lambda: os.getenv(

--- a/vllm/v1/worker/gpu/cudagraph_utils.py
+++ b/vllm/v1/worker/gpu/cudagraph_utils.py
@@ -34,6 +34,36 @@ from vllm.v1.worker.utils import AttentionGroup
 logger = init_logger(__name__)
 
 
+def _use_split_sm70_mtp_cudagraphs(vllm_config: VllmConfig) -> bool:
+    speculative_config = vllm_config.speculative_config
+    return bool(
+        envs.VLLM_SM70_MTP_SPLIT_DRAFT_CUDAGRAPHS
+        and speculative_config is not None
+        and speculative_config.method == "mtp"
+        and current_platform.is_cuda()
+        and current_platform.is_device_capability((7, 0))
+    )
+
+
+def _split_sm70_mtp_manager_capture_sizes(
+    vllm_config: VllmConfig,
+    decode_query_len: int,
+) -> list[int]:
+    capture_sizes = sorted(vllm_config.compilation_config.cudagraph_capture_sizes or [])
+    if decode_query_len != 1:
+        return capture_sizes
+
+    speculative_config = vllm_config.speculative_config
+    assert speculative_config is not None
+    verifier_query_len = speculative_config.num_speculative_state_tokens() + 1
+    return [
+        size // verifier_query_len
+        for size in capture_sizes
+        if size % verifier_query_len == 0
+        and size // verifier_query_len <= vllm_config.scheduler_config.max_num_seqs
+    ]
+
+
 class CapturedAttentionState(NamedTuple):
     attn_metadata: dict[str, Any] | None
     slot_mappings: dict[str, torch.Tensor]
@@ -111,15 +141,32 @@ class CudaGraphManager:
         self._graphs_captured = False
         self._candidates: list[list[BatchExecutionDescriptor]] = []
         self._capture_descs: dict[CUDAGraphMode, list[BatchExecutionDescriptor]] = {}
-        # adjust the cudagraph sizes to be a multiple of the uniform decode query length
-        self.compilation_config.adjust_cudagraph_sizes_for_spec_decode(
-            self.decode_query_len, self.tp_size
-        )
+        if _use_split_sm70_mtp_cudagraphs(vllm_config):
+            self._capture_sizes = _split_sm70_mtp_manager_capture_sizes(
+                vllm_config,
+                decode_query_len,
+            )
+            logger.info_once(
+                "Using split SM70 MTP CUDA graph manager shapes: "
+                "decode_query_len=%d capture_sizes=%s shared_verifier_shapes=%s.",
+                decode_query_len,
+                tuple(self._capture_sizes),
+                tuple(self.compilation_config.cudagraph_capture_sizes or ()),
+            )
+        else:
+            # Legacy MRV1 behavior. The rollback path deliberately preserves
+            # the shared in-place normalization used before split managers.
+            self.compilation_config.adjust_cudagraph_sizes_for_spec_decode(
+                self.decode_query_len, self.tp_size
+            )
+            self._capture_sizes = list(
+                self.compilation_config.cudagraph_capture_sizes or []
+            )
         self._init_candidates()
 
     def _init_candidates(self) -> None:
         """Build priority-ordered candidate lists for each token count."""
-        capture_sizes = self.compilation_config.cudagraph_capture_sizes
+        capture_sizes = self._capture_sizes
         if not (self.cudagraph_mode and capture_sizes):
             return
 


### PR DESCRIPTION
## Purpose

Add an opt-in SM70/MTP CUDA Graph ownership split so verifier and drafter managers can use exact token/request shapes without mutating the shared CompilationConfig.

The performance/equality matrix is not complete, so the audited behavior is deliberately default-off. Existing production graph ownership remains unchanged unless VLLM_SM70_MTP_SPLIT_DRAFT_CUDAGRAPHS=1 is set.

## Implementation

- Opt-in, SM70/MTP-only gate.
- Verifier token shapes are derived from MTP query length and request buckets.
- Drafter managers use request-count shapes.
- B32 remains a probe rather than a default production bucket.
- The legacy shared normalization path remains the default and immediate rollback.

## Test Plan

- Validate legacy behavior with the flag absent.
- Validate opt-in B1/B2/B4/B6/B8/B12/B16 dispatch and shared-config immutability.
- Run changed-file static gates.
- Do not claim a speedup until matched TP4 equality and decode A/B gates are completed.

## Test Result

- Focused opt-in/default and graph-manager tests: 5 passed.
- Capture-size policy matrix: 7 passed.
- Prior manager-level audit covered 30 selected q1/q5 dispatches with exact FULL graph shapes and zero shared-config mutations.
- Changed-file pre-commit and git diff --check: passed.
- No model E2E was repeated during maintainer audit.
- Status: safe optional infrastructure; no default performance claim.

## AI assistance

OpenAI Codex rebased the change onto current main, resolved the test-helper integration, and changed the unproven route from default-on to explicit opt-in.