### PR TITLE
[Bench][SM70] Add DFlash2 selector alignment diagnostics

### DIFF
--- a/benchmarks/analyze_dflash2_selector_alignment.py
+++ b/benchmarks/analyze_dflash2_selector_alignment.py
@@ -29,6 +29,7 @@ class ProposalConfig:
     unary_scale: float = 1.0
     edge_scale: float = 1.0
     future_beta: float = 0.0
+    greedy_mix: float = 0.0
     use_cached_logits: bool = False
 
 
@@ -129,20 +130,30 @@ def _proposal_probs(
     config: ProposalConfig,
 ) -> list[torch.Tensor]:
     if config.use_cached_logits:
-        return [
+        rows = [
             _compact_probs(row, config.proposal_top_p) for row in record.realized_logits
         ]
-
-    lattice = _transformed_lattice(record, config)
-    future = _backward_messages(lattice)
-    predecessors = _path_predecessors(record)
-    return [
-        _compact_probs(
-            lattice[step, predecessor] + config.future_beta * future[step],
-            config.proposal_top_p,
-        )
-        for step, predecessor in enumerate(predecessors)
-    ]
+    else:
+        lattice = _transformed_lattice(record, config)
+        future = _backward_messages(lattice)
+        predecessors = _path_predecessors(record)
+        rows = [
+            _compact_probs(
+                lattice[step, predecessor] + config.future_beta * future[step],
+                config.proposal_top_p,
+            )
+            for step, predecessor in enumerate(predecessors)
+        ]
+    if config.greedy_mix == 0.0:
+        return rows
+    if not 0.0 <= config.greedy_mix <= 1.0:
+        raise ValueError("greedy_mix must be in [0, 1]")
+    mixed_rows = []
+    for probs in rows:
+        mixed = probs * (1.0 - config.greedy_mix)
+        mixed[torch.argmax(probs)] += config.greedy_mix
+        mixed_rows.append(mixed)
+    return mixed_rows
 
 
 def _target_rows(record: AlignmentRecord) -> list[torch.Tensor]:
@@ -218,7 +229,7 @@ def _evaluate(records: list[AlignmentRecord], config: ProposalConfig) -> dict[st
 
 def _sweep_configs() -> list[ProposalConfig]:
     configs = [ProposalConfig(name="current", use_cached_logits=True)]
-    seen: set[tuple[float, float, float, float, float]] = set()
+    seen: set[tuple[float, float, float, float, float, float]] = set()
 
     def add(
         family: str,
@@ -227,8 +238,9 @@ def _sweep_configs() -> list[ProposalConfig]:
         unary: float = 1.0,
         edge: float = 1.0,
         beta: float = 0.0,
+        greedy_mix: float = 0.0,
     ) -> None:
-        key = (temperature, top_p, unary, edge, beta)
+        key = (temperature, top_p, unary, edge, beta, greedy_mix)
         if key in seen:
             return
         seen.add(key)
@@ -236,13 +248,14 @@ def _sweep_configs() -> list[ProposalConfig]:
             ProposalConfig(
                 name=(
                     f"{family}:t={temperature:g},p={top_p:g},u={unary:g},"
-                    f"e={edge:g},b={beta:g}"
+                    f"e={edge:g},b={beta:g},g={greedy_mix:g}"
                 ),
                 proposal_temperature_scale=temperature,
                 proposal_top_p=top_p,
                 unary_scale=unary,
                 edge_scale=edge,
                 future_beta=beta,
+                greedy_mix=greedy_mix,
             )
         )
 
@@ -251,6 +264,13 @@ def _sweep_configs() -> list[ProposalConfig]:
     for top_p in (0.9, 0.95, 0.98, 0.99):
         for temperature in (0.8, 0.9, 1.0):
             add("nucleus", temperature=temperature, top_p=top_p)
+    for greedy_mix in (0.1, 0.2, 0.3, 0.4, 0.5):
+        for temperature in (0.8, 0.9, 1.0, 1.1):
+            add(
+                "greedy-mixture",
+                temperature=temperature,
+                greedy_mix=greedy_mix,
+            )
     for unary in (0.75, 1.0, 1.25):
         for edge in (0.5, 0.75, 1.0, 1.25, 1.5):
             for temperature in (0.85, 1.0, 1.15):

--- a/benchmarks/analyze_dflash2_selector_alignment.py
+++ b/benchmarks/analyze_dflash2_selector_alignment.py
@@ -323,6 +323,27 @@ def summarize(pattern: str, top_n: int) -> dict[str, Any]:
     }
     current_tune = tune_results[0]["completion_length_proxy"]
     current_holdout = holdout_by_name["current"]["completion_length_proxy"]
+    position_policy = []
+    position_tune_overlaps = []
+    position_holdout_overlaps = []
+    for position in range(records[0].candidate_ids.shape[0]):
+        best = max(
+            tune_results,
+            key=lambda result: result["mean_overlap_by_position"][position],
+        )
+        holdout_best = holdout_by_name[best["config"]["name"]]
+        position_policy.append(
+            {
+                "position": position,
+                "config": best["config"],
+                "tune_overlap": best["mean_overlap_by_position"][position],
+                "holdout_overlap": holdout_best["mean_overlap_by_position"][position],
+            }
+        )
+        position_tune_overlaps.append(best["mean_overlap_by_position"][position])
+        position_holdout_overlaps.append(
+            holdout_best["mean_overlap_by_position"][position]
+        )
     ranked = sorted(
         tune_results[1:],
         key=lambda result: result["completion_length_proxy"],
@@ -364,6 +385,18 @@ def summarize(pattern: str, top_n: int) -> dict[str, Any]:
             "tune": tune_results[0],
             "holdout": holdout_by_name["current"],
         },
+        "position_policy": {
+            "selection": "best tune overlap independently at each depth",
+            "rows": position_policy,
+            "tune_completion_length_proxy": _completion_proxy(position_tune_overlaps),
+            "tune_delta": (_completion_proxy(position_tune_overlaps) - current_tune),
+            "holdout_completion_length_proxy": _completion_proxy(
+                position_holdout_overlaps
+            ),
+            "holdout_delta": (
+                _completion_proxy(position_holdout_overlaps) - current_holdout
+            ),
+        },
         "leaders": leaders,
     }
 
@@ -372,6 +405,7 @@ def render_markdown(summary: dict[str, Any]) -> str:
     contract = summary["contract"]
     baseline = summary["baseline"]
     current = summary["current"]
+    position_policy = summary["position_policy"]
     lines = [
         "# DFlash2 Selector Alignment Sweep",
         "",
@@ -401,6 +435,11 @@ def render_markdown(summary: dict[str, Any]) -> str:
             "- Cached/lattice max absolute mismatch: "
             f"`{baseline['cached_vs_lattice_max_abs']:.3e}`"
         ),
+        (
+            "- Position-wise held-out proxy/delta: "
+            f"`{position_policy['holdout_completion_length_proxy']:.4f}` / "
+            f"`{position_policy['holdout_delta']:+.4f}`"
+        ),
         "",
         "| candidate | tune proxy | tune delta | holdout proxy | holdout delta |",
         "| --- | ---: | ---: | ---: | ---: |",
@@ -412,6 +451,20 @@ def render_markdown(summary: dict[str, Any]) -> str:
             f"{row['tune_delta']:+.4f} | "
             f"{row['holdout_completion_length_proxy']:.4f} | "
             f"{row['holdout_delta']:+.4f} |"
+        )
+    lines.extend(
+        [
+            "",
+            "## Position-wise calibration policy",
+            "",
+            "| position | tune overlap | holdout overlap | configuration |",
+            "| ---: | ---: | ---: | --- |",
+        ]
+    )
+    for row in position_policy["rows"]:
+        lines.append(
+            f"| {row['position']} | {row['tune_overlap']:.4f} | "
+            f"{row['holdout_overlap']:.4f} | `{row['config']['name']}` |"
         )
     lines.append("")
     return "\n".join(lines)

--- a/benchmarks/analyze_dflash2_selector_alignment.py
+++ b/benchmarks/analyze_dflash2_selector_alignment.py
@@ -1,0 +1,444 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Audit and sweep exact DFlash2 selector proposals from alignment dumps.
+
+This tool consumes the B1 records emitted by the GPU-runner compact rejection
+path when ``VLLM_SPEC_DUMP_ALIGNMENT=1``. It never changes target sampling.
+Counterfactual results are one-step overlap proxies on the recorded prefixes;
+only an end-to-end run can establish a new acceptance-length result.
+"""
+
+from __future__ import annotations
+
+import argparse
+import glob
+import json
+import math
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+import torch
+
+
+@dataclass(frozen=True)
+class ProposalConfig:
+    name: str
+    proposal_temperature_scale: float = 1.0
+    proposal_top_p: float = 1.0
+    unary_scale: float = 1.0
+    edge_scale: float = 1.0
+    future_beta: float = 0.0
+    use_cached_logits: bool = False
+
+
+@dataclass
+class AlignmentRecord:
+    path: Path
+    step: int
+    temperature: float
+    top_p: float
+    target_topk_ids: torch.Tensor
+    target_topk_logits: torch.Tensor
+    candidate_ids: torch.Tensor
+    realized_logits: torch.Tensor
+    unary_logits: torch.Tensor
+    lattice_scores: torch.Tensor
+    draft_sampled: torch.Tensor
+    num_sampled: int
+
+
+def _compact_probs(logits: torch.Tensor, top_p: float) -> torch.Tensor:
+    """Apply the compact top-p contract used by the sparse rejection kernel."""
+    logits = logits.to(torch.float64)
+    order = torch.argsort(logits, descending=True, stable=True)
+    sorted_probs = torch.softmax(logits[order], dim=-1)
+    cumulative_before = torch.cumsum(sorted_probs, dim=-1) - sorted_probs
+    keep_sorted = (top_p >= 1.0) | (cumulative_before < top_p)
+    kept = torch.zeros_like(sorted_probs)
+    kept[keep_sorted] = sorted_probs[keep_sorted]
+    kept /= kept.sum()
+    probs = torch.zeros_like(kept)
+    probs[order] = kept
+    return probs
+
+
+def _distribution_overlap(
+    target_ids: torch.Tensor,
+    target_probs: torch.Tensor,
+    proposal_ids: torch.Tensor,
+    proposal_probs: torch.Tensor,
+) -> float:
+    matches = target_ids[:, None] == proposal_ids[None, :]
+    proposal_on_target = torch.where(
+        matches,
+        proposal_probs[None, :],
+        torch.zeros((), dtype=proposal_probs.dtype),
+    ).sum(dim=1)
+    return float(torch.minimum(target_probs, proposal_on_target).sum())
+
+
+def _support_mass(
+    target_ids: torch.Tensor,
+    target_probs: torch.Tensor,
+    proposal_ids: torch.Tensor,
+) -> float:
+    supported = (target_ids[:, None] == proposal_ids[None, :]).any(dim=1)
+    return float(target_probs[supported].sum())
+
+
+def _transformed_lattice(
+    record: AlignmentRecord, config: ProposalConfig
+) -> torch.Tensor:
+    unary = record.unary_logits[:, None, :].to(torch.float64)
+    lattice = record.lattice_scores.to(torch.float64)
+    edge = lattice - unary
+    denominator = record.temperature * config.proposal_temperature_scale
+    return (config.unary_scale * unary + config.edge_scale * edge) / denominator
+
+
+def _backward_messages(lattice: torch.Tensor) -> torch.Tensor:
+    """Compute normalized log-sum-exp future messages for a KxK chain."""
+    num_steps, top_k, _ = lattice.shape
+    future = torch.zeros((num_steps, top_k), dtype=lattice.dtype)
+    for step in range(num_steps - 2, -1, -1):
+        values = lattice[step + 1] + future[step + 1][None, :]
+        future[step] = torch.logsumexp(values, dim=-1)
+        future[step] -= future[step].max()
+    return future
+
+
+def _path_predecessors(record: AlignmentRecord) -> list[int]:
+    num_steps = record.candidate_ids.shape[0]
+    if record.draft_sampled.numel() < num_steps + 1:
+        raise ValueError(f"{record.path}: draft_sampled is missing the anchor row")
+    predecessors = [0]
+    for step in range(num_steps - 1):
+        proposed = int(record.draft_sampled[step + 1])
+        matches = torch.nonzero(record.candidate_ids[step] == proposed).flatten()
+        if matches.numel() != 1:
+            raise ValueError(
+                f"{record.path}: proposed token {proposed} is not unique at step {step}"
+            )
+        predecessors.append(int(matches[0]))
+    return predecessors
+
+
+def _proposal_probs(
+    record: AlignmentRecord,
+    config: ProposalConfig,
+) -> list[torch.Tensor]:
+    if config.use_cached_logits:
+        return [
+            _compact_probs(row, config.proposal_top_p) for row in record.realized_logits
+        ]
+
+    lattice = _transformed_lattice(record, config)
+    future = _backward_messages(lattice)
+    predecessors = _path_predecessors(record)
+    return [
+        _compact_probs(
+            lattice[step, predecessor] + config.future_beta * future[step],
+            config.proposal_top_p,
+        )
+        for step, predecessor in enumerate(predecessors)
+    ]
+
+
+def _target_rows(record: AlignmentRecord) -> list[torch.Tensor]:
+    rows = []
+    for logits in record.target_topk_logits[: record.candidate_ids.shape[0]]:
+        rows.append(_compact_probs(logits / record.temperature, record.top_p))
+    return rows
+
+
+def _load_record(path: Path) -> AlignmentRecord:
+    payload = torch.load(path, map_location="cpu", weights_only=True)
+    if payload.get("format") != "dflash2_selector_alignment_v1":
+        raise ValueError(f"{path}: unsupported alignment format")
+    candidate_ids = payload["selector_candidate_ids"].to(torch.int64)
+    cached_ids = payload["draft_candidate_ids"].to(torch.int64)
+    if not torch.equal(candidate_ids, cached_ids):
+        raise ValueError(f"{path}: packed selector IDs do not match request-slot cache")
+    record = AlignmentRecord(
+        path=path,
+        step=int(payload["step"]),
+        temperature=float(payload["temperature"]),
+        top_p=float(payload["top_p"]),
+        target_topk_ids=payload["target_topk_ids"].to(torch.int64),
+        target_topk_logits=payload["target_topk_logits"].to(torch.float64),
+        candidate_ids=candidate_ids,
+        realized_logits=payload["draft_realized_logits"].to(torch.float64),
+        unary_logits=payload["selector_unary_logits"].to(torch.float64),
+        lattice_scores=payload["selector_lattice_scores"].to(torch.float64),
+        draft_sampled=payload["draft_sampled"].to(torch.int64).flatten(),
+        num_sampled=int(payload["num_sampled"].flatten()[0]),
+    )
+    return record
+
+
+def _mean(values: list[float]) -> float:
+    return float(sum(values) / len(values)) if values else math.nan
+
+
+def _completion_proxy(per_position_overlap: list[float]) -> float:
+    survival = 1.0
+    result = 1.0
+    for overlap in per_position_overlap:
+        survival *= overlap
+        result += survival
+    return result
+
+
+def _evaluate(records: list[AlignmentRecord], config: ProposalConfig) -> dict[str, Any]:
+    num_steps = records[0].candidate_ids.shape[0]
+    overlaps = [[] for _ in range(num_steps)]
+    for record in records:
+        target_rows = _target_rows(record)
+        proposal_rows = _proposal_probs(record, config)
+        for step, (target_probs, proposal_probs) in enumerate(
+            zip(target_rows, proposal_rows)
+        ):
+            overlaps[step].append(
+                _distribution_overlap(
+                    record.target_topk_ids[step],
+                    target_probs,
+                    record.candidate_ids[step],
+                    proposal_probs,
+                )
+            )
+    means = [_mean(values) for values in overlaps]
+    return {
+        "config": asdict(config),
+        "num_records": len(records),
+        "mean_overlap_by_position": means,
+        "completion_length_proxy": _completion_proxy(means),
+    }
+
+
+def _sweep_configs() -> list[ProposalConfig]:
+    configs = [ProposalConfig(name="current", use_cached_logits=True)]
+    seen: set[tuple[float, float, float, float, float]] = set()
+
+    def add(
+        family: str,
+        temperature: float = 1.0,
+        top_p: float = 1.0,
+        unary: float = 1.0,
+        edge: float = 1.0,
+        beta: float = 0.0,
+    ) -> None:
+        key = (temperature, top_p, unary, edge, beta)
+        if key in seen:
+            return
+        seen.add(key)
+        configs.append(
+            ProposalConfig(
+                name=(
+                    f"{family}:t={temperature:g},p={top_p:g},u={unary:g},"
+                    f"e={edge:g},b={beta:g}"
+                ),
+                proposal_temperature_scale=temperature,
+                proposal_top_p=top_p,
+                unary_scale=unary,
+                edge_scale=edge,
+                future_beta=beta,
+            )
+        )
+
+    for temperature in (0.7, 0.8, 0.9, 0.95, 1.0, 1.05, 1.1, 1.2, 1.3):
+        add("temperature", temperature=temperature)
+    for top_p in (0.9, 0.95, 0.98, 0.99):
+        for temperature in (0.8, 0.9, 1.0):
+            add("nucleus", temperature=temperature, top_p=top_p)
+    for unary in (0.75, 1.0, 1.25):
+        for edge in (0.5, 0.75, 1.0, 1.25, 1.5):
+            for temperature in (0.85, 1.0, 1.15):
+                add(
+                    "edge-calibration",
+                    temperature=temperature,
+                    unary=unary,
+                    edge=edge,
+                )
+    for beta in (0.25, 0.5, 0.75, 1.0):
+        for temperature in (0.8, 0.9, 1.0, 1.1):
+            for edge in (0.75, 1.0, 1.25):
+                add(
+                    "future-message",
+                    temperature=temperature,
+                    edge=edge,
+                    beta=beta,
+                )
+    return configs
+
+
+def _baseline_diagnostics(records: list[AlignmentRecord]) -> dict[str, Any]:
+    num_steps = records[0].candidate_ids.shape[0]
+    support = [[] for _ in range(num_steps)]
+    cached_lattice_max_abs: list[float] = []
+    for record in records:
+        target_rows = _target_rows(record)
+        predecessors = _path_predecessors(record)
+        for step, target_probs in enumerate(target_rows):
+            support[step].append(
+                _support_mass(
+                    record.target_topk_ids[step],
+                    target_probs,
+                    record.candidate_ids[step],
+                )
+            )
+            expected = (
+                record.lattice_scores[step, predecessors[step]] / record.temperature
+            )
+            cached_lattice_max_abs.append(
+                float((expected - record.realized_logits[step]).abs().max())
+            )
+    support_means = [_mean(values) for values in support]
+    return {
+        "observed_mean_completion_tokens_per_round": _mean(
+            [float(record.num_sampled) for record in records]
+        ),
+        "candidate_support_mass_by_position": support_means,
+        "candidate_support_completion_upper_proxy": _completion_proxy(support_means),
+        "cached_vs_lattice_max_abs": max(cached_lattice_max_abs, default=math.nan),
+    }
+
+
+def summarize(pattern: str, top_n: int) -> dict[str, Any]:
+    paths = [Path(path) for path in sorted(glob.glob(pattern))]
+    if not paths:
+        raise ValueError(f"no selector alignment dumps matched {pattern!r}")
+    records = [_load_record(path) for path in paths]
+    tune = [record for record in records if record.step % 2 == 0]
+    holdout = [record for record in records if record.step % 2 == 1]
+    if not tune or not holdout:
+        tune = records
+        holdout = records
+
+    configs = _sweep_configs()
+    tune_results = [_evaluate(tune, config) for config in configs]
+    holdout_by_name = {
+        result["config"]["name"]: result
+        for result in (_evaluate(holdout, config) for config in configs)
+    }
+    current_tune = tune_results[0]["completion_length_proxy"]
+    current_holdout = holdout_by_name["current"]["completion_length_proxy"]
+    ranked = sorted(
+        tune_results[1:],
+        key=lambda result: result["completion_length_proxy"],
+        reverse=True,
+    )
+    leaders = []
+    for result in ranked[:top_n]:
+        holdout_result = holdout_by_name[result["config"]["name"]]
+        leaders.append(
+            {
+                "config": result["config"],
+                "tune_completion_length_proxy": result["completion_length_proxy"],
+                "tune_delta": result["completion_length_proxy"] - current_tune,
+                "holdout_completion_length_proxy": holdout_result[
+                    "completion_length_proxy"
+                ],
+                "holdout_delta": (
+                    holdout_result["completion_length_proxy"] - current_holdout
+                ),
+                "tune_mean_overlap_by_position": result["mean_overlap_by_position"],
+                "holdout_mean_overlap_by_position": holdout_result[
+                    "mean_overlap_by_position"
+                ],
+            }
+        )
+
+    return {
+        "contract": {
+            "glob": pattern,
+            "num_records": len(records),
+            "num_tune_records": len(tune),
+            "num_holdout_records": len(holdout),
+            "split": "even/odd sampler step",
+            "counterfactual_scope": "one-step recorded-prefix overlap proxy",
+            "end_to_end_claim": False,
+        },
+        "baseline": _baseline_diagnostics(records),
+        "current": {
+            "tune": tune_results[0],
+            "holdout": holdout_by_name["current"],
+        },
+        "leaders": leaders,
+    }
+
+
+def render_markdown(summary: dict[str, Any]) -> str:
+    contract = summary["contract"]
+    baseline = summary["baseline"]
+    current = summary["current"]
+    lines = [
+        "# DFlash2 Selector Alignment Sweep",
+        "",
+        (
+            f"- Records: `{contract['num_records']}` "
+            f"(tune `{contract['num_tune_records']}`, "
+            f"holdout `{contract['num_holdout_records']}`)"
+        ),
+        (
+            "- Counterfactual scope: one-step overlap on recorded prefixes; "
+            "this is not an end-to-end acceptance claim."
+        ),
+        (
+            "- Observed completion tokens/round: "
+            f"`{baseline['observed_mean_completion_tokens_per_round']:.4f}`"
+        ),
+        (
+            "- Current overlap proxy (tune/holdout): "
+            f"`{current['tune']['completion_length_proxy']:.4f}` / "
+            f"`{current['holdout']['completion_length_proxy']:.4f}`"
+        ),
+        (
+            "- Fixed-top16 support upper proxy: "
+            f"`{baseline['candidate_support_completion_upper_proxy']:.4f}`"
+        ),
+        (
+            "- Cached/lattice max absolute mismatch: "
+            f"`{baseline['cached_vs_lattice_max_abs']:.3e}`"
+        ),
+        "",
+        "| candidate | tune proxy | tune delta | holdout proxy | holdout delta |",
+        "| --- | ---: | ---: | ---: | ---: |",
+    ]
+    for row in summary["leaders"]:
+        lines.append(
+            f"| `{row['config']['name']}` | "
+            f"{row['tune_completion_length_proxy']:.4f} | "
+            f"{row['tune_delta']:+.4f} | "
+            f"{row['holdout_completion_length_proxy']:.4f} | "
+            f"{row['holdout_delta']:+.4f} |"
+        )
+    lines.append("")
+    return "\n".join(lines)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--glob",
+        default="/tmp/spec_alignment_dflash2_selector_*.pt",
+        help="Glob for GPU-runner DFlash2 selector alignment records.",
+    )
+    parser.add_argument("--top", type=int, default=20)
+    parser.add_argument("--out-json", type=Path)
+    parser.add_argument("--out-md", type=Path)
+    args = parser.parse_args()
+
+    summary = summarize(args.glob, args.top)
+    markdown = render_markdown(summary)
+    if args.out_json is not None:
+        args.out_json.parent.mkdir(parents=True, exist_ok=True)
+        args.out_json.write_text(json.dumps(summary, indent=2), encoding="utf-8")
+    if args.out_md is not None:
+        args.out_md.parent.mkdir(parents=True, exist_ok=True)
+        args.out_md.write_text(markdown, encoding="utf-8")
+    print(markdown)
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/benchmark_sm70_decode.py
+++ b/benchmarks/benchmark_sm70_decode.py
@@ -30,7 +30,13 @@ def _module_file(module_name: str) -> str | None:
     module = sys.modules.get(module_name)
     if module is not None:
         return getattr(module, "__file__", None)
-    spec = importlib.util.find_spec(module_name)
+    try:
+        spec = importlib.util.find_spec(module_name)
+    except (AttributeError, ImportError, ValueError):
+        # Optional extension parents can raise while find_spec imports them.
+        # Diagnostics must report an unavailable extension, not discard an
+        # otherwise successful benchmark at result-serialization time.
+        return None
     return spec.origin if spec is not None else None
 
 

--- a/benchmarks/benchmark_sm70_dflash2_gsm8k.py
+++ b/benchmarks/benchmark_sm70_dflash2_gsm8k.py
@@ -1,0 +1,484 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Measure target-only or DFlash2 on a fixed local quality subset."""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import hashlib
+import json
+import math
+import random
+import subprocess
+import time
+from collections import Counter
+from pathlib import Path
+from typing import Any
+
+import regex as re
+from benchmark_sm70_decode import (
+    _diff_spec_metrics,
+    _hash_ids,
+    _json_safe,
+    _module_file,
+    _module_realpath,
+    _request_metrics_dict,
+    _spec_metrics_snapshot,
+    _tracked_env,
+)
+
+INVALID_ANSWER = -9_999_999
+GSM8K_PROMPT_SUFFIX = (
+    "\nPlease reason step by step, and put your final answer within \\boxed{}."
+)
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--model", type=Path, required=True)
+    parser.add_argument("--draft-model", type=Path)
+    parser.add_argument("--dataset", type=Path, required=True)
+    parser.add_argument(
+        "--dataset-format",
+        choices=("gsm8k", "turns"),
+        default="gsm8k",
+        help=(
+            "Input schema. 'gsm8k' scores question/answer rows; 'turns' uses "
+            "the first preformatted turn and leaves task scoring to a separate "
+            "evaluator."
+        ),
+    )
+    parser.add_argument("--out", type=Path, required=True)
+    parser.add_argument("--mode", choices=("target-only", "dflash"), required=True)
+    parser.add_argument("--num-questions", type=int, default=64)
+    parser.add_argument("--start-index", type=int, default=0)
+    parser.add_argument(
+        "--dataset-order",
+        choices=("sequential", "zlab-shuffle42"),
+        default="sequential",
+    )
+    parser.add_argument("--max-tokens", type=int, default=256)
+    parser.add_argument("--warmup-tokens", type=int, default=32)
+    parser.add_argument("--temperature", type=float, default=1.0)
+    parser.add_argument("--tensor-parallel-size", type=int, default=4)
+    parser.add_argument("--max-model-len", type=int, default=2048)
+    parser.add_argument("--max-num-batched-tokens", type=int, default=512)
+    parser.add_argument("--max-num-seqs", type=int, default=4)
+    parser.add_argument("--sequential", action="store_true")
+    parser.add_argument("--gpu-memory-utilization", type=float, default=0.8)
+    parser.add_argument(
+        "--target-kv-cache-dtype",
+        choices=("auto", "fp8_e5m2"),
+        default="fp8_e5m2",
+    )
+    parser.add_argument("--enforce-eager", action="store_true")
+    parser.add_argument(
+        "--draft-sample-method",
+        choices=("greedy", "probabilistic"),
+        default="greedy",
+    )
+    parser.add_argument(
+        "--draft-attention-backend",
+        choices=("FLASH_ATTN_V100", "TRITON_ATTN"),
+        default="FLASH_ATTN_V100",
+        help="Draft-only attention backend; the target remains on FLASH_ATTN_V100.",
+    )
+    parser.add_argument("--seed", type=int, default=0)
+    parser.add_argument(
+        "--request-seed",
+        type=int,
+        default=0,
+        help="Sampling seed for every request; use -1 for server-style random seeds.",
+    )
+    parser.add_argument(
+        "--cuda-profiler-capture",
+        action="store_true",
+        help="Wrap the measured generation in cudaProfilerStart/Stop for nsys.",
+    )
+    return parser.parse_args()
+
+
+def _sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as file:
+        for chunk in iter(lambda: file.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _model_weight_files(model: Path) -> dict[str, str]:
+    index = model / "model.safetensors.index.json"
+    if not index.is_file():
+        weight = model / "model.safetensors"
+        return {weight.name: str(weight.resolve())}
+    weight_map = json.loads(index.read_text())["weight_map"]
+    return {
+        name: str((model / name).resolve()) for name in sorted(set(weight_map.values()))
+    }
+
+
+def _answer_value(text: str) -> int:
+    numbers = re.findall(r"\d+", text.replace(",", ""))
+    if not numbers:
+        return INVALID_ANSWER
+    try:
+        return int(ast.literal_eval(numbers[-1]))
+    except (SyntaxError, ValueError):
+        return INVALID_ANSWER
+
+
+def _percentile(values: list[float], quantile: float) -> float | None:
+    if not values:
+        return None
+    ordered = sorted(values)
+    position = (len(ordered) - 1) * quantile
+    lower = math.floor(position)
+    upper = math.ceil(position)
+    if lower == upper:
+        return ordered[lower]
+    weight = position - lower
+    return ordered[lower] + (ordered[upper] - ordered[lower]) * weight
+
+
+def _distribution(values: list[float]) -> dict[str, float | int | None]:
+    return {
+        "count": len(values),
+        "mean": sum(values) / len(values) if values else None,
+        "p50": _percentile(values, 0.50),
+        "p90": _percentile(values, 0.90),
+        "p99": _percentile(values, 0.99),
+        "min": min(values) if values else None,
+        "max": max(values) if values else None,
+    }
+
+
+def _load_rows(args: argparse.Namespace) -> list[tuple[int, dict[str, Any]]]:
+    rows = [
+        json.loads(line)
+        for line in args.dataset.read_text(encoding="utf-8").splitlines()
+        if line
+    ]
+    indices = list(range(len(rows)))
+    if args.dataset_order == "zlab-shuffle42":
+        random.Random(42).shuffle(indices)
+    selected_indices = indices[args.start_index : args.start_index + args.num_questions]
+    if len(selected_indices) != args.num_questions:
+        raise ValueError(
+            f"Requested {args.num_questions} rows at index {args.start_index}, "
+            f"but the dataset provided {len(selected_indices)}."
+        )
+    return [(index, rows[index]) for index in selected_indices]
+
+
+def _prompt_content(row: dict[str, Any], dataset_format: str) -> str:
+    if dataset_format == "gsm8k":
+        return str(row["question"]) + GSM8K_PROMPT_SUFFIX
+    turns = row.get("turns")
+    if not isinstance(turns, list) or not turns or not isinstance(turns[0], str):
+        raise ValueError("turns dataset rows must contain a non-empty string list")
+    return turns[0]
+
+
+def _summarize_requests(cases: list[dict[str, Any]]) -> dict[str, Any]:
+    metric_names = (
+        "queued_time",
+        "first_token_latency",
+        "prefill_time",
+        "decode_time",
+        "steady_decode_tps",
+        "tpot_seconds",
+    )
+    summary = {}
+    for metric_name in metric_names:
+        values = [
+            float(case["request_metrics"][metric_name])
+            for case in cases
+            if case["request_metrics"] is not None
+            and case["request_metrics"].get(metric_name) is not None
+        ]
+        summary[metric_name] = _distribution(values)
+
+    prefill_tps = [
+        case["prompt_tokens"] / case["request_metrics"]["prefill_time"]
+        for case in cases
+        if case["request_metrics"] is not None
+        and case["request_metrics"].get("prefill_time")
+    ]
+    summary["prefill_tokens_per_second"] = _distribution(prefill_tps)
+    summary["prompt_tokens"] = _distribution(
+        [float(case["prompt_tokens"]) for case in cases]
+    )
+    summary["output_tokens"] = _distribution(
+        [float(case["output_tokens"]) for case in cases]
+    )
+    return summary
+
+
+def main() -> int:
+    args = _parse_args()
+    if args.num_questions <= 0:
+        raise ValueError("--num-questions must be positive")
+    if args.request_seed < -1:
+        raise ValueError("--request-seed must be -1 or a non-negative integer")
+    if args.mode == "dflash" and args.draft_model is None:
+        raise ValueError("--draft-model is required for --mode dflash")
+
+    import torch
+    import vllm._C as vllm_c
+    import vllm._C_stable_libtorch as vllm_c_stable
+    from transformers import AutoTokenizer
+
+    import vllm
+    from vllm import LLM, SamplingParams
+
+    rows = _load_rows(args)
+    tokenizer = AutoTokenizer.from_pretrained(str(args.model))
+    prompt_contents = [_prompt_content(row, args.dataset_format) for _, row in rows]
+    prompts = [
+        tokenizer.apply_chat_template(
+            [
+                {
+                    "role": "user",
+                    "content": prompt_content,
+                }
+            ],
+            tokenize=False,
+            add_generation_prompt=True,
+            enable_thinking=True,
+            reasoning_effort="xhigh",
+        )
+        for prompt_content in prompt_contents
+    ]
+    prompt_token_counts = [len(tokenizer.encode(prompt)) for prompt in prompts]
+
+    speculative_config = None
+    if args.mode == "dflash":
+        speculative_config = {
+            "method": "dflash",
+            "model": str(args.draft_model),
+            "revision": "dedf8df68adfb1afeaf7b7480c0a0243108177b4",
+            "num_speculative_tokens": 7,
+            "kv_cache_dtype": "auto",
+            "attention_backend": args.draft_attention_backend,
+            "draft_sample_method": args.draft_sample_method,
+            "enforce_eager": args.enforce_eager,
+        }
+
+    engine_kwargs = {
+        "model": str(args.model),
+        "tensor_parallel_size": args.tensor_parallel_size,
+        "dtype": "half",
+        "kv_cache_dtype": args.target_kv_cache_dtype,
+        "attention_backend": "FLASH_ATTN_V100",
+        "max_model_len": args.max_model_len,
+        "max_num_batched_tokens": args.max_num_batched_tokens,
+        "max_num_seqs": args.max_num_seqs,
+        "gpu_memory_utilization": args.gpu_memory_utilization,
+        "enable_prefix_caching": False,
+        "disable_log_stats": False,
+        "enforce_eager": args.enforce_eager,
+        "seed": args.seed,
+        "speculative_config": speculative_config,
+    }
+    if args.cuda_profiler_capture:
+        engine_kwargs["profiler_config"] = {"profiler": "cuda"}
+
+    load_started = time.perf_counter()
+    llm = LLM(**engine_kwargs)
+    load_seconds = time.perf_counter() - load_started
+
+    request_seed = None if args.request_seed == -1 else args.request_seed
+    warmup_sampling = SamplingParams(
+        temperature=args.temperature,
+        top_p=0.95,
+        top_k=20,
+        max_tokens=args.warmup_tokens,
+        seed=request_seed,
+        skip_special_tokens=False,
+    )
+    llm.generate([prompts[0]], warmup_sampling, use_tqdm=False)
+
+    sampling = SamplingParams(
+        temperature=args.temperature,
+        top_p=0.95,
+        top_k=20,
+        max_tokens=args.max_tokens,
+        seed=request_seed,
+        skip_special_tokens=False,
+    )
+    spec_before = _spec_metrics_snapshot(llm)
+    if args.cuda_profiler_capture:
+        llm.start_profile()
+    started = time.perf_counter()
+    if args.sequential:
+        outputs = []
+        request_spec_metrics = []
+        for prompt in prompts:
+            request_spec_before = _spec_metrics_snapshot(llm)
+            outputs.append(llm.generate([prompt], sampling, use_tqdm=False)[0])
+            request_spec_after = _spec_metrics_snapshot(llm)
+            request_spec_metrics.append(
+                _diff_spec_metrics(request_spec_before, request_spec_after)
+            )
+    else:
+        outputs = llm.generate(prompts, sampling, use_tqdm=False)
+        request_spec_metrics = [None] * len(outputs)
+    elapsed_seconds = time.perf_counter() - started
+    if args.cuda_profiler_capture:
+        llm.stop_profile()
+    spec_after = _spec_metrics_snapshot(llm)
+
+    cases = []
+    for (
+        dataset_index,
+        row,
+    ), prompt_content, prompt_tokens, output, request_spec in zip(
+        rows, prompt_contents, prompt_token_counts, outputs, request_spec_metrics
+    ):
+        result = output.outputs[0]
+        token_ids = list(result.token_ids)
+        if args.dataset_format == "gsm8k":
+            prediction = _answer_value(result.text)
+            expected = _answer_value(row["answer"])
+            correct = prediction == expected
+        else:
+            prediction = None
+            expected = None
+            correct = None
+        cases.append(
+            {
+                "dataset_index": dataset_index,
+                "question": row.get("question"),
+                "prompt_content": prompt_content,
+                "expected_answer": expected,
+                "predicted_answer": prediction,
+                "correct": correct,
+                "prompt_tokens": prompt_tokens,
+                "output_tokens": len(token_ids),
+                "finish_reason": result.finish_reason,
+                "stop_reason": result.stop_reason,
+                "text": result.text,
+                "token_ids": token_ids,
+                "token_hash": _hash_ids(token_ids),
+                "spec_decode_metrics": request_spec,
+                "request_metrics": _request_metrics_dict(
+                    output.metrics,
+                    len(token_ids),
+                ),
+            }
+        )
+
+    total_output_tokens = sum(case["output_tokens"] for case in cases)
+    scored_cases = [case for case in cases if case["correct"] is not None]
+    correct = sum(bool(case["correct"]) for case in scored_cases)
+    invalid = sum(case["predicted_answer"] == INVALID_ANSWER for case in scored_cases)
+    per_request_acceptance_lengths = [
+        float(case["spec_decode_metrics"]["acceptance_length"])
+        for case in cases
+        if case["spec_decode_metrics"] is not None
+        and case["spec_decode_metrics"].get("acceptance_length") is not None
+    ]
+    per_request_completion_tokens_per_verification_step = [
+        case["output_tokens"] / case["spec_decode_metrics"]["num_drafts"]
+        for case in cases
+        if case["spec_decode_metrics"] is not None
+        and case["spec_decode_metrics"].get("num_drafts", 0) > 0
+    ]
+    c_extension = Path(vllm_c.__file__).resolve()
+    c_stable_extension = Path(vllm_c_stable.__file__).resolve()
+    payload = {
+        "contract": {
+            "source_sha": subprocess.check_output(
+                ["git", "rev-parse", "HEAD"],
+                cwd=Path(__file__).resolve().parents[1],
+                text=True,
+            ).strip(),
+            "mode": args.mode,
+            "dataset": str(args.dataset),
+            "dataset_sha256": _sha256_file(args.dataset),
+            "dataset_format": args.dataset_format,
+            "start_index": args.start_index,
+            "num_questions": args.num_questions,
+            "dataset_order": args.dataset_order,
+            "model": str(args.model),
+            "model_config_sha256": _sha256_file(args.model / "config.json"),
+            "model_index_sha256": (
+                _sha256_file(args.model / "model.safetensors.index.json")
+                if (args.model / "model.safetensors.index.json").is_file()
+                else None
+            ),
+            "model_weight_files": _model_weight_files(args.model),
+            "model_weights_realpath": str((args.model / "model.safetensors").resolve()),
+            "draft_model": str(args.draft_model) if args.draft_model else None,
+            "graph": not args.enforce_eager,
+            "sequential": args.sequential,
+            "sampling": {
+                "temperature": args.temperature,
+                "top_p": 0.95,
+                "top_k": 20,
+                "max_tokens": args.max_tokens,
+                "seed": request_seed,
+                "ignore_eos": False,
+                "thinking": True,
+                "reasoning_effort": "xhigh",
+                "prompt_suffix": (
+                    GSM8K_PROMPT_SUFFIX if args.dataset_format == "gsm8k" else None
+                ),
+            },
+            "engine_kwargs": engine_kwargs,
+        },
+        "runtime": {
+            "vllm_version": getattr(vllm, "__version__", None),
+            "vllm_file": getattr(vllm, "__file__", None),
+            "torch_version": torch.__version__,
+            "torch_cuda": torch.version.cuda,
+            "cuda_device_count": torch.accelerator.device_count(),
+            "device_capabilities": [
+                list(torch.cuda.get_device_capability(index))
+                for index in range(torch.accelerator.device_count())
+            ],
+            "c_extension": str(c_extension),
+            "c_extension_sha256": _sha256_file(c_extension),
+            "c_stable_extension": str(c_stable_extension),
+            "c_stable_extension_sha256": _sha256_file(c_stable_extension),
+            "flash_attn_v100_python": _module_file("flash_attn_v100"),
+            "flash_attn_v100_cuda": _module_realpath("flash_attn_v100_cuda"),
+            "tracked_env": _tracked_env(),
+            "load_seconds": load_seconds,
+        },
+        "results": {
+            "elapsed_seconds": elapsed_seconds,
+            "total_output_tokens": total_output_tokens,
+            "aggregate_output_tokens_per_second": (
+                total_output_tokens / elapsed_seconds
+            ),
+            "questions_per_second": len(cases) / elapsed_seconds,
+            "accuracy": correct / len(scored_cases) if scored_cases else None,
+            "invalid_answer_rate": (
+                invalid / len(scored_cases) if scored_cases else None
+            ),
+            "finish_reasons": dict(
+                Counter(str(case["finish_reason"]) for case in cases)
+            ),
+            "request_metrics": _summarize_requests(cases),
+            "spec_decode_metrics": _diff_spec_metrics(spec_before, spec_after),
+            "per_request_acceptance_length": _distribution(
+                per_request_acceptance_lengths
+            ),
+            "per_request_completion_tokens_per_verification_step": _distribution(
+                per_request_completion_tokens_per_verification_step
+            ),
+        },
+        "cases": cases,
+    }
+    payload = _json_safe(payload)
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    args.out.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+    printable = {"contract": payload["contract"], "results": payload["results"]}
+    print(json.dumps(printable, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/design/sm70_dflash2_acceptance_rd.md
+++ b/docs/design/sm70_dflash2_acceptance_rd.md
@@ -1,0 +1,74 @@
+# SM70 DFlash2 acceptance research without retraining
+
+## Scope and frozen contracts
+
+- Date: 2026-08-25.
+- Integration base: `onecat/main@34403018d917054dd7765d5e820ad29c8d342348`.
+- Branch: `codex/v100-v100-dflash2-acceptance-rd-20260825-113155`.
+- No draft or target retraining and no checkpoint edits.
+- Target validation remains the complete MRV2 block-eight workload: seven draft
+  tokens plus one target bonus row. DDTree index reuse and wider verifier trees
+  are outside this campaign.
+- Target sampling remains exact standard rejection at temperature 1.0, top-p
+  0.95, and top-k 20. A candidate proposal distribution is admissible only if
+  the selector draw and the rejection sampler consume the same exact `q`.
+
+The score gate remains the existing 128-row mixed32 dataset at
+`/data/minimax-h3/task-cache/v100-dflash2-target-graph-20ms/quality/datasets/dflash2-mixed-quality-32each.jsonl`,
+SHA256
+`85ce10d84735ec981c001663d5748b1939a81892ef3ccd4549aec66177795607`.
+It uses sequential B1, a fixed seed, xhigh reasoning, at most 2,048 generated
+tokens, and natural EOS. Corrected MBPP-32 and WikiText-2 PPL retain their
+existing independent gates. The historical native-grouped result is 83/96 on
+GSM8K/MATH-500/HumanEval, 25/32 on corrected MBPP, request-mean completion
+length 4.238430, and pooled acceptance length 3.749104.
+
+The production performance gate remains the PR #288 practical contract: TP4
+V100, 256K maximum context, `max_num_batched_tokens=4096`, prefix caching,
+Mamba align mode, FP8 E5M2 target KV, FP16 draft KV, Flash-V100, probabilistic
+DFlash2, tool/reasoning parsers, and FULL CUDA Graph. Its short-context complete
+round is 18.465--18.603 ms. Acceptance work may not increase verifier rows or
+regress that round by more than measurement noise.
+
+## First target and promotion gate
+
+The first research target is at least +0.5 request-mean completion tokens per
+verification round on the unchanged mixed32 contract. Promotion additionally
+requires:
+
+1. no aggregate task-score loss against the paired target-only and current
+   DFlash2 controls;
+2. no corrected-MBPP or WikiText PPL regression;
+3. exact rejection-distribution tests and normalized proposal rows;
+4. unchanged eight-row target validation and at most 0.05 ms incremental
+   selector latency on SM70;
+5. no material acceptance or latency regression at 1K, 32K, 128K, or 256K.
+
+## Selector headroom audit
+
+The first implementation is diagnostic-only. With both compact sparse
+rejection and `VLLM_SPEC_DUMP_ALIGNMENT=1`, the speculator keeps the checkpoint
+top16 IDs, unary logits, full `7 x 16 x 16` selector lattice, and exact realized
+proposal rows. The target sampler records its top20 rows and the actual strict
+rejection outcome. Disabled diagnostics allocate no shadow lattice and add no
+copy or sampler operation.
+
+`benchmarks/analyze_dflash2_selector_alignment.py` reports, by draft depth:
+
+- current overlap `sum(min(p, q))`;
+- target probability mass covered by the fixed top16 candidate support;
+- the gap between support mass and current overlap;
+- one-step counterfactual sweeps over proposal temperature, proposal nucleus,
+  unary/edge calibration, and backward log-sum-exp future messages.
+
+Even sampler steps tune the candidates and odd steps are a held-out report.
+Counterfactual values after a changed path are explicitly only recorded-prefix
+overlap proxies, not end-to-end acceptance claims. Survivors must be rerun on
+the frozen dataset.
+
+## Initial verification
+
+- Focused Ruff lint and format: passed.
+- Diagnostic analyzer synthetic checks: passed.
+- CPU DFlash2 suite with CUDA hidden: 77 passed, 12 expected CUDA skips.
+- No GPU performance or end-to-end acceptance result has been claimed yet.

--- a/docs/design/sm70_dflash2_nvfp4_17ms.md
+++ b/docs/design/sm70_dflash2_nvfp4_17ms.md
@@ -1,0 +1,108 @@
+# SM70 Qwen3.8 NVFP4 DFlash2 17 ms Campaign
+
+> **Status:** planning record only. No source optimization or 17 ms result is
+> claimed by this document. The historical baseline below is retained to make
+> the next implementation reproducible.
+
+## Scope and frozen baseline
+
+This campaign targets the complete batch-one DFlash2 speculative round measured
+with a Qwen3.8-27B NVFP4 workload on four V100 GPUs. Its historical baseline is
+`onecat/main@34403018d917054dd7765d5e820ad29c8d342348`; the planning record was
+integrated on `main@cadcf1d899b6d7511f815e7ee939b1e4676aff19`. It does not
+credit route-hit logs as performance evidence.
+
+The retained benchmark artifacts identify a mixed NVFP4/channel-FP8 target
+with a BF16 LM head and a DFlash2 draft at revision
+`dedf8df68adfb1afeaf7b7480c0a0243108177b4`. Private filesystem locations are
+intentionally not recorded. The frozen workload uses TP4 on an owned four-V100
+group, probabilistic DFlash2 with seven draft tokens, selector K=16, target
+top-k=20, FP8 E5M2 target KV, FP16 draft KV, Flash-V100 for target and draft
+attention, and FULL target and draft CUDA Graphs. Model/checkpoint labels are
+benchmark evidence only and must not activate an optimized runtime route.
+
+Two runtime contracts are deliberately kept separate:
+
+1. The localization contract uses a 32K maximum model length, 512 maximum
+   batched tokens, and disables prefix caching, Mamba alignment, and parsers.
+   It is used only for short unprofiled repeats, graph-node traces, and
+   exact-shape microbenchmarks.
+2. The promotion contract uses a 256K maximum model length, 4096 maximum
+   batched tokens, prefix caching, Mamba alignment, and the Qwen tool and
+   reasoning parsers. A speedup is not accepted until it reproduces under this
+   practical configuration.
+
+The current accepted practical baseline on PR #288 is `18.465--18.537 ms` per
+complete round for 512-token coding requests and `18.587--18.603 ms` for
+1,024-token coding requests. The high-acceptance MBPP item 28 baseline is
+`18.567 ms`, acceptance length `4.686`, and `251.60 token/s`, with a natural
+EOS and EvalPlus base/plus `1/1`. A fresh current-source 16-prompt GSM8K run
+measures request-mean acceptance `4.45732`, pooled acceptance `4.07740`, and
+`19.3688 ms` per round with diagnostic counters enabled. Diagnostic timing is
+not a production baseline.
+
+## Acceptance gates
+
+A short-context candidate is accepted only when all of the following hold:
+
+- the no-diagnostic promotion contract measures a mean and median complete
+  speculative round at or below `17.0 ms` across at least three independent
+  steady-state requests; the p90 must be at or below `17.5 ms`;
+- the same fixed prompt, seed, sampling parameters, output cap, CUDA Graph
+  shapes, and GPU set are used for the baseline/candidate pair;
+- paired request-mean acceptance does not fall by more than `0.05`, the
+  per-position counters remain healthy, and no stale-buffer, graph-replay, or
+  draft-KV mismatch appears;
+- the existing GSM8K, MATH-500, HumanEval, corrected MBPP, and WikiText PPL
+  gates do not regress versus target-only and the accepted DFlash2 baseline;
+- every retained performance optimization has an exact engine-contract
+  admission predicate, a rollback switch, focused numerical coverage, and an
+  unprofiled endpoint win. Once these gates pass, the optimized path is the
+  default; rollback remains for diagnosis rather than permanent opt-in.
+
+Long-context work is evaluated at 32K, 128K, and 256K. The candidate must not
+make complete-round latency or pure-decode throughput worse by more than 1%
+at any length. Numerical probes require finite outputs and a dtype-appropriate
+absolute/relative error envelope; official-sampling quality and acceptance
+must remain non-regressing. Bitwise output or greedy-token identity is not a
+promotion requirement when a changed but valid reduction order explains the
+difference. The 17 ms target applies to the short round; long-context results
+are reported as an explicit decay curve because the verifier attention cost
+necessarily grows with resident context.
+
+## Trace-first implementation sequence
+
+1. Reproduce the current no-diagnostic NVFP4 baseline in this worktree and
+   record source SHA, extension hashes, route logs, GPU clocks, and per-request
+   round statistics.
+2. Capture the smallest generation-only Nsight Systems trace that contains
+   steady CUDA Graph replays. Split every round into draft, draft-to-target,
+   target verification, and target-to-draft phases, then expand the target
+   phase into exact kernel categories and launch counts.
+3. Microbenchmark only the largest current-source bucket at its production
+   M/N/K, TP, dtype, and graph shapes. A microbenchmark result is directional
+   evidence, never an endpoint claim.
+4. Implement the smallest exact change that removes the measured bottleneck.
+   Rejected DDTree index reuse, skipped verification, generic auxiliary-stream
+   overlap, variable K, and approximate reranking are not retried: they either
+   changed output/acceptance or increased the complete round.
+5. Promote a default only after focused CPU/GPU numerical tests, graph replay,
+   three clean short repeats, the practical 256K configuration, the quality
+   suite, and the 32K/128K/256K decay sweep pass.
+
+The first trace should determine whether the remaining roughly `1.6 ms` is in
+NVFP4 QPN2/QPN8 projections, draft non-causal KV work, target verification,
+or scheduler/metadata boundaries. No saving is assigned to a hypothesis
+before that trace and its exact-shape microbenchmark exist.
+
+## Draft PR record
+
+Purpose: reduce the complete Qwen3.8-27B NVFP4 DFlash2 round to 17 ms on SM70
+without changing the sampling contract, acceptance, or task quality.
+
+Test plan: unprofiled paired endpoint repeats; Nsight graph-node phase
+breakdown; exact-shape microbenchmarks; focused numerical and CUDA Graph replay
+tests; GSM8K/MATH-500/HumanEval/MBPP/PPL quality gates; 32K/128K/256K decay
+sweep.
+
+Test result: pending current-source baseline and trace.

--- a/docs/design/sm70_v100_migration_control.md
+++ b/docs/design/sm70_v100_migration_control.md
@@ -43046,6 +43046,36 @@ Interpretation:
   The older public server's nominal cold result may have retained an identical
   prefix, so only the fresh-server numbers are treated as strict cold evidence.
 
+## 2026-08-25 Qwen3.8-27B NVFP4 DFlash2 17 ms campaign
+
+- This section is an active planning record, not evidence that a 17 ms result
+  or source optimization already exists. The document itself is safe to merge
+  while implementation and measurements remain pending.
+- The next isolated campaign starts from
+  `onecat/main@34403018d917054dd7765d5e820ad29c8d342348` and targets a stable
+  batch-one complete speculative round of at most `17.0 ms`. The frozen target
+  is the local mixed NVFP4/channel-FP8 Qwen3.8-27B checkpoint with BF16 LM
+  head, TP4 on V100 GPUs 0--3, E5M2 target KV, FP16 draft KV, seven draft
+  tokens, probabilistic sampling, and FULL target/draft CUDA Graphs.
+- The accepted PR #288 practical baseline is `18.465--18.603 ms`, so the
+  remaining measured gap is approximately `1.5--1.6 ms`. A current-source
+  no-diagnostic graph-node trace is required before choosing the next source
+  change. Historical DDTree index reuse, skipped verification, generic
+  auxiliary-stream overlap, variable K, and approximate reranking remain
+  rejected.
+- Development may use a 32K/512 minimal runtime only to localize kernels. The
+  promotion gate is the 256K/4096 configuration with prefix caching, Mamba
+  alignment, and tool/reasoning parsers enabled. Acceptance may not fall by
+  more than `0.05`; the existing scored datasets and PPL gates must not
+  regress. A separate 32K/128K/256K sweep protects long-context decay.
+- A retained speedup becomes default-on after the engine-contract admission,
+  rollback, numerical, official-sampling quality, and matched endpoint gates
+  pass. A valid reduction-order change need not be bitwise or greedy-token
+  identical, but it must remain finite, within a dtype-appropriate error
+  envelope, and non-regressing on acceptance and scored quality.
+- The full frozen contract, sequence, and pending Draft PR test record are in
+  `docs/design/sm70_dflash2_nvfp4_17ms.md`.
+
 ## 2026-08-25 Qwen3.8-27B NVFP4 long-context decode
 
 - The accepted candidate specializes only the SM70 E4M3 G6/D256 dual-CTA

--- a/tests/v1/spec_decode/test_dflash2.py
+++ b/tests/v1/spec_decode/test_dflash2.py
@@ -48,6 +48,7 @@ from vllm.v1.worker.gpu.sample.gumbel import gumbel_sample
 from vllm.v1.worker.gpu.spec_decode import init_speculator
 from vllm.v1.worker.gpu.spec_decode.dflash.speculator import DFlashSpeculator
 from vllm.v1.worker.gpu.spec_decode.dflash2.sparse_rejection import (
+    _parse_alignment_steps,
     _supports_sparse_sampling_contract,
 )
 from vllm.v1.worker.gpu.spec_decode.dflash2.speculator import (
@@ -260,10 +261,12 @@ def test_selector_default_path_does_not_allocate_sparse_score_cache(monkeypatch)
     allocated = torch.zeros((2, 7, 31), dtype=torch.float32)
     _stub_base(monkeypatch, allocated)
     monkeypatch.setattr(envs, "VLLM_SM70_DFLASH2_SPARSE_TARGET_REJECTION", False)
+    monkeypatch.setattr(envs, "VLLM_SPEC_DUMP_ALIGNMENT", False)
     speculator = DFlash2Speculator(None, torch.device("cpu"))
     assert speculator.draft_logits is allocated
     assert torch.isneginf(speculator.draft_logits).all()
     assert speculator.get_sparse_draft_logits() is None
+    assert speculator.get_selector_alignment_shadow() is None
 
 
 def test_selector_opt_in_allocates_sparse_score_cache(monkeypatch):
@@ -277,6 +280,39 @@ def test_selector_opt_in_allocates_sparse_score_cache(monkeypatch):
     assert candidate_ids.shape == (2, 7, 16)
     assert candidate_scores.shape == (2, 7, 16)
     assert candidate_scores.dtype is torch.float32
+
+
+def test_selector_alignment_shadow_is_explicit_and_keeps_full_lattice(monkeypatch):
+    allocated = torch.zeros((2, 7, 31), dtype=torch.float32)
+    _stub_base(monkeypatch, allocated)
+    monkeypatch.setattr(envs, "VLLM_SM70_DFLASH2_SPARSE_TARGET_REJECTION", True)
+    monkeypatch.setattr(envs, "VLLM_SPEC_DUMP_ALIGNMENT", True)
+
+    speculator = DFlash2Speculator(None, torch.device("cpu"))
+    shadow = speculator.get_selector_alignment_shadow()
+
+    assert shadow is not None
+    candidate_ids, unary_logits, lattice_scores = shadow
+    assert candidate_ids.shape == (2, 7, 16)
+    assert unary_logits.shape == (2, 7, 16)
+    assert unary_logits.dtype is torch.float32
+    assert lattice_scores.shape == (2, 7, 16, 16)
+    assert lattice_scores.dtype is torch.float32
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        (None, None),
+        ("", None),
+        ("1,3-5", {1, 3, 4, 5}),
+        ("5-3", set()),
+        ("bad", set()),
+        ("-1", set()),
+    ],
+)
+def test_selector_alignment_step_filter(raw, expected):
+    assert _parse_alignment_steps(raw) == expected
 
 
 def test_selector_uses_checkpoint_top16_and_fp32_proposal_cache(monkeypatch):

--- a/tests/v1/spec_decode/test_dflash2_selector_analysis.py
+++ b/tests/v1/spec_decode/test_dflash2_selector_analysis.py
@@ -1,0 +1,81 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import torch
+
+_ANALYZER_PATH = (
+    Path(__file__).parents[3] / "benchmarks/analyze_dflash2_selector_alignment.py"
+)
+_SPEC = importlib.util.spec_from_file_location(
+    "analyze_dflash2_selector_alignment", _ANALYZER_PATH
+)
+assert _SPEC is not None and _SPEC.loader is not None
+_ANALYZER = importlib.util.module_from_spec(_SPEC)
+sys.modules[_SPEC.name] = _ANALYZER
+_SPEC.loader.exec_module(_ANALYZER)
+
+
+def _record():
+    candidate_ids = torch.tensor([[10, 11], [20, 21]])
+    lattice = torch.tensor(
+        [
+            [[0.0, 0.0], [0.0, 0.0]],
+            [[0.0, 4.0], [0.0, -4.0]],
+        ],
+        dtype=torch.float64,
+    )
+    return _ANALYZER.AlignmentRecord(
+        path=Path("synthetic.pt"),
+        step=1,
+        temperature=1.0,
+        top_p=1.0,
+        target_topk_ids=candidate_ids,
+        target_topk_logits=torch.zeros((2, 2), dtype=torch.float64),
+        candidate_ids=candidate_ids,
+        realized_logits=torch.stack((lattice[0, 0], lattice[1, 0])),
+        unary_logits=torch.zeros((2, 2), dtype=torch.float64),
+        lattice_scores=lattice,
+        draft_sampled=torch.tensor([1, 10, 20]),
+        num_sampled=2,
+    )
+
+
+def test_compact_top_p_keeps_the_crossing_token():
+    probs = _ANALYZER._compact_probs(torch.log(torch.tensor([0.6, 0.3, 0.1])), 0.7)
+    torch.testing.assert_close(
+        probs, torch.tensor([2 / 3, 1 / 3, 0.0], dtype=torch.float64)
+    )
+
+
+def test_beta_zero_reconstructs_realized_selector_rows():
+    record = _record()
+    current = _ANALYZER._proposal_probs(
+        record,
+        _ANALYZER.ProposalConfig(name="current", use_cached_logits=True),
+    )
+    reconstructed = _ANALYZER._proposal_probs(
+        record,
+        _ANALYZER.ProposalConfig(name="beta-zero"),
+    )
+
+    for actual, expected in zip(reconstructed, current):
+        torch.testing.assert_close(actual, expected)
+
+
+def test_future_message_can_prefer_a_better_supported_branch():
+    record = _record()
+    local = _ANALYZER._proposal_probs(
+        record,
+        _ANALYZER.ProposalConfig(name="local"),
+    )[0]
+    global_chain = _ANALYZER._proposal_probs(
+        record,
+        _ANALYZER.ProposalConfig(name="global", future_beta=1.0),
+    )[0]
+
+    assert local[0] == local[1]
+    assert global_chain[0] > global_chain[1]

--- a/tests/v1/spec_decode/test_dflash2_selector_analysis.py
+++ b/tests/v1/spec_decode/test_dflash2_selector_analysis.py
@@ -79,3 +79,24 @@ def test_future_message_can_prefer_a_better_supported_branch():
 
     assert local[0] == local[1]
     assert global_chain[0] > global_chain[1]
+
+
+def test_greedy_mixture_is_normalized_and_moves_exact_mass():
+    record = _record()
+    baseline = _ANALYZER._proposal_probs(
+        record,
+        _ANALYZER.ProposalConfig(name="baseline", use_cached_logits=True),
+    )[1]
+    mixed = _ANALYZER._proposal_probs(
+        record,
+        _ANALYZER.ProposalConfig(
+            name="mixture",
+            greedy_mix=0.25,
+            use_cached_logits=True,
+        ),
+    )[1]
+
+    expected = baseline * 0.75
+    expected[torch.argmax(baseline)] += 0.25
+    torch.testing.assert_close(mixed, expected)
+    torch.testing.assert_close(mixed.sum(), torch.tensor(1.0, dtype=torch.float64))

--- a/vllm/v1/worker/gpu/spec_decode/dflash2/sparse_rejection.py
+++ b/vllm/v1/worker/gpu/spec_decode/dflash2/sparse_rejection.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+import os
 from typing import TYPE_CHECKING, Any
 
 import numpy as np
@@ -26,6 +27,125 @@ if TYPE_CHECKING:
 logger = init_logger(__name__)
 
 _TARGET_TOP_K = 20
+_SELECTOR_ALIGNMENT_DUMP_COUNT = 0
+_SELECTOR_ALIGNMENT_STEP = 0
+
+
+def _parse_alignment_steps(raw_steps: str | None) -> set[int] | None:
+    if not raw_steps:
+        return None
+    steps: set[int] = set()
+    try:
+        for item in raw_steps.split(","):
+            item = item.strip()
+            if not item:
+                continue
+            if "-" in item:
+                start_text, end_text = item.split("-", 1)
+                start = int(start_text)
+                end = int(end_text)
+                if start < 0 or end < start:
+                    return set()
+                steps.update(range(start, end + 1))
+            else:
+                step = int(item)
+                if step < 0:
+                    return set()
+                steps.add(step)
+    except ValueError:
+        return set()
+    return steps
+
+
+def _safe_dump_tag(raw_tag: str) -> str:
+    return "".join(ch if ch.isalnum() or ch in "._-" else "_" for ch in raw_tag)
+
+
+def _diagnostic_rank() -> int:
+    return int(os.getenv("RANK", os.getenv("LOCAL_RANK", "0")))
+
+
+def _maybe_dump_selector_alignment(
+    *,
+    speculator: DFlash2Speculator,
+    rejection_sampler: RejectionSampler,
+    input_batch: InputBatch,
+    target_topk_ids: torch.Tensor,
+    target_topk_logits: torch.Tensor,
+    draft_topk_ids: torch.Tensor,
+    draft_topk_logits: torch.Tensor,
+    draft_sampled: torch.Tensor,
+    pos: torch.Tensor,
+    sampled: torch.Tensor,
+    num_sampled: torch.Tensor,
+) -> None:
+    """Dump one exact B1 selector/target alignment record when requested."""
+    if not envs.VLLM_SPEC_DUMP_ALIGNMENT:
+        return
+    if _diagnostic_rank() != 0:
+        return
+
+    global _SELECTOR_ALIGNMENT_DUMP_COUNT, _SELECTOR_ALIGNMENT_STEP
+    _SELECTOR_ALIGNMENT_STEP += 1
+    if _SELECTOR_ALIGNMENT_DUMP_COUNT >= envs.VLLM_SPEC_DUMP_ALIGNMENT_LIMIT:
+        return
+    selected_steps = _parse_alignment_steps(envs.VLLM_SPEC_DUMP_ALIGNMENT_STEPS)
+    if selected_steps is not None and _SELECTOR_ALIGNMENT_STEP not in selected_steps:
+        return
+
+    shadow = speculator.get_selector_alignment_shadow()
+    if shadow is None:
+        return
+    shadow_ids, unary_logits, lattice_scores = shadow
+    req_state = int(input_batch.idx_mapping_np[0])
+    packed_row = 0
+    sampling_states = rejection_sampler.sampler.sampling_states
+
+    with torch.no_grad():
+        draft_sampled_cpu = draft_sampled.detach().cpu()
+        if bool(torch.all(draft_sampled_cpu == 0).item()):
+            return
+        payload = {
+            "format": "dflash2_selector_alignment_v1",
+            "rank": _diagnostic_rank(),
+            "step": _SELECTOR_ALIGNMENT_STEP,
+            "request_state": req_state,
+            "selector_top_k": speculator.selector_top_k,
+            "num_speculative_steps": speculator.num_speculative_steps,
+            "target_topk_ids": target_topk_ids.detach().cpu(),
+            "target_topk_logits": target_topk_logits.detach().float().cpu(),
+            "draft_candidate_ids": draft_topk_ids[req_state].detach().cpu(),
+            "draft_realized_logits": (
+                draft_topk_logits[req_state].detach().float().cpu()
+            ),
+            "selector_candidate_ids": shadow_ids[packed_row].detach().cpu(),
+            "selector_unary_logits": (unary_logits[packed_row].detach().float().cpu()),
+            "selector_lattice_scores": (
+                lattice_scores[packed_row].detach().float().cpu()
+            ),
+            "draft_sampled": draft_sampled_cpu,
+            "positions": pos.detach().cpu(),
+            "cu_num_logits": input_batch.cu_num_logits.detach().cpu(),
+            "idx_mapping": input_batch.idx_mapping.detach().cpu(),
+            "temperature": float(sampling_states.temperature.np[req_state]),
+            "top_p": float(sampling_states.top_p.np[req_state]),
+            "top_k": int(sampling_states.top_k.np[req_state]),
+            "sampled_token_ids": sampled.detach().cpu(),
+            "num_sampled": num_sampled.detach().cpu(),
+        }
+        _SELECTOR_ALIGNMENT_DUMP_COUNT += 1
+        dump_dir = os.getenv("VLLM_SPEC_DUMP_ALIGNMENT_DIR", "/tmp")
+        os.makedirs(dump_dir, exist_ok=True)
+        tag = _safe_dump_tag(os.getenv("VLLM_SPEC_DUMP_ALIGNMENT_TAG", ""))
+        tag_part = f"{tag}_" if tag else ""
+        dump_path = os.path.join(
+            dump_dir,
+            f"spec_alignment_dflash2_selector_{tag_part}pid{os.getpid()}_"
+            f"step{_SELECTOR_ALIGNMENT_STEP:06d}_"
+            f"{_SELECTOR_ALIGNMENT_DUMP_COUNT}.pt",
+        )
+        torch.save(payload, dump_path)
+        logger.warning("Dumped DFlash2 selector alignment diagnostics to %s", dump_path)
 
 
 def _supports_sparse_sampling_contract(
@@ -117,6 +237,19 @@ def try_dflash2_sparse_target_rejection(
         rejection_sampler.sampler.sampling_states.seeds.gpu,
         rejection_sampler.num_speculative_steps,
         use_fp64=rejection_sampler.sampler.use_fp64_gumbel,
+    )
+    _maybe_dump_selector_alignment(
+        speculator=speculator,
+        rejection_sampler=rejection_sampler,
+        input_batch=input_batch,
+        target_topk_ids=target_topk_ids,
+        target_topk_logits=target_topk_logits,
+        draft_topk_ids=draft_topk_ids,
+        draft_topk_logits=draft_topk_logits,
+        draft_sampled=draft_sampled,
+        pos=pos,
+        sampled=sampled,
+        num_sampled=num_sampled,
     )
     logger.info_once("Using SM70 DFlash2 compact target top-k rejection sampling.")
     return SamplerOutput(

--- a/vllm/v1/worker/gpu/spec_decode/dflash2/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/dflash2/speculator.py
@@ -228,6 +228,29 @@ class DFlash2Speculator(DFlashSpeculator):
         self._selector_path_state = torch.empty(
             self.max_num_reqs, dtype=torch.int32, device=device
         )
+        self._alignment_candidate_ids: torch.Tensor | None = None
+        self._alignment_unary_logits: torch.Tensor | None = None
+        self._alignment_lattice_scores: torch.Tensor | None = None
+        if (
+            envs.VLLM_SPEC_DUMP_ALIGNMENT
+            and envs.VLLM_SM70_DFLASH2_SPARSE_TARGET_REJECTION
+        ):
+            packed_shape = (
+                self.max_num_reqs,
+                self.num_speculative_steps,
+                self.selector_top_k,
+            )
+            self._alignment_candidate_ids = torch.empty(
+                packed_shape, dtype=torch.int64, device=device
+            )
+            self._alignment_unary_logits = torch.empty(
+                packed_shape, dtype=torch.float32, device=device
+            )
+            self._alignment_lattice_scores = torch.empty(
+                (*packed_shape, self.selector_top_k),
+                dtype=torch.float32,
+                device=device,
+            )
         self._use_sm70_tail = _requires_sm70_tail(device, self.num_speculative_steps)
         if self.draft_logits is not None:
             # The cache kernel writes only K columns; all other vocabulary
@@ -322,6 +345,20 @@ class DFlash2Speculator(DFlashSpeculator):
             return None
         return self._cached_candidate_ids, self._cached_candidate_scores
 
+    def get_selector_alignment_shadow(
+        self,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor] | None:
+        """Return packed selector tensors for an explicitly enabled diagnostic."""
+        if self._alignment_candidate_ids is None:
+            return None
+        assert self._alignment_unary_logits is not None
+        assert self._alignment_lattice_scores is not None
+        return (
+            self._alignment_candidate_ids,
+            self._alignment_unary_logits,
+            self._alignment_lattice_scores,
+        )
+
     def _generate_draft(
         self,
         num_reqs: int,
@@ -356,6 +393,12 @@ class DFlash2Speculator(DFlashSpeculator):
             hidden_states,
             anchor_token_ids,
         )
+        if self._alignment_candidate_ids is not None:
+            assert self._alignment_unary_logits is not None
+            assert self._alignment_lattice_scores is not None
+            self._alignment_candidate_ids[:num_reqs].copy_(candidate_ids)
+            self._alignment_unary_logits[:num_reqs].copy_(unary_logits)
+            self._alignment_lattice_scores[:num_reqs].copy_(scores)
         self._sample_path(candidate_ids, scores, num_reqs)
         if self.draft_logits is not None:
             self._cache_draft_logits(candidate_ids, num_sample)


### PR DESCRIPTION
## Purpose

Add explicit, default-off DFlash2 selector alignment capture and an offline analyzer for exact proposal-distribution research. The tooling records the fixed top16 IDs, unary logits, the 7x16x16 selector lattice, realized q rows, target top20 rows, and strict rejection outcomes only when VLLM_SPEC_DUMP_ALIGNMENT is enabled.

This PR does not change the production proposal policy and makes no acceptance or performance claim. It provides the evidence path needed to develop a later default-on optimization.

## Safety

- Disabled diagnostics allocate no shadow lattice and perform no tensor copy; the dump function is gated at the call site.
- Capture remains rank-0, B1 and limit/step filtered under the existing sparse-rejection contract.
- Private artifact paths are not committed.
- Runtime admission depends on SM70, sampler contract and explicit diagnostics, not model/checkpoint identity.

## Test Result

- Merged onto main@9368f49c4679ee8901288f56a329ccb639b2c657.
- CPU DFlash2/analyzer suite: 78 passed, 12 expected CUDA skips.
- All changed-file pre-commit hooks pass, including Ruff, mypy and markdown.
- Real GPU trace, held-out survivor and performance/acceptance claims remain future implementation work.