### PR TITLE
[Doc][SM70] Record Q8000 split-KV3 quality gate

### DIFF
--- a/docs/design/sm70_qwen38_fp8_prefill_decay.md
+++ b/docs/design/sm70_qwen38_fp8_prefill_decay.md
@@ -259,14 +259,33 @@ matches 12 eligible long chunks times 16 full-attention layers times two
 requests. KV capacity remains 2,424,439 tokens per rank and no OOM fallback
 occurs.
 
-Quality does not yet justify a default-on promotion. Every lane is internally
-stable between warmup and measurement, and the candidate is token-for-token
-identical to control B for both 256-token outputs. However, identical unsplit
-control A selects a different stable sampled stream despite the same official
-seed. The candidate therefore shows no unique output divergence, but this
-cross-process sampling instability cannot prove equivalence for a non-bitwise
-route. Keep Q8000 split-KV3 explicit and default-off until a deterministic
-greedy/natural-text or dataset-quality gate passes.
+Quality does not yet justify a default-on promotion. Every official-sampling
+lane is internally stable between warmup and measurement, and the candidate
+is token-for-token identical to control B for both 256-token outputs. However,
+identical unsplit control A selects a different stable sampled stream despite
+the same official seed. The candidate therefore shows no unique output
+divergence, but this cross-process sampling instability cannot prove
+equivalence for a non-bitwise route.
+
+A follow-up deterministic greedy gate used three exact-128K natural-text
+requests: two identical Chinese prompts and one Python task. Both control and
+candidate reproduce the duplicate prompt exactly within their own process,
+and all outputs are coherent; both Python outputs stop normally and return the
+same correct `add(a, b)` implementation. The two routes are not token-for-token
+equal, though. The Chinese outputs first differ at token 7 and align for
+126/128 tokens; the Python outputs first differ at token 20, with all 67
+control tokens aligned inside the 70-token candidate stream. Candidate prefill
+times are `47.1360/47.2292/47.3380 s` versus control
+`47.6704/47.8330/47.9274 s`. This unbracketed quality run is directionally
+consistent with the formal A/B/A but is not a replacement performance claim.
+All four candidate ranks report exactly 576 split-KV3 hits, matching three
+requests times 12 eligible chunks times 16 full-attention layers; controls
+report zero.
+
+The semantic smoke passes stability and basic task correctness, but strict
+greedy identity fails. Keep Q8000 split-KV3 explicit and default-off until a
+fixed-text logprob/perplexity or dataset-level quality gate establishes that
+the classified Type-B reduction-order drift does not reduce model quality.
 
 ## Artifacts
 
@@ -280,6 +299,9 @@ greedy/natural-text or dataset-quality gate passes.
   `results/splitkv3-q8000-kv{40000,64000,96000,128000}-v6.json`.
 - Q8000 endpoint A/B/A:
   `results/tp4-128k-splitkv3-q8000-{control-a,candidate,control-b}.json`.
+- Q8000 deterministic quality gate:
+  `results/tp4-128k-splitkv3-q8000-quality-{control,candidate}.json` and the
+  matching files under `logs/`.
 - Shape diagnostic and the zero-hit Q8192 negative run:
   `logs/tp4-splitkv3-shape-diag.log` and
   `results/tp4-128k-splitkv3-{control-a,candidate,control-b}.json`.

--- a/docs/design/sm70_v100_migration_control.md
+++ b/docs/design/sm70_v100_migration_control.md
@@ -42398,10 +42398,18 @@ Interpretation:
 - Each lane's warmup and measured 256-token stream is internally exact. The
   candidate and control B are also token-for-token identical, but identical
   unsplit control A selects a different stable sampled stream under the same
-  official seed. This cross-process sampling instability prevents default-on
-  promotion of a non-bitwise route. Keep the Q8000 gate experimental until a
-  deterministic greedy/natural-text or dataset-quality gate passes. Evidence
-  is under
+  official seed. This cross-process sampling instability is not equivalence
+  evidence for a non-bitwise route.
+- A deterministic greedy follow-up uses two identical Chinese exact-128K
+  prompts and one exact-128K Python task. Both routes are internally stable and
+  coherent, and both code responses stop normally with the same correct
+  `add(a, b)` implementation. Cross-route strict identity fails: Chinese first
+  differs at token 7 with 126/128 tokens aligned; Python first differs at token
+  20 with all 67 control tokens aligned in the 70-token candidate response.
+  Candidate ranks each report the expected 576 split-KV3 hits and controls
+  report zero. Keep the Q8000 gate default-off until fixed-text
+  logprob/perplexity or dataset-level evidence proves no quality loss from the
+  classified Type-B reduction-order drift. Evidence is under
   `/data/minimax-h3/task-cache/qwen38-fp8-128k-flashattention-20260824/`.
 
 ## 2026-08-23 Qwen3.8-27B-FP8 TP4 no-MTP QPN8 decode acceptance


### PR DESCRIPTION
## Purpose

Record the deterministic exact-128K quality gate completed after #275 merged. This follow-up is documentation-only and does not change runtime behavior. The Q8000 split-KV3 route added by #275 remains explicit and default-off.

## Source audit

- Verified both referenced result JSON files and matching logs in the task cache.
- The recorded three 131,072-token requests, greedy sampling settings, per-request prefill times, token divergence, finish reasons, and four per-rank 576-hit route summaries match the artifacts.
- The evidence is correctly classified as a semantic smoke, not route equivalence or a replacement performance baseline.
- No runtime selector is added. Model/checkpoint details describe the measured workload only and do not gate the optimization.

## Test Plan

- Qwen3.8-27B-FP8, TP4 V100, 131,072 input tokens, 128 greedy output tokens.
- E5M2 KV, chunk budget 8192, Mamba align, prefix cache, Flash-V100, no MTP, and FULL_AND_PIECEWISE CUDA graphs.
- Two identical Chinese prompts plus one Python `add(a, b)` prompt.
- Compare token IDs/hashes, repeat stability, task correctness, finish reasons, prefill timing, and per-rank attention-route summaries.

## Test Result

- Both control and candidate reproduce the duplicate Chinese request exactly within their own process.
- Both Python outputs stop normally and return the same correct `add(a, b)` implementation.
- Cross-route strict token identity fails. Chinese first differs at token 7 with 126/128 tokens aligned. Python first differs at token 20, with all 67 control tokens aligned in the 70-token candidate response.
- Candidate prefill times are 47.1360/47.2292/47.3380 seconds versus control 47.6704/47.8330/47.9274 seconds. This single-order quality run is supporting evidence only; the bracketed performance result remains the #275 A/B/A.
- Every candidate rank records exactly 576 Q8000 split-KV3 hits; controls record zero.
- Decision: retain the route as default-off until fixed-text logprob/perplexity or dataset-level evidence proves no quality loss from the Type-B reduction-order drift.
- Latest-main changed-file pre-commit and `git diff --check` passed; DCO sign-off is present.

Artifacts are under `/data/minimax-h3/task-cache/qwen38-fp8-128k-flashattention-20260824/`.
- GitHub `pre-commit --all-files` remains red because it reformats and flags unrelated baseline files; the identical job also fails on current `main` (`febf1fc96`). The two changed Markdown files pass the repository hooks locally, and the synthesized merge tree is exact and clean.