### PR TITLE
[Core] Persist selector-based DFlash GDN verify metadata

### DIFF
--- a/benchmarks/benchmark_sm70_dflash2_gdn_metadata.py
+++ b/benchmarks/benchmark_sm70_dflash2_gdn_metadata.py
@@ -247,6 +247,14 @@ def _run_case(
             num_warps=1,
         )
 
+    def fused_with_host_fence_step() -> None:
+        fused_step()
+        if (
+            common_metadata.spec_query_start_loc[-1].item()
+            != common_metadata.num_spec_decode_tokens
+        ):
+            raise AssertionError("invalid speculative query span")
+
     legacy_step()
     torch.cuda.synchronize()
     expected_states = [
@@ -291,9 +299,13 @@ def _run_case(
 
     legacy_launches = _profile_cuda_launches(legacy_step)
     fused_launches = _profile_cuda_launches(fused_step)
+    fused_with_host_fence_launches = _profile_cuda_launches(
+        fused_with_host_fence_step
+    )
     fused_kernel_only_launches = _profile_cuda_launches(fused_kernel_only_step)
     legacy = _measure(legacy_step, repeats)
     fused = _measure(fused_step, repeats)
+    fused_with_host_fence = _measure(fused_with_host_fence_step, repeats)
     fused_kernel_only = _measure(fused_kernel_only_step, repeats)
     return {
         "batch_size": batch_size,
@@ -303,10 +315,16 @@ def _run_case(
         "correctness": "bitwise_equal_after_poison",
         "legacy_cuda_launches": legacy_launches,
         "fused_cuda_launches": fused_launches,
+        "fused_with_host_fence_cuda_launches": fused_with_host_fence_launches,
         "fused_kernel_only_cuda_launches": fused_kernel_only_launches,
         "legacy": legacy,
         "fused": fused,
+        "fused_with_host_fence": fused_with_host_fence,
         "fused_kernel_only": fused_kernel_only,
+        "host_fence_wall_cost_p50_ms": (
+            fused_with_host_fence["synchronized_wall_ms"]["p50"]
+            - fused["synchronized_wall_ms"]["p50"]
+        ),
         "fused_python_overhead_p50_ms": (
             fused["synchronized_wall_ms"]["p50"]
             - fused_kernel_only["synchronized_wall_ms"]["p50"]

--- a/benchmarks/benchmark_sm70_dflash2_gdn_metadata.py
+++ b/benchmarks/benchmark_sm70_dflash2_gdn_metadata.py
@@ -68,7 +68,7 @@ def _profile_cuda_launches(step: Any) -> int:
 
     with profile(activities=[ProfilerActivity.CPU, ProfilerActivity.CUDA]) as prof:
         step()
-        torch.cuda.synchronize()
+        torch.accelerator.synchronize()
     return sum(
         1
         for event in prof.events()
@@ -79,10 +79,10 @@ def _profile_cuda_launches(step: Any) -> int:
 def _measure(step: Any, repeats: int) -> dict[str, dict[str, float]]:
     wall_samples: list[float] = []
     gpu_samples: list[float] = []
-    start = torch.cuda.Event(enable_timing=True)
-    end = torch.cuda.Event(enable_timing=True)
+    start = torch.Event(enable_timing=True)
+    end = torch.Event(enable_timing=True)
     for _ in range(repeats):
-        torch.cuda.synchronize()
+        torch.accelerator.synchronize()
         wall_start = time.perf_counter_ns()
         start.record()
         step()
@@ -256,7 +256,7 @@ def _run_case(
             raise AssertionError("invalid speculative query span")
 
     legacy_step()
-    torch.cuda.synchronize()
+    torch.accelerator.synchronize()
     expected_states = [
         builder.spec_state_indices_tensor.clone() for builder in builders
     ]
@@ -273,7 +273,7 @@ def _run_case(
     common_buffers.num_accepted_tokens.fill_(-1)
     common_buffers.spec_state_slot_selectors.fill_(-1)
     fused_step()
-    torch.cuda.synchronize()
+    torch.accelerator.synchronize()
     for actual_builder, expected_state in zip(builders, expected_states):
         torch.testing.assert_close(
             actual_builder.spec_state_indices_tensor,
@@ -295,7 +295,7 @@ def _run_case(
     for _ in range(warmup):
         legacy_step()
         fused_step()
-    torch.cuda.synchronize()
+    torch.accelerator.synchronize()
 
     legacy_launches = _profile_cuda_launches(legacy_step)
     fused_launches = _profile_cuda_launches(fused_step)

--- a/benchmarks/benchmark_sm70_dflash2_gdn_metadata.py
+++ b/benchmarks/benchmark_sm70_dflash2_gdn_metadata.py
@@ -299,9 +299,7 @@ def _run_case(
 
     legacy_launches = _profile_cuda_launches(legacy_step)
     fused_launches = _profile_cuda_launches(fused_step)
-    fused_with_host_fence_launches = _profile_cuda_launches(
-        fused_with_host_fence_step
-    )
+    fused_with_host_fence_launches = _profile_cuda_launches(fused_with_host_fence_step)
     fused_kernel_only_launches = _profile_cuda_launches(fused_kernel_only_step)
     legacy = _measure(legacy_step, repeats)
     fused = _measure(fused_step, repeats)

--- a/benchmarks/benchmark_sm70_dflash2_gdn_metadata.py
+++ b/benchmarks/benchmark_sm70_dflash2_gdn_metadata.py
@@ -1,0 +1,357 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Microbenchmark DFlash2 target GDN metadata construction on SM70."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import statistics
+import time
+from dataclasses import dataclass
+from types import SimpleNamespace
+from typing import Any
+
+import torch
+
+from vllm import envs
+from vllm.triton_utils import triton
+from vllm.v1.attention.backends.gdn_attn import (
+    DFlash2GDNGroupDescriptor,
+    _dflash2_gdn_group_metadata_kernel,
+    _get_ddtree_gdn_fast_common_buffers,
+    build_gdn_spec_decode_state_contract,
+    prepare_dflash2_gdn_group_metadata,
+)
+from vllm.v1.attention.backends.utils import PAD_SLOT_ID
+from vllm.v1.worker.gpu.attn_utils import compute_common_gdn_attn_metadata
+
+
+@dataclass
+class _MicroBuilder:
+    num_spec_state_tokens: int
+    decode_cudagraph_max_bs: int
+    spec_state_indices_tensor: torch.Tensor
+    _ddtree_fast_common_buffers: Any
+    use_full_cuda_graph: bool = True
+    vllm_config: Any = None
+
+    def __post_init__(self) -> None:
+        self.vllm_config = SimpleNamespace(
+            cache_config=SimpleNamespace(mamba_cache_mode="none")
+        )
+
+
+def _percentile(samples: list[float], quantile: float) -> float:
+    ordered = sorted(samples)
+    position = (len(ordered) - 1) * quantile
+    lower = int(position)
+    upper = min(lower + 1, len(ordered) - 1)
+    weight = position - lower
+    return ordered[lower] + (ordered[upper] - ordered[lower]) * weight
+
+
+def _distribution(samples: list[float]) -> dict[str, float]:
+    return {
+        "mean": statistics.fmean(samples),
+        "p50": _percentile(samples, 0.50),
+        "p90": _percentile(samples, 0.90),
+        "p99": _percentile(samples, 0.99),
+        "min": min(samples),
+        "max": max(samples),
+    }
+
+
+def _profile_cuda_launches(step: Any) -> int:
+    from torch.profiler import ProfilerActivity, profile
+
+    with profile(activities=[ProfilerActivity.CPU, ProfilerActivity.CUDA]) as prof:
+        step()
+        torch.cuda.synchronize()
+    return sum(
+        1
+        for event in prof.events()
+        if str(getattr(event, "device_type", "")).lower().endswith("cuda")
+    )
+
+
+def _measure(step: Any, repeats: int) -> dict[str, dict[str, float]]:
+    wall_samples: list[float] = []
+    gpu_samples: list[float] = []
+    start = torch.cuda.Event(enable_timing=True)
+    end = torch.cuda.Event(enable_timing=True)
+    for _ in range(repeats):
+        torch.cuda.synchronize()
+        wall_start = time.perf_counter_ns()
+        start.record()
+        step()
+        end.record()
+        end.synchronize()
+        wall_samples.append((time.perf_counter_ns() - wall_start) / 1e6)
+        gpu_samples.append(start.elapsed_time(end))
+    return {
+        "synchronized_wall_ms": _distribution(wall_samples),
+        "cuda_event_ms": _distribution(gpu_samples),
+    }
+
+
+def _run_case(
+    batch_size: int,
+    num_groups: int,
+    width: int,
+    warmup: int,
+    repeats: int,
+) -> dict[str, Any]:
+    device = torch.device("cuda")
+    num_actual_tokens = batch_size * width
+    common_buffers = _get_ddtree_gdn_fast_common_buffers(
+        device,
+        num_actual_tokens,
+        width,
+    )
+    builders = [
+        _MicroBuilder(
+            num_spec_state_tokens=width - 1,
+            decode_cudagraph_max_bs=num_actual_tokens,
+            spec_state_indices_tensor=torch.empty(
+                (num_actual_tokens, width), dtype=torch.int32, device=device
+            ),
+            _ddtree_fast_common_buffers=common_buffers,
+        )
+        for _ in range(num_groups)
+    ]
+    block_tables = tuple(
+        (
+            torch.arange(
+                batch_size * width,
+                dtype=torch.int32,
+                device=device,
+            ).view(batch_size, width)
+            + group_id * 10_000
+        ).contiguous()
+        for group_id in range(num_groups)
+    )
+    query_start_loc = torch.arange(
+        0,
+        num_actual_tokens + 1,
+        width,
+        dtype=torch.int32,
+        device=device,
+    )
+    query_start_loc_cpu = query_start_loc.cpu()
+    draft_counts_cpu = torch.full((batch_size,), width - 1, dtype=torch.int32)
+    common_metadata = compute_common_gdn_attn_metadata(
+        num_decode_draft_tokens_cpu=draft_counts_cpu,
+        query_start_loc=query_start_loc,
+        query_start_loc_cpu=query_start_loc_cpu,
+        num_spec_state_tokens=width - 1,
+        legacy_mixed_decode_routing=False,
+    )
+    assert common_metadata is not None
+    accepted_values = [3, 5, 7, 2]
+    accepted = torch.tensor(
+        [accepted_values[index % len(accepted_values)] for index in range(batch_size)],
+        dtype=torch.int32,
+        device=device,
+    )
+    seq_lens = torch.full((batch_size,), 4097, dtype=torch.int32, device=device)
+    spec_mask_cpu = torch.ones(batch_size, dtype=torch.bool)
+    spec_mask = common_metadata.spec_sequence_masks
+
+    def legacy_step() -> None:
+        for group_id, builder in enumerate(builders):
+            contract = build_gdn_spec_decode_state_contract(
+                block_table_tensor=block_tables[group_id],
+                seq_lens=seq_lens,
+                block_size=16,
+                num_spec=width - 1,
+                spec_sequence_masks_cpu=spec_mask_cpu,
+                num_accepted_tokens=accepted,
+                current_state_block_ids=None,
+                is_mamba_cache_all=False,
+            )
+            builder.spec_state_indices_tensor[:batch_size].copy_(
+                contract.spec_state_indices_tensor,
+                non_blocking=True,
+            )
+            builder.spec_state_indices_tensor[batch_size:].fill_(PAD_SLOT_ID)
+
+            common_buffers.spec_sequence_masks[:batch_size].copy_(
+                spec_mask, non_blocking=True
+            )
+            common_buffers.spec_sequence_masks[batch_size:].fill_(False)
+            common_buffers.spec_token_indx[:num_actual_tokens].copy_(
+                common_metadata.spec_token_indx,
+                non_blocking=True,
+            )
+            common_buffers.spec_query_start_loc[: batch_size + 1].copy_(
+                common_metadata.spec_query_start_loc,
+                non_blocking=True,
+            )
+            spec_num_query_tokens = common_metadata.spec_query_start_loc[-1]
+            common_buffers.spec_query_start_loc[batch_size + 1 :].fill_(
+                spec_num_query_tokens
+            )
+            common_buffers.num_accepted_tokens[:batch_size].copy_(
+                contract.num_accepted_tokens,
+                non_blocking=True,
+            )
+            common_buffers.num_accepted_tokens[batch_size:].fill_(1)
+            common_buffers.spec_state_slot_selectors[:batch_size].copy_(
+                contract.spec_state_slot_selectors,
+                non_blocking=True,
+            )
+            common_buffers.spec_state_slot_selectors[batch_size:].fill_(1)
+
+    descriptor: DFlash2GDNGroupDescriptor | None = None
+
+    def fused_step() -> None:
+        nonlocal descriptor
+        result = prepare_dflash2_gdn_group_metadata(
+            builders_by_group=[
+                (group_id, builder) for group_id, builder in enumerate(builders)
+            ],
+            block_tables=block_tables,
+            common_gdn_metadata=common_metadata,
+            num_accepted_tokens=accepted,
+            num_actual_tokens=num_actual_tokens,
+            descriptor=descriptor,
+        )
+        if result is None:
+            raise RuntimeError("fused DFlash2 GDN metadata path was not eligible")
+        _, descriptor = result
+
+    def fused_kernel_only_step() -> None:
+        if descriptor is None:
+            raise RuntimeError("fused descriptor has not been initialized")
+        block = triton.next_power_of_2(
+            max(num_actual_tokens * width, num_actual_tokens + 1)
+        )
+        _dflash2_gdn_group_metadata_kernel[(num_groups,)](
+            descriptor.block_table_ptrs,
+            descriptor.state_output_ptrs,
+            descriptor.block_table_strides,
+            common_metadata.spec_query_start_loc,
+            accepted,
+            accepted,
+            common_buffers.spec_sequence_masks,
+            common_buffers.spec_query_start_loc,
+            common_buffers.num_accepted_tokens,
+            common_buffers.spec_state_slot_selectors,
+            batch_size,
+            num_actual_tokens,
+            WIDTH=width,
+            PAD_ID=PAD_SLOT_ID,
+            BLOCK=block,
+            num_warps=1,
+        )
+
+    legacy_step()
+    torch.cuda.synchronize()
+    expected_states = [
+        builder.spec_state_indices_tensor.clone() for builder in builders
+    ]
+    expected_common = (
+        common_buffers.spec_sequence_masks.clone(),
+        common_buffers.spec_query_start_loc.clone(),
+        common_buffers.num_accepted_tokens.clone(),
+        common_buffers.spec_state_slot_selectors.clone(),
+    )
+    for builder in builders:
+        builder.spec_state_indices_tensor.fill_(777)
+    common_buffers.spec_sequence_masks.fill_(True)
+    common_buffers.spec_query_start_loc.fill_(-1)
+    common_buffers.num_accepted_tokens.fill_(-1)
+    common_buffers.spec_state_slot_selectors.fill_(-1)
+    fused_step()
+    torch.cuda.synchronize()
+    for actual_builder, expected_state in zip(builders, expected_states):
+        torch.testing.assert_close(
+            actual_builder.spec_state_indices_tensor,
+            expected_state,
+            rtol=0,
+            atol=0,
+        )
+    for actual, expected in zip(
+        (
+            common_buffers.spec_sequence_masks,
+            common_buffers.spec_query_start_loc,
+            common_buffers.num_accepted_tokens,
+            common_buffers.spec_state_slot_selectors,
+        ),
+        expected_common,
+    ):
+        torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+
+    for _ in range(warmup):
+        legacy_step()
+        fused_step()
+    torch.cuda.synchronize()
+
+    legacy_launches = _profile_cuda_launches(legacy_step)
+    fused_launches = _profile_cuda_launches(fused_step)
+    fused_kernel_only_launches = _profile_cuda_launches(fused_kernel_only_step)
+    legacy = _measure(legacy_step, repeats)
+    fused = _measure(fused_step, repeats)
+    fused_kernel_only = _measure(fused_kernel_only_step, repeats)
+    return {
+        "batch_size": batch_size,
+        "num_actual_tokens": num_actual_tokens,
+        "num_groups": num_groups,
+        "state_width": width,
+        "correctness": "bitwise_equal_after_poison",
+        "legacy_cuda_launches": legacy_launches,
+        "fused_cuda_launches": fused_launches,
+        "fused_kernel_only_cuda_launches": fused_kernel_only_launches,
+        "legacy": legacy,
+        "fused": fused,
+        "fused_kernel_only": fused_kernel_only,
+        "fused_python_overhead_p50_ms": (
+            fused["synchronized_wall_ms"]["p50"]
+            - fused_kernel_only["synchronized_wall_ms"]["p50"]
+        ),
+        "wall_speedup": (
+            legacy["synchronized_wall_ms"]["p50"] / fused["synchronized_wall_ms"]["p50"]
+        ),
+        "gpu_speedup": (legacy["cuda_event_ms"]["p50"] / fused["cuda_event_ms"]["p50"]),
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--batch-sizes", type=int, nargs="+", default=[1, 2, 4])
+    parser.add_argument("--num-groups", type=int, default=10)
+    parser.add_argument("--width", type=int, default=8)
+    parser.add_argument("--warmup", type=int, default=20)
+    parser.add_argument("--repeats", type=int, default=100)
+    args = parser.parse_args()
+
+    if not torch.cuda.is_available():
+        raise RuntimeError("CUDA is required")
+    if torch.cuda.get_device_capability() != (7, 0):
+        raise RuntimeError("this microbenchmark requires SM70")
+    os.environ["VLLM_SM70_DFLASH2_FUSED_GDN_METADATA"] = "1"
+    os.environ["VLLM_SM70_DFLASH2_GDN_METADATA_SHADOW"] = "0"
+    envs.disable_envs_cache()
+
+    results = [
+        _run_case(
+            batch_size=batch_size,
+            num_groups=args.num_groups,
+            width=args.width,
+            warmup=args.warmup,
+            repeats=args.repeats,
+        )
+        for batch_size in args.batch_sizes
+    ]
+    print(
+        json.dumps(
+            {"device": torch.cuda.get_device_name(), "cases": results},
+            indent=2,
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/design/sm70_v100_migration_control.md
+++ b/docs/design/sm70_v100_migration_control.md
@@ -358,6 +358,77 @@ Goal:
   SGLang report is
   `/data/models/v100-dflash2-20260820/sglang-audit/perf-rootcause/sglang-dflash2-single1-step20-v2.{qdstrm,nsys-rep,sqlite}`.
 
+### PR257 shared-metadata and packed-GDN checkpoint, 2026-08-22
+
+- Draft PR #257 is isolated on
+  `codex/v100-dflash2-gdn-metadata-20260822-122723`; it is stacked on PR #254
+  and changes only the MRV2 DFlash2 target-verification path. Eagle, MTP,
+  DFlash1, and `dflash_ddtree` retain their existing dispatch. Both candidate
+  leaves remain default-off while the TP4 profile and statistical-quality
+  gates are pending.
+- The first leaf adapts vLLM PR #52297 at fixed head
+  `5f4c9678d1bb791ffb3ad23a9ae4129db9eb299d`: request classification, token
+  indices, and query offsets are computed once per batch, while cache-group
+  state block IDs remain group-owned. A same-hash/AAL 64-token Graph B1 probe
+  improved steady decode from 84.79 to 91.10 tok/s and decode time from 0.7430
+  to 0.6915 s. The eager candidate regressed, so this evidence supports only
+  the production Graph route. An eight-request probabilistic probe changed the
+  aggregate acceptance trajectory and is not accepted as a compute-only speed
+  comparison.
+- This port does not yet remove the dominant state-contract fan-out. Each of
+  ten padded GDN cache groups still performs group-specific block-table work
+  plus repeated boolean compaction for accepted-state metadata. The next
+  metadata step must be judged by the measured draft-to-target interval and
+  kernel count, not by the upstream H200 claim alone. Upstream reports its
+  builder moving from about 900 to 300 microseconds and B1 throughput +61%; the
+  V100 result remains an independent gate.
+- A second DFlash2-only leaf removes packed-QKV rearrangement and the final GDN
+  output copy while preserving the existing split gating materialization. The
+  first implementation used `q * rsqrt(sum(q^2)+eps)` where the accepted
+  recurrent verifier uses `q / sqrt(sum(q^2)+eps)`. Although mathematically
+  equivalent, that changed at most one FP16 ULP in the operator test and moved
+  a fixed-seed probabilistic decision at output token 111. This explains why
+  the earlier fully fused and packed candidates followed the same alternate
+  trajectory.
+- The repaired packed kernel now explicitly selects the recurrent verifier's
+  launch geometry and arithmetic order, including `/sqrt` normalization and
+  the same decay exponential helper. Gating remains precomputed in its original
+  dtype. On a physical V100, all eight production-shape parity cases
+  (`Hq=4`, `Hv=12`, `K=V=128` per TP4 rank; B1/B2; draft 3/7; FP16/FP32
+  recurrent state) are bitwise equal for both output and persistent state. The
+  per-step low-precision state reload case also passes, and the complete shared
+  fused-sigmoid/recurrent file reports 27/27 passing tests.
+- Before the arithmetic repair, the fully fused greedy one-request diagnostic
+  kept the exact token hash and acceptance length while improving steady decode
+  99.15 to 103.45 tok/s (+4.34%) and decode time 1.2809 to 1.2277 s (-4.16%).
+  That number is retained only as evidence that this kernel family can reduce
+  work; it is not the accepted result for the repaired packed leaf. The repaired
+  leaf still needs a matched unprofiled B1 run and a control/candidate Nsight
+  pair before default enablement.
+- The statistical quality gate is broader than greedy identity. Greedy hashes
+  remain a sensitive diagnostic, while default enablement also requires bounded
+  fixed-text logprob/perplexity change and no regression on fixed subsets of
+  GSM8K, MATH-500, HumanEval, and MBPP. The retained datasets and SHA256 values
+  are `GSM8K 3730d312...`, `MATH-500 35dc4108...`,
+  `HumanEval 2f2871a1...`, `MBPP e9e9efa2...`, and WikiText-2 validation
+  `204929b7...`; all live under
+  `/data/models/v100-dflash2-20260820/datasets/` and are not repository assets.
+- The next Nsight pair must preserve TP4, Flash-V100, target E5M2 KV, draft
+  FP16 KV, block eight, single-request Graph execution, and the fixed request.
+  It will report draft Graph, draft-to-target metadata/input preparation,
+  target verifier Graph, rejection/target-to-draft, full round time, Graph node
+  count, rank-critical GPU service, and TP GPU-sum service. The existing control
+  trace lacks supported replay NVTX ranges and is therefore not fed through the
+  generic per-token parser; control and candidate will be recaptured with the
+  same replay markers rather than manufacturing a partial comparison.
+- SGLang PR #26520's final-state recomputation path is not selected for this
+  B1 lane. Its own acceptance-aligned result is 2.5% lower throughput than the
+  cached-state control. vLLM already writes speculative intermediate states to
+  state-pool slots, so the nearer-term path is shared/persistent metadata and a
+  numerically equivalent verifier kernel. ReplaySSM remains a later high-batch
+  research lane, not a substitute for the current single-request verification
+  cost gate.
+
 Main implementation priority:
 
 1. Add a decoupled SM70 TurboMind backend for AWQ and FP8 base GEMM.

--- a/docs/design/sm70_v100_migration_control.md
+++ b/docs/design/sm70_v100_migration_control.md
@@ -421,6 +421,60 @@ Goal:
   trace lacks supported replay NVTX ranges and is therefore not fed through the
   generic per-token parser; control and candidate will be recaptured with the
   same replay markers rather than manufacturing a partial comparison.
+- A stricter re-audit of the retained endpoint JSONs intersects the long-output
+  requests by `dataset_index` and requires both implementations to emit at
+  least 512 tokens. Across those 11 matched requests, vLLM uses 40.7194 ms per
+  verification round (`decode_time / num_drafts`) and SGLang uses at most
+  26.7101 ms (`request_elapsed_seconds / spec_verify_ct`), leaving a gap of at
+  least 14.0093 ms. The SGLang field includes prefill and is therefore an upper
+  bound on its decode-round cost. The earlier 40.7148/26.8166 ms values use the
+  independently selected 13/14-request long-output subsets and remain useful
+  aggregate references, but they are not a strictly paired endpoint statistic.
+- Re-parsing the existing node traces by complete round and taking the slowest
+  TP rank for every interval gives the following diagnostic wall table. These
+  values include graph-node tracing overhead and must not replace the endpoint
+  numbers above.
+
+  | traced phase | vLLM mean / p50 / p90 / p99 (ms) | SGLang mean / p50 / p90 / p99 (ms) | vLLM / SGLang launches per rank |
+  | --- | --- | --- | ---: |
+  | draft Graph | 4.065 / 4.028 / 4.073 / 4.088 | 3.961 / 3.928 / 4.123 / 4.193 | 185 / 158 |
+  | draft to target | 18.382 / 17.660 / 21.258 / 22.690 | 3.517 / 3.423 / 3.660 / 4.066 | 431 / 30 |
+  | target Graph | 24.835 / 24.880 / 24.943 / 24.995 | 19.723 / 19.600 / 19.939 / 20.526 | 2612 / 1130 |
+  | target to next draft | 2.791 / 2.793 / 2.806 / 2.809 | 4.216 / 4.188 / 4.332 / 4.402 | 63 / 125 |
+  | complete traced round | 49.860 / 49.145 / 52.410 / 54.266 | 31.212 / 31.038 / 31.905 / 31.906 | n/a |
+
+  Per-phase critical-rank means are diagnostic and are not strictly additive;
+  the complete-round row is measured directly from draft-Graph start to the
+  next draft-Graph start.
+- The 431-kernel vLLM draft-to-target interval now has an exact launch
+  accounting. Repeated GDN state-contract compaction and its generic
+  indexing/copy/scan helpers consume 423 launches and about 1.276 ms of
+  rank-average GPU service; block-table, slot, RoPE, and input mapping consume
+  seven launches and about 0.044 ms; the final TP4 reduce/synchronization is one
+  launch and averages about 0.598 ms. That reduce is primarily a rank-skew wait
+  at this boundary (0.128 ms p50, 1.339 ms p90, 6.241 ms p99), not a stable
+  0.598 ms compute kernel. SGLang reaches the target with 30 launches and about
+  0.115 ms GPU service. This makes removal of the ten repeated group contracts
+  the first optimization, before tuning the boundary collective itself.
+- Inside the target Graph, both implementations spend essentially the same
+  time in 256 target FP8 GEMMs (10.850 versus 10.570 ms of rank-average GPU
+  service). vLLM's excess is concentrated in 1,422 generic vectorized,
+  unrolled, and elementwise copy nodes (4.621 ms) versus SGLang's 211 nodes
+  (0.667 ms), plus the TP reduction path (2.350 ms on vLLM's slowest rank versus
+  1.603 ms on SGLang's slowest rank). Attention and KV-cache service are close.
+  SGLang includes roughly 0.979 ms of target LM-head GEMM and 0.129 ms of TP
+  all-gather inside its target Graph, whereas vLLM launches the corresponding
+  work after the graph; semantic comparisons must retain this boundary
+  difference.
+- With the repaired corpus-wide pooled acceptance length of 4.5644, the
+  current 40.7148 ms round cost corresponds to about 112 emitted tokens/s
+  before request-level residuals. A 32 ms round is only an intermediate gate
+  (about 143 tokens/s), and SGLang parity near 26.8 ms is about 170 tokens/s at
+  the same pooled acceptance. Reaching the requested 200 tokens/s without
+  relying on a higher acceptance length requires approximately 22.82 ms per
+  round. The optimization sequence is therefore persistent/fused GDN metadata,
+  removal of target-Graph copy/state fan-out, then the TP4 reduction path;
+  proposal/selector work is not on the critical gap.
 - SGLang PR #26520's final-state recomputation path is not selected for this
   B1 lane. Its own acceptance-aligned result is 2.5% lower throughput than the
   cached-state control. vLLM already writes speculative intermediate states to

--- a/docs/design/sm70_v100_migration_control.md
+++ b/docs/design/sm70_v100_migration_control.md
@@ -482,6 +482,20 @@ Goal:
   numerically equivalent verifier kernel. ReplaySSM remains a later high-batch
   research lane, not a substitute for the current single-request verification
   cost gate.
+- The first persistent pointer-table implementation has now passed an isolated
+  SM70 microbenchmark at the production block-eight width and ten target GDN
+  cache groups. It overwrites group-specific state IDs plus every shared live
+  and padded field in one Triton launch and remains bitwise equal to the legacy
+  contract after poisoning all persistent outputs. On an otherwise-idle V100,
+  the B1 legacy fan-out uses 400 CUDA launches and 5.360 ms synchronized-wall
+  p50 versus one launch and 0.354 ms for the fused path, a 15.13x speedup and
+  5.006 ms local saving. B2 is 5.360 versus 0.358 ms and B4 is 5.346 versus
+  0.354 ms, both about 15x. A separate lower-bound probe measures the raw fused
+  kernel at 0.056 ms wall / 0.040 ms GPU p50; roughly 0.305 ms remains in Python
+  eligibility, pointer validation, and metadata-view construction. These are
+  microbenchmark results, not yet an endpoint round-cost claim. The benchmark
+  is `benchmarks/benchmark_sm70_dflash2_gdn_metadata.py`; an unprofiled TP4
+  fixed-trajectory run remains required before default enablement.
 
 Main implementation priority:
 

--- a/docs/design/sm70_v100_migration_control.md
+++ b/docs/design/sm70_v100_migration_control.md
@@ -508,6 +508,57 @@ Goal:
   the production scalar host fence costs only 0.028 ms p50, so it is not the
   source of the former multi-millisecond Draft-to-Target gap and remains in
   place pending the end-to-end trajectory gate.
+- The first matched TP4 endpoint trace now validates that the microbenchmark
+  saving survives the real MRV2 DFlash2 path. Both runs use source
+  `11a190397abd7209ed1d3aeeeb8ed691e06087f7`, the same fixed shuffled GSM8K
+  request, Graph target and draft, block eight, probabilistic sampling, target
+  E5M2 KV, and draft FP16 KV. The control omitted the parent fast-path gate and
+  therefore exercised the generic metadata builder; the candidate enabled both
+  `VLLM_SM70_DFLASH2_VERIFY_FASTPATH=1` and
+  `VLLM_SM70_DFLASH2_FUSED_GDN_METADATA=1`.
+    - Control: 4.820868 s decode / 103 verification rounds = 46.8045 ms per
+      round, 88.99 steady-decode tok/s, and 86.11 aggregate tok/s.
+    - Fused candidate: 3.573145 s / 102 rounds = 35.0308 ms per round, 120.06
+      steady-decode tok/s, and 114.20 aggregate tok/s.
+    - This is an 11.7737 ms (`25.15%`) reduction in traced endpoint round cost,
+      `+34.92%` steady-decode throughput, and `+32.61%` aggregate throughput.
+      The 430 output token IDs and SHA256
+      `c3aa4bdf534d580213871cb17d31ee997db9cf2ae19ae4766646fe92d463a225`
+      are exactly equal and the answer remains correct. Acceptance length does
+      not regress: it moves from 4.1748 to 4.2157 (`+0.0409`).
+    - The candidate trace contains 412 fused metadata launches across TP4,
+      corresponding to 103 captured steps per rank (the request reports 102
+      draft/verification rounds). Generic CUB `DeviceReduce` and `DeviceSelect`
+      disappear (`20,800 -> 0` each); `DeviceScan` falls from 20,008 to 19,816,
+      leaving scans owned by other paths. CUDA runtime fan-out falls from
+      27,060 to 2,492 stream synchronizations, 90,524 to 16,328 async copies,
+      and 205,752 to 88,928 ordinary kernel launches across the four workers.
+      This proves that the wall saving is primarily removal of the repeated
+      host-synchronized metadata fan-out rather than the fused kernel's own
+      1.528 ms aggregate GPU service.
+    - These endpoint values were collected under low-overhead Graph-level
+      Nsight tracing and are the accepted matched A/B for this leaf. A short
+      node-level trace is still required to update the semantic Draft-to-Target
+      and target-verifier phase table; node tracing will be used for
+      composition only because it inflates absolute latency.
+  Artifacts are
+  `/data/minimax-h3/task-cache/v100-dflash2-pr257-gdn-metadata/results/dflash2-fused-viewcache-b1-graph-o512-{v2,v4}.json` and
+  `/data/minimax-h3/task-cache/v100-dflash2-pr257-gdn-metadata/profiles/latest-e2e/dflash2-fused-viewcache-b1-graph-v4.{qdstrm,nsys-rep,sqlite}`.
+- `dnv2003/v100-skinny` is useful as an optimization inventory, but its published
+  219.1 tok/s result is a Qwen3.8 mixed-NVFP4/FP8 MTP-k7 route on its 1Cat-vLLM
+  1.2.2 fork, not a DFlash2 result and therefore not a direct baseline. Its
+  chain-MTP GDN builder removes 21 device synchronizations and about 70 copies
+  for a reported 1.4 ms/step saving; PR257's persistent pointer table is the
+  stronger version of the same principle and now has direct DFlash2 evidence.
+  The fork's lagged CUDA-event/NVTX phase profiler is worth adapting to MRV2 so
+  verify, rejection, and proposal can be measured without adding a per-round
+  synchronization. Its partition pin is not active leverage at this run's
+  `max_model_len=8192`, and its FP16-KV win is specific to a route where FP8 KV
+  fell back to a scalar path; Flash-V100 reports the optimized E5M2 cache path
+  here, so any KV change still requires a matched A/B. The QPN8 verifier idea is
+  relevant, but the independently adapted block-FP8 implementation in Draft PR
+  #258 currently rejects speculative configurations. It must pass a dedicated
+  DFlash2 M=8 contract and quality gate before stacking onto this PR.
 
 Main implementation priority:
 

--- a/docs/design/sm70_v100_migration_control.md
+++ b/docs/design/sm70_v100_migration_control.md
@@ -496,6 +496,18 @@ Goal:
   microbenchmark results, not yet an endpoint round-cost claim. The benchmark
   is `benchmarks/benchmark_sm70_dflash2_gdn_metadata.py`; an unprofiled TP4
   fixed-trajectory run remains required before default enablement.
+- The persistent descriptor now also caches only the shape-specific
+  `GDNAttentionMetadata` views. Their backing state IDs, accepted counts,
+  selectors, masks, and query offsets are still overwritten by the fused
+  kernel on every replay. A poison-and-replay test proves that a same-shape
+  call reuses the view objects while observing new tensor contents, and a B2
+  to B1 transition proves that a shape change rebuilds the views. On the same
+  B1/ten-group/block-eight microbenchmark, the cached fused path is 0.131 ms
+  synchronized-wall p50 versus 0.383 ms before view caching; the remaining
+  Python delta over the 0.053 ms raw-kernel wall is about 0.078 ms. Reinstating
+  the production scalar host fence costs only 0.028 ms p50, so it is not the
+  source of the former multi-millisecond Draft-to-Target gap and remains in
+  place pending the end-to-end trajectory gate.
 
 Main implementation priority:
 

--- a/docs/design/sm70_v100_migration_control.md
+++ b/docs/design/sm70_v100_migration_control.md
@@ -537,13 +537,47 @@ Goal:
       host-synchronized metadata fan-out rather than the fused kernel's own
       1.528 ms aggregate GPU service.
     - These endpoint values were collected under low-overhead Graph-level
-      Nsight tracing and are the accepted matched A/B for this leaf. A short
-      node-level trace is still required to update the semantic Draft-to-Target
-      and target-verifier phase table; node tracing will be used for
-      composition only because it inflates absolute latency.
+      Nsight tracing and are the accepted matched A/B for this leaf. The short
+      node-level trace below updates the semantic Draft-to-Target and
+      target-verifier phase table; it is used for composition only because node
+      tracing inflates absolute latency.
   Artifacts are
   `/data/minimax-h3/task-cache/v100-dflash2-pr257-gdn-metadata/results/dflash2-fused-viewcache-b1-graph-o512-{v2,v4}.json` and
   `/data/minimax-h3/task-cache/v100-dflash2-pr257-gdn-metadata/profiles/latest-e2e/dflash2-fused-viewcache-b1-graph-v4.{qdstrm,nsys-rep,sqlite}`.
+- A follow-up 128-token node trace at source
+  `9b8af0dbbe1d48214a555a96bbe762d26524e87c` supplies the missing semantic
+  phase split. The trace contains 32 complete draft-to-draft intervals; after
+  dropping the first and last edge intervals, 30 steady rounds remain. For
+  every phase and round the table takes the slowest of the four TP ranks, which
+  matches the earlier vLLM/SGLang audit methodology.
+
+  | traced phase | old vLLM mean (ms) | fused vLLM mean / p50 / p90 / p99 (ms) | SGLang mean (ms) | fused launches per rank |
+  | --- | ---: | ---: | ---: | ---: |
+  | draft Graph | 4.065 | 4.046 / 4.048 / 4.078 / 4.090 | 3.961 | 185 |
+  | draft to target | 18.382 | 4.934 / 4.855 / 5.049 / 6.426 | 3.517 | 153 |
+  | target Graph | 24.835 | 24.740 / 24.747 / 24.892 / 24.907 | 19.723 | 2,612 |
+  | target to next draft | 2.791 | 2.838 / 2.840 / 2.849 / 2.934 | 4.216 | 63 |
+  | complete traced round | 49.860 | 36.300 / 36.257 / 36.424 / 37.827 | 31.212 | n/a |
+
+  The persistent/fused metadata path therefore removes 13.448 ms (`73.16%`)
+  and 278 launches per rank (`64.50%`) from Draft-to-Target. The remaining gap
+  to SGLang in that phase is 1.417 ms and 123 launches, while the complete
+  traced-round gap is 5.088 ms. The dominant residual is now the target Graph:
+  24.740 versus 19.723 ms (`+5.017 ms`), not the 4.046 ms draft Graph.
+- The remaining 153 Draft-to-Target eager kernels per rank are stable across all
+  30 steady rounds. They include one fused GDN metadata launch (0.0037 ms GPU
+  service), one TP4 one-stage reduce (0.2357 ms), 40 CUB scan/init launches
+  (0.1161 ms), 22 direct-copy launches (0.0686 ms), 20 index-select launches
+  (about 0.0926 ms), and 20 `compute_cuda_kernel<int>` launches (0.0614 ms),
+  plus small slot/block/RoPE/input-mapping kernels. Critical-rank GPU service is
+  only 0.989 ms on average inside the 4.934 ms wall interval, so the next
+  Draft-to-Target leaf should share/capture the residual common-attention and
+  input-mapping fan-out rather than tune the 3.7-us fused kernel. In parallel,
+  the larger end-to-end opportunity is the verifier Graph's generic
+  elementwise/copy/state fan-out and TP4 reduction path.
+  Artifacts are
+  `/data/minimax-h3/task-cache/v100-dflash2-pr257-gdn-metadata/results/dflash2-fused-viewcache-b1-nodes-o128-v5.json` and
+  `/data/minimax-h3/task-cache/v100-dflash2-pr257-gdn-metadata/profiles/latest-e2e/dflash2-fused-viewcache-b1-nodes-o128-v5.{qdstrm,nsys-rep,sqlite}`.
 - `dnv2003/v100-skinny` is useful as an optimization inventory, but its published
   219.1 tok/s result is a Qwen3.8 mixed-NVFP4/FP8 MTP-k7 route on its 1Cat-vLLM
   1.2.2 fork, not a DFlash2 result and therefore not a direct baseline. Its

--- a/tests/kernels/test_fused_sigmoid_gating_delta_rule.py
+++ b/tests/kernels/test_fused_sigmoid_gating_delta_rule.py
@@ -9,6 +9,10 @@ from vllm.model_executor.layers.fla.ops import (
     fused_recurrent_gated_delta_rule,
     fused_recurrent_gated_delta_rule_packed_decode,
     fused_sigmoid_gating_delta_rule_update,
+    fused_sigmoid_gating_delta_rule_update_mixed_qkv_out,
+)
+from vllm.model_executor.layers.mamba.gdn.qwen_gdn_linear_attn import (
+    fused_gdn_gating,
 )
 from vllm.model_executor.layers.mamba.gdn.qwen_gdn_linear_attn import (
     fused_gdn_gating,
@@ -341,3 +345,176 @@ def test_fused_sigmoid_gating_delta_rule_update_spec(
     torch.testing.assert_close(
         last_recurrent_state, last_recurrent_state_ref, atol=1e-2, rtol=1e-2
     )
+
+
+@pytest.mark.parametrize("num_reqs", [1, 2])
+@pytest.mark.parametrize("num_speculative_tokens", [3, 7])
+@pytest.mark.parametrize("state_dtype", [torch.float16, torch.float32])
+def test_dflash2_packed_verify_matches_split_fp16_contract(
+    num_reqs: int,
+    num_speculative_tokens: int,
+    state_dtype: torch.dtype,
+) -> None:
+    if not torch.cuda.is_available() or torch.cuda.get_device_capability() != (7, 0):
+        pytest.skip("the DFlash2 verifier fast path is SM70-only")
+
+    torch.set_default_device(DEVICE)
+    set_random_seed(11)
+    dtype = torch.float16
+    # Qwen3.8 target shape per rank at TP4.
+    num_k_heads, num_v_heads = 4, 12
+    head_k_dim = head_v_dim = 128
+    tokens_per_req = num_speculative_tokens + 1
+    num_tokens = num_reqs * tokens_per_req
+    qkv_width = 2 * num_k_heads * head_k_dim + num_v_heads * head_v_dim
+
+    mixed_qkv = torch.randn(num_tokens, qkv_width, dtype=dtype)
+    query, key, value = torch.split(
+        mixed_qkv,
+        [
+            num_k_heads * head_k_dim,
+            num_k_heads * head_k_dim,
+            num_v_heads * head_v_dim,
+        ],
+        dim=-1,
+    )
+    query = query.contiguous().view(1, num_tokens, num_k_heads, head_k_dim)
+    key = key.contiguous().view(1, num_tokens, num_k_heads, head_k_dim)
+    value = value.contiguous().view(1, num_tokens, num_v_heads, head_v_dim)
+    a = torch.randn(num_tokens, num_v_heads, dtype=dtype)
+    b = torch.randn(num_tokens, num_v_heads, dtype=dtype)
+    A_log = torch.randn(num_v_heads, dtype=torch.float32)
+    dt_bias = torch.randn(num_v_heads, dtype=dtype)
+    state_indices = torch.arange(num_tokens, dtype=torch.int32).view(
+        num_reqs, tokens_per_req
+    )
+    num_accepted_tokens = torch.randint(
+        1, tokens_per_req + 1, (num_reqs,), dtype=torch.int32
+    )
+    cu_seqlens = torch.arange(0, num_tokens + 1, tokens_per_req, dtype=torch.int32)
+    initial_state = torch.randn(
+        num_tokens + 3,
+        num_v_heads,
+        head_v_dim,
+        head_k_dim,
+        dtype=state_dtype,
+    )
+
+    g, beta = fused_gdn_gating(A_log, a, b, dt_bias)
+    reference_state = initial_state.clone()
+    reference_out, _ = fused_recurrent_gated_delta_rule(
+        q=query,
+        k=key,
+        v=value,
+        g=g,
+        beta=beta,
+        initial_state=reference_state,
+        inplace_final_state=True,
+        cu_seqlens=cu_seqlens,
+        ssm_state_indices=state_indices,
+        num_accepted_tokens=num_accepted_tokens,
+        use_qk_l2norm_in_kernel=True,
+    )
+
+    fused_state = initial_state.clone()
+    fused_out = torch.empty(num_tokens, 1, num_v_heads, head_v_dim, dtype=dtype)
+    fused_sigmoid_gating_delta_rule_update_mixed_qkv_out(
+        A_log=A_log,
+        a=a,
+        b=b,
+        dt_bias=dt_bias,
+        mixed_qkv=mixed_qkv,
+        num_q_heads=num_k_heads,
+        num_v_heads=num_v_heads,
+        head_k_dim=head_k_dim,
+        head_v_dim=head_v_dim,
+        out=fused_out,
+        initial_state=fused_state,
+        cu_seqlens=cu_seqlens,
+        ssm_state_indices=state_indices,
+        num_accepted_tokens=num_accepted_tokens,
+        use_qk_l2norm_in_kernel=True,
+        precomputed_g=g,
+        precomputed_beta=beta,
+        match_recurrent_schedule=True,
+        match_recurrent_numerics=True,
+    )
+    torch.accelerator.synchronize()
+
+    torch.testing.assert_close(fused_out.transpose(0, 1), reference_out, rtol=0, atol=0)
+    torch.testing.assert_close(fused_state, reference_state, rtol=0, atol=0)
+
+
+def test_dflash2_quantized_state_reload_matches_repeated_decode() -> None:
+    if not torch.cuda.is_available() or torch.cuda.get_device_capability() != (7, 0):
+        pytest.skip("the DFlash2 verifier fast path is SM70-only")
+
+    torch.set_default_device(DEVICE)
+    set_random_seed(12)
+    dtype = torch.float16
+    num_tokens = 4
+    num_k_heads, num_v_heads = 2, 4
+    head_k_dim = head_v_dim = 16
+    qkv_width = 2 * num_k_heads * head_k_dim + num_v_heads * head_v_dim
+    mixed_qkv = torch.randn(num_tokens, qkv_width, dtype=dtype)
+    a = torch.randn(num_tokens, num_v_heads, dtype=dtype)
+    b = torch.randn(num_tokens, num_v_heads, dtype=dtype)
+    A_log = torch.randn(num_v_heads, dtype=torch.float32)
+    dt_bias = torch.randn(num_v_heads, dtype=dtype)
+    initial_state = torch.randn(2, num_v_heads, head_v_dim, head_k_dim, dtype=dtype)
+    shared_state_indices = torch.zeros((1, num_tokens), dtype=torch.int32)
+    accepted = torch.ones(1, dtype=torch.int32)
+
+    fused_state = initial_state.clone()
+    fused_out = torch.empty(num_tokens, 1, num_v_heads, head_v_dim, dtype=dtype)
+    fused_sigmoid_gating_delta_rule_update_mixed_qkv_out(
+        A_log=A_log,
+        a=a,
+        b=b,
+        dt_bias=dt_bias,
+        mixed_qkv=mixed_qkv,
+        num_q_heads=num_k_heads,
+        num_v_heads=num_v_heads,
+        head_k_dim=head_k_dim,
+        head_v_dim=head_v_dim,
+        out=fused_out,
+        initial_state=fused_state,
+        cu_seqlens=torch.tensor([0, num_tokens], dtype=torch.int32),
+        ssm_state_indices=shared_state_indices,
+        num_accepted_tokens=accepted,
+        quantize_beta=True,
+        quantize_state_each_step=True,
+        match_recurrent_schedule=True,
+        use_qk_l2norm_in_kernel=True,
+    )
+
+    sequential_state = initial_state.clone()
+    sequential_outputs = []
+    one_token_cu_seqlens = torch.tensor([0, 1], dtype=torch.int32)
+    one_state_index = torch.zeros(1, dtype=torch.int32)
+    for token_idx in range(num_tokens):
+        token_out = torch.empty(1, 1, num_v_heads, head_v_dim, dtype=dtype)
+        fused_sigmoid_gating_delta_rule_update_mixed_qkv_out(
+            A_log=A_log,
+            a=a[token_idx : token_idx + 1],
+            b=b[token_idx : token_idx + 1],
+            dt_bias=dt_bias,
+            mixed_qkv=mixed_qkv[token_idx : token_idx + 1],
+            num_q_heads=num_k_heads,
+            num_v_heads=num_v_heads,
+            head_k_dim=head_k_dim,
+            head_v_dim=head_v_dim,
+            out=token_out,
+            initial_state=sequential_state,
+            cu_seqlens=one_token_cu_seqlens,
+            ssm_state_indices=one_state_index,
+            num_accepted_tokens=accepted,
+            quantize_beta=True,
+            match_recurrent_schedule=True,
+            use_qk_l2norm_in_kernel=True,
+        )
+        sequential_outputs.append(token_out)
+    torch.accelerator.synchronize()
+
+    assert torch.equal(fused_out, torch.cat(sequential_outputs, dim=0))
+    assert torch.equal(fused_state, sequential_state)

--- a/tests/kernels/test_fused_sigmoid_gating_delta_rule.py
+++ b/tests/kernels/test_fused_sigmoid_gating_delta_rule.py
@@ -14,9 +14,6 @@ from vllm.model_executor.layers.fla.ops import (
 from vllm.model_executor.layers.mamba.gdn.qwen_gdn_linear_attn import (
     fused_gdn_gating,
 )
-from vllm.model_executor.layers.mamba.gdn.qwen_gdn_linear_attn import (
-    fused_gdn_gating,
-)
 from vllm.platforms import current_platform
 from vllm.utils.torch_utils import set_random_seed
 
@@ -361,7 +358,7 @@ def test_dflash2_packed_verify_matches_split_fp16_contract(
     torch.set_default_device(DEVICE)
     set_random_seed(11)
     dtype = torch.float16
-    # Qwen3.8 target shape per rank at TP4.
+    # Production GDN verifier shape used by the recorded TP4 parity evidence.
     num_k_heads, num_v_heads = 4, 12
     head_k_dim = head_v_dim = 128
     tokens_per_req = num_speculative_tokens + 1

--- a/tests/v1/attention/test_gdn_metadata_builder.py
+++ b/tests/v1/attention/test_gdn_metadata_builder.py
@@ -184,6 +184,11 @@ def _create_gdn_builder(
         vllm_config.compilation_config.max_cudagraph_capture_size = (
             max_cudagraph_capture_size
         )
+    else:
+        # Keep the helper's default contract explicit. The repository-wide
+        # compilation default may select FULL graphs on CUDA platforms, which
+        # would pad otherwise eager metadata and make these tests route-dependent.
+        vllm_config.compilation_config.cudagraph_mode = CUDAGraphMode.NONE
     if num_speculative_tokens > 0:
         vllm_config.speculative_config = SpeculativeConfig(
             method="ngram",
@@ -459,9 +464,7 @@ def test_common_gdn_metadata_matches_full_graph_padding(local_gdn_model):
         num_actual_tokens=4,
     )
     num_accepted_tokens = torch.tensor([3], dtype=torch.int32, device=DEVICE)
-    num_decode_draft_tokens_cpu = torch.tensor(
-        [2], dtype=torch.int32, device="cpu"
-    )
+    num_decode_draft_tokens_cpu = torch.tensor([2], dtype=torch.int32, device="cpu")
 
     expected = generic_builder.build(
         common_prefix_len=0,

--- a/tests/v1/attention/test_gdn_metadata_builder.py
+++ b/tests/v1/attention/test_gdn_metadata_builder.py
@@ -39,6 +39,7 @@ from vllm.v1.attention.backends.gdn_attn import (
 )
 from vllm.v1.attention.backends.utils import PAD_SLOT_ID
 from vllm.v1.kv_cache_interface import MambaSpec
+from vllm.v1.worker.gpu.attn_utils import compute_common_gdn_attn_metadata
 
 BLOCK_SIZE = 16
 DEVICE = torch.device("cpu")
@@ -212,18 +213,71 @@ def _build(
     builder: GDNAttentionMetadataBuilder,
     batch_spec: BatchSpec,
     num_decode_draft_tokens: list[int] | None = None,
+    use_common_metadata: bool = False,
 ) -> GDNAttentionMetadata:
     """Build GDN attention metadata, optionally with spec-decode kwargs."""
     common = create_common_attn_metadata(batch_spec, BLOCK_SIZE, DEVICE)
     kwargs: dict = {}
     if num_decode_draft_tokens is not None:
-        kwargs["num_decode_draft_tokens_cpu"] = torch.tensor(
+        num_decode_draft_tokens_cpu = torch.tensor(
             num_decode_draft_tokens, dtype=torch.int32, device="cpu"
         )
-        kwargs["num_accepted_tokens"] = torch.ones(
+        num_accepted_tokens = torch.ones(
             batch_spec.batch_size, dtype=torch.int32, device=DEVICE
         )
+        kwargs["num_decode_draft_tokens_cpu"] = num_decode_draft_tokens_cpu
+        kwargs["num_accepted_tokens"] = num_accepted_tokens
+        if use_common_metadata:
+            kwargs["common_gdn_metadata"] = compute_common_gdn_attn_metadata(
+                num_decode_draft_tokens_cpu=num_decode_draft_tokens_cpu,
+                query_start_loc=common.query_start_loc,
+                query_start_loc_cpu=common.query_start_loc_cpu,
+                num_spec_state_tokens=builder.num_spec_state_tokens,
+                legacy_mixed_decode_routing=(
+                    qwen_gdn.envs.VLLM_SM70_MTP_LEGACY_GDN_MIXED_DECODE_ROUTING
+                ),
+            )
     return builder.build(common_prefix_len=0, common_attn_metadata=common, **kwargs)
+
+
+def _assert_gdn_metadata_equal(
+    actual: GDNAttentionMetadata,
+    expected: GDNAttentionMetadata,
+) -> None:
+    scalar_fields = (
+        "num_prefills",
+        "num_prefill_tokens",
+        "num_decodes",
+        "num_decode_tokens",
+        "num_spec_decodes",
+        "num_spec_decode_tokens",
+        "num_actual_tokens",
+    )
+    for field in scalar_fields:
+        assert getattr(actual, field) == getattr(expected, field), field
+
+    tensor_fields = (
+        "has_initial_state",
+        "spec_query_start_loc",
+        "non_spec_query_start_loc",
+        "spec_state_indices_tensor",
+        "non_spec_state_indices_tensor",
+        "spec_sequence_masks",
+        "spec_token_indx",
+        "non_spec_token_indx",
+        "num_accepted_tokens",
+        "spec_state_slot_selectors",
+        "chunk_indices",
+        "chunk_offsets",
+        "batch_ptr",
+        "token_chunk_offset_ptr",
+    )
+    for field in tensor_fields:
+        actual_tensor = getattr(actual, field)
+        expected_tensor = getattr(expected, field)
+        assert (actual_tensor is None) == (expected_tensor is None), field
+        if actual_tensor is not None:
+            assert torch.equal(actual_tensor, expected_tensor), field
 
 
 def _effective_spec_initial_state_slots(
@@ -258,6 +312,51 @@ def test_gdn_build_classification(
     assert meta.num_prefills == test_case.expected_num_prefills
     assert meta.num_prefill_tokens == test_case.expected_num_prefill_tokens
     assert meta.num_spec_decodes == test_case.expected_num_spec_decodes
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        case
+        for case in GDN_BUILD_TEST_CASES.values()
+        if case.num_decode_draft_tokens is not None
+    ],
+    ids=[
+        name
+        for name, case in GDN_BUILD_TEST_CASES.items()
+        if case.num_decode_draft_tokens is not None
+    ],
+)
+def test_common_gdn_metadata_matches_per_group_builder(
+    test_case: GDNBuildTestCase,
+    local_gdn_model: str,
+):
+    generic_builder = _create_gdn_builder(
+        local_gdn_model, test_case.num_speculative_tokens
+    )
+    common_builder = _create_gdn_builder(
+        local_gdn_model, test_case.num_speculative_tokens
+    )
+    batch = BatchSpec(
+        seq_lens=test_case.seq_lens,
+        query_lens=test_case.query_lens,
+    )
+
+    torch.manual_seed(0)
+    expected = _build(
+        generic_builder,
+        batch,
+        test_case.num_decode_draft_tokens,
+    )
+    torch.manual_seed(0)
+    actual = _build(
+        common_builder,
+        batch,
+        test_case.num_decode_draft_tokens,
+        use_common_metadata=True,
+    )
+
+    _assert_gdn_metadata_equal(actual, expected)
 
 
 def test_mixed_decode_stays_decode_fastpath(local_gdn_model):
@@ -335,6 +434,58 @@ def test_full_cuda_graph_spec_replay_tail_uses_pad_slot(local_gdn_model):
         [PAD_SLOT_ID] * 3,
         [PAD_SLOT_ID] * 3,
     ]
+
+
+def test_common_gdn_metadata_matches_full_graph_padding(local_gdn_model):
+    generic_builder = _create_gdn_builder(
+        local_gdn_model,
+        num_speculative_tokens=2,
+        use_full_cuda_graph=True,
+    )
+    common_builder = _create_gdn_builder(
+        local_gdn_model,
+        num_speculative_tokens=2,
+        use_full_cuda_graph=True,
+    )
+    batch = BatchSpec(seq_lens=[4097], query_lens=[3])
+    common = create_common_attn_metadata(batch, BLOCK_SIZE, DEVICE).replace(
+        block_table_tensor=torch.tensor(
+            [[10, 11, 12, 13, 14]],
+            dtype=torch.int32,
+            device=DEVICE,
+        ),
+        num_actual_tokens=4,
+    )
+    num_accepted_tokens = torch.tensor([3], dtype=torch.int32, device=DEVICE)
+    num_decode_draft_tokens_cpu = torch.tensor(
+        [2], dtype=torch.int32, device="cpu"
+    )
+
+    expected = generic_builder.build(
+        common_prefix_len=0,
+        common_attn_metadata=common,
+        num_accepted_tokens=num_accepted_tokens,
+        num_decode_draft_tokens_cpu=num_decode_draft_tokens_cpu,
+    )
+    common_metadata = compute_common_gdn_attn_metadata(
+        num_decode_draft_tokens_cpu=num_decode_draft_tokens_cpu,
+        query_start_loc=common.query_start_loc,
+        query_start_loc_cpu=common.query_start_loc_cpu,
+        num_spec_state_tokens=common_builder.num_spec_state_tokens,
+        legacy_mixed_decode_routing=(
+            qwen_gdn.envs.VLLM_SM70_MTP_LEGACY_GDN_MIXED_DECODE_ROUTING
+        ),
+    )
+    assert common_metadata is not None
+    actual = common_builder.build(
+        common_prefix_len=0,
+        common_attn_metadata=common,
+        num_accepted_tokens=num_accepted_tokens,
+        num_decode_draft_tokens_cpu=num_decode_draft_tokens_cpu,
+        common_gdn_metadata=common_metadata,
+    )
+
+    _assert_gdn_metadata_equal(actual, expected)
 
 
 def test_full_cuda_graph_capture_single_token_decode_is_not_spec(local_gdn_model):

--- a/tests/v1/attention/test_gdn_metadata_builder.py
+++ b/tests/v1/attention/test_gdn_metadata_builder.py
@@ -36,6 +36,7 @@ from vllm.v1.attention.backends.gdn_attn import (
     build_gdn_spec_decode_state_contract,
     gdn_spec_metadata_tensors,
     get_registered_gdn_spec_metadata_tensors,
+    prepare_dflash2_gdn_group_metadata,
 )
 from vllm.v1.attention.backends.utils import PAD_SLOT_ID
 from vllm.v1.kv_cache_interface import MambaSpec
@@ -173,6 +174,7 @@ def _create_gdn_builder(
     use_full_cuda_graph: bool = False,
     mamba_cache_mode: str = "none",
     max_cudagraph_capture_size: int = 4,
+    device: torch.device = DEVICE,
 ) -> GDNAttentionMetadataBuilder:
     """Create a GDNAttentionMetadataBuilder with minimal config."""
     vllm_config = create_vllm_config(model_name=model_name, block_size=BLOCK_SIZE)
@@ -197,7 +199,7 @@ def _create_gdn_builder(
         kv_cache_spec=mamba_spec,
         layer_names=["layer.0"],
         vllm_config=vllm_config,
-        device=DEVICE,
+        device=device,
     )
 
 
@@ -486,6 +488,181 @@ def test_common_gdn_metadata_matches_full_graph_padding(local_gdn_model):
     )
 
     _assert_gdn_metadata_equal(actual, expected)
+
+
+def test_prepared_dflash2_metadata_belongs_to_exact_builder(local_gdn_model):
+    builder = _create_gdn_builder(
+        local_gdn_model,
+        num_speculative_tokens=2,
+        use_full_cuda_graph=True,
+    )
+    batch = BatchSpec(seq_lens=[4097], query_lens=[3])
+    common = create_common_attn_metadata(batch, BLOCK_SIZE, DEVICE).replace(
+        block_table_tensor=torch.tensor(
+            [[10, 11, 12, 13]], dtype=torch.int32, device=DEVICE
+        ),
+        num_actual_tokens=4,
+    )
+    num_accepted_tokens = torch.tensor([2], dtype=torch.int32, device=DEVICE)
+    num_decode_draft_tokens_cpu = torch.tensor([2], dtype=torch.int32, device="cpu")
+    common_metadata = compute_common_gdn_attn_metadata(
+        num_decode_draft_tokens_cpu=num_decode_draft_tokens_cpu,
+        query_start_loc=common.query_start_loc,
+        query_start_loc_cpu=common.query_start_loc_cpu,
+        num_spec_state_tokens=builder.num_spec_state_tokens,
+        legacy_mixed_decode_routing=False,
+    )
+    assert common_metadata is not None
+    prepared = builder.build(
+        common_prefix_len=0,
+        common_attn_metadata=common,
+        num_accepted_tokens=num_accepted_tokens,
+        num_decode_draft_tokens_cpu=num_decode_draft_tokens_cpu,
+        common_gdn_metadata=common_metadata,
+    )
+
+    actual = builder.build(
+        common_prefix_len=0,
+        common_attn_metadata=common,
+        num_accepted_tokens=num_accepted_tokens,
+        num_decode_draft_tokens_cpu=num_decode_draft_tokens_cpu,
+        common_gdn_metadata=common_metadata,
+        prepared_dflash2_metadata=prepared,
+    )
+    assert actual is prepared
+
+    other_builder = _create_gdn_builder(
+        local_gdn_model,
+        num_speculative_tokens=2,
+        use_full_cuda_graph=True,
+    )
+    with pytest.raises(ValueError, match="does not belong"):
+        other_builder.build(
+            common_prefix_len=0,
+            common_attn_metadata=common,
+            num_accepted_tokens=num_accepted_tokens,
+            num_decode_draft_tokens_cpu=num_decode_draft_tokens_cpu,
+            common_gdn_metadata=common_metadata,
+            prepared_dflash2_metadata=prepared,
+        )
+
+
+def test_dflash2_fused_gdn_group_metadata_replay(
+    monkeypatch,
+    local_gdn_model,
+):
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA is required for the fused GDN metadata kernel")
+    device = torch.device("cuda")
+    if torch.cuda.get_device_capability(device) != (7, 0):
+        pytest.skip("the fused GDN metadata kernel is SM70-only")
+
+    # The accepted DFlash2 verifier keeps the legacy spec-core operator off.
+    # Fused metadata must therefore own its graph-stable buffers independently.
+    monkeypatch.setenv("VLLM_SM70_QWEN_GDN_SPEC_CORE_OP", "0")
+    monkeypatch.setenv("VLLM_SM70_DFLASH2_FUSED_GDN_METADATA", "1")
+    monkeypatch.setenv("VLLM_SM70_DFLASH2_GDN_METADATA_SHADOW", "1")
+    qwen_gdn.envs.disable_envs_cache()
+
+    builders = [
+        _create_gdn_builder(
+            local_gdn_model,
+            num_speculative_tokens=7,
+            use_full_cuda_graph=True,
+            max_cudagraph_capture_size=16,
+            device=device,
+        )
+        for _ in range(2)
+    ]
+    width = builders[0].num_spec_state_tokens + 1
+    assert width == 8
+    query_start_loc = torch.tensor([0, 8, 16], dtype=torch.int32, device=device)
+    query_start_loc_cpu = query_start_loc.cpu()
+    common_metadata = compute_common_gdn_attn_metadata(
+        num_decode_draft_tokens_cpu=torch.tensor([7, 7], dtype=torch.int32),
+        query_start_loc=query_start_loc,
+        query_start_loc_cpu=query_start_loc_cpu,
+        num_spec_state_tokens=7,
+        legacy_mixed_decode_routing=False,
+    )
+    assert common_metadata is not None
+
+    block_tables = (
+        torch.arange(10, 10 + 2 * width, dtype=torch.int32, device=device).view(
+            2, width
+        ),
+        torch.arange(100, 100 + 2 * width, dtype=torch.int32, device=device).view(
+            2, width
+        ),
+    )
+    accepted = torch.tensor([3, 5], dtype=torch.int32, device=device)
+    for builder in builders:
+        builder.spec_state_indices_tensor.fill_(777)
+
+    first_result = prepare_dflash2_gdn_group_metadata(
+        builders_by_group=[(0, builders[0]), (1, builders[1])],
+        block_tables=block_tables,
+        common_gdn_metadata=common_metadata,
+        num_accepted_tokens=accepted,
+        num_actual_tokens=16,
+        descriptor=None,
+    )
+    assert first_result is not None
+    prepared, descriptor = first_result
+    torch.cuda.synchronize(device)
+
+    for group_id, builder in enumerate(builders):
+        state = prepared[id(builder)].spec_state_indices_tensor
+        assert state is not None
+        torch.testing.assert_close(state[:2], block_tables[group_id], rtol=0, atol=0)
+        torch.testing.assert_close(
+            state[2:], torch.full_like(state[2:], PAD_SLOT_ID), rtol=0, atol=0
+        )
+    first = prepared[id(builders[0])]
+    assert first.spec_query_start_loc is not None
+    assert first.spec_query_start_loc.tolist() == [0, 8, 16] + [16] * 14
+    assert first.num_accepted_tokens is not None
+    assert first.num_accepted_tokens.tolist() == [3, 5] + [1] * 14
+    assert first.spec_state_slot_selectors is not None
+    assert first.spec_state_slot_selectors.tolist() == [3, 5] + [1] * 14
+    assert first.spec_sequence_masks is not None
+    assert first.spec_sequence_masks.tolist() == [True, True] + [False] * 14
+
+    # Poison every persistent output and replay with new source values. This
+    # catches stale graph-tail data and accidental reuse of one group's table.
+    for builder in builders:
+        builder.spec_state_indices_tensor.fill_(888)
+    common_buffers = builders[0]._ddtree_fast_common_buffers
+    assert common_buffers is not None
+    common_buffers.spec_sequence_masks.fill_(True)
+    common_buffers.spec_query_start_loc.fill_(-1)
+    common_buffers.num_accepted_tokens.fill_(-1)
+    common_buffers.spec_state_slot_selectors.fill_(-1)
+    block_tables[0].add_(1000)
+    block_tables[1].add_(2000)
+    accepted.copy_(torch.tensor([7, 2], dtype=torch.int32, device=device))
+
+    second_result = prepare_dflash2_gdn_group_metadata(
+        builders_by_group=[(0, builders[0]), (1, builders[1])],
+        block_tables=block_tables,
+        common_gdn_metadata=common_metadata,
+        num_accepted_tokens=accepted,
+        num_actual_tokens=16,
+        descriptor=descriptor,
+    )
+    assert second_result is not None
+    replayed, replay_descriptor = second_result
+    assert replay_descriptor is descriptor
+    torch.cuda.synchronize(device)
+    for group_id, builder in enumerate(builders):
+        state = replayed[id(builder)].spec_state_indices_tensor
+        assert state is not None
+        torch.testing.assert_close(state[:2], block_tables[group_id], rtol=0, atol=0)
+        torch.testing.assert_close(
+            state[2:], torch.full_like(state[2:], PAD_SLOT_ID), rtol=0, atol=0
+        )
+    assert replayed[id(builders[0])].num_accepted_tokens is not None
+    assert replayed[id(builders[0])].num_accepted_tokens.tolist() == [7, 2] + [1] * 14
 
 
 def test_full_cuda_graph_capture_single_token_decode_is_not_spec(local_gdn_model):

--- a/tests/v1/attention/test_gdn_metadata_builder.py
+++ b/tests/v1/attention/test_gdn_metadata_builder.py
@@ -653,6 +653,7 @@ def test_dflash2_fused_gdn_group_metadata_replay(
     assert second_result is not None
     replayed, replay_descriptor = second_result
     assert replay_descriptor is descriptor
+    assert replayed is prepared
     torch.cuda.synchronize(device)
     for group_id, builder in enumerate(builders):
         state = replayed[id(builder)].spec_state_indices_tensor
@@ -663,6 +664,38 @@ def test_dflash2_fused_gdn_group_metadata_replay(
         )
     assert replayed[id(builders[0])].num_accepted_tokens is not None
     assert replayed[id(builders[0])].num_accepted_tokens.tolist() == [7, 2] + [1] * 14
+
+    # The pointer tables remain valid when the graph batch shape changes, but
+    # the graph-buffer views do not. Ensure the cache key rebuilds their
+    # lengths instead of returning the steady-state B2 metadata.
+    single_common = compute_common_gdn_attn_metadata(
+        num_decode_draft_tokens_cpu=torch.tensor([7], dtype=torch.int32),
+        query_start_loc=torch.tensor([0, 8], dtype=torch.int32, device=device),
+        query_start_loc_cpu=torch.tensor([0, 8], dtype=torch.int32),
+        num_spec_state_tokens=7,
+        legacy_mixed_decode_routing=False,
+    )
+    assert single_common is not None
+    single_result = prepare_dflash2_gdn_group_metadata(
+        builders_by_group=[(0, builders[0]), (1, builders[1])],
+        block_tables=(block_tables[0][:1], block_tables[1][:1]),
+        common_gdn_metadata=single_common,
+        num_accepted_tokens=accepted[:1],
+        num_actual_tokens=8,
+        descriptor=descriptor,
+    )
+    assert single_result is not None
+    single_prepared, single_descriptor = single_result
+    assert single_descriptor is descriptor
+    assert single_prepared is not replayed
+    torch.cuda.synchronize(device)
+    single = single_prepared[id(builders[0])]
+    assert single.spec_state_indices_tensor is not None
+    assert single.spec_state_indices_tensor.shape == (8, 8)
+    assert single.spec_query_start_loc is not None
+    assert single.spec_query_start_loc.tolist() == [0, 8] + [8] * 7
+    assert single.num_accepted_tokens is not None
+    assert single.num_accepted_tokens.tolist() == [7] + [1] * 7
 
 
 def test_full_cuda_graph_capture_single_token_decode_is_not_spec(local_gdn_model):

--- a/tests/v1/attention/test_gdn_metadata_builder.py
+++ b/tests/v1/attention/test_gdn_metadata_builder.py
@@ -612,7 +612,7 @@ def test_dflash2_fused_gdn_group_metadata_replay(
     )
     assert first_result is not None
     prepared, descriptor = first_result
-    torch.cuda.synchronize(device)
+    torch.accelerator.synchronize(device)
 
     for group_id, builder in enumerate(builders):
         state = prepared[id(builder)].spec_state_indices_tensor
@@ -657,7 +657,7 @@ def test_dflash2_fused_gdn_group_metadata_replay(
     replayed, replay_descriptor = second_result
     assert replay_descriptor is descriptor
     assert replayed is prepared
-    torch.cuda.synchronize(device)
+    torch.accelerator.synchronize(device)
     for group_id, builder in enumerate(builders):
         state = replayed[id(builder)].spec_state_indices_tensor
         assert state is not None
@@ -691,7 +691,7 @@ def test_dflash2_fused_gdn_group_metadata_replay(
     single_prepared, single_descriptor = single_result
     assert single_descriptor is descriptor
     assert single_prepared is not replayed
-    torch.cuda.synchronize(device)
+    torch.accelerator.synchronize(device)
     single = single_prepared[id(builders[0])]
     assert single.spec_state_indices_tensor is not None
     assert single.spec_state_indices_tensor.shape == (8, 8)

--- a/tests/v1/spec_decode/test_dflash2.py
+++ b/tests/v1/spec_decode/test_dflash2.py
@@ -11,13 +11,10 @@ import vllm.model_executor.models.qwen3_dflash2 as dflash2_model
 import vllm.v1.attention.backends.flash_attn_v100 as flash_v100
 import vllm.v1.worker.gpu.attn_utils as attn_utils
 import vllm.v1.worker.gpu.spec_decode.dflash.speculator as dflash_speculator
+from vllm import envs
 from vllm.config.speculative import SpeculativeConfig
 from vllm.model_executor.layers.mamba.gdn.qwen_gdn_linear_attn import (
     _is_dflash2_spec_config,
-)
-from vllm.model_executor.layers.vocab_parallel_embedding import (
-    UnquantizedEmbeddingMethod,
-    _maybe_sm70_dflash2_lm_head_top20,
 )
 from vllm.model_executor.models.dflash_sm70 import (
     DFLASH_SM70_GATE_UP_INPUT_SCALE,
@@ -42,6 +39,22 @@ from vllm.v1.worker.gpu.spec_decode.dflash2.speculator import (
     _requires_sm70_tail,
     _selector_walk_kernel,
 )
+
+
+def test_dflash2_gdn_fastpaths_are_default_off(monkeypatch):
+    names = (
+        "VLLM_SM70_DFLASH2_VERIFY_FASTPATH",
+        "VLLM_SM70_DFLASH2_FUSED_GDN_METADATA",
+        "VLLM_SM70_DFLASH2_GDN_METADATA_SHADOW",
+        "VLLM_SM70_DFLASH2_FUSED_GDN_VERIFY",
+    )
+    for name in names:
+        monkeypatch.delenv(name, raising=False)
+    envs.disable_envs_cache()
+    try:
+        assert not any(getattr(envs, name) for name in names)
+    finally:
+        envs.disable_envs_cache()
 
 
 @pytest.mark.parametrize("block_size", [4, 6, 8])
@@ -242,47 +255,55 @@ def test_probabilistic_cache_respects_column_stride():
     assert torch.isnan(storage[:, :, vocab_size:]).all()
 
 
-def test_dflash2_architecture_dispatches_to_mrv2(monkeypatch):
+def test_dflash2_selector_contract_dispatches_to_mrv2(monkeypatch):
     monkeypatch.setattr(DFlash2Speculator, "__init__", lambda self, *_args: None)
     config = SimpleNamespace(
         speculative_config=SimpleNamespace(
             method="dflash",
-            draft_model_config=SimpleNamespace(architectures=["DFlash2DraftModel"]),
+            draft_model_config=SimpleNamespace(
+                hf_config=SimpleNamespace(dflash_config={"selector_top_k": 16})
+            ),
         )
     )
     assert isinstance(init_speculator(config, torch.device("cpu")), DFlash2Speculator)
 
 
-def test_dflash1_architecture_stays_on_official_mrv2_speculator(monkeypatch):
+def test_dflash_without_selector_stays_on_official_mrv2_speculator(monkeypatch):
     monkeypatch.setattr(DFlashSpeculator, "__init__", lambda self, *_args: None)
     config = SimpleNamespace(
         speculative_config=SimpleNamespace(
             method="dflash",
-            draft_model_config=SimpleNamespace(architectures=["DFlashDraftModel"]),
+            draft_model_config=SimpleNamespace(
+                hf_config=SimpleNamespace(dflash_config={})
+            ),
         )
     )
     assert isinstance(init_speculator(config, torch.device("cpu")), DFlashSpeculator)
 
 
 @pytest.mark.parametrize(
-    ("method", "architecture", "expected"),
+    ("method", "selector_top_k", "expected"),
     [
-        ("dflash", "DFlash2DraftModel", True),
-        ("dflash", "DFlashDraftModel", False),
-        ("dflash_ddtree", "DFlash2DraftModel", False),
-        ("mtp", "DFlash2DraftModel", False),
-        ("eagle3", "DFlash2DraftModel", False),
+        ("dflash", 16, True),
+        ("dflash", 0, False),
+        ("dflash_ddtree", 16, False),
+        ("mtp", 16, False),
+        ("eagle3", 16, False),
     ],
 )
-def test_fused_gdn_verify_config_is_dflash2_mrv2_only(
+def test_fused_gdn_verify_config_uses_selector_engine_contract(
     method: str,
-    architecture: str,
+    selector_top_k: int,
     expected: bool,
 ):
     config = SimpleNamespace(
         speculative_config=SimpleNamespace(
             method=method,
-            draft_model_config=SimpleNamespace(architectures=[architecture]),
+            draft_model_config=SimpleNamespace(
+                hf_config=SimpleNamespace(
+                    dflash_config={"selector_top_k": selector_top_k}
+                )
+            ),
         )
     )
 

--- a/tests/v1/spec_decode/test_dflash2.py
+++ b/tests/v1/spec_decode/test_dflash2.py
@@ -12,6 +12,13 @@ import vllm.v1.attention.backends.flash_attn_v100 as flash_v100
 import vllm.v1.worker.gpu.attn_utils as attn_utils
 import vllm.v1.worker.gpu.spec_decode.dflash.speculator as dflash_speculator
 from vllm.config.speculative import SpeculativeConfig
+from vllm.model_executor.layers.mamba.gdn.qwen_gdn_linear_attn import (
+    _is_dflash2_spec_config,
+)
+from vllm.model_executor.layers.vocab_parallel_embedding import (
+    UnquantizedEmbeddingMethod,
+    _maybe_sm70_dflash2_lm_head_top20,
+)
 from vllm.model_executor.models.dflash_sm70 import (
     DFLASH_SM70_GATE_UP_INPUT_SCALE,
     DFLASH_SM70_WIDE_OUTPUT_SCALE,
@@ -255,6 +262,31 @@ def test_dflash1_architecture_stays_on_official_mrv2_speculator(monkeypatch):
         )
     )
     assert isinstance(init_speculator(config, torch.device("cpu")), DFlashSpeculator)
+
+
+@pytest.mark.parametrize(
+    ("method", "architecture", "expected"),
+    [
+        ("dflash", "DFlash2DraftModel", True),
+        ("dflash", "DFlashDraftModel", False),
+        ("dflash_ddtree", "DFlash2DraftModel", False),
+        ("mtp", "DFlash2DraftModel", False),
+        ("eagle3", "DFlash2DraftModel", False),
+    ],
+)
+def test_fused_gdn_verify_config_is_dflash2_mrv2_only(
+    method: str,
+    architecture: str,
+    expected: bool,
+):
+    config = SimpleNamespace(
+        speculative_config=SimpleNamespace(
+            method=method,
+            draft_model_config=SimpleNamespace(architectures=[architecture]),
+        )
+    )
+
+    assert _is_dflash2_spec_config(config) is expected
 
 
 @pytest.mark.parametrize(

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -187,6 +187,7 @@ if TYPE_CHECKING:
     VLLM_SM70_ENABLE_LM_HEAD_FASTPATH: bool = False
     VLLM_SM70_LM_HEAD_TOP1: bool = True
     VLLM_SM70_LM_HEAD_TOP1_TC: bool = False
+    VLLM_SM70_DFLASH2_VERIFY_FASTPATH: bool = False
     VLLM_SM70_TOP1_CUSTOM_AR: bool = False
     VLLM_SM70_GREEDY_TOKEN_FASTPATH: bool = True
     VLLM_SM70_GREEDY_TOKEN_FASTPATH_TRACE: bool = False
@@ -1806,6 +1807,12 @@ environment_variables: dict[str, Callable[[], Any]] = {
     ),
     "VLLM_SM70_LM_HEAD_TOP1_TC": lambda: bool(
         int(os.getenv("VLLM_SM70_LM_HEAD_TOP1_TC", "0"))
+    ),
+    # Umbrella gate for DFlash2 target-verification optimizations. Keep this
+    # default-off while each stage is checked against the unchanged MRV2 path
+    # with identical weights, prompts, and sampling configuration.
+    "VLLM_SM70_DFLASH2_VERIFY_FASTPATH": lambda: bool(
+        int(os.getenv("VLLM_SM70_DFLASH2_VERIFY_FASTPATH", "0"))
     ),
     # Safe greedy-only shortcut: avoid full vocab all-gather/sampler work when
     # the request batch is pure greedy and has no penalties, logprobs, grammar,

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -188,6 +188,7 @@ if TYPE_CHECKING:
     VLLM_SM70_LM_HEAD_TOP1: bool = True
     VLLM_SM70_LM_HEAD_TOP1_TC: bool = False
     VLLM_SM70_DFLASH2_VERIFY_FASTPATH: bool = False
+    VLLM_SM70_DFLASH2_FUSED_GDN_VERIFY: bool = False
     VLLM_SM70_TOP1_CUSTOM_AR: bool = False
     VLLM_SM70_GREEDY_TOKEN_FASTPATH: bool = True
     VLLM_SM70_GREEDY_TOKEN_FASTPATH_TRACE: bool = False
@@ -1813,6 +1814,12 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # with identical weights, prompts, and sampling configuration.
     "VLLM_SM70_DFLASH2_VERIFY_FASTPATH": lambda: bool(
         int(os.getenv("VLLM_SM70_DFLASH2_VERIFY_FASTPATH", "0"))
+    ),
+    # DFlash2-only packed GDN target-verification kernel. This is deliberately
+    # independent from the shared-metadata umbrella gate so each optimization
+    # can be paired against the unchanged verifier in isolation.
+    "VLLM_SM70_DFLASH2_FUSED_GDN_VERIFY": lambda: bool(
+        int(os.getenv("VLLM_SM70_DFLASH2_FUSED_GDN_VERIFY", "0"))
     ),
     # Safe greedy-only shortcut: avoid full vocab all-gather/sampler work when
     # the request batch is pure greedy and has no penalties, logprobs, grammar,

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -1811,15 +1811,15 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "VLLM_SM70_LM_HEAD_TOP1_TC": lambda: bool(
         int(os.getenv("VLLM_SM70_LM_HEAD_TOP1_TC", "0"))
     ),
-    # Umbrella gate for DFlash2 target-verification optimizations. Keep this
-    # default-off while each stage is checked against the unchanged MRV2 path
-    # with identical weights, prompts, and sampling configuration.
+    # Umbrella gate for selector-based DFlash verification optimizations. Keep
+    # this default-off while each stage is checked against the unchanged MRV2
+    # path with identical weights, prompts, and sampling configuration.
     "VLLM_SM70_DFLASH2_VERIFY_FASTPATH": lambda: bool(
         int(os.getenv("VLLM_SM70_DFLASH2_VERIFY_FASTPATH", "0"))
     ),
-    # Build all DFlash2 target GDN state-index metadata with one pointer-table
-    # Triton launch. Keep separate from the shared-classification gate until
-    # the fixed-trajectory and mixed-batch Graph checks pass.
+    # Build all selector-based DFlash target GDN state-index metadata with one
+    # pointer-table Triton launch. Keep separate from the shared-classification
+    # gate until the fixed-trajectory and mixed-batch Graph checks pass.
     "VLLM_SM70_DFLASH2_FUSED_GDN_METADATA": lambda: bool(
         int(os.getenv("VLLM_SM70_DFLASH2_FUSED_GDN_METADATA", "0"))
     ),
@@ -1828,7 +1828,7 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "VLLM_SM70_DFLASH2_GDN_METADATA_SHADOW": lambda: bool(
         int(os.getenv("VLLM_SM70_DFLASH2_GDN_METADATA_SHADOW", "0"))
     ),
-    # DFlash2-only packed GDN target-verification kernel. This is deliberately
+    # Selector-based DFlash packed GDN verification kernel. This is deliberately
     # independent from the shared-metadata umbrella gate so each optimization
     # can be paired against the unchanged verifier in isolation.
     "VLLM_SM70_DFLASH2_FUSED_GDN_VERIFY": lambda: bool(

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -188,6 +188,8 @@ if TYPE_CHECKING:
     VLLM_SM70_LM_HEAD_TOP1: bool = True
     VLLM_SM70_LM_HEAD_TOP1_TC: bool = False
     VLLM_SM70_DFLASH2_VERIFY_FASTPATH: bool = False
+    VLLM_SM70_DFLASH2_FUSED_GDN_METADATA: bool = False
+    VLLM_SM70_DFLASH2_GDN_METADATA_SHADOW: bool = False
     VLLM_SM70_DFLASH2_FUSED_GDN_VERIFY: bool = False
     VLLM_SM70_TOP1_CUSTOM_AR: bool = False
     VLLM_SM70_GREEDY_TOKEN_FASTPATH: bool = True
@@ -1814,6 +1816,17 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # with identical weights, prompts, and sampling configuration.
     "VLLM_SM70_DFLASH2_VERIFY_FASTPATH": lambda: bool(
         int(os.getenv("VLLM_SM70_DFLASH2_VERIFY_FASTPATH", "0"))
+    ),
+    # Build all DFlash2 target GDN state-index metadata with one pointer-table
+    # Triton launch. Keep separate from the shared-classification gate until
+    # the fixed-trajectory and mixed-batch Graph checks pass.
+    "VLLM_SM70_DFLASH2_FUSED_GDN_METADATA": lambda: bool(
+        int(os.getenv("VLLM_SM70_DFLASH2_FUSED_GDN_METADATA", "0"))
+    ),
+    # Debug-only oracle: materialize the legacy advanced-indexing contract and
+    # compare it with the fused persistent buffers before graph replay.
+    "VLLM_SM70_DFLASH2_GDN_METADATA_SHADOW": lambda: bool(
+        int(os.getenv("VLLM_SM70_DFLASH2_GDN_METADATA_SHADOW", "0"))
     ),
     # DFlash2-only packed GDN target-verification kernel. This is deliberately
     # independent from the shared-metadata umbrella gate so each optimization

--- a/vllm/model_executor/layers/fla/ops/fused_sigmoid_gating.py
+++ b/vllm/model_executor/layers/fla/ops/fused_sigmoid_gating.py
@@ -13,6 +13,8 @@ import torch
 
 from vllm.triton_utils import tl, triton
 
+from .op import exp
+
 
 def _parse_positive_int_env(name: str) -> int | None:
     value = os.getenv(name)
@@ -83,6 +85,37 @@ def _select_fused_sigmoid_schedule(
     return BV, num_warps, num_stages
 
 
+def _select_fused_sigmoid_launch(
+    V: int,
+    N: int,
+    HV: int,
+    T: int,
+    device: torch.device,
+    *,
+    match_recurrent_schedule: bool,
+) -> tuple[int, int, int]:
+    if not _use_sm70_fused_sigmoid_schedule(device):
+        return min(triton.next_power_of_2(V), 32), 4, 3
+    if not match_recurrent_schedule:
+        return _select_fused_sigmoid_schedule(V, N, HV, device)
+
+    # The unfused verifier uses this launch geometry. Keeping it for the first
+    # fused rollout removes schedule-induced reduction-order changes from the
+    # correctness comparison; schedule tuning is a separate performance gate.
+    from .fused_recurrent import (
+        _select_sm70_bv,
+        _select_sm70_num_stages,
+        _select_sm70_num_warps,
+    )
+
+    BV = _select_sm70_bv(V, N, HV, device)
+    return (
+        BV,
+        _select_sm70_num_warps(BV, N, HV),
+        _select_sm70_num_stages(T),
+    )
+
+
 @triton.heuristics(
     {
         "USE_INITIAL_STATE": lambda args: args["h0"] is not None,
@@ -140,6 +173,10 @@ def fused_sigmoid_gating_delta_rule_update_kernel(
     IS_DDTREE: tl.constexpr,
     IS_KDA: tl.constexpr,
     MIXED_QKV: tl.constexpr,
+    PRECOMPUTED_GATING: tl.constexpr,
+    QUANTIZE_BETA: tl.constexpr,
+    QUANTIZE_STATE_EACH_STEP: tl.constexpr,
+    MATCH_RECURRENT_NUMERICS: tl.constexpr,
 ):
     i_k, i_v, i_nh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
     i_n, i_hv = i_nh // HV, i_nh % HV
@@ -237,25 +274,44 @@ def fused_sigmoid_gating_delta_rule_update_kernel(
         b_q = tl.load(p_q, mask=mask_k, other=0).to(tl.float32)
         b_k = tl.load(p_k, mask=mask_k, other=0).to(tl.float32)
         b_v = tl.load(p_v, mask=mask_v, other=0).to(tl.float32)
-        b_b = tl.load(p_b).to(tl.float32)
+        if PRECOMPUTED_GATING:
+            b_g = tl.load(p_a).to(tl.float32)
+            b_beta = tl.load(p_b).to(tl.float32)
+        else:
+            b_b = tl.load(p_b).to(tl.float32)
 
-        # If the model is loaded in fp16, without the .float() here, A might be -inf
-        x = tl.load(p_a).to(tl.float32) + tl.load(p_dt_bias).to(tl.float32)
-        softplus_x = tl.where(
-            beta * x <= threshold, (1 / beta) * tl.log(1 + tl.exp(beta * x)), x
-        )
-        b_g = -tl.exp(tl.load(p_A_log).to(tl.float32)) * softplus_x
+            # If the model is loaded in fp16, without the .float() here, A
+            # might be -inf.
+            x = tl.load(p_a).to(tl.float32) + tl.load(p_dt_bias).to(tl.float32)
+            softplus_x = tl.where(
+                beta * x <= threshold, (1 / beta) * tl.log(1 + tl.exp(beta * x)), x
+            )
+            b_g = -tl.exp(tl.load(p_A_log).to(tl.float32)) * softplus_x
 
-        # compute beta_output = sigmoid(b)
-        b_beta = tl.sigmoid(b_b.to(tl.float32))
+            # compute beta_output = sigmoid(b)
+            b_beta = tl.sigmoid(b_b.to(tl.float32))
+            if QUANTIZE_BETA:
+                # The split GDN verifier materializes beta in b.dtype before
+                # the recurrent kernel consumes it. Preserve that boundary.
+                b_beta = b_beta.to(p_b.dtype.element_ty).to(tl.float32)
 
         if USE_QK_L2NORM_IN_KERNEL:
-            b_q = b_q * (tl.rsqrt(tl.sum(b_q * b_q) + 1e-6))
-            b_k = b_k * (tl.rsqrt(tl.sum(b_k * b_k) + 1e-6))
+            if MATCH_RECURRENT_NUMERICS:
+                # Preserve the split recurrent verifier's operation order.
+                # Multiplication by rsqrt is mathematically equivalent but can
+                # move a probabilistic rejection decision by one FP16 ULP.
+                b_q = b_q / tl.sqrt(tl.sum(b_q * b_q) + 1e-6)
+                b_k = b_k / tl.sqrt(tl.sum(b_k * b_k) + 1e-6)
+            else:
+                b_q = b_q * (tl.rsqrt(tl.sum(b_q * b_q) + 1e-6))
+                b_k = b_k * (tl.rsqrt(tl.sum(b_k * b_k) + 1e-6))
         b_q = b_q * scale
         # [BV, BK]
         if not IS_KDA:
-            b_h *= tl.exp(b_g)
+            if MATCH_RECURRENT_NUMERICS:
+                b_h *= exp(b_g)
+            else:
+                b_h *= tl.exp(b_g)
         else:
             b_h *= tl.exp(b_g[None, :])
         # [BV]
@@ -277,10 +333,17 @@ def fused_sigmoid_gating_delta_rule_update_kernel(
                 p_ht = ht + final_state_idx * stride_final_state_token
                 p_ht = p_ht + i_hv * V * K + o_v[:, None] * K + o_k[None, :]
                 tl.store(p_ht, b_h.to(p_ht.dtype.element_ty), mask=mask_h)
+                if QUANTIZE_STATE_EACH_STEP:
+                    # Target verification handles several linear tokens in one
+                    # invocation. Reloading the just-persisted state reproduces
+                    # the low-precision store/load boundary of repeated decode.
+                    b_h = tl.load(p_ht, mask=mask_h, other=0).to(tl.float32)
         else:
             p_ht = ht + (bos + i_t) * stride_final_state_token
             p_ht = p_ht + i_hv * V * K + o_v[:, None] * K + o_k[None, :]
             tl.store(p_ht, b_h.to(p_ht.dtype.element_ty), mask=mask_h)
+            if QUANTIZE_STATE_EACH_STEP:
+                b_h = tl.load(p_ht, mask=mask_h, other=0).to(tl.float32)
 
         if MIXED_QKV:
             p_q += QKV_STRIDE
@@ -410,6 +473,10 @@ def fused_sigmoid_gating_delta_rule_update(
         USE_QK_L2NORM_IN_KERNEL=use_qk_l2norm_in_kernel,
         IS_KDA=is_kda,
         MIXED_QKV=False,
+        PRECOMPUTED_GATING=False,
+        QUANTIZE_BETA=False,
+        QUANTIZE_STATE_EACH_STEP=False,
+        MATCH_RECURRENT_NUMERICS=False,
         num_warps=num_warps,
         num_stages=num_stages,
     )
@@ -541,6 +608,10 @@ def fused_sigmoid_gating_delta_rule_update_mixed_qkv(
         USE_QK_L2NORM_IN_KERNEL=use_qk_l2norm_in_kernel,
         IS_KDA=False,
         MIXED_QKV=True,
+        PRECOMPUTED_GATING=False,
+        QUANTIZE_BETA=False,
+        QUANTIZE_STATE_EACH_STEP=False,
+        MATCH_RECURRENT_NUMERICS=False,
         num_warps=num_warps,
         num_stages=num_stages,
     )
@@ -564,9 +635,21 @@ def fused_sigmoid_gating_delta_rule_update_mixed_qkv_out(
     initial_state: torch.Tensor | None = None,
     cu_seqlens: torch.Tensor | None = None,
     ssm_state_indices: torch.Tensor | None = None,
+    num_accepted_tokens: torch.Tensor | None = None,
     use_qk_l2norm_in_kernel: bool = False,
+    quantize_beta: bool = False,
+    quantize_state_each_step: bool = False,
+    match_recurrent_schedule: bool = False,
+    match_recurrent_numerics: bool = False,
+    precomputed_g: torch.Tensor | None = None,
+    precomputed_beta: torch.Tensor | None = None,
 ) -> tuple[torch.Tensor, torch.Tensor]:
-    """Mixed-QKV fused update that writes into a caller-provided decode output."""
+    """Mixed-QKV update that writes into a caller-provided output buffer.
+
+    ``precomputed_g`` and ``precomputed_beta`` retain the split verifier's
+    exact gating materialization while still removing the packed-QKV rearrange.
+    Omitting both computes gating inside the recurrent kernel.
+    """
     if mixed_qkv.ndim != 2:
         raise ValueError("mixed_qkv must have shape [T, qkv_hidden].")
     if not mixed_qkv.is_contiguous():
@@ -575,6 +658,10 @@ def fused_sigmoid_gating_delta_rule_update_mixed_qkv_out(
         raise ValueError("cu_seqlens is required for mixed_qkv_out.")
     if ssm_state_indices is None:
         raise ValueError("ssm_state_indices is required for mixed_qkv_out.")
+    if (precomputed_g is None) != (precomputed_beta is None):
+        raise ValueError(
+            "precomputed_g and precomputed_beta must be provided together."
+        )
 
     T = mixed_qkv.shape[0]
     N = cu_seqlens.numel() - 1
@@ -597,6 +684,28 @@ def fused_sigmoid_gating_delta_rule_update_mixed_qkv_out(
     else:
         assert scale > 0, "scale must be positive"
 
+    use_precomputed_gating = precomputed_g is not None
+    if use_precomputed_gating:
+        assert precomputed_g is not None
+        assert precomputed_beta is not None
+        if precomputed_g.numel() != T * HV:
+            raise ValueError(
+                f"precomputed_g must contain {T * HV} values, "
+                f"got {precomputed_g.numel()}."
+            )
+        if precomputed_beta.numel() != T * HV:
+            raise ValueError(
+                f"precomputed_beta must contain {T * HV} values, "
+                f"got {precomputed_beta.numel()}."
+            )
+        if quantize_beta:
+            raise ValueError("precomputed_beta is already materialized in its dtype.")
+        kernel_a = precomputed_g.contiguous().view(T, HV)
+        kernel_b = precomputed_beta.contiguous().view(T, HV)
+    else:
+        kernel_a = a.contiguous()
+        kernel_b = b.contiguous()
+
     assert initial_state is not None
     final_state = initial_state
     stride_init_state_token = initial_state.stride(0)
@@ -608,18 +717,21 @@ def fused_sigmoid_gating_delta_rule_update_mixed_qkv_out(
         stride_indices_seq, stride_indices_tok = ssm_state_indices.stride()
 
     BK = triton.next_power_of_2(K)
-    BV, num_warps, num_stages = (
-        _select_fused_sigmoid_schedule(V, N, HV, mixed_qkv.device)
-        if _use_sm70_fused_sigmoid_schedule(mixed_qkv.device)
-        else (min(triton.next_power_of_2(V), 32), 4, 3)
+    BV, num_warps, num_stages = _select_fused_sigmoid_launch(
+        V,
+        N,
+        HV,
+        T,
+        mixed_qkv.device,
+        match_recurrent_schedule=match_recurrent_schedule,
     )
     NK, NV = triton.cdiv(K, BK), triton.cdiv(V, BV)
     assert NK == 1, "NK > 1 is not supported yet"
 
     fused_sigmoid_gating_delta_rule_update_kernel[(NK, NV, N * HV)](
         A_log=A_log,
-        a=a.contiguous(),
-        b=b.contiguous(),
+        a=kernel_a,
+        b=kernel_b,
         dt_bias=dt_bias,
         beta=beta,
         threshold=threshold,
@@ -632,7 +744,7 @@ def fused_sigmoid_gating_delta_rule_update_mixed_qkv_out(
         ht=final_state,
         cu_seqlens=cu_seqlens,
         ssm_state_indices=ssm_state_indices,
-        num_accepted_tokens=None,
+        num_accepted_tokens=num_accepted_tokens,
         ddtree_parent_ids=None,
         scale=scale,
         N=N,
@@ -658,6 +770,10 @@ def fused_sigmoid_gating_delta_rule_update_mixed_qkv_out(
         USE_QK_L2NORM_IN_KERNEL=use_qk_l2norm_in_kernel,
         IS_KDA=False,
         MIXED_QKV=True,
+        PRECOMPUTED_GATING=use_precomputed_gating,
+        QUANTIZE_BETA=quantize_beta,
+        QUANTIZE_STATE_EACH_STEP=quantize_state_each_step,
+        MATCH_RECURRENT_NUMERICS=match_recurrent_numerics,
         num_warps=num_warps,
         num_stages=num_stages,
     )

--- a/vllm/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py
+++ b/vllm/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py
@@ -590,6 +590,15 @@ def _sm70_qwen_gdn_spec_method(vllm_config: object) -> str | None:
     return getattr(spec_config, "method", None)
 
 
+def _is_dflash2_spec_config(vllm_config: object) -> bool:
+    spec_config = getattr(vllm_config, "speculative_config", None)
+    if spec_config is None or getattr(spec_config, "method", None) != "dflash":
+        return False
+    draft_model_config = getattr(spec_config, "draft_model_config", None)
+    architectures = getattr(draft_model_config, "architectures", None) or []
+    return "DFlash2DraftModel" in architectures
+
+
 def _sm70_qwen_gdn_full_forward_enabled(
     layer_name: LayerNameType,
     *,
@@ -2201,6 +2210,11 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
         self.enable_sm70_fused_sigmoid_mixed_qkv = (
             envs.VLLM_SM70_FUSED_SIGMOID_MIXED_QKV
         )
+        self.enable_sm70_dflash2_fused_gdn_verify = bool(
+            envs.VLLM_SM70_DFLASH2_FUSED_GDN_VERIFY
+            and current_platform.is_device_capability(70)
+            and _is_dflash2_spec_config(vllm_config)
+        )
         self.compare_sm70_fused_sigmoid_mixed_qkv = (
             envs.VLLM_SM70_FUSED_SIGMOID_MIXED_QKV_COMPARE
         )
@@ -2287,6 +2301,11 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
         if self.enable_flashqla_decode:
             logger.info_once(
                 "SM70 FlashQLA GDN decode route enabled.",
+                scope="local",
+            )
+        if self.enable_sm70_dflash2_fused_gdn_verify:
+            logger.info_once(
+                "SM70 DFlash2 packed GDN target-verification route enabled.",
                 scope="local",
             )
         if envs.is_set("VLLM_QWEN3_NEXT_FUSED_SIGMOID_GATING"):
@@ -4820,6 +4839,85 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
             kv_cache=kv_cache,
         )
 
+    def _can_use_dflash2_packed_gdn_verify(
+        self,
+        *,
+        mixed_qkv: torch.Tensor | None,
+        a: torch.Tensor,
+        b: torch.Tensor,
+        core_attn_out: torch.Tensor,
+        ssm_state: torch.Tensor,
+        attn_metadata: GDNAttentionMetadata,
+    ) -> bool:
+        return bool(
+            self.enable_sm70_dflash2_fused_gdn_verify
+            and mixed_qkv is not None
+            and attn_metadata.spec_sequence_masks is not None
+            and attn_metadata.num_spec_decodes > 0
+            and attn_metadata.num_prefills == 0
+            and attn_metadata.num_decodes == 0
+            and attn_metadata.ddtree_parent_ids is None
+            and attn_metadata.spec_query_start_loc is not None
+            and attn_metadata.spec_state_indices_tensor is not None
+            and attn_metadata.spec_state_slot_selectors is not None
+            and mixed_qkv.is_cuda
+            and mixed_qkv.dtype == torch.float16
+            and a.dtype == torch.float16
+            and b.dtype == torch.float16
+            # Qwen3.8's official target contract keeps the recurrent state in
+            # FP32; an explicit FP16 cache override is also supported.
+            and ssm_state.dtype in (torch.float16, torch.float32)
+            and mixed_qkv.is_contiguous()
+            and a.is_contiguous()
+            and b.is_contiguous()
+            and core_attn_out.is_contiguous()
+        )
+
+    def _forward_dflash2_packed_gdn_verify(
+        self,
+        *,
+        mixed_qkv: torch.Tensor,
+        a: torch.Tensor,
+        b: torch.Tensor,
+        core_attn_out: torch.Tensor,
+        ssm_state: torch.Tensor,
+        spec_query_start_loc: torch.Tensor,
+        spec_state_indices_tensor: torch.Tensor,
+        spec_state_slot_selectors: torch.Tensor,
+        num_spec_decodes: int,
+    ) -> torch.Tensor:
+        num_tokens = mixed_qkv.shape[0]
+        out = core_attn_out[:num_tokens].unsqueeze(1)
+        g, beta = fused_gdn_gating(self.A_log, a, b, self.dt_bias)
+        fused_sigmoid_gating_delta_rule_update_mixed_qkv_out(
+            A_log=self.A_log,
+            a=a,
+            b=b,
+            dt_bias=self.dt_bias,
+            mixed_qkv=mixed_qkv,
+            num_q_heads=self.num_k_heads // self.tp_size,
+            num_v_heads=self.num_v_heads // self.tp_size,
+            head_k_dim=self.head_k_dim,
+            head_v_dim=self.head_v_dim,
+            scale=self.head_k_dim**-0.5,
+            initial_state=ssm_state,
+            out=out,
+            cu_seqlens=spec_query_start_loc[: num_spec_decodes + 1],
+            ssm_state_indices=spec_state_indices_tensor[:num_spec_decodes],
+            num_accepted_tokens=spec_state_slot_selectors[:num_spec_decodes],
+            use_qk_l2norm_in_kernel=True,
+            # Keep gating materialization and launch geometry bitwise aligned
+            # with the current verifier. This stage removes packed-QKV
+            # rearrangement and the final output copy without changing the
+            # target recurrence. Fully fused gating stays separately testable.
+            precomputed_g=g,
+            precomputed_beta=beta,
+            quantize_state_each_step=False,
+            match_recurrent_schedule=True,
+            match_recurrent_numerics=True,
+        )
+        return out.transpose(0, 1)
+
     def _forward_core(
         self,
         mixed_qkv: torch.Tensor,
@@ -5172,7 +5270,18 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
             core_attn_out[:num_non_spec_tokens] = core_attn_out_non_spec.squeeze(0)
             return
 
-        query_spec, key_spec, value_spec = self.rearrange_mixed_qkv(mixed_qkv_spec)
+        use_dflash2_packed_gdn_verify = self._can_use_dflash2_packed_gdn_verify(
+            mixed_qkv=mixed_qkv_spec,
+            a=a,
+            b=b,
+            core_attn_out=core_attn_out,
+            ssm_state=ssm_state,
+            attn_metadata=attn_metadata,
+        )
+        if use_dflash2_packed_gdn_verify:
+            query_spec, key_spec, value_spec = None, None, None
+        else:
+            query_spec, key_spec, value_spec = self.rearrange_mixed_qkv(mixed_qkv_spec)
         prefill_l2norm_in_kernel = False
         use_original_flashqla_prefill = _sm70_flashqla_original_prefill_enabled()
         prefill_gate_is_exp = False
@@ -5287,7 +5396,27 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
                 assert spec_token_indx is not None
                 a_spec = a.index_select(0, spec_token_indx)
                 b_spec = b.index_select(0, spec_token_indx)
-            if ddtree_tree_gdn_pure_spec:
+            if use_dflash2_packed_gdn_verify:
+                assert mixed_qkv_spec is not None
+                assert spec_query_start_loc is not None
+                assert spec_state_indices_tensor is not None
+                assert spec_state_slot_selectors is not None
+                core_attn_out_spec = self._forward_dflash2_packed_gdn_verify(
+                    mixed_qkv=mixed_qkv_spec,
+                    a=a_spec,
+                    b=b_spec,
+                    core_attn_out=core_attn_out,
+                    ssm_state=ssm_state,
+                    spec_query_start_loc=spec_query_start_loc,
+                    spec_state_indices_tensor=spec_state_indices_tensor,
+                    spec_state_slot_selectors=spec_state_slot_selectors,
+                    num_spec_decodes=attn_metadata.num_spec_decodes,
+                )
+                last_recurrent_state = ssm_state
+                _log_runtime_route_once(
+                    "SM70 DFlash2 packed GDN target-verification route hit."
+                )
+            elif ddtree_tree_gdn_pure_spec:
                 assert mixed_qkv_spec is not None
                 assert spec_query_start_loc is not None
                 assert spec_state_indices_tensor is not None
@@ -5320,6 +5449,9 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
                 )
                 last_recurrent_state = ssm_state
             else:
+                assert query_spec is not None
+                assert key_spec is not None
+                assert value_spec is not None
                 g_spec, beta_spec = fused_gdn_gating(
                     self.A_log,
                     a_spec,
@@ -5526,7 +5658,8 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
             merged_out.index_copy_(1, non_spec_token_indx, core_attn_out_non_spec)
             core_attn_out[:num_actual_tokens] = merged_out.squeeze(0)
         elif spec_sequence_masks is not None:
-            core_attn_out[:num_actual_tokens] = core_attn_out_spec.squeeze(0)
+            if not use_dflash2_packed_gdn_verify:
+                core_attn_out[:num_actual_tokens] = core_attn_out_spec.squeeze(0)
         elif core_attn_out_non_spec is not None and not (
             attn_metadata.num_prefills > 0
             and spec_sequence_masks is None
@@ -6309,6 +6442,32 @@ def qwen_gdn_attention_core_spec_commit(
             max_query_len=spec_state_indices_tensor.size(-1),
             validate_data=False,
         )
+        if self._can_use_dflash2_packed_gdn_verify(
+            mixed_qkv=mixed_qkv_spec,
+            a=a,
+            b=b,
+            core_attn_out=core_attn_out,
+            ssm_state=ssm_state,
+            attn_metadata=attn_metadata,
+        ):
+            self._forward_dflash2_packed_gdn_verify(
+                mixed_qkv=mixed_qkv_spec,
+                a=a,
+                b=b,
+                core_attn_out=core_attn_out,
+                ssm_state=ssm_state,
+                spec_query_start_loc=spec_query_start_loc,
+                spec_state_indices_tensor=spec_state_indices_tensor,
+                spec_state_slot_selectors=spec_state_slot_selectors,
+                num_spec_decodes=attn_metadata.num_spec_decodes,
+            )
+            _log_runtime_route_once(
+                "SM70 DFlash2 packed GDN target-verification route hit."
+            )
+            _sm70_dump_gdn_core_tensor(
+                "core_out", layer_name, core_attn_out, metadata_source
+            )
+            return core_attn_out
         query_spec, key_spec, value_spec = self.rearrange_mixed_qkv(mixed_qkv_spec)
         g_spec, beta_spec = fused_gdn_gating(
             self.A_log,

--- a/vllm/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py
+++ b/vllm/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py
@@ -74,6 +74,7 @@ from vllm.v1.attention.backends.gdn_attn import (
     get_registered_gdn_spec_metadata_tensors,
 )
 from vllm.v1.attention.backends.utils import compute_causal_conv1d_metadata
+from vllm.v1.worker.gpu.spec_decode import uses_dflash_selector_engine
 
 # Optional ROCm AITER Triton kernels for the GDN decode fast-path.
 # Availability is checked centrally via rocm_aiter_ops; the actual function
@@ -591,12 +592,7 @@ def _sm70_qwen_gdn_spec_method(vllm_config: object) -> str | None:
 
 
 def _is_dflash2_spec_config(vllm_config: object) -> bool:
-    spec_config = getattr(vllm_config, "speculative_config", None)
-    if spec_config is None or getattr(spec_config, "method", None) != "dflash":
-        return False
-    draft_model_config = getattr(spec_config, "draft_model_config", None)
-    architectures = getattr(draft_model_config, "architectures", None) or []
-    return "DFlash2DraftModel" in architectures
+    return uses_dflash_selector_engine(vllm_config)
 
 
 def _sm70_qwen_gdn_full_forward_enabled(
@@ -4864,8 +4860,8 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
             and mixed_qkv.dtype == torch.float16
             and a.dtype == torch.float16
             and b.dtype == torch.float16
-            # Qwen3.8's official target contract keeps the recurrent state in
-            # FP32; an explicit FP16 cache override is also supported.
+            # The supported verifier contract keeps recurrent state in FP32;
+            # an explicit FP16 cache override is also supported.
             and ssm_state.dtype in (torch.float16, torch.float32)
             and mixed_qkv.is_contiguous()
             and a.is_contiguous()

--- a/vllm/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py
+++ b/vllm/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py
@@ -6442,13 +6442,15 @@ def qwen_gdn_attention_core_spec_commit(
             max_query_len=spec_state_indices_tensor.size(-1),
             validate_data=False,
         )
-        if self._can_use_dflash2_packed_gdn_verify(
-            mixed_qkv=mixed_qkv_spec,
-            a=a,
-            b=b,
-            core_attn_out=core_attn_out,
-            ssm_state=ssm_state,
-            attn_metadata=attn_metadata,
+        if isinstance(self, QwenGatedDeltaNetAttention) and (
+            self._can_use_dflash2_packed_gdn_verify(
+                mixed_qkv=mixed_qkv_spec,
+                a=a,
+                b=b,
+                core_attn_out=core_attn_out,
+                ssm_state=ssm_state,
+                attn_metadata=attn_metadata,
+            )
         ):
             self._forward_dflash2_packed_gdn_verify(
                 mixed_qkv=mixed_qkv_spec,

--- a/vllm/v1/attention/backends/gdn_attn.py
+++ b/vllm/v1/attention/backends/gdn_attn.py
@@ -1754,8 +1754,7 @@ class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]
                 assert spec_query_start_loc[-1].item() == num_spec_decode_tokens
             else:
                 assert (
-                    common_gdn_metadata.num_spec_decode_tokens
-                    == num_spec_decode_tokens
+                    common_gdn_metadata.num_spec_decode_tokens == num_spec_decode_tokens
                 )
             assert spec_state_indices_tensor is not None
             assert spec_state_indices_tensor.shape[0] == num_spec_decodes

--- a/vllm/v1/attention/backends/gdn_attn.py
+++ b/vllm/v1/attention/backends/gdn_attn.py
@@ -60,6 +60,16 @@ class _GDNDdTreeFastCommonBuffers:
     token_index_initialized_size: int = 0
 
 
+@dataclass
+class DFlash2GDNGroupDescriptor:
+    """Persistent pointer tables for one target runner's GDN cache groups."""
+
+    key: tuple[object, ...]
+    block_table_ptrs: torch.Tensor
+    state_output_ptrs: torch.Tensor
+    block_table_strides: torch.Tensor
+
+
 _GDN_DDTREE_FAST_COMMON_BUFFERS: dict[
     tuple[str, int | None, int, int], _GDNDdTreeFastCommonBuffers
 ] = {}
@@ -85,8 +95,9 @@ def _get_ddtree_gdn_fast_common_buffers(
         dtype=torch.bool,
         device=device,
     )
-    spec_token_indx = torch.empty(
-        (decode_cudagraph_max_bs * width,),
+    spec_token_capacity = decode_cudagraph_max_bs * width
+    spec_token_indx = torch.arange(
+        spec_token_capacity,
         dtype=torch.int32,
         device=device,
     )
@@ -117,6 +128,7 @@ def _get_ddtree_gdn_fast_common_buffers(
         spec_query_start_loc=spec_query_start_loc,
         num_accepted_tokens=num_accepted_tokens,
         spec_state_slot_selectors=spec_state_slot_selectors,
+        token_index_initialized_size=spec_token_capacity,
     )
     _GDN_DDTREE_FAST_COMMON_BUFFERS[key] = buffers
     return buffers
@@ -148,6 +160,72 @@ def _dflash_ddtree_gdn_fast_build_triton_enabled() -> bool:
     return os.getenv(
         "VLLM_DFLASH_DDTREE_GDN_FAST_BUILD_TRITON", "1"
     ).strip().lower() not in ("0", "false", "no", "off", "")
+
+
+@triton.jit
+def _load_gdn_i32_ptr(ptr_to_ptr):
+    ptr = tl.load(ptr_to_ptr)
+    ptr = tl.cast(ptr, tl.pointer_type(tl.int32))
+    return tl.multiple_of(ptr, 16)
+
+
+@triton.jit
+def _dflash2_gdn_group_metadata_kernel(
+    block_table_ptrs,
+    state_output_ptrs,
+    block_table_strides,
+    spec_query_start_loc_src,
+    num_accepted_src,
+    state_selector_src,
+    spec_sequence_masks_out,
+    spec_query_start_loc_out,
+    num_accepted_out,
+    state_selector_out,
+    num_spec_decodes,
+    batch_size,
+    WIDTH: tl.constexpr,
+    PAD_ID: tl.constexpr,
+    BLOCK: tl.constexpr,
+):
+    """Write every GDN group's state IDs and the shared graph metadata."""
+    group_id = tl.program_id(0)
+    block_table = _load_gdn_i32_ptr(block_table_ptrs + group_id)
+    state_output = _load_gdn_i32_ptr(state_output_ptrs + group_id)
+    block_table_stride = tl.load(block_table_strides + group_id)
+
+    offsets = tl.arange(0, BLOCK)
+    rows = offsets // WIDTH
+    columns = offsets % WIDTH
+    output_mask = offsets < batch_size * WIDTH
+    live_state_mask = output_mask & (rows < num_spec_decodes)
+    state_ids = tl.load(
+        block_table + rows * block_table_stride + columns,
+        mask=live_state_mask,
+        other=PAD_ID,
+    )
+    tl.store(state_output + offsets, state_ids, mask=output_mask)
+
+    # All groups share these buffers. Restrict the stores to group zero so the
+    # launch has one writer without introducing a second metadata kernel.
+    is_common_writer = group_id == 0
+    row_mask = (offsets < batch_size) & is_common_writer
+    live_row_mask = row_mask & (offsets < num_spec_decodes)
+    accepted = tl.load(num_accepted_src + offsets, mask=live_row_mask, other=1)
+    selectors = tl.load(state_selector_src + offsets, mask=live_row_mask, other=1)
+    tl.store(
+        spec_sequence_masks_out + offsets, offsets < num_spec_decodes, mask=row_mask
+    )
+    tl.store(num_accepted_out + offsets, accepted, mask=row_mask)
+    tl.store(state_selector_out + offsets, selectors, mask=row_mask)
+
+    query_mask = (offsets < batch_size + 1) & is_common_writer
+    query_src_offsets = tl.minimum(offsets, num_spec_decodes)
+    query_offsets = tl.load(
+        spec_query_start_loc_src + query_src_offsets,
+        mask=query_mask,
+        other=0,
+    )
+    tl.store(spec_query_start_loc_out + offsets, query_offsets, mask=query_mask)
 
 
 @triton.jit
@@ -717,7 +795,10 @@ class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]
         self._ddtree_fast_tail_key: tuple[int, int, int] | None = None
         if (
             self.use_spec_decode
-            and envs.VLLM_SM70_QWEN_GDN_SPEC_CORE_OP
+            and (
+                envs.VLLM_SM70_QWEN_GDN_SPEC_CORE_OP
+                or envs.VLLM_SM70_DFLASH2_FUSED_GDN_METADATA
+            )
             and _dflash_ddtree_gdn_shared_common_enabled()
         ):
             self._ddtree_fast_common_buffers = _get_ddtree_gdn_fast_common_buffers(
@@ -1185,6 +1266,7 @@ class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]
         num_decode_draft_tokens_cpu: torch.Tensor | None = None,
         spec_sequence_masks_cpu: torch.Tensor | None = None,
         common_gdn_metadata: CommonGDNSpecMetadata | None = None,
+        prepared_dflash2_metadata: GDNAttentionMetadata | None = None,
         current_state_block_ids: torch.Tensor | None = None,
         ddtree_parent_ids: torch.Tensor | None = None,
         ddtree_num_tree_tokens_cpu: torch.Tensor | None = None,
@@ -1201,6 +1283,34 @@ class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]
 
         query_start_loc = m.query_start_loc
         query_start_loc_cpu = m.query_start_loc_cpu
+        if prepared_dflash2_metadata is not None:
+            if (
+                for_cudagraph_capture
+                or common_gdn_metadata is None
+                or ddtree_parent_ids is not None
+                or current_state_block_ids is not None
+            ):
+                raise ValueError(
+                    "Prepared DFlash2 GDN metadata is valid only for MRV2 "
+                    "runtime graph replay"
+                )
+            prepared_state = prepared_dflash2_metadata.spec_state_indices_tensor
+            if (
+                prepared_state is None
+                or prepared_state.data_ptr()
+                != self.spec_state_indices_tensor.data_ptr()
+            ):
+                raise ValueError(
+                    "Prepared DFlash2 GDN metadata does not belong to this builder"
+                )
+            register_gdn_spec_metadata_tensors(
+                self.layer_names,
+                gdn_spec_metadata_tensors(
+                    prepared_dflash2_metadata,
+                    query_start_loc.device,
+                ),
+            )
+            return prepared_dflash2_metadata
         if fast_build and _dflash_ddtree_gdn_fast_build_enabled():
             fast_metadata = self._build_fast_pure_ddtree_full_graph(
                 common_attn_metadata=common_attn_metadata,
@@ -2038,3 +2148,252 @@ class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]
             spec_sequence_masks_cpu=spec_sequence_masks_cpu,
             for_cudagraph_capture=True,
         )
+
+
+def prepare_dflash2_gdn_group_metadata(
+    *,
+    builders_by_group: list[tuple[int, GDNAttentionMetadataBuilder]],
+    block_tables: tuple[torch.Tensor, ...],
+    common_gdn_metadata: CommonGDNSpecMetadata,
+    num_accepted_tokens: torch.Tensor,
+    num_actual_tokens: int,
+    descriptor: DFlash2GDNGroupDescriptor | None,
+) -> (
+    tuple[
+        dict[int, GDNAttentionMetadata],
+        DFlash2GDNGroupDescriptor,
+    ]
+    | None
+):
+    """Prepare all pure-MRV2 DFlash2 GDN graph metadata in one launch.
+
+    The current production target uses ``mamba_cache_mode=none``. Its legacy
+    contract compacts the live speculative rows from every group's block table,
+    then copies them into graph-stable buffers. DFlash2 batches keep those rows
+    at the front and CUDA-graph padding at the back, so the pointer-table kernel
+    can perform the identical copy and tail fill without ten independent
+    advanced-indexing pipelines.
+    """
+    if not envs.VLLM_SM70_DFLASH2_FUSED_GDN_METADATA:
+        return None
+    if not builders_by_group or num_actual_tokens <= 0:
+        return None
+    if num_accepted_tokens.device.type != "cuda":
+        return None
+    if num_accepted_tokens.dtype != torch.int32 or num_accepted_tokens.ndim != 1:
+        return None
+
+    spec_mask_cpu = common_gdn_metadata.spec_sequence_masks_cpu
+    num_spec_decodes = common_gdn_metadata.num_spec_decodes
+    if (
+        common_gdn_metadata.num_prefills != 0
+        or common_gdn_metadata.num_decodes != 0
+        or num_spec_decodes <= 0
+        or num_spec_decodes > num_actual_tokens
+        or num_spec_decodes > spec_mask_cpu.numel()
+        or common_gdn_metadata.num_spec_decode_tokens > num_actual_tokens
+    ):
+        return None
+    if not bool(torch.all(spec_mask_cpu[:num_spec_decodes]).item()):
+        return None
+    if bool(torch.any(spec_mask_cpu[num_spec_decodes:]).item()):
+        return None
+
+    query_start_loc = common_gdn_metadata.spec_query_start_loc
+    if (
+        query_start_loc.device != num_accepted_tokens.device
+        or query_start_loc.dtype != torch.int32
+        or query_start_loc.ndim != 1
+        or query_start_loc.numel() != num_spec_decodes + 1
+    ):
+        return None
+    if num_accepted_tokens.numel() < num_spec_decodes:
+        return None
+
+    first_builder = builders_by_group[0][1]
+    width = first_builder.num_spec_state_tokens + 1
+    common_buffers = first_builder._ddtree_fast_common_buffers
+    if common_buffers is None:
+        return None
+    if (
+        num_actual_tokens > first_builder.decode_cudagraph_max_bs
+        or common_gdn_metadata.num_spec_decode_tokens
+        > first_builder.decode_cudagraph_max_bs
+    ):
+        return None
+
+    input_tables: list[torch.Tensor] = []
+    output_states: list[torch.Tensor] = []
+    builder_ids: list[int] = []
+    group_ids: list[int] = []
+    seen_builders: set[int] = set()
+    for group_id, builder in builders_by_group:
+        builder_id = id(builder)
+        if builder_id in seen_builders:
+            continue
+        seen_builders.add(builder_id)
+        if (
+            builder.num_spec_state_tokens + 1 != width
+            or not builder.use_full_cuda_graph
+            or builder.vllm_config.cache_config.mamba_cache_mode != "none"
+            or builder.decode_cudagraph_max_bs < num_actual_tokens
+            or builder._ddtree_fast_common_buffers is not common_buffers
+            or group_id < 0
+            or group_id >= len(block_tables)
+        ):
+            return None
+        block_table = block_tables[group_id]
+        state_output = builder.spec_state_indices_tensor
+        if (
+            block_table.device != num_accepted_tokens.device
+            or block_table.dtype != torch.int32
+            or block_table.ndim != 2
+            or block_table.shape[0] < num_spec_decodes
+            or block_table.shape[1] < width
+            or not block_table.is_contiguous()
+            or state_output.device != num_accepted_tokens.device
+            or state_output.dtype != torch.int32
+            or state_output.ndim != 2
+            or state_output.shape[0] < num_actual_tokens
+            or state_output.shape[1] != width
+            or not state_output.is_contiguous()
+        ):
+            return None
+        input_tables.append(block_table)
+        output_states.append(state_output)
+        builder_ids.append(builder_id)
+        group_ids.append(group_id)
+
+    if not input_tables:
+        return None
+    spec_token_size = common_gdn_metadata.spec_token_indx.numel()
+    if (
+        spec_token_size > common_buffers.spec_token_indx.numel()
+        or num_actual_tokens > common_buffers.spec_sequence_masks.numel()
+        or num_actual_tokens + 1 > common_buffers.spec_query_start_loc.numel()
+    ):
+        return None
+    if spec_token_size > common_buffers.token_index_initialized_size:
+        return None
+
+    descriptor_key: tuple[object, ...] = (
+        num_accepted_tokens.device.type,
+        num_accepted_tokens.device.index,
+        width,
+        tuple(group_ids),
+        tuple(builder_ids),
+        tuple(table.data_ptr() for table in input_tables),
+        tuple(state.data_ptr() for state in output_states),
+        tuple(table.stride(0) for table in input_tables),
+    )
+    if descriptor is None or descriptor.key != descriptor_key:
+        descriptor = DFlash2GDNGroupDescriptor(
+            key=descriptor_key,
+            block_table_ptrs=torch.tensor(
+                [table.data_ptr() for table in input_tables],
+                dtype=torch.uint64,
+                device=num_accepted_tokens.device,
+            ),
+            state_output_ptrs=torch.tensor(
+                [state.data_ptr() for state in output_states],
+                dtype=torch.uint64,
+                device=num_accepted_tokens.device,
+            ),
+            block_table_strides=torch.tensor(
+                [table.stride(0) for table in input_tables],
+                dtype=torch.int64,
+                device=num_accepted_tokens.device,
+            ),
+        )
+
+    block = triton.next_power_of_2(
+        max(num_actual_tokens * width, num_actual_tokens + 1)
+    )
+    _dflash2_gdn_group_metadata_kernel[(len(input_tables),)](
+        descriptor.block_table_ptrs,
+        descriptor.state_output_ptrs,
+        descriptor.block_table_strides,
+        query_start_loc,
+        num_accepted_tokens,
+        num_accepted_tokens,
+        common_buffers.spec_sequence_masks,
+        common_buffers.spec_query_start_loc,
+        common_buffers.num_accepted_tokens,
+        common_buffers.spec_state_slot_selectors,
+        num_spec_decodes,
+        num_actual_tokens,
+        WIDTH=width,
+        PAD_ID=PAD_SLOT_ID,
+        BLOCK=block,
+        num_warps=1,
+    )
+    common_buffers.initialized_key = (
+        num_actual_tokens,
+        common_gdn_metadata.num_spec_decode_tokens,
+        width,
+    )
+
+    prepared: dict[int, GDNAttentionMetadata] = {}
+    for builder_id, state_output in zip(builder_ids, output_states):
+        prepared[builder_id] = GDNAttentionMetadata(
+            num_prefills=0,
+            num_prefill_tokens=0,
+            num_decodes=0,
+            num_decode_tokens=0,
+            num_spec_decodes=num_spec_decodes,
+            num_spec_decode_tokens=common_gdn_metadata.num_spec_decode_tokens,
+            num_actual_tokens=num_actual_tokens,
+            has_initial_state=None,
+            chunk_indices=None,
+            chunk_offsets=None,
+            spec_query_start_loc=common_buffers.spec_query_start_loc[
+                : num_actual_tokens + 1
+            ],
+            non_spec_query_start_loc=None,
+            spec_state_indices_tensor=state_output[:num_actual_tokens],
+            non_spec_state_indices_tensor=None,
+            spec_sequence_masks=common_buffers.spec_sequence_masks[:num_actual_tokens],
+            spec_token_indx=common_buffers.spec_token_indx[:spec_token_size],
+            non_spec_token_indx=common_buffers.non_spec_token_indx[:0],
+            num_accepted_tokens=common_buffers.num_accepted_tokens[:num_actual_tokens],
+            spec_state_slot_selectors=common_buffers.spec_state_slot_selectors[
+                :num_actual_tokens
+            ],
+            ddtree_parent_ids=None,
+            ddtree_num_tree_tokens_cpu=None,
+            nums_dict=None,
+            batch_ptr=None,
+            token_chunk_offset_ptr=None,
+        )
+
+    if envs.VLLM_SM70_DFLASH2_GDN_METADATA_SHADOW:
+        spec_mask = common_gdn_metadata.spec_sequence_masks
+        expected_accepted = num_accepted_tokens[spec_mask]
+        for group_id, builder in builders_by_group:
+            actual = prepared[id(builder)]
+            expected_state = block_tables[group_id][spec_mask, :width]
+            torch.testing.assert_close(
+                actual.spec_state_indices_tensor[:num_spec_decodes],
+                expected_state,
+                rtol=0,
+                atol=0,
+            )
+            torch.testing.assert_close(
+                actual.spec_state_indices_tensor[num_spec_decodes:],
+                torch.full_like(
+                    actual.spec_state_indices_tensor[num_spec_decodes:],
+                    PAD_SLOT_ID,
+                ),
+                rtol=0,
+                atol=0,
+            )
+        torch.testing.assert_close(
+            common_buffers.num_accepted_tokens[:num_spec_decodes],
+            expected_accepted,
+            rtol=0,
+            atol=0,
+        )
+        if torch.any(common_buffers.spec_sequence_masks[num_spec_decodes:]).item():
+            raise AssertionError("DFlash2 fused GDN metadata left a live padded row")
+
+    return prepared, descriptor

--- a/vllm/v1/attention/backends/gdn_attn.py
+++ b/vllm/v1/attention/backends/gdn_attn.py
@@ -68,6 +68,8 @@ class DFlash2GDNGroupDescriptor:
     block_table_ptrs: torch.Tensor
     state_output_ptrs: torch.Tensor
     block_table_strides: torch.Tensor
+    prepared_key: tuple[int, int, int, int] | None = None
+    prepared_metadata: dict[int, "GDNAttentionMetadata"] | None = None
 
 
 _GDN_DDTREE_FAST_COMMON_BUFFERS: dict[
@@ -2285,6 +2287,12 @@ def prepare_dflash2_gdn_group_metadata(
         tuple(table.data_ptr() for table in input_tables),
         tuple(state.data_ptr() for state in output_states),
         tuple(table.stride(0) for table in input_tables),
+        common_buffers.spec_sequence_masks.data_ptr(),
+        common_buffers.spec_token_indx.data_ptr(),
+        common_buffers.non_spec_token_indx.data_ptr(),
+        common_buffers.spec_query_start_loc.data_ptr(),
+        common_buffers.num_accepted_tokens.data_ptr(),
+        common_buffers.spec_state_slot_selectors.data_ptr(),
     )
     if descriptor is None or descriptor.key != descriptor_key:
         descriptor = DFlash2GDNGroupDescriptor(
@@ -2333,38 +2341,52 @@ def prepare_dflash2_gdn_group_metadata(
         width,
     )
 
-    prepared: dict[int, GDNAttentionMetadata] = {}
-    for builder_id, state_output in zip(builder_ids, output_states):
-        prepared[builder_id] = GDNAttentionMetadata(
-            num_prefills=0,
-            num_prefill_tokens=0,
-            num_decodes=0,
-            num_decode_tokens=0,
-            num_spec_decodes=num_spec_decodes,
-            num_spec_decode_tokens=common_gdn_metadata.num_spec_decode_tokens,
-            num_actual_tokens=num_actual_tokens,
-            has_initial_state=None,
-            chunk_indices=None,
-            chunk_offsets=None,
-            spec_query_start_loc=common_buffers.spec_query_start_loc[
-                : num_actual_tokens + 1
-            ],
-            non_spec_query_start_loc=None,
-            spec_state_indices_tensor=state_output[:num_actual_tokens],
-            non_spec_state_indices_tensor=None,
-            spec_sequence_masks=common_buffers.spec_sequence_masks[:num_actual_tokens],
-            spec_token_indx=common_buffers.spec_token_indx[:spec_token_size],
-            non_spec_token_indx=common_buffers.non_spec_token_indx[:0],
-            num_accepted_tokens=common_buffers.num_accepted_tokens[:num_actual_tokens],
-            spec_state_slot_selectors=common_buffers.spec_state_slot_selectors[
-                :num_actual_tokens
-            ],
-            ddtree_parent_ids=None,
-            ddtree_num_tree_tokens_cpu=None,
-            nums_dict=None,
-            batch_ptr=None,
-            token_chunk_offset_ptr=None,
-        )
+    prepared_key = (
+        num_spec_decodes,
+        num_actual_tokens,
+        common_gdn_metadata.num_spec_decode_tokens,
+        spec_token_size,
+    )
+    prepared = descriptor.prepared_metadata
+    if descriptor.prepared_key != prepared_key or prepared is None:
+        prepared = {}
+        for builder_id, state_output in zip(builder_ids, output_states):
+            prepared[builder_id] = GDNAttentionMetadata(
+                num_prefills=0,
+                num_prefill_tokens=0,
+                num_decodes=0,
+                num_decode_tokens=0,
+                num_spec_decodes=num_spec_decodes,
+                num_spec_decode_tokens=common_gdn_metadata.num_spec_decode_tokens,
+                num_actual_tokens=num_actual_tokens,
+                has_initial_state=None,
+                chunk_indices=None,
+                chunk_offsets=None,
+                spec_query_start_loc=common_buffers.spec_query_start_loc[
+                    : num_actual_tokens + 1
+                ],
+                non_spec_query_start_loc=None,
+                spec_state_indices_tensor=state_output[:num_actual_tokens],
+                non_spec_state_indices_tensor=None,
+                spec_sequence_masks=common_buffers.spec_sequence_masks[
+                    :num_actual_tokens
+                ],
+                spec_token_indx=common_buffers.spec_token_indx[:spec_token_size],
+                non_spec_token_indx=common_buffers.non_spec_token_indx[:0],
+                num_accepted_tokens=common_buffers.num_accepted_tokens[
+                    :num_actual_tokens
+                ],
+                spec_state_slot_selectors=common_buffers.spec_state_slot_selectors[
+                    :num_actual_tokens
+                ],
+                ddtree_parent_ids=None,
+                ddtree_num_tree_tokens_cpu=None,
+                nums_dict=None,
+                batch_ptr=None,
+                token_chunk_offset_ptr=None,
+            )
+        descriptor.prepared_key = prepared_key
+        descriptor.prepared_metadata = prepared
 
     if envs.VLLM_SM70_DFLASH2_GDN_METADATA_SHADOW:
         spec_mask = common_gdn_metadata.spec_sequence_masks

--- a/vllm/v1/attention/backends/gdn_attn.py
+++ b/vllm/v1/attention/backends/gdn_attn.py
@@ -27,6 +27,7 @@ from vllm.v1.attention.backends.utils import (
     split_decodes_and_prefills,
 )
 from vllm.v1.kv_cache_interface import AttentionSpec, MambaSpec
+from vllm.v1.worker.gpu.attn_utils import CommonGDNSpecMetadata
 
 logger = init_logger(__name__)
 
@@ -1183,6 +1184,7 @@ class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]
         spec_state_slot_selectors: torch.Tensor | None = None,
         num_decode_draft_tokens_cpu: torch.Tensor | None = None,
         spec_sequence_masks_cpu: torch.Tensor | None = None,
+        common_gdn_metadata: CommonGDNSpecMetadata | None = None,
         current_state_block_ids: torch.Tensor | None = None,
         ddtree_parent_ids: torch.Tensor | None = None,
         ddtree_num_tree_tokens_cpu: torch.Tensor | None = None,
@@ -1227,6 +1229,12 @@ class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]
         is_mamba_cache_all = self.vllm_config.cache_config.mamba_cache_mode == "all"
 
         num_reqs = query_start_loc_cpu.numel() - 1
+        if common_gdn_metadata is not None:
+            if ddtree_parent_ids is not None or current_state_block_ids is not None:
+                raise ValueError(
+                    "Common MRV2 GDN metadata cannot be used with DDTree state"
+                )
+            spec_sequence_masks_cpu = common_gdn_metadata.spec_sequence_masks_cpu
         if spec_sequence_masks_cpu is not None:
             assert spec_sequence_masks_cpu.dtype == torch.bool
             assert spec_sequence_masks_cpu.ndim == 1
@@ -1263,6 +1271,9 @@ class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]
         if not self.use_spec_decode:
             spec_sequence_masks = None
             num_spec_decodes = 0
+        elif common_gdn_metadata is not None:
+            spec_sequence_masks = common_gdn_metadata.spec_sequence_masks
+            num_spec_decodes = common_gdn_metadata.num_spec_decodes
         else:
             if spec_sequence_masks_cpu is None:
                 if num_decode_draft_tokens_cpu is None:
@@ -1473,9 +1484,11 @@ class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]
             else:
                 # query_start_loc may be padded for CUDA graph replay. The CPU
                 # metadata is authoritative for the live request count here.
-                query_lens = query_lens_cpu.to(
-                    query_start_loc.device, non_blocking=True
-                )
+                query_lens = None
+                if common_gdn_metadata is None:
+                    query_lens = query_lens_cpu.to(
+                        query_start_loc.device, non_blocking=True
+                    )
                 profile_state_contract_t0 = (
                     time.perf_counter() if metadata_profile else 0.0
                 )
@@ -1495,113 +1508,143 @@ class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]
                         time.perf_counter() - profile_state_contract_t0
                     ) * 1000.0
 
-                if envs.VLLM_SM70_MTP_LEGACY_GDN_MIXED_DECODE_ROUTING:
-                    # 0.0.3 kept ordinary query_len==1 rows on the decode path even
-                    # when another row was running speculative verification. This
-                    # is an A/B guard for MTP-only recurrent-state corruption.
-                    num_decodes = (non_spec_query_lens_cpu == 1).sum().item()
-                    num_prefills = (
-                        non_spec_query_lens_cpu.size(0) - num_decodes - num_zero_len
+                if common_gdn_metadata is not None:
+                    num_prefills = common_gdn_metadata.num_prefills
+                    num_prefill_tokens = common_gdn_metadata.num_prefill_tokens
+                    num_decodes = common_gdn_metadata.num_decodes
+                    num_decode_tokens = common_gdn_metadata.num_decode_tokens
+                    num_spec_decode_tokens = common_gdn_metadata.num_spec_decode_tokens
+                    spec_token_indx = common_gdn_metadata.spec_token_indx
+                    non_spec_token_indx = common_gdn_metadata.non_spec_token_indx
+                    spec_query_start_loc = common_gdn_metadata.spec_query_start_loc
+                    non_spec_query_start_loc = (
+                        common_gdn_metadata.non_spec_query_start_loc
                     )
-                    num_decode_tokens = num_decodes
-                    num_prefill_tokens = (
-                        non_spec_query_lens_cpu.sum().item() - num_decode_tokens
+                    non_spec_query_start_loc_cpu = (
+                        common_gdn_metadata.non_spec_query_start_loc_cpu
                     )
-                else:
-                    # When active spec decodes are present, route non-spec requests
-                    # through the prefill path so mixed batches keep separate GDN
-                    # state metadata for spec and non-spec tokens.
-                    num_decodes = 0
-                    num_prefills = non_spec_query_lens_cpu.size(0) - num_zero_len
-                    num_decode_tokens = 0
-                    num_prefill_tokens = non_spec_query_lens_cpu.sum().item()
-                num_spec_decode_tokens = (
-                    query_lens_cpu.sum().item() - num_prefill_tokens - num_decode_tokens
-                )
-
-                if num_prefills == 0 and num_decodes == 0:
-                    spec_token_size = min(
-                        num_spec_decodes * (self.num_spec_state_tokens + 1),
-                        query_start_loc_cpu[-1].item(),
-                    )
-                    spec_token_indx = torch.arange(
-                        spec_token_size,
-                        dtype=torch.int32,
-                        device=query_start_loc.device,
-                    )
-                    non_spec_token_indx = torch.empty(
-                        0, dtype=torch.int32, device=query_start_loc.device
-                    )
-                    spec_state_indices_tensor = state_contract.spec_state_indices_tensor
-                    if for_cudagraph_capture:
-                        spec_state_indices_tensor = torch.full_like(
-                            spec_state_indices_tensor, PAD_SLOT_ID
-                        )
-                    non_spec_state_indices_tensor = None
-                    # Padded sequences are always at the back, so the first
-                    # num_spec_decodes + 1 entries of query_start_loc already
-                    # contain the correct cumulative token counts.
-                    spec_query_start_loc = query_start_loc[: num_spec_decodes + 1]
-                    non_spec_query_start_loc = None
-                    non_spec_query_start_loc_cpu = None
-                else:
-                    spec_token_masks = torch.repeat_interleave(
-                        spec_sequence_masks,
-                        query_lens,
-                        output_size=query_start_loc_cpu[-1].item(),
-                    )
-                    index = torch.argsort(spec_token_masks, stable=True)
-                    num_non_spec_tokens = num_prefill_tokens + num_decode_tokens
-                    non_spec_token_indx = index[:num_non_spec_tokens]
-                    spec_token_indx = index[num_non_spec_tokens:]
-
                     spec_state_indices_tensor = state_contract.spec_state_indices_tensor
                     non_spec_state_indices_tensor = (
-                        state_contract.non_spec_state_indices_tensor
+                        None
+                        if num_prefills == 0 and num_decodes == 0
+                        else state_contract.non_spec_state_indices_tensor
                     )
-                    if for_cudagraph_capture:
-                        spec_state_indices_tensor = torch.full_like(
-                            spec_state_indices_tensor, PAD_SLOT_ID
+                else:
+                    if envs.VLLM_SM70_MTP_LEGACY_GDN_MIXED_DECODE_ROUTING:
+                        # 0.0.3 kept ordinary query_len==1 rows on the decode
+                        # path even when another row was running speculative
+                        # verification.
+                        num_decodes = (non_spec_query_lens_cpu == 1).sum().item()
+                        num_prefills = (
+                            non_spec_query_lens_cpu.size(0) - num_decodes - num_zero_len
                         )
-                        non_spec_state_indices_tensor = torch.full_like(
-                            non_spec_state_indices_tensor, PAD_SLOT_ID
+                        num_decode_tokens = num_decodes
+                        num_prefill_tokens = (
+                            non_spec_query_lens_cpu.sum().item() - num_decode_tokens
                         )
+                    else:
+                        # Mixed non-spec rows use the prefill path so their GDN
+                        # state metadata stays separate from verification rows.
+                        num_decodes = 0
+                        num_prefills = non_spec_query_lens_cpu.size(0) - num_zero_len
+                        num_decode_tokens = 0
+                        num_prefill_tokens = non_spec_query_lens_cpu.sum().item()
+                    num_spec_decode_tokens = (
+                        query_lens_cpu.sum().item()
+                        - num_prefill_tokens
+                        - num_decode_tokens
+                    )
 
-                    spec_query_start_loc = torch.zeros(
-                        num_spec_decodes + 1,
-                        dtype=torch.int32,
-                        device=query_start_loc.device,
-                    )
-                    torch.cumsum(
-                        query_lens[spec_sequence_masks],
-                        dim=0,
-                        out=spec_query_start_loc[1:],
-                    )
-                    non_spec_query_start_loc = torch.zeros(
-                        query_lens.size(0) - num_spec_decodes + 1,
-                        dtype=torch.int32,
-                        device=query_start_loc.device,
-                    )
-                    torch.cumsum(
-                        query_lens[~spec_sequence_masks],
-                        dim=0,
-                        out=non_spec_query_start_loc[1:],
-                    )
-                    non_spec_query_start_loc_cpu = torch.zeros(
-                        query_lens_cpu.size(0) - num_spec_decodes + 1,
-                        dtype=torch.int32,
-                        device="cpu",
-                    )
-                    torch.cumsum(
-                        query_lens_cpu[~spec_sequence_masks_cpu],
-                        dim=0,
-                        out=non_spec_query_start_loc_cpu[1:],
-                    )
+                    if num_prefills == 0 and num_decodes == 0:
+                        spec_token_size = min(
+                            num_spec_decodes * (self.num_spec_state_tokens + 1),
+                            query_start_loc_cpu[-1].item(),
+                        )
+                        spec_token_indx = torch.arange(
+                            spec_token_size,
+                            dtype=torch.int32,
+                            device=query_start_loc.device,
+                        )
+                        non_spec_token_indx = torch.empty(
+                            0,
+                            dtype=torch.int32,
+                            device=query_start_loc.device,
+                        )
+                        spec_state_indices_tensor = (
+                            state_contract.spec_state_indices_tensor
+                        )
+                        non_spec_state_indices_tensor = None
+                        # Padded sequences are always at the back.
+                        spec_query_start_loc = query_start_loc[: num_spec_decodes + 1]
+                        non_spec_query_start_loc = None
+                        non_spec_query_start_loc_cpu = None
+                    else:
+                        assert query_lens is not None
+                        spec_token_masks = torch.repeat_interleave(
+                            spec_sequence_masks,
+                            query_lens,
+                            output_size=query_start_loc_cpu[-1].item(),
+                        )
+                        index = torch.argsort(spec_token_masks, stable=True)
+                        num_non_spec_tokens = num_prefill_tokens + num_decode_tokens
+                        non_spec_token_indx = index[:num_non_spec_tokens]
+                        spec_token_indx = index[num_non_spec_tokens:]
+
+                        spec_state_indices_tensor = (
+                            state_contract.spec_state_indices_tensor
+                        )
+                        non_spec_state_indices_tensor = (
+                            state_contract.non_spec_state_indices_tensor
+                        )
+                        if for_cudagraph_capture:
+                            spec_state_indices_tensor = torch.full_like(
+                                spec_state_indices_tensor, PAD_SLOT_ID
+                            )
+                            non_spec_state_indices_tensor = torch.full_like(
+                                non_spec_state_indices_tensor, PAD_SLOT_ID
+                            )
+
+                        spec_query_start_loc = torch.zeros(
+                            num_spec_decodes + 1,
+                            dtype=torch.int32,
+                            device=query_start_loc.device,
+                        )
+                        torch.cumsum(
+                            query_lens[spec_sequence_masks],
+                            dim=0,
+                            out=spec_query_start_loc[1:],
+                        )
+                        non_spec_query_start_loc = torch.zeros(
+                            query_lens.size(0) - num_spec_decodes + 1,
+                            dtype=torch.int32,
+                            device=query_start_loc.device,
+                        )
+                        torch.cumsum(
+                            query_lens[~spec_sequence_masks],
+                            dim=0,
+                            out=non_spec_query_start_loc[1:],
+                        )
+                        non_spec_query_start_loc_cpu = torch.zeros(
+                            query_lens_cpu.size(0) - num_spec_decodes + 1,
+                            dtype=torch.int32,
+                            device="cpu",
+                        )
+                        torch.cumsum(
+                            query_lens_cpu[~spec_sequence_masks_cpu],
+                            dim=0,
+                            out=non_spec_query_start_loc_cpu[1:],
+                        )
 
                 num_accepted_tokens = state_contract.num_accepted_tokens
                 spec_state_slot_selectors = state_contract.spec_state_slot_selectors
             assert spec_query_start_loc is not None
-            assert spec_query_start_loc[-1].item() == num_spec_decode_tokens
+            if common_gdn_metadata is None:
+                assert spec_query_start_loc[-1].item() == num_spec_decode_tokens
+            else:
+                assert (
+                    common_gdn_metadata.num_spec_decode_tokens
+                    == num_spec_decode_tokens
+                )
             assert spec_state_indices_tensor is not None
             assert spec_state_indices_tensor.shape[0] == num_spec_decodes
 

--- a/vllm/v1/attention/backends/gdn_attn.py
+++ b/vllm/v1/attention/backends/gdn_attn.py
@@ -2387,22 +2387,25 @@ def prepare_dflash2_gdn_group_metadata(
         descriptor.prepared_key = prepared_key
         descriptor.prepared_metadata = prepared
 
+    assert prepared is not None
     if envs.VLLM_SM70_DFLASH2_GDN_METADATA_SHADOW:
         spec_mask = common_gdn_metadata.spec_sequence_masks
         expected_accepted = num_accepted_tokens[spec_mask]
         for group_id, builder in builders_by_group:
             actual = prepared[id(builder)]
+            actual_state = actual.spec_state_indices_tensor
+            assert actual_state is not None
             expected_state = block_tables[group_id][spec_mask, :width]
             torch.testing.assert_close(
-                actual.spec_state_indices_tensor[:num_spec_decodes],
+                actual_state[:num_spec_decodes],
                 expected_state,
                 rtol=0,
                 atol=0,
             )
             torch.testing.assert_close(
-                actual.spec_state_indices_tensor[num_spec_decodes:],
+                actual_state[num_spec_decodes:],
                 torch.full_like(
-                    actual.spec_state_indices_tensor[num_spec_decodes:],
+                    actual_state[num_spec_decodes:],
                     PAD_SLOT_ID,
                 ),
                 rtol=0,

--- a/vllm/v1/worker/gpu/attn_utils.py
+++ b/vllm/v1/worker/gpu/attn_utils.py
@@ -372,6 +372,159 @@ def build_slot_mappings_by_layer(
     return slot_mappings_by_layer
 
 
+@dataclass(frozen=True)
+class CommonGDNSpecMetadata:
+    """Batch-level GDN speculative metadata shared by every cache group."""
+
+    num_prefills: int
+    num_prefill_tokens: int
+    num_decodes: int
+    num_decode_tokens: int
+    num_spec_decodes: int
+    num_spec_decode_tokens: int
+    spec_query_start_loc: torch.Tensor
+    non_spec_query_start_loc: torch.Tensor | None
+    non_spec_query_start_loc_cpu: torch.Tensor | None
+    spec_sequence_masks_cpu: torch.Tensor
+    spec_sequence_masks: torch.Tensor
+    spec_token_indx: torch.Tensor
+    non_spec_token_indx: torch.Tensor
+
+
+def compute_common_gdn_attn_metadata(
+    *,
+    num_decode_draft_tokens_cpu: torch.Tensor | None,
+    query_start_loc: torch.Tensor,
+    query_start_loc_cpu: torch.Tensor,
+    num_spec_state_tokens: int,
+    legacy_mixed_decode_routing: bool,
+) -> CommonGDNSpecMetadata | None:
+    """Compute GDN speculative batch metadata once instead of per group.
+
+    State block IDs remain group-specific and are deliberately excluded. This
+    is the dependency boundary needed to share request classification, token
+    indices, and query offsets without changing recurrent-state ownership.
+    """
+    if num_spec_state_tokens <= 0 or num_decode_draft_tokens_cpu is None:
+        return None
+
+    num_reqs = query_start_loc_cpu.numel() - 1
+    if num_decode_draft_tokens_cpu.ndim != 1:
+        raise ValueError("num_decode_draft_tokens_cpu must be one-dimensional")
+    if num_decode_draft_tokens_cpu.numel() != num_reqs:
+        raise ValueError("num_decode_draft_tokens_cpu must align with query_start_loc")
+
+    spec_sequence_masks_cpu = num_decode_draft_tokens_cpu >= 0
+    num_spec_decodes = int(spec_sequence_masks_cpu.sum().item())
+    if num_spec_decodes == 0:
+        return None
+    num_spec_draft_tokens = int(
+        num_decode_draft_tokens_cpu[spec_sequence_masks_cpu].sum().item()
+    )
+    if num_spec_draft_tokens == 0:
+        return None
+
+    spec_sequence_masks = spec_sequence_masks_cpu.to(
+        query_start_loc.device, non_blocking=True
+    )
+    query_lens_cpu = query_start_loc_cpu[1:] - query_start_loc_cpu[:-1]
+    non_spec_query_lens_cpu = query_lens_cpu[~spec_sequence_masks_cpu]
+    num_zero_len = int((non_spec_query_lens_cpu == 0).sum().item())
+
+    if legacy_mixed_decode_routing:
+        num_decodes = int((non_spec_query_lens_cpu == 1).sum().item())
+        num_prefills = non_spec_query_lens_cpu.numel() - num_decodes - num_zero_len
+        num_decode_tokens = num_decodes
+        num_prefill_tokens = (
+            int(non_spec_query_lens_cpu.sum().item()) - num_decode_tokens
+        )
+    else:
+        num_decodes = 0
+        num_prefills = non_spec_query_lens_cpu.numel() - num_zero_len
+        num_decode_tokens = 0
+        num_prefill_tokens = int(non_spec_query_lens_cpu.sum().item())
+
+    num_spec_decode_tokens = (
+        int(query_lens_cpu.sum().item()) - num_prefill_tokens - num_decode_tokens
+    )
+    if num_prefills == 0 and num_decodes == 0:
+        spec_token_size = min(
+            num_spec_decodes * (num_spec_state_tokens + 1),
+            int(query_start_loc_cpu[-1].item()),
+        )
+        spec_token_indx = torch.arange(
+            spec_token_size,
+            dtype=torch.int32,
+            device=query_start_loc.device,
+        )
+        non_spec_token_indx = torch.empty(
+            0,
+            dtype=torch.int32,
+            device=query_start_loc.device,
+        )
+        spec_query_start_loc = query_start_loc[: num_spec_decodes + 1]
+        non_spec_query_start_loc = None
+        non_spec_query_start_loc_cpu = None
+    else:
+        query_lens = query_lens_cpu.to(query_start_loc.device, non_blocking=True)
+        spec_token_masks = torch.repeat_interleave(
+            spec_sequence_masks,
+            query_lens,
+            output_size=int(query_start_loc_cpu[-1].item()),
+        )
+        index = torch.argsort(spec_token_masks, stable=True)
+        num_non_spec_tokens = num_prefill_tokens + num_decode_tokens
+        non_spec_token_indx = index[:num_non_spec_tokens]
+        spec_token_indx = index[num_non_spec_tokens:]
+
+        spec_query_start_loc = torch.zeros(
+            num_spec_decodes + 1,
+            dtype=torch.int32,
+            device=query_start_loc.device,
+        )
+        torch.cumsum(
+            query_lens[spec_sequence_masks],
+            dim=0,
+            out=spec_query_start_loc[1:],
+        )
+        non_spec_query_start_loc = torch.zeros(
+            query_lens.numel() - num_spec_decodes + 1,
+            dtype=torch.int32,
+            device=query_start_loc.device,
+        )
+        torch.cumsum(
+            query_lens[~spec_sequence_masks],
+            dim=0,
+            out=non_spec_query_start_loc[1:],
+        )
+        non_spec_query_start_loc_cpu = torch.zeros(
+            query_lens_cpu.numel() - num_spec_decodes + 1,
+            dtype=torch.int32,
+            device="cpu",
+        )
+        torch.cumsum(
+            query_lens_cpu[~spec_sequence_masks_cpu],
+            dim=0,
+            out=non_spec_query_start_loc_cpu[1:],
+        )
+
+    return CommonGDNSpecMetadata(
+        num_prefills=num_prefills,
+        num_prefill_tokens=num_prefill_tokens,
+        num_decodes=num_decodes,
+        num_decode_tokens=num_decode_tokens,
+        num_spec_decodes=num_spec_decodes,
+        num_spec_decode_tokens=num_spec_decode_tokens,
+        spec_query_start_loc=spec_query_start_loc,
+        non_spec_query_start_loc=non_spec_query_start_loc,
+        non_spec_query_start_loc_cpu=non_spec_query_start_loc_cpu,
+        spec_sequence_masks_cpu=spec_sequence_masks_cpu,
+        spec_sequence_masks=spec_sequence_masks,
+        spec_token_indx=spec_token_indx,
+        non_spec_token_indx=non_spec_token_indx,
+    )
+
+
 def build_attn_metadata(
     attn_groups: list[list[AttentionGroup]],
     num_reqs: int,

--- a/vllm/v1/worker/gpu/cudagraph_utils.py
+++ b/vllm/v1/worker/gpu/cudagraph_utils.py
@@ -23,7 +23,6 @@ from vllm.logger import init_logger
 from vllm.model_executor.offloader.base import get_offloader
 from vllm.platforms import current_platform
 from vllm.sequence import IntermediateTensors
-from vllm.sm70_decode_trace import sm70_trace_call
 from vllm.v1.kv_cache_interface import KVCacheConfig
 from vllm.v1.worker.gpu.attn_utils import build_slot_mappings_by_layer
 from vllm.v1.worker.gpu.block_table import BlockTables
@@ -343,7 +342,7 @@ class CudaGraphManager:
         # cannot see. Without this, replay could overwrite static buffers
         # while those copies are still in flight.
         get_offloader().sync_prev_onload()
-        sm70_trace_call("v1_cudagraph.FULL.replay", self.graphs[desc].replay)
+        self.graphs[desc].replay()
 
 
 class ModelCudaGraphManager(CudaGraphManager):

--- a/vllm/v1/worker/gpu/cudagraph_utils.py
+++ b/vllm/v1/worker/gpu/cudagraph_utils.py
@@ -23,6 +23,7 @@ from vllm.logger import init_logger
 from vllm.model_executor.offloader.base import get_offloader
 from vllm.platforms import current_platform
 from vllm.sequence import IntermediateTensors
+from vllm.sm70_decode_trace import sm70_trace_call
 from vllm.v1.kv_cache_interface import KVCacheConfig
 from vllm.v1.worker.gpu.attn_utils import build_slot_mappings_by_layer
 from vllm.v1.worker.gpu.block_table import BlockTables
@@ -342,7 +343,7 @@ class CudaGraphManager:
         # cannot see. Without this, replay could overwrite static buffers
         # while those copies are still in flight.
         get_offloader().sync_prev_onload()
-        self.graphs[desc].replay()
+        sm70_trace_call("v1_cudagraph.FULL.replay", self.graphs[desc].replay)
 
 
 class ModelCudaGraphManager(CudaGraphManager):

--- a/vllm/v1/worker/gpu/model_states/mamba_hybrid.py
+++ b/vllm/v1/worker/gpu/model_states/mamba_hybrid.py
@@ -15,9 +15,15 @@ from vllm.model_executor.layers.mamba.mamba_utils import (
     get_conv_copy_spec,
     is_conv_state_dim_first,
 )
+from vllm.platforms import current_platform
 from vllm.triton_utils import triton
 from vllm.utils.platform_utils import is_pin_memory_available
-from vllm.v1.attention.backends.gdn_attn import GDNAttentionMetadataBuilder
+from vllm.v1.attention.backends.gdn_attn import (
+    DFlash2GDNGroupDescriptor,
+    GDNAttentionMetadata,
+    GDNAttentionMetadataBuilder,
+    prepare_dflash2_gdn_group_metadata,
+)
 from vllm.v1.attention.backends.mamba2_attn import Mamba2AttentionMetadataBuilder
 from vllm.v1.core.sched.output import NewRequestData
 from vllm.v1.kv_cache_interface import KVCacheConfig, MambaSpec
@@ -48,6 +54,7 @@ class MambaHybridAttnMetadata(ModelSpecificAttnMetadata):
     num_accepted_tokens: torch.Tensor | None = None
     num_decode_draft_tokens_cpu: torch.Tensor | None = None
     common_gdn_metadata: CommonGDNSpecMetadata | None = None
+    prepared_dflash2_gdn_metadata: dict[int, GDNAttentionMetadata] | None = None
 
     def get_extra_common_attn_kwargs(
         self,
@@ -76,6 +83,10 @@ class MambaHybridAttnMetadata(ModelSpecificAttnMetadata):
         }
         if isinstance(attn_metadata_builder, GDNAttentionMetadataBuilder):
             kwargs["common_gdn_metadata"] = self.common_gdn_metadata
+            if self.prepared_dflash2_gdn_metadata is not None:
+                kwargs["prepared_dflash2_metadata"] = (
+                    self.prepared_dflash2_gdn_metadata.get(id(attn_metadata_builder))
+                )
         return kwargs
 
 
@@ -113,6 +124,18 @@ class MambaHybridModelState(DefaultModelState):
             logger.info_once(
                 "DFlash2 shared GDN batch metadata fast path enabled."
             )
+        self._use_dflash2_fused_gdn_metadata = bool(
+            self._use_dflash2_common_gdn_metadata
+            and envs.VLLM_SM70_DFLASH2_FUSED_GDN_METADATA
+            and self.cache_config.mamba_cache_mode == "none"
+            and device.type == "cuda"
+            and current_platform.is_device_capability(70)
+        )
+        self._dflash2_gdn_builders: (
+            list[tuple[int, GDNAttentionMetadataBuilder]] | None
+        ) = None
+        self._dflash2_gdn_group_descriptor: DFlash2GDNGroupDescriptor | None = None
+        self._dflash2_fused_gdn_metadata_logged = False
         self._align_mode = self.cache_config.mamba_cache_mode == "align"
         if self._align_mode:
             self._mamba_state_idx_gpu = torch.full(
@@ -231,6 +254,20 @@ class MambaHybridModelState(DefaultModelState):
             input_batch.idx_mapping,
         )
 
+    def _get_dflash2_gdn_builders(
+        self,
+        attn_groups: list[list[AttentionGroup]],
+    ) -> list[tuple[int, GDNAttentionMetadataBuilder]]:
+        if self._dflash2_gdn_builders is None:
+            builders: list[tuple[int, GDNAttentionMetadataBuilder]] = []
+            for kv_cache_group_id, groups in enumerate(attn_groups):
+                for group in groups:
+                    builder = group.get_metadata_builder(0)
+                    if isinstance(builder, GDNAttentionMetadataBuilder):
+                        builders.append((kv_cache_group_id, builder))
+            self._dflash2_gdn_builders = builders
+        return self._dflash2_gdn_builders
+
     def prepare_attn(
         self,
         input_batch: InputBatch,
@@ -260,6 +297,7 @@ class MambaHybridModelState(DefaultModelState):
         num_accepted_tokens = None
         num_decode_draft_tokens_cpu = None
         common_gdn_metadata = None
+        prepared_dflash2_gdn_metadata = None
         if not for_capture:
             num_accepted_tokens = self.num_accepted_tokens_gpu.new_ones(num_reqs)
             num_accepted_tokens[: input_batch.num_reqs] = self.num_accepted_tokens_gpu[
@@ -294,11 +332,37 @@ class MambaHybridModelState(DefaultModelState):
                     ),
                 )
 
+            if (
+                self._use_dflash2_fused_gdn_metadata
+                and cudagraph_mode == CUDAGraphMode.FULL
+                and common_gdn_metadata is not None
+            ):
+                prepared_result = prepare_dflash2_gdn_group_metadata(
+                    builders_by_group=self._get_dflash2_gdn_builders(attn_groups),
+                    block_tables=block_tables,
+                    common_gdn_metadata=common_gdn_metadata,
+                    num_accepted_tokens=num_accepted_tokens,
+                    num_actual_tokens=num_tokens,
+                    descriptor=self._dflash2_gdn_group_descriptor,
+                )
+                if prepared_result is not None:
+                    (
+                        prepared_dflash2_gdn_metadata,
+                        self._dflash2_gdn_group_descriptor,
+                    ) = prepared_result
+                    if not self._dflash2_fused_gdn_metadata_logged:
+                        logger.info(
+                            "DFlash2 fused GDN metadata active for %d cache groups.",
+                            len(prepared_dflash2_gdn_metadata),
+                        )
+                        self._dflash2_fused_gdn_metadata_logged = True
+
         mamba_attn_metadata = MambaHybridAttnMetadata(
             is_prefilling=is_prefilling,
             num_accepted_tokens=num_accepted_tokens,
             num_decode_draft_tokens_cpu=num_decode_draft_tokens_cpu,
             common_gdn_metadata=common_gdn_metadata,
+            prepared_dflash2_gdn_metadata=prepared_dflash2_gdn_metadata,
         )
         attn_metadata = build_attn_metadata(
             attn_groups=attn_groups,

--- a/vllm/v1/worker/gpu/model_states/mamba_hybrid.py
+++ b/vllm/v1/worker/gpu/model_states/mamba_hybrid.py
@@ -300,7 +300,7 @@ class MambaHybridModelState(DefaultModelState):
             num_decode_draft_tokens_cpu=num_decode_draft_tokens_cpu,
             common_gdn_metadata=common_gdn_metadata,
         )
-        return build_attn_metadata(
+        attn_metadata = build_attn_metadata(
             attn_groups=attn_groups,
             num_reqs=num_reqs,
             num_tokens=num_tokens,
@@ -316,6 +316,16 @@ class MambaHybridModelState(DefaultModelState):
             model_specific_attn_metadata=mamba_attn_metadata,
             for_cudagraph_capture=for_capture,
         )
+        if common_gdn_metadata is not None:
+            # The legacy per-group builder fenced here through a GPU ``.item()``
+            # assertion. Keep one batch-level fence after every group's state
+            # contract and graph-buffer copy instead of removing the ordering
+            # edge or paying it once per GDN cache group.
+            assert (
+                common_gdn_metadata.spec_query_start_loc[-1].item()
+                == common_gdn_metadata.num_spec_decode_tokens
+            )
+        return attn_metadata
 
     def postprocess_state(
         self,

--- a/vllm/v1/worker/gpu/model_states/mamba_hybrid.py
+++ b/vllm/v1/worker/gpu/model_states/mamba_hybrid.py
@@ -121,9 +121,7 @@ class MambaHybridModelState(DefaultModelState):
             and "DFlash2DraftModel" in draft_architectures
         )
         if self._use_dflash2_common_gdn_metadata:
-            logger.info_once(
-                "DFlash2 shared GDN batch metadata fast path enabled."
-            )
+            logger.info_once("DFlash2 shared GDN batch metadata fast path enabled.")
         self._use_dflash2_fused_gdn_metadata = bool(
             self._use_dflash2_common_gdn_metadata
             and envs.VLLM_SM70_DFLASH2_FUSED_GDN_METADATA

--- a/vllm/v1/worker/gpu/model_states/mamba_hybrid.py
+++ b/vllm/v1/worker/gpu/model_states/mamba_hybrid.py
@@ -7,6 +7,7 @@ import numpy as np
 import torch
 import torch.nn as nn
 
+from vllm import envs
 from vllm.config import VllmConfig
 from vllm.config.compilation import CUDAGraphMode
 from vllm.model_executor.layers.mamba.mamba_utils import (
@@ -20,7 +21,11 @@ from vllm.v1.attention.backends.mamba2_attn import Mamba2AttentionMetadataBuilde
 from vllm.v1.core.sched.output import NewRequestData
 from vllm.v1.kv_cache_interface import KVCacheConfig, MambaSpec
 from vllm.v1.utils import CpuGpuBuffer
-from vllm.v1.worker.gpu.attn_utils import build_attn_metadata
+from vllm.v1.worker.gpu.attn_utils import (
+    CommonGDNSpecMetadata,
+    build_attn_metadata,
+    compute_common_gdn_attn_metadata,
+)
 from vllm.v1.worker.gpu.input_batch import InputBatch
 from vllm.v1.worker.gpu.mamba_align import (
     preprocess_mamba_align_fused_kernel,
@@ -39,6 +44,7 @@ class MambaHybridAttnMetadata(ModelSpecificAttnMetadata):
     is_prefilling: torch.Tensor
     num_accepted_tokens: torch.Tensor | None = None
     num_decode_draft_tokens_cpu: torch.Tensor | None = None
+    common_gdn_metadata: CommonGDNSpecMetadata | None = None
 
     def get_extra_common_attn_kwargs(
         self,
@@ -57,7 +63,7 @@ class MambaHybridAttnMetadata(ModelSpecificAttnMetadata):
             (Mamba2AttentionMetadataBuilder, GDNAttentionMetadataBuilder),
         ):
             return {}
-        return {
+        kwargs = {
             "num_accepted_tokens": None
             if self.num_accepted_tokens is None
             else self.num_accepted_tokens[:num_reqs],
@@ -65,6 +71,9 @@ class MambaHybridAttnMetadata(ModelSpecificAttnMetadata):
             if self.num_decode_draft_tokens_cpu is None
             else self.num_decode_draft_tokens_cpu[:num_reqs],
         }
+        if isinstance(attn_metadata_builder, GDNAttentionMetadataBuilder):
+            kwargs["common_gdn_metadata"] = self.common_gdn_metadata
+        return kwargs
 
 
 class MambaHybridModelState(DefaultModelState):
@@ -81,6 +90,21 @@ class MambaHybridModelState(DefaultModelState):
         self.cache_config = vllm_config.cache_config
         self.num_accepted_tokens_gpu = torch.ones(
             self.max_num_reqs, dtype=torch.int32, device=self.device
+        )
+        speculative_config = vllm_config.speculative_config
+        draft_model_config = (
+            speculative_config.draft_model_config
+            if speculative_config is not None
+            else None
+        )
+        draft_architectures: list[str] = []
+        if draft_model_config is not None:
+            draft_architectures = draft_model_config.architectures or []
+        self._use_dflash2_common_gdn_metadata = bool(
+            envs.VLLM_SM70_DFLASH2_VERIFY_FASTPATH
+            and speculative_config is not None
+            and speculative_config.use_dflash()
+            and "DFlash2DraftModel" in draft_architectures
         )
         self._align_mode = self.cache_config.mamba_cache_mode == "align"
         if self._align_mode:
@@ -228,6 +252,7 @@ class MambaHybridModelState(DefaultModelState):
         # compute them during actual (non-capture) forward execution.
         num_accepted_tokens = None
         num_decode_draft_tokens_cpu = None
+        common_gdn_metadata = None
         if not for_capture:
             num_accepted_tokens = self.num_accepted_tokens_gpu.new_ones(num_reqs)
             num_accepted_tokens[: input_batch.num_reqs] = self.num_accepted_tokens_gpu[
@@ -247,11 +272,26 @@ class MambaHybridModelState(DefaultModelState):
                     -1,
                 )
             num_decode_draft_tokens_cpu = torch.from_numpy(num_decode_draft_tokens_np)
+            if self._use_dflash2_common_gdn_metadata:
+                speculative_config = self.vllm_config.speculative_config
+                assert speculative_config is not None
+                common_gdn_metadata = compute_common_gdn_attn_metadata(
+                    num_decode_draft_tokens_cpu=num_decode_draft_tokens_cpu,
+                    query_start_loc=input_batch.query_start_loc,
+                    query_start_loc_cpu=query_start_loc_cpu,
+                    num_spec_state_tokens=(
+                        speculative_config.num_speculative_state_tokens()
+                    ),
+                    legacy_mixed_decode_routing=(
+                        envs.VLLM_SM70_MTP_LEGACY_GDN_MIXED_DECODE_ROUTING
+                    ),
+                )
 
         mamba_attn_metadata = MambaHybridAttnMetadata(
             is_prefilling=is_prefilling,
             num_accepted_tokens=num_accepted_tokens,
             num_decode_draft_tokens_cpu=num_decode_draft_tokens_cpu,
+            common_gdn_metadata=common_gdn_metadata,
         )
         return build_attn_metadata(
             attn_groups=attn_groups,

--- a/vllm/v1/worker/gpu/model_states/mamba_hybrid.py
+++ b/vllm/v1/worker/gpu/model_states/mamba_hybrid.py
@@ -10,6 +10,7 @@ import torch.nn as nn
 from vllm import envs
 from vllm.config import VllmConfig
 from vllm.config.compilation import CUDAGraphMode
+from vllm.logger import init_logger
 from vllm.model_executor.layers.mamba.mamba_utils import (
     get_conv_copy_spec,
     is_conv_state_dim_first,
@@ -37,6 +38,8 @@ from vllm.v1.worker.gpu.model_states.default import DefaultModelState
 from vllm.v1.worker.gpu.model_states.interface import ModelSpecificAttnMetadata
 from vllm.v1.worker.mamba_utils import MambaSpecDecodeGPUContext
 from vllm.v1.worker.utils import AttentionGroup
+
+logger = init_logger(__name__)
 
 
 @dataclass
@@ -106,6 +109,10 @@ class MambaHybridModelState(DefaultModelState):
             and speculative_config.use_dflash()
             and "DFlash2DraftModel" in draft_architectures
         )
+        if self._use_dflash2_common_gdn_metadata:
+            logger.info_once(
+                "DFlash2 shared GDN batch metadata fast path enabled."
+            )
         self._align_mode = self.cache_config.mamba_cache_mode == "align"
         if self._align_mode:
             self._mamba_state_idx_gpu = torch.full(

--- a/vllm/v1/worker/gpu/model_states/mamba_hybrid.py
+++ b/vllm/v1/worker/gpu/model_states/mamba_hybrid.py
@@ -42,6 +42,7 @@ from vllm.v1.worker.gpu.mamba_align import (
 from vllm.v1.worker.gpu.mm.encoder_cache import EncoderCache
 from vllm.v1.worker.gpu.model_states.default import DefaultModelState
 from vllm.v1.worker.gpu.model_states.interface import ModelSpecificAttnMetadata
+from vllm.v1.worker.gpu.spec_decode import uses_dflash_selector_engine
 from vllm.v1.worker.mamba_utils import MambaSpecDecodeGPUContext
 from vllm.v1.worker.utils import AttentionGroup
 
@@ -105,20 +106,9 @@ class MambaHybridModelState(DefaultModelState):
         self.num_accepted_tokens_gpu = torch.ones(
             self.max_num_reqs, dtype=torch.int32, device=self.device
         )
-        speculative_config = vllm_config.speculative_config
-        draft_model_config = (
-            speculative_config.draft_model_config
-            if speculative_config is not None
-            else None
-        )
-        draft_architectures: list[str] = []
-        if draft_model_config is not None:
-            draft_architectures = draft_model_config.architectures or []
         self._use_dflash2_common_gdn_metadata = bool(
             envs.VLLM_SM70_DFLASH2_VERIFY_FASTPATH
-            and speculative_config is not None
-            and speculative_config.use_dflash()
-            and "DFlash2DraftModel" in draft_architectures
+            and uses_dflash_selector_engine(vllm_config)
         )
         if self._use_dflash2_common_gdn_metadata:
             logger.info_once("DFlash2 shared GDN batch metadata fast path enabled.")

--- a/vllm/v1/worker/gpu/spec_decode/__init__.py
+++ b/vllm/v1/worker/gpu/spec_decode/__init__.py
@@ -1,8 +1,33 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+from collections.abc import Mapping
+
 import torch
 
 from vllm.config import VllmConfig
+
+
+def uses_dflash_selector_engine(vllm_config: object) -> bool:
+    """Return whether the configured DFlash algorithm exposes selector inputs.
+
+    Dispatch is based on the inference algorithm's configuration contract, not
+    a model, architecture, or checkpoint identity.
+    """
+    speculative_config = getattr(vllm_config, "speculative_config", None)
+    if (
+        speculative_config is None
+        or getattr(speculative_config, "method", None) != "dflash"
+    ):
+        return False
+    draft_model_config = getattr(speculative_config, "draft_model_config", None)
+    hf_config = getattr(draft_model_config, "hf_config", None)
+    dflash_config = getattr(hf_config, "dflash_config", None) or {}
+    if not isinstance(dflash_config, Mapping):
+        return False
+    try:
+        return int(dflash_config.get("selector_top_k", 0) or 0) > 0
+    except (TypeError, ValueError):
+        return False
 
 
 def init_speculator(vllm_config: VllmConfig, device: torch.device):
@@ -12,7 +37,7 @@ def init_speculator(vllm_config: VllmConfig, device: torch.device):
         draft_config = speculative_config.draft_model_config
         if draft_config is None:
             raise ValueError("method='dflash' requires a draft model config")
-        if "DFlash2DraftModel" in (draft_config.architectures or []):
+        if uses_dflash_selector_engine(vllm_config):
             from vllm.v1.worker.gpu.spec_decode.dflash2.speculator import (
                 DFlash2Speculator,
             )


### PR DESCRIPTION
## Purpose

Reduce selector-based DFlash verification overhead on SM70 while preserving the generic verifier fallback.

This branch is rebased directly onto current `main`. Runtime admission is based on the inference algorithm contract (`method=dflash` with a positive `selector_top_k`), SM70 capability, graph/cache mode, dtype, layout, and metadata invariants. It does not use model, architecture, or checkpoint identity.

The independently gated leaves:

- compute request classification and token offsets once per batch while keeping recurrent-state ownership per cache group;
- replace repeated cache-group state-contract pipelines with one persistent pointer-table Triton launch;
- cache only shape-specific metadata views while overwriting all backing buffers on every replay;
- remove packed-QKV rearrangement and the final GDN output copy while retaining the accepted recurrent operation order.

All four new environment gates remain default-off. Unsupported or mixed contracts fall back to the existing path.

## Audit fixes

- Removed the original model-architecture whitelist and replaced it with the selector-engine configuration contract.
- Removed the global CUDA Graph replay tracing wrapper because even a disabled wrapper adds Python overhead to every replay.
- Kept the packed verifier limited by exact hardware, dtype, contiguous-layout, pure-spec, non-DDTree, and state-cache conditions.
- Added explicit default-off coverage for every new gate.
- Fixed the rebased duplicate import and nullable shadow-validation typing found by the static gate.

## Test Plan and Result

Current rebased head:

- `108 passed` on one idle V100 across:
  - `tests/v1/spec_decode/test_dflash2.py`
  - `tests/v1/attention/test_gdn_metadata_builder.py`
  - `tests/kernels/test_fused_sigmoid_gating_delta_rule.py`
- Changed-file pre-commit passes completely, including Ruff check/format, mypy for Python 3.10, typos, SPDX, environment-default validation, forbidden-import checks, and the new-`torch.cuda` API gate.
- `git diff --check` passes.

No model end-to-end rerun was added during audit. The retained matched evidence reports:

- metadata microbenchmark, block width 8 and ten GDN groups: legacy B1 p50 `5.360 ms` versus fused/cached p50 `0.131 ms`;
- matched TP4 graph endpoint: `46.8045 -> 35.0308 ms` per verification round, `+34.92%` steady-decode throughput;
- all 430 compared token IDs and SHA256 were identical, with no acceptance-length regression;
- production-shape packed-verifier tests are bitwise equal for output and persistent state across B1/B2, draft 3/7, and FP16/FP32 state.

The optimizations remain explicit opt-ins until broader workload coverage justifies changing defaults.

## AI Assistance

OpenAI Codex assisted with source audit, rebase conflict repair, tests, and documentation.