### PR TITLE
[SM70] Add gated DSpark verifier and long-context improvements

### DIFF
--- a/benchmarks/analyze_dsv4_dspark_confidence.py
+++ b/benchmarks/analyze_dsv4_dspark_confidence.py
@@ -1,0 +1,288 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Calibrate and summarize DeepSeek-V4 DSpark confidence-head dumps."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+from collections import defaultdict
+from pathlib import Path
+from typing import Any
+
+import torch
+
+
+def _ece(probs: torch.Tensor, targets: torch.Tensor, bins: int = 15) -> float:
+    if probs.numel() == 0:
+        return math.nan
+    edges = torch.linspace(0.0, 1.0, bins + 1, dtype=torch.float64)
+    total = probs.numel()
+    value = 0.0
+    for index in range(bins):
+        if index + 1 == bins:
+            mask = (probs >= edges[index]) & (probs <= edges[index + 1])
+        else:
+            mask = (probs >= edges[index]) & (probs < edges[index + 1])
+        count = int(mask.sum())
+        if count:
+            gap = (probs[mask].mean() - targets[mask].mean()).abs()
+            value += float(gap) * count / total
+    return value
+
+
+def _soft_nll(logits: torch.Tensor, targets: torch.Tensor) -> float:
+    if logits.numel() == 0:
+        return math.nan
+    return float(torch.nn.functional.binary_cross_entropy_with_logits(logits, targets))
+
+
+def _fit_temperature(logits: torch.Tensor, targets: torch.Tensor) -> float:
+    if logits.numel() < 2:
+        return 1.0
+    # A dense one-dimensional search is deterministic, stable for fractional
+    # TV labels, and avoids adding scipy/sklearn to the benchmark environment.
+    temperatures = torch.logspace(-1.0, 1.0, 801, dtype=torch.float64)
+    scaled = logits.to(torch.float64).unsqueeze(0) / temperatures.unsqueeze(1)
+    losses = torch.nn.functional.binary_cross_entropy_with_logits(
+        scaled,
+        targets.to(torch.float64).expand_as(scaled),
+        reduction="none",
+    ).mean(dim=1)
+    return float(temperatures[int(losses.argmin())])
+
+
+def _binary_auc(scores: torch.Tensor, labels: torch.Tensor) -> float:
+    positives = scores[labels == 1]
+    negatives = scores[labels == 0]
+    if positives.numel() == 0 or negatives.numel() == 0:
+        return math.nan
+    # Proposal blocks are at most five positions in the production contract;
+    # this exact pairwise definition is small and handles ties correctly.
+    comparisons = positives[:, None] - negatives[None, :]
+    return float((comparisons.gt(0).float() + 0.5 * comparisons.eq(0).float()).mean())
+
+
+def _summary(
+    logits: torch.Tensor,
+    targets: torch.Tensor,
+    temperature: float,
+    observed_logits: torch.Tensor | None = None,
+    observed_labels: torch.Tensor | None = None,
+) -> dict[str, Any]:
+    scaled_logits = logits / temperature
+    probs = scaled_logits.sigmoid()
+    result: dict[str, Any] = {
+        "count": int(logits.numel()),
+        "temperature": temperature,
+        "predicted_mean": float(probs.mean()) if probs.numel() else math.nan,
+        "target_mean": float(targets.mean()) if targets.numel() else math.nan,
+        "ece": _ece(probs, targets),
+        "brier": (
+            float(torch.square(probs - targets).mean()) if probs.numel() else math.nan
+        ),
+        "soft_nll": _soft_nll(scaled_logits, targets),
+    }
+    if (
+        observed_logits is not None
+        and observed_labels is not None
+        and observed_labels.numel()
+    ):
+        result["observed_count"] = int(observed_labels.numel())
+        result["observed_acceptance"] = float(observed_labels.mean())
+        result["observed_auc"] = _binary_auc(
+            torch.sigmoid(observed_logits / temperature), observed_labels
+        )
+    return result
+
+
+def _load_rows(input_dir: Path, rank: int) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    for path in sorted(input_dir.glob("spec_alignment_*.pt")):
+        payload = torch.load(path, map_location="cpu", weights_only=True)
+        if int(payload.get("rank", -1)) != rank:
+            continue
+        required = (
+            "draft_confidence_logits",
+            "conditional_acceptance_targets",
+            "num_draft_tokens",
+            "output_valid_counts",
+        )
+        if not all(key in payload for key in required):
+            continue
+        payload["_path"] = str(path)
+        rows.append(payload)
+    return rows
+
+
+def analyze(rows: list[dict[str, Any]], calibration_fraction: float) -> dict[str, Any]:
+    if not rows:
+        raise ValueError("no rank-matching confidence alignment dumps were found")
+    max_position = max(max(row["num_draft_tokens"], default=0) for row in rows)
+    by_position: dict[int, dict[str, list[torch.Tensor]]] = defaultdict(
+        lambda: defaultdict(list)
+    )
+    prefix_by_position: dict[int, dict[str, list[torch.Tensor]]] = defaultdict(
+        lambda: defaultdict(list)
+    )
+
+    for row_index, row in enumerate(rows):
+        logits = row["draft_confidence_logits"].to(torch.float64)
+        targets = row["conditional_acceptance_targets"].to(torch.float64)
+        valid_counts = row["output_valid_counts"].to(torch.int64)
+        offset = 0
+        for request_index, count_raw in enumerate(row["num_draft_tokens"]):
+            count = int(count_raw)
+            request_logits = logits[offset : offset + count]
+            request_targets = targets[offset : offset + count]
+            accepted = max(0, min(count, int(valid_counts[request_index]) - 1))
+            split = (
+                "calibration"
+                if row_index < len(rows) * calibration_fraction
+                else "evaluation"
+            )
+            cumulative_pred_logits = request_logits
+            cumulative_targets = request_targets.cumprod(dim=0)
+            for position in range(count):
+                bucket = by_position[position]
+                bucket[f"{split}_logits"].append(
+                    request_logits[position : position + 1]
+                )
+                bucket[f"{split}_targets"].append(
+                    request_targets[position : position + 1]
+                )
+                if position <= accepted and position < count:
+                    observed = torch.tensor(
+                        [1.0 if position < accepted else 0.0], dtype=torch.float64
+                    )
+                    bucket[f"{split}_observed_logits"].append(
+                        request_logits[position : position + 1]
+                    )
+                    bucket[f"{split}_observed"].append(observed)
+
+                prefix_bucket = prefix_by_position[position]
+                prefix_bucket[f"{split}_logits"].append(
+                    cumulative_pred_logits[: position + 1]
+                )
+                prefix_bucket[f"{split}_targets"].append(
+                    cumulative_targets[position : position + 1]
+                )
+            offset += count
+
+    temperatures: list[float] = []
+    position_rows: list[dict[str, Any]] = []
+    for position in range(max_position):
+        bucket = by_position[position]
+        calibration_logits = torch.cat(bucket["calibration_logits"])
+        calibration_targets = torch.cat(bucket["calibration_targets"])
+        temperature = _fit_temperature(calibration_logits, calibration_targets)
+        temperatures.append(temperature)
+        evaluation_logits = torch.cat(
+            bucket["evaluation_logits"] or bucket["calibration_logits"]
+        )
+        evaluation_targets = torch.cat(
+            bucket["evaluation_targets"] or bucket["calibration_targets"]
+        )
+        observed_parts = bucket["evaluation_observed"] or bucket["calibration_observed"]
+        observed_logits_parts = (
+            bucket["evaluation_observed_logits"]
+            or bucket["calibration_observed_logits"]
+        )
+        observed = torch.cat(observed_parts) if observed_parts else None
+        observed_logits = (
+            torch.cat(observed_logits_parts) if observed_logits_parts else None
+        )
+        position_rows.append(
+            {
+                "position": position + 1,
+                "raw": _summary(
+                    evaluation_logits,
+                    evaluation_targets,
+                    1.0,
+                    observed_logits,
+                    observed,
+                ),
+                "calibrated": _summary(
+                    evaluation_logits,
+                    evaluation_targets,
+                    temperature,
+                    observed_logits,
+                    observed,
+                ),
+            }
+        )
+
+    prefix_rows: list[dict[str, Any]] = []
+    for position in range(max_position):
+        bucket = prefix_by_position[position]
+        logits_parts = bucket["evaluation_logits"] or bucket["calibration_logits"]
+        target_parts = bucket["evaluation_targets"] or bucket["calibration_targets"]
+        prefix_probs = torch.stack(
+            [
+                torch.sigmoid(part / torch.tensor(temperatures[: part.numel()])).prod()
+                for part in logits_parts
+            ]
+        )
+        prefix_targets = torch.cat(target_parts)
+        prefix_rows.append(
+            {
+                "position": position + 1,
+                "count": int(prefix_probs.numel()),
+                "predicted_mean": float(prefix_probs.mean()),
+                "target_mean": float(prefix_targets.mean()),
+                "ece": _ece(prefix_probs, prefix_targets),
+                "brier": float(torch.square(prefix_probs - prefix_targets).mean()),
+            }
+        )
+
+    return {
+        "schema_version": 1,
+        "dump_count": len(rows),
+        "rank": int(rows[0].get("rank", -1)),
+        "step_range": [int(rows[0]["step"]), int(rows[-1]["step"])],
+        "calibration_fraction": calibration_fraction,
+        "sequential_temperatures": temperatures,
+        "per_conditional_position": position_rows,
+        "per_prefix_position": prefix_rows,
+        "source_files": [row["_path"] for row in rows],
+    }
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--input-dir", type=Path, required=True)
+    parser.add_argument("--rank", type=int, default=0)
+    parser.add_argument("--calibration-fraction", type=float, default=0.7)
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args()
+    if not 0.0 < args.calibration_fraction < 1.0:
+        parser.error("--calibration-fraction must be in (0, 1)")
+    return args
+
+
+def main() -> None:
+    args = parse_args()
+    rows = _load_rows(args.input_dir, args.rank)
+    result = analyze(rows, args.calibration_fraction)
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+
+    def json_safe(value: Any) -> Any:
+        if isinstance(value, float) and not math.isfinite(value):
+            return None
+        if isinstance(value, dict):
+            return {key: json_safe(item) for key, item in value.items()}
+        if isinstance(value, list):
+            return [json_safe(item) for item in value]
+        return value
+
+    args.output.write_text(
+        json.dumps(json_safe(result), ensure_ascii=False, indent=2) + "\n"
+    )
+    print(
+        json.dumps({key: result[key] for key in ("dump_count", "rank", "step_range")})
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/benchmark_dsv4_dspark_long_context.py
+++ b/benchmarks/benchmark_dsv4_dspark_long_context.py
@@ -22,6 +22,9 @@ from urllib.parse import urlparse
 
 from transformers import AutoTokenizer
 
+_PROFILE_INTERVAL_MARKER = "SM70 spec runner profile interval_avg_ms "
+_PROFILE_FIELD_PATTERN = re.compile(r"([a-z_]+)=([-+]?\d+(?:\.\d+)?(?:[eE][-+]?\d+)?)")
+
 
 def _parse_lengths(raw: str) -> list[int]:
     values = sorted({int(value.strip()) for value in raw.split(",") if value.strip()})
@@ -170,6 +173,91 @@ def _longest_same_token_run(token_ids: list[int]) -> int:
     return longest
 
 
+def _profile_log_offset(profile_log: Path | None) -> int | None:
+    if profile_log is None:
+        return None
+    try:
+        return profile_log.stat().st_size
+    except FileNotFoundError:
+        return 0
+
+
+def _read_verifier_profile(
+    profile_log: Path | None,
+    offset: int | None,
+    verifier_rows: int,
+) -> dict[str, Any]:
+    if profile_log is None or offset is None:
+        return {"available": False, "reason": "profile log was not requested"}
+    try:
+        with profile_log.open("rb") as profile_file:
+            profile_file.seek(offset)
+            text = profile_file.read().decode("utf-8", errors="replace")
+    except FileNotFoundError:
+        return {"available": False, "reason": "profile log does not exist"}
+
+    intervals: list[dict[str, Any]] = []
+    for line in text.splitlines():
+        if _PROFILE_INTERVAL_MARKER not in line:
+            continue
+        fields = {
+            key: float(value)
+            for key, value in _PROFILE_FIELD_PATTERN.findall(
+                line.split(_PROFILE_INTERVAL_MARKER, 1)[1]
+            )
+        }
+        if int(fields.get("num_tokens", -1)) != verifier_rows:
+            continue
+        required = ("target_forward", "target_logits", "target_rejection_sample")
+        if any(name not in fields for name in required):
+            continue
+        interval = dict(fields)
+        for name in (
+            "calls",
+            "interval_calls",
+            "interval_spec_steps",
+            "num_tokens",
+            "num_reqs",
+        ):
+            if name in interval:
+                interval[name] = int(interval[name])
+        interval["complete_verifier_ms"] = sum(fields[name] for name in required)
+        intervals.append(interval)
+
+    # The first/last profiler window can straddle prefill or request teardown.
+    # Long sweeps run with a short profile interval and retain only complete
+    # interior windows when enough samples are available.
+    if len(intervals) >= 4:
+        steady_intervals = intervals[1:-1]
+    elif len(intervals) == 3:
+        steady_intervals = intervals[1:]
+    else:
+        steady_intervals = intervals
+    median_names = (
+        "target_forward",
+        "target_logits",
+        "target_rejection_sample",
+        "complete_verifier_ms",
+        "draft_total",
+    )
+    medians = {
+        name: statistics.median(
+            float(interval[name]) for interval in steady_intervals if name in interval
+        )
+        for name in median_names
+        if any(name in interval for interval in steady_intervals)
+    }
+    return {
+        "available": bool(intervals),
+        "profile_log": str(profile_log),
+        "verifier_rows": verifier_rows,
+        "raw_interval_count": len(intervals),
+        "steady_interval_count": len(steady_intervals),
+        "medians_ms": medians,
+        "intervals": intervals,
+    }
+
+
 def _stream_request(
     *,
     host: str,
@@ -287,11 +375,14 @@ def _run_case(
     top_p: float,
     seed: int,
     timeout: int,
+    num_speculative_tokens: int,
+    profile_log: Path | None,
 ) -> dict[str, Any]:
     marker = f"DSV4-CONTEXT-{target_tokens}-OK"
     messages, local_prompt_tokens, unit_count = _fit_messages(
         tokenizer, target_tokens, marker
     )
+    profile_offset = _profile_log_offset(profile_log)
     before = _metrics_snapshot(host, port, timeout)
     result = _stream_request(
         host=host,
@@ -310,8 +401,17 @@ def _run_case(
     accepted = after["accepted"] - before["accepted"]
     accepted_per_position = [
         after["positions"].get(position, 0.0) - before["positions"].get(position, 0.0)
-        for position in range(7)
+        for position in range(num_speculative_tokens)
     ]
+    verifier_profile = (
+        _read_verifier_profile(
+            profile_log,
+            profile_offset,
+            num_speculative_tokens + 1,
+        )
+        if num_speculative_tokens
+        else {"available": False, "reason": "speculative decoding is disabled"}
+    )
     output_text = f"{result['reasoning']}\n{result['content']}"
     output_ids = tokenizer.encode(output_text, add_special_tokens=False)
     completion_tokens = int(result["usage"].get("completion_tokens") or 0)
@@ -347,6 +447,7 @@ def _run_case(
                     for value in accepted_per_position
                 ],
             },
+            "verifier_profile": verifier_profile,
         }
     )
     result["passed"] = bool(
@@ -370,12 +471,22 @@ def _summary(records: list[dict[str, Any]]) -> dict[str, Any]:
         for record in records
         if record["speculative_metrics"]["round_wall_milliseconds"] is not None
     ]
+    verifier_costs = [
+        float(record["verifier_profile"]["medians_ms"]["complete_verifier_ms"])
+        for record in records
+        if record["verifier_profile"].get("medians_ms", {}).get("complete_verifier_ms")
+        is not None
+    ]
     return {
         "cases": len(records),
         "passed": all(record["passed"] for record in records),
         "pure_decode_tps_min": min(speeds) if speeds else None,
         "pure_decode_tps_median": statistics.median(speeds) if speeds else None,
         "round_wall_ms_max": max(round_costs) if round_costs else None,
+        "complete_verifier_ms_median": (
+            statistics.median(verifier_costs) if verifier_costs else None
+        ),
+        "complete_verifier_ms_max": max(verifier_costs) if verifier_costs else None,
     }
 
 
@@ -389,9 +500,14 @@ def main() -> int:
     parser.add_argument("--temperature", type=float, default=1.0)
     parser.add_argument("--top-p", type=float, default=1.0)
     parser.add_argument("--seed", type=int, default=20260824)
+    parser.add_argument("--num-speculative-tokens", type=int, default=7)
+    parser.add_argument("--profile-log", type=Path)
     parser.add_argument("--timeout", type=int, default=1800)
     parser.add_argument("--out", type=Path, required=True)
     args = parser.parse_args()
+
+    if not 0 <= args.num_speculative_tokens <= 7:
+        raise ValueError("--num-speculative-tokens must be in [0, 7]")
 
     parsed = urlparse(args.base_url)
     if parsed.scheme != "http" or not parsed.hostname:
@@ -418,6 +534,8 @@ def main() -> int:
             top_p=args.top_p,
             seed=args.seed,
             timeout=args.timeout,
+            num_speculative_tokens=args.num_speculative_tokens,
+            profile_log=args.profile_log,
         )
         records.append(record)
         contract = {
@@ -442,6 +560,7 @@ def main() -> int:
                         "pure_decode_tokens_per_second"
                     ],
                     "speculative_metrics": record["speculative_metrics"],
+                    "verifier_profile": record["verifier_profile"],
                     "output_health": record["output_health"],
                     "passed": record["passed"],
                 },

--- a/benchmarks/benchmark_dsv4_dspark_long_context.py
+++ b/benchmarks/benchmark_dsv4_dspark_long_context.py
@@ -13,13 +13,13 @@ from __future__ import annotations
 import argparse
 import http.client
 import json
-import re
 import statistics
 import time
 from pathlib import Path
 from typing import Any
 from urllib.parse import urlparse
 
+import regex as re
 from transformers import AutoTokenizer
 
 _PROFILE_INTERVAL_MARKER = "SM70 spec runner profile interval_avg_ms "

--- a/benchmarks/benchmark_dsv4_dspark_long_context.py
+++ b/benchmarks/benchmark_dsv4_dspark_long_context.py
@@ -1,0 +1,457 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Measure DSpark verification and output health across long contexts.
+
+The benchmark targets an already-running OpenAI-compatible server. It records
+stream timestamps together with vLLM speculative metrics so decode speed,
+verification-round cost, and draft acceptance can be compared per context
+bucket instead of being conflated with prefill latency.
+"""
+
+from __future__ import annotations
+
+import argparse
+import http.client
+import json
+import re
+import statistics
+import time
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlparse
+
+from transformers import AutoTokenizer
+
+
+def _parse_lengths(raw: str) -> list[int]:
+    values = sorted({int(value.strip()) for value in raw.split(",") if value.strip()})
+    if not values or values[0] <= 0:
+        raise ValueError("--lengths must contain positive integers")
+    return values
+
+
+def _template_token_ids(tokenizer: Any, messages: list[dict[str, str]]) -> list[int]:
+    try:
+        encoded = tokenizer.apply_chat_template(
+            messages,
+            tokenize=True,
+            add_generation_prompt=True,
+            enable_thinking=False,
+        )
+    except (TypeError, ValueError):
+        # DeepSeek V4's custom tokenizer mode supplies the template in the
+        # server rather than tokenizer_config.json. The constant allowance is
+        # only for fitting below the target; server-reported usage remains the
+        # authoritative prompt length in every result row.
+        encoded = [0] * 32
+        for message in messages:
+            encoded.extend(
+                tokenizer.encode(message["content"], add_special_tokens=False)
+            )
+    if isinstance(encoded, dict):
+        encoded = encoded["input_ids"]
+    elif hasattr(encoded, "input_ids"):
+        encoded = encoded.input_ids
+    if encoded and isinstance(encoded[0], list):
+        encoded = encoded[0]
+    return list(encoded)
+
+
+def _filler_unit(index: int) -> str:
+    return (
+        f"Record {index:06d}: unrelated inventory values "
+        f"{index * 17 % 9973}, {index * 31 % 7919}, {index * 43 % 6151}. "
+        "This record is only deterministic long-context filler and contains "
+        "no answer to the final instruction.\n"
+    )
+
+
+def _build_messages(unit_count: int, marker: str) -> list[dict[str, str]]:
+    filler = "".join(_filler_unit(index) for index in range(unit_count))
+    instruction = (
+        "\nFINAL INSTRUCTION: Ignore the inventory records. Begin the response "
+        f"with the exact marker {marker} on its own line, then write a concise "
+        "technical paragraph explaining why bounded CUDA-graph context buckets "
+        "reduce long-context decode latency. Do not repeat the marker."
+    )
+    return [
+        {
+            "role": "system",
+            "content": (
+                "Follow the final user instruction exactly. Long repeated context "
+                "must not cause repetition, garbling, or loss of the suffix."
+            ),
+        },
+        {"role": "user", "content": filler + instruction},
+    ]
+
+
+def _fit_messages(
+    tokenizer: Any,
+    target_tokens: int,
+    marker: str,
+) -> tuple[list[dict[str, str]], int, int]:
+    sample_count = 64
+    sample_tokens = len(
+        _template_token_ids(tokenizer, _build_messages(sample_count, marker))
+    )
+    base_tokens = len(_template_token_ids(tokenizer, _build_messages(0, marker)))
+    tokens_per_unit = max(1.0, (sample_tokens - base_tokens) / sample_count)
+    low = 0
+    high = max(1, int(target_tokens / tokens_per_unit * 1.2) + 32)
+    best_messages = _build_messages(0, marker)
+    best_tokens = len(_template_token_ids(tokenizer, best_messages))
+    best_units = 0
+    for _ in range(24):
+        if low > high:
+            break
+        middle = (low + high) // 2
+        messages = _build_messages(middle, marker)
+        prompt_tokens = len(_template_token_ids(tokenizer, messages))
+        if prompt_tokens <= target_tokens:
+            best_messages = messages
+            best_tokens = prompt_tokens
+            best_units = middle
+            low = middle + 1
+        else:
+            high = middle - 1
+    return best_messages, best_tokens, best_units
+
+
+def _metric_total(text: str, name: str) -> float:
+    return sum(
+        float(line.rsplit(" ", 1)[-1])
+        for line in text.splitlines()
+        if line.startswith(name + "{") or line.startswith(name + " ")
+    )
+
+
+def _metrics_snapshot(host: str, port: int, timeout: int) -> dict[str, Any]:
+    connection = http.client.HTTPConnection(host, port, timeout=timeout)
+    try:
+        connection.request("GET", "/metrics")
+        response = connection.getresponse()
+        raw = response.read()
+    finally:
+        connection.close()
+    if response.status != 200:
+        raise RuntimeError(f"metrics endpoint returned HTTP {response.status}")
+    text = raw.decode("utf-8", errors="replace")
+    positions: dict[int, float] = {}
+    prefix = "vllm:spec_decode_num_accepted_tokens_per_pos_total{"
+    for line in text.splitlines():
+        if not line.startswith(prefix):
+            continue
+        match = re.search(r'position="(\d+)"', line)
+        if match:
+            position = int(match.group(1))
+            positions[position] = positions.get(position, 0.0) + float(
+                line.rsplit(" ", 1)[-1]
+            )
+    return {
+        "rounds": _metric_total(text, "vllm:spec_decode_num_drafts_total"),
+        "proposed": _metric_total(text, "vllm:spec_decode_num_draft_tokens_total"),
+        "accepted": _metric_total(text, "vllm:spec_decode_num_accepted_tokens_total"),
+        "positions": positions,
+    }
+
+
+def _longest_same_token_run(token_ids: list[int]) -> int:
+    longest = 0
+    current = 0
+    previous: int | None = None
+    for token_id in token_ids:
+        if token_id == previous:
+            current += 1
+        else:
+            previous = token_id
+            current = 1
+        longest = max(longest, current)
+    return longest
+
+
+def _stream_request(
+    *,
+    host: str,
+    port: int,
+    model: str,
+    messages: list[dict[str, str]],
+    output_tokens: int,
+    temperature: float,
+    top_p: float,
+    seed: int,
+    timeout: int,
+) -> dict[str, Any]:
+    payload = {
+        "model": model,
+        "messages": messages,
+        "max_tokens": output_tokens,
+        "temperature": temperature,
+        "top_p": top_p,
+        "seed": seed,
+        "ignore_eos": True,
+        "stream": True,
+        "stream_options": {"include_usage": True},
+        "chat_template_kwargs": {"enable_thinking": False},
+    }
+    connection = http.client.HTTPConnection(host, port, timeout=timeout)
+    encoded = json.dumps(payload, ensure_ascii=False).encode("utf-8")
+    started_ns = time.perf_counter_ns()
+    first_token_ns: int | None = None
+    last_token_ns: int | None = None
+    content_parts: list[str] = []
+    reasoning_parts: list[str] = []
+    usage: dict[str, Any] = {}
+    finish_reason: str | None = None
+    try:
+        connection.request(
+            "POST",
+            "/v1/chat/completions",
+            body=encoded,
+            headers={"Content-Type": "application/json"},
+        )
+        response = connection.getresponse()
+        if response.status != 200:
+            raw = response.read()
+            raise RuntimeError(
+                f"request returned HTTP {response.status}: "
+                f"{raw.decode('utf-8', errors='replace')}"
+            )
+        for raw_line in response:
+            arrival_ns = time.perf_counter_ns()
+            line = raw_line.decode("utf-8", errors="replace").strip()
+            if not line.startswith("data: "):
+                continue
+            data = line[6:]
+            if data == "[DONE]":
+                break
+            event = json.loads(data)
+            if event.get("usage"):
+                usage = event["usage"]
+            choices = event.get("choices") or []
+            if not choices:
+                continue
+            choice = choices[0]
+            if choice.get("finish_reason") is not None:
+                finish_reason = choice["finish_reason"]
+            delta = choice.get("delta") or {}
+            content = delta.get("content") or ""
+            reasoning = delta.get("reasoning_content") or delta.get("reasoning") or ""
+            if content or reasoning:
+                first_token_ns = first_token_ns or arrival_ns
+                last_token_ns = arrival_ns
+                if content:
+                    content_parts.append(content)
+                if reasoning:
+                    reasoning_parts.append(reasoning)
+    finally:
+        finished_ns = time.perf_counter_ns()
+        connection.close()
+
+    completion_tokens = int(usage.get("completion_tokens") or 0)
+    decode_seconds = (
+        (last_token_ns - first_token_ns) / 1_000_000_000
+        if first_token_ns is not None and last_token_ns is not None
+        else None
+    )
+    return {
+        "request": payload,
+        "usage": usage,
+        "finish_reason": finish_reason,
+        "wall_seconds": (finished_ns - started_ns) / 1_000_000_000,
+        "ttft_seconds": (
+            (first_token_ns - started_ns) / 1_000_000_000
+            if first_token_ns is not None
+            else None
+        ),
+        "pure_decode_seconds": decode_seconds,
+        "pure_decode_tokens_per_second": (
+            (completion_tokens - 1) / decode_seconds
+            if completion_tokens > 1 and decode_seconds
+            else None
+        ),
+        "content": "".join(content_parts),
+        "reasoning": "".join(reasoning_parts),
+    }
+
+
+def _run_case(
+    *,
+    tokenizer: Any,
+    host: str,
+    port: int,
+    model: str,
+    target_tokens: int,
+    output_tokens: int,
+    temperature: float,
+    top_p: float,
+    seed: int,
+    timeout: int,
+) -> dict[str, Any]:
+    marker = f"DSV4-CONTEXT-{target_tokens}-OK"
+    messages, local_prompt_tokens, unit_count = _fit_messages(
+        tokenizer, target_tokens, marker
+    )
+    before = _metrics_snapshot(host, port, timeout)
+    result = _stream_request(
+        host=host,
+        port=port,
+        model=model,
+        messages=messages,
+        output_tokens=output_tokens,
+        temperature=temperature,
+        top_p=top_p,
+        seed=seed,
+        timeout=timeout,
+    )
+    after = _metrics_snapshot(host, port, timeout)
+    rounds = after["rounds"] - before["rounds"]
+    proposed = after["proposed"] - before["proposed"]
+    accepted = after["accepted"] - before["accepted"]
+    accepted_per_position = [
+        after["positions"].get(position, 0.0) - before["positions"].get(position, 0.0)
+        for position in range(7)
+    ]
+    output_text = f"{result['reasoning']}\n{result['content']}"
+    output_ids = tokenizer.encode(output_text, add_special_tokens=False)
+    completion_tokens = int(result["usage"].get("completion_tokens") or 0)
+    result.update(
+        {
+            "target_prompt_tokens": target_tokens,
+            "local_prompt_tokens": local_prompt_tokens,
+            "unit_count": unit_count,
+            "marker": marker,
+            "output_health": {
+                "marker_in_content": marker in result["content"],
+                "replacement_characters": output_text.count("\ufffd"),
+                "unique_output_tokens": len(set(output_ids)),
+                "longest_same_token_run": _longest_same_token_run(output_ids),
+            },
+            "speculative_metrics": {
+                "rounds": rounds,
+                "proposed_tokens": proposed,
+                "accepted_tokens": accepted,
+                "accepted_fraction_of_proposed": (
+                    accepted / proposed if proposed else None
+                ),
+                "mean_emitted_tokens_per_round": (
+                    1.0 + accepted / rounds if rounds else None
+                ),
+                "round_wall_milliseconds": (
+                    result["pure_decode_seconds"] * 1000.0 / rounds
+                    if result["pure_decode_seconds"] and rounds
+                    else None
+                ),
+                "unconditional_acceptance_per_position": [
+                    value / rounds if rounds else None
+                    for value in accepted_per_position
+                ],
+            },
+        }
+    )
+    result["passed"] = bool(
+        completion_tokens == output_tokens
+        and result["output_health"]["marker_in_content"]
+        and result["output_health"]["replacement_characters"] == 0
+        and result["output_health"]["unique_output_tokens"] >= 8
+        and result["output_health"]["longest_same_token_run"] < 16
+    )
+    return result
+
+
+def _summary(records: list[dict[str, Any]]) -> dict[str, Any]:
+    speeds = [
+        float(record["pure_decode_tokens_per_second"])
+        for record in records
+        if record["pure_decode_tokens_per_second"] is not None
+    ]
+    round_costs = [
+        float(record["speculative_metrics"]["round_wall_milliseconds"])
+        for record in records
+        if record["speculative_metrics"]["round_wall_milliseconds"] is not None
+    ]
+    return {
+        "cases": len(records),
+        "passed": all(record["passed"] for record in records),
+        "pure_decode_tps_min": min(speeds) if speeds else None,
+        "pure_decode_tps_median": statistics.median(speeds) if speeds else None,
+        "round_wall_ms_max": max(round_costs) if round_costs else None,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--base-url", default="http://127.0.0.1:8000")
+    parser.add_argument("--model", required=True)
+    parser.add_argument("--model-path", type=Path, required=True)
+    parser.add_argument("--lengths", default="1024,4096,16384,65536,131072,252000")
+    parser.add_argument("--output-tokens", type=int, default=128)
+    parser.add_argument("--temperature", type=float, default=1.0)
+    parser.add_argument("--top-p", type=float, default=1.0)
+    parser.add_argument("--seed", type=int, default=20260824)
+    parser.add_argument("--timeout", type=int, default=1800)
+    parser.add_argument("--out", type=Path, required=True)
+    args = parser.parse_args()
+
+    parsed = urlparse(args.base_url)
+    if parsed.scheme != "http" or not parsed.hostname:
+        raise ValueError("--base-url must be an http URL")
+    host = parsed.hostname
+    port = parsed.port or 80
+    tokenizer = AutoTokenizer.from_pretrained(
+        str(args.model_path),
+        local_files_only=True,
+        trust_remote_code=True,
+    )
+
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    records: list[dict[str, Any]] = []
+    for target_tokens in _parse_lengths(args.lengths):
+        record = _run_case(
+            tokenizer=tokenizer,
+            host=host,
+            port=port,
+            model=args.model,
+            target_tokens=target_tokens,
+            output_tokens=args.output_tokens,
+            temperature=args.temperature,
+            top_p=args.top_p,
+            seed=args.seed,
+            timeout=args.timeout,
+        )
+        records.append(record)
+        contract = {
+            key: str(value) if isinstance(value, Path) else value
+            for key, value in vars(args).items()
+        }
+        payload = {
+            "contract": contract,
+            "records": records,
+            "summary": _summary(records),
+        }
+        args.out.write_text(
+            json.dumps(payload, ensure_ascii=False, indent=2) + "\n",
+            encoding="utf-8",
+        )
+        print(
+            json.dumps(
+                {
+                    "target_prompt_tokens": target_tokens,
+                    "usage": record["usage"],
+                    "pure_decode_tokens_per_second": record[
+                        "pure_decode_tokens_per_second"
+                    ],
+                    "speculative_metrics": record["speculative_metrics"],
+                    "output_health": record["output_health"],
+                    "passed": record["passed"],
+                },
+                ensure_ascii=False,
+            ),
+            flush=True,
+        )
+
+    return 0 if all(record["passed"] for record in records) else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmarks/benchmark_dsv4_quality_api.py
+++ b/benchmarks/benchmark_dsv4_quality_api.py
@@ -1,0 +1,577 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Run paired HumanEval and LongBench-subset gates against a vLLM API."""
+
+from __future__ import annotations
+
+import argparse
+import ctypes
+import functools
+import http.client
+import json
+import os
+import re
+import resource
+import statistics
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlparse
+
+from transformers import AutoTokenizer
+
+NO_CHAT_DATASETS = {"trec", "triviaqa", "samsum", "lsht", "lcc", "repobench-p"}
+
+
+def _post_json(
+    *,
+    host: str,
+    port: int,
+    path: str,
+    payload: dict[str, Any],
+    timeout: int,
+) -> dict[str, Any]:
+    connection = http.client.HTTPConnection(host, port, timeout=timeout)
+    try:
+        connection.request(
+            "POST",
+            path,
+            body=json.dumps(payload, ensure_ascii=False).encode("utf-8"),
+            headers={"Content-Type": "application/json"},
+        )
+        response = connection.getresponse()
+        raw = response.read()
+    finally:
+        connection.close()
+    if response.status != 200:
+        raise RuntimeError(
+            f"{path} returned HTTP {response.status}: "
+            f"{raw.decode('utf-8', errors='replace')}"
+        )
+    return json.loads(raw)
+
+
+def _chat(
+    *,
+    host: str,
+    port: int,
+    model: str,
+    content: str,
+    max_tokens: int,
+    timeout: int,
+) -> tuple[str, dict[str, Any]]:
+    result = _post_json(
+        host=host,
+        port=port,
+        path="/v1/chat/completions",
+        timeout=timeout,
+        payload={
+            "model": model,
+            "messages": [{"role": "user", "content": content}],
+            "max_tokens": max_tokens,
+            "temperature": 0.0,
+            "top_p": 1.0,
+            "seed": 20260824,
+            "chat_template_kwargs": {"enable_thinking": False},
+        },
+    )
+    message = result["choices"][0]["message"]
+    return message.get("content") or "", result
+
+
+def _completion(
+    *,
+    host: str,
+    port: int,
+    model: str,
+    prompt: str,
+    max_tokens: int,
+    timeout: int,
+) -> tuple[str, dict[str, Any]]:
+    result = _post_json(
+        host=host,
+        port=port,
+        path="/v1/completions",
+        timeout=timeout,
+        payload={
+            "model": model,
+            "prompt": prompt,
+            "max_tokens": max_tokens,
+            "temperature": 0.0,
+            "top_p": 1.0,
+            "seed": 20260824,
+        },
+    )
+    return result["choices"][0].get("text") or "", result
+
+
+def _extract_python(text: str, entry_point: str) -> str:
+    blocks = re.findall(r"```(?:python)?\s*\n(.*?)```", text, flags=re.DOTALL)
+    for block in blocks:
+        if re.search(rf"\bdef\s+{re.escape(entry_point)}\s*\(", block):
+            return block.strip()
+    if blocks:
+        return max(blocks, key=len).strip()
+    return text.strip()
+
+
+def _sandbox_preexec(sandbox_dir: str) -> None:
+    """Deny filesystem/network access before executing generated code."""
+    libc = ctypes.CDLL(None, use_errno=True)
+    libc.syscall.restype = ctypes.c_long
+    libc.prctl.argtypes = [
+        ctypes.c_int,
+        ctypes.c_ulong,
+        ctypes.c_ulong,
+        ctypes.c_ulong,
+        ctypes.c_ulong,
+    ]
+    libc.prctl.restype = ctypes.c_int
+    sys_create_ruleset = 444
+    sys_add_rule = 445
+    sys_restrict_self = 446
+    abi = libc.syscall(sys_create_ruleset, 0, 0, 1)
+    if abi < 1:
+        raise OSError(ctypes.get_errno(), "Landlock is unavailable")
+
+    class RulesetAttr(ctypes.Structure):
+        _fields_ = [
+            ("handled_access_fs", ctypes.c_uint64),
+            ("handled_access_net", ctypes.c_uint64),
+        ]
+
+    class PathBeneathAttr(ctypes.Structure):
+        _pack_ = 1
+        _fields_ = [
+            ("allowed_access", ctypes.c_uint64),
+            ("parent_fd", ctypes.c_int32),
+        ]
+
+    handled_fs = (1 << 13) - 1
+    if abi >= 2:
+        handled_fs |= 1 << 13
+    if abi >= 3:
+        handled_fs |= 1 << 14
+    ruleset_attr = RulesetAttr(handled_fs, 3 if abi >= 4 else 0)
+    ruleset_fd = libc.syscall(
+        sys_create_ruleset,
+        ctypes.byref(ruleset_attr),
+        ctypes.sizeof(ruleset_attr),
+        0,
+    )
+    if ruleset_fd < 0:
+        raise OSError(ctypes.get_errno(), "landlock_create_ruleset")
+
+    read_only = (1 << 0) | (1 << 2) | (1 << 3)
+    allowed_paths = (
+        ("/usr", read_only),
+        ("/lib", read_only),
+        ("/lib64", read_only),
+        ("/dev/null", (1 << 1) | (1 << 2)),
+        ("/dev/urandom", 1 << 2),
+        (sandbox_dir, handled_fs),
+    )
+    for path, allowed_access in allowed_paths:
+        parent_fd = os.open(path, os.O_PATH | os.O_CLOEXEC)
+        path_attr = PathBeneathAttr(allowed_access, parent_fd)
+        if (
+            libc.syscall(
+                sys_add_rule,
+                ruleset_fd,
+                1,
+                ctypes.byref(path_attr),
+                0,
+            )
+            < 0
+        ):
+            raise OSError(ctypes.get_errno(), f"landlock_add_rule({path})")
+        os.close(parent_fd)
+
+    if libc.prctl(38, 1, 0, 0, 0) < 0:
+        raise OSError(ctypes.get_errno(), "PR_SET_NO_NEW_PRIVS")
+    if libc.syscall(sys_restrict_self, ruleset_fd, 0) < 0:
+        raise OSError(ctypes.get_errno(), "landlock_restrict_self")
+    os.close(ruleset_fd)
+
+    seccomp = ctypes.CDLL("libseccomp.so.2", use_errno=True)
+    seccomp.seccomp_init.argtypes = [ctypes.c_uint32]
+    seccomp.seccomp_init.restype = ctypes.c_void_p
+    seccomp.seccomp_syscall_resolve_name.argtypes = [ctypes.c_char_p]
+    seccomp.seccomp_syscall_resolve_name.restype = ctypes.c_int
+    seccomp.seccomp_rule_add.argtypes = [
+        ctypes.c_void_p,
+        ctypes.c_uint32,
+        ctypes.c_int,
+        ctypes.c_uint,
+    ]
+    seccomp.seccomp_rule_add.restype = ctypes.c_int
+    seccomp.seccomp_load.argtypes = [ctypes.c_void_p]
+    seccomp.seccomp_load.restype = ctypes.c_int
+    seccomp.seccomp_release.argtypes = [ctypes.c_void_p]
+    seccomp.seccomp_release.restype = None
+    context = seccomp.seccomp_init(0x7FFF0000)
+    if not context:
+        raise RuntimeError("seccomp_init failed")
+    deny_with_eperm = 0x00050000 | 1
+    for name in (
+        b"socket",
+        b"socketpair",
+        b"connect",
+        b"bind",
+        b"listen",
+        b"accept",
+        b"accept4",
+        b"sendto",
+        b"sendmsg",
+        b"recvfrom",
+        b"recvmsg",
+        b"kill",
+        b"tkill",
+        b"tgkill",
+        b"pidfd_open",
+        b"pidfd_getfd",
+        b"pidfd_send_signal",
+        b"ptrace",
+        b"process_vm_readv",
+        b"process_vm_writev",
+        b"kcmp",
+        b"fork",
+        b"vfork",
+        b"clone",
+        b"clone3",
+        b"unshare",
+        b"setns",
+        b"mount",
+        b"umount2",
+        b"pivot_root",
+        b"bpf",
+        b"perf_event_open",
+        b"userfaultfd",
+        b"keyctl",
+        b"add_key",
+        b"request_key",
+        b"open_by_handle_at",
+        b"name_to_handle_at",
+    ):
+        syscall_number = seccomp.seccomp_syscall_resolve_name(name)
+        if (
+            syscall_number >= 0
+            and seccomp.seccomp_rule_add(context, deny_with_eperm, syscall_number, 0)
+            != 0
+        ):
+            raise RuntimeError(f"seccomp_rule_add failed for {name!r}")
+    if seccomp.seccomp_load(context) != 0:
+        raise RuntimeError("seccomp_load failed")
+    seccomp.seccomp_release(context)
+
+    resource.setrlimit(resource.RLIMIT_CPU, (5, 5))
+    resource.setrlimit(resource.RLIMIT_AS, (256 << 20, 256 << 20))
+    resource.setrlimit(resource.RLIMIT_FSIZE, (1 << 20, 1 << 20))
+    resource.setrlimit(resource.RLIMIT_NPROC, (16, 16))
+
+
+def _execute_humaneval(program: str, timeout: int = 8) -> dict[str, Any]:
+    with tempfile.TemporaryDirectory(prefix="dsv4-humaneval-") as sandbox_dir:
+        output_path = Path(sandbox_dir) / "output.log"
+        try:
+            with output_path.open("wb") as output_file:
+                completed = subprocess.run(
+                    ["/usr/bin/python3", "-I", "-S", "-"],
+                    input=program.encode("utf-8"),
+                    stdout=output_file,
+                    stderr=subprocess.STDOUT,
+                    cwd=sandbox_dir,
+                    env={"PATH": "/usr/bin", "HOME": sandbox_dir},
+                    preexec_fn=functools.partial(_sandbox_preexec, sandbox_dir),
+                    timeout=timeout,
+                )
+            output = output_path.read_bytes()[-2000:].decode("utf-8", errors="replace")
+            return {
+                "passed": completed.returncode == 0,
+                "returncode": completed.returncode,
+                "output": output,
+            }
+        except subprocess.TimeoutExpired as exc:
+            return {
+                "passed": False,
+                "returncode": None,
+                "output": f"timeout: {exc}",
+            }
+
+
+def _run_humaneval(
+    *,
+    host: str,
+    port: int,
+    model: str,
+    tasks_path: Path,
+    limit: int,
+    timeout: int,
+) -> dict[str, Any]:
+    tasks = json.loads(tasks_path.read_text(encoding="utf-8"))[:limit]
+    records: list[dict[str, Any]] = []
+    for task in tasks:
+        prompt = (
+            "Complete the Python function below. Return runnable Python code "
+            "only, without Markdown or explanation.\n\n" + task["prompt"]
+        )
+        response, raw = _chat(
+            host=host,
+            port=port,
+            model=model,
+            content=prompt,
+            max_tokens=768,
+            timeout=timeout,
+        )
+        code = _extract_python(response, task["entry_point"])
+        if re.search(rf"\bdef\s+{re.escape(task['entry_point'])}\s*\(", code):
+            candidate = code
+        else:
+            candidate = task["prompt"] + code
+        program = candidate + "\n" + task["test"] + f"\ncheck({task['entry_point']})\n"
+        execution = _execute_humaneval(program)
+        records.append(
+            {
+                "task_id": task["task_id"],
+                "passed": execution["passed"],
+                "execution": execution,
+                "response": response,
+                "usage": raw.get("usage"),
+            }
+        )
+    passed = sum(int(record["passed"]) for record in records)
+    return {
+        "samples": len(records),
+        "passed": passed,
+        "pass_at_1": passed / len(records) if records else None,
+        "records": records,
+    }
+
+
+def _truncate_middle(tokenizer: Any, prompt: str, max_input_tokens: int) -> str:
+    token_ids = tokenizer.encode(prompt, add_special_tokens=False)
+    if len(token_ids) <= max_input_tokens:
+        return prompt
+    half = max_input_tokens // 2
+    return tokenizer.decode(
+        token_ids[:half], skip_special_tokens=True
+    ) + tokenizer.decode(token_ids[-half:], skip_special_tokens=True)
+
+
+def _select_longbench_rows(
+    rows: list[dict[str, Any]], limit: int
+) -> list[dict[str, Any]]:
+    rows = [row for row in rows if int(row.get("length", 0)) >= 8000] or rows
+    if len(rows) <= limit:
+        return rows
+    if limit == 1:
+        return [rows[len(rows) // 2]]
+    last = len(rows) - 1
+    return [rows[round(index * last / (limit - 1))] for index in range(limit)]
+
+
+def _run_longbench(
+    *,
+    tokenizer: Any,
+    host: str,
+    port: int,
+    model: str,
+    data_dir: Path,
+    longbench_root: Path,
+    datasets: list[str],
+    limit: int,
+    max_input_tokens: int,
+    timeout: int,
+) -> dict[str, Any]:
+    config_dir = longbench_root / "config"
+    prompt_formats = json.loads(
+        (config_dir / "dataset2prompt.json").read_text(encoding="utf-8")
+    )
+    max_output_tokens = json.loads(
+        (config_dir / "dataset2maxlen.json").read_text(encoding="utf-8")
+    )
+    sys.path.insert(0, str(longbench_root.resolve()))
+    try:
+        from eval import dataset2metric  # type: ignore
+    except ModuleNotFoundError as exc:
+        raise RuntimeError(
+            "LongBench metric dependencies are missing; install rouge, jieba, "
+            "and fuzzywuzzy into PYTHONPATH"
+        ) from exc
+
+    by_dataset: dict[str, Any] = {}
+    for dataset in datasets:
+        rows = [
+            json.loads(line)
+            for line in (data_dir / f"{dataset}.jsonl")
+            .read_text(encoding="utf-8")
+            .splitlines()
+            if line.strip()
+        ]
+        selected = _select_longbench_rows(rows, limit)
+        records: list[dict[str, Any]] = []
+        for row in selected:
+            prompt = prompt_formats[dataset].format(**row)
+            prompt = _truncate_middle(tokenizer, prompt, max_input_tokens)
+            if dataset in NO_CHAT_DATASETS:
+                prediction, raw = _completion(
+                    host=host,
+                    port=port,
+                    model=model,
+                    prompt=prompt,
+                    max_tokens=int(max_output_tokens[dataset]),
+                    timeout=timeout,
+                )
+            else:
+                prediction, raw = _chat(
+                    host=host,
+                    port=port,
+                    model=model,
+                    content=prompt,
+                    max_tokens=int(max_output_tokens[dataset]),
+                    timeout=timeout,
+                )
+            score = max(
+                float(
+                    dataset2metric[dataset](
+                        prediction,
+                        answer,
+                        all_classes=row.get("all_classes", []),
+                    )
+                )
+                for answer in row["answers"]
+            )
+            records.append(
+                {
+                    "length": row.get("length"),
+                    "score": score,
+                    "prediction": prediction,
+                    "answers": row["answers"],
+                    "usage": raw.get("usage"),
+                }
+            )
+        scores = [float(record["score"]) for record in records]
+        by_dataset[dataset] = {
+            "samples": len(records),
+            "score": 100.0 * statistics.mean(scores) if scores else None,
+            "records": records,
+        }
+    dataset_scores = [
+        float(result["score"])
+        for result in by_dataset.values()
+        if result["score"] is not None
+    ]
+    return {
+        "datasets": by_dataset,
+        "average_score": statistics.mean(dataset_scores) if dataset_scores else None,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--base-url", default="http://127.0.0.1:8000")
+    parser.add_argument("--model", required=True)
+    parser.add_argument("--model-path", type=Path, required=True)
+    parser.add_argument("--out", type=Path, required=True)
+    parser.add_argument(
+        "--humaneval-tasks",
+        type=Path,
+        default=Path(
+            "bench_results/ddtree_humaneval_sweep_20260625/humaneval_tasks.json"
+        ),
+    )
+    parser.add_argument("--humaneval-limit", type=int, default=32)
+    parser.add_argument(
+        "--longbench-data-dir",
+        type=Path,
+        default=Path("benchmark-data/longbench/data"),
+    )
+    parser.add_argument(
+        "--longbench-root",
+        type=Path,
+        default=Path("third_party/LongBench/LongBench"),
+    )
+    parser.add_argument(
+        "--longbench-datasets",
+        default="hotpotqa,multifieldqa_zh,gov_report,lcc",
+    )
+    parser.add_argument("--longbench-limit", type=int, default=4)
+    parser.add_argument("--longbench-max-input-tokens", type=int, default=32768)
+    parser.add_argument("--timeout", type=int, default=1200)
+    parser.add_argument("--min-humaneval-passes", type=int, default=0)
+    parser.add_argument("--min-longbench-average", type=float, default=0.0)
+    args = parser.parse_args()
+
+    parsed = urlparse(args.base_url)
+    if parsed.scheme != "http" or not parsed.hostname:
+        raise ValueError("--base-url must be an http URL")
+    host = parsed.hostname
+    port = parsed.port or 80
+    tokenizer = AutoTokenizer.from_pretrained(
+        str(args.model_path),
+        local_files_only=True,
+        trust_remote_code=True,
+    )
+
+    human_eval = _run_humaneval(
+        host=host,
+        port=port,
+        model=args.model,
+        tasks_path=args.humaneval_tasks,
+        limit=args.humaneval_limit,
+        timeout=args.timeout,
+    )
+    longbench = _run_longbench(
+        tokenizer=tokenizer,
+        host=host,
+        port=port,
+        model=args.model,
+        data_dir=args.longbench_data_dir,
+        longbench_root=args.longbench_root,
+        datasets=[
+            value.strip()
+            for value in args.longbench_datasets.split(",")
+            if value.strip()
+        ],
+        limit=args.longbench_limit,
+        max_input_tokens=args.longbench_max_input_tokens,
+        timeout=args.timeout,
+    )
+    passed = bool(
+        human_eval["passed"] >= args.min_humaneval_passes
+        and longbench["average_score"] is not None
+        and longbench["average_score"] >= args.min_longbench_average
+    )
+    result = {
+        "contract": {
+            key: str(value) if isinstance(value, Path) else value
+            for key, value in vars(args).items()
+        },
+        "human_eval": human_eval,
+        "longbench": longbench,
+        "passed": passed,
+    }
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    args.out.write_text(
+        json.dumps(result, ensure_ascii=False, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    print(
+        json.dumps(
+            {
+                "human_eval_passes": human_eval["passed"],
+                "human_eval_samples": human_eval["samples"],
+                "longbench_average": longbench["average_score"],
+                "passed": passed,
+            },
+            ensure_ascii=False,
+        ),
+        flush=True,
+    )
+    return 0 if passed else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmarks/benchmark_dsv4_quality_api.py
+++ b/benchmarks/benchmark_dsv4_quality_api.py
@@ -11,7 +11,6 @@ import hashlib
 import http.client
 import json
 import os
-import re
 import resource
 import statistics
 import subprocess
@@ -21,6 +20,7 @@ from pathlib import Path
 from typing import Any
 from urllib.parse import urlparse
 
+import regex as re
 from transformers import AutoTokenizer
 
 NO_CHAT_DATASETS = {"trec", "triviaqa", "samsum", "lsht", "lcc", "repobench-p"}

--- a/benchmarks/benchmark_dsv4_quality_api.py
+++ b/benchmarks/benchmark_dsv4_quality_api.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 import argparse
 import ctypes
 import functools
+import hashlib
 import http.client
 import json
 import os
@@ -23,6 +24,14 @@ from urllib.parse import urlparse
 from transformers import AutoTokenizer
 
 NO_CHAT_DATASETS = {"trec", "triviaqa", "samsum", "lsht", "lcc", "repobench-p"}
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as source:
+        for chunk in iter(lambda: source.read(1 << 20), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
 
 
 def _post_json(
@@ -403,13 +412,15 @@ def _run_longbench(
 
     by_dataset: dict[str, Any] = {}
     for dataset in datasets:
-        rows = [
-            json.loads(line)
-            for line in (data_dir / f"{dataset}.jsonl")
-            .read_text(encoding="utf-8")
-            .splitlines()
-            if line.strip()
-        ]
+        rows = []
+        for source_index, line in enumerate(
+            (data_dir / f"{dataset}.jsonl").read_text(encoding="utf-8").splitlines()
+        ):
+            if not line.strip():
+                continue
+            row = json.loads(line)
+            row["_source_index"] = source_index
+            rows.append(row)
         selected = _select_longbench_rows(rows, limit)
         records: list[dict[str, Any]] = []
         for row in selected:
@@ -445,6 +456,7 @@ def _run_longbench(
             )
             records.append(
                 {
+                    "source_index": row["_source_index"],
                     "length": row.get("length"),
                     "score": score,
                     "prediction": prediction,
@@ -515,6 +527,31 @@ def main() -> int:
         trust_remote_code=True,
     )
 
+    datasets = [
+        value.strip() for value in args.longbench_datasets.split(",") if value.strip()
+    ]
+    input_manifest = {
+        "humaneval_tasks": {
+            "path": str(args.humaneval_tasks),
+            "sha256": _sha256(args.humaneval_tasks),
+        },
+        "longbench_prompt_config": {
+            "path": str(args.longbench_root / "config/dataset2prompt.json"),
+            "sha256": _sha256(args.longbench_root / "config/dataset2prompt.json"),
+        },
+        "longbench_maxlen_config": {
+            "path": str(args.longbench_root / "config/dataset2maxlen.json"),
+            "sha256": _sha256(args.longbench_root / "config/dataset2maxlen.json"),
+        },
+        "longbench_datasets": {
+            dataset: {
+                "path": str(args.longbench_data_dir / f"{dataset}.jsonl"),
+                "sha256": _sha256(args.longbench_data_dir / f"{dataset}.jsonl"),
+            }
+            for dataset in datasets
+        },
+    }
+
     human_eval = _run_humaneval(
         host=host,
         port=port,
@@ -530,11 +567,7 @@ def main() -> int:
         model=args.model,
         data_dir=args.longbench_data_dir,
         longbench_root=args.longbench_root,
-        datasets=[
-            value.strip()
-            for value in args.longbench_datasets.split(",")
-            if value.strip()
-        ],
+        datasets=datasets,
         limit=args.longbench_limit,
         max_input_tokens=args.longbench_max_input_tokens,
         timeout=args.timeout,
@@ -549,6 +582,7 @@ def main() -> int:
             key: str(value) if isinstance(value, Path) else value
             for key, value in vars(args).items()
         },
+        "input_manifest": input_manifest,
         "human_eval": human_eval,
         "longbench": longbench,
         "passed": passed,

--- a/benchmarks/benchmark_sm70_mxfp4_moe_active_experts.py
+++ b/benchmarks/benchmark_sm70_mxfp4_moe_active_experts.py
@@ -670,11 +670,19 @@ def benchmark_verifier_m8_pipeline(
     dense = make_buffers()
     active = make_buffers()
     grouped = make_buffers()
+    expert_grouped = make_buffers()
 
     def pipeline_call(
-        buffers: dict[str, torch.Tensor], *, active_only: bool, grouped_m8: bool
+        buffers: dict[str, torch.Tensor],
+        *,
+        active_only: bool,
+        grouped_m8: bool,
+        expert_rows: bool = False,
     ) -> None:
         os.environ["VLLM_SM70_MXFP4_MOE_GROUPED_M8"] = "1" if grouped_m8 else "0"
+        os.environ["VLLM_SM70_MXFP4_MOE_GROUPED_M8_EXPERT_ROWS"] = (
+            "1" if expert_rows else "0"
+        )
         buffers["output"].zero_()
         buffers["topk_ids_i32"].copy_(topk_ids)
         buffers["permuted_idx"].fill_(total_slots)
@@ -699,7 +707,15 @@ def benchmark_verifier_m8_pipeline(
         if active_only:
             stage_offsets = buffers["compact_offsets"]
             if grouped_m8:
-                stage_expert_ids = buffers["permuted_experts_id"]
+                if expert_rows:
+                    _compact_mxfp4_active_experts(
+                        buffers["permuted_experts_id"],
+                        buffers["compact_offsets"],
+                        buffers["active_expert_ids"],
+                    )
+                    stage_expert_ids = buffers["active_expert_ids"]
+                else:
+                    stage_expert_ids = buffers["permuted_experts_id"]
             else:
                 _compact_mxfp4_active_experts(
                     buffers["permuted_experts_id"],
@@ -757,12 +773,24 @@ def benchmark_verifier_m8_pipeline(
     def grouped_call() -> None:
         pipeline_call(grouped, active_only=True, grouped_m8=True)
 
+    def expert_grouped_call() -> None:
+        pipeline_call(
+            expert_grouped,
+            active_only=True,
+            grouped_m8=True,
+            expert_rows=True,
+        )
+
     dense_call()
     active_call()
     grouped_call()
+    expert_grouped_call()
     torch.accelerator.synchronize()
     initial_equal = torch.equal(dense["output"], active["output"])
     grouped_initial_equal = torch.equal(dense["output"], grouped["output"])
+    expert_grouped_initial_equal = torch.equal(
+        dense["output"], expert_grouped["output"]
+    )
     stage_parity = {
         name: torch.equal(dense[name], active[name])
         for name in ("gate_up", "intermediate", "sorted_output", "output")
@@ -771,12 +799,24 @@ def benchmark_verifier_m8_pipeline(
         name: torch.equal(dense[name], grouped[name])
         for name in ("gate_up", "intermediate", "sorted_output", "output")
     }
+    expert_grouped_stage_parity = {
+        name: torch.equal(dense[name], expert_grouped[name])
+        for name in ("gate_up", "intermediate", "sorted_output", "output")
+    }
     grouped_stage_max_abs = {
         name: float((dense[name] - grouped[name]).abs().max().item())
         for name in ("gate_up", "intermediate", "sorted_output", "output")
     }
+    expert_grouped_stage_max_abs = {
+        name: float((dense[name] - expert_grouped[name]).abs().max().item())
+        for name in ("gate_up", "intermediate", "sorted_output", "output")
+    }
     grouped_stages_finite = all(
         bool(torch.isfinite(grouped[name]).all().item())
+        for name in ("gate_up", "intermediate", "sorted_output", "output")
+    )
+    expert_grouped_stages_finite = all(
+        bool(torch.isfinite(expert_grouped[name]).all().item())
         for name in ("gate_up", "intermediate", "sorted_output", "output")
     )
     expected_active_ids = sorted({expert for row in route_a for expert in row})
@@ -786,14 +826,17 @@ def benchmark_verifier_m8_pipeline(
     dense_graph = _capture(dense_call)
     active_graph = _capture(active_call)
     grouped_graph = _capture(grouped_call)
+    expert_grouped_graph = _capture(expert_grouped_call)
     dense_ms = _time_graph(dense_graph, repeats)
     active_ms = _time_graph(active_graph, repeats)
     grouped_ms = _time_graph(grouped_graph, repeats)
+    expert_grouped_ms = _time_graph(expert_grouped_graph, repeats)
 
     topk_ids.copy_(torch.tensor(route_b, dtype=torch.int32, device=device))
     dense_graph.replay()
     active_graph.replay()
     grouped_graph.replay()
+    expert_grouped_graph.replay()
     torch.accelerator.synchronize()
     replay_equal = torch.equal(dense["output"], active["output"])
     replay_max_abs = float((dense["output"] - active["output"]).abs().max().item())
@@ -801,12 +844,21 @@ def benchmark_verifier_m8_pipeline(
     grouped_replay_max_abs = float(
         (dense["output"] - grouped["output"]).abs().max().item()
     )
+    expert_grouped_replay_equal = torch.equal(dense["output"], expert_grouped["output"])
+    expert_grouped_replay_max_abs = float(
+        (dense["output"] - expert_grouped["output"]).abs().max().item()
+    )
     route_b_output = grouped["output"].clone()
+    expert_grouped_route_b_output = expert_grouped["output"].clone()
 
     topk_ids.copy_(torch.tensor(route_a, dtype=torch.int32, device=device))
     grouped_graph.replay()
+    expert_grouped_graph.replay()
     torch.accelerator.synchronize()
     route_changes_output = not torch.equal(grouped["output"], route_b_output)
+    expert_grouped_route_changes_output = not torch.equal(
+        expert_grouped["output"], expert_grouped_route_b_output
+    )
 
     result = {
         "route_case": route_case,
@@ -819,22 +871,37 @@ def benchmark_verifier_m8_pipeline(
         "dense_graph_ms": dense_ms,
         "active_graph_ms": active_ms,
         "grouped_graph_ms": grouped_ms,
+        "expert_grouped_graph_ms": expert_grouped_ms,
         "speedup": dense_ms / active_ms,
         "grouped_vs_active_speedup": active_ms / grouped_ms,
+        "expert_grouped_vs_slot_grouped_speedup": grouped_ms / expert_grouped_ms,
+        "expert_grouped_projected_savings_ms_per_43_layers": (
+            grouped_ms - expert_grouped_ms
+        )
+        * 43,
         "grouped_projected_savings_ms_per_43_layers": (active_ms - grouped_ms) * 43,
         "projected_savings_ms_per_43_layers": (dense_ms - active_ms) * 43,
         "initial_bitwise_equal": initial_equal,
         "grouped_initial_bitwise_equal": grouped_initial_equal,
+        "expert_grouped_initial_bitwise_equal": expert_grouped_initial_equal,
         "initial_stage_bitwise_equal": stage_parity,
         "grouped_initial_stage_bitwise_equal": grouped_stage_parity,
+        "expert_grouped_initial_stage_bitwise_equal": expert_grouped_stage_parity,
         "grouped_initial_stage_max_abs": grouped_stage_max_abs,
+        "expert_grouped_initial_stage_max_abs": expert_grouped_stage_max_abs,
         "grouped_stages_finite": grouped_stages_finite,
+        "expert_grouped_stages_finite": expert_grouped_stages_finite,
         "compact_ids_match": compact_ids_match,
         "dynamic_replay_bitwise_equal": replay_equal,
         "dynamic_replay_max_abs": replay_max_abs,
         "grouped_dynamic_replay_bitwise_equal": grouped_replay_equal,
         "grouped_dynamic_replay_max_abs": grouped_replay_max_abs,
+        "expert_grouped_dynamic_replay_bitwise_equal": expert_grouped_replay_equal,
+        "expert_grouped_dynamic_replay_max_abs": expert_grouped_replay_max_abs,
         "dynamic_route_changes_output": route_changes_output,
+        "expert_grouped_dynamic_route_changes_output": (
+            expert_grouped_route_changes_output
+        ),
     }
     base_gate_passed = (
         initial_equal
@@ -843,6 +910,8 @@ def benchmark_verifier_m8_pipeline(
         and replay_equal
         and route_changes_output
         and grouped_stages_finite
+        and expert_grouped_stages_finite
+        and expert_grouped_route_changes_output
     )
     grouped_bitwise_gate_passed = (
         grouped_initial_equal
@@ -1002,7 +1071,7 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument(
         "--route-case",
-        choices=("mixed", "unique48", "hot6"),
+        choices=("mixed", "unique48", "hot6", "all"),
         default="mixed",
         help="Verifier M8 expert-overlap distribution.",
     )
@@ -1023,15 +1092,23 @@ def main() -> int:
     args = parse_args()
     _require_sm70()
     if args.verifier_m8_pipeline:
-        result = benchmark_verifier_m8_pipeline(
-            num_experts=args.num_experts,
-            top_k=args.top_k,
-            repeats=args.repeats,
-            seed=args.seed,
-            route_case=args.route_case,
-            input_scale=args.input_scale,
-            require_grouped_bitwise=not args.allow_grouped_numeric_drift,
+        route_cases = (
+            ("mixed", "unique48", "hot6")
+            if args.route_case == "all"
+            else (args.route_case,)
         )
+        result = {
+            route_case: benchmark_verifier_m8_pipeline(
+                num_experts=args.num_experts,
+                top_k=args.top_k,
+                repeats=args.repeats,
+                seed=args.seed + index,
+                route_case=route_case,
+                input_scale=args.input_scale,
+                require_grouped_bitwise=not args.allow_grouped_numeric_drift,
+            )
+            for index, route_case in enumerate(route_cases)
+        }
         print(
             json.dumps(
                 {

--- a/benchmarks/benchmark_sm70_mxfp4_moe_active_experts.py
+++ b/benchmarks/benchmark_sm70_mxfp4_moe_active_experts.py
@@ -557,16 +557,19 @@ def benchmark_verifier_m8_pipeline(
     *,
     num_experts: int,
     top_k: int,
+    verifier_tokens: int,
     repeats: int,
     seed: int,
     route_case: str = "mixed",
     input_scale: float = 0.01,
     require_grouped_bitwise: bool = True,
 ) -> dict[str, object]:
-    """Compare dense-256, active-48 loop, and grouped verifier pipelines."""
-    num_tokens = 8
+    """Compare dense, active-loop, and grouped verifier pipelines."""
+    num_tokens = int(verifier_tokens)
     if num_experts != 256 or top_k != 6:
         raise ValueError("The verifier benchmark requires 256 experts/top-k=6")
+    if not 2 <= num_tokens <= 8:
+        raise ValueError("The verifier benchmark requires M in [2, 8]")
 
     torch.manual_seed(seed)
     device = torch.device("cuda")
@@ -676,10 +679,13 @@ def benchmark_verifier_m8_pipeline(
         buffers: dict[str, torch.Tensor],
         *,
         active_only: bool,
-        grouped_m8: bool,
+        grouped_verifier: bool,
         expert_rows: bool = False,
     ) -> None:
-        os.environ["VLLM_SM70_MXFP4_MOE_GROUPED_M8"] = "1" if grouped_m8 else "0"
+        os.environ["VLLM_SM70_MXFP4_MOE_GROUPED_M8"] = "0"
+        os.environ["VLLM_SM70_MXFP4_MOE_GROUPED_VERIFIER"] = (
+            "1" if grouped_verifier else "0"
+        )
         os.environ["VLLM_SM70_MXFP4_MOE_GROUPED_M8_EXPERT_ROWS"] = (
             "1" if expert_rows else "0"
         )
@@ -706,7 +712,7 @@ def benchmark_verifier_m8_pipeline(
         buffers["expert_offsets"].copy_(buffers["expert_offsets64"])
         if active_only:
             stage_offsets = buffers["compact_offsets"]
-            if grouped_m8:
+            if grouped_verifier:
                 if expert_rows:
                     _compact_mxfp4_active_experts(
                         buffers["permuted_experts_id"],
@@ -765,19 +771,19 @@ def benchmark_verifier_m8_pipeline(
         )
 
     def dense_call() -> None:
-        pipeline_call(dense, active_only=False, grouped_m8=False)
+        pipeline_call(dense, active_only=False, grouped_verifier=False)
 
     def active_call() -> None:
-        pipeline_call(active, active_only=True, grouped_m8=False)
+        pipeline_call(active, active_only=True, grouped_verifier=False)
 
     def grouped_call() -> None:
-        pipeline_call(grouped, active_only=True, grouped_m8=True)
+        pipeline_call(grouped, active_only=True, grouped_verifier=True)
 
     def expert_grouped_call() -> None:
         pipeline_call(
             expert_grouped,
             active_only=True,
-            grouped_m8=True,
+            grouped_verifier=True,
             expert_rows=True,
         )
 
@@ -923,7 +929,7 @@ def benchmark_verifier_m8_pipeline(
     if not base_gate_passed or (
         require_grouped_bitwise and not grouped_bitwise_gate_passed
     ):
-        raise RuntimeError(f"MXFP4 verifier M8 correctness gate failed: {result}")
+        raise RuntimeError(f"MXFP4 verifier correctness gate failed: {result}")
     return result
 
 
@@ -1063,6 +1069,13 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--full-pipeline", action="store_true")
     parser.add_argument("--verifier-m8-pipeline", action="store_true")
     parser.add_argument(
+        "--verifier-tokens",
+        type=int,
+        choices=range(2, 9),
+        default=8,
+        help="Target verifier row count M for the grouped pipeline gate.",
+    )
+    parser.add_argument(
         "--allow-grouped-numeric-drift",
         action="store_true",
         help=(
@@ -1073,7 +1086,7 @@ def parse_args() -> argparse.Namespace:
         "--route-case",
         choices=("mixed", "unique48", "hot6", "all"),
         default="mixed",
-        help="Verifier M8 expert-overlap distribution.",
+        help="Verifier expert-overlap distribution.",
     )
     parser.add_argument(
         "--profile-active-once",
@@ -1101,6 +1114,7 @@ def main() -> int:
             route_case: benchmark_verifier_m8_pipeline(
                 num_experts=args.num_experts,
                 top_k=args.top_k,
+                verifier_tokens=args.verifier_tokens,
                 repeats=args.repeats,
                 seed=args.seed + index,
                 route_case=route_case,
@@ -1112,7 +1126,7 @@ def main() -> int:
         print(
             json.dumps(
                 {
-                    "benchmark": "sm70_mxfp4_moe_verifier_m8_pipeline",
+                    "benchmark": "sm70_mxfp4_moe_verifier_pipeline",
                     "device": torch.cuda.get_device_name(),
                     "result": result,
                 },

--- a/benchmarks/compare_dsv4_quality_results.py
+++ b/benchmarks/compare_dsv4_quality_results.py
@@ -1,0 +1,335 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Compare matched no-speculation and DSpark quality artifacts."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _load_jsonl(path: Path) -> list[dict[str, Any]]:
+    return [
+        json.loads(line)
+        for line in path.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+
+
+def _manifest_hashes(value: Any, prefix: str = "") -> dict[str, str]:
+    if not isinstance(value, dict):
+        return {}
+    if isinstance(value.get("sha256"), str):
+        return {prefix: value["sha256"]}
+    hashes: dict[str, str] = {}
+    for key, child in value.items():
+        child_prefix = f"{prefix}.{key}" if prefix else key
+        hashes.update(_manifest_hashes(child, child_prefix))
+    return hashes
+
+
+def _compare_humaneval(
+    reference: dict[str, Any], candidate: dict[str, Any]
+) -> dict[str, Any]:
+    reference_rows = {row["task_id"]: row for row in reference["human_eval"]["records"]}
+    candidate_rows = {row["task_id"]: row for row in candidate["human_eval"]["records"]}
+    common = sorted(reference_rows.keys() & candidate_rows.keys())
+    regressions = [
+        task_id
+        for task_id in common
+        if reference_rows[task_id]["passed"] and not candidate_rows[task_id]["passed"]
+    ]
+    improvements = [
+        task_id
+        for task_id in common
+        if not reference_rows[task_id]["passed"] and candidate_rows[task_id]["passed"]
+    ]
+    exact_responses = sum(
+        reference_rows[task_id].get("response")
+        == candidate_rows[task_id].get("response")
+        for task_id in common
+    )
+    reference_passed = int(reference["human_eval"]["passed"])
+    candidate_passed = int(candidate["human_eval"]["passed"])
+    missing = sorted(reference_rows.keys() ^ candidate_rows.keys())
+    return {
+        "reference_passed": reference_passed,
+        "candidate_passed": candidate_passed,
+        "samples": len(common),
+        "exact_response_matches": exact_responses,
+        "regressions": regressions,
+        "improvements": improvements,
+        "missing_or_extra_tasks": missing,
+        "passed": not regressions
+        and not missing
+        and candidate_passed >= reference_passed,
+    }
+
+
+def _compare_longbench(
+    reference: dict[str, Any],
+    candidate: dict[str, Any],
+    tolerance: float,
+) -> dict[str, Any]:
+    reference_sets = reference["longbench"]["datasets"]
+    candidate_sets = candidate["longbench"]["datasets"]
+    missing = sorted(reference_sets.keys() ^ candidate_sets.keys())
+    results: dict[str, Any] = {}
+    for dataset in sorted(reference_sets.keys() & candidate_sets.keys()):
+        reference_rows = {
+            int(row["source_index"]): row for row in reference_sets[dataset]["records"]
+        }
+        candidate_rows = {
+            int(row["source_index"]): row for row in candidate_sets[dataset]["records"]
+        }
+        common = sorted(reference_rows.keys() & candidate_rows.keys())
+        row_mismatch = sorted(reference_rows.keys() ^ candidate_rows.keys())
+        input_mismatch = [
+            index
+            for index in common
+            if reference_rows[index].get("answers")
+            != candidate_rows[index].get("answers")
+        ]
+        regressions = [
+            {
+                "source_index": index,
+                "reference_score": float(reference_rows[index]["score"]),
+                "candidate_score": float(candidate_rows[index]["score"]),
+            }
+            for index in common
+            if float(candidate_rows[index]["score"]) + tolerance
+            < float(reference_rows[index]["score"])
+        ]
+        exact_predictions = sum(
+            reference_rows[index].get("prediction")
+            == candidate_rows[index].get("prediction")
+            for index in common
+        )
+        reference_score = float(reference_sets[dataset]["score"])
+        candidate_score = float(candidate_sets[dataset]["score"])
+        results[dataset] = {
+            "reference_score": reference_score,
+            "candidate_score": candidate_score,
+            "samples": len(common),
+            "exact_prediction_matches": exact_predictions,
+            "regressions": regressions,
+            "missing_or_extra_rows": row_mismatch,
+            "input_mismatches": input_mismatch,
+            "passed": not regressions
+            and not row_mismatch
+            and not input_mismatch
+            and candidate_score + tolerance >= reference_score,
+        }
+    reference_average = float(reference["longbench"]["average_score"])
+    candidate_average = float(candidate["longbench"]["average_score"])
+    return {
+        "reference_average": reference_average,
+        "candidate_average": candidate_average,
+        "score_tolerance": tolerance,
+        "datasets": results,
+        "missing_or_extra_datasets": missing,
+        "passed": not missing
+        and all(result["passed"] for result in results.values())
+        and candidate_average + tolerance >= reference_average,
+    }
+
+
+def _compare_api_quality(
+    reference: dict[str, Any],
+    candidate: dict[str, Any],
+    tolerance: float,
+) -> dict[str, Any]:
+    reference_hashes = _manifest_hashes(reference.get("input_manifest", {}))
+    candidate_hashes = _manifest_hashes(candidate.get("input_manifest", {}))
+    manifest_equal = bool(reference_hashes) and reference_hashes == candidate_hashes
+    humaneval = _compare_humaneval(reference, candidate)
+    longbench = _compare_longbench(reference, candidate, tolerance)
+    return {
+        "input_hashes_equal": manifest_equal,
+        "reference_input_hashes": reference_hashes,
+        "candidate_input_hashes": candidate_hashes,
+        "humaneval": humaneval,
+        "longbench": longbench,
+        "passed": manifest_equal and humaneval["passed"] and longbench["passed"],
+    }
+
+
+def _compare_gsm8k(
+    reference: dict[str, Any], candidate: dict[str, Any]
+) -> dict[str, Any]:
+    reference_rows = {int(row["index"]): row for row in reference["rows"]}
+    candidate_rows = {int(row["index"]): row for row in candidate["rows"]}
+    common = sorted(reference_rows.keys() & candidate_rows.keys())
+    missing = sorted(reference_rows.keys() ^ candidate_rows.keys())
+    input_mismatch = [
+        index
+        for index in common
+        if (
+            reference_rows[index].get("question"),
+            reference_rows[index].get("expected"),
+        )
+        != (
+            candidate_rows[index].get("question"),
+            candidate_rows[index].get("expected"),
+        )
+    ]
+    regressions = [
+        index
+        for index in common
+        if reference_rows[index]["correct"] and not candidate_rows[index]["correct"]
+    ]
+    exact_predictions = sum(
+        reference_rows[index].get("predicted") == candidate_rows[index].get("predicted")
+        for index in common
+    )
+    return {
+        "reference_correct": int(reference["correct"]),
+        "candidate_correct": int(candidate["correct"]),
+        "reference_invalid": int(reference["invalid"]),
+        "candidate_invalid": int(candidate["invalid"]),
+        "samples": len(common),
+        "exact_prediction_matches": exact_predictions,
+        "regressions": regressions,
+        "missing_or_extra_rows": missing,
+        "input_mismatches": input_mismatch,
+        "passed": not regressions
+        and not missing
+        and not input_mismatch
+        and int(candidate["correct"]) >= int(reference["correct"])
+        and int(candidate["invalid"]) <= int(reference["invalid"]),
+    }
+
+
+def _compare_needle(
+    reference: list[dict[str, Any]], candidate: list[dict[str, Any]]
+) -> dict[str, Any]:
+    reference_rows = {row["sample_id"]: row for row in reference}
+    candidate_rows = {row["sample_id"]: row for row in candidate}
+    common = sorted(reference_rows.keys() & candidate_rows.keys())
+    missing = sorted(reference_rows.keys() ^ candidate_rows.keys())
+    input_mismatch = [
+        sample_id
+        for sample_id in common
+        if (
+            reference_rows[sample_id].get("target_tokens"),
+            reference_rows[sample_id].get("depth"),
+            reference_rows[sample_id].get("code"),
+        )
+        != (
+            candidate_rows[sample_id].get("target_tokens"),
+            candidate_rows[sample_id].get("depth"),
+            candidate_rows[sample_id].get("code"),
+        )
+    ]
+    final_regressions = [
+        sample_id
+        for sample_id in common
+        if reference_rows[sample_id]["hit"] and not candidate_rows[sample_id]["hit"]
+    ]
+    anywhere_regressions = [
+        sample_id
+        for sample_id in common
+        if reference_rows[sample_id]["hit_anywhere"]
+        and not candidate_rows[sample_id]["hit_anywhere"]
+    ]
+    reference_hits = sum(bool(row["hit"]) for row in reference_rows.values())
+    candidate_hits = sum(bool(row["hit"]) for row in candidate_rows.values())
+    reference_anywhere = sum(
+        bool(row["hit_anywhere"]) for row in reference_rows.values()
+    )
+    candidate_anywhere = sum(
+        bool(row["hit_anywhere"]) for row in candidate_rows.values()
+    )
+    return {
+        "reference_final_hits": reference_hits,
+        "candidate_final_hits": candidate_hits,
+        "reference_anywhere_hits": reference_anywhere,
+        "candidate_anywhere_hits": candidate_anywhere,
+        "samples": len(common),
+        "final_hit_regressions": final_regressions,
+        "anywhere_hit_regressions": anywhere_regressions,
+        "missing_or_extra_rows": missing,
+        "input_mismatches": input_mismatch,
+        "passed": not final_regressions
+        and not anywhere_regressions
+        and not missing
+        and not input_mismatch
+        and candidate_hits >= reference_hits
+        and candidate_anywhere >= reference_anywhere,
+    }
+
+
+def _paired_paths(
+    parser: argparse.ArgumentParser,
+    reference: Path | None,
+    candidate: Path | None,
+    label: str,
+) -> bool:
+    if (reference is None) != (candidate is None):
+        parser.error(f"--reference-{label} and --candidate-{label} must be paired")
+    return reference is not None
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--reference-api", type=Path, required=True)
+    parser.add_argument("--candidate-api", type=Path, required=True)
+    parser.add_argument("--reference-gsm8k", type=Path)
+    parser.add_argument("--candidate-gsm8k", type=Path)
+    parser.add_argument("--reference-needle", type=Path)
+    parser.add_argument("--candidate-needle", type=Path)
+    parser.add_argument("--longbench-score-tolerance", type=float, default=0.0)
+    parser.add_argument("--out", type=Path, required=True)
+    args = parser.parse_args()
+    if args.longbench_score_tolerance < 0:
+        parser.error("--longbench-score-tolerance must be non-negative")
+
+    has_gsm8k = _paired_paths(
+        parser, args.reference_gsm8k, args.candidate_gsm8k, "gsm8k"
+    )
+    has_needle = _paired_paths(
+        parser, args.reference_needle, args.candidate_needle, "needle"
+    )
+    api = _compare_api_quality(
+        _load_json(args.reference_api),
+        _load_json(args.candidate_api),
+        args.longbench_score_tolerance,
+    )
+    result: dict[str, Any] = {
+        "contract": {
+            key: str(value) if isinstance(value, Path) else value
+            for key, value in vars(args).items()
+        },
+        "api_quality": api,
+    }
+    gates = [api["passed"]]
+    if has_gsm8k:
+        assert args.reference_gsm8k is not None and args.candidate_gsm8k is not None
+        result["gsm8k"] = _compare_gsm8k(
+            _load_json(args.reference_gsm8k), _load_json(args.candidate_gsm8k)
+        )
+        gates.append(result["gsm8k"]["passed"])
+    if has_needle:
+        assert args.reference_needle is not None and args.candidate_needle is not None
+        result["needle"] = _compare_needle(
+            _load_jsonl(args.reference_needle), _load_jsonl(args.candidate_needle)
+        )
+        gates.append(result["needle"]["passed"])
+    result["passed"] = all(gates)
+
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    args.out.write_text(
+        json.dumps(result, ensure_ascii=False, indent=2) + "\n", encoding="utf-8"
+    )
+    print(json.dumps(result, ensure_ascii=False), flush=True)
+    return 0 if result["passed"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/csrc/sm70_turbomind/ops/awq_sm70_gemm.cu
+++ b/csrc/sm70_turbomind/ops/awq_sm70_gemm.cu
@@ -1082,6 +1082,12 @@ bool mxfp4_moe_grouped_m8_enabled() {
   return raw != nullptr && std::atoi(raw) != 0;
 }
 
+bool mxfp4_moe_grouped_m8_expert_rows_enabled() {
+  const char* raw =
+      std::getenv("VLLM_SM70_MXFP4_MOE_GROUPED_M8_EXPERT_ROWS");
+  return raw != nullptr && std::atoi(raw) != 0;
+}
+
 bool mxfp4_moe_grouped_m8_fast_selector_enabled() {
   const char* raw = std::getenv("VLLM_SM70_MXFP4_MOE_GROUPED_M8_FAST_SELECTOR");
   return raw == nullptr || std::atoi(raw) != 0;
@@ -1395,6 +1401,7 @@ turbomind::gemm::DispatchPolicy select_mxfp4_moe_dispatch_policy(
       total_tokens == 48 && num_experts == 48 && group_size == 32 &&
       ((n == 512 && k == 4096) || (n == 4096 && k == 256));
   if (mxfp4_moe_grouped_m8_enabled() &&
+      !mxfp4_moe_grouped_m8_expert_rows_enabled() &&
       mxfp4_moe_grouped_m8_fast_selector_enabled() && exact_grouped_m8) {
     return turbomind::gemm::DispatchPolicy::kMxfp4MoeGroupedM8Fast;
   }
@@ -8197,8 +8204,18 @@ void mxfp4_moe_gemm_sm70_out_impl(
   op.quant_b = {turbomind::gemm::QuantType::kK, static_cast<int>(group_size)};
   op.batch_dim = 0;
   op.dispatch_num_override = compact_grouped_rows ? 1 : 0;
+  const bool dynamic_expert_rows =
+      compact_grouped_rows && num_experts == 48 &&
+      vllm::awq_sm70::mxfp4_moe_grouped_m8_expert_rows_enabled();
+  // The negative active-group contract is valid only when every group owns
+  // exactly one row (for example compact B1/top-6 and slot-grouped M8). Real
+  // expert segments can contain multiple rows and have graph-dynamic empty
+  // tails, so retain the single-group dispatch choice while letting the
+  // standard offsets scheduler discover their bounds on device.
   op.active_group_count =
-      compact_grouped_rows ? -static_cast<int>(num_experts) : 0;
+      compact_grouped_rows && !dynamic_expert_rows
+          ? -static_cast<int>(num_experts)
+          : 0;
 
   auto& workspace_holder = vllm::awq_sm70::get_workspace(device, stream);
   auto& gemm = vllm::awq_sm70::get_gemm(device);

--- a/csrc/sm70_turbomind/ops/awq_sm70_gemm.cu
+++ b/csrc/sm70_turbomind/ops/awq_sm70_gemm.cu
@@ -1082,6 +1082,12 @@ bool mxfp4_moe_grouped_m8_enabled() {
   return raw != nullptr && std::atoi(raw) != 0;
 }
 
+bool mxfp4_moe_grouped_verifier_enabled() {
+  const char* raw =
+      std::getenv("VLLM_SM70_MXFP4_MOE_GROUPED_VERIFIER");
+  return raw != nullptr && std::atoi(raw) != 0;
+}
+
 bool mxfp4_moe_grouped_m8_expert_rows_enabled() {
   const char* raw =
       std::getenv("VLLM_SM70_MXFP4_MOE_GROUPED_M8_EXPERT_ROWS");
@@ -8205,7 +8211,8 @@ void mxfp4_moe_gemm_sm70_out_impl(
   op.batch_dim = 0;
   op.dispatch_num_override = compact_grouped_rows ? 1 : 0;
   const bool dynamic_expert_rows =
-      compact_grouped_rows && num_experts == 48 &&
+      compact_grouped_rows && num_experts >= 12 && num_experts <= 48 &&
+      num_experts % 6 == 0 &&
       vllm::awq_sm70::mxfp4_moe_grouped_m8_expert_rows_enabled();
   // The negative active-group contract is valid only when every group owns
   // exactly one row (for example compact B1/top-6 and slot-grouped M8). Real
@@ -8285,7 +8292,13 @@ void mxfp4_moe_dense_stage_sm70_out(torch::Tensor out, torch::Tensor input,
   const bool grouped_m8_shape =
       input.size(0) == 48 && num_experts == 48 &&
       ((k == 4096 && n == 512) || (k == 256 && n == 4096));
-  if (vllm::awq_sm70::mxfp4_moe_grouped_m8_enabled() && grouped_m8_shape) {
+  const bool grouped_verifier_shape =
+      input.size(0) == num_experts && num_experts >= 12 &&
+      num_experts <= 48 && num_experts % 6 == 0 &&
+      ((k == 4096 && n == 512) || (k == 256 && n == 4096));
+  if ((vllm::awq_sm70::mxfp4_moe_grouped_m8_enabled() && grouped_m8_shape) ||
+      (vllm::awq_sm70::mxfp4_moe_grouped_verifier_enabled() &&
+       grouped_verifier_shape)) {
     // Keep every routed slot as an independent one-row group. Repeated experts
     // reuse the same weight pointer row, while the scheduler retains the exact
     // arithmetic contract already accepted for compact B1 decode.

--- a/csrc/sm70_turbomind/ops/awq_sm70_gemm.cu
+++ b/csrc/sm70_turbomind/ops/awq_sm70_gemm.cu
@@ -1083,14 +1083,12 @@ bool mxfp4_moe_grouped_m8_enabled() {
 }
 
 bool mxfp4_moe_grouped_verifier_enabled() {
-  const char* raw =
-      std::getenv("VLLM_SM70_MXFP4_MOE_GROUPED_VERIFIER");
+  const char* raw = std::getenv("VLLM_SM70_MXFP4_MOE_GROUPED_VERIFIER");
   return raw != nullptr && std::atoi(raw) != 0;
 }
 
 bool mxfp4_moe_grouped_m8_expert_rows_enabled() {
-  const char* raw =
-      std::getenv("VLLM_SM70_MXFP4_MOE_GROUPED_M8_EXPERT_ROWS");
+  const char* raw = std::getenv("VLLM_SM70_MXFP4_MOE_GROUPED_M8_EXPERT_ROWS");
   return raw != nullptr && std::atoi(raw) != 0;
 }
 
@@ -8219,10 +8217,9 @@ void mxfp4_moe_gemm_sm70_out_impl(
   // expert segments can contain multiple rows and have graph-dynamic empty
   // tails, so retain the single-group dispatch choice while letting the
   // standard offsets scheduler discover their bounds on device.
-  op.active_group_count =
-      compact_grouped_rows && !dynamic_expert_rows
-          ? -static_cast<int>(num_experts)
-          : 0;
+  op.active_group_count = compact_grouped_rows && !dynamic_expert_rows
+                              ? -static_cast<int>(num_experts)
+                              : 0;
 
   auto& workspace_holder = vllm::awq_sm70::get_workspace(device, stream);
   auto& gemm = vllm::awq_sm70::get_gemm(device);
@@ -8293,8 +8290,8 @@ void mxfp4_moe_dense_stage_sm70_out(torch::Tensor out, torch::Tensor input,
       input.size(0) == 48 && num_experts == 48 &&
       ((k == 4096 && n == 512) || (k == 256 && n == 4096));
   const bool grouped_verifier_shape =
-      input.size(0) == num_experts && num_experts >= 12 &&
-      num_experts <= 48 && num_experts % 6 == 0 &&
+      input.size(0) == num_experts && num_experts >= 12 && num_experts <= 48 &&
+      num_experts % 6 == 0 &&
       ((k == 4096 && n == 512) || (k == 256 && n == 4096));
   if ((vllm::awq_sm70::mxfp4_moe_grouped_m8_enabled() && grouped_m8_shape) ||
       (vllm::awq_sm70::mxfp4_moe_grouped_verifier_enabled() &&

--- a/docs/design/sm70_deepseek_v4_dspark_n7_latest_main.md
+++ b/docs/design/sm70_deepseek_v4_dspark_n7_latest_main.md
@@ -307,6 +307,33 @@ scoped greedy output remains byte-identical to control, and the quality prompt
 stops naturally after 76 coherent tokens. All task-owned services were stopped
 after validation.
 
+## M=8 Real-Expert Grouping Candidate
+
+The fixed 48 one-row grouped verifier still reloads the same expert weights
+when adjacent verifier rows select an overlapping expert. A default-off
+candidate compacts those rows into the real expert segments already produced
+on device, while retaining a fixed 48-entry graph contract. Empty tail groups
+remain device-visible zero-row entries, so the route adds no host readback.
+TurboMind keeps the single-group dispatch tactic but uses its ordinary
+device-offset scheduler for the variable row bounds.
+
+An exclusively owned V100 CUDA Graph gate covered mixed overlap, 48 distinct
+experts, and six hot experts. W13, activation, sorted W2 output, final output,
+and changed-route replay were bitwise identical to the admitted slot-grouped
+route in every case:
+
+| M=8 route distribution | Slot-grouped | Real-expert grouped | 43-layer projection |
+|---|---:|---:|---:|
+| Mixed, 34 unique experts | 0.42345 ms | 0.30437 ms | -5.120 ms |
+| 48 unique experts | 0.42407 ms | 0.43113 ms | +0.304 ms |
+| Six experts with eight rows each | 0.42183 ms | 0.15401 ms | -11.516 ms |
+
+The source gate released its GPU after completion. The route remains behind
+`VLLM_SM70_MXFP4_MOE_GROUPED_M8_EXPERT_ROWS=1` until a synchronized TP8
+full-model profile proves that production routing overlap transfers the mixed
+microbenchmark saving and the paired acceptance/quality gates pass. Evidence
+is retained under `/data/models/dsv4-verifier-20ms-expert-grouped-m8-r2`.
+
 ## Experiment Log
 
 | Date | Source | Test | Result | Decision |
@@ -340,6 +367,7 @@ after validation.
 | 2026-08-03 | candidate | Exact-selector seeds 4210-4219 | TPOT 31.282 -> 25.533 ms; emitted/chunk +4.0% | Accept speed and acceptance gates |
 | 2026-08-03 | candidate | Greedy equality and natural stop | 256-token SHA256 equal; coherent 71-token stop | Accept quality gate and enable by default |
 | 2026-08-03 | candidate | Scoped-policy full-model smoke | Target 32.426 ms; matched emitted/chunk -0.23%; greedy equal; natural stop | Accept final scoped selector |
+| 2026-08-24 | candidate | Real-expert-grouped M=8 CUDA Graph gate | Three route distributions bitwise; mixed projects -5.120 ms/43 layers; distinct-48 projects +0.304 ms | Admit only to matched TP8 profile and quality gate |
 
 ## Artifacts
 

--- a/docs/design/sm70_deepseek_v4_dspark_verifier_20ms_long_context.md
+++ b/docs/design/sm70_deepseek_v4_dspark_verifier_20ms_long_context.md
@@ -1,0 +1,146 @@
+# SM70 DeepSeek V4 DSpark Verifier and Long-Context Ledger
+
+This ledger tracks the 2026-08-24 TP8/V100 campaign for
+`/data/models/DeepSeek-V4-Flash-0731`. It complements the historical N7 ledger
+and prevents short route-hit smokes from being reused as verifier, long-context,
+or quality evidence.
+
+## Acceptance Contract
+
+- Eight V100 GPUs, TP8, one request, DeepSeek V4 Flash DSpark with seven draft
+  tokens, temperature 1.0, top-p 1.0, and the production strict rejection
+  sampler.
+- Primary speed gate: at least 100 pure decode token/s on the pinned 120-token
+  Chinese HTML prompt with 3,500 generated tokens. TTFT and prefill are reported
+  separately.
+- Primary latency gate: complete verifier at most 20 ms per speculative round.
+  Complete verifier means target forward, target logits, and strict
+  rejection/sampling. Draft work, accepted-state commit, CPU scheduling, and
+  total round wall are reported separately rather than hidden in that number.
+- Long-context gate: report raw contexts 1K, 4K, 16K, 64K, 128K, and 252K with
+  identical output length and sampling. Report verifier/round cost, acceptance
+  by position, emitted tokens/round, and pure decode separately.
+- Quality gate: compare no-speculation and DSpark on deterministic GSM8K,
+  HumanEval, a multilingual/multitask LongBench subset, and 128K/252K needle
+  retrieval. A speed result cannot promote a route that loses the paired quality
+  or output-health gates.
+- Shared-machine rule: launch only after an event-driven free-GPU gate, never
+  stop unrelated owners, avoid frequent polling, and terminate every task-owned
+  worker after the artifact is complete.
+
+## Reproduced Baselines
+
+Current latest-main source plus the admitted SM70 route repairs reproduces the
+historical endpoint target. Three 3,500-token runs measured 118.481, 115.975,
+and 116.288 token/s; median throughput is 116.288 token/s. The third run
+accepted 2,816 of 4,781 proposed draft tokens (0.589), emitted 5.123 tokens per
+round, and had per-position unconditional acceptance
+`0.8873/0.7818/0.6911/0.6047/0.5066/0.3880/0.2635`.
+
+The matched no-speculation route measured 66.014 token/s and 15.1483 ms/token
+at 1,024 input plus 256 output tokens. A synchronized DSpark profile measured:
+
+| Component | Steady median per round |
+|---|---:|
+| Target forward, M=8 | 34.295 ms |
+| Target logits | 0.326 ms |
+| Strict rejection/sample | 0.499 ms |
+| Complete verifier | 35.120 ms |
+| Draft GPU work | 4.419 ms |
+| Total round wall | 43.505 ms |
+
+The 20 ms goal therefore requires target-forward work, not sampler-only tuning.
+
+## Admitted Source Gates
+
+The following changes have passed focused current-source gates but still require
+their stated end-to-end promotion gate:
+
+1. FP32 mHC staging now covers verifier rows M=1..8. M=8 falls from 0.05383 to
+   0.01257 ms per call and projects 3.507 ms saved across 85 calls. Four V100
+   numerical cases were bitwise exact.
+2. The M=8 graph derives a bounded 2,048-token short-context bucket instead of
+   reserving the whole maximum context. CPU dispatcher tests pass; synchronized
+   TP8 transfer remains required.
+3. Single-request SM70 compressor C4/C128 intermediates use bounded private
+   device rings when prefix caching, pipeline parallelism, KV transfer, and
+   parallel drafting are absent. Seven V100 ring/workspace tests and eleven CPU
+   route tests pass. This removes paged intermediate growth without changing the
+   sparse attention/index cache.
+4. The long-context C4 indexer gathers paged FP8 keys once and uses FP32 cuBLAS
+   scores for all M=8 rows and 64 heads. It retains per-head ReLU and FP8 scale
+   semantics. The captured-graph test, shorter dynamic replay, graph-tail mask,
+   and workspace-width gate pass on V100.
+
+The indexer crossover gate uses FP32 scores, signed head weights, top-k 512,
+M=8, H=64, D=128, and CUDA Graph replay:
+
+| Compressed keys | Fused paged Triton | Gather + FP32 cuBLAS | 21-layer projection |
+|---:|---:|---:|---:|
+| 1,024 | 0.06854 ms | 0.02096 ms | -0.999 ms |
+| 2,048 | 0.13455 ms | 0.02519 ms | -2.297 ms |
+| 4,096 | 0.23433 ms | 0.04738 ms | -3.926 ms |
+| 8,192 | 0.45660 ms | 0.07680 ms | -7.976 ms |
+| 16,384 | 0.85016 ms | 0.14493 ms | -14.810 ms |
+
+All 40 rows retained the exact top-k set; maximum logit absolute difference was
+`1.221e-4`. The default crossover is 1,024 compressed keys. Generic batches,
+noncontiguous inputs, more than eight rows, and non-ReLU semantics retain the
+existing fused paged kernel.
+
+SM70 DeepSeek V4 graph context buckets now follow raw widths 2K, 4K, 16K, 64K,
+and 128K when the model maximum is 256K. Longer requests retain the generic
+full-context graph. An explicit `VLLM_SM70_DSV4_DECODE_CONTEXT_BUCKETS`, or an
+explicit MTP bucket override including an empty value, remains authoritative.
+
+## Long-Context Diagnosis
+
+DeepSeek V4 does not use the repository's classic Flash-V100 dense-attention
+decode route. Its production log identifies packed-FP8 SM70 sparse MLA with C4,
+C128, SWA-128, and top-k 512. Sparse attention after selection is nearly fixed
+work; the C4 indexer scan grows with compressed history and was the expected
+linear decay source. The private compressor rings address capacity and memory
+growth, while gather-once FP32 cuBLAS addresses the repeated index scan.
+
+`benchmarks/benchmark_dsv4_dspark_long_context.py` records each completed
+context incrementally. It uses server-reported prompt usage, separates TTFT
+from pure decode, snapshots speculative counters around each request, and gates
+suffix-marker retrieval, replacement characters, token diversity, and repeated
+token runs.
+
+## Quality Gate
+
+`benchmarks/benchmark_dsv4_quality_api.py` provides deterministic HumanEval and
+LongBench-subset API gates. HumanEval code executes with Landlock filesystem
+isolation, seccomp network/process restrictions, a private temporary directory,
+and CPU, address-space, output-file, and process limits. The sandbox has proven
+that normal Python works while `/home`, `/data`, global `/tmp`, networking,
+forking, and signalling other processes are denied.
+
+The first paired LongBench subset is `hotpotqa`, `multifieldqa_zh`,
+`gov_report`, and `lcc`. Official LongBench metrics are loaded from the pinned
+local checkout; `jieba==0.42.1`, `rouge==1.0.1`, and `fuzzywuzzy==0.18.0` are
+isolated under `/data/models/dsv4-quality-deps` rather than installed into the
+shared runtime environment.
+
+## Rejected or Deferred Paths
+
+- A TP8 M=8 64 KiB hierarchical all-reduce was slower than NCCL in isolation
+  and saved only 0.028 ms across 87 joined calls, within noise. It was fully
+  reverted and must not be repeated without a different communication design.
+- The expert-row grouped MXFP4 candidate is tracked separately. Its bitwise
+  microbenchmarks justify a full TP8 trial but not promotion by themselves.
+- Disabling per-head ReLU, changing index-cache layout, reducing index top-k,
+  or weakening strict rejection are outside the quality contract.
+
+## Artifact Roots
+
+- 100+ endpoint: `/data/models/v100-dsv4-0731-tp8-dspark-prob-n7-latest-c4-20260824-r6`
+- no-speculation: `/data/models/v100-dsv4-0731-tp8-nospec-latest-c4-20260824-r1`
+- synchronized breakdown: `/data/models/v100-dsv4-0731-tp8-dspark-prob-n7-profile-latest-c4-20260824-r1`
+- mHC source gate: `/data/models/dsv4-verifier-20ms-mhc-source-gate-r2-cuda128`
+- private rings: `/data/models/dsv4-verifier-20ms-private-ring-source-gate-r1`
+- indexer crossover: `/data/models/dsv4-verifier-20ms-indexer-crossover-r3`
+- indexer source gate: `/data/models/dsv4-verifier-20ms-indexer-source-gate-r1`
+- rejected TP8 all-reduce: `/data/models/dsv4-verifier-20ms-tp8-ar-screen-r1`
+

--- a/docs/design/sm70_deepseek_v4_dspark_verifier_20ms_long_context.md
+++ b/docs/design/sm70_deepseek_v4_dspark_verifier_20ms_long_context.md
@@ -59,18 +59,21 @@ their stated end-to-end promotion gate:
 1. FP32 mHC staging now covers verifier rows M=1..8. M=8 falls from 0.05383 to
    0.01257 ms per call and projects 3.507 ms saved across 85 calls. Four V100
    numerical cases were bitwise exact.
-2. The M=8 graph derives a bounded 2,048-token short-context bucket instead of
-   reserving the whole maximum context. CPU dispatcher tests pass; synchronized
-   TP8 transfer remains required.
-3. Single-request SM70 compressor C4/C128 intermediates use bounded private
+2. The M=8 graph can use a bounded 2,048-token short-context bucket instead of
+   reserving the whole maximum context. Speculative buckets require an explicit
+   `VLLM_SM70_DSV4_DECODE_CONTEXT_BUCKETS`; CPU dispatcher tests pass, while the
+   synchronized TP8 transfer remains required.
+3. A default-off `VLLM_SM70_DSV4_PRIVATE_COMPRESSOR_STATE=1` route stores
+   single-request SM70 compressor C4/C128 intermediates in bounded private
    device rings when prefix caching, pipeline parallelism, KV transfer, and
    parallel drafting are absent. Seven V100 ring/workspace tests and eleven CPU
-   route tests pass. This removes paged intermediate growth without changing the
-   sparse attention/index cache.
-4. The long-context C4 indexer gathers paged FP8 keys once and uses FP32 cuBLAS
-   scores for all M=8 rows and 64 heads. It retains per-head ReLU and FP8 scale
-   semantics. The captured-graph test, shorter dynamic replay, graph-tail mask,
-   and workspace-width gate pass on V100.
+   route tests pass. It cannot become the default before the long-context
+   quality and capacity gates finish.
+4. A default-off `VLLM_SM70_INDEXER_DECODE_CUBLAS=1` route gathers long-context
+   paged FP8 keys once and uses FP32 cuBLAS scores for bounded row shapes. It
+   retains per-head ReLU and FP8 scale semantics. The captured-graph test,
+   shorter dynamic replay, graph-tail mask, and workspace-width gate pass on
+   V100; the incomplete long-context quality gate keeps it opt-in.
 
 5. A default-off `VLLM_SM70_MXFP4_MOE_GROUPED_VERIFIER=1` route extends the
    single-launch, one-row-per-slot MXFP4 contract from M=8 to M=2..M=8. This is
@@ -95,8 +98,11 @@ retained under `/data/models/dsv4-verifier-20ms-variable-grouped-r1`; the
 single V100 was released after the gate.
 
 The 0731 checkpoint declares an official DSpark block size of five and stores
-`mtp.2.confidence_head.proj.weight`. The current runtime explicitly discards
-that weight. DeepSpec computes conditional step probabilities with a sigmoid,
+`mtp.2.confidence_head.proj.weight`. The runtime instantiates and loads that
+optional head only for explicit confidence-threshold scheduling or alignment
+diagnostics and fails cleanly if a requested projection is absent. Ordinary
+serving performs no confidence projection. DeepSpec computes conditional step
+probabilities with a sigmoid,
 uses their cumulative product for prefix reliability reporting, and truncates
 at the first conditional probability below a threshold. Before production
 confidence scheduling, this runtime must first collect calibration data on the
@@ -117,7 +123,7 @@ M=8, H=64, D=128, and CUDA Graph replay:
 | 16,384 | 0.85016 ms | 0.14493 ms | -14.810 ms |
 
 All 40 rows retained the exact top-k set; maximum logit absolute difference was
-`1.221e-4`. The default crossover is 1,024 compressed keys. Generic batches,
+`1.221e-4`. The opt-in crossover is 1,024 compressed keys. Generic batches,
 noncontiguous inputs, more than eight rows, and non-ReLU semantics retain the
 existing fused paged kernel.
 
@@ -136,10 +142,13 @@ gate retained the exact top-k set in all 30 rows and measured:
 The maximum logit absolute difference was `1.221e-4`. The microbenchmark owner
 released its V100 immediately after writing the artifact.
 
-SM70 DeepSeek V4 graph context buckets now follow raw widths 2K, 4K, 16K, 64K,
-and 128K when the model maximum is 256K. Longer requests retain the generic
-full-context graph. An explicit `VLLM_SM70_DSV4_DECODE_CONTEXT_BUCKETS`, or an
-explicit MTP bucket override including an empty value, remains authoritative.
+The speculative SM70 graph context candidate uses explicit raw widths 2K, 4K,
+16K, 64K, and 128K when the maximum is 256K. Longer requests retain the generic
+full-context graph. `VLLM_SM70_DSV4_DECODE_CONTEXT_BUCKETS` is required to
+enable the candidate; an explicit MTP bucket override, including an empty
+value, remains authoritative. Automatic non-speculative selection uses only
+the compressed-index operator configuration and never architecture or
+checkpoint identity.
 
 ## Long-Context Diagnosis
 
@@ -147,8 +156,9 @@ DeepSeek V4 does not use the repository's classic Flash-V100 dense-attention
 decode route. Its production log identifies packed-FP8 SM70 sparse MLA with C4,
 C128, SWA-128, and top-k 512. Sparse attention after selection is nearly fixed
 work; the C4 indexer scan grows with compressed history and was the expected
-linear decay source. The private compressor rings address capacity and memory
-growth, while gather-once FP32 cuBLAS addresses the repeated index scan.
+linear decay source. The opt-in private compressor rings address capacity and
+memory growth, while opt-in gather-once FP32 cuBLAS addresses the repeated
+index scan.
 
 `benchmarks/benchmark_dsv4_dspark_long_context.py` records each completed
 context incrementally. It uses server-reported prompt usage, separates TTFT

--- a/docs/design/sm70_deepseek_v4_dspark_verifier_20ms_long_context.md
+++ b/docs/design/sm70_deepseek_v4_dspark_verifier_20ms_long_context.md
@@ -121,6 +121,21 @@ All 40 rows retained the exact top-k set; maximum logit absolute difference was
 noncontiguous inputs, more than eight rows, and non-ReLU semantics retain the
 existing fused paged kernel.
 
+The production block-size candidate verifies M=5 rows. Its matched crossover
+gate retained the exact top-k set in all 30 rows and measured:
+
+| Compressed keys | Fused paged Triton | Gather + FP32 cuBLAS | 21-layer projection |
+|---:|---:|---:|---:|
+| 1,024 | 0.03548 ms | 0.01905 ms | -0.345 ms |
+| 2,048 | 0.06881 ms | 0.02196 ms | -0.984 ms |
+| 4,096 | 0.13532 ms | 0.03410 ms | -2.126 ms |
+| 8,192 | 0.26614 ms | 0.05806 ms | -4.370 ms |
+| 16,384 | 0.58173 ms | 0.10066 ms | -10.103 ms |
+| 65,536 | 1.92835 ms | 0.32707 ms | -33.627 ms |
+
+The maximum logit absolute difference was `1.221e-4`. The microbenchmark owner
+released its V100 immediately after writing the artifact.
+
 SM70 DeepSeek V4 graph context buckets now follow raw widths 2K, 4K, 16K, 64K,
 and 128K when the model maximum is 256K. Longer requests retain the generic
 full-context graph. An explicit `VLLM_SM70_DSV4_DECODE_CONTEXT_BUCKETS`, or an
@@ -139,7 +154,12 @@ growth, while gather-once FP32 cuBLAS addresses the repeated index scan.
 context incrementally. It uses server-reported prompt usage, separates TTFT
 from pure decode, snapshots speculative counters around each request, and gates
 suffix-marker retrieval, replacement characters, token diversity, and repeated
-token runs.
+token runs. When given the TP0 server log it also records interior synchronized
+profiler windows for target forward, target logits, strict rejection/sampling,
+and their summed complete-verifier cost. The verifier row count and acceptance
+positions follow the configured speculative width instead of assuming N=7. A
+zero speculative width records the matched no-speculation long-context speed
+and output-health curve without fabricating verifier counters.
 
 ## Quality Gate
 
@@ -175,5 +195,6 @@ shared runtime environment.
 - private rings: `/data/models/dsv4-verifier-20ms-private-ring-source-gate-r1`
 - indexer crossover: `/data/models/dsv4-verifier-20ms-indexer-crossover-r3`
 - indexer source gate: `/data/models/dsv4-verifier-20ms-indexer-source-gate-r1`
+- M=5 indexer crossover: `/data/models/dsv4-verifier-20ms-indexer-m5-r1`
 - M=5/M=6 grouped verifier: `/data/models/dsv4-verifier-20ms-variable-grouped-r1`
 - rejected TP8 all-reduce: `/data/models/dsv4-verifier-20ms-tp8-ar-screen-r1`

--- a/docs/design/sm70_deepseek_v4_dspark_verifier_20ms_long_context.md
+++ b/docs/design/sm70_deepseek_v4_dspark_verifier_20ms_long_context.md
@@ -178,6 +178,10 @@ shared runtime environment. Every quality artifact includes SHA-256 hashes for
 the HumanEval tasks, LongBench prompt/max-length configs, and each selected
 dataset. LongBench records retain their source-row indices so the matched
 no-speculation and DSpark scores cannot silently use different samples.
+`benchmarks/compare_dsv4_quality_results.py` then rejects any reference-pass to
+candidate-fail transition in HumanEval, GSM8K, an individual LongBench row, or
+either final/anywhere needle retrieval. Aggregate scores alone cannot hide a
+per-sample regression.
 
 ## Rejected or Deferred Paths
 

--- a/docs/design/sm70_deepseek_v4_dspark_verifier_20ms_long_context.md
+++ b/docs/design/sm70_deepseek_v4_dspark_verifier_20ms_long_context.md
@@ -72,6 +72,39 @@ their stated end-to-end promotion gate:
    semantics. The captured-graph test, shorter dynamic replay, graph-tail mask,
    and workspace-width gate pass on V100.
 
+5. A default-off `VLLM_SM70_MXFP4_MOE_GROUPED_VERIFIER=1` route extends the
+   single-launch, one-row-per-slot MXFP4 contract from M=8 to M=2..M=8. This is
+   required before a shorter or confidence-scheduled DSpark block can reduce
+   verifier latency; the previous M=2..M=7 path launched one operation per
+   compact expert and erased the benefit of verifying fewer rows.
+
+The focused M=5 and M=6 CUDA Graph gates covered mixed overlap, all-distinct
+slots, and six hot experts. Slot grouping and real-expert grouping were bitwise
+at every pipeline stage and after a changed-route replay in all six cases. The
+mixed-route results are:
+
+| Verifier rows | Active-expert loop | Slot grouped | Real-expert grouped |
+|---:|---:|---:|---:|
+| M=5, 22 unique of 30 slots | 1.98837 ms | 0.18552 ms | 0.18000 ms |
+| M=6, 26 unique of 36 slots | 1.32993 ms | 0.34895 ms | 0.27260 ms |
+
+All-distinct expert grouping is slightly slower than slot grouping
+(`+0.121 ms` projected over 43 layers at M=5 and `+0.210 ms` at M=6), so the
+full-model route must report the observed production overlap. Evidence is
+retained under `/data/models/dsv4-verifier-20ms-variable-grouped-r1`; the
+single V100 was released after the gate.
+
+The 0731 checkpoint declares an official DSpark block size of five and stores
+`mtp.2.confidence_head.proj.weight`. The current runtime explicitly discards
+that weight. DeepSpec computes conditional step probabilities with a sigmoid,
+uses their cumulative product for prefix reliability reporting, and truncates
+at the first conditional probability below a threshold. Before production
+confidence scheduling, this runtime must first collect calibration data on the
+pinned datasets and profile M=2..M=8 service; a raw uncalibrated threshold is
+not an acceptance or latency proof. Static N=4/N=5 trials use the same strict
+rejection sampler and therefore preserve the target distribution while the
+hardware width crossover is measured.
+
 The indexer crossover gate uses FP32 scores, signed head weights, top-k 512,
 M=8, H=64, D=128, and CUDA Graph replay:
 
@@ -142,5 +175,5 @@ shared runtime environment.
 - private rings: `/data/models/dsv4-verifier-20ms-private-ring-source-gate-r1`
 - indexer crossover: `/data/models/dsv4-verifier-20ms-indexer-crossover-r3`
 - indexer source gate: `/data/models/dsv4-verifier-20ms-indexer-source-gate-r1`
+- M=5/M=6 grouped verifier: `/data/models/dsv4-verifier-20ms-variable-grouped-r1`
 - rejected TP8 all-reduce: `/data/models/dsv4-verifier-20ms-tp8-ar-screen-r1`
-

--- a/docs/design/sm70_deepseek_v4_dspark_verifier_20ms_long_context.md
+++ b/docs/design/sm70_deepseek_v4_dspark_verifier_20ms_long_context.md
@@ -174,7 +174,10 @@ The first paired LongBench subset is `hotpotqa`, `multifieldqa_zh`,
 `gov_report`, and `lcc`. Official LongBench metrics are loaded from the pinned
 local checkout; `jieba==0.42.1`, `rouge==1.0.1`, and `fuzzywuzzy==0.18.0` are
 isolated under `/data/models/dsv4-quality-deps` rather than installed into the
-shared runtime environment.
+shared runtime environment. Every quality artifact includes SHA-256 hashes for
+the HumanEval tasks, LongBench prompt/max-length configs, and each selected
+dataset. LongBench records retain their source-row indices so the matched
+no-speculation and DSpark scores cannot silently use different samples.
 
 ## Rejected or Deferred Paths
 

--- a/docs/design/sm70_v100_migration_control.md
+++ b/docs/design/sm70_v100_migration_control.md
@@ -42763,6 +42763,7 @@ Interpretation:
   recorded profile remains evidence for the measured workload, not a runtime
   model whitelist. Full evidence is in
   `docs/design/sm70_dflash2_target_graph_20ms.md`.
+
 ## 2026-08-24 DeepSeek V4 DSpark verifier and long-context campaign
 
 - The active TP8/V100 campaign, exact baseline contracts, admitted focused
@@ -42776,3 +42777,14 @@ Interpretation:
   verifier result. Promotion requires a synchronized TP8 full-model profile,
   long-context 1K-252K evidence, paired no-speculation quality, and task-owned
   GPU cleanup.
+- Source-audit disposition: incomplete-risk leaves are retained only as
+  explicit opt-ins. `VLLM_SM70_INDEXER_DECODE_CUBLAS=1` enables gather-plus-FP32
+  cuBLAS, `VLLM_SM70_DSV4_PRIVATE_COMPRESSOR_STATE=1` enables private state
+  rings, and speculative context buckets require an explicit list. Default
+  serving does not compute or retain confidence logits unless a threshold or
+  alignment diagnostic consumes them, and a requested missing confidence
+  projection fails before use.
+- Runtime gates express hardware, operator configuration, tensor/layout,
+  graph, cache, and concurrency contracts. The architecture-name check was
+  removed; measured checkpoint details remain evidence only and never select
+  an optimization route.

--- a/docs/design/sm70_v100_migration_control.md
+++ b/docs/design/sm70_v100_migration_control.md
@@ -42763,3 +42763,16 @@ Interpretation:
   recorded profile remains evidence for the measured workload, not a runtime
   model whitelist. Full evidence is in
   `docs/design/sm70_dflash2_target_graph_20ms.md`.
+## 2026-08-24 DeepSeek V4 DSpark verifier and long-context campaign
+
+- The active TP8/V100 campaign, exact baseline contracts, admitted focused
+  gates, rejected paths, long-context sweep, and paired quality requirements
+  are recorded in
+  `docs/design/sm70_deepseek_v4_dspark_verifier_20ms_long_context.md`.
+- Latest-main DSpark has reproduced a 116.288 token/s median on the historical
+  3,500-token endpoint contract. The current complete verifier is 35.120 ms per
+  round; the active target is at most 20 ms without acceptance or dataset loss.
+- Do not cite indexer, mHC, compressor-ring, or MoE microbenchmarks as the final
+  verifier result. Promotion requires a synchronized TP8 full-model profile,
+  long-context 1K-252K evidence, paired no-speculation quality, and task-owned
+  GPU cleanup.

--- a/tests/kernels/test_compressor_kv_cache.py
+++ b/tests/kernels/test_compressor_kv_cache.py
@@ -12,6 +12,7 @@ These tests cover:
 """
 
 import math
+from types import SimpleNamespace
 
 import pytest
 import torch
@@ -24,6 +25,11 @@ from vllm.models.deepseek_v4.common.ops import (
 from vllm.models.deepseek_v4.common.ops.fused_compress_quant_cache import (
     _fused_kv_compress_norm_rope_insert_indexer_attn,
     _fused_kv_compress_norm_rope_insert_indexer_mxfp4_attn,
+    compress_norm_rope_store_triton,
+)
+from vllm.models.deepseek_v4.common.ops.save_partial_states import (
+    save_partial_states_to_ring,
+    stage_partial_states_from_ring,
 )
 
 from .test_fused_indexer_q_rope_quant import quantize_to_mxfp4
@@ -607,6 +613,12 @@ def test_fused_kv_insert_indexer(num_tokens: int, kv_block_size: int, use_fp4: b
         kv_cache,
         slot_mapping,
         kv_block_size,
+        state_cache,
+        state_cache.stride(0),
+        state_cache,
+        state_cache.stride(0),
+        rms_weight,
+        rms_weight.stride(0),
         HEAD_SIZE=HEAD_DIM,
         TRITON_BLOCK_SIZE=HEAD_DIM,
         STATE_WIDTH=coff * HEAD_DIM,
@@ -618,6 +630,10 @@ def test_fused_kv_insert_indexer(num_tokens: int, kv_block_size: int, use_fp4: b
         TOKEN_STRIDE=TOKEN_STRIDE,
         SCALE_DIM=SCALE_DIM,
         KV_BLOCK_STRIDE=kv_cache.stride(0),
+        USE_PRIVATE_STATE=False,
+        USE_DENSE_PRIVATE_STATE=False,
+        RING_SIZE=1,
+        PRIVATE_HISTORY_SIZE=1,
         num_warps=1,
     )
 
@@ -667,3 +683,212 @@ def test_fused_kv_insert_indexer(num_tokens: int, kv_block_size: int, use_fp4: b
             assert torch.equal(actual_scale, scale[i : i + 1]), (
                 f"token {i}: scale {actual_scale.item()} != {scale[i].item()}"
             )
+
+
+@pytest.mark.parametrize(
+    ("head_dim", "compress_ratio", "use_fp4_cache"),
+    [(512, 4, False), (512, 128, False), (128, 4, False)],
+)
+def test_private_compressor_ring_matches_paged_state_bytes(
+    head_dim: int, compress_ratio: int, use_fp4_cache: bool
+):
+    """The SM70 private-state gather must preserve final cache bytes exactly."""
+    torch.manual_seed(19)
+    device = "cuda"
+    overlap = compress_ratio == 4
+    coff = 1 + overlap
+    state_width = coff * head_dim
+    state_block_size = 4 if compress_ratio == 4 else 8
+    chunk_start = 12 if compress_ratio == 4 else 120
+    num_tokens = 12 if compress_ratio == 4 else 136
+    total_tokens = chunk_start + num_tokens
+    ring_size = coff * compress_ratio + 8
+
+    all_kv = torch.randn(total_tokens, state_width, dtype=torch.float32, device=device)
+    all_score = torch.randn_like(all_kv)
+    ape = torch.randn(compress_ratio, state_width, dtype=torch.float32, device=device)
+    absolute_positions = torch.arange(total_tokens, device=device)
+    stored_score = all_score + ape[absolute_positions % compress_ratio]
+    dense_state = torch.cat((all_kv, stored_score), dim=-1)
+
+    num_state_blocks = math.ceil(total_tokens / state_block_size)
+    state_cache = torch.zeros(
+        num_state_blocks,
+        state_block_size,
+        2 * state_width,
+        dtype=torch.float32,
+        device=device,
+    )
+    state_cache.view(-1, 2 * state_width)[:total_tokens].copy_(dense_state)
+    block_table = torch.arange(
+        num_state_blocks, dtype=torch.int32, device=device
+    ).unsqueeze(0)
+
+    state_ring = torch.empty(
+        1, ring_size, 2 * state_width, dtype=torch.float32, device=device
+    )
+    history_start = max(0, chunk_start - ring_size)
+    history_positions = torch.arange(history_start, chunk_start, device=device)
+    state_ring[0, history_positions % ring_size] = dense_state[history_positions]
+
+    positions = torch.arange(
+        chunk_start, total_tokens, dtype=torch.int64, device=device
+    )
+    valid_slot_mapping = torch.arange(num_tokens, dtype=torch.int64, device=device)
+    token_to_req = torch.zeros(num_tokens, dtype=torch.int32, device=device)
+    compressed_slot_mapping = torch.where(
+        (positions + 1) % compress_ratio == 0,
+        positions // compress_ratio,
+        -1,
+    )
+    kv_block_size = 16
+    num_compressed_tokens = math.ceil(total_tokens / compress_ratio)
+    num_kv_blocks = math.ceil(num_compressed_tokens / kv_block_size) + 1
+
+    if head_dim == 512:
+        token_stride, scale_dim, quant_block = 576, 8, 64
+    elif use_fp4_cache:
+        token_stride, scale_dim, quant_block = 64, 4, 32
+    else:
+        token_stride, scale_dim, quant_block = 128, 4, 128
+    bytes_per_token = token_stride + scale_dim
+    paged_output = torch.zeros(
+        num_kv_blocks,
+        kv_block_size,
+        bytes_per_token,
+        dtype=torch.uint8,
+        device=device,
+    )
+    private_output = torch.zeros_like(paged_output)
+    k_cache_metadata = SimpleNamespace(slot_mapping=compressed_slot_mapping)
+    rms_weight = torch.randn(head_dim, dtype=torch.bfloat16, device=device)
+    cos_sin_cache = torch.randn(total_tokens + 1, 64, device=device)
+    current_kv = all_kv[chunk_start:]
+    current_score = all_score[chunk_start:]
+
+    common_kwargs = dict(
+        current_kv=current_kv,
+        current_score=current_score,
+        ape=ape,
+        num_actual=num_tokens,
+        token_to_req_indices=token_to_req,
+        positions=positions,
+        slot_mapping=valid_slot_mapping,
+        block_table=block_table,
+        block_size=state_block_size,
+        state_width=state_width,
+        cos_sin_cache=cos_sin_cache,
+        k_cache_metadata=k_cache_metadata,
+        pdl_kwargs={},
+        head_dim=head_dim,
+        rope_head_dim=64,
+        compress_ratio=compress_ratio,
+        overlap=overlap,
+        use_fp4_cache=use_fp4_cache,
+        rms_norm_weight=rms_weight,
+        rms_norm_eps=1e-6,
+        quant_block=quant_block,
+        token_stride=token_stride,
+        scale_dim=scale_dim,
+    )
+    compress_norm_rope_store_triton(
+        state_cache=state_cache,
+        kv_cache=paged_output,
+        use_private_state=False,
+        **common_kwargs,
+    )
+    compress_norm_rope_store_triton(
+        state_cache=state_ring,
+        kv_cache=private_output,
+        use_private_state=True,
+        ring_size=ring_size,
+        **common_kwargs,
+    )
+
+    assert torch.equal(private_output, paged_output)
+
+    if compress_ratio == 128:
+        dense_state = torch.empty(
+            compress_ratio + num_tokens,
+            2 * state_width,
+            dtype=torch.float32,
+            device=device,
+        )
+        stage_partial_states_from_ring(
+            kv=current_kv,
+            score=current_score,
+            ape=ape,
+            positions=positions,
+            state_ring=state_ring,
+            dense_state=dense_state,
+            slot_mapping=valid_slot_mapping,
+            state_width=state_width,
+            history_size=compress_ratio,
+            compress_ratio=compress_ratio,
+        )
+        dense_output = torch.zeros_like(paged_output)
+        compress_norm_rope_store_triton(
+            state_cache=dense_state.unsqueeze(0),
+            kv_cache=dense_output,
+            use_dense_private_state=True,
+            private_history_size=compress_ratio,
+            **common_kwargs,
+        )
+        assert torch.equal(dense_output, paged_output)
+
+
+@pytest.mark.parametrize(
+    ("head_dim", "compress_ratio"), [(512, 4), (512, 128), (128, 4)]
+)
+def test_private_compressor_ring_keeps_only_chunk_tail(
+    head_dim: int, compress_ratio: int
+):
+    overlap = compress_ratio == 4
+    state_width = (1 + overlap) * head_dim
+    ring_size = (1 + overlap) * compress_ratio + 8
+    chunk_start = 4096
+    num_tokens = 8192
+    positions = torch.arange(
+        chunk_start,
+        chunk_start + num_tokens,
+        dtype=torch.int64,
+        device="cuda",
+    )
+    kv = torch.randn(num_tokens, state_width, dtype=torch.float32, device="cuda")
+    score = torch.randn_like(kv)
+    ape = torch.randn(compress_ratio, state_width, dtype=torch.float32, device="cuda")
+    state_ring = torch.full(
+        (1, ring_size, 2 * state_width),
+        float("nan"),
+        dtype=torch.float32,
+        device="cuda",
+    )
+    slot_mapping = torch.arange(num_tokens, dtype=torch.int64, device="cuda")
+    token_to_req = torch.zeros(num_tokens, dtype=torch.int32, device="cuda")
+    seq_lens = torch.tensor(
+        [chunk_start + num_tokens], dtype=torch.int32, device="cuda"
+    )
+
+    save_partial_states_to_ring(
+        kv=kv,
+        score=score,
+        ape=ape,
+        positions=positions,
+        state_ring=state_ring,
+        slot_mapping=slot_mapping,
+        token_to_req_indices=token_to_req,
+        seq_lens=seq_lens,
+        state_width=state_width,
+        compress_ratio=compress_ratio,
+    )
+
+    tail_positions = positions[-ring_size:]
+    actual = state_ring[0, tail_positions % ring_size]
+    expected = torch.cat(
+        (
+            kv[-ring_size:],
+            score[-ring_size:] + ape[tail_positions % compress_ratio],
+        ),
+        dim=-1,
+    )
+    assert torch.equal(actual, expected)

--- a/tests/kernels/test_deepseek_v4_sm70_indexer.py
+++ b/tests/kernels/test_deepseek_v4_sm70_indexer.py
@@ -41,8 +41,8 @@ def _reference_index_logits(
     does NOT factor to (sum_h weights[t, h] * q[t, h]) . k[s] - the relu sits
     between the weighting and the head sum.
     """
-    per_head = torch.einsum("thd,sd->ths", q.float(), k.float())
-    return torch.einsum("ths,th->ts", torch.relu(per_head), weights.float())
+    per_head = torch.einsum("mhd,nd->mhn", q.float(), k.float())
+    return torch.einsum("mhn,mh->mn", torch.relu(per_head), weights.float())
 
 
 def _reference_factored_logits(
@@ -264,7 +264,7 @@ def test_decode_cublas_keeps_the_fp32_topk_set_and_masks_graph_tail(monkeypatch)
     with torch.cuda.graph(graph, stream=capture_stream):
         candidate = candidate_call()
     graph.replay()
-    torch.cuda.synchronize()
+    torch.accelerator.synchronize()
 
     for row, row_len in enumerate(seq_lens.reshape(-1).tolist()):
         expected_topk = torch.topk(baseline[row, :row_len], 512).indices.sort().values
@@ -283,7 +283,7 @@ def test_decode_cublas_keeps_the_fp32_topk_set_and_masks_graph_tail(monkeypatch)
         q, cache, weights, seq_lens, block_table, graph_width
     )
     graph.replay()
-    torch.cuda.synchronize()
+    torch.accelerator.synchronize()
     for row, row_len in enumerate(seq_lens.reshape(-1).tolist()):
         expected_topk = (
             torch.topk(replay_baseline[row, :row_len], 512).indices.sort().values

--- a/tests/kernels/test_deepseek_v4_sm70_indexer.py
+++ b/tests/kernels/test_deepseek_v4_sm70_indexer.py
@@ -190,3 +190,36 @@ def test_decode_reads_the_block_major_paged_cache(monkeypatch, relu, fused):
         torch.testing.assert_close(
             actual[row, :seq_len].unsqueeze(0), expected, rtol=1e-2, atol=1e-2
         )
+
+
+@requires_sm70
+def test_sm70_indexer_decode_valid_logits_do_not_depend_on_workspace_width() -> None:
+    torch.manual_seed(20260804)
+    num_queries = 8
+    num_heads = 4
+    num_keys = 7
+    head_dim = 128
+    cache_block_size = 64
+
+    q = torch.randn(
+        (num_queries, num_heads, head_dim), device="cuda", dtype=torch.float16
+    )
+    weights = torch.randn((num_queries, num_heads), device="cuda", dtype=torch.float16)
+    cache = torch.zeros(
+        (1, cache_block_size, head_dim + 4), device="cuda", dtype=torch.uint8
+    )
+    cache[..., :head_dim].fill_(0x38)
+    cache[..., head_dim:].view(torch.float32).fill_(1.0)
+    seq_lens = torch.full((1, num_queries), num_keys, device="cuda", dtype=torch.int32)
+    block_table = torch.zeros((1, 1), device="cuda", dtype=torch.int32)
+
+    narrow = sm70_indexer_decode_logits(
+        q, cache, weights, seq_lens, block_table, max_seq_len=16
+    )
+    wide = sm70_indexer_decode_logits(
+        q, cache, weights, seq_lens, block_table, max_seq_len=64
+    )
+
+    assert narrow.shape == (num_queries, 16)
+    assert wide.shape == (num_queries, 64)
+    torch.testing.assert_close(narrow[:, :num_keys], wide[:, :num_keys], rtol=0, atol=0)

--- a/tests/kernels/test_deepseek_v4_sm70_indexer.py
+++ b/tests/kernels/test_deepseek_v4_sm70_indexer.py
@@ -193,6 +193,106 @@ def test_decode_reads_the_block_major_paged_cache(monkeypatch, relu, fused):
 
 
 @requires_sm70
+def test_decode_cublas_keeps_the_fp32_topk_set_and_masks_graph_tail(monkeypatch):
+    torch.manual_seed(20260824)
+    generator = torch.Generator().manual_seed(20260824)
+    num_rows, num_heads = 8, 64
+    live_seq_len = 1017
+    graph_width = 2048
+    blocks = (live_seq_len + _BLOCK_SIZE - 1) // _BLOCK_SIZE
+
+    bits, _ = _random_fp8_keys(blocks * _BLOCK_SIZE, generator)
+    value_bits = bits.reshape(blocks, _BLOCK_SIZE, _HEAD_DIM)
+    scales = torch.rand((blocks, _BLOCK_SIZE), generator=generator).cuda() + 0.5
+    cache = _build_paged_index_cache(value_bits, scales)
+    block_table = torch.full(
+        (1, graph_width // _BLOCK_SIZE),
+        -1,
+        dtype=torch.int32,
+        device="cuda",
+    )
+    block_table[0, :blocks] = torch.randperm(blocks, generator=generator).to(
+        device="cuda", dtype=torch.int32
+    )
+    seq_lens = torch.arange(
+        live_seq_len - num_rows + 1,
+        live_seq_len + 1,
+        dtype=torch.int32,
+        device="cuda",
+    ).view(1, num_rows)
+    q, weights = _make_queries(num_rows, num_heads)
+
+    monkeypatch.setattr(sm70_indexer, "_DECODE_CUBLAS", False)
+    baseline = sm70_indexer_decode_logits(
+        q, cache, weights, seq_lens, block_table, graph_width
+    )
+
+    static_workspace = (
+        torch.empty((graph_width, _HEAD_DIM), dtype=torch.float16, device="cuda"),
+        torch.empty((graph_width,), dtype=torch.float32, device="cuda"),
+        torch.empty(
+            (num_rows * num_heads, graph_width),
+            dtype=torch.float32,
+            device="cuda",
+        ),
+    )
+
+    class StaticWorkspace:
+        @staticmethod
+        def get_simultaneous(*specs):
+            assert len(specs) == len(static_workspace)
+            return static_workspace
+
+    monkeypatch.setattr(sm70_indexer, "_DECODE_CUBLAS", True)
+    monkeypatch.setattr(sm70_indexer, "_DECODE_CUBLAS_MIN_KEYS", 1)
+    monkeypatch.setattr(
+        sm70_indexer, "current_workspace_manager", lambda: StaticWorkspace()
+    )
+
+    def candidate_call():
+        return sm70_indexer_decode_logits(
+            q, cache, weights, seq_lens, block_table, graph_width
+        )
+
+    capture_stream = torch.cuda.Stream()
+    capture_stream.wait_stream(torch.cuda.current_stream())
+    with torch.cuda.stream(capture_stream):
+        for _ in range(3):
+            candidate_call()
+    capture_stream.synchronize()
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph, stream=capture_stream):
+        candidate = candidate_call()
+    graph.replay()
+    torch.cuda.synchronize()
+
+    for row, row_len in enumerate(seq_lens.reshape(-1).tolist()):
+        expected_topk = torch.topk(baseline[row, :row_len], 512).indices.sort().values
+        actual_topk = torch.topk(candidate[row, :row_len], 512).indices.sort().values
+        assert torch.equal(actual_topk, expected_topk)
+
+    # The graph bucket has no allocated blocks after the live request tail.
+    # Reaching this assertion proves the gather masked those -1 entries.
+    assert torch.isfinite(candidate[:, :live_seq_len]).all()
+
+    # Replay the same graph with a shorter live request. This exercises the
+    # device-derived bound instead of merely validating the capture-time row.
+    seq_lens.sub_(127)
+    monkeypatch.setattr(sm70_indexer, "_DECODE_CUBLAS", False)
+    replay_baseline = sm70_indexer_decode_logits(
+        q, cache, weights, seq_lens, block_table, graph_width
+    )
+    graph.replay()
+    torch.cuda.synchronize()
+    for row, row_len in enumerate(seq_lens.reshape(-1).tolist()):
+        expected_topk = (
+            torch.topk(replay_baseline[row, :row_len], 512).indices.sort().values
+        )
+        actual_topk = torch.topk(candidate[row, :row_len], 512).indices.sort().values
+        assert torch.equal(actual_topk, expected_topk)
+
+
+@requires_sm70
 def test_sm70_indexer_decode_valid_logits_do_not_depend_on_workspace_width() -> None:
     torch.manual_seed(20260804)
     num_queries = 8

--- a/tests/kernels/test_mhc_sm70_fp16.py
+++ b/tests/kernels/test_mhc_sm70_fp16.py
@@ -154,7 +154,10 @@ def test_mhc_sm70_fp16_block_m_prenorm_keeps_rows_independent() -> None:
     ),
     reason="NVIDIA V100/SM70 and TileLang required",
 )
-def test_mhc_sm70_fp32_stage_matches_fused_decode_bitwise() -> None:
+@pytest.mark.parametrize("num_tokens", [1, 4, 7, 8])
+def test_mhc_sm70_fp32_stage_matches_fused_decode_bitwise(
+    num_tokens: int,
+) -> None:
     from vllm.model_executor.kernels.mhc.tilelang_kernels import (
         mhc_fused_tilelang,
         sm70_mhc_dot_from_fp32_stage_tilelang,
@@ -165,21 +168,26 @@ def test_mhc_sm70_fp32_stage_matches_fused_decode_bitwise() -> None:
     hidden_size = 4096
     hc_mult = 4
     hc_out = 24
-    n_splits = 8
+    tile_n = 2 if num_tokens < 8 else 3
+    n_splits = 8 if num_tokens < 8 else 4
     device = mhc_tilelang.current_platform.device_type
 
-    x = torch.randn((1, hidden_size), device=device, dtype=torch.float16)
+    x = torch.randn((num_tokens, hidden_size), device=device, dtype=torch.float16)
     residual = torch.randn(
-        (1, hc_mult, hidden_size), device=device, dtype=torch.float16
+        (num_tokens, hc_mult, hidden_size), device=device, dtype=torch.float16
     )
-    post_mix = torch.randn((1, hc_mult), device=device, dtype=torch.float32)
-    comb_mix = torch.randn((1, hc_mult, hc_mult), device=device, dtype=torch.float32)
+    post_mix = torch.randn((num_tokens, hc_mult), device=device, dtype=torch.float32)
+    comb_mix = torch.randn(
+        (num_tokens, hc_mult, hc_mult), device=device, dtype=torch.float32
+    )
     fn = torch.randn((hc_out, hc_mult, hidden_size), device=device, dtype=torch.float32)
 
     baseline_gemm = torch.empty(
-        (n_splits, 1, hc_out), device=device, dtype=torch.float32
+        (n_splits, num_tokens, hc_out), device=device, dtype=torch.float32
     )
-    baseline_sqrsum = torch.empty((n_splits, 1), device=device, dtype=torch.float32)
+    baseline_sqrsum = torch.empty(
+        (n_splits, num_tokens), device=device, dtype=torch.float32
+    )
     baseline_residual = torch.empty_like(residual)
     candidate_gemm = torch.empty_like(baseline_gemm)
     candidate_sqrsum = torch.empty_like(baseline_sqrsum)
@@ -198,7 +206,7 @@ def test_mhc_sm70_fp32_stage_matches_fused_decode_bitwise() -> None:
         hc_mult,
         hidden_size,
         hc_out,
-        tile_n=2,
+        tile_n=tile_n,
         n_splits=n_splits,
         use_fp16=True,
     )
@@ -221,7 +229,7 @@ def test_mhc_sm70_fp32_stage_matches_fused_decode_bitwise() -> None:
         hidden_size,
         hc_mult,
         hc_out,
-        tile_n=2,
+        tile_n=tile_n,
         n_splits=n_splits,
     )
     torch.cuda.synchronize()

--- a/tests/kernels/test_mhc_sm70_fp16.py
+++ b/tests/kernels/test_mhc_sm70_fp16.py
@@ -232,7 +232,7 @@ def test_mhc_sm70_fp32_stage_matches_fused_decode_bitwise(
         tile_n=tile_n,
         n_splits=n_splits,
     )
-    torch.cuda.synchronize()
+    torch.accelerator.synchronize()
 
     torch.testing.assert_close(candidate_residual, baseline_residual, rtol=0, atol=0)
     torch.testing.assert_close(candidate_gemm, baseline_gemm, rtol=0, atol=0)

--- a/tests/models/test_deepseek_v4_sm70_routes.py
+++ b/tests/models/test_deepseek_v4_sm70_routes.py
@@ -211,7 +211,24 @@ def test_sm70_private_compressor_state_requires_a_contiguous_single_request():
     config.kv_transfer_config = None
     config.speculative_config.parallel_drafting = False
 
-    with patch.object(compressor, "current_platform", platform):
+    with (
+        patch.object(compressor, "current_platform", platform),
+        patch.object(
+            compressor.envs,
+            "VLLM_SM70_DSV4_PRIVATE_COMPRESSOR_STATE",
+            False,
+        ),
+    ):
+        assert not compressor._can_use_sm70_private_compressor_state(config)
+
+    with (
+        patch.object(compressor, "current_platform", platform),
+        patch.object(
+            compressor.envs,
+            "VLLM_SM70_DSV4_PRIVATE_COMPRESSOR_STATE",
+            True,
+        ),
+    ):
         assert compressor._can_use_sm70_private_compressor_state(config)
 
         config.speculative_config.parallel_drafting = True

--- a/tests/models/test_deepseek_v4_sm70_routes.py
+++ b/tests/models/test_deepseek_v4_sm70_routes.py
@@ -197,6 +197,35 @@ def test_v4_c128_boundary_detection():
     assert _get_c128_boundary(make_metadata([127, 10])) is True
 
 
+def test_sm70_private_compressor_state_requires_a_contiguous_single_request():
+    from vllm.models.deepseek_v4 import compressor
+
+    platform = MagicMock()
+    platform.is_cuda.return_value = True
+    platform.is_device_capability.return_value = True
+
+    config = MagicMock()
+    config.scheduler_config.max_num_seqs = 1
+    config.cache_config.enable_prefix_caching = False
+    config.parallel_config.pipeline_parallel_size = 1
+    config.kv_transfer_config = None
+    config.speculative_config.parallel_drafting = False
+
+    with patch.object(compressor, "current_platform", platform):
+        assert compressor._can_use_sm70_private_compressor_state(config)
+
+        config.speculative_config.parallel_drafting = True
+        assert not compressor._can_use_sm70_private_compressor_state(config)
+
+        config.speculative_config.parallel_drafting = False
+        config.scheduler_config.max_num_seqs = 2
+        assert not compressor._can_use_sm70_private_compressor_state(config)
+
+        config.scheduler_config.max_num_seqs = 1
+        config.cache_config.enable_prefix_caching = True
+        assert not compressor._can_use_sm70_private_compressor_state(config)
+
+
 def test_v4_c128_metadata_keeps_graph_stable_row_stride():
     from vllm.v1.attention.backends.mla import flashmla_sparse
 

--- a/tests/quantization/test_sm70_mxfp4_moe.py
+++ b/tests/quantization/test_sm70_mxfp4_moe.py
@@ -351,6 +351,45 @@ def test_mxfp4_sm70_m8_expert_grouped_dispatch_keeps_real_segments(monkeypatch):
     assert count == 48
 
 
+@pytest.mark.parametrize("expert_rows", [False, True])
+def test_mxfp4_sm70_m5_grouped_dispatch(expert_rows, monkeypatch):
+    buffers = {
+        "compact_expert_offsets": torch.arange(31, dtype=torch.int32) * 2,
+        "slot_expert_offsets": torch.arange(31, dtype=torch.int32),
+        "permuted_experts_id": torch.arange(30, dtype=torch.int32).flip(0),
+        "active_expert_ids": torch.arange(30, dtype=torch.int32),
+        "expert_offsets": torch.arange(257, dtype=torch.int32),
+        "dense_expert_ids": torch.arange(256, dtype=torch.int32),
+    }
+    monkeypatch.setattr(mxfp4_moe, "_mxfp4_active_expert_max_tokens", lambda: 8)
+    monkeypatch.setattr(mxfp4_moe, "_mxfp4_grouped_m8_enabled", lambda: False)
+    monkeypatch.setattr(mxfp4_moe, "_mxfp4_grouped_verifier_enabled", lambda: True)
+    monkeypatch.setattr(
+        mxfp4_moe,
+        "_mxfp4_grouped_m8_expert_rows_enabled",
+        lambda: expert_rows,
+    )
+
+    offsets, expert_ids, count = _select_mxfp4_stage_dispatch(
+        buffers,
+        num_tokens=5,
+        num_experts=256,
+        fully_replicated_experts=True,
+    )
+
+    expected_offsets = (
+        buffers["compact_expert_offsets"]
+        if expert_rows
+        else buffers["slot_expert_offsets"]
+    )
+    expected_ids = (
+        buffers["active_expert_ids"] if expert_rows else buffers["permuted_experts_id"]
+    )
+    assert offsets is expected_offsets
+    assert expert_ids is expected_ids
+    assert count == 30
+
+
 @pytest.mark.skipif(
     not torch.cuda.is_available() or torch.cuda.get_device_capability() != (7, 0),
     reason="requires NVIDIA V100/SM70",

--- a/tests/quantization/test_sm70_mxfp4_moe.py
+++ b/tests/quantization/test_sm70_mxfp4_moe.py
@@ -308,6 +308,9 @@ def test_mxfp4_sm70_m8_grouped_dispatch_keeps_one_row_slots(monkeypatch):
     }
     monkeypatch.setattr(mxfp4_moe, "_mxfp4_active_expert_max_tokens", lambda: 8)
     monkeypatch.setattr(mxfp4_moe, "_mxfp4_grouped_m8_enabled", lambda: True)
+    monkeypatch.setattr(
+        mxfp4_moe, "_mxfp4_grouped_m8_expert_rows_enabled", lambda: False
+    )
 
     offsets, expert_ids, count = _select_mxfp4_stage_dispatch(
         buffers,
@@ -318,6 +321,33 @@ def test_mxfp4_sm70_m8_grouped_dispatch_keeps_one_row_slots(monkeypatch):
 
     assert offsets is buffers["slot_expert_offsets"]
     assert expert_ids is buffers["permuted_experts_id"]
+    assert count == 48
+
+
+def test_mxfp4_sm70_m8_expert_grouped_dispatch_keeps_real_segments(monkeypatch):
+    buffers = {
+        "compact_expert_offsets": torch.arange(49, dtype=torch.int32) * 2,
+        "slot_expert_offsets": torch.arange(49, dtype=torch.int32),
+        "permuted_experts_id": torch.arange(48, dtype=torch.int32).flip(0),
+        "active_expert_ids": torch.arange(48, dtype=torch.int32),
+        "expert_offsets": torch.arange(257, dtype=torch.int32),
+        "dense_expert_ids": torch.arange(256, dtype=torch.int32),
+    }
+    monkeypatch.setattr(mxfp4_moe, "_mxfp4_active_expert_max_tokens", lambda: 8)
+    monkeypatch.setattr(mxfp4_moe, "_mxfp4_grouped_m8_enabled", lambda: True)
+    monkeypatch.setattr(
+        mxfp4_moe, "_mxfp4_grouped_m8_expert_rows_enabled", lambda: True
+    )
+
+    offsets, expert_ids, count = _select_mxfp4_stage_dispatch(
+        buffers,
+        num_tokens=8,
+        num_experts=256,
+        fully_replicated_experts=True,
+    )
+
+    assert offsets is buffers["compact_expert_offsets"]
+    assert expert_ids is buffers["active_expert_ids"]
     assert count == 48
 
 

--- a/tests/v1/attention/test_indexer_deepseek_v4_slot_mapping.py
+++ b/tests/v1/attention/test_indexer_deepseek_v4_slot_mapping.py
@@ -63,6 +63,9 @@ def test_indexer_builder_deepseek_v4_compressed_slot_mapping_uses_storage_block_
 
     md = builder.build(common_prefix_len=0, common_attn_metadata=common)
 
+    assert md.max_seq_len == 280
+    assert md.compressed_max_seq_len == 70
+
     # The compressed slot_mapping retains the original uncompressed size (40).
     # Only every compress_ratio-th position gets a valid slot; the rest are -1.
     assert md.slot_mapping.numel() == 40

--- a/tests/v1/core/test_kv_cache_utils.py
+++ b/tests/v1/core/test_kv_cache_utils.py
@@ -1930,6 +1930,60 @@ def test_get_kv_cache_spec_kind_prefers_specific_attention_subclasses():
     )
 
 
+def test_deepseek_v4_tuple_width_minimizes_physical_pool_pages():
+    full_spec = MLAAttentionSpec(
+        block_size=256,
+        num_kv_heads=1,
+        head_size=512,
+        dtype=torch.uint8,
+        cache_dtype_str="fp8_ds_mla",
+        compress_ratio=4,
+        alignment=576,
+        model_version="deepseek_v4",
+    )
+    swa_spec = SlidingWindowMLASpec(
+        block_size=64,
+        num_kv_heads=1,
+        head_size=512,
+        dtype=torch.uint8,
+        sliding_window=128,
+        cache_dtype_str="fp8_ds_mla",
+        alignment=576,
+        model_version="deepseek_v4",
+    )
+    grouped_specs = [
+        UniformTypeKVCacheSpecs(
+            block_size=256,
+            kv_cache_specs={f"full_{i}": full_spec for i in range(21)},
+        ),
+        UniformTypeKVCacheSpecs(
+            block_size=64,
+            kv_cache_specs={f"swa_{i}": swa_spec for i in range(46)},
+        ),
+    ]
+    vllm_config = SimpleNamespace(
+        model_config=SimpleNamespace(max_model_len=1_048_576),
+        scheduler_config=SimpleNamespace(max_num_batched_tokens=8192),
+        parallel_config=SimpleNamespace(
+            decode_context_parallel_size=1,
+            prefill_context_parallel_size=1,
+        ),
+    )
+
+    assert (
+        kv_cache_utils._select_deepseek_v4_tuple_width(
+            vllm_config,  # type: ignore[arg-type]
+            grouped_specs,
+        )
+        == 21
+    )
+    groups = kv_cache_utils._get_kv_cache_groups_uniform_groups(
+        vllm_config,  # type: ignore[arg-type]
+        grouped_specs,
+    )
+    assert [len(group.layer_names) for group in groups] == [21, 16, 15, 15]
+
+
 def test_get_kv_cache_spec_kind_unwraps_uniform_type_specs():
     uniform_mla_spec = UniformTypeKVCacheSpecs(
         block_size=16,

--- a/tests/v1/cudagraph/test_cudagraph_dispatch.py
+++ b/tests/v1/cudagraph/test_cudagraph_dispatch.py
@@ -406,6 +406,56 @@ class TestCudagraphDispatcher:
         disabled = CudagraphDispatcher(config)
         assert not disabled.sm70_dsv4_decode_context_buckets
 
+    def test_dsv4_context_bucket_is_derived_for_mtp_on_sm70(self, monkeypatch):
+        monkeypatch.delenv("VLLM_SM70_DSV4_DECODE_CONTEXT_BUCKETS", raising=False)
+        monkeypatch.delenv("VLLM_SM70_MTP_CONTEXT_BUCKETS", raising=False)
+        comp_config = CompilationConfig(
+            cudagraph_mode="FULL_DECODE_ONLY",
+            mode=CompilationMode.NONE,
+            cudagraph_capture_sizes=[8, 16],
+        )
+        config = _create_vllm_config(comp_config, max_num_seqs=2)
+        config.speculative_config = MagicMock(num_speculative_tokens=7)
+        config.model_config.architectures = ["DeepseekV4ForCausalLM"]
+        config.model_config.max_model_len = 4096
+        config.model_config.hf_config.index_topk = 512
+        config.model_config.hf_config.compress_ratios = [128, 4, 128]
+
+        with (
+            patch.object(current_platform, "is_cuda", return_value=True),
+            patch.object(current_platform, "is_device_capability", return_value=True),
+        ):
+            dispatcher = CudagraphDispatcher(config)
+        dispatcher.initialize_cudagraph_keys(
+            cudagraph_mode=comp_config.cudagraph_mode,
+            uniform_decode_query_len=8,
+        )
+
+        bounded = BatchDescriptor(
+            num_tokens=8,
+            num_reqs=1,
+            uniform=True,
+            attention_context_bucket=2048,
+        )
+        assert dispatcher.has_attention_context_buckets
+        assert bounded in dispatcher.cudagraph_keys[CUDAGraphMode.FULL]
+
+        mode, desc = dispatcher.dispatch(
+            num_tokens=8,
+            uniform_decode=True,
+            attention_context_len=1024,
+        )
+        assert mode == CUDAGraphMode.FULL
+        assert desc == bounded
+
+        monkeypatch.setenv("VLLM_SM70_MTP_CONTEXT_BUCKETS", "")
+        explicitly_disabled = CudagraphDispatcher(config)
+        explicitly_disabled.initialize_cudagraph_keys(
+            cudagraph_mode=comp_config.cudagraph_mode,
+            uniform_decode_query_len=8,
+        )
+        assert not explicitly_disabled.has_attention_context_buckets
+
     def test_fp8_e5m2_decode_context_bucket_is_shape_derived_on_sm70(self, monkeypatch):
         monkeypatch.delenv("VLLM_SM70_FP8_KV_DECODE_CONTEXT_BUCKETS", raising=False)
         comp_config = CompilationConfig(

--- a/tests/v1/cudagraph/test_cudagraph_dispatch.py
+++ b/tests/v1/cudagraph/test_cudagraph_dispatch.py
@@ -456,6 +456,60 @@ class TestCudagraphDispatcher:
         )
         assert not explicitly_disabled.has_attention_context_buckets
 
+    def test_dsv4_long_context_buckets_bound_mtp_graph_width(self, monkeypatch):
+        monkeypatch.delenv("VLLM_SM70_DSV4_DECODE_CONTEXT_BUCKETS", raising=False)
+        monkeypatch.delenv("VLLM_SM70_MTP_CONTEXT_BUCKETS", raising=False)
+        comp_config = CompilationConfig(
+            cudagraph_mode="FULL_DECODE_ONLY",
+            mode=CompilationMode.NONE,
+            cudagraph_capture_sizes=[8, 16],
+        )
+        config = _create_vllm_config(comp_config, max_num_seqs=2)
+        config.speculative_config = MagicMock(num_speculative_tokens=7)
+        config.model_config.architectures = ["DeepseekV4ForCausalLM"]
+        config.model_config.max_model_len = 262144
+        config.model_config.hf_config.index_topk = 512
+        config.model_config.hf_config.compress_ratios = [128, 4, 128]
+
+        with (
+            patch.object(current_platform, "is_cuda", return_value=True),
+            patch.object(current_platform, "is_device_capability", return_value=True),
+        ):
+            dispatcher = CudagraphDispatcher(config)
+        dispatcher.initialize_cudagraph_keys(
+            cudagraph_mode=comp_config.cudagraph_mode,
+            uniform_decode_query_len=8,
+        )
+
+        assert dispatcher.sm70_dsv4_decode_context_buckets == (
+            2048,
+            4096,
+            16384,
+            65536,
+            131072,
+        )
+        expected_buckets = {
+            3000: 4096,
+            5000: 16384,
+            20000: 65536,
+            100000: 131072,
+        }
+        for context_len, expected_bucket in expected_buckets.items():
+            mode, descriptor = dispatcher.dispatch(
+                num_tokens=8,
+                uniform_decode=True,
+                attention_context_len=context_len,
+            )
+            assert mode == CUDAGraphMode.FULL
+            assert descriptor.attention_context_bucket == expected_bucket
+
+        _, unbounded = dispatcher.dispatch(
+            num_tokens=8,
+            uniform_decode=True,
+            attention_context_len=200000,
+        )
+        assert unbounded.attention_context_bucket is None
+
     def test_fp8_e5m2_decode_context_bucket_is_shape_derived_on_sm70(self, monkeypatch):
         monkeypatch.delenv("VLLM_SM70_FP8_KV_DECODE_CONTEXT_BUCKETS", raising=False)
         comp_config = CompilationConfig(

--- a/tests/v1/cudagraph/test_cudagraph_dispatch.py
+++ b/tests/v1/cudagraph/test_cudagraph_dispatch.py
@@ -378,7 +378,9 @@ class TestCudagraphDispatcher:
             cudagraph_capture_sizes=[1, 2],
         )
         config = _create_vllm_config(comp_config, max_num_seqs=2)
-        config.model_config.architectures = ["DeepseekV4ForCausalLM"]
+        # Route by the compressed-index operator contract, not architecture or
+        # checkpoint identity.
+        config.model_config.architectures = ["UnrelatedForCausalLM"]
         config.model_config.max_model_len = 4096
         config.model_config.hf_config.index_topk = 512
         config.model_config.hf_config.compress_ratios = [128, 4, 128]
@@ -406,7 +408,9 @@ class TestCudagraphDispatcher:
         disabled = CudagraphDispatcher(config)
         assert not disabled.sm70_dsv4_decode_context_buckets
 
-    def test_dsv4_context_bucket_is_derived_for_mtp_on_sm70(self, monkeypatch):
+    def test_dsv4_context_bucket_requires_explicit_override_for_mtp_on_sm70(
+        self, monkeypatch
+    ):
         monkeypatch.delenv("VLLM_SM70_DSV4_DECODE_CONTEXT_BUCKETS", raising=False)
         monkeypatch.delenv("VLLM_SM70_MTP_CONTEXT_BUCKETS", raising=False)
         comp_config = CompilationConfig(
@@ -425,7 +429,11 @@ class TestCudagraphDispatcher:
             patch.object(current_platform, "is_cuda", return_value=True),
             patch.object(current_platform, "is_device_capability", return_value=True),
         ):
-            dispatcher = CudagraphDispatcher(config)
+            default_dispatcher = CudagraphDispatcher(config)
+        assert not default_dispatcher.has_attention_context_buckets
+
+        monkeypatch.setenv("VLLM_SM70_DSV4_DECODE_CONTEXT_BUCKETS", "2048")
+        dispatcher = CudagraphDispatcher(config)
         dispatcher.initialize_cudagraph_keys(
             cudagraph_mode=comp_config.cudagraph_mode,
             uniform_decode_query_len=8,
@@ -457,7 +465,10 @@ class TestCudagraphDispatcher:
         assert not explicitly_disabled.has_attention_context_buckets
 
     def test_dsv4_long_context_buckets_bound_mtp_graph_width(self, monkeypatch):
-        monkeypatch.delenv("VLLM_SM70_DSV4_DECODE_CONTEXT_BUCKETS", raising=False)
+        monkeypatch.setenv(
+            "VLLM_SM70_DSV4_DECODE_CONTEXT_BUCKETS",
+            "2048,4096,16384,65536,131072",
+        )
         monkeypatch.delenv("VLLM_SM70_MTP_CONTEXT_BUCKETS", raising=False)
         comp_config = CompilationConfig(
             cudagraph_mode="FULL_DECODE_ONLY",

--- a/tests/v1/spec_decode/test_dspark.py
+++ b/tests/v1/spec_decode/test_dspark.py
@@ -27,7 +27,9 @@ def test_deepseek_v4_dspark_checkpoint_name_mapping() -> None:
     assert remap("mtp.2.markov_head.markov_w1.weight") == (
         "model.markov_head.markov_w1.weight"
     )
-    assert remap("mtp.2.confidence_head.proj.weight") is None
+    assert remap("mtp.2.confidence_head.proj.weight") == (
+        "model.confidence_head.proj.weight"
+    )
 
 
 class _FakeDSparkModel:
@@ -46,6 +48,13 @@ class _FakeDSparkModel:
         bias = torch.zeros(previous.shape[0], self.vocab_size)
         bias.scatter_(1, ((previous + 1) % self.vocab_size).unsqueeze(1), 10.0)
         return bias
+
+    @staticmethod
+    def confidence_logits(
+        hidden_states: torch.Tensor,
+        markov_embeds: torch.Tensor,
+    ) -> torch.Tensor:
+        return hidden_states.sum(dim=-1) + markov_embeds.sum(dim=-1)
 
     @staticmethod
     def map_draft_to_target(token_ids: torch.Tensor) -> torch.Tensor:
@@ -83,6 +92,7 @@ def test_dspark_markov_sampling_is_sequential(
         for anchor in (1, 4)
     ]
     assert output.view(2, num_speculative_tokens).tolist() == expected
+    assert proposer._last_confidence_logits.shape == (2, num_speculative_tokens)
 
 
 @pytest.mark.parametrize("num_speculative_tokens", [5, 7])
@@ -132,6 +142,7 @@ def test_dspark_probabilistic_sampling_returns_sequential_probs(
         for anchor in (1, 4)
     ]
     assert output.view(2, num_speculative_tokens).tolist() == expected
+    assert proposer._last_confidence_logits.shape == (2, num_speculative_tokens)
 
 
 def test_dspark_replicated_linears_return_tensors() -> None:

--- a/tests/v1/spec_decode/test_dspark.py
+++ b/tests/v1/spec_decode/test_dspark.py
@@ -165,3 +165,33 @@ def test_dspark_replicated_linears_return_tensors() -> None:
     markov_head.markov_w2 = nn.Identity()
     markov_embed = torch.randn(3, 4)
     assert torch.equal(markov_head.bias(markov_embed), markov_embed)
+
+
+def test_dspark_confidence_scheduler_keeps_only_confident_prefix() -> None:
+    proposer = object.__new__(DSparkProposer)
+    proposer._confidence_temperatures = torch.tensor([[1.0, 2.0, 1.0, 1.0, 1.0]])
+    proposer._confidence_threshold = 0.7
+    proposer._max_verification_tokens = 4
+    logits = torch.tensor(
+        [
+            [2.0, 2.0, 0.0, 4.0, 4.0],
+            [2.0, 4.0, 4.0, 4.0, 4.0],
+            [0.0, 4.0, 4.0, 4.0, 4.0],
+        ]
+    )
+
+    lengths = proposer._select_verification_lengths(logits)
+
+    assert lengths.dtype == torch.int32
+    assert lengths.tolist() == [2, 4, 0]
+
+
+def test_dspark_confidence_scheduler_zero_threshold_uses_cap() -> None:
+    proposer = object.__new__(DSparkProposer)
+    proposer._confidence_temperatures = torch.ones((1, 5))
+    proposer._confidence_threshold = 0.0
+    proposer._max_verification_tokens = 2
+
+    lengths = proposer._select_verification_lengths(torch.randn(3, 5))
+
+    assert lengths.tolist() == [2, 2, 2]

--- a/tests/v1/spec_decode/test_dspark.py
+++ b/tests/v1/spec_decode/test_dspark.py
@@ -70,6 +70,8 @@ def test_dspark_markov_sampling_is_sequential(
     proposer.model = _FakeDSparkModel()
     proposer._enable_probabilistic_draft_probs = False
     proposer._static_draft_vocab = None
+    proposer.collect_confidence_logits = False
+    proposer.confidence_scheduling_enabled = False
     proposer.input_ids = torch.zeros(2 * num_speculative_tokens, dtype=torch.int32)
     proposer.input_ids[0] = 1
     proposer.input_ids[num_speculative_tokens] = 4
@@ -92,7 +94,8 @@ def test_dspark_markov_sampling_is_sequential(
         for anchor in (1, 4)
     ]
     assert output.view(2, num_speculative_tokens).tolist() == expected
-    assert proposer._last_confidence_logits.shape == (2, num_speculative_tokens)
+    assert proposer._last_confidence_logits is None
+    assert proposer._last_verification_lengths is None
 
 
 @pytest.mark.parametrize("num_speculative_tokens", [5, 7])
@@ -104,6 +107,8 @@ def test_dspark_probabilistic_sampling_returns_sequential_probs(
     proposer.model = _FakeDSparkModel()
     proposer._enable_probabilistic_draft_probs = True
     proposer._static_draft_vocab = None
+    proposer.collect_confidence_logits = True
+    proposer.confidence_scheduling_enabled = True
     proposer.input_ids = torch.zeros(2 * num_speculative_tokens, dtype=torch.int32)
     proposer.input_ids[0] = 1
     proposer.input_ids[num_speculative_tokens] = 4
@@ -143,6 +148,36 @@ def test_dspark_probabilistic_sampling_returns_sequential_probs(
     ]
     assert output.view(2, num_speculative_tokens).tolist() == expected
     assert proposer._last_confidence_logits.shape == (2, num_speculative_tokens)
+    assert proposer._last_verification_lengths.shape == (2,)
+    confidence_logits = proposer.take_last_confidence_logits()
+    verification_lengths = proposer.take_last_verification_lengths()
+    assert confidence_logits is not None
+    assert verification_lengths is not None
+    assert proposer.take_last_confidence_logits() is None
+    assert proposer.take_last_verification_lengths() is None
+
+
+def test_dspark_static_verification_cap_skips_confidence_projection() -> None:
+    proposer = object.__new__(DSparkProposer)
+    proposer.num_speculative_tokens = 5
+    proposer.model = _FakeDSparkModel()
+    proposer._enable_probabilistic_draft_probs = False
+    proposer._static_draft_vocab = None
+    proposer.collect_confidence_logits = False
+    proposer.confidence_scheduling_enabled = True
+    proposer._max_verification_tokens = 2
+    proposer.input_ids = torch.zeros(5, dtype=torch.int32)
+    proposer._anchor_indices = torch.tensor([0], dtype=torch.int64)
+
+    output, draft_probs = proposer._sample_draft_tokens(
+        torch.zeros(5, 2),
+        sampling_metadata=None,  # type: ignore[arg-type]
+    )
+
+    assert output.shape == (5,)
+    assert draft_probs is None
+    assert proposer._last_confidence_logits is None
+    assert proposer._last_verification_lengths.tolist() == [2]
 
 
 def test_dspark_replicated_linears_return_tensors() -> None:
@@ -165,6 +200,15 @@ def test_dspark_replicated_linears_return_tensors() -> None:
     markov_head.markov_w2 = nn.Identity()
     markov_embed = torch.randn(3, 4)
     assert torch.equal(markov_head.bias(markov_embed), markov_embed)
+
+
+def test_dspark_confidence_projection_rejects_missing_weight() -> None:
+    draft_model = object.__new__(DSparkDeepseekV4ForCausalLM)
+    nn.Module.__init__(draft_model)
+    draft_model._confidence_head_loaded = False
+
+    with pytest.raises(RuntimeError, match="did not provide confidence_head"):
+        draft_model.confidence_logits(torch.empty(1, 1), torch.empty(1, 1))
 
 
 def test_dspark_confidence_scheduler_keeps_only_confident_prefix() -> None:

--- a/tests/v1/spec_decode/test_mtp_draft_prob_alignment.py
+++ b/tests/v1/spec_decode/test_mtp_draft_prob_alignment.py
@@ -4,7 +4,10 @@
 import pytest
 import torch
 
-from vllm.v1.spec_decode.draft_prob_alignment import get_aligned_draft_probs
+from vllm.v1.spec_decode.draft_prob_alignment import (
+    get_aligned_draft_probs,
+    get_aligned_draft_scalar_values,
+)
 from vllm.v1.spec_decode.metadata import SpecDecodeMetadata
 
 
@@ -113,5 +116,29 @@ def test_get_spec_decode_draft_probs_rejects_cached_token_mismatch():
             draft_probs=torch.zeros((1, 2, 4), dtype=torch.float32),
             draft_prob_req_ids=["a"],
             draft_prob_token_ids=torch.tensor([[1, 9]], dtype=torch.int32),
+            spec_decode_metadata=_metadata([[1, 2]]),
+        )
+
+
+def test_get_aligned_draft_scalar_values_binds_prefixes_by_req_id():
+    values = torch.tensor([[0.1, 0.2, 0.3], [1.1, 1.2, 1.3]])
+    actual = get_aligned_draft_scalar_values(
+        req_ids=["b", "a"],
+        values=values,
+        value_req_ids=["a", "b"],
+        value_token_ids=torch.tensor([[10, 11, 12], [20, 21, 22]], dtype=torch.int32),
+        spec_decode_metadata=_metadata([[20], [10, 11]]),
+    )
+
+    assert torch.equal(actual, torch.tensor([1.1, 0.1, 0.2]))
+
+
+def test_get_aligned_draft_scalar_values_rejects_token_mismatch():
+    with pytest.raises(RuntimeError, match="do not match verifier draft tokens"):
+        get_aligned_draft_scalar_values(
+            req_ids=["a"],
+            values=torch.tensor([[0.1, 0.2]]),
+            value_req_ids=["a"],
+            value_token_ids=[[1, 9]],
             spec_decode_metadata=_metadata([[1, 2]]),
         )

--- a/tests/v1/worker/test_gpu_model_runner.py
+++ b/tests/v1/worker/test_gpu_model_runner.py
@@ -795,6 +795,25 @@ def test_sample_passes_reordered_draft_probs_to_rejection_sampler():
     assert torch.equal(passed_draft_probs, expected_draft_probs)
 
 
+def test_dspark_verification_lengths_trim_scheduler_drafts(monkeypatch):
+    runner = object.__new__(GPUModelRunner)
+    runner._draft_token_ids = torch.tensor([[1, 2, 3, 4, 5], [6, 7, 8, 9, 10]])
+    runner._draft_token_req_ids = ["a", "b"]
+    runner.draft_token_ids_event = object()
+    runner.draft_token_ids_cpu = runner._draft_token_ids.clone()
+    runner.dspark_confidence_scheduling = True
+    runner._dspark_verification_lengths_cpu = torch.tensor([2, 0], dtype=torch.int32)
+    monkeypatch.setattr(
+        "vllm.v1.worker.gpu_model_runner.sm70_trace_event_sync",
+        lambda *_args, **_kwargs: None,
+    )
+
+    token_ids, req_ids = runner._get_draft_token_ids_cpu()
+
+    assert req_ids == ["a", "b"]
+    assert token_ids == [[1, 2], []]
+
+
 @pytest.mark.skip_global_cleanup
 def test_sync_mamba_accepted_token_state_tracks_request_ownership():
     runner = object.__new__(GPUModelRunner)

--- a/vllm/config/speculative.py
+++ b/vllm/config/speculative.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 import copy
+import math
 from typing import TYPE_CHECKING, Any, Literal, get_args
 
 from pydantic import Field, SkipValidation, field_validator, model_validator
@@ -292,6 +293,20 @@ class SpeculativeConfig:
     distribution and uses the full draft logits for the probability ratio test
     during rejection sampling. This comes at the cost of additional GPU memory
     usage."""
+
+    dspark_confidence_threshold: float = Field(default=0.0, ge=0.0, le=1.0)
+    """Conditional-acceptance threshold for DSpark prefix scheduling. A value
+    of zero keeps every proposed position. Positive values retain only the
+    leading positions whose calibrated confidence is at least the threshold."""
+
+    dspark_confidence_temperatures: list[float] | None = None
+    """Optional positive per-position temperatures applied to DSpark confidence
+    logits before prefix scheduling. The list must match num_speculative_tokens."""
+
+    dspark_max_verification_tokens: int | None = Field(default=None, ge=0)
+    """Optional cap on DSpark draft tokens submitted to target verification.
+    DSpark still generates the checkpoint's complete block; only a prefix is
+    scheduled, so values below the checkpoint block size remain lossless."""
 
     def compute_hash(self) -> str:
         """
@@ -873,6 +888,31 @@ class SpeculativeConfig:
                             f"{self.num_speculative_tokens}. Smaller values "
                             "produce incorrect output."
                         )
+                    if (
+                        self.dspark_max_verification_tokens is not None
+                        and self.dspark_max_verification_tokens
+                        > self.num_speculative_tokens
+                    ):
+                        raise ValueError(
+                            "dspark_max_verification_tokens must be <= "
+                            f"num_speculative_tokens ({self.num_speculative_tokens}); "
+                            f"got {self.dspark_max_verification_tokens}."
+                        )
+                    temperatures = self.dspark_confidence_temperatures
+                    if temperatures is not None:
+                        if len(temperatures) != self.num_speculative_tokens:
+                            raise ValueError(
+                                "dspark_confidence_temperatures must have length "
+                                f"{self.num_speculative_tokens}; got {temperatures}."
+                            )
+                        if not all(
+                            math.isfinite(value) and value > 0.0
+                            for value in temperatures
+                        ):
+                            raise ValueError(
+                                "dspark_confidence_temperatures entries must be "
+                                f"finite and positive; got {temperatures}."
+                            )
 
                 if self.use_dflash_ddtree() and self.ddtree_budget is None:
                     self.ddtree_budget = self.num_speculative_tokens

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -243,6 +243,7 @@ if TYPE_CHECKING:
     VLLM_SM70_MXFP4_MOE_ACTIVE_EXPERT_MAX_TOKENS: int = 8
     VLLM_SM70_MXFP4_MOE_COMPACT_GROUPED_DECODE: bool = False
     VLLM_SM70_MXFP4_MOE_GROUPED_M8: bool = False
+    VLLM_SM70_MXFP4_MOE_GROUPED_VERIFIER: bool = False
     VLLM_SM70_MXFP4_MOE_GROUPED_M8_EXPERT_ROWS: bool = False
     VLLM_SM70_MXFP4_MOE_GROUPED_M8_FAST_SELECTOR: bool = True
     VLLM_SM70_MXFP4_MOE_DIRECT_TOP6_DECODE: bool = False
@@ -2142,6 +2143,11 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # active-expert stage calls into one TurboMind grouped launch.
     "VLLM_SM70_MXFP4_MOE_GROUPED_M8": lambda: bool(
         int(os.getenv("VLLM_SM70_MXFP4_MOE_GROUPED_M8", "0"))
+    ),
+    # Extend the one-launch grouped verifier route from M=8 to M=2..M=8.
+    # Kept independent until each width passes its CUDA Graph and model gates.
+    "VLLM_SM70_MXFP4_MOE_GROUPED_VERIFIER": lambda: bool(
+        int(os.getenv("VLLM_SM70_MXFP4_MOE_GROUPED_VERIFIER", "0"))
     ),
     # Group verifier slots routed to the same expert into one multi-row group.
     # This changes the MXFP4 reduction tactic, so it stays behind an

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -243,6 +243,7 @@ if TYPE_CHECKING:
     VLLM_SM70_MXFP4_MOE_ACTIVE_EXPERT_MAX_TOKENS: int = 8
     VLLM_SM70_MXFP4_MOE_COMPACT_GROUPED_DECODE: bool = False
     VLLM_SM70_MXFP4_MOE_GROUPED_M8: bool = False
+    VLLM_SM70_MXFP4_MOE_GROUPED_M8_EXPERT_ROWS: bool = False
     VLLM_SM70_MXFP4_MOE_GROUPED_M8_FAST_SELECTOR: bool = True
     VLLM_SM70_MXFP4_MOE_DIRECT_TOP6_DECODE: bool = False
     VLLM_SM70_DSV4_SPARSE_MLA_SPLITK_SWA: bool = False
@@ -2141,6 +2142,12 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # active-expert stage calls into one TurboMind grouped launch.
     "VLLM_SM70_MXFP4_MOE_GROUPED_M8": lambda: bool(
         int(os.getenv("VLLM_SM70_MXFP4_MOE_GROUPED_M8", "0"))
+    ),
+    # Group verifier slots routed to the same expert into one multi-row group.
+    # This changes the MXFP4 reduction tactic, so it stays behind an
+    # independent acceptance/quality gate.
+    "VLLM_SM70_MXFP4_MOE_GROUPED_M8_EXPERT_ROWS": lambda: bool(
+        int(os.getenv("VLLM_SM70_MXFP4_MOE_GROUPED_M8_EXPERT_ROWS", "0"))
     ),
     # Use deterministic W13/W2 tactics for the fixed 48 one-row
     # verifier groups instead of relying on capture-time autotune stability.

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -283,6 +283,7 @@ if TYPE_CHECKING:
     VLLM_SM70_MTP_CONCURRENCY_WARMUP: bool = False
     VLLM_SM70_MTP_CONTEXT_BUCKETS: str | None = None
     VLLM_SM70_DSV4_DECODE_CONTEXT_BUCKETS: str | None = None
+    VLLM_SM70_DSV4_PRIVATE_COMPRESSOR_STATE: bool = False
     VLLM_SM70_FP8_KV_DECODE_CONTEXT_BUCKETS: str | None = None
     VLLM_SM70_MTP_CONTEXT_BUCKET_PARTITION_SIZE: str | None = None
     VLLM_SM70_REJECTION_PROFILE: bool = False
@@ -2264,6 +2265,11 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "VLLM_SM70_MTP_CONTEXT_BUCKETS": lambda: os.getenv("VLLM_SM70_MTP_CONTEXT_BUCKETS"),
     "VLLM_SM70_DSV4_DECODE_CONTEXT_BUCKETS": lambda: os.getenv(
         "VLLM_SM70_DSV4_DECODE_CONTEXT_BUCKETS"
+    ),
+    # The private ring changes compressor-state ownership and lifetime. Keep it
+    # opt-in until its long-context quality and capacity gates are complete.
+    "VLLM_SM70_DSV4_PRIVATE_COMPRESSOR_STATE": lambda: bool(
+        int(os.getenv("VLLM_SM70_DSV4_PRIVATE_COMPRESSOR_STATE", "0"))
     ),
     "VLLM_SM70_FP8_KV_DECODE_CONTEXT_BUCKETS": lambda: os.getenv(
         "VLLM_SM70_FP8_KV_DECODE_CONTEXT_BUCKETS"

--- a/vllm/model_executor/kernels/mhc/tilelang.py
+++ b/vllm/model_executor/kernels/mhc/tilelang.py
@@ -626,12 +626,14 @@ def mhc_fused_post_pre_tilelang(
         and use_fp16
         and capability is not None
         and capability.to_int() == 70
-        and num_tokens == 1
+        and 1 <= num_tokens <= 8
         and hidden_size == 4096
         and hc_mult == 4
         and hc_mult3 == 24
-        and tile_n == 2
-        and n_splits == 8
+        and (
+            (num_tokens < 8 and tile_n == 2 and n_splits == 8)
+            or (num_tokens == 8 and tile_n == 3 and n_splits == 4)
+        )
     )
 
     gemm_out_mul = torch.empty(

--- a/vllm/model_executor/kernels/mhc/tilelang_kernels.py
+++ b/vllm/model_executor/kernels/mhc/tilelang_kernels.py
@@ -539,7 +539,7 @@ def sm70_mhc_post_fp32_stage_tilelang(
     n_thr: int = 256,
     n_splits: int = 8,
 ) -> tilelang.JITKernel:
-    """Materialize the M=1 post mapping without rounding the dot input."""
+    """Materialize a small-token post mapping without rounding the dot input."""
     num_tokens = T.dynamic("num_tokens")
     h_per_split = hidden // n_splits
     h_iters = h_per_split // n_thr
@@ -608,7 +608,7 @@ def sm70_mhc_dot_from_fp32_stage_tilelang(
     tile_n: int = 2,
     n_splits: int = 8,
 ) -> tilelang.JITKernel:
-    """Run the M=1 dot accumulation from the exact FP32 post stage."""
+    """Run small-token dot accumulation from the exact FP32 post stage."""
     num_tokens = T.dynamic("num_tokens")
     h_per_split = hidden // n_splits
     h_iters = h_per_split // n_thr

--- a/vllm/model_executor/layers/quantization/mxfp4_sm70_moe.py
+++ b/vllm/model_executor/layers/quantization/mxfp4_sm70_moe.py
@@ -64,6 +64,12 @@ def _mxfp4_grouped_m8_enabled() -> bool:
     return bool(envs.VLLM_SM70_MXFP4_MOE_GROUPED_M8)
 
 
+def _mxfp4_grouped_m8_expert_rows_enabled() -> bool:
+    return bool(
+        _mxfp4_grouped_m8_enabled() and envs.VLLM_SM70_MXFP4_MOE_GROUPED_M8_EXPERT_ROWS
+    )
+
+
 @triton.jit
 def _compact_sorted_experts_kernel(
     sorted_expert_ids_ptr,
@@ -141,6 +147,12 @@ def _select_mxfp4_stage_dispatch(
         # dynamic unique-expert count.
         graph_expert_slots = num_tokens * _DEEPSEEK_V4_FLASH_TOP_K
         if num_tokens == _GRAPH_SAFE_MAX_TOKENS and _mxfp4_grouped_m8_enabled():
+            if _mxfp4_grouped_m8_expert_rows_enabled():
+                return (
+                    buffers["compact_expert_offsets"],
+                    buffers["active_expert_ids"],
+                    graph_expert_slots,
+                )
             return (
                 buffers["slot_expert_offsets"],
                 buffers["permuted_experts_id"],
@@ -767,7 +779,9 @@ class Mxfp4SM70MoEMethod(Mxfp4MoEMethod):
             num_tokens > 1
             and num_tokens <= _mxfp4_active_expert_max_tokens()
             and not (
-                num_tokens == _GRAPH_SAFE_MAX_TOKENS and _mxfp4_grouped_m8_enabled()
+                num_tokens == _GRAPH_SAFE_MAX_TOKENS
+                and _mxfp4_grouped_m8_enabled()
+                and not _mxfp4_grouped_m8_expert_rows_enabled()
             )
             and layer.expert_map is None
             and layer.local_num_experts == layer.global_num_experts

--- a/vllm/model_executor/layers/quantization/mxfp4_sm70_moe.py
+++ b/vllm/model_executor/layers/quantization/mxfp4_sm70_moe.py
@@ -64,9 +64,24 @@ def _mxfp4_grouped_m8_enabled() -> bool:
     return bool(envs.VLLM_SM70_MXFP4_MOE_GROUPED_M8)
 
 
+def _mxfp4_grouped_verifier_enabled() -> bool:
+    return bool(envs.VLLM_SM70_MXFP4_MOE_GROUPED_VERIFIER)
+
+
+def _mxfp4_grouped_verifier_for_tokens(num_tokens: int) -> bool:
+    return bool(
+        (num_tokens == _GRAPH_SAFE_MAX_TOKENS and _mxfp4_grouped_m8_enabled())
+        or (
+            1 < num_tokens <= _GRAPH_SAFE_MAX_TOKENS
+            and _mxfp4_grouped_verifier_enabled()
+        )
+    )
+
+
 def _mxfp4_grouped_m8_expert_rows_enabled() -> bool:
     return bool(
-        _mxfp4_grouped_m8_enabled() and envs.VLLM_SM70_MXFP4_MOE_GROUPED_M8_EXPERT_ROWS
+        (_mxfp4_grouped_m8_enabled() or _mxfp4_grouped_verifier_enabled())
+        and envs.VLLM_SM70_MXFP4_MOE_GROUPED_M8_EXPERT_ROWS
     )
 
 
@@ -146,7 +161,7 @@ def _select_mxfp4_stage_dispatch(
         # tail entries as zero-row experts, avoiding a host readback of the
         # dynamic unique-expert count.
         graph_expert_slots = num_tokens * _DEEPSEEK_V4_FLASH_TOP_K
-        if num_tokens == _GRAPH_SAFE_MAX_TOKENS and _mxfp4_grouped_m8_enabled():
+        if _mxfp4_grouped_verifier_for_tokens(num_tokens):
             if _mxfp4_grouped_m8_expert_rows_enabled():
                 return (
                     buffers["compact_expert_offsets"],
@@ -779,8 +794,7 @@ class Mxfp4SM70MoEMethod(Mxfp4MoEMethod):
             num_tokens > 1
             and num_tokens <= _mxfp4_active_expert_max_tokens()
             and not (
-                num_tokens == _GRAPH_SAFE_MAX_TOKENS
-                and _mxfp4_grouped_m8_enabled()
+                _mxfp4_grouped_verifier_for_tokens(num_tokens)
                 and not _mxfp4_grouped_m8_expert_rows_enabled()
             )
             and layer.expert_map is None

--- a/vllm/model_executor/layers/sparse_attn_indexer.py
+++ b/vllm/model_executor/layers/sparse_attn_indexer.py
@@ -355,7 +355,7 @@ def sparse_attn_indexer(
                 padded_weights.reshape(num_padded_tokens, -1),
                 seq_lens,
                 decode_metadata.block_table,
-                attn_metadata_narrowed.max_seq_len,
+                attn_metadata_narrowed.compressed_max_seq_len,
             )
         elif current_platform.is_xpu():
             if padded_q_scale is not None:
@@ -397,7 +397,7 @@ def sparse_attn_indexer(
                 topk_indices,
                 topk_workspace,
                 topk_tokens,
-                attn_metadata_narrowed.max_seq_len,
+                logits.shape[1],
             )
         else:
             ops.top_k_per_row_decode(

--- a/vllm/models/deepseek_v4/attention.py
+++ b/vllm/models/deepseek_v4/attention.py
@@ -308,6 +308,7 @@ class DeepseekV4MultiHeadLatentAttentionWrapper(PluggableLayer):
                 rotate=True,
                 prefix=f"{prefix}.compressor",
                 k_cache_prefix=self.mla_attn.prefix,
+                validity_cache_prefix=self.swa_cache_layer.prefix,
             )
 
     def forward(
@@ -923,7 +924,7 @@ class DeepseekV4Indexer(nn.Module):
         attn_metadata = get_forward_context().attn_metadata
         if isinstance(attn_metadata, dict):
             indexer_metadata = cast(Any, attn_metadata[self.k_cache.prefix])
-            if indexer_metadata.max_seq_len // self.compress_ratio <= self.topk_tokens:
+            if indexer_metadata.compressed_max_seq_len <= self.topk_tokens:
                 compressor(compressed_kv_score, positions, rotary_emb)
                 assert self.topk_indices_buffer is not None
                 num_tokens = (

--- a/vllm/models/deepseek_v4/common/ops/__init__.py
+++ b/vllm/models/deepseek_v4/common/ops/__init__.py
@@ -11,7 +11,11 @@ from .fused_indexer_q import MXFP4_BLOCK_SIZE, fused_indexer_q_rope_quant
 from .fused_inv_rope_fp8_quant import fused_inv_rope_fp8_quant
 from .fused_mtp_input_rmsnorm import fused_mtp_input_rmsnorm, mtp_shared_head_rmsnorm
 from .fused_qk_rmsnorm import fused_q_kv_rmsnorm
-from .save_partial_states import save_partial_states
+from .save_partial_states import (
+    save_partial_states,
+    save_partial_states_to_ring,
+    stage_partial_states_from_ring,
+)
 
 __all__ = [
     "MXFP4_BLOCK_SIZE",
@@ -25,4 +29,6 @@ __all__ = [
     "mtp_shared_head_rmsnorm",
     "quantize_and_insert_k_cache",
     "save_partial_states",
+    "save_partial_states_to_ring",
+    "stage_partial_states_from_ring",
 ]

--- a/vllm/models/deepseek_v4/common/ops/fused_compress_quant_cache.py
+++ b/vllm/models/deepseek_v4/common/ops/fused_compress_quant_cache.py
@@ -30,8 +30,148 @@ from .fp8_software import fp32_to_fp8_e4m3fn_bits
 from .fused_indexer_q import _fp32x2_to_fp4x2
 
 
+@triton.jit
+def _gather_compressor_window(
+    state_cache_ptr,
+    state_cache_stride0,
+    state_cache_stride1,
+    current_kv_ptr,
+    current_kv_stride,
+    current_score_ptr,
+    current_score_stride,
+    ape_ptr,
+    ape_stride,
+    block_table_ptr,
+    block_table_stride,
+    positions_ptr,
+    position,
+    token_idx,
+    req_idx,
+    block_size,
+    block,
+    mask,
+    HEAD_SIZE: tl.constexpr,
+    STATE_WIDTH: tl.constexpr,
+    COMPRESS_RATIO: tl.constexpr,
+    OVERLAP: tl.constexpr,
+    USE_PRIVATE_STATE: tl.constexpr,
+    USE_DENSE_PRIVATE_STATE: tl.constexpr,
+    RING_SIZE: tl.constexpr,
+    PRIVATE_HISTORY_SIZE: tl.constexpr,
+):
+    """Gather a compression window from paged state or current input + ring."""
+    tokens = tl.arange(0, (1 + OVERLAP) * COMPRESS_RATIO)
+    pos = position - (1 + OVERLAP) * COMPRESS_RATIO + 1 + tokens
+    mask_pos = pos >= 0
+    head_offset = (tokens >= COMPRESS_RATIO).to(tl.int32) * HEAD_SIZE
+
+    if USE_DENSE_PRIVATE_STATE:
+        current_start = position - token_idx
+        dense_rows = pos - current_start + PRIVATE_HISTORY_SIZE
+        row_base = (
+            state_cache_ptr
+            + req_idx.to(tl.int64) * state_cache_stride0
+            + dense_rows.to(tl.int64) * state_cache_stride1
+            + head_offset
+        )
+        combined_mask = mask_pos[:, None] & mask[None, :]
+        score = tl.load(
+            row_base[:, None] + STATE_WIDTH + block[None, :],
+            mask=combined_mask,
+            other=float("-inf"),
+        )
+        kv = tl.load(
+            row_base[:, None] + block[None, :],
+            mask=combined_mask,
+            other=0.0,
+        )
+        return kv, score
+
+    if USE_PRIVATE_STATE:
+        # This route is gated to one request with contiguous positions.
+        current_start = position - token_idx
+        current_idx = pos - current_start
+        from_current = mask_pos & (current_idx >= 0)
+        from_history = mask_pos & (current_idx < 0)
+        current_mask = from_current[:, None] & mask[None, :]
+        history_mask = from_history[:, None] & mask[None, :]
+        offsets = head_offset[:, None] + block[None, :]
+
+        current_kv = tl.load(
+            current_kv_ptr
+            + current_idx[:, None].to(tl.int64) * current_kv_stride
+            + offsets,
+            mask=current_mask,
+            other=0.0,
+        ).to(tl.float32)
+        current_score = tl.load(
+            current_score_ptr
+            + current_idx[:, None].to(tl.int64) * current_score_stride
+            + offsets,
+            mask=current_mask,
+            other=0.0,
+        ).to(tl.float32)
+        ape = tl.load(
+            ape_ptr
+            + (pos % COMPRESS_RATIO)[:, None].to(tl.int64) * ape_stride
+            + offsets,
+            mask=current_mask,
+            other=0.0,
+        ).to(tl.float32)
+
+        safe_pos = tl.maximum(pos, 0)
+        ring_base = (
+            state_cache_ptr
+            + req_idx.to(tl.int64) * state_cache_stride0
+            + (safe_pos % RING_SIZE).to(tl.int64) * state_cache_stride1
+            + head_offset
+        )
+        history_kv = tl.load(
+            ring_base[:, None] + block[None, :],
+            mask=history_mask,
+            other=0.0,
+        )
+        history_score = tl.load(
+            ring_base[:, None] + STATE_WIDTH + block[None, :],
+            mask=history_mask,
+            other=float("-inf"),
+        )
+        kv = tl.where(current_mask, current_kv, history_kv)
+        score = tl.where(current_mask, current_score + ape, history_score)
+        return kv, score
+
+    block_indices = pos // block_size
+    block_numbers = tl.load(
+        block_table_ptr + req_idx * block_table_stride + block_indices,
+        mask=mask_pos,
+        other=0,
+    )
+    block_offsets = pos % block_size
+    row_base = (
+        state_cache_ptr
+        + block_numbers.to(tl.int64) * state_cache_stride0
+        + block_offsets * state_cache_stride1
+        + head_offset
+    )
+    combined_mask = mask_pos[:, None] & mask[None, :]
+    score = tl.load(
+        row_base[:, None] + STATE_WIDTH + block[None, :],
+        mask=combined_mask,
+        other=float("-inf"),
+    )
+    kv = tl.load(
+        row_base[:, None] + block[None, :],
+        mask=combined_mask,
+        other=0.0,
+    )
+    return kv, score
+
+
 def compress_norm_rope_store_triton(
     state_cache: torch.Tensor,
+    current_kv: torch.Tensor,
+    current_score: torch.Tensor,
+    ape: torch.Tensor,
     num_actual: int,
     token_to_req_indices: torch.Tensor,
     positions: torch.Tensor,
@@ -53,6 +193,10 @@ def compress_norm_rope_store_triton(
     quant_block: int,
     token_stride: int,
     scale_dim: int,
+    use_private_state: bool = False,
+    use_dense_private_state: bool = False,
+    ring_size: int = 1,
+    private_history_size: int = 1,
 ) -> None:
     """Shared triton launcher for the fused compress+norm+RoPE+insert path.
 
@@ -91,6 +235,12 @@ def compress_norm_rope_store_triton(
         kv_cache,
         k_cache_metadata.slot_mapping,
         kv_cache.shape[1],  # paged KV cache block size (tokens per block)
+        current_kv,
+        current_kv.stride(0),
+        current_score,
+        current_score.stride(0),
+        ape,
+        ape.stride(0),
         # constexprs
         HEAD_SIZE=head_dim,
         TRITON_BLOCK_SIZE=triton.next_power_of_2(head_dim),
@@ -106,6 +256,10 @@ def compress_norm_rope_store_triton(
         USE_SOFTWARE_FP8=(
             current_platform.is_cuda() and current_platform.is_device_capability((7, 0))
         ),
+        USE_PRIVATE_STATE=use_private_state,
+        USE_DENSE_PRIVATE_STATE=use_dense_private_state,
+        RING_SIZE=ring_size,
+        PRIVATE_HISTORY_SIZE=private_history_size,
         num_warps=num_warps,
         **pdl_kwargs,
     )
@@ -137,6 +291,13 @@ def _fused_kv_compress_norm_rope_insert_sparse_attn(
     k_cache_ptr,
     kv_slot_mapping_ptr,
     kv_cache_block_size,
+    # current chunk (private-state path)
+    current_kv_ptr,
+    current_kv_stride,
+    current_score_ptr,
+    current_score_stride,
+    ape_ptr,
+    ape_stride,
     # ── constexprs ──
     HEAD_SIZE: tl.constexpr,
     TRITON_BLOCK_SIZE: tl.constexpr,
@@ -150,6 +311,10 @@ def _fused_kv_compress_norm_rope_insert_sparse_attn(
     SCALE_DIM: tl.constexpr,  # 8 for DeepseekV4 (7 real + 1 pad)
     KV_BLOCK_STRIDE: tl.constexpr,
     USE_SOFTWARE_FP8: tl.constexpr,
+    USE_PRIVATE_STATE: tl.constexpr,
+    USE_DENSE_PRIVATE_STATE: tl.constexpr,
+    RING_SIZE: tl.constexpr,
+    PRIVATE_HISTORY_SIZE: tl.constexpr,
 ):
     """Fused compress → RMSNorm → FP8 quant (nope) → RoPE → bf16 store (rope).
 
@@ -172,47 +337,39 @@ def _fused_kv_compress_norm_rope_insert_sparse_attn(
     req_idx = tl.load(token_to_req_indices_ptr + token_idx)
 
     # ── Gather state cache entries ────────────────────────────────────
-    start = position - (1 + OVERLAP) * COMPRESS_RATIO + 1
-    tokens = tl.arange(0, (1 + OVERLAP) * COMPRESS_RATIO)
-    pos = start + tokens
-    mask_pos = pos >= 0
-
-    block_indices = pos // block_size
-    block_numbers = tl.load(
-        block_table_ptr + req_idx * block_table_stride + block_indices,
-        mask=mask_pos,
-        other=0,
-    )
-    block_offsets = pos % block_size
-    head_offset = (tokens >= COMPRESS_RATIO).to(tl.int32) * HEAD_SIZE
-
     block = tl.arange(0, TRITON_BLOCK_SIZE)
     mask = block < HEAD_SIZE
-    block_numbers_i64 = block_numbers.to(tl.int64)
-
-    # Precomputed row base shared by score and kv loads
-    row_base = (
-        state_cache_ptr
-        + block_numbers_i64 * state_cache_stride0
-        + block_offsets * state_cache_stride1
-        + head_offset
+    kv, score = _gather_compressor_window(
+        state_cache_ptr,
+        state_cache_stride0,
+        state_cache_stride1,
+        current_kv_ptr,
+        current_kv_stride,
+        current_score_ptr,
+        current_score_stride,
+        ape_ptr,
+        ape_stride,
+        block_table_ptr,
+        block_table_stride,
+        positions_ptr,
+        position,
+        token_idx,
+        req_idx,
+        block_size,
+        block,
+        mask,
+        HEAD_SIZE,
+        STATE_WIDTH,
+        COMPRESS_RATIO,
+        OVERLAP,
+        USE_PRIVATE_STATE,
+        USE_DENSE_PRIVATE_STATE,
+        RING_SIZE,
+        PRIVATE_HISTORY_SIZE,
     )
-
-    combined_mask = mask_pos[:, None] & mask[None, :]
 
     # ── Softmax + weighted sum ───────────────────────────────────────
-    score = tl.load(
-        row_base[:, None] + STATE_WIDTH + block[None, :],
-        mask=combined_mask,
-        other=float("-inf"),
-    )
     score = tl.softmax(score, dim=0)
-
-    kv = tl.load(
-        row_base[:, None] + block[None, :],
-        mask=combined_mask,
-        other=0.0,
-    )
 
     compressed_kv = tl.sum(kv * score, axis=0)  # [TRITON_BLOCK_SIZE] fp32
 
@@ -331,6 +488,13 @@ def _fused_kv_compress_norm_rope_insert_indexer_attn(
     k_cache_ptr,
     kv_slot_mapping_ptr,
     kv_cache_block_size,
+    # current chunk (private-state path)
+    current_kv_ptr,
+    current_kv_stride,
+    current_score_ptr,
+    current_score_stride,
+    ape_ptr,
+    ape_stride,
     # ── constexprs ──
     HEAD_SIZE: tl.constexpr,
     TRITON_BLOCK_SIZE: tl.constexpr,
@@ -344,6 +508,10 @@ def _fused_kv_compress_norm_rope_insert_indexer_attn(
     SCALE_DIM: tl.constexpr,  # 4 for indexer (1 float32)
     KV_BLOCK_STRIDE: tl.constexpr,
     USE_SOFTWARE_FP8: tl.constexpr,
+    USE_PRIVATE_STATE: tl.constexpr,
+    USE_DENSE_PRIVATE_STATE: tl.constexpr,
+    RING_SIZE: tl.constexpr,
+    PRIVATE_HISTORY_SIZE: tl.constexpr,
 ):
     """Fused compress → RMSNorm → RoPE → FP8 quant → store.
 
@@ -370,45 +538,37 @@ def _fused_kv_compress_norm_rope_insert_indexer_attn(
     req_idx = tl.load(token_to_req_indices_ptr + token_idx)
 
     # ── Gather state cache entries ────────────────────────────────────
-    start = position - (1 + OVERLAP) * COMPRESS_RATIO + 1
-    tokens = tl.arange(0, (1 + OVERLAP) * COMPRESS_RATIO)
-    pos = start + tokens
-    mask_pos = pos >= 0
-
-    block_indices = pos // block_size
-    block_numbers = tl.load(
-        block_table_ptr + req_idx * block_table_stride + block_indices,
-        mask=mask_pos,
-        other=0,
-    )
-    block_offsets = pos % block_size
-    head_offset = (tokens >= COMPRESS_RATIO).to(tl.int32) * HEAD_SIZE
-
     block = tl.arange(0, TRITON_BLOCK_SIZE)
     mask = block < HEAD_SIZE
-    block_numbers_i64 = block_numbers.to(tl.int64)
-
-    row_base = (
-        state_cache_ptr
-        + block_numbers_i64 * state_cache_stride0
-        + block_offsets * state_cache_stride1
-        + head_offset
-    )
-
-    combined_mask = mask_pos[:, None] & mask[None, :]
-
-    score = tl.load(
-        row_base[:, None] + STATE_WIDTH + block[None, :],
-        mask=combined_mask,
-        other=float("-inf"),
+    kv, score = _gather_compressor_window(
+        state_cache_ptr,
+        state_cache_stride0,
+        state_cache_stride1,
+        current_kv_ptr,
+        current_kv_stride,
+        current_score_ptr,
+        current_score_stride,
+        ape_ptr,
+        ape_stride,
+        block_table_ptr,
+        block_table_stride,
+        positions_ptr,
+        position,
+        token_idx,
+        req_idx,
+        block_size,
+        block,
+        mask,
+        HEAD_SIZE,
+        STATE_WIDTH,
+        COMPRESS_RATIO,
+        OVERLAP,
+        USE_PRIVATE_STATE,
+        USE_DENSE_PRIVATE_STATE,
+        RING_SIZE,
+        PRIVATE_HISTORY_SIZE,
     )
     score = tl.softmax(score, dim=0)
-
-    kv = tl.load(
-        row_base[:, None] + block[None, :],
-        mask=combined_mask,
-        other=0.0,
-    )
 
     compressed_kv = tl.sum(kv * score, axis=0)  # [TRITON_BLOCK_SIZE] fp32
 
@@ -512,6 +672,13 @@ def _fused_kv_compress_norm_rope_insert_indexer_mxfp4_attn(
     k_cache_ptr,
     kv_slot_mapping_ptr,
     kv_cache_block_size,
+    # current chunk (private-state path)
+    current_kv_ptr,
+    current_kv_stride,
+    current_score_ptr,
+    current_score_stride,
+    ape_ptr,
+    ape_stride,
     # ── constexprs ──
     HEAD_SIZE: tl.constexpr,
     TRITON_BLOCK_SIZE: tl.constexpr,
@@ -525,6 +692,10 @@ def _fused_kv_compress_norm_rope_insert_indexer_mxfp4_attn(
     SCALE_DIM: tl.constexpr,  # HEAD_SIZE // QUANT_BLOCK = 4 ue8m0 bytes/token
     KV_BLOCK_STRIDE: tl.constexpr,
     USE_SOFTWARE_FP8: tl.constexpr,
+    USE_PRIVATE_STATE: tl.constexpr,
+    USE_DENSE_PRIVATE_STATE: tl.constexpr,
+    RING_SIZE: tl.constexpr,
+    PRIVATE_HISTORY_SIZE: tl.constexpr,
 ):
     """Fused compress → RMSNorm → RoPE → MXFP4 quant → store.
 
@@ -553,45 +724,37 @@ def _fused_kv_compress_norm_rope_insert_indexer_mxfp4_attn(
     req_idx = tl.load(token_to_req_indices_ptr + token_idx)
 
     # ── Gather state cache entries ────────────────────────────────────
-    start = position - (1 + OVERLAP) * COMPRESS_RATIO + 1
-    tokens = tl.arange(0, (1 + OVERLAP) * COMPRESS_RATIO)
-    pos = start + tokens
-    mask_pos = pos >= 0
-
-    block_indices = pos // block_size
-    block_numbers = tl.load(
-        block_table_ptr + req_idx * block_table_stride + block_indices,
-        mask=mask_pos,
-        other=0,
-    )
-    block_offsets = pos % block_size
-    head_offset = (tokens >= COMPRESS_RATIO).to(tl.int32) * HEAD_SIZE
-
     block = tl.arange(0, TRITON_BLOCK_SIZE)
     mask = block < HEAD_SIZE
-    block_numbers_i64 = block_numbers.to(tl.int64)
-
-    row_base = (
-        state_cache_ptr
-        + block_numbers_i64 * state_cache_stride0
-        + block_offsets * state_cache_stride1
-        + head_offset
-    )
-
-    combined_mask = mask_pos[:, None] & mask[None, :]
-
-    score = tl.load(
-        row_base[:, None] + STATE_WIDTH + block[None, :],
-        mask=combined_mask,
-        other=float("-inf"),
+    kv, score = _gather_compressor_window(
+        state_cache_ptr,
+        state_cache_stride0,
+        state_cache_stride1,
+        current_kv_ptr,
+        current_kv_stride,
+        current_score_ptr,
+        current_score_stride,
+        ape_ptr,
+        ape_stride,
+        block_table_ptr,
+        block_table_stride,
+        positions_ptr,
+        position,
+        token_idx,
+        req_idx,
+        block_size,
+        block,
+        mask,
+        HEAD_SIZE,
+        STATE_WIDTH,
+        COMPRESS_RATIO,
+        OVERLAP,
+        USE_PRIVATE_STATE,
+        USE_DENSE_PRIVATE_STATE,
+        RING_SIZE,
+        PRIVATE_HISTORY_SIZE,
     )
     score = tl.softmax(score, dim=0)
-
-    kv = tl.load(
-        row_base[:, None] + block[None, :],
-        mask=combined_mask,
-        other=0.0,
-    )
 
     compressed_kv = tl.sum(kv * score, axis=0)  # [TRITON_BLOCK_SIZE] fp32
 

--- a/vllm/models/deepseek_v4/common/ops/save_partial_states.py
+++ b/vllm/models/deepseek_v4/common/ops/save_partial_states.py
@@ -45,6 +45,93 @@ def save_partial_states(
     )
 
 
+def save_partial_states_to_ring(
+    kv: torch.Tensor,
+    score: torch.Tensor,
+    ape: torch.Tensor,
+    positions: torch.Tensor,
+    state_ring: torch.Tensor,
+    slot_mapping: torch.Tensor,
+    token_to_req_indices: torch.Tensor,
+    seq_lens: torch.Tensor,
+    state_width: int,
+    compress_ratio: int,
+    pdl_kwargs: dict | None = None,
+) -> None:
+    """Keep only the compressor history that can cross a forward boundary."""
+    num_slots = slot_mapping.shape[0]
+    head_size = kv.shape[-1]
+    _save_partial_states_to_ring_kernel[(num_slots,)](
+        kv,
+        kv.stride(0),
+        score,
+        score.stride(0),
+        ape,
+        ape.stride(0),
+        positions,
+        state_ring,
+        state_ring.stride(0),
+        state_ring.stride(1),
+        slot_mapping,
+        token_to_req_indices,
+        seq_lens,
+        HEAD_SIZE=head_size,
+        TRITON_BLOCK_SIZE=triton.next_power_of_2(head_size),
+        STATE_WIDTH=state_width,
+        RING_SIZE=state_ring.shape[1],
+        COMPRESS_RATIO=compress_ratio,
+        **(pdl_kwargs or {}),
+    )
+
+
+def stage_partial_states_from_ring(
+    kv: torch.Tensor,
+    score: torch.Tensor,
+    ape: torch.Tensor,
+    positions: torch.Tensor,
+    state_ring: torch.Tensor,
+    dense_state: torch.Tensor,
+    slot_mapping: torch.Tensor,
+    state_width: int,
+    history_size: int,
+    compress_ratio: int,
+    pdl_kwargs: dict | None = None,
+) -> None:
+    """Stage private history and the current chunk into one dense state view."""
+    num_slots = slot_mapping.shape[0]
+    copy_block_size = triton.next_power_of_2(2 * state_width)
+    _copy_ring_history_to_dense_kernel[(history_size,)](
+        positions,
+        state_ring,
+        state_ring.stride(1),
+        dense_state,
+        dense_state.stride(0),
+        STATE_DIM=2 * state_width,
+        HISTORY_SIZE=history_size,
+        RING_SIZE=state_ring.shape[1],
+        BLOCK_SIZE=copy_block_size,
+        **(pdl_kwargs or {}),
+    )
+    _save_current_states_to_dense_kernel[(num_slots,)](
+        kv,
+        kv.stride(0),
+        score,
+        score.stride(0),
+        ape,
+        ape.stride(0),
+        positions,
+        dense_state,
+        dense_state.stride(0),
+        slot_mapping,
+        HEAD_SIZE=kv.shape[-1],
+        BLOCK_SIZE=triton.next_power_of_2(kv.shape[-1]),
+        STATE_WIDTH=state_width,
+        HISTORY_SIZE=history_size,
+        COMPRESS_RATIO=compress_ratio,
+        **(pdl_kwargs or {}),
+    )
+
+
 @triton.jit
 def _save_partial_states_kernel(
     kv_ptr,
@@ -99,3 +186,123 @@ def _save_partial_states_kernel(
         score + ape,
         mask=mask,
     )
+
+
+@triton.jit
+def _save_partial_states_to_ring_kernel(
+    kv_ptr,
+    kv_stride,
+    score_ptr,
+    score_stride,
+    ape_ptr,
+    ape_stride,
+    positions_ptr,
+    state_ring_ptr,
+    state_ring_stride0,
+    state_ring_stride1,
+    slot_mapping_ptr,
+    token_to_req_indices_ptr,
+    seq_lens_ptr,
+    HEAD_SIZE: tl.constexpr,
+    TRITON_BLOCK_SIZE: tl.constexpr,
+    STATE_WIDTH: tl.constexpr,
+    RING_SIZE: tl.constexpr,
+    COMPRESS_RATIO: tl.constexpr,
+):
+    token_idx = tl.program_id(0)
+    if tl.load(slot_mapping_ptr + token_idx) < 0:
+        return
+
+    req_idx = tl.load(token_to_req_indices_ptr + token_idx)
+    position = tl.load(positions_ptr + token_idx)
+    seq_len = tl.load(seq_lens_ptr + req_idx)
+    if position < seq_len - RING_SIZE:
+        return
+
+    ring_row = position % RING_SIZE
+    base_ptr = (
+        state_ring_ptr
+        + req_idx.to(tl.int64) * state_ring_stride0
+        + ring_row.to(tl.int64) * state_ring_stride1
+    )
+    block = tl.arange(0, TRITON_BLOCK_SIZE)
+    mask = block < HEAD_SIZE
+
+    kv = tl.load(kv_ptr + token_idx * kv_stride + block, mask=mask).to(tl.float32)
+    tl.store(base_ptr + block, kv, mask=mask)
+
+    ape_row = position % COMPRESS_RATIO
+    ape = tl.load(ape_ptr + ape_row * ape_stride + block, mask=mask).to(tl.float32)
+    score = tl.load(score_ptr + token_idx * score_stride + block, mask=mask).to(
+        tl.float32
+    )
+    tl.store(base_ptr + STATE_WIDTH + block, score + ape, mask=mask)
+
+
+@triton.jit
+def _copy_ring_history_to_dense_kernel(
+    positions_ptr,
+    state_ring_ptr,
+    state_ring_stride1,
+    dense_state_ptr,
+    dense_state_stride0,
+    STATE_DIM: tl.constexpr,
+    HISTORY_SIZE: tl.constexpr,
+    RING_SIZE: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+):
+    history_idx = tl.program_id(0)
+    current_start = tl.load(positions_ptr)
+    position = current_start - HISTORY_SIZE + history_idx
+    if position < 0:
+        return
+
+    block = tl.arange(0, BLOCK_SIZE)
+    mask = block < STATE_DIM
+    ring_row = position % RING_SIZE
+    values = tl.load(
+        state_ring_ptr + ring_row.to(tl.int64) * state_ring_stride1 + block,
+        mask=mask,
+    )
+    tl.store(
+        dense_state_ptr + history_idx * dense_state_stride0 + block,
+        values,
+        mask=mask,
+    )
+
+
+@triton.jit
+def _save_current_states_to_dense_kernel(
+    kv_ptr,
+    kv_stride,
+    score_ptr,
+    score_stride,
+    ape_ptr,
+    ape_stride,
+    positions_ptr,
+    dense_state_ptr,
+    dense_state_stride0,
+    slot_mapping_ptr,
+    HEAD_SIZE: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+    STATE_WIDTH: tl.constexpr,
+    HISTORY_SIZE: tl.constexpr,
+    COMPRESS_RATIO: tl.constexpr,
+):
+    token_idx = tl.program_id(0)
+    if tl.load(slot_mapping_ptr + token_idx) < 0:
+        return
+
+    block = tl.arange(0, BLOCK_SIZE)
+    mask = block < HEAD_SIZE
+    row_ptr = dense_state_ptr + (HISTORY_SIZE + token_idx) * dense_state_stride0
+    kv = tl.load(kv_ptr + token_idx * kv_stride + block, mask=mask).to(tl.float32)
+    tl.store(row_ptr + block, kv, mask=mask)
+
+    position = tl.load(positions_ptr + token_idx)
+    ape_row = position % COMPRESS_RATIO
+    ape = tl.load(ape_ptr + ape_row * ape_stride + block, mask=mask).to(tl.float32)
+    score = tl.load(score_ptr + token_idx * score_stride + block, mask=mask).to(
+        tl.float32
+    )
+    tl.store(row_ptr + STATE_WIDTH + block, score + ape, mask=mask)

--- a/vllm/models/deepseek_v4/compressor.py
+++ b/vllm/models/deepseek_v4/compressor.py
@@ -8,6 +8,7 @@ from typing import Any, ClassVar, cast
 import torch
 from torch import nn
 
+from vllm import envs
 from vllm.config import CUDAGraphMode, VllmConfig, get_current_vllm_config
 from vllm.forward_context import get_forward_context
 from vllm.logger import init_logger
@@ -45,7 +46,8 @@ def _can_use_sm70_private_compressor_state(vllm_config: VllmConfig) -> bool:
     kv_transfer_config = vllm_config.kv_transfer_config
     spec_config = vllm_config.speculative_config
     return (
-        current_platform.is_cuda()
+        envs.VLLM_SM70_DSV4_PRIVATE_COMPRESSOR_STATE
+        and current_platform.is_cuda()
         and current_platform.is_device_capability((7, 0))
         and vllm_config.scheduler_config.max_num_seqs == 1
         and not vllm_config.cache_config.enable_prefix_caching

--- a/vllm/models/deepseek_v4/compressor.py
+++ b/vllm/models/deepseek_v4/compressor.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any, ClassVar, cast
 
@@ -464,6 +465,7 @@ class DeepseekCompressor(nn.Module):
         k_cache_metadata = cast(Any, attn_metadata[self.k_cache_prefix])
         kv_cache = self._static_forward_context[self.k_cache_prefix].kv_cache
 
+        compress_norm_rope_store_fn: Callable[..., None]
         if current_platform.is_cuda() and not current_platform.is_device_capability(
             (7, 0)
         ):

--- a/vllm/models/deepseek_v4/compressor.py
+++ b/vllm/models/deepseek_v4/compressor.py
@@ -9,6 +9,7 @@ from torch import nn
 
 from vllm.config import CUDAGraphMode, VllmConfig, get_current_vllm_config
 from vllm.forward_context import get_forward_context
+from vllm.logger import init_logger
 from vllm.model_executor.layers.attention_layer_base import AttentionLayerBase
 from vllm.model_executor.layers.layernorm import RMSNorm
 from vllm.model_executor.layers.linear import MergedColumnParallelLinear
@@ -18,6 +19,8 @@ from vllm.models.deepseek_v4.common.ops.fused_compress_quant_cache import (
 from vllm.models.deepseek_v4.common.ops.fused_indexer_q import MXFP4_BLOCK_SIZE
 from vllm.models.deepseek_v4.common.ops.save_partial_states import (
     save_partial_states,
+    save_partial_states_to_ring,
+    stage_partial_states_from_ring,
 )
 from vllm.platforms import current_platform
 from vllm.v1.attention.backend import (
@@ -32,6 +35,27 @@ from vllm.v1.kv_cache_interface import (
     MLAAttentionSpec,
     SlidingWindowMLASpec,
 )
+from vllm.v1.worker.workspace import current_workspace_manager
+
+logger = init_logger(__name__)
+
+
+def _can_use_sm70_private_compressor_state(vllm_config: VllmConfig) -> bool:
+    kv_transfer_config = vllm_config.kv_transfer_config
+    spec_config = vllm_config.speculative_config
+    return (
+        current_platform.is_cuda()
+        and current_platform.is_device_capability((7, 0))
+        and vllm_config.scheduler_config.max_num_seqs == 1
+        and not vllm_config.cache_config.enable_prefix_caching
+        and vllm_config.parallel_config.pipeline_parallel_size == 1
+        # The private gather assumes one contiguous token chain. Parallel
+        # drafting uses multiple branches and must retain the paged fallback.
+        and (spec_config is None or not spec_config.parallel_drafting)
+        and (
+            kv_transfer_config is None or not kv_transfer_config.is_kv_transfer_instance
+        )
+    )
 
 
 def _get_c128_boundary(metadata: CommonAttentionMetadata) -> bool | None:
@@ -141,12 +165,27 @@ class CompressorStateCache(torch.nn.Module, AttentionLayerBase):
         dtype: torch.dtype,
         compress_ratio: int,
         prefix: str,
+        private_ring_size: int = 0,
+        max_num_reqs: int = 1,
     ):
         super().__init__()
         self.state_dim = state_dim
         self.dtype = dtype
         self.prefix = prefix
         self.kv_cache = torch.tensor([])
+        self.private_ring_size = private_ring_size
+        if private_ring_size > 0:
+            self.register_buffer(
+                "private_state",
+                torch.empty(
+                    (max_num_reqs, private_ring_size, state_dim),
+                    dtype=dtype,
+                    device=current_platform.device_type,
+                ),
+                persistent=False,
+            )
+        else:
+            self.private_state = None
         compilation_config = get_current_vllm_config().compilation_config
         if prefix in compilation_config.static_forward_context:
             raise ValueError(f"Duplicate layer name: {prefix}")
@@ -170,7 +209,9 @@ class CompressorStateCache(torch.nn.Module, AttentionLayerBase):
         else:
             raise ValueError(f"Invalid compress ratio: {compress_ratio}")
 
-    def get_kv_cache_spec(self, vllm_config: VllmConfig) -> KVCacheSpec:
+    def get_kv_cache_spec(self, vllm_config: VllmConfig) -> KVCacheSpec | None:
+        if self.private_state is not None:
+            return None
         return SlidingWindowMLASpec(  # only has one vector instead of K + V
             block_size=self.block_size,
             num_kv_heads=1,
@@ -206,6 +247,7 @@ class DeepseekCompressor(nn.Module):
         rotate: bool = False,
         prefix: str = "",
         k_cache_prefix="",
+        validity_cache_prefix="",
         use_fp4_cache: bool = False,
     ):
         super().__init__()
@@ -215,6 +257,7 @@ class DeepseekCompressor(nn.Module):
         self.rotate = rotate
         self.prefix = prefix
         self.k_cache_prefix = k_cache_prefix
+        self.validity_cache_prefix = validity_cache_prefix
         self.use_fp4_cache = use_fp4_cache
 
         config = vllm_config.model_config.hf_config
@@ -227,6 +270,17 @@ class DeepseekCompressor(nn.Module):
 
         self.overlap = compress_ratio == 4
         self.coff = 1 + self.overlap
+        self.use_private_state = _can_use_sm70_private_compressor_state(vllm_config)
+        num_speculative_tokens = (
+            vllm_config.speculative_config.num_speculative_tokens
+            if vllm_config.speculative_config is not None
+            else 0
+        )
+        private_ring_size = (
+            self.coff * compress_ratio + max(1, num_speculative_tokens + 1)
+            if self.use_private_state
+            else 0
+        )
 
         state_dtype = torch.float32
         self.ape = nn.Parameter(
@@ -254,7 +308,15 @@ class DeepseekCompressor(nn.Module):
             dtype=state_dtype,
             compress_ratio=compress_ratio,
             prefix=f"{prefix}.state_cache",
+            private_ring_size=private_ring_size,
+            max_num_reqs=self.max_num_reqs,
         )
+        if self.use_private_state:
+            logger.info_once(
+                "Using SM70 private DeepSeek V4 compressor state rings "
+                "(max_num_seqs=1, prefix cache disabled); paged compressor "
+                "state allocation is disabled."
+            )
 
         # Save reference to static_forward_context for forward-time KV cache lookup.
         # get_current_vllm_config() is only available during __init__, not forward.
@@ -303,19 +365,33 @@ class DeepseekCompressor(nn.Module):
         if not isinstance(attn_metadata, dict):
             return
 
-        state_metadata = cast(
-            CompressorMetadata, attn_metadata[self.state_cache.prefix]
-        )
-        token_to_req_indices = state_metadata.token_to_req_indices
-        slot_mapping = state_metadata.slot_mapping
+        seq_lens = None
+        if self.use_private_state:
+            assert self.validity_cache_prefix, (
+                "Private compressor state requires an SWA metadata source."
+            )
+            validity_metadata = cast(Any, attn_metadata[self.validity_cache_prefix])
+            token_to_req_indices = validity_metadata.token_to_req_indices
+            slot_mapping = validity_metadata.slot_mapping
+            block_table = validity_metadata.block_table
+            block_size = validity_metadata.block_size
+            seq_lens = validity_metadata.seq_lens
+            state_cache = self.state_cache.private_state
+            assert state_cache is not None
+            assert token_to_req_indices is not None and seq_lens is not None
+            state_width = self.state_cache.state_dim // 2
+            state_metadata = None
+        else:
+            state_metadata = cast(
+                CompressorMetadata, attn_metadata[self.state_cache.prefix]
+            )
+            token_to_req_indices = state_metadata.token_to_req_indices
+            slot_mapping = state_metadata.slot_mapping
+            block_table = state_metadata.block_table
+            block_size = state_metadata.block_size
+            state_cache = self.state_cache.kv_cache
+            state_width = state_cache.shape[-1] // 2
         num_actual = slot_mapping.shape[0]
-        block_table = state_metadata.block_table
-        block_size = state_metadata.block_size
-
-        # [num_blocks, block_size, kv_dim+score_dim], where kv_dim == score_dim
-        state_cache = self.state_cache.kv_cache
-        # kv_state stored in first half, score_state stored in second half
-        state_width = state_cache.shape[-1] // 2
         pdl_kwargs = (
             {}
             if current_platform.is_rocm() or current_platform.is_xpu()
@@ -328,21 +404,48 @@ class DeepseekCompressor(nn.Module):
         # GEMM; state_cache from this kernel) but neither emits/waits on PDL
         # grid dependency primitives, so launch_pdl=True caused a
         # read-after-write race and non-deterministic output.
-        save_partial_states(
-            kv=kv,
-            score=score,
-            ape=self.ape,
-            positions=positions,
-            state_cache=state_cache,
-            slot_mapping=slot_mapping,
-            block_size=block_size,
-            state_width=state_width,
-            compress_ratio=self.compress_ratio,
-            pdl_kwargs=pdl_kwargs,
-        )
+        if not self.use_private_state:
+            save_partial_states(
+                kv=kv,
+                score=score,
+                ape=self.ape,
+                positions=positions,
+                state_cache=state_cache,
+                slot_mapping=slot_mapping,
+                block_size=block_size,
+                state_width=state_width,
+                compress_ratio=self.compress_ratio,
+                pdl_kwargs=pdl_kwargs,
+            )
+
+        use_dense_private_state = self.use_private_state and self.compress_ratio == 128
+        compression_state_cache = state_cache
+        private_history_size = self.coff * self.compress_ratio
+        if use_dense_private_state:
+            (dense_state,) = current_workspace_manager().get_simultaneous(
+                (
+                    (private_history_size + num_actual, 2 * state_width),
+                    torch.float32,
+                )
+            )
+            stage_partial_states_from_ring(
+                kv=kv,
+                score=score,
+                ape=self.ape,
+                positions=positions,
+                state_ring=state_cache,
+                dense_state=dense_state,
+                slot_mapping=slot_mapping,
+                state_width=state_width,
+                history_size=private_history_size,
+                compress_ratio=self.compress_ratio,
+                pdl_kwargs=pdl_kwargs,
+            )
+            compression_state_cache = dense_state.unsqueeze(0)
 
         if (
             current_platform.is_cuda()
+            and not self.use_private_state
             and self.head_dim == 512
             and self.compress_ratio == 128
             and forward_context.cudagraph_runtime_mode != CUDAGraphMode.FULL
@@ -382,8 +485,8 @@ class DeepseekCompressor(nn.Module):
             # Always use a triton kernel.
             compress_norm_rope_store_fn = compress_norm_rope_store_triton
 
-        compress_norm_rope_store_fn(
-            state_cache=state_cache,
+        compress_kwargs = dict(
+            state_cache=compression_state_cache,
             num_actual=num_actual,
             token_to_req_indices=token_to_req_indices,
             positions=positions,
@@ -406,3 +509,31 @@ class DeepseekCompressor(nn.Module):
             token_stride=self._token_stride,
             scale_dim=self._scale_dim,
         )
+        if compress_norm_rope_store_fn is compress_norm_rope_store_triton:
+            compress_kwargs.update(
+                current_kv=kv,
+                current_score=score,
+                ape=self.ape,
+                use_private_state=self.use_private_state
+                and not use_dense_private_state,
+                use_dense_private_state=use_dense_private_state,
+                ring_size=self.state_cache.private_ring_size or 1,
+                private_history_size=private_history_size,
+            )
+        compress_norm_rope_store_fn(**compress_kwargs)
+
+        if self.use_private_state:
+            assert seq_lens is not None
+            save_partial_states_to_ring(
+                kv=kv,
+                score=score,
+                ape=self.ape,
+                positions=positions,
+                state_ring=state_cache,
+                slot_mapping=slot_mapping,
+                token_to_req_indices=token_to_req_indices,
+                seq_lens=seq_lens,
+                state_width=state_width,
+                compress_ratio=self.compress_ratio,
+                pdl_kwargs=pdl_kwargs,
+            )

--- a/vllm/models/deepseek_v4/nvidia/dspark.py
+++ b/vllm/models/deepseek_v4/nvidia/dspark.py
@@ -15,6 +15,7 @@ import regex as re
 import torch
 import torch.nn as nn
 
+from vllm import envs
 from vllm.config import VllmConfig, get_current_vllm_config
 from vllm.distributed import (
     get_tensor_model_parallel_rank,
@@ -98,7 +99,13 @@ class DSparkConfidenceHead(nn.Module):
 
 
 class DSparkDeepseekV4Model(nn.Module):
-    def __init__(self, *, vllm_config: VllmConfig, prefix: str = "") -> None:
+    def __init__(
+        self,
+        *,
+        vllm_config: VllmConfig,
+        prefix: str = "",
+        use_confidence_head: bool = False,
+    ) -> None:
         super().__init__()
         assert vllm_config.speculative_config is not None
         config = vllm_config.speculative_config.draft_model_config.hf_config
@@ -173,9 +180,13 @@ class DSparkDeepseekV4Model(nn.Module):
             config.dspark_markov_rank,
             prefix=maybe_prefix(prefix, "markov_head"),
         )
-        self.confidence_head = DSparkConfidenceHead(
-            config.hidden_size + config.dspark_markov_rank,
-            prefix=maybe_prefix(prefix, "confidence_head"),
+        self.confidence_head = (
+            DSparkConfidenceHead(
+                config.hidden_size + config.dspark_markov_rank,
+                prefix=maybe_prefix(prefix, "confidence_head"),
+            )
+            if use_confidence_head
+            else None
         )
 
     def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
@@ -293,8 +304,16 @@ class DSparkDeepseekV4ForCausalLM(nn.Module):
         assert vllm_config.speculative_config is not None
         self.draft_model_config = vllm_config.speculative_config.draft_model_config
         self.config = self.draft_model_config.hf_config
+        speculative_config = vllm_config.speculative_config
+        self._confidence_head_required = bool(
+            speculative_config.dspark_confidence_threshold > 0.0
+            or envs.VLLM_SPEC_DUMP_ALIGNMENT
+        )
+        self._confidence_head_loaded = False
         self.model = DSparkDeepseekV4Model(
-            vllm_config=vllm_config, prefix=maybe_prefix(prefix, "model")
+            vllm_config=vllm_config,
+            prefix=maybe_prefix(prefix, "model"),
+            use_confidence_head=self._confidence_head_required,
         )
         self.lm_head = ParallelLMHead(
             self.config.vocab_size,
@@ -346,7 +365,15 @@ class DSparkDeepseekV4ForCausalLM(nn.Module):
         hidden_states: torch.Tensor,
         markov_embeds: torch.Tensor,
     ) -> torch.Tensor:
-        return self.model.confidence_head(hidden_states, markov_embeds)
+        if not self._confidence_head_loaded:
+            raise RuntimeError(
+                "DSpark confidence logits were requested, but the draft "
+                "checkpoint did not provide confidence_head.proj.weight."
+            )
+        confidence_head = self.model.confidence_head
+        if confidence_head is None:
+            raise RuntimeError("DSpark confidence head was not initialized.")
+        return confidence_head(hidden_states, markov_embeds)
 
     def map_draft_to_target(self, draft_ids: torch.Tensor) -> torch.Tensor:
         return draft_ids
@@ -388,6 +415,11 @@ class DSparkDeepseekV4ForCausalLM(nn.Module):
         for checkpoint_name, loaded_weight in weights:
             name = self._remap_dspark_name(checkpoint_name)
             if name is None:
+                continue
+            # Ordinary serving does not instantiate the optional diagnostic /
+            # scheduler head, so ignore its checkpoint tensor without adding
+            # an unused parameter to the runtime model.
+            if name.startswith("model.confidence_head.") and name not in params_dict:
                 continue
             if name.endswith(".scale"):
                 suffix = (
@@ -453,6 +485,13 @@ class DSparkDeepseekV4ForCausalLM(nn.Module):
 
         for layer in self.model.layers:
             layer.ffn.finalize_mega_moe_weights()
+        confidence_weight_name = "model.confidence_head.proj.weight"
+        self._confidence_head_loaded = confidence_weight_name in loaded_params
+        if self._confidence_head_required and not self._confidence_head_loaded:
+            raise ValueError(
+                "DSpark confidence collection requires the draft checkpoint "
+                f"parameter {confidence_weight_name!r}."
+            )
         logger.info_once("DSpark draft model loaded: %d params", len(loaded_params))
         return loaded_params
 

--- a/vllm/models/deepseek_v4/nvidia/dspark.py
+++ b/vllm/models/deepseek_v4/nvidia/dspark.py
@@ -71,6 +71,32 @@ class DSparkMarkovHead(nn.Module):
         return self.markov_w2(markov_embed)
 
 
+class DSparkConfidenceHead(nn.Module):
+    """Replicated FP32 conditional-acceptance predictor."""
+
+    def __init__(self, input_size: int, prefix: str) -> None:
+        super().__init__()
+        # The checkpoint tensor is BF16, but the official implementation keeps
+        # this projection and its input in FP32 for calibration accuracy.
+        self.proj = ReplicatedLinear(
+            input_size,
+            1,
+            bias=False,
+            params_dtype=torch.float32,
+            quant_config=None,
+            return_bias=False,
+            prefix=maybe_prefix(prefix, "proj"),
+        )
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        markov_embeds: torch.Tensor,
+    ) -> torch.Tensor:
+        features = torch.cat((hidden_states.float(), markov_embeds.float()), dim=-1)
+        return self.proj(features).squeeze(-1)
+
+
 class DSparkDeepseekV4Model(nn.Module):
     def __init__(self, *, vllm_config: VllmConfig, prefix: str = "") -> None:
         super().__init__()
@@ -146,6 +172,10 @@ class DSparkDeepseekV4Model(nn.Module):
             config.vocab_size,
             config.dspark_markov_rank,
             prefix=maybe_prefix(prefix, "markov_head"),
+        )
+        self.confidence_head = DSparkConfidenceHead(
+            config.hidden_size + config.dspark_markov_rank,
+            prefix=maybe_prefix(prefix, "confidence_head"),
         )
 
     def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
@@ -311,6 +341,13 @@ class DSparkDeepseekV4ForCausalLM(nn.Module):
     def markov_bias(self, markov_embed: torch.Tensor) -> torch.Tensor:
         return self.model.markov_head.bias(markov_embed)
 
+    def confidence_logits(
+        self,
+        hidden_states: torch.Tensor,
+        markov_embeds: torch.Tensor,
+    ) -> torch.Tensor:
+        return self.model.confidence_head(hidden_states, markov_embeds)
+
     def map_draft_to_target(self, draft_ids: torch.Tensor) -> torch.Tensor:
         return draft_ids
 
@@ -426,14 +463,13 @@ class DSparkDeepseekV4ForCausalLM(nn.Module):
             return None
         stage = int(match.group(1))
         rest = match.group(2)
-        if rest.startswith("confidence_head."):
-            return None
         head_prefixes = (
             "norm.",
             "hc_head_fn",
             "hc_head_base",
             "hc_head_scale",
             "markov_head.",
+            "confidence_head.",
         )
         if rest.startswith(("main_proj.", "main_norm.")) or rest.startswith(
             head_prefixes

--- a/vllm/models/deepseek_v4/nvidia/model.py
+++ b/vllm/models/deepseek_v4/nvidia/model.py
@@ -801,6 +801,10 @@ class DeepseekV4Attention(nn.Module):
             quant_config=quant_config,
             prefix=prefix,
         )
+        if self.indexer is not None:
+            self.indexer.compressor.validity_cache_prefix = (
+                self.mla_attn.swa_cache_layer.prefix
+            )
 
     def forward(
         self,

--- a/vllm/models/deepseek_v4/sm70/indexer.py
+++ b/vllm/models/deepseek_v4/sm70/indexer.py
@@ -11,6 +11,7 @@ from vllm.models.deepseek_v4.common.ops.fp8_software import (
     fp8_e4m3fn_bits_to_fp32,
 )
 from vllm.triton_utils import tl, triton
+from vllm.v1.worker.workspace import current_workspace_manager
 
 _INDEX_HEAD_DIM = 128
 _INDEX_CACHE_BYTES = _INDEX_HEAD_DIM + 4
@@ -54,6 +55,18 @@ _PREFILL_CUBLAS = os.getenv("VLLM_SM70_INDEXER_PREFILL_CUBLAS", "1") == "1"
 _PREFILL_TILE_MB = int(os.getenv("VLLM_SM70_INDEXER_PREFILL_TILE_MB", "192"))
 _EPILOGUE_BLOCK_K = 256
 _EPILOGUE_BLOCK_H = 8
+
+# At long context the paged Triton decode kernel rescans the same FP8 MQA keys
+# once for every verifier row and head. For the one-request DSpark shape, gather
+# the keys once and let cuBLAS score all rows/heads together. FP32 output is
+# deliberate: an FP16 score intermediate produced rare top-k set changes at
+# 16K/64K compressed tokens. Short and generic shapes retain the fused paged
+# kernel, whose launch overhead is lower there.
+_DECODE_CUBLAS = os.getenv("VLLM_SM70_INDEXER_DECODE_CUBLAS", "1") == "1"
+_DECODE_CUBLAS_MIN_KEYS = int(
+    os.getenv("VLLM_SM70_INDEXER_DECODE_CUBLAS_MIN_KEYS", "1024")
+)
+_DECODE_CUBLAS_MAX_ROWS = 8
 
 
 @triton.jit
@@ -193,6 +206,71 @@ def _dequant_paged_index_k_kernel(
         dequant.to(out_ptr.type.element_ty),
         mask=valid[:, None],
     )
+
+
+@triton.jit
+def _gather_paged_index_k_unscaled_kernel(
+    cache_ptr,
+    block_table_ptr,
+    seq_lens_ptr,
+    out_k_ptr,
+    out_scale_ptr,
+    cache_stride0,
+    out_k_stride0,
+    cache_block_size,
+    max_seq_len,
+    num_rows,
+    head_dim: tl.constexpr,
+    MAX_ROWS: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    """Gather one request's live paged keys once for all verifier rows.
+
+    ``max_seq_len`` is a CUDA-graph bucket and can be much wider than the
+    currently allocated request. Derive the live bound on device from the
+    row lengths so graph replay never dereferences a ``-1`` block-table tail.
+    Rows outside the live bound are zeroed to keep the workspace deterministic;
+    the downstream top-k still applies each row's own sequence length.
+    """
+    key_offsets = tl.program_id(0) * BLOCK_N + tl.arange(0, BLOCK_N)
+    dim_offsets = tl.arange(0, head_dim)
+    row_offsets = tl.arange(0, MAX_ROWS)
+    row_lens = tl.load(
+        seq_lens_ptr + row_offsets,
+        mask=row_offsets < num_rows,
+        other=0,
+    )
+    live_seq_len = tl.max(row_lens, axis=0)
+    in_bucket = key_offsets < max_seq_len
+    valid = in_bucket & (key_offsets < live_seq_len)
+
+    block_in_seq = key_offsets // cache_block_size
+    pos_in_block = key_offsets % cache_block_size
+    physical_block = tl.load(
+        block_table_ptr + block_in_seq,
+        mask=valid,
+        other=0,
+    )
+    token_ptr, scale_ptr = _index_cache_ptrs(
+        cache_ptr,
+        physical_block,
+        pos_in_block,
+        cache_stride0,
+        cache_block_size,
+        head_dim,
+    )
+    packed = tl.load(
+        token_ptr[:, None] + dim_offsets[None, :],
+        mask=valid[:, None],
+        other=0,
+    )
+    scales = tl.load(scale_ptr, mask=valid, other=0.0).to(tl.float32)
+    tl.store(
+        out_k_ptr + key_offsets[:, None] * out_k_stride0 + dim_offsets[None, :],
+        fp8_e4m3fn_bits_to_fp32(packed).to(tl.float16),
+        mask=in_bucket[:, None],
+    )
+    tl.store(out_scale_ptr + key_offsets, scales, mask=in_bucket)
 
 
 @triton.jit
@@ -616,6 +694,68 @@ def sm70_indexer_prefill_logits(
     return torch.mm(weighted_q, k_fp16.t(), out_dtype=torch.float32)
 
 
+def _decode_logits_cublas(
+    q: torch.Tensor,
+    cache: torch.Tensor,
+    weights: torch.Tensor,
+    flat_lens: torch.Tensor,
+    block_table: torch.Tensor,
+    max_seq_len: int,
+) -> torch.Tensor:
+    """Score a one-request decode by sharing one paged gather across rows."""
+    total_rows, num_heads, head_dim = q.shape
+    workspace = current_workspace_manager()
+    gathered_k, k_scales, scores = workspace.get_simultaneous(
+        ((max_seq_len, head_dim), torch.float16),
+        ((max_seq_len,), torch.float32),
+        ((total_rows * num_heads, max_seq_len), torch.float32),
+    )
+    block_n = 16
+    _gather_paged_index_k_unscaled_kernel[(triton.cdiv(max_seq_len, block_n),)](
+        cache,
+        block_table,
+        flat_lens,
+        gathered_k,
+        k_scales,
+        cache.stride(0),
+        gathered_k.stride(0),
+        cache.shape[1],
+        max_seq_len,
+        total_rows,
+        head_dim=head_dim,
+        MAX_ROWS=_DECODE_CUBLAS_MAX_ROWS,
+        BLOCK_N=block_n,
+        num_warps=4,
+    )
+
+    q2 = q.reshape(total_rows * num_heads, head_dim)
+    torch.mm(
+        q2,
+        gathered_k.t(),
+        out=scores,
+        out_dtype=torch.float32,
+    )
+    out = torch.empty((total_rows, max_seq_len), dtype=torch.float32, device=q.device)
+    _relu_weight_headsum_kernel[
+        (total_rows, triton.cdiv(max_seq_len, _EPILOGUE_BLOCK_K))
+    ](
+        scores,
+        weights,
+        k_scales,
+        out,
+        scores.stride(0) * num_heads,
+        scores.stride(0),
+        weights.stride(0),
+        out.stride(0),
+        max_seq_len,
+        num_heads=num_heads,
+        BLOCK_K=_EPILOGUE_BLOCK_K,
+        BLOCK_H=_EPILOGUE_BLOCK_H,
+        num_warps=4,
+    )
+    return out
+
+
 def sm70_indexer_decode_logits(
     q: torch.Tensor,
     cache: torch.Tensor,
@@ -631,17 +771,41 @@ def sm70_indexer_decode_logits(
     # factored path collapses the head axis up front.
     weighted_q = q if _RELU_LOGITS else _combine_index_queries(q, weights)
 
-    if seq_lens.ndim == 2:
+    single_request = block_table.shape[0] == 1
+    native_rows = seq_lens.ndim == 2
+    if native_rows:
         next_n = seq_lens.shape[1]
         flat_lens = seq_lens.reshape(-1).to(torch.int32)
-        block_table = block_table.repeat_interleave(next_n, dim=0)
     else:
         flat_lens = seq_lens.reshape(-1).to(torch.int32)
     assert flat_lens.shape[0] == weighted_q.shape[0]
-    assert block_table.shape[0] == weighted_q.shape[0]
 
     max_seq_len = max(1, int(max_seq_len))
     total_rows = weighted_q.shape[0]
+
+    if (
+        _RELU_LOGITS
+        and _DECODE_CUBLAS
+        and max_seq_len >= _DECODE_CUBLAS_MIN_KEYS
+        and single_request
+        and 0 < total_rows <= _DECODE_CUBLAS_MAX_ROWS
+        and q.shape[1] % _EPILOGUE_BLOCK_H == 0
+        and q.is_contiguous()
+        and weights.is_contiguous()
+        and block_table.is_contiguous()
+    ):
+        return _decode_logits_cublas(
+            q,
+            cache,
+            weights,
+            flat_lens,
+            block_table,
+            max_seq_len,
+        )
+
+    if native_rows:
+        block_table = block_table.repeat_interleave(next_n, dim=0)
+    assert block_table.shape[0] == weighted_q.shape[0]
 
     if _RELU_LOGITS:
         out = torch.empty(

--- a/vllm/models/deepseek_v4/sm70/indexer.py
+++ b/vllm/models/deepseek_v4/sm70/indexer.py
@@ -10,6 +10,7 @@ import torch
 from vllm.models.deepseek_v4.common.ops.fp8_software import (
     fp8_e4m3fn_bits_to_fp32,
 )
+from vllm.platforms import current_platform
 from vllm.triton_utils import tl, triton
 from vllm.v1.worker.workspace import current_workspace_manager
 
@@ -57,12 +58,12 @@ _EPILOGUE_BLOCK_K = 256
 _EPILOGUE_BLOCK_H = 8
 
 # At long context the paged Triton decode kernel rescans the same FP8 MQA keys
-# once for every verifier row and head. For the one-request DSpark shape, gather
-# the keys once and let cuBLAS score all rows/heads together. FP32 output is
-# deliberate: an FP16 score intermediate produced rare top-k set changes at
-# 16K/64K compressed tokens. Short and generic shapes retain the fused paged
-# kernel, whose launch overhead is lower there.
-_DECODE_CUBLAS = os.getenv("VLLM_SM70_INDEXER_DECODE_CUBLAS", "1") == "1"
+# once for every verifier row and head. For a bounded one-request verifier
+# shape, gather the keys once and let cuBLAS score all rows/heads together.
+# FP32 output is deliberate: an FP16 score intermediate produced rare top-k
+# set changes at 16K/64K compressed tokens. Short and generic shapes retain the
+# fused paged kernel, whose launch overhead is lower there.
+_DECODE_CUBLAS = os.getenv("VLLM_SM70_INDEXER_DECODE_CUBLAS", "0") == "1"
 _DECODE_CUBLAS_MIN_KEYS = int(
     os.getenv("VLLM_SM70_INDEXER_DECODE_CUBLAS_MIN_KEYS", "1024")
 )
@@ -786,12 +787,39 @@ def sm70_indexer_decode_logits(
     if (
         _RELU_LOGITS
         and _DECODE_CUBLAS
+        and current_platform.is_cuda()
+        and current_platform.is_device_capability((7, 0))
         and max_seq_len >= _DECODE_CUBLAS_MIN_KEYS
         and single_request
+        and (native_rows or total_rows == 1)
         and 0 < total_rows <= _DECODE_CUBLAS_MAX_ROWS
+        and q.ndim == 3
+        and q.dtype == torch.float16
+        and q.shape[2] == _INDEX_HEAD_DIM
+        and q.shape[1] > 0
         and q.shape[1] % _EPILOGUE_BLOCK_H == 0
+        and weights.ndim == 2
+        and weights.shape == q.shape[:2]
+        and weights.dtype == torch.float32
+        and cache.ndim == 3
+        and cache.dtype == torch.uint8
+        and cache.shape[1] > 0
+        and cache.shape[2] == _INDEX_CACHE_BYTES
+        and cache.stride(1) == _INDEX_CACHE_BYTES
+        and cache.stride(2) == 1
+        and block_table.ndim == 2
+        and block_table.dtype == torch.int32
+        and flat_lens.dtype == torch.int32
+        and triton.cdiv(max_seq_len, cache.shape[1]) <= block_table.shape[1]
+        and q.device
+        == cache.device
+        == weights.device
+        == flat_lens.device
+        == block_table.device
         and q.is_contiguous()
         and weights.is_contiguous()
+        and cache.is_contiguous()
+        and flat_lens.is_contiguous()
         and block_table.is_contiguous()
     ):
         return _decode_logits_cublas(

--- a/vllm/v1/attention/backends/mla/indexer.py
+++ b/vllm/v1/attention/backends/mla/indexer.py
@@ -203,6 +203,11 @@ class DeepseekV32IndexerMetadata:
     # hacky way to access the data now, need to be in chunked meta
     seq_lens: torch.Tensor
     max_seq_len: int
+    # Decode seq_lens and the indexer KV cache use compressed positions for
+    # DeepSeek V4. Keep the matching host bound explicit: CUDA Graph capture
+    # needs a static logits width, but using the uncompressed attention bound
+    # launches 4x/128x too much work for C4/C128 layers.
+    compressed_max_seq_len: int
     slot_mapping: torch.Tensor
 
     # New for MLA (compared to FlashAttention)
@@ -627,6 +632,9 @@ class DeepseekV32IndexerMetadataBuilder(AttentionMetadataBuilder):
         attn_metadata = DeepseekV32IndexerMetadata(
             seq_lens=common_attn_metadata.seq_lens,
             max_seq_len=common_attn_metadata.max_seq_len,
+            compressed_max_seq_len=max(
+                1, common_attn_metadata.max_seq_len // self.compress_ratio
+            ),
             slot_mapping=compressed_slot_mapping,
             num_decodes=num_decodes,
             num_decode_tokens=num_decode_tokens,

--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -1470,42 +1470,36 @@ def group_and_unify_kv_cache_specs(
     return [mla_uniform_spec, *swa_uniform_specs]
 
 
-def _approximate_gcd(values: Sequence[int], *, lower_bound: int | None = None) -> int:
-    """Pick a chunk size that minimizes total upward padding.
+def _select_deepseek_v4_tuple_width(
+    vllm_config: VllmConfig,
+    grouped_specs: list[UniformTypeKVCacheSpecs],
+) -> int:
+    """Pick the DeepSeek V4 tuple width with the smallest physical pool.
 
-    Each x is rounded up to a multiple of d:
-
-      x -> ceil(x / d) * d
-
-    Total padding is:
-
-      pad(d) = sum_i (ceil(x_i / d) * d - x_i)
-
-    We brute-force d in [lower_bound, max(values)] (fine for small lists / small
-    maxima) and return the d with minimum padding. Ties prefer larger d.
+    Padding layer counts alone is insufficient: full/compressed MLA may need
+    thousands more pages than a short sliding-window group at long context.
+    Widening every physical block to save one SWA subgroup can therefore cost
+    substantially more memory than it saves.
     """
-    if not values:
-        raise ValueError("values must be non-empty")
-    if any(x <= 0 for x in values):
-        raise ValueError(f"values must be positive, got: {list(values)!r}")
+    tuple_counts = [spec.get_num_layer_tuples() for spec in grouped_specs]
+    page_counts = [spec.max_memory_usage_pages(vllm_config) for spec in grouped_specs]
+    min_width = tuple_counts[0]
+    max_width = max(tuple_counts)
 
-    min_d = max(1, lower_bound if lower_bound is not None else 1)
-    max_d = max(values)
-    if min_d > max_d:
-        return min_d
+    def pool_pages(width: int) -> int:
+        return width * sum(
+            cdiv(tuple_count, width) * page_count
+            for tuple_count, page_count in zip(tuple_counts, page_counts)
+        )
 
-    best_d = min_d
-    best_pad: int | None = None
-    for d in range(min_d, max_d + 1):
-        pad = sum((d - (x % d)) % d for x in values)
-        if best_pad is None or pad < best_pad or (pad == best_pad and d > best_d):
-            best_pad = pad
-            best_d = d
-
-    return best_d
+    return min(
+        range(min_width, max_width + 1),
+        key=lambda width: (pool_pages(width), width),
+    )
 
 
 def _get_kv_cache_groups_uniform_groups(
+    vllm_config: VllmConfig,
     grouped_specs: list[UniformTypeKVCacheSpecs],
 ) -> list[KVCacheGroupSpec]:
     """
@@ -1536,10 +1530,8 @@ def _get_kv_cache_groups_uniform_groups(
     num_layer_tuples_per_group: list[int] = [
         g_spec.get_num_layer_tuples() for g_spec in grouped_specs
     ]
-    # Choose `num_layer_tuples` to minimize total padding across groups.
-    num_layer_tuples = _approximate_gcd(
-        num_layer_tuples_per_group, lower_bound=num_layer_tuples_per_group[0]
-    )
+    # Choose `num_layer_tuples` by physical bytes, not layer-count padding.
+    num_layer_tuples = _select_deepseek_v4_tuple_width(vllm_config, grouped_specs)
     # Round up to the nearest multiple of `num_layer_tuples` (i.e., padding)
     num_layer_tuples_per_group = [
         round_up(x, num_layer_tuples) for x in num_layer_tuples_per_group
@@ -1666,7 +1658,9 @@ def get_kv_cache_groups(
         # yet some layers are full attention while others are sliding window
         # attention in different sizes. Need to group layers into multiple
         # UniformTypeKVCacheSpecs.
-        kv_cache_groups = _get_kv_cache_groups_uniform_groups(grouped_specs)
+        kv_cache_groups = _get_kv_cache_groups_uniform_groups(
+            vllm_config, grouped_specs
+        )
         _annotate_eagle_groups_deepseek_v4(vllm_config, kv_cache_spec, kv_cache_groups)
         return kv_cache_groups
 

--- a/vllm/v1/cudagraph_dispatcher.py
+++ b/vllm/v1/cudagraph_dispatcher.py
@@ -71,17 +71,27 @@ def _get_sm70_dsv4_decode_context_buckets(
     if not positive_ratios:
         return ()
 
-    bucket = topk_tokens * min(positive_ratios)
-    if bucket <= 0 or model_config.max_model_len <= bucket:
+    short_bucket = topk_tokens * min(positive_ratios)
+    if short_bucket <= 0 or model_config.max_model_len <= short_bucket:
         return ()
+    # Keep the graph width close enough to the live context that the C4
+    # indexer does not score the model's entire maximum length immediately
+    # after crossing the short-context bypass. The sparse progression limits
+    # startup graph count while covering the first long-indexer bucket and the
+    # 16K/64K/128K service points used by the long-context quality gates.
+    bucket_multipliers = (1, 2, 8, 32, 64)
+    buckets = tuple(
+        short_bucket * multiplier
+        for multiplier in bucket_multipliers
+        if short_bucket * multiplier < model_config.max_model_len
+    )
     logger.info_once(
-        "Auto-enabling the SM70 DeepSeek V4 short-context decode CUDA graph "
-        "at %d tokens. Set %s explicitly to override or to an empty value "
-        "to disable.",
-        bucket,
+        "Auto-enabling SM70 DeepSeek V4 decode CUDA graph context buckets "
+        "%s. Set %s explicitly to override or to an empty value to disable.",
+        buckets,
         env_name,
     )
-    return (bucket,)
+    return buckets
 
 
 def _is_sm70_fp8_kv_decode_shape(

--- a/vllm/v1/cudagraph_dispatcher.py
+++ b/vllm/v1/cudagraph_dispatcher.py
@@ -46,8 +46,6 @@ def _get_sm70_dsv4_decode_context_buckets(
     env_name = "VLLM_SM70_DSV4_DECODE_CONTEXT_BUCKETS"
     if env_name in os.environ:
         return _get_sm70_context_buckets(env_name)
-    if vllm_config.speculative_config is not None:
-        return ()
 
     model_config = vllm_config.model_config
     architectures = getattr(model_config, "architectures", ())
@@ -346,7 +344,9 @@ class CudagraphDispatcher:
 
     def _active_context_buckets(self) -> tuple[int, ...]:
         if self.uniform_decode_query_len > 1:
-            return self.sm70_mtp_context_buckets
+            if "VLLM_SM70_MTP_CONTEXT_BUCKETS" in os.environ:
+                return self.sm70_mtp_context_buckets
+            return self.sm70_dsv4_decode_context_buckets
         return tuple(
             sorted(
                 set(self.sm70_dsv4_decode_context_buckets)
@@ -375,7 +375,9 @@ class CudagraphDispatcher:
 
         if self.uniform_decode_query_len > 1:
             if batch_descriptor.num_tokens == self.uniform_decode_query_len:
-                return self.sm70_mtp_context_buckets
+                if "VLLM_SM70_MTP_CONTEXT_BUCKETS" in os.environ:
+                    return self.sm70_mtp_context_buckets
+                return self.sm70_dsv4_decode_context_buckets
             return ()
 
         buckets: set[int] = set()

--- a/vllm/v1/cudagraph_dispatcher.py
+++ b/vllm/v1/cudagraph_dispatcher.py
@@ -46,13 +46,13 @@ def _get_sm70_dsv4_decode_context_buckets(
     env_name = "VLLM_SM70_DSV4_DECODE_CONTEXT_BUCKETS"
     if env_name in os.environ:
         return _get_sm70_context_buckets(env_name)
+    # Speculative graphs cover multiple query rows and require a separate
+    # end-to-end long-context gate. They remain available through the explicit
+    # environment override above.
+    if vllm_config.speculative_config is not None:
+        return ()
 
     model_config = vllm_config.model_config
-    architectures = getattr(model_config, "architectures", ())
-    if not isinstance(architectures, (list, tuple)) or (
-        "DeepseekV4ForCausalLM" not in architectures
-    ):
-        return ()
     if not (
         current_platform.is_cuda() and current_platform.is_device_capability((7, 0))
     ):
@@ -86,7 +86,7 @@ def _get_sm70_dsv4_decode_context_buckets(
         if short_bucket * multiplier < model_config.max_model_len
     )
     logger.info_once(
-        "Auto-enabling SM70 DeepSeek V4 decode CUDA graph context buckets "
+        "Auto-enabling SM70 compressed-index decode CUDA graph context buckets "
         "%s. Set %s explicitly to override or to an empty value to disable.",
         buckets,
         env_name,

--- a/vllm/v1/sample/rejection_sampler.py
+++ b/vllm/v1/sample/rejection_sampler.py
@@ -657,6 +657,9 @@ class RejectionSampler(nn.Module):
                 "sampling_output_token_ids_tail": [
                     list(ids[-32:]) for ids in sampling_metadata.output_token_ids
                 ],
+                "sampling_output_lengths": [
+                    len(ids) for ids in sampling_metadata.output_token_ids
+                ],
                 "sampling_spec_token_ids": [
                     list(ids) for ids in (sampling_metadata.spec_token_ids or [])
                 ],

--- a/vllm/v1/sample/rejection_sampler.py
+++ b/vllm/v1/sample/rejection_sampler.py
@@ -270,6 +270,7 @@ class RejectionSampler(nn.Module):
         # [num_tokens + batch_size, vocab_size]
         logits: torch.Tensor,
         sampling_metadata: SamplingMetadata,
+        draft_confidence_logits: torch.Tensor | None = None,
     ) -> SamplerOutput:
         """
         Args:
@@ -331,6 +332,7 @@ class RejectionSampler(nn.Module):
                 bonus_logits_indices=bonus_logits_indices,
                 profile_events=profile_events,
                 profile_total_start=profile_total_start,
+                draft_confidence_logits=draft_confidence_logits,
             )
         # When indexing with a tensor (bonus_logits_indices), PyTorch
         # creates a new tensor with separate storage from the original
@@ -426,6 +428,7 @@ class RejectionSampler(nn.Module):
             bonus_token_ids=bonus_token_ids,
             output_token_ids=output_token_ids,
             sampling_metadata=sampling_metadata,
+            draft_confidence_logits=draft_confidence_logits,
         )
 
         logprobs_tensors = None
@@ -455,6 +458,7 @@ class RejectionSampler(nn.Module):
         bonus_logits_indices: torch.Tensor,
         profile_events: list[tuple[str, torch.cuda.Event, torch.cuda.Event]] | None,
         profile_total_start: torch.cuda.Event | None,
+        draft_confidence_logits: torch.Tensor | None,
     ) -> SamplerOutput:
         profile_constraints_start = _rejection_profile_start(profile_events)
         sampled_logits = logits.to(torch.float32)
@@ -510,6 +514,7 @@ class RejectionSampler(nn.Module):
             bonus_token_ids=bonus_token_ids,
             output_token_ids=output_token_ids,
             sampling_metadata=sampling_metadata,
+            draft_confidence_logits=draft_confidence_logits,
         )
         return SamplerOutput(
             sampled_token_ids=output_token_ids,
@@ -574,6 +579,7 @@ class RejectionSampler(nn.Module):
         bonus_token_ids: torch.Tensor,
         output_token_ids: torch.Tensor,
         sampling_metadata: SamplingMetadata,
+        draft_confidence_logits: torch.Tensor | None,
     ) -> None:
         global _SPEC_ALIGNMENT_DUMP_COUNT, _SPEC_ALIGNMENT_STEP_COUNTER
         _SPEC_ALIGNMENT_STEP_COUNTER += 1
@@ -672,9 +678,23 @@ class RejectionSampler(nn.Module):
                     .cpu()
                 )
                 payload["recovered_residual_mass"] = residual_mass.detach().cpu()
+                payload["conditional_acceptance_targets"] = (
+                    torch.minimum(target_probs, draft_probs).sum(dim=-1).detach().cpu()
+                )
                 draft_topk = torch.topk(draft_probs, k=k, dim=-1)
                 payload["draft_topk_ids"] = draft_topk.indices.detach().cpu()
                 payload["draft_topk_values"] = draft_topk.values.detach().cpu()
+            if draft_confidence_logits is not None:
+                if draft_confidence_logits.shape != (target_logits.shape[0],):
+                    raise RuntimeError(
+                        "Aligned DSpark confidence logits must have one value per "
+                        "draft token: "
+                        f"confidence={tuple(draft_confidence_logits.shape)}, "
+                        f"target={target_logits.shape[0]}."
+                    )
+                payload["draft_confidence_logits"] = (
+                    draft_confidence_logits.detach().float().cpu()
+                )
             _SPEC_ALIGNMENT_DUMP_COUNT += 1
             dump_dir = os.getenv("VLLM_SPEC_DUMP_ALIGNMENT_DIR", "/tmp")
             os.makedirs(dump_dir, exist_ok=True)

--- a/vllm/v1/spec_decode/draft_prob_alignment.py
+++ b/vllm/v1/spec_decode/draft_prob_alignment.py
@@ -160,3 +160,108 @@ def get_aligned_draft_probs(
     if not draft_probs_rows:
         return None
     return torch.cat(draft_probs_rows, dim=0).contiguous()
+
+
+def get_aligned_draft_scalar_values(
+    *,
+    req_ids: Sequence[str],
+    values: torch.Tensor | None,
+    value_req_ids: Sequence[str] | None,
+    value_token_ids: DraftProbTokenIds | None,
+    spec_decode_metadata: SpecDecodeMetadata,
+) -> torch.Tensor | None:
+    """Align a cached per-draft scalar tensor to verifier request order."""
+    if values is None or value_req_ids is None:
+        return None
+    if values.ndim != 2:
+        raise RuntimeError(
+            "Cached draft scalar values must have shape "
+            f"[num_requests, max_draft_tokens], got {tuple(values.shape)}."
+        )
+    if values.shape[0] != len(value_req_ids):
+        raise RuntimeError(
+            "Cached draft scalar row count does not match request ids: "
+            f"rows={values.shape[0]}, req_ids={len(value_req_ids)}."
+        )
+    if value_token_ids is None:
+        raise RuntimeError(
+            "Cached draft scalar values are missing their draft token ids; "
+            "cannot verify alignment."
+        )
+    if isinstance(value_token_ids, torch.Tensor):
+        if value_token_ids.ndim != 2 or value_token_ids.shape[0] != len(value_req_ids):
+            raise RuntimeError(
+                "Cached draft scalar token ids must have one 2-D row per "
+                f"request, got shape={tuple(value_token_ids.shape)}, "
+                f"req_ids={len(value_req_ids)}."
+            )
+    elif len(value_token_ids) != len(value_req_ids):
+        raise RuntimeError(
+            "Cached draft scalar token row count does not match request ids: "
+            f"rows={len(value_token_ids)}, req_ids={len(value_req_ids)}."
+        )
+    if len(req_ids) != len(spec_decode_metadata.num_draft_tokens):
+        raise RuntimeError(
+            "Spec decode draft metadata batch size does not match current "
+            f"requests: metadata={len(spec_decode_metadata.num_draft_tokens)}, "
+            f"req_ids={len(req_ids)}."
+        )
+    expected_num_draft_tokens = sum(spec_decode_metadata.num_draft_tokens)
+    if spec_decode_metadata.draft_token_ids.numel() != expected_num_draft_tokens:
+        raise RuntimeError(
+            "Spec decode draft token count does not match per-request counts: "
+            f"draft_token_ids={spec_decode_metadata.draft_token_ids.numel()}, "
+            f"num_draft_tokens={expected_num_draft_tokens}."
+        )
+
+    row_by_req_id = {req_id: idx for idx, req_id in enumerate(value_req_ids)}
+    aligned_rows: list[torch.Tensor] = []
+    draft_token_offset = 0
+    for req_id, num_draft in zip(req_ids, spec_decode_metadata.num_draft_tokens):
+        if num_draft == 0:
+            continue
+        row_idx = row_by_req_id.get(req_id)
+        if row_idx is None:
+            raise RuntimeError(
+                f"Missing cached draft scalar values for request {req_id}; "
+                "cannot verify alignment."
+            )
+        if values.shape[1] < num_draft:
+            raise RuntimeError(
+                "Cached draft scalar values do not have enough positions for "
+                f"request {req_id}: available={values.shape[1]}, needed={num_draft}."
+            )
+        expected_tokens = spec_decode_metadata.draft_token_ids[
+            draft_token_offset : draft_token_offset + num_draft
+        ]
+        if isinstance(value_token_ids, torch.Tensor):
+            if value_token_ids.shape[1] < num_draft:
+                raise RuntimeError(
+                    "Cached draft scalar token ids do not have enough positions "
+                    f"for request {req_id}: available={value_token_ids.shape[1]}, "
+                    f"needed={num_draft}."
+                )
+            cached_tokens = value_token_ids[row_idx, :num_draft].to(
+                device=expected_tokens.device,
+                dtype=expected_tokens.dtype,
+            )
+        else:
+            cached_token_row = value_token_ids[row_idx]
+            if len(cached_token_row) < num_draft:
+                raise RuntimeError(
+                    "Cached draft scalar token ids do not have enough positions "
+                    f"for request {req_id}: available={len(cached_token_row)}, "
+                    f"needed={num_draft}."
+                )
+            cached_tokens = torch.tensor(
+                cached_token_row[:num_draft],
+                device=expected_tokens.device,
+                dtype=expected_tokens.dtype,
+            )
+        _assert_cached_tokens_match(cached_tokens, expected_tokens, req_id)
+        aligned_rows.append(values[row_idx, :num_draft])
+        draft_token_offset += num_draft
+
+    if not aligned_rows:
+        return None
+    return torch.cat(aligned_rows, dim=0).contiguous()

--- a/vllm/v1/spec_decode/dspark.py
+++ b/vllm/v1/spec_decode/dspark.py
@@ -27,6 +27,10 @@ class DSparkProposer(DFlashProposer):
             torch.arange(self.max_batch_size, dtype=torch.int64, device=device)
             * self.num_query_per_req
         )
+        self._last_confidence_logits: torch.Tensor | None = None
+
+    def take_last_confidence_logits(self) -> torch.Tensor | None:
+        return self._last_confidence_logits
 
     @override
     def _sample_draft_tokens(
@@ -54,9 +58,11 @@ class DSparkProposer(DFlashProposer):
         # contents across asynchronous scheduling and CUDA Graph replay.
         prev = self.input_ids[self._anchor_indices[:batch_size]].to(torch.long)
         draft_tokens: list[torch.Tensor] = []
+        markov_embeds: list[torch.Tensor] = []
         draft_probs: list[torch.Tensor] | None = None
         for step in range(self.num_speculative_tokens):
             markov_embed = self.model.markov_embed(prev)
+            markov_embeds.append(markov_embed)
             step_logits = base_logits[:, step] + self.model.markov_bias(markov_embed)
             sampled, step_probs = self._sample_from_logits(
                 step_logits,
@@ -69,6 +75,13 @@ class DSparkProposer(DFlashProposer):
                     draft_probs = []
                 draft_probs.append(step_probs)
 
+        block_hidden_states = hidden_states.view(
+            batch_size, self.num_speculative_tokens, -1
+        )
+        self._last_confidence_logits = self.model.confidence_logits(
+            block_hidden_states,
+            torch.stack(markov_embeds, dim=1),
+        )
         flat_tokens = torch.stack(draft_tokens, dim=1).reshape(-1)
         if draft_probs is None:
             return flat_tokens, None

--- a/vllm/v1/spec_decode/dspark.py
+++ b/vllm/v1/spec_decode/dspark.py
@@ -27,10 +27,64 @@ class DSparkProposer(DFlashProposer):
             torch.arange(self.max_batch_size, dtype=torch.int64, device=device)
             * self.num_query_per_req
         )
+        temperatures = self.speculative_config.dspark_confidence_temperatures
+        if temperatures is None:
+            temperatures = [1.0] * self.num_speculative_tokens
+        self._confidence_temperatures = torch.tensor(
+            temperatures,
+            dtype=torch.float32,
+            device=device,
+        ).view(1, -1)
+        self._confidence_threshold = self.speculative_config.dspark_confidence_threshold
+        configured_cap = self.speculative_config.dspark_max_verification_tokens
+        self._max_verification_tokens = (
+            self.num_speculative_tokens if configured_cap is None else configured_cap
+        )
+        self.confidence_scheduling_enabled = (
+            self._confidence_threshold > 0.0
+            or self._max_verification_tokens < self.num_speculative_tokens
+        )
         self._last_confidence_logits: torch.Tensor | None = None
+        self._last_verification_lengths: torch.Tensor | None = None
 
     def take_last_confidence_logits(self) -> torch.Tensor | None:
         return self._last_confidence_logits
+
+    def take_last_verification_lengths(self) -> torch.Tensor | None:
+        return self._last_verification_lengths
+
+    def _select_verification_lengths(
+        self,
+        confidence_logits: torch.Tensor,
+    ) -> torch.Tensor:
+        temperatures = getattr(self, "_confidence_temperatures", None)
+        if temperatures is None:
+            temperatures = torch.ones(
+                (1, confidence_logits.shape[1]),
+                dtype=torch.float32,
+                device=confidence_logits.device,
+            )
+        threshold = float(getattr(self, "_confidence_threshold", 0.0))
+        cap = int(
+            getattr(
+                self,
+                "_max_verification_tokens",
+                confidence_logits.shape[1],
+            )
+        )
+        if threshold <= 0.0:
+            return torch.full(
+                (confidence_logits.shape[0],),
+                cap,
+                dtype=torch.int32,
+                device=confidence_logits.device,
+            )
+
+        conditional_probs = torch.sigmoid(confidence_logits.float() / temperatures)
+        confident_prefix = (
+            (conditional_probs >= threshold).to(torch.int32).cumprod(dim=1)
+        )
+        return confident_prefix.sum(dim=1).clamp_max_(cap).to(torch.int32)
 
     @override
     def _sample_draft_tokens(
@@ -81,6 +135,9 @@ class DSparkProposer(DFlashProposer):
         self._last_confidence_logits = self.model.confidence_logits(
             block_hidden_states,
             torch.stack(markov_embeds, dim=1),
+        )
+        self._last_verification_lengths = self._select_verification_lengths(
+            self._last_confidence_logits
         )
         flat_tokens = torch.stack(draft_tokens, dim=1).reshape(-1)
         if draft_probs is None:

--- a/vllm/v1/spec_decode/dspark.py
+++ b/vllm/v1/spec_decode/dspark.py
@@ -5,6 +5,7 @@
 import torch
 from typing_extensions import override
 
+from vllm import envs
 from vllm.config import VllmConfig
 from vllm.v1.sample.metadata import SamplingMetadata
 from vllm.v1.spec_decode.dflash import DFlashProposer
@@ -27,15 +28,17 @@ class DSparkProposer(DFlashProposer):
             torch.arange(self.max_batch_size, dtype=torch.int64, device=device)
             * self.num_query_per_req
         )
-        temperatures = self.speculative_config.dspark_confidence_temperatures
-        if temperatures is None:
-            temperatures = [1.0] * self.num_speculative_tokens
-        self._confidence_temperatures = torch.tensor(
-            temperatures,
-            dtype=torch.float32,
-            device=device,
-        ).view(1, -1)
         self._confidence_threshold = self.speculative_config.dspark_confidence_threshold
+        self._confidence_temperatures: torch.Tensor | None = None
+        if self._confidence_threshold > 0.0:
+            temperatures = self.speculative_config.dspark_confidence_temperatures
+            if temperatures is None:
+                temperatures = [1.0] * self.num_speculative_tokens
+            self._confidence_temperatures = torch.tensor(
+                temperatures,
+                dtype=torch.float32,
+                device=device,
+            ).view(1, -1)
         configured_cap = self.speculative_config.dspark_max_verification_tokens
         self._max_verification_tokens = (
             self.num_speculative_tokens if configured_cap is None else configured_cap
@@ -44,14 +47,24 @@ class DSparkProposer(DFlashProposer):
             self._confidence_threshold > 0.0
             or self._max_verification_tokens < self.num_speculative_tokens
         )
+        # A fixed cap needs verification lengths but not a confidence
+        # projection. Collect logits only when the calibrated threshold or the
+        # explicit alignment diagnostic consumes them.
+        self.collect_confidence_logits = (
+            self._confidence_threshold > 0.0 or envs.VLLM_SPEC_DUMP_ALIGNMENT
+        )
         self._last_confidence_logits: torch.Tensor | None = None
         self._last_verification_lengths: torch.Tensor | None = None
 
     def take_last_confidence_logits(self) -> torch.Tensor | None:
-        return self._last_confidence_logits
+        confidence_logits = self._last_confidence_logits
+        self._last_confidence_logits = None
+        return confidence_logits
 
     def take_last_verification_lengths(self) -> torch.Tensor | None:
-        return self._last_verification_lengths
+        verification_lengths = self._last_verification_lengths
+        self._last_verification_lengths = None
+        return verification_lengths
 
     def _select_verification_lengths(
         self,
@@ -112,11 +125,19 @@ class DSparkProposer(DFlashProposer):
         # contents across asynchronous scheduling and CUDA Graph replay.
         prev = self.input_ids[self._anchor_indices[:batch_size]].to(torch.long)
         draft_tokens: list[torch.Tensor] = []
-        markov_embeds: list[torch.Tensor] = []
+        self._last_confidence_logits = None
+        self._last_verification_lengths = None
+        collect_confidence_logits = bool(
+            getattr(self, "collect_confidence_logits", False)
+        )
+        markov_embeds: list[torch.Tensor] | None = (
+            [] if collect_confidence_logits else None
+        )
         draft_probs: list[torch.Tensor] | None = None
         for step in range(self.num_speculative_tokens):
             markov_embed = self.model.markov_embed(prev)
-            markov_embeds.append(markov_embed)
+            if markov_embeds is not None:
+                markov_embeds.append(markov_embed)
             step_logits = base_logits[:, step] + self.model.markov_bias(markov_embed)
             sampled, step_probs = self._sample_from_logits(
                 step_logits,
@@ -129,16 +150,26 @@ class DSparkProposer(DFlashProposer):
                     draft_probs = []
                 draft_probs.append(step_probs)
 
-        block_hidden_states = hidden_states.view(
-            batch_size, self.num_speculative_tokens, -1
-        )
-        self._last_confidence_logits = self.model.confidence_logits(
-            block_hidden_states,
-            torch.stack(markov_embeds, dim=1),
-        )
-        self._last_verification_lengths = self._select_verification_lengths(
-            self._last_confidence_logits
-        )
+        if markov_embeds is not None:
+            block_hidden_states = hidden_states.view(
+                batch_size, self.num_speculative_tokens, -1
+            )
+            self._last_confidence_logits = self.model.confidence_logits(
+                block_hidden_states,
+                torch.stack(markov_embeds, dim=1),
+            )
+        if bool(getattr(self, "confidence_scheduling_enabled", False)):
+            if self._last_confidence_logits is None:
+                self._last_verification_lengths = torch.full(
+                    (batch_size,),
+                    int(self._max_verification_tokens),
+                    dtype=torch.int32,
+                    device=hidden_states.device,
+                )
+            else:
+                self._last_verification_lengths = self._select_verification_lengths(
+                    self._last_confidence_logits
+                )
         flat_tokens = torch.stack(draft_tokens, dim=1).reshape(-1)
         if draft_probs is None:
             return flat_tokens, None

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -204,6 +204,7 @@ from vllm.v1.spec_decode.draft_model import DraftModelProposer
 from vllm.v1.spec_decode.draft_prob_alignment import (
     clone_draft_prob_token_ids,
     get_aligned_draft_probs,
+    get_aligned_draft_scalar_values,
 )
 from vllm.v1.spec_decode.dspark import DSparkProposer
 from vllm.v1.spec_decode.eagle import EagleProposer
@@ -1780,6 +1781,9 @@ class GPUModelRunner(
         self._draft_probs: torch.Tensor | None = None
         self._draft_prob_req_ids: list[str] | None = None
         self._draft_prob_token_ids: list[list[int]] | torch.Tensor | None = None
+        self._draft_confidence_logits: torch.Tensor | None = None
+        self._draft_confidence_req_ids: list[str] | None = None
+        self._draft_confidence_token_ids: list[list[int]] | torch.Tensor | None = None
         self._dflash_ddtree_payloads: tuple[DDTreeDraftPayload, ...] | None = None
         self._ddtree_parent_metadata: DDTreeParentMetadata | None = None
         self._ddtree_accepted_rows_cpu_sidecar: list[list[int]] | None = None
@@ -7397,6 +7401,9 @@ class GPUModelRunner(
             )
 
         draft_probs = self._get_spec_decode_draft_probs(spec_decode_metadata)
+        draft_confidence_logits = self._get_spec_decode_confidence_logits(
+            spec_decode_metadata
+        )
         if (
             self.speculative_config is not None
             and self.speculative_config.method == "mtp"
@@ -7416,6 +7423,7 @@ class GPUModelRunner(
             draft_probs,
             logits,
             sampling_metadata,
+            draft_confidence_logits=draft_confidence_logits,
         )
         target_candidate_ids = self.rejection_sampler.take_last_target_candidate_ids()
         if target_candidate_ids is not None and hasattr(
@@ -8954,6 +8962,9 @@ class GPUModelRunner(
         self._draft_probs = None
         self._draft_prob_req_ids = None
         self._draft_prob_token_ids = None
+        self._draft_confidence_logits = None
+        self._draft_confidence_req_ids = None
+        self._draft_confidence_token_ids = None
         self._dflash_ddtree_payloads = None
         self._ddtree_parent_metadata = None
         self._ddtree_accepted_rows_cpu_sidecar = None
@@ -9097,6 +9108,9 @@ class GPUModelRunner(
                 self._draft_probs = None
                 self._draft_prob_req_ids = None
                 self._draft_prob_token_ids = None
+                self._draft_confidence_logits = None
+                self._draft_confidence_req_ids = None
+                self._draft_confidence_token_ids = None
                 self._copy_draft_token_ids_to_cpu(scheduler_output)
 
         with record_function_or_nullcontext("gpu_model_runner: bookkeep"):
@@ -9471,6 +9485,22 @@ class GPUModelRunner(
             spec_decode_metadata=spec_decode_metadata,
         )
 
+    def _get_spec_decode_confidence_logits(
+        self, spec_decode_metadata: SpecDecodeMetadata
+    ) -> torch.Tensor | None:
+        # Alignment has a small but non-zero launch/copy cost. Keep it out of
+        # ordinary serving until confidence scheduling is explicitly enabled;
+        # alignment dumps are the calibration path used before that gate.
+        if not envs.VLLM_SPEC_DUMP_ALIGNMENT:
+            return None
+        return get_aligned_draft_scalar_values(
+            req_ids=self.input_batch.req_ids,
+            values=self._draft_confidence_logits,
+            value_req_ids=self._draft_confidence_req_ids,
+            value_token_ids=self._draft_confidence_token_ids,
+            spec_decode_metadata=spec_decode_metadata,
+        )
+
     def propose_draft_token_ids(
         self,
         scheduler_output: "SchedulerOutput",
@@ -9489,6 +9519,9 @@ class GPUModelRunner(
         self._draft_probs = None
         self._draft_prob_req_ids = None
         self._draft_prob_token_ids = None
+        self._draft_confidence_logits = None
+        self._draft_confidence_req_ids = None
+        self._draft_confidence_token_ids = None
         self._dflash_ddtree_payloads = None
         self._ddtree_parent_metadata = None
         self._ddtree_accepted_rows_cpu_sidecar = None
@@ -9803,6 +9836,14 @@ class GPUModelRunner(
                     self._draft_probs = draft_probs
                     self._draft_prob_req_ids = self.input_batch.req_ids.copy()
                     self._draft_prob_token_ids = clone_draft_prob_token_ids(
+                        draft_token_ids
+                    )
+            if hasattr(self.drafter, "take_last_confidence_logits"):
+                confidence_logits = self.drafter.take_last_confidence_logits()
+                if confidence_logits is not None:
+                    self._draft_confidence_logits = confidence_logits
+                    self._draft_confidence_req_ids = self.input_batch.req_ids.copy()
+                    self._draft_confidence_token_ids = clone_draft_prob_token_ids(
                         draft_token_ids
                     )
             if hasattr(self.drafter, "take_last_ddtree_payloads"):

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -391,7 +391,10 @@ def _dflash_ddtree_target_forward_nvtx_enabled() -> bool:
 
 
 def _dflash_ddtree_target_forward_profiler_step() -> int:
-    raw = os.getenv("VLLM_DFLASH_DDTREE_TARGET_FORWARD_PROFILER_STEP", "0")
+    raw = os.getenv(
+        "VLLM_SM70_SPEC_TARGET_FORWARD_PROFILER_STEP",
+        os.getenv("VLLM_DFLASH_DDTREE_TARGET_FORWARD_PROFILER_STEP", "0"),
+    )
     try:
         return max(0, int(raw))
     except ValueError:
@@ -1141,13 +1144,19 @@ class GPUModelRunner(
         if (
             not use_spec_decode
             or self.speculative_config is None
-            or not self.speculative_config.use_dflash_ddtree()
+            or not (
+                self.speculative_config.use_dflash_ddtree()
+                or self.speculative_config.use_dspark()
+            )
             or self.device.type != "cuda"
         ):
             yield
             return
 
-        nvtx_enabled = _dflash_ddtree_target_forward_nvtx_enabled()
+        nvtx_enabled = bool(
+            _dflash_ddtree_target_forward_nvtx_enabled()
+            or os.getenv("VLLM_SM70_SPEC_TARGET_FORWARD_NVTX", "0") == "1"
+        )
         profiler_step = _dflash_ddtree_target_forward_profiler_step()
         if not nvtx_enabled and profiler_step <= 0:
             yield
@@ -1155,9 +1164,13 @@ class GPUModelRunner(
 
         step = getattr(self, "_dflash_ddtree_target_forward_profile_step", 0) + 1
         self._dflash_ddtree_target_forward_profile_step = step
-        label = (
+        label_prefix = (
             "ddtree_target_forward"
-            f":step={step}:tokens={num_tokens}:reqs={num_reqs}"
+            if self.speculative_config.use_dflash_ddtree()
+            else "dspark_target_forward"
+        )
+        label = (
+            f"{label_prefix}:step={step}:tokens={num_tokens}:reqs={num_reqs}"
             f":mode={cudagraph_mode.name}:pid={os.getpid()}"
         )
         profile_this_step = profiler_step > 0 and step == profiler_step

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -1387,6 +1387,23 @@ class GPUModelRunner(
 
         # Async scheduling
         self.use_async_scheduling = bool(self.scheduler_config.async_scheduling)
+        self.dspark_confidence_scheduling = bool(
+            self.speculative_config is not None
+            and self.speculative_config.use_dspark()
+            and (
+                self.speculative_config.dspark_confidence_threshold > 0.0
+                or (
+                    self.speculative_config.dspark_max_verification_tokens is not None
+                    and self.speculative_config.dspark_max_verification_tokens
+                    < self.num_spec_tokens
+                )
+            )
+        )
+        if self.dspark_confidence_scheduling and self.use_async_scheduling:
+            raise ValueError(
+                "DSpark confidence prefix scheduling currently requires "
+                "synchronous scheduling."
+            )
         self._sm70_async_worker_execute_trace_step = 0
         self._sm70_async_worker_sample_trace_step = 0
         self._sm70_async_worker_input_prep_trace_step = 0
@@ -1784,6 +1801,15 @@ class GPUModelRunner(
         self._draft_confidence_logits: torch.Tensor | None = None
         self._draft_confidence_req_ids: list[str] | None = None
         self._draft_confidence_token_ids: list[list[int]] | torch.Tensor | None = None
+        self._dspark_verification_lengths: torch.Tensor | None = None
+        self._dspark_verification_lengths_cpu: torch.Tensor | None = None
+        if self.dspark_confidence_scheduling:
+            self._dspark_verification_lengths_cpu = torch.empty(
+                self.max_num_reqs,
+                dtype=torch.int32,
+                device="cpu",
+                pin_memory=self.pin_memory,
+            )
         self._dflash_ddtree_payloads: tuple[DDTreeDraftPayload, ...] | None = None
         self._ddtree_parent_metadata: DDTreeParentMetadata | None = None
         self._ddtree_accepted_rows_cpu_sidecar: list[list[int]] | None = None
@@ -8965,6 +8991,7 @@ class GPUModelRunner(
         self._draft_confidence_logits = None
         self._draft_confidence_req_ids = None
         self._draft_confidence_token_ids = None
+        self._dspark_verification_lengths = None
         self._dflash_ddtree_payloads = None
         self._ddtree_parent_metadata = None
         self._ddtree_accepted_rows_cpu_sidecar = None
@@ -9111,6 +9138,7 @@ class GPUModelRunner(
                 self._draft_confidence_logits = None
                 self._draft_confidence_req_ids = None
                 self._draft_confidence_token_ids = None
+                self._dspark_verification_lengths = None
                 self._copy_draft_token_ids_to_cpu(scheduler_output)
 
         with record_function_or_nullcontext("gpu_model_runner: bookkeep"):
@@ -9415,6 +9443,15 @@ class GPUModelRunner(
                 self.draft_token_ids_cpu[:num_reqs].copy_(
                     draft_token_ids, non_blocking=True
                 )
+                if self.dspark_confidence_scheduling:
+                    lengths = self._dspark_verification_lengths
+                    lengths_cpu = self._dspark_verification_lengths_cpu
+                    if lengths is None or lengths_cpu is None:
+                        raise RuntimeError(
+                            "DSpark confidence scheduling is enabled but the "
+                            "proposer did not return verification lengths."
+                        )
+                    lengths_cpu[:num_reqs].copy_(lengths[:num_reqs], non_blocking=True)
             else:
                 # No copy needed, just zero-out cpu tensor.
                 self.draft_token_ids_cpu[:num_reqs] = 0
@@ -9435,7 +9472,16 @@ class GPUModelRunner(
             self.draft_token_ids_event,
             "GPUModelRunner.draft_token_ids_event.synchronize",
         )
-        return self.draft_token_ids_cpu[: len(req_ids)].tolist(), req_ids
+        draft_token_ids = self.draft_token_ids_cpu[: len(req_ids)].tolist()
+        if self.dspark_confidence_scheduling:
+            lengths_cpu = self._dspark_verification_lengths_cpu
+            assert lengths_cpu is not None
+            lengths = lengths_cpu[: len(req_ids)].tolist()
+            draft_token_ids = [
+                token_ids[: max(0, min(int(length), len(token_ids)))]
+                for token_ids, length in zip(draft_token_ids, lengths, strict=True)
+            ]
+        return draft_token_ids, req_ids
 
     def _copy_valid_sampled_token_count(
         self, next_token_ids: torch.Tensor, valid_sampled_tokens_count: torch.Tensor
@@ -9522,6 +9568,7 @@ class GPUModelRunner(
         self._draft_confidence_logits = None
         self._draft_confidence_req_ids = None
         self._draft_confidence_token_ids = None
+        self._dspark_verification_lengths = None
         self._dflash_ddtree_payloads = None
         self._ddtree_parent_metadata = None
         self._ddtree_accepted_rows_cpu_sidecar = None
@@ -9846,6 +9893,10 @@ class GPUModelRunner(
                     self._draft_confidence_token_ids = clone_draft_prob_token_ids(
                         draft_token_ids
                     )
+            if hasattr(self.drafter, "take_last_verification_lengths"):
+                verification_lengths = self.drafter.take_last_verification_lengths()
+                if verification_lengths is not None:
+                    self._dspark_verification_lengths = verification_lengths
             if hasattr(self.drafter, "take_last_ddtree_payloads"):
                 self._dflash_ddtree_payloads = self.drafter.take_last_ddtree_payloads()
                 first_payload = (


### PR DESCRIPTION
## Purpose

- integrate the source-audited DSpark verifier, compressed-index, compressor-state, KV-pool, and benchmark tooling on current `main`
- keep runtime optimization selection engine-oriented: hardware, operator/configuration, tensor/layout, graph/cache, and bounded-concurrency contracts only
- preserve strict rejection semantics and retain incomplete long-context candidates as explicit opt-ins

## Audit disposition

- removed the architecture-name selector from CUDA Graph bucket derivation; checkpoint/model details are evidence, never runtime whitelists
- `VLLM_SM70_INDEXER_DECODE_CUBLAS=1` is required for gather + FP32 cuBLAS and now checks the complete SM70/query/weight/cache/layout/block-table contract
- `VLLM_SM70_DSV4_PRIVATE_COMPRESSOR_STATE=1` is required for private compressor rings
- speculative context buckets require explicit `VLLM_SM70_DSV4_DECODE_CONTEXT_BUCKETS`; an explicit MTP override remains authoritative
- ordinary serving does not instantiate or execute the optional confidence head; threshold/alignment users fail cleanly if its required weight is absent
- fixed verification caps produce lengths without the confidence projection

## Test Plan / Result

- [x] 74 focused CPU source/dispatch/configuration tests passed
- [x] complete changed-file pre-commit suite passed: ruff, formatting, typos, clang-format, markdownlint, mypy, SPDX, import/configuration checks
- [x] original branch V100 source gates retained: bitwise mHC M1/M4/M7/M8; private ring/workspace; M5/M6 grouped verifier; M5/M8 indexer exact-top-k and CUDA Graph replay
- [x] rebased onto current `main`; all 17 commits pass DCO
- [ ] expensive TP8 N4/M5 endpoint, 1K-252K sweep, and paired dataset quality were intentionally not rerun during source audit

Unchecked endpoint evidence does not block this merge because the affected indexer, private-state, variable-width grouped-verifier, and speculative long-context graph leaves remain default-off. They must not be cited as accepted default-path performance until their documented promotion gates pass.

Existing reproduced evidence: TP8 N7 median 116.288 token/s; matched no-speculation 66.014 token/s; exact microbenchmark and artifact details are recorded in `docs/design/sm70_deepseek_v4_dspark_verifier_20ms_long_context.md`.