### PR TITLE
[Kernel][SM70] Optimize exact-8K block-FP8 prefill on V100

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -398,6 +398,7 @@ if(VLLM_GPU_LANG STREQUAL "CUDA")
       "${VLLM_SM70_TURBOMIND_ROOT}/ops/tm_registry_sm70.cu"
       "${VLLM_SM70_TURBOMIND_ROOT}/ops/fp8_qpn8_sm70.cu"
       "${VLLM_SM70_TURBOMIND_ROOT}/ops/nvfp4_qpn4_sm70.cu"
+      "${VLLM_SM70_TURBOMIND_ROOT}/ops/qwen38_prefill_cutlass.cu"
       "${VLLM_SM70_TURBOMIND_ROOT}/ops/awq_sm70_gemm.cu")
 
     set_gencode_flags_for_srcs(

--- a/benchmarks/benchmark_sm70_cublas_gemm_algorithms.py
+++ b/benchmarks/benchmark_sm70_cublas_gemm_algorithms.py
@@ -42,11 +42,11 @@ def _event_trials(
 ) -> dict[str, Any]:
     for _ in range(warmup):
         launch()
-    torch.cuda.synchronize()
+    torch.accelerator.synchronize()
     samples: list[float] = []
     for _ in range(trials):
-        start = torch.cuda.Event(enable_timing=True)
-        end = torch.cuda.Event(enable_timing=True)
+        start = torch.Event(enable_timing=True)
+        end = torch.Event(enable_timing=True)
         start.record()
         for _ in range(iters):
             launch()
@@ -168,7 +168,7 @@ def _run_shape(
     ).mul_(0.02)
     reference = torch.empty((args.m, n), device=device, dtype=torch.float16)
     torch.mm(inputs, weight, out=reference)
-    torch.cuda.synchronize()
+    torch.accelerator.synchronize()
 
     algorithms = [_CUBLAS_GEMM_DEFAULT_TENSOR_OP] + list(
         range(_CUBLAS_GEMM_ALGO0_TENSOR_OP, _CUBLAS_GEMM_ALGO0_TENSOR_OP + 16)
@@ -185,7 +185,7 @@ def _run_shape(
         try:
             timing = _event_trials(launch, args.warmup, args.iters, args.trials)
             launch()
-            torch.cuda.synchronize()
+            torch.accelerator.synchronize()
             difference = (output.float() - reference.float()).abs()
             results.append(
                 {
@@ -202,7 +202,7 @@ def _run_shape(
                 }
             )
         except RuntimeError as error:
-            torch.cuda.synchronize()
+            torch.accelerator.synchronize()
             results.append({"algo": algo, "status": "rejected", "error": str(error)})
     return {
         "m": args.m,
@@ -220,7 +220,7 @@ def main() -> int:
     device = torch.device(args.device)
     if torch.cuda.get_device_capability(device) != (7, 0):
         raise RuntimeError("This benchmark requires SM70/V100.")
-    torch.cuda.set_device(device)
+    torch.accelerator.set_device_index(device)
     cublas = _Cublas(torch.cuda.current_stream(device).cuda_stream)
     try:
         shapes = [_run_shape(args, device, cublas, n) for n in args.n]

--- a/benchmarks/benchmark_sm70_cublas_gemm_algorithms.py
+++ b/benchmarks/benchmark_sm70_cublas_gemm_algorithms.py
@@ -1,0 +1,251 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Screen legacy cuBLAS Tensor Core algorithms on exact SM70 QKV shapes."""
+
+from __future__ import annotations
+
+import argparse
+import ctypes
+import json
+import statistics
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+import torch
+
+_CUBLAS_STATUS_SUCCESS = 0
+_CUBLAS_OP_N = 0
+_CUDA_R_16F = 2
+_CUBLAS_COMPUTE_32F = 68
+_CUBLAS_TENSOR_OP_MATH = 1
+_CUBLAS_GEMM_DEFAULT_TENSOR_OP = 99
+_CUBLAS_GEMM_ALGO0_TENSOR_OP = 100
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--json-out", type=Path, required=True)
+    parser.add_argument("--device", default="cuda:0")
+    parser.add_argument("--m", type=int, default=8000)
+    parser.add_argument("--k", type=int, default=5120)
+    parser.add_argument("--n", type=int, nargs="+", default=[4096, 3584])
+    parser.add_argument("--warmup", type=int, default=3)
+    parser.add_argument("--iters", type=int, default=10)
+    parser.add_argument("--trials", type=int, default=5)
+    parser.add_argument("--seed", type=int, default=20260823)
+    return parser.parse_args()
+
+
+def _event_trials(
+    launch: Callable[[], None], warmup: int, iters: int, trials: int
+) -> dict[str, Any]:
+    for _ in range(warmup):
+        launch()
+    torch.cuda.synchronize()
+    samples: list[float] = []
+    for _ in range(trials):
+        start = torch.cuda.Event(enable_timing=True)
+        end = torch.cuda.Event(enable_timing=True)
+        start.record()
+        for _ in range(iters):
+            launch()
+        end.record()
+        end.synchronize()
+        samples.append(float(start.elapsed_time(end) / iters))
+    return {
+        "median_ms": float(statistics.median(samples)),
+        "mean_ms": float(statistics.mean(samples)),
+        "min_ms": min(samples),
+        "max_ms": max(samples),
+        "samples_ms": samples,
+    }
+
+
+class _Cublas:
+    def __init__(self, stream: int) -> None:
+        self.lib = ctypes.CDLL("libcublas.so.12")
+        self.handle = ctypes.c_void_p()
+        self.lib.cublasCreate_v2.argtypes = [ctypes.POINTER(ctypes.c_void_p)]
+        self.lib.cublasCreate_v2.restype = ctypes.c_int
+        self.lib.cublasDestroy_v2.argtypes = [ctypes.c_void_p]
+        self.lib.cublasDestroy_v2.restype = ctypes.c_int
+        self.lib.cublasSetStream_v2.argtypes = [ctypes.c_void_p, ctypes.c_void_p]
+        self.lib.cublasSetStream_v2.restype = ctypes.c_int
+        self.lib.cublasSetMathMode.argtypes = [ctypes.c_void_p, ctypes.c_int]
+        self.lib.cublasSetMathMode.restype = ctypes.c_int
+        self.lib.cublasGemmEx.argtypes = [
+            ctypes.c_void_p,
+            ctypes.c_int,
+            ctypes.c_int,
+            ctypes.c_int,
+            ctypes.c_int,
+            ctypes.c_int,
+            ctypes.c_void_p,
+            ctypes.c_void_p,
+            ctypes.c_int,
+            ctypes.c_int,
+            ctypes.c_void_p,
+            ctypes.c_int,
+            ctypes.c_int,
+            ctypes.c_void_p,
+            ctypes.c_void_p,
+            ctypes.c_int,
+            ctypes.c_int,
+            ctypes.c_int,
+            ctypes.c_int,
+        ]
+        self.lib.cublasGemmEx.restype = ctypes.c_int
+        self._check(self.lib.cublasCreate_v2(ctypes.byref(self.handle)), "create")
+        self._check(
+            self.lib.cublasSetStream_v2(self.handle, ctypes.c_void_p(stream)),
+            "set stream",
+        )
+        self._check(
+            self.lib.cublasSetMathMode(self.handle, _CUBLAS_TENSOR_OP_MATH),
+            "set math mode",
+        )
+
+    @staticmethod
+    def _check(status: int, operation: str) -> None:
+        if status != _CUBLAS_STATUS_SUCCESS:
+            raise RuntimeError(f"cuBLAS {operation} failed with status {status}.")
+
+    def gemm(
+        self,
+        output: torch.Tensor,
+        inputs: torch.Tensor,
+        weight: torch.Tensor,
+        algo: int,
+    ) -> int:
+        m, k = inputs.shape
+        weight_k, n = weight.shape
+        if weight_k != k or output.shape != (m, n):
+            raise ValueError("Incompatible row-major GEMM shapes.")
+        alpha = ctypes.c_float(1.0)
+        beta = ctypes.c_float(0.0)
+        # Row-major C=MxN is column-major C^T=NxM. Compute
+        # C^T = weight^T(NxK) * inputs^T(KxM) without materializing transposes.
+        return int(
+            self.lib.cublasGemmEx(
+                self.handle,
+                _CUBLAS_OP_N,
+                _CUBLAS_OP_N,
+                n,
+                m,
+                k,
+                ctypes.byref(alpha),
+                ctypes.c_void_p(weight.data_ptr()),
+                _CUDA_R_16F,
+                n,
+                ctypes.c_void_p(inputs.data_ptr()),
+                _CUDA_R_16F,
+                k,
+                ctypes.byref(beta),
+                ctypes.c_void_p(output.data_ptr()),
+                _CUDA_R_16F,
+                n,
+                _CUBLAS_COMPUTE_32F,
+                algo,
+            )
+        )
+
+    def close(self) -> None:
+        if self.handle.value is not None:
+            self._check(self.lib.cublasDestroy_v2(self.handle), "destroy")
+            self.handle = ctypes.c_void_p()
+
+
+def _run_shape(
+    args: argparse.Namespace, device: torch.device, cublas: _Cublas, n: int
+) -> dict[str, Any]:
+    generator = torch.Generator(device=device).manual_seed(args.seed + n)
+    inputs = torch.randn(
+        (args.m, args.k), generator=generator, device=device, dtype=torch.float16
+    ).mul_(0.02)
+    weight = torch.randn(
+        (args.k, n), generator=generator, device=device, dtype=torch.float16
+    ).mul_(0.02)
+    reference = torch.empty((args.m, n), device=device, dtype=torch.float16)
+    torch.mm(inputs, weight, out=reference)
+    torch.cuda.synchronize()
+
+    algorithms = [_CUBLAS_GEMM_DEFAULT_TENSOR_OP] + list(
+        range(_CUBLAS_GEMM_ALGO0_TENSOR_OP, _CUBLAS_GEMM_ALGO0_TENSOR_OP + 16)
+    )
+    results: list[dict[str, Any]] = []
+    for algo in algorithms:
+        output = torch.empty_like(reference)
+
+        def launch(output: torch.Tensor = output, algo: int = algo) -> None:
+            status = cublas.gemm(output, inputs, weight, algo)
+            if status != _CUBLAS_STATUS_SUCCESS:
+                raise RuntimeError(f"cuBLAS algo {algo} returned status {status}.")
+
+        try:
+            timing = _event_trials(launch, args.warmup, args.iters, args.trials)
+            launch()
+            torch.cuda.synchronize()
+            difference = (output.float() - reference.float()).abs()
+            results.append(
+                {
+                    "algo": algo,
+                    "status": "success",
+                    "timing": timing,
+                    "useful_tflops": float(
+                        2 * args.m * n * args.k / (timing["median_ms"] * 1e-3) / 1e12
+                    ),
+                    "max_abs_diff": float(difference.max().item()),
+                    "mean_abs_diff": float(difference.mean().item()),
+                    "equal_elements": int((output == reference).sum().item()),
+                    "elements": output.numel(),
+                }
+            )
+        except RuntimeError as error:
+            torch.cuda.synchronize()
+            results.append({"algo": algo, "status": "rejected", "error": str(error)})
+    return {
+        "m": args.m,
+        "n": n,
+        "k": args.k,
+        "algorithms": sorted(
+            results,
+            key=lambda item: item.get("timing", {}).get("median_ms", float("inf")),
+        ),
+    }
+
+
+def main() -> int:
+    args = _parse_args()
+    device = torch.device(args.device)
+    if torch.cuda.get_device_capability(device) != (7, 0):
+        raise RuntimeError("This benchmark requires SM70/V100.")
+    torch.cuda.set_device(device)
+    cublas = _Cublas(torch.cuda.current_stream(device).cuda_stream)
+    try:
+        shapes = [_run_shape(args, device, cublas, n) for n in args.n]
+    finally:
+        cublas.close()
+    payload = {
+        "environment": {
+            "device": torch.cuda.get_device_name(device),
+            "torch": torch.__version__,
+            "torch_cuda": torch.version.cuda,
+            "m": args.m,
+            "k": args.k,
+            "n": args.n,
+            "warmup": args.warmup,
+            "iters": args.iters,
+            "trials": args.trials,
+            "seed": args.seed,
+        },
+        "shapes": shapes,
+    }
+    args.json_out.parent.mkdir(parents=True, exist_ok=True)
+    args.json_out.write_text(json.dumps(payload, indent=2) + "\n")
+    print(json.dumps(payload, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmarks/benchmark_sm70_fp8_prefill_exact_dense_blas.py
+++ b/benchmarks/benchmark_sm70_fp8_prefill_exact_dense_blas.py
@@ -1,0 +1,370 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Benchmark the exact-dense SM70 FP8 prefill path with a selected BLAS backend.
+
+This loads the real TP-local Qwen3.8 gate-up and down-projection weights.  Run
+each BLAS backend in a fresh process so global ATen and cuBLAS caches cannot
+contaminate the comparison.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import importlib.util
+import json
+import math
+import os
+import statistics
+import sys
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+import torch
+from safetensors import safe_open
+
+import vllm
+
+
+def _load_vllm_c_extension() -> None:
+    if "vllm._C" in sys.modules:
+        vllm._C = sys.modules["vllm._C"]
+        return
+    candidate = os.getenv("VLLM_BENCH_C_EXTENSION")
+    if candidate is None:
+        importlib.import_module("vllm._C")
+        return
+    spec = importlib.util.spec_from_file_location("vllm._C", candidate)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Cannot load candidate extension: {candidate}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["vllm._C"] = module
+    vllm._C = module
+    spec.loader.exec_module(module)
+
+
+_load_vllm_c_extension()
+
+from vllm import _sm70_ops as sm70_ops  # noqa: E402
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--model",
+        type=Path,
+        default=Path("/home/ymzx/models/Qwen3.8-27B-FP8"),
+    )
+    parser.add_argument("--json-out", type=Path, required=True)
+    parser.add_argument("--device", default="cuda:0")
+    parser.add_argument("--tp-size", type=int, default=4)
+    parser.add_argument("--tp-rank", type=int, default=0)
+    parser.add_argument(
+        "--cases",
+        nargs="+",
+        choices=("gate_up", "down", "attention_output"),
+        default=("gate_up", "down"),
+    )
+    parser.add_argument("--m", type=int, default=8000)
+    parser.add_argument(
+        "--backend",
+        choices=("exact-dense", "resident-turbomind-f16"),
+        default="exact-dense",
+    )
+    parser.add_argument(
+        "--gated-silu",
+        action="store_true",
+        help="Benchmark gate_up with the fused interleaved SiLU-and-mul output.",
+    )
+    parser.add_argument(
+        "--blas-library",
+        choices=("default", "cublas", "cublaslt"),
+        required=True,
+    )
+    parser.add_argument("--warmup", type=int, default=10)
+    parser.add_argument("--iters", type=int, default=30)
+    parser.add_argument("--trials", type=int, default=7)
+    parser.add_argument("--seed", type=int, default=20260823)
+    parser.add_argument("--cuda-graph", action="store_true")
+    return parser.parse_args()
+
+
+def _load_keys(model: Path, keys: list[str]) -> dict[str, torch.Tensor]:
+    index = json.loads((model / "model.safetensors.index.json").read_text())
+    weight_map: dict[str, str] = index["weight_map"]
+    by_file: dict[str, list[str]] = {}
+    for key in keys:
+        by_file.setdefault(weight_map[key], []).append(key)
+
+    result: dict[str, torch.Tensor] = {}
+    for filename, file_keys in by_file.items():
+        with safe_open(model / filename, framework="pt", device="cpu") as handle:
+            for key in file_keys:
+                result[key] = handle.get_tensor(key)
+    return result
+
+
+def _column_shard(
+    weight: torch.Tensor,
+    scales: torch.Tensor,
+    tp_size: int,
+    tp_rank: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    n = int(weight.shape[0])
+    if n % tp_size:
+        raise ValueError(f"N={n} is not divisible by TP={tp_size}.")
+    begin = tp_rank * (n // tp_size)
+    end = begin + n // tp_size
+    return (
+        weight.view(torch.uint8)[begin:end].contiguous(),
+        scales[begin // 128 : math.ceil(end / 128)].contiguous(),
+    )
+
+
+def _row_shard(
+    weight: torch.Tensor,
+    scales: torch.Tensor,
+    tp_size: int,
+    tp_rank: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    k = int(weight.shape[1])
+    if k % tp_size:
+        raise ValueError(f"K={k} is not divisible by TP={tp_size}.")
+    begin = tp_rank * (k // tp_size)
+    end = begin + k // tp_size
+    return (
+        weight.view(torch.uint8)[:, begin:end].contiguous(),
+        scales[:, begin // 128 : math.ceil(end / 128)].contiguous(),
+    )
+
+
+def _load_case(
+    model: Path,
+    case: str,
+    tp_size: int,
+    tp_rank: int,
+    device: torch.device,
+) -> tuple[torch.Tensor, torch.Tensor, list[str]]:
+    if case == "attention_output":
+        prefixes = ["model.language_model.layers.3.self_attn.o_proj"]
+    else:
+        root = "model.language_model.layers.1.mlp"
+        projections = ("gate_proj", "up_proj") if case == "gate_up" else ("down_proj",)
+        prefixes = [f"{root}.{projection}" for projection in projections]
+    keys = [
+        key
+        for prefix in prefixes
+        for key in (f"{prefix}.weight", f"{prefix}.weight_scale_inv")
+    ]
+    loaded = _load_keys(model, keys)
+
+    raw_parts: list[torch.Tensor] = []
+    scale_parts: list[torch.Tensor] = []
+    fp8_dtype: torch.dtype | None = None
+    for prefix in prefixes:
+        weight = loaded[f"{prefix}.weight"]
+        scales = loaded[f"{prefix}.weight_scale_inv"].float()
+        fp8_dtype = weight.dtype if fp8_dtype is None else fp8_dtype
+        if weight.dtype != fp8_dtype:
+            raise ValueError("Fused gate-up projections must use one FP8 dtype.")
+        shard = (
+            _column_shard(weight, scales, tp_size, tp_rank)
+            if case == "gate_up"
+            else _row_shard(weight, scales, tp_size, tp_rank)
+        )
+        raw_parts.append(shard[0])
+        scale_parts.append(shard[1])
+
+    assert fp8_dtype is not None
+    raw = torch.cat(raw_parts, dim=0)
+    scales = torch.cat(scale_parts, dim=0)
+    return (
+        raw.to(device).view(fp8_dtype).contiguous(),
+        scales.to(device).contiguous(),
+        prefixes,
+    )
+
+
+def _event_trials(
+    launch: Callable[[], None], warmup: int, iters: int, trials: int
+) -> dict[str, Any]:
+    for _ in range(warmup):
+        launch()
+    torch.accelerator.synchronize()
+    samples: list[float] = []
+    for _ in range(trials):
+        start = torch.cuda.Event(enable_timing=True)
+        end = torch.cuda.Event(enable_timing=True)
+        start.record()
+        for _ in range(iters):
+            launch()
+        end.record()
+        end.synchronize()
+        samples.append(float(start.elapsed_time(end) / iters))
+    return {
+        "median_ms": float(statistics.median(samples)),
+        "mean_ms": float(statistics.mean(samples)),
+        "min_ms": min(samples),
+        "max_ms": max(samples),
+        "samples_ms": samples,
+    }
+
+
+def _digest(tensor: torch.Tensor) -> str:
+    raw = tensor.detach().contiguous().cpu().view(torch.uint8).numpy().tobytes()
+    return hashlib.sha256(raw).hexdigest()
+
+
+def _file_digest(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _run_case(
+    args: argparse.Namespace, case: str, device: torch.device
+) -> dict[str, Any]:
+    qweight, scales, prefixes = _load_case(
+        args.model, case, args.tp_size, args.tp_rank, device
+    )
+    n, k = (int(dim) for dim in qweight.shape)
+    expected = {
+        "gate_up": (8704, 5120),
+        "down": (5120, 4352),
+        "attention_output": (5120, 1536),
+    }[case]
+    if (n, k) != expected:
+        raise ValueError(f"Unexpected {case} TP-local shape N={n}, K={k}.")
+
+    tm_weight, tm_scales, meta = sm70_ops.fp8_sm70_prepare(qweight, scales, 128)
+    k_ld, q_ld = (int(value) for value in meta.tolist())
+    generator = torch.Generator(device=device).manual_seed(args.seed + n + k)
+    inputs = torch.randn(
+        (args.m, k), generator=generator, device=device, dtype=torch.float16
+    ).mul_(0.1)
+    output = torch.empty((args.m, n), device=device, dtype=torch.float16)
+    if args.gated_silu and case == "gate_up":
+        output = torch.empty((args.m, n // 2), device=device, dtype=torch.float16)
+    resident_bytes = 0
+    if args.backend == "resident-turbomind-f16":
+        dense_weight = torch.empty((k, n), device=device, dtype=torch.float16)
+        sm70_ops.fp8_sm70_dequantize_out(dense_weight, tm_weight, tm_scales, 128)
+        source_weight = dense_weight.t().contiguous()
+        f16_tm_weight, f16_meta = sm70_ops.sm70_f16_prepare(source_weight)
+        f16_k_ld = int(f16_meta[0].item())
+        resident_bytes = f16_tm_weight.numel() * f16_tm_weight.element_size()
+
+        def eager_launch() -> None:
+            sm70_ops.sm70_f16_gemm_out(
+                output,
+                inputs,
+                f16_tm_weight,
+                f16_k_ld,
+                args.gated_silu and case == "gate_up",
+            )
+
+    else:
+        workspace = torch.empty((k, n), device=device, dtype=torch.float16)
+        resident_bytes = workspace.numel() * workspace.element_size()
+
+        def eager_launch() -> None:
+            sm70_ops.fp8_gemm_sm70_prefill_dispatch_out(
+                output,
+                workspace.data_ptr(),
+                inputs,
+                tm_weight,
+                tm_scales,
+                128,
+                k_ld,
+                q_ld,
+                args.gated_silu and case == "gate_up",
+                3920,
+            )
+
+    cutlass_env = "VLLM_SM70_FP8_PREFILL_CUTLASS"
+    selected_cutlass = os.environ.get(cutlass_env)
+    os.environ[cutlass_env] = "0"
+    eager_launch()
+    torch.accelerator.synchronize(device)
+    reference = output.clone()
+    if selected_cutlass is None:
+        os.environ.pop(cutlass_env)
+    else:
+        os.environ[cutlass_env] = selected_cutlass
+
+    launch = eager_launch
+    graph: torch.cuda.CUDAGraph | None = None
+    if args.cuda_graph:
+        for _ in range(3):
+            eager_launch()
+        torch.accelerator.synchronize(device)
+        graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(graph):
+            eager_launch()
+        launch = graph.replay
+
+    timing = _event_trials(launch, args.warmup, args.iters, args.trials)
+    launch()
+    torch.accelerator.synchronize(device)
+    output_float = output.float()
+    reference_float = reference.float()
+    return {
+        "case": case,
+        "prefixes": prefixes,
+        "m": args.m,
+        "n": n,
+        "k": k,
+        "timing": timing,
+        "useful_tflops": 2 * args.m * n * k / (timing["median_ms"] * 1e-3) / 1e12,
+        "output_sha256": _digest(output),
+        "reference_sha256": _digest(reference),
+        "output_bitwise_equal": bool(torch.equal(output, reference)),
+        "output_max_abs_diff": float(
+            torch.max(torch.abs(output_float - reference_float)).item()
+        ),
+        "output_finite": bool(torch.isfinite(output).all().item()),
+        "resident_bytes": resident_bytes,
+    }
+
+
+def main() -> int:
+    args = _parse_args()
+    device = torch.device(args.device)
+    if torch.cuda.get_device_capability(device) != (7, 0):
+        raise RuntimeError("This benchmark requires an SM70/V100 GPU.")
+    torch.accelerator.set_device_index(device.index or 0)
+    if args.blas_library != "default":
+        torch.backends.cuda.preferred_blas_library(args.blas_library)
+
+    results = [_run_case(args, case, device) for case in args.cases]
+    extension_path = Path(vllm._C.__file__).resolve()
+    payload = {
+        "environment": {
+            "model": str(args.model),
+            "device": torch.cuda.get_device_name(device),
+            "capability": list(torch.cuda.get_device_capability(device)),
+            "torch": torch.__version__,
+            "torch_cuda": torch.version.cuda,
+            "blas_library_requested": args.blas_library,
+            "blas_library_effective": str(torch.backends.cuda.preferred_blas_library()),
+            "gated_silu": args.gated_silu,
+            "backend": args.backend,
+            "cuda_graph": args.cuda_graph,
+            "cutlass": os.getenv(
+                "VLLM_SM70_FP8_PREFILL_CUTLASS", "<unset:default-on>"
+            ),
+            "vllm_c_extension": str(extension_path),
+            "vllm_c_extension_sha256": _file_digest(extension_path),
+            "tp_size": args.tp_size,
+            "tp_rank": args.tp_rank,
+            "seed": args.seed,
+        },
+        "results": results,
+    }
+    args.json_out.parent.mkdir(parents=True, exist_ok=True)
+    args.json_out.write_text(json.dumps(payload, indent=2) + "\n")
+    print(json.dumps(payload, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmarks/benchmark_sm70_fp8_prefill_exact_dense_blas.py
+++ b/benchmarks/benchmark_sm70_fp8_prefill_exact_dense_blas.py
@@ -54,7 +54,7 @@ def _parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--model",
         type=Path,
-        default=Path("/home/ymzx/models/Qwen3.8-27B-FP8"),
+        required=True,
     )
     parser.add_argument("--json-out", type=Path, required=True)
     parser.add_argument("--device", default="cuda:0")
@@ -194,8 +194,8 @@ def _event_trials(
     torch.accelerator.synchronize()
     samples: list[float] = []
     for _ in range(trials):
-        start = torch.cuda.Event(enable_timing=True)
-        end = torch.cuda.Event(enable_timing=True)
+        start = torch.Event(enable_timing=True)
+        end = torch.Event(enable_timing=True)
         start.record()
         for _ in range(iters):
             launch()
@@ -349,9 +349,7 @@ def main() -> int:
             "gated_silu": args.gated_silu,
             "backend": args.backend,
             "cuda_graph": args.cuda_graph,
-            "cutlass": os.getenv(
-                "VLLM_SM70_FP8_PREFILL_CUTLASS", "<unset:default-on>"
-            ),
+            "cutlass": os.getenv("VLLM_SM70_FP8_PREFILL_CUTLASS", "<unset:default-on>"),
             "vllm_c_extension": str(extension_path),
             "vllm_c_extension_sha256": _file_digest(extension_path),
             "tp_size": args.tp_size,

--- a/benchmarks/benchmark_sm70_fp8_prefill_tactics.py
+++ b/benchmarks/benchmark_sm70_fp8_prefill_tactics.py
@@ -66,7 +66,7 @@ def _parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--model",
         type=Path,
-        default=Path("/home/ymzx/models/Qwen3.8-27B-FP8"),
+        required=True,
     )
     parser.add_argument("--json-out", type=Path, required=True)
     parser.add_argument("--device", default="cuda:0")
@@ -102,7 +102,7 @@ def _parse_args() -> argparse.Namespace:
     parser.add_argument("--iters", type=int, default=50)
     parser.add_argument("--trials", type=int, default=7)
     parser.add_argument("--seed", type=int, default=20260823)
-    parser.add_argument("--qwen38-prescaled-prefill", action="store_true")
+    parser.add_argument("--exact-8k-prescaled-prefill", action="store_true")
     parser.add_argument("--cuda-graph", action="store_true")
     return parser.parse_args()
 
@@ -215,8 +215,8 @@ def _event_trials(
 
     samples_ms: list[float] = []
     for _ in range(trials):
-        start = torch.cuda.Event(enable_timing=True)
-        end = torch.cuda.Event(enable_timing=True)
+        start = torch.Event(enable_timing=True)
+        end = torch.Event(enable_timing=True)
         start.record()
         for _ in range(iters):
             launch()
@@ -259,7 +259,7 @@ def _run_case(
         raise ValueError(f"Unexpected {case} TP-local shape N={n}, K={k}.")
 
     tm_weight, tm_scales, meta = sm70_ops.fp8_sm70_prepare(qweight, scales, 128)
-    if args.qwen38_prescaled_prefill:
+    if args.exact_8k_prescaled_prefill:
         tm_scales.mul_(256)
     k_ld, q_ld = (int(value) for value in meta.tolist())
     generator = torch.Generator(device=device).manual_seed(args.seed + m)
@@ -278,7 +278,7 @@ def _run_case(
         "resident-mm",
     ):
         reference_output = torch.empty_like(output)
-        if args.qwen38_prescaled_prefill:
+        if args.exact_8k_prescaled_prefill:
             sm70_ops.fp8_gemm_sm70_prefill_prescaled_out(
                 reference_output,
                 inputs,
@@ -365,7 +365,7 @@ def _run_case(
                 )
 
     else:
-        if args.qwen38_prescaled_prefill:
+        if args.exact_8k_prescaled_prefill:
 
             def launch(
                 output: torch.Tensor = output,
@@ -466,11 +466,11 @@ def main() -> int:
             "iters": args.iters,
             "trials": args.trials,
             "seed": args.seed,
-            "qwen38_prescaled_prefill": args.qwen38_prescaled_prefill,
+            "exact_8k_prescaled_prefill": args.exact_8k_prescaled_prefill,
             "cuda_graph": args.cuda_graph,
             "tm_gemm_tune": os.environ.get("TM_GEMM_TUNE"),
             "fast_targets": os.environ.get("VLLM_SM70_AWQ_TP2_FAST_TARGETS"),
-            "qwen38_prefill_fast_selector": os.environ.get(
+            "fp8_prefill_fast_selector": os.environ.get(
                 "VLLM_SM70_FP8_PREFILL_FAST_SELECTOR"
             ),
         },

--- a/benchmarks/benchmark_sm70_fp8_prefill_tactics.py
+++ b/benchmarks/benchmark_sm70_fp8_prefill_tactics.py
@@ -12,22 +12,53 @@ from __future__ import annotations
 
 import argparse
 import hashlib
+import importlib.util
 import json
 import math
 import os
 import statistics
+import sys
 from collections.abc import Callable
 from pathlib import Path
 from typing import Any, Literal
 
 import torch
-import vllm._C  # noqa: F401
 from safetensors import safe_open
 
-from vllm import _sm70_ops as sm70_ops
+import vllm
+
+
+def _load_vllm_c_extension() -> None:
+    if "vllm._C" in sys.modules:
+        vllm._C = sys.modules["vllm._C"]
+        return
+    candidate = os.getenv("VLLM_BENCH_C_EXTENSION")
+    if candidate is None:
+        importlib.import_module("vllm._C")
+        return
+    spec = importlib.util.spec_from_file_location("vllm._C", candidate)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Cannot load candidate extension: {candidate}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["vllm._C"] = module
+    vllm._C = module
+    spec.loader.exec_module(module)
+
+
+_load_vllm_c_extension()
+
+from vllm import _sm70_ops as sm70_ops  # noqa: E402
 
 Case = Literal["gdn_qkvz", "full_qkv"]
-Policy = Literal["default", "measure", "resident-f16", "resident-f16-measure"]
+Policy = Literal[
+    "default",
+    "measure",
+    "resident-f16",
+    "resident-f16-measure",
+    "exact-dispatch",
+    "exact-mm",
+    "resident-mm",
+]
 
 
 def _parse_args() -> argparse.Namespace:
@@ -50,7 +81,15 @@ def _parse_args() -> argparse.Namespace:
     parser.add_argument("--m", type=int, nargs="+", default=[8000])
     parser.add_argument(
         "--policy",
-        choices=("default", "measure", "resident-f16", "resident-f16-measure"),
+        choices=(
+            "default",
+            "measure",
+            "resident-f16",
+            "resident-f16-measure",
+            "exact-dispatch",
+            "exact-mm",
+            "resident-mm",
+        ),
         required=True,
     )
     parser.add_argument(
@@ -63,6 +102,8 @@ def _parse_args() -> argparse.Namespace:
     parser.add_argument("--iters", type=int, default=50)
     parser.add_argument("--trials", type=int, default=7)
     parser.add_argument("--seed", type=int, default=20260823)
+    parser.add_argument("--qwen38-prescaled-prefill", action="store_true")
+    parser.add_argument("--cuda-graph", action="store_true")
     return parser.parse_args()
 
 
@@ -218,6 +259,8 @@ def _run_case(
         raise ValueError(f"Unexpected {case} TP-local shape N={n}, K={k}.")
 
     tm_weight, tm_scales, meta = sm70_ops.fp8_sm70_prepare(qweight, scales, 128)
+    if args.qwen38_prescaled_prefill:
+        tm_scales.mul_(256)
     k_ld, q_ld = (int(value) for value in meta.tolist())
     generator = torch.Generator(device=device).manual_seed(args.seed + m)
     inputs = torch.randn(
@@ -225,32 +268,134 @@ def _run_case(
     ).mul_(0.1)
     output = torch.empty((m, n), device=device, dtype=torch.float16)
     resident_bytes = 0
-    if args.policy in ("resident-f16", "resident-f16-measure"):
+    dense_workspace_bytes = 0
+    reference_output = None
+    if args.policy in (
+        "resident-f16",
+        "resident-f16-measure",
+        "exact-dispatch",
+        "exact-mm",
+        "resident-mm",
+    ):
+        reference_output = torch.empty_like(output)
+        if args.qwen38_prescaled_prefill:
+            sm70_ops.fp8_gemm_sm70_prefill_prescaled_out(
+                reference_output,
+                inputs,
+                tm_weight,
+                tm_scales,
+                128,
+                k_ld,
+                q_ld,
+            )
+        else:
+            sm70_ops.fp8_gemm_sm70_out(
+                reference_output,
+                inputs,
+                tm_weight,
+                tm_scales,
+                128,
+                k_ld,
+                q_ld,
+                False,
+            )
         dense_weight = torch.empty((k, n), device=device, dtype=torch.float16)
-        sm70_ops.fp8_sm70_dequantize_out(dense_weight, tm_weight, tm_scales, 128)
-        source_f16_weight = dense_weight.t().contiguous()
-        f16_tm_weight, f16_meta = sm70_ops.sm70_f16_prepare(source_f16_weight)
-        f16_k_ld = int(f16_meta[0].item())
-        resident_bytes = int(f16_tm_weight.numel() * f16_tm_weight.element_size())
+        dense_workspace_bytes = int(dense_weight.numel() * dense_weight.element_size())
+        if args.policy == "exact-dispatch":
 
-        def launch(
-            output: torch.Tensor = output,
-            inputs: torch.Tensor = inputs,
-            f16_tm_weight: torch.Tensor = f16_tm_weight,
-        ) -> None:
-            sm70_ops.sm70_f16_gemm_out(output, inputs, f16_tm_weight, f16_k_ld, False)
+            def launch(
+                output: torch.Tensor = output,
+                inputs: torch.Tensor = inputs,
+                dense_weight: torch.Tensor = dense_weight,
+                tm_weight: torch.Tensor = tm_weight,
+                tm_scales: torch.Tensor = tm_scales,
+            ) -> None:
+                sm70_ops.fp8_gemm_sm70_prefill_dispatch_out(
+                    output,
+                    dense_weight.data_ptr(),
+                    inputs,
+                    tm_weight,
+                    tm_scales,
+                    128,
+                    k_ld,
+                    q_ld,
+                    False,
+                    m,
+                )
+
+        elif args.policy == "exact-mm":
+
+            def launch(
+                output: torch.Tensor = output,
+                inputs: torch.Tensor = inputs,
+                dense_weight: torch.Tensor = dense_weight,
+                tm_weight: torch.Tensor = tm_weight,
+                tm_scales: torch.Tensor = tm_scales,
+            ) -> None:
+                sm70_ops.fp8_sm70_dequantize_out(
+                    dense_weight, tm_weight, tm_scales, 128
+                )
+                torch.mm(inputs, dense_weight, out=output)
+
+        elif args.policy == "resident-mm":
+            sm70_ops.fp8_sm70_dequantize_out(dense_weight, tm_weight, tm_scales, 128)
+            resident_bytes = dense_workspace_bytes
+
+            def launch(
+                output: torch.Tensor = output,
+                inputs: torch.Tensor = inputs,
+                dense_weight: torch.Tensor = dense_weight,
+            ) -> None:
+                torch.mm(inputs, dense_weight, out=output)
+
+        else:
+            sm70_ops.fp8_sm70_dequantize_out(dense_weight, tm_weight, tm_scales, 128)
+            resident_bytes = dense_workspace_bytes
+            source_f16_weight = dense_weight.t().contiguous()
+            f16_tm_weight, f16_meta = sm70_ops.sm70_f16_prepare(source_f16_weight)
+            f16_k_ld = int(f16_meta[0].item())
+
+            def launch(
+                output: torch.Tensor = output,
+                inputs: torch.Tensor = inputs,
+                f16_tm_weight: torch.Tensor = f16_tm_weight,
+            ) -> None:
+                sm70_ops.sm70_f16_gemm_out(
+                    output, inputs, f16_tm_weight, f16_k_ld, False
+                )
 
     else:
+        if args.qwen38_prescaled_prefill:
 
-        def launch(
-            output: torch.Tensor = output,
-            inputs: torch.Tensor = inputs,
-            tm_weight: torch.Tensor = tm_weight,
-            tm_scales: torch.Tensor = tm_scales,
-        ) -> None:
-            sm70_ops.fp8_gemm_sm70_out(
-                output, inputs, tm_weight, tm_scales, 128, k_ld, q_ld, False
-            )
+            def launch(
+                output: torch.Tensor = output,
+                inputs: torch.Tensor = inputs,
+                tm_weight: torch.Tensor = tm_weight,
+                tm_scales: torch.Tensor = tm_scales,
+            ) -> None:
+                sm70_ops.fp8_gemm_sm70_prefill_prescaled_out(
+                    output, inputs, tm_weight, tm_scales, 128, k_ld, q_ld
+                )
+
+        else:
+
+            def launch(
+                output: torch.Tensor = output,
+                inputs: torch.Tensor = inputs,
+                tm_weight: torch.Tensor = tm_weight,
+                tm_scales: torch.Tensor = tm_scales,
+            ) -> None:
+                sm70_ops.fp8_gemm_sm70_out(
+                    output, inputs, tm_weight, tm_scales, 128, k_ld, q_ld, False
+                )
+
+    if args.cuda_graph:
+        launch()
+        torch.accelerator.synchronize(device)
+        graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(graph):
+            launch()
+        launch = graph.replay
 
     timing = _event_trials(launch, args.warmup, args.iters, args.trials)
     launch()
@@ -265,10 +410,21 @@ def _run_case(
         "tm_meta": {"k_ld": k_ld, "q_ld": q_ld},
         "timing": timing,
         "useful_tflops": float(2 * m * n * k / seconds / 1e12),
+        "dense_workspace_bytes": dense_workspace_bytes,
         "resident_f16_bytes": resident_bytes,
         "output_sha256": _digest(output),
         "output_finite": bool(torch.isfinite(output).all().item()),
     }
+    if reference_output is not None:
+        difference = (output.float() - reference_output.float()).abs()
+        result["reference"] = {
+            "output_sha256": _digest(reference_output),
+            "equal": bool(torch.equal(output, reference_output)),
+            "max_abs_diff": float(difference.max().item()),
+            "mean_abs_diff": float(difference.mean().item()),
+            "equal_elements": int((output == reference_output).sum().item()),
+            "elements": output.numel(),
+        }
     del qweight, scales, tm_weight, tm_scales, inputs, output
     torch.accelerator.empty_cache()
     return result
@@ -310,10 +466,12 @@ def main() -> int:
             "iters": args.iters,
             "trials": args.trials,
             "seed": args.seed,
+            "qwen38_prescaled_prefill": args.qwen38_prescaled_prefill,
+            "cuda_graph": args.cuda_graph,
             "tm_gemm_tune": os.environ.get("TM_GEMM_TUNE"),
             "fast_targets": os.environ.get("VLLM_SM70_AWQ_TP2_FAST_TARGETS"),
             "qwen38_prefill_fast_selector": os.environ.get(
-                "VLLM_SM70_FP8_QWEN38_PREFILL_FAST_SELECTOR"
+                "VLLM_SM70_FP8_PREFILL_FAST_SELECTOR"
             ),
         },
         "results": results,

--- a/benchmarks/benchmark_sm70_fp8_prefill_tactics.py
+++ b/benchmarks/benchmark_sm70_fp8_prefill_tactics.py
@@ -1,0 +1,328 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Benchmark TurboMind tactics on Qwen3.8 FP8 prefill projections.
+
+This diagnostic loads the real TP-local fused QKVZ and QKV weights used by
+Qwen3.8-27B-FP8. Run each dispatch policy in a fresh process: TurboMind caches
+the first exact GEMM descriptor, so switching from ``default`` to ``measure``
+inside one process would not actually tune the already-cached shape.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import math
+import os
+import statistics
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any, Literal
+
+import torch
+import vllm._C  # noqa: F401
+from safetensors import safe_open
+
+from vllm import _sm70_ops as sm70_ops
+
+Case = Literal["gdn_qkvz", "full_qkv"]
+Policy = Literal["default", "measure", "resident-f16", "resident-f16-measure"]
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--model",
+        type=Path,
+        default=Path("/home/ymzx/models/Qwen3.8-27B-FP8"),
+    )
+    parser.add_argument("--json-out", type=Path, required=True)
+    parser.add_argument("--device", default="cuda:0")
+    parser.add_argument("--tp-size", type=int, default=4)
+    parser.add_argument("--tp-rank", type=int, default=0)
+    parser.add_argument(
+        "--cases",
+        choices=("gdn_qkvz", "full_qkv"),
+        nargs="+",
+        default=["gdn_qkvz", "full_qkv"],
+    )
+    parser.add_argument("--m", type=int, nargs="+", default=[8000])
+    parser.add_argument(
+        "--policy",
+        choices=("default", "measure", "resident-f16", "resident-f16-measure"),
+        required=True,
+    )
+    parser.add_argument(
+        "--safe-fast",
+        choices=("off", "preserve-splits", "preserve-split-count"),
+        default="off",
+        help="Optionally constrain measured tactics to the default split contract.",
+    )
+    parser.add_argument("--warmup", type=int, default=10)
+    parser.add_argument("--iters", type=int, default=50)
+    parser.add_argument("--trials", type=int, default=7)
+    parser.add_argument("--seed", type=int, default=20260823)
+    return parser.parse_args()
+
+
+def _load_keys(model: Path, keys: list[str]) -> dict[str, torch.Tensor]:
+    index = json.loads((model / "model.safetensors.index.json").read_text())
+    weight_map: dict[str, str] = index["weight_map"]
+    by_file: dict[str, list[str]] = {}
+    for key in keys:
+        by_file.setdefault(weight_map[key], []).append(key)
+
+    result: dict[str, torch.Tensor] = {}
+    for filename, file_keys in by_file.items():
+        with safe_open(model / filename, framework="pt", device="cpu") as handle:
+            for key in file_keys:
+                result[key] = handle.get_tensor(key)
+    return result
+
+
+def _column_shard(
+    weight: torch.Tensor,
+    scales: torch.Tensor,
+    tp_size: int,
+    tp_rank: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    n = int(weight.shape[0])
+    if n % tp_size:
+        raise ValueError(f"N={n} is not divisible by TP={tp_size}.")
+    begin = tp_rank * (n // tp_size)
+    end = begin + n // tp_size
+    scale_begin = begin // 128
+    scale_end = math.ceil(end / 128)
+    return (
+        weight.view(torch.uint8)[begin:end].contiguous(),
+        scales[scale_begin:scale_end].contiguous(),
+    )
+
+
+def _load_case(
+    model: Path,
+    case: Case,
+    tp_size: int,
+    tp_rank: int,
+    device: torch.device,
+) -> tuple[torch.Tensor, torch.Tensor, list[str]]:
+    root = "model.language_model.layers"
+    if case == "gdn_qkvz":
+        prefixes = [
+            f"{root}.1.linear_attn.in_proj_qkv",
+            f"{root}.1.linear_attn.in_proj_z",
+        ]
+    elif case == "full_qkv":
+        prefixes = [
+            f"{root}.3.self_attn.q_proj",
+            f"{root}.3.self_attn.k_proj",
+            f"{root}.3.self_attn.v_proj",
+        ]
+    else:
+        raise ValueError(f"Unknown case: {case}")
+
+    keys = [
+        key
+        for prefix in prefixes
+        for key in (f"{prefix}.weight", f"{prefix}.weight_scale_inv")
+    ]
+    loaded = _load_keys(model, keys)
+    raw_parts: list[torch.Tensor] = []
+    scale_parts: list[torch.Tensor] = []
+    fp8_dtype: torch.dtype | None = None
+    for prefix in prefixes:
+        weight = loaded[f"{prefix}.weight"]
+        scales = loaded[f"{prefix}.weight_scale_inv"].float()
+        if fp8_dtype is None:
+            fp8_dtype = weight.dtype
+        elif fp8_dtype != weight.dtype:
+            raise ValueError("Fused projections must use one FP8 dtype.")
+        raw, scale = _column_shard(weight, scales, tp_size, tp_rank)
+        raw_parts.append(raw)
+        scale_parts.append(scale)
+
+    assert fp8_dtype is not None
+    raw = torch.cat(raw_parts, dim=0)
+    scales = torch.cat(scale_parts, dim=0)
+    qweight = raw.to(device).view(fp8_dtype).contiguous()
+    return qweight, scales.to(device).contiguous(), prefixes
+
+
+def _configure_policy(policy: Policy, safe_fast: str, max_m: int) -> None:
+    os.environ["VLLM_SM70_FP8_DENSE_TUNE_MAX_M"] = str(max_m)
+    os.environ["VLLM_SM70_FP8_TUNE_SMALL_SHAPES"] = "1" if policy == "measure" else "0"
+    os.environ["VLLM_SM70_F16_DENSE_TUNE_MAX_M"] = str(max_m)
+    os.environ["VLLM_SM70_AWQ_TUNE_SMALL_SHAPES"] = (
+        "1" if policy == "resident-f16-measure" else "0"
+    )
+    os.environ["VLLM_SM70_FP8_SAFE_FAST_SELECTOR"] = "0" if safe_fast == "off" else "1"
+    os.environ["VLLM_SM70_FP8_PRESERVE_DEFAULT_SPLITS"] = (
+        "1" if safe_fast == "preserve-splits" else "0"
+    )
+    os.environ["VLLM_SM70_FP8_PRESERVE_DEFAULT_SPLITS_ONLY"] = (
+        "1" if safe_fast == "preserve-split-count" else "0"
+    )
+
+
+def _event_trials(
+    launch: Callable[[], None], warmup: int, iters: int, trials: int
+) -> dict[str, float]:
+    for _ in range(warmup):
+        launch()
+    torch.accelerator.synchronize()
+
+    samples_ms: list[float] = []
+    for _ in range(trials):
+        start = torch.cuda.Event(enable_timing=True)
+        end = torch.cuda.Event(enable_timing=True)
+        start.record()
+        for _ in range(iters):
+            launch()
+        end.record()
+        end.synchronize()
+        samples_ms.append(float(start.elapsed_time(end) / iters))
+    ordered = sorted(samples_ms)
+    return {
+        "median_ms": float(statistics.median(samples_ms)),
+        "min_ms": ordered[0],
+        "max_ms": ordered[-1],
+    }
+
+
+def _digest(tensor: torch.Tensor) -> str:
+    raw = tensor.detach().contiguous().cpu().view(torch.uint8).numpy().tobytes()
+    return hashlib.sha256(raw).hexdigest()
+
+
+def _file_digest(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1 << 20), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _run_case(
+    args: argparse.Namespace, case: Case, m: int, device: torch.device
+) -> dict[str, Any]:
+    qweight, scales, prefixes = _load_case(
+        args.model, case, args.tp_size, args.tp_rank, device
+    )
+    n, k = (int(dim) for dim in qweight.shape)
+    if (
+        k != 5120
+        or (case == "gdn_qkvz" and n != 4096)
+        or (case == "full_qkv" and n != 3584)
+    ):
+        raise ValueError(f"Unexpected {case} TP-local shape N={n}, K={k}.")
+
+    tm_weight, tm_scales, meta = sm70_ops.fp8_sm70_prepare(qweight, scales, 128)
+    k_ld, q_ld = (int(value) for value in meta.tolist())
+    generator = torch.Generator(device=device).manual_seed(args.seed + m)
+    inputs = torch.randn(
+        (m, k), generator=generator, device=device, dtype=torch.float16
+    ).mul_(0.1)
+    output = torch.empty((m, n), device=device, dtype=torch.float16)
+    resident_bytes = 0
+    if args.policy in ("resident-f16", "resident-f16-measure"):
+        dense_weight = torch.empty((k, n), device=device, dtype=torch.float16)
+        sm70_ops.fp8_sm70_dequantize_out(dense_weight, tm_weight, tm_scales, 128)
+        source_f16_weight = dense_weight.t().contiguous()
+        f16_tm_weight, f16_meta = sm70_ops.sm70_f16_prepare(source_f16_weight)
+        f16_k_ld = int(f16_meta[0].item())
+        resident_bytes = int(f16_tm_weight.numel() * f16_tm_weight.element_size())
+
+        def launch(
+            output: torch.Tensor = output,
+            inputs: torch.Tensor = inputs,
+            f16_tm_weight: torch.Tensor = f16_tm_weight,
+        ) -> None:
+            sm70_ops.sm70_f16_gemm_out(output, inputs, f16_tm_weight, f16_k_ld, False)
+
+    else:
+
+        def launch(
+            output: torch.Tensor = output,
+            inputs: torch.Tensor = inputs,
+            tm_weight: torch.Tensor = tm_weight,
+            tm_scales: torch.Tensor = tm_scales,
+        ) -> None:
+            sm70_ops.fp8_gemm_sm70_out(
+                output, inputs, tm_weight, tm_scales, 128, k_ld, q_ld, False
+            )
+
+    timing = _event_trials(launch, args.warmup, args.iters, args.trials)
+    launch()
+    torch.accelerator.synchronize(device)
+    seconds = timing["median_ms"] * 1e-3
+    result = {
+        "case": case,
+        "prefixes": prefixes,
+        "m": m,
+        "n": n,
+        "k": k,
+        "tm_meta": {"k_ld": k_ld, "q_ld": q_ld},
+        "timing": timing,
+        "useful_tflops": float(2 * m * n * k / seconds / 1e12),
+        "resident_f16_bytes": resident_bytes,
+        "output_sha256": _digest(output),
+        "output_finite": bool(torch.isfinite(output).all().item()),
+    }
+    del qweight, scales, tm_weight, tm_scales, inputs, output
+    torch.accelerator.empty_cache()
+    return result
+
+
+def main() -> int:
+    args = _parse_args()
+    if not torch.cuda.is_available():
+        raise RuntimeError("CUDA is required.")
+    device = torch.device(args.device)
+    if torch.cuda.get_device_capability(device) != (7, 0):
+        raise RuntimeError("This benchmark requires an SM70/V100 GPU.")
+    if args.tp_size <= 0 or not 0 <= args.tp_rank < args.tp_size:
+        raise ValueError("Invalid TP size/rank.")
+    if any(m < 1 for m in args.m):
+        raise ValueError("Every M must be positive.")
+    if args.warmup < 1 or args.iters < 1 or args.trials < 1:
+        raise ValueError("Warmup, iterations, and trials must be positive.")
+
+    torch.accelerator.set_device_index(device.index or 0)
+    _configure_policy(args.policy, args.safe_fast, max(args.m))
+    results = [_run_case(args, case, m, device) for case in args.cases for m in args.m]
+    extension_path = Path(vllm._C.__file__)
+    payload = {
+        "environment": {
+            "model": str(args.model),
+            "vllm_c_extension": str(extension_path),
+            "vllm_c_extension_sha256": _file_digest(extension_path),
+            "cuda_visible_devices": os.environ.get("CUDA_VISIBLE_DEVICES"),
+            "device": torch.cuda.get_device_name(device),
+            "capability": list(torch.cuda.get_device_capability(device)),
+            "torch": torch.__version__,
+            "torch_cuda": torch.version.cuda,
+            "tp_size": args.tp_size,
+            "tp_rank": args.tp_rank,
+            "policy": args.policy,
+            "safe_fast": args.safe_fast,
+            "warmup": args.warmup,
+            "iters": args.iters,
+            "trials": args.trials,
+            "seed": args.seed,
+            "tm_gemm_tune": os.environ.get("TM_GEMM_TUNE"),
+            "fast_targets": os.environ.get("VLLM_SM70_AWQ_TP2_FAST_TARGETS"),
+            "qwen38_prefill_fast_selector": os.environ.get(
+                "VLLM_SM70_FP8_QWEN38_PREFILL_FAST_SELECTOR"
+            ),
+        },
+        "results": results,
+    }
+    args.json_out.parent.mkdir(parents=True, exist_ok=True)
+    args.json_out.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+    print(json.dumps(payload, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmarks/benchmark_sm70_model_tokens.py
+++ b/benchmarks/benchmark_sm70_model_tokens.py
@@ -527,6 +527,10 @@ def _sm70_turbomind_policy(
         True,
     )
     fp8_qpn8 = _env_bool("VLLM_SM70_FP8_QPN8", False)
+    fp8_prefill_visible_dense_mm = _env_bool(
+        "VLLM_SM70_FP8_PREFILL_VISIBLE_DENSE_MM",
+        False,
+    )
     nvfp4_turbomind = _env_bool("VLLM_SM70_NVFP4_TURBOMIND", False)
     nvfp4_moe_grouped_prefill = _env_bool("VLLM_SM70_NVFP4_MOE_GROUPED_PREFILL", True)
     mxfp4_turbomind = _env_bool("VLLM_SM70_MXFP4_TURBOMIND", False)
@@ -593,6 +597,10 @@ def _sm70_turbomind_policy(
         "fp8_qpn8_large_m_fallback": "bounded_fp16_weight_workspace",
         "fp8_qpn8_large_m_gated_temporary": "M_x_8704_fp16",
         "VLLM_SM70_FP8_QPN8_LIBRARY": os.environ.get("VLLM_SM70_FP8_QPN8_LIBRARY"),
+        "VLLM_SM70_FP8_PREFILL_VISIBLE_DENSE_MM": os.environ.get(
+            "VLLM_SM70_FP8_PREFILL_VISIBLE_DENSE_MM"
+        ),
+        "fp8_prefill_visible_dense_mm_effective": fp8_prefill_visible_dense_mm,
         "VLLM_SM70_NVFP4_TURBOMIND": os.environ.get("VLLM_SM70_NVFP4_TURBOMIND"),
         "nvfp4_turbomind_effective": nvfp4_turbomind,
         "VLLM_SM70_NVFP4_MOE_GROUPED_PREFILL": os.environ.get(
@@ -1627,6 +1635,14 @@ def _dump(args: argparse.Namespace) -> int:
         )
 
     prompts = _load_prompts(args)
+    if args.repeat_count < 1:
+        raise ValueError("--repeat-count must be positive")
+    if args.repeat_count > 1 and len(prompts) != 1:
+        raise ValueError("--repeat-count greater than one requires one prompt")
+    if args.repeat_count > 1 and (
+        args.cuda_profiler_capture_generate or capture_decode_after_prefix_warmup
+    ):
+        raise ValueError("CUDA-profiler capture does not support repeated requests")
     if capture_decode_after_prefix_warmup and len(prompts) != 1:
         raise ValueError(
             "--cuda-profiler-capture-decode-after-prefix-warmup requires "
@@ -1693,21 +1709,30 @@ def _dump(args: argparse.Namespace) -> int:
 
         torch.accelerator.synchronize()
         torch.cuda.cudart().cudaProfilerStart()
-    start = time.perf_counter()
+    generate_seconds_by_repeat: list[float] = []
+    outputs = []
     try:
-        if args.sequential_prompts:
-            outputs = []
-            for prompt in prompts:
-                outputs.extend(llm.generate([prompt], sampling_params))
-        else:
-            outputs = llm.generate(prompts, sampling_params)
+        for repeat_index in range(args.repeat_count):
+            if (
+                repeat_index
+                and args.reset_prefix_cache_between_repeats
+                and not llm.reset_prefix_cache()
+            ):
+                raise RuntimeError("Failed to reset the idle prefix cache")
+            generate_start = time.perf_counter()
+            if args.sequential_prompts:
+                for prompt in prompts:
+                    outputs.extend(llm.generate([prompt], sampling_params))
+            else:
+                outputs.extend(llm.generate(prompts, sampling_params))
+            generate_seconds_by_repeat.append(time.perf_counter() - generate_start)
     finally:
         if args.cuda_profiler_capture_generate or capture_decode_after_prefix_warmup:
             import torch
 
             torch.accelerator.synchronize()
             torch.cuda.cudart().cudaProfilerStop()
-    generate_seconds = time.perf_counter() - start
+    generate_seconds = sum(generate_seconds_by_repeat)
     metrics_snapshot = _metric_snapshot(llm)
 
     import torch
@@ -1820,6 +1845,9 @@ def _dump(args: argparse.Namespace) -> int:
         "sequential_prompts": args.sequential_prompts,
         "load_seconds": load_seconds,
         "generate_seconds": generate_seconds,
+        "generate_seconds_by_repeat": generate_seconds_by_repeat,
+        "repeat_count": args.repeat_count,
+        "reset_prefix_cache_between_repeats": (args.reset_prefix_cache_between_repeats),
         "total_output_tokens": total_output_tokens,
         "records": records,
     }
@@ -2575,6 +2603,8 @@ def _parse_args() -> argparse.Namespace:
         ),
     )
     parser.add_argument("--max-tokens", type=int, default=16)
+    parser.add_argument("--repeat-count", type=int, default=1)
+    parser.add_argument("--reset-prefix-cache-between-repeats", action="store_true")
     parser.add_argument("--temperature", type=float, default=0.0)
     parser.add_argument("--top-p", type=float, default=1.0)
     parser.add_argument("--top-k", type=int, default=-1)

--- a/benchmarks/benchmark_sm70_prefill_gemm_collective.py
+++ b/benchmarks/benchmark_sm70_prefill_gemm_collective.py
@@ -45,13 +45,13 @@ def _event_trials(
 ) -> dict[str, Any]:
     for _ in range(warmup):
         launch()
-    torch.cuda.synchronize()
+    torch.accelerator.synchronize()
 
     samples: list[float] = []
     for _ in range(trials):
         dist.barrier()
-        start = torch.cuda.Event(enable_timing=True)
-        end = torch.cuda.Event(enable_timing=True)
+        start = torch.Event(enable_timing=True)
+        end = torch.Event(enable_timing=True)
         start.record()
         for _ in range(iters):
             launch()
@@ -75,7 +75,7 @@ def _digest(tensor: torch.Tensor) -> str:
 def main() -> int:
     args = _parse_args()
     local_rank = int(os.environ["LOCAL_RANK"])
-    torch.cuda.set_device(local_rank)
+    torch.accelerator.set_device_index(local_rank)
     dist.init_process_group(backend="nccl")
     rank = dist.get_rank()
     world_size = dist.get_world_size()
@@ -303,7 +303,7 @@ def main() -> int:
         launch()
     if not args.skip_symm_mem:
         pipelined()
-    torch.cuda.synchronize()
+    torch.accelerator.synchronize()
 
     if args.include_gemma_norm:
         assert baseline_normalized is not None

--- a/benchmarks/benchmark_sm70_prefill_gemm_collective.py
+++ b/benchmarks/benchmark_sm70_prefill_gemm_collective.py
@@ -1,0 +1,395 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Compare GEMM+all-reduce with pipelined GEMM+RS+AG on SM70.
+
+Launch this benchmark with torchrun.  It models the exact Qwen3.8 TP4
+row-parallel down/output projection boundary without loading the model.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import statistics
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+import torch
+import torch.distributed as dist
+from torch.distributed._symmetric_memory import enable_symm_mem_for_group
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--m", type=int, default=8000)
+    parser.add_argument("--k", type=int, default=4352)
+    parser.add_argument("--n", type=int, default=5120)
+    parser.add_argument("--warmup", type=int, default=5)
+    parser.add_argument("--iters", type=int, default=10)
+    parser.add_argument("--trials", type=int, default=7)
+    parser.add_argument("--chunk-counts", type=int, nargs="+", default=[2, 4, 8])
+    parser.add_argument("--chunk-axis", choices=("m", "n"), default="m")
+    parser.add_argument("--skip-symm-mem", action="store_true")
+    parser.add_argument("--include-gemma-norm", action="store_true")
+    parser.add_argument("--norm-epsilon", type=float, default=1e-6)
+    parser.add_argument("--seed", type=int, default=20260823)
+    parser.add_argument("--json-out", type=Path, required=True)
+    return parser.parse_args()
+
+
+def _event_trials(
+    launch: Callable[[], None], warmup: int, iters: int, trials: int
+) -> dict[str, Any]:
+    for _ in range(warmup):
+        launch()
+    torch.cuda.synchronize()
+
+    samples: list[float] = []
+    for _ in range(trials):
+        dist.barrier()
+        start = torch.cuda.Event(enable_timing=True)
+        end = torch.cuda.Event(enable_timing=True)
+        start.record()
+        for _ in range(iters):
+            launch()
+        end.record()
+        end.synchronize()
+        samples.append(float(start.elapsed_time(end) / iters))
+    return {
+        "median_ms": float(statistics.median(samples)),
+        "mean_ms": float(statistics.mean(samples)),
+        "min_ms": min(samples),
+        "max_ms": max(samples),
+        "samples_ms": samples,
+    }
+
+
+def _digest(tensor: torch.Tensor) -> str:
+    raw = tensor.detach().contiguous().cpu().view(torch.uint8).numpy().tobytes()
+    return hashlib.sha256(raw).hexdigest()
+
+
+def main() -> int:
+    args = _parse_args()
+    local_rank = int(os.environ["LOCAL_RANK"])
+    torch.cuda.set_device(local_rank)
+    dist.init_process_group(backend="nccl")
+    rank = dist.get_rank()
+    world_size = dist.get_world_size()
+    if world_size != 4:
+        raise RuntimeError("This benchmark requires TP4.")
+    if torch.cuda.get_device_capability(local_rank) != (7, 0):
+        raise RuntimeError("This benchmark requires SM70/V100 GPUs.")
+    if args.m % world_size:
+        raise ValueError("M must be divisible by the world size.")
+    chunk_extent = args.m if args.chunk_axis == "m" else args.n
+    if any(chunks <= 0 or chunk_extent % chunks for chunks in args.chunk_counts):
+        raise ValueError(
+            f"Every chunk count must be positive and divide {args.chunk_axis.upper()}."
+        )
+    if args.include_gemma_norm:
+        import vllm.kernels  # noqa: F401
+
+        if args.n != 5120:
+            raise ValueError("The SM70 Gemma long-prefill norm requires N=5120.")
+        if not hasattr(torch.ops._C, "sm70_gemma_long_prefill_fused_add_rms_norm"):
+            raise RuntimeError("The active extension lacks the SM70 Gemma norm op.")
+
+    group_name = dist.group.WORLD.group_name
+    if not args.skip_symm_mem:
+        enable_symm_mem_for_group(group_name)
+    device = torch.device("cuda", local_rank)
+    generator = torch.Generator(device=device).manual_seed(args.seed + rank)
+    inputs = torch.randn(
+        (args.m, args.k),
+        generator=generator,
+        device=device,
+        dtype=torch.float16,
+    ).mul_(0.1)
+    weight = torch.randn(
+        (args.k, args.n),
+        generator=generator,
+        device=device,
+        dtype=torch.float16,
+    ).mul_(0.01)
+    baseline_out = torch.empty((args.m, args.n), device=device, dtype=torch.float16)
+    pipelined_out = torch.empty_like(baseline_out)
+    plain_sp_mm_out = torch.empty_like(baseline_out)
+    plain_sp_out = torch.empty_like(baseline_out)
+    plain_sp_shard = torch.empty(
+        (args.m // world_size, args.n), device=device, dtype=torch.float16
+    )
+    chunked_outputs = {
+        chunks: torch.empty_like(baseline_out) for chunks in args.chunk_counts
+    }
+    chunked_n_comm_outputs: dict[int, list[torch.Tensor]] = {}
+    if args.chunk_axis == "n":
+        chunked_n_comm_outputs = {
+            chunks: [
+                torch.empty(
+                    (args.m, args.n // chunks),
+                    device=device,
+                    dtype=torch.float16,
+                )
+                for _ in range(chunks)
+            ]
+            for chunks in args.chunk_counts
+        }
+    residual = None
+    norm_weight = None
+    baseline_normalized = None
+    baseline_residual_out = None
+    pipelined_normalized_shard = None
+    pipelined_residual_shard = None
+    chunked_normalized: dict[int, torch.Tensor] = {}
+    chunked_residual_out: dict[int, torch.Tensor] = {}
+    if args.include_gemma_norm:
+        residual = torch.randn(
+            (args.m, args.n),
+            generator=torch.Generator(device=device).manual_seed(args.seed + 10000),
+            device=device,
+            dtype=torch.float32,
+        ).mul_(0.1)
+        norm_weight = torch.randn(
+            (args.n,),
+            generator=torch.Generator(device=device).manual_seed(args.seed + 20000),
+            device=device,
+            dtype=torch.bfloat16,
+        ).mul_(0.01)
+        baseline_normalized = torch.empty_like(baseline_out)
+        baseline_residual_out = torch.empty_like(residual)
+        pipelined_normalized_shard = torch.empty(
+            (args.m // world_size, args.n), device=device, dtype=torch.float16
+        )
+        pipelined_residual_shard = torch.empty(
+            (args.m // world_size, args.n), device=device, dtype=torch.float32
+        )
+        chunked_normalized = {
+            chunks: torch.empty_like(baseline_out) for chunks in args.chunk_counts
+        }
+        chunked_residual_out = {
+            chunks: torch.empty_like(residual) for chunks in args.chunk_counts
+        }
+
+    def norm_out(
+        output: torch.Tensor,
+        residual_output: torch.Tensor,
+        input: torch.Tensor,
+        input_residual: torch.Tensor,
+    ) -> None:
+        assert norm_weight is not None
+        torch.ops._C.sm70_gemma_long_prefill_fused_add_rms_norm(
+            output,
+            residual_output,
+            input,
+            input_residual,
+            norm_weight,
+            args.norm_epsilon,
+        )
+
+    def baseline() -> None:
+        torch.mm(inputs, weight, out=baseline_out)
+        dist.all_reduce(baseline_out)
+        if args.include_gemma_norm:
+            assert baseline_normalized is not None
+            assert baseline_residual_out is not None
+            assert residual is not None
+            norm_out(
+                baseline_normalized,
+                baseline_residual_out,
+                baseline_out,
+                residual,
+            )
+
+    def pipelined() -> None:
+        shard = torch.ops.symm_mem.fused_matmul_reduce_scatter(
+            inputs,
+            weight,
+            "sum",
+            0,
+            group_name,
+        )
+        if args.include_gemma_norm:
+            assert residual is not None
+            assert pipelined_normalized_shard is not None
+            assert pipelined_residual_shard is not None
+            residual_shard = residual.narrow(
+                0, rank * (args.m // world_size), args.m // world_size
+            )
+            norm_out(
+                pipelined_normalized_shard,
+                pipelined_residual_shard,
+                shard,
+                residual_shard,
+            )
+            shard = pipelined_normalized_shard
+        dist.all_gather_into_tensor(pipelined_out, shard)
+
+    def plain_sp() -> None:
+        torch.mm(inputs, weight, out=plain_sp_mm_out)
+        dist.reduce_scatter_tensor(plain_sp_shard, plain_sp_mm_out)
+        shard = plain_sp_shard
+        if args.include_gemma_norm:
+            assert residual is not None
+            assert pipelined_normalized_shard is not None
+            assert pipelined_residual_shard is not None
+            residual_shard = residual.narrow(
+                0, rank * (args.m // world_size), args.m // world_size
+            )
+            norm_out(
+                pipelined_normalized_shard,
+                pipelined_residual_shard,
+                shard,
+                residual_shard,
+            )
+            shard = pipelined_normalized_shard
+        dist.all_gather_into_tensor(plain_sp_out, shard)
+
+    def make_chunked_all_reduce(chunks: int) -> Callable[[], None]:
+        if args.chunk_axis == "m":
+            lhs_chunks = inputs.chunk(chunks, dim=0)
+            rhs_chunks = (weight,) * chunks
+            output_chunks = chunked_outputs[chunks].chunk(chunks, dim=0)
+        else:
+            lhs_chunks = (inputs,) * chunks
+            rhs_chunks = weight.chunk(chunks, dim=1)
+            output_chunks = chunked_n_comm_outputs[chunks]
+        result_chunks = chunked_outputs[chunks].chunk(
+            chunks, dim=0 if args.chunk_axis == "m" else 1
+        )
+
+        def launch() -> None:
+            works = []
+            for lhs, rhs, output_chunk in zip(lhs_chunks, rhs_chunks, output_chunks):
+                torch.mm(lhs, rhs, out=output_chunk)
+                works.append(dist.all_reduce(output_chunk, async_op=True))
+            for work, output_chunk, result_chunk in zip(
+                works, output_chunks, result_chunks
+            ):
+                work.wait()
+                if args.chunk_axis == "n":
+                    result_chunk.copy_(output_chunk)
+            if args.include_gemma_norm:
+                assert residual is not None
+                norm_out(
+                    chunked_normalized[chunks],
+                    chunked_residual_out[chunks],
+                    chunked_outputs[chunks],
+                    residual,
+                )
+
+        return launch
+
+    baseline_timing = _event_trials(baseline, args.warmup, args.iters, args.trials)
+    plain_sp_timing = _event_trials(plain_sp, args.warmup, args.iters, args.trials)
+    chunked_launches = {
+        chunks: make_chunked_all_reduce(chunks) for chunks in args.chunk_counts
+    }
+    chunked_timings = {
+        chunks: _event_trials(launch, args.warmup, args.iters, args.trials)
+        for chunks, launch in chunked_launches.items()
+    }
+    pipelined_timing = None
+    if not args.skip_symm_mem:
+        pipelined_timing = _event_trials(
+            pipelined, args.warmup, args.iters, args.trials
+        )
+    baseline()
+    plain_sp()
+    for launch in chunked_launches.values():
+        launch()
+    if not args.skip_symm_mem:
+        pipelined()
+    torch.cuda.synchronize()
+
+    if args.include_gemma_norm:
+        assert baseline_normalized is not None
+        baseline_result = baseline_normalized
+    else:
+        baseline_result = baseline_out
+    local_payload = {
+        "rank": rank,
+        "baseline": baseline_timing,
+        "baseline_sha256": _digest(baseline_result),
+        "plain_sp": None,
+        "pipelined": None,
+        "chunked": {},
+    }
+    plain_sp_difference = (baseline_result.float() - plain_sp_out.float()).abs()
+    local_payload["plain_sp"] = {
+        "timing": plain_sp_timing,
+        "speedup": baseline_timing["median_ms"] / plain_sp_timing["median_ms"],
+        "max_abs_diff": float(plain_sp_difference.max().item()),
+        "mean_abs_diff": float(plain_sp_difference.mean().item()),
+        "equal_elements": int((baseline_result == plain_sp_out).sum().item()),
+        "elements": baseline_result.numel(),
+        "sha256": _digest(plain_sp_out),
+    }
+    if pipelined_timing is not None:
+        difference = (baseline_result.float() - pipelined_out.float()).abs()
+        local_payload["pipelined"] = {
+            "timing": pipelined_timing,
+            "speedup": baseline_timing["median_ms"] / pipelined_timing["median_ms"],
+            "max_abs_diff": float(difference.max().item()),
+            "mean_abs_diff": float(difference.mean().item()),
+            "equal_elements": int((baseline_result == pipelined_out).sum().item()),
+            "elements": baseline_result.numel(),
+            "sha256": _digest(pipelined_out),
+        }
+    for chunks, output in chunked_outputs.items():
+        chunked_result = (
+            chunked_normalized[chunks] if args.include_gemma_norm else output
+        )
+        chunked_difference = (baseline_result.float() - chunked_result.float()).abs()
+        local_payload["chunked"][str(chunks)] = {
+            "timing": chunked_timings[chunks],
+            "speedup": baseline_timing["median_ms"]
+            / chunked_timings[chunks]["median_ms"],
+            "max_abs_diff": float(chunked_difference.max().item()),
+            "mean_abs_diff": float(chunked_difference.mean().item()),
+            "equal_elements": int((baseline_result == chunked_result).sum().item()),
+            "elements": baseline_result.numel(),
+            "sha256": _digest(chunked_result),
+        }
+    gathered: list[dict[str, Any] | None] = [None] * world_size
+    dist.all_gather_object(gathered, local_payload)
+    if rank == 0:
+        payload = {
+            "environment": {
+                "world_size": world_size,
+                "device": torch.cuda.get_device_name(local_rank),
+                "torch": torch.__version__,
+                "torch_cuda": torch.version.cuda,
+                "m": args.m,
+                "k": args.k,
+                "n": args.n,
+                "dtype": "float16",
+                "warmup": args.warmup,
+                "iters": args.iters,
+                "trials": args.trials,
+                "chunk_counts": args.chunk_counts,
+                "chunk_axis": args.chunk_axis,
+                "symm_mem": not args.skip_symm_mem,
+                "include_gemma_norm": args.include_gemma_norm,
+                "norm_epsilon": args.norm_epsilon,
+                "seed": args.seed,
+                "cuda_visible_devices": os.getenv("CUDA_VISIBLE_DEVICES"),
+                "nccl_algo": os.getenv("NCCL_ALGO"),
+                "nccl_proto": os.getenv("NCCL_PROTO"),
+                "nccl_min_nchannels": os.getenv("NCCL_MIN_NCHANNELS"),
+                "nccl_max_nchannels": os.getenv("NCCL_MAX_NCHANNELS"),
+            },
+            "ranks": gathered,
+        }
+        args.json_out.parent.mkdir(parents=True, exist_ok=True)
+        args.json_out.write_text(json.dumps(payload, indent=2) + "\n")
+        print(json.dumps(payload, indent=2))
+    dist.destroy_process_group()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmarks/benchmark_sm70_tp4_fused_norm_collective.py
+++ b/benchmarks/benchmark_sm70_tp4_fused_norm_collective.py
@@ -48,13 +48,13 @@ def _event_trials(
 ) -> dict[str, Any]:
     for _ in range(warmup):
         launch()
-    torch.cuda.synchronize()
+    torch.accelerator.synchronize()
 
     samples: list[float] = []
     for _ in range(trials):
         dist.barrier()
-        start = torch.cuda.Event(enable_timing=True)
-        end = torch.cuda.Event(enable_timing=True)
+        start = torch.Event(enable_timing=True)
+        end = torch.Event(enable_timing=True)
         start.record()
         for _ in range(iters):
             launch()
@@ -78,7 +78,7 @@ def _digest(tensor: torch.Tensor) -> str:
 def main() -> int:
     args = _parse_args()
     local_rank = int(os.environ["LOCAL_RANK"])
-    torch.cuda.set_device(local_rank)
+    torch.accelerator.set_device_index(local_rank)
     dist.init_process_group(backend="nccl")
     cpu_group = dist.new_group(backend="gloo")
     rank = dist.get_rank()
@@ -205,7 +205,7 @@ def main() -> int:
         graph_launches: dict[tuple[int, int], Callable[[], None]] = {}
         for variant, launch in candidate_launches.items():
             launch()
-            torch.cuda.synchronize()
+            torch.accelerator.synchronize()
             dist.barrier()
             graph = torch.cuda.CUDAGraph()
             with communicator.capture(), torch.cuda.graph(graph):
@@ -221,7 +221,7 @@ def main() -> int:
     baseline()
     for launch in candidate_launches.values():
         launch()
-    torch.cuda.synchronize()
+    torch.accelerator.synchronize()
     local_rows = args.m // world_size
     residual_reference = baseline_residual.narrow(0, rank * local_rows, local_rows)
     candidates: dict[str, Any] = {}

--- a/benchmarks/benchmark_sm70_tp4_fused_norm_collective.py
+++ b/benchmarks/benchmark_sm70_tp4_fused_norm_collective.py
@@ -1,0 +1,305 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Benchmark SM70 fused reduce-scatter + Gemma RMSNorm + all-gather.
+
+Launch with torchrun on a fully connected TP4 V100 group.  The candidate is a
+benchmark-only implementation of the communication topology in NVIDIA's NCCL
+Device API fused RMSNorm example, using vLLM's existing IPC buffers and
+cross-device signal substrate so it can be measured with NCCL 2.27.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import statistics
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+import torch
+import torch.distributed as dist
+
+import vllm.kernels  # noqa: F401
+from vllm.distributed.device_communicators.custom_all_reduce import CustomAllreduce
+from vllm.distributed.device_communicators.pynccl import PyNcclCommunicator
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--m", type=int, default=8000)
+    parser.add_argument("--n", type=int, default=5120)
+    parser.add_argument("--threads", type=int, nargs="+", default=[256, 512, 1024])
+    parser.add_argument("--blocks", type=int, nargs="+", default=[80])
+    parser.add_argument("--warmup", type=int, default=3)
+    parser.add_argument("--iters", type=int, default=5)
+    parser.add_argument("--trials", type=int, default=5)
+    parser.add_argument("--epsilon", type=float, default=1e-6)
+    parser.add_argument("--seed", type=int, default=20260823)
+    parser.add_argument("--candidate-cuda-graph", action="store_true")
+    parser.add_argument("--json-out", type=Path, required=True)
+    return parser.parse_args()
+
+
+def _event_trials(
+    launch: Callable[[], None], warmup: int, iters: int, trials: int
+) -> dict[str, Any]:
+    for _ in range(warmup):
+        launch()
+    torch.cuda.synchronize()
+
+    samples: list[float] = []
+    for _ in range(trials):
+        dist.barrier()
+        start = torch.cuda.Event(enable_timing=True)
+        end = torch.cuda.Event(enable_timing=True)
+        start.record()
+        for _ in range(iters):
+            launch()
+        end.record()
+        end.synchronize()
+        samples.append(float(start.elapsed_time(end) / iters))
+    return {
+        "median_ms": float(statistics.median(samples)),
+        "mean_ms": float(statistics.mean(samples)),
+        "min_ms": min(samples),
+        "max_ms": max(samples),
+        "samples_ms": samples,
+    }
+
+
+def _digest(tensor: torch.Tensor) -> str:
+    raw = tensor.detach().contiguous().cpu().view(torch.uint8).numpy().tobytes()
+    return hashlib.sha256(raw).hexdigest()
+
+
+def main() -> int:
+    args = _parse_args()
+    local_rank = int(os.environ["LOCAL_RANK"])
+    torch.cuda.set_device(local_rank)
+    dist.init_process_group(backend="nccl")
+    cpu_group = dist.new_group(backend="gloo")
+    rank = dist.get_rank()
+    world_size = dist.get_world_size()
+    if world_size != 4:
+        raise RuntimeError("This benchmark requires TP4.")
+    if torch.cuda.get_device_capability(local_rank) != (7, 0):
+        raise RuntimeError("This benchmark requires SM70/V100 GPUs.")
+    if args.n != 5120 or args.m % world_size:
+        raise ValueError("The candidate requires N=5120 and TP-divisible M.")
+    if any(threads not in (256, 512, 1024) for threads in args.threads):
+        raise ValueError("--threads choices must be 256, 512, or 1024.")
+    if any(blocks < 1 or blocks > 512 for blocks in args.blocks):
+        raise ValueError("--blocks choices must be in [1, 512].")
+    variants = [(threads, blocks) for threads in args.threads for blocks in args.blocks]
+
+    device = torch.device("cuda", local_rank)
+    generator = torch.Generator(device=device).manual_seed(args.seed + rank)
+    partial = torch.randn(
+        (args.m, args.n),
+        generator=generator,
+        device=device,
+        dtype=torch.float16,
+    ).mul_(0.1)
+    residual = torch.randn(
+        (args.m, args.n),
+        generator=torch.Generator(device=device).manual_seed(args.seed + 10000),
+        device=device,
+        dtype=torch.float32,
+    ).mul_(0.1)
+    weight = torch.randn(
+        (args.n,),
+        generator=torch.Generator(device=device).manual_seed(args.seed + 20000),
+        device=device,
+        dtype=torch.float16,
+    ).mul_(0.01)
+
+    baseline_reduced = torch.empty_like(partial)
+    baseline_normalized = torch.empty_like(partial)
+    baseline_residual = torch.empty_like(residual)
+    candidate_normalized = {variant: torch.empty_like(partial) for variant in variants}
+    candidate_residual = {
+        variant: torch.empty_like(residual, dtype=torch.float32) for variant in variants
+    }
+
+    max_size = partial.numel() * partial.element_size() + 1
+    pynccl = PyNcclCommunicator(group=cpu_group, device=device)
+    if pynccl.disabled:
+        raise RuntimeError("PyNccl is unavailable for the production baseline.")
+    communicator = CustomAllreduce(
+        cpu_group,
+        device,
+        max_size=max_size,
+        long_prefill_fusion_enabled=True,
+    )
+    if communicator.disabled:
+        raise RuntimeError("Custom all-reduce is unavailable for this TP4 group.")
+
+    def norm_out(
+        output: torch.Tensor,
+        residual_output: torch.Tensor,
+        input: torch.Tensor,
+        input_residual: torch.Tensor,
+    ) -> None:
+        torch.ops._C.sm70_gemma_long_prefill_fused_add_rms_norm(
+            output,
+            residual_output,
+            input,
+            input_residual,
+            weight,
+            args.epsilon,
+        )
+
+    def baseline() -> None:
+        pynccl.all_reduce(partial, baseline_reduced)
+        norm_out(
+            baseline_normalized,
+            baseline_residual,
+            baseline_reduced,
+            residual,
+        )
+
+    def baseline_all_reduce() -> None:
+        pynccl.all_reduce(partial, baseline_reduced)
+
+    def baseline_norm() -> None:
+        norm_out(
+            baseline_normalized,
+            baseline_residual,
+            baseline_reduced,
+            residual,
+        )
+
+    def d2d_copy() -> None:
+        baseline_reduced.copy_(partial)
+
+    def make_candidate(threads: int, blocks: int) -> Callable[[], None]:
+        def launch() -> None:
+            os.environ["VLLM_SM70_TP4_LONG_FUSED_NORM_THREADS"] = str(threads)
+            os.environ["VLLM_SM70_TP4_LONG_FUSED_NORM_BLOCKS"] = str(blocks)
+            communicator.sm70_tp4_reduce_scatter_gemma_rms_norm_all_gather(
+                partial,
+                residual,
+                weight,
+                args.epsilon,
+                normalized_out=candidate_normalized[(threads, blocks)],
+                residual_out=candidate_residual[(threads, blocks)],
+            )
+
+        return launch
+
+    baseline_timing = _event_trials(baseline, args.warmup, args.iters, args.trials)
+    baseline_ar_timing = _event_trials(
+        baseline_all_reduce, args.warmup, args.iters, args.trials
+    )
+    baseline_all_reduce()
+    baseline_norm_timing = _event_trials(
+        baseline_norm, args.warmup, args.iters, args.trials
+    )
+    copy_timing = _event_trials(d2d_copy, args.warmup, args.iters, args.trials)
+    candidate_launches = {variant: make_candidate(*variant) for variant in variants}
+    candidate_graphs: list[torch.cuda.CUDAGraph] = []
+    if args.candidate_cuda_graph:
+        graph_launches: dict[tuple[int, int], Callable[[], None]] = {}
+        for variant, launch in candidate_launches.items():
+            launch()
+            torch.cuda.synchronize()
+            dist.barrier()
+            graph = torch.cuda.CUDAGraph()
+            with communicator.capture(), torch.cuda.graph(graph):
+                launch()
+            candidate_graphs.append(graph)
+            graph_launches[variant] = graph.replay
+        candidate_launches = graph_launches
+    candidate_timings = {
+        variant: _event_trials(launch, args.warmup, args.iters, args.trials)
+        for variant, launch in candidate_launches.items()
+    }
+
+    baseline()
+    for launch in candidate_launches.values():
+        launch()
+    torch.cuda.synchronize()
+    local_rows = args.m // world_size
+    residual_reference = baseline_residual.narrow(0, rank * local_rows, local_rows)
+    candidates: dict[str, Any] = {}
+    for variant in variants:
+        threads, blocks = variant
+        normalized_difference = (
+            baseline_normalized.float() - candidate_normalized[variant].float()
+        ).abs()
+        candidate_residual_shard = candidate_residual[variant].narrow(
+            0, rank * local_rows, local_rows
+        )
+        residual_difference = (residual_reference - candidate_residual_shard).abs()
+        timing = candidate_timings[variant]
+        candidates[f"t{threads}_b{blocks}"] = {
+            "threads": threads,
+            "blocks": blocks,
+            "timing": timing,
+            "speedup": baseline_timing["median_ms"] / timing["median_ms"],
+            "normalized_max_abs_diff": float(normalized_difference.max().item()),
+            "normalized_mean_abs_diff": float(normalized_difference.mean().item()),
+            "normalized_equal_elements": int(
+                (baseline_normalized == candidate_normalized[variant]).sum().item()
+            ),
+            "normalized_elements": baseline_normalized.numel(),
+            "residual_max_abs_diff": float(residual_difference.max().item()),
+            "residual_mean_abs_diff": float(residual_difference.mean().item()),
+            "normalized_sha256": _digest(candidate_normalized[variant]),
+            "residual_shard_sha256": _digest(candidate_residual_shard),
+        }
+
+    local_payload = {
+        "rank": rank,
+        "baseline": baseline_timing,
+        "baseline_all_reduce": baseline_ar_timing,
+        "baseline_norm": baseline_norm_timing,
+        "d2d_copy": copy_timing,
+        "baseline_normalized_sha256": _digest(baseline_normalized),
+        "baseline_residual_shard_sha256": _digest(residual_reference),
+        "candidates": candidates,
+    }
+    gathered: list[dict[str, Any] | None] = [None] * world_size
+    dist.all_gather_object(gathered, local_payload)
+    if rank == 0:
+        payload = {
+            "environment": {
+                "world_size": world_size,
+                "device": torch.cuda.get_device_name(local_rank),
+                "torch": torch.__version__,
+                "torch_cuda": torch.version.cuda,
+                "m": args.m,
+                "n": args.n,
+                "dtype": "float16",
+                "residual_dtype": "float32",
+                "threads": args.threads,
+                "blocks": args.blocks,
+                "candidate_cuda_graph": args.candidate_cuda_graph,
+                "warmup": args.warmup,
+                "iters": args.iters,
+                "trials": args.trials,
+                "epsilon": args.epsilon,
+                "seed": args.seed,
+                "cuda_visible_devices": os.environ.get("CUDA_VISIBLE_DEVICES"),
+                "nccl_algo": os.environ.get("NCCL_ALGO"),
+                "nccl_proto": os.environ.get("NCCL_PROTO"),
+            },
+            "ranks": gathered,
+        }
+        args.json_out.parent.mkdir(parents=True, exist_ok=True)
+        args.json_out.write_text(json.dumps(payload, indent=2) + "\n")
+        print(json.dumps(payload, indent=2), flush=True)
+
+    communicator.close()
+    pynccl.destroy()
+    dist.barrier()
+    dist.destroy_process_group(cpu_group)
+    dist.destroy_process_group()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmarks/kernels/benchmark_device_communicators.py
+++ b/benchmarks/kernels/benchmark_device_communicators.py
@@ -49,9 +49,10 @@ logger = init_logger(__name__)
 # Default sequence lengths to benchmark
 DEFAULT_SEQUENCE_LENGTHS = [16, 64, 128, 512, 1024, 2048, 4096, 8192]
 
-# Fixed hidden size and dtype for all benchmarks
-HIDDEN_SIZE = 8192
-BENCHMARK_DTYPE = torch.bfloat16
+# Defaults preserve the original benchmark contract. CLI overrides make it
+# possible to replay an exact model communication shape.
+DEFAULT_HIDDEN_SIZE = 8192
+DEFAULT_BENCHMARK_DTYPE = torch.bfloat16
 
 # CUDA graph settings
 CUDA_GRAPH_CAPTURE_CYCLES = 10
@@ -67,16 +68,20 @@ class CommunicatorBenchmark:
         device: torch.device,
         cpu_group: ProcessGroup,
         sequence_lengths: list[int],
+        hidden_size: int,
+        dtype: torch.dtype,
     ):
         self.rank = rank
         self.world_size = world_size
         self.device = device
         self.cpu_group = cpu_group
+        self.hidden_size = hidden_size
+        self.dtype = dtype
 
         # Calculate max_size_override based on largest sequence length
         max_seq_len = max(sequence_lengths)
-        max_tensor_elements = max_seq_len * HIDDEN_SIZE
-        self.max_size_override = max_tensor_elements * BENCHMARK_DTYPE.itemsize + 1
+        max_tensor_elements = max_seq_len * self.hidden_size
+        self.max_size_override = max_tensor_elements * self.dtype.itemsize + 1
 
         # Initialize communicators
         self.custom_allreduce = None
@@ -337,7 +342,10 @@ class CommunicatorBenchmark:
         try:
             # Create test tensor (2D: sequence_length x hidden_size)
             tensor = torch.randn(
-                sequence_length, HIDDEN_SIZE, dtype=BENCHMARK_DTYPE, device=self.device
+                sequence_length,
+                self.hidden_size,
+                dtype=self.dtype,
+                device=self.device,
             )
             if not should_use_fn(tensor):
                 return None
@@ -405,16 +413,17 @@ def _calculate_speedup_info(comm_results: dict[str, float]) -> str:
 
 
 def print_results(
-    results: dict[str, dict[str, float]], sequence_lengths: list[int], world_size: int
+    results: dict[str, dict[str, float]],
+    sequence_lengths: list[int],
+    world_size: int,
+    hidden_size: int,
+    dtype: torch.dtype,
 ):
     """Print benchmark results in a formatted table."""
 
     print(f"\n{'=' * 130}")
     print("Device Communicator Benchmark Results")
-    print(
-        f"World Size: {world_size}, Data Type: {BENCHMARK_DTYPE}, "
-        f"Hidden Size: {HIDDEN_SIZE}"
-    )
+    print(f"World Size: {world_size}, Data Type: {dtype}, Hidden Size: {hidden_size}")
     print(f"{'=' * 130}")
 
     # Get all communicator names
@@ -436,15 +445,15 @@ def print_results(
     for seq_len in sequence_lengths:
         if seq_len in results:
             # Calculate tensor size in elements and bytes
-            tensor_elements = seq_len * HIDDEN_SIZE
-            tensor_bytes = tensor_elements * BENCHMARK_DTYPE.itemsize
+            tensor_elements = seq_len * hidden_size
+            tensor_bytes = tensor_elements * dtype.itemsize
 
             # Format tensor size (MB)
             tensor_size_mb = tensor_bytes / (1024 * 1024)
             tensor_size_str = f"{tensor_size_mb:.2f} MB"
 
             # Format tensor shape
-            tensor_shape = f"({seq_len}, {HIDDEN_SIZE})"
+            tensor_shape = f"({seq_len}, {hidden_size})"
 
             row = f"{tensor_shape:<20}{tensor_size_str:<15}"
             for comm in all_comms:
@@ -483,9 +492,24 @@ def main():
         "--num-trials", type=int, default=50, help="Number of benchmark trials"
     )
 
+    parser.add_argument(
+        "--hidden-size",
+        type=int,
+        default=DEFAULT_HIDDEN_SIZE,
+        help="Hidden dimension of the all-reduce tensor.",
+    )
+
+    parser.add_argument(
+        "--dtype",
+        choices=("float16", "bfloat16"),
+        default="bfloat16",
+        help="All-reduce tensor dtype.",
+    )
+
     parser.add_argument("--output-json", type=str, help="Output results to JSON file")
 
     args = parser.parse_args()
+    benchmark_dtype = getattr(torch, args.dtype)
 
     # Initialize distributed
     if not dist.is_initialized():
@@ -506,7 +530,13 @@ def main():
 
     # Initialize benchmark
     benchmark = CommunicatorBenchmark(
-        rank, world_size, device, cpu_group, args.sequence_lengths
+        rank,
+        world_size,
+        device,
+        cpu_group,
+        args.sequence_lengths,
+        args.hidden_size,
+        benchmark_dtype,
     )
 
     # Run benchmarks
@@ -518,7 +548,7 @@ def main():
                 "Benchmarking sequence length: %s (tensor shape: %s x %s)",
                 seq_len,
                 seq_len,
-                HIDDEN_SIZE,
+                args.hidden_size,
             )
 
         results = benchmark.benchmark_allreduce(
@@ -534,7 +564,13 @@ def main():
 
     # Print results (only rank 0)
     if rank == 0:
-        print_results(all_results, args.sequence_lengths, world_size)
+        print_results(
+            all_results,
+            args.sequence_lengths,
+            world_size,
+            args.hidden_size,
+            benchmark_dtype,
+        )
 
         # Save to JSON if requested
         if args.output_json:
@@ -548,8 +584,8 @@ def main():
 
             output_data = {
                 "world_size": world_size,
-                "dtype": str(BENCHMARK_DTYPE),
-                "hidden_size": HIDDEN_SIZE,
+                "dtype": str(benchmark_dtype),
+                "hidden_size": args.hidden_size,
                 "sequence_lengths": args.sequence_lengths,
                 "num_warmup": args.num_warmup,
                 "num_trials": args.num_trials,

--- a/csrc/custom_all_reduce.cu
+++ b/csrc/custom_all_reduce.cu
@@ -277,6 +277,82 @@ void sm70_tp4_all_reduce_gemma_rms_norm(
       reg_buffer_sz_bytes, epsilon);
 }
 
+void sm70_tp4_reduce_scatter_gemma_rms_norm_all_gather(
+    fptr_t _fa, torch::Tensor& inp, torch::Tensor& residual,
+    torch::Tensor& weight, torch::Tensor& normalized_out,
+    torch::Tensor& residual_out, fptr_t _reg_input_buffer,
+    fptr_t _reg_output_buffer, int64_t reg_buffer_sz_bytes, double epsilon) {
+  constexpr int64_t kWorldSize = 4;
+  constexpr int64_t kHiddenSize = vllm::kSm70GemmaRmsNormHiddenSize;
+  auto fa = reinterpret_cast<vllm::CustomAllreduce*>(_fa);
+  const at::cuda::OptionalCUDAGuard device_guard(device_of(inp));
+  auto stream = c10::cuda::getCurrentCUDAStream().stream();
+
+  TORCH_CHECK_EQ(fa->world_size_, kWorldSize);
+  TORCH_CHECK(fa->fully_connected_);
+  TORCH_CHECK_EQ(inp.scalar_type(), at::ScalarType::Half);
+  TORCH_CHECK_EQ(residual.scalar_type(), at::ScalarType::Float);
+  TORCH_CHECK(weight.scalar_type() == at::ScalarType::Half ||
+              weight.scalar_type() == at::ScalarType::Float);
+  TORCH_CHECK_EQ(normalized_out.scalar_type(), at::ScalarType::Half);
+  TORCH_CHECK_EQ(residual_out.scalar_type(), at::ScalarType::Float);
+  TORCH_CHECK_EQ(inp.dim(), 2);
+  TORCH_CHECK_EQ(inp.size(1), kHiddenSize);
+  TORCH_CHECK_EQ(inp.size(0) % kWorldSize, 0);
+  TORCH_CHECK_LE(inp.size(0) / kWorldSize,
+                 vllm::kSm70LongPrefillMaxTokensPerRank);
+  TORCH_CHECK(residual.sizes() == inp.sizes());
+  TORCH_CHECK(normalized_out.sizes() == inp.sizes());
+  TORCH_CHECK(residual_out.sizes() == inp.sizes());
+  TORCH_CHECK_EQ(weight.dim(), 1);
+  TORCH_CHECK_EQ(weight.numel(), kHiddenSize);
+  TORCH_CHECK_EQ(residual.get_device(), inp.get_device());
+  TORCH_CHECK_EQ(weight.get_device(), inp.get_device());
+  TORCH_CHECK_EQ(normalized_out.get_device(), inp.get_device());
+  TORCH_CHECK_EQ(residual_out.get_device(), inp.get_device());
+  TORCH_CHECK(inp.is_contiguous());
+  TORCH_CHECK(residual.is_contiguous());
+  TORCH_CHECK(weight.is_contiguous());
+  TORCH_CHECK(normalized_out.is_contiguous());
+  TORCH_CHECK(residual_out.is_contiguous());
+
+  auto* reg_input_buffer = reinterpret_cast<void*>(_reg_input_buffer);
+  auto* reg_output_buffer = reinterpret_cast<void*>(_reg_output_buffer);
+  const int64_t input_size = inp.numel() * inp.element_size();
+  TORCH_CHECK_LE(input_size, reg_buffer_sz_bytes);
+  if (reg_input_buffer != nullptr) {
+    AT_CUDA_CHECK(cudaMemcpyAsync(reg_input_buffer, inp.data_ptr(), input_size,
+                                  cudaMemcpyDeviceToDevice, stream));
+  } else {
+    reg_input_buffer = inp.data_ptr();
+  }
+  if (reg_output_buffer == nullptr) {
+    reg_output_buffer = normalized_out.data_ptr();
+  }
+
+  auto* input_ptr = reinterpret_cast<half*>(reg_input_buffer);
+  auto* shared_output_ptr = reinterpret_cast<half*>(reg_output_buffer);
+  auto* residual_ptr = reinterpret_cast<const float*>(residual.data_ptr());
+  auto* residual_out_ptr = reinterpret_cast<float*>(residual_out.data_ptr());
+  const int num_tokens = static_cast<int>(inp.size(0));
+  const float epsilon_f = static_cast<float>(epsilon);
+  if (weight.scalar_type() == at::ScalarType::Float) {
+    fa->sm70_reduce_scatter_gemma_rms_norm_all_gather<4, float, float>(
+        stream, input_ptr, shared_output_ptr, residual_ptr,
+        reinterpret_cast<const float*>(weight.data_ptr()), residual_out_ptr,
+        num_tokens, kHiddenSize, epsilon_f);
+  } else {
+    fa->sm70_reduce_scatter_gemma_rms_norm_all_gather<4, float, half>(
+        stream, input_ptr, shared_output_ptr, residual_ptr,
+        reinterpret_cast<const half*>(weight.data_ptr()), residual_out_ptr,
+        num_tokens, kHiddenSize, epsilon_f);
+  }
+  if (_reg_output_buffer != 0) {
+    AT_CUDA_CHECK(cudaMemcpyAsync(normalized_out.data_ptr(), reg_output_buffer,
+                                  input_size, cudaMemcpyDeviceToDevice, stream));
+  }
+}
+
 void all_reduce_sum2(fptr_t _fa, torch::Tensor& inp_a, torch::Tensor& inp_b,
                      torch::Tensor& out) {
   auto fa = reinterpret_cast<vllm::CustomAllreduce*>(_fa);

--- a/csrc/custom_all_reduce.cu
+++ b/csrc/custom_all_reduce.cu
@@ -161,12 +161,12 @@ void sm70_all_reduce_gemma_rms_norm_impl(
                 "SM70 TP4 Gemma RMSNorm prototype residual must be float32.");
   } else {
     TORCH_CHECK(residual.scalar_type() == at::ScalarType::Half ||
-                residual.scalar_type() == at::ScalarType::Float,
+                    residual.scalar_type() == at::ScalarType::Float,
                 "SM70 Gemma RMSNorm prototype residual must be float16 or "
                 "float32.");
   }
   TORCH_CHECK(weight.scalar_type() == at::ScalarType::Half ||
-              weight.scalar_type() == at::ScalarType::Float,
+                  weight.scalar_type() == at::ScalarType::Float,
               "SM70 Gemma RMSNorm prototype weight must be float16 or "
               "float32.");
   TORCH_CHECK_EQ(inp.dim(), 2);
@@ -176,8 +176,9 @@ void sm70_all_reduce_gemma_rms_norm_impl(
   TORCH_CHECK(normalized_out.sizes() == inp.sizes(),
               "SM70 Gemma RMSNorm prototype normalized_out shape must match "
               "inp.");
-  TORCH_CHECK(residual_out.sizes() == inp.sizes(),
-              "SM70 Gemma RMSNorm prototype residual_out shape must match inp.");
+  TORCH_CHECK(
+      residual_out.sizes() == inp.sizes(),
+      "SM70 Gemma RMSNorm prototype residual_out shape must match inp.");
   TORCH_CHECK_EQ(weight.dim(), 1);
   TORCH_CHECK_EQ(weight.numel(), kHiddenSize);
   TORCH_CHECK_EQ(residual.get_device(), inp.get_device());
@@ -349,7 +350,8 @@ void sm70_tp4_reduce_scatter_gemma_rms_norm_all_gather(
   }
   if (_reg_output_buffer != 0) {
     AT_CUDA_CHECK(cudaMemcpyAsync(normalized_out.data_ptr(), reg_output_buffer,
-                                  input_size, cudaMemcpyDeviceToDevice, stream));
+                                  input_size, cudaMemcpyDeviceToDevice,
+                                  stream));
   }
 }
 
@@ -383,17 +385,17 @@ void all_reduce_sum2(fptr_t _fa, torch::Tensor& inp_a, torch::Tensor& inp_b,
 
   switch (out.scalar_type()) {
     case at::ScalarType::Float: {
-      fa->allreduce_sum2<float>(stream, reinterpret_cast<float*>(inp_a.data_ptr()),
-                                reinterpret_cast<float*>(inp_b.data_ptr()),
-                                reinterpret_cast<float*>(out.data_ptr()),
-                                out.numel());
+      fa->allreduce_sum2<float>(
+          stream, reinterpret_cast<float*>(inp_a.data_ptr()),
+          reinterpret_cast<float*>(inp_b.data_ptr()),
+          reinterpret_cast<float*>(out.data_ptr()), out.numel());
       break;
     }
     case at::ScalarType::Half: {
-      fa->allreduce_sum2<half>(stream, reinterpret_cast<half*>(inp_a.data_ptr()),
-                               reinterpret_cast<half*>(inp_b.data_ptr()),
-                               reinterpret_cast<half*>(out.data_ptr()),
-                               out.numel());
+      fa->allreduce_sum2<half>(
+          stream, reinterpret_cast<half*>(inp_a.data_ptr()),
+          reinterpret_cast<half*>(inp_b.data_ptr()),
+          reinterpret_cast<half*>(out.data_ptr()), out.numel());
       break;
     }
 #if (__CUDA_ARCH__ >= 800 || !defined(__CUDA_ARCH__))
@@ -439,8 +441,7 @@ void top1_argmax(fptr_t _fa, torch::Tensor& input_pair, torch::Tensor& output,
 }
 
 void tile_runtime_all_reduce(fptr_t _fa, torch::Tensor& inp, torch::Tensor& out,
-                             fptr_t _reg_buffer,
-                             int64_t reg_buffer_sz_bytes,
+                             fptr_t _reg_buffer, int64_t reg_buffer_sz_bytes,
                              int64_t tile_numel, int64_t engine_blocks,
                              int64_t compute_iters) {
   auto fa = reinterpret_cast<vllm::CustomAllreduce*>(_fa);
@@ -488,8 +489,7 @@ void tile_runtime_all_reduce(fptr_t _fa, torch::Tensor& inp, torch::Tensor& out,
 void tile_runtime_all_reduce_engine(fptr_t _fa, torch::Tensor& inp,
                                     torch::Tensor& out, fptr_t _reg_buffer,
                                     int64_t reg_buffer_sz_bytes,
-                                    int64_t tile_numel,
-                                    int64_t producer_blocks,
+                                    int64_t tile_numel, int64_t producer_blocks,
                                     int64_t reducer_blocks,
                                     int64_t compute_iters) {
   auto fa = reinterpret_cast<vllm::CustomAllreduce*>(_fa);

--- a/csrc/custom_all_reduce.cuh
+++ b/csrc/custom_all_reduce.cuh
@@ -54,6 +54,9 @@ constexpr size_t kSm70Tp8HierarchicalAllreduceBytes = 4096 * sizeof(half);
 constexpr int kSm70Tp8CompletionSignalSlotBase = 2;
 constexpr int kSm70GemmaRmsNormHiddenSize = 5120;
 constexpr int kSm70GemmaRmsNormThreads = 1024;
+constexpr int kSm70LongPrefillSignalBlocks =
+    sm70_tile_runtime::kMaxSignalBlocks;
+constexpr int kSm70LongPrefillMaxTokensPerRank = 2048;
 
 inline int sm70_gemma_rms_norm_threads() {
   const char* raw = std::getenv("VLLM_SM70_TP2_AR_GEMMA_RMS_THREADS");
@@ -62,6 +65,20 @@ inline int sm70_gemma_rms_norm_threads() {
   return threads == 256 || threads == 512 || threads == 1024
              ? threads
              : kSm70GemmaRmsNormThreads;
+}
+
+inline int sm70_tp4_long_fused_norm_threads() {
+  const char* raw = std::getenv("VLLM_SM70_TP4_LONG_FUSED_NORM_THREADS");
+  if (raw == nullptr) return 512;
+  const int threads = std::atoi(raw);
+  return threads == 256 || threads == 512 || threads == 1024 ? threads : 512;
+}
+
+inline int sm70_tp4_long_fused_norm_blocks() {
+  const char* raw = std::getenv("VLLM_SM70_TP4_LONG_FUSED_NORM_BLOCKS");
+  if (raw == nullptr) return 80;
+  const int blocks = std::atoi(raw);
+  return blocks >= 1 && blocks <= kSm70LongPrefillSignalBlocks ? blocks : 80;
 }
 
 inline bool custom_allreduce_current_device_is_sm70() {
@@ -603,6 +620,129 @@ __global__ void __launch_bounds__(Threads, 1)
   }
 
   barrier_at_end<ngpus, true>(sg, self_sg, rank);
+}
+
+// Benchmark-only SM70 counterpart of NCCL's fused LSA RMSNorm example:
+// reduce-scatter token rows, apply the mixed-dtype Gemma RMSNorm locally, then
+// all-gather by writing the owned normalized rows into every peer output.
+// Each rank launches one CTA per owned token and therefore moves the same
+// asymptotic peer traffic as ring reduce-scatter + all-gather, without
+// materializing an intermediate all-reduce tensor.
+template <int Threads, int ngpus, typename ResidualT, typename WeightT>
+__global__ void __launch_bounds__(Threads, 1)
+    sm70_peer_reduce_scatter_gemma_rms_norm_all_gather(
+        RankData* _input_dp, RankData* _output_dp, RankSignals sg,
+        Signal* self_sg, const ResidualT* __restrict__ residual,
+        const WeightT* __restrict__ weight,
+        float* __restrict__ residual_out, int rank, int num_tokens,
+        float epsilon) {
+  static_assert(ngpus == 4);
+  using H4 = array_t<half, 4>;
+  constexpr int kVarianceVectorWidth = 4;
+  constexpr int kVectorsPerRow =
+      kSm70GemmaRmsNormHiddenSize / kVarianceVectorWidth;
+  constexpr int kVectorsPerThread =
+      (kVectorsPerRow + Threads - 1) / Threads;
+
+  __shared__ float inverse_rms;
+  // Preserve the accepted local GemmaNorm reduction topology. The valid-item
+  // count below limits participation to the threads in this launch.
+  using BlockReduce = cub::BlockReduce<float, 1024>;
+  __shared__ typename BlockReduce::TempStorage reduce_store;
+
+  const int tokens_per_rank = num_tokens / ngpus;
+  const int tid = threadIdx.x;
+  auto input_dp = *_input_dp;
+  auto output_dp = *_output_dp;
+
+  barrier_at_start<ngpus>(sg, self_sg, rank);
+
+  for (int local_row = blockIdx.x; local_row < tokens_per_rank;
+       local_row += gridDim.x) {
+    const int row = rank * tokens_per_rank + local_row;
+    const int vector_row_offset = row * kVectorsPerRow;
+    float4 row_values[kVectorsPerThread];
+    float variance = 0.0f;
+#pragma unroll
+    for (int iter = 0; iter < kVectorsPerThread; ++iter) {
+      const int vector_idx = tid + iter * Threads;
+      if (vector_idx >= kVectorsPerRow) continue;
+      const int global_vector_idx = vector_row_offset + vector_idx;
+      H4 reduced =
+          reinterpret_cast<const H4*>(input_dp.ptrs[0])[global_vector_idx];
+#pragma unroll
+      for (int peer = 1; peer < ngpus; ++peer) {
+        const H4 peer_value =
+            reinterpret_cast<const H4*>(input_dp.ptrs[peer])[global_vector_idx];
+#pragma unroll
+        for (int i = 0; i < kVarianceVectorWidth; ++i) {
+          // NCCL's f16 Sum specialization uses __hadd/__hadd2 at every ring
+          // step. Preserve that FP16 rounding contract instead of accumulating
+          // all four inputs in FP32 and rounding only once.
+          reduced.data[i] = __hadd(reduced.data[i], peer_value.data[i]);
+        }
+      }
+      const float4 residual_value =
+          reinterpret_cast<const float4*>(residual)[global_vector_idx];
+      float4 value;
+      value.x = __half2float(reduced.data[0]) + residual_value.x;
+      value.y = __half2float(reduced.data[1]) + residual_value.y;
+      value.z = __half2float(reduced.data[2]) + residual_value.z;
+      value.w = __half2float(reduced.data[3]) + residual_value.w;
+      row_values[iter] = value;
+      // Keep the public [M, H] residual shape so the compiled model graph does
+      // not change shape.  Only this rank's persistent token shard is valid;
+      // the next fused boundary reads the same shard and ignores other rows.
+      reinterpret_cast<float4*>(residual_out)[global_vector_idx] = value;
+      // Match the accepted local GemmaNorm exactly: each thread accumulates
+      // vector indices tid, tid + Threads, ... in x/y/z/w order before CUB.
+      variance += value.x * value.x;
+      variance += value.y * value.y;
+      variance += value.z * value.z;
+      variance += value.w * value.w;
+    }
+    variance =
+        BlockReduce(reduce_store).Reduce(variance, CubAddOp{}, blockDim.x);
+    if (tid == 0) {
+      inverse_rms = rsqrtf(variance / kSm70GemmaRmsNormHiddenSize + epsilon);
+    }
+    __syncthreads();
+
+    const float scale = inverse_rms;
+#pragma unroll
+    for (int iter = 0; iter < kVectorsPerThread; ++iter) {
+      const int vector_idx = tid + iter * Threads;
+      if (vector_idx >= kVectorsPerRow) continue;
+      const int column = vector_idx * kVarianceVectorWidth;
+      const float4 value = row_values[iter];
+      H4 normalized_pack;
+      normalized_pack.data[0] = __float2half_rn(
+          value.x * scale *
+          (sm70_gemma_rms_norm_to_float(weight[column]) + 1.0f));
+      normalized_pack.data[1] = __float2half_rn(
+          value.y * scale *
+          (sm70_gemma_rms_norm_to_float(weight[column + 1]) + 1.0f));
+      normalized_pack.data[2] = __float2half_rn(
+          value.z * scale *
+          (sm70_gemma_rms_norm_to_float(weight[column + 2]) + 1.0f));
+      normalized_pack.data[3] = __float2half_rn(
+          value.w * scale *
+          (sm70_gemma_rms_norm_to_float(weight[column + 3]) + 1.0f));
+#pragma unroll
+      for (int peer = 0; peer < ngpus; ++peer) {
+        auto* peer_output =
+            reinterpret_cast<H4*>(const_cast<void*>(output_dp.ptrs[peer]));
+        peer_output[vector_row_offset + vector_idx] = normalized_pack;
+      }
+    }
+    // CUB's temporary storage is reused by the next persistent row.
+    __syncthreads();
+  }
+
+  // The normalized rows are written directly into peer IPC buffers.  Unlike
+  // an ordinary final all-reduce barrier, this barrier must publish those
+  // remote stores before a peer starts its local output copy.
+  barrier_at_end<ngpus>(sg, self_sg, rank);
 }
 
 template <typename T, int ngpus>
@@ -1335,6 +1475,56 @@ class CustomAllreduce {
         break;
     }
 #undef VLLM_LAUNCH_SM70_GEMMA_RMS_NORM
+  }
+
+  template <int ngpus, typename ResidualT, typename WeightT>
+  void sm70_reduce_scatter_gemma_rms_norm_all_gather(
+      cudaStream_t stream, half* input, half* shared_output,
+      const ResidualT* residual, const WeightT* weight, float* residual_out,
+      int num_tokens, int hidden_size, float epsilon) {
+    if (world_size_ != ngpus || !fully_connected_ ||
+        !custom_allreduce_current_device_is_sm70()) {
+      throw std::runtime_error(
+          "SM70 long-prefill fused norm requires fully connected TP" +
+          std::to_string(ngpus) + " on SM70.");
+    }
+    if (hidden_size != kSm70GemmaRmsNormHiddenSize ||
+        num_tokens <= 0 || num_tokens % ngpus != 0) {
+      throw std::runtime_error(
+          "SM70 long-prefill fused norm requires a TP-divisible [M, 5120] "
+          "input.");
+    }
+    const int tokens_per_rank = num_tokens / ngpus;
+    if (tokens_per_rank > kSm70LongPrefillMaxTokensPerRank) {
+      throw std::runtime_error(
+          "SM70 long-prefill fused norm exceeds the token-shard capacity.");
+    }
+
+    RankData* input_ptrs =
+        rank_data_for_buffer(stream, input, "long-prefill fused norm input");
+    RankData* output_ptrs = rank_data_for_buffer(
+        stream, shared_output, "long-prefill fused norm output");
+    const int threads = sm70_tp4_long_fused_norm_threads();
+    const int blocks =
+        std::min(tokens_per_rank, sm70_tp4_long_fused_norm_blocks());
+#define VLLM_LAUNCH_SM70_TP4_LONG_FUSED_NORM(THREADS)                     \
+  sm70_peer_reduce_scatter_gemma_rms_norm_all_gather<                     \
+      THREADS, ngpus, ResidualT, WeightT>                                  \
+      <<<blocks, THREADS, 0, stream>>>(                                    \
+          input_ptrs, output_ptrs, sg_, self_sg_, residual, weight,        \
+          residual_out, rank_, num_tokens, epsilon)
+    switch (threads) {
+      case 256:
+        VLLM_LAUNCH_SM70_TP4_LONG_FUSED_NORM(256);
+        break;
+      case 1024:
+        VLLM_LAUNCH_SM70_TP4_LONG_FUSED_NORM(1024);
+        break;
+      default:
+        VLLM_LAUNCH_SM70_TP4_LONG_FUSED_NORM(512);
+        break;
+    }
+#undef VLLM_LAUNCH_SM70_TP4_LONG_FUSED_NORM
   }
 
   template <typename T>

--- a/csrc/custom_all_reduce.cuh
+++ b/csrc/custom_all_reduce.cuh
@@ -633,16 +633,14 @@ __global__ void __launch_bounds__(Threads, 1)
     sm70_peer_reduce_scatter_gemma_rms_norm_all_gather(
         RankData* _input_dp, RankData* _output_dp, RankSignals sg,
         Signal* self_sg, const ResidualT* __restrict__ residual,
-        const WeightT* __restrict__ weight,
-        float* __restrict__ residual_out, int rank, int num_tokens,
-        float epsilon) {
+        const WeightT* __restrict__ weight, float* __restrict__ residual_out,
+        int rank, int num_tokens, float epsilon) {
   static_assert(ngpus == 4);
   using H4 = array_t<half, 4>;
   constexpr int kVarianceVectorWidth = 4;
   constexpr int kVectorsPerRow =
       kSm70GemmaRmsNormHiddenSize / kVarianceVectorWidth;
-  constexpr int kVectorsPerThread =
-      (kVectorsPerRow + Threads - 1) / Threads;
+  constexpr int kVectorsPerThread = (kVectorsPerRow + Threads - 1) / Threads;
 
   __shared__ float inverse_rms;
   // Preserve the accepted local GemmaNorm reduction topology. The valid-item
@@ -1488,8 +1486,8 @@ class CustomAllreduce {
           "SM70 long-prefill fused norm requires fully connected TP" +
           std::to_string(ngpus) + " on SM70.");
     }
-    if (hidden_size != kSm70GemmaRmsNormHiddenSize ||
-        num_tokens <= 0 || num_tokens % ngpus != 0) {
+    if (hidden_size != kSm70GemmaRmsNormHiddenSize || num_tokens <= 0 ||
+        num_tokens % ngpus != 0) {
       throw std::runtime_error(
           "SM70 long-prefill fused norm requires a TP-divisible [M, 5120] "
           "input.");
@@ -1507,12 +1505,12 @@ class CustomAllreduce {
     const int threads = sm70_tp4_long_fused_norm_threads();
     const int blocks =
         std::min(tokens_per_rank, sm70_tp4_long_fused_norm_blocks());
-#define VLLM_LAUNCH_SM70_TP4_LONG_FUSED_NORM(THREADS)                     \
-  sm70_peer_reduce_scatter_gemma_rms_norm_all_gather<                     \
-      THREADS, ngpus, ResidualT, WeightT>                                  \
-      <<<blocks, THREADS, 0, stream>>>(                                    \
-          input_ptrs, output_ptrs, sg_, self_sg_, residual, weight,        \
-          residual_out, rank_, num_tokens, epsilon)
+#define VLLM_LAUNCH_SM70_TP4_LONG_FUSED_NORM(THREADS)                          \
+  sm70_peer_reduce_scatter_gemma_rms_norm_all_gather<THREADS, ngpus,           \
+                                                     ResidualT, WeightT>       \
+      <<<blocks, THREADS, 0, stream>>>(input_ptrs, output_ptrs, sg_, self_sg_, \
+                                       residual, weight, residual_out, rank_,  \
+                                       num_tokens, epsilon)
     switch (threads) {
       case 256:
         VLLM_LAUNCH_SM70_TP4_LONG_FUSED_NORM(256);

--- a/csrc/ops.h
+++ b/csrc/ops.h
@@ -202,12 +202,11 @@ void nvfp4_qpn4_dispatch_sm70_out(torch::Tensor out, int64_t dense_weight_ptr,
                                   bool use_scale_code, bool gated_silu);
 
 void fp8_gemm_sm70_prefill_prescaled_out(torch::Tensor out,
-                                      torch::Tensor _in_feats,
-                                      torch::Tensor _kernel,
-                                      torch::Tensor _prescaled_factors,
-                                      int64_t group_size,
-                                      int64_t k_ld,
-                                      int64_t q_ld);
+                                         torch::Tensor _in_feats,
+                                         torch::Tensor _kernel,
+                                         torch::Tensor _prescaled_factors,
+                                         int64_t group_size, int64_t k_ld,
+                                         int64_t q_ld);
 
 void fp8_gemm_sm70_prefill_dispatch_out(
     torch::Tensor out, int64_t dense_weight_ptr, torch::Tensor _in_feats,

--- a/csrc/ops.h
+++ b/csrc/ops.h
@@ -201,6 +201,14 @@ void nvfp4_qpn4_dispatch_sm70_out(torch::Tensor out, int64_t dense_weight_ptr,
                                   torch::Tensor scales, double global_scale,
                                   bool use_scale_code, bool gated_silu);
 
+void fp8_gemm_sm70_prefill_prescaled_out(torch::Tensor out,
+                                      torch::Tensor _in_feats,
+                                      torch::Tensor _kernel,
+                                      torch::Tensor _prescaled_factors,
+                                      int64_t group_size,
+                                      int64_t k_ld,
+                                      int64_t q_ld);
+
 void fp8_gemm_sm70_prefill_dispatch_out(
     torch::Tensor out, int64_t dense_weight_ptr, torch::Tensor _in_feats,
     torch::Tensor _kernel, torch::Tensor _scaling_factors, int64_t group_size,
@@ -513,6 +521,11 @@ void sm70_tp4_all_reduce_gemma_rms_norm(
     torch::Tensor& weight, torch::Tensor& normalized_out,
     torch::Tensor& residual_out, fptr_t reg_buffer, int64_t reg_buffer_sz_bytes,
     double epsilon);
+void sm70_tp4_reduce_scatter_gemma_rms_norm_all_gather(
+    fptr_t _fa, torch::Tensor& inp, torch::Tensor& residual,
+    torch::Tensor& weight, torch::Tensor& normalized_out,
+    torch::Tensor& residual_out, fptr_t reg_input_buffer,
+    fptr_t reg_output_buffer, int64_t reg_buffer_sz_bytes, double epsilon);
 void all_reduce_sum2(fptr_t _fa, torch::Tensor& inp_a, torch::Tensor& inp_b,
                      torch::Tensor& out);
 void top1_argmax(fptr_t _fa, torch::Tensor& input_pair, torch::Tensor& output,

--- a/csrc/sm70_tile_runtime_signal.cuh
+++ b/csrc/sm70_tile_runtime_signal.cuh
@@ -4,17 +4,19 @@
 
 namespace vllm::sm70_tile_runtime {
 
-// Keep the default all-reduce block limit unchanged, but allow the
-// TileRT-style MLP down-proj path to publish one flag per TurboMind N tile.
+// Keep the default TileRT/all-reduce block limit unchanged.  The larger signal
+// capacity is reserved for long-prefill collective-fusion experiments that use
+// one cross-rank barrier per owned token.
 constexpr int kMaxBlocks = 64;
+constexpr int kMaxSignalBlocks = 512;
 constexpr int kMaxRanks = 8;
 
 using FlagType = uint32_t;
 
 struct Signal {
-  alignas(128) FlagType start[kMaxBlocks][kMaxRanks];
-  alignas(128) FlagType end[kMaxBlocks][kMaxRanks];
-  alignas(128) FlagType _flag[kMaxBlocks];
+  alignas(128) FlagType start[kMaxSignalBlocks][kMaxRanks];
+  alignas(128) FlagType end[kMaxSignalBlocks][kMaxRanks];
+  alignas(128) FlagType _flag[kMaxSignalBlocks];
 };
 
 struct __align__(16) RankData {

--- a/csrc/sm70_tile_runtime_signal.cuh
+++ b/csrc/sm70_tile_runtime_signal.cuh
@@ -30,14 +30,13 @@ struct __align__(16) RankSignals {
 #if !defined(USE_ROCM)
 static __device__ __forceinline__ void store_flag_sys_visible(
     FlagType* flag_addr, FlagType flag) {
-  asm volatile("membar.sys; st.volatile.global.u32 [%1], %0;"
-               ::"r"(flag),
+  asm volatile("membar.sys; st.volatile.global.u32 [%1], %0;" ::"r"(flag),
                "l"(flag_addr)
                : "memory");
 }
 
-static __device__ __forceinline__ FlagType load_flag_sys_visible(
-    FlagType* flag_addr) {
+static __device__ __forceinline__ FlagType
+load_flag_sys_visible(FlagType* flag_addr) {
   FlagType flag;
   asm volatile("ld.volatile.global.u32 %0, [%1]; membar.sys;"
                : "=r"(flag)

--- a/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/attention/quantization.h
+++ b/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/attention/quantization.h
@@ -14,878 +14,858 @@ namespace turbomind {
 
 #define TM_ROUND_USE_CVT_RNI 1
 
-inline constexpr bool kFuseU4F16Dequant  = false;
+inline constexpr bool kFuseU4F16Dequant = false;
 inline constexpr bool kForceIntZeroPoint = false;
 
-template<class T>
-__device__ T Infinity()
-{
-    if constexpr (std::is_same_v<T, half>) {
-        return __ushort_as_half((unsigned short)0x7C00U);
-    }
+template <class T>
+__device__ T Infinity() {
+  if constexpr (std::is_same_v<T, half>) {
+    return __ushort_as_half((unsigned short)0x7C00U);
+  }
 
 #if __CUDA_ARCH__ >= 800
-    if constexpr (std::is_same_v<T, nv_bfloat16>) {
-        return __ushort_as_bfloat16((unsigned short)0x7F80U);
-    }
+  if constexpr (std::is_same_v<T, nv_bfloat16>) {
+    return __ushort_as_bfloat16((unsigned short)0x7F80U);
+  }
 #endif
 
-    if constexpr (std::is_same_v<T, float>) {
-        return __int_as_float(0x7f800000U);
-    }
+  if constexpr (std::is_same_v<T, float>) {
+    return __int_as_float(0x7f800000U);
+  }
 
-    return T{};
+  return T{};
 }
 
-template<class T>
-__device__ constexpr T Max(T a, T b)
-{
-    if constexpr (std::is_same_v<T, half>) {
-        return __hmax(a, b);
-    }
+template <class T>
+__device__ constexpr T Max(T a, T b) {
+  if constexpr (std::is_same_v<T, half>) {
+    return __hmax(a, b);
+  }
 
 #if __CUDA_ARCH__ >= 800
-    if constexpr (std::is_same_v<T, nv_bfloat16>) {
-        return __hmax(a, b);
-    }
+  if constexpr (std::is_same_v<T, nv_bfloat16>) {
+    return __hmax(a, b);
+  }
 #endif
 
-    if constexpr (std::is_same_v<T, float>) {
-        return fmaxf(a, b);
-    }
+  if constexpr (std::is_same_v<T, float>) {
+    return fmaxf(a, b);
+  }
 
-    if constexpr (std::is_same_v<T, int>) {
-        return max(a, b);
-    }
+  if constexpr (std::is_same_v<T, int>) {
+    return max(a, b);
+  }
 
-    return T{};
+  return T{};
 }
 
-template<class T>
-__device__ constexpr T Min(T a, T b)
-{
-    if constexpr (std::is_same_v<T, half>) {
-        return __hmin(a, b);
-    }
+template <class T>
+__device__ constexpr T Min(T a, T b) {
+  if constexpr (std::is_same_v<T, half>) {
+    return __hmin(a, b);
+  }
 
 #if __CUDA_ARCH__ >= 800
-    if constexpr (std::is_same_v<T, nv_bfloat16>) {
-        return __hmin(a, b);
-    }
+  if constexpr (std::is_same_v<T, nv_bfloat16>) {
+    return __hmin(a, b);
+  }
 #endif
 
-    if constexpr (std::is_same_v<T, float>) {
-        return fminf(a, b);
-    }
+  if constexpr (std::is_same_v<T, float>) {
+    return fminf(a, b);
+  }
 
-    if constexpr (std::is_same_v<T, int>) {
-        return min(a, b);
-    }
+  if constexpr (std::is_same_v<T, int>) {
+    return min(a, b);
+  }
 
-    return T{};
+  return T{};
 }
 
-template<bool norm = true>
-inline __device__ Array<half, 4> cvt_f16x4_u8(const Array<uint8_t, 4>& src)
-{
-    static constexpr uint32_t f16_magic = 0x64000000;
-    // 01234567 01234567
-    // SEEEEEMM MMMMMMMM
-    //      1MM XXXXXXXX
-    // (1 + x/2^10) * 2^(e-15) -> e-15=10 -> e=25=16+8+1 -> 01100100b -> 0x64
-    Array<uint32_t, 2> dst;
-    dst[0] = __byte_perm((uint32_t&)src, f16_magic, 0x7170);
-    dst[1] = __byte_perm((uint32_t&)src, f16_magic, 0x7372);
-    if constexpr (norm) {
-        for (int i = 0; i < 4; ++i) {
-            ((Array<half, 4>&)dst)[i] -= __ushort_as_half(0x6400U);
-        }
-    }
-    return (Array<half, 4>&)dst;
-}
-
-template<bool norm = true>
-inline __device__ Array<half, 4> cvt_f16x2x2_u8_trans(const Array<uint8_t, 4>& src)
-{
-    static constexpr uint32_t f16_magic = 0x64000000;
-    // 01234567 01234567
-    // SEEEEEMM MMMMMMMM
-    //      1MM XXXXXXXX
-    // (1 + x/2^10) * 2^(e-15) -> e-15=10 -> e=25=16+8+1 -> 01100100b -> 0x64
-    Array<uint32_t, 2> dst;
-    dst[0] = __byte_perm((uint32_t&)src, f16_magic, 0x7270);
-    dst[1] = __byte_perm((uint32_t&)src, f16_magic, 0x7371);
-    if constexpr (norm) {
-        for (int i = 0; i < 4; ++i) {
-            ((Array<half, 4>&)dst)[i] -= __ushort_as_half(0x6400U);
-        }
-    }
-    return (Array<half, 4>&)dst;
-}
-
-inline __device__ Array<nv_bfloat16, 4> cvt_bf16x4_u8(const Array<uint8_t, 4>& src)
-{
-    // 01234567 01234567 01234567 01234567
-    // SEEEEEEE EMMMMMMM MMMMMMMM MMMMMMMM
-    //          1MM...   XXXXXXXX
-    // (1 + x/2^15) * 2^(e-127) -> e-127=15 -> e=142 -> 01000111 -> 0x47
-    static constexpr uint32_t f32_magic = 0x47000000;  // 32768
-
-    Array<uint32_t, 4> tmp;
-    tmp[0] = __byte_perm((uint32_t&)src, f32_magic, 0x7604);
-    tmp[1] = __byte_perm((uint32_t&)src, f32_magic, 0x7614);
-    tmp[2] = __byte_perm((uint32_t&)src, f32_magic, 0x7624);
-    tmp[3] = __byte_perm((uint32_t&)src, f32_magic, 0x7634);
-
-    auto& vec = (Array<float, 4>&)tmp;
-
-    Array<nv_bfloat16, 4> dst;
-    PRAGMA_UNROLL
+template <bool norm = true>
+inline __device__ Array<half, 4> cvt_f16x4_u8(const Array<uint8_t, 4>& src) {
+  static constexpr uint32_t f16_magic = 0x64000000;
+  // 01234567 01234567
+  // SEEEEEMM MMMMMMMM
+  //      1MM XXXXXXXX
+  // (1 + x/2^10) * 2^(e-15) -> e-15=10 -> e=25=16+8+1 -> 01100100b -> 0x64
+  Array<uint32_t, 2> dst;
+  dst[0] = __byte_perm((uint32_t&)src, f16_magic, 0x7170);
+  dst[1] = __byte_perm((uint32_t&)src, f16_magic, 0x7372);
+  if constexpr (norm) {
     for (int i = 0; i < 4; ++i) {
-        dst[i] = __float2bfloat16(vec[i] - 32768.f);
+      ((Array<half, 4>&)dst)[i] -= __ushort_as_half(0x6400U);
     }
-    return dst;
+  }
+  return (Array<half, 4>&)dst;
 }
 
-inline __device__ Array<float, 4> cvt_f32x4_u8(const Array<uint8_t, 4>& src)
-{
-    // 01234567 01234567 01234567 01234567
-    // SEEEEEEE EMMMMMMM MMMMMMMM MMMMMMMM
-    //          1MM...   XXXXXXXX
-    // (1 + x/2^15) * 2^(e-127) -> e-127=15 -> e=142 -> 01000111 -> 0x47
-    static constexpr uint32_t f32_magic = 0x47000000;  // 32768
-
-    Array<uint32_t, 4> tmp;
-    tmp[0] = __byte_perm((uint32_t&)src, f32_magic, 0x7604);
-    tmp[1] = __byte_perm((uint32_t&)src, f32_magic, 0x7614);
-    tmp[2] = __byte_perm((uint32_t&)src, f32_magic, 0x7624);
-    tmp[3] = __byte_perm((uint32_t&)src, f32_magic, 0x7634);
-
-    auto& vec = (Array<float, 4>&)tmp;
-    PRAGMA_UNROLL
+template <bool norm = true>
+inline __device__ Array<half, 4> cvt_f16x2x2_u8_trans(
+    const Array<uint8_t, 4>& src) {
+  static constexpr uint32_t f16_magic = 0x64000000;
+  // 01234567 01234567
+  // SEEEEEMM MMMMMMMM
+  //      1MM XXXXXXXX
+  // (1 + x/2^10) * 2^(e-15) -> e-15=10 -> e=25=16+8+1 -> 01100100b -> 0x64
+  Array<uint32_t, 2> dst;
+  dst[0] = __byte_perm((uint32_t&)src, f16_magic, 0x7270);
+  dst[1] = __byte_perm((uint32_t&)src, f16_magic, 0x7371);
+  if constexpr (norm) {
     for (int i = 0; i < 4; ++i) {
-        vec[i] -= 32768.f;
+      ((Array<half, 4>&)dst)[i] -= __ushort_as_half(0x6400U);
     }
-    return vec;
+  }
+  return (Array<half, 4>&)dst;
 }
 
-template<bool norm = true>
-inline __device__ Array<nv_bfloat16, 8> cvt_bf16x8_u4(const Array<uint4_t, 8>& src)
-{
+inline __device__ Array<nv_bfloat16, 4> cvt_bf16x4_u8(
+    const Array<uint8_t, 4>& src) {
+  // 01234567 01234567 01234567 01234567
+  // SEEEEEEE EMMMMMMM MMMMMMMM MMMMMMMM
+  //          1MM...   XXXXXXXX
+  // (1 + x/2^15) * 2^(e-127) -> e-127=15 -> e=142 -> 01000111 -> 0x47
+  static constexpr uint32_t f32_magic = 0x47000000;  // 32768
+
+  Array<uint32_t, 4> tmp;
+  tmp[0] = __byte_perm((uint32_t&)src, f32_magic, 0x7604);
+  tmp[1] = __byte_perm((uint32_t&)src, f32_magic, 0x7614);
+  tmp[2] = __byte_perm((uint32_t&)src, f32_magic, 0x7624);
+  tmp[3] = __byte_perm((uint32_t&)src, f32_magic, 0x7634);
+
+  auto& vec = (Array<float, 4>&)tmp;
+
+  Array<nv_bfloat16, 4> dst;
+  PRAGMA_UNROLL
+  for (int i = 0; i < 4; ++i) {
+    dst[i] = __float2bfloat16(vec[i] - 32768.f);
+  }
+  return dst;
+}
+
+inline __device__ Array<float, 4> cvt_f32x4_u8(const Array<uint8_t, 4>& src) {
+  // 01234567 01234567 01234567 01234567
+  // SEEEEEEE EMMMMMMM MMMMMMMM MMMMMMMM
+  //          1MM...   XXXXXXXX
+  // (1 + x/2^15) * 2^(e-127) -> e-127=15 -> e=142 -> 01000111 -> 0x47
+  static constexpr uint32_t f32_magic = 0x47000000;  // 32768
+
+  Array<uint32_t, 4> tmp;
+  tmp[0] = __byte_perm((uint32_t&)src, f32_magic, 0x7604);
+  tmp[1] = __byte_perm((uint32_t&)src, f32_magic, 0x7614);
+  tmp[2] = __byte_perm((uint32_t&)src, f32_magic, 0x7624);
+  tmp[3] = __byte_perm((uint32_t&)src, f32_magic, 0x7634);
+
+  auto& vec = (Array<float, 4>&)tmp;
+  PRAGMA_UNROLL
+  for (int i = 0; i < 4; ++i) {
+    vec[i] -= 32768.f;
+  }
+  return vec;
+}
+
+template <bool norm = true>
+inline __device__ Array<nv_bfloat16, 8> cvt_bf16x8_u4(
+    const Array<uint4_t, 8>& src) {
 #if __CUDA_ARCH__ >= 800
-    // 01234567 01234567
-    // SEEEEEEE EMMMMMMM
-    //          1...XXXX
-    // (1 + x/2^7) * 2^(e-127) -> e-127=7 -> e=134 -> 0100 0011 -> 0x43
-    static constexpr uint32_t TEMPLATE = 0x43004300;  // nv_bfloat162(128, 128)
-    static constexpr uint32_t MASK     = 0x000f000f;
-    static constexpr uint32_t immLut   = (0xf0 & 0xcc) | 0xaa;
+  // 01234567 01234567
+  // SEEEEEEE EMMMMMMM
+  //          1...XXXX
+  // (1 + x/2^7) * 2^(e-127) -> e-127=7 -> e=134 -> 0100 0011 -> 0x43
+  static constexpr uint32_t TEMPLATE = 0x43004300;  // nv_bfloat162(128, 128)
+  static constexpr uint32_t MASK = 0x000f000f;
+  static constexpr uint32_t immLut = (0xf0 & 0xcc) | 0xaa;
 
-    Array<uint32_t, 4> h;
+  Array<uint32_t, 4> h;
 
-    static_assert(sizeof(Array<nv_bfloat16, 8>) == sizeof(Array<uint32_t, 4>));
+  static_assert(sizeof(Array<nv_bfloat16, 8>) == sizeof(Array<uint32_t, 4>));
 
-    uint32_t const& i4s    = reinterpret_cast<uint32_t const&>(src);
-    const uint32_t  i4s_4  = i4s >> 4;
-    const uint32_t  i4s_8  = i4s >> 8;
-    const uint32_t  i4s_12 = i4s >> 12;
+  uint32_t const& i4s = reinterpret_cast<uint32_t const&>(src);
+  const uint32_t i4s_4 = i4s >> 4;
+  const uint32_t i4s_8 = i4s >> 8;
+  const uint32_t i4s_12 = i4s >> 12;
 
-    asm volatile("lop3.b32 %0, %1, %2, %3, %4;\n" : "=r"(h[0]) : "r"(i4s), "n"(MASK), "n"(TEMPLATE), "n"(immLut));
-    asm volatile("lop3.b32 %0, %1, %2, %3, %4;\n" : "=r"(h[1]) : "r"(i4s_4), "n"(MASK), "n"(TEMPLATE), "n"(immLut));
-    asm volatile("lop3.b32 %0, %1, %2, %3, %4;\n" : "=r"(h[2]) : "r"(i4s_8), "n"(MASK), "n"(TEMPLATE), "n"(immLut));
-    asm volatile("lop3.b32 %0, %1, %2, %3, %4;\n" : "=r"(h[3]) : "r"(i4s_12), "n"(MASK), "n"(TEMPLATE), "n"(immLut));
+  asm volatile("lop3.b32 %0, %1, %2, %3, %4;\n"
+               : "=r"(h[0])
+               : "r"(i4s), "n"(MASK), "n"(TEMPLATE), "n"(immLut));
+  asm volatile("lop3.b32 %0, %1, %2, %3, %4;\n"
+               : "=r"(h[1])
+               : "r"(i4s_4), "n"(MASK), "n"(TEMPLATE), "n"(immLut));
+  asm volatile("lop3.b32 %0, %1, %2, %3, %4;\n"
+               : "=r"(h[2])
+               : "r"(i4s_8), "n"(MASK), "n"(TEMPLATE), "n"(immLut));
+  asm volatile("lop3.b32 %0, %1, %2, %3, %4;\n"
+               : "=r"(h[3])
+               : "r"(i4s_12), "n"(MASK), "n"(TEMPLATE), "n"(immLut));
 
-    if constexpr (norm) {
-        auto result = reinterpret_cast<nv_bfloat16*>(h.data());
-        PRAGMA_UNROLL
-        for (int i = 0; i < 8; ++i) {
-            result[i] -= nv_bfloat16(128.f);
-        }
+  if constexpr (norm) {
+    auto result = reinterpret_cast<nv_bfloat16*>(h.data());
+    PRAGMA_UNROLL
+    for (int i = 0; i < 8; ++i) {
+      result[i] -= nv_bfloat16(128.f);
     }
-    return (Array<nv_bfloat16, 8>&)h;
+  }
+  return (Array<nv_bfloat16, 8>&)h;
 #else
-    return {};
+  return {};
 #endif
 }
 
 #if TM_ROUND_USE_CVT_RNI
 
-template<class T>
-inline __device__ T round(float x)
-{
-    uint32_t y{};
-    if constexpr (std::is_same_v<T, uint8_t>) {
-        asm("cvt.rni.sat.u8.f32 %0, %1;\n" : "=r"(y) : "f"(x));
-    }
-    else if constexpr (std::is_same_v<T, uint16_t>) {
-        asm("cvt.rni.sat.u16.f32 %0, %1;\n" : "=r"(y) : "f"(x));
-    }
-    else if constexpr (std::is_same_v<T, uint32_t>) {
-        asm("cvt.rni.sat.u32.f32 %0, %1;\n" : "=r"(y) : "f"(x));
-    }
-    else if constexpr (std::is_same_v<T, int32_t>) {
-        asm("cvt.rni.sat.s32.f32 %0, %1;\n" : "=r"(y) : "f"(x));
-    }
-    else {
-        static_assert(!std::is_same_v<T, T>, "not implemented");
-    }
-    return y;
+template <class T>
+inline __device__ T round(float x) {
+  uint32_t y{};
+  if constexpr (std::is_same_v<T, uint8_t>) {
+    asm("cvt.rni.sat.u8.f32 %0, %1;\n" : "=r"(y) : "f"(x));
+  } else if constexpr (std::is_same_v<T, uint16_t>) {
+    asm("cvt.rni.sat.u16.f32 %0, %1;\n" : "=r"(y) : "f"(x));
+  } else if constexpr (std::is_same_v<T, uint32_t>) {
+    asm("cvt.rni.sat.u32.f32 %0, %1;\n" : "=r"(y) : "f"(x));
+  } else if constexpr (std::is_same_v<T, int32_t>) {
+    asm("cvt.rni.sat.s32.f32 %0, %1;\n" : "=r"(y) : "f"(x));
+  } else {
+    static_assert(!std::is_same_v<T, T>, "not implemented");
+  }
+  return y;
 }
 
-template<class T>
-inline __device__ T round(half x)
-{
-    uint32_t y{};
-    if constexpr (std::is_same_v<T, uint8_t>) {
-        asm("cvt.rni.sat.u8.f16 %0, %1;\n" : "=r"(y) : "h"((uint16_t&)x));
-    }
-    else if constexpr (std::is_same_v<T, uint16_t>) {
-        asm("cvt.rni.sat.u16.f16 %0, %1;\n" : "=r"(y) : "h"((uint16_t&)x));
-    }
-    else if constexpr (std::is_same_v<T, uint32_t>) {
-        asm("cvt.rni.sat.u32.f16 %0, %1;\n" : "=r"(y) : "h"((uint16_t&)x));
-    }
-    else if constexpr (std::is_same_v<T, int32_t>) {
-        asm("cvt.rni.sat.s32.f16 %0, %1;\n" : "=r"(y) : "h"((uint16_t&)x));
-    }
-    else {
-        static_assert(!std::is_same_v<T, T>, "not implemented");
-    }
-    return y;
+template <class T>
+inline __device__ T round(half x) {
+  uint32_t y{};
+  if constexpr (std::is_same_v<T, uint8_t>) {
+    asm("cvt.rni.sat.u8.f16 %0, %1;\n" : "=r"(y) : "h"((uint16_t&)x));
+  } else if constexpr (std::is_same_v<T, uint16_t>) {
+    asm("cvt.rni.sat.u16.f16 %0, %1;\n" : "=r"(y) : "h"((uint16_t&)x));
+  } else if constexpr (std::is_same_v<T, uint32_t>) {
+    asm("cvt.rni.sat.u32.f16 %0, %1;\n" : "=r"(y) : "h"((uint16_t&)x));
+  } else if constexpr (std::is_same_v<T, int32_t>) {
+    asm("cvt.rni.sat.s32.f16 %0, %1;\n" : "=r"(y) : "h"((uint16_t&)x));
+  } else {
+    static_assert(!std::is_same_v<T, T>, "not implemented");
+  }
+  return y;
 }
 
 #else
 
-template<class T>
-inline __device__ T round(float x)
-{
-    x += .5f;
+template <class T>
+inline __device__ T round(float x) {
+  x += .5f;
 
-    uint32_t y{};
-    if constexpr (std::is_same_v<T, uint8_t>) {
-        asm("cvt.rzi.sat.u8.f32 %0, %1;\n" : "=r"(y) : "f"(x));
-    }
-    else if constexpr (std::is_same_v<T, uint16_t>) {
-        asm("cvt.rzi.sat.u16.f32 %0, %1;\n" : "=r"(y) : "f"(x));
-    }
-    else if constexpr (std::is_same_v<T, uint32_t>) {
-        asm("cvt.rzi.sat.u32.f32 %0, %1;\n" : "=r"(y) : "f"(x));
-    }
-    else {
-        static_assert(!std::is_same_v<T, T>, "not implemented");
-    }
-    return y;
+  uint32_t y{};
+  if constexpr (std::is_same_v<T, uint8_t>) {
+    asm("cvt.rzi.sat.u8.f32 %0, %1;\n" : "=r"(y) : "f"(x));
+  } else if constexpr (std::is_same_v<T, uint16_t>) {
+    asm("cvt.rzi.sat.u16.f32 %0, %1;\n" : "=r"(y) : "f"(x));
+  } else if constexpr (std::is_same_v<T, uint32_t>) {
+    asm("cvt.rzi.sat.u32.f32 %0, %1;\n" : "=r"(y) : "f"(x));
+  } else {
+    static_assert(!std::is_same_v<T, T>, "not implemented");
+  }
+  return y;
 }
 
-template<class T>
-inline __device__ T round(half x)
-{
-    x += half(.5f);
+template <class T>
+inline __device__ T round(half x) {
+  x += half(.5f);
 
-    uint32_t y{};
-    if constexpr (std::is_same_v<T, uint8_t>) {
-        asm("cvt.rzi.sat.u8.f16 %0, %1;\n" : "=r"(y) : "h"((uint16_t&)x));
-    }
-    else if constexpr (std::is_same_v<T, uint16_t>) {
-        asm("cvt.rzi.sat.u16.f16 %0, %1;\n" : "=r"(y) : "h"((uint16_t&)x));
-    }
-    else if constexpr (std::is_same_v<T, uint32_t>) {
-        asm("cvt.rzi.sat.u32.f16 %0, %1;\n" : "=r"(y) : "h"((uint16_t&)x));
-    }
-    else {
-        static_assert(!std::is_same_v<T, T>, "not implemented");
-    }
-    return y;
+  uint32_t y{};
+  if constexpr (std::is_same_v<T, uint8_t>) {
+    asm("cvt.rzi.sat.u8.f16 %0, %1;\n" : "=r"(y) : "h"((uint16_t&)x));
+  } else if constexpr (std::is_same_v<T, uint16_t>) {
+    asm("cvt.rzi.sat.u16.f16 %0, %1;\n" : "=r"(y) : "h"((uint16_t&)x));
+  } else if constexpr (std::is_same_v<T, uint32_t>) {
+    asm("cvt.rzi.sat.u32.f16 %0, %1;\n" : "=r"(y) : "h"((uint16_t&)x));
+  } else {
+    static_assert(!std::is_same_v<T, T>, "not implemented");
+  }
+  return y;
 }
 
 #endif
 
-template<class To, class Ti, class B>
-inline __device__ To quant(Ti x, B n_bits)
-{
-    auto y = round<To>(x);
-    if constexpr (n_bits < sizeof(To) * 8) {  // saturate operation for sub-byte type
-        return min(y, To((1 << n_bits) - 1));
-    }
-    else {
-        return y;
-    }
+template <class To, class Ti, class B>
+inline __device__ To quant(Ti x, B n_bits) {
+  auto y = round<To>(x);
+  if constexpr (n_bits <
+                sizeof(To) * 8) {  // saturate operation for sub-byte type
+    return min(y, To((1 << n_bits) - 1));
+  } else {
+    return y;
+  }
 }
 
-template<int WarpThreadC, class T, int C>
-__device__ inline void warp_minmax(Array<T, 2>& stats, const Array<T, C>& x)
-{
+template <int WarpThreadC, class T, int C>
+__device__ inline void warp_minmax(Array<T, 2>& stats, const Array<T, C>& x) {
+  PRAGMA_UNROLL
+  for (int i = 0; i < C; ++i) {
+    stats[0] = Min(stats[0], x[i]);
+    stats[1] = Max(stats[1], x[i]);
+  }
+  if constexpr (sizeof(T) == 2) {
     PRAGMA_UNROLL
-    for (int i = 0; i < C; ++i) {
-        stats[0] = Min(stats[0], x[i]);
-        stats[1] = Max(stats[1], x[i]);
+    for (int mask = WarpThreadC / 2; mask > 0; mask /= 2) {
+      Array<T, 2> tmp;
+      (uint32_t&)tmp = __shfl_xor_sync(uint32_t(-1), (uint32_t&)stats, mask);
+      stats[0] = Min(stats[0], tmp[0]);
+      stats[1] = Max(stats[1], tmp[1]);
     }
-    if constexpr (sizeof(T) == 2) {
-        PRAGMA_UNROLL
-        for (int mask = WarpThreadC / 2; mask > 0; mask /= 2) {
-            Array<T, 2> tmp;
-            (uint32_t&)tmp = __shfl_xor_sync(uint32_t(-1), (uint32_t&)stats, mask);
-            stats[0]       = Min(stats[0], tmp[0]);
-            stats[1]       = Max(stats[1], tmp[1]);
-        }
+  } else {
+    PRAGMA_UNROLL
+    for (int mask = WarpThreadC / 2; mask > 0; mask /= 2) {
+      stats[0] = Min(stats[0], __shfl_xor_sync(uint32_t(-1), stats[0], mask));
+      stats[1] = Max(stats[1], __shfl_xor_sync(uint32_t(-1), stats[1], mask));
     }
-    else {
-        PRAGMA_UNROLL
-        for (int mask = WarpThreadC / 2; mask > 0; mask /= 2) {
-            stats[0] = Min(stats[0], __shfl_xor_sync(uint32_t(-1), stats[0], mask));
-            stats[1] = Max(stats[1], __shfl_xor_sync(uint32_t(-1), stats[1], mask));
-        }
-    }
+  }
 }
 
-template<int WarpThreadC, class P, class T, class B, int N, int C, int S>
-__device__ void warp_stats(Array<P, 2> (&param)[S], const Array<T, N> (&x)[S][C], B n_bits)
-{
+template <int WarpThreadC, class P, class T, class B, int N, int C, int S>
+__device__ void warp_stats(Array<P, 2> (&param)[S],
+                           const Array<T, N> (&x)[S][C], B n_bits) {
+  PRAGMA_UNROLL
+  for (int s = 0; s < S; ++s) {
+    Array<T, 2> stats{Infinity<T>(), -Infinity<T>()};
     PRAGMA_UNROLL
-    for (int s = 0; s < S; ++s) {
-        Array<T, 2> stats{Infinity<T>(), -Infinity<T>()};
-        PRAGMA_UNROLL
-        for (int c = 0; c < C; ++c) {
-            warp_minmax<WarpThreadC>(stats, x[s][c]);
-        }
-        const float inv_q_max = fdividef(1.f, float((1 << n_bits) - 1));
-        const float scale     = ((float)stats[1] - (float)stats[0]) * inv_q_max;
-        param[s][0]           = (P)scale;
-        param[s][1]           = (P)stats[0];
+    for (int c = 0; c < C; ++c) {
+      warp_minmax<WarpThreadC>(stats, x[s][c]);
+    }
+    const float inv_q_max = fdividef(1.f, float((1 << n_bits) - 1));
+    const float scale = ((float)stats[1] - (float)stats[0]) * inv_q_max;
+    param[s][0] = (P)scale;
+    param[s][1] = (P)stats[0];
 
-        if constexpr (kForceIntZeroPoint) {
+    if constexpr (kForceIntZeroPoint) {
 #if TM_ROUND_USE_CVT_RNI
-            // rintf -> cvt.rni.f32.f32
-            param[s][1] = (P)(rintf((float)stats[0] / scale) * scale);
+      // rintf -> cvt.rni.f32.f32
+      param[s][1] = (P)(rintf((float)stats[0] / scale) * scale);
 #else
-            // roundf -> cvt.rzi.f32.f32(x + 0.5)
-            param[s][1] = (P)(roundf((float)stats[0] / scale) * scale);
+      // roundf -> cvt.rzi.f32.f32(x + 0.5)
+      param[s][1] = (P)(roundf((float)stats[0] / scale) * scale);
 #endif
-        }
     }
+  }
 }
 
-template<class Q, class T, class P, class B, int N, int C, int S>
-__device__ void
-quantize(Array<Q, N> (&dst)[S][C], const Array<T, N> (&src)[S][C], const Array<P, 2> (&params)[S], B n_bits)
-{
+template <class Q, class T, class P, class B, int N, int C, int S>
+__device__ void quantize(Array<Q, N> (&dst)[S][C],
+                         const Array<T, N> (&src)[S][C],
+                         const Array<P, 2> (&params)[S], B n_bits) {
+  PRAGMA_UNROLL
+  for (int s = 0; s < S; ++s) {
+    P inv_scale = (P)fdividef(1.f, (float)params[s][0]);
+    P zero = params[s][1];
     PRAGMA_UNROLL
-    for (int s = 0; s < S; ++s) {
-        P inv_scale = (P)fdividef(1.f, (float)params[s][0]);
-        P zero      = params[s][1];
-        PRAGMA_UNROLL
-        for (int c = 0; c < C; ++c) {
-            PRAGMA_UNROLL
-            for (int i = 0; i < N; ++i) {
-                const auto v = ((P)src[s][c][i] - zero) * inv_scale;
-                dst[s][c][i] = quant<Q>(v, n_bits);
-            }
-        }
+    for (int c = 0; c < C; ++c) {
+      PRAGMA_UNROLL
+      for (int i = 0; i < N; ++i) {
+        const auto v = ((P)src[s][c][i] - zero) * inv_scale;
+        dst[s][c][i] = quant<Q>(v, n_bits);
+      }
     }
+  }
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////////
 
-// generic case for floating point -> floating point / integer -> integer conversion
-template<typename Ti, typename To, typename = void>
+// generic case for floating point -> floating point / integer -> integer
+// conversion
+template <typename Ti, typename To, typename = void>
 struct ConvertKvCache {
-    __device__ __host__ ConvertKvCache(float, float) {}
-    template<int N>
-    __device__ static auto convert(const Array<Ti, N>& vi)
-    {
-        Array<To, N> vo;
-        PRAGMA_UNROLL
-        for (int i = 0; i < N; ++i) {
-            vo[i] = (To)vi[i];
-        }
-        return vo;
+  __device__ __host__ ConvertKvCache(float, float) {}
+  template <int N>
+  __device__ static auto convert(const Array<Ti, N>& vi) {
+    Array<To, N> vo;
+    PRAGMA_UNROLL
+    for (int i = 0; i < N; ++i) {
+      vo[i] = (To)vi[i];
     }
-    template<int N>
-    inline __device__ auto operator()(const Array<Ti, N>& vi) const -> Array<To, N>
-    {
-        return convert(vi);
-    }
+    return vo;
+  }
+  template <int N>
+  inline __device__ auto operator()(const Array<Ti, N>& vi) const
+      -> Array<To, N> {
+    return convert(vi);
+  }
 };
 
 // generic case for converting to same type, bypass
-template<typename T>
+template <typename T>
 struct ConvertKvCache<T, T> {
-    __device__ __host__ ConvertKvCache(float, float) {}
-    template<int N>
-    __device__ static auto convert(const Array<T, N>& v)
-    {
-        return v;
-    }
-    template<int N>
-    inline __device__ auto operator()(const Array<T, N>& v) const -> Array<T, N>
-    {
-        return convert(v);
-    }
+  __device__ __host__ ConvertKvCache(float, float) {}
+  template <int N>
+  __device__ static auto convert(const Array<T, N>& v) {
+    return v;
+  }
+  template <int N>
+  inline __device__ auto operator()(const Array<T, N>& v) const -> Array<T, N> {
+    return convert(v);
+  }
 };
 
 //  floating point -> u8
-template<class T>
+template <class T>
 struct ConvertKvCache<T, uint8_t> {
-    T          inv_scale_;
-    T          zero_;
-    __device__ ConvertKvCache(T scale, T zero): zero_{zero}
-    {
-        // NVCC complains if we put this in the member init list
-        inv_scale_ = (T)fdividef(1.f, (float)scale);
-    }
+  T inv_scale_;
+  T zero_;
+  __device__ ConvertKvCache(T scale, T zero) : zero_{zero} {
+    // NVCC complains if we put this in the member init list
+    inv_scale_ = (T)fdividef(1.f, (float)scale);
+  }
 
-    template<int N>
-    __device__ auto operator()(const Array<T, N>& vi) const
-    {
-        Array<uint8_t, N> vo;
-        PRAGMA_UNROLL
-        for (int i = 0; i < N; ++i) {
-            vo[i] = quant<uint8_t>((vi[i] - zero_) * inv_scale_, std::integral_constant<int, 8>{});
-        }
-        return vo;
+  template <int N>
+  __device__ auto operator()(const Array<T, N>& vi) const {
+    Array<uint8_t, N> vo;
+    PRAGMA_UNROLL
+    for (int i = 0; i < N; ++i) {
+      vo[i] = quant<uint8_t>((vi[i] - zero_) * inv_scale_,
+                             std::integral_constant<int, 8>{});
     }
+    return vo;
+  }
 };
 
-template<class T>
+template <class T>
 struct ConvertKvCache<T, uint4_t> {
-    T          inv_scale_;
-    T          zero_;
-    __device__ ConvertKvCache(T scale, T zero): zero_{zero}
-    {
-        // NVCC complains if we put this in the member init list
-        inv_scale_ = (T)fdividef(1.f, (float)scale);
+  T inv_scale_;
+  T zero_;
+  __device__ ConvertKvCache(T scale, T zero) : zero_{zero} {
+    // NVCC complains if we put this in the member init list
+    inv_scale_ = (T)fdividef(1.f, (float)scale);
+  }
+
+  static __device__ Array<uint4_t, 8> pack(const Array<uint8_t, 8>& vi) {
+    Array<uint32_t, 2> ui = (Array<uint32_t, 2>&)vi;
+
+    ui[0] |= (ui[0] >> 12);
+    ui[1] |= (ui[1] >> 12);
+
+    //  7 6 5 4 3 2 1 0
+    // _7_67564_3_23120
+    uint32_t uo = __byte_perm(ui[0], ui[1], 0x5140);
+
+    return (Array<uint4_t, 8>&)uo;
+  }
+
+  /// TODO: try cvt.pack.sat.u4
+  template <int N>
+  __device__ auto operator()(const Array<T, N>& vi) const {
+    static_assert(N % 8 == 0);
+    Array<uint8_t, N> tmp;
+    PRAGMA_UNROLL
+    for (int i = 0; i < N; ++i) {
+      tmp[i] = quant<uint8_t>((vi[i] - zero_) * inv_scale_,
+                              std::integral_constant<int, 4>{});
     }
-
-    static __device__ Array<uint4_t, 8> pack(const Array<uint8_t, 8>& vi)
-    {
-        Array<uint32_t, 2> ui = (Array<uint32_t, 2>&)vi;
-
-        ui[0] |= (ui[0] >> 12);
-        ui[1] |= (ui[1] >> 12);
-
-        //  7 6 5 4 3 2 1 0
-        // _7_67564_3_23120
-        uint32_t uo = __byte_perm(ui[0], ui[1], 0x5140);
-
-        return (Array<uint4_t, 8>&)uo;
+    Array<uint4_t, N> vo;
+    PRAGMA_UNROLL
+    for (int i = 0; i < N; i += 8) {
+      (Array<uint4_t, 8>&)vo[i] = pack((Array<uint8_t, 8>&)tmp[i]);
     }
-
-    /// TODO: try cvt.pack.sat.u4
-    template<int N>
-    __device__ auto operator()(const Array<T, N>& vi) const
-    {
-        static_assert(N % 8 == 0);
-        Array<uint8_t, N> tmp;
-        PRAGMA_UNROLL
-        for (int i = 0; i < N; ++i) {
-            tmp[i] = quant<uint8_t>((vi[i] - zero_) * inv_scale_, std::integral_constant<int, 4>{});
-        }
-        Array<uint4_t, N> vo;
-        PRAGMA_UNROLL
-        for (int i = 0; i < N; i += 8) {
-            (Array<uint4_t, 8>&)vo[i] = pack((Array<uint8_t, 8>&)tmp[i]);
-        }
-        return vo;
-    }
+    return vo;
+  }
 };
-template<>
+template <>
 struct ConvertKvCache<uint4_t, half> {
+  half scale_;
+  half zero_;
 
-    half scale_;
-    half zero_;
+  __device__ ConvertKvCache(half scale, half zero) {
+    scale_ = scale;
+    zero_ = zero;
+  }
 
-    __device__ ConvertKvCache(half scale, half zero)
-    {
-        scale_ = scale;
-        zero_  = zero;
+  static __device__ Array<half, 8> cvt_f16x8_u4(const Array<uint4_t, 8>& vi) {
+    Array<half, 8> result;
+    uint32_t* h = reinterpret_cast<uint32_t*>(&result);
+    uint32_t const& i4s = reinterpret_cast<uint32_t const&>(vi);
+    static constexpr uint32_t immLut = (0xf0 & 0xcc) | 0xaa;
+    static constexpr uint32_t BOT_MASK = 0x000f000f;
+    static constexpr uint32_t TOP_MASK = 0x00f000f0;
+    static constexpr uint32_t MAGIC_NUM_0 = 0x64006400;  // `1024`
+    static constexpr uint32_t MAGIC_NUM_1 = 0x54005400;  // `64`
+    // const uint32_t            top_i4s     = i4s >> 8;
+    uint32_t top_i4s = __byte_perm(i4s, 0, 0x4321);
+    asm("lop3.b32 %0, %1, %2, %3, %4;\n"
+        : "=r"(h[0])
+        : "r"(i4s), "n"(BOT_MASK), "n"(MAGIC_NUM_0), "n"(immLut));
+    asm("lop3.b32 %0, %1, %2, %3, %4;\n"
+        : "=r"(h[1])
+        : "r"(i4s), "n"(TOP_MASK), "n"(MAGIC_NUM_1), "n"(immLut));
+    asm("lop3.b32 %0, %1, %2, %3, %4;\n"
+        : "=r"(h[2])
+        : "r"(top_i4s), "n"(BOT_MASK), "n"(MAGIC_NUM_0), "n"(immLut));
+    asm("lop3.b32 %0, %1, %2, %3, %4;\n"
+        : "=r"(h[3])
+        : "r"(top_i4s), "n"(TOP_MASK), "n"(MAGIC_NUM_1), "n"(immLut));
+    asm("sub.f16x2 %0, %1, %2;\n" : "=r"(h[0]) : "r"(h[0]), "r"(MAGIC_NUM_0));
+    asm("sub.f16x2 %0, %1, %2;\n" : "=r"(h[1]) : "r"(h[1]), "r"(MAGIC_NUM_1));
+    asm("sub.f16x2 %0, %1, %2;\n" : "=r"(h[2]) : "r"(h[2]), "r"(MAGIC_NUM_0));
+    asm("sub.f16x2 %0, %1, %2;\n" : "=r"(h[3]) : "r"(h[3]), "r"(MAGIC_NUM_1));
+    return result;
+  }
+
+  static __device__ Array<half, 8> cvt_f16x8_u4_biased(
+      const Array<uint4_t, 8>& vi) {
+    Array<half, 8> result;
+    uint32_t* h = reinterpret_cast<uint32_t*>(&result);
+    uint32_t const& i4s = reinterpret_cast<uint32_t const&>(vi);
+    static constexpr uint32_t immLut = (0xf0 & 0xcc) | 0xaa;
+    static constexpr uint32_t BOT_MASK = 0x000f000f;
+    static constexpr uint32_t TOP_MASK = 0x00f000f0;
+    static constexpr uint32_t MAGIC_NUM_1 = 0x54005400;        // `64`
+    static constexpr uint32_t MAGIC_NUM_2 = MAGIC_NUM_1 >> 4;  // `64` >> 4
+    const uint32_t top_i4s = i4s >> 8;
+    // uint32_t top_i4s = __byte_perm(i4s, 0, 0x4321);
+    asm("lop3.b32 %0, %1, %2, %3, %4;\n"
+        : "=r"(h[0])
+        : "r"(i4s), "n"(BOT_MASK), "n"(MAGIC_NUM_2), "n"(immLut));
+    asm("lop3.b32 %0, %1, %2, %3, %4;\n"
+        : "=r"(h[1])
+        : "r"(i4s), "n"(TOP_MASK), "n"(MAGIC_NUM_1), "n"(immLut));
+    asm("lop3.b32 %0, %1, %2, %3, %4;\n"
+        : "=r"(h[2])
+        : "r"(top_i4s), "n"(BOT_MASK), "n"(MAGIC_NUM_2), "n"(immLut));
+    asm("lop3.b32 %0, %1, %2, %3, %4;\n"
+        : "=r"(h[3])
+        : "r"(top_i4s), "n"(TOP_MASK), "n"(MAGIC_NUM_1), "n"(immLut));
+    h[0] <<= 4;
+    h[2] <<= 4;
+    return result;
+  }
+
+  template <int N>
+  __device__ static auto convert(const Array<uint4_t, N>& vi) {
+    Array<half, N> vo;
+    PRAGMA_UNROLL
+    for (int i = 0; i < N; i += 8) {
+      auto& v = (Array<half, 8>&)vo[i];
+      if constexpr (kFuseU4F16Dequant) {
+        v = cvt_f16x8_u4_biased((Array<uint4_t, 8>&)vi[i]);
+      } else {
+        v = cvt_f16x8_u4((Array<uint4_t, 8>&)vi[i]);
+      }
     }
+    return vo;
+  }
 
-    static __device__ Array<half, 8> cvt_f16x8_u4(const Array<uint4_t, 8>& vi)
-    {
-        Array<half, 8>            result;
-        uint32_t*                 h           = reinterpret_cast<uint32_t*>(&result);
-        uint32_t const&           i4s         = reinterpret_cast<uint32_t const&>(vi);
-        static constexpr uint32_t immLut      = (0xf0 & 0xcc) | 0xaa;
-        static constexpr uint32_t BOT_MASK    = 0x000f000f;
-        static constexpr uint32_t TOP_MASK    = 0x00f000f0;
-        static constexpr uint32_t MAGIC_NUM_0 = 0x64006400;  // `1024`
-        static constexpr uint32_t MAGIC_NUM_1 = 0x54005400;  // `64`
-        // const uint32_t            top_i4s     = i4s >> 8;
-        uint32_t top_i4s = __byte_perm(i4s, 0, 0x4321);
-        asm("lop3.b32 %0, %1, %2, %3, %4;\n" : "=r"(h[0]) : "r"(i4s), "n"(BOT_MASK), "n"(MAGIC_NUM_0), "n"(immLut));
-        asm("lop3.b32 %0, %1, %2, %3, %4;\n" : "=r"(h[1]) : "r"(i4s), "n"(TOP_MASK), "n"(MAGIC_NUM_1), "n"(immLut));
-        asm("lop3.b32 %0, %1, %2, %3, %4;\n" : "=r"(h[2]) : "r"(top_i4s), "n"(BOT_MASK), "n"(MAGIC_NUM_0), "n"(immLut));
-        asm("lop3.b32 %0, %1, %2, %3, %4;\n" : "=r"(h[3]) : "r"(top_i4s), "n"(TOP_MASK), "n"(MAGIC_NUM_1), "n"(immLut));
-        asm("sub.f16x2 %0, %1, %2;\n" : "=r"(h[0]) : "r"(h[0]), "r"(MAGIC_NUM_0));
-        asm("sub.f16x2 %0, %1, %2;\n" : "=r"(h[1]) : "r"(h[1]), "r"(MAGIC_NUM_1));
-        asm("sub.f16x2 %0, %1, %2;\n" : "=r"(h[2]) : "r"(h[2]), "r"(MAGIC_NUM_0));
-        asm("sub.f16x2 %0, %1, %2;\n" : "=r"(h[3]) : "r"(h[3]), "r"(MAGIC_NUM_1));
-        return result;
+  template <int N>
+  __device__ auto operator()(const Array<uint4_t, N>& vi) const {
+    auto vo = convert(vi);
+    PRAGMA_UNROLL
+    for (int i = 0; i < N; ++i) {
+      vo[i] = vo[i] * scale_ + zero_;
     }
-
-    static __device__ Array<half, 8> cvt_f16x8_u4_biased(const Array<uint4_t, 8>& vi)
-    {
-        Array<half, 8>            result;
-        uint32_t*                 h           = reinterpret_cast<uint32_t*>(&result);
-        uint32_t const&           i4s         = reinterpret_cast<uint32_t const&>(vi);
-        static constexpr uint32_t immLut      = (0xf0 & 0xcc) | 0xaa;
-        static constexpr uint32_t BOT_MASK    = 0x000f000f;
-        static constexpr uint32_t TOP_MASK    = 0x00f000f0;
-        static constexpr uint32_t MAGIC_NUM_1 = 0x54005400;        // `64`
-        static constexpr uint32_t MAGIC_NUM_2 = MAGIC_NUM_1 >> 4;  // `64` >> 4
-        const uint32_t            top_i4s     = i4s >> 8;
-        // uint32_t top_i4s = __byte_perm(i4s, 0, 0x4321);
-        asm("lop3.b32 %0, %1, %2, %3, %4;\n" : "=r"(h[0]) : "r"(i4s), "n"(BOT_MASK), "n"(MAGIC_NUM_2), "n"(immLut));
-        asm("lop3.b32 %0, %1, %2, %3, %4;\n" : "=r"(h[1]) : "r"(i4s), "n"(TOP_MASK), "n"(MAGIC_NUM_1), "n"(immLut));
-        asm("lop3.b32 %0, %1, %2, %3, %4;\n" : "=r"(h[2]) : "r"(top_i4s), "n"(BOT_MASK), "n"(MAGIC_NUM_2), "n"(immLut));
-        asm("lop3.b32 %0, %1, %2, %3, %4;\n" : "=r"(h[3]) : "r"(top_i4s), "n"(TOP_MASK), "n"(MAGIC_NUM_1), "n"(immLut));
-        h[0] <<= 4;
-        h[2] <<= 4;
-        return result;
-    }
-
-    template<int N>
-    __device__ static auto convert(const Array<uint4_t, N>& vi)
-    {
-        Array<half, N> vo;
-        PRAGMA_UNROLL
-        for (int i = 0; i < N; i += 8) {
-            auto& v = (Array<half, 8>&)vo[i];
-            if constexpr (kFuseU4F16Dequant) {
-                v = cvt_f16x8_u4_biased((Array<uint4_t, 8>&)vi[i]);
-            }
-            else {
-                v = cvt_f16x8_u4((Array<uint4_t, 8>&)vi[i]);
-            }
-        }
-        return vo;
-    }
-
-    template<int N>
-    __device__ auto operator()(const Array<uint4_t, N>& vi) const
-    {
-        auto vo = convert(vi);
-        PRAGMA_UNROLL
-        for (int i = 0; i < N; ++i) {
-            vo[i] = vo[i] * scale_ + zero_;
-        }
-        return vo;
-    }
+    return vo;
+  }
 };
 
-template<>
+template <>
 struct ConvertKvCache<uint4_t, nv_bfloat16> {
+  nv_bfloat16 scale_;
+  nv_bfloat16 zero_;
 
-    nv_bfloat16 scale_;
-    nv_bfloat16 zero_;
+  __device__ ConvertKvCache(nv_bfloat16 scale, nv_bfloat16 zero) {
+    scale_ = scale;
+    zero_ = zero;
+  }
 
-    __device__ ConvertKvCache(nv_bfloat16 scale, nv_bfloat16 zero)
-    {
-        scale_ = scale;
-        zero_  = zero;
+  template <int N>
+  __device__ static Array<nv_bfloat16, N> convert(const Array<uint4_t, N>& vi) {
+    Array<nv_bfloat16, N> vo{};
+    PRAGMA_UNROLL
+    for (int i = 0; i < N; i += 8) {
+      auto& v = (Array<short, 8>&)vo[i];
+      auto u = cvt_bf16x8_u4((Array<uint4_t, 8>&)vi[i]);
+      v = (Array<short, 8>&)u;
     }
+    return vo;
+  }
 
-    template<int N>
-    __device__ static Array<nv_bfloat16, N> convert(const Array<uint4_t, N>& vi)
-    {
-        Array<nv_bfloat16, N> vo{};
-        PRAGMA_UNROLL
-        for (int i = 0; i < N; i += 8) {
-            auto& v = (Array<short, 8>&)vo[i];
-            auto  u = cvt_bf16x8_u4((Array<uint4_t, 8>&)vi[i]);
-            v       = (Array<short, 8>&)u;
-        }
-        return vo;
+  template <int N>
+  __device__ Array<nv_bfloat16, N> operator()(
+      const Array<uint4_t, N>& vi) const {
+    auto vo = convert(vi);
+    PRAGMA_UNROLL
+    for (int i = 0; i < N; ++i) {
+      vo[i] = vo[i] * scale_ + zero_;
     }
-
-    template<int N>
-    __device__ Array<nv_bfloat16, N> operator()(const Array<uint4_t, N>& vi) const
-    {
-        auto vo = convert(vi);
-        PRAGMA_UNROLL
-        for (int i = 0; i < N; ++i) {
-            vo[i] = vo[i] * scale_ + zero_;
-        }
-        return (Array<nv_bfloat16, N>&)vo;
-    }
+    return (Array<nv_bfloat16, N>&)vo;
+  }
 };
 
-template<>
+template <>
 struct ConvertKvCache<uint4_t, float> {
-
 #if 1
-    ConvertKvCache<uint4_t, half> impl_;
+  ConvertKvCache<uint4_t, half> impl_;
 
-    __device__ ConvertKvCache(float scale, float zero): impl_{scale, zero} {}
+  __device__ ConvertKvCache(float scale, float zero) : impl_{scale, zero} {}
 
-    template<int N>
-    __device__ auto operator()(const Array<uint4_t, N>& vi) const
-    {
-        return cast<float>(impl_(vi));
-    }
+  template <int N>
+  __device__ auto operator()(const Array<uint4_t, N>& vi) const {
+    return cast<float>(impl_(vi));
+  }
 #else
-    static __device__ Array<half, 8> cvt_f16x8_u4_biased(const Array<uint4_t, 8>& vi)
-    {
-        Array<half, 8> result;
-        uint32_t* h = reinterpret_cast<uint32_t*>(&result);
-        uint32_t const& i4s = reinterpret_cast<uint32_t const&>(vi);
-        static constexpr uint32_t immLut = (0xf0 & 0xcc) | 0xaa;
-        static constexpr uint32_t BOT_MASK = 0x000f000f;
-        static constexpr uint32_t TOP_MASK = 0x00f000f0;
-        static constexpr uint32_t MAGIC_NUM_1 = 0x54005400;        // `64`
-        static constexpr uint32_t MAGIC_NUM_2 = MAGIC_NUM_1 >> 4;  // `64` >> 4
-        const uint32_t top_i4s = i4s >> 8;
-        asm("lop3.b32 %0, %1, %2, %3, %4;\n" : "=r"(h[0]) : "r"(i4s), "n"(BOT_MASK), "n"(MAGIC_NUM_2), "n"(immLut));
-        asm("lop3.b32 %0, %1, %2, %3, %4;\n" : "=r"(h[1]) : "r"(i4s), "n"(TOP_MASK), "n"(MAGIC_NUM_1), "n"(immLut));
-        asm("lop3.b32 %0, %1, %2, %3, %4;\n" : "=r"(h[2]) : "r"(top_i4s), "n"(BOT_MASK), "n"(MAGIC_NUM_2), "n"(immLut));
-        asm("lop3.b32 %0, %1, %2, %3, %4;\n" : "=r"(h[3]) : "r"(top_i4s), "n"(TOP_MASK), "n"(MAGIC_NUM_1), "n"(immLut));
-        h[0] <<= 4;
-        h[2] <<= 4;
-        return result;
-    }
-    float scale_;
-    float zero_;
-    __device__ ConvertKvCache(float scale, float zero)
-    {
-        scale_ = scale;
-        zero_ = zero - scale * 64.f;
-    }
-    template<int N>
-    __device__ auto operator()(const Array<uint4_t, N>& vi) const
-    {
-        auto vo = cast<float>(cvt_f16x8_u4_biased(vi));
-        using namespace ops;
-        return vo * scale_ + zero_;
-    }
+  static __device__ Array<half, 8> cvt_f16x8_u4_biased(
+      const Array<uint4_t, 8>& vi) {
+    Array<half, 8> result;
+    uint32_t* h = reinterpret_cast<uint32_t*>(&result);
+    uint32_t const& i4s = reinterpret_cast<uint32_t const&>(vi);
+    static constexpr uint32_t immLut = (0xf0 & 0xcc) | 0xaa;
+    static constexpr uint32_t BOT_MASK = 0x000f000f;
+    static constexpr uint32_t TOP_MASK = 0x00f000f0;
+    static constexpr uint32_t MAGIC_NUM_1 = 0x54005400;        // `64`
+    static constexpr uint32_t MAGIC_NUM_2 = MAGIC_NUM_1 >> 4;  // `64` >> 4
+    const uint32_t top_i4s = i4s >> 8;
+    asm("lop3.b32 %0, %1, %2, %3, %4;\n"
+        : "=r"(h[0])
+        : "r"(i4s), "n"(BOT_MASK), "n"(MAGIC_NUM_2), "n"(immLut));
+    asm("lop3.b32 %0, %1, %2, %3, %4;\n"
+        : "=r"(h[1])
+        : "r"(i4s), "n"(TOP_MASK), "n"(MAGIC_NUM_1), "n"(immLut));
+    asm("lop3.b32 %0, %1, %2, %3, %4;\n"
+        : "=r"(h[2])
+        : "r"(top_i4s), "n"(BOT_MASK), "n"(MAGIC_NUM_2), "n"(immLut));
+    asm("lop3.b32 %0, %1, %2, %3, %4;\n"
+        : "=r"(h[3])
+        : "r"(top_i4s), "n"(TOP_MASK), "n"(MAGIC_NUM_1), "n"(immLut));
+    h[0] <<= 4;
+    h[2] <<= 4;
+    return result;
+  }
+  float scale_;
+  float zero_;
+  __device__ ConvertKvCache(float scale, float zero) {
+    scale_ = scale;
+    zero_ = zero - scale * 64.f;
+  }
+  template <int N>
+  __device__ auto operator()(const Array<uint4_t, N>& vi) const {
+    auto vo = cast<float>(cvt_f16x8_u4_biased(vi));
+    using namespace ops;
+    return vo * scale_ + zero_;
+  }
 #endif
 };
 
 // u8 -> f32/f16/bf16
-template<class T>
+template <class T>
 struct ConvertKvCache<uint8_t, T> {
-    T          scale_;
-    T          zero_;
-    __device__ ConvertKvCache(T scale, T zero): scale_{scale}, zero_{zero} {}
+  T scale_;
+  T zero_;
+  __device__ ConvertKvCache(T scale, T zero) : scale_{scale}, zero_{zero} {}
 
-    template<int N>
-    __device__ static auto convert(const Array<uint8_t, N>& vi)
-    {
-        Array<T, N> vo;
-        PRAGMA_UNROLL
-        for (int n = 0; n < N; n += 4) {
-            auto& ui = (const Array<uint8_t, 4>&)vi[n];
-            auto& uo = (Array<T, 4>&)vo[n];
+  template <int N>
+  __device__ static auto convert(const Array<uint8_t, N>& vi) {
+    Array<T, N> vo;
+    PRAGMA_UNROLL
+    for (int n = 0; n < N; n += 4) {
+      auto& ui = (const Array<uint8_t, 4>&)vi[n];
+      auto& uo = (Array<T, 4>&)vo[n];
 
-            if constexpr (std::is_same_v<T, half>) {
-                uo = cvt_f16x4_u8<true>(ui);
-            }
-            else if constexpr (std::is_same_v<T, float>) {
-                uo = cvt_f32x4_u8(ui);
-            }
+      if constexpr (std::is_same_v<T, half>) {
+        uo = cvt_f16x4_u8<true>(ui);
+      } else if constexpr (std::is_same_v<T, float>) {
+        uo = cvt_f32x4_u8(ui);
+      }
 #if __CUDA_ARCH__ >= 800
-            else if constexpr (std::is_same_v<T, nv_bfloat16>) {
-                uo = cvt_bf16x4_u8(ui);
-            }
+      else if constexpr (std::is_same_v<T, nv_bfloat16>) {
+        uo = cvt_bf16x4_u8(ui);
+      }
 #endif
-        }
-        return vo;
     }
+    return vo;
+  }
 
-    template<int N>
-    __device__ auto operator()(const Array<uint8_t, N>& vi) const
-    {
-        auto vo = convert(vi);
-        PRAGMA_UNROLL
-        for (int i = 0; i < N; ++i) {
-            vo[i] = vo[i] * scale_ + zero_;
-        }
-        return vo;
+  template <int N>
+  __device__ auto operator()(const Array<uint8_t, N>& vi) const {
+    auto vo = convert(vi);
+    PRAGMA_UNROLL
+    for (int i = 0; i < N; ++i) {
+      vo[i] = vo[i] * scale_ + zero_;
     }
+    return vo;
+  }
 };
 
-template<class T>
+template <class T>
 struct ConvertKvCache<fp4_e2m1_t, T> {
+  __device__ static Array<bfloat16_t, 8> cvt_bf16x8_e2m1(
+      const Array<fp4_e2m1_t, 8>& vi) {
+    const uint32_t& x = (const uint32_t&)vi;
 
-    __device__ static Array<bfloat16_t, 8> cvt_bf16x8_e2m1(const Array<fp4_e2m1_t, 8>& vi)
-    {
-        const uint32_t& x = (const uint32_t&)vi;
+    constexpr uint32_t S = 0x80008000U;
+    constexpr uint32_t EM = 0x01C001C0U;
 
-        constexpr uint32_t S  = 0x80008000U;
-        constexpr uint32_t EM = 0x01C001C0U;
+    Array<uint32_t, 4> vo;
 
-        Array<uint32_t, 4> vo;
-
-        // clang-format off
+    // clang-format off
         vo[0] = (x << 12 & S) | (x << 6 & EM);
         vo[1] = (x <<  8 & S) | (x << 2 & EM);
         vo[2] = (x <<  4 & S) | (x >> 2 & EM);
         vo[3] = (x <<  0 & S) | (x >> 6 & EM);
-        // clang-format on
+    // clang-format on
 
-        constexpr uint32_t e  = (127U - 1U + 127U) << 7U;
-        constexpr uint32_t ee = e << 16U | e;
+    constexpr uint32_t e = (127U - 1U + 127U) << 7U;
+    constexpr uint32_t ee = e << 16U | e;
 
-        PRAGMA_UNROLL
-        for (int i = 0; i < 4; ++i) {
+    PRAGMA_UNROLL
+    for (int i = 0; i < 4; ++i) {
 #if TURBOMIND_ARCH_SM90
-            asm("mul.rn.bf16x2 %0, %1, %2;" : "=r"(vo[i]) : "r"(vo[i]), "r"(ee));
+      asm("mul.rn.bf16x2 %0, %1, %2;" : "=r"(vo[i]) : "r"(vo[i]), "r"(ee));
 #else
-            asm("fma.rn.bf16x2 %0, %1, %2, %3;" : "=r"(vo[i]) : "r"(vo[i]), "r"(ee), "r"(0));
+      asm("fma.rn.bf16x2 %0, %1, %2, %3;"
+          : "=r"(vo[i])
+          : "r"(vo[i]), "r"(ee), "r"(0));
 #endif
-        }
-
-        return (Array<bfloat16_t, 8>&)vo;
     }
 
-    __device__ static Array<half, 8> cvt_f16x8_e2m1(const Array<fp4_e2m1_t, 8>& vi)
-    {
-        const uint32_t& x = (const uint32_t&)vi;
+    return (Array<bfloat16_t, 8>&)vo;
+  }
 
-        constexpr uint32_t S  = 0x80008000U;
-        constexpr uint32_t EM = 0x0E000E00U;
+  __device__ static Array<half, 8> cvt_f16x8_e2m1(
+      const Array<fp4_e2m1_t, 8>& vi) {
+    const uint32_t& x = (const uint32_t&)vi;
 
-        Array<uint32_t, 4> vo;
+    constexpr uint32_t S = 0x80008000U;
+    constexpr uint32_t EM = 0x0E000E00U;
 
-        // clang-format off
+    Array<uint32_t, 4> vo;
+
+    // clang-format off
         vo[0] = (x << 12 & S) | (x << 9 & EM);
         vo[1] = (x <<  8 & S) | (x << 5 & EM);
         vo[2] = (x <<  4 & S) | (x << 1 & EM);
         vo[3] = (x <<  0 & S) | (x >> 3 & EM);
-        // clang-format on
+    // clang-format on
 
-        constexpr uint32_t e  = (15U - 1U + 15U) << 10U;
-        constexpr uint32_t ee = e << 16U | e;
-
-        PRAGMA_UNROLL
-        for (int i = 0; i < 4; ++i) {
-            asm volatile("mul.f16x2 %0, %1, %2;" : "=r"(vo[i]) : "r"(vo[i]), "r"(ee));
-        }
-
-        return (Array<half, 8>&)vo;
-    }
-
-    template<int N>
-    __device__ static auto convert(const Array<fp4_e2m1_t, N>& vi)
-    {
-        Array<T, N> vo;
-        PRAGMA_UNROLL
-        for (int i = 0; i < N; i += 8) {
-            auto& v = (Array<T, 8>&)vo[i];
-            if constexpr (std::is_same_v<T, bfloat16_t>) {
-                v = cvt_bf16x8_e2m1((Array<fp4_e2m1_t, 8>&)vi[i]);
-            }
-            else if constexpr (std::is_same_v<T, half_t>) {
-                v = cvt_f16x8_e2m1((Array<fp4_e2m1_t, 8>&)vi[i]);
-            }
-            else {
-                static_assert(N != N, "not implemented");
-            }
-        }
-        return vo;
-    }
-};
-
-__device__ inline Array<bfloat16_t, 4> cvt_bf16x4_e4m3(const Array<fp8_e4m3_t, 4>& vi)
-{
-    const uint32_t& x = (const uint32_t&)vi;
-
-    //    0   7   C   0
-    // SEEEEEEEEMMMMMMMSEEEEEEEEMMMMMMM
-    // SEEEEMMM        SEEEEMMM
-    //         SEEEEMMM        SEEEEMMM
-
-    constexpr uint32_t S  = 0x80008000U;
-    constexpr uint32_t EM = 0x07F007F0U;
-
-    Array<uint32_t, 2> vo;
-
-    vo[0] = (x << 8 & S) | (x << 4 & EM);
-    vo[1] = (x << 0 & S) | (x >> 4 & EM);
-
-    constexpr uint32_t e  = (127U - 7U + 127U) << 7U;
+    constexpr uint32_t e = (15U - 1U + 15U) << 10U;
     constexpr uint32_t ee = e << 16U | e;
 
     PRAGMA_UNROLL
-    for (int i = 0; i < 2; ++i) {
-#if TURBOMIND_ARCH_SM90
-        asm("mul.rn.bf16x2 %0, %1, %2;" : "=r"(vo[i]) : "r"(vo[i]), "r"(ee));
-#else
-        asm("fma.rn.bf16x2 %0, %1, %2, %3;" : "=r"(vo[i]) : "r"(vo[i]), "r"(ee), "r"(0));
-#endif
+    for (int i = 0; i < 4; ++i) {
+      asm volatile("mul.f16x2 %0, %1, %2;" : "=r"(vo[i]) : "r"(vo[i]), "r"(ee));
     }
 
-    return (Array<bfloat16_t, 4>&)vo;
-}
+    return (Array<half, 8>&)vo;
+  }
 
-template<bool ApplyExponentBias = true>
-__device__ inline Array<half, 4> cvt_f16x4_e4m3(const Array<fp8_e4m3_t, 4>& vi)
-{
-    const uint32_t& x = (const uint32_t&)vi;
-
-    //    3   F   8   0
-    // SEEEEEMMMMMMMMMMSEEEEEMMMMMMMMMM
-    // SEEEEMMM        SEEEEMMM
-    //         SEEEEMMM        SEEEEMMM
-
-    constexpr uint32_t S  = 0x80008000U;
-    constexpr uint32_t EM = 0x3F803F80U;
-
-    Array<uint32_t, 2> vo;
-
-    vo[0] = (x << 8 & S) | (x << 7 & EM);
-    vo[1] = (x << 0 & S) | (x >> 1 & EM);
-
-    constexpr uint32_t e  = (15U - 7U + 15U) << 10U;
-    constexpr uint32_t ee = e << 16U | e;
-
-    if constexpr (ApplyExponentBias) {
-        PRAGMA_UNROLL
-        for (int i = 0; i < 2; ++i) {
-            asm("mul.rn.f16x2 %0, %1, %2;" : "=r"(vo[i]) : "r"(vo[i]), "r"(ee));
-        }
+  template <int N>
+  __device__ static auto convert(const Array<fp4_e2m1_t, N>& vi) {
+    Array<T, N> vo;
+    PRAGMA_UNROLL
+    for (int i = 0; i < N; i += 8) {
+      auto& v = (Array<T, 8>&)vo[i];
+      if constexpr (std::is_same_v<T, bfloat16_t>) {
+        v = cvt_bf16x8_e2m1((Array<fp4_e2m1_t, 8>&)vi[i]);
+      } else if constexpr (std::is_same_v<T, half_t>) {
+        v = cvt_f16x8_e2m1((Array<fp4_e2m1_t, 8>&)vi[i]);
+      } else {
+        static_assert(N != N, "not implemented");
+      }
     }
-
-    return (Array<half, 4>&)vo;
-}
-
-template<class T>
-struct ConvertKvCache<fp8_e4m3_t, T> {
-
-    template<int N>
-    __device__ static auto convert(const Array<fp8_e4m3_t, N>& vi)
-    {
-        static_assert(N % 4 == 0);
-        Array<T, N> vo;
-        PRAGMA_UNROLL
-        for (int i = 0; i < N; i += 4) {
-            auto& v = (Array<T, 4>&)vo[i];
-            if constexpr (std::is_same_v<T, bfloat16_t>) {
-                v = cvt_bf16x4_e4m3((Array<fp8_e4m3_t, 4>&)vi[i]);
-            }
-            else if constexpr (std::is_same_v<T, half_t>) {
-                v = cvt_f16x4_e4m3((Array<fp8_e4m3_t, 4>&)vi[i]);
-            }
-            else {
-                static_assert(N != N, "not implemented");
-            }
-        }
-        return vo;
-    }
+    return vo;
+  }
 };
 
-template<class Q, class T>
-inline __device__ void StoreQuantParam(T* dst, Array<T, 2> src)
-{
-    Store(dst, src);
+__device__ inline Array<bfloat16_t, 4> cvt_bf16x4_e4m3(
+    const Array<fp8_e4m3_t, 4>& vi) {
+  const uint32_t& x = (const uint32_t&)vi;
+
+  //    0   7   C   0
+  // SEEEEEEEEMMMMMMMSEEEEEEEEMMMMMMM
+  // SEEEEMMM        SEEEEMMM
+  //         SEEEEMMM        SEEEEMMM
+
+  constexpr uint32_t S = 0x80008000U;
+  constexpr uint32_t EM = 0x07F007F0U;
+
+  Array<uint32_t, 2> vo;
+
+  vo[0] = (x << 8 & S) | (x << 4 & EM);
+  vo[1] = (x << 0 & S) | (x >> 4 & EM);
+
+  constexpr uint32_t e = (127U - 7U + 127U) << 7U;
+  constexpr uint32_t ee = e << 16U | e;
+
+  PRAGMA_UNROLL
+  for (int i = 0; i < 2; ++i) {
+#if TURBOMIND_ARCH_SM90
+    asm("mul.rn.bf16x2 %0, %1, %2;" : "=r"(vo[i]) : "r"(vo[i]), "r"(ee));
+#else
+    asm("fma.rn.bf16x2 %0, %1, %2, %3;"
+        : "=r"(vo[i])
+        : "r"(vo[i]), "r"(ee), "r"(0));
+#endif
+  }
+
+  return (Array<bfloat16_t, 4>&)vo;
 }
 
-template<>
-inline __device__ void StoreQuantParam<uint4_t, half>(half* dst, Array<half, 2> src)
-{
-    if constexpr (kFuseU4F16Dequant) {
-        src[1] = src[1] - src[0] * __ushort_as_half(0x5400);
+template <bool ApplyExponentBias = true>
+__device__ inline Array<half, 4> cvt_f16x4_e4m3(
+    const Array<fp8_e4m3_t, 4>& vi) {
+  const uint32_t& x = (const uint32_t&)vi;
+
+  //    3   F   8   0
+  // SEEEEEMMMMMMMMMMSEEEEEMMMMMMMMMM
+  // SEEEEMMM        SEEEEMMM
+  //         SEEEEMMM        SEEEEMMM
+
+  constexpr uint32_t S = 0x80008000U;
+  constexpr uint32_t EM = 0x3F803F80U;
+
+  Array<uint32_t, 2> vo;
+
+  vo[0] = (x << 8 & S) | (x << 7 & EM);
+  vo[1] = (x << 0 & S) | (x >> 1 & EM);
+
+  constexpr uint32_t e = (15U - 7U + 15U) << 10U;
+  constexpr uint32_t ee = e << 16U | e;
+
+  if constexpr (ApplyExponentBias) {
+    PRAGMA_UNROLL
+    for (int i = 0; i < 2; ++i) {
+      asm("mul.rn.f16x2 %0, %1, %2;" : "=r"(vo[i]) : "r"(vo[i]), "r"(ee));
     }
-    Store(dst, src);
+  }
+
+  return (Array<half, 4>&)vo;
+}
+
+template <class T>
+struct ConvertKvCache<fp8_e4m3_t, T> {
+  template <int N>
+  __device__ static auto convert(const Array<fp8_e4m3_t, N>& vi) {
+    static_assert(N % 4 == 0);
+    Array<T, N> vo;
+    PRAGMA_UNROLL
+    for (int i = 0; i < N; i += 4) {
+      auto& v = (Array<T, 4>&)vo[i];
+      if constexpr (std::is_same_v<T, bfloat16_t>) {
+        v = cvt_bf16x4_e4m3((Array<fp8_e4m3_t, 4>&)vi[i]);
+      } else if constexpr (std::is_same_v<T, half_t>) {
+        v = cvt_f16x4_e4m3((Array<fp8_e4m3_t, 4>&)vi[i]);
+      } else {
+        static_assert(N != N, "not implemented");
+      }
+    }
+    return vo;
+  }
+};
+
+template <class Q, class T>
+inline __device__ void StoreQuantParam(T* dst, Array<T, 2> src) {
+  Store(dst, src);
+}
+
+template <>
+inline __device__ void StoreQuantParam<uint4_t, half>(half* dst,
+                                                      Array<half, 2> src) {
+  if constexpr (kFuseU4F16Dequant) {
+    src[1] = src[1] - src[0] * __ushort_as_half(0x5400);
+  }
+  Store(dst, src);
 }
 
 }  // namespace turbomind

--- a/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/attention/quantization.h
+++ b/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/attention/quantization.h
@@ -817,6 +817,7 @@ __device__ inline Array<bfloat16_t, 4> cvt_bf16x4_e4m3(const Array<fp8_e4m3_t, 4
     return (Array<bfloat16_t, 4>&)vo;
 }
 
+template<bool ApplyExponentBias = true>
 __device__ inline Array<half, 4> cvt_f16x4_e4m3(const Array<fp8_e4m3_t, 4>& vi)
 {
     const uint32_t& x = (const uint32_t&)vi;
@@ -837,9 +838,11 @@ __device__ inline Array<half, 4> cvt_f16x4_e4m3(const Array<fp8_e4m3_t, 4>& vi)
     constexpr uint32_t e  = (15U - 7U + 15U) << 10U;
     constexpr uint32_t ee = e << 16U | e;
 
-    PRAGMA_UNROLL
-    for (int i = 0; i < 2; ++i) {
-        asm("mul.rn.f16x2 %0, %1, %2;" : "=r"(vo[i]) : "r"(vo[i]), "r"(ee));
+    if constexpr (ApplyExponentBias) {
+        PRAGMA_UNROLL
+        for (int i = 0; i < 2; ++i) {
+            asm("mul.rn.f16x2 %0, %1, %2;" : "=r"(vo[i]) : "r"(vo[i]), "r"(ee));
+        }
     }
 
     return (Array<half, 4>&)vo;

--- a/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/arch/config_sm70_s884.h
+++ b/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/arch/config_sm70_s884.h
@@ -57,7 +57,8 @@ struct Sm70_s884 {
              int  GroupSizeV = 1,
              int  TILE_C_M_  = -1,
              int  TILE_C_N_  = -1,
-             int  GmemLookahead = 1>
+             int  GmemLookahead = 1,
+             bool FullTiles      = false>
     struct Type {
 
         // (TM, TN, TK) = R(MMA_Atom, SmemCopy_Atom)
@@ -68,14 +69,21 @@ struct Sm70_s884 {
 
         using MMA = Tiled_MMA_v2<MMA_Atom, MMA_Map>;
 
+        using IteratorA = std::conditional_t<FullTiles,
+                                             IteratorSm70FullTile<MODE_A, PolicyA>,
+                                             IteratorSm70<MODE_A, PolicyA>>;
+        using IteratorB = std::conditional_t<FullTiles,
+                                             IteratorSm70FullTile<MODE_B, PolicyB>,
+                                             IteratorSm70<MODE_B, PolicyB>>;
+
         using Mainloop = MainloopSm70<MMA,
                                       A,
-                                      IteratorSm70<MODE_A, PolicyA>,
+                                      IteratorA,
                                       TransformA,
                                       U,
                                       GroupSizeU,
                                       B,
-                                      IteratorSm70<MODE_B, PolicyB>,
+                                      IteratorB,
                                       TransformB,
                                       V,
                                       GroupSizeV,
@@ -176,6 +184,18 @@ using Config_E4M3 = Sm70_s884<Operand_A<half>,             // A
                               half,                        // Tc
                               raster_order,
                               group_axis>;
+
+template<Order raster_order, int group_axis = -1>
+using Config_E4M3_Prescaled = Sm70_s884<Operand_A<half>,             // A
+                                        Transform_Default,           // transform A
+                                        VoidOperand,                 // U
+                                        Operand_B_Pack<fp8_e4m3_t>,  // B
+                                        Transform_HMMA_SIMT_B_PrescaledE4M3,
+                                        Operand_V_Pack<uint16_t>,  // pre-scaled V
+                                        kRowMajor,                 // order_C
+                                        half,                      // Tc
+                                        raster_order,
+                                        group_axis>;
 
 template<Order raster_order, int group_axis = -1>
 using Config_F16 = Sm70_s884<Operand_A<half>,       // A

--- a/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/arch/config_sm70_s884.h
+++ b/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/arch/config_sm70_s884.h
@@ -19,125 +19,85 @@
 
 namespace turbomind::gemm::sm70_s884 {
 
-template<class A,
-         class TransformA,
-         class U,
-         class B,
-         class TransformB,
-         class V,
-         Order order_C,
-         class Tc,
-         Order raster_order,
-         int   group_axis>
+template <class A, class TransformA, class U, class B, class TransformB,
+          class V, Order order_C, class Tc, Order raster_order, int group_axis>
 struct Sm70_s884 {
+  static_assert(A::SmemCopyAtom::K == B::SmemCopyAtom::K);
 
-    static_assert(A::SmemCopyAtom::K == B::SmemCopyAtom::K);
+  static constexpr int SMEM_M = A::SmemCopyAtom::M / A::SmemCopyAtom::kFragNum;
+  static constexpr int SMEM_N = B::SmemCopyAtom::M / B::SmemCopyAtom::kFragNum;
+  static constexpr int SMEM_K = A::SmemCopyAtom::K;
 
-    static constexpr int SMEM_M = A::SmemCopyAtom::M / A::SmemCopyAtom::kFragNum;
-    static constexpr int SMEM_N = B::SmemCopyAtom::M / B::SmemCopyAtom::kFragNum;
-    static constexpr int SMEM_K = A::SmemCopyAtom::K;
+  static constexpr auto MODE_ =
+      group_axis >= 0 ? Striding::kBlocked : Striding::kFlat;
 
-    static constexpr auto MODE_ = group_axis >= 0 ? Striding::kBlocked : Striding::kFlat;
+  static constexpr auto MODE_A = group_axis == 0 ? Striding::kIndexed : MODE_;
+  static constexpr auto MODE_B = group_axis == 1 ? Striding::kIndexed : MODE_;
+  static constexpr auto MODE_C = MODE_;
 
-    static constexpr auto MODE_A = group_axis == 0 ? Striding::kIndexed : MODE_;
-    static constexpr auto MODE_B = group_axis == 1 ? Striding::kIndexed : MODE_;
-    static constexpr auto MODE_C = MODE_;
+  template <int CTA_M, int CTA_N, int CTA_K, int TG_M, int TG_N, int TG_K,
+            class PolicyA, class PolicyB, int Stages, bool SplitK,
+            int GroupSizeU = 1, int GroupSizeV = 1, int TILE_C_M_ = -1,
+            int TILE_C_N_ = -1, int GmemLookahead = 1, bool FullTiles = false>
+  struct Type {
+    // (TM, TN, TK) = R(MMA_Atom, SmemCopy_Atom)
+    using MMA_Atom = SM70_MMA_884;
 
-    template<int CTA_M,
-             int CTA_N,
-             int CTA_K,
-             int TG_M,
-             int TG_N,
-             int TG_K,
-             class PolicyA,
-             class PolicyB,
-             int  Stages,
-             bool SplitK,
-             int  GroupSizeU = 1,
-             int  GroupSizeV = 1,
-             int  TILE_C_M_  = -1,
-             int  TILE_C_N_  = -1,
-             int  GmemLookahead = 1,
-             bool FullTiles      = false>
-    struct Type {
+    using Partition = Blocked<TG_M, TG_N, kColMajor>;
+    using MMA_Map =
+        MMA_Map<CTA_M, CTA_N, CTA_K, SMEM_M, SMEM_N, SMEM_K, Partition, TG_K>;
 
-        // (TM, TN, TK) = R(MMA_Atom, SmemCopy_Atom)
-        using MMA_Atom = SM70_MMA_884;
+    using MMA = Tiled_MMA_v2<MMA_Atom, MMA_Map>;
 
-        using Partition = Blocked<TG_M, TG_N, kColMajor>;
-        using MMA_Map   = MMA_Map<CTA_M, CTA_N, CTA_K, SMEM_M, SMEM_N, SMEM_K, Partition, TG_K>;
+    using IteratorA =
+        std::conditional_t<FullTiles, IteratorSm70FullTile<MODE_A, PolicyA>,
+                           IteratorSm70<MODE_A, PolicyA>>;
+    using IteratorB =
+        std::conditional_t<FullTiles, IteratorSm70FullTile<MODE_B, PolicyB>,
+                           IteratorSm70<MODE_B, PolicyB>>;
 
-        using MMA = Tiled_MMA_v2<MMA_Atom, MMA_Map>;
+    using Mainloop =
+        MainloopSm70<MMA, A, IteratorA, TransformA, U, GroupSizeU, B, IteratorB,
+                     TransformB, V, GroupSizeV, Stages, true,
+                     GmemLookahead>;  // FusePrefetch_
 
-        using IteratorA = std::conditional_t<FullTiles,
-                                             IteratorSm70FullTile<MODE_A, PolicyA>,
-                                             IteratorSm70<MODE_A, PolicyA>>;
-        using IteratorB = std::conditional_t<FullTiles,
-                                             IteratorSm70FullTile<MODE_B, PolicyB>,
-                                             IteratorSm70<MODE_B, PolicyB>>;
+    static constexpr int CHUNK_K =
+        std::lcm(std::lcm(GroupSizeU, GroupSizeV), CTA_K);
 
-        using Mainloop = MainloopSm70<MMA,
-                                      A,
-                                      IteratorA,
-                                      TransformA,
-                                      U,
-                                      GroupSizeU,
-                                      B,
-                                      IteratorB,
-                                      TransformB,
-                                      V,
-                                      GroupSizeV,
-                                      Stages,
-                                      true,
-                                      GmemLookahead>;  // FusePrefetch_
+    using Scheduler = SchedulerSm70<raster_order, CTA_M, CTA_N, CTA_K, CHUNK_K,
+                                    SplitK, group_axis>;
 
-        static constexpr int CHUNK_K = std::lcm(std::lcm(GroupSizeU, GroupSizeV), CTA_K);
+    static constexpr int TILE_C_M = TILE_C_M_ == -1 ? CTA_M : TILE_C_M_;
+    static constexpr int TILE_C_N = TILE_C_N_ == -1 ? CTA_N : TILE_C_N_;
 
-        using Scheduler = SchedulerSm70<raster_order, CTA_M, CTA_N, CTA_K, CHUNK_K, SplitK, group_axis>;
+    using Epilogue = gemm::Epilogue_<Tc, CTA_M, CTA_N, TILE_C_M, TILE_C_N,
+                                     MMA::kThreadCount, Rearrange<MMA>,
+                                     Operand_C<float, order_C>, MODE_C, SplitK>;
 
-        static constexpr int TILE_C_M = TILE_C_M_ == -1 ? CTA_M : TILE_C_M_;
-        static constexpr int TILE_C_N = TILE_C_N_ == -1 ? CTA_N : TILE_C_N_;
-
-        using Epilogue = gemm::Epilogue_<Tc,
-                                         CTA_M,
-                                         CTA_N,
-                                         TILE_C_M,
-                                         TILE_C_N,
-                                         MMA::kThreadCount,
-                                         Rearrange<MMA>,
-                                         Operand_C<float, order_C>,
-                                         MODE_C,
-                                         SplitK>;
-
-        using Kernel = GemmUniversal<Sm70, Mainloop, Epilogue, Scheduler>;
-    };
+    using Kernel = GemmUniversal<Sm70, Mainloop, Epilogue, Scheduler>;
+  };
 };
 
-template<Order raster_order>
-using Config_U4_d = Sm70_s884<typename GetOperand<HMMA_884, OPERAND_A, half, kRowMajor, false>::Operand,
-                              Transform_Default,
-                              VoidOperand,
-                              typename GetOperand<HMMA_884, OPERAND_B, uint4_t, kRowMajor, true>::Operand,
-                              Transform_HMMA_SIMT_B,
-                              typename GetOperand<HMMA_884, OPERAND_V, uint32_t, kColMajor, true>::Operand,
-                              kRowMajor,
-                              half,
-                              raster_order,
-                              -1>;
+template <Order raster_order>
+using Config_U4_d = Sm70_s884<
+    typename GetOperand<HMMA_884, OPERAND_A, half, kRowMajor, false>::Operand,
+    Transform_Default, VoidOperand,
+    typename GetOperand<HMMA_884, OPERAND_B, uint4_t, kRowMajor, true>::Operand,
+    Transform_HMMA_SIMT_B,
+    typename GetOperand<HMMA_884, OPERAND_V, uint32_t, kColMajor,
+                        true>::Operand,
+    kRowMajor, half, raster_order, -1>;
 
-template<Order raster_order>
-using Config_U4_d_A8x64Swizzle = Sm70_s884<Operand_A_Swizzle_8x64<half>,
-                                           Transform_Default,
-                                           VoidOperand,
-                                           typename GetOperand<HMMA_884, OPERAND_B, uint4_t, kRowMajor, true>::Operand,
-                                           Transform_HMMA_SIMT_B,
-                                           typename GetOperand<HMMA_884, OPERAND_V, uint32_t, kColMajor, true>::Operand,
-                                           kRowMajor,
-                                           half,
-                                           raster_order,
-                                           -1>;
+template <Order raster_order>
+using Config_U4_d_A8x64Swizzle = Sm70_s884<
+    Operand_A_Swizzle_8x64<half>, Transform_Default, VoidOperand,
+    typename GetOperand<HMMA_884, OPERAND_B, uint4_t, kRowMajor, true>::Operand,
+    Transform_HMMA_SIMT_B,
+    typename GetOperand<HMMA_884, OPERAND_V, uint32_t, kColMajor,
+                        true>::Operand,
+    kRowMajor, half, raster_order, -1>;
 
-template<Order raster_order>
+template <Order raster_order>
 using Config_U4_g = Sm70_s884<Operand_A<half>,           // A
                               Transform_Default,         // tarnsform A
                               VoidOperand,               // U
@@ -146,10 +106,9 @@ using Config_U4_g = Sm70_s884<Operand_A<half>,           // A
                               Operand_V_Pack<uint32_t>,  // V
                               kRowMajor,                 // order_C
                               half,                      // Tc
-                              raster_order,
-                              0>;
+                              raster_order, 0>;
 
-template<Order raster_order, int group_axis = -1>
+template <Order raster_order, int group_axis = -1>
 using Config_MXF4 = Sm70_s884<Operand_A<half>,             // A
                               Transform_Default,           // tarnsform A
                               VoidOperand,                 // U
@@ -158,10 +117,9 @@ using Config_MXF4 = Sm70_s884<Operand_A<half>,             // A
                               Operand_V_Pack<uint8_t>,     // V
                               kRowMajor,                   // order_C
                               half,                        // Tc
-                              raster_order,
-                              group_axis>;
+                              raster_order, group_axis>;
 
-template<Order raster_order, int group_axis = -1>
+template <Order raster_order, int group_axis = -1>
 using Config_NVF4 = Sm70_s884<Operand_A<half>,             // A
                               Transform_Default,           // tarnsform A
                               VoidOperand,                 // U
@@ -170,10 +128,9 @@ using Config_NVF4 = Sm70_s884<Operand_A<half>,             // A
                               Operand_V_Pack<uint16_t>,    // V
                               kRowMajor,                   // order_C
                               half,                        // Tc
-                              raster_order,
-                              group_axis>;
+                              raster_order, group_axis>;
 
-template<Order raster_order, int group_axis = -1>
+template <Order raster_order, int group_axis = -1>
 using Config_E4M3 = Sm70_s884<Operand_A<half>,             // A
                               Transform_Default,           // tarnsform A
                               VoidOperand,                 // U
@@ -182,22 +139,21 @@ using Config_E4M3 = Sm70_s884<Operand_A<half>,             // A
                               Operand_V_Pack<uint16_t>,    // V
                               kRowMajor,                   // order_C
                               half,                        // Tc
-                              raster_order,
-                              group_axis>;
+                              raster_order, group_axis>;
 
-template<Order raster_order, int group_axis = -1>
-using Config_E4M3_Prescaled = Sm70_s884<Operand_A<half>,             // A
-                                        Transform_Default,           // transform A
-                                        VoidOperand,                 // U
-                                        Operand_B_Pack<fp8_e4m3_t>,  // B
-                                        Transform_HMMA_SIMT_B_PrescaledE4M3,
-                                        Operand_V_Pack<uint16_t>,  // pre-scaled V
-                                        kRowMajor,                 // order_C
-                                        half,                      // Tc
-                                        raster_order,
-                                        group_axis>;
+template <Order raster_order, int group_axis = -1>
+using Config_E4M3_Prescaled =
+    Sm70_s884<Operand_A<half>,             // A
+              Transform_Default,           // transform A
+              VoidOperand,                 // U
+              Operand_B_Pack<fp8_e4m3_t>,  // B
+              Transform_HMMA_SIMT_B_PrescaledE4M3,
+              Operand_V_Pack<uint16_t>,  // pre-scaled V
+              kRowMajor,                 // order_C
+              half,                      // Tc
+              raster_order, group_axis>;
 
-template<Order raster_order, int group_axis = -1>
+template <Order raster_order, int group_axis = -1>
 using Config_F16 = Sm70_s884<Operand_A<half>,       // A
                              Transform_Default,     // tarnsform A
                              VoidOperand,           // U
@@ -206,7 +162,6 @@ using Config_F16 = Sm70_s884<Operand_A<half>,       // A
                              VoidOperand,           // V
                              kRowMajor,             // order_C
                              half,                  // Tc
-                             raster_order,
-                             group_axis>;
+                             raster_order, group_axis>;
 
 }  // namespace turbomind::gemm::sm70_s884

--- a/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/gemm.cu
+++ b/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/gemm.cu
@@ -248,6 +248,17 @@ std::optional<Sm70AwqTp2FastTarget> GetSm70Mxfp4MoeGroupedM8FastTarget(
   return std::nullopt;
 }
 
+std::optional<Sm70AwqTp2FastTarget>
+GetSm70Fp8BlockPrefillPrescaledTarget(const GemmDesc& desc) {
+  const std::string desc_str = to_string(desc);
+  if (desc_str == "sm70_f16_e4m3k128_f16_tnt_fff_8000x4096x5120_1" ||
+      desc_str == "sm70_f16_e4m3k128_f16_tnt_fff_8000x3584x5120_1") {
+    return Sm70AwqTp2FastTarget{
+        desc.n, desc.k, 64, 256, 16, 1, 3, true, "sm70_fp8_pscale_full"};
+  }
+  return std::nullopt;
+}
+
 bool MatchesSm70AwqTp2FastKernel(const Kernel& kernel,
                                  const Sm70AwqTp2FastTarget& target) {
   const int3 cta = kernel.cta_tile_size();
@@ -313,12 +324,14 @@ std::optional<LaunchSpec> SelectSm70AwqTp2FastSpec(
 const char* ToString(DispatchPolicy policy) {
   if ((policy & DispatchPolicy::kPreserveDefaultSplits) ||
       (policy & DispatchPolicy::kPreserveDefaultSplitCount) ||
-      (policy & DispatchPolicy::kMxfp4MoeGroupedM8Fast)) {
+      (policy & DispatchPolicy::kMxfp4MoeGroupedM8Fast) ||
+      (policy & DispatchPolicy::kSm70Fp8PrefillPrescaled)) {
     static thread_local std::string text;
     auto base = static_cast<DispatchPolicy>(
         (int)policy & ~(int)DispatchPolicy::kPreserveDefaultSplits &
         ~(int)DispatchPolicy::kPreserveDefaultSplitCount &
-        ~(int)DispatchPolicy::kMxfp4MoeGroupedM8Fast);
+        ~(int)DispatchPolicy::kMxfp4MoeGroupedM8Fast &
+        ~(int)DispatchPolicy::kSm70Fp8PrefillPrescaled);
     text = std::string(ToString(base));
     if (policy & DispatchPolicy::kPreserveDefaultSplits) {
       text += "|preserve_default_splits";
@@ -328,6 +341,9 @@ const char* ToString(DispatchPolicy policy) {
     }
     if (policy & DispatchPolicy::kMxfp4MoeGroupedM8Fast) {
       text += "|mxfp4_moe_grouped_m8_fast";
+    }
+    if (policy & DispatchPolicy::kSm70Fp8PrefillPrescaled) {
+      text += "|sm70_fp8_prefill_prescaled";
     }
     return text.c_str();
   }
@@ -370,7 +386,9 @@ void MaybeTraceGemmDispatch(const GemmDesc& desc, DispatchPolicy policy,
               << " swizzle=" << spec.swizzle << " cta=" << cta.x << "x" << cta.y
               << "x" << cta.z << " mma=" << mma.x << "x" << mma.y << "x"
               << mma.z << " stages=" << spec.kernel->stages()
-              << " smem=" << spec.kernel->smem_size();
+              << " smem=" << spec.kernel->smem_size()
+              << " regs=" << spec.kernel->info().attr.numRegs
+              << " max_ctas=" << spec.kernel->info().max_active_ctas;
   } else {
     std::cerr << " kernel=<none>";
   }
@@ -384,7 +402,8 @@ struct Gemm::Impl {
       : props_{GetCudaDeviceProps()},
         arch_{props_->major * 100 + props_->minor * 10},
         registry_{props_},
-        cache_{registry_.kernels()} {
+        cache_{registry_.kernels()},
+        sm70_fp8_prefill_cache_{registry_.kernels()} {
     if (arch_ == 700) {
       // V100 decode is dominated by many tiny GEMM/GEMV problems. A
       // broader search space consistently finds better launch specs than
@@ -422,6 +441,21 @@ struct Gemm::Impl {
       return spec.kernel &&
              spec.kernel->is_feasible(ctx.get_desc(*spec.kernel));
     };
+    if (policy & DispatchPolicy::kSm70Fp8PrefillPrescaled) {
+      if (auto spec = sm70_fp8_prefill_cache_.Find(desc);
+          spec && is_feasible(*spec)) {
+        return *spec;
+      }
+      if (auto fast_target = GetSm70Fp8BlockPrefillPrescaledTarget(desc)) {
+        auto specs = Find(ctx, barriers_size, partials_size, 0);
+        if (auto fast_spec = SelectSm70AwqTp2FastSpec(
+                ctx, specs, *fast_target, barriers_size, partials_size)) {
+          sm70_fp8_prefill_cache_.Insert(desc, *fast_spec);
+          return *fast_spec;
+        }
+      }
+      return {};
+    }
     if (policy & DispatchPolicy::kMxfp4MoeGroupedM8Fast) {
       if (auto fast_target = GetSm70Mxfp4MoeGroupedM8FastTarget(desc)) {
         auto specs = Find(ctx, barriers_size, partials_size, 0);
@@ -611,6 +645,8 @@ struct Gemm::Impl {
   std::optional<Measurer> measurer_;
 
   DispatchCache cache_;
+
+  DispatchCache sm70_fp8_prefill_cache_;
 
   std::mutex dispatch_mutex_;
 };

--- a/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/gemm.cu
+++ b/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/gemm.cu
@@ -90,6 +90,12 @@ bool Sm70Nvfp4Qwen38Tp4M1FastSelectorEnabled() {
   return !raw || std::atoi(raw) != 0;
 }
 
+// Default-on gate for exact block-FP8 8K prefill GEMM descriptors.
+bool Sm70Fp8BlockPrefillFastSelectorEnabled() {
+  const char* raw = std::getenv("VLLM_SM70_FP8_PREFILL_FAST_SELECTOR");
+  return !raw || std::atoi(raw) != 0;
+}
+
 struct Sm70AwqTp2FastTarget {
   int n;
   int k;
@@ -172,6 +178,11 @@ std::optional<Sm70AwqTp2FastTarget> GetSm70AwqTp2FastTarget(
       return Sm70AwqTp2FastTarget{
           desc.n, desc.k, 8, 32, 64, 3, 4, true, "c8x32_a1x1x64_01"};
     }
+  }
+  if (Sm70Fp8BlockPrefillFastSelectorEnabled() &&
+      (desc_str == "sm70_f16_e4m3k128_f16_tnt_fff_8000x4096x5120_1" ||
+       desc_str == "sm70_f16_e4m3k128_f16_tnt_fff_8000x3584x5120_1")) {
+    return Sm70AwqTp2FastTarget{desc.n, desc.k, 64, 256, 16, 1, 3, true, ""};
   }
   const bool awq_fast_selector_enabled = Sm70AwqTp2FastSelectorEnabled();
   if (awq_fast_selector_enabled) {

--- a/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/gemm.cu
+++ b/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/gemm.cu
@@ -248,8 +248,8 @@ std::optional<Sm70AwqTp2FastTarget> GetSm70Mxfp4MoeGroupedM8FastTarget(
   return std::nullopt;
 }
 
-std::optional<Sm70AwqTp2FastTarget>
-GetSm70Fp8BlockPrefillPrescaledTarget(const GemmDesc& desc) {
+std::optional<Sm70AwqTp2FastTarget> GetSm70Fp8BlockPrefillPrescaledTarget(
+    const GemmDesc& desc) {
   const std::string desc_str = to_string(desc);
   if (desc_str == "sm70_f16_e4m3k128_f16_tnt_fff_8000x4096x5120_1" ||
       desc_str == "sm70_f16_e4m3k128_f16_tnt_fff_8000x3584x5120_1") {

--- a/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/iterator_sm70.h
+++ b/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/iterator_sm70.h
@@ -274,4 +274,13 @@ struct IteratorSm70 {
     using Type = GmemIteratorSm70<T, Map, SmemLayout, kPack, kOrder, AlignedC, AlignedS, mode, Policy>;
 };
 
+// Exact-shape kernels may promise that every CTA covers a complete M/N/K tile.
+// Keep ThreadMap's intrinsic bounds (for example the one-row scale tile), but
+// remove runtime edge predicates from otherwise aligned A/B tiles.
+template<Striding mode, class Policy>
+struct IteratorSm70FullTile {
+    template<class T, class Map, class SmemLayout, Pack kPack, Order kOrder, bool, bool>
+    using Type = GmemIteratorSm70<T, Map, SmemLayout, kPack, kOrder, true, true, mode, Policy>;
+};
+
 }  // namespace turbomind::gemm

--- a/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/iterator_sm70.h
+++ b/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/iterator_sm70.h
@@ -16,271 +16,256 @@
 
 namespace turbomind::gemm {
 
-template<typename T, int N>
-inline __device__ void _Ld(Array<T, N>& dst, const T* src)
-{
-    static_assert(sizeof(Array<T, N>) <= sizeof(uint4));
+template <typename T, int N>
+inline __device__ void _Ld(Array<T, N>& dst, const T* src) {
+  static_assert(sizeof(Array<T, N>) <= sizeof(uint4));
 
-    if constexpr (sizeof(Array<T, N>) == sizeof(uint4)) {
-        (uint4&)dst = __ldcs((const uint4*)src);
-    }
-    else if constexpr (sizeof(Array<T, N>) == sizeof(uint2)) {
-        (uint2&)dst = __ldcs((const uint2*)src);
-    }
-    else if constexpr (sizeof(Array<T, N>) == sizeof(uint)) {
-        (uint&)dst = __ldcs((const uint*)src);
-    }
-    else {
-        static_assert(!std::is_same_v<T, T>);
-    }
+  if constexpr (sizeof(Array<T, N>) == sizeof(uint4)) {
+    (uint4&)dst = __ldcs((const uint4*)src);
+  } else if constexpr (sizeof(Array<T, N>) == sizeof(uint2)) {
+    (uint2&)dst = __ldcs((const uint2*)src);
+  } else if constexpr (sizeof(Array<T, N>) == sizeof(uint)) {
+    (uint&)dst = __ldcs((const uint*)src);
+  } else {
+    static_assert(!std::is_same_v<T, T>);
+  }
 }
 
-template<class T,
-         class Map,
-         class SmemLayout,
-         Pack     kPack,
-         Order    kOrder,
-         bool     AlignedC,
-         bool     AlignedS,
-         Striding mode,
-         class Policy_>
+template <class T, class Map, class SmemLayout, Pack kPack, Order kOrder,
+          bool AlignedC, bool AlignedS, Striding mode, class Policy_>
 struct GmemIteratorSm70 {
+  using ThreadMap = Map;
 
-    using ThreadMap = Map;
+  using AccessType = Array<T, Map::kAccessC>;
+  using Pointer = get_pointer_type<T>;
 
-    using AccessType = Array<T, Map::kAccessC>;
-    using Pointer    = get_pointer_type<T>;
+  using Policy = Policy_;
 
-    using Policy = Policy_;
+  static constexpr int ITER_S = Map::kIterS;
+  static constexpr int ITER_C = Map::kIterC;
 
-    static constexpr int ITER_S = Map::kIterS;
-    static constexpr int ITER_C = Map::kIterC;
+  static constexpr Striding kMode = mode;
+  static constexpr bool is_indexed = mode == Striding::kIndexed;
 
-    static constexpr Striding kMode      = mode;
-    static constexpr bool     is_indexed = mode == Striding::kIndexed;
+  const char* src_data_;
 
-    const char* src_data_;
+  int src_offset_;
+  int dst_offset_;
 
-    int src_offset_;
-    int dst_offset_;
+  int offset_c_;
+  int offset_s_;
 
-    int offset_c_;
-    int offset_s_;
+  int src_step_c_;
+  int src_step_s_;
 
-    int src_step_c_;
-    int src_step_s_;
+  int src_step_k_;
 
-    int src_step_k_;
+  Predicate<Map::kIterS, Map::kIterC, (AlignedC && Map::kAlignedC),
+            (AlignedS && Map::kAlignedS)>
+      pred_;
 
-    Predicate<Map::kIterS, Map::kIterC, (AlignedC && Map::kAlignedC), (AlignedS && Map::kAlignedS)> pred_;
+  bool g_mask{true};
 
-    bool g_mask{true};
+  SmemAccessor<T, SmemLayout> smem_data_;
 
-    SmemAccessor<T, SmemLayout> smem_data_;
+  static constexpr int2 kMK0 = cs2mk<kOrder>(SmemLayout::C0, SmemLayout::S0);
+  static constexpr int kPeriodC = ceil_div(SmemLayout::C0, Map::kDeltaC);
+  static constexpr int kPeriodS = ceil_div(SmemLayout::S0, Map::kDeltaS);
 
-    static constexpr int2 kMK0     = cs2mk<kOrder>(SmemLayout::C0, SmemLayout::S0);
-    static constexpr int  kPeriodC = ceil_div(SmemLayout::C0, Map::kDeltaC);
-    static constexpr int  kPeriodS = ceil_div(SmemLayout::S0, Map::kDeltaS);
+  int phases_[kPeriodS][kPeriodC];
 
-    int phases_[kPeriodS][kPeriodC];
+  const char* src_data_vec_[ITER_S];
 
-    const char* src_data_vec_[ITER_S];
+  using Fragments = AccessType[Map::kIterS][Map::kIterC];
 
-    using Fragments = AccessType[Map::kIterS][Map::kIterC];
+  __device__ static constexpr int2 pack(int2 mk) {
+    return Packing_v2<kPack, kOrder>::apply(mk);
+  }
 
-    __device__ static constexpr int2 pack(int2 mk)
-    {
-        return Packing_v2<kPack, kOrder>::apply(mk);
-    }
+  __device__ static constexpr int2 to_cs(int2 mk) {
+    return mk2cs<kOrder>(mk.x, mk.y);
+  }
 
-    __device__ static constexpr int2 to_cs(int2 mk)
-    {
-        return mk2cs<kOrder>(mk.x, mk.y);
-    }
+  __device__ GmemIteratorSm70() : smem_data_{Pointer{nullptr}} {};
 
-    __device__ GmemIteratorSm70(): smem_data_{Pointer{nullptr}} {};
+  __device__ GmemIteratorSm70(const MatrixData& mat, int2 offset, int2 extent)
+      : smem_data_{Pointer{(T*)nullptr}} {
+    const int warp_id = threadIdx.x / WARP_SIZE;
+    const int lane_id = threadIdx.x % WARP_SIZE;
 
-    __device__ GmemIteratorSm70(const MatrixData& mat, int2 offset, int2 extent): smem_data_{Pointer{(T*)nullptr}}
-    {
-        const int warp_id = threadIdx.x / WARP_SIZE;
-        const int lane_id = threadIdx.x % WARP_SIZE;
+    const Pointer data{(T*)mat.ptr.ptr};
+    const int ld = mat.ptr.stride;
 
-        const Pointer data{(T*)mat.ptr.ptr};
-        const int     ld = mat.ptr.stride;
+    const int2 offsets = Map::get_offset(warp_id, lane_id);
 
-        const int2 offsets = Map::get_offset(warp_id, lane_id);
+    offset_c_ = offsets.x;
+    offset_s_ = offsets.y;
 
-        offset_c_ = offsets.x;
-        offset_s_ = offsets.y;
+    // auto src_ptr = reinterpret_cast<const char*>((T*)data);
 
-        // auto src_ptr = reinterpret_cast<const char*>((T*)data);
-
-        if constexpr (pred_.is_active) {
-            extent = to_cs(pack(extent));
-            PRAGMA_UNROLL
-            for (int s = 0; s < Map::kIterS; ++s) {
-                PRAGMA_UNROLL
-                for (int c = 0; c < Map::kIterC; ++c) {
-                    int ss = offset_s_ + s * Map::kDeltaS;
-                    int cc = offset_c_ + c * Map::kDeltaC;
-                    if (ss < extent.y && cc < extent.x) {
-                        pred_.set(s, c);
-                    }
-                }
-            }
-        }
-
+    if constexpr (pred_.is_active) {
+      extent = to_cs(pack(extent));
+      PRAGMA_UNROLL
+      for (int s = 0; s < Map::kIterS; ++s) {
         PRAGMA_UNROLL
-        for (int s = 0; s < kPeriodS; ++s) {
-            PRAGMA_UNROLL
-            for (int c = 0; c < kPeriodC; ++c) {
-                phases_[s][c] = SmemLayout::apply(offset_s_ + s * Map::kDeltaS, offset_c_ + c * Map::kDeltaC);
-            }
+        for (int c = 0; c < Map::kIterC; ++c) {
+          int ss = offset_s_ + s * Map::kDeltaS;
+          int cc = offset_c_ + c * Map::kDeltaC;
+          if (ss < extent.y && cc < extent.x) {
+            pred_.set(s, c);
+          }
         }
-
-        const int src_offset = is_indexed ? offsets.x : offsets.x + offsets.y * ld;
-
-        src_offset_ = src_offset * bitsof<T> / bitsof<char>;
-
-        src_step_c_ = bitsof<T> * Map::kDeltaC / bitsof<char>;
-        src_step_s_ = bitsof<T> * Map::kDeltaS * ld / bitsof<char>;
-
-        src_step_k_ = bitsof<T> * cs2mk<kOrder>(Map::kDimC, Map::kDimS * ld).y / bitsof<char>;
-
-        // initialize for the first tile
-        if constexpr (is_indexed) {
-            const int2 cta_cs = to_cs(offset);
-            for (int s = 0; s < ITER_S; ++s) {
-                const int  ss    = cta_cs.y + offset_s_ + s * Map::kDeltaS;
-                const int  idx   = (mat.idxs && pred_(s, 0)) ? __ldg(mat.idxs + ss) : ss;
-                const auto tmp   = data + cs2idx({cta_cs.x, idx}, ld);
-                src_data_vec_[s] = reinterpret_cast<const char*>((T*)tmp) + src_offset_;
-            }
-        }
-        else {
-            auto src_data = data + cs2idx(to_cs(pack(offset)), ld);
-            src_data_     = reinterpret_cast<const char*>((T*)src_data) + src_offset_;
-        }
+      }
     }
 
-    __device__ constexpr int _src_step_k() const
-    {
-        return src_step_k_;
+    PRAGMA_UNROLL
+    for (int s = 0; s < kPeriodS; ++s) {
+      PRAGMA_UNROLL
+      for (int c = 0; c < kPeriodC; ++c) {
+        phases_[s][c] = SmemLayout::apply(offset_s_ + s * Map::kDeltaS,
+                                          offset_c_ + c * Map::kDeltaC);
+      }
     }
 
-    __device__ void ClearSmem(int pipe_iter = 0)
-    {
-        PRAGMA_UNROLL
-        for (int s = 0; s < Map::kIterS; ++s) {
-            PRAGMA_UNROLL
-            for (int c = 0; c < Map::kIterC; ++c) {
-                const int pred_s = offset_s_ + s * Map::kDeltaS < Map::kDimS;
-                const int pred_c = offset_c_ + c * Map::kDeltaC < Map::kDimC;
-                auto      ptr    = &smem_data_(offset_s_ + s * Map::kDeltaS, offset_c_ + c * Map::kDeltaC);
-                if ((Map::kAlignedC && Map::kAlignedS) || (pred_s && pred_c)) {
-                    turbomind::Store(ptr, Array<T, Map::kAccessC>{});
-                }
-            }
+    const int src_offset = is_indexed ? offsets.x : offsets.x + offsets.y * ld;
+
+    src_offset_ = src_offset * bitsof<T> / bitsof<char>;
+
+    src_step_c_ = bitsof<T> * Map::kDeltaC / bitsof<char>;
+    src_step_s_ = bitsof<T> * Map::kDeltaS * ld / bitsof<char>;
+
+    src_step_k_ =
+        bitsof<T> * cs2mk<kOrder>(Map::kDimC, Map::kDimS * ld).y / bitsof<char>;
+
+    // initialize for the first tile
+    if constexpr (is_indexed) {
+      const int2 cta_cs = to_cs(offset);
+      for (int s = 0; s < ITER_S; ++s) {
+        const int ss = cta_cs.y + offset_s_ + s * Map::kDeltaS;
+        const int idx = (mat.idxs && pred_(s, 0)) ? __ldg(mat.idxs + ss) : ss;
+        const auto tmp = data + cs2idx({cta_cs.x, idx}, ld);
+        src_data_vec_[s] = reinterpret_cast<const char*>((T*)tmp) + src_offset_;
+      }
+    } else {
+      auto src_data = data + cs2idx(to_cs(pack(offset)), ld);
+      src_data_ = reinterpret_cast<const char*>((T*)src_data) + src_offset_;
+    }
+  }
+
+  __device__ constexpr int _src_step_k() const { return src_step_k_; }
+
+  __device__ void ClearSmem(int pipe_iter = 0) {
+    PRAGMA_UNROLL
+    for (int s = 0; s < Map::kIterS; ++s) {
+      PRAGMA_UNROLL
+      for (int c = 0; c < Map::kIterC; ++c) {
+        const int pred_s = offset_s_ + s * Map::kDeltaS < Map::kDimS;
+        const int pred_c = offset_c_ + c * Map::kDeltaC < Map::kDimC;
+        auto ptr = &smem_data_(offset_s_ + s * Map::kDeltaS,
+                               offset_c_ + c * Map::kDeltaC);
+        if ((Map::kAlignedC && Map::kAlignedS) || (pred_s && pred_c)) {
+          turbomind::Store(ptr, Array<T, Map::kAccessC>{});
         }
+      }
     }
+  }
 
-    __device__ void Advance()
-    {
-        if constexpr (!is_indexed) {
-            if (!g_mask) {
-                src_data_ -= _src_step_k();
-            }
+  __device__ void Advance() {
+    if constexpr (!is_indexed) {
+      if (!g_mask) {
+        src_data_ -= _src_step_k();
+      }
+    }
+  }
+
+  __device__ void Copy(std::true_type, T* dst, const char* __restrict__ src,
+                       bool mask) {
+    if (mask) {
+      AccessType frag;
+      if constexpr (Policy_::kEvictPolicy != EvictPolicy::kEvictNormal) {
+        _Ld(frag, (const T*)src);
+      } else {
+        Ldg(frag, (const T*)src);
+      }
+      turbomind::Store(dst, frag);
+    }
+  }
+
+  __device__ void Fetch(Fragments& frags, bool tile_mask) {
+    PRAGMA_UNROLL
+    for (int s = 0; s < Map::kIterS; ++s) {
+      if constexpr (is_indexed) {
+        src_data_ = src_data_vec_[s];
+      }
+
+      PRAGMA_UNROLL
+      for (int c = 0; c < Map::kIterC; ++c) {
+        Copy2(frags[s][c], src_data_ + src_step_c_ * c,
+              tile_mask && g_mask && pred_(s, c));
+      }
+
+      if constexpr (is_indexed) {
+        src_data_vec_[s] += _src_step_k();
+      } else {
+        src_data_ += src_step_s_;
+        if (s == Map::kIterS - 1) {
+          src_data_ -= src_step_s_ * Map::kIterS;
+          src_data_ += _src_step_k();
         }
+      }
     }
+  }
 
-    __device__ void Copy(std::true_type, T* dst, const char* __restrict__ src, bool mask)
-    {
-        if (mask) {
-            AccessType frag;
-            if constexpr (Policy_::kEvictPolicy != EvictPolicy::kEvictNormal) {
-                _Ld(frag, (const T*)src);
-            }
-            else {
-                Ldg(frag, (const T*)src);
-            }
-            turbomind::Store(dst, frag);
+  __device__ void Store(Fragments& frags) {
+    PRAGMA_UNROLL
+    for (int s = 0; s < Map::kIterS; ++s) {
+      PRAGMA_UNROLL
+      for (int c = 0; c < Map::kIterC; ++c) {
+        // auto dst = &smem_data_(offset_s_ + s * Map::kDeltaS, offset_c_ + c *
+        // Map::kDeltaC);
+
+        const int i0 = SmemLayout::apply(  //
+            s / kPeriodS * kPeriodS * Map::kDeltaS,
+            c / kPeriodC * kPeriodC * Map::kDeltaC);
+        const int i1 = phases_[s % kPeriodS][c % kPeriodC];
+        auto dst = &smem_data_.ptr_[i0 + i1];
+
+        if (pred_(s, c)) {
+          turbomind::Store(dst, frags[s][c]);
         }
+      }
     }
+  }
 
-    __device__ void Fetch(Fragments& frags, bool tile_mask)
-    {
-        PRAGMA_UNROLL
-        for (int s = 0; s < Map::kIterS; ++s) {
-
-            if constexpr (is_indexed) {
-                src_data_ = src_data_vec_[s];
-            }
-
-            PRAGMA_UNROLL
-            for (int c = 0; c < Map::kIterC; ++c) {
-                Copy2(frags[s][c], src_data_ + src_step_c_ * c, tile_mask && g_mask && pred_(s, c));
-            }
-
-            if constexpr (is_indexed) {
-                src_data_vec_[s] += _src_step_k();
-            }
-            else {
-                src_data_ += src_step_s_;
-                if (s == Map::kIterS - 1) {
-                    src_data_ -= src_step_s_ * Map::kIterS;
-                    src_data_ += _src_step_k();
-                }
-            }
-        }
+  __device__ void Copy2(AccessType& frag, const char* __restrict__ src,
+                        bool mask) {
+    if (mask) {
+      if constexpr (Policy_::kEvictPolicy != EvictPolicy::kEvictNormal) {
+        _Ld(frag, (const T*)src);
+      } else {
+        Ldg(frag, (const T*)src);
+      }
     }
-
-    __device__ void Store(Fragments& frags)
-    {
-        PRAGMA_UNROLL
-        for (int s = 0; s < Map::kIterS; ++s) {
-            PRAGMA_UNROLL
-            for (int c = 0; c < Map::kIterC; ++c) {
-                // auto dst = &smem_data_(offset_s_ + s * Map::kDeltaS, offset_c_ + c * Map::kDeltaC);
-
-                const int i0  = SmemLayout::apply(  //
-                    s / kPeriodS * kPeriodS * Map::kDeltaS,
-                    c / kPeriodC * kPeriodC * Map::kDeltaC);
-                const int i1  = phases_[s % kPeriodS][c % kPeriodC];
-                auto      dst = &smem_data_.ptr_[i0 + i1];
-
-                if (pred_(s, c)) {
-                    turbomind::Store(dst, frags[s][c]);
-                }
-            }
-        }
-    }
-
-    __device__ void Copy2(AccessType& frag, const char* __restrict__ src, bool mask)
-    {
-        if (mask) {
-            if constexpr (Policy_::kEvictPolicy != EvictPolicy::kEvictNormal) {
-                _Ld(frag, (const T*)src);
-            }
-            else {
-                Ldg(frag, (const T*)src);
-            }
-        }
-    }
+  }
 };
 
-template<Striding mode, class Policy>
+template <Striding mode, class Policy>
 struct IteratorSm70 {
-    template<class T, class Map, class SmemLayout, Pack kPack, Order kOrder, bool AlignedC, bool AlignedS>
-    using Type = GmemIteratorSm70<T, Map, SmemLayout, kPack, kOrder, AlignedC, AlignedS, mode, Policy>;
+  template <class T, class Map, class SmemLayout, Pack kPack, Order kOrder,
+            bool AlignedC, bool AlignedS>
+  using Type = GmemIteratorSm70<T, Map, SmemLayout, kPack, kOrder, AlignedC,
+                                AlignedS, mode, Policy>;
 };
 
 // Exact-shape kernels may promise that every CTA covers a complete M/N/K tile.
 // Keep ThreadMap's intrinsic bounds (for example the one-row scale tile), but
 // remove runtime edge predicates from otherwise aligned A/B tiles.
-template<Striding mode, class Policy>
+template <Striding mode, class Policy>
 struct IteratorSm70FullTile {
-    template<class T, class Map, class SmemLayout, Pack kPack, Order kOrder, bool, bool>
-    using Type = GmemIteratorSm70<T, Map, SmemLayout, kPack, kOrder, true, true, mode, Policy>;
+  template <class T, class Map, class SmemLayout, Pack kPack, Order kOrder,
+            bool, bool>
+  using Type = GmemIteratorSm70<T, Map, SmemLayout, kPack, kOrder, true, true,
+                                mode, Policy>;
 };
 
 }  // namespace turbomind::gemm

--- a/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/kernel/sm70_884_8.cu
+++ b/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/kernel/sm70_884_8.cu
@@ -13,27 +13,25 @@ using D = cache_policy::Default;
 
 namespace {
 
-template<class Gemm>
-class Qwen38PrescaledFullTileKernelImpl final: public KernelImpl<Gemm> {
-public:
-    Qwen38PrescaledFullTileKernelImpl()
-    {
-        this->info_.name += "_sm70_fp8_pscale_full";
-    }
+template <class Gemm>
+class Qwen38PrescaledFullTileKernelImpl final : public KernelImpl<Gemm> {
+ public:
+  Qwen38PrescaledFullTileKernelImpl() {
+    this->info_.name += "_sm70_fp8_pscale_full";
+  }
 
-    bool is_feasible(const GemmDesc& desc) const noexcept override
-    {
-        return desc.m == 8000 && (desc.n == 4096 || desc.n == 3584) && desc.k == 5120 && desc.num == 1
-               && KernelImpl<Gemm>::is_feasible(desc);
-    }
+  bool is_feasible(const GemmDesc& desc) const noexcept override {
+    return desc.m == 8000 && (desc.n == 4096 || desc.n == 3584) &&
+           desc.k == 5120 && desc.num == 1 &&
+           KernelImpl<Gemm>::is_feasible(desc);
+  }
 };
 
 }  // namespace
 
-void Registry::sm70_884_8()
-{
-    if constexpr (1) {
-        // clang-format off
+void Registry::sm70_884_8() {
+  if constexpr (1) {
+    // clang-format off
         using C = Config_E4M3<kColMajor, 0>;
         Add<C::Type<128, 256,  16, 2, 4, 1, D, D, 2, true, 1, 128, 128, 128>>();
         Add<C::Type<128, 128,  16, 2, 2, 1, D, D, 2, true, 1, 128,  64, 128>>();
@@ -52,8 +50,8 @@ void Registry::sm70_884_8()
         using CP = Config_E4M3_Prescaled<kColMajor, 0>;
         using Q38PrescaledFull = CP::Type<64, 256, 16, 1, 4, 1, D, S, 2, true, 1, 128, 64, 128, 1, true>;
         Add(std::make_unique<Qwen38PrescaledFullTileKernelImpl<typename Q38PrescaledFull::Kernel>>());
-        // clang-format on
-    }
+    // clang-format on
+  }
 }
 
 }  // namespace turbomind::gemm

--- a/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/kernel/sm70_884_8.cu
+++ b/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/kernel/sm70_884_8.cu
@@ -11,6 +11,25 @@ using namespace cache_policy;
 using S = cache_policy::Stream;
 using D = cache_policy::Default;
 
+namespace {
+
+template<class Gemm>
+class Qwen38PrescaledFullTileKernelImpl final: public KernelImpl<Gemm> {
+public:
+    Qwen38PrescaledFullTileKernelImpl()
+    {
+        this->info_.name += "_sm70_fp8_pscale_full";
+    }
+
+    bool is_feasible(const GemmDesc& desc) const noexcept override
+    {
+        return desc.m == 8000 && (desc.n == 4096 || desc.n == 3584) && desc.k == 5120 && desc.num == 1
+               && KernelImpl<Gemm>::is_feasible(desc);
+    }
+};
+
+}  // namespace
+
 void Registry::sm70_884_8()
 {
     if constexpr (1) {
@@ -29,6 +48,10 @@ void Registry::sm70_884_8()
         Add<C::Type<  8, 128,  32, 1, 4, 1, D, S, 2, true, 1, 128>>();
         Add<C::Type<  8, 256,  64, 1, 4, 1, D, S, 2, true, 1, 128>>();
         Add<C::Type<  8, 256,  32, 1, 4, 1, D, S, 2, true, 1, 128>>();
+
+        using CP = Config_E4M3_Prescaled<kColMajor, 0>;
+        using Q38PrescaledFull = CP::Type<64, 256, 16, 1, 4, 1, D, S, 2, true, 1, 128, 64, 128, 1, true>;
+        Add(std::make_unique<Qwen38PrescaledFullTileKernelImpl<typename Q38PrescaledFull::Kernel>>());
         // clang-format on
     }
 }

--- a/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/transform.h
+++ b/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/transform.h
@@ -156,4 +156,41 @@ struct Transform_HMMA_SIMT_B {
     }
 };
 
+// FP8 scales that have absorbed the E4M3 exponent-bias factor (256) during
+// one-time weight preparation.
+struct Transform_HMMA_SIMT_B_PrescaledE4M3 {
+    template<class F, int Nf, int Mf, int K, class D, int Nd, int Md, class S, int Ns, int Ms, int Ks>
+    __device__ static void
+    apply(Array<F, Nf> (&frag)[K][Mf], int k, Array<D, Nd> (&data)[K][Md], Array<S, Ns> (&stat)[Ks][Ms], int div)
+    {
+        static_assert(std::is_same_v<D, fp8_e4m3_t>);
+        static_assert(std::is_same_v<F, half>);
+        static_assert(std::is_same_v<S, uint16_t>);
+        static_assert(Nf * Mf == Nd * Md);
+        static_assert(Nd % Nf == 0 && Mf % Md == 0);
+        static_assert(Nd % 4 == 0);
+
+        auto& frag_k = reinterpret_cast<Array<F, Nd>(&)[Md]>(frag[k]);
+        auto& stat_k = reinterpret_cast<Array<S, 1>(&)[Ns * Ms]>(stat[k / div]);
+        auto& data_k = data[k];
+
+        PRAGMA_UNROLL
+        for (int m = 0; m < Md; ++m) {
+            Array<F, Nd> tmp;
+            PRAGMA_UNROLL
+            for (int i = 0; i < Nd; i += 4) {
+                auto& src = reinterpret_cast<Array<fp8_e4m3_t, 4>&>(data_k[m][i]);
+                reinterpret_cast<Array<half, 4>&>(tmp[i]) = cvt_f16x4_e4m3<false>(src);
+            }
+            PRAGMA_UNROLL
+            for (int i = 0; i < Nd; i += 2) {
+                auto scale = __ushort_as_half(stat_k[(m * Nd + i) / Nf][0]);
+                tmp[i]     = __hmul(tmp[i], scale);
+                tmp[i + 1] = __hmul(tmp[i + 1], scale);
+            }
+            frag_k[m] = tmp;
+        }
+    }
+};
+
 }  // namespace turbomind::gemm

--- a/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/transform.h
+++ b/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/transform.h
@@ -13,184 +13,181 @@
 namespace turbomind::gemm {
 
 struct Transform_Default {
-    template<class T, int Nf, int Mf, int K, int Nd, int Md, class S>
-    __device__ static void apply(Array<T, Nf> (&frag)[K][Mf], int k, Array<T, Nd> (&data)[K][Md], S&, int div)
-    {
-        static_assert(Nf * Mf == Nd * Md);
-        static_assert(Nd % Nf == 0 && Mf % Md == 0);
-        static_assert(sizeof(frag) == sizeof(data));
+  template <class T, int Nf, int Mf, int K, int Nd, int Md, class S>
+  __device__ static void apply(Array<T, Nf> (&frag)[K][Mf], int k,
+                               Array<T, Nd> (&data)[K][Md], S&, int div) {
+    static_assert(Nf * Mf == Nd * Md);
+    static_assert(Nd % Nf == 0 && Mf % Md == 0);
+    static_assert(sizeof(frag) == sizeof(data));
 
-        // Alignment must be manually enforced for `reinterpret_cast`
-        auto& frag_k = reinterpret_cast<Array<T, Nd>(&)[Md]>(frag[k]);
-        auto& data_k = data[k];
+    // Alignment must be manually enforced for `reinterpret_cast`
+    auto& frag_k = reinterpret_cast<Array<T, Nd>(&)[Md]>(frag[k]);
+    auto& data_k = data[k];
 
-        PRAGMA_UNROLL
-        for (int i = 0; i < std::size(frag_k); ++i) {
-            frag_k[i] = data_k[i];
-        }
+    PRAGMA_UNROLL
+    for (int i = 0; i < std::size(frag_k); ++i) {
+      frag_k[i] = data_k[i];
     }
+  }
 };
 
-template<int StatStepS, int StatStepC>
+template <int StatStepS, int StatStepC>
 struct Transform_HMMA_16816 {
-    template<class F, int Nf, int Mf, int K, class D, int Nd, int Md, class S, int Ns, int Ms, int Ks>
-    __device__ static void
-    apply(Array<F, Nf> (&frag)[K][Mf], int k, Array<D, Nd> (&data)[K][Md], Array<S, Ns> (&stat)[Ks][Ms], int div)
-    {
-        static_assert(Nf * Mf == Nd * Md);
-        static_assert(Nd % Nf == 0 && Mf % Md == 0);
-        static_assert(Nf * Mf == Ns * Ms * 4);
+  template <class F, int Nf, int Mf, int K, class D, int Nd, int Md, class S,
+            int Ns, int Ms, int Ks>
+  __device__ static void apply(Array<F, Nf> (&frag)[K][Mf], int k,
+                               Array<D, Nd> (&data)[K][Md],
+                               Array<S, Ns> (&stat)[Ks][Ms], int div) {
+    static_assert(Nf * Mf == Nd * Md);
+    static_assert(Nd % Nf == 0 && Mf % Md == 0);
+    static_assert(Nf * Mf == Ns * Ms * 4);
 
-        auto& frag_k = reinterpret_cast<Array<F, Nd>(&)[Md]>(frag[k]);
-        auto& stat_k = reinterpret_cast<Array<S, 1>(&)[Ns * Ms]>(stat[k / div]);
-        auto& data_k = data[k];
+    auto& frag_k = reinterpret_cast<Array<F, Nd>(&)[Md]>(frag[k]);
+    auto& stat_k = reinterpret_cast<Array<S, 1>(&)[Ns * Ms]>(stat[k / div]);
+    auto& data_k = data[k];
 
+    PRAGMA_UNROLL
+    for (int m = 0; m < Md; ++m) {
+      auto tmp = ConvertKvCache<D, F>::convert(data_k[m]);
+      static_assert(Nd % 8 == 0);
+      PRAGMA_UNROLL
+      for (int i = 0; i < Nd; i += 8) {
         PRAGMA_UNROLL
-        for (int m = 0; m < Md; ++m) {
-            auto tmp = ConvertKvCache<D, F>::convert(data_k[m]);
-            static_assert(Nd % 8 == 0);
-            PRAGMA_UNROLL
-            for (int i = 0; i < Nd; i += 8) {
-                PRAGMA_UNROLL
-                for (int s = 0; s < 2; ++s) {
-                    PRAGMA_UNROLL
-                    for (int c = 0; c < 2; ++c) {
-                        const int idx = (m * Nd + i) / 8 * 2 + s * StatStepS + c * StatStepC;
-                        dequant((Array<F, 2>&)tmp[i + s * 4 + c * 2], stat_k[idx]);
-                    }
-                }
-            }
-
-            frag_k[m] = tmp;
+        for (int s = 0; s < 2; ++s) {
+          PRAGMA_UNROLL
+          for (int c = 0; c < 2; ++c) {
+            const int idx =
+                (m * Nd + i) / 8 * 2 + s * StatStepS + c * StatStepC;
+            dequant((Array<F, 2>&)tmp[i + s * 4 + c * 2], stat_k[idx]);
+          }
         }
-    }
+      }
 
-    template<class F>
-    __device__ static void dequant(Array<F, 2>& x, Array<uint32_t, 1> s)
-    {
-        Array<F, 2>& _s = (Array<F, 2>&)s;
-        x[0]            = __hfma(x[0], _s[0], _s[1]);
-        x[1]            = __hfma(x[1], _s[0], _s[1]);
+      frag_k[m] = tmp;
     }
+  }
 
-    __device__ static void dequant(Array<bfloat16_t, 2>& x, Array<uint8_t, 1> s)
-    {
-        bfloat16_t s1 = __ushort_as_bfloat16((uint16_t)s[0] << 7);
-        x[0]          = __hmul(x[0], s1);
-        x[1]          = __hmul(x[1], s1);
-    }
+  template <class F>
+  __device__ static void dequant(Array<F, 2>& x, Array<uint32_t, 1> s) {
+    Array<F, 2>& _s = (Array<F, 2>&)s;
+    x[0] = __hfma(x[0], _s[0], _s[1]);
+    x[1] = __hfma(x[1], _s[0], _s[1]);
+  }
 
-    __device__ static void dequant(Array<half_t, 2>& x, Array<uint8_t, 1> s)
-    {
-        // half_t s1 = __ushort_as_half(((uint16_t)s[0] + 15 - 127) << 10);
-        // Adjusted in `AdjustUe8m0ScaleForHalf`
-        half_t s1 = __ushort_as_half((uint16_t)s[0] << 10);
-        x[0]      = __hmul(x[0], s1);
-        x[1]      = __hmul(x[1], s1);
-    }
+  __device__ static void dequant(Array<bfloat16_t, 2>& x, Array<uint8_t, 1> s) {
+    bfloat16_t s1 = __ushort_as_bfloat16((uint16_t)s[0] << 7);
+    x[0] = __hmul(x[0], s1);
+    x[1] = __hmul(x[1], s1);
+  }
 
-    __device__ static void dequant(Array<bfloat16_t, 2>& x, Array<uint16_t, 1> s)
-    {
-        auto s1 = __ushort_as_bfloat16(s[0]);
-        x[0]    = __hmul(x[0], s1);
-        x[1]    = __hmul(x[1], s1);
-    }
+  __device__ static void dequant(Array<half_t, 2>& x, Array<uint8_t, 1> s) {
+    // half_t s1 = __ushort_as_half(((uint16_t)s[0] + 15 - 127) << 10);
+    // Adjusted in `AdjustUe8m0ScaleForHalf`
+    half_t s1 = __ushort_as_half((uint16_t)s[0] << 10);
+    x[0] = __hmul(x[0], s1);
+    x[1] = __hmul(x[1], s1);
+  }
 
-    __device__ static void dequant(Array<half, 2>& x, Array<uint16_t, 1> s)
-    {
-        auto s1 = __ushort_as_half(s[0]);
-        x[0]    = __hmul(x[0], s1);
-        x[1]    = __hmul(x[1], s1);
-    }
+  __device__ static void dequant(Array<bfloat16_t, 2>& x,
+                                 Array<uint16_t, 1> s) {
+    auto s1 = __ushort_as_bfloat16(s[0]);
+    x[0] = __hmul(x[0], s1);
+    x[1] = __hmul(x[1], s1);
+  }
+
+  __device__ static void dequant(Array<half, 2>& x, Array<uint16_t, 1> s) {
+    auto s1 = __ushort_as_half(s[0]);
+    x[0] = __hmul(x[0], s1);
+    x[1] = __hmul(x[1], s1);
+  }
 };
 
 // Used by SM70 MMA
 struct Transform_HMMA_SIMT_B {
-    template<class F, int Nf, int Mf, int K, class D, int Nd, int Md, class S, int Ns, int Ms, int Ks>
-    __device__ static void
-    apply(Array<F, Nf> (&frag)[K][Mf], int k, Array<D, Nd> (&data)[K][Md], Array<S, Ns> (&stat)[Ks][Ms], int div)
-    {
-        static_assert(Nf * Mf == Nd * Md);
-        static_assert(Nd % Nf == 0 && Mf % Md == 0);
+  template <class F, int Nf, int Mf, int K, class D, int Nd, int Md, class S,
+            int Ns, int Ms, int Ks>
+  __device__ static void apply(Array<F, Nf> (&frag)[K][Mf], int k,
+                               Array<D, Nd> (&data)[K][Md],
+                               Array<S, Ns> (&stat)[Ks][Ms], int div) {
+    static_assert(Nf * Mf == Nd * Md);
+    static_assert(Nd % Nf == 0 && Mf % Md == 0);
 
-        auto& frag_k = reinterpret_cast<Array<F, Nd>(&)[Md]>(frag[k]);
-        auto& stat_k = reinterpret_cast<Array<S, 1>(&)[Ns * Ms]>(stat[k / div]);
-        auto& data_k = data[k];
+    auto& frag_k = reinterpret_cast<Array<F, Nd>(&)[Md]>(frag[k]);
+    auto& stat_k = reinterpret_cast<Array<S, 1>(&)[Ns * Ms]>(stat[k / div]);
+    auto& data_k = data[k];
 
-        // static_assert(Nf != Nf);
+    // static_assert(Nf != Nf);
 
-        PRAGMA_UNROLL
-        for (int m = 0; m < Md; ++m) {
-            auto tmp = ConvertKvCache<D, F>::convert(data_k[m]);
-            PRAGMA_UNROLL
-            for (int i = 0; i < Nd; i += 2) {
-                dequant((Array<F, 2>&)tmp[i], stat_k[(m * Nd + i) / Nf]);
-            }
-            frag_k[m] = tmp;
-        }
+    PRAGMA_UNROLL
+    for (int m = 0; m < Md; ++m) {
+      auto tmp = ConvertKvCache<D, F>::convert(data_k[m]);
+      PRAGMA_UNROLL
+      for (int i = 0; i < Nd; i += 2) {
+        dequant((Array<F, 2>&)tmp[i], stat_k[(m * Nd + i) / Nf]);
+      }
+      frag_k[m] = tmp;
     }
+  }
 
-    template<class F>
-    __device__ static void dequant(Array<F, 2>& x, Array<uint32_t, 1> s)
-    {
-        Array<F, 2>& _s = (Array<F, 2>&)s;
+  template <class F>
+  __device__ static void dequant(Array<F, 2>& x, Array<uint32_t, 1> s) {
+    Array<F, 2>& _s = (Array<F, 2>&)s;
 
-        x[0] = __hfma(x[0], _s[0], _s[1]);
-        x[1] = __hfma(x[1], _s[0], _s[1]);
-    }
+    x[0] = __hfma(x[0], _s[0], _s[1]);
+    x[1] = __hfma(x[1], _s[0], _s[1]);
+  }
 
-    __device__ static void dequant(Array<half_t, 2>& x, Array<uint8_t, 1> s)
-    {
-        // half_t s1 = __ushort_as_half(((uint16_t)s[0] + 15 - 127) << 10);
-        // Adjusted in `AdjustUe8m0ScaleForHalf`
-        half_t s1 = __ushort_as_half((uint16_t)s[0] << 10);
-        x[0]      = __hmul(x[0], s1);
-        x[1]      = __hmul(x[1], s1);
-    }
+  __device__ static void dequant(Array<half_t, 2>& x, Array<uint8_t, 1> s) {
+    // half_t s1 = __ushort_as_half(((uint16_t)s[0] + 15 - 127) << 10);
+    // Adjusted in `AdjustUe8m0ScaleForHalf`
+    half_t s1 = __ushort_as_half((uint16_t)s[0] << 10);
+    x[0] = __hmul(x[0], s1);
+    x[1] = __hmul(x[1], s1);
+  }
 
-    __device__ static void dequant(Array<half, 2>& x, Array<uint16_t, 1> s)
-    {
-        auto s1 = __ushort_as_half(s[0]);
-        x[0]    = __hmul(x[0], s1);
-        x[1]    = __hmul(x[1], s1);
-    }
+  __device__ static void dequant(Array<half, 2>& x, Array<uint16_t, 1> s) {
+    auto s1 = __ushort_as_half(s[0]);
+    x[0] = __hmul(x[0], s1);
+    x[1] = __hmul(x[1], s1);
+  }
 };
 
 // FP8 scales that have absorbed the E4M3 exponent-bias factor (256) during
 // one-time weight preparation.
 struct Transform_HMMA_SIMT_B_PrescaledE4M3 {
-    template<class F, int Nf, int Mf, int K, class D, int Nd, int Md, class S, int Ns, int Ms, int Ks>
-    __device__ static void
-    apply(Array<F, Nf> (&frag)[K][Mf], int k, Array<D, Nd> (&data)[K][Md], Array<S, Ns> (&stat)[Ks][Ms], int div)
-    {
-        static_assert(std::is_same_v<D, fp8_e4m3_t>);
-        static_assert(std::is_same_v<F, half>);
-        static_assert(std::is_same_v<S, uint16_t>);
-        static_assert(Nf * Mf == Nd * Md);
-        static_assert(Nd % Nf == 0 && Mf % Md == 0);
-        static_assert(Nd % 4 == 0);
+  template <class F, int Nf, int Mf, int K, class D, int Nd, int Md, class S,
+            int Ns, int Ms, int Ks>
+  __device__ static void apply(Array<F, Nf> (&frag)[K][Mf], int k,
+                               Array<D, Nd> (&data)[K][Md],
+                               Array<S, Ns> (&stat)[Ks][Ms], int div) {
+    static_assert(std::is_same_v<D, fp8_e4m3_t>);
+    static_assert(std::is_same_v<F, half>);
+    static_assert(std::is_same_v<S, uint16_t>);
+    static_assert(Nf * Mf == Nd * Md);
+    static_assert(Nd % Nf == 0 && Mf % Md == 0);
+    static_assert(Nd % 4 == 0);
 
-        auto& frag_k = reinterpret_cast<Array<F, Nd>(&)[Md]>(frag[k]);
-        auto& stat_k = reinterpret_cast<Array<S, 1>(&)[Ns * Ms]>(stat[k / div]);
-        auto& data_k = data[k];
+    auto& frag_k = reinterpret_cast<Array<F, Nd>(&)[Md]>(frag[k]);
+    auto& stat_k = reinterpret_cast<Array<S, 1>(&)[Ns * Ms]>(stat[k / div]);
+    auto& data_k = data[k];
 
-        PRAGMA_UNROLL
-        for (int m = 0; m < Md; ++m) {
-            Array<F, Nd> tmp;
-            PRAGMA_UNROLL
-            for (int i = 0; i < Nd; i += 4) {
-                auto& src = reinterpret_cast<Array<fp8_e4m3_t, 4>&>(data_k[m][i]);
-                reinterpret_cast<Array<half, 4>&>(tmp[i]) = cvt_f16x4_e4m3<false>(src);
-            }
-            PRAGMA_UNROLL
-            for (int i = 0; i < Nd; i += 2) {
-                auto scale = __ushort_as_half(stat_k[(m * Nd + i) / Nf][0]);
-                tmp[i]     = __hmul(tmp[i], scale);
-                tmp[i + 1] = __hmul(tmp[i + 1], scale);
-            }
-            frag_k[m] = tmp;
-        }
+    PRAGMA_UNROLL
+    for (int m = 0; m < Md; ++m) {
+      Array<F, Nd> tmp;
+      PRAGMA_UNROLL
+      for (int i = 0; i < Nd; i += 4) {
+        auto& src = reinterpret_cast<Array<fp8_e4m3_t, 4>&>(data_k[m][i]);
+        reinterpret_cast<Array<half, 4>&>(tmp[i]) = cvt_f16x4_e4m3<false>(src);
+      }
+      PRAGMA_UNROLL
+      for (int i = 0; i < Nd; i += 2) {
+        auto scale = __ushort_as_half(stat_k[(m * Nd + i) / Nf][0]);
+        tmp[i] = __hmul(tmp[i], scale);
+        tmp[i + 1] = __hmul(tmp[i + 1], scale);
+      }
+      frag_k[m] = tmp;
     }
+  }
 };
 
 }  // namespace turbomind::gemm

--- a/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/types.h
+++ b/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/types.h
@@ -159,6 +159,7 @@ enum class DispatchPolicy : int
     kPreserveDefaultSplits     = 4,
     kPreserveDefaultSplitCount = 8,
     kMxfp4MoeGroupedM8Fast     = 16,
+    kSm70Fp8PrefillPrescaled   = 32,
 };
 
 constexpr bool operator&(const DispatchPolicy& a, const DispatchPolicy& b)

--- a/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/types.h
+++ b/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/types.h
@@ -7,270 +7,244 @@
 #include <cuda_runtime.h>
 
 #if ENABLE_BF16
-#include <cuda_bf16.h>
+  #include <cuda_bf16.h>
 #endif
 
 namespace turbomind::gemm {
 
-enum class Order : int
-{
-    kColMajor = 0,
-    kRowMajor = 1,
+enum class Order : int {
+  kColMajor = 0,
+  kRowMajor = 1,
 };
 
 inline constexpr Order kColMajor = Order::kColMajor;
 inline constexpr Order kRowMajor = Order::kRowMajor;
 
-constexpr Order operator~(Order a)
-{
-    return a == kColMajor ? kRowMajor : kColMajor;
+constexpr Order operator~(Order a) {
+  return a == kColMajor ? kRowMajor : kColMajor;
 }
 
-constexpr const char* to_string(Order order)
-{
-    switch (order) {
-        case kColMajor:
-            return "Col";
-        case kRowMajor:
-            return "Row";
-    }
-    return "";
+constexpr const char* to_string(Order order) {
+  switch (order) {
+    case kColMajor:
+      return "Col";
+    case kRowMajor:
+      return "Row";
+  }
+  return "";
 }
 
 using Pack = uint32_t;
 
-typedef enum MMA_Tag
-{
-    HMMA_16816 = 0x100,  // sm80+
-    HMMA_1688  = 0x200,  // sm75
-    HMMA_884   = 0x300,  // sm70
-    HMMA_SIMT  = 0x400,  // sm75-
+typedef enum MMA_Tag {
+  HMMA_16816 = 0x100,  // sm80+
+  HMMA_1688 = 0x200,   // sm75
+  HMMA_884 = 0x300,    // sm70
+  HMMA_SIMT = 0x400,   // sm75-
 } MMA_Tag;
 
-typedef enum Op_Tag
-{
-    OPERAND_A = 0x010,
-    OPERAND_B = 0x020,
-    OPERAND_U = 0x030,
-    OPERAND_V = 0x040,
-    OPERAND_C = 0x050,
-    OPERAND_D = 0x060,
+typedef enum Op_Tag {
+  OPERAND_A = 0x010,
+  OPERAND_B = 0x020,
+  OPERAND_U = 0x030,
+  OPERAND_V = 0x040,
+  OPERAND_C = 0x050,
+  OPERAND_D = 0x060,
 } Op_Tag;
 
-constexpr MMA_Tag get_mma_tag(Pack pack)
-{
-    return static_cast<MMA_Tag>(pack & 0xf00);
+constexpr MMA_Tag get_mma_tag(Pack pack) {
+  return static_cast<MMA_Tag>(pack & 0xf00);
 }
 
-constexpr Op_Tag get_operand_tag(Pack pack)
-{
-    return static_cast<Op_Tag>(pack & 0x0f0);
+constexpr Op_Tag get_operand_tag(Pack pack) {
+  return static_cast<Op_Tag>(pack & 0x0f0);
 }
 
-constexpr int get_pack_num(Pack pack)
-{
-    return pack & 0x00f;
-}
+constexpr int get_pack_num(Pack pack) { return pack & 0x00f; }
 
-enum class Striding : int
-{
-    kFlat,     // [1111,2222,3333]
-    kRagged,   // [11,2222222,333]  [0 , 2      , 9  ]
-    kIndexed,  // [xx xxxxxxx xxx], [01, 2345678, 9ab]
-    kBlocked,  // [11][22222][333]
+enum class Striding : int {
+  kFlat,     // [1111,2222,3333]
+  kRagged,   // [11,2222222,333]  [0 , 2      , 9  ]
+  kIndexed,  // [xx xxxxxxx xxx], [01, 2345678, 9ab]
+  kBlocked,  // [11][22222][333]
 };
 
-inline const char* to_string(Striding striding)
-{
-    switch (striding) {
-        case Striding::kFlat:
-            return "f";
-        case Striding::kRagged:
-            return "r";
-        case Striding::kIndexed:
-            return "i";
-        case Striding::kBlocked:
-            return "b";
-        default:
-            return "unknown";
-    }
+inline const char* to_string(Striding striding) {
+  switch (striding) {
+    case Striding::kFlat:
+      return "f";
+    case Striding::kRagged:
+      return "r";
+    case Striding::kIndexed:
+      return "i";
+    case Striding::kBlocked:
+      return "b";
+    default:
+      return "unknown";
+  }
 }
 
-enum class QuantType : int
-{
-    kNone    = 0,
-    kK       = 1,
-    kM       = 2,
-    kB       = 3,
-    kDefault = kK,
+enum class QuantType : int {
+  kNone = 0,
+  kK = 1,
+  kM = 2,
+  kB = 3,
+  kDefault = kK,
 };
 
-inline const char* to_string(QuantType q)
-{
-    switch (q) {
-        case QuantType::kNone:
-            return "none";
-        case QuantType::kK:
-            return "k";
-        case QuantType::kM:
-            return "m";
-        case QuantType::kB:
-            return "b";
-        default:
-            return "unknown";
-    }
+inline const char* to_string(QuantType q) {
+  switch (q) {
+    case QuantType::kNone:
+      return "none";
+    case QuantType::kK:
+      return "k";
+    case QuantType::kM:
+      return "m";
+    case QuantType::kB:
+      return "b";
+    default:
+      return "unknown";
+  }
 }
 
-enum class Epilogue : int
-{
-    kNone               = 0,
-    kChannelCombination = 0x1,
-    kGatedSilu          = 0x2,
-    kMoeWeightedReduce  = 0x4,
-    kTileAllReduce      = 0x8,
+enum class Epilogue : int {
+  kNone = 0,
+  kChannelCombination = 0x1,
+  kGatedSilu = 0x2,
+  kMoeWeightedReduce = 0x4,
+  kTileAllReduce = 0x8,
 };
 
 struct QuantDesc {
-    QuantType type;
-    int       group_size;
+  QuantType type;
+  int group_size;
 
-    operator bool() const noexcept
-    {
-        return (int)type || group_size;
-    }
+  operator bool() const noexcept { return (int)type || group_size; }
 };
 
-inline std::string to_string(QuantDesc desc)
-{
-    if (desc) {
-        return to_string(desc.type) + std::to_string(desc.group_size);
-    }
-    else {
-        return to_string(desc.type);
-    }
+inline std::string to_string(QuantDesc desc) {
+  if (desc) {
+    return to_string(desc.type) + std::to_string(desc.group_size);
+  } else {
+    return to_string(desc.type);
+  }
 }
 
-enum class DispatchPolicy : int
-{
-    kDefault                   = 0,
-    kMeasure                   = 1,
-    kReuse                     = 2,
-    kAppend                    = 3,
-    kPreserveDefaultSplits     = 4,
-    kPreserveDefaultSplitCount = 8,
-    kMxfp4MoeGroupedM8Fast     = 16,
-    kSm70Fp8PrefillPrescaled   = 32,
+enum class DispatchPolicy : int {
+  kDefault = 0,
+  kMeasure = 1,
+  kReuse = 2,
+  kAppend = 3,
+  kPreserveDefaultSplits = 4,
+  kPreserveDefaultSplitCount = 8,
+  kMxfp4MoeGroupedM8Fast = 16,
+  kSm70Fp8PrefillPrescaled = 32,
 };
 
-constexpr bool operator&(const DispatchPolicy& a, const DispatchPolicy& b)
-{
-    return ((int)a & (int)b);
+constexpr bool operator&(const DispatchPolicy& a, const DispatchPolicy& b) {
+  return ((int)a & (int)b);
 }
 
-constexpr DispatchPolicy operator|(const DispatchPolicy& a, const DispatchPolicy& b)
-{
-    return static_cast<DispatchPolicy>((int)a | (int)b);
+constexpr DispatchPolicy operator|(const DispatchPolicy& a,
+                                   const DispatchPolicy& b) {
+  return static_cast<DispatchPolicy>((int)a | (int)b);
 }
 
 class Kernel;
 class Context;
 
 struct Tape {
-    int   ctas;
-    int   max_num;
-    int   max_ctas;
-    char* buffer;
-    int4* gemm_shapes;
-    int4* tiled_shapes;
-    int4* tile_offsets;
-    int2* iter_k_ranges;
-    int*  tile_ids;
+  int ctas;
+  int max_num;
+  int max_ctas;
+  char* buffer;
+  int4* gemm_shapes;
+  int4* tiled_shapes;
+  int4* tile_offsets;
+  int2* iter_k_ranges;
+  int* tile_ids;
 };
 
 struct Operation {
-    DispatchPolicy dispatch;
-    Epilogue       epilogue;
-    QuantDesc      quant_a;
-    QuantDesc      quant_b;
-    int            batch_dim;
-    int            dispatch_num_override;
-    int            active_group_count;
-    void*          reserved;
-    void*          tile_allreduce;
+  DispatchPolicy dispatch;
+  Epilogue epilogue;
+  QuantDesc quant_a;
+  QuantDesc quant_b;
+  int batch_dim;
+  int dispatch_num_override;
+  int active_group_count;
+  void* reserved;
+  void* tile_allreduce;
 };
 
 struct MoeWeightedReduceParam {
-    void*        out;
-    const float* sorted_weights;
-    const int*   offsets;
+  void* out;
+  const float* sorted_weights;
+  const int* offsets;
 };
 
 struct TileAllReduceParam {
-    void* signals[8];
-    void* self_signal;
-    void* rank_data;
-    void* output;
-    int   rank;
-    int   world_size;
-    int   tile_numel;
-    int   output_numel;
-    int   reducer_blocks;
-    int   kernel_reducer_blocks;
-    int   producer_grid_x;
-    int   producer_grid_y;
-    int   producer_grid_z;
+  void* signals[8];
+  void* self_signal;
+  void* rank_data;
+  void* output;
+  int rank;
+  int world_size;
+  int tile_numel;
+  int output_numel;
+  int reducer_blocks;
+  int kernel_reducer_blocks;
+  int producer_grid_x;
+  int producer_grid_y;
+  int producer_grid_z;
 };
 
-inline Operation transpose(Operation o)
-{
-    std::swap(o.quant_a, o.quant_b);
-    o.batch_dim = 1 - o.batch_dim;
-    return o;
+inline Operation transpose(Operation o) {
+  std::swap(o.quant_a, o.quant_b);
+  o.batch_dim = 1 - o.batch_dim;
+  return o;
 }
 
 struct MatrixLayout {
-    DataType type;
-    Order    order;
-    int      rows;
-    int      cols;
-    int      ld;
-    Pack     pack;
-    int      num;
-    int*     offsets;
-    int*     idxs;
-    int*     group_idxs;
+  DataType type;
+  Order order;
+  int rows;
+  int cols;
+  int ld;
+  Pack pack;
+  int num;
+  int* offsets;
+  int* idxs;
+  int* group_idxs;
 };
 
-inline std::ostream& operator<<(std::ostream& os, const MatrixLayout& x)
-{
-    os << x.type << " " << to_string(x.order) << " " << x.rows << " " << x.cols << " " << x.num << " " << x.ld;
-    return os;
+inline std::ostream& operator<<(std::ostream& os, const MatrixLayout& x) {
+  os << x.type << " " << to_string(x.order) << " " << x.rows << " " << x.cols
+     << " " << x.num << " " << x.ld;
+  return os;
 }
 
-inline int64_t byte_size(const MatrixLayout& m)
-{
-    return byte_size(m.type, (int64_t)m.rows * m.cols);
+inline int64_t byte_size(const MatrixLayout& m) {
+  return byte_size(m.type, (int64_t)m.rows * m.cols);
 }
 
-inline Striding get_mode(const MatrixLayout& m)
-{
-    if (m.idxs) {
-        return Striding::kIndexed;
-    }
-    else if (m.ld == 0 || m.offsets) {
-        return Striding::kBlocked;
-    }
-    return Striding::kFlat;
+inline Striding get_mode(const MatrixLayout& m) {
+  if (m.idxs) {
+    return Striding::kIndexed;
+  } else if (m.ld == 0 || m.offsets) {
+    return Striding::kBlocked;
+  }
+  return Striding::kFlat;
 }
 
 struct Workspace {
-    void*  barriers;
-    size_t barriers_size;
-    void*  partials;
-    size_t partials_size;
-    void*  tensormaps;
-    size_t tensormaps_size;
-    int*   flags;
+  void* barriers;
+  size_t barriers_size;
+  void* partials;
+  size_t partials_size;
+  void* tensormaps;
+  size_t tensormaps_size;
+  int* flags;
 };
 
 }  // namespace turbomind::gemm

--- a/csrc/sm70_turbomind/ops/awq_sm70_gemm.cu
+++ b/csrc/sm70_turbomind/ops/awq_sm70_gemm.cu
@@ -3461,10 +3461,10 @@ void fp8_gemm_sm70_out(torch::Tensor out, torch::Tensor in_feats,
   TORCH_CHECK(out.stride(1) == 1,
               "fp8_gemm_sm70: output must be row-major contiguous.");
   if (exact_8k_prefill_prescaled) {
-    TORCH_CHECK(m == 8000 && k == 5120 && (n == 4096 || n == 3584) &&
-                    !gated_silu,
-                "fp8_gemm_sm70: pre-scaled block-FP8 prefill requires "
-                "M=8000, K=5120, N=4096/3584, and no fused epilogue.");
+    TORCH_CHECK(
+        m == 8000 && k == 5120 && (n == 4096 || n == 3584) && !gated_silu,
+        "fp8_gemm_sm70: pre-scaled block-FP8 prefill requires "
+        "M=8000, K=5120, N=4096/3584, and no fused epilogue.");
   }
   if (gated_silu) {
     TORCH_CHECK((n % 2) == 0,
@@ -3547,8 +3547,8 @@ void fp8_gemm_sm70_out(torch::Tensor out, torch::Tensor in_feats,
       device, static_cast<int>(m), static_cast<int>(n), static_cast<int>(k),
       static_cast<int>(group_size), stream);
   if (exact_8k_prefill_prescaled) {
-    op.dispatch = op.dispatch |
-                  turbomind::gemm::DispatchPolicy::kSm70Fp8PrefillPrescaled;
+    op.dispatch =
+        op.dispatch | turbomind::gemm::DispatchPolicy::kSm70Fp8PrefillPrescaled;
   }
   op.epilogue = gated_silu ? turbomind::gemm::Epilogue::kGatedSilu
                            : turbomind::gemm::Epilogue::kNone;
@@ -3568,11 +3568,9 @@ void fp8_gemm_sm70_out(torch::Tensor out, torch::Tensor in_feats,
 
 bool sm70_fp8_prefill_cutlass_gated_silu_enabled(
     const torch::Tensor& in_feats, const torch::Tensor& dense_weight) {
-  const char* raw =
-      std::getenv("VLLM_SM70_FP8_PREFILL_CUTLASS");
-  return (raw == nullptr || std::atoi(raw) != 0) &&
-         in_feats.size(0) == 8000 && in_feats.size(1) == 5120 &&
-         dense_weight.size(1) == 8704;
+  const char* raw = std::getenv("VLLM_SM70_FP8_PREFILL_CUTLASS");
+  return (raw == nullptr || std::atoi(raw) != 0) && in_feats.size(0) == 8000 &&
+         in_feats.size(1) == 5120 && dense_weight.size(1) == 8704;
 }
 
 void fp8_gemm_sm70_prefill_dispatch_out(
@@ -3591,19 +3589,17 @@ void fp8_gemm_sm70_prefill_dispatch_out(
       reinterpret_cast<void*>(dense_weight_ptr),
       {in_feats.size(1), tm_weight.size(1)}, in_feats.options());
   fp8_sm70_dequantize_out(dense_weight, tm_weight, tm_scales, group_size);
-  if (gated_silu && sm70_fp8_prefill_cutlass_gated_silu_enabled(
-                        in_feats, dense_weight)) {
-    auto gate_up = at::empty(
-        {in_feats.size(0), dense_weight.size(1)}, in_feats.options());
-    if (sm70_fp8_prefill_cutlass_out(gate_up, in_feats, dense_weight,
-                                       false)) {
+  if (gated_silu &&
+      sm70_fp8_prefill_cutlass_gated_silu_enabled(in_feats, dense_weight)) {
+    auto gate_up =
+        at::empty({in_feats.size(0), dense_weight.size(1)}, in_feats.options());
+    if (sm70_fp8_prefill_cutlass_out(gate_up, in_feats, dense_weight, false)) {
       sm70_silu_and_mul_interleaved_fp16_out(out, gate_up);
       C10_CUDA_KERNEL_LAUNCH_CHECK();
       return;
     }
   }
-  if (sm70_fp8_prefill_cutlass_out(out, in_feats, dense_weight,
-                                     gated_silu)) {
+  if (sm70_fp8_prefill_cutlass_out(out, in_feats, dense_weight, gated_silu)) {
     return;
   }
   if (gated_silu) {
@@ -4947,13 +4943,14 @@ void fp8_gemm_sm70_out(torch::Tensor out, torch::Tensor _in_feats,
                                     group_size, k_ld, q_ld, gated_silu);
 }
 
-void fp8_gemm_sm70_prefill_prescaled_out(
-    torch::Tensor out, torch::Tensor _in_feats, torch::Tensor _kernel,
-    torch::Tensor _prescaled_factors, int64_t group_size, int64_t k_ld,
-    int64_t q_ld) {
-  vllm::awq_sm70::fp8_gemm_sm70_out(
-      out, _in_feats, _kernel, _prescaled_factors, group_size, k_ld, q_ld,
-      false, true);
+void fp8_gemm_sm70_prefill_prescaled_out(torch::Tensor out,
+                                         torch::Tensor _in_feats,
+                                         torch::Tensor _kernel,
+                                         torch::Tensor _prescaled_factors,
+                                         int64_t group_size, int64_t k_ld,
+                                         int64_t q_ld) {
+  vllm::awq_sm70::fp8_gemm_sm70_out(out, _in_feats, _kernel, _prescaled_factors,
+                                    group_size, k_ld, q_ld, false, true);
 }
 
 void fp8_gemm_sm70_prefill_dispatch_out(

--- a/csrc/sm70_turbomind/ops/awq_sm70_gemm.cu
+++ b/csrc/sm70_turbomind/ops/awq_sm70_gemm.cu
@@ -37,6 +37,7 @@
 #include "src/turbomind/kernels/gemm/types.h"
 #include "src/turbomind/kernels/gemm/utils.h"
 #include "custom_all_reduce.cuh"
+#include "qwen38_prefill_cutlass.cuh"
 
 namespace turbomind {
 void unpack_awq_gemm(uint4_t* dst, const uint4_t* src, int rows, int cols,
@@ -3427,7 +3428,8 @@ void awq_gemm_sm70_out_tile_reduce(
 void fp8_gemm_sm70_out(torch::Tensor out, torch::Tensor in_feats,
                        torch::Tensor tm_weight, torch::Tensor tm_scales,
                        int64_t group_size, int64_t k_ld, int64_t q_ld,
-                       bool gated_silu) {
+                       bool gated_silu,
+                       bool exact_8k_prefill_prescaled = false) {
   TORCH_CHECK(in_feats.is_cuda(), "fp8_gemm_sm70: input must be CUDA.");
   TORCH_CHECK(tm_weight.is_cuda(), "fp8_gemm_sm70: weight must be CUDA.");
   TORCH_CHECK(tm_scales.is_cuda(), "fp8_gemm_sm70: scales must be CUDA.");
@@ -3458,6 +3460,12 @@ void fp8_gemm_sm70_out(torch::Tensor out, torch::Tensor in_feats,
               "fp8_gemm_sm70: output rows must match input rows.");
   TORCH_CHECK(out.stride(1) == 1,
               "fp8_gemm_sm70: output must be row-major contiguous.");
+  if (exact_8k_prefill_prescaled) {
+    TORCH_CHECK(m == 8000 && k == 5120 && (n == 4096 || n == 3584) &&
+                    !gated_silu,
+                "fp8_gemm_sm70: pre-scaled block-FP8 prefill requires "
+                "M=8000, K=5120, N=4096/3584, and no fused epilogue.");
+  }
   if (gated_silu) {
     TORCH_CHECK((n % 2) == 0,
                 "fp8_gemm_sm70: gated_silu requires even output dim.");
@@ -3538,6 +3546,10 @@ void fp8_gemm_sm70_out(torch::Tensor out, torch::Tensor in_feats,
   op.dispatch = select_fp8_dense_dispatch_policy(
       device, static_cast<int>(m), static_cast<int>(n), static_cast<int>(k),
       static_cast<int>(group_size), stream);
+  if (exact_8k_prefill_prescaled) {
+    op.dispatch = op.dispatch |
+                  turbomind::gemm::DispatchPolicy::kSm70Fp8PrefillPrescaled;
+  }
   op.epilogue = gated_silu ? turbomind::gemm::Epilogue::kGatedSilu
                            : turbomind::gemm::Epilogue::kNone;
   op.quant_a = {turbomind::gemm::QuantType::kNone, 0};
@@ -3552,6 +3564,15 @@ void fp8_gemm_sm70_out(torch::Tensor out, torch::Tensor in_feats,
                           desc_V, 0.f, out.data_ptr(), desc_D, out.data_ptr(),
                           desc_D, workspace_holder.workspace, stream);
   TORCH_CHECK(ec == 0, "fp8_gemm_sm70: TurboMind GEMM failed.");
+}
+
+bool sm70_fp8_prefill_cutlass_gated_silu_enabled(
+    const torch::Tensor& in_feats, const torch::Tensor& dense_weight) {
+  const char* raw =
+      std::getenv("VLLM_SM70_FP8_PREFILL_CUTLASS");
+  return (raw == nullptr || std::atoi(raw) != 0) &&
+         in_feats.size(0) == 8000 && in_feats.size(1) == 5120 &&
+         dense_weight.size(1) == 8704;
 }
 
 void fp8_gemm_sm70_prefill_dispatch_out(
@@ -3570,6 +3591,21 @@ void fp8_gemm_sm70_prefill_dispatch_out(
       reinterpret_cast<void*>(dense_weight_ptr),
       {in_feats.size(1), tm_weight.size(1)}, in_feats.options());
   fp8_sm70_dequantize_out(dense_weight, tm_weight, tm_scales, group_size);
+  if (gated_silu && sm70_fp8_prefill_cutlass_gated_silu_enabled(
+                        in_feats, dense_weight)) {
+    auto gate_up = at::empty(
+        {in_feats.size(0), dense_weight.size(1)}, in_feats.options());
+    if (sm70_fp8_prefill_cutlass_out(gate_up, in_feats, dense_weight,
+                                       false)) {
+      sm70_silu_and_mul_interleaved_fp16_out(out, gate_up);
+      C10_CUDA_KERNEL_LAUNCH_CHECK();
+      return;
+    }
+  }
+  if (sm70_fp8_prefill_cutlass_out(out, in_feats, dense_weight,
+                                     gated_silu)) {
+    return;
+  }
   if (gated_silu) {
     auto gate_up = at::mm(in_feats, dense_weight);
     sm70_silu_and_mul_interleaved_fp16_out(out, gate_up);
@@ -4909,6 +4945,15 @@ void fp8_gemm_sm70_out(torch::Tensor out, torch::Tensor _in_feats,
                        bool gated_silu) {
   vllm::awq_sm70::fp8_gemm_sm70_out(out, _in_feats, _kernel, _scaling_factors,
                                     group_size, k_ld, q_ld, gated_silu);
+}
+
+void fp8_gemm_sm70_prefill_prescaled_out(
+    torch::Tensor out, torch::Tensor _in_feats, torch::Tensor _kernel,
+    torch::Tensor _prescaled_factors, int64_t group_size, int64_t k_ld,
+    int64_t q_ld) {
+  vllm::awq_sm70::fp8_gemm_sm70_out(
+      out, _in_feats, _kernel, _prescaled_factors, group_size, k_ld, q_ld,
+      false, true);
 }
 
 void fp8_gemm_sm70_prefill_dispatch_out(

--- a/csrc/sm70_turbomind/ops/qwen38_prefill_cutlass.cu
+++ b/csrc/sm70_turbomind/ops/qwen38_prefill_cutlass.cu
@@ -29,8 +29,7 @@ using Sm70Fp8PrefillCutlassKernel =
         cutlass::half_t, cutlass::layout::RowMajor, float,
         cutlass::arch::OpClassTensorOp, cutlass::arch::Sm70,
         cutlass::gemm::GemmShape<128, 256, 32>,
-        cutlass::gemm::GemmShape<64, 64, 32>,
-        cutlass::gemm::GemmShape<8, 8, 4>,
+        cutlass::gemm::GemmShape<64, 64, 32>, cutlass::gemm::GemmShape<8, 8, 4>,
         cutlass::epilogue::thread::LinearCombination<cutlass::half_t, 8, float,
                                                      float>,
         cutlass::gemm::threadblock::GemmIdentityThreadblockSwizzle<8>, 2,
@@ -59,10 +58,8 @@ void maybe_log_sm70_fp8_prefill_cutlass_route(int64_t m, int64_t n, int64_t k) {
 
 }  // namespace
 
-bool sm70_fp8_prefill_cutlass_out(torch::Tensor out,
-                                    torch::Tensor in_feats,
-                                    torch::Tensor dense_weight,
-                                    bool gated_silu) {
+bool sm70_fp8_prefill_cutlass_out(torch::Tensor out, torch::Tensor in_feats,
+                                  torch::Tensor dense_weight, bool gated_silu) {
   const char* raw = std::getenv("VLLM_SM70_FP8_PREFILL_CUTLASS");
   if ((raw != nullptr && std::atoi(raw) == 0) || gated_silu ||
       in_feats.dim() != 2 || dense_weight.dim() != 2) {
@@ -74,9 +71,8 @@ bool sm70_fp8_prefill_cutlass_out(torch::Tensor out,
   const bool exact_gate_up = k == 5120 && n == 8704;
   const bool exact_down = k == 4352 && n == 5120;
   const bool exact_attention_output = k == 1536 && n == 5120;
-  if (in_feats.size(0) != 8000 ||
-      (!exact_qkv && !exact_gate_up && !exact_down &&
-       !exact_attention_output)) {
+  if (in_feats.size(0) != 8000 || (!exact_qkv && !exact_gate_up &&
+                                   !exact_down && !exact_attention_output)) {
     return false;
   }
 
@@ -86,9 +82,10 @@ bool sm70_fp8_prefill_cutlass_out(torch::Tensor out,
                   in_feats.scalar_type() == at::ScalarType::Half &&
                   dense_weight.scalar_type() == at::ScalarType::Half,
               "SM70 block-FP8 prefill CUTLASS GEMM expects float16 tensors.");
-  TORCH_CHECK(out.is_contiguous() && in_feats.is_contiguous() &&
-                  dense_weight.is_contiguous(),
-              "SM70 block-FP8 prefill CUTLASS GEMM expects contiguous tensors.");
+  TORCH_CHECK(
+      out.is_contiguous() && in_feats.is_contiguous() &&
+          dense_weight.is_contiguous(),
+      "SM70 block-FP8 prefill CUTLASS GEMM expects contiguous tensors.");
   TORCH_CHECK(out.dim() == 2 && dense_weight.size(0) == k &&
                   out.size(0) == in_feats.size(0) && out.size(1) == n,
               "SM70 block-FP8 prefill CUTLASS GEMM shape mismatch.");
@@ -97,8 +94,8 @@ bool sm70_fp8_prefill_cutlass_out(torch::Tensor out,
   const int m = static_cast<int>(in_feats.size(0));
   const int problem_n = static_cast<int>(n);
   const int problem_k = static_cast<int>(k);
-  auto* dense_ptr = reinterpret_cast<cutlass::half_t*>(
-      dense_weight.data_ptr<at::Half>());
+  auto* dense_ptr =
+      reinterpret_cast<cutlass::half_t*>(dense_weight.data_ptr<at::Half>());
   auto* input_ptr =
       reinterpret_cast<cutlass::half_t*>(in_feats.data_ptr<at::Half>());
   auto* output_ptr =

--- a/csrc/sm70_turbomind/ops/qwen38_prefill_cutlass.cu
+++ b/csrc/sm70_turbomind/ops/qwen38_prefill_cutlass.cu
@@ -1,0 +1,133 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+#include "qwen38_prefill_cutlass.cuh"
+
+#include <ATen/cuda/CUDAContext.h>
+#include <c10/cuda/CUDAGuard.h>
+
+#include <cutlass/gemm/device/gemm_universal_adapter.h>
+#include <cutlass/gemm/kernel/default_gemm_universal.h>
+
+#include <atomic>
+#include <cstring>
+#include <cstdlib>
+#include <iostream>
+
+namespace vllm::awq_sm70 {
+namespace {
+
+// Matches CUTLASS's generated
+// cutlass_tensorop_f16_s884gemm_f16_128x256_32x2_nn_align8 operation. The
+// profiler reports its logical instruction tile as 16x16x4, while the SM70
+// DefaultGemmUniversal specialization is built from native m8n8k4 MMA ops.
+using Sm70Fp8PrefillCutlassKernel =
+    typename cutlass::gemm::kernel::DefaultGemmUniversal<
+        cutlass::half_t, cutlass::layout::RowMajor,
+        cutlass::ComplexTransform::kNone, 8, cutlass::half_t,
+        cutlass::layout::RowMajor, cutlass::ComplexTransform::kNone, 8,
+        cutlass::half_t, cutlass::layout::RowMajor, float,
+        cutlass::arch::OpClassTensorOp, cutlass::arch::Sm70,
+        cutlass::gemm::GemmShape<128, 256, 32>,
+        cutlass::gemm::GemmShape<64, 64, 32>,
+        cutlass::gemm::GemmShape<8, 8, 4>,
+        cutlass::epilogue::thread::LinearCombination<cutlass::half_t, 8, float,
+                                                     float>,
+        cutlass::gemm::threadblock::GemmIdentityThreadblockSwizzle<8>, 2,
+        cutlass::arch::OpMultiplyAdd>::GemmKernel;
+using Sm70Fp8PrefillCutlassGemm =
+    cutlass::gemm::device::GemmUniversalAdapter<Sm70Fp8PrefillCutlassKernel>;
+
+void maybe_log_sm70_fp8_prefill_cutlass_route(int64_t m, int64_t n, int64_t k) {
+  const char* raw = std::getenv("VLLM_SM70_PROFILE_TRACE");
+  if (raw == nullptr || std::strcmp(raw, "1") != 0) {
+    return;
+  }
+  const unsigned bit = n == 8704   ? 1u
+                       : k == 4352 ? 2u
+                       : k == 1536 ? 4u
+                       : n == 4096 ? 8u
+                                   : 16u;
+  static std::atomic<unsigned> logged_shapes{0};
+  const unsigned previous =
+      logged_shapes.fetch_or(bit, std::memory_order_relaxed);
+  if ((previous & bit) == 0u) {
+    std::cerr << "SM70 block-FP8 exact-8K CUTLASS projection route M=" << m
+              << " N=" << n << " K=" << k << std::endl;
+  }
+}
+
+}  // namespace
+
+bool sm70_fp8_prefill_cutlass_out(torch::Tensor out,
+                                    torch::Tensor in_feats,
+                                    torch::Tensor dense_weight,
+                                    bool gated_silu) {
+  const char* raw = std::getenv("VLLM_SM70_FP8_PREFILL_CUTLASS");
+  if ((raw != nullptr && std::atoi(raw) == 0) || gated_silu ||
+      in_feats.dim() != 2 || dense_weight.dim() != 2) {
+    return false;
+  }
+  const int64_t k = in_feats.size(1);
+  const int64_t n = dense_weight.size(1);
+  const bool exact_qkv = k == 5120 && (n == 4096 || n == 3584);
+  const bool exact_gate_up = k == 5120 && n == 8704;
+  const bool exact_down = k == 4352 && n == 5120;
+  const bool exact_attention_output = k == 1536 && n == 5120;
+  if (in_feats.size(0) != 8000 ||
+      (!exact_qkv && !exact_gate_up && !exact_down &&
+       !exact_attention_output)) {
+    return false;
+  }
+
+  TORCH_CHECK(out.is_cuda() && in_feats.is_cuda() && dense_weight.is_cuda(),
+              "SM70 block-FP8 prefill CUTLASS GEMM expects CUDA tensors.");
+  TORCH_CHECK(out.scalar_type() == at::ScalarType::Half &&
+                  in_feats.scalar_type() == at::ScalarType::Half &&
+                  dense_weight.scalar_type() == at::ScalarType::Half,
+              "SM70 block-FP8 prefill CUTLASS GEMM expects float16 tensors.");
+  TORCH_CHECK(out.is_contiguous() && in_feats.is_contiguous() &&
+                  dense_weight.is_contiguous(),
+              "SM70 block-FP8 prefill CUTLASS GEMM expects contiguous tensors.");
+  TORCH_CHECK(out.dim() == 2 && dense_weight.size(0) == k &&
+                  out.size(0) == in_feats.size(0) && out.size(1) == n,
+              "SM70 block-FP8 prefill CUTLASS GEMM shape mismatch.");
+
+  const at::cuda::OptionalCUDAGuard device_guard(device_of(in_feats));
+  const int m = static_cast<int>(in_feats.size(0));
+  const int problem_n = static_cast<int>(n);
+  const int problem_k = static_cast<int>(k);
+  auto* dense_ptr = reinterpret_cast<cutlass::half_t*>(
+      dense_weight.data_ptr<at::Half>());
+  auto* input_ptr =
+      reinterpret_cast<cutlass::half_t*>(in_feats.data_ptr<at::Half>());
+  auto* output_ptr =
+      reinterpret_cast<cutlass::half_t*>(out.data_ptr<at::Half>());
+  maybe_log_sm70_fp8_prefill_cutlass_route(m, problem_n, problem_k);
+  typename Sm70Fp8PrefillCutlassGemm::Arguments arguments{
+      cutlass::gemm::GemmUniversalMode::kGemm,
+      {problem_n, m, problem_k},
+      1,
+      {1.0f, 0.0f},
+      dense_ptr,
+      input_ptr,
+      output_ptr,
+      output_ptr,
+      0,
+      0,
+      0,
+      0,
+      problem_n,
+      problem_k,
+      problem_n,
+      problem_n};
+  Sm70Fp8PrefillCutlassGemm gemm;
+  const cutlass::Status status =
+      gemm(arguments, nullptr, at::cuda::getCurrentCUDAStream());
+  TORCH_CHECK(status == cutlass::Status::kSuccess,
+              "SM70 block-FP8 prefill CUTLASS GEMM failed: ",
+              cutlassGetStatusString(status), ".");
+  return true;
+}
+
+}  // namespace vllm::awq_sm70

--- a/csrc/sm70_turbomind/ops/qwen38_prefill_cutlass.cuh
+++ b/csrc/sm70_turbomind/ops/qwen38_prefill_cutlass.cuh
@@ -7,9 +7,7 @@
 
 namespace vllm::awq_sm70 {
 
-bool sm70_fp8_prefill_cutlass_out(torch::Tensor out,
-                                    torch::Tensor in_feats,
-                                    torch::Tensor dense_weight,
-                                    bool gated_silu);
+bool sm70_fp8_prefill_cutlass_out(torch::Tensor out, torch::Tensor in_feats,
+                                  torch::Tensor dense_weight, bool gated_silu);
 
 }  // namespace vllm::awq_sm70

--- a/csrc/sm70_turbomind/ops/qwen38_prefill_cutlass.cuh
+++ b/csrc/sm70_turbomind/ops/qwen38_prefill_cutlass.cuh
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+#pragma once
+
+#include <torch/all.h>
+
+namespace vllm::awq_sm70 {
+
+bool sm70_fp8_prefill_cutlass_out(torch::Tensor out,
+                                    torch::Tensor in_feats,
+                                    torch::Tensor dense_weight,
+                                    bool gated_silu);
+
+}  // namespace vllm::awq_sm70

--- a/csrc/torch_bindings.cpp
+++ b/csrc/torch_bindings.cpp
@@ -302,6 +302,13 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, ops) {
            &nvfp4_qpn4_dispatch_sm70_out);
 
   ops.def(
+      "fp8_gemm_sm70_prefill_prescaled_out(Tensor(a!) out, Tensor _in_feats, "
+      "Tensor _kernel, Tensor _prescaled_factors, int group_size, int k_ld, "
+      "int q_ld) -> ()");
+  ops.impl("fp8_gemm_sm70_prefill_prescaled_out", torch::kCUDA,
+           &fp8_gemm_sm70_prefill_prescaled_out);
+
+  ops.def(
       "fp8_gemm_sm70_prefill_dispatch_out(Tensor(a!) out, "
       "int dense_weight_ptr, Tensor _in_feats, Tensor _kernel, "
       "Tensor _scaling_factors, int group_size, int k_ld, int q_ld, "
@@ -729,6 +736,14 @@ TORCH_LIBRARY_EXPAND(CONCAT(TORCH_EXTENSION_NAME, _custom_ar), custom_ar) {
       "int reg_buffer, int reg_buffer_sz_bytes, float epsilon) -> ()");
   custom_ar.impl("sm70_tp4_all_reduce_gemma_rms_norm", torch::kCUDA,
                  &sm70_tp4_all_reduce_gemma_rms_norm);
+  custom_ar.def(
+      "sm70_tp4_reduce_scatter_gemma_rms_norm_all_gather(int fa, Tensor inp, "
+      "Tensor residual, Tensor weight, Tensor! normalized_out, Tensor! "
+      "residual_out, int reg_input_buffer, int reg_output_buffer, int "
+      "reg_buffer_sz_bytes, float epsilon) -> ()");
+  custom_ar.impl("sm70_tp4_reduce_scatter_gemma_rms_norm_all_gather",
+                 torch::kCUDA,
+                 &sm70_tp4_reduce_scatter_gemma_rms_norm_all_gather);
   custom_ar.def(
       "all_reduce_sum2(int fa, Tensor inp_a, Tensor inp_b, Tensor! out) -> ()");
   custom_ar.impl("all_reduce_sum2", torch::kCUDA, &all_reduce_sum2);

--- a/docs/design/sm70_v100_migration_control.md
+++ b/docs/design/sm70_v100_migration_control.md
@@ -42300,3 +42300,48 @@ Interpretation:
   pass.
 - Full results, route details, quality artifacts, trace/resource tables, and
   exact evidence paths are in `docs/design/sm70_qwen38_nvfp4_decode.md`.
+## 2026-08-24 Qwen3.8-27B-FP8 exact-8K CUTLASS projections
+
+- The accepted starting point is TP4 V100, input 8000, output 1, FP8-E5M2 KV,
+  Flash-V100/FlashQLA, FULL_AND_PIECEWISE CUDA Graph, bounded exact-dense FP8
+  projections, and the fused TP4 reduce-scatter/Gemma norm/all-gather boundary.
+  Its request-wall median was `1.616075 s`, or `4950.27 prompt tok/s`.
+- The fused graph trace put `506.081/254.947/93.510 ms` into 64 gate/up, down,
+  and attention-output FP16 GEMMs. Their current useful rates were only about
+  `90.2/89.5/86.1 TFLOP/s`, despite the V100 SXM2's 125-TFLOP/s Tensor Core
+  peak. QKVZ plus QKV retained another `241.625 ms` at exact 8K.
+- NVIDIA CUTLASS profiler selected its generated SM70
+  `f16_s884gemm_f16_128x256_32x2_nn_align8` operation for all five exact TP4
+  shapes. It uses CTA `128x256x32`, warp `64x64x32`, native `m8n8k4`, two
+  stages, and split-K one. The compiled kernel uses 220 registers/thread,
+  256 threads, and no stack or local spill.
+- Real-checkpoint CUDA Graph operator tests passed bitwise equality. The key
+  complete-boundary medians improved gate/up `8.67876 -> 8.26086 ms`, down
+  `4.26622 -> 4.02442 ms`, and attention output `1.54365 -> 1.48992 ms`.
+  Gate/up reuses the same graph-captured full projection temporary and existing
+  interleaved SiLU kernel; it adds no resident weight or second workspace.
+- The final source-matching accepted extension SHA256 is
+  `6a7e8493ca04bd7738c9b016a6a0b4914b2c582598c920f99bb67626ae3e11c1`.
+  It is default-on only at `M=8000` for TP4 shapes
+  `(K,N)={5120x4096,5120x3584,5120x8704,4352x5120,1536x5120}`. Decode,
+  tails, other M values, and other shapes retain existing dispatch. Rollback is
+  `VLLM_SM70_FP8_PREFILL_CUTLASS=0`.
+- The source-matching final full-model run produced six steady request-wall
+  samples `1.559085/1.561460/1.560481/1.562664/1.564697/1.564643 s`.
+  Their `1.562062 s` median is `5121.44 prompt tok/s` with `0.132%` CV. The
+  pure prefill median is `1.547100 s`, or `5170.96 tok/s`. This saves
+  `54.013 ms`, raises wall throughput `3.46%`, and clears the 5000-tok/s
+  requirement by `121.44 tok/s`.
+- Route proof contains exactly 20 one-time messages, five admitted shapes on
+  each of four TP ranks. The accepted 766 graph-address registration count and
+  fused collective backend remain intact. Seven of seven official-sampling
+  outputs remain token `[1061]`, text `" This"`.
+- The side-stream two-workspace FP8 dequant prototype is rejected: placing its
+  two dequantizations across the RMSNorm window changed
+  `7.98956 -> 8.00819 ms` (`0.99767x`) despite bitwise equality. The
+  cuBLAS-algorithm-106 candidate
+  was also rejected. Both implementations were removed; do not repeat them as
+  substitutes for the accepted CUTLASS shape route.
+- Final evidence is under task-cache
+  `qwen38-fp8-prefill-utilization-20260823/results/`, especially
+  `full_model_cutlass_all_projections_final_source_tp4_fused_graph_i8000.raw.json`.

--- a/docs/design/sm70_v100_migration_control.md
+++ b/docs/design/sm70_v100_migration_control.md
@@ -42165,8 +42165,9 @@ Interpretation:
   the accepted TP-local gate/up `(K,N)=(5120,8704)`, down `(4352,5120)`, and
   output `(1536,5120)` projections. GDN input and full-attention QKV remain on
   TurboMind. The old layout is replaced at load time rather than retained.
-- Opt-in admission is exact-model and exact-shape gated to Qwen3.8-27B-FP8,
-  TP4, no MTP, and configured `max_num_seqs <= 8`. Native QPN8 handles M=1-8.
+- Opt-in admission uses the engine contract only: SM70 block-FP8 layout, TP4,
+  exact projection shapes, no MTP, and configured `max_num_seqs <= 8`.
+  Native QPN8 handles M=1-8.
   Wider-concurrency and MTP configurations retain TurboMind until their own
   performance and quality gates pass; this is not a batch-one-only dispatch.
 - The opaque C++ M dispatch prevents an AOTInductor M=1 trace from being reused
@@ -42300,6 +42301,7 @@ Interpretation:
   pass.
 - Full results, route details, quality artifacts, trace/resource tables, and
   exact evidence paths are in `docs/design/sm70_qwen38_nvfp4_decode.md`.
+
 ## 2026-08-24 Qwen3.8-27B-FP8 exact-8K CUTLASS projections
 
 - The accepted starting point is TP4 V100, input 8000, output 1, FP8-E5M2 KV,

--- a/tests/quantization/test_sm70_fp8_prefill_exact_dense.py
+++ b/tests/quantization/test_sm70_fp8_prefill_exact_dense.py
@@ -510,14 +510,15 @@ def test_fp8_prefill_visible_dense_mm_is_long_prefill_only(monkeypatch):
     scales = torch.empty((1, 6), dtype=torch.float16)
     calls = []
 
+    def fake_dequantize(out, qweight, factors, group_size):
+        calls.append((qweight, factors, group_size))
+        out.fill_(1)
+
     monkeypatch.setenv("VLLM_SM70_FP8_PREFILL_VISIBLE_DENSE_MM", "1")
     monkeypatch.setattr(torch.accelerator, "current_device_index", lambda: 0)
     monkeypatch.setattr(
         "vllm.model_executor.layers.quantization.fp8.sm70_ops.fp8_sm70_dequantize_out",
-        lambda out, qweight, factors, group_size: (
-            calls.append((qweight, factors, group_size)),
-            out.fill_(1),
-        ),
+        fake_dequantize,
     )
     envs.disable_envs_cache()
     _sm70_fp8_prefill_dense_workspaces[(0, torch.float16)] = workspace

--- a/tests/quantization/test_sm70_fp8_prefill_exact_dense.py
+++ b/tests/quantization/test_sm70_fp8_prefill_exact_dense.py
@@ -20,15 +20,17 @@ from vllm.model_executor.layers.quantization.compressed_tensors.schemes.compress
     _sm70_fp8_qpn8_enabled,
 )
 from vllm.model_executor.layers.quantization.fp8 import (
+    _SM70_FP8_EXACT_8K_PREFILL_M,
     _SM70_FP8_PREFILL_DENSE_MIN_M,
     _SM70_FP8_PREFILL_DENSE_WORKSPACE_BYTES,
     Fp8LinearMethod,
     _get_sm70_fp8_prefill_exact_dense_workspace,
-    _is_qwen38_27b_fp8_qpn8_model,
+    _is_sm70_fp8_exact_8k_prefill_layer,
     _is_sm70_fp8_prefill_exact_dense_layer,
     _is_sm70_fp8_qpn8_layer,
     _is_sm70_fp8_qpn8_runtime_contract,
     _sm70_fp8_prefill_dense_workspaces,
+    _sm70_fp8_prefill_visible_dense_mm,
 )
 
 
@@ -232,7 +234,6 @@ def test_compressed_tensors_channel_fp8_qpn8_prepares_and_dispatches(monkeypatch
     monkeypatch.setattr(
         f"{module}._sm70_channel_fp8_qpn8_config", lambda layer: (16, 2, False)
     )
-    monkeypatch.setattr(f"{module}._is_qwen38_27b_fp8_qpn8_model", lambda: True)
     monkeypatch.setattr(f"{module}._is_sm70_fp8_qpn8_runtime_contract", lambda: True)
     monkeypatch.setattr(f"{module}._missing_sm70_fp8_qpn8_ops", lambda: [])
     monkeypatch.setattr(
@@ -348,6 +349,24 @@ def test_fp8_prefill_exact_dense_is_default_on(monkeypatch):
         envs.disable_envs_cache()
 
 
+def test_fp8_exact_8k_prefill_controls_are_generic_defaults(monkeypatch):
+    for name in (
+        "VLLM_SM70_FP8_PREFILL_FAST_SELECTOR",
+        "VLLM_SM70_FP8_PREFILL_PRESCALED",
+        "VLLM_SM70_FP8_PREFILL_CUTLASS",
+        "VLLM_SM70_FP8_PREFILL_VISIBLE_DENSE_MM",
+    ):
+        monkeypatch.delenv(name, raising=False)
+    envs.disable_envs_cache()
+    try:
+        assert envs.VLLM_SM70_FP8_PREFILL_FAST_SELECTOR
+        assert envs.VLLM_SM70_FP8_PREFILL_PRESCALED
+        assert envs.VLLM_SM70_FP8_PREFILL_CUTLASS
+        assert not envs.VLLM_SM70_FP8_PREFILL_VISIBLE_DENSE_MM
+    finally:
+        envs.disable_envs_cache()
+
+
 def test_fp8_qpn8_is_opt_in_except_for_mixed_nvfp4(monkeypatch):
     monkeypatch.delenv("VLLM_SM70_FP8_QPN8", raising=False)
     monkeypatch.delenv("VLLM_SM70_FP8_QPN8_LIBRARY", raising=False)
@@ -372,6 +391,7 @@ def test_fp8_qpn8_is_opt_in_except_for_mixed_nvfp4(monkeypatch):
 def test_fp8_prefill_exact_dense_shape_gate_is_narrow():
     layer = SimpleNamespace(
         tp_size=4,
+        weight_block_size=[128, 128],
         prefix="model.language_model.layers.1.mlp.gate_up_proj",
         weight=SimpleNamespace(shape=(5120, 8704)),
     )
@@ -383,18 +403,45 @@ def test_fp8_prefill_exact_dense_shape_gate_is_narrow():
     layer.tp_size = 4
     layer.prefix = "model.language_model.layers.1.self_attn.qkv_proj"
     layer.weight = SimpleNamespace(shape=(5120, 3584))
-    assert not _is_sm70_fp8_prefill_exact_dense_layer(layer)
+    assert _is_sm70_fp8_prefill_exact_dense_layer(layer)
     layer.prefix = "model.language_model.layers.1.linear_attn.in_proj_qkvz"
     layer.weight = SimpleNamespace(shape=(5120, 4096))
-    assert not _is_sm70_fp8_prefill_exact_dense_layer(layer)
+    assert _is_sm70_fp8_prefill_exact_dense_layer(layer)
     layer.prefix = "model.language_model.layers.1.mlp.gate_up_proj"
     layer.weight = SimpleNamespace(shape=(5120, 8192))
     assert not _is_sm70_fp8_prefill_exact_dense_layer(layer)
+    layer.weight_block_size = [64, 128]
+    layer.weight = SimpleNamespace(shape=(5120, 8704))
+    assert not _is_sm70_fp8_prefill_exact_dense_layer(layer)
+
+
+def test_fp8_exact_8k_prefill_gate_uses_operator_contract_only():
+    layer = SimpleNamespace(
+        tp_size=4,
+        weight_block_size=[128, 128],
+        prefix="engine.layers.1.linear_attn.in_proj_qkvz",
+        weight=SimpleNamespace(shape=(5120, 4096)),
+    )
+
+    assert _is_sm70_fp8_exact_8k_prefill_layer(layer)
+    layer.prefix = "engine.layers.3.self_attn.qkv_proj"
+    layer.weight = SimpleNamespace(shape=(5120, 3584))
+    assert _is_sm70_fp8_exact_8k_prefill_layer(layer)
+
+    layer.tp_size = 2
+    assert not _is_sm70_fp8_exact_8k_prefill_layer(layer)
+    layer.tp_size = 4
+    layer.weight_block_size = [64, 128]
+    assert not _is_sm70_fp8_exact_8k_prefill_layer(layer)
+    layer.weight_block_size = [128, 128]
+    layer.weight = SimpleNamespace(shape=(5120, 4096))
+    assert not _is_sm70_fp8_exact_8k_prefill_layer(layer)
 
 
 def test_fp8_qpn8_shape_gate_uses_checkpoint_native_layout():
     layer = SimpleNamespace(
         tp_size=4,
+        weight_block_size=[128, 128],
         prefix="model.language_model.layers.1.mlp.gate_up_proj",
         weight=SimpleNamespace(shape=(8704, 5120)),
     )
@@ -412,24 +459,8 @@ def test_fp8_qpn8_shape_gate_uses_checkpoint_native_layout():
     assert not _is_sm70_fp8_qpn8_layer(layer)
 
 
-def test_fp8_qpn8_model_gate_is_qwen38_27b_specific(monkeypatch):
-    text_config = SimpleNamespace(
-        model_type="qwen3_5_text",
-        hidden_size=5120,
-        intermediate_size=17408,
-        num_hidden_layers=64,
-        full_attention_interval=4,
-        head_dim=256,
-    )
-    model_config = SimpleNamespace(
-        hf_config=SimpleNamespace(
-            model_type="qwen3_5",
-            architectures=["Qwen3_5ForConditionalGeneration"],
-        ),
-        hf_text_config=text_config,
-    )
+def test_fp8_qpn8_runtime_gate_uses_engine_contract_only(monkeypatch):
     vllm_config = SimpleNamespace(
-        model_config=model_config,
         scheduler_config=SimpleNamespace(max_num_seqs=8),
         speculative_config=None,
     )
@@ -438,15 +469,12 @@ def test_fp8_qpn8_model_gate_is_qwen38_27b_specific(monkeypatch):
         lambda: vllm_config,
     )
 
-    assert _is_qwen38_27b_fp8_qpn8_model()
     assert _is_sm70_fp8_qpn8_runtime_contract()
     vllm_config.scheduler_config.max_num_seqs = 16
     assert not _is_sm70_fp8_qpn8_runtime_contract()
     vllm_config.scheduler_config.max_num_seqs = 8
     vllm_config.speculative_config = object()
     assert not _is_sm70_fp8_qpn8_runtime_contract()
-    text_config.hidden_size = 4096
-    assert not _is_qwen38_27b_fp8_qpn8_model()
 
 
 def test_fp8_prefill_exact_dense_workspace_is_bounded():
@@ -474,6 +502,50 @@ def test_fp8_prefill_exact_dense_workspace_is_reused(monkeypatch):
         assert len(allocations) == 1
     finally:
         _sm70_fp8_prefill_dense_workspaces.clear()
+
+
+def test_fp8_prefill_visible_dense_mm_is_long_prefill_only(monkeypatch):
+    workspace = torch.empty(24, dtype=torch.float16)
+    weight = torch.empty((4, 6), dtype=torch.uint8)
+    scales = torch.empty((1, 6), dtype=torch.float16)
+    calls = []
+
+    monkeypatch.setenv("VLLM_SM70_FP8_PREFILL_VISIBLE_DENSE_MM", "1")
+    monkeypatch.setattr(torch.accelerator, "current_device_index", lambda: 0)
+    monkeypatch.setattr(
+        "vllm.model_executor.layers.quantization.fp8.sm70_ops.fp8_sm70_dequantize_out",
+        lambda out, qweight, factors, group_size: (
+            calls.append((qweight, factors, group_size)),
+            out.fill_(1),
+        ),
+    )
+    envs.disable_envs_cache()
+    _sm70_fp8_prefill_dense_workspaces[(0, torch.float16)] = workspace
+    try:
+        long_prefill = _sm70_fp8_prefill_visible_dense_mm(
+            torch.ones((_SM70_FP8_PREFILL_DENSE_MIN_M, 4), dtype=torch.float16),
+            weight,
+            scales,
+            workspace.data_ptr(),
+            gated_silu=False,
+            min_prefill_m=_SM70_FP8_PREFILL_DENSE_MIN_M,
+        )
+        tail = _sm70_fp8_prefill_visible_dense_mm(
+            torch.ones((1, 4), dtype=torch.float16),
+            weight,
+            scales,
+            workspace.data_ptr(),
+            gated_silu=False,
+            min_prefill_m=_SM70_FP8_PREFILL_DENSE_MIN_M,
+        )
+    finally:
+        _sm70_fp8_prefill_dense_workspaces.clear()
+        envs.disable_envs_cache()
+
+    assert long_prefill is not None
+    assert long_prefill.shape == (_SM70_FP8_PREFILL_DENSE_MIN_M, 6)
+    assert tail is None
+    assert calls == [(weight, scales, 128)]
 
 
 def test_fp8_prefill_dispatch_reaches_runtime_op_for_small_and_large_m(monkeypatch):
@@ -526,6 +598,70 @@ def test_fp8_prefill_dispatch_reaches_runtime_op_for_small_and_large_m(monkeypat
             False,
         ),
     ]
+
+
+def test_fp8_prefill_prescaled_scales_only_reach_exact_8k_route(monkeypatch):
+    calls = []
+
+    def fake_default(out, input, qweight, scales, *args):
+        calls.append(("default", input.shape[0], scales))
+        out.zero_()
+
+    def fake_prescaled(out, input, qweight, scales, *args):
+        calls.append(("prescaled", input.shape[0], scales))
+        out.zero_()
+
+    monkeypatch.setattr(
+        "vllm.model_executor.layers.quantization.fp8.sm70_ops.fp8_gemm_sm70_out",
+        fake_default,
+    )
+    monkeypatch.setattr(
+        "vllm.model_executor.layers.quantization.fp8.sm70_ops."
+        "fp8_gemm_sm70_prefill_prescaled_out",
+        fake_prescaled,
+    )
+    normal_scales = torch.empty((1, 6), dtype=torch.float16)
+    prescaled_scales = torch.empty((1, 6), dtype=torch.float16)
+    layer = SimpleNamespace(
+        sm70_fp8_turbomind=True,
+        sm70_fp8_bmm=False,
+        output_size_per_partition=6,
+        weight=torch.empty((4, 6), dtype=torch.uint8),
+        weight_scale_inv=normal_scales,
+        sm70_fp8_prefill_prescaled_scales=prescaled_scales,
+        sm70_fp8_k_ld=4,
+        sm70_fp8_q_ld=6,
+    )
+    method = SimpleNamespace()
+
+    monkeypatch.setenv("VLLM_SM70_FP8_PREFILL_FAST_SELECTOR", "1")
+    monkeypatch.setenv("VLLM_SM70_FP8_PREFILL_PRESCALED", "1")
+    envs.disable_envs_cache()
+    try:
+        Fp8LinearMethod.apply(method, layer, torch.empty((1, 4), dtype=torch.float16))
+        Fp8LinearMethod.apply(
+            method,
+            layer,
+            torch.empty((_SM70_FP8_EXACT_8K_PREFILL_M, 4), dtype=torch.float16),
+        )
+        monkeypatch.setenv("VLLM_SM70_FP8_PREFILL_PRESCALED", "0")
+        envs.disable_envs_cache()
+        Fp8LinearMethod.apply(
+            method,
+            layer,
+            torch.empty((_SM70_FP8_EXACT_8K_PREFILL_M, 4), dtype=torch.float16),
+        )
+    finally:
+        envs.disable_envs_cache()
+
+    assert [(route, m) for route, m, _ in calls] == [
+        ("default", 1),
+        ("prescaled", _SM70_FP8_EXACT_8K_PREFILL_M),
+        ("default", _SM70_FP8_EXACT_8K_PREFILL_M),
+    ]
+    assert calls[0][2] is normal_scales
+    assert calls[1][2] is prescaled_scales
+    assert calls[2][2] is normal_scales
 
 
 def test_fp8_qpn8_dispatches_small_m_and_workspace_fallback(monkeypatch):

--- a/vllm/_custom_ops.py
+++ b/vllm/_custom_ops.py
@@ -3032,6 +3032,32 @@ def sm70_tp4_all_reduce_gemma_rms_norm(
     )
 
 
+def sm70_tp4_reduce_scatter_gemma_rms_norm_all_gather(
+    fa: int,
+    inp: torch.Tensor,
+    residual: torch.Tensor,
+    weight: torch.Tensor,
+    normalized_out: torch.Tensor,
+    residual_out: torch.Tensor,
+    reg_input_buffer: int,
+    reg_output_buffer: int,
+    reg_buffer_sz_bytes: int,
+    epsilon: float,
+) -> None:
+    torch.ops._C_custom_ar.sm70_tp4_reduce_scatter_gemma_rms_norm_all_gather(
+        fa,
+        inp,
+        residual,
+        weight,
+        normalized_out,
+        residual_out,
+        reg_input_buffer,
+        reg_output_buffer,
+        reg_buffer_sz_bytes,
+        epsilon,
+    )
+
+
 def all_reduce_sum2(
     fa: int,
     inp_a: torch.Tensor,

--- a/vllm/_sm70_ops.py
+++ b/vllm/_sm70_ops.py
@@ -457,6 +457,35 @@ if hasattr(torch.ops._C, "fp8_gemm_sm70_out"):
         return None
 
 
+def fp8_gemm_sm70_prefill_prescaled_out(
+    out: torch.Tensor,
+    input: torch.Tensor,
+    qweight: torch.Tensor,
+    prescaled_factors: torch.Tensor,
+    group_size: int,
+    k_ld: int,
+    q_ld: int,
+) -> None:
+    _op("fp8_gemm_sm70_prefill_prescaled_out")(
+        out, input, qweight, prescaled_factors, group_size, k_ld, q_ld
+    )
+
+
+if hasattr(torch.ops._C, "fp8_gemm_sm70_prefill_prescaled_out"):
+
+    @register_fake("_C::fp8_gemm_sm70_prefill_prescaled_out")
+    def _fp8_gemm_sm70_prefill_prescaled_out_fake(
+        out: torch.Tensor,
+        input: torch.Tensor,
+        qweight: torch.Tensor,
+        prescaled_factors: torch.Tensor,
+        group_size: int,
+        k_ld: int,
+        q_ld: int,
+    ) -> None:
+        return None
+
+
 def fp8_qpn8_prepare_sm70(
     qweight: torch.Tensor,
     scales: torch.Tensor,

--- a/vllm/compilation/passes/fusion/allreduce_rms_fusion.py
+++ b/vllm/compilation/passes/fusion/allreduce_rms_fusion.py
@@ -442,6 +442,89 @@ def _sm70_ar_gemma_rms_match(match: pm.Match) -> bool:
     return False
 
 
+def _sm70_tp4_fusion_diagnostic(graph: fx.Graph) -> str:
+    """Summarize real post-grad users when the fail-closed pattern misses."""
+    all_reduces: list[fx.Node] = []
+    direct_users: dict[str, int] = {}
+    for node in graph.nodes:
+        if node.target != _ALL_REDUCE_OP:
+            continue
+        value = node.meta.get("val")
+        if value is None or value.dim() != 2 or value.shape[-1] != 5120:
+            continue
+        all_reduces.append(node)
+        for user in node.users:
+            target = str(user.target)
+            direct_users[target] = direct_users.get(target, 0) + 1
+
+    traces: list[str] = []
+    for root in all_reduces:
+        queue: list[tuple[fx.Node, int]] = [(root, 0)]
+        seen = {root}
+        trace_nodes: list[tuple[fx.Node, int]] = []
+        while queue and len(trace_nodes) < 32:
+            node, depth = queue.pop(0)
+            trace_nodes.append((node, depth))
+            if depth == 10:
+                continue
+            for user in node.users:
+                if user not in seen:
+                    seen.add(user)
+                    queue.append((user, depth + 1))
+        targets = " ".join(str(node.target) for node, _ in trace_nodes)
+        if "mean" not in targets and "rsqrt" not in targets and "rms" not in targets:
+            continue
+        lines = []
+        for node, depth in trace_nodes:
+            value = node.meta.get("val")
+            shape = getattr(value, "shape", None)
+            dtype = getattr(value, "dtype", None)
+            lines.append(
+                f"{depth}:{node.name}:{node.target}:shape={shape}:dtype={dtype}:"
+                f"args={node.args}:kwargs={node.kwargs}"
+            )
+        traces.append("\n".join(lines))
+        if len(traces) == 4:
+            break
+
+    return (
+        f"all_reduce_f16_5120={len(all_reduces)}; "
+        f"direct_users={direct_users}; candidate_traces=\n" + "\n---\n".join(traces)
+    )
+
+
+def _sm70_tp4_expected_graph_matches(graph: fx.Graph) -> int:
+    """Count supported FP32-residual boundaries in one post-grad graph."""
+    count = 0
+    for node in graph.nodes:
+        if (
+            node.target
+            != torch.ops.vllm.sm70_gemma_long_prefill_fused_add_rms_norm.default
+        ):
+            continue
+        reduced = node.args[0]
+        residual = node.args[1]
+        if not isinstance(reduced, fx.Node) or reduced.target != _ALL_REDUCE_OP:
+            continue
+        if not isinstance(residual, fx.Node):
+            continue
+        residual_value = residual.meta.get("val")
+        if residual_value is None or residual_value.dtype != torch.float32:
+            continue
+        input_node = reduced.args[0]
+        if not isinstance(input_node, fx.Node):
+            continue
+        value = input_node.meta.get("val")
+        if (
+            value is not None
+            and value.dtype == torch.float16
+            and value.dim() == 2
+            and value.shape[-1] == 5120
+        ):
+            count += 1
+    return count
+
+
 class Sm70AllReduceGemmaRMSNormPattern(BasePattern):
     def __init__(
         self,
@@ -486,6 +569,73 @@ class Sm70AllReduceGemmaRMSNormPattern(BasePattern):
             weight: torch.Tensor,
         ) -> tuple[torch.Tensor, torch.Tensor]:
             return torch.ops.vllm.sm70_tp2_all_reduce_gemma_rms_norm(
+                input,
+                residual,
+                weight,
+                self.epsilon,
+                group_name=self.group_name,
+            )
+
+        pm.register_replacement(
+            pattern,
+            replacement,
+            self.get_inputs(),
+            pm.fwd_only,
+            pm_pass,
+            extra_check=_sm70_ar_gemma_rms_match,
+        )
+
+        first_return_only = lambda fn: lambda a, b, c: fn(a, b, c)[0]
+        pm.register_replacement(
+            first_return_only(pattern),  # type: ignore[no-untyped-call]
+            first_return_only(replacement),  # type: ignore[no-untyped-call]
+            self.get_inputs(),
+            pm.fwd_only,
+            pm_pass,
+            extra_check=_sm70_ar_gemma_rms_match,
+        )
+
+
+class Sm70Tp4LongPrefillFusedNormPattern(BasePattern):
+    """Fuse TP4 AR plus the accepted opaque mixed-dtype Gemma norm."""
+
+    def __init__(
+        self,
+        epsilon: float,
+        dtype: torch.dtype,
+        device: str | None,
+    ) -> None:
+        super().__init__(dtype, device)
+        self.epsilon = epsilon
+        self.group_name = get_tp_group().unique_name
+
+    def get_inputs(self) -> list[torch.Tensor]:
+        return [
+            self.empty_f32(5, 5120),
+            self.empty(5, 5120),
+            self.empty(5120),
+        ]
+
+    def register(self, pm_pass: PatternMatcherPass) -> None:
+        def pattern(
+            residual: torch.Tensor,
+            input: torch.Tensor,
+            weight: torch.Tensor,
+        ) -> tuple[torch.Tensor, torch.Tensor]:
+            reduced = tensor_model_parallel_all_reduce(input)
+            return torch.ops.vllm.sm70_gemma_long_prefill_fused_add_rms_norm(
+                reduced,
+                residual,
+                weight,
+                self.epsilon,
+            )
+
+        def replacement(
+            residual: torch.Tensor,
+            input: torch.Tensor,
+            weight: torch.Tensor,
+        ) -> tuple[torch.Tensor, torch.Tensor]:
+            return torch.ops.vllm.sm70_tp4_reduce_scatter_gemma_rms_norm_all_gather(
                 input,
                 residual,
                 weight,
@@ -874,6 +1024,7 @@ class AllReduceFusionPass(VllmPatternMatcherPass):
         self.hidden_dim = config.model_config.get_hidden_size()
         self.group = get_tp_group().device_group
         rank = get_tensor_model_parallel_rank()
+        self.rank = rank
         sm70_common = (
             self.hidden_dim == 5120
             and self.model_dtype == torch.float16
@@ -882,7 +1033,20 @@ class AllReduceFusionPass(VllmPatternMatcherPass):
         self.sm70_tp2_mode = (
             envs.VLLM_SM70_TP2_AR_GEMMA_RMS_FUSION and self.tp_size == 2 and sm70_common
         )
-        self.sm70_mode = self.sm70_tp2_mode
+        self.sm70_tp4_long_mode = (
+            envs.VLLM_SM70_TP4_LONG_PREFILL_FUSED_NORM
+            and self.tp_size == 4
+            and sm70_common
+            and config.parallel_config.pipeline_parallel_size == 1
+            and config.speculative_config is None
+        )
+        self.sm70_tp4_model_expected_patterns = (
+            2 * config.model_config.get_num_layers(config.parallel_config) - 1
+            if self.sm70_tp4_long_mode
+            else 0
+        )
+        self.sm70_tp4_total_matches = 0
+        self.sm70_mode = self.sm70_tp2_mode or self.sm70_tp4_long_mode
         if self.sm70_mode:
             device_comm = get_tp_group().device_communicator
             ca_comm = (
@@ -893,6 +1057,25 @@ class AllReduceFusionPass(VllmPatternMatcherPass):
                     "SM70 TP%d allreduce-Gemma-RMS fusion requires active custom AR.",
                     self.tp_size,
                 )
+                return
+            if self.sm70_tp4_long_mode and ca_comm.long_prefill_output_ptrs is None:
+                logger.warning_once(
+                    "SM70 TP4 long-prefill collective-norm buffers are unavailable."
+                )
+                return
+            if self.sm70_tp4_long_mode and not hasattr(
+                torch.ops.vllm,
+                "sm70_gemma_long_prefill_fused_add_rms_norm",
+            ):
+                logger.warning_once(
+                    "SM70 long-prefill Gemma norm op is unavailable for TP4 fusion."
+                )
+                return
+            if self.sm70_tp4_long_mode and not hasattr(
+                torch.ops.vllm,
+                "sm70_tp4_reduce_scatter_gemma_rms_norm_all_gather",
+            ):
+                logger.warning_once("SM70 TP4 fused collective-norm op is unavailable.")
                 return
             self.max_token_num = config.scheduler_config.max_num_batched_tokens
             self.register_sm70_patterns()
@@ -968,6 +1151,14 @@ class AllReduceFusionPass(VllmPatternMatcherPass):
 
     @enable_fake_mode
     def register_sm70_patterns(self) -> None:
+        if self.sm70_tp4_long_mode:
+            Sm70Tp4LongPrefillFusedNormPattern(
+                1e-6,
+                self.model_dtype,
+                self.device,
+            ).register(self.patterns)
+            self.disabled = False
+            return
         for residual_dtype in (torch.float16, torch.float32):
             Sm70AllReduceGemmaRMSNormPattern(
                 1e-6,
@@ -1029,6 +1220,12 @@ class AllReduceFusionPass(VllmPatternMatcherPass):
         if self.disabled:
             logger.warning_once("AllReduce fusion pass is disabled.")
             return False
+        if getattr(self, "sm70_tp4_long_mode", False):
+            return bool(
+                compile_range.is_single_size()
+                and 8000 <= compile_range.start <= min(8192, self.max_token_num)
+                and compile_range.start % self.tp_size == 0
+            )
         return bool(compile_range.end <= self.max_token_num)
 
     @VllmInductorPass.time_and_log
@@ -1037,7 +1234,36 @@ class AllReduceFusionPass(VllmPatternMatcherPass):
             logger.debug("AllReduceFusionPass disabled")
             return
 
+        expected_graph_matches = (
+            _sm70_tp4_expected_graph_matches(graph) if self.sm70_tp4_long_mode else 0
+        )
         self.matched_count = self.patterns.apply(graph)
+        if self.sm70_tp4_long_mode and self.matched_count != expected_graph_matches:
+            if self.rank == 0:
+                logger.error(
+                    "SM70 TP4 fusion post-grad diagnostic:\n%s",
+                    _sm70_tp4_fusion_diagnostic(graph),
+                )
+            raise RuntimeError(
+                "SM70 TP4 long-prefill fused collective-norm requires a "
+                "complete residual chain in every piecewise graph: expected "
+                f"{expected_graph_matches} matches, got "
+                f"{self.matched_count}."
+            )
+        if self.sm70_tp4_long_mode:
+            self.sm70_tp4_total_matches += self.matched_count
+            if self.sm70_tp4_total_matches > self.sm70_tp4_model_expected_patterns:
+                raise RuntimeError(
+                    "SM70 TP4 long-prefill fused collective-norm exceeded the "
+                    "model residual-chain count: expected at most "
+                    f"{self.sm70_tp4_model_expected_patterns}, got "
+                    f"{self.sm70_tp4_total_matches}."
+                )
+            if self.sm70_tp4_total_matches == self.sm70_tp4_model_expected_patterns:
+                logger.info_once(
+                    "SM70 TP4 fused the complete %d-boundary model residual chain.",
+                    self.sm70_tp4_total_matches,
+                )
         logger.debug("Replaced %s patterns", self.matched_count)
         if getattr(self, "sm70_mode", False):
             logger.info(

--- a/vllm/compilation/passes/fusion/sequence_parallelism.py
+++ b/vllm/compilation/passes/fusion/sequence_parallelism.py
@@ -256,6 +256,71 @@ class MiddleAllReduceRMSNormPattern(_SequenceParallelPatternHelper):
         )
 
 
+class MiddleAllReduceSm70GemmaLongPrefillPattern(_SequenceParallelPatternHelper):
+    """Keep the accepted mixed-dtype SM70 norm while applying SP."""
+
+    def __init__(
+        self,
+        epsilon: float,
+        dtype: torch.dtype,
+        device: str | None,
+        weight_dtype: torch.dtype,
+    ) -> None:
+        super().__init__(epsilon, dtype, device)
+        self.weight_dtype = weight_dtype
+
+    def get_inputs(self) -> list[torch.Tensor]:
+        residual = torch.empty([4, 4], device=self.device, dtype=torch.float32)
+        mm_1 = torch.empty([4, 4], device=self.device, dtype=self.dtype)
+        weight = torch.empty([4], device=self.device, dtype=self.weight_dtype)
+        return [residual, mm_1, weight]
+
+    def register(self, pm_pass: PatternMatcherPass) -> None:
+        def pattern(
+            residual: torch.Tensor,
+            mm_1: torch.Tensor,
+            weight: torch.Tensor,
+        ) -> tuple[torch.Tensor, torch.Tensor]:
+            all_reduce = self._all_reduce(mm_1)
+            return torch.ops.vllm.sm70_gemma_long_prefill_fused_add_rms_norm(
+                all_reduce,
+                residual,
+                weight,
+                self.epsilon,
+            )
+
+        def replacement(
+            residual: torch.Tensor,
+            mm_1: torch.Tensor,
+            weight: torch.Tensor,
+        ) -> tuple[torch.Tensor, torch.Tensor]:
+            reduce_scatter = self._reduce_scatter(mm_1)
+            local_len = reduce_scatter.size(0)
+            residual = residual[
+                self.tp_rank * local_len : self.tp_rank * local_len + local_len, ...
+            ]
+            normalized, residual_out = (
+                torch.ops.vllm.sm70_gemma_long_prefill_fused_add_rms_norm(
+                    reduce_scatter,
+                    residual,
+                    weight,
+                    self.epsilon,
+                )
+            )
+            return self._all_gather(normalized), residual_out
+
+        pm.register_replacement(
+            pattern, replacement, self.get_inputs(), pm.fwd_only, pm_pass
+        )
+        pm.register_replacement(
+            get_first_out_wrapper(pattern),
+            get_first_out_wrapper(replacement),
+            self.get_inputs(),
+            pm.fwd_only,
+            pm_pass,
+        )
+
+
 class FirstAllReduceRMSNormStaticFP8Pattern(_SequenceParallelPatternHelper):
     def __init__(
         self,
@@ -583,6 +648,16 @@ class SequenceParallelismPass(VllmPatternMatcherPass):
             MiddleAllReduceRMSNormPattern(
                 epsilon, self.model_dtype, self.device
             ).register(self.patterns)
+            if epsilon == 1e-6 and hasattr(
+                torch.ops.vllm,
+                "sm70_gemma_long_prefill_fused_add_rms_norm",
+            ):
+                MiddleAllReduceSm70GemmaLongPrefillPattern(
+                    epsilon,
+                    self.model_dtype,
+                    self.device,
+                    self.model_dtype,
+                ).register(self.patterns)
 
         self.dump_patterns(config, self.patterns)
 

--- a/vllm/distributed/device_communicators/cuda_communicator.py
+++ b/vllm/distributed/device_communicators/cuda_communicator.py
@@ -21,9 +21,10 @@ from ..utils import StatelessProcessGroup
 from .base_device_communicator import DeviceCommunicatorBase
 
 logger = init_logger(__name__)
-_SEEN_TP_ALLREDUCE_PATHS: set[
-    tuple[str, str, tuple[int, ...], torch.dtype, int]
-] = set()
+_SM70_TP4_LONG_PREFILL_BUFFER_BYTES = 8192 * 5120 * 2
+_SEEN_TP_ALLREDUCE_PATHS: set[tuple[str, str, tuple[int, ...], torch.dtype, int]] = (
+    set()
+)
 
 
 def _trace_all_reduce_path(
@@ -82,6 +83,7 @@ class CudaCommunicator(DeviceCommunicatorBase):
             use_top1_custom_ar = False
             use_sm70_awq_mlp_down_tile_ar = False
             use_sm70_awq_mlp_down_tile_overlap = False
+            use_sm70_tp4_long_prefill_fused_norm = False
             use_torch_symm_mem = False
             use_flashinfer_allreduce = False
         else:
@@ -93,15 +95,19 @@ class CudaCommunicator(DeviceCommunicatorBase):
             use_sm70_awq_mlp_down_tile_overlap = (
                 envs.VLLM_SM70_AWQ_MLP_DOWN_TILE_OVERLAP
             )
+            use_sm70_tp4_long_prefill_fused_norm = (
+                envs.VLLM_SM70_TP4_LONG_PREFILL_FUSED_NORM
+                and self.world_size == 4
+                and current_platform.is_device_capability(70)
+            )
             use_torch_symm_mem = envs.VLLM_ALLREDUCE_USE_SYMM_MEM
             use_flashinfer_allreduce = envs.VLLM_ALLREDUCE_USE_FLASHINFER
 
         self.use_custom_allreduce = use_custom_allreduce
         self.use_top1_custom_ar = use_top1_custom_ar
         self.use_sm70_awq_mlp_down_tile_ar = use_sm70_awq_mlp_down_tile_ar
-        self.use_sm70_awq_mlp_down_tile_overlap = (
-            use_sm70_awq_mlp_down_tile_overlap
-        )
+        self.use_sm70_awq_mlp_down_tile_overlap = use_sm70_awq_mlp_down_tile_overlap
+        self.use_sm70_tp4_long_prefill_fused_norm = use_sm70_tp4_long_prefill_fused_norm
         self.use_torch_symm_mem = use_torch_symm_mem
         self.use_flashinfer_allreduce = use_flashinfer_allreduce
 
@@ -149,6 +155,7 @@ class CudaCommunicator(DeviceCommunicatorBase):
             or use_top1_custom_ar
             or use_sm70_awq_mlp_down_tile_ar
             or use_sm70_awq_mlp_down_tile_overlap
+            or use_sm70_tp4_long_prefill_fused_norm
         ) and self.world_size > 1:
             # Initialize a custom fast all-reduce implementation.
             # `use_top1_custom_ar` deliberately only provisions the IPC/signaling
@@ -161,6 +168,12 @@ class CudaCommunicator(DeviceCommunicatorBase):
                 symm_mem_enabled=(
                     self.symm_mem_comm is not None and not self.symm_mem_comm.disabled
                 ),
+                max_size=(
+                    _SM70_TP4_LONG_PREFILL_BUFFER_BYTES
+                    if use_sm70_tp4_long_prefill_fused_norm
+                    else 8192 * 1024
+                ),
+                long_prefill_fusion_enabled=use_sm70_tp4_long_prefill_fused_norm,
             )
 
             if current_platform.is_rocm():
@@ -435,6 +448,31 @@ class CudaCommunicator(DeviceCommunicatorBase):
             input_, residual, weight, epsilon
         )
 
+    def sm70_tp4_reduce_scatter_gemma_rms_norm_all_gather(
+        self,
+        input_: torch.Tensor,
+        residual: torch.Tensor,
+        weight: torch.Tensor,
+        epsilon: float,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        ca_comm = self.ca_comm
+        if (
+            not self.use_sm70_tp4_long_prefill_fused_norm
+            or ca_comm is None
+            or ca_comm.disabled
+            or not ca_comm.can_sm70_tp4_reduce_scatter_gemma_rms_norm_all_gather(
+                input_, residual, weight
+            )
+        ):
+            raise RuntimeError(
+                "SM70 TP4 long-prefill fused collective-norm route was "
+                "compiled for an unsupported runtime shape or communicator."
+            )
+        _trace_all_reduce_path(self, "sm70_tp4_fused_rs_norm_ag", input_)
+        return ca_comm.sm70_tp4_reduce_scatter_gemma_rms_norm_all_gather(
+            input_, residual, weight, epsilon
+        )
+
     def sm70_awq_mlp_down_tile_all_reduce(self, input_):
         if not self.use_sm70_awq_mlp_down_tile_ar:
             return None
@@ -468,18 +506,14 @@ class CudaCommunicator(DeviceCommunicatorBase):
             k_ld,
             q_ld,
             tile_numel=envs.VLLM_SM70_AWQ_MLP_DOWN_TILE_OVERLAP_TILE_NUMEL,
-            reducer_blocks=(
-                envs.VLLM_SM70_AWQ_MLP_DOWN_TILE_OVERLAP_REDUCER_BLOCKS
-            ),
+            reducer_blocks=(envs.VLLM_SM70_AWQ_MLP_DOWN_TILE_OVERLAP_REDUCER_BLOCKS),
             kernel_reducer_blocks=(
                 envs.VLLM_SM70_AWQ_MLP_DOWN_TILE_OVERLAP_KERNEL_REDUCER_BLOCKS
             ),
             overlap=envs.VLLM_SM70_AWQ_MLP_DOWN_TILE_OVERLAP_SIDE_STREAM,
         )
         if out is not None:
-            _trace_all_reduce_path(
-                self, "sm70_awq_mlp_down_tile_overlap", input_
-            )
+            _trace_all_reduce_path(self, "sm70_awq_mlp_down_tile_overlap", input_)
         return out
 
     def reduce_scatter(self, input_: torch.Tensor, dim: int = -1):

--- a/vllm/distributed/device_communicators/custom_all_reduce.py
+++ b/vllm/distributed/device_communicators/custom_all_reduce.py
@@ -68,6 +68,7 @@ class CustomAllreduce:
         device: int | str | torch.device,
         max_size=8192 * 1024,
         symm_mem_enabled=False,
+        long_prefill_fusion_enabled=False,
     ) -> None:
         """
         Args:
@@ -81,6 +82,7 @@ class CustomAllreduce:
         """
         self._IS_CAPTURING = False
         self.disabled = True
+        self.long_prefill_output_ptrs: list[int] | None = None
 
         if not custom_ar:
             # disable because of missing custom allreduce library
@@ -133,6 +135,7 @@ class CustomAllreduce:
         if (
             current_platform.is_cuda()
             and symm_mem_enabled
+            and not long_prefill_fusion_enabled
             and device_capability is not None
         ):
             device_capability_str = device_capability.as_version_str()
@@ -251,6 +254,12 @@ class CustomAllreduce:
             8 * 1024 * 1024, dtype=torch.uint8, device=self.device
         )
         self.max_size = max_size
+        # Provisioning the long-prefill fusion buffers must not widen ordinary
+        # custom-AR dispatch beyond its established 8-MiB policy. The fused
+        # predicate below uses the full allocation capacity explicitly.
+        self.dispatch_max_size = (
+            min(max_size, 8192 * 1024) if long_prefill_fusion_enabled else max_size
+        )
         self.rank = rank
         self.world_size = world_size
         self.fully_connected = fully_connected
@@ -259,6 +268,12 @@ class CustomAllreduce:
             self.meta_ptrs, self.rank_data, rank, self.fully_connected
         )
         ops.register_buffer(self._ptr, self.buffer_ptrs)
+        if long_prefill_fusion_enabled:
+            self.long_prefill_output_ptrs = self.create_shared_buffer(
+                max_size,
+                group=group,
+            )
+            ops.register_buffer(self._ptr, self.long_prefill_output_ptrs)
 
     @contextmanager
     def capture(self):
@@ -311,7 +326,7 @@ class CustomAllreduce:
         # for 4 or more non NVLink-capable GPUs, custom allreduce provides
         # little performance improvement over NCCL.
         if self.world_size == 2 or self.fully_connected:
-            return inp_size < self.max_size
+            return inp_size < self.dispatch_max_size
         return False
 
     def all_reduce(
@@ -442,6 +457,72 @@ class CustomAllreduce:
             and inp.ndim == 2
             and 1 <= inp.shape[0] <= 64
             and inp.shape[1] == 5120
+            and residual.shape == inp.shape
+            and residual.dtype == torch.float32
+            and weight.ndim == 1
+            and weight.numel() == 5120
+            and weight.dtype in (torch.float16, torch.float32)
+            and inp.is_contiguous()
+            and residual.is_contiguous()
+            and weight.is_contiguous()
+            and inp.device == residual.device == weight.device
+        )
+
+    def sm70_tp4_reduce_scatter_gemma_rms_norm_all_gather(
+        self,
+        inp: torch.Tensor,
+        residual: torch.Tensor,
+        weight: torch.Tensor,
+        epsilon: float,
+        *,
+        normalized_out: torch.Tensor | None = None,
+        residual_out: torch.Tensor | None = None,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Benchmark-only long-prefill fused RS + Gemma RMSNorm + AG."""
+        if not self.can_sm70_tp4_reduce_scatter_gemma_rms_norm_all_gather(
+            inp, residual, weight
+        ):
+            raise RuntimeError("SM70 TP4 long-prefill fused norm is unavailable")
+        assert self.long_prefill_output_ptrs is not None
+        if normalized_out is None:
+            normalized_out = torch.empty_like(inp)
+        if residual_out is None:
+            residual_out = torch.empty_like(residual, dtype=torch.float32)
+        graph_registered = (
+            self._IS_CAPTURING and torch.cuda.is_current_stream_capturing()
+        )
+        ops.sm70_tp4_reduce_scatter_gemma_rms_norm_all_gather(
+            self._ptr,
+            inp,
+            residual,
+            weight,
+            normalized_out,
+            residual_out,
+            0 if graph_registered else self.buffer_ptrs[self.rank],
+            0 if graph_registered else self.long_prefill_output_ptrs[self.rank],
+            self.max_size,
+            epsilon,
+        )
+        return normalized_out, residual_out
+
+    def can_sm70_tp4_reduce_scatter_gemma_rms_norm_all_gather(
+        self,
+        inp: torch.Tensor,
+        residual: torch.Tensor,
+        weight: torch.Tensor,
+    ) -> bool:
+        return (
+            not self.disabled
+            and self.long_prefill_output_ptrs is not None
+            and self.world_size == 4
+            and self.fully_connected
+            and inp.is_cuda
+            and inp.dtype == torch.float16
+            and inp.ndim == 2
+            and inp.shape[0] % self.world_size == 0
+            and 1 <= inp.shape[0] // self.world_size <= 2048
+            and inp.shape[1] == 5120
+            and inp.numel() * inp.element_size() <= self.max_size
             and residual.shape == inp.shape
             and residual.dtype == torch.float32
             and weight.ndim == 1
@@ -718,6 +799,12 @@ class CustomAllreduce:
             self._ptr = 0
             self.free_shared_buffer(self.meta_ptrs, rank=self.rank)
             self.free_shared_buffer(self.buffer_ptrs, rank=self.rank)
+            if self.long_prefill_output_ptrs is not None:
+                self.free_shared_buffer(
+                    self.long_prefill_output_ptrs,
+                    rank=self.rank,
+                )
+                self.long_prefill_output_ptrs = None
 
     def __del__(self):
         self.close()

--- a/vllm/distributed/parallel_state.py
+++ b/vllm/distributed/parallel_state.py
@@ -182,6 +182,33 @@ def sm70_tp2_all_reduce_gemma_rms_norm_fake(
     return torch.empty_like(tensor), torch.empty_like(residual, dtype=torch.float32)
 
 
+def sm70_tp4_reduce_scatter_gemma_rms_norm_all_gather(
+    tensor: torch.Tensor,
+    residual: torch.Tensor,
+    weight: torch.Tensor,
+    epsilon: float,
+    group_name: str,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    assert group_name in _groups, f"Group {group_name} is not found."
+    group = _groups[group_name]()
+    if group is None:
+        raise ValueError(f"Group {group_name} is destroyed.")
+    return group._sm70_tp4_reduce_scatter_gemma_rms_norm_all_gather_out_place(
+        tensor, residual, weight, epsilon
+    )
+
+
+def sm70_tp4_reduce_scatter_gemma_rms_norm_all_gather_fake(
+    tensor: torch.Tensor,
+    residual: torch.Tensor,
+    weight: torch.Tensor,
+    epsilon: float,
+    group_name: str,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    del weight, epsilon, group_name
+    return torch.empty_like(tensor), torch.empty_like(residual, dtype=torch.float32)
+
+
 def sm70_awq_mlp_down_tile_all_reduce(
     tensor: torch.Tensor, group_name: str
 ) -> torch.Tensor:
@@ -369,6 +396,12 @@ direct_register_custom_op(
     op_name="sm70_tp2_all_reduce_gemma_rms_norm",
     op_func=sm70_tp2_all_reduce_gemma_rms_norm,
     fake_impl=sm70_tp2_all_reduce_gemma_rms_norm_fake,
+)
+
+direct_register_custom_op(
+    op_name="sm70_tp4_reduce_scatter_gemma_rms_norm_all_gather",
+    op_func=sm70_tp4_reduce_scatter_gemma_rms_norm_all_gather,
+    fake_impl=sm70_tp4_reduce_scatter_gemma_rms_norm_all_gather_fake,
 )
 
 direct_register_custom_op(
@@ -695,9 +728,27 @@ class GroupCoordinator:
             raise RuntimeError("Device communicator lacks SM70 fused AR RMSNorm")
         return fused_op(input_, residual, weight, epsilon)
 
-    def sm70_awq_mlp_down_tile_all_reduce(
-        self, input_: torch.Tensor
-    ) -> torch.Tensor:
+    def _sm70_tp4_reduce_scatter_gemma_rms_norm_all_gather_out_place(
+        self,
+        input_: torch.Tensor,
+        residual: torch.Tensor,
+        weight: torch.Tensor,
+        epsilon: float,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        if self.device_communicator is None:
+            raise ValueError("No device communicator found")
+        fused_op = getattr(
+            self.device_communicator,
+            "sm70_tp4_reduce_scatter_gemma_rms_norm_all_gather",
+            None,
+        )
+        if fused_op is None:
+            raise RuntimeError(
+                "Device communicator lacks SM70 TP4 fused collective-norm"
+            )
+        return fused_op(input_, residual, weight, epsilon)
+
+    def sm70_awq_mlp_down_tile_all_reduce(self, input_: torch.Tensor) -> torch.Tensor:
         if self.world_size == 1:
             return input_
 

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -1639,8 +1639,8 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "VLLM_SM70_FP8_PREFILL_EXACT_DENSE": lambda: bool(
         int(os.getenv("VLLM_SM70_FP8_PREFILL_EXACT_DENSE", "1"))
     ),
-    # Memory-neutral QPN8 layout for model-, shape-, and runtime-gated
-    # Qwen3.8 TP4 no-MTP dense projections. Pure-FP8 checkpoints must opt in;
+    # Memory-neutral QPN8 layout for shape- and runtime-gated TP4 block-FP8
+    # dense projections. Pure-FP8 checkpoints must opt in;
     # a mixed NVFP4 checkpoint may select its separately validated default in
     # the compressed-tensors scheme. Explicit 0 disables both routes.
     "VLLM_SM70_FP8_QPN8": lambda: bool(int(os.getenv("VLLM_SM70_FP8_QPN8", "0"))),

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -153,6 +153,7 @@ if TYPE_CHECKING:
     VLLM_SM70_FP8_COORDINATED_TUNING: bool = True
     VLLM_SM70_FP8_REUSE_IMPORTED_CACHE: bool = False
     VLLM_SM70_FP8_SAFE_FAST_SELECTOR: bool = False
+    VLLM_SM70_FP8_QWEN38_PREFILL_FAST_SELECTOR: bool = True
     VLLM_SM70_FP8_PRESERVE_DEFAULT_SPLITS: bool = True
     VLLM_SM70_FP8_PRESERVE_DEFAULT_SPLITS_ONLY: bool = False
     VLLM_SM70_FP8_PREFILL_EXACT_DENSE: bool = True
@@ -1680,6 +1681,9 @@ environment_variables: dict[str, Callable[[], Any]] = {
     ),
     "VLLM_SM70_FP8_SAFE_FAST_SELECTOR": lambda: bool(
         int(os.getenv("VLLM_SM70_FP8_SAFE_FAST_SELECTOR", "0"))
+    ),
+    "VLLM_SM70_FP8_QWEN38_PREFILL_FAST_SELECTOR": lambda: bool(
+        int(os.getenv("VLLM_SM70_FP8_QWEN38_PREFILL_FAST_SELECTOR", "1"))
     ),
     "VLLM_SM70_FP8_PRESERVE_DEFAULT_SPLITS": lambda: bool(
         int(os.getenv("VLLM_SM70_FP8_PRESERVE_DEFAULT_SPLITS", "1"))

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -136,6 +136,9 @@ if TYPE_CHECKING:
     VLLM_SM70_AWQ_TP2_FAST_SELECTOR: bool = True
     VLLM_SM70_AWQ_TP2_FAST_TARGETS: str | None = None
     VLLM_SM70_TP2_AR_GEMMA_RMS_FUSION: bool = False
+    VLLM_SM70_TP4_LONG_PREFILL_FUSED_NORM: bool = False
+    VLLM_SM70_TP4_LONG_FUSED_NORM_THREADS: int = 512
+    VLLM_SM70_TP4_LONG_FUSED_NORM_BLOCKS: int = 80
     VLLM_SM70_AWQ_MLP_ENGINE: bool = False
     VLLM_SM70_AWQ_PREFILL_EXACT_DENSE: bool = True
     VLLM_SM70_AWQ_MLP_DOWN_TILE_AR: bool = False
@@ -153,13 +156,16 @@ if TYPE_CHECKING:
     VLLM_SM70_FP8_COORDINATED_TUNING: bool = True
     VLLM_SM70_FP8_REUSE_IMPORTED_CACHE: bool = False
     VLLM_SM70_FP8_SAFE_FAST_SELECTOR: bool = False
-    VLLM_SM70_FP8_QWEN38_PREFILL_FAST_SELECTOR: bool = True
+    VLLM_SM70_FP8_PREFILL_FAST_SELECTOR: bool = True
+    VLLM_SM70_FP8_PREFILL_PRESCALED: bool = True
+    VLLM_SM70_FP8_PREFILL_CUTLASS: bool = True
     VLLM_SM70_FP8_PRESERVE_DEFAULT_SPLITS: bool = True
     VLLM_SM70_FP8_PRESERVE_DEFAULT_SPLITS_ONLY: bool = False
     VLLM_SM70_FP8_PREFILL_EXACT_DENSE: bool = True
     VLLM_SM70_FP8_QPN8: bool = False
     VLLM_SM70_FP8_QPN8_LIBRARY: str | None = None
     VLLM_SM70_SAMPLER_LIBRARY: str | None = None
+    VLLM_SM70_FP8_PREFILL_VISIBLE_DENSE_MM: bool = False
     VLLM_SM70_MXFP4_TUNE_SMALL_SHAPES: bool = True
     VLLM_SM70_NVFP4_TUNE_SMALL_SHAPES: bool = True
     VLLM_SM70_NVFP4_QWEN38_TP4_M1_FAST_SELECTOR: bool = True
@@ -1605,6 +1611,17 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "VLLM_SM70_TP2_AR_GEMMA_RMS_FUSION": lambda: bool(
         int(os.getenv("VLLM_SM70_TP2_AR_GEMMA_RMS_FUSION", "0"))
     ),
+    # Default-off exact-8K TP4 experiment: fuse the row-parallel reduction,
+    # mixed-FP32-residual Gemma RMSNorm, and normalized-output all-gather.
+    "VLLM_SM70_TP4_LONG_PREFILL_FUSED_NORM": lambda: bool(
+        int(os.getenv("VLLM_SM70_TP4_LONG_PREFILL_FUSED_NORM", "0"))
+    ),
+    "VLLM_SM70_TP4_LONG_FUSED_NORM_THREADS": lambda: int(
+        os.getenv("VLLM_SM70_TP4_LONG_FUSED_NORM_THREADS", "512")
+    ),
+    "VLLM_SM70_TP4_LONG_FUSED_NORM_BLOCKS": lambda: int(
+        os.getenv("VLLM_SM70_TP4_LONG_FUSED_NORM_BLOCKS", "80")
+    ),
     # Experimental TileRT-inspired dense MLP lane for SM70 AWQ decode. The
     # first stage fuses gate_up_proj + SiluAndMul through the TurboMind GEMM
     # epilogue for M=1/TP2 while keeping the existing down_proj/reduce path.
@@ -1631,6 +1648,12 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # unset because the same operators are linked into vllm._C.
     "VLLM_SM70_FP8_QPN8_LIBRARY": lambda: os.getenv("VLLM_SM70_FP8_QPN8_LIBRARY", None),
     "VLLM_SM70_SAMPLER_LIBRARY": lambda: os.getenv("VLLM_SM70_SAMPLER_LIBRARY", None),
+    "VLLM_SM70_FP8_PREFILL_CUTLASS": lambda: bool(
+        int(os.getenv("VLLM_SM70_FP8_PREFILL_CUTLASS", "1"))
+    ),
+    "VLLM_SM70_FP8_PREFILL_VISIBLE_DENSE_MM": lambda: bool(
+        int(os.getenv("VLLM_SM70_FP8_PREFILL_VISIBLE_DENSE_MM", "0"))
+    ),
     # Experimental TileRT-inspired down-proj lane: after the row-parallel AWQ
     # GEMM, use the local tile-runtime TP2 all-reduce substrate for the MLP
     # hidden-state reduction. This is default-off until it wins end-to-end.
@@ -1682,8 +1705,11 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "VLLM_SM70_FP8_SAFE_FAST_SELECTOR": lambda: bool(
         int(os.getenv("VLLM_SM70_FP8_SAFE_FAST_SELECTOR", "0"))
     ),
-    "VLLM_SM70_FP8_QWEN38_PREFILL_FAST_SELECTOR": lambda: bool(
-        int(os.getenv("VLLM_SM70_FP8_QWEN38_PREFILL_FAST_SELECTOR", "1"))
+    "VLLM_SM70_FP8_PREFILL_FAST_SELECTOR": lambda: bool(
+        int(os.getenv("VLLM_SM70_FP8_PREFILL_FAST_SELECTOR", "1"))
+    ),
+    "VLLM_SM70_FP8_PREFILL_PRESCALED": lambda: bool(
+        int(os.getenv("VLLM_SM70_FP8_PREFILL_PRESCALED", "1"))
     ),
     "VLLM_SM70_FP8_PRESERVE_DEFAULT_SPLITS": lambda: bool(
         int(os.getenv("VLLM_SM70_FP8_PRESERVE_DEFAULT_SPLITS", "1"))

--- a/vllm/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py
+++ b/vllm/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py
@@ -3565,7 +3565,7 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
     def forward(
         self,
         hidden_states: torch.Tensor,
-        output: torch.Tensor,
+        output: torch.Tensor | None,
     ):
         if self.maybe_sm70_qwen_gdn_full_forward:
             layer_name = _encode_layer_name(self.prefix)
@@ -3587,14 +3587,14 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
                     layer_name,
                 )
                 return
-        self._forward_method(hidden_states, output)
+        return self._forward_method(hidden_states, output)
 
     def _full_forward(
         self,
         hidden_states: torch.Tensor,
         output: torch.Tensor,
     ):
-        self._forward_method(hidden_states, output)
+        return self._forward_method(hidden_states, output)
 
     def _compute_output_projection(
         self,
@@ -3650,18 +3650,19 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
         self,
         core_attn_out: torch.Tensor,
         z: torch.Tensor,
-        output: torch.Tensor,
+        output: torch.Tensor | None,
         num_tokens: int,
     ) -> torch.Tensor:
         layer_name = _encode_layer_name(self.prefix)
         proj_out = self._compute_output_projection(core_attn_out, z, num_tokens)
-        output[:num_tokens] = proj_out
-        _sm70_gdn_graph_buffer_copy(
-            "proj_output_after_write",
-            layer_name,
-            output[:num_tokens],
-            "proj",
-        )
+        if output is not None:
+            output[:num_tokens] = proj_out
+            _sm70_gdn_graph_buffer_copy(
+                "proj_output_after_write",
+                layer_name,
+                output[:num_tokens],
+                "proj",
+            )
         return proj_out
 
     def forward_hip(
@@ -3720,7 +3721,7 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
     def forward_cuda(
         self,
         hidden_states: torch.Tensor,
-        output: torch.Tensor,
+        output: torch.Tensor | None,
     ):
         """
         Forward pass with three parts:
@@ -3758,8 +3759,8 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
                     layer_name,
                 )
             else:
-                self._output_projection(core_attn_out, z, output, num_tokens)
-            return
+                return self._output_projection(core_attn_out, z, output, num_tokens)
+            return None
 
         if envs.VLLM_SM70_QWEN_GDN_INPUT_PROJECTION_OP:
             mixed_qkv = torch.empty(
@@ -3810,8 +3811,8 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
                     layer_name,
                 )
             else:
-                self._output_projection(core_attn_out, z, output, num_tokens)
-            return
+                return self._output_projection(core_attn_out, z, output, num_tokens)
+            return None
 
         # ============================================================
         # Part 1: Input Projection
@@ -3909,7 +3910,8 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
                 layer_name,
             )
         else:
-            self._output_projection(core_attn_out, z, output, num_tokens)
+            return self._output_projection(core_attn_out, z, output, num_tokens)
+        return None
 
     def forward_xpu(
         self,

--- a/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_w8a16_fp8.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_w8a16_fp8.py
@@ -24,7 +24,6 @@ from vllm.model_executor.layers.quantization.compressed_tensors.utils import (
 )
 from vllm.model_executor.layers.quantization.fp8 import (
     _get_sm70_fp8_prefill_exact_dense_workspace,
-    _is_qwen38_27b_fp8_qpn8_model,
     _is_sm70_fp8_qpn8_runtime_contract,
     _missing_sm70_fp8_qpn8_ops,
 )
@@ -205,7 +204,6 @@ class CompressedTensorsW8A16Fp8(CompressedTensorsScheme):
             qpn8_config = (
                 _sm70_channel_fp8_qpn8_config(layer)
                 if getattr(self, "use_sm70_fp8_qpn8", False)
-                and _is_qwen38_27b_fp8_qpn8_model()
                 else None
             )
             qpn8_concurrency = (

--- a/vllm/model_executor/layers/quantization/fp8.py
+++ b/vllm/model_executor/layers/quantization/fp8.py
@@ -101,6 +101,11 @@ ACTIVATION_SCHEMES = ["static", "dynamic"]
 logger = init_logger(__name__)
 
 _SM70_FP8_PREFILL_DENSE_MIN_M = 3920
+_SM70_FP8_EXACT_8K_PREFILL_M = 8000
+_SM70_FP8_EXACT_8K_PREFILL_SHAPES = {
+    "in_proj_qkvz": (5120, 4096),
+    "qkv_proj": (5120, 3584),
+}
 _SM70_FP8_PREFILL_DENSE_SHAPES = {
     "gate_up_proj": (5120, 8704),
     "down_proj": (4352, 5120),
@@ -133,11 +138,25 @@ _SM70_FP8_QPN8_MAX_NUM_SEQS = 8
 _sm70_fp8_prefill_dense_workspaces: dict[tuple[int, torch.dtype], torch.Tensor] = {}
 
 
+def _is_sm70_fp8_exact_8k_prefill_layer(layer: torch.nn.Module) -> bool:
+    if getattr(layer, "tp_size", 1) != 4:
+        return False
+    if getattr(layer, "weight_block_size", None) != [128, 128]:
+        return False
+    suffix = getattr(layer, "prefix", "").rsplit(".", 1)[-1]
+    expected = _SM70_FP8_EXACT_8K_PREFILL_SHAPES.get(suffix)
+    return expected is not None and tuple(layer.weight.shape) == expected
+
+
 def _is_sm70_fp8_prefill_exact_dense_layer(layer: torch.nn.Module) -> bool:
     if getattr(layer, "tp_size", 1) != 4:
         return False
+    if getattr(layer, "weight_block_size", None) != [128, 128]:
+        return False
     suffix = getattr(layer, "prefix", "").rsplit(".", 1)[-1]
     expected = _SM70_FP8_PREFILL_DENSE_SHAPES.get(suffix)
+    if expected is None:
+        expected = _SM70_FP8_EXACT_8K_PREFILL_SHAPES.get(suffix)
     if expected is None:
         return False
     return tuple(layer.weight.shape) == expected
@@ -147,6 +166,8 @@ def _is_sm70_fp8_qpn8_layer(layer: torch.nn.Module) -> bool:
     """Admit only shapes with an accepted bounded-workspace prefill route."""
     if getattr(layer, "tp_size", 1) != 4:
         return False
+    if getattr(layer, "weight_block_size", None) != [128, 128]:
+        return False
     suffix = getattr(layer, "prefix", "").rsplit(".", 1)[-1]
     expected_kn = _SM70_FP8_PREFILL_DENSE_SHAPES.get(suffix)
     if expected_kn is None:
@@ -154,24 +175,6 @@ def _is_sm70_fp8_qpn8_layer(layer: torch.nn.Module) -> bool:
     # Checkpoint-native block-FP8 weights are [N, K]; the shared prefill
     # workspace and QPN8 replacement parameter are [K, N].
     return tuple(reversed(layer.weight.shape)) == expected_kn
-
-
-def _is_qwen38_27b_fp8_qpn8_model() -> bool:
-    """Keep the automatic route specific to the accepted Qwen3.8-27B model."""
-    model_config = get_current_vllm_config().model_config
-    hf_config = model_config.hf_config
-    text_config = model_config.hf_text_config
-    return bool(
-        getattr(hf_config, "model_type", None) == "qwen3_5"
-        and getattr(hf_config, "architectures", None)
-        == ["Qwen3_5ForConditionalGeneration"]
-        and getattr(text_config, "model_type", None) == "qwen3_5_text"
-        and getattr(text_config, "hidden_size", None) == 5120
-        and getattr(text_config, "intermediate_size", None) == 17408
-        and getattr(text_config, "num_hidden_layers", None) == 64
-        and getattr(text_config, "full_attention_interval", None) == 4
-        and getattr(text_config, "head_dim", None) == 256
-    )
 
 
 def _is_sm70_fp8_qpn8_runtime_contract() -> bool:
@@ -213,6 +216,51 @@ def _get_sm70_fp8_prefill_exact_dense_workspace(
         return None
     _sm70_fp8_prefill_dense_workspaces[cache_key] = workspace
     return workspace
+
+
+def _sm70_fp8_prefill_visible_dense_mm(
+    input: torch.Tensor,
+    weight: torch.Tensor,
+    scales: torch.Tensor,
+    dense_weight_ptr: int | None,
+    *,
+    gated_silu: bool,
+    min_prefill_m: int,
+) -> torch.Tensor | None:
+    """Expose the long-prefill dense MM to AsyncTP pattern matching.
+
+    This diagnostic route intentionally keeps the accepted dequantization and
+    FP16 MM arithmetic while moving ``aten.mm`` out of the opaque C++ wrapper.
+    """
+    if not envs.VLLM_SM70_FP8_PREFILL_VISIBLE_DENSE_MM:
+        return None
+    if dense_weight_ptr is None:
+        return None
+    if input.dtype != torch.float16 or input.shape[0] < min_prefill_m:
+        return None
+
+    device_index = input.device.index
+    if device_index is None:
+        device_index = torch.accelerator.current_device_index()
+    workspace = _sm70_fp8_prefill_dense_workspaces.get((device_index, torch.float16))
+    if workspace is None:
+        return None
+    if not torch.compiler.is_compiling() and workspace.data_ptr() != dense_weight_ptr:
+        return None
+
+    dense_weight = workspace.narrow(0, 0, weight.numel()).view(weight.shape)
+    sm70_ops.fp8_sm70_dequantize_out(dense_weight, weight, scales, 128)
+    dense_out = torch.mm(input, dense_weight)
+    if not gated_silu:
+        return dense_out
+
+    out = torch.empty(
+        (input.shape[0], dense_out.shape[1] // 2),
+        dtype=input.dtype,
+        device=input.device,
+    )
+    sm70_ops.silu_and_mul_interleaved(out, dense_out)
+    return out
 
 
 class Fp8Config(QuantizationConfig):
@@ -665,21 +713,19 @@ class Fp8LinearMethod(LinearMethodBase):
                 return
             is_gated_silu_layer = self._is_sm70_gated_silu_layer(layer)
             use_gated_silu = is_gated_silu_layer and envs.VLLM_SM70_FP8_DENSE_GATED_SILU
-            qpn8_model_layer = (
-                envs.VLLM_SM70_FP8_QPN8
-                and _is_qwen38_27b_fp8_qpn8_model()
-                and _is_sm70_fp8_qpn8_layer(layer)
+            qpn8_candidate_layer = envs.VLLM_SM70_FP8_QPN8 and _is_sm70_fp8_qpn8_layer(
+                layer
             )
             qpn8_concurrency = (
-                _is_sm70_fp8_qpn8_runtime_contract() if qpn8_model_layer else False
+                _is_sm70_fp8_qpn8_runtime_contract() if qpn8_candidate_layer else False
             )
-            if qpn8_model_layer and not qpn8_concurrency:
+            if qpn8_candidate_layer and not qpn8_concurrency:
                 logger.info_once(
                     "The SM70 FP8 QPN8 route retains TurboMind when MTP is "
                     "enabled or max_num_seqs exceeds 8; the accepted native "
                     "QPN8 contract is no-MTP with M<=8."
                 )
-            if qpn8_model_layer and qpn8_concurrency:
+            if qpn8_candidate_layer and qpn8_concurrency:
                 missing_ops = _missing_sm70_fp8_qpn8_ops()
                 if missing_ops:
                     if os.getenv("VLLM_SM70_FP8_QPN8") is not None:
@@ -727,7 +773,7 @@ class Fp8LinearMethod(LinearMethodBase):
                         layer.sm70_fp8_qpn8_gated_prefetch = gated_prefetch
                     logger.info_once(
                         "Memory-neutral SM70 FP8 QPN8 path enabled for accepted "
-                        "Qwen3.8-27B TP4 dense shapes."
+                        "TP4 block-FP8 operator shapes."
                     )
                     return
                 if not missing_ops:
@@ -764,14 +810,34 @@ class Fp8LinearMethod(LinearMethodBase):
             layer.sm70_fp8_k_ld = int(meta[0].item())
             layer.sm70_fp8_q_ld = int(meta[1].item())
             if (
+                envs.VLLM_SM70_FP8_PREFILL_FAST_SELECTOR
+                and envs.VLLM_SM70_FP8_PREFILL_PRESCALED
+                and hasattr(torch.ops._C, "fp8_gemm_sm70_prefill_prescaled_out")
+                and _is_sm70_fp8_exact_8k_prefill_layer(layer)
+            ):
+                layer.register_buffer(
+                    "sm70_fp8_prefill_prescaled_scales",
+                    tm_scales.mul(256),
+                    persistent=False,
+                )
+                logger.info_once(
+                    "SM70 FP8 Qwen3.8 exact-8K pre-scaled projection path enabled."
+                )
+            if (
                 envs.VLLM_SM70_FP8_PREFILL_EXACT_DENSE
                 and hasattr(torch.ops._C, "fp8_gemm_sm70_prefill_dispatch_out")
                 and _is_sm70_fp8_prefill_exact_dense_layer(layer)
             ):
+                is_exact_8k_projection = _is_sm70_fp8_exact_8k_prefill_layer(layer)
                 workspace = _get_sm70_fp8_prefill_exact_dense_workspace(tm_weight)
                 if workspace is not None:
                     layer.sm70_fp8_prefill_exact_dense_workspace_ptr = (
                         workspace.data_ptr()
+                    )
+                    layer.sm70_fp8_prefill_exact_dense_min_m = (
+                        _SM70_FP8_EXACT_8K_PREFILL_M
+                        if is_exact_8k_projection
+                        else _SM70_FP8_PREFILL_DENSE_MIN_M
                     )
                     logger.info_once(
                         "SM70 FP8 exact-dense prefill path enabled with a bounded "
@@ -970,7 +1036,25 @@ class Fp8LinearMethod(LinearMethodBase):
             prefill_workspace_ptr = getattr(
                 layer, "sm70_fp8_prefill_exact_dense_workspace_ptr", None
             )
-            if prefill_workspace_ptr is not None and x_2d.dtype == torch.float16:
+            prefill_prescaled_scales = getattr(
+                layer, "sm70_fp8_prefill_prescaled_scales", None
+            )
+            prefill_min_m = getattr(
+                layer,
+                "sm70_fp8_prefill_exact_dense_min_m",
+                _SM70_FP8_PREFILL_DENSE_MIN_M,
+            )
+            visible_dense_out = _sm70_fp8_prefill_visible_dense_mm(
+                x_2d,
+                layer.weight,
+                layer.weight_scale_inv,
+                prefill_workspace_ptr,
+                gated_silu=False,
+                min_prefill_m=prefill_min_m,
+            )
+            if visible_dense_out is not None:
+                out_2d = visible_dense_out
+            elif prefill_workspace_ptr is not None and x_2d.dtype == torch.float16:
                 sm70_ops.fp8_gemm_sm70_prefill_dispatch_out(
                     out_2d,
                     prefill_workspace_ptr,
@@ -981,7 +1065,22 @@ class Fp8LinearMethod(LinearMethodBase):
                     layer.sm70_fp8_k_ld,
                     layer.sm70_fp8_q_ld,
                     False,
-                    _SM70_FP8_PREFILL_DENSE_MIN_M,
+                    prefill_min_m,
+                )
+            elif (
+                prefill_prescaled_scales is not None
+                and envs.VLLM_SM70_FP8_PREFILL_FAST_SELECTOR
+                and envs.VLLM_SM70_FP8_PREFILL_PRESCALED
+                and x_2d.shape[0] == _SM70_FP8_EXACT_8K_PREFILL_M
+            ):
+                sm70_ops.fp8_gemm_sm70_prefill_prescaled_out(
+                    out_2d,
+                    x_2d,
+                    layer.weight,
+                    prefill_prescaled_scales,
+                    128,
+                    layer.sm70_fp8_k_ld,
+                    layer.sm70_fp8_q_ld,
                 )
             else:
                 sm70_ops.fp8_gemm_sm70_out(
@@ -1114,6 +1213,25 @@ class Fp8LinearMethod(LinearMethodBase):
             layer, "sm70_fp8_prefill_exact_dense_workspace_ptr", None
         )
         if prefill_workspace_ptr is not None and x_2d.dtype == torch.float16:
+            visible_dense_out = _sm70_fp8_prefill_visible_dense_mm(
+                x_2d,
+                weight,
+                scales,
+                prefill_workspace_ptr,
+                gated_silu=True,
+                min_prefill_m=getattr(
+                    layer,
+                    "sm70_fp8_prefill_exact_dense_min_m",
+                    _SM70_FP8_PREFILL_DENSE_MIN_M,
+                ),
+            )
+            if visible_dense_out is not None:
+                return visible_dense_out.reshape(*x.shape[:-1], out_features)
+            min_prefill_m = getattr(
+                layer,
+                "sm70_fp8_prefill_exact_dense_min_m",
+                _SM70_FP8_PREFILL_DENSE_MIN_M,
+            )
             sm70_ops.fp8_gemm_sm70_prefill_dispatch_out(
                 out_2d,
                 prefill_workspace_ptr,
@@ -1124,7 +1242,7 @@ class Fp8LinearMethod(LinearMethodBase):
                 k_ld,
                 q_ld,
                 True,
-                _SM70_FP8_PREFILL_DENSE_MIN_M,
+                min_prefill_m,
             )
             return out_2d.reshape(*x.shape[:-1], out_features)
         sm70_ops.fp8_gemm_sm70_out(

--- a/vllm/model_executor/layers/quantization/fp8.py
+++ b/vllm/model_executor/layers/quantization/fp8.py
@@ -821,7 +821,7 @@ class Fp8LinearMethod(LinearMethodBase):
                     persistent=False,
                 )
                 logger.info_once(
-                    "SM70 FP8 Qwen3.8 exact-8K pre-scaled projection path enabled."
+                    "SM70 block-FP8 exact-8K pre-scaled projection path enabled."
                 )
             if (
                 envs.VLLM_SM70_FP8_PREFILL_EXACT_DENSE

--- a/vllm/model_executor/models/qwen3_5.py
+++ b/vllm/model_executor/models/qwen3_5.py
@@ -297,7 +297,7 @@ class Qwen3_5GatedDeltaNet(QwenGatedDeltaNetAttention):
     def forward_cuda(
         self,
         hidden_states: torch.Tensor,
-        output: torch.Tensor,
+        output: torch.Tensor | None,
     ):
         num_tokens = hidden_states.size(0)
         layer_name = _encode_layer_name(self.prefix)
@@ -363,7 +363,7 @@ class Qwen3_5GatedDeltaNet(QwenGatedDeltaNetAttention):
             conv_state_cache=conv_state_cache,
             ssm_state_cache=ssm_state_cache,
         )
-        self._output_projection(core_attn_out, z, output, num_tokens)
+        return self._output_projection(core_attn_out, z, output, num_tokens)
 
 
 class Qwen3_5DecoderLayer(Qwen3NextDecoderLayer):

--- a/vllm/model_executor/models/qwen3_next.py
+++ b/vllm/model_executor/models/qwen3_next.py
@@ -549,7 +549,7 @@ class Qwen3NextAttention(nn.Module):
     def forward(
         self,
         positions: torch.Tensor,
-        output: torch.Tensor,
+        output: torch.Tensor | None,
         hidden_states: torch.Tensor,
     ):
         qkv, _ = self.qkv_proj(hidden_states)
@@ -623,13 +623,16 @@ class Qwen3NextAttention(nn.Module):
                 attn_output,
             )
 
-        output[:], _ = self.o_proj(attn_output)
+        projected_output, _ = self.o_proj(attn_output)
+        if output is not None:
+            output[:] = projected_output
         _sm70_dump_qwen_layer_tensor(
             "full_attn_o_proj_out",
             self.layer_idx,
             "full_attention",
-            output,
+            projected_output,
         )
+        return projected_output
 
 
 class Qwen3NextDecoderLayer(nn.Module):
@@ -744,21 +747,33 @@ class Qwen3NextDecoderLayer(nn.Module):
             hidden_states,
         )
 
-        self_attention_output = torch.empty_like(hidden_states)
+        use_direct_attention_output = (
+            envs.VLLM_SM70_TP4_LONG_PREFILL_FUSED_NORM and torch.compiler.is_compiling()
+        )
+        self_attention_output = (
+            None if use_direct_attention_output else torch.empty_like(hidden_states)
+        )
         if self.layer_type == "linear_attention":
-            self.linear_attn(
+            projected_attention_output = self.linear_attn(
                 hidden_states=hidden_states,
                 output=self_attention_output,
             )
         elif self.layer_type == "full_attention":
-            self.self_attn(
+            projected_attention_output = self.self_attn(
                 hidden_states=hidden_states,
                 output=self_attention_output,
                 positions=positions,
             )
         else:
             raise ValueError("Invalid layer_type")
-        hidden_states = self_attention_output
+        if use_direct_attention_output:
+            if projected_attention_output is None:
+                raise RuntimeError(
+                    "SM70 TP4 fused prefill requires a direct attention output"
+                )
+            hidden_states = projected_attention_output
+        else:
+            hidden_states = self_attention_output
         hidden_states = _sm70_dump_qwen_layer_tensor(
             "attn_out",
             self.layer_idx,


### PR DESCRIPTION
## Purpose

Optimize exact-8K block-FP8 prefill GEMMs on V100/SM70 while keeping admission at the inference-engine/operator level. Qwen3.8-27B-FP8 is the matched validation workload, not a runtime identity constraint.

## What changed

- Add an SM70 CUTLASS Tensor Core route for exact `M=8000` block-FP8 prefill descriptors using CTA `128x256x32`, warp `64x64x32`, native Volta `m8n8k4`, two stages, and split-K one.
- Cover exact `(K,N)` descriptors `(5120,4096)`, `(5120,3584)`, `(5120,8704)`, `(4352,5120)`, and `(1536,5120)`.
- Admit the path only through generic contracts: SM70 build/runtime route, TP4 layer partition, `[128,128]` block-FP8 layout, FP16 activation/output, exact M/K/N, supported scale layout, and bounded shared workspace. No model name, architecture, or checkpoint whitelist is consulted.
- Generalize the public operator, environment variables, logs, and tests from model-specific names to block-FP8 prefill names.
- Remove the inherited QPN8 model-identity whitelist; QPN8 now uses its existing shape, quantization, TP, no-MTP, and concurrency contract. Pure-FP8 QPN8 remains opt-in.
- Keep the experimental long-prefill TP4 fused norm/collective path default-off.
- Replace direct benchmark `torch.cuda` synchronization/event/device APIs with accelerator-neutral APIs and remove private default model paths.

Rollback gates are independent:

- `VLLM_SM70_FP8_PREFILL_CUTLASS=0`
- `VLLM_SM70_FP8_PREFILL_FAST_SELECTOR=0`
- `VLLM_SM70_FP8_PREFILL_PRESCALED=0`
- `VLLM_SM70_FP8_PREFILL_EXACT_DENSE=0`
- `VLLM_SM70_TP4_LONG_PREFILL_FUSED_NORM=0`

Decode, tails, other M values, unsupported layouts, and unrecognized shapes retain their previous dispatch.

## Matched performance evidence

The original source-matching benchmark contract was:

- Qwen3.8-27B-FP8, TP4 on 4 x V100
- input/output 8000/1, cache reset between repeats
- FP8 E5M2 KV cache, Flash-V100/FlashQLA
- `FULL_AND_PIECEWISE` CUDA Graph, capture size 8000
- temperature 1.0, top-p 0.95, top-k 20, seed 20260823

The accepted baseline was `1.616075 s` / `4950.27 prompt tok/s`. Six steady candidate samples had a `1.562062 s` median / `5121.44 prompt tok/s`, a `+3.46%` throughput improvement with `0.132%` CV. Pure-prefill median was `1.547100 s` / `5170.96 tok/s`. All 7/7 sampled outputs remained token `[1061]` (`" This"`). Real-weight CUDA Graph operator comparisons were bitwise identical.

The audit changed admission/naming, tests, and formatting only; it did not change the accepted CUTLASS kernel arithmetic or tactic. Per the repository audit plan, no additional full-model end-to-end run was performed.

## Test plan and result

- `pytest -q tests/quantization/test_sm70_fp8_prefill_exact_dense.py`: **20 passed**.
- Full changed-file pre-commit suite: **passed**, including Ruff, clang-format, mypy, SPDX, forbidden imports, and the direct-`torch.cuda` gate.
- `git diff --check`: passed.
- Existing PR evidence: exact route/shape tests 11 passed, real-weight operator outputs bitwise identical, and matched full-model endpoint above.

This PR claims the exact-8K operator point only; it does not relabel the result as a full context-length curve.