### PR TITLE
[Kernel][SM70] Fuse exact-shape GDN decode projections

### DIFF
--- a/csrc/ops.h
+++ b/csrc/ops.h
@@ -175,6 +175,18 @@ void fp8_qpn8_gemm_sm70_out(torch::Tensor out, torch::Tensor input,
                             int64_t split_k, int64_t accumulator_chains,
                             bool fast_decoder, bool prefetch_codes);
 
+void fp8_qpn8_gemm_ba_split_sm70_out(torch::Tensor qkv_out, torch::Tensor z_out,
+                                     torch::Tensor b_out, torch::Tensor a_out,
+                                     torch::Tensor input, torch::Tensor codes,
+                                     torch::Tensor group_scales,
+                                     torch::Tensor ba_weight);
+
+void fp8_qpn8_dispatch_ba_split_sm70_out(
+    torch::Tensor qkv_out, torch::Tensor z_out, torch::Tensor b_out,
+    torch::Tensor a_out, torch::Tensor qkvz_staging, torch::Tensor ba_staging,
+    int64_t dense_weight_ptr, torch::Tensor input, torch::Tensor codes,
+    torch::Tensor group_scales, torch::Tensor ba_weight);
+
 void fp8_qpn8_gated_pair_sm70_out(torch::Tensor out, torch::Tensor input,
                                   torch::Tensor codes,
                                   torch::Tensor group_scales, int64_t split_k,

--- a/csrc/sm70_turbomind/ops/fp8_qpn8_sm70.cu
+++ b/csrc/sm70_turbomind/ops/fp8_qpn8_sm70.cu
@@ -16,6 +16,9 @@
 #include <cuda_fp16.h>
 #include <cuda_runtime.h>
 
+#include <cstdio>
+#include <mutex>
+
 namespace {
 
 __device__ __forceinline__ void fp8x8_to_half2x4(uint2 q, half2 out[4]) {
@@ -169,18 +172,99 @@ __global__ void fp8_qpn8_silu_and_mul_sm70_kernel(
         "+f"(C[5]), "+f"(C[6]), "+f"(C[7])                          \
       : "r"(A0), "r"(A1), "r"(B0), "r"(B1))
 
+__global__ void fp8_qpn8_ba_split_copy_sm70_kernel(
+    const half* __restrict__ qkvz, const half* __restrict__ ba,
+    half* __restrict__ qkv, half* __restrict__ z, half* __restrict__ b,
+    half* __restrict__ a, int m) {
+  constexpr int kQkvN = 2560;
+  constexpr int kZN = 1536;
+  constexpr int kQkvzN = kQkvN + kZN;
+  constexpr int kBAN = 24;
+  constexpr int kOutputN = kQkvzN + kBAN;
+  const int index = blockIdx.x * blockDim.x + threadIdx.x;
+  if (index >= m * kOutputN) {
+    return;
+  }
+  const int row = index / kOutputN;
+  const int col = index - row * kOutputN;
+  if (col < kQkvN) {
+    qkv[static_cast<size_t>(row) * kQkvN + col] =
+        qkvz[static_cast<size_t>(row) * kQkvzN + col];
+  } else if (col < kQkvzN) {
+    z[static_cast<size_t>(row) * kZN + col - kQkvN] =
+        qkvz[static_cast<size_t>(row) * kQkvzN + col];
+  } else if (col < kQkvzN + kBAN / 2) {
+    b[static_cast<size_t>(row) * (kBAN / 2) + col - kQkvzN] =
+        ba[static_cast<size_t>(row) * kBAN + col - kQkvzN];
+  } else {
+    a[static_cast<size_t>(row) * (kBAN / 2) + col - kQkvzN - kBAN / 2] =
+        ba[static_cast<size_t>(row) * kBAN + col - kQkvzN];
+  }
+}
+
 template <int SplitK, int NAcc, bool FastDecoder, bool PrefetchCodes,
-          bool M1Only = false>
-__global__ void fp8_qpn8_sm70_kernel(const uint8_t* __restrict__ codes,
-                                     const half* __restrict__ group_scales,
-                                     const half* __restrict__ input,
-                                     half* __restrict__ output, int n, int k,
-                                     int m, bool channel_scales) {
+          bool M1Only = false, bool FusedBA = false, bool SplitOutputs = false>
+__global__ void fp8_qpn8_sm70_kernel(
+    const uint8_t* __restrict__ codes, const half* __restrict__ group_scales,
+    const half* __restrict__ input, half* __restrict__ output,
+    half* __restrict__ z_output, const half* __restrict__ ba_weight,
+    half* __restrict__ ba_output, half* __restrict__ b_output,
+    half* __restrict__ a_output, int ba_n, int qkv_n, int n, int k, int m,
+    bool channel_scales) {
   __shared__ float partials[SplitK][M1Only ? 32 : 256];
 
   const int lane = threadIdx.x & 31;
   const int warp = threadIdx.x >> 5;
   const int tile = blockIdx.x;
+  if constexpr (FusedBA) {
+    const int qpn_tiles = n >> 5;
+    if (tile >= qpn_tiles) {
+      constexpr int kBARowsPerBlock = 2;
+      constexpr int kBAThreadsPerRow = 256;
+      const int ba_block = tile - qpn_tiles;
+      const int ba_group = threadIdx.x / kBAThreadsPerRow;
+      const int ba_thread = threadIdx.x % kBAThreadsPerRow;
+      const int ba_warp = ba_thread >> 5;
+      const int ba_row = ba_block * kBARowsPerBlock + ba_group;
+      float value = 0.0f;
+      const half2* input2 = reinterpret_cast<const half2*>(input);
+      const half2* weight2 = reinterpret_cast<const half2*>(
+          ba_weight + static_cast<size_t>(ba_row) * k);
+      for (int pair = ba_thread; pair < k / 2; pair += kBAThreadsPerRow) {
+        const float2 x = __half22float2(__ldg(input2 + pair));
+        const float2 weight = __half22float2(__ldg(weight2 + pair));
+        value = fmaf(x.x, weight.x, value);
+        value = fmaf(x.y, weight.y, value);
+      }
+#pragma unroll
+      for (int offset = 16; offset > 0; offset >>= 1) {
+        value += __shfl_down_sync(0xffffffffU, value, offset);
+      }
+      if (lane == 0) {
+        partials[ba_group][ba_warp] = value;
+      }
+      __syncthreads();
+      if (ba_warp == 0) {
+        value = lane < 8 ? partials[ba_group][lane] : 0.0f;
+#pragma unroll
+        for (int offset = 16; offset > 0; offset >>= 1) {
+          value += __shfl_down_sync(0xffffffffU, value, offset);
+        }
+        if (lane == 0 && ba_row < ba_n) {
+          if constexpr (SplitOutputs) {
+            if (ba_row < ba_n / 2) {
+              b_output[ba_row] = __float2half(value);
+            } else {
+              a_output[ba_row - ba_n / 2] = __float2half(value);
+            }
+          } else {
+            ba_output[ba_row] = __float2half(value);
+          }
+        }
+      }
+      return;
+    }
+  }
   const int quadpair = (lane >> 2) & 3;
   const int row = (lane & 3) + ((lane & 16) ? 4 : 0);
   const int groups_k16 = k >> 4;
@@ -304,7 +388,16 @@ __global__ void fp8_qpn8_sm70_kernel(const uint8_t* __restrict__ codes,
       value += partials[k_warp][element];
     }
     if constexpr (M1Only) {
-      output[tile * 32 + element] = __float2half(value);
+      const int output_col = tile * 32 + element;
+      if constexpr (SplitOutputs) {
+        if (output_col < qkv_n) {
+          output[output_col] = __float2half(value);
+        } else {
+          z_output[output_col - qkv_n] = __float2half(value);
+        }
+      } else {
+        output[output_col] = __float2half(value);
+      }
     } else {
       const int output_row = element >> 5;
       const int output_col = element & 31;
@@ -322,8 +415,22 @@ void launch_fp8_qpn8_sm70(const uint8_t* codes, const half* group_scales,
                           const half* input, half* output, int n, int k, int m,
                           bool channel_scales, cudaStream_t stream) {
   fp8_qpn8_sm70_kernel<SplitK, NAcc, FastDecoder, PrefetchCodes, M1Only>
-      <<<(n / 32), (32 * SplitK), 0, stream>>>(codes, group_scales, input,
-                                               output, n, k, m, channel_scales);
+      <<<(n / 32), (32 * SplitK), 0, stream>>>(
+          codes, group_scales, input, output, nullptr, nullptr, nullptr,
+          nullptr, nullptr, 0, n, n, k, m, channel_scales);
+}
+
+void launch_fp8_qpn8_ba_split_sm70(const uint8_t* codes,
+                                   const half* group_scales, const half* input,
+                                   half* qkv_output, half* z_output,
+                                   const half* ba_weight, half* b_output,
+                                   half* a_output, int ba_n, int qkv_n, int n,
+                                   int k, bool channel_scales,
+                                   cudaStream_t stream) {
+  fp8_qpn8_sm70_kernel<16, 2, true, false, true, true, true>
+      <<<(n / 32 + (ba_n + 1) / 2), 512, 0, stream>>>(
+          codes, group_scales, input, qkv_output, z_output, ba_weight, nullptr,
+          b_output, a_output, ba_n, qkv_n, n, k, 1, channel_scales);
 }
 
 template <int SplitK, int NAcc, bool FastDecoder, bool PrefetchCodes,
@@ -787,6 +894,161 @@ void fp8_qpn8_gemm_sm70_out(torch::Tensor out, torch::Tensor input,
   C10_CUDA_KERNEL_LAUNCH_CHECK();
 }
 
+void fp8_qpn8_gemm_ba_split_sm70_out(torch::Tensor qkv_out, torch::Tensor z_out,
+                                     torch::Tensor b_out, torch::Tensor a_out,
+                                     torch::Tensor input, torch::Tensor codes,
+                                     torch::Tensor group_scales,
+                                     torch::Tensor ba_weight) {
+  TORCH_CHECK(qkv_out.is_cuda() && z_out.is_cuda() && b_out.is_cuda() &&
+                  a_out.is_cuda() && input.is_cuda() && codes.is_cuda() &&
+                  group_scales.is_cuda() && ba_weight.is_cuda(),
+              "fp8_qpn8_gemm_ba_split_sm70_out: tensors must be CUDA tensors");
+  TORCH_CHECK(qkv_out.scalar_type() == torch::kFloat16 &&
+                  z_out.scalar_type() == torch::kFloat16 &&
+                  b_out.scalar_type() == torch::kFloat16 &&
+                  a_out.scalar_type() == torch::kFloat16 &&
+                  input.scalar_type() == torch::kFloat16 &&
+                  group_scales.scalar_type() == torch::kFloat16 &&
+                  ba_weight.scalar_type() == torch::kFloat16 &&
+                  codes.scalar_type() == torch::kUInt8,
+              "fp8_qpn8_gemm_ba_split_sm70_out: dtype mismatch");
+  TORCH_CHECK(qkv_out.is_contiguous() && z_out.is_contiguous() &&
+                  b_out.is_contiguous() && a_out.is_contiguous() &&
+                  input.is_contiguous() && codes.is_contiguous() &&
+                  group_scales.is_contiguous() && ba_weight.is_contiguous(),
+              "fp8_qpn8_gemm_ba_split_sm70_out: tensors must be contiguous");
+  TORCH_CHECK(qkv_out.get_device() == z_out.get_device() &&
+                  qkv_out.get_device() == b_out.get_device() &&
+                  qkv_out.get_device() == a_out.get_device() &&
+                  qkv_out.get_device() == input.get_device() &&
+                  qkv_out.get_device() == codes.get_device() &&
+                  qkv_out.get_device() == group_scales.get_device() &&
+                  qkv_out.get_device() == ba_weight.get_device(),
+              "fp8_qpn8_gemm_ba_split_sm70_out: tensors must share one device");
+
+  constexpr int64_t k = 5120;
+  constexpr int64_t n = 4096;
+  constexpr int64_t qkv_n = 2560;
+  constexpr int64_t z_n = n - qkv_n;
+  constexpr int64_t ba_n = 24;
+  TORCH_CHECK(input.dim() == 2 && input.size(0) == 1 && input.size(1) == k,
+              "fp8_qpn8_gemm_ba_split_sm70_out: expected input [1, 5120]");
+  TORCH_CHECK(qkv_out.numel() == qkv_n && z_out.numel() == z_n &&
+                  b_out.numel() == ba_n / 2 && a_out.numel() == ba_n / 2,
+              "fp8_qpn8_gemm_ba_split_sm70_out: output shape mismatch");
+  TORCH_CHECK(codes.numel() == n * k,
+              "fp8_qpn8_gemm_ba_split_sm70_out: packed code size mismatch");
+  TORCH_CHECK(group_scales.dim() == 2 && group_scales.size(0) == 1 &&
+                  group_scales.size(1) == n,
+              "fp8_qpn8_gemm_ba_split_sm70_out: expected channel scales");
+  TORCH_CHECK(ba_weight.dim() == 2 && ba_weight.size(0) == ba_n &&
+                  ba_weight.size(1) == k,
+              "fp8_qpn8_gemm_ba_split_sm70_out: b/a weight shape mismatch");
+
+  const at::cuda::OptionalCUDAGuard device_guard(device_of(input));
+  const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
+  launch_fp8_qpn8_ba_split_sm70(
+      codes.data_ptr<uint8_t>(),
+      reinterpret_cast<const half*>(group_scales.data_ptr<at::Half>()),
+      reinterpret_cast<const half*>(input.data_ptr<at::Half>()),
+      reinterpret_cast<half*>(qkv_out.data_ptr<at::Half>()),
+      reinterpret_cast<half*>(z_out.data_ptr<at::Half>()),
+      reinterpret_cast<const half*>(ba_weight.data_ptr<at::Half>()),
+      reinterpret_cast<half*>(b_out.data_ptr<at::Half>()),
+      reinterpret_cast<half*>(a_out.data_ptr<at::Half>()),
+      static_cast<int>(ba_n), static_cast<int>(qkv_n), static_cast<int>(n),
+      static_cast<int>(k), true, stream);
+  C10_CUDA_KERNEL_LAUNCH_CHECK();
+}
+
+void fp8_qpn8_dispatch_sm70_out(torch::Tensor out, int64_t dense_weight_ptr,
+                                torch::Tensor input, torch::Tensor codes,
+                                torch::Tensor group_scales, int64_t split_k,
+                                int64_t accumulator_chains, bool prefetch_codes,
+                                bool gated_silu);
+
+void fp8_qpn8_dispatch_ba_split_sm70_out(
+    torch::Tensor qkv_out, torch::Tensor z_out, torch::Tensor b_out,
+    torch::Tensor a_out, torch::Tensor qkvz_staging, torch::Tensor ba_staging,
+    int64_t dense_weight_ptr, torch::Tensor input, torch::Tensor codes,
+    torch::Tensor group_scales, torch::Tensor ba_weight) {
+  constexpr int64_t k = 5120;
+  constexpr int64_t n = 4096;
+  constexpr int64_t qkv_n = 2560;
+  constexpr int64_t z_n = n - qkv_n;
+  constexpr int64_t ba_n = 24;
+  const int64_t m = input.size(0);
+  TORCH_CHECK(input.dim() == 2 && input.size(1) == k && m >= 1,
+              "fp8_qpn8_dispatch_ba_split_sm70_out: bad input shape");
+  TORCH_CHECK(qkv_out.is_cuda() && z_out.is_cuda() && b_out.is_cuda() &&
+                  a_out.is_cuda() && qkvz_staging.is_cuda() &&
+                  ba_staging.is_cuda() && input.is_cuda() && codes.is_cuda() &&
+                  group_scales.is_cuda() && ba_weight.is_cuda(),
+              "fp8_qpn8_dispatch_ba_split_sm70_out: tensors must be CUDA");
+  TORCH_CHECK(qkv_out.scalar_type() == torch::kFloat16 &&
+                  z_out.scalar_type() == torch::kFloat16 &&
+                  b_out.scalar_type() == torch::kFloat16 &&
+                  a_out.scalar_type() == torch::kFloat16 &&
+                  qkvz_staging.scalar_type() == torch::kFloat16 &&
+                  ba_staging.scalar_type() == torch::kFloat16 &&
+                  input.scalar_type() == torch::kFloat16 &&
+                  group_scales.scalar_type() == torch::kFloat16 &&
+                  ba_weight.scalar_type() == torch::kFloat16 &&
+                  codes.scalar_type() == torch::kUInt8,
+              "fp8_qpn8_dispatch_ba_split_sm70_out: dtype mismatch");
+  TORCH_CHECK(
+      qkv_out.is_contiguous() && z_out.is_contiguous() &&
+          b_out.is_contiguous() && a_out.is_contiguous() &&
+          qkvz_staging.is_contiguous() && ba_staging.is_contiguous() &&
+          input.is_contiguous() && codes.is_contiguous() &&
+          group_scales.is_contiguous() && ba_weight.is_contiguous(),
+      "fp8_qpn8_dispatch_ba_split_sm70_out: tensors must be contiguous");
+  TORCH_CHECK(
+      qkv_out.numel() == m * qkv_n && z_out.numel() == m * z_n &&
+          b_out.numel() == m * ba_n / 2 && a_out.numel() == m * ba_n / 2 &&
+          qkvz_staging.numel() == m * n && ba_staging.numel() == m * ba_n,
+      "fp8_qpn8_dispatch_ba_split_sm70_out: output shape mismatch");
+  TORCH_CHECK(codes.dim() == 2 && codes.size(0) == k && codes.size(1) == n,
+              "fp8_qpn8_dispatch_ba_split_sm70_out: code shape mismatch");
+  TORCH_CHECK(group_scales.dim() == 2 && group_scales.size(0) == 1 &&
+                  group_scales.size(1) == n,
+              "fp8_qpn8_dispatch_ba_split_sm70_out: scale shape mismatch");
+  TORCH_CHECK(ba_weight.dim() == 2 && ba_weight.size(0) == ba_n &&
+                  ba_weight.size(1) == k,
+              "fp8_qpn8_dispatch_ba_split_sm70_out: b/a weight mismatch");
+
+  if (m == 1) {
+    static std::once_flag route_log_once;
+    std::call_once(route_log_once, []() {
+      std::fprintf(
+          stderr,
+          "SM70 Qwen3.8-27B no-MTP QPN8 qkv/z + FP16 b/a split C++ route "
+          "enabled.\n");
+      std::fflush(stderr);
+    });
+    fp8_qpn8_gemm_ba_split_sm70_out(qkv_out, z_out, b_out, a_out, input, codes,
+                                    group_scales, ba_weight);
+    return;
+  }
+
+  fp8_qpn8_dispatch_sm70_out(qkvz_staging, dense_weight_ptr, input, codes,
+                             group_scales, 16, 2, false, false);
+  at::mm_out(ba_staging, input, ba_weight.t());
+  const at::cuda::OptionalCUDAGuard device_guard(device_of(input));
+  constexpr int threads = 256;
+  const int64_t elements = m * (n + ba_n);
+  const int blocks = static_cast<int>((elements + threads - 1) / threads);
+  fp8_qpn8_ba_split_copy_sm70_kernel<<<blocks, threads, 0,
+                                       at::cuda::getCurrentCUDAStream()>>>(
+      reinterpret_cast<const half*>(qkvz_staging.data_ptr<at::Half>()),
+      reinterpret_cast<const half*>(ba_staging.data_ptr<at::Half>()),
+      reinterpret_cast<half*>(qkv_out.data_ptr<at::Half>()),
+      reinterpret_cast<half*>(z_out.data_ptr<at::Half>()),
+      reinterpret_cast<half*>(b_out.data_ptr<at::Half>()),
+      reinterpret_cast<half*>(a_out.data_ptr<at::Half>()), static_cast<int>(m));
+  C10_CUDA_KERNEL_LAUNCH_CHECK();
+}
+
 void fp8_qpn8_gated_pair_sm70_out(torch::Tensor out, torch::Tensor input,
                                   torch::Tensor codes,
                                   torch::Tensor group_scales, int64_t split_k,
@@ -957,6 +1219,19 @@ TORCH_LIBRARY_FRAGMENT(_C, ops) {
       "Tensor group_scales, int split_k, int accumulator_chains, "
       "bool fast_decoder, bool prefetch_codes) -> ()");
   ops.impl("fp8_qpn8_gemm_sm70_out", torch::kCUDA, &fp8_qpn8_gemm_sm70_out);
+  ops.def(
+      "fp8_qpn8_gemm_ba_split_sm70_out(Tensor(a!) qkv_out, Tensor(b!) "
+      "z_out, Tensor(c!) b_out, Tensor(d!) a_out, Tensor input, Tensor codes, "
+      "Tensor group_scales, Tensor ba_weight) -> ()");
+  ops.impl("fp8_qpn8_gemm_ba_split_sm70_out", torch::kCUDA,
+           &fp8_qpn8_gemm_ba_split_sm70_out);
+  ops.def(
+      "fp8_qpn8_dispatch_ba_split_sm70_out(Tensor(a!) qkv_out, Tensor(b!) "
+      "z_out, Tensor(c!) b_out, Tensor(d!) a_out, Tensor(e!) qkvz_staging, "
+      "Tensor(f!) ba_staging, int dense_weight_ptr, Tensor input, Tensor "
+      "codes, Tensor group_scales, Tensor ba_weight) -> ()");
+  ops.impl("fp8_qpn8_dispatch_ba_split_sm70_out", torch::kCUDA,
+           &fp8_qpn8_dispatch_ba_split_sm70_out);
   ops.def(
       "fp8_qpn8_gated_pair_sm70_out(Tensor(a!) out, Tensor input, "
       "Tensor codes, Tensor group_scales, int split_k, "

--- a/csrc/sm70_turbomind/ops/fp8_qpn8_sm70.cu
+++ b/csrc/sm70_turbomind/ops/fp8_qpn8_sm70.cu
@@ -2,8 +2,8 @@
 // SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 //
 // The QPN8 execution layout is derived from dnv2003/v100-skinny (MIT) and
-// its block-scale adaptation in haohervchb/sglang-V100. Automatic model
-// dispatch is restricted to accepted Qwen3.8-27B TP4 shapes and can be
+// its block-scale adaptation in haohervchb/sglang-V100. Automatic operator
+// dispatch is restricted to accepted SM70 tensor/layout contracts and can be
 // disabled with VLLM_SM70_FP8_QPN8=0.
 // See LICENSE.v100-skinny in this directory for the retained MIT notice.
 
@@ -936,8 +936,8 @@ void fp8_qpn8_gemm_ba_split_sm70_out(torch::Tensor qkv_out, torch::Tensor z_out,
   TORCH_CHECK(qkv_out.numel() == qkv_n && z_out.numel() == z_n &&
                   b_out.numel() == ba_n / 2 && a_out.numel() == ba_n / 2,
               "fp8_qpn8_gemm_ba_split_sm70_out: output shape mismatch");
-  TORCH_CHECK(codes.numel() == n * k,
-              "fp8_qpn8_gemm_ba_split_sm70_out: packed code size mismatch");
+  TORCH_CHECK(codes.dim() == 2 && codes.size(0) == k && codes.size(1) == n,
+              "fp8_qpn8_gemm_ba_split_sm70_out: expected codes [5120, 4096]");
   TORCH_CHECK(group_scales.dim() == 2 && group_scales.size(0) == 1 &&
                   group_scales.size(1) == n,
               "fp8_qpn8_gemm_ba_split_sm70_out: expected channel scales");
@@ -1008,6 +1008,17 @@ void fp8_qpn8_dispatch_ba_split_sm70_out(
           b_out.numel() == m * ba_n / 2 && a_out.numel() == m * ba_n / 2 &&
           qkvz_staging.numel() == m * n && ba_staging.numel() == m * ba_n,
       "fp8_qpn8_dispatch_ba_split_sm70_out: output shape mismatch");
+  TORCH_CHECK(
+      qkv_out.get_device() == z_out.get_device() &&
+          qkv_out.get_device() == b_out.get_device() &&
+          qkv_out.get_device() == a_out.get_device() &&
+          qkv_out.get_device() == qkvz_staging.get_device() &&
+          qkv_out.get_device() == ba_staging.get_device() &&
+          qkv_out.get_device() == input.get_device() &&
+          qkv_out.get_device() == codes.get_device() &&
+          qkv_out.get_device() == group_scales.get_device() &&
+          qkv_out.get_device() == ba_weight.get_device(),
+      "fp8_qpn8_dispatch_ba_split_sm70_out: tensors must share one device");
   TORCH_CHECK(codes.dim() == 2 && codes.size(0) == k && codes.size(1) == n,
               "fp8_qpn8_dispatch_ba_split_sm70_out: code shape mismatch");
   TORCH_CHECK(group_scales.dim() == 2 && group_scales.size(0) == 1 &&
@@ -1016,14 +1027,16 @@ void fp8_qpn8_dispatch_ba_split_sm70_out(
   TORCH_CHECK(ba_weight.dim() == 2 && ba_weight.size(0) == ba_n &&
                   ba_weight.size(1) == k,
               "fp8_qpn8_dispatch_ba_split_sm70_out: b/a weight mismatch");
+  TORCH_CHECK(m <= 8 || dense_weight_ptr != 0,
+              "fp8_qpn8_dispatch_ba_split_sm70_out: large-M requires the "
+              "dense QPN8 workspace");
 
   if (m == 1) {
     static std::once_flag route_log_once;
     std::call_once(route_log_once, []() {
-      std::fprintf(
-          stderr,
-          "SM70 Qwen3.8-27B no-MTP QPN8 qkv/z + FP16 b/a split C++ route "
-          "enabled.\n");
+      std::fprintf(stderr,
+                   "SM70 GDN QPN8 K5120/N4096 + FP16 b/a N24 split C++ route "
+                   "enabled.\n");
       std::fflush(stderr);
     });
     fp8_qpn8_gemm_ba_split_sm70_out(qkv_out, z_out, b_out, a_out, input, codes,

--- a/csrc/torch_bindings.cpp
+++ b/csrc/torch_bindings.cpp
@@ -266,6 +266,21 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, ops) {
   ops.impl("fp8_qpn8_gemm_sm70_out", torch::kCUDA, &fp8_qpn8_gemm_sm70_out);
 
   ops.def(
+      "fp8_qpn8_gemm_ba_split_sm70_out(Tensor(a!) qkv_out, Tensor(b!) "
+      "z_out, Tensor(c!) b_out, Tensor(d!) a_out, Tensor input, Tensor codes, "
+      "Tensor group_scales, Tensor ba_weight) -> ()");
+  ops.impl("fp8_qpn8_gemm_ba_split_sm70_out", torch::kCUDA,
+           &fp8_qpn8_gemm_ba_split_sm70_out);
+
+  ops.def(
+      "fp8_qpn8_dispatch_ba_split_sm70_out(Tensor(a!) qkv_out, Tensor(b!) "
+      "z_out, Tensor(c!) b_out, Tensor(d!) a_out, Tensor(e!) qkvz_staging, "
+      "Tensor(f!) ba_staging, int dense_weight_ptr, Tensor input, Tensor "
+      "codes, Tensor group_scales, Tensor ba_weight) -> ()");
+  ops.impl("fp8_qpn8_dispatch_ba_split_sm70_out", torch::kCUDA,
+           &fp8_qpn8_dispatch_ba_split_sm70_out);
+
+  ops.def(
       "fp8_qpn8_gated_pair_sm70_out(Tensor(a!) out, Tensor input, "
       "Tensor codes, Tensor group_scales, int split_k, "
       "int accumulator_chains, bool fast_decoder, bool prefetch_codes) -> ()");

--- a/docs/design/sm70_qwen38_nvfp4_decode.md
+++ b/docs/design/sm70_qwen38_nvfp4_decode.md
@@ -360,10 +360,16 @@ unchanged and removes work at the GDN boundary. The exact Qwen3.8 TP4 decode
 shape can issue its channel-FP8 QKV/Z projection and FP16 b/a projection from
 one QPN8 launch, writing the four destination tensors directly. A separate
 one-pass Triton kernel performs the 12-by-128 gated RMSNorm without changing
-the accepted arithmetic. Both paths are opt-in through
-`VLLM_SM70_QWEN_GDN_QPN8_BA_SPLIT=1` and
-`VLLM_SM70_QWEN_GDN_RMSNORM_ONEPASS=1`; other shapes and prefill retain the
-existing operators.
+the accepted arithmetic. The accepted pair is opt-in through both
+`VLLM_SM70_GDN_QPN8_BA_SPLIT=1` and
+`VLLM_SM70_GDN_RMSNORM_ONEPASS=1`; the split projection cannot activate
+without its paired RMSNorm gate. Other operator shapes and prefill retain the
+existing operators. These are hardware/layout/operator gates; the measured
+checkpoint identifies the evidence workload and does not select the route.
+The archived JSON predates this audit naming cleanup and records the former
+Qwen-prefixed flag names; kernel arithmetic is unchanged. The final source
+also rechecks the loaded QPN8 code/scales, workspace pointer, bias, dtype,
+contiguity, and same-device contracts before dispatch.
 
 The matched endpoint used the same four V100-SXM2-32GB GPUs, TP4, input 1024,
 output cap 256, official random sampling, E4M3 KV, Flash-V100, full CUDA graph,

--- a/docs/design/sm70_qwen38_nvfp4_decode.md
+++ b/docs/design/sm70_qwen38_nvfp4_decode.md
@@ -352,3 +352,59 @@ Primary evidence paths are:
 - `.artifacts/qwen38_nvfp4_speed_20260823/wheel_stage_clean_head_7bd1d783/`
 - `.artifacts/qwen38_nvfp4_speed_20260823/profiles/candidate_qwen38_nvfp4_sidecar_chunk80_nsys_nvml_i1k_o64_per_token.md`
 - `.artifacts/qwen38_nvfp4_speed_20260823/profiles/candidate_qwen38_nvfp4_sidecar_chunk80_resource_summary.md`
+
+## Quality-safe GDN decode fusion
+
+The next no-MTP batch-one optimization keeps the mixed checkpoint route map
+unchanged and removes work at the GDN boundary. The exact Qwen3.8 TP4 decode
+shape can issue its channel-FP8 QKV/Z projection and FP16 b/a projection from
+one QPN8 launch, writing the four destination tensors directly. A separate
+one-pass Triton kernel performs the 12-by-128 gated RMSNorm without changing
+the accepted arithmetic. Both paths are opt-in through
+`VLLM_SM70_QWEN_GDN_QPN8_BA_SPLIT=1` and
+`VLLM_SM70_QWEN_GDN_RMSNORM_ONEPASS=1`; other shapes and prefill retain the
+existing operators.
+
+The matched endpoint used the same four V100-SXM2-32GB GPUs, TP4, input 1024,
+output cap 256, official random sampling, E4M3 KV, Flash-V100, full CUDA graph,
+and no MTP. Each result is the stable median of three sequential requests and
+pure decode excludes TTFT/prefill.
+
+| Route | Pure TPOT | Steady decode | Output gate |
+|---|---:|---:|---|
+| Current control | 12.249652 ms | 81.634970 tok/s | frozen 256-token stream |
+| QPN8 QKV/Z plus b/a only | 11.941616 ms | 83.740763 tok/s | reject: first divergence at token 202 |
+| QPN8 QKV/Z plus b/a and one-pass RMSNorm | **11.921648 ms** | **83.881019 tok/s** | pass: 3/3 exact |
+
+The accepted pair improves steady decode by 2.751% and TPOT by 2.678% versus
+the matched control. All three accepted requests reproduce the control's full
+256-token SHA256
+`8b37337f4c393711cb8550db6bae909b1e85de8df1cf5ba8c60d8c000749c0a2`.
+The one-pass RMSNorm 48-layer microbenchmark is bitwise exact and saves
+55.946 us/token. The QKV projection is exact on all layers; b/a differs only
+at normal FP32-reduction roundoff (`6.368e-8` relative L2, maximum absolute
+error `2.384e-7`) and the paired endpoint restores exact sampled output.
+
+The post-rebase admission recheck uses the final source-built extension and
+the default Qwen3.5 model wrapper rather than a diagnostic GDN boundary. The
+C++ split-route oracle fired on all four TP ranks. Its matching latest-main
+control/candidate stable medians are `12.261727/11.956949 ms` and
+`81.554583/83.633383 tok/s`, a 2.549% decode-throughput improvement. All
+three candidate requests exactly match all three latest-main control
+256-token streams with SHA256
+`ca77db3b032a1600a8567adea706108c1bd8c5472b3ace2318c41ab17c66c1f9`.
+
+A fused Q/K RMSNorm, MRoPE, and KV-write experiment reached 85.451 and
+85.015 tok/s on its two stable repeats but is rejected: it diverged from the
+control at token 1 and stopped after 208 output tokens. That source and its
+route flag are intentionally absent from the submitted change.
+
+Primary local evidence paths are:
+
+- `.artifacts/qwen38_nvfp4_speed_20260823/results/gdn_endpoint_control_r3_i1k_o256.json`
+- `.artifacts/qwen38_nvfp4_speed_20260823/results/gdn_endpoint_ba_split_rms_r3_i1k_o256.json`
+- `.artifacts/qwen38_nvfp4_speed_20260823/results/current_main_gdn_control_r3_i1k_o256.json`
+- `.artifacts/qwen38_nvfp4_speed_20260823/results/current_main_gdn_route_recheck_r3_i1k_o256.json`
+- `.artifacts/qwen38_nvfp4_speed_20260823/results/gdn_rmsnorm_production_op_bound_48layers.json`
+- `.artifacts/qwen38_nvfp4_speed_20260823/results/qpn8_fused_ba_split_bound_48layers.json`
+- `.artifacts/qwen38_nvfp4_speed_20260823/results/qknorm_mrope_cache_gdn_ba_rms_r3_i1k_o256.json`

--- a/docs/design/sm70_v100_migration_control.md
+++ b/docs/design/sm70_v100_migration_control.md
@@ -42802,9 +42802,13 @@ Interpretation:
   `ca77db3b032a1600a8567adea706108c1bd8c5472b3ace2318c41ab17c66c1f9`.
 - The GDN RMSNorm 48-layer operator gate is bitwise exact and saves
   `55.946 us/token`. QKV is exact on all 48 layers; b/a has relative L2
-  `6.368e-8` and maximum absolute error `2.384e-7`. Both endpoint routes are
-  exact-shape, no-MTP, SM70, TP4 opt-ins and retain the original large-M and
-  unsupported-shape paths.
+  `6.368e-8` and maximum absolute error `2.384e-7`. The split projection is
+  admitted only when its one-pass RMSNorm pair is also enabled. Runtime
+  selection uses SM70, exact tensor/layout, QPN8 workspace, bias, TP, and
+  no-speculation contracts; the measured model/checkpoint is evidence only.
+  Large-M and unsupported shapes retain the original paths. Archived evidence
+  uses the pre-audit Qwen-prefixed flag names; final source uses generic GDN
+  flags and leaves the measured kernels unchanged.
 - QPN8 QKV/Z plus b/a alone reaches `83.740763 tok/s` but diverges at token
   202, so it is not an independent accepted configuration. It is accepted only
   together with the exact one-pass RMSNorm, whose paired endpoint restores the

--- a/docs/design/sm70_v100_migration_control.md
+++ b/docs/design/sm70_v100_migration_control.md
@@ -42783,6 +42783,40 @@ Interpretation:
 - Reproducible JSON and route logs are under
   `bench_results/qwen36_nvfp4_no_mtp_scaling_20260824/{results,logs,telemetry}`.
 
+## 2026-08-24 Qwen3.8-27B-NVFP4 GDN decode fusion
+
+- Frozen contract: TP4 on four V100-SXM2-32GB GPUs, input 1024, output cap
+  256, official random sampling, E4M3 KV, Flash-V100, full CUDA graph, and no
+  MTP. Pure decode excludes TTFT/prefill and each endpoint is the stable median
+  of three sequential requests.
+- The quality-safe QPN8 QKV/Z plus FP16 b/a split projection and one-pass GDN
+  RMSNorm improve the matched control from `12.249652 ms / 81.634970 tok/s`
+  to `11.921648 ms / 83.881019 tok/s`. All three requests exactly reproduce
+  the control's 256 token IDs and SHA256
+  `8b37337f4c393711cb8550db6bae909b1e85de8df1cf5ba8c60d8c000749c0a2`.
+- A final post-rebase default-wrapper admission recheck reports
+  `12.261727 ms / 81.554583 tok/s` for the matching control and
+  `11.956949 ms / 83.633383 tok/s` for the candidate. The C++ route oracle
+  fires on all four ranks and all three 256-token candidate streams exactly
+  match the current-main control hash
+  `ca77db3b032a1600a8567adea706108c1bd8c5472b3ace2318c41ab17c66c1f9`.
+- The GDN RMSNorm 48-layer operator gate is bitwise exact and saves
+  `55.946 us/token`. QKV is exact on all 48 layers; b/a has relative L2
+  `6.368e-8` and maximum absolute error `2.384e-7`. Both endpoint routes are
+  exact-shape, no-MTP, SM70, TP4 opt-ins and retain the original large-M and
+  unsupported-shape paths.
+- QPN8 QKV/Z plus b/a alone reaches `83.740763 tok/s` but diverges at token
+  202, so it is not an independent accepted configuration. It is accepted only
+  together with the exact one-pass RMSNorm, whose paired endpoint restores the
+  complete frozen output.
+- The Q/K RMSNorm plus MRoPE plus KV-write candidate reaches stable repeats of
+  `85.451/85.015 tok/s` but diverges at token 1 and stops at 208 tokens. Its
+  source, schema, flag, and rejected QPN4 communication experiments were
+  removed before submission.
+- Next target: quantify no-MTP pure-decode decay at exact final context lengths
+  16K, 64K, 128K, and 256K, reporting TTFT/prefill separately and preserving
+  the same model, quantization, TP, attention, KV, sampling, and graph routes.
+
 ## 2026-08-24 MRV2 DFlash2 score-gated verifier promotion
 
 - The native Flash-V100 grouped verifier keeps all eight MRV2 target rows and

--- a/tests/model_executor/test_qwen3_5_quantization.py
+++ b/tests/model_executor/test_qwen3_5_quantization.py
@@ -1,7 +1,11 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+from types import SimpleNamespace
 from unittest.mock import Mock, patch
+
+import pytest
+import torch
 
 
 class _QuantConfig:
@@ -9,6 +13,90 @@ class _QuantConfig:
         self.ignore: list[str] = []
         self.config: dict[str, object] = {}
         self.quantized_layers: dict[str, dict[str, str]] = {}
+
+
+@pytest.mark.parametrize(
+    ("split_enabled", "norm_enabled"),
+    [
+        (False, False),
+        (False, True),
+    ],
+)
+def test_sm70_gdn_qpn8_ba_split_is_disabled_without_split_flag(
+    monkeypatch,
+    split_enabled: bool,
+    norm_enabled: bool,
+) -> None:
+    from vllm.model_executor.layers.mamba.gdn import qwen_gdn_linear_attn as gdn
+
+    monkeypatch.setattr(gdn.envs, "VLLM_SM70_GDN_QPN8_BA_SPLIT", split_enabled)
+    monkeypatch.setattr(gdn.envs, "VLLM_SM70_GDN_RMSNORM_ONEPASS", norm_enabled)
+
+    assert not gdn._sm70_gdn_qpn8_ba_split_enabled()
+
+
+def test_sm70_gdn_qpn8_ba_split_rejects_unpaired_route(monkeypatch) -> None:
+    from vllm.model_executor.layers.mamba.gdn import qwen_gdn_linear_attn as gdn
+
+    monkeypatch.setattr(gdn.envs, "VLLM_SM70_GDN_QPN8_BA_SPLIT", True)
+    monkeypatch.setattr(gdn.envs, "VLLM_SM70_GDN_RMSNORM_ONEPASS", False)
+
+    with pytest.raises(RuntimeError, match="requires the accepted"):
+        gdn._sm70_gdn_qpn8_ba_split_enabled()
+
+
+def test_sm70_gdn_qpn8_ba_split_requires_source_built_ops(monkeypatch) -> None:
+    from vllm.model_executor.layers.mamba.gdn import qwen_gdn_linear_attn as gdn
+
+    monkeypatch.setattr(gdn.envs, "VLLM_SM70_GDN_QPN8_BA_SPLIT", True)
+    monkeypatch.setattr(gdn.envs, "VLLM_SM70_GDN_RMSNORM_ONEPASS", True)
+    monkeypatch.setattr(
+        gdn,
+        "_missing_sm70_gdn_qpn8_ba_ops",
+        lambda: ["fp8_qpn8_dispatch_ba_split_sm70_out"],
+    )
+
+    with pytest.raises(RuntimeError, match="requires the source-built"):
+        gdn._sm70_gdn_qpn8_ba_split_enabled()
+
+
+def test_sm70_gdn_qpn8_ba_split_accepts_complete_contract(monkeypatch) -> None:
+    from vllm.model_executor.layers.mamba.gdn import qwen_gdn_linear_attn as gdn
+
+    monkeypatch.setattr(gdn.envs, "VLLM_SM70_GDN_QPN8_BA_SPLIT", True)
+    monkeypatch.setattr(gdn.envs, "VLLM_SM70_GDN_RMSNORM_ONEPASS", True)
+    monkeypatch.setattr(gdn, "_missing_sm70_gdn_qpn8_ba_ops", lambda: [])
+
+    assert gdn._sm70_gdn_qpn8_ba_split_enabled()
+
+
+def test_sm70_gdn_qpn8_ba_weight_contract_is_layout_based() -> None:
+    from vllm.model_executor.layers.mamba.gdn import qwen_gdn_linear_attn as gdn
+
+    qkvz = SimpleNamespace(
+        sm70_fp8_qpn8=True,
+        sm70_fp8_prefill_exact_dense_workspace_ptr=42,
+        weight=torch.empty((5120, 4096), dtype=torch.uint8, device="meta"),
+        weight_scale_inv=torch.empty((1, 4096), dtype=torch.float16, device="meta"),
+        bias=None,
+    )
+    ba = SimpleNamespace(
+        weight=torch.empty((24, 5120), dtype=torch.float16, device="meta"),
+        bias=None,
+    )
+    layer = SimpleNamespace(
+        enable_sm70_gdn_qpn8_ba_split=True,
+        in_proj_qkvz=qkvz,
+        in_proj_ba=ba,
+    )
+
+    assert gdn._sm70_gdn_qpn8_ba_weight_contract(layer)
+
+    qkvz.bias = object()
+    assert not gdn._sm70_gdn_qpn8_ba_weight_contract(layer)
+    qkvz.bias = None
+    qkvz.weight = torch.empty((4096, 5120), dtype=torch.uint8, device="meta")
+    assert not gdn._sm70_gdn_qpn8_ba_weight_contract(layer)
 
 
 def test_qwen3_5_split_gdn_detects_compressed_tensors_ignore():

--- a/vllm/_sm70_ops.py
+++ b/vllm/_sm70_ops.py
@@ -659,7 +659,7 @@ def fp8_qpn8_gemm_ba_split_sm70_out(
     group_scales: torch.Tensor,
     ba_weight: torch.Tensor,
 ) -> None:
-    """Run exact Qwen3.8 decode qkvz FP8 and b/a FP16 projections."""
+    """Run the exact-shape GDN QKV/Z FP8 and b/a FP16 projections."""
     _op("fp8_qpn8_gemm_ba_split_sm70_out")(
         qkv_out,
         z_out,

--- a/vllm/_sm70_ops.py
+++ b/vllm/_sm70_ops.py
@@ -649,6 +649,93 @@ if hasattr(torch.ops._C, "fp8_qpn8_gemm_sm70_out"):
         return None
 
 
+def fp8_qpn8_gemm_ba_split_sm70_out(
+    qkv_out: torch.Tensor,
+    z_out: torch.Tensor,
+    b_out: torch.Tensor,
+    a_out: torch.Tensor,
+    input: torch.Tensor,
+    codes: torch.Tensor,
+    group_scales: torch.Tensor,
+    ba_weight: torch.Tensor,
+) -> None:
+    """Run exact Qwen3.8 decode qkvz FP8 and b/a FP16 projections."""
+    _op("fp8_qpn8_gemm_ba_split_sm70_out")(
+        qkv_out,
+        z_out,
+        b_out,
+        a_out,
+        input,
+        codes,
+        group_scales,
+        ba_weight,
+    )
+
+
+if hasattr(torch.ops._C, "fp8_qpn8_gemm_ba_split_sm70_out"):
+
+    @register_fake("_C::fp8_qpn8_gemm_ba_split_sm70_out")
+    def _fp8_qpn8_gemm_ba_split_sm70_out_fake(
+        qkv_out: torch.Tensor,
+        z_out: torch.Tensor,
+        b_out: torch.Tensor,
+        a_out: torch.Tensor,
+        input: torch.Tensor,
+        codes: torch.Tensor,
+        group_scales: torch.Tensor,
+        ba_weight: torch.Tensor,
+    ) -> None:
+        return None
+
+
+def fp8_qpn8_dispatch_ba_split_sm70_out(
+    qkv_out: torch.Tensor,
+    z_out: torch.Tensor,
+    b_out: torch.Tensor,
+    a_out: torch.Tensor,
+    qkvz_staging: torch.Tensor,
+    ba_staging: torch.Tensor,
+    dense_weight_ptr: int,
+    input: torch.Tensor,
+    codes: torch.Tensor,
+    group_scales: torch.Tensor,
+    ba_weight: torch.Tensor,
+) -> None:
+    """Dispatch exact M=1 fusion or the original large-M projection path."""
+    _op("fp8_qpn8_dispatch_ba_split_sm70_out")(
+        qkv_out,
+        z_out,
+        b_out,
+        a_out,
+        qkvz_staging,
+        ba_staging,
+        dense_weight_ptr,
+        input,
+        codes,
+        group_scales,
+        ba_weight,
+    )
+
+
+if hasattr(torch.ops._C, "fp8_qpn8_dispatch_ba_split_sm70_out"):
+
+    @register_fake("_C::fp8_qpn8_dispatch_ba_split_sm70_out")
+    def _fp8_qpn8_dispatch_ba_split_sm70_out_fake(
+        qkv_out: torch.Tensor,
+        z_out: torch.Tensor,
+        b_out: torch.Tensor,
+        a_out: torch.Tensor,
+        qkvz_staging: torch.Tensor,
+        ba_staging: torch.Tensor,
+        dense_weight_ptr: int,
+        input: torch.Tensor,
+        codes: torch.Tensor,
+        group_scales: torch.Tensor,
+        ba_weight: torch.Tensor,
+    ) -> None:
+        return None
+
+
 def fp8_qpn8_gated_pair_sm70_out(
     out: torch.Tensor,
     input: torch.Tensor,

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -497,8 +497,8 @@ if TYPE_CHECKING:
     VLLM_SM70_QWEN_GDN_DISABLE_INPUT_CORE_OP: bool = False
     VLLM_SM70_QWEN_GDN_INPUT_PROJECTION_OP: bool = False
     VLLM_SM70_QWEN_GDN_OUTPUT_PROJECTION_OP: bool = False
-    VLLM_SM70_QWEN_GDN_QPN8_BA_SPLIT: bool = False
-    VLLM_SM70_QWEN_GDN_RMSNORM_ONEPASS: bool = False
+    VLLM_SM70_GDN_QPN8_BA_SPLIT: bool = False
+    VLLM_SM70_GDN_RMSNORM_ONEPASS: bool = False
     VLLM_SM70_GEMMA_RMS_NORM_EAGER: bool = False
     VLLM_SM70_GEMMA_RMS_NORM_COMPILE_NATIVE: bool = False
     VLLM_SM70_GEMMA_LONG_PREFILL_FUSED: bool = True
@@ -2971,13 +2971,13 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "VLLM_SM70_QWEN_GDN_OUTPUT_PROJECTION_OP": lambda: bool(
         int(os.getenv("VLLM_SM70_QWEN_GDN_OUTPUT_PROJECTION_OP", "0"))
     ),
-    # Exact-shape Qwen3.8 no-MTP GDN decode fusions. Keep an explicit rollback
-    # switch even after the endpoint speed and frozen-output gates pass.
-    "VLLM_SM70_QWEN_GDN_QPN8_BA_SPLIT": lambda: bool(
-        int(os.getenv("VLLM_SM70_QWEN_GDN_QPN8_BA_SPLIT", "0"))
+    # Exact-shape SM70 GDN decode fusions. The measured workload is evidence,
+    # not a model-identity selector; runtime admission uses operator contracts.
+    "VLLM_SM70_GDN_QPN8_BA_SPLIT": lambda: bool(
+        int(os.getenv("VLLM_SM70_GDN_QPN8_BA_SPLIT", "0"))
     ),
-    "VLLM_SM70_QWEN_GDN_RMSNORM_ONEPASS": lambda: bool(
-        int(os.getenv("VLLM_SM70_QWEN_GDN_RMSNORM_ONEPASS", "0"))
+    "VLLM_SM70_GDN_RMSNORM_ONEPASS": lambda: bool(
+        int(os.getenv("VLLM_SM70_GDN_RMSNORM_ONEPASS", "0"))
     ),
     # Diagnostic-only: keep Qwen3.5/Gemma RMSNorm arithmetic behind an opaque
     # custom-op boundary under the SM70 compile/FULL graph lane.

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -497,6 +497,8 @@ if TYPE_CHECKING:
     VLLM_SM70_QWEN_GDN_DISABLE_INPUT_CORE_OP: bool = False
     VLLM_SM70_QWEN_GDN_INPUT_PROJECTION_OP: bool = False
     VLLM_SM70_QWEN_GDN_OUTPUT_PROJECTION_OP: bool = False
+    VLLM_SM70_QWEN_GDN_QPN8_BA_SPLIT: bool = False
+    VLLM_SM70_QWEN_GDN_RMSNORM_ONEPASS: bool = False
     VLLM_SM70_GEMMA_RMS_NORM_EAGER: bool = False
     VLLM_SM70_GEMMA_RMS_NORM_COMPILE_NATIVE: bool = False
     VLLM_SM70_GEMMA_LONG_PREFILL_FUSED: bool = True
@@ -2968,6 +2970,14 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # recurrent core in the latest split path.
     "VLLM_SM70_QWEN_GDN_OUTPUT_PROJECTION_OP": lambda: bool(
         int(os.getenv("VLLM_SM70_QWEN_GDN_OUTPUT_PROJECTION_OP", "0"))
+    ),
+    # Exact-shape Qwen3.8 no-MTP GDN decode fusions. Keep an explicit rollback
+    # switch even after the endpoint speed and frozen-output gates pass.
+    "VLLM_SM70_QWEN_GDN_QPN8_BA_SPLIT": lambda: bool(
+        int(os.getenv("VLLM_SM70_QWEN_GDN_QPN8_BA_SPLIT", "0"))
+    ),
+    "VLLM_SM70_QWEN_GDN_RMSNORM_ONEPASS": lambda: bool(
+        int(os.getenv("VLLM_SM70_QWEN_GDN_RMSNORM_ONEPASS", "0"))
     ),
     # Diagnostic-only: keep Qwen3.5/Gemma RMSNorm arithmetic behind an opaque
     # custom-op boundary under the SM70 compile/FULL graph lane.

--- a/vllm/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py
+++ b/vllm/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py
@@ -1330,12 +1330,42 @@ def _sm70_compile_graph_slice_dim(
     return tensor.index_select(dim, indices)
 
 
-def _sm70_qwen_gdn_rmsnorm_onepass_enabled() -> bool:
-    return envs.VLLM_SM70_QWEN_GDN_RMSNORM_ONEPASS
+def _sm70_gdn_rmsnorm_onepass_enabled() -> bool:
+    return envs.VLLM_SM70_GDN_RMSNORM_ONEPASS
+
+
+_SM70_GDN_QPN8_BA_REQUIRED_OPS = (
+    "fp8_qpn8_gemm_ba_split_sm70_out",
+    "fp8_qpn8_dispatch_ba_split_sm70_out",
+)
+
+
+def _missing_sm70_gdn_qpn8_ba_ops() -> list[str]:
+    return [
+        name
+        for name in _SM70_GDN_QPN8_BA_REQUIRED_OPS
+        if not hasattr(torch.ops._C, name)
+    ]
+
+
+def _sm70_gdn_qpn8_ba_split_enabled() -> bool:
+    if envs.VLLM_SM70_GDN_QPN8_BA_SPLIT and not envs.VLLM_SM70_GDN_RMSNORM_ONEPASS:
+        raise RuntimeError(
+            "VLLM_SM70_GDN_QPN8_BA_SPLIT=1 requires the accepted "
+            "VLLM_SM70_GDN_RMSNORM_ONEPASS=1 pair."
+        )
+    if envs.VLLM_SM70_GDN_QPN8_BA_SPLIT:
+        missing_ops = _missing_sm70_gdn_qpn8_ba_ops()
+        if missing_ops:
+            raise RuntimeError(
+                "VLLM_SM70_GDN_QPN8_BA_SPLIT=1 requires the source-built "
+                f"SM70 GDN extension; missing ops: {missing_ops}."
+            )
+    return envs.VLLM_SM70_GDN_QPN8_BA_SPLIT
 
 
 @triton.jit
-def _sm70_qwen_gdn_rmsnorm_gated_onepass_kernel(
+def _sm70_gdn_rmsnorm_gated_onepass_kernel(
     x_ptr,
     z_ptr,
     weight_ptr,
@@ -1364,13 +1394,19 @@ def _sm70_qwen_gdn_rmsnorm_gated_impl(
     activation: str,
 ) -> torch.Tensor:
     if (
-        x.is_cuda
+        _sm70_gdn_rmsnorm_onepass_enabled()
+        and current_platform.is_device_capability(70)
+        and x.is_cuda
         and x.dtype == torch.float16
         and x.shape == (12, 128)
         and x.is_contiguous()
+        and z.is_cuda
+        and z.device == x.device
         and z.dtype == x.dtype
         and z.shape == x.shape
         and z.is_contiguous()
+        and weight.is_cuda
+        and weight.device == x.device
         and weight.dtype == x.dtype
         and weight.shape == (128,)
         and weight.is_contiguous()
@@ -1379,7 +1415,7 @@ def _sm70_qwen_gdn_rmsnorm_gated_impl(
         and activation in ("silu", "swish")
     ):
         out = torch.empty_like(x)
-        _sm70_qwen_gdn_rmsnorm_gated_onepass_kernel[(12,)](
+        _sm70_gdn_rmsnorm_gated_onepass_kernel[(12,)](
             x,
             z,
             weight,
@@ -2326,8 +2362,8 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
                 1,
                 1 + int(vllm_config.speculative_config.num_speculative_state_tokens()),
             )
-        self.enable_sm70_qwen_gdn_rmsnorm_onepass = (
-            _sm70_qwen_gdn_rmsnorm_onepass_enabled()
+        self.enable_sm70_gdn_rmsnorm_onepass = (
+            _sm70_gdn_rmsnorm_onepass_enabled()
             and current_platform.is_device_capability(70)
             and self._sm70_spec_cache_stride == 1
             and self.hidden_size == 5120
@@ -2336,10 +2372,8 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
             and self.head_v_dim == 128
             and not self.gqa_interleaved_layout
         )
-        self.enable_sm70_qwen_gdn_qpn8_ba_split = (
-            envs.VLLM_SM70_QWEN_GDN_QPN8_BA_SPLIT
-            and current_platform.is_device_capability(70)
-            and hasattr(torch.ops._C, "fp8_qpn8_dispatch_ba_split_sm70_out")
+        self.enable_sm70_gdn_qpn8_ba_split = (
+            current_platform.is_device_capability(70)
             and self._sm70_spec_cache_stride == 1
             and self.hidden_size == 5120
             and self.tp_size == 4
@@ -2348,6 +2382,7 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
             and not self.gqa_interleaved_layout
             and not self.disable_tp_for_ba_proj
             and self.in_proj_ba is not None
+            and _sm70_gdn_qpn8_ba_split_enabled()
         )
         self.enable_packed_recurrent_decode = (
             envs.VLLM_ENABLE_FLA_PACKED_RECURRENT_DECODE
@@ -3820,7 +3855,7 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
         z = _sm70_dump_gdn_projection_tensor("proj_z", layer_name, z)
         profile_start = _sm70_gdn_prefill_profile_start()
         use_sm70_onepass_norm = (
-            self.enable_sm70_qwen_gdn_rmsnorm_onepass
+            self.enable_sm70_gdn_rmsnorm_onepass
             and num_tokens == 1
             and core_attn_out.dtype == torch.float16
             and core_attn_out.shape == (12, 128)
@@ -3844,7 +3879,7 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
             core_attn_out = self.norm.forward_cuda(core_attn_out, z)
         elif use_sm70_onepass_norm:
             _log_runtime_route_once(
-                "SM70 Qwen3.8-27B no-MTP GDN RMSNormGated one-pass route enabled."
+                "SM70 GDN 12x128 RMSNormGated one-pass route enabled."
             )
             core_attn_out = torch.ops.vllm.sm70_qwen_gdn_rmsnorm_gated(
                 core_attn_out,
@@ -7075,35 +7110,74 @@ def qwen_gdn_output_projection_fake(
     """Fake implementation for torch.compile."""
 
 
-def _sm70_qwen38_qpn8_ba_split_eligible(
+def _sm70_gdn_qpn8_ba_weight_contract(
+    self: "QwenGatedDeltaNetAttention",
+) -> bool:
+    """Check the loaded operator layout without using model identity."""
+    qkvz = self.in_proj_qkvz
+    ba = self.in_proj_ba
+    qkvz_weight = getattr(qkvz, "weight", None)
+    qkvz_scales = getattr(qkvz, "weight_scale_inv", None)
+    ba_weight = getattr(ba, "weight", None) if ba is not None else None
+    return bool(
+        self.enable_sm70_gdn_qpn8_ba_split
+        and ba is not None
+        and getattr(qkvz, "sm70_fp8_qpn8", False)
+        and int(getattr(qkvz, "sm70_fp8_prefill_exact_dense_workspace_ptr", 0)) > 0
+        and isinstance(qkvz_weight, torch.Tensor)
+        and qkvz_weight.dtype == torch.uint8
+        and qkvz_weight.shape == (5120, 4096)
+        and qkvz_weight.is_contiguous()
+        and isinstance(qkvz_scales, torch.Tensor)
+        and qkvz_scales.dtype == torch.float16
+        and qkvz_scales.shape == (1, 4096)
+        and qkvz_scales.is_contiguous()
+        and isinstance(ba_weight, torch.Tensor)
+        and ba_weight.dtype == torch.float16
+        and ba_weight.shape == (24, 5120)
+        and ba_weight.is_contiguous()
+        and qkvz_weight.device == qkvz_scales.device == ba_weight.device
+        and getattr(qkvz, "bias", None) is None
+        and getattr(ba, "bias", None) is None
+    )
+
+
+def _sm70_gdn_qpn8_ba_dispatch_eligible(
+    self: "QwenGatedDeltaNetAttention",
+    hidden_states: torch.Tensor,
+    layer_name: LayerNameType,
+) -> bool:
+    qkvz = self.in_proj_qkvz
+    ba = self.in_proj_ba
+    return bool(
+        _sm70_gdn_qpn8_ba_weight_contract(self)
+        and ba is not None
+        and not _sm70_gdn_projection_dump_requested(layer_name)
+        and hasattr(torch.ops._C, "fp8_qpn8_dispatch_ba_split_sm70_out")
+        and hasattr(torch.ops._C, "fp8_qpn8_gemm_ba_split_sm70_out")
+        and hidden_states.is_cuda
+        and hidden_states.dtype == torch.float16
+        and hidden_states.ndim == 2
+        and hidden_states.shape[1] == 5120
+        and hidden_states.is_contiguous()
+        and hidden_states.device == qkvz.weight.device == ba.weight.device
+    )
+
+
+def _sm70_gdn_qpn8_ba_split_eligible(
     self: "QwenGatedDeltaNetAttention",
     hidden_states: torch.Tensor,
     z_out: torch.Tensor,
     layer_name: LayerNameType,
 ) -> bool:
-    qkvz = self.in_proj_qkvz
-    ba = self.in_proj_ba
     return (
-        self.enable_sm70_qwen_gdn_qpn8_ba_split
-        and not _sm70_gdn_projection_dump_requested(layer_name)
-        and ba is not None
-        and hidden_states.dtype == torch.float16
+        _sm70_gdn_qpn8_ba_dispatch_eligible(self, hidden_states, layer_name)
         and hidden_states.shape == (1, 5120)
-        and hidden_states.is_contiguous()
+        and z_out.is_cuda
+        and z_out.device == hidden_states.device
         and z_out.dtype == hidden_states.dtype
         and z_out.shape == (1, 12, 128)
         and z_out.is_contiguous()
-        and getattr(qkvz, "sm70_fp8_qpn8", False)
-        and qkvz.weight.dtype == torch.uint8
-        and qkvz.weight.numel() == 4096 * 5120
-        and qkvz.weight.is_contiguous()
-        and qkvz.weight_scale_inv.dtype == torch.float16
-        and qkvz.weight_scale_inv.shape == (1, 4096)
-        and qkvz.weight_scale_inv.is_contiguous()
-        and ba.weight.dtype == torch.float16
-        and ba.weight.shape == (24, 5120)
-        and ba.weight.is_contiguous()
-        and getattr(ba, "bias", None) is None
     )
 
 
@@ -7125,7 +7199,7 @@ def qwen_gdn_input_projection_core(
         layer_name,
         hidden_states,
     )
-    if _sm70_qwen38_qpn8_ba_split_eligible(
+    if _sm70_gdn_qpn8_ba_split_eligible(
         self,
         hidden_states,
         z_out,
@@ -7147,7 +7221,7 @@ def qwen_gdn_input_projection_core(
             self.in_proj_ba.weight,
         )
         _log_runtime_route_once(
-            "SM70 Qwen3.8-27B no-MTP QPN8 qkv/z + FP16 b/a split route enabled."
+            "SM70 GDN QPN8 K5120/N4096 plus FP16 b/a N24 split route enabled."
         )
         z = z_out
     else:
@@ -7238,7 +7312,7 @@ def qwen_gdn_input_projection(
         layer_name,
         hidden_states,
     )
-    if _sm70_qwen38_qpn8_ba_split_eligible(
+    if _sm70_gdn_qpn8_ba_split_eligible(
         self,
         hidden_states,
         z_out,
@@ -7255,7 +7329,7 @@ def qwen_gdn_input_projection(
             self.in_proj_ba.weight,
         )
         _log_runtime_route_once(
-            "SM70 Qwen3.8-27B no-MTP QPN8 qkv/z + FP16 b/a split route enabled."
+            "SM70 GDN QPN8 K5120/N4096 plus FP16 b/a N24 split route enabled."
         )
         return
 

--- a/vllm/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py
+++ b/vllm/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py
@@ -12,6 +12,7 @@ import torch
 from einops import rearrange
 from torch import nn
 
+from vllm import _sm70_ops as sm70_ops
 from vllm import envs
 from vllm._aiter_ops import rocm_aiter_ops
 from vllm.config import VllmConfig, get_current_vllm_config
@@ -1329,6 +1330,30 @@ def _sm70_compile_graph_slice_dim(
     return tensor.index_select(dim, indices)
 
 
+def _sm70_qwen_gdn_rmsnorm_onepass_enabled() -> bool:
+    return envs.VLLM_SM70_QWEN_GDN_RMSNORM_ONEPASS
+
+
+@triton.jit
+def _sm70_qwen_gdn_rmsnorm_gated_onepass_kernel(
+    x_ptr,
+    z_ptr,
+    weight_ptr,
+    out_ptr,
+    D: tl.constexpr,
+    EPS: tl.constexpr,
+):
+    row = tl.program_id(0)
+    offsets = tl.arange(0, D)
+    x = tl.load(x_ptr + row * D + offsets).to(tl.float32)
+    z = tl.load(z_ptr + row * D + offsets).to(tl.float32)
+    weight = tl.load(weight_ptr + offsets).to(tl.float32)
+    sumsq = tl.sum(x * x, axis=0)
+    rstd = tl.rsqrt(sumsq / D + EPS)
+    gated = z * tl.sigmoid(z)
+    tl.store(out_ptr + row * D + offsets, x * rstd * weight * gated)
+
+
 def _sm70_qwen_gdn_rmsnorm_gated_impl(
     x: torch.Tensor,
     z: torch.Tensor,
@@ -1338,6 +1363,33 @@ def _sm70_qwen_gdn_rmsnorm_gated_impl(
     norm_before_gate: bool,
     activation: str,
 ) -> torch.Tensor:
+    if (
+        x.is_cuda
+        and x.dtype == torch.float16
+        and x.shape == (12, 128)
+        and x.is_contiguous()
+        and z.dtype == x.dtype
+        and z.shape == x.shape
+        and z.is_contiguous()
+        and weight.dtype == x.dtype
+        and weight.shape == (128,)
+        and weight.is_contiguous()
+        and group_size <= 0
+        and norm_before_gate
+        and activation in ("silu", "swish")
+    ):
+        out = torch.empty_like(x)
+        _sm70_qwen_gdn_rmsnorm_gated_onepass_kernel[(12,)](
+            x,
+            z,
+            weight,
+            out,
+            D=128,
+            EPS=eps,
+            num_warps=2,
+        )
+        return out
+
     from vllm.model_executor.layers.fla.ops.layernorm_guard import rmsnorm_fn
 
     return rmsnorm_fn(
@@ -2274,6 +2326,29 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
                 1,
                 1 + int(vllm_config.speculative_config.num_speculative_state_tokens()),
             )
+        self.enable_sm70_qwen_gdn_rmsnorm_onepass = (
+            _sm70_qwen_gdn_rmsnorm_onepass_enabled()
+            and current_platform.is_device_capability(70)
+            and self._sm70_spec_cache_stride == 1
+            and self.hidden_size == 5120
+            and self.tp_size == 4
+            and self.num_v_heads == 48
+            and self.head_v_dim == 128
+            and not self.gqa_interleaved_layout
+        )
+        self.enable_sm70_qwen_gdn_qpn8_ba_split = (
+            envs.VLLM_SM70_QWEN_GDN_QPN8_BA_SPLIT
+            and current_platform.is_device_capability(70)
+            and hasattr(torch.ops._C, "fp8_qpn8_dispatch_ba_split_sm70_out")
+            and self._sm70_spec_cache_stride == 1
+            and self.hidden_size == 5120
+            and self.tp_size == 4
+            and self.num_v_heads == 48
+            and self.head_v_dim == 128
+            and not self.gqa_interleaved_layout
+            and not self.disable_tp_for_ba_proj
+            and self.in_proj_ba is not None
+        )
         self.enable_packed_recurrent_decode = (
             envs.VLLM_ENABLE_FLA_PACKED_RECURRENT_DECODE
         )
@@ -3744,6 +3819,22 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
         )
         z = _sm70_dump_gdn_projection_tensor("proj_z", layer_name, z)
         profile_start = _sm70_gdn_prefill_profile_start()
+        use_sm70_onepass_norm = (
+            self.enable_sm70_qwen_gdn_rmsnorm_onepass
+            and num_tokens == 1
+            and core_attn_out.dtype == torch.float16
+            and core_attn_out.shape == (12, 128)
+            and core_attn_out.is_contiguous()
+            and z.dtype == core_attn_out.dtype
+            and z.shape == core_attn_out.shape
+            and z.is_contiguous()
+            and self.norm.weight.dtype == core_attn_out.dtype
+            and self.norm.weight.shape == (128,)
+            and self.norm.weight.is_contiguous()
+            and self.norm.group_size is None
+            and self.norm.norm_before_gate
+            and self.norm.activation in ("silu", "swish")
+        )
         if self.enable_sm70_dflash2_fused_gdn_norm:
             # RMSNormGated is decomposed into a nine-kernel native chain when
             # it is reached from the opaque Qwen GDN op under the default
@@ -3751,6 +3842,19 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
             # a one-pass Triton kernel with the same FP32 accumulation and
             # FP16 output contract, so call it directly on this isolated path.
             core_attn_out = self.norm.forward_cuda(core_attn_out, z)
+        elif use_sm70_onepass_norm:
+            _log_runtime_route_once(
+                "SM70 Qwen3.8-27B no-MTP GDN RMSNormGated one-pass route enabled."
+            )
+            core_attn_out = torch.ops.vllm.sm70_qwen_gdn_rmsnorm_gated(
+                core_attn_out,
+                z,
+                self.norm.weight,
+                self.norm.eps,
+                -1,
+                True,
+                self.norm.activation,
+            )
         else:
             core_attn_out = self.norm(core_attn_out, z)
         _sm70_gdn_prefill_profile_end(
@@ -6971,6 +7075,38 @@ def qwen_gdn_output_projection_fake(
     """Fake implementation for torch.compile."""
 
 
+def _sm70_qwen38_qpn8_ba_split_eligible(
+    self: "QwenGatedDeltaNetAttention",
+    hidden_states: torch.Tensor,
+    z_out: torch.Tensor,
+    layer_name: LayerNameType,
+) -> bool:
+    qkvz = self.in_proj_qkvz
+    ba = self.in_proj_ba
+    return (
+        self.enable_sm70_qwen_gdn_qpn8_ba_split
+        and not _sm70_gdn_projection_dump_requested(layer_name)
+        and ba is not None
+        and hidden_states.dtype == torch.float16
+        and hidden_states.shape == (1, 5120)
+        and hidden_states.is_contiguous()
+        and z_out.dtype == hidden_states.dtype
+        and z_out.shape == (1, 12, 128)
+        and z_out.is_contiguous()
+        and getattr(qkvz, "sm70_fp8_qpn8", False)
+        and qkvz.weight.dtype == torch.uint8
+        and qkvz.weight.numel() == 4096 * 5120
+        and qkvz.weight.is_contiguous()
+        and qkvz.weight_scale_inv.dtype == torch.float16
+        and qkvz.weight_scale_inv.shape == (1, 4096)
+        and qkvz.weight_scale_inv.is_contiguous()
+        and ba.weight.dtype == torch.float16
+        and ba.weight.shape == (24, 5120)
+        and ba.weight.is_contiguous()
+        and getattr(ba, "bias", None) is None
+    )
+
+
 def qwen_gdn_input_projection_core(
     hidden_states: torch.Tensor,
     z_out: torch.Tensor,
@@ -6989,46 +7125,75 @@ def qwen_gdn_input_projection_core(
         layer_name,
         hidden_states,
     )
-    mixed_qkvz, _ = self.in_proj_qkvz(hidden_states)
-    ba, _ = self.in_proj_ba(hidden_states)
-    mixed_qkvz = _sm70_dump_gdn_projection_tensor(
-        "input_core_in_proj_qkvz",
+    if _sm70_qwen38_qpn8_ba_split_eligible(
+        self,
+        hidden_states,
+        z_out,
         layer_name,
-        mixed_qkvz,
-    )
-    ba = _sm70_dump_gdn_projection_tensor("input_core_in_proj_ba", layer_name, ba)
-
-    if self.gqa_interleaved_layout:
-        query, key, value, z, b, a = self.fix_query_key_value_ordering(
-            mixed_qkvz,
-            ba,
+    ):
+        mixed_qkv = torch.empty(
+            (1, 2560), dtype=hidden_states.dtype, device=hidden_states.device
         )
-        query, key, value = map(
-            lambda x: rearrange(x, "l p d -> l (p d)"), (query, key, value)
+        b = torch.empty((1, 12), dtype=hidden_states.dtype, device=hidden_states.device)
+        a = torch.empty_like(b)
+        sm70_ops.fp8_qpn8_gemm_ba_split_sm70_out(
+            mixed_qkv,
+            z_out,
+            b,
+            a,
+            hidden_states,
+            self.in_proj_qkvz.weight,
+            self.in_proj_qkvz.weight_scale_inv,
+            self.in_proj_ba.weight,
         )
-        mixed_qkv = torch.cat((query, key, value), dim=-1)
+        _log_runtime_route_once(
+            "SM70 Qwen3.8-27B no-MTP QPN8 qkv/z + FP16 b/a split route enabled."
+        )
+        z = z_out
     else:
-        qkv_size = (self.key_dim * 2 + self.value_dim) // self.tp_size
-        z_size = self.value_dim // self.tp_size
-        mixed_qkv = mixed_qkvz[..., :qkv_size]
-        if envs.VLLM_SM70_GDN_MIXED_QKV_CONTIGUOUS:
-            mixed_qkv = mixed_qkv.contiguous()
-        z = _sm70_compile_graph_slice_dim(mixed_qkvz, -1, qkv_size, z_size)
-        z = z.reshape(z.size(0), -1, self.head_v_dim)
-        ba_size = ba.shape[-1] // 2
-        b = ba[..., :ba_size]
-        a = _sm70_compile_graph_slice_dim(ba, -1, ba_size, ba_size)
-        if self.disable_tp_for_ba_proj and self.tp_size > 1:
-            ba_chunk = self.num_v_heads // self.tp_size
-            ba_start = self.tp_rank * ba_chunk
-            b = b[:, ba_start : ba_start + ba_chunk]
-            a = a[:, ba_start : ba_start + ba_chunk]
-        b = b.contiguous()
-        a = a.contiguous()
+        mixed_qkvz, _ = self.in_proj_qkvz(hidden_states)
+        ba, _ = self.in_proj_ba(hidden_states)
+        mixed_qkvz = _sm70_dump_gdn_projection_tensor(
+            "input_core_in_proj_qkvz",
+            layer_name,
+            mixed_qkvz,
+        )
+        ba = _sm70_dump_gdn_projection_tensor("input_core_in_proj_ba", layer_name, ba)
 
-    if envs.VLLM_SM70_GDN_Z_CONTIGUOUS and current_platform.is_device_capability(70):
-        z = z.contiguous()
-    z_out.copy_(z)
+        if self.gqa_interleaved_layout:
+            query, key, value, z, b, a = self.fix_query_key_value_ordering(
+                mixed_qkvz,
+                ba,
+            )
+            query, key, value = map(
+                lambda x: rearrange(x, "l p d -> l (p d)"),
+                (query, key, value),
+            )
+            mixed_qkv = torch.cat((query, key, value), dim=-1)
+        else:
+            qkv_size = (self.key_dim * 2 + self.value_dim) // self.tp_size
+            z_size = self.value_dim // self.tp_size
+            mixed_qkv = mixed_qkvz[..., :qkv_size]
+            if envs.VLLM_SM70_GDN_MIXED_QKV_CONTIGUOUS:
+                mixed_qkv = mixed_qkv.contiguous()
+            z = _sm70_compile_graph_slice_dim(mixed_qkvz, -1, qkv_size, z_size)
+            z = z.reshape(z.size(0), -1, self.head_v_dim)
+            ba_size = ba.shape[-1] // 2
+            b = ba[..., :ba_size]
+            a = _sm70_compile_graph_slice_dim(ba, -1, ba_size, ba_size)
+            if self.disable_tp_for_ba_proj and self.tp_size > 1:
+                ba_chunk = self.num_v_heads // self.tp_size
+                ba_start = self.tp_rank * ba_chunk
+                b = b[:, ba_start : ba_start + ba_chunk]
+                a = a[:, ba_start : ba_start + ba_chunk]
+            b = b.contiguous()
+            a = a.contiguous()
+
+        if envs.VLLM_SM70_GDN_Z_CONTIGUOUS and current_platform.is_device_capability(
+            70
+        ):
+            z = z.contiguous()
+        z_out.copy_(z)
 
     _qwen_gdn_run_recurrent_core(
         self,
@@ -7073,7 +7238,29 @@ def qwen_gdn_input_projection(
         layer_name,
         hidden_states,
     )
+    if _sm70_qwen38_qpn8_ba_split_eligible(
+        self,
+        hidden_states,
+        z_out,
+        layer_name,
+    ):
+        sm70_ops.fp8_qpn8_gemm_ba_split_sm70_out(
+            mixed_qkv_out,
+            z_out,
+            b_out,
+            a_out,
+            hidden_states,
+            self.in_proj_qkvz.weight,
+            self.in_proj_qkvz.weight_scale_inv,
+            self.in_proj_ba.weight,
+        )
+        _log_runtime_route_once(
+            "SM70 Qwen3.8-27B no-MTP QPN8 qkv/z + FP16 b/a split route enabled."
+        )
+        return
+
     mixed_qkvz, _ = self.in_proj_qkvz(hidden_states)
+    assert self.in_proj_ba is not None
     ba, _ = self.in_proj_ba(hidden_states)
 
     if self.gqa_interleaved_layout:

--- a/vllm/model_executor/models/qwen3_5.py
+++ b/vllm/model_executor/models/qwen3_5.py
@@ -401,7 +401,48 @@ class Qwen3_5GatedDeltaNet(QwenGatedDeltaNetAttention):
             "gdn_hidden_states", layer_name, hidden_states
         )
 
-        if self.use_split_input_projections:
+        if self.enable_sm70_qwen_gdn_qpn8_ba_split:
+            mixed_qkv = torch.empty(
+                (num_tokens, qkv_size),
+                dtype=hidden_states.dtype,
+                device=hidden_states.device,
+            )
+            z = torch.empty(
+                (num_tokens, self.num_v_heads // self.tp_size, self.head_v_dim),
+                dtype=hidden_states.dtype,
+                device=hidden_states.device,
+            )
+            b = torch.empty(
+                (num_tokens, ba_size),
+                dtype=hidden_states.dtype,
+                device=hidden_states.device,
+            )
+            a = torch.empty_like(b)
+            qkvz_staging = torch.empty(
+                (num_tokens, qkv_size + z_size),
+                dtype=hidden_states.dtype,
+                device=hidden_states.device,
+            )
+            ba_staging = torch.empty(
+                (num_tokens, ba_size * 2),
+                dtype=hidden_states.dtype,
+                device=hidden_states.device,
+            )
+            assert self.in_proj_ba is not None
+            torch.ops._C.fp8_qpn8_dispatch_ba_split_sm70_out(
+                mixed_qkv,
+                z,
+                b,
+                a,
+                qkvz_staging,
+                ba_staging,
+                int(self.in_proj_qkvz.sm70_fp8_prefill_exact_dense_workspace_ptr),
+                hidden_states,
+                self.in_proj_qkvz.weight,
+                self.in_proj_qkvz.weight_scale_inv,
+                self.in_proj_ba.weight,
+            )
+        elif self.use_split_input_projections:
             mixed_qkvz, _ = self.in_proj_qkvz(hidden_states)
             assert self.in_proj_ba is not None
             ba, _ = self.in_proj_ba(hidden_states)

--- a/vllm/model_executor/models/qwen3_5.py
+++ b/vllm/model_executor/models/qwen3_5.py
@@ -48,6 +48,7 @@ from vllm.model_executor.layers.mamba.gdn.qwen_gdn_linear_attn import (
     _resolve_qwen_gdn_kv_cache_args,
     _sm70_compile_graph_slice_dim,
     _sm70_dump_gdn_projection_tensor,
+    _sm70_gdn_qpn8_ba_dispatch_eligible,
 )
 from vllm.model_executor.layers.mamba.mamba_utils import (
     MambaStateCopyFunc,
@@ -401,7 +402,11 @@ class Qwen3_5GatedDeltaNet(QwenGatedDeltaNetAttention):
             "gdn_hidden_states", layer_name, hidden_states
         )
 
-        if self.enable_sm70_qwen_gdn_qpn8_ba_split:
+        if _sm70_gdn_qpn8_ba_dispatch_eligible(
+            self,
+            hidden_states,
+            layer_name,
+        ):
             mixed_qkv = torch.empty(
                 (num_tokens, qkv_size),
                 dtype=hidden_states.dtype,


### PR DESCRIPTION
## Purpose

Add an opt-in SM70 GDN decode fusion while preserving the existing fallback paths. The measured Qwen3.8 NVFP4 workload is performance/quality evidence only: runtime admission does not inspect a model name, checkpoint path, architecture identity, or repository-specific identity field.

## Source audit and fixes

- The submitted QPN8 QKV/Z plus FP16 b/a kernel arithmetic matches the archived accepted operator and endpoint evidence.
- The original branch exposed the b/a split independently even though that configuration diverged at token 202. The audited source now requires the accepted one-pass RMSNorm pair; an unpaired enable request fails clearly instead of silently entering the rejected route.
- Both controls are generic and default-off: `VLLM_SM70_GDN_QPN8_BA_SPLIT=1` and `VLLM_SM70_GDN_RMSNORM_ONEPASS=1`.
- Admission is contract-based: SM70 capability, non-speculative cache stride, TP/layout dimensions, CUDA FP16 activations, exact QPN8 code/scale and b/a weight shapes, contiguous same-device tensors, no projection biases, a valid dense workspace, and both source-built extension operators.
- Weight admission is rechecked after quantized weights load and on dispatch. Missing source-built operators fail at setup; incompatible weights/tensors keep the existing path.
- Direct C++ entry points now validate exact shapes, dtypes, contiguity, device agreement, and the large-M workspace contract.
- The DFlash2 fused output-norm route keeps priority. Unsupported shapes, disabled flags, projection dumps, and prefill/large-M cases retain the established implementations.

## Frozen endpoint evidence

Four V100-SXM2-32GB GPUs, TP4, input 1024, output cap 256, official random sampling, E4M3 KV, Flash-V100, full CUDA graph, and no MTP. Pure decode excludes TTFT/prefill; each number is the stable median of three sequential requests.

| Route | Pure TPOT | Steady decode | Output gate |
|---|---:|---:|---|
| Matched control | 12.249652 ms | 81.634970 tok/s | frozen 256-token stream |
| Accepted paired fusion | **11.921648 ms** | **83.881019 tok/s** | 3/3 exact |

This is +2.751% steady decode and -2.678% TPOT. All three candidate requests reproduce SHA256 `8b37337f4c393711cb8550db6bae909b1e85de8df1cf5ba8c60d8c000749c0a2`.

The latest-main default-wrapper recheck reports 81.554583 tok/s / 12.261727 ms for control and 83.633383 tok/s / 11.956949 ms for candidate (+2.549%). All four TP ranks report the C++ route and all three 256-token candidate streams exactly match control SHA256 `ca77db3b032a1600a8567adea706108c1bd8c5472b3ace2318c41ab17c66c1f9`.

The 48-layer RMSNorm operator is bitwise exact and saves 55.946 us/token. QKV is exact; b/a relative L2 is `6.368e-8` with maximum absolute error `2.384e-7`.

Rejected experiments remain excluded: b/a split alone diverged at token 202; the Q/K RMSNorm + MRoPE + KV-write route diverged at token 1 and stopped after 208 tokens.

## Validation

- Replayed onto `main` `a6f4b8b70` with both commits DCO-signed.
- Current CUDA source compiled successfully as the standalone source-built operator with `TORCH_CUDA_ARCH_LIST=7.0`.
- `tests/model_executor/test_qwen3_5_quantization.py`: 13 passed on the final source, including paired-flag, missing-extension, and loaded-weight layout contracts.
- Changed-file ruff, format, typos, clang-format, markdownlint, mypy, SPDX, forbidden-import, configuration, and CUDA-API hooks: all passed.
- `git diff --check`: passed.
- No additional full-model E2E was run during audit; the existing matched GPU artifacts were verified and the audit changes only harden admission/failure contracts without changing accepted kernel arithmetic.

Evidence is recorded in `docs/design/sm70_qwen38_nvfp4_decode.md` and `docs/design/sm70_v100_migration_control.md`; raw local artifacts remain intentionally untracked.