### PR TITLE
[Bugfix][SM70] Guard grouped DFlash RMSNorm runtime

### DIFF
--- a/docs/design/sm70_dflash2_nvfp4_17ms.md
+++ b/docs/design/sm70_dflash2_nvfp4_17ms.md
@@ -41,6 +41,114 @@ measures request-mean acceptance `4.45732`, pooled acceptance `4.07740`, and
 `19.3688 ms` per round with diagnostic counters enabled. Diagnostic timing is
 not a production baseline.
 
+## Acceptance and runtime-binary audit
+
+The apparent NVFP4 acceptance regression was reproduced on the frozen 64-row
+GSM8K order, but it is not caused by NVFP4. With the same current source and
+the same official stochastic contract, FP8 measured request-mean/pooled
+acceptance `4.49887/3.89772` and 60/64 accuracy; NVFP4 measured
+`4.53642/3.79374` and 59/64. The request mean is slightly higher for NVFP4.
+Its lower pooled value comes from a longer generated trajectory and is not a
+valid quantization comparison by itself. The corresponding request-mean
+completion tokens per verification round are `4.49761` and `4.53214`; this
+closely related metric was previously mislabeled as request-mean acceptance.
+All future records report both fields explicitly.
+
+Both current paths are nevertheless below the repaired August 22 FP8 baseline
+of `5.38880/4.56444` (`5.38884` request-mean completion tokens per round).
+This is a real regression rather than only output-length mix: current FP8 is
+lower on 61 of the 64 matched prompts, with paired
+request-mean delta `-0.89123` and bootstrap 95% interval
+`[-1.02152,-0.75597]`. Restricting each run to outputs of at most 512 tokens
+still moves the mean from `5.60920` to `4.63777`.
+
+Single-variable runs exclude the target quantized operators and compact
+sampler as the main cause. Disabling NVFP4 QPN2 on the fixed 16 rows measured
+`4.37420` request mean instead of recovering the current `4.57520` control.
+Disabling FP8 target QPN8 on all 64 rows measured `4.49095/3.80785`, and
+disabling sparse target rejection measured `4.51820/4.02970`; none approaches
+the repaired baseline. All completed 64-row variants retained 60/64 FP8
+accuracy.
+
+The causal fault is binary provenance. The low-acceptance runs loaded
+`_C_stable_libtorch` SHA256 `fe986a...9ba8c`, even though the checked-out source
+contains the batched-weight RMSNorm repair. That binary predates the per-layer
+weight implementation: its focused GPU suite fails 10 of 13 cases, silently
+uses weight row zero for the other draft layers, and mismatches 81--96% of
+elements on multi-layer fixtures. The repaired binary SHA256
+`7689e5...d449` passes all 13 cases bitwise. The low result also numerically
+matches the historical pre-repair `4.5395/3.9725` baseline.
+
+The source now verifies the loaded stable extension once with deterministic
+nonzero per-layer inputs. A conforming binary continues to use the single
+grouped kernel after warmup. A stale binary emits an explicit warning and uses
+the bitwise per-layer fallback, so a wheel/source or worktree/symlink mismatch
+cannot silently lower acceptance again. The new fallback tests pass for both
+runtime behaviors; the full CPU DFlash2 suite reports 70 passed and 12 skipped.
+
+The repaired-binary FP8 closure uses the same frozen 64-row GSM8K contract and
+the dense selector baseline. It records request-mean acceptance `5.37699`,
+pooled acceptance `4.62217`, and request-mean completion tokens per round
+`5.37814`, with 61/64 correct and 62/64 natural stops. Against the repaired
+August 22 baseline, paired request-mean delta is `-0.01180` with bootstrap 95%
+interval `[-0.08421,0.06282]`; every position-wise pooled acceptance value is
+higher. The artifact records stable-extension SHA256 `7689e5...d449`. This
+closes the large acceptance regression: the stale-binary run was lower by
+`0.87812` request-mean tokens on the same rows, with bootstrap 95% interval
+`[0.75099,1.00344]` after repair. Its concurrently collected throughput is not
+a standalone performance baseline because NVFP4 compilation occupied the
+other TP4 group.
+
+The matching repaired-binary NVFP4 run records request-mean/pooled acceptance
+`5.39851/4.57051`, request-mean completion tokens per round `5.40178`, and
+59/64 correct with 62/64 natural stops. Its request mean is `+0.02152` versus
+the repaired current-source FP8 run; the paired 95% interval
+`[-0.10021,0.14795]` does not distinguish the two quantizations. The lower
+NVFP4 pooled value is explained by its longer output trajectory (35,366 versus
+32,658 tokens), not lower per-request acceptance. Relative to the stale NVFP4
+run, the repair adds `0.86209` request-mean tokens with 95% interval
+`[0.74547,0.98007]` and improves 62 of 64 matched rows.
+
+The experimental draft-MLP QPN8 route is rejected independently. On the same
+fixed 16 requests it changed request mean `4.57520 -> 4.51123` and pooled
+acceptance `4.39123 -> 4.09891`; the request delta `-0.06397` exceeds the
+`-0.05` gate. Its code and benchmark hook were removed rather than retained as
+a nominal 17 ms result.
+
+The corrected 16K coding-quality pair uses the same NVFP4 target, MBPP-32
+prompts, request seed, graph mode, E5M2 KV, and natural-EOS sampling on both
+sides. The dataset tests score no-DFlash `31/32` and DFlash2 `32/32`.
+EvalPlus maps 31 of those rows: base is `30/31` versus `31/31`, and plus is
+`27/31` versus `27/31`. At the plus level, each route alone passes one
+different row; exact paired McNemar `p=1.0`. Both routes naturally stop on 31
+rows and reach the 16K cap on one row. This provides no evidence of a DFlash2
+quality regression under the repaired runtime.
+
+The first score incorrectly reported one DFlash result as invalid syntax even
+though the complete executable answer followed `</think>`. The extractor had
+searched illustrative reasoning-era code fences before checking an unfenced
+final answer. The scorer now gives the final answer precedence, its regression
+fixture parses the affected `comb_sort` result, and both routes were rescored
+with the same corrected extractor. The corrected DFlash results are dataset
+tests `32/32`, EvalPlus base `31/31`, and EvalPlus plus `27/31`.
+
+The opt-in selector-QPN8 candidate also passes the fixed 64-row acceptance
+gate. Relative to the repaired dense selector, request-mean acceptance changes
+`5.39851 -> 5.43951`, pooled acceptance `4.57051 -> 4.58679`, and GSM8K
+`59/64 -> 60/64`. The paired request delta is `+0.04101` with bootstrap 95%
+interval `[-0.02309,0.10669]`; 23 rows improve, 15 fall, and 26 tie. It
+therefore has no acceptance-loss signal.
+
+Its first clean directional speed signal is positive but not promotable: the
+dense run on physical GPUs 4--7 measures request-mean/median complete round
+`19.083/19.046 ms`, while QPN8 on GPUs 0--3 measures `18.077/18.029 ms`.
+Aggregate output is `218.58 -> 229.41 token/s` and mean steady decode is
+`282.68 -> 300.12 token/s`. Because these are different physical groups, they
+are not a valid paired speed result. QPN8 also lowers available KV capacity
+from 529,616 to 459,817 tokens through its prepared rerank layout. An unrelated
+eight-GPU job occupied both groups before the same-GPU repeat; the candidate
+remains explicit opt-in and is not a default or a credited 17 ms result.
+
 ## Acceptance gates
 
 A short-context candidate is accepted only when all of the following hold:
@@ -105,4 +213,8 @@ breakdown; exact-shape microbenchmarks; focused numerical and CUDA Graph replay
 tests; GSM8K/MATH-500/HumanEval/MBPP/PPL quality gates; 32K/128K/256K decay
 sweep.
 
-Test result: pending current-source baseline and trace.
+Test result: the runtime-provenance acceptance repair and paired MBPP quality
+gate pass. Selector-QPN8 passes the acceptance gate and has a cross-group
+directional speed signal, but remains opt-in pending a same-GPU endpoint pair.
+The 17 ms endpoint and long-context performance gates remain pending; no
+rejected or unpaired speed candidate is credited.

--- a/docs/design/sm70_v100_migration_control.md
+++ b/docs/design/sm70_v100_migration_control.md
@@ -43169,6 +43169,52 @@ Interpretation:
   envelope, and non-regressing on acceptance and scored quality.
 - The full frozen contract, sequence, and pending Draft PR test record are in
   `docs/design/sm70_dflash2_nvfp4_17ms.md`.
+- The acceptance audit found a runtime/source mismatch rather than an NVFP4
+  regression. Current FP8 and NVFP4 request-mean acceptance values are
+  `4.49887` and `4.53642` (request-mean completion tokens per round are
+  `4.49761` and `4.53214`), but both runs loaded stale stable-ABI RMSNorm SHA
+  `fe986a...9ba8c`. Its
+  batched-weight suite fails 10/13 cases and reproduces the old row-zero
+  DFlash K-norm defect; repaired SHA `7689e5...d449` passes 13/13. Target
+  QPN2/QPN8 and sparse-rejection ablations do not recover acceptance.
+- DFlash now performs a one-time nonzero bitwise capability check before using
+  grouped per-layer K normalization. A stale binary is made correctness-safe
+  through an explicit per-layer fallback and warning. The two new behavior
+  tests and the full CPU DFlash2 suite pass (`70 passed, 12 skipped`). The
+  draft-MLP QPN8 experiment is removed after exceeding the `-0.05` paired
+  acceptance gate.
+- The repaired-binary FP8 formal rerun closes at request/pooled acceptance
+  `5.37699/4.62217`, 61/64 GSM8K, and stable SHA `7689e5...d449`. Relative to
+  the repaired August 22 formal baseline, paired request delta is `-0.01180`
+  with bootstrap 95% interval `[-0.08421,0.06282]`; every pooled position is
+  higher. Relative to the stale current-source run, repair adds `0.87812`
+  request-mean tokens with 95% interval `[0.75099,1.00344]`. The concurrent
+  throughput is excluded from standalone speed evidence.
+- The matching repaired NVFP4 formal run closes at request/pooled acceptance
+  `5.39851/4.57051` and 59/64 GSM8K. Its request mean is `+0.02152` versus
+  current repaired FP8 (paired 95% interval `[-0.10021,0.14795]`), while its
+  longer 35,366-token trajectory explains the lower pooled value. Repair adds
+  `0.86209` over stale NVFP4 with interval `[0.74547,0.98007]` and improves 62
+  of 64 rows. Its GSM8K pass/fail set is exactly the same as the repaired
+  August 22 FP8 reference (59 pass, 5 fail).
+- The repaired 16K executable MBPP-32 pair passes the quality gate. Dataset
+  tests are no-DFlash `31/32` versus DFlash2 `32/32`; EvalPlus base is
+  `30/31` versus `31/31`, and plus is `27/31` versus `27/31`. The plus
+  discordance is one win per route with exact McNemar `p=1.0`; both runs stop
+  naturally on 31 rows and hit the 16K limit on one. A scorer extraction bug
+  that preferred reasoning-era example fences over valid unfenced final code
+  caused the initial DFlash syntax false negative. Final-answer-first
+  extraction is regression-checked, and both sides use the corrected scorer.
+- The selector-QPN8 candidate passes acceptance but not yet performance
+  promotion. Dense-to-QPN8 request/pooled acceptance is
+  `5.39851/4.57051 -> 5.43951/4.58679`; the paired request delta is
+  `+0.04101` with 95% interval `[-0.02309,0.10669]`, and GSM8K is
+  `59/64 -> 60/64`. A cross-physical-group run shows directional complete
+  round `19.083 -> 18.077 ms`, aggregate `218.58 -> 229.41 token/s`, and
+  steady decode `282.68 -> 300.12 token/s`, but it is not accepted as a speed
+  pair. The prepared rerank layout reduces available KV capacity from 529,616
+  to 459,817 tokens. An unrelated eight-GPU job blocked the same-group repeat,
+  so the route remains opt-in and default-off.
 
 ## 2026-08-25 Qwen3.8-27B NVFP4 long-context decode
 

--- a/tests/v1/spec_decode/test_dflash2.py
+++ b/tests/v1/spec_decode/test_dflash2.py
@@ -9,6 +9,7 @@ import pytest
 import torch
 
 import vllm.model_executor.layers.logits_processor as logits_processor_module
+import vllm.model_executor.models.qwen3_dflash as dflash_model
 import vllm.model_executor.models.qwen3_dflash2 as dflash2_model
 import vllm.v1.attention.backends.flash_attn_v100 as flash_v100
 import vllm.v1.worker.gpu.attn_utils as attn_utils
@@ -20,6 +21,7 @@ from vllm.model_executor.layers.mamba.gdn.qwen_gdn_linear_attn import (
     _is_dflash2_spec_config,
 )
 from vllm.model_executor.layers.vocab_parallel_embedding import (
+    UnquantizedEmbeddingMethod,
     VocabParallelEmbedding,
     _sm70_dflash2_dense_order_topk,
     _sm70_dflash2_rerank_output_buffers,
@@ -37,6 +39,7 @@ from vllm.model_executor.models.qwen3_dflash import (
     _dflash_layer_causal,
 )
 from vllm.model_executor.models.qwen3_dflash2 import (
+    DFlash2Qwen3ForCausalLM,
     DFlash2Qwen3Model,
     _grouped_conv,
     _score_edges,
@@ -90,6 +93,91 @@ def _bare_dflash2_model() -> DFlash2Qwen3Model:
     torch.nn.Module.__init__(model)
     model.quant_config = None
     return model
+
+
+def _fake_rms_norm(
+    output: torch.Tensor,
+    input_: torch.Tensor,
+    weight: torch.Tensor,
+    epsilon: float,
+) -> None:
+    normalized = input_.float() * torch.rsqrt(
+        input_.float().pow(2).mean(dim=-1, keepdim=True) + epsilon
+    )
+    if weight.ndim == 2:
+        weight = weight.view(weight.shape[0], *([1] * (input_.ndim - 2)), -1)
+    output.copy_((normalized * weight.float()).to(output.dtype))
+
+
+def _bare_context_k_model() -> DFlashQwen3Model:
+    model = DFlashQwen3Model.__new__(DFlashQwen3Model)
+    torch.nn.Module.__init__(model)
+    model._rms_norm_eps = 1e-6
+    model._k_norm_weights = torch.tensor(
+        [
+            [1.0, 1.0, 1.0, 1.0],
+            [0.5, 1.5, 0.75, 1.25],
+            [1.5, 0.5, 1.25, 0.75],
+        ],
+        dtype=torch.float32,
+    )
+    model._batched_k_norm_runtime_verified = None
+    return model
+
+
+def test_context_k_norm_trusts_verified_batched_runtime(monkeypatch):
+    model = _bare_context_k_model()
+    all_k = torch.randn(3, 2, 1, 4)
+    calls = []
+
+    def grouped_runtime(output, input_, weight, epsilon):
+        calls.append(weight.ndim)
+        _fake_rms_norm(output, input_, weight, epsilon)
+
+    monkeypatch.setattr(dflash_model.ops, "rms_norm", grouped_runtime)
+    first = model._normalize_context_k(all_k)
+    assert model._batched_k_norm_runtime_verified is True
+    assert calls == [2, 1, 1, 1, 2]
+
+    calls.clear()
+    second = model._normalize_context_k(all_k)
+    assert calls == [2]
+    assert torch.equal(second, first)
+
+
+def test_context_k_norm_falls_back_for_stale_stable_binary(monkeypatch):
+    model = _bare_context_k_model()
+    # An all-zero profiling input would make the stale grouped output appear
+    # correct unless the capability probe uses its own nonzero fixture.
+    all_k = torch.zeros(3, 2, 1, 4)
+    calls = []
+
+    def stale_runtime(output, input_, weight, epsilon):
+        calls.append(weight.ndim)
+        # Historical stable-ABI binaries silently used row zero for a 2-D
+        # weight tensor. One-dimensional calls remained correct.
+        effective_weight = weight[0] if weight.ndim == 2 else weight
+        _fake_rms_norm(output, input_, effective_weight, epsilon)
+
+    monkeypatch.setattr(dflash_model.ops, "rms_norm", stale_runtime)
+    actual = model._normalize_context_k(all_k)
+    expected = torch.empty_like(all_k)
+    for layer_idx in range(all_k.shape[0]):
+        _fake_rms_norm(
+            expected[layer_idx],
+            all_k[layer_idx],
+            model._k_norm_weights[layer_idx],
+            model._rms_norm_eps,
+        )
+
+    assert model._batched_k_norm_runtime_verified is False
+    assert calls == [2, 1, 1, 1, 1, 1, 1]
+    assert torch.equal(actual, expected)
+
+    calls.clear()
+    repeated = model._normalize_context_k(all_k)
+    assert calls == [1, 1, 1]
+    assert torch.equal(repeated, expected)
 
 
 def test_sm70_tp4_shards_only_compatible_dflash2_context_projection(monkeypatch):
@@ -722,6 +810,40 @@ def test_target_topk_uses_reranked_local_candidates_without_dense_logits(monkeyp
     assert torch.equal(actual_ids, ids)
     torch.testing.assert_close(actual_values, expected_values)
     dense_apply.assert_not_called()
+
+
+def test_draft_candidates_use_reranked_lm_head_without_dense_logits(monkeypatch):
+    dense_apply = Mock(side_effect=AssertionError("dense logits must not run"))
+    values = torch.linspace(4.0, -4.0, 16, dtype=torch.float16).reshape(1, 16)
+    ids = torch.arange(200, 216, dtype=torch.int64).reshape(1, 16)
+    candidate_path = Mock(return_value=(values, ids))
+    lm_head = SimpleNamespace(
+        quant_method=UnquantizedEmbeddingMethod(),
+        maybe_get_sm70_dflash2_top20=candidate_path,
+    )
+    lm_head.quant_method.apply = dense_apply
+    model = SimpleNamespace(candidate_selector=SimpleNamespace(top_k=16))
+    dflash2 = SimpleNamespace(
+        lm_head=lm_head,
+        model=model,
+        output_multiplier=1.0,
+        final_logit_softcapping=None,
+    )
+    hidden_states = torch.empty((1, 8), dtype=torch.float16)
+    monkeypatch.setattr(
+        dflash2_model,
+        "get_tensor_model_parallel_world_size",
+        lambda: 1,
+    )
+
+    actual_ids, actual_values = DFlash2Qwen3ForCausalLM.compute_candidates(
+        dflash2, hidden_states
+    )
+
+    candidate_path.assert_called_once_with(hidden_states, 16)
+    dense_apply.assert_not_called()
+    assert torch.equal(actual_ids, ids)
+    assert torch.equal(actual_values, values.float())
 
 
 def test_lm_head_candidate_interface_falls_back_when_rerank_is_disabled(monkeypatch):

--- a/vllm/model_executor/models/qwen3_dflash.py
+++ b/vllm/model_executor/models/qwen3_dflash.py
@@ -518,6 +518,13 @@ class DFlashQwen3Model(nn.Module):
         self._k_norm_weights = torch.stack(
             [a.k_norm.weight.data for a in layers_attn], dim=0
         ).contiguous()
+        # The grouped call below relies on the stable-ABI RMSNorm extension
+        # selecting one weight row per outer (layer) index. Older binaries
+        # silently accepted the 2-D tensor but applied row zero to every
+        # layer, which severely lowers DFlash acceptance without affecting
+        # target-only output quality. Verify the loaded binary once before
+        # trusting its grouped result.
+        self._batched_k_norm_runtime_verified: bool | None = None
 
     def _build_fused_kv_buffers(self) -> None:
         """Build fused weight buffers for precompute_and_store_context_kv.
@@ -597,17 +604,71 @@ class DFlashQwen3Model(nn.Module):
         )
         return normed_context_states
 
+    def _normalize_context_k_per_layer(self, all_k: torch.Tensor) -> torch.Tensor:
+        """Reference path that works with pre-batched-weight RMSNorm binaries."""
+        all_k_normed = torch.empty_like(all_k)
+        for layer_idx in range(all_k.shape[0]):
+            ops.rms_norm(
+                all_k_normed[layer_idx],
+                all_k[layer_idx],
+                self._k_norm_weights[layer_idx],
+                self._rms_norm_eps,
+            )
+        return all_k_normed
+
+    def _verify_batched_context_k_norm_runtime(
+        self, dtype: torch.dtype, device: torch.device
+    ) -> bool:
+        """Check the loaded stable extension with nonzero per-layer inputs."""
+        num_layers, hidden_size = self._k_norm_weights.shape
+        probe = torch.ones(
+            (num_layers, 1, 1, hidden_size),
+            dtype=dtype,
+            device=device,
+        )
+        grouped = torch.empty_like(probe)
+        ops.rms_norm(
+            grouped,
+            probe,
+            self._k_norm_weights,
+            self._rms_norm_eps,
+        )
+        per_layer = self._normalize_context_k_per_layer(probe)
+        return torch.equal(grouped, per_layer)
+
     def _normalize_context_k(self, all_k: torch.Tensor) -> torch.Tensor:
         # --- Grouped RMSNorm K across all layers ([L, num_ctx, nkv, hd]) ---
         # The weight is selected per layer by the outermost (layer) index.
-        all_k_normed = torch.empty_like(all_k)
+        runtime_verified = getattr(self, "_batched_k_norm_runtime_verified", None)
+        if runtime_verified is None:
+            # This one-time comparison is normally consumed by model profiling
+            # or warmup. Use synthetic nonzero inputs so an all-zero dummy run
+            # cannot falsely approve a stale binary. The equality check
+            # deliberately synchronizes once: silently using the wrong K
+            # weights is a much larger failure than a cold startup fence.
+            runtime_verified = self._verify_batched_context_k_norm_runtime(
+                all_k.dtype, all_k.device
+            )
+            self._batched_k_norm_runtime_verified = runtime_verified
+            if not runtime_verified:
+                logger.warning_once(
+                    "The loaded stable-ABI RMSNorm extension does not preserve "
+                    "DFlash per-layer batched weights. Falling back to the "
+                    "bitwise per-layer path; rebuild the vLLM stable extension "
+                    "to restore the grouped K-normalization fast path."
+                )
+
+        if not runtime_verified:
+            return self._normalize_context_k_per_layer(all_k)
+
+        grouped = torch.empty_like(all_k)
         ops.rms_norm(
-            all_k_normed,
+            grouped,
             all_k,
             self._k_norm_weights,
             self._rms_norm_eps,
         )
-        return all_k_normed
+        return grouped
 
     def precompute_and_store_context_kv(
         self,

--- a/vllm/model_executor/models/qwen3_dflash2.py
+++ b/vllm/model_executor/models/qwen3_dflash2.py
@@ -451,16 +451,26 @@ class DFlash2Qwen3ForCausalLM(DFlashQwen3ForCausalLM):
             )
 
         selector = self.model.candidate_selector
-        logits = self.lm_head.quant_method.apply(self.lm_head, hidden_states, bias=None)
-        num_pad = self.lm_head.shard_indices.num_org_vocab_padding
-        if num_pad > 0:
-            logits[..., -num_pad:] = -float("inf")
-        values, ids = _topk(logits, selector.top_k)
-        ids = ids.to(torch.int64) + self.lm_head.shard_indices.org_vocab_start_index
+        local_candidates = self.lm_head.maybe_get_sm70_dflash2_top20(
+            hidden_states, selector.top_k
+        )
+        if local_candidates is None:
+            logits = self.lm_head.quant_method.apply(
+                self.lm_head, hidden_states, bias=None
+            )
+            num_pad = self.lm_head.shard_indices.num_org_vocab_padding
+            if num_pad > 0:
+                logits[..., -num_pad:] = -float("inf")
+            values, ids = _topk(logits, selector.top_k)
+            ids = ids.to(torch.int64) + self.lm_head.shard_indices.org_vocab_start_index
+        else:
+            values, ids = local_candidates
 
         if get_tensor_model_parallel_world_size() > 1:
             values = tensor_model_parallel_all_gather(values, dim=-1)
             ids = tensor_model_parallel_all_gather(ids, dim=-1)
+
+        if values.shape[-1] > selector.top_k:
             values, selected = _topk(values, selector.top_k)
             ids = ids.gather(-1, selected)
 


### PR DESCRIPTION
## Purpose

Protect DFlash grouped per-layer K normalization from stale stable-ABI RMSNorm binaries without slowing a conforming runtime, and reconnect the existing explicitly gated selector-QPN8 candidate path.

## Audit result

- A one-time nonzero operator probe compares grouped 2-D weights with the per-layer reference. Conforming binaries keep the grouped fast path; only a stale binary that reuses weight row zero falls back to the bitwise-correct per-layer route and emits a warning.
- The probe runs in eager context before captured query graphs and uses operator capability, tensor shape, dtype, and loaded-binary behavior only. It does not inspect model/checkpoint identity.
- Selector-QPN8 remains explicit opt-in: aggregate acceptance passes, but its speed comparison used different physical GPU groups and its prepared layout reduces KV capacity, so it is not promoted by this PR.

## Numerical and quality evidence

- Repaired FP8: request/pooled acceptance 5.37699/4.62217 and GSM8K 61/64.
- Repaired NVFP4: request/pooled acceptance 5.39851/4.57051 and GSM8K 59/64; paired request delta versus FP8 +0.02152.
- Matched MBPP-32: dataset tests 31/32 without DFlash versus 32/32 with DFlash; EvalPlus base 30/31 versus 31/31 and plus 27/31 versus 27/31, exact McNemar p=1.0. Greedy/token identity is not used as a gate.

## Test result

- Complete CPU DFlash2 suite on latest main with GPUs hidden: 78 passed, 12 skipped.
- Submitted repaired/stale GPU fixtures: repaired 13/13; stale 3/13, with the guard selecting the safe fallback.
- Changed-file pre-commit: all hooks passed. Repository-wide CI remains red on unrelated historical formatting baseline files.

Signed-off-by: yangzhuxinyzx <153831768+yangzhuxinyzx@users.noreply.github.com>