### PR TITLE
[Bugfix] Track in-flight KV eviction boundaries

### DIFF
--- a/docs/design/sm70_v100_migration_control.md
+++ b/docs/design/sm70_v100_migration_control.md
@@ -43178,3 +43178,25 @@ Interpretation:
   admission remains limited to device capability, dtype, batch/head geometry,
   cache strides, page size, graph semantics, and partition thresholds; no
   model, checkpoint, `model_type`, or architecture identity is consulted.
+
+## 2026-08-26 generic in-flight KV eviction audit
+
+- PR #293 mixed a valid engine-level cache lifetime repair with
+  architecture-keyed serving recipes, model-specific generation defaults, and
+  OCR prompt/resolution behavior. The architecture/model identity defaults are
+  not admitted to main; they are unrelated to inference-engine route safety.
+- The retained repair tracks tokens scheduled in batches whose outputs have
+  not settled yet. Sliding-window, chunked-local, prefix-anchored SWA, and
+  Mamba eviction now derive their safe freeing boundary from processed tokens,
+  rather than the scheduler's optimistic computed-token boundary. This avoids
+  recycling a KV block while an asynchronous or pipeline-parallel batch can
+  still read it, including when speculative tokens later roll back.
+- Recycling-aware admission reserves for the same executor concurrency bound:
+  pipeline depth for PP, asynchronous queue depth otherwise. The contract uses
+  scheduler concurrency, attention/cache geometry, token state, and block
+  lifetime only; it does not inspect a model, checkpoint, `model_type`, or
+  architecture identity.
+- Final-source validation passes 17 focused cache/accounting cases, all 11
+  async-scheduler unit cases, and a simple CPU-offload store/load round trip.
+  All changed-file pre-commit hooks pass. This is a cache lifetime correctness
+  repair; no throughput claim is attached.

--- a/tests/v1/core/test_async_scheduler.py
+++ b/tests/v1/core/test_async_scheduler.py
@@ -306,6 +306,9 @@ def test_abort_request_when_structured_output_fsm_cannot_advance():
     request.status = RequestStatus.RUNNING
     request.num_computed_tokens = request.num_tokens
     request.num_output_placeholders = 1
+    # This fixture calls update_from_output without schedule(); mirror the
+    # scheduled token that would normally be recorded by _update_after_schedule.
+    request.num_in_flight_tokens = 1
 
     scheduler.perf_metrics = None
     scheduler.connector = None

--- a/tests/v1/core/test_kv_cache_utils.py
+++ b/tests/v1/core/test_kv_cache_utils.py
@@ -1394,6 +1394,8 @@ def test_get_max_concurrency_for_kv_cache_config():
         enable_chunked_prefill=True,
         max_model_len=model_config.max_model_len,
         is_encoder_decoder=model_config.is_encoder_decoder,
+        # Pin to sync: SWA per-request bounds grow with overlapping batches.
+        async_scheduling=False,
     )
 
     vllm_config = VllmConfig(

--- a/tests/v1/core/test_prefix_caching.py
+++ b/tests/v1/core/test_prefix_caching.py
@@ -2876,7 +2876,8 @@ def test_can_fit_full_sequence_swa_cap_admits_long_prompt():
     manager = KVCacheManager(
         config,
         max_model_len=max_model_len,
-        max_num_batched_tokens=max_num_batched_tokens,
+        # Single (sync) batch in flight, so in-flight tokens == batched tokens.
+        max_in_flight_tokens=max_num_batched_tokens,
         enable_caching=True,
         hash_block_size=block_size,
     )
@@ -2932,7 +2933,8 @@ def test_can_fit_full_sequence_full_attention_still_gates_oversized():
     manager = KVCacheManager(
         config,
         max_model_len=max_model_len,
-        max_num_batched_tokens=max_num_batched_tokens,
+        # Single (sync) batch in flight, so in-flight tokens == batched tokens.
+        max_in_flight_tokens=max_num_batched_tokens,
         enable_caching=True,
         hash_block_size=block_size,
     )

--- a/tests/v1/core/test_single_type_kv_cache_manager.py
+++ b/tests/v1/core/test_single_type_kv_cache_manager.py
@@ -578,7 +578,7 @@ def test_prefix_anchored_swa_manager_registered():
     block_pool = BlockPool(num_gpu_blocks=100, enable_caching=False, hash_block_size=16)
     manager = get_manager_for_kv_cache_spec(
         spec,
-        max_num_batched_tokens=1024,
+        max_in_flight_tokens=1024,
         max_model_len=4096,
         block_pool=block_pool,
         enable_caching=False,

--- a/tests/v1/core/test_swa_inflight_window_free.py
+++ b/tests/v1/core/test_swa_inflight_window_free.py
@@ -1,0 +1,351 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Out-of-window block frees vs in-flight GPU steps.
+
+With async scheduling / PP, `num_computed_tokens` optimistically includes
+tokens of unprocessed steps whose attention windows still read the blocks
+just below the optimistic boundary (and rejected spec tokens can roll it
+back), so `allocate_slots` frees on the processed-token basis:
+`num_computed_tokens - num_in_flight_tokens`.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from vllm import envs
+from vllm.config import VllmConfig
+from vllm.v1.core.sched.output import SchedulerOutput
+from vllm.v1.kv_cache_interface import (
+    ChunkedLocalAttentionSpec,
+    PrefixAnchoredSWASpec,
+    SlidingWindowSpec,
+)
+from vllm.v1.outputs import ModelRunnerOutput
+
+from .utils import create_requests, create_scheduler, mock_kv
+
+NUM_PROMPT_TOKENS = 100
+BLOCK_SIZE = 16
+SLIDING_WINDOW = 16
+# Tokens 0..84 are outside the window of the next token to compute
+# (100 - 16 + 1 = 85), i.e. 5 full blocks.
+NUM_OUT_OF_WINDOW_BLOCKS = 85 // BLOCK_SIZE
+# Chunked-local skips whole chunks left of the current one:
+# (100 // 32) * 32 = 96 settled tokens -> 6 full blocks.
+CHUNK_SIZE = 32
+NUM_OUT_OF_CHUNK_BLOCKS = (NUM_PROMPT_TOKENS // CHUNK_SIZE) * CHUNK_SIZE // BLOCK_SIZE
+
+
+@pytest.mark.parametrize(
+    ("pp_size", "async_scheduling", "queue_depth", "expected_batches"),
+    [
+        (1, False, 0, 1),
+        (1, True, 0, 2),
+        (1, True, 4, 4),
+        (3, False, 0, 3),
+        (3, True, 4, 3),
+    ],
+)
+def test_max_in_flight_tokens_matches_executor_concurrency(
+    monkeypatch,
+    pp_size: int,
+    async_scheduling: bool,
+    queue_depth: int,
+    expected_batches: int,
+):
+    monkeypatch.setattr(envs, "VLLM_SM70_ASYNC_SCHEDULING_QUEUE_DEPTH", queue_depth)
+    config = object.__new__(VllmConfig)
+    config.parallel_config = SimpleNamespace(pipeline_parallel_size=pp_size)
+    config.scheduler_config = SimpleNamespace(
+        async_scheduling=async_scheduling,
+        max_num_batched_tokens=1024,
+    )
+
+    assert config.max_concurrent_batches == expected_batches
+    assert config.max_in_flight_tokens == expected_batches * 1024
+
+
+def _make_model_runner_output(
+    scheduler_output: SchedulerOutput,
+    token_id: int = 0,
+) -> ModelRunnerOutput:
+    req_ids = list(scheduler_output.num_scheduled_tokens.keys())
+    return ModelRunnerOutput(
+        req_ids=req_ids,
+        req_id_to_index={req_id: i for i, req_id in enumerate(req_ids)},
+        sampled_token_ids=[[token_id] for _ in req_ids],
+        logprobs=None,
+        prompt_logprobs_dict={},
+        pooler_output=[],
+    )
+
+
+def _create_swa_scheduler(async_scheduling: bool):
+    return create_scheduler(
+        block_size=BLOCK_SIZE,
+        async_scheduling=async_scheduling,
+        kv_cache_spec=SlidingWindowSpec(
+            block_size=BLOCK_SIZE,
+            num_kv_heads=1,
+            head_size=1,
+            dtype=torch.float32,
+            sliding_window=SLIDING_WINDOW,
+        ),
+    )
+
+
+def _create_chunked_scheduler(async_scheduling: bool):
+    return create_scheduler(
+        block_size=BLOCK_SIZE,
+        async_scheduling=async_scheduling,
+        kv_cache_spec=ChunkedLocalAttentionSpec(
+            block_size=BLOCK_SIZE,
+            num_kv_heads=1,
+            head_size=1,
+            dtype=torch.float32,
+            attention_chunk_size=CHUNK_SIZE,
+        ),
+    )
+
+
+def _create_anchored_scheduler(async_scheduling: bool):
+    return create_scheduler(
+        block_size=BLOCK_SIZE,
+        async_scheduling=async_scheduling,
+        enable_prefix_caching=False,
+        kv_cache_spec=PrefixAnchoredSWASpec(
+            block_size=BLOCK_SIZE,
+            num_kv_heads=1,
+            head_size=1,
+            dtype=torch.float32,
+            decode_sliding_window=SLIDING_WINDOW,
+        ),
+    )
+
+
+def _num_null_blocks(scheduler, request_id: str) -> int:
+    manager = scheduler.kv_cache_manager.coordinator.single_type_managers[0]
+    null_block = manager._null_block
+    return sum(1 for b in manager.req_to_blocks[request_id] if b is null_block)
+
+
+def test_num_in_flight_tokens_accounting():
+    scheduler = create_scheduler(async_scheduling=True)
+    request = create_requests(num_requests=1, num_tokens=NUM_PROMPT_TOKENS)[0]
+    scheduler.add_request(request)
+
+    out0 = scheduler.schedule()
+    assert request.num_in_flight_tokens == NUM_PROMPT_TOKENS
+    # Async: decode scheduled before the prefill output is processed.
+    out1 = scheduler.schedule()
+    assert request.num_in_flight_tokens == NUM_PROMPT_TOKENS + 1
+
+    scheduler.update_from_output(out0, _make_model_runner_output(out0))
+    assert request.num_in_flight_tokens == 1
+    scheduler.update_from_output(out1, _make_model_runner_output(out1))
+    assert request.num_in_flight_tokens == 0
+
+
+def test_swa_free_waits_for_in_flight_step():
+    """Async: out-of-window blocks stay allocated until the step that still
+    reads them has been processed."""
+    scheduler = _create_swa_scheduler(async_scheduling=True)
+    request = create_requests(
+        num_requests=1, num_tokens=NUM_PROMPT_TOKENS, block_size=BLOCK_SIZE
+    )[0]
+    scheduler.add_request(request)
+    req_id = request.request_id
+    block_pool = scheduler.kv_cache_manager.block_pool
+
+    out0 = scheduler.schedule()  # prefill, in flight from here on
+    free_after_prefill = block_pool.get_num_free_blocks()
+
+    # Decode scheduled while the prefill still reads the out-of-window blocks:
+    # they must not be freed yet.
+    out1 = scheduler.schedule()
+    assert _num_null_blocks(scheduler, req_id) == 0
+    assert block_pool.get_num_free_blocks() == free_after_prefill
+
+    # Prefill output processed; the next allocate frees the out-of-window
+    # blocks.
+    scheduler.update_from_output(out0, _make_model_runner_output(out0))
+    scheduler.schedule()
+    assert _num_null_blocks(scheduler, req_id) == NUM_OUT_OF_WINDOW_BLOCKS
+    assert (
+        block_pool.get_num_free_blocks()
+        == free_after_prefill + NUM_OUT_OF_WINDOW_BLOCKS
+    )
+    # Not double-freed on the following steps.
+    scheduler.update_from_output(out1, _make_model_runner_output(out1))
+    scheduler.schedule()
+    assert _num_null_blocks(scheduler, req_id) == NUM_OUT_OF_WINDOW_BLOCKS
+
+
+def test_swa_free_immediate_when_sync():
+    """Sync: no in-flight step at schedule time, frees happen at the first
+    decode allocation as before."""
+    scheduler = _create_swa_scheduler(async_scheduling=False)
+    request = create_requests(
+        num_requests=1, num_tokens=NUM_PROMPT_TOKENS, block_size=BLOCK_SIZE
+    )[0]
+    scheduler.add_request(request)
+    req_id = request.request_id
+
+    out0 = scheduler.schedule()
+    scheduler.update_from_output(out0, _make_model_runner_output(out0))
+    assert request.num_in_flight_tokens == 0
+
+    scheduler.schedule()
+    assert _num_null_blocks(scheduler, req_id) == NUM_OUT_OF_WINDOW_BLOCKS
+
+
+def test_anchored_swa_gap_free_waits_for_in_flight_step():
+    """Prefix-anchored SWA (windowed OCR decode): gap blocks between the
+    prefill tail and the decode window are freed on the processed-token
+    basis under async scheduling — an in-flight step whose attention still
+    reads the gap must hold the blocks."""
+    scheduler = _create_anchored_scheduler(async_scheduling=True)
+    request = create_requests(
+        num_requests=1,
+        num_tokens=NUM_PROMPT_TOKENS,
+        block_size=BLOCK_SIZE,
+        max_tokens=200,
+        ignore_eos=True,
+    )[0]
+    scheduler.add_request(request)
+    req_id = request.request_id
+
+    # Prefill, then decode until a full gap block exists on the PROCESSED
+    # basis: gap = [ceil(P/bs), (T - W) // bs) needs T >= 144 for block 7
+    # (P=100 -> first_gap_block 7; (144-16)//16 = 8).
+    out_prev = scheduler.schedule()  # prefill (in flight)
+    scheduler.update_from_output(out_prev, _make_model_runner_output(out_prev))
+    for _ in range(44):  # T: 100 -> 144, settled step by step
+        out = scheduler.schedule()
+        scheduler.update_from_output(out, _make_model_runner_output(out))
+    assert request.num_in_flight_tokens == 0
+    assert request.num_computed_tokens >= 144
+
+    # Async over-scheduling: the settled-basis allocate on this schedule may
+    # evict gap blocks for the SETTLED T.
+    out_a = scheduler.schedule()
+    null_settled = _num_null_blocks(scheduler, req_id)
+    assert null_settled >= 1  # gap eviction engaged at all
+
+    # Second in-flight step: the optimistic boundary advances by 1 token but
+    # the processed basis does not — no additional frees may happen.
+    out_b = scheduler.schedule()
+    assert _num_null_blocks(scheduler, req_id) == null_settled
+
+    scheduler.update_from_output(out_a, _make_model_runner_output(out_a))
+    scheduler.update_from_output(out_b, _make_model_runner_output(out_b))
+
+
+def test_swa_admission_cap_accounts_for_overlapping_batches():
+    spec = SlidingWindowSpec(
+        block_size=16,
+        num_kv_heads=1,
+        head_size=1,
+        dtype=torch.float32,
+        sliding_window=1024,
+    )
+    base = spec.max_admission_blocks_per_request(
+        max_in_flight_tokens=1024, max_model_len=16384
+    )
+    # (1024 - 1 + 1024) tokens -> 128 blocks, +1 for window misalignment.
+    assert base == 129
+    overlapped = spec.max_admission_blocks_per_request(
+        max_in_flight_tokens=2 * 1024, max_model_len=16384
+    )
+    # One extra in-flight chunk is held back: (1024 - 1 + 2 * 1024) tokens.
+    assert overlapped == 193
+
+
+def test_chunked_local_free_waits_for_in_flight_step():
+    """Chunked-local attention frees whole chunks left of the current one, and
+    is exposed to the same load-WAR: with async scheduling those chunks must
+    stay allocated until the in-flight step that still reads them settles."""
+    scheduler = _create_chunked_scheduler(async_scheduling=True)
+    request = create_requests(
+        num_requests=1, num_tokens=NUM_PROMPT_TOKENS, block_size=BLOCK_SIZE
+    )[0]
+    scheduler.add_request(request)
+    req_id = request.request_id
+    block_pool = scheduler.kv_cache_manager.block_pool
+
+    out0 = scheduler.schedule()  # prefill, in flight from here on
+    free_after_prefill = block_pool.get_num_free_blocks()
+
+    # Decode scheduled while the prefill still reads the out-of-chunk blocks.
+    out1 = scheduler.schedule()
+    assert _num_null_blocks(scheduler, req_id) == 0
+    assert block_pool.get_num_free_blocks() == free_after_prefill
+
+    # Prefill output processed; the next allocate frees the out-of-chunk blocks.
+    scheduler.update_from_output(out0, _make_model_runner_output(out0))
+    scheduler.schedule()
+    assert _num_null_blocks(scheduler, req_id) == NUM_OUT_OF_CHUNK_BLOCKS
+    assert (
+        block_pool.get_num_free_blocks() == free_after_prefill + NUM_OUT_OF_CHUNK_BLOCKS
+    )
+    # Not double-freed on the following steps.
+    scheduler.update_from_output(out1, _make_model_runner_output(out1))
+    scheduler.schedule()
+    assert _num_null_blocks(scheduler, req_id) == NUM_OUT_OF_CHUNK_BLOCKS
+
+
+def test_chunked_local_admission_cap_accounts_for_overlapping_batches():
+    spec = ChunkedLocalAttentionSpec(
+        block_size=16,
+        num_kv_heads=1,
+        head_size=1,
+        dtype=torch.float32,
+        attention_chunk_size=1024,
+    )
+    base = spec.max_admission_blocks_per_request(
+        max_in_flight_tokens=1024, max_model_len=16384
+    )
+    # (1024 + 1024) tokens -> 128 blocks.
+    assert base == 128
+    overlapped = spec.max_admission_blocks_per_request(
+        max_in_flight_tokens=2 * 1024, max_model_len=16384
+    )
+    # One extra in-flight chunk is held back: (1024 + 2 * 1024) tokens.
+    assert overlapped == 192
+
+
+def test_connector_finish_frees_on_settled_basis():
+    """The out-of-window prune done at request finish, before the block table
+    is handed to a KV connector, must use the same processed-token basis."""
+    scheduler = create_scheduler(
+        block_size=BLOCK_SIZE,
+        async_scheduling=True,
+        use_kv_connector=mock_kv(matched_tokens=0, is_async=False),
+        kv_cache_spec=SlidingWindowSpec(
+            block_size=BLOCK_SIZE,
+            num_kv_heads=1,
+            head_size=1,
+            dtype=torch.float32,
+            sliding_window=SLIDING_WINDOW,
+        ),
+    )
+    request = create_requests(
+        num_requests=1, num_tokens=NUM_PROMPT_TOKENS, block_size=BLOCK_SIZE
+    )[0]
+    scheduler.add_request(request)
+    req_id = request.request_id
+
+    out0 = scheduler.schedule()  # prefill, in flight from here on
+    scheduler.schedule()  # decode over-scheduled: num_computed_tokens optimistic
+
+    # Finishing now (connector store) must NOT prune out-of-window blocks the
+    # in-flight prefill still reads.
+    scheduler._connector_finished(request)
+    assert _num_null_blocks(scheduler, req_id) == 0
+
+    # Once the in-flight step settles, the same prune releases them.
+    scheduler.update_from_output(out0, _make_model_runner_output(out0))
+    scheduler._connector_finished(request)
+    assert _num_null_blocks(scheduler, req_id) == NUM_OUT_OF_WINDOW_BLOCKS

--- a/tests/v1/core/utils.py
+++ b/tests/v1/core/utils.py
@@ -28,6 +28,7 @@ from vllm.v1.kv_cache_interface import (
     FullAttentionSpec,
     KVCacheConfig,
     KVCacheGroupSpec,
+    KVCacheSpec,
 )
 from vllm.v1.request import Request
 from vllm.v1.structured_output import StructuredOutputManager
@@ -57,6 +58,7 @@ def create_scheduler(
     pipeline_parallel_size: int = 1,
     use_ec_connector: bool = False,
     ec_role: str | None = None,
+    kv_cache_spec: KVCacheSpec | None = None,
 ) -> Scheduler | AsyncScheduler:
     """Create scheduler under test.
 
@@ -144,20 +146,17 @@ def create_scheduler(
         speculative_config=speculative_config,
         ec_transfer_config=ec_transfer_config,
     )
+    if kv_cache_spec is None:
+        kv_cache_spec = FullAttentionSpec(
+            block_size=block_size,
+            num_kv_heads=1,
+            head_size=1,
+            dtype=torch.float32,
+        )
     kv_cache_config = KVCacheConfig(
         num_blocks=num_blocks,  # A large number of blocks to hold all requests
         kv_cache_tensors=[],
-        kv_cache_groups=[
-            KVCacheGroupSpec(
-                ["layer"],
-                FullAttentionSpec(
-                    block_size=block_size,
-                    num_kv_heads=1,
-                    head_size=1,
-                    dtype=torch.float32,
-                ),
-            )
-        ],
+        kv_cache_groups=[KVCacheGroupSpec(["layer"], kv_cache_spec)],
     )
     cache_config.num_gpu_blocks = num_blocks
     scheduler_cls = AsyncScheduler if async_scheduling else Scheduler

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -601,6 +601,28 @@ class VllmConfig:
         return hash_str
 
     @property
+    def max_concurrent_batches(self) -> int:
+        # Scheduler-side upper bound mirroring the executors'
+        # `max_concurrent_batches` (multiproc: queue depth under async
+        # scheduling, else the PP pipeline depth).
+        pp_size = self.parallel_config.pipeline_parallel_size
+        if pp_size <= 1 and self.scheduler_config.async_scheduling:
+            return max(2, envs.VLLM_SM70_ASYNC_SCHEDULING_QUEUE_DEPTH)
+        return pp_size
+
+    @property
+    def max_in_flight_tokens(self) -> int:
+        # Upper bound on tokens that are scheduled but not yet settled (freed):
+        # every concurrent batch may hold up to a full `max_num_batched_tokens`.
+        # Recycling-aware KV cache specs (sliding-window, chunked-local,
+        # prefix-anchored SWA) reserve for this because out-of-window blocks
+        # are freed on the processed-token basis, so in-flight steps
+        # transiently keep their blocks.
+        return (
+            self.max_concurrent_batches * self.scheduler_config.max_num_batched_tokens
+        )
+
+    @property
     def num_speculative_tokens(self) -> int:
         if (
             self.speculative_config is not None

--- a/vllm/v1/core/kv_cache_coordinator.py
+++ b/vllm/v1/core/kv_cache_coordinator.py
@@ -34,7 +34,7 @@ class KVCacheCoordinator(ABC):
         self,
         kv_cache_config: KVCacheConfig,
         max_model_len: int,
-        max_num_batched_tokens: int,
+        max_in_flight_tokens: int,
         use_eagle: bool,
         enable_caching: bool,
         enable_kv_cache_events: bool,
@@ -66,7 +66,7 @@ class KVCacheCoordinator(ABC):
         self.single_type_managers = tuple(
             get_manager_for_kv_cache_spec(
                 kv_cache_spec=kv_cache_group.kv_cache_spec,
-                max_num_batched_tokens=max_num_batched_tokens,
+                max_in_flight_tokens=max_in_flight_tokens,
                 max_model_len=max_model_len,
                 block_pool=self.block_pool,
                 enable_caching=enable_caching,
@@ -238,7 +238,7 @@ class KVCacheCoordinator(ABC):
     def remove_skipped_blocks(
         self,
         request_id: str,
-        total_computed_tokens: int,
+        processed_computed_tokens: int,
         num_prompt_tokens: int | None = None,
     ) -> None:
         """
@@ -247,15 +247,15 @@ class KVCacheCoordinator(ABC):
 
         Args:
             request_id: The request ID.
-            total_computed_tokens: The total number of computed tokens, including
-                local computed tokens and external computed tokens.
+            processed_computed_tokens: Computed-token prefix length covering
+                fully processed and committed tokens only (safe to free).
             num_prompt_tokens: Optional prompt length. Prefix-anchored SWA
                 managers use this to free gap blocks between the prefill tail
                 and the decode window; other manager types ignore it.
         """
         for manager in self.single_type_managers:
             manager.remove_skipped_blocks(
-                request_id, total_computed_tokens, num_prompt_tokens
+                request_id, processed_computed_tokens, num_prompt_tokens
             )
 
     def get_blocks(self, request_id: str) -> tuple[list[KVCacheBlock], ...]:
@@ -293,7 +293,7 @@ class KVCacheCoordinatorNoPrefixCache(KVCacheCoordinator):
         self,
         kv_cache_config: KVCacheConfig,
         max_model_len: int,
-        max_num_batched_tokens: int,
+        max_in_flight_tokens: int,
         use_eagle: bool,
         enable_kv_cache_events: bool,
         dcp_world_size: int,
@@ -304,7 +304,7 @@ class KVCacheCoordinatorNoPrefixCache(KVCacheCoordinator):
         super().__init__(
             kv_cache_config,
             max_model_len,
-            max_num_batched_tokens,
+            max_in_flight_tokens,
             use_eagle,
             False,
             enable_kv_cache_events,
@@ -340,7 +340,7 @@ class UnitaryKVCacheCoordinator(KVCacheCoordinator):
         self,
         kv_cache_config: KVCacheConfig,
         max_model_len: int,
-        max_num_batched_tokens: int,
+        max_in_flight_tokens: int,
         use_eagle: bool,
         enable_caching: bool,
         enable_kv_cache_events: bool,
@@ -352,7 +352,7 @@ class UnitaryKVCacheCoordinator(KVCacheCoordinator):
         super().__init__(
             kv_cache_config,
             max_model_len,
-            max_num_batched_tokens,
+            max_in_flight_tokens,
             use_eagle,
             enable_caching,
             enable_kv_cache_events,
@@ -407,7 +407,7 @@ class HybridKVCacheCoordinator(KVCacheCoordinator):
         self,
         kv_cache_config: KVCacheConfig,
         max_model_len: int,
-        max_num_batched_tokens: int,
+        max_in_flight_tokens: int,
         use_eagle: bool,
         enable_caching: bool,
         enable_kv_cache_events: bool,
@@ -419,7 +419,7 @@ class HybridKVCacheCoordinator(KVCacheCoordinator):
         super().__init__(
             kv_cache_config,
             max_model_len,
-            max_num_batched_tokens,
+            max_in_flight_tokens,
             use_eagle,
             enable_caching,
             enable_kv_cache_events,
@@ -618,7 +618,7 @@ class HybridKVCacheCoordinator(KVCacheCoordinator):
 def get_kv_cache_coordinator(
     kv_cache_config: KVCacheConfig,
     max_model_len: int,
-    max_num_batched_tokens: int,
+    max_in_flight_tokens: int,
     use_eagle: bool,
     enable_caching: bool,
     enable_kv_cache_events: bool,
@@ -631,7 +631,7 @@ def get_kv_cache_coordinator(
         return KVCacheCoordinatorNoPrefixCache(
             kv_cache_config,
             max_model_len,
-            max_num_batched_tokens,
+            max_in_flight_tokens,
             use_eagle,
             enable_kv_cache_events,
             dcp_world_size=dcp_world_size,
@@ -643,7 +643,7 @@ def get_kv_cache_coordinator(
         return UnitaryKVCacheCoordinator(
             kv_cache_config,
             max_model_len,
-            max_num_batched_tokens,
+            max_in_flight_tokens,
             use_eagle,
             enable_caching,
             enable_kv_cache_events,
@@ -655,7 +655,7 @@ def get_kv_cache_coordinator(
     return HybridKVCacheCoordinator(
         kv_cache_config,
         max_model_len,
-        max_num_batched_tokens,
+        max_in_flight_tokens,
         use_eagle,
         enable_caching,
         enable_kv_cache_events,

--- a/vllm/v1/core/kv_cache_manager.py
+++ b/vllm/v1/core/kv_cache_manager.py
@@ -117,7 +117,7 @@ class KVCacheManager:
         kv_cache_config: KVCacheConfig,
         max_model_len: int,
         hash_block_size: int,
-        max_num_batched_tokens: int | None = None,
+        max_in_flight_tokens: int | None = None,
         enable_caching: bool = True,
         use_eagle: bool = False,
         log_stats: bool = False,
@@ -130,8 +130,8 @@ class KVCacheManager:
         # When unset, fall back to `max_model_len` so the recycling-aware cap
         # collapses to the prior (uncapped) admission behavior. The scheduler
         # always supplies the real value at runtime.
-        if max_num_batched_tokens is None:
-            max_num_batched_tokens = max_model_len
+        if max_in_flight_tokens is None:
+            max_in_flight_tokens = max_model_len
 
         self.enable_caching = enable_caching
         self.use_eagle = use_eagle
@@ -145,7 +145,7 @@ class KVCacheManager:
         self.coordinator = get_kv_cache_coordinator(
             kv_cache_config=kv_cache_config,
             max_model_len=self.max_model_len,
-            max_num_batched_tokens=max_num_batched_tokens,
+            max_in_flight_tokens=max_in_flight_tokens,
             use_eagle=self.use_eagle,
             enable_caching=self.enable_caching,
             enable_kv_cache_events=enable_kv_cache_events,
@@ -374,9 +374,12 @@ class KVCacheManager:
         # insufficient free blocks.
         # Should call this function before allocating new blocks to reduce
         # the number of evicted blocks.
+        # Free on the processed-token basis: in-flight steps' attention windows
+        # still read blocks below the optimistic boundary, and rejected spec
+        # tokens can roll it back.
         self.coordinator.remove_skipped_blocks(
             request.request_id,
-            total_computed_tokens,
+            max(0, total_computed_tokens - request.num_in_flight_tokens),
             num_prompt_tokens=request.num_prompt_tokens,
         )
 
@@ -445,7 +448,7 @@ class KVCacheManager:
     def remove_skipped_blocks(
         self,
         request_id: str,
-        total_computed_tokens: int,
+        processed_computed_tokens: int,
         num_prompt_tokens: int | None = None,
     ) -> None:
         """Remove the blocks that are no longer needed from `blocks` and replace
@@ -453,13 +456,13 @@ class KVCacheManager:
 
         Args:
             request_id: The request ID.
-            total_computed_tokens: The total number of computed tokens, including
-                local computed tokens and external computed tokens.
+            processed_computed_tokens: Computed-token prefix length covering
+                fully processed and committed tokens only (safe to free).
             num_prompt_tokens: Optional prompt length for prefix-anchored SWA
                 gap eviction.
         """
         self.coordinator.remove_skipped_blocks(
-            request_id, total_computed_tokens, num_prompt_tokens
+            request_id, processed_computed_tokens, num_prompt_tokens
         )
 
     def evict_blocks(self, block_ids: set[int]) -> None:

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -258,7 +258,7 @@ class Scheduler(SchedulerInterface):
         self.kv_cache_manager = KVCacheManager(
             kv_cache_config=kv_cache_config,
             max_model_len=self.max_model_len,
-            max_num_batched_tokens=self.scheduler_config.max_num_batched_tokens,
+            max_in_flight_tokens=vllm_config.max_in_flight_tokens,
             enable_caching=self.cache_config.enable_prefix_caching,
             use_eagle=self.use_eagle,
             log_stats=self.log_stats,
@@ -1192,6 +1192,7 @@ class Scheduler(SchedulerInterface):
         for req_id, num_scheduled_token in num_scheduled_tokens.items():
             request = self.requests[req_id]
             request.num_computed_tokens += num_scheduled_token
+            request.num_in_flight_tokens += num_scheduled_token
             request.is_prefill_chunk = request.num_computed_tokens < (
                 request.num_tokens + request.num_output_placeholders
             )
@@ -1576,10 +1577,12 @@ class Scheduler(SchedulerInterface):
         stopped_preempted_reqs: set[Request] = set()
         for req_id, num_tokens_scheduled in num_scheduled_tokens.items():
             assert num_tokens_scheduled > 0
+            request = self.requests.get(req_id)
+            if request is not None:
+                request.num_in_flight_tokens -= num_tokens_scheduled
             if failed_kv_load_req_ids and req_id in failed_kv_load_req_ids:
                 # skip failed or rescheduled requests from KV load failure
                 continue
-            request = self.requests.get(req_id)
             if request is None or request.is_finished():
                 # The request is already finished. This can happen if the
                 # request is aborted while the model is executing it (e.g.,
@@ -2383,10 +2386,12 @@ class Scheduler(SchedulerInterface):
             return False, None
 
         # Free any out-of-window prefix blocks before we hand the block table to
-        # the connector.
+        # the connector, on the processed-token basis (see `allocate_slots`).
         self.kv_cache_manager.remove_skipped_blocks(
             request_id=request.request_id,
-            total_computed_tokens=request.num_computed_tokens,
+            processed_computed_tokens=max(
+                0, request.num_computed_tokens - request.num_in_flight_tokens
+            ),
             num_prompt_tokens=request.num_prompt_tokens,
         )
 

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -479,7 +479,7 @@ class SingleTypeKVCacheManager(ABC):
     def remove_skipped_blocks(
         self,
         request_id: str,
-        total_computed_tokens: int,
+        processed_computed_tokens: int,
         num_prompt_tokens: int | None = None,
     ) -> None:
         """
@@ -491,15 +491,15 @@ class SingleTypeKVCacheManager(ABC):
 
         Args:
             request_id: The request ID.
-            total_computed_tokens: The total number of computed tokens, including
-                local computed tokens and external computed tokens.
+            processed_computed_tokens: Computed-token prefix length covering
+                fully processed and committed tokens only (safe to free).
             num_prompt_tokens: Optional prompt length for attention types (e.g.
                 prefix-anchored SWA) that evict a middle gap rather than a head
                 prefix. Ignored by the default implementation.
         """
         del num_prompt_tokens
         # Remove the blocks that will be skipped during attention computation.
-        num_skipped_tokens = self.get_num_skipped_tokens(total_computed_tokens)
+        num_skipped_tokens = self.get_num_skipped_tokens(processed_computed_tokens)
         if num_skipped_tokens <= 0:
             # This indicates that ALL tokens are inside attention window.
             # Thus we do not need to free any blocks outside attention window.
@@ -608,14 +608,14 @@ class PrefixAnchoredSWAManager(FullAttentionManager):
     def remove_skipped_blocks(
         self,
         request_id: str,
-        total_computed_tokens: int,
+        processed_computed_tokens: int,
         num_prompt_tokens: int | None = None,
     ) -> None:
         """Free gap blocks that are no longer needed for attention.
 
         Gap = blocks entirely within
             [ceil(prefix_len / block_size) * block_size,
-             max(prefix_len, total_computed_tokens - decode_sliding_window))
+             max(prefix_len, processed_computed_tokens - decode_sliding_window))
 
         Freed blocks are replaced with null_block in req_to_blocks so the
         block_table handed to the attention backend stays valid (null_block
@@ -624,7 +624,7 @@ class PrefixAnchoredSWAManager(FullAttentionManager):
         """
         if num_prompt_tokens is None:
             super().remove_skipped_blocks(
-                request_id, total_computed_tokens, num_prompt_tokens
+                request_id, processed_computed_tokens, num_prompt_tokens
             )
             return
 
@@ -633,7 +633,7 @@ class PrefixAnchoredSWAManager(FullAttentionManager):
         first_gap_block = cdiv(num_prompt_tokens, bs)
         # Decode window start position; blocks before this are evictable.
         window_start = max(
-            num_prompt_tokens, total_computed_tokens - self.decode_sliding_window
+            num_prompt_tokens, processed_computed_tokens - self.decode_sliding_window
         )
         last_gap_block = window_start // bs  # exclusive upper bound
         self._remove_blocks_in_range(request_id, first_gap_block, last_gap_block)
@@ -1005,20 +1005,13 @@ class MambaManager(SingleTypeKVCacheManager):
     def remove_skipped_blocks(
         self,
         request_id: str,
-        num_computed_tokens: int,
+        processed_computed_tokens: int,
         num_prompt_tokens: int | None = None,
     ) -> None:
         assert isinstance(self.kv_cache_spec, MambaSpec)
 
-        # NOTE (tdoublep) with async scheduling, the num_computed_tokens can contain
-        # draft tokens from the previous step that may or may not be rejected later.
-        # This can make us think we are further ahead in the sequence than we actually
-        # are, so let's assume that all tokens are rejected so we don't free blocks
-        # that we might actually need.
-        num_computed_tokens = max(0, num_computed_tokens - self.num_speculative_blocks)
-
         super().remove_skipped_blocks(
-            request_id, num_computed_tokens, num_prompt_tokens
+            request_id, processed_computed_tokens, num_prompt_tokens
         )
         if self.mamba_cache_mode == "align":
             # `last_state_block_idx` refers to the block index allocated two steps ago.
@@ -1032,7 +1025,7 @@ class MambaManager(SingleTypeKVCacheManager):
             if (
                 last_state_block_idx is not None
                 and last_state_block_idx
-                < cdiv(num_computed_tokens, self.block_size) - 1
+                < cdiv(processed_computed_tokens, self.block_size) - 1
             ):
                 blocks = self.req_to_blocks[request_id]
                 if blocks[last_state_block_idx] != self._null_block:
@@ -1338,7 +1331,7 @@ spec_manager_map: dict[type[KVCacheSpec], type[SingleTypeKVCacheManager]] = {
 
 def get_manager_for_kv_cache_spec(
     kv_cache_spec: KVCacheSpec,
-    max_num_batched_tokens: int,
+    max_in_flight_tokens: int,
     max_model_len: int,
     **kwargs,
 ) -> SingleTypeKVCacheManager:
@@ -1349,7 +1342,7 @@ def get_manager_for_kv_cache_spec(
     if isinstance(kv_cache_spec, (SlidingWindowSpec, ChunkedLocalAttentionSpec)):
         kwargs["max_admission_blocks_per_request"] = (
             kv_cache_spec.max_admission_blocks_per_request(
-                max_num_batched_tokens=max_num_batched_tokens,
+                max_in_flight_tokens=max_in_flight_tokens,
                 max_model_len=max_model_len,
             )
         )

--- a/vllm/v1/kv_cache_interface.py
+++ b/vllm/v1/kv_cache_interface.py
@@ -454,7 +454,7 @@ class ChunkedLocalAttentionSpec(AttentionSpec):
     attention_chunk_size: int
 
     def max_admission_blocks_per_request(
-        self, max_num_batched_tokens: int, max_model_len: int
+        self, max_in_flight_tokens: int, max_model_len: int
     ) -> int:
         """Per-request admission cap, in blocks.
 
@@ -464,15 +464,15 @@ class ChunkedLocalAttentionSpec(AttentionSpec):
         """
         # During chunked prefill, we hold KV for at most one chunk window.
         num_tokens = min(
-            self.attention_chunk_size + max_num_batched_tokens, max_model_len
+            self.attention_chunk_size + max_in_flight_tokens, max_model_len
         )
         return cdiv(num_tokens, self.block_size)
 
     def max_memory_usage_bytes(self, vllm_config: VllmConfig) -> int:
         max_model_len = vllm_config.model_config.max_model_len
-        max_num_batched_tokens = vllm_config.scheduler_config.max_num_batched_tokens
+        max_in_flight_tokens = vllm_config.max_in_flight_tokens
         max_blocks = self.max_admission_blocks_per_request(
-            max_num_batched_tokens=max_num_batched_tokens, max_model_len=max_model_len
+            max_in_flight_tokens=max_in_flight_tokens, max_model_len=max_model_len
         )
         return max_blocks * self.page_size_bytes
 
@@ -507,7 +507,7 @@ class SlidingWindowSpec(AttentionSpec):
         )
 
     def max_admission_blocks_per_request(
-        self, max_num_batched_tokens: int, max_model_len: int
+        self, max_in_flight_tokens: int, max_model_len: int
     ) -> int:
         """Per-request admission cap, in blocks.
 
@@ -520,9 +520,7 @@ class SlidingWindowSpec(AttentionSpec):
         # During chunked prefill, we hold KV for the last `sliding_window-1`
         # computed tokens plus the newly scheduled tokens, and never more
         # than `max_model_len`.
-        num_tokens = min(
-            self.sliding_window - 1 + max_num_batched_tokens, max_model_len
-        )
+        num_tokens = min(self.sliding_window - 1 + max_in_flight_tokens, max_model_len)
         # +1 because the sliding window may not start from the beginning of
         # the block. E.g. block size 4 and num_token 4 needs two blocks
         # [XXCD][EF] to store the 6-token window [CDEF].
@@ -533,9 +531,9 @@ class SlidingWindowSpec(AttentionSpec):
             "DCP not support sliding window."
         )
         max_model_len = vllm_config.model_config.max_model_len
-        max_num_batched_tokens = vllm_config.scheduler_config.max_num_batched_tokens
+        max_in_flight_tokens = vllm_config.max_in_flight_tokens
         max_blocks = self.max_admission_blocks_per_request(
-            max_num_batched_tokens=max_num_batched_tokens, max_model_len=max_model_len
+            max_in_flight_tokens=max_in_flight_tokens, max_model_len=max_model_len
         )
         return max_blocks * self.page_size_bytes
 

--- a/vllm/v1/request.py
+++ b/vllm/v1/request.py
@@ -141,6 +141,11 @@ class Request:
         self.num_output_placeholders = 0
         self.async_tokens_to_discard = 0
 
+        # Tokens of steps whose output is not yet processed (async scheduling
+        # and PP run ahead of the GPU); `num_computed_tokens` counts them
+        # optimistically.
+        self.num_in_flight_tokens = 0
+
         self.spec_token_ids: list[int] = []
         self.num_computed_tokens = 0
         self.cache_salt: str | None = cache_salt

--- a/vllm/v1/simple_kv_offload/manager.py
+++ b/vllm/v1/simple_kv_offload/manager.py
@@ -119,9 +119,7 @@ class SimpleCPUOffloadScheduler:
         self.cpu_coordinator: KVCacheCoordinator = get_kv_cache_coordinator(
             kv_cache_config=self.cpu_kv_cache_config,
             max_model_len=vllm_config.model_config.max_model_len,
-            max_num_batched_tokens=(
-                vllm_config.scheduler_config.max_num_batched_tokens
-            ),
+            max_in_flight_tokens=vllm_config.max_in_flight_tokens,
             use_eagle=False,
             enable_caching=True,
             enable_kv_cache_events=self.enable_kv_cache_events,


### PR DESCRIPTION
## Purpose

Extract the model-independent inference-engine repair from #293 without merging architecture-keyed serving defaults or OCR-specific behavior.

- Track scheduled tokens whose outputs have not settled under async scheduling and pipeline parallelism.
- Free sliding-window, chunked-local, prefix-anchored SWA, and Mamba blocks only from the processed-token boundary.
- Size recycling-aware KV admission for the same concurrent-batch bound used by the executor.
- Preserve original author credit from #293.

Admission and lifetime decisions use scheduler concurrency, token state, cache geometry, attention windows, and block ownership only. No model name, checkpoint, model_type, or architecture identity is consulted.

## Test Plan / Result

- Focused in-flight/cache/accounting tests: 17 passed.
- Complete async scheduler unit file: 11 passed.
- Simple CPU-offload store/load round trip: passed.
- Changed-file pre-commit: all hooks passed.
- Source audit: no runtime model-identity admission found.

This is a cache-lifetime correctness repair; no throughput claim is made. Full-model E2E is unnecessary for this scheduler-only change.