### PR TITLE
[Kernel] Add SM70 ModelOpt NVFP4 MoE and MTP cold-start

### DIFF
--- a/benchmarks/benchmark_sm70_model_tokens.py
+++ b/benchmarks/benchmark_sm70_model_tokens.py
@@ -522,6 +522,7 @@ def _sm70_turbomind_policy() -> dict[str, Any]:
         True,
     )
     nvfp4_turbomind = _env_bool("VLLM_SM70_NVFP4_TURBOMIND", False)
+    nvfp4_moe_grouped_prefill = _env_bool("VLLM_SM70_NVFP4_MOE_GROUPED_PREFILL", True)
     mxfp4_turbomind = _env_bool("VLLM_SM70_MXFP4_TURBOMIND", False)
     fp8_dequant_fallback = _env_bool("VLLM_SM70_FP8_DEQUANT_FALLBACK", True)
     fp8_moe_dequant_fallback = _env_bool(
@@ -579,6 +580,10 @@ def _sm70_turbomind_policy() -> dict[str, Any]:
         "fp8_prefill_exact_dense_effective": fp8_prefill_exact_dense,
         "VLLM_SM70_NVFP4_TURBOMIND": os.environ.get("VLLM_SM70_NVFP4_TURBOMIND"),
         "nvfp4_turbomind_effective": nvfp4_turbomind,
+        "VLLM_SM70_NVFP4_MOE_GROUPED_PREFILL": os.environ.get(
+            "VLLM_SM70_NVFP4_MOE_GROUPED_PREFILL"
+        ),
+        "nvfp4_moe_grouped_prefill_effective": nvfp4_moe_grouped_prefill,
         "VLLM_SM70_MXFP4_TURBOMIND": os.environ.get("VLLM_SM70_MXFP4_TURBOMIND"),
         "mxfp4_turbomind_effective": mxfp4_turbomind,
         "VLLM_SM70_FP8_DEQUANT_FALLBACK": os.environ.get(

--- a/csrc/ops.h
+++ b/csrc/ops.h
@@ -503,15 +503,18 @@ void fp8_moe_dense_stage_sm70_out(torch::Tensor out,
                                   int64_t n,
                                   int64_t group_size);
 
-void mxfp4_moe_dense_stage_sm70_out(torch::Tensor out,
-                                    torch::Tensor input,
+void mxfp4_moe_dense_stage_sm70_out(torch::Tensor out, torch::Tensor input,
                                     torch::Tensor expert_offsets,
                                     torch::Tensor dense_expert_ids,
-                                    torch::Tensor ptrs_w,
-                                    torch::Tensor ptrs_s,
-                                    int64_t num_experts,
-                                    int64_t k,
-                                    int64_t n,
+                                    torch::Tensor ptrs_w, torch::Tensor ptrs_s,
+                                    int64_t num_experts, int64_t k, int64_t n,
+                                    int64_t group_size);
+
+void nvfp4_moe_dense_stage_sm70_out(torch::Tensor out, torch::Tensor input,
+                                    torch::Tensor expert_offsets,
+                                    torch::Tensor dense_expert_ids,
+                                    torch::Tensor ptrs_w, torch::Tensor ptrs_s,
+                                    int64_t num_experts, int64_t k, int64_t n,
                                     int64_t group_size);
 
 void mxfp4_moe_single_token_prepare_w13_sm70_out(

--- a/csrc/sm70_turbomind/ops/awq_sm70_gemm.cu
+++ b/csrc/sm70_turbomind/ops/awq_sm70_gemm.cu
@@ -911,6 +911,7 @@ enum class TuneKeyKind : int {
   kMxfp4Dense = 6,
   kNvfp4Dense = 7,
   kMxfp4Moe = 8,
+  kNvfp4Moe = 9,
 };
 
 struct DenseTuneKey {
@@ -1046,6 +1047,9 @@ turbomind::gemm::DispatchPolicy select_fp8_moe_dispatch_policy(
 turbomind::gemm::DispatchPolicy select_mxfp4_moe_dispatch_policy(
     int device, int total_tokens, int n, int k, int num_experts, int group_size,
     cudaStream_t stream);
+turbomind::gemm::DispatchPolicy select_nvfp4_moe_dispatch_policy(
+    int device, int total_tokens, int n, int k, int num_experts, int group_size,
+    cudaStream_t stream);
 
 bool tune_small_shapes_enabled() {
   const char* raw = std::getenv("VLLM_SM70_AWQ_TUNE_SMALL_SHAPES");
@@ -1084,6 +1088,11 @@ bool mxfp4_moe_grouped_m8_fast_selector_enabled() {
 
 bool nvfp4_tune_small_shapes_enabled() {
   const char* raw = std::getenv("VLLM_SM70_NVFP4_TUNE_SMALL_SHAPES");
+  return raw == nullptr || std::atoi(raw) != 0;
+}
+
+bool nvfp4_moe_grouped_prefill_enabled() {
+  const char* raw = std::getenv("VLLM_SM70_NVFP4_MOE_GROUPED_PREFILL");
   return raw == nullptr || std::atoi(raw) != 0;
 }
 
@@ -1360,6 +1369,14 @@ turbomind::gemm::DispatchPolicy select_mxfp4_moe_dispatch_policy(
   return select_moe_dispatch_policy_impl(
       device, total_tokens, n, k, num_experts, group_size, stream,
       TuneKeyKind::kMxfp4Moe, mxfp4_tune_small_shapes_enabled());
+}
+
+turbomind::gemm::DispatchPolicy select_nvfp4_moe_dispatch_policy(
+    int device, int total_tokens, int n, int k, int num_experts, int group_size,
+    cudaStream_t stream) {
+  return select_moe_dispatch_policy_impl(
+      device, total_tokens, n, k, num_experts, group_size, stream,
+      TuneKeyKind::kNvfp4Moe, nvfp4_tune_small_shapes_enabled());
 }
 
 WorkspaceHolder& get_workspace(int device, cudaStream_t stream) {
@@ -7578,6 +7595,232 @@ void mxfp4_moe_dense_stage_sm70_out(torch::Tensor out, torch::Tensor input,
     torch::Tensor offsets = expert_offsets.narrow(0, expert, 2);
     torch::Tensor expert_idx = dense_expert_ids.narrow(0, expert, 1);
     mxfp4_moe_gemm_sm70_out_impl(out, input, offsets, ptrs_w, ptrs_s, 1, k, n,
+                                 group_size, expert_idx);
+  }
+}
+
+void nvfp4_moe_gemm_sm70_out_impl(
+    torch::Tensor out, torch::Tensor sorted_input, torch::Tensor expert_offsets,
+    torch::Tensor strided_ptrs_w, torch::Tensor strided_ptrs_s,
+    int64_t num_experts, int64_t k, int64_t n, int64_t group_size,
+    torch::Tensor b_group_indices, bool compact_grouped_rows = false) {
+  TORCH_CHECK(
+      sorted_input.is_cuda() && sorted_input.scalar_type() == torch::kFloat16,
+      "nvfp4_moe_gemm_sm70: input must be CUDA float16.");
+  TORCH_CHECK(
+      expert_offsets.is_cuda() &&
+          expert_offsets.scalar_type() == torch::kInt32 &&
+          expert_offsets.is_contiguous(),
+      "nvfp4_moe_gemm_sm70: expert_offsets must be contiguous CUDA int32.");
+  TORCH_CHECK(strided_ptrs_w.is_cuda() && strided_ptrs_s.is_cuda(),
+              "nvfp4_moe_gemm_sm70: strided_ptrs must be CUDA.");
+  TORCH_CHECK(out.is_cuda() && out.scalar_type() == torch::kFloat16,
+              "nvfp4_moe_gemm_sm70: output must be CUDA float16.");
+  TORCH_CHECK(num_experts > 0 && k > 0 && n > 0,
+              "nvfp4_moe_gemm_sm70: invalid dimensions.");
+  TORCH_CHECK(group_size == 16,
+              "nvfp4_moe_gemm_sm70: only group_size=16 is supported.");
+  TORCH_CHECK(k % group_size == 0,
+              "nvfp4_moe_gemm_sm70: k must be divisible by group_size.");
+  TORCH_CHECK(sorted_input.dim() == 2 && sorted_input.size(1) == k,
+              "nvfp4_moe_gemm_sm70: input shape mismatch.");
+  TORCH_CHECK(out.dim() == 2 && out.size(0) == sorted_input.size(0) &&
+                  out.size(1) == n && out.stride(1) == 1,
+              "nvfp4_moe_gemm_sm70: output must be contiguous [tokens, n].");
+  TORCH_CHECK(expert_offsets.numel() >= num_experts + 1,
+              "nvfp4_moe_gemm_sm70: expert_offsets too small.");
+  TORCH_CHECK(b_group_indices.is_cuda() &&
+                  b_group_indices.scalar_type() == torch::kInt32 &&
+                  b_group_indices.is_contiguous() &&
+                  b_group_indices.numel() >= num_experts,
+              "nvfp4_moe_gemm_sm70: B group indices must be contiguous CUDA "
+              "int32.");
+
+  const int64_t total_tokens = sorted_input.size(0);
+  if (total_tokens == 0) {
+    return;
+  }
+
+  const at::cuda::OptionalCUDAGuard device_guard(device_of(sorted_input));
+  const int device = sorted_input.get_device();
+  const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
+
+  const auto fp4_converters = turbomind::gemm::GetConverters(
+      turbomind::kHalf, turbomind::kFloat4_e2m1, turbomind::kHalf, true, 70);
+  const auto fp8_converters = turbomind::gemm::GetConverters(
+      turbomind::kHalf, turbomind::kFloat8_e4m3, turbomind::kHalf, true, 70);
+  const auto* conv_w = fp4_converters[0];
+  const auto* conv_s = fp8_converters[1];
+  TORCH_CHECK(conv_w && conv_s,
+              "nvfp4_moe_gemm_sm70: no compatible TurboMind converters.");
+
+  turbomind::gemm::MatrixLayout desc_A{
+      turbomind::kHalf,
+      turbomind::gemm::kRowMajor,
+      static_cast<int>(total_tokens),
+      static_cast<int>(k),
+      static_cast<int>(sorted_input.stride(0)),
+  };
+  desc_A.num = static_cast<int>(num_experts);
+  desc_A.offsets = expert_offsets.data_ptr<int>();
+  turbomind::gemm::MatrixLayout desc_U{};
+
+  const auto order_w = conv_w->order;
+  const bool is_a_w = turbomind::gemm::get_operand_tag(conv_w->pack) ==
+                      turbomind::gemm::OPERAND_A;
+  const bool is_b_w = !is_a_w;
+  turbomind::gemm::MatrixLayout weight_desc{
+      turbomind::kHalf,
+      order_w,
+      static_cast<int>(n),
+      static_cast<int>(k),
+      order_w == turbomind::gemm::kRowMajor ? static_cast<int>(k)
+                                            : static_cast<int>(n),
+  };
+  if (is_b_w) {
+    std::swap(weight_desc.rows, weight_desc.cols);
+    weight_desc.order = ~weight_desc.order;
+  }
+  turbomind::gemm::MatrixLayout desc_B = weight_desc;
+  desc_B.type = turbomind::kFloat4_e2m1;
+  desc_B.pack = conv_w->pack;
+  if (is_a_w) {
+    desc_B = turbomind::gemm::transpose(desc_B);
+  }
+  desc_B.ld = 0;
+  desc_B.num = static_cast<int>(num_experts);
+  desc_B.group_idxs = b_group_indices.data_ptr<int>();
+
+  const auto order_s = conv_s->order;
+  const bool is_a_s = turbomind::gemm::get_operand_tag(conv_s->pack) ==
+                      turbomind::gemm::OPERAND_U;
+  const bool is_b_s = !is_a_s;
+  const int64_t num_groups = k / group_size;
+  turbomind::gemm::MatrixLayout scale_desc{
+      turbomind::kUint16,  order_s,
+      static_cast<int>(n), static_cast<int>(num_groups),
+      static_cast<int>(n),
+  };
+  if (is_b_s) {
+    std::swap(scale_desc.rows, scale_desc.cols);
+    scale_desc.order = ~scale_desc.order;
+  }
+  turbomind::gemm::MatrixLayout desc_V = scale_desc;
+  desc_V.pack = conv_s->pack;
+  if (is_a_s) {
+    desc_V = turbomind::gemm::transpose(desc_V);
+  }
+  desc_V.ld = 0;
+  desc_V.num = static_cast<int>(num_experts);
+  desc_V.group_idxs = b_group_indices.data_ptr<int>();
+
+  turbomind::gemm::MatrixLayout desc_D{
+      turbomind::kHalf,
+      turbomind::gemm::kRowMajor,
+      static_cast<int>(total_tokens),
+      static_cast<int>(n),
+      static_cast<int>(out.stride(0)),
+  };
+  desc_D.num = static_cast<int>(num_experts);
+  desc_D.offsets = expert_offsets.data_ptr<int>();
+
+  turbomind::gemm::Operation op{};
+  op.dispatch = vllm::awq_sm70::select_nvfp4_moe_dispatch_policy(
+      device, static_cast<int>(total_tokens), static_cast<int>(n),
+      static_cast<int>(k), static_cast<int>(num_experts),
+      static_cast<int>(group_size), stream);
+  op.epilogue = turbomind::gemm::Epilogue::kNone;
+  op.quant_a = {turbomind::gemm::QuantType::kNone, 0};
+  op.quant_b = {turbomind::gemm::QuantType::kK, static_cast<int>(group_size)};
+  op.batch_dim = 0;
+  op.dispatch_num_override = compact_grouped_rows ? 1 : 0;
+  op.active_group_count =
+      compact_grouped_rows ? -static_cast<int>(num_experts) : 0;
+
+  auto& workspace_holder = vllm::awq_sm70::get_workspace(device, stream);
+  auto& gemm = vllm::awq_sm70::get_gemm(device);
+  const int ec =
+      gemm.Run(op, 1.f, sorted_input.data_ptr(), desc_A, nullptr, desc_U,
+               strided_ptrs_w.data_ptr(), desc_B, strided_ptrs_s.data_ptr(),
+               desc_V, 0.f, out.data_ptr(), desc_D, out.data_ptr(), desc_D,
+               workspace_holder.workspace, stream);
+  TORCH_CHECK(ec == 0,
+              "nvfp4_moe_gemm_sm70: TurboMind batched GEMM failed (ec=", ec,
+              ").");
+}
+
+void nvfp4_moe_dense_stage_sm70_out(torch::Tensor out, torch::Tensor input,
+                                    torch::Tensor expert_offsets,
+                                    torch::Tensor dense_expert_ids,
+                                    torch::Tensor ptrs_w, torch::Tensor ptrs_s,
+                                    int64_t num_experts, int64_t k, int64_t n,
+                                    int64_t group_size) {
+  TORCH_CHECK(input.is_cuda() && input.scalar_type() == torch::kFloat16,
+              "nvfp4_moe_dense_stage_sm70_out: input must be CUDA float16.");
+  TORCH_CHECK(out.is_cuda() && out.scalar_type() == torch::kFloat16,
+              "nvfp4_moe_dense_stage_sm70_out: out must be CUDA float16.");
+  TORCH_CHECK(expert_offsets.is_cuda() &&
+                  expert_offsets.scalar_type() == torch::kInt32 &&
+                  expert_offsets.is_contiguous(),
+              "nvfp4_moe_dense_stage_sm70_out: expert_offsets must be "
+              "contiguous CUDA int32.");
+  TORCH_CHECK(dense_expert_ids.is_cuda() &&
+                  dense_expert_ids.scalar_type() == torch::kInt32 &&
+                  dense_expert_ids.is_contiguous(),
+              "nvfp4_moe_dense_stage_sm70_out: dense_expert_ids must be "
+              "contiguous CUDA int32.");
+  TORCH_CHECK(ptrs_w.is_cuda() && ptrs_s.is_cuda(),
+              "nvfp4_moe_dense_stage_sm70_out: ptr rows must be CUDA.");
+  TORCH_CHECK(num_experts > 0,
+              "nvfp4_moe_dense_stage_sm70_out: num_experts must be positive.");
+  TORCH_CHECK(group_size == 16,
+              "nvfp4_moe_dense_stage_sm70_out: only group_size=16 is "
+              "supported.");
+  TORCH_CHECK(input.dim() == 2 && input.size(1) == k,
+              "nvfp4_moe_dense_stage_sm70_out: input shape mismatch.");
+  TORCH_CHECK(
+      out.dim() == 2 && out.size(0) == input.size(0) && out.size(1) == n,
+      "nvfp4_moe_dense_stage_sm70_out: out shape mismatch.");
+  TORCH_CHECK(expert_offsets.numel() >= num_experts + 1,
+              "nvfp4_moe_dense_stage_sm70_out: expert_offsets too small.");
+  TORCH_CHECK(dense_expert_ids.numel() >= num_experts,
+              "nvfp4_moe_dense_stage_sm70_out: dense_expert_ids too small.");
+
+  const at::cuda::OptionalCUDAGuard device_guard(device_of(input));
+  static std::atomic<unsigned> logged_nvfp4_dense_stage{0u};
+  maybe_log_sm70_moe_route_once(
+      logged_nvfp4_dense_stage,
+      "SM70 NVFP4 MoE CUDA-graph-safe TurboMind path enabled C++ op reached",
+      input, input.size(0), num_experts);
+  constexpr int kNvfp4MaxCompactGroups = 8 * 8;
+  const bool compact_decode_shape =
+      input.size(0) == num_experts && num_experts <= kNvfp4MaxCompactGroups;
+  if (compact_decode_shape) {
+    nvfp4_moe_gemm_sm70_out_impl(out, input, expert_offsets, ptrs_w, ptrs_s,
+                                 num_experts, k, n, group_size,
+                                 dense_expert_ids, true);
+    return;
+  }
+  const bool exact_qwen36_prefill_shape =
+      input.size(0) > kNvfp4MaxCompactGroups && num_experts == 256 &&
+      ((k == 2048 && (n == 1024 || n == 512 || n == 256)) ||
+       (n == 2048 && (k == 512 || k == 256 || k == 128)));
+  if (vllm::awq_sm70::nvfp4_moe_grouped_prefill_enabled() &&
+      exact_qwen36_prefill_shape) {
+    static std::atomic<unsigned> logged_nvfp4_grouped_prefill{0u};
+    maybe_log_sm70_moe_route_once(
+        logged_nvfp4_grouped_prefill,
+        "SM70 NVFP4 MoE grouped TurboMind prefill path enabled C++ op reached",
+        input, input.size(0), num_experts);
+    nvfp4_moe_gemm_sm70_out_impl(out, input, expert_offsets, ptrs_w, ptrs_s,
+                                 num_experts, k, n, group_size,
+                                 dense_expert_ids);
+    return;
+  }
+  for (int expert = 0; expert < static_cast<int>(num_experts); ++expert) {
+    torch::Tensor offsets = expert_offsets.narrow(0, expert, 2);
+    torch::Tensor expert_idx = dense_expert_ids.narrow(0, expert, 1);
+    nvfp4_moe_gemm_sm70_out_impl(out, input, offsets, ptrs_w, ptrs_s, 1, k, n,
                                  group_size, expert_idx);
   }
 }

--- a/csrc/torch_bindings.cpp
+++ b/csrc/torch_bindings.cpp
@@ -501,6 +501,14 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, ops) {
            &mxfp4_moe_dense_stage_sm70_out);
 
   ops.def(
+      "nvfp4_moe_dense_stage_sm70_out("
+      "Tensor(a!) out, Tensor input, Tensor expert_offsets, "
+      "Tensor dense_expert_ids, Tensor ptrs_w, Tensor ptrs_s, "
+      "int num_experts, int k, int n, int group_size) -> ()");
+  ops.impl("nvfp4_moe_dense_stage_sm70_out", torch::kCUDA,
+           &nvfp4_moe_dense_stage_sm70_out);
+
+  ops.def(
       "mxfp4_moe_single_token_prepare_w13_sm70_out("
       "Tensor(a!) gate_up, Tensor(b!) compact_input, Tensor x, "
       "Tensor topk_ids, Tensor w13_ptrs_w, Tensor w13_ptrs_s, "

--- a/docs/design/sm70_v100_migration_control.md
+++ b/docs/design/sm70_v100_migration_control.md
@@ -41702,8 +41702,27 @@ Interpretation:
   through B18, and measured 0.8379 s prefill plus 174.76 token/s steady decode
   under the same model contract. It accepted 792/924 draft tokens, with mean
   acceptance length 4.43, and improved no-MTP decode by 1.49x. MTP prefill is
-  slower because the drafter participates; first-request sampler/Mamba JIT
-  warnings remain startup evidence and are not counted as steady decode.
+  slower because the drafter participates. That original run still exposed
+  first-request sampler/Mamba JIT, which the later cold-start work below moves
+  ahead of request processing.
+- The accepted cold-start patch warms the exact Mamba speculative postprocess,
+  all-greedy rejection sampler, and unquantized MTP-drafter MoE signatures. For
+  the checkpoint's 256-expert/top-8 draft, token counts 9, 33, and 257 cover the
+  sorted-assignment, unaligned-buffer, and SM70 small-to-large tile boundaries.
+  A fresh-cache ShareGPT16 run then produced no inference-time Triton JIT
+  warning: 97.69 end-to-end output token/s, 242.72 serial-prefill token/s,
+  120.09 pure-decode token/s, and 8.827 ms mean TPOT. Moving these compilations
+  into startup adds about 4.33 s to model load versus the preceding
+  Mamba/sampler-only candidate.
+- MTP quality is gated by dataset accuracy, validity, and repetition health,
+  not token equality with no-MTP. On pinned GSM8K test records 0-127 with
+  five-shot chat prompting, thinking disabled, greedy sampling, and a 512-token
+  cap, no-MTP scored 122/128 and three full-forward MTP4 runs scored 121, 122,
+  and 121. The post-rebase final at `d3b1ea3678` scored 121/128 with zero invalid
+  or repetitive records and the same wrong set as the preceding full MTP run:
+  `[2, 12, 37, 87, 89, 102, 119]`. Record 37 is a cap-induced truncation and is
+  correct at 1024 output tokens, so effective MTP4 accuracy is 122/128. A
+  standard-GDN diagnostic scored only 108/128 and is rejected.
 - A final default-grouped, no-MTP natural-text gate used two identical Chinese
   prompts and one Python prompt. All three requests reached EOS with `stop`;
   the duplicate outputs were token-for-token identical, and the code response
@@ -41712,5 +41731,9 @@ Interpretation:
 - Reproducible JSON, logs, numeric oracles, and the rejected compact experiment
   are under
   `bench_results/modelopt_mixed_nvfp4_moe_20260822/{results,logs,telemetry}`.
+  The final dataset artifact is
+  `results/tp4_mtp4_fp8kv_gsm8k_chat_nothink_5shot_128_coldstart_rebased_final_graph.json`;
+  the all-JIT-warm ShareGPT artifact is
+  `results/tp4_gpu0123_mtp4_fp8kv_sharegpt16_seed20260822_all_jit_warmup_reserved_graph.json`.
   These results are the accepted 35B evidence; earlier short route-hit and
   quality smokes must not be substituted for the matched speed contract.

--- a/docs/design/sm70_v100_migration_control.md
+++ b/docs/design/sm70_v100_migration_control.md
@@ -41671,3 +41671,46 @@ Interpretation:
   formatter changes from current main and keep large C/CUDA formatter work
   separate from accepted kernel repairs. Small policy substitutions still need
   their own current-source static/argument-equivalence checks before merge.
+
+## 2026-08-22 Qwen3.6-35B-A3B ModelOpt NVFP4 TurboMind route
+
+- The checkpoint at `/data/models/Qwen3.6-35B-A3B-NVFP4` is ModelOpt 0.37.0
+  `MIXED_PRECISION`: dense projections use FP8, routed/shared experts use
+  `W4A16_NVFP4`, and 19 `mtp.*` tensors are present and unquantized. Exact SM70
+  admission now requires both FP8 and NVFP4 TurboMind gates; unsupported model
+  shapes, TP8, EP, and all-to-all fail closed rather than taking a generic
+  fallback.
+- The native Qwen3.6-35B-A3B MoE contract is H2048, expert I512, 256 experts,
+  top-k 8, replicated experts, and TP1/2/4. B1-B8 decode uses compact active
+  expert groups. B9-B18 CUDA Graph/MTP decode and larger prefill use persistent
+  buffers with the full 256-expert grouped TurboMind operation. The grouped
+  prefill policy is default-on and may be disabled only for diagnosis with
+  `VLLM_SM70_NVFP4_MOE_GROUPED_PREFILL=0`.
+- A real layer-0 TP4 checkpoint oracle matched the previous per-expert route:
+  M4096 W13/W2 were bitwise identical and improved 20.39x/9.48x. Full-grouped
+  B9 and B18 had cosine 1.0, maximum absolute error at most 1.221e-4, and
+  21.59x-35.21x isolated-stage speedups. Expanding the compact path to 144
+  groups produced a roughly 0.495 W13 relative-L2 error and catastrophic W2
+  output, so the compact limit remains 64 groups; do not repeat that candidate.
+- Matching TP4, FP8-E5M2 KV-cache, Flash-V100/FlashQLA, full CUDA Graph,
+  input-4096/output-1024, max-length-8192 runs measured AWQ at 0.3813 s prefill
+  and 113.71 token/s steady decode. Default-grouped NVFP4 measured 0.4216 s and
+  116.99 token/s: prefill is 10.56% slower than AWQ while decode is 2.89%
+  faster, placing both in the same performance class. Grouping reduced NVFP4
+  prefill from 1.5479 s to 0.4216 s (3.67x).
+- MTP4 resolved the bundled draft as `Qwen3_5MoeMTP`, captured FULL CUDA Graphs
+  through B18, and measured 0.8379 s prefill plus 174.76 token/s steady decode
+  under the same model contract. It accepted 792/924 draft tokens, with mean
+  acceptance length 4.43, and improved no-MTP decode by 1.49x. MTP prefill is
+  slower because the drafter participates; first-request sampler/Mamba JIT
+  warnings remain startup evidence and are not counted as steady decode.
+- A final default-grouped, no-MTP natural-text gate used two identical Chinese
+  prompts and one Python prompt. All three requests reached EOS with `stop`;
+  the duplicate outputs were token-for-token identical, and the code response
+  produced a correct `add(a, b)` implementation. This supersedes the earlier
+  128-token truncated quality smoke for route acceptance.
+- Reproducible JSON, logs, numeric oracles, and the rejected compact experiment
+  are under
+  `bench_results/modelopt_mixed_nvfp4_moe_20260822/{results,logs,telemetry}`.
+  These results are the accepted 35B evidence; earlier short route-hit and
+  quality smokes must not be substituted for the matched speed contract.

--- a/tests/model_executor/test_qwen3_5_quantization.py
+++ b/tests/model_executor/test_qwen3_5_quantization.py
@@ -8,6 +8,7 @@ class _QuantConfig:
     def __init__(self) -> None:
         self.ignore: list[str] = []
         self.config: dict[str, object] = {}
+        self.quantized_layers: dict[str, dict[str, str]] = {}
 
 
 def test_qwen3_5_split_gdn_detects_compressed_tensors_ignore():
@@ -36,6 +37,53 @@ def test_qwen3_5_split_gdn_detects_compressed_tensors_config_ignore():
             "model.language_model.layers.0.linear_attn.in_proj_b",
             "model.language_model.layers.0.linear_attn.in_proj_a",
         ],
+    }
+
+    assert _uses_split_gdn_input_projections(quant_config)
+
+
+def test_qwen3_5_split_gdn_detects_modelopt_mixed_unquantized_ba():
+    from vllm.model_executor.models.qwen3_5 import (
+        _uses_split_gdn_input_projections,
+    )
+
+    quant_config = _QuantConfig()
+    prefix = "model.language_model.layers.0.linear_attn"
+    quant_config.quantized_layers = {
+        f"{prefix}.in_proj_qkv": {"quant_algo": "FP8"},
+        f"{prefix}.in_proj_z": {"quant_algo": "FP8"},
+    }
+
+    assert _uses_split_gdn_input_projections(quant_config)
+
+
+def test_qwen3_5_split_gdn_keeps_same_precision_projections_fused():
+    from vllm.model_executor.models.qwen3_5 import (
+        _uses_split_gdn_input_projections,
+    )
+
+    quant_config = _QuantConfig()
+    prefix = "model.language_model.layers.0.linear_attn"
+    quant_config.quantized_layers = {
+        f"{prefix}.{name}": {"quant_algo": "FP8"}
+        for name in ("in_proj_qkv", "in_proj_z", "in_proj_b", "in_proj_a")
+    }
+
+    assert not _uses_split_gdn_input_projections(quant_config)
+
+
+def test_qwen3_5_split_gdn_detects_different_modelopt_algorithms():
+    from vllm.model_executor.models.qwen3_5 import (
+        _uses_split_gdn_input_projections,
+    )
+
+    quant_config = _QuantConfig()
+    prefix = "model.language_model.layers.0.linear_attn"
+    quant_config.quantized_layers = {
+        f"{prefix}.in_proj_qkv": {"quant_algo": "FP8"},
+        f"{prefix}.in_proj_z": {"quant_algo": "FP8"},
+        f"{prefix}.in_proj_b": {"quant_algo": "W4A16_NVFP4"},
+        f"{prefix}.in_proj_a": {"quant_algo": "W4A16_NVFP4"},
     }
 
     assert _uses_split_gdn_input_projections(quant_config)

--- a/tests/quantization/test_sm70_modelopt_mixed_nvfp4.py
+++ b/tests/quantization/test_sm70_modelopt_mixed_nvfp4.py
@@ -1,0 +1,170 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Narrow SM70 admission and shape gates for ModelOpt mixed NVFP4."""
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+import torch
+
+from vllm import envs
+from vllm.model_executor.layers.quantization import modelopt
+from vllm.model_executor.layers.quantization import sm70_turbomind as sm70_tm
+from vllm.model_executor.layers.quantization.modelopt import (
+    ModelOptFp8Config,
+    ModelOptMixedPrecisionConfig,
+    ModelOptNvFp4Config,
+)
+from vllm.model_executor.layers.quantization.nvfp4_sm70_moe import (
+    ModelOptNvFp4SM70MoEMethod,
+    _validate_weight_layout,
+    validate_nvfp4_sm70_moe_contract,
+)
+
+
+def _mixed_config() -> ModelOptMixedPrecisionConfig:
+    fp8 = ModelOptFp8Config("FP8", True, None, [])
+    nvfp4 = ModelOptNvFp4Config(
+        quant_method="NVFP4",
+        is_checkpoint_nvfp4_serialized=True,
+    )
+    w4a16 = ModelOptNvFp4Config(
+        quant_method="W4A16_NVFP4",
+        is_checkpoint_nvfp4_serialized=True,
+    )
+    return ModelOptMixedPrecisionConfig(
+        kv_cache_quant_method=None,
+        exclude_modules=[],
+        quantized_layers={"model.layers.0.mlp.experts": {"quant_algo": "W4A16_NVFP4"}},
+        fp8_config=fp8,
+        nvfp4_config=nvfp4,
+        w4a16_nvfp4_config=w4a16,
+    )
+
+
+def _moe_contract(**overrides):
+    values = {
+        "num_experts": 256,
+        "experts_per_token": 8,
+        "hidden_dim": 2048,
+        "intermediate_size_per_partition": 128,
+        "tp_size": 4,
+        "moe_parallel_config": SimpleNamespace(use_all2all_kernels=False),
+    }
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+def test_mixed_min_capability_requires_exact_sm70_and_both_turbomind_routes():
+    with (
+        patch.object(sm70_tm, "is_exact_sm70_cuda_platform", return_value=True),
+        patch.object(sm70_tm, "use_turbomind", side_effect=[True, True]),
+    ):
+        assert ModelOptMixedPrecisionConfig.get_min_capability() == 70
+
+    with (
+        patch.object(sm70_tm, "is_exact_sm70_cuda_platform", return_value=True),
+        patch.object(sm70_tm, "use_turbomind", side_effect=[True, False]),
+    ):
+        assert ModelOptMixedPrecisionConfig.get_min_capability() == 89
+
+    with patch.object(sm70_tm, "is_exact_sm70_cuda_platform", return_value=False):
+        assert ModelOptMixedPrecisionConfig.get_min_capability() == 89
+
+
+def test_nvfp4_grouped_prefill_defaults_on_and_can_be_disabled(monkeypatch):
+    monkeypatch.delenv("VLLM_SM70_NVFP4_MOE_GROUPED_PREFILL", raising=False)
+    assert envs.VLLM_SM70_NVFP4_MOE_GROUPED_PREFILL
+
+    monkeypatch.setenv("VLLM_SM70_NVFP4_MOE_GROUPED_PREFILL", "0")
+    assert not envs.VLLM_SM70_NVFP4_MOE_GROUPED_PREFILL
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("num_experts", 128),
+        ("experts_per_token", 6),
+        ("hidden_dim", 4096),
+        ("intermediate_size_per_partition", 96),
+        ("tp_size", 2),
+    ],
+)
+def test_nvfp4_moe_contract_rejects_non_qwen36_shapes(field, value):
+    validate_nvfp4_sm70_moe_contract(_moe_contract())
+    with pytest.raises(NotImplementedError):
+        validate_nvfp4_sm70_moe_contract(_moe_contract(**{field: value}))
+
+
+def test_nvfp4_moe_contract_rejects_shape_consistent_unvalidated_tp8():
+    with pytest.raises(NotImplementedError, match="tensor parallel"):
+        validate_nvfp4_sm70_moe_contract(
+            _moe_contract(tp_size=8, intermediate_size_per_partition=64)
+        )
+
+
+def _meta_layer() -> SimpleNamespace:
+    experts, hidden, intermediate = 256, 2048, 128
+    return SimpleNamespace(
+        local_num_experts=experts,
+        moe_config=_moe_contract(),
+        w13_weight=torch.empty(
+            experts, 2 * intermediate, hidden // 2, dtype=torch.uint8, device="meta"
+        ),
+        w13_weight_scale=torch.empty(
+            experts,
+            2 * intermediate,
+            hidden // 16,
+            dtype=torch.float8_e4m3fn,
+            device="meta",
+        ),
+        w13_weight_scale_2=torch.empty(experts, 2, device="meta"),
+        w2_weight=torch.empty(
+            experts, hidden, intermediate // 2, dtype=torch.uint8, device="meta"
+        ),
+        w2_weight_scale=torch.empty(
+            experts,
+            hidden,
+            intermediate // 16,
+            dtype=torch.float8_e4m3fn,
+            device="meta",
+        ),
+        w2_weight_scale_2=torch.empty(experts, device="meta"),
+    )
+
+
+def test_nvfp4_moe_weight_layout_is_explicit():
+    layer = _meta_layer()
+    _validate_weight_layout(layer)
+
+    layer.w2_weight = torch.empty(256, 2048, 32, dtype=torch.uint8, device="meta")
+    with pytest.raises(ValueError, match="w2_weight"):
+        _validate_weight_layout(layer)
+
+
+def test_nvfp4_sm70_moe_owns_routing_without_generic_modular_wrapper():
+    method = ModelOptNvFp4SM70MoEMethod(
+        quant_config=ModelOptNvFp4Config(
+            quant_method="W4A16_NVFP4",
+            is_checkpoint_nvfp4_serialized=True,
+        ),
+        moe_config=_moe_contract(),
+    )
+
+    assert method.maybe_make_prepare_finalize() is None
+
+
+def test_mixed_w4a16_moe_requires_turbomind_on_sm70():
+    config = _mixed_config()
+
+    class FakeRoutedExperts:
+        moe_config = _moe_contract()
+
+    with (
+        patch.object(modelopt, "RoutedExperts", FakeRoutedExperts),
+        patch.object(sm70_tm, "is_exact_sm70_cuda_platform", return_value=True),
+        patch.object(sm70_tm, "should_use_nvfp4_moe_turbomind", return_value=False),
+        pytest.raises(NotImplementedError, match="TurboMind"),
+    ):
+        config.get_quant_method(FakeRoutedExperts(), "model.layers.0.mlp.experts")

--- a/tests/quantization/test_sm70_modelopt_mixed_nvfp4.py
+++ b/tests/quantization/test_sm70_modelopt_mixed_nvfp4.py
@@ -18,6 +18,7 @@ from vllm.model_executor.layers.quantization.modelopt import (
 )
 from vllm.model_executor.layers.quantization.nvfp4_sm70_moe import (
     ModelOptNvFp4SM70MoEMethod,
+    _prepare_compact_slot_groups,
     _validate_weight_layout,
     validate_nvfp4_sm70_moe_contract,
 )
@@ -153,6 +154,23 @@ def test_nvfp4_sm70_moe_owns_routing_without_generic_modular_wrapper():
     )
 
     assert method.maybe_make_prepare_finalize() is None
+
+
+@pytest.mark.skipif(
+    not torch.cuda.is_available() or torch.cuda.get_device_capability() != (7, 0),
+    reason="requires an exact SM70 CUDA device",
+)
+def test_nvfp4_compact_groups_keep_duplicate_expert_slots_independent():
+    sorted_expert_ids = torch.tensor(
+        [3, 3, 3, 17, 17, 42, 88, 88], dtype=torch.int32, device="cuda"
+    )
+    compact_offsets = torch.empty(9, dtype=torch.int32, device="cuda")
+    active_expert_ids = torch.empty(8, dtype=torch.int32, device="cuda")
+
+    _prepare_compact_slot_groups(sorted_expert_ids, compact_offsets, active_expert_ids)
+
+    assert torch.equal(compact_offsets.cpu(), torch.arange(9, dtype=torch.int32))
+    assert torch.equal(active_expert_ids.cpu(), sorted_expert_ids.cpu())
 
 
 def test_mixed_w4a16_moe_requires_turbomind_on_sm70():

--- a/tests/quantization/test_sm70_warmup.py
+++ b/tests/quantization/test_sm70_warmup.py
@@ -68,6 +68,155 @@ def test_fp8_warmup_matches_grouped_bmm_runtime_slice(monkeypatch):
     assert all(not call.gated_silu for call in calls)
 
 
+def test_fp8_warmup_supports_modelopt_turbomind_layout(monkeypatch):
+    layer = nn.Module()
+    layer.sm70_modelopt_fp8_turbomind = True
+    layer.sm70_modelopt_fp8_k_ld = 128
+    layer.sm70_modelopt_fp8_q_ld = 64
+    layer.output_size_per_partition = 64
+    layer.weight = nn.Parameter(
+        torch.empty((128, 64), dtype=torch.uint8), requires_grad=False
+    )
+    layer.weight_scale = nn.Parameter(
+        torch.empty((1, 64), dtype=torch.float16), requires_grad=False
+    )
+    model = nn.Sequential(layer)
+    calls = []
+    monkeypatch.setattr(torch.ops._C, "fp8_gemm_sm70_out_meta", object(), raising=False)
+    monkeypatch.setattr(
+        warmup.sm70_ops,
+        "fp8_gemm_sm70_out",
+        lambda out, x, weight, scales, group_size, k_ld, q_ld, gated_silu: calls.append(
+            (out.shape, x.shape, scales, group_size, k_ld, q_ld)
+        ),
+    )
+
+    discovered = list(warmup._iter_unique_fp8_dense_layers(model))
+    count = warmup._warmup_fp8_dense_layers(discovered, [1, 4])
+
+    assert discovered == [(layer, False)]
+    assert count == 2
+    assert [tuple(call[0]) for call in calls] == [(1, 64), (4, 64)]
+    assert all(call[2] is layer.weight_scale for call in calls)
+    assert all(call[3:] == (128, 128, 64) for call in calls)
+
+
+def _nvfp4_moe_layer() -> nn.Module:
+    layer = nn.Module()
+    layer.sm70_nvfp4_moe = True
+    layer.moe_config = SimpleNamespace(experts_per_token=8)
+    layer.swiglu_limit = None
+    layer.sm70_nvfp4_num_experts = 256
+    layer.sm70_nvfp4_w13_k_dim = 2048
+    layer.sm70_nvfp4_w13_n_dim = 256
+    layer.sm70_nvfp4_w2_k_dim = 128
+    layer.sm70_nvfp4_w2_n_dim = 2048
+    layer.sm70_nvfp4_group_size = 16
+    layer.sm70_nvfp4_graph_safe_max_tokens = 18
+    layer.w13_tm_weight = nn.Parameter(
+        torch.empty((1, 1), dtype=torch.uint8), requires_grad=False
+    )
+    layer.w13_strided_ptrs_w = torch.empty(1, dtype=torch.uint8)
+    layer.w13_strided_ptrs_s = torch.empty(1, dtype=torch.uint8)
+    layer.w2_strided_ptrs_w = torch.empty(1, dtype=torch.uint8)
+    layer.w2_strided_ptrs_s = torch.empty(1, dtype=torch.uint8)
+    layer._nvfp4_sm70_dense_expert_ids = torch.arange(256, dtype=torch.int32)
+    return layer
+
+
+def test_nvfp4_moe_warmup_discovers_and_uses_compact_decode_shapes(monkeypatch):
+    layer = _nvfp4_moe_layer()
+    model = nn.Sequential(layer)
+    calls = []
+    monkeypatch.setattr(
+        torch.ops._C, "nvfp4_moe_dense_stage_sm70_out", object(), raising=False
+    )
+
+    def record_call(
+        out,
+        x,
+        offsets,
+        expert_ids,
+        ptrs_w,
+        ptrs_s,
+        num_experts,
+        k,
+        n,
+        group_size,
+    ):
+        calls.append(
+            (
+                tuple(out.shape),
+                tuple(x.shape),
+                offsets.tolist(),
+                expert_ids.tolist(),
+                num_experts,
+                k,
+                n,
+                group_size,
+            )
+        )
+
+    monkeypatch.setattr(warmup.sm70_ops, "nvfp4_moe_dense_stage_sm70_out", record_call)
+    monkeypatch.setattr(
+        torch.ops._C,
+        "silu_and_mul",
+        lambda out, gate_up: out.zero_(),
+        raising=False,
+    )
+
+    discovered = list(warmup._iter_unique_nvfp4_moe_layers(model))
+    count = warmup._warmup_nvfp4_moe_decode_layers(discovered, [1, 2])
+
+    assert discovered == [layer]
+    assert count == 4
+    assert [call[4] for call in calls] == [8, 8, 16, 16]
+    assert calls[0][2] == list(range(9))
+    assert calls[0][3] == list(range(8))
+    assert calls[2][2] == list(range(17))
+    assert calls[2][3] == list(range(16))
+
+
+def test_nvfp4_moe_warmup_includes_supported_cuda_graph_shapes():
+    worker = SimpleNamespace(
+        vllm_config=SimpleNamespace(
+            compilation_config=SimpleNamespace(
+                cudagraph_capture_sizes=[1, 2, 4, 5, 8, 9, 18, 20]
+            )
+        )
+    )
+
+    assert warmup._get_nvfp4_moe_token_counts(
+        worker, [_nvfp4_moe_layer()], [1, 2, 4, 8]
+    ) == [1, 2, 4, 5, 8, 9, 18]
+
+
+def test_nvfp4_moe_warmup_uses_full_expert_groups_above_compact_b8(monkeypatch):
+    layer = _nvfp4_moe_layer()
+    calls = []
+    monkeypatch.setattr(
+        torch.ops._C, "nvfp4_moe_dense_stage_sm70_out", object(), raising=False
+    )
+    monkeypatch.setattr(
+        warmup.sm70_ops,
+        "nvfp4_moe_dense_stage_sm70_out",
+        lambda *args: calls.append(args),
+    )
+    monkeypatch.setattr(
+        torch.ops._C,
+        "silu_and_mul",
+        lambda out, gate_up: out.zero_(),
+        raising=False,
+    )
+
+    assert warmup._warmup_nvfp4_moe_decode_layers([layer], [9]) == 2
+    assert [call[6] for call in calls] == [256, 256]
+    assert all(call[2].numel() == 257 for call in calls)
+    assert all(call[3].numel() == 256 for call in calls)
+    assert calls[0][2][:73].tolist() == list(range(73))
+    assert calls[0][2][73:].tolist() == [72] * (257 - 73)
+
+
 def test_fp8_coordinated_warmup_leader_broadcasts_rank0_lut(monkeypatch):
     import vllm.distributed.parallel_state as parallel_state
 

--- a/tests/v1/spec_decode/test_mtp.py
+++ b/tests/v1/spec_decode/test_mtp.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+from types import SimpleNamespace
 from unittest import mock
 
 import pytest
@@ -26,9 +27,47 @@ from vllm.model_executor.models.llama import LlamaForCausalLM
 from vllm.platforms import current_platform
 from vllm.v1.attention.backends.registry import AttentionBackendEnum
 from vllm.v1.spec_decode.eagle import EagleProposer
+from vllm.v1.spec_decode.llm_base_proposer import (
+    SpecDecodeBaseProposer,
+    _sm70_mtp_moe_warmup_sizes,
+)
 
 mimo_7b_dir = "XiaomiMiMo/MiMo-7B-Base"
 DEVICE_TYPE = current_platform.device_type
+
+
+def test_sm70_mtp_moe_warmup_sizes():
+    assert _sm70_mtp_moe_warmup_sizes(256, 8, 8192) == (9, 33, 257)
+    assert _sm70_mtp_moe_warmup_sizes(256, 8, 32) == (9,)
+    assert _sm70_mtp_moe_warmup_sizes(0, 8, 8192) == ()
+
+
+def test_sm70_mtp_moe_warmup_runs_each_shape_once():
+    dummy_run = mock.Mock()
+    draft_model_config = SimpleNamespace(
+        is_moe=True,
+        hf_text_config=SimpleNamespace(num_experts_per_tok=8),
+        get_num_experts=lambda: 256,
+    )
+    proposer = SimpleNamespace(
+        method="mtp",
+        device=torch.device("cuda"),
+        draft_model_config=draft_model_config,
+        max_num_tokens=8192,
+        dummy_run=dummy_run,
+        _sm70_mtp_moe_warmed=False,
+    )
+
+    with (
+        mock.patch.object(current_platform, "is_device_capability", return_value=True),
+        mock.patch.object(torch.accelerator, "synchronize"),
+    ):
+        assert SpecDecodeBaseProposer.warmup_sm70_mtp_moe_kernels(proposer) == (
+            "mtp_draft_moe",
+        )
+
+    assert [call.args[0] for call in dummy_run.call_args_list] == [9, 33, 257]
+    assert all(call.kwargs["spec_step_idx"] == 0 for call in dummy_run.call_args_list)
 
 
 def _create_mtp_proposer(num_speculative_tokens: int) -> EagleProposer:

--- a/tests/v1/worker/test_mamba_utils.py
+++ b/tests/v1/worker/test_mamba_utils.py
@@ -544,6 +544,32 @@ def test_warmup_batch_memcpy_kernel():
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+def test_warmup_fused_postprocess_does_not_modify_state():
+    device = torch.device("cuda:0")
+    cfg = _TestConfig()
+    layer_names = ["layer_0"]
+    kv_cache_config = _make_kv_cache_config(cfg, layer_names)
+    gpu_ctx = _make_gpu_ctx(cfg, kv_cache_config, device)
+    _, _, conv_state, temporal_state, _, forward_context = _make_dual_layer_state(
+        cfg, device
+    )
+    block_table = torch.arange(
+        cfg.max_num_reqs * cfg.num_blocks,
+        dtype=torch.int32,
+        device=device,
+    ).reshape(cfg.max_num_reqs, cfg.num_blocks)
+    gpu_ctx.initialize_from_forward_context(
+        kv_cache_config, forward_context, _COPY_FUNCS, [block_table]
+    )
+    conv_before = conv_state.clone()
+    temporal_before = temporal_state.clone()
+
+    assert gpu_ctx.warmup_fused_postprocess()
+    assert torch.equal(conv_state, conv_before)
+    assert torch.equal(temporal_state, temporal_before)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
 class TestPostprocessMambaFusedKernel:
     """Tests for postprocess_mamba_fused_kernel comparing GPU vs CPU paths."""
 

--- a/tests/v1/worker/test_mamba_utils.py
+++ b/tests/v1/worker/test_mamba_utils.py
@@ -715,9 +715,7 @@ class TestPostprocessMambaFusedKernel:
         torch.manual_seed(20260617)
 
         accepted = [1, 2, 3, 4, 5]
-        req_ids = [f"same_{i}" for i in accepted] + [
-            f"cross_{i}" for i in accepted
-        ]
+        req_ids = [f"same_{i}" for i in accepted] + [f"cross_{i}" for i in accepted]
         num_accepted_tokens = accepted + accepted
         # scheduled=5 and draft=4 gives running_state = computed + 1.
         num_scheduled_tokens = {req_id: 5 for req_id in req_ids}
@@ -768,9 +766,7 @@ class TestPostprocessMambaFusedKernel:
         torch.accelerator.synchronize()
 
         gpu_ctx = _make_gpu_ctx(cfg, kv_cache_config, device)
-        block_table_gpu = torch.zeros(
-            len(req_ids), 8, dtype=torch.int32, device=device
-        )
+        block_table_gpu = torch.zeros(len(req_ids), 8, dtype=torch.int32, device=device)
         for i, block_ids in enumerate(block_ids_per_req):
             block_table_gpu[i, : len(block_ids)] = torch.tensor(
                 block_ids, dtype=torch.int32, device=device

--- a/vllm/_sm70_ops.py
+++ b/vllm/_sm70_ops.py
@@ -541,6 +541,50 @@ if hasattr(torch.ops._C, "mxfp4_moe_dense_stage_sm70_out"):
         return None
 
 
+def nvfp4_moe_dense_stage_sm70_out(
+    out: torch.Tensor,
+    input: torch.Tensor,
+    expert_offsets: torch.Tensor,
+    dense_expert_ids: torch.Tensor,
+    ptrs_w: torch.Tensor,
+    ptrs_s: torch.Tensor,
+    num_experts: int,
+    k: int,
+    n: int,
+    group_size: int,
+) -> None:
+    _op("nvfp4_moe_dense_stage_sm70_out")(
+        out,
+        input,
+        expert_offsets,
+        dense_expert_ids,
+        ptrs_w,
+        ptrs_s,
+        num_experts,
+        k,
+        n,
+        group_size,
+    )
+
+
+if hasattr(torch.ops._C, "nvfp4_moe_dense_stage_sm70_out"):
+
+    @register_fake("_C::nvfp4_moe_dense_stage_sm70_out")
+    def _nvfp4_moe_dense_stage_sm70_out_fake(
+        out: torch.Tensor,
+        input: torch.Tensor,
+        expert_offsets: torch.Tensor,
+        dense_expert_ids: torch.Tensor,
+        ptrs_w: torch.Tensor,
+        ptrs_s: torch.Tensor,
+        num_experts: int,
+        k: int,
+        n: int,
+        group_size: int,
+    ) -> None:
+        return None
+
+
 def mxfp4_moe_single_token_prepare_w13_sm70_out(
     gate_up: torch.Tensor,
     compact_input: torch.Tensor,

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -198,6 +198,7 @@ if TYPE_CHECKING:
     VLLM_SM70_FP8_TURBOMIND: bool = True
     VLLM_SM70_FP8_DENSE_GATED_SILU: bool = True
     VLLM_SM70_NVFP4_TURBOMIND: bool = True
+    VLLM_SM70_NVFP4_MOE_GROUPED_PREFILL: bool = True
     VLLM_SM70_MXFP4_TURBOMIND: bool = True
     VLLM_SM70_MXFP4_MOE_ACTIVE_EXPERT_B1: bool = False
     VLLM_SM70_MXFP4_MOE_ACTIVE_EXPERT_MAX_TOKENS: int = 8
@@ -1837,6 +1838,12 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # non-TurboMind route for diagnostics.
     "VLLM_SM70_NVFP4_TURBOMIND": lambda: bool(
         int(os.getenv("VLLM_SM70_NVFP4_TURBOMIND", "1"))
+    ),
+    # Dispatch all 256 routed experts in one grouped TurboMind call for the
+    # exact Qwen3.6-35B-A3B TP1/2/4 NVFP4 prefill shapes. B1-B8 decode keeps
+    # the compact active-expert route; larger graph shapes use full groups.
+    "VLLM_SM70_NVFP4_MOE_GROUPED_PREFILL": lambda: bool(
+        int(os.getenv("VLLM_SM70_NVFP4_MOE_GROUPED_PREFILL", "1"))
     ),
     "VLLM_SM70_MXFP4_TURBOMIND": lambda: bool(
         int(os.getenv("VLLM_SM70_MXFP4_TURBOMIND", "1"))

--- a/vllm/model_executor/layers/quantization/modelopt.py
+++ b/vllm/model_executor/layers/quantization/modelopt.py
@@ -453,6 +453,10 @@ class ModelOptFp8LinearMethod(LinearMethodBase):
         self.quant_config = quant_config
         self.out_dtype = torch.get_default_dtype()
         self.input_dtype = get_current_vllm_config().model_config.dtype
+        self.use_sm70_fp8_turbomind = (
+            sm70_tm.is_exact_sm70_cuda_platform()
+            and sm70_tm.use_turbomind(envs.VLLM_SM70_FP8_TURBOMIND)
+        )
 
     def create_weights(
         self,
@@ -502,6 +506,9 @@ class ModelOptFp8LinearMethod(LinearMethodBase):
             scale[:] = torch.finfo(torch.float32).min
             layer.register_parameter("input_scale", scale)
 
+        if self.use_sm70_fp8_turbomind:
+            return
+
         self.fp8_linear = init_fp8_linear_kernel(
             activation_quant_key=kFp8StaticTensorSym,
             weight_quant_key=kFp8StaticTensorSym,
@@ -518,6 +525,40 @@ class ModelOptFp8LinearMethod(LinearMethodBase):
             max_w_scale, weight = requantize_with_max_scale(
                 layer.weight, layer.weight_scale, layer.logical_widths
             )
+
+        if self.use_sm70_fp8_turbomind:
+            if not hasattr(torch.ops._C, "fp8_sm70_prepare"):
+                raise RuntimeError(
+                    "ModelOpt FP8 on SM70 requires the TurboMind extension "
+                    "with fp8_sm70_prepare."
+                )
+            if self.input_dtype != torch.float16:
+                raise RuntimeError(
+                    "ModelOpt FP8 TurboMind on SM70 requires FP16 activations, "
+                    f"got {self.input_dtype}."
+                )
+
+            from vllm import _sm70_ops as sm70_ops
+
+            block_size = 128
+            out_blocks = (weight.shape[0] + block_size - 1) // block_size
+            in_blocks = (weight.shape[1] + block_size - 1) // block_size
+            block_scales = (
+                max_w_scale.reshape(1, 1).expand(out_blocks, in_blocks).contiguous()
+            )
+            tm_weight, tm_scales, meta = sm70_ops.fp8_sm70_prepare(
+                weight, block_scales, block_size
+            )
+            replace_parameter(layer, "weight", tm_weight)
+            replace_parameter(layer, "weight_scale", tm_scales)
+            layer.input_scale = None
+            layer.sm70_modelopt_fp8_turbomind = True
+            layer.sm70_modelopt_fp8_group_size = block_size
+            layer.sm70_modelopt_fp8_k_ld = int(meta[0].item())
+            layer.sm70_modelopt_fp8_q_ld = int(meta[1].item())
+            logger.info_once("SM70 ModelOpt FP8 TurboMind W8A16 dense path enabled.")
+            return
+
         layer.weight = Parameter(weight.t(), requires_grad=False)
         layer.weight_scale = Parameter(max_w_scale, requires_grad=False)
         layer.input_scale = Parameter(layer.input_scale.max(), requires_grad=False)
@@ -529,6 +570,31 @@ class ModelOptFp8LinearMethod(LinearMethodBase):
         x: torch.Tensor,
         bias: torch.Tensor | None = None,
     ) -> torch.Tensor:
+        if getattr(layer, "sm70_modelopt_fp8_turbomind", False):
+            if x.dtype != torch.float16:
+                raise TypeError(
+                    "ModelOpt FP8 TurboMind on SM70 requires FP16 activations."
+                )
+            from vllm import _sm70_ops as sm70_ops
+
+            x_2d = x.reshape(-1, x.shape[-1])
+            out = torch.empty(
+                (x_2d.shape[0], layer.output_size_per_partition),
+                dtype=x.dtype,
+                device=x.device,
+            )
+            sm70_ops.fp8_gemm_sm70_out(
+                out,
+                x_2d,
+                layer.weight,
+                layer.weight_scale,
+                layer.sm70_modelopt_fp8_group_size,
+                layer.sm70_modelopt_fp8_k_ld,
+                layer.sm70_modelopt_fp8_q_ld,
+            )
+            if bias is not None:
+                out.add_(bias)
+            return out.reshape(*x.shape[:-1], layer.output_size_per_partition)
         return self.fp8_linear.apply_weights(layer, x, bias)
 
 
@@ -2286,6 +2352,12 @@ class ModelOptMixedPrecisionConfig(ModelOptQuantConfigBase):
 
     @classmethod
     def get_min_capability(cls) -> int:
+        if (
+            sm70_tm.is_exact_sm70_cuda_platform()
+            and sm70_tm.use_turbomind(envs.VLLM_SM70_FP8_TURBOMIND)
+            and sm70_tm.use_turbomind(envs.VLLM_SM70_NVFP4_TURBOMIND)
+        ):
+            return 70
         return 89
 
     @classmethod
@@ -2481,6 +2553,20 @@ class ModelOptMixedPrecisionConfig(ModelOptQuantConfigBase):
                     moe_config=layer.moe_config,
                 )
             if quant_algo == "W4A16_NVFP4":
+                if sm70_tm.is_exact_sm70_cuda_platform():
+                    if not sm70_tm.should_use_nvfp4_moe_turbomind():
+                        raise NotImplementedError(
+                            "ModelOpt W4A16 NVFP4 MoE on SM70 requires the "
+                            "TurboMind backend."
+                        )
+                    from vllm.model_executor.layers.quantization.nvfp4_sm70_moe import (
+                        ModelOptNvFp4SM70MoEMethod,
+                    )
+
+                    return ModelOptNvFp4SM70MoEMethod(
+                        quant_config=self.w4a16_nvfp4_config,
+                        moe_config=layer.moe_config,
+                    )
                 return ModelOptNvFp4FusedMoE(
                     quant_config=self.w4a16_nvfp4_config,
                     moe_config=layer.moe_config,

--- a/vllm/model_executor/layers/quantization/nvfp4_sm70_moe.py
+++ b/vllm/model_executor/layers/quantization/nvfp4_sm70_moe.py
@@ -48,7 +48,7 @@ _COMPACT_GROUPED_MAX_TOKENS: Final = 8
 
 
 @triton.jit
-def _compact_sorted_experts_kernel(
+def _prepare_compact_slot_groups_kernel(
     sorted_expert_ids_ptr,
     compact_offsets_ptr,
     active_expert_ids_ptr,
@@ -62,33 +62,19 @@ def _compact_sorted_experts_kernel(
         mask=valid,
         other=-1,
     )
-    previous_ids = tl.load(
-        sorted_expert_ids_ptr + offsets - 1,
-        mask=valid & (offsets > 0),
-        other=-2,
-    )
-    is_boundary = valid & ((offsets == 0) | (expert_ids != previous_ids))
-    active_indices = tl.cumsum(is_boundary.to(tl.int32), axis=0) - 1
-
     tl.store(
         compact_offsets_ptr + offsets,
-        TOTAL_SLOTS,
+        offsets,
         mask=offsets <= TOTAL_SLOTS,
     )
-    tl.store(active_expert_ids_ptr + offsets, 0, mask=valid)
     tl.store(
-        compact_offsets_ptr + active_indices,
-        offsets,
-        mask=is_boundary,
-    )
-    tl.store(
-        active_expert_ids_ptr + active_indices,
+        active_expert_ids_ptr + offsets,
         expert_ids,
-        mask=is_boundary,
+        mask=valid,
     )
 
 
-def _compact_active_experts(
+def _prepare_compact_slot_groups(
     sorted_expert_ids: torch.Tensor,
     compact_offsets: torch.Tensor,
     active_expert_ids: torch.Tensor,
@@ -98,7 +84,11 @@ def _compact_active_experts(
     if not (0 < total_slots <= max_slots):
         raise ValueError(f"Unsupported SM70 NVFP4 active-expert slots: {total_slots}")
     block = triton.next_power_of_2(total_slots + 1)
-    _compact_sorted_experts_kernel[(1,)](
+    # TurboMind's compact grouped dispatch forces one row per group. Keep each
+    # routed slot independent even when adjacent slots select the same expert;
+    # coalescing duplicate expert IDs would make the forced one-row scheduler
+    # silently skip or miscompute the additional rows.
+    _prepare_compact_slot_groups_kernel[(1,)](
         sorted_expert_ids,
         compact_offsets,
         active_expert_ids,
@@ -579,7 +569,7 @@ class ModelOptNvFp4SM70MoEMethod(ModelOptNvFp4FusedMoE):
         buffers["expert_offsets"].copy_(buffers["expert_offsets64"], non_blocking=True)
 
         if num_tokens <= _COMPACT_GROUPED_MAX_TOKENS:
-            _compact_active_experts(
+            _prepare_compact_slot_groups(
                 buffers["permuted_experts_id"],
                 buffers["compact_offsets"],
                 buffers["active_expert_ids"],

--- a/vllm/model_executor/layers/quantization/nvfp4_sm70_moe.py
+++ b/vllm/model_executor/layers/quantization/nvfp4_sm70_moe.py
@@ -1,0 +1,644 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Native SM70 TurboMind NVFP4 MoE for Qwen3.6-35B-A3B.
+
+The route keeps ModelOpt W4A16_NVFP4 expert weights packed. It combines the
+checkpoint's FP8 block scales with its explicit ModelOpt global scales once at
+load time, repacks both tensors for TurboMind, and never materializes an FP16
+expert-weight copy.
+"""
+
+from __future__ import annotations
+
+from typing import Final
+
+import torch
+from torch.nn import Parameter
+
+from vllm import _sm70_ops as sm70_ops
+from vllm.logger import init_logger
+from vllm.model_executor.layers.fused_moe import (
+    FusedMoEConfig,
+    FusedMoEMethodBase,
+    FusedMoEQuantConfig,
+    MoEActivation,
+    RoutedExperts,
+    SharedExperts,
+)
+from vllm.model_executor.layers.quantization.modelopt import (
+    ModelOptNvFp4Config,
+    ModelOptNvFp4FusedMoE,
+)
+from vllm.model_executor.layers.quantization.sm70_turbomind import (
+    NVFP4_GROUP_SIZE,
+    is_exact_sm70_cuda,
+    unpack_mxfp4_weight,
+)
+from vllm.triton_utils import tl, triton
+
+logger = init_logger(__name__)
+
+_QWEN36_HIDDEN_SIZE: Final = 2048
+_QWEN36_INTERMEDIATE_SIZE: Final = 512
+_QWEN36_NUM_EXPERTS: Final = 256
+_QWEN36_TOP_K: Final = 8
+_QWEN36_SUPPORTED_TP_SIZES: Final = (1, 2, 4)
+_GRAPH_SAFE_MAX_TOKENS: Final = 18
+_COMPACT_GROUPED_MAX_TOKENS: Final = 8
+
+
+@triton.jit
+def _compact_sorted_experts_kernel(
+    sorted_expert_ids_ptr,
+    compact_offsets_ptr,
+    active_expert_ids_ptr,
+    TOTAL_SLOTS: tl.constexpr,
+    BLOCK: tl.constexpr,
+):
+    offsets = tl.arange(0, BLOCK)
+    valid = offsets < TOTAL_SLOTS
+    expert_ids = tl.load(
+        sorted_expert_ids_ptr + offsets,
+        mask=valid,
+        other=-1,
+    )
+    previous_ids = tl.load(
+        sorted_expert_ids_ptr + offsets - 1,
+        mask=valid & (offsets > 0),
+        other=-2,
+    )
+    is_boundary = valid & ((offsets == 0) | (expert_ids != previous_ids))
+    active_indices = tl.cumsum(is_boundary.to(tl.int32), axis=0) - 1
+
+    tl.store(
+        compact_offsets_ptr + offsets,
+        TOTAL_SLOTS,
+        mask=offsets <= TOTAL_SLOTS,
+    )
+    tl.store(active_expert_ids_ptr + offsets, 0, mask=valid)
+    tl.store(
+        compact_offsets_ptr + active_indices,
+        offsets,
+        mask=is_boundary,
+    )
+    tl.store(
+        active_expert_ids_ptr + active_indices,
+        expert_ids,
+        mask=is_boundary,
+    )
+
+
+def _compact_active_experts(
+    sorted_expert_ids: torch.Tensor,
+    compact_offsets: torch.Tensor,
+    active_expert_ids: torch.Tensor,
+) -> None:
+    total_slots = sorted_expert_ids.numel()
+    max_slots = _COMPACT_GROUPED_MAX_TOKENS * _QWEN36_TOP_K
+    if not (0 < total_slots <= max_slots):
+        raise ValueError(f"Unsupported SM70 NVFP4 active-expert slots: {total_slots}")
+    block = triton.next_power_of_2(total_slots + 1)
+    _compact_sorted_experts_kernel[(1,)](
+        sorted_expert_ids,
+        compact_offsets,
+        active_expert_ids,
+        TOTAL_SLOTS=total_slots,
+        BLOCK=block,
+        num_warps=1,
+    )
+
+
+def validate_nvfp4_sm70_moe_contract(moe: FusedMoEConfig) -> None:
+    """Reject every model or topology outside the Qwen3.6 SM70 contract."""
+    if moe.num_experts != _QWEN36_NUM_EXPERTS:
+        raise NotImplementedError(
+            "SM70 TurboMind NVFP4 MoE currently supports Qwen3.6-35B-A3B "
+            f"with {_QWEN36_NUM_EXPERTS} experts, got {moe.num_experts}."
+        )
+    if moe.experts_per_token != _QWEN36_TOP_K:
+        raise NotImplementedError(
+            "SM70 TurboMind NVFP4 MoE currently supports top-k="
+            f"{_QWEN36_TOP_K}, got {moe.experts_per_token}."
+        )
+    if moe.hidden_dim != _QWEN36_HIDDEN_SIZE:
+        raise NotImplementedError(
+            "SM70 TurboMind NVFP4 MoE currently supports hidden size "
+            f"{_QWEN36_HIDDEN_SIZE}, got {moe.hidden_dim}."
+        )
+    if moe.tp_size not in _QWEN36_SUPPORTED_TP_SIZES:
+        raise NotImplementedError(
+            "SM70 TurboMind NVFP4 MoE currently supports tensor parallel "
+            f"sizes {_QWEN36_SUPPORTED_TP_SIZES}, got {moe.tp_size}."
+        )
+    local_intermediate = moe.intermediate_size_per_partition
+    if local_intermediate <= 0 or local_intermediate % NVFP4_GROUP_SIZE:
+        raise NotImplementedError(
+            "SM70 TurboMind NVFP4 MoE requires a positive local intermediate "
+            f"size divisible by {NVFP4_GROUP_SIZE}, got {local_intermediate}."
+        )
+    if local_intermediate * max(moe.tp_size, 1) != _QWEN36_INTERMEDIATE_SIZE:
+        raise NotImplementedError(
+            "SM70 TurboMind NVFP4 MoE currently supports Qwen3.6 expert "
+            f"intermediate size {_QWEN36_INTERMEDIATE_SIZE}; got local="
+            f"{local_intermediate}, tp_size={moe.tp_size}."
+        )
+    if moe.moe_parallel_config.use_all2all_kernels:
+        raise NotImplementedError(
+            "SM70 TurboMind NVFP4 MoE does not support DP+EP all-to-all."
+        )
+
+
+def _validate_weight_layout(layer: RoutedExperts) -> None:
+    local_experts = int(layer.local_num_experts)
+    hidden = int(layer.moe_config.hidden_dim)
+    intermediate = int(layer.moe_config.intermediate_size_per_partition)
+    expected = {
+        "w13_weight": (local_experts, 2 * intermediate, hidden // 2),
+        "w13_weight_scale": (
+            local_experts,
+            2 * intermediate,
+            hidden // NVFP4_GROUP_SIZE,
+        ),
+        "w13_weight_scale_2": (local_experts, 2),
+        "w2_weight": (local_experts, hidden, intermediate // 2),
+        "w2_weight_scale": (
+            local_experts,
+            hidden,
+            intermediate // NVFP4_GROUP_SIZE,
+        ),
+        "w2_weight_scale_2": (local_experts,),
+    }
+    tensors = {name: getattr(layer, name) for name in expected}
+    for name, shape in expected.items():
+        if tuple(tensors[name].shape) != shape:
+            raise ValueError(
+                f"SM70 NVFP4 MoE layout mismatch for {name}: "
+                f"expected {shape}, got {tuple(tensors[name].shape)}."
+            )
+    if layer.w13_weight.dtype != torch.uint8 or layer.w2_weight.dtype != torch.uint8:
+        raise TypeError("SM70 NVFP4 MoE requires packed uint8 expert weights.")
+    if (
+        layer.w13_weight_scale.dtype != torch.float8_e4m3fn
+        or layer.w2_weight_scale.dtype != torch.float8_e4m3fn
+    ):
+        raise TypeError("SM70 NVFP4 MoE requires FP8 E4M3 block scales.")
+
+
+class ModelOptNvFp4SM70MoEMethod(ModelOptNvFp4FusedMoE):
+    """Qwen3.6 ModelOpt W4A16_NVFP4 experts on native TurboMind SM70."""
+
+    def __init__(
+        self,
+        quant_config: ModelOptNvFp4Config,
+        moe_config: FusedMoEConfig,
+    ) -> None:
+        FusedMoEMethodBase.__init__(self, moe_config)
+        if quant_config.quant_method != "W4A16_NVFP4":
+            raise NotImplementedError(
+                "SM70 TurboMind ModelOpt NVFP4 MoE currently requires "
+                "W4A16_NVFP4 checkpoint weights."
+            )
+        self.quant_config = quant_config
+        self.use_a16 = True
+        self.use_global_sf = False
+        validate_nvfp4_sm70_moe_contract(moe_config)
+
+    @property
+    def supports_eplb(self) -> bool:
+        return False
+
+    def maybe_make_prepare_finalize(
+        self,
+        routing_tables: tuple[torch.Tensor, torch.Tensor, torch.Tensor] | None = None,
+    ) -> None:
+        # This method owns routing, TurboMind expert GEMMs, and unpermutation.
+        # Do not wrap it in the generic ModelOpt modular-kernel path.
+        del routing_tables
+        return None
+
+    def process_weights_after_loading(self, layer: RoutedExperts) -> None:
+        required_ops = (
+            "nvfp4_sm70_prepare",
+            "nvfp4_moe_dense_stage_sm70_out",
+            "awq_moe_build_strided_ptrs",
+        )
+        missing = [name for name in required_ops if not hasattr(torch.ops._C, name)]
+        if missing:
+            raise RuntimeError(
+                "Qwen3.6 NVFP4 MoE on SM70 requires the TurboMind extension "
+                "with " + ", ".join(missing) + "."
+            )
+        if not hasattr(torch.ops._moe_C, "moe_permute_with_scratch"):
+            raise RuntimeError(
+                "Qwen3.6 NVFP4 MoE on SM70 requires graph-safe MoE permute ops."
+            )
+        if self.moe.has_bias:
+            raise NotImplementedError("SM70 NVFP4 MoE does not support expert bias.")
+        if layer.activation != MoEActivation.SILU:
+            raise NotImplementedError(
+                "SM70 NVFP4 MoE currently supports SwiGLU/SILU only."
+            )
+        if layer.apply_router_weight_on_input:
+            raise NotImplementedError(
+                "SM70 NVFP4 MoE does not support router weights on input."
+            )
+        if layer.expert_map is not None:
+            raise NotImplementedError(
+                "SM70 NVFP4 MoE currently requires fully replicated experts."
+            )
+        if layer.local_num_experts != layer.global_num_experts:
+            raise NotImplementedError(
+                "SM70 NVFP4 MoE currently requires local and global experts to match."
+            )
+
+        validate_nvfp4_sm70_moe_contract(layer.moe_config)
+        _validate_weight_layout(layer)
+        num_experts = int(layer.local_num_experts)
+        hidden = int(layer.moe_config.hidden_dim)
+        intermediate = int(layer.moe_config.intermediate_size_per_partition)
+
+        w13_tm_weights: list[torch.Tensor] = []
+        w13_tm_scales: list[torch.Tensor] = []
+        w13_meta: list[torch.Tensor] = []
+        w2_tm_weights: list[torch.Tensor] = []
+        w2_tm_scales: list[torch.Tensor] = []
+        w2_meta: list[torch.Tensor] = []
+        for expert_id in range(num_experts):
+            w13_packed = unpack_mxfp4_weight(layer.w13_weight[expert_id].data)
+            w13_scales = layer.w13_weight_scale[expert_id].float().clone()
+            w13_global = layer.w13_weight_scale_2[expert_id].float()
+            w13_scales[:intermediate].mul_(w13_global[0])
+            w13_scales[intermediate:].mul_(w13_global[1])
+            prepared_w13 = sm70_ops.nvfp4_sm70_prepare(
+                w13_packed,
+                w13_scales.half().t().contiguous(),
+                NVFP4_GROUP_SIZE,
+            )
+            w13_tm_weights.append(prepared_w13[0])
+            w13_tm_scales.append(prepared_w13[1])
+            w13_meta.append(prepared_w13[2])
+
+            w2_packed = unpack_mxfp4_weight(layer.w2_weight[expert_id].data)
+            w2_scales = (
+                layer.w2_weight_scale[expert_id].float()
+                * layer.w2_weight_scale_2[expert_id].float()
+            )
+            prepared_w2 = sm70_ops.nvfp4_sm70_prepare(
+                w2_packed,
+                w2_scales.half().t().contiguous(),
+                NVFP4_GROUP_SIZE,
+            )
+            w2_tm_weights.append(prepared_w2[0])
+            w2_tm_scales.append(prepared_w2[1])
+            w2_meta.append(prepared_w2[2])
+
+        layer.w13_tm_weight = Parameter(
+            torch.stack(w13_tm_weights), requires_grad=False
+        )
+        layer.w13_tm_scales = Parameter(torch.stack(w13_tm_scales), requires_grad=False)
+        layer.w2_tm_weight = Parameter(torch.stack(w2_tm_weights), requires_grad=False)
+        layer.w2_tm_scales = Parameter(torch.stack(w2_tm_scales), requires_grad=False)
+
+        w13_k_ld = int(w13_meta[0][0].item())
+        w13_q_ld = int(w13_meta[0][1].item())
+        w2_k_ld = int(w2_meta[0][0].item())
+        w2_q_ld = int(w2_meta[0][1].item())
+        w13_ptrs = sm70_ops.awq_moe_build_strided_ptrs(
+            layer.w13_tm_weight,
+            layer.w13_tm_scales,
+            w13_k_ld,
+            w13_q_ld,
+            num_experts,
+        )
+        w2_ptrs = sm70_ops.awq_moe_build_strided_ptrs(
+            layer.w2_tm_weight,
+            layer.w2_tm_scales,
+            w2_k_ld,
+            w2_q_ld,
+            num_experts,
+        )
+        layer.w13_strided_ptrs_w = Parameter(w13_ptrs[0], requires_grad=False)
+        layer.w13_strided_ptrs_s = Parameter(w13_ptrs[1], requires_grad=False)
+        layer.w2_strided_ptrs_w = Parameter(w2_ptrs[0], requires_grad=False)
+        layer.w2_strided_ptrs_s = Parameter(w2_ptrs[1], requires_grad=False)
+
+        layer.sm70_nvfp4_moe = True
+        layer.sm70_nvfp4_num_experts = num_experts
+        layer.sm70_nvfp4_hidden_size = hidden
+        layer.sm70_nvfp4_intermediate_size = intermediate
+        layer.sm70_nvfp4_w13_k_dim = hidden
+        layer.sm70_nvfp4_w13_n_dim = 2 * intermediate
+        layer.sm70_nvfp4_w2_k_dim = intermediate
+        layer.sm70_nvfp4_w2_n_dim = hidden
+        layer.sm70_nvfp4_group_size = NVFP4_GROUP_SIZE
+        layer.sm70_nvfp4_graph_safe_max_tokens = _GRAPH_SAFE_MAX_TOKENS
+        self._allocate_graph_safe_decode_buffers(layer)
+
+        del layer.w13_weight
+        del layer.w13_weight_scale
+        del layer.w13_weight_scale_2
+        del layer.w13_input_scale
+        del layer.w2_weight
+        del layer.w2_weight_scale
+        del layer.w2_weight_scale_2
+        del layer.w2_input_scale
+        logger.info_once(
+            "SM70 ModelOpt NVFP4 TurboMind MoE path enabled for "
+            "Qwen3.6-35B-A3B (local_experts=%d, graph_safe_decode=B1-B%d, "
+            "compact_grouped_decode=B1-B%d).",
+            num_experts,
+            _GRAPH_SAFE_MAX_TOKENS,
+            _COMPACT_GROUPED_MAX_TOKENS,
+        )
+
+    def _allocate_graph_safe_decode_buffers(self, layer: RoutedExperts) -> None:
+        device = layer.w13_tm_weight.device
+        max_slots = _GRAPH_SAFE_MAX_TOKENS * _QWEN36_TOP_K
+        experts = int(layer.sm70_nvfp4_num_experts)
+        hidden = int(layer.sm70_nvfp4_hidden_size)
+        intermediate = int(layer.sm70_nvfp4_intermediate_size)
+
+        layer._nvfp4_sm70_output = torch.empty(
+            _GRAPH_SAFE_MAX_TOKENS, hidden, dtype=torch.float16, device=device
+        )
+        layer._nvfp4_sm70_permuted_input = torch.empty(
+            max_slots, hidden, dtype=torch.float16, device=device
+        )
+        layer._nvfp4_sm70_gate_up = torch.empty(
+            max_slots, 2 * intermediate, dtype=torch.float16, device=device
+        )
+        layer._nvfp4_sm70_intermediate = torch.empty(
+            max_slots, intermediate, dtype=torch.float16, device=device
+        )
+        layer._nvfp4_sm70_sorted_output = torch.empty(
+            max_slots, hidden, dtype=torch.float16, device=device
+        )
+        layer._nvfp4_sm70_expert_offsets = torch.empty(
+            experts + 1, dtype=torch.int32, device=device
+        )
+        layer._nvfp4_sm70_expert_offsets64 = torch.empty(
+            experts + 1, dtype=torch.int64, device=device
+        )
+        layer._nvfp4_sm70_inv_permuted_idx = torch.empty(
+            _GRAPH_SAFE_MAX_TOKENS,
+            _QWEN36_TOP_K,
+            dtype=torch.int32,
+            device=device,
+        )
+        layer._nvfp4_sm70_topk_ids = torch.empty(
+            _GRAPH_SAFE_MAX_TOKENS,
+            _QWEN36_TOP_K,
+            dtype=torch.int32,
+            device=device,
+        )
+        layer._nvfp4_sm70_token_expert_indices = torch.arange(
+            max_slots, dtype=torch.int32, device=device
+        ).view(_GRAPH_SAFE_MAX_TOKENS, _QWEN36_TOP_K)
+        layer._nvfp4_sm70_permuted_idx = torch.empty(
+            max_slots, dtype=torch.int32, device=device
+        )
+        layer._nvfp4_sm70_permuted_experts_id = torch.empty(
+            max_slots, dtype=torch.int32, device=device
+        )
+        layer._nvfp4_sm70_sorted_row_idx = torch.empty(
+            max_slots, dtype=torch.int32, device=device
+        )
+        layer._nvfp4_sm70_topk_ids_for_sort = torch.empty(
+            max_slots, dtype=torch.int32, device=device
+        )
+        workspace_size = torch.ops._moe_C.moe_permute_sort_workspace_size(
+            max_slots, layer.global_num_experts
+        )
+        layer._nvfp4_sm70_sort_workspace = torch.empty(
+            workspace_size, dtype=torch.int8, device=device
+        )
+        layer._nvfp4_sm70_dense_expert_ids = torch.arange(
+            experts, dtype=torch.int32, device=device
+        )
+        layer._nvfp4_sm70_compact_offsets = torch.empty(
+            max_slots + 1, dtype=torch.int32, device=device
+        )
+        layer._nvfp4_sm70_active_expert_ids = torch.empty(
+            max_slots, dtype=torch.int32, device=device
+        )
+
+    @staticmethod
+    def _persistent_buffers(
+        layer: RoutedExperts, num_tokens: int
+    ) -> dict[str, torch.Tensor]:
+        slots = num_tokens * _QWEN36_TOP_K
+        return {
+            "output": layer._nvfp4_sm70_output[:num_tokens],
+            "permuted_input": layer._nvfp4_sm70_permuted_input[:slots],
+            "gate_up": layer._nvfp4_sm70_gate_up[:slots],
+            "intermediate": layer._nvfp4_sm70_intermediate[:slots],
+            "sorted_output": layer._nvfp4_sm70_sorted_output[:slots],
+            "expert_offsets": layer._nvfp4_sm70_expert_offsets,
+            "expert_offsets64": layer._nvfp4_sm70_expert_offsets64,
+            "inv_permuted_idx": layer._nvfp4_sm70_inv_permuted_idx[:num_tokens],
+            "topk_ids": layer._nvfp4_sm70_topk_ids[:num_tokens],
+            "token_expert_indices": (
+                layer._nvfp4_sm70_token_expert_indices[:num_tokens]
+            ),
+            "permuted_idx": layer._nvfp4_sm70_permuted_idx[:slots],
+            "sort_workspace": layer._nvfp4_sm70_sort_workspace,
+            "permuted_experts_id": layer._nvfp4_sm70_permuted_experts_id[:slots],
+            "sorted_row_idx": layer._nvfp4_sm70_sorted_row_idx[:slots],
+            "topk_ids_for_sort": layer._nvfp4_sm70_topk_ids_for_sort[:slots],
+            "dense_expert_ids": layer._nvfp4_sm70_dense_expert_ids,
+            "compact_offsets": layer._nvfp4_sm70_compact_offsets[: slots + 1],
+            "active_expert_ids": layer._nvfp4_sm70_active_expert_ids[:slots],
+        }
+
+    @staticmethod
+    def _eager_buffers(
+        layer: RoutedExperts, num_tokens: int
+    ) -> dict[str, torch.Tensor]:
+        device = layer.w13_tm_weight.device
+        slots = num_tokens * _QWEN36_TOP_K
+        experts = int(layer.sm70_nvfp4_num_experts)
+        hidden = int(layer.sm70_nvfp4_hidden_size)
+        intermediate = int(layer.sm70_nvfp4_intermediate_size)
+        workspace_size = torch.ops._moe_C.moe_permute_sort_workspace_size(
+            slots, layer.global_num_experts
+        )
+        return {
+            "output": torch.empty(
+                num_tokens, hidden, dtype=torch.float16, device=device
+            ),
+            "permuted_input": torch.empty(
+                slots, hidden, dtype=torch.float16, device=device
+            ),
+            "gate_up": torch.empty(
+                slots, 2 * intermediate, dtype=torch.float16, device=device
+            ),
+            "intermediate": torch.empty(
+                slots, intermediate, dtype=torch.float16, device=device
+            ),
+            "sorted_output": torch.empty(
+                slots, hidden, dtype=torch.float16, device=device
+            ),
+            "expert_offsets": torch.empty(
+                experts + 1, dtype=torch.int32, device=device
+            ),
+            "expert_offsets64": torch.empty(
+                experts + 1, dtype=torch.int64, device=device
+            ),
+            "inv_permuted_idx": torch.empty(
+                num_tokens, _QWEN36_TOP_K, dtype=torch.int32, device=device
+            ),
+            "topk_ids": torch.empty(
+                num_tokens, _QWEN36_TOP_K, dtype=torch.int32, device=device
+            ),
+            "token_expert_indices": torch.arange(
+                slots, dtype=torch.int32, device=device
+            ).view(num_tokens, _QWEN36_TOP_K),
+            "permuted_idx": torch.empty(slots, dtype=torch.int32, device=device),
+            "sort_workspace": torch.empty(
+                workspace_size, dtype=torch.int8, device=device
+            ),
+            "permuted_experts_id": torch.empty(slots, dtype=torch.int32, device=device),
+            "sorted_row_idx": torch.empty(slots, dtype=torch.int32, device=device),
+            "topk_ids_for_sort": torch.empty(slots, dtype=torch.int32, device=device),
+            "dense_expert_ids": layer._nvfp4_sm70_dense_expert_ids,
+            "compact_offsets": torch.empty(slots + 1, dtype=torch.int32, device=device),
+            "active_expert_ids": torch.empty(slots, dtype=torch.int32, device=device),
+        }
+
+    def _get_buffers(
+        self, layer: RoutedExperts, num_tokens: int
+    ) -> dict[str, torch.Tensor]:
+        if 0 < num_tokens <= _GRAPH_SAFE_MAX_TOKENS:
+            return self._persistent_buffers(layer, num_tokens)
+        return self._eager_buffers(layer, num_tokens)
+
+    @staticmethod
+    def _apply_swiglu(
+        layer: RoutedExperts, out: torch.Tensor, gate_up: torch.Tensor
+    ) -> None:
+        if layer.swiglu_limit is None:
+            torch.ops._C.silu_and_mul(out, gate_up)
+        else:
+            torch.ops._C.silu_and_mul_with_clamp(
+                out, gate_up, float(layer.swiglu_limit)
+            )
+
+    def apply(
+        self,
+        layer: RoutedExperts,
+        x: torch.Tensor,
+        topk_weights: torch.Tensor,
+        topk_ids: torch.Tensor,
+        shared_experts: SharedExperts | None,
+        shared_experts_input: torch.Tensor | None,
+    ) -> torch.Tensor:
+        del shared_experts, shared_experts_input
+        if not x.is_cuda or x.dtype != torch.float16 or x.ndim != 2:
+            raise TypeError("SM70 NVFP4 MoE requires CUDA FP16 activations [M, H].")
+        if not is_exact_sm70_cuda(x, enabled=True):
+            raise RuntimeError("SM70 NVFP4 MoE dispatch is restricted to CUDA SM70.")
+        if x.shape[1] != _QWEN36_HIDDEN_SIZE:
+            raise ValueError(
+                "SM70 NVFP4 MoE activation hidden size mismatch: expected "
+                f"{_QWEN36_HIDDEN_SIZE}, got {x.shape[1]}."
+            )
+        if tuple(topk_ids.shape) != (x.shape[0], _QWEN36_TOP_K):
+            raise ValueError("SM70 NVFP4 MoE requires top-k IDs with shape [M, 8].")
+        if tuple(topk_weights.shape) != tuple(topk_ids.shape):
+            raise ValueError("SM70 NVFP4 MoE top-k weights and IDs must share shape.")
+        if topk_weights.dtype != torch.float32:
+            raise TypeError("SM70 NVFP4 MoE requires float32 top-k weights.")
+
+        num_tokens = x.shape[0]
+        if num_tokens == 0:
+            return x.new_empty((0, _QWEN36_HIDDEN_SIZE))
+        buffers = self._get_buffers(layer, num_tokens)
+        output = buffers["output"]
+        output.zero_()
+        slots = num_tokens * _QWEN36_TOP_K
+        topk_ids_i32 = buffers["topk_ids"]
+        topk_ids_i32.copy_(topk_ids, non_blocking=True)
+        buffers["permuted_idx"].fill_(slots)
+        torch.ops._moe_C.moe_permute_with_scratch(
+            x,
+            topk_ids_i32,
+            buffers["token_expert_indices"],
+            layer.expert_map,
+            layer.global_num_experts,
+            layer.local_num_experts,
+            _QWEN36_TOP_K,
+            buffers["permuted_input"],
+            buffers["expert_offsets64"],
+            buffers["inv_permuted_idx"],
+            buffers["permuted_idx"],
+            buffers["sort_workspace"],
+            buffers["permuted_experts_id"],
+            buffers["sorted_row_idx"],
+            buffers["topk_ids_for_sort"],
+        )
+        buffers["expert_offsets"].copy_(buffers["expert_offsets64"], non_blocking=True)
+
+        if num_tokens <= _COMPACT_GROUPED_MAX_TOKENS:
+            _compact_active_experts(
+                buffers["permuted_experts_id"],
+                buffers["compact_offsets"],
+                buffers["active_expert_ids"],
+            )
+            stage_offsets = buffers["compact_offsets"]
+            stage_expert_ids = buffers["active_expert_ids"]
+            stage_experts = slots
+        else:
+            stage_offsets = buffers["expert_offsets"]
+            stage_expert_ids = buffers["dense_expert_ids"]
+            stage_experts = int(layer.sm70_nvfp4_num_experts)
+
+        sm70_ops.nvfp4_moe_dense_stage_sm70_out(
+            buffers["gate_up"],
+            buffers["permuted_input"],
+            stage_offsets,
+            stage_expert_ids,
+            layer.w13_strided_ptrs_w,
+            layer.w13_strided_ptrs_s,
+            stage_experts,
+            layer.sm70_nvfp4_w13_k_dim,
+            layer.sm70_nvfp4_w13_n_dim,
+            layer.sm70_nvfp4_group_size,
+        )
+        self._apply_swiglu(layer, buffers["intermediate"], buffers["gate_up"])
+        sm70_ops.nvfp4_moe_dense_stage_sm70_out(
+            buffers["sorted_output"],
+            buffers["intermediate"],
+            stage_offsets,
+            stage_expert_ids,
+            layer.w2_strided_ptrs_w,
+            layer.w2_strided_ptrs_s,
+            stage_experts,
+            layer.sm70_nvfp4_w2_k_dim,
+            layer.sm70_nvfp4_w2_n_dim,
+            layer.sm70_nvfp4_group_size,
+        )
+        torch.ops._moe_C.moe_unpermute(
+            buffers["sorted_output"],
+            topk_weights,
+            buffers["inv_permuted_idx"],
+            buffers["expert_offsets64"],
+            _QWEN36_TOP_K,
+            output,
+        )
+        return output
+
+    def apply_monolithic(
+        self,
+        layer: RoutedExperts,
+        x: torch.Tensor,
+        router_logits: torch.Tensor,
+        input_ids: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        del layer, x, router_logits, input_ids
+        raise NotImplementedError("SM70 NVFP4 MoE is not a monolithic route.")
+
+    def get_fused_moe_quant_config(
+        self, layer: RoutedExperts
+    ) -> FusedMoEQuantConfig | None:
+        del layer
+        return None

--- a/vllm/model_executor/layers/quantization/nvfp4_sm70_moe.py
+++ b/vllm/model_executor/layers/quantization/nvfp4_sm70_moe.py
@@ -627,7 +627,7 @@ class ModelOptNvFp4SM70MoEMethod(ModelOptNvFp4FusedMoE):
         del layer, x, router_logits, input_ids
         raise NotImplementedError("SM70 NVFP4 MoE is not a monolithic route.")
 
-    def get_fused_moe_quant_config(
+    def get_fused_moe_quant_config(  # type: ignore[override]
         self, layer: RoutedExperts
     ) -> FusedMoEQuantConfig | None:
         del layer

--- a/vllm/model_executor/layers/quantization/sm70_turbomind.py
+++ b/vllm/model_executor/layers/quantization/sm70_turbomind.py
@@ -64,6 +64,13 @@ def should_use_mxfp4_moe_turbomind() -> bool:
     )
 
 
+def should_use_nvfp4_moe_turbomind() -> bool:
+    """Select the native NVFP4 MoE path only on exact SM70."""
+    return is_exact_sm70_cuda_platform() and use_turbomind(
+        envs.VLLM_SM70_NVFP4_TURBOMIND
+    )
+
+
 def should_prepare_turbomind(
     tensor: torch.Tensor,
     default_enabled: bool,

--- a/vllm/model_executor/models/qwen3_5.py
+++ b/vllm/model_executor/models/qwen3_5.py
@@ -116,6 +116,7 @@ from .utils import (
 
 logger = init_logger(__name__)
 
+
 def _parse_sm70_moe_dense_allowlist() -> set[str] | None:
     raw = envs.VLLM_SM70_MOE_DENSE_ALLOWLIST
     if raw is None:
@@ -329,15 +330,9 @@ class Qwen3_5GatedDeltaNet(QwenGatedDeltaNetAttention):
             ba_start = z_start + z_size
             a_start = ba_start + ba_size
             mixed_qkv = mixed_qkvzba[..., :qkv_size]
-            z = _sm70_compile_graph_slice_dim(
-                mixed_qkvzba, -1, z_start, z_size
-            )
-            b = _sm70_compile_graph_slice_dim(
-                mixed_qkvzba, -1, ba_start, ba_size
-            )
-            a = _sm70_compile_graph_slice_dim(
-                mixed_qkvzba, -1, a_start, ba_size
-            )
+            z = _sm70_compile_graph_slice_dim(mixed_qkvzba, -1, z_start, z_size)
+            b = _sm70_compile_graph_slice_dim(mixed_qkvzba, -1, ba_start, ba_size)
+            a = _sm70_compile_graph_slice_dim(mixed_qkvzba, -1, a_start, ba_size)
 
         mixed_qkv = _sm70_dump_gdn_projection_tensor(
             "split_mixed_qkv", layer_name, mixed_qkv

--- a/vllm/model_executor/models/qwen3_5.py
+++ b/vllm/model_executor/models/qwen3_5.py
@@ -146,15 +146,63 @@ def _uses_split_gdn_input_projections(
     raw_config = getattr(quant_config, "config", None)
     if isinstance(raw_config, dict):
         add_ignored_modules(raw_config.get("ignore"))
-    if not ignored_modules:
-        return False
-    return any(
+    if any(
         module_name == "linear_attn"
         or module_name.endswith(".linear_attn")
         or ("linear_attn.in_proj_a" in module_name)
         or ("linear_attn.in_proj_b" in module_name)
         for module_name in ignored_modules
-    )
+    ):
+        return True
+
+    # ModelOpt mixed checkpoints describe quantized modules positively in
+    # ``quantized_layers`` instead of listing the unquantized b/a projections
+    # in an ignore list. A fused qkv/z/b/a Linear would then allocate the b/a
+    # rows in the qkv/z quant format and leave their scale slots uninitialized.
+    # Compare algorithms per GDN layer and split whenever b/a is absent or
+    # differs from the quantized qkv/z group.
+    quantized_layers = getattr(quant_config, "quantized_layers", None)
+    if not isinstance(quantized_layers, dict):
+        return False
+
+    per_layer: dict[str, dict[str, str]] = {}
+    projection_names = {
+        "in_proj_qkv",
+        "in_proj_z",
+        "in_proj_b",
+        "in_proj_a",
+    }
+    marker = ".linear_attn."
+    for module_name, layer_info in quantized_layers.items():
+        if marker not in module_name or not isinstance(layer_info, dict):
+            continue
+        layer_prefix, projection_name = module_name.rsplit(marker, 1)
+        if projection_name not in projection_names:
+            continue
+        quant_algo = str(layer_info.get("quant_algo", "")).upper()
+        if quant_algo:
+            per_layer.setdefault(layer_prefix, {})[projection_name] = quant_algo
+
+    for projection_algos in per_layer.values():
+        qkvz_algos = {
+            projection_algos[name]
+            for name in ("in_proj_qkv", "in_proj_z")
+            if name in projection_algos
+        }
+        if not qkvz_algos:
+            continue
+        ba_algos = {
+            projection_algos[name]
+            for name in ("in_proj_b", "in_proj_a")
+            if name in projection_algos
+        }
+        has_ba_pair = all(
+            name in projection_algos for name in ("in_proj_b", "in_proj_a")
+        )
+        if not has_ba_pair or ba_algos != qkvz_algos:
+            return True
+
+    return False
 
 
 def _get_default_sm70_dense_force_suffixes(tp_size: int) -> set[str]:

--- a/vllm/model_executor/warmup/awq_sm70_warmup.py
+++ b/vllm/model_executor/warmup/awq_sm70_warmup.py
@@ -44,6 +44,7 @@ def _lut_cache_disabled_for_dynamic_quant_dispatch(
     has_fp8_dense: bool,
     fp4_kinds: set[str],
     has_mxfp4_moe: bool = False,
+    has_nvfp4_moe: bool = False,
 ) -> bool:
     awq_no_preserve = (
         has_awq_dense
@@ -59,7 +60,9 @@ def _lut_cache_disabled_for_dynamic_quant_dispatch(
     mxfp4_dynamic = (
         "mxfp4" in fp4_kinds or has_mxfp4_moe
     ) and envs.VLLM_SM70_MXFP4_TUNE_SMALL_SHAPES
-    nvfp4_dynamic = "nvfp4" in fp4_kinds and envs.VLLM_SM70_NVFP4_TUNE_SMALL_SHAPES
+    nvfp4_dynamic = (
+        "nvfp4" in fp4_kinds or has_nvfp4_moe
+    ) and envs.VLLM_SM70_NVFP4_TUNE_SMALL_SHAPES
     return awq_no_preserve or fp8_dynamic or mxfp4_dynamic or nvfp4_dynamic
 
 
@@ -259,7 +262,10 @@ def _iter_unique_fp8_dense_layers(
 ) -> Iterable[tuple[torch.nn.Module, bool]]:
     seen: set[tuple[int, int, bool]] = set()
     for layer in model.modules():
-        if not getattr(layer, "sm70_fp8_turbomind", False):
+        if not (
+            getattr(layer, "sm70_fp8_turbomind", False)
+            or getattr(layer, "sm70_modelopt_fp8_turbomind", False)
+        ):
             continue
 
         if getattr(layer, "sm70_fp8_bmm", False):
@@ -387,6 +393,45 @@ def _iter_unique_mxfp4_moe_layers(
         yield layer
 
 
+def _is_nvfp4_moe_sm70_layer(layer: torch.nn.Module) -> bool:
+    return getattr(layer, "sm70_nvfp4_moe", False) and all(
+        hasattr(layer, name)
+        for name in (
+            "w13_strided_ptrs_w",
+            "w13_strided_ptrs_s",
+            "w2_strided_ptrs_w",
+            "w2_strided_ptrs_s",
+            "sm70_nvfp4_num_experts",
+            "sm70_nvfp4_w13_k_dim",
+            "sm70_nvfp4_w13_n_dim",
+            "sm70_nvfp4_w2_k_dim",
+            "sm70_nvfp4_w2_n_dim",
+            "sm70_nvfp4_group_size",
+            "_nvfp4_sm70_dense_expert_ids",
+        )
+    )
+
+
+def _iter_unique_nvfp4_moe_layers(
+    model: torch.nn.Module,
+) -> Iterable[torch.nn.Module]:
+    seen: set[tuple[int, int, int, int, int]] = set()
+    for layer in model.modules():
+        if not _is_nvfp4_moe_sm70_layer(layer):
+            continue
+        key = (
+            int(layer.sm70_nvfp4_w13_k_dim),
+            int(layer.sm70_nvfp4_w13_n_dim),
+            int(layer.sm70_nvfp4_w2_k_dim),
+            int(layer.sm70_nvfp4_w2_n_dim),
+            int(layer.sm70_nvfp4_num_experts),
+        )
+        if key in seen:
+            continue
+        seen.add(key)
+        yield layer
+
+
 def _warmup_dense_layers(
     dense_layers: list[torch.nn.Module],
     m_values: list[int],
@@ -423,6 +468,7 @@ def _warmup_fp8_dense_layers(
 
     calls = 0
     for layer, gated_silu in dense_layers:
+        is_modelopt = getattr(layer, "sm70_modelopt_fp8_turbomind", False)
         if getattr(layer, "sm70_fp8_bmm", False):
             assert not gated_silu
             weight = layer.weight[0]
@@ -444,9 +490,14 @@ def _warmup_fp8_dense_layers(
             n_dim = int(weight.shape[1]) // 2
         else:
             weight = layer.weight
-            scales = layer.weight_scale_inv
-            k_ld = int(layer.sm70_fp8_k_ld)
-            q_ld = int(layer.sm70_fp8_q_ld)
+            if is_modelopt:
+                scales = layer.weight_scale
+                k_ld = int(layer.sm70_modelopt_fp8_k_ld)
+                q_ld = int(layer.sm70_modelopt_fp8_q_ld)
+            else:
+                scales = layer.weight_scale_inv
+                k_ld = int(layer.sm70_fp8_k_ld)
+                q_ld = int(layer.sm70_fp8_q_ld)
             n_dim = int(layer.output_size_per_partition)
 
         device = weight.device
@@ -644,6 +695,120 @@ def _warmup_mxfp4_moe_b1_layers(moe_layers: list[torch.nn.Module]) -> int:
     return calls
 
 
+def _warmup_nvfp4_moe_decode_layers(
+    moe_layers: list[torch.nn.Module], token_counts: list[int]
+) -> int:
+    """Tune compact B1-B8 and full-group B9+ NVFP4 graph shapes."""
+    if not hasattr(torch.ops._C, "nvfp4_moe_dense_stage_sm70_out"):
+        return 0
+
+    calls = 0
+    for layer in moe_layers:
+        device = layer.w13_tm_weight.device
+        top_k = int(layer.moe_config.experts_per_token)
+        max_experts = int(layer.sm70_nvfp4_num_experts)
+        for num_tokens in token_counts:
+            total_slots = num_tokens * top_k
+            if total_slots > max_experts:
+                continue
+            if num_tokens <= 8:
+                stage_experts = total_slots
+                expert_offsets = torch.arange(
+                    total_slots + 1, dtype=torch.int32, device=device
+                )
+                active_expert_ids = layer._nvfp4_sm70_dense_expert_ids[:total_slots]
+            else:
+                stage_experts = max_experts
+                expert_offsets = torch.full(
+                    (max_experts + 1,),
+                    total_slots,
+                    dtype=torch.int32,
+                    device=device,
+                )
+                expert_offsets[: total_slots + 1] = torch.arange(
+                    total_slots + 1, dtype=torch.int32, device=device
+                )
+                active_expert_ids = layer._nvfp4_sm70_dense_expert_ids
+            permuted_input = torch.empty(
+                total_slots,
+                int(layer.sm70_nvfp4_w13_k_dim),
+                dtype=torch.float16,
+                device=device,
+            )
+            gate_up = torch.empty(
+                total_slots,
+                int(layer.sm70_nvfp4_w13_n_dim),
+                dtype=torch.float16,
+                device=device,
+            )
+            intermediate = torch.empty(
+                total_slots,
+                int(layer.sm70_nvfp4_w2_k_dim),
+                dtype=torch.float16,
+                device=device,
+            )
+            sorted_output = torch.empty(
+                total_slots,
+                int(layer.sm70_nvfp4_w2_n_dim),
+                dtype=torch.float16,
+                device=device,
+            )
+            sm70_ops.nvfp4_moe_dense_stage_sm70_out(
+                gate_up,
+                permuted_input,
+                expert_offsets,
+                active_expert_ids,
+                layer.w13_strided_ptrs_w,
+                layer.w13_strided_ptrs_s,
+                stage_experts,
+                int(layer.sm70_nvfp4_w13_k_dim),
+                int(layer.sm70_nvfp4_w13_n_dim),
+                int(layer.sm70_nvfp4_group_size),
+            )
+            if layer.swiglu_limit is None:
+                torch.ops._C.silu_and_mul(intermediate, gate_up)
+            else:
+                torch.ops._C.silu_and_mul_with_clamp(
+                    intermediate, gate_up, float(layer.swiglu_limit)
+                )
+            sm70_ops.nvfp4_moe_dense_stage_sm70_out(
+                sorted_output,
+                intermediate,
+                expert_offsets,
+                active_expert_ids,
+                layer.w2_strided_ptrs_w,
+                layer.w2_strided_ptrs_s,
+                stage_experts,
+                int(layer.sm70_nvfp4_w2_k_dim),
+                int(layer.sm70_nvfp4_w2_n_dim),
+                int(layer.sm70_nvfp4_group_size),
+            )
+            calls += 2
+    return calls
+
+
+def _get_nvfp4_moe_token_counts(
+    worker: Worker,
+    moe_layers: list[torch.nn.Module],
+    base_token_counts: list[int],
+) -> list[int]:
+    """Include every NVFP4 CUDA-graph shape covered by persistent buffers."""
+    if not moe_layers:
+        return base_token_counts
+    max_tokens = max(
+        int(getattr(layer, "sm70_nvfp4_graph_safe_max_tokens", 8))
+        for layer in moe_layers
+    )
+    compilation_config = getattr(
+        getattr(worker, "vllm_config", None), "compilation_config", None
+    )
+    capture_sizes = getattr(compilation_config, "cudagraph_capture_sizes", None) or []
+    return sorted(
+        set(base_token_counts)
+        | {int(size) for size in capture_sizes if 0 < int(size) <= max_tokens}
+    )
+
+
 def _warmup_moe_single_token_layers(moe_layers: list[torch.nn.Module]) -> int:
     if not (
         hasattr(torch.ops._C, "awq_moe_single_token_dense_w13_sm70_out")
@@ -797,12 +962,14 @@ def sm70_awq_warmup(worker: Worker) -> None:
     fp4_dense_layers = list(_iter_unique_fp4_dense_layers(model))
     moe_layers = list(_iter_unique_moe_layers(model))
     mxfp4_moe_layers = list(_iter_unique_mxfp4_moe_layers(model))
+    nvfp4_moe_layers = list(_iter_unique_nvfp4_moe_layers(model))
     if not (
         dense_layers
         or fp8_dense_layers
         or fp4_dense_layers
         or moe_layers
         or mxfp4_moe_layers
+        or nvfp4_moe_layers
     ):
         return
 
@@ -812,6 +979,7 @@ def sm70_awq_warmup(worker: Worker) -> None:
         bool(fp8_dense_layers),
         fp4_kinds,
         bool(mxfp4_moe_layers),
+        bool(nvfp4_moe_layers),
     )
     imported_records = _load_lut_cache(device, skip_import=skip_lut_cache)
     if imported_records > 0:
@@ -823,20 +991,26 @@ def sm70_awq_warmup(worker: Worker) -> None:
 
     m_values = _get_decode_m_values(worker)
     moe_token_counts = _get_moe_token_counts(worker)
+    nvfp4_moe_token_counts = _get_nvfp4_moe_token_counts(
+        worker, nvfp4_moe_layers, moe_token_counts
+    )
     lut_path = _resolve_lut_path(device)
 
     logger.info(
         "Warming up SM70 TurboMind accepted routes (%d AWQ dense layer "
         "shapes, %d FP8 dense layer shapes, %d FP4 dense layer shapes, "
-        "%d MoE layer shapes, %d MXFP4 MoE B1 layer shapes, dense_m=%s, "
-        "moe_tokens=%s, lut_path=%s).",
+        "%d MoE layer shapes, %d MXFP4 MoE B1 layer shapes, "
+        "%d NVFP4 MoE layer shapes, dense_m=%s, "
+        "moe_tokens=%s, nvfp4_moe_tokens=%s, lut_path=%s).",
         len(dense_layers),
         len(fp8_dense_layers),
         len(fp4_dense_layers),
         len(moe_layers),
         len(mxfp4_moe_layers),
+        len(nvfp4_moe_layers),
         m_values,
         moe_token_counts,
+        nvfp4_moe_token_counts,
         lut_path,
     )
     with torch.inference_mode():
@@ -850,17 +1024,22 @@ def sm70_awq_warmup(worker: Worker) -> None:
         moe_stage_calls = _warmup_moe_dense_stage_layers(moe_layers, moe_token_counts)
         single_token_calls = _warmup_moe_single_token_layers(moe_layers)
         mxfp4_moe_stage_calls = _warmup_mxfp4_moe_b1_layers(mxfp4_moe_layers)
+        nvfp4_moe_stage_calls = _warmup_nvfp4_moe_decode_layers(
+            nvfp4_moe_layers, nvfp4_moe_token_counts
+        )
     torch.accelerator.synchronize(device)
     logger.info(
         "SM70 TurboMind warmup finished (%d AWQ dense calls, %d FP8 dense "
         "calls, %d FP4 dense calls, %d MoE stage calls, "
-        "%d single-token active-expert calls, %d MXFP4 MoE B1 stage calls).",
+        "%d single-token active-expert calls, %d MXFP4 MoE B1 stage calls, "
+        "%d NVFP4 MoE stage calls).",
         dense_calls,
         fp8_dense_calls,
         fp4_dense_calls,
         moe_stage_calls,
         single_token_calls,
         mxfp4_moe_stage_calls,
+        nvfp4_moe_stage_calls,
     )
     exported_records = _save_lut_cache(device, skip_export=skip_lut_cache)
     if exported_records > 0:

--- a/vllm/v1/spec_decode/llm_base_proposer.py
+++ b/vllm/v1/spec_decode/llm_base_proposer.py
@@ -87,6 +87,33 @@ def _sm70_mtp_profile_interval() -> int:
     return envs.VLLM_SM70_MTP_PROFILE_INTERVAL
 
 
+def _sm70_mtp_moe_warmup_sizes(
+    num_experts: int, top_k: int, max_num_tokens: int
+) -> tuple[int, ...]:
+    """Pick one token count for each SM70 Triton MoE dispatch region."""
+    if num_experts <= 0 or top_k <= 0 or max_num_tokens <= 0:
+        return ()
+
+    def prefer_unaligned(size: int) -> int:
+        # Triton otherwise specializes another kernel when token_count * top_k
+        # first loses 16-byte divisibility. This cannot happen when top_k is
+        # itself a multiple of 16.
+        if top_k % 16:
+            while size * top_k % 16 == 0:
+                size += 1
+        return size
+
+    sizes = {
+        # First sorted-assignment shape after the naive small-token path.
+        prefer_unaligned(num_experts // (top_k * 4) + 1),
+        # First shape whose sorted-token allocation is not block aligned.
+        prefer_unaligned((num_experts + top_k - 1) // top_k),
+        # First shape using the large-M SM70 0.0.3 MoE tile.
+        prefer_unaligned(num_experts + 1),
+    }
+    return tuple(sorted(size for size in sizes if size <= max_num_tokens))
+
+
 def _is_dflash_method(method: str | None) -> bool:
     return method in ("dflash", "dflash_ddtree", "dspark")
 
@@ -970,6 +997,45 @@ class SpecDecodeBaseProposer:
             "mtp_rejection_expand",
             "mtp_step_slot_mapping",
         )
+
+    def warmup_sm70_mtp_moe_kernels(self) -> tuple[str, ...]:
+        """Warm the finite Triton-MoE shape specializations used by MTP."""
+        if (
+            self.method != "mtp"
+            or self.device.type != "cuda"
+            or not current_platform.is_device_capability(70)
+            or not envs.VLLM_SM70_UNQUANTIZED_MOE_0DOT3_CONFIG
+            or not self.draft_model_config.is_moe
+        ):
+            return ()
+        if getattr(self, "_sm70_mtp_moe_warmed", False):
+            return ()
+        self._sm70_mtp_moe_warmed = True
+
+        text_config = self.draft_model_config.hf_text_config
+        top_k = int(getattr(text_config, "num_experts_per_tok", 0))
+        sizes = _sm70_mtp_moe_warmup_sizes(
+            self.draft_model_config.get_num_experts(),
+            top_k,
+            self.max_num_tokens,
+        )
+        if not sizes:
+            return ()
+
+        try:
+            for num_tokens in sizes:
+                self.dummy_run(
+                    num_tokens,
+                    use_cudagraphs=False,
+                    spec_step_idx=0,
+                )
+            torch.accelerator.synchronize()
+        except Exception as err:  # pragma: no cover - best-effort warmup
+            logger.warning_once("SM70 MTP MoE warmup skipped: %s", err)
+            return ()
+
+        logger.info_once("SM70 MTP MoE warmup finished: token_counts=%s", sizes)
+        return ("mtp_draft_moe",)
 
     def take_last_draft_probs(self) -> torch.Tensor | None:
         return self._last_draft_probs

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -2132,10 +2132,33 @@ class GPUModelRunner(
             and mamba_utils.warmup_batch_memcpy_kernel(self.device)
         ):
             warmed.append("mamba_batch_memcpy")
+        if (
+            self.cache_config.mamba_cache_mode == "align"
+            and self.speculative_config is not None
+            and self.model_config.is_hybrid
+        ):
+            mamba_bufs = self._get_mamba_bufs()
+            postprocess_ctx = mamba_bufs.postprocess_align
+            assert postprocess_ctx is not None
+            if not postprocess_ctx.is_initialized:
+                postprocess_ctx.initialize_from_forward_context(
+                    self.kv_cache_config,
+                    self.compilation_config.static_forward_context,
+                    self.model.get_mamba_state_copy_func(),
+                    [
+                        self.input_batch.block_table[group_id].get_device_tensor(1)
+                        for group_id in postprocess_ctx.mamba_group_ids
+                    ],
+                )
+            if postprocess_ctx.warmup_fused_postprocess():
+                warmed.append("mamba_spec_postprocess")
         drafter = getattr(self, "drafter", None)
         mtp_warmup = getattr(drafter, "warmup_sm70_mtp_hotpath_kernels", None)
         if mtp_warmup is not None:
             warmed.extend(mtp_warmup())
+        mtp_moe_warmup = getattr(drafter, "warmup_sm70_mtp_moe_kernels", None)
+        if mtp_moe_warmup is not None:
+            warmed.extend(mtp_moe_warmup())
         dflash_warmup = getattr(drafter, "warmup_sm70_dflash_hotpath_kernels", None)
         if dflash_warmup is not None:
             warmed.extend(dflash_warmup())
@@ -10826,6 +10849,21 @@ class GPUModelRunner(
                 draft_probs,
                 logits,
                 dummy_metadata,
+            )
+            # The mixed-sampling warmup above passes a non-null is_greedy
+            # tensor. Pure greedy serving passes None and otherwise triggers a
+            # separate Triton compile during the first decode verifier step.
+            greedy_metadata = replace(
+                dummy_metadata,
+                temperature=torch.zeros_like(dummy_metadata.temperature),
+                all_greedy=True,
+                all_random=False,
+            )
+            self.rejection_sampler(
+                dummy_spec_decode_metadata,
+                None,
+                logits,
+                greedy_metadata,
             )
         return sampler_output
 

--- a/vllm/v1/worker/mamba_utils.py
+++ b/vllm/v1/worker/mamba_utils.py
@@ -659,6 +659,55 @@ class MambaSpecDecodeGPUContext:
             HAS_DDTREE_ACCEPTED_NODES=has_ddtree,
         )
 
+    def warmup_fused_postprocess(self) -> bool:
+        """Compile the non-DDTree MTP signature without copying model state."""
+        if not self.is_initialized:
+            return False
+
+        device = self.state_base_addrs.device
+        num_accepted_tokens = torch.ones(1, dtype=torch.int32, device=device)
+        spec_state_slot_selectors = torch.ones(1, dtype=torch.int32, device=device)
+        mamba_state_idx = torch.zeros(1, dtype=torch.int32, device=device)
+        num_scheduled_tokens = torch.ones(1, dtype=torch.int32, device=device)
+        # Make the running length one token past a block boundary. The kernel
+        # therefore exits before dereferencing state or block-table pointers,
+        # while compiling the exact MTP specialization used at runtime.
+        num_computed_tokens = torch.full(
+            (1,), self.block_size, dtype=torch.int32, device=device
+        )
+        num_draft_tokens = torch.zeros(1, dtype=torch.int32, device=device)
+        ddtree_accepted_node_indices = torch.empty(
+            (1, 1), dtype=torch.int32, device=device
+        )
+
+        total_states = self.num_layers * self.num_state_types
+        postprocess_mamba_fused_kernel[(1, total_states)](
+            num_accepted_tokens,
+            spec_state_slot_selectors,
+            ddtree_accepted_node_indices,
+            ddtree_accepted_node_indices.stride(0),
+            mamba_state_idx,
+            num_scheduled_tokens,
+            num_computed_tokens,
+            num_draft_tokens,
+            self.block_table_ptrs,
+            self.block_table_stride_req,
+            self.state_base_addrs,
+            self.state_block_strides,
+            self.state_elem_sizes,
+            self.state_inner_sizes,
+            self.state_conv_widths,
+            self.state_group_indices,
+            self.num_accepted_tokens_out,
+            self.spec_state_slot_selectors_out,
+            1,
+            block_size=self.block_size,
+            COPY_BLOCK_SIZE=1024,
+            HAS_DDTREE_ACCEPTED_NODES=False,
+        )
+        torch.accelerator.synchronize()
+        return True
+
 
 @dataclasses.dataclass
 class MambaBuffers:


### PR DESCRIPTION
## Purpose

Add an exact-SM70 path for the Qwen3.6-35B-A3B ModelOpt 0.37 mixed checkpoint: FP8 dense projections plus W4A16_NVFP4 routed/shared experts through TurboMind. Preserve duplicate routed expert slots, split mixed-precision Qwen GDN projections correctly, and move the remaining MTP4 Triton compilation out of the first request.

Unsupported shapes, TP8, expert parallelism, and all-to-all configurations fail closed. The admitted checkpoint contract is H2048, expert I512, 256 experts, top-k 8, and TP1/2/4.

- Integration base: `675a12dedcca8cc020c033f1b1d0f1751d4b8efe`
- Final head/code SHA: `be9f0c73cb30bdcfa2ca101ec39da27b2d736b7d`

## Implementation

- Add graph-safe SM70 TurboMind grouped NVFP4 MoE operations and exact ModelOpt mixed admission.
- Use compact active-expert groups for B1-B8 and full 256-expert buffers for B9-B18/prefill.
- Preserve duplicate expert slots during grouped routing and keep mixed FP8/NVFP4 GDN projections on their correct quantization methods.
- Warm the exact Mamba speculative postprocess, all-greedy rejection sampler, and MTP-drafter MoE shapes 9/33/257 before graph capture.
- Record accepted/rejected routes, matched speed evidence, and the dataset quality gate in the SM70 migration control document.

## Test Plan

- Ruff check/format and mypy 3.10-3.13 on the final branch.
- Focused quantization, warmup, Qwen3.5 GDN, MTP, and Mamba tests.
- Real-checkpoint layer-0 numeric oracle and full TP4 CUDA Graph integration on physical V100 GPUs 0-3.
- Matching AWQ/NVFP4 input-4096/output-1024 performance contract.
- Fresh-cache final-SHA ShareGPT16 prefill/decode workload and pinned GSM8K records 0-127, five-shot chat, thinking disabled, greedy, max output 512.

## Test Result

- Final static checks: all 16 PR-touched Python files pass Ruff check/format; mypy passes for Python 3.10, 3.11, 3.12, and 3.13; changed-line clang-format reports no change for the three touched native files; `git diff --check` passes.
- Focused tests: 33 quantization/warmup/Qwen GDN/MTP tests passed; the GPU Mamba fused-postprocess state-preservation test passed.
- Real layer-0 M4096 W13/W2 matched bitwise; B9/B18 cosine was 1.0 with maximum absolute error <= 1.221e-4. A lossy 144-slot compact candidate was rejected; the compact limit remains 64.
- Matching no-MTP contract: AWQ prefill 0.3813 s / decode 113.71 tok/s; NVFP4 prefill 0.4216 s / decode 116.99 tok/s. NVFP4 decode is 2.89% faster and prefill is 10.56% slower, placing it in the same performance class.
- MTP4 matching long run: prefill 0.8379 s and steady decode 174.76 tok/s, 1.49x the NVFP4 no-MTP decode result.
- Final-SHA fresh-cache ShareGPT16: 97.678 end-to-end output tok/s, 241.973 serial-prefill tok/s, 120.096 pure-decode tok/s, 8.881 ms mean TPOT, 48.64% draft-token acceptance, and zero inference-time Triton JIT warnings. Versus the preceding all-warm candidate: -0.016% E2E, -0.307% prefill, +0.008% pure decode, +0.618% mean TPOT.
- Final-SHA GSM8K: 122/128 (95.3125%), zero invalid outputs, zero repetitive records, misses `[12, 37, 87, 89, 102, 119]`. Record 37 is the established 512-token truncation and is correct with a 1024-token cap. The standard-GDN diagnostic scored 108/128 and is rejected.

## Evidence

Local reproducible artifacts and logs are under `bench_results/modelopt_mixed_nvfp4_moe_20260822/`. Final merge artifacts:

- `results/tp4_gpu0123_mtp4_fp8kv_sharegpt16_seed20260822_final_be9f0c_graph.json`
- `logs/tp4_gpu0123_mtp4_fp8kv_sharegpt16_seed20260822_final_be9f0c_graph.log`
- `results/tp4_mtp4_fp8kv_gsm8k_chat_nothink_5shot_128_final_be9f0c_graph.json`
- `logs/tp4_mtp4_fp8kv_gsm8k_chat_nothink_5shot_128_final_be9f0c_graph.log`
- `results/tp4_nomtp_fp8kv_i4096_o1024_nvfp4_grouped.json`
- `results/tp4_nomtp_fp8kv_i4096_o1024_awq.json`
- `results/tp4_mtp4_fp8kv_i4096_o1024_nvfp4.json`

## CI note

The current all-files pre-commit job remains red on repository-wide mechanical debt already present on `main`: 65 unrelated Python files that Ruff would reformat, broad native formatting, vendored typos, generated docs lock drift, missing SPDX headers, forbidden imports, and legacy `torch.cuda` benchmark calls. The branch-specific mypy failure is fixed; all four CI mypy jobs now pass, and every PR-touched Python/native file passes its scoped formatter check.

## Risks and limits

- The fast route is deliberately shape- and topology-specific; other contracts do not silently enter it.
- MTP greedy outputs show one-question run-to-run variation, so quality is accepted by dataset accuracy/validity/repetition rather than token equality with no-MTP.
- Cold-start compilation is shifted into model initialization while eliminating measured request-time JIT.

Dependency PR #228 is already merged into `main`.
