### PR TITLE
[Doc] Record NVFP4 no-MTP concurrency control

### DIFF
--- a/docs/design/sm70_v100_migration_control.md
+++ b/docs/design/sm70_v100_migration_control.md
@@ -42743,6 +42743,46 @@ Interpretation:
   with zero invalid or repetitive records; the next quality gate belongs to
   any high-concurrency scheduler candidate that survives full-model A/B/A.
 
+### Matched no-MTP scaling control
+
+- A matched performance-only control disabled MTP while preserving the B10
+  source, model, TP4 physical GPU4-7 claim, 48 fixed ShareGPT requests,
+  sampling, FP8-E5M2 KV cache, TurboMind ModelOpt mixed FP8/NVFP4 route,
+  Flash-V100/FlashQLA, max length/batched tokens 8192, and
+  `FULL_AND_PIECEWISE` CUDA Graph policy. Every point reported
+  `speculative_config=None` and null speculative metrics, generated the exact
+  expected 9,115 prompt and 10,623 output tokens, and had no timed-request
+  Triton JIT warning. This control is not an MTP quality oracle; dataset-level
+  MTP quality remains gated independently.
+- The no-MTP curve is:
+
+  | concurrency | output tok/s | efficiency vs C1 | pure decode tok/s | serial prefill tok/s | P50 TPOT ms |
+  | ---: | ---: | ---: | ---: | ---: | ---: |
+  | 1 | 92.260 | 100.00% | 111.256 | 454.959 | 9.007 |
+  | 2 | 141.946 | 76.93% | 84.615 | 432.510 | 10.197 |
+  | 4 | 210.221 | 56.96% | 61.679 | 385.377 | 12.333 |
+  | 8 | 305.539 | 41.40% | 46.288 | 330.254 | 20.327 |
+  | 12 | 388.944 | 35.13% | 41.609 | 288.067 | 25.511 |
+  | 16 | 448.918 | 30.41% | 35.490 | 688.532 | 29.957 |
+
+- Relative to this no-MTP control, MTP4 improves output throughput by
+  `5.89/6.19/17.21/14.82/14.19/18.24%` at C1/C2/C4/C8/C12/C16 and improves
+  pure-decode throughput by `2.69/7.37/15.63/13.20/11.30/26.05%`.
+  MTP4 scaling efficiency is `0.00/0.22/6.09/3.49/2.75/3.55` percentage
+  points higher. Disabling MTP therefore neither recovers the absolute
+  high-concurrency throughput nor improves scaling; verifier/drafter work is
+  not the primary scaling bottleneck. Continue on the shared target decode
+  path, especially high-width routed-MoE scheduling and TP4 synchronization,
+  while retaining the independent MTP dataset-quality gate.
+- The first completely cold C1 process also exposed a startup-only anomaly:
+  FULL decode graph capture took 230.21 s, total graph capture took 294 s, and
+  recorded load time was 380.46 s. Subsequent independent processes captured
+  FULL decode graphs in less than two seconds and total graphs in 35-68 s.
+  This one-time cold-cache cost was outside every timed throughput interval;
+  investigate it separately rather than attributing it to steady-state decode.
+- Reproducible JSON and route logs are under
+  `bench_results/qwen36_nvfp4_no_mtp_scaling_20260824/{results,logs,telemetry}`.
+
 ## 2026-08-24 MRV2 DFlash2 score-gated verifier promotion
 
 - The native Flash-V100 grouped verifier keeps all eight MRV2 target rows and


### PR DESCRIPTION
## Purpose

Record the matched no-MTP concurrency control and compare it with the accepted MTP4 curve. This PR changes documentation only; benchmark artifacts remain local and are not committed.

## Source audit

- Verified all six result JSON files and matching route logs under `bench_results/qwen36_nvfp4_no_mtp_scaling_20260824/`.
- C1/C2/C4/C8/C12/C16 summaries match the documented throughput, pure-decode, serial-prefill, TPOT, token totals, and null speculative metrics.
- Recomputed every MTP4 relative throughput and scaling-efficiency delta; the recorded percentages are correct.
- Verified the cold C1 log reports 230.21 s FULL decode capture and 294 s total capture, while subsequent logs report sub-2 s FULL decode capture and 35-68 s total capture.
- The conclusion is scoped correctly: no-MTP is a performance control, not a quality oracle. Model/checkpoint details describe the measured workload only; no runtime identity selector is added.

## Test Plan

- Run C1/C2/C4/C8/C12/C16 with the same 48-request ShareGPT workload, TP4, FP8 E5M2 KV cache, TurboMind, Flash-V100/FlashQLA, and full CUDA graphs.
- Verify `speculative_config` is disabled, token totals match, and no timed-request Triton JIT appears.
- Run changed-file pre-commit and `git diff --check` after replaying the document onto latest `main`.

## Test Result

- All six benchmark points completed with exact 9,115 prompt / 10,623 output tokens and null speculative metrics.
- No-MTP scaling efficiency fell from 100.00% at C1 to 30.41% at C16; MTP4 reached 33.96% and was 18.24% faster in C16 output throughput.
- Latest-main changed-file pre-commit passed, including markdownlint and typos; `git diff --check` passed; DCO sign-off is present.
- Replayed onto `main` `3d8fbe36c`; remote `pre-run-check` passed. The workflow's all-files pre-commit job is independently red on that unchanged `main` because it rewrites unrelated baseline files; both changed Markdown files pass all applicable hooks, and the synthesized merge tree exactly matches the audited head tree.