### PR TITLE
[Kernel][SM70] Default long-prefill GQA architecture

### DIFF
--- a/cmake/external_projects/vllm_flash_attn.cmake
+++ b/cmake/external_projects/vllm_flash_attn.cmake
@@ -53,6 +53,9 @@ elseif(VLLM_FLASH_ATTN_SM70)
           COMMAND
             ${PATCH_EXECUTABLE} --batch --forward -p1 -l
             -i ${CMAKE_CURRENT_LIST_DIR}/../patches/sm70_flash_attn_d256_k_pingpong.patch
+          COMMAND
+            ${PATCH_EXECUTABLE} --batch --forward -p1 -l
+            -i ${CMAKE_CURRENT_LIST_DIR}/../patches/sm70_flash_attn_d256_gqa_arch.patch
           BINARY_DIR ${CMAKE_BINARY_DIR}/vllm-flash-attn
   )
 else()

--- a/cmake/patches/sm70_flash_attn_d256_gqa_arch.patch
+++ b/cmake/patches/sm70_flash_attn_d256_gqa_arch.patch
@@ -1,0 +1,1681 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index acf2219..d644e02 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -84,6 +84,7 @@ string(REPLACE "-O2" "-O3" CMAKE_CUDA_FLAGS_RELWITHDEBINFO "${CMAKE_CUDA_FLAGS_R
+
+ if (FA2_ENABLED)
+     set(FA2_GEN_SRCS
++        "csrc/flash_attn/src/flash_fwd_d256_gqa_arch_sm70.cu"
+         "csrc/flash_attn/src/flash_fwd_d256_splitd_sm70.cu"
+         "csrc/flash_attn/src/flash_fwd_hdim256_causal_prefill_sm70.cu"
+         "csrc/flash_attn/src/flash_fwd_split_hdim256_causal_prefill_sm70.cu")
+@@ -114,7 +115,8 @@ if (FA2_ENABLED)
+         csrc/flash_attn
+         csrc/flash_attn/src
+         csrc/common
+-        csrc/cutlass/include)
++        csrc/cutlass/include
++        csrc/cutlass/examples/35_gemm_softmax)
+
+     # custom definitions
+     target_compile_definitions(_vllm_fa2_C PRIVATE
+@@ -125,5 +127,15 @@ if (FA2_ENABLED)
+         # FLASHATTENTION_DISABLE_UNEVEN_K
+         # FLASHATTENTION_DISABLE_LOCAL
+         FLASHATTENTION_DISABLE_PYBIND
++        PREFIX_TORCH_EXTENSION
++        PREFIX_QK_FULL_STATS
++        QK_TB_M=128
++        QK_TB_N=512
++        QK_WARP_M=64
++        QK_WARP_N=128
++        PV_TB_M=64
++        PV_TB_N=256
++        PV_WARP_M=32
++        PV_WARP_N=64
+     )
+ endif ()
+diff --git a/csrc/flash_attn/flash_api_torch_lib.cpp b/csrc/flash_attn/flash_api_torch_lib.cpp
+index 4b7601a..f5b71a2 100644
+--- a/csrc/flash_attn/flash_api_torch_lib.cpp
++++ b/csrc/flash_attn/flash_api_torch_lib.cpp
+@@ -33,6 +33,24 @@ at::Tensor sm70_d256_splitd_dense_splitkv3_fwd(
+     double softmax_scale,
+     bool causal);
+
++at::Tensor sm70_d256_splitd_dense_state_fwd(
++    const at::Tensor &q,
++    const at::Tensor &k,
++    const at::Tensor &v,
++    at::Tensor &state_max,
++    at::Tensor &state_sum,
++    at::Tensor &out,
++    double softmax_scale,
++    bool causal);
++
++at::Tensor sm70_d256_gqa_architecture_fwd(
++    const at::Tensor &q,
++    const at::Tensor &k,
++    const at::Tensor &v,
++    at::Tensor &out,
++    double softmax_scale,
++    bool causal);
++
+ at::Tensor sm70_d256_splitd_paged_fwd(
+     const at::Tensor &q,
+     const at::Tensor &k,
+@@ -98,6 +116,17 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, ops) {
+     ops.impl("sm70_d256_splitd_n32_dense_fwd", torch::kCUDA,
+              make_pytorch_shim(&sm70_d256_splitd_dense_fwd));
+
++    ops.def("sm70_d256_splitd_n32_dense_state_fwd(Tensor q, Tensor k, "
++            "Tensor v, Tensor(a!) state_max, Tensor(b!) state_sum, "
++            "Tensor(c!) out, float softmax_scale, bool causal) -> Tensor(c!)");
++    ops.impl("sm70_d256_splitd_n32_dense_state_fwd", torch::kCUDA,
++             make_pytorch_shim(&sm70_d256_splitd_dense_state_fwd));
++
++    ops.def("sm70_d256_gqa_architecture_fwd(Tensor q, Tensor k, Tensor v, "
++            "Tensor(a!) out, float softmax_scale, bool causal) -> Tensor(a!)");
++    ops.impl("sm70_d256_gqa_architecture_fwd", torch::kCUDA,
++             make_pytorch_shim(&sm70_d256_gqa_architecture_fwd));
++
+     ops.def("sm70_d256_splitd_n32_dense_splitkv3_fwd(Tensor q, Tensor k, "
+             "Tensor v, Tensor(a!) partial_out, Tensor(b!) partial_max, "
+             "Tensor(c!) partial_sum, Tensor(d!) out, float softmax_scale, "
+diff --git a/csrc/flash_attn/src/flash_fwd_d256_gqa_arch_sm70.cu b/csrc/flash_attn/src/flash_fwd_d256_gqa_arch_sm70.cu
+new file mode 100644
+index 0000000..197453f
+--- /dev/null
++++ b/csrc/flash_attn/src/flash_fwd_d256_gqa_arch_sm70.cu
+@@ -0,0 +1,1351 @@
++// SPDX-License-Identifier: BSD-3-Clause
++
++/***************************************************************************************************
++ * End-to-end prefix architecture screen for V100/SM70.
++ *
++ * QK GEMM writes FP16 logits and row statistics. PV normalizes logits in its
++ * A-operand transform and writes one reusable FP16 block partial. A float
++ * online accumulator folds that partial into prefix softmax state before the
++ * next block, avoiding resident storage for every block partial.
++ **************************************************************************************************/
++
++#include <cuda_fp16.h>
++#include <cuda_runtime.h>
++#include <math_constants.h>
++
++#include <algorithm>
++#include <cmath>
++#include <cstdint>
++#include <cstdlib>
++#include <dlfcn.h>
++#include <iostream>
++#include <map>
++#include <memory>
++#include <mutex>
++#include <vector>
++
++#if defined(PREFIX_TORCH_EXTENSION)
++#include <ATen/ATen.h>
++#include <ATen/cuda/CUDAContext.h>
++#include <c10/cuda/CUDAGuard.h>
++#include <c10/cuda/CUDAException.h>
++#include "namespace_config.h"
++#endif
++
++#include "cutlass/cutlass.h"
++#include "cutlass/device_kernel.h"
++#include "cutlass/epilogue/thread/linear_combination.h"
++#include "cutlass/gemm/kernel/default_gemm.h"
++#include "cutlass/gemm/kernel/gemm.h"
++#include "cutlass/gemm/threadblock/mma_pipelined.h"
++#include "cutlass/layout/matrix.h"
++#include "cutlass/numeric_conversion.h"
++#include "gemm_with_softmax.h"
++
++namespace {
++
++using Element = cutlass::half_t;
++
++#ifndef QK_TB_M
++#define QK_TB_M 128
++#endif
++#ifndef QK_TB_N
++#define QK_TB_N 128
++#endif
++#ifndef QK_WARP_M
++#define QK_WARP_M 32
++#endif
++#ifndef QK_WARP_N
++#define QK_WARP_N 64
++#endif
++
++using QKLayoutA = cutlass::layout::RowMajor;
++using QKLayoutB = cutlass::layout::ColumnMajor;
++using QKThreadblockShape = cutlass::gemm::GemmShape<QK_TB_M, QK_TB_N, 32>;
++using QKWarpShape = cutlass::gemm::GemmShape<QK_WARP_M, QK_WARP_N, 32>;
++using QKInstructionShape = cutlass::gemm::GemmShape<8, 8, 4>;
++using QKOutputOp = cutlass::epilogue::thread::LinearCombination<
++    Element, 8, Element, Element>;
++using QKGemm = cutlass::GemmSoftmax<
++    Element,
++    QKLayoutA,
++    Element,
++    QKLayoutB,
++    Element,
++    Element,
++    cutlass::arch::OpClassTensorOp,
++    cutlass::arch::Sm70,
++    QKThreadblockShape,
++    QKWarpShape,
++    QKInstructionShape,
++    QKOutputOp,
++    2,
++    cutlass::MatrixShape<1, 1024>>;
++
++#ifndef PV_TB_M
++#define PV_TB_M 64
++#endif
++#ifndef PV_TB_N
++#define PV_TB_N 128
++#endif
++#ifndef PV_WARP_M
++#define PV_WARP_M 32
++#endif
++#ifndef PV_WARP_N
++#define PV_WARP_N 64
++#endif
++
++using PVLayout = cutlass::layout::RowMajor;
++using PVAccumulator = Element;
++using PVThreadblockShape = cutlass::gemm::GemmShape<PV_TB_M, PV_TB_N, 32>;
++using PVWarpShape = cutlass::gemm::GemmShape<PV_WARP_M, PV_WARP_N, 32>;
++using PVInstructionShape = cutlass::gemm::GemmShape<8, 8, 4>;
++using PVSwizzle = cutlass::gemm::threadblock::GemmIdentityThreadblockSwizzle<>;
++using PVOutputOp = cutlass::epilogue::thread::LinearCombination<
++    Element, 8, PVAccumulator, float>;
++
++constexpr int kPVAlignment = 8;
++
++using PVDefaultKernel = typename cutlass::gemm::kernel::DefaultGemm<
++    Element,
++    PVLayout,
++    kPVAlignment,
++    Element,
++    PVLayout,
++    kPVAlignment,
++    Element,
++    PVLayout,
++    PVAccumulator,
++    cutlass::arch::OpClassTensorOp,
++    cutlass::arch::Sm70,
++    PVThreadblockShape,
++    PVWarpShape,
++    PVInstructionShape,
++    PVOutputOp,
++    PVSwizzle,
++    2,
++    false,
++    cutlass::arch::OpMultiplyAdd>::GemmKernel;
++
++using PVDefaultMma = typename PVDefaultKernel::Mma;
++using PVIteratorA = typename PVDefaultMma::IteratorA;
++using PVIteratorB = typename PVDefaultMma::IteratorB;
++using PVSmemIteratorA = typename PVDefaultMma::SmemIteratorA;
++using PVSmemIteratorB = typename PVDefaultMma::SmemIteratorB;
++
++__device__ float const* g_row_max = nullptr;
++__device__ float const* g_row_inv_sum = nullptr;
++__device__ float* g_row_sum_out = nullptr;
++__device__ int g_rows = 0;
++
++#if defined(PREFIX_QK_FULL_STATS)
++struct ExpRowSumTransformA {
++  using InputFragment = typename PVIteratorA::Fragment;
++  using OutputFragment = cutlass::Array<
++      typename PVSmemIteratorA::Element, InputFragment::kElements>;
++  using ThreadMap = typename PVIteratorA::ThreadMap;
++  static constexpr int kAccessesPerVector =
++      PVIteratorA::UnderlyingIterator::kAccessesPerVector;
++  static constexpr int kContiguousIterations =
++      ThreadMap::Iterations::kContiguous;
++  static constexpr int kStridedIterations = ThreadMap::Iterations::kStrided;
++
++  float row_max[kStridedIterations];
++  float row_inv_sum[kStridedIterations];
++
++  CUTLASS_DEVICE
++  ExpRowSumTransformA() {
++    auto thread_offset = ThreadMap::initial_offset(threadIdx.x);
++#pragma unroll
++    for (int s = 0; s < kStridedIterations; ++s) {
++      int row = blockIdx.x * PVThreadblockShape::kM
++          + thread_offset.strided() + s * ThreadMap::Delta::kStrided;
++      row_max[s] = row < g_rows ? g_row_max[row] : 0.0f;
++      row_inv_sum[s] = row < g_rows ? g_row_inv_sum[row] : 0.0f;
++    }
++  }
++
++  CUTLASS_DEVICE
++  OutputFragment operator()(InputFragment const& input) {
++    OutputFragment output;
++    constexpr float kLog2E = 1.4426950408889634f;
++    constexpr int kElementsPerAccess = PVIteratorA::AccessType::kElements;
++    auto const* input_access =
++        reinterpret_cast<typename PVIteratorA::AccessType const*>(&input);
++    auto* output_access =
++        reinterpret_cast<typename PVIteratorA::AccessType*>(&output);
++#pragma unroll
++    for (int s = 0; s < kStridedIterations; ++s) {
++#pragma unroll
++      for (int c = 0; c < kContiguousIterations; ++c) {
++#pragma unroll
++        for (int v = 0; v < kAccessesPerVector; ++v) {
++          int index = v + kAccessesPerVector * (c + s * kContiguousIterations);
++          typename PVIteratorA::AccessType transformed;
++#pragma unroll
++          for (int e = 0; e < kElementsPerAccess; ++e) {
++            float value = static_cast<float>(input_access[index][e]);
++            transformed[e] = Element(
++                exp2f((value - row_max[s]) * kLog2E) * row_inv_sum[s]);
++          }
++          output_access[index] = transformed;
++        }
++      }
++    }
++    return output;
++  }
++};
++#else
++struct ExpRowSumTransformA {
++  using InputFragment = typename PVIteratorA::Fragment;
++  using OutputFragment = cutlass::Array<
++      typename PVSmemIteratorA::Element, InputFragment::kElements>;
++  using ThreadMap = typename PVIteratorA::ThreadMap;
++
++  static constexpr int kAccessesPerVector =
++      PVIteratorA::UnderlyingIterator::kAccessesPerVector;
++  static constexpr int kContiguousIterations =
++      ThreadMap::Iterations::kContiguous;
++  static constexpr int kStridedIterations = ThreadMap::Iterations::kStrided;
++
++  float row_max[kStridedIterations];
++  float row_sum[kStridedIterations];
++  bool valid = true;
++
++  CUTLASS_DEVICE
++  void set_valid(bool is_valid) {
++    valid = is_valid;
++  }
++
++  CUTLASS_DEVICE
++  ExpRowSumTransformA() {
++    auto thread_offset = ThreadMap::initial_offset(threadIdx.x);
++#pragma unroll
++    for (int s = 0; s < kStridedIterations; ++s) {
++      int row = blockIdx.x * PVThreadblockShape::kM
++          + thread_offset.strided() + s * ThreadMap::Delta::kStrided;
++      row_max[s] = row < g_rows ? g_row_max[row] : 0.0f;
++      row_sum[s] = 0.0f;
++    }
++  }
++
++  CUTLASS_DEVICE
++  OutputFragment operator()(InputFragment const& input) {
++    if (!valid) {
++      OutputFragment output;
++      output.clear();
++      return output;
++    }
++    OutputFragment output;
++    constexpr float kLog2E = 1.4426950408889634f;
++    constexpr int kElementsPerAccess = PVIteratorA::AccessType::kElements;
++    auto const* input_access =
++        reinterpret_cast<typename PVIteratorA::AccessType const*>(&input);
++    auto* output_access =
++        reinterpret_cast<typename PVIteratorA::AccessType*>(&output);
++#pragma unroll
++    for (int s = 0; s < kStridedIterations; ++s) {
++#pragma unroll
++      for (int c = 0; c < kContiguousIterations; ++c) {
++#pragma unroll
++        for (int v = 0; v < kAccessesPerVector; ++v) {
++          int index = v + kAccessesPerVector * (c + s * kContiguousIterations);
++          typename PVIteratorA::AccessType transformed;
++#pragma unroll
++          for (int e = 0; e < kElementsPerAccess; ++e) {
++            float value = static_cast<float>(input_access[index][e]);
++            float weight = exp2f((value - row_max[s]) * kLog2E);
++            if (blockIdx.y == 0) {
++              row_sum[s] += weight;
++            }
++            transformed[e] = Element(weight);
++          }
++          output_access[index] = transformed;
++        }
++      }
++    }
++    return output;
++  }
++
++  CUTLASS_DEVICE
++  void finalize() {
++    if (blockIdx.y != 0) {
++      return;
++    }
++    constexpr int kThreadsPerRow =
++        ThreadMap::Detail::WarpThreadArrangement::kContiguous;
++    auto thread_offset = ThreadMap::initial_offset(threadIdx.x);
++    int lane = threadIdx.x & 31;
++#pragma unroll
++    for (int s = 0; s < kStridedIterations; ++s) {
++      float sum = row_sum[s];
++#pragma unroll
++      for (int offset = 1; offset < kThreadsPerRow; offset <<= 1) {
++        sum += __shfl_xor_sync(0xffffffffu, sum, offset);
++      }
++      int row = blockIdx.x * PVThreadblockShape::kM
++          + thread_offset.strided() + s * ThreadMap::Delta::kStrided;
++      if ((lane % kThreadsPerRow) == 0 && row < g_rows) {
++        g_row_sum_out[row] = sum;
++      }
++    }
++  }
++};
++#endif
++
++using PVTransformB = cutlass::NumericArrayConverter<
++    typename PVSmemIteratorB::Element,
++    typename PVIteratorB::Element,
++    PVIteratorB::Fragment::kElements>;
++using PVMma = cutlass::gemm::threadblock::MmaPipelined<
++    typename PVDefaultMma::Shape,
++    PVIteratorA,
++    PVSmemIteratorA,
++    PVIteratorB,
++    PVSmemIteratorB,
++    PVAccumulator,
++    PVLayout,
++    typename PVDefaultMma::Policy,
++    ExpRowSumTransformA,
++    PVTransformB>;
++using PVKernel = cutlass::gemm::kernel::Gemm<
++    PVMma, typename PVDefaultKernel::Epilogue, PVSwizzle, false>;
++
++void check(cudaError_t result, char const* operation) {
++  if (result != cudaSuccess) {
++    std::cerr << operation << ": " << cudaGetErrorString(result) << "\n";
++    std::exit(EXIT_FAILURE);
++  }
++}
++
++void check(cutlass::Status status, char const* operation) {
++  if (status != cutlass::Status::kSuccess) {
++    std::cerr << operation << ": CUTLASS status " << int(status) << "\n";
++    std::exit(EXIT_FAILURE);
++  }
++}
++
++struct PVLauncher {
++  typename PVKernel::Params params;
++  dim3 grid;
++  dim3 block;
++  int smem_bytes;
++
++  PVLauncher(Element* scores, Element* value, Element* output, int rows, int k) {
++    cutlass::gemm::GemmCoord problem(rows, 256, k);
++    PVSwizzle swizzle;
++    auto tiled_shape = swizzle.get_tiled_shape(
++        problem,
++        {PVThreadblockShape::kM, PVThreadblockShape::kN,
++         PVThreadblockShape::kK},
++        1);
++    params = typename PVKernel::Params(
++        problem,
++        tiled_shape,
++        {scores, PVLayout(k)},
++        {value, PVLayout(256)},
++        {output, PVLayout(256)},
++        {output, PVLayout(256)},
++        typename PVOutputOp::Params(1.0f, 0.0f),
++        nullptr);
++    grid = swizzle.get_grid_shape(tiled_shape);
++    block = dim3(PVKernel::kThreadCount, 1, 1);
++    smem_bytes = int(sizeof(typename PVKernel::SharedStorage));
++    if (smem_bytes >= 48 * 1024) {
++      check(cudaFuncSetAttribute(
++                cutlass::Kernel<PVKernel>,
++                cudaFuncAttributeMaxDynamicSharedMemorySize,
++                smem_bytes),
++            "set PV dynamic shared memory");
++    }
++  }
++
++  void launch(cudaStream_t stream) const {
++    cutlass::Kernel<PVKernel><<<grid, block, smem_bytes, stream>>>(params);
++  }
++};
++
++__global__ void prepare_weights(
++    float const* block_max,
++    float const* block_sum,
++    float* weights,
++    float* state_max,
++    float* state_sum,
++    int blocks,
++    int rows) {
++  int row = blockIdx.x * blockDim.x + threadIdx.x;
++  if (row >= rows) {
++    return;
++  }
++  float global_max = -CUDART_INF_F;
++  for (int block = 0; block < blocks; ++block) {
++    global_max = fmaxf(global_max, block_max[block * rows + row]);
++  }
++  float denominator = 0.0f;
++  for (int block = 0; block < blocks; ++block) {
++    float scale = exp2f(
++        (block_max[block * rows + row] - global_max) *
++        1.4426950408889634f);
++#if defined(PREFIX_QK_FULL_STATS)
++    float scaled_sum = scale / block_sum[block * rows + row];
++    weights[block * rows + row] = scaled_sum;
++    denominator += scaled_sum;
++#else
++    weights[block * rows + row] = scale;
++    denominator += scale * block_sum[block * rows + row];
++#endif
++  }
++  float inverse = 1.0f / denominator;
++  for (int block = 0; block < blocks; ++block) {
++    weights[block * rows + row] *= inverse;
++  }
++  state_max[row] = global_max;
++  state_sum[row] = denominator;
++}
++
++__global__ void merge_partials(
++    __half const* partials,
++    float const* weights,
++    __half* output,
++    int blocks,
++    int rows) {
++  int pair = blockIdx.x * blockDim.x + threadIdx.x;
++  constexpr int kPairsPerRow = 128;
++  int total_pairs = rows * kPairsPerRow;
++  if (pair >= total_pairs) {
++    return;
++  }
++  int row = pair / kPairsPerRow;
++  int column_pair = pair - row * kPairsPerRow;
++  float2 accumulator = make_float2(0.0f, 0.0f);
++  auto const* partials2 = reinterpret_cast<__half2 const*>(partials);
++  auto* output2 = reinterpret_cast<__half2*>(output);
++  for (int block = 0; block < blocks; ++block) {
++    int index = (block * rows + row) * kPairsPerRow + column_pair;
++    float2 value = __half22float2(partials2[index]);
++    float weight = weights[block * rows + row];
++    accumulator.x = fmaf(weight, value.x, accumulator.x);
++    accumulator.y = fmaf(weight, value.y, accumulator.y);
++  }
++  output2[pair] = __floats2half2_rn(accumulator.x, accumulator.y);
++}
++
++__global__ void update_prefix_accumulator(
++    __half const* block_output,
++    float const* block_max,
++    float const* block_inv_sum,
++    float* prefix_accumulator,
++    float* prefix_max,
++    float* prefix_sum,
++    int rows,
++    bool initialize) {
++  int row = blockIdx.x;
++  int d = threadIdx.x;
++  if (row >= rows || d >= 256) {
++    return;
++  }
++  __shared__ float scales[3];
++  if (d == 0) {
++    constexpr float kLog2E = 1.4426950408889634f;
++    float next_max = block_max[row];
++    float next_mass = 1.0f / block_inv_sum[row];
++    if (initialize) {
++      scales[0] = 0.0f;
++      scales[1] = next_mass;
++      scales[2] = next_mass;
++      prefix_max[row] = next_max;
++    } else {
++      float old_max = prefix_max[row];
++      float global_max = fmaxf(old_max, next_max);
++      float old_scale = exp2f((old_max - global_max) * kLog2E);
++      float next_scale = exp2f((next_max - global_max) * kLog2E);
++      scales[0] = old_scale;
++      scales[1] = next_mass * next_scale;
++      scales[2] = prefix_sum[row] * old_scale + scales[1];
++      prefix_max[row] = global_max;
++    }
++    prefix_sum[row] = scales[2];
++  }
++  __syncthreads();
++  int64_t element = int64_t(row) * 256 + d;
++  float block_value = float(block_output[element]);
++  float old_value = initialize ? 0.0f : prefix_accumulator[element];
++  prefix_accumulator[element] =
++      fmaf(old_value, scales[0], block_value * scales[1]);
++}
++
++__global__ void prepare_prefix_update(
++    float const* block_max,
++    float const* block_inv_sum,
++    float* prefix_max,
++    float* prefix_sum,
++    float* old_scales,
++    float* block_scales,
++    int rows,
++    bool initialize) {
++  int row = blockIdx.x * blockDim.x + threadIdx.x;
++  if (row >= rows) {
++    return;
++  }
++  constexpr float kLog2E = 1.4426950408889634f;
++  float next_max = block_max[row];
++  float next_mass = 1.0f / block_inv_sum[row];
++  if (initialize) {
++    old_scales[row] = 0.0f;
++    block_scales[row] = next_mass;
++    prefix_max[row] = next_max;
++    prefix_sum[row] = next_mass;
++    return;
++  }
++  float old_max = prefix_max[row];
++  float global_max = fmaxf(old_max, next_max);
++  float old_scale = exp2f((old_max - global_max) * kLog2E);
++  float block_scale =
++      next_mass * exp2f((next_max - global_max) * kLog2E);
++  old_scales[row] = old_scale;
++  block_scales[row] = block_scale;
++  prefix_max[row] = global_max;
++  prefix_sum[row] = prefix_sum[row] * old_scale + block_scale;
++}
++
++__global__ void apply_prefix_update_half2(
++    __half const* block_output,
++    float* prefix_accumulator,
++    float const* old_scales,
++    float const* block_scales,
++    int rows,
++    bool initialize) {
++  int pair = blockIdx.x * blockDim.x + threadIdx.x;
++  constexpr int kPairsPerRow = 128;
++  if (pair >= rows * kPairsPerRow) {
++    return;
++  }
++  int row = pair / kPairsPerRow;
++  auto const* block2 = reinterpret_cast<__half2 const*>(block_output);
++  auto* accumulator2 = reinterpret_cast<float2*>(prefix_accumulator);
++  float2 block_value = __half22float2(block2[pair]);
++  float2 old_value = initialize
++      ? make_float2(0.0f, 0.0f)
++      : accumulator2[pair];
++  float old_scale = old_scales[row];
++  float block_scale = block_scales[row];
++  accumulator2[pair] = make_float2(
++      fmaf(old_value.x, old_scale, block_value.x * block_scale),
++      fmaf(old_value.y, old_scale, block_value.y * block_scale));
++}
++
++__global__ void finalize_prefix_accumulator(
++    float const* prefix_accumulator,
++    float const* prefix_sum,
++    __half* output,
++    int rows) {
++  int pair = blockIdx.x * blockDim.x + threadIdx.x;
++  constexpr int kPairsPerRow = 128;
++  if (pair >= rows * kPairsPerRow) {
++    return;
++  }
++  int row = pair / kPairsPerRow;
++  int64_t first = int64_t(pair) * 2;
++  float inverse = 1.0f / prefix_sum[row];
++  output[first] = __float2half_rn(prefix_accumulator[first] * inverse);
++  output[first + 1] =
++      __float2half_rn(prefix_accumulator[first + 1] * inverse);
++}
++
++__global__ void merge_prefix_accumulator_tail(
++    float const* prefix_accumulator,
++    float const* prefix_max,
++    float const* prefix_sum,
++    __half const* tail_output,
++    float const* tail_max,
++    float const* tail_sum,
++    __half* output,
++    int rows) {
++  int row = blockIdx.x;
++  int d = threadIdx.x;
++  __shared__ float masses[3];
++  if (d == 0) {
++    constexpr float kLog2E = 1.4426950408889634f;
++    float global_max = fmaxf(prefix_max[row], tail_max[row]);
++    masses[0] = exp2f((prefix_max[row] - global_max) * kLog2E);
++    masses[1] = tail_sum[row]
++        * exp2f((tail_max[row] - global_max) * kLog2E);
++    masses[2] = 1.0f / (prefix_sum[row] * masses[0] + masses[1]);
++  }
++  __syncthreads();
++  int64_t element = int64_t(row) * 256 + d;
++  float numerator = prefix_accumulator[element] * masses[0]
++      + float(tail_output[element]) * masses[1];
++  output[element] = __float2half_rn(numerator * masses[2]);
++}
++
++__global__ void merge_prefix_tail(
++    __half const* prefix_output,
++    float const* prefix_max,
++    float const* prefix_sum,
++    __half const* tail_output,
++    float const* tail_max,
++    float const* tail_sum,
++    __half* output,
++    int rows) {
++  int row = blockIdx.x;
++  int d = threadIdx.x;
++  __shared__ float masses[3];
++  if (d == 0) {
++    float global_max = fmaxf(prefix_max[row], tail_max[row]);
++    float prefix_scale = exp2f(
++        (prefix_max[row] - global_max) * 1.4426950408889634f);
++    float tail_scale = exp2f(
++        (tail_max[row] - global_max) * 1.4426950408889634f);
++    masses[0] = prefix_sum[row] * prefix_scale;
++    masses[1] = tail_sum[row] * tail_scale;
++    masses[2] = 1.0f / (masses[0] + masses[1]);
++  }
++  __syncthreads();
++  int64_t element = int64_t(row) * 256 + d;
++  float numerator = float(prefix_output[element]) * masses[0]
++      + float(tail_output[element]) * masses[1];
++  output[element] = __float2half_rn(numerator * masses[2]);
++}
++
++using DenseTailRaw = cudaError_t (*)(
++    const void*,
++    const void*,
++    const void*,
++    float*,
++    float*,
++    void*,
++    int,
++    int,
++    int,
++    int,
++    float,
++    cudaStream_t);
++
++__global__ void fill_pattern(__half* data, size_t elements, uint32_t seed) {
++  size_t index = size_t(blockIdx.x) * blockDim.x + threadIdx.x;
++  if (index >= elements) {
++    return;
++  }
++  uint32_t value = uint32_t(index) ^ seed;
++  value ^= value >> 16;
++  value *= 0x7feb352du;
++  value ^= value >> 15;
++  value *= 0x846ca68bu;
++  value ^= value >> 16;
++  float uniform = float(value & 0xffffu) * (2.0f / 65535.0f) - 1.0f;
++  data[index] = __float2half_rn(uniform);
++}
++
++struct BlockOperators {
++  int width;
++  QKGemm qk;
++  std::unique_ptr<PVLauncher> pv;
++};
++
++}  // namespace
++
++#if !defined(PREFIX_TORCH_EXTENSION)
++int main(int argc, char** argv) {
++  int block_n = argc > 1 ? std::atoi(argv[1]) : 2048;
++  int iterations = argc > 2 ? std::atoi(argv[2]) : 5;
++#if defined(PREFIX_FULL_ENDPOINT)
++  if (argc <= 3) {
++    std::cerr << "full endpoint requires the exact-tail extension path\n";
++    return EXIT_FAILURE;
++  }
++#endif
++  constexpr int kRows = 48000;
++  constexpr int kHeadDim = 256;
++  constexpr int kPrefix = 120000;
++  constexpr int kTail = 8000;
++  constexpr int kTotalKV = kPrefix + kTail;
++#if defined(PREFIX_FULL_ENDPOINT)
++  constexpr int kStoredKV = kTotalKV;
++#else
++  constexpr int kStoredKV = kPrefix;
++#endif
++  int blocks = (kPrefix + block_n - 1) / block_n;
++
++  Element* query = nullptr;
++  Element* key = nullptr;
++  Element* value = nullptr;
++  Element* scores = nullptr;
++  Element* partials = nullptr;
++  Element* output = nullptr;
++  float* qk_norm = nullptr;
++  float* qk_sum = nullptr;
++  float* prefix_accumulator = nullptr;
++  float* prefix_max = nullptr;
++  float* prefix_sum = nullptr;
++  float* old_scales = nullptr;
++  float* block_scales = nullptr;
++#if defined(PREFIX_FULL_ENDPOINT)
++  Element* tail_output = nullptr;
++  Element* final_output = nullptr;
++  Element* exact_output = nullptr;
++  float* tail_max = nullptr;
++  float* tail_sum = nullptr;
++#endif
++
++  int qk_tiles_n = (block_n + QKThreadblockShape::kN - 1) /
++      QKThreadblockShape::kN;
++  size_t partial_elements = size_t(kRows) * kHeadDim;
++  check(cudaMalloc(&query, size_t(kRows) * kHeadDim * sizeof(Element)), "allocate Q");
++  check(cudaMalloc(&key, size_t(kStoredKV) * kHeadDim * sizeof(Element)), "allocate K");
++  check(cudaMalloc(&value, size_t(kStoredKV) * kHeadDim * sizeof(Element)), "allocate V");
++  check(cudaMalloc(&scores, size_t(kRows) * block_n * sizeof(Element)), "allocate scores");
++  check(cudaMalloc(&partials, partial_elements * sizeof(Element)), "allocate partials");
++  check(cudaMalloc(&output, size_t(kRows) * kHeadDim * sizeof(Element)), "allocate output");
++  check(cudaMalloc(&qk_norm, size_t(qk_tiles_n) * kRows * sizeof(float)), "allocate QK max");
++  check(cudaMalloc(&qk_sum, size_t(qk_tiles_n) * kRows * sizeof(float)), "allocate QK sum");
++  check(cudaMalloc(
++            &prefix_accumulator,
++            size_t(kRows) * kHeadDim * sizeof(float)),
++        "allocate prefix accumulator");
++  check(cudaMalloc(&prefix_max, size_t(kRows) * sizeof(float)), "allocate prefix max");
++  check(cudaMalloc(&prefix_sum, size_t(kRows) * sizeof(float)), "allocate prefix sum");
++  check(cudaMalloc(&old_scales, size_t(kRows) * sizeof(float)),
++        "allocate old scales");
++  check(cudaMalloc(&block_scales, size_t(kRows) * sizeof(float)),
++        "allocate block scales");
++#if defined(PREFIX_FULL_ENDPOINT)
++  check(cudaMalloc(&tail_output, size_t(kRows) * kHeadDim * sizeof(Element)),
++        "allocate tail output");
++  check(cudaMalloc(&final_output, size_t(kRows) * kHeadDim * sizeof(Element)),
++        "allocate final output");
++  check(cudaMalloc(&exact_output, size_t(kRows) * kHeadDim * sizeof(Element)),
++        "allocate exact output");
++  check(cudaMalloc(&tail_max, size_t(kRows) * sizeof(float)), "allocate tail max");
++  check(cudaMalloc(&tail_sum, size_t(kRows) * sizeof(float)), "allocate tail sum");
++#endif
++  size_t query_elements = size_t(kRows) * kHeadDim;
++  size_t kv_elements = size_t(kStoredKV) * kHeadDim;
++  fill_pattern<<<(query_elements + 255) / 256, 256>>>(
++      reinterpret_cast<__half*>(query), query_elements, 0x12345678u);
++  fill_pattern<<<(kv_elements + 255) / 256, 256>>>(
++      reinterpret_cast<__half*>(key), kv_elements, 0x9abcdef0u);
++  fill_pattern<<<(kv_elements + 255) / 256, 256>>>(
++      reinterpret_cast<__half*>(value), kv_elements, 0x31415926u);
++  check(cudaGetLastError(), "initialize deterministic inputs");
++
++#if defined(PREFIX_FULL_ENDPOINT)
++  void* tail_handle = dlopen(argv[3], RTLD_NOW | RTLD_LOCAL);
++  if (tail_handle == nullptr) {
++    std::cerr << "load exact-tail extension: " << dlerror() << "\n";
++    return EXIT_FAILURE;
++  }
++  dlerror();
++  auto tail_raw = reinterpret_cast<DenseTailRaw>(
++      dlsym(tail_handle, "onecat_sm70_d256_dense_state_raw"));
++  char const* symbol_error = dlerror();
++  if (symbol_error != nullptr || tail_raw == nullptr) {
++    std::cerr << "load exact-tail entry point: "
++              << (symbol_error == nullptr ? "missing symbol" : symbol_error)
++              << "\n";
++    return EXIT_FAILURE;
++  }
++#endif
++
++  std::vector<BlockOperators> operators;
++  operators.reserve(blocks);
++  for (int block = 0; block < blocks; ++block) {
++    int begin = block * block_n;
++    int width = std::min(block_n, kPrefix - begin);
++    BlockOperators operation;
++    operation.width = width;
++    typename QKGemm::Arguments arguments(
++        {kRows, width, kHeadDim},
++        1,
++        {query, QKLayoutA(kHeadDim)},
++        {key + size_t(begin) * kHeadDim, QKLayoutB(kHeadDim)},
++        {scores, typename QKGemm::LayoutC(width)},
++        {scores, typename QKGemm::LayoutC(width)},
++        {Element(0.0625f), Element(0.0f)},
++        {qk_norm, typename QKGemm::LayoutN(kRows)},
++        {qk_sum, typename QKGemm::LayoutS(kRows)},
++        {scores, typename QKGemm::LayoutSoft(width)});
++    check(operation.qk.initialize(arguments), "initialize QK");
++    operation.pv = std::make_unique<PVLauncher>(
++        scores,
++        value + size_t(begin) * kHeadDim,
++        partials,
++        kRows,
++        width);
++    operators.push_back(std::move(operation));
++  }
++
++  check(cudaMemcpyToSymbol(g_rows, &kRows, sizeof(kRows)), "set row count");
++  float const* persistent_max_ptr = qk_norm;
++  check(cudaMemcpyToSymbol(
++            g_row_max,
++            &persistent_max_ptr,
++            sizeof(persistent_max_ptr)),
++        "set persistent PV max pointer");
++#if defined(PREFIX_QK_FULL_STATS)
++  float const* persistent_inv_sum_ptr = qk_sum;
++  check(cudaMemcpyToSymbol(
++            g_row_inv_sum,
++            &persistent_inv_sum_ptr,
++            sizeof(persistent_inv_sum_ptr)),
++        "set persistent PV inverse-sum pointer");
++#endif
++  cudaStream_t stream = nullptr;
++  auto launch = [&](cudaEvent_t blocks_done,
++                    cudaEvent_t prefix_done,
++                    cudaEvent_t tail_done) {
++    for (int block = 0; block < blocks; ++block) {
++      check(operators[block].qk(stream), "launch QK max");
++#if !defined(PREFIX_QK_FULL_STATS)
++      float* sum_ptr = block_sum + size_t(block) * kRows;
++      check(cudaMemcpyToSymbolAsync(
++                g_row_sum_out,
++                &sum_ptr,
++                sizeof(sum_ptr),
++                0,
++                cudaMemcpyHostToDevice,
++                stream),
++            "set PV sum pointer");
++#endif
++      operators[block].pv->launch(stream);
++      prepare_prefix_update<<<(kRows + 255) / 256, 256, 0, stream>>>(
++          qk_norm,
++          qk_sum,
++          prefix_max,
++          prefix_sum,
++          old_scales,
++          block_scales,
++          kRows,
++          block == 0);
++      int pairs = kRows * kHeadDim / 2;
++      apply_prefix_update_half2<<<(pairs + 255) / 256, 256, 0, stream>>>(
++          reinterpret_cast<__half const*>(partials),
++          prefix_accumulator,
++          old_scales,
++          block_scales,
++          kRows,
++          block == 0);
++    }
++    if (blocks_done != nullptr) {
++      check(cudaEventRecord(blocks_done, stream), "record QK/PV blocks done");
++    }
++#if !defined(PREFIX_FULL_ENDPOINT)
++    int pairs = kRows * kHeadDim / 2;
++    finalize_prefix_accumulator<<<(pairs + 255) / 256, 256, 0, stream>>>(
++        prefix_accumulator,
++        prefix_sum,
++        reinterpret_cast<__half*>(output),
++        kRows);
++#endif
++    if (prefix_done != nullptr) {
++      check(cudaEventRecord(prefix_done, stream), "record prefix merge done");
++    }
++#if defined(PREFIX_FULL_ENDPOINT)
++    check(tail_raw(
++              query,
++              key + size_t(kPrefix) * kHeadDim,
++              value + size_t(kPrefix) * kHeadDim,
++              tail_max,
++              tail_sum,
++              tail_output,
++              kTail,
++              kTail,
++              6,
++              1,
++              0.0625f,
++              stream),
++          "launch exact causal tail");
++    if (tail_done != nullptr) {
++      check(cudaEventRecord(tail_done, stream), "record causal tail done");
++    }
++    merge_prefix_accumulator_tail<<<kRows, kHeadDim, 0, stream>>>(
++        prefix_accumulator,
++        prefix_max,
++        prefix_sum,
++        reinterpret_cast<__half const*>(tail_output),
++        tail_max,
++        tail_sum,
++        reinterpret_cast<__half*>(final_output),
++        kRows);
++#endif
++  };
++
++  launch(nullptr, nullptr, nullptr);
++  check(cudaDeviceSynchronize(), "warmup synchronize");
++  cudaEvent_t start;
++  cudaEvent_t stop;
++  check(cudaEventCreate(&start), "create start");
++  check(cudaEventCreate(&stop), "create stop");
++  check(cudaEventRecord(start), "record start");
++  for (int iteration = 0; iteration < iterations; ++iteration) {
++    launch(nullptr, nullptr, nullptr);
++  }
++  check(cudaEventRecord(stop), "record stop");
++  check(cudaEventSynchronize(stop), "synchronize stop");
++  float elapsed_ms = 0.0f;
++  check(cudaEventElapsedTime(&elapsed_ms, start, stop), "elapsed time");
++  float endpoint_ms = elapsed_ms / float(iterations);
++  constexpr double kFrozenUsefulTflop = 60.0 * 0.101581;
++#if defined(PREFIX_FULL_ENDPOINT)
++  cudaEvent_t phase_start;
++  cudaEvent_t blocks_done;
++  cudaEvent_t prefix_done;
++  cudaEvent_t tail_done;
++  cudaEvent_t phase_stop;
++  check(cudaEventCreate(&phase_start), "create phase start");
++  check(cudaEventCreate(&blocks_done), "create blocks done");
++  check(cudaEventCreate(&prefix_done), "create prefix done");
++  check(cudaEventCreate(&tail_done), "create tail done");
++  check(cudaEventCreate(&phase_stop), "create phase stop");
++  check(cudaEventRecord(phase_start, stream), "record phase start");
++  launch(blocks_done, prefix_done, tail_done);
++  check(cudaEventRecord(phase_stop, stream), "record phase stop");
++  check(cudaEventSynchronize(phase_stop), "synchronize phase stop");
++  float blocks_ms = 0.0f;
++  float prefix_merge_ms = 0.0f;
++  float tail_ms = 0.0f;
++  float final_merge_ms = 0.0f;
++  check(cudaEventElapsedTime(&blocks_ms, phase_start, blocks_done),
++        "measure QK/PV blocks");
++  check(cudaEventElapsedTime(&prefix_merge_ms, blocks_done, prefix_done),
++        "measure prefix merge");
++  check(cudaEventElapsedTime(&tail_ms, prefix_done, tail_done),
++        "measure causal tail");
++  check(cudaEventElapsedTime(&final_merge_ms, tail_done, phase_stop),
++        "measure final merge");
++  check(tail_raw(
++            query,
++            key,
++            value,
++            tail_max,
++            tail_sum,
++            exact_output,
++            kTail,
++            kTotalKV,
++            6,
++            1,
++            0.0625f,
++            stream),
++        "launch monolithic exact reference");
++  check(cudaDeviceSynchronize(), "synchronize exact reference");
++  size_t output_elements = size_t(kRows) * kHeadDim;
++  std::vector<__half> candidate_host(output_elements);
++  std::vector<__half> reference_host(output_elements);
++  check(cudaMemcpy(
++            candidate_host.data(),
++            final_output,
++            output_elements * sizeof(__half),
++            cudaMemcpyDeviceToHost),
++        "copy candidate output");
++  check(cudaMemcpy(
++            reference_host.data(),
++            exact_output,
++            output_elements * sizeof(__half),
++            cudaMemcpyDeviceToHost),
++        "copy exact output");
++  double squared_error = 0.0;
++  double squared_reference = 0.0;
++  double absolute_error = 0.0;
++  float max_absolute_error = 0.0f;
++  size_t equal_elements = 0;
++  for (size_t index = 0; index < output_elements; ++index) {
++    float candidate_value = __half2float(candidate_host[index]);
++    float reference_value = __half2float(reference_host[index]);
++    float difference = candidate_value - reference_value;
++    float absolute = std::fabs(difference);
++    squared_error += double(difference) * difference;
++    squared_reference += double(reference_value) * reference_value;
++    absolute_error += absolute;
++    max_absolute_error = std::max(max_absolute_error, absolute);
++    equal_elements += candidate_value == reference_value;
++  }
++  double relative_l2 = std::sqrt(squared_error / squared_reference);
++  double mean_absolute_error = absolute_error / double(output_elements);
++  double measured_tflops = kFrozenUsefulTflop / (endpoint_ms * 1.0e-3);
++  std::cout << "{\n"
++            << "  \"block_n\": " << block_n << ",\n"
++            << "  \"blocks\": " << blocks << ",\n"
++            << "  \"full_attention_ms\": " << endpoint_ms << ",\n"
++            << "  \"useful_causal_tflops\": " << measured_tflops << ",\n"
++            << "  \"prefix_tokens\": " << kPrefix << ",\n"
++            << "  \"causal_tail_tokens\": " << kTail << ",\n"
++            << "  \"phases_ms\": {\n"
++            << "    \"prefix_qk_pv_blocks\": " << blocks_ms << ",\n"
++            << "    \"prefix_state_and_partial_merge\": "
++            << prefix_merge_ms << ",\n"
++            << "    \"exact_causal_tail\": " << tail_ms << ",\n"
++            << "    \"prefix_tail_merge\": " << final_merge_ms << "\n"
++            << "  },\n"
++            << "  \"numerical\": {\n"
++            << "    \"max_abs_diff\": " << max_absolute_error << ",\n"
++            << "    \"mean_abs_diff\": " << mean_absolute_error << ",\n"
++            << "    \"relative_l2\": " << relative_l2 << ",\n"
++            << "    \"equal_elements\": " << equal_elements << ",\n"
++            << "    \"elements\": " << output_elements << "\n"
++            << "  },\n"
++            << "  \"partial_storage_gib\": "
++            << double(partial_elements * sizeof(Element)) / double(1ull << 30)
++            << ",\n"
++            << "  \"note\": \"measured serial prefix + exact tail state + final merge endpoint\"\n"
++            << "}\n";
++  check(cudaEventDestroy(phase_start), "destroy phase start");
++  check(cudaEventDestroy(blocks_done), "destroy blocks done");
++  check(cudaEventDestroy(prefix_done), "destroy prefix done");
++  check(cudaEventDestroy(tail_done), "destroy tail done");
++  check(cudaEventDestroy(phase_stop), "destroy phase stop");
++#else
++  double projected_full_ms = endpoint_ms + 4.83;
++  double projected_tflops = kFrozenUsefulTflop / (projected_full_ms * 1.0e-3);
++  std::cout << "{\n"
++            << "  \"block_n\": " << block_n << ",\n"
++            << "  \"blocks\": " << blocks << ",\n"
++            << "  \"prefix_ms_including_merge\": " << endpoint_ms << ",\n"
++            << "  \"accepted_tail_ms\": 4.83,\n"
++            << "  \"projected_full_ms\": " << projected_full_ms << ",\n"
++            << "  \"projected_useful_tflops\": " << projected_tflops << ",\n"
++            << "  \"partial_storage_gib\": "
++            << double(partial_elements * sizeof(Element)) / double(1ull << 30)
++            << ",\n"
++            << "  \"note\": \"prefix endpoint; prefix/tail state merge excluded\"\n"
++            << "}\n";
++#endif
++
++  check(cudaEventDestroy(start), "destroy start");
++  check(cudaEventDestroy(stop), "destroy stop");
++  check(cudaFree(query), "free Q");
++  check(cudaFree(key), "free K");
++  check(cudaFree(value), "free V");
++  check(cudaFree(scores), "free scores");
++  check(cudaFree(partials), "free partials");
++  check(cudaFree(output), "free output");
++  check(cudaFree(qk_norm), "free QK max");
++  check(cudaFree(qk_sum), "free QK sum");
++  check(cudaFree(prefix_accumulator), "free prefix accumulator");
++  check(cudaFree(prefix_max), "free prefix max");
++  check(cudaFree(prefix_sum), "free prefix sum");
++  check(cudaFree(old_scales), "free old scales");
++  check(cudaFree(block_scales), "free block scales");
++#if defined(PREFIX_FULL_ENDPOINT)
++  check(cudaFree(tail_output), "free tail output");
++  check(cudaFree(final_output), "free final output");
++  check(cudaFree(exact_output), "free exact output");
++  check(cudaFree(tail_max), "free tail max");
++  check(cudaFree(tail_sum), "free tail sum");
++  dlclose(tail_handle);
++#endif
++  return 0;
++}
++#else
++
++extern "C" cudaError_t onecat_sm70_d256_dense_state_raw(
++    const void*,
++    const void*,
++    const void*,
++    float*,
++    float*,
++    void*,
++    int,
++    int,
++    int,
++    int,
++    float,
++    cudaStream_t);
++
++namespace FLASH_NAMESPACE {
++
++struct Sm70GqaScoreWorkspace {
++  at::Tensor scores;
++  cudaEvent_t completion = nullptr;
++  bool completion_recorded = false;
++  std::mutex launch_mutex;
++
++  Sm70GqaScoreWorkspace(const at::Tensor& q, int rows, int block_n)
++      : scores(at::empty({rows, block_n}, q.options())) {
++    C10_CUDA_CHECK(
++        cudaEventCreateWithFlags(&completion, cudaEventDisableTiming));
++  }
++
++  ~Sm70GqaScoreWorkspace() {
++    if (completion != nullptr) {
++      cudaEventDestroy(completion);
++    }
++  }
++};
++
++using Sm70GqaScoreWorkspacePtr = std::shared_ptr<Sm70GqaScoreWorkspace>;
++
++std::mutex& sm70_gqa_score_cache_mutex() {
++  static std::mutex cache_mutex;
++  return cache_mutex;
++}
++
++std::map<int, Sm70GqaScoreWorkspacePtr>& sm70_gqa_score_cache() {
++  static std::map<int, Sm70GqaScoreWorkspacePtr> cache;
++  return cache;
++}
++
++Sm70GqaScoreWorkspacePtr get_sm70_gqa_score_workspace(
++    const at::Tensor& q,
++    int rows,
++    int block_n) {
++  std::lock_guard<std::mutex> lock(sm70_gqa_score_cache_mutex());
++  int device = q.get_device();
++  auto& cache = sm70_gqa_score_cache();
++  auto& workspace = cache[device];
++  if (!workspace) {
++    workspace =
++        std::make_shared<Sm70GqaScoreWorkspace>(q, rows, block_n);
++  }
++  return workspace;
++}
++
++Sm70GqaScoreWorkspacePtr find_sm70_gqa_score_workspace(int device) {
++  std::lock_guard<std::mutex> lock(sm70_gqa_score_cache_mutex());
++  auto& cache = sm70_gqa_score_cache();
++  auto found = cache.find(device);
++  return found == cache.end() ? nullptr : found->second;
++}
++
++at::Tensor sm70_d256_gqa_architecture_fwd(
++    const at::Tensor& q,
++    const at::Tensor& k,
++    const at::Tensor& v,
++    at::Tensor& out,
++    double softmax_scale,
++    bool causal) {
++  constexpr int kQuery = 8000;
++  constexpr int kRows = 48000;
++  constexpr int kHeadDim = 256;
++  constexpr int kHeadsQ = 6;
++  constexpr int kHeadsKV = 1;
++  constexpr int kPrefix = 120000;
++  constexpr int kTail = 8000;
++  constexpr int kTotalKV = kPrefix + kTail;
++  constexpr int kBlockN = 8192;
++  constexpr int kBlocks = (kPrefix + kBlockN - 1) / kBlockN;
++
++  TORCH_CHECK(q.is_cuda() && k.is_cuda() && v.is_cuda() && out.is_cuda(),
++              "SM70 GQA architecture requires CUDA tensors");
++  TORCH_CHECK(q.scalar_type() == at::ScalarType::Half
++                  && k.scalar_type() == q.scalar_type()
++                  && v.scalar_type() == q.scalar_type()
++                  && out.scalar_type() == q.scalar_type(),
++              "SM70 GQA architecture requires FP16 q, k, v, and out");
++  TORCH_CHECK(q.sizes() == at::IntArrayRef({1, kQuery, kHeadsQ, kHeadDim})
++                  && k.sizes()
++                      == at::IntArrayRef({1, kTotalKV, kHeadsKV, kHeadDim})
++                  && v.sizes() == k.sizes() && out.sizes() == q.sizes(),
++              "SM70 GQA architecture only accepts the validated "
++              "Q8000/KV128000/Hq6/Hkv1/D256 shape");
++  TORCH_CHECK(q.is_contiguous() && k.is_contiguous() && v.is_contiguous()
++                  && out.is_contiguous(),
++              "SM70 GQA architecture requires contiguous tensors");
++  TORCH_CHECK(q.get_device() == k.get_device()
++                  && q.get_device() == v.get_device()
++                  && q.get_device() == out.get_device(),
++              "SM70 GQA architecture tensors must share one device");
++  TORCH_CHECK(causal, "SM70 GQA architecture requires causal attention");
++  TORCH_CHECK(std::abs(softmax_scale - 0.0625) < 1.0e-8,
++              "SM70 GQA architecture requires D256 softmax scale 1/16");
++
++  const at::cuda::OptionalCUDAGuard device_guard(q.device());
++  const int qk_tiles_n =
++      (kBlockN + QKThreadblockShape::kN - 1)
++      / QKThreadblockShape::kN;
++  cudaStream_t stream = at::cuda::getCurrentCUDAStream();
++
++  constexpr size_t kScratchAlignment = 256;
++  size_t scratch_bytes = 0;
++  auto reserve_scratch = [&](size_t bytes) {
++    scratch_bytes =
++        (scratch_bytes + kScratchAlignment - 1) & ~(kScratchAlignment - 1);
++    size_t offset = scratch_bytes;
++    scratch_bytes += bytes;
++    return offset;
++  };
++  size_t partial_offset = reserve_scratch(
++      size_t(kRows) * kHeadDim * sizeof(Element));
++  size_t prefix_accumulator_offset = reserve_scratch(
++      size_t(kRows) * kHeadDim * sizeof(float));
++  size_t tail_output_offset = reserve_scratch(
++      size_t(kRows) * kHeadDim * sizeof(Element));
++  size_t qk_norm_offset = reserve_scratch(
++      size_t(qk_tiles_n) * kRows * sizeof(float));
++  size_t qk_sum_offset = reserve_scratch(
++      size_t(qk_tiles_n) * kRows * sizeof(float));
++  size_t prefix_max_offset =
++      reserve_scratch(size_t(kRows) * sizeof(float));
++  size_t prefix_sum_offset =
++      reserve_scratch(size_t(kRows) * sizeof(float));
++  size_t old_scale_offset =
++      reserve_scratch(size_t(kRows) * sizeof(float));
++  size_t block_scale_offset =
++      reserve_scratch(size_t(kRows) * sizeof(float));
++  size_t tail_max_offset =
++      reserve_scratch(size_t(kRows) * sizeof(float));
++  size_t tail_sum_offset =
++      reserve_scratch(size_t(kRows) * sizeof(float));
++  int device = q.get_device();
++  auto score_workspace = find_sm70_gqa_score_workspace(device);
++  if (!score_workspace) {
++    constexpr size_t kRequiredPostWorkspaceHeadroom = 128 * 1024 * 1024;
++    constexpr size_t kScoreBytes =
++        size_t(kRows) * kBlockN * sizeof(Element);
++    size_t free_bytes = 0;
++    size_t total_bytes = 0;
++    C10_CUDA_CHECK(cudaMemGetInfo(&free_bytes, &total_bytes));
++    size_t required_bytes =
++        kScoreBytes + scratch_bytes + kRequiredPostWorkspaceHeadroom;
++    TORCH_CHECK_WITH(
++        OutOfMemoryError,
++        free_bytes >= required_bytes,
++        "SM70 GQA architecture requires ",
++        required_bytes / (1024 * 1024),
++        " MiB free before its first workspace allocation, including "
++        "128 MiB of downstream headroom, but only ",
++        free_bytes / (1024 * 1024),
++        " MiB remains out of ",
++        total_bytes / (1024 * 1024),
++        " MiB");
++    score_workspace =
++        get_sm70_gqa_score_workspace(q, kRows, kBlockN);
++  }
++  std::unique_lock<std::mutex> launch_lock(score_workspace->launch_mutex);
++  if (score_workspace->completion_recorded) {
++    C10_CUDA_CHECK(
++        cudaStreamWaitEvent(stream, score_workspace->completion, 0));
++  }
++  at::Tensor scratch = at::empty(
++      {static_cast<int64_t>(scratch_bytes)},
++      q.options().dtype(at::ScalarType::Byte));
++  auto* scratch_base = scratch.data_ptr<uint8_t>();
++
++  auto* query = reinterpret_cast<Element*>(q.data_ptr<at::Half>());
++  auto* key = reinterpret_cast<Element*>(k.data_ptr<at::Half>());
++  auto* value = reinterpret_cast<Element*>(v.data_ptr<at::Half>());
++  auto* score_ptr =
++      reinterpret_cast<Element*>(score_workspace->scores.data_ptr<at::Half>());
++  auto* partial_ptr =
++      reinterpret_cast<Element*>(scratch_base + partial_offset);
++  float* prefix_accumulator_ptr =
++      reinterpret_cast<float*>(scratch_base + prefix_accumulator_offset);
++  auto* tail_output_ptr =
++      reinterpret_cast<Element*>(scratch_base + tail_output_offset);
++  auto* output_ptr = reinterpret_cast<Element*>(out.data_ptr<at::Half>());
++  float* qk_norm_ptr =
++      reinterpret_cast<float*>(scratch_base + qk_norm_offset);
++  float* qk_sum_ptr =
++      reinterpret_cast<float*>(scratch_base + qk_sum_offset);
++  float* prefix_max_ptr =
++      reinterpret_cast<float*>(scratch_base + prefix_max_offset);
++  float* prefix_sum_ptr =
++      reinterpret_cast<float*>(scratch_base + prefix_sum_offset);
++  float* old_scale_ptr =
++      reinterpret_cast<float*>(scratch_base + old_scale_offset);
++  float* block_scale_ptr =
++      reinterpret_cast<float*>(scratch_base + block_scale_offset);
++  float* tail_max_ptr =
++      reinterpret_cast<float*>(scratch_base + tail_max_offset);
++  float* tail_sum_ptr =
++      reinterpret_cast<float*>(scratch_base + tail_sum_offset);
++
++  C10_CUDA_CHECK(onecat_sm70_d256_dense_state_raw(
++      query,
++      key + size_t(kPrefix) * kHeadDim,
++      value + size_t(kPrefix) * kHeadDim,
++      tail_max_ptr,
++      tail_sum_ptr,
++      tail_output_ptr,
++      kTail,
++      kTail,
++      kHeadsQ,
++      kHeadsKV,
++      static_cast<float>(softmax_scale),
++      stream));
++  C10_CUDA_CHECK(cudaMemcpyToSymbolAsync(
++      g_rows,
++      &kRows,
++      sizeof(kRows),
++      0,
++      cudaMemcpyHostToDevice,
++      stream));
++  float const* persistent_max_ptr = qk_norm_ptr;
++  C10_CUDA_CHECK(cudaMemcpyToSymbolAsync(
++      g_row_max,
++      &persistent_max_ptr,
++      sizeof(persistent_max_ptr),
++      0,
++      cudaMemcpyHostToDevice,
++      stream));
++  float const* persistent_inv_sum_ptr = qk_sum_ptr;
++  C10_CUDA_CHECK(cudaMemcpyToSymbolAsync(
++      g_row_inv_sum,
++      &persistent_inv_sum_ptr,
++      sizeof(persistent_inv_sum_ptr),
++      0,
++      cudaMemcpyHostToDevice,
++      stream));
++
++  for (int block = 0; block < kBlocks; ++block) {
++    int begin = block * kBlockN;
++    int width = std::min(kBlockN, kPrefix - begin);
++    BlockOperators operation;
++    operation.width = width;
++    typename QKGemm::Arguments arguments(
++        {kRows, width, kHeadDim},
++        1,
++        {query, QKLayoutA(kHeadDim)},
++        {key + size_t(begin) * kHeadDim, QKLayoutB(kHeadDim)},
++        {score_ptr, typename QKGemm::LayoutC(width)},
++        {score_ptr, typename QKGemm::LayoutC(width)},
++        {Element(static_cast<float>(softmax_scale)), Element(0.0f)},
++        {qk_norm_ptr, typename QKGemm::LayoutN(kRows)},
++        {qk_sum_ptr, typename QKGemm::LayoutS(kRows)},
++        {score_ptr, typename QKGemm::LayoutSoft(width)});
++    TORCH_CHECK(operation.qk.initialize(arguments) == cutlass::Status::kSuccess,
++                "initialize SM70 GQA QK block ", block, " failed");
++    operation.pv = std::make_unique<PVLauncher>(
++        score_ptr,
++        value + size_t(begin) * kHeadDim,
++        partial_ptr,
++        kRows,
++        width);
++    TORCH_CHECK(operation.qk(stream) == cutlass::Status::kSuccess,
++                "launch SM70 GQA QK block ", block, " failed");
++    operation.pv->launch(stream);
++    prepare_prefix_update<<<(kRows + 255) / 256, 256, 0, stream>>>(
++        qk_norm_ptr,
++        qk_sum_ptr,
++        prefix_max_ptr,
++        prefix_sum_ptr,
++        old_scale_ptr,
++        block_scale_ptr,
++        kRows,
++        block == 0);
++    constexpr int kPairs = kRows * kHeadDim / 2;
++    apply_prefix_update_half2<<<(kPairs + 255) / 256, 256, 0, stream>>>(
++        reinterpret_cast<__half const*>(partial_ptr),
++        prefix_accumulator_ptr,
++        old_scale_ptr,
++        block_scale_ptr,
++        kRows,
++        block == 0);
++  }
++  merge_prefix_accumulator_tail<<<kRows, kHeadDim, 0, stream>>>(
++      prefix_accumulator_ptr,
++      prefix_max_ptr,
++      prefix_sum_ptr,
++      reinterpret_cast<__half const*>(tail_output_ptr),
++      tail_max_ptr,
++      tail_sum_ptr,
++      reinterpret_cast<__half*>(output_ptr),
++      kRows);
++  C10_CUDA_KERNEL_LAUNCH_CHECK();
++  C10_CUDA_CHECK(cudaEventRecord(score_workspace->completion, stream));
++  score_workspace->completion_recorded = true;
++  return out;
++}
++
++}  // namespace FLASH_NAMESPACE
++
++#endif
+diff --git a/csrc/flash_attn/src/flash_fwd_d256_splitd_sm70.cu b/csrc/flash_attn/src/flash_fwd_d256_splitd_sm70.cu
+index 7a0f626..1fd4008 100644
+--- a/csrc/flash_attn/src/flash_fwd_d256_splitd_sm70.cu
++++ b/csrc/flash_attn/src/flash_fwd_d256_splitd_sm70.cu
+@@ -398,7 +398,11 @@ __device__ __forceinline__ int64_t paged_kv_thread_offset(
+         + (tid % kThreadsPerRow) * kElemsPerLoad;
+ }
+
+-template <typename Element, bool PagedKV, bool SplitKV3 = false>
++template <
++    typename Element,
++    bool PagedKV,
++    bool SplitKV3 = false,
++    bool StoreState = false>
+ __global__ __launch_bounds__(Sm70D256SplitDTraits::kNThreads, 1)
+ void sm70_d256_splitd_dense_kernel(
+     const Element *__restrict__ q,
+@@ -859,6 +863,29 @@ void sm70_d256_splitd_dense_kernel(
+             }
+         }
+     } else {
++        if constexpr (StoreState) {
++            if ((lane & 0x0e) == 0) {
++#pragma unroll
++                for (int slot = 0; slot < Traits::kQkRowsPerThread; ++slot) {
++                    const int row = FLASH_NAMESPACE::sm70_row_slot<
++                        Traits::kQkWarpRows>(slot, lane);
++                    const int query_row = query_row_base
++                        + group_row_base
++                        + n_warp * Traits::kQkWarpRows + row;
++                    const int64_t state_row =
++                        (static_cast<int64_t>(batch) * query_len + query_row)
++                            * heads_q
++                        + head_q;
++                    // The standalone prefix path stores maxima after applying
++                    // softmax_scale.  Export the dense-tail state in the same
++                    // natural-log coordinate so the two states can be merged
++                    // directly with exp(prefix_max - global_max).
++                    partial_max[state_row] = row_max[slot]
++                        * (softmax_scale_log2 * float(M_LN2));
++                    partial_sum[state_row] = row_sum[slot];
++                }
++            }
++        }
+         if ((lane & 0x0e) == 0) {
+ #pragma unroll
+             for (int slot = 0; slot < Traits::kQkRowsPerThread; ++slot) {
+@@ -1042,6 +1069,154 @@ at::Tensor sm70_d256_splitd_dense_fwd(
+     return out;
+ }
+
++at::Tensor sm70_d256_splitd_dense_state_fwd(
++    const at::Tensor &q,
++    const at::Tensor &k,
++    const at::Tensor &v,
++    at::Tensor &state_max,
++    at::Tensor &state_sum,
++    at::Tensor &out,
++    double softmax_scale,
++    bool causal) {
++    TORCH_CHECK(q.is_cuda() && k.is_cuda() && v.is_cuda()
++                    && state_max.is_cuda() && state_sum.is_cuda()
++                    && out.is_cuda(),
++                "dense-state inputs must be CUDA tensors");
++    TORCH_CHECK(q.scalar_type() == at::ScalarType::Half
++                    && k.scalar_type() == q.scalar_type()
++                    && v.scalar_type() == q.scalar_type()
++                    && out.scalar_type() == q.scalar_type(),
++                "dense-state requires FP16 q, k, v, and out");
++    TORCH_CHECK(state_max.scalar_type() == at::ScalarType::Float
++                    && state_sum.scalar_type() == at::ScalarType::Float,
++                "dense-state statistics must use FP32");
++    TORCH_CHECK(q.dim() == 4 && k.dim() == 4 && v.dim() == 4
++                    && q.size(0) == k.size(0) && k.sizes() == v.sizes(),
++                "dense-state q, k, and v shapes are invalid");
++    TORCH_CHECK(q.size(3) == Sm70D256SplitDTraits::kHeadDim
++                    && k.size(3) == Sm70D256SplitDTraits::kHeadDim
++                    && q.size(2) % k.size(2) == 0,
++                "dense-state requires D256 and valid GQA heads");
++    TORCH_CHECK(q.size(1) <= k.size(1)
++                    && q.size(1) % Sm70D256SplitDTraits::kBlockM == 0
++                    && k.size(1) % Sm70D256SplitDTraits::kBlockN == 0,
++                "dense-state lengths do not match the exact tiles");
++    TORCH_CHECK(out.sizes() == q.sizes() && out.is_contiguous()
++                    && state_max.is_contiguous() && state_sum.is_contiguous(),
++                "dense-state outputs must be contiguous");
++    const int64_t rows = q.size(0) * q.size(1) * q.size(2);
++    TORCH_CHECK(state_max.numel() == rows && state_sum.numel() == rows,
++                "dense-state statistic shapes are invalid");
++    TORCH_CHECK(causal, "dense-state requires causal attention");
++
++    const at::cuda::OptionalCUDAGuard device_guard(q.device());
++    const dim3 block(Sm70D256SplitDTraits::kNThreads);
++    const dim3 grid(
++        q.size(1) / Sm70D256SplitDTraits::kBlockM,
++        q.size(0),
++        q.size(2));
++    auto stream = at::cuda::getCurrentCUDAStream();
++    auto kernel = sm70_d256_splitd_dense_kernel<
++        cutlass::half_t, false, false, true>;
++    C10_CUDA_CHECK(cudaFuncSetAttribute(
++        kernel,
++        cudaFuncAttributeMaxDynamicSharedMemorySize,
++        Sm70D256SplitDTraits::kSmemBytes));
++    kernel<<<grid, block, Sm70D256SplitDTraits::kSmemBytes, stream>>>(
++        reinterpret_cast<const cutlass::half_t *>(q.data_ptr()),
++        reinterpret_cast<const cutlass::half_t *>(k.data_ptr()),
++        reinterpret_cast<const cutlass::half_t *>(v.data_ptr()),
++        reinterpret_cast<cutlass::half_t *>(out.data_ptr()),
++        static_cast<int>(q.stride(0)),
++        static_cast<int>(q.stride(1)),
++        static_cast<int>(q.stride(2)),
++        static_cast<int>(k.stride(0)),
++        static_cast<int>(k.stride(1)),
++        static_cast<int>(k.stride(2)),
++        static_cast<int>(v.stride(0)),
++        static_cast<int>(v.stride(1)),
++        static_cast<int>(v.stride(2)),
++        q.size(1),
++        k.size(1),
++        q.size(2),
++        k.size(2),
++        static_cast<float>(softmax_scale * M_LOG2E),
++        nullptr,
++        0,
++        0,
++        nullptr,
++        state_max.data_ptr<float>(),
++        state_sum.data_ptr<float>());
++    C10_CUDA_KERNEL_LAUNCH_CHECK();
++    return out;
++}
++
++// Raw fixed-layout entry point for the task-local end-to-end architecture
++// harness.  Keeping this in the same cubin guarantees that the measured tail
++// is the exact production candidate kernel rather than a reimplemented proxy.
++extern "C" cudaError_t onecat_sm70_d256_dense_state_raw(
++    const void *q,
++    const void *k,
++    const void *v,
++    float *state_max,
++    float *state_sum,
++    void *out,
++    int query_len,
++    int kv_len,
++    int heads_q,
++    int heads_kv,
++    float softmax_scale,
++    cudaStream_t stream) {
++    if (q == nullptr || k == nullptr || v == nullptr || state_max == nullptr
++        || state_sum == nullptr || out == nullptr || query_len <= 0
++        || kv_len < query_len || heads_q <= 0 || heads_kv <= 0
++        || heads_q % heads_kv != 0
++        || query_len % Sm70D256SplitDTraits::kBlockM != 0
++        || kv_len % Sm70D256SplitDTraits::kBlockN != 0) {
++        return cudaErrorInvalidValue;
++    }
++    const dim3 block(Sm70D256SplitDTraits::kNThreads);
++    const dim3 grid(
++        query_len / Sm70D256SplitDTraits::kBlockM,
++        1,
++        heads_q);
++    auto kernel = sm70_d256_splitd_dense_kernel<
++        cutlass::half_t, false, false, true>;
++    cudaError_t result = cudaFuncSetAttribute(
++        kernel,
++        cudaFuncAttributeMaxDynamicSharedMemorySize,
++        Sm70D256SplitDTraits::kSmemBytes);
++    if (result != cudaSuccess) {
++        return result;
++    }
++    kernel<<<grid, block, Sm70D256SplitDTraits::kSmemBytes, stream>>>(
++        static_cast<const cutlass::half_t *>(q),
++        static_cast<const cutlass::half_t *>(k),
++        static_cast<const cutlass::half_t *>(v),
++        static_cast<cutlass::half_t *>(out),
++        query_len * heads_q * Sm70D256SplitDTraits::kHeadDim,
++        heads_q * Sm70D256SplitDTraits::kHeadDim,
++        Sm70D256SplitDTraits::kHeadDim,
++        kv_len * heads_kv * Sm70D256SplitDTraits::kHeadDim,
++        heads_kv * Sm70D256SplitDTraits::kHeadDim,
++        Sm70D256SplitDTraits::kHeadDim,
++        kv_len * heads_kv * Sm70D256SplitDTraits::kHeadDim,
++        heads_kv * Sm70D256SplitDTraits::kHeadDim,
++        Sm70D256SplitDTraits::kHeadDim,
++        query_len,
++        kv_len,
++        heads_q,
++        heads_kv,
++        softmax_scale * float(M_LOG2E),
++        nullptr,
++        0,
++        0,
++        nullptr,
++        state_max,
++        state_sum);
++    return cudaPeekAtLastError();
++}
++
+ at::Tensor sm70_d256_splitd_dense_splitkv3_fwd(
+     const at::Tensor &q,
+     const at::Tensor &k,
+diff --git a/csrc/cutlass/examples/35_gemm_softmax/gemm_with_softmax.h b/csrc/cutlass/examples/35_gemm_softmax/gemm_with_softmax.h
+index 31b2b769..e5720b20 100644
+--- a/csrc/cutlass/examples/35_gemm_softmax/gemm_with_softmax.h
++++ b/csrc/cutlass/examples/35_gemm_softmax/gemm_with_softmax.h
+@@ -623,29 +623,9 @@ public:
+       return cutlass::Status::kErrorInternal;
+     }
+
+-    //
+-    // Launch the SoftmaxApplyKernel
+-    //
+-
+-    dim3 apply_block(SoftmaxApplyKernel::ApplyShape::kColumn, SoftmaxApplyKernel::ApplyShape::kRow);
+-
+-    int threadblock_rows = SoftmaxApplyKernel::ApplyShape::kRow;
+-    int threadblock_columns = SoftmaxApplyKernel::ApplyShape::kColumn * SoftmaxApplyKernel::kAlignment;
+-
+-    dim3 apply_grid(
+-      (params_.softmax.args.extent.row() + threadblock_rows - 1) / threadblock_rows,
+-      (params_.softmax.args.extent.column() + threadblock_columns - 1) / threadblock_columns,
+-      params_.softmax.args.batch_count);
+-
+-    Kernel<SoftmaxApplyKernel><<<
+-      apply_grid, apply_block, sizeof(typename SoftmaxApplyKernel::SharedStorage), stream
+-    >>>(params_.softmax);
+-
+-    result = cudaGetLastError();
+-
+-    if (result != cudaSuccess) {
+-      return cutlass::Status::kErrorInternal;
+-    }
++    // The SM70 GQA architecture consumes logits in the PV mainloop, so it
++    // intentionally stops after GEMM + final row-stat reduction. Materializing
++    // a second global probability matrix would erase the bandwidth win.
+
+     return cutlass::Status::kSuccess;
+   }

--- a/cmake/patches/sm70_flash_attn_d256_gqa_arch.patch
+++ b/cmake/patches/sm70_flash_attn_d256_gqa_arch.patch
@@ -1,5 +1,5 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index acf2219..d644e02 100644
+index acf2219..f5e2732 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -84,6 +84,7 @@ string(REPLACE "-O2" "-O3" CMAKE_CUDA_FLAGS_RELWITHDEBINFO "${CMAKE_CUDA_FLAGS_R
@@ -20,12 +20,13 @@ index acf2219..d644e02 100644
 
      # custom definitions
      target_compile_definitions(_vllm_fa2_C PRIVATE
-@@ -125,5 +127,15 @@ if (FA2_ENABLED)
+@@ -125,5 +127,16 @@ if (FA2_ENABLED)
          # FLASHATTENTION_DISABLE_UNEVEN_K
          # FLASHATTENTION_DISABLE_LOCAL
          FLASHATTENTION_DISABLE_PYBIND
 +        PREFIX_TORCH_EXTENSION
 +        PREFIX_QK_FULL_STATS
++        PREFIX_QK_SKIP_APPLY
 +        QK_TB_M=128
 +        QK_TB_N=512
 +        QK_WARP_M=64
@@ -1643,39 +1644,22 @@ index 7a0f626..1fd4008 100644
      const at::Tensor &q,
      const at::Tensor &k,
 diff --git a/csrc/cutlass/examples/35_gemm_softmax/gemm_with_softmax.h b/csrc/cutlass/examples/35_gemm_softmax/gemm_with_softmax.h
-index 31b2b769..e5720b20 100644
+index 31b2b769..2cb4ba74 100644
 --- a/csrc/cutlass/examples/35_gemm_softmax/gemm_with_softmax.h
 +++ b/csrc/cutlass/examples/35_gemm_softmax/gemm_with_softmax.h
-@@ -623,29 +623,9 @@ public:
+@@ -623,6 +623,7 @@ public:
        return cutlass::Status::kErrorInternal;
      }
 
--    //
--    // Launch the SoftmaxApplyKernel
--    //
--
--    dim3 apply_block(SoftmaxApplyKernel::ApplyShape::kColumn, SoftmaxApplyKernel::ApplyShape::kRow);
--
--    int threadblock_rows = SoftmaxApplyKernel::ApplyShape::kRow;
--    int threadblock_columns = SoftmaxApplyKernel::ApplyShape::kColumn * SoftmaxApplyKernel::kAlignment;
--
--    dim3 apply_grid(
--      (params_.softmax.args.extent.row() + threadblock_rows - 1) / threadblock_rows,
--      (params_.softmax.args.extent.column() + threadblock_columns - 1) / threadblock_columns,
--      params_.softmax.args.batch_count);
--
--    Kernel<SoftmaxApplyKernel><<<
--      apply_grid, apply_block, sizeof(typename SoftmaxApplyKernel::SharedStorage), stream
--    >>>(params_.softmax);
--
--    result = cudaGetLastError();
--
--    if (result != cudaSuccess) {
--      return cutlass::Status::kErrorInternal;
--    }
-+    // The SM70 GQA architecture consumes logits in the PV mainloop, so it
-+    // intentionally stops after GEMM + final row-stat reduction. Materializing
-+    // a second global probability matrix would erase the bandwidth win.
++#if !defined(PREFIX_QK_SKIP_APPLY)
+     //
+     // Launch the SoftmaxApplyKernel
+     //
+@@ -646,6 +647,7 @@ public:
+     if (result != cudaSuccess) {
+       return cutlass::Status::kErrorInternal;
+     }
++#endif
 
      return cutlass::Status::kSuccess;
    }

--- a/cmake/patches/sm70_flash_attn_d256_gqa_arch.patch
+++ b/cmake/patches/sm70_flash_attn_d256_gqa_arch.patch
@@ -89,7 +89,7 @@ new file mode 100644
 index 0000000..197453f
 --- /dev/null
 +++ b/csrc/flash_attn/src/flash_fwd_d256_gqa_arch_sm70.cu
-@@ -0,0 +1,1351 @@
+@@ -0,0 +1,1359 @@
 +// SPDX-License-Identifier: BSD-3-Clause
 +
 +/***************************************************************************************************
@@ -1210,11 +1210,11 @@ index 0000000..197453f
 +  constexpr int kHeadDim = 256;
 +  constexpr int kHeadsQ = 6;
 +  constexpr int kHeadsKV = 1;
-+  constexpr int kPrefix = 120000;
 +  constexpr int kTail = 8000;
-+  constexpr int kTotalKV = kPrefix + kTail;
++  constexpr int kMinTotalKV = 40000;
++  constexpr int kMaxTotalKV = 128000;
++  constexpr int kTotalKVStep = 8000;
 +  constexpr int kBlockN = 8192;
-+  constexpr int kBlocks = (kPrefix + kBlockN - 1) / kBlockN;
 +
 +  TORCH_CHECK(q.is_cuda() && k.is_cuda() && v.is_cuda() && out.is_cuda(),
 +              "SM70 GQA architecture requires CUDA tensors");
@@ -1224,11 +1224,19 @@ index 0000000..197453f
 +                  && out.scalar_type() == q.scalar_type(),
 +              "SM70 GQA architecture requires FP16 q, k, v, and out");
 +  TORCH_CHECK(q.sizes() == at::IntArrayRef({1, kQuery, kHeadsQ, kHeadDim})
-+                  && k.sizes()
-+                      == at::IntArrayRef({1, kTotalKV, kHeadsKV, kHeadDim})
++                  && k.dim() == 4 && k.size(0) == 1
++                  && k.size(2) == kHeadsKV && k.size(3) == kHeadDim
 +                  && v.sizes() == k.sizes() && out.sizes() == q.sizes(),
 +              "SM70 GQA architecture only accepts the validated "
-+              "Q8000/KV128000/Hq6/Hkv1/D256 shape");
++              "Q8000/Hq6/Hkv1/D256 dense shape family");
++  const int total_kv = static_cast<int>(k.size(1));
++  TORCH_CHECK(total_kv >= kMinTotalKV && total_kv <= kMaxTotalKV
++                  && total_kv % kTotalKVStep == 0,
++              "SM70 GQA architecture requires KV in [40000, 128000] "
++              "with an 8000-token step, got ",
++              total_kv);
++  const int prefix = total_kv - kTail;
++  const int blocks = (prefix + kBlockN - 1) / kBlockN;
 +  TORCH_CHECK(q.is_contiguous() && k.is_contiguous() && v.is_contiguous()
 +                  && out.is_contiguous(),
 +              "SM70 GQA architecture requires contiguous tensors");
@@ -1343,8 +1351,8 @@ index 0000000..197453f
 +
 +  C10_CUDA_CHECK(onecat_sm70_d256_dense_state_raw(
 +      query,
-+      key + size_t(kPrefix) * kHeadDim,
-+      value + size_t(kPrefix) * kHeadDim,
++      key + size_t(prefix) * kHeadDim,
++      value + size_t(prefix) * kHeadDim,
 +      tail_max_ptr,
 +      tail_sum_ptr,
 +      tail_output_ptr,
@@ -1378,9 +1386,9 @@ index 0000000..197453f
 +      cudaMemcpyHostToDevice,
 +      stream));
 +
-+  for (int block = 0; block < kBlocks; ++block) {
++  for (int block = 0; block < blocks; ++block) {
 +    int begin = block * kBlockN;
-+    int width = std::min(kBlockN, kPrefix - begin);
++    int width = std::min(kBlockN, prefix - begin);
 +    BlockOperators operation;
 +    operation.width = width;
 +    typename QKGemm::Arguments arguments(

--- a/docs/design/sm70_qwen38_fp8_prefill_decay.md
+++ b/docs/design/sm70_qwen38_fp8_prefill_decay.md
@@ -287,7 +287,7 @@ greedy identity fails. Keep Q8000 split-KV3 explicit and default-off until a
 fixed-text logprob/perplexity or dataset-level quality gate establishes that
 the classified Type-B reduction-order drift does not reduce model quality.
 
-## 2026-08-25 Q8000/KV128000 GQA-packed Attention Architecture
+## 2026-08-25 Q8000/KV40K..128K GQA-packed Attention Architecture
 
 This experiment freezes the final long-prefill call at causal FP16
 `Q=8000`, `KV=128000`, `Hq=6`, `Hkv=1`, and `D=256` on one
@@ -301,7 +301,7 @@ the long-shape NCU record showed one CTA/SM, 12.5% occupancy, 62.14% of cycles
 without an eligible warp, and only 9.06% DRAM throughput. The replacement is a
 different scheduling and dataflow architecture:
 
-- split the fully visible 120K prefix from the exact causal 8K tail;
+- split a fully visible 32K..120K prefix from the exact causal 8K tail;
 - pack all six GQA query heads into GEMM M=48,000;
 - run wide SM70 Tensor-Core QK GEMMs that emit FP16 scores plus row max/sum;
 - transform scores into normalized probabilities during the PV
@@ -318,6 +318,31 @@ score-cache layout measures `140.00213 -> 100.76979 ms`, or
 is `2.2888e-4 / 2.5430e-5` and relative L2 is `6.8629e-3` versus the exact
 FP32-accumulator route. BN7168 reaches only 58.42057 TFLOP/s and BN8000 only
 59.92825 TFLOP/s, so neither is promoted or rounded into a pass.
+
+The same bounded workspace was then generalized across the twelve observed
+8K-chunk shapes. Each row is a strict A/B bracket against the active split-KV3
+control:
+
+| KV tokens | split-KV3 ms | architecture ms | latency change | useful TFLOP/s |
+|---:|---:|---:|---:|---:|
+| 40,000 | 38.41638 | 29.81530 | -22.3891% | 59.34862 |
+| 48,000 | 47.25811 | 36.38477 | -23.0084% | 59.44005 |
+| 56,000 | 56.53999 | 42.68715 | -24.5010% | 59.87584 |
+| 64,000 | 65.17897 | 49.14552 | -24.5991% | 60.00842 |
+| 72,000 | 74.00670 | 55.44960 | -25.0749% | 60.27745 |
+| 80,000 | 82.74432 | 61.77792 | -25.3388% | 60.46783 |
+| 88,000 | 91.98507 | 68.37111 | -25.6715% | 60.38797 |
+| 96,000 | 100.88397 | 74.72862 | -25.9262% | 60.51241 |
+| 104,000 | 109.80642 | 81.09448 | -26.1478% | 60.61108 |
+| 112,000 | 118.42901 | 87.71959 | -25.9307% | 60.51602 |
+| 120,000 | 127.35232 | 93.99757 | -26.1909% | 60.65749 |
+| 128,000 | 135.93617 | 100.34193 | -26.1845% | 60.74103 |
+
+All 147,456,000 candidate output elements are finite. Across the family, the
+worst max absolute difference is `5.0354e-4` and worst relative L2 is
+`6.8983e-3` versus the exact FP32-accumulator route. The three shortest points
+remain slightly below 60 because the 43-TFLOP/s exact causal tail is a larger
+fixed fraction, but they are still 1.288x..1.325x faster than split-KV3.
 
 The architecture trace is compute-dense rather than launch-starved: 49 timed
 kernels occupy 95.630493 ms of a 95.809850-ms GPU span, or 99.81%. Prefix QK
@@ -336,7 +361,9 @@ and falls back to the exact route.
 
 The route is default-off behind
 `VLLM_FLASH_V100_PREFILL_D256_GQA_ARCH_128K_EXPERIMENTAL=1`, rejects CUDA graph
-capture, and admits only the frozen shape and scale. The final `.875` TP4
+capture, and admits only `Q=8000`, `KV=40000..128000` in 8000-token steps,
+`Hq=6/Hkv=1/D=256`, FP16, causal attention, and scale 1/16. The earlier
+endpoint-only `.875` TP4
 Qwen3.8-27B-FP8 control/candidate/control prefill times are
 `46.45658 / 45.47797 / 46.11195 s`. Relative to the `46.28426-s` bracketed
 control, the candidate lowers latency by 1.7421% and raises prompt throughput
@@ -345,13 +372,13 @@ architecture hits, with no architecture OOM/fallback, and all three runs emit
 the same 32 output token IDs and SHA256
 `df4fee7f5f0126fe6b391fe77b4fc19667831de5ef55fd69c28c2f52a3d7086e`.
 
-The `.88` run also succeeds at 45.53427-s prefill with the same hash and 16
+The endpoint-only `.88` run also succeeds at 45.53427-s prefill with the same hash and 16
 hits/rank. Its memory profiler left enough headroom, so the route passed rather
-than exercising the fallback branch. This exact-shape win is not the complete
-128K decay solution: it accelerates only the final `KV=128000` chunk. The next
-architecture gate expands admission across `Q=8000`, `KV=40000..128000`, where
-the same bounded score cache can cover up to 12 long chunks per full-attention
-layer.
+than exercising the fallback branch. The family operator now covers up to 12
+long chunks per full-attention layer. Its per-layer measured saving sums to
+267.024 ms, or a projected 4.272 s across 16 full-attention layers; this is not
+a whole-model claim. The remaining promotion gate is a clean TP4 A/B with 192
+expected family-route hits/rank and identical fixed-prompt output tokens.
 
 ## Artifacts
 
@@ -360,6 +387,8 @@ layer.
 - Final operator A/B/A:
   `results/torch-architecture-scorecache-final-v1-aba.json` under that task
   root.
+- Shape-family operator A/B:
+  `results/torch-architecture-shapefamily-v1-aba.json` under that task root.
 - Final TP4 `.875` model gate:
   `results/tp4-128k-architecture-scorecache-final-{control-a,candidate,control-b}-0875.json`.
 - Final high-memory `.88` route-success run:

--- a/docs/design/sm70_qwen38_fp8_prefill_decay.md
+++ b/docs/design/sm70_qwen38_fp8_prefill_decay.md
@@ -287,6 +287,59 @@ greedy identity fails. Keep Q8000 split-KV3 explicit and default-off until a
 fixed-text logprob/perplexity or dataset-level quality gate establishes that
 the classified Type-B reduction-order drift does not reduce model quality.
 
+## 2026-08-25 Q8000/KV128000 GQA-packed Attention Architecture
+
+This experiment freezes the final long-prefill call at causal FP16
+`Q=8000`, `KV=128000`, `Hq=6`, `Hkv=1`, and `D=256` on one
+V100-SXM2-32GB. Its metric is 6.094872576 useful causal TFLOPs divided by the
+complete Attention elapsed time. It is neither whole-model TOPS nor prompt
+tokens/s; the acceptance gate is at most 101.581 ms, or at least 60.0 useful
+causal TFLOP/s.
+
+Tile and barrier tuning of the fused BM64/BN32 kernel was already exhausted:
+the long-shape NCU record showed one CTA/SM, 12.5% occupancy, 62.14% of cycles
+without an eligible warp, and only 9.06% DRAM throughput. The replacement is a
+different scheduling and dataflow architecture:
+
+- split the fully visible 120K prefix from the exact causal 8K tail;
+- pack all six GQA query heads into GEMM M=48,000;
+- run wide SM70 Tensor-Core QK GEMMs that emit FP16 scores plus row max/sum;
+- transform scores into normalized probabilities during the PV
+  global-to-shared load, avoiding a materialized probability matrix;
+- fold one reusable FP16 PV partial into a FP32 online prefix
+  numerator/max/sum state;
+- export max/sum from the accepted exact 8K tail and merge the two online
+  softmax states.
+
+The retained score block is BN8192. Strict Torch A/B/A for the score-cache
+layout measures `139.74426 -> 100.22127 ms`, or
+`43.61448 -> 60.81416` useful causal TFLOP/s: 28.2824% lower latency and a
+1.39436x speedup. All 12,288,000 outputs are finite; max/mean absolute error
+is `2.2888e-4 / 2.5430e-5` and relative L2 is `6.8629e-3` versus the exact
+FP32-accumulator route. BN7168 reaches only 58.42057 TFLOP/s and BN8000 only
+59.92825 TFLOP/s, so neither is promoted or rounded into a pass.
+
+The architecture trace is compute-dense rather than launch-starved: 49 timed
+kernels occupy 95.630493 ms of a 95.809850-ms GPU span, or 99.81%. Prefix QK
+accounts for 54.22% and prefix PV 39.74%; the exact tail is 4.89%. The next
+compute ceiling is therefore QK/PV instruction efficiency, not additional
+host launch fusion.
+
+Real-model integration exposed a separate memory contract. Retaining all
+partials or the entire workspace passes the operator gate but leaves too
+little memory for the following 80-MiB TP all-reduce. The final layout retains
+only the 750-MiB FP16 score matrix per device and packs about 100 MiB of other
+state into one transient byte slab. Before first use it requires enough
+driver-visible free memory for both allocations plus 128 MiB of downstream
+headroom; otherwise it raises a typed OOM before touching the caching allocator
+and falls back to the exact route.
+
+The route is default-off behind
+`VLLM_FLASH_V100_PREFILL_D256_GQA_ARCH_128K_EXPERIMENTAL=1`, rejects CUDA graph
+capture, and admits only the frozen shape and scale. The final `.875` TP4
+control/candidate/control and `.88` fallback-safety runs remain the promotion
+gate; no whole-model speed claim is made before those results complete.
+
 ## Artifacts
 
 - K-stage task root:

--- a/docs/design/sm70_qwen38_fp8_prefill_decay.md
+++ b/docs/design/sm70_qwen38_fp8_prefill_decay.md
@@ -372,13 +372,17 @@ architecture hits, with no architecture OOM/fallback, and all three runs emit
 the same 32 output token IDs and SHA256
 `df4fee7f5f0126fe6b391fe77b4fc19667831de5ef55fd69c28c2f52a3d7086e`.
 
-The endpoint-only `.88` run also succeeds at 45.53427-s prefill with the same hash and 16
-hits/rank. Its memory profiler left enough headroom, so the route passed rather
-than exercising the fallback branch. The family operator now covers up to 12
-long chunks per full-attention layer. Its per-layer measured saving sums to
-267.024 ms, or a projected 4.272 s across 16 full-attention layers; this is not
-a whole-model claim. The remaining promotion gate is a clean TP4 A/B with 192
-expected family-route hits/rank and identical fixed-prompt output tokens.
+The endpoint-only `.88` run also succeeds at 45.53427-s prefill with the same
+hash and 16 hits/rank. Its memory profiler left enough headroom, so the route
+passed rather than exercising the fallback branch.
+
+The widened TP4 Qwen3.8-27B-FP8 gate brackets the candidate with `46.11195-s`
+and `46.09222-s` controls. Relative to their `46.10208-s` mean, the
+`41.51191-s` candidate lowers prefill latency by 9.9565% and raises prompt
+throughput from 2843.08 to 3157.46 token/s (11.0575%). Every rank logs exactly
+192 family-route hits with no architecture OOM/fallback. Both controls and the
+candidate emit the same 32 token IDs and SHA256
+`df4fee7f5f0126fe6b391fe77b4fc19667831de5ef55fd69c28c2f52a3d7086e`.
 
 ## Artifacts
 
@@ -389,6 +393,10 @@ expected family-route hits/rank and identical fixed-prompt output tokens.
   root.
 - Shape-family operator A/B:
   `results/torch-architecture-shapefamily-v1-aba.json` under that task root.
+- Shape-family TP4 model gate:
+  `results/tp4-128k-architecture-shapefamily-{candidate,control-after}-0875.json`,
+  bracketed with the endpoint gate's
+  `results/tp4-128k-architecture-scorecache-final-control-b-0875.json`.
 - Final TP4 `.875` model gate:
   `results/tp4-128k-architecture-scorecache-final-{control-a,candidate,control-b}-0875.json`.
 - Final high-memory `.88` route-success run:

--- a/docs/design/sm70_qwen38_fp8_prefill_decay.md
+++ b/docs/design/sm70_qwen38_fp8_prefill_decay.md
@@ -311,10 +311,10 @@ different scheduling and dataflow architecture:
 - export max/sum from the accepted exact 8K tail and merge the two online
   softmax states.
 
-The retained score block is BN8192. Strict Torch A/B/A for the score-cache
-layout measures `139.74426 -> 100.22127 ms`, or
-`43.61448 -> 60.81416` useful causal TFLOP/s: 28.2824% lower latency and a
-1.39436x speedup. All 12,288,000 outputs are finite; max/mean absolute error
+The retained score block is BN8192. Final frozen-extension Torch A/B/A for the
+score-cache layout measures `140.00213 -> 100.76979 ms`, or
+`43.53414 -> 60.48313` useful causal TFLOP/s: 28.0227% lower latency and a
+1.38933x speedup. All 12,288,000 outputs are finite; max/mean absolute error
 is `2.2888e-4 / 2.5430e-5` and relative L2 is `6.8629e-3` versus the exact
 FP32-accumulator route. BN7168 reaches only 58.42057 TFLOP/s and BN8000 only
 59.92825 TFLOP/s, so neither is promoted or rounded into a pass.
@@ -337,11 +337,34 @@ and falls back to the exact route.
 The route is default-off behind
 `VLLM_FLASH_V100_PREFILL_D256_GQA_ARCH_128K_EXPERIMENTAL=1`, rejects CUDA graph
 capture, and admits only the frozen shape and scale. The final `.875` TP4
-control/candidate/control and `.88` fallback-safety runs remain the promotion
-gate; no whole-model speed claim is made before those results complete.
+Qwen3.8-27B-FP8 control/candidate/control prefill times are
+`46.45658 / 45.47797 / 46.11195 s`. Relative to the `46.28426-s` bracketed
+control, the candidate lowers latency by 1.7421% and raises prompt throughput
+from 2831.89 to 2882.10 token/s (1.7729%). Every candidate rank logs 16
+architecture hits, with no architecture OOM/fallback, and all three runs emit
+the same 32 output token IDs and SHA256
+`df4fee7f5f0126fe6b391fe77b4fc19667831de5ef55fd69c28c2f52a3d7086e`.
+
+The `.88` run also succeeds at 45.53427-s prefill with the same hash and 16
+hits/rank. Its memory profiler left enough headroom, so the route passed rather
+than exercising the fallback branch. This exact-shape win is not the complete
+128K decay solution: it accelerates only the final `KV=128000` chunk. The next
+architecture gate expands admission across `Q=8000`, `KV=40000..128000`, where
+the same bounded score cache can cover up to 12 long chunks per full-attention
+layer.
 
 ## Artifacts
 
+- D256 GQA architecture task root:
+  `/data/minimax-h3/task-cache/qwen38-d256-attn-arch60-20260825`.
+- Final operator A/B/A:
+  `results/torch-architecture-scorecache-final-v1-aba.json` under that task
+  root.
+- Final TP4 `.875` model gate:
+  `results/tp4-128k-architecture-scorecache-final-{control-a,candidate,control-b}-0875.json`.
+- Final high-memory `.88` route-success run:
+  `results/tp4-128k-architecture-scorecache-final-preflight-fallback-088.json`;
+  despite the retained filename, the preflight passed and no fallback ran.
 - K-stage task root:
   `/data/minimax-h3/task-cache/qwen38-fp8-128k-flashattention-20260824`.
 - Final clean FA2 binary:

--- a/docs/design/sm70_v100_migration_control.md
+++ b/docs/design/sm70_v100_migration_control.md
@@ -1896,14 +1896,14 @@ Source behavior:
 - Decode path reads vLLM paged KV cache directly.
 - Prefill has direct and fallback paths, including paged KV gather fallback.
 
-D256 8K-by-128K GQA architecture checkpoint, 2026-08-25:
+D256 8K-by-40K..128K GQA architecture checkpoint, 2026-08-25:
 
 - Frozen single-rank shape is causal FP16 Q/K/V, `Q=8000`, `KV=128000`,
   `Hq=6`, `Hkv=1`, `D=256` on one V100-SXM2-32GB. The metric is useful
   causal Attention FLOPs divided by complete Attention elapsed time; it is not
   model TOPS or prompt throughput.
-- The architecture separates the fully visible 120K prefix from the causal 8K
-  tail. Six GQA heads are packed into GEMM M=48,000. QK writes FP16 logits and
+- The architecture separates a fully visible 32K..120K prefix from the causal
+  8K tail. Six GQA heads are packed into GEMM M=48,000. QK writes FP16 logits and
   row statistics; PV normalizes logits during its global-to-shared operand
   transform. One reusable FP16 block partial is folded into a FP32 online
   prefix numerator/state before the next block. The exact causal-tail kernel
@@ -1922,6 +1922,13 @@ D256 8K-by-128K GQA architecture checkpoint, 2026-08-25:
   max absolute difference is `2.2888e-4`, mean absolute difference
   `2.5430e-5`, and relative L2 `6.8629e-3`. Peak allocated memory is
   `1.11960 GiB`.
+- The generalized operator admits all twelve observed `Q=8000` chunk shapes,
+  `KV=40000..128000` in 8000-token steps. Strict per-length A/B measured
+  `59.34862..60.74103` useful causal TFLOP/s. Against the active split-KV3
+  control, every point is faster: latency is `22.3891%..26.1909%` lower and
+  speedup is `1.28848x..1.35485x`. All 147,456,000 candidate elements are
+  finite; the worst max absolute difference is `5.0354e-4` and worst relative
+  L2 is `6.8983e-3` versus the exact FP32-accumulator route.
 - Smaller score blocks do not pass the target: BN7168 is
   `104.32751 ms / 58.42057 TFLOP/s`; BN8000 is
   `101.70283 ms / 59.92825 TFLOP/s` and must not be rounded to 60. BN8192 is
@@ -1932,7 +1939,7 @@ D256 8K-by-128K GQA architecture checkpoint, 2026-08-25:
   fixed before timing. Synchronous device-symbol updates were changed to
   current-stream asynchronous copies so the integrated measurement includes no
   artificial whole-device fence.
-- Integration is exact-shape bounded and default-off behind
+- Integration is shape-family bounded and default-off behind
   `VLLM_FLASH_V100_PREFILL_D256_GQA_ARCH_128K_EXPERIMENTAL=1`. It rejects
   CUDA-graph capture and falls back to the exact dense kernel on workspace OOM.
   The final external FA2 patch applies cleanly after the existing D256
@@ -1956,11 +1963,12 @@ D256 8K-by-128K GQA architecture checkpoint, 2026-08-25:
   and 16 route hits/rank. Its profiler left enough headroom for the route, so
   this validates high-memory route success rather than directly exercising
   the preflight fallback branch.
-- This checkpoint passes the 60-TFLOP/s operator and real-model quality gates,
-  but remains default-off because the exact `KV=128000` admission covers only
-  the last long-prefill chunk. The next gate generalizes the architecture over
-  the observed `Q=8000`, `KV=40000..128000` shape family and measures the full
-  128K decay curve. Evidence and the experiment ledger are under
+- The shape-family operator gate is complete, but the widened real-model TP4
+  gate remains pending. The twelve per-layer split-KV3-to-architecture savings
+  sum to 267.024 ms; across 16 full-attention layers that projects 4.272 s, but
+  this is not a model result. Promotion requires a clean run with 192 expected
+  route hits/rank, bracketed prompt throughput, and identical fixed-prompt
+  tokens. Evidence and the experiment ledger are under
   `/data/minimax-h3/task-cache/qwen38-d256-attn-arch60-20260825/`.
 
 Latest target state:

--- a/docs/design/sm70_v100_migration_control.md
+++ b/docs/design/sm70_v100_migration_control.md
@@ -1896,6 +1896,60 @@ Source behavior:
 - Decode path reads vLLM paged KV cache directly.
 - Prefill has direct and fallback paths, including paged KV gather fallback.
 
+D256 8K-by-128K GQA architecture checkpoint, 2026-08-25:
+
+- Frozen single-rank shape is causal FP16 Q/K/V, `Q=8000`, `KV=128000`,
+  `Hq=6`, `Hkv=1`, `D=256` on one V100-SXM2-32GB. The metric is useful
+  causal Attention FLOPs divided by complete Attention elapsed time; it is not
+  model TOPS or prompt throughput.
+- The architecture separates the fully visible 120K prefix from the causal 8K
+  tail. Six GQA heads are packed into GEMM M=48,000. QK writes FP16 logits and
+  row statistics; PV normalizes logits during its global-to-shared operand
+  transform. One reusable FP16 block partial is folded into a FP32 online
+  prefix numerator/state before the next block. The exact causal-tail kernel
+  exports max/sum state and a final kernel merges prefix and tail.
+- The final BN8192 score-cache layout retains only the 750-MiB FP16 score
+  matrix per device. All other approximately 100 MiB of state is packed into
+  one transient aligned byte slab. A per-device event and mutex serialize
+  score reuse across streams. Before its first allocation, the route requires
+  driver-visible free memory for both workspaces plus 128 MiB of downstream
+  headroom; failure raises a typed OOM without touching the caching allocator
+  or launching a kernel, so the Python path can fall back safely.
+- Strict task-local Torch A/B/A measured the existing exact operator at
+  `139.74426 ms / 43.61 TFLOP/s` and the complete architecture at
+  `100.22127 ms / 60.81416 TFLOP/s`: `28.2824%` lower latency and `1.39436x`
+  speedup. All 12,288,000 outputs are finite; versus the exact operator,
+  max absolute difference is `2.2888e-4`, mean absolute difference
+  `2.5430e-5`, and relative L2 `6.8629e-3`. Peak allocated memory is
+  `1.11960 GiB`.
+- Smaller score blocks do not pass the target: BN7168 is
+  `104.32751 ms / 58.42057 TFLOP/s`; BN8000 is
+  `101.70283 ms / 59.92825 TFLOP/s` and must not be rounded to 60. BN8192 is
+  therefore retained while model KV reservation supplies downstream headroom.
+- QK and PV compile at 254 and 119 registers/thread with no spill, stack, or
+  local storage. The complete operator is loadable through `torch.ops`; the
+  initial namespace registration mismatch was caught by a static load test and
+  fixed before timing. Synchronous device-symbol updates were changed to
+  current-stream asynchronous copies so the integrated measurement includes no
+  artificial whole-device fence.
+- Integration is exact-shape bounded and default-off behind
+  `VLLM_FLASH_V100_PREFILL_D256_GQA_ARCH_128K_EXPERIMENTAL=1`. It rejects
+  CUDA-graph capture and falls back to the exact dense kernel on workspace OOM.
+  The final external FA2 patch applies cleanly after the existing D256
+  pipeline, split-KV3, and K-ping-pong patches, and a fresh CUDA 12.8 / Torch
+  cu128 SM70 build passes its operator-schema load test. The full Flash-V100
+  policy file passes 111/111 CPU tests; Ruff and `git diff --check` pass.
+- Real-model memory tests at `gpu_memory_utilization=0.88` rejected the fully
+  persistent and score-cache layouts after their first successful route call:
+  the following 80-MiB PYNCCL all-reduce had only 62-74 MiB free. This is a
+  downstream-headroom failure, not an Attention compute failure. A matched
+  `.875` TP4 control/candidate/control validation is queued on GPUs 4-7.
+- This checkpoint passes the 60-TFLOP/s microkernel/Torch gate but is not yet a
+  production model claim. Default enablement requires a clean Nsight timeline,
+  real Qwen3.8-27B-FP8 route-hit and prompt-throughput A/B, and fixed-prompt
+  logits/tokens quality evidence. Evidence and the experiment ledger are under
+  `/data/minimax-h3/task-cache/qwen38-d256-attn-arch60-20260825/`.
+
 Latest target state:
 
 - No `FLASH_ATTN_V100` enum.

--- a/docs/design/sm70_v100_migration_control.md
+++ b/docs/design/sm70_v100_migration_control.md
@@ -1963,12 +1963,15 @@ D256 8K-by-40K..128K GQA architecture checkpoint, 2026-08-25:
   and 16 route hits/rank. Its profiler left enough headroom for the route, so
   this validates high-memory route success rather than directly exercising
   the preflight fallback branch.
-- The shape-family operator gate is complete, but the widened real-model TP4
-  gate remains pending. The twelve per-layer split-KV3-to-architecture savings
-  sum to 267.024 ms; across 16 full-attention layers that projects 4.272 s, but
-  this is not a model result. Promotion requires a clean run with 192 expected
-  route hits/rank, bracketed prompt throughput, and identical fixed-prompt
-  tokens. Evidence and the experiment ledger are under
+- The widened TP4 Qwen3.8-27B-FP8 gate uses a `46.11195-s` control before the
+  candidate and a `46.09222-s` control after it. Against their `46.10208-s`
+  mean, the `41.51191-s` candidate lowers prefill latency by `9.9565%` and
+  raises prompt throughput from `2843.08` to `3157.46` token/s (`11.0575%`).
+  Every rank logs exactly 192 family-route hits with no architecture OOM or
+  fallback. Both controls and the candidate emit the same 32 token IDs and
+  SHA256
+  `df4fee7f5f0126fe6b391fe77b4fc19667831de5ef55fd69c28c2f52a3d7086e`.
+  Evidence and the experiment ledger are under
   `/data/minimax-h3/task-cache/qwen38-d256-attn-arch60-20260825/`.
 
 Latest target state:

--- a/docs/design/sm70_v100_migration_control.md
+++ b/docs/design/sm70_v100_migration_control.md
@@ -1915,9 +1915,9 @@ D256 8K-by-128K GQA architecture checkpoint, 2026-08-25:
   driver-visible free memory for both workspaces plus 128 MiB of downstream
   headroom; failure raises a typed OOM without touching the caching allocator
   or launching a kernel, so the Python path can fall back safely.
-- Strict task-local Torch A/B/A measured the existing exact operator at
-  `139.74426 ms / 43.61 TFLOP/s` and the complete architecture at
-  `100.22127 ms / 60.81416 TFLOP/s`: `28.2824%` lower latency and `1.39436x`
+- The final frozen-extension Torch A/B/A measured the existing exact operator
+  at `140.00213 ms / 43.53414 TFLOP/s` and the complete architecture at
+  `100.76979 ms / 60.48313 TFLOP/s`: `28.0227%` lower latency and `1.38933x`
   speedup. All 12,288,000 outputs are finite; versus the exact operator,
   max absolute difference is `2.2888e-4`, mean absolute difference
   `2.5430e-5`, and relative L2 `6.8629e-3`. Peak allocated memory is
@@ -1939,15 +1939,28 @@ D256 8K-by-128K GQA architecture checkpoint, 2026-08-25:
   pipeline, split-KV3, and K-ping-pong patches, and a fresh CUDA 12.8 / Torch
   cu128 SM70 build passes its operator-schema load test. The full Flash-V100
   policy file passes 111/111 CPU tests; Ruff and `git diff --check` pass.
-- Real-model memory tests at `gpu_memory_utilization=0.88` rejected the fully
-  persistent and score-cache layouts after their first successful route call:
-  the following 80-MiB PYNCCL all-reduce had only 62-74 MiB free. This is a
-  downstream-headroom failure, not an Attention compute failure. A matched
-  `.875` TP4 control/candidate/control validation is queued on GPUs 4-7.
-- This checkpoint passes the 60-TFLOP/s microkernel/Torch gate but is not yet a
-  production model claim. Default enablement requires a clean Nsight timeline,
-  real Qwen3.8-27B-FP8 route-hit and prompt-throughput A/B, and fixed-prompt
-  logits/tokens quality evidence. Evidence and the experiment ledger are under
+- Early real-model memory tests at `gpu_memory_utilization=0.88` rejected the
+  fully persistent and pre-preflight score-cache layouts after their first
+  successful route call: the following 80-MiB PYNCCL all-reduce had only
+  62-74 MiB free. This is a downstream-headroom failure, not an Attention
+  compute failure.
+- The final matched `.875` TP4 Qwen3.8-27B-FP8
+  control/candidate/control prefill times are `46.45658 / 45.47797 /
+  46.11195 s`. Against the `46.28426-s` bracketed control, the candidate is
+  `1.7421%` lower latency and `1.01773x` faster (`2831.89 -> 2882.10`
+  prompt token/s). Every candidate rank logs 16 architecture hits and no
+  architecture OOM/fallback. All three runs produce the same 32 output token
+  IDs and SHA256
+  `df4fee7f5f0126fe6b391fe77b4fc19667831de5ef55fd69c28c2f52a3d7086e`.
+- A final `.88` run also completes in `45.53427 s`, with the same token hash
+  and 16 route hits/rank. Its profiler left enough headroom for the route, so
+  this validates high-memory route success rather than directly exercising
+  the preflight fallback branch.
+- This checkpoint passes the 60-TFLOP/s operator and real-model quality gates,
+  but remains default-off because the exact `KV=128000` admission covers only
+  the last long-prefill chunk. The next gate generalizes the architecture over
+  the observed `Q=8000`, `KV=40000..128000` shape family and measures the full
+  128K decay curve. Evidence and the experiment ledger are under
   `/data/minimax-h3/task-cache/qwen38-d256-attn-arch60-20260825/`.
 
 Latest target state:

--- a/tests/v1/attention/test_sm70_flash_v100_policy.py
+++ b/tests/v1/attention/test_sm70_flash_v100_policy.py
@@ -868,7 +868,7 @@ def test_prefill_dense_splitkv3_policy_is_exact_shape_bounded(monkeypatch):
     )
 
 
-def test_prefill_d256_gqa_architecture_policy_is_exact_shape_bounded(monkeypatch):
+def test_prefill_d256_gqa_architecture_policy_is_shape_family_bounded(monkeypatch):
     import vllm.envs as envs
     import vllm.v1.attention.backends.flash_attn_v100 as flash_v100
 
@@ -891,15 +891,19 @@ def test_prefill_d256_gqa_architecture_policy_is_exact_shape_bounded(monkeypatch
 
     monkeypatch.setenv(name, "1")
     envs.disable_envs_cache()
-    assert flash_v100._should_use_prefill_d256_gqa_architecture(
-        query,
-        key,
-        value,
-        max_seqlen_q=8000,
-        max_seqlen_k=128000,
-        softmax_scale=0.0625,
-        architecture_op=object(),
-    )
+    for kv_len in range(40000, 128001, 8000):
+        family_key = torch.empty(
+            (1, kv_len, 1, 256), dtype=torch.float16, device="meta"
+        )
+        assert flash_v100._should_use_prefill_d256_gqa_architecture(
+            query,
+            family_key,
+            torch.empty_like(family_key),
+            max_seqlen_q=8000,
+            max_seqlen_k=kv_len,
+            softmax_scale=0.0625,
+            architecture_op=object(),
+        )
     assert not flash_v100._should_use_prefill_d256_gqa_architecture(
         query[:, :7999],
         key,
@@ -915,6 +919,15 @@ def test_prefill_d256_gqa_architecture_policy_is_exact_shape_bounded(monkeypatch
         value[:, :127999],
         max_seqlen_q=8000,
         max_seqlen_k=127999,
+        softmax_scale=0.0625,
+        architecture_op=object(),
+    )
+    assert not flash_v100._should_use_prefill_d256_gqa_architecture(
+        query,
+        key[:, :44000],
+        value[:, :44000],
+        max_seqlen_q=8000,
+        max_seqlen_k=44000,
         softmax_scale=0.0625,
         architecture_op=object(),
     )

--- a/tests/v1/attention/test_sm70_flash_v100_policy.py
+++ b/tests/v1/attention/test_sm70_flash_v100_policy.py
@@ -237,6 +237,19 @@ def test_sm70_fa2_d256_prefill_env_is_default_on(monkeypatch):
     assert envs.VLLM_FLASH_V100_FA2_D256_PREFILL is False
 
 
+def test_sm70_d256_gqa_architecture_env_is_default_off(monkeypatch):
+    import vllm.envs as envs
+
+    name = "VLLM_FLASH_V100_PREFILL_D256_GQA_ARCH_128K_EXPERIMENTAL"
+    monkeypatch.delenv(name, raising=False)
+    envs.disable_envs_cache()
+    assert envs.VLLM_FLASH_V100_PREFILL_D256_GQA_ARCH_128K_EXPERIMENTAL is False
+
+    monkeypatch.setenv(name, "1")
+    envs.disable_envs_cache()
+    assert envs.VLLM_FLASH_V100_PREFILL_D256_GQA_ARCH_128K_EXPERIMENTAL is True
+
+
 def test_sm70_e4m3_batch_xqa_env_contract(monkeypatch):
     import vllm.envs as envs
 
@@ -604,6 +617,7 @@ def test_prefix_prefill_prioritizes_gathered_exact_dense_over_paged(
     impl.head_size = 256
     impl.scale = 0.0625
     impl.sliding_window = None
+    impl.prefix_anchored_decode_window = None
     impl.kv_cache_dtype = "auto"
     impl.use_flash_v100_decode = False
     impl.use_decode_paged_prefill = False
@@ -724,6 +738,36 @@ def test_sm70_splitd_d256_loader_requires_exact_ops(monkeypatch):
     assert flash_v100._get_sm70_splitd_d256_ops() == (dense, paged, splitkv3)
 
 
+def test_sm70_d256_gqa_architecture_loader_is_optional(monkeypatch):
+    import vllm.v1.attention.backends.flash_attn_v100 as flash_v100
+
+    fake_interface = types.ModuleType("vllm.vllm_flash_attn.flash_attn_interface")
+    fake_package = types.ModuleType("vllm.vllm_flash_attn")
+    fake_package.__dict__["flash_attn_interface"] = fake_interface
+    monkeypatch.setitem(sys.modules, "vllm.vllm_flash_attn", fake_package)
+    monkeypatch.setitem(
+        sys.modules,
+        "vllm.vllm_flash_attn.flash_attn_interface",
+        fake_interface,
+    )
+
+    architecture = object()
+    fake_ops = SimpleNamespace(
+        _vllm_fa2_C=SimpleNamespace(
+            sm70_d256_gqa_architecture_fwd=architecture,
+        )
+    )
+    monkeypatch.setattr(flash_v100, "torch", SimpleNamespace(ops=fake_ops))
+    monkeypatch.setattr(
+        flash_v100,
+        "_sm70_d256_gqa_architecture_op_checked",
+        False,
+    )
+    monkeypatch.setattr(flash_v100, "_sm70_d256_gqa_architecture_op", None)
+
+    assert flash_v100._get_sm70_d256_gqa_architecture_op() is architecture
+
+
 def test_prefill_dense_splitkv3_workspace_reuses_exact_shape(monkeypatch):
     import vllm.v1.attention.backends.flash_attn_v100 as flash_v100
 
@@ -821,6 +865,67 @@ def test_prefill_dense_splitkv3_policy_is_exact_shape_bounded(monkeypatch):
         max_seqlen_q=8192,
         max_seqlen_k=65536,
         splitkv3_op=object(),
+    )
+
+
+def test_prefill_d256_gqa_architecture_policy_is_exact_shape_bounded(monkeypatch):
+    import vllm.envs as envs
+    import vllm.v1.attention.backends.flash_attn_v100 as flash_v100
+
+    name = "VLLM_FLASH_V100_PREFILL_D256_GQA_ARCH_128K_EXPERIMENTAL"
+    query = torch.empty((1, 8000, 6, 256), dtype=torch.float16, device="meta")
+    key = torch.empty((1, 128000, 1, 256), dtype=torch.float16, device="meta")
+    value = torch.empty_like(key)
+
+    monkeypatch.delenv(name, raising=False)
+    envs.disable_envs_cache()
+    assert not flash_v100._should_use_prefill_d256_gqa_architecture(
+        query,
+        key,
+        value,
+        max_seqlen_q=8000,
+        max_seqlen_k=128000,
+        softmax_scale=0.0625,
+        architecture_op=object(),
+    )
+
+    monkeypatch.setenv(name, "1")
+    envs.disable_envs_cache()
+    assert flash_v100._should_use_prefill_d256_gqa_architecture(
+        query,
+        key,
+        value,
+        max_seqlen_q=8000,
+        max_seqlen_k=128000,
+        softmax_scale=0.0625,
+        architecture_op=object(),
+    )
+    assert not flash_v100._should_use_prefill_d256_gqa_architecture(
+        query[:, :7999],
+        key,
+        value,
+        max_seqlen_q=7999,
+        max_seqlen_k=128000,
+        softmax_scale=0.0625,
+        architecture_op=object(),
+    )
+    assert not flash_v100._should_use_prefill_d256_gqa_architecture(
+        query,
+        key[:, :127999],
+        value[:, :127999],
+        max_seqlen_q=8000,
+        max_seqlen_k=127999,
+        softmax_scale=0.0625,
+        architecture_op=object(),
+    )
+    assert not flash_v100._should_use_prefill_d256_gqa_architecture(
+        query,
+        key,
+        value,
+        max_seqlen_q=8000,
+        max_seqlen_k=128000,
+        softmax_scale=1.0,
+        architecture_op=object(),
     )
 
 

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -346,6 +346,7 @@ if TYPE_CHECKING:
     VLLM_FLASH_V100_PREFILL_DENSE_SPLITKV3: bool = True
     VLLM_FLASH_V100_PREFILL_DENSE_SPLITKV3_MIN_KV: int = 32768
     VLLM_FLASH_V100_PREFILL_DENSE_SPLITKV3_Q8000_EXPERIMENTAL: bool = False
+    VLLM_FLASH_V100_PREFILL_D256_GQA_ARCH_128K_EXPERIMENTAL: bool = False
     VLLM_FLASH_V100_PREFILL_SPLIT_KV: bool = False
     VLLM_FLASH_V100_PREFILL_SPLIT_KV_TOKENS: int = 32768
     VLLM_FLASH_V100_PREFILL_SPLIT_KV_MIN_Q: int = 1
@@ -2449,6 +2450,14 @@ environment_variables: dict[str, Callable[[], Any]] = {
         int(
             os.getenv(
                 "VLLM_FLASH_V100_PREFILL_DENSE_SPLITKV3_Q8000_EXPERIMENTAL",
+                "0",
+            )
+        )
+    ),
+    "VLLM_FLASH_V100_PREFILL_D256_GQA_ARCH_128K_EXPERIMENTAL": lambda: bool(
+        int(
+            os.getenv(
+                "VLLM_FLASH_V100_PREFILL_D256_GQA_ARCH_128K_EXPERIMENTAL",
                 "0",
             )
         )

--- a/vllm/v1/attention/backends/flash_attn_v100.py
+++ b/vllm/v1/attention/backends/flash_attn_v100.py
@@ -1300,7 +1300,7 @@ def _get_sm70_splitd_d256_ops():
 
 
 def _get_sm70_d256_gqa_architecture_op():
-    """Load the optional 8K-by-128K SM70 GQA architecture operator."""
+    """Load the optional SM70 GQA long-prefill architecture operator."""
     global _sm70_d256_gqa_architecture_op
     global _sm70_d256_gqa_architecture_op_checked
     if _sm70_d256_gqa_architecture_op_checked:
@@ -1451,15 +1451,19 @@ def _should_use_prefill_d256_gqa_architecture(
     softmax_scale: float,
     architecture_op: Callable[..., torch.Tensor] | None,
 ) -> bool:
-    """Gate the measured Q8000/KV128000/Hq6/Hkv1/D256 dense route."""
+    """Gate the measured Q8000/KV40K..128K/Hq6/Hkv1/D256 family."""
     return (
         envs.VLLM_FLASH_V100_PREFILL_D256_GQA_ARCH_128K_EXPERIMENTAL
         and architecture_op is not None
         and query.shape == (1, 8000, 6, 256)
-        and key.shape == (1, 128000, 1, 256)
+        and key.ndim == 4
+        and key.shape[0] == 1
+        and key.shape[2:] == (1, 256)
         and value.shape == key.shape
         and max_seqlen_q == 8000
-        and max_seqlen_k == 128000
+        and max_seqlen_k == key.shape[1]
+        and 40000 <= max_seqlen_k <= 128000
+        and max_seqlen_k % 8000 == 0
         and query.dtype == torch.float16
         and key.dtype == query.dtype
         and value.dtype == query.dtype
@@ -1620,7 +1624,7 @@ def _try_sm70_fa2_d256_prefill(
                         if not _warned_prefill_d256_gqa_architecture_oom:
                             logger.warning(
                                 "Insufficient memory for the experimental "
-                                "SM70 D256 GQA 8K-by-128K architecture; "
+                                "SM70 D256 GQA long-prefill architecture; "
                                 "falling back to the exact dense kernel."
                             )
                             _warned_prefill_d256_gqa_architecture_oom = True
@@ -1628,10 +1632,10 @@ def _try_sm70_fa2_d256_prefill(
                         if not _logged_prefill_d256_gqa_architecture:
                             logger.info(
                                 "FLASH_ATTN_V100 experimental SM70 D256 GQA "
-                                "8K-by-128K architecture route active."
+                                "8K-by-40K..128K architecture route active."
                             )
                             _logged_prefill_d256_gqa_architecture = True
-                        _record_route("prefill_dense_d256_gqa_arch_128k")
+                        _record_route("prefill_dense_d256_gqa_arch_long")
                 if splitd_result is None and _should_use_prefill_dense_splitkv3(
                     query,
                     key,

--- a/vllm/v1/attention/backends/flash_attn_v100.py
+++ b/vllm/v1/attention/backends/flash_attn_v100.py
@@ -502,6 +502,8 @@ _flash_attn_prefill_paged_bfla = None
 _flash_attn_prefill_paged_splitkv = None
 _sm70_splitd_d256_ops = None
 _sm70_splitd_d256_ops_checked = False
+_sm70_d256_gqa_architecture_op = None
+_sm70_d256_gqa_architecture_op_checked = False
 _sm70_fa2_cu_seqlens_cache: dict[
     tuple[int, int, int, int], tuple[torch.Tensor, torch.Tensor]
 ] = {}
@@ -515,6 +517,7 @@ _warned_decode_fallback = False
 _warned_decode_strict_fallback = False
 _warned_prefill_gather_oom = False
 _warned_prefill_dense_splitkv3_oom = False
+_warned_prefill_d256_gqa_architecture_oom = False
 _logged_prefill_flash = False
 _logged_prefill_prefix_flash = False
 _logged_prefill_prefix_contig_dense = False
@@ -527,6 +530,7 @@ _logged_prefill_smallq_grouped_verify = False
 _logged_prefill_smallq_grouped_verify_gate = False
 _logged_prefill_fa2_d256 = False
 _logged_prefill_dense_splitkv3 = False
+_logged_prefill_d256_gqa_architecture = False
 _logged_prefill_triton_safe = False
 _logged_decode_flash = False
 _logged_decode_dense_reference = False
@@ -1295,6 +1299,35 @@ def _get_sm70_splitd_d256_ops():
     return _sm70_splitd_d256_ops
 
 
+def _get_sm70_d256_gqa_architecture_op():
+    """Load the optional 8K-by-128K SM70 GQA architecture operator."""
+    global _sm70_d256_gqa_architecture_op
+    global _sm70_d256_gqa_architecture_op_checked
+    if _sm70_d256_gqa_architecture_op_checked:
+        return _sm70_d256_gqa_architecture_op
+
+    _sm70_d256_gqa_architecture_op_checked = True
+    try:
+        # Importing the interface loads the vendored FA2 torch library.
+        from vllm.vllm_flash_attn import flash_attn_interface  # noqa: F401
+
+        _sm70_d256_gqa_architecture_op = getattr(
+            torch.ops._vllm_fa2_C,
+            "sm70_d256_gqa_architecture_fwd",
+            None,
+        )
+    except (AttributeError, ImportError, RuntimeError) as exc:
+        _sm70_d256_gqa_architecture_op = None
+        if envs.VLLM_FLASH_V100_PREFILL_D256_GQA_ARCH_128K_EXPERIMENTAL:
+            logger.warning_once(
+                "SM70 D256 GQA architecture operator is unavailable "
+                "(%s: %s); using the exact dense prefill kernel.",
+                type(exc).__name__,
+                exc,
+            )
+    return _sm70_d256_gqa_architecture_op
+
+
 def _uniform_cu_seqlens(
     tensor: torch.Tensor,
     *,
@@ -1408,6 +1441,38 @@ def _should_use_prefill_dense_splitkv3(
     )
 
 
+def _should_use_prefill_d256_gqa_architecture(
+    query: torch.Tensor,
+    key: torch.Tensor,
+    value: torch.Tensor,
+    *,
+    max_seqlen_q: int,
+    max_seqlen_k: int,
+    softmax_scale: float,
+    architecture_op: Callable[..., torch.Tensor] | None,
+) -> bool:
+    """Gate the measured Q8000/KV128000/Hq6/Hkv1/D256 dense route."""
+    return (
+        envs.VLLM_FLASH_V100_PREFILL_D256_GQA_ARCH_128K_EXPERIMENTAL
+        and architecture_op is not None
+        and query.shape == (1, 8000, 6, 256)
+        and key.shape == (1, 128000, 1, 256)
+        and value.shape == key.shape
+        and max_seqlen_q == 8000
+        and max_seqlen_k == 128000
+        and query.dtype == torch.float16
+        and key.dtype == query.dtype
+        and value.dtype == query.dtype
+        and query.device == key.device
+        and query.device == value.device
+        and query.is_contiguous()
+        and key.is_contiguous()
+        and value.is_contiguous()
+        and abs(softmax_scale - 0.0625) <= 1.0e-8
+        and not _is_cuda_graph_capturing(query)
+    )
+
+
 def _try_sm70_fa2_d256_prefill(
     query: torch.Tensor,
     key: torch.Tensor,
@@ -1424,6 +1489,9 @@ def _try_sm70_fa2_d256_prefill(
     seqused_k: torch.Tensor | None = None,
     block_table: torch.Tensor | None = None,
 ) -> torch.Tensor | None:
+    global _logged_prefill_d256_gqa_architecture
+    global _warned_prefill_d256_gqa_architecture_oom
+
     int32_max = torch.iinfo(torch.int32).max
     if not envs.VLLM_FLASH_V100_FA2_D256_PREFILL:
         return None
@@ -1524,7 +1592,47 @@ def _try_sm70_fa2_d256_prefill(
             )
             if splitd_eligible:
                 splitd_out = out if out is not None else torch.empty_like(query)
-                if _should_use_prefill_dense_splitkv3(
+                architecture_op = (
+                    _get_sm70_d256_gqa_architecture_op()
+                    if envs.VLLM_FLASH_V100_PREFILL_D256_GQA_ARCH_128K_EXPERIMENTAL
+                    else None
+                )
+                if _should_use_prefill_d256_gqa_architecture(
+                    query,
+                    key,
+                    value,
+                    max_seqlen_q=max_seqlen_q,
+                    max_seqlen_k=max_seqlen_k,
+                    softmax_scale=softmax_scale,
+                    architecture_op=architecture_op,
+                ):
+                    assert architecture_op is not None
+                    try:
+                        splitd_result = architecture_op(
+                            query,
+                            key,
+                            value,
+                            splitd_out,
+                            softmax_scale,
+                            True,
+                        )
+                    except torch.OutOfMemoryError:
+                        if not _warned_prefill_d256_gqa_architecture_oom:
+                            logger.warning(
+                                "Insufficient memory for the experimental "
+                                "SM70 D256 GQA 8K-by-128K architecture; "
+                                "falling back to the exact dense kernel."
+                            )
+                            _warned_prefill_d256_gqa_architecture_oom = True
+                    if splitd_result is not None:
+                        if not _logged_prefill_d256_gqa_architecture:
+                            logger.info(
+                                "FLASH_ATTN_V100 experimental SM70 D256 GQA "
+                                "8K-by-128K architecture route active."
+                            )
+                            _logged_prefill_d256_gqa_architecture = True
+                        _record_route("prefill_dense_d256_gqa_arch_128k")
+                if splitd_result is None and _should_use_prefill_dense_splitkv3(
                     query,
                     key,
                     max_seqlen_q=max_seqlen_q,


### PR DESCRIPTION
## Purpose

- Add a default-on SM70 attention architecture for the validated causal FP16 `Q=8000`, `KV=40000..128000` (step 8000), `Hq=6`, `Hkv=1`, `D=256`, scale `1/16` long-prefill family.
- Route only by device capability and tensor/runtime properties. There is no model name, checkpoint, `model_type`, or architecture-identity gate.
- Pack six GQA query heads into wide QK/PV Tensor-Core GEMMs, retain one reusable block partial, and merge the exact causal tail with online-softmax state.
- Retain one 750-MiB per-device score workspace, serialize cross-stream reuse with an event and mutex, and preflight the persistent plus transient allocation with 128 MiB of downstream headroom.
- Keep `VLLM_FLASH_V100_PREFILL_D256_GQA_ARCH_128K_EXPERIMENTAL=0` as the legacy rollback setting. CUDA graph capture and unsupported shapes fall through to existing paths; typed workspace OOM falls back to the exact dense route.

## Test Plan

- `pytest -q tests/v1/attention/test_sm70_flash_v100_policy.py` on a real V100.
- Changed-file pre-commit, including Ruff, mypy, Markdown, SPDX, forbidden-import, environment-default, and backend-documentation checks.
- Replay all four SM70 FA2 patches from the locked pristine vendored baseline and build/load `_vllm_fa2_C` with CUDA 12.8, Torch cu128, and `sm_70`.
- Direct current-source dense/candidate A/B at the 40K and 128K endpoints.
- Retain the existing strict 12-shape A/B and matched TP4 control/candidate/control evidence.

## Test Result

- Final policy suite: **112 passed** on V100, including direct architecture-OOM-to-dense-fallback coverage.
- All changed-file pre-commit hooks pass; `git diff --check` passes.
- Clean patch replay, CUDA 12.8 SM70 build, Torch operator schema/load, and launch pass. QK/PV compile at 254/119 registers with zero spill.
- Current-source KV40K: dense `39.29395 ms`, candidate `30.27579 ms`; `1.29787x` speedup and 22.95% lower latency.
- Current-source KV128K: dense `136.07628 ms`, candidate `100.20284 ms`; `1.35801x` speedup and 26.36% lower latency.
- KV40K numerical result: all outputs finite, max/mean absolute difference `5.4932e-4 / 4.4392e-5`, relative L2 `6.6098e-3`.
- KV128K numerical result: all outputs finite, max/mean absolute difference `2.2888e-4 / 2.5484e-5`, relative L2 `6.9166e-3`.
- Both pass the FP16 merge envelope of max absolute error `<=1e-3` and relative L2 `<=1e-2`. Bitwise and greedy token identity are not promotion requirements.
- Existing 12-shape evidence: every 40K..128K point is faster, with `1.28848x..1.35485x` speedup; all 147,456,000 candidate elements are finite, worst max absolute difference `5.0354e-4`, worst relative L2 `6.8983e-3`.
- Existing matched widened TP4 gate: bracketed control `46.10208 s`, candidate `41.51191 s`; prefill latency improves 9.9565% and prompt throughput improves 11.0575%. The identical 32-token smoke is retained only as route-health evidence.

## Safety

The default route is deliberately narrow and capability-based. Unsupported shapes, layouts, dtypes, scales, devices, paged KV, and CUDA graph capture do not enter it. A missing optional operator falls through. A typed persistent or transient workspace OOM is caught and executes the existing exact fallback instead of failing the request.