### PR TITLE
[Bugfix][Frontend][Model] Per-model serving defaults, DeepSeek-OCR resolution modes, and SWA async-eviction fix (SM70)

### DIFF
--- a/tests/entrypoints/openai/test_serving_defaults.py
+++ b/tests/entrypoints/openai/test_serving_defaults.py
@@ -1,0 +1,90 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Per-model serving defaults: fill-in, per-request override, bounds, and
+fail-closed processor validation (DoD: a client gets the model's recipe by
+default without knowing any engine knobs)."""
+
+import pytest
+
+from vllm.entrypoints.openai.serving_defaults import (
+    ModelServingDefaults,
+    get_model_serving_defaults,
+    merge_extra_args,
+    register_model_serving_defaults,
+    validate_required_logits_processors,
+)
+
+pytestmark = pytest.mark.cpu_test
+
+
+def _defaults() -> ModelServingDefaults:
+    return ModelServingDefaults(
+        sampling_defaults={"temperature": 0.0, "skip_special_tokens": False},
+        extra_args_defaults={
+            "ngram_size": 30,
+            "window_size": 90,
+            "whitelist_token_ids": [128821, 128822],
+        },
+        extra_args_bounds={"ngram_size": (1, 512), "window_size": (1, 8192)},
+        required_logits_processors=("pkg.mod.NGramPerReqLogitsProcessor",),
+    )
+
+
+def test_deepseek_ocr_registered_in_core():
+    defaults = get_model_serving_defaults(["DeepseekOCRForCausalLM"])
+    assert defaults is not None
+    assert defaults.extra_args_defaults["ngram_size"] == 30
+    assert defaults.extra_args_defaults["window_size"] == 90
+    assert defaults.sampling_defaults["skip_special_tokens"] is False
+    assert defaults.sampling_defaults["temperature"] == 0.0
+
+
+def test_unknown_architecture_has_no_defaults():
+    assert get_model_serving_defaults(["LlamaForCausalLM"]) is None
+    assert get_model_serving_defaults(None) is None
+
+
+def test_merge_fills_missing_keys():
+    merged = merge_extra_args(_defaults(), None)
+    assert merged["ngram_size"] == 30
+    assert merged["window_size"] == 90
+    assert merged["whitelist_token_ids"] == [128821, 128822]
+
+
+def test_merge_request_overrides_within_bounds():
+    merged = merge_extra_args(_defaults(), {"ngram_size": 20, "other": "x"})
+    assert merged["ngram_size"] == 20  # client override wins
+    assert merged["window_size"] == 90  # default preserved
+    assert merged["other"] == "x"  # unbounded keys pass through
+
+
+@pytest.mark.parametrize("bad", [0, -5, 100000, "30", 3.5, True])
+def test_merge_rejects_out_of_bounds_or_non_integer(bad):
+    with pytest.raises(ValueError):
+        merge_extra_args(_defaults(), {"ngram_size": bad})
+
+
+def test_required_processor_validation_passes_by_qualname_or_class_name():
+    validate_required_logits_processors(
+        _defaults(), ["pkg.mod.NGramPerReqLogitsProcessor"], "m"
+    )
+
+    class NGramPerReqLogitsProcessor:  # matched by bare class name
+        pass
+
+    validate_required_logits_processors(_defaults(), [NGramPerReqLogitsProcessor], "m")
+
+
+def test_required_processor_validation_fails_closed_when_missing():
+    with pytest.raises(ValueError, match="logits processor"):
+        validate_required_logits_processors(_defaults(), None, "m")
+    with pytest.raises(ValueError, match="logits processor"):
+        validate_required_logits_processors(_defaults(), ["OtherProcessor"], "m")
+
+
+def test_register_and_resolve_roundtrip():
+    register_model_serving_defaults(
+        "TestArchForCausalLM", ModelServingDefaults(sampling_defaults={"top_k": 1})
+    )
+    got = get_model_serving_defaults(["OtherArch", "TestArchForCausalLM"])
+    assert got is not None and got.sampling_defaults == {"top_k": 1}

--- a/tests/entrypoints/openai/test_serving_defaults.py
+++ b/tests/entrypoints/openai/test_serving_defaults.py
@@ -88,3 +88,53 @@ def test_register_and_resolve_roundtrip():
     )
     got = get_model_serving_defaults(["OtherArch", "TestArchForCausalLM"])
     assert got is not None and got.sampling_defaults == {"top_k": 1}
+
+
+def test_repetition_detection_default_applied_and_request_wins():
+    from types import SimpleNamespace
+
+    from vllm.entrypoints.openai.serving_defaults import (
+        ModelServingDefaults,
+        apply_repetition_detection_default,
+    )
+    from vllm.sampling_params import RepetitionDetectionParams
+
+    defaults = ModelServingDefaults(
+        repetition_detection_defaults={
+            "max_pattern_size": 60,
+            "min_pattern_size": 2,
+            "min_count": 8,
+        }
+    )
+    # Unset on the request -> default fills in.
+    sp = SimpleNamespace(repetition_detection=None)
+    apply_repetition_detection_default(defaults, sp)
+    assert isinstance(sp.repetition_detection, RepetitionDetectionParams)
+    assert sp.repetition_detection.min_count == 8
+
+    # Request-supplied value always wins.
+    own = RepetitionDetectionParams(
+        max_pattern_size=10, min_pattern_size=1, min_count=2
+    )
+    sp = SimpleNamespace(repetition_detection=own)
+    apply_repetition_detection_default(defaults, sp)
+    assert sp.repetition_detection is own
+
+    # No default configured -> untouched.
+    sp = SimpleNamespace(repetition_detection=None)
+    apply_repetition_detection_default(ModelServingDefaults(), sp)
+    assert sp.repetition_detection is None
+
+
+def test_dsocr_registration_includes_repetition_detection():
+    from vllm.entrypoints.openai.serving_defaults import (
+        get_model_serving_defaults,
+    )
+
+    d = get_model_serving_defaults(["DeepseekOCRForCausalLM"])
+    assert d is not None
+    assert d.repetition_detection_defaults == {
+        "max_pattern_size": 60,
+        "min_pattern_size": 2,
+        "min_count": 8,
+    }

--- a/tests/entrypoints/openai/test_serving_defaults.py
+++ b/tests/entrypoints/openai/test_serving_defaults.py
@@ -138,3 +138,71 @@ def test_dsocr_registration_includes_repetition_detection():
         "min_pattern_size": 2,
         "min_count": 8,
     }
+
+# ---------------------------------------------------------------------------
+# Multi-image request profile (multi-page document parsing recipes).
+# ---------------------------------------------------------------------------
+
+
+def _defaults_with_multi():
+    return ModelServingDefaults(
+        sampling_defaults={"temperature": 0.0},
+        extra_args_defaults={"ngram_size": 35, "window_size": 128},
+        extra_args_bounds={"ngram_size": (1, 128), "window_size": (1, 4096)},
+        extra_args_defaults_multi_image={"ngram_size": 35, "window_size": 1024},
+    )
+
+
+@pytest.mark.parametrize("n", [0, 1])
+def test_multi_profile_single_image_uses_single_defaults(n):
+    merged = merge_extra_args(_defaults_with_multi(), None, num_image_items=n)
+    assert merged["window_size"] == 128
+
+
+def test_multi_profile_selected_for_multi_image_requests():
+    merged = merge_extra_args(_defaults_with_multi(), None, num_image_items=3)
+    assert merged["window_size"] == 1024
+    assert merged["ngram_size"] == 35
+
+
+def test_multi_profile_request_override_still_bounded():
+    merged = merge_extra_args(
+        _defaults_with_multi(), {"window_size": 2048}, num_image_items=2
+    )
+    assert merged["window_size"] == 2048
+    with pytest.raises(ValueError):
+        merge_extra_args(
+            _defaults_with_multi(), {"window_size": 100000}, num_image_items=2
+        )
+
+
+def test_multi_profile_absent_falls_back_to_single():
+    d = ModelServingDefaults(extra_args_defaults={"window_size": 90})
+    assert merge_extra_args(d, None, num_image_items=5)["window_size"] == 90
+    assert d.sampling_defaults_for(5) == d.sampling_defaults
+
+
+def test_count_request_image_items_from_messages():
+    from vllm.entrypoints.openai.chat_completion.serving import (
+        _count_request_image_items,
+    )
+
+    class Req:
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "image_url", "image_url": {"url": "data:x"}},
+                    {"type": "text", "text": "a"},
+                    {"type": "image_url", "image_url": {"url": "data:y"}},
+                ],
+            },
+            {"role": "user", "content": "plain string content"},
+        ]
+
+    assert _count_request_image_items(Req()) == 2
+
+    class Empty:
+        messages = None
+
+    assert _count_request_image_items(Empty()) == 0

--- a/tests/entrypoints/test_ocr_chat_template_golden.py
+++ b/tests/entrypoints/test_ocr_chat_template_golden.py
@@ -1,0 +1,90 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Golden tests for the DeepSeek-OCR chat-template contract.
+
+The OCR checkpoint reports model_type "deepseek_vl_v2"; that model_type's
+fallback template inserts chat role markers and silently changes the OCR
+prompt relative to the validated offline recipe. These goldens pin (a) the
+architecture-keyed resolution to the raw-concatenation OCR template and
+(b) the exact rendered prompt strings for both documented OCR modes.
+"""
+
+import jinja2
+import pytest
+
+from vllm.transformers_utils.chat_templates.registry import (
+    get_chat_template_fallback_path,
+)
+
+pytestmark = pytest.mark.cpu_test
+
+
+def _render(template_path, messages, add_generation_prompt=True):
+    env = jinja2.Environment()  # noqa: S701 (prompt templates, not HTML)
+    env.globals["raise_exception"] = lambda msg: (_ for _ in ()).throw(
+        jinja2.TemplateError(msg)
+    )
+    template = env.from_string(template_path.read_text())
+    return template.render(
+        messages=messages,
+        bos_token="",
+        eos_token="",
+        add_generation_prompt=add_generation_prompt,
+    )
+
+
+def test_ocr_architecture_resolves_ocr_template_despite_vl2_model_type():
+    path = get_chat_template_fallback_path(
+        model_type="deepseek_vl_v2",
+        tokenizer_name_or_path="x",
+        architectures=["DeepseekOCRForCausalLM"],
+    )
+    assert path is not None and path.name == "template_deepseek_ocr.jinja"
+
+
+def test_genuine_vl2_chat_model_keeps_vl2_template():
+    path = get_chat_template_fallback_path(
+        model_type="deepseek_vl_v2",
+        tokenizer_name_or_path="x",
+        architectures=["DeepseekVLV2ForCausalLM"],
+    )
+    assert path is not None and path.name == "template_deepseek_vl2.jinja"
+    # And with no architecture info at all (old call shape), behavior is
+    # unchanged.
+    path = get_chat_template_fallback_path(
+        model_type="deepseek_vl_v2", tokenizer_name_or_path="x"
+    )
+    assert path is not None and path.name == "template_deepseek_vl2.jinja"
+
+
+def test_golden_plain_ocr_prompt_renders_byte_exact():
+    path = get_chat_template_fallback_path(
+        model_type="deepseek_vl_v2",
+        tokenizer_name_or_path="x",
+        architectures=["DeepseekOCRForCausalLM"],
+    )
+    out = _render(path, [{"role": "user", "content": "<image>\nFree OCR. "}])
+    assert out == "<image>\nFree OCR. "
+
+
+def test_golden_grounding_prompt_renders_byte_exact():
+    path = get_chat_template_fallback_path(
+        model_type="deepseek_vl_v2",
+        tokenizer_name_or_path="x",
+        architectures=["DeepseekOCRForCausalLM"],
+    )
+    prompt = "<image>\n<|grounding|>Convert the document to markdown. "
+    out = _render(path, [{"role": "user", "content": prompt}])
+    assert out == prompt
+
+
+def test_negative_control_vl2_template_injects_role_markers():
+    """Proves the goldens discriminate: rendering the same message through
+    the model_type fallback (what serving would do without the arch key)
+    changes the prompt."""
+    path = get_chat_template_fallback_path(
+        model_type="deepseek_vl_v2", tokenizer_name_or_path="x"
+    )
+    out = _render(path, [{"role": "user", "content": "<image>\nFree OCR. "}])
+    assert out != "<image>\nFree OCR. "
+    assert "<|User|>: " in out and "<|Assistant|>: " in out

--- a/tests/transformers_utils/test_deepseek_ocr_resolution_modes.py
+++ b/tests/transformers_utils/test_deepseek_ocr_resolution_modes.py
@@ -1,0 +1,162 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""DeepSeek-OCR resolution modes (R4): per-request ``image_mode`` selection,
+crop parametrization, the multi-image safeguard, and — critically — the
+producer/counter consistency contract (`tokenize_with_images` versus
+`count_image_tokens`), whose violation is the "N multimodal tokens vs M
+placeholders" crash class."""
+
+import os
+
+import pytest
+
+from vllm.transformers_utils.processors.deepseek_ocr import (
+    BASE_SIZE,
+    CROP_MODE,
+    IMAGE_SIZE,
+    RESOLUTION_MODES,
+    DeepseekOCRProcessor,
+    count_image_tokens_for,
+)
+
+DSOCR_PATH = os.environ.get("DSOCR_CHECKPOINT", "/mnt/models/DeepSeek-OCR")
+
+
+# ---------------------------------------------------------------------------
+# Pure-function tests (no tokenizer).
+# ---------------------------------------------------------------------------
+
+
+def test_mode_table_matches_official_config():
+    # Verbatim from the model repo's config.py (captured in the issue refs).
+    assert RESOLUTION_MODES == {
+        "tiny": {"base_size": 512, "image_size": 512, "crop_mode": False},
+        "small": {"base_size": 640, "image_size": 640, "crop_mode": False},
+        "base": {"base_size": 1024, "image_size": 1024, "crop_mode": False},
+        "large": {"base_size": 1280, "image_size": 1280, "crop_mode": False},
+        "gundam": {"base_size": 1024, "image_size": 640, "crop_mode": True},
+    }
+    # The module defaults ARE the gundam mode (byte-compat anchor).
+    assert (BASE_SIZE, IMAGE_SIZE, CROP_MODE) == (1024, 640, True)
+
+
+def _count(mode: str, width: int, height: int, **kw) -> int:
+    cfg = RESOLUTION_MODES[mode]
+    return count_image_tokens_for(
+        image_width=width,
+        image_height=height,
+        base_size=cfg["base_size"],
+        image_size=cfg["image_size"],
+        cropping=cfg["crop_mode"],
+        **kw,
+    )
+
+
+def test_no_crop_modes_are_size_independent():
+    for mode in ("tiny", "small", "base", "large"):
+        assert _count(mode, 100, 100) == _count(mode, 4000, 3000)
+
+
+def test_gundam_small_image_equals_no_crop_arithmetic():
+    # <= image_size on both dims: never cropped, regardless of crop_mode.
+    assert _count("gundam", 640, 480) == count_image_tokens_for(
+        image_width=640,
+        image_height=480,
+        base_size=1024,
+        image_size=640,
+        cropping=False,
+    )
+
+
+def test_gundam_large_image_counts_tiles():
+    assert _count("gundam", 1700, 2200) > _count("gundam", 100, 100)
+
+
+def test_max_crops_bounds_the_tile_count():
+    big = _count("gundam", 4000, 4000, max_crops=9)
+    small = _count("gundam", 4000, 4000, max_crops=2)
+    assert big > small
+
+
+# ---------------------------------------------------------------------------
+# Tokenizer-backed tests (real checkpoint; run on the GPU host, CPU-only).
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def tokenizer():
+    pytest.importorskip("transformers")
+    if not os.path.isdir(DSOCR_PATH):
+        pytest.skip("checkpoint unavailable")
+    from transformers import AutoTokenizer
+
+    return AutoTokenizer.from_pretrained(DSOCR_PATH)
+
+
+def _images(sizes):
+    from PIL import Image
+
+    return [Image.new("RGB", s, color="white") for s in sizes]
+
+
+def test_default_construction_is_gundam_byte_compat(tokenizer):
+    default = DeepseekOCRProcessor(tokenizer=tokenizer)
+    explicit = DeepseekOCRProcessor(tokenizer=tokenizer, image_mode="gundam")
+    for attr in ("base_size", "image_size", "crop_mode", "min_crops", "max_crops"):
+        assert getattr(default, attr) == getattr(explicit, attr)
+    assert default.crop_mode is True and default.image_size == 640
+
+
+def test_invalid_mode_and_crops_raise(tokenizer):
+    with pytest.raises(ValueError, match="image_mode"):
+        DeepseekOCRProcessor(tokenizer=tokenizer, image_mode="giant")
+    with pytest.raises(ValueError, match="crop bounds"):
+        DeepseekOCRProcessor(tokenizer=tokenizer, min_crops=5, max_crops=2)
+
+
+def test_image_mode_authoritative_over_trio(tokenizer):
+    # The processing info always forwards the constant trio; a named mode
+    # must win over it.
+    proc = DeepseekOCRProcessor(
+        tokenizer=tokenizer,
+        image_size=640,
+        base_size=1024,
+        crop_mode=True,
+        image_mode="base",
+    )
+    assert (proc.base_size, proc.image_size, proc.crop_mode) == (1024, 1024, False)
+
+
+@pytest.mark.parametrize("mode", [None, "base", "large", "tiny", "gundam"])
+@pytest.mark.parametrize("size", [(100, 100), (1200, 800), (1000, 2200)])
+def test_producer_counter_consistency(tokenizer, mode, size):
+    kwargs = {} if mode is None else {"image_mode": mode}
+    proc = DeepseekOCRProcessor(tokenizer=tokenizer, **kwargs)
+    out = proc(prompt="<image>\nFree OCR. ", images=_images([size]))
+    produced = int(out["num_image_tokens"][0])
+    counted = proc.count_image_tokens(
+        image_width=size[0], image_height=size[1], num_images=1
+    )
+    assert produced == counted
+
+
+def test_multi_image_guard_disables_crops_consistently(tokenizer):
+    proc = DeepseekOCRProcessor(tokenizer=tokenizer, disable_crop_for_multi_image=True)
+    sizes = [(1200, 800), (1000, 2200)]
+    out = proc(prompt="<image>a<image>b", images=_images(sizes))
+    spatial = out["images_spatial_crop"]
+    assert (spatial <= 1).all(), "multi-image request must not be tiled"
+    for i, size in enumerate(sizes):
+        produced = int(out["num_image_tokens"][i])
+        counted = proc.count_image_tokens(
+            image_width=size[0], image_height=size[1], num_images=len(sizes)
+        )
+        assert produced == counted
+
+
+def test_multi_image_default_keeps_cropping_byte_compat(tokenizer):
+    # DeepSeek-OCR's max_crops=6 is documented safe for multi-image; the
+    # guard defaults OFF so existing behavior is unchanged.
+    proc = DeepseekOCRProcessor(tokenizer=tokenizer)
+    out = proc(prompt="<image>a<image>b", images=_images([(1200, 800)] * 2))
+    assert (out["images_spatial_crop"] > 1).any()

--- a/tests/v1/core/test_kv_cache_utils.py
+++ b/tests/v1/core/test_kv_cache_utils.py
@@ -1394,6 +1394,8 @@ def test_get_max_concurrency_for_kv_cache_config():
         enable_chunked_prefill=True,
         max_model_len=model_config.max_model_len,
         is_encoder_decoder=model_config.is_encoder_decoder,
+        # Pin to sync: SWA per-request bounds grow with overlapping batches.
+        async_scheduling=False,
     )
 
     vllm_config = VllmConfig(

--- a/tests/v1/core/test_prefix_caching.py
+++ b/tests/v1/core/test_prefix_caching.py
@@ -2876,7 +2876,8 @@ def test_can_fit_full_sequence_swa_cap_admits_long_prompt():
     manager = KVCacheManager(
         config,
         max_model_len=max_model_len,
-        max_num_batched_tokens=max_num_batched_tokens,
+        # Single (sync) batch in flight, so in-flight tokens == batched tokens.
+        max_in_flight_tokens=max_num_batched_tokens,
         enable_caching=True,
         hash_block_size=block_size,
     )
@@ -2932,7 +2933,8 @@ def test_can_fit_full_sequence_full_attention_still_gates_oversized():
     manager = KVCacheManager(
         config,
         max_model_len=max_model_len,
-        max_num_batched_tokens=max_num_batched_tokens,
+        # Single (sync) batch in flight, so in-flight tokens == batched tokens.
+        max_in_flight_tokens=max_num_batched_tokens,
         enable_caching=True,
         hash_block_size=block_size,
     )

--- a/tests/v1/core/test_single_type_kv_cache_manager.py
+++ b/tests/v1/core/test_single_type_kv_cache_manager.py
@@ -578,7 +578,7 @@ def test_prefix_anchored_swa_manager_registered():
     block_pool = BlockPool(num_gpu_blocks=100, enable_caching=False, hash_block_size=16)
     manager = get_manager_for_kv_cache_spec(
         spec,
-        max_num_batched_tokens=1024,
+        max_in_flight_tokens=1024,
         max_model_len=4096,
         block_pool=block_pool,
         enable_caching=False,

--- a/tests/v1/core/test_swa_inflight_window_free.py
+++ b/tests/v1/core/test_swa_inflight_window_free.py
@@ -1,0 +1,317 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Out-of-window block frees vs in-flight GPU steps.
+
+With async scheduling / PP, `num_computed_tokens` optimistically includes
+tokens of unprocessed steps whose attention windows still read the blocks
+just below the optimistic boundary (and rejected spec tokens can roll it
+back), so `allocate_slots` frees on the processed-token basis:
+`num_computed_tokens - num_in_flight_tokens`.
+"""
+
+import torch
+
+from vllm.v1.core.sched.output import SchedulerOutput
+from vllm.v1.kv_cache_interface import (
+    ChunkedLocalAttentionSpec,
+    PrefixAnchoredSWASpec,
+    SlidingWindowSpec,
+)
+from vllm.v1.outputs import ModelRunnerOutput
+
+from .utils import create_requests, create_scheduler, mock_kv
+
+NUM_PROMPT_TOKENS = 100
+BLOCK_SIZE = 16
+SLIDING_WINDOW = 16
+# Tokens 0..84 are outside the window of the next token to compute
+# (100 - 16 + 1 = 85), i.e. 5 full blocks.
+NUM_OUT_OF_WINDOW_BLOCKS = 85 // BLOCK_SIZE
+# Chunked-local skips whole chunks left of the current one:
+# (100 // 32) * 32 = 96 settled tokens -> 6 full blocks.
+CHUNK_SIZE = 32
+NUM_OUT_OF_CHUNK_BLOCKS = (NUM_PROMPT_TOKENS // CHUNK_SIZE) * CHUNK_SIZE // BLOCK_SIZE
+
+
+def _make_model_runner_output(
+    scheduler_output: SchedulerOutput,
+    token_id: int = 0,
+) -> ModelRunnerOutput:
+    req_ids = list(scheduler_output.num_scheduled_tokens.keys())
+    return ModelRunnerOutput(
+        req_ids=req_ids,
+        req_id_to_index={req_id: i for i, req_id in enumerate(req_ids)},
+        sampled_token_ids=[[token_id] for _ in req_ids],
+        logprobs=None,
+        prompt_logprobs_dict={},
+        pooler_output=[],
+    )
+
+
+def _create_swa_scheduler(async_scheduling: bool):
+    return create_scheduler(
+        block_size=BLOCK_SIZE,
+        async_scheduling=async_scheduling,
+        kv_cache_spec=SlidingWindowSpec(
+            block_size=BLOCK_SIZE,
+            num_kv_heads=1,
+            head_size=1,
+            dtype=torch.float32,
+            sliding_window=SLIDING_WINDOW,
+        ),
+    )
+
+
+def _create_chunked_scheduler(async_scheduling: bool):
+    return create_scheduler(
+        block_size=BLOCK_SIZE,
+        async_scheduling=async_scheduling,
+        kv_cache_spec=ChunkedLocalAttentionSpec(
+            block_size=BLOCK_SIZE,
+            num_kv_heads=1,
+            head_size=1,
+            dtype=torch.float32,
+            attention_chunk_size=CHUNK_SIZE,
+        ),
+    )
+
+
+def _create_anchored_scheduler(async_scheduling: bool):
+    return create_scheduler(
+        block_size=BLOCK_SIZE,
+        async_scheduling=async_scheduling,
+        enable_prefix_caching=False,
+        kv_cache_spec=PrefixAnchoredSWASpec(
+            block_size=BLOCK_SIZE,
+            num_kv_heads=1,
+            head_size=1,
+            dtype=torch.float32,
+            decode_sliding_window=SLIDING_WINDOW,
+        ),
+    )
+
+
+def _num_null_blocks(scheduler, request_id: str) -> int:
+    manager = scheduler.kv_cache_manager.coordinator.single_type_managers[0]
+    null_block = manager._null_block
+    return sum(1 for b in manager.req_to_blocks[request_id] if b is null_block)
+
+
+def test_num_in_flight_tokens_accounting():
+    scheduler = create_scheduler(async_scheduling=True)
+    request = create_requests(num_requests=1, num_tokens=NUM_PROMPT_TOKENS)[0]
+    scheduler.add_request(request)
+
+    out0 = scheduler.schedule()
+    assert request.num_in_flight_tokens == NUM_PROMPT_TOKENS
+    # Async: decode scheduled before the prefill output is processed.
+    out1 = scheduler.schedule()
+    assert request.num_in_flight_tokens == NUM_PROMPT_TOKENS + 1
+
+    scheduler.update_from_output(out0, _make_model_runner_output(out0))
+    assert request.num_in_flight_tokens == 1
+    scheduler.update_from_output(out1, _make_model_runner_output(out1))
+    assert request.num_in_flight_tokens == 0
+
+
+def test_swa_free_waits_for_in_flight_step():
+    """Async: out-of-window blocks stay allocated until the step that still
+    reads them has been processed."""
+    scheduler = _create_swa_scheduler(async_scheduling=True)
+    request = create_requests(
+        num_requests=1, num_tokens=NUM_PROMPT_TOKENS, block_size=BLOCK_SIZE
+    )[0]
+    scheduler.add_request(request)
+    req_id = request.request_id
+    block_pool = scheduler.kv_cache_manager.block_pool
+
+    out0 = scheduler.schedule()  # prefill, in flight from here on
+    free_after_prefill = block_pool.get_num_free_blocks()
+
+    # Decode scheduled while the prefill still reads the out-of-window blocks:
+    # they must not be freed yet.
+    out1 = scheduler.schedule()
+    assert _num_null_blocks(scheduler, req_id) == 0
+    assert block_pool.get_num_free_blocks() == free_after_prefill
+
+    # Prefill output processed; the next allocate frees the out-of-window
+    # blocks.
+    scheduler.update_from_output(out0, _make_model_runner_output(out0))
+    scheduler.schedule()
+    assert _num_null_blocks(scheduler, req_id) == NUM_OUT_OF_WINDOW_BLOCKS
+    assert (
+        block_pool.get_num_free_blocks()
+        == free_after_prefill + NUM_OUT_OF_WINDOW_BLOCKS
+    )
+    # Not double-freed on the following steps.
+    scheduler.update_from_output(out1, _make_model_runner_output(out1))
+    scheduler.schedule()
+    assert _num_null_blocks(scheduler, req_id) == NUM_OUT_OF_WINDOW_BLOCKS
+
+
+def test_swa_free_immediate_when_sync():
+    """Sync: no in-flight step at schedule time, frees happen at the first
+    decode allocation as before."""
+    scheduler = _create_swa_scheduler(async_scheduling=False)
+    request = create_requests(
+        num_requests=1, num_tokens=NUM_PROMPT_TOKENS, block_size=BLOCK_SIZE
+    )[0]
+    scheduler.add_request(request)
+    req_id = request.request_id
+
+    out0 = scheduler.schedule()
+    scheduler.update_from_output(out0, _make_model_runner_output(out0))
+    assert request.num_in_flight_tokens == 0
+
+    scheduler.schedule()
+    assert _num_null_blocks(scheduler, req_id) == NUM_OUT_OF_WINDOW_BLOCKS
+
+
+def test_anchored_swa_gap_free_waits_for_in_flight_step():
+    """Prefix-anchored SWA (windowed OCR decode): gap blocks between the
+    prefill tail and the decode window are freed on the processed-token
+    basis under async scheduling — an in-flight step whose attention still
+    reads the gap must hold the blocks."""
+    scheduler = _create_anchored_scheduler(async_scheduling=True)
+    request = create_requests(
+        num_requests=1,
+        num_tokens=NUM_PROMPT_TOKENS,
+        block_size=BLOCK_SIZE,
+        max_tokens=200,
+        ignore_eos=True,
+    )[0]
+    scheduler.add_request(request)
+    req_id = request.request_id
+
+    # Prefill, then decode until a full gap block exists on the PROCESSED
+    # basis: gap = [ceil(P/bs), (T - W) // bs) needs T >= 144 for block 7
+    # (P=100 -> first_gap_block 7; (144-16)//16 = 8).
+    out_prev = scheduler.schedule()  # prefill (in flight)
+    scheduler.update_from_output(out_prev, _make_model_runner_output(out_prev))
+    for _ in range(44):  # T: 100 -> 144, settled step by step
+        out = scheduler.schedule()
+        scheduler.update_from_output(out, _make_model_runner_output(out))
+    assert request.num_in_flight_tokens == 0
+    assert request.num_computed_tokens >= 144
+
+    # Async over-scheduling: the settled-basis allocate on this schedule may
+    # evict gap blocks for the SETTLED T.
+    out_a = scheduler.schedule()
+    null_settled = _num_null_blocks(scheduler, req_id)
+    assert null_settled >= 1  # gap eviction engaged at all
+
+    # Second in-flight step: the optimistic boundary advances by 1 token but
+    # the processed basis does not — no additional frees may happen.
+    out_b = scheduler.schedule()
+    assert _num_null_blocks(scheduler, req_id) == null_settled
+
+    scheduler.update_from_output(out_a, _make_model_runner_output(out_a))
+    scheduler.update_from_output(out_b, _make_model_runner_output(out_b))
+
+
+def test_swa_admission_cap_accounts_for_overlapping_batches():
+    spec = SlidingWindowSpec(
+        block_size=16,
+        num_kv_heads=1,
+        head_size=1,
+        dtype=torch.float32,
+        sliding_window=1024,
+    )
+    base = spec.max_admission_blocks_per_request(
+        max_in_flight_tokens=1024, max_model_len=16384
+    )
+    # (1024 - 1 + 1024) tokens -> 128 blocks, +1 for window misalignment.
+    assert base == 129
+    overlapped = spec.max_admission_blocks_per_request(
+        max_in_flight_tokens=2 * 1024, max_model_len=16384
+    )
+    # One extra in-flight chunk is held back: (1024 - 1 + 2 * 1024) tokens.
+    assert overlapped == 193
+
+
+def test_chunked_local_free_waits_for_in_flight_step():
+    """Chunked-local attention frees whole chunks left of the current one, and
+    is exposed to the same load-WAR: with async scheduling those chunks must
+    stay allocated until the in-flight step that still reads them settles."""
+    scheduler = _create_chunked_scheduler(async_scheduling=True)
+    request = create_requests(
+        num_requests=1, num_tokens=NUM_PROMPT_TOKENS, block_size=BLOCK_SIZE
+    )[0]
+    scheduler.add_request(request)
+    req_id = request.request_id
+    block_pool = scheduler.kv_cache_manager.block_pool
+
+    out0 = scheduler.schedule()  # prefill, in flight from here on
+    free_after_prefill = block_pool.get_num_free_blocks()
+
+    # Decode scheduled while the prefill still reads the out-of-chunk blocks.
+    out1 = scheduler.schedule()
+    assert _num_null_blocks(scheduler, req_id) == 0
+    assert block_pool.get_num_free_blocks() == free_after_prefill
+
+    # Prefill output processed; the next allocate frees the out-of-chunk blocks.
+    scheduler.update_from_output(out0, _make_model_runner_output(out0))
+    scheduler.schedule()
+    assert _num_null_blocks(scheduler, req_id) == NUM_OUT_OF_CHUNK_BLOCKS
+    assert (
+        block_pool.get_num_free_blocks() == free_after_prefill + NUM_OUT_OF_CHUNK_BLOCKS
+    )
+    # Not double-freed on the following steps.
+    scheduler.update_from_output(out1, _make_model_runner_output(out1))
+    scheduler.schedule()
+    assert _num_null_blocks(scheduler, req_id) == NUM_OUT_OF_CHUNK_BLOCKS
+
+
+def test_chunked_local_admission_cap_accounts_for_overlapping_batches():
+    spec = ChunkedLocalAttentionSpec(
+        block_size=16,
+        num_kv_heads=1,
+        head_size=1,
+        dtype=torch.float32,
+        attention_chunk_size=1024,
+    )
+    base = spec.max_admission_blocks_per_request(
+        max_in_flight_tokens=1024, max_model_len=16384
+    )
+    # (1024 + 1024) tokens -> 128 blocks.
+    assert base == 128
+    overlapped = spec.max_admission_blocks_per_request(
+        max_in_flight_tokens=2 * 1024, max_model_len=16384
+    )
+    # One extra in-flight chunk is held back: (1024 + 2 * 1024) tokens.
+    assert overlapped == 192
+
+
+def test_connector_finish_frees_on_settled_basis():
+    """The out-of-window prune done at request finish, before the block table
+    is handed to a KV connector, must use the same processed-token basis."""
+    scheduler = create_scheduler(
+        block_size=BLOCK_SIZE,
+        async_scheduling=True,
+        use_kv_connector=mock_kv(matched_tokens=0, is_async=False),
+        kv_cache_spec=SlidingWindowSpec(
+            block_size=BLOCK_SIZE,
+            num_kv_heads=1,
+            head_size=1,
+            dtype=torch.float32,
+            sliding_window=SLIDING_WINDOW,
+        ),
+    )
+    request = create_requests(
+        num_requests=1, num_tokens=NUM_PROMPT_TOKENS, block_size=BLOCK_SIZE
+    )[0]
+    scheduler.add_request(request)
+    req_id = request.request_id
+
+    out0 = scheduler.schedule()  # prefill, in flight from here on
+    scheduler.schedule()  # decode over-scheduled: num_computed_tokens optimistic
+
+    # Finishing now (connector store) must NOT prune out-of-window blocks the
+    # in-flight prefill still reads.
+    scheduler._connector_finished(request)
+    assert _num_null_blocks(scheduler, req_id) == 0
+
+    # Once the in-flight step settles, the same prune releases them.
+    scheduler.update_from_output(out0, _make_model_runner_output(out0))
+    scheduler._connector_finished(request)
+    assert _num_null_blocks(scheduler, req_id) == NUM_OUT_OF_WINDOW_BLOCKS

--- a/tests/v1/core/utils.py
+++ b/tests/v1/core/utils.py
@@ -28,6 +28,7 @@ from vllm.v1.kv_cache_interface import (
     FullAttentionSpec,
     KVCacheConfig,
     KVCacheGroupSpec,
+    KVCacheSpec,
 )
 from vllm.v1.request import Request
 from vllm.v1.structured_output import StructuredOutputManager
@@ -57,6 +58,7 @@ def create_scheduler(
     pipeline_parallel_size: int = 1,
     use_ec_connector: bool = False,
     ec_role: str | None = None,
+    kv_cache_spec: KVCacheSpec | None = None,
 ) -> Scheduler | AsyncScheduler:
     """Create scheduler under test.
 
@@ -144,20 +146,17 @@ def create_scheduler(
         speculative_config=speculative_config,
         ec_transfer_config=ec_transfer_config,
     )
+    if kv_cache_spec is None:
+        kv_cache_spec = FullAttentionSpec(
+            block_size=block_size,
+            num_kv_heads=1,
+            head_size=1,
+            dtype=torch.float32,
+        )
     kv_cache_config = KVCacheConfig(
         num_blocks=num_blocks,  # A large number of blocks to hold all requests
         kv_cache_tensors=[],
-        kv_cache_groups=[
-            KVCacheGroupSpec(
-                ["layer"],
-                FullAttentionSpec(
-                    block_size=block_size,
-                    num_kv_heads=1,
-                    head_size=1,
-                    dtype=torch.float32,
-                ),
-            )
-        ],
+        kv_cache_groups=[KVCacheGroupSpec(["layer"], kv_cache_spec)],
     )
     cache_config.num_gpu_blocks = num_blocks
     scheduler_cls = AsyncScheduler if async_scheduling else Scheduler

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -601,6 +601,28 @@ class VllmConfig:
         return hash_str
 
     @property
+    def max_concurrent_batches(self) -> int:
+        # Scheduler-side upper bound mirroring the executors'
+        # `max_concurrent_batches` (multiproc: queue depth under async
+        # scheduling, else the PP pipeline depth).
+        pp_size = self.parallel_config.pipeline_parallel_size
+        if pp_size <= 1 and self.scheduler_config.async_scheduling:
+            return max(2, envs.VLLM_SM70_ASYNC_SCHEDULING_QUEUE_DEPTH)
+        return pp_size
+
+    @property
+    def max_in_flight_tokens(self) -> int:
+        # Upper bound on tokens that are scheduled but not yet settled (freed):
+        # every concurrent batch may hold up to a full `max_num_batched_tokens`.
+        # Recycling-aware KV cache specs (sliding-window, chunked-local,
+        # prefix-anchored SWA) reserve for this because out-of-window blocks
+        # are freed on the processed-token basis, so in-flight steps
+        # transiently keep their blocks.
+        return (
+            self.max_concurrent_batches * self.scheduler_config.max_num_batched_tokens
+        )
+
+    @property
     def num_speculative_tokens(self) -> int:
         if (
             self.speculative_config is not None

--- a/vllm/entrypoints/openai/chat_completion/protocol.py
+++ b/vllm/entrypoints/openai/chat_completion/protocol.py
@@ -243,7 +243,7 @@ class ChatCompletionRequest(OpenAIBaseModel):
     include_stop_str_in_output: bool = False
     ignore_eos: bool = False
     min_tokens: int = 0
-    skip_special_tokens: bool = True
+    skip_special_tokens: bool | None = None
     spaces_between_special_tokens: bool = True
     truncate_prompt_tokens: Annotated[int, Field(ge=-1, le=_INT64_MAX)] | None = None
     truncation_side: Literal["left", "right"] | None = Field(
@@ -571,6 +571,10 @@ class ChatCompletionRequest(OpenAIBaseModel):
             min_p = default_sampling_params.get(
                 "min_p", self._DEFAULT_SAMPLING_PARAMS["min_p"]
             )
+        if (skip_special_tokens := self.skip_special_tokens) is None:
+            skip_special_tokens = default_sampling_params.get(
+                "skip_special_tokens", True
+            )
 
         prompt_logprobs = self.prompt_logprobs
         if prompt_logprobs is None and self.echo:
@@ -629,7 +633,7 @@ class ChatCompletionRequest(OpenAIBaseModel):
             ignore_eos=self.ignore_eos,
             max_tokens=max_tokens,
             min_tokens=self.min_tokens,
-            skip_special_tokens=self.skip_special_tokens,
+            skip_special_tokens=skip_special_tokens,
             spaces_between_special_tokens=self.spaces_between_special_tokens,
             include_stop_str_in_output=self.include_stop_str_in_output,
             output_kind=RequestOutputKind.DELTA

--- a/vllm/entrypoints/openai/chat_completion/serving.py
+++ b/vllm/entrypoints/openai/chat_completion/serving.py
@@ -61,6 +61,11 @@ from vllm.entrypoints.openai.parser.harmony_utils import (
     get_streamable_parser_for_assistant,
     parse_chat_output,
 )
+from vllm.entrypoints.openai.serving_defaults import (
+    get_model_serving_defaults,
+    merge_extra_args,
+    validate_required_logits_processors,
+)
 from vllm.entrypoints.openai.utils import maybe_filter_parallel_tool_calls
 from vllm.entrypoints.utils import get_max_tokens, should_include_usage
 from vllm.inputs import EngineInput
@@ -151,6 +156,20 @@ class OpenAIServingChat(OpenAIServing):
         self.enable_prompt_tokens_details = enable_prompt_tokens_details
         self.enable_force_include_usage = enable_force_include_usage
         self.default_sampling_params = self.model_config.get_diff_sampling_param()
+        # Per-model serving recipe (e.g. document-OCR models): fill sampling
+        # defaults the hub generation_config does not provide, and fail loudly
+        # at startup when a recipe-required logits processor is not loaded.
+        self.model_serving_defaults = get_model_serving_defaults(
+            getattr(self.model_config, "architectures", None)
+        )
+        if self.model_serving_defaults is not None:
+            for key, value in self.model_serving_defaults.sampling_defaults.items():
+                self.default_sampling_params.setdefault(key, value)
+            validate_required_logits_processors(
+                self.model_serving_defaults,
+                self.model_config.logits_processors,
+                self.model_config.model,
+            )
         mc = self.model_config
         self.override_max_tokens = (
             self.default_sampling_params.get("max_tokens")
@@ -310,6 +329,14 @@ class OpenAIServingChat(OpenAIServing):
                     max_tokens,
                     self.default_sampling_params,
                 )
+                if self.model_serving_defaults is not None:
+                    try:
+                        merged = merge_extra_args(
+                            self.model_serving_defaults, sampling_params.extra_args
+                        )
+                    except ValueError as e:
+                        return self.create_error_response(str(e))
+                    sampling_params.extra_args = merged or None
 
             self._log_inputs(
                 sub_request_id,

--- a/vllm/entrypoints/openai/chat_completion/serving.py
+++ b/vllm/entrypoints/openai/chat_completion/serving.py
@@ -299,6 +299,7 @@ class OpenAIServingChat(OpenAIServing):
 
         # Schedule the request and get the result generator.
         max_model_len = self.model_config.max_model_len
+        num_image_items = _count_request_image_items(request)
         generators: list[AsyncGenerator[RequestOutput, None]] = []
         for i, engine_input in enumerate(engine_inputs):
             prompt_token_ids = self._extract_prompt_components(engine_input).token_ids
@@ -333,7 +334,9 @@ class OpenAIServingChat(OpenAIServing):
                 if self.model_serving_defaults is not None:
                     try:
                         merged = merge_extra_args(
-                            self.model_serving_defaults, sampling_params.extra_args
+                            self.model_serving_defaults,
+                            sampling_params.extra_args,
+                            num_image_items=num_image_items,
                         )
                     except ValueError as e:
                         return self.create_error_response(str(e))
@@ -341,6 +344,19 @@ class OpenAIServingChat(OpenAIServing):
                     apply_repetition_detection_default(
                         self.model_serving_defaults, sampling_params
                     )
+
+                    # Multi-image sampling profile: apply only the fields the
+                    # request did not set itself (single-image defaults were
+                    # already folded into default_sampling_params at init).
+                    if num_image_items > 1:
+                        multi = (
+                            self.model_serving_defaults.sampling_defaults_multi_image
+                        )
+                        for key, value in (multi or {}).items():
+                            if getattr(request, key, None) is None and hasattr(
+                                sampling_params, key
+                            ):
+                                setattr(sampling_params, key, value)
 
             self._log_inputs(
                 sub_request_id,
@@ -1627,3 +1643,35 @@ class OpenAIServingChat(OpenAIServing):
                 )
             ]
         )
+
+
+def _count_request_image_items(request: ChatCompletionRequest) -> int:
+    """Number of image items in the request messages.
+
+    Selects the serving-defaults profile (single vs multi page); counting is
+    done on the raw messages so it is independent of prompt preprocessing.
+    """
+    count = 0
+    messages = getattr(request, "messages", None) or []
+    for message in messages:
+        content = (
+            message.get("content")
+            if isinstance(message, dict)
+            else getattr(message, "content", None)
+        )
+        if not isinstance(content, list):
+            continue
+        for part in content:
+            part_type = (
+                part.get("type")
+                if isinstance(part, dict)
+                else getattr(part, "type", None)
+            )
+            if part_type in (
+                "image_url",
+                "input_image",
+                "image_embeds",
+                "image_pil",
+            ):
+                count += 1
+    return count

--- a/vllm/entrypoints/openai/chat_completion/serving.py
+++ b/vllm/entrypoints/openai/chat_completion/serving.py
@@ -62,6 +62,7 @@ from vllm.entrypoints.openai.parser.harmony_utils import (
     parse_chat_output,
 )
 from vllm.entrypoints.openai.serving_defaults import (
+    apply_repetition_detection_default,
     get_model_serving_defaults,
     merge_extra_args,
     validate_required_logits_processors,
@@ -337,6 +338,9 @@ class OpenAIServingChat(OpenAIServing):
                     except ValueError as e:
                         return self.create_error_response(str(e))
                     sampling_params.extra_args = merged or None
+                    apply_repetition_detection_default(
+                        self.model_serving_defaults, sampling_params
+                    )
 
             self._log_inputs(
                 sub_request_id,

--- a/vllm/entrypoints/openai/serving_defaults.py
+++ b/vllm/entrypoints/openai/serving_defaults.py
@@ -56,6 +56,22 @@ class ModelServingDefaults:
     # tokens. A request-supplied value always wins.
     repetition_detection_defaults: dict[str, int] | None = None
 
+    # Optional multi-image request profile (e.g. multi-page document
+    # parsing uses a different anti-repetition window). ``None`` falls back
+    # to the single-image values above. Bounds apply to both profiles.
+    sampling_defaults_multi_image: dict[str, Any] | None = None
+    extra_args_defaults_multi_image: dict[str, Any] | None = None
+
+    def sampling_defaults_for(self, num_image_items: int) -> dict[str, Any]:
+        if num_image_items > 1 and self.sampling_defaults_multi_image is not None:
+            return self.sampling_defaults_multi_image
+        return self.sampling_defaults
+
+    def extra_args_defaults_for(self, num_image_items: int) -> dict[str, Any]:
+        if num_image_items > 1 and self.extra_args_defaults_multi_image is not None:
+            return self.extra_args_defaults_multi_image
+        return self.extra_args_defaults
+
 
 _REGISTRY: dict[str, ModelServingDefaults] = {}
 
@@ -129,13 +145,17 @@ def apply_repetition_detection_default(defaults, sampling_params) -> None:
 def merge_extra_args(
     defaults: ModelServingDefaults,
     request_xargs: Mapping[str, Any] | None,
+    *,
+    num_image_items: int = 1,
 ) -> dict[str, Any]:
     """Overlay request ``vllm_xargs`` on the model's recipe defaults.
 
     Request keys win; integer keys with registered bounds are validated and
     a ValueError (surfaced as HTTP 400) is raised for out-of-range values.
+    The defaults profile is selected by the request's image count (multi-page
+    recipes may use e.g. a different anti-repetition window).
     """
-    merged: dict[str, Any] = dict(defaults.extra_args_defaults)
+    merged: dict[str, Any] = dict(defaults.extra_args_defaults_for(num_image_items))
     for key, value in (request_xargs or {}).items():
         bounds = defaults.extra_args_bounds.get(key)
         if bounds is not None:
@@ -192,5 +212,8 @@ register_model_serving_defaults(
         required_logits_processors=(
             "vllm.model_executor.models.deepseek_ocr.NGramPerReqLogitsProcessor",
         ),
+        # The DeepSeek-OCR README documents a single recipe with no
+        # multi-page variant — the single-image profile applies to any
+        # image count (multi profiles stay None).
     ),
 )

--- a/vllm/entrypoints/openai/serving_defaults.py
+++ b/vllm/entrypoints/openai/serving_defaults.py
@@ -1,0 +1,165 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Per-model serving defaults for the OpenAI-compatible endpoints.
+
+Some models are only correct when served with a specific decoding recipe
+(e.g. document-OCR models require their anti-repetition logits processor and
+``skip_special_tokens=False``). This registry lets the serving layer apply a
+model's recipe by default — a client gets correct, deterministic output
+without knowing any engine knobs — while still allowing per-request
+overrides through the existing request fields (``vllm_xargs``,
+``skip_special_tokens``, ...), clamped to registered bounds so a public API
+cannot be abused with pathological parameter values.
+
+Plugins register defaults for their models at import time via
+:func:`register_model_serving_defaults`; in-tree models register below.
+"""
+
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass, field
+from typing import Any
+
+from vllm.logger import init_logger
+
+logger = init_logger(__name__)
+
+
+@dataclass(frozen=True)
+class ModelServingDefaults:
+    """Serving-layer recipe for one model architecture."""
+
+    # Fill-in values for sampling fields the request left unset. Only keys
+    # understood by the protocol's `default_sampling_params` channel are
+    # meaningful here (e.g. "temperature", "skip_special_tokens").
+    sampling_defaults: dict[str, Any] = field(default_factory=dict)
+
+    # Default `SamplingParams.extra_args` entries (e.g. the anti-repetition
+    # processor parameters). Request-supplied `vllm_xargs` keys win, subject
+    # to `extra_args_bounds`.
+    extra_args_defaults: dict[str, Any] = field(default_factory=dict)
+
+    # Inclusive (lo, hi) bounds for integer `vllm_xargs` keys a client may
+    # override. Values outside the bounds are rejected (HTTP 400), not
+    # silently clamped, so misconfigured clients notice.
+    extra_args_bounds: dict[str, tuple[int, int]] = field(default_factory=dict)
+
+    # Fully-qualified names (or bare class names) of logits processors that
+    # MUST be loaded in the engine for this model's recipe to hold. Startup
+    # fails loudly when one is missing, instead of serving silently-degraded
+    # output.
+    required_logits_processors: tuple[str, ...] = ()
+
+
+_REGISTRY: dict[str, ModelServingDefaults] = {}
+
+
+def register_model_serving_defaults(
+    architecture: str, defaults: ModelServingDefaults
+) -> None:
+    """Register (or replace) the serving defaults for a model architecture."""
+    if architecture in _REGISTRY:
+        logger.warning(
+            "Overriding serving defaults previously registered for %s.",
+            architecture,
+        )
+    _REGISTRY[architecture] = defaults
+
+
+def get_model_serving_defaults(
+    architectures: Iterable[str] | None,
+) -> ModelServingDefaults | None:
+    """Resolve defaults for the first registered architecture, if any."""
+    for arch in architectures or ():
+        defaults = _REGISTRY.get(arch)
+        if defaults is not None:
+            return defaults
+    return None
+
+
+def _matches_processor(entry: Any, required: str) -> bool:
+    name = entry if isinstance(entry, str) else getattr(entry, "__name__", "")
+    short = required.rsplit(":", 1)[-1].rsplit(".", 1)[-1]
+    return name == required or name.rsplit(":", 1)[-1].rsplit(".", 1)[-1] == short
+
+
+def validate_required_logits_processors(
+    defaults: ModelServingDefaults,
+    loaded_processors: list[Any] | None,
+    model_name: str,
+) -> None:
+    """Fail startup when the model's recipe processors are not loaded.
+
+    The processors are loaded through the engine's ``--logits-processors``
+    channel; the serving defaults only supply their per-request parameters.
+    Serving without the processor would produce the documented looping
+    behavior with no visible error, so this is fail-closed.
+    """
+    for required in defaults.required_logits_processors:
+        if not any(
+            _matches_processor(entry, required) for entry in (loaded_processors or [])
+        ):
+            raise ValueError(
+                f"Model {model_name} requires the logits processor "
+                f"{required!r} for correct serving, but it is not loaded. "
+                f"Start the server with --logits-processors {required}."
+            )
+
+
+def merge_extra_args(
+    defaults: ModelServingDefaults,
+    request_xargs: Mapping[str, Any] | None,
+) -> dict[str, Any]:
+    """Overlay request ``vllm_xargs`` on the model's recipe defaults.
+
+    Request keys win; integer keys with registered bounds are validated and
+    a ValueError (surfaced as HTTP 400) is raised for out-of-range values.
+    """
+    merged: dict[str, Any] = dict(defaults.extra_args_defaults)
+    for key, value in (request_xargs or {}).items():
+        bounds = defaults.extra_args_bounds.get(key)
+        if bounds is not None:
+            lo, hi = bounds
+            if isinstance(value, bool) or not isinstance(value, int):
+                raise ValueError(
+                    f"vllm_xargs[{key!r}] must be an integer in "
+                    f"[{lo}, {hi}], got {value!r}."
+                )
+            if not lo <= value <= hi:
+                raise ValueError(
+                    f"vllm_xargs[{key!r}]={value} is outside the allowed "
+                    f"range [{lo}, {hi}] for this model."
+                )
+        merged[key] = value
+    return merged
+
+
+# --------------------------------------------------------------------------
+# In-tree registrations.
+# --------------------------------------------------------------------------
+
+# DeepSeek-OCR: the checkpoint README's serving recipe. The anti-repetition
+# processor is mandatory per the model's documentation ("prevent looping on
+# coordinate tokens"); `skip_special_tokens=False` and greedy decoding are
+# part of the transcription contract. Values: ngram_size=30, window_size=90,
+# whitelist = {<td>, </td>} token ids.
+register_model_serving_defaults(
+    "DeepseekOCRForCausalLM",
+    ModelServingDefaults(
+        sampling_defaults={
+            "temperature": 0.0,
+            "skip_special_tokens": False,
+        },
+        extra_args_defaults={
+            "ngram_size": 30,
+            "window_size": 90,
+            "whitelist_token_ids": [128821, 128822],
+        },
+        extra_args_bounds={
+            "ngram_size": (1, 512),
+            "window_size": (1, 8192),
+        },
+        required_logits_processors=(
+            "vllm.model_executor.models.deepseek_ocr.NGramPerReqLogitsProcessor",
+        ),
+    ),
+)

--- a/vllm/entrypoints/openai/serving_defaults.py
+++ b/vllm/entrypoints/openai/serving_defaults.py
@@ -49,6 +49,13 @@ class ModelServingDefaults:
     # output.
     required_logits_processors: tuple[str, ...] = ()
 
+    # Kwargs for SamplingParams.repetition_detection applied when the request
+    # does not set the field. Safety net for degeneration patterns that evade
+    # the n-gram processor (e.g. slow-drift table loops longer than its ban
+    # window): generation terminates instead of producing thousands of junk
+    # tokens. A request-supplied value always wins.
+    repetition_detection_defaults: dict[str, int] | None = None
+
 
 _REGISTRY: dict[str, ModelServingDefaults] = {}
 
@@ -105,6 +112,20 @@ def validate_required_logits_processors(
             )
 
 
+def apply_repetition_detection_default(defaults, sampling_params) -> None:
+    """Fill SamplingParams.repetition_detection from the model defaults when
+    the request left it unset."""
+    if (
+        defaults.repetition_detection_defaults
+        and getattr(sampling_params, "repetition_detection", None) is None
+    ):
+        from vllm.sampling_params import RepetitionDetectionParams
+
+        sampling_params.repetition_detection = RepetitionDetectionParams(
+            **defaults.repetition_detection_defaults
+        )
+
+
 def merge_extra_args(
     defaults: ModelServingDefaults,
     request_xargs: Mapping[str, Any] | None,
@@ -157,6 +178,16 @@ register_model_serving_defaults(
         extra_args_bounds={
             "ngram_size": (1, 512),
             "window_size": (1, 8192),
+        },
+        # Grounded in the observed failure (arXiv page-09 endpoint battery,
+        # w13): near-identical empty table rows repeated for ~6.5k tokens,
+        # evading the 90-token n-gram ban window. min_count=8 keeps legitimate
+        # dense tables (separators repeat, but full-row patterns rarely repeat
+        # 8x identically) while terminating clear degeneration.
+        repetition_detection_defaults={
+            "max_pattern_size": 60,
+            "min_pattern_size": 2,
+            "min_count": 8,
         },
         required_logits_processors=(
             "vllm.model_executor.models.deepseek_ocr.NGramPerReqLogitsProcessor",

--- a/vllm/model_executor/models/deepseek_ocr.py
+++ b/vllm/model_executor/models/deepseek_ocr.py
@@ -2,7 +2,6 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """Inference-only Deepseek-OCR model compatible with HuggingFace weights."""
 
-import math
 from collections.abc import Iterable, Mapping, Sequence
 from typing import Annotated, Literal
 
@@ -53,7 +52,7 @@ from vllm.transformers_utils.processors.deepseek_ocr import (
     BASE_SIZE,
     CROP_MODE,
     DeepseekOCRProcessor,
-    count_tiles,
+    count_image_tokens_for,
 )
 from vllm.utils.tensor_schema import TensorSchema, TensorShape
 from vllm.v1.sample.logits_processor import (
@@ -190,12 +189,15 @@ class DeepseekOCRProcessingInfo(BaseProcessingInfo):
         return self.ctx.get_hf_config(DeepseekVLV2Config)
 
     def get_hf_processor(self, **kwargs: object):
-        v1_processor_config = dict(
-            image_size=IMAGE_SIZE,
-            base_size=BASE_SIZE,
-            crop_mode=CROP_MODE,
-            strategy="v1",
-        )
+        v1_processor_config: dict[str, object] = dict(strategy="v1")
+        if "image_mode" not in kwargs:
+            # Only inject the constant trio when no named mode is requested;
+            # the processor treats ``image_mode`` as authoritative.
+            v1_processor_config.update(
+                image_size=IMAGE_SIZE,
+                base_size=BASE_SIZE,
+                crop_mode=CROP_MODE,
+            )
 
         return self.ctx.get_hf_processor(
             DeepseekOCRProcessor,
@@ -208,35 +210,13 @@ class DeepseekOCRProcessingInfo(BaseProcessingInfo):
     def get_num_image_tokens(
         self, *, image_width: int, image_height: int, cropping: bool = True
     ) -> int:
-        image_size = IMAGE_SIZE
-        base_size = BASE_SIZE
-        patch_size = 16
-        downsample_ratio = 4
-
-        if CROP_MODE:
-            if image_width <= 640 and image_height <= 640:
-                crop_ratio = [1, 1]
-            else:
-                # find the closest aspect ratio to the target
-                crop_ratio = count_tiles(
-                    image_width, image_height, image_size=IMAGE_SIZE
-                )
-
-            num_width_tiles, num_height_tiles = crop_ratio
-        else:
-            num_width_tiles = num_height_tiles = 1
-
-        h = w = math.ceil((base_size // patch_size) / downsample_ratio)
-
-        h2 = w2 = math.ceil((image_size // patch_size) / downsample_ratio)
-
-        global_views_tokens = h * (w + 1)
-        if num_width_tiles > 1 or num_height_tiles > 1:
-            local_views_tokens = (num_height_tiles * h2) * (num_width_tiles * w2 + 1)
-        else:
-            local_views_tokens = 0
-
-        return global_views_tokens + local_views_tokens + 1
+        return count_image_tokens_for(
+            image_width=image_width,
+            image_height=image_height,
+            base_size=BASE_SIZE,
+            image_size=IMAGE_SIZE,
+            cropping=cropping and CROP_MODE,
+        )
 
     def get_image_size_with_most_features(self) -> ImageSize:
         if IMAGE_SIZE == 1024 and BASE_SIZE == 1280:
@@ -334,10 +314,13 @@ class DeepseekOCRMultiModalProcessor(
             else:
                 size = images.get_image_size(item_idx)
 
-                num_image_tokens = self.info.get_num_image_tokens(
+                # Count with the SAME processor instance the request's
+                # mm kwargs construct (mode/crops), and the same sibling
+                # count — the producer/counter pair must never diverge.
+                num_image_tokens = hf_processor.count_image_tokens(
                     image_width=size.width,
                     image_height=size.height,
-                    cropping=CROP_MODE,
+                    num_images=images.get_count(),
                 )
             return [image_token_id] * num_image_tokens
 

--- a/vllm/renderers/hf.py
+++ b/vllm/renderers/hf.py
@@ -298,6 +298,7 @@ def resolve_chat_template(
     path = get_chat_template_fallback_path(
         model_type=model_config.hf_config.model_type,
         tokenizer_name_or_path=tokenizer.name_or_path,
+        architectures=getattr(model_config, "architectures", None),
     )
     if path is not None:
         logger.info_once(

--- a/vllm/transformers_utils/chat_templates/registry.py
+++ b/vllm/transformers_utils/chat_templates/registry.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-from collections.abc import Callable
+from collections.abc import Callable, Iterable
 from pathlib import Path
 from typing import TypeAlias
 
@@ -46,6 +46,34 @@ _MODEL_TYPE_TO_CHAT_TEMPLATE_FALLBACK: dict[str, ChatTemplatePath] = {
     "siglip2": CHAT_TEMPLATES_DIR / "template_basic.jinja",
 }
 
+# Architecture-keyed fallbacks take precedence over model_type ones: some
+# checkpoints reuse another family's model_type while needing a different
+# prompt contract. DeepSeek-OCR reports model_type "deepseek_vl_v2", whose
+# fallback template inserts chat role markers ("<|User|>: ...") and would
+# silently change the OCR prompt relative to the offline recipe; the OCR
+# architecture must resolve the raw-concatenation OCR template instead.
+# Keyed by architecture so genuine DeepSeek-VL2 chat checkpoints (same
+# model_type, different architecture) keep their chat template.
+_ARCH_TO_CHAT_TEMPLATE_FALLBACK: dict[str, ChatTemplatePath] = {
+    "DeepseekOCRForCausalLM": CHAT_TEMPLATES_DIR / "template_deepseek_ocr.jinja",
+}
+
+
+def register_chat_template_fallback_path_for_arch(
+    architecture: str,
+    chat_template: ChatTemplatePath,
+) -> None:
+    """Register an architecture-keyed chat template fallback (plugins too)."""
+    if architecture in _ARCH_TO_CHAT_TEMPLATE_FALLBACK:
+        logger.warning(
+            "Architecture %s already has a chat template registered. "
+            "It will be overwritten by the new chat template %s.",
+            architecture,
+            chat_template,
+        )
+
+    _ARCH_TO_CHAT_TEMPLATE_FALLBACK[architecture] = chat_template
+
 
 def register_chat_template_fallback_path(
     model_type: str,
@@ -65,8 +93,15 @@ def register_chat_template_fallback_path(
 def get_chat_template_fallback_path(
     model_type: str,
     tokenizer_name_or_path: str,
+    architectures: Iterable[str] | None = None,
 ) -> Path | None:
-    chat_template = _MODEL_TYPE_TO_CHAT_TEMPLATE_FALLBACK.get(model_type)
+    chat_template: ChatTemplatePath | None = None
+    for arch in architectures or ():
+        chat_template = _ARCH_TO_CHAT_TEMPLATE_FALLBACK.get(arch)
+        if chat_template is not None:
+            break
+    if chat_template is None:
+        chat_template = _MODEL_TYPE_TO_CHAT_TEMPLATE_FALLBACK.get(model_type)
     if callable(chat_template):
         chat_template = chat_template(tokenizer_name_or_path)
 

--- a/vllm/transformers_utils/processors/deepseek_ocr.py
+++ b/vllm/transformers_utils/processors/deepseek_ocr.py
@@ -11,18 +11,23 @@ from PIL import Image, ImageOps
 from transformers import BatchFeature, LlamaTokenizerFast
 from transformers.processing_utils import ProcessorMixin
 
-# TODO(Isotr0py): change modes for variants
-# see: https://github.com/deepseek-ai/DeepSeek-OCR/blob/8cf003d38821fa1b19c73da3bd1b0dc262ea8136/DeepSeek-OCR-master/DeepSeek-OCR-vllm/config.py#L1-L6
-# Tiny: base_size = 512, image_size = 512, crop_mode = False
-# Small: base_size = 640, image_size = 640, crop_mode = False
-# Base: base_size = 1024, image_size = 1024, crop_mode = False
-# Large: base_size = 1280, image_size = 1280, crop_mode = False
-# Gundam: base_size = 1024, image_size = 640, crop_mode = True
+# Official resolution modes, verbatim from the model's config.py:
+# https://github.com/deepseek-ai/DeepSeek-OCR/blob/8cf003d38821fa1b19c73da3bd1b0dc262ea8136/DeepSeek-OCR-master/DeepSeek-OCR-vllm/config.py#L1-L6
+# Selectable per request via the ``image_mode`` mm_processor_kwarg; the
+# default stays the Gundam configuration below (byte-compatible with the
+# previous hardcoded constants).
+RESOLUTION_MODES: dict[str, dict[str, object]] = {
+    "tiny": {"base_size": 512, "image_size": 512, "crop_mode": False},
+    "small": {"base_size": 640, "image_size": 640, "crop_mode": False},
+    "base": {"base_size": 1024, "image_size": 1024, "crop_mode": False},
+    "large": {"base_size": 1280, "image_size": 1280, "crop_mode": False},
+    "gundam": {"base_size": 1024, "image_size": 640, "crop_mode": True},
+}
+
 BASE_SIZE = 1024
 IMAGE_SIZE = 640
 CROP_MODE = True
 
-# TODO(Isotr0py): Expose as mm_kwargs
 MIN_CROPS = 2
 MAX_CROPS = 6  # max:9; If your GPU memory is small, it is recommended to set it to 6.
 
@@ -117,6 +122,53 @@ def dynamic_preprocess(
     return processed_images, target_aspect_ratio
 
 
+def count_image_tokens_for(
+    *,
+    image_width: int,
+    image_height: int,
+    base_size: int,
+    image_size: int,
+    cropping: bool,
+    min_crops: int = MIN_CROPS,
+    max_crops: int = MAX_CROPS,
+    strategy: str = "v1",
+    patch_size: int = 16,
+    downsample_ratio: int = 4,
+) -> int:
+    """Placeholder-token count mirroring ``tokenize_with_images``."""
+    if image_width <= image_size and image_height <= image_size:
+        crop_ratio = (1, 1)
+    elif cropping:
+        crop_ratio = count_tiles(
+            image_width,
+            image_height,
+            min_num=min_crops,
+            max_num=max_crops,
+            image_size=image_size,
+        )
+    else:
+        crop_ratio = (1, 1)
+    num_width_tiles, num_height_tiles = crop_ratio
+
+    num_queries = math.ceil((image_size // patch_size) / downsample_ratio)
+    num_queries_base = math.ceil((base_size // patch_size) / downsample_ratio)
+
+    num_tokens_base = (
+        (num_queries_base * (num_queries_base + 1))
+        if strategy == "v1"
+        else num_queries_base * num_queries_base
+    )
+    total = num_tokens_base + 1
+    if num_width_tiles > 1 or num_height_tiles > 1:
+        num_tokens_per_row = (
+            num_queries * num_width_tiles + 1
+            if strategy == "v1"
+            else num_queries * num_width_tiles
+        )
+        total += num_tokens_per_row * (num_queries * num_height_tiles)
+    return total
+
+
 class ImageTransform:
     def __init__(
         self,
@@ -160,11 +212,51 @@ class DeepseekOCRProcessor(ProcessorMixin):
         ignore_id: int = -100,
         image_size: int = IMAGE_SIZE,
         base_size: int = BASE_SIZE,
+        crop_mode: bool = CROP_MODE,
+        image_mode: str | None = None,
+        min_crops: int = MIN_CROPS,
+        max_crops: int = MAX_CROPS,
+        disable_crop_for_multi_image: bool = False,
         strategy: Literal["v1", "v2"] = "v1",
         **kwargs,
     ):
+        if image_mode is not None:
+            # The named mode is authoritative over any individually passed
+            # base_size/image_size/crop_mode (the vLLM processing info always
+            # forwards the defaults, so a raise-on-conflict would never let a
+            # mode through).
+            try:
+                mode = RESOLUTION_MODES[image_mode]
+            except KeyError:
+                raise ValueError(
+                    f"Unknown image_mode {image_mode!r}; valid modes: "
+                    f"{sorted(RESOLUTION_MODES)}"
+                ) from None
+            base_size = int(mode["base_size"])  # type: ignore[arg-type]
+            image_size = int(mode["image_size"])  # type: ignore[arg-type]
+            crop_mode = bool(mode["crop_mode"])
+        if not (
+            isinstance(min_crops, int)
+            and isinstance(max_crops, int)
+            and 1 <= min_crops <= max_crops
+        ):
+            raise ValueError(
+                f"Invalid crop bounds: min_crops={min_crops!r}, "
+                f"max_crops={max_crops!r} (need 1 <= min <= max)."
+            )
         self.image_size = image_size
         self.base_size = base_size
+        self.crop_mode = crop_mode
+        self.image_mode = image_mode
+        self.min_crops = min_crops
+        self.max_crops = max_crops
+        # Multi-image crop safeguard (derived checkpoints may raise
+        # max_crops; DeepSeek-OCR's max_crops=6 is safe for
+        # multi-image use, so this stays off by default). NOTE: when enabled,
+        # per-item processing depends on the sibling image count, so the
+        # multimodal processing cache must be disabled (the recipes already
+        # serve with mm_processor_cache_gb=0).
+        self.disable_crop_for_multi_image = disable_crop_for_multi_image
 
         # image token calculation strategy for
         # Deepseek-OCR and Deepseek-OCR-2
@@ -203,6 +295,40 @@ class DeepseekOCRProcessor(ProcessorMixin):
             **kwargs,
         )
 
+    def effective_cropping(self, num_images: int) -> bool:
+        """Whether cropping applies for a request with ``num_images`` images.
+
+        Mirrors the reference multi-image safeguard: when enabled, crop mode
+        is disabled as soon as more than one image is present.
+        """
+        if self.disable_crop_for_multi_image and num_images > 1:
+            return False
+        return self.crop_mode
+
+    def count_image_tokens(
+        self, *, image_width: int, image_height: int, num_images: int = 1
+    ) -> int:
+        """Number of <image> placeholder tokens for one image.
+
+        This mirrors ``tokenize_with_images`` exactly (same instance
+        parameters, same crop arithmetic, same multi-image safeguard) so the
+        prompt-update counting can never diverge from what processing
+        produces — a mismatch here is the "N multimodal tokens vs M
+        placeholders" crash class.
+        """
+        return count_image_tokens_for(
+            image_width=image_width,
+            image_height=image_height,
+            base_size=self.base_size,
+            image_size=self.image_size,
+            cropping=self.effective_cropping(num_images),
+            min_crops=self.min_crops,
+            max_crops=self.max_crops,
+            strategy=self.strategy,
+            patch_size=self.patch_size,
+            downsample_ratio=self.downsample_ratio,
+        )
+
     @property
     def bos_id(self):
         return self.tokenizer.bos_token_id
@@ -230,7 +356,7 @@ class DeepseekOCRProcessor(ProcessorMixin):
         self,
         prompt: str,
         images: list[Image.Image],
-        crop_mode: bool = CROP_MODE,
+        crop_mode: bool | None = None,
     ):
         """
 
@@ -253,6 +379,8 @@ class DeepseekOCRProcessor(ProcessorMixin):
         )
 
         sft_format = prompt
+        if crop_mode is None:
+            crop_mode = self.crop_mode
 
         (
             input_ids,
@@ -288,7 +416,7 @@ class DeepseekOCRProcessor(ProcessorMixin):
         *,
         prompt: str,
         images: list[Image.Image],
-        crop_mode: bool = CROP_MODE,
+        crop_mode: bool | None = None,
         **kwargs,
     ):
         prepare = self.process_one(
@@ -308,6 +436,9 @@ class DeepseekOCRProcessor(ProcessorMixin):
         cropping: bool = True,
     ):
         """Tokenize text with <image> tags."""
+
+        if cropping and not self.effective_cropping(len(images)):
+            cropping = False
 
         assert conversation.count(self.image_token) == len(images)
         text_splits = conversation.split(self.image_token)
@@ -332,7 +463,10 @@ class DeepseekOCRProcessor(ProcessorMixin):
                 crop_ratio = [1, 1]
             elif cropping:
                 images_crop_raw, crop_ratio = dynamic_preprocess(
-                    image, image_size=self.image_size
+                    image,
+                    min_num=self.min_crops,
+                    max_num=self.max_crops,
+                    image_size=self.image_size,
                 )
             else:
                 crop_ratio = [1, 1]

--- a/vllm/v1/core/kv_cache_coordinator.py
+++ b/vllm/v1/core/kv_cache_coordinator.py
@@ -34,7 +34,7 @@ class KVCacheCoordinator(ABC):
         self,
         kv_cache_config: KVCacheConfig,
         max_model_len: int,
-        max_num_batched_tokens: int,
+        max_in_flight_tokens: int,
         use_eagle: bool,
         enable_caching: bool,
         enable_kv_cache_events: bool,
@@ -66,7 +66,7 @@ class KVCacheCoordinator(ABC):
         self.single_type_managers = tuple(
             get_manager_for_kv_cache_spec(
                 kv_cache_spec=kv_cache_group.kv_cache_spec,
-                max_num_batched_tokens=max_num_batched_tokens,
+                max_in_flight_tokens=max_in_flight_tokens,
                 max_model_len=max_model_len,
                 block_pool=self.block_pool,
                 enable_caching=enable_caching,
@@ -238,7 +238,7 @@ class KVCacheCoordinator(ABC):
     def remove_skipped_blocks(
         self,
         request_id: str,
-        total_computed_tokens: int,
+        processed_computed_tokens: int,
         num_prompt_tokens: int | None = None,
     ) -> None:
         """
@@ -247,15 +247,15 @@ class KVCacheCoordinator(ABC):
 
         Args:
             request_id: The request ID.
-            total_computed_tokens: The total number of computed tokens, including
-                local computed tokens and external computed tokens.
+            processed_computed_tokens: Computed-token prefix length covering
+                fully processed and committed tokens only (safe to free).
             num_prompt_tokens: Optional prompt length. Prefix-anchored SWA
                 managers use this to free gap blocks between the prefill tail
                 and the decode window; other manager types ignore it.
         """
         for manager in self.single_type_managers:
             manager.remove_skipped_blocks(
-                request_id, total_computed_tokens, num_prompt_tokens
+                request_id, processed_computed_tokens, num_prompt_tokens
             )
 
     def get_blocks(self, request_id: str) -> tuple[list[KVCacheBlock], ...]:
@@ -293,7 +293,7 @@ class KVCacheCoordinatorNoPrefixCache(KVCacheCoordinator):
         self,
         kv_cache_config: KVCacheConfig,
         max_model_len: int,
-        max_num_batched_tokens: int,
+        max_in_flight_tokens: int,
         use_eagle: bool,
         enable_kv_cache_events: bool,
         dcp_world_size: int,
@@ -304,7 +304,7 @@ class KVCacheCoordinatorNoPrefixCache(KVCacheCoordinator):
         super().__init__(
             kv_cache_config,
             max_model_len,
-            max_num_batched_tokens,
+            max_in_flight_tokens,
             use_eagle,
             False,
             enable_kv_cache_events,
@@ -340,7 +340,7 @@ class UnitaryKVCacheCoordinator(KVCacheCoordinator):
         self,
         kv_cache_config: KVCacheConfig,
         max_model_len: int,
-        max_num_batched_tokens: int,
+        max_in_flight_tokens: int,
         use_eagle: bool,
         enable_caching: bool,
         enable_kv_cache_events: bool,
@@ -352,7 +352,7 @@ class UnitaryKVCacheCoordinator(KVCacheCoordinator):
         super().__init__(
             kv_cache_config,
             max_model_len,
-            max_num_batched_tokens,
+            max_in_flight_tokens,
             use_eagle,
             enable_caching,
             enable_kv_cache_events,
@@ -407,7 +407,7 @@ class HybridKVCacheCoordinator(KVCacheCoordinator):
         self,
         kv_cache_config: KVCacheConfig,
         max_model_len: int,
-        max_num_batched_tokens: int,
+        max_in_flight_tokens: int,
         use_eagle: bool,
         enable_caching: bool,
         enable_kv_cache_events: bool,
@@ -419,7 +419,7 @@ class HybridKVCacheCoordinator(KVCacheCoordinator):
         super().__init__(
             kv_cache_config,
             max_model_len,
-            max_num_batched_tokens,
+            max_in_flight_tokens,
             use_eagle,
             enable_caching,
             enable_kv_cache_events,
@@ -618,7 +618,7 @@ class HybridKVCacheCoordinator(KVCacheCoordinator):
 def get_kv_cache_coordinator(
     kv_cache_config: KVCacheConfig,
     max_model_len: int,
-    max_num_batched_tokens: int,
+    max_in_flight_tokens: int,
     use_eagle: bool,
     enable_caching: bool,
     enable_kv_cache_events: bool,
@@ -631,7 +631,7 @@ def get_kv_cache_coordinator(
         return KVCacheCoordinatorNoPrefixCache(
             kv_cache_config,
             max_model_len,
-            max_num_batched_tokens,
+            max_in_flight_tokens,
             use_eagle,
             enable_kv_cache_events,
             dcp_world_size=dcp_world_size,
@@ -643,7 +643,7 @@ def get_kv_cache_coordinator(
         return UnitaryKVCacheCoordinator(
             kv_cache_config,
             max_model_len,
-            max_num_batched_tokens,
+            max_in_flight_tokens,
             use_eagle,
             enable_caching,
             enable_kv_cache_events,
@@ -655,7 +655,7 @@ def get_kv_cache_coordinator(
     return HybridKVCacheCoordinator(
         kv_cache_config,
         max_model_len,
-        max_num_batched_tokens,
+        max_in_flight_tokens,
         use_eagle,
         enable_caching,
         enable_kv_cache_events,

--- a/vllm/v1/core/kv_cache_manager.py
+++ b/vllm/v1/core/kv_cache_manager.py
@@ -117,7 +117,7 @@ class KVCacheManager:
         kv_cache_config: KVCacheConfig,
         max_model_len: int,
         hash_block_size: int,
-        max_num_batched_tokens: int | None = None,
+        max_in_flight_tokens: int | None = None,
         enable_caching: bool = True,
         use_eagle: bool = False,
         log_stats: bool = False,
@@ -130,8 +130,8 @@ class KVCacheManager:
         # When unset, fall back to `max_model_len` so the recycling-aware cap
         # collapses to the prior (uncapped) admission behavior. The scheduler
         # always supplies the real value at runtime.
-        if max_num_batched_tokens is None:
-            max_num_batched_tokens = max_model_len
+        if max_in_flight_tokens is None:
+            max_in_flight_tokens = max_model_len
 
         self.enable_caching = enable_caching
         self.use_eagle = use_eagle
@@ -145,7 +145,7 @@ class KVCacheManager:
         self.coordinator = get_kv_cache_coordinator(
             kv_cache_config=kv_cache_config,
             max_model_len=self.max_model_len,
-            max_num_batched_tokens=max_num_batched_tokens,
+            max_in_flight_tokens=max_in_flight_tokens,
             use_eagle=self.use_eagle,
             enable_caching=self.enable_caching,
             enable_kv_cache_events=enable_kv_cache_events,
@@ -374,9 +374,12 @@ class KVCacheManager:
         # insufficient free blocks.
         # Should call this function before allocating new blocks to reduce
         # the number of evicted blocks.
+        # Free on the processed-token basis: in-flight steps' attention windows
+        # still read blocks below the optimistic boundary, and rejected spec
+        # tokens can roll it back.
         self.coordinator.remove_skipped_blocks(
             request.request_id,
-            total_computed_tokens,
+            max(0, total_computed_tokens - request.num_in_flight_tokens),
             num_prompt_tokens=request.num_prompt_tokens,
         )
 
@@ -445,7 +448,7 @@ class KVCacheManager:
     def remove_skipped_blocks(
         self,
         request_id: str,
-        total_computed_tokens: int,
+        processed_computed_tokens: int,
         num_prompt_tokens: int | None = None,
     ) -> None:
         """Remove the blocks that are no longer needed from `blocks` and replace
@@ -453,13 +456,13 @@ class KVCacheManager:
 
         Args:
             request_id: The request ID.
-            total_computed_tokens: The total number of computed tokens, including
-                local computed tokens and external computed tokens.
+            processed_computed_tokens: Computed-token prefix length covering
+                fully processed and committed tokens only (safe to free).
             num_prompt_tokens: Optional prompt length for prefix-anchored SWA
                 gap eviction.
         """
         self.coordinator.remove_skipped_blocks(
-            request_id, total_computed_tokens, num_prompt_tokens
+            request_id, processed_computed_tokens, num_prompt_tokens
         )
 
     def evict_blocks(self, block_ids: set[int]) -> None:

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -258,7 +258,7 @@ class Scheduler(SchedulerInterface):
         self.kv_cache_manager = KVCacheManager(
             kv_cache_config=kv_cache_config,
             max_model_len=self.max_model_len,
-            max_num_batched_tokens=self.scheduler_config.max_num_batched_tokens,
+            max_in_flight_tokens=vllm_config.max_in_flight_tokens,
             enable_caching=self.cache_config.enable_prefix_caching,
             use_eagle=self.use_eagle,
             log_stats=self.log_stats,
@@ -1192,6 +1192,7 @@ class Scheduler(SchedulerInterface):
         for req_id, num_scheduled_token in num_scheduled_tokens.items():
             request = self.requests[req_id]
             request.num_computed_tokens += num_scheduled_token
+            request.num_in_flight_tokens += num_scheduled_token
             request.is_prefill_chunk = request.num_computed_tokens < (
                 request.num_tokens + request.num_output_placeholders
             )
@@ -1576,10 +1577,12 @@ class Scheduler(SchedulerInterface):
         stopped_preempted_reqs: set[Request] = set()
         for req_id, num_tokens_scheduled in num_scheduled_tokens.items():
             assert num_tokens_scheduled > 0
+            request = self.requests.get(req_id)
+            if request is not None:
+                request.num_in_flight_tokens -= num_tokens_scheduled
             if failed_kv_load_req_ids and req_id in failed_kv_load_req_ids:
                 # skip failed or rescheduled requests from KV load failure
                 continue
-            request = self.requests.get(req_id)
             if request is None or request.is_finished():
                 # The request is already finished. This can happen if the
                 # request is aborted while the model is executing it (e.g.,
@@ -2383,10 +2386,12 @@ class Scheduler(SchedulerInterface):
             return False, None
 
         # Free any out-of-window prefix blocks before we hand the block table to
-        # the connector.
+        # the connector, on the processed-token basis (see `allocate_slots`).
         self.kv_cache_manager.remove_skipped_blocks(
             request_id=request.request_id,
-            total_computed_tokens=request.num_computed_tokens,
+            processed_computed_tokens=max(
+                0, request.num_computed_tokens - request.num_in_flight_tokens
+            ),
             num_prompt_tokens=request.num_prompt_tokens,
         )
 

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -479,7 +479,7 @@ class SingleTypeKVCacheManager(ABC):
     def remove_skipped_blocks(
         self,
         request_id: str,
-        total_computed_tokens: int,
+        processed_computed_tokens: int,
         num_prompt_tokens: int | None = None,
     ) -> None:
         """
@@ -491,15 +491,15 @@ class SingleTypeKVCacheManager(ABC):
 
         Args:
             request_id: The request ID.
-            total_computed_tokens: The total number of computed tokens, including
-                local computed tokens and external computed tokens.
+            processed_computed_tokens: Computed-token prefix length covering
+                fully processed and committed tokens only (safe to free).
             num_prompt_tokens: Optional prompt length for attention types (e.g.
                 prefix-anchored SWA) that evict a middle gap rather than a head
                 prefix. Ignored by the default implementation.
         """
         del num_prompt_tokens
         # Remove the blocks that will be skipped during attention computation.
-        num_skipped_tokens = self.get_num_skipped_tokens(total_computed_tokens)
+        num_skipped_tokens = self.get_num_skipped_tokens(processed_computed_tokens)
         if num_skipped_tokens <= 0:
             # This indicates that ALL tokens are inside attention window.
             # Thus we do not need to free any blocks outside attention window.
@@ -608,14 +608,14 @@ class PrefixAnchoredSWAManager(FullAttentionManager):
     def remove_skipped_blocks(
         self,
         request_id: str,
-        total_computed_tokens: int,
+        processed_computed_tokens: int,
         num_prompt_tokens: int | None = None,
     ) -> None:
         """Free gap blocks that are no longer needed for attention.
 
         Gap = blocks entirely within
             [ceil(prefix_len / block_size) * block_size,
-             max(prefix_len, total_computed_tokens - decode_sliding_window))
+             max(prefix_len, processed_computed_tokens - decode_sliding_window))
 
         Freed blocks are replaced with null_block in req_to_blocks so the
         block_table handed to the attention backend stays valid (null_block
@@ -624,7 +624,7 @@ class PrefixAnchoredSWAManager(FullAttentionManager):
         """
         if num_prompt_tokens is None:
             super().remove_skipped_blocks(
-                request_id, total_computed_tokens, num_prompt_tokens
+                request_id, processed_computed_tokens, num_prompt_tokens
             )
             return
 
@@ -633,7 +633,7 @@ class PrefixAnchoredSWAManager(FullAttentionManager):
         first_gap_block = cdiv(num_prompt_tokens, bs)
         # Decode window start position; blocks before this are evictable.
         window_start = max(
-            num_prompt_tokens, total_computed_tokens - self.decode_sliding_window
+            num_prompt_tokens, processed_computed_tokens - self.decode_sliding_window
         )
         last_gap_block = window_start // bs  # exclusive upper bound
         self._remove_blocks_in_range(request_id, first_gap_block, last_gap_block)
@@ -1005,20 +1005,13 @@ class MambaManager(SingleTypeKVCacheManager):
     def remove_skipped_blocks(
         self,
         request_id: str,
-        num_computed_tokens: int,
+        processed_computed_tokens: int,
         num_prompt_tokens: int | None = None,
     ) -> None:
         assert isinstance(self.kv_cache_spec, MambaSpec)
 
-        # NOTE (tdoublep) with async scheduling, the num_computed_tokens can contain
-        # draft tokens from the previous step that may or may not be rejected later.
-        # This can make us think we are further ahead in the sequence than we actually
-        # are, so let's assume that all tokens are rejected so we don't free blocks
-        # that we might actually need.
-        num_computed_tokens = max(0, num_computed_tokens - self.num_speculative_blocks)
-
         super().remove_skipped_blocks(
-            request_id, num_computed_tokens, num_prompt_tokens
+            request_id, processed_computed_tokens, num_prompt_tokens
         )
         if self.mamba_cache_mode == "align":
             # `last_state_block_idx` refers to the block index allocated two steps ago.
@@ -1032,7 +1025,7 @@ class MambaManager(SingleTypeKVCacheManager):
             if (
                 last_state_block_idx is not None
                 and last_state_block_idx
-                < cdiv(num_computed_tokens, self.block_size) - 1
+                < cdiv(processed_computed_tokens, self.block_size) - 1
             ):
                 blocks = self.req_to_blocks[request_id]
                 if blocks[last_state_block_idx] != self._null_block:
@@ -1338,7 +1331,7 @@ spec_manager_map: dict[type[KVCacheSpec], type[SingleTypeKVCacheManager]] = {
 
 def get_manager_for_kv_cache_spec(
     kv_cache_spec: KVCacheSpec,
-    max_num_batched_tokens: int,
+    max_in_flight_tokens: int,
     max_model_len: int,
     **kwargs,
 ) -> SingleTypeKVCacheManager:
@@ -1349,7 +1342,7 @@ def get_manager_for_kv_cache_spec(
     if isinstance(kv_cache_spec, (SlidingWindowSpec, ChunkedLocalAttentionSpec)):
         kwargs["max_admission_blocks_per_request"] = (
             kv_cache_spec.max_admission_blocks_per_request(
-                max_num_batched_tokens=max_num_batched_tokens,
+                max_in_flight_tokens=max_in_flight_tokens,
                 max_model_len=max_model_len,
             )
         )

--- a/vllm/v1/kv_cache_interface.py
+++ b/vllm/v1/kv_cache_interface.py
@@ -454,7 +454,7 @@ class ChunkedLocalAttentionSpec(AttentionSpec):
     attention_chunk_size: int
 
     def max_admission_blocks_per_request(
-        self, max_num_batched_tokens: int, max_model_len: int
+        self, max_in_flight_tokens: int, max_model_len: int
     ) -> int:
         """Per-request admission cap, in blocks.
 
@@ -464,15 +464,15 @@ class ChunkedLocalAttentionSpec(AttentionSpec):
         """
         # During chunked prefill, we hold KV for at most one chunk window.
         num_tokens = min(
-            self.attention_chunk_size + max_num_batched_tokens, max_model_len
+            self.attention_chunk_size + max_in_flight_tokens, max_model_len
         )
         return cdiv(num_tokens, self.block_size)
 
     def max_memory_usage_bytes(self, vllm_config: VllmConfig) -> int:
         max_model_len = vllm_config.model_config.max_model_len
-        max_num_batched_tokens = vllm_config.scheduler_config.max_num_batched_tokens
+        max_in_flight_tokens = vllm_config.max_in_flight_tokens
         max_blocks = self.max_admission_blocks_per_request(
-            max_num_batched_tokens=max_num_batched_tokens, max_model_len=max_model_len
+            max_in_flight_tokens=max_in_flight_tokens, max_model_len=max_model_len
         )
         return max_blocks * self.page_size_bytes
 
@@ -507,7 +507,7 @@ class SlidingWindowSpec(AttentionSpec):
         )
 
     def max_admission_blocks_per_request(
-        self, max_num_batched_tokens: int, max_model_len: int
+        self, max_in_flight_tokens: int, max_model_len: int
     ) -> int:
         """Per-request admission cap, in blocks.
 
@@ -520,9 +520,7 @@ class SlidingWindowSpec(AttentionSpec):
         # During chunked prefill, we hold KV for the last `sliding_window-1`
         # computed tokens plus the newly scheduled tokens, and never more
         # than `max_model_len`.
-        num_tokens = min(
-            self.sliding_window - 1 + max_num_batched_tokens, max_model_len
-        )
+        num_tokens = min(self.sliding_window - 1 + max_in_flight_tokens, max_model_len)
         # +1 because the sliding window may not start from the beginning of
         # the block. E.g. block size 4 and num_token 4 needs two blocks
         # [XXCD][EF] to store the 6-token window [CDEF].
@@ -533,9 +531,9 @@ class SlidingWindowSpec(AttentionSpec):
             "DCP not support sliding window."
         )
         max_model_len = vllm_config.model_config.max_model_len
-        max_num_batched_tokens = vllm_config.scheduler_config.max_num_batched_tokens
+        max_in_flight_tokens = vllm_config.max_in_flight_tokens
         max_blocks = self.max_admission_blocks_per_request(
-            max_num_batched_tokens=max_num_batched_tokens, max_model_len=max_model_len
+            max_in_flight_tokens=max_in_flight_tokens, max_model_len=max_model_len
         )
         return max_blocks * self.page_size_bytes
 

--- a/vllm/v1/request.py
+++ b/vllm/v1/request.py
@@ -141,6 +141,11 @@ class Request:
         self.num_output_placeholders = 0
         self.async_tokens_to_discard = 0
 
+        # Tokens of steps whose output is not yet processed (async scheduling
+        # and PP run ahead of the GPU); `num_computed_tokens` counts them
+        # optimistically.
+        self.num_in_flight_tokens = 0
+
         self.spec_token_ids: list[int] = []
         self.num_computed_tokens = 0
         self.cache_salt: str | None = cache_salt

--- a/vllm/v1/simple_kv_offload/manager.py
+++ b/vllm/v1/simple_kv_offload/manager.py
@@ -119,9 +119,7 @@ class SimpleCPUOffloadScheduler:
         self.cpu_coordinator: KVCacheCoordinator = get_kv_cache_coordinator(
             kv_cache_config=self.cpu_kv_cache_config,
             max_model_len=vllm_config.model_config.max_model_len,
-            max_num_batched_tokens=(
-                vllm_config.scheduler_config.max_num_batched_tokens
-            ),
+            max_in_flight_tokens=vllm_config.max_in_flight_tokens,
             use_eagle=False,
             enable_caching=True,
             enable_kv_cache_events=self.enable_kv_cache_events,


### PR DESCRIPTION
## What

Serving-quality improvements for long-generation OCR workloads, plus a
correctness fix for prefix-anchored SWA:

1. **Bugfix (prefix-anchored SWA):** out-of-window gap blocks were freed
   on the scheduled-token basis; under async scheduling this can free
   blocks the worker has not yet computed past. Free on the
   processed-token basis instead. Regression tests cover the async gap.
2. **Per-model serving defaults with request-override bounds:** an
   architecture-keyed registry applied at the chat endpoint. A model
   declares its recommended sampling/extra-args recipe; requests may
   override within declared bounds. DeepSeek-OCR registers its checkpoint
   README recipe (n-gram blocker 30/90 with whitelist tokens, temperature
   0, max_tokens 8192) so an unconfigured client gets the model's intended
   behavior via plain chat completions.
3. **Architecture-keyed chat template fallbacks:** DeepSeek-OCR's
   model_type previously fell through to the DeepSeek-VL2 template, which
   injects role markers the OCR checkpoint was not trained with; the
   fallback now pins the raw-concatenation prompt (golden test included).
4. **Repetition-detection default** for OCR serving: a bounded
   exact-pattern detector as a safety net for degenerate table pages,
   request-overridable.
5. **Per-request DeepSeek-OCR resolution modes:** the checkpoint's five
   official modes (tiny/small/base/large/gundam) selectable via
   `mm_processor_kwargs: {"image_mode": ...}`; multi-image serving
   profile; `max_crops` plumbing. The serving default remains the
   checkpoint's gundam configuration.

## Why

On document OCR, the model's own recipe is load-bearing: without the
n-gram blocker and the correct raw prompt, long pages degenerate into
loops. These changes make the endpoint serve the checkpoint's intended
recipe by default while keeping every knob per-request-overridable within
bounds. The SWA fix closes an async-scheduling correctness gap in that
capability (#281).

## Validation

All device work on Tesla V100-SXM2 32 GB (sm_70), fp16, on current main.

- 195 CPU tests green, including the prefix-anchored SWA
  admission/mask/manager suites, the new eviction-basis regression tests,
  resolution-mode suite, template golden, defaults/bounds and
  repetition-detection suites.
- Endpoint (serve) on V100: deterministic 3x byte-identical generations;
  resolution-mode discrimination (default = gundam as identity control;
  base/large produce distinct image-token counts); document-page scoring
  against known ground truth per mode.

## Serving DeepSeek-OCR (validated configuration)

Launch line used for every endpoint validation in this PR (Tesla
V100-SXM2 32 GB, fp16):

```bash
vllm serve /path/to/DeepSeek-OCR \
  --dtype float16 \
  --max-model-len 8192 \
  --gpu-memory-utilization 0.85 \
  --enforce-eager \
  --no-enable-prefix-caching \
  --mm-processor-cache-gb 0 \
  --logits-processors vllm.model_executor.models.deepseek_ocr:NGramPerReqLogitsProcessor
```

- `--logits-processors` loads the n-gram blocker class; the serving-defaults
  registry supplies its per-request parameters and **fails startup with the
  exact flag text if the class is missing** (never silent looping).
- `--no-enable-prefix-caching` / `--mm-processor-cache-gb 0` are the
  checkpoint recipe's engine flags.
- For multi-image requests add `--limit-mm-per-prompt '{"image":8}'`
  (the SM70 baseline defaults to 1 image per prompt).
- `--enforce-eager` is the validated configuration; CUDA graphs measured
  ~4x faster decode at ~1% window cost and can be enabled after a
  graph-mode validation pass.
- Tensor parallelism: the checkpoint has 10 attention heads, so
  `--tensor-parallel-size` must divide 10 (1 or 2 on a 4-GPU host); 4
  fails at startup with the head-divisibility error.

## Merge base

Branch applies and merges cleanly onto current `main` at `34403018d`
([Kernel][SM70] Optimize E4M3 page800 long decode, #290); all validation in
this PR ran on that base.
