### PR TITLE
[Core] Add generic UVA multimodal tower offload

### DIFF
--- a/docs/design/sm70_v100_migration_control.md
+++ b/docs/design/sm70_v100_migration_control.md
@@ -43405,3 +43405,25 @@ Interpretation:
   contract, validate artifact self-consistency, and gate aggregate HumanEval,
   LongBench, GSM8K, and needle-retrieval quality. They report directional
   sample flips but do not treat greedy identity as task quality.
+
+## 2026-08-26 generic multimodal-tower UVA offload
+
+- PR #297 originally wrapped one named vision module by invoking the layer
+  offloader a second time. That form is not admitted: it is model-specific,
+  loses the tower prefix needed by `--cpu-offload-params visual`, and violates
+  the prefetch backend's single-call contract.
+- The accepted path is an engine-level component hook on every module recorded
+  by the existing multimodal tower lifecycle. UVA qualifies relative parameter
+  names with the recorded module path before applying exact segment matching;
+  layer-prefetch and no-op backends inherit a single-component no-op. Parameters
+  already visited through `make_layers()` are not copied or counted twice.
+- Admission uses only the configured offload backend and budget, the explicit
+  parameter-path selector, and the module's generic tower role. It never reads
+  a model name, checkpoint path, `model_type`, or architecture identity. With no
+  CPU-offload budget the global offloader remains a no-op.
+- The submitted V100 evidence reports about 0.78 GiB additional device memory
+  per rank, a 152,056-token KV pool, and successful 151,296-token context on
+  two 16-GiB V100 ranks. Text-only decode does not execute the tower; image
+  prefill accepts the expected PCIe/UVA cost. This is capacity evidence, not a
+  general throughput claim, so the route remains explicitly configured rather
+  than becoming an unconditional default.

--- a/tests/model_executor/test_uva_tower_offload.py
+++ b/tests/model_executor/test_uva_tower_offload.py
@@ -1,0 +1,89 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from collections.abc import Generator
+from types import SimpleNamespace
+
+import torch.nn as nn
+
+from vllm.model_executor.models.interfaces import SupportsMultiModal
+from vllm.model_executor.offloader import (
+    BaseOffloader,
+    PrefetchOffloader,
+    get_offloader,
+    set_offloader,
+)
+from vllm.model_executor.offloader.uva import UVAOffloader
+
+
+class _RecordingOffloader(BaseOffloader):
+    def __init__(self) -> None:
+        self.component_calls: list[tuple[nn.Module, str]] = []
+
+    def wrap_modules(
+        self, modules_generator: Generator[nn.Module, None, None]
+    ) -> list[nn.Module]:
+        raise AssertionError("tower registration must not reuse the layer wrapper")
+
+    def wrap_module(
+        self, module: nn.Module, *, parameter_prefix: str = ""
+    ) -> nn.Module:
+        self.component_calls.append((module, parameter_prefix))
+        return module
+
+
+class _MultiModalModel(nn.Module):
+    _mark_tower_model = SupportsMultiModal._mark_tower_model
+
+
+def _selector_only_offloader(selectors: set[str]) -> UVAOffloader:
+    offloader = UVAOffloader.__new__(UVAOffloader)
+    offloader.cpu_offload_params = selectors
+    return offloader
+
+
+def test_uva_tower_selector_uses_qualified_parameter_path() -> None:
+    offloader = _selector_only_offloader({"visual"})
+
+    assert offloader._is_parameter_selected("patch_embed.proj.weight", "visual")
+    assert not offloader._is_parameter_selected("patch_embed.proj.weight", "audio")
+    assert not offloader._is_parameter_selected("patch_embed.proj.weight", "visualizer")
+    assert _selector_only_offloader(set())._is_parameter_selected(
+        "patch_embed.proj.weight", "visual"
+    )
+
+
+def test_uva_multi_segment_selector_remains_segment_exact() -> None:
+    offloader = _selector_only_offloader({"visual.patch_embed"})
+
+    assert offloader._is_parameter_selected("patch_embed.proj.weight", "visual")
+    assert not offloader._is_parameter_selected("patch_embedding.proj.weight", "visual")
+
+
+def test_tower_registration_uses_single_component_wrapper() -> None:
+    model = _MultiModalModel()
+    offloader = _RecordingOffloader()
+    previous_offloader = get_offloader()
+    config = SimpleNamespace(
+        model_config=SimpleNamespace(
+            multimodal_config=SimpleNamespace(get_limit_per_prompt=lambda _modality: 1)
+        )
+    )
+
+    set_offloader(offloader)
+    try:
+        with model._mark_tower_model(config, "image"):
+            model.visual = nn.Linear(4, 4)
+    finally:
+        set_offloader(previous_offloader)
+
+    assert model._tower_model_names == ["visual"]
+    assert offloader.component_calls == [(model.visual, "visual")]
+
+
+def test_prefetch_inherits_noop_component_wrapper() -> None:
+    tower = nn.Linear(4, 4)
+    offloader = PrefetchOffloader.__new__(PrefetchOffloader)
+
+    assert PrefetchOffloader.wrap_module is BaseOffloader.wrap_module
+    assert offloader.wrap_module(tower, parameter_prefix="visual") is tower

--- a/vllm/config/offload.py
+++ b/vllm/config/offload.py
@@ -40,6 +40,9 @@ class UVAOffloadConfig:
         - For parameter name "mlp.experts.w2_weight":
             - "experts" or "experts.w2_weight" will match.
             - "expert" or "w2" will NOT match (must be exact segments).
+        - A tower component name such as "visual" selects that complete
+          multimodal tower, including parameters whose names are relative to
+          the tower module.
     This allows distinguishing parameters like "w2_weight" and "w2_weight_scale".
     """
 

--- a/vllm/model_executor/models/interfaces.py
+++ b/vllm/model_executor/models/interfaces.py
@@ -265,6 +265,8 @@ class SupportsMultiModal(Protocol):
         If `targets` is set, instead include descendants that are an instance
         of `targets`, even if they aren't direct children.
         """
+        from vllm.model_executor.offloader import get_offloader
+
         from .utils import StageMissingLayer, collect_children, no_init_weights
 
         if isinstance(modalities, str):
@@ -290,6 +292,14 @@ class SupportsMultiModal(Protocol):
                 yield
 
         self._tower_model_names = children_names
+        offloader = get_offloader()
+        for name in children_names:
+            if not name:
+                continue
+            tower = self.get_submodule(name)
+            wrapped = offloader.wrap_module(tower, parameter_prefix=name)
+            if wrapped is not tower:
+                self.set_submodule(name, wrapped)
 
     @contextmanager
     def _mark_composite_model(

--- a/vllm/model_executor/models/qwen3_5.py
+++ b/vllm/model_executor/models/qwen3_5.py
@@ -846,6 +846,11 @@ class Qwen3_5ForConditionalGeneration(Qwen3VLForConditionalGeneration, IsHybrid)
                 quant_config=quant_config,
                 prefix=maybe_prefix(prefix, "visual"),
             )
+            # [patch 2026-08-25] Let --cpu-offload-gb / --cpu-offload-params
+            # move the vision tower into pinned host RAM (UVA zero-copy).
+            from vllm.model_executor.offloader import get_offloader
+
+            self.visual = get_offloader().wrap_modules([self.visual])[0]
 
         with self._mark_language_model(vllm_config):
             self.language_model = Qwen3_5ForCausalLM(

--- a/vllm/model_executor/offloader/base.py
+++ b/vllm/model_executor/offloader/base.py
@@ -76,6 +76,18 @@ class BaseOffloader(ABC):
         """
         return
 
+    def wrap_module(
+        self, module: nn.Module, *, parameter_prefix: str = ""
+    ) -> nn.Module:
+        """Optionally offload one non-layer component.
+
+        Layer-prefetch backends intentionally inherit this no-op. UVA
+        overrides it so model components created outside ``make_layers`` can
+        participate without invoking a backend's multi-layer wrapper twice.
+        """
+        del parameter_prefix
+        return module
+
     def sync_prev_onload(self) -> None:  # noqa: B027
         """Sync previous onload operations. Override in subclasses."""
         pass

--- a/vllm/model_executor/offloader/uva.py
+++ b/vllm/model_executor/offloader/uva.py
@@ -61,7 +61,30 @@ class UVAOffloader(BaseOffloader):
             )
         return modules
 
-    def _maybe_offload_to_cpu(self, module: nn.Module) -> nn.Module:
+    def wrap_module(
+        self, module: nn.Module, *, parameter_prefix: str = ""
+    ) -> nn.Module:
+        """Apply UVA offloading to one component with its qualified prefix."""
+        previous_offload_bytes = self.cpu_offload_bytes
+        module = self._maybe_offload_to_cpu(module, parameter_prefix=parameter_prefix)
+        if self.cpu_offload_bytes > previous_offload_bytes:
+            logger.info(
+                "Total CPU offloaded parameters: %s",
+                format_gib(self.cpu_offload_bytes),
+            )
+        return module
+
+    def _is_parameter_selected(self, name: str, parameter_prefix: str = "") -> bool:
+        if not self.cpu_offload_params:
+            return True
+        qualified_name = f"{parameter_prefix}.{name}" if parameter_prefix else name
+        return any(
+            f".{param}." in f".{qualified_name}." for param in self.cpu_offload_params
+        )
+
+    def _maybe_offload_to_cpu(
+        self, module: nn.Module, *, parameter_prefix: str = ""
+    ) -> nn.Module:
         """Offload module parameters to CPU using UVA if budget allows."""
         if (params := next(module.parameters(), None)) is None:
             return module
@@ -83,16 +106,17 @@ class UVAOffloader(BaseOffloader):
                 # one module might have some parameters offloaded and some not
                 break
 
-            if self.cpu_offload_params:
-                # Check if parameter belongs to the offloading set
-                # Add dots here to ensure we match full segments only
-                # e.g., "experts.w2_weight" matches "mlp.experts.w2_weight"
-                # but not "mlp.experts.w2_weight_scale"
-                should_offload = any(
-                    f".{param}." in f".{name}." for param in self.cpu_offload_params
-                )
-                if not should_offload:
-                    continue
+            # Add dots to require exact path-segment matches. A qualified
+            # prefix lets selectors such as ``visual`` target an entire tower
+            # even though ``module.named_parameters()`` returns relative names.
+            if not self._is_parameter_selected(name, parameter_prefix):
+                continue
+
+            # A component may contain layers already visited by make_layers().
+            # Do not copy or account for the same UVA parameter twice when the
+            # enclosing component is registered afterwards.
+            if getattr(p, "_vllm_is_uva_offloaded", False):
+                continue
 
             cpu_data = p.data.to(device="cpu")
             if self.pin_memory:


### PR DESCRIPTION
## Purpose

Allow multimodal tower parameters to participate in explicit UVA CPU offloading, recovering device memory for KV capacity without adding model/checkpoint identity admission.

## Audit fixes

- Replace the Qwen-specific `self.visual` patch with the existing generic multimodal-tower lifecycle hook.
- Preserve the tower path when matching `--cpu-offload-params`, so `visual` actually selects relative parameters such as `patch_embed.proj.weight`.
- Add a single-component offloader API. UVA implements it; prefetch and no-op backends inherit a no-op, avoiding the original second `wrap_modules()` call and its prefetch assertion.
- Skip parameters already UVA-offloaded through `make_layers()` so nested components are not copied or counted twice.

## Runtime contract

This remains explicitly configured through `--cpu-offload-gb` and optional parameter-path selectors because image/audio tower execution pays PCIe/UVA bandwidth. With no budget, the offloader is unchanged and no-op. Admission uses the selected backend, memory budget, exact parameter path, and generic tower role only; it never reads model name, checkpoint, `model_type`, or architecture identity. Text-only decode does not execute the tower.

## Test plan and result

- `pytest -q tests/model_executor/test_uva_tower_offload.py`: 4 passed.
- Changed-file pre-commit: all hooks passed, including ruff, formatting, typos, mypy, SPDX, configuration validation, and forbidden-import checks.
- Submitted V100 capacity evidence: about 0.78 GiB per rank recovered, KV pool increased to 152,056 tokens, and 151,296-token context completed on two V100 16-GiB ranks. This is capacity evidence, not a general throughput claim.

Signed-off-by: yangzhuxinyzx <153831768+yangzhuxinyzx@users.noreply.github.com>