### PR TITLE
[Core][SM70] Add opt-in MTP concurrency warmup

### DIFF
--- a/tests/v1/spec_decode/test_mtp.py
+++ b/tests/v1/spec_decode/test_mtp.py
@@ -13,6 +13,7 @@ from tests.v1.attention.utils import (
     create_standard_kv_cache_spec,
     try_get_attention_backend,
 )
+from vllm import envs
 from vllm.config import (
     CacheConfig,
     DeviceConfig,
@@ -45,8 +46,18 @@ def test_sm70_mtp_moe_warmup_sizes():
 
 def test_sm70_mtp_hotpath_warmup_batch_sizes():
     assert _sm70_mtp_hotpath_warmup_batch_sizes(1) == (1,)
-    assert _sm70_mtp_hotpath_warmup_batch_sizes(4) == (1, 4)
-    assert _sm70_mtp_hotpath_warmup_batch_sizes(64) == (1, 4)
+    assert _sm70_mtp_hotpath_warmup_batch_sizes(4) == (4,)
+    assert _sm70_mtp_hotpath_warmup_batch_sizes(4, include_alternate=True) == (1, 4)
+    assert _sm70_mtp_hotpath_warmup_batch_sizes(64, include_alternate=True) == (1, 4)
+
+
+def test_sm70_mtp_concurrency_warmup_is_default_off(monkeypatch):
+    monkeypatch.delenv("VLLM_SM70_MTP_CONCURRENCY_WARMUP", raising=False)
+    envs.disable_envs_cache()
+    try:
+        assert not envs.VLLM_SM70_MTP_CONCURRENCY_WARMUP
+    finally:
+        envs.disable_envs_cache()
 
 
 def test_sm70_mtp_moe_warmup_runs_each_shape_once():

--- a/tests/v1/spec_decode/test_mtp.py
+++ b/tests/v1/spec_decode/test_mtp.py
@@ -29,6 +29,7 @@ from vllm.v1.attention.backends.registry import AttentionBackendEnum
 from vllm.v1.spec_decode.eagle import EagleProposer
 from vllm.v1.spec_decode.llm_base_proposer import (
     SpecDecodeBaseProposer,
+    _sm70_mtp_hotpath_warmup_batch_sizes,
     _sm70_mtp_moe_warmup_sizes,
 )
 
@@ -40,6 +41,12 @@ def test_sm70_mtp_moe_warmup_sizes():
     assert _sm70_mtp_moe_warmup_sizes(256, 8, 8192) == (9, 33, 257)
     assert _sm70_mtp_moe_warmup_sizes(256, 8, 32) == (9,)
     assert _sm70_mtp_moe_warmup_sizes(0, 8, 8192) == ()
+
+
+def test_sm70_mtp_hotpath_warmup_batch_sizes():
+    assert _sm70_mtp_hotpath_warmup_batch_sizes(1) == (1,)
+    assert _sm70_mtp_hotpath_warmup_batch_sizes(4) == (1, 4)
+    assert _sm70_mtp_hotpath_warmup_batch_sizes(64) == (1, 4)
 
 
 def test_sm70_mtp_moe_warmup_runs_each_shape_once():

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -257,6 +257,7 @@ if TYPE_CHECKING:
     VLLM_SM70_MTP_PROFILE: bool = False
     VLLM_SM70_MTP_PROFILE_INTERVAL: int = 16
     VLLM_SM70_MTP_SPLIT_DRAFT_CUDAGRAPHS: bool = False
+    VLLM_SM70_MTP_CONCURRENCY_WARMUP: bool = False
     VLLM_SM70_MTP_CONTEXT_BUCKETS: str | None = None
     VLLM_SM70_DSV4_DECODE_CONTEXT_BUCKETS: str | None = None
     VLLM_SM70_FP8_KV_DECODE_CONTEXT_BUCKETS: str | None = None
@@ -2100,6 +2101,11 @@ environment_variables: dict[str, Callable[[], Any]] = {
     ),
     "VLLM_SM70_MTP_SPLIT_DRAFT_CUDAGRAPHS": lambda: bool(
         int(os.getenv("VLLM_SM70_MTP_SPLIT_DRAFT_CUDAGRAPHS", "0"))
+    ),
+    # Compile alternate single/concurrent MTP helper signatures at startup.
+    # Default-off until matched cold-start and steady-state evidence is complete.
+    "VLLM_SM70_MTP_CONCURRENCY_WARMUP": lambda: bool(
+        int(os.getenv("VLLM_SM70_MTP_CONCURRENCY_WARMUP", "0"))
     ),
     "VLLM_SM70_MTP_CONTEXT_BUCKETS": lambda: os.getenv("VLLM_SM70_MTP_CONTEXT_BUCKETS"),
     "VLLM_SM70_DSV4_DECODE_CONTEXT_BUCKETS": lambda: os.getenv(

--- a/vllm/v1/spec_decode/llm_base_proposer.py
+++ b/vllm/v1/spec_decode/llm_base_proposer.py
@@ -114,6 +114,12 @@ def _sm70_mtp_moe_warmup_sizes(
     return tuple(sorted(size for size in sizes if size <= max_num_tokens))
 
 
+def _sm70_mtp_hotpath_warmup_batch_sizes(max_batch_size: int) -> tuple[int, ...]:
+    """Cover Triton's single-request and concurrent scalar specializations."""
+    concurrent_batch_size = max(1, min(int(max_batch_size), 4))
+    return tuple(sorted({1, concurrent_batch_size}))
+
+
 def _is_dflash_method(method: str | None) -> bool:
     return method in ("dflash", "dflash_ddtree", "dspark")
 
@@ -862,6 +868,122 @@ class SpecDecodeBaseProposer:
             summary,
         )
 
+    def _warmup_sm70_mtp_hotpath_batch(self, batch_size: int, vocab_size: int) -> None:
+        valid_sampled_tokens_count = None
+        for num_sampled_tokens in sorted({1, self.num_speculative_tokens + 1}):
+            sampled_token_ids = torch.zeros(
+                (batch_size, num_sampled_tokens),
+                dtype=torch.int32,
+                device=self.device,
+            )
+            discard_request_mask = torch.zeros(
+                batch_size, dtype=torch.bool, device=self.device
+            )
+            backup_next_token_ids = torch.zeros(
+                batch_size, dtype=torch.int32, device=self.device
+            )
+            next_token_ids = torch.empty(
+                batch_size, dtype=torch.int32, device=self.device
+            )
+            next_valid_count = torch.empty_like(next_token_ids)
+            eagle_prepare_next_token_padded_kernel[(batch_size,)](
+                sampled_token_ids,
+                discard_request_mask,
+                backup_next_token_ids,
+                next_token_ids,
+                next_valid_count,
+                vocab_size,
+                num_sampled_tokens,
+                batch_size,
+                sampled_token_ids.stride(0),
+                BLOCK_SIZE_TOKENS=next_power_of_2(num_sampled_tokens),
+            )
+            if num_sampled_tokens == self.num_speculative_tokens + 1:
+                valid_sampled_tokens_count = next_valid_count
+        assert valid_sampled_tokens_count is not None
+
+        next_token_ids = torch.empty(batch_size, dtype=torch.int32, device=self.device)
+        cu_num_draft_tokens = (
+            torch.arange(
+                1,
+                batch_size + 1,
+                dtype=torch.int32,
+                device=self.device,
+            )
+            * self.num_speculative_tokens
+        )
+        query_start_loc = torch.arange(
+            batch_size + 1, dtype=torch.int32, device=self.device
+        )
+        token_indices_to_sample = torch.empty_like(next_token_ids)
+        num_rejected_tokens_gpu = torch.empty_like(next_token_ids)
+        eagle_prepare_inputs_padded_kernel[(batch_size,)](
+            cu_num_draft_tokens,
+            valid_sampled_tokens_count,
+            query_start_loc,
+            token_indices_to_sample,
+            num_rejected_tokens_gpu,
+            batch_size,
+        )
+
+        for dtype, replace_from, replace_to in (
+            (torch.float32, 0, 1),  # temperature
+            (torch.float32, 0, 0),  # top_p
+            (torch.int32, 0, 0),  # top_k
+        ):
+            rejection_expand_input = torch.ones(
+                batch_size, dtype=dtype, device=self.device
+            )
+            rejection_expand_output = torch.empty(
+                batch_size * self.num_speculative_tokens,
+                dtype=dtype,
+                device=self.device,
+            )
+            rejection_expand_kernel[(batch_size,)](
+                rejection_expand_output,
+                rejection_expand_input,
+                cu_num_draft_tokens,
+                replace_from,
+                replace_to,
+                MAX_NUM_TOKENS=MAX_SPEC_LEN,
+            )
+
+        n_blocks_per_req = max(
+            1, (self.max_model_len + self.block_size - 1) // self.block_size
+        )
+        positions = torch.zeros(batch_size, dtype=torch.int64, device=self.device)
+        block_table = torch.zeros(
+            (batch_size, n_blocks_per_req),
+            dtype=torch.int32,
+            device=self.device,
+        )
+        seq_lens = torch.ones(batch_size, dtype=torch.int32, device=self.device)
+        out_positions = torch.empty_like(positions)
+        out_slot_mapping = torch.empty(
+            batch_size, dtype=torch.int64, device=self.device
+        )
+        eagle_step_update_slot_mapping_and_metadata(
+            positions_1d=positions,
+            block_table_tensor=block_table,
+            seq_lens=seq_lens,
+            block_size=self.block_size,
+            max_model_len=self.max_model_len,
+            out_clamped_positions=out_positions,
+            out_slot_mapping=out_slot_mapping,
+            input_batch_size=batch_size,
+        )
+
+        draft_logits = torch.zeros(
+            (batch_size, vocab_size), dtype=torch.float32, device=self.device
+        )
+        draft_top_k = torch.full(
+            (batch_size,),
+            min(20, vocab_size),
+            dtype=torch.int32,
+            device=self.device,
+        )
+        apply_top_k_top_p(draft_logits, draft_top_k, None)
+
     def warmup_sm70_mtp_hotpath_kernels(self) -> tuple[str, ...]:
         """Warm MTP helper kernels that otherwise JIT on the first request."""
         if (
@@ -877,115 +999,9 @@ class SpecDecodeBaseProposer:
             return ()
 
         try:
-            batch_size = max(1, min(self.max_batch_size, 4))
             vocab_size = max(2, self.draft_model_config.get_vocab_size())
-
-            valid_sampled_tokens_count = None
-            for num_sampled_tokens in sorted({1, self.num_speculative_tokens + 1}):
-                sampled_token_ids = torch.zeros(
-                    (batch_size, num_sampled_tokens),
-                    dtype=torch.int32,
-                    device=self.device,
-                )
-                discard_request_mask = torch.zeros(
-                    batch_size, dtype=torch.bool, device=self.device
-                )
-                backup_next_token_ids = torch.zeros(
-                    batch_size, dtype=torch.int32, device=self.device
-                )
-                next_token_ids = torch.empty(
-                    batch_size, dtype=torch.int32, device=self.device
-                )
-                next_valid_count = torch.empty_like(next_token_ids)
-                eagle_prepare_next_token_padded_kernel[(batch_size,)](
-                    sampled_token_ids,
-                    discard_request_mask,
-                    backup_next_token_ids,
-                    next_token_ids,
-                    next_valid_count,
-                    vocab_size,
-                    num_sampled_tokens,
-                    batch_size,
-                    sampled_token_ids.stride(0),
-                    BLOCK_SIZE_TOKENS=next_power_of_2(num_sampled_tokens),
-                )
-                if num_sampled_tokens == self.num_speculative_tokens + 1:
-                    valid_sampled_tokens_count = next_valid_count
-            assert valid_sampled_tokens_count is not None
-
-            next_token_ids = torch.empty(
-                batch_size, dtype=torch.int32, device=self.device
-            )
-
-            cu_num_draft_tokens = (
-                torch.arange(
-                    1,
-                    batch_size + 1,
-                    dtype=torch.int32,
-                    device=self.device,
-                )
-                * self.num_speculative_tokens
-            )
-            query_start_loc = torch.arange(
-                batch_size + 1, dtype=torch.int32, device=self.device
-            )
-            token_indices_to_sample = torch.empty_like(next_token_ids)
-            num_rejected_tokens_gpu = torch.empty_like(next_token_ids)
-            eagle_prepare_inputs_padded_kernel[(batch_size,)](
-                cu_num_draft_tokens,
-                valid_sampled_tokens_count,
-                query_start_loc,
-                token_indices_to_sample,
-                num_rejected_tokens_gpu,
-                batch_size,
-            )
-
-            for dtype, replace_from, replace_to in (
-                (torch.float32, 0, 1),  # temperature
-                (torch.float32, 0, 0),  # top_p
-                (torch.int32, 0, 0),  # top_k
-            ):
-                rejection_expand_input = torch.ones(
-                    batch_size, dtype=dtype, device=self.device
-                )
-                rejection_expand_output = torch.empty(
-                    batch_size * self.num_speculative_tokens,
-                    dtype=dtype,
-                    device=self.device,
-                )
-                rejection_expand_kernel[(batch_size,)](
-                    rejection_expand_output,
-                    rejection_expand_input,
-                    cu_num_draft_tokens,
-                    replace_from,
-                    replace_to,
-                    MAX_NUM_TOKENS=MAX_SPEC_LEN,
-                )
-
-            n_blocks_per_req = max(
-                1, (self.max_model_len + self.block_size - 1) // self.block_size
-            )
-            positions = torch.zeros(batch_size, dtype=torch.int64, device=self.device)
-            block_table = torch.zeros(
-                (batch_size, n_blocks_per_req),
-                dtype=torch.int32,
-                device=self.device,
-            )
-            seq_lens = torch.ones(batch_size, dtype=torch.int32, device=self.device)
-            out_positions = torch.empty_like(positions)
-            out_slot_mapping = torch.empty(
-                batch_size, dtype=torch.int64, device=self.device
-            )
-            eagle_step_update_slot_mapping_and_metadata(
-                positions_1d=positions,
-                block_table_tensor=block_table,
-                seq_lens=seq_lens,
-                block_size=self.block_size,
-                max_model_len=self.max_model_len,
-                out_clamped_positions=out_positions,
-                out_slot_mapping=out_slot_mapping,
-                input_batch_size=batch_size,
-            )
+            for batch_size in _sm70_mtp_hotpath_warmup_batch_sizes(self.max_batch_size):
+                self._warmup_sm70_mtp_hotpath_batch(batch_size, vocab_size)
             torch.accelerator.synchronize()
         except Exception as err:  # pragma: no cover - best-effort warmup
             logger.warning_once("SM70 MTP hotpath warmup skipped: %s", err)
@@ -996,6 +1012,7 @@ class SpecDecodeBaseProposer:
             "mtp_prepare_inputs",
             "mtp_rejection_expand",
             "mtp_step_slot_mapping",
+            "mtp_draft_topk",
         )
 
     def warmup_sm70_mtp_moe_kernels(self) -> tuple[str, ...]:

--- a/vllm/v1/spec_decode/llm_base_proposer.py
+++ b/vllm/v1/spec_decode/llm_base_proposer.py
@@ -114,10 +114,14 @@ def _sm70_mtp_moe_warmup_sizes(
     return tuple(sorted(size for size in sizes if size <= max_num_tokens))
 
 
-def _sm70_mtp_hotpath_warmup_batch_sizes(max_batch_size: int) -> tuple[int, ...]:
-    """Cover Triton's single-request and concurrent scalar specializations."""
+def _sm70_mtp_hotpath_warmup_batch_sizes(
+    max_batch_size: int, include_alternate: bool = False
+) -> tuple[int, ...]:
+    """Preserve the primary warmup and optionally cover its alternate shape."""
     concurrent_batch_size = max(1, min(int(max_batch_size), 4))
-    return tuple(sorted({1, concurrent_batch_size}))
+    if include_alternate:
+        return tuple(sorted({1, concurrent_batch_size}))
+    return (concurrent_batch_size,)
 
 
 def _is_dflash_method(method: str | None) -> bool:
@@ -868,7 +872,9 @@ class SpecDecodeBaseProposer:
             summary,
         )
 
-    def _warmup_sm70_mtp_hotpath_batch(self, batch_size: int, vocab_size: int) -> None:
+    def _warmup_sm70_mtp_hotpath_batch(
+        self, batch_size: int, vocab_size: int, warm_draft_topk: bool
+    ) -> None:
         valid_sampled_tokens_count = None
         for num_sampled_tokens in sorted({1, self.num_speculative_tokens + 1}):
             sampled_token_ids = torch.zeros(
@@ -973,16 +979,17 @@ class SpecDecodeBaseProposer:
             input_batch_size=batch_size,
         )
 
-        draft_logits = torch.zeros(
-            (batch_size, vocab_size), dtype=torch.float32, device=self.device
-        )
-        draft_top_k = torch.full(
-            (batch_size,),
-            min(20, vocab_size),
-            dtype=torch.int32,
-            device=self.device,
-        )
-        apply_top_k_top_p(draft_logits, draft_top_k, None)
+        if warm_draft_topk:
+            draft_logits = torch.zeros(
+                (batch_size, vocab_size), dtype=torch.float32, device=self.device
+            )
+            draft_top_k = torch.full(
+                (batch_size,),
+                min(20, vocab_size),
+                dtype=torch.int32,
+                device=self.device,
+            )
+            apply_top_k_top_p(draft_logits, draft_top_k, None)
 
     def warmup_sm70_mtp_hotpath_kernels(self) -> tuple[str, ...]:
         """Warm MTP helper kernels that otherwise JIT on the first request."""
@@ -1000,20 +1007,27 @@ class SpecDecodeBaseProposer:
 
         try:
             vocab_size = max(2, self.draft_model_config.get_vocab_size())
-            for batch_size in _sm70_mtp_hotpath_warmup_batch_sizes(self.max_batch_size):
-                self._warmup_sm70_mtp_hotpath_batch(batch_size, vocab_size)
+            expanded_warmup = envs.VLLM_SM70_MTP_CONCURRENCY_WARMUP
+            for batch_size in _sm70_mtp_hotpath_warmup_batch_sizes(
+                self.max_batch_size, include_alternate=expanded_warmup
+            ):
+                self._warmup_sm70_mtp_hotpath_batch(
+                    batch_size, vocab_size, warm_draft_topk=expanded_warmup
+                )
             torch.accelerator.synchronize()
         except Exception as err:  # pragma: no cover - best-effort warmup
             logger.warning_once("SM70 MTP hotpath warmup skipped: %s", err)
             return ()
 
-        return (
+        warmed_kernels = [
             "mtp_prepare_next_token",
             "mtp_prepare_inputs",
             "mtp_rejection_expand",
             "mtp_step_slot_mapping",
-            "mtp_draft_topk",
-        )
+        ]
+        if envs.VLLM_SM70_MTP_CONCURRENCY_WARMUP:
+            warmed_kernels.append("mtp_draft_topk")
+        return tuple(warmed_kernels)
 
     def warmup_sm70_mtp_moe_kernels(self) -> tuple[str, ...]:
         """Warm the finite Triton-MoE shape specializations used by MTP."""

--- a/vllm/v1/worker/mamba_utils.py
+++ b/vllm/v1/worker/mamba_utils.py
@@ -660,51 +660,56 @@ class MambaSpecDecodeGPUContext:
         )
 
     def warmup_fused_postprocess(self) -> bool:
-        """Compile the non-DDTree MTP signature without copying model state."""
+        """Compile single and concurrent MTP signatures without state copies."""
         if not self.is_initialized:
             return False
 
         device = self.state_base_addrs.device
-        num_accepted_tokens = torch.ones(1, dtype=torch.int32, device=device)
-        spec_state_slot_selectors = torch.ones(1, dtype=torch.int32, device=device)
-        mamba_state_idx = torch.zeros(1, dtype=torch.int32, device=device)
-        num_scheduled_tokens = torch.ones(1, dtype=torch.int32, device=device)
-        # Make the running length one token past a block boundary. The kernel
-        # therefore exits before dereferencing state or block-table pointers,
-        # while compiling the exact MTP specialization used at runtime.
-        num_computed_tokens = torch.full(
-            (1,), self.block_size, dtype=torch.int32, device=device
-        )
-        num_draft_tokens = torch.zeros(1, dtype=torch.int32, device=device)
-        ddtree_accepted_node_indices = torch.empty(
-            (1, 1), dtype=torch.int32, device=device
-        )
-
         total_states = self.num_layers * self.num_state_types
-        postprocess_mamba_fused_kernel[(1, total_states)](
-            num_accepted_tokens,
-            spec_state_slot_selectors,
-            ddtree_accepted_node_indices,
-            ddtree_accepted_node_indices.stride(0),
-            mamba_state_idx,
-            num_scheduled_tokens,
-            num_computed_tokens,
-            num_draft_tokens,
-            self.block_table_ptrs,
-            self.block_table_stride_req,
-            self.state_base_addrs,
-            self.state_block_strides,
-            self.state_elem_sizes,
-            self.state_inner_sizes,
-            self.state_conv_widths,
-            self.state_group_indices,
-            self.num_accepted_tokens_out,
-            self.spec_state_slot_selectors_out,
-            1,
-            block_size=self.block_size,
-            COPY_BLOCK_SIZE=1024,
-            HAS_DDTREE_ACCEPTED_NODES=False,
-        )
+        max_num_reqs = int(self.num_accepted_tokens_out.shape[0])
+        for num_reqs in sorted({1, max(1, min(max_num_reqs, 4))}):
+            num_accepted_tokens = torch.ones(num_reqs, dtype=torch.int32, device=device)
+            spec_state_slot_selectors = torch.ones(
+                num_reqs, dtype=torch.int32, device=device
+            )
+            mamba_state_idx = torch.zeros(num_reqs, dtype=torch.int32, device=device)
+            num_scheduled_tokens = torch.ones(
+                num_reqs, dtype=torch.int32, device=device
+            )
+            # Put every request one token past a block boundary. The kernel
+            # exits before dereferencing state or block-table pointers.
+            num_computed_tokens = torch.full(
+                (num_reqs,), self.block_size, dtype=torch.int32, device=device
+            )
+            num_draft_tokens = torch.zeros(num_reqs, dtype=torch.int32, device=device)
+            ddtree_accepted_node_indices = torch.empty(
+                (1, 1), dtype=torch.int32, device=device
+            )
+
+            postprocess_mamba_fused_kernel[(num_reqs, total_states)](
+                num_accepted_tokens,
+                spec_state_slot_selectors,
+                ddtree_accepted_node_indices,
+                ddtree_accepted_node_indices.stride(0),
+                mamba_state_idx,
+                num_scheduled_tokens,
+                num_computed_tokens,
+                num_draft_tokens,
+                self.block_table_ptrs,
+                self.block_table_stride_req,
+                self.state_base_addrs,
+                self.state_block_strides,
+                self.state_elem_sizes,
+                self.state_inner_sizes,
+                self.state_conv_widths,
+                self.state_group_indices,
+                self.num_accepted_tokens_out,
+                self.spec_state_slot_selectors_out,
+                num_reqs,
+                block_size=self.block_size,
+                COPY_BLOCK_SIZE=1024,
+                HAS_DDTREE_ACCEPTED_NODES=False,
+            )
         torch.accelerator.synchronize()
         return True
 

--- a/vllm/v1/worker/mamba_utils.py
+++ b/vllm/v1/worker/mamba_utils.py
@@ -660,14 +660,17 @@ class MambaSpecDecodeGPUContext:
         )
 
     def warmup_fused_postprocess(self) -> bool:
-        """Compile single and concurrent MTP signatures without state copies."""
+        """Compile MTP postprocess signatures without copying model state."""
         if not self.is_initialized:
             return False
 
         device = self.state_base_addrs.device
         total_states = self.num_layers * self.num_state_types
-        max_num_reqs = int(self.num_accepted_tokens_out.shape[0])
-        for num_reqs in sorted({1, max(1, min(max_num_reqs, 4))}):
+        warmup_sizes = {1}
+        if envs.VLLM_SM70_MTP_CONCURRENCY_WARMUP:
+            max_num_reqs = int(self.num_accepted_tokens_out.shape[0])
+            warmup_sizes.add(max(1, min(max_num_reqs, 4)))
+        for num_reqs in sorted(warmup_sizes):
             num_accepted_tokens = torch.ones(num_reqs, dtype=torch.int32, device=device)
             spec_state_slot_selectors = torch.ones(
                 num_reqs, dtype=torch.int32, device=device


### PR DESCRIPTION
## Purpose

Add an opt-in startup warmup for alternate SM70 MTP concurrency signatures so deployments can trade a small startup cost for fewer first-request Triton compilations.

## What changed

- Preserve the existing primary proposer warmup shape by default.
- Under `VLLM_SM70_MTP_CONCURRENCY_WARMUP=1`, also warm the alternate batch-1/concurrent metadata signatures, the top-k-only probabilistic draft sampler, and the bounded Mamba postprocess concurrency signature.
- Keep the new expanded warmup **default-off** because the original PR had baseline and route-hit evidence but had not completed a matched exact-head candidate/control rerun.
- Warm Mamba postprocess through the early-exit sentinel path, so no model state or block-table data is copied.
- Do not change sampling semantics, logits, model state, quantized weights, buffers, or hot-path kernels.

This is an inference-engine warmup contract; it contains no model identity admission.

## Evidence

The original cold-cache TP4/SM70 MTP4 trace recorded five inference-time JIT kernel families at concurrency 4. The original GPU state-preservation smoke passed. Those results establish the compilation gap, but not enough evidence to make the expanded startup work a global default.

## Test plan and result

- Focused helper/default tests: **3 passed**.
- Changed-file pre-commit suite: **passed**, including Ruff, mypy, env-default validation, SPDX, and forbidden API/import gates.
- `git diff --check`: passed.
- No full-model end-to-end rerun was performed during source audit.

Rollback is immediate: leave `VLLM_SM70_MTP_CONCURRENCY_WARMUP` unset or set it to `0`.