### PR TITLE
[Attention][Core] Add generic prefix-anchored SWA on SM70

### DIFF
--- a/docs/design/sm70_prefix_anchored_swa.md
+++ b/docs/design/sm70_prefix_anchored_swa.md
@@ -1,0 +1,57 @@
+# SM70 Prefix-Anchored Sliding-Window Attention
+
+Prefix-anchored sliding-window attention is an explicit, model-agnostic
+inference-engine option for bounded decode KV usage on V100/SM70. The request
+prefix remains globally visible, while generated tokens attend only to the
+most recent configured window:
+
+```text
+visible(q, kv) = kv <= q and (kv < prefix_len or q - kv < window)
+```
+
+Enable it through `AttentionConfig`; checkpoint metadata and model architecture
+names do not activate or gate the route:
+
+```bash
+vllm serve <model> \
+  --attention-config '{"prefix_anchored_decode_window": 4096}'
+```
+
+The option is off by default. It changes attention semantics after generation
+exceeds the configured window, so it is not an exact-output optimization for a
+full-attention workload.
+
+## Current Engine Contract
+
+The engine admits the route only when all of these operator/runtime contracts
+hold:
+
+- NVIDIA SM70 and the `FLASH_ATTN_V100` backend;
+- causal, standard full decoder attention with fp16 KV;
+- equal key and value head sizes, with no attention sinks or per-layer window;
+- decode and prefill context-parallel sizes both equal to one;
+- no speculative decoding, KV connector, or KV-cache offloading.
+
+Prefix caching is disabled, and full CUDA graphs are reduced to piecewise
+graphs. Unsupported combinations fail during configuration or layer
+construction. Once enabled, missing or mismatched per-request prefix metadata
+is a hard runtime error; the engine never evicts gap blocks and then silently
+runs an unmasked kernel.
+
+## Validation Status
+
+Validation on the current `main` source includes:
+
+- 32 CPU tests covering the mask, generic engine admission, fail-closed
+  metadata, cache-spec registration, and middle-gap block reclamation;
+- a clean SM70 source build of the Flash-V100 extension;
+- 19 V100 operator tests for paged decode and paged prefill, including GQA,
+  multiple head sizes, multi-partition decode, full-prompt and continuation
+  shapes, a negative control, and the default-off path.
+- same-toolchain comparison against the current `origin/main` build: all 55
+  default-off scalar decode kernel instances and all 64 default-off paged
+  prefill kernel instances are SASS-identical.
+
+No model end-to-end or throughput claim is attached to this route yet. Treat
+performance and workload-level quality as separate acceptance gates before
+enabling it in a production configuration.

--- a/flash-attention-v100/flash_attn_v100/flash_attn_interface.py
+++ b/flash-attention-v100/flash_attn_v100/flash_attn_interface.py
@@ -938,6 +938,8 @@ def flash_attn_decode_paged(
     workspace_seq_capacity_hint: int | None = None,
     active_num_partitions: torch.Tensor | None = None,
     partition_size_hint: int | None = None,
+    anchor_lens: torch.Tensor | None = None,
+    anchored_window: int = 0,
 ):
     if softmax_scale is None:
         softmax_scale = q.shape[-1] ** -0.5
@@ -946,9 +948,16 @@ def flash_attn_decode_paged(
     block_table = maybe_contiguous(block_table)
     seq_lens = maybe_contiguous(seq_lens)
     out = maybe_contiguous(out)
+    anchor_lens = maybe_contiguous(anchor_lens)
     window_size_left, window_size_right = window_size
     if window_size_left < -1 or window_size_right < -1:
         raise ValueError(f"Invalid window_size={window_size}; values must be >= -1")
+    if anchored_window < 0:
+        raise ValueError("anchored_window must be non-negative")
+    if (anchored_window > 0) != (anchor_lens is not None):
+        raise ValueError(
+            "anchor_lens and a positive anchored_window must be provided together"
+        )
     batch_capacity = q.shape[0]
     num_heads = q.shape[1]
     head_dim = q.shape[2]
@@ -1001,6 +1010,8 @@ def flash_attn_decode_paged(
         float(v_scale),
         int(window_size_left),
         int(window_size_right),
+        anchor_lens,
+        int(anchored_window),
     )
 
 
@@ -1342,6 +1353,8 @@ def flash_attn_prefill_paged(
     v_scale: float = 1.0,
     causal: bool = True,
     window_size: tuple = (-1, -1),
+    anchor_lens: torch.Tensor | None = None,
+    anchored_window: int = 0,
 ):
     if softmax_scale is None:
         softmax_scale = q.shape[-1] ** -0.5
@@ -1351,9 +1364,16 @@ def flash_attn_prefill_paged(
     block_table = maybe_contiguous(block_table)
     seq_lens = maybe_contiguous(seq_lens)
     out = maybe_contiguous(out)
+    anchor_lens = maybe_contiguous(anchor_lens)
     window_size_left, window_size_right = window_size
     if window_size_left < -1 or window_size_right < -1:
         raise ValueError(f"Invalid window_size={window_size}; values must be >= -1")
+    if anchored_window < 0:
+        raise ValueError("anchored_window must be non-negative")
+    if (anchored_window > 0) != (anchor_lens is not None):
+        raise ValueError(
+            "anchor_lens and a positive anchored_window must be provided together"
+        )
 
     q_ = q.permute(0, 2, 1, 3).contiguous()
     out_ = out.permute(0, 2, 1, 3).contiguous() if out is not None else None
@@ -1372,6 +1392,8 @@ def flash_attn_prefill_paged(
         causal,
         int(window_size_left),
         int(window_size_right),
+        anchor_lens,
+        int(anchored_window),
     )
     return _copy_bhmd_to_bmhd_out(out_, out_original)
 
@@ -1543,6 +1565,8 @@ def flash_attn_prefill_paged_bhmd(
         causal,
         int(window_size_left),
         int(window_size_right),
+        None,
+        0,
     )
 
 

--- a/flash-attention-v100/include/fused_mha.h
+++ b/flash-attention-v100/include/fused_mha.h
@@ -26,7 +26,8 @@ at::Tensor flash_attention_decode_paged(
     const float softmax_scale, const int partition_size,
     const int launch_num_partitions, const std::string& kv_cache_dtype,
     const float k_scale, const float v_scale, const int window_size_left,
-    const int window_size_right);
+    const int window_size_right, const std::optional<at::Tensor>& anchor_lens,
+    const int64_t anchored_window);
 
 at::Tensor flash_attention_decode_paged_xqa(
     const at::Tensor& q, const at::Tensor& k_cache, const at::Tensor& v_cache,
@@ -83,7 +84,8 @@ at::Tensor flash_attention_prefill_paged(
     const at::Tensor& seq_lens, const float softmax_scale,
     const std::string& kv_cache_dtype, const float k_scale, const float v_scale,
     const bool is_causal, const int window_size_left,
-    const int window_size_right);
+    const int window_size_right, const std::optional<at::Tensor>& anchor_lens,
+    const int64_t anchored_window);
 
 std::vector<at::Tensor>
 flash_attention_prefill_paged_d256_bm32_allp_pair_scratch(

--- a/flash-attention-v100/kernel/flash_decode_paged.cu
+++ b/flash-attention-v100/kernel/flash_decode_paged.cu
@@ -5,6 +5,7 @@
 #include <torch/extension.h>
 #include <algorithm>
 #include <atomic>
+#include <climits>
 #include <cstdlib>
 #include <string>
 #include <type_traits>
@@ -814,7 +815,7 @@ __device__ __forceinline__ float dot_qk_cache(const __half* __restrict__ q_ptr,
 }
 
 template <int D, int PARTITION_SIZE, int KV_DTYPE,
-          int SEQ_LEN_ROUTE = kXQARouteAllSeqLens>
+          int SEQ_LEN_ROUTE = kXQARouteAllSeqLens, bool ANCHORED_SWA = false>
 __global__ void flash_attention_decode_partition_kernel(
     const __half* __restrict__ q, const void* __restrict__ k_cache,
     const void* __restrict__ v_cache, __half* __restrict__ tmp_out,
@@ -832,7 +833,12 @@ __global__ void flash_attention_decode_partition_kernel(
     const int64_t v_head_stride, const float softmax_scale, const float k_scale,
     const float v_scale, const int window_size_left,
     const int window_size_right, const int route_seq_len_begin,
-    const int route_seq_len_end, const int route_seq_len_final) {
+    const int route_seq_len_end, const int route_seq_len_final,
+    const int* __restrict__ anchor_lens, const int anchored_window) {
+  // The anchored decode-window mask variant is only generated for the fp16-KV
+  // configuration; every other instantiation keeps its original code path.
+  static_assert(!ANCHORED_SWA || KV_DTYPE == flash_v100::KV_CACHE_DTYPE_FP16,
+                "ANCHORED_SWA requires an fp16 KV cache");
   const int batch_idx = blockIdx.x;
   const int head_idx = blockIdx.y;
   const int partition_idx = blockIdx.z;
@@ -869,6 +875,17 @@ __global__ void flash_attention_decode_partition_kernel(
                              : seq_len - 1;
   const int part_start = max(start_token_idx, min_token_idx);
   const int part_end = min(start_token_idx + PARTITION_SIZE, max_token_idx + 1);
+
+  // Anchored decode window: keys below the per-request prompt length stay
+  // globally visible; later (generated) keys must fall inside the sliding
+  // window over generated positions. Keys inside [gap_lo, gap_hi) are masked.
+  int gap_lo = seq_len;
+  int gap_hi = seq_len;
+  if constexpr (ANCHORED_SWA) {
+    const int anchor_len = anchor_lens[batch_idx];
+    gap_lo = anchor_len;
+    gap_hi = max(anchor_len, query_pos - anchored_window + 1);
+  }
   const int q_per_kv = num_heads_q / num_heads_kv;
   const int kv_head_idx = head_idx / q_per_kv;
   const int lane = threadIdx.x % kWarpSize;
@@ -928,9 +945,21 @@ __global__ void flash_attention_decode_partition_kernel(
 
     float score = dot_qk_cache<D, KV_DTYPE>(q_shared, k_cache, k_index, lane);
     if (lane == 0) {
-      score *= score_scale;
-      scores_shared[token_local] = score;
-      local_max = fmaxf(local_max, score);
+      if constexpr (ANCHORED_SWA) {
+        const int token_idx = part_start + token_local;
+        if (token_idx >= gap_lo && token_idx < gap_hi) {
+          // Masked gap key: never contributes (nulled gap blocks included).
+          scores_shared[token_local] = -1.0e30f;
+        } else {
+          score *= score_scale;
+          scores_shared[token_local] = score;
+          local_max = fmaxf(local_max, score);
+        }
+      } else {
+        score *= score_scale;
+        scores_shared[token_local] = score;
+        local_max = fmaxf(local_max, score);
+      }
     }
   }
 
@@ -938,6 +967,14 @@ __global__ void flash_attention_decode_partition_kernel(
 
   float local_sum = 0.f;
   for (int i = threadIdx.x; i < part_tokens; i += blockDim.x) {
+    if constexpr (ANCHORED_SWA) {
+      const int token_idx = part_start + i;
+      if (token_idx >= gap_lo && token_idx < gap_hi) {
+        // Exact zero weight for masked keys (no reliance on expf underflow).
+        scores_shared[i] = 0.f;
+        continue;
+      }
+    }
     const float p = __expf(scores_shared[i] - part_max);
     scores_shared[i] = p;
     local_sum += p;
@@ -2682,7 +2719,8 @@ void launch_flash_attention_decode_paged(
     const int window_size_left, const int window_size_right,
     cudaStream_t stream, const int route_seq_len_begin = 0,
     const int route_seq_len_end = 0, const int route_seq_len_final = 0,
-    const bool launch_reduce = true) {
+    const bool launch_reduce = true, const int* anchor_lens = nullptr,
+    const int anchored_window = 0) {
   const int batch_size = q.size(0);
   const int num_heads_q = q.size(1);
   const int num_heads_kv = k_cache.size(2);
@@ -2696,22 +2734,41 @@ void launch_flash_attention_decode_paged(
   const size_t reduce_shared_mem =
       static_cast<size_t>(2 * max_num_partitions) * sizeof(float);
 
-  flash_attention_decode_partition_kernel<D, PARTITION_SIZE, KV_DTYPE,
-                                          SEQ_LEN_ROUTE>
-      <<<partition_grid, block, 0, stream>>>(
-          reinterpret_cast<const __half*>(q.data_ptr<at::Half>()),
-          k_cache.data_ptr(), v_cache.data_ptr(),
-          reinterpret_cast<__half*>(tmp_out.data_ptr<at::Half>()),
-          max_logits.data_ptr<float>(), exp_sums.data_ptr<float>(),
-          block_table.data_ptr<int>(), seq_lens.data_ptr<int>(),
-          active_num_partitions.data_ptr<int>(), batch_size, max_num_blocks,
-          max_num_partitions, num_heads_q, num_heads_kv, block_size,
-          q.stride(0), q.stride(1), tmp_out.stride(0), tmp_out.stride(1),
-          tmp_out.stride(2), max_logits.stride(0), max_logits.stride(1),
-          k_cache.stride(0), k_cache.stride(1), k_cache.stride(2),
-          v_cache.stride(0), v_cache.stride(1), v_cache.stride(2),
-          softmax_scale, k_scale, v_scale, window_size_left, window_size_right,
-          route_seq_len_begin, route_seq_len_end, route_seq_len_final);
+  const bool use_anchored = anchor_lens != nullptr && anchored_window > 0;
+  // Second kernel version: the anchored decode-window mask is a separate
+  // template instantiation, generated only for the fp16-KV configuration;
+  // the non-anchored instantiations stay untouched.
+  const auto launch_partition = [&](auto anchored_tag) {
+    constexpr bool kAnchored = decltype(anchored_tag)::value;
+    flash_attention_decode_partition_kernel<D, PARTITION_SIZE, KV_DTYPE,
+                                            SEQ_LEN_ROUTE, kAnchored>
+        <<<partition_grid, block, 0, stream>>>(
+            reinterpret_cast<const __half*>(q.data_ptr<at::Half>()),
+            k_cache.data_ptr(), v_cache.data_ptr(),
+            reinterpret_cast<__half*>(tmp_out.data_ptr<at::Half>()),
+            max_logits.data_ptr<float>(), exp_sums.data_ptr<float>(),
+            block_table.data_ptr<int>(), seq_lens.data_ptr<int>(),
+            active_num_partitions.data_ptr<int>(), batch_size, max_num_blocks,
+            max_num_partitions, num_heads_q, num_heads_kv, block_size,
+            q.stride(0), q.stride(1), tmp_out.stride(0), tmp_out.stride(1),
+            tmp_out.stride(2), max_logits.stride(0), max_logits.stride(1),
+            k_cache.stride(0), k_cache.stride(1), k_cache.stride(2),
+            v_cache.stride(0), v_cache.stride(1), v_cache.stride(2),
+            softmax_scale, k_scale, v_scale, window_size_left,
+            window_size_right, route_seq_len_begin, route_seq_len_end,
+            route_seq_len_final, anchor_lens, anchored_window);
+  };
+  if constexpr (KV_DTYPE == flash_v100::KV_CACHE_DTYPE_FP16) {
+    if (use_anchored) {
+      launch_partition(std::true_type{});
+    } else {
+      launch_partition(std::false_type{});
+    }
+  } else {
+    TORCH_CHECK(!use_anchored,
+                "anchored decode window requires an fp16 KV cache");
+    launch_partition(std::false_type{});
+  }
 
   if (!launch_reduce) {
     return;
@@ -3148,7 +3205,8 @@ at::Tensor flash_attention_decode_paged(
     const float softmax_scale, const int partition_size,
     const int launch_num_partitions, const std::string& kv_cache_dtype,
     const float k_scale, const float v_scale, const int window_size_left,
-    const int window_size_right) {
+    const int window_size_right, const std::optional<at::Tensor>& anchor_lens,
+    const int64_t anchored_window) {
   TORCH_CHECK(q.is_cuda(), "q must be on CUDA");
   TORCH_CHECK(k_cache.is_cuda() && v_cache.is_cuda(),
               "k/v cache must be on CUDA");
@@ -3234,6 +3292,30 @@ at::Tensor flash_attention_decode_paged(
   TORCH_CHECK(window_size_left >= -1 && window_size_right >= -1,
               "window sizes must be >= -1");
 
+  TORCH_CHECK(anchored_window >= 0 && anchored_window <= INT_MAX,
+              "anchored_window must fit in a non-negative int32");
+  TORCH_CHECK((anchored_window > 0) == anchor_lens.has_value(),
+              "anchor_lens and a positive anchored_window must be provided "
+              "together");
+  const bool use_anchored = anchor_lens.has_value();
+  const int* anchor_lens_ptr = nullptr;
+  if (use_anchored) {
+    const at::Tensor& anchors = anchor_lens.value();
+    TORCH_CHECK(anchors.is_cuda(), "anchor_lens must be on CUDA");
+    TORCH_CHECK(anchors.device() == q.device(),
+                "anchor_lens must be on the q device");
+    TORCH_CHECK(anchors.dtype() == torch::kInt32, "anchor_lens must be int32");
+    TORCH_CHECK(anchors.dim() == 1 && anchors.size(0) == batch_size,
+                "anchor_lens must have shape [B]");
+    TORCH_CHECK(anchors.is_contiguous(), "anchor_lens must be contiguous");
+    TORCH_CHECK(kv_dtype_code == flash_v100::KV_CACHE_DTYPE_FP16,
+                "anchored decode window requires an fp16 KV cache");
+    TORCH_CHECK(window_size_left == -1 && window_size_right == -1,
+                "anchored decode window cannot be combined with "
+                "sliding-window attention");
+    anchor_lens_ptr = anchors.data_ptr<int>();
+  }
+
   at::Tensor out = out_.has_value() ? out_.value() : torch::empty_like(q);
   TORCH_CHECK(out.is_cuda(), "out must be on CUDA");
   TORCH_CHECK(out.dtype() == torch::kFloat16, "out must be fp16");
@@ -3243,11 +3325,12 @@ at::Tensor flash_attention_decode_paged(
   auto stream = at::cuda::getCurrentCUDAStream().stream();
   c10::cuda::CUDAGuard device_guard(q.device());
 
-#define LAUNCH_TYPED(HDIM, PARTITION, KV_DTYPE_CODE)                         \
-  launch_flash_attention_decode_paged<HDIM, PARTITION, KV_DTYPE_CODE>(       \
-      q, k_cache, v_cache, out, block_table, seq_lens, tmp_out, max_logits,  \
-      exp_sums, active_num_partitions, softmax_scale, launch_num_partitions, \
-      k_scale, v_scale, window_size_left, window_size_right, stream)
+#define LAUNCH_TYPED(HDIM, PARTITION, KV_DTYPE_CODE)                          \
+  launch_flash_attention_decode_paged<HDIM, PARTITION, KV_DTYPE_CODE>(        \
+      q, k_cache, v_cache, out, block_table, seq_lens, tmp_out, max_logits,   \
+      exp_sums, active_num_partitions, softmax_scale, launch_num_partitions,  \
+      k_scale, v_scale, window_size_left, window_size_right, stream, 0, 0, 0, \
+      true, anchor_lens_ptr, static_cast<int>(anchored_window))
 
 #define LAUNCH_BY_KV_DTYPE(HDIM, PARTITION)                                 \
   do {                                                                      \

--- a/flash-attention-v100/kernel/fused_mha_forward_paged.cu
+++ b/flash-attention-v100/kernel/fused_mha_forward_paged.cu
@@ -3,6 +3,7 @@
 #include <cuda_fp16.h>
 #include <torch/extension.h>
 #include <algorithm>
+#include <climits>
 #include <cstddef>
 #include <cstdlib>
 #include <cstring>
@@ -222,7 +223,7 @@ __device__ __forceinline__ void load_pipeline_swizzled_matrix_a_fragment(
 }
 
 template <int Q_STRIDE, int S_STRIDE, int K_TILES, bool IS_CAUSAL,
-          bool SWIZZLED_Q = false>
+          bool SWIZZLED_Q = false, bool ANCHORED_SWA = false>
 __device__ __forceinline__ void pipeline_qk_slice(
     const __half* __restrict__ sQ, float* __restrict__ score,
     const __half* __restrict__ k_cache, const int* __restrict__ page_idx,
@@ -231,7 +232,8 @@ __device__ __forceinline__ void pipeline_qk_slice(
     int start_col, int valid_k_rows, int start_row, int valid_q_rows,
     int causal_q_offset, int tile_n, int k_begin, bool load_partial,
     bool finalize, float softmax_scale, int window_size_left,
-    int window_size_right, float neg_inf) {
+    int window_size_right, float neg_inf, int anchor_len = 0,
+    int anchored_window = 0) {
   if (tile_n >= valid_k_rows) {
     return;
   }
@@ -294,9 +296,15 @@ __device__ __forceinline__ void pipeline_qk_slice(
         is_window_valid =
             is_window_valid && global_n <= global_q_pos + window_size_right;
       }
-      acc_frag.x[i] = (is_valid && is_causal_valid && is_window_valid)
-                          ? acc_frag.x[i] * softmax_scale
-                          : neg_inf;
+      bool is_anchor_valid = true;
+      if constexpr (ANCHORED_SWA) {
+        is_anchor_valid = (global_n < anchor_len) ||
+                          (global_q_pos - global_n < anchored_window);
+      }
+      acc_frag.x[i] =
+          (is_valid && is_causal_valid && is_window_valid && is_anchor_valid)
+              ? acc_frag.x[i] * softmax_scale
+              : neg_inf;
     }
   }
 
@@ -343,7 +351,8 @@ __device__ __forceinline__ void pipeline_pv_tile(
 template <int D, bool LOW_SMEM, bool LOW_SMEM_CONTIG_FAST,
           bool LOW_SMEM_SCALAR_QK, bool LOW_SMEM_BM32, bool SPLIT_KV,
           bool IS_CAUSAL, int KV_DTYPE, bool D256_OUTPUT_STRIDE_268 = false,
-          bool D256_SW_PIPELINE_QK = false, bool D256_SW_PIPELINE_PV = false>
+          bool D256_SW_PIPELINE_QK = false, bool D256_SW_PIPELINE_PV = false,
+          bool ANCHORED_SWA = false>
 __global__ void __launch_bounds__(
     KernelConfig<D, LOW_SMEM, LOW_SMEM_SCALAR_QK, LOW_SMEM_BM32,
                  D256_OUTPUT_STRIDE_268, D256_SW_PIPELINE_QK,
@@ -365,7 +374,11 @@ __global__ void __launch_bounds__(
         const float k_scale, const float v_scale, const int window_size_left,
         const int window_size_right, float* __restrict__ split_tmp_out,
         float* __restrict__ split_tmp_row_max,
-        float* __restrict__ split_tmp_row_sum, const int split_kv_tiles) {
+        float* __restrict__ split_tmp_row_sum, const int split_kv_tiles,
+        const int* __restrict__ anchor_lens, const int anchored_window) {
+  static_assert(!ANCHORED_SWA ||
+                    (IS_CAUSAL && KV_DTYPE == flash_v100::KV_CACHE_DTYPE_FP16),
+                "ANCHORED_SWA requires causal attention and an fp16 KV cache");
   using Config = KernelConfig<D, LOW_SMEM, LOW_SMEM_SCALAR_QK, LOW_SMEM_BM32,
                               D256_OUTPUT_STRIDE_268, D256_SW_PIPELINE_QK,
                               D256_SW_PIPELINE_PV>;
@@ -408,6 +421,11 @@ __global__ void __launch_bounds__(
   int num_n_tiles = (actual_N + BLOCK_N - 1) / BLOCK_N;
   const int valid_q_rows = min(BLOCK_M, M - start_row);
   const int causal_q_offset = max(actual_N - M, 0);
+
+  int anchor_len = 0;
+  if constexpr (ANCHORED_SWA) {
+    anchor_len = anchor_lens[batch_id];
+  }
 
   int max_key_pos = actual_N - 1;
   if constexpr (IS_CAUSAL) {
@@ -524,12 +542,13 @@ __global__ void __launch_bounds__(
 
       if (warp_id < BLOCK_N / WMMA_N) {
         const int valid_k_rows = min(BLOCK_N, actual_N);
-        pipeline_qk_slice<Q_STRIDE, S_STRIDE, D / WMMA_K, IS_CAUSAL, true>(
+        pipeline_qk_slice<Q_STRIDE, S_STRIDE, D / WMMA_K, IS_CAUSAL, true,
+                          ANCHORED_SWA>(
             sQ, sS, k_cache_h, sPageIdx, sPageOffset, k_block_stride,
             k_token_stride, k_head_stride, kv_head_id, 0, valid_k_rows,
             start_row, valid_q_rows, causal_q_offset, warp_id * WMMA_N, 0,
             false, true, softmax_scale, window_size_left, window_size_right,
-            NEG_INF);
+            NEG_INF, anchor_len, anchored_window);
       }
       __syncthreads();
 
@@ -666,13 +685,14 @@ __global__ void __launch_bounds__(
 
           if (sub_start == 0) {
             if (warp_id < BLOCK_N / WMMA_N) {
-              pipeline_qk_slice<Q_STRIDE, S_STRIDE, D / WMMA_K, IS_CAUSAL,
-                                true>(
+              pipeline_qk_slice<Q_STRIDE, S_STRIDE, D / WMMA_K, IS_CAUSAL, true,
+                                ANCHORED_SWA>(
                   sQ, score_next, k_cache_h, page_idx_next, page_offset_next,
                   k_block_stride, k_token_stride, k_head_stride, kv_head_id,
                   next_start_col, next_valid_k_rows, start_row, valid_q_rows,
                   causal_q_offset, warp_id * WMMA_N, 0, false, true,
-                  softmax_scale, window_size_left, window_size_right, NEG_INF);
+                  softmax_scale, window_size_left, window_size_right, NEG_INF,
+                  anchor_len, anchored_window);
             } else {
               const int pv_warp = warp_id - BLOCK_N / WMMA_N;
               pipeline_pv_tile<P_STRIDE, O_STRIDE, true>(
@@ -866,6 +886,11 @@ __global__ void __launch_bounds__(
           if (window_size_right >= 0) {
             is_valid = is_valid && global_n <= global_q_pos + window_size_right;
           }
+          if constexpr (ANCHORED_SWA) {
+            is_valid =
+                is_valid && ((global_n < anchor_len) ||
+                             (global_q_pos - global_n < anchored_window));
+          }
 
           float acc = 0.0f;
           if (is_valid) {
@@ -887,12 +912,12 @@ __global__ void __launch_bounds__(
         constexpr int QK_TILES = BLOCK_N / WMMA_N;
         if (warp_id < QK_TILES) {
           pipeline_qk_slice<Q_STRIDE, S_STRIDE, D / WMMA_K, IS_CAUSAL,
-                            D256_SW_PIPELINE_PV>(
+                            D256_SW_PIPELINE_PV, ANCHORED_SWA>(
               sQ, sS, K_cache_h, sPageIdx, sPageOffset, k_block_stride,
               k_token_stride, k_head_stride, kv_head_id, start_col,
               valid_k_rows, start_row, valid_q_rows, causal_q_offset,
               warp_id * WMMA_N, 0, false, true, softmax_scale, window_size_left,
-              window_size_right, NEG_INF);
+              window_size_right, NEG_INF, anchor_len, anchored_window);
         }
       } else {
         const int num_tiles_m_qk = (BLOCK_M + WMMA_M - 1) / WMMA_M;
@@ -986,7 +1011,14 @@ __global__ void __launch_bounds__(
                                 global_n <= global_q_pos + window_size_right;
             }
 
-            acc_frag.x[i] = (is_valid && is_causal_valid && is_window_valid)
+            bool is_anchor_valid = true;
+            if constexpr (ANCHORED_SWA) {
+              is_anchor_valid = (global_n < anchor_len) ||
+                                (global_q_pos - global_n < anchored_window);
+            }
+
+            acc_frag.x[i] = (is_valid && is_causal_valid && is_window_valid &&
+                             is_anchor_valid)
                                 ? acc_frag.x[i] * softmax_scale
                                 : NEG_INF;
           }
@@ -1132,7 +1164,14 @@ __global__ void __launch_bounds__(
                 is_window_valid && global_n <= global_q_pos + window_size_right;
           }
 
-          acc_frag.x[i] = (is_valid && is_causal_valid && is_window_valid)
+          bool is_anchor_valid = true;
+          if constexpr (ANCHORED_SWA) {
+            is_anchor_valid = (global_n < anchor_len) ||
+                              (global_q_pos - global_n < anchored_window);
+          }
+
+          acc_frag.x[i] = (is_valid && is_causal_valid && is_window_valid &&
+                           is_anchor_valid)
                               ? acc_frag.x[i] * softmax_scale
                               : NEG_INF;
         }
@@ -1757,7 +1796,8 @@ void launcher_flash_attention_forward_paged_impl(
     int64_t bfla_mask_stride_h, int64_t bfla_mask_stride_q,
     int64_t bfla_mask_stride_k, float softmax_scale, bool is_causal,
     float k_scale, float v_scale, int window_size_left, int window_size_right,
-    cudaStream_t stream) {
+    cudaStream_t stream, const int* anchor_lens = nullptr,
+    int anchored_window = 0) {
   using Config = KernelConfig<D, LOW_SMEM, LOW_SMEM_SCALAR_QK, LOW_SMEM_BM32,
                               D256_OUTPUT_STRIDE_268, D256_SW_PIPELINE_QK,
                               D256_SW_PIPELINE_PV>;
@@ -1783,6 +1823,35 @@ void launcher_flash_attention_forward_paged_impl(
 
   TORCH_CHECK(smem <= MAX_SMEM_PER_SM, "Shared memory exceeds 96KB: ", smem,
               " bytes");
+
+  const bool use_anchored = anchor_lens != nullptr && anchored_window > 0;
+  TORCH_CHECK(!use_anchored || is_causal,
+              "anchored decode window requires causal attention");
+  if constexpr (KV_DTYPE == flash_v100::KV_CACHE_DTYPE_FP16) {
+    if (use_anchored) {
+      auto anchored_kernel = flash_attention_forward_kernel_paged<
+          D, LOW_SMEM, LOW_SMEM_CONTIG_FAST, LOW_SMEM_SCALAR_QK, LOW_SMEM_BM32,
+          false, true, KV_DTYPE, D256_OUTPUT_STRIDE_268, D256_SW_PIPELINE_QK,
+          D256_SW_PIPELINE_PV, true>;
+      cudaFuncSetAttribute((void*)anchored_kernel,
+                           cudaFuncAttributeMaxDynamicSharedMemorySize, smem);
+      anchored_kernel<<<grid, block, smem, stream>>>(
+          reinterpret_cast<const __half*>(Q.data_ptr()), K_cache.data_ptr(),
+          V_cache.data_ptr(), reinterpret_cast<__half*>(Out.data_ptr()),
+          softmax_lse.data_ptr<float>(), block_table.data_ptr<int>(),
+          seq_lens.data_ptr<int>(), B, H, M, N, bfla_mask_ptr,
+          bfla_mask_block_n, bfla_mask_stride_b, bfla_mask_stride_h,
+          bfla_mask_stride_q, bfla_mask_stride_k, page_block_size, num_kv_heads,
+          k_block_stride, k_token_stride, k_head_stride, v_block_stride,
+          v_token_stride, v_head_stride, softmax_scale, k_scale, v_scale,
+          window_size_left, window_size_right, nullptr, nullptr, nullptr, 0,
+          anchor_lens, anchored_window);
+      return;
+    }
+  } else {
+    TORCH_CHECK(!use_anchored,
+                "anchored decode window requires an fp16 KV cache");
+  }
 
   auto kernel =
       is_causal
@@ -1810,7 +1879,7 @@ void launcher_flash_attention_forward_paged_impl(
         bfla_mask_stride_k, page_block_size, num_kv_heads, k_block_stride,
         k_token_stride, k_head_stride, v_block_stride, v_token_stride,
         v_head_stride, softmax_scale, k_scale, v_scale, window_size_left,
-        window_size_right, nullptr, nullptr, nullptr, 0);
+        window_size_right, nullptr, nullptr, nullptr, 0, nullptr, 0);
   } else {
     flash_attention_forward_kernel_paged<
         D, LOW_SMEM, LOW_SMEM_CONTIG_FAST, LOW_SMEM_SCALAR_QK, LOW_SMEM_BM32,
@@ -1824,7 +1893,7 @@ void launcher_flash_attention_forward_paged_impl(
         bfla_mask_stride_k, page_block_size, num_kv_heads, k_block_stride,
         k_token_stride, k_head_stride, v_block_stride, v_token_stride,
         v_head_stride, softmax_scale, k_scale, v_scale, window_size_left,
-        window_size_right, nullptr, nullptr, nullptr, 0);
+        window_size_right, nullptr, nullptr, nullptr, 0, nullptr, 0);
   }
 }
 
@@ -1987,7 +2056,7 @@ void launcher_flash_attention_forward_paged_splitkv_impl(
             softmax_scale, k_scale, v_scale, window_size_left,
             window_size_right, split_tmp_out.data_ptr<float>(),
             split_tmp_row_max.data_ptr<float>(),
-            split_tmp_row_sum.data_ptr<float>(), split_kv_tiles);
+            split_tmp_row_sum.data_ptr<float>(), split_kv_tiles, nullptr, 0);
   } else {
     flash_attention_forward_kernel_paged<D, LOW_SMEM, LOW_SMEM_CONTIG_FAST,
                                          LOW_SMEM_SCALAR_QK, false, true, false,
@@ -2002,7 +2071,7 @@ void launcher_flash_attention_forward_paged_splitkv_impl(
             softmax_scale, k_scale, v_scale, window_size_left,
             window_size_right, split_tmp_out.data_ptr<float>(),
             split_tmp_row_max.data_ptr<float>(),
-            split_tmp_row_sum.data_ptr<float>(), split_kv_tiles);
+            split_tmp_row_sum.data_ptr<float>(), split_kv_tiles, nullptr, 0);
   }
 
   const dim3 merge_grid(grid_x, 1, B * H);
@@ -3105,7 +3174,27 @@ void launcher_flash_attention_forward_paged(
     cudaStream_t stream, const int* bfla_mask_ptr = nullptr,
     int bfla_mask_block_n = 0, int64_t bfla_mask_stride_b = 0,
     int64_t bfla_mask_stride_h = 0, int64_t bfla_mask_stride_q = 0,
-    int64_t bfla_mask_stride_k = 0) {
+    int64_t bfla_mask_stride_k = 0, const int* anchor_lens = nullptr,
+    int anchored_window = 0) {
+  if (anchor_lens != nullptr && anchored_window > 0) {
+    TORCH_CHECK(KV_DTYPE == flash_v100::KV_CACHE_DTYPE_FP16,
+                "anchored decode window requires an fp16 KV cache");
+    TORCH_CHECK(is_causal, "anchored decode window requires causal attention");
+    TORCH_CHECK(window_size_left < 0 && window_size_right < 0,
+                "anchored decode window cannot be combined with "
+                "sliding-window attention");
+    TORCH_CHECK(bfla_mask_ptr == nullptr,
+                "anchored decode window cannot be combined with a "
+                "block sparsity mask");
+    launcher_flash_attention_forward_paged_impl<D, KV_DTYPE, false, false,
+                                                false, false>(
+        Q, K_cache, V_cache, Out, softmax_lse, block_table, seq_lens,
+        bfla_mask_ptr, bfla_mask_block_n, bfla_mask_stride_b,
+        bfla_mask_stride_h, bfla_mask_stride_q, bfla_mask_stride_k,
+        softmax_scale, is_causal, k_scale, v_scale, window_size_left,
+        window_size_right, stream, anchor_lens, anchored_window);
+    return;
+  }
   if constexpr (D == 256 && KV_DTYPE == flash_v100::KV_CACHE_DTYPE_FP16) {
     const int M = Q.size(2);
     const int page_block_size = K_cache.size(1);
@@ -3442,7 +3531,8 @@ at::Tensor flash_attention_prefill_paged(
     const at::Tensor& seq_lens, const float softmax_scale,
     const std::string& kv_cache_dtype, const float k_scale, const float v_scale,
     const bool is_causal, const int window_size_left,
-    const int window_size_right) {
+    const int window_size_right, const std::optional<at::Tensor>& anchor_lens,
+    const int64_t anchored_window) {
   TORCH_CHECK(q.dtype() == torch::kFloat16, "q must be fp16");
   const int kv_dtype_code = kv_cache_dtype_code_from_string(kv_cache_dtype);
   TORCH_CHECK(kv_dtype_code >= 0,
@@ -3482,6 +3572,31 @@ at::Tensor flash_attention_prefill_paged(
   TORCH_CHECK(window_size_left >= -1 && window_size_right >= -1,
               "window sizes must be >= -1");
 
+  TORCH_CHECK(anchored_window >= 0 && anchored_window <= INT_MAX,
+              "anchored_window must fit in a non-negative int32");
+  TORCH_CHECK((anchored_window > 0) == anchor_lens.has_value(),
+              "anchor_lens and a positive anchored_window must be provided "
+              "together");
+  const bool use_anchored = anchor_lens.has_value();
+  const int* anchor_lens_ptr = nullptr;
+  if (use_anchored) {
+    const at::Tensor& anchors = anchor_lens.value();
+    TORCH_CHECK(anchors.is_cuda(), "anchor_lens must be on CUDA");
+    TORCH_CHECK(anchors.device() == q.device(),
+                "anchor_lens must be on the q device");
+    TORCH_CHECK(anchors.dtype() == torch::kInt32, "anchor_lens must be int32");
+    TORCH_CHECK(anchors.dim() == 1 && anchors.size(0) == B,
+                "anchor_lens must have shape [B]");
+    TORCH_CHECK(anchors.is_contiguous(), "anchor_lens must be contiguous");
+    TORCH_CHECK(kv_dtype_code == flash_v100::KV_CACHE_DTYPE_FP16,
+                "anchored decode window requires an fp16 KV cache");
+    TORCH_CHECK(is_causal, "anchored decode window requires causal attention");
+    TORCH_CHECK(window_size_left == -1 && window_size_right == -1,
+                "anchored decode window cannot be combined with "
+                "sliding-window attention");
+    anchor_lens_ptr = anchors.data_ptr<int>();
+  }
+
   at::Tensor out_fp16 = out_.has_value() ? out_.value() : torch::zeros_like(q);
   auto softmax_lse =
       torch::zeros({B, H, M}, torch::dtype(torch::kFloat32).device(q.device()));
@@ -3491,11 +3606,12 @@ at::Tensor flash_attention_prefill_paged(
   bool sm70 = props->major == 7 && props->minor == 0;
   TORCH_CHECK(sm70, "Kernel supports only Volta GPUs.");
 
-#define LAUNCH_PAGED_TYPED(HDIM, KV_DTYPE_CODE)                          \
-  launcher_flash_attention_forward_paged<HDIM, KV_DTYPE_CODE>(           \
-      q, k_cache, v_cache, out_fp16, softmax_lse, block_table, seq_lens, \
-      softmax_scale, is_causal, k_scale, v_scale, window_size_left,      \
-      window_size_right, stream)
+#define LAUNCH_PAGED_TYPED(HDIM, KV_DTYPE_CODE)                           \
+  launcher_flash_attention_forward_paged<HDIM, KV_DTYPE_CODE>(            \
+      q, k_cache, v_cache, out_fp16, softmax_lse, block_table, seq_lens,  \
+      softmax_scale, is_causal, k_scale, v_scale, window_size_left,       \
+      window_size_right, stream, nullptr, 0, 0, 0, 0, 0, anchor_lens_ptr, \
+      static_cast<int>(anchored_window))
 
 #define LAUNCH_PAGED_BY_KV(HDIM)                                            \
   do {                                                                      \

--- a/tests/config/test_prefix_anchored_swa.py
+++ b/tests/config/test_prefix_anchored_swa.py
@@ -1,0 +1,158 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+import vllm.platforms as platforms
+from vllm.config.attention import AttentionConfig
+from vllm.config.vllm import apply_prefix_anchored_swa_constraints
+from vllm.model_executor.layers.attention.attention import Attention
+from vllm.v1.attention.backend import AttentionType
+from vllm.v1.attention.backends.registry import AttentionBackendEnum
+from vllm.v1.kv_cache_interface import PrefixAnchoredSWASpec
+
+
+def _config(window: int = 128) -> SimpleNamespace:
+    return SimpleNamespace(
+        attention_config=AttentionConfig(
+            prefix_anchored_decode_window=window,
+        ),
+        cache_config=SimpleNamespace(
+            cache_dtype="auto",
+            enable_prefix_caching=True,
+            kv_offloading_size=None,
+        ),
+        model_config=SimpleNamespace(dtype=torch.float16, use_mla=False),
+        parallel_config=SimpleNamespace(
+            decode_context_parallel_size=1,
+            prefill_context_parallel_size=1,
+        ),
+        kv_transfer_config=None,
+        speculative_config=None,
+    )
+
+
+@pytest.fixture
+def sm70_platform(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        platforms,
+        "current_platform",
+        SimpleNamespace(
+            is_cuda=lambda: True,
+            is_device_capability=lambda capability: capability == (7, 0),
+        ),
+    )
+
+
+def test_engine_contract_is_model_identity_independent(sm70_platform: None):
+    cfg = _config()
+
+    apply_prefix_anchored_swa_constraints(cfg)
+
+    assert cfg.attention_config.backend == AttentionBackendEnum.FLASH_ATTN_V100
+    assert not cfg.cache_config.enable_prefix_caching
+
+
+@pytest.mark.parametrize("window", [0, -1])
+def test_engine_option_rejects_nonpositive_window(window: int):
+    with pytest.raises(ValueError):
+        AttentionConfig(prefix_anchored_decode_window=window)
+
+
+def test_engine_contract_rejects_non_fp16_kv(sm70_platform: None):
+    cfg = _config()
+    cfg.cache_config.cache_dtype = "fp8_e5m2"
+
+    with pytest.raises(ValueError, match="requires an fp16 KV cache"):
+        apply_prefix_anchored_swa_constraints(cfg)
+
+
+@pytest.mark.parametrize(
+    ("path", "value", "message"),
+    [
+        ("model_config.use_mla", True, "MLA attention"),
+        ("attention_config.use_non_causal", True, "causal decoder"),
+        ("parallel_config.decode_context_parallel_size", 2, "context parallelism"),
+        ("cache_config.kv_offloading_size", 1.0, "KV-cache offloading"),
+        (
+            "kv_transfer_config",
+            SimpleNamespace(kv_connector="ExampleConnector"),
+            "KV connectors",
+        ),
+        ("speculative_config", object(), "speculative decoding"),
+        (
+            "attention_config.backend",
+            AttentionBackendEnum.TRITON_ATTN,
+            "requires FLASH_ATTN_V100",
+        ),
+    ],
+)
+def test_engine_contract_rejects_unsupported_runtime_combinations(
+    sm70_platform: None,
+    path: str,
+    value: object,
+    message: str,
+):
+    cfg = _config()
+    target = cfg
+    parts = path.split(".")
+    for part in parts[:-1]:
+        target = getattr(target, part)
+    setattr(target, parts[-1], value)
+
+    with pytest.raises(ValueError, match=message):
+        apply_prefix_anchored_swa_constraints(cfg)
+
+
+def test_engine_contract_rejects_non_sm70(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(
+        platforms,
+        "current_platform",
+        SimpleNamespace(
+            is_cuda=lambda: True,
+            is_device_capability=lambda capability: False,
+        ),
+    )
+
+    with pytest.raises(ValueError, match="SM70 GPU"):
+        apply_prefix_anchored_swa_constraints(_config())
+
+
+def test_base_attention_emits_prefix_anchored_spec_without_model_subclass():
+    layer = object.__new__(Attention)
+    object.__setattr__(layer, "attn_type", AttentionType.DECODER)
+    object.__setattr__(
+        layer,
+        "attn_backend",
+        SimpleNamespace(get_name=lambda: "FLASH_ATTN_V100"),
+    )
+    object.__setattr__(layer, "kv_cache_dtype", "auto")
+    object.__setattr__(layer, "kv_cache_torch_dtype", torch.float16)
+    object.__setattr__(layer, "sliding_window", None)
+    object.__setattr__(layer, "num_kv_heads", 4)
+    object.__setattr__(layer, "head_size", 128)
+    object.__setattr__(layer, "head_size_v", 128)
+    object.__setattr__(layer, "has_sink", False)
+    vllm_config = SimpleNamespace(
+        cache_config=SimpleNamespace(block_size=16),
+        attention_config=SimpleNamespace(prefix_anchored_decode_window=256),
+    )
+
+    spec = Attention.get_kv_cache_spec(layer, vllm_config)
+
+    assert isinstance(spec, PrefixAnchoredSWASpec)
+    assert spec.decode_sliding_window == 256
+
+
+def test_prefix_anchored_spec_rejects_nonpositive_window():
+    with pytest.raises(ValueError, match="greater than zero"):
+        PrefixAnchoredSWASpec(
+            block_size=16,
+            num_kv_heads=1,
+            head_size=64,
+            dtype=torch.float16,
+            decode_sliding_window=0,
+        )

--- a/tests/kernels/attention/test_sm70_flash_v100_anchored_swa.py
+++ b/tests/kernels/attention/test_sm70_flash_v100_anchored_swa.py
@@ -1,0 +1,288 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""SM70 Flash-V100 anchored decode-window mask kernel tests.
+
+Validates the masked (second) kernel instantiations of the paged decode and
+paged prefill kernels against a plain torch reference:
+``causal AND (kv < anchor_len OR q_abs - kv < window)``, element-wise.
+
+Requires a CUDA device and the flash_attn_v100 extension built with the
+anchored kernel arguments; skipped otherwise.
+"""
+
+from collections.abc import Callable
+from typing import Any
+
+import pytest
+import torch
+
+cuda_available = torch.cuda.is_available()
+FlashOp = Callable[..., Any]
+flash_ops: tuple[FlashOp, FlashOp] | None = None
+if cuda_available:
+    try:
+        from flash_attn_v100 import (
+            flash_attn_decode_paged,
+            flash_attn_prefill_paged,
+        )
+
+        flash_ops = (flash_attn_decode_paged, flash_attn_prefill_paged)
+    except ImportError:
+        flash_ops = None
+
+pytestmark = pytest.mark.skipif(
+    not cuda_available or flash_ops is None,
+    reason="requires CUDA and the flash_attn_v100 extension",
+)
+
+
+def _require_flash_ops() -> tuple[FlashOp, FlashOp]:
+    assert flash_ops is not None
+    return flash_ops
+
+
+def _anchored_mask(
+    q_positions: torch.Tensor,
+    kv_len: int,
+    anchor_len: int,
+    window: int,
+    device: str,
+) -> torch.Tensor:
+    """Boolean keep-mask [num_q, kv_len]; True = attend."""
+    kv = torch.arange(kv_len, device=device)[None, :]
+    q = q_positions[:, None]
+    causal = kv <= q
+    in_prefix = kv < anchor_len
+    in_window = (q - kv) < window
+    return causal & (in_prefix | in_window)
+
+
+def _ref_attention(
+    q: torch.Tensor,  # [num_q, H, D]
+    k: torch.Tensor,  # [kv_len, H_kv, D]
+    v: torch.Tensor,
+    mask: torch.Tensor,  # [num_q, kv_len]
+    scale: float,
+) -> torch.Tensor:
+    group = q.shape[1] // k.shape[1]
+    k_exp = k.repeat_interleave(group, dim=1)
+    v_exp = v.repeat_interleave(group, dim=1)
+    scores = torch.einsum("qhd,khd->hqk", q.float(), k_exp.float()) * scale
+    scores = scores.masked_fill(~mask[None], float("-inf"))
+    probs = torch.softmax(scores, dim=-1)
+    return torch.einsum("hqk,khd->qhd", probs, v_exp.float())
+
+
+def _build_paged_kv(
+    kv_len: int,
+    block_size: int,
+    num_kv_heads: int,
+    head_dim: int,
+    device: str,
+    dtype: torch.dtype,
+    seed: int,
+):
+    torch.manual_seed(seed)
+    num_blocks = (kv_len + block_size - 1) // block_size + 2
+    k_cache = torch.randn(
+        num_blocks, block_size, num_kv_heads, head_dim, device=device, dtype=dtype
+    )
+    v_cache = torch.randn_like(k_cache)
+    block_table = torch.arange(num_blocks, dtype=torch.int32, device=device).unsqueeze(
+        0
+    )
+    k_lin = k_cache.reshape(-1, num_kv_heads, head_dim)[:kv_len]
+    v_lin = v_cache.reshape(-1, num_kv_heads, head_dim)[:kv_len]
+    return k_cache, v_cache, block_table, k_lin, v_lin
+
+
+@pytest.mark.parametrize(
+    "head_dim,num_heads,num_kv_heads",
+    [(256, 8, 4), (128, 8, 8), (128, 8, 4), (64, 4, 4)],
+)
+# kv_len=1100 spans three 512-token partitions with the middle partition
+# entirely inside the masked gap (exercises the neutral-stats path).
+@pytest.mark.parametrize(
+    "anchor,window,kv_len", [(32, 16, 96), (16, 8, 40), (32, 16, 1100)]
+)
+def test_decode_paged_anchored_matches_reference(
+    head_dim, num_heads, num_kv_heads, anchor, window, kv_len
+):
+    device = "cuda"
+    dtype = torch.float16
+    block_size = 16
+    scale = head_dim**-0.5
+
+    k_cache, v_cache, block_table, k_lin, v_lin = _build_paged_kv(
+        kv_len, block_size, num_kv_heads, head_dim, device, dtype, seed=0
+    )
+    q = torch.randn(1, num_heads, head_dim, device=device, dtype=dtype)
+    seq_lens = torch.tensor([kv_len], dtype=torch.int32, device=device)
+    anchor_lens = torch.tensor([anchor], dtype=torch.int32, device=device)
+
+    out = torch.empty_like(q)
+    decode_op, _ = _require_flash_ops()
+    decode_op(
+        q,
+        k_cache,
+        v_cache,
+        block_table,
+        seq_lens,
+        softmax_scale=scale,
+        out=out,
+        anchor_lens=anchor_lens,
+        anchored_window=window,
+    )
+
+    q_pos = torch.tensor([kv_len - 1], device=device)
+    mask = _anchored_mask(q_pos, kv_len, anchor, window, device)
+    assert not mask[0].all(), "test must exercise a non-trivial gap"
+    ref = _ref_attention(q[0].unsqueeze(0), k_lin, v_lin, mask, scale)
+    torch.testing.assert_close(out[0].float(), ref[0], atol=2e-2, rtol=2e-2)
+
+
+def test_decode_paged_anchored_off_path_unchanged():
+    """Without anchor arguments the decode op matches its own baseline."""
+    device = "cuda"
+    dtype = torch.float16
+    head_dim, num_heads, num_kv_heads = 128, 8, 8
+    kv_len, block_size = 96, 16
+    scale = head_dim**-0.5
+
+    k_cache, v_cache, block_table, k_lin, v_lin = _build_paged_kv(
+        kv_len, block_size, num_kv_heads, head_dim, device, dtype, seed=1
+    )
+    q = torch.randn(1, num_heads, head_dim, device=device, dtype=dtype)
+    seq_lens = torch.tensor([kv_len], dtype=torch.int32, device=device)
+
+    out = torch.empty_like(q)
+    decode_op, _ = _require_flash_ops()
+    decode_op(q, k_cache, v_cache, block_table, seq_lens, softmax_scale=scale, out=out)
+    q_pos = torch.tensor([kv_len - 1], device=device)
+    causal = _anchored_mask(q_pos, kv_len, kv_len, kv_len, device)
+    assert causal[0].all()
+    ref = _ref_attention(q[0].unsqueeze(0), k_lin, v_lin, causal, scale)
+    torch.testing.assert_close(out[0].float(), ref[0], atol=2e-2, rtol=2e-2)
+
+
+def test_decode_paged_uses_per_request_anchor_lengths():
+    device = "cuda"
+    dtype = torch.float16
+    head_dim, num_heads, num_kv_heads = 128, 8, 4
+    kv_len, block_size, window = 96, 16, 16
+    anchors = (16, 32)
+    scale = head_dim**-0.5
+
+    k_cache, v_cache, block_table, k_lin, v_lin = _build_paged_kv(
+        kv_len, block_size, num_kv_heads, head_dim, device, dtype, seed=3
+    )
+    block_table = block_table.repeat(2, 1)
+    q = torch.randn(2, num_heads, head_dim, device=device, dtype=dtype)
+    seq_lens = torch.full((2,), kv_len, dtype=torch.int32, device=device)
+    anchor_lens = torch.tensor(anchors, dtype=torch.int32, device=device)
+
+    decode_op, _ = _require_flash_ops()
+    out = torch.empty_like(q)
+    decode_op(
+        q,
+        k_cache,
+        v_cache,
+        block_table,
+        seq_lens,
+        softmax_scale=scale,
+        out=out,
+        anchor_lens=anchor_lens,
+        anchored_window=window,
+    )
+
+    q_pos = torch.tensor([kv_len - 1], device=device)
+    for batch_idx, anchor in enumerate(anchors):
+        mask = _anchored_mask(q_pos, kv_len, anchor, window, device)
+        ref = _ref_attention(q[batch_idx].unsqueeze(0), k_lin, v_lin, mask, scale)
+        torch.testing.assert_close(out[batch_idx].float(), ref[0], atol=2e-2, rtol=2e-2)
+
+
+@pytest.mark.parametrize(
+    "head_dim,num_heads,num_kv_heads",
+    [(256, 8, 4), (128, 8, 4)],
+)
+@pytest.mark.parametrize(
+    "anchor,window,kv_len,q_len", [(32, 16, 96, 8), (16, 8, 48, 48)]
+)
+def test_prefill_paged_anchored_matches_reference(
+    head_dim, num_heads, num_kv_heads, anchor, window, kv_len, q_len
+):
+    """Masked paged prefill vs torch reference.
+
+    Covers both the chunked-continuation shape (q_len < kv_len, queries in
+    the decode region) and the full-sequence shape (q_len == kv_len, where
+    prompt-region queries must stay purely causal).
+    """
+    device = "cuda"
+    dtype = torch.float16
+    block_size = 16
+    scale = head_dim**-0.5
+
+    k_cache, v_cache, block_table, k_lin, v_lin = _build_paged_kv(
+        kv_len, block_size, num_kv_heads, head_dim, device, dtype, seed=2
+    )
+    q = torch.randn(1, q_len, num_heads, head_dim, device=device, dtype=dtype)
+    seq_lens = torch.tensor([kv_len], dtype=torch.int32, device=device)
+    anchor_lens = torch.tensor([anchor], dtype=torch.int32, device=device)
+
+    _, prefill_op = _require_flash_ops()
+    out = prefill_op(
+        q,
+        k_cache,
+        v_cache,
+        block_table,
+        seq_lens,
+        softmax_scale=scale,
+        causal=True,
+        anchor_lens=anchor_lens,
+        anchored_window=window,
+    )
+
+    # Query absolute positions: the last q_len positions of the sequence.
+    q_pos = torch.arange(kv_len - q_len, kv_len, device=device)
+    mask = _anchored_mask(q_pos, kv_len, anchor, window, device)
+    ref = _ref_attention(q[0], k_lin, v_lin, mask, scale)
+    torch.testing.assert_close(out[0].float(), ref.float(), atol=2e-2, rtol=2e-2)
+
+
+def test_prefill_paged_uses_per_request_anchor_lengths():
+    device = "cuda"
+    dtype = torch.float16
+    head_dim, num_heads, num_kv_heads = 128, 8, 4
+    kv_len, q_len, block_size, window = 96, 8, 16, 16
+    anchors = (16, 32)
+    scale = head_dim**-0.5
+
+    k_cache, v_cache, block_table, k_lin, v_lin = _build_paged_kv(
+        kv_len, block_size, num_kv_heads, head_dim, device, dtype, seed=4
+    )
+    block_table = block_table.repeat(2, 1)
+    q = torch.randn(2, q_len, num_heads, head_dim, device=device, dtype=dtype)
+    seq_lens = torch.full((2,), kv_len, dtype=torch.int32, device=device)
+    anchor_lens = torch.tensor(anchors, dtype=torch.int32, device=device)
+
+    _, prefill_op = _require_flash_ops()
+    out = prefill_op(
+        q,
+        k_cache,
+        v_cache,
+        block_table,
+        seq_lens,
+        softmax_scale=scale,
+        causal=True,
+        anchor_lens=anchor_lens,
+        anchored_window=window,
+    )
+
+    q_pos = torch.arange(kv_len - q_len, kv_len, device=device)
+    for batch_idx, anchor in enumerate(anchors):
+        mask = _anchored_mask(q_pos, kv_len, anchor, window, device)
+        ref = _ref_attention(q[batch_idx], k_lin, v_lin, mask, scale)
+        torch.testing.assert_close(
+            out[batch_idx].float(), ref.float(), atol=2e-2, rtol=2e-2
+        )

--- a/tests/v1/attention/test_prefix_anchored_swa_mask.py
+++ b/tests/v1/attention/test_prefix_anchored_swa_mask.py
@@ -1,0 +1,181 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Tests for the prefix-anchored sliding-window attention mask.
+
+Semantics under test: keys inside the prompt/prefix (``kv < anchor_len``)
+stay globally visible; generated keys are additionally restricted to a
+sliding window (``q_abs - kv < window``); everything is AND-ed with the
+causal mask.
+
+The CPU tests validate the mask formula (the same one the masked kernels
+implement) against plain causal attention with a torch reference.
+"""
+
+from types import SimpleNamespace
+from typing import Any, cast
+
+import pytest
+import torch
+
+from vllm.v1.attention.backend import AttentionType
+from vllm.v1.attention.backends.flash_attn_v100 import (
+    FlashAttnV100Impl,
+    FlashAttnV100MetadataBuilder,
+)
+
+
+def anchored_swa_mask(
+    seq_len: int, anchor_len: int, window: int, device: str = "cpu"
+) -> torch.Tensor:
+    """Boolean keep-mask [seq_len, seq_len]; True = attend.
+
+    Mirrors the kernel formula:
+    ``causal AND (kv < anchor_len OR q_abs - kv < window)``.
+    """
+    q = torch.arange(seq_len, device=device)[:, None]
+    kv = torch.arange(seq_len, device=device)[None, :]
+    causal = kv <= q
+    in_prefix = kv < anchor_len
+    in_window = (q - kv) < window
+    return causal & (in_prefix | in_window)
+
+
+def causal_mask(seq_len: int, device: str = "cpu") -> torch.Tensor:
+    q = torch.arange(seq_len, device=device)[:, None]
+    kv = torch.arange(seq_len, device=device)[None, :]
+    return kv <= q
+
+
+def ref_attention(
+    q: torch.Tensor, k: torch.Tensor, v: torch.Tensor, mask: torch.Tensor
+) -> torch.Tensor:
+    """Plain fp32 reference attention. q/k/v: [heads, seq, dim]."""
+    scale = q.shape[-1] ** -0.5
+    scores = torch.einsum("hqd,hkd->hqk", q.float(), k.float()) * scale
+    scores = scores.masked_fill(~mask[None], float("-inf"))
+    probs = torch.softmax(scores, dim=-1)
+    return torch.einsum("hqk,hkd->hqd", probs, v.float())
+
+
+def _flash_impl(window: int | None) -> FlashAttnV100Impl:
+    impl = object.__new__(FlashAttnV100Impl)
+    object.__setattr__(impl, "prefix_anchored_decode_window", window)
+    object.__setattr__(impl, "attn_type", AttentionType.DECODER)
+    object.__setattr__(impl, "kv_cache_dtype", "auto")
+    return impl
+
+
+@pytest.mark.cpu_test
+def test_backend_default_off_does_not_inspect_metadata():
+    class NoMetadataAccess:
+        def __getattr__(self, name: str):
+            raise AssertionError(f"default-off path inspected {name}")
+
+    metadata = cast(Any, NoMetadataAccess())
+    assert _flash_impl(None)._anchored_swa_params(metadata) == (None, 0)
+
+
+@pytest.mark.cpu_test
+def test_backend_enabled_fails_closed_without_matching_metadata():
+    with pytest.raises(RuntimeError, match="metadata does not match"):
+        _flash_impl(128)._anchored_swa_params(cast(Any, object()))
+
+
+@pytest.mark.cpu_test
+def test_metadata_builder_attaches_prefix_lengths_for_eager_path():
+    builder = object.__new__(FlashAttnV100MetadataBuilder)
+    object.__setattr__(builder, "decode_sliding_window", 128)
+    object.__setattr__(builder, "device", torch.device("cpu"))
+    object.__setattr__(
+        builder,
+        "persistent_prefix_anchor_lens",
+        torch.empty(4, dtype=torch.int32),
+    )
+    metadata = SimpleNamespace()
+    common = SimpleNamespace(
+        prefix_anchor_lens=torch.tensor([7, 11], dtype=torch.int64),
+        num_reqs=2,
+    )
+
+    builder._attach_prefix_anchored_metadata(
+        cast(Any, metadata),
+        cast(Any, common),
+    )
+
+    assert metadata.decode_sliding_window == 128
+    assert metadata.prefix_anchor_lens.dtype == torch.int32
+    assert metadata.prefix_anchor_lens.tolist() == [7, 11]
+
+
+@pytest.mark.cpu_test
+def test_metadata_builder_fails_closed_without_prefix_lengths():
+    builder = object.__new__(FlashAttnV100MetadataBuilder)
+    object.__setattr__(builder, "decode_sliding_window", 128)
+    object.__setattr__(builder, "device", torch.device("cpu"))
+    object.__setattr__(
+        builder,
+        "persistent_prefix_anchor_lens",
+        torch.empty(4, dtype=torch.int32),
+    )
+
+    with pytest.raises(RuntimeError, match="requires per-request prefix lengths"):
+        builder._attach_prefix_anchored_metadata(
+            cast(Any, SimpleNamespace()),
+            cast(Any, SimpleNamespace(prefix_anchor_lens=None, num_reqs=2)),
+        )
+
+
+@pytest.mark.cpu_test
+def test_mask_equals_causal_while_within_window():
+    # While the number of generated tokens is <= window, no key falls in the
+    # gap, so the mask must be exactly the causal mask.
+    anchor, window = 6, 8
+    for seq_len in range(1, anchor + window + 1):
+        assert torch.equal(
+            anchored_swa_mask(seq_len, anchor, window),
+            causal_mask(seq_len),
+        ), f"seq_len={seq_len}"
+
+
+@pytest.mark.cpu_test
+def test_mask_prunes_gap_beyond_window():
+    anchor, window = 6, 8
+    seq_len = anchor + window + 3  # 3 generated keys fall out of the window
+    mask = anchored_swa_mask(seq_len, anchor, window)
+    causal = causal_mask(seq_len)
+    assert not torch.equal(mask, causal)
+    # The last query keeps: the full prefix and the window of recent keys...
+    last = mask[-1]
+    assert last[:anchor].all(), "prefix must stay globally visible"
+    assert last[seq_len - window :].all(), "recent window must be visible"
+    # ...and drops exactly the gap keys in between.
+    gap = last[anchor : seq_len - window]
+    assert not gap.any(), "gap keys must be masked"
+    # Prefix queries (inside the prompt) are never affected.
+    assert torch.equal(mask[: anchor + window], causal[: anchor + window])
+
+
+@pytest.mark.cpu_test
+def test_attention_output_equivalence_and_divergence():
+    torch.manual_seed(0)
+    heads, dim = 2, 32
+    anchor, window = 6, 8
+
+    # Within the window: identical outputs.
+    seq_len = anchor + window
+    q, k, v = (torch.randn(heads, seq_len, dim) for _ in range(3))
+    out_anchored = ref_attention(q, k, v, anchored_swa_mask(seq_len, anchor, window))
+    out_causal = ref_attention(q, k, v, causal_mask(seq_len))
+    torch.testing.assert_close(out_anchored, out_causal)
+
+    # Beyond the window: the late queries must diverge from full attention
+    # (negative control proving the mask actually removes information).
+    seq_len = anchor + 2 * window
+    q, k, v = (torch.randn(heads, seq_len, dim) for _ in range(3))
+    out_anchored = ref_attention(q, k, v, anchored_swa_mask(seq_len, anchor, window))
+    out_causal = ref_attention(q, k, v, causal_mask(seq_len))
+    assert not torch.allclose(out_anchored[:, -1], out_causal[:, -1])
+    # Queries that see no gap still match exactly.
+    torch.testing.assert_close(
+        out_anchored[:, : anchor + window], out_causal[:, : anchor + window]
+    )

--- a/tests/v1/core/test_single_type_kv_cache_manager.py
+++ b/tests/v1/core/test_single_type_kv_cache_manager.py
@@ -14,9 +14,14 @@ from vllm.v1.core.kv_cache_utils import (
 )
 from vllm.v1.core.single_type_kv_cache_manager import (
     ChunkedLocalAttentionManager,
+    PrefixAnchoredSWAManager,
     SlidingWindowManager,
 )
-from vllm.v1.kv_cache_interface import ChunkedLocalAttentionSpec, SlidingWindowSpec
+from vllm.v1.kv_cache_interface import (
+    ChunkedLocalAttentionSpec,
+    PrefixAnchoredSWASpec,
+    SlidingWindowSpec,
+)
 
 pytestmark = pytest.mark.cpu_test
 
@@ -481,3 +486,103 @@ def test_predictor_matches_allocator_blocks_calculation_with_admission_cap():
             f"but allocator pulled {len(new_blocks)}"
         )
         total_computed = num_tokens
+
+
+def test_prefix_anchored_swa_remove_skipped_blocks_gap_range():
+    block_size = 4
+    spec = PrefixAnchoredSWASpec(
+        block_size=block_size,
+        num_kv_heads=1,
+        head_size=1,
+        dtype=torch.float32,
+        decode_sliding_window=8,
+    )
+    block_pool = BlockPool(
+        num_gpu_blocks=2000, enable_caching=True, hash_block_size=block_size
+    )
+    manager = PrefixAnchoredSWAManager(
+        spec,
+        block_pool=block_pool,
+        enable_caching=True,
+        kv_cache_group_id=0,
+    )
+
+    null_block_id = block_pool.null_block.block_id
+    original_block_ids = list(range(1000, 1010))
+    block_table = [KVCacheBlock(id_) for id_ in original_block_ids]
+    manager.req_to_blocks["test"] = block_table
+
+    prefix_len = 16
+
+    # Without num_prompt_tokens, gap blocks are not evicted (full-attention
+    # default path).
+    manager.remove_skipped_blocks("test", 28)
+    assert [b.block_id for b in block_table] == original_block_ids
+
+    # Gap = block 4 only (tokens [16, 20) fall in the gap).
+    manager.remove_skipped_blocks("test", 28, num_prompt_tokens=prefix_len)
+    expected = original_block_ids.copy()
+    expected[4] = null_block_id
+    assert [b.block_id for b in block_table] == expected
+
+    # Window moves: blocks 5 and 6 also enter the gap; block 4 is already
+    # null and stays null.
+    manager.remove_skipped_blocks("test", 36, num_prompt_tokens=prefix_len)
+    expected[5] = null_block_id
+    expected[6] = null_block_id
+    assert [b.block_id for b in block_table] == expected
+
+    # Blocks holding the prefix and the live decode window are never touched.
+    assert [b.block_id for b in block_table[:4]] == original_block_ids[:4]
+    assert [b.block_id for b in block_table[7:]] == original_block_ids[7:]
+
+
+def test_prefix_anchored_swa_spec_merge():
+    def make_spec(window: int) -> PrefixAnchoredSWASpec:
+        return PrefixAnchoredSWASpec(
+            block_size=16,
+            num_kv_heads=2,
+            head_size=64,
+            dtype=torch.float16,
+            decode_sliding_window=window,
+        )
+
+    merged = PrefixAnchoredSWASpec.merge([make_spec(128), make_spec(128)])
+    assert isinstance(merged, PrefixAnchoredSWASpec)
+    assert merged.decode_sliding_window == 128
+    assert merged.block_size == 16
+    assert merged.num_kv_heads == 2
+    assert merged.head_size == 64
+    assert merged.head_size_v == 64
+    assert merged.dtype == torch.float16
+
+    with pytest.raises(AssertionError):
+        PrefixAnchoredSWASpec.merge([make_spec(128), make_spec(64)])
+
+
+def test_prefix_anchored_swa_manager_registered():
+    from vllm.v1.core.single_type_kv_cache_manager import (
+        get_manager_for_kv_cache_spec,
+        spec_manager_map,
+    )
+
+    assert spec_manager_map[PrefixAnchoredSWASpec] is PrefixAnchoredSWAManager
+
+    spec = PrefixAnchoredSWASpec(
+        block_size=16,
+        num_kv_heads=1,
+        head_size=64,
+        dtype=torch.float16,
+        decode_sliding_window=128,
+    )
+    block_pool = BlockPool(num_gpu_blocks=100, enable_caching=False, hash_block_size=16)
+    manager = get_manager_for_kv_cache_spec(
+        spec,
+        max_num_batched_tokens=1024,
+        max_model_len=4096,
+        block_pool=block_pool,
+        enable_caching=False,
+        kv_cache_group_id=0,
+    )
+    assert isinstance(manager, PrefixAnchoredSWAManager)
+    assert manager.decode_sliding_window == 128

--- a/vllm/config/attention.py
+++ b/vllm/config/attention.py
@@ -3,7 +3,7 @@
 
 from typing import Any, Literal
 
-from pydantic import field_validator
+from pydantic import Field, field_validator
 
 from vllm.config.utils import config
 from vllm.v1.attention.backends.mla.prefill.registry import MLAPrefillBackendEnum
@@ -52,6 +52,12 @@ class AttentionConfig:
 
     use_non_causal: bool = False
     """Whether to use non-causal (bidirectional) attention."""
+
+    prefix_anchored_decode_window: int | None = Field(default=None, gt=0, le=2**31 - 1)
+    """Bound generated-token KV to this sliding window while keeping the
+    request prefix globally visible. This is an explicit, model-agnostic
+    engine option. It is currently supported only by the SM70
+    ``FLASH_ATTN_V100`` fp16 causal path. ``None`` disables it."""
 
     flex_attn_block_m: int | None = None
     """Triton kernel BLOCK_M tile size for flex attention.

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -230,6 +230,81 @@ def enable_mla_dual_rms_norm_fusion(cfg: "VllmConfig") -> bool:
     return rocm_aiter_ops.is_enabled() and check_aiter_fused_qk_rmsnorm()
 
 
+def apply_prefix_anchored_swa_constraints(cfg: "VllmConfig") -> None:
+    """Validate the model-agnostic prefix-anchored SWA engine contract."""
+    window = cfg.attention_config.prefix_anchored_decode_window
+    if window is None:
+        return
+
+    from vllm.platforms import current_platform
+    from vllm.v1.attention.backends.registry import AttentionBackendEnum
+
+    if not (
+        current_platform.is_cuda() and current_platform.is_device_capability((7, 0))
+    ):
+        raise ValueError("prefix_anchored_decode_window requires an NVIDIA SM70 GPU")
+
+    model_config = cfg.model_config
+    if model_config is None:
+        raise ValueError("prefix_anchored_decode_window requires a model config")
+    if model_config.use_mla:
+        raise ValueError("prefix_anchored_decode_window does not support MLA attention")
+    if cfg.attention_config.use_non_causal:
+        raise ValueError(
+            "prefix_anchored_decode_window requires causal decoder attention"
+        )
+
+    cache_dtype = cfg.cache_config.cache_dtype
+    effective_cache_dtype = model_config.dtype if cache_dtype == "auto" else cache_dtype
+    if effective_cache_dtype not in (torch.float16, "float16"):
+        raise ValueError(
+            "prefix_anchored_decode_window requires an fp16 KV cache; "
+            f"got cache_dtype={cache_dtype!r} and model dtype={model_config.dtype}"
+        )
+
+    parallel_config = cfg.parallel_config
+    if (
+        parallel_config.decode_context_parallel_size != 1
+        or parallel_config.prefill_context_parallel_size != 1
+    ):
+        raise ValueError(
+            "prefix_anchored_decode_window does not support decode or prefill "
+            "context parallelism"
+        )
+    if cfg.cache_config.kv_offloading_size is not None:
+        raise ValueError(
+            "prefix_anchored_decode_window does not support KV-cache offloading"
+        )
+    if (
+        cfg.kv_transfer_config is not None
+        and cfg.kv_transfer_config.kv_connector is not None
+    ):
+        raise ValueError("prefix_anchored_decode_window does not support KV connectors")
+    if cfg.speculative_config is not None:
+        raise ValueError(
+            "prefix_anchored_decode_window does not yet support speculative decoding"
+        )
+
+    backend = cfg.attention_config.backend
+    if backend is None:
+        cfg.attention_config.backend = AttentionBackendEnum.FLASH_ATTN_V100
+        logger.info(
+            "Prefix-anchored sliding-window attention: auto-selecting the "
+            "FLASH_ATTN_V100 backend."
+        )
+    elif backend != AttentionBackendEnum.FLASH_ATTN_V100:
+        raise ValueError(
+            "prefix_anchored_decode_window requires FLASH_ATTN_V100; "
+            f"got {backend.name}"
+        )
+    if cfg.cache_config.enable_prefix_caching:
+        cfg.cache_config.enable_prefix_caching = False
+        logger.info(
+            "Prefix-anchored sliding-window attention: disabling prefix "
+            "caching (windowed decode KV is not reusable across requests)."
+        )
+
+
 OPTIMIZATION_LEVEL_00 = {
     "compilation_config": {
         "pass_config": {
@@ -964,6 +1039,8 @@ class VllmConfig:
 
         if self.lora_config is not None:
             self.lora_config.verify_with_model_config(self.model_config)
+
+        apply_prefix_anchored_swa_constraints(self)
 
         if (
             self.mamba_config.enable_stochastic_rounding
@@ -1771,6 +1848,22 @@ class VllmConfig:
                     self.compilation_config.cudagraph_mode = (
                         CUDAGraphMode.FULL_DECODE_ONLY
                     )
+
+            # Prefix-anchored sliding-window attention: full-graph capture
+            # bakes attention metadata that carries no per-request anchor
+            # lengths, so the anchored decode-window mask cannot run inside a
+            # full cudagraph. Piecewise graphs keep attention outside capture.
+            if (
+                self.attention_config.prefix_anchored_decode_window is not None
+                and self.compilation_config.cudagraph_mode.has_full_cudagraphs()
+            ):
+                logger.info(
+                    "Prefix-anchored sliding-window attention does not "
+                    "support full cudagraphs. Overriding cudagraph_mode "
+                    "from %s to PIECEWISE.",
+                    self.compilation_config.cudagraph_mode.name,
+                )
+                self.compilation_config.cudagraph_mode = CUDAGraphMode.PIECEWISE
 
             # Check if KV connector requires PIECEWISE mode for CUDA graphs
             if (

--- a/vllm/model_executor/layers/attention/attention.py
+++ b/vllm/model_executor/layers/attention/attention.py
@@ -41,6 +41,8 @@ from vllm.v1.attention.selector import get_attn_backend
 from vllm.v1.kv_cache_interface import (
     FullAttentionSpec,
     KVCacheSpec,
+    KVQuantMode,
+    PrefixAnchoredSWASpec,
     SlidingWindowSpec,
     get_kv_quant_mode,
 )
@@ -372,6 +374,42 @@ class Attention(nn.Module, AttentionLayerBase):
                 f"but got {self.attn_backend.get_name()}."
             )
 
+        prefix_anchored_decode_window = getattr(
+            vllm_config.attention_config,
+            "prefix_anchored_decode_window",
+            None,
+        )
+        if (
+            prefix_anchored_decode_window is not None
+            and attn_type == AttentionType.DECODER
+        ):
+            if self.attn_backend.get_name() != "FLASH_ATTN_V100":
+                raise ValueError(
+                    "prefix-anchored SWA requires standard full decoder "
+                    "attention on FLASH_ATTN_V100"
+                )
+            if self.sliding_window is not None:
+                raise ValueError(
+                    "prefix-anchored SWA cannot be combined with per-layer "
+                    "sliding-window attention"
+                )
+            if (
+                get_kv_quant_mode(self.kv_cache_dtype) != KVQuantMode.NONE
+                or self.kv_cache_torch_dtype != torch.float16
+            ):
+                raise ValueError("prefix-anchored SWA requires an fp16 KV cache")
+            if self.head_size_v != self.head_size:
+                raise ValueError(
+                    "prefix-anchored SWA requires identical key/value head sizes"
+                )
+            if self.has_sink:
+                raise ValueError(
+                    "prefix-anchored SWA cannot be combined with attention sinks"
+                )
+            extra_impl_args["prefix_anchored_decode_window"] = (
+                prefix_anchored_decode_window
+            )
+
         if self.attn_backend.get_name() == "FLEX_ATTENTION":
             block_m = vllm_config.attention_config.flex_attn_block_m
             block_n = vllm_config.attention_config.flex_attn_block_n
@@ -601,6 +639,45 @@ class Attention(nn.Module, AttentionLayerBase):
         # Should not be called for enc-dec or encoder-only attention.
         assert self.attn_type == AttentionType.DECODER
         quant_mode = get_kv_quant_mode(self.kv_cache_dtype)
+        anchored_window = getattr(
+            vllm_config.attention_config,
+            "prefix_anchored_decode_window",
+            None,
+        )
+        if anchored_window is not None:
+            if self.attn_backend.get_name() != "FLASH_ATTN_V100":
+                raise ValueError(
+                    "prefix-anchored SWA requires the FLASH_ATTN_V100 backend"
+                )
+            if self.sliding_window is not None:
+                raise ValueError(
+                    "prefix-anchored SWA cannot be combined with per-layer "
+                    "sliding-window attention"
+                )
+            if (
+                quant_mode != KVQuantMode.NONE
+                or self.kv_cache_torch_dtype != torch.float16
+            ):
+                raise ValueError("prefix-anchored SWA requires an fp16 KV cache")
+            if self.kv_cache_dtype.startswith("turboquant_"):
+                raise ValueError("prefix-anchored SWA does not support TurboQuant KV")
+            if self.head_size_v != self.head_size:
+                raise ValueError(
+                    "prefix-anchored SWA requires identical key/value head sizes"
+                )
+            if self.has_sink:
+                raise ValueError(
+                    "prefix-anchored SWA cannot be combined with attention sinks"
+                )
+            return PrefixAnchoredSWASpec(
+                block_size=block_size,
+                num_kv_heads=self.num_kv_heads,
+                head_size=self.head_size,
+                head_size_v=self.head_size_v,
+                dtype=self.kv_cache_torch_dtype,
+                kv_quant_mode=quant_mode,
+                decode_sliding_window=anchored_window,
+            )
         if self.sliding_window is not None:
             assert not vllm_config.model_config.use_mla, (
                 "MLA is not supported for slidingwindow"

--- a/vllm/v1/attention/backend.py
+++ b/vllm/v1/attention/backend.py
@@ -419,6 +419,14 @@ class CommonAttentionMetadata:
     decode rows (assumes every draft was accepted). Not safe for kernels
     that need exact per-row context lengths on decode rows."""
 
+    prefix_anchor_lens: torch.Tensor | None = None
+    """(batch_size,) per-request prefix length (prompt token count) for
+    prefix-anchored sliding-window attention. Tokens with logical index below
+    this stay globally visible; later (generated) tokens additionally see a
+    fixed sliding window. None disables the mechanism. The attention backend
+    copies this into its own persistent buffer and reads the window size from
+    the cache group's ``PrefixAnchoredSWASpec``."""
+
     # WARNING: Deprecated fields. Will be removed in a future release (v0.15.0)
     _seq_lens_cpu: torch.Tensor | None = None
     _num_computed_tokens_cpu: torch.Tensor | None = None
@@ -527,6 +535,7 @@ class CommonAttentionMetadata:
             dcp_local_seq_lens=maybe_slice_reqs(self.dcp_local_seq_lens),
             dcp_local_seq_lens_cpu=maybe_slice_reqs(self.dcp_local_seq_lens_cpu),
             is_prefilling=maybe_slice_reqs(self.is_prefilling),
+            prefix_anchor_lens=maybe_slice_reqs(self.prefix_anchor_lens),
         )
 
 

--- a/vllm/v1/attention/backends/flash_attn_v100.py
+++ b/vllm/v1/attention/backends/flash_attn_v100.py
@@ -34,6 +34,7 @@ from vllm.v1.attention.backends.triton_attn import (
     TritonAttentionMetadata,
     TritonAttentionMetadataBuilder,
 )
+from vllm.v1.kv_cache_interface import PrefixAnchoredSWASpec
 from vllm.v1.worker.gpu.spec_decode import uses_dflash_selector_engine
 
 logger = init_logger(__name__)
@@ -433,6 +434,8 @@ class FlashAttnV100Metadata(TritonAttentionMetadata):
     flash_v100_cudagraph_capture: bool
     flash_v100_batch_context_routing: bool
     flash_v100_contig_dense_cache: dict[tuple[int, int, int, int, int], int]
+    prefix_anchor_lens: torch.Tensor | None = None
+    decode_sliding_window: int | None = None
     flash_v100_decode_max_seq_len_hint: int | None
     flash_v100_decode_workspace_seq_capacity_hint: int | None
     flash_v100_static_decode_seq_hint: int | None
@@ -2954,6 +2957,21 @@ class FlashAttnV100MetadataBuilder(TritonAttentionMetadataBuilder):
             )
         self._draft_block_table: torch.Tensor | None = None
         self._draft_seq_lens: torch.Tensor | None = None
+        # Prefix-anchored SWA: persistent per-request prompt-length buffer so
+        # the device address stays stable across steps.
+        kv_cache_spec = self.kv_cache_spec
+        self.decode_sliding_window = (
+            kv_cache_spec.decode_sliding_window
+            if isinstance(kv_cache_spec, PrefixAnchoredSWASpec)
+            else None
+        )
+        self.persistent_prefix_anchor_lens: torch.Tensor | None = None
+        if self.decode_sliding_window is not None:
+            self.persistent_prefix_anchor_lens = torch.empty(
+                self.vllm_config.scheduler_config.max_num_seqs,
+                dtype=torch.int32,
+                device=self.device,
+            )
         self._draft_query_start_loc: torch.Tensor | None = None
         self._flash_draft_buffer_shape: tuple[int, int] | None = None
         self._smallq_decode_block_table: torch.Tensor | None = None
@@ -2962,6 +2980,40 @@ class FlashAttnV100MetadataBuilder(TritonAttentionMetadataBuilder):
         self._smallq_token_indices: torch.Tensor | None = None
         self._smallq_buffer_shape: tuple[int, int, int] | None = None
         self._decode_active_num_partitions: torch.Tensor | None = None
+
+    def _attach_prefix_anchored_metadata(
+        self,
+        attn_metadata: TritonAttentionMetadata,
+        common_attn_metadata,
+    ) -> None:
+        window = self.decode_sliding_window
+        if window is None:
+            return
+
+        prefix_anchor_lens = common_attn_metadata.prefix_anchor_lens
+        if prefix_anchor_lens is None:
+            raise RuntimeError(
+                "prefix-anchored SWA requires per-request prefix lengths"
+            )
+        assert self.persistent_prefix_anchor_lens is not None
+        anchor_reqs = common_attn_metadata.num_reqs
+        if prefix_anchor_lens.ndim != 1 or prefix_anchor_lens.numel() < anchor_reqs:
+            raise RuntimeError(
+                "prefix-anchored SWA prefix lengths must have shape [num_reqs]"
+            )
+        if anchor_reqs > self.persistent_prefix_anchor_lens.numel():
+            raise RuntimeError(
+                "prefix-anchored SWA request count exceeds metadata capacity"
+            )
+
+        prefix_anchor_lens = prefix_anchor_lens.to(
+            device=self.device, dtype=torch.int32, non_blocking=True
+        )
+        persistent_anchor_lens = self.persistent_prefix_anchor_lens[:anchor_reqs]
+        persistent_anchor_lens.copy_(prefix_anchor_lens[:anchor_reqs])
+        flash_metadata = _as_flash_v100_metadata(attn_metadata)
+        flash_metadata.prefix_anchor_lens = persistent_anchor_lens
+        flash_metadata.decode_sliding_window = window
 
     def _attach_common_flash_metadata(
         self,
@@ -3726,6 +3778,7 @@ class FlashAttnV100MetadataBuilder(TritonAttentionMetadataBuilder):
         attn_metadata = super().build_for_cudagraph_capture(common_attn_metadata)
         self._attach_common_flash_metadata(attn_metadata, common_attn_metadata)
         flash_metadata = _as_flash_v100_metadata(attn_metadata)
+        self._attach_prefix_anchored_metadata(attn_metadata, common_attn_metadata)
         flash_metadata.seq_lens_cpu = capture_seq_lens_cpu
 
         # The Triton builder shortens capture seq_lens to 1 so full graph
@@ -3793,6 +3846,7 @@ class FlashAttnV100MetadataBuilder(TritonAttentionMetadataBuilder):
             common_prefix_len, common_attn_metadata, fast_build
         )
         self._attach_common_flash_metadata(attn_metadata, common_attn_metadata)
+        self._attach_prefix_anchored_metadata(attn_metadata, common_attn_metadata)
         self._attach_ddtree_metadata(
             attn_metadata,
             ddtree_parent_ids=ddtree_parent_ids,
@@ -4110,6 +4164,9 @@ class FlashAttnV100Impl(TritonAttentionImpl):
     """Flash Attention V100 implementation with explicit fallback policy."""
 
     def __init__(self, *args, **kwargs):
+        self.prefix_anchored_decode_window = kwargs.pop(
+            "prefix_anchored_decode_window", None
+        )
         super().__init__(*args, **kwargs)
         self.kv_cache_dtype = _normalize_flash_v100_kv_cache_dtype(self.kv_cache_dtype)
         _log_kv_dtype_contract(self.kv_cache_dtype)
@@ -4139,10 +4196,16 @@ class FlashAttnV100Impl(TritonAttentionImpl):
                 "workspace_seq_capacity_hint",
                 "active_num_partitions",
                 "partition_size_hint",
+                "anchor_lens",
+                "anchored_window",
             )
             if self.flash_attn_decode_paged is not None
             and _callable_accepts_keyword(self.flash_attn_decode_paged, name)
         }
+        self._flash_prefill_paged_supports_anchor = (
+            self.flash_attn_prefill_paged is not None
+            and _callable_accepts_keyword(self.flash_attn_prefill_paged, "anchor_lens")
+        )
         paged_prefill_enable = os.getenv("VLLM_FLASH_V100_ENABLE_PAGED_PREFILL")
         paged_prefill_disable = (
             os.getenv("VLLM_FLASH_V100_DISABLE_PAGED_PREFILL", "0") == "1"
@@ -4273,6 +4336,52 @@ class FlashAttnV100Impl(TritonAttentionImpl):
         self._decode_cache_v: torch.Tensor | None = None
         self._decode_cache_len = 0
         self._decode_cache_capacity = 0
+
+        if self.prefix_anchored_decode_window is not None:
+            if (
+                self.prefix_anchored_decode_window <= 0
+                or self.attn_type != AttentionType.DECODER
+                or self.kv_cache_dtype != "auto"
+            ):
+                raise ValueError(
+                    "prefix-anchored SWA requires a positive window, causal "
+                    "decoder attention, and an fp16 KV cache"
+                )
+            if self.use_triton_prefill:
+                raise ValueError(
+                    "prefix-anchored SWA cannot use the Triton prefill fallback"
+                )
+            if (
+                not self.use_flash_v100_decode
+                or not self.use_decode_scalar_paged
+                or not {"anchor_lens", "anchored_window"}
+                <= self._flash_decode_paged_kwargs
+            ):
+                raise RuntimeError(
+                    "prefix-anchored SWA requires the masked scalar paged "
+                    "decode extension"
+                )
+            if (
+                not self.use_flash_v100_prefill_paged
+                or not self._flash_prefill_paged_supports_anchor
+            ):
+                raise RuntimeError(
+                    "prefix-anchored SWA requires the masked paged prefill extension"
+                )
+
+            # Select the only two routes that carry the anchored mask once at
+            # construction time. The default-off hot path therefore retains
+            # its existing route predicates without extra metadata parsing.
+            self.smallq_decode_max_query_len = 0
+            self.use_decode_paged_prefill = False
+            self.use_decode_dense_cache = False
+            self.use_decode_dense_reference = False
+            self.use_decode_xqa = False
+            self.use_smallq_decode_xqa = False
+            self.use_flash_v100_prefill_splitkv = False
+            self.use_flash_v100_prefill_bfla = False
+            self.use_flash_v100_prefill_contig_dense = False
+            self.use_flash_v100_prefill_gather_dense = False
 
     def _reset_decode_cache(self) -> None:
         self._decode_cache_k = None
@@ -4846,6 +4955,8 @@ class FlashAttnV100Impl(TritonAttentionImpl):
         workspace_seq_capacity_hint: int | None = None,
         active_num_partitions: int | None = None,
         partition_size_hint: int | None = None,
+        anchor_lens: torch.Tensor | None = None,
+        anchored_window: int = 0,
     ) -> None:
         kwargs: dict[str, object] = {
             "softmax_scale": softmax_scale,
@@ -4861,6 +4972,15 @@ class FlashAttnV100Impl(TritonAttentionImpl):
                 "FLASH_ATTN_V100 decode op does not support sliding-window "
                 "attention with this extension build."
             )
+        if anchor_lens is not None and anchored_window > 0:
+            if "anchor_lens" not in self._flash_decode_paged_kwargs:
+                raise RuntimeError(
+                    "FLASH_ATTN_V100 decode op does not support the anchored "
+                    "decode-window mask with this extension build; rebuild "
+                    "flash_attn_v100."
+                )
+            kwargs["anchor_lens"] = anchor_lens
+            kwargs["anchored_window"] = anchored_window
         optional_kwargs = {
             "max_seq_len_hint": max_seq_len_hint,
             "workspace_seq_capacity_hint": workspace_seq_capacity_hint,
@@ -5142,6 +5262,34 @@ class FlashAttnV100Impl(TritonAttentionImpl):
         )
         _record_route("prefill_smallq_decode_scalar")
 
+    def _anchored_swa_params(
+        self,
+        attn_metadata: TritonAttentionMetadata,
+    ) -> tuple[torch.Tensor | None, int]:
+        """Anchored decode-window mask parameters, when active.
+
+        Returns ``(prefix_anchor_lens, decode_sliding_window)`` when this
+        decoder cache group carries the engine's prefix-anchored spec and
+        per-request prompt lengths; otherwise ``(None, 0)``.
+        """
+        window = self.prefix_anchored_decode_window
+        if window is None:
+            return None, 0
+
+        metadata_window = getattr(attn_metadata, "decode_sliding_window", None)
+        anchor_lens = getattr(attn_metadata, "prefix_anchor_lens", None)
+        if (
+            self.attn_type != AttentionType.DECODER
+            or self.kv_cache_dtype != "auto"
+            or metadata_window != window
+            or anchor_lens is None
+        ):
+            raise RuntimeError(
+                "FLASH_ATTN_V100 prefix-anchored SWA metadata does not match "
+                "the enabled decoder-layer contract"
+            )
+        return anchor_lens, int(window)
+
     def _small_query_decode_enabled(
         self,
         attn_metadata: TritonAttentionMetadata,
@@ -5152,7 +5300,6 @@ class FlashAttnV100Impl(TritonAttentionImpl):
             or self.smallq_decode_max_query_len <= 0
         ):
             return False
-
         query_start_loc_cpu = getattr(attn_metadata, "query_start_loc_cpu", None)
         query_start_loc = (
             query_start_loc_cpu
@@ -6202,6 +6349,10 @@ class FlashAttnV100Impl(TritonAttentionImpl):
     ) -> torch.Tensor:
         """Decode path using Flash V100 directly over paged KV cache."""
         window_size = self._flash_v100_window_size(causal=True)
+        if self.prefix_anchored_decode_window is None:
+            anchor_lens, anchored_window = None, 0
+        else:
+            anchor_lens, anchored_window = self._anchored_swa_params(attn_metadata)
         num_actual_tokens = attn_metadata.num_actual_tokens
         query = query[:num_actual_tokens]
         out_view = output[:num_actual_tokens]
@@ -6348,6 +6499,8 @@ class FlashAttnV100Impl(TritonAttentionImpl):
                 "flash_v100_decode_active_num_partitions",
                 None,
             ),
+            anchor_lens=anchor_lens,
+            anchored_window=anchored_window,
         )
         _record_route("decode_scalar_paged")
         return output
@@ -7235,6 +7388,25 @@ class FlashAttnV100Impl(TritonAttentionImpl):
         global _logged_prefill_compare, _logged_prefill_smallq_decode
         causal = getattr(attn_metadata, "causal", True)
         window_size = self._flash_v100_window_size(causal)
+        if self.prefix_anchored_decode_window is None:
+            anchor_lens, anchored_window = None, 0
+        else:
+            anchor_lens, anchored_window = self._anchored_swa_params(attn_metadata)
+        if anchor_lens is not None:
+            # Fail closed: with the anchored decode-window mask active the
+            # KV cache manager evicts gap blocks, so running any unmasked
+            # prefill route would silently produce wrong output.
+            if not self.use_flash_v100_prefill_paged:
+                raise RuntimeError(
+                    "FLASH_ATTN_V100 anchored decode-window mask requires "
+                    "the paged prefill kernel; it is disabled or unavailable."
+                )
+            if not self._flash_prefill_paged_supports_anchor:
+                raise RuntimeError(
+                    "FLASH_ATTN_V100 prefill op does not support the "
+                    "anchored decode-window mask with this extension build; "
+                    "rebuild flash_attn_v100."
+                )
         num_actual_tokens = attn_metadata.num_actual_tokens
         query = query[:num_actual_tokens]
         out_view = output[:num_actual_tokens]
@@ -7270,6 +7442,11 @@ class FlashAttnV100Impl(TritonAttentionImpl):
             attn_metadata,
             query_start_loc,
         ):
+            if anchor_lens is not None:
+                raise RuntimeError(
+                    "FLASH_ATTN_V100 anchored decode-window mask does not "
+                    "support ddtree drafting metadata."
+                )
             return self._flash_v100_ddtree_small_query_prefill_dense(
                 layer,
                 query,
@@ -7285,6 +7462,7 @@ class FlashAttnV100Impl(TritonAttentionImpl):
 
         if (
             causal
+            and anchor_lens is None
             and self.use_flash_v100_decode
             and self.smallq_decode_max_query_len > 0
             and max_query_len <= self.smallq_decode_max_query_len
@@ -7324,6 +7502,36 @@ class FlashAttnV100Impl(TritonAttentionImpl):
                 q_len = end - start
                 seq_len = int(seq_lens[i].item())
                 q_seq = query[start:end].unsqueeze(0)
+                if anchor_lens is not None:
+                    # Anchored decode-window mask: single masked paged
+                    # prefill route; every unmasked fast path is bypassed.
+                    _record_route("prefill_prefix_paged_anchored")
+                    out_seq = self._run_prefill_paged_call(
+                        route="prefill_prefix_paged_anchored",
+                        q_len=q_len,
+                        seq_len=seq_len,
+                        heads_q=query.shape[1],
+                        heads_kv=num_kv_heads,
+                        head_dim=head_dim,
+                        block_size=block_size,
+                        fn=lambda q_seq=q_seq, i=i: self.flash_attn_prefill_paged(  # type: ignore[misc]
+                            q_seq,
+                            key_cache,
+                            value_cache,
+                            attn_metadata.block_table[i : i + 1],
+                            attn_metadata.seq_lens[i : i + 1],
+                            softmax_scale=self.scale,
+                            kv_cache_dtype=self.kv_cache_dtype,
+                            k_scale=float(layer._k_scale_float),
+                            v_scale=float(layer._v_scale_float),
+                            causal=causal,
+                            window_size=window_size,
+                            anchor_lens=anchor_lens[i : i + 1],
+                            anchored_window=anchored_window,
+                        ),
+                    )
+                    out_view[start:end].copy_(out_seq.squeeze(0))
+                    continue
                 bfla_block_mask = None
                 use_bfla = self._should_use_prefill_bfla(
                     q_len=q_len,

--- a/vllm/v1/core/kv_cache_coordinator.py
+++ b/vllm/v1/core/kv_cache_coordinator.py
@@ -236,7 +236,10 @@ class KVCacheCoordinator(ABC):
         ]
 
     def remove_skipped_blocks(
-        self, request_id: str, total_computed_tokens: int
+        self,
+        request_id: str,
+        total_computed_tokens: int,
+        num_prompt_tokens: int | None = None,
     ) -> None:
         """
         Remove the blocks that are no longer needed from `blocks` and replace
@@ -246,9 +249,14 @@ class KVCacheCoordinator(ABC):
             request_id: The request ID.
             total_computed_tokens: The total number of computed tokens, including
                 local computed tokens and external computed tokens.
+            num_prompt_tokens: Optional prompt length. Prefix-anchored SWA
+                managers use this to free gap blocks between the prefill tail
+                and the decode window; other manager types ignore it.
         """
         for manager in self.single_type_managers:
-            manager.remove_skipped_blocks(request_id, total_computed_tokens)
+            manager.remove_skipped_blocks(
+                request_id, total_computed_tokens, num_prompt_tokens
+            )
 
     def get_blocks(self, request_id: str) -> tuple[list[KVCacheBlock], ...]:
         """

--- a/vllm/v1/core/kv_cache_manager.py
+++ b/vllm/v1/core/kv_cache_manager.py
@@ -375,7 +375,9 @@ class KVCacheManager:
         # Should call this function before allocating new blocks to reduce
         # the number of evicted blocks.
         self.coordinator.remove_skipped_blocks(
-            request.request_id, total_computed_tokens
+            request.request_id,
+            total_computed_tokens,
+            num_prompt_tokens=request.num_prompt_tokens,
         )
 
         num_blocks_to_allocate = self.coordinator.get_num_blocks_to_allocate(
@@ -441,7 +443,10 @@ class KVCacheManager:
         self.coordinator.free(request.request_id)
 
     def remove_skipped_blocks(
-        self, request_id: str, total_computed_tokens: int
+        self,
+        request_id: str,
+        total_computed_tokens: int,
+        num_prompt_tokens: int | None = None,
     ) -> None:
         """Remove the blocks that are no longer needed from `blocks` and replace
         the removed blocks with null_block.
@@ -450,8 +455,12 @@ class KVCacheManager:
             request_id: The request ID.
             total_computed_tokens: The total number of computed tokens, including
                 local computed tokens and external computed tokens.
+            num_prompt_tokens: Optional prompt length for prefix-anchored SWA
+                gap eviction.
         """
-        self.coordinator.remove_skipped_blocks(request_id, total_computed_tokens)
+        self.coordinator.remove_skipped_blocks(
+            request_id, total_computed_tokens, num_prompt_tokens
+        )
 
     def evict_blocks(self, block_ids: set[int]) -> None:
         """evict blocks from the prefix cache by their block IDs.

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -2387,6 +2387,7 @@ class Scheduler(SchedulerInterface):
         self.kv_cache_manager.remove_skipped_blocks(
             request_id=request.request_id,
             total_computed_tokens=request.num_computed_tokens,
+            num_prompt_tokens=request.num_prompt_tokens,
         )
 
         block_ids = self.kv_cache_manager.get_block_ids_for_computed_tokens(

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -20,6 +20,7 @@ from vllm.v1.kv_cache_interface import (
     KVCacheSpec,
     MambaSpec,
     MLAAttentionSpec,
+    PrefixAnchoredSWASpec,
     SinkFullAttentionSpec,
     SlidingWindowMLASpec,
     SlidingWindowSpec,
@@ -445,8 +446,41 @@ class SingleTypeKVCacheManager(ABC):
 
         raise NotImplementedError
 
+    def _remove_blocks_in_range(
+        self,
+        request_id: str,
+        first_block: int,
+        last_block: int,
+    ) -> None:
+        """Free blocks in ``[first_block, last_block)`` and replace with null_block.
+
+        Iterates backward so newly-evictable tail blocks are reached even after
+        earlier blocks in the range were nulled in a prior call.
+        """
+        if request_id not in self.req_to_blocks:
+            return
+        if first_block >= last_block:
+            return
+        blocks = self.req_to_blocks[request_id]
+        last_block = min(last_block, len(blocks))
+
+        freed: list[KVCacheBlock] = []
+        for i in range(last_block - 1, first_block - 1, -1):
+            if blocks[i] == self._null_block:
+                # If the block is already a null block, the blocks before it
+                # should also have been set to null blocks by the previous calls
+                # to this function.
+                break
+            freed.append(blocks[i])
+            blocks[i] = self._null_block
+        if freed:
+            self.block_pool.free_blocks(freed)
+
     def remove_skipped_blocks(
-        self, request_id: str, total_computed_tokens: int
+        self,
+        request_id: str,
+        total_computed_tokens: int,
+        num_prompt_tokens: int | None = None,
     ) -> None:
         """
         Remove and free the blocks that are no longer needed for attention computation.
@@ -459,7 +493,11 @@ class SingleTypeKVCacheManager(ABC):
             request_id: The request ID.
             total_computed_tokens: The total number of computed tokens, including
                 local computed tokens and external computed tokens.
+            num_prompt_tokens: Optional prompt length for attention types (e.g.
+                prefix-anchored SWA) that evict a middle gap rather than a head
+                prefix. Ignored by the default implementation.
         """
+        del num_prompt_tokens
         # Remove the blocks that will be skipped during attention computation.
         num_skipped_tokens = self.get_num_skipped_tokens(total_computed_tokens)
         if num_skipped_tokens <= 0:
@@ -468,25 +506,12 @@ class SingleTypeKVCacheManager(ABC):
             # A typical case is full attention that we never free any token
             # before the request is finished.
             return
-        blocks = self.req_to_blocks[request_id]
         num_skipped_blocks = num_skipped_tokens // self.block_size
         # `num_skipped_tokens` may include tokens that haven't been allocated yet
         # (e.g., when the attention window moves into the external computed tokens
-        # range), so we must cap to the number of blocks that currently exist for
-        # this request.
-        num_skipped_blocks = min(num_skipped_blocks, len(blocks))
-        removed_blocks: list[KVCacheBlock] = []
-        # Because the block starts from index 0, the num_skipped_block-th block
-        # corresponds to index num_skipped_blocks - 1.
-        for i in range(num_skipped_blocks - 1, -1, -1):
-            if blocks[i] == self._null_block:
-                # If the block is already a null block, the blocks before it
-                # should also have been set to null blocks by the previous calls
-                # to this function.
-                break
-            removed_blocks.append(blocks[i])
-            blocks[i] = self._null_block
-        self.block_pool.free_blocks(removed_blocks)
+        # range); `_remove_blocks_in_range` caps to the number of blocks that
+        # currently exist for this request.
+        self._remove_blocks_in_range(request_id, 0, num_skipped_blocks)
 
     def get_num_skipped_tokens(self, num_computed_tokens: int) -> int:
         """
@@ -565,6 +590,53 @@ class FullAttentionManager(SingleTypeKVCacheManager):
             else:
                 break
         return num_common_blocks
+
+
+class PrefixAnchoredSWAManager(FullAttentionManager):
+    """KV cache manager for prefix-anchored sliding-window attention.
+
+    When ``num_prompt_tokens`` is supplied to ``remove_skipped_blocks``, frees
+    gap blocks between the prefill tail and the current decode window.  This
+    bounds per-request KV memory at O(prefix_len + decode_sliding_window)
+    instead of growing linearly with decode length.
+    """
+
+    def __init__(self, kv_cache_spec: PrefixAnchoredSWASpec, **kwargs) -> None:
+        super().__init__(kv_cache_spec, **kwargs)
+        self.decode_sliding_window: int = kv_cache_spec.decode_sliding_window
+
+    def remove_skipped_blocks(
+        self,
+        request_id: str,
+        total_computed_tokens: int,
+        num_prompt_tokens: int | None = None,
+    ) -> None:
+        """Free gap blocks that are no longer needed for attention.
+
+        Gap = blocks entirely within
+            [ceil(prefix_len / block_size) * block_size,
+             max(prefix_len, total_computed_tokens - decode_sliding_window))
+
+        Freed blocks are replaced with null_block in req_to_blocks so the
+        block_table handed to the attention backend stays valid (null_block
+        KV is all-zero; the backend mask marks gap positions as non-visible
+        so they never contribute to the output).
+        """
+        if num_prompt_tokens is None:
+            super().remove_skipped_blocks(
+                request_id, total_computed_tokens, num_prompt_tokens
+            )
+            return
+
+        bs = self.block_size
+        # First block fully after the prefill boundary.
+        first_gap_block = cdiv(num_prompt_tokens, bs)
+        # Decode window start position; blocks before this are evictable.
+        window_start = max(
+            num_prompt_tokens, total_computed_tokens - self.decode_sliding_window
+        )
+        last_gap_block = window_start // bs  # exclusive upper bound
+        self._remove_blocks_in_range(request_id, first_gap_block, last_gap_block)
 
 
 class SlidingWindowManager(SingleTypeKVCacheManager):
@@ -930,7 +1002,12 @@ class MambaManager(SingleTypeKVCacheManager):
 
         return computed_blocks
 
-    def remove_skipped_blocks(self, request_id: str, num_computed_tokens: int) -> None:
+    def remove_skipped_blocks(
+        self,
+        request_id: str,
+        num_computed_tokens: int,
+        num_prompt_tokens: int | None = None,
+    ) -> None:
         assert isinstance(self.kv_cache_spec, MambaSpec)
 
         # NOTE (tdoublep) with async scheduling, the num_computed_tokens can contain
@@ -940,7 +1017,9 @@ class MambaManager(SingleTypeKVCacheManager):
         # that we might actually need.
         num_computed_tokens = max(0, num_computed_tokens - self.num_speculative_blocks)
 
-        super().remove_skipped_blocks(request_id, num_computed_tokens)
+        super().remove_skipped_blocks(
+            request_id, num_computed_tokens, num_prompt_tokens
+        )
         if self.mamba_cache_mode == "align":
             # `last_state_block_idx` refers to the block index allocated two steps ago.
             # The block allocated in the previous step is used to copy Mamba states
@@ -1247,6 +1326,7 @@ spec_manager_map: dict[type[KVCacheSpec], type[SingleTypeKVCacheManager]] = {
     TQFullAttentionSpec: FullAttentionManager,
     MLAAttentionSpec: FullAttentionManager,
     HiddenStateCacheSpec: FullAttentionManager,
+    PrefixAnchoredSWASpec: PrefixAnchoredSWAManager,
     SlidingWindowSpec: SlidingWindowManager,
     SlidingWindowMLASpec: SlidingWindowManager,
     ChunkedLocalAttentionSpec: ChunkedLocalAttentionManager,

--- a/vllm/v1/kv_cache_interface.py
+++ b/vllm/v1/kv_cache_interface.py
@@ -404,6 +404,52 @@ class HiddenStateCacheSpec(MLAAttentionSpec):
 
 
 @dataclass(frozen=True, kw_only=True)
+class PrefixAnchoredSWASpec(FullAttentionSpec):
+    """KV cache spec for prefix-anchored sliding-window attention.
+
+    Prefill (prompt/prefix) tokens are always globally visible.
+    Only the last ``decode_sliding_window`` generated tokens are kept in the
+    KV cache; gap blocks (between the prefill tail and the current decode
+    window) are evicted during each decode step to bound per-request memory
+    at O(prefix_blocks + window_blocks).
+    """
+
+    decode_sliding_window: int
+
+    def __post_init__(self) -> None:
+        super().__post_init__()
+        if self.decode_sliding_window <= 0:
+            raise ValueError("decode_sliding_window must be greater than zero")
+
+    @classmethod
+    def merge(cls, specs: list[Self]) -> Self:
+        assert all(isinstance(spec, PrefixAnchoredSWASpec) for spec in specs), (
+            "All attention layers in the same KV cache group must be "
+            "PrefixAnchoredSWASpec."
+        )
+        windows = {spec.decode_sliding_window for spec in specs}
+        assert len(windows) == 1, (
+            "All prefix-anchored SWA layers must share the same "
+            f"decode_sliding_window, got {windows}"
+        )
+        # Delegate common field merging to the parent, then reattach the
+        # decode window.
+        base = FullAttentionSpec.merge(specs)  # type: ignore[arg-type]
+        return cls(
+            block_size=base.block_size,
+            num_kv_heads=base.num_kv_heads,
+            head_size=base.head_size,
+            head_size_v=base.head_size_v,
+            dtype=base.dtype,
+            kv_quant_mode=base.kv_quant_mode,
+            page_size_padded=base.page_size_padded,
+            sliding_window=base.sliding_window,
+            attention_chunk_size=base.attention_chunk_size,
+            decode_sliding_window=windows.pop(),
+        )
+
+
+@dataclass(frozen=True, kw_only=True)
 class ChunkedLocalAttentionSpec(AttentionSpec):
     attention_chunk_size: int
 

--- a/vllm/v1/worker/gpu/attn_utils.py
+++ b/vllm/v1/worker/gpu/attn_utils.py
@@ -543,6 +543,7 @@ def build_attn_metadata(
     model_specific_attn_metadata: ModelSpecificAttnMetadata | None = None,
     for_cudagraph_capture: bool = False,
     causal: bool | torch.Tensor | Mapping[int, bool] = True,
+    prefix_anchor_lens: torch.Tensor | None = None,
 ) -> dict[str, Any]:
     seq_lens = seq_lens[:num_reqs]
     if dcp_local_seq_lens is not None:
@@ -581,6 +582,7 @@ def build_attn_metadata(
             causal=group_causal,
             dcp_local_seq_lens=dcp_local_seq_lens,
             positions=positions,
+            prefix_anchor_lens=prefix_anchor_lens,
             **common_attn_metadata_extra_kwargs,
         )
 

--- a/vllm/v1/worker/gpu/input_batch.py
+++ b/vllm/v1/worker/gpu/input_batch.py
@@ -84,6 +84,10 @@ class InputBatch:
     # Whether any requests in batch use structured output.
     has_structured_output_reqs: bool
 
+    # [num_reqs_after_padding] per-request prompt length for prefix-anchored
+    # sliding-window attention (optional).
+    prefix_anchor_lens: torch.Tensor | None = None
+
     @classmethod
     def make_dummy(
         cls,

--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -212,6 +212,20 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             max_num_tokens=self.max_num_tokens,
             device=self.device,
         )
+        # Prefix-anchored SWA: persistent GPU buffer for per-request prompt
+        # lengths (stable device address across steps).
+        self.prefix_anchor_lens_buffer: torch.Tensor | None = None
+        if (
+            getattr(
+                self.vllm_config.attention_config,
+                "prefix_anchored_decode_window",
+                None,
+            )
+            is not None
+        ):
+            self.prefix_anchor_lens_buffer = torch.zeros(
+                self.max_num_reqs, dtype=torch.int32, device=self.device
+            )
 
         self.sampler: Sampler | None = None
         self.rejection_sampler: RejectionSampler | None = None
@@ -919,6 +933,16 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             out=seq_lens_cpu_upper_bound_np[:num_reqs],
         )
         seq_lens_cpu_upper_bound = torch.from_numpy(seq_lens_cpu_upper_bound_np)
+
+        prefix_anchor_lens = None
+        if self.prefix_anchor_lens_buffer is not None:
+            prefix_anchor_lens = self.prefix_anchor_lens_buffer[:num_reqs_padded]
+            prefix_anchor_lens[:num_reqs] = self.req_states.prompt_len.gpu[
+                idx_mapping[:num_reqs]
+            ]
+            if num_reqs_padded > num_reqs:
+                prefix_anchor_lens[num_reqs:].zero_()
+
         return InputBatch(
             req_ids=req_ids,
             num_reqs=num_reqs,
@@ -944,6 +968,7 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             cu_num_logits=cu_num_logits,
             cu_num_logits_np=cu_num_logits_np,
             has_structured_output_reqs=scheduler_output.has_structured_output_requests,
+            prefix_anchor_lens=prefix_anchor_lens,
         )
 
     def prepare_attn(

--- a/vllm/v1/worker/gpu/model_states/default.py
+++ b/vllm/v1/worker/gpu/model_states/default.py
@@ -195,5 +195,6 @@ class DefaultModelState(ModelState):
             dcp_local_seq_lens=input_batch.dcp_local_seq_lens,
             positions=input_batch.positions,
             for_cudagraph_capture=for_capture,
+            prefix_anchor_lens=input_batch.prefix_anchor_lens,
         )
         return attn_metadata

--- a/vllm/v1/worker/gpu/model_states/mamba_hybrid.py
+++ b/vllm/v1/worker/gpu/model_states/mamba_hybrid.py
@@ -449,6 +449,7 @@ class MambaHybridModelState(DefaultModelState):
             dcp_local_seq_lens=input_batch.dcp_local_seq_lens,
             model_specific_attn_metadata=mamba_attn_metadata,
             for_cudagraph_capture=for_capture,
+            prefix_anchor_lens=input_batch.prefix_anchor_lens,
         )
         if common_gdn_metadata is not None:
             assert common_gdn_metadata.spec_query_start_loc.numel() == (

--- a/vllm/v1/worker/gpu/model_states/whisper.py
+++ b/vllm/v1/worker/gpu/model_states/whisper.py
@@ -161,6 +161,7 @@ class WhisperModelState(ModelState):
             dcp_local_seq_lens=input_batch.dcp_local_seq_lens,
             model_specific_attn_metadata=whisper_attn_metadata,
             for_cudagraph_capture=for_capture,
+            prefix_anchor_lens=input_batch.prefix_anchor_lens,
         )
         return attn_metadata
 

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -5343,6 +5343,20 @@ class GPUModelRunner(
             seq_lens_cpu = None
             num_computed_tokens_cpu = None
 
+        # Prefix-anchored SWA: pass per-request prompt lengths so the
+        # attention backend can keep the prefix globally visible. The backend
+        # owns the persistent device buffer.
+        prefix_anchor_lens = None
+        if (
+            getattr(
+                self.vllm_config.attention_config,
+                "prefix_anchored_decode_window",
+                None,
+            )
+            is not None
+        ):
+            prefix_anchor_lens = num_prompt_tokens_cpu
+
         cm_base = CommonAttentionMetadata(
             query_start_loc=self.query_start_loc.gpu[: num_reqs_padded + 1],
             query_start_loc_cpu=self.query_start_loc.cpu[: num_reqs_padded + 1],
@@ -5360,6 +5374,7 @@ class GPUModelRunner(
             cudagraph_graph_variant=cudagraph_graph_variant,
             is_prefilling=is_prefilling,
             positions=self.positions[:num_tokens_padded],
+            prefix_anchor_lens=prefix_anchor_lens,
         )
 
         current_mamba_state_block_ids_by_gid: dict[int, torch.Tensor] = {}


### PR DESCRIPTION
## Purpose

Replacement for #239, rebased onto current `main`. Adds prefix-anchored sliding-window attention as an explicit, default-off inference-engine capability. Admission is based only on hardware, operator, tensor/cache, graph, and concurrency contracts; it does not inspect model/checkpoint/architecture identity.

The engine option is `AttentionConfig.prefix_anchored_decode_window`. The prefix remains globally visible while generated-token KV outside the live window is masked and reclaimed. Unsupported combinations fail up front, and missing runtime metadata fails closed.

## Key audit fixes over #239

- removed DeepSeek/OCR-specific classes and checkpoint config wiring
- moved activation to model-agnostic `AttentionConfig` and base `Attention`
- rebased the CUDA changes over the current Flash-V100 kernel stack
- rejected non-positive windows, non-fp16 KV, non-SM70, MLA/local/sink attention, CP, speculation, KV connectors/offload, and unsupported backends
- fixed the missing eager/piecewise metadata path
- made masked extension availability and metadata consistency hard startup/runtime gates
- preserved original-author attribution without carrying unsigned commits

## Test Plan / Result

- `pytest -q tests/config/test_prefix_anchored_swa.py tests/v1/attention/test_prefix_anchored_swa_mask.py tests/v1/core/test_single_type_kv_cache_manager.py`: **32 passed**
- SM70 source build: `CUDA_HOME=/usr MAX_JOBS=4 TORCH_CUDA_ARCH_LIST=7.0 python setup.py build_ext --inplace`: **passed**
- `pytest -q tests/kernels/attention/test_sm70_flash_v100_anchored_swa.py` on V100: **19 passed**
- changed-file pre-commit suite, including Ruff, clang-format, mypy, SPDX and config/docs checks: **passed**
- same-toolchain SASS comparison to current `origin/main`: **55/55 decode** and **64/64 paged-prefill** default-off instances byte-identical

No model end-to-end or throughput claim is made. Refs #239.