### PR TITLE
[Bugfix] Zero reused KV blocks in MRV2

### DIFF
--- a/docs/design/sm70_v100_migration_control.md
+++ b/docs/design/sm70_v100_migration_control.md
@@ -42788,3 +42788,31 @@ Interpretation:
   graph, cache, and concurrency contracts. The architecture-name check was
   removed; measured checkpoint details remain evidence only and never select
   an optimization route.
+
+## 2026-08-24 PR #276 cache-block reuse audit
+
+- The reported corruption root cause is valid: a reused full-attention cache
+  block can retain non-finite values in slots that its new owner has not yet
+  written, and arithmetic masking does not make `0 * NaN` finite. The MRV2
+  runner had omitted the cache-zero lifecycle hook already used by the legacy
+  runner.
+- MRV2 now initializes the shared `KVBlockZeroer` metadata and consumes the
+  scheduler's `new_block_ids_to_zero` before either attention or a zero-token
+  early return. Work is proportional to newly allocated blocks, uses the
+  cache-group/operator layout metadata, and introduces no per-step sequence
+  length readback or request-by-layer launch loop.
+- The PR's per-step tail walker and sampled-token vocabulary clamp are
+  rejected. The former performs device-to-host synchronization plus many
+  small zero launches on every step; the latter turns corrupted output into
+  an arbitrary boundary token and hides the producer. The proposed GDN PAD
+  replication and last-column gather clamp are also rejected: the align-mode
+  allocator already guarantees a live current block plus its speculative
+  scratch window, so those fallbacks would conceal a broken block-table
+  contract and repeat an unrelated state block.
+- Route selection and correctness depend only on allocation lifecycle,
+  cache-group layout, block IDs, tensor shape/dtype, and operator contracts.
+  No model, checkpoint, or architecture identity participates in the fix.
+- Focused validation covers MRV2 zeroer initialization and zero-before-return
+  ordering, dense and multi-pool interleaved zeroing, Mamba align allocation,
+  and the existing GDN state-window contracts. No full-model end-to-end run
+  was required for this source-level repair.

--- a/tests/v1/worker/test_gpu_model_runner_v2_kv_zero.py
+++ b/tests/v1/worker/test_gpu_model_runner_v2_kv_zero.py
@@ -1,0 +1,87 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+from typing import Any
+
+import torch
+
+from vllm.v1.worker.gpu import model_runner as mrv2
+
+
+class FakeKVBlockZeroer:
+    def __init__(self, device: torch.device, pin_memory: bool):
+        self.device = device
+        self.pin_memory = pin_memory
+        self.init_kwargs: dict[str, Any] | None = None
+
+    def init_meta(self, **kwargs: Any) -> None:
+        kwargs["attn_groups_iter"] = list(kwargs["attn_groups_iter"])
+        self.init_kwargs = kwargs
+
+
+def test_v2_initializes_kv_zeroer_from_all_attention_groups(monkeypatch) -> None:
+    monkeypatch.setattr(mrv2, "KVBlockZeroer", FakeKVBlockZeroer)
+    monkeypatch.setattr(mrv2, "is_pin_memory_available", lambda: False)
+
+    groups = [[object()], [object(), object()]]
+    static_forward_context = object()
+    runner = mrv2.GPUModelRunner.__new__(mrv2.GPUModelRunner)
+    runner.device = torch.device("cpu")
+    runner.attn_groups = groups
+    runner._kernel_block_sizes = [16, 32]
+    runner.cache_config = SimpleNamespace(cache_dtype="auto")
+    runner.compilation_config = SimpleNamespace(
+        static_forward_context=static_forward_context
+    )
+
+    runner._init_kv_zero_meta()
+
+    zeroer = runner._kv_block_zeroer
+    assert isinstance(zeroer, FakeKVBlockZeroer)
+    assert zeroer.device == runner.device
+    assert zeroer.pin_memory is False
+    assert zeroer.init_kwargs == {
+        "attn_groups_iter": [*groups[0], *groups[1]],
+        "kernel_block_sizes": [16, 32],
+        "cache_dtype": "auto",
+        "runner_only_attn_layers": set(),
+        "static_forward_context": static_forward_context,
+    }
+
+
+def test_v2_clears_new_cache_blocks_before_zero_token_return() -> None:
+    events: list[object] = []
+    empty_output = object()
+
+    def no_forward(_: Any) -> object:
+        events.append("no_forward")
+        return empty_output
+
+    runner = mrv2.GPUModelRunner.__new__(mrv2.GPUModelRunner)
+    runner.finish_requests = lambda _: events.append("finish")
+    runner.free_states = lambda _: events.append("free")
+    runner.add_requests = lambda _: events.append("add")
+    runner.update_requests = lambda _: events.append("update")
+    runner.block_tables = SimpleNamespace(
+        apply_staged_writes=lambda: events.append("apply")
+    )
+    runner._zero_block_ids = lambda block_ids: events.append(("zero", block_ids))
+    runner.kv_connector = SimpleNamespace(no_forward=no_forward)
+    scheduler_output = SimpleNamespace(
+        total_num_scheduled_tokens=0,
+        new_block_ids_to_zero=[3, 7],
+    )
+
+    output = runner.execute_model(scheduler_output)
+
+    assert output is empty_output
+    assert events == [
+        "finish",
+        "free",
+        "add",
+        "update",
+        "apply",
+        ("zero", [3, 7]),
+        "no_forward",
+    ]

--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -47,6 +47,7 @@ from vllm.sequence import IntermediateTensors
 from vllm.tasks import SupportedTask
 from vllm.utils.math_utils import cdiv
 from vllm.utils.mem_utils import DeviceMemoryProfiler, format_gib
+from vllm.utils.platform_utils import is_pin_memory_available
 from vllm.utils.torch_utils import STR_DTYPE_TO_TORCH_DTYPE
 from vllm.v1.core.sched.output import GrammarOutput, SchedulerOutput
 from vllm.v1.kv_cache_interface import KVCacheConfig, MambaSpec
@@ -107,6 +108,7 @@ from vllm.v1.worker.gpu.spec_decode.utils import DraftTokensHandler
 from vllm.v1.worker.gpu.states import RequestState
 from vllm.v1.worker.gpu.structured_outputs import StructuredOutputsWorker
 from vllm.v1.worker.lora_model_runner_mixin import LoRAModelRunnerMixin
+from vllm.v1.worker.utils import KVBlockZeroer
 
 logger = init_logger(__name__)
 
@@ -403,6 +405,7 @@ class GPUModelRunner(LoRAModelRunnerMixin):
         self.attn_groups, attn_cg_support, kernel_block_sizes = init_attn_backend(
             self.kv_cache_config, self.vllm_config, self.device
         )
+        self._kernel_block_sizes = kernel_block_sizes
         self.block_tables = BlockTables(
             block_sizes=block_sizes,
             max_num_reqs=self.max_num_reqs,
@@ -463,6 +466,24 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             self.vllm_config,
         )
         self.kv_connector = get_kv_connector(self.vllm_config, kv_caches_dict)
+
+    def _init_kv_zero_meta(self) -> None:
+        """Precompute metadata used to clear newly allocated cache blocks."""
+        self._kv_block_zeroer = KVBlockZeroer(
+            self.device, pin_memory=is_pin_memory_available()
+        )
+        self._kv_block_zeroer.init_meta(
+            attn_groups_iter=(group for groups in self.attn_groups for group in groups),
+            kernel_block_sizes=self._kernel_block_sizes,
+            cache_dtype=self.cache_config.cache_dtype,
+            runner_only_attn_layers=set(),
+            static_forward_context=self.compilation_config.static_forward_context,
+        )
+
+    def _zero_block_ids(self, block_ids: list[int]) -> None:
+        """Clear cache blocks before their first use after allocation."""
+        if hasattr(self, "_kv_block_zeroer"):
+            self._kv_block_zeroer.zero_block_ids(block_ids)
 
     @torch.inference_mode()
     @step_eplb_after(is_dummy=True)
@@ -1057,6 +1078,8 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             self.add_requests(scheduler_output)
             self.update_requests(scheduler_output)
             self.block_tables.apply_staged_writes()
+            if scheduler_output.new_block_ids_to_zero:
+                self._zero_block_ids(scheduler_output.new_block_ids_to_zero)
             if scheduler_output.total_num_scheduled_tokens == 0:
                 # No need to run the model.
                 empty_output = self.kv_connector.no_forward(scheduler_output)


### PR DESCRIPTION
## Purpose

Fix stale/non-finite cache data on block reuse in the new MRV2 runner by restoring the existing scheduler-to-runner cache-zero lifecycle contract. This replaces the old 59-file umbrella branch with one focused change rebased on current `main`.

## Source audit

- The reported stale full-attention KV block root cause is valid.
- MRV2 now initializes the shared `KVBlockZeroer` and consumes `SchedulerOutput.new_block_ids_to_zero` before attention or a zero-token early return.
- The path runs only when the scheduler allocates/reuses blocks; it adds no model/checkpoint/architecture selector, per-step sequence-length D2H readback, request-by-layer loop, or token clamp.
- Rejected from the original branch: default-on sampled-token clipping, per-step tail walking, diagnostic-only probes, GDN PAD replication, and last-column gather clamping. Those either mask corruption, add hot-path synchronization/launches, or conceal a broken block-table contract.
- The fix relies only on allocation lifecycle, cache-group/operator layout, block IDs, tensor dtype/shape, and graph-safe zeroing.

## Test Plan

```bash
CUDA_VISIBLE_DEVICES="" UV_PROJECT_ENVIRONMENT=/home/ymzx/miniconda3/envs/vllm-0.0.5-t210 uv run --no-sync pytest -q tests/v1/worker/test_gpu_model_runner_v2_kv_zero.py tests/v1/worker/test_kv_block_zeroer.py
CUDA_VISIBLE_DEVICES="" UV_PROJECT_ENVIRONMENT=/home/ymzx/miniconda3/envs/vllm-0.0.5-t210 uv run --no-sync pytest -q tests/v1/attention/test_gdn_metadata_builder.py -k "align or state_contract"
CUDA_VISIBLE_DEVICES="" UV_PROJECT_ENVIRONMENT=/home/ymzx/miniconda3/envs/vllm-0.0.5-t210 uv run --no-sync pytest -q tests/v1/core/test_prefix_caching.py -k mamba_align
UV_PROJECT_ENVIRONMENT=/home/ymzx/miniconda3/envs/vllm-0.0.5-t210 uv run --no-sync pre-commit run --files vllm/v1/worker/gpu/model_runner.py tests/v1/worker/test_gpu_model_runner_v2_kv_zero.py docs/design/sm70_v100_migration_control.md
```

## Test Result

- MRV2 wiring plus CPU zeroer contracts: 7 passed, 2 CUDA tests skipped under isolated CPU run.
- GDN align/state contracts: 5 passed.
- Mamba align allocator contracts: 2 passed.
- All changed-file pre-commit hooks passed, including ruff, mypy, markdownlint, SPDX, and forbidden-import/API checks.
- The shared CUDA zeroer and its multi-pool interleaved layout were already validated on V100 while auditing merged PR #280; this PR does not change that kernel. No full-model E2E was run.

Signed-off-by: yangzhuxinyzx <153831768+yangzhuxinyzx@users.noreply.github.com>