### PR TITLE
[Bugfix] Prevent MM cache hang from stale LRU order keys

### DIFF
--- a/vllm/utils/cache.py
+++ b/vllm/utils/cache.py
@@ -118,10 +118,8 @@ class LRUCache(cachetools.LRUCache[_K, _V]):
         return info
 
     def touch(self, key: _K) -> None:
-        try:
+        if key in self:
             self._LRUCache__order.move_to_end(key)  # type: ignore
-        except KeyError:
-            self._LRUCache__order[key] = None  # type: ignore
 
     @overload
     def get(self, key: _K, /) -> _V | None: ...


### PR DESCRIPTION
## Summary

Backport of upstream fix **vllm-project/vllm#43595** (merged 2026-06-09) for issue **vllm-project/vllm#43941**. The diff is identical to the merged upstream change.

`LRUCache.touch()` added nonexistent keys to the LRU `__order` dict, creating **orphan entries** that exist in `__order` but not in `__data`. When the multimodal processor cache filled up and cachetools eviction called `popitem()`, it kept selecting the same orphan key, `pop()` removed nothing, `currsize` never decreased, and the eviction `while currsize > maxsize` loop spun forever with the GIL held.

**Observed in production (SM70 build, TP4, multimodal workload):** EngineCore's `process_input_sockets` thread hung inside `popitem`, new requests were never queued to the scheduler, engine metrics logging stopped — while the API server kept answering `/health` with 200, so the service looked alive but processed nothing.

Fix: `touch()` only reorders keys that actually exist in the cache.

## Duplicate-work check

- No open PR in this repo addresses this (`gh pr list --search "LRUCache orphan"` / `"cache infinite loop"` → empty).
- This is a straight backport of the already-merged upstream fix, not a new approach. (Upstream PR #44533 with the same intent was closed unmerged in favor of #43595.)

## Tests

`pytest` is not installed in the deployment venv, so the change was verified by loading `vllm/utils/cache.py` directly with the venv interpreter under a 10s alarm (the old code infinite-loops on this scenario):

- `touch()` on a nonexistent key no longer creates an orphan entry in `order`
- cache fill + eviction completes and evicts the real LRU item
- `touch()` on an existing key still refreshes LRU order

All checks passed on every local tree carrying this patch. The patched build is deployed to the production service that originally hit this hang.

## AI assistance

This PR was prepared with AI assistance (Kimi Code CLI): diagnosis via py-spy stack dump of the hung production process, backport of the upstream patch, and test execution. A human has reviewed the diff.
