### PR TITLE
[Bugfix][SM70] Align speculative GDN beta precision

### DIFF
--- a/benchmarks/benchmark_sm70_gdn_exactness.py
+++ b/benchmarks/benchmark_sm70_gdn_exactness.py
@@ -165,12 +165,15 @@ def _make_inputs(args: argparse.Namespace) -> dict[str, torch.Tensor]:
         )
         * args.input_scale
     ).to(dtype)
-    g = -torch.rand(
-        (args.batch, args.seqlen, args.v_heads),
-        device=device,
-        dtype=torch.float32,
-        generator=generator,
-    ) * args.gate_scale
+    g = (
+        -torch.rand(
+            (args.batch, args.seqlen, args.v_heads),
+            device=device,
+            dtype=torch.float32,
+            generator=generator,
+        )
+        * args.gate_scale
+    )
     beta = torch.sigmoid(
         torch.randn(
             (args.batch, args.seqlen, args.v_heads),
@@ -211,9 +214,7 @@ def _make_inputs(args: argparse.Namespace) -> dict[str, torch.Tensor]:
         "initial_state": initial_state.cpu(),
     }
     if args.cu_seqlens:
-        result["cu_seqlens"] = torch.tensor(
-            [0, args.seqlen], dtype=torch.int32
-        )
+        result["cu_seqlens"] = torch.tensor([0, args.seqlen], dtype=torch.int32)
     return result
 
 
@@ -565,25 +566,17 @@ def _make_spec_decode_cudagraph_inputs(
     max_query_len = args.num_spec + 1
     graph_rows = args.graph_rows or max_query_len
     if graph_rows < max_query_len:
-        raise ValueError(
-            f"--graph-rows must be >= num_spec + 1 ({max_query_len})"
-        )
+        raise ValueError(f"--graph-rows must be >= num_spec + 1 ({max_query_len})")
     if args.state_slots < max_query_len:
-        raise ValueError(
-            f"--state-slots must be >= num_spec + 1 ({max_query_len})"
-        )
+        raise ValueError(f"--state-slots must be >= num_spec + 1 ({max_query_len})")
     if args.fixed_query_len is not None and not (
         1 <= args.fixed_query_len <= max_query_len
     ):
-        raise ValueError(
-            f"--fixed-query-len must be in [1, {max_query_len}]"
-        )
+        raise ValueError(f"--fixed-query-len must be in [1, {max_query_len}]")
     if args.fixed_accepted is not None and not (
         1 <= args.fixed_accepted <= max_query_len
     ):
-        raise ValueError(
-            f"--fixed-accepted must be in [1, {max_query_len}]"
-        )
+        raise ValueError(f"--fixed-accepted must be in [1, {max_query_len}]")
 
     q_dim = args.k_heads * args.head_k_dim
     k_dim = args.k_heads * args.head_k_dim
@@ -769,7 +762,27 @@ def _load_or_create_spec_decode_cudagraph_inputs(
         payload = _torch_load(Path(args.input_file))
         if "inputs" not in payload:
             raise ValueError(f"{args.input_file} does not contain saved inputs")
-        return payload["inputs"]
+        inputs = payload["inputs"]
+        available_steps = int(inputs["mixed_qkv_seq"].shape[0])
+        if args.steps > available_steps:
+            raise ValueError(
+                f"--steps={args.steps} exceeds the {available_steps} saved steps"
+            )
+        if args.steps < available_steps:
+            inputs = dict(inputs)
+            for name in (
+                "mixed_qkv_seq",
+                "a_seq",
+                "b_seq",
+                "query_start_loc_seq",
+                "state_indices_seq",
+                "num_accepted_tokens_seq",
+                "query_lens",
+                "z_seq",
+            ):
+                if name in inputs:
+                    inputs[name] = inputs[name][: args.steps].contiguous()
+        return inputs
     return _make_spec_decode_cudagraph_inputs(args)
 
 
@@ -852,13 +865,7 @@ def _add_spec_projection_inputs(
 def _load_or_create_spec_projection_inputs(
     args: argparse.Namespace,
 ) -> dict[str, torch.Tensor]:
-    if args.input_file:
-        payload = _torch_load(Path(args.input_file))
-        if "inputs" not in payload:
-            raise ValueError(f"{args.input_file} does not contain saved inputs")
-        inputs = payload["inputs"]
-    else:
-        inputs = _make_spec_decode_cudagraph_inputs(args)
+    inputs = _load_or_create_spec_decode_cudagraph_inputs(args)
     return _add_spec_projection_inputs(args, inputs)
 
 
@@ -906,12 +913,14 @@ def _make_sigmoid_gating_inputs(args: argparse.Namespace) -> dict[str, torch.Ten
         )
         * args.gate_scale
     )
-    inputs.update({
-        "a": a.cpu(),
-        "b": b.cpu(),
-        "A_log": a_log.cpu(),
-        "dt_bias": dt_bias.cpu(),
-    })
+    inputs.update(
+        {
+            "a": a.cpu(),
+            "b": b.cpu(),
+            "A_log": a_log.cpu(),
+            "dt_bias": dt_bias.cpu(),
+        }
+    )
     if getattr(args, "decode_segments", False):
         if args.batch != 1:
             raise ValueError("decode-segments fixture requires --batch 1")
@@ -937,9 +946,7 @@ def _make_sigmoid_gating_inputs(args: argparse.Namespace) -> dict[str, torch.Ten
                 dtype=state_dtype,
             )
         inputs["initial_state"] = initial_state.cpu()
-        inputs["cu_seqlens"] = torch.arange(
-            0, args.seqlen + 1, dtype=torch.int32
-        )
+        inputs["cu_seqlens"] = torch.arange(0, args.seqlen + 1, dtype=torch.int32)
         inputs["ssm_state_indices"] = torch.arange(
             1, args.seqlen + 1, dtype=torch.int32
         )
@@ -1105,9 +1112,7 @@ def run_case(args: argparse.Namespace) -> int:
 
     outputs: dict[str, torch.Tensor | None] = {
         "out": out.detach().cpu(),
-        "final_state": final_state.detach().cpu()
-        if final_state is not None
-        else None,
+        "final_state": final_state.detach().cpu() if final_state is not None else None,
     }
     if args.save_intermediates:
         pipeline_outputs = _run_chunk_pipeline(cuda_inputs, cu_seqlens, scale)
@@ -1161,12 +1166,17 @@ def run_case(args: argparse.Namespace) -> int:
     out_path = Path(args.out)
     out_path.parent.mkdir(parents=True, exist_ok=True)
     torch.save(payload, out_path)
-    print(json.dumps({
-        "out": str(out_path),
-        "elapsed_s": elapsed_s,
-        "timing_summary": payload["timing_summary"],
-        "output_summaries": payload["output_summaries"],
-    }, indent=2))
+    print(
+        json.dumps(
+            {
+                "out": str(out_path),
+                "elapsed_s": elapsed_s,
+                "timing_summary": payload["timing_summary"],
+                "output_summaries": payload["output_summaries"],
+            },
+            indent=2,
+        )
+    )
     return 0
 
 
@@ -1269,12 +1279,17 @@ def run_recurrent_case(args: argparse.Namespace) -> int:
     out_path = Path(args.out)
     out_path.parent.mkdir(parents=True, exist_ok=True)
     torch.save(payload, out_path)
-    print(json.dumps({
-        "out": str(out_path),
-        "elapsed_s": elapsed_s,
-        "timing_summary": payload["timing_summary"],
-        "output_summaries": payload["output_summaries"],
-    }, indent=2))
+    print(
+        json.dumps(
+            {
+                "out": str(out_path),
+                "elapsed_s": elapsed_s,
+                "timing_summary": payload["timing_summary"],
+                "output_summaries": payload["output_summaries"],
+            },
+            indent=2,
+        )
+    )
     return 0
 
 
@@ -1385,12 +1400,17 @@ def run_sigmoid_gating_case(args: argparse.Namespace) -> int:
     out_path = Path(args.out)
     out_path.parent.mkdir(parents=True, exist_ok=True)
     torch.save(payload, out_path)
-    print(json.dumps({
-        "out": str(out_path),
-        "elapsed_s": elapsed_s,
-        "timing_summary": payload["timing_summary"],
-        "output_summaries": payload["output_summaries"],
-    }, indent=2))
+    print(
+        json.dumps(
+            {
+                "out": str(out_path),
+                "elapsed_s": elapsed_s,
+                "timing_summary": payload["timing_summary"],
+                "output_summaries": payload["output_summaries"],
+            },
+            indent=2,
+        )
+    )
     return 0
 
 
@@ -1512,12 +1532,17 @@ def run_sigmoid_gating_mixed_qkv_case(args: argparse.Namespace) -> int:
     out_path = Path(args.out)
     out_path.parent.mkdir(parents=True, exist_ok=True)
     torch.save(payload, out_path)
-    print(json.dumps({
-        "out": str(out_path),
-        "elapsed_s": elapsed_s,
-        "timing_summary": payload["timing_summary"],
-        "output_summaries": payload["output_summaries"],
-    }, indent=2))
+    print(
+        json.dumps(
+            {
+                "out": str(out_path),
+                "elapsed_s": elapsed_s,
+                "timing_summary": payload["timing_summary"],
+                "output_summaries": payload["output_summaries"],
+            },
+            indent=2,
+        )
+    )
     return 0
 
 
@@ -1851,12 +1876,17 @@ def run_packed_recurrent_case(args: argparse.Namespace) -> int:
     out_path = Path(args.out)
     out_path.parent.mkdir(parents=True, exist_ok=True)
     torch.save(payload, out_path)
-    print(json.dumps({
-        "out": str(out_path),
-        "elapsed_s": elapsed_s,
-        "timing_summary": payload["timing_summary"],
-        "output_summaries": payload["output_summaries"],
-    }, indent=2))
+    print(
+        json.dumps(
+            {
+                "out": str(out_path),
+                "elapsed_s": elapsed_s,
+                "timing_summary": payload["timing_summary"],
+                "output_summaries": payload["output_summaries"],
+            },
+            indent=2,
+        )
+    )
     return 0
 
 
@@ -1947,9 +1977,7 @@ def run_flashqla_decode_case(args: argparse.Namespace) -> int:
         "metadata": _metadata(args),
         "config": {
             "op": "flashqla_sm70_gdn_decode_full_route",
-            "route_components": (
-                "fused_mixed_qkv+gating+l2norm+global_state_update"
-            ),
+            "route_components": ("fused_mixed_qkv+gating+l2norm+global_state_update"),
             "batch": args.batch,
             "k_heads": args.k_heads,
             "v_heads": args.v_heads,
@@ -1984,12 +2012,17 @@ def run_flashqla_decode_case(args: argparse.Namespace) -> int:
     out_path = Path(args.out)
     out_path.parent.mkdir(parents=True, exist_ok=True)
     torch.save(payload, out_path)
-    print(json.dumps({
-        "out": str(out_path),
-        "elapsed_s": elapsed_s,
-        "timing_summary": payload["timing_summary"],
-        "output_summaries": payload["output_summaries"],
-    }, indent=2))
+    print(
+        json.dumps(
+            {
+                "out": str(out_path),
+                "elapsed_s": elapsed_s,
+                "timing_summary": payload["timing_summary"],
+                "output_summaries": payload["output_summaries"],
+            },
+            indent=2,
+        )
+    )
     return 0
 
 
@@ -2116,13 +2149,10 @@ def run_packed_recurrent_cudagraph_case(args: argparse.Namespace) -> int:
     }
     comparisons = {
         "out": _compare_tensor(outputs["eager_out"], outputs["graph_out"]),
-        "final_state": _compare_tensor(
-            outputs["eager_state"], outputs["graph_state"]
-        ),
+        "final_state": _compare_tensor(outputs["eager_state"], outputs["graph_state"]),
     }
     strict_ok = all(
-        item["torch_equal"] and item["max_diff"] == 0.0
-        for item in comparisons.values()
+        item["torch_equal"] and item["max_diff"] == 0.0 for item in comparisons.values()
     )
     saved_inputs = {name: tensor.cpu() for name, tensor in inputs.items()}
     payload = {
@@ -2160,12 +2190,17 @@ def run_packed_recurrent_cudagraph_case(args: argparse.Namespace) -> int:
     out_path = Path(args.out)
     out_path.parent.mkdir(parents=True, exist_ok=True)
     torch.save(payload, out_path)
-    print(json.dumps({
-        "out": str(out_path),
-        "strict_ok": strict_ok,
-        "elapsed_s": elapsed_s,
-        "comparisons": comparisons,
-    }, indent=2))
+    print(
+        json.dumps(
+            {
+                "out": str(out_path),
+                "strict_ok": strict_ok,
+                "elapsed_s": elapsed_s,
+                "comparisons": comparisons,
+            },
+            indent=2,
+        )
+    )
     return 0 if strict_ok else 1
 
 
@@ -2247,13 +2282,10 @@ def run_conv_update_cudagraph_case(args: argparse.Namespace) -> int:
     }
     comparisons = {
         "out": _compare_tensor(outputs["eager_out"], outputs["graph_out"]),
-        "final_state": _compare_tensor(
-            outputs["eager_state"], outputs["graph_state"]
-        ),
+        "final_state": _compare_tensor(outputs["eager_state"], outputs["graph_state"]),
     }
     strict_ok = all(
-        item["torch_equal"] and item["max_diff"] == 0.0
-        for item in comparisons.values()
+        item["torch_equal"] and item["max_diff"] == 0.0 for item in comparisons.values()
     )
     saved_inputs = {name: tensor.cpu() for name, tensor in inputs.items()}
     payload = {
@@ -2288,12 +2320,17 @@ def run_conv_update_cudagraph_case(args: argparse.Namespace) -> int:
     out_path = Path(args.out)
     out_path.parent.mkdir(parents=True, exist_ok=True)
     torch.save(payload, out_path)
-    print(json.dumps({
-        "out": str(out_path),
-        "strict_ok": strict_ok,
-        "elapsed_s": elapsed_s,
-        "comparisons": comparisons,
-    }, indent=2))
+    print(
+        json.dumps(
+            {
+                "out": str(out_path),
+                "strict_ok": strict_ok,
+                "elapsed_s": elapsed_s,
+                "comparisons": comparisons,
+            },
+            indent=2,
+        )
+    )
     return 0 if strict_ok else 1
 
 
@@ -2364,6 +2401,9 @@ def run_spec_decode_cudagraph_case(args: argparse.Namespace) -> int:
             a,
             b,
             cuda_inputs["dt_bias"],
+            beta_dtype=(
+                torch.float32 if args.beta_output_dtype == "float32" else b.dtype
+            ),
         )
         core_out, _ = fused_recurrent_gated_delta_rule(
             q=query,
@@ -2471,8 +2511,7 @@ def run_spec_decode_cudagraph_case(args: argparse.Namespace) -> int:
 
     query_lens = inputs["query_lens"].to(torch.int64)
     live_token_mask = (
-        torch.arange(max_query_len, dtype=torch.int64)[None, :]
-        < query_lens[:, None]
+        torch.arange(max_query_len, dtype=torch.int64)[None, :] < query_lens[:, None]
     )
     outputs: dict[str, torch.Tensor | None] = {
         "eager_live_out": eager_out.detach().cpu()[live_token_mask],
@@ -2529,6 +2568,7 @@ def run_spec_decode_cudagraph_case(args: argparse.Namespace) -> int:
             "conv_width": args.conv_width,
             "dtype": args.dtype,
             "state_dtype": args.state_dtype,
+            "beta_output_dtype": args.beta_output_dtype,
             "seed": args.seed,
             "scale": scale,
             "silu": args.silu,
@@ -2557,13 +2597,18 @@ def run_spec_decode_cudagraph_case(args: argparse.Namespace) -> int:
     out_path = Path(args.out)
     out_path.parent.mkdir(parents=True, exist_ok=True)
     torch.save(payload, out_path)
-    print(json.dumps({
-        "out": str(out_path),
-        "strict_ok": strict_ok,
-        "elapsed_s": elapsed_s,
-        "config": payload["config"],
-        "comparisons": comparisons,
-    }, indent=2))
+    print(
+        json.dumps(
+            {
+                "out": str(out_path),
+                "strict_ok": strict_ok,
+                "elapsed_s": elapsed_s,
+                "config": payload["config"],
+                "comparisons": comparisons,
+            },
+            indent=2,
+        )
+    )
     return 0 if strict_ok else 1
 
 
@@ -2650,6 +2695,9 @@ def run_spec_mixed_qkv_candidate_case(args: argparse.Namespace) -> int:
             a,
             b,
             cuda_inputs["dt_bias"],
+            beta_dtype=(
+                torch.float32 if args.beta_output_dtype == "float32" else b.dtype
+            ),
         )
         core_out, _ = fused_recurrent_gated_delta_rule(
             q=query,
@@ -2704,7 +2752,9 @@ def run_spec_mixed_qkv_candidate_case(args: argparse.Namespace) -> int:
         )
         out.copy_(core_out.squeeze(0))
 
-    def run_eager_sequence(launch_fn: Any) -> tuple[
+    def run_eager_sequence(
+        launch_fn: Any,
+    ) -> tuple[
         torch.Tensor,
         torch.Tensor,
         torch.Tensor,
@@ -2804,8 +2854,7 @@ def run_spec_mixed_qkv_candidate_case(args: argparse.Namespace) -> int:
 
     query_lens = inputs["query_lens"].to(torch.int64)
     live_token_mask = (
-        torch.arange(max_query_len, dtype=torch.int64)[None, :]
-        < query_lens[:, None]
+        torch.arange(max_query_len, dtype=torch.int64)[None, :] < query_lens[:, None]
     )
     outputs: dict[str, torch.Tensor] = {
         "split_live_out": split_out.detach().cpu()[live_token_mask],
@@ -2871,6 +2920,7 @@ def run_spec_mixed_qkv_candidate_case(args: argparse.Namespace) -> int:
             "conv_width": args.conv_width,
             "dtype": args.dtype,
             "state_dtype": args.state_dtype,
+            "beta_output_dtype": args.beta_output_dtype,
             "seed": args.seed,
             "scale": scale,
             "silu": args.silu,
@@ -2898,13 +2948,18 @@ def run_spec_mixed_qkv_candidate_case(args: argparse.Namespace) -> int:
     out_path = Path(args.out)
     out_path.parent.mkdir(parents=True, exist_ok=True)
     torch.save(payload, out_path)
-    print(json.dumps({
-        "out": str(out_path),
-        "strict_ok": strict_ok,
-        "timing": timing,
-        "config": payload["config"],
-        "comparisons": comparisons,
-    }, indent=2))
+    print(
+        json.dumps(
+            {
+                "out": str(out_path),
+                "strict_ok": strict_ok,
+                "timing": timing,
+                "config": payload["config"],
+                "comparisons": comparisons,
+            },
+            indent=2,
+        )
+    )
     return 0 if strict_ok else 1
 
 
@@ -3169,8 +3224,7 @@ def run_spec_commit_vs_standard_case(args: argparse.Namespace) -> int:
 
     query_lens = inputs["query_lens"].to(torch.int64)
     live_token_mask = (
-        torch.arange(max_query_len, dtype=torch.int64)[None, :]
-        < query_lens[:, None]
+        torch.arange(max_query_len, dtype=torch.int64)[None, :] < query_lens[:, None]
     )
     outputs: dict[str, torch.Tensor | None] = {
         "standard_live_out": standard_out.detach().cpu()[live_token_mask],
@@ -3286,13 +3340,18 @@ def run_spec_commit_vs_standard_case(args: argparse.Namespace) -> int:
     out_path = Path(args.out)
     out_path.parent.mkdir(parents=True, exist_ok=True)
     torch.save(payload, out_path)
-    print(json.dumps({
-        "out": str(out_path),
-        "strict_ok": strict_ok,
-        "elapsed_s": elapsed_s,
-        "config": payload["config"],
-        "comparisons": comparisons,
-    }, indent=2))
+    print(
+        json.dumps(
+            {
+                "out": str(out_path),
+                "strict_ok": strict_ok,
+                "elapsed_s": elapsed_s,
+                "config": payload["config"],
+                "comparisons": comparisons,
+            },
+            indent=2,
+        )
+    )
     return 0 if strict_ok else 1
 
 
@@ -3796,8 +3855,7 @@ def run_spec_commit_projection_case(args: argparse.Namespace) -> int:
 
     query_lens = inputs["query_lens"].to(torch.int64)
     live_token_mask = (
-        torch.arange(max_query_len, dtype=torch.int64)[None, :]
-        < query_lens[:, None]
+        torch.arange(max_query_len, dtype=torch.int64)[None, :] < query_lens[:, None]
     )
     outputs: dict[str, torch.Tensor | None] = {
         "standard_live_output": standard_output.detach().cpu()[live_token_mask],
@@ -3986,12 +4044,15 @@ def run_spec_commit_projection_case(args: argparse.Namespace) -> int:
                 "direct_compile_ssm_state",
             ]
         )
-    strict_ok = all(
-        comparisons[name] is not None
-        and comparisons[name]["torch_equal"]
-        and comparisons[name]["max_diff"] == 0.0
-        for name in strict_keys
-    ) and compile_step_error is None
+    strict_ok = (
+        all(
+            comparisons[name] is not None
+            and comparisons[name]["torch_equal"]
+            and comparisons[name]["max_diff"] == 0.0
+            for name in strict_keys
+        )
+        and compile_step_error is None
+    )
     accepted_hist = torch.bincount(
         inputs["num_accepted_tokens_seq"][:, 0].to(torch.int64),
         minlength=max_query_len + 1,
@@ -4050,13 +4111,18 @@ def run_spec_commit_projection_case(args: argparse.Namespace) -> int:
     out_path = Path(args.out)
     out_path.parent.mkdir(parents=True, exist_ok=True)
     torch.save(payload, out_path)
-    print(json.dumps({
-        "out": str(out_path),
-        "strict_ok": strict_ok,
-        "elapsed_s": elapsed_s,
-        "config": payload["config"],
-        "comparisons": comparisons,
-    }, indent=2))
+    print(
+        json.dumps(
+            {
+                "out": str(out_path),
+                "strict_ok": strict_ok,
+                "elapsed_s": elapsed_s,
+                "config": payload["config"],
+                "comparisons": comparisons,
+            },
+            indent=2,
+        )
+    )
     return 0 if strict_ok else 1
 
 
@@ -4231,9 +4297,7 @@ def make_parser() -> argparse.ArgumentParser:
     sigmoid.add_argument("--v-heads", type=int, default=8)
     sigmoid.add_argument("--head-k-dim", type=int, default=128)
     sigmoid.add_argument("--head-v-dim", type=int, default=128)
-    sigmoid.add_argument(
-        "--dtype", choices=("float16", "bfloat16"), default="float16"
-    )
+    sigmoid.add_argument("--dtype", choices=("float16", "bfloat16"), default="float16")
     sigmoid.add_argument(
         "--state-dtype",
         choices=("same", "float16", "bfloat16", "float32"),
@@ -4294,9 +4358,7 @@ def make_parser() -> argparse.ArgumentParser:
     model_mixed = subparsers.add_parser("run-model-mixed-qkv-route")
     model_mixed.add_argument("--out", required=True)
     model_mixed.add_argument("--input-file")
-    model_mixed.add_argument(
-        "--case-name", default="gdn_model_mixed_qkv_route_smoke"
-    )
+    model_mixed.add_argument("--case-name", default="gdn_model_mixed_qkv_route_smoke")
     model_mixed.add_argument("--batch", type=int, default=1)
     model_mixed.add_argument("--seqlen", type=int, default=16)
     model_mixed.add_argument("--k-heads", type=int, default=4)
@@ -4414,16 +4476,12 @@ def make_parser() -> argparse.ArgumentParser:
     )
     packed_cg.add_argument("--random-initial-state", action="store_true")
     packed_cg.add_argument("--capture-null-indices", action="store_true")
-    packed_cg.set_defaults(
-        func=run_packed_recurrent_cudagraph_case, l2norm_inputs=True
-    )
+    packed_cg.set_defaults(func=run_packed_recurrent_cudagraph_case, l2norm_inputs=True)
 
     conv_cg = subparsers.add_parser("run-conv-update-cudagraph")
     conv_cg.add_argument("--out", required=True)
     conv_cg.add_argument("--input-file")
-    conv_cg.add_argument(
-        "--case-name", default="gdn_conv_update_cudagraph_exactness"
-    )
+    conv_cg.add_argument("--case-name", default="gdn_conv_update_cudagraph_exactness")
     conv_cg.add_argument("--batch", type=int, default=2)
     conv_cg.add_argument("--seqlen", type=int, default=1024)
     conv_cg.add_argument("--k-heads", type=int, default=4)
@@ -4448,9 +4506,7 @@ def make_parser() -> argparse.ArgumentParser:
     spec_cg = subparsers.add_parser("run-spec-decode-cudagraph")
     spec_cg.add_argument("--out", required=True)
     spec_cg.add_argument("--input-file")
-    spec_cg.add_argument(
-        "--case-name", default="gdn_spec_decode_cudagraph_exactness"
-    )
+    spec_cg.add_argument("--case-name", default="gdn_spec_decode_cudagraph_exactness")
     spec_cg.add_argument("--steps", type=int, default=512)
     spec_cg.add_argument("--num-spec", type=int, default=4)
     spec_cg.add_argument("--graph-rows", type=int)
@@ -4462,6 +4518,12 @@ def make_parser() -> argparse.ArgumentParser:
     spec_cg.add_argument("--head-v-dim", type=int, default=128)
     spec_cg.add_argument("--conv-width", type=int, default=4)
     spec_cg.add_argument("--dtype", choices=("float16", "bfloat16"), default="float16")
+    spec_cg.add_argument(
+        "--beta-output-dtype",
+        choices=("input", "float32"),
+        default="float32",
+        help="Materialize split-verifier beta in the input dtype or FP32.",
+    )
     spec_cg.add_argument(
         "--state-dtype",
         choices=("same", "float16", "bfloat16", "float32"),
@@ -4489,9 +4551,7 @@ def make_parser() -> argparse.ArgumentParser:
     spec_mixed = subparsers.add_parser("run-spec-mixed-qkv-candidate")
     spec_mixed.add_argument("--out", required=True)
     spec_mixed.add_argument("--input-file")
-    spec_mixed.add_argument(
-        "--case-name", default="gdn_spec_mixed_qkv_candidate"
-    )
+    spec_mixed.add_argument("--case-name", default="gdn_spec_mixed_qkv_candidate")
     spec_mixed.add_argument("--steps", type=int, default=512)
     spec_mixed.add_argument("--num-spec", type=int, default=4)
     spec_mixed.add_argument("--graph-rows", type=int)
@@ -4504,6 +4564,12 @@ def make_parser() -> argparse.ArgumentParser:
     spec_mixed.add_argument("--conv-width", type=int, default=4)
     spec_mixed.add_argument(
         "--dtype", choices=("float16", "bfloat16"), default="float16"
+    )
+    spec_mixed.add_argument(
+        "--beta-output-dtype",
+        choices=("input", "float32"),
+        default="float32",
+        help="Materialize split-verifier beta in the input dtype or FP32.",
     )
     spec_mixed.add_argument(
         "--state-dtype",
@@ -4532,9 +4598,7 @@ def make_parser() -> argparse.ArgumentParser:
     spec_op = subparsers.add_parser("run-spec-commit-vs-standard")
     spec_op.add_argument("--out", required=True)
     spec_op.add_argument("--input-file")
-    spec_op.add_argument(
-        "--case-name", default="gdn_spec_commit_vs_standard_exactness"
-    )
+    spec_op.add_argument("--case-name", default="gdn_spec_commit_vs_standard_exactness")
     spec_op.add_argument("--steps", type=int, default=512)
     spec_op.add_argument("--num-spec", type=int, default=4)
     spec_op.add_argument("--graph-rows", type=int)

--- a/tests/kernels/test_fused_sigmoid_gating_delta_rule.py
+++ b/tests/kernels/test_fused_sigmoid_gating_delta_rule.py
@@ -7,12 +7,159 @@ import torch.nn.functional as F
 
 from vllm.model_executor.layers.fla.ops import (
     fused_recurrent_gated_delta_rule,
+    fused_recurrent_gated_delta_rule_packed_decode,
     fused_sigmoid_gating_delta_rule_update,
+)
+from vllm.model_executor.layers.mamba.gdn.qwen_gdn_linear_attn import (
+    fused_gdn_gating,
 )
 from vllm.platforms import current_platform
 from vllm.utils.torch_utils import set_random_seed
 
 DEVICE = current_platform.device_type
+
+
+def _bitwise_diff_stats(
+    actual: torch.Tensor,
+    expected: torch.Tensor,
+) -> tuple[int, float, float]:
+    diff = actual.float() - expected.float()
+    return (
+        torch.count_nonzero(actual != expected).item(),
+        diff.abs().max().item(),
+        diff.abs().mean().item(),
+    )
+
+
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+def test_split_verify_matches_fused_decode_beta_semantics(
+    dtype: torch.dtype,
+) -> None:
+    torch.set_default_device(DEVICE)
+    if dtype is torch.bfloat16 and not torch.cuda.is_bf16_supported():
+        pytest.skip("BF16 requires a supported accelerator")
+    set_random_seed(0)
+
+    # Qwen3.8-27B TP4 per-rank head geometry (16 QK heads, 48 V heads).
+    num_qk_heads = 4
+    num_v_heads = 12
+    head_dim = 128
+    scale = head_dim**-0.5
+    # Make the decay exactly zero in both kernels so this regression isolates
+    # beta materialization instead of also measuring unrelated fused/split
+    # decay rounding. softplus(-100) rounds to zero in the kernel.
+    A_log = torch.zeros(num_v_heads, dtype=torch.float32)
+    dt_bias = torch.zeros(num_v_heads, dtype=dtype)
+    a = torch.full((1, num_v_heads), -100, dtype=dtype)
+    # sigmoid(-0.5) is not exactly representable in FP16 or BF16, exposing
+    # whether the split verifier keeps the fused decode FP32 beta semantics.
+    b = torch.full((1, num_v_heads), -0.5, dtype=dtype)
+    query = torch.rand(1, 1, num_qk_heads, head_dim, dtype=dtype)
+    key = torch.rand_like(query)
+    value = torch.rand(1, 1, num_v_heads, head_dim, dtype=dtype)
+    # A zero state also removes decay and dot-product reduction-order effects
+    # from this one-step comparison. The state transition then differs only
+    # through the materialized beta value.
+    initial_state = torch.zeros(
+        1,
+        num_v_heads,
+        head_dim,
+        head_dim,
+        dtype=torch.float32,
+    )
+    state_indices = torch.zeros(1, dtype=torch.int32)
+    cu_seqlens = torch.tensor([0, 1], dtype=torch.int32)
+
+    fused_state = initial_state.clone()
+    fused_output, _ = fused_sigmoid_gating_delta_rule_update(
+        A_log=A_log,
+        a=a,
+        b=b,
+        dt_bias=dt_bias,
+        q=query,
+        k=key,
+        v=value,
+        scale=scale,
+        initial_state=fused_state,
+        inplace_final_state=True,
+        cu_seqlens=cu_seqlens,
+        ssm_state_indices=state_indices,
+        use_qk_l2norm_in_kernel=False,
+    )
+
+    packed_state = initial_state.clone()
+    packed_output = torch.empty_like(fused_output)
+    mixed_qkv = torch.cat(
+        [
+            query.squeeze(0).reshape(1, -1),
+            key.squeeze(0).reshape(1, -1),
+            value.squeeze(0).reshape(1, -1),
+        ],
+        dim=-1,
+    ).contiguous()
+    fused_recurrent_gated_delta_rule_packed_decode(
+        mixed_qkv=mixed_qkv,
+        a=a,
+        b=b,
+        A_log=A_log,
+        dt_bias=dt_bias,
+        scale=scale,
+        initial_state=packed_state,
+        out=packed_output,
+        ssm_state_indices=state_indices,
+        use_qk_l2norm_in_kernel=False,
+    )
+
+    def run_split(
+        beta_dtype: torch.dtype | None,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        g, beta = fused_gdn_gating(
+            A_log,
+            a,
+            b,
+            dt_bias,
+            beta_dtype=beta_dtype,
+        )
+        state = initial_state.clone()
+        output, _ = fused_recurrent_gated_delta_rule(
+            q=query,
+            k=key,
+            v=value,
+            g=g,
+            beta=beta,
+            scale=scale,
+            initial_state=state,
+            inplace_final_state=True,
+            ssm_state_indices=state_indices,
+            cu_seqlens=cu_seqlens,
+            use_qk_l2norm_in_kernel=False,
+        )
+        return output, state, beta
+
+    fixed_output, fixed_state, fixed_beta = run_split(torch.float32)
+    legacy_output, legacy_state, legacy_beta = run_split(None)
+
+    assert fixed_beta.dtype is torch.float32
+    assert legacy_beta.dtype is dtype
+    fixed_output_diff = _bitwise_diff_stats(fixed_output, fused_output)
+    fixed_state_diff = _bitwise_diff_stats(fixed_state, fused_state)
+    legacy_output_diff = _bitwise_diff_stats(legacy_output, fused_output)
+    legacy_state_diff = _bitwise_diff_stats(legacy_state, fused_state)
+    assert torch.equal(packed_output, fused_output), _bitwise_diff_stats(
+        packed_output, fused_output
+    )
+    assert torch.equal(packed_state, fused_state), _bitwise_diff_stats(
+        packed_state, fused_state
+    )
+    assert torch.equal(fixed_output, fused_output), fixed_output_diff
+    assert torch.equal(fixed_state, fused_state), (
+        "fixed",
+        fixed_state_diff,
+        "legacy",
+        legacy_state_diff,
+    )
+    assert legacy_state_diff[0] > 0, legacy_state_diff
+    assert legacy_output_diff[0] > 0, legacy_output_diff
 
 
 @pytest.mark.parametrize("tp_size", [1])

--- a/tests/v1/attention/test_gdn_metadata_builder.py
+++ b/tests/v1/attention/test_gdn_metadata_builder.py
@@ -468,9 +468,7 @@ def test_spec_state_slot_selector_can_differ_from_accepted_count(local_gdn_model
         common_prefix_len=0,
         common_attn_metadata=common,
         num_accepted_tokens=torch.tensor([2], dtype=torch.int32, device=DEVICE),
-        spec_state_slot_selectors=torch.tensor(
-            [4], dtype=torch.int32, device=DEVICE
-        ),
+        spec_state_slot_selectors=torch.tensor([4], dtype=torch.int32, device=DEVICE),
         num_decode_draft_tokens_cpu=torch.tensor([4], dtype=torch.int32, device="cpu"),
     )
 
@@ -749,9 +747,7 @@ def test_gdn_state_contract_debug_assert_rejects_pad_accepted_slot(
             spec_sequence_masks_cpu=torch.tensor(
                 [True], dtype=torch.bool, device="cpu"
             ),
-            num_accepted_tokens=torch.tensor(
-                [5], dtype=torch.int32, device=DEVICE
-            ),
+            num_accepted_tokens=torch.tensor([5], dtype=torch.int32, device=DEVICE),
             current_state_block_ids=None,
             is_mamba_cache_all=False,
         )
@@ -778,9 +774,7 @@ def test_spec_commit_pure_decode_consumes_padded_graph_rows_without_metadata_pat
         num_spec_decodes=2,
         num_spec_decode_tokens=10,
         num_actual_tokens=10,
-        spec_query_start_loc=torch.tensor(
-            [0, 5, 10], dtype=torch.int32, device=DEVICE
-        ),
+        spec_query_start_loc=torch.tensor([0, 5, 10], dtype=torch.int32, device=DEVICE),
         spec_state_indices_tensor=torch.tensor(
             [[10, 11, 12, 13, 14], [20, 21, 22, 23, 24]],
             dtype=torch.int32,
@@ -821,7 +815,6 @@ def test_spec_commit_pure_decode_consumes_padded_graph_rows_without_metadata_pat
     seen: dict[str, object] = {}
 
     class FakeLayer:
-
         def __init__(self) -> None:
             self.conv1d = torch.nn.Identity()
             self.conv1d.weight = torch.empty((8, 1, 1), device=DEVICE)
@@ -862,10 +855,11 @@ def test_spec_commit_pure_decode_consumes_padded_graph_rows_without_metadata_pat
         seen["conv"] = True
         return x + 1
 
-    def fake_gating(a_log, a_tensor, b_tensor, dt_bias):
+    def fake_gating(a_log, a_tensor, b_tensor, dt_bias, *, beta_dtype=None):
         del a_log, dt_bias
         assert a_tensor is a
         assert b_tensor is b
+        assert beta_dtype is torch.float32
         seen["gating"] = True
         return a_tensor + 2, b_tensor + 3
 
@@ -1023,9 +1017,7 @@ def test_sm70_qwen_gdn_blocks_003_spec_core_only_for_deep_native_mtp(
     expected,
 ):
     monkeypatch.setenv("VLLM_SM70_QWEN_GDN_003_SPEC_CORE_OP", "1")
-    monkeypatch.delenv(
-        "VLLM_SM70_QWEN_GDN_003_SPEC_ALLOW_DEEP_MTP", raising=False
-    )
+    monkeypatch.delenv("VLLM_SM70_QWEN_GDN_003_SPEC_ALLOW_DEEP_MTP", raising=False)
     _clear_envs_cache()
 
     vllm_config = SimpleNamespace(
@@ -1036,9 +1028,7 @@ def test_sm70_qwen_gdn_blocks_003_spec_core_only_for_deep_native_mtp(
     )
 
     assert (
-        qwen_gdn._sm70_qwen_gdn_block_003_spec_for_deep_native_mtp(
-            vllm_config
-        )
+        qwen_gdn._sm70_qwen_gdn_block_003_spec_for_deep_native_mtp(vllm_config)
         is expected
     )
 
@@ -1057,9 +1047,7 @@ def test_sm70_qwen_gdn_003_spec_core_deep_mtp_override_is_diagnostic(
         )
     )
 
-    assert not qwen_gdn._sm70_qwen_gdn_block_003_spec_for_deep_native_mtp(
-        vllm_config
-    )
+    assert not qwen_gdn._sm70_qwen_gdn_block_003_spec_for_deep_native_mtp(vllm_config)
 
 
 def test_sm70_qwen_gdn_003_spec_core_route_has_priority(

--- a/vllm/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py
+++ b/vllm/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py
@@ -2745,6 +2745,7 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
                     a_spec.index_select(0, path_token_idx),
                     b_spec.index_select(0, path_token_idx),
                     self.dt_bias,
+                    beta_dtype=torch.float32,
                 )
                 local_ssm_state = initial_ssm_state[req_row : req_row + 1].clone()
                 _, root_final_state = fused_recurrent_gated_delta_rule(
@@ -2841,6 +2842,7 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
                     a_spec.index_select(0, path_token_idx),
                     b_spec.index_select(0, path_token_idx),
                     self.dt_bias,
+                    beta_dtype=torch.float32,
                 )
                 local_ssm_state = initial_ssm_state[req_row : req_row + 1].clone()
                 _, path_final_state = fused_recurrent_gated_delta_rule(
@@ -3134,6 +3136,7 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
                 a_spec,
                 b_spec,
                 self.dt_bias,
+                beta_dtype=torch.float32,
             )
             core_attn_out_linear, _ = fused_recurrent_gated_delta_rule(
                 q=query_linear,
@@ -3249,6 +3252,7 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
                 a_spec.index_select(0, token_idx),
                 b_spec.index_select(0, token_idx),
                 self.dt_bias,
+                beta_dtype=torch.float32,
             )
             cu_seqlens = torch.arange(
                 input_state_idx.shape[0] + 1,
@@ -3336,6 +3340,7 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
                     a_spec.index_select(0, token_idx),
                     b_spec.index_select(0, token_idx),
                     self.dt_bias,
+                    beta_dtype=torch.float32,
                 )
                 cu_seqlens = torch.arange(
                     conv_state_indices.shape[0] + 1,
@@ -5314,7 +5319,11 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
                 last_recurrent_state = ssm_state
             else:
                 g_spec, beta_spec = fused_gdn_gating(
-                    self.A_log, a_spec, b_spec, self.dt_bias
+                    self.A_log,
+                    a_spec,
+                    b_spec,
+                    self.dt_bias,
+                    beta_dtype=torch.float32,
                 )
                 core_attn_out_spec, last_recurrent_state = (
                     fused_recurrent_gated_delta_rule(
@@ -6304,6 +6313,7 @@ def qwen_gdn_attention_core_spec_commit(
             a,
             b,
             self.dt_bias,
+            beta_dtype=torch.float32,
         )
         core_attn_out_spec, _ = fused_recurrent_gated_delta_rule(
             q=query_spec,
@@ -6984,18 +6994,25 @@ def fused_gdn_gating(
     dt_bias: torch.Tensor,
     beta: float = 1.0,
     threshold: float = 20.0,
+    *,
+    beta_dtype: torch.dtype | None = None,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     """
     Fused computation of g and beta for Gated Delta Net.
     g = -self.A_log.float().exp() * F.softplus(a.float() + self.dt_bias)
-    beta_output = b.sigmoid()
+    beta_output = b.sigmoid(), materialized in beta_dtype when provided.
+
+    Speculative recurrent updates request FP32 beta to match the fused packed
+    decode transition. Other callers retain the historical b.dtype output.
     TODO maybe use torch.compile to replace this triton kernel
     """
     batch, num_heads = a.shape
     seq_len = 1
     grid = (batch, seq_len, triton.cdiv(num_heads, 8))
     g = torch.empty(1, batch, num_heads, dtype=torch.float32, device=a.device)
-    beta_output = torch.empty(1, batch, num_heads, dtype=b.dtype, device=b.device)
+    if beta_dtype is None:
+        beta_dtype = b.dtype
+    beta_output = torch.empty(1, batch, num_heads, dtype=beta_dtype, device=b.device)
     fused_gdn_gating_kernel[grid](
         g,
         beta_output,


### PR DESCRIPTION
## Purpose

Normal packed GDN decode consumes `beta = sigmoid(b)` at FP32 precision inside
the recurrent update. The split speculative verifier instead materialized beta
in the activation dtype before passing it to the FP32 recurrent kernel. That
rounding is small for one transition, but the FP32 recurrent state persists
across decode steps.

This PR:

- lets `fused_gdn_gating` select the beta output dtype while preserving its
  historical default;
- requests FP32 beta only for split speculative recurrent paths, including
  state commit and verifier diagnostic paths;
- leaves non-speculative prefill behavior unchanged;
- does not change weights, quantization, KV-cache dtype, recurrent-state dtype,
  or any public tensor format.

## Test Plan

```bash
python -m pytest -q \
  tests/kernels/test_fused_sigmoid_gating_delta_rule.py \
  tests/kernels/test_fused_recurrent_packed_decode.py

python -m pytest -q \
  tests/v1/attention/test_gdn_metadata_builder.py::test_spec_commit_pure_decode_consumes_padded_graph_rows_without_metadata_patch

python benchmarks/benchmark_sm70_gdn_exactness.py \
  run-spec-mixed-qkv-candidate \
  --out /tmp/gdn-beta-fixed.pt \
  --steps 2048 --state-slots 5 --slot-stride 0 \
  --random-initial-state --state-dtype float32 \
  --k-heads 4 --v-heads 12 \
  --beta-output-dtype float32

python benchmarks/benchmark_sm70_gdn_exactness.py \
  run-spec-mixed-qkv-candidate \
  --out /tmp/gdn-beta-control.pt \
  --input-file /tmp/gdn-beta-fixed.pt --steps 2048 \
  --state-dtype float32 --k-heads 4 --v-heads 12 \
  --beta-output-dtype input
```

The exact regression uses Qwen3.8-27B TP4 per-rank geometry: 4 QK heads,
12 V heads, and head dimension 128. It isolates beta by using a zero initial
state and zero decay, then compares fused normal decode, packed normal decode,
the fixed split verifier, and the previous split behavior.

Model-level A/B used 4x V100 PCIe, TP4, MTP4, greedy draft sampling, FP16
activations, FP8 E5M2 KV cache, and identical prompts/runtime hashes. Only the
GDN beta materialization differed between each legacy/fixed pair.

## Test Result

- Latest-main V100 kernel gate: **28 passed**.
- Targeted state-commit metadata test: **1 passed**.
- For FP16 and BF16, fused normal decode, packed normal decode, and the fixed
  split verifier are bitwise equal in the beta-isolated output and state
  transition. The previous split behavior differs in both.

At 2,048 recurrent steps with random FP32 initial state:

| dtype | metric | previous split | FP32-beta split | reduction |
|---|---:|---:|---:|---:|
| FP16 | differing output elements | 666,736 | 1,215 | 99.82% |
| FP16 | state max abs error | 8.605e-7 | 9.313e-10 | 924x |
| FP16 | state mean abs error | 2.084e-8 | 1.584e-11 | 1,315x |
| BF16 | differing output elements | 1,194,242 | 329 | 99.972% |
| BF16 | state max abs error | 7.852e-6 | 1.397e-9 | 5,621x |
| BF16 | state mean abs error | 1.594e-7 | 1.767e-11 | 9,020x |

The remaining tiny differences in the random-state benchmark come from other
split-versus-packed kernel arithmetic; the beta-isolated regression is bitwise
equal.

Deterministic model-level first divergent generated token (1-based):

| weights | prompt | generated tokens | first divergence |
|---|---:|---:|---:|
| AWQ W4A16 | 8K | 2,048 | 192 |
| AWQ W4A16 | 128K | 2,048 | 21 |
| official FP8 W8A16 | 8K | 1,024 | 933 |
| official FP8 W8A16 | 128K | 1,024 | equal |
| official weights, W16A16 runtime | 8K | 2,048 | 58 |
| official weights, W16A16 runtime | 128K | 2,048 | 31 |

This confirms real token-trajectory impact for both tested quantized formats.
It is not monotonic in prompt length or quantization because token margins and
the later generated trajectory also matter.

For the matched FP8 runs, acceptance was identical before/after in both prompt
bands. Decode throughput was 100.457 vs 100.407 tok/s at 8K and 77.758 vs
77.706 tok/s at 128K, so no stable performance regression was measured.

Validation is currently limited to the tested V100/SM70 runtime. This PR only
aligns beta precision and does not claim to eliminate every source of
speculative/non-speculative numerical divergence.
