### PR TITLE
[Core][Kernel][SM70] Fix PP profiling and compact MXFP4 shapes

### DIFF
--- a/csrc/sm70_turbomind/ops/awq_sm70_gemm.cu
+++ b/csrc/sm70_turbomind/ops/awq_sm70_gemm.cu
@@ -8276,10 +8276,10 @@ void mxfp4_moe_dense_stage_sm70_out(torch::Tensor out, torch::Tensor input,
       logged_mxfp4_dense_stage,
       "SM70 MXFP4 MoE CUDA-graph-safe dense-stage path enabled C++ op reached",
       input, input.size(0), num_experts);
-  const bool compact_decode_shape =
-      input.size(0) == num_experts && num_experts == 6 &&
-      ((k == 4096 && (n == 512 || n == 1024)) ||
-       (n == 4096 && (k == 256 || k == 512)));
+  const bool compact_decode_shape = input.size(0) == num_experts &&
+                                    num_experts == 6 &&
+                                    ((k == 4096 && (n == 512 || n == 1024)) ||
+                                     (n == 4096 && (k == 256 || k == 512)));
   if (vllm::awq_sm70::mxfp4_moe_compact_grouped_decode_enabled() &&
       compact_decode_shape) {
     mxfp4_moe_gemm_sm70_out_impl(out, input, expert_offsets, ptrs_w, ptrs_s,
@@ -8571,7 +8571,7 @@ void mxfp4_moe_single_token_prepare_w13_sm70_out(
   TORCH_CHECK(group_size == 32 && w13_k == hidden_logical_size &&
                   (w13_n == 512 || w13_n == 1024),
               "mxfp4_moe_single_token_prepare_w13_sm70_out: unsupported "
-              "DeepSeek V4 W13 shape contract.");
+              "MXFP4 W13 shape contract.");
   TORCH_CHECK(
       compact_input.is_cuda() &&
           compact_input.scalar_type() == torch::kFloat16 &&

--- a/csrc/sm70_turbomind/ops/awq_sm70_gemm.cu
+++ b/csrc/sm70_turbomind/ops/awq_sm70_gemm.cu
@@ -8278,7 +8278,8 @@ void mxfp4_moe_dense_stage_sm70_out(torch::Tensor out, torch::Tensor input,
       input, input.size(0), num_experts);
   const bool compact_decode_shape =
       input.size(0) == num_experts && num_experts == 6 &&
-      ((k == 4096 && n == 512) || (k == 256 && n == 4096));
+      ((k == 4096 && (n == 512 || n == 1024)) ||
+       (n == 4096 && (k == 256 || k == 512)));
   if (vllm::awq_sm70::mxfp4_moe_compact_grouped_decode_enabled() &&
       compact_decode_shape) {
     mxfp4_moe_gemm_sm70_out_impl(out, input, expert_offsets, ptrs_w, ptrs_s,
@@ -8567,7 +8568,8 @@ void mxfp4_moe_single_token_prepare_w13_sm70_out(
   TORCH_CHECK(topk_ids.numel() == kTopK,
               "mxfp4_moe_single_token_prepare_w13_sm70_out: exact top-k=6 is "
               "required.");
-  TORCH_CHECK(group_size == 32 && w13_k == hidden_logical_size && w13_n == 512,
+  TORCH_CHECK(group_size == 32 && w13_k == hidden_logical_size &&
+                  (w13_n == 512 || w13_n == 1024),
               "mxfp4_moe_single_token_prepare_w13_sm70_out: unsupported "
               "DeepSeek V4 W13 shape contract.");
   TORCH_CHECK(

--- a/docs/design/sm70_v100_migration_control.md
+++ b/docs/design/sm70_v100_migration_control.md
@@ -43081,3 +43081,27 @@ Interpretation:
   The server's common D256 prefill fallback warning is outside the pure-decode
   metric, so this change closes long decode only and must not be cited as a
   prefill improvement.
+
+## 2026-08-25 generic PP profiling and compact MXFP4 audit
+
+- PR #283 mixed accepted engine work with rejected workload experiments. Its
+  QPN8 candidates had repeated baseline-correct-to-candidate-wrong quality
+  regressions, while the metadata-free PP transfer recovered only about
+  `0.034 ms/token` in the full endpoint. Neither path is promoted to main.
+- The retained PP repair is model-independent. A non-last pipeline stage can
+  return `IntermediateTensors` during a dummy profile/capture; the runner now
+  selects the semantic `hidden_states` entry instead of treating the wrapper
+  as a tensor. A CPU unit test also proves that dictionary insertion order
+  cannot select a residual tensor accidentally.
+- The retained MXFP4 route is admitted only by the existing SM70 operator,
+  group size 32, six one-row groups, and exact `(K,N)` tensor shapes. Runtime
+  code does not inspect checkpoint paths, model names, `model_type`, or
+  architecture identity, and the compact grouped route remains default-off.
+- On a V100, both new shapes are bitwise equal to the per-expert fallback and
+  pass CUDA Graph replay. Median operator time changes from `0.139827` to
+  `0.037478 ms` for `(4096,1024)` and from `0.064696` to `0.021371 ms` for
+  `(512,4096)`, or `3.731x` and `3.027x` respectively. Final-source reruns on
+  latest main measured `0.151521` to `0.040428 ms` (`3.748x`) and `0.065004`
+  to `0.022538 ms` (`2.884x`). The full CUDA 12.8
+  extension builds with target architecture 7.0 only; 28 CPU checks and the
+  changed-file static gate pass.

--- a/tests/quantization/test_sm70_mxfp4_moe.py
+++ b/tests/quantization/test_sm70_mxfp4_moe.py
@@ -6,6 +6,7 @@ from types import SimpleNamespace
 import pytest
 import torch
 
+from vllm import _sm70_ops as sm70_ops
 from vllm import envs
 from vllm.model_executor.layers.fused_moe import (
     FusedMoEConfig,
@@ -430,6 +431,110 @@ def test_mxfp4_sm70_active_expert_compaction_replays_dynamic_routes():
     torch.testing.assert_close(
         compact_offsets.cpu(), torch.arange(49, dtype=torch.int32)
     )
+
+
+@pytest.mark.parametrize(("k", "n"), [(4096, 1024), (512, 4096)])
+@pytest.mark.skipif(
+    not torch.cuda.is_available() or torch.cuda.get_device_capability() != (7, 0),
+    reason="requires NVIDIA V100/SM70",
+)
+def test_mxfp4_sm70_tp4_compact_shapes_match_per_expert(
+    monkeypatch: pytest.MonkeyPatch,
+    k: int,
+    n: int,
+):
+    num_experts = 6
+    group_size = 32
+    torch.manual_seed(20260825)
+    packed = torch.randint(0, 16, (k, n), dtype=torch.uint8, device="cuda")
+    scales = torch.full((k // group_size, n), 127, dtype=torch.uint8, device="cuda")
+    weight, scale, meta = sm70_ops.mxfp4_sm70_prepare(packed, scales, group_size)
+    weights = weight.unsqueeze(0).repeat(num_experts, *([1] * weight.ndim))
+    expert_scales = scale.unsqueeze(0).repeat(num_experts, *([1] * scale.ndim))
+    ptrs_w, ptrs_s = torch.ops._C.awq_moe_build_strided_ptrs(
+        weights,
+        expert_scales,
+        int(meta[0].item()),
+        int(meta[1].item()),
+        num_experts,
+    )
+    x = torch.randn((1, k), dtype=torch.float16, device="cuda") * 0.01
+    grouped_input = x.expand(num_experts, -1).contiguous()
+    offsets = torch.arange(num_experts + 1, dtype=torch.int32, device="cuda")
+    expert_ids = torch.arange(num_experts, dtype=torch.int32, device="cuda")
+    reference = torch.empty((num_experts, n), dtype=torch.float16, device="cuda")
+    actual = torch.empty_like(reference)
+
+    monkeypatch.setenv("VLLM_SM70_MXFP4_MOE_COMPACT_GROUPED_DECODE", "0")
+    torch.ops._C.mxfp4_moe_dense_stage_sm70_out(
+        reference,
+        grouped_input,
+        offsets,
+        expert_ids,
+        ptrs_w,
+        ptrs_s,
+        num_experts,
+        k,
+        n,
+        group_size,
+    )
+    monkeypatch.setenv("VLLM_SM70_MXFP4_MOE_COMPACT_GROUPED_DECODE", "1")
+    torch.ops._C.mxfp4_moe_dense_stage_sm70_out(
+        actual,
+        grouped_input,
+        offsets,
+        expert_ids,
+        ptrs_w,
+        ptrs_s,
+        num_experts,
+        k,
+        n,
+        group_size,
+    )
+    torch.accelerator.synchronize()
+    torch.testing.assert_close(actual, reference, rtol=0.0, atol=0.0)
+
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        torch.ops._C.mxfp4_moe_dense_stage_sm70_out(
+            actual,
+            grouped_input,
+            offsets,
+            expert_ids,
+            ptrs_w,
+            ptrs_s,
+            num_experts,
+            k,
+            n,
+            group_size,
+        )
+    graph.replay()
+    torch.accelerator.synchronize()
+    torch.testing.assert_close(actual, reference, rtol=0.0, atol=0.0)
+
+    if (k, n) == (4096, 1024):
+        direct = torch.empty_like(actual)
+        direct_input = torch.empty_like(grouped_input)
+        direct_offsets = torch.empty_like(offsets)
+        inverse_indices = torch.empty(num_experts, dtype=torch.int32, device="cuda")
+        direct_expert_ids = torch.empty_like(expert_ids)
+        torch.ops._C.mxfp4_moe_single_token_prepare_w13_sm70_out(
+            direct,
+            direct_input,
+            x,
+            expert_ids.view(1, num_experts),
+            ptrs_w,
+            ptrs_s,
+            direct_offsets,
+            inverse_indices,
+            direct_expert_ids,
+            k,
+            n,
+            group_size,
+            k,
+        )
+        torch.accelerator.synchronize()
+        torch.testing.assert_close(direct, reference, rtol=0.0, atol=0.0)
 
 
 def test_mxfp4_sm70_post_load_reads_bias_from_method_config(monkeypatch):

--- a/tests/v1/worker/test_gpu_model_runner.py
+++ b/tests/v1/worker/test_gpu_model_runner.py
@@ -26,6 +26,7 @@ from vllm.model_executor.layers.attention import Attention
 from vllm.model_executor.layers.mamba.mamba_mixer2 import MambaMixer2
 from vllm.platforms import current_platform
 from vllm.sampling_params import SamplingParams
+from vllm.sequence import IntermediateTensors
 from vllm.utils.mem_constants import GiB_bytes
 from vllm.utils.system_utils import update_environment_variables
 from vllm.utils.torch_utils import set_random_seed
@@ -49,6 +50,27 @@ from vllm.v1.worker.utils import select_common_block_size
 BLOCK_SIZE = 16
 NUM_BLOCKS = 10
 DEVICE_TYPE = current_platform.device_type
+
+
+def test_unwrap_pipeline_intermediate_hidden_states_uses_semantic_key():
+    hidden_states = torch.zeros((2, 3))
+    residual = torch.ones_like(hidden_states)
+    output = IntermediateTensors({"residual": residual, "hidden_states": hidden_states})
+
+    assert (
+        gpu_model_runner_module._unwrap_pipeline_intermediate_hidden_states(output)
+        is hidden_states
+    )
+    assert (
+        gpu_model_runner_module._unwrap_pipeline_intermediate_hidden_states(
+            hidden_states
+        )
+        is hidden_states
+    )
+    with pytest.raises(RuntimeError, match="must contain a 'hidden_states' tensor"):
+        gpu_model_runner_module._unwrap_pipeline_intermediate_hidden_states(
+            IntermediateTensors({"residual": residual})
+        )
 
 
 def initialize_kv_cache(runner: GPUModelRunner):

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -271,6 +271,19 @@ _SM70_MTP_STEP_DUMP_COUNTER = 0
 _SM70_DECODE_EVENT_TRACE_CONFIG_LOGGED = False
 
 
+def _unwrap_pipeline_intermediate_hidden_states(
+    output: torch.Tensor | IntermediateTensors,
+) -> torch.Tensor:
+    if not isinstance(output, IntermediateTensors):
+        return output
+    try:
+        return output.tensors["hidden_states"]
+    except KeyError as exc:
+        raise RuntimeError(
+            "Pipeline intermediate output must contain a 'hidden_states' tensor."
+        ) from exc
+
+
 def _dflash_ddtree_debug_enabled() -> bool:
     return os.getenv("VLLM_DFLASH_DDTREE_DEBUG", "0") == "1"
 
@@ -10894,7 +10907,9 @@ class GPUModelRunner(
                 # Non-last PP ranks return intermediate tensors instead of
                 # logits-bearing hidden states. Dummy-run callers only need a
                 # tensor to preserve the profiling/capture return contract.
-                hidden_states = next(iter(hidden_states.tensors.values()))
+                hidden_states = _unwrap_pipeline_intermediate_hidden_states(
+                    hidden_states
+                )
 
             if self.speculative_config and (
                 self.speculative_config.use_eagle()

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -10889,6 +10889,13 @@ class GPUModelRunner(
             else:
                 hidden_states = outputs
 
+            if isinstance(hidden_states, IntermediateTensors):
+                assert not get_pp_group().is_last_rank
+                # Non-last PP ranks return intermediate tensors instead of
+                # logits-bearing hidden states. Dummy-run callers only need a
+                # tensor to preserve the profiling/capture return contract.
+                hidden_states = next(iter(hidden_states.tensors.values()))
+
             if self.speculative_config and (
                 self.speculative_config.use_eagle()
                 or self.speculative_config.uses_draft_model()


### PR DESCRIPTION
## Purpose

Supersede the accepted engine-level subset of #283 without carrying its rejected model-workload experiments into main.

- unwrap non-last pipeline-stage dummy outputs through the semantic hidden_states tensor
- admit the existing default-off compact MXFP4 grouped operator for two additional exact SM70 shapes
- keep runtime admission independent of model name, checkpoint, model_type, or architecture identity

The original #283 QPN8 candidate showed repeated baseline-correct-to-candidate-wrong quality regressions. Its static PP candidate recovered only about 0.034 ms/token at the endpoint. Neither is included here.

## Test plan and result

- changed-file pre-commit: passed
- CPU: 28 passed, 3 GPU-only skipped
- CUDA 12.8 full extension build, target architecture 7.0 only: passed
- V100 exactness and CUDA Graph replay for K4096/N1024 and K512/N4096: 2 passed, bitwise equal to the per-expert fallback
- final-source V100 microbenchmark:
  - K4096/N1024: 0.151521 ms to 0.040428 ms, 3.748x
  - K512/N4096: 0.065004 ms to 0.022538 ms, 2.884x

No full-model E2E run is claimed or required for this source/operator audit.
