### PR TITLE
[Kernel][SM70] Widen batched E5M2 XQA loads

### DIFF
--- a/benchmarks/benchmark_sm70_decode.py
+++ b/benchmarks/benchmark_sm70_decode.py
@@ -683,6 +683,10 @@ def _sm70_attention_policy(kv_cache_dtype: Any) -> dict[str, Any]:
         "VLLM_FLASH_V100_XQA_E5M2_PAIR_LOAD",
         True,
     )
+    e5m2_batch_wide_load = _env_bool(
+        "VLLM_FLASH_V100_XQA_E5M2_BATCH_WIDE_LOAD",
+        True,
+    )
     decode_dynamic_partitions = _env_bool(
         "VLLM_FLASH_V100_DECODE_DYNAMIC_PARTITIONS",
         True,
@@ -798,6 +802,10 @@ def _sm70_attention_policy(kv_cache_dtype: Any) -> dict[str, Any]:
             "VLLM_FLASH_V100_XQA_E5M2_PAIR_LOAD"
         ),
         "e5m2_pair_load_effective": e5m2_pair_load,
+        "VLLM_FLASH_V100_XQA_E5M2_BATCH_WIDE_LOAD": os.environ.get(
+            "VLLM_FLASH_V100_XQA_E5M2_BATCH_WIDE_LOAD"
+        ),
+        "e5m2_batch_wide_load_effective": e5m2_batch_wide_load,
         "exact_mtp5_fp8_p1024_dual_cta_policy": (
             smallq_decode_use_xqa
             and mtp5_xqa_dual_cta

--- a/benchmarks/benchmark_sm70_model_tokens.py
+++ b/benchmarks/benchmark_sm70_model_tokens.py
@@ -885,6 +885,10 @@ def _sm70_attention_policy(kv_cache_dtype: Any) -> dict[str, Any]:
         "VLLM_FLASH_V100_XQA_E5M2_PAIR_LOAD",
         True,
     )
+    e5m2_batch_wide_load = _env_bool(
+        "VLLM_FLASH_V100_XQA_E5M2_BATCH_WIDE_LOAD",
+        True,
+    )
     decode_fp8_xqa_min_seq_len = _env_int(
         "VLLM_FLASH_V100_DECODE_FP8_XQA_MIN_SEQ_LEN",
         16384,
@@ -996,6 +1000,10 @@ def _sm70_attention_policy(kv_cache_dtype: Any) -> dict[str, Any]:
             "VLLM_FLASH_V100_XQA_E5M2_PAIR_LOAD"
         ),
         "e5m2_pair_load_effective": e5m2_pair_load,
+        "VLLM_FLASH_V100_XQA_E5M2_BATCH_WIDE_LOAD": os.environ.get(
+            "VLLM_FLASH_V100_XQA_E5M2_BATCH_WIDE_LOAD"
+        ),
+        "e5m2_batch_wide_load_effective": e5m2_batch_wide_load,
         "VLLM_FLASH_V100_DECODE_FP8_XQA_MIN_SEQ_LEN": os.environ.get(
             "VLLM_FLASH_V100_DECODE_FP8_XQA_MIN_SEQ_LEN"
         ),

--- a/flash-attention-v100/kernel/flash_decode_paged.cu
+++ b/flash-attention-v100/kernel/flash_decode_paged.cu
@@ -167,6 +167,11 @@ bool xqa_e5m2_pair_load_enabled() {
   return value == nullptr || value[0] != '0';
 }
 
+bool xqa_e5m2_batch_wide_load_enabled() {
+  const char* value = std::getenv("VLLM_FLASH_V100_XQA_E5M2_BATCH_WIDE_LOAD");
+  return value == nullptr || value[0] != '0';
+}
+
 int xqa_e5m2_p1024_begin() {
   const char* value = std::getenv("VLLM_FLASH_V100_XQA_E5M2_P1024_BEGIN");
   return value == nullptr ? 61633 : std::max(1, std::atoi(value));
@@ -2840,6 +2845,17 @@ at::Tensor flash_attention_decode_paged_xqa(
       use_e5m2_g6_dual_cta && xqa_e5m2_partition_page_ids_enabled();
   const bool use_e5m2_pair_load =
       use_e5m2_partition_page_ids && xqa_e5m2_pair_load_enabled();
+  // The B1 E5M2 route already amortizes page-table lookups across a p256
+  // partition and converts two half8 vectors from one aligned 128-bit load.
+  // Reuse that exact load path for the batch/context route without changing
+  // its partition, softmax, PV, or reduction order. Restrict the page size so
+  // one partition always fits the existing shared page-id capacity.
+  const bool use_e5m2_batch_wide_load =
+      use_e5m2_g6_batch_context_route && partition_size == 256 &&
+      k_cache.size(1) >= 256 && k_cache.size(1) % 16 == 0 &&
+      (batch_context_route == XQABatchContextRoute::kDualCta ||
+       batch_context_route == XQABatchContextRoute::kDualCtaSplit) &&
+      xqa_e5m2_batch_wide_load_enabled();
   const bool use_g6_dual_cta =
       use_g6_p1024_auto || use_g6_p1024_sawtooth || use_mtp5_dual_cta ||
       use_e5m2_g6_dual_cta ||
@@ -2879,6 +2895,14 @@ at::Tensor flash_attention_decode_paged_xqa(
   trace_xqa_batch_context_route(q.size(0), batch_context_max_seq_len,
                                 partition_size, k_cache.size(1),
                                 batch_context_route);
+  static bool traced_e5m2_batch_wide_load = false;
+  if (xqa_batch_context_routing_trace_enabled() && use_e5m2_batch_wide_load &&
+      !traced_e5m2_batch_wide_load) {
+    TORCH_WARN(
+        "Flash-V100 XQA batched E5M2 partition page reuse and paired "
+        "128-bit loads active");
+    traced_e5m2_batch_wide_load = true;
+  }
   static bool traced_block16_layout = false;
   if (xqa_block16_layout_trace_enabled() && block16_layout_mode != 0 &&
       !traced_block16_layout) {
@@ -3199,12 +3223,22 @@ at::Tensor flash_attention_decode_paged_xqa(
           launch_num_partitions, use_split_reduce, split_reduce_dim_tile,
           stream);
     } else if (partition_size == 256) {
-      launch_flash_attention_decode_paged_xqa_tc_256_wide<
-          256, 6, true, kXQATCG6DualCtaThreads, 2, 0, false>(
-          q, k_cache, v_cache, out, block_table, seq_lens, tmp_out, max_logits,
-          exp_sums, active_num_partitions, softmax_scale, k_scale, v_scale,
-          launch_num_partitions, use_split_reduce, split_reduce_dim_tile,
-          stream);
+      if (use_e5m2_batch_wide_load) {
+        launch_flash_attention_decode_paged_xqa_tc_256_wide<
+            256, 6, true, kXQATCG6DualCtaThreads, 2, 0, false, false,
+            kXQARouteAllSeqLens, false, true, true>(
+            q, k_cache, v_cache, out, block_table, seq_lens, tmp_out,
+            max_logits, exp_sums, active_num_partitions, softmax_scale, k_scale,
+            v_scale, launch_num_partitions, use_split_reduce,
+            split_reduce_dim_tile, stream);
+      } else {
+        launch_flash_attention_decode_paged_xqa_tc_256_wide<
+            256, 6, true, kXQATCG6DualCtaThreads, 2, 0, false>(
+            q, k_cache, v_cache, out, block_table, seq_lens, tmp_out,
+            max_logits, exp_sums, active_num_partitions, softmax_scale, k_scale,
+            v_scale, launch_num_partitions, use_split_reduce,
+            split_reduce_dim_tile, stream);
+      }
     } else if (partition_size == 512) {
       launch_flash_attention_decode_paged_xqa_tc_256_wide<
           512, 6, false, kXQATCG6DualCtaThreads, 2, 0, false>(

--- a/tests/v1/attention/test_sm70_flash_v100_policy.py
+++ b/tests/v1/attention/test_sm70_flash_v100_policy.py
@@ -245,6 +245,7 @@ def test_sm70_e5m2_decode_fast_route_envs_are_default_on(monkeypatch):
         "VLLM_FLASH_V100_XQA_E5M2_G6_SPLIT_REDUCE",
         "VLLM_FLASH_V100_XQA_E5M2_PARTITION_PAGE_IDS",
         "VLLM_FLASH_V100_XQA_E5M2_PAIR_LOAD",
+        "VLLM_FLASH_V100_XQA_E5M2_BATCH_WIDE_LOAD",
     )
     for name in names:
         monkeypatch.delenv(name, raising=False)
@@ -254,6 +255,7 @@ def test_sm70_e5m2_decode_fast_route_envs_are_default_on(monkeypatch):
     assert envs.VLLM_FLASH_V100_XQA_E5M2_G6_SPLIT_REDUCE is True
     assert envs.VLLM_FLASH_V100_XQA_E5M2_PARTITION_PAGE_IDS is True
     assert envs.VLLM_FLASH_V100_XQA_E5M2_PAIR_LOAD is True
+    assert envs.VLLM_FLASH_V100_XQA_E5M2_BATCH_WIDE_LOAD is True
     assert envs.VLLM_FLASH_V100_XQA_E5M2_P1024_BEGIN == 61633
 
     for name in names:
@@ -263,6 +265,7 @@ def test_sm70_e5m2_decode_fast_route_envs_are_default_on(monkeypatch):
     assert envs.VLLM_FLASH_V100_XQA_E5M2_G6_SPLIT_REDUCE is False
     assert envs.VLLM_FLASH_V100_XQA_E5M2_PARTITION_PAGE_IDS is False
     assert envs.VLLM_FLASH_V100_XQA_E5M2_PAIR_LOAD is False
+    assert envs.VLLM_FLASH_V100_XQA_E5M2_BATCH_WIDE_LOAD is False
 
     monkeypatch.setenv("VLLM_FLASH_V100_XQA_E5M2_P1024_BEGIN", "49152")
     envs.disable_envs_cache()

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -354,6 +354,7 @@ if TYPE_CHECKING:
     VLLM_FLASH_V100_XQA_E5M2_P1024_BEGIN: int = 61633
     VLLM_FLASH_V100_XQA_E5M2_PARTITION_PAGE_IDS: bool = True
     VLLM_FLASH_V100_XQA_E5M2_PAIR_LOAD: bool = True
+    VLLM_FLASH_V100_XQA_E5M2_BATCH_WIDE_LOAD: bool = True
     VLLM_FLASH_V100_XQA_E5M2_G6_DUAL_CTA_TRACE: bool = False
     VLLM_FLASH_V100_TRACE_DECODE_ACTIVE: bool = False
     VLLM_FLASH_V100_DECODE_USE_SCALAR_PAGED: bool = True
@@ -2361,6 +2362,9 @@ environment_variables: dict[str, Callable[[], Any]] = {
     ),
     "VLLM_FLASH_V100_XQA_E5M2_PAIR_LOAD": lambda: bool(
         int(os.getenv("VLLM_FLASH_V100_XQA_E5M2_PAIR_LOAD", "1"))
+    ),
+    "VLLM_FLASH_V100_XQA_E5M2_BATCH_WIDE_LOAD": lambda: bool(
+        int(os.getenv("VLLM_FLASH_V100_XQA_E5M2_BATCH_WIDE_LOAD", "1"))
     ),
     "VLLM_FLASH_V100_XQA_E5M2_G6_DUAL_CTA_TRACE": lambda: bool(
         int(os.getenv("VLLM_FLASH_V100_XQA_E5M2_G6_DUAL_CTA_TRACE", "0"))


### PR DESCRIPTION
## Purpose

Extend the accepted SM70 E5M2 XQA data-movement optimization from the B1 route to the real batched long-context decode route. For B>=4 p256 dual-CTA paths with page size >=256, reuse page IDs across the partition and convert two half8 vectors from one aligned 128-bit load. Softmax, PV, partition boundaries, reducer order, and output datatype are unchanged.

- Base: `onecat/main@6c7a8617fe838cbc61ba8ce0c85f14bc2b3e269e`
- Head: `08797d98cf988e1e67f59e03fa3dc04eddd5a220`
- Rollback: `VLLM_FLASH_V100_XQA_E5M2_BATCH_WIDE_LOAD=0`
- Default: enabled only for SM70 XQA, FP8 E5M2 KV, GQA6/D256, p256, B>=4 batch/context `dual_cta` or `dual_cta_split`, page size >=256 and divisible by 16

## Runtime contract

- Model: `/home/ymzx/models/Qwen3.8-27B-FP8`
- Hardware: 4x V100-32GB, physical GPU4-7, TP4
- Python 3.12.13, Torch 2.10.0+cu128, CUDA 12.8
- No MTP; FP8 E5M2 KV; prefix cache; Mamba align; `FLASH_ATTN_V100`
- CUDA graph: `FULL_AND_PIECEWISE`, no-MTP FULL shapes `1,2,4,8,16`
- Dataset/sampling: NVIDIA SPEED-Bench `low_entropy`, `temperature=1.0`, `top_k=20`, `top_p=0.95`, natural EOS
- A/B differs only in `VLLM_FLASH_V100_XQA_E5M2_BATCH_WIDE_LOAD=0/1`

Server capture logs confirm B16 long-context `dual_cta` and B8 long-context `dual_cta_split` are captured in FULL graphs. All four ranks report `partition page reuse and paired 128-bit loads active` for the candidate.

## Static, build, and operator correctness

- Changed-file pre-commit: passed (Ruff, Ruff format, typos, clang-format, mypy, configuration and policy hooks).
- Focused tests: 24 passed across SM70 policy, batch/context planner, and CUDA-graph dispatch.
- Native CUDA 12.8 SM70 extension build: passed; SHA256 `b6a0f76d637880ac570db40e982e1db26252117c392c9320752d4e8a248336e8`.
- Candidate SASS/resource contract: aligned 128-bit cache load; 168 registers/thread, 32-byte stack, zero spill; same two-CTA residency envelope as control.
- Same-process randomized-page operator A/B is bitwise exact (`max_abs_diff=0`) for uniform/ragged B4/B8/B12/B16, page256/page800, 12K/17.8K/32K contexts. B1 is exactly unaffected.

Representative operator medians:

| Shape | Control | Candidate | Speedup | Correctness |
|---|---:|---:|---:|---|
| uniform B8, 17.8K, page800 | 0.492544 ms | 0.406528 ms | 1.212x | bitwise |
| uniform B16, 17.8K, page800 | 0.743424 ms | 0.602112 ms | 1.235x | bitwise |
| ragged B8, 17.8K, page800 | 0.447488 ms | 0.367616 ms | 1.217x | bitwise |
| ragged B16, 17.8K, page800 | 0.683008 ms | 0.551936 ms | 1.238x | bitwise |
| ragged B16, 32K, page800 | 1.171296 ms | 0.925808 ms | 1.265x | bitwise |

## Full-model pure-decode result

Each cell has one prefix warmup and five effective repetitions. Pure decode is the first-wave overlap from the time all requests emitted their first token until the earliest request finished; TTFT/prefill is excluded.

| Cell | Control pure TPS | Candidate pure TPS | Delta | Control graph TPOT | Candidate graph TPOT |
|---|---:|---:|---:|---:|---:|
| B8 / 1K | 424.604 | 425.425 | +0.194% | 18.841 ms | 18.805 ms |
| B8 / 16K | 345.680 | 366.492 | **+6.021%** | 23.143 ms | 21.829 ms |
| B16 / 1K | 708.076 | 709.792 | +0.242% | 22.596 ms | 22.542 ms |
| B16 / 16K | 529.071 | 570.982 | **+7.922%** | 30.242 ms | 28.022 ms |

- `GM_B8 = sqrt(1.001935 * 1.060206) - 1 = +3.066%`
- `GM_B16 = sqrt(1.002424 * 1.079218) - 1 = +4.011%`
- No required cell regresses; both geometric-mean gates exceed 3%.

## NCU mechanism evidence

Single-GPU B16 ragged 17.8K/page800 exact-shape NCU, same 192-thread p256 dual-CTA specialization:

| Metric | Control | Candidate | Change |
|---|---:|---:|---:|
| kernel duration | 648.352 us | 499.520 us | -22.95% |
| L1 global-load requests | 656,443 | 383,814 | **-41.53%** |
| executed warp instructions | 97,998,831 | 83,583,696 | **-14.71%** |
| DRAM bytes read | 139,467,936 | 139,458,464 | -0.007% |
| L2 read sectors | 4,451,015 | 4,449,216 | -0.040% |
| achieved occupancy | 18.26% | 18.16% | unchanged |
| long-scoreboard stall | 39.14% | 30.10% | -9.04 pp |
| eligible warps/scheduler | 0.55 | 0.65 | +18.2% |
| issue active | 37.52% | 41.60% | +4.08 pp |
| tensor active | 1.68% | 2.19% | +0.51 pp |

The gain is therefore reduced page/scalar movement and dependency pressure, not increased occupancy or reduced HBM bytes. The same tensor work is fed more continuously.

## Serving quality

- Current candidate GSM8K: 5-shot, first 32 test questions, B16, max 512, official sampling, natural EOS: **23/32 (71.875%)**, invalid 0/32, healthy 32/32, natural stop 22/32.
- This matches the previously accepted current-route GSM8K candidate score (23/32) and is not lower than its 22/32 control.
- All SPEED-Bench A/B cells completed with identical input/output token-count shapes and 256 output tokens/request.

Official stochastic serving is not cross-process token-exact in this stack: even B1/1K, where this candidate is provably not dispatched, differs after a server restart, while a three-call same-process B1 probe is exact. Prior control-vs-control GSM8K self-repeat was only 20/32 token-exact. Consequently, correctness is gated by bitwise operator A/B plus the official-sampling GSM8K health/accuracy gate; greedy output was not used for performance or quality scoring.

## CI note

The repository-wide `pre-commit` GitHub job fails on pre-existing main-branch all-files formatting/typo/vendor/SPDX debt outside these five files. `pre-run-check` passes, all changed-file hooks pass locally, and the four CI mypy groups pass. This PR does not bulk-format unrelated upstream files.

## Decision

The bitwise operator gate, FULL route gate, no-regression gate, 3% geometric-mean gate, and official-sampling quality gate pass. The change is ready to merge with the default-on narrow dispatch and explicit rollback switch above.
