### PR TITLE
[Kernel][SM70] Add opt-in MTP concurrency tuning

### DIFF
--- a/benchmarks/benchmark_sm70_model_tokens.py
+++ b/benchmarks/benchmark_sm70_model_tokens.py
@@ -1651,11 +1651,6 @@ def _dump(args: argparse.Namespace) -> int:
         args.cuda_profiler_capture_generate or capture_decode_after_prefix_warmup
     ):
         raise ValueError("CUDA-profiler capture does not support repeated requests")
-    if capture_decode_after_prefix_warmup and len(prompts) != 1:
-        raise ValueError(
-            "--cuda-profiler-capture-decode-after-prefix-warmup requires "
-            "exactly one prompt"
-        )
     sampling_params = SamplingParams(
         max_tokens=args.max_tokens,
         temperature=args.temperature,
@@ -2605,9 +2600,9 @@ def _parse_args() -> argparse.Namespace:
         "--cuda-profiler-capture-decode-after-prefix-warmup",
         action="store_true",
         help=(
-            "Prime one prompt with prefix caching while the CUDA profiler is "
+            "Prime the prompts with prefix caching while the CUDA profiler is "
             "off, then capture only the second matching llm.generate call. "
-            "Requires one non-sequential prompt and CUDA graphs."
+            "Requires non-sequential prompts and CUDA graphs."
         ),
     )
     parser.add_argument("--max-tokens", type=int, default=16)

--- a/benchmarks/benchmark_sm70_model_tokens.py
+++ b/benchmarks/benchmark_sm70_model_tokens.py
@@ -543,6 +543,10 @@ def _sm70_turbomind_policy(
         "VLLM_SM70_UNQUANTIZED_MOE_0DOT3_CONFIG",
         True,
     )
+    qwen36_mtp_moe_tuned_config = _env_bool(
+        "VLLM_SM70_QWEN36_MTP_MOE_TUNED_CONFIG",
+        True,
+    )
     awq_warmup = _env_bool("VLLM_SM70_AWQ_WARMUP", True)
     awq_moe_disable = _env_bool("VLLM_SM70_AWQ_MOE_DISABLE", False)
     awq_moe_batched = _env_bool("VLLM_SM70_AWQ_MOE_BATCHED_GEMM", True)
@@ -621,6 +625,10 @@ def _sm70_turbomind_policy(
             "VLLM_SM70_UNQUANTIZED_MOE_0DOT3_CONFIG"
         ),
         "unquantized_moe_0dot3_config_effective": (unquantized_moe_0dot3_config),
+        "VLLM_SM70_QWEN36_MTP_MOE_TUNED_CONFIG": os.environ.get(
+            "VLLM_SM70_QWEN36_MTP_MOE_TUNED_CONFIG"
+        ),
+        "qwen36_mtp_moe_tuned_config_effective": qwen36_mtp_moe_tuned_config,
         "VLLM_SM70_AWQ_WARMUP": os.environ.get("VLLM_SM70_AWQ_WARMUP"),
         "awq_warmup_effective": awq_warmup,
         "VLLM_SM70_AWQ_WARMUP_MAX_M": os.environ.get("VLLM_SM70_AWQ_WARMUP_MAX_M"),

--- a/csrc/custom_all_reduce.cuh
+++ b/csrc/custom_all_reduce.cuh
@@ -51,6 +51,7 @@ inline hipPointer_attribute rangeStartAddrAttr =
 
 constexpr size_t kSm70Tp2SmallAllreduceBytes = 40 * 1024;
 constexpr size_t kSm70Tp8HierarchicalAllreduceBytes = 4096 * sizeof(half);
+constexpr size_t kSm70Tp4MtpVerifierBytesPerRequest = 5 * 2048 * sizeof(half);
 constexpr int kSm70Tp8CompletionSignalSlotBase = 2;
 constexpr int kSm70GemmaRmsNormHiddenSize = 5120;
 constexpr int kSm70GemmaRmsNormThreads = 1024;
@@ -114,12 +115,28 @@ inline bool sm70_tp8_hierarchical_peer(int rank, int peer) {
 }
 
 inline int custom_allreduce_block_limit(int default_limit, int world_size,
-                                        size_t bytes) {
+                                        bool fully_connected, size_t bytes,
+                                        bool tune_sm70_tp4_mtp) {
   const char* raw = std::getenv("VLLM_CUSTOM_ALLREDUCE_BLOCK_LIMIT");
   if (raw == nullptr || raw[0] == '\0') {
     if (world_size == 2 && bytes <= kSm70Tp2SmallAllreduceBytes &&
         custom_allreduce_current_device_is_sm70()) {
       return 1;
+    }
+    const char* tune_raw = std::getenv("VLLM_SM70_TP4_MTP_AR_BLOCK_TUNING");
+    const bool tuning_enabled =
+        tune_raw == nullptr || tune_raw[0] == '\0' || std::atoi(tune_raw) != 0;
+    if (tune_sm70_tp4_mtp && tuning_enabled &&
+        default_limit == defaultBlockLimit && world_size == 4 &&
+        fully_connected && custom_allreduce_current_device_is_sm70()) {
+      if (bytes == kSm70Tp4MtpVerifierBytesPerRequest) {
+        return 1;
+      }
+      if (bytes == 8 * kSm70Tp4MtpVerifierBytesPerRequest ||
+          bytes == 12 * kSm70Tp4MtpVerifierBytesPerRequest ||
+          bytes == 16 * kSm70Tp4MtpVerifierBytesPerRequest) {
+        return 8;
+      }
     }
     return default_limit;
   }
@@ -1306,7 +1323,8 @@ class CustomAllreduce {
   void allreduce(cudaStream_t stream, T* input, T* output, int size,
                  int threads = 512, int block_limit = defaultBlockLimit) {
     block_limit = custom_allreduce_block_limit(
-        block_limit, world_size_, static_cast<size_t>(size) * sizeof(T));
+        block_limit, world_size_, fully_connected_,
+        static_cast<size_t>(size) * sizeof(T), true);
     auto d = packed_t<T>::P::size;
     if (size % d != 0)
       throw std::runtime_error(
@@ -1530,7 +1548,8 @@ class CustomAllreduce {
                       int size, int threads = 512,
                       int block_limit = defaultBlockLimit) {
     block_limit = custom_allreduce_block_limit(
-        block_limit, world_size_, static_cast<size_t>(size) * sizeof(T));
+        block_limit, world_size_, fully_connected_,
+        static_cast<size_t>(size) * sizeof(T), false);
     auto d = packed_t<T>::P::size;
     if (size % d != 0)
       throw std::runtime_error(

--- a/csrc/custom_all_reduce.cuh
+++ b/csrc/custom_all_reduce.cuh
@@ -125,7 +125,7 @@ inline int custom_allreduce_block_limit(int default_limit, int world_size,
     }
     const char* tune_raw = std::getenv("VLLM_SM70_TP4_MTP_AR_BLOCK_TUNING");
     const bool tuning_enabled =
-        tune_raw == nullptr || tune_raw[0] == '\0' || std::atoi(tune_raw) != 0;
+        tune_raw != nullptr && tune_raw[0] != '\0' && std::atoi(tune_raw) != 0;
     if (tune_sm70_tp4_mtp && tuning_enabled &&
         default_limit == defaultBlockLimit && world_size == 4 &&
         fully_connected && custom_allreduce_current_device_is_sm70()) {

--- a/csrc/sm70_turbomind/ops/awq_sm70_gemm.cu
+++ b/csrc/sm70_turbomind/ops/awq_sm70_gemm.cu
@@ -1221,12 +1221,17 @@ int mxfp4_dense_tune_max_m() {
 
 int nvfp4_dense_tune_max_m() {
   const char* raw = std::getenv("VLLM_SM70_NVFP4_DENSE_TUNE_MAX_M");
-  return raw ? std::max(std::atoi(raw), 0) : 16;
+  return raw ? std::max(std::atoi(raw), 0) : 80;
 }
 
 int moe_tune_max_tokens() {
   const char* raw = std::getenv("VLLM_SM70_AWQ_MOE_TUNE_MAX_TOKENS");
   return raw ? std::max(std::atoi(raw), 0) : 128;
+}
+
+int nvfp4_moe_tune_max_tokens() {
+  const char* raw = std::getenv("VLLM_SM70_NVFP4_MOE_TUNE_MAX_TOKENS");
+  return raw ? std::max(std::atoi(raw), 0) : 640;
 }
 
 int sm70_f16_dense_max_m() {
@@ -1331,8 +1336,11 @@ turbomind::gemm::DispatchPolicy select_nvfp4_dense_dispatch_policy(
 
 turbomind::gemm::DispatchPolicy select_moe_dispatch_policy_impl(
     int device, int total_tokens, int n, int k, int num_experts, int group_size,
-    cudaStream_t stream, TuneKeyKind kind, bool tune_enabled) {
-  if (!tune_enabled || total_tokens > moe_tune_max_tokens()) {
+    cudaStream_t stream, TuneKeyKind kind, bool tune_enabled,
+    int max_tune_tokens = -1) {
+  const int tune_limit =
+      max_tune_tokens >= 0 ? max_tune_tokens : moe_tune_max_tokens();
+  if (!tune_enabled || total_tokens > tune_limit) {
     return turbomind::gemm::DispatchPolicy::kDefault;
   }
 
@@ -1387,7 +1395,8 @@ turbomind::gemm::DispatchPolicy select_nvfp4_moe_dispatch_policy(
     cudaStream_t stream) {
   return select_moe_dispatch_policy_impl(
       device, total_tokens, n, k, num_experts, group_size, stream,
-      TuneKeyKind::kNvfp4Moe, nvfp4_tune_small_shapes_enabled());
+      TuneKeyKind::kNvfp4Moe, nvfp4_tune_small_shapes_enabled(),
+      nvfp4_moe_tune_max_tokens());
 }
 
 WorkspaceHolder& get_workspace(int device, cudaStream_t stream) {

--- a/csrc/sm70_turbomind/ops/awq_sm70_gemm.cu
+++ b/csrc/sm70_turbomind/ops/awq_sm70_gemm.cu
@@ -1221,7 +1221,7 @@ int mxfp4_dense_tune_max_m() {
 
 int nvfp4_dense_tune_max_m() {
   const char* raw = std::getenv("VLLM_SM70_NVFP4_DENSE_TUNE_MAX_M");
-  return raw ? std::max(std::atoi(raw), 0) : 80;
+  return raw ? std::max(std::atoi(raw), 0) : 16;
 }
 
 int moe_tune_max_tokens() {

--- a/csrc/sm70_turbomind/ops/awq_sm70_gemm.cu
+++ b/csrc/sm70_turbomind/ops/awq_sm70_gemm.cu
@@ -1231,7 +1231,7 @@ int moe_tune_max_tokens() {
 
 int nvfp4_moe_tune_max_tokens() {
   const char* raw = std::getenv("VLLM_SM70_NVFP4_MOE_TUNE_MAX_TOKENS");
-  return raw ? std::max(std::atoi(raw), 0) : 640;
+  return raw ? std::max(std::atoi(raw), 0) : 128;
 }
 
 int sm70_f16_dense_max_m() {
@@ -7863,7 +7863,7 @@ void nvfp4_moe_dense_stage_sm70_out(torch::Tensor out, torch::Tensor input,
       "SM70 NVFP4 MoE CUDA-graph-safe TurboMind path enabled C++ op reached",
       input, input.size(0), num_experts);
   constexpr int kNvfp4LegacyCompactGroups = 8 * 8;
-  // Cover the Qwen3.6 C2 verifier bound. Duplicate expert selections
+  // Cover the validated top-k8 B10 verifier bound. Duplicate expert selections
   // remain separate one-row groups, so this is a routed-slot bound rather
   // than an active-expert bound. Keep the dense-grouped cutoff independent:
   // a disabled compact route above 64 rows must not fall back per expert.

--- a/csrc/sm70_turbomind/ops/awq_sm70_gemm.cu
+++ b/csrc/sm70_turbomind/ops/awq_sm70_gemm.cu
@@ -7862,7 +7862,12 @@ void nvfp4_moe_dense_stage_sm70_out(torch::Tensor out, torch::Tensor input,
       logged_nvfp4_dense_stage,
       "SM70 NVFP4 MoE CUDA-graph-safe TurboMind path enabled C++ op reached",
       input, input.size(0), num_experts);
-  constexpr int kNvfp4MaxCompactGroups = 8 * 8;
+  constexpr int kNvfp4LegacyCompactGroups = 8 * 8;
+  // Cover the Qwen3.6 C2 verifier bound. Duplicate expert selections
+  // remain separate one-row groups, so this is a routed-slot bound rather
+  // than an active-expert bound. Keep the dense-grouped cutoff independent:
+  // a disabled compact route above 64 rows must not fall back per expert.
+  constexpr int kNvfp4MaxCompactGroups = 10 * 8;
   const bool compact_decode_shape =
       input.size(0) == num_experts && num_experts <= kNvfp4MaxCompactGroups;
   if (compact_decode_shape) {
@@ -7872,7 +7877,7 @@ void nvfp4_moe_dense_stage_sm70_out(torch::Tensor out, torch::Tensor input,
     return;
   }
   const bool exact_qwen36_prefill_shape =
-      input.size(0) > kNvfp4MaxCompactGroups && num_experts == 256 &&
+      input.size(0) > kNvfp4LegacyCompactGroups && num_experts == 256 &&
       ((k == 2048 && (n == 1024 || n == 512 || n == 256)) ||
        (n == 2048 && (k == 512 || k == 256 || k == 128)));
   if (vllm::awq_sm70::nvfp4_moe_grouped_prefill_enabled() &&

--- a/docs/design/sm70_v100_migration_control.md
+++ b/docs/design/sm70_v100_migration_control.md
@@ -42358,7 +42358,14 @@ Interpretation:
 - Final evidence is under task-cache
   `qwen38-fp8-prefill-utilization-20260823/results/`, especially
   `full_model_cutlass_all_projections_final_source_tp4_fused_graph_i8000.raw.json`.
+
 ## 2026-08-24 Qwen3.6-35B NVFP4 MTP4 concurrency scaling
+
+- Audit disposition: the B10 compact-routing extension has its own matched
+  speed and GSM8K evidence and remains enabled. The broader high-width tune
+  limit, exact-shape drafter tile, all-reduce block policy, and eight-warp
+  sampler remain opt-in because their matched formal curve and combined
+  dataset-quality gate are incomplete.
 
 - The formal workload uses ModelOpt mixed FP8/NVFP4, TP4 on V100 GPU0-3,
   Flash-V100/FlashQLA, FP8-E5M2 KV cache, MTP4 probabilistic sampling with
@@ -42392,6 +42399,8 @@ Interpretation:
   measured `535.635/524.376/539.113 tok/s`; the candidate endpoint mean is
   `+2.48%`, summed pure decode is `+2.85%`, and P50 TPOT improves about `4.0%`
   with stable MTP acceptance.
+  Production keeps the prior 128-row default; reproducing this candidate
+  requires `VLLM_SM70_NVFP4_MOE_TUNE_MAX_TOKENS=640`.
 - Two earlier low-width target-MoE candidates are rejected. Directly reusing
   sorted expert IDs instead of the compact metadata copy regressed the C1
   sandwich; splitting B9/B10 into 64-slot compact chunks was numerically
@@ -42411,10 +42420,12 @@ Interpretation:
   improve `1.543x/2.656x/2.879x/2.697x/2.625x` at the formal
   C2/C4/C8/C12/C16 widths.
 - The route-hit candidate initially exposed request-time old-tile MoE
-  signatures. Exact Qwen3.6 TP4 startup now warms tuned M1-M16 plus M33/M257
+  signatures. The exact E256/H2048/I128/top-k8 TP4 contract can warm tuned
+  M1-M16 plus M33/M257
   and explicitly covers legacy M1/M2/M9/M10 naive/aligned signatures; a fresh
-  48-request run then produced no inference-time `fused_moe_kernel` JIT. Other
-  MTP models retain the old `(9,33,257)` warmup set.
+  48-request run then produced no inference-time `fused_moe_kernel` JIT.
+  Unmatched shapes retain the old `(9,33,257)` warmup set, and the tuned route
+  requires `VLLM_SM70_MTP_MOE_TUNED_CONFIG=1`.
 - Full-model evidence rejects the isolated M1 result. A physical-GPU4-7 C1
   candidate/control/candidate sandwich measured endpoint-mean summed pure
   decode `112.233` versus control `115.451 tok/s` (`-2.79%`) and endpoint-mean
@@ -42436,16 +42447,17 @@ Interpretation:
   `8.750 ms` (`-0.82%`). The source heuristic is limited to fully connected
   SM70 TP4, the exact MTP4 payloads, and ordinary all-reduce; the global block
   override still takes precedence and
-  `VLLM_SM70_TP4_MTP_AR_BLOCK_TUNING=0` restores the legacy policy.
+  the policy is enabled only by
+  `VLLM_SM70_TP4_MTP_AR_BLOCK_TUNING=1`; unset/zero retains the legacy policy.
 - The C1 graph also spends about `0.509 ms` per cycle in the combined
   top-k/top-p kernel over five 248,320-vocabulary verifier rows. Keeping the
   existing 8192/4096 tiles and masking algorithm but launching eight rather
   than four warps improves isolated B5/B10/B20/B40/B60/B80 means by
   `1.737x/1.943x/1.881x/1.732x/1.689x/1.646x`. Every candidate had zero finite
-  mask or retained-value mismatches against the four-warp result. The default
-  source change is therefore restricted to combined top-k plus top-p on SM70
-  with Qwen3.6's exact vocabulary; setting
-  `VLLM_SM70_QWEN36_TOPK_TOPP_8_WARPS=0` restores Triton's default launch.
+  mask or retained-value mismatches against the four-warp result. The opt-in
+  source change is restricted to combined top-k plus top-p on SM70, vocabulary
+  248,320, and measured row counts 5/10/20/40/60/80. Enable it with
+  `VLLM_SM70_TOPK_TOPP_8_WARPS=1`; unset/zero keeps Triton's default launch.
 - Corrected slot-independent compact metadata is finite and route-correct on a
   real TP4 layer through B20. B9 is bitwise equal to the dense route. B10 has
   cosine at least `0.99999988`, relative L2 at most `1.0115e-4`, and maximum

--- a/docs/design/sm70_v100_migration_control.md
+++ b/docs/design/sm70_v100_migration_control.md
@@ -42347,3 +42347,35 @@ Interpretation:
 - Final evidence is under task-cache
   `qwen38-fp8-prefill-utilization-20260823/results/`, especially
   `full_model_cutlass_all_projections_final_source_tp4_fused_graph_i8000.raw.json`.
+## 2026-08-24 Qwen3.6-35B NVFP4 MTP4 concurrency scaling
+
+- The formal workload uses ModelOpt mixed FP8/NVFP4, TP4 on V100 GPU0-3,
+  Flash-V100/FlashQLA, FP8-E5M2 KV cache, MTP4 probabilistic sampling with
+  local argmax, max length/batched tokens 8192, and 48 fixed ShareGPT requests
+  totaling 9,115 prompt and 10,623 output tokens. Forty-eight requests give
+  C16 three complete waves and remove the tail-underfill artifact in the
+  earlier 16-request localization sweep.
+- Current-main output throughput at C1/C2/C4/C8/C12/C16 is respectively
+  98.265/146.124/276.600/414.315/491.270/542.982 tok/s. Scaling efficiency
+  relative to C1 is 100.00%/74.35%/70.37%/52.70%/41.66%/34.54%. Mean MTP
+  acceptance length remains 2.887-2.955 and draft acceptance remains
+  47.18%-48.87%, so the scaling loss is not an acceptance collapse.
+- The old AWQ scheduling pair is rejected for this route. Shared-expert stream
+  overlap plus `all_reduce_sum2` regressed corrected C16 output 4.10%; isolated
+  overlap and sum2 regressed 4.66% and 4.06%. The pair also regressed C1 from
+  98.265 to 94.880 tok/s (3.45%). Leave both switches default-off for NVFP4.
+- MTP4 verifier width is five times request concurrency. Production warmup
+  currently stops at NVFP4 MoE M15 and dense M16, while captured C4/C8/C12/C16
+  shapes require M20/M40/M60/M80, or 160/320/480/640 routed rows.
+- Clean independent-process graph microbenchmarks on one exclusively claimed
+  V100 show measured routed-MoE W13/W2 speedups at M20/M40/M60/M80 of
+  1.107x/1.311x, 1.200x/1.179x, 1.195x/1.181x, and 1.177x/1.117x. Shared-dense
+  W13/W2 speedups are 1.742x/1.261x, 2.749x/1.181x, 2.004x/1.179x, and
+  1.519x/1.348x. All outputs are finite; maximum accumulation-order difference
+  is 6.104e-5, which still requires the dataset-level quality gate.
+- The bounded candidate raises only NVFP4 dense/MoE tune limits to M80 and 640
+  routed rows, derives warmup widths from the already-captured CUDA Graph
+  sizes, and builds balanced 256-expert offsets above 32 verifier tokens. It
+  does not change quantization, routing, attention, MTP acceptance, or sampling
+  semantics. Focused warmup tests pass; C16 full-model speed, the full six-point
+  curve, and GSM8K/ShareGPT quality remain required before acceptance.

--- a/docs/design/sm70_v100_migration_control.md
+++ b/docs/design/sm70_v100_migration_control.md
@@ -42412,5 +42412,25 @@ Interpretation:
   was `154.865/147.180/163.480 tok/s`; endpoint mean is `+8.15%`. Summed pure
   decode improves `+4.47%`, P50 TPOT is effectively flat (`+0.14%`), and mean
   acceptance is lower than control rather than artificially favorable. M17+
-  retains the old prefill tile. The final six-point GPU0-3 curve and
-  GSM8K/ShareGPT quality remain required.
+  retains the old prefill tile.
+- Every C1 graph all-reduce in the Nsight trace is the exact 10,240-element
+  FP16 verifier payload. A TP4 operator sweep found that one CTA is faster for
+  this 20-KiB payload, while eight CTAs are faster only for the exact
+  C8/C12/C16 verifier payloads; C2/C4 retain the default. A physical-GPU4-7 C1
+  candidate/control/candidate sandwich with the one-CTA launch measured
+  endpoint-mean pure decode `116.405` versus `112.842 tok/s` (`+3.16%`), output
+  `103.070` versus `100.112 tok/s` (`+2.96%`), and P50 TPOT `8.678` versus
+  `8.750 ms` (`-0.82%`). The source heuristic is limited to fully connected
+  SM70 TP4, the exact MTP4 payloads, and ordinary all-reduce; the global block
+  override still takes precedence and
+  `VLLM_SM70_TP4_MTP_AR_BLOCK_TUNING=0` restores the legacy policy.
+- The C1 graph also spends about `0.509 ms` per cycle in the combined
+  top-k/top-p kernel over five 248,320-vocabulary verifier rows. Keeping the
+  existing 8192/4096 tiles and masking algorithm but launching eight rather
+  than four warps improves isolated B5/B10/B20/B40/B60/B80 means by
+  `1.737x/1.943x/1.881x/1.732x/1.689x/1.646x`. Every candidate had zero finite
+  mask or retained-value mismatches against the four-warp result. The default
+  source change is therefore restricted to combined top-k plus top-p on SM70
+  with Qwen3.6's exact vocabulary; setting
+  `VLLM_SM70_QWEN36_TOPK_TOPP_8_WARPS=0` restores Triton's default launch.
+- The final six-point GPU0-3 curve and GSM8K/ShareGPT quality remain required.

--- a/docs/design/sm70_v100_migration_control.md
+++ b/docs/design/sm70_v100_migration_control.md
@@ -42364,8 +42364,8 @@ Interpretation:
   overlap plus `all_reduce_sum2` regressed corrected C16 output 4.10%; isolated
   overlap and sum2 regressed 4.66% and 4.06%. The pair also regressed C1 from
   98.265 to 94.880 tok/s (3.45%). Leave both switches default-off for NVFP4.
-- MTP4 verifier width is five times request concurrency. Production warmup
-  currently stops at NVFP4 MoE M15 and dense M16, while captured C4/C8/C12/C16
+- MTP4 verifier width is five times request concurrency. Before this work,
+  production warmup stopped at NVFP4 MoE M15 while captured C4/C8/C12/C16
   shapes require M20/M40/M60/M80, or 160/320/480/640 routed rows.
 - Clean independent-process graph microbenchmarks on one exclusively claimed
   V100 show measured routed-MoE W13/W2 speedups at M20/M40/M60/M80 of
@@ -42373,9 +42373,44 @@ Interpretation:
   W13/W2 speedups are 1.742x/1.261x, 2.749x/1.181x, 2.004x/1.179x, and
   1.519x/1.348x. All outputs are finite; maximum accumulation-order difference
   is 6.104e-5, which still requires the dataset-level quality gate.
-- The bounded candidate raises only NVFP4 dense/MoE tune limits to M80 and 640
-  routed rows, derives warmup widths from the already-captured CUDA Graph
-  sizes, and builds balanced 256-expert offsets above 32 verifier tokens. It
-  does not change quantization, routing, attention, MTP acceptance, or sampling
-  semantics. Focused warmup tests pass; C16 full-model speed, the full six-point
-  curve, and GSM8K/ShareGPT quality remain required before acceptance.
+- The high-width candidate raises only the NVFP4 MoE tune limit to 640 routed
+  rows, derives warmup widths from the already-captured CUDA Graph sizes, and
+  builds balanced 256-expert offsets above 32 verifier tokens. The dense-NVFP4
+  M80 extension was isolated and withdrawn; its default remains M16. In a
+  48-request C16 candidate/control/candidate sandwich, routed-MoE tuning
+  measured `535.635/524.376/539.113 tok/s`; the candidate endpoint mean is
+  `+2.48%`, summed pure decode is `+2.85%`, and P50 TPOT improves about `4.0%`
+  with stable MTP acceptance.
+- Two low-width target-MoE candidates are rejected. Directly reusing sorted
+  expert IDs instead of the compact metadata copy regressed the C1 sandwich;
+  splitting B9/B10 into correctness-bounded 64-slot compact chunks was
+  numerically healthy but `41.5%/10.3%` slower. Direct compact execution above
+  64 slots remains correctness-invalid and must not be retried.
+- A C1 Nsight graph-node trace identified the bundled unquantized MTP drafter
+  MoE as a separate `2.825 ms` per-cycle hotspot. An initial oracle incorrectly
+  used the checkpoint-global I512 shape. The first candidate startup log proved
+  that TP4 shards it to local I128 (`E=256,N=128` config lookup); the candidate
+  therefore did not route-hit and its full-model run was stopped before
+  measurement. The global-I512 speedups are not TP4 selection evidence. The
+  corrected local E256/H2048/I128/top-k8 M1-M16 graph oracle is bitwise equal
+  at every width. The isolated M1 operation improved `1.290x` by retaining
+  N32/K64 and reducing to two warps; M2-M16 select M8/N128/K32/W4/S3 and
+  improve `1.543x/2.656x/2.879x/2.697x/2.625x` at the formal
+  C2/C4/C8/C12/C16 widths.
+- The route-hit candidate initially exposed request-time old-tile MoE
+  signatures. Exact Qwen3.6 TP4 startup now warms tuned M1-M16 plus M33/M257
+  and explicitly covers legacy M1/M2/M9/M10 naive/aligned signatures; a fresh
+  48-request run then produced no inference-time `fused_moe_kernel` JIT. Other
+  MTP models retain the old `(9,33,257)` warmup set.
+- Full-model evidence rejects the isolated M1 result. A physical-GPU4-7 C1
+  candidate/control/candidate sandwich measured endpoint-mean summed pure
+  decode `112.233` versus control `115.451 tok/s` (`-2.79%`) and endpoint-mean
+  P50 TPOT `8.874` versus `8.758 ms` (`+1.33%`). M1 therefore retains the exact
+  0.0.3 tile; balanced single-GPU kernel means are not a substitute for TP4
+  rank-imbalance and synchronization behavior.
+- The narrowed M2-M16 candidate passes C2. Candidate/control/candidate output
+  was `154.865/147.180/163.480 tok/s`; endpoint mean is `+8.15%`. Summed pure
+  decode improves `+4.47%`, P50 TPOT is effectively flat (`+0.14%`), and mean
+  acceptance is lower than control rather than artificially favorable. M17+
+  retains the old prefill tile. The final six-point GPU0-3 curve and
+  GSM8K/ShareGPT quality remain required.

--- a/docs/design/sm70_v100_migration_control.md
+++ b/docs/design/sm70_v100_migration_control.md
@@ -42015,17 +42015,20 @@ Interpretation:
   shapes, TP8, EP, and all-to-all fail closed rather than taking a generic
   fallback.
 - The native Qwen3.6-35B-A3B MoE contract is H2048, expert I512, 256 experts,
-  top-k 8, replicated experts, and TP1/2/4. B1-B8 decode uses compact active
-  expert groups. B9-B18 CUDA Graph/MTP decode and larger prefill use persistent
+  top-k 8, replicated experts, and TP1/2/4. B1-B10 decode uses compact routed
+  slot groups. B11-B18 CUDA Graph/MTP decode and larger prefill use persistent
   buffers with the full 256-expert grouped TurboMind operation. The grouped
   prefill policy is default-on and may be disabled only for diagnosis with
   `VLLM_SM70_NVFP4_MOE_GROUPED_PREFILL=0`.
 - A real layer-0 TP4 checkpoint oracle matched the previous per-expert route:
   M4096 W13/W2 were bitwise identical and improved 20.39x/9.48x. Full-grouped
   B9 and B18 had cosine 1.0, maximum absolute error at most 1.221e-4, and
-  21.59x-35.21x isolated-stage speedups. Expanding the compact path to 144
-  groups produced a roughly 0.495 W13 relative-L2 error and catastrophic W2
-  output, so the compact limit remains 64 groups; do not repeat that candidate.
+  21.59x-35.21x isolated-stage speedups. A rejected 144-group experiment
+  coalesced repeated expert IDs even though the forced-one-row scheduler
+  requires routed slots to remain independent; its roughly 0.495 W13
+  relative-L2 error and catastrophic W2 output do not establish a general
+  64-group correctness limit. The corrected slot-independent B9/B10 evidence
+  is recorded in the concurrency section below.
 - Matching TP4, FP8-E5M2 KV-cache, Flash-V100/FlashQLA, full CUDA Graph,
   input-4096/output-1024, max-length-8192 runs measured AWQ at 0.3813 s prefill
   and 113.71 token/s steady decode. Default-grouped NVFP4 measured 0.4216 s and
@@ -42057,6 +42060,12 @@ Interpretation:
   `[2, 12, 37, 87, 89, 102, 119]`. Record 37 is a cap-induced truncation and is
   correct at 1024 output tokens, so effective MTP4 accuracy is 122/128. A
   standard-GDN diagnostic scored only 108/128 and is rejected.
+- The bounded B10 source at `5422173e99` passes the same pinned GSM8K-128
+  MTP4 gate at 122/128 (95.3125%), with zero invalid answers, zero repetitive
+  records, and wrong indices `[2, 12, 87, 89, 102, 119]`. It generated 19,434
+  output tokens in 135.967 s. This is dataset-level evidence that the B10
+  extension does not regress the accepted MTP4 quality band; no-MTP token
+  equality is not used as its oracle.
 - A final default-grouped, no-MTP natural-text gate used two identical Chinese
   prompts and one Python prompt. All three requests reached EOS with `stop`;
   the duplicate outputs were token-for-token identical, and the code response
@@ -42069,6 +42078,8 @@ Interpretation:
   `results/tp4_mtp4_fp8kv_gsm8k_chat_nothink_5shot_128_coldstart_rebased_final_graph.json`;
   the all-JIT-warm ShareGPT artifact is
   `results/tp4_gpu0123_mtp4_fp8kv_sharegpt16_seed20260822_all_jit_warmup_reserved_graph.json`.
+  The bounded-B10 dataset artifact is
+  `bench_results/qwen36_nvfp4_concurrency_scaling_20260824/results/candidate_final_mtp4_gsm8k_chat_nothink_5shot_128.json`.
   These results are the accepted 35B evidence; earlier short route-hit and
   quality smokes must not be substituted for the matched speed contract.
 
@@ -42472,5 +42483,6 @@ Interpretation:
   fallback. It may reduce padded grouped scheduling without a host readback or
   a probabilistic correctness assumption. A persistent tile scheduler remains
   the larger follow-up if guarded active-group bucketing cannot beat its extra
-  CUDA Graph launch. The B10 GSM8K-128 quality gate remains pending while the
-  physical TP4 GPUs are occupied by an unrelated task.
+  CUDA Graph launch. B10 has passed the pinned GSM8K-128 MTP4 gate at 122/128,
+  with zero invalid or repetitive records; the next quality gate belongs to
+  any high-concurrency scheduler candidate that survives full-model A/B/A.

--- a/docs/design/sm70_v100_migration_control.md
+++ b/docs/design/sm70_v100_migration_control.md
@@ -42381,11 +42381,13 @@ Interpretation:
   measured `535.635/524.376/539.113 tok/s`; the candidate endpoint mean is
   `+2.48%`, summed pure decode is `+2.85%`, and P50 TPOT improves about `4.0%`
   with stable MTP acceptance.
-- Two low-width target-MoE candidates are rejected. Directly reusing sorted
-  expert IDs instead of the compact metadata copy regressed the C1 sandwich;
-  splitting B9/B10 into correctness-bounded 64-slot compact chunks was
-  numerically healthy but `41.5%/10.3%` slower. Direct compact execution above
-  64 slots remains correctness-invalid and must not be retried.
+- Two earlier low-width target-MoE candidates are rejected. Directly reusing
+  sorted expert IDs instead of the compact metadata copy regressed the C1
+  sandwich; splitting B9/B10 into 64-slot compact chunks was numerically
+  healthy but `41.5%/10.3%` slower. The old conclusion that every direct
+  compact execution above 64 slots was invalid was too broad: that experiment
+  coalesced repeated expert IDs even though TurboMind's forced-one-row
+  scheduler requires each routed slot to remain an independent group.
 - A C1 Nsight graph-node trace identified the bundled unquantized MTP drafter
   MoE as a separate `2.825 ms` per-cycle hotspot. An initial oracle incorrectly
   used the checkpoint-global I512 shape. The first candidate startup log proved
@@ -42433,4 +42435,42 @@ Interpretation:
   source change is therefore restricted to combined top-k plus top-p on SM70
   with Qwen3.6's exact vocabulary; setting
   `VLLM_SM70_QWEN36_TOPK_TOPP_8_WARPS=0` restores Triton's default launch.
-- The final six-point GPU0-3 curve and GSM8K/ShareGPT quality remain required.
+- Corrected slot-independent compact metadata is finite and route-correct on a
+  real TP4 layer through B20. B9 is bitwise equal to the dense route. B10 has
+  cosine at least `0.99999988`, relative L2 at most `1.0115e-4`, and maximum
+  absolute error `2.38e-7`; its isolated graph stage is `1.091x` faster. The
+  production candidate stops at B10/80 routed slots and prewarms the exact
+  B1-B10 metadata signatures before CUDA Graph capture.
+- A physical-GPU4-7 C2 candidate/control/candidate sandwich accepts B10.
+  Output was `154.608/147.135/160.890 tok/s`; candidate-mean output improves
+  `7.21%`. Pure decode was `91.962/89.762/94.566 tok/s`, a `3.90%` candidate
+  mean gain. Candidate mean acceptance length was lower than control
+  (`2.909` versus `2.963`), so acceptance does not explain the win. Extending
+  compact routing through B20 is rejected by a matching C4 sandwich: candidate
+  mean output/pure decode regressed `1.90%/2.48%`, with P50 TPOT about `1.18%`
+  worse. B11+ therefore keeps the 256-expert dense-grouped route.
+- The final B10 48-request curve on one exclusive physical-GPU4-7 claim is:
+
+  | concurrency | output tok/s | efficiency vs C1 | pure decode tok/s | serial prefill tok/s | P50 TPOT ms | mean acceptance |
+  | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+  | 1 | 97.693 | 100.00% | 114.247 | 564.795 | 8.522 | 2.890 |
+  | 2 | 150.736 | 77.15% | 90.851 | 423.341 | 10.207 | 2.946 |
+  | 4 | 246.399 | 63.05% | 71.322 | 596.885 | 13.559 | 2.884 |
+  | 8 | 350.834 | 44.89% | 52.398 | 629.601 | 20.006 | 2.969 |
+  | 12 | 444.117 | 37.88% | 46.313 | 631.019 | 22.274 | 2.909 |
+  | 16 | 530.810 | 33.96% | 44.734 | 720.400 | 23.478 | 2.900 |
+
+- Relative to the preceding final-source single-run curve, output/pure-decode
+  movement was C1 `-2.73/-3.08%`, C2 `+3.13/+2.41%`, C4
+  `-0.73/-0.18%`, C8 `-2.93/-2.99%`, C12 `+4.21/+3.93%`, and C16
+  `-4.47/-6.38%`. This alternating high-width movement is not attributable to
+  the bounded B10 route; B11+ still uses the same dense-grouped main shape and
+  only drain-tail widths can reach B9/B10. Treat B10 as a low-concurrency win,
+  not as high-concurrency recovery.
+- The next target-side candidate must compact GPU-resident active expert IDs
+  for B20/B40/B60/B80 and use a device-count guard with an exact full-group
+  fallback. It may reduce padded grouped scheduling without a host readback or
+  a probabilistic correctness assumption. A persistent tile scheduler remains
+  the larger follow-up if guarded active-group bucketing cannot beat its extra
+  CUDA Graph launch. The B10 GSM8K-128 quality gate remains pending while the
+  physical TP4 GPUs are occupied by an unrelated task.

--- a/tests/kernels/moe/test_sm70_unquantized_moe_config.py
+++ b/tests/kernels/moe/test_sm70_unquantized_moe_config.py
@@ -6,18 +6,23 @@ import pytest
 import vllm.envs as envs
 import vllm.model_executor.layers.fused_moe.fused_moe as fused_moe_module
 from vllm.model_executor.layers.fused_moe.fused_moe import (
-    _get_sm70_qwen36_mtp_moe_decode_config,
-    force_sm70_qwen36_mtp_moe_legacy_config,
+    _get_sm70_mtp_moe_decode_config,
+    force_sm70_mtp_moe_legacy_config,
 )
 
 
-def test_qwen36_mtp_sm70_decode_config_keeps_legacy_tile_at_m1():
-    assert _get_sm70_qwen36_mtp_moe_decode_config(1, 256, 128, 2048, 8) is None
+@pytest.fixture(autouse=True)
+def _enable_tuned_mtp_config(monkeypatch):
+    monkeypatch.setattr(envs, "VLLM_SM70_MTP_MOE_TUNED_CONFIG", True)
+
+
+def test_mtp_sm70_decode_config_keeps_legacy_tile_at_m1():
+    assert _get_sm70_mtp_moe_decode_config(1, 256, 128, 2048, 8) is None
 
 
 @pytest.mark.parametrize("m", range(2, 17))
-def test_qwen36_mtp_sm70_decode_config_uses_tp4_local_tile(m):
-    config = _get_sm70_qwen36_mtp_moe_decode_config(m, 256, 128, 2048, 8)
+def test_mtp_sm70_decode_config_uses_exact_local_tile(m):
+    config = _get_sm70_mtp_moe_decode_config(m, 256, 128, 2048, 8)
 
     assert config is not None
     assert config["BLOCK_SIZE_M"] == 8
@@ -35,22 +40,22 @@ def test_qwen36_mtp_sm70_decode_config_uses_tp4_local_tile(m):
         (2, 256, 128, 2048, 4),
     ],
 )
-def test_qwen36_mtp_sm70_decode_config_is_shape_bounded(shape):
-    assert _get_sm70_qwen36_mtp_moe_decode_config(*shape) is None
+def test_mtp_sm70_decode_config_is_shape_bounded(shape):
+    assert _get_sm70_mtp_moe_decode_config(*shape) is None
 
 
-def test_qwen36_mtp_sm70_decode_config_can_be_disabled(monkeypatch):
-    monkeypatch.setattr(envs, "VLLM_SM70_QWEN36_MTP_MOE_TUNED_CONFIG", False)
+def test_mtp_sm70_decode_config_can_be_disabled(monkeypatch):
+    monkeypatch.setattr(envs, "VLLM_SM70_MTP_MOE_TUNED_CONFIG", False)
 
-    assert _get_sm70_qwen36_mtp_moe_decode_config(2, 256, 128, 2048, 8) is None
+    assert _get_sm70_mtp_moe_decode_config(2, 256, 128, 2048, 8) is None
 
 
-def test_qwen36_mtp_sm70_decode_config_can_be_forced_to_legacy_for_warmup():
-    with force_sm70_qwen36_mtp_moe_legacy_config():
-        config = _get_sm70_qwen36_mtp_moe_decode_config(2, 256, 128, 2048, 8)
+def test_mtp_sm70_decode_config_can_be_forced_to_legacy_for_warmup():
+    with force_sm70_mtp_moe_legacy_config():
+        config = _get_sm70_mtp_moe_decode_config(2, 256, 128, 2048, 8)
 
     assert config is None
-    assert _get_sm70_qwen36_mtp_moe_decode_config(2, 256, 128, 2048, 8) is not None
+    assert _get_sm70_mtp_moe_decode_config(2, 256, 128, 2048, 8) is not None
 
 
 class _FakeSM70Platform:
@@ -67,7 +72,7 @@ class _FakeSM70Platform:
         return capability == 70
 
 
-def test_qwen36_mtp_sm70_decode_config_is_selected_by_default(monkeypatch):
+def test_mtp_sm70_decode_config_is_selected_when_opted_in(monkeypatch):
     monkeypatch.setattr(fused_moe_module, "current_platform", _FakeSM70Platform())
 
     config = fused_moe_module.get_default_config(2, 256, 128, 2048, 8, None)
@@ -77,9 +82,9 @@ def test_qwen36_mtp_sm70_decode_config_is_selected_by_default(monkeypatch):
     assert config["BLOCK_SIZE_K"] == 32
 
 
-def test_qwen36_mtp_sm70_decode_config_rolls_back_to_0dot3(monkeypatch):
+def test_mtp_sm70_decode_config_rolls_back_to_0dot3(monkeypatch):
     monkeypatch.setattr(fused_moe_module, "current_platform", _FakeSM70Platform())
-    monkeypatch.setattr(envs, "VLLM_SM70_QWEN36_MTP_MOE_TUNED_CONFIG", False)
+    monkeypatch.setattr(envs, "VLLM_SM70_MTP_MOE_TUNED_CONFIG", False)
 
     config = fused_moe_module.get_default_config(1, 256, 128, 2048, 8, None)
 

--- a/tests/kernels/moe/test_sm70_unquantized_moe_config.py
+++ b/tests/kernels/moe/test_sm70_unquantized_moe_config.py
@@ -1,0 +1,88 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+
+import vllm.envs as envs
+import vllm.model_executor.layers.fused_moe.fused_moe as fused_moe_module
+from vllm.model_executor.layers.fused_moe.fused_moe import (
+    _get_sm70_qwen36_mtp_moe_decode_config,
+    force_sm70_qwen36_mtp_moe_legacy_config,
+)
+
+
+def test_qwen36_mtp_sm70_decode_config_keeps_legacy_tile_at_m1():
+    assert _get_sm70_qwen36_mtp_moe_decode_config(1, 256, 128, 2048, 8) is None
+
+
+@pytest.mark.parametrize("m", range(2, 17))
+def test_qwen36_mtp_sm70_decode_config_uses_tp4_local_tile(m):
+    config = _get_sm70_qwen36_mtp_moe_decode_config(m, 256, 128, 2048, 8)
+
+    assert config is not None
+    assert config["BLOCK_SIZE_M"] == 8
+    assert config["BLOCK_SIZE_N"] == 128
+    assert config["BLOCK_SIZE_K"] == 32
+
+
+@pytest.mark.parametrize(
+    "shape",
+    [
+        (17, 256, 128, 2048, 8),
+        (2, 128, 128, 2048, 8),
+        (2, 256, 512, 2048, 8),
+        (2, 256, 128, 4096, 8),
+        (2, 256, 128, 2048, 4),
+    ],
+)
+def test_qwen36_mtp_sm70_decode_config_is_shape_bounded(shape):
+    assert _get_sm70_qwen36_mtp_moe_decode_config(*shape) is None
+
+
+def test_qwen36_mtp_sm70_decode_config_can_be_disabled(monkeypatch):
+    monkeypatch.setattr(envs, "VLLM_SM70_QWEN36_MTP_MOE_TUNED_CONFIG", False)
+
+    assert _get_sm70_qwen36_mtp_moe_decode_config(2, 256, 128, 2048, 8) is None
+
+
+def test_qwen36_mtp_sm70_decode_config_can_be_forced_to_legacy_for_warmup():
+    with force_sm70_qwen36_mtp_moe_legacy_config():
+        config = _get_sm70_qwen36_mtp_moe_decode_config(2, 256, 128, 2048, 8)
+
+    assert config is None
+    assert _get_sm70_qwen36_mtp_moe_decode_config(2, 256, 128, 2048, 8) is not None
+
+
+class _FakeSM70Platform:
+    @staticmethod
+    def is_cuda():
+        return True
+
+    @staticmethod
+    def is_rocm():
+        return False
+
+    @staticmethod
+    def has_device_capability(capability):
+        return capability == 70
+
+
+def test_qwen36_mtp_sm70_decode_config_is_selected_by_default(monkeypatch):
+    monkeypatch.setattr(fused_moe_module, "current_platform", _FakeSM70Platform())
+
+    config = fused_moe_module.get_default_config(2, 256, 128, 2048, 8, None)
+
+    assert config["BLOCK_SIZE_M"] == 8
+    assert config["BLOCK_SIZE_N"] == 128
+    assert config["BLOCK_SIZE_K"] == 32
+
+
+def test_qwen36_mtp_sm70_decode_config_rolls_back_to_0dot3(monkeypatch):
+    monkeypatch.setattr(fused_moe_module, "current_platform", _FakeSM70Platform())
+    monkeypatch.setattr(envs, "VLLM_SM70_QWEN36_MTP_MOE_TUNED_CONFIG", False)
+
+    config = fused_moe_module.get_default_config(1, 256, 128, 2048, 8, None)
+
+    assert config["BLOCK_SIZE_N"] == 32
+    assert config["BLOCK_SIZE_K"] == 64
+    assert "num_warps" not in config

--- a/tests/quantization/test_sm70_modelopt_mixed_nvfp4.py
+++ b/tests/quantization/test_sm70_modelopt_mixed_nvfp4.py
@@ -160,18 +160,19 @@ def test_nvfp4_sm70_moe_owns_routing_without_generic_modular_wrapper():
     not torch.cuda.is_available() or torch.cuda.get_device_capability() != (7, 0),
     reason="requires an exact SM70 CUDA device",
 )
-def test_nvfp4_compact_groups_keep_duplicate_expert_slots_independent():
-    sorted_expert_ids = torch.tensor(
-        [3, 3, 3, 17, 17, 42, 88, 88], dtype=torch.int32, device="cuda"
-    )
-    compact_offsets = torch.empty(9, dtype=torch.int32, device="cuda")
-    active_expert_ids = torch.empty(8, dtype=torch.int32, device="cuda")
+@pytest.mark.parametrize("total_slots", (8, 72, 80))
+def test_nvfp4_compact_groups_keep_duplicate_expert_slots_independent(total_slots):
+    sorted_expert_ids = (
+        torch.arange(total_slots, dtype=torch.int32, device="cuda") // 3
+    ) % 256
+    compact_offsets = torch.empty(total_slots + 1, dtype=torch.int32, device="cuda")
+    active_expert_ids = torch.empty(total_slots, dtype=torch.int32, device="cuda")
 
     _prepare_compact_slot_groups(sorted_expert_ids, compact_offsets, active_expert_ids)
 
     assert torch.equal(
         compact_offsets.cpu(),
-        torch.arange(9, dtype=torch.int32, device="cpu"),
+        torch.arange(total_slots + 1, dtype=torch.int32, device="cpu"),
     )
     assert torch.equal(active_expert_ids.cpu(), sorted_expert_ids.cpu())
 

--- a/tests/quantization/test_sm70_warmup.py
+++ b/tests/quantization/test_sm70_warmup.py
@@ -194,7 +194,8 @@ def test_nvfp4_moe_warmup_discovers_and_uses_compact_decode_shapes(monkeypatch):
     assert calls[2][3] == list(range(16))
 
 
-def test_nvfp4_moe_warmup_includes_supported_cuda_graph_shapes():
+def test_nvfp4_moe_warmup_includes_opted_in_cuda_graph_shapes(monkeypatch):
+    monkeypatch.setattr(warmup.envs, "VLLM_SM70_NVFP4_MOE_TUNE_MAX_TOKENS", 640)
     worker = SimpleNamespace(
         vllm_config=SimpleNamespace(
             compilation_config=SimpleNamespace(

--- a/tests/quantization/test_sm70_warmup.py
+++ b/tests/quantization/test_sm70_warmup.py
@@ -199,31 +199,6 @@ def test_nvfp4_moe_warmup_includes_supported_cuda_graph_shapes():
     ) == [1, 2, 4, 5, 8, 9, 18, 20, 40, 60, 80]
 
 
-def test_nvfp4_dense_warmup_includes_tuned_cuda_graph_shapes():
-    worker = SimpleNamespace(
-        vllm_config=SimpleNamespace(
-            compilation_config=SimpleNamespace(
-                cudagraph_capture_sizes=[1, 5, 10, 20, 40, 60, 80, 81]
-            )
-        )
-    )
-    state = SimpleNamespace(op_kind="nvfp4")
-
-    assert warmup._get_nvfp4_dense_m_values(worker, [state], [1, 2, 4, 8, 16]) == [
-        1,
-        2,
-        4,
-        5,
-        8,
-        10,
-        16,
-        20,
-        40,
-        60,
-        80,
-    ]
-
-
 def test_nvfp4_moe_warmup_uses_full_expert_groups_above_compact_b8(monkeypatch):
     layer = _nvfp4_moe_layer()
     calls = []

--- a/tests/quantization/test_sm70_warmup.py
+++ b/tests/quantization/test_sm70_warmup.py
@@ -189,14 +189,39 @@ def test_nvfp4_moe_warmup_includes_supported_cuda_graph_shapes():
     worker = SimpleNamespace(
         vllm_config=SimpleNamespace(
             compilation_config=SimpleNamespace(
-                cudagraph_capture_sizes=[1, 2, 4, 5, 8, 9, 18, 20]
+                cudagraph_capture_sizes=[1, 2, 4, 5, 8, 9, 18, 20, 40, 60, 80, 81]
             )
         )
     )
 
     assert warmup._get_nvfp4_moe_token_counts(
         worker, [_nvfp4_moe_layer()], [1, 2, 4, 8]
-    ) == [1, 2, 4, 5, 8, 9, 18]
+    ) == [1, 2, 4, 5, 8, 9, 18, 20, 40, 60, 80]
+
+
+def test_nvfp4_dense_warmup_includes_tuned_cuda_graph_shapes():
+    worker = SimpleNamespace(
+        vllm_config=SimpleNamespace(
+            compilation_config=SimpleNamespace(
+                cudagraph_capture_sizes=[1, 5, 10, 20, 40, 60, 80, 81]
+            )
+        )
+    )
+    state = SimpleNamespace(op_kind="nvfp4")
+
+    assert warmup._get_nvfp4_dense_m_values(worker, [state], [1, 2, 4, 8, 16]) == [
+        1,
+        2,
+        4,
+        5,
+        8,
+        10,
+        16,
+        20,
+        40,
+        60,
+        80,
+    ]
 
 
 def test_nvfp4_moe_warmup_uses_full_expert_groups_above_compact_b8(monkeypatch):
@@ -223,6 +248,33 @@ def test_nvfp4_moe_warmup_uses_full_expert_groups_above_compact_b8(monkeypatch):
     assert all(call[3].numel() == 256 for call in calls)
     assert calls[0][2][:73].tolist() == list(range(73))
     assert calls[0][2][73:].tolist() == [72] * (257 - 73)
+
+
+def test_nvfp4_moe_warmup_supports_mtp4_c16_width(monkeypatch):
+    layer = _nvfp4_moe_layer()
+    calls = []
+    monkeypatch.setattr(
+        torch.ops._C, "nvfp4_moe_dense_stage_sm70_out", object(), raising=False
+    )
+    monkeypatch.setattr(
+        warmup.sm70_ops,
+        "nvfp4_moe_dense_stage_sm70_out",
+        lambda *args: calls.append(args),
+    )
+    monkeypatch.setattr(
+        torch.ops._C,
+        "silu_and_mul",
+        lambda out, gate_up: out.zero_(),
+        raising=False,
+    )
+
+    assert warmup._warmup_nvfp4_moe_decode_layers([layer], [80]) == 2
+    assert [tuple(call[0].shape) for call in calls] == [(640, 256), (640, 2048)]
+    assert [call[6] for call in calls] == [256, 256]
+    offsets = calls[0][2]
+    assert offsets.numel() == 257
+    assert offsets[:4].tolist() == [0, 3, 6, 9]
+    assert offsets[-1].item() == 640
 
 
 def test_fp8_coordinated_warmup_leader_broadcasts_rank0_lut(monkeypatch):

--- a/tests/quantization/test_sm70_warmup.py
+++ b/tests/quantization/test_sm70_warmup.py
@@ -121,6 +121,7 @@ def _nvfp4_moe_layer() -> nn.Module:
     layer.sm70_nvfp4_w2_n_dim = 2048
     layer.sm70_nvfp4_group_size = 16
     layer.sm70_nvfp4_graph_safe_max_tokens = 18
+    layer.sm70_nvfp4_compact_grouped_max_tokens = 10
     layer.w13_tm_weight = nn.Parameter(
         torch.empty((1, 1), dtype=torch.uint8), requires_grad=False
     )
@@ -167,6 +168,14 @@ def test_nvfp4_moe_warmup_discovers_and_uses_compact_decode_shapes(monkeypatch):
 
     monkeypatch.setattr(warmup.sm70_ops, "nvfp4_moe_dense_stage_sm70_out", record_call)
     monkeypatch.setattr(
+        warmup,
+        "_prepare_compact_slot_groups",
+        lambda sorted_ids, offsets, active_ids: (
+            offsets.copy_(torch.arange(offsets.numel(), dtype=torch.int32)),
+            active_ids.copy_(sorted_ids),
+        ),
+    )
+    monkeypatch.setattr(
         torch.ops._C,
         "silu_and_mul",
         lambda out, gate_up: out.zero_(),
@@ -196,10 +205,44 @@ def test_nvfp4_moe_warmup_includes_supported_cuda_graph_shapes():
 
     assert warmup._get_nvfp4_moe_token_counts(
         worker, [_nvfp4_moe_layer()], [1, 2, 4, 8]
-    ) == [1, 2, 4, 5, 8, 9, 18, 20, 40, 60, 80]
+    ) == [*range(1, 11), 18, 20, 40, 60, 80]
 
 
-def test_nvfp4_moe_warmup_uses_full_expert_groups_above_compact_b8(monkeypatch):
+def test_nvfp4_moe_warmup_uses_slot_compact_through_b10(monkeypatch):
+    layer = _nvfp4_moe_layer()
+    calls = []
+    monkeypatch.setattr(
+        torch.ops._C, "nvfp4_moe_dense_stage_sm70_out", object(), raising=False
+    )
+    monkeypatch.setattr(
+        warmup.sm70_ops,
+        "nvfp4_moe_dense_stage_sm70_out",
+        lambda *args: calls.append(args),
+    )
+    monkeypatch.setattr(
+        warmup,
+        "_prepare_compact_slot_groups",
+        lambda sorted_ids, offsets, active_ids: (
+            offsets.copy_(torch.arange(offsets.numel(), dtype=torch.int32)),
+            active_ids.copy_(sorted_ids),
+        ),
+    )
+    monkeypatch.setattr(
+        torch.ops._C,
+        "silu_and_mul",
+        lambda out, gate_up: out.zero_(),
+        raising=False,
+    )
+
+    assert warmup._warmup_nvfp4_moe_decode_layers([layer], [9, 10]) == 4
+    assert [call[6] for call in calls] == [72, 72, 80, 80]
+    assert all(call[2].numel() == call[6] + 1 for call in calls)
+    assert all(call[3].numel() == call[6] for call in calls)
+    assert calls[0][2].tolist() == list(range(73))
+    assert calls[2][2].tolist() == list(range(81))
+
+
+def test_nvfp4_moe_warmup_uses_full_expert_groups_above_compact_b10(monkeypatch):
     layer = _nvfp4_moe_layer()
     calls = []
     monkeypatch.setattr(
@@ -217,12 +260,12 @@ def test_nvfp4_moe_warmup_uses_full_expert_groups_above_compact_b8(monkeypatch):
         raising=False,
     )
 
-    assert warmup._warmup_nvfp4_moe_decode_layers([layer], [9]) == 2
+    assert warmup._warmup_nvfp4_moe_decode_layers([layer], [11]) == 2
     assert [call[6] for call in calls] == [256, 256]
     assert all(call[2].numel() == 257 for call in calls)
     assert all(call[3].numel() == 256 for call in calls)
-    assert calls[0][2][:73].tolist() == list(range(73))
-    assert calls[0][2][73:].tolist() == [72] * (257 - 73)
+    assert calls[0][2][:89].tolist() == list(range(89))
+    assert calls[0][2][89:].tolist() == [88] * (257 - 89)
 
 
 def test_nvfp4_moe_warmup_supports_mtp4_c16_width(monkeypatch):

--- a/tests/test_envs.py
+++ b/tests/test_envs.py
@@ -126,13 +126,19 @@ def test_sm70_concurrency_tuning_envs(
 ) -> None:
     names = (
         "VLLM_SM70_TP4_MTP_AR_BLOCK_TUNING",
-        "VLLM_SM70_QWEN36_TOPK_TOPP_8_WARPS",
+        "VLLM_SM70_TOPK_TOPP_8_WARPS",
+        "VLLM_SM70_MTP_MOE_TUNED_CONFIG",
     )
     for name in names:
         monkeypatch.delenv(name, raising=False)
-        assert environment_variables[name]() is True
-        monkeypatch.setenv(name, "0")
         assert environment_variables[name]() is False
+        monkeypatch.setenv(name, "1")
+        assert environment_variables[name]() is True
+
+    monkeypatch.delenv("VLLM_SM70_NVFP4_MOE_TUNE_MAX_TOKENS", raising=False)
+    assert environment_variables["VLLM_SM70_NVFP4_MOE_TUNE_MAX_TOKENS"]() == 128
+    monkeypatch.setenv("VLLM_SM70_NVFP4_MOE_TUNE_MAX_TOKENS", "640")
+    assert environment_variables["VLLM_SM70_NVFP4_MOE_TUNE_MAX_TOKENS"]() == 640
 
 
 def test_flash_v100_g6_sawtooth_pipeline_envs(

--- a/tests/test_envs.py
+++ b/tests/test_envs.py
@@ -121,6 +121,20 @@ def test_precompiled_install_flags_are_orthogonal() -> None:
         assert environment_variables["VLLM_USE_PRECOMPILED_RUST"]() is False
 
 
+def test_sm70_concurrency_tuning_envs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    names = (
+        "VLLM_SM70_TP4_MTP_AR_BLOCK_TUNING",
+        "VLLM_SM70_QWEN36_TOPK_TOPP_8_WARPS",
+    )
+    for name in names:
+        monkeypatch.delenv(name, raising=False)
+        assert environment_variables[name]() is True
+        monkeypatch.setenv(name, "0")
+        assert environment_variables[name]() is False
+
+
 def test_flash_v100_g6_sawtooth_pipeline_envs(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/v1/spec_decode/test_mtp.py
+++ b/tests/v1/spec_decode/test_mtp.py
@@ -41,6 +41,11 @@ DEVICE_TYPE = current_platform.device_type
 def test_sm70_mtp_moe_warmup_sizes():
     assert _sm70_mtp_moe_warmup_sizes(256, 8, 8192) == (9, 33, 257)
     assert _sm70_mtp_moe_warmup_sizes(256, 8, 32) == (9,)
+    assert _sm70_mtp_moe_warmup_sizes(256, 8, 8192, 16) == (
+        *range(1, 17),
+        33,
+        257,
+    )
     assert _sm70_mtp_moe_warmup_sizes(0, 8, 8192) == ()
 
 
@@ -64,13 +69,20 @@ def test_sm70_mtp_moe_warmup_runs_each_shape_once():
     dummy_run = mock.Mock()
     draft_model_config = SimpleNamespace(
         is_moe=True,
-        hf_text_config=SimpleNamespace(num_experts_per_tok=8),
+        hf_text_config=SimpleNamespace(
+            num_experts_per_tok=8,
+            moe_intermediate_size=512,
+        ),
         get_num_experts=lambda: 256,
+        get_hidden_size=lambda: 4096,
     )
     proposer = SimpleNamespace(
         method="mtp",
         device=torch.device("cuda"),
         draft_model_config=draft_model_config,
+        vllm_config=SimpleNamespace(
+            parallel_config=SimpleNamespace(tensor_parallel_size=4)
+        ),
         max_num_tokens=8192,
         dummy_run=dummy_run,
         _sm70_mtp_moe_warmed=False,
@@ -86,6 +98,48 @@ def test_sm70_mtp_moe_warmup_runs_each_shape_once():
 
     assert [call.args[0] for call in dummy_run.call_args_list] == [9, 33, 257]
     assert all(call.kwargs["spec_step_idx"] == 0 for call in dummy_run.call_args_list)
+
+
+def test_sm70_qwen36_mtp_moe_warmup_covers_decode_tiles():
+    dummy_run = mock.Mock()
+    draft_model_config = SimpleNamespace(
+        is_moe=True,
+        hf_text_config=SimpleNamespace(
+            num_experts_per_tok=8,
+            moe_intermediate_size=512,
+        ),
+        get_num_experts=lambda: 256,
+        get_hidden_size=lambda: 2048,
+    )
+    proposer = SimpleNamespace(
+        method="mtp",
+        device=torch.device("cuda"),
+        draft_model_config=draft_model_config,
+        vllm_config=SimpleNamespace(
+            parallel_config=SimpleNamespace(tensor_parallel_size=4)
+        ),
+        max_num_tokens=8192,
+        dummy_run=dummy_run,
+        _sm70_mtp_moe_warmed=False,
+    )
+
+    with (
+        mock.patch.object(current_platform, "is_device_capability", return_value=True),
+        mock.patch.object(torch.accelerator, "synchronize"),
+    ):
+        assert SpecDecodeBaseProposer.warmup_sm70_mtp_moe_kernels(proposer) == (
+            "mtp_draft_moe",
+        )
+
+    assert [call.args[0] for call in dummy_run.call_args_list] == [
+        *range(1, 17),
+        33,
+        257,
+        1,
+        2,
+        9,
+        10,
+    ]
 
 
 def _create_mtp_proposer(num_speculative_tokens: int) -> EagleProposer:

--- a/tests/v1/spec_decode/test_mtp.py
+++ b/tests/v1/spec_decode/test_mtp.py
@@ -100,7 +100,7 @@ def test_sm70_mtp_moe_warmup_runs_each_shape_once():
     assert all(call.kwargs["spec_step_idx"] == 0 for call in dummy_run.call_args_list)
 
 
-def test_sm70_qwen36_mtp_moe_warmup_covers_decode_tiles():
+def test_sm70_mtp_moe_warmup_covers_opted_in_exact_tiles():
     dummy_run = mock.Mock()
     draft_model_config = SimpleNamespace(
         is_moe=True,
@@ -126,6 +126,7 @@ def test_sm70_qwen36_mtp_moe_warmup_covers_decode_tiles():
     with (
         mock.patch.object(current_platform, "is_device_capability", return_value=True),
         mock.patch.object(torch.accelerator, "synchronize"),
+        mock.patch.object(envs, "VLLM_SM70_MTP_MOE_TUNED_CONFIG", True),
     ):
         assert SpecDecodeBaseProposer.warmup_sm70_mtp_moe_kernels(proposer) == (
             "mtp_draft_moe",

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -193,12 +193,14 @@ if TYPE_CHECKING:
     VLLM_SM70_COMPACT_TOPK20_SAMPLER: bool = False
     VLLM_SM70_CHUNKED_TOPK20_CHUNKS: int = 0
     VLLM_SM70_TP_LOCAL_TOPK20_SAMPLER: bool = False
+    VLLM_SM70_QWEN36_TOPK_TOPP_8_WARPS: bool = True
     VLLM_SM70_ASYNC_SCHEDULING_QUEUE_DEPTH: int = 0
     VLLM_SM70_ASYNC_STAGED_INPUT_PREP: bool = False
     VLLM_SM70_ASYNC_CPU_TRACE: bool = False
     VLLM_SM70_ASYNC_CPU_TRACE_EVERY: int = 16
     VLLM_TP_ALLREDUCE_TRACE: bool = False
     VLLM_CUSTOM_ALLREDUCE_BLOCK_LIMIT: int | None = None
+    VLLM_SM70_TP4_MTP_AR_BLOCK_TUNING: bool = True
     VLLM_SM70_TP4_M5_AR_THREADS: int | None = None
     VLLM_SM70_TP4_SMALL_AR_PACK32: bool = False
     VLLM_SM70_F16_DENSE_ALLOWLIST: str | None = None
@@ -1816,6 +1818,11 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "VLLM_SM70_GREEDY_TOKEN_FASTPATH_TRACE": lambda: bool(
         int(os.getenv("VLLM_SM70_GREEDY_TOKEN_FASTPATH_TRACE", "0"))
     ),
+    # Use the V100-tuned launch for Qwen3.6's 248320-vocabulary combined
+    # top-k/top-p kernel. Set to 0 to preserve Triton's four-warp default.
+    "VLLM_SM70_QWEN36_TOPK_TOPP_8_WARPS": lambda: bool(
+        int(os.getenv("VLLM_SM70_QWEN36_TOPK_TOPP_8_WARPS", "1"))
+    ),
     # Diagnostic SM70 async scheduling depth override. Default 0 preserves
     # upstream behavior. Values >2 let no-PP async scheduling enqueue more real
     # decode steps before collecting CPU-visible outputs; this changes queueing
@@ -1842,6 +1849,11 @@ environment_variables: dict[str, Callable[[], Any]] = {
         int(os.environ["VLLM_CUSTOM_ALLREDUCE_BLOCK_LIMIT"])
         if "VLLM_CUSTOM_ALLREDUCE_BLOCK_LIMIT" in os.environ
         else None
+    ),
+    # Tune only the exact Qwen3.6 MTP4 verifier all-reduce payloads on
+    # fully-connected SM70 TP4. Set to 0 for the legacy 36-CTA launch policy.
+    "VLLM_SM70_TP4_MTP_AR_BLOCK_TUNING": lambda: bool(
+        int(os.getenv("VLLM_SM70_TP4_MTP_AR_BLOCK_TUNING", "1"))
     ),
     "VLLM_SM70_TP4_M5_AR_THREADS": lambda: (
         int(os.environ["VLLM_SM70_TP4_M5_AR_THREADS"])

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -178,10 +178,11 @@ if TYPE_CHECKING:
     VLLM_SM70_AWQ_DENSE_TUNE_MAX_M: int = 16
     VLLM_SM70_FP8_DENSE_TUNE_MAX_M: int = 16
     VLLM_SM70_MXFP4_DENSE_TUNE_MAX_M: int = 16
-    VLLM_SM70_NVFP4_DENSE_TUNE_MAX_M: int = 16
+    VLLM_SM70_NVFP4_DENSE_TUNE_MAX_M: int = 80
     VLLM_SM70_DSV4_FP16_GEMV: bool = False
     VLLM_SM70_DSV4_MHC_FP32_STAGE: bool = True
     VLLM_SM70_AWQ_MOE_TUNE_MAX_TOKENS: int = 128
+    VLLM_SM70_NVFP4_MOE_TUNE_MAX_TOKENS: int = 640
     VLLM_SM70_ENABLE_DENSE_F16_FASTPATH: bool = False
     VLLM_SM70_ENABLE_LM_HEAD_FASTPATH: bool = False
     VLLM_SM70_LM_HEAD_TOP1: bool = True
@@ -1754,7 +1755,7 @@ environment_variables: dict[str, Callable[[], Any]] = {
         os.getenv("VLLM_SM70_MXFP4_DENSE_TUNE_MAX_M", "16")
     ),
     "VLLM_SM70_NVFP4_DENSE_TUNE_MAX_M": lambda: int(
-        os.getenv("VLLM_SM70_NVFP4_DENSE_TUNE_MAX_M", "16")
+        os.getenv("VLLM_SM70_NVFP4_DENSE_TUNE_MAX_M", "80")
     ),
     "VLLM_SM70_DSV4_FP16_GEMV": lambda: bool(
         int(os.getenv("VLLM_SM70_DSV4_FP16_GEMV", "0"))
@@ -1764,6 +1765,9 @@ environment_variables: dict[str, Callable[[], Any]] = {
     ),
     "VLLM_SM70_AWQ_MOE_TUNE_MAX_TOKENS": lambda: int(
         os.getenv("VLLM_SM70_AWQ_MOE_TUNE_MAX_TOKENS", "128")
+    ),
+    "VLLM_SM70_NVFP4_MOE_TUNE_MAX_TOKENS": lambda: int(
+        os.getenv("VLLM_SM70_NVFP4_MOE_TUNE_MAX_TOKENS", "640")
     ),
     # Experimental unquantized FP16 SM70 TurboMind fast paths. Keep default-off:
     # these must pass the numeric policy and model-level token gate before

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -178,7 +178,7 @@ if TYPE_CHECKING:
     VLLM_SM70_AWQ_DENSE_TUNE_MAX_M: int = 16
     VLLM_SM70_FP8_DENSE_TUNE_MAX_M: int = 16
     VLLM_SM70_MXFP4_DENSE_TUNE_MAX_M: int = 16
-    VLLM_SM70_NVFP4_DENSE_TUNE_MAX_M: int = 80
+    VLLM_SM70_NVFP4_DENSE_TUNE_MAX_M: int = 16
     VLLM_SM70_DSV4_FP16_GEMV: bool = False
     VLLM_SM70_DSV4_MHC_FP32_STAGE: bool = True
     VLLM_SM70_AWQ_MOE_TUNE_MAX_TOKENS: int = 128
@@ -489,6 +489,7 @@ if TYPE_CHECKING:
     VLLM_QWEN3NEXT_ENABLE_SHARED_MOE_OVERLAP: bool = False
     VLLM_SM70_DISABLE_QWEN3NEXT_SHARED_MOE_OVERLAP: bool = False
     VLLM_SM70_UNQUANTIZED_MOE_0DOT3_CONFIG: bool = True
+    VLLM_SM70_QWEN36_MTP_MOE_TUNED_CONFIG: bool = True
     VLLM_SM70_DENSE_CUDAGRAPH_CAPTURE: bool = False
     VLLM_SM70_USE_BREAKABLE_CUDAGRAPH: bool = False
     VLLM_SM70_FLASH_V100_0DOT3_COMPILE_GRAPH: bool = False
@@ -1755,7 +1756,7 @@ environment_variables: dict[str, Callable[[], Any]] = {
         os.getenv("VLLM_SM70_MXFP4_DENSE_TUNE_MAX_M", "16")
     ),
     "VLLM_SM70_NVFP4_DENSE_TUNE_MAX_M": lambda: int(
-        os.getenv("VLLM_SM70_NVFP4_DENSE_TUNE_MAX_M", "80")
+        os.getenv("VLLM_SM70_NVFP4_DENSE_TUNE_MAX_M", "16")
     ),
     "VLLM_SM70_DSV4_FP16_GEMV": lambda: bool(
         int(os.getenv("VLLM_SM70_DSV4_FP16_GEMV", "0"))
@@ -2879,6 +2880,11 @@ environment_variables: dict[str, Callable[[], Any]] = {
     ),
     "VLLM_SM70_UNQUANTIZED_MOE_0DOT3_CONFIG": lambda: bool(
         int(os.getenv("VLLM_SM70_UNQUANTIZED_MOE_0DOT3_CONFIG", "1"))
+    ),
+    # Decode-only tiles for the bundled Qwen3.6 E256/H2048/I128-per-TP4-rank
+    # top-k8 MTP drafter. Larger token counts retain the 0.0.3 prefill config.
+    "VLLM_SM70_QWEN36_MTP_MOE_TUNED_CONFIG": lambda: bool(
+        int(os.getenv("VLLM_SM70_QWEN36_MTP_MOE_TUNED_CONFIG", "1"))
     ),
     # Legacy SM70 CUDA-graph capture-size tuning from 0.0.3. Default-off
     # because dense capture can increase startup/compile cost; when enabled on

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -182,7 +182,7 @@ if TYPE_CHECKING:
     VLLM_SM70_DSV4_FP16_GEMV: bool = False
     VLLM_SM70_DSV4_MHC_FP32_STAGE: bool = True
     VLLM_SM70_AWQ_MOE_TUNE_MAX_TOKENS: int = 128
-    VLLM_SM70_NVFP4_MOE_TUNE_MAX_TOKENS: int = 640
+    VLLM_SM70_NVFP4_MOE_TUNE_MAX_TOKENS: int = 128
     VLLM_SM70_ENABLE_DENSE_F16_FASTPATH: bool = False
     VLLM_SM70_ENABLE_LM_HEAD_FASTPATH: bool = False
     VLLM_SM70_LM_HEAD_TOP1: bool = True
@@ -193,14 +193,14 @@ if TYPE_CHECKING:
     VLLM_SM70_COMPACT_TOPK20_SAMPLER: bool = False
     VLLM_SM70_CHUNKED_TOPK20_CHUNKS: int = 0
     VLLM_SM70_TP_LOCAL_TOPK20_SAMPLER: bool = False
-    VLLM_SM70_QWEN36_TOPK_TOPP_8_WARPS: bool = True
+    VLLM_SM70_TOPK_TOPP_8_WARPS: bool = False
     VLLM_SM70_ASYNC_SCHEDULING_QUEUE_DEPTH: int = 0
     VLLM_SM70_ASYNC_STAGED_INPUT_PREP: bool = False
     VLLM_SM70_ASYNC_CPU_TRACE: bool = False
     VLLM_SM70_ASYNC_CPU_TRACE_EVERY: int = 16
     VLLM_TP_ALLREDUCE_TRACE: bool = False
     VLLM_CUSTOM_ALLREDUCE_BLOCK_LIMIT: int | None = None
-    VLLM_SM70_TP4_MTP_AR_BLOCK_TUNING: bool = True
+    VLLM_SM70_TP4_MTP_AR_BLOCK_TUNING: bool = False
     VLLM_SM70_TP4_M5_AR_THREADS: int | None = None
     VLLM_SM70_TP4_SMALL_AR_PACK32: bool = False
     VLLM_SM70_F16_DENSE_ALLOWLIST: str | None = None
@@ -491,7 +491,7 @@ if TYPE_CHECKING:
     VLLM_QWEN3NEXT_ENABLE_SHARED_MOE_OVERLAP: bool = False
     VLLM_SM70_DISABLE_QWEN3NEXT_SHARED_MOE_OVERLAP: bool = False
     VLLM_SM70_UNQUANTIZED_MOE_0DOT3_CONFIG: bool = True
-    VLLM_SM70_QWEN36_MTP_MOE_TUNED_CONFIG: bool = True
+    VLLM_SM70_MTP_MOE_TUNED_CONFIG: bool = False
     VLLM_SM70_DENSE_CUDAGRAPH_CAPTURE: bool = False
     VLLM_SM70_USE_BREAKABLE_CUDAGRAPH: bool = False
     VLLM_SM70_FLASH_V100_0DOT3_COMPILE_GRAPH: bool = False
@@ -1770,7 +1770,7 @@ environment_variables: dict[str, Callable[[], Any]] = {
         os.getenv("VLLM_SM70_AWQ_MOE_TUNE_MAX_TOKENS", "128")
     ),
     "VLLM_SM70_NVFP4_MOE_TUNE_MAX_TOKENS": lambda: int(
-        os.getenv("VLLM_SM70_NVFP4_MOE_TUNE_MAX_TOKENS", "640")
+        os.getenv("VLLM_SM70_NVFP4_MOE_TUNE_MAX_TOKENS", "128")
     ),
     # Experimental unquantized FP16 SM70 TurboMind fast paths. Keep default-off:
     # these must pass the numeric policy and model-level token gate before
@@ -1818,10 +1818,9 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "VLLM_SM70_GREEDY_TOKEN_FASTPATH_TRACE": lambda: bool(
         int(os.getenv("VLLM_SM70_GREEDY_TOKEN_FASTPATH_TRACE", "0"))
     ),
-    # Use the V100-tuned launch for Qwen3.6's 248320-vocabulary combined
-    # top-k/top-p kernel. Set to 0 to preserve Triton's four-warp default.
-    "VLLM_SM70_QWEN36_TOPK_TOPP_8_WARPS": lambda: bool(
-        int(os.getenv("VLLM_SM70_QWEN36_TOPK_TOPP_8_WARPS", "1"))
+    # Opt-in V100 launch for the exact validated combined top-k/top-p shapes.
+    "VLLM_SM70_TOPK_TOPP_8_WARPS": lambda: bool(
+        int(os.getenv("VLLM_SM70_TOPK_TOPP_8_WARPS", "0"))
     ),
     # Diagnostic SM70 async scheduling depth override. Default 0 preserves
     # upstream behavior. Values >2 let no-PP async scheduling enqueue more real
@@ -1850,10 +1849,9 @@ environment_variables: dict[str, Callable[[], Any]] = {
         if "VLLM_CUSTOM_ALLREDUCE_BLOCK_LIMIT" in os.environ
         else None
     ),
-    # Tune only the exact Qwen3.6 MTP4 verifier all-reduce payloads on
-    # fully-connected SM70 TP4. Set to 0 for the legacy 36-CTA launch policy.
+    # Opt in exact MTP4 verifier payloads on fully-connected SM70 TP4.
     "VLLM_SM70_TP4_MTP_AR_BLOCK_TUNING": lambda: bool(
-        int(os.getenv("VLLM_SM70_TP4_MTP_AR_BLOCK_TUNING", "1"))
+        int(os.getenv("VLLM_SM70_TP4_MTP_AR_BLOCK_TUNING", "0"))
     ),
     "VLLM_SM70_TP4_M5_AR_THREADS": lambda: (
         int(os.environ["VLLM_SM70_TP4_M5_AR_THREADS"])
@@ -2893,10 +2891,10 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "VLLM_SM70_UNQUANTIZED_MOE_0DOT3_CONFIG": lambda: bool(
         int(os.getenv("VLLM_SM70_UNQUANTIZED_MOE_0DOT3_CONFIG", "1"))
     ),
-    # Decode-only tiles for the bundled Qwen3.6 E256/H2048/I128-per-TP4-rank
-    # top-k8 MTP drafter. Larger token counts retain the 0.0.3 prefill config.
-    "VLLM_SM70_QWEN36_MTP_MOE_TUNED_CONFIG": lambda: bool(
-        int(os.getenv("VLLM_SM70_QWEN36_MTP_MOE_TUNED_CONFIG", "1"))
+    # Opt-in decode tiles for the exact E256/N128/K2048/top-k8 SM70 contract.
+    # Larger or unmatched token shapes retain the 0.0.3 config.
+    "VLLM_SM70_MTP_MOE_TUNED_CONFIG": lambda: bool(
+        int(os.getenv("VLLM_SM70_MTP_MOE_TUNED_CONFIG", "0"))
     ),
     # Legacy SM70 CUDA-graph capture-size tuning from 0.0.3. Default-off
     # because dense capture can increase startup/compile cost; when enabled on

--- a/vllm/model_executor/layers/fused_moe/fused_moe.py
+++ b/vllm/model_executor/layers/fused_moe/fused_moe.py
@@ -5,6 +5,8 @@
 import functools
 import json
 import os
+from collections.abc import Iterator
+from contextlib import contextmanager
 from typing import Any
 
 import torch
@@ -33,6 +35,20 @@ from vllm.triton_utils import tl, triton
 from vllm.utils.torch_utils import direct_register_custom_op
 
 logger = init_logger(__name__)
+
+_force_sm70_qwen36_mtp_moe_legacy_config = False
+
+
+@contextmanager
+def force_sm70_qwen36_mtp_moe_legacy_config() -> Iterator[None]:
+    """Temporarily select the legacy SM70 MoE tile during startup warmup."""
+    global _force_sm70_qwen36_mtp_moe_legacy_config
+    previous = _force_sm70_qwen36_mtp_moe_legacy_config
+    _force_sm70_qwen36_mtp_moe_legacy_config = True
+    try:
+        yield
+    finally:
+        _force_sm70_qwen36_mtp_moe_legacy_config = previous
 
 
 @triton.jit
@@ -1200,6 +1216,35 @@ def should_moe_wna16_use_cuda(
     )
 
 
+def _get_sm70_qwen36_mtp_moe_decode_config(
+    M: int,
+    E: int,
+    N: int,
+    K: int,
+    topk: int,
+) -> dict[str, int] | None:
+    """Return the graph-tuned Qwen3.6 MTP drafter tile for M2-M16."""
+    if (
+        _force_sm70_qwen36_mtp_moe_legacy_config
+        or not envs.VLLM_SM70_QWEN36_MTP_MOE_TUNED_CONFIG
+    ):
+        return None
+    if (E, N, K, topk) != (256, 128, 2048, 8) or not 2 <= M <= 16:
+        return None
+
+    # TP4 shards the checkpoint-global I512 expert width to I128 per rank.
+    # M2-M16 all select this tile in the exact local-shape graph oracle.
+    return {
+        "BLOCK_SIZE_M": 8,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 32,
+        "GROUP_SIZE_M": 1,
+        "SPLIT_K": 1,
+        "num_warps": 4,
+        "num_stages": 3,
+    }
+
+
 def get_default_config(
     M: int,
     E: int,
@@ -1262,7 +1307,13 @@ def get_default_config(
         # upstream's larger small-batch tiles are poor for single-token SM70
         # decode, which is the FP8-MoE-dequant fallback route used by the
         # old 35B-FP8 baseline.
-        if M <= E:
+        qwen36_mtp_config = _get_sm70_qwen36_mtp_moe_decode_config(M, E, N, K, topk)
+        if qwen36_mtp_config is not None:
+            config = qwen36_mtp_config
+            logger.info_once(
+                f"Using SM70 Qwen3.6 MTP unquantized MoE tuned decode config: {config}"
+            )
+        elif M <= E:
             config = {
                 "BLOCK_SIZE_M": 16,
                 "BLOCK_SIZE_N": 32,
@@ -1278,9 +1329,7 @@ def get_default_config(
                 "GROUP_SIZE_M": 8,
                 "SPLIT_K": 1,
             }
-        logger.info_once(
-            f"Using SM70 0.0.3 unquantized MoE default config: {config}"
-        )
+        logger.info_once(f"Using SM70 0.0.3 unquantized MoE default config: {config}")
     else:
         # General defaults for bf16/fp16 and fp8 per-tensor.
         # Tile sizes scale with batch: small batches are memory-bound

--- a/vllm/model_executor/layers/fused_moe/fused_moe.py
+++ b/vllm/model_executor/layers/fused_moe/fused_moe.py
@@ -36,19 +36,19 @@ from vllm.utils.torch_utils import direct_register_custom_op
 
 logger = init_logger(__name__)
 
-_force_sm70_qwen36_mtp_moe_legacy_config = False
+_force_sm70_mtp_moe_legacy_config = False
 
 
 @contextmanager
-def force_sm70_qwen36_mtp_moe_legacy_config() -> Iterator[None]:
+def force_sm70_mtp_moe_legacy_config() -> Iterator[None]:
     """Temporarily select the legacy SM70 MoE tile during startup warmup."""
-    global _force_sm70_qwen36_mtp_moe_legacy_config
-    previous = _force_sm70_qwen36_mtp_moe_legacy_config
-    _force_sm70_qwen36_mtp_moe_legacy_config = True
+    global _force_sm70_mtp_moe_legacy_config
+    previous = _force_sm70_mtp_moe_legacy_config
+    _force_sm70_mtp_moe_legacy_config = True
     try:
         yield
     finally:
-        _force_sm70_qwen36_mtp_moe_legacy_config = previous
+        _force_sm70_mtp_moe_legacy_config = previous
 
 
 @triton.jit
@@ -1216,18 +1216,15 @@ def should_moe_wna16_use_cuda(
     )
 
 
-def _get_sm70_qwen36_mtp_moe_decode_config(
+def _get_sm70_mtp_moe_decode_config(
     M: int,
     E: int,
     N: int,
     K: int,
     topk: int,
 ) -> dict[str, int] | None:
-    """Return the graph-tuned Qwen3.6 MTP drafter tile for M2-M16."""
-    if (
-        _force_sm70_qwen36_mtp_moe_legacy_config
-        or not envs.VLLM_SM70_QWEN36_MTP_MOE_TUNED_CONFIG
-    ):
+    """Return the graph-tuned exact-shape SM70 MTP tile for M2-M16."""
+    if _force_sm70_mtp_moe_legacy_config or not envs.VLLM_SM70_MTP_MOE_TUNED_CONFIG:
         return None
     if (E, N, K, topk) != (256, 128, 2048, 8) or not 2 <= M <= 16:
         return None
@@ -1307,12 +1304,10 @@ def get_default_config(
         # upstream's larger small-batch tiles are poor for single-token SM70
         # decode, which is the FP8-MoE-dequant fallback route used by the
         # old 35B-FP8 baseline.
-        qwen36_mtp_config = _get_sm70_qwen36_mtp_moe_decode_config(M, E, N, K, topk)
-        if qwen36_mtp_config is not None:
-            config = qwen36_mtp_config
-            logger.info_once(
-                f"Using SM70 Qwen3.6 MTP unquantized MoE tuned decode config: {config}"
-            )
+        sm70_mtp_config = _get_sm70_mtp_moe_decode_config(M, E, N, K, topk)
+        if sm70_mtp_config is not None:
+            config = sm70_mtp_config
+            logger.info_once(f"Using tuned exact-shape SM70 MTP MoE config: {config}")
         elif M <= E:
             config = {
                 "BLOCK_SIZE_M": 16,

--- a/vllm/model_executor/layers/quantization/nvfp4_sm70_moe.py
+++ b/vllm/model_executor/layers/quantization/nvfp4_sm70_moe.py
@@ -99,7 +99,7 @@ def _prepare_compact_slot_groups(
 
 
 def validate_nvfp4_sm70_moe_contract(moe: FusedMoEConfig) -> None:
-    """Reject every model or topology outside the Qwen3.6 SM70 contract."""
+    """Reject every topology outside the validated SM70 NVFP4 contract."""
     if moe.num_experts != _QWEN36_NUM_EXPERTS:
         raise NotImplementedError(
             "SM70 TurboMind NVFP4 MoE currently supports Qwen3.6-35B-A3B "

--- a/vllm/model_executor/layers/quantization/nvfp4_sm70_moe.py
+++ b/vllm/model_executor/layers/quantization/nvfp4_sm70_moe.py
@@ -44,7 +44,7 @@ _QWEN36_NUM_EXPERTS: Final = 256
 _QWEN36_TOP_K: Final = 8
 _QWEN36_SUPPORTED_TP_SIZES: Final = (1, 2, 4)
 _GRAPH_SAFE_MAX_TOKENS: Final = 18
-_COMPACT_GROUPED_MAX_TOKENS: Final = 8
+_COMPACT_GROUPED_MAX_TOKENS: Final = 10
 
 
 @triton.jit
@@ -322,6 +322,7 @@ class ModelOptNvFp4SM70MoEMethod(ModelOptNvFp4FusedMoE):
         layer.sm70_nvfp4_w2_n_dim = hidden
         layer.sm70_nvfp4_group_size = NVFP4_GROUP_SIZE
         layer.sm70_nvfp4_graph_safe_max_tokens = _GRAPH_SAFE_MAX_TOKENS
+        layer.sm70_nvfp4_compact_grouped_max_tokens = _COMPACT_GROUPED_MAX_TOKENS
         self._allocate_graph_safe_decode_buffers(layer)
 
         del layer.w13_weight

--- a/vllm/model_executor/warmup/awq_sm70_warmup.py
+++ b/vllm/model_executor/warmup/awq_sm70_warmup.py
@@ -818,25 +818,6 @@ def _get_nvfp4_moe_token_counts(
     )
 
 
-def _get_nvfp4_dense_m_values(
-    worker: Worker,
-    fp4_dense_layers: list[Any],
-    base_m_values: list[int],
-) -> list[int]:
-    """Include captured dense NVFP4 widths accepted by its tuner."""
-    if not any(state.op_kind == "nvfp4" for state in fp4_dense_layers):
-        return base_m_values
-    max_m = max(0, int(envs.VLLM_SM70_NVFP4_DENSE_TUNE_MAX_M))
-    compilation_config = getattr(
-        getattr(worker, "vllm_config", None), "compilation_config", None
-    )
-    capture_sizes = getattr(compilation_config, "cudagraph_capture_sizes", None) or []
-    return sorted(
-        set(base_m_values)
-        | {int(size) for size in capture_sizes if 0 < int(size) <= max_m}
-    )
-
-
 def _warmup_moe_single_token_layers(moe_layers: list[torch.nn.Module]) -> int:
     if not (
         hasattr(torch.ops._C, "awq_moe_single_token_dense_w13_sm70_out")
@@ -1022,14 +1003,13 @@ def sm70_awq_warmup(worker: Worker) -> None:
     nvfp4_moe_token_counts = _get_nvfp4_moe_token_counts(
         worker, nvfp4_moe_layers, moe_token_counts
     )
-    nvfp4_dense_m_values = _get_nvfp4_dense_m_values(worker, fp4_dense_layers, m_values)
     lut_path = _resolve_lut_path(device)
 
     logger.info(
         "Warming up SM70 TurboMind accepted routes (%d AWQ dense layer "
         "shapes, %d FP8 dense layer shapes, %d FP4 dense layer shapes, "
         "%d MoE layer shapes, %d MXFP4 MoE B1 layer shapes, "
-        "%d NVFP4 MoE layer shapes, dense_m=%s, nvfp4_dense_m=%s, "
+        "%d NVFP4 MoE layer shapes, dense_m=%s, "
         "moe_tokens=%s, nvfp4_moe_tokens=%s, lut_path=%s).",
         len(dense_layers),
         len(fp8_dense_layers),
@@ -1038,7 +1018,6 @@ def sm70_awq_warmup(worker: Worker) -> None:
         len(mxfp4_moe_layers),
         len(nvfp4_moe_layers),
         m_values,
-        nvfp4_dense_m_values,
         moe_token_counts,
         nvfp4_moe_token_counts,
         lut_path,
@@ -1050,13 +1029,7 @@ def sm70_awq_warmup(worker: Worker) -> None:
             m_values,
             device,
         )
-        fp4_dense_calls = _warmup_fp4_dense_layers(
-            [state for state in fp4_dense_layers if state.op_kind == "mxfp4"],
-            m_values,
-        ) + _warmup_fp4_dense_layers(
-            [state for state in fp4_dense_layers if state.op_kind == "nvfp4"],
-            nvfp4_dense_m_values,
-        )
+        fp4_dense_calls = _warmup_fp4_dense_layers(fp4_dense_layers, m_values)
         moe_stage_calls = _warmup_moe_dense_stage_layers(moe_layers, moe_token_counts)
         single_token_calls = _warmup_moe_single_token_layers(moe_layers)
         mxfp4_moe_stage_calls = _warmup_mxfp4_moe_b1_layers(mxfp4_moe_layers)

--- a/vllm/model_executor/warmup/awq_sm70_warmup.py
+++ b/vllm/model_executor/warmup/awq_sm70_warmup.py
@@ -721,8 +721,6 @@ def _warmup_nvfp4_moe_decode_layers(
         max_experts = int(layer.sm70_nvfp4_num_experts)
         for num_tokens in token_counts:
             total_slots = num_tokens * top_k
-            if total_slots > max_experts:
-                continue
             if num_tokens <= 8:
                 stage_experts = total_slots
                 expert_offsets = torch.arange(
@@ -731,14 +729,8 @@ def _warmup_nvfp4_moe_decode_layers(
                 active_expert_ids = layer._nvfp4_sm70_dense_expert_ids[:total_slots]
             else:
                 stage_experts = max_experts
-                expert_offsets = torch.full(
-                    (max_experts + 1,),
-                    total_slots,
-                    dtype=torch.int32,
-                    device=device,
-                )
-                expert_offsets[: total_slots + 1] = torch.arange(
-                    total_slots + 1, dtype=torch.int32, device=device
+                expert_offsets = _build_balanced_offsets(
+                    total_slots, max_experts, device
                 )
                 active_expert_ids = layer._nvfp4_sm70_dense_expert_ids
             permuted_input = torch.empty(
@@ -804,13 +796,18 @@ def _get_nvfp4_moe_token_counts(
     moe_layers: list[torch.nn.Module],
     base_token_counts: list[int],
 ) -> list[int]:
-    """Include every NVFP4 CUDA-graph shape covered by persistent buffers."""
+    """Include graph-safe and tuned NVFP4 CUDA-graph token widths."""
     if not moe_layers:
         return base_token_counts
-    max_tokens = max(
+    graph_safe_max_tokens = max(
         int(getattr(layer, "sm70_nvfp4_graph_safe_max_tokens", 8))
         for layer in moe_layers
     )
+    max_top_k = max(int(layer.moe_config.experts_per_token) for layer in moe_layers)
+    tuned_max_tokens = max(0, int(envs.VLLM_SM70_NVFP4_MOE_TUNE_MAX_TOKENS)) // max(
+        max_top_k, 1
+    )
+    max_tokens = max(graph_safe_max_tokens, tuned_max_tokens)
     compilation_config = getattr(
         getattr(worker, "vllm_config", None), "compilation_config", None
     )
@@ -818,6 +815,25 @@ def _get_nvfp4_moe_token_counts(
     return sorted(
         set(base_token_counts)
         | {int(size) for size in capture_sizes if 0 < int(size) <= max_tokens}
+    )
+
+
+def _get_nvfp4_dense_m_values(
+    worker: Worker,
+    fp4_dense_layers: list[Any],
+    base_m_values: list[int],
+) -> list[int]:
+    """Include captured dense NVFP4 widths accepted by its tuner."""
+    if not any(state.op_kind == "nvfp4" for state in fp4_dense_layers):
+        return base_m_values
+    max_m = max(0, int(envs.VLLM_SM70_NVFP4_DENSE_TUNE_MAX_M))
+    compilation_config = getattr(
+        getattr(worker, "vllm_config", None), "compilation_config", None
+    )
+    capture_sizes = getattr(compilation_config, "cudagraph_capture_sizes", None) or []
+    return sorted(
+        set(base_m_values)
+        | {int(size) for size in capture_sizes if 0 < int(size) <= max_m}
     )
 
 
@@ -1006,13 +1022,14 @@ def sm70_awq_warmup(worker: Worker) -> None:
     nvfp4_moe_token_counts = _get_nvfp4_moe_token_counts(
         worker, nvfp4_moe_layers, moe_token_counts
     )
+    nvfp4_dense_m_values = _get_nvfp4_dense_m_values(worker, fp4_dense_layers, m_values)
     lut_path = _resolve_lut_path(device)
 
     logger.info(
         "Warming up SM70 TurboMind accepted routes (%d AWQ dense layer "
         "shapes, %d FP8 dense layer shapes, %d FP4 dense layer shapes, "
         "%d MoE layer shapes, %d MXFP4 MoE B1 layer shapes, "
-        "%d NVFP4 MoE layer shapes, dense_m=%s, "
+        "%d NVFP4 MoE layer shapes, dense_m=%s, nvfp4_dense_m=%s, "
         "moe_tokens=%s, nvfp4_moe_tokens=%s, lut_path=%s).",
         len(dense_layers),
         len(fp8_dense_layers),
@@ -1021,6 +1038,7 @@ def sm70_awq_warmup(worker: Worker) -> None:
         len(mxfp4_moe_layers),
         len(nvfp4_moe_layers),
         m_values,
+        nvfp4_dense_m_values,
         moe_token_counts,
         nvfp4_moe_token_counts,
         lut_path,
@@ -1032,7 +1050,13 @@ def sm70_awq_warmup(worker: Worker) -> None:
             m_values,
             device,
         )
-        fp4_dense_calls = _warmup_fp4_dense_layers(fp4_dense_layers, m_values)
+        fp4_dense_calls = _warmup_fp4_dense_layers(
+            [state for state in fp4_dense_layers if state.op_kind == "mxfp4"],
+            m_values,
+        ) + _warmup_fp4_dense_layers(
+            [state for state in fp4_dense_layers if state.op_kind == "nvfp4"],
+            nvfp4_dense_m_values,
+        )
         moe_stage_calls = _warmup_moe_dense_stage_layers(moe_layers, moe_token_counts)
         single_token_calls = _warmup_moe_single_token_layers(moe_layers)
         mxfp4_moe_stage_calls = _warmup_mxfp4_moe_b1_layers(mxfp4_moe_layers)

--- a/vllm/model_executor/warmup/awq_sm70_warmup.py
+++ b/vllm/model_executor/warmup/awq_sm70_warmup.py
@@ -15,6 +15,9 @@ import vllm.envs as envs
 from vllm import _sm70_ops as sm70_ops
 from vllm.logger import init_logger
 from vllm.model_executor.layers.quantization import sm70_turbomind as sm70_tm
+from vllm.model_executor.layers.quantization.nvfp4_sm70_moe import (
+    _prepare_compact_slot_groups,
+)
 
 if TYPE_CHECKING:
     from vllm.v1.worker.gpu_worker import Worker
@@ -710,7 +713,7 @@ def _warmup_mxfp4_moe_b1_layers(moe_layers: list[torch.nn.Module]) -> int:
 def _warmup_nvfp4_moe_decode_layers(
     moe_layers: list[torch.nn.Module], token_counts: list[int]
 ) -> int:
-    """Tune compact B1-B8 and full-group B9+ NVFP4 graph shapes."""
+    """Tune compact and full-group NVFP4 graph shapes."""
     if not hasattr(torch.ops._C, "nvfp4_moe_dense_stage_sm70_out"):
         return 0
 
@@ -719,14 +722,25 @@ def _warmup_nvfp4_moe_decode_layers(
         device = layer.w13_tm_weight.device
         top_k = int(layer.moe_config.experts_per_token)
         max_experts = int(layer.sm70_nvfp4_num_experts)
+        compact_max_tokens = int(
+            getattr(layer, "sm70_nvfp4_compact_grouped_max_tokens", 8)
+        )
         for num_tokens in token_counts:
             total_slots = num_tokens * top_k
-            if num_tokens <= 8:
+            if num_tokens <= compact_max_tokens:
                 stage_experts = total_slots
-                expert_offsets = torch.arange(
+                sorted_expert_ids = layer._nvfp4_sm70_dense_expert_ids[:total_slots]
+                expert_offsets = torch.empty(
                     total_slots + 1, dtype=torch.int32, device=device
                 )
-                active_expert_ids = layer._nvfp4_sm70_dense_expert_ids[:total_slots]
+                active_expert_ids = torch.empty(
+                    total_slots, dtype=torch.int32, device=device
+                )
+                _prepare_compact_slot_groups(
+                    sorted_expert_ids,
+                    expert_offsets,
+                    active_expert_ids,
+                )
             else:
                 stage_experts = max_experts
                 expert_offsets = _build_balanced_offsets(
@@ -803,6 +817,10 @@ def _get_nvfp4_moe_token_counts(
         int(getattr(layer, "sm70_nvfp4_graph_safe_max_tokens", 8))
         for layer in moe_layers
     )
+    compact_max_tokens = max(
+        int(getattr(layer, "sm70_nvfp4_compact_grouped_max_tokens", 8))
+        for layer in moe_layers
+    )
     max_top_k = max(int(layer.moe_config.experts_per_token) for layer in moe_layers)
     tuned_max_tokens = max(0, int(envs.VLLM_SM70_NVFP4_MOE_TUNE_MAX_TOKENS)) // max(
         max_top_k, 1
@@ -814,6 +832,7 @@ def _get_nvfp4_moe_token_counts(
     capture_sizes = getattr(compilation_config, "cudagraph_capture_sizes", None) or []
     return sorted(
         set(base_token_counts)
+        | set(range(1, compact_max_tokens + 1))
         | {int(size) for size in capture_sizes if 0 < int(size) <= max_tokens}
     )
 

--- a/vllm/v1/sample/ops/topk_topp_triton.py
+++ b/vllm/v1/sample/ops/topk_topp_triton.py
@@ -1048,17 +1048,18 @@ def apply_top_k_top_p_triton(
 
     launch_kwargs: dict[str, int] = {}
     if (
-        envs.VLLM_SM70_QWEN36_TOPK_TOPP_8_WARPS
+        envs.VLLM_SM70_TOPK_TOPP_8_WARPS
         and logits.device.type == "cuda"
         and current_platform.is_cuda()
         and current_platform.is_device_capability((7, 0))
+        and logits.shape[0] in (5, 10, 20, 40, 60, 80)
         and vocab_size == 248_320
         and topk_enabled
         and topp_enabled
     ):
-        # Qwen3.6 MTP4 presents five verifier rows per live request. On V100,
-        # eight warps preserve this kernel's tile and masking algorithm while
-        # using the otherwise idle lanes in its reduction-heavy passes.
+        # The measured MTP4 contract has five verifier rows per live request.
+        # Eight warps preserve the tile and masking algorithm while using the
+        # otherwise idle lanes in its reduction-heavy passes.
         launch_kwargs["num_warps"] = 8
 
     _topk_topp_kernel[(NUM_PROGRAMS,)](

--- a/vllm/v1/sample/ops/topk_topp_triton.py
+++ b/vllm/v1/sample/ops/topk_topp_triton.py
@@ -11,6 +11,8 @@ using Pivot-based Truncation and Selection" By Park et al.
 
 import torch
 
+from vllm import envs
+from vllm.platforms import current_platform
 from vllm.triton_utils import tl, triton
 from vllm.utils.math_utils import next_power_of_2
 from vllm.utils.platform_utils import num_compute_units
@@ -1044,6 +1046,21 @@ def apply_top_k_top_p_triton(
     else:
         block_size, block_size_trunc = 8192, 4096
 
+    launch_kwargs: dict[str, int] = {}
+    if (
+        envs.VLLM_SM70_QWEN36_TOPK_TOPP_8_WARPS
+        and logits.device.type == "cuda"
+        and current_platform.is_cuda()
+        and current_platform.is_device_capability((7, 0))
+        and vocab_size == 248_320
+        and topk_enabled
+        and topp_enabled
+    ):
+        # Qwen3.6 MTP4 presents five verifier rows per live request. On V100,
+        # eight warps preserve this kernel's tile and masking algorithm while
+        # using the otherwise idle lanes in its reduction-heavy passes.
+        launch_kwargs["num_warps"] = 8
+
     _topk_topp_kernel[(NUM_PROGRAMS,)](
         logits,
         logits.stride(0),
@@ -1059,6 +1076,7 @@ def apply_top_k_top_p_triton(
         BLOCK_SIZE_TRUNC=block_size_trunc,
         TOPK_ENABLED=topk_enabled,
         TOPP_ENABLED=topp_enabled,
+        **launch_kwargs,
     )
 
     return logits

--- a/vllm/v1/spec_decode/llm_base_proposer.py
+++ b/vllm/v1/spec_decode/llm_base_proposer.py
@@ -88,7 +88,10 @@ def _sm70_mtp_profile_interval() -> int:
 
 
 def _sm70_mtp_moe_warmup_sizes(
-    num_experts: int, top_k: int, max_num_tokens: int
+    num_experts: int,
+    top_k: int,
+    max_num_tokens: int,
+    decode_tile_max_tokens: int = 0,
 ) -> tuple[int, ...]:
     """Pick one token count for each SM70 Triton MoE dispatch region."""
     if num_experts <= 0 or top_k <= 0 or max_num_tokens <= 0:
@@ -111,6 +114,7 @@ def _sm70_mtp_moe_warmup_sizes(
         # First shape using the large-M SM70 0.0.3 MoE tile.
         prefer_unaligned(num_experts + 1),
     }
+    sizes.update(range(1, min(decode_tile_max_tokens, max_num_tokens) + 1))
     return tuple(sorted(size for size in sizes if size <= max_num_tokens))
 
 
@@ -1045,11 +1049,23 @@ class SpecDecodeBaseProposer:
 
         text_config = self.draft_model_config.hf_text_config
         top_k = int(getattr(text_config, "num_experts_per_tok", 0))
+        num_experts = self.draft_model_config.get_num_experts()
+        tp_size = self.vllm_config.parallel_config.tensor_parallel_size
+        use_qwen36_decode_tiles = (
+            envs.VLLM_SM70_QWEN36_MTP_MOE_TUNED_CONFIG
+            and num_experts == 256
+            and top_k == 8
+            and self.draft_model_config.get_hidden_size() == 2048
+            and int(getattr(text_config, "moe_intermediate_size", 0)) == 512
+            and tp_size == 4
+        )
         sizes = _sm70_mtp_moe_warmup_sizes(
-            self.draft_model_config.get_num_experts(),
+            num_experts,
             top_k,
             self.max_num_tokens,
+            decode_tile_max_tokens=16 if use_qwen36_decode_tiles else 0,
         )
+        legacy_sizes = (1, 2, 9, 10) if use_qwen36_decode_tiles else ()
         if not sizes:
             return ()
 
@@ -1060,12 +1076,34 @@ class SpecDecodeBaseProposer:
                     use_cudagraphs=False,
                     spec_step_idx=0,
                 )
+            if legacy_sizes:
+                # The tuned drafter tile replaces legacy graph
+                # specializations that used to be compiled incidentally.
+                # Other unquantized MoE calls can reuse those legacy Triton
+                # signatures during serving. Cover both token divisibility
+                # cases for the naive (M1/M2) and aligned (M9/M10) assignment
+                # paths instead of allowing a first-request JIT spike.
+                from vllm.model_executor.layers.fused_moe.fused_moe import (
+                    force_sm70_qwen36_mtp_moe_legacy_config,
+                )
+
+                with force_sm70_qwen36_mtp_moe_legacy_config():
+                    for num_tokens in legacy_sizes:
+                        self.dummy_run(
+                            num_tokens,
+                            use_cudagraphs=False,
+                            spec_step_idx=0,
+                        )
             torch.accelerator.synchronize()
         except Exception as err:  # pragma: no cover - best-effort warmup
             logger.warning_once("SM70 MTP MoE warmup skipped: %s", err)
             return ()
 
-        logger.info_once("SM70 MTP MoE warmup finished: token_counts=%s", sizes)
+        logger.info_once(
+            "SM70 MTP MoE warmup finished: token_counts=%s, legacy_token_counts=%s",
+            sizes,
+            legacy_sizes,
+        )
         return ("mtp_draft_moe",)
 
     def take_last_draft_probs(self) -> torch.Tensor | None:

--- a/vllm/v1/spec_decode/llm_base_proposer.py
+++ b/vllm/v1/spec_decode/llm_base_proposer.py
@@ -1051,8 +1051,8 @@ class SpecDecodeBaseProposer:
         top_k = int(getattr(text_config, "num_experts_per_tok", 0))
         num_experts = self.draft_model_config.get_num_experts()
         tp_size = self.vllm_config.parallel_config.tensor_parallel_size
-        use_qwen36_decode_tiles = (
-            envs.VLLM_SM70_QWEN36_MTP_MOE_TUNED_CONFIG
+        use_mtp_decode_tiles = (
+            envs.VLLM_SM70_MTP_MOE_TUNED_CONFIG
             and num_experts == 256
             and top_k == 8
             and self.draft_model_config.get_hidden_size() == 2048
@@ -1063,9 +1063,9 @@ class SpecDecodeBaseProposer:
             num_experts,
             top_k,
             self.max_num_tokens,
-            decode_tile_max_tokens=16 if use_qwen36_decode_tiles else 0,
+            decode_tile_max_tokens=16 if use_mtp_decode_tiles else 0,
         )
-        legacy_sizes = (1, 2, 9, 10) if use_qwen36_decode_tiles else ()
+        legacy_sizes = (1, 2, 9, 10) if use_mtp_decode_tiles else ()
         if not sizes:
             return ()
 
@@ -1084,10 +1084,10 @@ class SpecDecodeBaseProposer:
                 # cases for the naive (M1/M2) and aligned (M9/M10) assignment
                 # paths instead of allowing a first-request JIT spike.
                 from vllm.model_executor.layers.fused_moe.fused_moe import (
-                    force_sm70_qwen36_mtp_moe_legacy_config,
+                    force_sm70_mtp_moe_legacy_config,
                 )
 
-                with force_sm70_qwen36_mtp_moe_legacy_config():
+                with force_sm70_mtp_moe_legacy_config():
                     for num_tokens in legacy_sizes:
                         self.dummy_run(
                             num_tokens,


### PR DESCRIPTION
## Purpose

Preserve the validated SM70 NVFP4 B10 compact-routing improvement and make the broader MTP concurrency tuning available as explicit, operator-level opt-ins while matched formal-curve and combined quality evidence remain incomplete.

## What changed

- Extend slot-independent compact NVFP4 routing through B10/top-k8 (80 routed slots). B11+ keeps the 256-expert dense-grouped route.
- Add bounded high-width NVFP4 MoE tactic warmup, exact-shape unquantized MTP MoE tiles, exact TP4 verifier all-reduce block policies, and an eight-warp combined top-k/top-p launch.
- Admit each optimization through hardware/operator contracts (SM70, TP topology, exact tensor shapes/payload bytes, vocabulary size, row counts, top-k/top-p mode). No model name, architecture, or checkpoint identity is consulted.
- Keep the broader changes opt-in:
  - `VLLM_SM70_NVFP4_MOE_TUNE_MAX_TOKENS=640` (default remains 128)
  - `VLLM_SM70_MTP_MOE_TUNED_CONFIG=1`
  - `VLLM_SM70_TP4_MTP_AR_BLOCK_TUNING=1`
  - `VLLM_SM70_TOPK_TOPP_8_WARPS=1`
- Restrict the eight-warp sampler to the measured rows 5/10/20/40/60/80 and vocabulary 248,320.
- Preserve the benchmark's repeat-count safety checks while allowing multi-prompt profiler capture.

## Evidence

Existing PR evidence includes exact-shape numerical microbenchmarks, fresh-cache C1/C2/C4/C8/C12/C16 curves, CUDA Graph attribution, and matched sandwiches for individual candidates. The B10 route has matched C2 speed evidence and a pinned GSM8K-128 result of 122/128 with zero invalid/repetitive records.

The combined broad policy still lacks the requested matched GPU0-3 formal curve and joint GSM8K/ShareGPT gate, so it is not a production default.

## Test plan and result

- SM70 MoE/warmup/env/MTP contract tests: **44 passed**.
- Mixed ModelOpt NVFP4 source tests: **11 passed, 3 GPU tests skipped** because all V100s were occupied by unrelated active TP jobs during audit.
- Full changed-file pre-commit suite: **passed**, including Ruff, clang-format, mypy, SPDX, forbidden imports/APIs, and env-default validation.
- `git diff --check`: passed.
- No additional full-model end-to-end run was performed during source audit.

The measured model remains useful validation evidence, but runtime admission is entirely engine/operator based.