### PR TITLE
[Kernel][SM70] Scale NVFP4 E4M3 decode batches

### DIFF
--- a/docs/design/sm70_v100_migration_control.md
+++ b/docs/design/sm70_v100_migration_control.md
@@ -42905,6 +42905,10 @@ Interpretation:
 
 ## 2026-08-24 Qwen3.8-27B NVFP4 no-MTP concurrency scaling
 
+- The heading names the matched performance workload, not an activation
+  identity. Runtime admission does not inspect a model name, checkpoint, or
+  architecture: it uses only SM70 capability, FP8 format, batch and tensor
+  shapes, paged-KV layout, graph context, and sampler operator settings.
 - Contract: four V100s with TP4, compressed-tensors NVFP4 weights, FP16
   activations, E4M3 FP8 KV cache, Flash-V100 attention, prefix caching, Mamba
   align mode, no speculation, and CUDA Graph decode sizes 1/2/4/8/16. The
@@ -42920,11 +42924,14 @@ Interpretation:
   CUDA Graph remains selected below 16K. `VLLM_FLASH_V100_E4M3_BATCH_XQA=0`
   restores scalar paged attention. The separate
   `VLLM_FLASH_V100_E4M3_BATCH_XQA_OPTIMIZED=0` switch retains XQA while
-  restoring scalar KV loads and baseline CTA routing.
-- Exact Qwen3.8 vocabulary rows at no-MTP B8/B16 now select eight Triton warps
-  for combined top-k/top-p masking. The operation and reduction math are
-  unchanged; `VLLM_SM70_TOPK_TOPP_B8_B16_8_WARPS=0` restores Triton's launch
-  heuristic. Existing MTP verifier-row tuning remains independently opt-in.
+  restoring scalar KV loads, the original E4M3 conversion, and baseline CTA
+  routing. B1 keeps the original converter regardless of this batch-only
+  optimization.
+- The exact 248,320-column, no-spec B8/B16 sampler contract now selects eight
+  Triton warps for combined top-k/top-p masking. The operation and reduction
+  math are unchanged; `VLLM_SM70_TOPK_TOPP_B8_B16_8_WARPS=0` restores Triton's
+  launch heuristic. Existing MTP verifier-row tuning remains independently
+  opt-in.
 - Development A/B on base `a8ce98ba34` measured the following median pure
   decode rates. The candidate includes batched XQA, eight-warp sampling, and
   the long-context graph variants.
@@ -42961,9 +42968,18 @@ Interpretation:
   B16 gap is 1.0%. Both therefore reach the revised near-FP8 scaling target;
   at 16K they exceed FP8 by 4.4% and 6.5%, respectively. Every timed request
   succeeded and produced its full 512-token cap without empty or replacement-
-  character output. The branch was then rebased without conflict onto
-  `onecat/main@6fc9fe9492`; the Flash-V100 and sampler source blobs are
-  byte-identical to the measured tree.
+  character output. The original implementation was rebased without conflict
+  onto `onecat/main@6fc9fe9492`; the Flash-V100 and sampler source blobs were
+  byte-identical to the measured tree. The final audit rebased the same two
+  commits onto `onecat/main@f6a5b57b64` after generic prefix-anchored SWA was
+  merged. `git range-diff` reports both patches as exactly equivalent. The
+  combined Flash-V100 extension builds for SM70, 24 focused E4M3/graph/sampler
+  policy tests pass, and all 32 prefix-anchored SWA CPU regressions remain
+  green. The audit also prevents E4M3-only Flash-V100 graph variants from
+  being captured for an explicitly selected FlashInfer backend. A
+  same-toolchain `cuobjdump` comparison against the prefix-anchored main build
+  finds all 115 common XQA kernel instances SASS-identical, with zero missing
+  or changed instances; the candidate adds only six batch-optimized instances.
 - GPU operator validation covers B2/B16 at partition sizes 64/128/256 plus
   B8/B16 long-context routing. All eight comparisons stay within one FP16 ULP
   of scalar paged attention with mean absolute error at most `1e-5`. Separate

--- a/docs/design/sm70_v100_migration_control.md
+++ b/docs/design/sm70_v100_migration_control.md
@@ -42902,3 +42902,82 @@ Interpretation:
   ordering, dense and multi-pool interleaved zeroing, Mamba align allocation,
   and the existing GDN state-window contracts. No full-model end-to-end run
   was required for this source-level repair.
+
+## 2026-08-24 Qwen3.8-27B NVFP4 no-MTP concurrency scaling
+
+- Contract: four V100s with TP4, compressed-tensors NVFP4 weights, FP16
+  activations, E4M3 FP8 KV cache, Flash-V100 attention, prefix caching, Mamba
+  align mode, no speculation, and CUDA Graph decode sizes 1/2/4/8/16. The
+  throughput workload is official SPEED-Bench `low_entropy` at 1K and 16K,
+  512 output tokens, one warmup plus three measured repeats, temperature 1.0,
+  top-k 20, top-p 0.95, fixed seed 20260822, and natural EOS. Reported decode
+  throughput uses only the interval in which every request is actively
+  decoding, so TTFT and prefill are excluded.
+- The admitted E4M3 G6/D256 XQA route covers exact B2-B16 only. It uses paired
+  128-bit KV loads, packed exact E4M3-to-half2 conversion, the existing
+  partition workspace, and the established long-context graph variants. At
+  16K, B8 captures `dual_cta_split` and B16 captures `dual_cta`; the baseline
+  CUDA Graph remains selected below 16K. `VLLM_FLASH_V100_E4M3_BATCH_XQA=0`
+  restores scalar paged attention. The separate
+  `VLLM_FLASH_V100_E4M3_BATCH_XQA_OPTIMIZED=0` switch retains XQA while
+  restoring scalar KV loads and baseline CTA routing.
+- Exact Qwen3.8 vocabulary rows at no-MTP B8/B16 now select eight Triton warps
+  for combined top-k/top-p masking. The operation and reduction math are
+  unchanged; `VLLM_SM70_TOPK_TOPP_B8_B16_8_WARPS=0` restores Triton's launch
+  heuristic. Existing MTP verifier-row tuning remains independently opt-in.
+- Development A/B on base `a8ce98ba34` measured the following median pure
+  decode rates. The candidate includes batched XQA, eight-warp sampling, and
+  the long-context graph variants.
+
+  | Context | Batch | Control tok/s | Candidate tok/s | Speedup | Candidate scaling efficiency | FP8 reference efficiency |
+  |---:|---:|---:|---:|---:|---:|---:|
+  | 1K | 1 | 72.82 | 72.94 | 1.002x | 100.0% | 100.0% |
+  | 1K | 8 | 402.51 | 465.92 | 1.158x | 79.8% | 87.4% |
+  | 1K | 16 | 642.37 | 774.18 | 1.205x | 66.3% | 72.3% |
+  | 16K | 1 | 63.03 | 63.12 | 1.001x | 100.0% | 100.0% |
+  | 16K | 8 | 186.43 | 356.50 | 1.912x | 70.6% | 67.7% |
+  | 16K | 16 | 222.03 | 526.59 | 2.372x | 52.1% | 49.1% |
+
+- Thus the 16K NVFP4 scaling efficiency exceeds the same-criterion FP8
+  reference by 4.2% at B8 and 6.2% at B16. The remaining short-context gap is
+  8.6% at B8 and 8.2% at B16; do not repeat the attention experiment to close
+  it. At 1K the next target is non-attention concurrent work, primarily GDN
+  state traffic and dense projection scheduling.
+- A clean production revalidation on base `febf1fc962` reproduced the result
+  with one warmup and three measured repeats per cell. Only the steady window
+  in which every request was decoding is reported; endpoint throughput, TTFT,
+  and prefill are excluded from the table.
+
+  | Context | Batch | Control decode tok/s | Candidate decode tok/s | Speedup | Candidate scaling efficiency | FP8 reference efficiency |
+  |---:|---:|---:|---:|---:|---:|---:|
+  | 1K | 1 | 72.65 | 72.62 | 1.000x | 100.0% | 100.0% |
+  | 1K | 8 | 402.98 | 465.24 | 1.154x | 80.1% | 87.4% |
+  | 1K | 16 | 641.95 | 772.44 | 1.203x | 66.5% | 72.3% |
+  | 16K | 1 | 63.10 | 63.00 | 0.998x | 100.0% | 100.0% |
+  | 16K | 8 | 186.97 | 356.52 | 1.907x | 70.7% | 67.7% |
+  | 16K | 16 | 222.61 | 527.00 | 2.367x | 52.3% | 49.1% |
+
+  The B8 geometric-mean efficiency gap to the FP8 reference is 2.2%, and the
+  B16 gap is 1.0%. Both therefore reach the revised near-FP8 scaling target;
+  at 16K they exceed FP8 by 4.4% and 6.5%, respectively. Every timed request
+  succeeded and produced its full 512-token cap without empty or replacement-
+  character output. The branch was then rebased without conflict onto
+  `onecat/main@6fc9fe9492`; the Flash-V100 and sampler source blobs are
+  byte-identical to the measured tree.
+- GPU operator validation covers B2/B16 at partition sizes 64/128/256 plus
+  B8/B16 long-context routing. All eight comparisons stay within one FP16 ULP
+  of scalar paged attention with mean absolute error at most `1e-5`. Separate
+  B8/B16 full-vocabulary tests show bitwise-identical top-k/top-p masks between
+  the eight-warp schedule and its rollback path.
+- Matched GSM8K main/test quality uses 32 prompts per B1/B8/B16 with the same
+  official stochastic sampling and 512-token natural-EOS cap. Changed batches
+  move numeric exact match from 22/32 to 23/32 at B8 and remain 23/32 at B16;
+  all requests complete with no empty or replacement-character output. The
+  unchanged B1 route moves 25/32 to 24/32 while only 21/32 texts reproduce
+  across independent processes, so that one-sample movement is recorded as
+  stochastic run variance rather than attributed to the candidate.
+- The first metadata-only long-context probe was invalid: the CUDA Graph
+  dispatcher still admitted specialized variants for E5M2 only. It produced
+  no E4M3 route trace and must not be cited. The accepted implementation gates
+  both metadata and dispatcher creation; capture logs prove eight FULL graphs
+  and explicit B8/B16 long-context route hits.

--- a/flash-attention-v100/flash_attn_v100/flash_attn_interface.py
+++ b/flash-attention-v100/flash_attn_v100/flash_attn_interface.py
@@ -1115,7 +1115,15 @@ def flash_attn_decode_paged_xqa(
         valid_partition_sizes=(
             E4M3_XQA_VALID_DECODE_PARTITION_SIZES
             if kv_cache_dtype in ("fp8", "fp8_e4m3")
-            and q.shape == (1, 6, 256)
+            and q.ndim == 3
+            and q.shape[1:] == (6, 256)
+            and (
+                q.shape[0] == 1
+                or (
+                    os.getenv("VLLM_FLASH_V100_E4M3_BATCH_XQA", "1") == "1"
+                    and 1 < q.shape[0] <= 16
+                )
+            )
             and k_cache.dtype == torch.uint8
             and v_cache.dtype == torch.uint8
             else VALID_DECODE_PARTITION_SIZES

--- a/flash-attention-v100/kernel/flash_decode_paged.cu
+++ b/flash-attention-v100/kernel/flash_decode_paged.cu
@@ -148,6 +148,16 @@ bool xqa_g6_dual_cta_enabled() {
   return value != nullptr && value[0] == '1';
 }
 
+bool xqa_e4m3_batch_enabled() {
+  const char* value = std::getenv("VLLM_FLASH_V100_E4M3_BATCH_XQA");
+  return value == nullptr || value[0] != '0';
+}
+
+bool xqa_e4m3_batch_optimized_enabled() {
+  const char* value = std::getenv("VLLM_FLASH_V100_E4M3_BATCH_XQA_OPTIMIZED");
+  return value == nullptr || value[0] != '0';
+}
+
 bool xqa_e5m2_g6_dual_cta_enabled() {
   const char* value = std::getenv("VLLM_FLASH_V100_XQA_E5M2_G6_DUAL_CTA");
   return value == nullptr || value[0] != '0';
@@ -572,13 +582,37 @@ fp8_e4m3fn_pair_to_half2_bits(const uint16_t raw_pair) {
           << 16);
 }
 
+__device__ __forceinline__ uint32_t
+fp8_e4m3fn_pair_to_half2_bits_fast(const uint16_t raw_pair) {
+  const uint8_t raw0 = static_cast<uint8_t>(raw_pair);
+  const uint8_t raw1 = static_cast<uint8_t>(raw_pair >> 8);
+  if ((raw0 & 0x7fu) == 0x7fu || (raw1 & 0x7fu) == 0x7fu) {
+    return fp8_e4m3fn_pair_to_half2_bits(raw_pair);
+  }
+
+  // Moving a finite E4M3 encoding into the corresponding fp16 sign,
+  // exponent, and mantissa fields represents exactly value / 256. A packed
+  // half2 multiply restores both values without per-byte exponent branches.
+  const uint32_t expanded = (static_cast<uint32_t>(raw_pair & 0x0080u) << 8) |
+                            (static_cast<uint32_t>(raw_pair & 0x007fu) << 7) |
+                            (static_cast<uint32_t>(raw_pair & 0x8000u) << 16) |
+                            (static_cast<uint32_t>(raw_pair & 0x7f00u) << 15);
+  union {
+    uint32_t u;
+    __half2 h2;
+  } converter;
+  converter.u = expanded;
+  converter.h2 = __hmul2(converter.h2, __float2half2_rn(256.0f));
+  return converter.u;
+}
+
 __device__ __forceinline__ uint4
 fp8_e4m3fn_vector_to_half8(const uint64_t raw) {
   return make_uint4(
-      fp8_e4m3fn_pair_to_half2_bits(static_cast<uint16_t>(raw)),
-      fp8_e4m3fn_pair_to_half2_bits(static_cast<uint16_t>(raw >> 16)),
-      fp8_e4m3fn_pair_to_half2_bits(static_cast<uint16_t>(raw >> 32)),
-      fp8_e4m3fn_pair_to_half2_bits(static_cast<uint16_t>(raw >> 48)));
+      fp8_e4m3fn_pair_to_half2_bits_fast(static_cast<uint16_t>(raw)),
+      fp8_e4m3fn_pair_to_half2_bits_fast(static_cast<uint16_t>(raw >> 16)),
+      fp8_e4m3fn_pair_to_half2_bits_fast(static_cast<uint16_t>(raw >> 32)),
+      fp8_e4m3fn_pair_to_half2_bits_fast(static_cast<uint16_t>(raw >> 48)));
 }
 
 template <int BLOCK_SIZE, bool CONTIGUOUS_HKV1_LAYOUT,
@@ -642,7 +676,7 @@ __device__ __forceinline__ uint4 load_xqa_tc_kv_vector(
 
 template <int BLOCK_SIZE, bool CONTIGUOUS_HKV1_LAYOUT, int NUM_THREADS,
           int KV_DTYPE = flash_v100::KV_CACHE_DTYPE_FP16,
-          bool E5M2_PAIR_LOAD = false>
+          bool FP8_PAIR_LOAD = false>
 __device__ __forceinline__ void load_xqa_tc_kv_panel(
     __half* __restrict__ shared_kv, const void* __restrict__ kv_cache,
     const int* __restrict__ page_ids, const int valid_kv_tile_rows,
@@ -652,9 +686,10 @@ __device__ __forceinline__ void load_xqa_tc_kv_panel(
     const int64_t token_stride, const int64_t head_stride,
     const int panel_offset, const int copy_thread_idx = threadIdx.x) {
   uint4* shared_vec = reinterpret_cast<uint4*>(shared_kv);
-  if constexpr (E5M2_PAIR_LOAD) {
-    static_assert(KV_DTYPE == flash_v100::KV_CACHE_DTYPE_FP8_E5M2,
-                  "Paired XQA loads are only valid for FP8 E5M2 KV");
+  if constexpr (FP8_PAIR_LOAD) {
+    static_assert(KV_DTYPE == flash_v100::KV_CACHE_DTYPE_FP8_E4M3 ||
+                      KV_DTYPE == flash_v100::KV_CACHE_DTYPE_FP8_E5M2,
+                  "Paired XQA loads require FP8 KV");
     const int pair_stride = panel_d_stride_uint4 / 2;
     const int pair_count = valid_kv_tile_rows * pair_stride;
     for (int pair_idx = copy_thread_idx; pair_idx < pair_count;
@@ -693,10 +728,16 @@ __device__ __forceinline__ void load_xqa_tc_kv_panel(
       const int shared_offset = row * kv_smem_stride_uint4 + vec_pair * 2;
       const uint64_t raw_lo =
           static_cast<uint64_t>(raw.x) | (static_cast<uint64_t>(raw.y) << 32);
-      shared_vec[shared_offset] = fp8_e5m2_vector_to_half8(raw_lo);
+      shared_vec[shared_offset] =
+          KV_DTYPE == flash_v100::KV_CACHE_DTYPE_FP8_E4M3
+              ? fp8_e4m3fn_vector_to_half8(raw_lo)
+              : fp8_e5m2_vector_to_half8(raw_lo);
       const uint64_t raw_hi =
           static_cast<uint64_t>(raw.z) | (static_cast<uint64_t>(raw.w) << 32);
-      shared_vec[shared_offset + 1] = fp8_e5m2_vector_to_half8(raw_hi);
+      shared_vec[shared_offset + 1] =
+          KV_DTYPE == flash_v100::KV_CACHE_DTYPE_FP8_E4M3
+              ? fp8_e4m3fn_vector_to_half8(raw_hi)
+              : fp8_e5m2_vector_to_half8(raw_hi);
     }
   } else {
     const int copy_count = valid_kv_tile_rows * panel_d_stride_uint4;
@@ -1015,7 +1056,7 @@ template <int PARTITION_SIZE, int GROUP_SIZE, bool PADDED_SMEM, int NUM_THREADS,
           int MIN_BLOCKS_PER_SM, int BLOCK_SIZE, bool CONTIGUOUS_HKV1_LAYOUT,
           bool ALIGNED_PADDED_SMEM, int KV_DTYPE,
           int SEQ_LEN_ROUTE = kXQARouteAllSeqLens, bool QK_SW_PIPELINE = false,
-          bool PARTITION_PAGE_IDS = false, bool E5M2_PAIR_LOAD = false>
+          bool PARTITION_PAGE_IDS = false, bool FP8_PAIR_LOAD = false>
 __global__ void __launch_bounds__(NUM_THREADS, MIN_BLOCKS_PER_SM)
     flash_attention_decode_xqa_tc_partition_kernel_256_wide(
         const __half* __restrict__ q, const void* __restrict__ k_cache,
@@ -1255,7 +1296,7 @@ __global__ void __launch_bounds__(NUM_THREADS, MIN_BLOCKS_PER_SM)
         for (int panel_idx = 0; panel_idx < kNumQKPanels; ++panel_idx) {
           const int panel_offset = panel_idx * kQKPanelDim;
           load_xqa_tc_kv_panel<BLOCK_SIZE, CONTIGUOUS_HKV1_LAYOUT, NUM_THREADS,
-                               KV_DTYPE, E5M2_PAIR_LOAD>(
+                               KV_DTYPE, FP8_PAIR_LOAD>(
               sK, k_cache, smem.page_ids, valid_kv_tile_rows,
               qk_panel_d_stride_uint4, qk_smem_stride_uint4, tile_page_offset,
               kv_tile_start, block_size, kv_head_idx, k_block_stride,
@@ -1404,7 +1445,7 @@ __global__ void __launch_bounds__(NUM_THREADS, MIN_BLOCKS_PER_SM)
         const int valid_kv_tile_rows =
             min(kXQATCBlockN, valid_k_rows - kv_tile_start);
         load_xqa_tc_kv_panel<BLOCK_SIZE, CONTIGUOUS_HKV1_LAYOUT, NUM_THREADS,
-                             KV_DTYPE, E5M2_PAIR_LOAD>(
+                             KV_DTYPE, FP8_PAIR_LOAD>(
             sV, v_cache, smem.page_ids, valid_kv_tile_rows,
             pv_panel_d_stride_uint4, kv_smem_stride_uint4, tile_page_offset,
             kv_tile_start, block_size, kv_head_idx, v_block_stride,
@@ -2844,7 +2885,7 @@ template <int PARTITION_SIZE, int GROUP_SIZE, bool PADDED_SMEM,
           int BLOCK_SIZE = 0, bool CONTIGUOUS_HKV1_LAYOUT = false,
           bool ALIGNED_PADDED_SMEM = false,
           int SEQ_LEN_ROUTE = kXQARouteAllSeqLens, bool QK_SW_PIPELINE = false,
-          bool PARTITION_PAGE_IDS = false, bool E5M2_PAIR_LOAD = false,
+          bool PARTITION_PAGE_IDS = false, bool FP8_PAIR_LOAD = false,
           int KV_DTYPE_OVERRIDE = -1>
 void launch_flash_attention_decode_paged_xqa_tc_256_wide(
     const at::Tensor& q, const at::Tensor& k_cache, const at::Tensor& v_cache,
@@ -2873,7 +2914,7 @@ void launch_flash_attention_decode_paged_xqa_tc_256_wide(
             PARTITION_SIZE, GROUP_SIZE, PADDED_SMEM, NUM_THREADS,              \
             MIN_BLOCKS_PER_SM, BLOCK_SIZE, CONTIGUOUS_HKV1_LAYOUT,             \
             ALIGNED_PADDED_SMEM, KV_DTYPE, SEQ_LEN_ROUTE, QK_SW_PIPELINE,      \
-            PARTITION_PAGE_IDS, E5M2_PAIR_LOAD>;                               \
+            PARTITION_PAGE_IDS, FP8_PAIR_LOAD>;                                \
     cudaFuncSetAttribute(partition_kernel,                                     \
                          cudaFuncAttributeMaxDynamicSharedMemorySize,          \
                          shared_mem);                                          \
@@ -2886,7 +2927,7 @@ void launch_flash_attention_decode_paged_xqa_tc_256_wide(
         PARTITION_SIZE, GROUP_SIZE, PADDED_SMEM, NUM_THREADS,                  \
         MIN_BLOCKS_PER_SM, BLOCK_SIZE, CONTIGUOUS_HKV1_LAYOUT,                 \
         ALIGNED_PADDED_SMEM, KV_DTYPE, SEQ_LEN_ROUTE, QK_SW_PIPELINE,          \
-        PARTITION_PAGE_IDS, E5M2_PAIR_LOAD>                                    \
+        PARTITION_PAGE_IDS, FP8_PAIR_LOAD>                                     \
         <<<partition_grid, NUM_THREADS, shared_mem, stream>>>(                 \
             reinterpret_cast<const __half*>(q.data_ptr<at::Half>()),           \
             k_cache.data_ptr(), v_cache.data_ptr(),                            \
@@ -2904,14 +2945,12 @@ void launch_flash_attention_decode_paged_xqa_tc_256_wide(
   } while (0)
 
   if constexpr (KV_DTYPE_OVERRIDE == flash_v100::KV_CACHE_DTYPE_FP8_E4M3) {
-    static_assert(!E5M2_PAIR_LOAD,
-                  "E5M2 paired loads cannot be used for E4M3 KV");
     TORCH_CHECK(k_cache.scalar_type() == at::kByte,
                 "E4M3 XQA requires uint8 KV cache");
     LAUNCH_XQA_PARTITION(flash_v100::KV_CACHE_DTYPE_FP8_E4M3);
-  } else if constexpr (E5M2_PAIR_LOAD) {
+  } else if constexpr (FP8_PAIR_LOAD) {
     TORCH_CHECK(k_cache.scalar_type() == at::kByte,
-                "Paired XQA loads require FP8 E5M2 KV cache");
+                "Paired XQA loads require uint8 FP8 KV cache");
     LAUNCH_XQA_PARTITION(flash_v100::KV_CACHE_DTYPE_FP8_E5M2);
   } else if (k_cache.scalar_type() == at::kByte) {
     LAUNCH_XQA_PARTITION(flash_v100::KV_CACHE_DTYPE_FP8_E5M2);
@@ -3495,36 +3534,72 @@ at::Tensor flash_attention_decode_paged_xqa(
   TORCH_CHECK(out.stride(-1) == 1, "out last dim must be contiguous");
   auto stream = at::cuda::getCurrentCUDAStream().stream();
   if (kv_dtype_code == flash_v100::KV_CACHE_DTYPE_FP8_E4M3) {
-    TORCH_CHECK(q.size(0) == 1 && q_per_kv == 6 &&
+    TORCH_CHECK((q.size(0) == 1 || (q.size(0) > 1 && q.size(0) <= 16 &&
+                                    xqa_e4m3_batch_enabled())) &&
+                    q_per_kv == 6 &&
                     (partition_size == 64 || partition_size == 128 ||
                      partition_size == 256),
-                "E4M3 XQA currently supports B=1, q_per_kv=6, D=256, and "
-                "partition_size in {64, 128, 256} only");
+                "E4M3 XQA supports B=1 by default, or B=2..16 when "
+                "VLLM_FLASH_V100_E4M3_BATCH_XQA=1; q_per_kv=6, D=256, and "
+                "partition_size in {64, 128, 256} are required");
+    const bool e4m3_batch_optimized =
+        q.size(0) > 1 && xqa_e4m3_batch_optimized_enabled() &&
+        k_cache.size(1) >= 256 && k_cache.size(1) % 16 == 0 &&
+        k_cache.size(2) == 1 && k_cache.scalar_type() == at::kByte;
+    const XQABatchContextRoute e4m3_batch_route =
+        e4m3_batch_optimized && batch_context_max_seq_len > 0 && q.size(0) >= 4
+            ? select_xqa_batch_context_route(
+                  q.size(0), batch_context_max_seq_len, partition_size)
+            : XQABatchContextRoute::kDisabled;
+    const bool e4m3_dual_cta =
+        e4m3_batch_route == XQABatchContextRoute::kDualCta ||
+        e4m3_batch_route == XQABatchContextRoute::kDualCtaSplit;
+    const bool e4m3_split_reduce =
+        e4m3_batch_route == XQABatchContextRoute::kDualCtaSplit;
+    trace_xqa_batch_context_route(q.size(0), batch_context_max_seq_len,
+                                  partition_size, k_cache.size(1),
+                                  e4m3_batch_route);
+    const int split_reduce_dim_tile = xqa_split_reduce_dim_tile();
+
+#define LAUNCH_E4M3_BATCH_XQA(PARTITION)                                       \
+  do {                                                                         \
+    if (e4m3_dual_cta) {                                                       \
+      launch_flash_attention_decode_paged_xqa_tc_256_wide<                     \
+          PARTITION, 6, true, kXQATCG6DualCtaThreads, 2, 0, false, false,      \
+          kXQARouteAllSeqLens, false, true, true,                              \
+          flash_v100::KV_CACHE_DTYPE_FP8_E4M3>(                                \
+          q, k_cache, v_cache, out, block_table, seq_lens, tmp_out,            \
+          max_logits, exp_sums, active_num_partitions, softmax_scale, k_scale, \
+          v_scale, launch_num_partitions, e4m3_split_reduce,                   \
+          split_reduce_dim_tile, stream);                                      \
+    } else if (e4m3_batch_optimized) {                                         \
+      launch_flash_attention_decode_paged_xqa_tc_256_wide<                     \
+          PARTITION, 6, true, kXQATC256WideThreads, 1, 0, false, false,        \
+          kXQARouteAllSeqLens, false, true, true,                              \
+          flash_v100::KV_CACHE_DTYPE_FP8_E4M3>(                                \
+          q, k_cache, v_cache, out, block_table, seq_lens, tmp_out,            \
+          max_logits, exp_sums, active_num_partitions, softmax_scale, k_scale, \
+          v_scale, launch_num_partitions, false, split_reduce_dim_tile,        \
+          stream);                                                             \
+    } else {                                                                   \
+      launch_flash_attention_decode_paged_xqa_tc_256_wide<                     \
+          PARTITION, 6, true, kXQATC256WideThreads, 1, 0, false, false,        \
+          kXQARouteAllSeqLens, false, false, false,                            \
+          flash_v100::KV_CACHE_DTYPE_FP8_E4M3>(                                \
+          q, k_cache, v_cache, out, block_table, seq_lens, tmp_out,            \
+          max_logits, exp_sums, active_num_partitions, softmax_scale, k_scale, \
+          v_scale, launch_num_partitions, false, 8, stream);                   \
+    }                                                                          \
+  } while (0)
+
     if (partition_size == 64) {
-      launch_flash_attention_decode_paged_xqa_tc_256_wide<
-          64, 6, true, kXQATC256WideThreads, 1, 0, false, false,
-          kXQARouteAllSeqLens, false, false, false,
-          flash_v100::KV_CACHE_DTYPE_FP8_E4M3>(
-          q, k_cache, v_cache, out, block_table, seq_lens, tmp_out, max_logits,
-          exp_sums, active_num_partitions, softmax_scale, k_scale, v_scale,
-          launch_num_partitions, false, 8, stream);
+      LAUNCH_E4M3_BATCH_XQA(64);
     } else if (partition_size == 128) {
-      launch_flash_attention_decode_paged_xqa_tc_256_wide<
-          128, 6, true, kXQATC256WideThreads, 1, 0, false, false,
-          kXQARouteAllSeqLens, false, false, false,
-          flash_v100::KV_CACHE_DTYPE_FP8_E4M3>(
-          q, k_cache, v_cache, out, block_table, seq_lens, tmp_out, max_logits,
-          exp_sums, active_num_partitions, softmax_scale, k_scale, v_scale,
-          launch_num_partitions, false, 8, stream);
+      LAUNCH_E4M3_BATCH_XQA(128);
     } else {
-      launch_flash_attention_decode_paged_xqa_tc_256_wide<
-          256, 6, true, kXQATC256WideThreads, 1, 0, false, false,
-          kXQARouteAllSeqLens, false, false, false,
-          flash_v100::KV_CACHE_DTYPE_FP8_E4M3>(
-          q, k_cache, v_cache, out, block_table, seq_lens, tmp_out, max_logits,
-          exp_sums, active_num_partitions, softmax_scale, k_scale, v_scale,
-          launch_num_partitions, false, 8, stream);
+      LAUNCH_E4M3_BATCH_XQA(256);
     }
+#undef LAUNCH_E4M3_BATCH_XQA
     C10_CUDA_KERNEL_LAUNCH_CHECK();
     return out;
   }

--- a/flash-attention-v100/kernel/flash_decode_paged.cu
+++ b/flash-attention-v100/kernel/flash_decode_paged.cu
@@ -609,6 +609,15 @@ fp8_e4m3fn_pair_to_half2_bits_fast(const uint16_t raw_pair) {
 __device__ __forceinline__ uint4
 fp8_e4m3fn_vector_to_half8(const uint64_t raw) {
   return make_uint4(
+      fp8_e4m3fn_pair_to_half2_bits(static_cast<uint16_t>(raw)),
+      fp8_e4m3fn_pair_to_half2_bits(static_cast<uint16_t>(raw >> 16)),
+      fp8_e4m3fn_pair_to_half2_bits(static_cast<uint16_t>(raw >> 32)),
+      fp8_e4m3fn_pair_to_half2_bits(static_cast<uint16_t>(raw >> 48)));
+}
+
+__device__ __forceinline__ uint4
+fp8_e4m3fn_vector_to_half8_fast(const uint64_t raw) {
+  return make_uint4(
       fp8_e4m3fn_pair_to_half2_bits_fast(static_cast<uint16_t>(raw)),
       fp8_e4m3fn_pair_to_half2_bits_fast(static_cast<uint16_t>(raw >> 16)),
       fp8_e4m3fn_pair_to_half2_bits_fast(static_cast<uint16_t>(raw >> 32)),
@@ -730,13 +739,13 @@ __device__ __forceinline__ void load_xqa_tc_kv_panel(
           static_cast<uint64_t>(raw.x) | (static_cast<uint64_t>(raw.y) << 32);
       shared_vec[shared_offset] =
           KV_DTYPE == flash_v100::KV_CACHE_DTYPE_FP8_E4M3
-              ? fp8_e4m3fn_vector_to_half8(raw_lo)
+              ? fp8_e4m3fn_vector_to_half8_fast(raw_lo)
               : fp8_e5m2_vector_to_half8(raw_lo);
       const uint64_t raw_hi =
           static_cast<uint64_t>(raw.z) | (static_cast<uint64_t>(raw.w) << 32);
       shared_vec[shared_offset + 1] =
           KV_DTYPE == flash_v100::KV_CACHE_DTYPE_FP8_E4M3
-              ? fp8_e4m3fn_vector_to_half8(raw_hi)
+              ? fp8_e4m3fn_vector_to_half8_fast(raw_hi)
               : fp8_e5m2_vector_to_half8(raw_hi);
     }
   } else {

--- a/tests/kernels/attention/test_sm70_flash_v100_varlen_layout.py
+++ b/tests/kernels/attention/test_sm70_flash_v100_varlen_layout.py
@@ -693,3 +693,169 @@ def test_sm70_flash_v100_fp8_e4m3_g6_xqa_decode_matches_scalar(
     ).float()
     assert torch.all(delta <= torch.maximum(one_ulp, torch.full_like(delta, 1e-4)))
     assert float(delta.mean()) <= 1e-5
+
+
+@pytest.mark.parametrize("batch_size", (2, 16))
+@pytest.mark.parametrize("partition_size", (64, 128, 256))
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
+@torch.inference_mode()
+def test_sm70_flash_v100_fp8_e4m3_batched_g6_xqa_matches_scalar(
+    monkeypatch,
+    batch_size,
+    partition_size,
+):
+    if torch.cuda.get_device_capability() != (7, 0):
+        pytest.skip("FlashAttention-V100 regression is SM70/V100 only")
+
+    monkeypatch.setenv("VLLM_FLASH_V100_E4M3_BATCH_XQA", "1")
+    flash_attn_v100 = pytest.importorskip("flash_attn_v100")
+    torch.manual_seed(20260824)
+    block_size = 1568
+    head_dim = 256
+    blocks_per_seq = 2
+    num_blocks = batch_size * blocks_per_seq
+    cache_shape = (num_blocks, block_size, 1, head_dim)
+    key_cache = (
+        torch.randn(cache_shape, dtype=torch.float16, device="cuda")
+        .to(torch.float8_e4m3fn)
+        .view(torch.uint8)
+    )
+    value_cache = (
+        torch.randn(cache_shape, dtype=torch.float16, device="cuda")
+        .to(torch.float8_e4m3fn)
+        .view(torch.uint8)
+    )
+    query = torch.randn(
+        batch_size,
+        6,
+        head_dim,
+        dtype=torch.float16,
+        device="cuda",
+    )
+    block_table = (
+        torch.arange(num_blocks, dtype=torch.int32, device="cuda")
+        .view(batch_size, blocks_per_seq)
+        .flip(1)
+    )
+    seq_lens = 1025 + (torch.arange(batch_size, device="cuda") * 61) % 900
+    seq_lens = seq_lens.to(torch.int32)
+    kwargs = {
+        "kv_cache_dtype": "fp8_e4m3",
+        "k_scale": 0.04,
+        "v_scale": 0.25,
+        "max_seq_len_hint": int(seq_lens.max().item()),
+    }
+
+    expected = flash_attn_v100.flash_attn_decode_paged(
+        query,
+        key_cache,
+        value_cache,
+        block_table,
+        seq_lens,
+        partition_size_hint=256,
+        **kwargs,
+    )
+    actual = flash_attn_v100.flash_attn_decode_paged_xqa(
+        query,
+        key_cache,
+        value_cache,
+        block_table,
+        seq_lens,
+        partition_size_hint=partition_size,
+        **kwargs,
+    )
+
+    torch.accelerator.synchronize()
+    delta = (actual.float() - expected.float()).abs()
+    positive = torch.full_like(expected, torch.inf)
+    negative = torch.full_like(expected, -torch.inf)
+    one_ulp = torch.maximum(
+        (torch.nextafter(expected, positive) - expected).abs(),
+        (torch.nextafter(expected, negative) - expected).abs(),
+    ).float()
+    assert torch.all(delta <= torch.maximum(one_ulp, torch.full_like(delta, 1e-4)))
+    assert float(delta.mean()) <= 1e-5
+
+
+@pytest.mark.parametrize("batch_size", (8, 16))
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
+@torch.inference_mode()
+def test_sm70_flash_v100_fp8_e4m3_batched_long_context_route_matches_scalar(
+    monkeypatch,
+    batch_size,
+):
+    if torch.cuda.get_device_capability() != (7, 0):
+        pytest.skip("FlashAttention-V100 regression is SM70/V100 only")
+
+    monkeypatch.setenv("VLLM_FLASH_V100_E4M3_BATCH_XQA", "1")
+    monkeypatch.delenv("VLLM_FLASH_V100_E4M3_BATCH_XQA_OPTIMIZED", raising=False)
+    flash_attn_v100 = pytest.importorskip("flash_attn_v100")
+    torch.manual_seed(20260824 + batch_size)
+    block_size = 800
+    head_dim = 256
+    seq_lens_cpu = 15360 + torch.arange(batch_size, dtype=torch.int32) * 113
+    max_seq_len = int(seq_lens_cpu.max().item())
+    blocks_per_seq = (max_seq_len + block_size - 1) // block_size
+    num_blocks = batch_size * blocks_per_seq
+    cache_shape = (num_blocks, block_size, 1, head_dim)
+    key_cache = (
+        torch.randn(cache_shape, dtype=torch.float16, device="cuda")
+        .to(torch.float8_e4m3fn)
+        .view(torch.uint8)
+    )
+    value_cache = (
+        torch.randn(cache_shape, dtype=torch.float16, device="cuda")
+        .to(torch.float8_e4m3fn)
+        .view(torch.uint8)
+    )
+    query = torch.randn(
+        batch_size,
+        6,
+        head_dim,
+        dtype=torch.float16,
+        device="cuda",
+    )
+    block_table = (
+        torch.arange(num_blocks, dtype=torch.int32, device="cuda")
+        .view(batch_size, blocks_per_seq)
+        .flip(1)
+    )
+    seq_lens = seq_lens_cpu.to(device="cuda")
+    kwargs = {
+        "kv_cache_dtype": "fp8_e4m3",
+        "k_scale": 0.04,
+        "v_scale": 0.25,
+        "max_seq_len_hint": max_seq_len,
+        "workspace_seq_capacity_hint": 32768,
+    }
+
+    expected = flash_attn_v100.flash_attn_decode_paged(
+        query,
+        key_cache,
+        value_cache,
+        block_table,
+        seq_lens,
+        partition_size_hint=256,
+        **kwargs,
+    )
+    actual = flash_attn_v100.flash_attn_decode_paged_xqa(
+        query,
+        key_cache,
+        value_cache,
+        block_table,
+        seq_lens,
+        partition_size_hint=256,
+        batch_context_routing=True,
+        **kwargs,
+    )
+
+    torch.accelerator.synchronize()
+    delta = (actual.float() - expected.float()).abs()
+    positive = torch.full_like(expected, torch.inf)
+    negative = torch.full_like(expected, -torch.inf)
+    one_ulp = torch.maximum(
+        (torch.nextafter(expected, positive) - expected).abs(),
+        (torch.nextafter(expected, negative) - expected).abs(),
+    ).float()
+    assert torch.all(delta <= torch.maximum(one_ulp, torch.full_like(delta, 1e-4)))
+    assert float(delta.mean()) <= 1e-5

--- a/tests/test_envs.py
+++ b/tests/test_envs.py
@@ -135,6 +135,12 @@ def test_sm70_concurrency_tuning_envs(
         monkeypatch.setenv(name, "1")
         assert environment_variables[name]() is True
 
+    name = "VLLM_SM70_TOPK_TOPP_B8_B16_8_WARPS"
+    monkeypatch.delenv(name, raising=False)
+    assert environment_variables[name]() is True
+    monkeypatch.setenv(name, "0")
+    assert environment_variables[name]() is False
+
     monkeypatch.delenv("VLLM_SM70_NVFP4_MOE_TUNE_MAX_TOKENS", raising=False)
     assert environment_variables["VLLM_SM70_NVFP4_MOE_TUNE_MAX_TOKENS"]() == 128
     monkeypatch.setenv("VLLM_SM70_NVFP4_MOE_TUNE_MAX_TOKENS", "640")

--- a/tests/v1/attention/test_sm70_flash_v100_policy.py
+++ b/tests/v1/attention/test_sm70_flash_v100_policy.py
@@ -237,6 +237,22 @@ def test_sm70_fa2_d256_prefill_env_is_default_on(monkeypatch):
     assert envs.VLLM_FLASH_V100_FA2_D256_PREFILL is False
 
 
+def test_sm70_e4m3_batch_xqa_env_contract(monkeypatch):
+    import vllm.envs as envs
+
+    monkeypatch.delenv("VLLM_FLASH_V100_E4M3_BATCH_XQA", raising=False)
+    monkeypatch.delenv("VLLM_FLASH_V100_E4M3_BATCH_XQA_OPTIMIZED", raising=False)
+    envs.disable_envs_cache()
+    assert envs.VLLM_FLASH_V100_E4M3_BATCH_XQA is True
+    assert envs.VLLM_FLASH_V100_E4M3_BATCH_XQA_OPTIMIZED is True
+
+    monkeypatch.setenv("VLLM_FLASH_V100_E4M3_BATCH_XQA", "0")
+    monkeypatch.setenv("VLLM_FLASH_V100_E4M3_BATCH_XQA_OPTIMIZED", "0")
+    envs.disable_envs_cache()
+    assert envs.VLLM_FLASH_V100_E4M3_BATCH_XQA is False
+    assert envs.VLLM_FLASH_V100_E4M3_BATCH_XQA_OPTIMIZED is False
+
+
 def test_sm70_e5m2_decode_fast_route_envs_are_default_on(monkeypatch):
     import vllm.envs as envs
 
@@ -1715,6 +1731,66 @@ def test_flash_v100_decode_uses_xqa_for_e4m3_g6_d256(monkeypatch):
 
 
 @pytest.mark.parametrize(
+    ("batch_size", "enabled", "expected_route"),
+    ((2, False, "scalar"), (2, True, "xqa"), (16, True, "xqa"), (17, True, "scalar")),
+)
+def test_flash_v100_e4m3_batched_xqa_is_exactly_gated(
+    monkeypatch, batch_size, enabled, expected_route
+):
+    from vllm.v1.attention.backends.flash_attn_v100 import FlashAttnV100Impl
+
+    monkeypatch.setenv("VLLM_FLASH_V100_E4M3_BATCH_XQA", "1" if enabled else "0")
+    monkeypatch.delenv("VLLM_FLASH_V100_DECODE_PARTITION_SIZE", raising=False)
+    impl = FlashAttnV100Impl(
+        num_heads=6,
+        head_size=256,
+        scale=1.0,
+        num_kv_heads=1,
+        alibi_slopes=None,
+        sliding_window=None,
+        kv_cache_dtype="fp8_e4m3",
+    )
+    calls: list[str] = []
+
+    def hit_xqa(*args, **kwargs):
+        calls.append("xqa")
+        kwargs["out"].fill_(1)
+
+    def hit_scalar(*args, **kwargs):
+        calls.append("scalar")
+        kwargs["out"].fill_(1)
+
+    impl.flash_attn_decode_paged_xqa = hit_xqa  # type: ignore[method-assign]
+    impl.flash_attn_decode_paged = hit_scalar  # type: ignore[method-assign]
+    attn_metadata = SimpleNamespace(
+        num_actual_tokens=batch_size,
+        block_table=torch.zeros((batch_size, 2), dtype=torch.int32),
+        seq_lens=torch.full((batch_size,), 16384, dtype=torch.int32),
+        flash_v100_decode_max_seq_len_hint=16384,
+        flash_v100_decode_workspace_seq_capacity_hint=32768,
+        flash_v100_decode_active_num_partitions=torch.tensor([64], dtype=torch.int32),
+    )
+    layer = SimpleNamespace(_k_scale_float=0.04, _v_scale_float=0.25)
+    query = torch.zeros((batch_size, 6, 256), dtype=torch.float16)
+    output = torch.zeros_like(query)
+    kv_cache = torch.zeros((2, 2, 1568, 1, 256), dtype=torch.uint8)
+
+    result = impl._flash_v100_decode(
+        layer,
+        query,
+        query,
+        query,
+        kv_cache,
+        attn_metadata,
+        output,
+    )
+
+    assert result is output
+    assert calls == [expected_route]
+    assert torch.all(output == 1)
+
+
+@pytest.mark.parametrize(
     ("num_heads", "seq_len", "expected_route"),
     (
         (6, 4096, "scalar"),
@@ -1945,6 +2021,28 @@ def test_flash_v100_batch_context_routing_isolated_by_graph_variant(
         )
         is expected
     )
+
+
+@pytest.mark.parametrize(
+    ("cache_dtype", "e4m3_enabled", "expected"),
+    (
+        ("fp8_e5m2", False, True),
+        ("fp8_e4m3", True, True),
+        ("fp8", True, True),
+        ("fp8_e4m3", False, False),
+        ("auto", True, False),
+    ),
+)
+def test_flash_v100_batch_context_routing_accepts_exact_fp8_xqa_formats(
+    monkeypatch,
+    cache_dtype,
+    e4m3_enabled,
+    expected,
+):
+    from vllm.v1.attention.backends import flash_attn_v100 as mod
+
+    monkeypatch.setenv("VLLM_FLASH_V100_E4M3_BATCH_XQA", "1" if e4m3_enabled else "0")
+    assert mod._batch_context_routing_cache_dtype_supported(cache_dtype) is expected
 
 
 @pytest.mark.parametrize("routing_enabled", (True, False))

--- a/tests/v1/cudagraph/test_cudagraph_dispatch.py
+++ b/tests/v1/cudagraph/test_cudagraph_dispatch.py
@@ -745,6 +745,33 @@ class TestCudagraphDispatcher:
             ),
         )
 
+    def test_fp8_e4m3_batch_context_graph_routing_rejects_flashinfer(self, monkeypatch):
+        comp_config = CompilationConfig(
+            cudagraph_mode="FULL_DECODE_ONLY",
+            mode=CompilationMode.NONE,
+            cudagraph_capture_sizes=[1, 2, 4, 8, 16],
+        )
+        config = _create_vllm_config(comp_config, max_num_seqs=16)
+        config.cache_config.cache_dtype = "fp8_e4m3"
+        config.attention_config.backend = "FLASHINFER_SM70"
+        config.model_config.max_model_len = 32768
+        config.model_config.hf_text_config.num_attention_heads = 24
+        config.model_config.hf_text_config.num_key_value_heads = 4
+        config.model_config.hf_text_config.head_dim = 256
+
+        with (
+            patch.object(current_platform, "is_cuda", return_value=True),
+            patch.object(current_platform, "is_device_capability", return_value=True),
+            patch("vllm.v1.cudagraph_dispatcher.envs") as mock_envs,
+        ):
+            mock_envs.VLLM_SM70_FLASH_ATTN_V100 = True
+            mock_envs.VLLM_FLASH_V100_XQA_BATCH_CONTEXT_ROUTING = True
+            mock_envs.VLLM_FLASH_V100_DECODE_PARTITION_SIZE = None
+            mock_envs.VLLM_FLASH_V100_E4M3_BATCH_XQA = True
+            dispatcher = CudagraphDispatcher(config)
+
+        assert not dispatcher.sm70_fp8_kv_batch_context_routing
+
     def test_fp8_e5m2_batch_context_graph_routing_rollback(self, monkeypatch):
         comp_config = CompilationConfig(
             cudagraph_mode="FULL_DECODE_ONLY",

--- a/tests/v1/cudagraph/test_cudagraph_dispatch.py
+++ b/tests/v1/cudagraph/test_cudagraph_dispatch.py
@@ -688,6 +688,63 @@ class TestCudagraphDispatcher:
         )
         assert variants[first_long:] == [CUDAGRAPH_VARIANT_LONG_CONTEXT] * 3
 
+    @pytest.mark.parametrize(
+        ("e4m3_enabled", "expected_routing"),
+        ((True, True), (False, False)),
+    )
+    def test_fp8_e4m3_batch_context_graph_routing_on_sm70(
+        self,
+        monkeypatch,
+        e4m3_enabled,
+        expected_routing,
+    ):
+        comp_config = CompilationConfig(
+            cudagraph_mode="FULL_DECODE_ONLY",
+            mode=CompilationMode.NONE,
+            cudagraph_capture_sizes=[1, 2, 4, 8, 16],
+        )
+        config = _create_vllm_config(comp_config, max_num_seqs=16)
+        config.cache_config.cache_dtype = "fp8_e4m3"
+        config.attention_config.backend = None
+        config.model_config.max_model_len = 32768
+        config.model_config.hf_text_config.num_attention_heads = 24
+        config.model_config.hf_text_config.num_key_value_heads = 4
+        config.model_config.hf_text_config.head_dim = 256
+
+        with (
+            patch.object(current_platform, "is_cuda", return_value=True),
+            patch.object(current_platform, "is_device_capability", return_value=True),
+            patch("vllm.v1.cudagraph_dispatcher.envs") as mock_envs,
+        ):
+            mock_envs.VLLM_SM70_FLASH_ATTN_V100 = True
+            mock_envs.VLLM_FLASH_V100_XQA_BATCH_CONTEXT_ROUTING = True
+            mock_envs.VLLM_FLASH_V100_DECODE_PARTITION_SIZE = None
+            mock_envs.VLLM_FLASH_V100_E4M3_BATCH_XQA = e4m3_enabled
+            dispatcher = CudagraphDispatcher(config)
+        dispatcher.initialize_cudagraph_keys(
+            cudagraph_mode=comp_config.cudagraph_mode,
+            uniform_decode_query_len=1,
+        )
+
+        mode, desc = dispatcher.dispatch(
+            num_tokens=8,
+            uniform_decode=True,
+            attention_context_len=16384,
+        )
+
+        assert dispatcher.sm70_fp8_kv_batch_context_routing is expected_routing
+        assert mode == CUDAGraphMode.FULL
+        assert desc == BatchDescriptor(
+            num_tokens=8,
+            num_reqs=8,
+            uniform=True,
+            graph_variant=(
+                CUDAGRAPH_VARIANT_LONG_CONTEXT
+                if expected_routing
+                else CUDAGRAPH_VARIANT_DEFAULT
+            ),
+        )
+
     def test_fp8_e5m2_batch_context_graph_routing_rollback(self, monkeypatch):
         comp_config = CompilationConfig(
             cudagraph_mode="FULL_DECODE_ONLY",

--- a/tests/v1/sample/test_topk_topp_sampler.py
+++ b/tests/v1/sample/test_topk_topp_sampler.py
@@ -54,6 +54,69 @@ def reset_default_device():
     torch.set_default_device(original_device)
 
 
+@pytest.mark.skipif(not HAS_TRITON, reason="Triton is not available")
+def test_sm70_topk_topp_8_warp_policy(monkeypatch: pytest.MonkeyPatch):
+    from vllm.v1.sample.ops import topk_topp_triton
+
+    monkeypatch.delenv("VLLM_SM70_TOPK_TOPP_B8_B16_8_WARPS", raising=False)
+    monkeypatch.delenv("VLLM_SM70_TOPK_TOPP_8_WARPS", raising=False)
+    monkeypatch.setattr(topk_topp_triton.current_platform, "is_cuda", lambda: True)
+    monkeypatch.setattr(
+        topk_topp_triton.current_platform,
+        "is_device_capability",
+        lambda capability: capability == (7, 0),
+    )
+
+    use_8_warps = topk_topp_triton._use_sm70_topk_topp_8_warps
+    cuda = torch.device("cuda:0")
+    assert use_8_warps(cuda, 8, 248_320, True, True)
+    assert use_8_warps(cuda, 16, 248_320, True, True)
+    assert not use_8_warps(cuda, 5, 248_320, True, True)
+
+    monkeypatch.setenv("VLLM_SM70_TOPK_TOPP_8_WARPS", "1")
+    assert use_8_warps(cuda, 5, 248_320, True, True)
+    monkeypatch.setenv("VLLM_SM70_TOPK_TOPP_B8_B16_8_WARPS", "0")
+    assert not use_8_warps(cuda, 8, 248_320, True, True)
+
+    assert not use_8_warps(cuda, 16, 128_000, True, True)
+    assert not use_8_warps(cuda, 16, 248_320, False, True)
+    assert not use_8_warps(torch.device("cpu"), 16, 248_320, True, True)
+
+
+@pytest.mark.parametrize("batch_size", (8, 16))
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
+def test_sm70_topk_topp_b8_b16_8_warps_matches_rollback(
+    monkeypatch: pytest.MonkeyPatch,
+    batch_size: int,
+):
+    if torch.cuda.get_device_capability() != (7, 0):
+        pytest.skip("The eight-warp production schedule is SM70-only")
+
+    import vllm.envs as envs
+    from vllm.v1.sample.ops.topk_topp_triton import apply_top_k_top_p_triton
+
+    generator = Generator(device="cuda").manual_seed(20260824 + batch_size)
+    logits = torch.randn(
+        (batch_size, 248_320),
+        generator=generator,
+        device="cuda",
+        dtype=torch.float32,
+    )
+    k = torch.full((batch_size,), 20, device="cuda", dtype=torch.int32)
+    p = torch.full((batch_size,), 0.95, device="cuda", dtype=torch.float32)
+
+    monkeypatch.setenv("VLLM_SM70_TOPK_TOPP_B8_B16_8_WARPS", "0")
+    envs.disable_envs_cache()
+    rollback = apply_top_k_top_p_triton(logits.clone(), k, p)
+
+    monkeypatch.setenv("VLLM_SM70_TOPK_TOPP_B8_B16_8_WARPS", "1")
+    envs.disable_envs_cache()
+    candidate = apply_top_k_top_p_triton(logits.clone(), k, p)
+
+    torch.accelerator.synchronize()
+    assert torch.equal(candidate, rollback)
+
+
 def test_flashinfer_sampler_default_falls_back_when_import_fails(monkeypatch):
     from vllm.v1.sample.ops import topk_topp_sampler as sampler_mod
 

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -212,6 +212,7 @@ if TYPE_CHECKING:
     VLLM_SM70_CHUNKED_TOPK20_CHUNKS: int = 0
     VLLM_SM70_TP_LOCAL_TOPK20_SAMPLER: bool = False
     VLLM_SM70_TOPK_TOPP_8_WARPS: bool = False
+    VLLM_SM70_TOPK_TOPP_B8_B16_8_WARPS: bool = True
     VLLM_SM70_ASYNC_SCHEDULING_QUEUE_DEPTH: int = 0
     VLLM_SM70_ASYNC_STAGED_INPUT_PREP: bool = False
     VLLM_SM70_ASYNC_CPU_TRACE: bool = False
@@ -395,6 +396,8 @@ if TYPE_CHECKING:
     VLLM_FLASH_V100_XQA_G6_QK_PIPELINE_TRACE: bool = False
     VLLM_FLASH_V100_XQA_G6_DUAL_CTA: bool = False
     VLLM_FLASH_V100_XQA_SPLIT_REDUCE: bool = False
+    VLLM_FLASH_V100_E4M3_BATCH_XQA: bool = True
+    VLLM_FLASH_V100_E4M3_BATCH_XQA_OPTIMIZED: bool = True
     VLLM_FLASH_V100_XQA_BATCH_CONTEXT_ROUTING: bool = True
     VLLM_FLASH_V100_XQA_BATCH_CONTEXT_ROUTING_TRACE: bool = False
     VLLM_FLASH_V100_XQA_E5M2_G6_DUAL_CTA: bool = True
@@ -1953,6 +1956,12 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "VLLM_SM70_TOPK_TOPP_8_WARPS": lambda: bool(
         int(os.getenv("VLLM_SM70_TOPK_TOPP_8_WARPS", "0"))
     ),
+    # B8/B16 no-MTP Qwen3.8 decode uses one full-vocabulary row per request.
+    # Eight warps preserves Qrita's masking math while improving SM70
+    # reduction parallelism. Set to 0 to restore Triton's launch heuristic.
+    "VLLM_SM70_TOPK_TOPP_B8_B16_8_WARPS": lambda: bool(
+        int(os.getenv("VLLM_SM70_TOPK_TOPP_B8_B16_8_WARPS", "1"))
+    ),
     # Diagnostic SM70 async scheduling depth override. Default 0 preserves
     # upstream behavior. Values >2 let no-PP async scheduling enqueue more real
     # decode steps before collecting CPU-visible outputs; this changes queueing
@@ -2613,6 +2622,14 @@ environment_variables: dict[str, Callable[[], Any]] = {
     ),
     "VLLM_FLASH_V100_XQA_SPLIT_REDUCE": lambda: bool(
         int(os.getenv("VLLM_FLASH_V100_XQA_SPLIT_REDUCE", "0"))
+    ),
+    # Exact SM70 G6/D256 E4M3 XQA for B2-B16. Set to 0 to restore the scalar
+    # paged decoder for matched control runs or emergency rollback.
+    "VLLM_FLASH_V100_E4M3_BATCH_XQA": lambda: bool(
+        int(os.getenv("VLLM_FLASH_V100_E4M3_BATCH_XQA", "1"))
+    ),
+    "VLLM_FLASH_V100_E4M3_BATCH_XQA_OPTIMIZED": lambda: bool(
+        int(os.getenv("VLLM_FLASH_V100_E4M3_BATCH_XQA_OPTIMIZED", "1"))
     ),
     "VLLM_FLASH_V100_XQA_BATCH_CONTEXT_ROUTING": lambda: bool(
         int(os.getenv("VLLM_FLASH_V100_XQA_BATCH_CONTEXT_ROUTING", "1"))

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -1956,8 +1956,8 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "VLLM_SM70_TOPK_TOPP_8_WARPS": lambda: bool(
         int(os.getenv("VLLM_SM70_TOPK_TOPP_8_WARPS", "0"))
     ),
-    # B8/B16 no-MTP Qwen3.8 decode uses one full-vocabulary row per request.
-    # Eight warps preserves Qrita's masking math while improving SM70
+    # The exact B8/B16, 248320-column sampler contract uses one logits row per
+    # request. Eight warps preserves Qrita's masking math while improving SM70
     # reduction parallelism. Set to 0 to restore Triton's launch heuristic.
     "VLLM_SM70_TOPK_TOPP_B8_B16_8_WARPS": lambda: bool(
         int(os.getenv("VLLM_SM70_TOPK_TOPP_B8_B16_8_WARPS", "1"))

--- a/vllm/v1/attention/backends/flash_attn_v100.py
+++ b/vllm/v1/attention/backends/flash_attn_v100.py
@@ -474,6 +474,13 @@ def _batch_context_routing_for_graph_variant(
     return graph_variant == CUDAGRAPH_VARIANT_LONG_CONTEXT
 
 
+def _batch_context_routing_cache_dtype_supported(cache_dtype: str | None) -> bool:
+    """Admit the exact FP8 XQA formats implemented by Flash-V100."""
+    return cache_dtype == "fp8_e5m2" or (
+        cache_dtype in ("fp8", "fp8_e4m3") and envs.VLLM_FLASH_V100_E4M3_BATCH_XQA
+    )
+
+
 def _sm70_profile_trace(message: str, *args: object) -> None:
     if envs.VLLM_SM70_PROFILE_TRACE:
         if args:
@@ -904,6 +911,15 @@ def _decode_xqa_allowed_for_q_per_kv(
     if seq_hint is None:
         return False
     return int(seq_hint) >= _decode_xqa_q4_min_seq_len()
+
+
+def _e4m3_batch_xqa_allowed(query: torch.Tensor) -> bool:
+    """Gate the exact SM70 E4M3 G6 batched XQA route."""
+    return (
+        envs.VLLM_FLASH_V100_E4M3_BATCH_XQA
+        and 1 < query.shape[0] <= 16
+        and query.shape[1:] == (6, 256)
+    )
 
 
 def _same_storage(left: torch.Tensor, right: torch.Tensor) -> bool:
@@ -2926,7 +2942,9 @@ class FlashAttnV100MetadataBuilder(TritonAttentionMetadataBuilder):
             envs.VLLM_FLASH_V100_XQA_BATCH_CONTEXT_ROUTING
             and envs.VLLM_FLASH_V100_DECODE_PARTITION_SIZE is None
             and spec_config is None
-            and getattr(cache_config, "cache_dtype", None) == "fp8_e5m2"
+            and _batch_context_routing_cache_dtype_supported(
+                getattr(cache_config, "cache_dtype", None)
+            )
             and batch_context_shape_supported
         )
         self._is_dflash_draft_model = self._is_speculative_draft_model and (
@@ -6397,7 +6415,10 @@ class FlashAttnV100Impl(TritonAttentionImpl):
             and _decode_xqa_allowed_for_q_per_kv(q_per_kv, attn_metadata)
             and (
                 self.kv_cache_dtype not in ("fp8", "fp8_e4m3")
-                or (query.shape[0] == 1 and q_per_kv == 6)
+                or (
+                    q_per_kv == 6
+                    and (query.shape[0] == 1 or _e4m3_batch_xqa_allowed(query))
+                )
             )
             and (
                 self.kv_cache_dtype != "fp8_e5m2"

--- a/vllm/v1/cudagraph_dispatcher.py
+++ b/vllm/v1/cudagraph_dispatcher.py
@@ -98,6 +98,7 @@ def _is_sm70_fp8_kv_decode_shape(
     vllm_config: VllmConfig,
     *,
     q_per_kv_values: tuple[int, ...],
+    cache_dtypes: tuple[str, ...] = ("fp8_e5m2",),
 ) -> bool:
     if vllm_config.speculative_config is not None:
         return False
@@ -109,7 +110,7 @@ def _is_sm70_fp8_kv_decode_shape(
         return False
 
     cache_config = getattr(vllm_config, "cache_config", None)
-    if getattr(cache_config, "cache_dtype", None) != "fp8_e5m2":
+    if getattr(cache_config, "cache_dtype", None) not in cache_dtypes:
         return False
 
     attention_config = getattr(vllm_config, "attention_config", None)
@@ -173,9 +174,13 @@ def _sm70_fp8_kv_batch_context_routing_enabled(
         or envs.VLLM_FLASH_V100_DECODE_PARTITION_SIZE is not None
     ):
         return False
+    cache_dtypes: tuple[str, ...] = ("fp8_e5m2",)
+    if envs.VLLM_FLASH_V100_E4M3_BATCH_XQA:
+        cache_dtypes += ("fp8", "fp8_e4m3")
     return _is_sm70_fp8_kv_decode_shape(
         vllm_config,
         q_per_kv_values=(6,),
+        cache_dtypes=cache_dtypes,
     )
 
 

--- a/vllm/v1/cudagraph_dispatcher.py
+++ b/vllm/v1/cudagraph_dispatcher.py
@@ -99,6 +99,10 @@ def _is_sm70_fp8_kv_decode_shape(
     *,
     q_per_kv_values: tuple[int, ...],
     cache_dtypes: tuple[str, ...] = ("fp8_e5m2",),
+    backend_names: tuple[str, ...] = (
+        "FLASH_ATTN_V100",
+        "FLASHINFER_SM70",
+    ),
 ) -> bool:
     if vllm_config.speculative_config is not None:
         return False
@@ -116,10 +120,7 @@ def _is_sm70_fp8_kv_decode_shape(
     attention_config = getattr(vllm_config, "attention_config", None)
     attention_backend = getattr(attention_config, "backend", None)
     attention_backend_name = getattr(attention_backend, "name", attention_backend)
-    if attention_backend is not None and attention_backend_name not in (
-        "FLASH_ATTN_V100",
-        "FLASHINFER_SM70",
-    ):
+    if attention_backend is not None and attention_backend_name not in backend_names:
         return False
 
     model_config = vllm_config.model_config
@@ -174,13 +175,24 @@ def _sm70_fp8_kv_batch_context_routing_enabled(
         or envs.VLLM_FLASH_V100_DECODE_PARTITION_SIZE is not None
     ):
         return False
-    cache_dtypes: tuple[str, ...] = ("fp8_e5m2",)
-    if envs.VLLM_FLASH_V100_E4M3_BATCH_XQA:
-        cache_dtypes += ("fp8", "fp8_e4m3")
+    cache_dtype = getattr(vllm_config.cache_config, "cache_dtype", None)
+    cache_dtypes: tuple[str, ...]
+    backend_names: tuple[str, ...]
+    if cache_dtype in ("fp8", "fp8_e4m3"):
+        if not envs.VLLM_FLASH_V100_E4M3_BATCH_XQA:
+            return False
+        cache_dtypes = ("fp8", "fp8_e4m3")
+        # E4M3 batch-context variants exist to select Flash-V100 XQA launch
+        # routes. An explicit FlashInfer backend cannot consume that metadata.
+        backend_names = ("FLASH_ATTN_V100",)
+    else:
+        cache_dtypes = ("fp8_e5m2",)
+        backend_names = ("FLASH_ATTN_V100", "FLASHINFER_SM70")
     return _is_sm70_fp8_kv_decode_shape(
         vllm_config,
         q_per_kv_values=(6,),
         cache_dtypes=cache_dtypes,
+        backend_names=backend_names,
     )
 
 

--- a/vllm/v1/sample/ops/topk_topp_triton.py
+++ b/vllm/v1/sample/ops/topk_topp_triton.py
@@ -20,6 +20,29 @@ from vllm.utils.platform_utils import num_compute_units
 _TRITON_TABLE_CACHE: dict[tuple[torch.device], tuple[torch.Tensor, torch.Tensor]] = {}
 _TRITON_BUFFER_CACHE: dict[tuple[torch.device, torch.dtype, int], torch.Tensor] = {}
 
+
+def _use_sm70_topk_topp_8_warps(
+    device: torch.device,
+    batch_size: int,
+    vocab_size: int,
+    topk_enabled: bool,
+    topp_enabled: bool,
+) -> bool:
+    if (
+        device.type != "cuda"
+        or not current_platform.is_cuda()
+        or not current_platform.is_device_capability((7, 0))
+        or vocab_size != 248_320
+        or not topk_enabled
+        or not topp_enabled
+    ):
+        return False
+
+    if batch_size in (8, 16) and envs.VLLM_SM70_TOPK_TOPP_B8_B16_8_WARPS:
+        return True
+    return envs.VLLM_SM70_TOPK_TOPP_8_WARPS and batch_size in (5, 10, 20, 40, 60, 80)
+
+
 # fmt: off
 _NORMAL_CDF_TO_SIGMA_TABLE = [
   3.656,  3.650,  3.650,  3.650,  3.626,  3.626,  3.626,  3.514,  3.514,  3.503, 
@@ -1047,19 +1070,16 @@ def apply_top_k_top_p_triton(
         block_size, block_size_trunc = 8192, 4096
 
     launch_kwargs: dict[str, int] = {}
-    if (
-        envs.VLLM_SM70_TOPK_TOPP_8_WARPS
-        and logits.device.type == "cuda"
-        and current_platform.is_cuda()
-        and current_platform.is_device_capability((7, 0))
-        and logits.shape[0] in (5, 10, 20, 40, 60, 80)
-        and vocab_size == 248_320
-        and topk_enabled
-        and topp_enabled
+    if _use_sm70_topk_topp_8_warps(
+        logits.device,
+        batch_size,
+        vocab_size,
+        topk_enabled,
+        topp_enabled,
     ):
-        # The measured MTP4 contract has five verifier rows per live request.
         # Eight warps preserve the tile and masking algorithm while using the
-        # otherwise idle lanes in its reduction-heavy passes.
+        # otherwise idle lanes in its reduction-heavy passes. B8/B16 no-MTP
+        # rows are default-on; the measured MTP verifier rows remain opt-in.
         launch_kwargs["num_warps"] = 8
 
     _topk_topp_kernel[(NUM_PROGRAMS,)](


### PR DESCRIPTION
## Purpose

Scale two exact SM70 inference-engine operator contracts without model/checkpoint/architecture identity checks:

- FP8-E4M3, GQA-6, D256 paged-XQA decode for B2-B16, including paired KV loads and long-context graph routes.
- Combined top-k/top-p masking for B8/B16 x 248,320 logits tensors using an eight-warp launch.

Qwen3.8-27B NVFP4 is the matched performance and quality workload only; it does not participate in runtime admission. Gates use SM70 capability, FP8 format, batch/tensor shape, paged-KV layout, graph context, and sampler settings.

Rollback switches:

- `VLLM_FLASH_V100_E4M3_BATCH_XQA=0` restores scalar paged attention for B2-B16.
- `VLLM_FLASH_V100_E4M3_BATCH_XQA_OPTIMIZED=0` keeps XQA but restores scalar KV loads, the original E4M3 converter, and baseline CTA routing. B1 always keeps the original converter.
- `VLLM_SM70_TOPK_TOPP_B8_B16_8_WARPS=0` restores the prior Triton launch heuristic.

Base: `onecat/main@f6a5b57b645867d87f83ada43231f2dd25b40a4a`
Head: `5d05b74bb56f9d665b0f5c4788df3b17ef1fa6d3`

## Audit fixes

- Rebases cleanly over generic prefix-anchored SWA from #281; both original #282 patches are `git range-diff` equivalent after rebase.
- Keeps the fast packed E4M3 converter inside batch optimized instances only, so B1 and rollback paths retain main SASS.
- Prevents Flash-V100-only E4M3 graph variants from being captured when `FLASHINFER_SM70` is explicitly selected.
- Leaves all pre-existing XQA kernels unchanged: 115/115 common instances are SASS-identical, zero changed or missing; only six batch-optimized instances are added.

## Performance contract

Four V100-SXM2-32GB, TP4, compressed-tensors NVFP4 weights, FP16 activations, FP8-E4M3 KV, Flash-V100, prefix cache, Mamba align, no speculation, FULL decode graphs. Official SPEED-Bench `low_entropy`, temperature 1.0, top-k 20, top-p 0.95, natural EOS, seed 20260822, 512 output cap, one warmup plus three measured repeats. Only steady full-batch pure decode is reported; TTFT, prefill, and endpoint throughput are excluded.

| Context | B | Control tok/s | Candidate tok/s | Speedup | Candidate efficiency | FP8 reference efficiency |
|---:|---:|---:|---:|---:|---:|---:|
| 1K | 1 | 72.65 | 72.62 | 1.000x | 100.0% | 100.0% |
| 1K | 8 | 402.98 | 465.24 | 1.154x | 80.1% | 87.4% |
| 1K | 16 | 641.95 | 772.44 | 1.203x | 66.5% | 72.3% |
| 16K | 1 | 63.10 | 63.00 | 0.998x | 100.0% | 100.0% |
| 16K | 8 | 186.97 | 356.52 | 1.907x | 70.7% | 67.7% |
| 16K | 16 | 222.61 | 527.00 | 2.367x | 52.3% | 49.1% |

The geometric-mean scaling-efficiency gap to FP8 is 2.2% at B8 and 1.0% at B16. At 16K, NVFP4 exceeds the matched FP8 efficiency by 4.4%/6.5% at B8/B16.

## Test plan and result

- Final-head focused CPU engine policy/dispatcher/sampler tests: **24 passed**.
- #281 prefix-anchored compatibility regressions on this head: **32 passed**.
- Final-head SM70 source build with CUDA 12.0 / Torch CUDA 12.8 minor-version warning: **passed and linked**.
- Changed-file pre-commit including Ruff, clang-format, Markdown, mypy, SPDX, config and docs gates: **passed**.
- Same-toolchain SASS comparison to the #281 main build: **115/115 common XQA instances identical**, six new, zero changed/missing.
- V100 operator evidence on the same optimized math/routes: **8 attention comparisons** (B2/B16 at p64/p128/p256 and B8/B16 long context), within one FP16 ULP and mean absolute error <= 1e-5; **2 sampler comparisons** (B8/B16), bitwise equal to rollback.
- Matched GSM8K main/test, 32 prompts each at B1/B8/B16: 22/32 to 23/32 at B8, 23/32 unchanged at B16, zero invalid outputs.

No full-model end-to-end or throughput run was repeated after the final current-main rebase; the audited performance patches are equivalent, the measured optimized instances are unchanged, and the requested merge scope is source plus focused validation.