### PR TITLE
[Bugfix] KVBlockZeroer: per-segment block stride for interleaved KV layouts

### DIFF
--- a/tests/v1/worker/test_kv_block_zeroer.py
+++ b/tests/v1/worker/test_kv_block_zeroer.py
@@ -6,13 +6,14 @@ n_segs * page_size_el). Build such a layout directly and check that zeroing
 block 1 clears only block 1's cells; the old single-page_size_el stride zeros
 the wrong cells, so this fails before the fix and passes after.
 """
+
 from types import SimpleNamespace
 
 import pytest
 import torch
 
 from vllm.v1.kv_cache_interface import MambaSpec
-from vllm.v1.worker.utils import KVBlockZeroer
+from vllm.v1.worker.utils import KVBlockZeroer, _infer_segment_block_strides
 
 CELL_ELS = 8  # int32 elements zeroed per (block, segment)
 CELL_BYTES = CELL_ELS * 4
@@ -20,14 +21,37 @@ N_LAYERS = 3  # -> n_segs = 3 interleaved segments
 N_BLOCKS = 4
 
 
+@pytest.mark.parametrize(
+    ("seg_addrs", "page_size_el", "expected"),
+    [
+        ([0x1000], 8, [8]),
+        ([0x1000, 0x2000], 8, [8, 8]),
+        ([0x1000, 0x1020, 0x1040], 8, [24, 24, 24]),
+        # Two independent two-segment interleaved pools. Input order differs
+        # from address order to prove strides stay bound to their segments.
+        ([0x3020, 0x1000, 0x3000, 0x1020], 8, [16, 16, 16, 16]),
+    ],
+)
+def test_infer_segment_block_strides(
+    seg_addrs: list[int],
+    page_size_el: int,
+    expected: list[int],
+) -> None:
+    assert _infer_segment_block_strides(seg_addrs, page_size_el) == expected
+
+
+def test_infer_segment_block_strides_rejects_duplicate_addresses() -> None:
+    with pytest.raises(ValueError, match="must be unique"):
+        _infer_segment_block_strides([0x1000, 0x1000], 8)
+
+
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
-def test_zero_block_ids_block_major_interleaved():
+def test_zero_block_ids_block_major_interleaved() -> None:
     device = torch.device("cuda")
 
     # Block-major interleaved buffer: cell k holds (block B, layer i) where
     # k == B * N_LAYERS + i. Fill with a sentinel so any write is visible.
-    flat = torch.ones(N_BLOCKS * N_LAYERS * CELL_ELS, dtype=torch.int32,
-                       device=device)
+    flat = torch.ones(N_BLOCKS * N_LAYERS * CELL_ELS, dtype=torch.int32, device=device)
 
     # One mamba spec whose page is exactly one cell; page_size_padded lets us
     # pin page_size_bytes without depending on real state shapes.
@@ -47,7 +71,7 @@ def test_zero_block_ids_block_major_interleaved():
     # Layer i's state view starts one cell into the buffer, so the segment base
     # addresses are exactly one cell apart -> the interleaved layout.
     static_forward_context = {
-        name: SimpleNamespace(kv_cache=[flat[i * CELL_ELS:]])
+        name: SimpleNamespace(kv_cache=[flat[i * CELL_ELS :]])
         for i, name in enumerate(layer_names)
     }
 
@@ -64,13 +88,74 @@ def test_zero_block_ids_block_major_interleaved():
     # does not discriminate; block 1 does).
     target = 1
     zeroer.zero_block_ids([target])
-    torch.cuda.synchronize()
+    torch.accelerator.synchronize()
 
     cells = flat.view(N_BLOCKS * N_LAYERS, CELL_ELS)
-    zeroed = {int(k) for k in range(cells.shape[0])
-              if bool((cells[k] == 0).all())}
+    zeroed = {int(k) for k in range(cells.shape[0]) if bool((cells[k] == 0).all())}
     expected = {target * N_LAYERS + i for i in range(N_LAYERS)}
     assert zeroed == expected, (
         f"expected only block {target}'s cells {sorted(expected)} to be "
         f"zeroed, got {sorted(zeroed)}"
     )
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+def test_zero_block_ids_multiple_interleaved_pools() -> None:
+    device = torch.device("cuda")
+    layers_per_pool = 2
+    buffers = [
+        torch.ones(
+            N_BLOCKS * layers_per_pool * CELL_ELS,
+            dtype=torch.int32,
+            device=device,
+        )
+        for _ in range(2)
+    ]
+    spec = MambaSpec(
+        block_size=16,
+        shapes=((1,),),
+        dtypes=(torch.int32,),
+        page_size_padded=CELL_BYTES,
+    )
+    groups = []
+    static_forward_context = {}
+    for pool_index, buffer in enumerate(buffers):
+        layer_names = [
+            f"mamba.{pool_index}.{layer_index}"
+            for layer_index in range(layers_per_pool)
+        ]
+        groups.append(
+            SimpleNamespace(
+                kv_cache_spec=spec,
+                kv_cache_group_id=pool_index,
+                layer_names=layer_names,
+                backend=None,
+            )
+        )
+        static_forward_context.update(
+            {
+                name: SimpleNamespace(kv_cache=[buffer[index * CELL_ELS :]])
+                for index, name in enumerate(layer_names)
+            }
+        )
+
+    zeroer = KVBlockZeroer(device, pin_memory=False)
+    zeroer.init_meta(
+        groups,
+        kernel_block_sizes=[spec.block_size] * len(groups),
+        cache_dtype="auto",
+        runner_only_attn_layers=set(),
+        static_forward_context=static_forward_context,
+    )
+
+    target = 1
+    zeroer.zero_block_ids([target])
+    torch.accelerator.synchronize()
+
+    expected = {target * layers_per_pool + index for index in range(layers_per_pool)}
+    for buffer in buffers:
+        cells = buffer.view(N_BLOCKS * layers_per_pool, CELL_ELS)
+        zeroed = {
+            index for index in range(cells.shape[0]) if bool((cells[index] == 0).all())
+        }
+        assert zeroed == expected

--- a/tests/v1/worker/test_kv_block_zeroer.py
+++ b/tests/v1/worker/test_kv_block_zeroer.py
@@ -1,0 +1,76 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""KVBlockZeroer must zero the right blocks under a block-major interleaved KV
+layout (n_segs segments one cell apart, so the block stride is
+n_segs * page_size_el). Build such a layout directly and check that zeroing
+block 1 clears only block 1's cells; the old single-page_size_el stride zeros
+the wrong cells, so this fails before the fix and passes after.
+"""
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from vllm.v1.kv_cache_interface import MambaSpec
+from vllm.v1.worker.utils import KVBlockZeroer
+
+CELL_ELS = 8  # int32 elements zeroed per (block, segment)
+CELL_BYTES = CELL_ELS * 4
+N_LAYERS = 3  # -> n_segs = 3 interleaved segments
+N_BLOCKS = 4
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+def test_zero_block_ids_block_major_interleaved():
+    device = torch.device("cuda")
+
+    # Block-major interleaved buffer: cell k holds (block B, layer i) where
+    # k == B * N_LAYERS + i. Fill with a sentinel so any write is visible.
+    flat = torch.ones(N_BLOCKS * N_LAYERS * CELL_ELS, dtype=torch.int32,
+                       device=device)
+
+    # One mamba spec whose page is exactly one cell; page_size_padded lets us
+    # pin page_size_bytes without depending on real state shapes.
+    spec = MambaSpec(
+        block_size=16,
+        shapes=((1,),),
+        dtypes=(torch.int32,),
+        page_size_padded=CELL_BYTES,
+    )
+    layer_names = [f"mamba.{i}" for i in range(N_LAYERS)]
+    group = SimpleNamespace(
+        kv_cache_spec=spec,
+        kv_cache_group_id=0,
+        layer_names=layer_names,
+        backend=None,  # unused on the mamba path
+    )
+    # Layer i's state view starts one cell into the buffer, so the segment base
+    # addresses are exactly one cell apart -> the interleaved layout.
+    static_forward_context = {
+        name: SimpleNamespace(kv_cache=[flat[i * CELL_ELS:]])
+        for i, name in enumerate(layer_names)
+    }
+
+    zeroer = KVBlockZeroer(device, pin_memory=False)
+    zeroer.init_meta(
+        [group],
+        kernel_block_sizes=[spec.block_size],
+        cache_dtype="auto",
+        runner_only_attn_layers=set(),
+        static_forward_context=static_forward_context,
+    )
+
+    # Zero block 1 (block 0 is correct under both old and new strides, so it
+    # does not discriminate; block 1 does).
+    target = 1
+    zeroer.zero_block_ids([target])
+    torch.cuda.synchronize()
+
+    cells = flat.view(N_BLOCKS * N_LAYERS, CELL_ELS)
+    zeroed = {int(k) for k in range(cells.shape[0])
+              if bool((cells[k] == 0).all())}
+    expected = {target * N_LAYERS + i for i in range(N_LAYERS)}
+    assert zeroed == expected, (
+        f"expected only block {target}'s cells {sorted(expected)} to be "
+        f"zeroed, got {sorted(zeroed)}"
+    )

--- a/vllm/v1/worker/utils.py
+++ b/vllm/v1/worker/utils.py
@@ -37,6 +37,44 @@ from vllm.v1.kv_cache_interface import (
 logger = init_logger(__name__)
 
 
+def _infer_segment_block_strides(
+    seg_addrs: list[int],
+    page_size_el: int,
+) -> list[int]:
+    """Infer logical block strides from block-major segment address runs.
+
+    Dense segments advance by one page. An interleaved pool exposes one segment
+    base per cell, exactly ``page_size_el * 4`` bytes apart, and advances to the
+    next logical block after every segment in that address run. Treat separate
+    runs independently so multiple pools do not disable one another.
+    """
+    if page_size_el <= 0:
+        raise ValueError(f"page_size_el must be positive, got {page_size_el}.")
+    if len(set(seg_addrs)) != len(seg_addrs):
+        raise ValueError("Segment addresses must be unique.")
+
+    block_strides = [page_size_el] * len(seg_addrs)
+    if len(seg_addrs) < 2:
+        return block_strides
+
+    cell_bytes = page_size_el * 4
+    ordered = sorted((addr, index) for index, addr in enumerate(seg_addrs))
+    run_start = 0
+    for run_end in range(1, len(ordered) + 1):
+        if (
+            run_end < len(ordered)
+            and ordered[run_end][0] - ordered[run_end - 1][0] == cell_bytes
+        ):
+            continue
+        run = ordered[run_start:run_end]
+        if len(run) > 1:
+            run_stride = page_size_el * len(run)
+            for _, original_index in run:
+                block_strides[original_index] = run_stride
+        run_start = run_end
+    return block_strides
+
+
 @triton.jit(do_not_specialize=["n_blocks"])
 def _zero_kv_blocks_kernel(
     seg_addrs_ptr,
@@ -161,8 +199,7 @@ class KVBlockZeroer:
                         page_size_el = cur_page_el
                     else:
                         assert page_size_el == cur_page_el, (
-                            f"Non-uniform page sizes: {page_size_el} vs "
-                            f"{cur_page_el}"
+                            f"Non-uniform page sizes: {page_size_el} vs {cur_page_el}"
                         )
 
                     block_stride_bytes = cur_bytes
@@ -193,8 +230,7 @@ class KVBlockZeroer:
                         page_size_el = cur_page_el
                     else:
                         assert page_size_el == cur_page_el, (
-                            f"Non-uniform page sizes: {page_size_el} vs "
-                            f"{cur_page_el}"
+                            f"Non-uniform page sizes: {page_size_el} vs {cur_page_el}"
                         )
                     seg_addrs.append(dp)
 
@@ -204,21 +240,15 @@ class KVBlockZeroer:
 
         blk_size = min(largest_power_of_2_divisor(page_size_el), 1024)
 
-        # Per-block stride within a segment. Dense layouts space blocks
-        # page_size_el apart, but a block-major interleaved pool (kvcached's
-        # contiguous layout) packs the n_segs segments one cell apart, so its
-        # real stride is n_segs * page_size_el. Detect that from the segment
-        # spacing; page_size_el (dense) stays the safe default.
+        # Dense layouts space blocks page_size_el apart. Block-major
+        # interleaved pools expose segment starts one cell apart and advance by
+        # the number of segments in that contiguous address run. Infer each
+        # run separately because a process may own more than one KV pool.
         n_segs = len(seg_addrs)
-        cell_bytes = page_size_el * 4  # int32 elements -> bytes
-        addrs = sorted(seg_addrs)
-        interleaved = n_segs > 1 and all(
-            b - a == cell_bytes for a, b in zip(addrs, addrs[1:])
-        )
-        block_stride_el = page_size_el * n_segs if interleaved else page_size_el
-        # One stride per segment (uniform here), read by seg_index in-kernel.
-        seg_block_strides = torch.full(
-            (n_segs,), block_stride_el, dtype=torch.int64, device=self.device
+        seg_block_strides = torch.tensor(
+            _infer_segment_block_strides(seg_addrs, page_size_el),
+            dtype=torch.int64,
+            device=self.device,
         )
 
         self._id_cap = 8192

--- a/vllm/v1/worker/utils.py
+++ b/vllm/v1/worker/utils.py
@@ -40,6 +40,7 @@ logger = init_logger(__name__)
 @triton.jit(do_not_specialize=["n_blocks"])
 def _zero_kv_blocks_kernel(
     seg_addrs_ptr,
+    seg_block_strides_ptr,
     block_ids_ptr,
     n_blocks,
     N_SEGS: tl.constexpr,
@@ -55,6 +56,9 @@ def _zero_kv_blocks_kernel(
 
     seg_addrs_ptr holds absolute byte addresses (int64) for each segment,
     allowing segments to live in different CUDA allocations.
+    seg_block_strides_ptr holds the per-segment block-to-block stride in
+    elements, kept separate from the PAGE_SIZE_EL span each block zeros (they
+    differ for interleaved layouts, see init_meta).
 
     Programs are mapped as (block_index, seg_index, chunk_index).
     """
@@ -69,9 +73,11 @@ def _zero_kv_blocks_kernel(
     chunk_index = remainder % chunks
     block_id = tl.load(block_ids_ptr + block_index)
     seg_addr = tl.load(seg_addrs_ptr + seg_index)
+    block_stride_el = tl.load(seg_block_strides_ptr + seg_index)
     ptr = tl.cast(seg_addr, tl.pointer_type(tl.int32))
     offset = (
-        block_id.to(tl.int64) * PAGE_SIZE_EL + chunk_index.to(tl.int64) * BLOCK_SIZE
+        block_id.to(tl.int64) * block_stride_el.to(tl.int64)
+        + chunk_index.to(tl.int64) * BLOCK_SIZE
     )
     cols = tl.arange(0, BLOCK_SIZE).to(tl.int64)
     tl.store(ptr + offset + cols, tl.zeros([BLOCK_SIZE], dtype=tl.int32))
@@ -88,7 +94,7 @@ class KVBlockZeroer:
     def __init__(self, device: torch.device, pin_memory: bool):
         self.device = device
         self.pin_memory = pin_memory
-        self._meta: tuple[torch.Tensor, int, int, int] | None = None
+        self._meta: tuple[torch.Tensor, torch.Tensor, int, int, int] | None = None
         self._id_cap: int = 0
         self._ids_pinned: torch.Tensor | None = None
         self._ids_gpu: torch.Tensor | None = None
@@ -197,6 +203,24 @@ class KVBlockZeroer:
             return
 
         blk_size = min(largest_power_of_2_divisor(page_size_el), 1024)
+
+        # Per-block stride within a segment. Dense layouts space blocks
+        # page_size_el apart, but a block-major interleaved pool (kvcached's
+        # contiguous layout) packs the n_segs segments one cell apart, so its
+        # real stride is n_segs * page_size_el. Detect that from the segment
+        # spacing; page_size_el (dense) stays the safe default.
+        n_segs = len(seg_addrs)
+        cell_bytes = page_size_el * 4  # int32 elements -> bytes
+        addrs = sorted(seg_addrs)
+        interleaved = n_segs > 1 and all(
+            b - a == cell_bytes for a, b in zip(addrs, addrs[1:])
+        )
+        block_stride_el = page_size_el * n_segs if interleaved else page_size_el
+        # One stride per segment (uniform here), read by seg_index in-kernel.
+        seg_block_strides = torch.full(
+            (n_segs,), block_stride_el, dtype=torch.int64, device=self.device
+        )
+
         self._id_cap = 8192
         self._ids_pinned = torch.empty(
             self._id_cap,
@@ -206,16 +230,17 @@ class KVBlockZeroer:
         self._ids_gpu = torch.empty(self._id_cap, dtype=torch.int64, device=self.device)
         self._meta = (
             torch.tensor(seg_addrs, dtype=torch.uint64, device=self.device),
+            seg_block_strides,
             page_size_el,
             blk_size,
-            len(seg_addrs),
+            n_segs,
         )
 
     def zero_block_ids(self, block_ids: list[int]) -> None:
         """Zero the KV cache memory for the given block IDs."""
         if not block_ids or self._meta is None:
             return
-        seg_addrs, page_size_el, blk_size, n_segs = self._meta
+        seg_addrs, seg_block_strides, page_size_el, blk_size, n_segs = self._meta
         n_blocks = len(block_ids)
         if n_blocks > self._id_cap:
             self._id_cap = n_blocks * 2
@@ -234,6 +259,7 @@ class KVBlockZeroer:
         grid = (n_blocks * n_segs * (page_size_el // blk_size),)
         _zero_kv_blocks_kernel[grid](
             seg_addrs,
+            seg_block_strides,
             idx,
             n_blocks,
             N_SEGS=n_segs,


### PR DESCRIPTION


## Purpose

Cheers for maintaining this fork, the SM70/V100 support has been great and it's basically the
only way I can run these newer hybrid models on my old cards! Hit one bug in the KV block
zeroer under kvcached and wanted to send the fix back.

Setup is 2x Tesla V100-SXM2-16GB, NVLink'd, serving OvisOCR2 (`Qwen3_5`, hybrid
GDN/Mamba + attention) at TP1 with kvcached providing elastic KV so a couple of models fit on
the small cards. kvcached in its default contiguous layout.

The symptom was OCR output silently degenerating into a repeated-token runaway (`!!!!...`), no
crash. It's stateful, a fresh server's first request is fine and it gets worse as the block
pool recycles across requests. I couldn't reproduce it with kvcached off, and the workaround
I'd been running was `KVCACHED_CONTIGUOUS_LAYOUT=false`.

Root cause: `KVBlockZeroer` (zeros recycled KV blocks each step for hybrid mamba/GDN models)
walks consecutive blocks with `block_id * PAGE_SIZE_EL`, i.e. it assumes the per-block stride
equals the per-block span. That's true for the dense layout where each segment is a separate
per-layer block array `page_size_el` apart. kvcached's contiguous layout is block-major
interleaved though: every layer's per-block cells are interleaved and the `n_segs` segments sit
exactly one cell apart in a single run, so the real stride is `n_segs * page_size_el`. The
kernel under-strides by `n_segs`, zeros the wrong blocks' cells and leaves recycled blocks
dirty, then the GDN/SSM kernel reads a previous sequence's state and the output falls apart.
It's a wrong address, not a race (in-bounds writes, so compute-sanitizer doesn't catch it), and
only bites hybrid + contiguous, which is why the dense stride sidestepped it.

Fix: carry a per-segment block stride (`seg_block_strides`) into the kernel, kept separate from
the `PAGE_SIZE_EL` span each block zeros. That's the same shape upstream's `KVBlockZeroer`
already uses. The interleaved layout is detected from the segment address spacing, since the
interleaving lives in the cross-allocation
base addresses which a single tensor's `.stride()` can't express. Dense layout is unchanged
(`block_stride == page_size_el`) so it's a no-op there.

It's a correctness fix, previously-wrong output comes back correct. The end-to-end failure only
shows with kvcached's interleaved layout, however the underlying defect is demonstrable without
kvcached or a model: the test in the first commit builds a synthetic interleaved layout and
shows the current kernel zeroing the wrong blocks, red before the fix and green after. It also
drops an unsound "stride == span" assumption and nudges the fork back toward upstream's
per-segment shape.

## Test Plan

New unit test (repo-native, GPU only, no kvcached and no model), split across two commits so
it's red then green. Check out the test commit to watch it fail, fast-forward onto the fix to
watch it pass:

```bash
pytest tests/v1/worker/test_kv_block_zeroer.py
```

End-to-end on a V100 (OvisOCR2, TP1, kvcached on, contiguous): a churned multi-request OCR run
with `KVBlockZeroer` active, degenerate rate before vs after, plus a
`KVCACHED_CONTIGUOUS_LAYOUT=false` (dense) run to check the dense path is untouched.

## Test Result

- Unit test: red before the fix (zeros cells `[1,2,3]`), green after (zeros `[3,4,5]`).
- End-to-end: a 4-page churned OCR run went from 75% degenerate (repeated-token runaway) to 0%,
  output byte-identical to the `KVCACHED_CONTIGUOUS_LAYOUT=false` reference on every page.
- Regression: with `KVCACHED_CONTIGUOUS_LAYOUT=false` (dense), still 0% degenerate and
  byte-identical, so the dense path is unaffected.

---

Checklist: purpose and root cause above, test plan and before/after results included, no
docs/examples touched. Used Claude to help track this down and write it up, I've reviewed every
changed line.

## Maintainer source audit

- rebased onto current `main` after #274
- retained the contributor's per-segment kernel contract and replaced the single global interleaving decision with independent contiguous address-run inference, so multiple KV pools remain correct
- route selection is purely memory-layout based; it does not inspect model or checkpoint identity
- added CPU stride cases for dense, single-pool, unsorted, duplicate, and two-pool layouts
- added a second V100 kernel regression covering two independent interleaved pools
- V100 result: `7 passed`
- complete changed-file pre-commit: passed (ruff, format, typos, mypy, SPDX/import/config checks)
- all 3 commits pass DCO
