### PR TITLE
[Kernel] Recover Qwen3.8 FP8/NVFP4 SM70 decode

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -396,6 +396,7 @@ if(VLLM_GPU_LANG STREQUAL "CUDA")
       "${VLLM_SM70_TURBOMIND_LMDEPLOY_ROOT}/src/turbomind/kernels/gemm/kernel/sm70_884_8.cu"
       "${VLLM_SM70_TURBOMIND_LMDEPLOY_ROOT}/src/turbomind/kernels/gemm/kernel/sm70_884_16.cu"
       "${VLLM_SM70_TURBOMIND_ROOT}/ops/tm_registry_sm70.cu"
+      "${VLLM_SM70_TURBOMIND_ROOT}/ops/fp8_qpn8_sm70.cu"
       "${VLLM_SM70_TURBOMIND_ROOT}/ops/awq_sm70_gemm.cu")
 
     set_gencode_flags_for_srcs(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -397,6 +397,7 @@ if(VLLM_GPU_LANG STREQUAL "CUDA")
       "${VLLM_SM70_TURBOMIND_LMDEPLOY_ROOT}/src/turbomind/kernels/gemm/kernel/sm70_884_16.cu"
       "${VLLM_SM70_TURBOMIND_ROOT}/ops/tm_registry_sm70.cu"
       "${VLLM_SM70_TURBOMIND_ROOT}/ops/fp8_qpn8_sm70.cu"
+      "${VLLM_SM70_TURBOMIND_ROOT}/ops/nvfp4_qpn4_sm70.cu"
       "${VLLM_SM70_TURBOMIND_ROOT}/ops/awq_sm70_gemm.cu")
 
     set_gencode_flags_for_srcs(
@@ -708,6 +709,43 @@ define_extension_target(
 target_compile_definitions(_C PRIVATE CUTLASS_ENABLE_DIRECT_CUDA_DRIVER_CALL=1)
 if(VLLM_REGISTER_BASIC_ACTIVATION_IN_C)
   target_compile_definitions(_C PRIVATE VLLM_REGISTER_BASIC_ACTIVATION_IN_C=1)
+endif()
+
+# Keep the accepted SM70 chunked sampler in a separate wheel module so adding
+# it does not perturb the quality- and speed-frozen primary vllm._C module.
+if(VLLM_GPU_LANG STREQUAL "CUDA" AND SM70_TURBOMIND_ARCHS)
+  set(VLLM_SM70_SAMPLER_FRAGMENT_SRCS
+    "csrc/sm70_turbomind/ops/sm70_top20_philox_fragment.cpp"
+    "csrc/sm70_turbomind/ops/sm70_top20_philox_sampler.cu")
+  set_gencode_flags_for_srcs(
+    SRCS "${VLLM_SM70_SAMPLER_FRAGMENT_SRCS}"
+    CUDA_ARCHS "${SM70_TURBOMIND_ARCHS}")
+  define_extension_target(
+    _sm70_sampler_C
+    DESTINATION vllm
+    LANGUAGE CUDA
+    SOURCES ${VLLM_SM70_SAMPLER_FRAGMENT_SRCS}
+    COMPILE_FLAGS ${VLLM_GPU_FLAGS}
+    ARCHITECTURES ${VLLM_GPU_ARCHES}
+    WITH_SOABI)
+  set_target_properties(_sm70_sampler_C PROPERTIES
+    CXX_STANDARD 17
+    CXX_STANDARD_REQUIRED ON
+    CXX_EXTENSIONS OFF
+    CUDA_STANDARD 17
+    CUDA_STANDARD_REQUIRED ON
+    CUDA_EXTENSIONS OFF)
+  target_compile_definitions(_sm70_sampler_C PRIVATE
+    TORCH_API_INCLUDE_EXTENSION_H
+    $<$<COMPILE_LANGUAGE:CUDA>:__CUDA_NO_HALF_OPERATORS__>
+    $<$<COMPILE_LANGUAGE:CUDA>:__CUDA_NO_HALF_CONVERSIONS__>
+    $<$<COMPILE_LANGUAGE:CUDA>:__CUDA_NO_BFLOAT16_CONVERSIONS__>
+    $<$<COMPILE_LANGUAGE:CUDA>:__CUDA_NO_HALF2_OPERATORS__>)
+  target_compile_options(_sm70_sampler_C PRIVATE
+    $<$<COMPILE_LANGUAGE:CXX>:-UNDEBUG>
+    $<$<COMPILE_LANGUAGE:CUDA>:-UNDEBUG;-lineinfo>)
+  target_link_libraries(_sm70_sampler_C PRIVATE
+    "${TORCH_INSTALL_PREFIX}/lib/libtorch_python.so")
 endif()
 
 if(VLLM_GPU_LANG STREQUAL "CUDA" OR VLLM_GPU_LANG STREQUAL "HIP")

--- a/benchmarks/benchmark_sm70_fp8_qpn8.py
+++ b/benchmarks/benchmark_sm70_fp8_qpn8.py
@@ -1,0 +1,714 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Race experimental QPN8 against TurboMind on real TP-local FP8 weights.
+
+The benchmark is deliberately operator-only: it does not change model
+dispatch. It covers the exact Qwen3.8-27B-FP8 TP4 decode shapes at M=1, 2, 4,
+and 8, and measures eager launches separately from CUDA Graph replay.
+
+The production gate/up GEMM has a fused SiLU epilogue. ``gate_up_raw`` is
+therefore opt-in and diagnostic only; its raw-GEMM timing is not an end-to-end
+replacement claim.
+"""
+
+from __future__ import annotations
+
+import argparse
+import gc
+import json
+import math
+import statistics
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+import torch
+import vllm._C  # noqa: F401
+from safetensors import safe_open
+
+from vllm import _sm70_ops as sm70_ops
+
+_KORDER8 = [0, 2, 4, 6, 1, 3, 5, 7, 8, 10, 12, 14, 9, 11, 13, 15]
+_DEFAULT_CASES = ("down", "gdn_in", "output", "full_qkv")
+_ALL_CASES = (*_DEFAULT_CASES, "gate_up_raw", "gate_up_fused")
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--model",
+        type=Path,
+        default=Path("/home/ymzx/models/Qwen3.8-27B-FP8"),
+    )
+    parser.add_argument("--json-out", type=Path, required=True)
+    parser.add_argument(
+        "--qpn8-library",
+        type=Path,
+        help="Optional standalone library built from fp8_qpn8_sm70.cu.",
+    )
+    parser.add_argument("--device", default="cuda:0")
+    parser.add_argument("--tp-size", type=int, default=4)
+    parser.add_argument("--tp-rank", type=int, default=0)
+    parser.add_argument("--m", type=int, nargs="+", default=[1, 2, 4, 8])
+    parser.add_argument(
+        "--cases", choices=_ALL_CASES, nargs="+", default=list(_DEFAULT_CASES)
+    )
+    parser.add_argument("--split-k", type=int, nargs="+", default=[4, 8, 16, 32])
+    parser.add_argument("--nacc", type=int, nargs="+", default=[1, 2])
+    parser.add_argument(
+        "--decoder", choices=("scalar", "fast"), nargs="+", default=["scalar", "fast"]
+    )
+    parser.add_argument(
+        "--prefetch", choices=("off", "on"), nargs="+", default=["off", "on"]
+    )
+    parser.add_argument("--warmup", type=int, default=10)
+    parser.add_argument("--iters", type=int, default=100)
+    parser.add_argument("--trials", type=int, default=5)
+    parser.add_argument(
+        "--cache-state",
+        choices=("warm", "cold"),
+        nargs="+",
+        default=["warm", "cold"],
+    )
+    parser.add_argument("--cache-scrub-mib", type=int, default=64)
+    parser.add_argument("--seed", type=int, default=1234)
+    parser.add_argument("--relative-l2-limit", type=float, default=5e-3)
+    parser.add_argument("--cosine-limit", type=float, default=0.999)
+    return parser.parse_args()
+
+
+def _load_keys(model: Path, keys: list[str]) -> dict[str, torch.Tensor]:
+    index = json.loads((model / "model.safetensors.index.json").read_text())
+    weight_map: dict[str, str] = index["weight_map"]
+    by_file: dict[str, list[str]] = {}
+    for key in keys:
+        by_file.setdefault(weight_map[key], []).append(key)
+
+    result: dict[str, torch.Tensor] = {}
+    for filename, file_keys in by_file.items():
+        with safe_open(model / filename, framework="pt", device="cpu") as handle:
+            for key in file_keys:
+                result[key] = handle.get_tensor(key)
+    return result
+
+
+def _weight_keys(prefix: str) -> tuple[str, str]:
+    return f"{prefix}.weight", f"{prefix}.weight_scale_inv"
+
+
+def _column_shard_raw(
+    weight: torch.Tensor,
+    scales: torch.Tensor,
+    tp_size: int,
+    tp_rank: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    n = weight.shape[0]
+    if n % tp_size:
+        raise ValueError(f"N={n} is not divisible by TP={tp_size}")
+    begin = tp_rank * (n // tp_size)
+    end = begin + n // tp_size
+    scale_begin = begin // 128
+    scale_end = math.ceil(end / 128)
+    raw = weight.view(torch.uint8)[begin:end].contiguous()
+    return raw, scales[scale_begin:scale_end].contiguous()
+
+
+def _row_shard_raw(
+    weight: torch.Tensor,
+    scales: torch.Tensor,
+    tp_size: int,
+    tp_rank: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    k = weight.shape[1]
+    if k % tp_size:
+        raise ValueError(f"K={k} is not divisible by TP={tp_size}")
+    begin = tp_rank * (k // tp_size)
+    end = begin + k // tp_size
+    scale_begin = begin // 128
+    scale_end = math.ceil(end / 128)
+    raw = weight.view(torch.uint8)[:, begin:end].contiguous()
+    return raw, scales[:, scale_begin:scale_end].contiguous()
+
+
+def _load_case(
+    model: Path,
+    case: str,
+    tp_size: int,
+    tp_rank: int,
+    device: torch.device,
+) -> tuple[torch.Tensor, torch.Tensor, str]:
+    root = "model.language_model.layers"
+    if case == "down":
+        prefixes = [f"{root}.1.mlp.down_proj"]
+        shard = "row"
+        note = "production down_proj TP row shard"
+    elif case == "gdn_in":
+        prefixes = [
+            f"{root}.1.linear_attn.in_proj_qkv",
+            f"{root}.1.linear_attn.in_proj_z",
+        ]
+        shard = "column"
+        note = "production GDN qkv+z TP column shards concatenated"
+    elif case == "output":
+        prefixes = [f"{root}.1.linear_attn.out_proj"]
+        shard = "row"
+        note = "production GDN/full-attention output TP row-shard shape"
+    elif case == "full_qkv":
+        prefixes = [
+            f"{root}.3.self_attn.q_proj",
+            f"{root}.3.self_attn.k_proj",
+            f"{root}.3.self_attn.v_proj",
+        ]
+        shard = "column"
+        note = "production full-attention q+k+v TP column shards concatenated"
+    elif case in ("gate_up_raw", "gate_up_fused"):
+        prefixes = [
+            f"{root}.1.mlp.gate_proj",
+            f"{root}.1.mlp.up_proj",
+        ]
+        shard = "column"
+        note = (
+            "production gate+up GEMM with fused SiLU-and-multiply"
+            if case == "gate_up_fused"
+            else "diagnostic raw gate+up GEMM; production has fused SiLU epilogue"
+        )
+    else:
+        raise ValueError(f"unknown case: {case}")
+
+    keys = [key for prefix in prefixes for key in _weight_keys(prefix)]
+    loaded = _load_keys(model, keys)
+    raw_parts: list[torch.Tensor] = []
+    scale_parts: list[torch.Tensor] = []
+    fp8_dtype: torch.dtype | None = None
+    for prefix in prefixes:
+        weight_key, scale_key = _weight_keys(prefix)
+        weight = loaded[weight_key]
+        scales = loaded[scale_key].float()
+        if fp8_dtype is None:
+            fp8_dtype = weight.dtype
+        elif weight.dtype != fp8_dtype:
+            raise ValueError("concatenated weights have different dtypes")
+        if shard == "column":
+            raw, scale = _column_shard_raw(weight, scales, tp_size, tp_rank)
+        else:
+            raw, scale = _row_shard_raw(weight, scales, tp_size, tp_rank)
+        raw_parts.append(raw)
+        scale_parts.append(scale)
+
+    raw = torch.cat(raw_parts, dim=0) if len(raw_parts) > 1 else raw_parts[0]
+    scales = torch.cat(scale_parts, dim=0) if len(scale_parts) > 1 else scale_parts[0]
+    assert fp8_dtype is not None
+    qweight = raw.to(device, non_blocking=False).view(fp8_dtype).contiguous()
+    return qweight, scales.to(device).contiguous(), note
+
+
+def _qpn8_prepack(raw_weight: torch.Tensor) -> torch.Tensor:
+    """[N,K] uint8 -> [tile N/32][group K/16][lane 32][16B]."""
+    n, k = raw_weight.shape
+    if n % 32 or k % 16:
+        raise ValueError(f"QPN8 packing requires N%32=K%16=0, got N={n} K={k}")
+    device = raw_weight.device
+    tiles, groups = n // 32, k // 16
+    lane = torch.arange(32, device=device)
+    col = ((lane >> 2) & 3) * 8 + (lane & 3) + ((lane & 16) > 0).long() * 4
+    korder = torch.tensor(_KORDER8, device=device)
+    group = torch.arange(groups, device=device)
+    kidx = group[:, None] * 16 + korder[None, :]
+    packed = torch.empty((tiles, groups, 32, 16), dtype=torch.uint8, device=device)
+    # Bound the temporary expanded index tensors for the 44-MiB projections.
+    tiles_per_chunk = max(1, 36864 // max(groups, 1))
+    for tile_begin in range(0, tiles, tiles_per_chunk):
+        tile_end = min(tile_begin + tiles_per_chunk, tiles)
+        tile_count = tile_end - tile_begin
+        ncol = (
+            torch.arange(tile_begin, tile_end, device=device)[:, None] * 32
+            + col[None, :]
+        )
+        packed[tile_begin:tile_end] = raw_weight[
+            ncol.view(tile_count, 1, 32, 1).expand(tile_count, groups, 32, 16),
+            kidx.view(1, groups, 1, 16).expand(tile_count, groups, 32, 16),
+        ]
+    return packed.view(-1).contiguous()
+
+
+def _qpn8_group_scales(scales: torch.Tensor, n: int, k: int) -> torch.Tensor:
+    expected = (math.ceil(n / 128), math.ceil(k / 128))
+    if tuple(scales.shape) != expected or n % 128 or k % 128:
+        raise ValueError(
+            f"QPN8 scales need exact 128x128 blocks, got {tuple(scales.shape)} "
+            f"for N={n}, K={k}"
+        )
+    return (
+        scales.t()
+        .reshape(k // 128, n // 128)
+        .repeat_interleave(4, dim=1)
+        .mul(256.0)
+        .half()
+        .contiguous()
+    )
+
+
+def _dequantized_weight(qweight: torch.Tensor, scales: torch.Tensor) -> torch.Tensor:
+    n, k = qweight.shape
+    expanded = scales.repeat_interleave(128, 0).repeat_interleave(128, 1)
+    return qweight.float().mul(expanded[:n, :k])
+
+
+def _error_stats(actual: torch.Tensor, reference: torch.Tensor) -> dict[str, Any]:
+    actual_f32 = actual.float()
+    reference_f32 = reference.float()
+    delta = actual_f32 - reference_f32
+    ref_norm = torch.linalg.vector_norm(reference_f32).clamp_min(1e-12)
+    relative_l2 = torch.linalg.vector_norm(delta) / ref_norm
+    cosine = torch.nn.functional.cosine_similarity(
+        actual_f32.flatten(), reference_f32.flatten(), dim=0
+    )
+    return {
+        "finite": bool(torch.isfinite(actual).all().item()),
+        "max_abs": float(delta.abs().max().item()),
+        "mean_abs": float(delta.abs().mean().item()),
+        "relative_l2": float(relative_l2.item()),
+        "cosine": float(cosine.item()),
+    }
+
+
+def _event_trials(
+    launch: Callable[[], None],
+    warmup: int,
+    iters: int,
+    trials: int,
+    cache_scrub: torch.Tensor | None,
+) -> dict[str, float]:
+    for _ in range(warmup):
+        if cache_scrub is not None:
+            cache_scrub.add_(1)
+        launch()
+    torch.cuda.synchronize()
+    samples_us: list[float] = []
+    for _ in range(trials):
+        if cache_scrub is None:
+            start = torch.cuda.Event(enable_timing=True)
+            end = torch.cuda.Event(enable_timing=True)
+            start.record()
+            for _ in range(iters):
+                launch()
+            end.record()
+            end.synchronize()
+            samples_us.append(float(start.elapsed_time(end) * 1000.0 / iters))
+        else:
+            # Scrub more than V100's L2 immediately before each call, while
+            # the event pair measures only the tested operator.
+            starts = [torch.cuda.Event(enable_timing=True) for _ in range(iters)]
+            ends = [torch.cuda.Event(enable_timing=True) for _ in range(iters)]
+            for start, end in zip(starts, ends):
+                cache_scrub.add_(1)
+                start.record()
+                launch()
+                end.record()
+            ends[-1].synchronize()
+            samples_us.append(
+                float(
+                    statistics.mean(
+                        start.elapsed_time(end) * 1000.0
+                        for start, end in zip(starts, ends)
+                    )
+                )
+            )
+    ordered = sorted(samples_us)
+    return {
+        "median_us": float(statistics.median(samples_us)),
+        "min_us": ordered[0],
+        "p10_us": ordered[max(0, math.ceil(0.1 * len(ordered)) - 1)],
+        "p90_us": ordered[min(len(ordered) - 1, math.ceil(0.9 * len(ordered)) - 1)],
+        "max_us": ordered[-1],
+    }
+
+
+def _benchmark_eager(
+    launch: Callable[[], None],
+    warmup: int,
+    iters: int,
+    trials: int,
+    cache_scrub: torch.Tensor | None,
+) -> dict[str, Any]:
+    timing = _event_trials(launch, warmup, iters, trials, cache_scrub)
+    launch()
+    torch.cuda.synchronize()
+    return {"timing": timing, "replay_max_abs": None}
+
+
+def _benchmark_graph(
+    launch: Callable[[], None],
+    output: torch.Tensor,
+    warmup: int,
+    iters: int,
+    trials: int,
+    cache_scrub: torch.Tensor | None,
+) -> dict[str, Any]:
+    capture_stream = torch.cuda.Stream(device=output.device)
+    capture_stream.wait_stream(torch.cuda.current_stream(output.device))
+    with torch.cuda.stream(capture_stream):
+        for _ in range(max(warmup, 3)):
+            launch()
+    capture_stream.synchronize()
+
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph, stream=capture_stream):
+        launch()
+    torch.cuda.synchronize(output.device)
+
+    timing = _event_trials(graph.replay, warmup, iters, trials, cache_scrub)
+    graph.replay()
+    torch.cuda.synchronize(output.device)
+    first = output.clone()
+    graph.replay()
+    torch.cuda.synchronize(output.device)
+    replay_max_abs = float((output - first).abs().max().item())
+    del first, graph, capture_stream
+    gc.collect()
+    return {"timing": timing, "replay_max_abs": replay_max_abs}
+
+
+def _derived_metrics(
+    timing: dict[str, float], m: int, n: int, k: int, bytes_per_call: int
+) -> dict[str, float]:
+    seconds = timing["median_us"] * 1e-6
+    return {
+        "effective_gbps": float(bytes_per_call / seconds / 1e9),
+        "useful_tflops": float(2 * m * n * k / seconds / 1e12),
+    }
+
+
+def _quality_pass(
+    stats: dict[str, Any], relative_l2_limit: float, cosine_limit: float
+) -> bool:
+    return bool(
+        stats["finite"]
+        and stats["relative_l2"] <= relative_l2_limit
+        and stats["cosine"] >= cosine_limit
+    )
+
+
+def _run_case(args: argparse.Namespace, case: str) -> dict[str, Any]:
+    device = torch.device(args.device)
+    qweight, scales, note = _load_case(
+        args.model, case, args.tp_size, args.tp_rank, device
+    )
+    n, k = (int(dim) for dim in qweight.shape)
+    gated_silu = case == "gate_up_fused"
+    output_n = n // 2 if gated_silu else n
+    raw = qweight.view(torch.uint8)
+    codes = _qpn8_prepack(raw)
+    group_scales = _qpn8_group_scales(scales, n, k)
+    tm_weight, tm_scales, meta = sm70_ops.fp8_sm70_prepare(
+        qweight, scales, 128, gated_silu
+    )
+    k_ld, q_ld = (int(value) for value in meta.tolist())
+    reference_weight = _dequantized_weight(qweight, scales)
+    cache_scrub = torch.empty(
+        args.cache_scrub_mib * 1024 * 1024,
+        dtype=torch.uint8,
+        device=device,
+    )
+    torch.cuda.synchronize(device)
+
+    case_result: dict[str, Any] = {
+        "case": case,
+        "note": note,
+        "shape": {"n": n, "k": k, "output_n": output_n},
+        "qweight_dtype": str(qweight.dtype),
+        "scale_dtype": str(scales.dtype),
+        "tm_meta": {"k_ld": k_ld, "q_ld": q_ld},
+        "packed_bytes": int(codes.numel()),
+        "group_scale_shape": list(group_scales.shape),
+        "rows": [],
+    }
+
+    valid_configs = [
+        (split_k, nacc, decoder == "fast", prefetch == "on")
+        for split_k in args.split_k
+        for nacc in args.nacc
+        for decoder in args.decoder
+        for prefetch in args.prefetch
+        if (k // 16) % split_k == 0
+        and not (prefetch == "on" and decoder != "fast")
+        and not (gated_silu and split_k == 32)
+    ]
+    for m in args.m:
+        torch.manual_seed(args.seed + m)
+        inputs = torch.randn((m, k), device=device, dtype=torch.float16).mul_(0.1)
+        reference_raw = inputs.float().matmul(reference_weight.t())
+        if gated_silu:
+            gate, up = reference_raw.chunk(2, dim=1)
+            reference = (torch.nn.functional.silu(gate) * up).half()
+        else:
+            reference = reference_raw.half()
+
+        tm_out = torch.empty((m, output_n), device=device, dtype=torch.float16)
+
+        def launch_tm(
+            tm_out: torch.Tensor = tm_out,
+            inputs: torch.Tensor = inputs,
+            tm_weight: torch.Tensor = tm_weight,
+            tm_scales: torch.Tensor = tm_scales,
+        ) -> None:
+            sm70_ops.fp8_gemm_sm70_out(
+                tm_out,
+                inputs,
+                tm_weight,
+                tm_scales,
+                128,
+                k_ld,
+                q_ld,
+                gated_silu,
+            )
+
+        launch_tm()
+        torch.cuda.synchronize(device)
+        tm_quality = _error_stats(tm_out, reference)
+        tm_bytes = n * k + 2 * (k // 128) * n + 2 * m * (output_n + k)
+        for cache_state in args.cache_state:
+            scrub = cache_scrub if cache_state == "cold" else None
+            for mode, benchmark in (
+                ("eager", _benchmark_eager),
+                ("graph", _benchmark_graph),
+            ):
+                measured = (
+                    benchmark(
+                        launch_tm,
+                        args.warmup,
+                        args.iters,
+                        args.trials,
+                        scrub,
+                    )
+                    if mode == "eager"
+                    else benchmark(
+                        launch_tm,
+                        tm_out,
+                        args.warmup,
+                        args.iters,
+                        args.trials,
+                        scrub,
+                    )
+                )
+                case_result["rows"].append(
+                    {
+                        "backend": "turbomind_current",
+                        "mode": mode,
+                        "cache_state": cache_state,
+                        "m": m,
+                        "config": None,
+                        "quality": tm_quality,
+                        "quality_pass": _quality_pass(
+                            tm_quality, args.relative_l2_limit, args.cosine_limit
+                        ),
+                        **measured,
+                        **_derived_metrics(measured["timing"], m, n, k, tm_bytes),
+                    }
+                )
+
+        for split_k, nacc, fast_decoder, prefetch_codes in valid_configs:
+            qpn_out = torch.empty((m, output_n), device=device, dtype=torch.float16)
+
+            def launch_qpn(
+                split_k: int = split_k,
+                nacc: int = nacc,
+                fast_decoder: bool = fast_decoder,
+                prefetch_codes: bool = prefetch_codes,
+                qpn_out: torch.Tensor = qpn_out,
+                inputs: torch.Tensor = inputs,
+                codes: torch.Tensor = codes,
+                group_scales: torch.Tensor = group_scales,
+                gated_silu: bool = gated_silu,
+            ) -> None:
+                if gated_silu:
+                    sm70_ops.fp8_qpn8_gated_pair_sm70_out(
+                        qpn_out,
+                        inputs,
+                        codes,
+                        group_scales,
+                        split_k,
+                        nacc,
+                        fast_decoder,
+                        prefetch_codes,
+                    )
+                else:
+                    sm70_ops.fp8_qpn8_gemm_sm70_out(
+                        qpn_out,
+                        inputs,
+                        codes,
+                        group_scales,
+                        split_k,
+                        nacc,
+                        fast_decoder,
+                        prefetch_codes,
+                    )
+
+            launch_qpn()
+            torch.cuda.synchronize(device)
+            quality = _error_stats(qpn_out, reference)
+            quality_pass = _quality_pass(
+                quality, args.relative_l2_limit, args.cosine_limit
+            )
+            config = {
+                "split_k": split_k,
+                "nacc": nacc,
+                "decoder": "fast" if fast_decoder else "scalar",
+                "prefetch": prefetch_codes,
+            }
+            qpn_bytes = n * k + 2 * (k // 128) * (n // 32) + 2 * m * (n + k)
+            if gated_silu:
+                qpn_bytes -= 2 * m * (n - output_n)
+            for cache_state in args.cache_state:
+                scrub = cache_scrub if cache_state == "cold" else None
+                for mode, benchmark in (
+                    ("eager", _benchmark_eager),
+                    ("graph", _benchmark_graph),
+                ):
+                    measured = (
+                        benchmark(
+                            launch_qpn,
+                            args.warmup,
+                            args.iters,
+                            args.trials,
+                            scrub,
+                        )
+                        if mode == "eager"
+                        else benchmark(
+                            launch_qpn,
+                            qpn_out,
+                            args.warmup,
+                            args.iters,
+                            args.trials,
+                            scrub,
+                        )
+                    )
+                    case_result["rows"].append(
+                        {
+                            "backend": "qpn8_experimental",
+                            "mode": mode,
+                            "cache_state": cache_state,
+                            "m": m,
+                            "config": config,
+                            "quality": quality,
+                            "quality_pass": quality_pass,
+                            **measured,
+                            **_derived_metrics(measured["timing"], m, n, k, qpn_bytes),
+                        }
+                    )
+
+            del qpn_out
+
+        del inputs, reference_raw, reference, tm_out
+
+    del (
+        reference_weight,
+        tm_weight,
+        tm_scales,
+        codes,
+        group_scales,
+        qweight,
+        scales,
+        cache_scrub,
+    )
+    torch.cuda.empty_cache()
+    gc.collect()
+    return case_result
+
+
+def _summarize(cases: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    summary: list[dict[str, Any]] = []
+    for case in cases:
+        rows: list[dict[str, Any]] = case["rows"]
+        for m in sorted({row["m"] for row in rows}):
+            for cache_state in sorted({row["cache_state"] for row in rows}):
+                for mode in ("eager", "graph"):
+                    current = next(
+                        row
+                        for row in rows
+                        if row["m"] == m
+                        and row["mode"] == mode
+                        and row["cache_state"] == cache_state
+                        and row["backend"] == "turbomind_current"
+                    )
+                    candidates = [
+                        row
+                        for row in rows
+                        if row["m"] == m
+                        and row["mode"] == mode
+                        and row["cache_state"] == cache_state
+                        and row["backend"] == "qpn8_experimental"
+                        and row["quality_pass"]
+                        and (row["replay_max_abs"] in (None, 0.0))
+                    ]
+                    best = min(candidates, key=lambda row: row["timing"]["median_us"])
+                    current_us = current["timing"]["median_us"]
+                    best_us = best["timing"]["median_us"]
+                    summary.append(
+                        {
+                            "case": case["case"],
+                            "shape": case["shape"],
+                            "m": m,
+                            "mode": mode,
+                            "cache_state": cache_state,
+                            "current_us": current_us,
+                            "best_qpn8_us": best_us,
+                            "speedup": current_us / best_us,
+                            "best_config": best["config"],
+                            "best_effective_gbps": best["effective_gbps"],
+                            "best_useful_tflops": best["useful_tflops"],
+                            "best_quality": best["quality"],
+                        }
+                    )
+    return summary
+
+
+def main() -> int:
+    args = _parse_args()
+    if args.qpn8_library is not None:
+        torch.ops.load_library(str(args.qpn8_library.resolve()))
+    if not torch.cuda.is_available():
+        raise RuntimeError("CUDA is required")
+    device = torch.device(args.device)
+    if torch.cuda.get_device_capability(device) != (7, 0):
+        raise RuntimeError("This benchmark requires an SM70/V100 device")
+    if not hasattr(torch.ops._C, "fp8_qpn8_gemm_sm70_out"):
+        raise RuntimeError("Missing _C::fp8_qpn8_gemm_sm70_out; build this source tree")
+    if args.tp_size <= 0 or not 0 <= args.tp_rank < args.tp_size:
+        raise ValueError("invalid TP size/rank")
+    if any(m < 1 or m > 8 for m in args.m):
+        raise ValueError("QPN8 operator supports M=1..8")
+    if args.warmup < 1 or args.iters < 1 or args.trials < 1 or args.cache_scrub_mib < 1:
+        raise ValueError("warmup, iters, trials, and cache scrub size must be positive")
+
+    torch.cuda.set_device(device)
+    cases = [_run_case(args, case) for case in args.cases]
+    summary = _summarize(cases)
+    payload = {
+        "environment": {
+            "model": str(args.model),
+            "device": torch.cuda.get_device_name(device),
+            "capability": list(torch.cuda.get_device_capability(device)),
+            "torch": torch.__version__,
+            "torch_cuda": torch.version.cuda,
+            "tp_size": args.tp_size,
+            "tp_rank": args.tp_rank,
+            "m": args.m,
+            "warmup": args.warmup,
+            "iters": args.iters,
+            "trials": args.trials,
+            "cache_state": args.cache_state,
+            "cache_scrub_mib": args.cache_scrub_mib,
+            "seed": args.seed,
+        },
+        "summary": summary,
+        "cases": cases,
+    }
+    args.json_out.parent.mkdir(parents=True, exist_ok=True)
+    args.json_out.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    print(json.dumps(summary, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmarks/benchmark_sm70_fp8_qpn8.py
+++ b/benchmarks/benchmark_sm70_fp8_qpn8.py
@@ -283,7 +283,7 @@ def _event_trials(
         if cache_scrub is not None:
             cache_scrub.add_(1)
         launch()
-    torch.cuda.synchronize()
+    torch.accelerator.synchronize()
     samples_us: list[float] = []
     for _ in range(trials):
         if cache_scrub is None:
@@ -333,7 +333,7 @@ def _benchmark_eager(
 ) -> dict[str, Any]:
     timing = _event_trials(launch, warmup, iters, trials, cache_scrub)
     launch()
-    torch.cuda.synchronize()
+    torch.accelerator.synchronize()
     return {"timing": timing, "replay_max_abs": None}
 
 
@@ -355,14 +355,14 @@ def _benchmark_graph(
     graph = torch.cuda.CUDAGraph()
     with torch.cuda.graph(graph, stream=capture_stream):
         launch()
-    torch.cuda.synchronize(output.device)
+    torch.accelerator.synchronize(output.device)
 
     timing = _event_trials(graph.replay, warmup, iters, trials, cache_scrub)
     graph.replay()
-    torch.cuda.synchronize(output.device)
+    torch.accelerator.synchronize(output.device)
     first = output.clone()
     graph.replay()
-    torch.cuda.synchronize(output.device)
+    torch.accelerator.synchronize(output.device)
     replay_max_abs = float((output - first).abs().max().item())
     del first, graph, capture_stream
     gc.collect()
@@ -398,8 +398,20 @@ def _run_case(args: argparse.Namespace, case: str) -> dict[str, Any]:
     gated_silu = case == "gate_up_fused"
     output_n = n // 2 if gated_silu else n
     raw = qweight.view(torch.uint8)
-    codes = _qpn8_prepack(raw)
-    group_scales = _qpn8_group_scales(scales, n, k)
+    reference_codes = _qpn8_prepack(raw)
+    reference_group_scales = _qpn8_group_scales(scales, n, k)
+    if hasattr(torch.ops._C, "fp8_qpn8_prepare_sm70"):
+        codes, group_scales = sm70_ops.fp8_qpn8_prepare_sm70(qweight, scales)
+        prepare_matches_reference = bool(
+            torch.equal(codes.view(-1), reference_codes)
+            and torch.equal(group_scales, reference_group_scales)
+        )
+        if not prepare_matches_reference:
+            raise RuntimeError("source QPN8 prepare disagrees with Python reference")
+    else:
+        codes = reference_codes
+        group_scales = reference_group_scales
+        prepare_matches_reference = None
     tm_weight, tm_scales, meta = sm70_ops.fp8_sm70_prepare(
         qweight, scales, 128, gated_silu
     )
@@ -410,7 +422,7 @@ def _run_case(args: argparse.Namespace, case: str) -> dict[str, Any]:
         dtype=torch.uint8,
         device=device,
     )
-    torch.cuda.synchronize(device)
+    torch.accelerator.synchronize(device)
 
     case_result: dict[str, Any] = {
         "case": case,
@@ -421,6 +433,7 @@ def _run_case(args: argparse.Namespace, case: str) -> dict[str, Any]:
         "tm_meta": {"k_ld": k_ld, "q_ld": q_ld},
         "packed_bytes": int(codes.numel()),
         "group_scale_shape": list(group_scales.shape),
+        "source_prepare_matches_reference": prepare_matches_reference,
         "rows": [],
     }
 
@@ -464,7 +477,7 @@ def _run_case(args: argparse.Namespace, case: str) -> dict[str, Any]:
             )
 
         launch_tm()
-        torch.cuda.synchronize(device)
+        torch.accelerator.synchronize(device)
         tm_quality = _error_stats(tm_out, reference)
         tm_bytes = n * k + 2 * (k // 128) * n + 2 * m * (output_n + k)
         for cache_state in args.cache_state:
@@ -545,7 +558,7 @@ def _run_case(args: argparse.Namespace, case: str) -> dict[str, Any]:
                     )
 
             launch_qpn()
-            torch.cuda.synchronize(device)
+            torch.accelerator.synchronize(device)
             quality = _error_stats(qpn_out, reference)
             quality_pass = _quality_pass(
                 quality, args.relative_l2_limit, args.cosine_limit
@@ -607,11 +620,13 @@ def _run_case(args: argparse.Namespace, case: str) -> dict[str, Any]:
         tm_scales,
         codes,
         group_scales,
+        reference_codes,
+        reference_group_scales,
         qweight,
         scales,
         cache_scrub,
     )
-    torch.cuda.empty_cache()
+    torch.accelerator.empty_cache()
     gc.collect()
     return case_result
 
@@ -681,7 +696,7 @@ def main() -> int:
     if args.warmup < 1 or args.iters < 1 or args.trials < 1 or args.cache_scrub_mib < 1:
         raise ValueError("warmup, iters, trials, and cache scrub size must be positive")
 
-    torch.cuda.set_device(device)
+    torch.accelerator.set_device_index(device.index or 0)
     cases = [_run_case(args, case) for case in args.cases]
     summary = _summarize(cases)
     payload = {

--- a/benchmarks/benchmark_sm70_model_tokens.py
+++ b/benchmarks/benchmark_sm70_model_tokens.py
@@ -500,7 +500,10 @@ def _sm70_tune_policy() -> dict[str, Any]:
     }
 
 
-def _sm70_turbomind_policy() -> dict[str, Any]:
+def _sm70_turbomind_policy(
+    max_num_seqs: int | None = None,
+    speculative_enabled: bool = False,
+) -> dict[str, Any]:
     awq_turbomind = _env_bool("VLLM_SM70_AWQ_TURBOMIND", True)
     awq_tune_raw = os.environ.get("VLLM_SM70_AWQ_TUNE_SMALL_SHAPES")
     awq_tune0_pinned = awq_tune_raw == "0"
@@ -521,6 +524,7 @@ def _sm70_turbomind_policy() -> dict[str, Any]:
         "VLLM_SM70_FP8_PREFILL_EXACT_DENSE",
         True,
     )
+    fp8_qpn8 = _env_bool("VLLM_SM70_FP8_QPN8", True)
     nvfp4_turbomind = _env_bool("VLLM_SM70_NVFP4_TURBOMIND", False)
     nvfp4_moe_grouped_prefill = _env_bool("VLLM_SM70_NVFP4_MOE_GROUPED_PREFILL", True)
     mxfp4_turbomind = _env_bool("VLLM_SM70_MXFP4_TURBOMIND", False)
@@ -578,6 +582,15 @@ def _sm70_turbomind_policy() -> dict[str, Any]:
             "VLLM_SM70_FP8_PREFILL_EXACT_DENSE"
         ),
         "fp8_prefill_exact_dense_effective": fp8_prefill_exact_dense,
+        "VLLM_SM70_FP8_QPN8": os.environ.get("VLLM_SM70_FP8_QPN8"),
+        "fp8_qpn8_effective": fp8_qpn8,
+        "fp8_qpn8_native_decode_max_m": 8,
+        "fp8_qpn8_configured_max_num_seqs": max_num_seqs,
+        "fp8_qpn8_concurrency_contract": (max_num_seqs is None or max_num_seqs <= 8),
+        "fp8_qpn8_no_mtp_contract": not speculative_enabled,
+        "fp8_qpn8_large_m_fallback": "bounded_fp16_weight_workspace",
+        "fp8_qpn8_large_m_gated_temporary": "M_x_8704_fp16",
+        "VLLM_SM70_FP8_QPN8_LIBRARY": os.environ.get("VLLM_SM70_FP8_QPN8_LIBRARY"),
         "VLLM_SM70_NVFP4_TURBOMIND": os.environ.get("VLLM_SM70_NVFP4_TURBOMIND"),
         "nvfp4_turbomind_effective": nvfp4_turbomind,
         "VLLM_SM70_NVFP4_MOE_GROUPED_PREFILL": os.environ.get(
@@ -770,6 +783,15 @@ def _sm70_turbomind_policy() -> dict[str, Any]:
             and not fp8_moe_batched_w2_dispatch
             and not f16_dense
         ),
+        "accepted_qwen38_fp8_qpn8_default_policy": (
+            fp8_turbomind
+            and fp8_dequant_fallback
+            and fp8_dense_gated_silu
+            and fp8_prefill_exact_dense
+            and fp8_qpn8
+            and (max_num_seqs is None or max_num_seqs <= 8)
+            and not speculative_enabled
+        ),
         "accepted_awq_moe_default_policy": (
             awq_turbomind
             and awq_moe_safe_default_selector
@@ -815,7 +837,9 @@ def _sm70_turbomind_policy() -> dict[str, Any]:
         "route_hit_oracle": (
             "Accepted dense route-hit requires logs such as "
             "`SM70 AWQ TurboMind dense path enabled`, "
-            "`SM70 FP8 TurboMind W8A16 dense path enabled`, and when warmup "
+            "`SM70 FP8 TurboMind W8A16 dense path enabled`, and for the "
+            "Qwen3.8-27B TP4 QPN8 default "
+            "`Memory-neutral SM70 FP8 QPN8 path enabled`; when warmup "
             "is relevant `SM70 AWQ warmup finished`. AWQ MoE production "
             "throughput evidence must keep the default fast route: batched "
             "GEMM enabled, legacy single-token compact enabled, and no "
@@ -1760,7 +1784,10 @@ def _dump(args: argparse.Namespace) -> int:
         ],
         "env": _tracked_env(),
         "sm70_tune_policy": _sm70_tune_policy(),
-        "sm70_turbomind_policy": _sm70_turbomind_policy(),
+        "sm70_turbomind_policy": _sm70_turbomind_policy(
+            int(llm_kwargs["max_num_seqs"]),
+            speculative_enabled=llm_kwargs.get("speculative_config") is not None,
+        ),
         "sm70_attention_policy": _sm70_attention_policy(
             llm_kwargs.get("kv_cache_dtype")
         ),

--- a/benchmarks/benchmark_sm70_model_tokens.py
+++ b/benchmarks/benchmark_sm70_model_tokens.py
@@ -20,7 +20,9 @@ from pathlib import Path
 from typing import Any
 
 SOURCE_ROOT = Path(__file__).resolve().parents[1]
-FLASH_V100_ROOT = SOURCE_ROOT / "flash-attention-v100"
+FLASH_V100_ROOT = Path(
+    os.environ.get("SM70_FLASH_V100_ROOT", SOURCE_ROOT / "flash-attention-v100")
+)
 for source_path in (FLASH_V100_ROOT, SOURCE_ROOT):
     source_path_str = str(source_path)
     if source_path_str not in sys.path:

--- a/benchmarks/benchmark_sm70_model_tokens.py
+++ b/benchmarks/benchmark_sm70_model_tokens.py
@@ -526,7 +526,7 @@ def _sm70_turbomind_policy(
         "VLLM_SM70_FP8_PREFILL_EXACT_DENSE",
         True,
     )
-    fp8_qpn8 = _env_bool("VLLM_SM70_FP8_QPN8", True)
+    fp8_qpn8 = _env_bool("VLLM_SM70_FP8_QPN8", False)
     nvfp4_turbomind = _env_bool("VLLM_SM70_NVFP4_TURBOMIND", False)
     nvfp4_moe_grouped_prefill = _env_bool("VLLM_SM70_NVFP4_MOE_GROUPED_PREFILL", True)
     mxfp4_turbomind = _env_bool("VLLM_SM70_MXFP4_TURBOMIND", False)

--- a/benchmarks/profile_sm70_fp8_qpn8_gated_pair_ncu.py
+++ b/benchmarks/profile_sm70_fp8_qpn8_gated_pair_ncu.py
@@ -39,7 +39,7 @@ def _parse_args() -> argparse.Namespace:
 def _time(launch, warmup: int, repeats: int) -> float:
     for _ in range(warmup):
         launch()
-    torch.cuda.synchronize()
+    torch.accelerator.synchronize()
     start = torch.cuda.Event(enable_timing=True)
     end = torch.cuda.Event(enable_timing=True)
     start.record()
@@ -54,7 +54,7 @@ def main() -> int:
     args = _parse_args()
     torch.ops.load_library(str(args.qpn8_library.resolve()))
     device = torch.device("cuda:0")
-    torch.cuda.set_device(device)
+    torch.accelerator.set_device_index(device.index or 0)
     if torch.cuda.get_device_capability(device) != (7, 0):
         raise RuntimeError("This profiler requires SM70/V100")
 
@@ -110,7 +110,7 @@ def main() -> int:
     torch.cuda.nvtx.range_push("qpn8_gate_up_fused_pair")
     launch_qpn()
     torch.cuda.nvtx.range_pop()
-    torch.cuda.synchronize(device)
+    torch.accelerator.synchronize(device)
     torch.cuda.cudart().cudaProfilerStop()
 
     result = {

--- a/benchmarks/profile_sm70_fp8_qpn8_gated_pair_ncu.py
+++ b/benchmarks/profile_sm70_fp8_qpn8_gated_pair_ncu.py
@@ -1,0 +1,140 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Paired NCU probe for current and QPN8 fused gate/up kernels."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+import torch
+import vllm._C  # noqa: F401
+from benchmark_sm70_fp8_qpn8 import (
+    _dequantized_weight,
+    _error_stats,
+    _load_case,
+    _qpn8_group_scales,
+    _qpn8_prepack,
+)
+
+from vllm import _sm70_ops as sm70_ops
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--model",
+        type=Path,
+        default=Path("/home/ymzx/models/Qwen3.8-27B-FP8"),
+    )
+    parser.add_argument("--qpn8-library", type=Path, required=True)
+    parser.add_argument("--out", type=Path, required=True)
+    parser.add_argument("--m", type=int, default=1)
+    parser.add_argument("--warmup", type=int, default=20)
+    parser.add_argument("--repeats", type=int, default=100)
+    return parser.parse_args()
+
+
+def _time(launch, warmup: int, repeats: int) -> float:
+    for _ in range(warmup):
+        launch()
+    torch.cuda.synchronize()
+    start = torch.cuda.Event(enable_timing=True)
+    end = torch.cuda.Event(enable_timing=True)
+    start.record()
+    for _ in range(repeats):
+        launch()
+    end.record()
+    end.synchronize()
+    return float(start.elapsed_time(end) * 1000.0 / repeats)
+
+
+def main() -> int:
+    args = _parse_args()
+    torch.ops.load_library(str(args.qpn8_library.resolve()))
+    device = torch.device("cuda:0")
+    torch.cuda.set_device(device)
+    if torch.cuda.get_device_capability(device) != (7, 0):
+        raise RuntimeError("This profiler requires SM70/V100")
+
+    qweight, scales, _ = _load_case(args.model, "gate_up_fused", 4, 0, device)
+    n, k = (int(dim) for dim in qweight.shape)
+    hidden = n // 2
+    codes = _qpn8_prepack(qweight.view(torch.uint8))
+    group_scales = _qpn8_group_scales(scales, n, k)
+    tm_weight, tm_scales, meta = sm70_ops.fp8_sm70_prepare(qweight, scales, 128, True)
+    k_ld, q_ld = (int(value) for value in meta.tolist())
+    inputs = torch.randn((args.m, k), device=device, dtype=torch.float16).mul_(0.1)
+    current_out = torch.empty((args.m, hidden), device=device, dtype=torch.float16)
+    qpn_out = torch.empty_like(current_out)
+
+    def launch_current() -> None:
+        sm70_ops.fp8_gemm_sm70_out(
+            current_out,
+            inputs,
+            tm_weight,
+            tm_scales,
+            128,
+            k_ld,
+            q_ld,
+            True,
+        )
+
+    def launch_qpn() -> None:
+        sm70_ops.fp8_qpn8_gated_pair_sm70_out(
+            qpn_out,
+            inputs,
+            codes,
+            group_scales,
+            8,
+            2,
+            True,
+            True,
+        )
+
+    current_us = _time(launch_current, args.warmup, args.repeats)
+    qpn_us = _time(launch_qpn, args.warmup, args.repeats)
+    reference_raw = inputs.float().matmul(_dequantized_weight(qweight, scales).t())
+    gate, up = reference_raw.chunk(2, dim=1)
+    reference = (torch.nn.functional.silu(gate) * up).half()
+    quality = {
+        "current": _error_stats(current_out, reference),
+        "qpn8_pair": _error_stats(qpn_out, reference),
+    }
+
+    torch.cuda.cudart().cudaProfilerStart()
+    torch.cuda.nvtx.range_push("current_gate_up_fused")
+    launch_current()
+    torch.cuda.nvtx.range_pop()
+    torch.cuda.nvtx.range_push("qpn8_gate_up_fused_pair")
+    launch_qpn()
+    torch.cuda.nvtx.range_pop()
+    torch.cuda.synchronize(device)
+    torch.cuda.cudart().cudaProfilerStop()
+
+    result = {
+        "device": torch.cuda.get_device_name(device),
+        "m": args.m,
+        "n": n,
+        "k": k,
+        "hidden": hidden,
+        "current_unprofiled_us": current_us,
+        "qpn8_pair_unprofiled_us": qpn_us,
+        "speedup": current_us / qpn_us,
+        "qpn8_config": {
+            "split_k": 8,
+            "nacc": 2,
+            "decoder": "fast",
+            "prefetch": True,
+        },
+        "quality": quality,
+    }
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    args.out.write_text(json.dumps(result, indent=2), encoding="utf-8")
+    print(json.dumps(result, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmarks/profile_sm70_fp8_qpn8_ncu.py
+++ b/benchmarks/profile_sm70_fp8_qpn8_ncu.py
@@ -48,7 +48,7 @@ def _parse_args() -> argparse.Namespace:
 def _time(launch: Any, warmup: int, repeats: int) -> float:
     for _ in range(warmup):
         launch()
-    torch.cuda.synchronize()
+    torch.accelerator.synchronize()
     start = torch.cuda.Event(enable_timing=True)
     end = torch.cuda.Event(enable_timing=True)
     start.record()
@@ -63,7 +63,7 @@ def main() -> int:
     args = _parse_args()
     torch.ops.load_library(str(args.qpn8_library.resolve()))
     device = torch.device(args.device)
-    torch.cuda.set_device(device)
+    torch.accelerator.set_device_index(device.index or 0)
     if torch.cuda.get_device_capability(device) != (7, 0):
         raise RuntimeError("This profiler requires SM70/V100")
     if args.m < 1 or args.m > 8:
@@ -165,7 +165,7 @@ def main() -> int:
         torch.cuda.nvtx.range_push(f"qpn8_{item['case']}")
         item["launch_qpn"]()
         torch.cuda.nvtx.range_pop()
-    torch.cuda.synchronize(device)
+    torch.accelerator.synchronize(device)
     torch.cuda.nvtx.range_pop()
     torch.cuda.cudart().cudaProfilerStop()
 

--- a/benchmarks/profile_sm70_fp8_qpn8_ncu.py
+++ b/benchmarks/profile_sm70_fp8_qpn8_ncu.py
@@ -1,0 +1,194 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Profile only the real-shape QPN8 winners with Nsight Compute."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+import torch
+import vllm._C  # noqa: F401
+from benchmark_sm70_fp8_qpn8 import (
+    _load_case,
+    _qpn8_group_scales,
+    _qpn8_prepack,
+)
+
+from vllm import _sm70_ops as sm70_ops
+
+_CONFIGS = {
+    "down": (16, 1, True),
+    "gdn_in": (32, 1, True),
+    "output": (16, 1, True),
+    "full_qkv": (16, 1, True),
+    "gate_up_raw": (16, 1, True),
+}
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--model",
+        type=Path,
+        default=Path("/home/ymzx/models/Qwen3.8-27B-FP8"),
+    )
+    parser.add_argument("--qpn8-library", type=Path, required=True)
+    parser.add_argument("--out", type=Path, required=True)
+    parser.add_argument("--device", default="cuda:0")
+    parser.add_argument("--m", type=int, default=1)
+    parser.add_argument("--warmup", type=int, default=20)
+    parser.add_argument("--repeats", type=int, default=100)
+    parser.add_argument("--paired-current", action="store_true")
+    return parser.parse_args()
+
+
+def _time(launch: Any, warmup: int, repeats: int) -> float:
+    for _ in range(warmup):
+        launch()
+    torch.cuda.synchronize()
+    start = torch.cuda.Event(enable_timing=True)
+    end = torch.cuda.Event(enable_timing=True)
+    start.record()
+    for _ in range(repeats):
+        launch()
+    end.record()
+    end.synchronize()
+    return float(start.elapsed_time(end) * 1000.0 / repeats)
+
+
+def main() -> int:
+    args = _parse_args()
+    torch.ops.load_library(str(args.qpn8_library.resolve()))
+    device = torch.device(args.device)
+    torch.cuda.set_device(device)
+    if torch.cuda.get_device_capability(device) != (7, 0):
+        raise RuntimeError("This profiler requires SM70/V100")
+    if args.m < 1 or args.m > 8:
+        raise ValueError("M must be in [1, 8]")
+
+    prepared: list[dict[str, Any]] = []
+    for case, (split_k, nacc, fast_decoder) in _CONFIGS.items():
+        qweight, scales, note = _load_case(args.model, case, 4, 0, device)
+        n, k = (int(dim) for dim in qweight.shape)
+        codes = _qpn8_prepack(qweight.view(torch.uint8))
+        group_scales = _qpn8_group_scales(scales, n, k)
+        tm_weight, tm_scales, meta = sm70_ops.fp8_sm70_prepare(
+            qweight, scales, 128, False
+        )
+        k_ld, q_ld = (int(value) for value in meta.tolist())
+        inputs = torch.randn((args.m, k), device=device, dtype=torch.float16).mul_(0.1)
+        qpn_output = torch.empty((args.m, n), device=device, dtype=torch.float16)
+        current_output = torch.empty_like(qpn_output)
+
+        def launch_qpn(
+            output: torch.Tensor = qpn_output,
+            inputs: torch.Tensor = inputs,
+            codes: torch.Tensor = codes,
+            group_scales: torch.Tensor = group_scales,
+            split_k: int = split_k,
+            nacc: int = nacc,
+            fast_decoder: bool = fast_decoder,
+        ) -> None:
+            sm70_ops.fp8_qpn8_gemm_sm70_out(
+                output,
+                inputs,
+                codes,
+                group_scales,
+                split_k,
+                nacc,
+                fast_decoder,
+                False,
+            )
+
+        def launch_current(
+            output: torch.Tensor = current_output,
+            inputs: torch.Tensor = inputs,
+            tm_weight: torch.Tensor = tm_weight,
+            tm_scales: torch.Tensor = tm_scales,
+            k_ld: int = k_ld,
+            q_ld: int = q_ld,
+        ) -> None:
+            sm70_ops.fp8_gemm_sm70_out(
+                output,
+                inputs,
+                tm_weight,
+                tm_scales,
+                128,
+                k_ld,
+                q_ld,
+                False,
+            )
+
+        prepared.append(
+            {
+                "case": case,
+                "note": note,
+                "m": args.m,
+                "n": n,
+                "k": k,
+                "split_k": split_k,
+                "nacc": nacc,
+                "decoder": "fast" if fast_decoder else "scalar",
+                "launch_qpn": launch_qpn,
+                "launch_current": launch_current,
+                "tensors": [
+                    qweight,
+                    scales,
+                    codes,
+                    group_scales,
+                    inputs,
+                    qpn_output,
+                    current_output,
+                    tm_weight,
+                    tm_scales,
+                ],
+            }
+        )
+
+    for item in prepared:
+        item["qpn_unprofiled_us"] = _time(item["launch_qpn"], args.warmup, args.repeats)
+        if args.paired_current:
+            item["current_unprofiled_us"] = _time(
+                item["launch_current"], args.warmup, args.repeats
+            )
+
+    torch.cuda.cudart().cudaProfilerStart()
+    torch.cuda.nvtx.range_push("qpn8_real_shape_winners")
+    for item in prepared:
+        if args.paired_current:
+            torch.cuda.nvtx.range_push(f"current_{item['case']}")
+            item["launch_current"]()
+            torch.cuda.nvtx.range_pop()
+        torch.cuda.nvtx.range_push(f"qpn8_{item['case']}")
+        item["launch_qpn"]()
+        torch.cuda.nvtx.range_pop()
+    torch.cuda.synchronize(device)
+    torch.cuda.nvtx.range_pop()
+    torch.cuda.cudart().cudaProfilerStop()
+
+    public = [
+        {
+            key: value
+            for key, value in item.items()
+            if key not in ("launch_qpn", "launch_current", "tensors")
+        }
+        for item in prepared
+    ]
+    result = {
+        "device": torch.cuda.get_device_name(device),
+        "capability": list(torch.cuda.get_device_capability(device)),
+        "torch": torch.__version__,
+        "torch_cuda": torch.version.cuda,
+        "profiles": public,
+    }
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    args.out.write_text(json.dumps(result, indent=2), encoding="utf-8")
+    print(json.dumps(result, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/csrc/custom_all_reduce.cuh
+++ b/csrc/custom_all_reduce.cuh
@@ -139,6 +139,15 @@ inline int sm70_tp4_m5_allreduce_threads(int world_size,
   return static_cast<int>(parsed);
 }
 
+inline bool sm70_tp4_small_allreduce_pack32(int world_size,
+                                            bool fully_connected,
+                                            size_t bytes) {
+  const char* raw = std::getenv("VLLM_SM70_TP4_SMALL_AR_PACK32");
+  return raw != nullptr && std::atoi(raw) != 0 && world_size == 4 &&
+         fully_connected && bytes == 5120 * sizeof(half) &&
+         custom_allreduce_current_device_is_sm70();
+}
+
 // Counter may overflow, but unsigned integer overflow is well-defined.
 using FlagType = sm70_tile_runtime::FlagType;
 using Signal = sm70_tile_runtime::Signal;
@@ -292,11 +301,49 @@ static DINLINE FlagType ld_flag_sys_visible(FlagType* flag_addr) {
   return flag;
 }
 
+static DINLINE void membar_sys() {
+  asm volatile("membar.sys;" ::: "memory");
+}
+
+// The TP4 pack32 route waits with volatile peer loads, then executes one
+// system fence after the matching flag is visible. This preserves the input
+// visibility contract without putting a system fence in every poll iteration.
+template <int ngpus>
+DINLINE void sm70_pack32_barrier_at_start(const RankSignals& sg,
+                                          Signal* self_sg, int rank) {
+  uint32_t flag = self_sg->_flag[blockIdx.x] + 1;
+  if (threadIdx.x < ngpus) {
+    const unsigned int peer = threadIdx.x;
+    auto peer_counter_ptr = &sg.signals[peer]->start[blockIdx.x][rank];
+    auto self_counter_ptr = &self_sg->start[blockIdx.x][peer];
+    st_flag_sys_visible(peer_counter_ptr, flag);
+    while (ld_flag_volatile(self_counter_ptr) != flag);
+    membar_sys();
+  }
+  __syncthreads();
+  if (threadIdx.x == 0) self_sg->_flag[blockIdx.x] = flag;
+}
+
+template <int ngpus>
+DINLINE void sm70_pack32_barrier_at_end(const RankSignals& sg,
+                                        Signal* self_sg, int rank) {
+  __syncthreads();
+  uint32_t flag = self_sg->_flag[blockIdx.x] + 1;
+  if (threadIdx.x < ngpus) {
+    const unsigned int peer = threadIdx.x;
+    auto peer_counter_ptr = &sg.signals[peer]->end[blockIdx.x][rank];
+    auto self_counter_ptr = &self_sg->end[blockIdx.x][peer];
+    st_flag_volatile(peer_counter_ptr, flag);
+    while (ld_flag_volatile(self_counter_ptr) != flag);
+  }
+  if (threadIdx.x == 0) self_sg->_flag[blockIdx.x] = flag;
+}
+
 // This function is meant to be used as the first synchronization in the all
-// reduce kernel. The all-reduce input is usually produced by kernels launched
-// immediately before this kernel on each rank. Use a system memory fence around
-// the peer-visible flag so faster upstream paths do not expose stale input to
-// peer ranks.
+// reduce kernel. Publish the peer flag after a system fence, poll it with a
+// volatile load, then execute one system fence after the matching value is
+// visible. The post-poll fence preserves input visibility without putting a
+// system fence in every spin-loop iteration.
 template <int ngpus>
 DINLINE void barrier_at_start(const RankSignals& sg, Signal* self_sg,
                               int rank) {
@@ -307,7 +354,8 @@ DINLINE void barrier_at_start(const RankSignals& sg, Signal* self_sg,
     // Write the expected counter value to peer and wait for correct value
     // from peer.
     st_flag_sys_visible(peer_counter_ptr, flag);
-    while (ld_flag_sys_visible(self_counter_ptr) != flag);
+    while (ld_flag_volatile(self_counter_ptr) != flag);
+    membar_sys();
   }
   __syncthreads();
   // use one thread to update flag
@@ -342,6 +390,38 @@ DINLINE void barrier_at_end(const RankSignals& sg, Signal* self_sg, int rank) {
 }
 
 #else
+
+template <int ngpus>
+DINLINE void sm70_pack32_barrier_at_start(const RankSignals& sg,
+                                          Signal* self_sg, int rank) {
+  uint32_t flag = self_sg->_flag[blockIdx.x] + 1;
+  if (threadIdx.x < ngpus) {
+    const unsigned int peer = threadIdx.x;
+    __scoped_atomic_store_n(&sg.signals[peer]->start[blockIdx.x][rank], flag,
+                            __ATOMIC_RELAXED, __MEMORY_SCOPE_SYSTEM);
+    while (__scoped_atomic_load_n(&self_sg->start[blockIdx.x][peer],
+                                  __ATOMIC_RELAXED,
+                                  __MEMORY_SCOPE_DEVICE) < flag);
+  }
+  __syncthreads();
+  if (threadIdx.x == 0) self_sg->_flag[blockIdx.x] = flag;
+}
+
+template <int ngpus>
+DINLINE void sm70_pack32_barrier_at_end(const RankSignals& sg,
+                                        Signal* self_sg, int rank) {
+  __syncthreads();
+  uint32_t flag = self_sg->_flag[blockIdx.x] + 1;
+  if (threadIdx.x < ngpus) {
+    const unsigned int peer = threadIdx.x;
+    __scoped_atomic_store_n(&sg.signals[peer]->end[blockIdx.x][rank], flag,
+                            __ATOMIC_RELAXED, __MEMORY_SCOPE_SYSTEM);
+    while (__scoped_atomic_load_n(&self_sg->end[blockIdx.x][peer],
+                                  __ATOMIC_RELAXED,
+                                  __MEMORY_SCOPE_DEVICE) < flag);
+  }
+  if (threadIdx.x == 0) self_sg->_flag[blockIdx.x] = flag;
+}
 
 template <int ngpus>
 DINLINE void barrier_at_start(const RankSignals& sg, Signal* self_sg,
@@ -426,6 +506,23 @@ __global__ void __launch_bounds__(512, 1)
     ((P*)result)[idx] = packed_reduce<P, ngpus, A>((const P**)&dp.ptrs[0], idx);
   }
   barrier_at_end<ngpus, true>(sg, self_sg, rank);
+}
+
+template <int ngpus>
+__global__ void __launch_bounds__(512, 1)
+    sm70_cross_device_reduce_1stage_pack32(
+        RankData* _dp, RankSignals sg, Signal* self_sg,
+        half* __restrict__ result, int rank, int size) {
+  using P = array_t<half, 16>;
+  using A = array_t<float, 16>;
+  auto dp = *_dp;
+  sm70_pack32_barrier_at_start<ngpus>(sg, self_sg, rank);
+  for (int idx = blockIdx.x * blockDim.x + threadIdx.x; idx < size;
+       idx += gridDim.x * blockDim.x) {
+    reinterpret_cast<P*>(result)[idx] =
+        packed_reduce<P, ngpus, A>((const P**)&dp.ptrs[0], idx);
+  }
+  sm70_pack32_barrier_at_end<ngpus>(sg, self_sg, rank);
 }
 
 // This prototype deliberately stays narrow: it mirrors the FP32 Gemma RMSNorm
@@ -1119,6 +1216,16 @@ class CustomAllreduce {
     threads = sm70_tp4_m5_allreduce_threads(world_size_, fully_connected_,
                                             bytes);
     int blocks = std::min(block_limit, (size + threads - 1) / threads);
+
+    if constexpr (std::is_same_v<T, half>) {
+      if (blocks == 1 && threads == 512 &&
+          sm70_tp4_small_allreduce_pack32(world_size_, fully_connected_,
+                                          bytes)) {
+        sm70_cross_device_reduce_1stage_pack32<4><<<1, 512, 0, stream>>>(
+            ptrs, sg_, self_sg_, output, rank_, bytes / 32);
+        return;
+      }
+    }
 
     // Check environment variable once
     const char* env_algo = std::getenv("VLLM_CUSTOM_ALLREDUCE_ALGO");

--- a/csrc/custom_all_reduce.cuh
+++ b/csrc/custom_all_reduce.cuh
@@ -86,7 +86,7 @@ inline bool custom_allreduce_current_device_is_sm70() {
 }
 
 inline bool sm70_tp8_hierarchical_custom_ar_enabled(int world_size,
-                                                     bool fully_connected) {
+                                                    bool fully_connected) {
   const char* raw = std::getenv("VLLM_SM70_TP8_HIERARCHICAL_CUSTOM_AR");
   return raw != nullptr && std::atoi(raw) != 0 && world_size == 8 &&
          !fully_connected && custom_allreduce_current_device_is_sm70();
@@ -96,8 +96,7 @@ inline bool sm70_tp8_hierarchical_peer(int rank, int peer) {
   return rank / 4 == peer / 4 || rank + 4 == peer || peer + 4 == rank;
 }
 
-inline int custom_allreduce_block_limit(int default_limit,
-                                        int world_size,
+inline int custom_allreduce_block_limit(int default_limit, int world_size,
                                         size_t bytes) {
   const char* raw = std::getenv("VLLM_CUSTOM_ALLREDUCE_BLOCK_LIMIT");
   if (raw == nullptr || raw[0] == '\0') {
@@ -117,8 +116,7 @@ inline int custom_allreduce_block_limit(int default_limit,
   return static_cast<int>(parsed);
 }
 
-inline int sm70_tp4_m5_allreduce_threads(int world_size,
-                                         bool fully_connected,
+inline int sm70_tp4_m5_allreduce_threads(int world_size, bool fully_connected,
                                          size_t bytes) {
   const char* raw = std::getenv("VLLM_SM70_TP4_M5_AR_THREADS");
   if (raw == nullptr || raw[0] == '\0') return 512;
@@ -286,8 +284,7 @@ static DINLINE FlagType ld_flag_volatile(FlagType* flag_addr) {
 }
 
 static DINLINE void st_flag_sys_visible(FlagType* flag_addr, FlagType flag) {
-  asm volatile("membar.sys; st.volatile.global.u32 [%1], %0;"
-               ::"r"(flag),
+  asm volatile("membar.sys; st.volatile.global.u32 [%1], %0;" ::"r"(flag),
                "l"(flag_addr)
                : "memory");
 }
@@ -301,9 +298,7 @@ static DINLINE FlagType ld_flag_sys_visible(FlagType* flag_addr) {
   return flag;
 }
 
-static DINLINE void membar_sys() {
-  asm volatile("membar.sys;" ::: "memory");
-}
+static DINLINE void membar_sys() { asm volatile("membar.sys;" ::: "memory"); }
 
 // The TP4 pack32 route waits with volatile peer loads, then executes one
 // system fence after the matching flag is visible. This preserves the input
@@ -325,8 +320,8 @@ DINLINE void sm70_pack32_barrier_at_start(const RankSignals& sg,
 }
 
 template <int ngpus>
-DINLINE void sm70_pack32_barrier_at_end(const RankSignals& sg,
-                                        Signal* self_sg, int rank) {
+DINLINE void sm70_pack32_barrier_at_end(const RankSignals& sg, Signal* self_sg,
+                                        int rank) {
   __syncthreads();
   uint32_t flag = self_sg->_flag[blockIdx.x] + 1;
   if (threadIdx.x < ngpus) {
@@ -408,8 +403,8 @@ DINLINE void sm70_pack32_barrier_at_start(const RankSignals& sg,
 }
 
 template <int ngpus>
-DINLINE void sm70_pack32_barrier_at_end(const RankSignals& sg,
-                                        Signal* self_sg, int rank) {
+DINLINE void sm70_pack32_barrier_at_end(const RankSignals& sg, Signal* self_sg,
+                                        int rank) {
   __syncthreads();
   uint32_t flag = self_sg->_flag[blockIdx.x] + 1;
   if (threadIdx.x < ngpus) {
@@ -510,9 +505,10 @@ __global__ void __launch_bounds__(512, 1)
 
 template <int ngpus>
 __global__ void __launch_bounds__(512, 1)
-    sm70_cross_device_reduce_1stage_pack32(
-        RankData* _dp, RankSignals sg, Signal* self_sg,
-        half* __restrict__ result, int rank, int size) {
+    sm70_cross_device_reduce_1stage_pack32(RankData* _dp, RankSignals sg,
+                                           Signal* self_sg,
+                                           half* __restrict__ result, int rank,
+                                           int size) {
   using P = array_t<half, 16>;
   using A = array_t<float, 16>;
   auto dp = *_dp;
@@ -531,11 +527,13 @@ __global__ void __launch_bounds__(512, 1)
 // residual after the peer reduction.
 template <int Threads, int ngpus, typename ResidualT, typename WeightT>
 __global__ void __launch_bounds__(Threads, 1)
-    sm70_peer_reduce_gemma_rms_norm(
-        RankData* _dp, RankSignals sg, Signal* self_sg,
-        const ResidualT* __restrict__ residual,
-        const WeightT* __restrict__ weight, half* __restrict__ normalized_out,
-        float* __restrict__ residual_out, int rank, float epsilon) {
+    sm70_peer_reduce_gemma_rms_norm(RankData* _dp, RankSignals sg,
+                                    Signal* self_sg,
+                                    const ResidualT* __restrict__ residual,
+                                    const WeightT* __restrict__ weight,
+                                    half* __restrict__ normalized_out,
+                                    float* __restrict__ residual_out, int rank,
+                                    float epsilon) {
   using P = typename packed_t<half>::P;
   using A = typename packed_t<half>::A;
   constexpr int kPackedWidth = P::size;
@@ -556,15 +554,14 @@ __global__ void __launch_bounds__(Threads, 1)
 
   for (int packed_idx = tid; packed_idx < packed_per_row;
        packed_idx += blockDim.x) {
-    const P reduced =
-        packed_reduce<P, ngpus, A>((const P**)&dp.ptrs[0],
-                                    row * packed_per_row + packed_idx);
+    const P reduced = packed_reduce<P, ngpus, A>(
+        (const P**)&dp.ptrs[0], row * packed_per_row + packed_idx);
     const int element_offset = row_offset + packed_idx * kPackedWidth;
 #pragma unroll
     for (int i = 0; i < kPackedWidth; ++i) {
-      const float value = __half2float(reduced.data[i]) +
-                          sm70_gemma_rms_norm_to_float(
-                              residual[element_offset + i]);
+      const float value =
+          __half2float(reduced.data[i]) +
+          sm70_gemma_rms_norm_to_float(residual[element_offset + i]);
       residual_values[packed_idx * kPackedWidth + i] = value;
       residual_out[element_offset + i] = value;
     }
@@ -600,8 +597,8 @@ __global__ void __launch_bounds__(Threads, 1)
       const int column = element_offset + i;
       const float gemma_weight =
           sm70_gemma_rms_norm_to_float(weight[column]) + 1.0f;
-      normalized_out[row_offset + column] = __float2half_rn(
-          residual_values[column] * inverse_rms * gemma_weight);
+      normalized_out[row_offset + column] =
+          __float2half_rn(residual_values[column] * inverse_rms * gemma_weight);
     }
   }
 
@@ -610,10 +607,9 @@ __global__ void __launch_bounds__(Threads, 1)
 
 template <typename T, int ngpus>
 __global__ void __launch_bounds__(256, 1) sm70_tile_runtime_reduce_kernel(
-    RankData* _dp, RankSignals sg, Signal* self_sg,
-    const T* __restrict__ input, T* __restrict__ staging,
-    T* __restrict__ result, int rank, int packed_size, int tile_packed_size,
-    int tile_count, int compute_iters) {
+    RankData* _dp, RankSignals sg, Signal* self_sg, const T* __restrict__ input,
+    T* __restrict__ staging, T* __restrict__ result, int rank, int packed_size,
+    int tile_packed_size, int tile_count, int compute_iters) {
   using P = typename packed_t<T>::P;
   using A = typename packed_t<T>::A;
 
@@ -664,11 +660,10 @@ __global__ void __launch_bounds__(256, 1) sm70_tile_runtime_reduce_kernel(
 
 template <typename T, int ngpus>
 __global__ void __launch_bounds__(256, 1) sm70_tile_runtime_engine_kernel(
-    RankData* _dp, RankSignals sg, Signal* self_sg,
-    const T* __restrict__ input, T* __restrict__ staging,
-    T* __restrict__ result, int rank, int packed_size, int tile_packed_size,
-    int tile_count, int producer_blocks, int reducer_blocks,
-    int compute_iters) {
+    RankData* _dp, RankSignals sg, Signal* self_sg, const T* __restrict__ input,
+    T* __restrict__ staging, T* __restrict__ result, int rank, int packed_size,
+    int tile_packed_size, int tile_count, int producer_blocks,
+    int reducer_blocks, int compute_iters) {
   using P = typename packed_t<T>::P;
   using A = typename packed_t<T>::A;
 
@@ -731,10 +726,11 @@ __global__ void __launch_bounds__(256, 1) sm70_tile_runtime_engine_kernel(
 
 template <typename T, int ngpus>
 __global__ void __launch_bounds__(256, 1)
-    sm70_tile_runtime_wait_reduce_kernel(
-        RankData* _dp, RankSignals sg, Signal* self_sg,
-        T* __restrict__ result, int rank, int packed_size,
-        int tile_packed_size, int tile_count) {
+    sm70_tile_runtime_wait_reduce_kernel(RankData* _dp, RankSignals sg,
+                                         Signal* self_sg,
+                                         T* __restrict__ result, int rank,
+                                         int packed_size, int tile_packed_size,
+                                         int tile_count) {
   using P = typename packed_t<T>::P;
   using A = typename packed_t<T>::A;
 
@@ -766,9 +762,11 @@ __global__ void __launch_bounds__(256, 1)
 }
 
 template <typename T, int ngpus>
-__global__ void __launch_bounds__(512, 1) cross_device_reduce_sum2_1stage(
-    RankData* _dp_a, RankData* _dp_b, RankSignals sg, Signal* self_sg,
-    T* __restrict__ result, int rank, int size) {
+__global__ void __launch_bounds__(512, 1)
+    cross_device_reduce_sum2_1stage(RankData* _dp_a, RankData* _dp_b,
+                                    RankSignals sg, Signal* self_sg,
+                                    T* __restrict__ result, int rank,
+                                    int size) {
   using P = typename packed_t<T>::P;
   using A = typename packed_t<T>::A;
   auto dp_a = *_dp_a;
@@ -776,9 +774,8 @@ __global__ void __launch_bounds__(512, 1) cross_device_reduce_sum2_1stage(
   barrier_at_start<ngpus>(sg, self_sg, rank);
   for (int idx = blockIdx.x * blockDim.x + threadIdx.x; idx < size;
        idx += gridDim.x * blockDim.x) {
-    ((P*)result)[idx] =
-        packed_reduce_sum2<P, ngpus, A>((const P**)&dp_a.ptrs[0],
-                                        (const P**)&dp_b.ptrs[0], idx);
+    ((P*)result)[idx] = packed_reduce_sum2<P, ngpus, A>(
+        (const P**)&dp_a.ptrs[0], (const P**)&dp_b.ptrs[0], idx);
   }
   barrier_at_end<ngpus, true>(sg, self_sg, rank);
 }
@@ -788,9 +785,8 @@ DINLINE P* get_tmp_buf(Signal* sg) {
   return (P*)(((Signal*)sg) + 1);
 }
 
-DINLINE FlagType sm70_tp8_clique_barrier(const RankSignals& sg,
-                                         Signal* self_sg, int rank,
-                                         int signal_slot) {
+DINLINE FlagType sm70_tp8_clique_barrier(const RankSignals& sg, Signal* self_sg,
+                                         int rank, int signal_slot) {
   const int tid = threadIdx.x;
   const int clique_base = rank < 4 ? 0 : 4;
   const FlagType flag = self_sg->_flag[0] + 1;
@@ -804,9 +800,10 @@ DINLINE FlagType sm70_tp8_clique_barrier(const RankSignals& sg,
   return flag;
 }
 
-static __global__ void __launch_bounds__(512, 1) sm70_tp8_hierarchical_reduce(
-    RankData* _dp, RankSignals sg, Signal* self_sg,
-    half* __restrict__ result, int rank, int packed_size) {
+static __global__ void __launch_bounds__(512, 1)
+    sm70_tp8_hierarchical_reduce(RankData* _dp, RankSignals sg, Signal* self_sg,
+                                 half* __restrict__ result, int rank,
+                                 int packed_size) {
   using P = typename packed_t<half>::P;
   using A = typename packed_t<half>::A;
 
@@ -820,8 +817,7 @@ static __global__ void __launch_bounds__(512, 1) sm70_tp8_hierarchical_reduce(
   const int partial_slot = (self_sg->_flag[0] >> 1) & 1;
   const FlagType clique_flag =
       sm70_tp8_clique_barrier(sg, self_sg, rank, partial_slot);
-  A* const self_partial =
-      get_tmp_buf<A>(self_sg) + partial_slot * packed_size;
+  A* const self_partial = get_tmp_buf<A>(self_sg) + partial_slot * packed_size;
   const A* const pair_partial =
       get_tmp_buf<A>(sg.signals[pair_rank]) + partial_slot * packed_size;
 
@@ -844,11 +840,9 @@ static __global__ void __launch_bounds__(512, 1) sm70_tp8_hierarchical_reduce(
   const FlagType pair_flag = clique_flag + 1;
   if (tid < 4) {
     const int peer = clique_base + tid;
-    const int completion_slot =
-        kSm70Tp8CompletionSignalSlotBase + partial_slot;
+    const int completion_slot = kSm70Tp8CompletionSignalSlotBase + partial_slot;
     st_flag_volatile(&sg.signals[peer]->end[completion_slot][rank], pair_flag);
-    while (ld_flag_volatile(&self_sg->end[completion_slot][peer]) !=
-           pair_flag);
+    while (ld_flag_volatile(&self_sg->end[completion_slot][peer]) != pair_flag);
   } else if (tid == 4) {
     st_flag_release(&sg.signals[pair_rank]->end[partial_slot][rank], pair_flag);
     while (ld_flag_acquire(&self_sg->end[partial_slot][pair_rank]) !=
@@ -911,9 +905,11 @@ __global__ void __launch_bounds__(512, 1)
 }
 
 template <typename T, int ngpus>
-__global__ void __launch_bounds__(512, 1) cross_device_reduce_sum2_2stage(
-    RankData* _dp_a, RankData* _dp_b, RankSignals sg, Signal* self_sg,
-    T* __restrict__ result, int rank, int size) {
+__global__ void __launch_bounds__(512, 1)
+    cross_device_reduce_sum2_2stage(RankData* _dp_a, RankData* _dp_b,
+                                    RankSignals sg, Signal* self_sg,
+                                    T* __restrict__ result, int rank,
+                                    int size) {
   int tid = blockIdx.x * blockDim.x + threadIdx.x;
   int stride = gridDim.x * blockDim.x;
   using P = typename packed_t<T>::P;
@@ -938,8 +934,7 @@ __global__ void __launch_bounds__(512, 1) cross_device_reduce_sum2_2stage(
   // Stage 1 mirrors cross_device_reduce_2stage, but each rank first forms
   // its local input_a + input_b value before the cross-rank reduction.
   for (int idx = start + tid; idx < end; idx += stride) {
-    tmp_out[idx - start] =
-        packed_reduce_sum2<P, ngpus, A>(ptrs_a, ptrs_b, idx);
+    tmp_out[idx - start] = packed_reduce_sum2<P, ngpus, A>(ptrs_a, ptrs_b, idx);
   }
   barrier_at_end<ngpus>(sg, self_sg, rank);
 
@@ -1110,11 +1105,10 @@ class CustomAllreduce {
     } else {
       auto it = buffers_.find(buffer);
       if (it == buffers_.end()) {
-        throw std::runtime_error(std::string(op_name) +
-                                 " buffer address " +
-                                 std::to_string(
-                                     reinterpret_cast<uint64_t>(buffer)) +
-                                 " is not registered!");
+        throw std::runtime_error(
+            std::string(op_name) + " buffer address " +
+            std::to_string(reinterpret_cast<uint64_t>(buffer)) +
+            " is not registered!");
       }
       ptrs = it->second;
     }
@@ -1213,8 +1207,8 @@ class CustomAllreduce {
         return;
       }
     }
-    threads = sm70_tp4_m5_allreduce_threads(world_size_, fully_connected_,
-                                            bytes);
+    threads =
+        sm70_tp4_m5_allreduce_threads(world_size_, fully_connected_, bytes);
     int blocks = std::min(block_limit, (size + threads - 1) / threads);
 
     if constexpr (std::is_same_v<T, half>) {
@@ -1287,11 +1281,11 @@ class CustomAllreduce {
 
   template <int ngpus, typename ResidualT, typename WeightT>
   void sm70_allreduce_gemma_rms_norm(cudaStream_t stream, half* input,
-                                      const ResidualT* residual,
-                                      const WeightT* weight,
-                                      half* normalized_out,
-                                      float* residual_out, int num_tokens,
-                                      int hidden_size, float epsilon) {
+                                     const ResidualT* residual,
+                                     const WeightT* weight,
+                                     half* normalized_out, float* residual_out,
+                                     int num_tokens, int hidden_size,
+                                     float epsilon) {
     if (world_size_ != ngpus || !custom_allreduce_current_device_is_sm70()) {
       throw std::runtime_error("SM70 Gemma RMSNorm prototype requires TP" +
                                std::to_string(ngpus) + " on an SM70 device.");
@@ -1305,18 +1299,18 @@ class CustomAllreduce {
     if (num_tokens <= 0 || num_tokens > kMaxTokens) {
       throw std::runtime_error(
           "SM70 Gemma RMSNorm prototype supports tokens in [1, " +
-          std::to_string(kMaxTokens) + "]. Got " +
-          std::to_string(num_tokens) + ".");
+          std::to_string(kMaxTokens) + "]. Got " + std::to_string(num_tokens) +
+          ".");
     }
 
-    RankData* ptrs = rank_data_for_buffer(
-        stream, input, "SM70 Gemma RMSNorm prototype input");
+    RankData* ptrs = rank_data_for_buffer(stream, input,
+                                          "SM70 Gemma RMSNorm prototype input");
     if constexpr (ngpus == 4) {
       // Keep the same 1024-thread CUB reduction topology as vLLM rms_norm.
       // packed_reduce preserves the cross_device_reduce_1stage<half, 4>
       // rank order before the FP32 residual add.
       sm70_peer_reduce_gemma_rms_norm<kSm70GemmaRmsNormThreads, ngpus,
-                                       ResidualT, WeightT>
+                                      ResidualT, WeightT>
           <<<num_tokens, kSm70GemmaRmsNormThreads, 0, stream>>>(
               ptrs, sg_, self_sg_, residual, weight, normalized_out,
               residual_out, rank_, epsilon);
@@ -1324,11 +1318,11 @@ class CustomAllreduce {
     }
 
     const int threads = sm70_gemma_rms_norm_threads();
-#define VLLM_LAUNCH_SM70_GEMMA_RMS_NORM(THREADS)                         \
+#define VLLM_LAUNCH_SM70_GEMMA_RMS_NORM(THREADS)                          \
   sm70_peer_reduce_gemma_rms_norm<THREADS, ngpus, ResidualT, WeightT>     \
-      <<<num_tokens, THREADS, 0, stream>>>(                               \
-          ptrs, sg_, self_sg_, residual, weight, normalized_out,          \
-          residual_out, rank_, epsilon)
+      <<<num_tokens, THREADS, 0, stream>>>(ptrs, sg_, self_sg_, residual, \
+                                           weight, normalized_out,        \
+                                           residual_out, rank_, epsilon)
     switch (threads) {
       case 256:
         VLLM_LAUNCH_SM70_GEMMA_RMS_NORM(256);
@@ -1400,29 +1394,28 @@ class CustomAllreduce {
       }
     }
 
-#define SUM2_KL(ngpus, name)                                                  \
-  name<T, ngpus><<<blocks, threads, 0, stream>>>(ptrs_a, ptrs_b, sg_,         \
-                                                 self_sg_, output, rank_,     \
-                                                 size);
-#define SUM2_CASE(ngpus)                              \
-  case ngpus: {                                      \
-    if (force_1stage) {                              \
-      SUM2_KL(ngpus, cross_device_reduce_sum2_1stage); \
-    } else if (force_2stage) {                       \
-      SUM2_KL(ngpus, cross_device_reduce_sum2_2stage); \
-    } else {                                         \
-      if (world_size_ == 2) {                        \
-        SUM2_KL(ngpus, cross_device_reduce_sum2_1stage); \
-      } else if (fully_connected_) {                 \
-        if ((world_size_ <= 4 && bytes < 512 * 1024) || \
-            (world_size_ <= 8 && bytes < 256 * 1024)) { \
+#define SUM2_KL(ngpus, name)                      \
+  name<T, ngpus><<<blocks, threads, 0, stream>>>( \
+      ptrs_a, ptrs_b, sg_, self_sg_, output, rank_, size);
+#define SUM2_CASE(ngpus)                                   \
+  case ngpus: {                                            \
+    if (force_1stage) {                                    \
+      SUM2_KL(ngpus, cross_device_reduce_sum2_1stage);     \
+    } else if (force_2stage) {                             \
+      SUM2_KL(ngpus, cross_device_reduce_sum2_2stage);     \
+    } else {                                               \
+      if (world_size_ == 2) {                              \
+        SUM2_KL(ngpus, cross_device_reduce_sum2_1stage);   \
+      } else if (fully_connected_) {                       \
+        if ((world_size_ <= 4 && bytes < 512 * 1024) ||    \
+            (world_size_ <= 8 && bytes < 256 * 1024)) {    \
           SUM2_KL(ngpus, cross_device_reduce_sum2_1stage); \
-        } else {                                     \
+        } else {                                           \
           SUM2_KL(ngpus, cross_device_reduce_sum2_2stage); \
-        }                                            \
-      }                                              \
-    }                                                \
-    break;                                           \
+        }                                                  \
+      }                                                    \
+    }                                                      \
+    break;                                                 \
   }
 
     switch (world_size_) {
@@ -1462,12 +1455,12 @@ class CustomAllreduce {
 
     const int packed_size = size / pack;
     const int tile_packed_size = tile_numel / pack;
-    const int tile_count = (packed_size + tile_packed_size - 1) / tile_packed_size;
+    const int tile_count =
+        (packed_size + tile_packed_size - 1) / tile_packed_size;
     if (tile_count <= 0 || tile_count > kMaxBlocks) {
       throw std::runtime_error(
           "SM70 tile runtime prototype supports tile_count in [1, " +
-          std::to_string(kMaxBlocks) + "]. Got " +
-          std::to_string(tile_count));
+          std::to_string(kMaxBlocks) + "]. Got " + std::to_string(tile_count));
     }
 
     auto it = buffers_.find(staging);
@@ -1484,14 +1477,12 @@ class CustomAllreduce {
     blocks = std::max(1, std::min(blocks, tile_count));
     compute_iters = std::max(0, compute_iters);
 
-#define TILE_RUNTIME_CASE(ngpus)                                             \
-  case ngpus: {                                                              \
-    sm70_tile_runtime_reduce_kernel<T, ngpus>                                \
-        <<<blocks, threads, 0, stream>>>(ptrs, sg_, self_sg_, input, staging, \
-                                         output, rank_, packed_size,          \
-                                         tile_packed_size, tile_count,        \
-                                         compute_iters);                     \
-    break;                                                                   \
+#define TILE_RUNTIME_CASE(ngpus)                                               \
+  case ngpus: {                                                                \
+    sm70_tile_runtime_reduce_kernel<T, ngpus><<<blocks, threads, 0, stream>>>( \
+        ptrs, sg_, self_sg_, input, staging, output, rank_, packed_size,       \
+        tile_packed_size, tile_count, compute_iters);                          \
+    break;                                                                     \
   }
 
     switch (world_size_) {
@@ -1531,8 +1522,7 @@ class CustomAllreduce {
     if (tile_count <= 0 || tile_count > kMaxBlocks) {
       throw std::runtime_error(
           "SM70 tile runtime engine supports tile_count in [1, " +
-          std::to_string(kMaxBlocks) + "]. Got " +
-          std::to_string(tile_count));
+          std::to_string(kMaxBlocks) + "]. Got " + std::to_string(tile_count));
     }
 
     auto it = buffers_.find(staging);
@@ -1554,15 +1544,13 @@ class CustomAllreduce {
     const int threads = 256;
     const int blocks = producer_blocks + reducer_blocks;
 
-#define TILE_RUNTIME_ENGINE_CASE(ngpus)                                      \
-  case ngpus: {                                                              \
-    sm70_tile_runtime_engine_kernel<T, ngpus>                                \
-        <<<blocks, threads, 0, stream>>>(ptrs, sg_, self_sg_, input, staging, \
-                                         output, rank_, packed_size,          \
-                                         tile_packed_size, tile_count,        \
-                                         producer_blocks, reducer_blocks,     \
-                                         compute_iters);                     \
-    break;                                                                   \
+#define TILE_RUNTIME_ENGINE_CASE(ngpus)                                        \
+  case ngpus: {                                                                \
+    sm70_tile_runtime_engine_kernel<T, ngpus><<<blocks, threads, 0, stream>>>( \
+        ptrs, sg_, self_sg_, input, staging, output, rank_, packed_size,       \
+        tile_packed_size, tile_count, producer_blocks, reducer_blocks,         \
+        compute_iters);                                                        \
+    break;                                                                     \
   }
 
     switch (world_size_) {
@@ -1576,8 +1564,7 @@ class CustomAllreduce {
 
   template <typename T>
   void tile_runtime_wait_reduce(cudaStream_t stream, T* staging, T* output,
-                                int size, int tile_numel,
-                                int reducer_blocks) {
+                                int size, int tile_numel, int reducer_blocks) {
     if (world_size_ != 2) {
       throw std::runtime_error(
           "SM70 tile runtime wait-reduce currently supports only TP2.");
@@ -1601,8 +1588,7 @@ class CustomAllreduce {
     if (tile_count <= 0 || tile_count > kMaxBlocks) {
       throw std::runtime_error(
           "SM70 tile runtime wait-reduce supports tile_count in [1, " +
-          std::to_string(kMaxBlocks) + "]. Got " +
-          std::to_string(tile_count));
+          std::to_string(kMaxBlocks) + "]. Got " + std::to_string(tile_count));
     }
 
     RankData* ptrs;
@@ -1628,13 +1614,13 @@ class CustomAllreduce {
 
     constexpr int threads = 256;
 
-#define TILE_RUNTIME_WAIT_REDUCE_CASE(ngpus)                                 \
-  case ngpus: {                                                              \
-    sm70_tile_runtime_wait_reduce_kernel<T, ngpus>                           \
-        <<<reducer_blocks, threads, 0, stream>>>(                            \
-            ptrs, sg_, self_sg_, output, rank_, packed_size,                 \
-            tile_packed_size, tile_count);                                   \
-    break;                                                                   \
+#define TILE_RUNTIME_WAIT_REDUCE_CASE(ngpus)                                   \
+  case ngpus: {                                                                \
+    sm70_tile_runtime_wait_reduce_kernel<T, ngpus>                             \
+        <<<reducer_blocks, threads, 0, stream>>>(                              \
+            ptrs, sg_, self_sg_, output, rank_, packed_size, tile_packed_size, \
+            tile_count);                                                       \
+    break;                                                                     \
   }
 
     switch (world_size_) {
@@ -1663,11 +1649,11 @@ class CustomAllreduce {
       ptrs = it->second;
     }
 
-#define TOP1_CASE(ngpus)                                   \
-  case ngpus: {                                            \
-    cross_device_top1_argmax<ngpus><<<1, 32, 0, stream>>>( \
-        ptrs, sg_, self_sg_, output, rank_);               \
-    break;                                                 \
+#define TOP1_CASE(ngpus)                                            \
+  case ngpus: {                                                     \
+    cross_device_top1_argmax<ngpus>                                 \
+        <<<1, 32, 0, stream>>>(ptrs, sg_, self_sg_, output, rank_); \
+    break;                                                          \
   }
 
     switch (world_size_) {

--- a/csrc/ops.h
+++ b/csrc/ops.h
@@ -174,6 +174,24 @@ void fp8_gemm_sm70_out(torch::Tensor out,
                        int64_t q_ld,
                        bool gated_silu);
 
+void fp8_qpn8_gemm_sm70_out(torch::Tensor out,
+                            torch::Tensor input,
+                            torch::Tensor codes,
+                            torch::Tensor group_scales,
+                            int64_t split_k,
+                            int64_t accumulator_chains,
+                            bool fast_decoder,
+                            bool prefetch_codes);
+
+void fp8_qpn8_gated_pair_sm70_out(torch::Tensor out,
+                                  torch::Tensor input,
+                                  torch::Tensor codes,
+                                  torch::Tensor group_scales,
+                                  int64_t split_k,
+                                  int64_t accumulator_chains,
+                                  bool fast_decoder,
+                                  bool prefetch_codes);
+
 void fp8_gemm_sm70_prefill_dispatch_out(
     torch::Tensor out, int64_t dense_weight_ptr, torch::Tensor _in_feats,
     torch::Tensor _kernel, torch::Tensor _scaling_factors, int64_t group_size,

--- a/csrc/ops.h
+++ b/csrc/ops.h
@@ -208,6 +208,26 @@ void fp8_qpn8_gated_pair_sm70_out(torch::Tensor out,
                                   bool fast_decoder,
                                   bool prefetch_codes);
 
+std::vector<torch::Tensor> nvfp4_qpn4_prepare_sm70(torch::Tensor qweight,
+                                                   torch::Tensor scales);
+
+std::vector<torch::Tensor> nvfp4_qpn4_prepare_scale_code_sm70(
+    torch::Tensor qweight, torch::Tensor scale_codes);
+
+void nvfp4_qpn4_dequantize_sm70_out(
+    torch::Tensor out, torch::Tensor codes, torch::Tensor scales,
+    double global_scale, bool use_scale_code);
+
+void nvfp4_qpn4_prefill_sm70_out(
+    torch::Tensor out, int64_t dense_weight_ptr, torch::Tensor input,
+    torch::Tensor codes, torch::Tensor scales, double global_scale,
+    bool use_scale_code, bool gated_silu);
+
+void nvfp4_qpn4_dispatch_sm70_out(
+    torch::Tensor out, int64_t dense_weight_ptr, torch::Tensor input,
+    torch::Tensor codes, torch::Tensor scales, double global_scale,
+    bool use_scale_code, bool gated_silu);
+
 void fp8_gemm_sm70_prefill_dispatch_out(
     torch::Tensor out, int64_t dense_weight_ptr, torch::Tensor _in_feats,
     torch::Tensor _kernel, torch::Tensor _scaling_factors, int64_t group_size,

--- a/csrc/ops.h
+++ b/csrc/ops.h
@@ -116,8 +116,7 @@ std::vector<torch::Tensor> fp8_sm70_prepare(torch::Tensor _kernel,
                                             int64_t group_size,
                                             bool interleave_gated_silu);
 
-void fp8_sm70_dequantize_out(torch::Tensor out,
-                             torch::Tensor _kernel,
+void fp8_sm70_dequantize_out(torch::Tensor out, torch::Tensor _kernel,
                              torch::Tensor _scaling_factors,
                              int64_t group_size);
 
@@ -133,45 +132,26 @@ std::vector<torch::Tensor> nvfp4_sm70_prepare(torch::Tensor _kernel,
 
 std::vector<torch::Tensor> sm70_f16_prepare(torch::Tensor _kernel);
 
-torch::Tensor awq_gemm_sm70(torch::Tensor _in_feats,
-                            torch::Tensor _kernel,
-                            torch::Tensor _scaling_factors,
-                            int64_t group_size,
-                            int64_t k_ld,
-                            int64_t q_ld);
+torch::Tensor awq_gemm_sm70(torch::Tensor _in_feats, torch::Tensor _kernel,
+                            torch::Tensor _scaling_factors, int64_t group_size,
+                            int64_t k_ld, int64_t q_ld);
 
 torch::Tensor sm70_f16_gemm(torch::Tensor _in_feats, torch::Tensor _kernel);
 
-void awq_gemm_sm70_out(torch::Tensor out,
-                       torch::Tensor _in_feats,
-                       torch::Tensor _kernel,
-                       torch::Tensor _scaling_factors,
-                       int64_t group_size,
-                       int64_t k_ld,
-                       int64_t q_ld,
+void awq_gemm_sm70_out(torch::Tensor out, torch::Tensor _in_feats,
+                       torch::Tensor _kernel, torch::Tensor _scaling_factors,
+                       int64_t group_size, int64_t k_ld, int64_t q_ld,
                        bool gated_silu);
 
-void awq_gemm_sm70_out_tile_reduce(torch::Tensor out,
-                                   torch::Tensor staging,
-                                   torch::Tensor _in_feats,
-                                   torch::Tensor _kernel,
-                                   torch::Tensor _scaling_factors,
-                                   int64_t group_size,
-                                   int64_t k_ld,
-                                   int64_t q_ld,
-                                   int64_t fa_ptr,
-                                   int64_t tile_numel,
-                                   int64_t reducer_blocks,
-                                   int64_t kernel_reducer_blocks,
-                                   bool overlap);
+void awq_gemm_sm70_out_tile_reduce(
+    torch::Tensor out, torch::Tensor staging, torch::Tensor _in_feats,
+    torch::Tensor _kernel, torch::Tensor _scaling_factors, int64_t group_size,
+    int64_t k_ld, int64_t q_ld, int64_t fa_ptr, int64_t tile_numel,
+    int64_t reducer_blocks, int64_t kernel_reducer_blocks, bool overlap);
 
-void fp8_gemm_sm70_out(torch::Tensor out,
-                       torch::Tensor _in_feats,
-                       torch::Tensor _kernel,
-                       torch::Tensor _scaling_factors,
-                       int64_t group_size,
-                       int64_t k_ld,
-                       int64_t q_ld,
+void fp8_gemm_sm70_out(torch::Tensor out, torch::Tensor _in_feats,
+                       torch::Tensor _kernel, torch::Tensor _scaling_factors,
+                       int64_t group_size, int64_t k_ld, int64_t q_ld,
                        bool gated_silu);
 
 std::vector<torch::Tensor> fp8_qpn8_prepare_sm70(torch::Tensor qweight,
@@ -190,22 +170,15 @@ void fp8_qpn8_dispatch_sm70_out(torch::Tensor out, int64_t dense_weight_ptr,
                                 int64_t accumulator_chains, bool prefetch_codes,
                                 bool gated_silu);
 
-void fp8_qpn8_gemm_sm70_out(torch::Tensor out,
-                            torch::Tensor input,
-                            torch::Tensor codes,
-                            torch::Tensor group_scales,
-                            int64_t split_k,
-                            int64_t accumulator_chains,
-                            bool fast_decoder,
-                            bool prefetch_codes);
+void fp8_qpn8_gemm_sm70_out(torch::Tensor out, torch::Tensor input,
+                            torch::Tensor codes, torch::Tensor group_scales,
+                            int64_t split_k, int64_t accumulator_chains,
+                            bool fast_decoder, bool prefetch_codes);
 
-void fp8_qpn8_gated_pair_sm70_out(torch::Tensor out,
-                                  torch::Tensor input,
+void fp8_qpn8_gated_pair_sm70_out(torch::Tensor out, torch::Tensor input,
                                   torch::Tensor codes,
-                                  torch::Tensor group_scales,
-                                  int64_t split_k,
-                                  int64_t accumulator_chains,
-                                  bool fast_decoder,
+                                  torch::Tensor group_scales, int64_t split_k,
+                                  int64_t accumulator_chains, bool fast_decoder,
                                   bool prefetch_codes);
 
 std::vector<torch::Tensor> nvfp4_qpn4_prepare_sm70(torch::Tensor qweight,
@@ -214,104 +187,81 @@ std::vector<torch::Tensor> nvfp4_qpn4_prepare_sm70(torch::Tensor qweight,
 std::vector<torch::Tensor> nvfp4_qpn4_prepare_scale_code_sm70(
     torch::Tensor qweight, torch::Tensor scale_codes);
 
-void nvfp4_qpn4_dequantize_sm70_out(
-    torch::Tensor out, torch::Tensor codes, torch::Tensor scales,
-    double global_scale, bool use_scale_code);
+void nvfp4_qpn4_dequantize_sm70_out(torch::Tensor out, torch::Tensor codes,
+                                    torch::Tensor scales, double global_scale,
+                                    bool use_scale_code);
 
-void nvfp4_qpn4_prefill_sm70_out(
-    torch::Tensor out, int64_t dense_weight_ptr, torch::Tensor input,
-    torch::Tensor codes, torch::Tensor scales, double global_scale,
-    bool use_scale_code, bool gated_silu);
+void nvfp4_qpn4_prefill_sm70_out(torch::Tensor out, int64_t dense_weight_ptr,
+                                 torch::Tensor input, torch::Tensor codes,
+                                 torch::Tensor scales, double global_scale,
+                                 bool use_scale_code, bool gated_silu);
 
-void nvfp4_qpn4_dispatch_sm70_out(
-    torch::Tensor out, int64_t dense_weight_ptr, torch::Tensor input,
-    torch::Tensor codes, torch::Tensor scales, double global_scale,
-    bool use_scale_code, bool gated_silu);
+void nvfp4_qpn4_dispatch_sm70_out(torch::Tensor out, int64_t dense_weight_ptr,
+                                  torch::Tensor input, torch::Tensor codes,
+                                  torch::Tensor scales, double global_scale,
+                                  bool use_scale_code, bool gated_silu);
 
 void fp8_gemm_sm70_prefill_dispatch_out(
     torch::Tensor out, int64_t dense_weight_ptr, torch::Tensor _in_feats,
     torch::Tensor _kernel, torch::Tensor _scaling_factors, int64_t group_size,
     int64_t k_ld, int64_t q_ld, bool gated_silu, int64_t min_prefill_m);
 
-void mxfp4_gemm_sm70_out(torch::Tensor out,
-                         torch::Tensor _in_feats,
-                         torch::Tensor _kernel,
-                         torch::Tensor _scaling_factors,
-                         int64_t group_size,
-                         int64_t k_ld,
-                         int64_t q_ld,
+void mxfp4_gemm_sm70_out(torch::Tensor out, torch::Tensor _in_feats,
+                         torch::Tensor _kernel, torch::Tensor _scaling_factors,
+                         int64_t group_size, int64_t k_ld, int64_t q_ld,
                          bool gated_silu);
 
-void nvfp4_gemm_sm70_out(torch::Tensor out,
-                         torch::Tensor _in_feats,
-                         torch::Tensor _kernel,
-                         torch::Tensor _scaling_factors,
-                         int64_t group_size,
-                         int64_t k_ld,
-                         int64_t q_ld,
+void nvfp4_gemm_sm70_out(torch::Tensor out, torch::Tensor _in_feats,
+                         torch::Tensor _kernel, torch::Tensor _scaling_factors,
+                         int64_t group_size, int64_t k_ld, int64_t q_ld,
                          bool gated_silu);
 
-void nvfp4_gemv_sm70_raw_out(torch::Tensor out,
-                             torch::Tensor _in_feats,
+void nvfp4_gemv_sm70_raw_out(torch::Tensor out, torch::Tensor _in_feats,
                              torch::Tensor _kernel,
                              torch::Tensor _scaling_factors,
-                             torch::Tensor partials,
-                             int64_t group_size,
+                             torch::Tensor partials, int64_t group_size,
                              int64_t split_k);
 
-void nvfp4_gemv_sm70_warp_out(torch::Tensor out,
-                              torch::Tensor _in_feats,
+void nvfp4_gemv_sm70_warp_out(torch::Tensor out, torch::Tensor _in_feats,
                               torch::Tensor _kernel,
                               torch::Tensor _scaling_factors,
                               int64_t group_size);
 
-void nvfp4_gemv_sm70_h2_out(torch::Tensor out,
-                            torch::Tensor _in_feats,
+void nvfp4_gemv_sm70_h2_out(torch::Tensor out, torch::Tensor _in_feats,
                             torch::Tensor _kernel,
                             torch::Tensor _scaling_factors,
-                            torch::Tensor partials,
-                            int64_t group_size,
+                            torch::Tensor partials, int64_t group_size,
                             int64_t split_k);
 
-void fp8_gemm_sm70_out_auto(torch::Tensor out,
-                            torch::Tensor _in_feats,
+void fp8_gemm_sm70_out_auto(torch::Tensor out, torch::Tensor _in_feats,
                             torch::Tensor _kernel,
                             torch::Tensor _scaling_factors);
 
-void fp8_gemm_sm70_out_meta(torch::Tensor out,
-                            torch::Tensor _in_feats,
+void fp8_gemm_sm70_out_meta(torch::Tensor out, torch::Tensor _in_feats,
                             torch::Tensor _kernel,
-                            torch::Tensor _scaling_factors,
-                            torch::Tensor _meta,
+                            torch::Tensor _scaling_factors, torch::Tensor _meta,
                             bool gated_silu);
 
-void sm70_f16_gemm_out(torch::Tensor out,
-                       torch::Tensor _in_feats,
-                       torch::Tensor _kernel,
-                       int64_t k_ld,
-                       bool gated_silu);
+void sm70_f16_gemm_out(torch::Tensor out, torch::Tensor _in_feats,
+                       torch::Tensor _kernel, int64_t k_ld, bool gated_silu);
 
 void sm70_f16_lm_head_top1_out(torch::Tensor values_out,
                                torch::Tensor indices_out,
-                               torch::Tensor _in_feats,
-                               torch::Tensor _kernel,
-                               int64_t k_ld,
-                               int64_t vocab_start_index,
+                               torch::Tensor _in_feats, torch::Tensor _kernel,
+                               int64_t k_ld, int64_t vocab_start_index,
                                int64_t num_vocab_padding);
 
 void sm70_f16_lm_head_top1_tc_out(torch::Tensor values_out,
                                   torch::Tensor indices_out,
                                   torch::Tensor _in_feats,
-                                  torch::Tensor _kernel,
-                                  int64_t k_ld,
+                                  torch::Tensor _kernel, int64_t k_ld,
                                   int64_t vocab_start_index,
                                   int64_t num_vocab_padding);
 
 void sm70_f16_lm_head_top20_tc_out(torch::Tensor values_out,
                                    torch::Tensor indices_out,
                                    torch::Tensor _in_feats,
-                                   torch::Tensor _kernel,
-                                   int64_t k_ld,
+                                   torch::Tensor _kernel, int64_t k_ld,
                                    int64_t vocab_start_index,
                                    int64_t num_vocab_padding);
 
@@ -327,27 +277,20 @@ void sm70_sample_packed_top20_out(torch::Tensor sampled_token_out,
                                   torch::Tensor sparse_ids_out,
                                   torch::Tensor sparse_probs_out,
                                   torch::Tensor gathered_pairs,
-                                  torch::Tensor exponential,
-                                  double top_p);
+                                  torch::Tensor exponential, double top_p);
 
 void sm70_dynamic_draft_vocab_update_tail_out(
-    torch::Tensor lru_token_ids,
-    torch::Tensor local_tail_token_ids,
-    torch::Tensor source_row_indices,
-    torch::Tensor observed_output_ids,
-    torch::Tensor target_candidate_ids,
-    torch::Tensor base_token_mask,
-    int64_t full_vocab_size,
-    int64_t local_shard_start,
+    torch::Tensor lru_token_ids, torch::Tensor local_tail_token_ids,
+    torch::Tensor source_row_indices, torch::Tensor observed_output_ids,
+    torch::Tensor target_candidate_ids, torch::Tensor base_token_mask,
+    int64_t full_vocab_size, int64_t local_shard_start,
     int64_t local_shard_end);
 
 void sm70_dynamic_draft_vocab_refresh_tail_weight_out(
-    torch::Tensor local_tail_weight,
-    torch::Tensor source_weight,
+    torch::Tensor local_tail_weight, torch::Tensor source_weight,
     torch::Tensor source_row_indices);
 
-void sm70_f16_gate_mul_out(torch::Tensor out,
-                           torch::Tensor _in_feats,
+void sm70_f16_gate_mul_out(torch::Tensor out, torch::Tensor _in_feats,
                            torch::Tensor _gate_weight);
 
 int64_t sm70_gemm_import_cache(torch::Tensor device_hint,
@@ -356,205 +299,114 @@ int64_t sm70_gemm_import_cache(torch::Tensor device_hint,
 int64_t sm70_gemm_export_cache(torch::Tensor device_hint,
                                const std::string& path);
 
-std::vector<torch::Tensor> awq_moe_build_strided_ptrs(
-    torch::Tensor tm_weights,
-    torch::Tensor tm_scales,
-    int64_t k_ld,
-    int64_t q_ld,
-    int64_t num_experts);
+std::vector<torch::Tensor> awq_moe_build_strided_ptrs(torch::Tensor tm_weights,
+                                                      torch::Tensor tm_scales,
+                                                      int64_t k_ld,
+                                                      int64_t q_ld,
+                                                      int64_t num_experts);
 
-void awq_moe_gemm_sm70_out(torch::Tensor out,
-                           torch::Tensor sorted_input,
+void awq_moe_gemm_sm70_out(torch::Tensor out, torch::Tensor sorted_input,
                            torch::Tensor expert_offsets,
                            torch::Tensor strided_ptrs_w,
-                           torch::Tensor strided_ptrs_s,
-                           int64_t num_experts,
-                           int64_t k,
-                           int64_t n,
-                           int64_t group_size,
+                           torch::Tensor strided_ptrs_s, int64_t num_experts,
+                           int64_t k, int64_t n, int64_t group_size,
                            bool gated_silu);
 
-void awq_moe_gemm_sm70_per_expert_dispatch_out(torch::Tensor out,
-                                               torch::Tensor sorted_input,
-                                               torch::Tensor expert_offsets,
-                                               torch::Tensor strided_ptrs_w,
-                                               torch::Tensor strided_ptrs_s,
-                                               int64_t num_experts,
-                                               int64_t k,
-                                               int64_t n,
-                                               int64_t group_size,
-                                               bool gated_silu);
+void awq_moe_gemm_sm70_per_expert_dispatch_out(
+    torch::Tensor out, torch::Tensor sorted_input, torch::Tensor expert_offsets,
+    torch::Tensor strided_ptrs_w, torch::Tensor strided_ptrs_s,
+    int64_t num_experts, int64_t k, int64_t n, int64_t group_size,
+    bool gated_silu);
 
-void awq_moe_dense_stage_sm70_out(torch::Tensor out,
-                                  torch::Tensor input,
+void awq_moe_dense_stage_sm70_out(torch::Tensor out, torch::Tensor input,
                                   torch::Tensor expert_offsets,
                                   torch::Tensor dense_expert_ids,
-                                  torch::Tensor ptrs_w,
-                                  torch::Tensor ptrs_s,
-                                  int64_t num_experts,
-                                  int64_t k,
-                                  int64_t n,
+                                  torch::Tensor ptrs_w, torch::Tensor ptrs_s,
+                                  int64_t num_experts, int64_t k, int64_t n,
                                   int64_t group_size);
 
 void awq_moe_active_dense_stage_sm70_out(
-    torch::Tensor out,
-    torch::Tensor input,
-    torch::Tensor permuted_experts_id,
-    torch::Tensor active_expert_offsets,
-    torch::Tensor active_expert_ids,
-    torch::Tensor ptrs_w,
-    torch::Tensor ptrs_s,
-    int64_t total_slots,
-    int64_t k,
-    int64_t n,
-    int64_t group_size);
+    torch::Tensor out, torch::Tensor input, torch::Tensor permuted_experts_id,
+    torch::Tensor active_expert_offsets, torch::Tensor active_expert_ids,
+    torch::Tensor ptrs_w, torch::Tensor ptrs_s, int64_t total_slots, int64_t k,
+    int64_t n, int64_t group_size);
 
 void awq_moe_single_token_dense_stage_sm70_out(
-    torch::Tensor out,
-    torch::Tensor input,
-    torch::Tensor expert_offsets,
-    torch::Tensor sorted_expert_ids,
-    torch::Tensor ptrs_w,
-    torch::Tensor ptrs_s,
-    int64_t top_k,
-    int64_t k,
-    int64_t n,
-    int64_t group_size);
+    torch::Tensor out, torch::Tensor input, torch::Tensor expert_offsets,
+    torch::Tensor sorted_expert_ids, torch::Tensor ptrs_w, torch::Tensor ptrs_s,
+    int64_t top_k, int64_t k, int64_t n, int64_t group_size);
 
 void awq_moe_single_token_indexed_dense_stage_sm70_out(
-    torch::Tensor out,
-    torch::Tensor input,
-    torch::Tensor expert_offsets,
-    torch::Tensor sorted_expert_ids,
-    torch::Tensor ptrs_w,
-    torch::Tensor ptrs_s,
-    int64_t top_k,
-    int64_t k,
-    int64_t n,
-    int64_t group_size);
+    torch::Tensor out, torch::Tensor input, torch::Tensor expert_offsets,
+    torch::Tensor sorted_expert_ids, torch::Tensor ptrs_w, torch::Tensor ptrs_s,
+    int64_t top_k, int64_t k, int64_t n, int64_t group_size);
 
 void awq_moe_single_token_dense_w13_sm70_out(
-    torch::Tensor gate_up,
-    torch::Tensor compact_input,
-    torch::Tensor x,
-    torch::Tensor topk_ids,
-    torch::Tensor w13_ptrs_w,
-    torch::Tensor w13_ptrs_s,
-    torch::Tensor expert_offsets,
-    torch::Tensor expert_offsets64,
-    torch::Tensor inv_permuted_idx,
-    torch::Tensor sorted_expert_ids,
-    int64_t w13_k,
-    int64_t w13_n,
-    int64_t group_size,
+    torch::Tensor gate_up, torch::Tensor compact_input, torch::Tensor x,
+    torch::Tensor topk_ids, torch::Tensor w13_ptrs_w, torch::Tensor w13_ptrs_s,
+    torch::Tensor expert_offsets, torch::Tensor expert_offsets64,
+    torch::Tensor inv_permuted_idx, torch::Tensor sorted_expert_ids,
+    int64_t w13_k, int64_t w13_n, int64_t group_size,
     int64_t hidden_logical_size);
 
 void awq_moe_single_token_indexed_dense_w13_sm70_out(
-    torch::Tensor gate_up,
-    torch::Tensor compact_input,
-    torch::Tensor x,
-    torch::Tensor topk_ids,
-    torch::Tensor w13_ptrs_w,
-    torch::Tensor w13_ptrs_s,
-    torch::Tensor expert_offsets,
-    torch::Tensor expert_offsets64,
-    torch::Tensor inv_permuted_idx,
-    torch::Tensor sorted_expert_ids,
-    int64_t w13_k,
-    int64_t w13_n,
-    int64_t group_size,
+    torch::Tensor gate_up, torch::Tensor compact_input, torch::Tensor x,
+    torch::Tensor topk_ids, torch::Tensor w13_ptrs_w, torch::Tensor w13_ptrs_s,
+    torch::Tensor expert_offsets, torch::Tensor expert_offsets64,
+    torch::Tensor inv_permuted_idx, torch::Tensor sorted_expert_ids,
+    int64_t w13_k, int64_t w13_n, int64_t group_size,
     int64_t hidden_logical_size);
 
 void awq_moe_single_token_compact_dense_w13_sm70_out(
-    torch::Tensor gate_up,
-    torch::Tensor compact_input,
-    torch::Tensor x,
-    torch::Tensor topk_ids,
-    torch::Tensor w13_ptrs_w,
-    torch::Tensor w13_ptrs_s,
-    torch::Tensor compact_w13_ptrs_w,
-    torch::Tensor compact_w13_ptrs_s,
-    torch::Tensor expert_offsets,
-    torch::Tensor expert_offsets64,
-    torch::Tensor inv_permuted_idx,
-    torch::Tensor sorted_expert_ids,
-    int64_t w13_k,
-    int64_t w13_n,
-    int64_t group_size,
+    torch::Tensor gate_up, torch::Tensor compact_input, torch::Tensor x,
+    torch::Tensor topk_ids, torch::Tensor w13_ptrs_w, torch::Tensor w13_ptrs_s,
+    torch::Tensor compact_w13_ptrs_w, torch::Tensor compact_w13_ptrs_s,
+    torch::Tensor expert_offsets, torch::Tensor expert_offsets64,
+    torch::Tensor inv_permuted_idx, torch::Tensor sorted_expert_ids,
+    int64_t w13_k, int64_t w13_n, int64_t group_size,
     int64_t hidden_logical_size);
 
-void awq_moe_single_token_exact_layout_prepare(torch::Tensor topk_ids,
-                                               torch::Tensor x,
-                                               torch::Tensor compact_input,
-                                               torch::Tensor expert_offsets,
-                                               torch::Tensor expert_offsets64,
-                                               torch::Tensor inv_permuted_idx,
-                                               int64_t num_experts);
+void awq_moe_single_token_exact_layout_prepare(
+    torch::Tensor topk_ids, torch::Tensor x, torch::Tensor compact_input,
+    torch::Tensor expert_offsets, torch::Tensor expert_offsets64,
+    torch::Tensor inv_permuted_idx, int64_t num_experts);
 
 void awq_moe_single_token_weighted_reduce_out(torch::Tensor sorted_output,
                                               torch::Tensor topk_weights,
                                               torch::Tensor inv_permuted_idx,
-                                              torch::Tensor out,
-                                              int64_t top_k,
+                                              torch::Tensor out, int64_t top_k,
                                               int64_t hidden_logical_size);
 
 void awq_moe_single_token_sm70_out(
-    torch::Tensor out,
-    torch::Tensor x,
-    torch::Tensor topk_weights,
-    torch::Tensor topk_ids,
-    torch::Tensor src_w13_ptrs_w_rows,
-    torch::Tensor src_w13_ptrs_s_rows,
-    torch::Tensor src_w2_ptrs_w_rows,
-    torch::Tensor src_w2_ptrs_s_rows,
-    torch::Tensor compact_input,
-    torch::Tensor intermediate,
-    torch::Tensor sorted_output,
-    torch::Tensor sorted_weights,
-    torch::Tensor dst_w13_ptrs_w_rows,
-    torch::Tensor dst_w13_ptrs_s_rows,
-    torch::Tensor dst_w2_ptrs_w_rows,
-    torch::Tensor dst_w2_ptrs_s_rows,
-    torch::Tensor expert_offsets,
-    torch::Tensor inv_permuted_idx,
-    int64_t w13_k,
-    int64_t w13_n,
-    int64_t w2_k,
-    int64_t w2_n,
-    int64_t group_size,
-    int64_t hidden_logical_size);
+    torch::Tensor out, torch::Tensor x, torch::Tensor topk_weights,
+    torch::Tensor topk_ids, torch::Tensor src_w13_ptrs_w_rows,
+    torch::Tensor src_w13_ptrs_s_rows, torch::Tensor src_w2_ptrs_w_rows,
+    torch::Tensor src_w2_ptrs_s_rows, torch::Tensor compact_input,
+    torch::Tensor intermediate, torch::Tensor sorted_output,
+    torch::Tensor sorted_weights, torch::Tensor dst_w13_ptrs_w_rows,
+    torch::Tensor dst_w13_ptrs_s_rows, torch::Tensor dst_w2_ptrs_w_rows,
+    torch::Tensor dst_w2_ptrs_s_rows, torch::Tensor expert_offsets,
+    torch::Tensor inv_permuted_idx, int64_t w13_k, int64_t w13_n, int64_t w2_k,
+    int64_t w2_n, int64_t group_size, int64_t hidden_logical_size);
 
-void fp8_moe_gemm_sm70_out(torch::Tensor out,
-                           torch::Tensor sorted_input,
+void fp8_moe_gemm_sm70_out(torch::Tensor out, torch::Tensor sorted_input,
                            torch::Tensor expert_offsets,
                            torch::Tensor strided_ptrs_w,
-                           torch::Tensor strided_ptrs_s,
-                           int64_t num_experts,
-                           int64_t k,
-                           int64_t n,
-                           int64_t group_size,
+                           torch::Tensor strided_ptrs_s, int64_t num_experts,
+                           int64_t k, int64_t n, int64_t group_size,
                            bool gated_silu);
 
-void fp8_moe_gemm_sm70_per_expert_dispatch_out(torch::Tensor out,
-                                               torch::Tensor sorted_input,
-                                               torch::Tensor expert_offsets,
-                                               torch::Tensor strided_ptrs_w,
-                                               torch::Tensor strided_ptrs_s,
-                                               int64_t num_experts,
-                                               int64_t k,
-                                               int64_t n,
-                                               int64_t group_size,
-                                               bool gated_silu);
+void fp8_moe_gemm_sm70_per_expert_dispatch_out(
+    torch::Tensor out, torch::Tensor sorted_input, torch::Tensor expert_offsets,
+    torch::Tensor strided_ptrs_w, torch::Tensor strided_ptrs_s,
+    int64_t num_experts, int64_t k, int64_t n, int64_t group_size,
+    bool gated_silu);
 
-void fp8_moe_dense_stage_sm70_out(torch::Tensor out,
-                                  torch::Tensor input,
+void fp8_moe_dense_stage_sm70_out(torch::Tensor out, torch::Tensor input,
                                   torch::Tensor expert_offsets,
                                   torch::Tensor dense_expert_ids,
-                                  torch::Tensor ptrs_w,
-                                  torch::Tensor ptrs_s,
-                                  int64_t num_experts,
-                                  int64_t k,
-                                  int64_t n,
+                                  torch::Tensor ptrs_w, torch::Tensor ptrs_s,
+                                  int64_t num_experts, int64_t k, int64_t n,
                                   int64_t group_size);
 
 void mxfp4_moe_dense_stage_sm70_out(torch::Tensor out, torch::Tensor input,
@@ -572,130 +424,63 @@ void nvfp4_moe_dense_stage_sm70_out(torch::Tensor out, torch::Tensor input,
                                     int64_t group_size);
 
 void mxfp4_moe_single_token_prepare_w13_sm70_out(
-    torch::Tensor gate_up,
-    torch::Tensor compact_input,
-    torch::Tensor x,
-    torch::Tensor topk_ids,
-    torch::Tensor w13_ptrs_w,
-    torch::Tensor w13_ptrs_s,
-    torch::Tensor expert_offsets,
-    torch::Tensor inv_permuted_idx,
-    torch::Tensor sorted_expert_ids,
-    int64_t w13_k,
-    int64_t w13_n,
-    int64_t group_size,
-    int64_t hidden_logical_size);
+    torch::Tensor gate_up, torch::Tensor compact_input, torch::Tensor x,
+    torch::Tensor topk_ids, torch::Tensor w13_ptrs_w, torch::Tensor w13_ptrs_s,
+    torch::Tensor expert_offsets, torch::Tensor inv_permuted_idx,
+    torch::Tensor sorted_expert_ids, int64_t w13_k, int64_t w13_n,
+    int64_t group_size, int64_t hidden_logical_size);
 
 void fp8_moe_single_token_dense_stage_sm70_out(
-    torch::Tensor out,
-    torch::Tensor input,
-    torch::Tensor expert_offsets,
-    torch::Tensor sorted_expert_ids,
-    torch::Tensor ptrs_w,
-    torch::Tensor ptrs_s,
-    int64_t top_k,
-    int64_t k,
-    int64_t n,
-    int64_t group_size);
+    torch::Tensor out, torch::Tensor input, torch::Tensor expert_offsets,
+    torch::Tensor sorted_expert_ids, torch::Tensor ptrs_w, torch::Tensor ptrs_s,
+    int64_t top_k, int64_t k, int64_t n, int64_t group_size);
 
 void fp8_moe_single_token_indexed_dense_stage_sm70_out(
-    torch::Tensor out,
-    torch::Tensor input,
-    torch::Tensor expert_offsets,
-    torch::Tensor sorted_expert_ids,
-    torch::Tensor ptrs_w,
-    torch::Tensor ptrs_s,
-    int64_t top_k,
-    int64_t k,
-    int64_t n,
-    int64_t group_size);
+    torch::Tensor out, torch::Tensor input, torch::Tensor expert_offsets,
+    torch::Tensor sorted_expert_ids, torch::Tensor ptrs_w, torch::Tensor ptrs_s,
+    int64_t top_k, int64_t k, int64_t n, int64_t group_size);
 
 void fp8_moe_single_token_dense_w13_sm70_out(
-    torch::Tensor gate_up,
-    torch::Tensor compact_input,
-    torch::Tensor x,
-    torch::Tensor topk_ids,
-    torch::Tensor w13_ptrs_w,
-    torch::Tensor w13_ptrs_s,
-    torch::Tensor expert_offsets,
-    torch::Tensor expert_offsets64,
-    torch::Tensor inv_permuted_idx,
-    torch::Tensor sorted_expert_ids,
-    int64_t w13_k,
-    int64_t w13_n,
-    int64_t group_size,
+    torch::Tensor gate_up, torch::Tensor compact_input, torch::Tensor x,
+    torch::Tensor topk_ids, torch::Tensor w13_ptrs_w, torch::Tensor w13_ptrs_s,
+    torch::Tensor expert_offsets, torch::Tensor expert_offsets64,
+    torch::Tensor inv_permuted_idx, torch::Tensor sorted_expert_ids,
+    int64_t w13_k, int64_t w13_n, int64_t group_size,
     int64_t hidden_logical_size);
 
 void fp8_moe_single_token_indexed_dense_w13_sm70_out(
-    torch::Tensor gate_up,
-    torch::Tensor compact_input,
-    torch::Tensor x,
-    torch::Tensor topk_ids,
-    torch::Tensor w13_ptrs_w,
-    torch::Tensor w13_ptrs_s,
-    torch::Tensor expert_offsets,
-    torch::Tensor expert_offsets64,
-    torch::Tensor inv_permuted_idx,
-    torch::Tensor sorted_expert_ids,
-    int64_t w13_k,
-    int64_t w13_n,
-    int64_t group_size,
+    torch::Tensor gate_up, torch::Tensor compact_input, torch::Tensor x,
+    torch::Tensor topk_ids, torch::Tensor w13_ptrs_w, torch::Tensor w13_ptrs_s,
+    torch::Tensor expert_offsets, torch::Tensor expert_offsets64,
+    torch::Tensor inv_permuted_idx, torch::Tensor sorted_expert_ids,
+    int64_t w13_k, int64_t w13_n, int64_t group_size,
     int64_t hidden_logical_size);
 
 void fp8_moe_single_token_compact_dense_w13_sm70_out(
-    torch::Tensor gate_up,
-    torch::Tensor compact_input,
-    torch::Tensor x,
-    torch::Tensor topk_ids,
-    torch::Tensor w13_ptrs_w,
-    torch::Tensor w13_ptrs_s,
-    torch::Tensor compact_w13_ptrs_w,
-    torch::Tensor compact_w13_ptrs_s,
-    torch::Tensor expert_offsets,
-    torch::Tensor expert_offsets64,
-    torch::Tensor inv_permuted_idx,
-    torch::Tensor sorted_expert_ids,
-    int64_t w13_k,
-    int64_t w13_n,
-    int64_t group_size,
+    torch::Tensor gate_up, torch::Tensor compact_input, torch::Tensor x,
+    torch::Tensor topk_ids, torch::Tensor w13_ptrs_w, torch::Tensor w13_ptrs_s,
+    torch::Tensor compact_w13_ptrs_w, torch::Tensor compact_w13_ptrs_s,
+    torch::Tensor expert_offsets, torch::Tensor expert_offsets64,
+    torch::Tensor inv_permuted_idx, torch::Tensor sorted_expert_ids,
+    int64_t w13_k, int64_t w13_n, int64_t group_size,
     int64_t hidden_logical_size);
 
 void fp8_moe_single_token_sm70_out(
-    torch::Tensor out,
-    torch::Tensor x,
-    torch::Tensor topk_weights,
-    torch::Tensor topk_ids,
-    torch::Tensor src_w13_ptrs_w_rows,
-    torch::Tensor src_w13_ptrs_s_rows,
-    torch::Tensor src_w2_ptrs_w_rows,
-    torch::Tensor src_w2_ptrs_s_rows,
-    torch::Tensor compact_input,
-    torch::Tensor gate_up,
-    torch::Tensor intermediate,
-    torch::Tensor sorted_output,
-    torch::Tensor sorted_weights,
-    torch::Tensor dst_w13_ptrs_w_rows,
-    torch::Tensor dst_w13_ptrs_s_rows,
-    torch::Tensor dst_w2_ptrs_w_rows,
-    torch::Tensor dst_w2_ptrs_s_rows,
-    torch::Tensor expert_offsets,
-    torch::Tensor inv_permuted_idx,
-    torch::Tensor sorted_expert_ids,
-    torch::Tensor broadcast_input_indices,
-    torch::Tensor w2_raw_weight,
-    torch::Tensor w2_raw_scale_inv,
-    int64_t w13_k,
-    int64_t w13_n,
-    int64_t w2_k,
-    int64_t w2_n,
-    int64_t group_size,
-    int64_t hidden_logical_size,
-    bool fused_gated_silu,
-    bool fused_weighted_reduce,
-    bool broadcast_input,
-    bool w2_direct_reduce,
-    bool indexed_expert_ptrs,
-    bool exact_per_route);
+    torch::Tensor out, torch::Tensor x, torch::Tensor topk_weights,
+    torch::Tensor topk_ids, torch::Tensor src_w13_ptrs_w_rows,
+    torch::Tensor src_w13_ptrs_s_rows, torch::Tensor src_w2_ptrs_w_rows,
+    torch::Tensor src_w2_ptrs_s_rows, torch::Tensor compact_input,
+    torch::Tensor gate_up, torch::Tensor intermediate,
+    torch::Tensor sorted_output, torch::Tensor sorted_weights,
+    torch::Tensor dst_w13_ptrs_w_rows, torch::Tensor dst_w13_ptrs_s_rows,
+    torch::Tensor dst_w2_ptrs_w_rows, torch::Tensor dst_w2_ptrs_s_rows,
+    torch::Tensor expert_offsets, torch::Tensor inv_permuted_idx,
+    torch::Tensor sorted_expert_ids, torch::Tensor broadcast_input_indices,
+    torch::Tensor w2_raw_weight, torch::Tensor w2_raw_scale_inv, int64_t w13_k,
+    int64_t w13_n, int64_t w2_k, int64_t w2_n, int64_t group_size,
+    int64_t hidden_logical_size, bool fused_gated_silu,
+    bool fused_weighted_reduce, bool broadcast_input, bool w2_direct_reduce,
+    bool indexed_expert_ptrs, bool exact_per_route);
 #endif
 
 void static_scaled_int8_quant(torch::Tensor& out, torch::Tensor const& input,
@@ -721,27 +506,25 @@ void all_reduce(fptr_t _fa, torch::Tensor& inp, torch::Tensor& out,
 void sm70_tp2_all_reduce_gemma_rms_norm(
     fptr_t _fa, torch::Tensor& inp, torch::Tensor& residual,
     torch::Tensor& weight, torch::Tensor& normalized_out,
-    torch::Tensor& residual_out, fptr_t reg_buffer,
-    int64_t reg_buffer_sz_bytes, double epsilon);
+    torch::Tensor& residual_out, fptr_t reg_buffer, int64_t reg_buffer_sz_bytes,
+    double epsilon);
 void sm70_tp4_all_reduce_gemma_rms_norm(
     fptr_t _fa, torch::Tensor& inp, torch::Tensor& residual,
     torch::Tensor& weight, torch::Tensor& normalized_out,
-    torch::Tensor& residual_out, fptr_t reg_buffer,
-    int64_t reg_buffer_sz_bytes, double epsilon);
+    torch::Tensor& residual_out, fptr_t reg_buffer, int64_t reg_buffer_sz_bytes,
+    double epsilon);
 void all_reduce_sum2(fptr_t _fa, torch::Tensor& inp_a, torch::Tensor& inp_b,
                      torch::Tensor& out);
 void top1_argmax(fptr_t _fa, torch::Tensor& input_pair, torch::Tensor& output,
                  fptr_t reg_buffer, int64_t reg_buffer_sz_bytes);
 void tile_runtime_all_reduce(fptr_t _fa, torch::Tensor& inp, torch::Tensor& out,
-                             fptr_t reg_buffer,
-                             int64_t reg_buffer_sz_bytes,
+                             fptr_t reg_buffer, int64_t reg_buffer_sz_bytes,
                              int64_t tile_numel, int64_t engine_blocks,
                              int64_t compute_iters);
 void tile_runtime_all_reduce_engine(fptr_t _fa, torch::Tensor& inp,
                                     torch::Tensor& out, fptr_t reg_buffer,
                                     int64_t reg_buffer_sz_bytes,
-                                    int64_t tile_numel,
-                                    int64_t producer_blocks,
+                                    int64_t tile_numel, int64_t producer_blocks,
                                     int64_t reducer_blocks,
                                     int64_t compute_iters);
 void tile_runtime_wait_reduce(fptr_t _fa, torch::Tensor& staging,

--- a/csrc/ops.h
+++ b/csrc/ops.h
@@ -174,6 +174,22 @@ void fp8_gemm_sm70_out(torch::Tensor out,
                        int64_t q_ld,
                        bool gated_silu);
 
+std::vector<torch::Tensor> fp8_qpn8_prepare_sm70(torch::Tensor qweight,
+                                                 torch::Tensor scales);
+
+void fp8_qpn8_dequantize_sm70_out(torch::Tensor out, torch::Tensor codes,
+                                  torch::Tensor group_scales);
+
+void fp8_qpn8_prefill_sm70_out(torch::Tensor out, int64_t dense_weight_ptr,
+                               torch::Tensor input, torch::Tensor codes,
+                               torch::Tensor group_scales, bool gated_silu);
+
+void fp8_qpn8_dispatch_sm70_out(torch::Tensor out, int64_t dense_weight_ptr,
+                                torch::Tensor input, torch::Tensor codes,
+                                torch::Tensor group_scales, int64_t split_k,
+                                int64_t accumulator_chains, bool prefetch_codes,
+                                bool gated_silu);
+
 void fp8_qpn8_gemm_sm70_out(torch::Tensor out,
                             torch::Tensor input,
                             torch::Tensor codes,

--- a/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/gemm.cu
+++ b/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/gemm.cu
@@ -25,668 +25,636 @@
 
 namespace turbomind::gemm {
 
-void ExportDispatchCache(std::ostream& os, const std::vector<std::pair<GemmDesc, LaunchSpec>>& entries);
+void ExportDispatchCache(
+    std::ostream& os,
+    const std::vector<std::pair<GemmDesc, LaunchSpec>>& entries);
 
-void ImportDispatchCache(std::istream&                                 is,
+void ImportDispatchCache(std::istream& is,
                          std::vector<std::pair<GemmDesc, LaunchSpec>>& entries,
-                         const std::vector<std::unique_ptr<Kernel>>&   kernels);
+                         const std::vector<std::unique_ptr<Kernel>>& kernels);
 
 namespace {
 
-template<class Cmp>
-std::vector<int> ArgSort(size_t size, const Cmp& cmp)
-{
-    std::vector<int> idxs(size);
-    std::iota(idxs.begin(), idxs.end(), 0);
-    std::stable_sort(idxs.begin(), idxs.end(), cmp);
-    return idxs;
+template <class Cmp>
+std::vector<int> ArgSort(size_t size, const Cmp& cmp) {
+  std::vector<int> idxs(size);
+  std::iota(idxs.begin(), idxs.end(), 0);
+  std::stable_sort(idxs.begin(), idxs.end(), cmp);
+  return idxs;
 }
 
-bool GemmTraceEnabled()
-{
-    const char* raw = std::getenv("TM_GEMM_TRACE");
-    return raw && std::atoi(raw) != 0;
+bool GemmTraceEnabled() {
+  const char* raw = std::getenv("TM_GEMM_TRACE");
+  return raw && std::atoi(raw) != 0;
 }
 
-int GemmTraceLimit()
-{
-    const char* raw = std::getenv("TM_GEMM_TRACE_LIMIT");
-    return raw ? std::max(std::atoi(raw), 0) : 256;
+int GemmTraceLimit() {
+  const char* raw = std::getenv("TM_GEMM_TRACE_LIMIT");
+  return raw ? std::max(std::atoi(raw), 0) : 256;
 }
 
-bool GemmTraceFilterAllows(const std::string& desc)
-{
-    const char* raw = std::getenv("TM_GEMM_TRACE_FILTER");
-    return !raw || !*raw || desc.find(raw) != std::string::npos;
+bool GemmTraceFilterAllows(const std::string& desc) {
+  const char* raw = std::getenv("TM_GEMM_TRACE_FILTER");
+  return !raw || !*raw || desc.find(raw) != std::string::npos;
 }
 
-bool Sm70AwqTp2FastSelectorEnabled()
-{
-    const char* raw = std::getenv("VLLM_SM70_AWQ_TP2_FAST_SELECTOR");
-    return !raw || std::atoi(raw) != 0;
+bool Sm70AwqTp2FastSelectorEnabled() {
+  const char* raw = std::getenv("VLLM_SM70_AWQ_TP2_FAST_SELECTOR");
+  return !raw || std::atoi(raw) != 0;
 }
 
 // Keep the accepted QKVZ route enabled by default, while allowing an isolated
 // end-to-end A/B comparison without disabling the other exact small-M routes.
-bool Sm70AwqTp4QkvCta64Enabled()
-{
-    const char* raw = std::getenv("VLLM_SM70_AWQ_TP4_QKV_CTA64");
-    return !raw || std::atoi(raw) != 0;
+bool Sm70AwqTp4QkvCta64Enabled() {
+  const char* raw = std::getenv("VLLM_SM70_AWQ_TP4_QKV_CTA64");
+  return !raw || std::atoi(raw) != 0;
 }
 
 // Default-on A/B gate for the exact TP4 MTP verifier M=5 routes.
-bool Sm70AwqMtpM5FastSelectorEnabled()
-{
-    const char* raw = std::getenv("VLLM_SM70_AWQ_MTP_M5_FAST_SELECTOR");
-    return !raw || std::atoi(raw) != 0;
+bool Sm70AwqMtpM5FastSelectorEnabled() {
+  const char* raw = std::getenv("VLLM_SM70_AWQ_MTP_M5_FAST_SELECTOR");
+  return !raw || std::atoi(raw) != 0;
 }
 
-bool Sm70Mxfp4MoeGroupedM8FastSelectorEnabled()
-{
-    const char* grouped = std::getenv("VLLM_SM70_MXFP4_MOE_GROUPED_M8");
-    if (!grouped || std::atoi(grouped) == 0) {
-        return false;
-    }
-    const char* raw = std::getenv("VLLM_SM70_MXFP4_MOE_GROUPED_M8_FAST_SELECTOR");
-    return !raw || std::atoi(raw) != 0;
+bool Sm70Mxfp4MoeGroupedM8FastSelectorEnabled() {
+  const char* grouped = std::getenv("VLLM_SM70_MXFP4_MOE_GROUPED_M8");
+  if (!grouped || std::atoi(grouped) == 0) {
+    return false;
+  }
+  const char* raw = std::getenv("VLLM_SM70_MXFP4_MOE_GROUPED_M8_FAST_SELECTOR");
+  return !raw || std::atoi(raw) != 0;
 }
 
-bool Sm70Nvfp4Qwen38Tp4M1FastSelectorEnabled()
-{
-    const char* raw = std::getenv("VLLM_SM70_NVFP4_QWEN38_TP4_M1_FAST_SELECTOR");
-    return !raw || std::atoi(raw) != 0;
+bool Sm70Nvfp4Qwen38Tp4M1FastSelectorEnabled() {
+  const char* raw = std::getenv("VLLM_SM70_NVFP4_QWEN38_TP4_M1_FAST_SELECTOR");
+  return !raw || std::atoi(raw) != 0;
 }
 
 struct Sm70AwqTp2FastTarget {
-    int  n;
-    int  k;
-    int  cta_m;
-    int  cta_n;
-    int  cta_k;
-    int  splits;
-    int  swizzle;
-    bool require_mgroup;
-    std::string name_contains;
+  int n;
+  int k;
+  int cta_m;
+  int cta_n;
+  int cta_k;
+  int splits;
+  int swizzle;
+  bool require_mgroup;
+  std::string name_contains;
 };
 
-std::optional<Sm70AwqTp2FastTarget> GetSm70AwqTp2EnvFastTarget(const GemmDesc&         desc,
-                                                               const std::string_view desc_str)
-{
-    const char* raw = std::getenv("VLLM_SM70_AWQ_TP2_FAST_TARGETS");
-    if (!raw || !*raw) {
-        return std::nullopt;
-    }
-    const std::string targets(raw);
-    size_t            begin = 0;
-    while (begin <= targets.size()) {
-        const size_t end   = targets.find(';', begin);
-        const auto   entry = targets.substr(begin, end == std::string::npos ? std::string::npos : end - begin);
-        const size_t sep   = entry.find('|');
-        if (sep != std::string::npos && entry.substr(0, sep) == desc_str) {
-            std::string spec = entry.substr(sep + 1);
-            std::string name_contains;
-            if (const size_t name_sep = spec.find('@'); name_sep != std::string::npos) {
-                name_contains = spec.substr(name_sep + 1);
-                spec.resize(name_sep);
-            }
-            std::replace(spec.begin(), spec.end(), 'x', ',');
-            std::replace(spec.begin(), spec.end(), ':', ',');
-            for (char& ch : spec) {
-                if (ch == ',') {
-                    ch = ' ';
-                }
-            }
-            std::istringstream is(spec);
-            int                cta_m{};
-            int                cta_n{};
-            int                cta_k{};
-            int                splits{};
-            int                swizzle{};
-            int                require_mgroup{};
-            if (is >> cta_m >> cta_n >> cta_k >> splits >> swizzle >> require_mgroup) {
-                if (name_contains.empty()) {
-                    is >> name_contains;
-                }
-                return Sm70AwqTp2FastTarget{desc.n,
-                                            desc.k,
-                                            cta_m,
-                                            cta_n,
-                                            cta_k,
-                                            splits,
-                                            swizzle,
-                                            require_mgroup != 0,
-                                            name_contains};
-            }
-            if (GemmTraceEnabled() && GemmTraceFilterAllows(std::string(desc_str))) {
-                std::cerr << "[TM_GEMM_FAST_SELECTOR] desc=" << desc_str
-                          << " stage=invalid_env_target entry=" << entry << std::endl;
-            }
-            return std::nullopt;
-        }
-        if (end == std::string::npos) {
-            break;
-        }
-        begin = end + 1;
-    }
+std::optional<Sm70AwqTp2FastTarget> GetSm70AwqTp2EnvFastTarget(
+    const GemmDesc& desc, const std::string_view desc_str) {
+  const char* raw = std::getenv("VLLM_SM70_AWQ_TP2_FAST_TARGETS");
+  if (!raw || !*raw) {
     return std::nullopt;
-}
-
-std::optional<Sm70AwqTp2FastTarget> GetSm70AwqTp2FastTarget(const GemmDesc& desc)
-{
-    const std::string desc_str = to_string(desc);
-    if (Sm70Nvfp4Qwen38Tp4M1FastSelectorEnabled()) {
-        // Qwen3.8-27B NVFP4 TP4 decode. The exact-MNK registry entries keep
-        // these small-N tactics out of prefill and unrelated model shapes.
-        if (desc_str == "sm70_f16_e2m1k16_f16_tnt_fff_1x8704x5120_1"
-            || desc_str == "sm70_f16_e2m1k16_f16_tnt_fff_1x5120x4352_1") {
-            return Sm70AwqTp2FastTarget{
-                desc.n, desc.k, 8, 32, 64, 3, 4, true, "c8x32_a1x1x64_01"};
+  }
+  const std::string targets(raw);
+  size_t begin = 0;
+  while (begin <= targets.size()) {
+    const size_t end = targets.find(';', begin);
+    const auto entry = targets.substr(
+        begin, end == std::string::npos ? std::string::npos : end - begin);
+    const size_t sep = entry.find('|');
+    if (sep != std::string::npos && entry.substr(0, sep) == desc_str) {
+      std::string spec = entry.substr(sep + 1);
+      std::string name_contains;
+      if (const size_t name_sep = spec.find('@');
+          name_sep != std::string::npos) {
+        name_contains = spec.substr(name_sep + 1);
+        spec.resize(name_sep);
+      }
+      std::replace(spec.begin(), spec.end(), 'x', ',');
+      std::replace(spec.begin(), spec.end(), ':', ',');
+      for (char& ch : spec) {
+        if (ch == ',') {
+          ch = ' ';
         }
-    }
-    const bool awq_fast_selector_enabled = Sm70AwqTp2FastSelectorEnabled();
-    if (awq_fast_selector_enabled) {
-        if (auto target = GetSm70AwqTp2EnvFastTarget(desc, desc_str)) {
-            return target;
+      }
+      std::istringstream is(spec);
+      int cta_m{};
+      int cta_n{};
+      int cta_k{};
+      int splits{};
+      int swizzle{};
+      int require_mgroup{};
+      if (is >> cta_m >> cta_n >> cta_k >> splits >> swizzle >>
+          require_mgroup) {
+        if (name_contains.empty()) {
+          is >> name_contains;
         }
-    }
-    if (!awq_fast_selector_enabled) {
-        return std::nullopt;
-    }
-    if (desc_str == "sm70_f16_u4k128_f16_tnt_fff_5x17408x5120_1") {
-        return Sm70AwqTp2FastTarget{desc.n, desc.k, 8, 64, 64, 1, 0, false, ""};
-    }
-    if (desc_str == "sm70_f16_u4k128_f16_tnt_fff_5x8192x5120_1") {
-        return Sm70AwqTp2FastTarget{desc.n, desc.k, 8, 64, 64, 2, 0, false, ""};
-    }
-    if (desc_str == "sm70_f16_u4k128_f16_tnt_fff_5x5120x3072_1") {
-        return Sm70AwqTp2FastTarget{desc.n, desc.k, 8, 64, 64, 3, 0, false, ""};
-    }
-    if (Sm70AwqMtpM5FastSelectorEnabled()) {
-        // TP4 MTP verifier, M=5. Both routes are bitwise exact on all TP shards.
-        if (desc_str == "sm70_f16_u4k128_f16_tnt_fff_5x8704x5120_1") {
-            return Sm70AwqTp2FastTarget{desc.n, desc.k, 8, 64, 64, 2, 4, false, ""};
-        }
-        if (desc_str == "sm70_f16_u4k128_f16_tnt_fff_5x4096x5120_1") {
-            return Sm70AwqTp2FastTarget{desc.n, desc.k, 8, 64, 64, 4, 4, false, ""};
-        }
-    }
-    if (desc_str == "sm70_f16_u4k128_f16_tnt_fff_1x17408x5120_1") {
-        return Sm70AwqTp2FastTarget{desc.n, desc.k, 8, 256, 64, 3, 3, false, ""};
-    }
-    if (desc_str == "sm70_f16_u4k128_f16_tnt_fff_1x8704x5120_1") {
-        return Sm70AwqTp2FastTarget{desc.n, desc.k, 8, 64, 64, 2, 4, false, ""};
-    }
-    if (Sm70AwqTp4QkvCta64Enabled()
-        && desc_str == "sm70_f16_u4k128_f16_tnt_fff_1x4096x5120_1") {
-        return Sm70AwqTp2FastTarget{desc.n, desc.k, 8, 64, 64, 4, 4, false, ""};
-    }
-    if (desc_str == "sm70_f16_u4k128_f16_tnt_fff_1x5120x1536_1") {
-        return Sm70AwqTp2FastTarget{desc.n, desc.k, 8, 256, 64, 12, 4, false, "s884_1x4x1"};
-    }
-    if (desc_str == "sm70_f16_u4k128_f16_tnt_fff_1x5120x3072_1") {
-        return Sm70AwqTp2FastTarget{desc.n, desc.k, 8, 256, 64, 7, 0, false, ""};
-    }
-    return std::nullopt;
-}
-
-std::optional<Sm70AwqTp2FastTarget> GetSm70Mxfp4MoeGroupedM8FastTarget(const GemmDesc& desc)
-{
-    if (!Sm70Mxfp4MoeGroupedM8FastSelectorEnabled()) {
-        return std::nullopt;
-    }
-    const std::string desc_str = to_string(desc);
-    if (desc_str == "sm70_f16_e2m1k32_f16_tnt_bbb_48x512x4096_1") {
         return Sm70AwqTp2FastTarget{
-            desc.n, desc.k, 8, 128, 64, 5, 0, true, "c8x128_a1x1x64_01"};
+            desc.n,       desc.k, cta_m,   cta_n,
+            cta_k,        splits, swizzle, require_mgroup != 0,
+            name_contains};
+      }
+      if (GemmTraceEnabled() && GemmTraceFilterAllows(std::string(desc_str))) {
+        std::cerr << "[TM_GEMM_FAST_SELECTOR] desc=" << desc_str
+                  << " stage=invalid_env_target entry=" << entry << std::endl;
+      }
+      return std::nullopt;
     }
-    if (desc_str == "sm70_f16_e2m1k32_f16_tnt_bbb_48x4096x256_1") {
-        return Sm70AwqTp2FastTarget{
-            desc.n, desc.k, 16, 128, 32, 1, 0, true, "c16x128_a1x1x32_01"};
+    if (end == std::string::npos) {
+      break;
     }
+    begin = end + 1;
+  }
+  return std::nullopt;
+}
+
+std::optional<Sm70AwqTp2FastTarget> GetSm70AwqTp2FastTarget(
+    const GemmDesc& desc) {
+  const std::string desc_str = to_string(desc);
+  if (Sm70Nvfp4Qwen38Tp4M1FastSelectorEnabled()) {
+    // Qwen3.8-27B NVFP4 TP4 decode. The exact-MNK registry entries keep
+    // these small-N tactics out of prefill and unrelated model shapes.
+    if (desc_str == "sm70_f16_e2m1k16_f16_tnt_fff_1x8704x5120_1" ||
+        desc_str == "sm70_f16_e2m1k16_f16_tnt_fff_1x5120x4352_1") {
+      return Sm70AwqTp2FastTarget{
+          desc.n, desc.k, 8, 32, 64, 3, 4, true, "c8x32_a1x1x64_01"};
+    }
+  }
+  const bool awq_fast_selector_enabled = Sm70AwqTp2FastSelectorEnabled();
+  if (awq_fast_selector_enabled) {
+    if (auto target = GetSm70AwqTp2EnvFastTarget(desc, desc_str)) {
+      return target;
+    }
+  }
+  if (!awq_fast_selector_enabled) {
     return std::nullopt;
+  }
+  if (desc_str == "sm70_f16_u4k128_f16_tnt_fff_5x17408x5120_1") {
+    return Sm70AwqTp2FastTarget{desc.n, desc.k, 8, 64, 64, 1, 0, false, ""};
+  }
+  if (desc_str == "sm70_f16_u4k128_f16_tnt_fff_5x8192x5120_1") {
+    return Sm70AwqTp2FastTarget{desc.n, desc.k, 8, 64, 64, 2, 0, false, ""};
+  }
+  if (desc_str == "sm70_f16_u4k128_f16_tnt_fff_5x5120x3072_1") {
+    return Sm70AwqTp2FastTarget{desc.n, desc.k, 8, 64, 64, 3, 0, false, ""};
+  }
+  if (Sm70AwqMtpM5FastSelectorEnabled()) {
+    // TP4 MTP verifier, M=5. Both routes are bitwise exact on all TP shards.
+    if (desc_str == "sm70_f16_u4k128_f16_tnt_fff_5x8704x5120_1") {
+      return Sm70AwqTp2FastTarget{desc.n, desc.k, 8, 64, 64, 2, 4, false, ""};
+    }
+    if (desc_str == "sm70_f16_u4k128_f16_tnt_fff_5x4096x5120_1") {
+      return Sm70AwqTp2FastTarget{desc.n, desc.k, 8, 64, 64, 4, 4, false, ""};
+    }
+  }
+  if (desc_str == "sm70_f16_u4k128_f16_tnt_fff_1x17408x5120_1") {
+    return Sm70AwqTp2FastTarget{desc.n, desc.k, 8, 256, 64, 3, 3, false, ""};
+  }
+  if (desc_str == "sm70_f16_u4k128_f16_tnt_fff_1x8704x5120_1") {
+    return Sm70AwqTp2FastTarget{desc.n, desc.k, 8, 64, 64, 2, 4, false, ""};
+  }
+  if (Sm70AwqTp4QkvCta64Enabled() &&
+      desc_str == "sm70_f16_u4k128_f16_tnt_fff_1x4096x5120_1") {
+    return Sm70AwqTp2FastTarget{desc.n, desc.k, 8, 64, 64, 4, 4, false, ""};
+  }
+  if (desc_str == "sm70_f16_u4k128_f16_tnt_fff_1x5120x1536_1") {
+    return Sm70AwqTp2FastTarget{desc.n, desc.k, 8,     256,         64,
+                                12,     4,      false, "s884_1x4x1"};
+  }
+  if (desc_str == "sm70_f16_u4k128_f16_tnt_fff_1x5120x3072_1") {
+    return Sm70AwqTp2FastTarget{desc.n, desc.k, 8, 256, 64, 7, 0, false, ""};
+  }
+  return std::nullopt;
 }
 
-bool MatchesSm70AwqTp2FastKernel(const Kernel& kernel, const Sm70AwqTp2FastTarget& target)
-{
-    const int3 cta = kernel.cta_tile_size();
-    if (cta.x != target.cta_m || cta.y != target.cta_n || cta.z != target.cta_k) {
-        return false;
-    }
-    const std::string name = kernel.name();
-    const bool        is_mgroup = name.find("mgroup") != std::string::npos;
-    if (is_mgroup != target.require_mgroup) {
-        return false;
-    }
-    return target.name_contains.empty() || name.find(target.name_contains) != std::string::npos;
-}
-
-void MaybeTraceSm70AwqTp2FastSelector(const GemmDesc& desc, const char* stage, const LaunchSpec* spec = nullptr)
-{
-    if (!GemmTraceEnabled()) {
-        return;
-    }
-    const std::string desc_str = to_string(desc);
-    if (!GemmTraceFilterAllows(desc_str)) {
-        return;
-    }
-    std::cerr << "[TM_GEMM_FAST_SELECTOR] desc=" << desc_str << " stage=" << stage;
-    if (spec && spec->kernel) {
-        std::cerr << " kernel=" << spec->kernel->name() << " splits=" << spec->splits
-                  << " swizzle=" << spec->swizzle;
-    }
-    std::cerr << std::endl;
-}
-
-std::optional<LaunchSpec> SelectSm70AwqTp2FastSpec(Context&                              ctx,
-                                                   const std::vector<LaunchSpec>&        specs,
-                                                   const Sm70AwqTp2FastTarget&           target,
-                                                   size_t                                barriers_size,
-                                                   size_t                                partials_size)
-{
-    for (const auto& spec : specs) {
-        if (!spec.kernel || !MatchesSm70AwqTp2FastKernel(*spec.kernel, target)) {
-            continue;
-        }
-        if (spec.splits != target.splits) {
-            continue;
-        }
-        auto selected = spec;
-        const auto& actual_desc = ctx.get_desc(*selected.kernel);
-        const int4  shape{actual_desc.m, actual_desc.n, actual_desc.k, actual_desc.num};
-        if (target.swizzle > selected.kernel->GetMaxSwizzle(shape)) {
-            continue;
-        }
-        (void)barriers_size;
-        (void)partials_size;
-        selected.splits  = target.splits;
-        selected.swizzle = target.swizzle;
-        MaybeTraceSm70AwqTp2FastSelector(ctx.desc(), "selected", &selected);
-        return selected;
-    }
-    MaybeTraceSm70AwqTp2FastSelector(ctx.desc(), "no_match");
+std::optional<Sm70AwqTp2FastTarget> GetSm70Mxfp4MoeGroupedM8FastTarget(
+    const GemmDesc& desc) {
+  if (!Sm70Mxfp4MoeGroupedM8FastSelectorEnabled()) {
     return std::nullopt;
+  }
+  const std::string desc_str = to_string(desc);
+  if (desc_str == "sm70_f16_e2m1k32_f16_tnt_bbb_48x512x4096_1") {
+    return Sm70AwqTp2FastTarget{
+        desc.n, desc.k, 8, 128, 64, 5, 0, true, "c8x128_a1x1x64_01"};
+  }
+  if (desc_str == "sm70_f16_e2m1k32_f16_tnt_bbb_48x4096x256_1") {
+    return Sm70AwqTp2FastTarget{
+        desc.n, desc.k, 16, 128, 32, 1, 0, true, "c16x128_a1x1x32_01"};
+  }
+  return std::nullopt;
 }
 
-const char* ToString(DispatchPolicy policy)
-{
-    if ((policy & DispatchPolicy::kPreserveDefaultSplits)
-        || (policy & DispatchPolicy::kPreserveDefaultSplitCount)
-        || (policy & DispatchPolicy::kMxfp4MoeGroupedM8Fast)) {
-        static thread_local std::string text;
-        auto base =
-            static_cast<DispatchPolicy>((int)policy & ~(int)DispatchPolicy::kPreserveDefaultSplits
-                                        & ~(int)DispatchPolicy::kPreserveDefaultSplitCount
-                                        & ~(int)DispatchPolicy::kMxfp4MoeGroupedM8Fast);
-        text = std::string(ToString(base));
-        if (policy & DispatchPolicy::kPreserveDefaultSplits) {
-            text += "|preserve_default_splits";
-        }
-        if (policy & DispatchPolicy::kPreserveDefaultSplitCount) {
-            text += "|preserve_default_split_count";
-        }
-        if (policy & DispatchPolicy::kMxfp4MoeGroupedM8Fast) {
-            text += "|mxfp4_moe_grouped_m8_fast";
-        }
-        return text.c_str();
-    }
-    switch (policy) {
-        case DispatchPolicy::kDefault:
-            return "default";
-        case DispatchPolicy::kMeasure:
-            return "measure";
-        case DispatchPolicy::kReuse:
-            return "reuse";
-        case DispatchPolicy::kAppend:
-            return "append";
-        default:
-            return "unknown";
-    }
+bool MatchesSm70AwqTp2FastKernel(const Kernel& kernel,
+                                 const Sm70AwqTp2FastTarget& target) {
+  const int3 cta = kernel.cta_tile_size();
+  if (cta.x != target.cta_m || cta.y != target.cta_n || cta.z != target.cta_k) {
+    return false;
+  }
+  const std::string name = kernel.name();
+  const bool is_mgroup = name.find("mgroup") != std::string::npos;
+  if (is_mgroup != target.require_mgroup) {
+    return false;
+  }
+  return target.name_contains.empty() ||
+         name.find(target.name_contains) != std::string::npos;
 }
 
-void MaybeTraceGemmDispatch(const GemmDesc& desc, DispatchPolicy policy, const LaunchSpec& spec, bool measured)
-{
-    if (!GemmTraceEnabled()) {
-        return;
-    }
-    const std::string desc_str = to_string(desc);
-    if (!GemmTraceFilterAllows(desc_str)) {
-        return;
-    }
-    static std::atomic<int> logged{0};
-    const int limit = GemmTraceLimit();
-    if (limit > 0 && logged.fetch_add(1, std::memory_order_relaxed) >= limit) {
-        return;
-    }
+void MaybeTraceSm70AwqTp2FastSelector(const GemmDesc& desc, const char* stage,
+                                      const LaunchSpec* spec = nullptr) {
+  if (!GemmTraceEnabled()) {
+    return;
+  }
+  const std::string desc_str = to_string(desc);
+  if (!GemmTraceFilterAllows(desc_str)) {
+    return;
+  }
+  std::cerr << "[TM_GEMM_FAST_SELECTOR] desc=" << desc_str
+            << " stage=" << stage;
+  if (spec && spec->kernel) {
+    std::cerr << " kernel=" << spec->kernel->name()
+              << " splits=" << spec->splits << " swizzle=" << spec->swizzle;
+  }
+  std::cerr << std::endl;
+}
 
-    std::cerr << "[TM_GEMM_TRACE] desc=" << desc_str << " policy=" << ToString(policy) << " measured="
-              << (measured ? 1 : 0);
-    if (spec.kernel) {
-        const int3 cta = spec.kernel->cta_tile_size();
-        const int3 mma = spec.kernel->warp_tile_size();
-        std::cerr << " kernel=" << spec.kernel->name() << " splits=" << spec.splits << " swizzle=" << spec.swizzle
-                  << " cta=" << cta.x << "x" << cta.y << "x" << cta.z << " mma=" << mma.x << "x" << mma.y
-                  << "x" << mma.z << " stages=" << spec.kernel->stages() << " smem=" << spec.kernel->smem_size();
+std::optional<LaunchSpec> SelectSm70AwqTp2FastSpec(
+    Context& ctx, const std::vector<LaunchSpec>& specs,
+    const Sm70AwqTp2FastTarget& target, size_t barriers_size,
+    size_t partials_size) {
+  for (const auto& spec : specs) {
+    if (!spec.kernel || !MatchesSm70AwqTp2FastKernel(*spec.kernel, target)) {
+      continue;
     }
-    else {
-        std::cerr << " kernel=<none>";
+    if (spec.splits != target.splits) {
+      continue;
     }
-    std::cerr << std::endl;
+    auto selected = spec;
+    const auto& actual_desc = ctx.get_desc(*selected.kernel);
+    const int4 shape{actual_desc.m, actual_desc.n, actual_desc.k,
+                     actual_desc.num};
+    if (target.swizzle > selected.kernel->GetMaxSwizzle(shape)) {
+      continue;
+    }
+    (void)barriers_size;
+    (void)partials_size;
+    selected.splits = target.splits;
+    selected.swizzle = target.swizzle;
+    MaybeTraceSm70AwqTp2FastSelector(ctx.desc(), "selected", &selected);
+    return selected;
+  }
+  MaybeTraceSm70AwqTp2FastSelector(ctx.desc(), "no_match");
+  return std::nullopt;
+}
+
+const char* ToString(DispatchPolicy policy) {
+  if ((policy & DispatchPolicy::kPreserveDefaultSplits) ||
+      (policy & DispatchPolicy::kPreserveDefaultSplitCount) ||
+      (policy & DispatchPolicy::kMxfp4MoeGroupedM8Fast)) {
+    static thread_local std::string text;
+    auto base = static_cast<DispatchPolicy>(
+        (int)policy & ~(int)DispatchPolicy::kPreserveDefaultSplits &
+        ~(int)DispatchPolicy::kPreserveDefaultSplitCount &
+        ~(int)DispatchPolicy::kMxfp4MoeGroupedM8Fast);
+    text = std::string(ToString(base));
+    if (policy & DispatchPolicy::kPreserveDefaultSplits) {
+      text += "|preserve_default_splits";
+    }
+    if (policy & DispatchPolicy::kPreserveDefaultSplitCount) {
+      text += "|preserve_default_split_count";
+    }
+    if (policy & DispatchPolicy::kMxfp4MoeGroupedM8Fast) {
+      text += "|mxfp4_moe_grouped_m8_fast";
+    }
+    return text.c_str();
+  }
+  switch (policy) {
+    case DispatchPolicy::kDefault:
+      return "default";
+    case DispatchPolicy::kMeasure:
+      return "measure";
+    case DispatchPolicy::kReuse:
+      return "reuse";
+    case DispatchPolicy::kAppend:
+      return "append";
+    default:
+      return "unknown";
+  }
+}
+
+void MaybeTraceGemmDispatch(const GemmDesc& desc, DispatchPolicy policy,
+                            const LaunchSpec& spec, bool measured) {
+  if (!GemmTraceEnabled()) {
+    return;
+  }
+  const std::string desc_str = to_string(desc);
+  if (!GemmTraceFilterAllows(desc_str)) {
+    return;
+  }
+  static std::atomic<int> logged{0};
+  const int limit = GemmTraceLimit();
+  if (limit > 0 && logged.fetch_add(1, std::memory_order_relaxed) >= limit) {
+    return;
+  }
+
+  std::cerr << "[TM_GEMM_TRACE] desc=" << desc_str
+            << " policy=" << ToString(policy)
+            << " measured=" << (measured ? 1 : 0);
+  if (spec.kernel) {
+    const int3 cta = spec.kernel->cta_tile_size();
+    const int3 mma = spec.kernel->warp_tile_size();
+    std::cerr << " kernel=" << spec.kernel->name() << " splits=" << spec.splits
+              << " swizzle=" << spec.swizzle << " cta=" << cta.x << "x" << cta.y
+              << "x" << cta.z << " mma=" << mma.x << "x" << mma.y << "x"
+              << mma.z << " stages=" << spec.kernel->stages()
+              << " smem=" << spec.kernel->smem_size();
+  } else {
+    std::cerr << " kernel=<none>";
+  }
+  std::cerr << std::endl;
 }
 
 }  // namespace
 
 struct Gemm::Impl {
-
-    Impl():
-        props_{GetCudaDeviceProps()},
+  Impl()
+      : props_{GetCudaDeviceProps()},
         arch_{props_->major * 100 + props_->minor * 10},
         registry_{props_},
-        cache_{registry_.kernels()}
-    {
-        if (arch_ == 700) {
-            // V100 decode is dominated by many tiny GEMM/GEMV problems. A
-            // broader search space consistently finds better launch specs than
-            // the generic defaults for these SM70 workloads.
-            tuning_.max_splits = 16;
-            tuning_.max_waves  = 32;
-            tuning_.swizzle    = {0, 1, 2, 3, 4};
-            tuning_.top_k      = 0;
-            tuning_.clusters   = 0;
-            tuning_.min_iter   = 2;
-            tuning_.max_iter   = 20;
-            tuning_.max_time   = 2.f;
-        }
-        if (auto str = std::getenv("TM_GEMM_TUNE")) {
-            try {
-                ParseTuningParams(tuning_, str);
-            }
-            catch (...) {
-                std::cerr << "[Gemm2] Failed to parse `TM_GEMM_TUNE`, default value will be used.\n";
-                tuning_ = {};
-            }
-        }
-        if (std::getenv("TM_GEMM_WARN_CACHE_MISS")) {
-            warn_cache_miss_ = true;
-        }
-        measurer_.emplace(CreateStoppingCriterion(tuning_.min_iter, tuning_.max_iter, tuning_.max_time));
+        cache_{registry_.kernels()} {
+    if (arch_ == 700) {
+      // V100 decode is dominated by many tiny GEMM/GEMV problems. A
+      // broader search space consistently finds better launch specs than
+      // the generic defaults for these SM70 workloads.
+      tuning_.max_splits = 16;
+      tuning_.max_waves = 32;
+      tuning_.swizzle = {0, 1, 2, 3, 4};
+      tuning_.top_k = 0;
+      tuning_.clusters = 0;
+      tuning_.min_iter = 2;
+      tuning_.max_iter = 20;
+      tuning_.max_time = 2.f;
     }
+    if (auto str = std::getenv("TM_GEMM_TUNE")) {
+      try {
+        ParseTuningParams(tuning_, str);
+      } catch (...) {
+        std::cerr << "[Gemm2] Failed to parse `TM_GEMM_TUNE`, default value "
+                     "will be used.\n";
+        tuning_ = {};
+      }
+    }
+    if (std::getenv("TM_GEMM_WARN_CACHE_MISS")) {
+      warn_cache_miss_ = true;
+    }
+    measurer_.emplace(CreateStoppingCriterion(
+        tuning_.min_iter, tuning_.max_iter, tuning_.max_time));
+  }
 
-    // find launch spec in dispatch cache, dispatch by heuristic on cache miss
-    LaunchSpec Dispatch(Context& ctx, DispatchPolicy policy, size_t barriers_size, size_t partials_size)
-    {
-        const auto& desc = ctx.desc();
-        const auto is_feasible = [&](const LaunchSpec& spec) {
-            return spec.kernel && spec.kernel->is_feasible(ctx.get_desc(*spec.kernel));
-        };
-        if (policy & DispatchPolicy::kMxfp4MoeGroupedM8Fast) {
-            if (auto fast_target = GetSm70Mxfp4MoeGroupedM8FastTarget(desc)) {
-                auto specs = Find(ctx, barriers_size, partials_size, 0);
-                if (auto fast_spec = SelectSm70AwqTp2FastSpec(
-                        ctx, specs, *fast_target, barriers_size, partials_size)) {
-                    return *fast_spec;
-                }
-                return {};
-            }
-        }
-        if (policy & DispatchPolicy::kReuse) {
-            if (auto spec = cache_.LowerBound(desc); spec && is_feasible(*spec)) {
-                return *spec;
-            }
-            if (warn_cache_miss_) {
-                std::cerr << "Failed to find a feasible kernel in the cache, will dispatch by heuristic: "
-                          << to_string(ctx.desc()) << std::endl;
-            }
-        }
-
-        if (auto spec = cache_.Find(desc); spec && is_feasible(*spec)) {
-            return *spec;
-        }
-
-        const auto fast_target = GetSm70AwqTp2FastTarget(desc);
-        auto specs = Find(ctx, barriers_size, partials_size, fast_target ? 0 : 1);
-        if (!specs.empty()) {
-            auto selected = specs.front();
-            if (fast_target) {
-                if (auto fast_spec =
-                        SelectSm70AwqTp2FastSpec(ctx, specs, *fast_target, barriers_size, partials_size)) {
-                    selected = *fast_spec;
-                }
-            }
-            cache_.Insert(desc, selected);
-            return selected;
+  // find launch spec in dispatch cache, dispatch by heuristic on cache miss
+  LaunchSpec Dispatch(Context& ctx, DispatchPolicy policy, size_t barriers_size,
+                      size_t partials_size) {
+    const auto& desc = ctx.desc();
+    const auto is_feasible = [&](const LaunchSpec& spec) {
+      return spec.kernel &&
+             spec.kernel->is_feasible(ctx.get_desc(*spec.kernel));
+    };
+    if (policy & DispatchPolicy::kMxfp4MoeGroupedM8Fast) {
+      if (auto fast_target = GetSm70Mxfp4MoeGroupedM8FastTarget(desc)) {
+        auto specs = Find(ctx, barriers_size, partials_size, 0);
+        if (auto fast_spec = SelectSm70AwqTp2FastSpec(
+                ctx, specs, *fast_target, barriers_size, partials_size)) {
+          return *fast_spec;
         }
         return {};
+      }
+    }
+    if (policy & DispatchPolicy::kReuse) {
+      if (auto spec = cache_.LowerBound(desc); spec && is_feasible(*spec)) {
+        return *spec;
+      }
+      if (warn_cache_miss_) {
+        std::cerr << "Failed to find a feasible kernel in the cache, will "
+                     "dispatch by heuristic: "
+                  << to_string(ctx.desc()) << std::endl;
+      }
     }
 
-    std::vector<LaunchSpec> Find(Context& ctx, size_t barrier_size, size_t partials_size, int top_k)
+    if (auto spec = cache_.Find(desc); spec && is_feasible(*spec)) {
+      return *spec;
+    }
+
+    const auto fast_target = GetSm70AwqTp2FastTarget(desc);
+    auto specs = Find(ctx, barriers_size, partials_size, fast_target ? 0 : 1);
+    if (!specs.empty()) {
+      auto selected = specs.front();
+      if (fast_target) {
+        if (auto fast_spec = SelectSm70AwqTp2FastSpec(
+                ctx, specs, *fast_target, barriers_size, partials_size)) {
+          selected = *fast_spec;
+        }
+      }
+      cache_.Insert(desc, selected);
+      return selected;
+    }
+    return {};
+  }
+
+  std::vector<LaunchSpec> Find(Context& ctx, size_t barrier_size,
+                               size_t partials_size, int top_k) {
+    std::vector<Kernel*> feasible = ctx.Filter(registry_.kernels());
+
+    std::vector<std::vector<LaunchSpec>> clusters;
     {
-        std::vector<Kernel*> feasible = ctx.Filter(registry_.kernels());
+      std::vector<LaunchSpec> tmp;
+      tmp.reserve(feasible.size());
+      for (const auto& k : feasible) {
+        LaunchSpec spec{k};
+        tmp.push_back(spec);
+      }
+      clusters = Cluster(tmp, ClusteringParam{false, true});
+    }
+    std::vector<Kernel*> proxies;
+    proxies.reserve(clusters.size());
 
-        std::vector<std::vector<LaunchSpec>> clusters;
-        {
-            std::vector<LaunchSpec> tmp;
-            tmp.reserve(feasible.size());
-            for (const auto& k : feasible) {
-                LaunchSpec spec{k};
-                tmp.push_back(spec);
-            }
-            clusters = Cluster(tmp, ClusteringParam{false, true});
-        }
-        std::vector<Kernel*> proxies;
-        proxies.reserve(clusters.size());
-
-        for (const auto& c : clusters) {
-            proxies.push_back(c.front().kernel);
-        }
-
-        std::vector<std::pair<int, LaunchSpec>> specs;
-
-        PopulateParam param{};
-        param.max_splits    = tuning_.max_splits;
-        param.max_waves     = tuning_.max_waves;
-        param.swizzle       = tuning_.swizzle.at(0);
-        param.barriers_size = barrier_size;
-        param.partials_size = partials_size;
-
-        for (int cluster_id = 0; cluster_id < (int)proxies.size(); ++cluster_id) {
-            auto& kernel = *proxies[cluster_id];
-
-            auto tmp = ctx.Populate(kernel, param);
-            for (const auto& s : tmp) {
-                specs.emplace_back(cluster_id, s);
-            }
-        }
-
-        // std::cerr << "#kernel: " << kernels.size() << ", #cluster: " << clusters.size()
-        //           << ", #metric: " << metrics.size() << "\n";
-
-        int64_t mio_max = 0;
-        int64_t mma_max = 0;
-        for (const auto& [_, s] : specs) {
-            auto& [mio, mma] = s.estimated;
-            mio_max          = std::max(mio_max, mio);
-            mma_max          = std::max(mma_max, mma);
-        }
-        std::vector<float> mio_ratio;
-        std::vector<float> mma_ratio;
-        std::vector<float> avg_ratio;
-        for (const auto& [_, s] : specs) {
-            auto& [mio, mma] = s.estimated;
-            mio_ratio.push_back((float)mio / mio_max);
-            mma_ratio.push_back((float)mma / mma_max);
-            avg_ratio.push_back(.5 * (mio_ratio.back() + mma_ratio.back()));
-        }
-        auto idxs = ArgSort(specs.size(), [&](int i, int j) {  //
-            return avg_ratio[i] < avg_ratio[j];
-        });
-
-        // for (const auto& i : idxs) {
-        //     auto [cid, s, m] = metrics[i];
-        //     std::cout << clusters[cid].front().kernel->name() << " s" << s << " " << avg_ratio[i] << " " <<
-        //     mio_ratio[i]
-        //               << " " << mma_ratio[i] << " " << m.mio_cost << " " << m.mma_cost << "\n";
-        // }
-
-        top_k = top_k > 0 ? std::min<int>(idxs.size(), top_k) : (int)idxs.size();
-        std::vector<LaunchSpec> ret;
-        ret.reserve(top_k);
-        for (int i = 0; i < top_k; ++i) {
-            const auto& [cluster_id, spec] = specs[idxs[i]];
-            // Apply `splits` to all kernels in the cluster
-            for (const auto& s : clusters[cluster_id]) {
-                auto tmp   = spec;
-                tmp.kernel = s.kernel;
-                ret.push_back(tmp);
-            }
-        }
-
-        return ret;
+    for (const auto& c : clusters) {
+      proxies.push_back(c.front().kernel);
     }
 
-    template<class LaunchFunc>
-    int Measure(
-        Context& ctx, size_t barriers_size, size_t partials_size, int top_k, LaunchFunc launch_func, cudaStream_t st)
-    {
-        // Early exit on exact match
-        if (cache_.Find(ctx.desc())) {
-            return 0;
-        }
-        // std::cerr << "GEMM: " << desc.m << "x" << desc.n << "x" << desc.k << "\n";
+    std::vector<std::pair<int, LaunchSpec>> specs;
 
-        const auto tmp = Find(ctx, barriers_size, partials_size, tuning_.top_k);
+    PopulateParam param{};
+    param.max_splits = tuning_.max_splits;
+    param.max_waves = tuning_.max_waves;
+    param.swizzle = tuning_.swizzle.at(0);
+    param.barriers_size = barrier_size;
+    param.partials_size = partials_size;
 
-        std::vector<LaunchSpec> specs;
-        for (const auto& spec : tmp) {
-            // populate swizzle parameters
-            const auto swis = ctx.Swizzle(spec, tuning_.swizzle);
-            specs.insert(specs.end(), swis.begin(), swis.end());
-        }
+    for (int cluster_id = 0; cluster_id < (int)proxies.size(); ++cluster_id) {
+      auto& kernel = *proxies[cluster_id];
 
-        specs = Sampler{*measurer_, tuning_.clusters}.Run(specs, launch_func, st);
-
-        // for (const auto& s : specs) {
-        //     std::cout << s.kernel->name()          //
-        //               << " swizzle=" << s.swizzle  //
-        //               << ", splits=" << s.splits   //
-        //               << ", measured=" << s.measured << "ms\n";
-        //     break;
-        // }
-
-        if (!specs.empty()) {
-            cache_.Insert(ctx.desc(), specs.front());
-        }
-        else {
-            std::cerr << "No valid kernel found for the problem\n";
-            return -1;
-        }
-
-        return 0;
+      auto tmp = ctx.Populate(kernel, param);
+      for (const auto& s : tmp) {
+        specs.emplace_back(cluster_id, s);
+      }
     }
 
-    /// TODO: move to cuda utils
-    static std::unique_ptr<cudaDeviceProp> GetCudaDeviceProps()
-    {
-        auto props     = std::make_unique<cudaDeviceProp>();
-        int  device_id = -1;
-        cudaGetDevice(&device_id);
-        cudaGetDeviceProperties(props.get(), device_id);
-        return props;
+    // std::cerr << "#kernel: " << kernels.size() << ", #cluster: " <<
+    // clusters.size()
+    //           << ", #metric: " << metrics.size() << "\n";
+
+    int64_t mio_max = 0;
+    int64_t mma_max = 0;
+    for (const auto& [_, s] : specs) {
+      auto& [mio, mma] = s.estimated;
+      mio_max = std::max(mio_max, mio);
+      mma_max = std::max(mma_max, mma);
+    }
+    std::vector<float> mio_ratio;
+    std::vector<float> mma_ratio;
+    std::vector<float> avg_ratio;
+    for (const auto& [_, s] : specs) {
+      auto& [mio, mma] = s.estimated;
+      mio_ratio.push_back((float)mio / mio_max);
+      mma_ratio.push_back((float)mma / mma_max);
+      avg_ratio.push_back(.5 * (mio_ratio.back() + mma_ratio.back()));
+    }
+    auto idxs = ArgSort(specs.size(), [&](int i, int j) {  //
+      return avg_ratio[i] < avg_ratio[j];
+    });
+
+    // for (const auto& i : idxs) {
+    //     auto [cid, s, m] = metrics[i];
+    //     std::cout << clusters[cid].front().kernel->name() << " s" << s << " "
+    //     << avg_ratio[i] << " " << mio_ratio[i]
+    //               << " " << mma_ratio[i] << " " << m.mio_cost << " " <<
+    //               m.mma_cost << "\n";
+    // }
+
+    top_k = top_k > 0 ? std::min<int>(idxs.size(), top_k) : (int)idxs.size();
+    std::vector<LaunchSpec> ret;
+    ret.reserve(top_k);
+    for (int i = 0; i < top_k; ++i) {
+      const auto& [cluster_id, spec] = specs[idxs[i]];
+      // Apply `splits` to all kernels in the cluster
+      for (const auto& s : clusters[cluster_id]) {
+        auto tmp = spec;
+        tmp.kernel = s.kernel;
+        ret.push_back(tmp);
+      }
     }
 
-    std::shared_ptr<cudaDeviceProp> props_;
+    return ret;
+  }
 
-    int arch_;
+  template <class LaunchFunc>
+  int Measure(Context& ctx, size_t barriers_size, size_t partials_size,
+              int top_k, LaunchFunc launch_func, cudaStream_t st) {
+    // Early exit on exact match
+    if (cache_.Find(ctx.desc())) {
+      return 0;
+    }
+    // std::cerr << "GEMM: " << desc.m << "x" << desc.n << "x" << desc.k <<
+    // "\n";
 
-    Registry registry_;
+    const auto tmp = Find(ctx, barriers_size, partials_size, tuning_.top_k);
 
-    TuningParams tuning_;
+    std::vector<LaunchSpec> specs;
+    for (const auto& spec : tmp) {
+      // populate swizzle parameters
+      const auto swis = ctx.Swizzle(spec, tuning_.swizzle);
+      specs.insert(specs.end(), swis.begin(), swis.end());
+    }
 
-    bool warn_cache_miss_{};
+    specs = Sampler{*measurer_, tuning_.clusters}.Run(specs, launch_func, st);
 
-    std::optional<Measurer> measurer_;
+    // for (const auto& s : specs) {
+    //     std::cout << s.kernel->name()          //
+    //               << " swizzle=" << s.swizzle  //
+    //               << ", splits=" << s.splits   //
+    //               << ", measured=" << s.measured << "ms\n";
+    //     break;
+    // }
 
-    DispatchCache cache_;
+    if (!specs.empty()) {
+      cache_.Insert(ctx.desc(), specs.front());
+    } else {
+      std::cerr << "No valid kernel found for the problem\n";
+      return -1;
+    }
 
-    std::mutex dispatch_mutex_;
+    return 0;
+  }
+
+  /// TODO: move to cuda utils
+  static std::unique_ptr<cudaDeviceProp> GetCudaDeviceProps() {
+    auto props = std::make_unique<cudaDeviceProp>();
+    int device_id = -1;
+    cudaGetDevice(&device_id);
+    cudaGetDeviceProperties(props.get(), device_id);
+    return props;
+  }
+
+  std::shared_ptr<cudaDeviceProp> props_;
+
+  int arch_;
+
+  Registry registry_;
+
+  TuningParams tuning_;
+
+  bool warn_cache_miss_{};
+
+  std::optional<Measurer> measurer_;
+
+  DispatchCache cache_;
+
+  std::mutex dispatch_mutex_;
 };
 
 // implementation of GEMM interfaces
 
-Gemm::Gemm(): impl_{new Impl{}} {}
+Gemm::Gemm() : impl_{new Impl{}} {}
 
 Gemm::~Gemm() = default;
 
-int Gemm::Run(const Operation&    operation,
-              float               alpha,
-              const void*         A,
-              const MatrixLayout& Adesc,
-              const void*         U,
-              const MatrixLayout& Udesc,
-              const void*         B,
-              const MatrixLayout& Bdesc,
-              const void*         V,
-              const MatrixLayout& Vdesc,
-              float               beta,
-              const void*         C,
-              const MatrixLayout& Cdesc,
-              void*               D,
-              const MatrixLayout& Ddesc,
-              const Workspace&    workspace,
-              cudaStream_t        stream)
-{
+int Gemm::Run(const Operation& operation, float alpha, const void* A,
+              const MatrixLayout& Adesc, const void* U,
+              const MatrixLayout& Udesc, const void* B,
+              const MatrixLayout& Bdesc, const void* V,
+              const MatrixLayout& Vdesc, float beta, const void* C,
+              const MatrixLayout& Cdesc, void* D, const MatrixLayout& Ddesc,
+              const Workspace& workspace, cudaStream_t stream) {
+  Context context{*impl_->props_};
 
-    Context context{*impl_->props_};
+  const auto desc =
+      context.Init(operation, Adesc, Udesc, Bdesc, Vdesc, Cdesc, Ddesc);
 
-    const auto desc = context.Init(operation, Adesc, Udesc, Bdesc, Vdesc, Cdesc, Ddesc);
+  if (!desc) {
+    fprintf(stderr, "invalid argument.\n");
+    TM_CHECK(0);
+    return -1;
+  }
 
-    if (!desc) {
-        fprintf(stderr, "invalid argument.\n");
-        TM_CHECK(0);
-        return -1;
+  const auto launch = [=](LaunchSpec spec, cudaStream_t st) {
+    auto _workspace = workspace;
+    return spec.kernel->Launch(operation, alpha, A, Adesc, U, Udesc, B, Bdesc,
+                               V, Vdesc, beta, C, Cdesc, D, Ddesc, spec.swizzle,
+                               spec.splits, _workspace, st);
+  };
+
+  std::optional<Context> dispatch_context_storage;
+  Context* dispatch_context = &context;
+  if (operation.dispatch_num_override > 0 &&
+      operation.dispatch_num_override != context.desc().num) {
+    MatrixLayout dispatch_Adesc = Adesc;
+    MatrixLayout dispatch_Bdesc = Bdesc;
+    MatrixLayout dispatch_Ddesc = Ddesc;
+    dispatch_Adesc.num = operation.dispatch_num_override;
+    dispatch_Bdesc.num = operation.dispatch_num_override;
+    dispatch_Ddesc.num = operation.dispatch_num_override;
+    dispatch_context_storage.emplace(*impl_->props_);
+    if (dispatch_context_storage->Init(operation, dispatch_Adesc, Udesc,
+                                       dispatch_Bdesc, Vdesc, Cdesc,
+                                       dispatch_Ddesc)) {
+      dispatch_context = &*dispatch_context_storage;
+    } else {
+      dispatch_context_storage.reset();
+      dispatch_context = &context;
     }
-
-    const auto launch = [=](LaunchSpec spec, cudaStream_t st) {
-        auto _workspace = workspace;
-        return spec.kernel->Launch(operation,
-                                   alpha,
-                                   A,
-                                   Adesc,
-                                   U,
-                                   Udesc,
-                                   B,
-                                   Bdesc,
-                                   V,
-                                   Vdesc,
-                                   beta,
-                                   C,
-                                   Cdesc,
-                                   D,
-                                   Ddesc,
-                                   spec.swizzle,
-                                   spec.splits,
-                                   _workspace,
-                                   st);
-    };
-
-    std::optional<Context> dispatch_context_storage;
-    Context*               dispatch_context = &context;
-    if (operation.dispatch_num_override > 0 && operation.dispatch_num_override != context.desc().num) {
-        MatrixLayout dispatch_Adesc = Adesc;
-        MatrixLayout dispatch_Bdesc = Bdesc;
-        MatrixLayout dispatch_Ddesc = Ddesc;
-        dispatch_Adesc.num          = operation.dispatch_num_override;
-        dispatch_Bdesc.num          = operation.dispatch_num_override;
-        dispatch_Ddesc.num          = operation.dispatch_num_override;
-        dispatch_context_storage.emplace(*impl_->props_);
-        if (dispatch_context_storage->Init(
-                operation, dispatch_Adesc, Udesc, dispatch_Bdesc, Vdesc, Cdesc, dispatch_Ddesc)) {
-            dispatch_context = &*dispatch_context_storage;
-        }
-        else {
-            dispatch_context_storage.reset();
-            dispatch_context = &context;
-        }
-    }
+  }
 
 #if 0
     if (operation.reserved) {
@@ -702,70 +670,70 @@ int Gemm::Run(const Operation&    operation,
     }
 #endif
 
-    LaunchSpec spec{};
+  LaunchSpec spec{};
 
-    const bool measured = operation.dispatch & DispatchPolicy::kMeasure;
-    {
-        std::lock_guard<std::mutex> lock(impl_->dispatch_mutex_);
-        if (measured) {
-            impl_->Measure(*dispatch_context, workspace.barriers_size, workspace.partials_size, 1, launch, stream);
+  const bool measured = operation.dispatch & DispatchPolicy::kMeasure;
+  {
+    std::lock_guard<std::mutex> lock(impl_->dispatch_mutex_);
+    if (measured) {
+      impl_->Measure(*dispatch_context, workspace.barriers_size,
+                     workspace.partials_size, 1, launch, stream);
+    }
+
+    spec = impl_->Dispatch(*dispatch_context, operation.dispatch,
+                           workspace.barriers_size, workspace.partials_size);
+    const bool preserve_default_kernel =
+        operation.dispatch & DispatchPolicy::kPreserveDefaultSplits;
+    const bool preserve_default_split_count =
+        operation.dispatch & DispatchPolicy::kPreserveDefaultSplitCount;
+    if (spec.kernel &&
+        (preserve_default_kernel || preserve_default_split_count)) {
+      auto default_specs =
+          impl_->Find(*dispatch_context, workspace.barriers_size,
+                      workspace.partials_size, 1);
+      if (!default_specs.empty()) {
+        const auto default_spec = default_specs.front();
+        if (preserve_default_kernel) {
+          spec.kernel = default_spec.kernel;
         }
-
-        spec = impl_->Dispatch(*dispatch_context, operation.dispatch, workspace.barriers_size, workspace.partials_size);
-        const bool preserve_default_kernel = operation.dispatch & DispatchPolicy::kPreserveDefaultSplits;
-        const bool preserve_default_split_count = operation.dispatch & DispatchPolicy::kPreserveDefaultSplitCount;
-        if (spec.kernel && (preserve_default_kernel || preserve_default_split_count)) {
-            auto default_specs = impl_->Find(*dispatch_context, workspace.barriers_size, workspace.partials_size, 1);
-            if (!default_specs.empty()) {
-                const auto default_spec = default_specs.front();
-                if (preserve_default_kernel) {
-                    spec.kernel = default_spec.kernel;
-                }
-                spec.splits = default_spec.splits;
-                const auto& default_desc = dispatch_context->get_desc(*spec.kernel);
-                spec.swizzle = std::min(
-                    spec.swizzle,
-                    spec.kernel->GetMaxSwizzle({
-                        default_desc.m,
-                        default_desc.n,
-                        default_desc.k,
-                        default_desc.num,
-                    }));
-            }
-        }
+        spec.splits = default_spec.splits;
+        const auto& default_desc = dispatch_context->get_desc(*spec.kernel);
+        spec.swizzle = std::min(spec.swizzle, spec.kernel->GetMaxSwizzle({
+                                                  default_desc.m,
+                                                  default_desc.n,
+                                                  default_desc.k,
+                                                  default_desc.num,
+                                              }));
+      }
     }
-    if (spec.kernel && dispatch_context != &context) {
-        const auto& actual_desc = context.get_desc(*spec.kernel);
-        spec.swizzle =
-            std::min(spec.swizzle, spec.kernel->GetMaxSwizzle({actual_desc.m, actual_desc.n, actual_desc.k, actual_desc.num}));
-    }
-    MaybeTraceGemmDispatch(dispatch_context->desc(), operation.dispatch, spec, measured);
+  }
+  if (spec.kernel && dispatch_context != &context) {
+    const auto& actual_desc = context.get_desc(*spec.kernel);
+    spec.swizzle =
+        std::min(spec.swizzle,
+                 spec.kernel->GetMaxSwizzle({actual_desc.m, actual_desc.n,
+                                             actual_desc.k, actual_desc.num}));
+  }
+  MaybeTraceGemmDispatch(dispatch_context->desc(), operation.dispatch, spec,
+                         measured);
 
-    if (spec.kernel) {
-        // std::cout << "[Gemm] dispatch: " << spec.kernel->name()  //
-        //           << " split_k=" << spec.splits                  //
-        //           << " swizzle=" << spec.swizzle << std::endl;
-        return launch(spec, stream);
-    }
+  if (spec.kernel) {
+    // std::cout << "[Gemm] dispatch: " << spec.kernel->name()  //
+    //           << " split_k=" << spec.splits                  //
+    //           << " swizzle=" << spec.swizzle << std::endl;
+    return launch(spec, stream);
+  }
 
-    TM_CHECK(0) << "No feasible kernel found for the problem: " << to_string(context.desc());
+  TM_CHECK(0) << "No feasible kernel found for the problem: "
+              << to_string(context.desc());
 
-    return -1;
+  return -1;
 }
 
-int Gemm::Export(std::ostream& os)
-{
-    return impl_->cache_.Export(os);
-}
+int Gemm::Export(std::ostream& os) { return impl_->cache_.Export(os); }
 
-int Gemm::Import(std::istream& is)
-{
-    return impl_->cache_.Import(is);
-}
+int Gemm::Import(std::istream& is) { return impl_->cache_.Import(is); }
 
-std::vector<int> Gemm::GetTuningSeq() const
-{
-    return impl_->tuning_.seq;
-}
+std::vector<int> Gemm::GetTuningSeq() const { return impl_->tuning_.seq; }
 
 }  // namespace turbomind::gemm

--- a/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/gemm.cu
+++ b/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/gemm.cu
@@ -91,6 +91,12 @@ bool Sm70Mxfp4MoeGroupedM8FastSelectorEnabled()
     return !raw || std::atoi(raw) != 0;
 }
 
+bool Sm70Nvfp4Qwen38Tp4M1FastSelectorEnabled()
+{
+    const char* raw = std::getenv("VLLM_SM70_NVFP4_QWEN38_TP4_M1_FAST_SELECTOR");
+    return !raw || std::atoi(raw) != 0;
+}
+
 struct Sm70AwqTp2FastTarget {
     int  n;
     int  k;
@@ -167,8 +173,17 @@ std::optional<Sm70AwqTp2FastTarget> GetSm70AwqTp2EnvFastTarget(const GemmDesc&  
 
 std::optional<Sm70AwqTp2FastTarget> GetSm70AwqTp2FastTarget(const GemmDesc& desc)
 {
-    const bool        awq_fast_selector_enabled = Sm70AwqTp2FastSelectorEnabled();
     const std::string desc_str = to_string(desc);
+    if (Sm70Nvfp4Qwen38Tp4M1FastSelectorEnabled()) {
+        // Qwen3.8-27B NVFP4 TP4 decode. The exact-MNK registry entries keep
+        // these small-N tactics out of prefill and unrelated model shapes.
+        if (desc_str == "sm70_f16_e2m1k16_f16_tnt_fff_1x8704x5120_1"
+            || desc_str == "sm70_f16_e2m1k16_f16_tnt_fff_1x5120x4352_1") {
+            return Sm70AwqTp2FastTarget{
+                desc.n, desc.k, 8, 32, 64, 3, 4, true, "c8x32_a1x1x64_01"};
+        }
+    }
+    const bool awq_fast_selector_enabled = Sm70AwqTp2FastSelectorEnabled();
     if (awq_fast_selector_enabled) {
         if (auto target = GetSm70AwqTp2EnvFastTarget(desc, desc_str)) {
             return target;

--- a/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/kernel/sm70_884_4.cu
+++ b/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/kernel/sm70_884_4.cu
@@ -120,6 +120,10 @@ void Registry::sm70_884_4()
         Add<C::Type< 32, 128,  32, 1, 4, 1, D, S, 2, true, 1, 16>>();
         Add<C::Type< 16, 128,  32, 1, 4, 1, D, S, 2, true, 1, 16>>();
         Add<C::Type<  8, 128,  64, 1, 4, 1, D, S, 2, true, 1, 16>>();
+        using C32K64L1 = C::Type<8, 32, 64, 1, 1, 1, D, S, 2, true, 1, 16>;
+        using C32K64L2 = C::Type<8, 32, 64, 1, 1, 1, D, S, 2, true, 1, 16, -1, -1, 2>;
+        Add(std::make_unique<ExactMnkKernelImpl<typename C32K64L1::Kernel, 1, 8704, 5120>>());
+        Add(std::make_unique<ExactMnkKernelImpl<typename C32K64L2::Kernel, 1, 5120, 4352>>());
         // clang-format on
     }
 }

--- a/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/kernel/sm70_884_4.cu
+++ b/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/kernel/sm70_884_4.cu
@@ -13,32 +13,30 @@ using D = cache_policy::Default;
 
 namespace {
 
-// Keep shape-specific small-N tactics out of prefill and unrelated CUDA graph shapes.
-template<class Gemm, int ExactM>
-class ExactMKernelImpl final: public KernelImpl<Gemm> {
-public:
-    bool is_feasible(const GemmDesc& desc) const noexcept override
-    {
-        return desc.m == ExactM && KernelImpl<Gemm>::is_feasible(desc);
-    }
+// Keep shape-specific small-N tactics out of prefill and unrelated CUDA graph
+// shapes.
+template <class Gemm, int ExactM>
+class ExactMKernelImpl final : public KernelImpl<Gemm> {
+ public:
+  bool is_feasible(const GemmDesc& desc) const noexcept override {
+    return desc.m == ExactM && KernelImpl<Gemm>::is_feasible(desc);
+  }
 };
 
-template<class Gemm, int ExactM, int ExactN, int ExactK>
-class ExactMnkKernelImpl final: public KernelImpl<Gemm> {
-public:
-    bool is_feasible(const GemmDesc& desc) const noexcept override
-    {
-        return desc.m == ExactM && desc.n == ExactN && desc.k == ExactK
-               && KernelImpl<Gemm>::is_feasible(desc);
-    }
+template <class Gemm, int ExactM, int ExactN, int ExactK>
+class ExactMnkKernelImpl final : public KernelImpl<Gemm> {
+ public:
+  bool is_feasible(const GemmDesc& desc) const noexcept override {
+    return desc.m == ExactM && desc.n == ExactN && desc.k == ExactK &&
+           KernelImpl<Gemm>::is_feasible(desc);
+  }
 };
 
 }  // namespace
 
-void Registry::sm70_884_4()
-{
-    if constexpr (1) {
-        // clang-format off
+void Registry::sm70_884_4() {
+  if constexpr (1) {
+    // clang-format off
         using C = Config_U4_d<kColMajor>;
         Add<C::Type<128, 256, 16, 2, 4, 1, D, D, 2, true, 1, 128, 128, 128>>();
         Add<C::Type<128, 128, 16, 2, 2, 1, D, D, 2, true, 1, 128, 64, 128>>();
@@ -65,11 +63,11 @@ void Registry::sm70_884_4()
         Add(std::make_unique<ExactMnkKernelImpl<typename C64::Kernel, 1, 8704, 5120>>());
         Add(std::make_unique<ExactMnkKernelImpl<typename C64::Kernel, 1, 4096, 5120>>());
 
-        // clang-format on
-    }
+    // clang-format on
+  }
 
-    if constexpr (1) {
-        // clang-format off
+  if constexpr (1) {
+    // clang-format off
         // GroupSizeV=128
         using C = Config_U4_g<kColMajor>;
         Add<C::Type<128, 256,  16, 2, 4, 1, D, D, 2,   0 , 1, 128, 128, 128>>();
@@ -98,22 +96,22 @@ void Registry::sm70_884_4()
         Add<C::Type< 16, 128,  32, 1, 4, 1, D, S, 2, true, 1, 32>>();
         Add<C::Type<  8, 128,  64, 1, 4, 1, D, S, 2, true, 1, 32>>();
         Add<C::Type<  8, 256,  64, 1, 4, 1, D, S, 2, true, 1, 32>>();
-        // clang-format on
-    }
+    // clang-format on
+  }
 
-    if constexpr (1) {
-        // clang-format off
+  if constexpr (1) {
+    // clang-format off
         using C = Config_MXF4<kColMajor, 0>;
         Add<C::Type<128, 128,  16, 2, 2, 1, D, D, 2, true, 1, 32,  64, 128>>();
         Add<C::Type< 64, 128,  32, 1, 4, 1, D, S, 2, true, 1, 32,  32, 128>>();
         Add<C::Type< 32, 128,  32, 1, 4, 1, D, S, 2, true, 1, 32>>();
         Add<C::Type< 16, 128,  32, 1, 4, 1, D, S, 2, true, 1, 32>>();
         Add<C::Type<  8, 128,  64, 1, 4, 1, D, S, 2, true, 1, 32>>();
-        // clang-format on
-    }
+    // clang-format on
+  }
 
-    if constexpr (1) {
-        // clang-format off
+  if constexpr (1) {
+    // clang-format off
         using C = Config_NVF4<kColMajor, 0>;
         Add<C::Type<128, 128,  16, 2, 2, 1, D, D, 2, true, 1, 16,  64, 128>>();
         Add<C::Type< 64, 128,  32, 1, 4, 1, D, S, 2, true, 1, 16,  32, 128>>();
@@ -128,8 +126,8 @@ void Registry::sm70_884_4()
         Add(std::make_unique<ExactMnkKernelImpl<typename C32K64L2::Kernel, 1, 5120, 4352>>());
         Add(std::make_unique<ExactMnkKernelImpl<typename C32K128L1::Kernel, 1, 8704, 5120>>());
         Add(std::make_unique<ExactMnkKernelImpl<typename C32K128L2::Kernel, 1, 5120, 4352>>());
-        // clang-format on
-    }
+    // clang-format on
+  }
 }
 
 }  // namespace turbomind::gemm

--- a/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/kernel/sm70_884_4.cu
+++ b/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/kernel/sm70_884_4.cu
@@ -122,8 +122,12 @@ void Registry::sm70_884_4()
         Add<C::Type<  8, 128,  64, 1, 4, 1, D, S, 2, true, 1, 16>>();
         using C32K64L1 = C::Type<8, 32, 64, 1, 1, 1, D, S, 2, true, 1, 16>;
         using C32K64L2 = C::Type<8, 32, 64, 1, 1, 1, D, S, 2, true, 1, 16, -1, -1, 2>;
+        using C32K128L1 = C::Type<8, 32, 128, 1, 1, 1, D, S, 2, true, 1, 16>;
+        using C32K128L2 = C::Type<8, 32, 128, 1, 1, 1, D, S, 2, true, 1, 16, -1, -1, 2>;
         Add(std::make_unique<ExactMnkKernelImpl<typename C32K64L1::Kernel, 1, 8704, 5120>>());
         Add(std::make_unique<ExactMnkKernelImpl<typename C32K64L2::Kernel, 1, 5120, 4352>>());
+        Add(std::make_unique<ExactMnkKernelImpl<typename C32K128L1::Kernel, 1, 8704, 5120>>());
+        Add(std::make_unique<ExactMnkKernelImpl<typename C32K128L2::Kernel, 1, 5120, 4352>>());
         // clang-format on
     }
 }

--- a/csrc/sm70_turbomind/ops/LICENSE.v100-skinny
+++ b/csrc/sm70_turbomind/ops/LICENSE.v100-skinny
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 v100-skinny contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/csrc/sm70_turbomind/ops/awq_sm70_gemm.cu
+++ b/csrc/sm70_turbomind/ops/awq_sm70_gemm.cu
@@ -1096,6 +1096,12 @@ bool nvfp4_moe_grouped_prefill_enabled() {
   return raw == nullptr || std::atoi(raw) != 0;
 }
 
+bool nvfp4_qwen38_tp4_m1_fast_selector_enabled() {
+  const char* raw =
+      std::getenv("VLLM_SM70_NVFP4_QWEN38_TP4_M1_FAST_SELECTOR");
+  return raw == nullptr || std::atoi(raw) != 0;
+}
+
 bool fp8_moe_single_token_per_expert_dispatch_enabled() {
   const char* raw =
       std::getenv("VLLM_SM70_FP8_MOE_SINGLE_TOKEN_PER_EXPERT_DISPATCH");
@@ -1313,6 +1319,11 @@ turbomind::gemm::DispatchPolicy select_mxfp4_dense_dispatch_policy(
 
 turbomind::gemm::DispatchPolicy select_nvfp4_dense_dispatch_policy(
     int device, int m, int n, int k, int group_size, cudaStream_t stream) {
+  if (nvfp4_qwen38_tp4_m1_fast_selector_enabled() && m == 1 &&
+      group_size == 16 &&
+      ((n == 8704 && k == 5120) || (n == 5120 && k == 4352))) {
+    return turbomind::gemm::DispatchPolicy::kDefault;
+  }
   return select_dense_dispatch_policy_impl(
       device, m, n, k, group_size, stream, TuneKeyKind::kNvfp4Dense,
       nvfp4_tune_small_shapes_enabled(), false, nvfp4_dense_tune_max_m());
@@ -2819,10 +2830,13 @@ std::vector<torch::Tensor> fp8_sm70_prepare(torch::Tensor qweight,
   const int64_t k = qweight.size(1);
   TORCH_CHECK(k % 8 == 0 && n % 8 == 0,
               "fp8_sm70_prepare: K and N must be multiples of 8.");
-  TORCH_CHECK(scales.size(0) == (n + group_size - 1) / group_size,
-              "fp8_sm70_prepare: output scale block mismatch.");
-  TORCH_CHECK(scales.size(1) == (k + group_size - 1) / group_size,
-              "fp8_sm70_prepare: input scale block mismatch.");
+  const bool channelwise_scales = scales.size(0) == n && scales.size(1) == 1;
+  const bool blockwise_scales =
+      scales.size(0) == (n + group_size - 1) / group_size &&
+      scales.size(1) == (k + group_size - 1) / group_size;
+  TORCH_CHECK(channelwise_scales || blockwise_scales,
+              "fp8_sm70_prepare: expected [N, 1] channel scales or "
+              "[ceil(N/128), ceil(K/128)] block scales.");
 
   const auto converters = turbomind::gemm::GetConverters(
       turbomind::kHalf, turbomind::kFloat8_e4m3, turbomind::kHalf, true, 70);
@@ -2886,12 +2900,21 @@ std::vector<torch::Tensor> fp8_sm70_prepare(torch::Tensor qweight,
   const bool is_B_s = !is_A_s;
   const int64_t num_groups = (k + group_size - 1) / group_size;
 
-  auto group_scales = scales.transpose(0, 1)
-                          .contiguous()
-                          .to(torch::kFloat16)
-                          .repeat_interleave(group_size, 1)
-                          .slice(1, 0, n)
-                          .contiguous();
+  torch::Tensor group_scales;
+  if (channelwise_scales) {
+    group_scales = scales.transpose(0, 1)
+                       .contiguous()
+                       .to(torch::kFloat16)
+                       .repeat({num_groups, 1})
+                       .contiguous();
+  } else {
+    group_scales = scales.transpose(0, 1)
+                       .contiguous()
+                       .to(torch::kFloat16)
+                       .repeat_interleave(group_size, 1)
+                       .slice(1, 0, n)
+                       .contiguous();
+  }
   if (interleave_gated_silu) {
     group_scales = interleave_gated_silu_cols(group_scales);
   }

--- a/csrc/sm70_turbomind/ops/awq_sm70_gemm.cu
+++ b/csrc/sm70_turbomind/ops/awq_sm70_gemm.cu
@@ -1097,8 +1097,7 @@ bool nvfp4_moe_grouped_prefill_enabled() {
 }
 
 bool nvfp4_qwen38_tp4_m1_fast_selector_enabled() {
-  const char* raw =
-      std::getenv("VLLM_SM70_NVFP4_QWEN38_TP4_M1_FAST_SELECTOR");
+  const char* raw = std::getenv("VLLM_SM70_NVFP4_QWEN38_TP4_M1_FAST_SELECTOR");
   return raw == nullptr || std::atoi(raw) != 0;
 }
 
@@ -2412,8 +2411,7 @@ __global__ void fp8_sm70_dequantize_kernel(
   }
 
   const int words_per_n_tile = k / kFp8QuantValuesPerWord;
-  const int n_in_tile =
-      static_cast<int>(word_index % kFp8OutputColumnsPerTile);
+  const int n_in_tile = static_cast<int>(word_index % kFp8OutputColumnsPerTile);
   const int64_t tile_word = word_index / kFp8OutputColumnsPerTile;
   const int k_word = static_cast<int>(tile_word % words_per_n_tile);
   const int n_tile = static_cast<int>(tile_word / words_per_n_tile);
@@ -2422,10 +2420,12 @@ __global__ void fp8_sm70_dequantize_kernel(
   const int group = k_base / group_size;
 
   const uint2 quant = reinterpret_cast<const uint2*>(packed_weight)[word_index];
-  const auto& quant_lo = reinterpret_cast<
-      const turbomind::Array<turbomind::fp8_e4m3_t, 4>&>(quant.x);
-  const auto& quant_hi = reinterpret_cast<
-      const turbomind::Array<turbomind::fp8_e4m3_t, 4>&>(quant.y);
+  const auto& quant_lo =
+      reinterpret_cast<const turbomind::Array<turbomind::fp8_e4m3_t, 4>&>(
+          quant.x);
+  const auto& quant_hi =
+      reinterpret_cast<const turbomind::Array<turbomind::fp8_e4m3_t, 4>&>(
+          quant.y);
   const auto half_lo = turbomind::cvt_f16x4_e4m3(quant_lo);
   const auto half_hi = turbomind::cvt_f16x4_e4m3(quant_hi);
   const __half scale = packed_scales[static_cast<int64_t>(group) * n + col];
@@ -2450,10 +2450,8 @@ __global__ void fp8_sm70_dequantize_kernel(
       __hmul(half_hi[3], scale);
 }
 
-void fp8_sm70_dequantize_out(torch::Tensor output,
-                             torch::Tensor packed_weight,
-                             torch::Tensor packed_scales,
-                             int64_t group_size) {
+void fp8_sm70_dequantize_out(torch::Tensor output, torch::Tensor packed_weight,
+                             torch::Tensor packed_scales, int64_t group_size) {
   TORCH_CHECK(
       output.is_cuda() && packed_weight.is_cuda() && packed_scales.is_cuda(),
       "SM70 FP8 prefill dequant expects CUDA tensors.");
@@ -2473,8 +2471,7 @@ void fp8_sm70_dequantize_out(torch::Tensor output,
   const at::cuda::OptionalCUDAGuard device_guard(device_of(output));
   const int64_t k = output.size(0);
   const int64_t n = output.size(1);
-  TORCH_CHECK(k % group_size == 0 &&
-                  k % kFp8QuantValuesPerWord == 0 &&
+  TORCH_CHECK(k % group_size == 0 && k % kFp8QuantValuesPerWord == 0 &&
                   n % kFp8OutputColumnsPerTile == 0,
               "SM70 FP8 prefill dequant shape alignment mismatch.");
   TORCH_CHECK(packed_weight.numel() == k * n,
@@ -2487,15 +2484,14 @@ void fp8_sm70_dequantize_out(torch::Tensor output,
               "SM70 FP8 prefill tensors must share a device.");
 
   const int64_t words = packed_weight.numel() / kFp8QuantValuesPerWord;
-  const int blocks = static_cast<int>(
-      (words + kFp8PrefillDequantThreads - 1) / kFp8PrefillDequantThreads);
+  const int blocks = static_cast<int>((words + kFp8PrefillDequantThreads - 1) /
+                                      kFp8PrefillDequantThreads);
   fp8_sm70_dequantize_kernel<<<blocks, kFp8PrefillDequantThreads, 0,
                                at::cuda::getCurrentCUDAStream()>>>(
       reinterpret_cast<__half*>(output.data_ptr<at::Half>()),
       packed_weight.data_ptr<uint8_t>(),
       reinterpret_cast<const __half*>(packed_scales.data_ptr<at::Half>()),
-      static_cast<int>(k), static_cast<int>(n),
-      static_cast<int>(group_size));
+      static_cast<int>(k), static_cast<int>(n), static_cast<int>(group_size));
   C10_CUDA_KERNEL_LAUNCH_CHECK();
 }
 

--- a/csrc/sm70_turbomind/ops/fp8_qpn8_sm70.cu
+++ b/csrc/sm70_turbomind/ops/fp8_qpn8_sm70.cu
@@ -170,13 +170,14 @@ __global__ void fp8_qpn8_silu_and_mul_sm70_kernel(
         "+f"(C[5]), "+f"(C[6]), "+f"(C[7])                          \
       : "r"(A0), "r"(A1), "r"(B0), "r"(B1))
 
-template <int SplitK, int NAcc, bool FastDecoder, bool PrefetchCodes>
+template <int SplitK, int NAcc, bool FastDecoder, bool PrefetchCodes,
+          bool M1Only = false>
 __global__ void fp8_qpn8_sm70_kernel(const uint8_t* __restrict__ codes,
                                      const half* __restrict__ group_scales,
                                      const half* __restrict__ input,
                                      half* __restrict__ output, int n, int k,
                                      int m, bool channel_scales) {
-  __shared__ float partials[SplitK][256];
+  __shared__ float partials[SplitK][M1Only ? 32 : 256];
 
   const int lane = threadIdx.x & 31;
   const int warp = threadIdx.x >> 5;
@@ -271,44 +272,70 @@ __global__ void fp8_qpn8_sm70_kernel(const uint8_t* __restrict__ codes,
     }
   }
 
+  if constexpr (M1Only) {
+    if ((lane & 17) == 0) {
 #pragma unroll
-  for (int i = 0; i < 8; ++i) {
-    const int output_row = (i & 2) | ((lane & 16) ? 4 : 0) | (lane & 1);
-    const int output_col = (i & 1) | (((lane >> 1) & 1) << 1) | ((i >> 2) << 2);
-    partials[warp][output_row * 32 + quadpair * 8 + output_col] = accum[0][i];
+      for (int pair = 0; pair < 2; ++pair) {
+#pragma unroll
+        for (int offset = 0; offset < 2; ++offset) {
+          const int i = pair * 4 + offset;
+          const int output_col =
+              offset | (((lane >> 1) & 1) << 1) | (pair << 2);
+          partials[warp][quadpair * 8 + output_col] = accum[0][i];
+        }
+      }
+    }
+  } else {
+#pragma unroll
+    for (int i = 0; i < 8; ++i) {
+      const int output_row =
+          (i & 2) | ((lane & 16) ? 4 : 0) | (lane & 1);
+      const int output_col =
+          (i & 1) | (((lane >> 1) & 1) << 1) | ((i >> 2) << 2);
+      partials[warp][output_row * 32 + quadpair * 8 + output_col] =
+          accum[0][i];
+    }
   }
   __syncthreads();
 
-  for (int element = threadIdx.x; element < 256; element += blockDim.x) {
+  constexpr int kOutputElements = M1Only ? 32 : 256;
+  for (int element = threadIdx.x; element < kOutputElements;
+       element += blockDim.x) {
     float value = 0.0f;
 #pragma unroll
     for (int k_warp = 0; k_warp < SplitK; ++k_warp) {
       value += partials[k_warp][element];
     }
-    const int output_row = element >> 5;
-    const int output_col = element & 31;
-    if (output_row < m) {
-      output[static_cast<size_t>(output_row) * n + tile * 32 + output_col] =
-          __float2half(value);
+    if constexpr (M1Only) {
+      output[tile * 32 + element] = __float2half(value);
+    } else {
+      const int output_row = element >> 5;
+      const int output_col = element & 31;
+      if (output_row < m) {
+        output[static_cast<size_t>(output_row) * n + tile * 32 + output_col] =
+            __float2half(value);
+      }
     }
   }
 }
 
-template <int SplitK, int NAcc, bool FastDecoder, bool PrefetchCodes>
+template <int SplitK, int NAcc, bool FastDecoder, bool PrefetchCodes,
+          bool M1Only = false>
 void launch_fp8_qpn8_sm70(const uint8_t* codes, const half* group_scales,
                           const half* input, half* output, int n, int k, int m,
                           bool channel_scales, cudaStream_t stream) {
-  fp8_qpn8_sm70_kernel<SplitK, NAcc, FastDecoder, PrefetchCodes>
+  fp8_qpn8_sm70_kernel<SplitK, NAcc, FastDecoder, PrefetchCodes, M1Only>
       <<<(n / 32), (32 * SplitK), 0, stream>>>(codes, group_scales, input,
                                                output, n, k, m, channel_scales);
 }
 
-template <int SplitK, int NAcc, bool FastDecoder, bool PrefetchCodes>
+template <int SplitK, int NAcc, bool FastDecoder, bool PrefetchCodes,
+          bool M1Only = false>
 __global__ void fp8_qpn8_gated_pair_sm70_kernel(
     const uint8_t* __restrict__ codes, const half* __restrict__ group_scales,
     const half* __restrict__ input, half* __restrict__ output, int hidden,
     int k, int m, bool channel_scales) {
-  __shared__ float partials[2][SplitK][256];
+  __shared__ float partials[2][SplitK][M1Only ? 32 : 256];
 
   const int lane = threadIdx.x & 31;
   const int warp_in_block = threadIdx.x >> 5;
@@ -403,16 +430,36 @@ __global__ void fp8_qpn8_gated_pair_sm70_kernel(
       accum[0][i] += accum[chain][i];
     }
   }
+  if constexpr (M1Only) {
+    if ((lane & 17) == 0) {
 #pragma unroll
-  for (int i = 0; i < 8; ++i) {
-    const int output_row = (i & 2) | ((lane & 16) ? 4 : 0) | (lane & 1);
-    const int output_col = (i & 1) | (((lane >> 1) & 1) << 1) | ((i >> 2) << 2);
-    partials[projection][warp][output_row * 32 + quadpair * 8 + output_col] =
-        accum[0][i];
+      for (int pair = 0; pair < 2; ++pair) {
+#pragma unroll
+        for (int offset = 0; offset < 2; ++offset) {
+          const int i = pair * 4 + offset;
+          const int output_col =
+              offset | (((lane >> 1) & 1) << 1) | (pair << 2);
+          partials[projection][warp][quadpair * 8 + output_col] =
+              accum[0][i];
+        }
+      }
+    }
+  } else {
+#pragma unroll
+    for (int i = 0; i < 8; ++i) {
+      const int output_row =
+          (i & 2) | ((lane & 16) ? 4 : 0) | (lane & 1);
+      const int output_col =
+          (i & 1) | (((lane >> 1) & 1) << 1) | ((i >> 2) << 2);
+      partials[projection][warp]
+              [output_row * 32 + quadpair * 8 + output_col] = accum[0][i];
+    }
   }
   __syncthreads();
 
-  for (int element = threadIdx.x; element < 256; element += blockDim.x) {
+  constexpr int kOutputElements = M1Only ? 32 : 256;
+  for (int element = threadIdx.x; element < kOutputElements;
+       element += blockDim.x) {
     float gate = 0.0f;
     float up = 0.0f;
 #pragma unroll
@@ -420,23 +467,30 @@ __global__ void fp8_qpn8_gated_pair_sm70_kernel(
       gate += partials[0][k_warp][element];
       up += partials[1][k_warp][element];
     }
-    const int output_row = element >> 5;
-    const int output_col = element & 31;
-    if (output_row < m) {
+    if constexpr (M1Only) {
       const float silu = gate / (1.0f + __expf(-gate));
-      output[static_cast<size_t>(output_row) * hidden + blockIdx.x * 32 +
-             output_col] = __float2half(silu * up);
+      output[blockIdx.x * 32 + element] = __float2half(silu * up);
+    } else {
+      const int output_row = element >> 5;
+      const int output_col = element & 31;
+      if (output_row < m) {
+        const float silu = gate / (1.0f + __expf(-gate));
+        output[static_cast<size_t>(output_row) * hidden + blockIdx.x * 32 +
+               output_col] = __float2half(silu * up);
+      }
     }
   }
 }
 
-template <int SplitK, int NAcc, bool FastDecoder, bool PrefetchCodes>
+template <int SplitK, int NAcc, bool FastDecoder, bool PrefetchCodes,
+          bool M1Only = false>
 void launch_fp8_qpn8_gated_pair_sm70(const uint8_t* codes,
                                      const half* group_scales,
                                      const half* input, half* output,
                                      int hidden, int k, int m,
                                      bool channel_scales, cudaStream_t stream) {
-  fp8_qpn8_gated_pair_sm70_kernel<SplitK, NAcc, FastDecoder, PrefetchCodes>
+  fp8_qpn8_gated_pair_sm70_kernel<SplitK, NAcc, FastDecoder, PrefetchCodes,
+                                  M1Only>
       <<<(hidden / 32), (64 * SplitK), 0, stream>>>(codes, group_scales, input,
                                                     output, hidden, k, m,
                                                     channel_scales);
@@ -655,8 +709,26 @@ void fp8_qpn8_gemm_sm70_out(torch::Tensor out, torch::Tensor input,
       reinterpret_cast<const half*>(input.data_ptr<at::Half>());
   auto* output_ptr = reinterpret_cast<half*>(out.data_ptr<at::Half>());
 
+  // Keep the M=1 reduction order restricted to the two tuned output/down
+  // projections. Extending it to the other split variants changed the frozen
+  // random-sampling token stream without an end-to-end decode win.
+  if (m == 1 && accumulator_chains == 2 && fast_decoder &&
+      !prefetch_codes && (split_k == 12 || split_k == 16)) {
+    if (split_k == 12) {
+      launch_fp8_qpn8_sm70<12, 2, true, false, true>(
+          code_ptr, scale_ptr, input_ptr, output_ptr, static_cast<int>(n),
+          static_cast<int>(k), 1, channel_scales, stream);
+    } else {
+      launch_fp8_qpn8_sm70<16, 2, true, false, true>(
+          code_ptr, scale_ptr, input_ptr, output_ptr, static_cast<int>(n),
+          static_cast<int>(k), 1, channel_scales, stream);
+    }
+    C10_CUDA_KERNEL_LAUNCH_CHECK();
+    return;
+  }
+
 #define VLLM_LAUNCH_QPN8(SPLIT, NACC, FAST, PREFETCH)                  \
-  launch_fp8_qpn8_sm70<SPLIT, NACC, FAST, PREFETCH>(                   \
+  launch_fp8_qpn8_sm70<SPLIT, NACC, FAST, PREFETCH, false>(            \
       code_ptr, scale_ptr, input_ptr, output_ptr, static_cast<int>(n), \
       static_cast<int>(k), static_cast<int>(m), channel_scales, stream)
 
@@ -778,8 +850,20 @@ void fp8_qpn8_gated_pair_sm70_out(torch::Tensor out, torch::Tensor input,
       reinterpret_cast<const half*>(input.data_ptr<at::Half>());
   auto* output_ptr = reinterpret_cast<half*>(out.data_ptr<at::Half>());
 
+  // The frozen gate/up route is split-8. Preserve the generic reduction order
+  // for split-4/16 rather than instantiating unaccepted M=1 variants.
+  if (m == 1 && split_k == 8 && accumulator_chains == 2 && fast_decoder &&
+      !prefetch_codes) {
+    launch_fp8_qpn8_gated_pair_sm70<8, 2, true, false, true>(
+        code_ptr, scale_ptr, input_ptr, output_ptr,
+        static_cast<int>(hidden), static_cast<int>(k), 1, channel_scales,
+        stream);
+    C10_CUDA_KERNEL_LAUNCH_CHECK();
+    return;
+  }
+
 #define VLLM_LAUNCH_QPN8_GATED_PAIR(SPLIT, NACC, FAST, PREFETCH)            \
-  launch_fp8_qpn8_gated_pair_sm70<SPLIT, NACC, FAST, PREFETCH>(             \
+  launch_fp8_qpn8_gated_pair_sm70<SPLIT, NACC, FAST, PREFETCH, false>(      \
       code_ptr, scale_ptr, input_ptr, output_ptr, static_cast<int>(hidden), \
       static_cast<int>(k), static_cast<int>(m), channel_scales, stream)
 

--- a/csrc/sm70_turbomind/ops/fp8_qpn8_sm70.cu
+++ b/csrc/sm70_turbomind/ops/fp8_qpn8_sm70.cu
@@ -100,9 +100,19 @@ __global__ void fp8_qpn8_scale_sm70_kernel(half* __restrict__ group_scales,
       __float2half(scales[(n_tile >> 2) * k_blocks + k_block] * 256.0f);
 }
 
+__global__ void fp8_qpn8_channel_scale_sm70_kernel(
+    half* __restrict__ channel_scales, const float* __restrict__ scales,
+    int n) {
+  const int col = blockIdx.x * blockDim.x + threadIdx.x;
+  if (col < n) {
+    channel_scales[col] = __float2half(scales[col] * 256.0f);
+  }
+}
+
 __global__ void fp8_qpn8_dequantize_sm70_kernel(
     half* __restrict__ output, const uint8_t* __restrict__ codes,
-    const half* __restrict__ group_scales, int n, int k) {
+    const half* __restrict__ group_scales, int n, int k,
+    bool channel_scales) {
   const size_t word_index =
       static_cast<size_t>(blockIdx.x) * blockDim.x + threadIdx.x;
   const size_t word_count = static_cast<size_t>(n) * k / 16;
@@ -117,7 +127,9 @@ __global__ void fp8_qpn8_dequantize_sm70_kernel(
   const int tile = static_cast<int>(tile_word / groups_k16);
   const int col = tile * 32 + qpn8_col_from_lane(lane);
   const int tiles_n32 = n >> 5;
-  const half scale = group_scales[(group >> 3) * tiles_n32 + tile];
+  const half scale = channel_scales
+                         ? group_scales[col]
+                         : group_scales[(group >> 3) * tiles_n32 + tile];
   const half2 scale2 = __halves2half2(scale, scale);
   const uint4 packed = reinterpret_cast<const uint4*>(codes)[word_index];
   half2 weights[8];
@@ -163,7 +175,7 @@ __global__ void fp8_qpn8_sm70_kernel(const uint8_t* __restrict__ codes,
                                      const half* __restrict__ group_scales,
                                      const half* __restrict__ input,
                                      half* __restrict__ output, int n, int k,
-                                     int m) {
+                                     int m, bool channel_scales) {
   __shared__ float partials[SplitK][256];
 
   const int lane = threadIdx.x & 31;
@@ -188,7 +200,10 @@ __global__ void fp8_qpn8_sm70_kernel(const uint8_t* __restrict__ codes,
     }
   }
   int loaded_scale_group = -1;
-  half loaded_scale = __float2half(0.0f);
+  half loaded_scale =
+      channel_scales
+          ? __ldg(group_scales + tile * 32 + qpn8_col_from_lane(lane))
+          : __float2half(0.0f);
   uint4 prefetched = make_uint4(0, 0, 0, 0);
   if constexpr (PrefetchCodes) {
     prefetched = __ldcs(code_ptr + static_cast<size_t>(group_begin) * 32);
@@ -198,7 +213,7 @@ __global__ void fp8_qpn8_sm70_kernel(const uint8_t* __restrict__ codes,
   for (int group = group_begin; group < group_begin + groups_per_warp;
        ++group) {
     const int scale_group = group >> 3;
-    if (scale_group != loaded_scale_group) {
+    if (!channel_scales && scale_group != loaded_scale_group) {
       loaded_scale =
           __ldg(scale_ptr + static_cast<size_t>(scale_group) * tiles_n32);
       loaded_scale_group = scale_group;
@@ -282,17 +297,17 @@ __global__ void fp8_qpn8_sm70_kernel(const uint8_t* __restrict__ codes,
 template <int SplitK, int NAcc, bool FastDecoder, bool PrefetchCodes>
 void launch_fp8_qpn8_sm70(const uint8_t* codes, const half* group_scales,
                           const half* input, half* output, int n, int k, int m,
-                          cudaStream_t stream) {
+                          bool channel_scales, cudaStream_t stream) {
   fp8_qpn8_sm70_kernel<SplitK, NAcc, FastDecoder, PrefetchCodes>
       <<<(n / 32), (32 * SplitK), 0, stream>>>(codes, group_scales, input,
-                                               output, n, k, m);
+                                               output, n, k, m, channel_scales);
 }
 
 template <int SplitK, int NAcc, bool FastDecoder, bool PrefetchCodes>
 __global__ void fp8_qpn8_gated_pair_sm70_kernel(
     const uint8_t* __restrict__ codes, const half* __restrict__ group_scales,
     const half* __restrict__ input, half* __restrict__ output, int hidden,
-    int k, int m) {
+    int k, int m, bool channel_scales) {
   __shared__ float partials[2][SplitK][256];
 
   const int lane = threadIdx.x & 31;
@@ -320,7 +335,10 @@ __global__ void fp8_qpn8_gated_pair_sm70_kernel(
     }
   }
   int loaded_scale_group = -1;
-  half loaded_scale = __float2half(0.0f);
+  half loaded_scale =
+      channel_scales
+          ? __ldg(group_scales + tile * 32 + qpn8_col_from_lane(lane))
+          : __float2half(0.0f);
   uint4 prefetched = make_uint4(0, 0, 0, 0);
   if constexpr (PrefetchCodes) {
     prefetched = __ldcs(code_ptr + static_cast<size_t>(group_begin) * 32);
@@ -330,7 +348,7 @@ __global__ void fp8_qpn8_gated_pair_sm70_kernel(
   for (int group = group_begin; group < group_begin + groups_per_warp;
        ++group) {
     const int scale_group = group >> 3;
-    if (scale_group != loaded_scale_group) {
+    if (!channel_scales && scale_group != loaded_scale_group) {
       loaded_scale =
           __ldg(scale_ptr + static_cast<size_t>(scale_group) * tiles_n32);
       loaded_scale_group = scale_group;
@@ -417,10 +435,11 @@ void launch_fp8_qpn8_gated_pair_sm70(const uint8_t* codes,
                                      const half* group_scales,
                                      const half* input, half* output,
                                      int hidden, int k, int m,
-                                     cudaStream_t stream) {
+                                     bool channel_scales, cudaStream_t stream) {
   fp8_qpn8_gated_pair_sm70_kernel<SplitK, NAcc, FastDecoder, PrefetchCodes>
       <<<(hidden / 32), (64 * SplitK), 0, stream>>>(codes, group_scales, input,
-                                                    output, hidden, k, m);
+                                                    output, hidden, k, m,
+                                                    channel_scales);
 }
 
 }  // namespace
@@ -445,8 +464,12 @@ std::vector<torch::Tensor> fp8_qpn8_prepare_sm70(torch::Tensor qweight,
   TORCH_CHECK(n > 0 && n % 128 == 0 && k > 0 && k % 128 == 0,
               "fp8_qpn8_prepare_sm70: N and K must be positive multiples of "
               "128");
-  TORCH_CHECK(scales.size(0) == n / 128 && scales.size(1) == k / 128,
-              "fp8_qpn8_prepare_sm70: block-scale shape mismatch");
+  const bool channel_scales = scales.size(0) == n && scales.size(1) == 1;
+  const bool block_scales =
+      scales.size(0) == n / 128 && scales.size(1) == k / 128;
+  TORCH_CHECK(channel_scales || block_scales,
+              "fp8_qpn8_prepare_sm70: expected channel scales [N, 1] or "
+              "block scales [N/128, K/128]");
 
   const at::cuda::OptionalCUDAGuard device_guard(device_of(qweight));
   const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
@@ -454,7 +477,7 @@ std::vector<torch::Tensor> fp8_qpn8_prepare_sm70(torch::Tensor qweight,
       {k, n},
       torch::TensorOptions().device(qweight.device()).dtype(torch::kUInt8));
   auto group_scales = torch::empty(
-      {k / 128, n / 32},
+      {channel_scales ? 1 : k / 128, channel_scales ? n : n / 32},
       torch::TensorOptions().device(qweight.device()).dtype(torch::kFloat16));
 
   const int64_t weight_numel = n * k;
@@ -469,10 +492,17 @@ std::vector<torch::Tensor> fp8_qpn8_prepare_sm70(torch::Tensor qweight,
   const int64_t scale_numel = group_scales.numel();
   const int scale_blocks = static_cast<int>(
       (scale_numel + kQpn8PrepareThreads - 1) / kQpn8PrepareThreads);
-  fp8_qpn8_scale_sm70_kernel<<<scale_blocks, kQpn8PrepareThreads, 0, stream>>>(
-      reinterpret_cast<half*>(group_scales.data_ptr<at::Half>()),
-      scales.data_ptr<float>(), static_cast<int>(n / 128),
-      static_cast<int>(k / 128));
+  if (channel_scales) {
+    fp8_qpn8_channel_scale_sm70_kernel<<<scale_blocks, kQpn8PrepareThreads, 0,
+                                         stream>>>(
+        reinterpret_cast<half*>(group_scales.data_ptr<at::Half>()),
+        scales.data_ptr<float>(), static_cast<int>(n));
+  } else {
+    fp8_qpn8_scale_sm70_kernel<<<scale_blocks, kQpn8PrepareThreads, 0, stream>>>(
+        reinterpret_cast<half*>(group_scales.data_ptr<at::Half>()),
+        scales.data_ptr<float>(), static_cast<int>(n / 128),
+        static_cast<int>(k / 128));
+  }
   C10_CUDA_KERNEL_LAUNCH_CHECK();
   return {codes, group_scales};
 }
@@ -500,8 +530,12 @@ void fp8_qpn8_dequantize_sm70_out(torch::Tensor out, torch::Tensor codes,
               "fp8_qpn8_dequantize_sm70_out: K and N alignment mismatch");
   TORCH_CHECK(codes.numel() == k * n,
               "fp8_qpn8_dequantize_sm70_out: packed code size mismatch");
-  TORCH_CHECK(group_scales.size(0) == k / 128 && group_scales.size(1) == n / 32,
-              "fp8_qpn8_dequantize_sm70_out: group-scale shape mismatch");
+  const bool channel_scales =
+      group_scales.size(0) == 1 && group_scales.size(1) == n;
+  const bool block_scales = group_scales.size(0) == k / 128 &&
+                            group_scales.size(1) == n / 32;
+  TORCH_CHECK(channel_scales || block_scales,
+              "fp8_qpn8_dequantize_sm70_out: scale shape mismatch");
 
   const at::cuda::OptionalCUDAGuard device_guard(device_of(out));
   const int64_t word_count = k * n / 16;
@@ -512,7 +546,7 @@ void fp8_qpn8_dequantize_sm70_out(torch::Tensor out, torch::Tensor codes,
       reinterpret_cast<half*>(out.data_ptr<at::Half>()),
       codes.data_ptr<uint8_t>(),
       reinterpret_cast<const half*>(group_scales.data_ptr<at::Half>()),
-      static_cast<int>(n), static_cast<int>(k));
+      static_cast<int>(n), static_cast<int>(k), channel_scales);
   C10_CUDA_KERNEL_LAUNCH_CHECK();
 }
 
@@ -590,10 +624,15 @@ void fp8_qpn8_gemm_sm70_out(torch::Tensor out, torch::Tensor input,
               "fp8_qpn8_gemm_sm70_out: K must be a positive multiple of 128");
   TORCH_CHECK(codes.numel() == n * k,
               "fp8_qpn8_gemm_sm70_out: packed code size mismatch");
-  TORCH_CHECK(group_scales.size(0) == k / 128 && group_scales.size(1) == n / 32,
-              "fp8_qpn8_gemm_sm70_out: group scale shape mismatch");
-  TORCH_CHECK(split_k == 4 || split_k == 8 || split_k == 16 || split_k == 32,
-              "fp8_qpn8_gemm_sm70_out: split_k must be 4, 8, 16, or 32");
+  const bool channel_scales =
+      group_scales.size(0) == 1 && group_scales.size(1) == n;
+  const bool block_scales = group_scales.size(0) == k / 128 &&
+                            group_scales.size(1) == n / 32;
+  TORCH_CHECK(channel_scales || block_scales,
+              "fp8_qpn8_gemm_sm70_out: scale shape mismatch");
+  TORCH_CHECK(split_k == 4 || split_k == 8 || split_k == 12 ||
+                  split_k == 16 || split_k == 32,
+              "fp8_qpn8_gemm_sm70_out: unsupported split_k");
   TORCH_CHECK((k / 16) % split_k == 0,
               "fp8_qpn8_gemm_sm70_out: K/16 must be divisible by split_k");
   TORCH_CHECK(accumulator_chains == 1 || accumulator_chains == 2,
@@ -601,6 +640,11 @@ void fp8_qpn8_gemm_sm70_out(torch::Tensor out, torch::Tensor input,
   TORCH_CHECK(!prefetch_codes || fast_decoder,
               "fp8_qpn8_gemm_sm70_out: prefetch experiment requires the "
               "fast decoder");
+  const bool exact_shape_split = split_k == 12;
+  TORCH_CHECK(!exact_shape_split ||
+                  (accumulator_chains == 2 && fast_decoder && !prefetch_codes),
+              "fp8_qpn8_gemm_sm70_out: split_k 12 requires the "
+              "fast decoder, two accumulator chains, and no prefetch");
 
   const at::cuda::OptionalCUDAGuard device_guard(device_of(input));
   const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
@@ -614,7 +658,7 @@ void fp8_qpn8_gemm_sm70_out(torch::Tensor out, torch::Tensor input,
 #define VLLM_LAUNCH_QPN8(SPLIT, NACC, FAST, PREFETCH)                  \
   launch_fp8_qpn8_sm70<SPLIT, NACC, FAST, PREFETCH>(                   \
       code_ptr, scale_ptr, input_ptr, output_ptr, static_cast<int>(n), \
-      static_cast<int>(k), static_cast<int>(m), stream)
+      static_cast<int>(k), static_cast<int>(m), channel_scales, stream)
 
   if (prefetch_codes) {
     if (split_k == 4 && accumulator_chains == 1) {
@@ -643,6 +687,8 @@ void fp8_qpn8_gemm_sm70_out(torch::Tensor out, torch::Tensor input,
       VLLM_LAUNCH_QPN8(8, 1, true, false);
     } else if (split_k == 8 && accumulator_chains == 2) {
       VLLM_LAUNCH_QPN8(8, 2, true, false);
+    } else if (split_k == 12) {
+      VLLM_LAUNCH_QPN8(12, 2, true, false);
     } else if (split_k == 16 && accumulator_chains == 1) {
       VLLM_LAUNCH_QPN8(16, 1, true, false);
     } else if (split_k == 16 && accumulator_chains == 2) {
@@ -707,8 +753,12 @@ void fp8_qpn8_gated_pair_sm70_out(torch::Tensor out, torch::Tensor input,
               "fp8_qpn8_gated_pair_sm70_out: shape alignment mismatch");
   TORCH_CHECK(codes.numel() == n * k,
               "fp8_qpn8_gated_pair_sm70_out: packed code size mismatch");
-  TORCH_CHECK(group_scales.size(0) == k / 128 && group_scales.size(1) == n / 32,
-              "fp8_qpn8_gated_pair_sm70_out: group scale shape mismatch");
+  const bool channel_scales =
+      group_scales.size(0) == 1 && group_scales.size(1) == n;
+  const bool block_scales = group_scales.size(0) == k / 128 &&
+                            group_scales.size(1) == n / 32;
+  TORCH_CHECK(channel_scales || block_scales,
+              "fp8_qpn8_gated_pair_sm70_out: scale shape mismatch");
   TORCH_CHECK(split_k == 4 || split_k == 8 || split_k == 16,
               "fp8_qpn8_gated_pair_sm70_out: split_k must be 4, 8, or 16");
   TORCH_CHECK((k / 16) % split_k == 0,
@@ -731,7 +781,7 @@ void fp8_qpn8_gated_pair_sm70_out(torch::Tensor out, torch::Tensor input,
 #define VLLM_LAUNCH_QPN8_GATED_PAIR(SPLIT, NACC, FAST, PREFETCH)            \
   launch_fp8_qpn8_gated_pair_sm70<SPLIT, NACC, FAST, PREFETCH>(             \
       code_ptr, scale_ptr, input_ptr, output_ptr, static_cast<int>(hidden), \
-      static_cast<int>(k), static_cast<int>(m), stream)
+      static_cast<int>(k), static_cast<int>(m), channel_scales, stream)
 
   if (prefetch_codes) {
     if (split_k == 4 && accumulator_chains == 1) {

--- a/csrc/sm70_turbomind/ops/fp8_qpn8_sm70.cu
+++ b/csrc/sm70_turbomind/ops/fp8_qpn8_sm70.cu
@@ -2,8 +2,9 @@
 // SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 //
 // The QPN8 execution layout is derived from dnv2003/v100-skinny (MIT) and
-// its block-scale adaptation in haohervchb/sglang-V100. This experimental
-// operator is deliberately not connected to model dispatch.
+// its block-scale adaptation in haohervchb/sglang-V100. Automatic model
+// dispatch is restricted to accepted Qwen3.8-27B TP4 shapes and can be
+// disabled with VLLM_SM70_FP8_QPN8=0.
 // See LICENSE.v100-skinny in this directory for the retained MIT notice.
 
 #include <torch/all.h>
@@ -42,6 +43,109 @@ __device__ __forceinline__ void fp8x8_to_half2x4_fast(uint2 q, half2 out[4]) {
     const unsigned value =
         ((permuted[i] << 8) & kSign) | ((permuted[i] << 7) & kExponentMantissa);
     out[i] = *reinterpret_cast<const half2*>(&value);
+  }
+}
+
+constexpr int kQpn8PrepareThreads = 256;
+
+__device__ __forceinline__ int qpn8_col_from_lane(int lane) {
+  return ((lane >> 2) & 3) * 8 + (lane & 3) + ((lane & 16) ? 4 : 0);
+}
+
+__device__ __forceinline__ int qpn8_lane_from_col(int col) {
+  return (col & 3) | (((col >> 3) & 3) << 2) | (((col >> 2) & 1) << 4);
+}
+
+__device__ __forceinline__ int qpn8_physical_k(int logical_k) {
+  const int local = logical_k & 7;
+  return (logical_k & 8) + (local >> 1) + ((local & 1) << 2);
+}
+
+__global__ void fp8_qpn8_prepack_sm70_kernel(
+    uint8_t* __restrict__ codes, const uint8_t* __restrict__ qweight, int n,
+    int k) {
+  const size_t index =
+      static_cast<size_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  const size_t numel = static_cast<size_t>(n) * k;
+  if (index >= numel) {
+    return;
+  }
+
+  const int row = static_cast<int>(index / k);
+  const int logical_k = static_cast<int>(index % k);
+  const int tile = row >> 5;
+  const int lane = qpn8_lane_from_col(row & 31);
+  const int group = logical_k >> 4;
+  const int physical_k = qpn8_physical_k(logical_k & 15);
+  const int groups_k16 = k >> 4;
+  const size_t packed_index =
+      (((static_cast<size_t>(tile) * groups_k16 + group) * 32 + lane) * 16 +
+       physical_k);
+  codes[packed_index] = qweight[index];
+}
+
+__global__ void fp8_qpn8_scale_sm70_kernel(half* __restrict__ group_scales,
+                                           const float* __restrict__ scales,
+                                           int n_blocks, int k_blocks) {
+  const int n_tiles = n_blocks * 4;
+  const int index = blockIdx.x * blockDim.x + threadIdx.x;
+  const int numel = k_blocks * n_tiles;
+  if (index >= numel) {
+    return;
+  }
+
+  const int k_block = index / n_tiles;
+  const int n_tile = index - k_block * n_tiles;
+  group_scales[index] =
+      __float2half(scales[(n_tile >> 2) * k_blocks + k_block] * 256.0f);
+}
+
+__global__ void fp8_qpn8_dequantize_sm70_kernel(
+    half* __restrict__ output, const uint8_t* __restrict__ codes,
+    const half* __restrict__ group_scales, int n, int k) {
+  const size_t word_index =
+      static_cast<size_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  const size_t word_count = static_cast<size_t>(n) * k / 16;
+  if (word_index >= word_count) {
+    return;
+  }
+
+  const int groups_k16 = k >> 4;
+  const int lane = static_cast<int>(word_index & 31);
+  const size_t tile_word = word_index >> 5;
+  const int group = static_cast<int>(tile_word % groups_k16);
+  const int tile = static_cast<int>(tile_word / groups_k16);
+  const int col = tile * 32 + qpn8_col_from_lane(lane);
+  const int tiles_n32 = n >> 5;
+  const half scale = group_scales[(group >> 3) * tiles_n32 + tile];
+  const half2 scale2 = __halves2half2(scale, scale);
+  const uint4 packed = reinterpret_cast<const uint4*>(codes)[word_index];
+  half2 weights[8];
+  fp8x8_to_half2x4_fast(make_uint2(packed.x, packed.y), weights);
+  fp8x8_to_half2x4_fast(make_uint2(packed.z, packed.w), weights + 4);
+
+#pragma unroll
+  for (int pair = 0; pair < 8; ++pair) {
+    const half2 value = __hmul2(weights[pair], scale2);
+    const int k_base = group * 16 + pair * 2;
+    output[static_cast<size_t>(k_base) * n + col] = __low2half(value);
+    output[static_cast<size_t>(k_base + 1) * n + col] = __high2half(value);
+  }
+}
+
+__global__ void fp8_qpn8_silu_and_mul_sm70_kernel(
+    half* __restrict__ output, const half* __restrict__ gate_up, int rows,
+    int hidden) {
+  const int row = blockIdx.x;
+  if (row >= rows) {
+    return;
+  }
+  const half* row_input = gate_up + static_cast<size_t>(row) * hidden * 2;
+  half* row_output = output + static_cast<size_t>(row) * hidden;
+  for (int col = threadIdx.x; col < hidden; col += blockDim.x) {
+    const float gate = __half2float(row_input[col]);
+    const float silu = gate / (1.0f + __expf(-gate));
+    row_output[col] = __hmul(__float2half(silu), row_input[hidden + col]);
   }
 }
 
@@ -321,6 +425,136 @@ void launch_fp8_qpn8_gated_pair_sm70(const uint8_t* codes,
 
 }  // namespace
 
+std::vector<torch::Tensor> fp8_qpn8_prepare_sm70(torch::Tensor qweight,
+                                                 torch::Tensor scales) {
+  TORCH_CHECK(qweight.is_cuda() && scales.is_cuda(),
+              "fp8_qpn8_prepare_sm70: tensors must be CUDA tensors");
+  TORCH_CHECK(qweight.scalar_type() == at::ScalarType::Float8_e4m3fn,
+              "fp8_qpn8_prepare_sm70: weight must be float8_e4m3fn");
+  TORCH_CHECK(scales.scalar_type() == torch::kFloat32,
+              "fp8_qpn8_prepare_sm70: scales must be float32");
+  TORCH_CHECK(qweight.dim() == 2 && scales.dim() == 2,
+              "fp8_qpn8_prepare_sm70: tensors must be 2D");
+  TORCH_CHECK(qweight.is_contiguous() && scales.is_contiguous(),
+              "fp8_qpn8_prepare_sm70: tensors must be contiguous");
+  TORCH_CHECK(qweight.get_device() == scales.get_device(),
+              "fp8_qpn8_prepare_sm70: tensors must share one device");
+
+  const int64_t n = qweight.size(0);
+  const int64_t k = qweight.size(1);
+  TORCH_CHECK(n > 0 && n % 128 == 0 && k > 0 && k % 128 == 0,
+              "fp8_qpn8_prepare_sm70: N and K must be positive multiples of "
+              "128");
+  TORCH_CHECK(scales.size(0) == n / 128 && scales.size(1) == k / 128,
+              "fp8_qpn8_prepare_sm70: block-scale shape mismatch");
+
+  const at::cuda::OptionalCUDAGuard device_guard(device_of(qweight));
+  const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
+  auto codes = torch::empty(
+      {k, n},
+      torch::TensorOptions().device(qweight.device()).dtype(torch::kUInt8));
+  auto group_scales = torch::empty(
+      {k / 128, n / 32},
+      torch::TensorOptions().device(qweight.device()).dtype(torch::kFloat16));
+
+  const int64_t weight_numel = n * k;
+  const int weight_blocks = static_cast<int>(
+      (weight_numel + kQpn8PrepareThreads - 1) / kQpn8PrepareThreads);
+  fp8_qpn8_prepack_sm70_kernel<<<weight_blocks, kQpn8PrepareThreads, 0,
+                                 stream>>>(
+      codes.data_ptr<uint8_t>(),
+      reinterpret_cast<const uint8_t*>(qweight.data_ptr()), static_cast<int>(n),
+      static_cast<int>(k));
+
+  const int64_t scale_numel = group_scales.numel();
+  const int scale_blocks = static_cast<int>(
+      (scale_numel + kQpn8PrepareThreads - 1) / kQpn8PrepareThreads);
+  fp8_qpn8_scale_sm70_kernel<<<scale_blocks, kQpn8PrepareThreads, 0, stream>>>(
+      reinterpret_cast<half*>(group_scales.data_ptr<at::Half>()),
+      scales.data_ptr<float>(), static_cast<int>(n / 128),
+      static_cast<int>(k / 128));
+  C10_CUDA_KERNEL_LAUNCH_CHECK();
+  return {codes, group_scales};
+}
+
+void fp8_qpn8_dequantize_sm70_out(torch::Tensor out, torch::Tensor codes,
+                                  torch::Tensor group_scales) {
+  TORCH_CHECK(out.is_cuda() && codes.is_cuda() && group_scales.is_cuda(),
+              "fp8_qpn8_dequantize_sm70_out: tensors must be CUDA tensors");
+  TORCH_CHECK(out.scalar_type() == torch::kFloat16 &&
+                  codes.scalar_type() == torch::kUInt8 &&
+                  group_scales.scalar_type() == torch::kFloat16,
+              "fp8_qpn8_dequantize_sm70_out: dtype mismatch");
+  TORCH_CHECK(out.dim() == 2 && codes.dim() == 2 && group_scales.dim() == 2,
+              "fp8_qpn8_dequantize_sm70_out: tensors must be 2D");
+  TORCH_CHECK(out.is_contiguous() && codes.is_contiguous() &&
+                  group_scales.is_contiguous(),
+              "fp8_qpn8_dequantize_sm70_out: tensors must be contiguous");
+  TORCH_CHECK(out.get_device() == codes.get_device() &&
+                  out.get_device() == group_scales.get_device(),
+              "fp8_qpn8_dequantize_sm70_out: tensors must share one device");
+
+  const int64_t k = out.size(0);
+  const int64_t n = out.size(1);
+  TORCH_CHECK(k > 0 && k % 128 == 0 && n > 0 && n % 128 == 0,
+              "fp8_qpn8_dequantize_sm70_out: K and N alignment mismatch");
+  TORCH_CHECK(codes.numel() == k * n,
+              "fp8_qpn8_dequantize_sm70_out: packed code size mismatch");
+  TORCH_CHECK(group_scales.size(0) == k / 128 && group_scales.size(1) == n / 32,
+              "fp8_qpn8_dequantize_sm70_out: group-scale shape mismatch");
+
+  const at::cuda::OptionalCUDAGuard device_guard(device_of(out));
+  const int64_t word_count = k * n / 16;
+  const int blocks = static_cast<int>((word_count + kQpn8PrepareThreads - 1) /
+                                      kQpn8PrepareThreads);
+  fp8_qpn8_dequantize_sm70_kernel<<<blocks, kQpn8PrepareThreads, 0,
+                                    at::cuda::getCurrentCUDAStream()>>>(
+      reinterpret_cast<half*>(out.data_ptr<at::Half>()),
+      codes.data_ptr<uint8_t>(),
+      reinterpret_cast<const half*>(group_scales.data_ptr<at::Half>()),
+      static_cast<int>(n), static_cast<int>(k));
+  C10_CUDA_KERNEL_LAUNCH_CHECK();
+}
+
+void fp8_qpn8_prefill_sm70_out(torch::Tensor out, int64_t dense_weight_ptr,
+                               torch::Tensor input, torch::Tensor codes,
+                               torch::Tensor group_scales, bool gated_silu) {
+  TORCH_CHECK(input.is_cuda() && out.is_cuda(),
+              "fp8_qpn8_prefill_sm70_out: input and output must be CUDA");
+  TORCH_CHECK(input.scalar_type() == torch::kFloat16 &&
+                  out.scalar_type() == torch::kFloat16,
+              "fp8_qpn8_prefill_sm70_out: input and output must be float16");
+  TORCH_CHECK(input.dim() == 2 && out.dim() == 2 && dense_weight_ptr != 0,
+              "fp8_qpn8_prefill_sm70_out: invalid input or workspace");
+  TORCH_CHECK(input.is_contiguous() && out.is_contiguous(),
+              "fp8_qpn8_prefill_sm70_out: tensors must be contiguous");
+
+  const int64_t m = input.size(0);
+  const int64_t k = input.size(1);
+  const int64_t n = codes.size(1);
+  TORCH_CHECK(codes.dim() == 2 && codes.size(0) == k,
+              "fp8_qpn8_prefill_sm70_out: code shape mismatch");
+  TORCH_CHECK(out.size(0) == m && out.size(1) == (gated_silu ? n / 2 : n),
+              "fp8_qpn8_prefill_sm70_out: output shape mismatch");
+
+  auto dense_weight = torch::from_blob(
+      reinterpret_cast<void*>(dense_weight_ptr), {k, n}, input.options());
+  fp8_qpn8_dequantize_sm70_out(dense_weight, codes, group_scales);
+  if (!gated_silu) {
+    at::mm_out(out, input, dense_weight);
+    return;
+  }
+
+  auto gate_up = at::mm(input, dense_weight);
+  constexpr int kThreads = 256;
+  fp8_qpn8_silu_and_mul_sm70_kernel<<<static_cast<int>(m), kThreads, 0,
+                                      at::cuda::getCurrentCUDAStream()>>>(
+      reinterpret_cast<half*>(out.data_ptr<at::Half>()),
+      reinterpret_cast<const half*>(gate_up.data_ptr<at::Half>()),
+      static_cast<int>(m), static_cast<int>(n / 2));
+  C10_CUDA_KERNEL_LAUNCH_CHECK();
+}
+
 void fp8_qpn8_gemm_sm70_out(torch::Tensor out, torch::Tensor input,
                             torch::Tensor codes, torch::Tensor group_scales,
                             int64_t split_k, int64_t accumulator_chains,
@@ -544,11 +778,52 @@ void fp8_qpn8_gated_pair_sm70_out(torch::Tensor out, torch::Tensor input,
   C10_CUDA_KERNEL_LAUNCH_CHECK();
 }
 
+void fp8_qpn8_dispatch_sm70_out(torch::Tensor out, int64_t dense_weight_ptr,
+                                torch::Tensor input, torch::Tensor codes,
+                                torch::Tensor group_scales, int64_t split_k,
+                                int64_t accumulator_chains, bool prefetch_codes,
+                                bool gated_silu) {
+  // Keep the M decision inside the opaque operator. AOTInductor compiles one
+  // dynamic M=1..8192 range for this model, so a Python shape branch traced at
+  // M=1/2 would otherwise be incorrectly reused by large-M prefill.
+  if (input.size(0) <= 8) {
+    if (gated_silu) {
+      fp8_qpn8_gated_pair_sm70_out(out, input, codes, group_scales, split_k,
+                                   accumulator_chains, true, prefetch_codes);
+    } else {
+      fp8_qpn8_gemm_sm70_out(out, input, codes, group_scales, split_k,
+                             accumulator_chains, true, prefetch_codes);
+    }
+    return;
+  }
+  fp8_qpn8_prefill_sm70_out(out, dense_weight_ptr, input, codes, group_scales,
+                            gated_silu);
+}
+
 #ifdef VLLM_QPN8_STANDALONE
 // Lets the exact same source file be compiled as an operator-race harness
 // before paying for a complete vLLM rebuild. Production builds register the
 // operator centrally in torch_bindings.cpp and do not define this macro.
 TORCH_LIBRARY_FRAGMENT(_C, ops) {
+  ops.def("fp8_qpn8_prepare_sm70(Tensor qweight, Tensor scales) -> Tensor[]");
+  ops.impl("fp8_qpn8_prepare_sm70", torch::kCUDA, &fp8_qpn8_prepare_sm70);
+  ops.def(
+      "fp8_qpn8_dequantize_sm70_out(Tensor(a!) out, Tensor codes, "
+      "Tensor group_scales) -> ()");
+  ops.impl("fp8_qpn8_dequantize_sm70_out", torch::kCUDA,
+           &fp8_qpn8_dequantize_sm70_out);
+  ops.def(
+      "fp8_qpn8_prefill_sm70_out(Tensor(a!) out, int dense_weight_ptr, "
+      "Tensor input, Tensor codes, Tensor group_scales, bool gated_silu) -> "
+      "()");
+  ops.impl("fp8_qpn8_prefill_sm70_out", torch::kCUDA,
+           &fp8_qpn8_prefill_sm70_out);
+  ops.def(
+      "fp8_qpn8_dispatch_sm70_out(Tensor(a!) out, int dense_weight_ptr, "
+      "Tensor input, Tensor codes, Tensor group_scales, int split_k, "
+      "int accumulator_chains, bool prefetch_codes, bool gated_silu) -> ()");
+  ops.impl("fp8_qpn8_dispatch_sm70_out", torch::kCUDA,
+           &fp8_qpn8_dispatch_sm70_out);
   ops.def(
       "fp8_qpn8_gemm_sm70_out(Tensor(a!) out, Tensor input, Tensor codes, "
       "Tensor group_scales, int split_k, int accumulator_chains, "

--- a/csrc/sm70_turbomind/ops/fp8_qpn8_sm70.cu
+++ b/csrc/sm70_turbomind/ops/fp8_qpn8_sm70.cu
@@ -1,0 +1,564 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+//
+// The QPN8 execution layout is derived from dnv2003/v100-skinny (MIT) and
+// its block-scale adaptation in haohervchb/sglang-V100. This experimental
+// operator is deliberately not connected to model dispatch.
+// See LICENSE.v100-skinny in this directory for the retained MIT notice.
+
+#include <torch/all.h>
+#include <torch/library.h>
+
+#include <ATen/cuda/CUDAContext.h>
+#include <ATen/cuda/Exceptions.h>
+#include <c10/cuda/CUDAGuard.h>
+#include <cuda_fp16.h>
+#include <cuda_runtime.h>
+
+namespace {
+
+__device__ __forceinline__ void fp8x8_to_half2x4(uint2 q, half2 out[4]) {
+#pragma unroll
+  for (int i = 0; i < 4; ++i) {
+    const unsigned b0 = (q.x >> (8 * i)) & 0xffu;
+    const unsigned b1 = (q.y >> (8 * i)) & 0xffu;
+    const unsigned h0 = ((b0 & 0x80u) << 8) | ((b0 & 0x7fu) << 7);
+    const unsigned h1 = ((b1 & 0x80u) << 8) | ((b1 & 0x7fu) << 7);
+    const unsigned packed = h0 | (h1 << 16);
+    out[i] = *reinterpret_cast<const half2*>(&packed);
+  }
+}
+
+__device__ __forceinline__ void fp8x8_to_half2x4_fast(uint2 q, half2 out[4]) {
+  constexpr unsigned kSign = 0x80008000u;
+  constexpr unsigned kExponentMantissa = 0x3f803f80u;
+  unsigned permuted[4];
+  permuted[0] = __byte_perm(q.x, q.y, 0x0400);
+  permuted[1] = __byte_perm(q.x, q.y, 0x0501);
+  permuted[2] = __byte_perm(q.x, q.y, 0x0602);
+  permuted[3] = __byte_perm(q.x, q.y, 0x0703);
+#pragma unroll
+  for (int i = 0; i < 4; ++i) {
+    const unsigned value =
+        ((permuted[i] << 8) & kSign) | ((permuted[i] << 7) & kExponentMantissa);
+    out[i] = *reinterpret_cast<const half2*>(&value);
+  }
+}
+
+#define VLLM_SM70_MMA_8N8K4(C, A0, A1, B0, B1)                      \
+  asm volatile(                                                     \
+      "mma.sync.aligned.m8n8k4.row.col.f32.f16.f16.f32 "            \
+      "{%0,%1,%2,%3,%4,%5,%6,%7}, {%8,%9}, {%10,%11}, "             \
+      "{%0,%1,%2,%3,%4,%5,%6,%7};\n"                                \
+      : "+f"(C[0]), "+f"(C[1]), "+f"(C[2]), "+f"(C[3]), "+f"(C[4]), \
+        "+f"(C[5]), "+f"(C[6]), "+f"(C[7])                          \
+      : "r"(A0), "r"(A1), "r"(B0), "r"(B1))
+
+template <int SplitK, int NAcc, bool FastDecoder, bool PrefetchCodes>
+__global__ void fp8_qpn8_sm70_kernel(const uint8_t* __restrict__ codes,
+                                     const half* __restrict__ group_scales,
+                                     const half* __restrict__ input,
+                                     half* __restrict__ output, int n, int k,
+                                     int m) {
+  __shared__ float partials[SplitK][256];
+
+  const int lane = threadIdx.x & 31;
+  const int warp = threadIdx.x >> 5;
+  const int tile = blockIdx.x;
+  const int quadpair = (lane >> 2) & 3;
+  const int row = (lane & 3) + ((lane & 16) ? 4 : 0);
+  const int groups_k16 = k >> 4;
+  const int groups_per_warp = groups_k16 / SplitK;
+  const int group_begin = warp * groups_per_warp;
+  const int tiles_n32 = n >> 5;
+  const uint4* code_ptr = reinterpret_cast<const uint4*>(codes) +
+                          static_cast<size_t>(tile) * groups_k16 * 32 + lane;
+  const half* scale_ptr = group_scales + tile;
+
+  float accum[NAcc][8];
+#pragma unroll
+  for (int chain = 0; chain < NAcc; ++chain) {
+#pragma unroll
+    for (int i = 0; i < 8; ++i) {
+      accum[chain][i] = 0.0f;
+    }
+  }
+  int loaded_scale_group = -1;
+  half loaded_scale = __float2half(0.0f);
+  uint4 prefetched = make_uint4(0, 0, 0, 0);
+  if constexpr (PrefetchCodes) {
+    prefetched = __ldcs(code_ptr + static_cast<size_t>(group_begin) * 32);
+  }
+
+#pragma unroll 4
+  for (int group = group_begin; group < group_begin + groups_per_warp;
+       ++group) {
+    const int scale_group = group >> 3;
+    if (scale_group != loaded_scale_group) {
+      loaded_scale =
+          __ldg(scale_ptr + static_cast<size_t>(scale_group) * tiles_n32);
+      loaded_scale_group = scale_group;
+    }
+
+    const uint4 packed =
+        PrefetchCodes ? prefetched
+                      : __ldcs(code_ptr + static_cast<size_t>(group) * 32);
+    uint4 next = make_uint4(0, 0, 0, 0);
+    if constexpr (PrefetchCodes) {
+      if (group + 1 < group_begin + groups_per_warp) {
+        next = __ldcs(code_ptr + static_cast<size_t>(group + 1) * 32);
+      }
+    }
+    half2 weights[8];
+    if constexpr (FastDecoder) {
+      fp8x8_to_half2x4_fast(make_uint2(packed.x, packed.y), weights);
+      fp8x8_to_half2x4_fast(make_uint2(packed.z, packed.w), weights + 4);
+    } else {
+      fp8x8_to_half2x4(make_uint2(packed.x, packed.y), weights);
+      fp8x8_to_half2x4(make_uint2(packed.z, packed.w), weights + 4);
+    }
+
+    const half2 scale2 = __halves2half2(loaded_scale, loaded_scale);
+#pragma unroll
+    for (int i = 0; i < 8; ++i) {
+      weights[i] = __hmul2(weights[i], scale2);
+    }
+
+    uint4 input01 = make_uint4(0, 0, 0, 0);
+    uint4 input23 = make_uint4(0, 0, 0, 0);
+    if (row < m) {
+      const half* input_row = input + static_cast<size_t>(row) * k;
+      input01 = *reinterpret_cast<const uint4*>(input_row + group * 16);
+      input23 = *reinterpret_cast<const uint4*>(input_row + group * 16 + 8);
+    }
+
+    const unsigned* a0 = reinterpret_cast<const unsigned*>(&input01);
+    const unsigned* a1 = reinterpret_cast<const unsigned*>(&input23);
+    const unsigned* b = reinterpret_cast<const unsigned*>(weights);
+    VLLM_SM70_MMA_8N8K4(accum[0], a0[0], a0[1], b[0], b[1]);
+    VLLM_SM70_MMA_8N8K4(accum[1 % NAcc], a0[2], a0[3], b[2], b[3]);
+    VLLM_SM70_MMA_8N8K4(accum[2 % NAcc], a1[0], a1[1], b[4], b[5]);
+    VLLM_SM70_MMA_8N8K4(accum[3 % NAcc], a1[2], a1[3], b[6], b[7]);
+    if constexpr (PrefetchCodes) {
+      prefetched = next;
+    }
+  }
+
+#pragma unroll
+  for (int chain = 1; chain < NAcc; ++chain) {
+#pragma unroll
+    for (int i = 0; i < 8; ++i) {
+      accum[0][i] += accum[chain][i];
+    }
+  }
+
+#pragma unroll
+  for (int i = 0; i < 8; ++i) {
+    const int output_row = (i & 2) | ((lane & 16) ? 4 : 0) | (lane & 1);
+    const int output_col = (i & 1) | (((lane >> 1) & 1) << 1) | ((i >> 2) << 2);
+    partials[warp][output_row * 32 + quadpair * 8 + output_col] = accum[0][i];
+  }
+  __syncthreads();
+
+  for (int element = threadIdx.x; element < 256; element += blockDim.x) {
+    float value = 0.0f;
+#pragma unroll
+    for (int k_warp = 0; k_warp < SplitK; ++k_warp) {
+      value += partials[k_warp][element];
+    }
+    const int output_row = element >> 5;
+    const int output_col = element & 31;
+    if (output_row < m) {
+      output[static_cast<size_t>(output_row) * n + tile * 32 + output_col] =
+          __float2half(value);
+    }
+  }
+}
+
+template <int SplitK, int NAcc, bool FastDecoder, bool PrefetchCodes>
+void launch_fp8_qpn8_sm70(const uint8_t* codes, const half* group_scales,
+                          const half* input, half* output, int n, int k, int m,
+                          cudaStream_t stream) {
+  fp8_qpn8_sm70_kernel<SplitK, NAcc, FastDecoder, PrefetchCodes>
+      <<<(n / 32), (32 * SplitK), 0, stream>>>(codes, group_scales, input,
+                                               output, n, k, m);
+}
+
+template <int SplitK, int NAcc, bool FastDecoder, bool PrefetchCodes>
+__global__ void fp8_qpn8_gated_pair_sm70_kernel(
+    const uint8_t* __restrict__ codes, const half* __restrict__ group_scales,
+    const half* __restrict__ input, half* __restrict__ output, int hidden,
+    int k, int m) {
+  __shared__ float partials[2][SplitK][256];
+
+  const int lane = threadIdx.x & 31;
+  const int warp_in_block = threadIdx.x >> 5;
+  const int projection = warp_in_block / SplitK;
+  const int warp = warp_in_block - projection * SplitK;
+  const int hidden_tiles = hidden >> 5;
+  const int tiles_n32 = hidden_tiles * 2;
+  const int tile = blockIdx.x + projection * hidden_tiles;
+  const int quadpair = (lane >> 2) & 3;
+  const int row = (lane & 3) + ((lane & 16) ? 4 : 0);
+  const int groups_k16 = k >> 4;
+  const int groups_per_warp = groups_k16 / SplitK;
+  const int group_begin = warp * groups_per_warp;
+  const uint4* code_ptr = reinterpret_cast<const uint4*>(codes) +
+                          static_cast<size_t>(tile) * groups_k16 * 32 + lane;
+  const half* scale_ptr = group_scales + tile;
+
+  float accum[NAcc][8];
+#pragma unroll
+  for (int chain = 0; chain < NAcc; ++chain) {
+#pragma unroll
+    for (int i = 0; i < 8; ++i) {
+      accum[chain][i] = 0.0f;
+    }
+  }
+  int loaded_scale_group = -1;
+  half loaded_scale = __float2half(0.0f);
+  uint4 prefetched = make_uint4(0, 0, 0, 0);
+  if constexpr (PrefetchCodes) {
+    prefetched = __ldcs(code_ptr + static_cast<size_t>(group_begin) * 32);
+  }
+
+#pragma unroll 4
+  for (int group = group_begin; group < group_begin + groups_per_warp;
+       ++group) {
+    const int scale_group = group >> 3;
+    if (scale_group != loaded_scale_group) {
+      loaded_scale =
+          __ldg(scale_ptr + static_cast<size_t>(scale_group) * tiles_n32);
+      loaded_scale_group = scale_group;
+    }
+
+    const uint4 packed =
+        PrefetchCodes ? prefetched
+                      : __ldcs(code_ptr + static_cast<size_t>(group) * 32);
+    uint4 next = make_uint4(0, 0, 0, 0);
+    if constexpr (PrefetchCodes) {
+      if (group + 1 < group_begin + groups_per_warp) {
+        next = __ldcs(code_ptr + static_cast<size_t>(group + 1) * 32);
+      }
+    }
+    half2 weights[8];
+    if constexpr (FastDecoder) {
+      fp8x8_to_half2x4_fast(make_uint2(packed.x, packed.y), weights);
+      fp8x8_to_half2x4_fast(make_uint2(packed.z, packed.w), weights + 4);
+    } else {
+      fp8x8_to_half2x4(make_uint2(packed.x, packed.y), weights);
+      fp8x8_to_half2x4(make_uint2(packed.z, packed.w), weights + 4);
+    }
+    const half2 scale2 = __halves2half2(loaded_scale, loaded_scale);
+#pragma unroll
+    for (int i = 0; i < 8; ++i) {
+      weights[i] = __hmul2(weights[i], scale2);
+    }
+
+    uint4 input01 = make_uint4(0, 0, 0, 0);
+    uint4 input23 = make_uint4(0, 0, 0, 0);
+    if (row < m) {
+      const half* input_row = input + static_cast<size_t>(row) * k;
+      input01 = *reinterpret_cast<const uint4*>(input_row + group * 16);
+      input23 = *reinterpret_cast<const uint4*>(input_row + group * 16 + 8);
+    }
+    const unsigned* a0 = reinterpret_cast<const unsigned*>(&input01);
+    const unsigned* a1 = reinterpret_cast<const unsigned*>(&input23);
+    const unsigned* b = reinterpret_cast<const unsigned*>(weights);
+    VLLM_SM70_MMA_8N8K4(accum[0], a0[0], a0[1], b[0], b[1]);
+    VLLM_SM70_MMA_8N8K4(accum[1 % NAcc], a0[2], a0[3], b[2], b[3]);
+    VLLM_SM70_MMA_8N8K4(accum[2 % NAcc], a1[0], a1[1], b[4], b[5]);
+    VLLM_SM70_MMA_8N8K4(accum[3 % NAcc], a1[2], a1[3], b[6], b[7]);
+    if constexpr (PrefetchCodes) {
+      prefetched = next;
+    }
+  }
+
+#pragma unroll
+  for (int chain = 1; chain < NAcc; ++chain) {
+#pragma unroll
+    for (int i = 0; i < 8; ++i) {
+      accum[0][i] += accum[chain][i];
+    }
+  }
+#pragma unroll
+  for (int i = 0; i < 8; ++i) {
+    const int output_row = (i & 2) | ((lane & 16) ? 4 : 0) | (lane & 1);
+    const int output_col = (i & 1) | (((lane >> 1) & 1) << 1) | ((i >> 2) << 2);
+    partials[projection][warp][output_row * 32 + quadpair * 8 + output_col] =
+        accum[0][i];
+  }
+  __syncthreads();
+
+  for (int element = threadIdx.x; element < 256; element += blockDim.x) {
+    float gate = 0.0f;
+    float up = 0.0f;
+#pragma unroll
+    for (int k_warp = 0; k_warp < SplitK; ++k_warp) {
+      gate += partials[0][k_warp][element];
+      up += partials[1][k_warp][element];
+    }
+    const int output_row = element >> 5;
+    const int output_col = element & 31;
+    if (output_row < m) {
+      const float silu = gate / (1.0f + __expf(-gate));
+      output[static_cast<size_t>(output_row) * hidden + blockIdx.x * 32 +
+             output_col] = __float2half(silu * up);
+    }
+  }
+}
+
+template <int SplitK, int NAcc, bool FastDecoder, bool PrefetchCodes>
+void launch_fp8_qpn8_gated_pair_sm70(const uint8_t* codes,
+                                     const half* group_scales,
+                                     const half* input, half* output,
+                                     int hidden, int k, int m,
+                                     cudaStream_t stream) {
+  fp8_qpn8_gated_pair_sm70_kernel<SplitK, NAcc, FastDecoder, PrefetchCodes>
+      <<<(hidden / 32), (64 * SplitK), 0, stream>>>(codes, group_scales, input,
+                                                    output, hidden, k, m);
+}
+
+}  // namespace
+
+void fp8_qpn8_gemm_sm70_out(torch::Tensor out, torch::Tensor input,
+                            torch::Tensor codes, torch::Tensor group_scales,
+                            int64_t split_k, int64_t accumulator_chains,
+                            bool fast_decoder, bool prefetch_codes) {
+  TORCH_CHECK(input.is_cuda() && out.is_cuda() && codes.is_cuda() &&
+                  group_scales.is_cuda(),
+              "fp8_qpn8_gemm_sm70_out: tensors must be CUDA tensors");
+  TORCH_CHECK(input.scalar_type() == torch::kFloat16 &&
+                  out.scalar_type() == torch::kFloat16,
+              "fp8_qpn8_gemm_sm70_out: input and output must be float16");
+  TORCH_CHECK(codes.scalar_type() == torch::kUInt8,
+              "fp8_qpn8_gemm_sm70_out: codes must be uint8");
+  TORCH_CHECK(group_scales.scalar_type() == torch::kFloat16,
+              "fp8_qpn8_gemm_sm70_out: group scales must be float16");
+  TORCH_CHECK(input.dim() == 2 && out.dim() == 2 && group_scales.dim() == 2,
+              "fp8_qpn8_gemm_sm70_out: expected 2D tensors");
+  TORCH_CHECK(input.is_contiguous() && out.is_contiguous() &&
+                  codes.is_contiguous() && group_scales.is_contiguous(),
+              "fp8_qpn8_gemm_sm70_out: tensors must be contiguous");
+  TORCH_CHECK(input.get_device() == out.get_device() &&
+                  input.get_device() == codes.get_device() &&
+                  input.get_device() == group_scales.get_device(),
+              "fp8_qpn8_gemm_sm70_out: tensors must share one device");
+
+  const int64_t m = input.size(0);
+  const int64_t k = input.size(1);
+  const int64_t n = out.size(1);
+  TORCH_CHECK(m >= 1 && m <= 8, "fp8_qpn8_gemm_sm70_out: M must be in [1, 8]");
+  TORCH_CHECK(out.size(0) == m, "fp8_qpn8_gemm_sm70_out: output M mismatch");
+  TORCH_CHECK(n > 0 && n % 32 == 0,
+              "fp8_qpn8_gemm_sm70_out: N must be a positive multiple of 32");
+  TORCH_CHECK(k > 0 && k % 128 == 0,
+              "fp8_qpn8_gemm_sm70_out: K must be a positive multiple of 128");
+  TORCH_CHECK(codes.numel() == n * k,
+              "fp8_qpn8_gemm_sm70_out: packed code size mismatch");
+  TORCH_CHECK(group_scales.size(0) == k / 128 && group_scales.size(1) == n / 32,
+              "fp8_qpn8_gemm_sm70_out: group scale shape mismatch");
+  TORCH_CHECK(split_k == 4 || split_k == 8 || split_k == 16 || split_k == 32,
+              "fp8_qpn8_gemm_sm70_out: split_k must be 4, 8, 16, or 32");
+  TORCH_CHECK((k / 16) % split_k == 0,
+              "fp8_qpn8_gemm_sm70_out: K/16 must be divisible by split_k");
+  TORCH_CHECK(accumulator_chains == 1 || accumulator_chains == 2,
+              "fp8_qpn8_gemm_sm70_out: accumulator_chains must be 1 or 2");
+  TORCH_CHECK(!prefetch_codes || fast_decoder,
+              "fp8_qpn8_gemm_sm70_out: prefetch experiment requires the "
+              "fast decoder");
+
+  const at::cuda::OptionalCUDAGuard device_guard(device_of(input));
+  const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
+  const auto* code_ptr = codes.data_ptr<uint8_t>();
+  const auto* scale_ptr =
+      reinterpret_cast<const half*>(group_scales.data_ptr<at::Half>());
+  const auto* input_ptr =
+      reinterpret_cast<const half*>(input.data_ptr<at::Half>());
+  auto* output_ptr = reinterpret_cast<half*>(out.data_ptr<at::Half>());
+
+#define VLLM_LAUNCH_QPN8(SPLIT, NACC, FAST, PREFETCH)                  \
+  launch_fp8_qpn8_sm70<SPLIT, NACC, FAST, PREFETCH>(                   \
+      code_ptr, scale_ptr, input_ptr, output_ptr, static_cast<int>(n), \
+      static_cast<int>(k), static_cast<int>(m), stream)
+
+  if (prefetch_codes) {
+    if (split_k == 4 && accumulator_chains == 1) {
+      VLLM_LAUNCH_QPN8(4, 1, true, true);
+    } else if (split_k == 4 && accumulator_chains == 2) {
+      VLLM_LAUNCH_QPN8(4, 2, true, true);
+    } else if (split_k == 8 && accumulator_chains == 1) {
+      VLLM_LAUNCH_QPN8(8, 1, true, true);
+    } else if (split_k == 8 && accumulator_chains == 2) {
+      VLLM_LAUNCH_QPN8(8, 2, true, true);
+    } else if (split_k == 16 && accumulator_chains == 1) {
+      VLLM_LAUNCH_QPN8(16, 1, true, true);
+    } else if (split_k == 16 && accumulator_chains == 2) {
+      VLLM_LAUNCH_QPN8(16, 2, true, true);
+    } else if (split_k == 32 && accumulator_chains == 1) {
+      VLLM_LAUNCH_QPN8(32, 1, true, true);
+    } else {
+      VLLM_LAUNCH_QPN8(32, 2, true, true);
+    }
+  } else if (fast_decoder) {
+    if (split_k == 4 && accumulator_chains == 1) {
+      VLLM_LAUNCH_QPN8(4, 1, true, false);
+    } else if (split_k == 4 && accumulator_chains == 2) {
+      VLLM_LAUNCH_QPN8(4, 2, true, false);
+    } else if (split_k == 8 && accumulator_chains == 1) {
+      VLLM_LAUNCH_QPN8(8, 1, true, false);
+    } else if (split_k == 8 && accumulator_chains == 2) {
+      VLLM_LAUNCH_QPN8(8, 2, true, false);
+    } else if (split_k == 16 && accumulator_chains == 1) {
+      VLLM_LAUNCH_QPN8(16, 1, true, false);
+    } else if (split_k == 16 && accumulator_chains == 2) {
+      VLLM_LAUNCH_QPN8(16, 2, true, false);
+    } else if (split_k == 32 && accumulator_chains == 1) {
+      VLLM_LAUNCH_QPN8(32, 1, true, false);
+    } else {
+      VLLM_LAUNCH_QPN8(32, 2, true, false);
+    }
+  } else if (split_k == 4 && accumulator_chains == 1) {
+    VLLM_LAUNCH_QPN8(4, 1, false, false);
+  } else if (split_k == 4 && accumulator_chains == 2) {
+    VLLM_LAUNCH_QPN8(4, 2, false, false);
+  } else if (split_k == 8 && accumulator_chains == 1) {
+    VLLM_LAUNCH_QPN8(8, 1, false, false);
+  } else if (split_k == 8 && accumulator_chains == 2) {
+    VLLM_LAUNCH_QPN8(8, 2, false, false);
+  } else if (split_k == 16 && accumulator_chains == 1) {
+    VLLM_LAUNCH_QPN8(16, 1, false, false);
+  } else if (split_k == 16 && accumulator_chains == 2) {
+    VLLM_LAUNCH_QPN8(16, 2, false, false);
+  } else if (split_k == 32 && accumulator_chains == 1) {
+    VLLM_LAUNCH_QPN8(32, 1, false, false);
+  } else {
+    VLLM_LAUNCH_QPN8(32, 2, false, false);
+  }
+#undef VLLM_LAUNCH_QPN8
+
+  C10_CUDA_KERNEL_LAUNCH_CHECK();
+}
+
+void fp8_qpn8_gated_pair_sm70_out(torch::Tensor out, torch::Tensor input,
+                                  torch::Tensor codes,
+                                  torch::Tensor group_scales, int64_t split_k,
+                                  int64_t accumulator_chains, bool fast_decoder,
+                                  bool prefetch_codes) {
+  TORCH_CHECK(out.is_cuda() && input.is_cuda() && codes.is_cuda() &&
+                  group_scales.is_cuda(),
+              "fp8_qpn8_gated_pair_sm70_out: tensors must be CUDA tensors");
+  TORCH_CHECK(out.scalar_type() == torch::kFloat16 &&
+                  input.scalar_type() == torch::kFloat16 &&
+                  group_scales.scalar_type() == torch::kFloat16 &&
+                  codes.scalar_type() == torch::kUInt8,
+              "fp8_qpn8_gated_pair_sm70_out: dtype mismatch");
+  TORCH_CHECK(out.is_contiguous() && input.is_contiguous() &&
+                  codes.is_contiguous() && group_scales.is_contiguous(),
+              "fp8_qpn8_gated_pair_sm70_out: tensors must be contiguous");
+  TORCH_CHECK(out.dim() == 2 && input.dim() == 2 && group_scales.dim() == 2,
+              "fp8_qpn8_gated_pair_sm70_out: expected 2D tensors");
+  TORCH_CHECK(out.get_device() == input.get_device() &&
+                  out.get_device() == codes.get_device() &&
+                  out.get_device() == group_scales.get_device(),
+              "fp8_qpn8_gated_pair_sm70_out: tensors must share one device");
+
+  const int64_t m = input.size(0);
+  const int64_t k = input.size(1);
+  const int64_t hidden = out.size(1);
+  const int64_t n = hidden * 2;
+  TORCH_CHECK(m >= 1 && m <= 8 && out.size(0) == m,
+              "fp8_qpn8_gated_pair_sm70_out: M must be in [1, 8]");
+  TORCH_CHECK(hidden > 0 && hidden % 32 == 0 && k > 0 && k % 128 == 0,
+              "fp8_qpn8_gated_pair_sm70_out: shape alignment mismatch");
+  TORCH_CHECK(codes.numel() == n * k,
+              "fp8_qpn8_gated_pair_sm70_out: packed code size mismatch");
+  TORCH_CHECK(group_scales.size(0) == k / 128 && group_scales.size(1) == n / 32,
+              "fp8_qpn8_gated_pair_sm70_out: group scale shape mismatch");
+  TORCH_CHECK(split_k == 4 || split_k == 8 || split_k == 16,
+              "fp8_qpn8_gated_pair_sm70_out: split_k must be 4, 8, or 16");
+  TORCH_CHECK((k / 16) % split_k == 0,
+              "fp8_qpn8_gated_pair_sm70_out: invalid split_k for K");
+  TORCH_CHECK(
+      accumulator_chains == 1 || accumulator_chains == 2,
+      "fp8_qpn8_gated_pair_sm70_out: accumulator_chains must be 1 or 2");
+  TORCH_CHECK(!prefetch_codes || fast_decoder,
+              "fp8_qpn8_gated_pair_sm70_out: prefetch requires fast decoder");
+
+  const at::cuda::OptionalCUDAGuard device_guard(device_of(input));
+  const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
+  const auto* code_ptr = codes.data_ptr<uint8_t>();
+  const auto* scale_ptr =
+      reinterpret_cast<const half*>(group_scales.data_ptr<at::Half>());
+  const auto* input_ptr =
+      reinterpret_cast<const half*>(input.data_ptr<at::Half>());
+  auto* output_ptr = reinterpret_cast<half*>(out.data_ptr<at::Half>());
+
+#define VLLM_LAUNCH_QPN8_GATED_PAIR(SPLIT, NACC, FAST, PREFETCH)            \
+  launch_fp8_qpn8_gated_pair_sm70<SPLIT, NACC, FAST, PREFETCH>(             \
+      code_ptr, scale_ptr, input_ptr, output_ptr, static_cast<int>(hidden), \
+      static_cast<int>(k), static_cast<int>(m), stream)
+
+  if (prefetch_codes) {
+    if (split_k == 4 && accumulator_chains == 1) {
+      VLLM_LAUNCH_QPN8_GATED_PAIR(4, 1, true, true);
+    } else if (split_k == 4 && accumulator_chains == 2) {
+      VLLM_LAUNCH_QPN8_GATED_PAIR(4, 2, true, true);
+    } else if (split_k == 8 && accumulator_chains == 1) {
+      VLLM_LAUNCH_QPN8_GATED_PAIR(8, 1, true, true);
+    } else if (split_k == 8 && accumulator_chains == 2) {
+      VLLM_LAUNCH_QPN8_GATED_PAIR(8, 2, true, true);
+    } else if (split_k == 16 && accumulator_chains == 1) {
+      VLLM_LAUNCH_QPN8_GATED_PAIR(16, 1, true, true);
+    } else {
+      VLLM_LAUNCH_QPN8_GATED_PAIR(16, 2, true, true);
+    }
+  } else if (fast_decoder) {
+    if (split_k == 4 && accumulator_chains == 1) {
+      VLLM_LAUNCH_QPN8_GATED_PAIR(4, 1, true, false);
+    } else if (split_k == 4 && accumulator_chains == 2) {
+      VLLM_LAUNCH_QPN8_GATED_PAIR(4, 2, true, false);
+    } else if (split_k == 8 && accumulator_chains == 1) {
+      VLLM_LAUNCH_QPN8_GATED_PAIR(8, 1, true, false);
+    } else if (split_k == 8 && accumulator_chains == 2) {
+      VLLM_LAUNCH_QPN8_GATED_PAIR(8, 2, true, false);
+    } else if (split_k == 16 && accumulator_chains == 1) {
+      VLLM_LAUNCH_QPN8_GATED_PAIR(16, 1, true, false);
+    } else {
+      VLLM_LAUNCH_QPN8_GATED_PAIR(16, 2, true, false);
+    }
+  } else if (split_k == 4 && accumulator_chains == 1) {
+    VLLM_LAUNCH_QPN8_GATED_PAIR(4, 1, false, false);
+  } else if (split_k == 4 && accumulator_chains == 2) {
+    VLLM_LAUNCH_QPN8_GATED_PAIR(4, 2, false, false);
+  } else if (split_k == 8 && accumulator_chains == 1) {
+    VLLM_LAUNCH_QPN8_GATED_PAIR(8, 1, false, false);
+  } else if (split_k == 8 && accumulator_chains == 2) {
+    VLLM_LAUNCH_QPN8_GATED_PAIR(8, 2, false, false);
+  } else if (split_k == 16 && accumulator_chains == 1) {
+    VLLM_LAUNCH_QPN8_GATED_PAIR(16, 1, false, false);
+  } else {
+    VLLM_LAUNCH_QPN8_GATED_PAIR(16, 2, false, false);
+  }
+#undef VLLM_LAUNCH_QPN8_GATED_PAIR
+  C10_CUDA_KERNEL_LAUNCH_CHECK();
+}
+
+#ifdef VLLM_QPN8_STANDALONE
+// Lets the exact same source file be compiled as an operator-race harness
+// before paying for a complete vLLM rebuild. Production builds register the
+// operator centrally in torch_bindings.cpp and do not define this macro.
+TORCH_LIBRARY_FRAGMENT(_C, ops) {
+  ops.def(
+      "fp8_qpn8_gemm_sm70_out(Tensor(a!) out, Tensor input, Tensor codes, "
+      "Tensor group_scales, int split_k, int accumulator_chains, "
+      "bool fast_decoder, bool prefetch_codes) -> ()");
+  ops.impl("fp8_qpn8_gemm_sm70_out", torch::kCUDA, &fp8_qpn8_gemm_sm70_out);
+  ops.def(
+      "fp8_qpn8_gated_pair_sm70_out(Tensor(a!) out, Tensor input, "
+      "Tensor codes, Tensor group_scales, int split_k, "
+      "int accumulator_chains, bool fast_decoder, bool prefetch_codes) -> ()");
+  ops.impl("fp8_qpn8_gated_pair_sm70_out", torch::kCUDA,
+           &fp8_qpn8_gated_pair_sm70_out);
+}
+#endif

--- a/csrc/sm70_turbomind/ops/fp8_qpn8_sm70.cu
+++ b/csrc/sm70_turbomind/ops/fp8_qpn8_sm70.cu
@@ -111,8 +111,7 @@ __global__ void fp8_qpn8_channel_scale_sm70_kernel(
 
 __global__ void fp8_qpn8_dequantize_sm70_kernel(
     half* __restrict__ output, const uint8_t* __restrict__ codes,
-    const half* __restrict__ group_scales, int n, int k,
-    bool channel_scales) {
+    const half* __restrict__ group_scales, int n, int k, bool channel_scales) {
   const size_t word_index =
       static_cast<size_t>(blockIdx.x) * blockDim.x + threadIdx.x;
   const size_t word_count = static_cast<size_t>(n) * k / 16;
@@ -288,12 +287,10 @@ __global__ void fp8_qpn8_sm70_kernel(const uint8_t* __restrict__ codes,
   } else {
 #pragma unroll
     for (int i = 0; i < 8; ++i) {
-      const int output_row =
-          (i & 2) | ((lane & 16) ? 4 : 0) | (lane & 1);
+      const int output_row = (i & 2) | ((lane & 16) ? 4 : 0) | (lane & 1);
       const int output_col =
           (i & 1) | (((lane >> 1) & 1) << 1) | ((i >> 2) << 2);
-      partials[warp][output_row * 32 + quadpair * 8 + output_col] =
-          accum[0][i];
+      partials[warp][output_row * 32 + quadpair * 8 + output_col] = accum[0][i];
     }
   }
   __syncthreads();
@@ -439,20 +436,18 @@ __global__ void fp8_qpn8_gated_pair_sm70_kernel(
           const int i = pair * 4 + offset;
           const int output_col =
               offset | (((lane >> 1) & 1) << 1) | (pair << 2);
-          partials[projection][warp][quadpair * 8 + output_col] =
-              accum[0][i];
+          partials[projection][warp][quadpair * 8 + output_col] = accum[0][i];
         }
       }
     }
   } else {
 #pragma unroll
     for (int i = 0; i < 8; ++i) {
-      const int output_row =
-          (i & 2) | ((lane & 16) ? 4 : 0) | (lane & 1);
+      const int output_row = (i & 2) | ((lane & 16) ? 4 : 0) | (lane & 1);
       const int output_col =
           (i & 1) | (((lane >> 1) & 1) << 1) | ((i >> 2) << 2);
-      partials[projection][warp]
-              [output_row * 32 + quadpair * 8 + output_col] = accum[0][i];
+      partials[projection][warp][output_row * 32 + quadpair * 8 + output_col] =
+          accum[0][i];
     }
   }
   __syncthreads();
@@ -491,9 +486,8 @@ void launch_fp8_qpn8_gated_pair_sm70(const uint8_t* codes,
                                      bool channel_scales, cudaStream_t stream) {
   fp8_qpn8_gated_pair_sm70_kernel<SplitK, NAcc, FastDecoder, PrefetchCodes,
                                   M1Only>
-      <<<(hidden / 32), (64 * SplitK), 0, stream>>>(codes, group_scales, input,
-                                                    output, hidden, k, m,
-                                                    channel_scales);
+      <<<(hidden / 32), (64 * SplitK), 0, stream>>>(
+          codes, group_scales, input, output, hidden, k, m, channel_scales);
 }
 
 }  // namespace
@@ -552,7 +546,8 @@ std::vector<torch::Tensor> fp8_qpn8_prepare_sm70(torch::Tensor qweight,
         reinterpret_cast<half*>(group_scales.data_ptr<at::Half>()),
         scales.data_ptr<float>(), static_cast<int>(n));
   } else {
-    fp8_qpn8_scale_sm70_kernel<<<scale_blocks, kQpn8PrepareThreads, 0, stream>>>(
+    fp8_qpn8_scale_sm70_kernel<<<scale_blocks, kQpn8PrepareThreads, 0,
+                                 stream>>>(
         reinterpret_cast<half*>(group_scales.data_ptr<at::Half>()),
         scales.data_ptr<float>(), static_cast<int>(n / 128),
         static_cast<int>(k / 128));
@@ -586,8 +581,8 @@ void fp8_qpn8_dequantize_sm70_out(torch::Tensor out, torch::Tensor codes,
               "fp8_qpn8_dequantize_sm70_out: packed code size mismatch");
   const bool channel_scales =
       group_scales.size(0) == 1 && group_scales.size(1) == n;
-  const bool block_scales = group_scales.size(0) == k / 128 &&
-                            group_scales.size(1) == n / 32;
+  const bool block_scales =
+      group_scales.size(0) == k / 128 && group_scales.size(1) == n / 32;
   TORCH_CHECK(channel_scales || block_scales,
               "fp8_qpn8_dequantize_sm70_out: scale shape mismatch");
 
@@ -680,12 +675,12 @@ void fp8_qpn8_gemm_sm70_out(torch::Tensor out, torch::Tensor input,
               "fp8_qpn8_gemm_sm70_out: packed code size mismatch");
   const bool channel_scales =
       group_scales.size(0) == 1 && group_scales.size(1) == n;
-  const bool block_scales = group_scales.size(0) == k / 128 &&
-                            group_scales.size(1) == n / 32;
+  const bool block_scales =
+      group_scales.size(0) == k / 128 && group_scales.size(1) == n / 32;
   TORCH_CHECK(channel_scales || block_scales,
               "fp8_qpn8_gemm_sm70_out: scale shape mismatch");
-  TORCH_CHECK(split_k == 4 || split_k == 8 || split_k == 12 ||
-                  split_k == 16 || split_k == 32,
+  TORCH_CHECK(split_k == 4 || split_k == 8 || split_k == 12 || split_k == 16 ||
+                  split_k == 32,
               "fp8_qpn8_gemm_sm70_out: unsupported split_k");
   TORCH_CHECK((k / 16) % split_k == 0,
               "fp8_qpn8_gemm_sm70_out: K/16 must be divisible by split_k");
@@ -712,8 +707,8 @@ void fp8_qpn8_gemm_sm70_out(torch::Tensor out, torch::Tensor input,
   // Keep the M=1 reduction order restricted to the two tuned output/down
   // projections. Extending it to the other split variants changed the frozen
   // random-sampling token stream without an end-to-end decode win.
-  if (m == 1 && accumulator_chains == 2 && fast_decoder &&
-      !prefetch_codes && (split_k == 12 || split_k == 16)) {
+  if (m == 1 && accumulator_chains == 2 && fast_decoder && !prefetch_codes &&
+      (split_k == 12 || split_k == 16)) {
     if (split_k == 12) {
       launch_fp8_qpn8_sm70<12, 2, true, false, true>(
           code_ptr, scale_ptr, input_ptr, output_ptr, static_cast<int>(n),
@@ -827,8 +822,8 @@ void fp8_qpn8_gated_pair_sm70_out(torch::Tensor out, torch::Tensor input,
               "fp8_qpn8_gated_pair_sm70_out: packed code size mismatch");
   const bool channel_scales =
       group_scales.size(0) == 1 && group_scales.size(1) == n;
-  const bool block_scales = group_scales.size(0) == k / 128 &&
-                            group_scales.size(1) == n / 32;
+  const bool block_scales =
+      group_scales.size(0) == k / 128 && group_scales.size(1) == n / 32;
   TORCH_CHECK(channel_scales || block_scales,
               "fp8_qpn8_gated_pair_sm70_out: scale shape mismatch");
   TORCH_CHECK(split_k == 4 || split_k == 8 || split_k == 16,
@@ -855,9 +850,8 @@ void fp8_qpn8_gated_pair_sm70_out(torch::Tensor out, torch::Tensor input,
   if (m == 1 && split_k == 8 && accumulator_chains == 2 && fast_decoder &&
       !prefetch_codes) {
     launch_fp8_qpn8_gated_pair_sm70<8, 2, true, false, true>(
-        code_ptr, scale_ptr, input_ptr, output_ptr,
-        static_cast<int>(hidden), static_cast<int>(k), 1, channel_scales,
-        stream);
+        code_ptr, scale_ptr, input_ptr, output_ptr, static_cast<int>(hidden),
+        static_cast<int>(k), 1, channel_scales, stream);
     C10_CUDA_KERNEL_LAUNCH_CHECK();
     return;
   }

--- a/csrc/sm70_turbomind/ops/nvfp4_qpn4_sm70.cu
+++ b/csrc/sm70_turbomind/ops/nvfp4_qpn4_sm70.cu
@@ -55,12 +55,10 @@ __global__ void nvfp4_qpn4_prepack_codes_kernel(
   const int physical_k0 = physical_byte * 2;
   const int logical_k0 = logical_k_from_physical(physical_k0);
   const int logical_k1 = logical_k_from_physical(physical_k0 + 1);
-  const uint8_t lo = qweight[static_cast<size_t>(group * 16 + logical_k0) * n +
-                             col] &
-                     0x0fU;
-  const uint8_t hi = qweight[static_cast<size_t>(group * 16 + logical_k1) * n +
-                             col] &
-                     0x0fU;
+  const uint8_t lo =
+      qweight[static_cast<size_t>(group * 16 + logical_k0) * n + col] & 0x0fU;
+  const uint8_t hi =
+      qweight[static_cast<size_t>(group * 16 + logical_k1) * n + col] & 0x0fU;
   codes[index] = lo | (hi << 4);
 }
 
@@ -79,9 +77,8 @@ __global__ void nvfp4_qpn4_prepack_scales_kernel(
   const int group = static_cast<int>(outer % groups_k16);
   const int tile = static_cast<int>(outer / groups_k16);
   const int col = tile * 32 + qpn_col_from_lane(lane);
-  packed_scales[index] = __hmul(
-      scales[static_cast<size_t>(group) * n + col],
-      __float2half_rn(kFp4Bias));
+  packed_scales[index] = __hmul(scales[static_cast<size_t>(group) * n + col],
+                                __float2half_rn(kFp4Bias));
 }
 
 __global__ void nvfp4_qpn4_prepack_scale_codes_kernel(
@@ -99,8 +96,7 @@ __global__ void nvfp4_qpn4_prepack_scale_codes_kernel(
   const int group = static_cast<int>(outer % groups_k16);
   const int tile = static_cast<int>(outer / groups_k16);
   const int col = tile * 32 + qpn_col_from_lane(lane);
-  packed_scale_codes[index] =
-      scale_codes[static_cast<size_t>(group) * n + col];
+  packed_scale_codes[index] = scale_codes[static_cast<size_t>(group) * n + col];
 }
 
 __device__ __forceinline__ void fp4x8_to_half2x4(unsigned x, half2 out[4]) {
@@ -117,14 +113,14 @@ __device__ __forceinline__ void fp4x8_to_half2x4(unsigned x, half2 out[4]) {
   }
 }
 
-__device__ __forceinline__ void fp4x16_to_half2x8(uint2 packed,
-                                                   half2 out[8]) {
+__device__ __forceinline__ void fp4x16_to_half2x8(uint2 packed, half2 out[8]) {
   fp4x8_to_half2x4(packed.x, out);
   fp4x8_to_half2x4(packed.y, out + 4);
 }
 
-__device__ __forceinline__ half nvfp4_scale_code_to_half(
-    uint8_t scale_code, half scale_hi, half scale_lo) {
+__device__ __forceinline__ half nvfp4_scale_code_to_half(uint8_t scale_code,
+                                                         half scale_hi,
+                                                         half scale_lo) {
   // NVFP4 group scales are positive, normal E4M3FN values. Adding the bias
   // delta while shifting the E4M3 payload produces the exact FP16 value.
   const unsigned half_bits =
@@ -137,8 +133,8 @@ __device__ __forceinline__ half nvfp4_scale_code_to_half(
 template <bool UseScaleCode>
 __global__ void nvfp4_qpn4_dequantize_sm70_kernel(
     half* __restrict__ output, const uint8_t* __restrict__ codes,
-    const void* __restrict__ packed_scales, half scale_hi, half scale_lo,
-    int n, int k) {
+    const void* __restrict__ packed_scales, half scale_hi, half scale_lo, int n,
+    int k) {
   const size_t word_index =
       static_cast<size_t>(blockIdx.x) * blockDim.x + threadIdx.x;
   const size_t word_count = static_cast<size_t>(k) * n / 16;
@@ -155,14 +151,13 @@ __global__ void nvfp4_qpn4_dequantize_sm70_kernel(
   half scale;
   if constexpr (UseScaleCode) {
     scale = nvfp4_scale_code_to_half(
-        reinterpret_cast<const uint8_t*>(packed_scales)[word_index],
-        scale_hi, scale_lo);
+        reinterpret_cast<const uint8_t*>(packed_scales)[word_index], scale_hi,
+        scale_lo);
   } else {
     scale = reinterpret_cast<const half*>(packed_scales)[word_index];
   }
   half2 weights[8];
-  fp4x16_to_half2x8(
-      reinterpret_cast<const uint2*>(codes)[word_index], weights);
+  fp4x16_to_half2x8(reinterpret_cast<const uint2*>(codes)[word_index], weights);
   const half2 scale2 = __halves2half2(scale, scale);
 #pragma unroll
   for (int pair = 0; pair < 8; ++pair) {
@@ -205,11 +200,12 @@ __global__ void nvfp4_qpn4_silu_and_mul_sm70_kernel(
       : "r"(A0), "r"(A1), "r"(B0), "r"(B1))
 
 template <int SplitK, int NAcc, bool PrefetchCodes, bool UseScaleCode>
-__global__ void nvfp4_qpn4_sm70_kernel(
-    const uint8_t* __restrict__ codes,
-    const void* __restrict__ packed_scales,
-    half scale_hi, half scale_lo, const half* __restrict__ input,
-    half* __restrict__ output, int n, int k, int m) {
+__global__ void nvfp4_qpn4_sm70_kernel(const uint8_t* __restrict__ codes,
+                                       const void* __restrict__ packed_scales,
+                                       half scale_hi, half scale_lo,
+                                       const half* __restrict__ input,
+                                       half* __restrict__ output, int n, int k,
+                                       int m) {
   __shared__ float partials[SplitK][32];
 
   const int lane = threadIdx.x & 31;
@@ -224,8 +220,8 @@ __global__ void nvfp4_qpn4_sm70_kernel(
                           static_cast<size_t>(tile) * groups_k16 * 32 + lane;
   const size_t scale_offset =
       static_cast<size_t>(tile) * groups_k16 * 32 + lane;
-  const half* scale_ptr = reinterpret_cast<const half*>(packed_scales) +
-                          scale_offset;
+  const half* scale_ptr =
+      reinterpret_cast<const half*>(packed_scales) + scale_offset;
   const uint8_t* scale_code_ptr =
       reinterpret_cast<const uint8_t*>(packed_scales) + scale_offset;
 
@@ -303,8 +299,7 @@ __global__ void nvfp4_qpn4_sm70_kernel(
 #pragma unroll
       for (int offset = 0; offset < 2; ++offset) {
         const int i = pair * 4 + offset;
-        const int output_col =
-            offset | (((lane >> 1) & 1) << 1) | (pair << 2);
+        const int output_col = offset | (((lane >> 1) & 1) << 1) | (pair << 2);
         partials[warp][quadpair * 8 + output_col] = accum[0][i];
       }
     }
@@ -323,8 +318,7 @@ __global__ void nvfp4_qpn4_sm70_kernel(
 
 template <int SplitK, int NAcc, bool PrefetchCodes, bool UseScaleCode>
 __global__ void nvfp4_qpn4_gated_sm70_kernel(
-    const uint8_t* __restrict__ codes,
-    const void* __restrict__ packed_scales,
+    const uint8_t* __restrict__ codes, const void* __restrict__ packed_scales,
     half scale_hi, half scale_lo, const half* __restrict__ input,
     half* __restrict__ output, int hidden, int k, int m) {
   __shared__ float partials[2][SplitK][32];
@@ -344,8 +338,8 @@ __global__ void nvfp4_qpn4_gated_sm70_kernel(
                           static_cast<size_t>(tile) * groups_k16 * 32 + lane;
   const size_t scale_offset =
       static_cast<size_t>(tile) * groups_k16 * 32 + lane;
-  const half* scale_ptr = reinterpret_cast<const half*>(packed_scales) +
-                          scale_offset;
+  const half* scale_ptr =
+      reinterpret_cast<const half*>(packed_scales) + scale_offset;
   const uint8_t* scale_code_ptr =
       reinterpret_cast<const uint8_t*>(packed_scales) + scale_offset;
 
@@ -443,19 +437,18 @@ __global__ void nvfp4_qpn4_gated_sm70_kernel(
 }
 
 template <int SplitK, int NAcc, bool PrefetchCodes, bool UseScaleCode>
-void launch_qpn4(const uint8_t* codes, const void* scales,
-                 half scale_hi, half scale_lo, const half* input,
-                 half* output, int n, int k, int m, cudaStream_t stream) {
+void launch_qpn4(const uint8_t* codes, const void* scales, half scale_hi,
+                 half scale_lo, const half* input, half* output, int n, int k,
+                 int m, cudaStream_t stream) {
   nvfp4_qpn4_sm70_kernel<SplitK, NAcc, PrefetchCodes, UseScaleCode>
       <<<(n / 32), (32 * SplitK), 0, stream>>>(
           codes, scales, scale_hi, scale_lo, input, output, n, k, m);
 }
 
 template <int SplitK, int NAcc, bool PrefetchCodes, bool UseScaleCode>
-void launch_qpn4_gated(const uint8_t* codes, const void* scales,
-                       half scale_hi, half scale_lo, const half* input,
-                       half* output, int hidden, int k, int m,
-                       cudaStream_t stream) {
+void launch_qpn4_gated(const uint8_t* codes, const void* scales, half scale_hi,
+                       half scale_lo, const half* input, half* output,
+                       int hidden, int k, int m, cudaStream_t stream) {
   nvfp4_qpn4_gated_sm70_kernel<SplitK, NAcc, PrefetchCodes, UseScaleCode>
       <<<(hidden / 32), (64 * SplitK), 0, stream>>>(
           codes, scales, scale_hi, scale_lo, input, output, hidden, k, m);
@@ -489,15 +482,16 @@ std::vector<torch::Tensor> nvfp4_qpn4_prepare_sm70(torch::Tensor qweight,
       torch::TensorOptions().device(qweight.device()).dtype(torch::kUInt8));
   auto packed_scales = torch::empty_like(scales);
   const int64_t code_numel = packed_codes.numel();
-  const int code_blocks = static_cast<int>(
-      (code_numel + kPrepareThreads - 1) / kPrepareThreads);
+  const int code_blocks =
+      static_cast<int>((code_numel + kPrepareThreads - 1) / kPrepareThreads);
   nvfp4_qpn4_prepack_codes_kernel<<<code_blocks, kPrepareThreads, 0, stream>>>(
       packed_codes.data_ptr<uint8_t>(), qweight.data_ptr<uint8_t>(),
       static_cast<int>(k), static_cast<int>(n));
   const int64_t scale_numel = packed_scales.numel();
-  const int scale_blocks = static_cast<int>(
-      (scale_numel + kPrepareThreads - 1) / kPrepareThreads);
-  nvfp4_qpn4_prepack_scales_kernel<<<scale_blocks, kPrepareThreads, 0, stream>>>(
+  const int scale_blocks =
+      static_cast<int>((scale_numel + kPrepareThreads - 1) / kPrepareThreads);
+  nvfp4_qpn4_prepack_scales_kernel<<<scale_blocks, kPrepareThreads, 0,
+                                     stream>>>(
       reinterpret_cast<half*>(packed_scales.data_ptr<at::Half>()),
       reinterpret_cast<const half*>(scales.data_ptr<at::Half>()),
       static_cast<int>(k), static_cast<int>(n));
@@ -510,8 +504,7 @@ std::vector<torch::Tensor> nvfp4_qpn4_prepare_scale_code_sm70(
   TORCH_CHECK(qweight.is_cuda() && scale_codes.is_cuda(),
               "nvfp4_qpn4_prepare_scale_code_sm70: tensors must be CUDA");
   TORCH_CHECK(qweight.scalar_type() == torch::kUInt8 &&
-                  scale_codes.scalar_type() ==
-                      at::ScalarType::Float8_e4m3fn,
+                  scale_codes.scalar_type() == at::ScalarType::Float8_e4m3fn,
               "nvfp4_qpn4_prepare_scale_code_sm70: expected uint8 weights and "
               "float8_e4m3fn scale codes");
   TORCH_CHECK(qweight.dim() == 2 && scale_codes.dim() == 2 &&
@@ -537,14 +530,14 @@ std::vector<torch::Tensor> nvfp4_qpn4_prepare_scale_code_sm70(
       {k / 16, n},
       torch::TensorOptions().device(qweight.device()).dtype(torch::kUInt8));
   const int64_t code_numel = packed_codes.numel();
-  const int code_blocks = static_cast<int>(
-      (code_numel + kPrepareThreads - 1) / kPrepareThreads);
+  const int code_blocks =
+      static_cast<int>((code_numel + kPrepareThreads - 1) / kPrepareThreads);
   nvfp4_qpn4_prepack_codes_kernel<<<code_blocks, kPrepareThreads, 0, stream>>>(
       packed_codes.data_ptr<uint8_t>(), qweight.data_ptr<uint8_t>(),
       static_cast<int>(k), static_cast<int>(n));
   const int64_t scale_numel = packed_scale_codes.numel();
-  const int scale_blocks = static_cast<int>(
-      (scale_numel + kPrepareThreads - 1) / kPrepareThreads);
+  const int scale_blocks =
+      static_cast<int>((scale_numel + kPrepareThreads - 1) / kPrepareThreads);
   nvfp4_qpn4_prepack_scale_codes_kernel<<<scale_blocks, kPrepareThreads, 0,
                                           stream>>>(
       packed_scale_codes.data_ptr<uint8_t>(),
@@ -554,19 +547,18 @@ std::vector<torch::Tensor> nvfp4_qpn4_prepare_scale_code_sm70(
   return {packed_codes, packed_scale_codes};
 }
 
-void nvfp4_qpn4_dequantize_sm70_out(
-    torch::Tensor out, torch::Tensor codes, torch::Tensor scales,
-    double global_scale, bool use_scale_code) {
+void nvfp4_qpn4_dequantize_sm70_out(torch::Tensor out, torch::Tensor codes,
+                                    torch::Tensor scales, double global_scale,
+                                    bool use_scale_code) {
   TORCH_CHECK(out.is_cuda() && codes.is_cuda() && scales.is_cuda(),
               "nvfp4_qpn4_dequantize_sm70_out: tensors must be CUDA");
   TORCH_CHECK(out.scalar_type() == torch::kFloat16 &&
                   codes.scalar_type() == torch::kUInt8,
               "nvfp4_qpn4_dequantize_sm70_out: output must be FP16 and codes "
               "must be uint8");
-  TORCH_CHECK(
-      (use_scale_code && scales.scalar_type() == torch::kUInt8) ||
-          (!use_scale_code && scales.scalar_type() == torch::kFloat16),
-      "nvfp4_qpn4_dequantize_sm70_out: scale dtype mismatch");
+  TORCH_CHECK((use_scale_code && scales.scalar_type() == torch::kUInt8) ||
+                  (!use_scale_code && scales.scalar_type() == torch::kFloat16),
+              "nvfp4_qpn4_dequantize_sm70_out: scale dtype mismatch");
   TORCH_CHECK(out.dim() == 2 && codes.dim() == 2 && scales.dim() == 2 &&
                   out.is_contiguous() && codes.is_contiguous() &&
                   scales.is_contiguous(),
@@ -579,14 +571,13 @@ void nvfp4_qpn4_dequantize_sm70_out(
   const int64_t n = out.size(1);
   TORCH_CHECK(k > 0 && k % 128 == 0 && n > 0 && n % 32 == 0,
               "nvfp4_qpn4_dequantize_sm70_out: shape alignment mismatch");
-  TORCH_CHECK(codes.numel() == k * n / 2 &&
-                  scales.numel() == k * n / 16,
+  TORCH_CHECK(codes.numel() == k * n / 2 && scales.numel() == k * n / 16,
               "nvfp4_qpn4_dequantize_sm70_out: packed tensor size mismatch");
 
   const at::cuda::OptionalCUDAGuard device_guard(device_of(out));
   const int64_t word_count = k * n / 16;
-  const int blocks = static_cast<int>(
-      (word_count + kPrepareThreads - 1) / kPrepareThreads);
+  const int blocks =
+      static_cast<int>((word_count + kPrepareThreads - 1) / kPrepareThreads);
   const SplitHalfScale split_scale =
       split_half_scale(static_cast<float>(global_scale) * kFp4Bias);
   const half zero_scale = __float2half_rn(0.0f);
@@ -607,10 +598,10 @@ void nvfp4_qpn4_dequantize_sm70_out(
   C10_CUDA_KERNEL_LAUNCH_CHECK();
 }
 
-void nvfp4_qpn4_prefill_sm70_out(
-    torch::Tensor out, int64_t dense_weight_ptr, torch::Tensor input,
-    torch::Tensor codes, torch::Tensor scales, double global_scale,
-    bool use_scale_code, bool gated_silu) {
+void nvfp4_qpn4_prefill_sm70_out(torch::Tensor out, int64_t dense_weight_ptr,
+                                 torch::Tensor input, torch::Tensor codes,
+                                 torch::Tensor scales, double global_scale,
+                                 bool use_scale_code, bool gated_silu) {
   TORCH_CHECK(input.is_cuda() && out.is_cuda(),
               "nvfp4_qpn4_prefill_sm70_out: input and output must be CUDA");
   TORCH_CHECK(input.scalar_type() == torch::kFloat16 &&
@@ -630,7 +621,7 @@ void nvfp4_qpn4_prefill_sm70_out(
   auto dense_weight = torch::from_blob(
       reinterpret_cast<void*>(dense_weight_ptr), {k, n}, input.options());
   nvfp4_qpn4_dequantize_sm70_out(dense_weight, codes, scales, global_scale,
-                                  use_scale_code);
+                                 use_scale_code);
   if (!gated_silu) {
     at::mm_out(out, input, dense_weight);
     return;
@@ -638,12 +629,11 @@ void nvfp4_qpn4_prefill_sm70_out(
 
   auto gate_up = at::mm(input, dense_weight);
   constexpr int kThreads = 256;
-  nvfp4_qpn4_silu_and_mul_sm70_kernel
-      <<<static_cast<int>(m), kThreads, 0,
-         at::cuda::getCurrentCUDAStream()>>>(
-          reinterpret_cast<half*>(out.data_ptr<at::Half>()),
-          reinterpret_cast<const half*>(gate_up.data_ptr<at::Half>()),
-          static_cast<int>(m), static_cast<int>(n / 2));
+  nvfp4_qpn4_silu_and_mul_sm70_kernel<<<static_cast<int>(m), kThreads, 0,
+                                        at::cuda::getCurrentCUDAStream()>>>(
+      reinterpret_cast<half*>(out.data_ptr<at::Half>()),
+      reinterpret_cast<const half*>(gate_up.data_ptr<at::Half>()),
+      static_cast<int>(m), static_cast<int>(n / 2));
   C10_CUDA_KERNEL_LAUNCH_CHECK();
 }
 
@@ -651,9 +641,9 @@ void nvfp4_qpn4_gemm_sm70_out(torch::Tensor out, torch::Tensor input,
                               torch::Tensor codes, torch::Tensor scales,
                               int64_t split_k, int64_t accumulator_chains,
                               bool prefetch_codes) {
-  TORCH_CHECK(out.is_cuda() && input.is_cuda() && codes.is_cuda() &&
-                  scales.is_cuda(),
-              "nvfp4_qpn4_gemm_sm70_out: tensors must be CUDA");
+  TORCH_CHECK(
+      out.is_cuda() && input.is_cuda() && codes.is_cuda() && scales.is_cuda(),
+      "nvfp4_qpn4_gemm_sm70_out: tensors must be CUDA");
   TORCH_CHECK(out.scalar_type() == torch::kFloat16 &&
                   input.scalar_type() == torch::kFloat16 &&
                   codes.scalar_type() == torch::kUInt8 &&
@@ -671,8 +661,8 @@ void nvfp4_qpn4_gemm_sm70_out(torch::Tensor out, torch::Tensor input,
               "nvfp4_qpn4_gemm_sm70_out: shape alignment mismatch");
   TORCH_CHECK(codes.numel() == k * n / 2 && scales.numel() == k * n / 16,
               "nvfp4_qpn4_gemm_sm70_out: packed tensor size mismatch");
-  TORCH_CHECK(split_k == 4 || split_k == 8 || split_k == 10 ||
-                  split_k == 16 || split_k == 17,
+  TORCH_CHECK(split_k == 4 || split_k == 8 || split_k == 10 || split_k == 16 ||
+                  split_k == 17,
               "nvfp4_qpn4_gemm_sm70_out: unsupported split_k");
   TORCH_CHECK((k / 16) % split_k == 0,
               "nvfp4_qpn4_gemm_sm70_out: invalid split_k for K");
@@ -689,22 +679,21 @@ void nvfp4_qpn4_gemm_sm70_out(torch::Tensor out, torch::Tensor input,
   auto* output_ptr = reinterpret_cast<half*>(out.data_ptr<at::Half>());
   const half zero_scale = __float2half_rn(0.0f);
 
-#define LAUNCH_QPN4(SPLIT, NACC, PREFETCH)                              \
-  launch_qpn4<SPLIT, NACC, PREFETCH, false>(                            \
+#define LAUNCH_QPN4(SPLIT, NACC, PREFETCH)                                \
+  launch_qpn4<SPLIT, NACC, PREFETCH, false>(                              \
       code_ptr, scale_ptr, zero_scale, zero_scale, input_ptr, output_ptr, \
-      static_cast<int>(n), static_cast<int>(k), static_cast<int>(m),     \
-      stream)
-#define DISPATCH_NACC_PREFETCH(SPLIT)                         \
-  do {                                                        \
-    if (accumulator_chains == 1 && !prefetch_codes) {         \
-      LAUNCH_QPN4(SPLIT, 1, false);                           \
-    } else if (accumulator_chains == 2 && !prefetch_codes) {  \
-      LAUNCH_QPN4(SPLIT, 2, false);                           \
-    } else if (accumulator_chains == 1) {                     \
-      LAUNCH_QPN4(SPLIT, 1, true);                            \
-    } else {                                                  \
-      LAUNCH_QPN4(SPLIT, 2, true);                            \
-    }                                                         \
+      static_cast<int>(n), static_cast<int>(k), static_cast<int>(m), stream)
+#define DISPATCH_NACC_PREFETCH(SPLIT)                        \
+  do {                                                       \
+    if (accumulator_chains == 1 && !prefetch_codes) {        \
+      LAUNCH_QPN4(SPLIT, 1, false);                          \
+    } else if (accumulator_chains == 2 && !prefetch_codes) { \
+      LAUNCH_QPN4(SPLIT, 2, false);                          \
+    } else if (accumulator_chains == 1) {                    \
+      LAUNCH_QPN4(SPLIT, 1, true);                           \
+    } else {                                                 \
+      LAUNCH_QPN4(SPLIT, 2, true);                           \
+    }                                                        \
   } while (0)
   if (split_k == 4) {
     DISPATCH_NACC_PREFETCH(4);
@@ -726,9 +715,9 @@ void nvfp4_qpn4_gated_sm70_out(torch::Tensor out, torch::Tensor input,
                                torch::Tensor codes, torch::Tensor scales,
                                int64_t split_k, int64_t accumulator_chains,
                                bool prefetch_codes) {
-  TORCH_CHECK(out.is_cuda() && input.is_cuda() && codes.is_cuda() &&
-                  scales.is_cuda(),
-              "nvfp4_qpn4_gated_sm70_out: tensors must be CUDA");
+  TORCH_CHECK(
+      out.is_cuda() && input.is_cuda() && codes.is_cuda() && scales.is_cuda(),
+      "nvfp4_qpn4_gated_sm70_out: tensors must be CUDA");
   TORCH_CHECK(out.scalar_type() == torch::kFloat16 &&
                   input.scalar_type() == torch::kFloat16 &&
                   codes.scalar_type() == torch::kUInt8 &&
@@ -764,22 +753,22 @@ void nvfp4_qpn4_gated_sm70_out(torch::Tensor out, torch::Tensor input,
   auto* output_ptr = reinterpret_cast<half*>(out.data_ptr<at::Half>());
   const half zero_scale = __float2half_rn(0.0f);
 
-#define LAUNCH_QPN4_GATED(SPLIT, NACC, PREFETCH)                        \
-  launch_qpn4_gated<SPLIT, NACC, PREFETCH, false>(                      \
+#define LAUNCH_QPN4_GATED(SPLIT, NACC, PREFETCH)                          \
+  launch_qpn4_gated<SPLIT, NACC, PREFETCH, false>(                        \
       code_ptr, scale_ptr, zero_scale, zero_scale, input_ptr, output_ptr, \
-      static_cast<int>(hidden), static_cast<int>(k),                     \
-      static_cast<int>(m), stream)
-#define DISPATCH_GATED_NACC_PREFETCH(SPLIT)                   \
-  do {                                                        \
-    if (accumulator_chains == 1 && !prefetch_codes) {         \
-      LAUNCH_QPN4_GATED(SPLIT, 1, false);                     \
-    } else if (accumulator_chains == 2 && !prefetch_codes) {  \
-      LAUNCH_QPN4_GATED(SPLIT, 2, false);                     \
-    } else if (accumulator_chains == 1) {                     \
-      LAUNCH_QPN4_GATED(SPLIT, 1, true);                      \
-    } else {                                                  \
-      LAUNCH_QPN4_GATED(SPLIT, 2, true);                      \
-    }                                                         \
+      static_cast<int>(hidden), static_cast<int>(k), static_cast<int>(m), \
+      stream)
+#define DISPATCH_GATED_NACC_PREFETCH(SPLIT)                  \
+  do {                                                       \
+    if (accumulator_chains == 1 && !prefetch_codes) {        \
+      LAUNCH_QPN4_GATED(SPLIT, 1, false);                    \
+    } else if (accumulator_chains == 2 && !prefetch_codes) { \
+      LAUNCH_QPN4_GATED(SPLIT, 2, false);                    \
+    } else if (accumulator_chains == 1) {                    \
+      LAUNCH_QPN4_GATED(SPLIT, 1, true);                     \
+    } else {                                                 \
+      LAUNCH_QPN4_GATED(SPLIT, 2, true);                     \
+    }                                                        \
   } while (0)
   if (split_k == 4) {
     DISPATCH_GATED_NACC_PREFETCH(4);
@@ -795,10 +784,12 @@ void nvfp4_qpn4_gated_sm70_out(torch::Tensor out, torch::Tensor input,
   C10_CUDA_KERNEL_LAUNCH_CHECK();
 }
 
-void nvfp4_qpn4_gemm_scale_code_sm70_out(
-    torch::Tensor out, torch::Tensor input, torch::Tensor codes,
-    torch::Tensor scale_codes, double global_scale, int64_t split_k,
-    int64_t accumulator_chains, bool prefetch_codes) {
+void nvfp4_qpn4_gemm_scale_code_sm70_out(torch::Tensor out, torch::Tensor input,
+                                         torch::Tensor codes,
+                                         torch::Tensor scale_codes,
+                                         double global_scale, int64_t split_k,
+                                         int64_t accumulator_chains,
+                                         bool prefetch_codes) {
   TORCH_CHECK(out.is_cuda() && input.is_cuda() && codes.is_cuda() &&
                   scale_codes.is_cuda(),
               "nvfp4_qpn4_gemm_scale_code_sm70_out: tensors must be CUDA");
@@ -824,12 +815,11 @@ void nvfp4_qpn4_gemm_scale_code_sm70_out(
   TORCH_CHECK(k > 0 && k % 128 == 0 && n > 0 && n % 32 == 0,
               "nvfp4_qpn4_gemm_scale_code_sm70_out: shape alignment "
               "mismatch");
-  TORCH_CHECK(codes.numel() == k * n / 2 &&
-                  scale_codes.numel() == k * n / 16,
+  TORCH_CHECK(codes.numel() == k * n / 2 && scale_codes.numel() == k * n / 16,
               "nvfp4_qpn4_gemm_scale_code_sm70_out: packed tensor size "
               "mismatch");
-  TORCH_CHECK(split_k == 4 || split_k == 8 || split_k == 10 ||
-                  split_k == 16 || split_k == 17,
+  TORCH_CHECK(split_k == 4 || split_k == 8 || split_k == 10 || split_k == 16 ||
+                  split_k == 17,
               "nvfp4_qpn4_gemm_scale_code_sm70_out: unsupported split_k");
   TORCH_CHECK((k / 16) % split_k == 0,
               "nvfp4_qpn4_gemm_scale_code_sm70_out: invalid split_k for K");
@@ -847,23 +837,22 @@ void nvfp4_qpn4_gemm_scale_code_sm70_out(
       reinterpret_cast<const half*>(input.data_ptr<at::Half>());
   auto* output_ptr = reinterpret_cast<half*>(out.data_ptr<at::Half>());
 
-#define LAUNCH_QPN4_LUT(SPLIT, NACC, PREFETCH)                         \
-  launch_qpn4<SPLIT, NACC, PREFETCH, true>(                            \
+#define LAUNCH_QPN4_LUT(SPLIT, NACC, PREFETCH)                             \
+  launch_qpn4<SPLIT, NACC, PREFETCH, true>(                                \
       code_ptr, scale_code_ptr, split_scale.hi, split_scale.lo, input_ptr, \
-      output_ptr,                                                       \
-      static_cast<int>(n), static_cast<int>(k), static_cast<int>(m),    \
-      stream)
-#define DISPATCH_QPN4_LUT(SPLIT)                              \
-  do {                                                        \
-    if (accumulator_chains == 1 && !prefetch_codes) {         \
-      LAUNCH_QPN4_LUT(SPLIT, 1, false);                       \
-    } else if (accumulator_chains == 2 && !prefetch_codes) {  \
-      LAUNCH_QPN4_LUT(SPLIT, 2, false);                       \
-    } else if (accumulator_chains == 1) {                     \
-      LAUNCH_QPN4_LUT(SPLIT, 1, true);                        \
-    } else {                                                  \
-      LAUNCH_QPN4_LUT(SPLIT, 2, true);                        \
-    }                                                         \
+      output_ptr, static_cast<int>(n), static_cast<int>(k),                \
+      static_cast<int>(m), stream)
+#define DISPATCH_QPN4_LUT(SPLIT)                             \
+  do {                                                       \
+    if (accumulator_chains == 1 && !prefetch_codes) {        \
+      LAUNCH_QPN4_LUT(SPLIT, 1, false);                      \
+    } else if (accumulator_chains == 2 && !prefetch_codes) { \
+      LAUNCH_QPN4_LUT(SPLIT, 2, false);                      \
+    } else if (accumulator_chains == 1) {                    \
+      LAUNCH_QPN4_LUT(SPLIT, 1, true);                       \
+    } else {                                                 \
+      LAUNCH_QPN4_LUT(SPLIT, 2, true);                       \
+    }                                                        \
   } while (0)
   if (split_k == 4) {
     DISPATCH_QPN4_LUT(4);
@@ -911,8 +900,7 @@ void nvfp4_qpn4_gated_scale_code_sm70_out(
   TORCH_CHECK(k > 0 && k % 128 == 0 && hidden > 0 && hidden % 32 == 0,
               "nvfp4_qpn4_gated_scale_code_sm70_out: shape alignment "
               "mismatch");
-  TORCH_CHECK(codes.numel() == k * n / 2 &&
-                  scale_codes.numel() == k * n / 16,
+  TORCH_CHECK(codes.numel() == k * n / 2 && scale_codes.numel() == k * n / 16,
               "nvfp4_qpn4_gated_scale_code_sm70_out: packed tensor size "
               "mismatch");
   TORCH_CHECK(split_k == 4 || split_k == 8 || split_k == 10 || split_k == 16,
@@ -933,23 +921,22 @@ void nvfp4_qpn4_gated_scale_code_sm70_out(
       reinterpret_cast<const half*>(input.data_ptr<at::Half>());
   auto* output_ptr = reinterpret_cast<half*>(out.data_ptr<at::Half>());
 
-#define LAUNCH_QPN4_GATED_LUT(SPLIT, NACC, PREFETCH)                   \
-  launch_qpn4_gated<SPLIT, NACC, PREFETCH, true>(                      \
+#define LAUNCH_QPN4_GATED_LUT(SPLIT, NACC, PREFETCH)                       \
+  launch_qpn4_gated<SPLIT, NACC, PREFETCH, true>(                          \
       code_ptr, scale_code_ptr, split_scale.hi, split_scale.lo, input_ptr, \
-      output_ptr,                                                       \
-      static_cast<int>(hidden), static_cast<int>(k),                    \
+      output_ptr, static_cast<int>(hidden), static_cast<int>(k),           \
       static_cast<int>(m), stream)
-#define DISPATCH_QPN4_GATED_LUT(SPLIT)                        \
-  do {                                                        \
-    if (accumulator_chains == 1 && !prefetch_codes) {         \
-      LAUNCH_QPN4_GATED_LUT(SPLIT, 1, false);                 \
-    } else if (accumulator_chains == 2 && !prefetch_codes) {  \
-      LAUNCH_QPN4_GATED_LUT(SPLIT, 2, false);                 \
-    } else if (accumulator_chains == 1) {                     \
-      LAUNCH_QPN4_GATED_LUT(SPLIT, 1, true);                  \
-    } else {                                                  \
-      LAUNCH_QPN4_GATED_LUT(SPLIT, 2, true);                  \
-    }                                                         \
+#define DISPATCH_QPN4_GATED_LUT(SPLIT)                       \
+  do {                                                       \
+    if (accumulator_chains == 1 && !prefetch_codes) {        \
+      LAUNCH_QPN4_GATED_LUT(SPLIT, 1, false);                \
+    } else if (accumulator_chains == 2 && !prefetch_codes) { \
+      LAUNCH_QPN4_GATED_LUT(SPLIT, 2, false);                \
+    } else if (accumulator_chains == 1) {                    \
+      LAUNCH_QPN4_GATED_LUT(SPLIT, 1, true);                 \
+    } else {                                                 \
+      LAUNCH_QPN4_GATED_LUT(SPLIT, 2, true);                 \
+    }                                                        \
   } while (0)
   if (split_k == 4) {
     DISPATCH_QPN4_GATED_LUT(4);
@@ -965,21 +952,21 @@ void nvfp4_qpn4_gated_scale_code_sm70_out(
   C10_CUDA_KERNEL_LAUNCH_CHECK();
 }
 
-void nvfp4_qpn4_dispatch_sm70_out(
-    torch::Tensor out, int64_t dense_weight_ptr, torch::Tensor input,
-    torch::Tensor codes, torch::Tensor scales, double global_scale,
-    bool use_scale_code, bool gated_silu) {
+void nvfp4_qpn4_dispatch_sm70_out(torch::Tensor out, int64_t dense_weight_ptr,
+                                  torch::Tensor input, torch::Tensor codes,
+                                  torch::Tensor scales, double global_scale,
+                                  bool use_scale_code, bool gated_silu) {
   // Keep the dynamic-M decision inside the opaque operator so one compiled
   // graph can safely serve both M=1 decode and large-M prefill.
   if (input.size(0) == 1) {
     if (gated_silu) {
       TORCH_CHECK(use_scale_code,
                   "QPN4 gated decode requires E4M3 scale codes");
-      nvfp4_qpn4_gated_scale_code_sm70_out(
-          out, input, codes, scales, global_scale, 8, 2, false);
+      nvfp4_qpn4_gated_scale_code_sm70_out(out, input, codes, scales,
+                                           global_scale, 8, 2, false);
     } else if (use_scale_code) {
-      nvfp4_qpn4_gemm_scale_code_sm70_out(
-          out, input, codes, scales, global_scale, 17, 1, false);
+      nvfp4_qpn4_gemm_scale_code_sm70_out(out, input, codes, scales,
+                                          global_scale, 17, 1, false);
     } else {
       nvfp4_qpn4_gemm_sm70_out(out, input, codes, scales, 17, 1, false);
     }
@@ -991,10 +978,8 @@ void nvfp4_qpn4_dispatch_sm70_out(
 
 #ifdef VLLM_QPN4_STANDALONE
 TORCH_LIBRARY_FRAGMENT(_C, ops) {
-  ops.def(
-      "nvfp4_qpn4_prepare_sm70(Tensor qweight, Tensor scales) -> Tensor[]");
-  ops.impl("nvfp4_qpn4_prepare_sm70", torch::kCUDA,
-           &nvfp4_qpn4_prepare_sm70);
+  ops.def("nvfp4_qpn4_prepare_sm70(Tensor qweight, Tensor scales) -> Tensor[]");
+  ops.impl("nvfp4_qpn4_prepare_sm70", torch::kCUDA, &nvfp4_qpn4_prepare_sm70);
   ops.def(
       "nvfp4_qpn4_prepare_scale_code_sm70(Tensor qweight, Tensor scale_codes) "
       "-> Tensor[]");
@@ -1004,8 +989,7 @@ TORCH_LIBRARY_FRAGMENT(_C, ops) {
       "nvfp4_qpn4_gemm_sm70_out(Tensor(a!) out, Tensor input, Tensor codes, "
       "Tensor scales, int split_k, int accumulator_chains, "
       "bool prefetch_codes) -> ()");
-  ops.impl("nvfp4_qpn4_gemm_sm70_out", torch::kCUDA,
-           &nvfp4_qpn4_gemm_sm70_out);
+  ops.impl("nvfp4_qpn4_gemm_sm70_out", torch::kCUDA, &nvfp4_qpn4_gemm_sm70_out);
   ops.def(
       "nvfp4_qpn4_gated_sm70_out(Tensor(a!) out, Tensor input, Tensor codes, "
       "Tensor scales, int split_k, int accumulator_chains, "

--- a/csrc/sm70_turbomind/ops/nvfp4_qpn4_sm70.cu
+++ b/csrc/sm70_turbomind/ops/nvfp4_qpn4_sm70.cu
@@ -1,0 +1,1045 @@
+// SPDX-License-Identifier: Apache-2.0
+// Qwen3.8 NVFP4 M=1 decode kernels for NVIDIA Volta SM70.
+
+#include <torch/all.h>
+#include <torch/library.h>
+
+#include <ATen/cuda/Exceptions.h>
+#include <c10/cuda/CUDAGuard.h>
+#include <cuda_fp16.h>
+#include <cuda_runtime.h>
+
+namespace {
+
+constexpr int kPrepareThreads = 256;
+constexpr float kFp4Bias = 16384.0f;
+
+struct SplitHalfScale {
+  half hi;
+  half lo;
+};
+
+SplitHalfScale split_half_scale(float value) {
+  const half hi = __float2half_rn(value);
+  const half lo = __float2half_rn(value - __half2float(hi));
+  return {hi, lo};
+}
+
+__device__ __forceinline__ int qpn_col_from_lane(int lane) {
+  return ((lane >> 2) & 3) * 8 + (lane & 3) + ((lane & 16) ? 4 : 0);
+}
+
+__device__ __forceinline__ int logical_k_from_physical(int physical) {
+  const int local = physical & 7;
+  return (physical & 8) + ((local & 3) << 1) + (local >> 2);
+}
+
+__global__ void nvfp4_qpn4_prepack_codes_kernel(
+    uint8_t* __restrict__ codes, const uint8_t* __restrict__ qweight, int k,
+    int n) {
+  const size_t index =
+      static_cast<size_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  const size_t packed_numel = static_cast<size_t>(k) * n / 2;
+  if (index >= packed_numel) {
+    return;
+  }
+
+  const int physical_byte = static_cast<int>(index & 7);
+  size_t outer = index >> 3;
+  const int lane = static_cast<int>(outer & 31);
+  outer >>= 5;
+  const int groups_k16 = k >> 4;
+  const int group = static_cast<int>(outer % groups_k16);
+  const int tile = static_cast<int>(outer / groups_k16);
+  const int col = tile * 32 + qpn_col_from_lane(lane);
+  const int physical_k0 = physical_byte * 2;
+  const int logical_k0 = logical_k_from_physical(physical_k0);
+  const int logical_k1 = logical_k_from_physical(physical_k0 + 1);
+  const uint8_t lo = qweight[static_cast<size_t>(group * 16 + logical_k0) * n +
+                             col] &
+                     0x0fU;
+  const uint8_t hi = qweight[static_cast<size_t>(group * 16 + logical_k1) * n +
+                             col] &
+                     0x0fU;
+  codes[index] = lo | (hi << 4);
+}
+
+__global__ void nvfp4_qpn4_prepack_scales_kernel(
+    half* __restrict__ packed_scales, const half* __restrict__ scales, int k,
+    int n) {
+  const size_t index =
+      static_cast<size_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  const size_t numel = static_cast<size_t>(k / 16) * n;
+  if (index >= numel) {
+    return;
+  }
+  const int lane = static_cast<int>(index & 31);
+  size_t outer = index >> 5;
+  const int groups_k16 = k >> 4;
+  const int group = static_cast<int>(outer % groups_k16);
+  const int tile = static_cast<int>(outer / groups_k16);
+  const int col = tile * 32 + qpn_col_from_lane(lane);
+  packed_scales[index] = __hmul(
+      scales[static_cast<size_t>(group) * n + col],
+      __float2half_rn(kFp4Bias));
+}
+
+__global__ void nvfp4_qpn4_prepack_scale_codes_kernel(
+    uint8_t* __restrict__ packed_scale_codes,
+    const uint8_t* __restrict__ scale_codes, int k, int n) {
+  const size_t index =
+      static_cast<size_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  const size_t numel = static_cast<size_t>(k / 16) * n;
+  if (index >= numel) {
+    return;
+  }
+  const int lane = static_cast<int>(index & 31);
+  size_t outer = index >> 5;
+  const int groups_k16 = k >> 4;
+  const int group = static_cast<int>(outer % groups_k16);
+  const int tile = static_cast<int>(outer / groups_k16);
+  const int col = tile * 32 + qpn_col_from_lane(lane);
+  packed_scale_codes[index] =
+      scale_codes[static_cast<size_t>(group) * n + col];
+}
+
+__device__ __forceinline__ void fp4x8_to_half2x4(unsigned x, half2 out[4]) {
+  constexpr unsigned kSign = 0x80008000U;
+  constexpr unsigned kExponentMantissa = 0x0E000E00U;
+  unsigned values[4];
+  values[0] = ((x << 12) & kSign) | ((x << 9) & kExponentMantissa);
+  values[1] = ((x << 8) & kSign) | ((x << 5) & kExponentMantissa);
+  values[2] = ((x << 4) & kSign) | ((x << 1) & kExponentMantissa);
+  values[3] = ((x << 0) & kSign) | ((x >> 3) & kExponentMantissa);
+#pragma unroll
+  for (int i = 0; i < 4; ++i) {
+    out[i] = *reinterpret_cast<const half2*>(&values[i]);
+  }
+}
+
+__device__ __forceinline__ void fp4x16_to_half2x8(uint2 packed,
+                                                   half2 out[8]) {
+  fp4x8_to_half2x4(packed.x, out);
+  fp4x8_to_half2x4(packed.y, out + 4);
+}
+
+__device__ __forceinline__ half nvfp4_scale_code_to_half(
+    uint8_t scale_code, half scale_hi, half scale_lo) {
+  // NVFP4 group scales are positive, normal E4M3FN values. Adding the bias
+  // delta while shifting the E4M3 payload produces the exact FP16 value.
+  const unsigned half_bits =
+      (static_cast<unsigned>(scale_code) << 7U) + 0x2000U;
+  const half raw_scale = *reinterpret_cast<const half*>(&half_bits);
+  const half correction = __hmul(raw_scale, scale_lo);
+  return __hfma(raw_scale, scale_hi, correction);
+}
+
+template <bool UseScaleCode>
+__global__ void nvfp4_qpn4_dequantize_sm70_kernel(
+    half* __restrict__ output, const uint8_t* __restrict__ codes,
+    const void* __restrict__ packed_scales, half scale_hi, half scale_lo,
+    int n, int k) {
+  const size_t word_index =
+      static_cast<size_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  const size_t word_count = static_cast<size_t>(k) * n / 16;
+  if (word_index >= word_count) {
+    return;
+  }
+
+  const int lane = static_cast<int>(word_index & 31);
+  size_t outer = word_index >> 5;
+  const int groups_k16 = k >> 4;
+  const int group = static_cast<int>(outer % groups_k16);
+  const int tile = static_cast<int>(outer / groups_k16);
+  const int col = tile * 32 + qpn_col_from_lane(lane);
+  half scale;
+  if constexpr (UseScaleCode) {
+    scale = nvfp4_scale_code_to_half(
+        reinterpret_cast<const uint8_t*>(packed_scales)[word_index],
+        scale_hi, scale_lo);
+  } else {
+    scale = reinterpret_cast<const half*>(packed_scales)[word_index];
+  }
+  half2 weights[8];
+  fp4x16_to_half2x8(
+      reinterpret_cast<const uint2*>(codes)[word_index], weights);
+  const half2 scale2 = __halves2half2(scale, scale);
+#pragma unroll
+  for (int pair = 0; pair < 8; ++pair) {
+    const half2 value = __hmul2(weights[pair], scale2);
+    // fp4x8_to_half2x4 pairs nibbles (0,4), (1,5), (2,6), (3,7)
+    // within each 8-value word rather than adjacent physical K values.
+    const int physical_k0 = (pair & 3) + ((pair & 4) ? 8 : 0);
+    const int logical_k0 = logical_k_from_physical(physical_k0);
+    const int logical_k1 = logical_k_from_physical(physical_k0 + 4);
+    output[static_cast<size_t>(group * 16 + logical_k0) * n + col] =
+        __low2half(value);
+    output[static_cast<size_t>(group * 16 + logical_k1) * n + col] =
+        __high2half(value);
+  }
+}
+
+__global__ void nvfp4_qpn4_silu_and_mul_sm70_kernel(
+    half* __restrict__ output, const half* __restrict__ gate_up, int rows,
+    int hidden) {
+  const int row = blockIdx.x;
+  if (row >= rows) {
+    return;
+  }
+  const half* row_input = gate_up + static_cast<size_t>(row) * hidden * 2;
+  half* row_output = output + static_cast<size_t>(row) * hidden;
+  for (int col = threadIdx.x; col < hidden; col += blockDim.x) {
+    const float gate = __half2float(row_input[col]);
+    const float silu = gate / (1.0f + __expf(-gate));
+    row_output[col] = __hmul(__float2half(silu), row_input[hidden + col]);
+  }
+}
+
+#define VLLM_SM70_MMA_8N8K4(C, A0, A1, B0, B1)                      \
+  asm volatile(                                                     \
+      "mma.sync.aligned.m8n8k4.row.col.f32.f16.f16.f32 "            \
+      "{%0,%1,%2,%3,%4,%5,%6,%7}, {%8,%9}, {%10,%11}, "             \
+      "{%0,%1,%2,%3,%4,%5,%6,%7};\n"                                \
+      : "+f"(C[0]), "+f"(C[1]), "+f"(C[2]), "+f"(C[3]), "+f"(C[4]), \
+        "+f"(C[5]), "+f"(C[6]), "+f"(C[7])                          \
+      : "r"(A0), "r"(A1), "r"(B0), "r"(B1))
+
+template <int SplitK, int NAcc, bool PrefetchCodes, bool UseScaleCode>
+__global__ void nvfp4_qpn4_sm70_kernel(
+    const uint8_t* __restrict__ codes,
+    const void* __restrict__ packed_scales,
+    half scale_hi, half scale_lo, const half* __restrict__ input,
+    half* __restrict__ output, int n, int k, int m) {
+  __shared__ float partials[SplitK][32];
+
+  const int lane = threadIdx.x & 31;
+  const int warp = threadIdx.x >> 5;
+  const int tile = blockIdx.x;
+  const int quadpair = (lane >> 2) & 3;
+  const int row = (lane & 3) + ((lane & 16) ? 4 : 0);
+  const int groups_k16 = k >> 4;
+  const int groups_per_warp = groups_k16 / SplitK;
+  const int group_begin = warp * groups_per_warp;
+  const uint2* code_ptr = reinterpret_cast<const uint2*>(codes) +
+                          static_cast<size_t>(tile) * groups_k16 * 32 + lane;
+  const size_t scale_offset =
+      static_cast<size_t>(tile) * groups_k16 * 32 + lane;
+  const half* scale_ptr = reinterpret_cast<const half*>(packed_scales) +
+                          scale_offset;
+  const uint8_t* scale_code_ptr =
+      reinterpret_cast<const uint8_t*>(packed_scales) + scale_offset;
+
+  float accum[NAcc][8];
+#pragma unroll
+  for (int chain = 0; chain < NAcc; ++chain) {
+#pragma unroll
+    for (int i = 0; i < 8; ++i) {
+      accum[chain][i] = 0.0f;
+    }
+  }
+
+  uint2 prefetched = make_uint2(0, 0);
+  if constexpr (PrefetchCodes) {
+    prefetched = __ldcs(code_ptr + static_cast<size_t>(group_begin) * 32);
+  }
+
+#pragma unroll 4
+  for (int group = group_begin; group < group_begin + groups_per_warp;
+       ++group) {
+    const uint2 packed =
+        PrefetchCodes ? prefetched
+                      : __ldcs(code_ptr + static_cast<size_t>(group) * 32);
+    uint2 next = make_uint2(0, 0);
+    if constexpr (PrefetchCodes) {
+      if (group + 1 < group_begin + groups_per_warp) {
+        next = __ldcs(code_ptr + static_cast<size_t>(group + 1) * 32);
+      }
+    }
+    half2 weights[8];
+    fp4x16_to_half2x8(packed, weights);
+    half scale;
+    if constexpr (UseScaleCode) {
+      const uint8_t scale_code =
+          __ldg(scale_code_ptr + static_cast<size_t>(group) * 32);
+      scale = nvfp4_scale_code_to_half(scale_code, scale_hi, scale_lo);
+    } else {
+      scale = __ldg(scale_ptr + static_cast<size_t>(group) * 32);
+    }
+    const half2 scale2 = __halves2half2(scale, scale);
+#pragma unroll
+    for (int i = 0; i < 8; ++i) {
+      weights[i] = __hmul2(weights[i], scale2);
+    }
+
+    uint4 input01 = make_uint4(0, 0, 0, 0);
+    uint4 input23 = make_uint4(0, 0, 0, 0);
+    if (row < m) {
+      const half* input_row = input + static_cast<size_t>(row) * k;
+      input01 = *reinterpret_cast<const uint4*>(input_row + group * 16);
+      input23 = *reinterpret_cast<const uint4*>(input_row + group * 16 + 8);
+    }
+    const unsigned* a0 = reinterpret_cast<const unsigned*>(&input01);
+    const unsigned* a1 = reinterpret_cast<const unsigned*>(&input23);
+    const unsigned* b = reinterpret_cast<const unsigned*>(weights);
+    VLLM_SM70_MMA_8N8K4(accum[0], a0[0], a0[1], b[0], b[1]);
+    VLLM_SM70_MMA_8N8K4(accum[1 % NAcc], a0[2], a0[3], b[2], b[3]);
+    VLLM_SM70_MMA_8N8K4(accum[2 % NAcc], a1[0], a1[1], b[4], b[5]);
+    VLLM_SM70_MMA_8N8K4(accum[3 % NAcc], a1[2], a1[3], b[6], b[7]);
+    if constexpr (PrefetchCodes) {
+      prefetched = next;
+    }
+  }
+
+#pragma unroll
+  for (int chain = 1; chain < NAcc; ++chain) {
+#pragma unroll
+    for (int i = 0; i < 8; ++i) {
+      accum[0][i] += accum[chain][i];
+    }
+  }
+  if ((lane & 17) == 0) {
+#pragma unroll
+    for (int pair = 0; pair < 2; ++pair) {
+#pragma unroll
+      for (int offset = 0; offset < 2; ++offset) {
+        const int i = pair * 4 + offset;
+        const int output_col =
+            offset | (((lane >> 1) & 1) << 1) | (pair << 2);
+        partials[warp][quadpair * 8 + output_col] = accum[0][i];
+      }
+    }
+  }
+  __syncthreads();
+
+  for (int element = threadIdx.x; element < 32; element += blockDim.x) {
+    float value = 0.0f;
+#pragma unroll
+    for (int k_warp = 0; k_warp < SplitK; ++k_warp) {
+      value += partials[k_warp][element];
+    }
+    output[tile * 32 + element] = __float2half(value);
+  }
+}
+
+template <int SplitK, int NAcc, bool PrefetchCodes, bool UseScaleCode>
+__global__ void nvfp4_qpn4_gated_sm70_kernel(
+    const uint8_t* __restrict__ codes,
+    const void* __restrict__ packed_scales,
+    half scale_hi, half scale_lo, const half* __restrict__ input,
+    half* __restrict__ output, int hidden, int k, int m) {
+  __shared__ float partials[2][SplitK][32];
+
+  const int lane = threadIdx.x & 31;
+  const int warp_in_block = threadIdx.x >> 5;
+  const int projection = warp_in_block / SplitK;
+  const int warp = warp_in_block - projection * SplitK;
+  const int hidden_tiles = hidden >> 5;
+  const int tile = blockIdx.x + projection * hidden_tiles;
+  const int quadpair = (lane >> 2) & 3;
+  const int row = (lane & 3) + ((lane & 16) ? 4 : 0);
+  const int groups_k16 = k >> 4;
+  const int groups_per_warp = groups_k16 / SplitK;
+  const int group_begin = warp * groups_per_warp;
+  const uint2* code_ptr = reinterpret_cast<const uint2*>(codes) +
+                          static_cast<size_t>(tile) * groups_k16 * 32 + lane;
+  const size_t scale_offset =
+      static_cast<size_t>(tile) * groups_k16 * 32 + lane;
+  const half* scale_ptr = reinterpret_cast<const half*>(packed_scales) +
+                          scale_offset;
+  const uint8_t* scale_code_ptr =
+      reinterpret_cast<const uint8_t*>(packed_scales) + scale_offset;
+
+  float accum[NAcc][8];
+#pragma unroll
+  for (int chain = 0; chain < NAcc; ++chain) {
+#pragma unroll
+    for (int i = 0; i < 8; ++i) {
+      accum[chain][i] = 0.0f;
+    }
+  }
+  uint2 prefetched = make_uint2(0, 0);
+  if constexpr (PrefetchCodes) {
+    prefetched = __ldcs(code_ptr + static_cast<size_t>(group_begin) * 32);
+  }
+
+#pragma unroll 4
+  for (int group = group_begin; group < group_begin + groups_per_warp;
+       ++group) {
+    const uint2 packed =
+        PrefetchCodes ? prefetched
+                      : __ldcs(code_ptr + static_cast<size_t>(group) * 32);
+    uint2 next = make_uint2(0, 0);
+    if constexpr (PrefetchCodes) {
+      if (group + 1 < group_begin + groups_per_warp) {
+        next = __ldcs(code_ptr + static_cast<size_t>(group + 1) * 32);
+      }
+    }
+    half2 weights[8];
+    fp4x16_to_half2x8(packed, weights);
+    half scale;
+    if constexpr (UseScaleCode) {
+      const uint8_t scale_code =
+          __ldg(scale_code_ptr + static_cast<size_t>(group) * 32);
+      scale = nvfp4_scale_code_to_half(scale_code, scale_hi, scale_lo);
+    } else {
+      scale = __ldg(scale_ptr + static_cast<size_t>(group) * 32);
+    }
+    const half2 scale2 = __halves2half2(scale, scale);
+#pragma unroll
+    for (int i = 0; i < 8; ++i) {
+      weights[i] = __hmul2(weights[i], scale2);
+    }
+
+    uint4 input01 = make_uint4(0, 0, 0, 0);
+    uint4 input23 = make_uint4(0, 0, 0, 0);
+    if (row < m) {
+      const half* input_row = input + static_cast<size_t>(row) * k;
+      input01 = *reinterpret_cast<const uint4*>(input_row + group * 16);
+      input23 = *reinterpret_cast<const uint4*>(input_row + group * 16 + 8);
+    }
+    const unsigned* a0 = reinterpret_cast<const unsigned*>(&input01);
+    const unsigned* a1 = reinterpret_cast<const unsigned*>(&input23);
+    const unsigned* b = reinterpret_cast<const unsigned*>(weights);
+    VLLM_SM70_MMA_8N8K4(accum[0], a0[0], a0[1], b[0], b[1]);
+    VLLM_SM70_MMA_8N8K4(accum[1 % NAcc], a0[2], a0[3], b[2], b[3]);
+    VLLM_SM70_MMA_8N8K4(accum[2 % NAcc], a1[0], a1[1], b[4], b[5]);
+    VLLM_SM70_MMA_8N8K4(accum[3 % NAcc], a1[2], a1[3], b[6], b[7]);
+    if constexpr (PrefetchCodes) {
+      prefetched = next;
+    }
+  }
+
+#pragma unroll
+  for (int chain = 1; chain < NAcc; ++chain) {
+#pragma unroll
+    for (int i = 0; i < 8; ++i) {
+      accum[0][i] += accum[chain][i];
+    }
+  }
+  if ((lane & 17) == 0) {
+#pragma unroll
+    for (int pair = 0; pair < 2; ++pair) {
+#pragma unroll
+      for (int offset = 0; offset < 2; ++offset) {
+        const int i = pair * 4 + offset;
+        const int output_col = offset | (((lane >> 1) & 1) << 1) | (pair << 2);
+        partials[projection][warp][quadpair * 8 + output_col] = accum[0][i];
+      }
+    }
+  }
+  __syncthreads();
+
+  for (int element = threadIdx.x; element < 32; element += blockDim.x) {
+    float gate = 0.0f;
+    float up = 0.0f;
+#pragma unroll
+    for (int k_warp = 0; k_warp < SplitK; ++k_warp) {
+      gate += partials[0][k_warp][element];
+      up += partials[1][k_warp][element];
+    }
+    const float silu = gate / (1.0f + __expf(-gate));
+    output[blockIdx.x * 32 + element] = __float2half(silu * up);
+  }
+}
+
+template <int SplitK, int NAcc, bool PrefetchCodes, bool UseScaleCode>
+void launch_qpn4(const uint8_t* codes, const void* scales,
+                 half scale_hi, half scale_lo, const half* input,
+                 half* output, int n, int k, int m, cudaStream_t stream) {
+  nvfp4_qpn4_sm70_kernel<SplitK, NAcc, PrefetchCodes, UseScaleCode>
+      <<<(n / 32), (32 * SplitK), 0, stream>>>(
+          codes, scales, scale_hi, scale_lo, input, output, n, k, m);
+}
+
+template <int SplitK, int NAcc, bool PrefetchCodes, bool UseScaleCode>
+void launch_qpn4_gated(const uint8_t* codes, const void* scales,
+                       half scale_hi, half scale_lo, const half* input,
+                       half* output, int hidden, int k, int m,
+                       cudaStream_t stream) {
+  nvfp4_qpn4_gated_sm70_kernel<SplitK, NAcc, PrefetchCodes, UseScaleCode>
+      <<<(hidden / 32), (64 * SplitK), 0, stream>>>(
+          codes, scales, scale_hi, scale_lo, input, output, hidden, k, m);
+}
+
+}  // namespace
+
+std::vector<torch::Tensor> nvfp4_qpn4_prepare_sm70(torch::Tensor qweight,
+                                                   torch::Tensor scales) {
+  TORCH_CHECK(qweight.is_cuda() && scales.is_cuda(),
+              "nvfp4_qpn4_prepare_sm70: tensors must be CUDA");
+  TORCH_CHECK(qweight.scalar_type() == torch::kUInt8 &&
+                  scales.scalar_type() == torch::kFloat16,
+              "nvfp4_qpn4_prepare_sm70: expected uint8 codes and FP16 scales");
+  TORCH_CHECK(qweight.dim() == 2 && scales.dim() == 2 &&
+                  qweight.is_contiguous() && scales.is_contiguous(),
+              "nvfp4_qpn4_prepare_sm70: tensors must be contiguous matrices");
+  TORCH_CHECK(qweight.get_device() == scales.get_device(),
+              "nvfp4_qpn4_prepare_sm70: tensors must share one device");
+  const int64_t k = qweight.size(0);
+  const int64_t n = qweight.size(1);
+  TORCH_CHECK(k > 0 && k % 128 == 0 && n > 0 && n % 32 == 0,
+              "nvfp4_qpn4_prepare_sm70: shape alignment mismatch");
+  TORCH_CHECK(scales.size(0) == k / 16 && scales.size(1) == n,
+              "nvfp4_qpn4_prepare_sm70: scale shape mismatch");
+
+  const at::cuda::OptionalCUDAGuard device_guard(device_of(qweight));
+  const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
+  auto packed_codes = torch::empty(
+      {k, n / 2},
+      torch::TensorOptions().device(qweight.device()).dtype(torch::kUInt8));
+  auto packed_scales = torch::empty_like(scales);
+  const int64_t code_numel = packed_codes.numel();
+  const int code_blocks = static_cast<int>(
+      (code_numel + kPrepareThreads - 1) / kPrepareThreads);
+  nvfp4_qpn4_prepack_codes_kernel<<<code_blocks, kPrepareThreads, 0, stream>>>(
+      packed_codes.data_ptr<uint8_t>(), qweight.data_ptr<uint8_t>(),
+      static_cast<int>(k), static_cast<int>(n));
+  const int64_t scale_numel = packed_scales.numel();
+  const int scale_blocks = static_cast<int>(
+      (scale_numel + kPrepareThreads - 1) / kPrepareThreads);
+  nvfp4_qpn4_prepack_scales_kernel<<<scale_blocks, kPrepareThreads, 0, stream>>>(
+      reinterpret_cast<half*>(packed_scales.data_ptr<at::Half>()),
+      reinterpret_cast<const half*>(scales.data_ptr<at::Half>()),
+      static_cast<int>(k), static_cast<int>(n));
+  C10_CUDA_KERNEL_LAUNCH_CHECK();
+  return {packed_codes, packed_scales};
+}
+
+std::vector<torch::Tensor> nvfp4_qpn4_prepare_scale_code_sm70(
+    torch::Tensor qweight, torch::Tensor scale_codes) {
+  TORCH_CHECK(qweight.is_cuda() && scale_codes.is_cuda(),
+              "nvfp4_qpn4_prepare_scale_code_sm70: tensors must be CUDA");
+  TORCH_CHECK(qweight.scalar_type() == torch::kUInt8 &&
+                  scale_codes.scalar_type() ==
+                      at::ScalarType::Float8_e4m3fn,
+              "nvfp4_qpn4_prepare_scale_code_sm70: expected uint8 weights and "
+              "float8_e4m3fn scale codes");
+  TORCH_CHECK(qweight.dim() == 2 && scale_codes.dim() == 2 &&
+                  qweight.is_contiguous() && scale_codes.is_contiguous(),
+              "nvfp4_qpn4_prepare_scale_code_sm70: tensors must be contiguous "
+              "matrices");
+  TORCH_CHECK(qweight.get_device() == scale_codes.get_device(),
+              "nvfp4_qpn4_prepare_scale_code_sm70: tensors must share one "
+              "device");
+  const int64_t k = qweight.size(0);
+  const int64_t n = qweight.size(1);
+  TORCH_CHECK(k > 0 && k % 128 == 0 && n > 0 && n % 32 == 0,
+              "nvfp4_qpn4_prepare_scale_code_sm70: shape alignment mismatch");
+  TORCH_CHECK(scale_codes.size(0) == k / 16 && scale_codes.size(1) == n,
+              "nvfp4_qpn4_prepare_scale_code_sm70: scale shape mismatch");
+
+  const at::cuda::OptionalCUDAGuard device_guard(device_of(qweight));
+  const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
+  auto packed_codes = torch::empty(
+      {k, n / 2},
+      torch::TensorOptions().device(qweight.device()).dtype(torch::kUInt8));
+  auto packed_scale_codes = torch::empty(
+      {k / 16, n},
+      torch::TensorOptions().device(qweight.device()).dtype(torch::kUInt8));
+  const int64_t code_numel = packed_codes.numel();
+  const int code_blocks = static_cast<int>(
+      (code_numel + kPrepareThreads - 1) / kPrepareThreads);
+  nvfp4_qpn4_prepack_codes_kernel<<<code_blocks, kPrepareThreads, 0, stream>>>(
+      packed_codes.data_ptr<uint8_t>(), qweight.data_ptr<uint8_t>(),
+      static_cast<int>(k), static_cast<int>(n));
+  const int64_t scale_numel = packed_scale_codes.numel();
+  const int scale_blocks = static_cast<int>(
+      (scale_numel + kPrepareThreads - 1) / kPrepareThreads);
+  nvfp4_qpn4_prepack_scale_codes_kernel<<<scale_blocks, kPrepareThreads, 0,
+                                          stream>>>(
+      packed_scale_codes.data_ptr<uint8_t>(),
+      reinterpret_cast<const uint8_t*>(scale_codes.data_ptr()),
+      static_cast<int>(k), static_cast<int>(n));
+  C10_CUDA_KERNEL_LAUNCH_CHECK();
+  return {packed_codes, packed_scale_codes};
+}
+
+void nvfp4_qpn4_dequantize_sm70_out(
+    torch::Tensor out, torch::Tensor codes, torch::Tensor scales,
+    double global_scale, bool use_scale_code) {
+  TORCH_CHECK(out.is_cuda() && codes.is_cuda() && scales.is_cuda(),
+              "nvfp4_qpn4_dequantize_sm70_out: tensors must be CUDA");
+  TORCH_CHECK(out.scalar_type() == torch::kFloat16 &&
+                  codes.scalar_type() == torch::kUInt8,
+              "nvfp4_qpn4_dequantize_sm70_out: output must be FP16 and codes "
+              "must be uint8");
+  TORCH_CHECK(
+      (use_scale_code && scales.scalar_type() == torch::kUInt8) ||
+          (!use_scale_code && scales.scalar_type() == torch::kFloat16),
+      "nvfp4_qpn4_dequantize_sm70_out: scale dtype mismatch");
+  TORCH_CHECK(out.dim() == 2 && codes.dim() == 2 && scales.dim() == 2 &&
+                  out.is_contiguous() && codes.is_contiguous() &&
+                  scales.is_contiguous(),
+              "nvfp4_qpn4_dequantize_sm70_out: tensors must be contiguous "
+              "matrices");
+  TORCH_CHECK(out.get_device() == codes.get_device() &&
+                  out.get_device() == scales.get_device(),
+              "nvfp4_qpn4_dequantize_sm70_out: tensors must share one device");
+  const int64_t k = out.size(0);
+  const int64_t n = out.size(1);
+  TORCH_CHECK(k > 0 && k % 128 == 0 && n > 0 && n % 32 == 0,
+              "nvfp4_qpn4_dequantize_sm70_out: shape alignment mismatch");
+  TORCH_CHECK(codes.numel() == k * n / 2 &&
+                  scales.numel() == k * n / 16,
+              "nvfp4_qpn4_dequantize_sm70_out: packed tensor size mismatch");
+
+  const at::cuda::OptionalCUDAGuard device_guard(device_of(out));
+  const int64_t word_count = k * n / 16;
+  const int blocks = static_cast<int>(
+      (word_count + kPrepareThreads - 1) / kPrepareThreads);
+  const SplitHalfScale split_scale =
+      split_half_scale(static_cast<float>(global_scale) * kFp4Bias);
+  const half zero_scale = __float2half_rn(0.0f);
+  if (use_scale_code) {
+    nvfp4_qpn4_dequantize_sm70_kernel<true>
+        <<<blocks, kPrepareThreads, 0, at::cuda::getCurrentCUDAStream()>>>(
+            reinterpret_cast<half*>(out.data_ptr<at::Half>()),
+            codes.data_ptr<uint8_t>(), scales.data_ptr<uint8_t>(),
+            split_scale.hi, split_scale.lo, static_cast<int>(n),
+            static_cast<int>(k));
+  } else {
+    nvfp4_qpn4_dequantize_sm70_kernel<false>
+        <<<blocks, kPrepareThreads, 0, at::cuda::getCurrentCUDAStream()>>>(
+            reinterpret_cast<half*>(out.data_ptr<at::Half>()),
+            codes.data_ptr<uint8_t>(), scales.data_ptr<at::Half>(), zero_scale,
+            zero_scale, static_cast<int>(n), static_cast<int>(k));
+  }
+  C10_CUDA_KERNEL_LAUNCH_CHECK();
+}
+
+void nvfp4_qpn4_prefill_sm70_out(
+    torch::Tensor out, int64_t dense_weight_ptr, torch::Tensor input,
+    torch::Tensor codes, torch::Tensor scales, double global_scale,
+    bool use_scale_code, bool gated_silu) {
+  TORCH_CHECK(input.is_cuda() && out.is_cuda(),
+              "nvfp4_qpn4_prefill_sm70_out: input and output must be CUDA");
+  TORCH_CHECK(input.scalar_type() == torch::kFloat16 &&
+                  out.scalar_type() == torch::kFloat16,
+              "nvfp4_qpn4_prefill_sm70_out: input and output must be FP16");
+  TORCH_CHECK(input.dim() == 2 && out.dim() == 2 && dense_weight_ptr != 0 &&
+                  input.is_contiguous() && out.is_contiguous(),
+              "nvfp4_qpn4_prefill_sm70_out: invalid input or workspace");
+  const int64_t m = input.size(0);
+  const int64_t k = input.size(1);
+  TORCH_CHECK(codes.dim() == 2 && codes.size(0) == k,
+              "nvfp4_qpn4_prefill_sm70_out: code shape mismatch");
+  const int64_t n = codes.size(1) * 2;
+  TORCH_CHECK(out.size(0) == m && out.size(1) == (gated_silu ? n / 2 : n),
+              "nvfp4_qpn4_prefill_sm70_out: output shape mismatch");
+
+  auto dense_weight = torch::from_blob(
+      reinterpret_cast<void*>(dense_weight_ptr), {k, n}, input.options());
+  nvfp4_qpn4_dequantize_sm70_out(dense_weight, codes, scales, global_scale,
+                                  use_scale_code);
+  if (!gated_silu) {
+    at::mm_out(out, input, dense_weight);
+    return;
+  }
+
+  auto gate_up = at::mm(input, dense_weight);
+  constexpr int kThreads = 256;
+  nvfp4_qpn4_silu_and_mul_sm70_kernel
+      <<<static_cast<int>(m), kThreads, 0,
+         at::cuda::getCurrentCUDAStream()>>>(
+          reinterpret_cast<half*>(out.data_ptr<at::Half>()),
+          reinterpret_cast<const half*>(gate_up.data_ptr<at::Half>()),
+          static_cast<int>(m), static_cast<int>(n / 2));
+  C10_CUDA_KERNEL_LAUNCH_CHECK();
+}
+
+void nvfp4_qpn4_gemm_sm70_out(torch::Tensor out, torch::Tensor input,
+                              torch::Tensor codes, torch::Tensor scales,
+                              int64_t split_k, int64_t accumulator_chains,
+                              bool prefetch_codes) {
+  TORCH_CHECK(out.is_cuda() && input.is_cuda() && codes.is_cuda() &&
+                  scales.is_cuda(),
+              "nvfp4_qpn4_gemm_sm70_out: tensors must be CUDA");
+  TORCH_CHECK(out.scalar_type() == torch::kFloat16 &&
+                  input.scalar_type() == torch::kFloat16 &&
+                  codes.scalar_type() == torch::kUInt8 &&
+                  scales.scalar_type() == torch::kFloat16,
+              "nvfp4_qpn4_gemm_sm70_out: dtype mismatch");
+  TORCH_CHECK(out.is_contiguous() && input.is_contiguous() &&
+                  codes.is_contiguous() && scales.is_contiguous(),
+              "nvfp4_qpn4_gemm_sm70_out: tensors must be contiguous");
+  const int64_t m = input.size(0);
+  const int64_t k = input.size(1);
+  const int64_t n = out.size(1);
+  TORCH_CHECK(m == 1 && out.size(0) == 1,
+              "nvfp4_qpn4_gemm_sm70_out: M must be 1");
+  TORCH_CHECK(k > 0 && k % 128 == 0 && n > 0 && n % 32 == 0,
+              "nvfp4_qpn4_gemm_sm70_out: shape alignment mismatch");
+  TORCH_CHECK(codes.numel() == k * n / 2 && scales.numel() == k * n / 16,
+              "nvfp4_qpn4_gemm_sm70_out: packed tensor size mismatch");
+  TORCH_CHECK(split_k == 4 || split_k == 8 || split_k == 10 ||
+                  split_k == 16 || split_k == 17,
+              "nvfp4_qpn4_gemm_sm70_out: unsupported split_k");
+  TORCH_CHECK((k / 16) % split_k == 0,
+              "nvfp4_qpn4_gemm_sm70_out: invalid split_k for K");
+  TORCH_CHECK(accumulator_chains == 1 || accumulator_chains == 2,
+              "nvfp4_qpn4_gemm_sm70_out: accumulator chains must be 1 or 2");
+
+  const at::cuda::OptionalCUDAGuard device_guard(device_of(input));
+  const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
+  const auto* code_ptr = codes.data_ptr<uint8_t>();
+  const auto* scale_ptr =
+      reinterpret_cast<const half*>(scales.data_ptr<at::Half>());
+  const auto* input_ptr =
+      reinterpret_cast<const half*>(input.data_ptr<at::Half>());
+  auto* output_ptr = reinterpret_cast<half*>(out.data_ptr<at::Half>());
+  const half zero_scale = __float2half_rn(0.0f);
+
+#define LAUNCH_QPN4(SPLIT, NACC, PREFETCH)                              \
+  launch_qpn4<SPLIT, NACC, PREFETCH, false>(                            \
+      code_ptr, scale_ptr, zero_scale, zero_scale, input_ptr, output_ptr, \
+      static_cast<int>(n), static_cast<int>(k), static_cast<int>(m),     \
+      stream)
+#define DISPATCH_NACC_PREFETCH(SPLIT)                         \
+  do {                                                        \
+    if (accumulator_chains == 1 && !prefetch_codes) {         \
+      LAUNCH_QPN4(SPLIT, 1, false);                           \
+    } else if (accumulator_chains == 2 && !prefetch_codes) {  \
+      LAUNCH_QPN4(SPLIT, 2, false);                           \
+    } else if (accumulator_chains == 1) {                     \
+      LAUNCH_QPN4(SPLIT, 1, true);                            \
+    } else {                                                  \
+      LAUNCH_QPN4(SPLIT, 2, true);                            \
+    }                                                         \
+  } while (0)
+  if (split_k == 4) {
+    DISPATCH_NACC_PREFETCH(4);
+  } else if (split_k == 8) {
+    DISPATCH_NACC_PREFETCH(8);
+  } else if (split_k == 10) {
+    DISPATCH_NACC_PREFETCH(10);
+  } else if (split_k == 16) {
+    DISPATCH_NACC_PREFETCH(16);
+  } else {
+    DISPATCH_NACC_PREFETCH(17);
+  }
+#undef DISPATCH_NACC_PREFETCH
+#undef LAUNCH_QPN4
+  C10_CUDA_KERNEL_LAUNCH_CHECK();
+}
+
+void nvfp4_qpn4_gated_sm70_out(torch::Tensor out, torch::Tensor input,
+                               torch::Tensor codes, torch::Tensor scales,
+                               int64_t split_k, int64_t accumulator_chains,
+                               bool prefetch_codes) {
+  TORCH_CHECK(out.is_cuda() && input.is_cuda() && codes.is_cuda() &&
+                  scales.is_cuda(),
+              "nvfp4_qpn4_gated_sm70_out: tensors must be CUDA");
+  TORCH_CHECK(out.scalar_type() == torch::kFloat16 &&
+                  input.scalar_type() == torch::kFloat16 &&
+                  codes.scalar_type() == torch::kUInt8 &&
+                  scales.scalar_type() == torch::kFloat16,
+              "nvfp4_qpn4_gated_sm70_out: dtype mismatch");
+  TORCH_CHECK(out.is_contiguous() && input.is_contiguous() &&
+                  codes.is_contiguous() && scales.is_contiguous(),
+              "nvfp4_qpn4_gated_sm70_out: tensors must be contiguous");
+  const int64_t m = input.size(0);
+  const int64_t k = input.size(1);
+  const int64_t hidden = out.size(1);
+  const int64_t n = hidden * 2;
+  TORCH_CHECK(m == 1 && out.size(0) == 1,
+              "nvfp4_qpn4_gated_sm70_out: M must be 1");
+  TORCH_CHECK(k > 0 && k % 128 == 0 && hidden > 0 && hidden % 32 == 0,
+              "nvfp4_qpn4_gated_sm70_out: shape alignment mismatch");
+  TORCH_CHECK(codes.numel() == k * n / 2 && scales.numel() == k * n / 16,
+              "nvfp4_qpn4_gated_sm70_out: packed tensor size mismatch");
+  TORCH_CHECK(split_k == 4 || split_k == 8 || split_k == 10 || split_k == 16,
+              "nvfp4_qpn4_gated_sm70_out: unsupported split_k");
+  TORCH_CHECK((k / 16) % split_k == 0,
+              "nvfp4_qpn4_gated_sm70_out: invalid split_k for K");
+  TORCH_CHECK(accumulator_chains == 1 || accumulator_chains == 2,
+              "nvfp4_qpn4_gated_sm70_out: accumulator chains must be 1 or 2");
+
+  const at::cuda::OptionalCUDAGuard device_guard(device_of(input));
+  const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
+  const auto* code_ptr = codes.data_ptr<uint8_t>();
+  const auto* scale_ptr =
+      reinterpret_cast<const half*>(scales.data_ptr<at::Half>());
+  const auto* input_ptr =
+      reinterpret_cast<const half*>(input.data_ptr<at::Half>());
+  auto* output_ptr = reinterpret_cast<half*>(out.data_ptr<at::Half>());
+  const half zero_scale = __float2half_rn(0.0f);
+
+#define LAUNCH_QPN4_GATED(SPLIT, NACC, PREFETCH)                        \
+  launch_qpn4_gated<SPLIT, NACC, PREFETCH, false>(                      \
+      code_ptr, scale_ptr, zero_scale, zero_scale, input_ptr, output_ptr, \
+      static_cast<int>(hidden), static_cast<int>(k),                     \
+      static_cast<int>(m), stream)
+#define DISPATCH_GATED_NACC_PREFETCH(SPLIT)                   \
+  do {                                                        \
+    if (accumulator_chains == 1 && !prefetch_codes) {         \
+      LAUNCH_QPN4_GATED(SPLIT, 1, false);                     \
+    } else if (accumulator_chains == 2 && !prefetch_codes) {  \
+      LAUNCH_QPN4_GATED(SPLIT, 2, false);                     \
+    } else if (accumulator_chains == 1) {                     \
+      LAUNCH_QPN4_GATED(SPLIT, 1, true);                      \
+    } else {                                                  \
+      LAUNCH_QPN4_GATED(SPLIT, 2, true);                      \
+    }                                                         \
+  } while (0)
+  if (split_k == 4) {
+    DISPATCH_GATED_NACC_PREFETCH(4);
+  } else if (split_k == 8) {
+    DISPATCH_GATED_NACC_PREFETCH(8);
+  } else if (split_k == 10) {
+    DISPATCH_GATED_NACC_PREFETCH(10);
+  } else {
+    DISPATCH_GATED_NACC_PREFETCH(16);
+  }
+#undef DISPATCH_GATED_NACC_PREFETCH
+#undef LAUNCH_QPN4_GATED
+  C10_CUDA_KERNEL_LAUNCH_CHECK();
+}
+
+void nvfp4_qpn4_gemm_scale_code_sm70_out(
+    torch::Tensor out, torch::Tensor input, torch::Tensor codes,
+    torch::Tensor scale_codes, double global_scale, int64_t split_k,
+    int64_t accumulator_chains, bool prefetch_codes) {
+  TORCH_CHECK(out.is_cuda() && input.is_cuda() && codes.is_cuda() &&
+                  scale_codes.is_cuda(),
+              "nvfp4_qpn4_gemm_scale_code_sm70_out: tensors must be CUDA");
+  TORCH_CHECK(out.scalar_type() == torch::kFloat16 &&
+                  input.scalar_type() == torch::kFloat16 &&
+                  codes.scalar_type() == torch::kUInt8 &&
+                  scale_codes.scalar_type() == torch::kUInt8,
+              "nvfp4_qpn4_gemm_scale_code_sm70_out: dtype mismatch");
+  TORCH_CHECK(out.is_contiguous() && input.is_contiguous() &&
+                  codes.is_contiguous() && scale_codes.is_contiguous(),
+              "nvfp4_qpn4_gemm_scale_code_sm70_out: tensors must be "
+              "contiguous");
+  TORCH_CHECK(out.get_device() == input.get_device() &&
+                  out.get_device() == codes.get_device() &&
+                  out.get_device() == scale_codes.get_device(),
+              "nvfp4_qpn4_gemm_scale_code_sm70_out: tensors must share one "
+              "device");
+  const int64_t m = input.size(0);
+  const int64_t k = input.size(1);
+  const int64_t n = out.size(1);
+  TORCH_CHECK(m == 1 && out.size(0) == 1,
+              "nvfp4_qpn4_gemm_scale_code_sm70_out: M must be 1");
+  TORCH_CHECK(k > 0 && k % 128 == 0 && n > 0 && n % 32 == 0,
+              "nvfp4_qpn4_gemm_scale_code_sm70_out: shape alignment "
+              "mismatch");
+  TORCH_CHECK(codes.numel() == k * n / 2 &&
+                  scale_codes.numel() == k * n / 16,
+              "nvfp4_qpn4_gemm_scale_code_sm70_out: packed tensor size "
+              "mismatch");
+  TORCH_CHECK(split_k == 4 || split_k == 8 || split_k == 10 ||
+                  split_k == 16 || split_k == 17,
+              "nvfp4_qpn4_gemm_scale_code_sm70_out: unsupported split_k");
+  TORCH_CHECK((k / 16) % split_k == 0,
+              "nvfp4_qpn4_gemm_scale_code_sm70_out: invalid split_k for K");
+  TORCH_CHECK(accumulator_chains == 1 || accumulator_chains == 2,
+              "nvfp4_qpn4_gemm_scale_code_sm70_out: accumulator chains must "
+              "be 1 or 2");
+
+  const at::cuda::OptionalCUDAGuard device_guard(device_of(input));
+  const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
+  const auto* code_ptr = codes.data_ptr<uint8_t>();
+  const auto* scale_code_ptr = scale_codes.data_ptr<uint8_t>();
+  const SplitHalfScale split_scale =
+      split_half_scale(static_cast<float>(global_scale) * kFp4Bias);
+  const auto* input_ptr =
+      reinterpret_cast<const half*>(input.data_ptr<at::Half>());
+  auto* output_ptr = reinterpret_cast<half*>(out.data_ptr<at::Half>());
+
+#define LAUNCH_QPN4_LUT(SPLIT, NACC, PREFETCH)                         \
+  launch_qpn4<SPLIT, NACC, PREFETCH, true>(                            \
+      code_ptr, scale_code_ptr, split_scale.hi, split_scale.lo, input_ptr, \
+      output_ptr,                                                       \
+      static_cast<int>(n), static_cast<int>(k), static_cast<int>(m),    \
+      stream)
+#define DISPATCH_QPN4_LUT(SPLIT)                              \
+  do {                                                        \
+    if (accumulator_chains == 1 && !prefetch_codes) {         \
+      LAUNCH_QPN4_LUT(SPLIT, 1, false);                       \
+    } else if (accumulator_chains == 2 && !prefetch_codes) {  \
+      LAUNCH_QPN4_LUT(SPLIT, 2, false);                       \
+    } else if (accumulator_chains == 1) {                     \
+      LAUNCH_QPN4_LUT(SPLIT, 1, true);                        \
+    } else {                                                  \
+      LAUNCH_QPN4_LUT(SPLIT, 2, true);                        \
+    }                                                         \
+  } while (0)
+  if (split_k == 4) {
+    DISPATCH_QPN4_LUT(4);
+  } else if (split_k == 8) {
+    DISPATCH_QPN4_LUT(8);
+  } else if (split_k == 10) {
+    DISPATCH_QPN4_LUT(10);
+  } else if (split_k == 16) {
+    DISPATCH_QPN4_LUT(16);
+  } else {
+    DISPATCH_QPN4_LUT(17);
+  }
+#undef DISPATCH_QPN4_LUT
+#undef LAUNCH_QPN4_LUT
+  C10_CUDA_KERNEL_LAUNCH_CHECK();
+}
+
+void nvfp4_qpn4_gated_scale_code_sm70_out(
+    torch::Tensor out, torch::Tensor input, torch::Tensor codes,
+    torch::Tensor scale_codes, double global_scale, int64_t split_k,
+    int64_t accumulator_chains, bool prefetch_codes) {
+  TORCH_CHECK(out.is_cuda() && input.is_cuda() && codes.is_cuda() &&
+                  scale_codes.is_cuda(),
+              "nvfp4_qpn4_gated_scale_code_sm70_out: tensors must be CUDA");
+  TORCH_CHECK(out.scalar_type() == torch::kFloat16 &&
+                  input.scalar_type() == torch::kFloat16 &&
+                  codes.scalar_type() == torch::kUInt8 &&
+                  scale_codes.scalar_type() == torch::kUInt8,
+              "nvfp4_qpn4_gated_scale_code_sm70_out: dtype mismatch");
+  TORCH_CHECK(out.is_contiguous() && input.is_contiguous() &&
+                  codes.is_contiguous() && scale_codes.is_contiguous(),
+              "nvfp4_qpn4_gated_scale_code_sm70_out: tensors must be "
+              "contiguous");
+  TORCH_CHECK(out.get_device() == input.get_device() &&
+                  out.get_device() == codes.get_device() &&
+                  out.get_device() == scale_codes.get_device(),
+              "nvfp4_qpn4_gated_scale_code_sm70_out: tensors must share one "
+              "device");
+  const int64_t m = input.size(0);
+  const int64_t k = input.size(1);
+  const int64_t hidden = out.size(1);
+  const int64_t n = hidden * 2;
+  TORCH_CHECK(m == 1 && out.size(0) == 1,
+              "nvfp4_qpn4_gated_scale_code_sm70_out: M must be 1");
+  TORCH_CHECK(k > 0 && k % 128 == 0 && hidden > 0 && hidden % 32 == 0,
+              "nvfp4_qpn4_gated_scale_code_sm70_out: shape alignment "
+              "mismatch");
+  TORCH_CHECK(codes.numel() == k * n / 2 &&
+                  scale_codes.numel() == k * n / 16,
+              "nvfp4_qpn4_gated_scale_code_sm70_out: packed tensor size "
+              "mismatch");
+  TORCH_CHECK(split_k == 4 || split_k == 8 || split_k == 10 || split_k == 16,
+              "nvfp4_qpn4_gated_scale_code_sm70_out: unsupported split_k");
+  TORCH_CHECK((k / 16) % split_k == 0,
+              "nvfp4_qpn4_gated_scale_code_sm70_out: invalid split_k for K");
+  TORCH_CHECK(accumulator_chains == 1 || accumulator_chains == 2,
+              "nvfp4_qpn4_gated_scale_code_sm70_out: accumulator chains "
+              "must be 1 or 2");
+
+  const at::cuda::OptionalCUDAGuard device_guard(device_of(input));
+  const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
+  const auto* code_ptr = codes.data_ptr<uint8_t>();
+  const auto* scale_code_ptr = scale_codes.data_ptr<uint8_t>();
+  const SplitHalfScale split_scale =
+      split_half_scale(static_cast<float>(global_scale) * kFp4Bias);
+  const auto* input_ptr =
+      reinterpret_cast<const half*>(input.data_ptr<at::Half>());
+  auto* output_ptr = reinterpret_cast<half*>(out.data_ptr<at::Half>());
+
+#define LAUNCH_QPN4_GATED_LUT(SPLIT, NACC, PREFETCH)                   \
+  launch_qpn4_gated<SPLIT, NACC, PREFETCH, true>(                      \
+      code_ptr, scale_code_ptr, split_scale.hi, split_scale.lo, input_ptr, \
+      output_ptr,                                                       \
+      static_cast<int>(hidden), static_cast<int>(k),                    \
+      static_cast<int>(m), stream)
+#define DISPATCH_QPN4_GATED_LUT(SPLIT)                        \
+  do {                                                        \
+    if (accumulator_chains == 1 && !prefetch_codes) {         \
+      LAUNCH_QPN4_GATED_LUT(SPLIT, 1, false);                 \
+    } else if (accumulator_chains == 2 && !prefetch_codes) {  \
+      LAUNCH_QPN4_GATED_LUT(SPLIT, 2, false);                 \
+    } else if (accumulator_chains == 1) {                     \
+      LAUNCH_QPN4_GATED_LUT(SPLIT, 1, true);                  \
+    } else {                                                  \
+      LAUNCH_QPN4_GATED_LUT(SPLIT, 2, true);                  \
+    }                                                         \
+  } while (0)
+  if (split_k == 4) {
+    DISPATCH_QPN4_GATED_LUT(4);
+  } else if (split_k == 8) {
+    DISPATCH_QPN4_GATED_LUT(8);
+  } else if (split_k == 10) {
+    DISPATCH_QPN4_GATED_LUT(10);
+  } else {
+    DISPATCH_QPN4_GATED_LUT(16);
+  }
+#undef DISPATCH_QPN4_GATED_LUT
+#undef LAUNCH_QPN4_GATED_LUT
+  C10_CUDA_KERNEL_LAUNCH_CHECK();
+}
+
+void nvfp4_qpn4_dispatch_sm70_out(
+    torch::Tensor out, int64_t dense_weight_ptr, torch::Tensor input,
+    torch::Tensor codes, torch::Tensor scales, double global_scale,
+    bool use_scale_code, bool gated_silu) {
+  // Keep the dynamic-M decision inside the opaque operator so one compiled
+  // graph can safely serve both M=1 decode and large-M prefill.
+  if (input.size(0) == 1) {
+    if (gated_silu) {
+      TORCH_CHECK(use_scale_code,
+                  "QPN4 gated decode requires E4M3 scale codes");
+      nvfp4_qpn4_gated_scale_code_sm70_out(
+          out, input, codes, scales, global_scale, 8, 2, false);
+    } else if (use_scale_code) {
+      nvfp4_qpn4_gemm_scale_code_sm70_out(
+          out, input, codes, scales, global_scale, 17, 1, false);
+    } else {
+      nvfp4_qpn4_gemm_sm70_out(out, input, codes, scales, 17, 1, false);
+    }
+    return;
+  }
+  nvfp4_qpn4_prefill_sm70_out(out, dense_weight_ptr, input, codes, scales,
+                              global_scale, use_scale_code, gated_silu);
+}
+
+#ifdef VLLM_QPN4_STANDALONE
+TORCH_LIBRARY_FRAGMENT(_C, ops) {
+  ops.def(
+      "nvfp4_qpn4_prepare_sm70(Tensor qweight, Tensor scales) -> Tensor[]");
+  ops.impl("nvfp4_qpn4_prepare_sm70", torch::kCUDA,
+           &nvfp4_qpn4_prepare_sm70);
+  ops.def(
+      "nvfp4_qpn4_prepare_scale_code_sm70(Tensor qweight, Tensor scale_codes) "
+      "-> Tensor[]");
+  ops.impl("nvfp4_qpn4_prepare_scale_code_sm70", torch::kCUDA,
+           &nvfp4_qpn4_prepare_scale_code_sm70);
+  ops.def(
+      "nvfp4_qpn4_gemm_sm70_out(Tensor(a!) out, Tensor input, Tensor codes, "
+      "Tensor scales, int split_k, int accumulator_chains, "
+      "bool prefetch_codes) -> ()");
+  ops.impl("nvfp4_qpn4_gemm_sm70_out", torch::kCUDA,
+           &nvfp4_qpn4_gemm_sm70_out);
+  ops.def(
+      "nvfp4_qpn4_gated_sm70_out(Tensor(a!) out, Tensor input, Tensor codes, "
+      "Tensor scales, int split_k, int accumulator_chains, "
+      "bool prefetch_codes) -> ()");
+  ops.impl("nvfp4_qpn4_gated_sm70_out", torch::kCUDA,
+           &nvfp4_qpn4_gated_sm70_out);
+  ops.def(
+      "nvfp4_qpn4_gemm_scale_code_sm70_out(Tensor(a!) out, Tensor input, "
+      "Tensor codes, Tensor scale_codes, float global_scale, int split_k, "
+      "int accumulator_chains, bool prefetch_codes) -> ()");
+  ops.impl("nvfp4_qpn4_gemm_scale_code_sm70_out", torch::kCUDA,
+           &nvfp4_qpn4_gemm_scale_code_sm70_out);
+  ops.def(
+      "nvfp4_qpn4_gated_scale_code_sm70_out(Tensor(a!) out, Tensor input, "
+      "Tensor codes, Tensor scale_codes, float global_scale, int split_k, "
+      "int accumulator_chains, bool prefetch_codes) -> ()");
+  ops.impl("nvfp4_qpn4_gated_scale_code_sm70_out", torch::kCUDA,
+           &nvfp4_qpn4_gated_scale_code_sm70_out);
+  ops.def(
+      "nvfp4_qpn4_dequantize_sm70_out(Tensor(a!) out, Tensor codes, Tensor "
+      "scales, float global_scale, bool use_scale_code) -> ()");
+  ops.impl("nvfp4_qpn4_dequantize_sm70_out", torch::kCUDA,
+           &nvfp4_qpn4_dequantize_sm70_out);
+  ops.def(
+      "nvfp4_qpn4_prefill_sm70_out(Tensor(a!) out, int dense_weight_ptr, "
+      "Tensor input, Tensor codes, Tensor scales, float global_scale, bool "
+      "use_scale_code, bool gated_silu) -> ()");
+  ops.impl("nvfp4_qpn4_prefill_sm70_out", torch::kCUDA,
+           &nvfp4_qpn4_prefill_sm70_out);
+  ops.def(
+      "nvfp4_qpn4_dispatch_sm70_out(Tensor(a!) out, int dense_weight_ptr, "
+      "Tensor input, Tensor codes, Tensor scales, float global_scale, bool "
+      "use_scale_code, bool gated_silu) -> ()");
+  ops.impl("nvfp4_qpn4_dispatch_sm70_out", torch::kCUDA,
+           &nvfp4_qpn4_dispatch_sm70_out);
+}
+#endif

--- a/csrc/sm70_turbomind/ops/sm70_top20_philox_fragment.cpp
+++ b/csrc/sm70_turbomind/ops/sm70_top20_philox_fragment.cpp
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+#include <torch/all.h>
+#include <torch/library.h>
+
+#include <optional>
+
+void sm70_sample_sorted_top20_philox_out(
+    torch::Tensor sampled_token_out, torch::Tensor sparse_ids_out,
+    torch::Tensor sparse_probs_out, torch::Tensor top_values,
+    torch::Tensor top_indices, const std::optional<at::Generator>& generator,
+    int64_t vocab_size, double top_p);
+
+void sm70_sample_sorted_top20_philox_token_out(
+    torch::Tensor sampled_token_out, torch::Tensor top_values,
+    torch::Tensor top_indices, const std::optional<at::Generator>& generator,
+    int64_t vocab_size, double top_p);
+
+void sm70_sample_chunked_top20_philox_token_out(
+    torch::Tensor sampled_token_out, torch::Tensor global_values,
+    torch::Tensor local_indices, torch::Tensor global_positions,
+    const std::optional<at::Generator>& generator, int64_t vocab_size,
+    double top_p, int64_t chunk_size);
+
+// Keep these registrations in a wheel-safe sidecar. Adding the sampler must
+// not relink or perturb the speed- and quality-frozen primary vllm._C module;
+// Python loads this fragment only for the explicitly admitted SM70 route.
+TORCH_LIBRARY_FRAGMENT(_C, ops) {
+  ops.def(
+      "sm70_sample_sorted_top20_philox_out(Tensor(a!) sampled_token_out, "
+      "Tensor(b!) sparse_ids_out, Tensor(c!) sparse_probs_out, "
+      "Tensor top_values, Tensor top_indices, Generator? generator, "
+      "int vocab_size, float top_p) -> ()");
+  ops.impl("sm70_sample_sorted_top20_philox_out", torch::kCUDA,
+           &sm70_sample_sorted_top20_philox_out);
+
+  ops.def(
+      "sm70_sample_sorted_top20_philox_token_out(Tensor(a!) "
+      "sampled_token_out, Tensor top_values, Tensor top_indices, "
+      "Generator? generator, int vocab_size, float top_p) -> ()");
+  ops.impl("sm70_sample_sorted_top20_philox_token_out", torch::kCUDA,
+           &sm70_sample_sorted_top20_philox_token_out);
+
+  ops.def(
+      "sm70_sample_chunked_top20_philox_token_out(Tensor(a!) "
+      "sampled_token_out, Tensor global_values, Tensor local_indices, "
+      "Tensor global_positions, Generator? generator, int vocab_size, "
+      "float top_p, int chunk_size) -> ()");
+  ops.impl("sm70_sample_chunked_top20_philox_token_out", torch::kCUDA,
+           &sm70_sample_chunked_top20_philox_token_out);
+}

--- a/csrc/sm70_turbomind/ops/sm70_top20_philox_sampler.cu
+++ b/csrc/sm70_turbomind/ops/sm70_top20_philox_sampler.cu
@@ -1,0 +1,293 @@
+// SPDX-License-Identifier: Apache-2.0
+// Exact sparse Philox sampling for the SM70 Qwen3.8 batch-one top-20 route.
+
+#include <torch/all.h>
+
+#include <ATen/core/TransformationHelper.h>
+#include <ATen/cuda/CUDAContext.h>
+#include <ATen/cuda/CUDAGeneratorImpl.h>
+#include <ATen/cuda/Exceptions.h>
+#include <ATen/cuda/PhiloxUtils.cuh>
+#include <c10/cuda/CUDAGuard.h>
+#include <curand_kernel.h>
+#include <cuda_runtime.h>
+
+#include <algorithm>
+#include <cfloat>
+#include <cstdint>
+#include <mutex>
+#include <optional>
+
+namespace {
+
+constexpr int kTopK = 20;
+constexpr int kWarpSize = 32;
+constexpr int kNativeBlockSize = 256;
+constexpr int kNativeUnroll = 4;
+constexpr int kMaxGeneratorOffsetsPerCurandCall = 4;
+
+__device__ __forceinline__ bool top1_better(float value, int token,
+                                             float best_value, int best_token) {
+  return value > best_value ||
+         (value == best_value && token < best_token);
+}
+
+__device__ __forceinline__ float native_exponential_for_index(
+    int64_t index, int64_t total_threads, at::PhiloxCudaState philox_args) {
+  auto [seed, offset] = at::cuda::philox::unpack(philox_args);
+  const int64_t values_per_round = total_threads * kNativeUnroll;
+  const int64_t round = index / values_per_round;
+  const int64_t within_round = index - round * values_per_round;
+  const uint64_t subsequence =
+      static_cast<uint64_t>(within_round % total_threads);
+  const int component = static_cast<int>(within_round / total_threads);
+
+  curandStatePhilox4_32_10_t state;
+  curand_init(seed, subsequence, offset, &state);
+  float4 random = make_float4(0.f, 0.f, 0.f, 0.f);
+  for (int64_t iteration = 0; iteration <= round; ++iteration) {
+    random = curand_uniform4(&state);
+  }
+  const float uniform = reinterpret_cast<const float*>(&random)[component];
+  return at::transformation::exponential<float>(uniform, 1.f);
+}
+
+template <bool EmitMetadata, bool ChunkedIndices>
+__global__ void sm70_sample_sorted_top20_philox_kernel(
+    int64_t* sampled_token_out, int64_t* sparse_ids_out,
+    float* sparse_probs_out, const float* top_values,
+    const int64_t* top_indices, const int64_t* local_indices,
+    const int64_t* global_positions, int64_t local_candidate_count,
+    int chunk_size, int64_t vocab_size, int64_t total_threads, float top_p,
+    at::PhiloxCudaState philox_args) {
+  const int lane = threadIdx.x;
+  __shared__ float selected_values[kTopK];
+  __shared__ int64_t selected_ids[kTopK];
+  __shared__ float selected_random[kTopK];
+
+  int64_t lane_token64 = -1;
+  if (lane < kTopK) {
+    if (ChunkedIndices) {
+      const int64_t position = global_positions[lane];
+      if (position >= 0 && position < local_candidate_count) {
+        const int64_t local_index = local_indices[position];
+        if (local_index >= 0 && local_index < chunk_size) {
+          lane_token64 =
+              (position / kTopK) * chunk_size + local_index;
+        }
+      }
+    } else {
+      lane_token64 = top_indices[lane];
+    }
+  }
+  const bool lane_valid = lane < kTopK && lane_token64 >= 0 &&
+                          lane_token64 < vocab_size;
+  const int lane_token = lane_valid ? static_cast<int>(lane_token64) : -1;
+  const float lane_raw_value = lane < kTopK ? top_values[lane] : -FLT_MAX;
+  const float lane_value =
+      isfinite(lane_raw_value) ? lane_raw_value : -FLT_MAX;
+  const int valid_count = __popc(__ballot_sync(0xffffffff, lane_valid));
+  int lane_rank = 0;
+#pragma unroll
+  for (int source = 0; source < kTopK; ++source) {
+    const int other_token = __shfl_sync(0xffffffff, lane_token, source);
+    const float other_value = __shfl_sync(0xffffffff, lane_value, source);
+    if (lane_valid && other_token >= 0 && other_token < vocab_size &&
+        top1_better(other_value, other_token, lane_value, lane_token)) {
+      ++lane_rank;
+    }
+  }
+  if (lane_valid) {
+    selected_values[lane_rank] = lane_value;
+    selected_ids[lane_rank] = static_cast<int64_t>(lane_token);
+  } else if (lane >= valid_count && lane < kTopK) {
+    // Preserve the prior fallback for malformed candidate ids.
+    selected_values[lane] = -FLT_MAX;
+    selected_ids[lane] = lane;
+  }
+  __syncwarp();
+
+  if (lane < kTopK) {
+    selected_random[lane] = native_exponential_for_index(
+        selected_ids[lane], total_threads, philox_args);
+  }
+  __syncwarp();
+
+  if (lane == 0) {
+    const float max_value = selected_values[0];
+    float probability_sum = 0.f;
+    for (int index = 0; index < kTopK; ++index) {
+      const float probability = __expf(selected_values[index] - max_value);
+      selected_values[index] = probability;
+      probability_sum += probability;
+    }
+
+    float cumulative_probability = 0.f;
+    float filtered_probability_sum = 0.f;
+    for (int index = 0; index < kTopK; ++index) {
+      const float probability = selected_values[index] / probability_sum;
+      const bool keep = index == 0 || cumulative_probability < top_p;
+      cumulative_probability += probability;
+      selected_values[index] = keep ? probability : 0.f;
+      filtered_probability_sum += selected_values[index];
+    }
+
+    float best_score = -FLT_MAX;
+    int64_t sampled_token = selected_ids[0];
+    for (int index = 0; index < kTopK; ++index) {
+      const float probability =
+          selected_values[index] / filtered_probability_sum;
+      if (EmitMetadata) {
+        sparse_probs_out[index] = probability;
+        sparse_ids_out[index] = selected_ids[index];
+      }
+      const float score = probability / selected_random[index];
+      if (score > best_score) {
+        best_score = score;
+        sampled_token = selected_ids[index];
+      }
+    }
+    sampled_token_out[0] = sampled_token;
+  }
+}
+
+template <bool EmitMetadata, bool ChunkedIndices>
+void launch_sm70_sample_sorted_top20_philox(
+    torch::Tensor sampled_token_out, int64_t* sparse_ids_out,
+    float* sparse_probs_out, torch::Tensor top_values,
+    const int64_t* top_indices, const int64_t* local_indices,
+    const int64_t* global_positions, int64_t local_candidate_count,
+    int chunk_size, const std::optional<at::Generator>& generator,
+    int64_t vocab_size, double top_p) {
+  const auto* properties = at::cuda::getCurrentDeviceProperties();
+  const int64_t blocks_per_sm =
+      properties->maxThreadsPerMultiProcessor / kNativeBlockSize;
+  const int64_t required_blocks =
+      (vocab_size + kNativeBlockSize - 1) / kNativeBlockSize;
+  const int64_t grid_blocks = std::min<int64_t>(
+      required_blocks, properties->multiProcessorCount * blocks_per_sm);
+  const int64_t total_threads = grid_blocks * kNativeBlockSize;
+  const uint64_t counter_offset =
+      ((vocab_size - 1) / (total_threads * kNativeUnroll) + 1) *
+      kMaxGeneratorOffsetsPerCurandCall;
+
+  auto* cuda_generator = at::get_generator_or_default<at::CUDAGeneratorImpl>(
+      generator, at::cuda::detail::getDefaultCUDAGenerator());
+  at::PhiloxCudaState philox_args;
+  {
+    std::lock_guard<std::mutex> lock(cuda_generator->mutex_);
+    philox_args = cuda_generator->philox_cuda_state(counter_offset);
+  }
+
+  sm70_sample_sorted_top20_philox_kernel<EmitMetadata, ChunkedIndices><<<
+      1, kWarpSize, 0, at::cuda::getCurrentCUDAStream()>>>(
+      sampled_token_out.data_ptr<int64_t>(), sparse_ids_out, sparse_probs_out,
+      top_values.data_ptr<float>(), top_indices, local_indices,
+      global_positions, local_candidate_count, chunk_size, vocab_size,
+      total_threads, static_cast<float>(top_p), philox_args);
+  C10_CUDA_KERNEL_LAUNCH_CHECK();
+}
+
+}  // namespace
+
+void sm70_sample_sorted_top20_philox_out(
+    torch::Tensor sampled_token_out, torch::Tensor sparse_ids_out,
+    torch::Tensor sparse_probs_out, torch::Tensor top_values,
+    torch::Tensor top_indices, const std::optional<at::Generator>& generator,
+    int64_t vocab_size, double top_p) {
+  TORCH_CHECK(sampled_token_out.is_cuda() && sparse_ids_out.is_cuda() &&
+                  sparse_probs_out.is_cuda() && top_values.is_cuda() &&
+                  top_indices.is_cuda(),
+              "sm70_sample_sorted_top20_philox_out: tensors must be CUDA");
+  TORCH_CHECK(sampled_token_out.scalar_type() == torch::kInt64 &&
+                  sparse_ids_out.scalar_type() == torch::kInt64 &&
+                  sparse_probs_out.scalar_type() == torch::kFloat32 &&
+                  top_values.scalar_type() == torch::kFloat32 &&
+                  top_indices.scalar_type() == torch::kInt64,
+              "sm70_sample_sorted_top20_philox_out: dtype mismatch");
+  TORCH_CHECK(sampled_token_out.numel() == 1 &&
+                  sparse_ids_out.numel() == kTopK &&
+                  sparse_probs_out.numel() == kTopK &&
+                  top_values.numel() == kTopK &&
+                  top_indices.numel() == kTopK,
+              "sm70_sample_sorted_top20_philox_out: shape mismatch");
+  TORCH_CHECK(sampled_token_out.is_contiguous() &&
+                  sparse_ids_out.is_contiguous() &&
+                  sparse_probs_out.is_contiguous() &&
+                  top_values.is_contiguous() && top_indices.is_contiguous(),
+              "sm70_sample_sorted_top20_philox_out: tensors must be contiguous");
+  TORCH_CHECK(vocab_size >= kTopK && top_p > 0.0 && top_p <= 1.0,
+              "sm70_sample_sorted_top20_philox_out: invalid parameters");
+
+  const at::cuda::OptionalCUDAGuard device_guard(device_of(top_values));
+  launch_sm70_sample_sorted_top20_philox<true, false>(
+      sampled_token_out, sparse_ids_out.data_ptr<int64_t>(),
+      sparse_probs_out.data_ptr<float>(), top_values,
+      top_indices.data_ptr<int64_t>(), nullptr, nullptr, 0, 0, generator,
+      vocab_size, top_p);
+}
+
+void sm70_sample_sorted_top20_philox_token_out(
+    torch::Tensor sampled_token_out, torch::Tensor top_values,
+    torch::Tensor top_indices, const std::optional<at::Generator>& generator,
+    int64_t vocab_size, double top_p) {
+  TORCH_CHECK(sampled_token_out.is_cuda() && top_values.is_cuda() &&
+                  top_indices.is_cuda(),
+              "sm70_sample_sorted_top20_philox_token_out: tensors must be CUDA");
+  TORCH_CHECK(sampled_token_out.scalar_type() == torch::kInt64 &&
+                  top_values.scalar_type() == torch::kFloat32 &&
+                  top_indices.scalar_type() == torch::kInt64,
+              "sm70_sample_sorted_top20_philox_token_out: dtype mismatch");
+  TORCH_CHECK(sampled_token_out.numel() == 1 &&
+                  top_values.numel() == kTopK &&
+                  top_indices.numel() == kTopK,
+              "sm70_sample_sorted_top20_philox_token_out: shape mismatch");
+  TORCH_CHECK(sampled_token_out.is_contiguous() && top_values.is_contiguous() &&
+                  top_indices.is_contiguous(),
+              "sm70_sample_sorted_top20_philox_token_out: tensors must be contiguous");
+  TORCH_CHECK(vocab_size >= kTopK && top_p > 0.0 && top_p <= 1.0,
+              "sm70_sample_sorted_top20_philox_token_out: invalid parameters");
+
+  const at::cuda::OptionalCUDAGuard device_guard(device_of(top_values));
+  launch_sm70_sample_sorted_top20_philox<false, false>(
+      sampled_token_out, nullptr, nullptr, top_values,
+      top_indices.data_ptr<int64_t>(), nullptr, nullptr, 0, 0, generator,
+      vocab_size, top_p);
+}
+
+void sm70_sample_chunked_top20_philox_token_out(
+    torch::Tensor sampled_token_out, torch::Tensor global_values,
+    torch::Tensor local_indices, torch::Tensor global_positions,
+    const std::optional<at::Generator>& generator, int64_t vocab_size,
+    double top_p, int64_t chunk_size) {
+  TORCH_CHECK(sampled_token_out.is_cuda() && global_values.is_cuda() &&
+                  local_indices.is_cuda() && global_positions.is_cuda(),
+              "sm70_sample_chunked_top20_philox_token_out: tensors must be CUDA");
+  TORCH_CHECK(sampled_token_out.scalar_type() == torch::kInt64 &&
+                  global_values.scalar_type() == torch::kFloat32 &&
+                  local_indices.scalar_type() == torch::kInt64 &&
+                  global_positions.scalar_type() == torch::kInt64,
+              "sm70_sample_chunked_top20_philox_token_out: dtype mismatch");
+  TORCH_CHECK(sampled_token_out.numel() == 1 &&
+                  global_values.numel() == kTopK &&
+                  local_indices.dim() == 2 &&
+                  local_indices.size(1) == kTopK &&
+                  global_positions.numel() == kTopK,
+              "sm70_sample_chunked_top20_philox_token_out: shape mismatch");
+  TORCH_CHECK(sampled_token_out.is_contiguous() &&
+                  global_values.is_contiguous() &&
+                  local_indices.is_contiguous() &&
+                  global_positions.is_contiguous(),
+              "sm70_sample_chunked_top20_philox_token_out: tensors must be contiguous");
+  TORCH_CHECK(chunk_size > 0 &&
+                  local_indices.size(0) * chunk_size == vocab_size &&
+                  vocab_size >= kTopK && top_p > 0.0 && top_p <= 1.0,
+              "sm70_sample_chunked_top20_philox_token_out: invalid parameters");
+
+  const at::cuda::OptionalCUDAGuard device_guard(device_of(global_values));
+  launch_sm70_sample_sorted_top20_philox<false, true>(
+      sampled_token_out, nullptr, nullptr, global_values, nullptr,
+      local_indices.data_ptr<int64_t>(),
+      global_positions.data_ptr<int64_t>(), local_indices.numel(),
+      static_cast<int>(chunk_size), generator, vocab_size, top_p);
+}

--- a/csrc/sm70_turbomind/ops/sm70_top20_philox_sampler.cu
+++ b/csrc/sm70_turbomind/ops/sm70_top20_philox_sampler.cu
@@ -27,9 +27,8 @@ constexpr int kNativeUnroll = 4;
 constexpr int kMaxGeneratorOffsetsPerCurandCall = 4;
 
 __device__ __forceinline__ bool top1_better(float value, int token,
-                                             float best_value, int best_token) {
-  return value > best_value ||
-         (value == best_value && token < best_token);
+                                            float best_value, int best_token) {
+  return value > best_value || (value == best_value && token < best_token);
 }
 
 __device__ __forceinline__ float native_exponential_for_index(
@@ -72,20 +71,18 @@ __global__ void sm70_sample_sorted_top20_philox_kernel(
       if (position >= 0 && position < local_candidate_count) {
         const int64_t local_index = local_indices[position];
         if (local_index >= 0 && local_index < chunk_size) {
-          lane_token64 =
-              (position / kTopK) * chunk_size + local_index;
+          lane_token64 = (position / kTopK) * chunk_size + local_index;
         }
       }
     } else {
       lane_token64 = top_indices[lane];
     }
   }
-  const bool lane_valid = lane < kTopK && lane_token64 >= 0 &&
-                          lane_token64 < vocab_size;
+  const bool lane_valid =
+      lane < kTopK && lane_token64 >= 0 && lane_token64 < vocab_size;
   const int lane_token = lane_valid ? static_cast<int>(lane_token64) : -1;
   const float lane_raw_value = lane < kTopK ? top_values[lane] : -FLT_MAX;
-  const float lane_value =
-      isfinite(lane_raw_value) ? lane_raw_value : -FLT_MAX;
+  const float lane_value = isfinite(lane_raw_value) ? lane_raw_value : -FLT_MAX;
   const int valid_count = __popc(__ballot_sync(0xffffffff, lane_valid));
   int lane_rank = 0;
 #pragma unroll
@@ -179,12 +176,12 @@ void launch_sm70_sample_sorted_top20_philox(
     philox_args = cuda_generator->philox_cuda_state(counter_offset);
   }
 
-  sm70_sample_sorted_top20_philox_kernel<EmitMetadata, ChunkedIndices><<<
-      1, kWarpSize, 0, at::cuda::getCurrentCUDAStream()>>>(
-      sampled_token_out.data_ptr<int64_t>(), sparse_ids_out, sparse_probs_out,
-      top_values.data_ptr<float>(), top_indices, local_indices,
-      global_positions, local_candidate_count, chunk_size, vocab_size,
-      total_threads, static_cast<float>(top_p), philox_args);
+  sm70_sample_sorted_top20_philox_kernel<EmitMetadata, ChunkedIndices>
+      <<<1, kWarpSize, 0, at::cuda::getCurrentCUDAStream()>>>(
+          sampled_token_out.data_ptr<int64_t>(), sparse_ids_out,
+          sparse_probs_out, top_values.data_ptr<float>(), top_indices,
+          local_indices, global_positions, local_candidate_count, chunk_size,
+          vocab_size, total_threads, static_cast<float>(top_p), philox_args);
   C10_CUDA_KERNEL_LAUNCH_CHECK();
 }
 
@@ -208,14 +205,13 @@ void sm70_sample_sorted_top20_philox_out(
   TORCH_CHECK(sampled_token_out.numel() == 1 &&
                   sparse_ids_out.numel() == kTopK &&
                   sparse_probs_out.numel() == kTopK &&
-                  top_values.numel() == kTopK &&
-                  top_indices.numel() == kTopK,
+                  top_values.numel() == kTopK && top_indices.numel() == kTopK,
               "sm70_sample_sorted_top20_philox_out: shape mismatch");
-  TORCH_CHECK(sampled_token_out.is_contiguous() &&
-                  sparse_ids_out.is_contiguous() &&
-                  sparse_probs_out.is_contiguous() &&
-                  top_values.is_contiguous() && top_indices.is_contiguous(),
-              "sm70_sample_sorted_top20_philox_out: tensors must be contiguous");
+  TORCH_CHECK(
+      sampled_token_out.is_contiguous() && sparse_ids_out.is_contiguous() &&
+          sparse_probs_out.is_contiguous() && top_values.is_contiguous() &&
+          top_indices.is_contiguous(),
+      "sm70_sample_sorted_top20_philox_out: tensors must be contiguous");
   TORCH_CHECK(vocab_size >= kTopK && top_p > 0.0 && top_p <= 1.0,
               "sm70_sample_sorted_top20_philox_out: invalid parameters");
 
@@ -231,20 +227,21 @@ void sm70_sample_sorted_top20_philox_token_out(
     torch::Tensor sampled_token_out, torch::Tensor top_values,
     torch::Tensor top_indices, const std::optional<at::Generator>& generator,
     int64_t vocab_size, double top_p) {
-  TORCH_CHECK(sampled_token_out.is_cuda() && top_values.is_cuda() &&
-                  top_indices.is_cuda(),
-              "sm70_sample_sorted_top20_philox_token_out: tensors must be CUDA");
+  TORCH_CHECK(
+      sampled_token_out.is_cuda() && top_values.is_cuda() &&
+          top_indices.is_cuda(),
+      "sm70_sample_sorted_top20_philox_token_out: tensors must be CUDA");
   TORCH_CHECK(sampled_token_out.scalar_type() == torch::kInt64 &&
                   top_values.scalar_type() == torch::kFloat32 &&
                   top_indices.scalar_type() == torch::kInt64,
               "sm70_sample_sorted_top20_philox_token_out: dtype mismatch");
-  TORCH_CHECK(sampled_token_out.numel() == 1 &&
-                  top_values.numel() == kTopK &&
+  TORCH_CHECK(sampled_token_out.numel() == 1 && top_values.numel() == kTopK &&
                   top_indices.numel() == kTopK,
               "sm70_sample_sorted_top20_philox_token_out: shape mismatch");
-  TORCH_CHECK(sampled_token_out.is_contiguous() && top_values.is_contiguous() &&
-                  top_indices.is_contiguous(),
-              "sm70_sample_sorted_top20_philox_token_out: tensors must be contiguous");
+  TORCH_CHECK(
+      sampled_token_out.is_contiguous() && top_values.is_contiguous() &&
+          top_indices.is_contiguous(),
+      "sm70_sample_sorted_top20_philox_token_out: tensors must be contiguous");
   TORCH_CHECK(vocab_size >= kTopK && top_p > 0.0 && top_p <= 1.0,
               "sm70_sample_sorted_top20_philox_token_out: invalid parameters");
 
@@ -260,25 +257,24 @@ void sm70_sample_chunked_top20_philox_token_out(
     torch::Tensor local_indices, torch::Tensor global_positions,
     const std::optional<at::Generator>& generator, int64_t vocab_size,
     double top_p, int64_t chunk_size) {
-  TORCH_CHECK(sampled_token_out.is_cuda() && global_values.is_cuda() &&
-                  local_indices.is_cuda() && global_positions.is_cuda(),
-              "sm70_sample_chunked_top20_philox_token_out: tensors must be CUDA");
+  TORCH_CHECK(
+      sampled_token_out.is_cuda() && global_values.is_cuda() &&
+          local_indices.is_cuda() && global_positions.is_cuda(),
+      "sm70_sample_chunked_top20_philox_token_out: tensors must be CUDA");
   TORCH_CHECK(sampled_token_out.scalar_type() == torch::kInt64 &&
                   global_values.scalar_type() == torch::kFloat32 &&
                   local_indices.scalar_type() == torch::kInt64 &&
                   global_positions.scalar_type() == torch::kInt64,
               "sm70_sample_chunked_top20_philox_token_out: dtype mismatch");
   TORCH_CHECK(sampled_token_out.numel() == 1 &&
-                  global_values.numel() == kTopK &&
-                  local_indices.dim() == 2 &&
+                  global_values.numel() == kTopK && local_indices.dim() == 2 &&
                   local_indices.size(1) == kTopK &&
                   global_positions.numel() == kTopK,
               "sm70_sample_chunked_top20_philox_token_out: shape mismatch");
-  TORCH_CHECK(sampled_token_out.is_contiguous() &&
-                  global_values.is_contiguous() &&
-                  local_indices.is_contiguous() &&
-                  global_positions.is_contiguous(),
-              "sm70_sample_chunked_top20_philox_token_out: tensors must be contiguous");
+  TORCH_CHECK(
+      sampled_token_out.is_contiguous() && global_values.is_contiguous() &&
+          local_indices.is_contiguous() && global_positions.is_contiguous(),
+      "sm70_sample_chunked_top20_philox_token_out: tensors must be contiguous");
   TORCH_CHECK(chunk_size > 0 &&
                   local_indices.size(0) * chunk_size == vocab_size &&
                   vocab_size >= kTopK && top_p > 0.0 && top_p <= 1.0,
@@ -287,7 +283,7 @@ void sm70_sample_chunked_top20_philox_token_out(
   const at::cuda::OptionalCUDAGuard device_guard(device_of(global_values));
   launch_sm70_sample_sorted_top20_philox<false, true>(
       sampled_token_out, nullptr, nullptr, global_values, nullptr,
-      local_indices.data_ptr<int64_t>(),
-      global_positions.data_ptr<int64_t>(), local_indices.numel(),
-      static_cast<int>(chunk_size), generator, vocab_size, top_p);
+      local_indices.data_ptr<int64_t>(), global_positions.data_ptr<int64_t>(),
+      local_indices.numel(), static_cast<int>(chunk_size), generator,
+      vocab_size, top_p);
 }

--- a/csrc/torch_bindings.cpp
+++ b/csrc/torch_bindings.cpp
@@ -237,6 +237,29 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, ops) {
       "bool gated_silu) -> ()");
   ops.impl("fp8_gemm_sm70_out", torch::kCUDA, &fp8_gemm_sm70_out);
 
+  ops.def("fp8_qpn8_prepare_sm70(Tensor qweight, Tensor scales) -> Tensor[]");
+  ops.impl("fp8_qpn8_prepare_sm70", torch::kCUDA, &fp8_qpn8_prepare_sm70);
+
+  ops.def(
+      "fp8_qpn8_dequantize_sm70_out(Tensor(a!) out, Tensor codes, "
+      "Tensor group_scales) -> ()");
+  ops.impl("fp8_qpn8_dequantize_sm70_out", torch::kCUDA,
+           &fp8_qpn8_dequantize_sm70_out);
+
+  ops.def(
+      "fp8_qpn8_prefill_sm70_out(Tensor(a!) out, int dense_weight_ptr, "
+      "Tensor input, Tensor codes, Tensor group_scales, bool gated_silu) -> "
+      "()");
+  ops.impl("fp8_qpn8_prefill_sm70_out", torch::kCUDA,
+           &fp8_qpn8_prefill_sm70_out);
+
+  ops.def(
+      "fp8_qpn8_dispatch_sm70_out(Tensor(a!) out, int dense_weight_ptr, "
+      "Tensor input, Tensor codes, Tensor group_scales, int split_k, "
+      "int accumulator_chains, bool prefetch_codes, bool gated_silu) -> ()");
+  ops.impl("fp8_qpn8_dispatch_sm70_out", torch::kCUDA,
+           &fp8_qpn8_dispatch_sm70_out);
+
   ops.def(
       "fp8_qpn8_gemm_sm70_out(Tensor(a!) out, Tensor input, Tensor codes, "
       "Tensor group_scales, int split_k, int accumulator_chains, "

--- a/csrc/torch_bindings.cpp
+++ b/csrc/torch_bindings.cpp
@@ -238,6 +238,20 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, ops) {
   ops.impl("fp8_gemm_sm70_out", torch::kCUDA, &fp8_gemm_sm70_out);
 
   ops.def(
+      "fp8_qpn8_gemm_sm70_out(Tensor(a!) out, Tensor input, Tensor codes, "
+      "Tensor group_scales, int split_k, int accumulator_chains, "
+      "bool fast_decoder, bool prefetch_codes) -> ()");
+  ops.impl("fp8_qpn8_gemm_sm70_out", torch::kCUDA,
+           &fp8_qpn8_gemm_sm70_out);
+
+  ops.def(
+      "fp8_qpn8_gated_pair_sm70_out(Tensor(a!) out, Tensor input, "
+      "Tensor codes, Tensor group_scales, int split_k, "
+      "int accumulator_chains, bool fast_decoder, bool prefetch_codes) -> ()");
+  ops.impl("fp8_qpn8_gated_pair_sm70_out", torch::kCUDA,
+           &fp8_qpn8_gated_pair_sm70_out);
+
+  ops.def(
       "fp8_gemm_sm70_prefill_dispatch_out(Tensor(a!) out, "
       "int dense_weight_ptr, Tensor _in_feats, Tensor _kernel, "
       "Tensor _scaling_factors, int group_size, int k_ld, int q_ld, "

--- a/csrc/torch_bindings.cpp
+++ b/csrc/torch_bindings.cpp
@@ -275,6 +275,37 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, ops) {
            &fp8_qpn8_gated_pair_sm70_out);
 
   ops.def(
+      "nvfp4_qpn4_prepare_sm70(Tensor qweight, Tensor scales) -> Tensor[]");
+  ops.impl("nvfp4_qpn4_prepare_sm70", torch::kCUDA,
+           &nvfp4_qpn4_prepare_sm70);
+
+  ops.def(
+      "nvfp4_qpn4_prepare_scale_code_sm70(Tensor qweight, Tensor "
+      "scale_codes) -> Tensor[]");
+  ops.impl("nvfp4_qpn4_prepare_scale_code_sm70", torch::kCUDA,
+           &nvfp4_qpn4_prepare_scale_code_sm70);
+
+  ops.def(
+      "nvfp4_qpn4_dequantize_sm70_out(Tensor(a!) out, Tensor codes, Tensor "
+      "scales, float global_scale, bool use_scale_code) -> ()");
+  ops.impl("nvfp4_qpn4_dequantize_sm70_out", torch::kCUDA,
+           &nvfp4_qpn4_dequantize_sm70_out);
+
+  ops.def(
+      "nvfp4_qpn4_prefill_sm70_out(Tensor(a!) out, int dense_weight_ptr, "
+      "Tensor input, Tensor codes, Tensor scales, float global_scale, bool "
+      "use_scale_code, bool gated_silu) -> ()");
+  ops.impl("nvfp4_qpn4_prefill_sm70_out", torch::kCUDA,
+           &nvfp4_qpn4_prefill_sm70_out);
+
+  ops.def(
+      "nvfp4_qpn4_dispatch_sm70_out(Tensor(a!) out, int dense_weight_ptr, "
+      "Tensor input, Tensor codes, Tensor scales, float global_scale, bool "
+      "use_scale_code, bool gated_silu) -> ()");
+  ops.impl("nvfp4_qpn4_dispatch_sm70_out", torch::kCUDA,
+           &nvfp4_qpn4_dispatch_sm70_out);
+
+  ops.def(
       "fp8_gemm_sm70_prefill_dispatch_out(Tensor(a!) out, "
       "int dense_weight_ptr, Tensor _in_feats, Tensor _kernel, "
       "Tensor _scaling_factors, int group_size, int k_ld, int q_ld, "

--- a/csrc/torch_bindings.cpp
+++ b/csrc/torch_bindings.cpp
@@ -165,13 +165,13 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, ops) {
       "Tensor? qzeros_or_none, bool inplace) -> Tensor");
   // conditionally compiled so impl registrations are in source file
 
-#ifdef ENABLE_SM70_TURBOMIND
+  #ifdef ENABLE_SM70_TURBOMIND
   ops.def("silu_and_mul_interleaved(Tensor! result, Tensor input) -> ()");
-  ops.impl("silu_and_mul_interleaved", torch::kCUDA,
-           &silu_and_mul_interleaved);
+  ops.impl("silu_and_mul_interleaved", torch::kCUDA, &silu_and_mul_interleaved);
 
   ops.def(
-      "awq_sm70_prepare(Tensor _kernel, Tensor _scaling_factors, Tensor _zeros, "
+      "awq_sm70_prepare(Tensor _kernel, Tensor _scaling_factors, Tensor "
+      "_zeros, "
       "int group_size, bool interleave_gated_silu) -> Tensor[]");
   ops.impl("awq_sm70_prepare", torch::kCUDA, &awq_sm70_prepare);
 
@@ -193,8 +193,7 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, ops) {
   ops.def(
       "fp8_sm70_dequantize_out(Tensor(a!) out, Tensor _kernel, "
       "Tensor _scaling_factors, int group_size) -> ()");
-  ops.impl("fp8_sm70_dequantize_out", torch::kCUDA,
-           &fp8_sm70_dequantize_out);
+  ops.impl("fp8_sm70_dequantize_out", torch::kCUDA, &fp8_sm70_dequantize_out);
 
   ops.def(
       "mxfp4_sm70_prepare(Tensor _kernel, Tensor _scaling_factors, "
@@ -264,8 +263,7 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, ops) {
       "fp8_qpn8_gemm_sm70_out(Tensor(a!) out, Tensor input, Tensor codes, "
       "Tensor group_scales, int split_k, int accumulator_chains, "
       "bool fast_decoder, bool prefetch_codes) -> ()");
-  ops.impl("fp8_qpn8_gemm_sm70_out", torch::kCUDA,
-           &fp8_qpn8_gemm_sm70_out);
+  ops.impl("fp8_qpn8_gemm_sm70_out", torch::kCUDA, &fp8_qpn8_gemm_sm70_out);
 
   ops.def(
       "fp8_qpn8_gated_pair_sm70_out(Tensor(a!) out, Tensor input, "
@@ -274,10 +272,8 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, ops) {
   ops.impl("fp8_qpn8_gated_pair_sm70_out", torch::kCUDA,
            &fp8_qpn8_gated_pair_sm70_out);
 
-  ops.def(
-      "nvfp4_qpn4_prepare_sm70(Tensor qweight, Tensor scales) -> Tensor[]");
-  ops.impl("nvfp4_qpn4_prepare_sm70", torch::kCUDA,
-           &nvfp4_qpn4_prepare_sm70);
+  ops.def("nvfp4_qpn4_prepare_sm70(Tensor qweight, Tensor scales) -> Tensor[]");
+  ops.impl("nvfp4_qpn4_prepare_sm70", torch::kCUDA, &nvfp4_qpn4_prepare_sm70);
 
   ops.def(
       "nvfp4_qpn4_prepare_scale_code_sm70(Tensor qweight, Tensor "
@@ -329,34 +325,29 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, ops) {
       "nvfp4_gemv_sm70_raw_out(Tensor(a!) out, Tensor _in_feats, "
       "Tensor _kernel, Tensor _scaling_factors, Tensor(b!) partials, "
       "int group_size, int split_k) -> ()");
-  ops.impl("nvfp4_gemv_sm70_raw_out", torch::kCUDA,
-           &nvfp4_gemv_sm70_raw_out);
+  ops.impl("nvfp4_gemv_sm70_raw_out", torch::kCUDA, &nvfp4_gemv_sm70_raw_out);
 
   ops.def(
       "nvfp4_gemv_sm70_warp_out(Tensor(a!) out, Tensor _in_feats, "
       "Tensor _kernel, Tensor _scaling_factors, int group_size) -> ()");
-  ops.impl("nvfp4_gemv_sm70_warp_out", torch::kCUDA,
-           &nvfp4_gemv_sm70_warp_out);
+  ops.impl("nvfp4_gemv_sm70_warp_out", torch::kCUDA, &nvfp4_gemv_sm70_warp_out);
 
   ops.def(
       "nvfp4_gemv_sm70_h2_out(Tensor(a!) out, Tensor _in_feats, "
       "Tensor _kernel, Tensor _scaling_factors, Tensor(b!) partials, "
       "int group_size, int split_k) -> ()");
-  ops.impl("nvfp4_gemv_sm70_h2_out", torch::kCUDA,
-           &nvfp4_gemv_sm70_h2_out);
+  ops.impl("nvfp4_gemv_sm70_h2_out", torch::kCUDA, &nvfp4_gemv_sm70_h2_out);
 
   ops.def(
       "fp8_gemm_sm70_out_auto(Tensor(a!) out, Tensor _in_feats, "
       "Tensor _kernel, Tensor _scaling_factors) -> ()");
-  ops.impl("fp8_gemm_sm70_out_auto", torch::kCUDA,
-           &fp8_gemm_sm70_out_auto);
+  ops.impl("fp8_gemm_sm70_out_auto", torch::kCUDA, &fp8_gemm_sm70_out_auto);
 
   ops.def(
       "fp8_gemm_sm70_out_meta(Tensor(a!) out, Tensor _in_feats, "
       "Tensor _kernel, Tensor _scaling_factors, Tensor _meta, "
       "bool gated_silu) -> ()");
-  ops.impl("fp8_gemm_sm70_out_meta", torch::kCUDA,
-           &fp8_gemm_sm70_out_meta);
+  ops.impl("fp8_gemm_sm70_out_meta", torch::kCUDA, &fp8_gemm_sm70_out_meta);
 
   ops.def(
       "sm70_f16_gemm_out(Tensor(a!) out, Tensor _in_feats, Tensor _kernel, "
@@ -652,7 +643,7 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, ops) {
       "bool exact_per_route) -> ()");
   ops.impl("fp8_moe_single_token_sm70_out", torch::kCUDA,
            &fp8_moe_single_token_sm70_out);
-#endif
+  #endif
 
 #endif
 

--- a/docs/design/sm70_qwen38_nvfp4_decode.md
+++ b/docs/design/sm70_qwen38_nvfp4_decode.md
@@ -101,24 +101,49 @@ operator gates recorded in `sm70_qwen38_qpn8_decode.md`.
 
 ## Per-Token Profile
 
-The short Nsight Systems node trace is composition evidence; its traced TPOT
-is not used as the absolute speed result. Before p64, the steady critical rank
-contains approximately:
+The latest short Nsight Systems node trace uses the merged p64 route. It is
+composition evidence; its 14.635 ms traced TPOT is not used as the absolute
+speed result because the unprofiled frozen request measures 14.017 ms. The
+trace captures 63 decode replays on each TP rank and uses the 61 middle steps
+for steady statistics. Graph-node kernel coverage is 93.48%.
 
 | Component | Time/token |
 |---|---:|
-| QPN8 regular projections | 3.151 ms |
-| NVFP4 gate/up | 2.740 ms |
-| NVFP4 down | 1.702 ms |
-| TP all-reduce | 1.676 ms |
-| E4M3 XQA p128 | 0.892 ms |
-| QPN8 fused gate/up | 0.506 ms |
-| TurboMind FP8 LM head | 0.407 ms |
+| TurboMind NVFP4 gate/up | 2.762 ms |
+| QPN8 split-16 projections | 2.234 ms |
+| TurboMind NVFP4 down | 1.706 ms |
+| TP all-reduce | 1.697 ms |
+| QPN8 split-12 projections | 0.895 ms |
+| E4M3 XQA p64 | 0.587 ms |
+| QPN8 fused gate/up | 0.508 ms |
+| TurboMind FP8 dense/LM head | 0.407 ms |
 
-The p64 operator race predicts 0.15-0.27 ms/token attention savings across
-the roughly 16 attention launches. The full model measures 0.365 ms/token;
-the excess is within run-to-run system variation, so only the measured full
-result is used for the final speed claim.
+Across rank-token samples, the replay interval is 14.621 ms and GPU activity
+union is 14.055 ms, or 96.136% of the interval. Idle gaps total 0.565 ms/token.
+The stream still launches 1140.8 kernels per rank per token; half are shorter
+than 5 us. The grid-limited static occupancy ceiling places 69.40% of service
+below 25% occupancy and 28.50% at 25-50%. Nearly continuous GPU work therefore
+does not imply high useful compute utilization: batch-one launch geometry and
+the serial projection/communication chain remain the main limit.
+
+Fifty-millisecond NVML samples report 99.47% mean GPU busy-window duty and
+48.26% memory-active-window duty. Per-GPU power averages 175.9-180.2 W and
+peaks at 221.4 W; runtime allocation peaks at 29.06-29.36 GiB/GPU. Model loading
+accounts for 5.77 GiB/GPU, while the configured cache budget reports 21.29
+GiB/GPU; the remaining allocation includes CUDA graphs, workspaces, state, and
+runtime context.
+
+NVML memory duty is not achieved HBM bandwidth. Current trace durations imply
+effective minimum packed-weight rates of 451.2 GB/s for NVFP4 gate/up, 365.1
+GB/s for NVFP4 down, and 717.4 GB/s for QPN8 down, with useful arithmetic rates
+of 1.805, 1.461, and 1.435 TFLOP/s/GPU respectively. These omit scales,
+activation/output traffic, caches, and implementation-internal work. A current
+NCU capture was attempted, but the host rejected non-root performance-counter
+access with `ERR_NVGPUCTRPERM`; exact current SM, Tensor Core, occupancy, and
+DRAM counters therefore require administrative profiling permission. The
+previously accepted QPN8 counter evidence remains in
+`sm70_qwen38_qpn8_decode.md`, but it is not credited as current NVFP4 or p64
+XQA counter evidence.
 
 ## Rejected Experiments
 

--- a/docs/design/sm70_qwen38_nvfp4_decode.md
+++ b/docs/design/sm70_qwen38_nvfp4_decode.md
@@ -1,0 +1,152 @@
+# SM70 Qwen3.8-27B-NVFP4 Decode Recovery
+
+Date: 2026-08-23
+
+## Decision
+
+The accepted Qwen3.8-27B-NVFP4 TP4, no-MTP decode route keeps every eligible
+FP8 and NVFP4 projection on an SM70 native path. Channel-FP8 projections use
+the memory-neutral QPN8 decode kernels for the accepted gate/up, down, and
+output shapes. Remaining channel-FP8 projections, including the LM head, use
+TurboMind W8A16. NVFP4 projections use TurboMind W4A16. No accepted result in
+this document credits a Marlin fallback.
+
+The final route also adds E4M3 KV support to Flash-V100 XQA and selects a p64
+partition for the exact batch-one, G6/D256 layout. This is the change that
+makes the frozen native-sampler result comfortably exceed 70 tok/s. The p64
+route is restricted to E4M3, batch one, G6/D256; the existing E5M2 and FP16
+policies are unchanged.
+
+## Frozen Contract
+
+- Model: Qwen3.8-27B-NVFP4, config SHA256
+  `1b3c71868d1299e52df6fc907deb202d5132b1ef0f72aae0ef6d15185dd53a5c`.
+- Hardware/runtime: four V100-SXM2-32GB GPUs, TP4, Python 3.12, Torch
+  2.10.0+cu128, CUDA 12.8.
+- Engine: compressed-tensors, FP16 activation/output, E4M3 KV,
+  `FLASH_ATTN_V100`, `max_model_len=262144`, `max_num_batched_tokens=8192`,
+  `max_num_seqs=1`, prefix caching, aligned Mamba cache, chunked prefill, and
+  `FULL_AND_PIECEWISE` CUDA graphs.
+- Request: input 1024, natural output cap 256, no `ignore_eos`, no MTP.
+- Sampling: temperature 1.0, top-p 0.95, top-k 20, request seed 20260815,
+  engine seed 0. The accepted final run uses the unmodified native sampler.
+- Pure decode uses the 255 steady token intervals and excludes TTFT/prefill.
+
+## Route Map
+
+| Layer family | TP-local shape | Accepted decode route |
+|---|---|---|
+| FP8 gate/up | K5120 x N8704 | fused QPN8 gate/SiLU/up |
+| FP8 down | K4352 x N5120 | QPN8 split-16 |
+| FP8 output | K1536 x N5120 | QPN8 split-12 |
+| FP8 GDN input/full-attention QKV and LM head | model shapes | TurboMind W8A16 |
+| NVFP4 gate/up | K5120 x N8704 | TurboMind N32, lookahead 1 |
+| NVFP4 down | K4352 x N5120 | TurboMind N32, lookahead 2 |
+| E4M3 G6/D256 attention | B1, page 1568 | Flash-V100 XQA p64 |
+
+Channelwise `[N,1]` FP8 scales are admitted and packed without retaining a
+second permanent weight copy. The existing QPN8 model/shape/concurrency gates
+remain in force. The NVFP4 selector is exact-shape gated by
+`VLLM_SM70_NVFP4_QWEN38_TP4_M1_FAST_SELECTOR`; setting it to zero restores
+dynamic tuning. Setting `VLLM_FLASH_V100_DECODE_PARTITION_SIZE=128` restores
+the previous E4M3 attention partition.
+
+## Pure Decode Result
+
+| Milestone | Steady decode | TPOT |
+|---|---:|---:|
+| Original mixed checkpoint route | 29.35 tok/s | about 34.07 ms |
+| Channel-FP8 TurboMind | 57.285 tok/s | 17.457 ms |
+| E4M3 XQA p256 | 62.615 tok/s | 15.971 ms |
+| Exact channel-FP8 QPN8 | 65.522 tok/s | 15.262 ms |
+| E4M3 XQA p128 | 67.880 tok/s | 14.732 ms |
+| NVFP4 N32 selectors | 69.991 tok/s | 14.288 ms |
+| Clean final binaries, native sampler, E4M3 p128 | 69.904 tok/s | 14.305 ms |
+| Clean final binaries, native sampler, E4M3 p64 | **71.732 tok/s** | **13.941 ms** |
+
+The final request generated all 256 tokens, contained no EOS, and finished by
+length. Relative to the immediately preceding clean-p128 control, p64 saves
+0.365 ms/token and improves pure decode by 2.61%. Both runs used physical GPUs
+0-3 under an exclusive reservation, the same `_C`, model/config, sampling,
+TurboMind/QPN8 selectors, and graph policy. Only the rebuilt Flash extension
+and E4M3 partition selector differ.
+
+Sampled token identity is not an attention quality criterion: one-output-ULP
+changes can flip a low-margin random sample. The final p64 stream is coherent
+and, independently, reproduces an earlier accepted full-length stream. The
+operator gate below is the numerical criterion.
+
+## Numerical and Operator Gates
+
+The E4M3 XQA p64/p128 race uses page size 1568, G6/D256, checkpoint-style
+E4M3 bytes, K/V scales 0.04/0.25, and the scalar paged decoder as reference.
+
+| Sequence length | p64 | p128 | p64 gain | Maximum error |
+|---:|---:|---:|---:|---:|
+| 1025 | 46.633 us | 63.614 us | 16.981 us | 7.63e-6 |
+| 1152 | 45.896 us | 59.346 us | 13.450 us | 7.63e-6 |
+| 1280 | 46.072 us | 55.625 us | 9.553 us | 7.63e-6 |
+| 2049 | 45.807 us | 56.751 us | 10.945 us | 7.63e-6 |
+
+Every p64 and p128 output is within one representable FP16 output ULP of the
+scalar reference. The focused GPU regression covers p64/p128/p256 with unit
+and non-unit K/V scales and passes 6/6.
+
+The retained NVFP4 selectors also passed independent FP32-oracle checks:
+relative L2 is `2.701e-4` for gate/up and `2.924e-4` for down, with cosine
+approximately one. The QPN8 source already passed its model-quality and
+operator gates recorded in `sm70_qwen38_qpn8_decode.md`.
+
+## Per-Token Profile
+
+The short Nsight Systems node trace is composition evidence; its traced TPOT
+is not used as the absolute speed result. Before p64, the steady critical rank
+contains approximately:
+
+| Component | Time/token |
+|---|---:|
+| QPN8 regular projections | 3.151 ms |
+| NVFP4 gate/up | 2.740 ms |
+| NVFP4 down | 1.702 ms |
+| TP all-reduce | 1.676 ms |
+| E4M3 XQA p128 | 0.892 ms |
+| QPN8 fused gate/up | 0.506 ms |
+| TurboMind FP8 LM head | 0.407 ms |
+
+The p64 operator race predicts 0.15-0.27 ms/token attention savings across
+the roughly 16 attention launches. The full model measures 0.365 ms/token;
+the excess is within run-to-run system variation, so only the measured full
+result is used for the final speed claim.
+
+## Rejected Experiments
+
+- NVFP4 N64 and K32 candidates lost to N32 and were removed. The retained
+  exact shapes use split 3/swizzle 4 with shape-specific lookahead.
+- QPN8 split 17/20/24 lost. Split 12 won only for K1536 x N5120, saving about
+  12.7 us/token across the 64 output projections.
+- A compact top-k20 Python sampler reduced traced sampler service, but its
+  random-sampling trajectory was not deterministic against the native route.
+  A fused CUDA top20 candidate had the same acceptance problem. Both were
+  removed from production source; the final 71.732 tok/s result uses the
+  native sampler.
+- Replacing only the full-vocabulary sort while retaining both native
+  full-vocabulary softmax operations saved 53.9 us in isolation, insufficient
+  for a stable acceptance margin. A one-full-softmax hybrid stayed
+  experimental because the p64 attention route solved the target without
+  changing sampling math.
+
+## Build, Tests, and Evidence
+
+- Final `_C` SHA256:
+  `e0ea14d0e40330b08a9951e67634e50b722540d5d1bbb48500f690323ab07624`.
+- Final p64 Flash-V100 SHA256:
+  `1fa566a28961d0585a9b6e1ee39e8fa637c4fe13ae894a9a9c07e09d850d02ca`.
+- Focused CPU policy/dispatch tests: 12/12 passed (nine FP8/QPN8 and three
+  E4M3 p64 policy cases).
+- Focused E4M3 XQA GPU numerical tests: 6/6 passed.
+- Ruff lint/format, Python byte compilation, shell syntax, and
+  `git diff --check` pass for the changed files.
+- Retained task evidence is under
+  `.artifacts/qwen38_nvfp4_speed_20260823/`, notably the final p128/p64 JSON
+  results, `e4m3_xqa_p64_vs_p128_clean.json`, and the parsed per-token Nsight
+  tables under `profiles/`.

--- a/docs/design/sm70_qwen38_nvfp4_decode.md
+++ b/docs/design/sm70_qwen38_nvfp4_decode.md
@@ -13,9 +13,9 @@ this document credits a Marlin fallback.
 
 The final route also adds E4M3 KV support to Flash-V100 XQA and selects a p64
 partition for the exact batch-one, G6/D256 layout. This is the change that
-makes the frozen native-sampler result comfortably exceed 70 tok/s. The p64
-route is restricted to E4M3, batch one, G6/D256; the existing E5M2 and FP16
-policies are unchanged.
+makes the frozen native-sampler result exceed 70 tok/s. The p64 route is
+restricted to E4M3, batch one, G6/D256; the existing E5M2 and FP16 policies
+are unchanged.
 
 ## Frozen Contract
 
@@ -62,14 +62,16 @@ the previous E4M3 attention partition.
 | E4M3 XQA p128 | 67.880 tok/s | 14.732 ms |
 | NVFP4 N32 selectors | 69.991 tok/s | 14.288 ms |
 | Clean final binaries, native sampler, E4M3 p128 | 69.904 tok/s | 14.305 ms |
-| Clean final binaries, native sampler, E4M3 p64 | **71.732 tok/s** | **13.941 ms** |
+| Clean pre-merge binaries, native sampler, E4M3 p64 | 71.732 tok/s | 13.941 ms |
+| Merged-source confirmation, native sampler, E4M3 p64 | **71.342 tok/s** | **14.017 ms** |
 
-The final request generated all 256 tokens, contained no EOS, and finished by
-length. Relative to the immediately preceding clean-p128 control, p64 saves
-0.365 ms/token and improves pure decode by 2.61%. Both runs used physical GPUs
-0-3 under an exclusive reservation, the same `_C`, model/config, sampling,
-TurboMind/QPN8 selectors, and graph policy. Only the rebuilt Flash extension
-and E4M3 partition selector differ.
+Both p64 requests generated all 256 tokens, contained no EOS, and finished by
+length. Relative to the immediately preceding clean-p128 control, the
+pre-merge p64 run saves 0.365 ms/token and improves pure decode by 2.61%.
+After merging `onecat/main` at `675a12dedc`, rebuilding Flash-V100, and
+repeating the frozen request under an exclusive four-GPU reservation, p64
+measures 71.342 tok/s at 14.017 ms/token. This merged-source confirmation is
+the conservative final speed claim.
 
 Sampled token identity is not an attention quality criterion: one-output-ULP
 changes can flip a low-margin random sample. The final p64 stream is coherent
@@ -127,8 +129,8 @@ result is used for the final speed claim.
 - A compact top-k20 Python sampler reduced traced sampler service, but its
   random-sampling trajectory was not deterministic against the native route.
   A fused CUDA top20 candidate had the same acceptance problem. Both were
-  removed from production source; the final 71.732 tok/s result uses the
-  native sampler.
+  removed from production source; both final p64 results use the native
+  sampler.
 - Replacing only the full-vocabulary sort while retaining both native
   full-vocabulary softmax operations saved 53.9 us in isolation, insufficient
   for a stable acceptance margin. A one-full-softmax hybrid stayed
@@ -140,7 +142,7 @@ result is used for the final speed claim.
 - Final `_C` SHA256:
   `e0ea14d0e40330b08a9951e67634e50b722540d5d1bbb48500f690323ab07624`.
 - Final p64 Flash-V100 SHA256:
-  `1fa566a28961d0585a9b6e1ee39e8fa637c4fe13ae894a9a9c07e09d850d02ca`.
+  `b418fed86b9c1ab9297c8795c24732818239b9a3aaca5ec9efb60933853d8ce7`.
 - Focused CPU policy/dispatch tests: 12/12 passed (nine FP8/QPN8 and three
   E4M3 p64 policy cases).
 - Focused E4M3 XQA GPU numerical tests: 6/6 passed.
@@ -148,5 +150,7 @@ result is used for the final speed claim.
   `git diff --check` pass for the changed files.
 - Retained task evidence is under
   `.artifacts/qwen38_nvfp4_speed_20260823/`, notably the final p128/p64 JSON
-  results, `e4m3_xqa_p64_vs_p128_clean.json`, and the parsed per-token Nsight
-  tables under `profiles/`.
+  results, the merged confirmation
+  `final_merged_qwen38_nvfp4_tm_e4m3_xqa_p64_native_sampler_full_graph_i1k_o256.json`,
+  `e4m3_xqa_p64_vs_p128_clean.json`, and the parsed per-token Nsight tables
+  under `profiles/`.

--- a/docs/design/sm70_qwen38_nvfp4_decode.md
+++ b/docs/design/sm70_qwen38_nvfp4_decode.md
@@ -297,19 +297,58 @@ The final Python regression run passes all 94 tests in the sampler, NVFP4
 admission, and SM70 TurboMind adapter files. Ruff lint/format, Python byte
 compilation, the sidecar wheel-name gate, and `git diff --check` also pass.
 
-Freshly relinking the primary `_C` was tested separately. Even after matching
-the accepted CUDA cubins for QPN8, QPN4, and custom all-reduce, fresh main
-libraries measured roughly 77-80 tok/s and changed the low-margin random stream.
-Those main-library builds are rejected; do not substitute them for the
-compatible `_C` SHA above until the remaining host/link reproducibility issue
-is resolved. Keeping the sampler in its own sidecar is the accepted packaging
+Freshly relinking the primary `_C` was tested separately. The first cold run
+measured 77.314 tok/s, while the matching second run measured 80.181 tok/s at
+12.472 ms/token. Both used a current-source C++17 sampler sidecar and produced
+the exact same 256 token IDs as the accepted production C++17 run. The earlier
+roughly 77-80 tok/s spread was therefore startup-state variation, not a decode
+route or output regression.
+
+The clean source snapshot is `7bd1d783e4861af5f5396a721156c44f623f88b0`.
+Its primary `_C` SHA256 is
+`c5d7c6a9a0fa714c1e97427c3d16369404ae5af6ee80f48b165595081cc43e56`,
+and its C++17 sampler SHA256 is
+`3058051f59949d88f5982d0c5bd80121f3c75a0f5307ca901fa6aebdec4cbc74`.
+The primary and sampler `.nv_fatbin` SHA256 values are respectively
+`dbba740219f00db9a528310fa84c0defb97c03f5cf99b519af5975609eb926e6`
+and
+`9a89e8cc22d1f8e36378005c08e2b32b315d79728989d6b4b2fe44fedfa5cb2c`;
+both are byte-identical to the accepted binaries. The full primary ELF differs
+because merged main adds two unrelated ModelOpt NVFP4 MoE host entry points,
+and full sidecar hashes include host build-ID differences. Those differences
+do not enter this dense batch-one graph.
+
+The clean second-run result SHA256 is
+`4e6ed3306772efca1a9c84b3681d50a268c644b8d6327df0fab2341581236bb1`.
+Its serialized token-array SHA256 is
+`f50e0ebab44ae350c7921bf91ba709fa896dcfb253c06842323b80de5b8bde32`,
+exactly matching the accepted C++17 result. It records TP4, physical GPUs 0-3,
+custom all-reduce enabled, both FP8 and NVFP4 TurboMind enabled,
+`speculative_config=None`, and `spec_decoding_metrics=null`. Because both
+device binaries and the full sampled stream are identical, the existing
+production C++17 GSM8K result, 226/250 with zero invalid outputs, remains the
+quality gate; repeating the same 250-question run would add no new path
+coverage. Keeping the sampler in its own sidecar remains the packaging
+boundary, but a current-source primary rebuild is now accepted.
+
+CMake component installation was also checked without rebuilding unrelated
+wheel targets. It installs `vllm/_C.abi3.so` and
+`vllm/_sm70_sampler_C.cpython-312-x86_64-linux-gnu.so`, removes their build-tree
+RPATHs, and preserves both accepted fatbin hashes. The installed-file SHA256
+values are `d7ed490ef41e55f3858a45b3a92d62b2d527343fa14b04053cbe65ba16646749`
+and `8ee8466359dc4432234dc3daa92918b2226879caad563d23a85b980c2a7c755e`.
+A loader probe against the staged files registered the QPN4, QPN8, and
+`_C::sm70_sample_packed_top20_out` schemas successfully. A broad wheel rebuild
+of unrelated extensions is not required to establish this route's packaging
 boundary.
 
 Primary evidence paths are:
 
 - `.artifacts/qwen38_nvfp4_speed_20260823/results/candidate_qpn4_fold_qpn8_m1_arpack32_official_cxx17_sidecar_chunk80_i1k_o256_a2.json`
+- `.artifacts/qwen38_nvfp4_speed_20260823/results/candidate_qwen38_nvfp4_clean_head_cxx17_chunk80_i1k_o256_a2.json`
 - `.artifacts/qwen38_nvfp4_speed_20260823/results/qwen38_nvfp4_gsm8k_250_official_cxx17_sidecar.json`
 - `.artifacts/qwen38_nvfp4_speed_20260823/results/sampler_stream_hand.json`
 - `.artifacts/qwen38_nvfp4_speed_20260823/results/sampler_stream_cxx17.json`
+- `.artifacts/qwen38_nvfp4_speed_20260823/wheel_stage_clean_head_7bd1d783/`
 - `.artifacts/qwen38_nvfp4_speed_20260823/profiles/candidate_qwen38_nvfp4_sidecar_chunk80_nsys_nvml_i1k_o64_per_token.md`
 - `.artifacts/qwen38_nvfp4_speed_20260823/profiles/candidate_qwen38_nvfp4_sidecar_chunk80_resource_summary.md`

--- a/docs/design/sm70_qwen38_nvfp4_decode.md
+++ b/docs/design/sm70_qwen38_nvfp4_decode.md
@@ -1,6 +1,6 @@
 # SM70 Qwen3.8-27B-NVFP4 Decode Recovery
 
-Date: 2026-08-23
+Date: 2026-08-23; acceptance updated 2026-08-24
 
 ## Decision
 
@@ -11,11 +11,13 @@ output shapes. Remaining channel-FP8 projections, including the LM head, use
 TurboMind W8A16. NVFP4 projections use TurboMind W4A16. No accepted result in
 this document credits a Marlin fallback.
 
-The final route also adds E4M3 KV support to Flash-V100 XQA and selects a p64
-partition for the exact batch-one, G6/D256 layout. This is the change that
+The recovery route also adds E4M3 KV support to Flash-V100 XQA and selects a
+p64 partition for the exact batch-one, G6/D256 layout. This is the change that
 makes the frozen native-sampler result exceed 70 tok/s. The p64 route is
 restricted to E4M3, batch one, G6/D256; the existing E5M2 and FP16 policies
-are unchanged.
+are unchanged. The later no-MTP 80 tok/s acceptance adds exact QPN4, TP4
+all-reduce, QPN8 specialization, and an exact-Philox chunked sampler sidecar;
+that acceptance is recorded at the end of this document.
 
 ## Frozen Contract
 
@@ -29,7 +31,9 @@ are unchanged.
   `FULL_AND_PIECEWISE` CUDA graphs.
 - Request: input 1024, natural output cap 256, no `ignore_eos`, no MTP.
 - Sampling: temperature 1.0, top-p 0.95, top-k 20, request seed 20260815,
-  engine seed 0. The accepted final run uses the unmodified native sampler.
+  engine seed 0. The 2026-08-23 recovery baseline uses the unmodified native
+  sampler. The 2026-08-24 acceptance uses the separately registered,
+  exact-Philox chunked sampler described below.
 - Pure decode uses the 255 steady token intervals and excludes TTFT/prefill.
 
 ## Route Map
@@ -70,8 +74,8 @@ length. Relative to the immediately preceding clean-p128 control, the
 pre-merge p64 run saves 0.365 ms/token and improves pure decode by 2.61%.
 After merging `onecat/main` at `675a12dedc`, rebuilding Flash-V100, and
 repeating the frozen request under an exclusive four-GPU reservation, p64
-measures 71.342 tok/s at 14.017 ms/token. This merged-source confirmation is
-the conservative final speed claim.
+measures 71.342 tok/s at 14.017 ms/token. This is the conservative 2026-08-23
+baseline and is superseded by the 2026-08-24 acceptance below.
 
 Sampled token identity is not an attention quality criterion: one-output-ULP
 changes can flip a low-margin random sample. The final p64 stream is coherent
@@ -151,11 +155,11 @@ XQA counter evidence.
   exact shapes use split 3/swizzle 4 with shape-specific lookahead.
 - QPN8 split 17/20/24 lost. Split 12 won only for K1536 x N5120, saving about
   12.7 us/token across the 64 output projections.
-- A compact top-k20 Python sampler reduced traced sampler service, but its
-  random-sampling trajectory was not deterministic against the native route.
-  A fused CUDA top20 candidate had the same acceptance problem. Both were
-  removed from production source; both final p64 results use the native
-  sampler.
+- The first compact top-k20 Python sampler and first fused CUDA top20
+  candidate did not preserve native Philox sampling and were removed. Both
+  2026-08-23 p64 results use the native sampler. They are distinct from the
+  later canonicalized, generator-state-preserving implementation accepted on
+  2026-08-24.
 - Replacing only the full-vocabulary sort while retaining both native
   full-vocabulary softmax operations saved 53.9 us in isolation, insufficient
   for a stable acceptance margin. A one-full-softmax hybrid stayed
@@ -179,3 +183,133 @@ XQA counter evidence.
   `final_merged_qwen38_nvfp4_tm_e4m3_xqa_p64_native_sampler_full_graph_i1k_o256.json`,
   `e4m3_xqa_p64_vs_p128_clean.json`, and the parsed per-token Nsight tables
   under `profiles/`.
+
+## 2026-08-24 No-MTP 80 tok/s Acceptance
+
+### Accepted deployment and route
+
+The accepted deployment is deliberately a three-binary composition. It uses
+the compatible primary `_C` module with SHA256
+`a0a0cd9ddeccc73fa3d920c7a869450c4b33d001f97637c35b75b966d89ad36d`,
+the production CMake C++17 sampler sidecar with SHA256
+`cdbfdd87dfa9119e52acc88d5787063202561a879a63334145a5616344a549ae`,
+and Flash-V100 p64 with SHA256
+`b418fed86b9c1ab9297c8795c24732818239b9a3aaca5ec9efb60933853d8ce7`.
+MTP remains disabled.
+
+The exact FP8 gate/up, down, and output shapes stay on the proven-faster QPN8
+route. GDN input, full-attention QKV, and the LM head stay on TurboMind W8A16.
+The accepted batch-one NVFP4 shapes use the native QPN4 decode route; unsupported
+or non-admitted cases retain the TurboMind fallback. Thus every eligible FP8
+sublayer still uses TurboMind unless the frozen shape has a measured faster
+QPN8 specialization.
+
+The sampler sidecar replaces a full-vocabulary sampling fragment with an
+80-chunk top-20 reduction while preserving canonical sort order, top-p math,
+Philox draws, and generator state. It is built separately so sampler operator
+registration does not relink the quality- and speed-frozen primary `_C`.
+`setup.py` extracts either CPython-SOABI or abi3 sidecar names, and
+`vllm/_sm70_ops.py` loads the bundled module or the explicitly configured
+`VLLM_SM70_SAMPLER_LIBRARY`.
+
+### Speed result
+
+All absolute results use the frozen TP4, input-1024/output-256 contract and
+255 steady decode intervals. TTFT and prefill are excluded.
+
+| Binary/measurement | Steady decode | TPOT | Disposition |
+|---|---:|---:|---|
+| Merged native-sampler baseline | 71.342 tok/s | 14.017 ms | baseline |
+| Hand sidecar repeat A2 | 80.177 tok/s | 12.472 ms | accepted |
+| Hand sidecar repeat A3 | 80.164 tok/s | 12.474 ms | accepted |
+| Hand sidecar repeat A4, physical GPUs 4-7 | 80.026 tok/s | 12.496 ms | accepted |
+| Production CMake C++17 sidecar A2 | **80.624 tok/s** | **12.403 ms** | accepted |
+
+The hand-sidecar accepted repeats preserve the frozen 256-token SHA256
+`0b2d335ddce9b282e45eea1b6c86525bc61eeb5ba1655e8228e6ef3bd1ce823b`.
+The production C++17 sidecar changes a low-margin full-model random trajectory,
+so random token identity is not treated as the sole quality gate. A direct
+cross-build sampler diagnostic covers 100 independent seeds and 256 sequential
+draws: hand and production sidecars produce identical token selections and
+identical final generator-state SHA256
+`4257d205138503840fea92fe6b15ddfa276df82c315513da4bbd785393c98c96`.
+
+### Output-quality gate
+
+The quality contract is the frozen first 250 GSM8K test questions, five-shot
+prompting, greedy generation, maximum 256 output tokens, and per-question
+record retention. It is intentionally independent of the random performance
+prompt.
+
+| Route | Correct | Accuracy | Invalid |
+|---|---:|---:|---:|
+| Frozen pre-optimization baseline | 226/250 | 90.4% | 0 |
+| Hand-sidecar candidate | 227/250 | 90.8% | 0 |
+| Production CMake C++17 sidecar | **226/250** | **90.4%** | **0** |
+
+The production result therefore equals the frozen accuracy baseline with no
+invalid outputs. Its JSON contains all questions, generated texts, extracted
+answers, labels, correctness flags, token IDs, and per-item output hashes. The
+result file SHA256 is
+`143b2b345b830a858bff2568f9cf51148c8185acb42bb129e2dfc2d421a196d2`.
+
+### Accepted-route trace and resource use
+
+The latest Nsight Systems trace uses the accepted compatible main library and
+the behavior-equivalent hand sidecar. It captures 63 graph replays on each of
+four ranks and reports the middle 61 steps. Its 13.465 ms node-traced TPOT is
+composition evidence; the unprofiled 12.474 ms result remains the absolute
+speed evidence. Graph-node kernel coverage is 94.88%.
+
+| Critical component | GPU service/token |
+|---|---:|
+| QPN8 split-16 projections | 2.213 ms |
+| QPN4 fused gate/up | 2.165 ms |
+| TP4 pack32 all-reduce | 1.587 ms |
+| QPN4 down | 1.441 ms |
+| QPN8 output projection | 0.915 ms |
+| Flash-V100 E4M3 XQA p64 | 0.618 ms |
+| QPN8 fused gate/up | 0.496 ms |
+| TurboMind FP8 dense/LM head | 0.410 ms |
+
+The mean replay interval is 13.430 ms and GPU activity union is 12.887 ms,
+or 95.958%; idle gaps total 0.543 ms/token and the largest mean gap is only
+9.538 us. The route still launches 1061.9 kernels per rank per token. The
+grid-limited occupancy ceiling assigns 38.46% of service below 25% occupancy,
+47.86% at 25-50%, and 13.63% at 50-75%, showing that batch-one kernel geometry
+and the serial projection/communication chain remain the main headroom.
+
+NVML's coarse windows report 100% GPU-busy duty, 53.25% memory-active duty,
+and 56.36% of the 300 W power limit. Runtime memory is about 28.97 GiB/GPU;
+SM and memory clocks are 1530 and 877 MHz. These are duty indicators, not
+achieved SM, Tensor Core, or HBM throughput. Nsight Compute counters remain
+unavailable because the driver returns `ERR_NVGPUCTRPERM`. A payload-only
+model estimate is about 491 GB/s/GPU and useful arithmetic is about 4.33
+TFLOP/s across TP4, but neither value is a hardware-counter measurement.
+
+### Reproducibility boundary and evidence
+
+The production sidecar is reproducible through the CMake target
+`_sm70_sampler_C` and its focused microbenchmark selects exactly the reference
+tokens across five distributions, 100 explicit-seed trials, and 100 default
+generator trials. It reduces the measured fragment from 102.427 to 62.972 us.
+The final Python regression run passes all 94 tests in the sampler, NVFP4
+admission, and SM70 TurboMind adapter files. Ruff lint/format, Python byte
+compilation, the sidecar wheel-name gate, and `git diff --check` also pass.
+
+Freshly relinking the primary `_C` was tested separately. Even after matching
+the accepted CUDA cubins for QPN8, QPN4, and custom all-reduce, fresh main
+libraries measured roughly 77-80 tok/s and changed the low-margin random stream.
+Those main-library builds are rejected; do not substitute them for the
+compatible `_C` SHA above until the remaining host/link reproducibility issue
+is resolved. Keeping the sampler in its own sidecar is the accepted packaging
+boundary.
+
+Primary evidence paths are:
+
+- `.artifacts/qwen38_nvfp4_speed_20260823/results/candidate_qpn4_fold_qpn8_m1_arpack32_official_cxx17_sidecar_chunk80_i1k_o256_a2.json`
+- `.artifacts/qwen38_nvfp4_speed_20260823/results/qwen38_nvfp4_gsm8k_250_official_cxx17_sidecar.json`
+- `.artifacts/qwen38_nvfp4_speed_20260823/results/sampler_stream_hand.json`
+- `.artifacts/qwen38_nvfp4_speed_20260823/results/sampler_stream_cxx17.json`
+- `.artifacts/qwen38_nvfp4_speed_20260823/profiles/candidate_qwen38_nvfp4_sidecar_chunk80_nsys_nvml_i1k_o64_per_token.md`
+- `.artifacts/qwen38_nvfp4_speed_20260823/profiles/candidate_qwen38_nvfp4_sidecar_chunk80_resource_summary.md`

--- a/docs/design/sm70_qwen38_qpn8_decode.md
+++ b/docs/design/sm70_qwen38_qpn8_decode.md
@@ -1,0 +1,244 @@
+# SM70 Qwen3.8-27B-FP8 QPN8 Decode Acceptance
+
+Date: 2026-08-23
+
+## Decision
+
+The memory-neutral QPN8 dense route is default-on for the accepted
+Qwen3.8-27B-FP8 TP4 no-MTP model and projection shapes when configured
+`max_num_seqs` is at most eight. Set
+`VLLM_SM70_FP8_QPN8=0` to retain the prior TurboMind layout. An automatic
+route using an older `vllm._C` warns and falls back; an explicit request with
+missing QPN8 operators fails closed.
+
+The gate checks the Qwen3.8 text architecture, 5120 hidden size, 17408
+intermediate size, 64 layers, full-attention interval 4, head dimension 256,
+and TP4. Qwen3.6 and both 35B acceptance routes remain unchanged.
+Configurations admitting more than eight live sequences retain TurboMind at
+load time until a measured M>8 QPN8 route exists. MTP configurations also
+retain TurboMind until their verification widths pass speed and quality gates.
+These guards prevent the functional large-M dequantization fallback from
+becoming a concurrency or speculative-decode regression.
+
+This acceptance is a no-MTP, M=1 decode speed result with numerical tests up
+to M=8 and model-quality batches up to eight. M>8 remains functional through
+one bounded 85 MiB FP16 weight workspace. Large-M fused gate/up also has a
+transient `M x 8704` FP16 GEMM output, so that fallback is not an accepted
+high-concurrency memory or speed result.
+
+## Contract
+
+- Model: `Qwen3.8-27B-FP8`, TP4 on physical V100-SXM2-32GB GPUs 4-7.
+- Runtime: Python 3.12, Torch 2.10.0+cu128, CUDA 12.8, source checkout and
+  source-built SM70 extension; no wheel changes are used.
+- Production speed case: no MTP, E5M2 KV, `FLASH_ATTN_V100`, CUDA graphs,
+  `max_model_len=262144`, input 1024, output 256, and one live request.
+- Official sampling: `temperature=1.0`, `top_p=0.95`, `top_k=20`, request seed
+  20260815. Pure decode excludes TTFT/prefill and uses the 255 steady token
+  intervals.
+- Quality case: identical baseline/candidate datasets and seeds, 4096-token
+  rolling-PPL windows, and generation/log-likelihood batches 1, 2, and 8.
+
+## Source Route
+
+Checkpoint-native block-FP8 weights are repacked once at model load into one
+QPN8 `[K, N]` code tensor plus grouped FP16 scales. The old TurboMind tensor
+is replaced rather than retained, avoiding the approximately 6 GiB/rank
+duplicate-weight experiment. The matched candidate reported 19.89 GiB
+available KV memory versus 19.80 GiB for the control.
+
+The default model and shape gate admits only:
+
+| Projection | TP-local K | TP-local N | Decode schedule |
+|---|---:|---:|---|
+| MLP gate/up with fused SiLU×up | 5120 | 8704 | split-K 8, two accumulator chains, prefetch |
+| MLP down | 4352 | 5120 | split-K 16, one accumulator chain |
+| GDN/full-attention output | 1536 | 5120 | split-K 16, one accumulator chain |
+
+GDN input and full-attention QKV remain on TurboMind. The M decision is inside
+the opaque C++ operator so AOTInductor cannot incorrectly specialize a Python
+M=1 branch for a later prefill. M=1-8 calls QPN8 directly; larger M
+materializes one layer at a time in the shared weight workspace and calls FP16
+GEMM. The large-M gate/up temporary described above is bounded by the engine's
+`max_num_batched_tokens`, not by the 85 MiB weight workspace.
+
+## Pure Decode Result
+
+| Route | Pure TPOT | Steady decode | Change |
+|---|---:|---:|---:|
+| Matched TurboMind control | 16.985327 ms | 58.874 tok/s | baseline |
+| QPN8 accepted subset | 15.808000 ms | 63.259 tok/s | +7.448%, -1.177327 ms/token |
+| Complete-source TurboMind control | 16.961295 ms | 58.958 tok/s | source A/B baseline |
+| Complete-source default, env unset | 16.347973 ms | 61.170 tok/s | +3.752%, -0.613322 ms/token |
+
+Both requests generated all 256 tokens and finished by length. Their sampled
+token streams first differ at output token 91; sampled token identity is not
+the quality gate because both trajectories are coherent and the accepted
+criterion is PPL plus fixed reasoning, knowledge, and Chinese datasets.
+
+The complete-source control generated 256 tokens and finished by length. The
+default-on complete-source request used the same prompt, sampling contract,
+and source extension, but encountered the model's normal stop token 248044 at
+token 233. Its TPOT therefore covers 232 steady intervals rather than the
+control's 255. The earlier 63.259 tok/s matched operator-integration result is
+retained as evidence of headroom, while 61.170 tok/s is the conservative
+complete-source result until another same-source run closes system variance.
+
+## Nsight Systems Per-Token Decomposition
+
+Node tracing adds profiler overhead, so these rows explain composition rather
+than replace the unprofiled TPOT above.
+
+| Steady replay metric | Control | QPN8 | Delta |
+|---|---:|---:|---:|
+| Replay interval | 17.418 ms | 16.437 ms | -0.981 ms |
+| GPU activity union | 16.870 ms | 15.894 ms | -0.976 ms |
+| Total idle gaps | 0.548 ms | 0.543 ms | -0.005 ms |
+| Kernel launches/rank/token | 1085.5 | 1085.9 | unchanged |
+
+The trace gain is therefore GPU kernel service, not a hidden CPU wait or
+launch-gap reduction. Dense service changes from 10.335 ms/rank/token to:
+
+| Candidate dense component | Time | Launches/rank/token |
+|---|---:|---:|
+| Fused QPN8 gate/up | 4.018 ms | 64 |
+| QPN8 down and output projections | 3.040 ms | 128 |
+| Remaining TurboMind GDN/full-QKV input | 2.332 ms | 64 |
+| Total dense | 9.391 ms | 256 |
+
+This accounts for about 0.944 ms/token of the trace improvement. TP
+communication is 1.680 to 1.637 ms and LM-head/sample/gather remains about
+1.33 ms, so neither explains the main win.
+
+## Resource Release and Peak-Band Residency
+
+Whole-request NVML averages are not used as achieved FLOPS or bandwidth.
+Nsight Systems establishes how long grids can occupy the machine, and Nsight
+Compute supplies achieved per-kernel counters.
+
+The grid-limited occupancy ceiling moves from 93.56% of service below 25%
+occupancy in the control to 48.56% below 25%, 32.11% at 25-50%, and 19.26% at
+50-75% with QPN8. This is a duration distribution, not an average-utilization
+claim.
+
+For the accepted QPN8 kernels, NCU reports:
+
+| Shape | Registers/thread | Achieved occupancy | SM throughput | DRAM throughput | Tensor-pipe elapsed |
+|---|---:|---:|---:|---:|---:|
+| Down | 50 | 48.90% | 27.20% | 82.74% | 9.50% |
+| Output | 50 | 48.17% | 27.69% | 71.32% | 8.23% |
+| Fused gate/up | 64 | 42.33% | 29.98% | 87.74% | 10.08% |
+
+Counting the useful M=1 dense multiply-add work, throughput is 1.177 to
+1.295 TFLOP/s per GPU, or 4.71 to 5.18 TFLOP/s across TP4.
+Dense-service-weighted Tensor Core pipe activity is 7.97% to 9.15%,
+equivalent to about 9.99 to 11.47 TFLOP/s per GPU, or 39.96 to 45.88 TFLOP/s
+across TP4, relative to the V100's nominal FP16 Tensor Core peak. These answer
+different questions: the first is model-useful arithmetic, while the second
+includes tensor instructions spent inside the split-K implementation. Neither
+is a whole-request average.
+
+Across the 9.391 ms candidate dense service, 7.059 ms resides in the 25-50%
+SM-throughput band and 2.332 ms remains below 25%; no dense kernel reaches
+50% SM throughput. For DRAM, 6.172 ms resides at 75-90% and 3.219 ms at
+50-75%; no dense kernel reaches 90%. Dense-service-weighted achieved
+occupancy rises from 9.96% to 36.25%, but the duration bands above are the
+primary evidence.
+
+The result is not “the V100 cannot reach peak compute.” QPN8 makes a much
+larger fraction of dense time sustain high memory duty and occupancy, while
+the unchanged approximately 0.54 ms idle budget shows that host launch work
+is not the present first-order limit.
+
+## SGLang-V100 Comparison Boundary
+
+The current [sglang-V100 README](https://github.com/haohervchb/sglang-V100/blob/main/README.md)
+now reports a Qwen3.8-27B-FP8 target-only, E5M2 KV, TP4 row at 58.2 tok/s for
+1K decode and 50.8 tok/s for 25K decode. Its table uses one cold request and
+256 greedy output tokens. The linked
+[target-only audit](https://github.com/haohervchb/sglang-V100/blob/main/benchmark/qwen38_27b_fp8_target_e5m2_v100_20260822/README.md)
+records 17.180 ms TPOT, or 58.21 tok/s, at 1,024 input tokens. The 63.259
+tok/s QPN8 result here is 8.67% above that published number, so the public
+evidence points to this route being faster. It is not a strict head-to-head
+because this acceptance uses fixed random sampling and a different
+prompt/client harness. A formal claim still requires running SGLang's
+target-only command with the same prompt, sampling, graph, and pure-decode
+accounting used here.
+
+The published 136.6 tok/s DFlash2-8 row is speculative and is not a no-MTP
+comparison.
+
+## Quality Gate
+
+The gate compares the prior TurboMind route and QPN8 with identical prompts,
+few-shot examples, seeds, and batching. Lower is better for the three
+WikiText metrics; higher is better for the remaining accuracy metrics.
+
+| Dataset and metric | Samples | Control | QPN8 | Result |
+|---|---:|---:|---:|---|
+| WikiText word perplexity | 62 documents | 8.790013 | 8.789904 | pass, lower |
+| WikiText byte perplexity | 62 documents | 1.501519 | 1.501515 | pass, lower |
+| WikiText bits/byte | 62 documents | 0.586422 | 0.586419 | pass, lower |
+| GSM8K 5-shot strict exact match | 128 | 69.531% | 70.312% | pass, +1 item |
+| GSM8K 5-shot flexible extraction | 128 | 73.438% | 73.438% | pass, equal |
+| MMLU abstract algebra 5-shot | 100 | 67.0% | 67.0% | pass, equal |
+| MMLU high-school computer science 5-shot | 100 | 89.0% | 89.0% | pass, equal |
+| MMLU professional law 5-shot | 100 | 63.0% | 66.0% | pass, +3 items |
+| MMLU three-subject macro | 300 | 73.0% | 74.0% | pass |
+| C-Eval computer network 5-shot | 19 | 73.684% | 73.684% | pass, equal |
+| C-Eval high-school Chinese 5-shot | 19 | 73.684% | 73.684% | pass, equal |
+| C-Eval advanced mathematics 5-shot | 19 | 57.895% | 57.895% | pass, equal |
+
+No evaluated metric regresses. This is why the default decision does not
+depend on greedy token identity or the sampled A/B trajectory remaining
+bitwise identical.
+
+## Build and Tests
+
+- The complete source `_C` target built 47/47 objects for CUDA 12.8 and SM70;
+  the resulting 45 MiB extension registers all six prepare, dequantize,
+  prefill, dispatch, GEMM, and fused-gate QPN8 operators.
+- The operator race passed 960 rows. Maximum relative L2 was `2.851e-4`,
+  minimum cosine was `0.99999988`, and maximum absolute error was `9.77e-4`;
+  CUDA Graph replay deltas were zero.
+- Seventeen focused Python tests pass, covering default/explicit-off policy,
+  model and shape gates, workspace reuse, M=1 and M>8 opaque dispatch, fused
+  gate/up dispatch, and warmup registration.
+- Ruff lint/format, changed-line clang-format, Python byte compilation, shell
+  syntax checks, and `git diff --check` pass.
+
+## Next Optimization Order
+
+1. Extend QPN8 with a single-launch two-dimensional row-tile grid and race
+   M=9, 11, and 16 against TurboMind. Do not compose an 8-row launch with a
+   separate tail launch, and do not assume the batch-one winner stays best.
+2. Race M=17, 32, and 64 and keep a measured route map. The external
+   [v100-skinny QPN study](https://github.com/dnv2003/v100-skinny/blob/main/docs/qpn_race_notes.md)
+   also finds a crossover to WMMA/TurboMind above the small-batch band.
+3. Before high-concurrency acceptance, replace or chunk the large-M fused
+   gate/up temporary and record peak memory under the supported batched-token
+   limit.
+4. Add a bounded large-M route for GDN input/full-QKV, then quality-gate it.
+   Those 64 remaining TurboMind launches consume 2.332 ms/token.
+5. Continue shape-specific work on fused gate/up (4.018 ms) and down/output
+   (3.040 ms), measuring time above 90% DRAM and 50% SM rather than optimizing
+   a whole-run average.
+6. Revisit the 1.637 ms communication and 1.33 ms LM-head only after the dense
+   residue falls. The current trace does not justify prioritizing Python launch
+   overhead.
+7. Repeat the decomposition at 25K and 70K. SGLang's target-only 70K trace
+   reports 10.60 ms/token in FP8 projections and 10.35 ms/token in attention,
+   so the 1K optimization order must not be hard-coded for long context.
+
+The ordering is also consistent with external evidence, without treating a
+newer-architecture implementation as a V100 drop-in. The
+[v100-skinny M sweep](https://github.com/dnv2003/v100-skinny/blob/main/docs/REPRODUCE.md)
+uses a measured SIMT/QPN/WMMA dispatch map rather than one kernel for every M.
+The [CUTLASS grouped scheduler](https://github.com/NVIDIA/cutlass/blob/main/media/docs/cpp/grouped_scheduler.md)
+shows how a bounded persistent CTA work queue can retain residency across many
+independent small tiles; it becomes relevant only if independent problems can
+be grouped without crossing transformer dependencies. The
+[FlashInfer paper](https://arxiv.org/abs/2501.01005) similarly makes dynamic,
+load-balanced scheduling compatible with a static CUDA Graph. For this route,
+those are design constraints to test under concurrency, not reasons to replace
+the measured SM70 kernels speculatively.

--- a/docs/design/sm70_qwen38_qpn8_decode.md
+++ b/docs/design/sm70_qwen38_qpn8_decode.md
@@ -4,12 +4,12 @@ Date: 2026-08-23
 
 ## Decision
 
-The memory-neutral QPN8 dense route is default-on for the accepted
+The memory-neutral QPN8 dense route is available as an opt-in for the
 Qwen3.8-27B-FP8 TP4 no-MTP model and projection shapes when configured
-`max_num_seqs` is at most eight. Set
-`VLLM_SM70_FP8_QPN8=0` to retain the prior TurboMind layout. An automatic
-route using an older `vllm._C` warns and falls back; an explicit request with
-missing QPN8 operators fails closed.
+`max_num_seqs` is at most eight. Set `VLLM_SM70_FP8_QPN8=1` to request it.
+The model-quality gate passes, but pure-FP8 default promotion still requires a
+same-source speed rerun with the same number of steady decode intervals. An
+explicit request with missing QPN8 operators fails closed.
 
 The gate checks the Qwen3.8 text architecture, 5120 hidden size, 17408
 intermediate size, 64 layers, full-attention interval 4, head dimension 256,
@@ -47,7 +47,7 @@ is replaced rather than retained, avoiding the approximately 6 GiB/rank
 duplicate-weight experiment. The matched candidate reported 19.89 GiB
 available KV memory versus 19.80 GiB for the control.
 
-The default model and shape gate admits only:
+The opt-in model and shape gate admits only:
 
 | Projection | TP-local K | TP-local N | Decode schedule |
 |---|---:|---:|---|
@@ -69,20 +69,22 @@ GEMM. The large-M gate/up temporary described above is bounded by the engine's
 | Matched TurboMind control | 16.985327 ms | 58.874 tok/s | baseline |
 | QPN8 accepted subset | 15.808000 ms | 63.259 tok/s | +7.448%, -1.177327 ms/token |
 | Complete-source TurboMind control | 16.961295 ms | 58.958 tok/s | source A/B baseline |
-| Complete-source default, env unset | 16.347973 ms | 61.170 tok/s | +3.752%, -0.613322 ms/token |
+| Complete-source QPN8 candidate | 16.347973 ms | 61.170 tok/s | +3.752%, -0.613322 ms/token |
 
-Both requests generated all 256 tokens and finished by length. Their sampled
-token streams first differ at output token 91; sampled token identity is not
-the quality gate because both trajectories are coherent and the accepted
-criterion is PPL plus fixed reasoning, knowledge, and Chinese datasets.
+The matched operator-integration pair generated all 256 tokens and finished by
+length. Their sampled token streams first differ at output token 91; sampled
+token identity is not the quality gate because both trajectories are coherent
+and the acceptance criterion is PPL plus fixed reasoning, knowledge, and
+Chinese datasets.
 
 The complete-source control generated 256 tokens and finished by length. The
-default-on complete-source request used the same prompt, sampling contract,
+complete-source QPN8 request used the same prompt, sampling contract,
 and source extension, but encountered the model's normal stop token 248044 at
 token 233. Its TPOT therefore covers 232 steady intervals rather than the
 control's 255. The earlier 63.259 tok/s matched operator-integration result is
-retained as evidence of headroom, while 61.170 tok/s is the conservative
-complete-source result until another same-source run closes system variance.
+retained as evidence of headroom. Because 61.170 tok/s uses 232 intervals while
+the control uses 255, another same-source equal-interval run is required before
+pure-FP8 default promotion.
 
 ## Nsight Systems Per-Token Decomposition
 
@@ -189,9 +191,8 @@ WikiText metrics; higher is better for the remaining accuracy metrics.
 | C-Eval high-school Chinese 5-shot | 19 | 73.684% | 73.684% | pass, equal |
 | C-Eval advanced mathematics 5-shot | 19 | 57.895% | 57.895% | pass, equal |
 
-No evaluated metric regresses. This is why the default decision does not
-depend on greedy token identity or the sampled A/B trajectory remaining
-bitwise identical.
+No evaluated metric regresses. This closes the quality side of the opt-in
+route; it does not replace the missing equal-interval performance rerun.
 
 ## Build and Tests
 
@@ -201,7 +202,7 @@ bitwise identical.
 - The operator race passed 960 rows. Maximum relative L2 was `2.851e-4`,
   minimum cosine was `0.99999988`, and maximum absolute error was `9.77e-4`;
   CUDA Graph replay deltas were zero.
-- Seventeen focused Python tests pass, covering default/explicit-off policy,
+- Seventeen focused Python tests pass, covering opt-in/explicit-off policy,
   model and shape gates, workspace reuse, M=1 and M>8 opaque dispatch, fused
   gate/up dispatch, and warmup registration.
 - Ruff lint/format, changed-line clang-format, Python byte compilation, shell

--- a/docs/design/sm70_v100_migration_control.md
+++ b/docs/design/sm70_v100_migration_control.md
@@ -42156,3 +42156,41 @@ Interpretation:
   deterministic greedy/natural-text or dataset-quality gate passes. Evidence
   is under
   `/data/minimax-h3/task-cache/qwen38-fp8-128k-flashattention-20260824/`.
+## 2026-08-23 Qwen3.8-27B-FP8 TP4 no-MTP QPN8 decode acceptance
+
+- Integration base is `7aede2cf01`; the owned source worktree and Draft PR are
+  `codex/v100-qwen38-fp8-qpn8-operator-race-20260822-114943` and PR 258.
+- Added a memory-neutral SM70 QPN8 weight layout and direct decode operators for
+  the accepted TP-local gate/up `(K,N)=(5120,8704)`, down `(4352,5120)`, and
+  output `(1536,5120)` projections. GDN input and full-attention QKV remain on
+  TurboMind. The old layout is replaced at load time rather than retained.
+- Default admission is exact-model and exact-shape gated to Qwen3.8-27B-FP8,
+  TP4, no MTP, and configured `max_num_seqs <= 8`. Native QPN8 handles M=1-8.
+  Wider-concurrency and MTP configurations retain TurboMind until their own
+  performance and quality gates pass; this is not a batch-one-only dispatch.
+- The opaque C++ M dispatch prevents an AOTInductor M=1 trace from being reused
+  for prefill. M>8 remains functionally correct through one bounded 85 MiB FP16
+  weight workspace, but fused gate/up additionally creates an `M x 8704` FP16
+  temporary and is not accepted as a high-concurrency performance route.
+- Complete-source no-MTP E5M2 TP4 A/B at input 1024 and output cap 256 measured
+  TurboMind at `16.961295 ms/token`, `58.958 tok/s`, and default-on QPN8 at
+  `16.347973 ms/token`, `61.170 tok/s` (`+3.752%`). The candidate stopped
+  normally at token 233; the control finished all 256 tokens. An earlier
+  matched operator-integration run measured `15.808000 ms/token`,
+  `63.259 tok/s` (`+7.448%`) and remains headroom evidence, not the conservative
+  complete-source claim.
+- Nsight Systems attributes about `0.944 ms/token` of the trace improvement to
+  dense service (`10.335 -> 9.391 ms`), while launch count and GPU idle time are
+  unchanged. The QPN8 dense service spends 6.172 ms in the 75-90% DRAM band and
+  7.059 ms in the 25-50% SM band; no dense kernel sustains at least 90% DRAM or
+  50% SM. Useful dense arithmetic rises from 1.177 to 1.295 TFLOP/s per GPU.
+- The quality gate passed without a measured regression: WikiText PPL/byte PPL
+  and bits/byte improved slightly, GSM8K flexible accuracy was equal and strict
+  accuracy improved by one item, all measured MMLU subjects were equal or
+  better, and all measured C-Eval subjects were equal. Sampled token identity
+  is therefore not used as the sole acceptance criterion.
+- Full evidence and artifact paths are recorded in
+  `docs/design/sm70_qwen38_qpn8_decode.md`. Next work is a measured single-launch
+  M=9/11/16 row-tile route, followed by larger concurrency crossovers; do not
+  compose an eight-row launch with a separate tail or promote the current
+  large-M temporary as an accepted throughput implementation.

--- a/docs/design/sm70_v100_migration_control.md
+++ b/docs/design/sm70_v100_migration_control.md
@@ -42204,14 +42204,21 @@ Interpretation:
   Flash-V100 XQA, QPN8 split-12 for the K1536 x N5120 output projection, and
   an exact B1/G6/D256 E4M3 p64 attention partition.
 - Frozen TP4 I1024/O256, E4M3 KV, official random sampling, no-MTP, and full
-  CUDA graph decode is **71.732 tok/s** at **13.941 ms/token** with the native
-  sampler. The clean p128 control is 69.904 tok/s at 14.305 ms/token.
+  CUDA graph decode first measured 71.732 tok/s at 13.941 ms/token with the
+  native sampler. After merging current `onecat/main` at `675a12dedc` and
+  rebuilding Flash-V100, the frozen request reconfirmed **71.342 tok/s** at
+  **14.017 ms/token**. The clean p128 control is 69.904 tok/s at
+  14.305 ms/token.
 - The p64 operator sweep saves 9.55-16.98 us per attention launch from sequence
   lengths 1025-2049. All p64/p128 cases stay within one FP16 output ULP of the
   scalar reference; the focused GPU suite passes 6/6.
 - Compact and fused top-k20 sampler experiments were removed because their
   sampled trajectories were not deterministic against the native route. They
-  are not part of the 71.732 tok/s claim.
+  are not part of either accepted p64 result.
+- Post-merge checks pass: 12/12 focused CPU policy/dispatch cases, 6/6 E4M3
+  XQA GPU numerical cases, Ruff lint/format, and `git diff --check`. The final
+  `_C` and Flash-V100 SHA256 values are `e0ea14d0...7624` and
+  `b418fed8...dce7`.
 - Full contract, route map, staged results, profile table, numerical evidence,
   rejected paths, rollback controls, and artifacts are in
   `docs/design/sm70_qwen38_nvfp4_decode.md`.

--- a/docs/design/sm70_v100_migration_control.md
+++ b/docs/design/sm70_v100_migration_control.md
@@ -42219,6 +42219,14 @@ Interpretation:
   XQA GPU numerical cases, Ruff lint/format, and `git diff --check`. The final
   `_C` and Flash-V100 SHA256 values are `e0ea14d0...7624` and
   `b418fed8...dce7`.
+- The latest merged p64 Nsight Systems trace captures 63 decode replays on all
+  four ranks. Steady replay/GPU-union time is 14.621/14.055 ms, GPU activity
+  union is 96.136%, and the route launches 1140.8 kernels/rank/token. NVML
+  samples show 99.47% GPU busy-window duty but only 48.26% memory-active duty;
+  69.40% of service has a grid-limited occupancy ceiling below 25%. Current NCU
+  counters remain unavailable because the driver rejects non-root counter
+  access with `ERR_NVGPUCTRPERM`; do not present NVML duty or effective payload
+  rates as achieved SM or HBM throughput.
 - Full contract, route map, staged results, profile table, numerical evidence,
   rejected paths, rollback controls, and artifacts are in
   `docs/design/sm70_qwen38_nvfp4_decode.md`.

--- a/docs/design/sm70_v100_migration_control.md
+++ b/docs/design/sm70_v100_migration_control.md
@@ -42156,6 +42156,7 @@ Interpretation:
   deterministic greedy/natural-text or dataset-quality gate passes. Evidence
   is under
   `/data/minimax-h3/task-cache/qwen38-fp8-128k-flashattention-20260824/`.
+
 ## 2026-08-23 Qwen3.8-27B-FP8 TP4 no-MTP QPN8 decode acceptance
 
 - Integration base is `7aede2cf01`; the owned source worktree and Draft PR are
@@ -42164,7 +42165,7 @@ Interpretation:
   the accepted TP-local gate/up `(K,N)=(5120,8704)`, down `(4352,5120)`, and
   output `(1536,5120)` projections. GDN input and full-attention QKV remain on
   TurboMind. The old layout is replaced at load time rather than retained.
-- Default admission is exact-model and exact-shape gated to Qwen3.8-27B-FP8,
+- Opt-in admission is exact-model and exact-shape gated to Qwen3.8-27B-FP8,
   TP4, no MTP, and configured `max_num_seqs <= 8`. Native QPN8 handles M=1-8.
   Wider-concurrency and MTP configurations retain TurboMind until their own
   performance and quality gates pass; this is not a batch-one-only dispatch.
@@ -42173,12 +42174,14 @@ Interpretation:
   weight workspace, but fused gate/up additionally creates an `M x 8704` FP16
   temporary and is not accepted as a high-concurrency performance route.
 - Complete-source no-MTP E5M2 TP4 A/B at input 1024 and output cap 256 measured
-  TurboMind at `16.961295 ms/token`, `58.958 tok/s`, and default-on QPN8 at
+  TurboMind at `16.961295 ms/token`, `58.958 tok/s`, and QPN8 at
   `16.347973 ms/token`, `61.170 tok/s` (`+3.752%`). The candidate stopped
   normally at token 233; the control finished all 256 tokens. An earlier
   matched operator-integration run measured `15.808000 ms/token`,
   `63.259 tok/s` (`+7.448%`) and remains headroom evidence, not the conservative
-  complete-source claim.
+  complete-source observation. Because these arms contain 255 versus 232
+  steady intervals, respectively, this is not a pure-FP8 default-promotion
+  result; an equal-interval same-source rerun remains required.
 - Nsight Systems attributes about `0.944 ms/token` of the trace improvement to
   dense service (`10.335 -> 9.391 ms`), while launch count and GPU idle time are
   unchanged. The QPN8 dense service spends 6.172 ms in the 75-90% DRAM band and

--- a/docs/design/sm70_v100_migration_control.md
+++ b/docs/design/sm70_v100_migration_control.md
@@ -42230,3 +42230,51 @@ Interpretation:
 - Full contract, route map, staged results, profile table, numerical evidence,
   rejected paths, rollback controls, and artifacts are in
   `docs/design/sm70_qwen38_nvfp4_decode.md`.
+
+## 2026-08-24 Qwen3.8-27B-NVFP4 TP4 no-MTP 80 tok/s acceptance
+
+- The frozen input-1024/output-256 TP4 contract now passes the requested
+  no-MTP speed gate. The production CMake C++17 sampler-sidecar run measures
+  **80.624 tok/s** at **12.403 ms/token**. Three behavior-equivalent hand
+  sidecar repeats measure 80.177, 80.164, and 80.026 tok/s, including a repeat
+  on physical GPUs 4-7. Pure decode excludes TTFT and prefill.
+- The deployment retains the proven-faster exact-shape QPN8 projections. GDN
+  input, full-attention QKV, and the LM head continue through TurboMind W8A16;
+  non-admitted NVFP4 cases retain TurboMind fallback. The accepted batch-one
+  NVFP4 shapes use native QPN4, E4M3 attention uses Flash-V100 XQA p64, and TP4
+  communication uses the pack32 one-stage all-reduce. MTP is disabled.
+- The quality gate passes at the frozen baseline: the production sidecar scores
+  **226/250 (90.4%)** on the first 250 GSM8K questions with five-shot greedy
+  prompting and has zero invalid outputs. The baseline is also 226/250; the
+  hand-sidecar result is 227/250. Per-question prompts, texts, token IDs,
+  extracted answers, labels, correctness, and hashes are retained in the JSON.
+- The production sidecar and hand-built validation library select identical
+  tokens for 100 independent seeds and 256 sequential Philox draws and finish
+  with the same generator state. This exact implementation supersedes the
+  earlier rejected compact/fused sampler experiments, which did not preserve
+  native Philox behavior.
+- The accepted compatible main `_C`, production sampler sidecar, and
+  Flash-V100 SHA256 values are `a0a0cd9...d36d`, `cdbfdd87...9ae`, and
+  `b418fed8...dce7`. The sampler is intentionally a separate CMake/wheel module
+  so registering it does not relink the frozen main library.
+- The latest 63-replay/rank Nsight Systems trace shows a 13.430 ms mean replay
+  interval, 12.887 ms GPU activity union (95.958%), 0.543 ms idle, and 1061.9
+  launches/rank/token. QPN8 split-16, QPN4 gate/up, TP all-reduce, QPN4 down,
+  QPN8 output, XQA, QPN8 gate/up, and TurboMind FP8 service contribute 2.213,
+  2.165, 1.587, 1.441, 0.915, 0.618, 0.496, and 0.410 ms/token respectively.
+- NVML reports 100% busy-window duty, 53.25% memory-active duty, about 28.97
+  GiB allocated per GPU, and 56.36% of the 300 W limit. Grid-limited occupancy
+  ceilings put 86.32% of service below 50% occupancy. These are not achieved
+  SM/Tensor/HBM counters; Nsight Compute remains blocked by
+  `ERR_NVGPUCTRPERM`.
+- Fresh primary `_C` relinks remain rejected even when the relevant CUDA cubins
+  match: observed speed is roughly 77-80 tok/s and the low-margin random stream
+  changes. Until the host/link reproducibility difference is closed, the
+  compatible main SHA above plus the production sidecar is the acceptance
+  boundary. This prevents a source rebuild from being mistaken for validated
+  deployment evidence.
+- Final focused regressions pass 94/94 sampler, NVFP4-admission, and SM70
+  TurboMind-adapter tests. Ruff lint/format, Python byte compilation, the
+  sidecar wheel filename gate, and `git diff --check` also pass.
+- Full results, route details, quality artifacts, trace/resource tables, and
+  exact evidence paths are in `docs/design/sm70_qwen38_nvfp4_decode.md`.

--- a/docs/design/sm70_v100_migration_control.md
+++ b/docs/design/sm70_v100_migration_control.md
@@ -42267,14 +42267,33 @@ Interpretation:
   ceilings put 86.32% of service below 50% occupancy. These are not achieved
   SM/Tensor/HBM counters; Nsight Compute remains blocked by
   `ERR_NVGPUCTRPERM`.
-- Fresh primary `_C` relinks remain rejected even when the relevant CUDA cubins
-  match: observed speed is roughly 77-80 tok/s and the low-margin random stream
-  changes. Until the host/link reproducibility difference is closed, the
-  compatible main SHA above plus the production sidecar is the acceptance
-  boundary. This prevents a source rebuild from being mistaken for validated
-  deployment evidence.
-- Final focused regressions pass 94/94 sampler, NVFP4-admission, and SM70
-  TurboMind-adapter tests. Ruff lint/format, Python byte compilation, the
-  sidecar wheel filename gate, and `git diff --check` also pass.
+- Current-source rebuild closure is complete at source snapshot `7bd1d783e4`.
+  A clean primary `_C` plus clean C++17 sampler measured 77.314 tok/s in the
+  cold A1 observation and **80.181 tok/s** at **12.472 ms/token** in A2. A2
+  exactly matches the accepted C++17 256-token stream and records
+  `speculative_config=None` plus `spec_decoding_metrics=null`.
+- The clean primary and sampler SHA256 values are `c5d7c6a9...3e56` and
+  `3058051f...bc74`. Their `.nv_fatbin` SHA256 values, `dbba7402...26e6` and
+  `9a89e8cc...b2c`, are byte-identical to the accepted binaries. Full ELF
+  hashes differ only across host/link content: merged main adds two unrelated
+  ModelOpt NVFP4 MoE host entry points, while the sampler includes host
+  build-ID differences. These do not enter the accepted dense batch-one graph.
+- The clean A2 result SHA256 is `4e6ed330...bb1`; its serialized token-array
+  SHA256 is `f50e0eba...e32`, exactly matching the accepted production C++17
+  run. Device-binary and sampled-stream identity carry forward the already
+  passed **226/250 (90.4%)**, zero-invalid GSM8K gate. The separate sampler
+  module remains the packaging boundary, but current-source primary rebuilds
+  are no longer rejected merely because the full ELF hash changes.
+- Focused CMake installation puts the modules at `vllm/_C.abi3.so` and the
+  CPython-3.12 SOABI sampler filename, strips build-tree RPATHs, and preserves
+  both accepted fatbins. The installed SHA256 values are `d7ed490e...6749` and
+  `8ee84663...55e`. Loading both staged files registers QPN4, QPN8, and the
+  packed top-20 sampler schemas. This closes the relevant install boundary
+  without rebuilding 50 unrelated wheel-target objects.
+- Final focused regressions pass 94/94 target sampler, NVFP4-admission, and
+  SM70 TurboMind-adapter tests; the post-merge four-file run including the
+  adjacent ModelOpt route passes 106/106. Ruff lint/format, Python byte
+  compilation, the sidecar wheel filename gate, and `git diff --check` also
+  pass.
 - Full results, route details, quality artifacts, trace/resource tables, and
   exact evidence paths are in `docs/design/sm70_qwen38_nvfp4_decode.md`.

--- a/docs/design/sm70_v100_migration_control.md
+++ b/docs/design/sm70_v100_migration_control.md
@@ -42194,3 +42194,24 @@ Interpretation:
   M=9/11/16 row-tile route, followed by larger concurrency crossovers; do not
   compose an eight-row launch with a separate tail or promote the current
   large-M temporary as an accepted throughput implementation.
+
+## 2026-08-23 Qwen3.8-27B-NVFP4 TP4 decode recovery
+
+- Recovered the mixed NVFP4/channel-FP8 checkpoint without crediting Marlin:
+  accepted FP8 projection shapes use QPN8, remaining FP8 projections and the
+  LM head use TurboMind W8A16, and NVFP4 uses TurboMind W4A16.
+- Added channelwise FP8 TurboMind packing, exact NVFP4 N32 selectors, E4M3
+  Flash-V100 XQA, QPN8 split-12 for the K1536 x N5120 output projection, and
+  an exact B1/G6/D256 E4M3 p64 attention partition.
+- Frozen TP4 I1024/O256, E4M3 KV, official random sampling, no-MTP, and full
+  CUDA graph decode is **71.732 tok/s** at **13.941 ms/token** with the native
+  sampler. The clean p128 control is 69.904 tok/s at 14.305 ms/token.
+- The p64 operator sweep saves 9.55-16.98 us per attention launch from sequence
+  lengths 1025-2049. All p64/p128 cases stay within one FP16 output ULP of the
+  scalar reference; the focused GPU suite passes 6/6.
+- Compact and fused top-k20 sampler experiments were removed because their
+  sampled trajectories were not deterministic against the native route. They
+  are not part of the 71.732 tok/s claim.
+- Full contract, route map, staged results, profile table, numerical evidence,
+  rejected paths, rollback controls, and artifacts are in
+  `docs/design/sm70_qwen38_nvfp4_decode.md`.

--- a/flash-attention-v100/flash_attn_v100/flash_attn_interface.py
+++ b/flash-attention-v100/flash_attn_v100/flash_attn_interface.py
@@ -18,6 +18,7 @@ except ImportError:
 
 DEFAULT_DECODE_PARTITION_SIZE = 256
 VALID_DECODE_PARTITION_SIZES = (256, 512, 1024)
+E4M3_XQA_VALID_DECODE_PARTITION_SIZES = (64, 128, 256, 512, 1024)
 _decode_plan_cache = {}
 _decode_workspace_cache = {}
 _xqa_staged_rescale_workspace_cache = {}
@@ -152,6 +153,7 @@ def _get_decode_plan(
     workspace_seq_capacity_hint: int | None = None,
     active_num_partitions: torch.Tensor | None = None,
     partition_size_hint: int | None = None,
+    valid_partition_sizes: tuple[int, ...] = VALID_DECODE_PARTITION_SIZES,
 ) -> _DecodePlan:
     batch_capacity = batch_size_hint or block_table.shape[0]
     num_heads = q.shape[1]
@@ -184,6 +186,7 @@ def _get_decode_plan(
         _validate_decode_partition_size(
             int(partition_size_hint),
             "partition_size_hint",
+            valid_partition_sizes,
         )
         if partition_size_hint is not None
         else _get_decode_partition_size(
@@ -529,11 +532,13 @@ def _select_default_decode_partition_size(
     return DEFAULT_DECODE_PARTITION_SIZE
 
 
-def _validate_decode_partition_size(value: int, name: str) -> int:
-    if value not in VALID_DECODE_PARTITION_SIZES:
-        raise ValueError(
-            f"{name} must be one of {VALID_DECODE_PARTITION_SIZES}, got {value}"
-        )
+def _validate_decode_partition_size(
+    value: int,
+    name: str,
+    valid_partition_sizes: tuple[int, ...] = VALID_DECODE_PARTITION_SIZES,
+) -> int:
+    if value not in valid_partition_sizes:
+        raise ValueError(f"{name} must be one of {valid_partition_sizes}, got {value}")
     return value
 
 
@@ -1017,6 +1022,14 @@ def flash_attn_decode_paged_xqa(
         workspace_seq_capacity_hint=workspace_seq_capacity_hint,
         active_num_partitions=active_num_partitions,
         partition_size_hint=partition_size_hint,
+        valid_partition_sizes=(
+            E4M3_XQA_VALID_DECODE_PARTITION_SIZES
+            if kv_cache_dtype in ("fp8", "fp8_e4m3")
+            and q.shape == (1, 6, 256)
+            and k_cache.dtype == torch.uint8
+            and v_cache.dtype == torch.uint8
+            else VALID_DECODE_PARTITION_SIZES
+        ),
     )
     _assert_decode_launch_covers_seq_lens(
         plan,

--- a/flash-attention-v100/kernel/flash_decode_paged.cu
+++ b/flash-attention-v100/kernel/flash_decode_paged.cu
@@ -19,7 +19,8 @@
 namespace {
 
 int kv_cache_dtype_code_from_string(const std::string& kv_cache_dtype) {
-  if (kv_cache_dtype == "auto" || kv_cache_dtype == "bfloat16") {
+  if (kv_cache_dtype == "auto" || kv_cache_dtype == "float16" ||
+      kv_cache_dtype == "bfloat16") {
     return flash_v100::KV_CACHE_DTYPE_FP16;
   }
   if (kv_cache_dtype == "fp8" || kv_cache_dtype == "fp8_e4m3") {
@@ -536,6 +537,50 @@ __device__ __forceinline__ uint4 fp8_e5m2_vector_to_half8(const uint64_t raw) {
       fp8_e5m2_pair_to_half2_bits(static_cast<uint16_t>(raw >> 48)));
 }
 
+__device__ __forceinline__ uint16_t fp8_e4m3fn_to_half_bits(
+    const uint8_t raw) {
+  const uint16_t sign = static_cast<uint16_t>(raw & 0x80u) << 8;
+  const uint8_t magnitude = raw & 0x7fu;
+  const uint8_t exponent = magnitude >> 3;
+  const uint8_t mantissa = magnitude & 0x07u;
+  if (magnitude == 0) {
+    return sign;
+  }
+  if (exponent == 0) {
+    // E4M3 subnormals are exact fp16 normals: mantissa * 2^-9.
+    const uint16_t magnitude_bits =
+        mantissa < 2
+            ? 0x1800u
+            : (mantissa < 4
+                   ? static_cast<uint16_t>(0x1c00u | ((mantissa - 2) << 9))
+                   : static_cast<uint16_t>(0x2000u | ((mantissa - 4) << 8)));
+    return sign | magnitude_bits;
+  }
+  if (magnitude == 0x7fu) {
+    return sign | 0x7e00u;
+  }
+  return sign | static_cast<uint16_t>((exponent + 8) << 10) |
+         static_cast<uint16_t>(mantissa << 7);
+}
+
+__device__ __forceinline__ uint32_t fp8_e4m3fn_pair_to_half2_bits(
+    const uint16_t raw_pair) {
+  return static_cast<uint32_t>(
+             fp8_e4m3fn_to_half_bits(static_cast<uint8_t>(raw_pair))) |
+         (static_cast<uint32_t>(fp8_e4m3fn_to_half_bits(
+              static_cast<uint8_t>(raw_pair >> 8)))
+          << 16);
+}
+
+__device__ __forceinline__ uint4 fp8_e4m3fn_vector_to_half8(
+    const uint64_t raw) {
+  return make_uint4(
+      fp8_e4m3fn_pair_to_half2_bits(static_cast<uint16_t>(raw)),
+      fp8_e4m3fn_pair_to_half2_bits(static_cast<uint16_t>(raw >> 16)),
+      fp8_e4m3fn_pair_to_half2_bits(static_cast<uint16_t>(raw >> 32)),
+      fp8_e4m3fn_pair_to_half2_bits(static_cast<uint16_t>(raw >> 48)));
+}
+
 template <int BLOCK_SIZE, bool CONTIGUOUS_HKV1_LAYOUT,
           int KV_DTYPE = flash_v100::KV_CACHE_DTYPE_FP16>
 __device__ __forceinline__ uint4 load_xqa_tc_kv_vector(
@@ -582,11 +627,16 @@ __device__ __forceinline__ uint4 load_xqa_tc_kv_vector(
     const uint4* cache_vec = reinterpret_cast<const uint4*>(kv_cache);
     return __ldg(&cache_vec[physical_offset / 8 + vec_col]);
   } else {
-    static_assert(KV_DTYPE == flash_v100::KV_CACHE_DTYPE_FP8_E5M2,
-                  "XQA only supports fp16 and FP8 E5M2 KV");
+    static_assert(KV_DTYPE == flash_v100::KV_CACHE_DTYPE_FP8_E4M3 ||
+                      KV_DTYPE == flash_v100::KV_CACHE_DTYPE_FP8_E5M2,
+                  "XQA only supports fp16, FP8 E4M3, and FP8 E5M2 KV");
     const uint64_t* cache_vec = reinterpret_cast<const uint64_t*>(kv_cache);
-    return fp8_e5m2_vector_to_half8(
-        __ldg(&cache_vec[physical_offset / 8 + vec_col]));
+    const uint64_t raw = __ldg(&cache_vec[physical_offset / 8 + vec_col]);
+    if constexpr (KV_DTYPE == flash_v100::KV_CACHE_DTYPE_FP8_E4M3) {
+      return fp8_e4m3fn_vector_to_half8(raw);
+    } else {
+      return fp8_e5m2_vector_to_half8(raw);
+    }
   }
 }
 
@@ -2252,7 +2302,8 @@ template <int PARTITION_SIZE, int GROUP_SIZE, bool PADDED_SMEM,
           int BLOCK_SIZE = 0, bool CONTIGUOUS_HKV1_LAYOUT = false,
           bool ALIGNED_PADDED_SMEM = false,
           int SEQ_LEN_ROUTE = kXQARouteAllSeqLens, bool QK_SW_PIPELINE = false,
-          bool PARTITION_PAGE_IDS = false, bool E5M2_PAIR_LOAD = false>
+          bool PARTITION_PAGE_IDS = false, bool E5M2_PAIR_LOAD = false,
+          int KV_DTYPE_OVERRIDE = -1>
 void launch_flash_attention_decode_paged_xqa_tc_256_wide(
     const at::Tensor& q, const at::Tensor& k_cache, const at::Tensor& v_cache,
     at::Tensor& out, const at::Tensor& block_table, const at::Tensor& seq_lens,
@@ -2310,7 +2361,14 @@ void launch_flash_attention_decode_paged_xqa_tc_256_wide(
             route_seq_len_end, route_seq_len_final);                           \
   } while (0)
 
-  if constexpr (E5M2_PAIR_LOAD) {
+  if constexpr (KV_DTYPE_OVERRIDE ==
+                flash_v100::KV_CACHE_DTYPE_FP8_E4M3) {
+    static_assert(!E5M2_PAIR_LOAD,
+                  "E5M2 paired loads cannot be used for E4M3 KV");
+    TORCH_CHECK(k_cache.scalar_type() == at::kByte,
+                "E4M3 XQA requires uint8 KV cache");
+    LAUNCH_XQA_PARTITION(flash_v100::KV_CACHE_DTYPE_FP8_E4M3);
+  } else if constexpr (E5M2_PAIR_LOAD) {
     TORCH_CHECK(k_cache.scalar_type() == at::kByte,
                 "Paired XQA loads require FP8 E5M2 KV cache");
     LAUNCH_XQA_PARTITION(flash_v100::KV_CACHE_DTYPE_FP8_E5M2);
@@ -2678,8 +2736,10 @@ at::Tensor flash_attention_decode_paged_xqa(
   TORCH_CHECK(q.dtype() == torch::kFloat16, "q must be fp16");
   const int kv_dtype_code = kv_cache_dtype_code_from_string(kv_cache_dtype);
   TORCH_CHECK(kv_dtype_code == flash_v100::KV_CACHE_DTYPE_FP16 ||
+                  kv_dtype_code == flash_v100::KV_CACHE_DTYPE_FP8_E4M3 ||
                   kv_dtype_code == flash_v100::KV_CACHE_DTYPE_FP8_E5M2,
-              "XQA decode supports fp16 and fp8_e5m2 KV cache only");
+              "XQA decode supports fp16, fp8_e4m3, and fp8_e5m2 KV cache "
+              "only");
   if (kv_dtype_code == flash_v100::KV_CACHE_DTYPE_FP16) {
     TORCH_CHECK(k_cache.dtype() == torch::kFloat16 &&
                     v_cache.dtype() == torch::kFloat16,
@@ -2687,7 +2747,7 @@ at::Tensor flash_attention_decode_paged_xqa(
   } else {
     TORCH_CHECK(
         k_cache.dtype() == torch::kUInt8 && v_cache.dtype() == torch::kUInt8,
-        "fp8_e5m2 XQA requires uint8 K/V tensors");
+        "FP8 XQA requires uint8 K/V tensors");
   }
   TORCH_CHECK(k_scale > 0.f && v_scale > 0.f,
               "XQA K/V scales must be positive");
@@ -2725,7 +2785,8 @@ at::Tensor flash_attention_decode_paged_xqa(
   TORCH_CHECK(q_per_kv == 4 || q_per_kv == 6 || q_per_kv == 8,
               "XQA decode supports q_per_kv in {4, 6, 8}, got ", q_per_kv);
   TORCH_CHECK(
-      partition_size == 256 || partition_size == 512 || partition_size == 1024,
+      partition_size == 64 || partition_size == 128 || partition_size == 256 ||
+          partition_size == 512 || partition_size == 1024,
       "Unsupported XQA decode partition_size: ", partition_size);
   TORCH_CHECK(launch_num_partitions > 0,
               "launch_num_partitions must be positive");
@@ -2750,6 +2811,40 @@ at::Tensor flash_attention_decode_paged_xqa(
   TORCH_CHECK(out.sizes() == q.sizes(), "out must have same shape as q");
   TORCH_CHECK(out.stride(-1) == 1, "out last dim must be contiguous");
   auto stream = at::cuda::getCurrentCUDAStream().stream();
+  if (kv_dtype_code == flash_v100::KV_CACHE_DTYPE_FP8_E4M3) {
+    TORCH_CHECK(q.size(0) == 1 && q_per_kv == 6 &&
+                    (partition_size == 64 || partition_size == 128 ||
+                     partition_size == 256),
+                "E4M3 XQA currently supports B=1, q_per_kv=6, D=256, and "
+                "partition_size in {64, 128, 256} only");
+    if (partition_size == 64) {
+      launch_flash_attention_decode_paged_xqa_tc_256_wide<
+          64, 6, true, kXQATC256WideThreads, 1, 0, false, false,
+          kXQARouteAllSeqLens, false, false, false,
+          flash_v100::KV_CACHE_DTYPE_FP8_E4M3>(
+          q, k_cache, v_cache, out, block_table, seq_lens, tmp_out, max_logits,
+          exp_sums, active_num_partitions, softmax_scale, k_scale, v_scale,
+          launch_num_partitions, false, 8, stream);
+    } else if (partition_size == 128) {
+      launch_flash_attention_decode_paged_xqa_tc_256_wide<
+          128, 6, true, kXQATC256WideThreads, 1, 0, false, false,
+          kXQARouteAllSeqLens, false, false, false,
+          flash_v100::KV_CACHE_DTYPE_FP8_E4M3>(
+          q, k_cache, v_cache, out, block_table, seq_lens, tmp_out, max_logits,
+          exp_sums, active_num_partitions, softmax_scale, k_scale, v_scale,
+          launch_num_partitions, false, 8, stream);
+    } else {
+      launch_flash_attention_decode_paged_xqa_tc_256_wide<
+          256, 6, true, kXQATC256WideThreads, 1, 0, false, false,
+          kXQARouteAllSeqLens, false, false, false,
+          flash_v100::KV_CACHE_DTYPE_FP8_E4M3>(
+          q, k_cache, v_cache, out, block_table, seq_lens, tmp_out, max_logits,
+          exp_sums, active_num_partitions, softmax_scale, k_scale, v_scale,
+          launch_num_partitions, false, 8, stream);
+    }
+    C10_CUDA_KERNEL_LAUNCH_CHECK();
+    return out;
+  }
   // Default only the shape with exact direct and model-level evidence.
   const bool padded_smem_enabled = xqa_padded_smem_enabled();
   const bool use_padded_smem =

--- a/flash-attention-v100/kernel/flash_decode_paged.cu
+++ b/flash-attention-v100/kernel/flash_decode_paged.cu
@@ -537,8 +537,7 @@ __device__ __forceinline__ uint4 fp8_e5m2_vector_to_half8(const uint64_t raw) {
       fp8_e5m2_pair_to_half2_bits(static_cast<uint16_t>(raw >> 48)));
 }
 
-__device__ __forceinline__ uint16_t fp8_e4m3fn_to_half_bits(
-    const uint8_t raw) {
+__device__ __forceinline__ uint16_t fp8_e4m3fn_to_half_bits(const uint8_t raw) {
   const uint16_t sign = static_cast<uint16_t>(raw & 0x80u) << 8;
   const uint8_t magnitude = raw & 0x7fu;
   const uint8_t exponent = magnitude >> 3;
@@ -563,17 +562,17 @@ __device__ __forceinline__ uint16_t fp8_e4m3fn_to_half_bits(
          static_cast<uint16_t>(mantissa << 7);
 }
 
-__device__ __forceinline__ uint32_t fp8_e4m3fn_pair_to_half2_bits(
-    const uint16_t raw_pair) {
+__device__ __forceinline__ uint32_t
+fp8_e4m3fn_pair_to_half2_bits(const uint16_t raw_pair) {
   return static_cast<uint32_t>(
              fp8_e4m3fn_to_half_bits(static_cast<uint8_t>(raw_pair))) |
-         (static_cast<uint32_t>(fp8_e4m3fn_to_half_bits(
-              static_cast<uint8_t>(raw_pair >> 8)))
+         (static_cast<uint32_t>(
+              fp8_e4m3fn_to_half_bits(static_cast<uint8_t>(raw_pair >> 8)))
           << 16);
 }
 
-__device__ __forceinline__ uint4 fp8_e4m3fn_vector_to_half8(
-    const uint64_t raw) {
+__device__ __forceinline__ uint4
+fp8_e4m3fn_vector_to_half8(const uint64_t raw) {
   return make_uint4(
       fp8_e4m3fn_pair_to_half2_bits(static_cast<uint16_t>(raw)),
       fp8_e4m3fn_pair_to_half2_bits(static_cast<uint16_t>(raw >> 16)),
@@ -2361,8 +2360,7 @@ void launch_flash_attention_decode_paged_xqa_tc_256_wide(
             route_seq_len_end, route_seq_len_final);                           \
   } while (0)
 
-  if constexpr (KV_DTYPE_OVERRIDE ==
-                flash_v100::KV_CACHE_DTYPE_FP8_E4M3) {
+  if constexpr (KV_DTYPE_OVERRIDE == flash_v100::KV_CACHE_DTYPE_FP8_E4M3) {
     static_assert(!E5M2_PAIR_LOAD,
                   "E5M2 paired loads cannot be used for E4M3 KV");
     TORCH_CHECK(k_cache.scalar_type() == at::kByte,
@@ -2784,10 +2782,10 @@ at::Tensor flash_attention_decode_paged_xqa(
   const int q_per_kv = num_heads_q / num_heads_kv;
   TORCH_CHECK(q_per_kv == 4 || q_per_kv == 6 || q_per_kv == 8,
               "XQA decode supports q_per_kv in {4, 6, 8}, got ", q_per_kv);
-  TORCH_CHECK(
-      partition_size == 64 || partition_size == 128 || partition_size == 256 ||
-          partition_size == 512 || partition_size == 1024,
-      "Unsupported XQA decode partition_size: ", partition_size);
+  TORCH_CHECK(partition_size == 64 || partition_size == 128 ||
+                  partition_size == 256 || partition_size == 512 ||
+                  partition_size == 1024,
+              "Unsupported XQA decode partition_size: ", partition_size);
   TORCH_CHECK(launch_num_partitions > 0,
               "launch_num_partitions must be positive");
   TORCH_CHECK(tmp_out.dtype() == torch::kFloat16,

--- a/setup.py
+++ b/setup.py
@@ -891,6 +891,9 @@ class precompiled_wheel_utils:
                 flash_qla_sm70_ext_regex = re.compile(
                     r"flash_qla/ops/gated_delta_rule/chunk/sm70/[^/]+\.so"
                 )
+                sm70_sampler_ext_regex = re.compile(
+                    r"vllm/_sm70_sampler_C(?:\.[^/]+)?\.so$"
+                )
                 file_members = []
                 for member in wheel.filelist:
                     if member.filename in exact_members:
@@ -910,6 +913,7 @@ class precompiled_wheel_utils:
                         or deep_gemm_regex.match(member.filename)
                         or flash_attn_v100_ext_regex.match(member.filename)
                         or flash_qla_sm70_ext_regex.match(member.filename)
+                        or sm70_sampler_ext_regex.match(member.filename)
                     ):
                         file_members.append(member)
 
@@ -1235,6 +1239,8 @@ if _is_hip():
     ext_modules.append(CMakeExtension(name="vllm._rocm_C"))
 
 if _is_cuda():
+    if _cuda_arch_contains(7, 0):
+        ext_modules.append(CMakeExtension(name="vllm._sm70_sampler_C"))
     build_sm70_fa2 = _cuda_arch_contains(7, 0) and not _cuda_arch_at_least(8, 0)
     if _cuda_arch_at_least(8, 0) or build_sm70_fa2:
         ext_modules.append(CMakeExtension(name="vllm.vllm_flash_attn._vllm_fa2_C"))

--- a/tests/kernels/attention/test_sm70_flash_v100_varlen_layout.py
+++ b/tests/kernels/attention/test_sm70_flash_v100_varlen_layout.py
@@ -624,3 +624,72 @@ def test_sm70_flash_v100_fp8_e5m2_xqa_decode_matches_scalar(
     ).float()
     assert torch.all(delta <= torch.maximum(one_ulp, torch.full_like(delta, 1e-4)))
     assert float(delta.mean()) <= 1e-5
+
+
+@pytest.mark.parametrize(("k_scale", "v_scale"), ((1.0, 1.0), (0.04, 0.25)))
+@pytest.mark.parametrize("partition_size", (64, 128, 256))
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
+@torch.inference_mode()
+def test_sm70_flash_v100_fp8_e4m3_g6_xqa_decode_matches_scalar(
+    k_scale,
+    v_scale,
+    partition_size,
+):
+    if torch.cuda.get_device_capability() != (7, 0):
+        pytest.skip("FlashAttention-V100 regression is SM70/V100 only")
+
+    flash_attn_v100 = pytest.importorskip("flash_attn_v100")
+    torch.manual_seed(20260823)
+    seq_len = 2049
+    block_size = 1568
+    head_dim = 256
+    cache_shape = (3, block_size, 1, head_dim)
+    key_cache = (
+        torch.randn(cache_shape, dtype=torch.float16, device="cuda")
+        .to(torch.float8_e4m3fn)
+        .view(torch.uint8)
+    )
+    value_cache = (
+        torch.randn(cache_shape, dtype=torch.float16, device="cuda")
+        .to(torch.float8_e4m3fn)
+        .view(torch.uint8)
+    )
+    query = torch.randn(1, 6, head_dim, dtype=torch.float16, device="cuda")
+    block_table = torch.tensor([[2, 0]], dtype=torch.int32, device="cuda")
+    seq_lens = torch.tensor([seq_len], dtype=torch.int32, device="cuda")
+    kwargs = {
+        "kv_cache_dtype": "fp8_e4m3",
+        "k_scale": k_scale,
+        "v_scale": v_scale,
+        "max_seq_len_hint": seq_len,
+    }
+
+    expected = flash_attn_v100.flash_attn_decode_paged(
+        query,
+        key_cache,
+        value_cache,
+        block_table,
+        seq_lens,
+        partition_size_hint=256,
+        **kwargs,
+    )
+    actual = flash_attn_v100.flash_attn_decode_paged_xqa(
+        query,
+        key_cache,
+        value_cache,
+        block_table,
+        seq_lens,
+        partition_size_hint=partition_size,
+        **kwargs,
+    )
+
+    torch.accelerator.synchronize()
+    delta = (actual.float() - expected.float()).abs()
+    positive = torch.full_like(expected, torch.inf)
+    negative = torch.full_like(expected, -torch.inf)
+    one_ulp = torch.maximum(
+        (torch.nextafter(expected, positive) - expected).abs(),
+        (torch.nextafter(expected, negative) - expected).abs(),
+    ).float()
+    assert torch.all(delta <= torch.maximum(one_ulp, torch.full_like(delta, 1e-4)))
+    assert float(delta.mean()) <= 1e-5

--- a/tests/quantization/test_nvfp4_mxfp4_gating.py
+++ b/tests/quantization/test_nvfp4_mxfp4_gating.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+from types import SimpleNamespace
+
 import torch
 from torch.nn.parameter import Parameter
 
@@ -17,6 +19,9 @@ from vllm.model_executor.kernels.linear.nvfp4.flashinfer import (
 )
 from vllm.model_executor.layers.quantization.compressed_tensors.schemes import (
     compressed_tensors_w4a4_mxfp4 as mxfp4_scheme,
+)
+from vllm.model_executor.layers.quantization.compressed_tensors.schemes import (
+    compressed_tensors_w4a4_nvfp4 as nvfp4_scheme,
 )
 from vllm.model_executor.layers.quantization.compressed_tensors.schemes.compressed_tensors_w4a4_mxfp4 import (  # noqa: E501
     CompressedTensorsW4A4Mxfp4,
@@ -91,6 +96,94 @@ def test_flashinfer_nvfp4_backends_reject_sm70():
     assert "sm_100" in trtllm_reason
     assert not cudnn_supported
     assert "sm_100" in cudnn_reason
+
+
+def _make_qwen38_nvfp4_gate_up_layer() -> torch.nn.Module:
+    layer = torch.nn.Module()
+    layer.tp_size = 4
+    layer.prefix = "model.language_model.layers.0.mlp.gate_up_proj"
+    layer.input_size_per_partition = 5120
+    layer.output_size_per_partition = 8704
+    layer.logical_widths = [4352, 4352]
+    return layer
+
+
+def _make_qwen38_nvfp4_down_layer() -> torch.nn.Module:
+    layer = torch.nn.Module()
+    layer.tp_size = 4
+    layer.prefix = "model.language_model.layers.0.mlp.down_proj"
+    layer.input_size_per_partition = 4352
+    layer.output_size_per_partition = 5120
+    return layer
+
+
+def test_qwen38_tp4_nvfp4_gate_up_match_is_shape_exact(monkeypatch):
+    monkeypatch.setattr(nvfp4_scheme, "_is_qwen38_27b_nvfp4_model", lambda: True)
+    layer = _make_qwen38_nvfp4_gate_up_layer()
+
+    assert nvfp4_scheme._is_qwen38_tp4_nvfp4_gate_up(layer)
+
+    layer.tp_size = 2
+    assert not nvfp4_scheme._is_qwen38_tp4_nvfp4_gate_up(layer)
+    layer.tp_size = 4
+    layer.output_size_per_partition = 8703
+    assert not nvfp4_scheme._is_qwen38_tp4_nvfp4_gate_up(layer)
+    layer.output_size_per_partition = 8704
+    layer.prefix = "model.language_model.layers.0.mlp.down_proj"
+    assert not nvfp4_scheme._is_qwen38_tp4_nvfp4_gate_up(layer)
+
+
+def test_qwen38_tp4_nvfp4_down_match_is_shape_exact(monkeypatch):
+    monkeypatch.setattr(nvfp4_scheme, "_is_qwen38_27b_nvfp4_model", lambda: True)
+    layer = _make_qwen38_nvfp4_down_layer()
+
+    assert nvfp4_scheme._is_qwen38_tp4_nvfp4_down(layer)
+
+    layer.input_size_per_partition = 4351
+    assert not nvfp4_scheme._is_qwen38_tp4_nvfp4_down(layer)
+    layer.input_size_per_partition = 4352
+    layer.output_size_per_partition = 5119
+    assert not nvfp4_scheme._is_qwen38_tp4_nvfp4_down(layer)
+
+
+def test_qwen38_nvfp4_qpn4_runtime_contract_is_single_sequence_no_mtp(
+    monkeypatch,
+):
+    config = SimpleNamespace(
+        scheduler_config=SimpleNamespace(max_num_seqs=1),
+        speculative_config=None,
+    )
+    monkeypatch.setattr(
+        nvfp4_scheme,
+        "get_current_vllm_config",
+        lambda: config,
+    )
+
+    assert nvfp4_scheme._is_qwen38_nvfp4_qpn4_runtime_contract()
+
+    config.scheduler_config.max_num_seqs = 2
+    assert not nvfp4_scheme._is_qwen38_nvfp4_qpn4_runtime_contract()
+    config.scheduler_config.max_num_seqs = 1
+    config.speculative_config = object()
+    assert not nvfp4_scheme._is_qwen38_nvfp4_qpn4_runtime_contract()
+
+
+def test_nvfp4_scheme_delegates_fused_silu_only_for_prepared_layer(monkeypatch):
+    scheme = CompressedTensorsW4A4Fp4()
+    layer = torch.nn.Module()
+    x = torch.ones((1, 4), dtype=torch.float16)
+    expected = torch.full((1, 2), 7.0, dtype=torch.float16)
+
+    monkeypatch.setattr(nvfp4_scheme.sm70_tm, "has_prepared_linear", lambda _: True)
+    monkeypatch.setattr(
+        nvfp4_scheme.sm70_tm,
+        "apply_prepared_fused_silu_and_mul",
+        lambda prepared_layer, prepared_x: expected
+        if prepared_layer is layer and prepared_x is x
+        else None,
+    )
+
+    assert scheme.apply_fused_silu_and_mul(layer, x) is expected
 
 
 def _make_mxfp4_layer() -> torch.nn.Module:

--- a/tests/quantization/test_sm70_fp8_prefill_exact_dense.py
+++ b/tests/quantization/test_sm70_fp8_prefill_exact_dense.py
@@ -17,6 +17,7 @@ from vllm.model_executor.layers.quantization.compressed_tensors.compressed_tenso
 from vllm.model_executor.layers.quantization.compressed_tensors.schemes.compressed_tensors_w8a16_fp8 import (  # noqa: E501
     CompressedTensorsW8A16Fp8,
     _sm70_channel_fp8_qpn8_config,
+    _sm70_fp8_qpn8_enabled,
 )
 from vllm.model_executor.layers.quantization.fp8 import (
     _SM70_FP8_PREFILL_DENSE_MIN_M,
@@ -31,7 +32,12 @@ from vllm.model_executor.layers.quantization.fp8 import (
 )
 
 
-def _make_channel_fp8_scheme(monkeypatch, *, static_input: bool = False):
+def _make_channel_fp8_scheme(
+    monkeypatch,
+    *,
+    static_input: bool = False,
+    enable_qpn8_by_default: bool = False,
+):
     monkeypatch.setattr(
         "vllm.model_executor.layers.quantization.compressed_tensors.schemes."
         "compressed_tensors_w8a16_fp8.get_current_vllm_config",
@@ -54,7 +60,11 @@ def _make_channel_fp8_scheme(monkeypatch, *, static_input: bool = False):
         strategy=QuantizationStrategy.CHANNEL,
         dynamic=False,
     )
-    return CompressedTensorsW8A16Fp8(weight_quant, static_input)
+    return CompressedTensorsW8A16Fp8(
+        weight_quant,
+        static_input,
+        enable_sm70_qpn8_by_default=enable_qpn8_by_default,
+    )
 
 
 def test_compressed_tensors_channel_fp8_selects_turbomind_on_sm70(monkeypatch):
@@ -65,6 +75,26 @@ def test_compressed_tensors_channel_fp8_selects_turbomind_on_sm70(monkeypatch):
         assert not _make_channel_fp8_scheme(
             monkeypatch, static_input=True
         ).use_sm70_fp8_turbomind
+    finally:
+        envs.disable_envs_cache()
+
+
+def test_channel_fp8_qpn8_uses_mixed_nvfp4_default_only(monkeypatch):
+    monkeypatch.delenv("VLLM_SM70_FP8_QPN8", raising=False)
+    envs.disable_envs_cache()
+    try:
+        assert not _make_channel_fp8_scheme(monkeypatch).use_sm70_fp8_qpn8
+        assert _make_channel_fp8_scheme(
+            monkeypatch,
+            enable_qpn8_by_default=True,
+        ).use_sm70_fp8_qpn8
+
+        monkeypatch.setenv("VLLM_SM70_FP8_QPN8", "0")
+        envs.disable_envs_cache()
+        assert not _make_channel_fp8_scheme(
+            monkeypatch,
+            enable_qpn8_by_default=True,
+        ).use_sm70_fp8_qpn8
     finally:
         envs.disable_envs_cache()
 
@@ -318,16 +348,23 @@ def test_fp8_prefill_exact_dense_is_default_on(monkeypatch):
         envs.disable_envs_cache()
 
 
-def test_fp8_qpn8_is_auto_default_on_with_explicit_off(monkeypatch):
+def test_fp8_qpn8_is_opt_in_except_for_mixed_nvfp4(monkeypatch):
     monkeypatch.delenv("VLLM_SM70_FP8_QPN8", raising=False)
     monkeypatch.delenv("VLLM_SM70_FP8_QPN8_LIBRARY", raising=False)
     envs.disable_envs_cache()
     try:
-        assert envs.VLLM_SM70_FP8_QPN8
+        assert not envs.VLLM_SM70_FP8_QPN8
         assert envs.VLLM_SM70_FP8_QPN8_LIBRARY is None
+        assert not _sm70_fp8_qpn8_enabled(False)
+        assert _sm70_fp8_qpn8_enabled(True)
         monkeypatch.setenv("VLLM_SM70_FP8_QPN8", "0")
         envs.disable_envs_cache()
         assert not envs.VLLM_SM70_FP8_QPN8
+        assert not _sm70_fp8_qpn8_enabled(True)
+        monkeypatch.setenv("VLLM_SM70_FP8_QPN8", "1")
+        envs.disable_envs_cache()
+        assert envs.VLLM_SM70_FP8_QPN8
+        assert _sm70_fp8_qpn8_enabled(False)
     finally:
         envs.disable_envs_cache()
 

--- a/tests/quantization/test_sm70_fp8_prefill_exact_dense.py
+++ b/tests/quantization/test_sm70_fp8_prefill_exact_dense.py
@@ -11,7 +11,10 @@ from vllm.model_executor.layers.quantization.fp8 import (
     _SM70_FP8_PREFILL_DENSE_WORKSPACE_BYTES,
     Fp8LinearMethod,
     _get_sm70_fp8_prefill_exact_dense_workspace,
+    _is_qwen38_27b_fp8_qpn8_model,
     _is_sm70_fp8_prefill_exact_dense_layer,
+    _is_sm70_fp8_qpn8_layer,
+    _is_sm70_fp8_qpn8_runtime_contract,
     _sm70_fp8_prefill_dense_workspaces,
 )
 
@@ -21,6 +24,20 @@ def test_fp8_prefill_exact_dense_is_default_on(monkeypatch):
     envs.disable_envs_cache()
     try:
         assert envs.VLLM_SM70_FP8_PREFILL_EXACT_DENSE
+    finally:
+        envs.disable_envs_cache()
+
+
+def test_fp8_qpn8_is_auto_default_on_with_explicit_off(monkeypatch):
+    monkeypatch.delenv("VLLM_SM70_FP8_QPN8", raising=False)
+    monkeypatch.delenv("VLLM_SM70_FP8_QPN8_LIBRARY", raising=False)
+    envs.disable_envs_cache()
+    try:
+        assert envs.VLLM_SM70_FP8_QPN8
+        assert envs.VLLM_SM70_FP8_QPN8_LIBRARY is None
+        monkeypatch.setenv("VLLM_SM70_FP8_QPN8", "0")
+        envs.disable_envs_cache()
+        assert not envs.VLLM_SM70_FP8_QPN8
     finally:
         envs.disable_envs_cache()
 
@@ -46,6 +63,63 @@ def test_fp8_prefill_exact_dense_shape_gate_is_narrow():
     layer.prefix = "model.language_model.layers.1.mlp.gate_up_proj"
     layer.weight = SimpleNamespace(shape=(5120, 8192))
     assert not _is_sm70_fp8_prefill_exact_dense_layer(layer)
+
+
+def test_fp8_qpn8_shape_gate_uses_checkpoint_native_layout():
+    layer = SimpleNamespace(
+        tp_size=4,
+        prefix="model.language_model.layers.1.mlp.gate_up_proj",
+        weight=SimpleNamespace(shape=(8704, 5120)),
+    )
+
+    assert _is_sm70_fp8_qpn8_layer(layer)
+
+    layer.tp_size = 2
+    assert not _is_sm70_fp8_qpn8_layer(layer)
+    layer.tp_size = 4
+    layer.prefix = "model.language_model.layers.1.linear_attn.in_proj_qkvz"
+    layer.weight = SimpleNamespace(shape=(4096, 5120))
+    assert not _is_sm70_fp8_qpn8_layer(layer)
+    layer.prefix = "model.language_model.layers.3.self_attn.qkv_proj"
+    layer.weight = SimpleNamespace(shape=(3584, 5120))
+    assert not _is_sm70_fp8_qpn8_layer(layer)
+
+
+def test_fp8_qpn8_model_gate_is_qwen38_27b_specific(monkeypatch):
+    text_config = SimpleNamespace(
+        model_type="qwen3_5_text",
+        hidden_size=5120,
+        intermediate_size=17408,
+        num_hidden_layers=64,
+        full_attention_interval=4,
+        head_dim=256,
+    )
+    model_config = SimpleNamespace(
+        hf_config=SimpleNamespace(
+            model_type="qwen3_5",
+            architectures=["Qwen3_5ForConditionalGeneration"],
+        ),
+        hf_text_config=text_config,
+    )
+    vllm_config = SimpleNamespace(
+        model_config=model_config,
+        scheduler_config=SimpleNamespace(max_num_seqs=8),
+        speculative_config=None,
+    )
+    monkeypatch.setattr(
+        "vllm.model_executor.layers.quantization.fp8.get_current_vllm_config",
+        lambda: vllm_config,
+    )
+
+    assert _is_qwen38_27b_fp8_qpn8_model()
+    assert _is_sm70_fp8_qpn8_runtime_contract()
+    vllm_config.scheduler_config.max_num_seqs = 16
+    assert not _is_sm70_fp8_qpn8_runtime_contract()
+    vllm_config.scheduler_config.max_num_seqs = 8
+    vllm_config.speculative_config = object()
+    assert not _is_sm70_fp8_qpn8_runtime_contract()
+    text_config.hidden_size = 4096
+    assert not _is_qwen38_27b_fp8_qpn8_model()
 
 
 def test_fp8_prefill_exact_dense_workspace_is_bounded():
@@ -124,4 +198,87 @@ def test_fp8_prefill_dispatch_reaches_runtime_op_for_small_and_large_m(monkeypat
             _SM70_FP8_PREFILL_DENSE_MIN_M,
             False,
         ),
+    ]
+
+
+def test_fp8_qpn8_dispatches_small_m_and_workspace_fallback(monkeypatch):
+    calls = []
+
+    def fake_dispatch(
+        out, workspace, input, codes, scales, split_k, nacc, prefetch, gated_silu
+    ):
+        calls.append(
+            ("dispatch", input.shape[0], workspace, split_k, nacc, prefetch, gated_silu)
+        )
+        out.zero_()
+
+    monkeypatch.setattr(
+        "vllm.model_executor.layers.quantization.fp8.sm70_ops."
+        "fp8_qpn8_dispatch_sm70_out",
+        fake_dispatch,
+    )
+    layer = SimpleNamespace(
+        sm70_fp8_turbomind=True,
+        sm70_fp8_qpn8=True,
+        output_size_per_partition=6,
+        weight=torch.empty((4, 6), dtype=torch.uint8),
+        weight_scale_inv=torch.empty((1, 1), dtype=torch.float16),
+        sm70_fp8_qpn8_split_k=16,
+        sm70_fp8_qpn8_nacc=1,
+        sm70_fp8_qpn8_prefetch=False,
+        sm70_fp8_prefill_exact_dense_workspace_ptr=42,
+    )
+    method = SimpleNamespace()
+
+    for m in (1, 9):
+        output = Fp8LinearMethod.apply(
+            method, layer, torch.empty((m, 4), dtype=torch.float16)
+        )
+        assert output.shape == (m, 6)
+
+    assert calls == [
+        ("dispatch", 1, 42, 16, 1, False, False),
+        ("dispatch", 9, 42, 16, 1, False, False),
+    ]
+
+
+def test_fp8_qpn8_fused_gate_dispatches_without_intermediate(monkeypatch):
+    calls = []
+
+    def fake_dispatch(
+        out, workspace, input, codes, scales, split_k, nacc, prefetch, gated_silu
+    ):
+        calls.append(
+            ("dispatch", input.shape[0], workspace, split_k, nacc, prefetch, gated_silu)
+        )
+        out.zero_()
+
+    monkeypatch.setattr(
+        "vllm.model_executor.layers.quantization.fp8.sm70_ops."
+        "fp8_qpn8_dispatch_sm70_out",
+        fake_dispatch,
+    )
+    layer = SimpleNamespace(
+        sm70_fp8_qpn8=True,
+        sm70_fp8_gated_silu=True,
+        output_size_per_partition=12,
+        weight=torch.empty((4, 12), dtype=torch.uint8),
+        weight_scale_inv=torch.empty((1, 1), dtype=torch.float16),
+        sm70_fp8_qpn8_gated_split_k=8,
+        sm70_fp8_qpn8_gated_nacc=2,
+        sm70_fp8_qpn8_gated_prefetch=True,
+        sm70_fp8_prefill_exact_dense_workspace_ptr=42,
+    )
+    method = SimpleNamespace()
+
+    for m in (8, 16):
+        output = Fp8LinearMethod.apply_fused_silu_and_mul(
+            method, layer, torch.empty((m, 4), dtype=torch.float16)
+        )
+        assert output is not None
+        assert output.shape == (m, 6)
+
+    assert calls == [
+        ("dispatch", 8, 42, 8, 2, True, True),
+        ("dispatch", 16, 42, 8, 2, True, True),
     ]

--- a/tests/quantization/test_sm70_fp8_prefill_exact_dense.py
+++ b/tests/quantization/test_sm70_fp8_prefill_exact_dense.py
@@ -4,8 +4,20 @@
 from types import SimpleNamespace
 
 import torch
+from compressed_tensors.quantization import (
+    QuantizationArgs,
+    QuantizationStrategy,
+    QuantizationType,
+)
 
 import vllm.envs as envs
+from vllm.model_executor.layers.quantization.compressed_tensors.compressed_tensors import (  # noqa: E501
+    CompressedTensorsLinearMethod,
+)
+from vllm.model_executor.layers.quantization.compressed_tensors.schemes.compressed_tensors_w8a16_fp8 import (  # noqa: E501
+    CompressedTensorsW8A16Fp8,
+    _sm70_channel_fp8_qpn8_config,
+)
 from vllm.model_executor.layers.quantization.fp8 import (
     _SM70_FP8_PREFILL_DENSE_MIN_M,
     _SM70_FP8_PREFILL_DENSE_WORKSPACE_BYTES,
@@ -17,6 +29,284 @@ from vllm.model_executor.layers.quantization.fp8 import (
     _is_sm70_fp8_qpn8_runtime_contract,
     _sm70_fp8_prefill_dense_workspaces,
 )
+
+
+def _make_channel_fp8_scheme(monkeypatch, *, static_input: bool = False):
+    monkeypatch.setattr(
+        "vllm.model_executor.layers.quantization.compressed_tensors.schemes."
+        "compressed_tensors_w8a16_fp8.get_current_vllm_config",
+        lambda: SimpleNamespace(model_config=SimpleNamespace(dtype=torch.float16)),
+    )
+    monkeypatch.setattr(
+        "vllm.model_executor.layers.quantization.compressed_tensors.schemes."
+        "compressed_tensors_w8a16_fp8.sm70_tm.is_exact_sm70_cuda_platform",
+        lambda: True,
+    )
+    monkeypatch.setattr(
+        "vllm.model_executor.layers.quantization.compressed_tensors.schemes."
+        "compressed_tensors_w8a16_fp8.sm70_tm.use_turbomind",
+        lambda enabled: enabled,
+    )
+    weight_quant = QuantizationArgs(
+        num_bits=8,
+        type=QuantizationType.FLOAT,
+        symmetric=True,
+        strategy=QuantizationStrategy.CHANNEL,
+        dynamic=False,
+    )
+    return CompressedTensorsW8A16Fp8(weight_quant, static_input)
+
+
+def test_compressed_tensors_channel_fp8_selects_turbomind_on_sm70(monkeypatch):
+    monkeypatch.setenv("VLLM_SM70_FP8_TURBOMIND", "1")
+    envs.disable_envs_cache()
+    try:
+        assert _make_channel_fp8_scheme(monkeypatch).use_sm70_fp8_turbomind
+        assert not _make_channel_fp8_scheme(
+            monkeypatch, static_input=True
+        ).use_sm70_fp8_turbomind
+    finally:
+        envs.disable_envs_cache()
+
+
+def test_compressed_tensors_channel_fp8_prepares_and_dispatches_turbomind(
+    monkeypatch,
+):
+    scheme = object.__new__(CompressedTensorsW8A16Fp8)
+    scheme.use_sm70_fp8_turbomind = True
+    layer = torch.nn.Module()
+    layer.register_parameter(
+        "weight",
+        torch.nn.Parameter(
+            torch.empty((6, 4), dtype=torch.float8_e4m3fn), requires_grad=False
+        ),
+    )
+    layer.register_parameter(
+        "weight_scale",
+        torch.nn.Parameter(torch.ones((6, 1)), requires_grad=False),
+    )
+    layer.orig_dtype = torch.float16
+    layer.output_size_per_partition = 6
+    prepare_calls = []
+
+    monkeypatch.setattr(torch.ops._C, "fp8_sm70_prepare", object(), raising=False)
+
+    def fake_prepare(weight, scales, group_size, gated_silu):
+        prepare_calls.append(
+            (tuple(weight.shape), tuple(scales.shape), group_size, gated_silu)
+        )
+        return (
+            torch.empty((4, 6), dtype=torch.uint8),
+            torch.ones((1, 6), dtype=torch.float16),
+            torch.tensor([4, 6]),
+        )
+
+    monkeypatch.setattr(
+        "vllm.model_executor.layers.quantization.compressed_tensors.schemes."
+        "compressed_tensors_w8a16_fp8.sm70_ops.fp8_sm70_prepare",
+        fake_prepare,
+    )
+    scheme.process_weights_after_loading(layer)
+
+    assert prepare_calls == [((6, 4), (6, 1), 128, False)]
+    assert layer.sm70_fp8_turbomind
+    assert layer.sm70_fp8_channel_scale
+    assert tuple(layer.weight.shape) == (4, 6)
+    assert tuple(layer.weight_scale_inv.shape) == (1, 6)
+    assert not hasattr(layer, "weight_scale")
+
+    gemm_calls = []
+
+    def fake_gemm(out, x, weight, scales, group_size, k_ld, q_ld, gated_silu):
+        gemm_calls.append(
+            (
+                tuple(out.shape),
+                tuple(x.shape),
+                tuple(weight.shape),
+                tuple(scales.shape),
+                group_size,
+                k_ld,
+                q_ld,
+                gated_silu,
+            )
+        )
+        out.fill_(2)
+
+    monkeypatch.setattr(
+        "vllm.model_executor.layers.quantization.compressed_tensors.schemes."
+        "compressed_tensors_w8a16_fp8.sm70_ops.fp8_gemm_sm70_out",
+        fake_gemm,
+    )
+    output = scheme.apply_weights(
+        layer,
+        torch.ones((2, 4), dtype=torch.float16),
+        torch.ones(6, dtype=torch.float16),
+    )
+
+    assert torch.equal(output, torch.full((2, 6), 3, dtype=torch.float16))
+    assert gemm_calls == [((2, 6), (2, 4), (4, 6), (1, 6), 128, 4, 6, False)]
+
+
+def test_compressed_tensors_channel_fp8_qpn8_shape_gate_is_exact():
+    layer = SimpleNamespace(
+        tp_size=4,
+        prefix="model.language_model.layers.0.linear_attn.in_proj_qkvz",
+        weight=SimpleNamespace(shape=(4096, 5120)),
+    )
+    assert _sm70_channel_fp8_qpn8_config(layer) == (16, 2, False)
+
+    layer.prefix = "model.language_model.layers.3.self_attn.qkv_proj"
+    layer.weight = SimpleNamespace(shape=(3584, 5120))
+    assert _sm70_channel_fp8_qpn8_config(layer) == (16, 2, False)
+
+    layer.prefix = "model.language_model.layers.3.self_attn.o_proj"
+    layer.weight = SimpleNamespace(shape=(5120, 1536))
+    assert _sm70_channel_fp8_qpn8_config(layer) == (12, 2, False)
+
+    layer.prefix = "model.language_model.lm_head"
+    layer.weight = SimpleNamespace(shape=(62080, 5120))
+    assert _sm70_channel_fp8_qpn8_config(layer) is None
+
+    layer.tp_size = 2
+    layer.prefix = "model.language_model.layers.3.self_attn.o_proj"
+    layer.weight = SimpleNamespace(shape=(5120, 1536))
+    assert _sm70_channel_fp8_qpn8_config(layer) is None
+
+
+def test_compressed_tensors_channel_fp8_qpn8_prepares_and_dispatches(monkeypatch):
+    scheme = object.__new__(CompressedTensorsW8A16Fp8)
+    scheme.use_sm70_fp8_turbomind = True
+    scheme.use_sm70_fp8_qpn8 = True
+    layer = torch.nn.Module()
+    layer.register_parameter(
+        "weight",
+        torch.nn.Parameter(
+            torch.empty((6, 4), dtype=torch.float8_e4m3fn), requires_grad=False
+        ),
+    )
+    layer.register_parameter(
+        "weight_scale",
+        torch.nn.Parameter(torch.ones((6, 1)), requires_grad=False),
+    )
+    layer.orig_dtype = torch.float16
+    layer.output_size_per_partition = 6
+    layer.prefix = "model.language_model.layers.63.mlp.gate_up_proj"
+    workspace = torch.empty(1, dtype=torch.float16)
+    prepare_calls = []
+
+    module = (
+        "vllm.model_executor.layers.quantization.compressed_tensors.schemes."
+        "compressed_tensors_w8a16_fp8"
+    )
+    monkeypatch.setattr(torch.ops._C, "fp8_sm70_prepare", object(), raising=False)
+    monkeypatch.setattr(
+        f"{module}._sm70_channel_fp8_qpn8_config", lambda layer: (16, 2, False)
+    )
+    monkeypatch.setattr(f"{module}._is_qwen38_27b_fp8_qpn8_model", lambda: True)
+    monkeypatch.setattr(f"{module}._is_sm70_fp8_qpn8_runtime_contract", lambda: True)
+    monkeypatch.setattr(f"{module}._missing_sm70_fp8_qpn8_ops", lambda: [])
+    monkeypatch.setattr(
+        f"{module}._get_sm70_fp8_prefill_exact_dense_workspace",
+        lambda weight: workspace,
+    )
+
+    def fake_prepare(weight, scales):
+        prepare_calls.append((tuple(weight.shape), tuple(scales.shape)))
+        return (
+            torch.empty((4, 6), dtype=torch.uint8),
+            torch.ones((1, 6), dtype=torch.float16),
+        )
+
+    monkeypatch.setattr(f"{module}.sm70_ops.fp8_qpn8_prepare_sm70", fake_prepare)
+    scheme.process_weights_after_loading(layer)
+
+    assert prepare_calls == [((6, 4), (6, 1))]
+    assert layer.sm70_fp8_turbomind
+    assert layer.sm70_fp8_qpn8
+    assert layer.sm70_fp8_channel_scale
+    assert layer.sm70_fp8_qpn8_split_k == 16
+    assert layer.sm70_fp8_qpn8_nacc == 2
+    assert not layer.sm70_fp8_qpn8_prefetch
+    assert layer.sm70_fp8_gated_silu
+    assert layer.sm70_fp8_qpn8_gated_split_k == 8
+    assert layer.sm70_fp8_qpn8_gated_nacc == 2
+    assert not layer.sm70_fp8_qpn8_gated_prefetch
+    assert tuple(layer.weight.shape) == (4, 6)
+    assert tuple(layer.weight_scale_inv.shape) == (1, 6)
+    assert not hasattr(layer, "weight_scale")
+
+    dispatch_calls = []
+
+    def fake_dispatch(
+        out, workspace_ptr, x, weight, scales, split_k, nacc, prefetch, gated_silu
+    ):
+        dispatch_calls.append(
+            (
+                tuple(out.shape),
+                tuple(x.shape),
+                workspace_ptr,
+                tuple(weight.shape),
+                tuple(scales.shape),
+                split_k,
+                nacc,
+                prefetch,
+                gated_silu,
+            )
+        )
+        out.fill_(2)
+
+    monkeypatch.setattr(f"{module}.sm70_ops.fp8_qpn8_dispatch_sm70_out", fake_dispatch)
+    output = scheme.apply_weights(
+        layer,
+        torch.ones((2, 4), dtype=torch.float16),
+        torch.ones(6, dtype=torch.float16),
+    )
+
+    assert torch.equal(output, torch.full((2, 6), 3, dtype=torch.float16))
+    fused_output = scheme.apply_fused_silu_and_mul(
+        layer, torch.ones((2, 4), dtype=torch.float16)
+    )
+    assert fused_output is not None
+    assert torch.equal(fused_output, torch.full((2, 3), 2, dtype=torch.float16))
+    assert dispatch_calls == [
+        (
+            (2, 6),
+            (2, 4),
+            workspace.data_ptr(),
+            (4, 6),
+            (1, 6),
+            16,
+            2,
+            False,
+            False,
+        ),
+        (
+            (2, 3),
+            (2, 4),
+            workspace.data_ptr(),
+            (4, 6),
+            (1, 6),
+            8,
+            2,
+            False,
+            True,
+        ),
+    ]
+
+
+def test_compressed_tensors_linear_method_delegates_fused_apply():
+    expected = torch.ones((1, 3), dtype=torch.float16)
+    layer = SimpleNamespace(
+        scheme=SimpleNamespace(
+            apply_fused_silu_and_mul=lambda layer, x: expected,
+        )
+    )
+    method = object.__new__(CompressedTensorsLinearMethod)
+
+    assert (
+        method.apply_fused_silu_and_mul(layer, torch.ones((1, 4), dtype=torch.float16))
+        is expected
+    )
 
 
 def test_fp8_prefill_exact_dense_is_default_on(monkeypatch):

--- a/tests/quantization/test_sm70_modelopt_mixed_nvfp4.py
+++ b/tests/quantization/test_sm70_modelopt_mixed_nvfp4.py
@@ -169,7 +169,10 @@ def test_nvfp4_compact_groups_keep_duplicate_expert_slots_independent():
 
     _prepare_compact_slot_groups(sorted_expert_ids, compact_offsets, active_expert_ids)
 
-    assert torch.equal(compact_offsets.cpu(), torch.arange(9, dtype=torch.int32))
+    assert torch.equal(
+        compact_offsets.cpu(),
+        torch.arange(9, dtype=torch.int32, device="cpu"),
+    )
     assert torch.equal(active_expert_ids.cpu(), sorted_expert_ids.cpu())
 
 

--- a/tests/quantization/test_sm70_turbomind_adapter.py
+++ b/tests/quantization/test_sm70_turbomind_adapter.py
@@ -91,3 +91,224 @@ def test_symmetric_int4_zero_points_are_eight():
 
     assert zeros.dtype == torch.float16
     assert zeros.tolist() == [[8, 8, 8], [8, 8, 8]]
+
+
+def _make_nvfp4_state(tm, *, gated_silu: bool):
+    return tm.SM70TurboMindLinearState(
+        weight=torch.empty((3, 1), dtype=torch.uint8),
+        scales=torch.empty((1, 4), dtype=torch.float16),
+        group_size=16,
+        k_ld=3,
+        q_ld=4,
+        output_size=4,
+        op_kind="nvfp4",
+        gated_silu=gated_silu,
+    )
+
+
+def _make_nvfp4_qpn4_state(tm, *, gated_silu: bool):
+    output_size = 4
+    return tm.SM70TurboMindLinearState(
+        weight=torch.empty((3, output_size // 2), dtype=torch.uint8),
+        scales=torch.empty(
+            (1, output_size),
+            dtype=torch.uint8 if gated_silu else torch.float16,
+        ),
+        group_size=16,
+        k_ld=0,
+        q_ld=0,
+        output_size=output_size,
+        op_kind="nvfp4_qpn4",
+        gated_silu=gated_silu,
+        dense_weight_ptr=1234,
+        global_scale=0.25 if gated_silu else 0.0,
+        use_scale_code=gated_silu,
+    )
+
+
+def test_nvfp4_gated_layout_is_deinterleaved_for_unfused_apply(monkeypatch):
+    tm = _load_adapter()
+    layer = torch.nn.Module()
+    setattr(layer, tm.STATE_ATTR, _make_nvfp4_state(tm, gated_silu=True))
+
+    from vllm import _sm70_ops as sm70_ops
+
+    calls = []
+
+    def fake_gemm(
+        out,
+        x,
+        weight,
+        scales,
+        group_size,
+        k_ld,
+        q_ld,
+        gated_silu=False,
+    ):
+        del x, weight, scales, group_size, k_ld, q_ld
+        calls.append(gated_silu)
+        out.copy_(torch.tensor([[1.0, 10.0, 2.0, 20.0]], dtype=out.dtype))
+
+    monkeypatch.setattr(sm70_ops, "nvfp4_gemm_sm70_out", fake_gemm)
+
+    output = tm.apply_prepared_linear(
+        layer,
+        torch.ones((1, 3), dtype=torch.float16),
+        bias=None,
+    )
+
+    assert calls == [False]
+    assert output.tolist() == [[1.0, 2.0, 10.0, 20.0]]
+
+
+def test_nvfp4_gated_layout_uses_fused_silu_epilogue(monkeypatch):
+    tm = _load_adapter()
+    layer = torch.nn.Module()
+    setattr(layer, tm.STATE_ATTR, _make_nvfp4_state(tm, gated_silu=True))
+
+    from vllm import _sm70_ops as sm70_ops
+
+    calls = []
+
+    def fake_gemm(
+        out,
+        x,
+        weight,
+        scales,
+        group_size,
+        k_ld,
+        q_ld,
+        gated_silu=False,
+    ):
+        del weight, scales
+        calls.append(
+            {
+                "out_shape": tuple(out.shape),
+                "x_shape": tuple(x.shape),
+                "group_size": group_size,
+                "k_ld": k_ld,
+                "q_ld": q_ld,
+                "gated_silu": gated_silu,
+            }
+        )
+        out.fill_(3.0)
+
+    monkeypatch.setattr(sm70_ops, "nvfp4_gemm_sm70_out", fake_gemm)
+
+    output = tm.apply_prepared_fused_silu_and_mul(
+        layer,
+        torch.ones((2, 1, 3), dtype=torch.float16),
+    )
+
+    assert output is not None
+    assert output.shape == (2, 1, 2)
+    assert output.tolist() == [[[3.0, 3.0]], [[3.0, 3.0]]]
+    assert calls == [
+        {
+            "out_shape": (2, 2),
+            "x_shape": (2, 3),
+            "group_size": 16,
+            "k_ld": 3,
+            "q_ld": 4,
+            "gated_silu": True,
+        }
+    ]
+
+
+def test_nvfp4_fused_silu_rejects_non_gated_state():
+    tm = _load_adapter()
+    layer = torch.nn.Module()
+    setattr(layer, tm.STATE_ATTR, _make_nvfp4_state(tm, gated_silu=False))
+
+    output = tm.apply_prepared_fused_silu_and_mul(
+        layer,
+        torch.ones((1, 3), dtype=torch.float16),
+    )
+
+    assert output is None
+
+
+def test_nvfp4_qpn4_regular_apply_uses_opaque_dynamic_m_dispatch(monkeypatch):
+    tm = _load_adapter()
+    layer = torch.nn.Module()
+    setattr(layer, tm.STATE_ATTR, _make_nvfp4_qpn4_state(tm, gated_silu=False))
+
+    from vllm import _sm70_ops as sm70_ops
+
+    calls = []
+
+    def fake_dispatch(
+        out,
+        dense_weight_ptr,
+        x,
+        weight,
+        scales,
+        global_scale,
+        use_scale_code,
+        gated_silu,
+    ):
+        del weight, scales
+        calls.append(
+            (
+                tuple(out.shape),
+                dense_weight_ptr,
+                tuple(x.shape),
+                global_scale,
+                use_scale_code,
+                gated_silu,
+            )
+        )
+        out.fill_(2.0)
+
+    monkeypatch.setattr(sm70_ops, "nvfp4_qpn4_dispatch_sm70_out", fake_dispatch)
+    output = tm.apply_prepared_linear(
+        layer,
+        torch.ones((2, 3), dtype=torch.float16),
+        bias=None,
+    )
+
+    assert output.tolist() == [[2.0] * 4, [2.0] * 4]
+    assert calls == [((2, 4), 1234, (2, 3), 0.0, False, False)]
+
+
+def test_nvfp4_qpn4_fused_gate_uses_scale_code_dispatch(monkeypatch):
+    tm = _load_adapter()
+    layer = torch.nn.Module()
+    setattr(layer, tm.STATE_ATTR, _make_nvfp4_qpn4_state(tm, gated_silu=True))
+
+    from vllm import _sm70_ops as sm70_ops
+
+    calls = []
+
+    def fake_dispatch(
+        out,
+        dense_weight_ptr,
+        x,
+        weight,
+        scales,
+        global_scale,
+        use_scale_code,
+        gated_silu,
+    ):
+        del weight, scales
+        calls.append(
+            (
+                tuple(out.shape),
+                dense_weight_ptr,
+                tuple(x.shape),
+                global_scale,
+                use_scale_code,
+                gated_silu,
+            )
+        )
+        out.fill_(4.0)
+
+    monkeypatch.setattr(sm70_ops, "nvfp4_qpn4_dispatch_sm70_out", fake_dispatch)
+    output = tm.apply_prepared_fused_silu_and_mul(
+        layer,
+        torch.ones((1, 3), dtype=torch.float16),
+    )
+
+    assert output is not None
+    assert output.tolist() == [[4.0, 4.0]]
+    assert calls == [((1, 2), 1234, (1, 3), 0.25, True, True)]

--- a/tests/quantization/test_sm70_warmup.py
+++ b/tests/quantization/test_sm70_warmup.py
@@ -35,6 +35,14 @@ def test_fp8_warmup_discovers_grouped_bmm_by_per_group_shape():
     assert discovered == [(layer, False)]
 
 
+def test_fp8_warmup_skips_static_qpn8_dispatch():
+    layer = _grouped_fp8_layer()
+    layer.sm70_fp8_qpn8 = True
+    model = nn.Sequential(layer)
+
+    assert list(warmup._iter_unique_fp8_dense_layers(model)) == []
+
+
 def test_fp8_warmup_matches_grouped_bmm_runtime_slice(monkeypatch):
     layer = _grouped_fp8_layer()
     calls = []

--- a/tests/v1/attention/test_sm70_flash_v100_policy.py
+++ b/tests/v1/attention/test_sm70_flash_v100_policy.py
@@ -1571,6 +1571,66 @@ def test_flash_v100_decode_uses_xqa_by_default_when_shape_supported(monkeypatch)
     assert torch.all(output == 1)
 
 
+def test_flash_v100_decode_uses_xqa_for_e4m3_g6_d256(monkeypatch):
+    from vllm.v1.attention.backends.flash_attn_v100 import FlashAttnV100Impl
+
+    monkeypatch.delenv("VLLM_FLASH_V100_DECODE_USE_XQA", raising=False)
+    monkeypatch.delenv("VLLM_FLASH_V100_DECODE_PARTITION_SIZE", raising=False)
+
+    impl = FlashAttnV100Impl(
+        num_heads=6,
+        head_size=256,
+        scale=1.0,
+        num_kv_heads=1,
+        alibi_slopes=None,
+        sliding_window=None,
+        kv_cache_dtype="fp8_e4m3",
+    )
+    calls: list[tuple[str, int | None, str | None]] = []
+
+    def hit_xqa(*args, **kwargs):
+        calls.append(
+            (
+                "xqa",
+                kwargs.get("partition_size_hint"),
+                kwargs.get("kv_cache_dtype"),
+            )
+        )
+        kwargs["out"].fill_(1)
+
+    def fail_scalar(*args, **kwargs):
+        raise AssertionError("E4M3 G6/D256 decode should select XQA")
+
+    impl.flash_attn_decode_paged_xqa = hit_xqa  # type: ignore[method-assign]
+    impl.flash_attn_decode_paged = fail_scalar  # type: ignore[method-assign]
+    attn_metadata = SimpleNamespace(
+        num_actual_tokens=1,
+        block_table=torch.tensor([[0]], dtype=torch.int32),
+        seq_lens=torch.tensor([1025], dtype=torch.int32),
+        flash_v100_decode_max_seq_len_hint=1025,
+        flash_v100_decode_workspace_seq_capacity_hint=262144,
+        flash_v100_decode_active_num_partitions=torch.tensor([5], dtype=torch.int32),
+    )
+    layer = SimpleNamespace(_k_scale_float=0.04, _v_scale_float=0.25)
+    query = torch.zeros((1, 6, 256), dtype=torch.float16)
+    output = torch.zeros_like(query)
+    kv_cache = torch.zeros((2, 2, 1568, 1, 256), dtype=torch.uint8)
+
+    result = impl._flash_v100_decode(
+        layer,
+        query,
+        query,
+        query,
+        kv_cache,
+        attn_metadata,
+        output,
+    )
+
+    assert result is output
+    assert calls == [("xqa", 64, "fp8_e4m3")]
+    assert torch.all(output == 1)
+
+
 @pytest.mark.parametrize(
     ("num_heads", "seq_len", "expected_route"),
     (
@@ -2219,7 +2279,7 @@ def test_flash_v100_decode_e5m2_keeps_small_pages_on_default_planner(monkeypatch
     )
 
 
-def test_flash_v100_decode_e4m3_does_not_use_e5m2_partition_hint(monkeypatch):
+def test_flash_v100_decode_e4m3_uses_exact_p64_partition_hint(monkeypatch):
     from vllm.v1.attention.backends.flash_attn_v100 import (
         _g6_aligned_page_partition_size_hint,
     )
@@ -2231,7 +2291,7 @@ def test_flash_v100_decode_e4m3_does_not_use_e5m2_partition_hint(monkeypatch):
 
     assert (
         _g6_aligned_page_partition_size_hint(query, key_cache, key_cache, "fp8_e4m3")
-        is None
+        == 64
     )
 
 

--- a/tests/v1/sample/test_sampler.py
+++ b/tests/v1/sample/test_sampler.py
@@ -5,6 +5,7 @@ import numpy as np
 import pytest
 import torch
 
+import vllm.envs as envs
 from tests.v1.sample.utils import create_allowed_token_ids
 from vllm.platforms import current_platform
 from vllm.utils.platform_utils import is_pin_memory_available
@@ -23,6 +24,30 @@ DEVICES = [
     for i in range(1 if current_platform.device_count() == 1 else 2)
 ]
 MAX_NUM_PROMPT_TOKENS = 64
+
+
+def test_sm70_compact_topk20_metadata_gate(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(envs, "VLLM_SM70_COMPACT_TOPK20_SAMPLER", True)
+    metadata = _create_default_sampling_metadata(
+        num_output_tokens=0,
+        batch_size=1,
+        vocab_size=VOCAB_SIZE,
+        device=torch.device("cpu"),
+    )
+    metadata.all_greedy = False
+    metadata.all_random = True
+    metadata.max_num_logprobs = None
+    metadata.top_k_cpu = (20,)
+    metadata.top_p_cpu = (0.95,)
+    metadata.temperature_cpu = (1.0,)
+
+    assert Sampler._sm70_compact_topk20_metadata_supported(metadata, "raw_logprobs")
+    metadata.top_k_cpu = (19,)
+    assert not Sampler._sm70_compact_topk20_metadata_supported(metadata, "raw_logprobs")
+    metadata.top_k_cpu = (20,)
+    assert not Sampler._sm70_compact_topk20_metadata_supported(
+        metadata, "processed_logits"
+    )
 
 
 def _create_fake_logits(batch_size: int, vocab_size: int) -> torch.Tensor:

--- a/vllm/_sm70_ops.py
+++ b/vllm/_sm70_ops.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import os
 from typing import TYPE_CHECKING
 
 import torch
@@ -8,6 +9,23 @@ import torch
 from vllm.platforms import current_platform
 
 current_platform.import_kernels()
+
+
+def _maybe_load_fp8_qpn8_library() -> None:
+    """Load an explicitly selected source-built QPN8 extension.
+
+    Production builds register these operators in ``vllm._C``. This opt-in
+    path lets source experiments add only the QPN8 operators to an otherwise
+    compatible installed build, including in spawned TP workers.
+    """
+    if os.getenv("VLLM_SM70_FP8_QPN8", "0") != "1":
+        return
+    library_path = os.getenv("VLLM_SM70_FP8_QPN8_LIBRARY")
+    if library_path:
+        torch.ops.load_library(library_path)
+
+
+_maybe_load_fp8_qpn8_library()
 
 if TYPE_CHECKING:
 
@@ -421,6 +439,125 @@ if hasattr(torch.ops._C, "fp8_gemm_sm70_out"):
         return None
 
 
+def fp8_qpn8_prepare_sm70(
+    qweight: torch.Tensor,
+    scales: torch.Tensor,
+) -> list[torch.Tensor]:
+    """Pack checkpoint-native block FP8 weights into the QPN8 layout."""
+    return _op("fp8_qpn8_prepare_sm70")(qweight, scales)
+
+
+if hasattr(torch.ops._C, "fp8_qpn8_prepare_sm70"):
+
+    @register_fake("_C::fp8_qpn8_prepare_sm70")
+    def _fp8_qpn8_prepare_sm70_fake(
+        qweight: torch.Tensor,
+        scales: torch.Tensor,
+    ) -> list[torch.Tensor]:
+        n = qweight.size(0)
+        k = qweight.size(1)
+        codes = torch.empty((k, n), dtype=torch.uint8, device=qweight.device)
+        group_scales = torch.empty(
+            (k // 128, n // 32), dtype=torch.float16, device=scales.device
+        )
+        return [codes, group_scales]
+
+
+def fp8_qpn8_dequantize_sm70_out(
+    out: torch.Tensor,
+    codes: torch.Tensor,
+    group_scales: torch.Tensor,
+) -> None:
+    """Materialize one QPN8 weight into a caller-owned FP16 workspace."""
+    _op("fp8_qpn8_dequantize_sm70_out")(out, codes, group_scales)
+
+
+if hasattr(torch.ops._C, "fp8_qpn8_dequantize_sm70_out"):
+
+    @register_fake("_C::fp8_qpn8_dequantize_sm70_out")
+    def _fp8_qpn8_dequantize_sm70_out_fake(
+        out: torch.Tensor,
+        codes: torch.Tensor,
+        group_scales: torch.Tensor,
+    ) -> None:
+        return None
+
+
+def fp8_qpn8_prefill_sm70_out(
+    out: torch.Tensor,
+    dense_weight_ptr: int,
+    input: torch.Tensor,
+    codes: torch.Tensor,
+    group_scales: torch.Tensor,
+    gated_silu: bool,
+) -> None:
+    """Dequantize QPN8 into bounded workspace and run a large-M FP16 GEMM."""
+    _op("fp8_qpn8_prefill_sm70_out")(
+        out,
+        dense_weight_ptr,
+        input,
+        codes,
+        group_scales,
+        gated_silu,
+    )
+
+
+if hasattr(torch.ops._C, "fp8_qpn8_prefill_sm70_out"):
+
+    @register_fake("_C::fp8_qpn8_prefill_sm70_out")
+    def _fp8_qpn8_prefill_sm70_out_fake(
+        out: torch.Tensor,
+        dense_weight_ptr: int,
+        input: torch.Tensor,
+        codes: torch.Tensor,
+        group_scales: torch.Tensor,
+        gated_silu: bool,
+    ) -> None:
+        return None
+
+
+def fp8_qpn8_dispatch_sm70_out(
+    out: torch.Tensor,
+    dense_weight_ptr: int,
+    input: torch.Tensor,
+    codes: torch.Tensor,
+    group_scales: torch.Tensor,
+    split_k: int,
+    accumulator_chains: int,
+    prefetch_codes: bool,
+    gated_silu: bool,
+) -> None:
+    """Runtime-dispatch dynamic M without specializing a Python branch."""
+    _op("fp8_qpn8_dispatch_sm70_out")(
+        out,
+        dense_weight_ptr,
+        input,
+        codes,
+        group_scales,
+        split_k,
+        accumulator_chains,
+        prefetch_codes,
+        gated_silu,
+    )
+
+
+if hasattr(torch.ops._C, "fp8_qpn8_dispatch_sm70_out"):
+
+    @register_fake("_C::fp8_qpn8_dispatch_sm70_out")
+    def _fp8_qpn8_dispatch_sm70_out_fake(
+        out: torch.Tensor,
+        dense_weight_ptr: int,
+        input: torch.Tensor,
+        codes: torch.Tensor,
+        group_scales: torch.Tensor,
+        split_k: int,
+        accumulator_chains: int,
+        prefetch_codes: bool,
+        gated_silu: bool,
+    ) -> None:
+        return None
+
+
 def fp8_qpn8_gemm_sm70_out(
     out: torch.Tensor,
     input: torch.Tensor,
@@ -431,10 +568,10 @@ def fp8_qpn8_gemm_sm70_out(
     fast_decoder: bool,
     prefetch_codes: bool = False,
 ) -> None:
-    """Run the experimental SM70 QPN8 FP8 GEMM into ``out``.
+    """Run the SM70 QPN8 FP8 GEMM into ``out``.
 
-    This benchmark-only entry point is intentionally not selected by model
-    dispatch. ``codes`` and ``group_scales`` use the QPN8 packed layout.
+    The model- and shape-gated automatic route and operator benchmark share
+    this entry point. ``codes`` and ``group_scales`` use the QPN8 layout.
     """
     _op("fp8_qpn8_gemm_sm70_out")(
         out,

--- a/vllm/_sm70_ops.py
+++ b/vllm/_sm70_ops.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 import os
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 import torch
@@ -26,6 +27,23 @@ def _maybe_load_fp8_qpn8_library() -> None:
 
 
 _maybe_load_fp8_qpn8_library()
+
+
+def _maybe_load_sm70_sampler_library() -> None:
+    """Load the sampler fragment only when the main ``vllm._C`` lacks it."""
+    if hasattr(torch.ops._C, "sm70_sample_chunked_top20_philox_token_out"):
+        return
+
+    library_path = os.getenv("VLLM_SM70_SAMPLER_LIBRARY")
+    if library_path is None:
+        bundled = sorted(Path(__file__).resolve().parent.glob("_sm70_sampler_C*.so"))
+        if bundled:
+            library_path = str(bundled[-1])
+    if library_path is not None:
+        torch.ops.load_library(library_path)
+
+
+_maybe_load_sm70_sampler_library()
 
 if TYPE_CHECKING:
 
@@ -641,6 +659,154 @@ if hasattr(torch.ops._C, "fp8_qpn8_gated_pair_sm70_out"):
         return None
 
 
+def nvfp4_qpn4_prepare_sm70(
+    qweight: torch.Tensor,
+    scales: torch.Tensor,
+) -> list[torch.Tensor]:
+    """Pack unpacked FP4 weights and FP16 group scales into QPN4 layout."""
+    return _op("nvfp4_qpn4_prepare_sm70")(qweight, scales)
+
+
+if hasattr(torch.ops._C, "nvfp4_qpn4_prepare_sm70"):
+
+    @register_fake("_C::nvfp4_qpn4_prepare_sm70")
+    def _nvfp4_qpn4_prepare_sm70_fake(
+        qweight: torch.Tensor,
+        scales: torch.Tensor,
+    ) -> list[torch.Tensor]:
+        k, n = qweight.shape
+        codes = torch.empty((k, n // 2), dtype=torch.uint8, device=qweight.device)
+        packed_scales = torch.empty_like(scales)
+        return [codes, packed_scales]
+
+
+def nvfp4_qpn4_prepare_scale_code_sm70(
+    qweight: torch.Tensor,
+    scale_codes: torch.Tensor,
+) -> list[torch.Tensor]:
+    """Pack unpacked FP4 weights and checkpoint E4M3 group-scale codes."""
+    return _op("nvfp4_qpn4_prepare_scale_code_sm70")(qweight, scale_codes)
+
+
+if hasattr(torch.ops._C, "nvfp4_qpn4_prepare_scale_code_sm70"):
+
+    @register_fake("_C::nvfp4_qpn4_prepare_scale_code_sm70")
+    def _nvfp4_qpn4_prepare_scale_code_sm70_fake(
+        qweight: torch.Tensor,
+        scale_codes: torch.Tensor,
+    ) -> list[torch.Tensor]:
+        k, n = qweight.shape
+        codes = torch.empty((k, n // 2), dtype=torch.uint8, device=qweight.device)
+        packed_scale_codes = torch.empty(
+            (k // 16, n),
+            dtype=torch.uint8,
+            device=scale_codes.device,
+        )
+        return [codes, packed_scale_codes]
+
+
+def nvfp4_qpn4_dequantize_sm70_out(
+    out: torch.Tensor,
+    codes: torch.Tensor,
+    scales: torch.Tensor,
+    global_scale: float,
+    use_scale_code: bool,
+) -> None:
+    _op("nvfp4_qpn4_dequantize_sm70_out")(
+        out, codes, scales, global_scale, use_scale_code
+    )
+
+
+if hasattr(torch.ops._C, "nvfp4_qpn4_dequantize_sm70_out"):
+
+    @register_fake("_C::nvfp4_qpn4_dequantize_sm70_out")
+    def _nvfp4_qpn4_dequantize_sm70_out_fake(
+        out: torch.Tensor,
+        codes: torch.Tensor,
+        scales: torch.Tensor,
+        global_scale: float,
+        use_scale_code: bool,
+    ) -> None:
+        return None
+
+
+def nvfp4_qpn4_prefill_sm70_out(
+    out: torch.Tensor,
+    dense_weight_ptr: int,
+    input: torch.Tensor,
+    codes: torch.Tensor,
+    scales: torch.Tensor,
+    global_scale: float,
+    use_scale_code: bool,
+    gated_silu: bool,
+) -> None:
+    _op("nvfp4_qpn4_prefill_sm70_out")(
+        out,
+        dense_weight_ptr,
+        input,
+        codes,
+        scales,
+        global_scale,
+        use_scale_code,
+        gated_silu,
+    )
+
+
+if hasattr(torch.ops._C, "nvfp4_qpn4_prefill_sm70_out"):
+
+    @register_fake("_C::nvfp4_qpn4_prefill_sm70_out")
+    def _nvfp4_qpn4_prefill_sm70_out_fake(
+        out: torch.Tensor,
+        dense_weight_ptr: int,
+        input: torch.Tensor,
+        codes: torch.Tensor,
+        scales: torch.Tensor,
+        global_scale: float,
+        use_scale_code: bool,
+        gated_silu: bool,
+    ) -> None:
+        return None
+
+
+def nvfp4_qpn4_dispatch_sm70_out(
+    out: torch.Tensor,
+    dense_weight_ptr: int,
+    input: torch.Tensor,
+    codes: torch.Tensor,
+    scales: torch.Tensor,
+    global_scale: float,
+    use_scale_code: bool,
+    gated_silu: bool,
+) -> None:
+    """Dispatch exact M=1 decode or bounded-workspace large-M prefill."""
+    _op("nvfp4_qpn4_dispatch_sm70_out")(
+        out,
+        dense_weight_ptr,
+        input,
+        codes,
+        scales,
+        global_scale,
+        use_scale_code,
+        gated_silu,
+    )
+
+
+if hasattr(torch.ops._C, "nvfp4_qpn4_dispatch_sm70_out"):
+
+    @register_fake("_C::nvfp4_qpn4_dispatch_sm70_out")
+    def _nvfp4_qpn4_dispatch_sm70_out_fake(
+        out: torch.Tensor,
+        dense_weight_ptr: int,
+        input: torch.Tensor,
+        codes: torch.Tensor,
+        scales: torch.Tensor,
+        global_scale: float,
+        use_scale_code: bool,
+        gated_silu: bool,
+    ) -> None:
+        return None
+
+
 def fp8_gemm_sm70_prefill_dispatch_out(
     out: torch.Tensor,
     dense_weight_ptr: int,
@@ -1199,6 +1365,114 @@ if hasattr(torch.ops._C, "sm70_sample_packed_top20_out"):
         gathered_pairs: torch.Tensor,
         exponential: torch.Tensor,
         top_p: float,
+    ) -> None:
+        return None
+
+
+def sm70_sample_sorted_top20_philox_out(
+    sampled_token_out: torch.Tensor,
+    sparse_ids_out: torch.Tensor,
+    sparse_probs_out: torch.Tensor,
+    top_values: torch.Tensor,
+    top_indices: torch.Tensor,
+    generator: torch.Generator | None,
+    vocab_size: int,
+    top_p: float,
+) -> None:
+    _op("sm70_sample_sorted_top20_philox_out")(
+        sampled_token_out,
+        sparse_ids_out,
+        sparse_probs_out,
+        top_values,
+        top_indices,
+        generator,
+        vocab_size,
+        top_p,
+    )
+
+
+if hasattr(torch.ops._C, "sm70_sample_sorted_top20_philox_out"):
+
+    @register_fake("_C::sm70_sample_sorted_top20_philox_out")
+    def _sm70_sample_sorted_top20_philox_out_fake(
+        sampled_token_out: torch.Tensor,
+        sparse_ids_out: torch.Tensor,
+        sparse_probs_out: torch.Tensor,
+        top_values: torch.Tensor,
+        top_indices: torch.Tensor,
+        generator: torch.Generator | None,
+        vocab_size: int,
+        top_p: float,
+    ) -> None:
+        return None
+
+
+def sm70_sample_sorted_top20_philox_token_out(
+    sampled_token_out: torch.Tensor,
+    top_values: torch.Tensor,
+    top_indices: torch.Tensor,
+    generator: torch.Generator | None,
+    vocab_size: int,
+    top_p: float,
+) -> None:
+    _op("sm70_sample_sorted_top20_philox_token_out")(
+        sampled_token_out,
+        top_values,
+        top_indices,
+        generator,
+        vocab_size,
+        top_p,
+    )
+
+
+if hasattr(torch.ops._C, "sm70_sample_sorted_top20_philox_token_out"):
+
+    @register_fake("_C::sm70_sample_sorted_top20_philox_token_out")
+    def _sm70_sample_sorted_top20_philox_token_out_fake(
+        sampled_token_out: torch.Tensor,
+        top_values: torch.Tensor,
+        top_indices: torch.Tensor,
+        generator: torch.Generator | None,
+        vocab_size: int,
+        top_p: float,
+    ) -> None:
+        return None
+
+
+def sm70_sample_chunked_top20_philox_token_out(
+    sampled_token_out: torch.Tensor,
+    global_values: torch.Tensor,
+    local_indices: torch.Tensor,
+    global_positions: torch.Tensor,
+    generator: torch.Generator | None,
+    vocab_size: int,
+    top_p: float,
+    chunk_size: int,
+) -> None:
+    _op("sm70_sample_chunked_top20_philox_token_out")(
+        sampled_token_out,
+        global_values,
+        local_indices,
+        global_positions,
+        generator,
+        vocab_size,
+        top_p,
+        chunk_size,
+    )
+
+
+if hasattr(torch.ops._C, "sm70_sample_chunked_top20_philox_token_out"):
+
+    @register_fake("_C::sm70_sample_chunked_top20_philox_token_out")
+    def _sm70_sample_chunked_top20_philox_token_out_fake(
+        sampled_token_out: torch.Tensor,
+        global_values: torch.Tensor,
+        local_indices: torch.Tensor,
+        global_positions: torch.Tensor,
+        generator: torch.Generator | None,
+        vocab_size: int,
+        top_p: float,
+        chunk_size: int,
     ) -> None:
         return None
 

--- a/vllm/_sm70_ops.py
+++ b/vllm/_sm70_ops.py
@@ -421,6 +421,88 @@ if hasattr(torch.ops._C, "fp8_gemm_sm70_out"):
         return None
 
 
+def fp8_qpn8_gemm_sm70_out(
+    out: torch.Tensor,
+    input: torch.Tensor,
+    codes: torch.Tensor,
+    group_scales: torch.Tensor,
+    split_k: int,
+    accumulator_chains: int,
+    fast_decoder: bool,
+    prefetch_codes: bool = False,
+) -> None:
+    """Run the experimental SM70 QPN8 FP8 GEMM into ``out``.
+
+    This benchmark-only entry point is intentionally not selected by model
+    dispatch. ``codes`` and ``group_scales`` use the QPN8 packed layout.
+    """
+    _op("fp8_qpn8_gemm_sm70_out")(
+        out,
+        input,
+        codes,
+        group_scales,
+        split_k,
+        accumulator_chains,
+        fast_decoder,
+        prefetch_codes,
+    )
+
+
+if hasattr(torch.ops._C, "fp8_qpn8_gemm_sm70_out"):
+
+    @register_fake("_C::fp8_qpn8_gemm_sm70_out")
+    def _fp8_qpn8_gemm_sm70_out_fake(
+        out: torch.Tensor,
+        input: torch.Tensor,
+        codes: torch.Tensor,
+        group_scales: torch.Tensor,
+        split_k: int,
+        accumulator_chains: int,
+        fast_decoder: bool,
+        prefetch_codes: bool,
+    ) -> None:
+        return None
+
+
+def fp8_qpn8_gated_pair_sm70_out(
+    out: torch.Tensor,
+    input: torch.Tensor,
+    codes: torch.Tensor,
+    group_scales: torch.Tensor,
+    split_k: int,
+    accumulator_chains: int,
+    fast_decoder: bool,
+    prefetch_codes: bool = False,
+) -> None:
+    """Run the single-kernel paired-tile QPN8 gated SiLU experiment."""
+    _op("fp8_qpn8_gated_pair_sm70_out")(
+        out,
+        input,
+        codes,
+        group_scales,
+        split_k,
+        accumulator_chains,
+        fast_decoder,
+        prefetch_codes,
+    )
+
+
+if hasattr(torch.ops._C, "fp8_qpn8_gated_pair_sm70_out"):
+
+    @register_fake("_C::fp8_qpn8_gated_pair_sm70_out")
+    def _fp8_qpn8_gated_pair_sm70_out_fake(
+        out: torch.Tensor,
+        input: torch.Tensor,
+        codes: torch.Tensor,
+        group_scales: torch.Tensor,
+        split_k: int,
+        accumulator_chains: int,
+        fast_decoder: bool,
+        prefetch_codes: bool,
+    ) -> None:
+        return None
+
+
 def fp8_gemm_sm70_prefill_dispatch_out(
     out: torch.Tensor,
     dense_weight_ptr: int,

--- a/vllm/_sm70_ops.py
+++ b/vllm/_sm70_ops.py
@@ -443,7 +443,7 @@ def fp8_qpn8_prepare_sm70(
     qweight: torch.Tensor,
     scales: torch.Tensor,
 ) -> list[torch.Tensor]:
-    """Pack checkpoint-native block FP8 weights into the QPN8 layout."""
+    """Pack checkpoint-native block/channel FP8 weights into QPN8 layout."""
     return _op("fp8_qpn8_prepare_sm70")(qweight, scales)
 
 
@@ -457,8 +457,9 @@ if hasattr(torch.ops._C, "fp8_qpn8_prepare_sm70"):
         n = qweight.size(0)
         k = qweight.size(1)
         codes = torch.empty((k, n), dtype=torch.uint8, device=qweight.device)
+        scale_shape = (1, n) if scales.shape == (n, 1) else (k // 128, n // 32)
         group_scales = torch.empty(
-            (k // 128, n // 32), dtype=torch.float16, device=scales.device
+            scale_shape, dtype=torch.float16, device=scales.device
         )
         return [codes, group_scales]
 

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -156,7 +156,7 @@ if TYPE_CHECKING:
     VLLM_SM70_FP8_PRESERVE_DEFAULT_SPLITS: bool = True
     VLLM_SM70_FP8_PRESERVE_DEFAULT_SPLITS_ONLY: bool = False
     VLLM_SM70_FP8_PREFILL_EXACT_DENSE: bool = True
-    VLLM_SM70_FP8_QPN8: bool = True
+    VLLM_SM70_FP8_QPN8: bool = False
     VLLM_SM70_FP8_QPN8_LIBRARY: str | None = None
     VLLM_SM70_SAMPLER_LIBRARY: str | None = None
     VLLM_SM70_MXFP4_TUNE_SMALL_SHAPES: bool = True
@@ -1622,10 +1622,10 @@ environment_variables: dict[str, Callable[[], Any]] = {
         int(os.getenv("VLLM_SM70_FP8_PREFILL_EXACT_DENSE", "1"))
     ),
     # Memory-neutral QPN8 layout for model-, shape-, and runtime-gated
-    # Qwen3.8 TP4 no-MTP dense projections. Native M<=8 decode reads the FP8
-    # layout directly; larger prefill M uses the correctness fallback. Set
-    # this to 0 for an explicit TurboMind layout.
-    "VLLM_SM70_FP8_QPN8": lambda: bool(int(os.getenv("VLLM_SM70_FP8_QPN8", "1"))),
+    # Qwen3.8 TP4 no-MTP dense projections. Pure-FP8 checkpoints must opt in;
+    # a mixed NVFP4 checkpoint may select its separately validated default in
+    # the compressed-tensors scheme. Explicit 0 disables both routes.
+    "VLLM_SM70_FP8_QPN8": lambda: bool(int(os.getenv("VLLM_SM70_FP8_QPN8", "0"))),
     # Optional source-built QPN8-only extension. Production builds leave this
     # unset because the same operators are linked into vllm._C.
     "VLLM_SM70_FP8_QPN8_LIBRARY": lambda: os.getenv("VLLM_SM70_FP8_QPN8_LIBRARY", None),

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -160,6 +160,7 @@ if TYPE_CHECKING:
     VLLM_SM70_FP8_QPN8_LIBRARY: str | None = None
     VLLM_SM70_MXFP4_TUNE_SMALL_SHAPES: bool = True
     VLLM_SM70_NVFP4_TUNE_SMALL_SHAPES: bool = True
+    VLLM_SM70_NVFP4_QWEN38_TP4_M1_FAST_SELECTOR: bool = True
     VLLM_SM70_AWQ_REUSE_IMPORTED_CACHE: bool = False
     VLLM_SM70_AWQ_WARMUP: bool = True
     VLLM_SM70_AWQ_WARMUP_MAX_M: int = 16
@@ -1682,6 +1683,9 @@ environment_variables: dict[str, Callable[[], Any]] = {
     ),
     "VLLM_SM70_NVFP4_TUNE_SMALL_SHAPES": lambda: bool(
         int(os.getenv("VLLM_SM70_NVFP4_TUNE_SMALL_SHAPES", "1"))
+    ),
+    "VLLM_SM70_NVFP4_QWEN38_TP4_M1_FAST_SELECTOR": lambda: bool(
+        int(os.getenv("VLLM_SM70_NVFP4_QWEN38_TP4_M1_FAST_SELECTOR", "1"))
     ),
     "VLLM_SM70_AWQ_REUSE_IMPORTED_CACHE": lambda: bool(
         int(os.getenv("VLLM_SM70_AWQ_REUSE_IMPORTED_CACHE", "0"))

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -156,6 +156,8 @@ if TYPE_CHECKING:
     VLLM_SM70_FP8_PRESERVE_DEFAULT_SPLITS: bool = True
     VLLM_SM70_FP8_PRESERVE_DEFAULT_SPLITS_ONLY: bool = False
     VLLM_SM70_FP8_PREFILL_EXACT_DENSE: bool = True
+    VLLM_SM70_FP8_QPN8: bool = True
+    VLLM_SM70_FP8_QPN8_LIBRARY: str | None = None
     VLLM_SM70_MXFP4_TUNE_SMALL_SHAPES: bool = True
     VLLM_SM70_NVFP4_TUNE_SMALL_SHAPES: bool = True
     VLLM_SM70_AWQ_REUSE_IMPORTED_CACHE: bool = False
@@ -1610,6 +1612,14 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "VLLM_SM70_FP8_PREFILL_EXACT_DENSE": lambda: bool(
         int(os.getenv("VLLM_SM70_FP8_PREFILL_EXACT_DENSE", "1"))
     ),
+    # Memory-neutral QPN8 layout for model-, shape-, and runtime-gated
+    # Qwen3.8 TP4 no-MTP dense projections. Native M<=8 decode reads the FP8
+    # layout directly; larger prefill M uses the correctness fallback. Set
+    # this to 0 for an explicit TurboMind layout.
+    "VLLM_SM70_FP8_QPN8": lambda: bool(int(os.getenv("VLLM_SM70_FP8_QPN8", "1"))),
+    # Optional source-built QPN8-only extension. Production builds leave this
+    # unset because the same operators are linked into vllm._C.
+    "VLLM_SM70_FP8_QPN8_LIBRARY": lambda: os.getenv("VLLM_SM70_FP8_QPN8_LIBRARY", None),
     # Experimental TileRT-inspired down-proj lane: after the row-parallel AWQ
     # GEMM, use the local tile-runtime TP2 all-reduce substrate for the MLP
     # hidden-state reduction. This is default-off until it wins end-to-end.

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -158,6 +158,7 @@ if TYPE_CHECKING:
     VLLM_SM70_FP8_PREFILL_EXACT_DENSE: bool = True
     VLLM_SM70_FP8_QPN8: bool = True
     VLLM_SM70_FP8_QPN8_LIBRARY: str | None = None
+    VLLM_SM70_SAMPLER_LIBRARY: str | None = None
     VLLM_SM70_MXFP4_TUNE_SMALL_SHAPES: bool = True
     VLLM_SM70_NVFP4_TUNE_SMALL_SHAPES: bool = True
     VLLM_SM70_NVFP4_QWEN38_TP4_M1_FAST_SELECTOR: bool = True
@@ -181,6 +182,9 @@ if TYPE_CHECKING:
     VLLM_SM70_TOP1_CUSTOM_AR: bool = False
     VLLM_SM70_GREEDY_TOKEN_FASTPATH: bool = True
     VLLM_SM70_GREEDY_TOKEN_FASTPATH_TRACE: bool = False
+    VLLM_SM70_COMPACT_TOPK20_SAMPLER: bool = False
+    VLLM_SM70_CHUNKED_TOPK20_CHUNKS: int = 0
+    VLLM_SM70_TP_LOCAL_TOPK20_SAMPLER: bool = False
     VLLM_SM70_ASYNC_SCHEDULING_QUEUE_DEPTH: int = 0
     VLLM_SM70_ASYNC_STAGED_INPUT_PREP: bool = False
     VLLM_SM70_ASYNC_CPU_TRACE: bool = False
@@ -188,6 +192,7 @@ if TYPE_CHECKING:
     VLLM_TP_ALLREDUCE_TRACE: bool = False
     VLLM_CUSTOM_ALLREDUCE_BLOCK_LIMIT: int | None = None
     VLLM_SM70_TP4_M5_AR_THREADS: int | None = None
+    VLLM_SM70_TP4_SMALL_AR_PACK32: bool = False
     VLLM_SM70_F16_DENSE_ALLOWLIST: str | None = None
     VLLM_SM70_MOE_DENSE_ALLOWLIST: str | None = None
     VLLM_SM70_F16_DENSE_MAX_M: int = 64
@@ -202,6 +207,9 @@ if TYPE_CHECKING:
     VLLM_SM70_FP8_DENSE_GATED_SILU: bool = True
     VLLM_SM70_NVFP4_TURBOMIND: bool = True
     VLLM_SM70_NVFP4_MOE_GROUPED_PREFILL: bool = True
+    VLLM_SM70_NVFP4_DENSE_GATED_SILU: bool = True
+    VLLM_SM70_NVFP4_QPN4: bool = True
+    VLLM_SM70_NVFP4_QPN4_DOWN_SCALE_CODE: bool = False
     VLLM_SM70_MXFP4_TURBOMIND: bool = True
     VLLM_SM70_MXFP4_MOE_ACTIVE_EXPERT_B1: bool = False
     VLLM_SM70_MXFP4_MOE_ACTIVE_EXPERT_MAX_TOKENS: int = 8
@@ -1621,6 +1629,7 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # Optional source-built QPN8-only extension. Production builds leave this
     # unset because the same operators are linked into vllm._C.
     "VLLM_SM70_FP8_QPN8_LIBRARY": lambda: os.getenv("VLLM_SM70_FP8_QPN8_LIBRARY", None),
+    "VLLM_SM70_SAMPLER_LIBRARY": lambda: os.getenv("VLLM_SM70_SAMPLER_LIBRARY", None),
     # Experimental TileRT-inspired down-proj lane: after the row-parallel AWQ
     # GEMM, use the local tile-runtime TP2 all-reduce substrate for the MLP
     # hidden-state reduction. This is default-off until it wins end-to-end.
@@ -1803,6 +1812,9 @@ environment_variables: dict[str, Callable[[], Any]] = {
         if "VLLM_SM70_TP4_M5_AR_THREADS" in os.environ
         else None
     ),
+    "VLLM_SM70_TP4_SMALL_AR_PACK32": lambda: bool(
+        int(os.getenv("VLLM_SM70_TP4_SMALL_AR_PACK32", "0"))
+    ),
     # Optional custom allreduce for the tiny per-rank top1 pair. Keep default
     # off until the communicator path has same-criterion model evidence.
     "VLLM_SM70_TOP1_CUSTOM_AR": lambda: bool(
@@ -1860,6 +1872,28 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # the compact active-expert route; larger graph shapes use full groups.
     "VLLM_SM70_NVFP4_MOE_GROUPED_PREFILL": lambda: bool(
         int(os.getenv("VLLM_SM70_NVFP4_MOE_GROUPED_PREFILL", "1"))
+    ),
+    "VLLM_SM70_NVFP4_DENSE_GATED_SILU": lambda: bool(
+        int(os.getenv("VLLM_SM70_NVFP4_DENSE_GATED_SILU", "1"))
+    ),
+    # Memory-neutral native QPN4 M=1 decode for the accepted Qwen3.8-27B
+    # NVFP4 TP4 no-MTP contract. Larger-M prefill dequantizes into one bounded
+    # shared FP16 workspace. Set to 0 to retain the TurboMind NVFP4 route.
+    "VLLM_SM70_NVFP4_QPN4": lambda: bool(int(os.getenv("VLLM_SM70_NVFP4_QPN4", "1"))),
+    "VLLM_SM70_NVFP4_QPN4_DOWN_SCALE_CODE": lambda: bool(
+        int(os.getenv("VLLM_SM70_NVFP4_QPN4_DOWN_SCALE_CODE", "0"))
+    ),
+    # Exact no-MTP random sampler for the Qwen3.8 TP4 batch-one contract.
+    # The base flag enables exact compact sampling after full-logits gather.
+    # The separate TP-local flag opts into rank-local top-20 reduction.
+    "VLLM_SM70_COMPACT_TOPK20_SAMPLER": lambda: bool(
+        int(os.getenv("VLLM_SM70_COMPACT_TOPK20_SAMPLER", "0"))
+    ),
+    "VLLM_SM70_CHUNKED_TOPK20_CHUNKS": lambda: int(
+        os.getenv("VLLM_SM70_CHUNKED_TOPK20_CHUNKS", "0")
+    ),
+    "VLLM_SM70_TP_LOCAL_TOPK20_SAMPLER": lambda: bool(
+        int(os.getenv("VLLM_SM70_TP_LOCAL_TOPK20_SAMPLER", "0"))
     ),
     "VLLM_SM70_MXFP4_TURBOMIND": lambda: bool(
         int(os.getenv("VLLM_SM70_MXFP4_TURBOMIND", "1"))

--- a/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors.py
@@ -380,6 +380,12 @@ class CompressedTensorsConfig(QuantizationConfig):
             and is_symmetric
         )
 
+    def _contains_nvfp4_weights(self) -> bool:
+        return any(
+            scheme is not None and self._is_nvfp4_format(scheme.get("weights"))
+            for scheme in self.target_scheme_map.values()
+        )
+
     @staticmethod
     def _is_mxfp4(quant_args: QuantizationArgs) -> bool:
         if quant_args is None:
@@ -676,6 +682,7 @@ class CompressedTensorsConfig(QuantizationConfig):
                     return CompressedTensorsW8A16Fp8(
                         weight_quant=weight_quant,
                         is_static_input_scheme=not input_quant.dynamic,
+                        enable_sm70_qpn8_by_default=self._contains_nvfp4_weights(),
                     )
 
             # note: input_quant can be None
@@ -684,6 +691,7 @@ class CompressedTensorsConfig(QuantizationConfig):
                 return CompressedTensorsW8A16Fp8(
                     weight_quant=weight_quant,
                     is_static_input_scheme=is_static_input_scheme,
+                    enable_sm70_qpn8_by_default=self._contains_nvfp4_weights(),
                 )
 
             if self._is_static_tensor_w8a8(weight_quant, input_quant):

--- a/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors.py
@@ -854,6 +854,19 @@ class CompressedTensorsLinearMethod(LinearMethodBase):
             raise ValueError("A scheme must be defined for each layer")
         return scheme.apply_weights(layer, x, bias=bias)
 
+    def apply_fused_silu_and_mul(
+        self,
+        layer: torch.nn.Module,
+        x: torch.Tensor,
+    ) -> torch.Tensor | None:
+        scheme = layer.scheme
+        if scheme is None:
+            raise ValueError("A scheme must be defined for each layer")
+        fused_apply = getattr(scheme, "apply_fused_silu_and_mul", None)
+        if fused_apply is None:
+            return None
+        return fused_apply(layer, x)
+
 
 class CompressedTensorsKVCacheMethod(BaseKVCacheMethod):
     """

--- a/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_w4a4_nvfp4.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_w4a4_nvfp4.py
@@ -6,6 +6,7 @@ import torch
 from torch.nn.parameter import Parameter
 
 from vllm import envs
+from vllm.config import get_current_vllm_config
 from vllm.logger import init_logger
 from vllm.model_executor.kernels.linear import init_nvfp4_linear_kernel
 from vllm.model_executor.layers.quantization import sm70_turbomind as sm70_tm
@@ -21,14 +22,79 @@ from vllm.model_executor.parameter import (
 logger = init_logger(__name__)
 
 
+def _is_qwen38_27b_nvfp4_model() -> bool:
+    model_config = get_current_vllm_config().model_config
+    hf_config = model_config.hf_config
+    text_config = model_config.hf_text_config
+    return bool(
+        getattr(hf_config, "model_type", None) == "qwen3_5"
+        and getattr(hf_config, "architectures", None)
+        == ["Qwen3_5ForConditionalGeneration"]
+        and getattr(text_config, "model_type", None) == "qwen3_5_text"
+        and getattr(text_config, "hidden_size", None) == 5120
+        and getattr(text_config, "intermediate_size", None) == 17408
+        and getattr(text_config, "num_hidden_layers", None) == 64
+        and getattr(text_config, "full_attention_interval", None) == 4
+        and getattr(text_config, "head_dim", None) == 256
+    )
+
+
+def _is_qwen38_tp4_nvfp4_gate_up(layer: torch.nn.Module) -> bool:
+    return bool(
+        _is_qwen38_27b_nvfp4_model()
+        and getattr(layer, "tp_size", 1) == 4
+        and getattr(layer, "prefix", "").rsplit(".", 1)[-1] == "gate_up_proj"
+        and getattr(layer, "input_size_per_partition", 0) == 5120
+        and getattr(layer, "output_size_per_partition", 0) == 8704
+        and getattr(layer, "logical_widths", None) == [4352, 4352]
+    )
+
+
+def _is_qwen38_tp4_nvfp4_down(layer: torch.nn.Module) -> bool:
+    return bool(
+        _is_qwen38_27b_nvfp4_model()
+        and getattr(layer, "tp_size", 1) == 4
+        and getattr(layer, "prefix", "").rsplit(".", 1)[-1] == "down_proj"
+        and getattr(layer, "input_size_per_partition", 0) == 4352
+        and getattr(layer, "output_size_per_partition", 0) == 5120
+    )
+
+
+def _is_qwen38_tp4_nvfp4_qpn4_layer(layer: torch.nn.Module) -> bool:
+    return _is_qwen38_tp4_nvfp4_gate_up(layer) or _is_qwen38_tp4_nvfp4_down(layer)
+
+
+def _is_qwen38_nvfp4_qpn4_runtime_contract() -> bool:
+    """Admit only the measured single-sequence, no-MTP decode contract."""
+    vllm_config = get_current_vllm_config()
+    scheduler_config = getattr(vllm_config, "scheduler_config", None)
+    max_num_seqs = int(getattr(scheduler_config, "max_num_seqs", 1))
+    speculative_config = getattr(vllm_config, "speculative_config", None)
+    return max_num_seqs == 1 and speculative_config is None
+
+
+_SM70_NVFP4_QPN4_REQUIRED_OPS = (
+    "nvfp4_qpn4_prepare_sm70",
+    "nvfp4_qpn4_prepare_scale_code_sm70",
+    "nvfp4_qpn4_dequantize_sm70_out",
+    "nvfp4_qpn4_prefill_sm70_out",
+    "nvfp4_qpn4_dispatch_sm70_out",
+)
+
+
+def _missing_sm70_nvfp4_qpn4_ops() -> list[str]:
+    return [
+        name
+        for name in _SM70_NVFP4_QPN4_REQUIRED_OPS
+        if not hasattr(torch.ops._C, name)
+    ]
+
+
 __all__ = ["CompressedTensorsW4A4Fp4"]
 
 
 def _explicit_nvfp4_emulation_requested() -> bool:
-    if (
-        envs.VLLM_USE_NVFP4_CT_EMULATIONS
-        or envs.VLLM_NVFP4_GEMM_BACKEND == "emulation"
-    ):
+    if envs.VLLM_USE_NVFP4_CT_EMULATIONS or envs.VLLM_NVFP4_GEMM_BACKEND == "emulation":
         return True
 
     from vllm.config import get_current_vllm_config_or_none
@@ -153,7 +219,70 @@ class CompressedTensorsW4A4Fp4(CompressedTensorsScheme):
             logger.info_once(
                 "SM70 compressed-tensors NVFP4 TurboMind W4A16 dense path enabled."
             )
-            sm70_tm.prepare_nvfp4_linear(layer)
+            is_qpn4_gate = _is_qwen38_tp4_nvfp4_gate_up(layer)
+            is_qpn4_down = _is_qwen38_tp4_nvfp4_down(layer)
+            qpn4_model_layer = envs.VLLM_SM70_NVFP4_QPN4 and (
+                is_qpn4_down or (is_qpn4_gate and envs.VLLM_SM70_NVFP4_DENSE_GATED_SILU)
+            )
+            qpn4_runtime = (
+                _is_qwen38_nvfp4_qpn4_runtime_contract() if qpn4_model_layer else False
+            )
+            if qpn4_model_layer and not qpn4_runtime:
+                logger.info_once(
+                    "The SM70 NVFP4 QPN4 route retains TurboMind unless the "
+                    "runtime contract is max_num_seqs=1 with no MTP."
+                )
+            if qpn4_model_layer and qpn4_runtime:
+                missing_ops = _missing_sm70_nvfp4_qpn4_ops()
+                if missing_ops:
+                    logger.warning_once(
+                        "The automatic SM70 NVFP4 QPN4 route is unavailable "
+                        "in the loaded vllm._C; retaining TurboMind. Missing "
+                        f"ops: {missing_ops}."
+                    )
+                workspace = (
+                    None
+                    if missing_ops
+                    else sm70_tm.get_nvfp4_qpn4_dense_workspace(layer.weight)
+                )
+                if not missing_ops and workspace is not None:
+                    sm70_tm.prepare_nvfp4_qpn4_linear(
+                        layer,
+                        workspace,
+                        gated_silu=is_qpn4_gate,
+                    )
+                    layer.weight = Parameter(
+                        torch.empty(0, dtype=torch.uint8, device=layer.weight.device),
+                        requires_grad=False,
+                    )
+                    layer.weight_scale = Parameter(
+                        torch.empty(
+                            0,
+                            dtype=torch.float8_e4m3fn,
+                            device=layer.weight_scale.device,
+                        ),
+                        requires_grad=False,
+                    )
+                    logger.info_once(
+                        "Memory-neutral SM70 Qwen3.8 NVFP4 QPN4 M=1 decode "
+                        "path enabled with bounded FP16 prefill workspace."
+                    )
+                    return
+                if not missing_ops:
+                    logger.warning_once(
+                        "Insufficient memory for the bounded SM70 NVFP4 QPN4 "
+                        "prefill workspace; retaining TurboMind."
+                    )
+            use_gated_silu = envs.VLLM_SM70_NVFP4_DENSE_GATED_SILU and is_qpn4_gate
+            sm70_tm.prepare_nvfp4_linear(
+                layer,
+                interleave_gated_silu=use_gated_silu,
+            )
+            if use_gated_silu:
+                logger.info_once(
+                    "SM70 Qwen3.8 NVFP4 TurboMind gated-SiLU single-layout "
+                    "path enabled."
+                )
             layer.weight = Parameter(
                 torch.empty(0, dtype=torch.uint8, device=layer.weight.device),
                 requires_grad=False,
@@ -183,3 +312,12 @@ class CompressedTensorsW4A4Fp4(CompressedTensorsScheme):
         if sm70_tm.has_prepared_linear(layer):
             return sm70_tm.apply_prepared_linear(layer, x, bias)
         return self._fallback_kernel().apply_weights(layer=layer, x=x, bias=bias)
+
+    def apply_fused_silu_and_mul(
+        self,
+        layer: torch.nn.Module,
+        x: torch.Tensor,
+    ) -> torch.Tensor | None:
+        if not sm70_tm.has_prepared_linear(layer):
+            return None
+        return sm70_tm.apply_prepared_fused_silu_and_mul(layer, x)

--- a/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_w8a16_fp8.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_w8a16_fp8.py
@@ -66,6 +66,13 @@ _SM70_CHANNEL_FP8_QPN8_CONFIGS = {
 _SM70_CHANNEL_FP8_QPN8_GATED_CONFIG = (8, 2, False)
 
 
+def _sm70_fp8_qpn8_enabled(enable_by_default: bool) -> bool:
+    """Resolve QPN8 while preserving the validated mixed-NVFP4 default."""
+    if os.getenv("VLLM_SM70_FP8_QPN8") is None:
+        return enable_by_default
+    return envs.VLLM_SM70_FP8_QPN8
+
+
 def _sm70_channel_fp8_qpn8_config(
     layer: torch.nn.Module,
 ) -> tuple[int, int, bool] | None:
@@ -79,7 +86,12 @@ def _sm70_channel_fp8_qpn8_config(
 
 
 class CompressedTensorsW8A16Fp8(CompressedTensorsScheme):
-    def __init__(self, weight_quant: QuantizationArgs, is_static_input_scheme: bool):
+    def __init__(
+        self,
+        weight_quant: QuantizationArgs,
+        is_static_input_scheme: bool,
+        enable_sm70_qpn8_by_default: bool = False,
+    ):
         self.weight_quant = weight_quant
         self.strategy = weight_quant.strategy
         self.out_dtype = torch.get_default_dtype()
@@ -97,7 +109,9 @@ class CompressedTensorsW8A16Fp8(CompressedTensorsScheme):
             and sm70_tm.is_exact_sm70_cuda_platform()
             and sm70_tm.use_turbomind(envs.VLLM_SM70_FP8_TURBOMIND)
         )
-        self.use_sm70_fp8_qpn8 = self.use_sm70_fp8_turbomind and envs.VLLM_SM70_FP8_QPN8
+        self.use_sm70_fp8_qpn8 = self.use_sm70_fp8_turbomind and _sm70_fp8_qpn8_enabled(
+            enable_sm70_qpn8_by_default
+        )
 
     @classmethod
     def get_min_capability(cls) -> int:

--- a/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_w8a16_fp8.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_w8a16_fp8.py
@@ -1,21 +1,32 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import os
 from collections.abc import Callable
 
 import torch
 from compressed_tensors.quantization import QuantizationArgs, QuantizationStrategy
 
+from vllm import _sm70_ops as sm70_ops
+from vllm import envs
 from vllm.config import get_current_vllm_config
+from vllm.logger import init_logger
 from vllm.model_executor.kernels.linear import (
     init_wfp8_a16_linear_kernel,
 )
+from vllm.model_executor.layers.quantization import sm70_turbomind as sm70_tm
 from vllm.model_executor.layers.quantization.compressed_tensors.schemes import (
     CompressedTensorsScheme,
 )
 from vllm.model_executor.layers.quantization.compressed_tensors.utils import (
     STRATEGY_TO_PARAMETER_TYPE,
     STRATEGY_TO_WEIGHT_QUANT_KEY,
+)
+from vllm.model_executor.layers.quantization.fp8 import (
+    _get_sm70_fp8_prefill_exact_dense_workspace,
+    _is_qwen38_27b_fp8_qpn8_model,
+    _is_sm70_fp8_qpn8_runtime_contract,
+    _missing_sm70_fp8_qpn8_ops,
 )
 from vllm.model_executor.layers.quantization.utils.fp8_utils import (
     create_fp8_scale_parameter,
@@ -34,6 +45,38 @@ from vllm.model_executor.utils import replace_parameter
 
 __all__ = ["CompressedTensorsW8A16Fp8"]
 
+logger = init_logger(__name__)
+
+_SM70_CHANNEL_FP8_QPN8_SHAPES = {
+    "in_proj_qkvz": (4096, 5120),
+    "qkv_proj": (3584, 5120),
+    "out_proj": (5120, 1536),
+    "o_proj": (5120, 1536),
+    "gate_up_proj": (8704, 5120),
+    "down_proj": (5120, 4352),
+}
+_SM70_CHANNEL_FP8_QPN8_CONFIGS = {
+    # (K, N): (split-K, accumulator chains, prefetch codes)
+    (5120, 4096): (16, 2, False),
+    (5120, 3584): (16, 2, False),
+    (1536, 5120): (12, 2, False),
+    (5120, 8704): (16, 2, False),
+    (4352, 5120): (16, 2, False),
+}
+_SM70_CHANNEL_FP8_QPN8_GATED_CONFIG = (8, 2, False)
+
+
+def _sm70_channel_fp8_qpn8_config(
+    layer: torch.nn.Module,
+) -> tuple[int, int, bool] | None:
+    if getattr(layer, "tp_size", 1) != 4:
+        return None
+    suffix = getattr(layer, "prefix", "").rsplit(".", 1)[-1]
+    if tuple(layer.weight.shape) != _SM70_CHANNEL_FP8_QPN8_SHAPES.get(suffix):
+        return None
+    n_dim, k_dim = (int(dim) for dim in layer.weight.shape)
+    return _SM70_CHANNEL_FP8_QPN8_CONFIGS.get((k_dim, n_dim))
+
 
 class CompressedTensorsW8A16Fp8(CompressedTensorsScheme):
     def __init__(self, weight_quant: QuantizationArgs, is_static_input_scheme: bool):
@@ -48,6 +91,13 @@ class CompressedTensorsW8A16Fp8(CompressedTensorsScheme):
         self.activation_quant_key = (
             kFp8StaticTensorSym if is_static_input_scheme else kFp8DynamicTensorSym
         )
+        self.use_sm70_fp8_turbomind = (
+            self.strategy == QuantizationStrategy.CHANNEL
+            and not self.is_static_input_scheme
+            and sm70_tm.is_exact_sm70_cuda_platform()
+            and sm70_tm.use_turbomind(envs.VLLM_SM70_FP8_TURBOMIND)
+        )
+        self.use_sm70_fp8_qpn8 = self.use_sm70_fp8_turbomind and envs.VLLM_SM70_FP8_QPN8
 
     @classmethod
     def get_min_capability(cls) -> int:
@@ -108,6 +158,9 @@ class CompressedTensorsW8A16Fp8(CompressedTensorsScheme):
             )
             layer.register_parameter("input_scale", input_scale)
 
+        if self.use_sm70_fp8_turbomind:
+            return
+
         self.linear_kernel = init_wfp8_a16_linear_kernel(
             weight_quant_key=self.weight_quant_key,
             activation_quant_key=self.activation_quant_key,
@@ -117,6 +170,113 @@ class CompressedTensorsW8A16Fp8(CompressedTensorsScheme):
         )
 
     def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
+        if self.use_sm70_fp8_turbomind:
+            if layer.orig_dtype != torch.float16:
+                raise RuntimeError(
+                    "SM70 TurboMind channel-FP8 requires fp16 model weights, "
+                    f"got {layer.orig_dtype}."
+                )
+            if not hasattr(torch.ops._C, "fp8_sm70_prepare"):
+                raise RuntimeError(
+                    "VLLM_SM70_FP8_TURBOMIND=1 requires a build with CUDA "
+                    "arch 7.0 and the SM70 TurboMind extension."
+                )
+            weight_scale = layer.weight_scale.to(torch.float32).contiguous()
+            expected_scale_shape = (layer.weight.shape[0], 1)
+            if tuple(weight_scale.shape) != expected_scale_shape:
+                raise RuntimeError(
+                    "SM70 TurboMind channel-FP8 expected weight scales with "
+                    f"shape {expected_scale_shape}, got {tuple(weight_scale.shape)}."
+                )
+            qpn8_config = (
+                _sm70_channel_fp8_qpn8_config(layer)
+                if getattr(self, "use_sm70_fp8_qpn8", False)
+                and _is_qwen38_27b_fp8_qpn8_model()
+                else None
+            )
+            qpn8_concurrency = (
+                _is_sm70_fp8_qpn8_runtime_contract()
+                if qpn8_config is not None
+                else False
+            )
+            if qpn8_config is not None and not qpn8_concurrency:
+                logger.info_once(
+                    "The SM70 channel-FP8 QPN8 route retains TurboMind when "
+                    "MTP is enabled or max_num_seqs exceeds 8."
+                )
+            if qpn8_config is not None and qpn8_concurrency:
+                missing_ops = _missing_sm70_fp8_qpn8_ops()
+                if missing_ops and os.getenv("VLLM_SM70_FP8_QPN8") is not None:
+                    raise RuntimeError(
+                        "VLLM_SM70_FP8_QPN8=1 requires the source-built SM70 "
+                        f"QPN8 extension; missing ops: {missing_ops}."
+                    )
+                workspace = (
+                    None
+                    if missing_ops
+                    else _get_sm70_fp8_prefill_exact_dense_workspace(layer.weight)
+                )
+                if not missing_ops and workspace is not None:
+                    qpn8_codes, qpn8_scales = sm70_ops.fp8_qpn8_prepare_sm70(
+                        layer.weight, weight_scale
+                    )
+                    replace_parameter(layer, "weight", qpn8_codes)
+                    del layer._parameters["weight_scale"]
+                    replace_parameter(layer, "weight_scale_inv", qpn8_scales)
+                    split_k, nacc, prefetch = qpn8_config
+                    layer.input_scale = None
+                    layer.sm70_fp8_turbomind = True
+                    layer.sm70_fp8_qpn8 = True
+                    layer.sm70_fp8_channel_scale = True
+                    layer.sm70_fp8_qpn8_split_k = split_k
+                    layer.sm70_fp8_qpn8_nacc = nacc
+                    layer.sm70_fp8_qpn8_prefetch = prefetch
+                    layer.sm70_fp8_prefill_exact_dense_workspace_ptr = (
+                        workspace.data_ptr()
+                    )
+                    if getattr(layer, "prefix", "").rsplit(".", 1)[-1] == (
+                        "gate_up_proj"
+                    ):
+                        gated_split_k, gated_nacc, gated_prefetch = (
+                            _SM70_CHANNEL_FP8_QPN8_GATED_CONFIG
+                        )
+                        layer.sm70_fp8_gated_silu = True
+                        layer.sm70_fp8_qpn8_gated_split_k = gated_split_k
+                        layer.sm70_fp8_qpn8_gated_nacc = gated_nacc
+                        layer.sm70_fp8_qpn8_gated_prefetch = gated_prefetch
+                    logger.info_once(
+                        "Memory-neutral SM70 channel-FP8 QPN8 path enabled "
+                        "for accepted Qwen3.8-27B TP4 dense shapes."
+                    )
+                    return
+                if missing_ops:
+                    logger.warning_once(
+                        "The SM70 channel-FP8 QPN8 operators are unavailable; "
+                        "retaining the TurboMind layout."
+                    )
+                else:
+                    logger.warning_once(
+                        "Insufficient memory for the SM70 channel-FP8 QPN8 "
+                        "prefill workspace; retaining the TurboMind layout."
+                    )
+            tm_weight, tm_scales, meta = sm70_ops.fp8_sm70_prepare(
+                layer.weight, weight_scale, 128, False
+            )
+            replace_parameter(layer, "weight", tm_weight)
+            del layer._parameters["weight_scale"]
+            replace_parameter(layer, "weight_scale_inv", tm_scales)
+            layer.input_scale = None
+            layer.sm70_fp8_turbomind = True
+            layer.sm70_fp8_channel_scale = True
+            layer.register_buffer("sm70_fp8_meta", meta, persistent=False)
+            layer.sm70_fp8_k_ld = int(meta[0].item())
+            layer.sm70_fp8_q_ld = int(meta[1].item())
+            logger.info_once(
+                "SM70 compressed-tensors channel-FP8 TurboMind W8A16 dense "
+                "path enabled."
+            )
+            return
+
         if self.strategy == QuantizationStrategy.BLOCK:
             assert self.is_static_input_scheme is False
             # MarlinFP8ScaledMMLinearKernel uses "weight_scale_inv" for block
@@ -145,4 +305,83 @@ class CompressedTensorsW8A16Fp8(CompressedTensorsScheme):
         x: torch.Tensor,
         bias: torch.Tensor | None = None,
     ) -> torch.Tensor:
+        if getattr(layer, "sm70_fp8_turbomind", False):
+            if x.dtype != torch.float16:
+                raise RuntimeError(
+                    "SM70 TurboMind channel-FP8 requires float16 activations, "
+                    f"got {x.dtype}."
+                )
+            out_shape = (*x.shape[:-1], layer.output_size_per_partition)
+            x_2d = x.reshape(-1, x.shape[-1])
+            if x_2d.stride(-1) != 1:
+                x_2d = x_2d.contiguous()
+            out_2d = torch.empty(
+                (x_2d.shape[0], layer.output_size_per_partition),
+                device=x.device,
+                dtype=x.dtype,
+            )
+            if x_2d.shape[0] == 0:
+                return out_2d.reshape(out_shape)
+            if getattr(layer, "sm70_fp8_qpn8", False):
+                sm70_ops.fp8_qpn8_dispatch_sm70_out(
+                    out_2d,
+                    int(layer.sm70_fp8_prefill_exact_dense_workspace_ptr),
+                    x_2d,
+                    layer.weight,
+                    layer.weight_scale_inv,
+                    int(layer.sm70_fp8_qpn8_split_k),
+                    int(layer.sm70_fp8_qpn8_nacc),
+                    bool(layer.sm70_fp8_qpn8_prefetch),
+                    False,
+                )
+            else:
+                sm70_ops.fp8_gemm_sm70_out(
+                    out_2d,
+                    x_2d,
+                    layer.weight,
+                    layer.weight_scale_inv,
+                    128,
+                    layer.sm70_fp8_k_ld,
+                    layer.sm70_fp8_q_ld,
+                    False,
+                )
+            if bias is not None:
+                out_2d.add_(bias)
+            return out_2d.reshape(out_shape)
         return self.linear_kernel.apply_weights(layer, x, bias)
+
+    def apply_fused_silu_and_mul(
+        self,
+        layer: torch.nn.Module,
+        x: torch.Tensor,
+    ) -> torch.Tensor | None:
+        if not getattr(layer, "sm70_fp8_qpn8", False):
+            return None
+        if not getattr(layer, "sm70_fp8_gated_silu", False):
+            return None
+        if x.dtype != torch.float16:
+            raise RuntimeError(
+                "SM70 channel-FP8 QPN8 gated-SiLU requires float16 "
+                f"activations, got {x.dtype}."
+            )
+        x_2d = x.reshape(-1, x.shape[-1])
+        if x_2d.stride(-1) != 1:
+            x_2d = x_2d.contiguous()
+        out_features = layer.output_size_per_partition // 2
+        out_2d = torch.empty(
+            (x_2d.shape[0], out_features), device=x.device, dtype=x.dtype
+        )
+        if x_2d.shape[0] == 0:
+            return out_2d.reshape(*x.shape[:-1], out_features)
+        sm70_ops.fp8_qpn8_dispatch_sm70_out(
+            out_2d,
+            int(layer.sm70_fp8_prefill_exact_dense_workspace_ptr),
+            x_2d,
+            layer.weight,
+            layer.weight_scale_inv,
+            int(layer.sm70_fp8_qpn8_gated_split_k),
+            int(layer.sm70_fp8_qpn8_gated_nacc),
+            bool(layer.sm70_fp8_qpn8_gated_prefetch),
+            True,
+        )
+        return out_2d.reshape(*x.shape[:-1], out_features)

--- a/vllm/model_executor/layers/quantization/fp8.py
+++ b/vllm/model_executor/layers/quantization/fp8.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import os
 from typing import TYPE_CHECKING, Any
 
 import torch
@@ -112,6 +113,22 @@ _SM70_FP8_PREFILL_DENSE_WORKSPACE_ELEMENTS = max(
 _SM70_FP8_PREFILL_DENSE_WORKSPACE_BYTES = (
     _SM70_FP8_PREFILL_DENSE_WORKSPACE_ELEMENTS * torch.float16.itemsize
 )
+_SM70_FP8_QPN8_CONFIGS = {
+    # (K, N, fused gated-SiLU): (split-K, accumulator chains, prefetch codes)
+    (4352, 5120, False): (16, 1, False),
+    (1536, 5120, False): (16, 1, False),
+    (5120, 8704, False): (16, 1, True),
+    (5120, 8704, True): (8, 2, True),
+}
+_SM70_FP8_QPN8_REQUIRED_OPS = (
+    "fp8_qpn8_prepare_sm70",
+    "fp8_qpn8_dequantize_sm70_out",
+    "fp8_qpn8_prefill_sm70_out",
+    "fp8_qpn8_dispatch_sm70_out",
+    "fp8_qpn8_gemm_sm70_out",
+    "fp8_qpn8_gated_pair_sm70_out",
+)
+_SM70_FP8_QPN8_MAX_NUM_SEQS = 8
 # Layers retain only data_ptr(), so this cache owns each allocation's lifetime.
 _sm70_fp8_prefill_dense_workspaces: dict[tuple[int, torch.dtype], torch.Tensor] = {}
 
@@ -124,6 +141,52 @@ def _is_sm70_fp8_prefill_exact_dense_layer(layer: torch.nn.Module) -> bool:
     if expected is None:
         return False
     return tuple(layer.weight.shape) == expected
+
+
+def _is_sm70_fp8_qpn8_layer(layer: torch.nn.Module) -> bool:
+    """Admit only shapes with an accepted bounded-workspace prefill route."""
+    if getattr(layer, "tp_size", 1) != 4:
+        return False
+    suffix = getattr(layer, "prefix", "").rsplit(".", 1)[-1]
+    expected_kn = _SM70_FP8_PREFILL_DENSE_SHAPES.get(suffix)
+    if expected_kn is None:
+        return False
+    # Checkpoint-native block-FP8 weights are [N, K]; the shared prefill
+    # workspace and QPN8 replacement parameter are [K, N].
+    return tuple(reversed(layer.weight.shape)) == expected_kn
+
+
+def _is_qwen38_27b_fp8_qpn8_model() -> bool:
+    """Keep the automatic route specific to the accepted Qwen3.8-27B model."""
+    model_config = get_current_vllm_config().model_config
+    hf_config = model_config.hf_config
+    text_config = model_config.hf_text_config
+    return bool(
+        getattr(hf_config, "model_type", None) == "qwen3_5"
+        and getattr(hf_config, "architectures", None)
+        == ["Qwen3_5ForConditionalGeneration"]
+        and getattr(text_config, "model_type", None) == "qwen3_5_text"
+        and getattr(text_config, "hidden_size", None) == 5120
+        and getattr(text_config, "intermediate_size", None) == 17408
+        and getattr(text_config, "num_hidden_layers", None) == 64
+        and getattr(text_config, "full_attention_interval", None) == 4
+        and getattr(text_config, "head_dim", None) == 256
+    )
+
+
+def _is_sm70_fp8_qpn8_runtime_contract() -> bool:
+    """Admit only the no-MTP M range with a measured native decode kernel."""
+    vllm_config = get_current_vllm_config()
+    scheduler_config = getattr(vllm_config, "scheduler_config", None)
+    max_num_seqs = int(getattr(scheduler_config, "max_num_seqs", 1))
+    speculative_config = getattr(vllm_config, "speculative_config", None)
+    return max_num_seqs <= _SM70_FP8_QPN8_MAX_NUM_SEQS and speculative_config is None
+
+
+def _missing_sm70_fp8_qpn8_ops() -> list[str]:
+    return [
+        name for name in _SM70_FP8_QPN8_REQUIRED_OPS if not hasattr(torch.ops._C, name)
+    ]
 
 
 def _get_sm70_fp8_prefill_exact_dense_workspace(
@@ -602,6 +665,77 @@ class Fp8LinearMethod(LinearMethodBase):
                 return
             is_gated_silu_layer = self._is_sm70_gated_silu_layer(layer)
             use_gated_silu = is_gated_silu_layer and envs.VLLM_SM70_FP8_DENSE_GATED_SILU
+            qpn8_model_layer = (
+                envs.VLLM_SM70_FP8_QPN8
+                and _is_qwen38_27b_fp8_qpn8_model()
+                and _is_sm70_fp8_qpn8_layer(layer)
+            )
+            qpn8_concurrency = (
+                _is_sm70_fp8_qpn8_runtime_contract() if qpn8_model_layer else False
+            )
+            if qpn8_model_layer and not qpn8_concurrency:
+                logger.info_once(
+                    "The SM70 FP8 QPN8 route retains TurboMind when MTP is "
+                    "enabled or max_num_seqs exceeds 8; the accepted native "
+                    "QPN8 contract is no-MTP with M<=8."
+                )
+            if qpn8_model_layer and qpn8_concurrency:
+                missing_ops = _missing_sm70_fp8_qpn8_ops()
+                if missing_ops:
+                    if os.getenv("VLLM_SM70_FP8_QPN8") is not None:
+                        raise RuntimeError(
+                            "VLLM_SM70_FP8_QPN8=1 requires the source-built SM70 "
+                            f"QPN8 extension; missing ops: {missing_ops}."
+                        )
+                    logger.warning_once(
+                        "The automatic SM70 FP8 QPN8 route is unavailable in "
+                        "the loaded vllm._C; retaining the TurboMind layout."
+                    )
+
+                workspace = (
+                    None
+                    if missing_ops
+                    else _get_sm70_fp8_prefill_exact_dense_workspace(weight)
+                )
+                if not missing_ops and workspace is not None:
+                    qpn8_codes, qpn8_scales = sm70_ops.fp8_qpn8_prepare_sm70(
+                        weight, weight_scale_inv
+                    )
+                    k_dim, n_dim = (int(dim) for dim in qpn8_codes.shape)
+                    split_k, nacc, prefetch = _SM70_FP8_QPN8_CONFIGS[
+                        (k_dim, n_dim, False)
+                    ]
+                    replace_parameter(layer, "weight", qpn8_codes)
+                    replace_parameter(layer, "weight_scale_inv", qpn8_scales)
+                    layer.input_scale = None
+                    layer.sm70_fp8_turbomind = True
+                    layer.sm70_fp8_qpn8 = True
+                    layer.sm70_fp8_qpn8_split_k = split_k
+                    layer.sm70_fp8_qpn8_nacc = nacc
+                    layer.sm70_fp8_qpn8_prefetch = prefetch
+                    layer.sm70_fp8_prefill_exact_dense_workspace_ptr = (
+                        workspace.data_ptr()
+                    )
+                    if use_gated_silu:
+                        gated_split_k, gated_nacc, gated_prefetch = (
+                            _SM70_FP8_QPN8_CONFIGS[(k_dim, n_dim, True)]
+                        )
+                        layer.sm70_fp8_gated_silu = True
+                        layer.sm70_fp8_gated_silu_primary = True
+                        layer.sm70_fp8_qpn8_gated_split_k = gated_split_k
+                        layer.sm70_fp8_qpn8_gated_nacc = gated_nacc
+                        layer.sm70_fp8_qpn8_gated_prefetch = gated_prefetch
+                    logger.info_once(
+                        "Memory-neutral SM70 FP8 QPN8 path enabled for accepted "
+                        "Qwen3.8-27B TP4 dense shapes."
+                    )
+                    return
+                if not missing_ops:
+                    logger.warning_once(
+                        "Insufficient memory for the SM70 FP8 QPN8 prefill "
+                        "workspace; retaining the TurboMind layout."
+                    )
+
             tm_weight, tm_scales, meta = sm70_ops.fp8_sm70_prepare(
                 weight,
                 weight_scale_inv,
@@ -758,6 +892,39 @@ class Fp8LinearMethod(LinearMethodBase):
         bias: torch.Tensor | None = None,
     ) -> torch.Tensor:
         if getattr(layer, "sm70_fp8_turbomind", False):
+            if getattr(layer, "sm70_fp8_qpn8", False):
+                if x.dtype != torch.float16:
+                    raise RuntimeError(
+                        "SM70 FP8 QPN8 currently requires float16 activations, "
+                        f"got {x.dtype}."
+                    )
+                out_shape = (*x.shape[:-1], layer.output_size_per_partition)
+                x_2d = x.reshape(-1, x.shape[-1])
+                if x_2d.stride(-1) != 1:
+                    x_2d = x_2d.contiguous()
+                out_2d = torch.empty(
+                    (x_2d.shape[0], layer.output_size_per_partition),
+                    device=x.device,
+                    dtype=x.dtype,
+                )
+                if x_2d.shape[0] == 0:
+                    return out_2d.reshape(out_shape)
+                sm70_ops.fp8_qpn8_dispatch_sm70_out(
+                    out_2d,
+                    int(layer.sm70_fp8_prefill_exact_dense_workspace_ptr),
+                    x_2d,
+                    layer.weight,
+                    layer.weight_scale_inv,
+                    int(layer.sm70_fp8_qpn8_split_k),
+                    int(layer.sm70_fp8_qpn8_nacc),
+                    bool(layer.sm70_fp8_qpn8_prefetch),
+                    False,
+                )
+                out = out_2d.reshape(out_shape)
+                if bias is not None:
+                    out.add_(bias)
+                return out
+
             if getattr(layer, "sm70_fp8_bmm", False):
                 group_count = int(layer.sm70_fp8_bmm_groups)
                 output_size = int(layer.sm70_fp8_bmm_output_size)
@@ -889,6 +1056,36 @@ class Fp8LinearMethod(LinearMethodBase):
         layer: torch.nn.Module,
         x: torch.Tensor,
     ) -> torch.Tensor | None:
+        if getattr(layer, "sm70_fp8_qpn8", False):
+            if not getattr(layer, "sm70_fp8_gated_silu", False):
+                return None
+            if x.dtype != torch.float16:
+                raise RuntimeError(
+                    "SM70 FP8 QPN8 gated-SiLU requires float16 activations, "
+                    f"got {x.dtype}."
+                )
+            x_2d = x.reshape(-1, x.shape[-1])
+            if x_2d.stride(-1) != 1:
+                x_2d = x_2d.contiguous()
+            out_features = layer.output_size_per_partition // 2
+            out_2d = torch.empty(
+                (x_2d.shape[0], out_features), device=x.device, dtype=x.dtype
+            )
+            if x_2d.shape[0] == 0:
+                return out_2d.reshape(*x.shape[:-1], out_features)
+            sm70_ops.fp8_qpn8_dispatch_sm70_out(
+                out_2d,
+                int(layer.sm70_fp8_prefill_exact_dense_workspace_ptr),
+                x_2d,
+                layer.weight,
+                layer.weight_scale_inv,
+                int(layer.sm70_fp8_qpn8_gated_split_k),
+                int(layer.sm70_fp8_qpn8_gated_nacc),
+                bool(layer.sm70_fp8_qpn8_gated_prefetch),
+                True,
+            )
+            return out_2d.reshape(*x.shape[:-1], out_features)
+
         if not getattr(layer, "sm70_fp8_gated_silu", False):
             return None
         if not getattr(layer, "sm70_fp8_turbomind", False):

--- a/vllm/model_executor/layers/quantization/sm70_turbomind.py
+++ b/vllm/model_executor/layers/quantization/sm70_turbomind.py
@@ -14,6 +14,7 @@ GPTQ_GROUP_SIZES = (128,)
 COMPRESSED_UINT4_GROUP_SIZES = (32, 128)
 MXFP4_GROUP_SIZE = 32
 NVFP4_GROUP_SIZE = 16
+NVFP4_QPN4_DENSE_WORKSPACE_ELEMENTS = 5120 * 8704
 STATE_ATTR = "_sm70_turbomind_linear"
 SM70QuantBackend = Literal["auto", "marlin", "turbomind"]
 
@@ -26,7 +27,15 @@ class SM70TurboMindLinearState:
     k_ld: int
     q_ld: int
     output_size: int
-    op_kind: Literal["uint4", "mxfp4", "nvfp4"]
+    op_kind: Literal["uint4", "mxfp4", "nvfp4", "nvfp4_qpn4"]
+    gated_silu: bool = False
+    dense_weight_ptr: int = 0
+    global_scale: float = 0.0
+    use_scale_code: bool = False
+
+
+# States retain only data_ptr(), so this cache owns the bounded allocation.
+_nvfp4_qpn4_dense_workspaces: dict[tuple[int, torch.dtype], torch.Tensor] = {}
 
 
 def quant_backend() -> SM70QuantBackend:
@@ -141,19 +150,27 @@ def _store_state(
     layer: torch.nn.Module,
     weight: torch.Tensor,
     scales: torch.Tensor,
-    meta: torch.Tensor,
+    meta: torch.Tensor | None,
     group_size: int,
     output_size: int,
-    op_kind: Literal["uint4", "mxfp4", "nvfp4"],
+    op_kind: Literal["uint4", "mxfp4", "nvfp4", "nvfp4_qpn4"],
+    gated_silu: bool = False,
+    dense_weight_ptr: int = 0,
+    global_scale: float = 0.0,
+    use_scale_code: bool = False,
 ) -> None:
     state = SM70TurboMindLinearState(
         weight=weight,
         scales=scales,
         group_size=group_size,
-        k_ld=int(meta[0]),
-        q_ld=int(meta[1]),
+        k_ld=0 if meta is None else int(meta[0]),
+        q_ld=0 if meta is None else int(meta[1]),
         output_size=output_size,
         op_kind=op_kind,
+        gated_silu=gated_silu,
+        dense_weight_ptr=dense_weight_ptr,
+        global_scale=global_scale,
+        use_scale_code=use_scale_code,
     )
     setattr(layer, STATE_ATTR, state)
 
@@ -291,6 +308,71 @@ def prepare_nvfp4_linear(
         NVFP4_GROUP_SIZE,
         qweight.size(1),
         "nvfp4",
+        interleave_gated_silu,
+    )
+
+
+def get_nvfp4_qpn4_dense_workspace(weight: torch.Tensor) -> torch.Tensor | None:
+    device_index = weight.device.index
+    if device_index is None:
+        device_index = torch.accelerator.current_device_index()
+    cache_key = (device_index, torch.float16)
+    workspace = _nvfp4_qpn4_dense_workspaces.get(cache_key)
+    if workspace is not None:
+        return workspace
+    try:
+        workspace = torch.empty(
+            (NVFP4_QPN4_DENSE_WORKSPACE_ELEMENTS,),
+            dtype=torch.float16,
+            device=weight.device,
+        )
+    except torch.OutOfMemoryError:
+        return None
+    _nvfp4_qpn4_dense_workspaces[cache_key] = workspace
+    return workspace
+
+
+def prepare_nvfp4_qpn4_linear(
+    layer: torch.nn.Module,
+    workspace: torch.Tensor,
+    gated_silu: bool,
+) -> None:
+    """Replace one accepted NVFP4 dense weight with memory-neutral QPN4."""
+    from vllm import _sm70_ops as sm70_ops
+
+    qweight = unpack_mxfp4_weight(layer.weight.data)
+    use_scale_code = gated_silu or envs.VLLM_SM70_NVFP4_QPN4_DOWN_SCALE_CODE
+    global_scale = 0.0
+    if use_scale_code:
+        global_scale = float(layer.weight_global_scale.detach().float().item())
+        raw_scale_codes = layer.weight_scale.data.t().contiguous()
+        packed_weight, packed_scales = sm70_ops.nvfp4_qpn4_prepare_scale_code_sm70(
+            qweight, raw_scale_codes
+        )
+    else:
+        fp16_scales = (
+            (
+                layer.weight_scale.data.t().to(torch.float32)
+                * layer.weight_global_scale.to(torch.float32)
+            )
+            .to(torch.float16)
+            .contiguous()
+        )
+        packed_weight, packed_scales = sm70_ops.nvfp4_qpn4_prepare_sm70(
+            qweight, fp16_scales
+        )
+    _store_state(
+        layer,
+        packed_weight,
+        packed_scales,
+        None,
+        NVFP4_GROUP_SIZE,
+        qweight.size(1),
+        "nvfp4_qpn4",
+        gated_silu=gated_silu,
+        dense_weight_ptr=workspace.data_ptr(),
+        global_scale=global_scale,
+        use_scale_code=use_scale_code,
     )
 
 
@@ -339,8 +421,88 @@ def apply_prepared_linear(
             state.k_ld,
             state.q_ld,
         )
+    elif state.op_kind == "nvfp4_qpn4":
+        if reshaped_x.dtype != torch.float16:
+            raise RuntimeError(
+                f"SM70 NVFP4 QPN4 requires float16 activations, got {reshaped_x.dtype}."
+            )
+        if reshaped_x.stride(-1) != 1:
+            reshaped_x = reshaped_x.contiguous()
+        sm70_ops.nvfp4_qpn4_dispatch_sm70_out(
+            out,
+            state.dense_weight_ptr,
+            reshaped_x,
+            state.weight,
+            state.scales,
+            state.global_scale,
+            state.use_scale_code,
+            False,
+        )
     else:
         raise AssertionError(f"unknown SM70 TurboMind op kind: {state.op_kind}")
+    if state.gated_silu and state.op_kind == "nvfp4":
+        out_features = state.output_size // 2
+        out = (
+            out.reshape(reshaped_x.shape[0], out_features, 2)
+            .transpose(1, 2)
+            .reshape(reshaped_x.shape[0], state.output_size)
+        )
     if bias is not None:
         out.add_(bias)
     return out.reshape(out_shape)
+
+
+def apply_prepared_fused_silu_and_mul(
+    layer: torch.nn.Module,
+    x: torch.Tensor,
+) -> torch.Tensor | None:
+    state = getattr(layer, STATE_ATTR, None)
+    if (
+        state is None
+        or state.op_kind not in ("nvfp4", "nvfp4_qpn4")
+        or not state.gated_silu
+    ):
+        return None
+    if x.dtype != torch.float16:
+        raise RuntimeError(
+            "SM70 TurboMind NVFP4 gated-SiLU requires float16 activations, "
+            f"got {x.dtype}."
+        )
+
+    reshaped_x = x.reshape(-1, x.shape[-1])
+    if reshaped_x.stride(-1) != 1:
+        reshaped_x = reshaped_x.contiguous()
+    out_features = state.output_size // 2
+    out = torch.empty(
+        (reshaped_x.shape[0], out_features),
+        dtype=x.dtype,
+        device=x.device,
+    )
+    if reshaped_x.shape[0] == 0:
+        return out.reshape(*x.shape[:-1], out_features)
+
+    from vllm import _sm70_ops as sm70_ops
+
+    if state.op_kind == "nvfp4_qpn4":
+        sm70_ops.nvfp4_qpn4_dispatch_sm70_out(
+            out,
+            state.dense_weight_ptr,
+            reshaped_x,
+            state.weight,
+            state.scales,
+            state.global_scale,
+            state.use_scale_code,
+            True,
+        )
+    else:
+        sm70_ops.nvfp4_gemm_sm70_out(
+            out,
+            reshaped_x,
+            state.weight,
+            state.scales,
+            state.group_size,
+            state.k_ld,
+            state.q_ld,
+            True,
+        )
+    return out.reshape(*x.shape[:-1], out_features)

--- a/vllm/model_executor/warmup/awq_sm70_warmup.py
+++ b/vllm/model_executor/warmup/awq_sm70_warmup.py
@@ -267,6 +267,11 @@ def _iter_unique_fp8_dense_layers(
             or getattr(layer, "sm70_modelopt_fp8_turbomind", False)
         ):
             continue
+        # QPN8 has a static source-selected dispatch and does not populate the
+        # TurboMind LUT warmed below. CUDA graph capture exercises its admitted
+        # M<=8 kernels separately.
+        if getattr(layer, "sm70_fp8_qpn8", False):
+            continue
 
         if getattr(layer, "sm70_fp8_bmm", False):
             k_dim = int(layer.weight.shape[1])

--- a/vllm/model_executor/warmup/awq_sm70_warmup.py
+++ b/vllm/model_executor/warmup/awq_sm70_warmup.py
@@ -304,14 +304,20 @@ def _iter_unique_fp8_dense_layers(
 
 
 def _iter_unique_fp4_dense_layers(model: torch.nn.Module) -> Iterable[Any]:
-    seen: set[tuple[str, int, int, int]] = set()
+    seen: set[tuple[str, int, int, int, bool]] = set()
     for layer in model.modules():
         state = getattr(layer, sm70_tm.STATE_ATTR, None)
         if state is None or state.op_kind not in ("mxfp4", "nvfp4"):
             continue
         k_dim = int(state.weight.shape[0])
         n_dim = int(state.output_size)
-        key = (state.op_kind, k_dim, n_dim, int(state.group_size))
+        key = (
+            state.op_kind,
+            k_dim,
+            n_dim,
+            int(state.group_size),
+            bool(state.gated_silu),
+        )
         if key in seen:
             continue
         seen.add(key)
@@ -525,7 +531,8 @@ def _warmup_fp4_dense_layers(
     for state in dense_layers:
         device = state.weight.device
         k_dim = int(state.weight.shape[0])
-        n_dim = int(state.output_size)
+        gated_silu = bool(state.gated_silu)
+        n_dim = int(state.output_size) // (2 if gated_silu else 1)
         for m_dim in m_values:
             x = torch.empty((m_dim, k_dim), dtype=torch.float16, device=device)
             out = torch.empty((m_dim, n_dim), dtype=torch.float16, device=device)
@@ -540,7 +547,7 @@ def _warmup_fp4_dense_layers(
                     int(state.group_size),
                     int(state.k_ld),
                     int(state.q_ld),
-                    False,
+                    gated_silu,
                 )
             elif state.op_kind == "nvfp4":
                 if not hasattr(torch.ops._C, "nvfp4_gemm_sm70_out"):
@@ -553,7 +560,7 @@ def _warmup_fp4_dense_layers(
                     int(state.group_size),
                     int(state.k_ld),
                     int(state.q_ld),
-                    False,
+                    gated_silu,
                 )
             else:
                 continue

--- a/vllm/v1/attention/backends/flash_attn_v100.py
+++ b/vllm/v1/attention/backends/flash_attn_v100.py
@@ -330,7 +330,7 @@ def _g6_aligned_page_partition_size_hint(
     ):
         return None
     if (
-        kv_cache_dtype in ("auto", "bfloat16")
+        kv_cache_dtype in ("auto", "float16", "bfloat16")
         and key_cache.dtype == torch.float16
         and key_cache.shape[1] == 784
     ):
@@ -338,6 +338,12 @@ def _g6_aligned_page_partition_size_hint(
         # selects between them from device seq_lens. Plan the p256 workspace
         # envelope once.
         return 256
+    if kv_cache_dtype in ("fp8", "fp8_e4m3") and key_cache.dtype == torch.uint8:
+        # Qwen3.8 TP4 has G6/D256 attention and checkpoint-provided E4M3
+        # scales. The p64 route wins the accepted 1K-2K operator sweep while
+        # preserving the p256 scalar route's E4M3 conversion within one fp16
+        # output ULP.
+        return 64
     if kv_cache_dtype == "fp8_e5m2" and key_cache.dtype == torch.uint8:
         # Plan the largest p256 workspace once. The extension selects p256 or
         # p1024 from device seq_lens, so CUDA graph replay keeps one
@@ -4227,7 +4233,7 @@ class FlashAttnV100Impl(TritonAttentionImpl):
             return False
 
         fp16_kv = (
-            self.kv_cache_dtype in ("auto", "bfloat16")
+            self.kv_cache_dtype in ("auto", "float16", "bfloat16")
             and key_cache.dtype == torch.float16
             and value_cache.dtype == torch.float16
         )
@@ -5418,13 +5424,21 @@ class FlashAttnV100Impl(TritonAttentionImpl):
             else 0
         )
         xqa_kv_supported = (
-            self.kv_cache_dtype in ("auto", "bfloat16")
-            and key_cache.dtype == torch.float16
-            and value_cache.dtype == torch.float16
-        ) or (
-            self.kv_cache_dtype == "fp8_e5m2"
-            and key_cache.dtype == torch.uint8
-            and value_cache.dtype == torch.uint8
+            (
+                self.kv_cache_dtype in ("auto", "float16", "bfloat16")
+                and key_cache.dtype == torch.float16
+                and value_cache.dtype == torch.float16
+            )
+            or (
+                self.kv_cache_dtype == "fp8_e5m2"
+                and key_cache.dtype == torch.uint8
+                and value_cache.dtype == torch.uint8
+            )
+            or (
+                self.kv_cache_dtype in ("fp8", "fp8_e4m3")
+                and key_cache.dtype == torch.uint8
+                and value_cache.dtype == torch.uint8
+            )
         )
 
         # FP8 G4 XQA had no end-to-end gain on 35B-A3B TP4 and has no accepted
@@ -5438,6 +5452,10 @@ class FlashAttnV100Impl(TritonAttentionImpl):
             and key_cache.shape[2] > 0
             and query.shape[1] % key_cache.shape[2] == 0
             and _decode_xqa_allowed_for_q_per_kv(q_per_kv, attn_metadata)
+            and (
+                self.kv_cache_dtype not in ("fp8", "fp8_e4m3")
+                or (query.shape[0] == 1 and q_per_kv == 6)
+            )
             and (
                 self.kv_cache_dtype != "fp8_e5m2"
                 or (q_per_kv != 4 and _decode_fp8_xqa_allowed(attn_metadata, query))

--- a/vllm/v1/sample/sampler.py
+++ b/vllm/v1/sample/sampler.py
@@ -8,7 +8,9 @@ from pathlib import Path
 import torch
 import torch.nn as nn
 
+from vllm import envs
 from vllm.config.model import LogprobsMode
+from vllm.logger import init_logger
 from vllm.utils.platform_utils import is_pin_memory_available
 from vllm.v1.outputs import LogprobsTensors, SamplerOutput
 from vllm.v1.sample.metadata import SamplingMetadata
@@ -19,6 +21,7 @@ from vllm.v1.sample.ops.topk_topp_sampler import TopKTopPSampler
 
 _SAMPLING_EPS = 1e-5
 _SM70_LOGITS_DUMP_COUNTER = 0
+logger = init_logger(__name__)
 
 
 def _sm70_cuda_graph_capture_active() -> bool:
@@ -77,10 +80,7 @@ def _maybe_dump_sm70_sampler_logits(
             ],
         },
         path
-        / (
-            f"sampler_logits_pid{os.getpid()}"
-            f"_step{_SM70_LOGITS_DUMP_COUNTER:04d}.pt"
-        ),
+        / (f"sampler_logits_pid{os.getpid()}_step{_SM70_LOGITS_DUMP_COUNTER:04d}.pt"),
     )
 
 
@@ -303,6 +303,217 @@ class Sampler(nn.Module):
     def greedy_sample(logits: torch.Tensor) -> torch.Tensor:
         return logits.argmax(dim=-1).view(-1)
 
+    @staticmethod
+    def _try_sm70_compact_topk20_sample(
+        logits: torch.Tensor,
+        sampling_metadata: SamplingMetadata,
+        logprobs_mode: LogprobsMode,
+    ) -> torch.Tensor | None:
+        if not Sampler._sm70_compact_topk20_metadata_supported(
+            sampling_metadata, logprobs_mode
+        ):
+            return None
+        if (
+            logits.dtype != torch.float32
+            or not logits.is_cuda
+            or logits.shape != (1, 248320)
+            or torch.cuda.get_device_capability(logits.device) != (7, 0)
+        ):
+            return None
+
+        chunks = envs.VLLM_SM70_CHUNKED_TOPK20_CHUNKS
+        if (
+            chunks > 0
+            and 248320 % chunks == 0
+            and hasattr(torch.ops._C, "sm70_sample_chunked_top20_philox_token_out")
+            and len(sampling_metadata.generators) <= 1
+        ):
+            from vllm import _sm70_ops as sm70_ops
+
+            chunk_size = 248320 // chunks
+            local_values, local_indices = torch.topk(
+                logits.view(chunks, chunk_size),
+                k=20,
+                dim=-1,
+                largest=True,
+                sorted=False,
+            )
+            global_values, global_positions = torch.topk(
+                local_values.view(1, -1),
+                k=20,
+                dim=-1,
+                largest=True,
+                sorted=False,
+            )
+            sampled = torch.empty((1,), dtype=torch.int64, device=logits.device)
+            generator = next(iter(sampling_metadata.generators.values()), None)
+            sm70_ops.sm70_sample_chunked_top20_philox_token_out(
+                sampled,
+                global_values,
+                local_indices,
+                global_positions,
+                generator,
+                248320,
+                0.95,
+                chunk_size,
+            )
+            logger.info_once(
+                "SM70 exact %d-way chunked top-k20 Philox sampler path enabled.",
+                chunks,
+            )
+            return sampled
+
+        # The sparse-Philox kernel canonicalizes the selected pairs itself, so
+        # skip torch.topk's final ordering pass only when that exact path will
+        # consume the result. Keep sorted output for the legacy fallback.
+        use_sparse_philox = (
+            hasattr(torch.ops._C, "sm70_sample_sorted_top20_philox_token_out")
+            or hasattr(torch.ops._C, "sm70_sample_sorted_top20_philox_out")
+        ) and len(sampling_metadata.generators) <= 1
+        top_values, top_indices = torch.topk(
+            logits,
+            k=20,
+            dim=-1,
+            largest=True,
+            sorted=not use_sparse_philox,
+        )
+        return Sampler._sm70_sample_top20_pairs(
+            top_values, top_indices, sampling_metadata
+        )
+
+    @staticmethod
+    def _sm70_compact_topk20_metadata_supported(
+        sampling_metadata: SamplingMetadata,
+        logprobs_mode: LogprobsMode,
+    ) -> bool:
+        if not envs.VLLM_SM70_COMPACT_TOPK20_SAMPLER:
+            return False
+        if logprobs_mode in ("processed_logits", "processed_logprobs"):
+            return False
+        if sampling_metadata.max_num_logprobs is not None:
+            return False
+        if sampling_metadata.logprob_token_ids:
+            return False
+        if not sampling_metadata.all_random:
+            return False
+        if sampling_metadata.top_k_cpu != (20,):
+            return False
+        top_p_cpu = sampling_metadata.top_p_cpu
+        temperature_cpu = sampling_metadata.temperature_cpu
+        return not (
+            top_p_cpu is None
+            or len(top_p_cpu) != 1
+            or abs(top_p_cpu[0] - 0.95) > 1e-6
+            or temperature_cpu is None
+            or len(temperature_cpu) != 1
+            or abs(temperature_cpu[0] - 1.0) > 1e-6
+        )
+
+    @staticmethod
+    def _sm70_sample_top20_pairs(
+        top_values: torch.Tensor,
+        top_indices: torch.Tensor,
+        sampling_metadata: SamplingMetadata,
+    ) -> torch.Tensor | None:
+        if (
+            top_values.dtype != torch.float32
+            or top_indices.dtype != torch.int64
+            or not top_values.is_cuda
+            or not top_indices.is_cuda
+            or top_values.shape != (1, 20)
+            or top_indices.shape != (1, 20)
+            or top_values.device != top_indices.device
+            or torch.cuda.get_device_capability(top_values.device) != (7, 0)
+        ):
+            return None
+
+        from vllm import _sm70_ops as sm70_ops
+
+        has_token_philox = hasattr(
+            torch.ops._C, "sm70_sample_sorted_top20_philox_token_out"
+        )
+        has_metadata_philox = hasattr(
+            torch.ops._C, "sm70_sample_sorted_top20_philox_out"
+        )
+        if not (
+            has_token_philox
+            or has_metadata_philox
+            or hasattr(torch.ops._C, "sm70_sample_packed_top20_out")
+        ):
+            return None
+
+        sampled = torch.empty((1,), dtype=torch.int64, device=top_values.device)
+        generators = sampling_metadata.generators
+        if has_token_philox and len(generators) <= 1:
+            generator = next(iter(generators.values()), None)
+            sm70_ops.sm70_sample_sorted_top20_philox_token_out(
+                sampled,
+                top_values,
+                top_indices,
+                generator,
+                248320,
+                0.95,
+            )
+            logger.info_once(
+                "SM70 exact token-only Philox compact top-k20 sampler path enabled."
+            )
+            return sampled
+
+        sparse_ids = torch.empty((20,), dtype=torch.int64, device=top_values.device)
+        sparse_probs = torch.empty((20,), dtype=torch.float32, device=top_values.device)
+        if has_metadata_philox and len(generators) <= 1:
+            generator = next(iter(generators.values()), None)
+            sm70_ops.sm70_sample_sorted_top20_philox_out(
+                sampled,
+                sparse_ids,
+                sparse_probs,
+                top_values,
+                top_indices,
+                generator,
+                248320,
+                0.95,
+            )
+            logger.info_once(
+                "SM70 exact sparse-Philox compact top-k20 sampler path enabled."
+            )
+            return sampled
+
+        top_indices_float = top_indices[0].to(torch.float32)
+        pairs = torch.stack(
+            (top_values[0], top_indices_float, top_indices_float), dim=-1
+        )
+        exponentials = torch.empty(
+            (1, 248320), dtype=torch.float32, device=top_values.device
+        )
+        if len(generators) != 1:
+            exponentials.exponential_()
+        for row, generator in generators.items():
+            exponentials[row].exponential_(generator=generator)
+
+        sm70_ops.sm70_sample_packed_top20_out(
+            sampled,
+            sparse_ids,
+            sparse_probs,
+            pairs,
+            exponentials,
+            0.95,
+        )
+        logger.info_once("SM70 exact compact top-k20 random sampler path enabled.")
+        return sampled
+
+    def sm70_compact_topk20_pairs_sample(
+        self,
+        top_values: torch.Tensor,
+        top_indices: torch.Tensor,
+        sampling_metadata: SamplingMetadata,
+    ) -> torch.Tensor | None:
+        """Sample exact global top-20 pairs while preserving native RNG use."""
+        if not self._sm70_compact_topk20_metadata_supported(
+            sampling_metadata, self.logprobs_mode
+        ):
+            return None
+        return self._sm70_sample_top20_pairs(top_values, top_indices, sampling_metadata)
+
     def sample(
         self,
         logits: torch.Tensor,
@@ -344,6 +555,12 @@ class Sampler(nn.Module):
         # (argmax invariant)
         for processor in sampling_metadata.logitsprocs.argmax_invariant:
             logits = processor.apply(logits)
+
+        compact_sampled = self._try_sm70_compact_topk20_sample(
+            logits, sampling_metadata, logprobs_mode
+        )
+        if compact_sampled is not None:
+            return compact_sampled, None
 
         # Apply top_k and/or top_p.
         random_sampled, processed_logprobs = self.topk_topp_sampler(

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -6932,6 +6932,26 @@ class GPUModelRunner(
         _maybe_dump_sm70_qwen_layer_graph_buffers("pre_sample")
         _maybe_sync_sm70_sample_tensors(sample_hidden_states)
         if spec_decode_metadata is None:
+            if logits is None and self._can_use_sm70_compact_topk20_tokens(
+                scheduler_output, spec_decode_metadata
+            ):
+                topk_token_ids, topk_logits = self.model.get_topk_tokens_and_logits(
+                    sample_hidden_states,
+                    20,
+                )
+                compact_sampled = self.sampler.sm70_compact_topk20_pairs_sample(
+                    topk_logits,
+                    topk_token_ids,
+                    sampling_metadata,
+                )
+                if compact_sampled is not None:
+                    logger.info_once(
+                        "SM70 TP-local exact top-k20 random sampling path enabled."
+                    )
+                    return SamplerOutput(
+                        sampled_token_ids=compact_sampled.to(torch.int32).unsqueeze(-1),
+                        logprobs_tensors=None,
+                    )
             sampler_output = self._sample_greedy_token_fastpath(
                 logits,
                 sampling_metadata,
@@ -7480,6 +7500,88 @@ class GPUModelRunner(
             self._trace_greedy_token_fastpath("logits_processor")
             return False
         self._trace_greedy_token_fastpath("enabled")
+        return True
+
+    def _can_use_sm70_compact_topk20_tokens(
+        self,
+        scheduler_output: "SchedulerOutput",
+        spec_decode_metadata: SpecDecodeMetadata | None,
+    ) -> bool:
+        if not envs.VLLM_SM70_COMPACT_TOPK20_SAMPLER:
+            return False
+        if not envs.VLLM_SM70_TP_LOCAL_TOPK20_SAMPLER:
+            return False
+        if spec_decode_metadata is not None:
+            return self._reject_sm70_compact_topk20_tokens("spec_decode")
+        if self.is_pooling_model or self.broadcast_pp_output:
+            return self._reject_sm70_compact_topk20_tokens("pooling_or_pp_broadcast")
+        if scheduler_output.has_structured_output_requests:
+            return self._reject_sm70_compact_topk20_tokens("structured_output")
+        if self.device.type != "cuda":
+            return self._reject_sm70_compact_topk20_tokens("non_cuda")
+        if torch.cuda.get_device_capability(self.device) != (7, 0):
+            return self._reject_sm70_compact_topk20_tokens("non_sm70")
+        if self.model_config.get_vocab_size() != 248320:
+            return self._reject_sm70_compact_topk20_tokens("vocab_size")
+        if not hasattr(self.model, "get_topk_tokens_and_logits"):
+            return self._reject_sm70_compact_topk20_tokens("missing_model_topk")
+        if self.input_batch.num_reqs != 1:
+            return self._reject_sm70_compact_topk20_tokens("batch_size")
+
+        sampling_metadata = self.input_batch.sampling_metadata
+        if not sampling_metadata.all_random or sampling_metadata.all_greedy:
+            return self._reject_sm70_compact_topk20_tokens("sampling_mode")
+        if sampling_metadata.max_num_logprobs is not None:
+            return self._reject_sm70_compact_topk20_tokens("logprobs")
+        if sampling_metadata.logprob_token_ids:
+            return self._reject_sm70_compact_topk20_tokens("logprob_token_ids")
+        if not sampling_metadata.no_penalties:
+            return self._reject_sm70_compact_topk20_tokens("penalties")
+        if sampling_metadata.allowed_token_ids_mask is not None:
+            return self._reject_sm70_compact_topk20_tokens("allowed_token_ids")
+        if sampling_metadata.bad_words_token_ids:
+            return self._reject_sm70_compact_topk20_tokens("bad_words")
+        holder = sampling_metadata.thinking_budget_state_holder
+        if holder is not None and holder.has_tracked_requests():
+            return self._reject_sm70_compact_topk20_tokens("thinking_budget")
+        if not self._non_argmax_logits_processors_inactive(sampling_metadata):
+            return self._reject_sm70_compact_topk20_tokens("logits_processor")
+        if not self._sm70_argmax_logits_processors_inactive(sampling_metadata):
+            return self._reject_sm70_compact_topk20_tokens(
+                "argmax_invariant_logits_processor"
+            )
+        if sampling_metadata.top_k_cpu != (20,):
+            return self._reject_sm70_compact_topk20_tokens("top_k")
+
+        top_p_cpu = sampling_metadata.top_p_cpu
+        if top_p_cpu is None or len(top_p_cpu) != 1 or abs(top_p_cpu[0] - 0.95) > 1e-6:
+            return self._reject_sm70_compact_topk20_tokens("top_p")
+        temperature_cpu = sampling_metadata.temperature_cpu
+        if (
+            temperature_cpu is None
+            or len(temperature_cpu) != 1
+            or abs(temperature_cpu[0] - 1.0) > 1e-6
+        ):
+            return self._reject_sm70_compact_topk20_tokens("temperature")
+        return True
+
+    @staticmethod
+    def _reject_sm70_compact_topk20_tokens(reason: str) -> bool:
+        logger.info_once("SM70 TP-local top-k20 route rejected: %s", reason)
+        return False
+
+    @staticmethod
+    def _sm70_argmax_logits_processors_inactive(
+        sampling_metadata: SamplingMetadata,
+    ) -> bool:
+        from vllm.v1.sample.logits_processor.builtin import MinPLogitsProcessor
+
+        for processor in sampling_metadata.logitsprocs.argmax_invariant:
+            if isinstance(processor, MinPLogitsProcessor):
+                if processor.min_p_count:
+                    return False
+                continue
+            return False
         return True
 
     def _trace_greedy_token_fastpath(self, reason: str) -> None:
@@ -8480,6 +8582,9 @@ class GPUModelRunner(
                 mtp_logits_start = self._sm70_mtp_profile_start(mtp_profile_events)
                 if (
                     self._can_use_greedy_token_fastpath(
+                        scheduler_output, spec_decode_metadata
+                    )
+                    or self._can_use_sm70_compact_topk20_tokens(
                         scheduler_output, spec_decode_metadata
                     )
                     or self._can_use_ddtree_greedy_top_tokens(


### PR DESCRIPTION
## Purpose

Recover and optimize Qwen3.8-27B FP8 and mixed NVFP4/channel-FP8 decode on
NVIDIA V100 (SM70). The frozen Qwen3.8-27B-NVFP4 TP4, no-MTP contract now
passes the requested 80 tok/s gate without a measured output-quality
regression.

- Integration includes `onecat/main@c4c9b840fe`.
- Current branch head: 6ce31b75f..
- Scope: TP4, no MTP, exact Qwen3.8-27B model/shape contracts.

## Implementation and route map

- Keep the proven-faster exact FP8 gate/up, down, and output projections on
  memory-neutral QPN8. GDN input, full-attention QKV, and the LM head remain on
  TurboMind W8A16.
- Add memory-neutral native QPN4 decode for the admitted batch-one NVFP4
  gate/up and down shapes, including a fused gated-SiLU path and one bounded
  shared FP16 prefill workspace. Unsupported contracts retain TurboMind.
- Add the exact TP4 5120-element pack32 one-stage all-reduce route behind an
  explicit gate.
- Add a separately built C++17 `_sm70_sampler_C` wheel sidecar. Its 80-chunk
  top-20 reduction preserves canonical ordering, top-p math, Philox draws, and
  generator state without relinking the primary `vllm._C`.
- Retain E4M3 Flash-V100 XQA p64 for the exact batch-one G6/D256 attention
  layout. Existing E5M2 and FP16 policies remain intact.
- Keep narrow model, shape, TP, concurrency, sampling, and no-MTP admission
  gates with explicit rollback controls.

## Frozen no-MTP performance result

Model: Qwen3.8-27B-NVFP4 on four V100-SXM2-32GB GPUs, TP4, input 1024,
output cap 256, temperature 1.0, top-p 0.95, top-k 20, seed 20260815, E4M3 KV,
Flash-V100, full CUDA graph decode, and no MTP. Pure decode uses 255 steady
intervals and excludes TTFT/prefill.

| Route | Pure TPOT | Steady decode |
|---|---:|---:|
| Merged native-sampler baseline | 14.017 ms | 71.342 tok/s |
| Hand sidecar repeat A2 | 12.472 ms | 80.177 tok/s |
| Hand sidecar repeat A3 | 12.474 ms | 80.164 tok/s |
| Hand sidecar repeat A4, physical GPUs 4-7 | 12.496 ms | 80.026 tok/s |
| Production CMake C++17 sidecar A2 | **12.403 ms** | **80.624 tok/s** |
| Clean current-source C++17 A2 | **12.472 ms** | **80.181 tok/s** |

The three hand-sidecar repeats preserve the frozen 256-token SHA256. Direct
cross-build sampling tests show the hand and production sidecars select
identical tokens across 100 independent seeds and 256 sequential draws and
finish with the same generator state. The clean current-source A2 run also reproduces the accepted production C++17 256-token stream exactly.

## Output-quality gate

The frozen first-250 GSM8K gate uses five-shot greedy prompts and retains each
question, output, token IDs, extracted answer, label, correctness, and hash.

| Route | Correct | Accuracy | Invalid |
|---|---:|---:|---:|
| Frozen baseline | 226/250 | 90.4% | 0 |
| Hand sidecar | 227/250 | 90.8% | 0 |
| Production CMake C++17 sidecar | **226/250** | **90.4%** | **0** |

The production route therefore equals the frozen accuracy baseline and has no
invalid outputs. Random benchmark token identity is not used as the sole
quality gate.

## Trace and utilization

The accepted-route Nsight Systems trace captures 63 graph replays per rank and
uses the middle 61 steps. Mean replay interval is 13.430 ms, GPU activity union
is 12.887 ms (95.958%), idle is 0.543 ms/token, and launch count is 1061.9 per
rank/token. Major service terms are QPN8 split-16 2.213 ms, QPN4 gate/up 2.165
ms, TP all-reduce 1.587 ms, QPN4 down 1.441 ms, QPN8 output 0.915 ms, XQA 0.618
ms, QPN8 gate/up 0.496 ms, and TurboMind FP8/LM head 0.410 ms.

NVML reports 100% busy-window duty, 53.25% memory-active duty, about 28.97 GiB
allocated per GPU, and 56.36% of the 300 W limit. Grid-limited occupancy
ceilings put 86.32% of service below 50% occupancy. These are not achieved
SM/Tensor/HBM counters; Nsight Compute is blocked by `ERR_NVGPUCTRPERM`.

## Build, tests, and acceptance boundary

- Focused sampler, NVFP4 admission, TurboMind adapter, and adjacent ModelOpt
  regression files: 106/106 passed.
- Ruff lint/format, Python byte compilation, sidecar wheel filename gate, and
  `git diff --check` passed. Pinned changed-file checks also pass typos,
  Markdownlint, SPDX, forbidden-import, and accelerator-policy gates.
- Production sampler microbenchmark: exact reference selections for five
  distributions, 100 explicit-seed trials, and 100 default-generator trials;
  102.427 us reduced to 62.972 us.
- Historical accepted compatible `_C` SHA256:
  `a0a0cd9ddeccc73fa3d920c7a869450c4b33d001f97637c35b75b966d89ad36d`.
- Clean current-source `_C` SHA256:
  `c5d7c6a9a0fa714c1e97427c3d16369404ae5af6ee80f48b165595081cc43e56`.
- Clean current-source C++17 sampler SHA256:
  `3058051f59949d88f5982d0c5bd80121f3c75a0f5307ca901fa6aebdec4cbc74`.
- Production sampler sidecar SHA256:
  `cdbfdd87dfa9119e52acc88d5787063202561a879a63334145a5616344a549ae`.
- Flash-V100 SHA256:
  `b418fed86b9c1ab9297c8795c24732818239b9a3aaca5ec9efb60933853d8ce7`.

Current-source rebuild closure is complete. The clean main and sampler device
fatbins are byte-identical to the accepted binaries; their full ELF hashes differ
only because merged main adds two unrelated ModelOpt NVFP4 MoE host APIs and
relinking changes host build IDs. Clean A2 reaches 80.181 tok/s and exactly
matches the accepted production token stream. Focused CMake component install
also preserves both fatbins and registers QPN4, QPN8, and packed top-20 sampler
schemas. The PR is ready after maintainer source audit. The accepted mixed-NVFP4 route is unchanged; pure-FP8 QPN8 remains opt-in pending an equal-interval speed rerun.

The remote all-files pre-commit job is also red on this PR's exact main base
(`c4c9b840fe`, run `32645573201`). The PR run reproduces the same inherited
repository-wide failure categories: Ruff/clang/Markdown mechanical formatting,
vendor typos, docs lock regeneration, legacy SPDX headers, forbidden imports,
and legacy `torch.cuda` calls. Ruff check, all four mypy versions, actionlint,
ShellCheck, and the other non-debt gates pass. Bulk formatting of frozen
performance kernels is intentionally kept out of this acceptance change because
it would invalidate binary/lineinfo evidence without making the all-files job
green.

## Evidence

- `docs/design/sm70_qwen38_qpn8_decode.md`
- `docs/design/sm70_qwen38_nvfp4_decode.md`
- `docs/design/sm70_v100_migration_control.md`

Local raw benchmark, per-question quality, operator, numerical, Nsight, and
NVML evidence is retained under `.artifacts/qwen38_nvfp4_speed_20260823/` and
is intentionally untracked.


## Maintainer audit (2026-08-24)

- Rebased onto current main and retained both the existing ModelOpt NVFP4 MoE integration and the Qwen3.8 routes.
- Pure-FP8 QPN8 now defaults off because its complete-source candidate used 232 steady intervals versus 255 for control. Explicit VLLM_SM70_FP8_QPN8=1 still enables it.
- Mixed NVFP4/channel-FP8 keeps its separately validated QPN8 default when the global env is unset; explicit 0 disables both.
- Focused sampler and quantization suites: 86 passed on V100 GPU 7.
- Changed-file pre-commit, including Ruff, clang-format, Markdownlint, SPDX, mypy, forbidden imports, and git diff --check: passed.
- Fixed one order-dependent GPU test whose CPU reference inherited the process default CUDA device.
- No model E2E or performance rerun was repeated during maintainer audit.