### PR TITLE
[Core][SM70] Restore practical DFlash2 performance closure

### DIFF
--- a/docs/design/sm70_v100_migration_control.md
+++ b/docs/design/sm70_v100_migration_control.md
@@ -42997,3 +42997,29 @@ Interpretation:
   no E4M3 route trace and must not be cited. The accepted implementation gates
   both metadata and dispatcher creation; capture logs prove eight FULL graphs
   and explicit B8/B16 long-context route hits.
+
+## 2026-08-25 DFlash2 practical-performance closure
+
+- PRs #252, #253, #257, #266, and #284 are already merged. The missing
+  performance closure was twelve post-#284 files that remained only in the
+  measured production worktree, not an open historical PR.
+- A matched single-request coding probe with FP8 E5M2 KV, 256K maximum
+  context, 4096 maximum batched tokens, prefix caching, Mamba align, CUDA
+  Graph, and tool/reasoning parsers measured `18.66--18.83 ms` per complete
+  round (`131.2--139.9 tok/s`) on that production tree. The clean
+  `onecat/main@05d5aa4e57` route hit the same visible QPN8, sharded projection,
+  grouped verifier, and CUDA Graph logs but measured `27.84--27.96 ms`
+  (`90.5--92.6 tok/s`). Route-hit logs alone are therefore not an acceptable
+  performance proof.
+- Draft PR #288 restores the exact missing source closure on latest main. The
+  decode hot path enables fused GDN group metadata for `mamba_cache_mode=align`
+  and makes disabled GDN dump hooks return before CUDA runtime queries. The
+  prefill half skips unused DFlash queries on intermediate 4096-token chunks
+  and keeps the small-M TurboMind projection out of large-M prefill shapes.
+- Focused pre-commit passes. On the latest-main worktree, DFlash2/GDN CPU
+  suites report `110 passed, 32 skipped`; the V100 align-metadata replay and
+  AOT fullgraph predicate tests both pass. The first end-to-end launch produced
+  no timing result because an external TP4 job acquired GPUs 4--7 between API
+  startup and worker memory admission. Wait for the cards and rerun the exact
+  practical contract before merging; do not lower memory utilization or cite
+  that failed launch as implementation evidence.

--- a/docs/design/sm70_v100_migration_control.md
+++ b/docs/design/sm70_v100_migration_control.md
@@ -43023,3 +43023,25 @@ Interpretation:
   startup and worker memory admission. Wait for the cards and rerun the exact
   practical contract before merging; do not lower memory utilization or cite
   that failed launch as implementation evidence.
+- The queued clean rerun on PR #288 used the exact practical contract: TP4 on
+  V100, FP8 E5M2 target KV, FP16 draft KV, 256K maximum context, 4096 maximum
+  batched tokens, prefix caching, Mamba align, probabilistic DFlash2, CUDA
+  Graph, and the Qwen tool/reasoning parsers. Startup logs prove QPN8 exact
+  rerank, the TP4 sharded context projection, the one-pass grouped verifier,
+  target and draft graph capture, and, critically, fused GDN metadata for all
+  10 cache groups.
+- After one explicitly excluded first-request JIT warmup, four 512-token
+  single-request runs of `给我写个自我介绍网页吧` measured `18.465--18.537 ms`
+  per complete round and `133.05--146.63 tok/s`; acceptance length was
+  `2.457--2.718`. Three 1,024-token practical coding runs measured
+  `18.587--18.603 ms`, `132.62--139.93 tok/s`, and acceptance length
+  `2.470--2.606`, reproducing the measured production worktree.
+- The historical high-acceptance MBPP item 28 reproduced `251.60 tok/s`,
+  `18.567 ms` per complete round, acceptance length `4.686`, and a natural-EOS
+  328-token completion. Its complete generated text has the same SHA256 as the
+  previous production result, and EvalPlus reports base `1/1` and plus `1/1`.
+  This closes both the roughly 18 ms and the 220+ token/s restoration gates.
+- A fresh 32K chunked-prefill request logged the context-only DFlash path and
+  measured `10.58--10.65 s` cold; the identical prefix hit measured `1.405 s`.
+  The older public server's nominal cold result may have retained an identical
+  prefix, so only the fresh-server numbers are treated as strict cold evidence.

--- a/tests/kernels/core/test_sm70_dflash2_gemma_rms.py
+++ b/tests/kernels/core/test_sm70_dflash2_gemma_rms.py
@@ -96,3 +96,26 @@ def test_sm70_dflash2_gemma_fused_add_rms_allows_aot_warmup_shape(monkeypatch):
     weight = torch.empty(5120, dtype=torch.float16, device="cuda")
 
     assert _use_sm70_dflash2_gemma_fused_add_rms(x, residual, weight)
+
+
+def test_sm70_dflash2_gemma_fused_predicate_is_fullgraph_safe(monkeypatch):
+    if not torch.cuda.is_available() or torch.cuda.get_device_capability() != (7, 0):
+        pytest.skip("SM70 CUDA device required")
+
+    monkeypatch.setenv("VLLM_SM70_DFLASH2_FUSED_GEMMA_RMS", "1")
+    monkeypatch.setenv("VLLM_SM70_FLASH_V100_0DOT3_COMPILE_GRAPH", "1")
+    x = torch.zeros((8, 5120), dtype=torch.float16, device="cuda")
+    residual = torch.empty_like(x, dtype=torch.float32)
+    weight = torch.empty(5120, dtype=torch.float16, device="cuda")
+
+    @torch.compile(backend="eager", fullgraph=True)
+    def apply_predicate(
+        values: torch.Tensor,
+        residual_values: torch.Tensor,
+        norm_weight: torch.Tensor,
+    ) -> torch.Tensor:
+        if _use_sm70_dflash2_gemma_fused_add_rms(values, residual_values, norm_weight):
+            return values + 1
+        return values
+
+    torch.testing.assert_close(apply_predicate(x, residual, weight), x + 1)

--- a/tests/v1/attention/test_gdn_metadata_builder.py
+++ b/tests/v1/attention/test_gdn_metadata_builder.py
@@ -49,6 +49,24 @@ BLOCK_SIZE = 16
 DEVICE = torch.device("cpu")
 
 
+def test_disabled_gdn_core_dump_avoids_cuda_runtime_query(monkeypatch):
+    monkeypatch.delenv("VLLM_SM70_DUMP_GDN_CORE_DIR", raising=False)
+    monkeypatch.delenv("VLLM_SM70_DUMP_GDN_GRAPH_BUFFERS", raising=False)
+    monkeypatch.delenv("VLLM_SM70_DUMP_GDN_GRAPH_DIR", raising=False)
+
+    def fail_debug_work(*_args, **_kwargs):
+        raise AssertionError("disabled debug hook performed debug work")
+
+    cuda_module = vars(qwen_gdn.torch)["cuda"]
+    monkeypatch.setattr(cuda_module, "is_current_stream_capturing", fail_debug_work)
+    monkeypatch.setattr(qwen_gdn, "_sm70_gdn_graph_buffer_copy", fail_debug_work)
+    qwen_gdn._sm70_dump_gdn_core_tensor(
+        "input_qkv",
+        "layer.0",
+        torch.zeros(1),
+    )
+
+
 def test_mamba_hybrid_passes_seq_lens_cpu_upper_bound(monkeypatch):
     """Flash-V100 metadata must not lazily copy seq_lens back from the GPU."""
 
@@ -79,6 +97,7 @@ def test_mamba_hybrid_passes_seq_lens_cpu_upper_bound(monkeypatch):
         seq_lens=torch.tensor([123], dtype=torch.int32),
         seq_lens_cpu_upper_bound=seq_lens_cpu_upper_bound,
         dcp_local_seq_lens=None,
+        prefix_anchor_lens=None,
     )
     state.prepare_attn(
         input_batch,
@@ -760,6 +779,148 @@ def test_dflash2_fused_gdn_group_metadata_replay(
     assert single.spec_query_start_loc.tolist() == [0, 8] + [8] * 7
     assert single.num_accepted_tokens is not None
     assert single.num_accepted_tokens.tolist() == [7] + [1] * 7
+
+
+def test_dflash2_fused_gdn_group_metadata_align_replay(
+    monkeypatch,
+    local_gdn_model,
+):
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA is required for the fused GDN metadata kernel")
+    device = torch.device("cuda")
+    if torch.cuda.get_device_capability(device) != (7, 0):
+        pytest.skip("the fused GDN metadata kernel is SM70-only")
+
+    monkeypatch.setenv("VLLM_SM70_QWEN_GDN_SPEC_CORE_OP", "0")
+    monkeypatch.setenv("VLLM_SM70_DFLASH2_FUSED_GDN_METADATA", "1")
+    monkeypatch.setenv("VLLM_SM70_DFLASH2_GDN_METADATA_SHADOW", "1")
+    qwen_gdn.envs.disable_envs_cache()
+
+    builders = [
+        _create_gdn_builder(
+            local_gdn_model,
+            num_speculative_tokens=7,
+            use_full_cuda_graph=True,
+            mamba_cache_mode="align",
+            max_cudagraph_capture_size=16,
+            device=device,
+        )
+        for _ in range(2)
+    ]
+    width = builders[0].num_spec_state_tokens + 1
+    query_start_loc = torch.tensor([0, 8, 16], dtype=torch.int32, device=device)
+    common_metadata = compute_common_gdn_attn_metadata(
+        num_decode_draft_tokens_cpu=torch.tensor([7, 7], dtype=torch.int32),
+        query_start_loc=query_start_loc,
+        query_start_loc_cpu=query_start_loc.cpu(),
+        num_spec_state_tokens=7,
+        legacy_mixed_decode_routing=False,
+    )
+    assert common_metadata is not None
+
+    table_columns = 32
+    block_tables = (
+        torch.arange(
+            10,
+            10 + 2 * table_columns,
+            dtype=torch.int32,
+            device=device,
+        ).view(2, table_columns),
+        torch.arange(
+            100,
+            100 + 2 * table_columns,
+            dtype=torch.int32,
+            device=device,
+        ).view(2, table_columns),
+    )
+    # Batch rows deliberately map to non-adjacent persistent request slots.
+    req_index_mapping = torch.tensor([2, 0], dtype=torch.int32, device=device)
+    state_start_indices = torch.tensor([3, 12, 7, 18], dtype=torch.int32, device=device)
+    accepted = torch.tensor([3, 5], dtype=torch.int32, device=device)
+
+    # Align metadata is incomplete without both persistent-state inputs.
+    assert (
+        prepare_dflash2_gdn_group_metadata(
+            builders_by_group=[(0, builders[0]), (1, builders[1])],
+            block_tables=block_tables,
+            common_gdn_metadata=common_metadata,
+            num_accepted_tokens=accepted,
+            num_actual_tokens=16,
+            descriptor=None,
+            state_start_indices=state_start_indices,
+        )
+        is None
+    )
+
+    first_result = prepare_dflash2_gdn_group_metadata(
+        builders_by_group=[(0, builders[0]), (1, builders[1])],
+        block_tables=block_tables,
+        common_gdn_metadata=common_metadata,
+        num_accepted_tokens=accepted,
+        num_actual_tokens=16,
+        descriptor=None,
+        state_start_indices=state_start_indices,
+        req_index_mapping=req_index_mapping,
+    )
+    assert first_result is not None
+    prepared, descriptor = first_result
+    torch.accelerator.synchronize(device)
+
+    starts = [7, 3]
+    for group_id, builder in enumerate(builders):
+        state = prepared[id(builder)].spec_state_indices_tensor
+        assert state is not None
+        expected = torch.stack(
+            [
+                block_tables[group_id][row, start : start + width]
+                for row, start in enumerate(starts)
+            ]
+        )
+        torch.testing.assert_close(state[:2], expected, rtol=0, atol=0)
+        torch.testing.assert_close(
+            state[2:], torch.full_like(state[2:], PAD_SLOT_ID), rtol=0, atol=0
+        )
+
+    # Replay with the same persistent pointers but a different request mapping
+    # and state columns. CUDA graph replay must observe the live values.
+    for builder in builders:
+        builder.spec_state_indices_tensor.fill_(888)
+    # The model runner allocates this short mapping per batch. Its pointer is
+    # intentionally allowed to change without rebuilding the group descriptor.
+    req_index_mapping = torch.tensor([1, 3], dtype=torch.int32, device=device)
+    state_start_indices.copy_(
+        torch.tensor([2, 9, 5, 20], dtype=torch.int32, device=device)
+    )
+    second_result = prepare_dflash2_gdn_group_metadata(
+        builders_by_group=[(0, builders[0]), (1, builders[1])],
+        block_tables=block_tables,
+        common_gdn_metadata=common_metadata,
+        num_accepted_tokens=accepted,
+        num_actual_tokens=16,
+        descriptor=descriptor,
+        state_start_indices=state_start_indices,
+        req_index_mapping=req_index_mapping,
+    )
+    assert second_result is not None
+    replayed, replay_descriptor = second_result
+    assert replay_descriptor is descriptor
+    assert replayed is prepared
+    torch.accelerator.synchronize(device)
+
+    starts = [9, 20]
+    for group_id, builder in enumerate(builders):
+        state = replayed[id(builder)].spec_state_indices_tensor
+        assert state is not None
+        expected = torch.stack(
+            [
+                block_tables[group_id][row, start : start + width]
+                for row, start in enumerate(starts)
+            ]
+        )
+        torch.testing.assert_close(state[:2], expected, rtol=0, atol=0)
+        torch.testing.assert_close(
+            state[2:], torch.full_like(state[2:], PAD_SLOT_ID), rtol=0, atol=0
+        )
 
 
 def test_full_cuda_graph_capture_single_token_decode_is_not_spec(local_gdn_model):

--- a/tests/v1/spec_decode/test_dflash2.py
+++ b/tests/v1/spec_decode/test_dflash2.py
@@ -127,6 +127,7 @@ def test_sm70_tp4_shards_only_compatible_dflash2_context_projection(monkeypatch)
     assert created["input_size"] == 25600
     assert created["output_size"] == 5120
     assert projection._sm70_f16_force_enable is True
+    assert projection._sm70_f16_max_m == 64
 
 
 @pytest.mark.parametrize(
@@ -917,6 +918,91 @@ def test_dflash_attention_builders_receive_the_draft_model_config(monkeypatch):
     assert config.model_config is draft_model_config
     assert config.attention_config.source is attention_config
     assert config.attention_config.use_non_causal is True
+
+
+@pytest.mark.parametrize(
+    ("mask", "expected"),
+    [
+        (np.array([True], dtype=np.bool_), True),
+        (np.array([True, True], dtype=np.bool_), True),
+        (np.array([True, False], dtype=np.bool_), False),
+        (np.array([False], dtype=np.bool_), False),
+        (None, False),
+    ],
+)
+def test_dflash_context_only_prefill_requires_every_live_request(mask, expected):
+    batch = SimpleNamespace(
+        num_reqs=1 if mask is None else mask.size,
+        is_incomplete_prefilling_np=mask,
+    )
+    assert dflash_speculator._is_context_only_prefill(batch) is expected
+
+
+def test_dflash_intermediate_prefill_materializes_context_without_query(monkeypatch):
+    prepare_inputs = Mock()
+    monkeypatch.setattr(dflash_speculator, "prepare_dflash_inputs", prepare_inputs)
+
+    speculator = DFlashSpeculator.__new__(DFlashSpeculator)
+    speculator.max_model_len = 256
+    speculator.num_query_per_req = 8
+    speculator.num_speculative_steps = 7
+    speculator.max_num_reqs = 1
+    speculator.max_num_tokens = 8
+    speculator.hidden_states = torch.zeros(8, 3)
+    speculator.draft_tokens = torch.zeros(1, 7, dtype=torch.int64)
+    speculator.input_buffers = object()
+    speculator.context_positions = torch.zeros(8, dtype=torch.int64)
+    speculator.sample_indices = torch.zeros(7, dtype=torch.int64)
+    speculator.sample_pos = torch.zeros(7, dtype=torch.int64)
+    speculator.sample_idx_mapping = torch.zeros(7, dtype=torch.int32)
+    speculator.temperature = torch.ones(1)
+    speculator.seeds = torch.zeros(1, dtype=torch.int64)
+    speculator.parallel_drafting_token_id = 0
+    speculator.sample_from_anchor = False
+    speculator.draft_kv_cache_group_id = 0
+    speculator.draft_kv_cache_group_ids = [0]
+    speculator.block_tables = SimpleNamespace(
+        slot_mappings=[torch.zeros(8, dtype=torch.int64)],
+        input_block_tables=[torch.zeros(1, 8, dtype=torch.int32)],
+        kernel_block_sizes=[1],
+        cp_rank=0,
+        cp_size=1,
+        cp_interleave=1,
+    )
+    speculator._context_slot_mappings = torch.zeros(1, 8, dtype=torch.int64)
+    speculator._layer_group_idx = None
+    speculator._context_only_prefill_logged = False
+    speculator.model = SimpleNamespace(
+        precompute_and_store_context_kv=Mock(),
+    )
+
+    input_batch = SimpleNamespace(
+        num_reqs=1,
+        num_tokens=4,
+        seq_lens_cpu_upper_bound=torch.tensor([4], dtype=torch.int32),
+        is_incomplete_prefilling_np=np.array([True], dtype=np.bool_),
+    )
+    output = speculator.propose(
+        input_batch=input_batch,
+        attn_metadata={},
+        slot_mappings={},
+        last_hidden_states=torch.arange(12, dtype=torch.float32).view(4, 3),
+        aux_hidden_states=None,
+        num_sampled=torch.zeros(1, dtype=torch.int32),
+        num_rejected=torch.zeros(1, dtype=torch.int32),
+        last_sampled=torch.zeros(1, dtype=torch.int64),
+        next_prefill_tokens=torch.zeros(1, dtype=torch.int64),
+        temperature=torch.ones(1),
+        seeds=torch.zeros(1, dtype=torch.int64),
+    )
+
+    prepare_inputs.assert_called_once()
+    speculator.model.precompute_and_store_context_kv.assert_called_once()
+    torch.testing.assert_close(
+        speculator.hidden_states[:4],
+        torch.arange(12, dtype=torch.float32).view(4, 3),
+    )
+    assert output.tolist() == [[-1] * 7]
 
 
 def test_noncausal_dflash_capture_binds_paged_prefix_attention(monkeypatch):

--- a/vllm/model_executor/layers/layernorm.py
+++ b/vllm/model_executor/layers/layernorm.py
@@ -86,7 +86,9 @@ def _use_sm70_dflash2_gemma_fused_add_rms(
     return bool(
         envs.VLLM_SM70_DFLASH2_FUSED_GEMMA_RMS
         and envs.VLLM_SM70_FLASH_V100_0DOT3_COMPILE_GRAPH
-        and current_platform.is_device_capability(70)
+        # Keep the cached platform query out of the AOT fullgraph. The helper
+        # below is explicitly constant-foldable by Dynamo.
+        and _sm70_gemma_long_prefill_available()
         and residual is not None
         and x.is_cuda
         and x.dtype == torch.float16

--- a/vllm/model_executor/layers/linear.py
+++ b/vllm/model_executor/layers/linear.py
@@ -64,6 +64,9 @@ def _maybe_sm70_dense_forward(
         return None
     if not hasattr(torch.ops._C, "sm70_f16_gemm"):
         return None
+    max_m = getattr(layer, "_sm70_f16_max_m", None)
+    if max_m is not None and x.numel() // x.shape[-1] > max_m:
+        return None
 
     if envs.VLLM_SM70_F16_DENSE_DEBUG or envs.VLLM_QWEN3_NEXT_SM70_TRACE:
         rows = x.numel() // x.shape[-1]
@@ -1793,14 +1796,10 @@ class RowParallelLinear(LinearBase):
         if output is None:
             output_parallel = _maybe_sm70_dense_forward(self, input_parallel, bias_)
             if output_parallel is None:
-                output_parallel = self.quant_method.apply(
-                    self, input_parallel, bias_
-                )
+                output_parallel = self.quant_method.apply(self, input_parallel, bias_)
 
             if self.reduce_results and self.tp_size > 1:
-                output = _maybe_sm70_awq_mlp_down_tile_all_reduce(
-                    self, output_parallel
-                )
+                output = _maybe_sm70_awq_mlp_down_tile_all_reduce(self, output_parallel)
                 if output is None:
                     output = tensor_model_parallel_all_reduce(output_parallel)
             else:

--- a/vllm/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py
+++ b/vllm/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py
@@ -503,11 +503,19 @@ def _sm70_dump_gdn_core_tensor(
     tensor: torch.Tensor,
     source: str = "core",
 ) -> None:
-    _sm70_gdn_graph_buffer_copy(label, layer_name, tensor, source)
-    if torch.cuda.is_current_stream_capturing():
-        return
     dump_dir = os.getenv("VLLM_SM70_DUMP_GDN_CORE_DIR")
-    if not dump_dir:
+    graph_dump = os.getenv("VLLM_SM70_DUMP_GDN_GRAPH_BUFFERS") == "1" and bool(
+        os.getenv("VLLM_SM70_DUMP_GDN_GRAPH_DIR")
+    )
+    # Keep the production path free of CUDA runtime queries. This hook runs
+    # several times per GDN layer, while core dumps are normally disabled.
+    if not dump_dir and not graph_dump:
+        return
+    if graph_dump:
+        _sm70_gdn_graph_buffer_copy(label, layer_name, tensor, source)
+    if not dump_dir or not tensor.is_cuda:
+        return
+    if torch.cuda.is_current_stream_capturing():
         return
     raw_layer_ids = os.getenv("VLLM_SM70_DUMP_GDN_CORE_LAYER_IDS")
     if raw_layer_ids:

--- a/vllm/model_executor/models/qwen3_dflash2.py
+++ b/vllm/model_executor/models/qwen3_dflash2.py
@@ -362,6 +362,10 @@ class DFlash2Qwen3Model(DFlashQwen3Model):
             return_bias=False,
         )
         projection._sm70_f16_force_enable = True
+        # TurboMind wins at the 8-row decode shape, while cuBLAS is faster for
+        # 128+ context rows. Keep the exact small-M path and let ordinary
+        # F.linear handle chunked-prefill projection shapes.
+        projection._sm70_f16_max_m = 64
         logger.info_once(
             "Using TP4 output-sharded DFlash2 target-hidden projection on SM70 "
             "(25600->5120 plus compact all-gather)."

--- a/vllm/v1/attention/backends/gdn_attn.py
+++ b/vllm/v1/attention/backends/gdn_attn.py
@@ -176,6 +176,8 @@ def _dflash2_gdn_group_metadata_kernel(
     block_table_ptrs,
     state_output_ptrs,
     block_table_strides,
+    state_start_indices,
+    req_index_mapping,
     spec_query_start_loc_src,
     num_accepted_src,
     state_selector_src,
@@ -188,6 +190,7 @@ def _dflash2_gdn_group_metadata_kernel(
     WIDTH: tl.constexpr,
     PAD_ID: tl.constexpr,
     BLOCK: tl.constexpr,
+    USE_STATE_START: tl.constexpr,
 ):
     """Write every GDN group's state IDs and the shared graph metadata."""
     group_id = tl.program_id(0)
@@ -200,8 +203,23 @@ def _dflash2_gdn_group_metadata_kernel(
     columns = offsets % WIDTH
     output_mask = offsets < batch_size * WIDTH
     live_state_mask = output_mask & (rows < num_spec_decodes)
+    state_columns = columns
+    if USE_STATE_START:
+        req_indices = tl.load(
+            req_index_mapping + rows,
+            mask=live_state_mask,
+            other=0,
+        )
+        live_state_mask &= req_indices >= 0
+        state_starts = tl.load(
+            state_start_indices + req_indices,
+            mask=live_state_mask,
+            other=-1,
+        )
+        state_columns = columns + state_starts
+        live_state_mask &= (state_starts >= 0) & (state_columns < block_table_stride)
     state_ids = tl.load(
-        block_table + rows * block_table_stride + columns,
+        block_table + rows * block_table_stride + state_columns,
         mask=live_state_mask,
         other=PAD_ID,
     )
@@ -2168,6 +2186,8 @@ def prepare_dflash2_gdn_group_metadata(
     num_accepted_tokens: torch.Tensor,
     num_actual_tokens: int,
     descriptor: DFlash2GDNGroupDescriptor | None,
+    state_start_indices: torch.Tensor | None = None,
+    req_index_mapping: torch.Tensor | None = None,
 ) -> (
     tuple[
         dict[int, GDNAttentionMetadata],
@@ -2177,12 +2197,12 @@ def prepare_dflash2_gdn_group_metadata(
 ):
     """Prepare all pure-MRV2 DFlash2 GDN graph metadata in one launch.
 
-    The current production target uses ``mamba_cache_mode=none``. Its legacy
-    contract compacts the live speculative rows from every group's block table,
-    then copies them into graph-stable buffers. DFlash2 batches keep those rows
-    at the front and CUDA-graph padding at the back, so the pointer-table kernel
-    can perform the identical copy and tail fill without ten independent
-    advanced-indexing pipelines.
+    ``mamba_cache_mode=none`` reads the first speculative state columns.
+    ``mamba_cache_mode=align`` supplies the authoritative, post-precopy state
+    column for each live request. DFlash2 batches keep live speculative rows at
+    the front and CUDA-graph padding at the back, so one pointer-table kernel can
+    perform the same state selection and tail fill without ten independent
+    gather/copy pipelines.
     """
     if not envs.VLLM_SM70_DFLASH2_FUSED_GDN_METADATA:
         return None
@@ -2193,6 +2213,22 @@ def prepare_dflash2_gdn_group_metadata(
     if num_accepted_tokens.dtype != torch.int32 or num_accepted_tokens.ndim != 1:
         return None
 
+    use_state_start = state_start_indices is not None
+    if use_state_start != (req_index_mapping is not None):
+        return None
+    if use_state_start:
+        assert state_start_indices is not None
+        assert req_index_mapping is not None
+        if (
+            state_start_indices.device != num_accepted_tokens.device
+            or state_start_indices.dtype != torch.int32
+            or state_start_indices.ndim != 1
+            or req_index_mapping.device != num_accepted_tokens.device
+            or req_index_mapping.dtype != torch.int32
+            or req_index_mapping.ndim != 1
+        ):
+            return None
+
     spec_mask_cpu = common_gdn_metadata.spec_sequence_masks_cpu
     num_spec_decodes = common_gdn_metadata.num_spec_decodes
     if (
@@ -2202,6 +2238,10 @@ def prepare_dflash2_gdn_group_metadata(
         or num_spec_decodes > num_actual_tokens
         or num_spec_decodes > spec_mask_cpu.numel()
         or common_gdn_metadata.num_spec_decode_tokens > num_actual_tokens
+        or (
+            req_index_mapping is not None
+            and req_index_mapping.numel() < num_spec_decodes
+        )
     ):
         return None
     if not bool(torch.all(spec_mask_cpu[:num_spec_decodes]).item()):
@@ -2221,6 +2261,11 @@ def prepare_dflash2_gdn_group_metadata(
         return None
 
     first_builder = builders_by_group[0][1]
+    mamba_cache_mode = first_builder.vllm_config.cache_config.mamba_cache_mode
+    if mamba_cache_mode not in ("none", "align"):
+        return None
+    if use_state_start != (mamba_cache_mode == "align"):
+        return None
     width = first_builder.num_spec_state_tokens + 1
     common_buffers = first_builder._ddtree_fast_common_buffers
     if common_buffers is None:
@@ -2245,7 +2290,7 @@ def prepare_dflash2_gdn_group_metadata(
         if (
             builder.num_spec_state_tokens + 1 != width
             or not builder.use_full_cuda_graph
-            or builder.vllm_config.cache_config.mamba_cache_mode != "none"
+            or builder.vllm_config.cache_config.mamba_cache_mode != mamba_cache_mode
             or builder.decode_cudagraph_max_bs < num_actual_tokens
             or builder._ddtree_fast_common_buffers is not common_buffers
             or group_id < 0
@@ -2295,6 +2340,7 @@ def prepare_dflash2_gdn_group_metadata(
         tuple(table.data_ptr() for table in input_tables),
         tuple(state.data_ptr() for state in output_states),
         tuple(table.stride(0) for table in input_tables),
+        use_state_start,
         common_buffers.spec_sequence_masks.data_ptr(),
         common_buffers.spec_token_indx.data_ptr(),
         common_buffers.non_spec_token_indx.data_ptr(),
@@ -2329,6 +2375,8 @@ def prepare_dflash2_gdn_group_metadata(
         descriptor.block_table_ptrs,
         descriptor.state_output_ptrs,
         descriptor.block_table_strides,
+        num_accepted_tokens if state_start_indices is None else state_start_indices,
+        num_accepted_tokens if req_index_mapping is None else req_index_mapping,
         query_start_loc,
         num_accepted_tokens,
         num_accepted_tokens,
@@ -2341,6 +2389,7 @@ def prepare_dflash2_gdn_group_metadata(
         WIDTH=width,
         PAD_ID=PAD_SLOT_ID,
         BLOCK=block,
+        USE_STATE_START=use_state_start,
         num_warps=1,
     )
     common_buffers.initialized_key = (
@@ -2404,7 +2453,20 @@ def prepare_dflash2_gdn_group_metadata(
             actual = prepared[id(builder)]
             actual_state = actual.spec_state_indices_tensor
             assert actual_state is not None
-            expected_state = block_tables[group_id][spec_mask, :width]
+            source_table = block_tables[group_id][spec_mask]
+            if use_state_start:
+                assert state_start_indices is not None
+                assert req_index_mapping is not None
+                req_indices = req_index_mapping[:num_spec_decodes].to(torch.long)
+                starts = state_start_indices[req_indices].to(torch.long)
+                columns = starts[:, None] + torch.arange(
+                    width,
+                    dtype=torch.long,
+                    device=source_table.device,
+                )
+                expected_state = torch.gather(source_table, 1, columns)
+            else:
+                expected_state = source_table[:, :width]
             torch.testing.assert_close(
                 actual_state[:num_spec_decodes],
                 expected_state,

--- a/vllm/v1/worker/gpu/input_batch.py
+++ b/vllm/v1/worker/gpu/input_batch.py
@@ -87,6 +87,10 @@ class InputBatch:
     # [num_reqs_after_padding] per-request prompt length for prefix-anchored
     # sliding-window attention (optional).
     prefix_anchor_lens: torch.Tensor | None = None
+    # CPU mask for requests whose scheduled chunk does not finish prefill.
+    # Model-specific runners may use this to omit work whose outputs cannot be
+    # consumed until a later chunk. None is equivalent to all False.
+    is_incomplete_prefilling_np: np.ndarray | None = None
 
     @classmethod
     def make_dummy(

--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -875,6 +875,13 @@ class GPUModelRunner(LoRAModelRunnerMixin):
         query_start_loc_np = query_start_loc_np[: num_reqs_padded + 1]
         query_start_loc = self.input_buffers.query_start_loc[: num_reqs_padded + 1]
         is_prefilling_np = self.req_states.is_prefilling(idx_mapping_np)
+        computed_prefill_lens = self.req_states.num_computed_prefill_tokens[
+            idx_mapping_np
+        ]
+        prefill_lens = self.req_states.prefill_len.np[idx_mapping_np]
+        is_incomplete_prefilling_np = is_prefilling_np & (
+            computed_prefill_lens + num_scheduled_tokens < prefill_lens
+        )
 
         # Get prefill tokens if any.
         if np.any(is_prefilling_np):
@@ -969,6 +976,7 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             cu_num_logits_np=cu_num_logits_np,
             has_structured_output_reqs=scheduler_output.has_structured_output_requests,
             prefix_anchor_lens=prefix_anchor_lens,
+            is_incomplete_prefilling_np=is_incomplete_prefilling_np,
         )
 
     def prepare_attn(

--- a/vllm/v1/worker/gpu/model_states/mamba_hybrid.py
+++ b/vllm/v1/worker/gpu/model_states/mamba_hybrid.py
@@ -134,7 +134,7 @@ class MambaHybridModelState(DefaultModelState):
         self._use_dflash2_fused_gdn_metadata = bool(
             self._use_dflash2_common_gdn_metadata
             and envs.VLLM_SM70_DFLASH2_FUSED_GDN_METADATA
-            and self.cache_config.mamba_cache_mode == "none"
+            and self.cache_config.mamba_cache_mode in ("none", "align")
             and device.type == "cuda"
             and current_platform.is_device_capability(70)
         )
@@ -380,6 +380,12 @@ class MambaHybridModelState(DefaultModelState):
                     num_accepted_tokens=num_accepted_tokens,
                     num_actual_tokens=num_tokens,
                     descriptor=self._dflash2_gdn_group_descriptor,
+                    state_start_indices=(
+                        self._mamba_state_idx_gpu if self._align_mode else None
+                    ),
+                    req_index_mapping=(
+                        input_batch.idx_mapping if self._align_mode else None
+                    ),
                 )
                 if prepared_result is not None:
                     (

--- a/vllm/v1/worker/gpu/spec_decode/dflash/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/dflash/speculator.py
@@ -15,6 +15,7 @@ from vllm.triton_utils import tl, triton
 from vllm.v1.attention.backend import AttentionCGSupport
 from vllm.v1.attention.backends.utils import PAD_SLOT_ID
 from vllm.v1.kv_cache_interface import KVCacheConfig
+from vllm.v1.utils import record_function_or_nullcontext
 from vllm.v1.worker.gpu.attn_utils import build_slot_mappings_by_layer
 from vllm.v1.worker.gpu.block_table import BlockTables
 from vllm.v1.worker.gpu.cp_utils import cp_local_slot, prepare_dcp_local_seq_lens
@@ -28,6 +29,15 @@ from vllm.v1.worker.gpu.spec_decode.utils import get_parallel_drafting_token_id
 from vllm.v1.worker.utils import AttentionGroup
 
 logger = init_logger(__name__)
+
+
+def _is_context_only_prefill(input_batch: InputBatch) -> bool:
+    incomplete_prefill = input_batch.is_incomplete_prefilling_np
+    return bool(
+        incomplete_prefill is not None
+        and incomplete_prefill.size == input_batch.num_reqs
+        and np.all(incomplete_prefill)
+    )
 
 
 class DFlashSpeculator(DraftModelSpeculator):
@@ -99,6 +109,7 @@ class DFlashSpeculator(DraftModelSpeculator):
 
         self.query_cudagraph_manager: DFlashCudaGraphManager | None = None
         self.draft_kv_cache_group_id: int = -1
+        self._context_only_prefill_logged = False
 
     @property
     def attn_vllm_config(self) -> VllmConfig:
@@ -355,12 +366,16 @@ class DFlashSpeculator(DraftModelSpeculator):
         # hidden_states the same as the target model's. This means, we pad each
         # request's query length to include any rejected positions.
         if aux_hidden_states:
-            hidden_states = self.model.combine_hidden_states(
-                torch.cat(aux_hidden_states, dim=-1)
-            )
+            with record_function_or_nullcontext("dflash: concatenate target hidden"):
+                combined_target_hidden = torch.cat(aux_hidden_states, dim=-1)
+            with record_function_or_nullcontext("dflash: project target hidden"):
+                hidden_states = self.model.combine_hidden_states(combined_target_hidden)
         else:
             hidden_states = last_hidden_states
-        self.hidden_states[:num_target_tokens].copy_(hidden_states[:num_target_tokens])
+        with record_function_or_nullcontext("dflash: stage target hidden"):
+            self.hidden_states[:num_target_tokens].copy_(
+                hidden_states[:num_target_tokens]
+            )
 
         if dummy_run and skip_attn_for_dummy_run:
             # Memory profiling path: block_tables / kv_cache_config are not initialized.
@@ -384,37 +399,38 @@ class DFlashSpeculator(DraftModelSpeculator):
         # That buffer's address is what the captured CUDA graph reads from at replay.
         assert self.draft_kv_cache_group_id >= 0
         # Support multiple draft KV cache groups by preparing inputs once for each
-        for i, gid in enumerate(self.draft_kv_cache_group_ids):
-            prepare_dflash_inputs(
-                self.input_buffers,
-                self.block_tables.slot_mappings[gid],
-                self.context_positions,
-                self._context_slot_mappings[i],
-                self.sample_indices,
-                self.sample_pos,
-                self.sample_idx_mapping,
-                self.temperature,
-                self.seeds,
-                input_batch,
-                num_sampled,
-                num_rejected,
-                last_sampled,
-                next_prefill_tokens,
-                temperature,
-                seeds,
-                self.block_tables.input_block_tables[gid],
-                self.block_tables.kernel_block_sizes[gid],
-                self.block_tables.cp_rank,
-                self.block_tables.cp_size,
-                self.block_tables.cp_interleave,
-                self.parallel_drafting_token_id,
-                self.num_query_per_req,
-                self.num_speculative_steps,
-                self.max_num_reqs,
-                self.max_num_tokens,
-                self.max_model_len,
-                self.sample_from_anchor,
-            )
+        with record_function_or_nullcontext("dflash: prepare inputs"):
+            for i, gid in enumerate(self.draft_kv_cache_group_ids):
+                prepare_dflash_inputs(
+                    self.input_buffers,
+                    self.block_tables.slot_mappings[gid],
+                    self.context_positions,
+                    self._context_slot_mappings[i],
+                    self.sample_indices,
+                    self.sample_pos,
+                    self.sample_idx_mapping,
+                    self.temperature,
+                    self.seeds,
+                    input_batch,
+                    num_sampled,
+                    num_rejected,
+                    last_sampled,
+                    next_prefill_tokens,
+                    temperature,
+                    seeds,
+                    self.block_tables.input_block_tables[gid],
+                    self.block_tables.kernel_block_sizes[gid],
+                    self.block_tables.cp_rank,
+                    self.block_tables.cp_size,
+                    self.block_tables.cp_interleave,
+                    self.parallel_drafting_token_id,
+                    self.num_query_per_req,
+                    self.num_speculative_steps,
+                    self.max_num_reqs,
+                    self.max_num_tokens,
+                    self.max_model_len,
+                    self.sample_from_anchor,
+                )
 
         # Pre-insert context K/V into the cache. Runs eagerly outside the captured graph
         # because the context shape varies per step. During dummy runs the block tables
@@ -429,53 +445,71 @@ class DFlashSpeculator(DraftModelSpeculator):
             ]
         else:
             context_slots = self._context_slot_mappings[0][:num_target_tokens]
-        self.model.precompute_and_store_context_kv(
-            self.hidden_states[:num_target_tokens],
-            self.context_positions[:num_target_tokens],
-            context_slots,
-        )
-
-        # Every DFlash step has exactly num_query_per_req tokens, so we can use FULL CGs
-        batch_desc, num_tokens_across_dp = dispatch_cg_and_sync_dp(
-            self.query_cudagraph_manager,
-            num_reqs,
-            num_query_tokens,
-            uniform_token_count=self.num_query_per_req,
-            dp_size=self.dp_size,
-            dp_rank=self.dp_rank,
-            need_eager=is_profile,
-        )
-
-        num_reqs_padded = batch_desc.num_reqs or num_reqs
-        num_tokens_padded = batch_desc.num_tokens
-
-        # Rebuild the draft attention metadata even when replaying the FULL
-        # graph so that any attention metadata builder state is updated.
-        draft_attn_metadata = self._build_draft_attn_metadata(
-            num_reqs=num_reqs,
-            num_reqs_padded=num_reqs_padded,
-            num_tokens_padded=num_tokens_padded,
-            seq_lens_cpu_upper_bound=input_batch.seq_lens_cpu_upper_bound,
-            step=self.num_query_per_req,
-            causal=self._group_causal,
-        )
-        draft_slot_mappings_by_layer = build_slot_mappings_by_layer(
-            self.block_tables.slot_mappings[:, :num_tokens_padded],
-            self.kv_cache_config,
-        )
-
-        if batch_desc.cg_mode == CUDAGraphMode.FULL:
-            assert self.query_cudagraph_manager is not None
-            self.query_cudagraph_manager.run_fullgraph(batch_desc)
-        else:
-            self._generate_draft(
-                num_reqs,
-                num_tokens_padded,
-                draft_attn_metadata,
-                draft_slot_mappings_by_layer,
-                num_tokens_across_dp=num_tokens_across_dp,
-                cudagraph_runtime_mode=batch_desc.cg_mode,
+        with record_function_or_nullcontext("dflash: materialize context kv"):
+            self.model.precompute_and_store_context_kv(
+                self.hidden_states[:num_target_tokens],
+                self.context_positions[:num_target_tokens],
+                context_slots,
             )
+
+        if not dummy_run and _is_context_only_prefill(input_batch):
+            # Intermediate chunked-prefill steps only need to materialize the
+            # target hidden states into draft KV. Their proposed tokens cannot
+            # be consumed before the final prompt chunk, which will run the
+            # normal query graph and replace this sentinel output.
+            self.draft_tokens[:num_reqs].fill_(-1)
+            if not self._context_only_prefill_logged:
+                logger.info(
+                    "%s context-only path is skipping unused draft queries "
+                    "for intermediate prefill chunks.",
+                    self._speculator_name,
+                )
+                self._context_only_prefill_logged = True
+            return self.draft_tokens[:num_reqs]
+
+        with record_function_or_nullcontext("dflash: query and selector"):
+            # Every DFlash step has exactly num_query_per_req tokens, so we can
+            # use FULL CUDA graphs.
+            batch_desc, num_tokens_across_dp = dispatch_cg_and_sync_dp(
+                self.query_cudagraph_manager,
+                num_reqs,
+                num_query_tokens,
+                uniform_token_count=self.num_query_per_req,
+                dp_size=self.dp_size,
+                dp_rank=self.dp_rank,
+                need_eager=is_profile,
+            )
+
+            num_reqs_padded = batch_desc.num_reqs or num_reqs
+            num_tokens_padded = batch_desc.num_tokens
+
+            # Rebuild the draft attention metadata even when replaying the FULL
+            # graph so that any attention metadata builder state is updated.
+            draft_attn_metadata = self._build_draft_attn_metadata(
+                num_reqs=num_reqs,
+                num_reqs_padded=num_reqs_padded,
+                num_tokens_padded=num_tokens_padded,
+                seq_lens_cpu_upper_bound=input_batch.seq_lens_cpu_upper_bound,
+                step=self.num_query_per_req,
+                causal=self._group_causal,
+            )
+            draft_slot_mappings_by_layer = build_slot_mappings_by_layer(
+                self.block_tables.slot_mappings[:, :num_tokens_padded],
+                self.kv_cache_config,
+            )
+
+            if batch_desc.cg_mode == CUDAGraphMode.FULL:
+                assert self.query_cudagraph_manager is not None
+                self.query_cudagraph_manager.run_fullgraph(batch_desc)
+            else:
+                self._generate_draft(
+                    num_reqs,
+                    num_tokens_padded,
+                    draft_attn_metadata,
+                    draft_slot_mappings_by_layer,
+                    num_tokens_across_dp=num_tokens_across_dp,
+                    cudagraph_runtime_mode=batch_desc.cg_mode,
+                )
 
         return self.draft_tokens[:num_reqs]
 


### PR DESCRIPTION
## Purpose

Restore the post-#284 DFlash2 practical-config performance closure that remained only in the measured production worktree. This covers the align-mode fused GDN metadata hot path, disabled-debug zero-overhead gate, fullgraph-safe SM70 predicate, and chunked-prefill context-only work elimination.

## Test Plan

- Focused pre-commit and mypy
- DFlash2 and GDN metadata unit suites
- V100 align metadata and AOT fullgraph tests
- Same-build TP4 practical API: FP8 E5M2 KV, 256K max context, max batched tokens 4096, prefix cache, Mamba align, CUDA Graph, tool/reasoning parsers
- Historical high-acceptance single-request speed and EvalPlus quality gate
- Fresh 32K chunked-prefill cold/hit smoke

## Test Result

- Focused pre-commit and mypy passed.
- CPU: 110 passed, 32 expected CUDA skips.
- V100 focused: 2 passed.
- Startup route proof: QPN8 exact rerank, TP4 sharded context projection, one-pass grouped verifier, target/draft CUDA Graph, and fused GDN metadata for all 10 cache groups.
- Four 512-token single-request runs: 18.465--18.537 ms per complete round; 133.05--146.63 tok/s.
- Three 1,024-token practical coding runs: 18.587--18.603 ms; 132.62--139.93 tok/s.
- Historical MBPP item 28: 251.60 tok/s, 18.567 ms, acceptance length 4.686, 328-token natural EOS.
- Quality: generated text SHA256 exactly matches the previous production result; EvalPlus base 1/1 and plus 1/1.
- Fresh 32K chunked prefill: 10.58--10.65 s cold; 1.405 s prefix hit; context-only route logged.

The first 128-token request triggered expected runtime JIT and is explicitly excluded from steady-state timing. GitHub all-repository pre-commit still reports unrelated pre-existing global formatting/lint debt; every changed file passes the focused hooks.