### PR TITLE
[Bugfix][SM70] Bound Gemma4 tower attention memory

### DIFF
--- a/docs/design/sm70_v100_migration_control.md
+++ b/docs/design/sm70_v100_migration_control.md
@@ -43565,3 +43565,42 @@ Interpretation:
   or eager call retains the existing pull collective. Explicit `=0` is the
   rollback. No model, checkpoint, `model_type`, or architecture identity is
   consulted.
+
+## 2026-08-26 historical PR #104 Gemma4 tower-memory audit
+
+- Historical PR #104 is not replayed as a branch. Five of its six commits are
+  already superseded by newer main-line attention, compile-warmup, MTP, and
+  metadata paths. Its remaining Gemma4 multimodal memory fix is rebuilt from
+  `origin/main@1492e6985a741da09329127b4d4171882b70402b` on
+  `codex/v100-gemma4-sm70-mm-sdpa-20260826-013904`.
+- The old post-load `tower.to(dtype)` approach is incompatible with the
+  generic UVA tower offload merged in PR #297: it can replace the registered
+  UVA storage with a new device tensor. The current repair instead passes the
+  configured FP16 dtype to Transformers while constructing the vision/audio
+  towers, before tower registration and weight loading. This path is admitted
+  only on exact SM70 with a configured FP16 model dtype; other platforms and
+  dtypes keep their current construction and mask behavior.
+- Both the current image-bucket encoder and the newer video-frame encoder use
+  a broadcast additive key-padding mask of shape `[B,1,1,N]`. Transformers
+  5.5.3 returns this prepared 4D mask as-is, avoiding its normal expansion of
+  a 2D validity mask to `[B,1,N,N]`. The implementation constructs the mask
+  entirely on device and does not branch on a CUDA scalar.
+- On a Tesla V100-SXM2-32GB, forced memory-efficient SDPA accepts the FP16
+  broadcast mask and produces bitwise-identical output to the bool validity
+  mask in the focused probe (`max_abs=0`). The same forced backend rejects
+  BF16 on SM70 with `No available kernel`, confirming the dtype dispatch
+  defect rather than assuming it from model identity.
+- At the production failure shape `B=2,N=10080`, Transformers 5.5.3 expands
+  the 2D mask to 203,212,800 bool elements (about 194.2 MiB). The broadcast
+  form stores 20,160 FP16 elements (about 0.04 MiB), a 10,080x element-count
+  reduction. Seven warmed CUDA-event samples measure medians of 1.346 ms and
+  0.042 ms respectively; this is mask-construction evidence, not a full-model
+  throughput claim.
+- CPU SDPA probes under Transformers 5.5.3 also produce exact equality for
+  padded bool/additive masks and for an all-zero additive mask versus no mask.
+  A tiny Gemma4 vision tower confirms that `AutoModel.from_config(dtype=fp16)`
+  creates FP16 parameters before loading. Ruff, formatting, `diff --check`,
+  and compile checks pass. The repository pytest entrypoint is currently
+  blocked before collection by the environment's unrelated stale
+  `mistral_common` (`NamedToolChoice` import); no service or end-to-end run is
+  claimed.

--- a/tests/models/multimodal/processing/test_gemma4.py
+++ b/tests/models/multimodal/processing/test_gemma4.py
@@ -10,6 +10,7 @@ from PIL import Image as PILImage
 from vllm.model_executor.models.gemma4_mm import (
     Gemma4ForConditionalGeneration,
     Gemma4ImagePixelInputs,
+    _build_broadcast_additive_padding_mask,
 )
 from vllm.multimodal import MULTIMODAL_REGISTRY
 from vllm.multimodal.inputs import MultiModalFieldConfig
@@ -20,6 +21,51 @@ from ...utils import build_model_context
 
 # TODO: to be updated to "google/gemma-4-e2b-it" once the models are available
 GEMMA4_MODEL_ID = "google/gemma-4-E2B-it"
+
+
+def test_broadcast_additive_padding_mask_matches_bool_sdpa() -> None:
+    torch.manual_seed(0)
+    padding_positions = torch.tensor(
+        [[False, False, True, True], [False, False, False, True]]
+    )
+    additive_mask = _build_broadcast_additive_padding_mask(
+        padding_positions, torch.float32
+    )
+
+    assert additive_mask.shape == (2, 1, 1, 4)
+    assert additive_mask.dtype == torch.float32
+    assert torch.equal(additive_mask.isneginf(), padding_positions[:, None, None, :])
+
+    query = torch.randn(2, 2, 4, 8)
+    key = torch.randn(2, 2, 4, 8)
+    value = torch.randn(2, 2, 4, 8)
+    bool_mask = (~padding_positions)[:, None, None, :]
+
+    bool_output = torch.nn.functional.scaled_dot_product_attention(
+        query, key, value, attn_mask=bool_mask
+    )
+    additive_output = torch.nn.functional.scaled_dot_product_attention(
+        query, key, value, attn_mask=additive_mask
+    )
+    torch.testing.assert_close(additive_output, bool_output, rtol=0, atol=0)
+
+
+def test_broadcast_additive_padding_mask_without_padding_matches_none() -> None:
+    padding_positions = torch.zeros((1, 4), dtype=torch.bool)
+    additive_mask = _build_broadcast_additive_padding_mask(
+        padding_positions, torch.float32
+    )
+    query = torch.randn(1, 2, 4, 8)
+    key = torch.randn(1, 2, 4, 8)
+    value = torch.randn(1, 2, 4, 8)
+
+    unmasked_output = torch.nn.functional.scaled_dot_product_attention(
+        query, key, value
+    )
+    additive_output = torch.nn.functional.scaled_dot_product_attention(
+        query, key, value, attn_mask=additive_mask
+    )
+    torch.testing.assert_close(additive_output, unmasked_output, rtol=0, atol=0)
 
 
 def test_gemma4_image_schema_accepts_variable_patch_counts():

--- a/vllm/model_executor/models/gemma4_mm.py
+++ b/vllm/model_executor/models/gemma4_mm.py
@@ -102,6 +102,19 @@ def _get_max_soft_tokens(
     return None, False
 
 
+def _build_broadcast_additive_padding_mask(
+    padding_positions: torch.Tensor,
+    dtype: torch.dtype,
+) -> torch.Tensor:
+    """Build an SDPA key-padding mask without materializing query rows."""
+    batch_size, num_patches = padding_positions.shape
+    return torch.zeros(
+        (batch_size, 1, 1, num_patches),
+        dtype=dtype,
+        device=padding_positions.device,
+    ).masked_fill_(padding_positions[:, None, None, :], float("-inf"))
+
+
 # ---------------------------------------------------------------------------
 # Input schema
 # ---------------------------------------------------------------------------
@@ -948,6 +961,7 @@ class Gemma4ForConditionalGeneration(
 
     def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):
         super().__init__()
+        model_config = vllm_config.model_config
         config = vllm_config.model_config.hf_config
         quant_config = vllm_config.quant_config
         multimodal_config = vllm_config.model_config.multimodal_config
@@ -955,9 +969,27 @@ class Gemma4ForConditionalGeneration(
         self.quant_config = quant_config
         self.multimodal_config = multimodal_config
 
+        # SM70 memory-efficient SDPA accepts fp16/fp32, but not bf16. Gemma4
+        # checkpoints can independently mark their HF towers as bf16 even when
+        # the vLLM model dtype is fp16, which otherwise forces quadratic math
+        # attention. Select the model dtype during construction so subsequent
+        # UVA tower registration and weight loading preserve their storage.
+        self._use_sm70_memory_efficient_mm_sdpa = (
+            current_platform.is_cuda()
+            and current_platform.is_device_capability(70)
+            and model_config.dtype == torch.float16
+        )
+        tower_init_kwargs = (
+            {"dtype": model_config.dtype}
+            if self._use_sm70_memory_efficient_mm_sdpa
+            else {}
+        )
+
         # ---- Vision tower (shared by image and video) ----
         with self._mark_tower_model(vllm_config, {"image", "video"}):
-            self.vision_tower = AutoModel.from_config(config=config.vision_config)
+            self.vision_tower = AutoModel.from_config(
+                config=config.vision_config, **tower_init_kwargs
+            )
             self.embed_vision = Gemma4MultimodalEmbedder(
                 config.vision_config, config.text_config
             )
@@ -965,7 +997,9 @@ class Gemma4ForConditionalGeneration(
         # ---- Audio tower (variants with audio_config) ----
         if config.audio_config is not None:
             with self._mark_tower_model(vllm_config, "audio"):
-                self.audio_tower = AutoModel.from_config(config=config.audio_config)
+                self.audio_tower = AutoModel.from_config(
+                    config=config.audio_config, **tower_init_kwargs
+                )
                 # AutoModel.from_config does NOT call post_init(),
                 # which is needed to initialize buffers that are absent
                 # from the checkpoint (e.g. inv_timescales for relative
@@ -1194,9 +1228,16 @@ class Gemma4ForConditionalGeneration(
                 pad_tensor = (pp_tensor == -1).all(dim=-1)
 
                 inputs_embeds = vt.patch_embedder(pv_tensor, pp_tensor, pad_tensor)
+                attention_mask = (
+                    _build_broadcast_additive_padding_mask(
+                        pad_tensor, inputs_embeds.dtype
+                    )
+                    if self._use_sm70_memory_efficient_mm_sdpa
+                    else ~pad_tensor
+                )
                 encoder_outputs = vt.encoder(
                     inputs_embeds=inputs_embeds,
-                    attention_mask=~pad_tensor,
+                    attention_mask=attention_mask,
                     pixel_position_ids=pp_tensor,
                 )
                 hidden_states = encoder_outputs.last_hidden_state
@@ -1302,9 +1343,14 @@ class Gemma4ForConditionalGeneration(
             pad_chunk = padding_positions[i : i + max_batch_size]
 
             inputs_embeds = vt.patch_embedder(pv_chunk, pp_chunk, pad_chunk)
+            attention_mask = (
+                _build_broadcast_additive_padding_mask(pad_chunk, inputs_embeds.dtype)
+                if self._use_sm70_memory_efficient_mm_sdpa
+                else ~pad_chunk
+            )
             encoder_outputs = vt.encoder(
                 inputs_embeds=inputs_embeds,
-                attention_mask=~pad_chunk,
+                attention_mask=attention_mask,
                 pixel_position_ids=pp_chunk,
             )
             last_hidden_states_list.append(encoder_outputs.last_hidden_state)


### PR DESCRIPTION
## Purpose

Rebuild the remaining valid leaf of historical PR #104 on the latest main, without replaying its obsolete branch.

On exact SM70 with an FP16 engine dtype, Gemma4 checkpoints can construct their Hugging Face vision/audio towers as BF16. V100 memory-efficient SDPA rejects BF16, and Transformers 5.5.3 expands the current 2D validity mask to [B,1,N,N]. At B=2,N=10080, the mask alone stores about 194.2 MiB and the BF16 fallback can materialize quadratic attention scores.

This change:

- selects FP16 while constructing Gemma4 HF towers on exact SM70, before generic UVA tower registration and weight loading;
- supplies a broadcast additive [B,1,1,N] key-padding mask for both current image and video encoder paths;
- leaves non-SM70 devices and non-FP16 configurations unchanged;
- records why the old post-load tower.to(dtype) patch is rejected after PR #297 because it can invalidate UVA storage.

No model/checkpoint identity is used for admission.

## Integration base

- Latest base: origin/main@6cdfc4430aa44bb6e50000ca420173603b147d12
- Branch merged current main instead of rebasing the published history.
- Historical source reviewed: #104 commit 82f642c520fe1653d7921d5ee0ac0421cc99118a

## Test Plan

- whole-repository pre-commit on latest main
- Python compile and focused mask helper checks
- Transformers 5.5.3 CPU SDPA semantic comparison
- Transformers 5.5.3 tiny Gemma4 tower dtype construction
- exact V100/SM70 forced memory-efficient SDPA operator gate
- exact failure-shape mask construction microbenchmark at B=2,N=10080

End-to-end serving is intentionally out of scope for this source audit.

## Test Result

- pre-commit run -a on latest main: all hooks passed, including ruff, mypy, static policies, and repository-specific checks.
- CPU SDPA: padded bool vs additive output is bitwise equal; no-padding additive vs no mask is bitwise equal.
- Transformers 5.5.3 tiny Gemma4 vision tower: AutoModel.from_config(dtype=torch.float16) creates only FP16 parameters.
- Tesla V100-SXM2-32GB, CC 7.0, forced SDPBackend.EFFICIENT_ATTENTION:
  - FP16 bool vs broadcast additive mask: max_abs=0;
  - BF16: expected No available kernel rejection;
  - peak allocation for the operator probe: 0.021 MiB.
- Exact mask shape B=2,N=10080, 7 warmed CUDA-event samples:
  - Transformers 2D to 4D bool mask: 203,212,800 elements, median 1.346 ms, about 194.2 MiB stored;
  - broadcast FP16 mask: 20,160 elements, median 0.042 ms, about 0.04 MiB stored;
  - stored element count reduced 10,080x.

The repository pytest entrypoint in the audit environment is blocked before collection by an unrelated stale mistral_common NamedToolChoice import. The focused test logic was executed directly under the repository-pinned Transformers 5.5.3 environment and passed. No full-model throughput claim is made.
