### PR TITLE
[Bugfix][Distributed] Make custom allreduce graph capture VMM-safe

### DIFF
--- a/tests/distributed/test_custom_all_reduce_allocator.py
+++ b/tests/distributed/test_custom_all_reduce_allocator.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 import pytest
+import regex as re
 
 from vllm.distributed.device_communicators import custom_all_reduce
 
@@ -22,16 +23,139 @@ def _patch_allocator_settings(monkeypatch: pytest.MonkeyPatch) -> list[str]:
 def test_cuda_ipc_capture_temporarily_disables_expandable_segments(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    allocator_conf = (
+        "max_split_size_mb:512,garbage_collection_threshold:0.8,"
+        "expandable_segments:True"
+    )
     monkeypatch.setenv(
         "PYTORCH_CUDA_ALLOC_CONF",
-        "max_split_size_mb:512,expandable_segments:True",
+        allocator_conf,
     )
     settings = _patch_allocator_settings(monkeypatch)
 
     with custom_all_reduce._disable_expandable_segments_for_cuda_ipc(True):
-        assert settings == ["expandable_segments:False"]
+        assert settings == [allocator_conf.replace("True", "False")]
 
-    assert settings == ["expandable_segments:False", "expandable_segments:True"]
+    assert settings == [allocator_conf.replace("True", "False"), allocator_conf]
+
+
+def test_cuda_ipc_capture_preserves_allocator_state(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    allocator_conf = (
+        "max_split_size_mb:512,roundup_power2_divisions:4,"
+        "garbage_collection_threshold:0.8,expandable_segments:True"
+    )
+    monkeypatch.setenv("PYTORCH_CUDA_ALLOC_CONF", allocator_conf)
+    monkeypatch.setattr(custom_all_reduce.current_platform, "is_cuda", lambda: True)
+    allocator_state: dict[str, int | float | bool] = {
+        "max_split_size_mb": 512,
+        "roundup_power2_divisions": 4,
+        "garbage_collection_threshold": 0.8,
+        "expandable_segments": True,
+    }
+
+    def set_allocator_settings(conf: str) -> None:
+        # Model PyTorch's parseArgs behavior: these options reset whenever
+        # they are omitted from a runtime settings update.
+        allocator_state.update(
+            max_split_size_mb=-1,
+            roundup_power2_divisions=0,
+            garbage_collection_threshold=0.0,
+        )
+        for key in allocator_state:
+            match = re.search(rf"(?:^|,){key}:([^,]+)", conf)
+            if match is None:
+                continue
+            value = match.group(1)
+            if key == "garbage_collection_threshold":
+                allocator_state[key] = float(value)
+            elif key == "expandable_segments":
+                allocator_state[key] = value == "True"
+            else:
+                allocator_state[key] = int(value)
+
+    monkeypatch.setattr(
+        custom_all_reduce.torch.cuda.memory,
+        "_set_allocator_settings",
+        set_allocator_settings,
+    )
+
+    with custom_all_reduce._disable_expandable_segments_for_cuda_ipc(True):
+        assert allocator_state == {
+            "max_split_size_mb": 512,
+            "roundup_power2_divisions": 4,
+            "garbage_collection_threshold": 0.8,
+            "expandable_segments": False,
+        }
+
+    assert allocator_state == {
+        "max_split_size_mb": 512,
+        "roundup_power2_divisions": 4,
+        "garbage_collection_threshold": 0.8,
+        "expandable_segments": True,
+    }
+
+
+def test_cuda_ipc_capture_supports_unified_allocator_conf(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("PYTORCH_CUDA_ALLOC_CONF", raising=False)
+    allocator_conf = "max_split_size_mb:512,expandable_segments:True"
+    monkeypatch.setenv("PYTORCH_ALLOC_CONF", allocator_conf)
+    settings = _patch_allocator_settings(monkeypatch)
+
+    with custom_all_reduce._disable_expandable_segments_for_cuda_ipc(True):
+        pass
+
+    assert settings == [allocator_conf.replace("True", "False"), allocator_conf]
+
+
+@pytest.mark.parametrize("legacy_conf", ["", "expandable_segments:False"])
+def test_legacy_allocator_conf_takes_precedence_over_unified_conf(
+    monkeypatch: pytest.MonkeyPatch,
+    legacy_conf: str,
+) -> None:
+    monkeypatch.setenv("PYTORCH_CUDA_ALLOC_CONF", legacy_conf)
+    monkeypatch.setenv("PYTORCH_ALLOC_CONF", "expandable_segments:True")
+    settings = _patch_allocator_settings(monkeypatch)
+
+    with custom_all_reduce._disable_expandable_segments_for_cuda_ipc(True):
+        pass
+
+    assert settings == []
+
+
+def test_enabled_legacy_allocator_conf_takes_precedence(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    legacy_conf = "max_split_size_mb:512,expandable_segments:True"
+    monkeypatch.setenv("PYTORCH_CUDA_ALLOC_CONF", legacy_conf)
+    monkeypatch.setenv("PYTORCH_ALLOC_CONF", "expandable_segments:False")
+    settings = _patch_allocator_settings(monkeypatch)
+
+    with custom_all_reduce._disable_expandable_segments_for_cuda_ipc(True):
+        pass
+
+    assert settings == [legacy_conf.replace("True", "False"), legacy_conf]
+
+
+def test_cuda_ipc_capture_preserves_bracketed_allocator_syntax(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    allocator_conf = (
+        "roundup_power2_divisions:[256:1,512:2,>:4], expandable_segments : True"
+    )
+    monkeypatch.setenv("PYTORCH_CUDA_ALLOC_CONF", allocator_conf)
+    settings = _patch_allocator_settings(monkeypatch)
+
+    with custom_all_reduce._disable_expandable_segments_for_cuda_ipc(True):
+        pass
+
+    assert settings == [
+        allocator_conf.replace("True", "False"),
+        allocator_conf,
+    ]
 
 
 def test_cuda_ipc_capture_restores_allocator_after_error(
@@ -90,6 +214,7 @@ def test_cuda_ipc_capture_allocator_guard_is_otherwise_a_noop(
     active: bool,
     allocator_conf: str,
 ) -> None:
+    monkeypatch.delenv("PYTORCH_ALLOC_CONF", raising=False)
     monkeypatch.setenv("PYTORCH_CUDA_ALLOC_CONF", allocator_conf)
     settings = _patch_allocator_settings(monkeypatch)
 

--- a/tests/distributed/test_custom_all_reduce_allocator.py
+++ b/tests/distributed/test_custom_all_reduce_allocator.py
@@ -1,0 +1,99 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+
+from vllm.distributed.device_communicators import custom_all_reduce
+
+pytestmark = pytest.mark.skip_global_cleanup
+
+
+def _patch_allocator_settings(monkeypatch: pytest.MonkeyPatch) -> list[str]:
+    settings: list[str] = []
+    monkeypatch.setattr(custom_all_reduce.current_platform, "is_cuda", lambda: True)
+    monkeypatch.setattr(
+        custom_all_reduce.torch.cuda.memory,
+        "_set_allocator_settings",
+        settings.append,
+    )
+    return settings
+
+
+def test_cuda_ipc_capture_temporarily_disables_expandable_segments(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(
+        "PYTORCH_CUDA_ALLOC_CONF",
+        "max_split_size_mb:512,expandable_segments:True",
+    )
+    settings = _patch_allocator_settings(monkeypatch)
+
+    with custom_all_reduce._disable_expandable_segments_for_cuda_ipc(True):
+        assert settings == ["expandable_segments:False"]
+
+    assert settings == ["expandable_segments:False", "expandable_segments:True"]
+
+
+def test_cuda_ipc_capture_restores_allocator_after_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("PYTORCH_CUDA_ALLOC_CONF", "expandable_segments:True")
+    settings = _patch_allocator_settings(monkeypatch)
+
+    with (
+        pytest.raises(RuntimeError, match="capture failed"),
+        custom_all_reduce._disable_expandable_segments_for_cuda_ipc(True),
+    ):
+        raise RuntimeError("capture failed")
+
+    assert settings == ["expandable_segments:False", "expandable_segments:True"]
+
+
+def test_custom_allreduce_registers_graph_buffers_before_allocator_restore(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("PYTORCH_CUDA_ALLOC_CONF", "expandable_segments:True")
+    settings = _patch_allocator_settings(monkeypatch)
+    communicator = object.__new__(custom_all_reduce.CustomAllreduce)
+    communicator.disabled = False
+    communicator._IS_CAPTURING = False
+    communicator._ptr = None
+    registration_state: list[tuple[list[str], bool]] = []
+
+    def register_graph_buffers() -> None:
+        registration_state.append((list(settings), communicator._IS_CAPTURING))
+
+    monkeypatch.setattr(
+        communicator,
+        "register_graph_buffers",
+        register_graph_buffers,
+    )
+
+    with communicator.capture():
+        assert communicator._IS_CAPTURING
+        assert settings == ["expandable_segments:False"]
+
+    assert registration_state == [(["expandable_segments:False"], False)]
+    assert settings == ["expandable_segments:False", "expandable_segments:True"]
+
+
+@pytest.mark.parametrize(
+    ("active", "allocator_conf"),
+    [
+        (False, "expandable_segments:True"),
+        (True, "expandable_segments:False"),
+        (True, ""),
+    ],
+)
+def test_cuda_ipc_capture_allocator_guard_is_otherwise_a_noop(
+    monkeypatch: pytest.MonkeyPatch,
+    active: bool,
+    allocator_conf: str,
+) -> None:
+    monkeypatch.setenv("PYTORCH_CUDA_ALLOC_CONF", allocator_conf)
+    settings = _patch_allocator_settings(monkeypatch)
+
+    with custom_all_reduce._disable_expandable_segments_for_cuda_ipc(active):
+        pass
+
+    assert settings == []

--- a/vllm/distributed/device_communicators/custom_all_reduce.py
+++ b/vllm/distributed/device_communicators/custom_all_reduce.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import os
 from contextlib import contextmanager
 from typing import cast
 
@@ -28,6 +29,34 @@ except Exception:
 logger = init_logger(__name__)
 
 _SM70_TP8_HIERARCHICAL_ELEMENTS = 4096
+
+
+@contextmanager
+def _disable_expandable_segments_for_cuda_ipc(active: bool):
+    """Keep CUDA-IPC graph buffers on cudaMalloc-backed allocations.
+
+    ``cudaIpcGetMemHandle`` cannot export CUDA VMM allocations created when
+    ``PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True`` is active. Custom
+    all-reduce exports graph buffers through that legacy IPC API, so disable
+    expandable segments for the complete capture and registration window.
+    """
+    allocator_conf = os.environ.get("PYTORCH_CUDA_ALLOC_CONF", "")
+    should_disable = (
+        active
+        and current_platform.is_cuda()
+        and "expandable_segments:True" in allocator_conf
+    )
+    if should_disable:
+        logger.info_once(
+            "Temporarily disabling expandable_segments during custom allreduce "
+            "CUDA graph capture for CUDA IPC compatibility."
+        )
+        torch.cuda.memory._set_allocator_settings("expandable_segments:False")
+    try:
+        yield
+    finally:
+        if should_disable:
+            torch.cuda.memory._set_allocator_settings("expandable_segments:True")
 
 
 def _sm70_tp8_hierarchical_peer_ranks(rank: int) -> tuple[int, ...]:
@@ -304,13 +333,14 @@ class CustomAllreduce:
         `register_graph_buffers` call at the end of the context.
         It records all the buffer addresses used in the CUDA graph.
         """
-        try:
-            self._IS_CAPTURING = True
-            yield
-        finally:
-            self._IS_CAPTURING = False
-            if not self.disabled:
-                self.register_graph_buffers()
+        with _disable_expandable_segments_for_cuda_ipc(not self.disabled):
+            try:
+                self._IS_CAPTURING = True
+                yield
+            finally:
+                self._IS_CAPTURING = False
+                if not self.disabled:
+                    self.register_graph_buffers()
 
     def register_graph_buffers(self):
         handle, offset = ops.get_graph_buffer_ipc_meta(self._ptr)

--- a/vllm/distributed/device_communicators/custom_all_reduce.py
+++ b/vllm/distributed/device_communicators/custom_all_reduce.py
@@ -5,6 +5,7 @@ import os
 from contextlib import contextmanager
 from typing import cast
 
+import regex as re
 import torch
 import torch.distributed as dist
 from torch.distributed import ProcessGroup
@@ -29,6 +30,21 @@ except Exception:
 logger = init_logger(__name__)
 
 _SM70_TP8_HIERARCHICAL_ELEMENTS = 4096
+_EXPANDABLE_SEGMENTS_TRUE_PATTERN = re.compile(
+    r"((?:^|,)\s*expandable_segments\s*:\s*)True(?=\s*(?:,|$))"
+)
+
+
+def _get_effective_allocator_conf() -> str:
+    """Return the allocator config selected by PyTorch on CUDA.
+
+    PyTorch 2.10 prefers the legacy CUDA-specific variable whenever it is
+    present, even when its value is empty, and otherwise falls back to the
+    unified accelerator variable.
+    """
+    if "PYTORCH_CUDA_ALLOC_CONF" in os.environ:
+        return os.environ["PYTORCH_CUDA_ALLOC_CONF"]
+    return os.environ.get("PYTORCH_ALLOC_CONF", "")
 
 
 @contextmanager
@@ -36,27 +52,27 @@ def _disable_expandable_segments_for_cuda_ipc(active: bool):
     """Keep CUDA-IPC graph buffers on cudaMalloc-backed allocations.
 
     ``cudaIpcGetMemHandle`` cannot export CUDA VMM allocations created when
-    ``PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True`` is active. Custom
-    all-reduce exports graph buffers through that legacy IPC API, so disable
-    expandable segments for the complete capture and registration window.
+    ``expandable_segments:True`` is active through either supported allocator
+    environment variable. Custom all-reduce exports graph buffers through that
+    legacy IPC API, so disable expandable segments for the complete capture
+    and registration window while preserving every other allocator option.
     """
-    allocator_conf = os.environ.get("PYTORCH_CUDA_ALLOC_CONF", "")
-    should_disable = (
-        active
-        and current_platform.is_cuda()
-        and "expandable_segments:True" in allocator_conf
+    allocator_conf = _get_effective_allocator_conf()
+    disabled_conf, replacements = _EXPANDABLE_SEGMENTS_TRUE_PATTERN.subn(
+        r"\1False", allocator_conf
     )
+    should_disable = active and current_platform.is_cuda() and replacements > 0
     if should_disable:
         logger.info_once(
             "Temporarily disabling expandable_segments during custom allreduce "
             "CUDA graph capture for CUDA IPC compatibility."
         )
-        torch.cuda.memory._set_allocator_settings("expandable_segments:False")
+        torch.cuda.memory._set_allocator_settings(disabled_conf)
     try:
         yield
     finally:
         if should_disable:
-            torch.cuda.memory._set_allocator_settings("expandable_segments:True")
+            torch.cuda.memory._set_allocator_settings(allocator_conf)
 
 
 def _sm70_tp8_hierarchical_peer_ranks(rank: int) -> tuple[int, ...]:


### PR DESCRIPTION
## Purpose

Backport and harden the capture-scoped allocator guard from vllm-project/vllm#43923 so 1Cat custom all-reduce can capture CUDA Graph buffers when either supported PyTorch allocator variable enables expandable segments.

Custom all-reduce exports graph buffers with legacy `cudaIpcGetMemHandle`. CUDA VMM allocations created by expandable segments cannot be exported through that API, so graph-buffer registration otherwise fails with `invalid argument`. The guard temporarily disables expandable segments for the complete capture and registration window, then restores the full effective allocator configuration.

## Scope

- one runtime implementation file;
- one CPU-runnable focused test file;
- no SM70-only dispatch, model, quantization, attention, or native-kernel change;
- disabled custom all-reduce and configurations without an effective `expandable_segments:True` remain no-ops.

The implementation follows PyTorch 2.10 precedence: a present `PYTORCH_CUDA_ALLOC_CONF` wins, including an empty value; otherwise it falls back to `PYTORCH_ALLOC_CONF`. It changes only the `expandable_segments` token in the selected full configuration, preserving and restoring options such as `max_split_size_mb`, `roundup_power2_divisions`, and `garbage_collection_threshold`.

## Duplicate-work and provenance

This started as an explicit 1Cat backport of the still-open vLLM PR #43923, not a competing implementation. Review on this PR identified two correctness gaps in the original patch: lossy partial allocator updates and missing unified-variable support. The follow-up commit fixes both locally. No open 1Cat PR covers this path. The original author remains co-author of the backport commit.

1Cat #248 concerns VMM-safe native CPU KV offload and does not cover custom all-reduce CUDA IPC graph buffers.

## Tests

- focused pytest: 12 passed;
- changed-file pre-commit hooks: all passed, including Ruff, mypy, SPDX, forbidden-import, and CUDA-API checks;
- `git diff --check`: passed.

The tests cover full mixed-config state preservation, legacy/unified variable selection and precedence, bracketed allocator syntax, normal and exceptional restoration, graph-buffer registration ordering, and inactive/no-option no-op behavior. One stateful test models PyTorch `parseArgs` resetting omitted allocator fields, rather than only checking setter call strings.

## PyTorch 2.10 / V100 validation

Fresh isolated validation used 2 x Tesla V100 PCIe 32 GB and `torch==2.10.0+cu128` without changing a service or production route.

- Mixed legacy config snapshot: `max_split_size_mb:512`, `roundup_power2_divisions:4`, and `garbage_collection_threshold:0.8` remained unchanged while expandable segments toggled `True -> False -> True`; the complete post-context allocator snapshot equaled the pre-context snapshot.
- Unified-only `PYTORCH_ALLOC_CONF` snapshot: the same `True -> False -> True` transition and exact post-context restoration passed.
- TP2 custom all-reduce CUDA Graph register/replay passed on both ranks with the mixed legacy config. `CUSTOM` was selected, each rank registered its graph address, output matched the expected all-reduce result, and allocator state was exactly restored.
- The same TP2 graph gate also passed with unified-only `PYTORCH_ALLOC_CONF`.

Historical full-service evidence for the same capture mechanism remains:

- Before the guard, both the fork runtime and a base runtime failed during graph-buffer registration with `custom_all_reduce.cuh invalid argument`.
- With the guard, both ranks registered 848 graph addresses, CUDA Graph capture completed, and the service returned the expected deterministic output.
- AWQ and FP8, each with MTP off and K4, completed the TP2 portion of a 40-cell 8K-to-256K matrix.
- In one fixed AWQ/MTP2/concurrency-4 hot A/B, CUSTOM reached 211.07 aggregate tok/s versus 188.15 for PYNCCL-only, +12.2%. This is configuration-specific evidence, not a universal throughput claim.

The PR is ready after the requested changes and latest-main source audit. The fresh gate above is a focused allocator/custom-all-reduce test, not a new current-main full-model serving matrix.

## AI assistance

AI assistance was used for isolation, focused tests, validation review, and drafting. Leon reviewed the design and authorized the follow-up implementation; he remains responsible for understanding and defending the change before it is marked ready again.

## Latest-main audit

- Replayed unchanged onto `main` `7bee39776`; both commits retain the original author/co-author credits and DCO sign-offs.
- Confirmed the still-open upstream vLLM #43923 root cause and compared its patch; this version additionally preserves the complete selected allocator configuration and supports the PyTorch 2.10 unified variable.
- Confirmed PyTorch 2.10 CUDA allocator environment precedence from its installed/source header implementation.
- CPU-focused allocator/capture suite: 12 passed. All changed-file pre-commit hooks and `git diff --check` passed.
- No model, checkpoint, architecture, quantization, attention, or kernel selector is introduced.