### PR TITLE
[Bugfix][SpecDecode] Honor final-stage-local drafter topology

### DIFF
--- a/docs/design/sm70_deepseek_v4_flash_bringup.md
+++ b/docs/design/sm70_deepseek_v4_flash_bringup.md
@@ -55,6 +55,36 @@ kernel module and userspace NVML versions differ. Local validation is limited
 to static and CPU tests until reboot; GPU correctness and performance run on
 the remote V100 host after the PR is merged and freshly cloned.
 
+## PP Topology Follow-up (2026-08-22)
+
+The original bring-up named PP2 x TP4 as a required deployment candidate, but
+the retained full-model evidence covers TP8 only. The follow-up closes that
+gap on current `onecat/main` at `7aede2cf010d92815c9d7bff25867b4fa009b6cb`.
+
+- The roughly 160 GB checkpoint cannot fit pure TP4 or pure PP4 on four
+  V100-32GB GPUs. The memory-feasible eight-GPU candidates are PP2 x TP4 and,
+  if four pipeline stages are required, PP4 x TP2.
+- The default 43-layer partitions are `22+21` for PP2 and `11+11+11+10` for
+  PP4. DSpark target layers 40-42 remain entirely on the final pipeline stage
+  in both layouts, matching the runner's final-stage-only drafter ownership.
+- PP intermediate tensors must retain the four mHC streams with shape
+  `[tokens, 4, 4096]`; collapsing them to a two-dimensional hidden state at a
+  stage boundary would change model semantics.
+- The first runtime gate is PP2 x TP4 with the same model, FP8 MLA KV, DSpark
+  N7, 1024/256 request, sampling, graph mode, and fast-stack flags as the
+  accepted TP8 reproduction. The TP8-only hierarchical all-reduce is disabled
+  for each TP4 group.
+
+The first current-main PP2 x TP4 attempt failed before worker launch. DSpark's
+draft config inherited target `pipeline_parallel_size=2`, so generic model
+validation required the final-stage-local `DSparkDraftModel` to implement
+`SupportsPP`. The runner intentionally constructs the complete drafter only on
+the final target PP rank; partitioning that three-layer draft again would not
+match its ownership model. The candidate therefore gives DSpark a draft-local
+PP size of one while retaining the target TP/PP topology and draft TP size.
+Exact configuration regressions pass for PP2 x TP4 and PP4 x TP2. Post-fix
+runtime route, quality, speed, and cleanup evidence remain pending.
+
 ## Upstream Reuse
 
 Reuse these official implementations and semantics:

--- a/docs/design/sm70_deepseek_v4_flash_bringup.md
+++ b/docs/design/sm70_deepseek_v4_flash_bringup.md
@@ -58,8 +58,10 @@ the remote V100 host after the PR is merged and freshly cloned.
 ## PP Topology Follow-up (2026-08-22)
 
 The original bring-up named PP2 x TP4 as a required deployment candidate, but
-the retained full-model evidence covers TP8 only. The follow-up closes that
-gap on current `onecat/main` at `7aede2cf010d92815c9d7bff25867b4fa009b6cb`.
+the retained full-model evidence covers TP8 only. This follow-up removes the
+configuration blocker on current `onecat/main` at
+`7aede2cf010d92815c9d7bff25867b4fa009b6cb`; the full runtime evidence gap
+remains explicit below.
 
 - The roughly 160 GB checkpoint cannot fit pure TP4 or pure PP4 on four
   V100-32GB GPUs. The memory-feasible eight-GPU candidates are PP2 x TP4 and,
@@ -81,9 +83,11 @@ validation required the final-stage-local `DSparkDraftModel` to implement
 `SupportsPP`. The runner intentionally constructs the complete drafter only on
 the final target PP rank; partitioning that three-layer draft again would not
 match its ownership model. The candidate therefore gives DSpark a draft-local
-PP size of one while retaining the target TP/PP topology and draft TP size.
-Exact configuration regressions pass for PP2 x TP4 and PP4 x TP2. Post-fix
-runtime route, quality, speed, and cleanup evidence remain pending.
+PP size of one while retaining the target TP/PP topology and draft TP size. It
+also rejects a custom layer partition if any configured target layer falls
+outside the final target pipeline stage. Exact configuration regressions pass
+for PP2 x TP4 and PP4 x TP2. Post-fix runtime route, quality, speed, and cleanup
+evidence remain pending.
 
 ## Upstream Reuse
 

--- a/tests/models/test_deepseek_v4_pipeline.py
+++ b/tests/models/test_deepseek_v4_pipeline.py
@@ -1,0 +1,50 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from vllm.distributed.utils import get_pp_indices
+from vllm.models.deepseek_v4.nvidia.model import DeepseekV4Model
+
+
+@pytest.mark.parametrize(
+    ("pp_size", "expected_partitions"),
+    [
+        (2, [(0, 22), (22, 43)]),
+        (4, [(0, 11), (11, 22), (22, 33), (33, 43)]),
+    ],
+)
+def test_deepseek_v4_pipeline_partitions_keep_dspark_targets_on_last_stage(
+    monkeypatch: pytest.MonkeyPatch,
+    pp_size: int,
+    expected_partitions: list[tuple[int, int]],
+) -> None:
+    monkeypatch.delenv("VLLM_PP_LAYER_PARTITION", raising=False)
+
+    partitions = [get_pp_indices(43, rank, pp_size) for rank in range(pp_size)]
+
+    assert partitions == expected_partitions
+    last_start, last_end = partitions[-1]
+    assert all(last_start <= layer_id < last_end for layer_id in (40, 41, 42))
+
+
+def test_deepseek_v4_pipeline_intermediate_preserves_mhc_streams() -> None:
+    model = SimpleNamespace(
+        hc_mult=4,
+        config=SimpleNamespace(hidden_size=4096),
+    )
+
+    intermediate = DeepseekV4Model.make_empty_intermediate_tensors(
+        model,
+        batch_size=3,
+        dtype=torch.float16,
+        device=torch.device("cpu"),
+    )
+
+    assert set(intermediate.tensors) == {"hidden_states"}
+    assert intermediate["hidden_states"].shape == (3, 4, 4096)
+    assert intermediate["hidden_states"].dtype == torch.float16
+    assert torch.count_nonzero(intermediate["hidden_states"]) == 0

--- a/tests/v1/spec_decode/test_dspark.py
+++ b/tests/v1/spec_decode/test_dspark.py
@@ -19,13 +19,13 @@ from vllm.transformers_utils.configs.deepseek_v4 import DeepseekV4Config
 from vllm.v1.spec_decode.dspark import DSparkProposer
 
 
-@pytest.mark.parametrize(("pp_size", "tp_size"), [(2, 4), (4, 2)])
-def test_dspark_draft_is_local_to_last_pipeline_stage(
+def _make_dspark_speculative_config(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
+    *,
     pp_size: int,
     tp_size: int,
-) -> None:
+) -> tuple[ParallelConfig, SpeculativeConfig]:
     monkeypatch.setattr(current_platform, "device_count", lambda: 8)
     DeepseekV4Config(
         architectures=["DeepseekV4ForCausalLM"],
@@ -51,18 +51,48 @@ def test_dspark_draft_is_local_to_last_pipeline_stage(
         pipeline_parallel_size=pp_size,
         tensor_parallel_size=tp_size,
     )
-
     speculative_config = SpeculativeConfig(
         target_model_config=target_model_config,
         target_parallel_config=target_parallel_config,
         method="dspark",
         num_speculative_tokens=7,
     )
+    return target_parallel_config, speculative_config
+
+
+@pytest.mark.parametrize(("pp_size", "tp_size"), [(2, 4), (4, 2)])
+def test_dspark_draft_is_local_to_last_pipeline_stage(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    pp_size: int,
+    tp_size: int,
+) -> None:
+    target_parallel_config, speculative_config = _make_dspark_speculative_config(
+        tmp_path,
+        monkeypatch,
+        pp_size=pp_size,
+        tp_size=tp_size,
+    )
 
     assert target_parallel_config.pipeline_parallel_size == pp_size
     assert speculative_config.draft_parallel_config.pipeline_parallel_size == 1
     assert speculative_config.draft_parallel_config.tensor_parallel_size == tp_size
     assert speculative_config.draft_model_config.architectures == ["DSparkDraftModel"]
+
+
+def test_dspark_rejects_target_layers_outside_final_pipeline_stage(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("VLLM_PP_LAYER_PARTITION", "42,1")
+
+    with pytest.raises(ValueError, match="final target pipeline stage"):
+        _make_dspark_speculative_config(
+            tmp_path,
+            monkeypatch,
+            pp_size=2,
+            tp_size=4,
+        )
 
 
 def test_deepseek_v4_dspark_checkpoint_name_mapping() -> None:

--- a/tests/v1/spec_decode/test_dspark.py
+++ b/tests/v1/spec_decode/test_dspark.py
@@ -1,18 +1,68 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+from pathlib import Path
 from types import MethodType, SimpleNamespace
 
 import pytest
 import torch
 import torch.nn as nn
 
+from vllm.config import ModelConfig, ParallelConfig, SpeculativeConfig
 from vllm.models.deepseek_v4.nvidia.dspark import (
     DSparkDeepseekV4ForCausalLM,
     DSparkDeepseekV4Model,
     DSparkMarkovHead,
 )
+from vllm.platforms import current_platform
+from vllm.transformers_utils.configs.deepseek_v4 import DeepseekV4Config
 from vllm.v1.spec_decode.dspark import DSparkProposer
+
+
+@pytest.mark.parametrize(("pp_size", "tp_size"), [(2, 4), (4, 2)])
+def test_dspark_draft_is_local_to_last_pipeline_stage(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    pp_size: int,
+    tp_size: int,
+) -> None:
+    monkeypatch.setattr(current_platform, "device_count", lambda: 8)
+    DeepseekV4Config(
+        architectures=["DeepseekV4ForCausalLM"],
+        hidden_size=4096,
+        num_hidden_layers=43,
+        num_attention_heads=64,
+        num_key_value_heads=1,
+        vocab_size=129280,
+        num_nextn_predict_layers=1,
+        dspark_target_layer_ids=[40, 41, 42],
+        dspark_block_size=5,
+        dspark_noise_token_id=128799,
+        dspark_markov_rank=256,
+    ).save_pretrained(tmp_path)
+    target_model_config = ModelConfig(
+        model=str(tmp_path),
+        tokenizer=str(tmp_path),
+        runner="generate",
+        dtype=torch.float16,
+        max_model_len=2048,
+    )
+    target_parallel_config = ParallelConfig(
+        pipeline_parallel_size=pp_size,
+        tensor_parallel_size=tp_size,
+    )
+
+    speculative_config = SpeculativeConfig(
+        target_model_config=target_model_config,
+        target_parallel_config=target_parallel_config,
+        method="dspark",
+        num_speculative_tokens=7,
+    )
+
+    assert target_parallel_config.pipeline_parallel_size == pp_size
+    assert speculative_config.draft_parallel_config.pipeline_parallel_size == 1
+    assert speculative_config.draft_parallel_config.tensor_parallel_size == tp_size
+    assert speculative_config.draft_model_config.architectures == ["DSparkDraftModel"]
 
 
 def test_deepseek_v4_dspark_checkpoint_name_mapping() -> None:

--- a/vllm/config/speculative.py
+++ b/vllm/config/speculative.py
@@ -913,6 +913,7 @@ class SpeculativeConfig:
                                 "dspark_confidence_temperatures entries must be "
                                 f"finite and positive; got {temperatures}."
                             )
+                    self._verify_dspark_final_stage_ownership()
 
                 if self.use_dflash_ddtree() and self.ddtree_budget is None:
                     self.ddtree_budget = self.num_speculative_tokens
@@ -946,6 +947,31 @@ class SpeculativeConfig:
                     )
                 )
         return self
+
+    def _verify_dspark_final_stage_ownership(self) -> None:
+        """Validate the layer contract for a final-stage-local drafter."""
+        from vllm.distributed.utils import get_pp_indices
+
+        pp_size = self.target_parallel_config.pipeline_parallel_size
+        num_layers = self.target_model_config.get_total_num_hidden_layers()
+        last_start, last_end = get_pp_indices(num_layers, pp_size - 1, pp_size)
+        layer_ids = tuple(
+            getattr(
+                self.draft_model_config.hf_config,
+                "dspark_target_layer_ids",
+                (),
+            )
+        )
+        outside_last_stage = [
+            layer_id for layer_id in layer_ids if not last_start <= layer_id < last_end
+        ]
+        if not layer_ids or outside_last_stage:
+            raise ValueError(
+                "DSpark's final-stage-local drafter requires every "
+                "dspark_target_layer_id to belong to the final target pipeline "
+                f"stage [{last_start}, {last_end}); got {layer_ids}. Adjust "
+                "VLLM_PP_LAYER_PARTITION or the DSpark layer contract."
+            )
 
     def _validate_suffix_decoding(self):
         if not has_arctic_inference():

--- a/vllm/config/speculative.py
+++ b/vllm/config/speculative.py
@@ -935,7 +935,14 @@ class SpeculativeConfig:
 
                 self.draft_parallel_config = (
                     SpeculativeConfig.create_draft_parallel_config(
-                        self.target_parallel_config, self.draft_tensor_parallel_size
+                        self.target_parallel_config,
+                        self.draft_tensor_parallel_size,
+                        # The runner constructs the complete DSpark drafter on
+                        # the target model's final PP rank. It is local to that
+                        # stage rather than partitioned across target PP ranks.
+                        speculative_draft_pipeline_parallel_size=(
+                            1 if self.use_dspark() else None
+                        ),
                     )
                 )
         return self
@@ -1078,13 +1085,19 @@ class SpeculativeConfig:
     def create_draft_parallel_config(
         target_parallel_config: ParallelConfig,
         speculative_draft_tensor_parallel_size: int,
+        speculative_draft_pipeline_parallel_size: int | None = None,
     ) -> ParallelConfig:
         """Create a parallel config for use by the draft worker.
 
-        This is mostly a copy of the target parallel config, except the tp_size.
+        This is mostly a copy of the target parallel config, except the draft
+        tensor size and, for final-stage-local drafters, pipeline size.
         """
         draft_parallel_config = ParallelConfig(
-            pipeline_parallel_size=target_parallel_config.pipeline_parallel_size,
+            pipeline_parallel_size=(
+                target_parallel_config.pipeline_parallel_size
+                if speculative_draft_pipeline_parallel_size is None
+                else speculative_draft_pipeline_parallel_size
+            ),
             tensor_parallel_size=speculative_draft_tensor_parallel_size,
             distributed_executor_backend=target_parallel_config.distributed_executor_backend,
             max_parallel_loading_workers=target_parallel_config.max_parallel_loading_workers,


### PR DESCRIPTION
## Purpose

Allow a speculative drafter that is wholly owned by the final target pipeline stage to validate with draft-local PP size 1 while leaving the target PP/TP topology unchanged. The current consumer is the DSpark proposer; admission is based on the configured speculative method, target PP topology, and layer ownership contract, not a model name or checkpoint identity.

## Source audit and fixes

- The runner already constructs the complete DSpark drafter only on each target PP group's final stage. Requiring that local drafter to advertise target-wide `SupportsPP` was therefore a configuration error.
- The draft validation config now uses PP1 and retains the target draft TP. Target PP2 x TP4 / PP4 x TP2 execution configs remain unchanged.
- The original patch covered only default 43-layer partitions. Audit added a startup validation for custom `VLLM_PP_LAYER_PARTITION`: every configured `dspark_target_layer_id` must belong to the actual final target stage, otherwise startup fails with a corrective error.
- The draft helper remains generic: callers may override draft-local PP only for an explicitly final-stage-local algorithm; other speculative methods retain target PP behavior.
- The four-stream mHC pipeline intermediate remains `[tokens, 4, 4096]`; no tensor arithmetic, kernel, checkpoint mapping, or runtime identity selector changes.

## Validation

- Replayed onto latest `main` `31b3c4dfc`; both commits are DCO-signed.
- `tests/v1/spec_decode/test_dspark.py` plus `tests/models/test_deepseek_v4_pipeline.py`: 16 passed.
- Covered PP2 x TP4 and PP4 x TP2 default partitions, draft PP1/TP preservation, custom partition rejection, target-layer ownership, and mHC intermediate shape.
- Changed-file ruff, format, typos, markdownlint, mypy, SPDX, forbidden-import, configuration, and CUDA-API hooks: all passed.
- `git diff --check`: passed.

## Runtime evidence scope

The retained TP8 DSpark route evidence is unchanged. The pre-fix PP2 x TP4 attempt reproduced the expected `SupportsPP` validation failure before workers launched and cleaned up correctly. Per the current audit scope, no expensive post-fix full-model E2E was run; this merge removes and guards the configuration blocker without claiming a new PP performance or quality baseline. PP speed/quality claims still require a later matched benchmark with exact topology and workload settings.