### PR TITLE
[CI/Build] Restore repository pre-commit baseline

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ default_install_hook_types:
 default_stages:
   - pre-commit # Run locally
   - manual # Run in CI
-exclude: '(vllm/third_party/.*|flash_qla/.*)'
+exclude: '(vllm/third_party/.*|flash_qla/.*|csrc/sm70_turbomind/lmdeploy/.*)'
 repos:
 - repo: https://github.com/astral-sh/ruff-pre-commit
   rev: v0.14.0
@@ -35,6 +35,11 @@ repos:
   rev: v1.7.7
   hooks:
   - id: actionlint
+- repo: https://github.com/shellcheck-py/shellcheck-py
+  rev: 745eface02aef23e168a8afb6b5737818efbea95 # v0.11.0.1
+  hooks:
+  - id: shellcheck
+    args: ["-s", "bash", "--format=gcc", "--severity=error"]
 - repo: https://github.com/astral-sh/uv-pre-commit
   rev: 0.11.1
   hooks:
@@ -177,11 +182,6 @@ repos:
     entry: python tools/pre_commit/mypy.py 1 "3.13"
     <<: *mypy_common
     stages: [manual] # Only run in CI
-  - id: shellcheck
-    name: Lint shell scripts
-    entry: tools/pre_commit/shellcheck.sh
-    language: script
-    types: [shell]
   - id: png-lint
     name: Lint PNG exports from excalidraw
     entry: tools/pre_commit/png-lint.sh

--- a/benchmarks/benchmark_dspark_api.py
+++ b/benchmarks/benchmark_dspark_api.py
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 """Issue one reproducible OpenAI chat request for DSpark validation."""
 

--- a/benchmarks/benchmark_dspark_stream.py
+++ b/benchmarks/benchmark_dspark_stream.py
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 """Measure one streamed completions request with separate TTFT and TPOT."""
 

--- a/benchmarks/benchmark_sm70_flashinfer_fixed_entry.py
+++ b/benchmarks/benchmark_sm70_flashinfer_fixed_entry.py
@@ -263,9 +263,7 @@ def _active_ctas_per_sm(
     threads_per_cta: int,
     shared_bytes_per_cta: int,
 ) -> int:
-    register_limited = SM70_REGISTERS_PER_SM // (
-        registers_per_thread * threads_per_cta
-    )
+    register_limited = SM70_REGISTERS_PER_SM // (registers_per_thread * threads_per_cta)
     shared_limited = SM70_SHARED_BYTES_PER_SM // shared_bytes_per_cta
     thread_limited = SM70_THREADS_PER_SM // threads_per_cta
     return min(register_limited, shared_limited, thread_limited, SM70_MAX_CTA_PER_SM)
@@ -350,9 +348,7 @@ def _paged_resource_gate(kernel: Mapping[str, Any]) -> dict[str, Any]:
             f"requires <= {PAGED_MAX_SHARED_BYTES}"
         )
     if kernel["active_ctas_per_sm"] != 2:
-        reasons.append(
-            f"active_ctas_per_sm={kernel['active_ctas_per_sm']}, requires 2"
-        )
+        reasons.append(f"active_ctas_per_sm={kernel['active_ctas_per_sm']}, requires 2")
     instructions = kernel["instructions"]
     if instructions["hmma"] == 0:
         reasons.append("paged target has no HMMA")
@@ -617,15 +613,9 @@ def _pairwise_stats(
     return {
         "right_minus_left_mean_ms": float(statistics.mean(deltas)),
         "right_minus_left_p50_ms": float(statistics.median(deltas)),
-        "right_faster_wins": sum(
-            right_ms < left_ms for left_ms, right_ms in paired
-        ),
-        "left_faster_wins": sum(
-            left_ms < right_ms for left_ms, right_ms in paired
-        ),
-        "ties": sum(
-            left_ms == right_ms for left_ms, right_ms in paired
-        ),
+        "right_faster_wins": sum(right_ms < left_ms for left_ms, right_ms in paired),
+        "left_faster_wins": sum(left_ms < right_ms for left_ms, right_ms in paired),
+        "ties": sum(left_ms == right_ms for left_ms, right_ms in paired),
         "right_vs_left_mean_pct": (
             (right_stats["mean_ms"] / left_stats["mean_ms"] - 1.0) * 100.0
         ),

--- a/benchmarks/benchmark_sm70_flashqla_indexed_state_cache.py
+++ b/benchmarks/benchmark_sm70_flashqla_indexed_state_cache.py
@@ -72,27 +72,38 @@ def main() -> None:
     dtype = torch.float16
     scale = args.dim**-0.5
 
-    q = (torch.randn(1, args.tokens, args.q_heads, args.dim,
-                     device=device, dtype=dtype) * 0.05).contiguous()
+    q = (
+        torch.randn(1, args.tokens, args.q_heads, args.dim, device=device, dtype=dtype)
+        * 0.05
+    ).contiguous()
     k = (torch.randn_like(q) * 0.05).contiguous()
-    v = (torch.randn(1, args.tokens, args.v_heads, args.dim,
-                     device=device, dtype=dtype) * 0.1).contiguous()
-    g = (torch.randn(1, args.tokens, args.v_heads,
-                     device=device, dtype=torch.float32) * 0.02 - 0.04).contiguous()
-    beta = torch.rand(1, args.tokens, args.v_heads,
-                      device=device, dtype=torch.float32).contiguous()
+    v = (
+        torch.randn(1, args.tokens, args.v_heads, args.dim, device=device, dtype=dtype)
+        * 0.1
+    ).contiguous()
+    g = (
+        torch.randn(1, args.tokens, args.v_heads, device=device, dtype=torch.float32)
+        * 0.02
+        - 0.04
+    ).contiguous()
+    beta = torch.rand(
+        1, args.tokens, args.v_heads, device=device, dtype=torch.float32
+    ).contiguous()
     cu_seqlens = torch.tensor([0, args.tokens], device=device, dtype=torch.int32)
     state_indices = torch.tensor([args.state_index], device=device, dtype=torch.long)
     has_initial_state = torch.ones(1, device=device, dtype=torch.bool)
 
-    base_state_cache = (torch.randn(
-        args.state_slots,
-        args.v_heads,
-        args.dim,
-        args.dim,
-        device=device,
-        dtype=torch.float32,
-    ) * 0.01).contiguous()
+    base_state_cache = (
+        torch.randn(
+            args.state_slots,
+            args.v_heads,
+            args.dim,
+            args.dim,
+            device=device,
+            dtype=torch.float32,
+        )
+        * 0.01
+    ).contiguous()
     gather_cache = base_state_cache.clone()
     indexed_cache = base_state_cache.clone()
     gather_out = torch.empty_like(v)
@@ -151,8 +162,9 @@ def main() -> None:
 
     correctness = {
         "out": _diff(gather_result, indexed_result),
-        "state_slot": _diff(gather_cache[args.state_index],
-                            indexed_cache[args.state_index]),
+        "state_slot": _diff(
+            gather_cache[args.state_index], indexed_cache[args.state_index]
+        ),
     }
     if args.state_slots > 1:
         untouched_index = 0 if args.state_index != 0 else args.state_slots - 1

--- a/benchmarks/benchmark_sm70_fp8_fixed_vs_dynamic.py
+++ b/benchmarks/benchmark_sm70_fp8_fixed_vs_dynamic.py
@@ -65,8 +65,9 @@ def _candidate_layers(model_path: Path) -> tuple[dict[str, str], list[str]]:
     return weight_map, layers
 
 
-def _select_layers(layers: list[str], layer_ids: set[int],
-                   max_layers: int) -> list[str]:
+def _select_layers(
+    layers: list[str], layer_ids: set[int], max_layers: int
+) -> list[str]:
     selected: list[str] = []
     seen_kind: set[str] = set()
     for prefix in layers:
@@ -100,8 +101,7 @@ def _run_case(
             "skip": "shape_not_multiple_128",
         }
 
-    tm_weight, tm_scales, meta = sm70_ops.fp8_sm70_prepare(
-        qweight, scales, group_size)
+    tm_weight, tm_scales, meta = sm70_ops.fp8_sm70_prepare(qweight, scales, group_size)
     x = torch.randn((m, k), device=qweight.device, dtype=torch.float16)
 
     fixed = torch.empty((m, n), device=qweight.device, dtype=torch.float16)
@@ -120,8 +120,7 @@ def _run_case(
 
     os.environ["VLLM_SM70_FP8_TUNE_SMALL_SHAPES"] = "0"
     fixed_after = torch.empty((m, n), device=qweight.device, dtype=torch.float16)
-    sm70_ops.fp8_gemm_sm70_out_meta(
-        fixed_after, x, tm_weight, tm_scales, meta)
+    sm70_ops.fp8_gemm_sm70_out_meta(fixed_after, x, tm_weight, tm_scales, meta)
     torch.accelerator.synchronize(qweight.device)
 
     diff_dynamic = (fixed.float() - dynamic.float()).abs()
@@ -178,8 +177,7 @@ def main() -> int:
     results: list[dict[str, Any]] = []
     try:
         for prefix in selected:
-            qweight, scales = _load_fp8_layer(
-                args.model, weight_map, prefix, device)
+            qweight, scales = _load_fp8_layer(args.model, weight_map, prefix, device)
             for m in args.m:
                 results.append(_run_case(prefix, qweight, scales, m))
     finally:
@@ -189,7 +187,8 @@ def main() -> int:
             os.environ["VLLM_SM70_FP8_TUNE_SMALL_SHAPES"] = original_env
 
     failures = [
-        item for item in results
+        item
+        for item in results
         if item.get("fixed_vs_dynamic_max_diff", 0.0) != 0.0
         or not item.get("fixed_vs_dynamic_equal", True)
     ]

--- a/benchmarks/benchmark_sm70_hmma_c2a_mincomm.py
+++ b/benchmarks/benchmark_sm70_hmma_c2a_mincomm.py
@@ -7,12 +7,13 @@ from __future__ import annotations
 import argparse
 import json
 import os
-import re
 import shutil
 import subprocess
 import tempfile
 from pathlib import Path
 from typing import Any
+
+import regex as re
 
 SYMBOLS = {
     "reference": "sm70_hmma_c2a_reference",

--- a/benchmarks/benchmark_sm70_instruction_latency.py
+++ b/benchmarks/benchmark_sm70_instruction_latency.py
@@ -7,12 +7,13 @@ from __future__ import annotations
 import argparse
 import json
 import os
-import re
 import shutil
 import subprocess
 import tempfile
 from pathlib import Path
 from typing import Any
+
+import regex as re
 
 
 def _parse_args() -> argparse.Namespace:

--- a/benchmarks/benchmark_sm70_lm_head_top1.py
+++ b/benchmarks/benchmark_sm70_lm_head_top1.py
@@ -111,9 +111,7 @@ def main() -> int:
 
     x = torch.randn((args.m, args.k), device=device, dtype=torch.float16)
     weight = torch.randn((args.n, args.k), device=device, dtype=torch.float16)
-    torch_logits_out = torch.empty(
-        (args.m, args.n), device=device, dtype=torch.float16
-    )
+    torch_logits_out = torch.empty((args.m, args.n), device=device, dtype=torch.float16)
     prepared = sm70_ops.sm70_f16_prepare(weight)
     tm_weight = prepared[0]
     k_ld = int(prepared[1][0].item())
@@ -121,7 +119,7 @@ def main() -> int:
     def torch_mm_max() -> tuple[torch.Tensor, torch.Tensor]:
         logits = torch.mm(x, weight.t())
         if args.pad:
-            logits[:, -args.pad:] = -float("inf")
+            logits[:, -args.pad :] = -float("inf")
         values, indices = logits.max(dim=-1)
         return values, indices.to(torch.int64) + args.vocab_start
 
@@ -189,15 +187,21 @@ def main() -> int:
     def sm70_gemm_max() -> tuple[torch.Tensor, torch.Tensor]:
         sm70_ops.sm70_f16_gemm_out(logits_out, x, tm_weight, k_ld, False)
         if args.pad:
-            logits_out[:, -args.pad:] = -float("inf")
+            logits_out[:, -args.pad :] = -float("inf")
         values, indices = logits_out.max(dim=-1)
         return values, indices.to(torch.int64) + args.vocab_start
 
     sm70_values, sm70_indices = sm70_gemm_max()
     sm70_ms = _bench_cuda_ms(lambda: sm70_gemm_max(), args.warmup, args.iters)
     results.append(
-        _stats("sm70_gemm_then_max", sm70_values, sm70_indices, ref_values,
-               ref_indices, sm70_ms)
+        _stats(
+            "sm70_gemm_then_max",
+            sm70_values,
+            sm70_indices,
+            ref_values,
+            ref_indices,
+            sm70_ms,
+        )
     )
 
     torch_mm_ms = _bench_cuda_ms(lambda: torch_mm_max(), args.warmup, args.iters)

--- a/benchmarks/benchmark_sm70_long_quality_suffix.py
+++ b/benchmarks/benchmark_sm70_long_quality_suffix.py
@@ -220,9 +220,9 @@ def main() -> None:
                     "im_end_count": result["im_end_count"],
                     "unique_tokens": result["unique_tokens"],
                     "top_token_count_id": result["top_token_count_id"],
-                    "steady_decode_tps": (
-                        result["request_metrics"] or {}
-                    ).get("steady_decode_tps"),
+                    "steady_decode_tps": (result["request_metrics"] or {}).get(
+                        "steady_decode_tps"
+                    ),
                     "prefix": text[:160],
                 },
                 ensure_ascii=False,

--- a/benchmarks/benchmark_sm70_native_bm32_allp_crossblock_micro.py
+++ b/benchmarks/benchmark_sm70_native_bm32_allp_crossblock_micro.py
@@ -103,8 +103,7 @@ def _require_environment(args: argparse.Namespace) -> None:
         raise ValueError(f"formal runs require exactly {K_DEFAULT_ROUNDS} rounds.")
     if args.launches_per_sample != K_DEFAULT_LAUNCHES:
         raise ValueError(
-            "formal runs require exactly "
-            f"{K_DEFAULT_LAUNCHES} launches per sample."
+            f"formal runs require exactly {K_DEFAULT_LAUNCHES} launches per sample."
         )
 
 
@@ -261,12 +260,8 @@ def _inspect_sass(binary: Path) -> dict[str, Any]:
         "kernels": kernels,
         "static_instruction_delta": {
             mnemonic: (
-                kernels.get("candidate", {})
-                .get("instructions", {})
-                .get(mnemonic, 0)
-                - kernels.get("baseline", {})
-                .get("instructions", {})
-                .get(mnemonic, 0)
+                kernels.get("candidate", {}).get("instructions", {}).get(mnemonic, 0)
+                - kernels.get("baseline", {}).get("instructions", {}).get(mnemonic, 0)
             )
             for mnemonic in ("hmma", "ldg", "lds", "sts", "ldl", "stl", "bar")
         },
@@ -302,13 +297,11 @@ def _resource_gate(
             )
         if resource.get("registers_per_thread", 65) > 64:
             reasons.append(
-                f"{path} REG={resource.get('registers_per_thread')}, "
-                "requires <=64"
+                f"{path} REG={resource.get('registers_per_thread')}, requires <=64"
             )
         if resource.get("local_bytes_per_thread") != 0:
             reasons.append(
-                f"{path} LOCAL={resource.get('local_bytes_per_thread')}, "
-                "requires 0"
+                f"{path} LOCAL={resource.get('local_bytes_per_thread')}, requires 0"
             )
         if resource.get("static_shared_bytes") != K_ALLP_SHARED_BYTES:
             reasons.append(
@@ -333,8 +326,7 @@ def _resource_gate(
             continue
         if ptxas["registers_per_thread"] > 64:
             reasons.append(
-                f"PTXAS {path} REG={ptxas['registers_per_thread']}, "
-                "requires <=64"
+                f"PTXAS {path} REG={ptxas['registers_per_thread']}, requires <=64"
             )
         for key in ("stack_frame_bytes", "spill_store_bytes", "spill_load_bytes"):
             if ptxas[key] != 0:
@@ -356,9 +348,7 @@ def _resource_gate(
             instructions = path_sass.get("instructions", {})
             for mnemonic in ("hmma", "ldg", "lds", "sts"):
                 if instructions.get(mnemonic, 0) == 0:
-                    reasons.append(
-                        f"{path} SASS has no {mnemonic.upper()} instruction"
-                    )
+                    reasons.append(f"{path} SASS has no {mnemonic.upper()} instruction")
             if instructions.get("ldl", 0) or instructions.get("stl", 0):
                 reasons.append(
                     f"{path} SASS has local instructions "
@@ -397,40 +387,31 @@ def _resource_gate(
     return not reasons, reasons
 
 
-def _correctness_gate(
-    payload: dict[str, Any], groups: int
-) -> tuple[bool, list[str]]:
+def _correctness_gate(payload: dict[str, Any], groups: int) -> tuple[bool, list[str]]:
     reasons: list[str] = []
     exactness = payload.get("exactness") or {}
     expected_words = groups * K_M * K_D // 2
     if exactness.get("word_dtype") != "uint32 packed fp16":
         reasons.append(
-            "word_dtype="
-            f"{exactness.get('word_dtype')}, requires uint32 packed fp16"
+            f"word_dtype={exactness.get('word_dtype')}, requires uint32 packed fp16"
         )
     if exactness.get("word_count") != expected_words:
         reasons.append(
-            "word_count="
-            f"{exactness.get('word_count')}, requires {expected_words}"
+            f"word_count={exactness.get('word_count')}, requires {expected_words}"
         )
     if exactness.get("full_output") is not True:
         reasons.append("C++ probe did not compare the full output")
     if exactness.get("bitwise_equal") is not True:
         reasons.append("candidate output is not bitwise equal to baseline")
     if exactness.get("mismatch_words") != 0:
-        reasons.append(
-            "mismatch_words="
-            f"{exactness.get('mismatch_words')}, requires 0"
-        )
+        reasons.append(f"mismatch_words={exactness.get('mismatch_words')}, requires 0")
     xor = exactness.get("xor", {})
     if xor.get("max_word") != 0 or xor.get("reduction") != 0:
         reasons.append("packed uint32 XOR result is nonzero")
     return not reasons, reasons
 
 
-def _performance_gate(
-    payload: dict[str, Any], rounds: int
-) -> tuple[bool, list[str]]:
+def _performance_gate(payload: dict[str, Any], rounds: int) -> tuple[bool, list[str]]:
     reasons: list[str] = []
     pairs = payload.get("pairs") or {}
     if pairs.get("count") != rounds:
@@ -441,13 +422,10 @@ def _performance_gate(
             f"candidate_faster={pairs.get('candidate_faster')}, "
             f"requires >= {required_wins}/{rounds}"
         )
-    speedup_pct = (payload.get("timing") or {}).get(
-        "candidate_speedup_vs_baseline_pct"
-    )
+    speedup_pct = (payload.get("timing") or {}).get("candidate_speedup_vs_baseline_pct")
     if speedup_pct is None or speedup_pct < K_REQUIRED_SPEEDUP_PCT:
         reasons.append(
-            f"median speedup={speedup_pct}, requires "
-            f">= {K_REQUIRED_SPEEDUP_PCT}%"
+            f"median speedup={speedup_pct}, requires >= {K_REQUIRED_SPEEDUP_PCT}%"
         )
     return not reasons, reasons
 
@@ -666,14 +644,11 @@ def _run_ncu_kernel(
             "mio_throttle_per_warp_active": metrics.get(
                 "smsp__warp_issue_stalled_mio_throttle_per_warp_active"
             ),
-            "tensor_instructions": metrics.get(
-                "smsp__inst_executed_pipe_tensor.sum"
-            ),
+            "tensor_instructions": metrics.get("smsp__inst_executed_pipe_tensor.sum"),
         },
         "stdout_tail": completed.stdout[-3000:],
         "stderr_tail": completed.stderr[-3000:],
-        "permission_error": "ERR_NVGPUCTRPERM"
-        in (completed.stdout + completed.stderr),
+        "permission_error": "ERR_NVGPUCTRPERM" in (completed.stdout + completed.stderr),
     }
 
 
@@ -830,8 +805,7 @@ def _main() -> int:
         "benchmark": "sm70_native_bm32_allp_crossblock_micro",
         "target": "sm_70",
         "matrix": [
-            {"pattern": pattern, "nblocks": nblocks}
-            for pattern, nblocks in K_CASES
+            {"pattern": pattern, "nblocks": nblocks} for pattern, nblocks in K_CASES
         ],
         "configuration": {
             "groups": args.groups,

--- a/benchmarks/benchmark_sm70_native_bm32_allp_scratch_micro.py
+++ b/benchmarks/benchmark_sm70_native_bm32_allp_scratch_micro.py
@@ -94,10 +94,7 @@ def _require_environment(args: argparse.Namespace) -> None:
     if args.rounds < K_DEFAULT_ROUNDS:
         raise ValueError(f"rounds must be at least {K_DEFAULT_ROUNDS}.")
     if args.launches_per_sample < K_DEFAULT_LAUNCHES:
-        raise ValueError(
-            "launches-per-sample must be at least "
-            f"{K_DEFAULT_LAUNCHES}."
-        )
+        raise ValueError(f"launches-per-sample must be at least {K_DEFAULT_LAUNCHES}.")
 
 
 def _graphics_clock_mhz(physical_gpu: int) -> int:
@@ -248,8 +245,7 @@ def _inspect_sass(binary: Path) -> dict[str, Any]:
             "ctas_per_group": ctas_per_group,
             "instructions": instructions,
             "instructions_per_group": {
-                name: count * ctas_per_group
-                for name, count in instructions.items()
+                name: count * ctas_per_group for name, count in instructions.items()
             },
         }
     baseline_instructions = kernels.get("baseline", {}).get("instructions", {})
@@ -293,13 +289,11 @@ def _resource_gate(
             )
         if resource.get("registers_per_thread", 65) > 64:
             reasons.append(
-                f"{path} REG={resource.get('registers_per_thread')}, "
-                "requires <=64"
+                f"{path} REG={resource.get('registers_per_thread')}, requires <=64"
             )
         if resource.get("local_bytes_per_thread") != 0:
             reasons.append(
-                f"{path} LOCAL={resource.get('local_bytes_per_thread')}, "
-                "requires 0"
+                f"{path} LOCAL={resource.get('local_bytes_per_thread')}, requires 0"
             )
         if resource.get("static_shared_bytes") != K_ALLP_SHARED_BYTES:
             reasons.append(
@@ -326,8 +320,7 @@ def _resource_gate(
             continue
         if ptxas["registers_per_thread"] > 64:
             reasons.append(
-                f"PTXAS {path} REG={ptxas['registers_per_thread']}, "
-                "requires <=64"
+                f"PTXAS {path} REG={ptxas['registers_per_thread']}, requires <=64"
             )
         for key in ("stack_frame_bytes", "spill_store_bytes", "spill_load_bytes"):
             if ptxas[key] != 0:
@@ -348,9 +341,7 @@ def _resource_gate(
             instructions = path_sass.get("instructions", {})
             for mnemonic in ("hmma", "ldg", "lds"):
                 if instructions.get(mnemonic, 0) == 0:
-                    reasons.append(
-                        f"{path} SASS has no {mnemonic.upper()} instruction"
-                    )
+                    reasons.append(f"{path} SASS has no {mnemonic.upper()} instruction")
             if instructions.get("ldl", 0) or instructions.get("stl", 0):
                 reasons.append(
                     f"{path} SASS has local instructions "
@@ -380,46 +371,35 @@ def _resource_gate(
     }
     for key, expected in expected_scratch.items():
         if scratch.get(key) != expected:
-            reasons.append(
-                f"scratch {key}={scratch.get(key)}, requires {expected}"
-            )
+            reasons.append(f"scratch {key}={scratch.get(key)}, requires {expected}")
     return not reasons, reasons
 
 
-def _correctness_gate(
-    payload: dict[str, Any], groups: int
-) -> tuple[bool, list[str]]:
+def _correctness_gate(payload: dict[str, Any], groups: int) -> tuple[bool, list[str]]:
     reasons: list[str] = []
     exactness = payload.get("exactness", {})
     expected_words = groups * K_M * K_D // 2
     if exactness.get("word_dtype") != "uint32 packed fp16":
         reasons.append(
-            "word_dtype="
-            f"{exactness.get('word_dtype')}, requires uint32 packed fp16"
+            f"word_dtype={exactness.get('word_dtype')}, requires uint32 packed fp16"
         )
     if exactness.get("word_count") != expected_words:
         reasons.append(
-            "word_count="
-            f"{exactness.get('word_count')}, requires {expected_words}"
+            f"word_count={exactness.get('word_count')}, requires {expected_words}"
         )
     if exactness.get("full_output") is not True:
         reasons.append("C++ probe did not compare the full output")
     if exactness.get("bitwise_equal") is not True:
         reasons.append("candidate output is not bitwise equal to baseline")
     if exactness.get("mismatch_words") != 0:
-        reasons.append(
-            "mismatch_words="
-            f"{exactness.get('mismatch_words')}, requires 0"
-        )
+        reasons.append(f"mismatch_words={exactness.get('mismatch_words')}, requires 0")
     xor = exactness.get("xor", {})
     if xor.get("max_word") != 0 or xor.get("reduction") != 0:
         reasons.append("packed uint32 XOR result is nonzero")
     return not reasons, reasons
 
 
-def _performance_gate(
-    payload: dict[str, Any], rounds: int
-) -> tuple[bool, list[str]]:
+def _performance_gate(payload: dict[str, Any], rounds: int) -> tuple[bool, list[str]]:
     reasons: list[str] = []
     pairs = payload.get("pairs", {})
     if pairs.get("count") != rounds:
@@ -430,13 +410,10 @@ def _performance_gate(
             f"candidate_faster={pairs.get('candidate_faster')}, "
             f"requires >= {required_wins}/{rounds}"
         )
-    speedup_pct = payload.get("timing", {}).get(
-        "candidate_speedup_vs_baseline_pct"
-    )
+    speedup_pct = payload.get("timing", {}).get("candidate_speedup_vs_baseline_pct")
     if speedup_pct is None or speedup_pct < K_REQUIRED_SPEEDUP_PCT:
         reasons.append(
-            f"median speedup={speedup_pct}, requires "
-            f">= {K_REQUIRED_SPEEDUP_PCT}%"
+            f"median speedup={speedup_pct}, requires >= {K_REQUIRED_SPEEDUP_PCT}%"
         )
     return not reasons, reasons
 
@@ -502,9 +479,7 @@ def _run_case(
     resource_passed, resource_reasons = _resource_gate(
         payload, sass, ptxas_baseline, ptxas_candidate, build_command
     )
-    performance_passed, performance_reasons = _performance_gate(
-        payload, args.rounds
-    )
+    performance_passed, performance_reasons = _performance_gate(payload, args.rounds)
     reasons = [
         *([] if completed.returncode == 0 else ["C++ benchmark returned nonzero"]),
         *correctness_reasons,
@@ -625,14 +600,11 @@ def _run_ncu_kernel(
                 "l1tex__data_bank_conflicts_pipe_lsu_mem_shared.sum"
             ),
             "duration_ns": metrics.get("gpu__time_duration.sum"),
-            "tensor_instructions": metrics.get(
-                "smsp__inst_executed_pipe_tensor.sum"
-            ),
+            "tensor_instructions": metrics.get("smsp__inst_executed_pipe_tensor.sum"),
         },
         "stdout_tail": completed.stdout[-3000:],
         "stderr_tail": completed.stderr[-3000:],
-        "permission_error": "ERR_NVGPUCTRPERM"
-        in (completed.stdout + completed.stderr),
+        "permission_error": "ERR_NVGPUCTRPERM" in (completed.stdout + completed.stderr),
     }
 
 
@@ -659,17 +631,13 @@ def _ncu_payload(
 
 
 def _aggregate_gates(cases: list[dict[str, Any]]) -> dict[str, Any]:
-    correctness_all_cases = all(
-        case["gates"]["correctness_passed"] for case in cases
-    )
+    correctness_all_cases = all(case["gates"]["correctness_passed"] for case in cases)
     resource_all_cases = all(case["gates"]["resource_passed"] for case in cases)
     all_case_performance_passed = all(
         case["gates"]["performance_passed"] for case in cases
     )
     aggregate_passed = (
-        correctness_all_cases
-        and resource_all_cases
-        and all_case_performance_passed
+        correctness_all_cases and resource_all_cases and all_case_performance_passed
     )
     reasons: list[str] = []
     if not correctness_all_cases:
@@ -735,8 +703,7 @@ def main() -> int:
         "benchmark": "sm70_native_bm32_allp_scratch_micro",
         "target": "sm_70",
         "matrix": [
-            {"pattern": pattern, "nblocks": nblocks}
-            for pattern, nblocks in K_CASES
+            {"pattern": pattern, "nblocks": nblocks} for pattern, nblocks in K_CASES
         ],
         "configuration": {
             "groups": args.groups,

--- a/benchmarks/benchmark_sm70_native_bm32_full_phase_allp_micro.py
+++ b/benchmarks/benchmark_sm70_native_bm32_full_phase_allp_micro.py
@@ -87,10 +87,7 @@ def _require_environment(args: argparse.Namespace) -> None:
     if args.rounds < K_DEFAULT_ROUNDS:
         raise ValueError(f"rounds must be at least {K_DEFAULT_ROUNDS}.")
     if args.launches_per_sample < K_DEFAULT_LAUNCHES:
-        raise ValueError(
-            "launches-per-sample must be at least "
-            f"{K_DEFAULT_LAUNCHES}."
-        )
+        raise ValueError(f"launches-per-sample must be at least {K_DEFAULT_LAUNCHES}.")
 
 
 def _graphics_clock_mhz(physical_gpu: int) -> int:
@@ -239,8 +236,7 @@ def _inspect_sass(binary: Path) -> dict[str, Any]:
             "ctas_per_group": ctas_per_group,
             "instructions": instructions,
             "instructions_per_group": {
-                name: count * ctas_per_group
-                for name, count in instructions.items()
+                name: count * ctas_per_group for name, count in instructions.items()
             },
         }
     return {"available": True, "binary": str(binary), "kernels": kernels}
@@ -266,8 +262,7 @@ def _resource_gate(
         reasons.append("C++ runtime resource gate did not pass")
     if baseline.get("threads_per_cta") != 512:
         reasons.append(
-            "baseline threads_per_cta="
-            f"{baseline.get('threads_per_cta')}, requires 512"
+            f"baseline threads_per_cta={baseline.get('threads_per_cta')}, requires 512"
         )
     if baseline.get("active_ctas_per_sm", 0) < 2:
         reasons.append(
@@ -281,18 +276,15 @@ def _resource_gate(
         )
     if candidate.get("registers_per_thread", 65) > 64:
         reasons.append(
-            "candidate REG="
-            f"{candidate.get('registers_per_thread')}, requires <=64"
+            f"candidate REG={candidate.get('registers_per_thread')}, requires <=64"
         )
     if candidate.get("local_bytes_per_thread") != 0:
         reasons.append(
-            "candidate LOCAL="
-            f"{candidate.get('local_bytes_per_thread')}, requires 0"
+            f"candidate LOCAL={candidate.get('local_bytes_per_thread')}, requires 0"
         )
     if candidate.get("static_shared_bytes", 48 * 1024 + 1) > 48 * 1024:
         reasons.append(
-            "candidate shared="
-            f"{candidate.get('static_shared_bytes')}, requires <=49152"
+            f"candidate shared={candidate.get('static_shared_bytes')}, requires <=49152"
         )
     if candidate.get("active_ctas_per_sm", 0) < 2:
         reasons.append(
@@ -348,40 +340,31 @@ def _resource_gate(
     return not reasons, reasons
 
 
-def _correctness_gate(
-    payload: dict[str, Any], groups: int
-) -> tuple[bool, list[str]]:
+def _correctness_gate(payload: dict[str, Any], groups: int) -> tuple[bool, list[str]]:
     reasons: list[str] = []
     exactness = payload.get("exactness", {})
     expected_words = groups * K_M * K_D // 2
     if exactness.get("word_dtype") != "uint32 packed fp16":
         reasons.append(
-            "word_dtype="
-            f"{exactness.get('word_dtype')}, requires uint32 packed fp16"
+            f"word_dtype={exactness.get('word_dtype')}, requires uint32 packed fp16"
         )
     if exactness.get("word_count") != expected_words:
         reasons.append(
-            "word_count="
-            f"{exactness.get('word_count')}, requires {expected_words}"
+            f"word_count={exactness.get('word_count')}, requires {expected_words}"
         )
     if exactness.get("full_output") is not True:
         reasons.append("C++ probe did not compare the full output")
     if exactness.get("bitwise_equal") is not True:
         reasons.append("candidate output is not bitwise equal to baseline")
     if exactness.get("mismatch_words") != 0:
-        reasons.append(
-            "mismatch_words="
-            f"{exactness.get('mismatch_words')}, requires 0"
-        )
+        reasons.append(f"mismatch_words={exactness.get('mismatch_words')}, requires 0")
     xor = exactness.get("xor", {})
     if xor.get("max_word") != 0 or xor.get("reduction") != 0:
         reasons.append("packed uint32 XOR result is nonzero")
     return not reasons, reasons
 
 
-def _performance_gate(
-    payload: dict[str, Any], rounds: int
-) -> tuple[bool, list[str]]:
+def _performance_gate(payload: dict[str, Any], rounds: int) -> tuple[bool, list[str]]:
     reasons: list[str] = []
     timing = payload.get("timing", {})
     pairs = payload.get("pairs", {})
@@ -390,8 +373,7 @@ def _performance_gate(
         reasons.append("candidate speedup was not reported")
     elif speedup < K_REQUIRED_SPEEDUP_PCT:
         reasons.append(
-            f"candidate speedup {speedup:.3f}% is below "
-            f"{K_REQUIRED_SPEEDUP_PCT:.3f}%"
+            f"candidate speedup {speedup:.3f}% is below {K_REQUIRED_SPEEDUP_PCT:.3f}%"
         )
     if pairs.get("count") != rounds:
         reasons.append(f"pair count={pairs.get('count')}, requires {rounds}")
@@ -468,9 +450,7 @@ def _run_case(
     resource_passed, resource_reasons = _resource_gate(
         payload, sass, ptxas_candidate, build_command
     )
-    performance_passed, performance_reasons = _performance_gate(
-        payload, args.rounds
-    )
+    performance_passed, performance_reasons = _performance_gate(payload, args.rounds)
     reasons = [
         *([] if completed.returncode == 0 else ["C++ benchmark returned nonzero"]),
         *correctness_reasons,
@@ -584,14 +564,11 @@ def _run_ncu_kernel(
             "long_scoreboard_per_warp_active": metrics.get(
                 "smsp__warp_issue_stalled_long_scoreboard_per_warp_active"
             ),
-            "tensor_instructions": metrics.get(
-                "smsp__inst_executed_pipe_tensor.sum"
-            ),
+            "tensor_instructions": metrics.get("smsp__inst_executed_pipe_tensor.sum"),
         },
         "stdout_tail": completed.stdout[-3000:],
         "stderr_tail": completed.stderr[-3000:],
-        "permission_error": "ERR_NVGPUCTRPERM"
-        in (completed.stdout + completed.stderr),
+        "permission_error": "ERR_NVGPUCTRPERM" in (completed.stdout + completed.stderr),
     }
 
 
@@ -620,9 +597,7 @@ def _ncu_payload(
 def _aggregate_gates(cases: list[dict[str, Any]]) -> dict[str, Any]:
     primary_cases = [case for case in cases if case["nblocks"] == 4]
     short_cases = [case for case in cases if case["nblocks"] != 4]
-    correctness_all_cases = all(
-        case["gates"]["correctness_passed"] for case in cases
-    )
+    correctness_all_cases = all(case["gates"]["correctness_passed"] for case in cases)
     resource_all_cases = all(case["gates"]["resource_passed"] for case in cases)
     primary_performance_passed = all(
         case["gates"]["performance_passed"] for case in primary_cases
@@ -631,9 +606,7 @@ def _aggregate_gates(cases: list[dict[str, Any]]) -> dict[str, Any]:
         case["gates"]["performance_passed"] for case in cases
     )
     short_case_performance_failures = [
-        case["name"]
-        for case in short_cases
-        if not case["gates"]["performance_passed"]
+        case["name"] for case in short_cases if not case["gates"]["performance_passed"]
     ]
     aggregate_passed = (
         correctness_all_cases and resource_all_cases and primary_performance_passed
@@ -702,8 +675,7 @@ def main() -> int:
         "benchmark": "sm70_native_bm32_full_phase_allp_micro",
         "target": "sm_70",
         "matrix": [
-            {"pattern": pattern, "nblocks": nblocks}
-            for pattern, nblocks in K_CASES
+            {"pattern": pattern, "nblocks": nblocks} for pattern, nblocks in K_CASES
         ],
         "configuration": {
             "groups": args.groups,

--- a/benchmarks/benchmark_sm70_native_bm32_full_phase_micro.py
+++ b/benchmarks/benchmark_sm70_native_bm32_full_phase_micro.py
@@ -87,10 +87,7 @@ def _require_environment(args: argparse.Namespace) -> None:
     if args.rounds < K_DEFAULT_ROUNDS:
         raise ValueError(f"rounds must be at least {K_DEFAULT_ROUNDS}.")
     if args.launches_per_sample < K_DEFAULT_LAUNCHES:
-        raise ValueError(
-            "launches-per-sample must be at least "
-            f"{K_DEFAULT_LAUNCHES}."
-        )
+        raise ValueError(f"launches-per-sample must be at least {K_DEFAULT_LAUNCHES}.")
 
 
 def _graphics_clock_mhz(physical_gpu: int) -> int:
@@ -239,8 +236,7 @@ def _inspect_sass(binary: Path) -> dict[str, Any]:
             "ctas_per_group": ctas_per_group,
             "instructions": instructions,
             "instructions_per_group": {
-                name: count * ctas_per_group
-                for name, count in instructions.items()
+                name: count * ctas_per_group for name, count in instructions.items()
             },
         }
     return {"available": True, "binary": str(binary), "kernels": kernels}
@@ -266,8 +262,7 @@ def _resource_gate(
         reasons.append("C++ runtime resource gate did not pass")
     if baseline.get("threads_per_cta") != 512:
         reasons.append(
-            "baseline threads_per_cta="
-            f"{baseline.get('threads_per_cta')}, requires 512"
+            f"baseline threads_per_cta={baseline.get('threads_per_cta')}, requires 512"
         )
     if baseline.get("active_ctas_per_sm", 0) < 2:
         reasons.append(
@@ -281,18 +276,15 @@ def _resource_gate(
         )
     if candidate.get("registers_per_thread", 65) > 64:
         reasons.append(
-            "candidate REG="
-            f"{candidate.get('registers_per_thread')}, requires <=64"
+            f"candidate REG={candidate.get('registers_per_thread')}, requires <=64"
         )
     if candidate.get("local_bytes_per_thread") != 0:
         reasons.append(
-            "candidate LOCAL="
-            f"{candidate.get('local_bytes_per_thread')}, requires 0"
+            f"candidate LOCAL={candidate.get('local_bytes_per_thread')}, requires 0"
         )
     if candidate.get("static_shared_bytes", 48 * 1024 + 1) > 48 * 1024:
         reasons.append(
-            "candidate shared="
-            f"{candidate.get('static_shared_bytes')}, requires <=49152"
+            f"candidate shared={candidate.get('static_shared_bytes')}, requires <=49152"
         )
     if candidate.get("active_ctas_per_sm", 0) < 2:
         reasons.append(
@@ -348,40 +340,31 @@ def _resource_gate(
     return not reasons, reasons
 
 
-def _correctness_gate(
-    payload: dict[str, Any], groups: int
-) -> tuple[bool, list[str]]:
+def _correctness_gate(payload: dict[str, Any], groups: int) -> tuple[bool, list[str]]:
     reasons: list[str] = []
     exactness = payload.get("exactness", {})
     expected_words = groups * K_M * K_D // 2
     if exactness.get("word_dtype") != "uint32 packed fp16":
         reasons.append(
-            "word_dtype="
-            f"{exactness.get('word_dtype')}, requires uint32 packed fp16"
+            f"word_dtype={exactness.get('word_dtype')}, requires uint32 packed fp16"
         )
     if exactness.get("word_count") != expected_words:
         reasons.append(
-            "word_count="
-            f"{exactness.get('word_count')}, requires {expected_words}"
+            f"word_count={exactness.get('word_count')}, requires {expected_words}"
         )
     if exactness.get("full_output") is not True:
         reasons.append("C++ probe did not compare the full output")
     if exactness.get("bitwise_equal") is not True:
         reasons.append("candidate output is not bitwise equal to baseline")
     if exactness.get("mismatch_words") != 0:
-        reasons.append(
-            "mismatch_words="
-            f"{exactness.get('mismatch_words')}, requires 0"
-        )
+        reasons.append(f"mismatch_words={exactness.get('mismatch_words')}, requires 0")
     xor = exactness.get("xor", {})
     if xor.get("max_word") != 0 or xor.get("reduction") != 0:
         reasons.append("packed uint32 XOR result is nonzero")
     return not reasons, reasons
 
 
-def _performance_gate(
-    payload: dict[str, Any], rounds: int
-) -> tuple[bool, list[str]]:
+def _performance_gate(payload: dict[str, Any], rounds: int) -> tuple[bool, list[str]]:
     reasons: list[str] = []
     timing = payload.get("timing", {})
     pairs = payload.get("pairs", {})
@@ -390,8 +373,7 @@ def _performance_gate(
         reasons.append("candidate speedup was not reported")
     elif speedup < K_REQUIRED_SPEEDUP_PCT:
         reasons.append(
-            f"candidate speedup {speedup:.3f}% is below "
-            f"{K_REQUIRED_SPEEDUP_PCT:.3f}%"
+            f"candidate speedup {speedup:.3f}% is below {K_REQUIRED_SPEEDUP_PCT:.3f}%"
         )
     if pairs.get("count") != rounds:
         reasons.append(f"pair count={pairs.get('count')}, requires {rounds}")
@@ -468,9 +450,7 @@ def _run_case(
     resource_passed, resource_reasons = _resource_gate(
         payload, sass, ptxas_candidate, build_command
     )
-    performance_passed, performance_reasons = _performance_gate(
-        payload, args.rounds
-    )
+    performance_passed, performance_reasons = _performance_gate(payload, args.rounds)
     reasons = [
         *([] if completed.returncode == 0 else ["C++ benchmark returned nonzero"]),
         *correctness_reasons,
@@ -584,14 +564,11 @@ def _run_ncu_kernel(
             "long_scoreboard_per_warp_active": metrics.get(
                 "smsp__warp_issue_stalled_long_scoreboard_per_warp_active"
             ),
-            "tensor_instructions": metrics.get(
-                "smsp__inst_executed_pipe_tensor.sum"
-            ),
+            "tensor_instructions": metrics.get("smsp__inst_executed_pipe_tensor.sum"),
         },
         "stdout_tail": completed.stdout[-3000:],
         "stderr_tail": completed.stderr[-3000:],
-        "permission_error": "ERR_NVGPUCTRPERM"
-        in (completed.stdout + completed.stderr),
+        "permission_error": "ERR_NVGPUCTRPERM" in (completed.stdout + completed.stderr),
     }
 
 
@@ -620,9 +597,7 @@ def _ncu_payload(
 def _aggregate_gates(cases: list[dict[str, Any]]) -> dict[str, Any]:
     primary_cases = [case for case in cases if case["nblocks"] == 4]
     short_cases = [case for case in cases if case["nblocks"] != 4]
-    correctness_all_cases = all(
-        case["gates"]["correctness_passed"] for case in cases
-    )
+    correctness_all_cases = all(case["gates"]["correctness_passed"] for case in cases)
     resource_all_cases = all(case["gates"]["resource_passed"] for case in cases)
     primary_performance_passed = all(
         case["gates"]["performance_passed"] for case in primary_cases
@@ -631,9 +606,7 @@ def _aggregate_gates(cases: list[dict[str, Any]]) -> dict[str, Any]:
         case["gates"]["performance_passed"] for case in cases
     )
     short_case_performance_failures = [
-        case["name"]
-        for case in short_cases
-        if not case["gates"]["performance_passed"]
+        case["name"] for case in short_cases if not case["gates"]["performance_passed"]
     ]
     aggregate_passed = (
         correctness_all_cases and resource_all_cases and primary_performance_passed
@@ -702,8 +675,7 @@ def main() -> int:
         "benchmark": "sm70_native_bm32_full_phase_micro",
         "target": "sm_70",
         "matrix": [
-            {"pattern": pattern, "nblocks": nblocks}
-            for pattern, nblocks in K_CASES
+            {"pattern": pattern, "nblocks": nblocks} for pattern, nblocks in K_CASES
         ],
         "configuration": {
             "groups": args.groups,

--- a/benchmarks/benchmark_sm70_native_bm32_pv_panel_micro.py
+++ b/benchmarks/benchmark_sm70_native_bm32_pv_panel_micro.py
@@ -108,9 +108,7 @@ def _build_binary(verbose: bool) -> tuple[Path, list[str], str]:
     if nvcc is None:
         raise RuntimeError("nvcc is required to build the SM70 BM32 PV microbenchmark.")
     source = (
-        Path(__file__).resolve().parent
-        / "csrc"
-        / "sm70_native_bm32_pv_panel_micro.cu"
+        Path(__file__).resolve().parent / "csrc" / "sm70_native_bm32_pv_panel_micro.cu"
     )
     build_dir = (
         Path(tempfile.gettempdir())
@@ -228,8 +226,7 @@ def _resource_gate(
         )
     if baseline.get("threads_per_cta") != 512:
         reasons.append(
-            "baseline threads_per_cta="
-            f"{baseline.get('threads_per_cta')}, requires 512"
+            f"baseline threads_per_cta={baseline.get('threads_per_cta')}, requires 512"
         )
     if baseline.get("resident_active_warps") != 32:
         reasons.append(
@@ -258,13 +255,11 @@ def _resource_gate(
         )
     if candidate.get("registers_per_thread", 65) > 64:
         reasons.append(
-            "candidate REG="
-            f"{candidate.get('registers_per_thread')}, requires <=64"
+            f"candidate REG={candidate.get('registers_per_thread')}, requires <=64"
         )
     if candidate.get("local_bytes_per_thread") != 0:
         reasons.append(
-            "candidate LOCAL="
-            f"{candidate.get('local_bytes_per_thread')}, requires 0"
+            f"candidate LOCAL={candidate.get('local_bytes_per_thread')}, requires 0"
         )
     if candidate_topology.get("ctas_per_group") != 1:
         reasons.append(
@@ -388,9 +383,7 @@ def _run_ncu_kernel(
             "long_scoreboard_per_warp_active": metrics.get(
                 "smsp__warp_issue_stalled_long_scoreboard_per_warp_active"
             ),
-            "tensor_instructions": metrics.get(
-                "smsp__inst_executed_pipe_tensor.sum"
-            ),
+            "tensor_instructions": metrics.get("smsp__inst_executed_pipe_tensor.sum"),
         },
         "stdout_tail": result.stdout[-3000:],
         "stderr_tail": result.stderr[-3000:],

--- a/benchmarks/benchmark_sm70_raw_hmma_probe.py
+++ b/benchmarks/benchmark_sm70_raw_hmma_probe.py
@@ -32,10 +32,7 @@ def _build_binary(source: Path, verbose: bool) -> tuple[Path, list[str]]:
     if nvcc is None:
         raise RuntimeError("nvcc is required to build the SM70 raw HMMA probe.")
 
-    build_dir = (
-        Path(tempfile.gettempdir())
-        / f"vllm-sm70-raw-hmma-probe-{os.getuid()}"
-    )
+    build_dir = Path(tempfile.gettempdir()) / f"vllm-sm70-raw-hmma-probe-{os.getuid()}"
     build_dir.mkdir(parents=True, exist_ok=True)
     binary = build_dir / "sm70_raw_hmma_probe_sm70"
     command = [

--- a/benchmarks/benchmark_sm70_rejection_sampler_micro.py
+++ b/benchmarks/benchmark_sm70_rejection_sampler_micro.py
@@ -174,9 +174,7 @@ def _sparse_target_topk_topp_rejection_prototype(
     target_logits = sampled_logits[:num_tokens].float()
     bonus_logits = sampled_logits[num_tokens:].float()
 
-    target_topk_values, target_topk_ids = torch.topk(
-        target_logits, k=top_k, dim=-1
-    )
+    target_topk_values, target_topk_ids = torch.topk(target_logits, k=top_k, dim=-1)
     target_topk_probs = target_topk_values.softmax(dim=-1, dtype=torch.float32)
     target_remove_mask = target_topk_probs.cumsum(dim=-1) > top_p
     target_remove_mask[:, 1:] = target_remove_mask[:, :-1].clone()
@@ -191,9 +189,7 @@ def _sparse_target_topk_topp_rejection_prototype(
     bonus_remove_mask = bonus_topk_probs.cumsum(dim=-1) > top_p
     bonus_remove_mask[:, 1:] = bonus_remove_mask[:, :-1].clone()
     bonus_remove_mask[:, 0] = False
-    bonus_topk_values = bonus_topk_values.masked_fill(
-        bonus_remove_mask, -float("inf")
-    )
+    bonus_topk_values = bonus_topk_values.masked_fill(bonus_remove_mask, -float("inf"))
     bonus_topk_probs = bonus_topk_values.softmax(dim=-1, dtype=torch.float32)
 
     draft_ids_i64 = draft_token_ids.to(torch.int64).view(-1, 1)
@@ -210,9 +206,9 @@ def _sparse_target_topk_topp_rejection_prototype(
     ).clamp_max(1.0)
     accepted_prefix = (torch.rand_like(accept_ratio) <= accept_ratio).cumprod(0)
 
-    residual = (
-        target_topk_probs - draft_probs.gather(1, target_topk_ids)
-    ).clamp_min_(0.0)
+    residual = (target_topk_probs - draft_probs.gather(1, target_topk_ids)).clamp_min_(
+        0.0
+    )
     residual_q = torch.empty_like(residual).exponential_()
     recovered_offsets = (residual / residual_q).argmax(dim=-1, keepdim=True)
     recovered_token_ids = target_topk_ids.gather(1, recovered_offsets).view(-1)
@@ -247,9 +243,9 @@ def _full_vocab_topk_topp_probability_reference(
         k=min(top_k, probs.shape[-1]),
         dim=-1,
     )
-    residual = (
-        target_top_probs - draft_probs.gather(1, target_top_ids)
-    ).clamp_min_(0.0)
+    residual = (target_top_probs - draft_probs.gather(1, target_top_ids)).clamp_min_(
+        0.0
+    )
     return target_draft_probs, target_top_ids, residual
 
 
@@ -292,9 +288,7 @@ def _compact_tp2_topk_topp_probability_prototype(
         target_probs,
         torch.zeros_like(target_probs),
     ).sum(dim=-1)
-    residual = (
-        target_probs - draft_probs.gather(1, target_ids)
-    ).clamp_min_(0.0)
+    residual = (target_probs - draft_probs.gather(1, target_ids)).clamp_min_(0.0)
     return target_draft_probs, target_ids, residual
 
 
@@ -394,9 +388,7 @@ def main() -> None:
         bonus_logits_indices=torch.tensor(
             [num_tokens], dtype=torch.int32, device=device
         ),
-        logits_indices=torch.arange(
-            num_tokens + 1, dtype=torch.int32, device=device
-        ),
+        logits_indices=torch.arange(num_tokens + 1, dtype=torch.int32, device=device),
     )
 
     target_logits_constrained = apply_sampling_constraints(
@@ -495,9 +487,9 @@ def main() -> None:
             args.iters,
         ),
         "target_prepare_with_clone": _time_cuda(
-            lambda: target_prepare_base[target_prepare_indices].to(
-                torch.float32
-            ).clone(),
+            lambda: target_prepare_base[target_prepare_indices]
+            .to(torch.float32)
+            .clone(),
             args.warmup,
             args.iters,
         ),

--- a/benchmarks/benchmark_sm70_source_inventory.py
+++ b/benchmarks/benchmark_sm70_source_inventory.py
@@ -502,19 +502,14 @@ def _scan_tree(root: Path) -> dict[str, Any]:
         "file_count": file_count,
         "scanned_bytes": scanned_bytes,
         "env_vars": {
-            name: sorted(files)
-            for name, files in sorted(env_to_files.items())
+            name: sorted(files) for name, files in sorted(env_to_files.items())
         },
         "runtime_env_vars": {
-            name: sorted(files)
-            for name, files in sorted(runtime_env_to_files.items())
+            name: sorted(files) for name, files in sorted(runtime_env_to_files.items())
         },
         "env_file_counts": dict(sorted(env_counts.items())),
         "keyword_files": dict(sorted(keyword_files.items())),
-        "torch_ops": {
-            name: sorted(files)
-            for name, files in sorted(torch_ops.items())
-        },
+        "torch_ops": {name: sorted(files) for name, files in sorted(torch_ops.items())},
     }
 
 
@@ -597,11 +592,11 @@ def _compact_diff(old: dict[str, Any], latest: dict[str, Any]) -> dict[str, Any]
     diff["old_only_torch_op_classification"] = _classify_old_only_torch_ops(
         diff["torch_ops"]["old_only"]
     )
-    diff["old_only_runtime_env_classification"] = (
-        _classify_old_only_runtime_envs(diff["runtime_env_vars"]["old_only"])
+    diff["old_only_runtime_env_classification"] = _classify_old_only_runtime_envs(
+        diff["runtime_env_vars"]["old_only"]
     )
-    diff["old_only_keyword_file_classification"] = (
-        _classify_old_only_keyword_files(diff["keyword_files"]["old_only"])
+    diff["old_only_keyword_file_classification"] = _classify_old_only_keyword_files(
+        diff["keyword_files"]["old_only"]
     )
     return diff
 
@@ -617,15 +612,9 @@ def _classification_counts(section: dict[str, Any]) -> dict[str, Any]:
 
 
 def _inventory_gate(diff: dict[str, Any]) -> dict[str, Any]:
-    runtime_env = _classification_counts(
-        diff["old_only_runtime_env_classification"]
-    )
-    keyword_files = _classification_counts(
-        diff["old_only_keyword_file_classification"]
-    )
-    torch_ops = _classification_counts(
-        diff["old_only_torch_op_classification"]
-    )
+    runtime_env = _classification_counts(diff["old_only_runtime_env_classification"])
+    keyword_files = _classification_counts(diff["old_only_keyword_file_classification"])
+    torch_ops = _classification_counts(diff["old_only_torch_op_classification"])
     old_only_env_vars = diff["env_vars"]["old_only"]
     complete = (
         not old_only_env_vars
@@ -675,32 +664,37 @@ def main() -> int:
         json.dumps(payload, indent=args.indent, sort_keys=True) + "\n",
         encoding="utf-8",
     )
-    print(json.dumps({
-        "out": str(args.out),
-        "old_files": payload["old"]["file_count"],
-        "latest_files": payload["latest"]["file_count"],
-        "old_env_vars": len(payload["old"]["env_vars"]),
-        "latest_env_vars": len(payload["latest"]["env_vars"]),
-        "old_runtime_env_vars": len(payload["old"]["runtime_env_vars"]),
-        "latest_runtime_env_vars": len(payload["latest"]["runtime_env_vars"]),
-            "old_keyword_files": len(payload["old"]["keyword_files"]),
-            "latest_keyword_files": len(payload["latest"]["keyword_files"]),
-            "old_torch_ops": len(payload["old"]["torch_ops"]),
-            "latest_torch_ops": len(payload["latest"]["torch_ops"]),
-            "inventory_complete": payload["inventory_gate"]["complete"],
-            "old_only_env_vars": payload["inventory_gate"][
-                "old_only_env_vars_count"
-            ],
-            "old_only_runtime_env_unclassified": payload["inventory_gate"][
-                "old_only_runtime_env"
-            ]["unclassified_count"],
-            "old_only_keyword_files_unclassified": payload["inventory_gate"][
-                "old_only_keyword_files"
-            ]["unclassified_count"],
-            "old_only_torch_ops_unclassified": payload["inventory_gate"][
-                "old_only_torch_ops"
-            ]["unclassified_count"],
-        }, sort_keys=True))
+    print(
+        json.dumps(
+            {
+                "out": str(args.out),
+                "old_files": payload["old"]["file_count"],
+                "latest_files": payload["latest"]["file_count"],
+                "old_env_vars": len(payload["old"]["env_vars"]),
+                "latest_env_vars": len(payload["latest"]["env_vars"]),
+                "old_runtime_env_vars": len(payload["old"]["runtime_env_vars"]),
+                "latest_runtime_env_vars": len(payload["latest"]["runtime_env_vars"]),
+                "old_keyword_files": len(payload["old"]["keyword_files"]),
+                "latest_keyword_files": len(payload["latest"]["keyword_files"]),
+                "old_torch_ops": len(payload["old"]["torch_ops"]),
+                "latest_torch_ops": len(payload["latest"]["torch_ops"]),
+                "inventory_complete": payload["inventory_gate"]["complete"],
+                "old_only_env_vars": payload["inventory_gate"][
+                    "old_only_env_vars_count"
+                ],
+                "old_only_runtime_env_unclassified": payload["inventory_gate"][
+                    "old_only_runtime_env"
+                ]["unclassified_count"],
+                "old_only_keyword_files_unclassified": payload["inventory_gate"][
+                    "old_only_keyword_files"
+                ]["unclassified_count"],
+                "old_only_torch_ops_unclassified": payload["inventory_gate"][
+                    "old_only_torch_ops"
+                ]["unclassified_count"],
+            },
+            sort_keys=True,
+        )
+    )
     return 0
 
 

--- a/benchmarks/benchmark_sm70_turbomind_parity.py
+++ b/benchmarks/benchmark_sm70_turbomind_parity.py
@@ -94,8 +94,9 @@ def _load_awq(
     device: torch.device,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     weight_map = _weight_map(model_path)
-    with safe_open(model_path / weight_map[f"{layer}.qweight"],
-                   framework="pt", device="cpu") as f:
+    with safe_open(
+        model_path / weight_map[f"{layer}.qweight"], framework="pt", device="cpu"
+    ) as f:
         qweight = f.get_tensor(f"{layer}.qweight").to(device).contiguous()
         scales = f.get_tensor(f"{layer}.scales").to(device).contiguous()
         qzeros = f.get_tensor(f"{layer}.qzeros").to(device).contiguous()
@@ -108,8 +109,9 @@ def _load_fp8(
     device: torch.device,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     weight_map = _weight_map(model_path)
-    with safe_open(model_path / weight_map[f"{layer}.weight"],
-                   framework="pt", device="cpu") as f:
+    with safe_open(
+        model_path / weight_map[f"{layer}.weight"], framework="pt", device="cpu"
+    ) as f:
         weight = f.get_tensor(f"{layer}.weight").to(device).contiguous()
         scales = (
             f.get_tensor(f"{layer}.weight_scale_inv")
@@ -158,9 +160,7 @@ def _dump_fp8(
     ops = _import_sm70_ops()
     weight, scales = _load_fp8(args.model, args.layer, device)
     x = _make_input(args.m, weight.shape[1], device)
-    tm_weight, tm_scales, meta = ops.fp8_sm70_prepare(
-        weight, scales, args.group_size
-    )
+    tm_weight, tm_scales, meta = ops.fp8_sm70_prepare(weight, scales, args.group_size)
     out = torch.empty((args.m, weight.shape[0]), device=device, dtype=torch.float16)
     ops.fp8_gemm_sm70_out_meta(out, x, tm_weight, tm_scales, meta)
     details = {
@@ -205,8 +205,13 @@ def _dump(args: argparse.Namespace) -> int:
         "output": out.detach().cpu(),
     }
     torch.save(payload, args.out)
-    print(json.dumps({k: v for k, v in payload.items() if k != "output"},
-                     indent=2, sort_keys=True))
+    print(
+        json.dumps(
+            {k: v for k, v in payload.items() if k != "output"},
+            indent=2,
+            sort_keys=True,
+        )
+    )
     return 0
 
 
@@ -270,9 +275,9 @@ def _bench_awq(
     tm_weight, tm_scales, meta = ops.awq_sm70_prepare(
         qweight, scales, qzeros, args.group_size
     )
-    out = torch.empty((args.m, qweight.shape[1] * 8),
-                      device=device,
-                      dtype=torch.float16)
+    out = torch.empty(
+        (args.m, qweight.shape[1] * 8), device=device, dtype=torch.float16
+    )
     k_ld = int(meta[0].item())
     q_ld = int(meta[1].item())
 
@@ -300,9 +305,7 @@ def _bench_fp8(
     ops = _import_sm70_ops()
     weight, scales = _load_fp8(args.model, args.layer, device)
     x = _make_input(args.m, weight.shape[1], device)
-    tm_weight, tm_scales, meta = ops.fp8_sm70_prepare(
-        weight, scales, args.group_size
-    )
+    tm_weight, tm_scales, meta = ops.fp8_sm70_prepare(weight, scales, args.group_size)
     out = torch.empty((args.m, weight.shape[0]), device=device, dtype=torch.float16)
 
     def run() -> None:

--- a/benchmarks/benchmark_sm70_wmma_fragment_probe.py
+++ b/benchmarks/benchmark_sm70_wmma_fragment_probe.py
@@ -15,11 +15,7 @@ from torch.utils.cpp_extension import load
 
 
 def _load_extension() -> object:
-    source = (
-        Path(__file__).resolve().parent
-        / "csrc"
-        / "sm70_wmma_fragment_probe.cu"
-    )
+    source = Path(__file__).resolve().parent / "csrc" / "sm70_wmma_fragment_probe.cu"
     os.environ.setdefault("TORCH_CUDA_ARCH_LIST", "7.0")
     return load(
         name="sm70_wmma_fragment_probe_v3",
@@ -41,17 +37,16 @@ def _parse_args() -> argparse.Namespace:
 def main() -> int:
     args = _parse_args()
     device = torch.device(args.device)
-    if not torch.cuda.is_available() or torch.cuda.get_device_capability(
-        device
-    ) != (7, 0):
+    if not torch.cuda.is_available() or torch.cuda.get_device_capability(device) != (
+        7,
+        0,
+    ):
         raise RuntimeError("This probe requires an SM70 CUDA device.")
 
     extension = _load_extension()
     tile = torch.arange(256, device=device, dtype=torch.float16).reshape(16, 16)
     words = extension.dump_matrix_a_fragment(tile, args.stride)
-    reference_words, swizzled_words = (
-        extension.compare_swizzled_matrix_a_fragment(tile)
-    )
+    reference_words, swizzled_words = extension.compare_swizzled_matrix_a_fragment(tile)
     matrix_b_row_words = extension.dump_matrix_b_fragment(tile, False)
     matrix_b_col_storage = tile.t().contiguous()
     matrix_b_col_words = extension.dump_matrix_b_fragment(
@@ -59,9 +54,7 @@ def main() -> int:
         True,
     )
     matrix_b_reference_words, matrix_b_compact_words = (
-        extension.compare_compact_matrix_b_col_fragment(
-            matrix_b_col_storage
-        )
+        extension.compare_compact_matrix_b_col_fragment(matrix_b_col_storage)
     )
     torch.accelerator.synchronize(device)
     elements = words.cpu().view(torch.float16).to(torch.int32).reshape(32, 16)
@@ -69,15 +62,10 @@ def main() -> int:
     counts = Counter(value for lane in mapping for value in lane)
     multiplicities = Counter(counts.values())
     matrix_b_elements = (
-        matrix_b_col_words.cpu()
-        .view(torch.float16)
-        .to(torch.int32)
-        .reshape(32, 16)
+        matrix_b_col_words.cpu().view(torch.float16).to(torch.int32).reshape(32, 16)
     )
     matrix_b_mapping = matrix_b_elements.tolist()
-    matrix_b_counts = Counter(
-        value for lane in matrix_b_mapping for value in lane
-    )
+    matrix_b_counts = Counter(value for lane in matrix_b_mapping for value in lane)
     matrix_b_multiplicities = Counter(matrix_b_counts.values())
     payload = {
         "device": str(device),
@@ -94,10 +82,7 @@ def main() -> int:
             torch.equal(reference_words, swizzled_words)
         ),
         "swizzled_fragment_max_word_xor": int(
-            torch.bitwise_xor(reference_words, swizzled_words)
-            .abs()
-            .max()
-            .item()
+            torch.bitwise_xor(reference_words, swizzled_words).abs().max().item()
         ),
         "matrix_b": {
             "lane_elements": matrix_b_mapping,
@@ -106,8 +91,7 @@ def main() -> int:
                 str(key): value
                 for key, value in sorted(matrix_b_multiplicities.items())
             },
-            "all_elements_covered": sorted(matrix_b_counts)
-            == list(range(256)),
+            "all_elements_covered": sorted(matrix_b_counts) == list(range(256)),
             "row_col_fragment_words_equal": bool(
                 torch.equal(matrix_b_row_words, matrix_b_col_words)
             ),

--- a/benchmarks/compare_sm70_tensor_dumps.py
+++ b/benchmarks/compare_sm70_tensor_dumps.py
@@ -79,11 +79,13 @@ def _load_records(root: Path) -> dict[tuple[Any, ...], list[dict[str, Any]]]:
         source = payload.get("source", payload.get("layer_type", "unknown"))
         shape = tuple(payload.get("shape", tuple(tensor.shape)))
         key = (step, layer_idx, source, label, shape)
-        records.setdefault(key, []).append({
-            "path": str(path),
-            "pid": payload.get("pid"),
-            "tensor": tensor,
-        })
+        records.setdefault(key, []).append(
+            {
+                "path": str(path),
+                "pid": payload.get("pid"),
+                "tensor": tensor,
+            }
+        )
     return records
 
 
@@ -134,33 +136,37 @@ def compare_dirs(left: Path, right: Path, top: int) -> dict[str, Any]:
         right_items = right_records.get(key, [])
         step, layer_idx, source, label, shape = key
         if not left_items or not right_items:
-            missing.append({
-                "step": step,
-                "layer_idx": layer_idx,
-                "source": source,
-                "label": label,
-                "shape": shape,
-                "left_count": len(left_items),
-                "right_count": len(right_items),
-            })
+            missing.append(
+                {
+                    "step": step,
+                    "layer_idx": layer_idx,
+                    "source": source,
+                    "label": label,
+                    "shape": shape,
+                    "left_count": len(left_items),
+                    "right_count": len(right_items),
+                }
+            )
             continue
         _, pairs = _best_pairing(left_items, right_items)
         for left_idx, right_idx, stats in pairs:
             left_tensor = left_items[left_idx]["tensor"]
             right_tensor = right_items[right_idx]["tensor"]
-            summaries.append({
-                "step": step,
-                "layer_idx": layer_idx,
-                "source": source,
-                "label": label,
-                "shape": shape,
-                "left_pid": left_items[left_idx]["pid"],
-                "right_pid": right_items[right_idx]["pid"],
-                "left_path": left_items[left_idx]["path"],
-                "right_path": right_items[right_idx]["path"],
-                **stats,
-                "rows": _row_stats(left_tensor, right_tensor),
-            })
+            summaries.append(
+                {
+                    "step": step,
+                    "layer_idx": layer_idx,
+                    "source": source,
+                    "label": label,
+                    "shape": shape,
+                    "left_pid": left_items[left_idx]["pid"],
+                    "right_pid": right_items[right_idx]["pid"],
+                    "left_path": left_items[left_idx]["path"],
+                    "right_path": right_items[right_idx]["path"],
+                    **stats,
+                    "rows": _row_stats(left_tensor, right_tensor),
+                }
+            )
 
     by_worst = sorted(
         summaries,
@@ -262,10 +268,12 @@ def _numeric_gate(
 
     if missing and not allow_missing:
         for item in missing[:20]:
-            violations.append({
-                "reason": "missing_tensor_dump",
-                **item,
-            })
+            violations.append(
+                {
+                    "reason": "missing_tensor_dump",
+                    **item,
+                }
+            )
 
     for item in compared:
         max_abs = float(item.get("max_abs", math.inf))
@@ -280,21 +288,25 @@ def _numeric_gate(
             )
 
         if item.get("shape_mismatch"):
-            violations.append({
-                "reason": "shape_mismatch",
-                **_record_ref(item),
-                "left_shape": item.get("left_shape"),
-                "right_shape": item.get("right_shape"),
-            })
+            violations.append(
+                {
+                    "reason": "shape_mismatch",
+                    **_record_ref(item),
+                    "left_shape": item.get("left_shape"),
+                    "right_shape": item.get("right_shape"),
+                }
+            )
             continue
 
         if not math.isfinite(max_abs) or not math.isfinite(mean_abs):
-            violations.append({
-                "reason": "non_finite_diff",
-                **_record_ref(item),
-                "max_abs": item.get("max_abs"),
-                "mean_abs": item.get("mean_abs"),
-            })
+            violations.append(
+                {
+                    "reason": "non_finite_diff",
+                    **_record_ref(item),
+                    "max_abs": item.get("max_abs"),
+                    "mean_abs": item.get("mean_abs"),
+                }
+            )
             continue
 
         item_max_abs_bound, max_abs_rule = _bound_for_item(
@@ -304,21 +316,25 @@ def _numeric_gate(
         )
         if item_max_abs_bound is None:
             if max_abs != 0.0:
-                pending.append({
-                    "reason": "nonzero_max_abs_without_bound",
-                    **_record_ref(item),
-                    "max_abs": max_abs,
-                })
+                pending.append(
+                    {
+                        "reason": "nonzero_max_abs_without_bound",
+                        **_record_ref(item),
+                        "max_abs": max_abs,
+                    }
+                )
         else:
             checked_max_abs += 1
             if max_abs > item_max_abs_bound:
-                violations.append({
-                    "reason": "max_abs_exceeds_bound",
-                    **_record_ref(item),
-                    "max_abs": max_abs,
-                    "bound": item_max_abs_bound,
-                    "bound_rule": max_abs_rule,
-                })
+                violations.append(
+                    {
+                        "reason": "max_abs_exceeds_bound",
+                        **_record_ref(item),
+                        "max_abs": max_abs,
+                        "bound": item_max_abs_bound,
+                        "bound_rule": max_abs_rule,
+                    }
+                )
 
         item_mean_abs_bound, mean_abs_rule = _bound_for_item(
             item,
@@ -328,23 +344,27 @@ def _numeric_gate(
         if item_mean_abs_bound is not None:
             checked_mean_abs += 1
             if mean_abs > item_mean_abs_bound:
-                violations.append({
-                    "reason": "mean_abs_exceeds_bound",
-                    **_record_ref(item),
-                    "mean_abs": mean_abs,
-                    "bound": item_mean_abs_bound,
-                    "bound_rule": mean_abs_rule,
-                })
+                violations.append(
+                    {
+                        "reason": "mean_abs_exceeds_bound",
+                        **_record_ref(item),
+                        "mean_abs": mean_abs,
+                        "bound": item_mean_abs_bound,
+                        "bound_rule": mean_abs_rule,
+                    }
+                )
 
         if min_cosine is not None and cosine is not None:
             checked_cosine += 1
             if cosine < min_cosine:
-                violations.append({
-                    "reason": "cosine_below_bound",
-                    **_record_ref(item),
-                    "cosine": cosine,
-                    "bound": min_cosine,
-                })
+                violations.append(
+                    {
+                        "reason": "cosine_below_bound",
+                        **_record_ref(item),
+                        "cosine": cosine,
+                        "bound": min_cosine,
+                    }
+                )
 
     if checked_max_abs == 0 and (max_abs_bound is not None or max_abs_rules):
         pending.append("no tensors matched any max_abs bound")

--- a/benchmarks/kernels/benchmark_dspark_markov.py
+++ b/benchmarks/kernels/benchmark_dspark_markov.py
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 """Microbenchmark DSpark's sequential Markov sampling chain."""
 

--- a/benchmarks/kernels/benchmark_dspark_metadata.py
+++ b/benchmarks/kernels/benchmark_dspark_metadata.py
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 """Validate DSpark query expansion and non-causal SWA metadata."""
 

--- a/benchmarks/kernels/benchmark_dspark_sm70_attention.py
+++ b/benchmarks/kernels/benchmark_dspark_sm70_attention.py
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 """Replay a real DSpark packed-FP8 attention dump at N=7."""
 

--- a/benchmarks/kernels/benchmark_sm70_fp8_graph_capture.py
+++ b/benchmarks/kernels/benchmark_sm70_fp8_graph_capture.py
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 """Validate an uncached SM70 FP8 GEMM shape under CUDA Graph capture."""
 

--- a/benchmarks/verify_sm70_artifact.py
+++ b/benchmarks/verify_sm70_artifact.py
@@ -75,18 +75,14 @@ AWQ_TURBOMIND_DENSE_JSON_EXPECTATIONS = (
     ("sm70_turbomind_policy.awq_turbomind_effective", True),
 )
 
-AWQ_TURBOMIND_DENSE_REQUIRED_LOGS = (
-    "SM70 AWQ TurboMind dense path enabled",
-)
+AWQ_TURBOMIND_DENSE_REQUIRED_LOGS = ("SM70 AWQ TurboMind dense path enabled",)
 
 FP8_TURBOMIND_DENSE_JSON_EXPECTATIONS = (
     ("sm70_turbomind_policy.fp8_turbomind_effective", True),
     ("sm70_turbomind_policy.fp8_dequant_fallback_effective", True),
 )
 
-FP8_TURBOMIND_DENSE_REQUIRED_LOGS = (
-    "SM70 FP8 TurboMind W8A16 dense path enabled",
-)
+FP8_TURBOMIND_DENSE_REQUIRED_LOGS = ("SM70 FP8 TurboMind W8A16 dense path enabled",)
 
 FP8_0DOT3_DENSE_DEQUANT_JSON_EXPECTATIONS = (
     ("sm70_turbomind_policy.fp8_turbomind_effective", False),
@@ -105,8 +101,7 @@ AWQ_MOE_SAFE_ROUTE_JSON_EXPECTATIONS = (
     ("sm70_turbomind_policy.accepted_awq_moe_default_policy", True),
     ("sm70_turbomind_policy.awq_moe_disable_effective", False),
     ("sm70_turbomind_policy.awq_moe_batched_gemm_effective", False),
-    ("sm70_turbomind_policy.awq_moe_legacy_single_token_compact_effective",
-     False),
+    ("sm70_turbomind_policy.awq_moe_legacy_single_token_compact_effective", False),
     ("sm70_moe_policy.single_token_unpermute_fastpath_effective", True),
 )
 
@@ -121,8 +116,7 @@ AWQ_MOE_BATCHED_SAFE_ROUTE_JSON_EXPECTATIONS = (
     ("sm70_turbomind_policy.accepted_awq_moe_default_policy", True),
     ("sm70_turbomind_policy.awq_moe_disable_effective", False),
     ("sm70_turbomind_policy.awq_moe_batched_gemm_effective", True),
-    ("sm70_turbomind_policy.awq_moe_legacy_single_token_compact_effective",
-     False),
+    ("sm70_turbomind_policy.awq_moe_legacy_single_token_compact_effective", False),
 )
 
 AWQ_MOE_BATCHED_SAFE_ROUTE_REQUIRED_LOGS = (
@@ -138,8 +132,7 @@ AWQ_MOE_0DOT3_BASELINE_ROUTE_JSON_EXPECTATIONS = (
     ("sm70_turbomind_policy.awq_moe_0dot3_baseline_policy", True),
     ("sm70_turbomind_policy.awq_moe_disable_effective", False),
     ("sm70_turbomind_policy.awq_moe_batched_gemm_effective", True),
-    ("sm70_turbomind_policy.awq_moe_legacy_single_token_compact_effective",
-     True),
+    ("sm70_turbomind_policy.awq_moe_legacy_single_token_compact_effective", True),
 )
 
 AWQ_MOE_0DOT3_BASELINE_ROUTE_REQUIRED_LOGS = (
@@ -153,9 +146,7 @@ FP8_MOE_SAFE_ROUTE_JSON_EXPECTATIONS = (
     ("sm70_turbomind_policy.fp8_moe_batched_gemm_effective", True),
 )
 
-FP8_MOE_SAFE_ROUTE_REQUIRED_LOGS = (
-    "SM70 FP8 MoE TurboMind batched path enabled",
-)
+FP8_MOE_SAFE_ROUTE_REQUIRED_LOGS = ("SM70 FP8 MoE TurboMind batched path enabled",)
 
 FP8_MOE_0DOT3_FALLBACK_ROUTE_JSON_EXPECTATIONS = (
     ("sm70_turbomind_policy.fp8_moe_0dot3_dequant_fallback_policy", True),
@@ -281,9 +272,7 @@ def _get_json_path(payload: Any, path: str) -> Any:
 
 def _parse_expectation(raw: str) -> tuple[str, Any]:
     if "=" not in raw:
-        raise ValueError(
-            f"Expected PATH=VALUE for --expect-json, got {raw!r}"
-        )
+        raise ValueError(f"Expected PATH=VALUE for --expect-json, got {raw!r}")
     path, expected = raw.split("=", 1)
     if not path:
         raise ValueError(f"Expected non-empty PATH in {raw!r}")
@@ -339,17 +328,13 @@ def _awq_moe_safe_tune_gate_for_meta(meta: Any) -> dict[str, Any]:
         }
 
     raw = tune_policy.get("VLLM_SM70_AWQ_TUNE_SMALL_SHAPES")
-    tune_safe_default = tune_policy.get(
-        "awq_moe_safe_default_selector_effective"
-    )
+    tune_safe_default = tune_policy.get("awq_moe_safe_default_selector_effective")
     turbomind_safe_default = turbomind_policy.get(
         "awq_moe_safe_default_selector_effective"
     )
     pinned = raw == "0"
     source_safe_unset = (
-        raw is None
-        and tune_safe_default is True
-        and turbomind_safe_default is True
+        raw is None and tune_safe_default is True and turbomind_safe_default is True
     )
     return {
         "passed": pinned or source_safe_unset,
@@ -409,10 +394,12 @@ def _awq_moe_safe_tune_gate(payload: Any) -> dict[str, Any]:
     return {
         "passed": False,
         "location": None,
-        "checks": [{
-            "passed": False,
-            "reason": "no top-level or compare metadata policies found",
-        }],
+        "checks": [
+            {
+                "passed": False,
+                "reason": "no top-level or compare metadata policies found",
+            }
+        ],
     }
 
 
@@ -529,8 +516,7 @@ def _model_quality_failures(payload: Any) -> list[str]:
     failures = []
     if gate.get("label") != "model-pass":
         failures.append(
-            "model_quality_gate.label is not model-pass "
-            f"({gate.get('label')!r})"
+            f"model_quality_gate.label is not model-pass ({gate.get('label')!r})"
         )
     if gate.get("default_acceptance") != "model-level gate passed":
         failures.append(
@@ -586,8 +572,7 @@ def _inventory_complete_failures(payload: Any) -> list[str]:
     failures = []
     if gate.get("label") != "inventory-complete":
         failures.append(
-            "inventory_gate.label is not inventory-complete "
-            f"({gate.get('label')!r})"
+            f"inventory_gate.label is not inventory-complete ({gate.get('label')!r})"
         )
     if gate.get("complete") is not True:
         failures.append("inventory_gate.complete is not true")
@@ -595,8 +580,7 @@ def _inventory_complete_failures(payload: Any) -> list[str]:
     old_only_env_vars = gate.get("old_only_env_vars")
     if old_only_env_vars:
         failures.append(
-            "inventory_gate.old_only_env_vars is not empty: "
-            f"{old_only_env_vars!r}"
+            f"inventory_gate.old_only_env_vars is not empty: {old_only_env_vars!r}"
         )
     if gate.get("old_only_env_vars_count") != 0:
         failures.append(
@@ -647,11 +631,13 @@ def _verify(
         present = location is not None
         if not present:
             missing_policies.append(policy)
-        policy_results.append({
-            "policy": policy,
-            "present": present,
-            "location": location,
-        })
+        policy_results.append(
+            {
+                "policy": policy,
+                "present": present,
+                "location": location,
+            }
+        )
 
     json_results = []
     failed_json_expectations = []
@@ -678,10 +664,12 @@ def _verify(
         present = text in logs
         if not present:
             missing_log_texts.append(text)
-        log_results.append({
-            "text": text,
-            "present": present,
-        })
+        log_results.append(
+            {
+                "text": text,
+                "present": present,
+            }
+        )
 
     log_regex_results = []
     missing_log_regexes = []
@@ -689,10 +677,12 @@ def _verify(
         present = re.search(pattern, logs) is not None
         if not present:
             missing_log_regexes.append(pattern)
-        log_regex_results.append({
-            "pattern": pattern,
-            "present": present,
-        })
+        log_regex_results.append(
+            {
+                "pattern": pattern,
+                "present": present,
+            }
+        )
 
     rejected_log_results = []
     rejected_log_texts = []
@@ -700,10 +690,12 @@ def _verify(
         present = text in logs
         if present:
             rejected_log_texts.append(text)
-        rejected_log_results.append({
-            "text": text,
-            "present": present,
-        })
+        rejected_log_results.append(
+            {
+                "text": text,
+                "present": present,
+            }
+        )
 
     rejected_log_regex_results = []
     rejected_log_regexes = []
@@ -711,10 +703,12 @@ def _verify(
         present = re.search(pattern, logs) is not None
         if present:
             rejected_log_regexes.append(pattern)
-        rejected_log_regex_results.append({
-            "pattern": pattern,
-            "present": present,
-        })
+        rejected_log_regex_results.append(
+            {
+                "pattern": pattern,
+                "present": present,
+            }
+        )
 
     decode_timing_failures = (
         _decode_timing_failures(payload) if require_decode_timing else []
@@ -723,8 +717,7 @@ def _verify(
         _model_quality_failures(payload) if require_model_quality_pass else []
     )
     inventory_complete_failures = (
-        _inventory_complete_failures(payload)
-        if require_inventory_complete else []
+        _inventory_complete_failures(payload) if require_inventory_complete else []
     )
 
     passed = not (
@@ -888,9 +881,7 @@ def _build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--require-awq-turbomind-dense",
         action="store_true",
-        help=(
-            "Require SM70 AWQ TurboMind dense policy and its runtime route log."
-        ),
+        help=("Require SM70 AWQ TurboMind dense policy and its runtime route log."),
     )
     parser.add_argument(
         "--require-fp8-turbomind-dense",
@@ -1017,9 +1008,7 @@ def main() -> int:
 
     try:
         payload = _read_json(args.json)
-        expectations = [
-            _parse_expectation(raw) for raw in args.expect_json
-        ]
+        expectations = [_parse_expectation(raw) for raw in args.expect_json]
         log_expectations = list(args.expect_log)
         log_regex_expectations = list(args.expect_log_regex)
         rejected_log_expectations = list(args.reject_log)
@@ -1034,9 +1023,7 @@ def main() -> int:
             log_expectations.extend(FULL_FLASH_V100_REQUIRED_LOGS)
             log_expectations.extend(SM70_FP8_KV_CACHE_ROUTE_REQUIRED_LOGS)
             rejected_log_expectations.extend(FULL_FLASH_V100_REJECTED_LOGS)
-            rejected_log_expectations.extend(
-                SM70_FP8_KV_CACHE_ROUTE_REJECTED_LOGS
-            )
+            rejected_log_expectations.extend(SM70_FP8_KV_CACHE_ROUTE_REJECTED_LOGS)
         if args.require_turbomind_default_policy:
             expectations.extend(TURBOMIND_DEFAULT_JSON_EXPECTATIONS)
         if args.require_awq_turbomind_dense:
@@ -1057,27 +1044,17 @@ def main() -> int:
         if args.require_awq_moe_batched_safe_route:
             expectations.extend(AWQ_MOE_BATCHED_SAFE_ROUTE_JSON_EXPECTATIONS)
             log_expectations.extend(AWQ_MOE_BATCHED_SAFE_ROUTE_REQUIRED_LOGS)
-            rejected_log_expectations.extend(
-                AWQ_MOE_BATCHED_SAFE_ROUTE_REJECTED_LOGS
-            )
+            rejected_log_expectations.extend(AWQ_MOE_BATCHED_SAFE_ROUTE_REJECTED_LOGS)
         if args.require_awq_moe_0dot3_baseline_route:
             expectations.extend(AWQ_MOE_0DOT3_BASELINE_ROUTE_JSON_EXPECTATIONS)
-            log_expectations.extend(
-                AWQ_MOE_0DOT3_BASELINE_ROUTE_REQUIRED_LOGS
-            )
+            log_expectations.extend(AWQ_MOE_0DOT3_BASELINE_ROUTE_REQUIRED_LOGS)
         if args.require_fp8_moe_safe_route:
             expectations.extend(FP8_MOE_SAFE_ROUTE_JSON_EXPECTATIONS)
             log_expectations.extend(FP8_MOE_SAFE_ROUTE_REQUIRED_LOGS)
         if args.require_fp8_moe_0dot3_fallback_route:
-            expectations.extend(
-                FP8_MOE_0DOT3_FALLBACK_ROUTE_JSON_EXPECTATIONS
-            )
-            log_expectations.extend(
-                FP8_MOE_0DOT3_FALLBACK_ROUTE_REQUIRED_LOGS
-            )
-            rejected_log_expectations.extend(
-                FP8_MOE_0DOT3_FALLBACK_ROUTE_REJECTED_LOGS
-            )
+            expectations.extend(FP8_MOE_0DOT3_FALLBACK_ROUTE_JSON_EXPECTATIONS)
+            log_expectations.extend(FP8_MOE_0DOT3_FALLBACK_ROUTE_REQUIRED_LOGS)
+            rejected_log_expectations.extend(FP8_MOE_0DOT3_FALLBACK_ROUTE_REJECTED_LOGS)
         extra_required_policies = list(args.require_policy)
         if args.require_sm70_breakable_graph_route:
             extra_required_policies.append("sm70_graph_policy")
@@ -1085,12 +1062,8 @@ def main() -> int:
             log_expectations.extend(SM70_BREAKABLE_GRAPH_ROUTE_REQUIRED_LOGS)
         if args.require_sm70_flash_v100_0dot3_compile_graph:
             extra_required_policies.append("sm70_graph_policy")
-            expectations.extend(
-                SM70_FLASH_V100_0DOT3_COMPILE_GRAPH_JSON_EXPECTATIONS
-            )
-            log_expectations.extend(
-                SM70_FLASH_V100_0DOT3_COMPILE_GRAPH_REQUIRED_LOGS
-            )
+            expectations.extend(SM70_FLASH_V100_0DOT3_COMPILE_GRAPH_JSON_EXPECTATIONS)
+            log_expectations.extend(SM70_FLASH_V100_0DOT3_COMPILE_GRAPH_REQUIRED_LOGS)
             rejected_log_expectations.extend(
                 SM70_FLASH_V100_0DOT3_COMPILE_GRAPH_REJECTED_LOGS
             )
@@ -1098,19 +1071,17 @@ def main() -> int:
             extra_required_policies.append("sm70_comm_policy")
             expectations.extend(SM70_CUSTOM_ALLREDUCE_ROUTE_JSON_EXPECTATIONS)
             log_expectations.extend(SM70_CUSTOM_ALLREDUCE_ROUTE_REQUIRED_LOGS)
-            rejected_log_expectations.extend(
-                SM70_CUSTOM_ALLREDUCE_ROUTE_REJECTED_LOGS
-            )
+            rejected_log_expectations.extend(SM70_CUSTOM_ALLREDUCE_ROUTE_REJECTED_LOGS)
         if args.require_sm70_all_reduce_sum2_route:
             extra_required_policies.append("sm70_comm_policy")
             expectations.extend(SM70_ALL_REDUCE_SUM2_ROUTE_JSON_EXPECTATIONS)
             log_expectations.extend(SM70_ALL_REDUCE_SUM2_ROUTE_REQUIRED_LOGS)
-            log_regex_expectations.extend(
-                SM70_ALL_REDUCE_SUM2_ROUTE_REQUIRED_REGEXES
-            )
-        required_policies = [] if args.require_inventory_complete else list(
-            dict.fromkeys(
-                list(DEFAULT_REQUIRED_POLICIES) + extra_required_policies
+            log_regex_expectations.extend(SM70_ALL_REDUCE_SUM2_ROUTE_REQUIRED_REGEXES)
+        required_policies = (
+            []
+            if args.require_inventory_complete
+            else list(
+                dict.fromkeys(list(DEFAULT_REQUIRED_POLICIES) + extra_required_policies)
             )
         )
         result = _verify(
@@ -1127,10 +1098,7 @@ def main() -> int:
             require_model_quality_pass=args.require_model_quality_pass,
             require_inventory_complete=args.require_inventory_complete,
         )
-        if (
-            args.require_awq_moe_safe_route
-            or args.require_awq_moe_batched_safe_route
-        ):
+        if args.require_awq_moe_safe_route or args.require_awq_moe_batched_safe_route:
             awq_moe_safe_tune_gate = _awq_moe_safe_tune_gate(payload)
             result["awq_moe_safe_tune_gate"] = awq_moe_safe_tune_gate
             if not awq_moe_safe_tune_gate["passed"]:

--- a/csrc/moe/marlin_moe_wna16/sm70_marlin_fp8_gemm.cu
+++ b/csrc/moe/marlin_moe_wna16/sm70_marlin_fp8_gemm.cu
@@ -35,22 +35,25 @@ class Sm70MoeFp8IteratorB {
   static int const kPackedMacroN = PackedMacroN_;
   static constexpr bool kUseMetadataVectorWords = UseMetadataVectorWords_;
   using Element = cutlass::half_t;
-  using Fragment = cutlass::Array<
-      Element, ThreadMap::Iterations::kCount * ThreadMap::kElementsPerAccess>;
-    static_assert(Shape::kN == 64 || Shape::kN == 128 || Shape::kN == 256,
-                "SM70 Marlin MoE FP8 IteratorB expects CTA_N in {64, 128, 256}.");
-  static_assert(ThreadMap::Iterations::kContiguous ==
-                    Shape::kN / kQuantTileN,
-                "SM70 Marlin MoE FP8 IteratorB expects one contiguous iteration per "
-                "64-column quant tile.");
+  using Fragment = cutlass::Array<Element, ThreadMap::Iterations::kCount *
+                                               ThreadMap::kElementsPerAccess>;
+  static_assert(
+      Shape::kN == 64 || Shape::kN == 128 || Shape::kN == 256,
+      "SM70 Marlin MoE FP8 IteratorB expects CTA_N in {64, 128, 256}.");
+  static_assert(
+      ThreadMap::Iterations::kContiguous == Shape::kN / kQuantTileN,
+      "SM70 Marlin MoE FP8 IteratorB expects one contiguous iteration per "
+      "64-column quant tile.");
   static_assert(ThreadMap::Delta::kContiguous == kQuantTileN,
                 "SM70 Marlin MoE FP8 IteratorB expects 64-column deltas.");
-  static_assert(ThreadMap::kElementsPerAccess == kFp8ValuesPerAccess,
-                "SM70 Marlin MoE FP8 IteratorB expects two packed FP8 words per "
-                "access.");
-  static_assert(ThreadMap::Iterations::kStrided >= 1,
-                "SM70 Marlin MoE U8-family IteratorB expects one or more strided "
-                "iterations.");
+  static_assert(
+      ThreadMap::kElementsPerAccess == kFp8ValuesPerAccess,
+      "SM70 Marlin MoE FP8 IteratorB expects two packed FP8 words per "
+      "access.");
+  static_assert(
+      ThreadMap::Iterations::kStrided >= 1,
+      "SM70 Marlin MoE U8-family IteratorB expects one or more strided "
+      "iterations.");
   static constexpr int kQweightWordStrideWords = kPackedMacroN / kQuantTileN;
 
   struct Params {
@@ -83,12 +86,11 @@ class Sm70MoeFp8IteratorB {
  public:
   CUTLASS_DEVICE
   Sm70MoeFp8IteratorB(Params const& params, uint32_t const* qweight,
-                       half const* scales, half const*, int thread_id,
-                       int expert, int k_offset, int n_offset)
+                      half const* scales, half const*, int thread_id,
+                      int expert, int k_offset, int n_offset)
       : qweight_(qweight),
-        scales_expert_base_(scales +
-                            (expert >= 0 ? expert : 0) *
-                                params.num_groups * params.size_n),
+        scales_expert_base_(scales + (expert >= 0 ? expert : 0) *
+                                         params.num_groups * params.size_n),
         params_(params),
         thread_offset_(ThreadMap::initial_offset(thread_id)),
         expert_(expert),
@@ -130,9 +132,7 @@ class Sm70MoeFp8IteratorB {
   }
 
   CUTLASS_DEVICE
-  int metadata_group_offset(int group) const {
-    return group * params_.size_n;
-  }
+  int metadata_group_offset(int group) const { return group * params_.size_n; }
 
   CUTLASS_DEVICE
   int scale_group(int logical_k) const {
@@ -155,8 +155,8 @@ class Sm70MoeFp8IteratorB {
   CUTLASS_DEVICE
   void cache_metadata_lane_vectors(int c, int group, int cache_n) const {
     int const metadata_offset = metadata_group_offset(group) + cache_n;
-    half2 const* scale_vec = reinterpret_cast<half2 const*>(
-        scales_expert_base_ + metadata_offset);
+    half2 const* scale_vec =
+        reinterpret_cast<half2 const*>(scales_expert_base_ + metadata_offset);
     half2* scale_cache = cached_scales_ + c * 4;
     scale_cache[0] = scale_vec[0];
     scale_cache[1] = scale_vec[1];
@@ -167,8 +167,8 @@ class Sm70MoeFp8IteratorB {
   CUTLASS_DEVICE
   void cache_metadata_vector_words(int c, int group, int cache_n) const {
     int const metadata_offset = metadata_group_offset(group) + cache_n;
-    uint4 const scale_words = *reinterpret_cast<uint4 const*>(
-        scales_expert_base_ + metadata_offset);
+    uint4 const scale_words =
+        *reinterpret_cast<uint4 const*>(scales_expert_base_ + metadata_offset);
     half2 const* scale_vec = reinterpret_cast<half2 const*>(&scale_words);
     half2* scale_cache = cached_scales_ + c * 4;
     scale_cache[0] = scale_vec[0];
@@ -181,9 +181,8 @@ class Sm70MoeFp8IteratorB {
   void cache_current_group_metadata(int group) const {
     CUTLASS_PRAGMA_UNROLL
     for (int c = 0; c < ThreadMap::Iterations::kContiguous; ++c) {
-      int const cache_n =
-          n_offset_ + thread_offset_.contiguous() +
-          c * ThreadMap::Delta::kContiguous;
+      int const cache_n = n_offset_ + thread_offset_.contiguous() +
+                          c * ThreadMap::Delta::kContiguous;
       if constexpr (kUseMetadataVectorWords) {
         cache_metadata_vector_words(c, group, cache_n);
       } else {
@@ -244,8 +243,9 @@ class Sm70MoeFp8IteratorB {
           frag_vec[3] = __hmul2(deq[1], scale_vec[3]);
         }
       } else {
-        static_assert(ThreadMap::Iterations::kContiguous == 1,
-                      "Unsupported SM70 Marlin MoE FP8 contiguous iteration count.");
+        static_assert(
+            ThreadMap::Iterations::kContiguous == 1,
+            "Unsupported SM70 Marlin MoE FP8 contiguous iteration count.");
         uint32_t const qword0 =
             load_qword_vector<1>(qweight_ + qweight_base_offset_);
         uint32_t const qword1 = load_qword_vector<1>(
@@ -267,9 +267,8 @@ class Sm70MoeFp8IteratorB {
       int const logical_n_base = n_offset_ + thread_offset_.contiguous();
       CUTLASS_PRAGMA_UNROLL
       for (int s = 0; s < ThreadMap::Iterations::kStrided; ++s) {
-        int const logical_k_s =
-            k_offset_ + thread_offset_.strided() +
-            s * ThreadMap::Delta::kStrided;
+        int const logical_k_s = k_offset_ + thread_offset_.strided() +
+                                s * ThreadMap::Delta::kStrided;
         if constexpr (kGroupSize != -1) {
           cache_current_group_metadata(scale_group(logical_k_s));
         }
@@ -277,10 +276,9 @@ class Sm70MoeFp8IteratorB {
             expert_qweight_base_offset() +
             qweight_offset_from_logical(params_, logical_k_s, logical_n_base);
         if constexpr (ThreadMap::Iterations::kContiguous == 4) {
-          uint4 const qwords0 =
-              load_qword_vector<4>(qweight_ + qweight_base_s);
-          uint4 const qwords1 = load_qword_vector<4>(
-              qweight_ + qweight_base_s + kQweightWordStrideWords);
+          uint4 const qwords0 = load_qword_vector<4>(qweight_ + qweight_base_s);
+          uint4 const qwords1 = load_qword_vector<4>(qweight_ + qweight_base_s +
+                                                     kQweightWordStrideWords);
           CUTLASS_PRAGMA_UNROLL
           for (int c = 0; c < ThreadMap::Iterations::kContiguous; ++c) {
             constexpr int kAccess = ThreadMap::kElementsPerAccess;
@@ -294,22 +292,17 @@ class Sm70MoeFp8IteratorB {
             half2* frag_vec = reinterpret_cast<half2*>(frag.data() + frag_base);
             marlin::dequant<half2, vllm::kFE4M3fn.id(), true>(
                 static_cast<int>(qword0), deq);
-            frag_vec[0] =
-                __hmul2(deq[0], scale_vec[0]);
-            frag_vec[1] =
-                __hmul2(deq[1], scale_vec[1]);
+            frag_vec[0] = __hmul2(deq[0], scale_vec[0]);
+            frag_vec[1] = __hmul2(deq[1], scale_vec[1]);
             marlin::dequant<half2, vllm::kFE4M3fn.id(), true>(
                 static_cast<int>(qword1), deq);
-            frag_vec[2] =
-                __hmul2(deq[0], scale_vec[2]);
-            frag_vec[3] =
-                __hmul2(deq[1], scale_vec[3]);
+            frag_vec[2] = __hmul2(deq[0], scale_vec[2]);
+            frag_vec[3] = __hmul2(deq[1], scale_vec[3]);
           }
         } else if constexpr (ThreadMap::Iterations::kContiguous == 2) {
-          uint2 const qwords0 =
-              load_qword_vector<2>(qweight_ + qweight_base_s);
-          uint2 const qwords1 = load_qword_vector<2>(
-              qweight_ + qweight_base_s + kQweightWordStrideWords);
+          uint2 const qwords0 = load_qword_vector<2>(qweight_ + qweight_base_s);
+          uint2 const qwords1 = load_qword_vector<2>(qweight_ + qweight_base_s +
+                                                     kQweightWordStrideWords);
           CUTLASS_PRAGMA_UNROLL
           for (int c = 0; c < ThreadMap::Iterations::kContiguous; ++c) {
             constexpr int kAccess = ThreadMap::kElementsPerAccess;
@@ -323,20 +316,17 @@ class Sm70MoeFp8IteratorB {
             half2* frag_vec = reinterpret_cast<half2*>(frag.data() + frag_base);
             marlin::dequant<half2, vllm::kFE4M3fn.id(), true>(
                 static_cast<int>(qword0), deq);
-            frag_vec[0] =
-                __hmul2(deq[0], scale_vec[0]);
-            frag_vec[1] =
-                __hmul2(deq[1], scale_vec[1]);
+            frag_vec[0] = __hmul2(deq[0], scale_vec[0]);
+            frag_vec[1] = __hmul2(deq[1], scale_vec[1]);
             marlin::dequant<half2, vllm::kFE4M3fn.id(), true>(
                 static_cast<int>(qword1), deq);
-            frag_vec[2] =
-                __hmul2(deq[0], scale_vec[2]);
-            frag_vec[3] =
-                __hmul2(deq[1], scale_vec[3]);
+            frag_vec[2] = __hmul2(deq[0], scale_vec[2]);
+            frag_vec[3] = __hmul2(deq[1], scale_vec[3]);
           }
         } else {
-          static_assert(ThreadMap::Iterations::kContiguous == 1,
-                        "Unsupported SM70 Marlin MoE FP8 contiguous iteration count.");
+          static_assert(
+              ThreadMap::Iterations::kContiguous == 1,
+              "Unsupported SM70 Marlin MoE FP8 contiguous iteration count.");
           uint32_t const qword0 =
               load_qword_vector<1>(qweight_ + qweight_base_s);
           uint32_t const qword1 = load_qword_vector<1>(
@@ -366,8 +356,7 @@ class Sm70MoeFp8IteratorB {
       return;
     }
 
-    if constexpr (kGroupSize != -1 &&
-                  ThreadMap::Iterations::kStrided == 1) {
+    if constexpr (kGroupSize != -1 && ThreadMap::Iterations::kStrided == 1) {
       int const first_logical_k = k_offset_ + thread_offset_.strided();
       cache_current_group_metadata(scale_group(first_logical_k));
     }
@@ -386,18 +375,17 @@ struct Sm70MoeFp8GemmSpec {
   using IteratorA = Sm70MoeGatherIteratorA<Shape, ThreadMap>;
 
   template <typename Shape, typename ThreadMap, int GroupSize, int PackedMacroN>
-  using IteratorB =
-      Sm70MoeFp8IteratorB<Shape, ThreadMap, GroupSize, PackedMacroN,
-                          UseMetadataVectorWords>;
+  using IteratorB = Sm70MoeFp8IteratorB<Shape, ThreadMap, GroupSize,
+                                        PackedMacroN, UseMetadataVectorWords>;
 };
 
-template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM,
-          int WarpN, int WarpK, int GroupSize, int PackedMacroN,
+template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM, int WarpN,
+          int WarpK, int GroupSize, int PackedMacroN,
           bool UseMetadataVectorWords = true>
 using Sm70MoeFp8GemmTraits =
-    Sm70MarlinMoeGemmTraits<
-        Sm70MoeFp8GemmSpec<UseMetadataVectorWords>, CtaM, CtaN, CtaK,
-        Warps, WarpM, WarpN, WarpK, GroupSize, PackedMacroN>;
+    Sm70MarlinMoeGemmTraits<Sm70MoeFp8GemmSpec<UseMetadataVectorWords>, CtaM,
+                            CtaN, CtaK, Warps, WarpM, WarpN, WarpK, GroupSize,
+                            PackedMacroN>;
 
 template <bool UseMetadataVectorWords = true>
 struct Sm70MoeFp8Launcher {
@@ -419,16 +407,16 @@ struct Sm70MoeFp8Launcher {
   int64_t size_k;
   int requested_split_k;
 
-  template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM,
-          int WarpN, int WarpK, int GroupSize, int PackedMacroN>
+  template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM, int WarpN,
+            int WarpK, int GroupSize, int PackedMacroN>
   torch::Tensor operator()() const {
-    using Traits = Sm70MoeFp8GemmTraits<CtaM, CtaN, CtaK, Warps, WarpM,
-                                        WarpN, WarpK, GroupSize, PackedMacroN,
-                                        UseMetadataVectorWords>;
+    using Traits =
+        Sm70MoeFp8GemmTraits<CtaM, CtaN, CtaK, Warps, WarpM, WarpN, WarpK,
+                             GroupSize, PackedMacroN, UseMetadataVectorWords>;
     return launch_sm70_marlin_moe_gemm<Traits>(
         a, c, b_q_weight, b_scales, b_zeros, global_scale, sorted_token_ids,
-        expert_ids, num_tokens_past_padded, topk_weights, moe_block_size,
-        top_k, mul_topk_weights, size_m, size_n, size_k, requested_split_k);
+        expert_ids, num_tokens_past_padded, topk_weights, moe_block_size, top_k,
+        mul_topk_weights, size_m, size_n, size_k, requested_split_k);
   }
 };
 
@@ -446,9 +434,10 @@ torch::Tensor sm70_marlin_fp8_gemm(
   auto const params = sm70_marlin_moe_auto_stage_params(
       "fp8_e4m3", group_size, moe_block_size, top_k, size_m, size_n, size_k);
   Sm70CtaGeometry const geometry = params.geometry;
-  validate_sm70_marlin_moe_stage_cta_geometry_supported("SM70 Marlin MoE fp8_e4m3", geometry);
-  validate_sm70_marlin_moe_stage_cta_n_alignment("SM70 Marlin MoE fp8_e4m3", geometry,
-                                        size_n);
+  validate_sm70_marlin_moe_stage_cta_geometry_supported(
+      "SM70 Marlin MoE fp8_e4m3", geometry);
+  validate_sm70_marlin_moe_stage_cta_n_alignment("SM70 Marlin MoE fp8_e4m3",
+                                                 geometry, size_n);
   TORCH_CHECK(size_k % geometry.cta_k == 0,
               "SM70 Marlin MoE fp8_e4m3 requires K divisible by CTA_K=",
               geometry.cta_k, ". Got K=", size_k, ".");
@@ -457,17 +446,45 @@ torch::Tensor sm70_marlin_fp8_gemm(
   auto empty_float = torch::empty(
       {0}, torch::TensorOptions().dtype(at::kFloat).device(a.device()));
   if (params.use_metadata_vector_words) {
-    Sm70MoeFp8Launcher<true> const launcher{
-        a, c, b_q_weight, b_scales, empty_half, empty_float, sorted_token_ids,
-        expert_ids, num_tokens_past_padded, topk_weights, moe_block_size, top_k,
-        mul_topk_weights, size_m, size_n, size_k, params.requested_split_k};
-    return dispatch_sm70_marlin_moe_fp8_geometry(launcher, geometry, params.packed_macro_n, group_size);
+    Sm70MoeFp8Launcher<true> const launcher{a,
+                                            c,
+                                            b_q_weight,
+                                            b_scales,
+                                            empty_half,
+                                            empty_float,
+                                            sorted_token_ids,
+                                            expert_ids,
+                                            num_tokens_past_padded,
+                                            topk_weights,
+                                            moe_block_size,
+                                            top_k,
+                                            mul_topk_weights,
+                                            size_m,
+                                            size_n,
+                                            size_k,
+                                            params.requested_split_k};
+    return dispatch_sm70_marlin_moe_fp8_geometry(
+        launcher, geometry, params.packed_macro_n, group_size);
   }
-  Sm70MoeFp8Launcher<false> const launcher{
-      a, c, b_q_weight, b_scales, empty_half, empty_float, sorted_token_ids,
-      expert_ids, num_tokens_past_padded, topk_weights, moe_block_size, top_k,
-      mul_topk_weights, size_m, size_n, size_k, params.requested_split_k};
-  return dispatch_sm70_marlin_moe_fp8_geometry(launcher, geometry, params.packed_macro_n, group_size);
+  Sm70MoeFp8Launcher<false> const launcher{a,
+                                           c,
+                                           b_q_weight,
+                                           b_scales,
+                                           empty_half,
+                                           empty_float,
+                                           sorted_token_ids,
+                                           expert_ids,
+                                           num_tokens_past_padded,
+                                           topk_weights,
+                                           moe_block_size,
+                                           top_k,
+                                           mul_topk_weights,
+                                           size_m,
+                                           size_n,
+                                           size_k,
+                                           params.requested_split_k};
+  return dispatch_sm70_marlin_moe_fp8_geometry(
+      launcher, geometry, params.packed_macro_n, group_size);
 }
 
 }  // namespace marlin_moe_wna16

--- a/csrc/moe/marlin_moe_wna16/sm70_marlin_gemm.cuh
+++ b/csrc/moe/marlin_moe_wna16/sm70_marlin_gemm.cuh
@@ -27,22 +27,22 @@
 
 namespace marlin_moe_wna16 {
 
-using marlin::sm70::Sm70CtaGeometry;
-using marlin::sm70::Sm70MarlinAutoParams;
-using marlin::sm70::Sm70MarlinMoeAutoParamsContext;
-using marlin::sm70::Sm70SplitKPartition;
-using marlin::sm70::Sm70MarlinMmaPipelined;
-using marlin::sm70::Sm70WarpShape;
 using marlin::sm70::configure_sm70_dynamic_smem;
 using marlin::sm70::kQuantTileK;
 using marlin::sm70::kQuantTileN;
+using marlin::sm70::sm70_active_split_k;
 using marlin::sm70::sm70_marlin_any_auto_env_is_set;
 using marlin::sm70::sm70_marlin_auto_packed_macro_n;
 using marlin::sm70::sm70_marlin_auto_params_from_env;
 using marlin::sm70::sm70_marlin_cta_geometry_is_supported;
 using marlin::sm70::sm70_marlin_default_auto_params;
-using marlin::sm70::sm70_active_split_k;
 using marlin::sm70::sm70_splitk_partition;
+using marlin::sm70::Sm70CtaGeometry;
+using marlin::sm70::Sm70MarlinAutoParams;
+using marlin::sm70::Sm70MarlinMmaPipelined;
+using marlin::sm70::Sm70MarlinMoeAutoParamsContext;
+using marlin::sm70::Sm70SplitKPartition;
+using marlin::sm70::Sm70WarpShape;
 using marlin::sm70::validate_sm70_marlin_auto_params;
 
 inline constexpr char const* kSupportedSm70MarlinMoeCtaGeometries =
@@ -55,9 +55,9 @@ inline constexpr char const* kSupportedSm70MarlinMoeCtaGeometries =
     "geometries are dense-only.";
 
 inline bool sm70_marlin_moe_auto_env_is_set() {
-  return sm70_marlin_any_auto_env_is_set(
-      "SM70_MARLIN_MOE_CTA_GEOMETRY", "SM70_MARLIN_MOE_SPLIT_K",
-      "SM70_MARLIN_MOE_METADATA_CACHE");
+  return sm70_marlin_any_auto_env_is_set("SM70_MARLIN_MOE_CTA_GEOMETRY",
+                                         "SM70_MARLIN_MOE_SPLIT_K",
+                                         "SM70_MARLIN_MOE_METADATA_CACHE");
 }
 
 inline Sm70MarlinAutoParams sm70_marlin_moe_auto_params_from_env(
@@ -68,16 +68,14 @@ inline Sm70MarlinAutoParams sm70_marlin_moe_auto_params_from_env(
 }
 
 inline bool sm70_marlin_moe_try_select_quanttrio_qwen3_6_35b_a3b_awq_params(
-    Sm70MarlinMoeAutoParamsContext const& ctx,
-    Sm70MarlinAutoParams& params) {
+    Sm70MarlinMoeAutoParamsContext const& ctx, Sm70MarlinAutoParams& params) {
   if (ctx.quant_format == nullptr ||
-      std::strcmp(ctx.quant_format, "uint4") != 0 ||
-      ctx.group_size != 128 || ctx.size_m <= 0) {
+      std::strcmp(ctx.quant_format, "uint4") != 0 || ctx.group_size != 128 ||
+      ctx.size_m <= 0) {
     return false;
   }
 
-  auto const set_params = [&](Sm70CtaGeometry geometry,
-                              int requested_split_k,
+  auto const set_params = [&](Sm70CtaGeometry geometry, int requested_split_k,
                               bool use_metadata_vector_words) {
     params = {geometry, requested_split_k, use_metadata_vector_words,
               ctx.packed_macro_n};
@@ -152,8 +150,7 @@ inline bool sm70_marlin_moe_try_select_quanttrio_qwen3_6_35b_a3b_awq_params(
       }
       return set_params({64, 128, 32, 8, 32, 32, 32}, 1, false);
     }
-    if (ctx.moe_block_size == 64 &&
-        (ctx.size_n == 256 || ctx.size_n == 1024)) {
+    if (ctx.moe_block_size == 64 && (ctx.size_n == 256 || ctx.size_n == 1024)) {
       return set_params({64, 256, 32, 4, 64, 64, 32}, 1, false);
     }
   }
@@ -162,16 +159,14 @@ inline bool sm70_marlin_moe_try_select_quanttrio_qwen3_6_35b_a3b_awq_params(
 }
 
 inline bool sm70_marlin_moe_try_select_quanttrio_qwen3_5_122b_a10b_awq_params(
-    Sm70MarlinMoeAutoParamsContext const& ctx,
-    Sm70MarlinAutoParams& params) {
+    Sm70MarlinMoeAutoParamsContext const& ctx, Sm70MarlinAutoParams& params) {
   if (ctx.quant_format == nullptr ||
-      std::strcmp(ctx.quant_format, "uint4") != 0 ||
-      ctx.group_size != 128 || ctx.size_m <= 0) {
+      std::strcmp(ctx.quant_format, "uint4") != 0 || ctx.group_size != 128 ||
+      ctx.size_m <= 0) {
     return false;
   }
 
-  auto const set_params = [&](Sm70CtaGeometry geometry,
-                              int requested_split_k,
+  auto const set_params = [&](Sm70CtaGeometry geometry, int requested_split_k,
                               bool use_metadata_vector_words) {
     params = {geometry, requested_split_k, use_metadata_vector_words,
               ctx.packed_macro_n};
@@ -278,16 +273,14 @@ inline bool sm70_marlin_moe_try_select_quanttrio_qwen3_5_122b_a10b_awq_params(
 }
 
 inline bool sm70_marlin_moe_try_select_quanttrio_minimax_m2_7_awq_params(
-    Sm70MarlinMoeAutoParamsContext const& ctx,
-    Sm70MarlinAutoParams& params) {
+    Sm70MarlinMoeAutoParamsContext const& ctx, Sm70MarlinAutoParams& params) {
   if (ctx.quant_format == nullptr ||
-      std::strcmp(ctx.quant_format, "uint4") != 0 ||
-      ctx.group_size != 128 || ctx.size_m <= 0) {
+      std::strcmp(ctx.quant_format, "uint4") != 0 || ctx.group_size != 128 ||
+      ctx.size_m <= 0) {
     return false;
   }
 
-  auto const set_params = [&](Sm70CtaGeometry geometry,
-                              int requested_split_k,
+  auto const set_params = [&](Sm70CtaGeometry geometry, int requested_split_k,
                               bool use_metadata_vector_words) {
     params = {geometry, requested_split_k, use_metadata_vector_words,
               ctx.packed_macro_n};
@@ -378,17 +371,16 @@ inline bool sm70_marlin_moe_try_select_quanttrio_minimax_m2_7_awq_params(
   return false;
 }
 
-inline bool sm70_marlin_moe_try_select_cyankiwi_qwen3_5_122b_a10b_awq_8bit_params(
-    Sm70MarlinMoeAutoParamsContext const& ctx,
-    Sm70MarlinAutoParams& params) {
+inline bool
+sm70_marlin_moe_try_select_cyankiwi_qwen3_5_122b_a10b_awq_8bit_params(
+    Sm70MarlinMoeAutoParamsContext const& ctx, Sm70MarlinAutoParams& params) {
   if (ctx.quant_format == nullptr ||
-      std::strcmp(ctx.quant_format, "uint8b128") != 0 ||
-      ctx.group_size != 32 || ctx.size_m <= 0) {
+      std::strcmp(ctx.quant_format, "uint8b128") != 0 || ctx.group_size != 32 ||
+      ctx.size_m <= 0) {
     return false;
   }
 
-  auto const set_params = [&](Sm70CtaGeometry geometry,
-                              int requested_split_k,
+  auto const set_params = [&](Sm70CtaGeometry geometry, int requested_split_k,
                               bool use_metadata_vector_words) {
     params = {geometry, requested_split_k, use_metadata_vector_words,
               ctx.packed_macro_n};
@@ -400,57 +392,57 @@ inline bool sm70_marlin_moe_try_select_cyankiwi_qwen3_5_122b_a10b_awq_8bit_param
     // top_k=1
     if (ctx.top_k == 1 && ctx.size_n == 3072) {
       if (ctx.size_k == 128) {
-          if (ctx.size_m <= 8) {
-            return set_params({32,128,32,4,32,32,32}, 1, true);
-          }
-          if (ctx.size_m <= 256) {
-            return set_params({32,256,32,4,32,64,32}, 1, true);
-          }
-          return set_params({32,256,32,4,32,64,32}, 1, true);
+        if (ctx.size_m <= 8) {
+          return set_params({32, 128, 32, 4, 32, 32, 32}, 1, true);
+        }
+        if (ctx.size_m <= 256) {
+          return set_params({32, 256, 32, 4, 32, 64, 32}, 1, true);
+        }
+        return set_params({32, 256, 32, 4, 32, 64, 32}, 1, true);
       }
     }
     if (ctx.top_k == 1 && ctx.size_n == 3072) {
       if (ctx.size_k == 256) {
-        return set_params({32,256,32,4,32,64,32}, 1, true);
+        return set_params({32, 256, 32, 4, 32, 64, 32}, 1, true);
       }
     }
     if (ctx.top_k == 1 && ctx.size_n == 3072) {
       if (ctx.size_k == 1024) {
-          if (ctx.size_m <= 8) {
-            return set_params({32,128,32,4,32,32,32}, 1, true);
-          }
-          return set_params({32,256,32,4,32,64,32}, 1, true);
+        if (ctx.size_m <= 8) {
+          return set_params({32, 128, 32, 4, 32, 32, 32}, 1, true);
+        }
+        return set_params({32, 256, 32, 4, 32, 64, 32}, 1, true);
       }
     }
     // top_k=8
     if (ctx.top_k == 8 && ctx.size_k == 3072) {
       if (ctx.size_n == 256) {
-          if (ctx.size_m <= 1) {
-            return set_params({32,128,32,4,32,32,32}, 8, true);
-          }
-          if (ctx.size_m <= 32) {
-            return set_params({32,128,128,8,32,64,32}, 1, true);
-          }
-          return set_params({32,128,64,8,32,32,32}, 1, true);
+        if (ctx.size_m <= 1) {
+          return set_params({32, 128, 32, 4, 32, 32, 32}, 8, true);
+        }
+        if (ctx.size_m <= 32) {
+          return set_params({32, 128, 128, 8, 32, 64, 32}, 1, true);
+        }
+        return set_params({32, 128, 64, 8, 32, 32, 32}, 1, true);
       }
     }
     if (ctx.top_k == 8 && ctx.size_k == 3072) {
       if (ctx.size_n == 512) {
-          if (ctx.size_m <= 1) {
-            return set_params({32,256,32,4,32,64,32}, 8, true);
-          }
-          if (ctx.size_m <= 32) {
-            return set_params({32,256,64,8,32,64,32}, 1, true);
-          }
-          return set_params({32,256,32,4,32,64,32}, 1, true);
+        if (ctx.size_m <= 1) {
+          return set_params({32, 256, 32, 4, 32, 64, 32}, 8, true);
+        }
+        if (ctx.size_m <= 32) {
+          return set_params({32, 256, 64, 8, 32, 64, 32}, 1, true);
+        }
+        return set_params({32, 256, 32, 4, 32, 64, 32}, 1, true);
       }
     }
     if (ctx.top_k == 8 && ctx.size_k == 3072) {
       if (ctx.size_n == 2048) {
-          if (ctx.size_m <= 1) {
-            return set_params({32,256,32,4,32,64,32}, 2, true);
-          }
-          return set_params({32,256,32,4,32,64,32}, 1, true);
+        if (ctx.size_m <= 1) {
+          return set_params({32, 256, 32, 4, 32, 64, 32}, 2, true);
+        }
+        return set_params({32, 256, 32, 4, 32, 64, 32}, 1, true);
       }
     }
   }
@@ -460,13 +452,13 @@ inline bool sm70_marlin_moe_try_select_cyankiwi_qwen3_5_122b_a10b_awq_8bit_param
     // top_k=1
     if (ctx.top_k == 1 && ctx.size_n == 3072) {
       if (ctx.size_k == 1024) {
-        return set_params({32,256,32,4,32,64,32}, 1, true);
+        return set_params({32, 256, 32, 4, 32, 64, 32}, 1, true);
       }
     }
     // top_k=8
     if (ctx.top_k == 8 && ctx.size_k == 3072) {
       if (ctx.size_n == 2048) {
-        return set_params({32,256,32,4,32,64,32}, 1, true);
+        return set_params({32, 256, 32, 4, 32, 64, 32}, 1, true);
       }
     }
   }
@@ -476,13 +468,13 @@ inline bool sm70_marlin_moe_try_select_cyankiwi_qwen3_5_122b_a10b_awq_8bit_param
     // top_k=1
     if (ctx.top_k == 1 && ctx.size_n == 3072) {
       if (ctx.size_k == 1024) {
-        return set_params({32,256,32,4,32,64,32}, 1, true);
+        return set_params({32, 256, 32, 4, 32, 64, 32}, 1, true);
       }
     }
     // top_k=8
     if (ctx.top_k == 8 && ctx.size_k == 3072) {
       if (ctx.size_n == 2048) {
-        return set_params({32,256,32,4,32,64,32}, 1, true);
+        return set_params({32, 256, 32, 4, 32, 64, 32}, 1, true);
       }
     }
   }
@@ -492,33 +484,33 @@ inline bool sm70_marlin_moe_try_select_cyankiwi_qwen3_5_122b_a10b_awq_8bit_param
     // top_k=1
     if (ctx.top_k == 1 && ctx.size_n == 3072) {
       if (ctx.size_k == 128) {
-        return set_params({64,256,32,4,64,64,32}, 1, false);
+        return set_params({64, 256, 32, 4, 64, 64, 32}, 1, false);
       }
     }
     if (ctx.top_k == 1 && ctx.size_n == 3072) {
       if (ctx.size_k == 256) {
-        return set_params({64,256,32,4,64,64,32}, 1, false);
+        return set_params({64, 256, 32, 4, 64, 64, 32}, 1, false);
       }
     }
     if (ctx.top_k == 1 && ctx.size_n == 3072) {
       if (ctx.size_k == 1024) {
-        return set_params({64,256,32,4,64,64,32}, 1, false);
+        return set_params({64, 256, 32, 4, 64, 64, 32}, 1, false);
       }
     }
     // top_k=8
     if (ctx.top_k == 8 && ctx.size_k == 3072) {
       if (ctx.size_n == 256) {
-        return set_params({64,256,32,4,64,64,32}, 1, false);
+        return set_params({64, 256, 32, 4, 64, 64, 32}, 1, false);
       }
     }
     if (ctx.top_k == 8 && ctx.size_k == 3072) {
       if (ctx.size_n == 512) {
-        return set_params({64,256,32,4,64,64,32}, 1, false);
+        return set_params({64, 256, 32, 4, 64, 64, 32}, 1, false);
       }
     }
     if (ctx.top_k == 8 && ctx.size_k == 3072) {
       if (ctx.size_n == 2048) {
-        return set_params({64,256,32,4,64,64,32}, 1, false);
+        return set_params({64, 256, 32, 4, 64, 64, 32}, 1, false);
       }
     }
   }
@@ -527,16 +519,14 @@ inline bool sm70_marlin_moe_try_select_cyankiwi_qwen3_5_122b_a10b_awq_8bit_param
 }
 
 inline bool sm70_marlin_moe_try_select_cyankiwi_qwen3_6_35b_a3b_awq_4bit_params(
-    Sm70MarlinMoeAutoParamsContext const& ctx,
-    Sm70MarlinAutoParams& params) {
+    Sm70MarlinMoeAutoParamsContext const& ctx, Sm70MarlinAutoParams& params) {
   if (ctx.quant_format == nullptr ||
-      std::strcmp(ctx.quant_format, "uint4") != 0 ||
-      ctx.group_size != 32 || ctx.size_m <= 0) {
+      std::strcmp(ctx.quant_format, "uint4") != 0 || ctx.group_size != 32 ||
+      ctx.size_m <= 0) {
     return false;
   }
 
-  auto const set_params = [&](Sm70CtaGeometry geometry,
-                              int requested_split_k,
+  auto const set_params = [&](Sm70CtaGeometry geometry, int requested_split_k,
                               bool use_metadata_vector_words) {
     params = {geometry, requested_split_k, use_metadata_vector_words,
               ctx.packed_macro_n};
@@ -548,63 +538,63 @@ inline bool sm70_marlin_moe_try_select_cyankiwi_qwen3_6_35b_a3b_awq_4bit_params(
     // top_k=1
     if (ctx.top_k == 1 && ctx.size_n == 2048) {
       if (ctx.size_k == 64) {
-          if (ctx.size_m <= 8) {
-            return set_params({32,64,32,4,32,32,16}, 1, false);
-          }
-          if (ctx.size_m <= 256) {
-            return set_params({32,256,32,4,32,64,32}, 1, true);
-          }
-          return set_params({32,256,32,4,32,64,32}, 1, true);
+        if (ctx.size_m <= 8) {
+          return set_params({32, 64, 32, 4, 32, 32, 16}, 1, false);
+        }
+        if (ctx.size_m <= 256) {
+          return set_params({32, 256, 32, 4, 32, 64, 32}, 1, true);
+        }
+        return set_params({32, 256, 32, 4, 32, 64, 32}, 1, true);
       }
     }
     if (ctx.top_k == 1 && ctx.size_n == 2048) {
       if (ctx.size_k == 128) {
-          if (ctx.size_m <= 8) {
-            return set_params({32,64,32,4,32,32,16}, 1, true);
-          }
-          if (ctx.size_m <= 256) {
-            return set_params({32,256,32,4,32,64,32}, 1, true);
-          }
-          return set_params({32,256,32,4,32,64,32}, 1, true);
+        if (ctx.size_m <= 8) {
+          return set_params({32, 64, 32, 4, 32, 32, 16}, 1, true);
+        }
+        if (ctx.size_m <= 256) {
+          return set_params({32, 256, 32, 4, 32, 64, 32}, 1, true);
+        }
+        return set_params({32, 256, 32, 4, 32, 64, 32}, 1, true);
       }
     }
     if (ctx.top_k == 1 && ctx.size_n == 2048) {
       if (ctx.size_k == 512) {
-          if (ctx.size_m <= 8) {
-            return set_params({32,128,32,4,32,64,16}, 1, true);
-          }
-          return set_params({32,256,32,4,32,64,32}, 1, true);
+        if (ctx.size_m <= 8) {
+          return set_params({32, 128, 32, 4, 32, 64, 16}, 1, true);
+        }
+        return set_params({32, 256, 32, 4, 32, 64, 32}, 1, true);
       }
     }
     // top_k=8
     if (ctx.top_k == 8 && ctx.size_k == 2048) {
       if (ctx.size_n == 128) {
-          if (ctx.size_m <= 1) {
-            return set_params({32,128,32,4,32,32,32}, 8, false);
-          }
-          if (ctx.size_m <= 32) {
-            return set_params({32,128,64,8,32,64,16}, 2, false);
-          }
-          return set_params({32,128,128,8,32,64,32}, 1, true);
+        if (ctx.size_m <= 1) {
+          return set_params({32, 128, 32, 4, 32, 32, 32}, 8, false);
+        }
+        if (ctx.size_m <= 32) {
+          return set_params({32, 128, 64, 8, 32, 64, 16}, 2, false);
+        }
+        return set_params({32, 128, 128, 8, 32, 64, 32}, 1, true);
       }
     }
     if (ctx.top_k == 8 && ctx.size_k == 2048) {
       if (ctx.size_n == 256) {
-          if (ctx.size_m <= 1) {
-            return set_params({32,128,32,4,32,32,32}, 8, true);
-          }
-          if (ctx.size_m <= 32) {
-            return set_params({32,128,128,8,32,64,32}, 1, true);
-          }
-          return set_params({32,256,64,8,32,64,32}, 1, false);
+        if (ctx.size_m <= 1) {
+          return set_params({32, 128, 32, 4, 32, 32, 32}, 8, true);
+        }
+        if (ctx.size_m <= 32) {
+          return set_params({32, 128, 128, 8, 32, 64, 32}, 1, true);
+        }
+        return set_params({32, 256, 64, 8, 32, 64, 32}, 1, false);
       }
     }
     if (ctx.top_k == 8 && ctx.size_k == 2048) {
       if (ctx.size_n == 1024) {
-          if (ctx.size_m <= 1) {
-            return set_params({32,256,32,4,32,64,32}, 4, true);
-          }
-          return set_params({32,256,32,4,32,64,32}, 1, true);
+        if (ctx.size_m <= 1) {
+          return set_params({32, 256, 32, 4, 32, 64, 32}, 4, true);
+        }
+        return set_params({32, 256, 32, 4, 32, 64, 32}, 1, true);
       }
     }
   }
@@ -614,16 +604,16 @@ inline bool sm70_marlin_moe_try_select_cyankiwi_qwen3_6_35b_a3b_awq_4bit_params(
     // top_k=1
     if (ctx.top_k == 1 && ctx.size_n == 2048) {
       if (ctx.size_k == 512) {
-        return set_params({32,256,32,4,32,64,32}, 1, true);
+        return set_params({32, 256, 32, 4, 32, 64, 32}, 1, true);
       }
     }
     // top_k=8
     if (ctx.top_k == 8 && ctx.size_k == 2048) {
       if (ctx.size_n == 1024) {
-          if (ctx.size_m <= 32) {
-            return set_params({32,256,64,8,32,64,32}, 1, false);
-          }
-          return set_params({32,256,32,4,32,64,32}, 1, true);
+        if (ctx.size_m <= 32) {
+          return set_params({32, 256, 64, 8, 32, 64, 32}, 1, false);
+        }
+        return set_params({32, 256, 32, 4, 32, 64, 32}, 1, true);
       }
     }
   }
@@ -633,13 +623,13 @@ inline bool sm70_marlin_moe_try_select_cyankiwi_qwen3_6_35b_a3b_awq_4bit_params(
     // top_k=1
     if (ctx.top_k == 1 && ctx.size_n == 2048) {
       if (ctx.size_k == 512) {
-        return set_params({32,256,32,4,32,64,32}, 1, true);
+        return set_params({32, 256, 32, 4, 32, 64, 32}, 1, true);
       }
     }
     // top_k=8
     if (ctx.top_k == 8 && ctx.size_k == 2048) {
       if (ctx.size_n == 1024) {
-        return set_params({32,256,64,8,32,64,32}, 1, true);
+        return set_params({32, 256, 64, 8, 32, 64, 32}, 1, true);
       }
     }
   }
@@ -649,36 +639,36 @@ inline bool sm70_marlin_moe_try_select_cyankiwi_qwen3_6_35b_a3b_awq_4bit_params(
     // top_k=1
     if (ctx.top_k == 1 && ctx.size_n == 2048) {
       if (ctx.size_k == 64) {
-        return set_params({64,256,32,4,64,64,32}, 1, false);
+        return set_params({64, 256, 32, 4, 64, 64, 32}, 1, false);
       }
     }
     if (ctx.top_k == 1 && ctx.size_n == 2048) {
       if (ctx.size_k == 128) {
-        return set_params({64,256,32,4,64,64,32}, 1, false);
+        return set_params({64, 256, 32, 4, 64, 64, 32}, 1, false);
       }
     }
     if (ctx.top_k == 1 && ctx.size_n == 2048) {
       if (ctx.size_k == 512) {
-        return set_params({64,256,32,4,64,64,32}, 1, false);
+        return set_params({64, 256, 32, 4, 64, 64, 32}, 1, false);
       }
     }
     // top_k=8
     if (ctx.top_k == 8 && ctx.size_k == 2048) {
       if (ctx.size_n == 128) {
-          if (ctx.size_m <= 2048) {
-            return set_params({64,128,32,4,64,64,16}, 1, false);
-          }
-          return set_params({64,128,32,8,32,32,32}, 1, true);
+        if (ctx.size_m <= 2048) {
+          return set_params({64, 128, 32, 4, 64, 64, 16}, 1, false);
+        }
+        return set_params({64, 128, 32, 8, 32, 32, 32}, 1, true);
       }
     }
     if (ctx.top_k == 8 && ctx.size_k == 2048) {
       if (ctx.size_n == 256) {
-        return set_params({64,256,32,4,64,64,32}, 1, false);
+        return set_params({64, 256, 32, 4, 64, 64, 32}, 1, false);
       }
     }
     if (ctx.top_k == 8 && ctx.size_k == 2048) {
       if (ctx.size_n == 1024) {
-        return set_params({64,256,32,4,64,64,32}, 1, false);
+        return set_params({64, 256, 32, 4, 64, 64, 32}, 1, false);
       }
     }
   }
@@ -686,17 +676,16 @@ inline bool sm70_marlin_moe_try_select_cyankiwi_qwen3_6_35b_a3b_awq_4bit_params(
   return false;
 }
 
-inline bool sm70_marlin_moe_try_select_cyankiwi_qwen3_6_35b_a3b_awq_nvfp4_params(
-    Sm70MarlinMoeAutoParamsContext const& ctx,
-    Sm70MarlinAutoParams& params) {
+inline bool
+sm70_marlin_moe_try_select_cyankiwi_qwen3_6_35b_a3b_awq_nvfp4_params(
+    Sm70MarlinMoeAutoParamsContext const& ctx, Sm70MarlinAutoParams& params) {
   if (ctx.quant_format == nullptr ||
-      std::strcmp(ctx.quant_format, "nvfp4") != 0 ||
-      ctx.group_size != 16 || ctx.size_m <= 0) {
+      std::strcmp(ctx.quant_format, "nvfp4") != 0 || ctx.group_size != 16 ||
+      ctx.size_m <= 0) {
     return false;
   }
 
-  auto const set_params = [&](Sm70CtaGeometry geometry,
-                              int requested_split_k,
+  auto const set_params = [&](Sm70CtaGeometry geometry, int requested_split_k,
                               bool use_metadata_vector_words) {
     params = {geometry, requested_split_k, use_metadata_vector_words,
               ctx.packed_macro_n};
@@ -708,63 +697,63 @@ inline bool sm70_marlin_moe_try_select_cyankiwi_qwen3_6_35b_a3b_awq_nvfp4_params
     // top_k=1
     if (ctx.top_k == 1 && ctx.size_n == 2048) {
       if (ctx.size_k == 64) {
-          if (ctx.size_m <= 8) {
-            return set_params({32,128,64,4,32,64,32}, 1, true);
-          }
-          if (ctx.size_m <= 256) {
-            return set_params({32,128,32,4,32,32,32}, 1, true);
-          }
-          return set_params({32,128,32,4,32,32,32}, 1, true);
+        if (ctx.size_m <= 8) {
+          return set_params({32, 128, 64, 4, 32, 64, 32}, 1, true);
+        }
+        if (ctx.size_m <= 256) {
+          return set_params({32, 128, 32, 4, 32, 32, 32}, 1, true);
+        }
+        return set_params({32, 128, 32, 4, 32, 32, 32}, 1, true);
       }
     }
     if (ctx.top_k == 1 && ctx.size_n == 2048) {
       if (ctx.size_k == 128) {
-          if (ctx.size_m <= 8) {
-            return set_params({32,128,32,4,32,32,32}, 1, false);
-          }
-          if (ctx.size_m <= 256) {
-            return set_params({32,128,32,4,32,32,32}, 1, true);
-          }
-          return set_params({32,128,32,4,32,32,32}, 1, false);
+        if (ctx.size_m <= 8) {
+          return set_params({32, 128, 32, 4, 32, 32, 32}, 1, false);
+        }
+        if (ctx.size_m <= 256) {
+          return set_params({32, 128, 32, 4, 32, 32, 32}, 1, true);
+        }
+        return set_params({32, 128, 32, 4, 32, 32, 32}, 1, false);
       }
     }
     if (ctx.top_k == 1 && ctx.size_n == 2048) {
       if (ctx.size_k == 512) {
-          if (ctx.size_m <= 8) {
-            return set_params({32,128,64,4,32,64,32}, 1, true);
-          }
-          return set_params({32,128,32,4,32,32,32}, 1, true);
+        if (ctx.size_m <= 8) {
+          return set_params({32, 128, 64, 4, 32, 64, 32}, 1, true);
+        }
+        return set_params({32, 128, 32, 4, 32, 32, 32}, 1, true);
       }
     }
     // top_k=8
     if (ctx.top_k == 8 && ctx.size_k == 2048) {
       if (ctx.size_n == 128) {
-          if (ctx.size_m <= 1) {
-            return set_params({32,64,32,4,32,32,16}, 8, true);
-          }
-          if (ctx.size_m <= 32) {
-            return set_params({32,128,64,8,32,32,32}, 4, true);
-          }
-          return set_params({32,128,128,8,32,64,32}, 1, true);
+        if (ctx.size_m <= 1) {
+          return set_params({32, 64, 32, 4, 32, 32, 16}, 8, true);
+        }
+        if (ctx.size_m <= 32) {
+          return set_params({32, 128, 64, 8, 32, 32, 32}, 4, true);
+        }
+        return set_params({32, 128, 128, 8, 32, 64, 32}, 1, true);
       }
     }
     if (ctx.top_k == 8 && ctx.size_k == 2048) {
       if (ctx.size_n == 256) {
-          if (ctx.size_m <= 1) {
-            return set_params({32,128,32,4,32,32,32}, 8, true);
-          }
-          if (ctx.size_m <= 32) {
-            return set_params({32,128,128,8,32,64,32}, 1, true);
-          }
-          return set_params({32,256,64,8,32,64,32}, 1, true);
+        if (ctx.size_m <= 1) {
+          return set_params({32, 128, 32, 4, 32, 32, 32}, 8, true);
+        }
+        if (ctx.size_m <= 32) {
+          return set_params({32, 128, 128, 8, 32, 64, 32}, 1, true);
+        }
+        return set_params({32, 256, 64, 8, 32, 64, 32}, 1, true);
       }
     }
     if (ctx.top_k == 8 && ctx.size_k == 2048) {
       if (ctx.size_n == 1024) {
-          if (ctx.size_m <= 1) {
-            return set_params({32,128,32,4,32,32,32}, 4, false);
-          }
-          return set_params({32,128,32,4,32,32,32}, 1, true);
+        if (ctx.size_m <= 1) {
+          return set_params({32, 128, 32, 4, 32, 32, 32}, 4, false);
+        }
+        return set_params({32, 128, 32, 4, 32, 32, 32}, 1, true);
       }
     }
   }
@@ -774,16 +763,16 @@ inline bool sm70_marlin_moe_try_select_cyankiwi_qwen3_6_35b_a3b_awq_nvfp4_params
     // top_k=1
     if (ctx.top_k == 1 && ctx.size_n == 2048) {
       if (ctx.size_k == 512) {
-        return set_params({32,128,32,4,32,32,32}, 1, false);
+        return set_params({32, 128, 32, 4, 32, 32, 32}, 1, false);
       }
     }
     // top_k=8
     if (ctx.top_k == 8 && ctx.size_k == 2048) {
       if (ctx.size_n == 1024) {
-          if (ctx.size_m <= 32) {
-            return set_params({32,256,64,8,32,64,32}, 1, true);
-          }
-          return set_params({32,128,32,4,32,32,32}, 1, true);
+        if (ctx.size_m <= 32) {
+          return set_params({32, 256, 64, 8, 32, 64, 32}, 1, true);
+        }
+        return set_params({32, 128, 32, 4, 32, 32, 32}, 1, true);
       }
     }
   }
@@ -793,13 +782,13 @@ inline bool sm70_marlin_moe_try_select_cyankiwi_qwen3_6_35b_a3b_awq_nvfp4_params
     // top_k=1
     if (ctx.top_k == 1 && ctx.size_n == 2048) {
       if (ctx.size_k == 512) {
-        return set_params({32,128,32,4,32,32,32}, 1, true);
+        return set_params({32, 128, 32, 4, 32, 32, 32}, 1, true);
       }
     }
     // top_k=8
     if (ctx.top_k == 8 && ctx.size_k == 2048) {
       if (ctx.size_n == 1024) {
-        return set_params({32,256,64,8,32,64,32}, 1, false);
+        return set_params({32, 256, 64, 8, 32, 64, 32}, 1, false);
       }
     }
   }
@@ -809,45 +798,45 @@ inline bool sm70_marlin_moe_try_select_cyankiwi_qwen3_6_35b_a3b_awq_nvfp4_params
     // top_k=1
     if (ctx.top_k == 1 && ctx.size_n == 2048) {
       if (ctx.size_k == 64) {
-          if (ctx.size_m <= 16384) {
-            return set_params({64,64,32,4,32,32,32}, 1, true);
-          }
-          return set_params({64,256,32,4,64,64,32}, 1, false);
+        if (ctx.size_m <= 16384) {
+          return set_params({64, 64, 32, 4, 32, 32, 32}, 1, true);
+        }
+        return set_params({64, 256, 32, 4, 64, 64, 32}, 1, false);
       }
     }
     if (ctx.top_k == 1 && ctx.size_n == 2048) {
       if (ctx.size_k == 128) {
-        return set_params({64,256,32,4,64,64,32}, 1, true);
+        return set_params({64, 256, 32, 4, 64, 64, 32}, 1, true);
       }
     }
     if (ctx.top_k == 1 && ctx.size_n == 2048) {
       if (ctx.size_k == 512) {
-          if (ctx.size_m <= 16384) {
-            return set_params({64,256,32,4,64,64,32}, 1, false);
-          }
-          return set_params({64,256,32,4,64,64,32}, 1, true);
+        if (ctx.size_m <= 16384) {
+          return set_params({64, 256, 32, 4, 64, 64, 32}, 1, false);
+        }
+        return set_params({64, 256, 32, 4, 64, 64, 32}, 1, true);
       }
     }
     // top_k=8
     if (ctx.top_k == 8 && ctx.size_k == 2048) {
       if (ctx.size_n == 128) {
-          if (ctx.size_m <= 2048) {
-            return set_params({32,128,32,4,32,32,32}, 1, true);
-          }
-          return set_params({64,128,32,8,32,32,32}, 1, true);
+        if (ctx.size_m <= 2048) {
+          return set_params({32, 128, 32, 4, 32, 32, 32}, 1, true);
+        }
+        return set_params({64, 128, 32, 8, 32, 32, 32}, 1, true);
       }
     }
     if (ctx.top_k == 8 && ctx.size_k == 2048) {
       if (ctx.size_n == 256) {
-          if (ctx.size_m <= 2048) {
-            return set_params({64,256,32,4,64,64,32}, 1, true);
-          }
-          return set_params({64,256,64,8,64,64,32}, 1, false);
+        if (ctx.size_m <= 2048) {
+          return set_params({64, 256, 32, 4, 64, 64, 32}, 1, true);
+        }
+        return set_params({64, 256, 64, 8, 64, 64, 32}, 1, false);
       }
     }
     if (ctx.top_k == 8 && ctx.size_k == 2048) {
       if (ctx.size_n == 1024) {
-        return set_params({64,256,32,4,64,64,32}, 1, true);
+        return set_params({64, 256, 32, 4, 64, 64, 32}, 1, true);
       }
     }
   }
@@ -855,17 +844,16 @@ inline bool sm70_marlin_moe_try_select_cyankiwi_qwen3_6_35b_a3b_awq_nvfp4_params
   return false;
 }
 
-inline bool sm70_marlin_moe_try_select_cyankiwi_qwen3_coder_next_awq_4bit_params(
-    Sm70MarlinMoeAutoParamsContext const& ctx,
-    Sm70MarlinAutoParams& params) {
+inline bool
+sm70_marlin_moe_try_select_cyankiwi_qwen3_coder_next_awq_4bit_params(
+    Sm70MarlinMoeAutoParamsContext const& ctx, Sm70MarlinAutoParams& params) {
   if (ctx.quant_format == nullptr ||
-      std::strcmp(ctx.quant_format, "uint4b8") != 0 ||
-      ctx.group_size != 32 || ctx.size_m <= 0) {
+      std::strcmp(ctx.quant_format, "uint4b8") != 0 || ctx.group_size != 32 ||
+      ctx.size_m <= 0) {
     return false;
   }
 
-  auto const set_params = [&](Sm70CtaGeometry geometry,
-                              int requested_split_k,
+  auto const set_params = [&](Sm70CtaGeometry geometry, int requested_split_k,
                               bool use_metadata_vector_words) {
     params = {geometry, requested_split_k, use_metadata_vector_words,
               ctx.packed_macro_n};
@@ -877,63 +865,63 @@ inline bool sm70_marlin_moe_try_select_cyankiwi_qwen3_coder_next_awq_4bit_params
     // top_k=1
     if (ctx.top_k == 1 && ctx.size_n == 2048) {
       if (ctx.size_k == 64) {
-          if (ctx.size_m <= 10) {
-            return set_params({32,128,32,4,32,32,32}, 1, true);
-          }
-          if (ctx.size_m <= 320) {
-            return set_params({32,256,32,4,32,64,32}, 1, true);
-          }
-          return set_params({32,256,32,4,32,64,32}, 1, true);
+        if (ctx.size_m <= 10) {
+          return set_params({32, 128, 32, 4, 32, 32, 32}, 1, true);
+        }
+        if (ctx.size_m <= 320) {
+          return set_params({32, 256, 32, 4, 32, 64, 32}, 1, true);
+        }
+        return set_params({32, 256, 32, 4, 32, 64, 32}, 1, true);
       }
     }
     if (ctx.top_k == 1 && ctx.size_n == 2048) {
       if (ctx.size_k == 128) {
-        return set_params({32,256,32,4,32,64,32}, 1, true);
+        return set_params({32, 256, 32, 4, 32, 64, 32}, 1, true);
       }
     }
     if (ctx.top_k == 1 && ctx.size_n == 2048) {
       if (ctx.size_k == 512) {
-          if (ctx.size_m <= 10) {
-            return set_params({32,128,64,4,32,64,32}, 1, true);
-          }
-          if (ctx.size_m <= 320) {
-            return set_params({32,256,32,4,32,64,32}, 1, true);
-          }
-          return set_params({32,256,32,4,32,64,32}, 1, true);
+        if (ctx.size_m <= 10) {
+          return set_params({32, 128, 64, 4, 32, 64, 32}, 1, true);
+        }
+        if (ctx.size_m <= 320) {
+          return set_params({32, 256, 32, 4, 32, 64, 32}, 1, true);
+        }
+        return set_params({32, 256, 32, 4, 32, 64, 32}, 1, true);
       }
     }
     // top_k=10
     if (ctx.top_k == 10 && ctx.size_k == 2048) {
       if (ctx.size_n == 128) {
-          if (ctx.size_m <= 1) {
-            return set_params({32,64,32,4,32,32,16}, 8, true);
-          }
-          if (ctx.size_m <= 32) {
-            return set_params({32,128,64,8,32,64,16}, 2, true);
-          }
-          return set_params({32,128,128,8,32,64,32}, 1, true);
+        if (ctx.size_m <= 1) {
+          return set_params({32, 64, 32, 4, 32, 32, 16}, 8, true);
+        }
+        if (ctx.size_m <= 32) {
+          return set_params({32, 128, 64, 8, 32, 64, 16}, 2, true);
+        }
+        return set_params({32, 128, 128, 8, 32, 64, 32}, 1, true);
       }
     }
     if (ctx.top_k == 10 && ctx.size_k == 2048) {
       if (ctx.size_n == 256) {
-          if (ctx.size_m <= 1) {
-            return set_params({32,128,32,4,32,32,32}, 8, true);
-          }
-          if (ctx.size_m <= 32) {
-            return set_params({32,128,128,8,32,64,32}, 1, true);
-          }
-          return set_params({32,256,64,8,32,64,32}, 1, true);
+        if (ctx.size_m <= 1) {
+          return set_params({32, 128, 32, 4, 32, 32, 32}, 8, true);
+        }
+        if (ctx.size_m <= 32) {
+          return set_params({32, 128, 128, 8, 32, 64, 32}, 1, true);
+        }
+        return set_params({32, 256, 64, 8, 32, 64, 32}, 1, true);
       }
     }
     if (ctx.top_k == 10 && ctx.size_k == 2048) {
       if (ctx.size_n == 1024) {
-          if (ctx.size_m <= 1) {
-            return set_params({32,256,32,4,32,64,32}, 4, true);
-          }
-          if (ctx.size_m <= 32) {
-            return set_params({32,256,32,4,32,64,32}, 1, true);
-          }
-          return set_params({32,256,32,4,32,64,32}, 1, true);
+        if (ctx.size_m <= 1) {
+          return set_params({32, 256, 32, 4, 32, 64, 32}, 4, true);
+        }
+        if (ctx.size_m <= 32) {
+          return set_params({32, 256, 32, 4, 32, 64, 32}, 1, true);
+        }
+        return set_params({32, 256, 32, 4, 32, 64, 32}, 1, true);
       }
     }
   }
@@ -943,13 +931,13 @@ inline bool sm70_marlin_moe_try_select_cyankiwi_qwen3_coder_next_awq_4bit_params
     // top_k=1
     if (ctx.top_k == 1 && ctx.size_n == 2048) {
       if (ctx.size_k == 512) {
-        return set_params({32,256,32,4,32,64,32}, 1, true);
+        return set_params({32, 256, 32, 4, 32, 64, 32}, 1, true);
       }
     }
     // top_k=10
     if (ctx.top_k == 10 && ctx.size_k == 2048) {
       if (ctx.size_n == 1024) {
-        return set_params({32,256,32,4,32,64,32}, 1, true);
+        return set_params({32, 256, 32, 4, 32, 64, 32}, 1, true);
       }
     }
   }
@@ -959,23 +947,23 @@ inline bool sm70_marlin_moe_try_select_cyankiwi_qwen3_coder_next_awq_4bit_params
     // top_k=1
     if (ctx.top_k == 1 && ctx.size_n == 2048) {
       if (ctx.size_k == 64) {
-        return set_params({64,256,32,4,64,64,32}, 1, false);
+        return set_params({64, 256, 32, 4, 64, 64, 32}, 1, false);
       }
     }
     if (ctx.top_k == 1 && ctx.size_n == 2048) {
       if (ctx.size_k == 128) {
-        return set_params({64,256,32,4,64,64,32}, 1, false);
+        return set_params({64, 256, 32, 4, 64, 64, 32}, 1, false);
       }
     }
     // top_k=10
     if (ctx.top_k == 10 && ctx.size_k == 2048) {
       if (ctx.size_n == 128) {
-        return set_params({64,128,32,8,32,32,32}, 1, false);
+        return set_params({64, 128, 32, 8, 32, 32, 32}, 1, false);
       }
     }
     if (ctx.top_k == 10 && ctx.size_k == 2048) {
       if (ctx.size_n == 256) {
-        return set_params({64,256,32,4,64,64,32}, 1, false);
+        return set_params({64, 256, 32, 4, 64, 64, 32}, 1, false);
       }
     }
   }
@@ -985,33 +973,33 @@ inline bool sm70_marlin_moe_try_select_cyankiwi_qwen3_coder_next_awq_4bit_params
     // top_k=1
     if (ctx.top_k == 1 && ctx.size_n == 2048) {
       if (ctx.size_k == 64) {
-        return set_params({64,256,32,4,64,64,32}, 1, false);
+        return set_params({64, 256, 32, 4, 64, 64, 32}, 1, false);
       }
     }
     if (ctx.top_k == 1 && ctx.size_n == 2048) {
       if (ctx.size_k == 128) {
-        return set_params({64,256,32,4,64,64,32}, 1, false);
+        return set_params({64, 256, 32, 4, 64, 64, 32}, 1, false);
       }
     }
     if (ctx.top_k == 1 && ctx.size_n == 2048) {
       if (ctx.size_k == 512) {
-        return set_params({64,256,32,4,64,64,32}, 1, false);
+        return set_params({64, 256, 32, 4, 64, 64, 32}, 1, false);
       }
     }
     // top_k=10
     if (ctx.top_k == 10 && ctx.size_k == 2048) {
       if (ctx.size_n == 128) {
-        return set_params({64,128,32,4,32,64,32}, 1, true);
+        return set_params({64, 128, 32, 4, 32, 64, 32}, 1, true);
       }
     }
     if (ctx.top_k == 10 && ctx.size_k == 2048) {
       if (ctx.size_n == 256) {
-        return set_params({64,256,32,4,64,64,32}, 1, false);
+        return set_params({64, 256, 32, 4, 64, 64, 32}, 1, false);
       }
     }
     if (ctx.top_k == 10 && ctx.size_k == 2048) {
       if (ctx.size_n == 1024) {
-        return set_params({64,256,32,4,64,64,32}, 1, false);
+        return set_params({64, 256, 32, 4, 64, 64, 32}, 1, false);
       }
     }
   }
@@ -1019,17 +1007,16 @@ inline bool sm70_marlin_moe_try_select_cyankiwi_qwen3_coder_next_awq_4bit_params
   return false;
 }
 
-inline bool sm70_marlin_moe_try_select_cyankiwi_qwen3_coder_next_awq_8bit_params(
-    Sm70MarlinMoeAutoParamsContext const& ctx,
-    Sm70MarlinAutoParams& params) {
+inline bool
+sm70_marlin_moe_try_select_cyankiwi_qwen3_coder_next_awq_8bit_params(
+    Sm70MarlinMoeAutoParamsContext const& ctx, Sm70MarlinAutoParams& params) {
   if (ctx.quant_format == nullptr ||
-      std::strcmp(ctx.quant_format, "uint8b128") != 0 ||
-      ctx.group_size != 32 || ctx.size_m <= 0) {
+      std::strcmp(ctx.quant_format, "uint8b128") != 0 || ctx.group_size != 32 ||
+      ctx.size_m <= 0) {
     return false;
   }
 
-  auto const set_params = [&](Sm70CtaGeometry geometry,
-                              int requested_split_k,
+  auto const set_params = [&](Sm70CtaGeometry geometry, int requested_split_k,
                               bool use_metadata_vector_words) {
     params = {geometry, requested_split_k, use_metadata_vector_words,
               ctx.packed_macro_n};
@@ -1041,63 +1028,63 @@ inline bool sm70_marlin_moe_try_select_cyankiwi_qwen3_coder_next_awq_8bit_params
     // top_k=1
     if (ctx.top_k == 1 && ctx.size_n == 2048) {
       if (ctx.size_k == 64) {
-        return set_params({32,256,32,4,32,64,32}, 1, true);
+        return set_params({32, 256, 32, 4, 32, 64, 32}, 1, true);
       }
     }
     if (ctx.top_k == 1 && ctx.size_n == 2048) {
       if (ctx.size_k == 128) {
-          if (ctx.size_m <= 10) {
-            return set_params({32,128,32,4,32,32,32}, 1, true);
-          }
-          if (ctx.size_m <= 320) {
-            return set_params({32,256,32,4,32,64,32}, 1, true);
-          }
-          return set_params({32,256,32,4,32,64,32}, 1, true);
+        if (ctx.size_m <= 10) {
+          return set_params({32, 128, 32, 4, 32, 32, 32}, 1, true);
+        }
+        if (ctx.size_m <= 320) {
+          return set_params({32, 256, 32, 4, 32, 64, 32}, 1, true);
+        }
+        return set_params({32, 256, 32, 4, 32, 64, 32}, 1, true);
       }
     }
     if (ctx.top_k == 1 && ctx.size_n == 2048) {
       if (ctx.size_k == 512) {
-          if (ctx.size_m <= 10) {
-            return set_params({32,256,64,8,32,64,32}, 1, true);
-          }
-          if (ctx.size_m <= 320) {
-            return set_params({32,256,32,4,32,64,32}, 1, true);
-          }
-          return set_params({32,256,32,4,32,64,32}, 1, true);
+        if (ctx.size_m <= 10) {
+          return set_params({32, 256, 64, 8, 32, 64, 32}, 1, true);
+        }
+        if (ctx.size_m <= 320) {
+          return set_params({32, 256, 32, 4, 32, 64, 32}, 1, true);
+        }
+        return set_params({32, 256, 32, 4, 32, 64, 32}, 1, true);
       }
     }
     // top_k=10
     if (ctx.top_k == 10 && ctx.size_k == 2048) {
       if (ctx.size_n == 128) {
-          if (ctx.size_m <= 1) {
-            return set_params({32,64,32,4,32,32,16}, 8, true);
-          }
-          if (ctx.size_m <= 32) {
-            return set_params({32,128,64,8,32,64,16}, 2, true);
-          }
-          return set_params({32,128,128,8,32,64,32}, 1, true);
+        if (ctx.size_m <= 1) {
+          return set_params({32, 64, 32, 4, 32, 32, 16}, 8, true);
+        }
+        if (ctx.size_m <= 32) {
+          return set_params({32, 128, 64, 8, 32, 64, 16}, 2, true);
+        }
+        return set_params({32, 128, 128, 8, 32, 64, 32}, 1, true);
       }
     }
     if (ctx.top_k == 10 && ctx.size_k == 2048) {
       if (ctx.size_n == 256) {
-          if (ctx.size_m <= 1) {
-            return set_params({32,256,32,4,32,64,32}, 8, true);
-          }
-          if (ctx.size_m <= 32) {
-            return set_params({32,128,128,8,32,64,32}, 1, true);
-          }
-          return set_params({32,256,64,8,32,64,32}, 1, true);
+        if (ctx.size_m <= 1) {
+          return set_params({32, 256, 32, 4, 32, 64, 32}, 8, true);
+        }
+        if (ctx.size_m <= 32) {
+          return set_params({32, 128, 128, 8, 32, 64, 32}, 1, true);
+        }
+        return set_params({32, 256, 64, 8, 32, 64, 32}, 1, true);
       }
     }
     if (ctx.top_k == 10 && ctx.size_k == 2048) {
       if (ctx.size_n == 1024) {
-          if (ctx.size_m <= 1) {
-            return set_params({32,128,128,8,32,64,32}, 1, true);
-          }
-          if (ctx.size_m <= 32) {
-            return set_params({32,256,32,4,32,64,32}, 1, true);
-          }
-          return set_params({32,256,32,4,32,64,32}, 1, true);
+        if (ctx.size_m <= 1) {
+          return set_params({32, 128, 128, 8, 32, 64, 32}, 1, true);
+        }
+        if (ctx.size_m <= 32) {
+          return set_params({32, 256, 32, 4, 32, 64, 32}, 1, true);
+        }
+        return set_params({32, 256, 32, 4, 32, 64, 32}, 1, true);
       }
     }
   }
@@ -1107,13 +1094,13 @@ inline bool sm70_marlin_moe_try_select_cyankiwi_qwen3_coder_next_awq_8bit_params
     // top_k=1
     if (ctx.top_k == 1 && ctx.size_n == 2048) {
       if (ctx.size_k == 512) {
-        return set_params({32,256,32,4,32,64,32}, 1, true);
+        return set_params({32, 256, 32, 4, 32, 64, 32}, 1, true);
       }
     }
     // top_k=10
     if (ctx.top_k == 10 && ctx.size_k == 2048) {
       if (ctx.size_n == 1024) {
-        return set_params({32,256,32,4,32,64,32}, 1, true);
+        return set_params({32, 256, 32, 4, 32, 64, 32}, 1, true);
       }
     }
   }
@@ -1123,23 +1110,23 @@ inline bool sm70_marlin_moe_try_select_cyankiwi_qwen3_coder_next_awq_8bit_params
     // top_k=1
     if (ctx.top_k == 1 && ctx.size_n == 2048) {
       if (ctx.size_k == 64) {
-        return set_params({64,256,32,4,64,64,32}, 1, false);
+        return set_params({64, 256, 32, 4, 64, 64, 32}, 1, false);
       }
     }
     if (ctx.top_k == 1 && ctx.size_n == 2048) {
       if (ctx.size_k == 128) {
-        return set_params({64,256,32,4,64,64,32}, 1, false);
+        return set_params({64, 256, 32, 4, 64, 64, 32}, 1, false);
       }
     }
     // top_k=10
     if (ctx.top_k == 10 && ctx.size_k == 2048) {
       if (ctx.size_n == 128) {
-        return set_params({64,128,32,8,32,32,32}, 1, false);
+        return set_params({64, 128, 32, 8, 32, 32, 32}, 1, false);
       }
     }
     if (ctx.top_k == 10 && ctx.size_k == 2048) {
       if (ctx.size_n == 256) {
-        return set_params({64,256,32,4,64,64,32}, 1, false);
+        return set_params({64, 256, 32, 4, 64, 64, 32}, 1, false);
       }
     }
   }
@@ -1149,33 +1136,33 @@ inline bool sm70_marlin_moe_try_select_cyankiwi_qwen3_coder_next_awq_8bit_params
     // top_k=1
     if (ctx.top_k == 1 && ctx.size_n == 2048) {
       if (ctx.size_k == 64) {
-        return set_params({64,256,32,4,64,64,32}, 1, false);
+        return set_params({64, 256, 32, 4, 64, 64, 32}, 1, false);
       }
     }
     if (ctx.top_k == 1 && ctx.size_n == 2048) {
       if (ctx.size_k == 128) {
-        return set_params({64,256,32,4,64,64,32}, 1, false);
+        return set_params({64, 256, 32, 4, 64, 64, 32}, 1, false);
       }
     }
     if (ctx.top_k == 1 && ctx.size_n == 2048) {
       if (ctx.size_k == 512) {
-        return set_params({64,256,32,4,64,64,32}, 1, false);
+        return set_params({64, 256, 32, 4, 64, 64, 32}, 1, false);
       }
     }
     // top_k=10
     if (ctx.top_k == 10 && ctx.size_k == 2048) {
       if (ctx.size_n == 128) {
-        return set_params({64,128,32,8,32,32,32}, 1, false);
+        return set_params({64, 128, 32, 8, 32, 32, 32}, 1, false);
       }
     }
     if (ctx.top_k == 10 && ctx.size_k == 2048) {
       if (ctx.size_n == 256) {
-        return set_params({64,256,32,4,64,64,32}, 1, false);
+        return set_params({64, 256, 32, 4, 64, 64, 32}, 1, false);
       }
     }
     if (ctx.top_k == 10 && ctx.size_k == 2048) {
       if (ctx.size_n == 1024) {
-        return set_params({64,256,32,4,64,64,32}, 1, false);
+        return set_params({64, 256, 32, 4, 64, 64, 32}, 1, false);
       }
     }
   }
@@ -1184,16 +1171,14 @@ inline bool sm70_marlin_moe_try_select_cyankiwi_qwen3_coder_next_awq_8bit_params
 }
 
 inline bool sm70_marlin_moe_try_select_nvidia_glm_4_7_nvfp4_params(
-    Sm70MarlinMoeAutoParamsContext const& ctx,
-    Sm70MarlinAutoParams& params) {
+    Sm70MarlinMoeAutoParamsContext const& ctx, Sm70MarlinAutoParams& params) {
   if (ctx.quant_format == nullptr ||
-      std::strcmp(ctx.quant_format, "nvfp4") != 0 ||
-      ctx.group_size != 16 || ctx.size_m <= 0) {
+      std::strcmp(ctx.quant_format, "nvfp4") != 0 || ctx.group_size != 16 ||
+      ctx.size_m <= 0) {
     return false;
   }
 
-  auto const set_params = [&](Sm70CtaGeometry geometry,
-                              int requested_split_k,
+  auto const set_params = [&](Sm70CtaGeometry geometry, int requested_split_k,
                               bool use_metadata_vector_words) {
     params = {geometry, requested_split_k, use_metadata_vector_words,
               ctx.packed_macro_n};
@@ -1205,63 +1190,63 @@ inline bool sm70_marlin_moe_try_select_nvidia_glm_4_7_nvfp4_params(
     // top_k=1
     if (ctx.top_k == 1 && ctx.size_n == 5120) {
       if (ctx.size_k == 192) {
-          if (ctx.size_m <= 8) {
-            return set_params({32,128,32,4,32,32,32}, 1, false);
-          }
-          if (ctx.size_m <= 256) {
-            return set_params({32,128,32,4,32,32,32}, 1, false);
-          }
-          return set_params({32,128,32,4,32,32,32}, 1, true);
+        if (ctx.size_m <= 8) {
+          return set_params({32, 128, 32, 4, 32, 32, 32}, 1, false);
+        }
+        if (ctx.size_m <= 256) {
+          return set_params({32, 128, 32, 4, 32, 32, 32}, 1, false);
+        }
+        return set_params({32, 128, 32, 4, 32, 32, 32}, 1, true);
       }
     }
     if (ctx.top_k == 1 && ctx.size_n == 5120) {
       if (ctx.size_k == 384) {
-          if (ctx.size_m <= 8) {
-            return set_params({32,256,32,4,32,64,32}, 1, true);
-          }
-          if (ctx.size_m <= 256) {
-            return set_params({32,128,32,4,32,32,32}, 1, true);
-          }
-          return set_params({32,128,32,4,32,32,32}, 1, true);
+        if (ctx.size_m <= 8) {
+          return set_params({32, 256, 32, 4, 32, 64, 32}, 1, true);
+        }
+        if (ctx.size_m <= 256) {
+          return set_params({32, 128, 32, 4, 32, 32, 32}, 1, true);
+        }
+        return set_params({32, 128, 32, 4, 32, 32, 32}, 1, true);
       }
     }
     if (ctx.top_k == 1 && ctx.size_n == 5120) {
       if (ctx.size_k == 1536) {
-          if (ctx.size_m <= 8) {
-            return set_params({32,128,32,4,32,32,32}, 1, true);
-          }
-          return set_params({32,128,32,4,32,32,32}, 1, false);
+        if (ctx.size_m <= 8) {
+          return set_params({32, 128, 32, 4, 32, 32, 32}, 1, true);
+        }
+        return set_params({32, 128, 32, 4, 32, 32, 32}, 1, false);
       }
     }
     // top_k=8
     if (ctx.top_k == 8 && ctx.size_k == 5120) {
       if (ctx.size_n == 384) {
-          if (ctx.size_m <= 1) {
-            return set_params({32,128,32,4,32,32,32}, 8, true);
-          }
-          if (ctx.size_m <= 32) {
-            return set_params({32,128,32,4,32,64,16}, 2, true);
-          }
-          return set_params({32,128,32,4,32,64,16}, 1, true);
+        if (ctx.size_m <= 1) {
+          return set_params({32, 128, 32, 4, 32, 32, 32}, 8, true);
+        }
+        if (ctx.size_m <= 32) {
+          return set_params({32, 128, 32, 4, 32, 64, 16}, 2, true);
+        }
+        return set_params({32, 128, 32, 4, 32, 64, 16}, 1, true);
       }
     }
     if (ctx.top_k == 8 && ctx.size_k == 5120) {
       if (ctx.size_n == 768) {
-          if (ctx.size_m <= 1) {
-            return set_params({32,128,32,4,32,64,16}, 4, true);
-          }
-          if (ctx.size_m <= 32) {
-            return set_params({32,128,32,4,32,64,16}, 1, true);
-          }
-          return set_params({32,128,32,4,32,32,32}, 4, true);
+        if (ctx.size_m <= 1) {
+          return set_params({32, 128, 32, 4, 32, 64, 16}, 4, true);
+        }
+        if (ctx.size_m <= 32) {
+          return set_params({32, 128, 32, 4, 32, 64, 16}, 1, true);
+        }
+        return set_params({32, 128, 32, 4, 32, 32, 32}, 4, true);
       }
     }
     if (ctx.top_k == 8 && ctx.size_k == 5120) {
       if (ctx.size_n == 3072) {
-          if (ctx.size_m <= 1) {
-            return set_params({32,128,32,4,32,32,32}, 8, true);
-          }
-          return set_params({32,128,32,4,32,32,32}, 2, true);
+        if (ctx.size_m <= 1) {
+          return set_params({32, 128, 32, 4, 32, 32, 32}, 8, true);
+        }
+        return set_params({32, 128, 32, 4, 32, 32, 32}, 2, true);
       }
     }
   }
@@ -1271,19 +1256,19 @@ inline bool sm70_marlin_moe_try_select_nvidia_glm_4_7_nvfp4_params(
     // top_k=1
     if (ctx.top_k == 1 && ctx.size_n == 5120) {
       if (ctx.size_k == 1536) {
-          if (ctx.size_m <= 256) {
-            return set_params({32,256,64,8,32,64,32}, 1, true);
-          }
-          return set_params({32,128,32,4,32,32,32}, 1, true);
+        if (ctx.size_m <= 256) {
+          return set_params({32, 256, 64, 8, 32, 64, 32}, 1, true);
+        }
+        return set_params({32, 128, 32, 4, 32, 32, 32}, 1, true);
       }
     }
     // top_k=8
     if (ctx.top_k == 8 && ctx.size_k == 5120) {
       if (ctx.size_n == 3072) {
-          if (ctx.size_m <= 32) {
-            return set_params({32,128,32,4,32,32,32}, 4, true);
-          }
-          return set_params({32,256,64,8,32,64,32}, 1, true);
+        if (ctx.size_m <= 32) {
+          return set_params({32, 128, 32, 4, 32, 32, 32}, 4, true);
+        }
+        return set_params({32, 256, 64, 8, 32, 64, 32}, 1, true);
       }
     }
   }
@@ -1293,13 +1278,13 @@ inline bool sm70_marlin_moe_try_select_nvidia_glm_4_7_nvfp4_params(
     // top_k=1
     if (ctx.top_k == 1 && ctx.size_n == 5120) {
       if (ctx.size_k == 1536) {
-        return set_params({32,256,64,8,32,64,32}, 1, true);
+        return set_params({32, 256, 64, 8, 32, 64, 32}, 1, true);
       }
     }
     // top_k=8
     if (ctx.top_k == 8 && ctx.size_k == 5120) {
       if (ctx.size_n == 3072) {
-        return set_params({32,256,64,8,32,64,32}, 1, true);
+        return set_params({32, 256, 64, 8, 32, 64, 32}, 1, true);
       }
     }
   }
@@ -1309,42 +1294,42 @@ inline bool sm70_marlin_moe_try_select_nvidia_glm_4_7_nvfp4_params(
     // top_k=1
     if (ctx.top_k == 1 && ctx.size_n == 5120) {
       if (ctx.size_k == 192) {
-          if (ctx.size_m <= 16384) {
-            return set_params({64,256,32,4,64,64,32}, 1, true);
-          }
-          return set_params({64,256,32,4,64,64,32}, 1, false);
+        if (ctx.size_m <= 16384) {
+          return set_params({64, 256, 32, 4, 64, 64, 32}, 1, true);
+        }
+        return set_params({64, 256, 32, 4, 64, 64, 32}, 1, false);
       }
     }
     if (ctx.top_k == 1 && ctx.size_n == 5120) {
       if (ctx.size_k == 384) {
-          if (ctx.size_m <= 16384) {
-            return set_params({64,256,32,4,64,64,32}, 1, false);
-          }
-          return set_params({64,256,32,4,64,64,32}, 1, true);
+        if (ctx.size_m <= 16384) {
+          return set_params({64, 256, 32, 4, 64, 64, 32}, 1, false);
+        }
+        return set_params({64, 256, 32, 4, 64, 64, 32}, 1, true);
       }
     }
     if (ctx.top_k == 1 && ctx.size_n == 5120) {
       if (ctx.size_k == 1536) {
-        return set_params({64,256,32,4,64,64,32}, 1, true);
+        return set_params({64, 256, 32, 4, 64, 64, 32}, 1, true);
       }
     }
     // top_k=8
     if (ctx.top_k == 8 && ctx.size_k == 5120) {
       if (ctx.size_n == 384) {
-          if (ctx.size_m <= 2048) {
-            return set_params({64,128,32,8,32,32,32}, 1, false);
-          }
-          return set_params({64,128,32,8,32,32,32}, 1, true);
+        if (ctx.size_m <= 2048) {
+          return set_params({64, 128, 32, 8, 32, 32, 32}, 1, false);
+        }
+        return set_params({64, 128, 32, 8, 32, 32, 32}, 1, true);
       }
     }
     if (ctx.top_k == 8 && ctx.size_k == 5120) {
       if (ctx.size_n == 768) {
-        return set_params({64,256,32,4,64,64,32}, 1, true);
+        return set_params({64, 256, 32, 4, 64, 64, 32}, 1, true);
       }
     }
     if (ctx.top_k == 8 && ctx.size_k == 5120) {
       if (ctx.size_n == 3072) {
-        return set_params({64,256,32,4,64,64,32}, 1, true);
+        return set_params({64, 256, 32, 4, 64, 64, 32}, 1, true);
       }
     }
   }
@@ -1353,16 +1338,14 @@ inline bool sm70_marlin_moe_try_select_nvidia_glm_4_7_nvfp4_params(
 }
 
 inline bool sm70_marlin_moe_try_select_nvidia_minimax_m2_7_nvfp4_params(
-    Sm70MarlinMoeAutoParamsContext const& ctx,
-    Sm70MarlinAutoParams& params) {
+    Sm70MarlinMoeAutoParamsContext const& ctx, Sm70MarlinAutoParams& params) {
   if (ctx.quant_format == nullptr ||
-      std::strcmp(ctx.quant_format, "nvfp4") != 0 ||
-      ctx.group_size != 16 || ctx.size_m <= 0) {
+      std::strcmp(ctx.quant_format, "nvfp4") != 0 || ctx.group_size != 16 ||
+      ctx.size_m <= 0) {
     return false;
   }
 
-  auto const set_params = [&](Sm70CtaGeometry geometry,
-                              int requested_split_k,
+  auto const set_params = [&](Sm70CtaGeometry geometry, int requested_split_k,
                               bool use_metadata_vector_words) {
     params = {geometry, requested_split_k, use_metadata_vector_words,
               ctx.packed_macro_n};
@@ -1374,63 +1357,63 @@ inline bool sm70_marlin_moe_try_select_nvidia_minimax_m2_7_nvfp4_params(
     // top_k=1
     if (ctx.top_k == 1 && ctx.size_n == 3072) {
       if (ctx.size_k == 192) {
-          if (ctx.size_m <= 8) {
-            return set_params({32,128,32,4,32,32,32}, 1, true);
-          }
-          if (ctx.size_m <= 256) {
-            return set_params({32,128,32,4,32,32,32}, 1, true);
-          }
-          return set_params({32,256,32,4,32,64,32}, 1, true);
+        if (ctx.size_m <= 8) {
+          return set_params({32, 128, 32, 4, 32, 32, 32}, 1, true);
+        }
+        if (ctx.size_m <= 256) {
+          return set_params({32, 128, 32, 4, 32, 32, 32}, 1, true);
+        }
+        return set_params({32, 256, 32, 4, 32, 64, 32}, 1, true);
       }
     }
     if (ctx.top_k == 1 && ctx.size_n == 3072) {
       if (ctx.size_k == 384) {
-          if (ctx.size_m <= 8) {
-            return set_params({32,256,32,4,32,64,32}, 1, true);
-          }
-          if (ctx.size_m <= 256) {
-            return set_params({32,256,32,4,32,64,32}, 1, false);
-          }
-          return set_params({32,256,32,4,32,64,32}, 1, true);
+        if (ctx.size_m <= 8) {
+          return set_params({32, 256, 32, 4, 32, 64, 32}, 1, true);
+        }
+        if (ctx.size_m <= 256) {
+          return set_params({32, 256, 32, 4, 32, 64, 32}, 1, false);
+        }
+        return set_params({32, 256, 32, 4, 32, 64, 32}, 1, true);
       }
     }
     if (ctx.top_k == 1 && ctx.size_n == 3072) {
       if (ctx.size_k == 1536) {
-          if (ctx.size_m <= 8) {
-            return set_params({32,128,32,4,32,64,16}, 1, true);
-          }
-          return set_params({32,128,32,4,32,32,32}, 1, true);
+        if (ctx.size_m <= 8) {
+          return set_params({32, 128, 32, 4, 32, 64, 16}, 1, true);
+        }
+        return set_params({32, 128, 32, 4, 32, 32, 32}, 1, true);
       }
     }
     // top_k=8
     if (ctx.top_k == 8 && ctx.size_k == 3072) {
       if (ctx.size_n == 384) {
-          if (ctx.size_m <= 1) {
-            return set_params({32,128,32,4,32,32,32}, 8, false);
-          }
-          if (ctx.size_m <= 32) {
-            return set_params({32,128,32,4,32,64,16}, 2, true);
-          }
-          return set_params({32,128,32,4,32,64,16}, 1, true);
+        if (ctx.size_m <= 1) {
+          return set_params({32, 128, 32, 4, 32, 32, 32}, 8, false);
+        }
+        if (ctx.size_m <= 32) {
+          return set_params({32, 128, 32, 4, 32, 64, 16}, 2, true);
+        }
+        return set_params({32, 128, 32, 4, 32, 64, 16}, 1, true);
       }
     }
     if (ctx.top_k == 8 && ctx.size_k == 3072) {
       if (ctx.size_n == 768) {
-          if (ctx.size_m <= 1) {
-            return set_params({32,128,32,4,32,32,32}, 4, true);
-          }
-          if (ctx.size_m <= 32) {
-            return set_params({32,128,32,4,32,64,16}, 1, true);
-          }
-          return set_params({32,128,32,4,32,64,16}, 1, true);
+        if (ctx.size_m <= 1) {
+          return set_params({32, 128, 32, 4, 32, 32, 32}, 4, true);
+        }
+        if (ctx.size_m <= 32) {
+          return set_params({32, 128, 32, 4, 32, 64, 16}, 1, true);
+        }
+        return set_params({32, 128, 32, 4, 32, 64, 16}, 1, true);
       }
     }
     if (ctx.top_k == 8 && ctx.size_k == 3072) {
       if (ctx.size_n == 3072) {
-          if (ctx.size_m <= 1) {
-            return set_params({32,128,32,4,32,32,32}, 4, true);
-          }
-          return set_params({32,256,64,8,32,64,32}, 1, true);
+        if (ctx.size_m <= 1) {
+          return set_params({32, 128, 32, 4, 32, 32, 32}, 4, true);
+        }
+        return set_params({32, 256, 64, 8, 32, 64, 32}, 1, true);
       }
     }
   }
@@ -1440,19 +1423,19 @@ inline bool sm70_marlin_moe_try_select_nvidia_minimax_m2_7_nvfp4_params(
     // top_k=1
     if (ctx.top_k == 1 && ctx.size_n == 3072) {
       if (ctx.size_k == 1536) {
-          if (ctx.size_m <= 256) {
-            return set_params({32,256,64,8,32,64,32}, 1, true);
-          }
-          return set_params({32,128,32,4,32,32,32}, 1, true);
+        if (ctx.size_m <= 256) {
+          return set_params({32, 256, 64, 8, 32, 64, 32}, 1, true);
+        }
+        return set_params({32, 128, 32, 4, 32, 32, 32}, 1, true);
       }
     }
     // top_k=8
     if (ctx.top_k == 8 && ctx.size_k == 3072) {
       if (ctx.size_n == 3072) {
-          if (ctx.size_m <= 32) {
-            return set_params({32,256,64,8,32,64,32}, 1, true);
-          }
-          return set_params({32,128,32,4,32,32,32}, 1, true);
+        if (ctx.size_m <= 32) {
+          return set_params({32, 256, 64, 8, 32, 64, 32}, 1, true);
+        }
+        return set_params({32, 128, 32, 4, 32, 32, 32}, 1, true);
       }
     }
   }
@@ -1462,13 +1445,13 @@ inline bool sm70_marlin_moe_try_select_nvidia_minimax_m2_7_nvfp4_params(
     // top_k=1
     if (ctx.top_k == 1 && ctx.size_n == 3072) {
       if (ctx.size_k == 1536) {
-        return set_params({32,256,64,8,32,64,32}, 1, true);
+        return set_params({32, 256, 64, 8, 32, 64, 32}, 1, true);
       }
     }
     // top_k=8
     if (ctx.top_k == 8 && ctx.size_k == 3072) {
       if (ctx.size_n == 3072) {
-        return set_params({32,256,64,8,32,64,32}, 1, false);
+        return set_params({32, 256, 64, 8, 32, 64, 32}, 1, false);
       }
     }
   }
@@ -1478,45 +1461,45 @@ inline bool sm70_marlin_moe_try_select_nvidia_minimax_m2_7_nvfp4_params(
     // top_k=1
     if (ctx.top_k == 1 && ctx.size_n == 3072) {
       if (ctx.size_k == 192) {
-          if (ctx.size_m <= 16384) {
-            return set_params({64,256,32,4,64,64,32}, 1, true);
-          }
-          return set_params({64,256,32,4,64,64,32}, 1, false);
+        if (ctx.size_m <= 16384) {
+          return set_params({64, 256, 32, 4, 64, 64, 32}, 1, true);
+        }
+        return set_params({64, 256, 32, 4, 64, 64, 32}, 1, false);
       }
     }
     if (ctx.top_k == 1 && ctx.size_n == 3072) {
       if (ctx.size_k == 384) {
-          if (ctx.size_m <= 16384) {
-            return set_params({64,256,32,4,64,64,32}, 1, false);
-          }
-          return set_params({64,256,32,4,64,64,32}, 1, true);
+        if (ctx.size_m <= 16384) {
+          return set_params({64, 256, 32, 4, 64, 64, 32}, 1, false);
+        }
+        return set_params({64, 256, 32, 4, 64, 64, 32}, 1, true);
       }
     }
     if (ctx.top_k == 1 && ctx.size_n == 3072) {
       if (ctx.size_k == 1536) {
-          if (ctx.size_m <= 16384) {
-            return set_params({64,256,32,4,64,64,32}, 1, true);
-          }
-          return set_params({64,256,32,4,64,64,32}, 1, false);
+        if (ctx.size_m <= 16384) {
+          return set_params({64, 256, 32, 4, 64, 64, 32}, 1, true);
+        }
+        return set_params({64, 256, 32, 4, 64, 64, 32}, 1, false);
       }
     }
     // top_k=8
     if (ctx.top_k == 8 && ctx.size_k == 3072) {
       if (ctx.size_n == 384) {
-          if (ctx.size_m <= 2048) {
-            return set_params({64,128,32,8,32,32,32}, 1, true);
-          }
-          return set_params({64,128,32,8,32,32,32}, 1, false);
+        if (ctx.size_m <= 2048) {
+          return set_params({64, 128, 32, 8, 32, 32, 32}, 1, true);
+        }
+        return set_params({64, 128, 32, 8, 32, 32, 32}, 1, false);
       }
     }
     if (ctx.top_k == 8 && ctx.size_k == 3072) {
       if (ctx.size_n == 768) {
-        return set_params({64,256,32,4,64,64,32}, 1, true);
+        return set_params({64, 256, 32, 4, 64, 64, 32}, 1, true);
       }
     }
     if (ctx.top_k == 8 && ctx.size_k == 3072) {
       if (ctx.size_n == 3072) {
-        return set_params({64,256,32,4,64,64,32}, 1, true);
+        return set_params({64, 256, 32, 4, 64, 64, 32}, 1, true);
       }
     }
   }
@@ -1525,16 +1508,14 @@ inline bool sm70_marlin_moe_try_select_nvidia_minimax_m2_7_nvfp4_params(
 }
 
 inline bool sm70_marlin_moe_try_select_nvidia_qwen3_6_35b_a3b_nvfp4_params(
-    Sm70MarlinMoeAutoParamsContext const& ctx,
-    Sm70MarlinAutoParams& params) {
+    Sm70MarlinMoeAutoParamsContext const& ctx, Sm70MarlinAutoParams& params) {
   if (ctx.quant_format == nullptr ||
-      std::strcmp(ctx.quant_format, "nvfp4") != 0 ||
-      ctx.group_size != 16 || ctx.size_m <= 0) {
+      std::strcmp(ctx.quant_format, "nvfp4") != 0 || ctx.group_size != 16 ||
+      ctx.size_m <= 0) {
     return false;
   }
 
-  auto const set_params = [&](Sm70CtaGeometry geometry,
-                              int requested_split_k,
+  auto const set_params = [&](Sm70CtaGeometry geometry, int requested_split_k,
                               bool use_metadata_vector_words) {
     params = {geometry, requested_split_k, use_metadata_vector_words,
               ctx.packed_macro_n};
@@ -1546,63 +1527,63 @@ inline bool sm70_marlin_moe_try_select_nvidia_qwen3_6_35b_a3b_nvfp4_params(
     // top_k=1
     if (ctx.top_k == 1 && ctx.size_n == 2048) {
       if (ctx.size_k == 64) {
-          if (ctx.size_m <= 8) {
-            return set_params({32,64,64,4,32,32,32}, 1, true);
-          }
-          if (ctx.size_m <= 256) {
-            return set_params({32,128,32,4,32,32,32}, 1, true);
-          }
-          return set_params({32,128,32,4,32,32,32}, 1, true);
+        if (ctx.size_m <= 8) {
+          return set_params({32, 64, 64, 4, 32, 32, 32}, 1, true);
+        }
+        if (ctx.size_m <= 256) {
+          return set_params({32, 128, 32, 4, 32, 32, 32}, 1, true);
+        }
+        return set_params({32, 128, 32, 4, 32, 32, 32}, 1, true);
       }
     }
     if (ctx.top_k == 1 && ctx.size_n == 2048) {
       if (ctx.size_k == 128) {
-          if (ctx.size_m <= 8) {
-            return set_params({32,64,64,4,32,32,32}, 1, true);
-          }
-          if (ctx.size_m <= 256) {
-            return set_params({32,128,32,4,32,32,32}, 1, true);
-          }
-          return set_params({32,128,32,4,32,32,32}, 1, true);
+        if (ctx.size_m <= 8) {
+          return set_params({32, 64, 64, 4, 32, 32, 32}, 1, true);
+        }
+        if (ctx.size_m <= 256) {
+          return set_params({32, 128, 32, 4, 32, 32, 32}, 1, true);
+        }
+        return set_params({32, 128, 32, 4, 32, 32, 32}, 1, true);
       }
     }
     if (ctx.top_k == 1 && ctx.size_n == 2048) {
       if (ctx.size_k == 512) {
-          if (ctx.size_m <= 8) {
-            return set_params({32,128,64,4,32,64,32}, 1, true);
-          }
-          return set_params({32,128,32,4,32,32,32}, 1, true);
+        if (ctx.size_m <= 8) {
+          return set_params({32, 128, 64, 4, 32, 64, 32}, 1, true);
+        }
+        return set_params({32, 128, 32, 4, 32, 32, 32}, 1, true);
       }
     }
     // top_k=8
     if (ctx.top_k == 8 && ctx.size_k == 2048) {
       if (ctx.size_n == 128) {
-          if (ctx.size_m <= 1) {
-            return set_params({32,64,32,4,32,32,16}, 8, true);
-          }
-          if (ctx.size_m <= 32) {
-            return set_params({32,128,64,8,32,32,32}, 4, true);
-          }
-          return set_params({32,128,128,8,32,64,32}, 1, true);
+        if (ctx.size_m <= 1) {
+          return set_params({32, 64, 32, 4, 32, 32, 16}, 8, true);
+        }
+        if (ctx.size_m <= 32) {
+          return set_params({32, 128, 64, 8, 32, 32, 32}, 4, true);
+        }
+        return set_params({32, 128, 128, 8, 32, 64, 32}, 1, true);
       }
     }
     if (ctx.top_k == 8 && ctx.size_k == 2048) {
       if (ctx.size_n == 256) {
-          if (ctx.size_m <= 1) {
-            return set_params({32,128,32,4,32,32,32}, 8, true);
-          }
-          if (ctx.size_m <= 32) {
-            return set_params({32,128,128,8,32,64,32}, 1, true);
-          }
-          return set_params({32,256,64,8,32,64,32}, 1, true);
+        if (ctx.size_m <= 1) {
+          return set_params({32, 128, 32, 4, 32, 32, 32}, 8, true);
+        }
+        if (ctx.size_m <= 32) {
+          return set_params({32, 128, 128, 8, 32, 64, 32}, 1, true);
+        }
+        return set_params({32, 256, 64, 8, 32, 64, 32}, 1, true);
       }
     }
     if (ctx.top_k == 8 && ctx.size_k == 2048) {
       if (ctx.size_n == 1024) {
-          if (ctx.size_m <= 1) {
-            return set_params({32,128,32,4,32,32,32}, 4, true);
-          }
-          return set_params({32,128,32,4,32,32,32}, 1, true);
+        if (ctx.size_m <= 1) {
+          return set_params({32, 128, 32, 4, 32, 32, 32}, 4, true);
+        }
+        return set_params({32, 128, 32, 4, 32, 32, 32}, 1, true);
       }
     }
   }
@@ -1612,16 +1593,16 @@ inline bool sm70_marlin_moe_try_select_nvidia_qwen3_6_35b_a3b_nvfp4_params(
     // top_k=1
     if (ctx.top_k == 1 && ctx.size_n == 2048) {
       if (ctx.size_k == 512) {
-        return set_params({32,128,32,4,32,32,32}, 1, true);
+        return set_params({32, 128, 32, 4, 32, 32, 32}, 1, true);
       }
     }
     // top_k=8
     if (ctx.top_k == 8 && ctx.size_k == 2048) {
       if (ctx.size_n == 1024) {
-          if (ctx.size_m <= 32) {
-            return set_params({32,256,64,8,32,64,32}, 1, true);
-          }
-          return set_params({32,128,32,4,32,32,32}, 1, true);
+        if (ctx.size_m <= 32) {
+          return set_params({32, 256, 64, 8, 32, 64, 32}, 1, true);
+        }
+        return set_params({32, 128, 32, 4, 32, 32, 32}, 1, true);
       }
     }
   }
@@ -1631,13 +1612,13 @@ inline bool sm70_marlin_moe_try_select_nvidia_qwen3_6_35b_a3b_nvfp4_params(
     // top_k=1
     if (ctx.top_k == 1 && ctx.size_n == 2048) {
       if (ctx.size_k == 512) {
-        return set_params({32,128,32,4,32,32,32}, 1, true);
+        return set_params({32, 128, 32, 4, 32, 32, 32}, 1, true);
       }
     }
     // top_k=8
     if (ctx.top_k == 8 && ctx.size_k == 2048) {
       if (ctx.size_n == 1024) {
-        return set_params({32,256,64,8,32,64,32}, 1, true);
+        return set_params({32, 256, 64, 8, 32, 64, 32}, 1, true);
       }
     }
   }
@@ -1647,48 +1628,48 @@ inline bool sm70_marlin_moe_try_select_nvidia_qwen3_6_35b_a3b_nvfp4_params(
     // top_k=1
     if (ctx.top_k == 1 && ctx.size_n == 2048) {
       if (ctx.size_k == 64) {
-          if (ctx.size_m <= 16384) {
-            return set_params({64,64,32,4,32,32,32}, 1, false);
-          }
-          return set_params({64,256,32,4,64,64,32}, 1, false);
+        if (ctx.size_m <= 16384) {
+          return set_params({64, 64, 32, 4, 32, 32, 32}, 1, false);
+        }
+        return set_params({64, 256, 32, 4, 64, 64, 32}, 1, false);
       }
     }
     if (ctx.top_k == 1 && ctx.size_n == 2048) {
       if (ctx.size_k == 128) {
-        return set_params({64,256,32,4,64,64,32}, 1, true);
+        return set_params({64, 256, 32, 4, 64, 64, 32}, 1, true);
       }
     }
     if (ctx.top_k == 1 && ctx.size_n == 2048) {
       if (ctx.size_k == 512) {
-          if (ctx.size_m <= 16384) {
-            return set_params({64,256,32,4,64,64,32}, 1, false);
-          }
-          return set_params({64,256,32,4,64,64,32}, 1, true);
+        if (ctx.size_m <= 16384) {
+          return set_params({64, 256, 32, 4, 64, 64, 32}, 1, false);
+        }
+        return set_params({64, 256, 32, 4, 64, 64, 32}, 1, true);
       }
     }
     // top_k=8
     if (ctx.top_k == 8 && ctx.size_k == 2048) {
       if (ctx.size_n == 128) {
-          if (ctx.size_m <= 2048) {
-            return set_params({32,128,32,4,32,32,32}, 1, true);
-          }
-          return set_params({64,128,32,8,32,32,32}, 1, true);
+        if (ctx.size_m <= 2048) {
+          return set_params({32, 128, 32, 4, 32, 32, 32}, 1, true);
+        }
+        return set_params({64, 128, 32, 8, 32, 32, 32}, 1, true);
       }
     }
     if (ctx.top_k == 8 && ctx.size_k == 2048) {
       if (ctx.size_n == 256) {
-          if (ctx.size_m <= 2048) {
-            return set_params({64,256,32,4,64,64,32}, 1, true);
-          }
-          return set_params({64,256,64,8,64,64,32}, 1, false);
+        if (ctx.size_m <= 2048) {
+          return set_params({64, 256, 32, 4, 64, 64, 32}, 1, true);
+        }
+        return set_params({64, 256, 64, 8, 64, 64, 32}, 1, false);
       }
     }
     if (ctx.top_k == 8 && ctx.size_k == 2048) {
       if (ctx.size_n == 1024) {
-          if (ctx.size_m <= 2048) {
-            return set_params({64,256,32,4,64,64,32}, 1, false);
-          }
-          return set_params({64,256,32,4,64,64,32}, 1, true);
+        if (ctx.size_m <= 2048) {
+          return set_params({64, 256, 32, 4, 64, 64, 32}, 1, false);
+        }
+        return set_params({64, 256, 32, 4, 64, 64, 32}, 1, true);
       }
     }
   }
@@ -1696,17 +1677,16 @@ inline bool sm70_marlin_moe_try_select_nvidia_qwen3_6_35b_a3b_nvfp4_params(
   return false;
 }
 
-inline bool sm70_marlin_moe_try_select_nvidia_qwen3_next_80b_a3b_thinking_nvfp4_params(
-    Sm70MarlinMoeAutoParamsContext const& ctx,
-    Sm70MarlinAutoParams& params) {
+inline bool
+sm70_marlin_moe_try_select_nvidia_qwen3_next_80b_a3b_thinking_nvfp4_params(
+    Sm70MarlinMoeAutoParamsContext const& ctx, Sm70MarlinAutoParams& params) {
   if (ctx.quant_format == nullptr ||
-      std::strcmp(ctx.quant_format, "nvfp4") != 0 ||
-      ctx.group_size != 16 || ctx.size_m <= 0) {
+      std::strcmp(ctx.quant_format, "nvfp4") != 0 || ctx.group_size != 16 ||
+      ctx.size_m <= 0) {
     return false;
   }
 
-  auto const set_params = [&](Sm70CtaGeometry geometry,
-                              int requested_split_k,
+  auto const set_params = [&](Sm70CtaGeometry geometry, int requested_split_k,
                               bool use_metadata_vector_words) {
     params = {geometry, requested_split_k, use_metadata_vector_words,
               ctx.packed_macro_n};
@@ -1718,69 +1698,69 @@ inline bool sm70_marlin_moe_try_select_nvidia_qwen3_next_80b_a3b_thinking_nvfp4_
     // top_k=1
     if (ctx.top_k == 1 && ctx.size_n == 2048) {
       if (ctx.size_k == 64) {
-          if (ctx.size_m <= 10) {
-            return set_params({32,128,32,4,32,32,32}, 1, false);
-          }
-          if (ctx.size_m <= 320) {
-            return set_params({32,128,32,4,32,32,32}, 1, true);
-          }
-          return set_params({32,256,32,4,32,64,32}, 1, true);
+        if (ctx.size_m <= 10) {
+          return set_params({32, 128, 32, 4, 32, 32, 32}, 1, false);
+        }
+        if (ctx.size_m <= 320) {
+          return set_params({32, 128, 32, 4, 32, 32, 32}, 1, true);
+        }
+        return set_params({32, 256, 32, 4, 32, 64, 32}, 1, true);
       }
     }
     if (ctx.top_k == 1 && ctx.size_n == 2048) {
       if (ctx.size_k == 128) {
-          if (ctx.size_m <= 10) {
-            return set_params({32,128,32,4,32,32,32}, 1, true);
-          }
-          if (ctx.size_m <= 320) {
-            return set_params({32,128,32,4,32,32,32}, 1, true);
-          }
-          return set_params({32,256,32,4,32,64,32}, 1, true);
+        if (ctx.size_m <= 10) {
+          return set_params({32, 128, 32, 4, 32, 32, 32}, 1, true);
+        }
+        if (ctx.size_m <= 320) {
+          return set_params({32, 128, 32, 4, 32, 32, 32}, 1, true);
+        }
+        return set_params({32, 256, 32, 4, 32, 64, 32}, 1, true);
       }
     }
     if (ctx.top_k == 1 && ctx.size_n == 2048) {
       if (ctx.size_k == 512) {
-          if (ctx.size_m <= 10) {
-            return set_params({32,256,64,8,32,64,32}, 1, true);
-          }
-          if (ctx.size_m <= 320) {
-            return set_params({32,128,32,4,32,32,32}, 1, true);
-          }
-          return set_params({32,128,32,4,32,32,32}, 1, false);
+        if (ctx.size_m <= 10) {
+          return set_params({32, 256, 64, 8, 32, 64, 32}, 1, true);
+        }
+        if (ctx.size_m <= 320) {
+          return set_params({32, 128, 32, 4, 32, 32, 32}, 1, true);
+        }
+        return set_params({32, 128, 32, 4, 32, 32, 32}, 1, false);
       }
     }
     // top_k=10
     if (ctx.top_k == 10 && ctx.size_k == 2048) {
       if (ctx.size_n == 128) {
-          if (ctx.size_m <= 1) {
-            return set_params({32,64,32,4,32,32,16}, 8, false);
-          }
-          if (ctx.size_m <= 32) {
-            return set_params({32,128,64,8,32,64,16}, 2, true);
-          }
-          return set_params({32,128,128,8,32,64,32}, 1, true);
+        if (ctx.size_m <= 1) {
+          return set_params({32, 64, 32, 4, 32, 32, 16}, 8, false);
+        }
+        if (ctx.size_m <= 32) {
+          return set_params({32, 128, 64, 8, 32, 64, 16}, 2, true);
+        }
+        return set_params({32, 128, 128, 8, 32, 64, 32}, 1, true);
       }
     }
     if (ctx.top_k == 10 && ctx.size_k == 2048) {
       if (ctx.size_n == 256) {
-          if (ctx.size_m <= 1) {
-            return set_params({32,128,32,4,32,32,32}, 8, true);
-          }
-          if (ctx.size_m <= 32) {
-            return set_params({32,128,128,8,32,64,32}, 1, true);
-          }
-          return set_params({32,256,64,8,32,64,32}, 1, true);
+        if (ctx.size_m <= 1) {
+          return set_params({32, 128, 32, 4, 32, 32, 32}, 8, true);
+        }
+        if (ctx.size_m <= 32) {
+          return set_params({32, 128, 128, 8, 32, 64, 32}, 1, true);
+        }
+        return set_params({32, 256, 64, 8, 32, 64, 32}, 1, true);
       }
     }
     if (ctx.top_k == 10 && ctx.size_k == 2048) {
       if (ctx.size_n == 1024) {
-          if (ctx.size_m <= 1) {
-            return set_params({32,128,128,8,32,64,32}, 1, true);
-          }
-          if (ctx.size_m <= 32) {
-            return set_params({32,256,32,4,32,64,32}, 1, false);
-          }
-          return set_params({32,128,32,4,32,32,32}, 1, true);
+        if (ctx.size_m <= 1) {
+          return set_params({32, 128, 128, 8, 32, 64, 32}, 1, true);
+        }
+        if (ctx.size_m <= 32) {
+          return set_params({32, 256, 32, 4, 32, 64, 32}, 1, false);
+        }
+        return set_params({32, 128, 32, 4, 32, 32, 32}, 1, true);
       }
     }
   }
@@ -1790,13 +1770,13 @@ inline bool sm70_marlin_moe_try_select_nvidia_qwen3_next_80b_a3b_thinking_nvfp4_
     // top_k=1
     if (ctx.top_k == 1 && ctx.size_n == 2048) {
       if (ctx.size_k == 512) {
-        return set_params({32,128,32,4,32,32,32}, 1, true);
+        return set_params({32, 128, 32, 4, 32, 32, 32}, 1, true);
       }
     }
     // top_k=10
     if (ctx.top_k == 10 && ctx.size_k == 2048) {
       if (ctx.size_n == 1024) {
-        return set_params({32,128,32,4,32,32,32}, 1, true);
+        return set_params({32, 128, 32, 4, 32, 32, 32}, 1, true);
       }
     }
   }
@@ -1806,23 +1786,23 @@ inline bool sm70_marlin_moe_try_select_nvidia_qwen3_next_80b_a3b_thinking_nvfp4_
     // top_k=1
     if (ctx.top_k == 1 && ctx.size_n == 2048) {
       if (ctx.size_k == 64) {
-        return set_params({64,256,32,4,64,64,32}, 1, true);
+        return set_params({64, 256, 32, 4, 64, 64, 32}, 1, true);
       }
     }
     if (ctx.top_k == 1 && ctx.size_n == 2048) {
       if (ctx.size_k == 128) {
-        return set_params({64,256,32,4,64,64,32}, 1, true);
+        return set_params({64, 256, 32, 4, 64, 64, 32}, 1, true);
       }
     }
     // top_k=10
     if (ctx.top_k == 10 && ctx.size_k == 2048) {
       if (ctx.size_n == 128) {
-        return set_params({64,128,32,8,32,32,32}, 1, false);
+        return set_params({64, 128, 32, 8, 32, 32, 32}, 1, false);
       }
     }
     if (ctx.top_k == 10 && ctx.size_k == 2048) {
       if (ctx.size_n == 256) {
-        return set_params({64,256,32,4,64,64,32}, 1, false);
+        return set_params({64, 256, 32, 4, 64, 64, 32}, 1, false);
       }
     }
   }
@@ -1832,36 +1812,36 @@ inline bool sm70_marlin_moe_try_select_nvidia_qwen3_next_80b_a3b_thinking_nvfp4_
     // top_k=1
     if (ctx.top_k == 1 && ctx.size_n == 2048) {
       if (ctx.size_k == 64) {
-        return set_params({64,256,32,4,64,64,32}, 1, true);
+        return set_params({64, 256, 32, 4, 64, 64, 32}, 1, true);
       }
     }
     if (ctx.top_k == 1 && ctx.size_n == 2048) {
       if (ctx.size_k == 128) {
-        return set_params({64,256,32,4,64,64,32}, 1, true);
+        return set_params({64, 256, 32, 4, 64, 64, 32}, 1, true);
       }
     }
     if (ctx.top_k == 1 && ctx.size_n == 2048) {
       if (ctx.size_k == 512) {
-          if (ctx.size_m <= 20480) {
-            return set_params({64,256,32,4,64,64,32}, 1, false);
-          }
-          return set_params({64,256,32,4,64,64,32}, 1, true);
+        if (ctx.size_m <= 20480) {
+          return set_params({64, 256, 32, 4, 64, 64, 32}, 1, false);
+        }
+        return set_params({64, 256, 32, 4, 64, 64, 32}, 1, true);
       }
     }
     // top_k=10
     if (ctx.top_k == 10 && ctx.size_k == 2048) {
       if (ctx.size_n == 128) {
-        return set_params({64,128,32,8,32,32,32}, 1, true);
+        return set_params({64, 128, 32, 8, 32, 32, 32}, 1, true);
       }
     }
     if (ctx.top_k == 10 && ctx.size_k == 2048) {
       if (ctx.size_n == 256) {
-        return set_params({64,256,32,4,64,64,32}, 1, true);
+        return set_params({64, 256, 32, 4, 64, 64, 32}, 1, true);
       }
     }
     if (ctx.top_k == 10 && ctx.size_k == 2048) {
       if (ctx.size_n == 1024) {
-        return set_params({64,256,32,4,64,64,32}, 1, true);
+        return set_params({64, 256, 32, 4, 64, 64, 32}, 1, true);
       }
     }
   }
@@ -1870,16 +1850,14 @@ inline bool sm70_marlin_moe_try_select_nvidia_qwen3_next_80b_a3b_thinking_nvfp4_
 }
 
 inline bool sm70_marlin_moe_try_select_cyankiwi_minimax_m2_7_awq_4bit_params(
-    Sm70MarlinMoeAutoParamsContext const& ctx,
-    Sm70MarlinAutoParams& params) {
+    Sm70MarlinMoeAutoParamsContext const& ctx, Sm70MarlinAutoParams& params) {
   if (ctx.quant_format == nullptr ||
-      std::strcmp(ctx.quant_format, "uint4b8") != 0 ||
-      ctx.group_size != 32 || ctx.size_m <= 0) {
+      std::strcmp(ctx.quant_format, "uint4b8") != 0 || ctx.group_size != 32 ||
+      ctx.size_m <= 0) {
     return false;
   }
 
-  auto const set_params = [&](Sm70CtaGeometry geometry,
-                              int requested_split_k,
+  auto const set_params = [&](Sm70CtaGeometry geometry, int requested_split_k,
                               bool use_metadata_vector_words) {
     params = {geometry, requested_split_k, use_metadata_vector_words,
               ctx.packed_macro_n};
@@ -1995,16 +1973,14 @@ inline bool sm70_marlin_moe_try_select_cyankiwi_minimax_m2_7_awq_4bit_params(
 }
 
 inline bool sm70_marlin_moe_try_select_cyankiwi_glm_4_7_awq_4bit_params(
-    Sm70MarlinMoeAutoParamsContext const& ctx,
-    Sm70MarlinAutoParams& params) {
+    Sm70MarlinMoeAutoParamsContext const& ctx, Sm70MarlinAutoParams& params) {
   if (ctx.quant_format == nullptr ||
-      std::strcmp(ctx.quant_format, "uint4b8") != 0 ||
-      ctx.group_size != 32 || ctx.size_m <= 0) {
+      std::strcmp(ctx.quant_format, "uint4b8") != 0 || ctx.group_size != 32 ||
+      ctx.size_m <= 0) {
     return false;
   }
 
-  auto const set_params = [&](Sm70CtaGeometry geometry,
-                              int requested_split_k,
+  auto const set_params = [&](Sm70CtaGeometry geometry, int requested_split_k,
                               bool use_metadata_vector_words) {
     params = {geometry, requested_split_k, use_metadata_vector_words,
               ctx.packed_macro_n};
@@ -2108,16 +2084,14 @@ inline bool sm70_marlin_moe_try_select_cyankiwi_glm_4_7_awq_4bit_params(
 }
 
 inline bool sm70_marlin_moe_try_select_quanttrio_glm_4_7_awq_params(
-    Sm70MarlinMoeAutoParamsContext const& ctx,
-    Sm70MarlinAutoParams& params) {
+    Sm70MarlinMoeAutoParamsContext const& ctx, Sm70MarlinAutoParams& params) {
   if (ctx.quant_format == nullptr ||
-      std::strcmp(ctx.quant_format, "uint4") != 0 ||
-      ctx.group_size != 128 || ctx.size_m <= 0) {
+      std::strcmp(ctx.quant_format, "uint4") != 0 || ctx.group_size != 128 ||
+      ctx.size_m <= 0) {
     return false;
   }
 
-  auto const set_params = [&](Sm70CtaGeometry geometry,
-                              int requested_split_k,
+  auto const set_params = [&](Sm70CtaGeometry geometry, int requested_split_k,
                               bool use_metadata_vector_words) {
     params = {geometry, requested_split_k, use_metadata_vector_words,
               ctx.packed_macro_n};
@@ -2206,20 +2180,21 @@ inline bool sm70_marlin_moe_try_select_quanttrio_glm_4_7_awq_params(
 }
 
 inline Sm70MarlinAutoParams sm70_marlin_moe_auto_stage_params(
-    char const* quant_format, int64_t group_size,
-    int64_t moe_block_size, int64_t top_k, int64_t size_m,
-    int64_t size_n, int64_t size_k) {
+    char const* quant_format, int64_t group_size, int64_t moe_block_size,
+    int64_t top_k, int64_t size_m, int64_t size_n, int64_t size_k) {
   Sm70MarlinMoeAutoParamsContext const ctx{
-      quant_format, group_size, moe_block_size, top_k, size_m, size_n, size_k,
-      sm70_marlin_auto_packed_macro_n(size_n)};
+      quant_format,   group_size,
+      moe_block_size, top_k,
+      size_m,         size_n,
+      size_k,         sm70_marlin_auto_packed_macro_n(size_n)};
 
   if (sm70_marlin_moe_auto_env_is_set()) {
     return sm70_marlin_moe_auto_params_from_env(ctx);
   }
 
   Sm70MarlinAutoParams params{};
-  if (sm70_marlin_moe_try_select_quanttrio_qwen3_6_35b_a3b_awq_params(
-          ctx, params)) {
+  if (sm70_marlin_moe_try_select_quanttrio_qwen3_6_35b_a3b_awq_params(ctx,
+                                                                      params)) {
     validate_sm70_marlin_auto_params("MoE", params);
     return params;
   }
@@ -2228,8 +2203,8 @@ inline Sm70MarlinAutoParams sm70_marlin_moe_auto_stage_params(
     validate_sm70_marlin_auto_params("MoE", params);
     return params;
   }
-  if (sm70_marlin_moe_try_select_quanttrio_minimax_m2_7_awq_params(
-          ctx, params)) {
+  if (sm70_marlin_moe_try_select_quanttrio_minimax_m2_7_awq_params(ctx,
+                                                                   params)) {
     validate_sm70_marlin_auto_params("MoE", params);
     return params;
   }
@@ -2258,18 +2233,17 @@ inline Sm70MarlinAutoParams sm70_marlin_moe_auto_stage_params(
     validate_sm70_marlin_auto_params("MoE", params);
     return params;
   }
-  if (sm70_marlin_moe_try_select_nvidia_glm_4_7_nvfp4_params(
-          ctx, params)) {
+  if (sm70_marlin_moe_try_select_nvidia_glm_4_7_nvfp4_params(ctx, params)) {
     validate_sm70_marlin_auto_params("MoE", params);
     return params;
   }
-  if (sm70_marlin_moe_try_select_nvidia_minimax_m2_7_nvfp4_params(
-          ctx, params)) {
+  if (sm70_marlin_moe_try_select_nvidia_minimax_m2_7_nvfp4_params(ctx,
+                                                                  params)) {
     validate_sm70_marlin_auto_params("MoE", params);
     return params;
   }
-  if (sm70_marlin_moe_try_select_nvidia_qwen3_6_35b_a3b_nvfp4_params(
-          ctx, params)) {
+  if (sm70_marlin_moe_try_select_nvidia_qwen3_6_35b_a3b_nvfp4_params(ctx,
+                                                                     params)) {
     validate_sm70_marlin_auto_params("MoE", params);
     return params;
   }
@@ -2283,13 +2257,12 @@ inline Sm70MarlinAutoParams sm70_marlin_moe_auto_stage_params(
     validate_sm70_marlin_auto_params("MoE", params);
     return params;
   }
-  if (sm70_marlin_moe_try_select_cyankiwi_glm_4_7_awq_4bit_params(
-          ctx, params)) {
+  if (sm70_marlin_moe_try_select_cyankiwi_glm_4_7_awq_4bit_params(ctx,
+                                                                  params)) {
     validate_sm70_marlin_auto_params("MoE", params);
     return params;
   }
-  if (sm70_marlin_moe_try_select_quanttrio_glm_4_7_awq_params(
-          ctx, params)) {
+  if (sm70_marlin_moe_try_select_quanttrio_glm_4_7_awq_params(ctx, params)) {
     validate_sm70_marlin_auto_params("MoE", params);
     return params;
   }
@@ -2303,46 +2276,44 @@ inline bool sm70_marlin_moe_cta_geometry_is_supported(
          sm70_marlin_cta_geometry_is_supported(geometry);
 }
 
-inline void validate_sm70_marlin_moe_stage_cta_geometry_supported(char const* op_name,
-                                                                  Sm70CtaGeometry geometry) {
+inline void validate_sm70_marlin_moe_stage_cta_geometry_supported(
+    char const* op_name, Sm70CtaGeometry geometry) {
   TORCH_CHECK(sm70_marlin_moe_cta_geometry_is_supported(geometry),
               "Unsupported SM70 Marlin MoE CTA geometry for ", op_name, ": ",
-              geometry.cta_m, "x", geometry.cta_n, "x", geometry.cta_k,
-              "x", geometry.warps, "x", geometry.warp_m, "x",
-              geometry.warp_n, "x", geometry.warp_k,
-              ". Supported geometries are ",
+              geometry.cta_m, "x", geometry.cta_n, "x", geometry.cta_k, "x",
+              geometry.warps, "x", geometry.warp_m, "x", geometry.warp_n, "x",
+              geometry.warp_k, ". Supported geometries are ",
               kSupportedSm70MarlinMoeCtaGeometries, ".");
 }
 
-inline void validate_sm70_marlin_moe_stage_cta_n_alignment(char const* op_name,
-                                                           Sm70CtaGeometry geometry,
-                                                           int64_t size_n) {
+inline void validate_sm70_marlin_moe_stage_cta_n_alignment(
+    char const* op_name, Sm70CtaGeometry geometry, int64_t size_n) {
   TORCH_CHECK(
       size_n % geometry.cta_n == 0 && size_n % kQuantTileN == 0,
       "SM70 Marlin MoE requires size_n divisible by both CTA_N and 64 for ",
-      op_name, " with CTA geometry ", geometry.cta_m, "x", geometry.cta_n,
-      "x", geometry.cta_k, "x", geometry.warps, "x", geometry.warp_m,
-      "x", geometry.warp_n, "x", geometry.warp_k, ". Got size_n = ",
-      size_n, ".");
+      op_name, " with CTA geometry ", geometry.cta_m, "x", geometry.cta_n, "x",
+      geometry.cta_k, "x", geometry.warps, "x", geometry.warp_m, "x",
+      geometry.warp_n, "x", geometry.warp_k, ". Got size_n = ", size_n, ".");
 }
 
 template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM, int WarpN,
           int WarpK, int PackedMacroN, typename Launcher>
-torch::Tensor dispatch_sm70_marlin_moe_group_size(
-    Launcher const& launcher, int64_t group_size, char const* quant_name) {
+torch::Tensor dispatch_sm70_marlin_moe_group_size(Launcher const& launcher,
+                                                  int64_t group_size,
+                                                  char const* quant_name) {
   switch (group_size) {
     case -1:
-      return launcher.template operator()<CtaM, CtaN, CtaK, Warps, WarpM,
-                                          WarpN, WarpK, -1, PackedMacroN>();
+      return launcher.template operator()<CtaM, CtaN, CtaK, Warps, WarpM, WarpN,
+                                          WarpK, -1, PackedMacroN>();
     case 32:
-      return launcher.template operator()<CtaM, CtaN, CtaK, Warps, WarpM,
-                                          WarpN, WarpK, 32, PackedMacroN>();
+      return launcher.template operator()<CtaM, CtaN, CtaK, Warps, WarpM, WarpN,
+                                          WarpK, 32, PackedMacroN>();
     case 64:
-      return launcher.template operator()<CtaM, CtaN, CtaK, Warps, WarpM,
-                                          WarpN, WarpK, 64, PackedMacroN>();
+      return launcher.template operator()<CtaM, CtaN, CtaK, Warps, WarpM, WarpN,
+                                          WarpK, 64, PackedMacroN>();
     case 128:
-      return launcher.template operator()<CtaM, CtaN, CtaK, Warps, WarpM,
-                                          WarpN, WarpK, 128, PackedMacroN>();
+      return launcher.template operator()<CtaM, CtaN, CtaK, Warps, WarpM, WarpN,
+                                          WarpK, 128, PackedMacroN>();
     default:
       TORCH_CHECK(false, "SM70 Marlin MoE ", quant_name,
                   " supports only group_size -1, 32, 64, or 128. Got ",
@@ -2357,17 +2328,17 @@ torch::Tensor dispatch_sm70_marlin_moe_group_size_with_group32(
     Launcher const& launcher, int64_t group_size, char const* quant_name) {
   switch (group_size) {
     case -1:
-      return launcher.template operator()<CtaM, CtaN, CtaK, Warps, WarpM,
-                                          WarpN, WarpK, -1, PackedMacroN>();
+      return launcher.template operator()<CtaM, CtaN, CtaK, Warps, WarpM, WarpN,
+                                          WarpK, -1, PackedMacroN>();
     case 32:
-      return launcher.template operator()<CtaM, CtaN, CtaK, Warps, WarpM,
-                                          WarpN, WarpK, 32, PackedMacroN>();
+      return launcher.template operator()<CtaM, CtaN, CtaK, Warps, WarpM, WarpN,
+                                          WarpK, 32, PackedMacroN>();
     case 64:
-      return launcher.template operator()<CtaM, CtaN, CtaK, Warps, WarpM,
-                                          WarpN, WarpK, 64, PackedMacroN>();
+      return launcher.template operator()<CtaM, CtaN, CtaK, Warps, WarpM, WarpN,
+                                          WarpK, 64, PackedMacroN>();
     case 128:
-      return launcher.template operator()<CtaM, CtaN, CtaK, Warps, WarpM,
-                                          WarpN, WarpK, 128, PackedMacroN>();
+      return launcher.template operator()<CtaM, CtaN, CtaK, Warps, WarpM, WarpN,
+                                          WarpK, 128, PackedMacroN>();
     default:
       TORCH_CHECK(false, "SM70 Marlin MoE ", quant_name,
                   " supports only group_size -1, 32, 64, or 128. Got ",
@@ -2378,15 +2349,15 @@ torch::Tensor dispatch_sm70_marlin_moe_group_size_with_group32(
 
 template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM, int WarpN,
           int WarpK, int PackedMacroN, typename Launcher>
-torch::Tensor dispatch_sm70_marlin_moe_fp8_group_size(
-    Launcher const& launcher, int64_t group_size) {
+torch::Tensor dispatch_sm70_marlin_moe_fp8_group_size(Launcher const& launcher,
+                                                      int64_t group_size) {
   switch (group_size) {
     case -1:
-      return launcher.template operator()<CtaM, CtaN, CtaK, Warps, WarpM,
-                                          WarpN, WarpK, -1, PackedMacroN>();
+      return launcher.template operator()<CtaM, CtaN, CtaK, Warps, WarpM, WarpN,
+                                          WarpK, -1, PackedMacroN>();
     case 128:
-      return launcher.template operator()<CtaM, CtaN, CtaK, Warps, WarpM,
-                                          WarpN, WarpK, 128, PackedMacroN>();
+      return launcher.template operator()<CtaM, CtaN, CtaK, Warps, WarpM, WarpN,
+                                          WarpK, 128, PackedMacroN>();
     default:
       TORCH_CHECK(false,
                   "SM70 Marlin MoE fp8_e4m3 supports only group_size -1 "
@@ -2448,10 +2419,9 @@ struct Sm70MarlinMoeFp8GroupSizeDispatchLauncher {
   template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM, int WarpN,
             int WarpK, int PackedMacroN>
   torch::Tensor operator()() const {
-    return dispatch_sm70_marlin_moe_fp8_group_size<CtaM, CtaN, CtaK, Warps,
-                                                   WarpM, WarpN, WarpK,
-                                                   PackedMacroN>(
-        inner, group_size);
+    return dispatch_sm70_marlin_moe_fp8_group_size<
+        CtaM, CtaN, CtaK, Warps, WarpM, WarpN, WarpK, PackedMacroN>(inner,
+                                                                    group_size);
   }
 };
 
@@ -2465,59 +2435,59 @@ struct Sm70MarlinMoeFixedGroupSizeDispatchLauncher {
             int WarpK, int PackedMacroN>
   torch::Tensor operator()() const {
     return dispatch_sm70_marlin_moe_fixed_group_size<
-        CtaM, CtaN, CtaK, Warps, WarpM, WarpN, WarpK, GroupSize,
-        PackedMacroN>(inner, group_size, quant_name);
+        CtaM, CtaN, CtaK, Warps, WarpM, WarpN, WarpK, GroupSize, PackedMacroN>(
+        inner, group_size, quant_name);
   }
 };
 
 template <typename Launcher>
-torch::Tensor dispatch_sm70_marlin_moe_cta_geometry(
-    Launcher const& launcher, Sm70CtaGeometry geometry, int packed_macro_n,
-    char const* quant_name) {
-#define DISPATCH_SM70_MOE_PACKED_MACRO_N(CM, CN, CK, W, WM, WN, WK, PMN)  \
+torch::Tensor dispatch_sm70_marlin_moe_cta_geometry(Launcher const& launcher,
+                                                    Sm70CtaGeometry geometry,
+                                                    int packed_macro_n,
+                                                    char const* quant_name) {
+#define DISPATCH_SM70_MOE_PACKED_MACRO_N(CM, CN, CK, W, WM, WN, WK, PMN)   \
   if (packed_macro_n == PMN) {                                             \
     return launcher.template operator()<CM, CN, CK, W, WM, WN, WK, PMN>(); \
   }
 
-#define DISPATCH_SM70_MOE_GEOMETRY(CM, CN, CK, W, WM, WN, WK, PMN)         \
-  if (geometry.cta_m == CM && geometry.cta_n == CN &&                      \
-      geometry.cta_k == CK && geometry.warps == W &&                       \
-      geometry.warp_m == WM && geometry.warp_n == WN &&                    \
-      geometry.warp_k == WK) {                                             \
-    DISPATCH_SM70_MOE_PACKED_MACRO_N(CM, CN, CK, W, WM, WN, WK, PMN)       \
+#define DISPATCH_SM70_MOE_GEOMETRY(CM, CN, CK, W, WM, WN, WK, PMN)             \
+  if (geometry.cta_m == CM && geometry.cta_n == CN && geometry.cta_k == CK &&  \
+      geometry.warps == W && geometry.warp_m == WM && geometry.warp_n == WN && \
+      geometry.warp_k == WK) {                                                 \
+    DISPATCH_SM70_MOE_PACKED_MACRO_N(CM, CN, CK, W, WM, WN, WK, PMN)           \
   }
 
-#define FOR_EACH_SM70_MOE_GEOMETRY(M)                                     \
-  M(32, 64, 32, 4, 32, 32, 16, 128)                                       \
-  M(32, 64, 32, 4, 32, 32, 16, 256)                                       \
-  M(32, 64, 64, 4, 32, 32, 32, 128)                                       \
-  M(32, 64, 64, 4, 32, 32, 32, 256)                                       \
-  M(32, 128, 32, 4, 32, 32, 32, 128)                                      \
-  M(32, 128, 32, 4, 32, 32, 32, 256)                                      \
-  M(32, 128, 32, 4, 32, 64, 16, 128)                                      \
-  M(32, 128, 32, 4, 32, 64, 16, 256)                                      \
-  M(32, 128, 64, 4, 32, 64, 32, 128)                                      \
-  M(32, 128, 64, 4, 32, 64, 32, 256)                                      \
-  M(32, 128, 64, 8, 32, 32, 32, 128)                                      \
-  M(32, 128, 64, 8, 32, 32, 32, 256)                                      \
-  M(32, 128, 64, 8, 32, 64, 16, 128)                                      \
-  M(32, 128, 64, 8, 32, 64, 16, 256)                                      \
-  M(32, 128, 128, 8, 32, 64, 32, 128)                                     \
-  M(32, 128, 128, 8, 32, 64, 32, 256)                                     \
-  M(32, 256, 32, 4, 32, 64, 32, 256)                                      \
-  M(32, 256, 64, 8, 32, 64, 32, 256)                                      \
-  M(64, 64, 32, 4, 32, 32, 32, 64)                                        \
-  M(64, 64, 32, 4, 32, 32, 32, 128)                                       \
-  M(64, 64, 32, 4, 32, 32, 32, 256)                                       \
-  M(64, 128, 32, 4, 32, 64, 32, 128)                                      \
-  M(64, 128, 32, 4, 32, 64, 32, 256)                                      \
-  M(64, 128, 32, 4, 64, 64, 16, 128)                                      \
-  M(64, 128, 32, 4, 64, 64, 16, 256)                                      \
-  M(64, 128, 32, 8, 32, 32, 32, 128)                                      \
-  M(64, 128, 32, 8, 32, 32, 32, 256)                                      \
-  M(64, 128, 64, 4, 64, 64, 32, 128)                                      \
-  M(64, 128, 64, 4, 64, 64, 32, 256)                                      \
-  M(64, 256, 32, 4, 64, 64, 32, 256)                                      \
+#define FOR_EACH_SM70_MOE_GEOMETRY(M) \
+  M(32, 64, 32, 4, 32, 32, 16, 128)   \
+  M(32, 64, 32, 4, 32, 32, 16, 256)   \
+  M(32, 64, 64, 4, 32, 32, 32, 128)   \
+  M(32, 64, 64, 4, 32, 32, 32, 256)   \
+  M(32, 128, 32, 4, 32, 32, 32, 128)  \
+  M(32, 128, 32, 4, 32, 32, 32, 256)  \
+  M(32, 128, 32, 4, 32, 64, 16, 128)  \
+  M(32, 128, 32, 4, 32, 64, 16, 256)  \
+  M(32, 128, 64, 4, 32, 64, 32, 128)  \
+  M(32, 128, 64, 4, 32, 64, 32, 256)  \
+  M(32, 128, 64, 8, 32, 32, 32, 128)  \
+  M(32, 128, 64, 8, 32, 32, 32, 256)  \
+  M(32, 128, 64, 8, 32, 64, 16, 128)  \
+  M(32, 128, 64, 8, 32, 64, 16, 256)  \
+  M(32, 128, 128, 8, 32, 64, 32, 128) \
+  M(32, 128, 128, 8, 32, 64, 32, 256) \
+  M(32, 256, 32, 4, 32, 64, 32, 256)  \
+  M(32, 256, 64, 8, 32, 64, 32, 256)  \
+  M(64, 64, 32, 4, 32, 32, 32, 64)    \
+  M(64, 64, 32, 4, 32, 32, 32, 128)   \
+  M(64, 64, 32, 4, 32, 32, 32, 256)   \
+  M(64, 128, 32, 4, 32, 64, 32, 128)  \
+  M(64, 128, 32, 4, 32, 64, 32, 256)  \
+  M(64, 128, 32, 4, 64, 64, 16, 128)  \
+  M(64, 128, 32, 4, 64, 64, 16, 256)  \
+  M(64, 128, 32, 8, 32, 32, 32, 128)  \
+  M(64, 128, 32, 8, 32, 32, 32, 256)  \
+  M(64, 128, 64, 4, 64, 64, 32, 128)  \
+  M(64, 128, 64, 4, 64, 64, 32, 256)  \
+  M(64, 256, 32, 4, 64, 64, 32, 256)  \
   M(64, 256, 64, 8, 64, 64, 32, 256)
 
   FOR_EACH_SM70_MOE_GEOMETRY(DISPATCH_SM70_MOE_GEOMETRY)
@@ -2537,8 +2507,8 @@ torch::Tensor dispatch_sm70_marlin_moe_geometry(Launcher const& launcher,
                                                 int64_t group_size,
                                                 char const* quant_name) {
   return dispatch_sm70_marlin_moe_cta_geometry(
-      Sm70MarlinMoeGroupSizeDispatchLauncher<Launcher>{
-          launcher, group_size, quant_name},
+      Sm70MarlinMoeGroupSizeDispatchLauncher<Launcher>{launcher, group_size,
+                                                       quant_name},
       geometry, packed_macro_n, quant_name);
 }
 
@@ -2547,18 +2517,18 @@ torch::Tensor dispatch_sm70_marlin_moe_geometry_with_group32(
     Launcher const& launcher, Sm70CtaGeometry geometry, int packed_macro_n,
     int64_t group_size, char const* quant_name) {
   return dispatch_sm70_marlin_moe_cta_geometry(
-      Sm70MarlinMoeGroupSize32DispatchLauncher<Launcher>{
-          launcher, group_size, quant_name},
+      Sm70MarlinMoeGroupSize32DispatchLauncher<Launcher>{launcher, group_size,
+                                                         quant_name},
       geometry, packed_macro_n, quant_name);
 }
 
 template <typename Launcher>
-torch::Tensor dispatch_sm70_marlin_moe_fp8_geometry(
-    Launcher const& launcher, Sm70CtaGeometry geometry, int packed_macro_n,
-    int64_t group_size) {
+torch::Tensor dispatch_sm70_marlin_moe_fp8_geometry(Launcher const& launcher,
+                                                    Sm70CtaGeometry geometry,
+                                                    int packed_macro_n,
+                                                    int64_t group_size) {
   return dispatch_sm70_marlin_moe_cta_geometry(
-      Sm70MarlinMoeFp8GroupSizeDispatchLauncher<Launcher>{launcher,
-                                                          group_size},
+      Sm70MarlinMoeFp8GroupSizeDispatchLauncher<Launcher>{launcher, group_size},
       geometry, packed_macro_n, "fp8_e4m3");
 }
 
@@ -2603,8 +2573,8 @@ class Sm70MoeGatherIteratorA {
   using Element = cutlass::half_t;
   using Layout = cutlass::layout::RowMajor;
   using TensorCoord = cutlass::MatrixCoord;
-  using Fragment = cutlass::Array<
-      Element, ThreadMap::Iterations::kCount * ThreadMap::kElementsPerAccess>;
+  using Fragment = cutlass::Array<Element, ThreadMap::Iterations::kCount *
+                                               ThreadMap::kElementsPerAccess>;
   struct Params {
     int lda;
     int moe_block_size;
@@ -2689,9 +2659,8 @@ class Sm70MoeGatherIteratorA {
 
     CUTLASS_PRAGMA_UNROLL
     for (int s = 0; s < ThreadMap::Iterations::kStrided; ++s) {
-      int const local_row =
-          local_m_offset_ + thread_offset_.strided() +
-          s * ThreadMap::Delta::kStrided;
+      int const local_row = local_m_offset_ + thread_offset_.strided() +
+                            s * ThreadMap::Delta::kStrided;
       int const route_row = moe_block_ * params_.moe_block_size + local_row;
 
       int sorted_id = -1;
@@ -2699,20 +2668,17 @@ class Sm70MoeGatherIteratorA {
                        route_row < params_.padded_tokens;
       if (valid_row) {
         sorted_id = sorted_token_ids_[route_row];
-        valid_row =
-            sorted_id >= 0 && sorted_id < params_.expanded_token_count;
+        valid_row = sorted_id >= 0 && sorted_id < params_.expanded_token_count;
       }
 
       int const token_row = valid_row ? (sorted_id / params_.top_k) : 0;
 
       CUTLASS_PRAGMA_UNROLL
       for (int c = 0; c < ThreadMap::Iterations::kContiguous; ++c) {
-        int const logical_k =
-            k_offset_ + thread_offset_.contiguous() +
-            c * ThreadMap::Delta::kContiguous;
-        int const frag_base =
-            (c + s * ThreadMap::Iterations::kContiguous) *
-            ThreadMap::kElementsPerAccess;
+        int const logical_k = k_offset_ + thread_offset_.contiguous() +
+                              c * ThreadMap::Delta::kContiguous;
+        int const frag_base = (c + s * ThreadMap::Iterations::kContiguous) *
+                              ThreadMap::kElementsPerAccess;
         bool const valid = valid_row && logical_k < params_.lda;
 
         CUTLASS_PRAGMA_UNROLL
@@ -2754,8 +2720,8 @@ struct Sm70MarlinMoeGemmTraits {
   using LayoutB = cutlass::layout::RowMajor;
   using LayoutC = cutlass::layout::RowMajor;
   using ThreadblockShape = cutlass::gemm::GemmShape<CtaM, CtaN, CtaK>;
-  using WarpShape =
-      typename Sm70WarpShape<CtaM, CtaN, CtaK, Warps, WarpM, WarpN, WarpK>::Type;
+  using WarpShape = typename Sm70WarpShape<CtaM, CtaN, CtaK, Warps, WarpM,
+                                           WarpN, WarpK>::Type;
   static_assert(WarpShape::kM <= 64 && WarpShape::kN <= 64,
                 "SM70 Marlin MoE keeps per-warp M/N no larger than 64.");
   using InstructionShape = cutlass::gemm::GemmShape<8, 8, 4>;
@@ -2763,13 +2729,16 @@ struct Sm70MarlinMoeGemmTraits {
       ThreadblockShape, WarpShape, InstructionShape, ElementA, LayoutA,
       ElementB, LayoutB, ElementAccumulator, LayoutC,
       cutlass::arch::OpClassTensorOp, 2, cutlass::arch::OpMultiplyAdd>;
-  static_assert(MmaCore::kThreads == Warps * 32,
-                "SM70 Marlin MoE launch threads must match CUTLASS warp count.");
-  using IteratorA = typename Spec::template IteratorA<
-      ThreadblockShape, typename MmaCore::IteratorThreadMapA>;
-  using IteratorB = typename Spec::template IteratorB<
-      ThreadblockShape, typename MmaCore::IteratorThreadMapB, GroupSize,
-      PackedMacroN>;
+  static_assert(
+      MmaCore::kThreads == Warps * 32,
+      "SM70 Marlin MoE launch threads must match CUTLASS warp count.");
+  using IteratorA =
+      typename Spec::template IteratorA<ThreadblockShape,
+                                        typename MmaCore::IteratorThreadMapA>;
+  using IteratorB =
+      typename Spec::template IteratorB<ThreadblockShape,
+                                        typename MmaCore::IteratorThreadMapB,
+                                        GroupSize, PackedMacroN>;
   using Mma = Sm70MarlinMmaPipelined<
       ThreadblockShape, IteratorA, typename MmaCore::SmemIteratorA, IteratorB,
       typename MmaCore::SmemIteratorB, ElementAccumulator, LayoutC,
@@ -2818,11 +2787,11 @@ class Sm70MoeScatterEpilogue {
                       typename SharedLoadIterator::Fragment const& frag,
                       int32_t const* __restrict__ sorted_token_ids,
                       float const* __restrict__ topk_weights,
-                      cutlass::half_t* __restrict__ c,
-                      int n, int moe_block, int local_m_offset,
-                      int moe_block_size, int expanded_token_count,
-                      int padded_tokens, bool mul_topk_weights,
-                      bool atomic_store, float output_scale) const {
+                      cutlass::half_t* __restrict__ c, int n, int moe_block,
+                      int local_m_offset, int moe_block_size,
+                      int expanded_token_count, int padded_tokens,
+                      bool mul_topk_weights, bool atomic_store,
+                      float output_scale) const {
     float const* frag_ptr = reinterpret_cast<float const*>(&frag);
     half* c_half = reinterpret_cast<half*>(c);
     int const thread_start_row = destination_iterator.thread_start_row();
@@ -2838,20 +2807,17 @@ class Sm70MoeScatterEpilogue {
           int const frag_row_idx =
               row + ThreadMap::Iterations::kRow *
                         (group + ThreadMap::Iterations::kGroup * cluster);
-          int const row_offset =
-              row * ThreadMap::Delta::kRow +
-              group * ThreadMap::Delta::kGroup +
-              cluster * ThreadMap::Delta::kCluster;
-          int const local_row =
-              local_m_offset + thread_start_row + row_offset;
+          int const row_offset = row * ThreadMap::Delta::kRow +
+                                 group * ThreadMap::Delta::kGroup +
+                                 cluster * ThreadMap::Delta::kCluster;
+          int const local_row = local_m_offset + thread_start_row + row_offset;
           int const route_row = moe_block * moe_block_size + local_row;
           bool valid_row =
               local_row < moe_block_size && route_row < padded_tokens;
           int sorted_id = -1;
           if (valid_row) {
             sorted_id = sorted_token_ids[route_row];
-            valid_row =
-                sorted_id >= 0 && sorted_id < expanded_token_count;
+            valid_row = sorted_id >= 0 && sorted_id < expanded_token_count;
           }
           float const route_scale =
               (valid_row && mul_topk_weights) ? topk_weights[sorted_id] : 1.0f;
@@ -2896,8 +2862,7 @@ class Sm70MoeScatterEpilogue {
     int const warp_mn = warp_idx % (WarpCount::kM * WarpCount::kN);
     int const warp_m = warp_mn % WarpCount::kM;
     int const warp_n = warp_mn / WarpCount::kM;
-    cutlass::MatrixCoord warp_offset{warp_k * WarpCount::kM + warp_m,
-                                     warp_n};
+    cutlass::MatrixCoord warp_offset{warp_k * WarpCount::kM + warp_m, warp_n};
     warp_tile_iterator_.add_tile_offset(warp_offset);
   }
 
@@ -2906,11 +2871,11 @@ class Sm70MoeScatterEpilogue {
                   AccumulatorTile const& accumulators,
                   int32_t const* __restrict__ sorted_token_ids,
                   float const* __restrict__ topk_weights,
-                  cutlass::half_t* __restrict__ c,
-                  int n, int moe_block, int local_m_offset,
-                  int moe_block_size, int expanded_token_count,
-                  int padded_tokens, bool mul_topk_weights,
-                  bool atomic_store, float output_scale = 1.0f) {
+                  cutlass::half_t* __restrict__ c, int n, int moe_block,
+                  int local_m_offset, int moe_block_size,
+                  int expanded_token_count, int padded_tokens,
+                  bool mul_topk_weights, bool atomic_store,
+                  float output_scale = 1.0f) {
     AccumulatorFragmentIterator accum_fragment_iterator(accumulators);
 
     CUTLASS_PRAGMA_UNROLL
@@ -2956,19 +2921,19 @@ class Sm70MoeScatterEpilogue {
 };
 
 template <typename Traits, bool SplitK>
-__global__ __launch_bounds__(Traits::MmaCore::kThreads, 1)
-void sm70_marlin_moe_gemm_kernel(
+__global__
+__launch_bounds__(Traits::MmaCore::kThreads, 1) void sm70_marlin_moe_gemm_kernel(
     cutlass::half_t const* __restrict__ a,
     uint32_t const* __restrict__ b_q_weight,
     typename Traits::GemmSpec::ScaleElement const* __restrict__ b_scales,
     typename Traits::GemmSpec::ZeroElement const* __restrict__ b_zeros,
-    float const* __restrict__ global_scale,
-    cutlass::half_t* __restrict__ c,
+    float const* __restrict__ global_scale, cutlass::half_t* __restrict__ c,
     int32_t const* __restrict__ sorted_token_ids,
     int32_t const* __restrict__ expert_ids,
     int32_t const* __restrict__ num_tokens_past_padded,
     float const* __restrict__ topk_weights, int moe_block_size, int top_k,
-    bool mul_topk_weights, int m, int n, int k, int lda, int requested_split_k) {
+    bool mul_topk_weights, int m, int n, int k, int lda,
+    int requested_split_k) {
   using Mma = typename Traits::Mma;
   using Epilogue = Sm70MoeScatterEpilogue<Traits>;
   constexpr int CtaM = Traits::ThreadblockShape::kM;
@@ -3002,8 +2967,8 @@ void sm70_marlin_moe_gemm_kernel(
   int partition_k = k;
   if constexpr (SplitK) {
     Sm70SplitKPartition const partition =
-        sm70_splitk_partition<Traits::kGroupSize, CtaK>(
-            k, requested_split_k, int(blockIdx.z));
+        sm70_splitk_partition<Traits::kGroupSize, CtaK>(k, requested_split_k,
+                                                        int(blockIdx.z));
     if (partition.partition_k == 0) {
       return;
     }
@@ -3014,8 +2979,8 @@ void sm70_marlin_moe_gemm_kernel(
   int const n_offset = int(blockIdx.y) * CtaN;
 
   typename Mma::IteratorA iterator_A(
-      typename Mma::IteratorA::Params(lda, moe_block_size, top_k, m,
-                                      m * top_k, padded_tokens),
+      typename Mma::IteratorA::Params(lda, moe_block_size, top_k, m, m * top_k,
+                                      padded_tokens),
       a, sorted_token_ids, thread_idx, moe_block, local_m_offset, k_begin);
   typename Mma::IteratorB iterator_B(
       typename Mma::IteratorB::Params(k, n),
@@ -3042,8 +3007,8 @@ void sm70_marlin_moe_gemm_kernel(
   }
   Epilogue epilogue(shared_storage.epilogue, thread_idx, warp_idx, lane_idx);
   epilogue(iterator_D, accumulators, sorted_token_ids, topk_weights, c, n,
-           moe_block, local_m_offset, moe_block_size, m * top_k,
-           padded_tokens, mul_topk_weights, SplitK, output_scale);
+           moe_block, local_m_offset, moe_block_size, m * top_k, padded_tokens,
+           mul_topk_weights, SplitK, output_scale);
 }
 
 template <typename Traits>
@@ -3103,9 +3068,9 @@ torch::Tensor launch_sm70_marlin_moe_gemm(
   smem_bytes = configure_sm70_dynamic_smem<SharedStorage>(split_kernel);
 
   int64_t const numel = size_m * top_k * size_n;
-  C10_CUDA_CHECK(cudaMemsetAsync(
-      c.data_ptr<at::Half>(), 0,
-      static_cast<size_t>(numel) * sizeof(at::Half), stream));
+  C10_CUDA_CHECK(cudaMemsetAsync(c.data_ptr<at::Half>(), 0,
+                                 static_cast<size_t>(numel) * sizeof(at::Half),
+                                 stream));
 
   int const active_split_k =
       sm70_active_split_k(static_cast<int>(size_k), requested_split_k, CtaK);
@@ -3115,11 +3080,11 @@ torch::Tensor launch_sm70_marlin_moe_gemm(
       reinterpret_cast<uint32_t const*>(b_q_weight.data_ptr<int32_t>()),
       b_scales_ptr, b_zeros_ptr, global_scale_ptr,
       reinterpret_cast<cutlass::half_t*>(c.data_ptr<at::Half>()),
-      sorted_token_ids.data_ptr<int32_t>(),
-      expert_ids.data_ptr<int32_t>(), num_tokens_past_padded.data_ptr<int32_t>(),
+      sorted_token_ids.data_ptr<int32_t>(), expert_ids.data_ptr<int32_t>(),
+      num_tokens_past_padded.data_ptr<int32_t>(),
       topk_weights.data_ptr<float>(), int(moe_block_size), int(top_k),
-      mul_topk_weights, int(size_m), int(size_n), int(size_k),
-      int(a.stride(0)), requested_split_k);
+      mul_topk_weights, int(size_m), int(size_n), int(size_k), int(a.stride(0)),
+      requested_split_k);
   C10_CUDA_KERNEL_LAUNCH_CHECK();
   return c;
 }

--- a/csrc/moe/marlin_moe_wna16/sm70_marlin_moe_dispatch.cu
+++ b/csrc/moe/marlin_moe_wna16/sm70_marlin_moe_dispatch.cu
@@ -43,15 +43,13 @@ __device__ __forceinline__ int sm70_inverse_zp_interleave(int idx,
   return inv[idx];
 }
 
-__device__ __forceinline__ int sm70_inverse_scale_perm(int idx,
-                                                       int perm_len) {
+__device__ __forceinline__ int sm70_inverse_scale_perm(int idx, int perm_len) {
   if (perm_len == 64) {
     return (idx % 8) * 8 + idx / 8;
   }
-  constexpr int inv[32] = {0,  1,  8,  9,  16, 17, 24, 25,
-                           2,  3,  10, 11, 18, 19, 26, 27,
-                           4,  5,  12, 13, 20, 21, 28, 29,
-                           6,  7,  14, 15, 22, 23, 30, 31};
+  constexpr int inv[32] = {0,  1,  8,  9,  16, 17, 24, 25, 2,  3,  10,
+                           11, 18, 19, 26, 27, 4,  5,  12, 13, 20, 21,
+                           28, 29, 6,  7,  14, 15, 22, 23, 30, 31};
   return inv[idx];
 }
 
@@ -66,10 +64,9 @@ __global__ void sm70_unpermute_half_metadata_kernel(
 }
 
 __global__ void sm70_unpack_moe_zp_to_half_kernel(
-    const int32_t* __restrict__ packed_zp,
-    const half* __restrict__ scales, half* __restrict__ out,
-    int64_t total, int64_t num_groups, int64_t size_n, int64_t packed_n,
-    int num_bits, bool is_a_8bit) {
+    const int32_t* __restrict__ packed_zp, const half* __restrict__ scales,
+    half* __restrict__ out, int64_t total, int64_t num_groups, int64_t size_n,
+    int64_t packed_n, int num_bits, bool is_a_8bit) {
   const int64_t idx = blockIdx.x * blockDim.x + threadIdx.x;
   if (idx >= total) return;
 
@@ -83,15 +80,14 @@ __global__ void sm70_unpack_moe_zp_to_half_kernel(
   if (!is_a_8bit) {
     packed_col_in_block =
         (packed_col_in_block / pack_factor) * pack_factor +
-        sm70_inverse_zp_interleave(packed_col_in_block % pack_factor,
-                                   num_bits);
+        sm70_inverse_zp_interleave(packed_col_in_block % pack_factor, num_bits);
   }
   const int64_t packed_col = block64 * 64 + packed_col_in_block;
-  const uint32_t word = reinterpret_cast<const uint32_t*>(packed_zp)
-      [(expert * num_groups + group) * packed_n + packed_col / pack_factor];
-  const uint32_t zp =
-      (word >> ((packed_col % pack_factor) * num_bits)) &
-      ((1u << num_bits) - 1u);
+  const uint32_t word = reinterpret_cast<const uint32_t*>(
+      packed_zp)[(expert * num_groups + group) * packed_n +
+                 packed_col / pack_factor];
+  const uint32_t zp = (word >> ((packed_col % pack_factor) * num_bits)) &
+                      ((1u << num_bits) - 1u);
   out[idx] = __float2half(static_cast<float>(zp) * __half2float(scales[idx]));
 }
 
@@ -111,8 +107,8 @@ torch::Tensor sm70_moe_scales_as_logical(torch::Tensor const& b_scales,
   const int64_t total = out.numel();
   constexpr int threads = 256;
   const int blocks = static_cast<int>((total + threads - 1) / threads);
-  sm70_unpermute_half_metadata_kernel<<<
-      blocks, threads, 0, at::cuda::getCurrentCUDAStream()>>>(
+  sm70_unpermute_half_metadata_kernel<<<blocks, threads, 0,
+                                        at::cuda::getCurrentCUDAStream()>>>(
       reinterpret_cast<const half*>(b_scales.data_ptr<at::Half>()),
       reinterpret_cast<half*>(out.data_ptr<at::Half>()), total, perm_len);
   C10_CUDA_KERNEL_LAUNCH_CHECK();
@@ -120,9 +116,8 @@ torch::Tensor sm70_moe_scales_as_logical(torch::Tensor const& b_scales,
 }
 
 torch::Tensor sm70_moe_zp_as_half(torch::Tensor const& b_zeros,
-                                  torch::Tensor const& b_scales,
-                                  int64_t size_n, int num_bits,
-                                  bool is_a_8bit) {
+                                  torch::Tensor const& b_scales, int64_t size_n,
+                                  int num_bits, bool is_a_8bit) {
   if (b_zeros.scalar_type() == at::ScalarType::Half) {
     return b_zeros;
   }
@@ -143,14 +138,13 @@ torch::Tensor sm70_moe_zp_as_half(torch::Tensor const& b_zeros,
   TORCH_CHECK(b_scales.scalar_type() == at::ScalarType::Half,
               "SM70 Marlin MoE packed zero-point adapter expects fp16 scales.");
 
-  auto out =
-      torch::empty({b_scales.size(0), b_scales.size(1), size_n},
-                   b_scales.options());
+  auto out = torch::empty({b_scales.size(0), b_scales.size(1), size_n},
+                          b_scales.options());
   const int64_t total = out.numel();
   constexpr int threads = 256;
   const int blocks = static_cast<int>((total + threads - 1) / threads);
-  sm70_unpack_moe_zp_to_half_kernel<<<
-      blocks, threads, 0, at::cuda::getCurrentCUDAStream()>>>(
+  sm70_unpack_moe_zp_to_half_kernel<<<blocks, threads, 0,
+                                      at::cuda::getCurrentCUDAStream()>>>(
       b_zeros.data_ptr<int32_t>(),
       reinterpret_cast<const half*>(b_scales.data_ptr<at::Half>()),
       reinterpret_cast<half*>(out.data_ptr<at::Half>()), total,
@@ -229,8 +223,7 @@ torch::Tensor moe_wna16_marlin_gemm(
     std::optional<torch::Tensor> const& global_scale_or_none,
     std::optional<torch::Tensor> const& b_zeros_or_none,
     std::optional<torch::Tensor> const& g_idx_or_none,
-    std::optional<torch::Tensor> const& perm_or_none,
-    torch::Tensor& workspace,
+    std::optional<torch::Tensor> const& perm_or_none, torch::Tensor& workspace,
     torch::Tensor& sorted_token_ids, torch::Tensor& expert_ids,
     torch::Tensor& num_tokens_past_padded, torch::Tensor& topk_weights,
     int64_t moe_block_size, int64_t top_k, bool mul_topk_weights,
@@ -308,8 +301,7 @@ torch::Tensor moe_wna16_marlin_gemm(
               "SM70 Marlin MoE supports only float16 outputs.");
   TORCH_CHECK(s_type == vllm::kFloat16 ||
                   (b_type == vllm::kFE2M1f &&
-                   (s_type == vllm::kFE4M3fn ||
-                    s_type == vllm::kFE8M0fnu)),
+                   (s_type == vllm::kFE4M3fn || s_type == vllm::kFE8M0fnu)),
               "SM70 Marlin MoE supports only float16 scales, "
               "except FP4 uses float8_e4m3fn scales for NVFP4 or "
               "float8_e8m0fnu scales for MXFP4.");
@@ -364,10 +356,8 @@ torch::Tensor moe_wna16_marlin_gemm(
   TORCH_CHECK(b_scales.is_contiguous(), "b_scales is not contiguous");
   TORCH_CHECK(b_scales.scalar_type() == at::ScalarType::Half ||
                   (b_type == vllm::kFE2M1f &&
-                   (b_scales.scalar_type() ==
-                        at::ScalarType::Float8_e4m3fn ||
-                    b_scales.scalar_type() ==
-                        at::ScalarType::Float8_e8m0fnu)),
+                   (b_scales.scalar_type() == at::ScalarType::Float8_e4m3fn ||
+                    b_scales.scalar_type() == at::ScalarType::Float8_e8m0fnu)),
               "SM70 Marlin MoE supports float16 scales, except FP4 uses "
               "float8_e4m3fn scales for NVFP4 or float8_e8m0fnu scales for "
               "MXFP4.");
@@ -457,17 +447,15 @@ torch::Tensor moe_wna16_marlin_gemm(
 
   torch::Tensor b_scales_kernel = b_scales;
   if (b_scales.scalar_type() == at::ScalarType::Half) {
-    b_scales_kernel =
-        sm70_moe_scales_as_logical(b_scales, size_k, group_size,
-                                   a_type.size_bits() == 8);
+    b_scales_kernel = sm70_moe_scales_as_logical(b_scales, size_k, group_size,
+                                                 a_type.size_bits() == 8);
   }
 
   torch::Tensor global_scale;
   if (global_scale_or_none.has_value()) {
     global_scale = global_scale_or_none.value();
-    TORCH_CHECK(
-        b_type == vllm::kFE2M1f && s_type == vllm::kFE4M3fn,
-        "SM70 Marlin MoE supports global_scale only for nvfp4 format.");
+    TORCH_CHECK(b_type == vllm::kFE2M1f && s_type == vllm::kFE4M3fn,
+                "SM70 Marlin MoE supports global_scale only for nvfp4 format.");
     TORCH_CHECK(global_scale.device().is_cuda(), "global_scale is not on GPU");
     TORCH_CHECK(global_scale.is_contiguous(), "global_scale is not contiguous");
     TORCH_CHECK(global_scale.scalar_type() == at::ScalarType::Float,
@@ -510,9 +498,9 @@ torch::Tensor moe_wna16_marlin_gemm(
                 "weights when zero-points are enabled. Got = ",
                 b_type.str());
     if (!is_zp_float && b_zeros.scalar_type() == at::ScalarType::Int) {
-      b_zeros = sm70_moe_zp_as_half(
-          b_zeros, b_scales_kernel, size_n, b_type == vllm::kU4 ? 4 : 8,
-          a_type.size_bits() == 8);
+      b_zeros = sm70_moe_zp_as_half(b_zeros, b_scales_kernel, size_n,
+                                    b_type == vllm::kU4 ? 4 : 8,
+                                    a_type.size_bits() == 8);
       zp_is_float = true;
     }
   } else {
@@ -535,8 +523,7 @@ torch::Tensor moe_wna16_marlin_gemm(
     TORCH_CHECK(num_groups == b_zeros.size(1),
                 "b_zeros dim 1 = ", b_zeros.size(1),
                 " is not num_groups = ", num_groups);
-    TORCH_CHECK(b_zeros.size(2) == size_n,
-                "b_zeros dim 2 = ", b_zeros.size(2),
+    TORCH_CHECK(b_zeros.size(2) == size_n, "b_zeros dim 2 = ", b_zeros.size(2),
                 " is not size_n = ", size_n);
   } else {
     TORCH_CHECK(!zp_is_float,
@@ -559,20 +546,18 @@ torch::Tensor moe_wna16_marlin_gemm(
 
   TORCH_CHECK(!has_act_order,
               "act_order is not supported for the SM70 Marlin MoE path.");
-  TORCH_CHECK(!has_bias,
-              "SM70 Marlin MoE does not support bias.");
+  TORCH_CHECK(!has_bias, "SM70 Marlin MoE does not support bias.");
   TORCH_CHECK(!use_atomic_add,
               "SM70 Marlin MoE does not support atomic-add "
               "output.");
-  TORCH_CHECK(is_k_full,
-              "SM70 Marlin MoE requires full-K inputs.");
+  TORCH_CHECK(is_k_full, "SM70 Marlin MoE requires full-K inputs.");
 
   if (b_type == vllm::kU4) {
     TORCH_CHECK(has_zp && zp_is_float,
                 "SM70 Marlin MoE uint4 path requires fp16 zero points.");
     return MARLIN_NAMESPACE_NAME::sm70_marlin_u4_gemm(
-        a, c, b_q_weight, b_scales_kernel, b_zeros, sorted_token_ids, expert_ids,
-        num_tokens_past_padded, topk_weights, moe_block_size, top_k,
+        a, c, b_q_weight, b_scales_kernel, b_zeros, sorted_token_ids,
+        expert_ids, num_tokens_past_padded, topk_weights, moe_block_size, top_k,
         mul_topk_weights, size_m, size_n, size_k, group_size);
   }
 
@@ -580,8 +565,8 @@ torch::Tensor moe_wna16_marlin_gemm(
     TORCH_CHECK(has_zp && zp_is_float,
                 "SM70 Marlin MoE uint8 path requires fp16 zero points.");
     return MARLIN_NAMESPACE_NAME::sm70_marlin_u8_gemm(
-        a, c, b_q_weight, b_scales_kernel, b_zeros, sorted_token_ids, expert_ids,
-        num_tokens_past_padded, topk_weights, moe_block_size, top_k,
+        a, c, b_q_weight, b_scales_kernel, b_zeros, sorted_token_ids,
+        expert_ids, num_tokens_past_padded, topk_weights, moe_block_size, top_k,
         mul_topk_weights, size_m, size_n, size_k, group_size);
   }
 
@@ -622,8 +607,9 @@ torch::Tensor moe_wna16_marlin_gemm(
     TORCH_CHECK(!has_zp && !is_zp_float,
                 "SM70 Marlin MoE fp4 does not support zero-point metadata.");
     if (s_type == vllm::kFE4M3fn) {
-      TORCH_CHECK(global_scale.numel() == num_experts,
-                  "the global_scale parameter must be passed for nvfp4 format.");
+      TORCH_CHECK(
+          global_scale.numel() == num_experts,
+          "the global_scale parameter must be passed for nvfp4 format.");
       TORCH_CHECK(group_size == 16,
                   "SM70 Marlin MoE NVFP4 supports only group_size 16. "
                   "Got ",

--- a/csrc/moe/marlin_moe_wna16/sm70_marlin_mxfp4_gemm.cu
+++ b/csrc/moe/marlin_moe_wna16/sm70_marlin_mxfp4_gemm.cu
@@ -51,7 +51,8 @@ void dequant_e8m0_scales_to_half2(int q, half2* scale_cache) {
   *reinterpret_cast<uint2*>(scale_cache) = vec_res;
 }
 
-template <typename Shape_, typename ThreadMap_, int GroupSize_, int PackedMacroN_>
+template <typename Shape_, typename ThreadMap_, int GroupSize_,
+          int PackedMacroN_>
 class Sm70MoeMxfp4IteratorB {
  public:
   using Shape = Shape_;
@@ -59,22 +60,25 @@ class Sm70MoeMxfp4IteratorB {
   static int const kGroupSize = GroupSize_;
   static int const kPackedMacroN = PackedMacroN_;
   using Element = cutlass::half_t;
-  using Fragment = cutlass::Array<
-      Element, ThreadMap::Iterations::kCount * ThreadMap::kElementsPerAccess>;
-    static_assert(Shape::kN == 64 || Shape::kN == 128 || Shape::kN == 256,
-                "SM70 Marlin MoE MXFP4 IteratorB expects CTA_N in {64, 128, 256}.");
-  static_assert(ThreadMap::Iterations::kContiguous ==
-                    Shape::kN / kQuantTileN,
-                "SM70 Marlin MoE MXFP4 IteratorB expects one contiguous iteration "
-                "per 64-column quant tile.");
+  using Fragment = cutlass::Array<Element, ThreadMap::Iterations::kCount *
+                                               ThreadMap::kElementsPerAccess>;
+  static_assert(
+      Shape::kN == 64 || Shape::kN == 128 || Shape::kN == 256,
+      "SM70 Marlin MoE MXFP4 IteratorB expects CTA_N in {64, 128, 256}.");
+  static_assert(
+      ThreadMap::Iterations::kContiguous == Shape::kN / kQuantTileN,
+      "SM70 Marlin MoE MXFP4 IteratorB expects one contiguous iteration "
+      "per 64-column quant tile.");
   static_assert(ThreadMap::Delta::kContiguous == kQuantTileN,
                 "SM70 Marlin MoE MXFP4 IteratorB expects 64-column deltas.");
-  static_assert(ThreadMap::kElementsPerAccess == kMxfp4ValuesPerWord,
-                "SM70 Marlin MoE MXFP4 IteratorB expects one packed FP4 word per "
-                "access.");
-  static_assert(ThreadMap::Iterations::kStrided >= 1,
-                "SM70 Marlin MoE U4-family IteratorB expects one or more strided "
-                "iterations.");
+  static_assert(
+      ThreadMap::kElementsPerAccess == kMxfp4ValuesPerWord,
+      "SM70 Marlin MoE MXFP4 IteratorB expects one packed FP4 word per "
+      "access.");
+  static_assert(
+      ThreadMap::Iterations::kStrided >= 1,
+      "SM70 Marlin MoE U4-family IteratorB expects one or more strided "
+      "iterations.");
   struct Params {
     int size_k;
     int size_n;
@@ -85,9 +89,7 @@ class Sm70MoeMxfp4IteratorB {
 
     CUTLASS_HOST_DEVICE
     Params(int size_k_, int size_n_)
-        : size_k(size_k_),
-          size_n(size_n_),
-          num_groups(size_k_ / GroupSize_) {}
+        : size_k(size_k_), size_n(size_n_), num_groups(size_k_ / GroupSize_) {}
   };
 
  private:
@@ -108,9 +110,8 @@ class Sm70MoeMxfp4IteratorB {
                         uint8_t const* scales, half const*, int thread_id,
                         int expert, int k_offset, int n_offset)
       : qweight_(qweight),
-        scales_expert_base_(scales +
-                            (expert >= 0 ? expert : 0) *
-                                params.num_groups * params.size_n),
+        scales_expert_base_(scales + (expert >= 0 ? expert : 0) *
+                                         params.num_groups * params.size_n),
         params_(params),
         thread_offset_(ThreadMap::initial_offset(thread_id)),
         expert_(expert),
@@ -149,9 +150,7 @@ class Sm70MoeMxfp4IteratorB {
   }
 
   CUTLASS_DEVICE
-  int metadata_group_offset(int group) const {
-    return group * params_.size_n;
-  }
+  int metadata_group_offset(int group) const { return group * params_.size_n; }
 
   CUTLASS_DEVICE
   int scale_group(int logical_k) const {
@@ -184,14 +183,12 @@ class Sm70MoeMxfp4IteratorB {
     CUTLASS_PRAGMA_UNROLL
     for (int s = 0; s < ThreadMap::Iterations::kStrided; ++s) {
       int const logical_k =
-          k_offset_ + thread_offset_.strided() +
-          s * ThreadMap::Delta::kStrided;
+          k_offset_ + thread_offset_.strided() + s * ThreadMap::Delta::kStrided;
       int const group = scale_group(logical_k);
       CUTLASS_PRAGMA_UNROLL
       for (int c = 0; c < ThreadMap::Iterations::kContiguous; ++c) {
-        int const cache_n =
-            n_offset_ + thread_offset_.contiguous() +
-            c * ThreadMap::Delta::kContiguous;
+        int const cache_n = n_offset_ + thread_offset_.contiguous() +
+                            c * ThreadMap::Delta::kContiguous;
         int const cache_index = c + s * ThreadMap::Iterations::kContiguous;
         cache_metadata_e8m0_scales(cache_index, group, cache_n);
       }
@@ -244,8 +241,9 @@ class Sm70MoeMxfp4IteratorB {
           frag_vec[3] = __hmul2(deq[1], scale_vec[3]);
         }
       } else {
-        static_assert(ThreadMap::Iterations::kContiguous == 1,
-                      "Unsupported SM70 Marlin MoE MXFP4 contiguous iteration count.");
+        static_assert(
+            ThreadMap::Iterations::kContiguous == 1,
+            "Unsupported SM70 Marlin MoE MXFP4 contiguous iteration count.");
         uint32_t const qword =
             load_qword_vector<1>(qweight_ + qweight_base_offset_);
         half2 const* scale_vec = cached_scales_;
@@ -265,15 +263,13 @@ class Sm70MoeMxfp4IteratorB {
       int const logical_n_base = n_offset_ + thread_offset_.contiguous();
       CUTLASS_PRAGMA_UNROLL
       for (int s = 0; s < ThreadMap::Iterations::kStrided; ++s) {
-        int const logical_k_s =
-            k_offset_ + thread_offset_.strided() +
-            s * ThreadMap::Delta::kStrided;
+        int const logical_k_s = k_offset_ + thread_offset_.strided() +
+                                s * ThreadMap::Delta::kStrided;
         int const qweight_base_s =
             expert_qweight_base_offset() +
             qweight_offset_from_logical(params_, logical_k_s, logical_n_base);
         if constexpr (ThreadMap::Iterations::kContiguous == 4) {
-          auto const qwords =
-              load_qword_vector<4>(qweight_ + qweight_base_s);
+          auto const qwords = load_qword_vector<4>(qweight_ + qweight_base_s);
           CUTLASS_PRAGMA_UNROLL
           for (int c = 0; c < ThreadMap::Iterations::kContiguous; ++c) {
             constexpr int kAccess = ThreadMap::kElementsPerAccess;
@@ -296,8 +292,7 @@ class Sm70MoeMxfp4IteratorB {
             frag_vec[3] = __hmul2(deq[1], scale_vec[3]);
           }
         } else if constexpr (ThreadMap::Iterations::kContiguous == 2) {
-          auto const qwords =
-              load_qword_vector<2>(qweight_ + qweight_base_s);
+          auto const qwords = load_qword_vector<2>(qweight_ + qweight_base_s);
           CUTLASS_PRAGMA_UNROLL
           for (int c = 0; c < ThreadMap::Iterations::kContiguous; ++c) {
             constexpr int kAccess = ThreadMap::kElementsPerAccess;
@@ -320,8 +315,9 @@ class Sm70MoeMxfp4IteratorB {
             frag_vec[3] = __hmul2(deq[1], scale_vec[3]);
           }
         } else {
-          static_assert(ThreadMap::Iterations::kContiguous == 1,
-                        "Unsupported SM70 Marlin MoE MXFP4 contiguous iteration count.");
+          static_assert(
+              ThreadMap::Iterations::kContiguous == 1,
+              "Unsupported SM70 Marlin MoE MXFP4 contiguous iteration count.");
           uint32_t const qword =
               load_qword_vector<1>(qweight_ + qweight_base_s);
           constexpr int kAccess = ThreadMap::kElementsPerAccess;
@@ -364,15 +360,15 @@ struct Sm70MoeMxfp4GemmSpec {
   using IteratorA = Sm70MoeGatherIteratorA<Shape, ThreadMap>;
 
   template <typename Shape, typename ThreadMap, int GroupSize, int PackedMacroN>
-  using IteratorB = Sm70MoeMxfp4IteratorB<Shape, ThreadMap, GroupSize, PackedMacroN>;
+  using IteratorB =
+      Sm70MoeMxfp4IteratorB<Shape, ThreadMap, GroupSize, PackedMacroN>;
 };
 
-template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM,
-          int WarpN, int WarpK, int GroupSize, int PackedMacroN>
+template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM, int WarpN,
+          int WarpK, int GroupSize, int PackedMacroN>
 using Sm70MoeMxfp4GemmTraits =
-    Sm70MarlinMoeGemmTraits<Sm70MoeMxfp4GemmSpec, CtaM, CtaN, CtaK,
-                            Warps, WarpM, WarpN, WarpK, GroupSize,
-                            PackedMacroN>;
+    Sm70MarlinMoeGemmTraits<Sm70MoeMxfp4GemmSpec, CtaM, CtaN, CtaK, Warps,
+                            WarpM, WarpN, WarpK, GroupSize, PackedMacroN>;
 
 struct Sm70MoeMxfp4Launcher {
   torch::Tensor& a;
@@ -393,15 +389,15 @@ struct Sm70MoeMxfp4Launcher {
   int64_t size_k;
   int requested_split_k;
 
-  template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM,
-          int WarpN, int WarpK, int GroupSize, int PackedMacroN>
+  template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM, int WarpN,
+            int WarpK, int GroupSize, int PackedMacroN>
   torch::Tensor operator()() const {
-    using Traits = Sm70MoeMxfp4GemmTraits<CtaM, CtaN, CtaK, Warps, WarpM,
-                                    WarpN, WarpK, GroupSize, PackedMacroN>;
+    using Traits = Sm70MoeMxfp4GemmTraits<CtaM, CtaN, CtaK, Warps, WarpM, WarpN,
+                                          WarpK, GroupSize, PackedMacroN>;
     return launch_sm70_marlin_moe_gemm<Traits>(
         a, c, b_q_weight, b_scales, b_zeros, global_scale, sorted_token_ids,
-        expert_ids, num_tokens_past_padded, topk_weights, moe_block_size,
-        top_k, mul_topk_weights, size_m, size_n, size_k, requested_split_k);
+        expert_ids, num_tokens_past_padded, topk_weights, moe_block_size, top_k,
+        mul_topk_weights, size_m, size_n, size_k, requested_split_k);
   }
 };
 
@@ -419,9 +415,10 @@ torch::Tensor sm70_marlin_mxfp4_gemm(
   auto const params = sm70_marlin_moe_auto_stage_params(
       "mxfp4", group_size, moe_block_size, top_k, size_m, size_n, size_k);
   Sm70CtaGeometry const geometry = params.geometry;
-  validate_sm70_marlin_moe_stage_cta_geometry_supported("SM70 Marlin MoE mxfp4", geometry);
-  validate_sm70_marlin_moe_stage_cta_n_alignment("SM70 Marlin MoE mxfp4", geometry,
-                                        size_n);
+  validate_sm70_marlin_moe_stage_cta_geometry_supported("SM70 Marlin MoE mxfp4",
+                                                        geometry);
+  validate_sm70_marlin_moe_stage_cta_n_alignment("SM70 Marlin MoE mxfp4",
+                                                 geometry, size_n);
   TORCH_CHECK(size_k % geometry.cta_k == 0,
               "SM70 Marlin MoE mxfp4 requires K divisible by CTA_K=",
               geometry.cta_k, ". Got K=", size_k, ".");
@@ -429,10 +426,23 @@ torch::Tensor sm70_marlin_mxfp4_gemm(
   auto empty_half = torch::empty({0}, b_scales.options().dtype(at::kHalf));
   auto empty_float = torch::empty(
       {0}, torch::TensorOptions().dtype(at::kFloat).device(a.device()));
-  Sm70MoeMxfp4Launcher const launcher{
-      a, c, b_q_weight, b_scales, empty_half, empty_float, sorted_token_ids,
-      expert_ids, num_tokens_past_padded, topk_weights, moe_block_size, top_k,
-      mul_topk_weights, size_m, size_n, size_k, params.requested_split_k};
+  Sm70MoeMxfp4Launcher const launcher{a,
+                                      c,
+                                      b_q_weight,
+                                      b_scales,
+                                      empty_half,
+                                      empty_float,
+                                      sorted_token_ids,
+                                      expert_ids,
+                                      num_tokens_past_padded,
+                                      topk_weights,
+                                      moe_block_size,
+                                      top_k,
+                                      mul_topk_weights,
+                                      size_m,
+                                      size_n,
+                                      size_k,
+                                      params.requested_split_k};
   return dispatch_sm70_marlin_moe_fixed_group_geometry<32>(
       launcher, geometry, params.packed_macro_n, group_size, "mxfp4");
 }

--- a/csrc/moe/marlin_moe_wna16/sm70_marlin_nvfp4_gemm.cu
+++ b/csrc/moe/marlin_moe_wna16/sm70_marlin_nvfp4_gemm.cu
@@ -26,7 +26,8 @@ namespace {
 
 constexpr int kNvfp4ValuesPerWord = 8;
 
-template <typename Shape_, typename ThreadMap_, int GroupSize_, int PackedMacroN_>
+template <typename Shape_, typename ThreadMap_, int GroupSize_,
+          int PackedMacroN_>
 class Sm70MoeNvfp4IteratorB {
  public:
   using Shape = Shape_;
@@ -34,22 +35,25 @@ class Sm70MoeNvfp4IteratorB {
   static int const kGroupSize = GroupSize_;
   static int const kPackedMacroN = PackedMacroN_;
   using Element = cutlass::half_t;
-  using Fragment = cutlass::Array<
-      Element, ThreadMap::Iterations::kCount * ThreadMap::kElementsPerAccess>;
-    static_assert(Shape::kN == 64 || Shape::kN == 128 || Shape::kN == 256,
-                "SM70 Marlin MoE NVFP4 IteratorB expects CTA_N in {64, 128, 256}.");
-  static_assert(ThreadMap::Iterations::kContiguous ==
-                    Shape::kN / kQuantTileN,
-                "SM70 Marlin MoE NVFP4 IteratorB expects one contiguous iteration "
-                "per 64-column quant tile.");
+  using Fragment = cutlass::Array<Element, ThreadMap::Iterations::kCount *
+                                               ThreadMap::kElementsPerAccess>;
+  static_assert(
+      Shape::kN == 64 || Shape::kN == 128 || Shape::kN == 256,
+      "SM70 Marlin MoE NVFP4 IteratorB expects CTA_N in {64, 128, 256}.");
+  static_assert(
+      ThreadMap::Iterations::kContiguous == Shape::kN / kQuantTileN,
+      "SM70 Marlin MoE NVFP4 IteratorB expects one contiguous iteration "
+      "per 64-column quant tile.");
   static_assert(ThreadMap::Delta::kContiguous == kQuantTileN,
                 "SM70 Marlin MoE NVFP4 IteratorB expects 64-column deltas.");
-  static_assert(ThreadMap::kElementsPerAccess == kNvfp4ValuesPerWord,
-                "SM70 Marlin MoE NVFP4 IteratorB expects one packed FP4 word per "
-                "access.");
-  static_assert(ThreadMap::Iterations::kStrided >= 1,
-                "SM70 Marlin MoE U4-family IteratorB expects one or more strided "
-                "iterations.");
+  static_assert(
+      ThreadMap::kElementsPerAccess == kNvfp4ValuesPerWord,
+      "SM70 Marlin MoE NVFP4 IteratorB expects one packed FP4 word per "
+      "access.");
+  static_assert(
+      ThreadMap::Iterations::kStrided >= 1,
+      "SM70 Marlin MoE U4-family IteratorB expects one or more strided "
+      "iterations.");
   struct Params {
     int size_k;
     int size_n;
@@ -60,9 +64,7 @@ class Sm70MoeNvfp4IteratorB {
 
     CUTLASS_HOST_DEVICE
     Params(int size_k_, int size_n_)
-        : size_k(size_k_),
-          size_n(size_n_),
-          num_groups(size_k_ / GroupSize_) {}
+        : size_k(size_k_), size_n(size_n_), num_groups(size_k_ / GroupSize_) {}
   };
 
  private:
@@ -83,9 +85,8 @@ class Sm70MoeNvfp4IteratorB {
                         uint8_t const* scales, half const*, int thread_id,
                         int expert, int k_offset, int n_offset)
       : qweight_(qweight),
-        scales_expert_base_(scales +
-                            (expert >= 0 ? expert : 0) *
-                                params.num_groups * params.size_n),
+        scales_expert_base_(scales + (expert >= 0 ? expert : 0) *
+                                         params.num_groups * params.size_n),
         params_(params),
         thread_offset_(ThreadMap::initial_offset(thread_id)),
         expert_(expert),
@@ -124,9 +125,7 @@ class Sm70MoeNvfp4IteratorB {
   }
 
   CUTLASS_DEVICE
-  int metadata_group_offset(int group) const {
-    return group * params_.size_n;
-  }
+  int metadata_group_offset(int group) const { return group * params_.size_n; }
 
   CUTLASS_DEVICE
   int scale_group(int logical_k) const {
@@ -159,14 +158,12 @@ class Sm70MoeNvfp4IteratorB {
     CUTLASS_PRAGMA_UNROLL
     for (int s = 0; s < ThreadMap::Iterations::kStrided; ++s) {
       int const logical_k =
-          k_offset_ + thread_offset_.strided() +
-          s * ThreadMap::Delta::kStrided;
+          k_offset_ + thread_offset_.strided() + s * ThreadMap::Delta::kStrided;
       int const group = scale_group(logical_k);
       CUTLASS_PRAGMA_UNROLL
       for (int c = 0; c < ThreadMap::Iterations::kContiguous; ++c) {
-        int const cache_n =
-            n_offset_ + thread_offset_.contiguous() +
-            c * ThreadMap::Delta::kContiguous;
+        int const cache_n = n_offset_ + thread_offset_.contiguous() +
+                            c * ThreadMap::Delta::kContiguous;
         int const cache_index = c + s * ThreadMap::Iterations::kContiguous;
         cache_metadata_fp8_scales(cache_index, group, cache_n);
       }
@@ -219,8 +216,9 @@ class Sm70MoeNvfp4IteratorB {
           frag_vec[3] = __hmul2(deq[1], scale_vec[3]);
         }
       } else {
-        static_assert(ThreadMap::Iterations::kContiguous == 1,
-                      "Unsupported SM70 Marlin MoE NVFP4 contiguous iteration count.");
+        static_assert(
+            ThreadMap::Iterations::kContiguous == 1,
+            "Unsupported SM70 Marlin MoE NVFP4 contiguous iteration count.");
         uint32_t const qword =
             load_qword_vector<1>(qweight_ + qweight_base_offset_);
         half2 const* scale_vec = cached_scales_;
@@ -240,15 +238,13 @@ class Sm70MoeNvfp4IteratorB {
       int const logical_n_base = n_offset_ + thread_offset_.contiguous();
       CUTLASS_PRAGMA_UNROLL
       for (int s = 0; s < ThreadMap::Iterations::kStrided; ++s) {
-        int const logical_k_s =
-            k_offset_ + thread_offset_.strided() +
-            s * ThreadMap::Delta::kStrided;
+        int const logical_k_s = k_offset_ + thread_offset_.strided() +
+                                s * ThreadMap::Delta::kStrided;
         int const qweight_base_s =
             expert_qweight_base_offset() +
             qweight_offset_from_logical(params_, logical_k_s, logical_n_base);
         if constexpr (ThreadMap::Iterations::kContiguous == 4) {
-          auto const qwords =
-              load_qword_vector<4>(qweight_ + qweight_base_s);
+          auto const qwords = load_qword_vector<4>(qweight_ + qweight_base_s);
           CUTLASS_PRAGMA_UNROLL
           for (int c = 0; c < ThreadMap::Iterations::kContiguous; ++c) {
             constexpr int kAccess = ThreadMap::kElementsPerAccess;
@@ -271,8 +267,7 @@ class Sm70MoeNvfp4IteratorB {
             frag_vec[3] = __hmul2(deq[1], scale_vec[3]);
           }
         } else if constexpr (ThreadMap::Iterations::kContiguous == 2) {
-          auto const qwords =
-              load_qword_vector<2>(qweight_ + qweight_base_s);
+          auto const qwords = load_qword_vector<2>(qweight_ + qweight_base_s);
           CUTLASS_PRAGMA_UNROLL
           for (int c = 0; c < ThreadMap::Iterations::kContiguous; ++c) {
             constexpr int kAccess = ThreadMap::kElementsPerAccess;
@@ -295,8 +290,9 @@ class Sm70MoeNvfp4IteratorB {
             frag_vec[3] = __hmul2(deq[1], scale_vec[3]);
           }
         } else {
-          static_assert(ThreadMap::Iterations::kContiguous == 1,
-                        "Unsupported SM70 Marlin MoE NVFP4 contiguous iteration count.");
+          static_assert(
+              ThreadMap::Iterations::kContiguous == 1,
+              "Unsupported SM70 Marlin MoE NVFP4 contiguous iteration count.");
           uint32_t const qword =
               load_qword_vector<1>(qweight_ + qweight_base_s);
           constexpr int kAccess = ThreadMap::kElementsPerAccess;
@@ -339,15 +335,15 @@ struct Sm70MoeNvfp4GemmSpec {
   using IteratorA = Sm70MoeGatherIteratorA<Shape, ThreadMap>;
 
   template <typename Shape, typename ThreadMap, int GroupSize, int PackedMacroN>
-  using IteratorB = Sm70MoeNvfp4IteratorB<Shape, ThreadMap, GroupSize, PackedMacroN>;
+  using IteratorB =
+      Sm70MoeNvfp4IteratorB<Shape, ThreadMap, GroupSize, PackedMacroN>;
 };
 
-template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM,
-          int WarpN, int WarpK, int GroupSize, int PackedMacroN>
+template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM, int WarpN,
+          int WarpK, int GroupSize, int PackedMacroN>
 using Sm70MoeNvfp4GemmTraits =
-    Sm70MarlinMoeGemmTraits<Sm70MoeNvfp4GemmSpec, CtaM, CtaN, CtaK,
-                            Warps, WarpM, WarpN, WarpK, GroupSize,
-                            PackedMacroN>;
+    Sm70MarlinMoeGemmTraits<Sm70MoeNvfp4GemmSpec, CtaM, CtaN, CtaK, Warps,
+                            WarpM, WarpN, WarpK, GroupSize, PackedMacroN>;
 
 struct Sm70MoeNvfp4Launcher {
   torch::Tensor& a;
@@ -368,15 +364,15 @@ struct Sm70MoeNvfp4Launcher {
   int64_t size_k;
   int requested_split_k;
 
-  template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM,
-          int WarpN, int WarpK, int GroupSize, int PackedMacroN>
+  template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM, int WarpN,
+            int WarpK, int GroupSize, int PackedMacroN>
   torch::Tensor operator()() const {
-    using Traits = Sm70MoeNvfp4GemmTraits<CtaM, CtaN, CtaK, Warps, WarpM,
-                                    WarpN, WarpK, GroupSize, PackedMacroN>;
+    using Traits = Sm70MoeNvfp4GemmTraits<CtaM, CtaN, CtaK, Warps, WarpM, WarpN,
+                                          WarpK, GroupSize, PackedMacroN>;
     return launch_sm70_marlin_moe_gemm<Traits>(
         a, c, b_q_weight, b_scales, b_zeros, global_scale, sorted_token_ids,
-        expert_ids, num_tokens_past_padded, topk_weights, moe_block_size,
-        top_k, mul_topk_weights, size_m, size_n, size_k, requested_split_k);
+        expert_ids, num_tokens_past_padded, topk_weights, moe_block_size, top_k,
+        mul_topk_weights, size_m, size_n, size_k, requested_split_k);
   }
 };
 
@@ -394,18 +390,32 @@ torch::Tensor sm70_marlin_nvfp4_gemm(
   auto const params = sm70_marlin_moe_auto_stage_params(
       "nvfp4", group_size, moe_block_size, top_k, size_m, size_n, size_k);
   Sm70CtaGeometry const geometry = params.geometry;
-  validate_sm70_marlin_moe_stage_cta_geometry_supported("SM70 Marlin MoE nvfp4", geometry);
-  validate_sm70_marlin_moe_stage_cta_n_alignment("SM70 Marlin MoE nvfp4", geometry,
-                                        size_n);
+  validate_sm70_marlin_moe_stage_cta_geometry_supported("SM70 Marlin MoE nvfp4",
+                                                        geometry);
+  validate_sm70_marlin_moe_stage_cta_n_alignment("SM70 Marlin MoE nvfp4",
+                                                 geometry, size_n);
   TORCH_CHECK(size_k % geometry.cta_k == 0,
               "SM70 Marlin MoE nvfp4 requires K divisible by CTA_K=",
               geometry.cta_k, ". Got K=", size_k, ".");
 
   auto empty_half = torch::empty({0}, b_scales.options().dtype(at::kHalf));
-  Sm70MoeNvfp4Launcher const launcher{
-      a, c, b_q_weight, b_scales, empty_half, global_scale, sorted_token_ids,
-      expert_ids, num_tokens_past_padded, topk_weights, moe_block_size, top_k,
-      mul_topk_weights, size_m, size_n, size_k, params.requested_split_k};
+  Sm70MoeNvfp4Launcher const launcher{a,
+                                      c,
+                                      b_q_weight,
+                                      b_scales,
+                                      empty_half,
+                                      global_scale,
+                                      sorted_token_ids,
+                                      expert_ids,
+                                      num_tokens_past_padded,
+                                      topk_weights,
+                                      moe_block_size,
+                                      top_k,
+                                      mul_topk_weights,
+                                      size_m,
+                                      size_n,
+                                      size_k,
+                                      params.requested_split_k};
   return dispatch_sm70_marlin_moe_fixed_group_geometry<16>(
       launcher, geometry, params.packed_macro_n, group_size, "nvfp4");
 }

--- a/csrc/moe/marlin_moe_wna16/sm70_marlin_u4_gemm.cu
+++ b/csrc/moe/marlin_moe_wna16/sm70_marlin_u4_gemm.cu
@@ -35,21 +35,23 @@ class Sm70MoeU4ZpIteratorB {
   static int const kPackedMacroN = PackedMacroN_;
   static constexpr bool kUseMetadataVectorWords = UseMetadataVectorWords_;
   using Element = cutlass::half_t;
-  using Fragment = cutlass::Array<
-      Element, ThreadMap::Iterations::kCount * ThreadMap::kElementsPerAccess>;
-  static_assert(Shape::kN == 64 || Shape::kN == 128 || Shape::kN == 256,
-                "SM70 Marlin MoE U4 IteratorB expects CTA_N in {64, 128, 256}.");
-  static_assert(ThreadMap::Iterations::kContiguous ==
-                    Shape::kN / kQuantTileN,
-                "SM70 Marlin MoE U4 IteratorB expects one contiguous iteration per "
-                "64-column quant tile.");
+  using Fragment = cutlass::Array<Element, ThreadMap::Iterations::kCount *
+                                               ThreadMap::kElementsPerAccess>;
+  static_assert(
+      Shape::kN == 64 || Shape::kN == 128 || Shape::kN == 256,
+      "SM70 Marlin MoE U4 IteratorB expects CTA_N in {64, 128, 256}.");
+  static_assert(
+      ThreadMap::Iterations::kContiguous == Shape::kN / kQuantTileN,
+      "SM70 Marlin MoE U4 IteratorB expects one contiguous iteration per "
+      "64-column quant tile.");
   static_assert(ThreadMap::Delta::kContiguous == kQuantTileN,
                 "SM70 Marlin MoE U4 IteratorB expects 64-column deltas.");
   static_assert(ThreadMap::kElementsPerAccess == kU4ValuesPerWord,
                 "SM70 Marlin MoE U4 IteratorB expects one packed int4 word per "
                 "access.");
   static_assert(ThreadMap::Iterations::kStrided >= 1,
-                "SM70 Marlin MoE U4-family IteratorB expects one or more strided iterations.");
+                "SM70 Marlin MoE U4-family IteratorB expects one or more "
+                "strided iterations.");
   struct Params {
     int size_k;
     int size_n;
@@ -85,11 +87,10 @@ class Sm70MoeU4ZpIteratorB {
                        half const* scales, half const* zp, int thread_id,
                        int expert, int k_offset, int n_offset)
       : qweight_(qweight),
-        scales_expert_base_(scales +
-                            (expert >= 0 ? expert : 0) *
-                                params.num_groups * params.size_n),
-        zp_expert_base_(zp + (expert >= 0 ? expert : 0) *
-                                 params.num_groups * params.size_n),
+        scales_expert_base_(scales + (expert >= 0 ? expert : 0) *
+                                         params.num_groups * params.size_n),
+        zp_expert_base_(zp + (expert >= 0 ? expert : 0) * params.num_groups *
+                                 params.size_n),
         params_(params),
         thread_offset_(ThreadMap::initial_offset(thread_id)),
         expert_(expert),
@@ -131,17 +132,14 @@ class Sm70MoeU4ZpIteratorB {
   }
 
   CUTLASS_DEVICE
-  int metadata_group_offset(int group) const {
-    return group * params_.size_n;
-  }
+  int metadata_group_offset(int group) const { return group * params_.size_n; }
 
   CUTLASS_DEVICE
   int scale_group(int logical_k) const {
     if constexpr (kGroupSize == -1) {
       return 0;
     } else {
-      static_assert(kGroupSize == 32 || kGroupSize == 64 ||
-                        kGroupSize == 128,
+      static_assert(kGroupSize == 32 || kGroupSize == 64 || kGroupSize == 128,
                     "SM70 Marlin MoE U4 supports only group sizes -1, 32, 64, "
                     "and 128.");
       return logical_k / kGroupSize;
@@ -158,16 +156,16 @@ class Sm70MoeU4ZpIteratorB {
   CUTLASS_DEVICE
   void cache_metadata_lane_vectors(int c, int group, int cache_n) const {
     int const metadata_offset = metadata_group_offset(group) + cache_n;
-    half2 const* scale_vec = reinterpret_cast<half2 const*>(
-        scales_expert_base_ + metadata_offset);
+    half2 const* scale_vec =
+        reinterpret_cast<half2 const*>(scales_expert_base_ + metadata_offset);
     half2* scale_cache = cached_scales_ + c * 4;
     scale_cache[0] = scale_vec[0];
     scale_cache[1] = scale_vec[1];
     scale_cache[2] = scale_vec[2];
     scale_cache[3] = scale_vec[3];
 
-    half2 const* zp_vec = reinterpret_cast<half2 const*>(
-        zp_expert_base_ + metadata_offset);
+    half2 const* zp_vec =
+        reinterpret_cast<half2 const*>(zp_expert_base_ + metadata_offset);
     half2* zp_cache = cached_zp_ + c * 4;
     zp_cache[0] = zp_vec[0];
     zp_cache[1] = zp_vec[1];
@@ -178,8 +176,8 @@ class Sm70MoeU4ZpIteratorB {
   CUTLASS_DEVICE
   void cache_metadata_vector_words(int c, int group, int cache_n) const {
     int const metadata_offset = metadata_group_offset(group) + cache_n;
-    uint4 const scale_words = *reinterpret_cast<uint4 const*>(
-        scales_expert_base_ + metadata_offset);
+    uint4 const scale_words =
+        *reinterpret_cast<uint4 const*>(scales_expert_base_ + metadata_offset);
     half2 const* scale_vec = reinterpret_cast<half2 const*>(&scale_words);
     half2* scale_cache = cached_scales_ + c * 4;
     scale_cache[0] = scale_vec[0];
@@ -187,8 +185,8 @@ class Sm70MoeU4ZpIteratorB {
     scale_cache[2] = scale_vec[2];
     scale_cache[3] = scale_vec[3];
 
-    uint4 const zp_words = *reinterpret_cast<uint4 const*>(
-        zp_expert_base_ + metadata_offset);
+    uint4 const zp_words =
+        *reinterpret_cast<uint4 const*>(zp_expert_base_ + metadata_offset);
     half2 const* zp_vec = reinterpret_cast<half2 const*>(&zp_words);
     half2* zp_cache = cached_zp_ + c * 4;
     zp_cache[0] = zp_vec[0];
@@ -201,9 +199,8 @@ class Sm70MoeU4ZpIteratorB {
   void cache_current_group_metadata(int group) const {
     CUTLASS_PRAGMA_UNROLL
     for (int c = 0; c < ThreadMap::Iterations::kContiguous; ++c) {
-      int const cache_n =
-          n_offset_ + thread_offset_.contiguous() +
-          c * ThreadMap::Delta::kContiguous;
+      int const cache_n = n_offset_ + thread_offset_.contiguous() +
+                          c * ThreadMap::Delta::kContiguous;
       if constexpr (kUseMetadataVectorWords) {
         cache_metadata_vector_words(c, group, cache_n);
       } else {
@@ -228,8 +225,8 @@ class Sm70MoeU4ZpIteratorB {
 
           half2 deq[2];
           half2* frag_vec = reinterpret_cast<half2*>(frag.data() + frag_base);
-          marlin::dequant<half2, vllm::kU4.id(), false>(
-              static_cast<int>(qword), deq);
+          marlin::dequant<half2, vllm::kU4.id(), false>(static_cast<int>(qword),
+                                                        deq);
           frag_vec[0] = __hfma2(deq[0], scale_vec[0], __hneg2(zp_vec[0]));
           frag_vec[1] = __hfma2(deq[1], scale_vec[1], __hneg2(zp_vec[1]));
           marlin::dequant<half2, vllm::kU4.id(), false>(
@@ -250,8 +247,8 @@ class Sm70MoeU4ZpIteratorB {
 
           half2 deq[2];
           half2* frag_vec = reinterpret_cast<half2*>(frag.data() + frag_base);
-          marlin::dequant<half2, vllm::kU4.id(), false>(
-              static_cast<int>(qword), deq);
+          marlin::dequant<half2, vllm::kU4.id(), false>(static_cast<int>(qword),
+                                                        deq);
           frag_vec[0] = __hfma2(deq[0], scale_vec[0], __hneg2(zp_vec[0]));
           frag_vec[1] = __hfma2(deq[1], scale_vec[1], __hneg2(zp_vec[1]));
           marlin::dequant<half2, vllm::kU4.id(), false>(
@@ -260,16 +257,18 @@ class Sm70MoeU4ZpIteratorB {
           frag_vec[3] = __hfma2(deq[1], scale_vec[3], __hneg2(zp_vec[3]));
         }
       } else {
-        static_assert(ThreadMap::Iterations::kContiguous == 1,
-                      "Unsupported SM70 Marlin MoE U4 contiguous iteration count.");
-        uint32_t const qword = load_qword_vector<1>(qweight_ + qweight_base_offset_);
+        static_assert(
+            ThreadMap::Iterations::kContiguous == 1,
+            "Unsupported SM70 Marlin MoE U4 contiguous iteration count.");
+        uint32_t const qword =
+            load_qword_vector<1>(qweight_ + qweight_base_offset_);
         half2 const* scale_vec = cached_scales_;
         half2 const* zp_vec = cached_zp_;
 
         half2 deq[2];
         half2* frag_vec = reinterpret_cast<half2*>(frag.data());
-        marlin::dequant<half2, vllm::kU4.id(), false>(
-            static_cast<int>(qword), deq);
+        marlin::dequant<half2, vllm::kU4.id(), false>(static_cast<int>(qword),
+                                                      deq);
         frag_vec[0] = __hfma2(deq[0], scale_vec[0], __hneg2(zp_vec[0]));
         frag_vec[1] = __hfma2(deq[1], scale_vec[1], __hneg2(zp_vec[1]));
         marlin::dequant<half2, vllm::kU4.id(), false>(
@@ -281,9 +280,8 @@ class Sm70MoeU4ZpIteratorB {
       int const logical_n_base = n_offset_ + thread_offset_.contiguous();
       CUTLASS_PRAGMA_UNROLL
       for (int s = 0; s < ThreadMap::Iterations::kStrided; ++s) {
-        int const logical_k_s =
-            k_offset_ + thread_offset_.strided() +
-            s * ThreadMap::Delta::kStrided;
+        int const logical_k_s = k_offset_ + thread_offset_.strided() +
+                                s * ThreadMap::Delta::kStrided;
         if constexpr (kGroupSize != -1) {
           cache_current_group_metadata(scale_group(logical_k_s));
         }
@@ -291,8 +289,7 @@ class Sm70MoeU4ZpIteratorB {
             expert_qweight_base_offset() +
             qweight_offset_from_logical(params_, logical_k_s, logical_n_base);
         if constexpr (ThreadMap::Iterations::kContiguous == 4) {
-          auto const qwords =
-              load_qword_vector<4>(qweight_ + qweight_base_s);
+          auto const qwords = load_qword_vector<4>(qweight_ + qweight_base_s);
           CUTLASS_PRAGMA_UNROLL
           for (int c = 0; c < ThreadMap::Iterations::kContiguous; ++c) {
             constexpr int kAccess = ThreadMap::kElementsPerAccess;
@@ -314,8 +311,7 @@ class Sm70MoeU4ZpIteratorB {
             frag_vec[3] = __hfma2(deq[1], scale_vec[3], __hneg2(zp_vec[3]));
           }
         } else if constexpr (ThreadMap::Iterations::kContiguous == 2) {
-          auto const qwords =
-              load_qword_vector<2>(qweight_ + qweight_base_s);
+          auto const qwords = load_qword_vector<2>(qweight_ + qweight_base_s);
           CUTLASS_PRAGMA_UNROLL
           for (int c = 0; c < ThreadMap::Iterations::kContiguous; ++c) {
             constexpr int kAccess = ThreadMap::kElementsPerAccess;
@@ -337,9 +333,11 @@ class Sm70MoeU4ZpIteratorB {
             frag_vec[3] = __hfma2(deq[1], scale_vec[3], __hneg2(zp_vec[3]));
           }
         } else {
-          static_assert(ThreadMap::Iterations::kContiguous == 1,
-                        "Unsupported SM70 Marlin MoE U4 contiguous iteration count.");
-          uint32_t const qword = load_qword_vector<1>(qweight_ + qweight_base_s);
+          static_assert(
+              ThreadMap::Iterations::kContiguous == 1,
+              "Unsupported SM70 Marlin MoE U4 contiguous iteration count.");
+          uint32_t const qword =
+              load_qword_vector<1>(qweight_ + qweight_base_s);
           constexpr int kAccess = ThreadMap::kElementsPerAccess;
           int const frag_base = s * kAccess;
           half2 const* scale_vec = cached_scales_;
@@ -347,8 +345,8 @@ class Sm70MoeU4ZpIteratorB {
 
           half2 deq[2];
           half2* frag_vec = reinterpret_cast<half2*>(frag.data() + frag_base);
-          marlin::dequant<half2, vllm::kU4.id(), false>(
-              static_cast<int>(qword), deq);
+          marlin::dequant<half2, vllm::kU4.id(), false>(static_cast<int>(qword),
+                                                        deq);
           frag_vec[0] = __hfma2(deq[0], scale_vec[0], __hneg2(zp_vec[0]));
           frag_vec[1] = __hfma2(deq[1], scale_vec[1], __hneg2(zp_vec[1]));
           marlin::dequant<half2, vllm::kU4.id(), false>(
@@ -366,8 +364,7 @@ class Sm70MoeU4ZpIteratorB {
       return;
     }
 
-    if constexpr (kGroupSize != -1 &&
-                  ThreadMap::Iterations::kStrided == 1) {
+    if constexpr (kGroupSize != -1 && ThreadMap::Iterations::kStrided == 1) {
       int const first_logical_k = k_offset_ + thread_offset_.strided();
       cache_current_group_metadata(scale_group(first_logical_k));
     }
@@ -386,18 +383,17 @@ struct Sm70MoeU4ZpGemmSpec {
   using IteratorA = Sm70MoeGatherIteratorA<Shape, ThreadMap>;
 
   template <typename Shape, typename ThreadMap, int GroupSize, int PackedMacroN>
-  using IteratorB =
-      Sm70MoeU4ZpIteratorB<Shape, ThreadMap, GroupSize, PackedMacroN,
-                           UseMetadataVectorWords>;
+  using IteratorB = Sm70MoeU4ZpIteratorB<Shape, ThreadMap, GroupSize,
+                                         PackedMacroN, UseMetadataVectorWords>;
 };
 
-template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM,
-          int WarpN, int WarpK, int GroupSize, int PackedMacroN,
+template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM, int WarpN,
+          int WarpK, int GroupSize, int PackedMacroN,
           bool UseMetadataVectorWords = true>
 using Sm70MoeU4ZpGemmTraits =
-    Sm70MarlinMoeGemmTraits<
-        Sm70MoeU4ZpGemmSpec<UseMetadataVectorWords>, CtaM, CtaN, CtaK,
-        Warps, WarpM, WarpN, WarpK, GroupSize, PackedMacroN>;
+    Sm70MarlinMoeGemmTraits<Sm70MoeU4ZpGemmSpec<UseMetadataVectorWords>, CtaM,
+                            CtaN, CtaK, Warps, WarpM, WarpN, WarpK, GroupSize,
+                            PackedMacroN>;
 
 template <bool UseMetadataVectorWords = true>
 struct Sm70MoeU4Launcher {
@@ -419,16 +415,16 @@ struct Sm70MoeU4Launcher {
   int64_t size_k;
   int requested_split_k;
 
-  template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM,
-          int WarpN, int WarpK, int GroupSize, int PackedMacroN>
+  template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM, int WarpN,
+            int WarpK, int GroupSize, int PackedMacroN>
   torch::Tensor operator()() const {
-    using Traits = Sm70MoeU4ZpGemmTraits<CtaM, CtaN, CtaK, Warps, WarpM,
-                                         WarpN, WarpK, GroupSize, PackedMacroN,
-                                         UseMetadataVectorWords>;
+    using Traits =
+        Sm70MoeU4ZpGemmTraits<CtaM, CtaN, CtaK, Warps, WarpM, WarpN, WarpK,
+                              GroupSize, PackedMacroN, UseMetadataVectorWords>;
     return launch_sm70_marlin_moe_gemm<Traits>(
         a, c, b_q_weight, b_scales, b_zeros, global_scale, sorted_token_ids,
-        expert_ids, num_tokens_past_padded, topk_weights, moe_block_size,
-        top_k, mul_topk_weights, size_m, size_n, size_k, requested_split_k);
+        expert_ids, num_tokens_past_padded, topk_weights, moe_block_size, top_k,
+        mul_topk_weights, size_m, size_n, size_k, requested_split_k);
   }
 };
 
@@ -446,9 +442,10 @@ torch::Tensor sm70_marlin_u4_gemm(
   auto const params = sm70_marlin_moe_auto_stage_params(
       "uint4", group_size, moe_block_size, top_k, size_m, size_n, size_k);
   Sm70CtaGeometry const geometry = params.geometry;
-  validate_sm70_marlin_moe_stage_cta_geometry_supported("SM70 Marlin MoE uint4", geometry);
-  validate_sm70_marlin_moe_stage_cta_n_alignment("SM70 Marlin MoE uint4", geometry,
-                                        size_n);
+  validate_sm70_marlin_moe_stage_cta_geometry_supported("SM70 Marlin MoE uint4",
+                                                        geometry);
+  validate_sm70_marlin_moe_stage_cta_n_alignment("SM70 Marlin MoE uint4",
+                                                 geometry, size_n);
   TORCH_CHECK(size_k % geometry.cta_k == 0,
               "SM70 Marlin MoE uint4 requires K divisible by CTA_K=",
               geometry.cta_k, ". Got K=", size_k, ".");
@@ -456,19 +453,45 @@ torch::Tensor sm70_marlin_u4_gemm(
   auto empty_float = torch::empty(
       {0}, torch::TensorOptions().dtype(at::kFloat).device(a.device()));
   if (params.use_metadata_vector_words) {
-    Sm70MoeU4Launcher<true> const launcher{
-        a, c, b_q_weight, b_scales, b_zeros, empty_float, sorted_token_ids,
-        expert_ids, num_tokens_past_padded, topk_weights, moe_block_size, top_k,
-        mul_topk_weights, size_m, size_n, size_k, params.requested_split_k};
-    return dispatch_sm70_marlin_moe_geometry(launcher, geometry, params.packed_macro_n, group_size,
-        "uint4");
+    Sm70MoeU4Launcher<true> const launcher{a,
+                                           c,
+                                           b_q_weight,
+                                           b_scales,
+                                           b_zeros,
+                                           empty_float,
+                                           sorted_token_ids,
+                                           expert_ids,
+                                           num_tokens_past_padded,
+                                           topk_weights,
+                                           moe_block_size,
+                                           top_k,
+                                           mul_topk_weights,
+                                           size_m,
+                                           size_n,
+                                           size_k,
+                                           params.requested_split_k};
+    return dispatch_sm70_marlin_moe_geometry(
+        launcher, geometry, params.packed_macro_n, group_size, "uint4");
   }
-  Sm70MoeU4Launcher<false> const launcher{
-      a, c, b_q_weight, b_scales, b_zeros, empty_float, sorted_token_ids,
-      expert_ids, num_tokens_past_padded, topk_weights, moe_block_size, top_k,
-      mul_topk_weights, size_m, size_n, size_k, params.requested_split_k};
-  return dispatch_sm70_marlin_moe_geometry(launcher, geometry, params.packed_macro_n, group_size,
-      "uint4");
+  Sm70MoeU4Launcher<false> const launcher{a,
+                                          c,
+                                          b_q_weight,
+                                          b_scales,
+                                          b_zeros,
+                                          empty_float,
+                                          sorted_token_ids,
+                                          expert_ids,
+                                          num_tokens_past_padded,
+                                          topk_weights,
+                                          moe_block_size,
+                                          top_k,
+                                          mul_topk_weights,
+                                          size_m,
+                                          size_n,
+                                          size_k,
+                                          params.requested_split_k};
+  return dispatch_sm70_marlin_moe_geometry(
+      launcher, geometry, params.packed_macro_n, group_size, "uint4");
 }
 
 }  // namespace marlin_moe_wna16

--- a/csrc/moe/marlin_moe_wna16/sm70_marlin_u4b8_gemm.cu
+++ b/csrc/moe/marlin_moe_wna16/sm70_marlin_u4b8_gemm.cu
@@ -35,22 +35,25 @@ class Sm70MoeU4B8IteratorB {
   static int const kPackedMacroN = PackedMacroN_;
   static constexpr bool kUseMetadataVectorWords = UseMetadataVectorWords_;
   using Element = cutlass::half_t;
-  using Fragment = cutlass::Array<
-      Element, ThreadMap::Iterations::kCount * ThreadMap::kElementsPerAccess>;
-    static_assert(Shape::kN == 64 || Shape::kN == 128 || Shape::kN == 256,
-                "SM70 Marlin MoE U4B8 IteratorB expects CTA_N in {64, 128, 256}.");
-  static_assert(ThreadMap::Iterations::kContiguous ==
-                    Shape::kN / kQuantTileN,
-                "SM70 Marlin MoE U4B8 IteratorB expects one contiguous iteration per "
-                "64-column quant tile.");
+  using Fragment = cutlass::Array<Element, ThreadMap::Iterations::kCount *
+                                               ThreadMap::kElementsPerAccess>;
+  static_assert(
+      Shape::kN == 64 || Shape::kN == 128 || Shape::kN == 256,
+      "SM70 Marlin MoE U4B8 IteratorB expects CTA_N in {64, 128, 256}.");
+  static_assert(
+      ThreadMap::Iterations::kContiguous == Shape::kN / kQuantTileN,
+      "SM70 Marlin MoE U4B8 IteratorB expects one contiguous iteration per "
+      "64-column quant tile.");
   static_assert(ThreadMap::Delta::kContiguous == kQuantTileN,
                 "SM70 Marlin MoE U4B8 IteratorB expects 64-column deltas.");
-  static_assert(ThreadMap::kElementsPerAccess == kU4ValuesPerWord,
-                "SM70 Marlin MoE U4B8 IteratorB expects one packed int4 word per "
-                "access.");
-  static_assert(ThreadMap::Iterations::kStrided >= 1,
-                "SM70 Marlin MoE U4-family IteratorB expects one or more strided "
-                "iterations.");
+  static_assert(
+      ThreadMap::kElementsPerAccess == kU4ValuesPerWord,
+      "SM70 Marlin MoE U4B8 IteratorB expects one packed int4 word per "
+      "access.");
+  static_assert(
+      ThreadMap::Iterations::kStrided >= 1,
+      "SM70 Marlin MoE U4-family IteratorB expects one or more strided "
+      "iterations.");
   struct Params {
     int size_k;
     int size_n;
@@ -84,9 +87,8 @@ class Sm70MoeU4B8IteratorB {
                        half const* scales, half const*, int thread_id,
                        int expert, int k_offset, int n_offset)
       : qweight_(qweight),
-        scales_expert_base_(scales +
-                            (expert >= 0 ? expert : 0) *
-                                params.num_groups * params.size_n),
+        scales_expert_base_(scales + (expert >= 0 ? expert : 0) *
+                                         params.num_groups * params.size_n),
         params_(params),
         thread_offset_(ThreadMap::initial_offset(thread_id)),
         expert_(expert),
@@ -128,19 +130,17 @@ class Sm70MoeU4B8IteratorB {
   }
 
   CUTLASS_DEVICE
-  int metadata_group_offset(int group) const {
-    return group * params_.size_n;
-  }
+  int metadata_group_offset(int group) const { return group * params_.size_n; }
 
   CUTLASS_DEVICE
   int scale_group(int logical_k) const {
     if constexpr (kGroupSize == -1) {
       return 0;
     } else {
-      static_assert(kGroupSize == 32 || kGroupSize == 64 ||
-                        kGroupSize == 128,
-                    "SM70 Marlin MoE U4B8 supports only group sizes -1, 32, 64, "
-                    "and 128.");
+      static_assert(
+          kGroupSize == 32 || kGroupSize == 64 || kGroupSize == 128,
+          "SM70 Marlin MoE U4B8 supports only group sizes -1, 32, 64, "
+          "and 128.");
       return logical_k / kGroupSize;
     }
   }
@@ -155,8 +155,8 @@ class Sm70MoeU4B8IteratorB {
   CUTLASS_DEVICE
   void cache_metadata_lane_vectors(int c, int group, int cache_n) const {
     int const metadata_offset = metadata_group_offset(group) + cache_n;
-    half2 const* scale_vec = reinterpret_cast<half2 const*>(
-        scales_expert_base_ + metadata_offset);
+    half2 const* scale_vec =
+        reinterpret_cast<half2 const*>(scales_expert_base_ + metadata_offset);
     half2* scale_cache = cached_scales_ + c * 4;
     scale_cache[0] = scale_vec[0];
     scale_cache[1] = scale_vec[1];
@@ -167,8 +167,8 @@ class Sm70MoeU4B8IteratorB {
   CUTLASS_DEVICE
   void cache_metadata_vector_words(int c, int group, int cache_n) const {
     int const metadata_offset = metadata_group_offset(group) + cache_n;
-    uint4 const scale_words = *reinterpret_cast<uint4 const*>(
-        scales_expert_base_ + metadata_offset);
+    uint4 const scale_words =
+        *reinterpret_cast<uint4 const*>(scales_expert_base_ + metadata_offset);
     half2 const* scale_vec = reinterpret_cast<half2 const*>(&scale_words);
     half2* scale_cache = cached_scales_ + c * 4;
     scale_cache[0] = scale_vec[0];
@@ -181,9 +181,8 @@ class Sm70MoeU4B8IteratorB {
   void cache_current_group_metadata(int group) const {
     CUTLASS_PRAGMA_UNROLL
     for (int c = 0; c < ThreadMap::Iterations::kContiguous; ++c) {
-      int const cache_n =
-          n_offset_ + thread_offset_.contiguous() +
-          c * ThreadMap::Delta::kContiguous;
+      int const cache_n = n_offset_ + thread_offset_.contiguous() +
+                          c * ThreadMap::Delta::kContiguous;
       if constexpr (kUseMetadataVectorWords) {
         cache_metadata_vector_words(c, group, cache_n);
       } else {
@@ -238,16 +237,17 @@ class Sm70MoeU4B8IteratorB {
           frag_vec[3] = __hmul2(deq[1], scale_vec[3]);
         }
       } else {
-        static_assert(ThreadMap::Iterations::kContiguous == 1,
-                      "Unsupported SM70 Marlin MoE U4B8 contiguous iteration count.");
+        static_assert(
+            ThreadMap::Iterations::kContiguous == 1,
+            "Unsupported SM70 Marlin MoE U4B8 contiguous iteration count.");
         uint32_t const qword =
             load_qword_vector<1>(qweight_ + qweight_base_offset_);
         half2 const* scale_vec = cached_scales_;
 
         half2 deq[2];
         half2* frag_vec = reinterpret_cast<half2*>(frag.data());
-        marlin::dequant<half2, vllm::kU4B8.id(), false>(
-            static_cast<int>(qword), deq);
+        marlin::dequant<half2, vllm::kU4B8.id(), false>(static_cast<int>(qword),
+                                                        deq);
         frag_vec[0] = __hmul2(deq[0], scale_vec[0]);
         frag_vec[1] = __hmul2(deq[1], scale_vec[1]);
         marlin::dequant<half2, vllm::kU4B8.id(), false>(
@@ -259,9 +259,8 @@ class Sm70MoeU4B8IteratorB {
       int const logical_n_base = n_offset_ + thread_offset_.contiguous();
       CUTLASS_PRAGMA_UNROLL
       for (int s = 0; s < ThreadMap::Iterations::kStrided; ++s) {
-        int const logical_k_s =
-            k_offset_ + thread_offset_.strided() +
-            s * ThreadMap::Delta::kStrided;
+        int const logical_k_s = k_offset_ + thread_offset_.strided() +
+                                s * ThreadMap::Delta::kStrided;
         if constexpr (kGroupSize != -1) {
           cache_current_group_metadata(scale_group(logical_k_s));
         }
@@ -269,8 +268,7 @@ class Sm70MoeU4B8IteratorB {
             expert_qweight_base_offset() +
             qweight_offset_from_logical(params_, logical_k_s, logical_n_base);
         if constexpr (ThreadMap::Iterations::kContiguous == 4) {
-          auto const qwords =
-              load_qword_vector<4>(qweight_ + qweight_base_s);
+          auto const qwords = load_qword_vector<4>(qweight_ + qweight_base_s);
           CUTLASS_PRAGMA_UNROLL
           for (int c = 0; c < ThreadMap::Iterations::kContiguous; ++c) {
             constexpr int kAccess = ThreadMap::kElementsPerAccess;
@@ -291,8 +289,7 @@ class Sm70MoeU4B8IteratorB {
             frag_vec[3] = __hmul2(deq[1], scale_vec[3]);
           }
         } else if constexpr (ThreadMap::Iterations::kContiguous == 2) {
-          auto const qwords =
-              load_qword_vector<2>(qweight_ + qweight_base_s);
+          auto const qwords = load_qword_vector<2>(qweight_ + qweight_base_s);
           CUTLASS_PRAGMA_UNROLL
           for (int c = 0; c < ThreadMap::Iterations::kContiguous; ++c) {
             constexpr int kAccess = ThreadMap::kElementsPerAccess;
@@ -313,8 +310,9 @@ class Sm70MoeU4B8IteratorB {
             frag_vec[3] = __hmul2(deq[1], scale_vec[3]);
           }
         } else {
-          static_assert(ThreadMap::Iterations::kContiguous == 1,
-                        "Unsupported SM70 Marlin MoE U4B8 contiguous iteration count.");
+          static_assert(
+              ThreadMap::Iterations::kContiguous == 1,
+              "Unsupported SM70 Marlin MoE U4B8 contiguous iteration count.");
           uint32_t const qword =
               load_qword_vector<1>(qweight_ + qweight_base_s);
           constexpr int kAccess = ThreadMap::kElementsPerAccess;
@@ -342,8 +340,7 @@ class Sm70MoeU4B8IteratorB {
       return;
     }
 
-    if constexpr (kGroupSize != -1 &&
-                  ThreadMap::Iterations::kStrided == 1) {
+    if constexpr (kGroupSize != -1 && ThreadMap::Iterations::kStrided == 1) {
       int const first_logical_k = k_offset_ + thread_offset_.strided();
       cache_current_group_metadata(scale_group(first_logical_k));
     }
@@ -362,18 +359,17 @@ struct Sm70MoeU4B8GemmSpec {
   using IteratorA = Sm70MoeGatherIteratorA<Shape, ThreadMap>;
 
   template <typename Shape, typename ThreadMap, int GroupSize, int PackedMacroN>
-  using IteratorB =
-      Sm70MoeU4B8IteratorB<Shape, ThreadMap, GroupSize, PackedMacroN,
-                           UseMetadataVectorWords>;
+  using IteratorB = Sm70MoeU4B8IteratorB<Shape, ThreadMap, GroupSize,
+                                         PackedMacroN, UseMetadataVectorWords>;
 };
 
-template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM,
-          int WarpN, int WarpK, int GroupSize, int PackedMacroN,
+template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM, int WarpN,
+          int WarpK, int GroupSize, int PackedMacroN,
           bool UseMetadataVectorWords = true>
 using Sm70MoeU4B8GemmTraits =
-    Sm70MarlinMoeGemmTraits<
-        Sm70MoeU4B8GemmSpec<UseMetadataVectorWords>, CtaM, CtaN, CtaK,
-        Warps, WarpM, WarpN, WarpK, GroupSize, PackedMacroN>;
+    Sm70MarlinMoeGemmTraits<Sm70MoeU4B8GemmSpec<UseMetadataVectorWords>, CtaM,
+                            CtaN, CtaK, Warps, WarpM, WarpN, WarpK, GroupSize,
+                            PackedMacroN>;
 
 template <bool UseMetadataVectorWords = true>
 struct Sm70MoeU4B8Launcher {
@@ -395,16 +391,16 @@ struct Sm70MoeU4B8Launcher {
   int64_t size_k;
   int requested_split_k;
 
-  template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM,
-          int WarpN, int WarpK, int GroupSize, int PackedMacroN>
+  template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM, int WarpN,
+            int WarpK, int GroupSize, int PackedMacroN>
   torch::Tensor operator()() const {
-    using Traits = Sm70MoeU4B8GemmTraits<CtaM, CtaN, CtaK, Warps, WarpM,
-                                         WarpN, WarpK, GroupSize, PackedMacroN,
-                                         UseMetadataVectorWords>;
+    using Traits =
+        Sm70MoeU4B8GemmTraits<CtaM, CtaN, CtaK, Warps, WarpM, WarpN, WarpK,
+                              GroupSize, PackedMacroN, UseMetadataVectorWords>;
     return launch_sm70_marlin_moe_gemm<Traits>(
         a, c, b_q_weight, b_scales, b_zeros, global_scale, sorted_token_ids,
-        expert_ids, num_tokens_past_padded, topk_weights, moe_block_size,
-        top_k, mul_topk_weights, size_m, size_n, size_k, requested_split_k);
+        expert_ids, num_tokens_past_padded, topk_weights, moe_block_size, top_k,
+        mul_topk_weights, size_m, size_n, size_k, requested_split_k);
   }
 };
 
@@ -422,9 +418,10 @@ torch::Tensor sm70_marlin_u4b8_gemm(
   auto const params = sm70_marlin_moe_auto_stage_params(
       "uint4b8", group_size, moe_block_size, top_k, size_m, size_n, size_k);
   Sm70CtaGeometry const geometry = params.geometry;
-  validate_sm70_marlin_moe_stage_cta_geometry_supported("SM70 Marlin MoE uint4b8", geometry);
-  validate_sm70_marlin_moe_stage_cta_n_alignment("SM70 Marlin MoE uint4b8", geometry,
-                                        size_n);
+  validate_sm70_marlin_moe_stage_cta_geometry_supported(
+      "SM70 Marlin MoE uint4b8", geometry);
+  validate_sm70_marlin_moe_stage_cta_n_alignment("SM70 Marlin MoE uint4b8",
+                                                 geometry, size_n);
   TORCH_CHECK(size_k % geometry.cta_k == 0,
               "SM70 Marlin MoE uint4b8 requires K divisible by CTA_K=",
               geometry.cta_k, ". Got K=", size_k, ".");
@@ -433,17 +430,43 @@ torch::Tensor sm70_marlin_u4b8_gemm(
   auto empty_float = torch::empty(
       {0}, torch::TensorOptions().dtype(at::kFloat).device(a.device()));
   if (params.use_metadata_vector_words) {
-    Sm70MoeU4B8Launcher<true> const launcher{
-        a, c, b_q_weight, b_scales, empty_half, empty_float, sorted_token_ids,
-        expert_ids, num_tokens_past_padded, topk_weights, moe_block_size, top_k,
-        mul_topk_weights, size_m, size_n, size_k, params.requested_split_k};
+    Sm70MoeU4B8Launcher<true> const launcher{a,
+                                             c,
+                                             b_q_weight,
+                                             b_scales,
+                                             empty_half,
+                                             empty_float,
+                                             sorted_token_ids,
+                                             expert_ids,
+                                             num_tokens_past_padded,
+                                             topk_weights,
+                                             moe_block_size,
+                                             top_k,
+                                             mul_topk_weights,
+                                             size_m,
+                                             size_n,
+                                             size_k,
+                                             params.requested_split_k};
     return dispatch_sm70_marlin_moe_geometry(
         launcher, geometry, params.packed_macro_n, group_size, "uint4b8");
   }
-  Sm70MoeU4B8Launcher<false> const launcher{
-      a, c, b_q_weight, b_scales, empty_half, empty_float, sorted_token_ids,
-      expert_ids, num_tokens_past_padded, topk_weights, moe_block_size, top_k,
-      mul_topk_weights, size_m, size_n, size_k, params.requested_split_k};
+  Sm70MoeU4B8Launcher<false> const launcher{a,
+                                            c,
+                                            b_q_weight,
+                                            b_scales,
+                                            empty_half,
+                                            empty_float,
+                                            sorted_token_ids,
+                                            expert_ids,
+                                            num_tokens_past_padded,
+                                            topk_weights,
+                                            moe_block_size,
+                                            top_k,
+                                            mul_topk_weights,
+                                            size_m,
+                                            size_n,
+                                            size_k,
+                                            params.requested_split_k};
   return dispatch_sm70_marlin_moe_geometry(
       launcher, geometry, params.packed_macro_n, group_size, "uint4b8");
 }

--- a/csrc/moe/marlin_moe_wna16/sm70_marlin_u8_gemm.cu
+++ b/csrc/moe/marlin_moe_wna16/sm70_marlin_u8_gemm.cu
@@ -35,22 +35,24 @@ class Sm70MoeU8ZpIteratorB {
   static int const kPackedMacroN = PackedMacroN_;
   static constexpr bool kUseMetadataVectorWords = UseMetadataVectorWords_;
   using Element = cutlass::half_t;
-  using Fragment = cutlass::Array<
-      Element, ThreadMap::Iterations::kCount * ThreadMap::kElementsPerAccess>;
-    static_assert(Shape::kN == 64 || Shape::kN == 128 || Shape::kN == 256,
-                "SM70 Marlin MoE U8 IteratorB expects CTA_N in {64, 128, 256}.");
-  static_assert(ThreadMap::Iterations::kContiguous ==
-                    Shape::kN / kQuantTileN,
-                "SM70 Marlin MoE U8 IteratorB expects one contiguous iteration per "
-                "64-column quant tile.");
+  using Fragment = cutlass::Array<Element, ThreadMap::Iterations::kCount *
+                                               ThreadMap::kElementsPerAccess>;
+  static_assert(
+      Shape::kN == 64 || Shape::kN == 128 || Shape::kN == 256,
+      "SM70 Marlin MoE U8 IteratorB expects CTA_N in {64, 128, 256}.");
+  static_assert(
+      ThreadMap::Iterations::kContiguous == Shape::kN / kQuantTileN,
+      "SM70 Marlin MoE U8 IteratorB expects one contiguous iteration per "
+      "64-column quant tile.");
   static_assert(ThreadMap::Delta::kContiguous == kQuantTileN,
                 "SM70 Marlin MoE U8 IteratorB expects 64-column deltas.");
   static_assert(ThreadMap::kElementsPerAccess == kU8ValuesPerAccess,
                 "SM70 Marlin MoE U8 IteratorB expects two packed U8 words per "
                 "access.");
-  static_assert(ThreadMap::Iterations::kStrided >= 1,
-                "SM70 Marlin MoE U8-family IteratorB expects one or more strided "
-                "iterations.");
+  static_assert(
+      ThreadMap::Iterations::kStrided >= 1,
+      "SM70 Marlin MoE U8-family IteratorB expects one or more strided "
+      "iterations.");
   static constexpr int kQweightWordStrideWords = kPackedMacroN / kQuantTileN;
 
   struct Params {
@@ -88,11 +90,10 @@ class Sm70MoeU8ZpIteratorB {
                        half const* scales, half const* zp, int thread_id,
                        int expert, int k_offset, int n_offset)
       : qweight_(qweight),
-        scales_expert_base_(scales +
-                            (expert >= 0 ? expert : 0) *
-                                params.num_groups * params.size_n),
-        zp_expert_base_(zp + (expert >= 0 ? expert : 0) *
-                                 params.num_groups * params.size_n),
+        scales_expert_base_(scales + (expert >= 0 ? expert : 0) *
+                                         params.num_groups * params.size_n),
+        zp_expert_base_(zp + (expert >= 0 ? expert : 0) * params.num_groups *
+                                 params.size_n),
         params_(params),
         thread_offset_(ThreadMap::initial_offset(thread_id)),
         expert_(expert),
@@ -134,17 +135,14 @@ class Sm70MoeU8ZpIteratorB {
   }
 
   CUTLASS_DEVICE
-  int metadata_group_offset(int group) const {
-    return group * params_.size_n;
-  }
+  int metadata_group_offset(int group) const { return group * params_.size_n; }
 
   CUTLASS_DEVICE
   int scale_group(int logical_k) const {
     if constexpr (kGroupSize == -1) {
       return 0;
     } else {
-      static_assert(kGroupSize == 32 || kGroupSize == 64 ||
-                        kGroupSize == 128,
+      static_assert(kGroupSize == 32 || kGroupSize == 64 || kGroupSize == 128,
                     "SM70 Marlin MoE U8 supports only group sizes -1, 32, 64, "
                     "and 128.");
       return logical_k / kGroupSize;
@@ -161,16 +159,16 @@ class Sm70MoeU8ZpIteratorB {
   CUTLASS_DEVICE
   void cache_metadata_lane_vectors(int c, int group, int cache_n) const {
     int const metadata_offset = metadata_group_offset(group) + cache_n;
-    half2 const* scale_vec = reinterpret_cast<half2 const*>(
-        scales_expert_base_ + metadata_offset);
+    half2 const* scale_vec =
+        reinterpret_cast<half2 const*>(scales_expert_base_ + metadata_offset);
     half2* scale_cache = cached_scales_ + c * 4;
     scale_cache[0] = scale_vec[0];
     scale_cache[1] = scale_vec[1];
     scale_cache[2] = scale_vec[2];
     scale_cache[3] = scale_vec[3];
 
-    half2 const* zp_vec = reinterpret_cast<half2 const*>(
-        zp_expert_base_ + metadata_offset);
+    half2 const* zp_vec =
+        reinterpret_cast<half2 const*>(zp_expert_base_ + metadata_offset);
     half2* zp_cache = cached_zp_ + c * 4;
     zp_cache[0] = zp_vec[0];
     zp_cache[1] = zp_vec[1];
@@ -181,8 +179,8 @@ class Sm70MoeU8ZpIteratorB {
   CUTLASS_DEVICE
   void cache_metadata_vector_words(int c, int group, int cache_n) const {
     int const metadata_offset = metadata_group_offset(group) + cache_n;
-    uint4 const scale_words = *reinterpret_cast<uint4 const*>(
-        scales_expert_base_ + metadata_offset);
+    uint4 const scale_words =
+        *reinterpret_cast<uint4 const*>(scales_expert_base_ + metadata_offset);
     half2 const* scale_vec = reinterpret_cast<half2 const*>(&scale_words);
     half2* scale_cache = cached_scales_ + c * 4;
     scale_cache[0] = scale_vec[0];
@@ -190,8 +188,8 @@ class Sm70MoeU8ZpIteratorB {
     scale_cache[2] = scale_vec[2];
     scale_cache[3] = scale_vec[3];
 
-    uint4 const zp_words = *reinterpret_cast<uint4 const*>(
-        zp_expert_base_ + metadata_offset);
+    uint4 const zp_words =
+        *reinterpret_cast<uint4 const*>(zp_expert_base_ + metadata_offset);
     half2 const* zp_vec = reinterpret_cast<half2 const*>(&zp_words);
     half2* zp_cache = cached_zp_ + c * 4;
     zp_cache[0] = zp_vec[0];
@@ -204,9 +202,8 @@ class Sm70MoeU8ZpIteratorB {
   void cache_current_group_metadata(int group) const {
     CUTLASS_PRAGMA_UNROLL
     for (int c = 0; c < ThreadMap::Iterations::kContiguous; ++c) {
-      int const cache_n =
-          n_offset_ + thread_offset_.contiguous() +
-          c * ThreadMap::Delta::kContiguous;
+      int const cache_n = n_offset_ + thread_offset_.contiguous() +
+                          c * ThreadMap::Delta::kContiguous;
       if constexpr (kUseMetadataVectorWords) {
         cache_metadata_vector_words(c, group, cache_n);
       } else {
@@ -269,8 +266,9 @@ class Sm70MoeU8ZpIteratorB {
           frag_vec[3] = __hfma2(deq[1], scale_vec[3], __hneg2(zp_vec[3]));
         }
       } else {
-        static_assert(ThreadMap::Iterations::kContiguous == 1,
-                      "Unsupported SM70 Marlin MoE U8 contiguous iteration count.");
+        static_assert(
+            ThreadMap::Iterations::kContiguous == 1,
+            "Unsupported SM70 Marlin MoE U8 contiguous iteration count.");
         uint32_t const qword0 =
             load_qword_vector<1>(qweight_ + qweight_base_offset_);
         uint32_t const qword1 = load_qword_vector<1>(
@@ -280,12 +278,12 @@ class Sm70MoeU8ZpIteratorB {
 
         half2 deq[2];
         half2* frag_vec = reinterpret_cast<half2*>(frag.data());
-        marlin::dequant<half2, vllm::kU8.id(), false>(
-            static_cast<int>(qword0), deq);
+        marlin::dequant<half2, vllm::kU8.id(), false>(static_cast<int>(qword0),
+                                                      deq);
         frag_vec[0] = __hfma2(deq[0], scale_vec[0], __hneg2(zp_vec[0]));
         frag_vec[1] = __hfma2(deq[1], scale_vec[1], __hneg2(zp_vec[1]));
-        marlin::dequant<half2, vllm::kU8.id(), false>(
-            static_cast<int>(qword1), deq);
+        marlin::dequant<half2, vllm::kU8.id(), false>(static_cast<int>(qword1),
+                                                      deq);
         frag_vec[2] = __hfma2(deq[0], scale_vec[2], __hneg2(zp_vec[2]));
         frag_vec[3] = __hfma2(deq[1], scale_vec[3], __hneg2(zp_vec[3]));
       }
@@ -293,9 +291,8 @@ class Sm70MoeU8ZpIteratorB {
       int const logical_n_base = n_offset_ + thread_offset_.contiguous();
       CUTLASS_PRAGMA_UNROLL
       for (int s = 0; s < ThreadMap::Iterations::kStrided; ++s) {
-        int const logical_k_s =
-            k_offset_ + thread_offset_.strided() +
-            s * ThreadMap::Delta::kStrided;
+        int const logical_k_s = k_offset_ + thread_offset_.strided() +
+                                s * ThreadMap::Delta::kStrided;
         if constexpr (kGroupSize != -1) {
           cache_current_group_metadata(scale_group(logical_k_s));
         }
@@ -303,10 +300,9 @@ class Sm70MoeU8ZpIteratorB {
             expert_qweight_base_offset() +
             qweight_offset_from_logical(params_, logical_k_s, logical_n_base);
         if constexpr (ThreadMap::Iterations::kContiguous == 4) {
-          uint4 const qwords0 =
-              load_qword_vector<4>(qweight_ + qweight_base_s);
-          uint4 const qwords1 = load_qword_vector<4>(
-              qweight_ + qweight_base_s + kQweightWordStrideWords);
+          uint4 const qwords0 = load_qword_vector<4>(qweight_ + qweight_base_s);
+          uint4 const qwords1 = load_qword_vector<4>(qweight_ + qweight_base_s +
+                                                     kQweightWordStrideWords);
           CUTLASS_PRAGMA_UNROLL
           for (int c = 0; c < ThreadMap::Iterations::kContiguous; ++c) {
             constexpr int kAccess = ThreadMap::kElementsPerAccess;
@@ -321,22 +317,17 @@ class Sm70MoeU8ZpIteratorB {
             half2* frag_vec = reinterpret_cast<half2*>(frag.data() + frag_base);
             marlin::dequant<half2, vllm::kU8.id(), false>(
                 static_cast<int>(qword0), deq);
-            frag_vec[0] =
-                __hfma2(deq[0], scale_vec[0], __hneg2(zp_vec[0]));
-            frag_vec[1] =
-                __hfma2(deq[1], scale_vec[1], __hneg2(zp_vec[1]));
+            frag_vec[0] = __hfma2(deq[0], scale_vec[0], __hneg2(zp_vec[0]));
+            frag_vec[1] = __hfma2(deq[1], scale_vec[1], __hneg2(zp_vec[1]));
             marlin::dequant<half2, vllm::kU8.id(), false>(
                 static_cast<int>(qword1), deq);
-            frag_vec[2] =
-                __hfma2(deq[0], scale_vec[2], __hneg2(zp_vec[2]));
-            frag_vec[3] =
-                __hfma2(deq[1], scale_vec[3], __hneg2(zp_vec[3]));
+            frag_vec[2] = __hfma2(deq[0], scale_vec[2], __hneg2(zp_vec[2]));
+            frag_vec[3] = __hfma2(deq[1], scale_vec[3], __hneg2(zp_vec[3]));
           }
         } else if constexpr (ThreadMap::Iterations::kContiguous == 2) {
-          uint2 const qwords0 =
-              load_qword_vector<2>(qweight_ + qweight_base_s);
-          uint2 const qwords1 = load_qword_vector<2>(
-              qweight_ + qweight_base_s + kQweightWordStrideWords);
+          uint2 const qwords0 = load_qword_vector<2>(qweight_ + qweight_base_s);
+          uint2 const qwords1 = load_qword_vector<2>(qweight_ + qweight_base_s +
+                                                     kQweightWordStrideWords);
           CUTLASS_PRAGMA_UNROLL
           for (int c = 0; c < ThreadMap::Iterations::kContiguous; ++c) {
             constexpr int kAccess = ThreadMap::kElementsPerAccess;
@@ -351,20 +342,17 @@ class Sm70MoeU8ZpIteratorB {
             half2* frag_vec = reinterpret_cast<half2*>(frag.data() + frag_base);
             marlin::dequant<half2, vllm::kU8.id(), false>(
                 static_cast<int>(qword0), deq);
-            frag_vec[0] =
-                __hfma2(deq[0], scale_vec[0], __hneg2(zp_vec[0]));
-            frag_vec[1] =
-                __hfma2(deq[1], scale_vec[1], __hneg2(zp_vec[1]));
+            frag_vec[0] = __hfma2(deq[0], scale_vec[0], __hneg2(zp_vec[0]));
+            frag_vec[1] = __hfma2(deq[1], scale_vec[1], __hneg2(zp_vec[1]));
             marlin::dequant<half2, vllm::kU8.id(), false>(
                 static_cast<int>(qword1), deq);
-            frag_vec[2] =
-                __hfma2(deq[0], scale_vec[2], __hneg2(zp_vec[2]));
-            frag_vec[3] =
-                __hfma2(deq[1], scale_vec[3], __hneg2(zp_vec[3]));
+            frag_vec[2] = __hfma2(deq[0], scale_vec[2], __hneg2(zp_vec[2]));
+            frag_vec[3] = __hfma2(deq[1], scale_vec[3], __hneg2(zp_vec[3]));
           }
         } else {
-          static_assert(ThreadMap::Iterations::kContiguous == 1,
-                        "Unsupported SM70 Marlin MoE U8 contiguous iteration count.");
+          static_assert(
+              ThreadMap::Iterations::kContiguous == 1,
+              "Unsupported SM70 Marlin MoE U8 contiguous iteration count.");
           uint32_t const qword0 =
               load_qword_vector<1>(qweight_ + qweight_base_s);
           uint32_t const qword1 = load_qword_vector<1>(
@@ -395,8 +383,7 @@ class Sm70MoeU8ZpIteratorB {
       return;
     }
 
-    if constexpr (kGroupSize != -1 &&
-                  ThreadMap::Iterations::kStrided == 1) {
+    if constexpr (kGroupSize != -1 && ThreadMap::Iterations::kStrided == 1) {
       int const first_logical_k = k_offset_ + thread_offset_.strided();
       cache_current_group_metadata(scale_group(first_logical_k));
     }
@@ -415,18 +402,17 @@ struct Sm70MoeU8ZpGemmSpec {
   using IteratorA = Sm70MoeGatherIteratorA<Shape, ThreadMap>;
 
   template <typename Shape, typename ThreadMap, int GroupSize, int PackedMacroN>
-  using IteratorB =
-      Sm70MoeU8ZpIteratorB<Shape, ThreadMap, GroupSize, PackedMacroN,
-                           UseMetadataVectorWords>;
+  using IteratorB = Sm70MoeU8ZpIteratorB<Shape, ThreadMap, GroupSize,
+                                         PackedMacroN, UseMetadataVectorWords>;
 };
 
-template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM,
-          int WarpN, int WarpK, int GroupSize, int PackedMacroN,
+template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM, int WarpN,
+          int WarpK, int GroupSize, int PackedMacroN,
           bool UseMetadataVectorWords = true>
 using Sm70MoeU8ZpGemmTraits =
-    Sm70MarlinMoeGemmTraits<
-        Sm70MoeU8ZpGemmSpec<UseMetadataVectorWords>, CtaM, CtaN, CtaK,
-        Warps, WarpM, WarpN, WarpK, GroupSize, PackedMacroN>;
+    Sm70MarlinMoeGemmTraits<Sm70MoeU8ZpGemmSpec<UseMetadataVectorWords>, CtaM,
+                            CtaN, CtaK, Warps, WarpM, WarpN, WarpK, GroupSize,
+                            PackedMacroN>;
 
 template <bool UseMetadataVectorWords = true>
 struct Sm70MoeU8Launcher {
@@ -448,16 +434,16 @@ struct Sm70MoeU8Launcher {
   int64_t size_k;
   int requested_split_k;
 
-  template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM,
-          int WarpN, int WarpK, int GroupSize, int PackedMacroN>
+  template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM, int WarpN,
+            int WarpK, int GroupSize, int PackedMacroN>
   torch::Tensor operator()() const {
-    using Traits = Sm70MoeU8ZpGemmTraits<CtaM, CtaN, CtaK, Warps, WarpM,
-                                         WarpN, WarpK, GroupSize, PackedMacroN,
-                                         UseMetadataVectorWords>;
+    using Traits =
+        Sm70MoeU8ZpGemmTraits<CtaM, CtaN, CtaK, Warps, WarpM, WarpN, WarpK,
+                              GroupSize, PackedMacroN, UseMetadataVectorWords>;
     return launch_sm70_marlin_moe_gemm<Traits>(
         a, c, b_q_weight, b_scales, b_zeros, global_scale, sorted_token_ids,
-        expert_ids, num_tokens_past_padded, topk_weights, moe_block_size,
-        top_k, mul_topk_weights, size_m, size_n, size_k, requested_split_k);
+        expert_ids, num_tokens_past_padded, topk_weights, moe_block_size, top_k,
+        mul_topk_weights, size_m, size_n, size_k, requested_split_k);
   }
 };
 
@@ -475,9 +461,10 @@ torch::Tensor sm70_marlin_u8_gemm(
   auto const params = sm70_marlin_moe_auto_stage_params(
       "uint8", group_size, moe_block_size, top_k, size_m, size_n, size_k);
   Sm70CtaGeometry const geometry = params.geometry;
-  validate_sm70_marlin_moe_stage_cta_geometry_supported("SM70 Marlin MoE uint8", geometry);
-  validate_sm70_marlin_moe_stage_cta_n_alignment("SM70 Marlin MoE uint8", geometry,
-                                        size_n);
+  validate_sm70_marlin_moe_stage_cta_geometry_supported("SM70 Marlin MoE uint8",
+                                                        geometry);
+  validate_sm70_marlin_moe_stage_cta_n_alignment("SM70 Marlin MoE uint8",
+                                                 geometry, size_n);
   TORCH_CHECK(size_k % geometry.cta_k == 0,
               "SM70 Marlin MoE uint8 requires K divisible by CTA_K=",
               geometry.cta_k, ". Got K=", size_k, ".");
@@ -485,19 +472,45 @@ torch::Tensor sm70_marlin_u8_gemm(
   auto empty_float = torch::empty(
       {0}, torch::TensorOptions().dtype(at::kFloat).device(a.device()));
   if (params.use_metadata_vector_words) {
-    Sm70MoeU8Launcher<true> const launcher{
-        a, c, b_q_weight, b_scales, b_zeros, empty_float, sorted_token_ids,
-        expert_ids, num_tokens_past_padded, topk_weights, moe_block_size, top_k,
-        mul_topk_weights, size_m, size_n, size_k, params.requested_split_k};
-    return dispatch_sm70_marlin_moe_geometry_with_group32(launcher, geometry, params.packed_macro_n, group_size,
-        "uint8");
+    Sm70MoeU8Launcher<true> const launcher{a,
+                                           c,
+                                           b_q_weight,
+                                           b_scales,
+                                           b_zeros,
+                                           empty_float,
+                                           sorted_token_ids,
+                                           expert_ids,
+                                           num_tokens_past_padded,
+                                           topk_weights,
+                                           moe_block_size,
+                                           top_k,
+                                           mul_topk_weights,
+                                           size_m,
+                                           size_n,
+                                           size_k,
+                                           params.requested_split_k};
+    return dispatch_sm70_marlin_moe_geometry_with_group32(
+        launcher, geometry, params.packed_macro_n, group_size, "uint8");
   }
-  Sm70MoeU8Launcher<false> const launcher{
-      a, c, b_q_weight, b_scales, b_zeros, empty_float, sorted_token_ids,
-      expert_ids, num_tokens_past_padded, topk_weights, moe_block_size, top_k,
-      mul_topk_weights, size_m, size_n, size_k, params.requested_split_k};
-  return dispatch_sm70_marlin_moe_geometry_with_group32(launcher, geometry, params.packed_macro_n, group_size,
-      "uint8");
+  Sm70MoeU8Launcher<false> const launcher{a,
+                                          c,
+                                          b_q_weight,
+                                          b_scales,
+                                          b_zeros,
+                                          empty_float,
+                                          sorted_token_ids,
+                                          expert_ids,
+                                          num_tokens_past_padded,
+                                          topk_weights,
+                                          moe_block_size,
+                                          top_k,
+                                          mul_topk_weights,
+                                          size_m,
+                                          size_n,
+                                          size_k,
+                                          params.requested_split_k};
+  return dispatch_sm70_marlin_moe_geometry_with_group32(
+      launcher, geometry, params.packed_macro_n, group_size, "uint8");
 }
 
 }  // namespace marlin_moe_wna16

--- a/csrc/moe/marlin_moe_wna16/sm70_marlin_u8b128_gemm.cu
+++ b/csrc/moe/marlin_moe_wna16/sm70_marlin_u8b128_gemm.cu
@@ -35,22 +35,25 @@ class Sm70MoeU8B128IteratorB {
   static int const kPackedMacroN = PackedMacroN_;
   static constexpr bool kUseMetadataVectorWords = UseMetadataVectorWords_;
   using Element = cutlass::half_t;
-  using Fragment = cutlass::Array<
-      Element, ThreadMap::Iterations::kCount * ThreadMap::kElementsPerAccess>;
-    static_assert(Shape::kN == 64 || Shape::kN == 128 || Shape::kN == 256,
-                "SM70 Marlin MoE U8B128 IteratorB expects CTA_N in {64, 128, 256}.");
-  static_assert(ThreadMap::Iterations::kContiguous ==
-                    Shape::kN / kQuantTileN,
-                "SM70 Marlin MoE U8B128 IteratorB expects one contiguous iteration per "
-                "64-column quant tile.");
+  using Fragment = cutlass::Array<Element, ThreadMap::Iterations::kCount *
+                                               ThreadMap::kElementsPerAccess>;
+  static_assert(
+      Shape::kN == 64 || Shape::kN == 128 || Shape::kN == 256,
+      "SM70 Marlin MoE U8B128 IteratorB expects CTA_N in {64, 128, 256}.");
+  static_assert(
+      ThreadMap::Iterations::kContiguous == Shape::kN / kQuantTileN,
+      "SM70 Marlin MoE U8B128 IteratorB expects one contiguous iteration per "
+      "64-column quant tile.");
   static_assert(ThreadMap::Delta::kContiguous == kQuantTileN,
                 "SM70 Marlin MoE U8B128 IteratorB expects 64-column deltas.");
-  static_assert(ThreadMap::kElementsPerAccess == kU8B128ValuesPerAccess,
-                "SM70 Marlin MoE U8B128 IteratorB expects two packed U8B128 words "
-                "per access.");
-  static_assert(ThreadMap::Iterations::kStrided >= 1,
-                "SM70 Marlin MoE U8-family IteratorB expects one or more strided "
-                "iterations.");
+  static_assert(
+      ThreadMap::kElementsPerAccess == kU8B128ValuesPerAccess,
+      "SM70 Marlin MoE U8B128 IteratorB expects two packed U8B128 words "
+      "per access.");
+  static_assert(
+      ThreadMap::Iterations::kStrided >= 1,
+      "SM70 Marlin MoE U8-family IteratorB expects one or more strided "
+      "iterations.");
   static constexpr int kQweightWordStrideWords = kPackedMacroN / kQuantTileN;
 
   struct Params {
@@ -86,9 +89,8 @@ class Sm70MoeU8B128IteratorB {
                          half const* scales, half const*, int thread_id,
                          int expert, int k_offset, int n_offset)
       : qweight_(qweight),
-        scales_expert_base_(scales +
-                            (expert >= 0 ? expert : 0) *
-                                params.num_groups * params.size_n),
+        scales_expert_base_(scales + (expert >= 0 ? expert : 0) *
+                                         params.num_groups * params.size_n),
         params_(params),
         thread_offset_(ThreadMap::initial_offset(thread_id)),
         expert_(expert),
@@ -130,19 +132,17 @@ class Sm70MoeU8B128IteratorB {
   }
 
   CUTLASS_DEVICE
-  int metadata_group_offset(int group) const {
-    return group * params_.size_n;
-  }
+  int metadata_group_offset(int group) const { return group * params_.size_n; }
 
   CUTLASS_DEVICE
   int scale_group(int logical_k) const {
     if constexpr (kGroupSize == -1) {
       return 0;
     } else {
-      static_assert(kGroupSize == 32 || kGroupSize == 64 ||
-                        kGroupSize == 128,
-                    "SM70 Marlin MoE U8B128 supports only group sizes -1, 32, 64, "
-                    "and 128.");
+      static_assert(
+          kGroupSize == 32 || kGroupSize == 64 || kGroupSize == 128,
+          "SM70 Marlin MoE U8B128 supports only group sizes -1, 32, 64, "
+          "and 128.");
       return logical_k / kGroupSize;
     }
   }
@@ -157,8 +157,8 @@ class Sm70MoeU8B128IteratorB {
   CUTLASS_DEVICE
   void cache_metadata_lane_vectors(int c, int group, int cache_n) const {
     int const metadata_offset = metadata_group_offset(group) + cache_n;
-    half2 const* scale_vec = reinterpret_cast<half2 const*>(
-        scales_expert_base_ + metadata_offset);
+    half2 const* scale_vec =
+        reinterpret_cast<half2 const*>(scales_expert_base_ + metadata_offset);
     half2* scale_cache = cached_scales_ + c * 4;
     scale_cache[0] = scale_vec[0];
     scale_cache[1] = scale_vec[1];
@@ -169,8 +169,8 @@ class Sm70MoeU8B128IteratorB {
   CUTLASS_DEVICE
   void cache_metadata_vector_words(int c, int group, int cache_n) const {
     int const metadata_offset = metadata_group_offset(group) + cache_n;
-    uint4 const scale_words = *reinterpret_cast<uint4 const*>(
-        scales_expert_base_ + metadata_offset);
+    uint4 const scale_words =
+        *reinterpret_cast<uint4 const*>(scales_expert_base_ + metadata_offset);
     half2 const* scale_vec = reinterpret_cast<half2 const*>(&scale_words);
     half2* scale_cache = cached_scales_ + c * 4;
     scale_cache[0] = scale_vec[0];
@@ -183,9 +183,8 @@ class Sm70MoeU8B128IteratorB {
   void cache_current_group_metadata(int group) const {
     CUTLASS_PRAGMA_UNROLL
     for (int c = 0; c < ThreadMap::Iterations::kContiguous; ++c) {
-      int const cache_n =
-          n_offset_ + thread_offset_.contiguous() +
-          c * ThreadMap::Delta::kContiguous;
+      int const cache_n = n_offset_ + thread_offset_.contiguous() +
+                          c * ThreadMap::Delta::kContiguous;
       if constexpr (kUseMetadataVectorWords) {
         cache_metadata_vector_words(c, group, cache_n);
       } else {
@@ -246,8 +245,9 @@ class Sm70MoeU8B128IteratorB {
           frag_vec[3] = __hmul2(deq[1], scale_vec[3]);
         }
       } else {
-        static_assert(ThreadMap::Iterations::kContiguous == 1,
-                      "Unsupported SM70 Marlin MoE U8B128 contiguous iteration count.");
+        static_assert(
+            ThreadMap::Iterations::kContiguous == 1,
+            "Unsupported SM70 Marlin MoE U8B128 contiguous iteration count.");
         uint32_t const qword0 =
             load_qword_vector<1>(qweight_ + qweight_base_offset_);
         uint32_t const qword1 = load_qword_vector<1>(
@@ -269,9 +269,8 @@ class Sm70MoeU8B128IteratorB {
       int const logical_n_base = n_offset_ + thread_offset_.contiguous();
       CUTLASS_PRAGMA_UNROLL
       for (int s = 0; s < ThreadMap::Iterations::kStrided; ++s) {
-        int const logical_k_s =
-            k_offset_ + thread_offset_.strided() +
-            s * ThreadMap::Delta::kStrided;
+        int const logical_k_s = k_offset_ + thread_offset_.strided() +
+                                s * ThreadMap::Delta::kStrided;
         if constexpr (kGroupSize != -1) {
           cache_current_group_metadata(scale_group(logical_k_s));
         }
@@ -279,10 +278,9 @@ class Sm70MoeU8B128IteratorB {
             expert_qweight_base_offset() +
             qweight_offset_from_logical(params_, logical_k_s, logical_n_base);
         if constexpr (ThreadMap::Iterations::kContiguous == 4) {
-          uint4 const qwords0 =
-              load_qword_vector<4>(qweight_ + qweight_base_s);
-          uint4 const qwords1 = load_qword_vector<4>(
-              qweight_ + qweight_base_s + kQweightWordStrideWords);
+          uint4 const qwords0 = load_qword_vector<4>(qweight_ + qweight_base_s);
+          uint4 const qwords1 = load_qword_vector<4>(qweight_ + qweight_base_s +
+                                                     kQweightWordStrideWords);
           CUTLASS_PRAGMA_UNROLL
           for (int c = 0; c < ThreadMap::Iterations::kContiguous; ++c) {
             constexpr int kAccess = ThreadMap::kElementsPerAccess;
@@ -296,22 +294,17 @@ class Sm70MoeU8B128IteratorB {
             half2* frag_vec = reinterpret_cast<half2*>(frag.data() + frag_base);
             marlin::dequant<half2, vllm::kU8B128.id(), false>(
                 static_cast<int>(qword0), deq);
-            frag_vec[0] =
-                __hmul2(deq[0], scale_vec[0]);
-            frag_vec[1] =
-                __hmul2(deq[1], scale_vec[1]);
+            frag_vec[0] = __hmul2(deq[0], scale_vec[0]);
+            frag_vec[1] = __hmul2(deq[1], scale_vec[1]);
             marlin::dequant<half2, vllm::kU8B128.id(), false>(
                 static_cast<int>(qword1), deq);
-            frag_vec[2] =
-                __hmul2(deq[0], scale_vec[2]);
-            frag_vec[3] =
-                __hmul2(deq[1], scale_vec[3]);
+            frag_vec[2] = __hmul2(deq[0], scale_vec[2]);
+            frag_vec[3] = __hmul2(deq[1], scale_vec[3]);
           }
         } else if constexpr (ThreadMap::Iterations::kContiguous == 2) {
-          uint2 const qwords0 =
-              load_qword_vector<2>(qweight_ + qweight_base_s);
-          uint2 const qwords1 = load_qword_vector<2>(
-              qweight_ + qweight_base_s + kQweightWordStrideWords);
+          uint2 const qwords0 = load_qword_vector<2>(qweight_ + qweight_base_s);
+          uint2 const qwords1 = load_qword_vector<2>(qweight_ + qweight_base_s +
+                                                     kQweightWordStrideWords);
           CUTLASS_PRAGMA_UNROLL
           for (int c = 0; c < ThreadMap::Iterations::kContiguous; ++c) {
             constexpr int kAccess = ThreadMap::kElementsPerAccess;
@@ -325,20 +318,17 @@ class Sm70MoeU8B128IteratorB {
             half2* frag_vec = reinterpret_cast<half2*>(frag.data() + frag_base);
             marlin::dequant<half2, vllm::kU8B128.id(), false>(
                 static_cast<int>(qword0), deq);
-            frag_vec[0] =
-                __hmul2(deq[0], scale_vec[0]);
-            frag_vec[1] =
-                __hmul2(deq[1], scale_vec[1]);
+            frag_vec[0] = __hmul2(deq[0], scale_vec[0]);
+            frag_vec[1] = __hmul2(deq[1], scale_vec[1]);
             marlin::dequant<half2, vllm::kU8B128.id(), false>(
                 static_cast<int>(qword1), deq);
-            frag_vec[2] =
-                __hmul2(deq[0], scale_vec[2]);
-            frag_vec[3] =
-                __hmul2(deq[1], scale_vec[3]);
+            frag_vec[2] = __hmul2(deq[0], scale_vec[2]);
+            frag_vec[3] = __hmul2(deq[1], scale_vec[3]);
           }
         } else {
-          static_assert(ThreadMap::Iterations::kContiguous == 1,
-                        "Unsupported SM70 Marlin MoE U8B128 contiguous iteration count.");
+          static_assert(
+              ThreadMap::Iterations::kContiguous == 1,
+              "Unsupported SM70 Marlin MoE U8B128 contiguous iteration count.");
           uint32_t const qword0 =
               load_qword_vector<1>(qweight_ + qweight_base_s);
           uint32_t const qword1 = load_qword_vector<1>(
@@ -368,8 +358,7 @@ class Sm70MoeU8B128IteratorB {
       return;
     }
 
-    if constexpr (kGroupSize != -1 &&
-                  ThreadMap::Iterations::kStrided == 1) {
+    if constexpr (kGroupSize != -1 && ThreadMap::Iterations::kStrided == 1) {
       int const first_logical_k = k_offset_ + thread_offset_.strided();
       cache_current_group_metadata(scale_group(first_logical_k));
     }
@@ -393,13 +382,13 @@ struct Sm70MoeU8B128GemmSpec {
                              UseMetadataVectorWords>;
 };
 
-template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM,
-          int WarpN, int WarpK, int GroupSize, int PackedMacroN,
+template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM, int WarpN,
+          int WarpK, int GroupSize, int PackedMacroN,
           bool UseMetadataVectorWords = true>
 using Sm70MoeU8B128GemmTraits =
-    Sm70MarlinMoeGemmTraits<
-        Sm70MoeU8B128GemmSpec<UseMetadataVectorWords>, CtaM, CtaN, CtaK,
-        Warps, WarpM, WarpN, WarpK, GroupSize, PackedMacroN>;
+    Sm70MarlinMoeGemmTraits<Sm70MoeU8B128GemmSpec<UseMetadataVectorWords>, CtaM,
+                            CtaN, CtaK, Warps, WarpM, WarpN, WarpK, GroupSize,
+                            PackedMacroN>;
 
 template <bool UseMetadataVectorWords = true>
 struct Sm70MoeU8B128Launcher {
@@ -421,16 +410,17 @@ struct Sm70MoeU8B128Launcher {
   int64_t size_k;
   int requested_split_k;
 
-  template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM,
-          int WarpN, int WarpK, int GroupSize, int PackedMacroN>
+  template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM, int WarpN,
+            int WarpK, int GroupSize, int PackedMacroN>
   torch::Tensor operator()() const {
-    using Traits = Sm70MoeU8B128GemmTraits<CtaM, CtaN, CtaK, Warps, WarpM,
-                                           WarpN, WarpK, GroupSize, PackedMacroN,
-                                           UseMetadataVectorWords>;
+    using Traits =
+        Sm70MoeU8B128GemmTraits<CtaM, CtaN, CtaK, Warps, WarpM, WarpN, WarpK,
+                                GroupSize, PackedMacroN,
+                                UseMetadataVectorWords>;
     return launch_sm70_marlin_moe_gemm<Traits>(
         a, c, b_q_weight, b_scales, b_zeros, global_scale, sorted_token_ids,
-        expert_ids, num_tokens_past_padded, topk_weights, moe_block_size,
-        top_k, mul_topk_weights, size_m, size_n, size_k, requested_split_k);
+        expert_ids, num_tokens_past_padded, topk_weights, moe_block_size, top_k,
+        mul_topk_weights, size_m, size_n, size_k, requested_split_k);
   }
 };
 
@@ -448,9 +438,10 @@ torch::Tensor sm70_marlin_u8b128_gemm(
   auto const params = sm70_marlin_moe_auto_stage_params(
       "uint8b128", group_size, moe_block_size, top_k, size_m, size_n, size_k);
   Sm70CtaGeometry const geometry = params.geometry;
-  validate_sm70_marlin_moe_stage_cta_geometry_supported("SM70 Marlin MoE uint8b128", geometry);
-  validate_sm70_marlin_moe_stage_cta_n_alignment("SM70 Marlin MoE uint8b128", geometry,
-                                        size_n);
+  validate_sm70_marlin_moe_stage_cta_geometry_supported(
+      "SM70 Marlin MoE uint8b128", geometry);
+  validate_sm70_marlin_moe_stage_cta_n_alignment("SM70 Marlin MoE uint8b128",
+                                                 geometry, size_n);
   TORCH_CHECK(size_k % geometry.cta_k == 0,
               "SM70 Marlin MoE uint8b128 requires K divisible by CTA_K=",
               geometry.cta_k, ". Got K=", size_k, ".");
@@ -459,17 +450,43 @@ torch::Tensor sm70_marlin_u8b128_gemm(
   auto empty_float = torch::empty(
       {0}, torch::TensorOptions().dtype(at::kFloat).device(a.device()));
   if (params.use_metadata_vector_words) {
-    Sm70MoeU8B128Launcher<true> const launcher{
-        a, c, b_q_weight, b_scales, empty_half, empty_float, sorted_token_ids,
-        expert_ids, num_tokens_past_padded, topk_weights, moe_block_size, top_k,
-        mul_topk_weights, size_m, size_n, size_k, params.requested_split_k};
+    Sm70MoeU8B128Launcher<true> const launcher{a,
+                                               c,
+                                               b_q_weight,
+                                               b_scales,
+                                               empty_half,
+                                               empty_float,
+                                               sorted_token_ids,
+                                               expert_ids,
+                                               num_tokens_past_padded,
+                                               topk_weights,
+                                               moe_block_size,
+                                               top_k,
+                                               mul_topk_weights,
+                                               size_m,
+                                               size_n,
+                                               size_k,
+                                               params.requested_split_k};
     return dispatch_sm70_marlin_moe_geometry_with_group32(
         launcher, geometry, params.packed_macro_n, group_size, "uint8b128");
   }
-  Sm70MoeU8B128Launcher<false> const launcher{
-      a, c, b_q_weight, b_scales, empty_half, empty_float, sorted_token_ids,
-      expert_ids, num_tokens_past_padded, topk_weights, moe_block_size, top_k,
-      mul_topk_weights, size_m, size_n, size_k, params.requested_split_k};
+  Sm70MoeU8B128Launcher<false> const launcher{a,
+                                              c,
+                                              b_q_weight,
+                                              b_scales,
+                                              empty_half,
+                                              empty_float,
+                                              sorted_token_ids,
+                                              expert_ids,
+                                              num_tokens_past_padded,
+                                              topk_weights,
+                                              moe_block_size,
+                                              top_k,
+                                              mul_topk_weights,
+                                              size_m,
+                                              size_n,
+                                              size_k,
+                                              params.requested_split_k};
   return dispatch_sm70_marlin_moe_geometry_with_group32(
       launcher, geometry, params.packed_macro_n, group_size, "uint8b128");
 }

--- a/csrc/moe/moe_permute_unpermute_op.cu
+++ b/csrc/moe/moe_permute_unpermute_op.cu
@@ -28,9 +28,7 @@ torch::Tensor maybe_allocate_tensor(
   return torch::empty(expected_sizes, torch::dtype(dtype).device(device));
 }
 
-int64_t pad_to_multiple_of_16(int64_t value) {
-  return (value + 15) / 16 * 16;
-}
+int64_t pad_to_multiple_of_16(int64_t value) { return (value + 15) / 16 * 16; }
 
 }  // namespace
 
@@ -72,16 +70,15 @@ void moe_permute_impl(
   auto expanded_rows = n_token * topk;
   auto stream = at::cuda::getCurrentCUDAStream().stream();
 
-  if (canUseSingleTokenMoePermuteFastPath(
-          n_token, topk, expert_map.has_value(), n_expert, n_local_expert)) {
+  if (canUseSingleTokenMoePermuteFastPath(n_token, topk, expert_map.has_value(),
+                                          n_expert, n_local_expert)) {
     if (input.scalar_type() == at::ScalarType::Half) {
       singleTokenMoePermuteLauncher<half>(
           get_ptr<half>(input), get_ptr<int>(topk_ids),
           get_ptr<half>(permuted_input),
           get_ptr<int64_t>(expert_first_token_offset),
           get_ptr<int>(inv_permuted_idx), get_ptr<int>(permuted_idx),
-          static_cast<int>(n_expert), static_cast<int>(topk), n_hidden,
-          stream);
+          static_cast<int>(n_expert), static_cast<int>(topk), n_hidden, stream);
       return;
     }
     if (input.scalar_type() == at::ScalarType::BFloat16) {
@@ -90,8 +87,7 @@ void moe_permute_impl(
           get_ptr<__nv_bfloat16>(permuted_input),
           get_ptr<int64_t>(expert_first_token_offset),
           get_ptr<int>(inv_permuted_idx), get_ptr<int>(permuted_idx),
-          static_cast<int>(n_expert), static_cast<int>(topk), n_hidden,
-          stream);
+          static_cast<int>(n_expert), static_cast<int>(topk), n_hidden, stream);
       return;
     }
     if (input.scalar_type() == at::ScalarType::Float) {
@@ -100,8 +96,7 @@ void moe_permute_impl(
           get_ptr<float>(permuted_input),
           get_ptr<int64_t>(expert_first_token_offset),
           get_ptr<int>(inv_permuted_idx), get_ptr<int>(permuted_idx),
-          static_cast<int>(n_expert), static_cast<int>(topk), n_hidden,
-          stream);
+          static_cast<int>(n_expert), static_cast<int>(topk), n_hidden, stream);
       return;
     }
   }

--- a/csrc/moe/permute_unpermute_kernels/moe_permute_unpermute_kernel.cu
+++ b/csrc/moe/permute_unpermute_kernels/moe_permute_unpermute_kernel.cu
@@ -93,10 +93,12 @@ bool singleTokenUnpermuteFastPathEnabled() {
 }
 
 template <typename T>
-__global__ void singleTokenMoePermuteKernel(
-    T const* input, int const* topk_ids, T* permuted_output,
-    int64_t* expert_first_token_offset, int* inv_permuted_idx,
-    int* permuted_idx, int num_experts, int topk, int64_t cols) {
+__global__ void singleTokenMoePermuteKernel(T const* input, int const* topk_ids,
+                                            T* permuted_output,
+                                            int64_t* expert_first_token_offset,
+                                            int* inv_permuted_idx,
+                                            int* permuted_idx, int num_experts,
+                                            int topk, int64_t cols) {
   __shared__ int sorted_ids[kSingleTokenFastPathMaxTopK];
   __shared__ int sorted_src[kSingleTokenFastPathMaxTopK];
 
@@ -177,8 +179,8 @@ __global__ void singleTokenMoeUnpermuteKernel(
 
   auto const* expanded_rows_v =
       reinterpret_cast<InputElem const*>(expanded_permuted_rows);
-  auto* reduced_row_ptr_v = reinterpret_cast<OutputElem*>(
-      reduced_unpermuted_output);
+  auto* reduced_row_ptr_v =
+      reinterpret_cast<OutputElem*>(reduced_unpermuted_output);
   int64_t const num_elems_in_col = cols / FINALIZE_ELEM_PER_THREAD;
 
   for (int64_t elem_index = threadIdx.x; elem_index < num_elems_in_col;
@@ -186,7 +188,7 @@ __global__ void singleTokenMoeUnpermuteKernel(
     ComputeElem thread_output;
     thread_output.fill(0);
 
-#pragma unroll
+  #pragma unroll
     for (int k_idx = 0; k_idx < kSingleTokenFastPathMaxTopK; ++k_idx) {
       if (k_idx >= topk) {
         break;
@@ -222,11 +224,12 @@ bool canUseSingleTokenMoePermuteFastPath(int64_t n_token, int64_t topk,
 }
 
 template <typename T>
-void singleTokenMoePermuteLauncher(
-    T const* input, int const* topk_ids, T* permuted_output,
-    int64_t* expert_first_token_offset, int* inv_permuted_idx,
-    int* permuted_idx, int num_experts, int topk, int64_t cols,
-    cudaStream_t stream) {
+void singleTokenMoePermuteLauncher(T const* input, int const* topk_ids,
+                                   T* permuted_output,
+                                   int64_t* expert_first_token_offset,
+                                   int* inv_permuted_idx, int* permuted_idx,
+                                   int num_experts, int topk, int64_t cols,
+                                   cudaStream_t stream) {
   constexpr int threads = 256;
   singleTokenMoePermuteKernel<T><<<1, threads, 0, stream>>>(
       input, topk_ids, permuted_output, expert_first_token_offset,

--- a/csrc/moe/permute_unpermute_kernels/moe_permute_unpermute_kernel.h
+++ b/csrc/moe/permute_unpermute_kernels/moe_permute_unpermute_kernel.h
@@ -80,11 +80,12 @@ bool canUseSingleTokenMoePermuteFastPath(int64_t n_token, int64_t topk,
                                          int64_t n_local_expert);
 
 template <typename T>
-void singleTokenMoePermuteLauncher(
-    T const* input, int const* topk_ids, T* permuted_output,
-    int64_t* expert_first_token_offset, int* inv_permuted_idx,
-    int* permuted_idx, int num_experts, int topk, int64_t cols,
-    cudaStream_t stream);
+void singleTokenMoePermuteLauncher(T const* input, int const* topk_ids,
+                                   T* permuted_output,
+                                   int64_t* expert_first_token_offset,
+                                   int* inv_permuted_idx, int* permuted_idx,
+                                   int num_experts, int topk, int64_t cols,
+                                   cudaStream_t stream);
 
 bool canUseSingleTokenMoeUnpermuteFastPath(int64_t n_token, int64_t topk);
 

--- a/csrc/quantization/marlin/sm70_awq_marlin_repack.cu
+++ b/csrc/quantization/marlin/sm70_awq_marlin_repack.cu
@@ -92,8 +92,7 @@ __global__ void awq_marlin_repack_kernel(
       constexpr int sh_stride = tile_n_ints;
       int4* sh_stage_ptr = sh + stage_size * pipe;
       uint32_t* sh_stage_int_ptr = reinterpret_cast<uint32_t*>(sh_stage_ptr);
-      uint32_t packed_src =
-          sh_stage_int_ptr[local_k * sh_stride + local_n_vec];
+      uint32_t packed_src = sh_stage_int_ptr[local_k * sh_stride + local_n_vec];
 
       constexpr int undo_pack[8] = {0, 4, 1, 5, 2, 6, 3, 7};
       constexpr int pack_idx[8] = {0, 2, 4, 6, 1, 3, 5, 7};
@@ -114,9 +113,8 @@ __global__ void awq_marlin_repack_kernel(
       int const cta_first_n_tile = cta_n_tile * cta_n_tiles;
       int const subtile = n_tile_id - cta_first_n_tile;
       int const local_word = local_k * 8 + local_n_vec;
-      int const cta_n_offset =
-          cta_n_tile * cta_n_tiles * tile_size +
-          local_word * cta_n_tiles + subtile;
+      int const cta_n_offset = cta_n_tile * cta_n_tiles * tile_size +
+                               local_word * cta_n_tiles + subtile;
       out_ptr[k_tile_id * n_tiles * tile_size + cta_n_offset] = res;
       return;
     }
@@ -155,9 +153,8 @@ __global__ void awq_marlin_repack_kernel(
       int const cta_first_n_tile = cta_n_tile * cta_n_tiles;
       int const subtile = n_tile_id - cta_first_n_tile;
       int const local_word = local_k * 16 + local_n_word;
-      int const cta_n_offset =
-          cta_n_tile * cta_n_tiles * tile_size +
-          local_word * cta_n_tiles + subtile;
+      int const cta_n_offset = cta_n_tile * cta_n_tiles * tile_size +
+                               local_word * cta_n_tiles + subtile;
       out_ptr[k_tile_id * n_tiles * tile_size + cta_n_offset] = res;
       return;
     }
@@ -304,16 +301,15 @@ __global__ void awq_marlin_repack_kernel(
             b_q_weight_ptr, out_ptr, size_k, size_n);                      \
   } else
 
-#define CALL_FOR_CTA(CTA_N)                                                \
-  do {                                                                     \
-    CALL_IF(4, false, CTA_N)                                               \
-    CALL_IF(8, false, CTA_N)                                               \
-    CALL_IF(4, true, CTA_N)                                                \
-    CALL_IF(8, true, CTA_N)                                                \
-    {                                                                      \
-      TORCH_CHECK(false, "Unsupported repack config: num_bits = ",         \
-                  num_bits, ", is_a_8bit = ", is_a_8bit);                 \
-    }                                                                      \
+#define CALL_FOR_CTA(CTA_N)                                                  \
+  do {                                                                       \
+    CALL_IF(4, false, CTA_N)                                                 \
+    CALL_IF(8, false, CTA_N)                                                 \
+    CALL_IF(4, true, CTA_N)                                                  \
+    CALL_IF(8, true, CTA_N) {                                                \
+      TORCH_CHECK(false, "Unsupported repack config: num_bits = ", num_bits, \
+                  ", is_a_8bit = ", is_a_8bit);                              \
+    }                                                                        \
   } while (false)
 
 torch::Tensor awq_marlin_repack(torch::Tensor& b_q_weight, int64_t size_k,

--- a/csrc/quantization/marlin/sm70_gptq_marlin_repack.cu
+++ b/csrc/quantization/marlin/sm70_gptq_marlin_repack.cu
@@ -164,9 +164,8 @@ __global__ void gptq_marlin_repack_kernel(
       int const cta_first_n_tile = cta_n_tile * cta_n_tiles;
       int const subtile = n_tile_id - cta_first_n_tile;
       int const local_word = local_k * 8 + local_n_vec;
-      int const cta_n_offset =
-          cta_n_tile * cta_n_tiles * tile_size +
-          local_word * cta_n_tiles + subtile;
+      int const cta_n_offset = cta_n_tile * cta_n_tiles * tile_size +
+                               local_word * cta_n_tiles + subtile;
       out_ptr[k_tile_id * n_tiles * tile_size + cta_n_offset] = res;
       return;
     }
@@ -215,9 +214,8 @@ __global__ void gptq_marlin_repack_kernel(
       int const cta_first_n_tile = cta_n_tile * cta_n_tiles;
       int const subtile = n_tile_id - cta_first_n_tile;
       int const local_word = local_k * 16 + local_n_word;
-      int const cta_n_offset =
-          cta_n_tile * cta_n_tiles * tile_size +
-          local_word * cta_n_tiles + subtile;
+      int const cta_n_offset = cta_n_tile * cta_n_tiles * tile_size +
+                               local_word * cta_n_tiles + subtile;
       out_ptr[k_tile_id * n_tiles * tile_size + cta_n_offset] = res;
       return;
     }
@@ -381,19 +379,17 @@ __global__ void gptq_marlin_repack_kernel(
             b_q_weight_ptr, perm_ptr, out_ptr, size_k, size_n);             \
   } else
 
-#define CALL_FOR_CTA(CTA_N)                                                 \
-  do {                                                                      \
-    CALL_IF(4, false, false, CTA_N)                                         \
-    CALL_IF(4, true, false, CTA_N)                                          \
-    CALL_IF(8, false, false, CTA_N)                                         \
-    CALL_IF(8, true, false, CTA_N)                                          \
-    CALL_IF(4, false, true, CTA_N)                                          \
-    CALL_IF(8, false, true, CTA_N)                                          \
-    {                                                                       \
-      TORCH_CHECK(false, "Unsupported repack config: num_bits = ",          \
-                  num_bits, ", has_perm = ", has_perm,                     \
-                  ", is_a_8bit = ", is_a_8bit);                            \
-    }                                                                       \
+#define CALL_FOR_CTA(CTA_N)                                                  \
+  do {                                                                       \
+    CALL_IF(4, false, false, CTA_N)                                          \
+    CALL_IF(4, true, false, CTA_N)                                           \
+    CALL_IF(8, false, false, CTA_N)                                          \
+    CALL_IF(8, true, false, CTA_N)                                           \
+    CALL_IF(4, false, true, CTA_N)                                           \
+    CALL_IF(8, false, true, CTA_N) {                                         \
+      TORCH_CHECK(false, "Unsupported repack config: num_bits = ", num_bits, \
+                  ", has_perm = ", has_perm, ", is_a_8bit = ", is_a_8bit);   \
+    }                                                                        \
   } while (false)
 
 torch::Tensor gptq_marlin_repack(torch::Tensor& b_q_weight, torch::Tensor& perm,

--- a/csrc/quantization/marlin/sm70_marlin_common.cuh
+++ b/csrc/quantization/marlin/sm70_marlin_common.cuh
@@ -28,31 +28,29 @@ inline size_t configure_sm70_dynamic_smem(Kernel kernel) {
   return smem_bytes;
 }
 
-constexpr int sm70_const_min(int lhs, int rhs) {
-  return lhs < rhs ? lhs : rhs;
-}
+constexpr int sm70_const_min(int lhs, int rhs) { return lhs < rhs ? lhs : rhs; }
 
-constexpr bool sm70_marlin_basic_geometry_values_supported(
-    int cta_m, int cta_n, int cta_k, int warps, int warp_m, int warp_n,
-    int warp_k) {
+constexpr bool sm70_marlin_basic_geometry_values_supported(int cta_m, int cta_n,
+                                                           int cta_k, int warps,
+                                                           int warp_m,
+                                                           int warp_n,
+                                                           int warp_k) {
   return (cta_m == 32 || cta_m == 64 || cta_m == 128 || cta_m == 256) &&
          (cta_n == 64 || cta_n == 128 || cta_n == 256) &&
          (cta_k == 16 || cta_k == 32 || cta_k == 64 || cta_k == 128) &&
-         (warps == 4 || warps == 8) &&
-         (warp_m == 32 || warp_m == 64) &&
-         (warp_n == 32 || warp_n == 64) &&
-         (warp_k == 16 || warp_k == 32);
+         (warps == 4 || warps == 8) && (warp_m == 32 || warp_m == 64) &&
+         (warp_n == 32 || warp_n == 64) && (warp_k == 16 || warp_k == 32);
 }
 
-constexpr bool sm70_marlin_warp_decomposition_supported(
-    int cta_m, int cta_n, int cta_k, int warps, int warp_m, int warp_n,
-    int warp_k) {
-  if (!sm70_marlin_basic_geometry_values_supported(
-          cta_m, cta_n, cta_k, warps, warp_m, warp_n, warp_k)) {
+constexpr bool sm70_marlin_warp_decomposition_supported(int cta_m, int cta_n,
+                                                        int cta_k, int warps,
+                                                        int warp_m, int warp_n,
+                                                        int warp_k) {
+  if (!sm70_marlin_basic_geometry_values_supported(cta_m, cta_n, cta_k, warps,
+                                                   warp_m, warp_n, warp_k)) {
     return false;
   }
-  if (cta_m % warp_m != 0 || cta_n % warp_n != 0 ||
-      cta_k % warp_k != 0) {
+  if (cta_m % warp_m != 0 || cta_n % warp_n != 0 || cta_k % warp_k != 0) {
     return false;
   }
   return (cta_m / warp_m) * (cta_n / warp_n) * (cta_k / warp_k) == warps;
@@ -65,8 +63,7 @@ constexpr bool sm70_marlin_pitchlinear_threadmap_supported(
   if (shape_contiguous % elements_per_access != 0) {
     return false;
   }
-  int const shape_access_contiguous =
-      shape_contiguous / elements_per_access;
+  int const shape_access_contiguous = shape_contiguous / elements_per_access;
   int const shape_access_strided = shape_strided;
   if (shape_access_contiguous % warp_thread_contiguous != 0 ||
       shape_access_strided % warp_thread_strided != 0) {
@@ -74,8 +71,7 @@ constexpr bool sm70_marlin_pitchlinear_threadmap_supported(
   }
   int const warp_access_contiguous =
       shape_access_contiguous / warp_thread_contiguous;
-  int const warp_access_strided =
-      shape_access_strided / warp_thread_strided;
+  int const warp_access_strided = shape_access_strided / warp_thread_strided;
   int const warp_count = threads / 32;
   if (warp_access_strided <= 0 || warp_count <= 0) {
     return false;
@@ -90,43 +86,40 @@ constexpr bool sm70_marlin_pitchlinear_threadmap_supported(
   if (warps_contiguous <= 0) {
     return false;
   }
-  int const iterations_contiguous =
-      warp_access_contiguous / warps_contiguous;
+  int const iterations_contiguous = warp_access_contiguous / warps_contiguous;
   int const iterations_strided = warp_access_strided / warps_strided;
   return iterations_contiguous > 0 && iterations_strided > 0;
 }
 
-constexpr bool sm70_marlin_b_threadmap_matches_quant_iterator(
-    int cta_n, int cta_k, int threads) {
+constexpr bool sm70_marlin_b_threadmap_matches_quant_iterator(int cta_n,
+                                                              int cta_k,
+                                                              int threads) {
   constexpr int kElementsPerAccess = 8;
   constexpr int kWarpThreadContiguous = 8;
   constexpr int kWarpThreadStrided = 4;
   if (!sm70_marlin_pitchlinear_threadmap_supported(
-          cta_n, cta_k, threads, kWarpThreadContiguous,
-          kWarpThreadStrided, kElementsPerAccess)) {
+          cta_n, cta_k, threads, kWarpThreadContiguous, kWarpThreadStrided,
+          kElementsPerAccess)) {
     return false;
   }
   int const shape_access_contiguous = cta_n / kElementsPerAccess;
   int const shape_access_strided = cta_k;
   int const warp_access_contiguous =
       shape_access_contiguous / kWarpThreadContiguous;
-  int const warp_access_strided =
-      shape_access_strided / kWarpThreadStrided;
+  int const warp_access_strided = shape_access_strided / kWarpThreadStrided;
   int const warp_count = threads / 32;
   int const warps_strided =
       warp_access_strided >= warp_count ? warp_count : warp_access_strided;
   int const warps_contiguous =
       warp_count > warp_access_strided ? warp_count / warps_strided : 1;
-  int const iterations_contiguous =
-      warp_access_contiguous / warps_contiguous;
-  int const delta_contiguous =
-      kWarpThreadContiguous * kElementsPerAccess;
+  int const iterations_contiguous = warp_access_contiguous / warps_contiguous;
+  int const delta_contiguous = kWarpThreadContiguous * kElementsPerAccess;
   return iterations_contiguous == cta_n / kQuantTileN &&
          delta_contiguous == kQuantTileN;
 }
 
-constexpr bool sm70_marlin_volta_epilogue_supported(
-    int cta_m, int cta_n, int warps, int warp_m) {
+constexpr bool sm70_marlin_volta_epilogue_supported(int cta_m, int cta_n,
+                                                    int warps, int warp_m) {
   constexpr int kShapeRow = 4;
   constexpr int kShapeGroup = 4;
   constexpr int kElementsPerAccess = 8;
@@ -183,8 +176,8 @@ constexpr bool sm70_marlin_volta_epilogue_supported(
 constexpr bool sm70_marlin_cta_geometry_is_supported_constexpr(
     int cta_m, int cta_n, int cta_k, int warps, int warp_m, int warp_n,
     int warp_k) {
-  if (!sm70_marlin_warp_decomposition_supported(
-          cta_m, cta_n, cta_k, warps, warp_m, warp_n, warp_k)) {
+  if (!sm70_marlin_warp_decomposition_supported(cta_m, cta_n, cta_k, warps,
+                                                warp_m, warp_n, warp_k)) {
     return false;
   }
   int const threads = warps * 32;
@@ -192,12 +185,11 @@ constexpr bool sm70_marlin_cta_geometry_is_supported_constexpr(
   // DefaultMmaCore. Its A/B thread maps are fixed to 128-bit half loads.
   // CTA_K=16 is a mathematical GEMM shape but does not provide enough
   // contiguous A accesses for that thread map.
-  if (!sm70_marlin_pitchlinear_threadmap_supported(
-          cta_k, cta_m, threads, 4, 8, 8)) {
+  if (!sm70_marlin_pitchlinear_threadmap_supported(cta_k, cta_m, threads, 4, 8,
+                                                   8)) {
     return false;
   }
-  if (!sm70_marlin_b_threadmap_matches_quant_iterator(cta_n, cta_k,
-                                                      threads)) {
+  if (!sm70_marlin_b_threadmap_matches_quant_iterator(cta_n, cta_k, threads)) {
     return false;
   }
   return sm70_marlin_volta_epilogue_supported(cta_m, cta_n, warps, warp_m);
@@ -212,8 +204,7 @@ struct Sm70WarpShape {
                 "SM70 Marlin supports CTA_N in {64, 128, 256}.");
   static_assert(CtaK == 16 || CtaK == 32 || CtaK == 64 || CtaK == 128,
                 "SM70 Marlin supports CTA_K in {16, 32, 64, 128}.");
-  static_assert(Warps == 4 || Warps == 8,
-                "SM70 Marlin supports 4 or 8 warps.");
+  static_assert(Warps == 4 || Warps == 8, "SM70 Marlin supports 4 or 8 warps.");
   static_assert(WarpM == 32 || WarpM == 64,
                 "SM70 Marlin supports Warp_M in {32, 64}.");
   static_assert(WarpN == 32 || WarpN == 64,
@@ -283,8 +274,7 @@ inline constexpr char const* kSupportedSm70MarlinCtaGeometries =
     "decomposition, current CUTLASS Volta thread-map support, and "
     "phase-aware SM70 Marlin warp-K offset support.";
 
-inline bool sm70_marlin_cta_geometry_is_supported(
-    Sm70CtaGeometry geometry) {
+inline bool sm70_marlin_cta_geometry_is_supported(Sm70CtaGeometry geometry) {
   return sm70_marlin_cta_geometry_is_supported_constexpr(
       geometry.cta_m, geometry.cta_n, geometry.cta_k, geometry.warps,
       geometry.warp_m, geometry.warp_n, geometry.warp_k);
@@ -300,8 +290,10 @@ inline int sm70_marlin_auto_packed_macro_n(int64_t size_n) {
   if (size_n % 64 == 0) {
     return 64;
   }
-  TORCH_CHECK(false, "SM70 Marlin requires size_n divisible "
-                     "by 64. Got size_n = ", size_n, ".");
+  TORCH_CHECK(false,
+              "SM70 Marlin requires size_n divisible "
+              "by 64. Got size_n = ",
+              size_n, ".");
   return 0;
 }
 
@@ -309,14 +301,12 @@ inline bool sm70_marlin_packed_macro_n_is_supported(int packed_macro_n) {
   return packed_macro_n == 64 || packed_macro_n == 128 || packed_macro_n == 256;
 }
 
-inline bool sm70_marlin_requested_split_k_is_supported(
-    int requested_split_k) {
+inline bool sm70_marlin_requested_split_k_is_supported(int requested_split_k) {
   return requested_split_k == 1 || requested_split_k == 2 ||
          requested_split_k == 4 || requested_split_k == 8;
 }
 
-inline Sm70MarlinAutoParams sm70_marlin_default_auto_params(
-    int packed_macro_n);
+inline Sm70MarlinAutoParams sm70_marlin_default_auto_params(int packed_macro_n);
 
 inline Sm70CtaGeometry sm70_marlin_default_geometry_from_packed_macro_n(
     int packed_macro_n) {
@@ -328,8 +318,8 @@ inline Sm70CtaGeometry sm70_marlin_default_geometry_from_packed_macro_n(
     case 256:
       return {32, 256, 32, 4, 32, 64, 32};
     default:
-      TORCH_CHECK(false, "Unsupported SM70 Marlin packed macro-N=",
-                  packed_macro_n,
+      TORCH_CHECK(false,
+                  "Unsupported SM70 Marlin packed macro-N=", packed_macro_n,
                   ".");
   }
   return {0, 0, 0, 0, 0, 0, 0};
@@ -337,10 +327,8 @@ inline Sm70CtaGeometry sm70_marlin_default_geometry_from_packed_macro_n(
 
 inline Sm70MarlinAutoParams sm70_marlin_default_auto_params(
     int packed_macro_n) {
-  return {sm70_marlin_default_geometry_from_packed_macro_n(packed_macro_n),
-          1,
-          true,
-          packed_macro_n};
+  return {sm70_marlin_default_geometry_from_packed_macro_n(packed_macro_n), 1,
+          true, packed_macro_n};
 }
 
 inline bool sm70_marlin_parse_int_component(char const*& cursor, int& value) {
@@ -386,9 +374,10 @@ inline bool sm70_marlin_try_get_geometry_env(char const* env_name,
   if (value == nullptr || value[0] == '\0') {
     return false;
   }
-  TORCH_CHECK(sm70_marlin_parse_geometry_env_value(value, geometry),
-              "Invalid ", env_name, " value '", value,
-              "'. Expected {CTA_M}x{CTA_N}x{CTA_K}x{Warps}x{WarpM}x{WarpN}x{WarpK}.");
+  TORCH_CHECK(
+      sm70_marlin_parse_geometry_env_value(value, geometry), "Invalid ",
+      env_name, " value '", value,
+      "'. Expected {CTA_M}x{CTA_N}x{CTA_K}x{Warps}x{WarpM}x{WarpN}x{WarpK}.");
   return true;
 }
 
@@ -409,8 +398,8 @@ inline bool sm70_marlin_try_get_split_k_env(char const* env_name,
   return true;
 }
 
-inline bool sm70_marlin_try_get_metadata_env(
-    char const* env_name, bool& use_metadata_vector_words) {
+inline bool sm70_marlin_try_get_metadata_env(char const* env_name,
+                                             bool& use_metadata_vector_words) {
   char const* value = std::getenv(env_name);
   if (value == nullptr || value[0] == '\0') {
     return false;
@@ -433,9 +422,9 @@ inline bool sm70_marlin_env_is_set(char const* env_name) {
   return value != nullptr && value[0] != '\0';
 }
 
-inline bool sm70_marlin_any_auto_env_is_set(
-    char const* geometry_env_name, char const* split_k_env_name,
-    char const* metadata_env_name) {
+inline bool sm70_marlin_any_auto_env_is_set(char const* geometry_env_name,
+                                            char const* split_k_env_name,
+                                            char const* metadata_env_name) {
   return sm70_marlin_env_is_set(geometry_env_name) ||
          sm70_marlin_env_is_set(split_k_env_name) ||
          sm70_marlin_env_is_set(metadata_env_name);
@@ -447,14 +436,13 @@ inline void validate_sm70_marlin_packed_macro_n(char const* op_name,
   TORCH_CHECK(sm70_marlin_packed_macro_n_is_supported(packed_macro_n),
               "Unsupported SM70 Marlin packed macro-N for ", op_name, ": ",
               packed_macro_n, ".");
-  TORCH_CHECK(packed_macro_n % geometry.cta_n == 0,
-              "SM70 Marlin ", op_name,
+  TORCH_CHECK(packed_macro_n % geometry.cta_n == 0, "SM70 Marlin ", op_name,
               " requires PackedMacroN divisible by CTA_N. Got PackedMacroN=",
               packed_macro_n, ", CTA_N=", geometry.cta_n, ".");
 }
 
-inline void validate_sm70_marlin_auto_params(
-    char const* op_name, Sm70MarlinAutoParams params) {
+inline void validate_sm70_marlin_auto_params(char const* op_name,
+                                             Sm70MarlinAutoParams params) {
   TORCH_CHECK(sm70_marlin_cta_geometry_is_supported(params.geometry),
               "Unsupported SM70 Marlin CTA geometry for ", op_name, ": ",
               params.geometry.cta_m, "x", params.geometry.cta_n, "x",
@@ -474,8 +462,7 @@ inline Sm70MarlinAutoParams sm70_marlin_auto_params_from_env(
     char const* op_name, char const* geometry_env_name,
     char const* split_k_env_name, char const* metadata_env_name,
     int packed_macro_n) {
-  Sm70MarlinAutoParams params =
-      sm70_marlin_default_auto_params(packed_macro_n);
+  Sm70MarlinAutoParams params = sm70_marlin_default_auto_params(packed_macro_n);
   sm70_marlin_try_get_geometry_env(geometry_env_name, params.geometry);
   sm70_marlin_try_get_split_k_env(split_k_env_name, params.requested_split_k);
   sm70_marlin_try_get_metadata_env(metadata_env_name,
@@ -485,31 +472,27 @@ inline Sm70MarlinAutoParams sm70_marlin_auto_params_from_env(
 }
 
 inline bool sm70_marlin_dense_auto_env_is_set() {
-  return sm70_marlin_any_auto_env_is_set(
-      "SM70_MARLIN_DENSE_CTA_GEOMETRY", "SM70_MARLIN_DENSE_SPLIT_K",
-      "SM70_MARLIN_DENSE_METADATA_CACHE");
+  return sm70_marlin_any_auto_env_is_set("SM70_MARLIN_DENSE_CTA_GEOMETRY",
+                                         "SM70_MARLIN_DENSE_SPLIT_K",
+                                         "SM70_MARLIN_DENSE_METADATA_CACHE");
 }
 
 inline Sm70MarlinAutoParams sm70_marlin_dense_auto_params_from_env(
     Sm70MarlinDenseAutoParamsContext const& ctx) {
   return sm70_marlin_auto_params_from_env(
-      "Dense", "SM70_MARLIN_DENSE_CTA_GEOMETRY",
-      "SM70_MARLIN_DENSE_SPLIT_K", "SM70_MARLIN_DENSE_METADATA_CACHE",
-      ctx.packed_macro_n);
+      "Dense", "SM70_MARLIN_DENSE_CTA_GEOMETRY", "SM70_MARLIN_DENSE_SPLIT_K",
+      "SM70_MARLIN_DENSE_METADATA_CACHE", ctx.packed_macro_n);
 }
 
-inline bool
-sm70_marlin_dense_try_select_quanttrio_qwen3_6_27b_awq_params(
-    Sm70MarlinDenseAutoParamsContext const& ctx,
-    Sm70MarlinAutoParams& params) {
+inline bool sm70_marlin_dense_try_select_quanttrio_qwen3_6_27b_awq_params(
+    Sm70MarlinDenseAutoParamsContext const& ctx, Sm70MarlinAutoParams& params) {
   if (ctx.quant_format == nullptr ||
-      std::strcmp(ctx.quant_format, "uint4") != 0 ||
-      ctx.group_size != 128 || ctx.size_m <= 0) {
+      std::strcmp(ctx.quant_format, "uint4") != 0 || ctx.group_size != 128 ||
+      ctx.size_m <= 0) {
     return false;
   }
 
-  auto const set_params = [&](Sm70CtaGeometry geometry,
-                              int requested_split_k,
+  auto const set_params = [&](Sm70CtaGeometry geometry, int requested_split_k,
                               bool use_metadata_vector_words) {
     params = {geometry, requested_split_k, use_metadata_vector_words,
               ctx.packed_macro_n};
@@ -596,16 +579,14 @@ sm70_marlin_dense_try_select_quanttrio_qwen3_6_27b_awq_params(
 
 inline bool
 sm70_marlin_dense_try_select_cyankiwi_qwen3_6_27b_awq_bf16_nvfp4_params(
-    Sm70MarlinDenseAutoParamsContext const& ctx,
-    Sm70MarlinAutoParams& params) {
+    Sm70MarlinDenseAutoParamsContext const& ctx, Sm70MarlinAutoParams& params) {
   if (ctx.quant_format == nullptr ||
-      std::strcmp(ctx.quant_format, "nvfp4") != 0 ||
-      ctx.group_size != 16 || ctx.size_m <= 0) {
+      std::strcmp(ctx.quant_format, "nvfp4") != 0 || ctx.group_size != 16 ||
+      ctx.size_m <= 0) {
     return false;
   }
 
-  auto const set_params = [&](Sm70CtaGeometry geometry,
-                              int requested_split_k,
+  auto const set_params = [&](Sm70CtaGeometry geometry, int requested_split_k,
                               bool use_metadata_vector_words) {
     params = {geometry, requested_split_k, use_metadata_vector_words,
               ctx.packed_macro_n};
@@ -614,147 +595,144 @@ sm70_marlin_dense_try_select_cyankiwi_qwen3_6_27b_awq_bf16_nvfp4_params(
 
   if (ctx.size_n == 2048 && ctx.size_k == 5120) {
     if (ctx.size_m <= 1) {
-      return set_params({32,128,32,4,32,32,32}, 8, true);
+      return set_params({32, 128, 32, 4, 32, 32, 32}, 8, true);
     }
     if (ctx.size_m <= 32) {
-      return set_params({32,64,64,4,32,64,16}, 4, true);
+      return set_params({32, 64, 64, 4, 32, 64, 16}, 4, true);
     }
     if (ctx.size_m <= 64) {
-      return set_params({64,64,64,4,32,64,32}, 4, true);
+      return set_params({64, 64, 64, 4, 32, 64, 32}, 4, true);
     }
     if (ctx.size_m <= 2048) {
-      return set_params({128,256,32,8,64,64,32}, 1, true);
+      return set_params({128, 256, 32, 8, 64, 64, 32}, 1, true);
     }
-    return set_params({128,256,32,8,64,64,32}, 1, false);
+    return set_params({128, 256, 32, 8, 64, 64, 32}, 1, false);
   }
 
   if (ctx.size_n == 3584 && ctx.size_k == 5120) {
     if (ctx.size_m <= 1) {
-      return set_params({32,128,32,4,32,32,32}, 8, true);
+      return set_params({32, 128, 32, 4, 32, 32, 32}, 8, true);
     }
     if (ctx.size_m <= 32) {
-      return set_params({32,64,64,4,32,64,16}, 4, true);
+      return set_params({32, 64, 64, 4, 32, 64, 16}, 4, true);
     }
     if (ctx.size_m <= 64) {
-      return set_params({64,64,32,4,32,32,32}, 4, true);
+      return set_params({64, 64, 32, 4, 32, 32, 32}, 4, true);
     }
     if (ctx.size_m <= 2048) {
-      return set_params({128,256,32,8,64,64,32}, 1, true);
+      return set_params({128, 256, 32, 8, 64, 64, 32}, 1, true);
     }
-    return set_params({128,256,32,8,64,64,32}, 1, true);
+    return set_params({128, 256, 32, 8, 64, 64, 32}, 1, true);
   }
 
   if (ctx.size_n == 4352 && ctx.size_k == 5120) {
     if (ctx.size_m <= 1) {
-      return set_params({32,128,32,4,32,32,32}, 8, true);
+      return set_params({32, 128, 32, 4, 32, 32, 32}, 8, true);
     }
     if (ctx.size_m <= 32) {
-      return set_params({32,64,64,4,32,32,32}, 4, true);
+      return set_params({32, 64, 64, 4, 32, 32, 32}, 4, true);
     }
     if (ctx.size_m <= 64) {
-      return set_params({64,64,32,4,32,32,32}, 4, false);
+      return set_params({64, 64, 32, 4, 32, 32, 32}, 4, false);
     }
     if (ctx.size_m <= 2048) {
-      return set_params({128,256,32,8,64,64,32}, 1, false);
+      return set_params({128, 256, 32, 8, 64, 64, 32}, 1, false);
     }
-    return set_params({128,256,32,8,64,64,32}, 1, true);
+    return set_params({128, 256, 32, 8, 64, 64, 32}, 1, true);
   }
 
   if (ctx.size_n == 5120 && ctx.size_k == 768) {
     if (ctx.size_m <= 1) {
-      return set_params({64,64,64,4,32,64,32}, 1, false);
+      return set_params({64, 64, 64, 4, 32, 64, 32}, 1, false);
     }
     if (ctx.size_m <= 32) {
-      return set_params({32,64,64,4,32,64,16}, 1, false);
+      return set_params({32, 64, 64, 4, 32, 64, 16}, 1, false);
     }
     if (ctx.size_m <= 64) {
-      return set_params({32,64,32,4,32,32,16}, 1, true);
+      return set_params({32, 64, 32, 4, 32, 32, 16}, 1, true);
     }
     if (ctx.size_m <= 2048) {
-      return set_params({128,256,32,8,64,64,32}, 1, true);
+      return set_params({128, 256, 32, 8, 64, 64, 32}, 1, true);
     }
-    return set_params({128,256,32,8,64,64,32}, 1, false);
+    return set_params({128, 256, 32, 8, 64, 64, 32}, 1, false);
   }
 
   if (ctx.size_n == 5120 && ctx.size_k == 1536) {
     if (ctx.size_m <= 1) {
-      return set_params({32,64,64,4,32,64,16}, 1, true);
+      return set_params({32, 64, 64, 4, 32, 64, 16}, 1, true);
     }
     if (ctx.size_m <= 32) {
-      return set_params({64,64,32,4,32,32,32}, 1, true);
+      return set_params({64, 64, 32, 4, 32, 32, 32}, 1, true);
     }
     if (ctx.size_m <= 64) {
-      return set_params({64,64,32,4,32,32,32}, 1, false);
+      return set_params({64, 64, 32, 4, 32, 32, 32}, 1, false);
     }
     if (ctx.size_m <= 2048) {
-      return set_params({128,256,32,8,64,64,32}, 1, true);
+      return set_params({128, 256, 32, 8, 64, 64, 32}, 1, true);
     }
-    return set_params({128,256,32,8,64,64,32}, 1, true);
+    return set_params({128, 256, 32, 8, 64, 64, 32}, 1, true);
   }
 
   if (ctx.size_n == 5120 && ctx.size_k == 2176) {
     if (ctx.size_m <= 1) {
-      return set_params({32,128,32,4,32,32,32}, 8, true);
+      return set_params({32, 128, 32, 4, 32, 32, 32}, 8, true);
     }
     if (ctx.size_m <= 32) {
-      return set_params({32,64,128,4,32,64,32}, 1, true);
+      return set_params({32, 64, 128, 4, 32, 64, 32}, 1, true);
     }
     if (ctx.size_m <= 64) {
-      return set_params({32,128,128,8,32,64,32}, 1, true);
+      return set_params({32, 128, 128, 8, 32, 64, 32}, 1, true);
     }
     if (ctx.size_m <= 2048) {
-      return set_params({128,256,32,8,64,64,32}, 1, true);
+      return set_params({128, 256, 32, 8, 64, 64, 32}, 1, true);
     }
-    return set_params({128,256,32,8,64,64,32}, 1, true);
+    return set_params({128, 256, 32, 8, 64, 64, 32}, 1, true);
   }
 
   if (ctx.size_n == 5120 && ctx.size_k == 4352) {
     if (ctx.size_m <= 1) {
-      return set_params({32,128,32,4,32,32,32}, 8, true);
+      return set_params({32, 128, 32, 4, 32, 32, 32}, 8, true);
     }
     if (ctx.size_m <= 32) {
-      return set_params({32,128,64,8,32,32,32}, 2, true);
+      return set_params({32, 128, 64, 8, 32, 32, 32}, 2, true);
     }
     if (ctx.size_m <= 64) {
-      return set_params({32,128,128,8,32,64,32}, 1, true);
+      return set_params({32, 128, 128, 8, 32, 64, 32}, 1, true);
     }
     if (ctx.size_m <= 2048) {
-      return set_params({128,256,32,8,64,64,32}, 1, true);
+      return set_params({128, 256, 32, 8, 64, 64, 32}, 1, true);
     }
-    return set_params({128,256,32,8,64,64,32}, 1, true);
+    return set_params({128, 256, 32, 8, 64, 64, 32}, 1, true);
   }
 
   if (ctx.size_n == 8704 && ctx.size_k == 5120) {
     if (ctx.size_m <= 1) {
-      return set_params({32,128,32,4,32,32,32}, 4, true);
+      return set_params({32, 128, 32, 4, 32, 32, 32}, 4, true);
     }
     if (ctx.size_m <= 32) {
-      return set_params({32,128,32,4,32,32,32}, 4, false);
+      return set_params({32, 128, 32, 4, 32, 32, 32}, 4, false);
     }
     if (ctx.size_m <= 64) {
-      return set_params({64,128,128,8,64,64,32}, 1, true);
+      return set_params({64, 128, 128, 8, 64, 64, 32}, 1, true);
     }
     if (ctx.size_m <= 2048) {
-      return set_params({128,256,32,8,64,64,32}, 1, true);
+      return set_params({128, 256, 32, 8, 64, 64, 32}, 1, true);
     }
-    return set_params({128,256,32,8,64,64,32}, 1, true);
+    return set_params({128, 256, 32, 8, 64, 64, 32}, 1, true);
   }
 
   return false;
 }
 
-inline bool
-sm70_marlin_dense_try_select_nvidia_glm_4_7_nvfp4_params(
-    Sm70MarlinDenseAutoParamsContext const& ctx,
-    Sm70MarlinAutoParams& params) {
+inline bool sm70_marlin_dense_try_select_nvidia_glm_4_7_nvfp4_params(
+    Sm70MarlinDenseAutoParamsContext const& ctx, Sm70MarlinAutoParams& params) {
   if (ctx.quant_format == nullptr ||
-      std::strcmp(ctx.quant_format, "nvfp4") != 0 ||
-      ctx.group_size != 16 || ctx.size_m <= 0) {
+      std::strcmp(ctx.quant_format, "nvfp4") != 0 || ctx.group_size != 16 ||
+      ctx.size_m <= 0) {
     return false;
   }
 
-  auto const set_params = [&](Sm70CtaGeometry geometry,
-                              int requested_split_k,
+  auto const set_params = [&](Sm70CtaGeometry geometry, int requested_split_k,
                               bool use_metadata_vector_words) {
     params = {geometry, requested_split_k, use_metadata_vector_words,
               ctx.packed_macro_n};
@@ -763,293 +741,282 @@ sm70_marlin_dense_try_select_nvidia_glm_4_7_nvfp4_params(
 
   if (ctx.size_n == 384 && ctx.size_k == 5120) {
     if (ctx.size_m <= 1) {
-      return set_params({32,64,64,4,32,64,16}, 8, true);
+      return set_params({32, 64, 64, 4, 32, 64, 16}, 8, true);
     }
     if (ctx.size_m <= 32) {
-      return set_params({32,64,64,4,32,32,32}, 8, true);
+      return set_params({32, 64, 64, 4, 32, 32, 32}, 8, true);
     }
     if (ctx.size_m <= 64) {
-      return set_params({32,64,64,4,32,64,16}, 8, true);
+      return set_params({32, 64, 64, 4, 32, 64, 16}, 8, true);
     }
     if (ctx.size_m <= 2048) {
-      return set_params({64,64,64,4,64,32,32}, 1, true);
+      return set_params({64, 64, 64, 4, 64, 32, 32}, 1, true);
     }
-    return set_params({64,128,32,4,32,64,32}, 1, true);
+    return set_params({64, 128, 32, 4, 32, 64, 32}, 1, true);
   }
 
   if (ctx.size_n == 768 && ctx.size_k == 5120) {
     if (ctx.size_m <= 1) {
-      return set_params({32,64,64,4,32,32,32}, 8, true);
+      return set_params({32, 64, 64, 4, 32, 32, 32}, 8, true);
     }
     if (ctx.size_m <= 32) {
-      return set_params({32,64,64,4,32,64,16}, 8, false);
+      return set_params({32, 64, 64, 4, 32, 64, 16}, 8, false);
     }
     if (ctx.size_m <= 64) {
-      return set_params({32,64,64,4,32,32,32}, 4, true);
+      return set_params({32, 64, 64, 4, 32, 32, 32}, 4, true);
     }
     if (ctx.size_m <= 2048) {
-      return set_params({128,64,32,4,32,64,32}, 1, true);
+      return set_params({128, 64, 32, 4, 32, 64, 32}, 1, true);
     }
-    return set_params({64,128,32,4,32,64,32}, 1, true);
+    return set_params({64, 128, 32, 4, 32, 64, 32}, 1, true);
   }
 
   if (ctx.size_n == 3072 && ctx.size_k == 5120) {
     if (ctx.size_m <= 1) {
-      return set_params({32,128,32,4,32,32,32}, 8, true);
+      return set_params({32, 128, 32, 4, 32, 32, 32}, 8, true);
     }
     if (ctx.size_m <= 32) {
-      return set_params({32,64,64,4,32,64,16}, 4, true);
+      return set_params({32, 64, 64, 4, 32, 64, 16}, 4, true);
     }
     if (ctx.size_m <= 64) {
-      return set_params({64,64,32,4,32,32,32}, 4, true);
+      return set_params({64, 64, 32, 4, 32, 32, 32}, 4, true);
     }
     if (ctx.size_m <= 2048) {
-      return set_params({128,128,64,8,64,64,32}, 1, true);
+      return set_params({128, 128, 64, 8, 64, 64, 32}, 1, true);
     }
-    return set_params({128,256,32,8,64,64,32}, 1, true);
+    return set_params({128, 256, 32, 8, 64, 64, 32}, 1, true);
   }
 
   if (ctx.size_n == 5120 && ctx.size_k == 192) {
     if (ctx.size_m <= 1) {
-      return set_params({32,64,64,4,32,32,32}, 1, true);
+      return set_params({32, 64, 64, 4, 32, 32, 32}, 1, true);
     }
     if (ctx.size_m <= 32) {
-      return set_params({32,64,32,4,32,32,16}, 1, true);
+      return set_params({32, 64, 32, 4, 32, 32, 16}, 1, true);
     }
     if (ctx.size_m <= 64) {
-      return set_params({32,64,32,4,32,32,16}, 1, true);
+      return set_params({32, 64, 32, 4, 32, 32, 16}, 1, true);
     }
     if (ctx.size_m <= 2048) {
-      return set_params({128,128,32,4,64,64,32}, 1, true);
+      return set_params({128, 128, 32, 4, 64, 64, 32}, 1, true);
     }
-    return set_params({128,128,32,4,64,64,32}, 1, true);
+    return set_params({128, 128, 32, 4, 64, 64, 32}, 1, true);
   }
 
   if (ctx.size_n == 5120 && ctx.size_k == 384) {
     if (ctx.size_m <= 1) {
-      return set_params({32,64,32,4,32,32,16}, 1, true);
+      return set_params({32, 64, 32, 4, 32, 32, 16}, 1, true);
     }
     if (ctx.size_m <= 32) {
-      return set_params({32,64,32,4,32,32,16}, 1, true);
+      return set_params({32, 64, 32, 4, 32, 32, 16}, 1, true);
     }
     if (ctx.size_m <= 64) {
-      return set_params({32,64,32,4,32,32,16}, 1, true);
+      return set_params({32, 64, 32, 4, 32, 32, 16}, 1, true);
     }
     if (ctx.size_m <= 2048) {
-      return set_params({128,256,32,8,64,64,32}, 1, true);
+      return set_params({128, 256, 32, 8, 64, 64, 32}, 1, true);
     }
-    return set_params({128,256,32,8,64,64,32}, 1, true);
+    return set_params({128, 256, 32, 8, 64, 64, 32}, 1, true);
   }
 
   if (ctx.size_n == 5120 && ctx.size_k == 1536) {
     if (ctx.size_m <= 1) {
-      return set_params({32,64,64,4,32,32,32}, 4, true);
+      return set_params({32, 64, 64, 4, 32, 32, 32}, 4, true);
     }
     if (ctx.size_m <= 32) {
-      return set_params({32,64,64,4,32,32,32}, 1, true);
+      return set_params({32, 64, 64, 4, 32, 32, 32}, 1, true);
     }
     if (ctx.size_m <= 64) {
-      return set_params({32,128,32,4,32,32,32}, 1, true);
+      return set_params({32, 128, 32, 4, 32, 32, 32}, 1, true);
     }
     if (ctx.size_m <= 2048) {
-      return set_params({128,256,32,8,64,64,32}, 1, true);
+      return set_params({128, 256, 32, 8, 64, 64, 32}, 1, true);
     }
-    return set_params({128,256,32,8,64,64,32}, 1, true);
+    return set_params({128, 256, 32, 8, 64, 64, 32}, 1, true);
   }
 
   if (ctx.size_n == 5120 && ctx.size_k == 3072) {
     if (ctx.size_m <= 1) {
-      return set_params({32,128,32,4,32,32,32}, 8, true);
+      return set_params({32, 128, 32, 4, 32, 32, 32}, 8, true);
     }
     if (ctx.size_m <= 32) {
-      return set_params({32,64,64,4,32,64,16}, 2, false);
+      return set_params({32, 64, 64, 4, 32, 64, 16}, 2, false);
     }
     if (ctx.size_m <= 64) {
-      return set_params({32,128,128,8,32,64,32}, 1, true);
+      return set_params({32, 128, 128, 8, 32, 64, 32}, 1, true);
     }
     if (ctx.size_m <= 2048) {
-      return set_params({128,256,32,8,64,64,32}, 1, true);
+      return set_params({128, 256, 32, 8, 64, 64, 32}, 1, true);
     }
-    return set_params({128,256,32,8,64,64,32}, 1, true);
+    return set_params({128, 256, 32, 8, 64, 64, 32}, 1, true);
   }
 
   if (ctx.size_n == 6144 && ctx.size_k == 5120) {
     if (ctx.size_m <= 1) {
-      return set_params({32,128,32,4,32,32,32}, 4, true);
+      return set_params({32, 128, 32, 4, 32, 32, 32}, 4, true);
     }
     if (ctx.size_m <= 32) {
-      return set_params({32,128,32,4,32,32,32}, 4, true);
+      return set_params({32, 128, 32, 4, 32, 32, 32}, 4, true);
     }
     if (ctx.size_m <= 64) {
-      return set_params({64,128,32,4,32,64,32}, 4, false);
+      return set_params({64, 128, 32, 4, 32, 64, 32}, 4, false);
     }
     if (ctx.size_m <= 2048) {
-      return set_params({128,256,32,8,64,64,32}, 1, true);
+      return set_params({128, 256, 32, 8, 64, 64, 32}, 1, true);
     }
-    return set_params({128,256,32,8,64,64,32}, 1, true);
+    return set_params({128, 256, 32, 8, 64, 64, 32}, 1, true);
   }
 
   return false;
 }
 
-inline bool
-sm70_marlin_dense_try_select_nvidia_qwen3_6_35b_a3b_nvfp4_params(
-    Sm70MarlinDenseAutoParamsContext const& ctx,
-    Sm70MarlinAutoParams& params) {
+inline bool sm70_marlin_dense_try_select_nvidia_qwen3_6_35b_a3b_nvfp4_params(
+    Sm70MarlinDenseAutoParamsContext const& ctx, Sm70MarlinAutoParams& params) {
   if (ctx.quant_format == nullptr || ctx.size_m <= 0) {
     return false;
   }
 
-  auto const set_params = [&](Sm70CtaGeometry geometry,
-                              int requested_split_k,
+  auto const set_params = [&](Sm70CtaGeometry geometry, int requested_split_k,
                               bool use_metadata_vector_words) {
     params = {geometry, requested_split_k, use_metadata_vector_words,
               ctx.packed_macro_n};
     return true;
   };
 
-  if (std::strcmp(ctx.quant_format, "fp8_e4m3") == 0 &&
-      ctx.group_size == 512 &&
+  if (std::strcmp(ctx.quant_format, "fp8_e4m3") == 0 && ctx.group_size == 512 &&
       ctx.size_n == 2048 && ctx.size_k == 512) {
     if (ctx.size_m <= 1) {
-      return set_params({32,64,32,4,32,32,16}, 1, true);
+      return set_params({32, 64, 32, 4, 32, 32, 16}, 1, true);
     }
     if (ctx.size_m <= 32) {
-      return set_params({32,64,32,4,32,32,16}, 1, false);
+      return set_params({32, 64, 32, 4, 32, 32, 16}, 1, false);
     }
     if (ctx.size_m <= 64) {
-      return set_params({32,64,32,4,32,32,16}, 1, true);
+      return set_params({32, 64, 32, 4, 32, 32, 16}, 1, true);
     }
     if (ctx.size_m <= 2048) {
-      return set_params({128,256,32,8,64,64,32}, 1, true);
+      return set_params({128, 256, 32, 8, 64, 64, 32}, 1, true);
     }
-    return set_params({128,256,32,8,64,64,32}, 1, true);
+    return set_params({128, 256, 32, 8, 64, 64, 32}, 1, true);
   }
 
   if (std::strcmp(ctx.quant_format, "fp8_e4m3") == 0 &&
-      ctx.group_size == 1024 &&
-      ctx.size_n == 2048 && ctx.size_k == 1024) {
+      ctx.group_size == 1024 && ctx.size_n == 2048 && ctx.size_k == 1024) {
     if (ctx.size_m <= 1) {
-      return set_params({32,64,64,4,32,32,32}, 1, true);
+      return set_params({32, 64, 64, 4, 32, 32, 32}, 1, true);
     }
     if (ctx.size_m <= 32) {
-      return set_params({32,64,64,4,32,32,32}, 1, true);
+      return set_params({32, 64, 64, 4, 32, 32, 32}, 1, true);
     }
     if (ctx.size_m <= 64) {
-      return set_params({32,64,64,4,32,32,32}, 1, true);
+      return set_params({32, 64, 64, 4, 32, 32, 32}, 1, true);
     }
     if (ctx.size_m <= 2048) {
-      return set_params({128,256,32,8,64,64,32}, 1, true);
+      return set_params({128, 256, 32, 8, 64, 64, 32}, 1, true);
     }
-    return set_params({128,256,32,8,64,64,32}, 1, true);
+    return set_params({128, 256, 32, 8, 64, 64, 32}, 1, true);
   }
 
   if (std::strcmp(ctx.quant_format, "fp8_e4m3") == 0 &&
-      ctx.group_size == 2048 &&
-      ctx.size_n == 1536 && ctx.size_k == 2048) {
+      ctx.group_size == 2048 && ctx.size_n == 1536 && ctx.size_k == 2048) {
     if (ctx.size_m <= 1) {
-      return set_params({32,64,32,4,32,32,16}, 4, true);
+      return set_params({32, 64, 32, 4, 32, 32, 16}, 4, true);
     }
     if (ctx.size_m <= 32) {
-      return set_params({32,64,64,4,32,32,32}, 4, true);
+      return set_params({32, 64, 64, 4, 32, 32, 32}, 4, true);
     }
     if (ctx.size_m <= 64) {
-      return set_params({32,64,64,4,32,32,32}, 4, true);
+      return set_params({32, 64, 64, 4, 32, 32, 32}, 4, true);
     }
     if (ctx.size_m <= 2048) {
-      return set_params({64,128,32,4,32,64,32}, 1, false);
+      return set_params({64, 128, 32, 4, 32, 64, 32}, 1, false);
     }
-    return set_params({128,256,32,8,64,64,32}, 1, true);
+    return set_params({128, 256, 32, 8, 64, 64, 32}, 1, true);
   }
 
   if (std::strcmp(ctx.quant_format, "fp8_e4m3") == 0 &&
-      ctx.group_size == 2048 &&
-      ctx.size_n == 2560 && ctx.size_k == 2048) {
+      ctx.group_size == 2048 && ctx.size_n == 2560 && ctx.size_k == 2048) {
     if (ctx.size_m <= 1) {
-      return set_params({32,64,32,4,32,32,16}, 8, true);
+      return set_params({32, 64, 32, 4, 32, 32, 16}, 8, true);
     }
     if (ctx.size_m <= 32) {
-      return set_params({32,64,64,4,32,32,32}, 2, true);
+      return set_params({32, 64, 64, 4, 32, 32, 32}, 2, true);
     }
     if (ctx.size_m <= 64) {
-      return set_params({32,64,64,4,32,64,16}, 1, true);
+      return set_params({32, 64, 64, 4, 32, 64, 16}, 1, true);
     }
     if (ctx.size_m <= 2048) {
-      return set_params({128,256,32,8,64,64,32}, 1, true);
+      return set_params({128, 256, 32, 8, 64, 64, 32}, 1, true);
     }
-    return set_params({128,256,32,8,64,64,32}, 1, true);
+    return set_params({128, 256, 32, 8, 64, 64, 32}, 1, true);
   }
 
-  if (std::strcmp(ctx.quant_format, "nvfp4") == 0 &&
-      ctx.group_size == 16 &&
+  if (std::strcmp(ctx.quant_format, "nvfp4") == 0 && ctx.group_size == 16 &&
       ctx.size_n == 128 && ctx.size_k == 2048) {
     if (ctx.size_m <= 1) {
-      return set_params({32,64,32,4,32,32,16}, 4, true);
+      return set_params({32, 64, 32, 4, 32, 32, 16}, 4, true);
     }
     if (ctx.size_m <= 32) {
-      return set_params({32,64,64,4,32,32,32}, 4, true);
+      return set_params({32, 64, 64, 4, 32, 32, 32}, 4, true);
     }
     if (ctx.size_m <= 64) {
-      return set_params({32,64,64,4,32,32,32}, 4, true);
+      return set_params({32, 64, 64, 4, 32, 32, 32}, 4, true);
     }
     if (ctx.size_m <= 2048) {
-      return set_params({64,64,64,4,32,64,32}, 1, true);
+      return set_params({64, 64, 64, 4, 32, 64, 32}, 1, true);
     }
-    return set_params({128,64,128,8,64,64,32}, 1, true);
+    return set_params({128, 64, 128, 8, 64, 64, 32}, 1, true);
   }
 
-  if (std::strcmp(ctx.quant_format, "nvfp4") == 0 &&
-      ctx.group_size == 16 &&
+  if (std::strcmp(ctx.quant_format, "nvfp4") == 0 && ctx.group_size == 16 &&
       ctx.size_n == 256 && ctx.size_k == 2048) {
     if (ctx.size_m <= 1) {
-      return set_params({32,64,32,4,32,32,16}, 4, true);
+      return set_params({32, 64, 32, 4, 32, 32, 16}, 4, true);
     }
     if (ctx.size_m <= 32) {
-      return set_params({32,64,64,4,32,32,32}, 4, true);
+      return set_params({32, 64, 64, 4, 32, 32, 32}, 4, true);
     }
     if (ctx.size_m <= 64) {
-      return set_params({32,64,64,4,32,32,32}, 4, true);
+      return set_params({32, 64, 64, 4, 32, 32, 32}, 4, true);
     }
     if (ctx.size_m <= 2048) {
-      return set_params({128,64,128,8,64,64,32}, 1, false);
+      return set_params({128, 64, 128, 8, 64, 64, 32}, 1, false);
     }
-    return set_params({128,64,32,4,32,64,32}, 1, false);
+    return set_params({128, 64, 32, 4, 32, 64, 32}, 1, false);
   }
 
-  if (std::strcmp(ctx.quant_format, "nvfp4") == 0 &&
-      ctx.group_size == 16 &&
+  if (std::strcmp(ctx.quant_format, "nvfp4") == 0 && ctx.group_size == 16 &&
       ctx.size_n == 2048 && ctx.size_k == 64) {
     if (ctx.size_m <= 1) {
-      return set_params({32,64,64,4,32,64,16}, 1, false);
+      return set_params({32, 64, 64, 4, 32, 64, 16}, 1, false);
     }
     if (ctx.size_m <= 32) {
-      return set_params({32,64,64,4,32,32,32}, 1, true);
+      return set_params({32, 64, 64, 4, 32, 32, 32}, 1, true);
     }
     if (ctx.size_m <= 64) {
-      return set_params({32,64,64,4,32,64,16}, 1, false);
+      return set_params({32, 64, 64, 4, 32, 64, 16}, 1, false);
     }
     if (ctx.size_m <= 2048) {
-      return set_params({32,128,32,4,32,32,32}, 1, true);
+      return set_params({32, 128, 32, 4, 32, 32, 32}, 1, true);
     }
-    return set_params({128,64,32,4,32,64,32}, 1, false);
+    return set_params({128, 64, 32, 4, 32, 64, 32}, 1, false);
   }
 
-  if (std::strcmp(ctx.quant_format, "nvfp4") == 0 &&
-      ctx.group_size == 16 &&
+  if (std::strcmp(ctx.quant_format, "nvfp4") == 0 && ctx.group_size == 16 &&
       ctx.size_n == 2048 && ctx.size_k == 128) {
     if (ctx.size_m <= 1) {
-      return set_params({32,64,64,4,32,32,32}, 1, false);
+      return set_params({32, 64, 64, 4, 32, 32, 32}, 1, false);
     }
     if (ctx.size_m <= 32) {
-      return set_params({32,64,64,4,32,32,32}, 1, true);
+      return set_params({32, 64, 64, 4, 32, 32, 32}, 1, true);
     }
     if (ctx.size_m <= 64) {
-      return set_params({32,64,64,4,32,64,16}, 1, false);
+      return set_params({32, 64, 64, 4, 32, 64, 16}, 1, false);
     }
     if (ctx.size_m <= 2048) {
-      return set_params({128,64,32,4,32,64,32}, 1, true);
+      return set_params({128, 64, 32, 4, 32, 64, 32}, 1, true);
     }
-    return set_params({128,64,32,4,32,64,32}, 1, true);
+    return set_params({128, 64, 32, 4, 32, 64, 32}, 1, true);
   }
 
   return false;
@@ -1057,16 +1024,14 @@ sm70_marlin_dense_try_select_nvidia_qwen3_6_35b_a3b_nvfp4_params(
 
 inline bool
 sm70_marlin_dense_try_select_nvidia_qwen3_next_80b_a3b_thinking_nvfp4_params(
-    Sm70MarlinDenseAutoParamsContext const& ctx,
-    Sm70MarlinAutoParams& params) {
+    Sm70MarlinDenseAutoParamsContext const& ctx, Sm70MarlinAutoParams& params) {
   if (ctx.quant_format == nullptr ||
-      std::strcmp(ctx.quant_format, "nvfp4") != 0 ||
-      ctx.group_size != 16 || ctx.size_m <= 0) {
+      std::strcmp(ctx.quant_format, "nvfp4") != 0 || ctx.group_size != 16 ||
+      ctx.size_m <= 0) {
     return false;
   }
 
-  auto const set_params = [&](Sm70CtaGeometry geometry,
-                              int requested_split_k,
+  auto const set_params = [&](Sm70CtaGeometry geometry, int requested_split_k,
                               bool use_metadata_vector_words) {
     params = {geometry, requested_split_k, use_metadata_vector_words,
               ctx.packed_macro_n};
@@ -1075,115 +1040,112 @@ sm70_marlin_dense_try_select_nvidia_qwen3_next_80b_a3b_thinking_nvfp4_params(
 
   if (ctx.size_n == 128 && ctx.size_k == 2048) {
     if (ctx.size_m <= 1) {
-      return set_params({32,64,32,4,32,32,16}, 4, true);
+      return set_params({32, 64, 32, 4, 32, 32, 16}, 4, true);
     }
     if (ctx.size_m <= 32) {
-      return set_params({32,64,32,4,32,32,16}, 4, true);
+      return set_params({32, 64, 32, 4, 32, 32, 16}, 4, true);
     }
     if (ctx.size_m <= 64) {
-      return set_params({32,64,64,4,32,32,32}, 4, true);
+      return set_params({32, 64, 64, 4, 32, 32, 32}, 4, true);
     }
     if (ctx.size_m <= 2048) {
-      return set_params({64,64,64,4,32,64,32}, 1, true);
+      return set_params({64, 64, 64, 4, 32, 64, 32}, 1, true);
     }
-    return set_params({128,64,128,8,64,64,32}, 1, true);
+    return set_params({128, 64, 128, 8, 64, 64, 32}, 1, true);
   }
 
   if (ctx.size_n == 256 && ctx.size_k == 2048) {
     if (ctx.size_m <= 1) {
-      return set_params({32,64,32,4,32,32,16}, 4, true);
+      return set_params({32, 64, 32, 4, 32, 32, 16}, 4, true);
     }
     if (ctx.size_m <= 32) {
-      return set_params({32,64,64,4,32,32,32}, 4, true);
+      return set_params({32, 64, 64, 4, 32, 32, 32}, 4, true);
     }
     if (ctx.size_m <= 64) {
-      return set_params({32,64,64,4,32,32,32}, 4, true);
+      return set_params({32, 64, 64, 4, 32, 32, 32}, 4, true);
     }
     if (ctx.size_m <= 2048) {
-      return set_params({128,64,128,8,64,64,32}, 1, true);
+      return set_params({128, 64, 128, 8, 64, 64, 32}, 1, true);
     }
-    return set_params({128,64,32,4,32,64,32}, 1, true);
+    return set_params({128, 64, 32, 4, 32, 64, 32}, 1, true);
   }
 
   if (ctx.size_n == 2048 && ctx.size_k == 64) {
     if (ctx.size_m <= 1) {
-      return set_params({32,64,64,4,32,64,16}, 1, true);
+      return set_params({32, 64, 64, 4, 32, 64, 16}, 1, true);
     }
     if (ctx.size_m <= 32) {
-      return set_params({32,64,64,4,32,32,32}, 1, true);
+      return set_params({32, 64, 64, 4, 32, 32, 32}, 1, true);
     }
     if (ctx.size_m <= 64) {
-      return set_params({32,64,64,4,32,32,32}, 1, false);
+      return set_params({32, 64, 64, 4, 32, 32, 32}, 1, false);
     }
     if (ctx.size_m <= 2048) {
-      return set_params({64,64,32,4,32,32,32}, 1, true);
+      return set_params({64, 64, 32, 4, 32, 32, 32}, 1, true);
     }
-    return set_params({128,64,32,4,32,64,32}, 1, true);
+    return set_params({128, 64, 32, 4, 32, 64, 32}, 1, true);
   }
 
   if (ctx.size_n == 2048 && ctx.size_k == 128) {
     if (ctx.size_m <= 1) {
-      return set_params({32,128,32,4,32,32,32}, 1, true);
+      return set_params({32, 128, 32, 4, 32, 32, 32}, 1, true);
     }
     if (ctx.size_m <= 32) {
-      return set_params({32,64,64,4,32,64,16}, 1, true);
+      return set_params({32, 64, 64, 4, 32, 64, 16}, 1, true);
     }
     if (ctx.size_m <= 64) {
-      return set_params({32,64,64,4,32,32,32}, 1, true);
+      return set_params({32, 64, 64, 4, 32, 32, 32}, 1, true);
     }
     if (ctx.size_m <= 2048) {
-      return set_params({128,64,32,4,32,64,32}, 1, true);
+      return set_params({128, 64, 32, 4, 32, 64, 32}, 1, true);
     }
-    return set_params({128,64,32,4,32,64,32}, 1, false);
+    return set_params({128, 64, 32, 4, 32, 64, 32}, 1, false);
   }
 
   if (ctx.size_n == 2048 && ctx.size_k == 512) {
     if (ctx.size_m <= 1) {
-      return set_params({32,64,64,4,32,32,32}, 1, true);
+      return set_params({32, 64, 64, 4, 32, 32, 32}, 1, true);
     }
     if (ctx.size_m <= 32) {
-      return set_params({32,64,64,4,32,32,32}, 1, false);
+      return set_params({32, 64, 64, 4, 32, 32, 32}, 1, false);
     }
     if (ctx.size_m <= 64) {
-      return set_params({32,64,32,4,32,32,16}, 1, false);
+      return set_params({32, 64, 32, 4, 32, 32, 16}, 1, false);
     }
     if (ctx.size_m <= 2048) {
-      return set_params({128,128,32,4,64,64,32}, 1, true);
+      return set_params({128, 128, 32, 4, 64, 64, 32}, 1, true);
     }
-    return set_params({128,256,32,8,64,64,32}, 1, true);
+    return set_params({128, 256, 32, 8, 64, 64, 32}, 1, true);
   }
 
   if (ctx.size_n == 2048 && ctx.size_k == 1024) {
     if (ctx.size_m <= 1) {
-      return set_params({64,64,32,4,32,32,32}, 1, true);
+      return set_params({64, 64, 32, 4, 32, 32, 32}, 1, true);
     }
     if (ctx.size_m <= 32) {
-      return set_params({32,64,64,4,32,32,32}, 1, false);
+      return set_params({32, 64, 64, 4, 32, 32, 32}, 1, false);
     }
     if (ctx.size_m <= 64) {
-      return set_params({32,64,64,4,32,32,32}, 1, true);
+      return set_params({32, 64, 64, 4, 32, 32, 32}, 1, true);
     }
     if (ctx.size_m <= 2048) {
-      return set_params({128,256,32,8,64,64,32}, 1, true);
+      return set_params({128, 256, 32, 8, 64, 64, 32}, 1, true);
     }
-    return set_params({128,256,32,8,64,64,32}, 1, true);
+    return set_params({128, 256, 32, 8, 64, 64, 32}, 1, true);
   }
 
   return false;
 }
 
-inline bool
-sm70_marlin_dense_try_select_cyankiwi_minimax_m2_7_awq_4bit_params(
-    Sm70MarlinDenseAutoParamsContext const& ctx,
-    Sm70MarlinAutoParams& params) {
+inline bool sm70_marlin_dense_try_select_cyankiwi_minimax_m2_7_awq_4bit_params(
+    Sm70MarlinDenseAutoParamsContext const& ctx, Sm70MarlinAutoParams& params) {
   if (ctx.quant_format == nullptr ||
-      std::strcmp(ctx.quant_format, "uint4b8") != 0 ||
-      ctx.group_size != 32 || ctx.size_m <= 0) {
+      std::strcmp(ctx.quant_format, "uint4b8") != 0 || ctx.group_size != 32 ||
+      ctx.size_m <= 0) {
     return false;
   }
 
-  auto const set_params = [&](Sm70CtaGeometry geometry,
-                              int requested_split_k,
+  auto const set_params = [&](Sm70CtaGeometry geometry, int requested_split_k,
                               bool use_metadata_vector_words) {
     params = {geometry, requested_split_k, use_metadata_vector_words,
               ctx.packed_macro_n};
@@ -1246,18 +1208,15 @@ sm70_marlin_dense_try_select_cyankiwi_minimax_m2_7_awq_4bit_params(
   return false;
 }
 
-inline bool
-sm70_marlin_dense_try_select_cyankiwi_glm_4_7_awq_4bit_params(
-    Sm70MarlinDenseAutoParamsContext const& ctx,
-    Sm70MarlinAutoParams& params) {
+inline bool sm70_marlin_dense_try_select_cyankiwi_glm_4_7_awq_4bit_params(
+    Sm70MarlinDenseAutoParamsContext const& ctx, Sm70MarlinAutoParams& params) {
   if (ctx.quant_format == nullptr ||
-      std::strcmp(ctx.quant_format, "uint4b8") != 0 ||
-      ctx.group_size != 32 || ctx.size_m <= 0) {
+      std::strcmp(ctx.quant_format, "uint4b8") != 0 || ctx.group_size != 32 ||
+      ctx.size_m <= 0) {
     return false;
   }
 
-  auto const set_params = [&](Sm70CtaGeometry geometry,
-                              int requested_split_k,
+  auto const set_params = [&](Sm70CtaGeometry geometry, int requested_split_k,
                               bool use_metadata_vector_words) {
     params = {geometry, requested_split_k, use_metadata_vector_words,
               ctx.packed_macro_n};
@@ -1323,18 +1282,15 @@ sm70_marlin_dense_try_select_cyankiwi_glm_4_7_awq_4bit_params(
   return false;
 }
 
-inline bool
-sm70_marlin_dense_try_select_quanttrio_glm_4_7_awq_params(
-    Sm70MarlinDenseAutoParamsContext const& ctx,
-    Sm70MarlinAutoParams& params) {
+inline bool sm70_marlin_dense_try_select_quanttrio_glm_4_7_awq_params(
+    Sm70MarlinDenseAutoParamsContext const& ctx, Sm70MarlinAutoParams& params) {
   if (ctx.quant_format == nullptr ||
-      std::strcmp(ctx.quant_format, "uint4") != 0 ||
-      ctx.group_size != 128 || ctx.size_m <= 0) {
+      std::strcmp(ctx.quant_format, "uint4") != 0 || ctx.group_size != 128 ||
+      ctx.size_m <= 0) {
     return false;
   }
 
-  auto const set_params = [&](Sm70CtaGeometry geometry,
-                              int requested_split_k,
+  auto const set_params = [&](Sm70CtaGeometry geometry, int requested_split_k,
                               bool use_metadata_vector_words) {
     params = {geometry, requested_split_k, use_metadata_vector_words,
               ctx.packed_macro_n};
@@ -1426,16 +1382,16 @@ inline Sm70MarlinAutoParams sm70_marlin_dense_auto_params(
     char const* quant_format, int64_t group_size, int64_t size_m,
     int64_t size_n, int64_t size_k) {
   Sm70MarlinDenseAutoParamsContext const ctx{
-      quant_format, group_size, size_m, size_n, size_k,
-      sm70_marlin_auto_packed_macro_n(size_n)};
+      quant_format, group_size, size_m,
+      size_n,       size_k,     sm70_marlin_auto_packed_macro_n(size_n)};
 
   if (sm70_marlin_dense_auto_env_is_set()) {
     return sm70_marlin_dense_auto_params_from_env(ctx);
   }
 
   Sm70MarlinAutoParams params{};
-  if (sm70_marlin_dense_try_select_quanttrio_qwen3_6_27b_awq_params(
-          ctx, params)) {
+  if (sm70_marlin_dense_try_select_quanttrio_qwen3_6_27b_awq_params(ctx,
+                                                                    params)) {
     validate_sm70_marlin_auto_params("Dense", params);
     return params;
   }
@@ -1444,8 +1400,7 @@ inline Sm70MarlinAutoParams sm70_marlin_dense_auto_params(
     validate_sm70_marlin_auto_params("Dense", params);
     return params;
   }
-  if (sm70_marlin_dense_try_select_nvidia_glm_4_7_nvfp4_params(
-          ctx, params)) {
+  if (sm70_marlin_dense_try_select_nvidia_glm_4_7_nvfp4_params(ctx, params)) {
     validate_sm70_marlin_auto_params("Dense", params);
     return params;
   }
@@ -1464,13 +1419,12 @@ inline Sm70MarlinAutoParams sm70_marlin_dense_auto_params(
     validate_sm70_marlin_auto_params("Dense", params);
     return params;
   }
-  if (sm70_marlin_dense_try_select_cyankiwi_glm_4_7_awq_4bit_params(
-          ctx, params)) {
+  if (sm70_marlin_dense_try_select_cyankiwi_glm_4_7_awq_4bit_params(ctx,
+                                                                    params)) {
     validate_sm70_marlin_auto_params("Dense", params);
     return params;
   }
-  if (sm70_marlin_dense_try_select_quanttrio_glm_4_7_awq_params(
-          ctx, params)) {
+  if (sm70_marlin_dense_try_select_quanttrio_glm_4_7_awq_params(ctx, params)) {
     validate_sm70_marlin_auto_params("Dense", params);
     return params;
   }
@@ -1478,27 +1432,25 @@ inline Sm70MarlinAutoParams sm70_marlin_dense_auto_params(
   return sm70_marlin_default_auto_params(ctx.packed_macro_n);
 }
 
-inline void validate_sm70_marlin_dense_cta_geometry_supported(char const* op_name,
-                                                              Sm70CtaGeometry geometry) {
+inline void validate_sm70_marlin_dense_cta_geometry_supported(
+    char const* op_name, Sm70CtaGeometry geometry) {
   TORCH_CHECK(sm70_marlin_cta_geometry_is_supported(geometry),
               "Unsupported SM70 Marlin CTA geometry for ", op_name, ": ",
-              geometry.cta_m, "x", geometry.cta_n, "x", geometry.cta_k,
-              "x", geometry.warps, "x", geometry.warp_m, "x",
-              geometry.warp_n, "x", geometry.warp_k,
-              ". Supported geometries are ",
+              geometry.cta_m, "x", geometry.cta_n, "x", geometry.cta_k, "x",
+              geometry.warps, "x", geometry.warp_m, "x", geometry.warp_n, "x",
+              geometry.warp_k, ". Supported geometries are ",
               kSupportedSm70MarlinCtaGeometries, ".");
 }
 
 inline void validate_sm70_marlin_dense_cta_n_alignment(char const* op_name,
                                                        Sm70CtaGeometry geometry,
                                                        int64_t size_n) {
-  TORCH_CHECK(
-      size_n % geometry.cta_n == 0 && size_n % kQuantTileN == 0,
-      "SM70 Marlin requires size_n divisible by both CTA_N and 64 for ",
-      op_name, " with CTA geometry ", geometry.cta_m, "x", geometry.cta_n,
-      "x", geometry.cta_k, "x", geometry.warps, "x", geometry.warp_m,
-      "x", geometry.warp_n, "x", geometry.warp_k, ". Got size_n = ",
-      size_n, ".");
+  TORCH_CHECK(size_n % geometry.cta_n == 0 && size_n % kQuantTileN == 0,
+              "SM70 Marlin requires size_n divisible by both CTA_N and 64 for ",
+              op_name, " with CTA geometry ", geometry.cta_m, "x",
+              geometry.cta_n, "x", geometry.cta_k, "x", geometry.warps, "x",
+              geometry.warp_m, "x", geometry.warp_n, "x", geometry.warp_k,
+              ". Got size_n = ", size_n, ".");
 }
 
 }  // namespace marlin::sm70

--- a/csrc/quantization/marlin/sm70_marlin_dispatch.cu
+++ b/csrc/quantization/marlin/sm70_marlin_dispatch.cu
@@ -43,15 +43,13 @@ __device__ __forceinline__ int sm70_inverse_zp_interleave(int idx,
   return inv[idx];
 }
 
-__device__ __forceinline__ int sm70_inverse_scale_perm(int idx,
-                                                       int perm_len) {
+__device__ __forceinline__ int sm70_inverse_scale_perm(int idx, int perm_len) {
   if (perm_len == 64) {
     return (idx % 8) * 8 + idx / 8;
   }
-  constexpr int inv[32] = {0,  1,  8,  9,  16, 17, 24, 25,
-                           2,  3,  10, 11, 18, 19, 26, 27,
-                           4,  5,  12, 13, 20, 21, 28, 29,
-                           6,  7,  14, 15, 22, 23, 30, 31};
+  constexpr int inv[32] = {0,  1,  8,  9,  16, 17, 24, 25, 2,  3,  10,
+                           11, 18, 19, 26, 27, 4,  5,  12, 13, 20, 21,
+                           28, 29, 6,  7,  14, 15, 22, 23, 30, 31};
   return inv[idx];
 }
 
@@ -66,10 +64,9 @@ __global__ void sm70_unpermute_half_metadata_kernel(
 }
 
 __global__ void sm70_unpack_dense_zp_to_half_kernel(
-    const int32_t* __restrict__ packed_zp,
-    const half* __restrict__ scales, half* __restrict__ out,
-    int64_t total, int64_t size_n, int64_t packed_n, int num_bits,
-    bool is_a_8bit) {
+    const int32_t* __restrict__ packed_zp, const half* __restrict__ scales,
+    half* __restrict__ out, int64_t total, int64_t size_n, int64_t packed_n,
+    int num_bits, bool is_a_8bit) {
   const int64_t idx = blockIdx.x * blockDim.x + threadIdx.x;
   if (idx >= total) return;
 
@@ -81,21 +78,18 @@ __global__ void sm70_unpack_dense_zp_to_half_kernel(
   if (!is_a_8bit) {
     packed_col_in_block =
         (packed_col_in_block / pack_factor) * pack_factor +
-        sm70_inverse_zp_interleave(packed_col_in_block % pack_factor,
-                                   num_bits);
+        sm70_inverse_zp_interleave(packed_col_in_block % pack_factor, num_bits);
   }
   const int64_t packed_col = block64 * 64 + packed_col_in_block;
-  const uint32_t word = reinterpret_cast<const uint32_t*>(packed_zp)
-      [(idx / size_n) * packed_n + packed_col / pack_factor];
-  const uint32_t zp =
-      (word >> ((packed_col % pack_factor) * num_bits)) &
-      ((1u << num_bits) - 1u);
+  const uint32_t word = reinterpret_cast<const uint32_t*>(
+      packed_zp)[(idx / size_n) * packed_n + packed_col / pack_factor];
+  const uint32_t zp = (word >> ((packed_col % pack_factor) * num_bits)) &
+                      ((1u << num_bits) - 1u);
   out[idx] = __float2half(static_cast<float>(zp) * __half2float(scales[idx]));
 }
 
 torch::Tensor sm70_dense_scales_as_logical(torch::Tensor const& b_scales,
-                                           int64_t size_k,
-                                           int64_t group_size,
+                                           int64_t size_k, int64_t group_size,
                                            bool is_a_8bit) {
   TORCH_CHECK(b_scales.scalar_type() == at::ScalarType::Half,
               "SM70 Marlin adapter expects fp16 scales.");
@@ -103,15 +97,14 @@ torch::Tensor sm70_dense_scales_as_logical(torch::Tensor const& b_scales,
       group_size < size_k && group_size != -1 && !is_a_8bit;
   const int perm_len = uses_group_perm ? 64 : 32;
   TORCH_CHECK(b_scales.numel() % perm_len == 0,
-              "SM70 Marlin scale metadata size is not divisible by ",
-              perm_len);
+              "SM70 Marlin scale metadata size is not divisible by ", perm_len);
 
   auto out = torch::empty_like(b_scales);
   const int64_t total = out.numel();
   constexpr int threads = 256;
   const int blocks = static_cast<int>((total + threads - 1) / threads);
-  sm70_unpermute_half_metadata_kernel<<<
-      blocks, threads, 0, at::cuda::getCurrentCUDAStream()>>>(
+  sm70_unpermute_half_metadata_kernel<<<blocks, threads, 0,
+                                        at::cuda::getCurrentCUDAStream()>>>(
       reinterpret_cast<const half*>(b_scales.data_ptr<at::Half>()),
       reinterpret_cast<half*>(out.data_ptr<at::Half>()), total, perm_len);
   C10_CUDA_KERNEL_LAUNCH_CHECK();
@@ -143,8 +136,8 @@ torch::Tensor sm70_dense_zp_as_half(torch::Tensor const& b_zeros,
   const int64_t total = out.numel();
   constexpr int threads = 256;
   const int blocks = static_cast<int>((total + threads - 1) / threads);
-  sm70_unpack_dense_zp_to_half_kernel<<<
-      blocks, threads, 0, at::cuda::getCurrentCUDAStream()>>>(
+  sm70_unpack_dense_zp_to_half_kernel<<<blocks, threads, 0,
+                                        at::cuda::getCurrentCUDAStream()>>>(
       b_zeros.data_ptr<int32_t>(),
       reinterpret_cast<const half*>(b_scales.data_ptr<at::Half>()),
       reinterpret_cast<half*>(out.data_ptr<at::Half>()), total, size_n,
@@ -202,8 +195,7 @@ torch::Tensor marlin_gemm(
     std::optional<torch::Tensor> const& global_scale_or_none,
     std::optional<torch::Tensor> const& b_zeros_or_none,
     std::optional<torch::Tensor> const& g_idx_or_none,
-    std::optional<torch::Tensor> const& perm_or_none,
-    torch::Tensor& workspace,
+    std::optional<torch::Tensor> const& perm_or_none, torch::Tensor& workspace,
     vllm::ScalarTypeId const& b_type_id, int64_t size_m, int64_t size_n,
     int64_t size_k, bool is_k_full, bool use_atomic_add, bool use_fp32_reduce,
     bool is_zp_float) {
@@ -273,8 +265,7 @@ torch::Tensor marlin_gemm(
               "SM70 build only supports float16 outputs.");
   TORCH_CHECK(s_type == vllm::kFloat16 ||
                   (b_type == vllm::kFE2M1f &&
-                   (s_type == vllm::kFE4M3fn ||
-                    s_type == vllm::kFE8M0fnu)),
+                   (s_type == vllm::kFE4M3fn || s_type == vllm::kFE8M0fnu)),
               "SM70 build only supports float16 scales, except FP4 uses "
               "float8_e4m3fn scales for NVFP4 or float8_e8m0fnu scales for "
               "MXFP4.");
@@ -325,10 +316,8 @@ torch::Tensor marlin_gemm(
   TORCH_CHECK(b_scales.is_contiguous(), "b_scales is not contiguous");
   TORCH_CHECK(b_scales.scalar_type() == at::ScalarType::Half ||
                   (b_type == vllm::kFE2M1f &&
-                   (b_scales.scalar_type() ==
-                        at::ScalarType::Float8_e4m3fn ||
-                    b_scales.scalar_type() ==
-                        at::ScalarType::Float8_e8m0fnu)),
+                   (b_scales.scalar_type() == at::ScalarType::Float8_e4m3fn ||
+                    b_scales.scalar_type() == at::ScalarType::Float8_e8m0fnu)),
               "SM70 build only supports float16 scales, except FP4 uses "
               "float8_e4m3fn scales for NVFP4 or float8_e8m0fnu scales for "
               "MXFP4.");
@@ -421,21 +410,18 @@ torch::Tensor marlin_gemm(
 
   torch::Tensor b_scales_kernel = b_scales;
   if (b_scales.scalar_type() == at::ScalarType::Half) {
-    b_scales_kernel =
-        sm70_dense_scales_as_logical(b_scales, size_k, group_size,
-                                     a_type.size_bits() == 8);
+    b_scales_kernel = sm70_dense_scales_as_logical(b_scales, size_k, group_size,
+                                                   a_type.size_bits() == 8);
   }
 
   torch::Tensor global_scale;
   if (global_scale_or_none.has_value()) {
     global_scale = global_scale_or_none.value();
-    TORCH_CHECK(
-        b_type == vllm::kFE2M1f && s_type == vllm::kFE4M3fn,
-        "SM70 Marlin supports global_scale only for "
-        "nvfp4 format.");
+    TORCH_CHECK(b_type == vllm::kFE2M1f && s_type == vllm::kFE4M3fn,
+                "SM70 Marlin supports global_scale only for "
+                "nvfp4 format.");
     TORCH_CHECK(global_scale.device().is_cuda(), "global_scale is not on GPU");
-    TORCH_CHECK(global_scale.is_contiguous(),
-                "global_scale is not contiguous");
+    TORCH_CHECK(global_scale.is_contiguous(), "global_scale is not contiguous");
     TORCH_CHECK(global_scale.scalar_type() == at::ScalarType::Float,
                 "SM70 Marlin NVFP4 expects fp32 global_scale.");
     TORCH_CHECK(global_scale.numel() == 1,
@@ -463,8 +449,7 @@ torch::Tensor marlin_gemm(
   if (b_zeros_or_none.has_value()) {
     b_zeros = b_zeros_or_none.value();
     TORCH_CHECK(b_zeros.device().is_cuda(), "b_zeros is not on GPU");
-    TORCH_CHECK(b_zeros.is_contiguous(),
-                "b_zeros is not contiguous");
+    TORCH_CHECK(b_zeros.is_contiguous(), "b_zeros is not contiguous");
   } else {
     b_zeros = torch::empty({0}, options);
   }
@@ -477,9 +462,9 @@ torch::Tensor marlin_gemm(
 
   if (has_zp) {
     if (!is_zp_float && b_zeros.scalar_type() == at::ScalarType::Int) {
-      b_zeros = sm70_dense_zp_as_half(
-          b_zeros, b_scales_kernel, size_n, b_type == vllm::kU4 ? 4 : 8,
-          a_type.size_bits() == 8);
+      b_zeros = sm70_dense_zp_as_half(b_zeros, b_scales_kernel, size_n,
+                                      b_type == vllm::kU4 ? 4 : 8,
+                                      a_type.size_bits() == 8);
       zp_is_float = true;
     }
   }
@@ -493,8 +478,7 @@ torch::Tensor marlin_gemm(
     TORCH_CHECK(b_zeros.scalar_type() == at::ScalarType::Half,
                 "SM70 Marlin uint4/uint8 dense path expects fp16 "
                 "zero points.");
-    TORCH_CHECK(b_zeros.size(1) == size_n,
-                "b_zeros dim 1 = ", b_zeros.size(1),
+    TORCH_CHECK(b_zeros.size(1) == size_n, "b_zeros dim 1 = ", b_zeros.size(1),
                 " is not size_n = ", size_n);
     TORCH_CHECK(num_groups == b_zeros.size(0),
                 "b_zeros dim 0 = ", b_zeros.size(0),
@@ -523,30 +507,26 @@ torch::Tensor marlin_gemm(
               "SM70 Marlin expects int32 packed weights.");
   TORCH_CHECK(!has_act_order,
               "act_order is not supported for the SM70 Marlin path.");
-  TORCH_CHECK(!has_bias,
-              "SM70 Marlin does not support bias. TODO: add epilogue bias fusion.");
+  TORCH_CHECK(
+      !has_bias,
+      "SM70 Marlin does not support bias. TODO: add epilogue bias fusion.");
   TORCH_CHECK((b_type == vllm::kFE2M1f && s_type == vllm::kFE4M3fn) ||
                   global_scale.numel() == 0,
               "SM70 Marlin supports global_scale only for "
               "nvfp4 format.");
   TORCH_CHECK(!use_atomic_add,
               "SM70 Marlin does not support atomic-add output.");
-  TORCH_CHECK(is_k_full,
-              "SM70 Marlin requires full-K non act-order inputs.");
-  TORCH_CHECK(size_k % 32 == 0,
-              "SM70 Marlin requires size_k % 32 == 0.");
-  TORCH_CHECK(size_n % 64 == 0,
-              "SM70 Marlin requires size_n % 64 == 0.");
+  TORCH_CHECK(is_k_full, "SM70 Marlin requires full-K non act-order inputs.");
+  TORCH_CHECK(size_k % 32 == 0, "SM70 Marlin requires size_k % 32 == 0.");
+  TORCH_CHECK(size_n % 64 == 0, "SM70 Marlin requires size_n % 64 == 0.");
   TORCH_CHECK(group_size == -1 || group_size > 0,
-              "SM70 Marlin received invalid group_size = ",
-              group_size);
+              "SM70 Marlin received invalid group_size = ", group_size);
 
   if (b_type == vllm::kU4) {
     TORCH_CHECK(size_k % 32 == 0,
                 "SM70 Marlin uint4 dense path requires size_k % 32 == 0.");
-    TORCH_CHECK(
-        has_zp && zp_is_float,
-        "SM70 Marlin uint4 dense path requires fp16 zero points.");
+    TORCH_CHECK(has_zp && zp_is_float,
+                "SM70 Marlin uint4 dense path requires fp16 zero points.");
     return sm70_marlin_u4_gemm(a, c, b_q_weight, b_scales_kernel, b_zeros,
                                size_m, size_n, size_k, group_size);
   }
@@ -554,17 +534,15 @@ torch::Tensor marlin_gemm(
   if (b_type == vllm::kU8) {
     TORCH_CHECK(size_k % 32 == 0,
                 "SM70 Marlin uint8 dense path requires size_k % 32 == 0.");
-    TORCH_CHECK(
-        has_zp && zp_is_float,
-        "SM70 Marlin uint8 dense path requires fp16 zero points.");
+    TORCH_CHECK(has_zp && zp_is_float,
+                "SM70 Marlin uint8 dense path requires fp16 zero points.");
     return sm70_marlin_u8_gemm(a, c, b_q_weight, b_scales_kernel, b_zeros,
                                size_m, size_n, size_k, group_size);
   }
 
   if (b_type == vllm::kU8B128) {
-    TORCH_CHECK(
-        size_k % 32 == 0,
-        "SM70 Marlin uint8b128 dense path requires size_k % 32 == 0.");
+    TORCH_CHECK(size_k % 32 == 0,
+                "SM70 Marlin uint8b128 dense path requires size_k % 32 == 0.");
     TORCH_CHECK(!has_zp && !is_zp_float,
                 "SM70 Marlin uint8b128 does not support "
                 "zero-point metadata.");
@@ -573,9 +551,8 @@ torch::Tensor marlin_gemm(
   }
 
   if (b_type == vllm::kFE4M3fn) {
-    TORCH_CHECK(
-        size_k % 32 == 0,
-        "SM70 Marlin FP8 dense path requires size_k % 32 == 0.");
+    TORCH_CHECK(size_k % 32 == 0,
+                "SM70 Marlin FP8 dense path requires size_k % 32 == 0.");
     TORCH_CHECK(group_size == -1 || group_size == 128,
                 "SM70 Marlin FP8 supports only group_size -1 or "
                 "128. Got ",
@@ -588,15 +565,15 @@ torch::Tensor marlin_gemm(
   }
 
   if (b_type == vllm::kFE2M1f) {
-    TORCH_CHECK(
-        size_k % 32 == 0,
-        "SM70 Marlin FP4 dense path requires size_k % 32 == 0.");
+    TORCH_CHECK(size_k % 32 == 0,
+                "SM70 Marlin FP4 dense path requires size_k % 32 == 0.");
     TORCH_CHECK(!has_zp && !is_zp_float,
                 "SM70 Marlin FP4 does not support zero-point "
                 "metadata.");
     if (s_type == vllm::kFE4M3fn) {
-      TORCH_CHECK(global_scale.numel() == 1,
-                  "the global_scale parameter must be passed for nvfp4 format.");
+      TORCH_CHECK(
+          global_scale.numel() == 1,
+          "the global_scale parameter must be passed for nvfp4 format.");
       TORCH_CHECK(group_size == 16,
                   "SM70 Marlin NVFP4 supports only group_size 16. "
                   "Got ",

--- a/csrc/quantization/marlin/sm70_marlin_fp8_gemm.cu
+++ b/csrc/quantization/marlin/sm70_marlin_fp8_gemm.cu
@@ -20,26 +20,26 @@
 #include "cutlass/layout/tensor_op_multiplicand_sm70.h"
 #include "cutlass/transform/threadblock/predicated_tile_iterator.h"
 
-using marlin::sm70::Sm70CtaGeometry;
-using marlin::sm70::Sm70AtomicFp16Epilogue;
-using marlin::sm70::Sm70AtomicFp32Epilogue;
-using marlin::sm70::sm70_marlin_narrow_f32_to_f16;
-using marlin::sm70::Sm70MarlinGemmTraits;
-using marlin::sm70::Sm70SplitKPartition;
-using marlin::sm70::validate_sm70_marlin_dense_cta_geometry_supported;
-using marlin::sm70::validate_sm70_marlin_dense_cta_n_alignment;
 using marlin::sm70::configure_sm70_dynamic_smem;
 using marlin::sm70::dispatch_sm70_marlin_fp8_geometry;
 using marlin::sm70::kQuantTileK;
 using marlin::sm70::kQuantTileN;
-using marlin::sm70::sm70_marlin_dense_auto_params;
 using marlin::sm70::load_qword_vector;
 using marlin::sm70::qword_from_vector;
-using marlin::sm70::sm70_marlin_cta_grid;
 using marlin::sm70::sm70_active_split_k;
+using marlin::sm70::sm70_marlin_cta_grid;
+using marlin::sm70::sm70_marlin_dense_auto_params;
+using marlin::sm70::sm70_marlin_narrow_f32_to_f16;
 using marlin::sm70::sm70_splitk_partition;
+using marlin::sm70::Sm70AtomicFp16Epilogue;
+using marlin::sm70::Sm70AtomicFp32Epilogue;
+using marlin::sm70::Sm70CtaGeometry;
+using marlin::sm70::Sm70MarlinGemmTraits;
+using marlin::sm70::Sm70SplitKPartition;
 using marlin::sm70::u8_packed_macro_n_qweight_offset_from_logical;
 using marlin::sm70::u8_packed_macro_n_qweight_word_stride;
+using marlin::sm70::validate_sm70_marlin_dense_cta_geometry_supported;
+using marlin::sm70::validate_sm70_marlin_dense_cta_n_alignment;
 
 namespace {
 
@@ -55,12 +55,11 @@ class Sm70Fp8IteratorB {
   static int const kPackedMacroN = PackedMacroN_;
   static constexpr bool kUseMetadataVectorWords = UseMetadataVectorWords_;
   using Element = cutlass::half_t;
-  using Fragment = cutlass::Array<
-      Element, ThreadMap::Iterations::kCount * ThreadMap::kElementsPerAccess>;
+  using Fragment = cutlass::Array<Element, ThreadMap::Iterations::kCount *
+                                               ThreadMap::kElementsPerAccess>;
   static_assert(Shape::kN == 64 || Shape::kN == 128 || Shape::kN == 256,
                 "SM70 Marlin FP8 IteratorB expects CTA_N in {64, 128, 256}.");
-  static_assert(ThreadMap::Iterations::kContiguous ==
-                    Shape::kN / kQuantTileN,
+  static_assert(ThreadMap::Iterations::kContiguous == Shape::kN / kQuantTileN,
                 "SM70 Marlin FP8 IteratorB expects one contiguous iteration "
                 "per 64-column quant tile.");
   static_assert(ThreadMap::Delta::kContiguous == kQuantTileN,
@@ -161,13 +160,12 @@ class Sm70Fp8IteratorB {
   CUTLASS_DEVICE
   static int qweight_offset_from_logical(Params const& params, int logical_k,
                                          int logical_n) {
-    return u8_packed_macro_n_qweight_offset_from_logical<kPackedMacroN>(params.size_n, logical_k,
-                                                     logical_n);
+    return u8_packed_macro_n_qweight_offset_from_logical<kPackedMacroN>(
+        params.size_n, logical_k, logical_n);
   }
 
   CUTLASS_DEVICE
-  static int qweight_word_stride_from_logical(Params const&,
-                                              int logical_n) {
+  static int qweight_word_stride_from_logical(Params const&, int logical_n) {
     return u8_packed_macro_n_qweight_word_stride<kPackedMacroN>();
   }
 
@@ -198,9 +196,8 @@ class Sm70Fp8IteratorB {
   void cache_current_group_metadata(int group) const {
     CUTLASS_PRAGMA_UNROLL
     for (int c = 0; c < ThreadMap::Iterations::kContiguous; ++c) {
-      int const cache_n =
-          n_offset_ + thread_offset_.contiguous() +
-          c * ThreadMap::Delta::kContiguous;
+      int const cache_n = n_offset_ + thread_offset_.contiguous() +
+                          c * ThreadMap::Delta::kContiguous;
       if constexpr (kUseMetadataVectorWords) {
         cache_metadata_vector_words(c, group, cache_n);
       } else {
@@ -261,8 +258,9 @@ class Sm70Fp8IteratorB {
           frag_vec[3] = __hmul2(deq[1], scale_vec[3]);
         }
       } else {
-        static_assert(ThreadMap::Iterations::kContiguous == 1,
-                      "Unsupported SM70 Marlin FP8 contiguous iteration count.");
+        static_assert(
+            ThreadMap::Iterations::kContiguous == 1,
+            "Unsupported SM70 Marlin FP8 contiguous iteration count.");
         uint32_t const qword0 =
             load_qword_vector<1>(qweight_ + qweight_base_offset_);
         uint32_t const qword1 = load_qword_vector<1>(
@@ -284,19 +282,17 @@ class Sm70Fp8IteratorB {
       int const logical_n_base = n_offset_ + thread_offset_.contiguous();
       CUTLASS_PRAGMA_UNROLL
       for (int s = 0; s < ThreadMap::Iterations::kStrided; ++s) {
-        int const logical_k_s =
-            k_offset_ + thread_offset_.strided() +
-            s * ThreadMap::Delta::kStrided;
+        int const logical_k_s = k_offset_ + thread_offset_.strided() +
+                                s * ThreadMap::Delta::kStrided;
         if constexpr (kGroupSize != -1) {
           cache_current_group_metadata(scale_group(logical_k_s));
         }
         int const qweight_base_s =
             qweight_offset_from_logical(params_, logical_k_s, logical_n_base);
         if constexpr (ThreadMap::Iterations::kContiguous == 4) {
-          uint4 const qwords0 =
-              load_qword_vector<4>(qweight_ + qweight_base_s);
-          uint4 const qwords1 = load_qword_vector<4>(
-              qweight_ + qweight_base_s + kQweightWordStrideWords);
+          uint4 const qwords0 = load_qword_vector<4>(qweight_ + qweight_base_s);
+          uint4 const qwords1 = load_qword_vector<4>(qweight_ + qweight_base_s +
+                                                     kQweightWordStrideWords);
           CUTLASS_PRAGMA_UNROLL
           for (int c = 0; c < ThreadMap::Iterations::kContiguous; ++c) {
             constexpr int kAccess = ThreadMap::kElementsPerAccess;
@@ -318,10 +314,9 @@ class Sm70Fp8IteratorB {
             frag_vec[3] = __hmul2(deq[1], scale_vec[3]);
           }
         } else if constexpr (ThreadMap::Iterations::kContiguous == 2) {
-          uint2 const qwords0 =
-              load_qword_vector<2>(qweight_ + qweight_base_s);
-          uint2 const qwords1 = load_qword_vector<2>(
-              qweight_ + qweight_base_s + kQweightWordStrideWords);
+          uint2 const qwords0 = load_qword_vector<2>(qweight_ + qweight_base_s);
+          uint2 const qwords1 = load_qword_vector<2>(qweight_ + qweight_base_s +
+                                                     kQweightWordStrideWords);
           CUTLASS_PRAGMA_UNROLL
           for (int c = 0; c < ThreadMap::Iterations::kContiguous; ++c) {
             constexpr int kAccess = ThreadMap::kElementsPerAccess;
@@ -343,8 +338,9 @@ class Sm70Fp8IteratorB {
             frag_vec[3] = __hmul2(deq[1], scale_vec[3]);
           }
         } else {
-          static_assert(ThreadMap::Iterations::kContiguous == 1,
-                        "Unsupported SM70 Marlin FP8 contiguous iteration count.");
+          static_assert(
+              ThreadMap::Iterations::kContiguous == 1,
+              "Unsupported SM70 Marlin FP8 contiguous iteration count.");
           uint32_t const qword0 =
               load_qword_vector<1>(qweight_ + qweight_base_s);
           uint32_t const qword1 = load_qword_vector<1>(
@@ -374,8 +370,7 @@ class Sm70Fp8IteratorB {
       return;
     }
 
-    if constexpr (kGroupSize != -1 &&
-                  ThreadMap::Iterations::kStrided == 1) {
+    if constexpr (kGroupSize != -1 && ThreadMap::Iterations::kStrided == 1) {
       int const first_logical_k = k_offset_ + thread_offset_.strided();
       cache_current_group_metadata(scale_group(first_logical_k));
     }
@@ -387,32 +382,29 @@ class Sm70Fp8IteratorB {
 template <bool UseMetadataVectorWords = true>
 struct Sm70Fp8GemmSpec {
   template <typename Shape, typename ThreadMap, int GroupSize, int PackedMacroN>
-  using IteratorB =
-      Sm70Fp8IteratorB<Shape, ThreadMap, GroupSize, PackedMacroN,
-                       UseMetadataVectorWords>;
+  using IteratorB = Sm70Fp8IteratorB<Shape, ThreadMap, GroupSize, PackedMacroN,
+                                     UseMetadataVectorWords>;
 };
 
-template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM,
-          int WarpN, int WarpK, int GroupSize, int PackedMacroN,
+template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM, int WarpN,
+          int WarpK, int GroupSize, int PackedMacroN,
           bool UseMetadataVectorWords = true>
 using Sm70Fp8GemmTraits =
-    Sm70MarlinGemmTraits<Sm70Fp8GemmSpec<UseMetadataVectorWords>, CtaM,
-                         CtaN, CtaK, Warps, WarpM, WarpN, WarpK,
-                         GroupSize, PackedMacroN>;
+    Sm70MarlinGemmTraits<Sm70Fp8GemmSpec<UseMetadataVectorWords>, CtaM, CtaN,
+                         CtaK, Warps, WarpM, WarpN, WarpK, GroupSize,
+                         PackedMacroN>;
 
-template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM,
-          int WarpN, int WarpK, int GroupSize, int PackedMacroN,
+template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM, int WarpN,
+          int WarpK, int GroupSize, int PackedMacroN,
           bool UseMetadataVectorWords = true>
-__global__ __launch_bounds__(Warps * 32, 1)
-void sm70_marlin_fp8_gemm_kernel(
+__global__ __launch_bounds__(Warps * 32, 1) void sm70_marlin_fp8_gemm_kernel(
     cutlass::half_t const* __restrict__ a,
     uint32_t const* __restrict__ b_q_weight,
     cutlass::half_t const* __restrict__ b_scales,
     cutlass::half_t* __restrict__ c, int m, int n, int k, int lda) {
   using Traits =
-      Sm70Fp8GemmTraits<CtaM, CtaN, CtaK, Warps, WarpM, WarpN, WarpK,
-                        GroupSize, PackedMacroN,
-                        UseMetadataVectorWords>;
+      Sm70Fp8GemmTraits<CtaM, CtaN, CtaK, Warps, WarpM, WarpN, WarpK, GroupSize,
+                        PackedMacroN, UseMetadataVectorWords>;
   using Mma = typename Traits::Mma;
   using Epilogue = typename Traits::Epilogue;
 
@@ -432,10 +424,10 @@ void sm70_marlin_fp8_gemm_kernel(
   typename Traits::LayoutA layout_a(lda);
   typename Traits::LayoutC layout_c(n);
 
-  typename Mma::IteratorA iterator_A(
-      typename Mma::IteratorA::Params(layout_a),
-      const_cast<cutlass::half_t*>(a), cutlass::MatrixCoord(m, k), thread_idx,
-      tb_offset_A);
+  typename Mma::IteratorA iterator_A(typename Mma::IteratorA::Params(layout_a),
+                                     const_cast<cutlass::half_t*>(a),
+                                     cutlass::MatrixCoord(m, k), thread_idx,
+                                     tb_offset_A);
   typename Mma::IteratorB iterator_B(
       typename Mma::IteratorB::Params(k, n),
       reinterpret_cast<uint32_t const*>(b_q_weight),
@@ -460,18 +452,19 @@ void sm70_marlin_fp8_gemm_kernel(
   epilogue(output_op, iterator_D, accumulators, iterator_C);
 }
 
-template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM,
-          int WarpN, int WarpK, int GroupSize, int PackedMacroN,
+template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM, int WarpN,
+          int WarpK, int GroupSize, int PackedMacroN,
           bool UseMetadataVectorWords = true>
-__global__ __launch_bounds__(Warps * 32, 1)
-void sm70_marlin_fp8_gemm_splitk_kernel(
+__global__
+__launch_bounds__(Warps * 32, 1) void sm70_marlin_fp8_gemm_splitk_kernel(
     cutlass::half_t const* __restrict__ a,
     uint32_t const* __restrict__ b_q_weight,
     cutlass::half_t const* __restrict__ b_scales,
-    cutlass::half_t* __restrict__ c, float* __restrict__ c32, int m, int n, int k, int lda, int requested_split_k) {
-  using Traits = Sm70Fp8GemmTraits<CtaM, CtaN, CtaK, Warps, WarpM, WarpN,
-                                   WarpK, GroupSize, PackedMacroN,
-                                   UseMetadataVectorWords>;
+    cutlass::half_t* __restrict__ c, float* __restrict__ c32, int m, int n,
+    int k, int lda, int requested_split_k) {
+  using Traits =
+      Sm70Fp8GemmTraits<CtaM, CtaN, CtaK, Warps, WarpM, WarpN, WarpK, GroupSize,
+                        PackedMacroN, UseMetadataVectorWords>;
   using Mma = typename Traits::Mma;
   using AtomicEpilogue = Sm70AtomicFp32Epilogue<Traits>;
 
@@ -482,14 +475,13 @@ void sm70_marlin_fp8_gemm_splitk_kernel(
   int const thread_idx = threadIdx.x;
   int const warp_idx = cutlass::canonical_warp_idx_sync();
   int const lane_idx = threadIdx.x % 32;
-  Sm70SplitKPartition const partition =
-      sm70_splitk_partition<GroupSize, CtaK>(k, requested_split_k, int(blockIdx.z));
+  Sm70SplitKPartition const partition = sm70_splitk_partition<GroupSize, CtaK>(
+      k, requested_split_k, int(blockIdx.z));
   if (partition.partition_k == 0) {
     return;
   }
 
-  cutlass::MatrixCoord tb_offset_A{int(blockIdx.x) * CtaM,
-                                   partition.k_begin};
+  cutlass::MatrixCoord tb_offset_A{int(blockIdx.x) * CtaM, partition.k_begin};
   cutlass::MatrixCoord tb_offset_B{partition.k_begin, int(blockIdx.y) * CtaN};
   cutlass::MatrixCoord tb_offset_C{int(blockIdx.x) * CtaM,
                                    int(blockIdx.y) * CtaN};
@@ -497,10 +489,10 @@ void sm70_marlin_fp8_gemm_splitk_kernel(
   typename Traits::LayoutA layout_a(lda);
   typename Traits::LayoutC layout_c(n);
 
-  typename Mma::IteratorA iterator_A(
-      typename Mma::IteratorA::Params(layout_a),
-      const_cast<cutlass::half_t*>(a), cutlass::MatrixCoord(m, k), thread_idx,
-      tb_offset_A);
+  typename Mma::IteratorA iterator_A(typename Mma::IteratorA::Params(layout_a),
+                                     const_cast<cutlass::half_t*>(a),
+                                     cutlass::MatrixCoord(m, k), thread_idx,
+                                     tb_offset_A);
   typename Mma::IteratorB iterator_B(
       typename Mma::IteratorB::Params(k, n),
       reinterpret_cast<uint32_t const*>(b_q_weight),
@@ -514,9 +506,8 @@ void sm70_marlin_fp8_gemm_splitk_kernel(
   mma(gemm_k_iterations, accumulators, iterator_A, iterator_B, accumulators);
 
   typename AtomicEpilogue::OutputTileIterator iterator_D(
-      typename AtomicEpilogue::OutputTileIterator::Params(layout_c),
-      c, cutlass::MatrixCoord(m, n),
-      thread_idx, tb_offset_C);
+      typename AtomicEpilogue::OutputTileIterator::Params(layout_c), c,
+      cutlass::MatrixCoord(m, n), thread_idx, tb_offset_C);
 
   AtomicEpilogue epilogue(shared_storage.epilogue, thread_idx, warp_idx,
                           lane_idx);
@@ -525,20 +516,23 @@ void sm70_marlin_fp8_gemm_splitk_kernel(
 
 }  // namespace
 
-template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM,
-          int WarpN, int WarpK, int GroupSize, int PackedMacroN,
+template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM, int WarpN,
+          int WarpK, int GroupSize, int PackedMacroN,
           bool UseMetadataVectorWords = true>
-torch::Tensor launch_sm70_marlin_fp8_gemm(
-    torch::Tensor& a, torch::Tensor& c, torch::Tensor& b_q_weight,
-    torch::Tensor& b_scales, int64_t size_m, int64_t size_n, int64_t size_k,
-    int requested_split_k) {
+torch::Tensor launch_sm70_marlin_fp8_gemm(torch::Tensor& a, torch::Tensor& c,
+                                          torch::Tensor& b_q_weight,
+                                          torch::Tensor& b_scales,
+                                          int64_t size_m, int64_t size_n,
+                                          int64_t size_k,
+                                          int requested_split_k) {
   auto kernel =
-      sm70_marlin_fp8_gemm_kernel<CtaM, CtaN, CtaK, Warps, WarpM, WarpN,
-                                  WarpK, GroupSize, PackedMacroN,
+      sm70_marlin_fp8_gemm_kernel<CtaM, CtaN, CtaK, Warps, WarpM, WarpN, WarpK,
+                                  GroupSize, PackedMacroN,
                                   UseMetadataVectorWords>;
-  using SharedStorage = typename Sm70Fp8GemmTraits<
-      CtaM, CtaN, CtaK, Warps, WarpM, WarpN, WarpK, GroupSize,
-      PackedMacroN, UseMetadataVectorWords>::SharedStorage;
+  using SharedStorage =
+      typename Sm70Fp8GemmTraits<CtaM, CtaN, CtaK, Warps, WarpM, WarpN, WarpK,
+                                 GroupSize, PackedMacroN,
+                                 UseMetadataVectorWords>::SharedStorage;
   size_t smem_bytes = configure_sm70_dynamic_smem<SharedStorage>(kernel);
 
   dim3 block(Warps * 32);
@@ -558,14 +552,13 @@ torch::Tensor launch_sm70_marlin_fp8_gemm(
   }
 
   TORCH_CHECK(size_k % int64_t(CtaK) == 0,
-              "SM70 Marlin fp8_e4m3 requires K divisible by CTA_K=",
-              CtaK, " for requested_split_k > 1. Got K=", size_k,
+              "SM70 Marlin fp8_e4m3 requires K divisible by CTA_K=", CtaK,
+              " for requested_split_k > 1. Got K=", size_k,
               ", requested_split_k=", requested_split_k, ".");
 
   auto split_kernel =
-      sm70_marlin_fp8_gemm_splitk_kernel<CtaM, CtaN, CtaK, Warps, WarpM,
-                                         WarpN, WarpK, GroupSize,
-                                         PackedMacroN,
+      sm70_marlin_fp8_gemm_splitk_kernel<CtaM, CtaN, CtaK, Warps, WarpM, WarpN,
+                                         WarpK, GroupSize, PackedMacroN,
                                          UseMetadataVectorWords>;
   smem_bytes = configure_sm70_dynamic_smem<SharedStorage>(split_kernel);
 
@@ -573,8 +566,7 @@ torch::Tensor launch_sm70_marlin_fp8_gemm(
   // 0009: fp32 split-K scratch (zeroed for the fp32 atomicAdd), M*N floats.
   // Only allocated on the split_k>1 path, which the auto-selector uses ONLY at
   // low batch (M<128), so the scratch is bounded and small.
-  auto c32 = torch::zeros({size_m, size_n},
-                          a.options().dtype(at::kFloat));
+  auto c32 = torch::zeros({size_m, size_n}, a.options().dtype(at::kFloat));
 
   dim3 grid = sm70_marlin_cta_grid(size_m, size_n, CtaM, CtaN);
   int const active_split_k =
@@ -585,9 +577,9 @@ torch::Tensor launch_sm70_marlin_fp8_gemm(
       reinterpret_cast<uint32_t const*>(b_q_weight.data_ptr<int32_t>()),
       reinterpret_cast<cutlass::half_t const*>(b_scales.data_ptr<at::Half>()),
       reinterpret_cast<cutlass::half_t*>(c.data_ptr<at::Half>()),
-      c32.data_ptr<float>(),
-      static_cast<int>(size_m), static_cast<int>(size_n),
-      static_cast<int>(size_k), static_cast<int>(a.stride(0)), requested_split_k);
+      c32.data_ptr<float>(), static_cast<int>(size_m), static_cast<int>(size_n),
+      static_cast<int>(size_k), static_cast<int>(a.stride(0)),
+      requested_split_k);
   C10_CUDA_KERNEL_LAUNCH_CHECK();
 
   // 0009: single deterministic-width fp32->fp16 narrow of the scratch.
@@ -595,8 +587,8 @@ torch::Tensor launch_sm70_marlin_fp8_gemm(
   int const narrow_grid =
       static_cast<int>((numel + narrow_block - 1) / narrow_block);
   sm70_marlin_narrow_f32_to_f16<256><<<narrow_grid, narrow_block, 0, stream>>>(
-      c32.data_ptr<float>(),
-      reinterpret_cast<half*>(c.data_ptr<at::Half>()), numel);
+      c32.data_ptr<float>(), reinterpret_cast<half*>(c.data_ptr<at::Half>()),
+      numel);
   C10_CUDA_KERNEL_LAUNCH_CHECK();
 
   return c;
@@ -613,8 +605,8 @@ struct Sm70Fp8Launcher {
   int64_t size_k;
   int requested_split_k;
 
-  template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM,
-            int WarpN, int WarpK, int GroupSize, int PackedMacroN>
+  template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM, int WarpN,
+            int WarpK, int GroupSize, int PackedMacroN>
   torch::Tensor operator()() const {
     return launch_sm70_marlin_fp8_gemm<CtaM, CtaN, CtaK, Warps, WarpM, WarpN,
                                        WarpK, GroupSize, PackedMacroN,
@@ -630,21 +622,23 @@ torch::Tensor sm70_marlin_fp8_gemm(torch::Tensor& a, torch::Tensor& c,
                                    int64_t group_size) {
   c10::cuda::CUDAGuard device_guard(a.device());
 
-  auto const params = sm70_marlin_dense_auto_params(
-      "fp8_e4m3", group_size, size_m, size_n, size_k);
+  auto const params = sm70_marlin_dense_auto_params("fp8_e4m3", group_size,
+                                                    size_m, size_n, size_k);
   Sm70CtaGeometry const geometry = params.geometry;
-  validate_sm70_marlin_dense_cta_geometry_supported("SM70 Marlin fp8_e4m3", geometry);
-  validate_sm70_marlin_dense_cta_n_alignment("SM70 Marlin fp8_e4m3", geometry, size_n);
+  validate_sm70_marlin_dense_cta_geometry_supported("SM70 Marlin fp8_e4m3",
+                                                    geometry);
+  validate_sm70_marlin_dense_cta_n_alignment("SM70 Marlin fp8_e4m3", geometry,
+                                             size_n);
   if (params.use_metadata_vector_words) {
     Sm70Fp8Launcher<true> const launcher{
-        a, c, b_q_weight, b_scales, size_m, size_n, size_k,
-        params.requested_split_k};
-    return dispatch_sm70_marlin_fp8_geometry(
-        launcher, geometry, params.packed_macro_n, group_size);
+        a,      c,      b_q_weight, b_scales,
+        size_m, size_n, size_k,     params.requested_split_k};
+    return dispatch_sm70_marlin_fp8_geometry(launcher, geometry,
+                                             params.packed_macro_n, group_size);
   }
   Sm70Fp8Launcher<false> const launcher{
-      a, c, b_q_weight, b_scales, size_m, size_n, size_k,
-      params.requested_split_k};
-  return dispatch_sm70_marlin_fp8_geometry(
-      launcher, geometry, params.packed_macro_n, group_size);
+      a,      c,      b_q_weight, b_scales,
+      size_m, size_n, size_k,     params.requested_split_k};
+  return dispatch_sm70_marlin_fp8_geometry(launcher, geometry,
+                                           params.packed_macro_n, group_size);
 }

--- a/csrc/quantization/marlin/sm70_marlin_gemm.cuh
+++ b/csrc/quantization/marlin/sm70_marlin_gemm.cuh
@@ -30,8 +30,7 @@ struct Sm70MarlinGemmTraits {
                 "SM70 Marlin supports CTA_N in {64, 128, 256}.");
   static_assert(CtaK == 16 || CtaK == 32 || CtaK == 64 || CtaK == 128,
                 "SM70 Marlin supports CTA_K in {16, 32, 64, 128}.");
-  static_assert(Warps == 4 || Warps == 8,
-                "SM70 Marlin supports 4 or 8 warps.");
+  static_assert(Warps == 4 || Warps == 8, "SM70 Marlin supports 4 or 8 warps.");
   static_assert(PackedMacroN == 64 || PackedMacroN == 128 ||
                     PackedMacroN == 256,
                 "SM70 Marlin packed macro-N must be 64, 128, or 256.");
@@ -45,8 +44,8 @@ struct Sm70MarlinGemmTraits {
   using LayoutB = cutlass::layout::RowMajor;
   using LayoutC = cutlass::layout::RowMajor;
   using ThreadblockShape = cutlass::gemm::GemmShape<CtaM, CtaN, CtaK>;
-  using WarpShape =
-      typename Sm70WarpShape<CtaM, CtaN, CtaK, Warps, WarpM, WarpN, WarpK>::Type;
+  using WarpShape = typename Sm70WarpShape<CtaM, CtaN, CtaK, Warps, WarpM,
+                                           WarpN, WarpK>::Type;
   static_assert(WarpShape::kM <= 64 && WarpShape::kN <= 64,
                 "SM70 Marlin keeps per-warp M/N no larger than 64.");
   using InstructionShape = cutlass::gemm::GemmShape<8, 8, 4>;
@@ -60,9 +59,10 @@ struct Sm70MarlinGemmTraits {
       cutlass::MatrixShape<ThreadblockShape::kM, ThreadblockShape::kK>,
       ElementA, LayoutA, 1, typename MmaCore::IteratorThreadMapA,
       128 / cutlass::sizeof_bits<ElementA>::value>;
-  using IteratorB = typename Spec::template IteratorB<
-      ThreadblockShape, typename MmaCore::IteratorThreadMapB, GroupSize,
-      PackedMacroN>;
+  using IteratorB =
+      typename Spec::template IteratorB<ThreadblockShape,
+                                        typename MmaCore::IteratorThreadMapB,
+                                        GroupSize, PackedMacroN>;
   using Mma = Sm70MarlinMmaPipelined<
       ThreadblockShape, IteratorA, typename MmaCore::SmemIteratorA, IteratorB,
       typename MmaCore::SmemIteratorB, ElementAccumulator, LayoutC,
@@ -102,17 +102,17 @@ torch::Tensor dispatch_sm70_marlin_group_size(Launcher const& launcher,
                                               char const* quant_name) {
   switch (group_size) {
     case -1:
-      return launcher.template operator()<CtaM, CtaN, CtaK, Warps, WarpM,
-                                          WarpN, WarpK, -1, PackedMacroN>();
+      return launcher.template operator()<CtaM, CtaN, CtaK, Warps, WarpM, WarpN,
+                                          WarpK, -1, PackedMacroN>();
     case 32:
-      return launcher.template operator()<CtaM, CtaN, CtaK, Warps, WarpM,
-                                          WarpN, WarpK, 32, PackedMacroN>();
+      return launcher.template operator()<CtaM, CtaN, CtaK, Warps, WarpM, WarpN,
+                                          WarpK, 32, PackedMacroN>();
     case 64:
-      return launcher.template operator()<CtaM, CtaN, CtaK, Warps, WarpM,
-                                          WarpN, WarpK, 64, PackedMacroN>();
+      return launcher.template operator()<CtaM, CtaN, CtaK, Warps, WarpM, WarpN,
+                                          WarpK, 64, PackedMacroN>();
     case 128:
-      return launcher.template operator()<CtaM, CtaN, CtaK, Warps, WarpM,
-                                          WarpN, WarpK, 128, PackedMacroN>();
+      return launcher.template operator()<CtaM, CtaN, CtaK, Warps, WarpM, WarpN,
+                                          WarpK, 128, PackedMacroN>();
     default:
       TORCH_CHECK(false, "SM70 Marlin ", quant_name,
                   " supports only group_size -1, 32, 64, or 128. Got ",
@@ -127,17 +127,17 @@ torch::Tensor dispatch_sm70_marlin_group_size_with_group32(
     Launcher const& launcher, int64_t group_size, char const* quant_name) {
   switch (group_size) {
     case -1:
-      return launcher.template operator()<CtaM, CtaN, CtaK, Warps, WarpM,
-                                          WarpN, WarpK, -1, PackedMacroN>();
+      return launcher.template operator()<CtaM, CtaN, CtaK, Warps, WarpM, WarpN,
+                                          WarpK, -1, PackedMacroN>();
     case 32:
-      return launcher.template operator()<CtaM, CtaN, CtaK, Warps, WarpM,
-                                          WarpN, WarpK, 32, PackedMacroN>();
+      return launcher.template operator()<CtaM, CtaN, CtaK, Warps, WarpM, WarpN,
+                                          WarpK, 32, PackedMacroN>();
     case 64:
-      return launcher.template operator()<CtaM, CtaN, CtaK, Warps, WarpM,
-                                          WarpN, WarpK, 64, PackedMacroN>();
+      return launcher.template operator()<CtaM, CtaN, CtaK, Warps, WarpM, WarpN,
+                                          WarpK, 64, PackedMacroN>();
     case 128:
-      return launcher.template operator()<CtaM, CtaN, CtaK, Warps, WarpM,
-                                          WarpN, WarpK, 128, PackedMacroN>();
+      return launcher.template operator()<CtaM, CtaN, CtaK, Warps, WarpM, WarpN,
+                                          WarpK, 128, PackedMacroN>();
     default:
       TORCH_CHECK(false, "SM70 Marlin ", quant_name,
                   " supports only group_size -1, 32, 64, or 128. Got ",
@@ -152,15 +152,16 @@ torch::Tensor dispatch_sm70_marlin_fp8_group_size(Launcher const& launcher,
                                                   int64_t group_size) {
   switch (group_size) {
     case -1:
-      return launcher.template operator()<CtaM, CtaN, CtaK, Warps, WarpM,
-                                          WarpN, WarpK, -1, PackedMacroN>();
+      return launcher.template operator()<CtaM, CtaN, CtaK, Warps, WarpM, WarpN,
+                                          WarpK, -1, PackedMacroN>();
     case 128:
-      return launcher.template operator()<CtaM, CtaN, CtaK, Warps, WarpM,
-                                          WarpN, WarpK, 128, PackedMacroN>();
+      return launcher.template operator()<CtaM, CtaN, CtaK, Warps, WarpM, WarpN,
+                                          WarpK, 128, PackedMacroN>();
     default:
-      TORCH_CHECK(false,
-                  "SM70 Marlin fp8_e4m3 supports only group_size -1 or 128. Got ",
-                  group_size, ".");
+      TORCH_CHECK(
+          false,
+          "SM70 Marlin fp8_e4m3 supports only group_size -1 or 128. Got ",
+          group_size, ".");
   }
   return torch::Tensor();
 }
@@ -175,58 +176,57 @@ torch::Tensor dispatch_sm70_marlin_cta_geometry(Launcher const& launcher,
     return launcher.template operator()<CM, CN, CK, W, WM, WN, WK, PMN>(); \
   }
 
-#define DISPATCH_SM70_GEOMETRY(CM, CN, CK, W, WM, WN, WK, PMN)             \
-  if (geometry.cta_m == CM && geometry.cta_n == CN &&                      \
-      geometry.cta_k == CK && geometry.warps == W &&                       \
-      geometry.warp_m == WM && geometry.warp_n == WN &&                    \
-      geometry.warp_k == WK) {                                             \
-    DISPATCH_SM70_PACKED_MACRO_N(CM, CN, CK, W, WM, WN, WK, PMN)           \
+#define DISPATCH_SM70_GEOMETRY(CM, CN, CK, W, WM, WN, WK, PMN)                 \
+  if (geometry.cta_m == CM && geometry.cta_n == CN && geometry.cta_k == CK &&  \
+      geometry.warps == W && geometry.warp_m == WM && geometry.warp_n == WN && \
+      geometry.warp_k == WK) {                                                 \
+    DISPATCH_SM70_PACKED_MACRO_N(CM, CN, CK, W, WM, WN, WK, PMN)               \
   }
 
-#define FOR_EACH_SM70_GEOMETRY(M)                                         \
-  M(32, 64, 32, 4, 32, 32, 16, 128)                                       \
-  M(32, 64, 32, 4, 32, 32, 16, 256)                                       \
-  M(32, 64, 64, 4, 32, 32, 32, 128)                                       \
-  M(32, 64, 64, 4, 32, 32, 32, 256)                                       \
-  M(32, 64, 64, 4, 32, 64, 16, 128)                                       \
-  M(32, 64, 64, 4, 32, 64, 16, 256)                                       \
-  M(32, 64, 128, 4, 32, 64, 32, 128)                                      \
-  M(32, 64, 128, 4, 32, 64, 32, 256)                                      \
-  M(32, 128, 32, 4, 32, 32, 32, 128)                                      \
-  M(32, 128, 32, 4, 32, 32, 32, 256)                                      \
-  M(32, 128, 64, 4, 32, 64, 32, 128)                                      \
-  M(32, 128, 64, 4, 32, 64, 32, 256)                                      \
-  M(32, 128, 64, 8, 32, 32, 32, 128)                                      \
-  M(32, 128, 64, 8, 32, 32, 32, 256)                                      \
-  M(32, 128, 128, 8, 32, 64, 32, 128)                                     \
-  M(32, 128, 128, 8, 32, 64, 32, 256)                                     \
-  M(32, 256, 32, 4, 32, 64, 32, 256)                                      \
-  M(32, 256, 64, 8, 32, 64, 32, 256)                                      \
-  M(64, 64, 32, 4, 32, 32, 32, 64)                                        \
-  M(64, 64, 32, 4, 32, 32, 32, 128)                                       \
-  M(64, 64, 32, 4, 32, 32, 32, 256)                                       \
-  M(64, 64, 32, 4, 64, 32, 16, 128)                                       \
-  M(64, 64, 32, 4, 64, 32, 16, 256)                                       \
-  M(64, 64, 64, 4, 32, 64, 32, 128)                                       \
-  M(64, 64, 64, 4, 32, 64, 32, 256)                                       \
-  M(64, 64, 64, 4, 64, 32, 32, 128)                                       \
-  M(64, 64, 64, 4, 64, 32, 32, 256)                                       \
-  M(64, 64, 64, 4, 64, 64, 16, 128)                                       \
-  M(64, 64, 64, 4, 64, 64, 16, 256)                                       \
-  M(64, 128, 32, 4, 32, 64, 32, 128)                                      \
-  M(64, 128, 32, 4, 32, 64, 32, 256)                                      \
-  M(64, 128, 32, 4, 64, 32, 32, 128)                                      \
-  M(64, 128, 32, 4, 64, 32, 32, 256)                                      \
-  M(64, 128, 128, 8, 64, 64, 32, 128)                                     \
-  M(64, 128, 128, 8, 64, 64, 32, 256)                                     \
-  M(128, 64, 32, 4, 32, 64, 32, 128)                                      \
-  M(128, 64, 32, 4, 32, 64, 32, 256)                                      \
-  M(128, 64, 128, 8, 64, 64, 32, 128)                                     \
-  M(128, 64, 128, 8, 64, 64, 32, 256)                                     \
-  M(128, 128, 32, 4, 64, 64, 32, 128)                                     \
-  M(128, 128, 32, 4, 64, 64, 32, 256)                                     \
-  M(128, 128, 64, 8, 64, 64, 32, 128)                                     \
-  M(128, 128, 64, 8, 64, 64, 32, 256)                                     \
+#define FOR_EACH_SM70_GEOMETRY(M)     \
+  M(32, 64, 32, 4, 32, 32, 16, 128)   \
+  M(32, 64, 32, 4, 32, 32, 16, 256)   \
+  M(32, 64, 64, 4, 32, 32, 32, 128)   \
+  M(32, 64, 64, 4, 32, 32, 32, 256)   \
+  M(32, 64, 64, 4, 32, 64, 16, 128)   \
+  M(32, 64, 64, 4, 32, 64, 16, 256)   \
+  M(32, 64, 128, 4, 32, 64, 32, 128)  \
+  M(32, 64, 128, 4, 32, 64, 32, 256)  \
+  M(32, 128, 32, 4, 32, 32, 32, 128)  \
+  M(32, 128, 32, 4, 32, 32, 32, 256)  \
+  M(32, 128, 64, 4, 32, 64, 32, 128)  \
+  M(32, 128, 64, 4, 32, 64, 32, 256)  \
+  M(32, 128, 64, 8, 32, 32, 32, 128)  \
+  M(32, 128, 64, 8, 32, 32, 32, 256)  \
+  M(32, 128, 128, 8, 32, 64, 32, 128) \
+  M(32, 128, 128, 8, 32, 64, 32, 256) \
+  M(32, 256, 32, 4, 32, 64, 32, 256)  \
+  M(32, 256, 64, 8, 32, 64, 32, 256)  \
+  M(64, 64, 32, 4, 32, 32, 32, 64)    \
+  M(64, 64, 32, 4, 32, 32, 32, 128)   \
+  M(64, 64, 32, 4, 32, 32, 32, 256)   \
+  M(64, 64, 32, 4, 64, 32, 16, 128)   \
+  M(64, 64, 32, 4, 64, 32, 16, 256)   \
+  M(64, 64, 64, 4, 32, 64, 32, 128)   \
+  M(64, 64, 64, 4, 32, 64, 32, 256)   \
+  M(64, 64, 64, 4, 64, 32, 32, 128)   \
+  M(64, 64, 64, 4, 64, 32, 32, 256)   \
+  M(64, 64, 64, 4, 64, 64, 16, 128)   \
+  M(64, 64, 64, 4, 64, 64, 16, 256)   \
+  M(64, 128, 32, 4, 32, 64, 32, 128)  \
+  M(64, 128, 32, 4, 32, 64, 32, 256)  \
+  M(64, 128, 32, 4, 64, 32, 32, 128)  \
+  M(64, 128, 32, 4, 64, 32, 32, 256)  \
+  M(64, 128, 128, 8, 64, 64, 32, 128) \
+  M(64, 128, 128, 8, 64, 64, 32, 256) \
+  M(128, 64, 32, 4, 32, 64, 32, 128)  \
+  M(128, 64, 32, 4, 32, 64, 32, 256)  \
+  M(128, 64, 128, 8, 64, 64, 32, 128) \
+  M(128, 64, 128, 8, 64, 64, 32, 256) \
+  M(128, 128, 32, 4, 64, 64, 32, 128) \
+  M(128, 128, 32, 4, 64, 64, 32, 256) \
+  M(128, 128, 64, 8, 64, 64, 32, 128) \
+  M(128, 128, 64, 8, 64, 64, 32, 256) \
   M(128, 256, 32, 8, 64, 64, 32, 256)
 
   FOR_EACH_SM70_GEOMETRY(DISPATCH_SM70_GEOMETRY)
@@ -261,8 +261,8 @@ torch::Tensor dispatch_sm70_marlin_geometry(Launcher const& launcher,
                                             int64_t group_size,
                                             char const* quant_name) {
   return dispatch_sm70_marlin_cta_geometry(
-      Sm70MarlinGroupSizeDispatchLauncher<Launcher>{
-          launcher, group_size, quant_name},
+      Sm70MarlinGroupSizeDispatchLauncher<Launcher>{launcher, group_size,
+                                                    quant_name},
       geometry, packed_macro_n, quant_name);
 }
 
@@ -300,8 +300,8 @@ torch::Tensor dispatch_sm70_marlin_geometry_with_group32(
     Launcher const& launcher, Sm70CtaGeometry geometry, int packed_macro_n,
     int64_t group_size, char const* quant_name) {
   return dispatch_sm70_marlin_cta_geometry(
-      Sm70MarlinGroupSize32DispatchLauncher<Launcher>{
-          launcher, group_size, quant_name},
+      Sm70MarlinGroupSize32DispatchLauncher<Launcher>{launcher, group_size,
+                                                      quant_name},
       geometry, packed_macro_n, quant_name);
 }
 
@@ -339,8 +339,8 @@ struct Sm70MarlinFixedGroupDispatchLauncher {
             int WarpK, int PackedMacroN>
   torch::Tensor operator()() const {
     return dispatch_sm70_marlin_fixed_group_size<
-        CtaM, CtaN, CtaK, Warps, WarpM, WarpN, WarpK, GroupSize,
-        PackedMacroN>(inner, group_size, quant_name);
+        CtaM, CtaN, CtaK, Warps, WarpM, WarpN, WarpK, GroupSize, PackedMacroN>(
+        inner, group_size, quant_name);
   }
 };
 

--- a/csrc/quantization/marlin/sm70_marlin_iterator_utils.cuh
+++ b/csrc/quantization/marlin/sm70_marlin_iterator_utils.cuh
@@ -30,23 +30,23 @@ struct QwordVector<4> {
 template <int ContiguousWords>
 CUTLASS_DEVICE typename QwordVector<ContiguousWords>::Type load_qword_vector(
     uint32_t const* ptr) {
-  static_assert(ContiguousWords == 1 || ContiguousWords == 2 ||
-                    ContiguousWords == 4,
-                "SM70 qword vector load supports 1, 2, or 4 words.");
+  static_assert(
+      ContiguousWords == 1 || ContiguousWords == 2 || ContiguousWords == 4,
+      "SM70 qword vector load supports 1, 2, or 4 words.");
   if constexpr (ContiguousWords == 1) {
     return *ptr;
   } else {
-    return *reinterpret_cast<typename QwordVector<ContiguousWords>::Type const*>(
-        ptr);
+    return *reinterpret_cast<
+        typename QwordVector<ContiguousWords>::Type const*>(ptr);
   }
 }
 
 template <int ContiguousWords>
 CUTLASS_DEVICE uint32_t qword_from_vector(
     typename QwordVector<ContiguousWords>::Type const& words, int c) {
-  static_assert(ContiguousWords == 1 || ContiguousWords == 2 ||
-                    ContiguousWords == 4,
-                "SM70 qword vector access supports 1, 2, or 4 words.");
+  static_assert(
+      ContiguousWords == 1 || ContiguousWords == 2 || ContiguousWords == 4,
+      "SM70 qword vector access supports 1, 2, or 4 words.");
   if constexpr (ContiguousWords == 1) {
     return words;
   } else {
@@ -68,9 +68,9 @@ CUTLASS_DEVICE uint32_t qword_from_vector(uint2 const& words, int c) {
 template <int PackedMacroN>
 CUTLASS_DEVICE int u4_packed_macro_n_qweight_offset_from_logical(
     int size_n, int logical_k, int logical_n) {
-  static_assert(PackedMacroN == 64 || PackedMacroN == 128 ||
-                    PackedMacroN == 256,
-                "SM70 Marlin packed macro-N must be 64, 128, or 256.");
+  static_assert(
+      PackedMacroN == 64 || PackedMacroN == 128 || PackedMacroN == 256,
+      "SM70 Marlin packed macro-N must be 64, 128, or 256.");
   constexpr int kGroupTiles = PackedMacroN / kQuantTileN;
   int const k_tile = logical_k / kQuantTileK;
   int const local_k = logical_k - k_tile * kQuantTileK;
@@ -89,9 +89,9 @@ CUTLASS_DEVICE int u4_packed_macro_n_qweight_offset_from_logical(
 template <int PackedMacroN>
 CUTLASS_DEVICE int u8_packed_macro_n_qweight_offset_from_logical(
     int size_n, int logical_k, int logical_n) {
-  static_assert(PackedMacroN == 64 || PackedMacroN == 128 ||
-                    PackedMacroN == 256,
-                "SM70 Marlin packed macro-N must be 64, 128, or 256.");
+  static_assert(
+      PackedMacroN == 64 || PackedMacroN == 128 || PackedMacroN == 256,
+      "SM70 Marlin packed macro-N must be 64, 128, or 256.");
   constexpr int kGroupTiles = PackedMacroN / kQuantTileN;
   int const k_tile = logical_k / kQuantTileK;
   int const local_k = logical_k - k_tile * kQuantTileK;
@@ -109,9 +109,9 @@ CUTLASS_DEVICE int u8_packed_macro_n_qweight_offset_from_logical(
 
 template <int PackedMacroN>
 CUTLASS_DEVICE int u8_packed_macro_n_qweight_word_stride() {
-  static_assert(PackedMacroN == 64 || PackedMacroN == 128 ||
-                    PackedMacroN == 256,
-                "SM70 Marlin packed macro-N must be 64, 128, or 256.");
+  static_assert(
+      PackedMacroN == 64 || PackedMacroN == 128 || PackedMacroN == 256,
+      "SM70 Marlin packed macro-N must be 64, 128, or 256.");
   return PackedMacroN / kQuantTileN;
 }
 

--- a/csrc/quantization/marlin/sm70_marlin_mma.cuh
+++ b/csrc/quantization/marlin/sm70_marlin_mma.cuh
@@ -7,17 +7,16 @@
 
 namespace marlin::sm70 {
 
-template <
-    typename Shape_, typename IteratorA_, typename SmemIteratorA_,
-    typename IteratorB_, typename SmemIteratorB_, typename ElementC_,
-    typename LayoutC_, typename Policy_,
-    typename TransformA_ = cutlass::NumericArrayConverter<
-        typename SmemIteratorA_::Element, typename IteratorA_::Element,
-        IteratorA_::Fragment::kElements>,
-    typename TransformB_ = cutlass::NumericArrayConverter<
-        typename SmemIteratorB_::Element, typename IteratorB_::Element,
-        IteratorB_::Fragment::kElements>,
-    typename Enable = bool>
+template <typename Shape_, typename IteratorA_, typename SmemIteratorA_,
+          typename IteratorB_, typename SmemIteratorB_, typename ElementC_,
+          typename LayoutC_, typename Policy_,
+          typename TransformA_ = cutlass::NumericArrayConverter<
+              typename SmemIteratorA_::Element, typename IteratorA_::Element,
+              IteratorA_::Fragment::kElements>,
+          typename TransformB_ = cutlass::NumericArrayConverter<
+              typename SmemIteratorB_::Element, typename IteratorB_::Element,
+              IteratorB_::Fragment::kElements>,
+          typename Enable = bool>
 class Sm70MarlinMmaPipelined
     : public cutlass::gemm::threadblock::MmaBase<Shape_, Policy_, 2> {
  public:
@@ -106,10 +105,10 @@ class Sm70MarlinMmaPipelined
 
  public:
   CUTLASS_DEVICE
-  Sm70MarlinMmaPipelined(
-      typename Base::SharedStorage& shared_storage, int thread_idx,
-      int warp_idx, int lane_idx, TransformA transform_A = TransformA(),
-      TransformB transform_B = TransformB())
+  Sm70MarlinMmaPipelined(typename Base::SharedStorage& shared_storage,
+                         int thread_idx, int warp_idx, int lane_idx,
+                         TransformA transform_A = TransformA(),
+                         TransformB transform_B = TransformB())
       : Base(shared_storage, thread_idx, warp_idx, lane_idx),
         smem_iterator_A_(shared_storage.operand_A_ref(), thread_idx),
         smem_iterator_B_(shared_storage.operand_B_ref(), thread_idx),
@@ -154,12 +153,12 @@ class Sm70MarlinMmaPipelined
       this->smem_iterator_B_.add_tile_offset({-Base::kStages, 0});
 
       if constexpr (Policy::kPartitionsK > 1) {
-        add_warp_tile_k_group_offset(
-            (Policy::kPartitionsK - 1) * Base::kWarpGemmIterations);
+        add_warp_tile_k_group_offset((Policy::kPartitionsK - 1) *
+                                     Base::kWarpGemmIterations);
       }
     } else {
-      add_warp_tile_k_group_offset(
-          -(Policy::kPartitionsK + 1) * Base::kWarpGemmIterations);
+      add_warp_tile_k_group_offset(-(Policy::kPartitionsK + 1) *
+                                   Base::kWarpGemmIterations);
     }
 
     smem_write_stage_idx ^= 1;
@@ -222,10 +221,10 @@ class Sm70MarlinMmaPipelined
           advance_smem_stages();
         }
 
-        this->warp_tile_iterator_A_.set_kgroup_index(
-            (warp_mma_k + 1) % Base::kWarpGemmIterations);
-        this->warp_tile_iterator_B_.set_kgroup_index(
-            (warp_mma_k + 1) % Base::kWarpGemmIterations);
+        this->warp_tile_iterator_A_.set_kgroup_index((warp_mma_k + 1) %
+                                                     Base::kWarpGemmIterations);
+        this->warp_tile_iterator_B_.set_kgroup_index((warp_mma_k + 1) %
+                                                     Base::kWarpGemmIterations);
 
         this->warp_tile_iterator_A_.load(warp_frag_A[(warp_mma_k + 1) % 2]);
         this->warp_tile_iterator_B_.load(warp_frag_B[(warp_mma_k + 1) % 2]);

--- a/csrc/quantization/marlin/sm70_marlin_mxfp4_gemm.cu
+++ b/csrc/quantization/marlin/sm70_marlin_mxfp4_gemm.cu
@@ -21,25 +21,25 @@
 #include "cutlass/layout/tensor_op_multiplicand_sm70.h"
 #include "cutlass/transform/threadblock/predicated_tile_iterator.h"
 
-using marlin::sm70::Sm70CtaGeometry;
-using marlin::sm70::Sm70AtomicFp16Epilogue;
-using marlin::sm70::Sm70AtomicFp32Epilogue;
-using marlin::sm70::sm70_marlin_narrow_f32_to_f16;
-using marlin::sm70::Sm70MarlinGemmTraits;
-using marlin::sm70::Sm70SplitKPartition;
-using marlin::sm70::validate_sm70_marlin_dense_cta_geometry_supported;
-using marlin::sm70::validate_sm70_marlin_dense_cta_n_alignment;
 using marlin::sm70::configure_sm70_dynamic_smem;
 using marlin::sm70::dispatch_sm70_marlin_fixed_group_geometry;
 using marlin::sm70::kQuantTileK;
 using marlin::sm70::kQuantTileN;
-using marlin::sm70::sm70_marlin_dense_auto_params;
 using marlin::sm70::load_qword_vector;
 using marlin::sm70::qword_from_vector;
-using marlin::sm70::sm70_marlin_cta_grid;
 using marlin::sm70::sm70_active_split_k;
+using marlin::sm70::sm70_marlin_cta_grid;
+using marlin::sm70::sm70_marlin_dense_auto_params;
+using marlin::sm70::sm70_marlin_narrow_f32_to_f16;
 using marlin::sm70::sm70_splitk_partition;
+using marlin::sm70::Sm70AtomicFp16Epilogue;
+using marlin::sm70::Sm70AtomicFp32Epilogue;
+using marlin::sm70::Sm70CtaGeometry;
+using marlin::sm70::Sm70MarlinGemmTraits;
+using marlin::sm70::Sm70SplitKPartition;
 using marlin::sm70::u4_packed_macro_n_qweight_offset_from_logical;
+using marlin::sm70::validate_sm70_marlin_dense_cta_geometry_supported;
+using marlin::sm70::validate_sm70_marlin_dense_cta_n_alignment;
 
 namespace {
 
@@ -72,7 +72,8 @@ void dequant_e8m0_scales_to_half2(int q, half2* scale_cache) {
   *reinterpret_cast<uint2*>(scale_cache) = vec_res;
 }
 
-template <typename Shape_, typename ThreadMap_, int GroupSize_, int PackedMacroN_>
+template <typename Shape_, typename ThreadMap_, int GroupSize_,
+          int PackedMacroN_>
 class Sm70Mxfp4IteratorB {
  public:
   using Shape = Shape_;
@@ -80,12 +81,11 @@ class Sm70Mxfp4IteratorB {
   static int const kGroupSize = GroupSize_;
   static int const kPackedMacroN = PackedMacroN_;
   using Element = cutlass::half_t;
-  using Fragment = cutlass::Array<
-      Element, ThreadMap::Iterations::kCount * ThreadMap::kElementsPerAccess>;
+  using Fragment = cutlass::Array<Element, ThreadMap::Iterations::kCount *
+                                               ThreadMap::kElementsPerAccess>;
   static_assert(Shape::kN == 64 || Shape::kN == 128 || Shape::kN == 256,
                 "SM70 Marlin MXFP4 IteratorB expects CTA_N in {64, 128, 256}.");
-  static_assert(ThreadMap::Iterations::kContiguous ==
-                    Shape::kN / kQuantTileN,
+  static_assert(ThreadMap::Iterations::kContiguous == Shape::kN / kQuantTileN,
                 "SM70 Marlin MXFP4 IteratorB expects one contiguous iteration "
                 "per 64-column quant tile.");
   static_assert(ThreadMap::Delta::kContiguous == kQuantTileN,
@@ -94,7 +94,8 @@ class Sm70Mxfp4IteratorB {
                 "SM70 Marlin MXFP4 IteratorB expects one packed FP4 word per "
                 "access.");
   static_assert(ThreadMap::Iterations::kStrided >= 1,
-                "SM70 Marlin U4-family IteratorB expects one or more strided iterations.");
+                "SM70 Marlin U4-family IteratorB expects one or more strided "
+                "iterations.");
   struct Params {
     int size_n;
     int aligned_initial_k_step;
@@ -176,8 +177,8 @@ class Sm70Mxfp4IteratorB {
   CUTLASS_DEVICE
   static int qweight_offset_from_logical(Params const& params, int logical_k,
                                          int logical_n) {
-    return u4_packed_macro_n_qweight_offset_from_logical<kPackedMacroN>(params.size_n, logical_k,
-                                                     logical_n);
+    return u4_packed_macro_n_qweight_offset_from_logical<kPackedMacroN>(
+        params.size_n, logical_k, logical_n);
   }
 
   CUTLASS_DEVICE
@@ -196,14 +197,12 @@ class Sm70Mxfp4IteratorB {
     CUTLASS_PRAGMA_UNROLL
     for (int s = 0; s < ThreadMap::Iterations::kStrided; ++s) {
       int const logical_k =
-          k_offset_ + thread_offset_.strided() +
-          s * ThreadMap::Delta::kStrided;
+          k_offset_ + thread_offset_.strided() + s * ThreadMap::Delta::kStrided;
       int const group = scale_group(logical_k);
       CUTLASS_PRAGMA_UNROLL
       for (int c = 0; c < ThreadMap::Iterations::kContiguous; ++c) {
-        int const cache_n =
-            n_offset_ + thread_offset_.contiguous() +
-            c * ThreadMap::Delta::kContiguous;
+        int const cache_n = n_offset_ + thread_offset_.contiguous() +
+                            c * ThreadMap::Delta::kContiguous;
         int const cache_index = c + s * ThreadMap::Iterations::kContiguous;
         cache_metadata_e8m0_scales(cache_index, group, cache_n);
       }
@@ -256,9 +255,11 @@ class Sm70Mxfp4IteratorB {
           frag_vec[3] = __hmul2(deq[1], scale_vec[3]);
         }
       } else {
-        static_assert(ThreadMap::Iterations::kContiguous == 1,
-                      "Unsupported SM70 Marlin MXFP4 contiguous iteration count.");
-        uint32_t const qword = load_qword_vector<1>(qweight_ + qweight_base_offset_);
+        static_assert(
+            ThreadMap::Iterations::kContiguous == 1,
+            "Unsupported SM70 Marlin MXFP4 contiguous iteration count.");
+        uint32_t const qword =
+            load_qword_vector<1>(qweight_ + qweight_base_offset_);
         half2 const* scale_vec = cached_scales_;
 
         half2 deq[2];
@@ -276,14 +277,12 @@ class Sm70Mxfp4IteratorB {
       int const logical_n_base = n_offset_ + thread_offset_.contiguous();
       CUTLASS_PRAGMA_UNROLL
       for (int s = 0; s < ThreadMap::Iterations::kStrided; ++s) {
-        int const logical_k_s =
-            k_offset_ + thread_offset_.strided() +
-            s * ThreadMap::Delta::kStrided;
+        int const logical_k_s = k_offset_ + thread_offset_.strided() +
+                                s * ThreadMap::Delta::kStrided;
         int const qweight_base_s =
             qweight_offset_from_logical(params_, logical_k_s, logical_n_base);
         if constexpr (ThreadMap::Iterations::kContiguous == 4) {
-          auto const qwords =
-              load_qword_vector<4>(qweight_ + qweight_base_s);
+          auto const qwords = load_qword_vector<4>(qweight_ + qweight_base_s);
           CUTLASS_PRAGMA_UNROLL
           for (int c = 0; c < ThreadMap::Iterations::kContiguous; ++c) {
             constexpr int kAccess = ThreadMap::kElementsPerAccess;
@@ -304,8 +303,7 @@ class Sm70Mxfp4IteratorB {
             frag_vec[3] = __hmul2(deq[1], scale_vec[3]);
           }
         } else if constexpr (ThreadMap::Iterations::kContiguous == 2) {
-          auto const qwords =
-              load_qword_vector<2>(qweight_ + qweight_base_s);
+          auto const qwords = load_qword_vector<2>(qweight_ + qweight_base_s);
           CUTLASS_PRAGMA_UNROLL
           for (int c = 0; c < ThreadMap::Iterations::kContiguous; ++c) {
             constexpr int kAccess = ThreadMap::kElementsPerAccess;
@@ -326,9 +324,11 @@ class Sm70Mxfp4IteratorB {
             frag_vec[3] = __hmul2(deq[1], scale_vec[3]);
           }
         } else {
-          static_assert(ThreadMap::Iterations::kContiguous == 1,
-                        "Unsupported SM70 Marlin MXFP4 contiguous iteration count.");
-          uint32_t const qword = load_qword_vector<1>(qweight_ + qweight_base_s);
+          static_assert(
+              ThreadMap::Iterations::kContiguous == 1,
+              "Unsupported SM70 Marlin MXFP4 contiguous iteration count.");
+          uint32_t const qword =
+              load_qword_vector<1>(qweight_ + qweight_base_s);
           constexpr int kAccess = ThreadMap::kElementsPerAccess;
           int const frag_base = s * kAccess;
           half2 const* scale_vec = cached_scales_;
@@ -361,26 +361,25 @@ class Sm70Mxfp4IteratorB {
 
 struct Sm70Mxfp4GemmSpec {
   template <typename Shape, typename ThreadMap, int GroupSize, int PackedMacroN>
-  using IteratorB = Sm70Mxfp4IteratorB<Shape, ThreadMap, GroupSize, PackedMacroN>;
+  using IteratorB =
+      Sm70Mxfp4IteratorB<Shape, ThreadMap, GroupSize, PackedMacroN>;
 };
 
-template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM,
-          int WarpN, int WarpK, int GroupSize, int PackedMacroN>
+template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM, int WarpN,
+          int WarpK, int GroupSize, int PackedMacroN>
 using Sm70Mxfp4GemmTraits =
-    Sm70MarlinGemmTraits<Sm70Mxfp4GemmSpec, CtaM, CtaN, CtaK,
-                         Warps, WarpM, WarpN, WarpK, GroupSize, PackedMacroN>;
+    Sm70MarlinGemmTraits<Sm70Mxfp4GemmSpec, CtaM, CtaN, CtaK, Warps, WarpM,
+                         WarpN, WarpK, GroupSize, PackedMacroN>;
 
-template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM,
-          int WarpN, int WarpK, int GroupSize, int PackedMacroN>
-__global__ __launch_bounds__(Warps * 32, 1)
-void sm70_marlin_mxfp4_gemm_kernel(
+template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM, int WarpN,
+          int WarpK, int GroupSize, int PackedMacroN>
+__global__ __launch_bounds__(Warps * 32, 1) void sm70_marlin_mxfp4_gemm_kernel(
     cutlass::half_t const* __restrict__ a,
     uint32_t const* __restrict__ b_q_weight,
-    uint8_t const* __restrict__ b_scales,
-    cutlass::half_t* __restrict__ c, int m, int n, int k, int lda) {
-  using Traits =
-      Sm70Mxfp4GemmTraits<CtaM, CtaN, CtaK, Warps, WarpM,
-                                  WarpN, WarpK, GroupSize, PackedMacroN>;
+    uint8_t const* __restrict__ b_scales, cutlass::half_t* __restrict__ c,
+    int m, int n, int k, int lda) {
+  using Traits = Sm70Mxfp4GemmTraits<CtaM, CtaN, CtaK, Warps, WarpM, WarpN,
+                                     WarpK, GroupSize, PackedMacroN>;
   using Mma = typename Traits::Mma;
   using Epilogue = typename Traits::Epilogue;
 
@@ -400,10 +399,10 @@ void sm70_marlin_mxfp4_gemm_kernel(
   typename Traits::LayoutA layout_a(lda);
   typename Traits::LayoutC layout_c(n);
 
-  typename Mma::IteratorA iterator_A(
-      typename Mma::IteratorA::Params(layout_a),
-      const_cast<cutlass::half_t*>(a), cutlass::MatrixCoord(m, k), thread_idx,
-      tb_offset_A);
+  typename Mma::IteratorA iterator_A(typename Mma::IteratorA::Params(layout_a),
+                                     const_cast<cutlass::half_t*>(a),
+                                     cutlass::MatrixCoord(m, k), thread_idx,
+                                     tb_offset_A);
   typename Mma::IteratorB iterator_B(
       typename Mma::IteratorB::Params(k, n),
       reinterpret_cast<uint32_t const*>(b_q_weight),
@@ -428,16 +427,17 @@ void sm70_marlin_mxfp4_gemm_kernel(
   epilogue(output_op, iterator_D, accumulators, iterator_C);
 }
 
-template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM,
-          int WarpN, int WarpK, int GroupSize, int PackedMacroN>
-__global__ __launch_bounds__(Warps * 32, 1)
-void sm70_marlin_mxfp4_gemm_splitk_kernel(
+template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM, int WarpN,
+          int WarpK, int GroupSize, int PackedMacroN>
+__global__
+__launch_bounds__(Warps * 32, 1) void sm70_marlin_mxfp4_gemm_splitk_kernel(
     cutlass::half_t const* __restrict__ a,
     uint32_t const* __restrict__ b_q_weight,
-    uint8_t const* __restrict__ b_scales,
-    cutlass::half_t* __restrict__ c, float* __restrict__ c32, int m, int n, int k, int lda, int requested_split_k) {
-  using Traits = Sm70Mxfp4GemmTraits<CtaM, CtaN, CtaK, Warps, WarpM,
-                                  WarpN, WarpK, GroupSize, PackedMacroN>;
+    uint8_t const* __restrict__ b_scales, cutlass::half_t* __restrict__ c,
+    float* __restrict__ c32, int m, int n, int k, int lda,
+    int requested_split_k) {
+  using Traits = Sm70Mxfp4GemmTraits<CtaM, CtaN, CtaK, Warps, WarpM, WarpN,
+                                     WarpK, GroupSize, PackedMacroN>;
   using Mma = typename Traits::Mma;
   using AtomicEpilogue = Sm70AtomicFp32Epilogue<Traits>;
 
@@ -448,14 +448,13 @@ void sm70_marlin_mxfp4_gemm_splitk_kernel(
   int const thread_idx = threadIdx.x;
   int const warp_idx = cutlass::canonical_warp_idx_sync();
   int const lane_idx = threadIdx.x % 32;
-  Sm70SplitKPartition const partition =
-      sm70_splitk_partition<GroupSize, CtaK>(k, requested_split_k, int(blockIdx.z));
+  Sm70SplitKPartition const partition = sm70_splitk_partition<GroupSize, CtaK>(
+      k, requested_split_k, int(blockIdx.z));
   if (partition.partition_k == 0) {
     return;
   }
 
-  cutlass::MatrixCoord tb_offset_A{int(blockIdx.x) * CtaM,
-                                   partition.k_begin};
+  cutlass::MatrixCoord tb_offset_A{int(blockIdx.x) * CtaM, partition.k_begin};
   cutlass::MatrixCoord tb_offset_B{partition.k_begin, int(blockIdx.y) * CtaN};
   cutlass::MatrixCoord tb_offset_C{int(blockIdx.x) * CtaM,
                                    int(blockIdx.y) * CtaN};
@@ -463,10 +462,10 @@ void sm70_marlin_mxfp4_gemm_splitk_kernel(
   typename Traits::LayoutA layout_a(lda);
   typename Traits::LayoutC layout_c(n);
 
-  typename Mma::IteratorA iterator_A(
-      typename Mma::IteratorA::Params(layout_a),
-      const_cast<cutlass::half_t*>(a), cutlass::MatrixCoord(m, k), thread_idx,
-      tb_offset_A);
+  typename Mma::IteratorA iterator_A(typename Mma::IteratorA::Params(layout_a),
+                                     const_cast<cutlass::half_t*>(a),
+                                     cutlass::MatrixCoord(m, k), thread_idx,
+                                     tb_offset_A);
   typename Mma::IteratorB iterator_B(
       typename Mma::IteratorB::Params(k, n),
       reinterpret_cast<uint32_t const*>(b_q_weight),
@@ -480,9 +479,8 @@ void sm70_marlin_mxfp4_gemm_splitk_kernel(
   mma(gemm_k_iterations, accumulators, iterator_A, iterator_B, accumulators);
 
   typename AtomicEpilogue::OutputTileIterator iterator_D(
-      typename AtomicEpilogue::OutputTileIterator::Params(layout_c),
-      c, cutlass::MatrixCoord(m, n),
-      thread_idx, tb_offset_C);
+      typename AtomicEpilogue::OutputTileIterator::Params(layout_c), c,
+      cutlass::MatrixCoord(m, n), thread_idx, tb_offset_C);
 
   AtomicEpilogue epilogue(shared_storage.epilogue, thread_idx, warp_idx,
                           lane_idx);
@@ -491,18 +489,20 @@ void sm70_marlin_mxfp4_gemm_splitk_kernel(
 
 }  // namespace
 
-template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM,
-          int WarpN, int WarpK, int GroupSize, int PackedMacroN>
-torch::Tensor launch_sm70_marlin_mxfp4_gemm(
-    torch::Tensor& a, torch::Tensor& c, torch::Tensor& b_q_weight,
-    torch::Tensor& b_scales, int64_t size_m, int64_t size_n, int64_t size_k,
-    int requested_split_k) {
+template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM, int WarpN,
+          int WarpK, int GroupSize, int PackedMacroN>
+torch::Tensor launch_sm70_marlin_mxfp4_gemm(torch::Tensor& a, torch::Tensor& c,
+                                            torch::Tensor& b_q_weight,
+                                            torch::Tensor& b_scales,
+                                            int64_t size_m, int64_t size_n,
+                                            int64_t size_k,
+                                            int requested_split_k) {
   auto kernel =
-      sm70_marlin_mxfp4_gemm_kernel<CtaM, CtaN, CtaK, Warps, WarpM, WarpN, WarpK,
-                  GroupSize, PackedMacroN>;
-  using SharedStorage = typename Sm70Mxfp4GemmTraits<
-      CtaM, CtaN, CtaK, Warps, WarpM, WarpN, WarpK, GroupSize,
-      PackedMacroN>::SharedStorage;
+      sm70_marlin_mxfp4_gemm_kernel<CtaM, CtaN, CtaK, Warps, WarpM, WarpN,
+                                    WarpK, GroupSize, PackedMacroN>;
+  using SharedStorage =
+      typename Sm70Mxfp4GemmTraits<CtaM, CtaN, CtaK, Warps, WarpM, WarpN, WarpK,
+                                   GroupSize, PackedMacroN>::SharedStorage;
   size_t smem_bytes = configure_sm70_dynamic_smem<SharedStorage>(kernel);
 
   dim3 block(Warps * 32);
@@ -522,21 +522,19 @@ torch::Tensor launch_sm70_marlin_mxfp4_gemm(
   }
 
   TORCH_CHECK(size_k % int64_t(CtaK) == 0,
-              "SM70 Marlin mxfp4 requires K divisible by CTA_K=",
-              CtaK, " for requested_split_k > 1. Got K=", size_k,
+              "SM70 Marlin mxfp4 requires K divisible by CTA_K=", CtaK,
+              " for requested_split_k > 1. Got K=", size_k,
               ", requested_split_k=", requested_split_k, ".");
 
-  auto split_kernel =
-      sm70_marlin_mxfp4_gemm_splitk_kernel<CtaM, CtaN, CtaK, Warps, WarpM, WarpN,
-                  WarpK, GroupSize, PackedMacroN>;
+  auto split_kernel = sm70_marlin_mxfp4_gemm_splitk_kernel<
+      CtaM, CtaN, CtaK, Warps, WarpM, WarpN, WarpK, GroupSize, PackedMacroN>;
   smem_bytes = configure_sm70_dynamic_smem<SharedStorage>(split_kernel);
 
   int64_t const numel = size_m * size_n;
   // 0009: fp32 split-K scratch (zeroed for the fp32 atomicAdd), M*N floats.
   // Only allocated on the split_k>1 path, which the auto-selector uses ONLY at
   // low batch (M<128), so the scratch is bounded and small.
-  auto c32 = torch::zeros({size_m, size_n},
-                          a.options().dtype(at::kFloat));
+  auto c32 = torch::zeros({size_m, size_n}, a.options().dtype(at::kFloat));
 
   dim3 grid = sm70_marlin_cta_grid(size_m, size_n, CtaM, CtaN);
   int const active_split_k =
@@ -547,9 +545,9 @@ torch::Tensor launch_sm70_marlin_mxfp4_gemm(
       reinterpret_cast<uint32_t const*>(b_q_weight.data_ptr<int32_t>()),
       reinterpret_cast<uint8_t const*>(b_scales.data_ptr()),
       reinterpret_cast<cutlass::half_t*>(c.data_ptr<at::Half>()),
-      c32.data_ptr<float>(),
-      static_cast<int>(size_m), static_cast<int>(size_n),
-      static_cast<int>(size_k), static_cast<int>(a.stride(0)), requested_split_k);
+      c32.data_ptr<float>(), static_cast<int>(size_m), static_cast<int>(size_n),
+      static_cast<int>(size_k), static_cast<int>(a.stride(0)),
+      requested_split_k);
   C10_CUDA_KERNEL_LAUNCH_CHECK();
 
   // 0009: single deterministic-width fp32->fp16 narrow of the scratch.
@@ -557,8 +555,8 @@ torch::Tensor launch_sm70_marlin_mxfp4_gemm(
   int const narrow_grid =
       static_cast<int>((numel + narrow_block - 1) / narrow_block);
   sm70_marlin_narrow_f32_to_f16<256><<<narrow_grid, narrow_block, 0, stream>>>(
-      c32.data_ptr<float>(),
-      reinterpret_cast<half*>(c.data_ptr<at::Half>()), numel);
+      c32.data_ptr<float>(), reinterpret_cast<half*>(c.data_ptr<at::Half>()),
+      numel);
   C10_CUDA_KERNEL_LAUNCH_CHECK();
 
   return c;
@@ -574,11 +572,11 @@ struct Sm70Mxfp4Launcher {
   int64_t size_k;
   int requested_split_k;
 
-  template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM,
-            int WarpN, int WarpK, int GroupSize, int PackedMacroN>
+  template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM, int WarpN,
+            int WarpK, int GroupSize, int PackedMacroN>
   torch::Tensor operator()() const {
-    return launch_sm70_marlin_mxfp4_gemm<CtaM, CtaN, CtaK, Warps, WarpM, WarpN, WarpK,
-                  GroupSize, PackedMacroN>(
+    return launch_sm70_marlin_mxfp4_gemm<CtaM, CtaN, CtaK, Warps, WarpM, WarpN,
+                                         WarpK, GroupSize, PackedMacroN>(
         a, c, b_q_weight, b_scales, size_m, size_n, size_k, requested_split_k);
   }
 };
@@ -590,14 +588,16 @@ torch::Tensor sm70_marlin_mxfp4_gemm(torch::Tensor& a, torch::Tensor& c,
                                      int64_t group_size) {
   c10::cuda::CUDAGuard device_guard(a.device());
 
-  auto const params = sm70_marlin_dense_auto_params(
-      "mxfp4", group_size, size_m, size_n, size_k);
+  auto const params = sm70_marlin_dense_auto_params("mxfp4", group_size, size_m,
+                                                    size_n, size_k);
   Sm70CtaGeometry const geometry = params.geometry;
-  validate_sm70_marlin_dense_cta_geometry_supported("SM70 Marlin mxfp4", geometry);
-  validate_sm70_marlin_dense_cta_n_alignment("SM70 Marlin mxfp4", geometry, size_n);
+  validate_sm70_marlin_dense_cta_geometry_supported("SM70 Marlin mxfp4",
+                                                    geometry);
+  validate_sm70_marlin_dense_cta_n_alignment("SM70 Marlin mxfp4", geometry,
+                                             size_n);
   Sm70Mxfp4Launcher const launcher{
-      a, c, b_q_weight, b_scales, size_m, size_n, size_k,
-      params.requested_split_k};
+      a,      c,      b_q_weight, b_scales,
+      size_m, size_n, size_k,     params.requested_split_k};
   return dispatch_sm70_marlin_fixed_group_geometry<32>(
       launcher, geometry, params.packed_macro_n, group_size, "mxfp4");
 }

--- a/csrc/quantization/marlin/sm70_marlin_nvfp4_gemm.cu
+++ b/csrc/quantization/marlin/sm70_marlin_nvfp4_gemm.cu
@@ -21,31 +21,32 @@
 #include "cutlass/layout/tensor_op_multiplicand_sm70.h"
 #include "cutlass/transform/threadblock/predicated_tile_iterator.h"
 
-using marlin::sm70::Sm70CtaGeometry;
-using marlin::sm70::Sm70AtomicFp16Epilogue;
-using marlin::sm70::Sm70AtomicFp32Epilogue;
-using marlin::sm70::sm70_marlin_narrow_f32_to_f16;
-using marlin::sm70::Sm70MarlinGemmTraits;
-using marlin::sm70::Sm70SplitKPartition;
-using marlin::sm70::validate_sm70_marlin_dense_cta_geometry_supported;
-using marlin::sm70::validate_sm70_marlin_dense_cta_n_alignment;
 using marlin::sm70::configure_sm70_dynamic_smem;
 using marlin::sm70::dispatch_sm70_marlin_fixed_group_geometry;
 using marlin::sm70::kQuantTileK;
 using marlin::sm70::kQuantTileN;
-using marlin::sm70::sm70_marlin_dense_auto_params;
 using marlin::sm70::load_qword_vector;
 using marlin::sm70::qword_from_vector;
-using marlin::sm70::sm70_marlin_cta_grid;
 using marlin::sm70::sm70_active_split_k;
+using marlin::sm70::sm70_marlin_cta_grid;
+using marlin::sm70::sm70_marlin_dense_auto_params;
+using marlin::sm70::sm70_marlin_narrow_f32_to_f16;
 using marlin::sm70::sm70_splitk_partition;
+using marlin::sm70::Sm70AtomicFp16Epilogue;
+using marlin::sm70::Sm70AtomicFp32Epilogue;
+using marlin::sm70::Sm70CtaGeometry;
+using marlin::sm70::Sm70MarlinGemmTraits;
+using marlin::sm70::Sm70SplitKPartition;
 using marlin::sm70::u4_packed_macro_n_qweight_offset_from_logical;
+using marlin::sm70::validate_sm70_marlin_dense_cta_geometry_supported;
+using marlin::sm70::validate_sm70_marlin_dense_cta_n_alignment;
 
 namespace {
 
 constexpr int kNvfp4ValuesPerWord = 8;
 
-template <typename Shape_, typename ThreadMap_, int GroupSize_, int PackedMacroN_>
+template <typename Shape_, typename ThreadMap_, int GroupSize_,
+          int PackedMacroN_>
 class Sm70Nvfp4IteratorB {
  public:
   using Shape = Shape_;
@@ -53,12 +54,11 @@ class Sm70Nvfp4IteratorB {
   static int const kGroupSize = GroupSize_;
   static int const kPackedMacroN = PackedMacroN_;
   using Element = cutlass::half_t;
-  using Fragment = cutlass::Array<
-      Element, ThreadMap::Iterations::kCount * ThreadMap::kElementsPerAccess>;
+  using Fragment = cutlass::Array<Element, ThreadMap::Iterations::kCount *
+                                               ThreadMap::kElementsPerAccess>;
   static_assert(Shape::kN == 64 || Shape::kN == 128 || Shape::kN == 256,
                 "SM70 Marlin NVFP4 IteratorB expects CTA_N in {64, 128, 256}.");
-  static_assert(ThreadMap::Iterations::kContiguous ==
-                    Shape::kN / kQuantTileN,
+  static_assert(ThreadMap::Iterations::kContiguous == Shape::kN / kQuantTileN,
                 "SM70 Marlin NVFP4 IteratorB expects one contiguous iteration "
                 "per 64-column quant tile.");
   static_assert(ThreadMap::Delta::kContiguous == kQuantTileN,
@@ -67,7 +67,8 @@ class Sm70Nvfp4IteratorB {
                 "SM70 Marlin NVFP4 IteratorB expects one packed FP4 word per "
                 "access.");
   static_assert(ThreadMap::Iterations::kStrided >= 1,
-                "SM70 Marlin U4-family IteratorB expects one or more strided iterations.");
+                "SM70 Marlin U4-family IteratorB expects one or more strided "
+                "iterations.");
   struct Params {
     int size_n;
     int aligned_initial_k_step;
@@ -149,8 +150,8 @@ class Sm70Nvfp4IteratorB {
   CUTLASS_DEVICE
   static int qweight_offset_from_logical(Params const& params, int logical_k,
                                          int logical_n) {
-    return u4_packed_macro_n_qweight_offset_from_logical<kPackedMacroN>(params.size_n, logical_k,
-                                                     logical_n);
+    return u4_packed_macro_n_qweight_offset_from_logical<kPackedMacroN>(
+        params.size_n, logical_k, logical_n);
   }
 
   CUTLASS_DEVICE
@@ -170,14 +171,12 @@ class Sm70Nvfp4IteratorB {
     CUTLASS_PRAGMA_UNROLL
     for (int s = 0; s < ThreadMap::Iterations::kStrided; ++s) {
       int const logical_k =
-          k_offset_ + thread_offset_.strided() +
-          s * ThreadMap::Delta::kStrided;
+          k_offset_ + thread_offset_.strided() + s * ThreadMap::Delta::kStrided;
       int const group = scale_group(logical_k);
       CUTLASS_PRAGMA_UNROLL
       for (int c = 0; c < ThreadMap::Iterations::kContiguous; ++c) {
-        int const cache_n =
-            n_offset_ + thread_offset_.contiguous() +
-            c * ThreadMap::Delta::kContiguous;
+        int const cache_n = n_offset_ + thread_offset_.contiguous() +
+                            c * ThreadMap::Delta::kContiguous;
         int const cache_index = c + s * ThreadMap::Iterations::kContiguous;
         cache_metadata_fp8_scales(cache_index, group, cache_n);
       }
@@ -230,9 +229,11 @@ class Sm70Nvfp4IteratorB {
           frag_vec[3] = __hmul2(deq[1], scale_vec[3]);
         }
       } else {
-        static_assert(ThreadMap::Iterations::kContiguous == 1,
-                      "Unsupported SM70 Marlin NVFP4 contiguous iteration count.");
-        uint32_t const qword = load_qword_vector<1>(qweight_ + qweight_base_offset_);
+        static_assert(
+            ThreadMap::Iterations::kContiguous == 1,
+            "Unsupported SM70 Marlin NVFP4 contiguous iteration count.");
+        uint32_t const qword =
+            load_qword_vector<1>(qweight_ + qweight_base_offset_);
         half2 const* scale_vec = cached_scales_;
 
         half2 deq[2];
@@ -250,14 +251,12 @@ class Sm70Nvfp4IteratorB {
       int const logical_n_base = n_offset_ + thread_offset_.contiguous();
       CUTLASS_PRAGMA_UNROLL
       for (int s = 0; s < ThreadMap::Iterations::kStrided; ++s) {
-        int const logical_k_s =
-            k_offset_ + thread_offset_.strided() +
-            s * ThreadMap::Delta::kStrided;
+        int const logical_k_s = k_offset_ + thread_offset_.strided() +
+                                s * ThreadMap::Delta::kStrided;
         int const qweight_base_s =
             qweight_offset_from_logical(params_, logical_k_s, logical_n_base);
         if constexpr (ThreadMap::Iterations::kContiguous == 4) {
-          auto const qwords =
-              load_qword_vector<4>(qweight_ + qweight_base_s);
+          auto const qwords = load_qword_vector<4>(qweight_ + qweight_base_s);
           CUTLASS_PRAGMA_UNROLL
           for (int c = 0; c < ThreadMap::Iterations::kContiguous; ++c) {
             constexpr int kAccess = ThreadMap::kElementsPerAccess;
@@ -280,8 +279,7 @@ class Sm70Nvfp4IteratorB {
             frag_vec[3] = __hmul2(deq[1], scale_vec[3]);
           }
         } else if constexpr (ThreadMap::Iterations::kContiguous == 2) {
-          auto const qwords =
-              load_qword_vector<2>(qweight_ + qweight_base_s);
+          auto const qwords = load_qword_vector<2>(qweight_ + qweight_base_s);
           CUTLASS_PRAGMA_UNROLL
           for (int c = 0; c < ThreadMap::Iterations::kContiguous; ++c) {
             constexpr int kAccess = ThreadMap::kElementsPerAccess;
@@ -304,9 +302,11 @@ class Sm70Nvfp4IteratorB {
             frag_vec[3] = __hmul2(deq[1], scale_vec[3]);
           }
         } else {
-          static_assert(ThreadMap::Iterations::kContiguous == 1,
-                        "Unsupported SM70 Marlin NVFP4 contiguous iteration count.");
-          uint32_t const qword = load_qword_vector<1>(qweight_ + qweight_base_s);
+          static_assert(
+              ThreadMap::Iterations::kContiguous == 1,
+              "Unsupported SM70 Marlin NVFP4 contiguous iteration count.");
+          uint32_t const qword =
+              load_qword_vector<1>(qweight_ + qweight_base_s);
           constexpr int kAccess = ThreadMap::kElementsPerAccess;
           int const frag_base = s * kAccess;
           half2 const* scale_vec =
@@ -340,27 +340,26 @@ class Sm70Nvfp4IteratorB {
 
 struct Sm70Nvfp4GemmSpec {
   template <typename Shape, typename ThreadMap, int GroupSize, int PackedMacroN>
-  using IteratorB = Sm70Nvfp4IteratorB<Shape, ThreadMap, GroupSize, PackedMacroN>;
+  using IteratorB =
+      Sm70Nvfp4IteratorB<Shape, ThreadMap, GroupSize, PackedMacroN>;
 };
 
-template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM,
-          int WarpN, int WarpK, int GroupSize, int PackedMacroN>
+template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM, int WarpN,
+          int WarpK, int GroupSize, int PackedMacroN>
 using Sm70Nvfp4GemmTraits =
-    Sm70MarlinGemmTraits<Sm70Nvfp4GemmSpec, CtaM, CtaN, CtaK,
-                         Warps, WarpM, WarpN, WarpK, GroupSize, PackedMacroN>;
+    Sm70MarlinGemmTraits<Sm70Nvfp4GemmSpec, CtaM, CtaN, CtaK, Warps, WarpM,
+                         WarpN, WarpK, GroupSize, PackedMacroN>;
 
-template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM,
-          int WarpN, int WarpK, int GroupSize, int PackedMacroN>
-__global__ __launch_bounds__(Warps * 32, 1)
-void sm70_marlin_nvfp4_gemm_kernel(
+template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM, int WarpN,
+          int WarpK, int GroupSize, int PackedMacroN>
+__global__ __launch_bounds__(Warps * 32, 1) void sm70_marlin_nvfp4_gemm_kernel(
     cutlass::half_t const* __restrict__ a,
     uint32_t const* __restrict__ b_q_weight,
     uint8_t const* __restrict__ b_scales,
-    float const* __restrict__ global_scale,
-    cutlass::half_t* __restrict__ c, int m, int n, int k, int lda) {
-  using Traits =
-      Sm70Nvfp4GemmTraits<CtaM, CtaN, CtaK, Warps, WarpM,
-                                  WarpN, WarpK, GroupSize, PackedMacroN>;
+    float const* __restrict__ global_scale, cutlass::half_t* __restrict__ c,
+    int m, int n, int k, int lda) {
+  using Traits = Sm70Nvfp4GemmTraits<CtaM, CtaN, CtaK, Warps, WarpM, WarpN,
+                                     WarpK, GroupSize, PackedMacroN>;
   using Mma = typename Traits::Mma;
   using Epilogue = typename Traits::Epilogue;
 
@@ -380,10 +379,10 @@ void sm70_marlin_nvfp4_gemm_kernel(
   typename Traits::LayoutA layout_a(lda);
   typename Traits::LayoutC layout_c(n);
 
-  typename Mma::IteratorA iterator_A(
-      typename Mma::IteratorA::Params(layout_a),
-      const_cast<cutlass::half_t*>(a), cutlass::MatrixCoord(m, k), thread_idx,
-      tb_offset_A);
+  typename Mma::IteratorA iterator_A(typename Mma::IteratorA::Params(layout_a),
+                                     const_cast<cutlass::half_t*>(a),
+                                     cutlass::MatrixCoord(m, k), thread_idx,
+                                     tb_offset_A);
   typename Mma::IteratorB iterator_B(
       typename Mma::IteratorB::Params(k, n),
       reinterpret_cast<uint32_t const*>(b_q_weight),
@@ -408,17 +407,18 @@ void sm70_marlin_nvfp4_gemm_kernel(
   epilogue(output_op, iterator_D, accumulators, iterator_C);
 }
 
-template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM,
-          int WarpN, int WarpK, int GroupSize, int PackedMacroN>
-__global__ __launch_bounds__(Warps * 32, 1)
-void sm70_marlin_nvfp4_gemm_splitk_kernel(
+template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM, int WarpN,
+          int WarpK, int GroupSize, int PackedMacroN>
+__global__
+__launch_bounds__(Warps * 32, 1) void sm70_marlin_nvfp4_gemm_splitk_kernel(
     cutlass::half_t const* __restrict__ a,
     uint32_t const* __restrict__ b_q_weight,
     uint8_t const* __restrict__ b_scales,
-    float const* __restrict__ global_scale,
-    cutlass::half_t* __restrict__ c, float* __restrict__ c32, int m, int n, int k, int lda, int requested_split_k) {
-  using Traits = Sm70Nvfp4GemmTraits<CtaM, CtaN, CtaK, Warps, WarpM,
-                                  WarpN, WarpK, GroupSize, PackedMacroN>;
+    float const* __restrict__ global_scale, cutlass::half_t* __restrict__ c,
+    float* __restrict__ c32, int m, int n, int k, int lda,
+    int requested_split_k) {
+  using Traits = Sm70Nvfp4GemmTraits<CtaM, CtaN, CtaK, Warps, WarpM, WarpN,
+                                     WarpK, GroupSize, PackedMacroN>;
   using Mma = typename Traits::Mma;
   using AtomicEpilogue = Sm70AtomicFp32Epilogue<Traits>;
 
@@ -429,14 +429,13 @@ void sm70_marlin_nvfp4_gemm_splitk_kernel(
   int const thread_idx = threadIdx.x;
   int const warp_idx = cutlass::canonical_warp_idx_sync();
   int const lane_idx = threadIdx.x % 32;
-  Sm70SplitKPartition const partition =
-      sm70_splitk_partition<GroupSize, CtaK>(k, requested_split_k, int(blockIdx.z));
+  Sm70SplitKPartition const partition = sm70_splitk_partition<GroupSize, CtaK>(
+      k, requested_split_k, int(blockIdx.z));
   if (partition.partition_k == 0) {
     return;
   }
 
-  cutlass::MatrixCoord tb_offset_A{int(blockIdx.x) * CtaM,
-                                   partition.k_begin};
+  cutlass::MatrixCoord tb_offset_A{int(blockIdx.x) * CtaM, partition.k_begin};
   cutlass::MatrixCoord tb_offset_B{partition.k_begin, int(blockIdx.y) * CtaN};
   cutlass::MatrixCoord tb_offset_C{int(blockIdx.x) * CtaM,
                                    int(blockIdx.y) * CtaN};
@@ -444,10 +443,10 @@ void sm70_marlin_nvfp4_gemm_splitk_kernel(
   typename Traits::LayoutA layout_a(lda);
   typename Traits::LayoutC layout_c(n);
 
-  typename Mma::IteratorA iterator_A(
-      typename Mma::IteratorA::Params(layout_a),
-      const_cast<cutlass::half_t*>(a), cutlass::MatrixCoord(m, k), thread_idx,
-      tb_offset_A);
+  typename Mma::IteratorA iterator_A(typename Mma::IteratorA::Params(layout_a),
+                                     const_cast<cutlass::half_t*>(a),
+                                     cutlass::MatrixCoord(m, k), thread_idx,
+                                     tb_offset_A);
   typename Mma::IteratorB iterator_B(
       typename Mma::IteratorB::Params(k, n),
       reinterpret_cast<uint32_t const*>(b_q_weight),
@@ -463,9 +462,8 @@ void sm70_marlin_nvfp4_gemm_splitk_kernel(
   accumulators = scale_accumulators(accumulators, global_scale[0]);
 
   typename AtomicEpilogue::OutputTileIterator iterator_D(
-      typename AtomicEpilogue::OutputTileIterator::Params(layout_c),
-      c, cutlass::MatrixCoord(m, n),
-      thread_idx, tb_offset_C);
+      typename AtomicEpilogue::OutputTileIterator::Params(layout_c), c,
+      cutlass::MatrixCoord(m, n), thread_idx, tb_offset_C);
 
   AtomicEpilogue epilogue(shared_storage.epilogue, thread_idx, warp_idx,
                           lane_idx);
@@ -474,18 +472,18 @@ void sm70_marlin_nvfp4_gemm_splitk_kernel(
 
 }  // namespace
 
-template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM,
-          int WarpN, int WarpK, int GroupSize, int PackedMacroN>
+template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM, int WarpN,
+          int WarpK, int GroupSize, int PackedMacroN>
 torch::Tensor launch_sm70_marlin_nvfp4_gemm(
     torch::Tensor& a, torch::Tensor& c, torch::Tensor& b_q_weight,
     torch::Tensor& b_scales, torch::Tensor& global_scale, int64_t size_m,
     int64_t size_n, int64_t size_k, int requested_split_k) {
   auto kernel =
-      sm70_marlin_nvfp4_gemm_kernel<CtaM, CtaN, CtaK, Warps, WarpM, WarpN, WarpK,
-                  GroupSize, PackedMacroN>;
-  using SharedStorage = typename Sm70Nvfp4GemmTraits<
-      CtaM, CtaN, CtaK, Warps, WarpM, WarpN, WarpK, GroupSize,
-      PackedMacroN>::SharedStorage;
+      sm70_marlin_nvfp4_gemm_kernel<CtaM, CtaN, CtaK, Warps, WarpM, WarpN,
+                                    WarpK, GroupSize, PackedMacroN>;
+  using SharedStorage =
+      typename Sm70Nvfp4GemmTraits<CtaM, CtaN, CtaK, Warps, WarpM, WarpN, WarpK,
+                                   GroupSize, PackedMacroN>::SharedStorage;
   size_t smem_bytes = configure_sm70_dynamic_smem<SharedStorage>(kernel);
 
   dim3 block(Warps * 32);
@@ -506,21 +504,19 @@ torch::Tensor launch_sm70_marlin_nvfp4_gemm(
   }
 
   TORCH_CHECK(size_k % int64_t(CtaK) == 0,
-              "SM70 Marlin nvfp4 requires K divisible by CTA_K=",
-              CtaK, " for requested_split_k > 1. Got K=", size_k,
+              "SM70 Marlin nvfp4 requires K divisible by CTA_K=", CtaK,
+              " for requested_split_k > 1. Got K=", size_k,
               ", requested_split_k=", requested_split_k, ".");
 
-  auto split_kernel =
-      sm70_marlin_nvfp4_gemm_splitk_kernel<CtaM, CtaN, CtaK, Warps, WarpM, WarpN,
-                  WarpK, GroupSize, PackedMacroN>;
+  auto split_kernel = sm70_marlin_nvfp4_gemm_splitk_kernel<
+      CtaM, CtaN, CtaK, Warps, WarpM, WarpN, WarpK, GroupSize, PackedMacroN>;
   smem_bytes = configure_sm70_dynamic_smem<SharedStorage>(split_kernel);
 
   int64_t const numel = size_m * size_n;
   // 0009: fp32 split-K scratch (zeroed for the fp32 atomicAdd), M*N floats.
   // Only allocated on the split_k>1 path, which the auto-selector uses ONLY at
   // low batch (M<128), so the scratch is bounded and small.
-  auto c32 = torch::zeros({size_m, size_n},
-                          a.options().dtype(at::kFloat));
+  auto c32 = torch::zeros({size_m, size_n}, a.options().dtype(at::kFloat));
 
   dim3 grid = sm70_marlin_cta_grid(size_m, size_n, CtaM, CtaN);
   int const active_split_k =
@@ -532,9 +528,9 @@ torch::Tensor launch_sm70_marlin_nvfp4_gemm(
       reinterpret_cast<uint8_t const*>(b_scales.data_ptr()),
       reinterpret_cast<float const*>(global_scale.data_ptr<float>()),
       reinterpret_cast<cutlass::half_t*>(c.data_ptr<at::Half>()),
-      c32.data_ptr<float>(),
-      static_cast<int>(size_m), static_cast<int>(size_n),
-      static_cast<int>(size_k), static_cast<int>(a.stride(0)), requested_split_k);
+      c32.data_ptr<float>(), static_cast<int>(size_m), static_cast<int>(size_n),
+      static_cast<int>(size_k), static_cast<int>(a.stride(0)),
+      requested_split_k);
   C10_CUDA_KERNEL_LAUNCH_CHECK();
 
   // 0009: single deterministic-width fp32->fp16 narrow of the scratch.
@@ -542,8 +538,8 @@ torch::Tensor launch_sm70_marlin_nvfp4_gemm(
   int const narrow_grid =
       static_cast<int>((numel + narrow_block - 1) / narrow_block);
   sm70_marlin_narrow_f32_to_f16<256><<<narrow_grid, narrow_block, 0, stream>>>(
-      c32.data_ptr<float>(),
-      reinterpret_cast<half*>(c.data_ptr<at::Half>()), numel);
+      c32.data_ptr<float>(), reinterpret_cast<half*>(c.data_ptr<at::Half>()),
+      numel);
   C10_CUDA_KERNEL_LAUNCH_CHECK();
 
   return c;
@@ -560,11 +556,11 @@ struct Sm70Nvfp4Launcher {
   int64_t size_k;
   int requested_split_k;
 
-  template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM,
-            int WarpN, int WarpK, int GroupSize, int PackedMacroN>
+  template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM, int WarpN,
+            int WarpK, int GroupSize, int PackedMacroN>
   torch::Tensor operator()() const {
-    return launch_sm70_marlin_nvfp4_gemm<CtaM, CtaN, CtaK, Warps, WarpM, WarpN, WarpK,
-                  GroupSize, PackedMacroN>(
+    return launch_sm70_marlin_nvfp4_gemm<CtaM, CtaN, CtaK, Warps, WarpM, WarpN,
+                                         WarpK, GroupSize, PackedMacroN>(
         a, c, b_q_weight, b_scales, global_scale, size_m, size_n, size_k,
         requested_split_k);
   }
@@ -578,14 +574,22 @@ torch::Tensor sm70_marlin_nvfp4_gemm(torch::Tensor& a, torch::Tensor& c,
                                      int64_t size_k, int64_t group_size) {
   c10::cuda::CUDAGuard device_guard(a.device());
 
-  auto const params = sm70_marlin_dense_auto_params(
-      "nvfp4", group_size, size_m, size_n, size_k);
+  auto const params = sm70_marlin_dense_auto_params("nvfp4", group_size, size_m,
+                                                    size_n, size_k);
   Sm70CtaGeometry const geometry = params.geometry;
-  validate_sm70_marlin_dense_cta_geometry_supported("SM70 Marlin nvfp4", geometry);
-  validate_sm70_marlin_dense_cta_n_alignment("SM70 Marlin nvfp4", geometry, size_n);
-  Sm70Nvfp4Launcher const launcher{
-      a, c, b_q_weight, b_scales, global_scale, size_m, size_n, size_k,
-      params.requested_split_k};
+  validate_sm70_marlin_dense_cta_geometry_supported("SM70 Marlin nvfp4",
+                                                    geometry);
+  validate_sm70_marlin_dense_cta_n_alignment("SM70 Marlin nvfp4", geometry,
+                                             size_n);
+  Sm70Nvfp4Launcher const launcher{a,
+                                   c,
+                                   b_q_weight,
+                                   b_scales,
+                                   global_scale,
+                                   size_m,
+                                   size_n,
+                                   size_k,
+                                   params.requested_split_k};
   return dispatch_sm70_marlin_fixed_group_geometry<16>(
       launcher, geometry, params.packed_macro_n, group_size, "nvfp4");
 }

--- a/csrc/quantization/marlin/sm70_marlin_splitk.cuh
+++ b/csrc/quantization/marlin/sm70_marlin_splitk.cuh
@@ -22,9 +22,7 @@ int sm70_splitk_ceil_div_int(int numerator, int denominator) {
 }
 
 CUTLASS_HOST_DEVICE
-int sm70_splitk_min_int(int lhs, int rhs) {
-  return lhs < rhs ? lhs : rhs;
-}
+int sm70_splitk_min_int(int lhs, int rhs) { return lhs < rhs ? lhs : rhs; }
 
 template <int GroupSize, int CtaK = kCtaK>
 CUTLASS_HOST_DEVICE int sm70_splitk_group_tiles() {
@@ -76,8 +74,8 @@ int sm70_splitk_partition_tile_count(int remaining_tiles,
 }
 
 template <int GroupSize, int CtaK = kCtaK>
-CUTLASS_HOST_DEVICE Sm70SplitKPartition sm70_splitk_partition(
-    int k, int requested_split_k, int partition_idx) {
+CUTLASS_HOST_DEVICE Sm70SplitKPartition
+sm70_splitk_partition(int k, int requested_split_k, int partition_idx) {
   int const active_split_k = sm70_active_split_k(k, requested_split_k, CtaK);
   if (partition_idx >= active_split_k) {
     return {0, 0};
@@ -135,10 +133,9 @@ class Sm70AtomicFp16Epilogue {
           int const frag_row_idx =
               row + ThreadMap::Iterations::kRow *
                         (group + ThreadMap::Iterations::kGroup * cluster);
-          int const row_offset =
-              row * ThreadMap::Delta::kRow +
-              group * ThreadMap::Delta::kGroup +
-              cluster * ThreadMap::Delta::kCluster;
+          int const row_offset = row * ThreadMap::Delta::kRow +
+                                 group * ThreadMap::Delta::kGroup +
+                                 cluster * ThreadMap::Delta::kCluster;
           int const logical_row = thread_start_row + row_offset;
 
           CUTLASS_PRAGMA_UNROLL
@@ -168,7 +165,7 @@ class Sm70AtomicFp16Epilogue {
  public:
   CUTLASS_DEVICE
   Sm70AtomicFp16Epilogue(SharedStorage& shared_storage, int thread_idx,
-                              int warp_idx, int lane_idx)
+                         int warp_idx, int lane_idx)
       : warp_tile_iterator_(shared_storage.reference(), lane_idx),
         shared_load_iterator_(shared_storage.reference(), thread_idx) {
     using WarpCount = typename CutlassEpilogue::WarpCount;
@@ -177,8 +174,7 @@ class Sm70AtomicFp16Epilogue {
     int const warp_m = warp_mn % WarpCount::kM;
     int const warp_n = warp_mn / WarpCount::kM;
 
-    cutlass::MatrixCoord warp_offset{warp_k * WarpCount::kM + warp_m,
-                                     warp_n};
+    cutlass::MatrixCoord warp_offset{warp_k * WarpCount::kM + warp_m, warp_n};
     warp_tile_iterator_.add_tile_offset(warp_offset);
   }
 
@@ -220,8 +216,7 @@ class Sm70AtomicFp16Epilogue {
             CutlassEpilogue::kSmemPointerOffset);
       }
 
-      atomic_store_fragment(destination_iterator, aligned_accum_fragment, c,
-                            n);
+      atomic_store_fragment(destination_iterator, aligned_accum_fragment, c, n);
       ++destination_iterator;
     }
   }
@@ -263,10 +258,9 @@ class Sm70AtomicFp32Epilogue {
           int const frag_row_idx =
               row + ThreadMap::Iterations::kRow *
                         (group + ThreadMap::Iterations::kGroup * cluster);
-          int const row_offset =
-              row * ThreadMap::Delta::kRow +
-              group * ThreadMap::Delta::kGroup +
-              cluster * ThreadMap::Delta::kCluster;
+          int const row_offset = row * ThreadMap::Delta::kRow +
+                                 group * ThreadMap::Delta::kGroup +
+                                 cluster * ThreadMap::Delta::kCluster;
           int const logical_row = thread_start_row + row_offset;
 
           CUTLASS_PRAGMA_UNROLL
@@ -295,7 +289,7 @@ class Sm70AtomicFp32Epilogue {
  public:
   CUTLASS_DEVICE
   Sm70AtomicFp32Epilogue(SharedStorage& shared_storage, int thread_idx,
-                              int warp_idx, int lane_idx)
+                         int warp_idx, int lane_idx)
       : warp_tile_iterator_(shared_storage.reference(), lane_idx),
         shared_load_iterator_(shared_storage.reference(), thread_idx) {
     using WarpCount = typename CutlassEpilogue::WarpCount;
@@ -304,15 +298,14 @@ class Sm70AtomicFp32Epilogue {
     int const warp_m = warp_mn % WarpCount::kM;
     int const warp_n = warp_mn / WarpCount::kM;
 
-    cutlass::MatrixCoord warp_offset{warp_k * WarpCount::kM + warp_m,
-                                     warp_n};
+    cutlass::MatrixCoord warp_offset{warp_k * WarpCount::kM + warp_m, warp_n};
     warp_tile_iterator_.add_tile_offset(warp_offset);
   }
 
   CUTLASS_DEVICE
   void operator()(OutputTileIterator destination_iterator,
-                  AccumulatorTile const& accumulators,
-                  float* __restrict__ c, int n) {
+                  AccumulatorTile const& accumulators, float* __restrict__ c,
+                  int n) {
     AccumulatorFragmentIterator accum_fragment_iterator(accumulators);
 
     CUTLASS_PRAGMA_UNROLL
@@ -347,17 +340,16 @@ class Sm70AtomicFp32Epilogue {
             CutlassEpilogue::kSmemPointerOffset);
       }
 
-      atomic_store_fragment(destination_iterator, aligned_accum_fragment, c,
-                            n);
+      atomic_store_fragment(destination_iterator, aligned_accum_fragment, c, n);
       ++destination_iterator;
     }
   }
 };
 
-
-// 0009: single fp32->fp16 narrow of the split-K scratch (replaces the per-partial
-// __float2half_rn narrow the fp16-atomic epilogue did S times). Templated so the
-// symbol has vague linkage across the 7 gemm TUs that include this header.
+// 0009: single fp32->fp16 narrow of the split-K scratch (replaces the
+// per-partial
+// __float2half_rn narrow the fp16-atomic epilogue did S times). Templated so
+// the symbol has vague linkage across the 7 gemm TUs that include this header.
 template <int BlockSize = 256>
 __global__ void sm70_marlin_narrow_f32_to_f16(const float* __restrict__ src,
                                               half* __restrict__ dst,

--- a/csrc/quantization/marlin/sm70_marlin_u4_gemm.cu
+++ b/csrc/quantization/marlin/sm70_marlin_u4_gemm.cu
@@ -20,25 +20,25 @@
 #include "cutlass/layout/tensor_op_multiplicand_sm70.h"
 #include "cutlass/transform/threadblock/predicated_tile_iterator.h"
 
-using marlin::sm70::Sm70CtaGeometry;
-using marlin::sm70::Sm70AtomicFp16Epilogue;
-using marlin::sm70::Sm70AtomicFp32Epilogue;
-using marlin::sm70::sm70_marlin_narrow_f32_to_f16;
-using marlin::sm70::Sm70MarlinGemmTraits;
-using marlin::sm70::Sm70SplitKPartition;
-using marlin::sm70::validate_sm70_marlin_dense_cta_geometry_supported;
-using marlin::sm70::validate_sm70_marlin_dense_cta_n_alignment;
 using marlin::sm70::configure_sm70_dynamic_smem;
 using marlin::sm70::dispatch_sm70_marlin_geometry;
 using marlin::sm70::kQuantTileK;
 using marlin::sm70::kQuantTileN;
-using marlin::sm70::sm70_marlin_dense_auto_params;
 using marlin::sm70::load_qword_vector;
 using marlin::sm70::qword_from_vector;
-using marlin::sm70::sm70_marlin_cta_grid;
 using marlin::sm70::sm70_active_split_k;
+using marlin::sm70::sm70_marlin_cta_grid;
+using marlin::sm70::sm70_marlin_dense_auto_params;
+using marlin::sm70::sm70_marlin_narrow_f32_to_f16;
 using marlin::sm70::sm70_splitk_partition;
+using marlin::sm70::Sm70AtomicFp16Epilogue;
+using marlin::sm70::Sm70AtomicFp32Epilogue;
+using marlin::sm70::Sm70CtaGeometry;
+using marlin::sm70::Sm70MarlinGemmTraits;
+using marlin::sm70::Sm70SplitKPartition;
 using marlin::sm70::u4_packed_macro_n_qweight_offset_from_logical;
+using marlin::sm70::validate_sm70_marlin_dense_cta_geometry_supported;
+using marlin::sm70::validate_sm70_marlin_dense_cta_n_alignment;
 
 namespace {
 
@@ -54,12 +54,11 @@ class Sm70U4ZpIteratorB {
   static int const kPackedMacroN = PackedMacroN_;
   static constexpr bool kUseMetadataVectorWords = UseMetadataVectorWords_;
   using Element = cutlass::half_t;
-  using Fragment = cutlass::Array<
-      Element, ThreadMap::Iterations::kCount * ThreadMap::kElementsPerAccess>;
+  using Fragment = cutlass::Array<Element, ThreadMap::Iterations::kCount *
+                                               ThreadMap::kElementsPerAccess>;
   static_assert(Shape::kN == 64 || Shape::kN == 128 || Shape::kN == 256,
                 "SM70 Marlin U4 IteratorB expects CTA_N in {64, 128, 256}.");
-  static_assert(ThreadMap::Iterations::kContiguous ==
-                    Shape::kN / kQuantTileN,
+  static_assert(ThreadMap::Iterations::kContiguous == Shape::kN / kQuantTileN,
                 "SM70 Marlin U4 IteratorB expects one contiguous iteration per "
                 "64-column quant tile.");
   static_assert(ThreadMap::Delta::kContiguous == kQuantTileN,
@@ -68,7 +67,8 @@ class Sm70U4ZpIteratorB {
                 "SM70 Marlin U4 IteratorB expects one packed int4 word per "
                 "access.");
   static_assert(ThreadMap::Iterations::kStrided >= 1,
-                "SM70 Marlin U4-family IteratorB expects one or more strided iterations.");
+                "SM70 Marlin U4-family IteratorB expects one or more strided "
+                "iterations.");
   struct Params {
     int size_n;
     int aligned_initial_k_step;
@@ -115,7 +115,7 @@ class Sm70U4ZpIteratorB {
     qweight_base_offset_ =
         qweight_offset_from_logical(params_, logical_k, logical_n);
     if constexpr (kGroupSize == -1) {
-        cache_current_group_metadata(0);
+      cache_current_group_metadata(0);
     }
   }
 
@@ -151,8 +151,7 @@ class Sm70U4ZpIteratorB {
     if constexpr (kGroupSize == -1) {
       return 0;
     } else {
-      static_assert(kGroupSize == 32 || kGroupSize == 64 ||
-                        kGroupSize == 128,
+      static_assert(kGroupSize == 32 || kGroupSize == 64 || kGroupSize == 128,
                     "SM70 Marlin U4 supports only group sizes "
                     "-1, 32, 64, and 128.");
       return logical_k / kGroupSize;
@@ -162,8 +161,8 @@ class Sm70U4ZpIteratorB {
   CUTLASS_DEVICE
   static int qweight_offset_from_logical(Params const& params, int logical_k,
                                          int logical_n) {
-    return u4_packed_macro_n_qweight_offset_from_logical<kPackedMacroN>(params.size_n, logical_k,
-                                                  logical_n);
+    return u4_packed_macro_n_qweight_offset_from_logical<kPackedMacroN>(
+        params.size_n, logical_k, logical_n);
   }
 
   CUTLASS_DEVICE
@@ -176,8 +175,8 @@ class Sm70U4ZpIteratorB {
     scale_cache[2] = scale_vec[2];
     scale_cache[3] = scale_vec[3];
 
-    half2 const* zp_vec = reinterpret_cast<half2 const*>(
-        zp_ + group * params_.size_n + cache_n);
+    half2 const* zp_vec =
+        reinterpret_cast<half2 const*>(zp_ + group * params_.size_n + cache_n);
     half2* zp_cache = cached_zp_ + c * 4;
     zp_cache[0] = zp_vec[0];
     zp_cache[1] = zp_vec[1];
@@ -196,8 +195,8 @@ class Sm70U4ZpIteratorB {
     scale_cache[2] = scale_vec[2];
     scale_cache[3] = scale_vec[3];
 
-    uint4 const zp_words = *reinterpret_cast<uint4 const*>(
-        zp_ + group * params_.size_n + cache_n);
+    uint4 const zp_words =
+        *reinterpret_cast<uint4 const*>(zp_ + group * params_.size_n + cache_n);
     half2 const* zp_vec = reinterpret_cast<half2 const*>(&zp_words);
     half2* zp_cache = cached_zp_ + c * 4;
     zp_cache[0] = zp_vec[0];
@@ -210,9 +209,8 @@ class Sm70U4ZpIteratorB {
   void cache_current_group_metadata(int group) const {
     CUTLASS_PRAGMA_UNROLL
     for (int c = 0; c < ThreadMap::Iterations::kContiguous; ++c) {
-      int const cache_n =
-          n_offset_ + thread_offset_.contiguous() +
-          c * ThreadMap::Delta::kContiguous;
+      int const cache_n = n_offset_ + thread_offset_.contiguous() +
+                          c * ThreadMap::Delta::kContiguous;
       if constexpr (kUseMetadataVectorWords) {
         cache_metadata_vector_words(c, group, cache_n);
       } else {
@@ -237,8 +235,8 @@ class Sm70U4ZpIteratorB {
 
           half2 deq[2];
           half2* frag_vec = reinterpret_cast<half2*>(frag.data() + frag_base);
-          marlin::dequant<half2, vllm::kU4.id(), false>(
-              static_cast<int>(qword), deq);
+          marlin::dequant<half2, vllm::kU4.id(), false>(static_cast<int>(qword),
+                                                        deq);
           frag_vec[0] = __hfma2(deq[0], scale_vec[0], __hneg2(zp_vec[0]));
           frag_vec[1] = __hfma2(deq[1], scale_vec[1], __hneg2(zp_vec[1]));
           marlin::dequant<half2, vllm::kU4.id(), false>(
@@ -259,8 +257,8 @@ class Sm70U4ZpIteratorB {
 
           half2 deq[2];
           half2* frag_vec = reinterpret_cast<half2*>(frag.data() + frag_base);
-          marlin::dequant<half2, vllm::kU4.id(), false>(
-              static_cast<int>(qword), deq);
+          marlin::dequant<half2, vllm::kU4.id(), false>(static_cast<int>(qword),
+                                                        deq);
           frag_vec[0] = __hfma2(deq[0], scale_vec[0], __hneg2(zp_vec[0]));
           frag_vec[1] = __hfma2(deq[1], scale_vec[1], __hneg2(zp_vec[1]));
           marlin::dequant<half2, vllm::kU4.id(), false>(
@@ -271,14 +269,15 @@ class Sm70U4ZpIteratorB {
       } else {
         static_assert(ThreadMap::Iterations::kContiguous == 1,
                       "Unsupported SM70 Marlin U4 contiguous iteration count.");
-        uint32_t const qword = load_qword_vector<1>(qweight_ + qweight_base_offset_);
+        uint32_t const qword =
+            load_qword_vector<1>(qweight_ + qweight_base_offset_);
         half2 const* scale_vec = cached_scales_;
         half2 const* zp_vec = cached_zp_;
 
         half2 deq[2];
         half2* frag_vec = reinterpret_cast<half2*>(frag.data());
-        marlin::dequant<half2, vllm::kU4.id(), false>(
-            static_cast<int>(qword), deq);
+        marlin::dequant<half2, vllm::kU4.id(), false>(static_cast<int>(qword),
+                                                      deq);
         frag_vec[0] = __hfma2(deq[0], scale_vec[0], __hneg2(zp_vec[0]));
         frag_vec[1] = __hfma2(deq[1], scale_vec[1], __hneg2(zp_vec[1]));
         marlin::dequant<half2, vllm::kU4.id(), false>(
@@ -290,17 +289,15 @@ class Sm70U4ZpIteratorB {
       int const logical_n_base = n_offset_ + thread_offset_.contiguous();
       CUTLASS_PRAGMA_UNROLL
       for (int s = 0; s < ThreadMap::Iterations::kStrided; ++s) {
-        int const logical_k_s =
-            k_offset_ + thread_offset_.strided() +
-            s * ThreadMap::Delta::kStrided;
+        int const logical_k_s = k_offset_ + thread_offset_.strided() +
+                                s * ThreadMap::Delta::kStrided;
         if constexpr (kGroupSize != -1) {
           cache_current_group_metadata(scale_group(logical_k_s));
         }
         int const qweight_base_s =
             qweight_offset_from_logical(params_, logical_k_s, logical_n_base);
         if constexpr (ThreadMap::Iterations::kContiguous == 4) {
-          auto const qwords =
-              load_qword_vector<4>(qweight_ + qweight_base_s);
+          auto const qwords = load_qword_vector<4>(qweight_ + qweight_base_s);
           CUTLASS_PRAGMA_UNROLL
           for (int c = 0; c < ThreadMap::Iterations::kContiguous; ++c) {
             constexpr int kAccess = ThreadMap::kElementsPerAccess;
@@ -314,20 +311,15 @@ class Sm70U4ZpIteratorB {
             half2* frag_vec = reinterpret_cast<half2*>(frag.data() + frag_base);
             marlin::dequant<half2, vllm::kU4.id(), false>(
                 static_cast<int>(qword), deq);
-            frag_vec[0] =
-                __hfma2(deq[0], scale_vec[0], __hneg2(zp_vec[0]));
-            frag_vec[1] =
-                __hfma2(deq[1], scale_vec[1], __hneg2(zp_vec[1]));
+            frag_vec[0] = __hfma2(deq[0], scale_vec[0], __hneg2(zp_vec[0]));
+            frag_vec[1] = __hfma2(deq[1], scale_vec[1], __hneg2(zp_vec[1]));
             marlin::dequant<half2, vllm::kU4.id(), false>(
                 static_cast<int>(qword >> 8), deq);
-            frag_vec[2] =
-                __hfma2(deq[0], scale_vec[2], __hneg2(zp_vec[2]));
-            frag_vec[3] =
-                __hfma2(deq[1], scale_vec[3], __hneg2(zp_vec[3]));
+            frag_vec[2] = __hfma2(deq[0], scale_vec[2], __hneg2(zp_vec[2]));
+            frag_vec[3] = __hfma2(deq[1], scale_vec[3], __hneg2(zp_vec[3]));
           }
         } else if constexpr (ThreadMap::Iterations::kContiguous == 2) {
-          auto const qwords =
-              load_qword_vector<2>(qweight_ + qweight_base_s);
+          auto const qwords = load_qword_vector<2>(qweight_ + qweight_base_s);
           CUTLASS_PRAGMA_UNROLL
           for (int c = 0; c < ThreadMap::Iterations::kContiguous; ++c) {
             constexpr int kAccess = ThreadMap::kElementsPerAccess;
@@ -341,21 +333,19 @@ class Sm70U4ZpIteratorB {
             half2* frag_vec = reinterpret_cast<half2*>(frag.data() + frag_base);
             marlin::dequant<half2, vllm::kU4.id(), false>(
                 static_cast<int>(qword), deq);
-            frag_vec[0] =
-                __hfma2(deq[0], scale_vec[0], __hneg2(zp_vec[0]));
-            frag_vec[1] =
-                __hfma2(deq[1], scale_vec[1], __hneg2(zp_vec[1]));
+            frag_vec[0] = __hfma2(deq[0], scale_vec[0], __hneg2(zp_vec[0]));
+            frag_vec[1] = __hfma2(deq[1], scale_vec[1], __hneg2(zp_vec[1]));
             marlin::dequant<half2, vllm::kU4.id(), false>(
                 static_cast<int>(qword >> 8), deq);
-            frag_vec[2] =
-                __hfma2(deq[0], scale_vec[2], __hneg2(zp_vec[2]));
-            frag_vec[3] =
-                __hfma2(deq[1], scale_vec[3], __hneg2(zp_vec[3]));
+            frag_vec[2] = __hfma2(deq[0], scale_vec[2], __hneg2(zp_vec[2]));
+            frag_vec[3] = __hfma2(deq[1], scale_vec[3], __hneg2(zp_vec[3]));
           }
         } else {
-          static_assert(ThreadMap::Iterations::kContiguous == 1,
-                        "Unsupported SM70 Marlin U4 contiguous iteration count.");
-          uint32_t const qword = load_qword_vector<1>(qweight_ + qweight_base_s);
+          static_assert(
+              ThreadMap::Iterations::kContiguous == 1,
+              "Unsupported SM70 Marlin U4 contiguous iteration count.");
+          uint32_t const qword =
+              load_qword_vector<1>(qweight_ + qweight_base_s);
           constexpr int kAccess = ThreadMap::kElementsPerAccess;
           int const frag_base = s * kAccess;
           half2 const* scale_vec = cached_scales_;
@@ -363,8 +353,8 @@ class Sm70U4ZpIteratorB {
 
           half2 deq[2];
           half2* frag_vec = reinterpret_cast<half2*>(frag.data() + frag_base);
-          marlin::dequant<half2, vllm::kU4.id(), false>(
-              static_cast<int>(qword), deq);
+          marlin::dequant<half2, vllm::kU4.id(), false>(static_cast<int>(qword),
+                                                        deq);
           frag_vec[0] = __hfma2(deq[0], scale_vec[0], __hneg2(zp_vec[0]));
           frag_vec[1] = __hfma2(deq[1], scale_vec[1], __hneg2(zp_vec[1]));
           marlin::dequant<half2, vllm::kU4.id(), false>(
@@ -382,8 +372,7 @@ class Sm70U4ZpIteratorB {
       return;
     }
 
-    if constexpr (kGroupSize != -1 &&
-                  ThreadMap::Iterations::kStrided == 1) {
+    if constexpr (kGroupSize != -1 && ThreadMap::Iterations::kStrided == 1) {
       int const first_logical_k = k_offset_ + thread_offset_.strided();
       cache_current_group_metadata(scale_group(first_logical_k));
     }
@@ -395,32 +384,30 @@ class Sm70U4ZpIteratorB {
 template <bool UseMetadataVectorWords = true>
 struct Sm70U4ZpGemmSpec {
   template <typename Shape, typename ThreadMap, int GroupSize, int PackedMacroN>
-  using IteratorB =
-      Sm70U4ZpIteratorB<Shape, ThreadMap, GroupSize, PackedMacroN,
-                        UseMetadataVectorWords>;
+  using IteratorB = Sm70U4ZpIteratorB<Shape, ThreadMap, GroupSize, PackedMacroN,
+                                      UseMetadataVectorWords>;
 };
 
-template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM,
-          int WarpN, int WarpK, int GroupSize, int PackedMacroN,
+template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM, int WarpN,
+          int WarpK, int GroupSize, int PackedMacroN,
           bool UseMetadataVectorWords = true>
 using Sm70U4ZpGemmTraits =
-    Sm70MarlinGemmTraits<Sm70U4ZpGemmSpec<UseMetadataVectorWords>, CtaM,
-                         CtaN, CtaK, Warps, WarpM, WarpN, WarpK,
-                         GroupSize, PackedMacroN>;
+    Sm70MarlinGemmTraits<Sm70U4ZpGemmSpec<UseMetadataVectorWords>, CtaM, CtaN,
+                         CtaK, Warps, WarpM, WarpN, WarpK, GroupSize,
+                         PackedMacroN>;
 
-template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM,
-          int WarpN, int WarpK, int GroupSize, int PackedMacroN,
+template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM, int WarpN,
+          int WarpK, int GroupSize, int PackedMacroN,
           bool UseMetadataVectorWords = true>
-__global__ __launch_bounds__(Warps * 32, 1)
-void sm70_marlin_u4_gemm_kernel(
+__global__ __launch_bounds__(Warps * 32, 1) void sm70_marlin_u4_gemm_kernel(
     cutlass::half_t const* __restrict__ a,
     uint32_t const* __restrict__ b_q_weight,
     cutlass::half_t const* __restrict__ b_scales,
     cutlass::half_t const* __restrict__ b_zeros,
     cutlass::half_t* __restrict__ c, int m, int n, int k, int lda) {
-  using Traits = Sm70U4ZpGemmTraits<CtaM, CtaN, CtaK, Warps, WarpM,
-                                    WarpN, WarpK, GroupSize, PackedMacroN,
-                                    UseMetadataVectorWords>;
+  using Traits =
+      Sm70U4ZpGemmTraits<CtaM, CtaN, CtaK, Warps, WarpM, WarpN, WarpK,
+                         GroupSize, PackedMacroN, UseMetadataVectorWords>;
   using Mma = typename Traits::Mma;
   using Epilogue = typename Traits::Epilogue;
 
@@ -440,10 +427,10 @@ void sm70_marlin_u4_gemm_kernel(
   typename Traits::LayoutA layout_a(lda);
   typename Traits::LayoutC layout_c(n);
 
-  typename Mma::IteratorA iterator_A(
-      typename Mma::IteratorA::Params(layout_a),
-      const_cast<cutlass::half_t*>(a), cutlass::MatrixCoord(m, k), thread_idx,
-      tb_offset_A);
+  typename Mma::IteratorA iterator_A(typename Mma::IteratorA::Params(layout_a),
+                                     const_cast<cutlass::half_t*>(a),
+                                     cutlass::MatrixCoord(m, k), thread_idx,
+                                     tb_offset_A);
   typename Mma::IteratorB iterator_B(
       typename Mma::IteratorB::Params(k, n),
       reinterpret_cast<uint32_t const*>(b_q_weight),
@@ -469,19 +456,20 @@ void sm70_marlin_u4_gemm_kernel(
   epilogue(output_op, iterator_D, accumulators, iterator_C);
 }
 
-template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM,
-          int WarpN, int WarpK, int GroupSize, int PackedMacroN,
+template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM, int WarpN,
+          int WarpK, int GroupSize, int PackedMacroN,
           bool UseMetadataVectorWords = true>
-__global__ __launch_bounds__(Warps * 32, 1)
-void sm70_marlin_u4_gemm_splitk_kernel(
+__global__
+__launch_bounds__(Warps * 32, 1) void sm70_marlin_u4_gemm_splitk_kernel(
     cutlass::half_t const* __restrict__ a,
     uint32_t const* __restrict__ b_q_weight,
     cutlass::half_t const* __restrict__ b_scales,
     cutlass::half_t const* __restrict__ b_zeros,
-    cutlass::half_t* __restrict__ c, float* __restrict__ c32, int m, int n, int k, int lda, int requested_split_k) {
-  using Traits = Sm70U4ZpGemmTraits<CtaM, CtaN, CtaK, Warps, WarpM,
-                                    WarpN, WarpK, GroupSize, PackedMacroN,
-                                    UseMetadataVectorWords>;
+    cutlass::half_t* __restrict__ c, float* __restrict__ c32, int m, int n,
+    int k, int lda, int requested_split_k) {
+  using Traits =
+      Sm70U4ZpGemmTraits<CtaM, CtaN, CtaK, Warps, WarpM, WarpN, WarpK,
+                         GroupSize, PackedMacroN, UseMetadataVectorWords>;
   using Mma = typename Traits::Mma;
   using AtomicEpilogue = Sm70AtomicFp32Epilogue<Traits>;
 
@@ -492,14 +480,13 @@ void sm70_marlin_u4_gemm_splitk_kernel(
   int const thread_idx = threadIdx.x;
   int const warp_idx = cutlass::canonical_warp_idx_sync();
   int const lane_idx = threadIdx.x % 32;
-  Sm70SplitKPartition const partition =
-      sm70_splitk_partition<GroupSize, CtaK>(k, requested_split_k, int(blockIdx.z));
+  Sm70SplitKPartition const partition = sm70_splitk_partition<GroupSize, CtaK>(
+      k, requested_split_k, int(blockIdx.z));
   if (partition.partition_k == 0) {
     return;
   }
 
-  cutlass::MatrixCoord tb_offset_A{int(blockIdx.x) * CtaM,
-                                   partition.k_begin};
+  cutlass::MatrixCoord tb_offset_A{int(blockIdx.x) * CtaM, partition.k_begin};
   cutlass::MatrixCoord tb_offset_B{partition.k_begin, int(blockIdx.y) * CtaN};
   cutlass::MatrixCoord tb_offset_C{int(blockIdx.x) * CtaM,
                                    int(blockIdx.y) * CtaN};
@@ -507,10 +494,10 @@ void sm70_marlin_u4_gemm_splitk_kernel(
   typename Traits::LayoutA layout_a(lda);
   typename Traits::LayoutC layout_c(n);
 
-  typename Mma::IteratorA iterator_A(
-      typename Mma::IteratorA::Params(layout_a),
-      const_cast<cutlass::half_t*>(a), cutlass::MatrixCoord(m, k), thread_idx,
-      tb_offset_A);
+  typename Mma::IteratorA iterator_A(typename Mma::IteratorA::Params(layout_a),
+                                     const_cast<cutlass::half_t*>(a),
+                                     cutlass::MatrixCoord(m, k), thread_idx,
+                                     tb_offset_A);
   typename Mma::IteratorB iterator_B(
       typename Mma::IteratorB::Params(k, n),
       reinterpret_cast<uint32_t const*>(b_q_weight),
@@ -525,9 +512,8 @@ void sm70_marlin_u4_gemm_splitk_kernel(
   mma(gemm_k_iterations, accumulators, iterator_A, iterator_B, accumulators);
 
   typename AtomicEpilogue::OutputTileIterator iterator_D(
-      typename AtomicEpilogue::OutputTileIterator::Params(layout_c),
-      c, cutlass::MatrixCoord(m, n),
-      thread_idx, tb_offset_C);
+      typename AtomicEpilogue::OutputTileIterator::Params(layout_c), c,
+      cutlass::MatrixCoord(m, n), thread_idx, tb_offset_C);
 
   AtomicEpilogue epilogue(shared_storage.epilogue, thread_idx, warp_idx,
                           lane_idx);
@@ -536,19 +522,23 @@ void sm70_marlin_u4_gemm_splitk_kernel(
 
 }  // namespace
 
-template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM,
-          int WarpN, int WarpK, int GroupSize, int PackedMacroN,
+template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM, int WarpN,
+          int WarpK, int GroupSize, int PackedMacroN,
           bool UseMetadataVectorWords = true>
-torch::Tensor launch_sm70_marlin_u4_gemm(
-    torch::Tensor& a, torch::Tensor& c, torch::Tensor& b_q_weight,
-    torch::Tensor& b_scales, torch::Tensor& b_zeros, int64_t size_m,
-    int64_t size_n, int64_t size_k, int requested_split_k) {
-  auto kernel = sm70_marlin_u4_gemm_kernel<CtaM, CtaN, CtaK, Warps, WarpM, WarpN, WarpK,
-                                           GroupSize, PackedMacroN,
-                                           UseMetadataVectorWords>;
-  using SharedStorage = typename Sm70U4ZpGemmTraits<
-      CtaM, CtaN, CtaK, Warps, WarpM, WarpN, WarpK, GroupSize,
-      PackedMacroN, UseMetadataVectorWords>::SharedStorage;
+torch::Tensor launch_sm70_marlin_u4_gemm(torch::Tensor& a, torch::Tensor& c,
+                                         torch::Tensor& b_q_weight,
+                                         torch::Tensor& b_scales,
+                                         torch::Tensor& b_zeros, int64_t size_m,
+                                         int64_t size_n, int64_t size_k,
+                                         int requested_split_k) {
+  auto kernel =
+      sm70_marlin_u4_gemm_kernel<CtaM, CtaN, CtaK, Warps, WarpM, WarpN, WarpK,
+                                 GroupSize, PackedMacroN,
+                                 UseMetadataVectorWords>;
+  using SharedStorage =
+      typename Sm70U4ZpGemmTraits<CtaM, CtaN, CtaK, Warps, WarpM, WarpN, WarpK,
+                                  GroupSize, PackedMacroN,
+                                  UseMetadataVectorWords>::SharedStorage;
   size_t smem_bytes = configure_sm70_dynamic_smem<SharedStorage>(kernel);
   dim3 block(Warps * 32);
   cudaStream_t stream = at::cuda::getCurrentCUDAStream(a.get_device()).stream();
@@ -558,8 +548,7 @@ torch::Tensor launch_sm70_marlin_u4_gemm(
     kernel<<<grid, block, smem_bytes, stream>>>(
         reinterpret_cast<cutlass::half_t const*>(a.data_ptr<at::Half>()),
         reinterpret_cast<uint32_t const*>(b_q_weight.data_ptr<int32_t>()),
-        reinterpret_cast<cutlass::half_t const*>(
-            b_scales.data_ptr<at::Half>()),
+        reinterpret_cast<cutlass::half_t const*>(b_scales.data_ptr<at::Half>()),
         reinterpret_cast<cutlass::half_t const*>(b_zeros.data_ptr<at::Half>()),
         reinterpret_cast<cutlass::half_t*>(c.data_ptr<at::Half>()),
         static_cast<int>(size_m), static_cast<int>(size_n),
@@ -569,8 +558,8 @@ torch::Tensor launch_sm70_marlin_u4_gemm(
   }
 
   TORCH_CHECK(size_k % int64_t(CtaK) == 0,
-              "SM70 Marlin uint4 requires K divisible by CTA_K=",
-              CtaK, " for requested_split_k > 1. Got K=", size_k,
+              "SM70 Marlin uint4 requires K divisible by CTA_K=", CtaK,
+              " for requested_split_k > 1. Got K=", size_k,
               ", requested_split_k=", requested_split_k, ".");
 
   auto split_kernel =
@@ -583,8 +572,7 @@ torch::Tensor launch_sm70_marlin_u4_gemm(
   // 0009: fp32 split-K scratch (zeroed for the fp32 atomicAdd), M*N floats.
   // Only allocated on the split_k>1 path, which the auto-selector uses ONLY at
   // low batch (M<128), so the scratch is bounded and small.
-  auto c32 = torch::zeros({size_m, size_n},
-                          a.options().dtype(at::kFloat));
+  auto c32 = torch::zeros({size_m, size_n}, a.options().dtype(at::kFloat));
 
   dim3 grid = sm70_marlin_cta_grid(size_m, size_n, CtaM, CtaN);
   int const active_split_k =
@@ -596,9 +584,9 @@ torch::Tensor launch_sm70_marlin_u4_gemm(
       reinterpret_cast<cutlass::half_t const*>(b_scales.data_ptr<at::Half>()),
       reinterpret_cast<cutlass::half_t const*>(b_zeros.data_ptr<at::Half>()),
       reinterpret_cast<cutlass::half_t*>(c.data_ptr<at::Half>()),
-      c32.data_ptr<float>(),
-      static_cast<int>(size_m), static_cast<int>(size_n),
-      static_cast<int>(size_k), static_cast<int>(a.stride(0)), requested_split_k);
+      c32.data_ptr<float>(), static_cast<int>(size_m), static_cast<int>(size_n),
+      static_cast<int>(size_k), static_cast<int>(a.stride(0)),
+      requested_split_k);
   C10_CUDA_KERNEL_LAUNCH_CHECK();
 
   // 0009: single deterministic-width fp32->fp16 narrow of the scratch.
@@ -606,8 +594,8 @@ torch::Tensor launch_sm70_marlin_u4_gemm(
   int const narrow_grid =
       static_cast<int>((numel + narrow_block - 1) / narrow_block);
   sm70_marlin_narrow_f32_to_f16<256><<<narrow_grid, narrow_block, 0, stream>>>(
-      c32.data_ptr<float>(),
-      reinterpret_cast<half*>(c.data_ptr<at::Half>()), numel);
+      c32.data_ptr<float>(), reinterpret_cast<half*>(c.data_ptr<at::Half>()),
+      numel);
   C10_CUDA_KERNEL_LAUNCH_CHECK();
 
   return c;
@@ -625,38 +613,44 @@ struct Sm70U4Launcher {
   int64_t size_k;
   int requested_split_k;
 
-  template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM,
-            int WarpN, int WarpK, int GroupSize, int PackedMacroN>
+  template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM, int WarpN,
+            int WarpK, int GroupSize, int PackedMacroN>
   torch::Tensor operator()() const {
-    return launch_sm70_marlin_u4_gemm<CtaM, CtaN, CtaK, Warps, WarpM, WarpN, WarpK,
-                                      GroupSize, PackedMacroN,
+    return launch_sm70_marlin_u4_gemm<CtaM, CtaN, CtaK, Warps, WarpM, WarpN,
+                                      WarpK, GroupSize, PackedMacroN,
                                       UseMetadataVectorWords>(
-        a, c, b_q_weight, b_scales, b_zeros, size_m, size_n, size_k, requested_split_k);
+        a, c, b_q_weight, b_scales, b_zeros, size_m, size_n, size_k,
+        requested_split_k);
   }
 };
 
-torch::Tensor sm70_marlin_u4_gemm(
-    torch::Tensor& a, torch::Tensor& c, torch::Tensor& b_q_weight,
-    torch::Tensor& b_scales, torch::Tensor& b_zeros, int64_t size_m,
-    int64_t size_n, int64_t size_k, int64_t group_size) {
+torch::Tensor sm70_marlin_u4_gemm(torch::Tensor& a, torch::Tensor& c,
+                                  torch::Tensor& b_q_weight,
+                                  torch::Tensor& b_scales,
+                                  torch::Tensor& b_zeros, int64_t size_m,
+                                  int64_t size_n, int64_t size_k,
+                                  int64_t group_size) {
   c10::cuda::CUDAGuard device_guard(a.device());
 
-  auto const params =
-      sm70_marlin_dense_auto_params("uint4", group_size, size_m, size_n,
-                                    size_k);
+  auto const params = sm70_marlin_dense_auto_params("uint4", group_size, size_m,
+                                                    size_n, size_k);
   Sm70CtaGeometry const geometry = params.geometry;
-  validate_sm70_marlin_dense_cta_geometry_supported("SM70 Marlin uint4", geometry);
-  validate_sm70_marlin_dense_cta_n_alignment("SM70 Marlin uint4", geometry, size_n);
+  validate_sm70_marlin_dense_cta_geometry_supported("SM70 Marlin uint4",
+                                                    geometry);
+  validate_sm70_marlin_dense_cta_n_alignment("SM70 Marlin uint4", geometry,
+                                             size_n);
   if (params.use_metadata_vector_words) {
     Sm70U4Launcher<true> const launcher{
-        a, c, b_q_weight, b_scales, b_zeros, size_m, size_n,
-        size_k, params.requested_split_k};
+        a,        c,       b_q_weight,
+        b_scales, b_zeros, size_m,
+        size_n,   size_k,  params.requested_split_k};
     return dispatch_sm70_marlin_geometry(
         launcher, geometry, params.packed_macro_n, group_size, "uint4");
   }
   Sm70U4Launcher<false> const launcher{
-      a, c, b_q_weight, b_scales, b_zeros, size_m, size_n,
-      size_k, params.requested_split_k};
+      a,        c,       b_q_weight,
+      b_scales, b_zeros, size_m,
+      size_n,   size_k,  params.requested_split_k};
   return dispatch_sm70_marlin_geometry(
       launcher, geometry, params.packed_macro_n, group_size, "uint4");
 }

--- a/csrc/quantization/marlin/sm70_marlin_u4b8_gemm.cu
+++ b/csrc/quantization/marlin/sm70_marlin_u4b8_gemm.cu
@@ -20,25 +20,25 @@
 #include "cutlass/layout/tensor_op_multiplicand_sm70.h"
 #include "cutlass/transform/threadblock/predicated_tile_iterator.h"
 
-using marlin::sm70::Sm70CtaGeometry;
-using marlin::sm70::Sm70AtomicFp16Epilogue;
-using marlin::sm70::Sm70AtomicFp32Epilogue;
-using marlin::sm70::sm70_marlin_narrow_f32_to_f16;
-using marlin::sm70::Sm70MarlinGemmTraits;
-using marlin::sm70::Sm70SplitKPartition;
-using marlin::sm70::validate_sm70_marlin_dense_cta_geometry_supported;
-using marlin::sm70::validate_sm70_marlin_dense_cta_n_alignment;
 using marlin::sm70::configure_sm70_dynamic_smem;
 using marlin::sm70::dispatch_sm70_marlin_geometry;
 using marlin::sm70::kQuantTileK;
 using marlin::sm70::kQuantTileN;
-using marlin::sm70::sm70_marlin_dense_auto_params;
 using marlin::sm70::load_qword_vector;
 using marlin::sm70::qword_from_vector;
-using marlin::sm70::sm70_marlin_cta_grid;
 using marlin::sm70::sm70_active_split_k;
+using marlin::sm70::sm70_marlin_cta_grid;
+using marlin::sm70::sm70_marlin_dense_auto_params;
+using marlin::sm70::sm70_marlin_narrow_f32_to_f16;
 using marlin::sm70::sm70_splitk_partition;
+using marlin::sm70::Sm70AtomicFp16Epilogue;
+using marlin::sm70::Sm70AtomicFp32Epilogue;
+using marlin::sm70::Sm70CtaGeometry;
+using marlin::sm70::Sm70MarlinGemmTraits;
+using marlin::sm70::Sm70SplitKPartition;
 using marlin::sm70::u4_packed_macro_n_qweight_offset_from_logical;
+using marlin::sm70::validate_sm70_marlin_dense_cta_geometry_supported;
+using marlin::sm70::validate_sm70_marlin_dense_cta_n_alignment;
 
 namespace {
 
@@ -54,12 +54,11 @@ class Sm70U4B8IteratorB {
   static int const kPackedMacroN = PackedMacroN_;
   static constexpr bool kUseMetadataVectorWords = UseMetadataVectorWords_;
   using Element = cutlass::half_t;
-  using Fragment = cutlass::Array<
-      Element, ThreadMap::Iterations::kCount * ThreadMap::kElementsPerAccess>;
+  using Fragment = cutlass::Array<Element, ThreadMap::Iterations::kCount *
+                                               ThreadMap::kElementsPerAccess>;
   static_assert(Shape::kN == 64 || Shape::kN == 128 || Shape::kN == 256,
                 "SM70 Marlin U4B8 IteratorB expects CTA_N in {64, 128, 256}.");
-  static_assert(ThreadMap::Iterations::kContiguous ==
-                    Shape::kN / kQuantTileN,
+  static_assert(ThreadMap::Iterations::kContiguous == Shape::kN / kQuantTileN,
                 "SM70 Marlin U4B8 IteratorB expects one contiguous iteration "
                 "per 64-column quant tile.");
   static_assert(ThreadMap::Delta::kContiguous == kQuantTileN,
@@ -68,7 +67,8 @@ class Sm70U4B8IteratorB {
                 "SM70 Marlin U4B8 IteratorB expects one packed int4 word per "
                 "access.");
   static_assert(ThreadMap::Iterations::kStrided >= 1,
-                "SM70 Marlin U4-family IteratorB expects one or more strided iterations.");
+                "SM70 Marlin U4-family IteratorB expects one or more strided "
+                "iterations.");
   struct Params {
     int size_n;
     int aligned_initial_k_step;
@@ -148,8 +148,7 @@ class Sm70U4B8IteratorB {
     if constexpr (kGroupSize == -1) {
       return 0;
     } else {
-      static_assert(kGroupSize == 32 || kGroupSize == 64 ||
-                        kGroupSize == 128,
+      static_assert(kGroupSize == 32 || kGroupSize == 64 || kGroupSize == 128,
                     "SM70 Marlin U4B8 supports only group sizes "
                     "-1, 32, 64, and 128.");
       return logical_k / kGroupSize;
@@ -159,8 +158,8 @@ class Sm70U4B8IteratorB {
   CUTLASS_DEVICE
   static int qweight_offset_from_logical(Params const& params, int logical_k,
                                          int logical_n) {
-    return u4_packed_macro_n_qweight_offset_from_logical<kPackedMacroN>(params.size_n, logical_k,
-                                                  logical_n);
+    return u4_packed_macro_n_qweight_offset_from_logical<kPackedMacroN>(
+        params.size_n, logical_k, logical_n);
   }
 
   CUTLASS_DEVICE
@@ -190,9 +189,8 @@ class Sm70U4B8IteratorB {
   void cache_current_group_metadata(int group) const {
     CUTLASS_PRAGMA_UNROLL
     for (int c = 0; c < ThreadMap::Iterations::kContiguous; ++c) {
-      int const cache_n =
-          n_offset_ + thread_offset_.contiguous() +
-          c * ThreadMap::Delta::kContiguous;
+      int const cache_n = n_offset_ + thread_offset_.contiguous() +
+                          c * ThreadMap::Delta::kContiguous;
       if constexpr (kUseMetadataVectorWords) {
         cache_metadata_vector_words(c, group, cache_n);
       } else {
@@ -247,15 +245,17 @@ class Sm70U4B8IteratorB {
           frag_vec[3] = __hmul2(deq[1], scale_vec[3]);
         }
       } else {
-        static_assert(ThreadMap::Iterations::kContiguous == 1,
-                      "Unsupported SM70 Marlin U4B8 contiguous iteration count.");
-        uint32_t const qword = load_qword_vector<1>(qweight_ + qweight_base_offset_);
+        static_assert(
+            ThreadMap::Iterations::kContiguous == 1,
+            "Unsupported SM70 Marlin U4B8 contiguous iteration count.");
+        uint32_t const qword =
+            load_qword_vector<1>(qweight_ + qweight_base_offset_);
         half2 const* scale_vec = cached_scales_;
 
         half2 deq[2];
         half2* frag_vec = reinterpret_cast<half2*>(frag.data());
-        marlin::dequant<half2, vllm::kU4B8.id(), false>(
-            static_cast<int>(qword), deq);
+        marlin::dequant<half2, vllm::kU4B8.id(), false>(static_cast<int>(qword),
+                                                        deq);
         frag_vec[0] = __hmul2(deq[0], scale_vec[0]);
         frag_vec[1] = __hmul2(deq[1], scale_vec[1]);
         marlin::dequant<half2, vllm::kU4B8.id(), false>(
@@ -267,17 +267,15 @@ class Sm70U4B8IteratorB {
       int const logical_n_base = n_offset_ + thread_offset_.contiguous();
       CUTLASS_PRAGMA_UNROLL
       for (int s = 0; s < ThreadMap::Iterations::kStrided; ++s) {
-        int const logical_k_s =
-            k_offset_ + thread_offset_.strided() +
-            s * ThreadMap::Delta::kStrided;
+        int const logical_k_s = k_offset_ + thread_offset_.strided() +
+                                s * ThreadMap::Delta::kStrided;
         if constexpr (kGroupSize != -1) {
           cache_current_group_metadata(scale_group(logical_k_s));
         }
         int const qweight_base_s =
             qweight_offset_from_logical(params_, logical_k_s, logical_n_base);
         if constexpr (ThreadMap::Iterations::kContiguous == 4) {
-          auto const qwords =
-              load_qword_vector<4>(qweight_ + qweight_base_s);
+          auto const qwords = load_qword_vector<4>(qweight_ + qweight_base_s);
           CUTLASS_PRAGMA_UNROLL
           for (int c = 0; c < ThreadMap::Iterations::kContiguous; ++c) {
             constexpr int kAccess = ThreadMap::kElementsPerAccess;
@@ -298,8 +296,7 @@ class Sm70U4B8IteratorB {
             frag_vec[3] = __hmul2(deq[1], scale_vec[3]);
           }
         } else if constexpr (ThreadMap::Iterations::kContiguous == 2) {
-          auto const qwords =
-              load_qword_vector<2>(qweight_ + qweight_base_s);
+          auto const qwords = load_qword_vector<2>(qweight_ + qweight_base_s);
           CUTLASS_PRAGMA_UNROLL
           for (int c = 0; c < ThreadMap::Iterations::kContiguous; ++c) {
             constexpr int kAccess = ThreadMap::kElementsPerAccess;
@@ -320,9 +317,11 @@ class Sm70U4B8IteratorB {
             frag_vec[3] = __hmul2(deq[1], scale_vec[3]);
           }
         } else {
-          static_assert(ThreadMap::Iterations::kContiguous == 1,
-                        "Unsupported SM70 Marlin U4B8 contiguous iteration count.");
-          uint32_t const qword = load_qword_vector<1>(qweight_ + qweight_base_s);
+          static_assert(
+              ThreadMap::Iterations::kContiguous == 1,
+              "Unsupported SM70 Marlin U4B8 contiguous iteration count.");
+          uint32_t const qword =
+              load_qword_vector<1>(qweight_ + qweight_base_s);
           constexpr int kAccess = ThreadMap::kElementsPerAccess;
           int const frag_base = s * kAccess;
           half2 const* scale_vec = cached_scales_;
@@ -348,8 +347,7 @@ class Sm70U4B8IteratorB {
       return;
     }
 
-    if constexpr (kGroupSize != -1 &&
-                  ThreadMap::Iterations::kStrided == 1) {
+    if constexpr (kGroupSize != -1 && ThreadMap::Iterations::kStrided == 1) {
       int const first_logical_k = k_offset_ + thread_offset_.strided();
       cache_current_group_metadata(scale_group(first_logical_k));
     }
@@ -361,31 +359,29 @@ class Sm70U4B8IteratorB {
 template <bool UseMetadataVectorWords = true>
 struct Sm70U4B8GemmSpec {
   template <typename Shape, typename ThreadMap, int GroupSize, int PackedMacroN>
-  using IteratorB =
-      Sm70U4B8IteratorB<Shape, ThreadMap, GroupSize, PackedMacroN,
-                        UseMetadataVectorWords>;
+  using IteratorB = Sm70U4B8IteratorB<Shape, ThreadMap, GroupSize, PackedMacroN,
+                                      UseMetadataVectorWords>;
 };
 
-template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM,
-          int WarpN, int WarpK, int GroupSize, int PackedMacroN,
+template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM, int WarpN,
+          int WarpK, int GroupSize, int PackedMacroN,
           bool UseMetadataVectorWords = true>
 using Sm70U4B8GemmTraits =
-    Sm70MarlinGemmTraits<Sm70U4B8GemmSpec<UseMetadataVectorWords>, CtaM,
-                         CtaN, CtaK, Warps, WarpM, WarpN, WarpK,
-                         GroupSize, PackedMacroN>;
+    Sm70MarlinGemmTraits<Sm70U4B8GemmSpec<UseMetadataVectorWords>, CtaM, CtaN,
+                         CtaK, Warps, WarpM, WarpN, WarpK, GroupSize,
+                         PackedMacroN>;
 
-template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM,
-          int WarpN, int WarpK, int GroupSize, int PackedMacroN,
+template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM, int WarpN,
+          int WarpK, int GroupSize, int PackedMacroN,
           bool UseMetadataVectorWords = true>
-__global__ __launch_bounds__(Warps * 32, 1)
-void sm70_marlin_u4b8_gemm_kernel(
+__global__ __launch_bounds__(Warps * 32, 1) void sm70_marlin_u4b8_gemm_kernel(
     cutlass::half_t const* __restrict__ a,
     uint32_t const* __restrict__ b_q_weight,
     cutlass::half_t const* __restrict__ b_scales,
     cutlass::half_t* __restrict__ c, int m, int n, int k, int lda) {
-  using Traits = Sm70U4B8GemmTraits<CtaM, CtaN, CtaK, Warps, WarpM,
-                                    WarpN, WarpK, GroupSize, PackedMacroN,
-                                    UseMetadataVectorWords>;
+  using Traits =
+      Sm70U4B8GemmTraits<CtaM, CtaN, CtaK, Warps, WarpM, WarpN, WarpK,
+                         GroupSize, PackedMacroN, UseMetadataVectorWords>;
   using Mma = typename Traits::Mma;
   using Epilogue = typename Traits::Epilogue;
 
@@ -405,10 +401,10 @@ void sm70_marlin_u4b8_gemm_kernel(
   typename Traits::LayoutA layout_a(lda);
   typename Traits::LayoutC layout_c(n);
 
-  typename Mma::IteratorA iterator_A(
-      typename Mma::IteratorA::Params(layout_a),
-      const_cast<cutlass::half_t*>(a), cutlass::MatrixCoord(m, k), thread_idx,
-      tb_offset_A);
+  typename Mma::IteratorA iterator_A(typename Mma::IteratorA::Params(layout_a),
+                                     const_cast<cutlass::half_t*>(a),
+                                     cutlass::MatrixCoord(m, k), thread_idx,
+                                     tb_offset_A);
   typename Mma::IteratorB iterator_B(
       typename Mma::IteratorB::Params(k, n),
       reinterpret_cast<uint32_t const*>(b_q_weight),
@@ -433,18 +429,19 @@ void sm70_marlin_u4b8_gemm_kernel(
   epilogue(output_op, iterator_D, accumulators, iterator_C);
 }
 
-template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM,
-          int WarpN, int WarpK, int GroupSize, int PackedMacroN,
+template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM, int WarpN,
+          int WarpK, int GroupSize, int PackedMacroN,
           bool UseMetadataVectorWords = true>
-__global__ __launch_bounds__(Warps * 32, 1)
-void sm70_marlin_u4b8_gemm_splitk_kernel(
+__global__
+__launch_bounds__(Warps * 32, 1) void sm70_marlin_u4b8_gemm_splitk_kernel(
     cutlass::half_t const* __restrict__ a,
     uint32_t const* __restrict__ b_q_weight,
     cutlass::half_t const* __restrict__ b_scales,
-    cutlass::half_t* __restrict__ c, float* __restrict__ c32, int m, int n, int k, int lda, int requested_split_k) {
-  using Traits = Sm70U4B8GemmTraits<CtaM, CtaN, CtaK, Warps, WarpM,
-                                    WarpN, WarpK, GroupSize, PackedMacroN,
-                                    UseMetadataVectorWords>;
+    cutlass::half_t* __restrict__ c, float* __restrict__ c32, int m, int n,
+    int k, int lda, int requested_split_k) {
+  using Traits =
+      Sm70U4B8GemmTraits<CtaM, CtaN, CtaK, Warps, WarpM, WarpN, WarpK,
+                         GroupSize, PackedMacroN, UseMetadataVectorWords>;
   using Mma = typename Traits::Mma;
   using AtomicEpilogue = Sm70AtomicFp32Epilogue<Traits>;
 
@@ -455,14 +452,13 @@ void sm70_marlin_u4b8_gemm_splitk_kernel(
   int const thread_idx = threadIdx.x;
   int const warp_idx = cutlass::canonical_warp_idx_sync();
   int const lane_idx = threadIdx.x % 32;
-  Sm70SplitKPartition const partition =
-      sm70_splitk_partition<GroupSize, CtaK>(k, requested_split_k, int(blockIdx.z));
+  Sm70SplitKPartition const partition = sm70_splitk_partition<GroupSize, CtaK>(
+      k, requested_split_k, int(blockIdx.z));
   if (partition.partition_k == 0) {
     return;
   }
 
-  cutlass::MatrixCoord tb_offset_A{int(blockIdx.x) * CtaM,
-                                   partition.k_begin};
+  cutlass::MatrixCoord tb_offset_A{int(blockIdx.x) * CtaM, partition.k_begin};
   cutlass::MatrixCoord tb_offset_B{partition.k_begin, int(blockIdx.y) * CtaN};
   cutlass::MatrixCoord tb_offset_C{int(blockIdx.x) * CtaM,
                                    int(blockIdx.y) * CtaN};
@@ -470,10 +466,10 @@ void sm70_marlin_u4b8_gemm_splitk_kernel(
   typename Traits::LayoutA layout_a(lda);
   typename Traits::LayoutC layout_c(n);
 
-  typename Mma::IteratorA iterator_A(
-      typename Mma::IteratorA::Params(layout_a),
-      const_cast<cutlass::half_t*>(a), cutlass::MatrixCoord(m, k), thread_idx,
-      tb_offset_A);
+  typename Mma::IteratorA iterator_A(typename Mma::IteratorA::Params(layout_a),
+                                     const_cast<cutlass::half_t*>(a),
+                                     cutlass::MatrixCoord(m, k), thread_idx,
+                                     tb_offset_A);
   typename Mma::IteratorB iterator_B(
       typename Mma::IteratorB::Params(k, n),
       reinterpret_cast<uint32_t const*>(b_q_weight),
@@ -487,9 +483,8 @@ void sm70_marlin_u4b8_gemm_splitk_kernel(
   mma(gemm_k_iterations, accumulators, iterator_A, iterator_B, accumulators);
 
   typename AtomicEpilogue::OutputTileIterator iterator_D(
-      typename AtomicEpilogue::OutputTileIterator::Params(layout_c),
-      c, cutlass::MatrixCoord(m, n),
-      thread_idx, tb_offset_C);
+      typename AtomicEpilogue::OutputTileIterator::Params(layout_c), c,
+      cutlass::MatrixCoord(m, n), thread_idx, tb_offset_C);
 
   AtomicEpilogue epilogue(shared_storage.epilogue, thread_idx, warp_idx,
                           lane_idx);
@@ -498,20 +493,23 @@ void sm70_marlin_u4b8_gemm_splitk_kernel(
 
 }  // namespace
 
-template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM,
-          int WarpN, int WarpK, int GroupSize, int PackedMacroN,
+template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM, int WarpN,
+          int WarpK, int GroupSize, int PackedMacroN,
           bool UseMetadataVectorWords = true>
-torch::Tensor launch_sm70_marlin_u4b8_gemm(
-    torch::Tensor& a, torch::Tensor& c, torch::Tensor& b_q_weight,
-    torch::Tensor& b_scales, int64_t size_m, int64_t size_n, int64_t size_k,
-    int requested_split_k) {
+torch::Tensor launch_sm70_marlin_u4b8_gemm(torch::Tensor& a, torch::Tensor& c,
+                                           torch::Tensor& b_q_weight,
+                                           torch::Tensor& b_scales,
+                                           int64_t size_m, int64_t size_n,
+                                           int64_t size_k,
+                                           int requested_split_k) {
   auto kernel =
-      sm70_marlin_u4b8_gemm_kernel<CtaM, CtaN, CtaK, Warps, WarpM, WarpN,
-                                   WarpK, GroupSize, PackedMacroN,
+      sm70_marlin_u4b8_gemm_kernel<CtaM, CtaN, CtaK, Warps, WarpM, WarpN, WarpK,
+                                   GroupSize, PackedMacroN,
                                    UseMetadataVectorWords>;
-  using SharedStorage = typename Sm70U4B8GemmTraits<
-      CtaM, CtaN, CtaK, Warps, WarpM, WarpN, WarpK, GroupSize,
-      PackedMacroN, UseMetadataVectorWords>::SharedStorage;
+  using SharedStorage =
+      typename Sm70U4B8GemmTraits<CtaM, CtaN, CtaK, Warps, WarpM, WarpN, WarpK,
+                                  GroupSize, PackedMacroN,
+                                  UseMetadataVectorWords>::SharedStorage;
   size_t smem_bytes = configure_sm70_dynamic_smem<SharedStorage>(kernel);
 
   dim3 block(Warps * 32);
@@ -531,14 +529,13 @@ torch::Tensor launch_sm70_marlin_u4b8_gemm(
   }
 
   TORCH_CHECK(size_k % int64_t(CtaK) == 0,
-              "SM70 Marlin uint4b8 requires K divisible by CTA_K=",
-              CtaK, " for requested_split_k > 1. Got K=", size_k,
+              "SM70 Marlin uint4b8 requires K divisible by CTA_K=", CtaK,
+              " for requested_split_k > 1. Got K=", size_k,
               ", requested_split_k=", requested_split_k, ".");
 
   auto split_kernel =
-      sm70_marlin_u4b8_gemm_splitk_kernel<CtaM, CtaN, CtaK, Warps, WarpM,
-                                          WarpN, WarpK, GroupSize,
-                                          PackedMacroN,
+      sm70_marlin_u4b8_gemm_splitk_kernel<CtaM, CtaN, CtaK, Warps, WarpM, WarpN,
+                                          WarpK, GroupSize, PackedMacroN,
                                           UseMetadataVectorWords>;
   smem_bytes = configure_sm70_dynamic_smem<SharedStorage>(split_kernel);
 
@@ -546,8 +543,7 @@ torch::Tensor launch_sm70_marlin_u4b8_gemm(
   // 0009: fp32 split-K scratch (zeroed for the fp32 atomicAdd), M*N floats.
   // Only allocated on the split_k>1 path, which the auto-selector uses ONLY at
   // low batch (M<128), so the scratch is bounded and small.
-  auto c32 = torch::zeros({size_m, size_n},
-                          a.options().dtype(at::kFloat));
+  auto c32 = torch::zeros({size_m, size_n}, a.options().dtype(at::kFloat));
 
   dim3 grid = sm70_marlin_cta_grid(size_m, size_n, CtaM, CtaN);
   int const active_split_k =
@@ -558,9 +554,9 @@ torch::Tensor launch_sm70_marlin_u4b8_gemm(
       reinterpret_cast<uint32_t const*>(b_q_weight.data_ptr<int32_t>()),
       reinterpret_cast<cutlass::half_t const*>(b_scales.data_ptr<at::Half>()),
       reinterpret_cast<cutlass::half_t*>(c.data_ptr<at::Half>()),
-      c32.data_ptr<float>(),
-      static_cast<int>(size_m), static_cast<int>(size_n),
-      static_cast<int>(size_k), static_cast<int>(a.stride(0)), requested_split_k);
+      c32.data_ptr<float>(), static_cast<int>(size_m), static_cast<int>(size_n),
+      static_cast<int>(size_k), static_cast<int>(a.stride(0)),
+      requested_split_k);
   C10_CUDA_KERNEL_LAUNCH_CHECK();
 
   // 0009: single deterministic-width fp32->fp16 narrow of the scratch.
@@ -568,8 +564,8 @@ torch::Tensor launch_sm70_marlin_u4b8_gemm(
   int const narrow_grid =
       static_cast<int>((numel + narrow_block - 1) / narrow_block);
   sm70_marlin_narrow_f32_to_f16<256><<<narrow_grid, narrow_block, 0, stream>>>(
-      c32.data_ptr<float>(),
-      reinterpret_cast<half*>(c.data_ptr<at::Half>()), numel);
+      c32.data_ptr<float>(), reinterpret_cast<half*>(c.data_ptr<at::Half>()),
+      numel);
   C10_CUDA_KERNEL_LAUNCH_CHECK();
 
   return c;
@@ -586,8 +582,8 @@ struct Sm70U4B8Launcher {
   int64_t size_k;
   int requested_split_k;
 
-  template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM,
-            int WarpN, int WarpK, int GroupSize, int PackedMacroN>
+  template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM, int WarpN,
+            int WarpK, int GroupSize, int PackedMacroN>
   torch::Tensor operator()() const {
     return launch_sm70_marlin_u4b8_gemm<CtaM, CtaN, CtaK, Warps, WarpM, WarpN,
                                         WarpK, GroupSize, PackedMacroN,
@@ -603,21 +599,23 @@ torch::Tensor sm70_marlin_u4b8_gemm(torch::Tensor& a, torch::Tensor& c,
                                     int64_t group_size) {
   c10::cuda::CUDAGuard device_guard(a.device());
 
-  auto const params = sm70_marlin_dense_auto_params(
-      "uint4b8", group_size, size_m, size_n, size_k);
+  auto const params = sm70_marlin_dense_auto_params("uint4b8", group_size,
+                                                    size_m, size_n, size_k);
   Sm70CtaGeometry const geometry = params.geometry;
-  validate_sm70_marlin_dense_cta_geometry_supported("SM70 Marlin uint4b8", geometry);
-  validate_sm70_marlin_dense_cta_n_alignment("SM70 Marlin uint4b8", geometry, size_n);
+  validate_sm70_marlin_dense_cta_geometry_supported("SM70 Marlin uint4b8",
+                                                    geometry);
+  validate_sm70_marlin_dense_cta_n_alignment("SM70 Marlin uint4b8", geometry,
+                                             size_n);
   if (params.use_metadata_vector_words) {
     Sm70U4B8Launcher<true> const launcher{
-        a, c, b_q_weight, b_scales, size_m, size_n, size_k,
-        params.requested_split_k};
+        a,      c,      b_q_weight, b_scales,
+        size_m, size_n, size_k,     params.requested_split_k};
     return dispatch_sm70_marlin_geometry(
         launcher, geometry, params.packed_macro_n, group_size, "uint4b8");
   }
   Sm70U4B8Launcher<false> const launcher{
-      a, c, b_q_weight, b_scales, size_m, size_n, size_k,
-      params.requested_split_k};
+      a,      c,      b_q_weight, b_scales,
+      size_m, size_n, size_k,     params.requested_split_k};
   return dispatch_sm70_marlin_geometry(
       launcher, geometry, params.packed_macro_n, group_size, "uint4b8");
 }

--- a/csrc/quantization/marlin/sm70_marlin_u8_gemm.cu
+++ b/csrc/quantization/marlin/sm70_marlin_u8_gemm.cu
@@ -20,26 +20,26 @@
 #include "cutlass/layout/tensor_op_multiplicand_sm70.h"
 #include "cutlass/transform/threadblock/predicated_tile_iterator.h"
 
-using marlin::sm70::Sm70CtaGeometry;
-using marlin::sm70::Sm70AtomicFp16Epilogue;
-using marlin::sm70::Sm70AtomicFp32Epilogue;
-using marlin::sm70::sm70_marlin_narrow_f32_to_f16;
-using marlin::sm70::Sm70MarlinGemmTraits;
-using marlin::sm70::Sm70SplitKPartition;
-using marlin::sm70::validate_sm70_marlin_dense_cta_geometry_supported;
-using marlin::sm70::validate_sm70_marlin_dense_cta_n_alignment;
 using marlin::sm70::configure_sm70_dynamic_smem;
 using marlin::sm70::dispatch_sm70_marlin_geometry_with_group32;
 using marlin::sm70::kQuantTileK;
 using marlin::sm70::kQuantTileN;
-using marlin::sm70::sm70_marlin_dense_auto_params;
 using marlin::sm70::load_qword_vector;
 using marlin::sm70::qword_from_vector;
-using marlin::sm70::sm70_marlin_cta_grid;
 using marlin::sm70::sm70_active_split_k;
+using marlin::sm70::sm70_marlin_cta_grid;
+using marlin::sm70::sm70_marlin_dense_auto_params;
+using marlin::sm70::sm70_marlin_narrow_f32_to_f16;
 using marlin::sm70::sm70_splitk_partition;
+using marlin::sm70::Sm70AtomicFp16Epilogue;
+using marlin::sm70::Sm70AtomicFp32Epilogue;
+using marlin::sm70::Sm70CtaGeometry;
+using marlin::sm70::Sm70MarlinGemmTraits;
+using marlin::sm70::Sm70SplitKPartition;
 using marlin::sm70::u8_packed_macro_n_qweight_offset_from_logical;
 using marlin::sm70::u8_packed_macro_n_qweight_word_stride;
+using marlin::sm70::validate_sm70_marlin_dense_cta_geometry_supported;
+using marlin::sm70::validate_sm70_marlin_dense_cta_n_alignment;
 
 namespace {
 
@@ -55,12 +55,11 @@ class Sm70U8ZpIteratorB {
   static int const kPackedMacroN = PackedMacroN_;
   static constexpr bool kUseMetadataVectorWords = UseMetadataVectorWords_;
   using Element = cutlass::half_t;
-  using Fragment = cutlass::Array<
-      Element, ThreadMap::Iterations::kCount * ThreadMap::kElementsPerAccess>;
+  using Fragment = cutlass::Array<Element, ThreadMap::Iterations::kCount *
+                                               ThreadMap::kElementsPerAccess>;
   static_assert(Shape::kN == 64 || Shape::kN == 128 || Shape::kN == 256,
                 "SM70 Marlin U8 IteratorB expects CTA_N in {64, 128, 256}.");
-  static_assert(ThreadMap::Iterations::kContiguous ==
-                    Shape::kN / kQuantTileN,
+  static_assert(ThreadMap::Iterations::kContiguous == Shape::kN / kQuantTileN,
                 "SM70 Marlin U8 IteratorB expects one contiguous iteration per "
                 "64-column quant tile.");
   static_assert(ThreadMap::Delta::kContiguous == kQuantTileN,
@@ -119,7 +118,7 @@ class Sm70U8ZpIteratorB {
     qweight_base_offset_ =
         qweight_offset_from_logical(params_, logical_k, logical_n);
     if constexpr (kGroupSize == -1) {
-        cache_current_group_metadata(0);
+      cache_current_group_metadata(0);
     }
   }
 
@@ -155,8 +154,7 @@ class Sm70U8ZpIteratorB {
     if constexpr (kGroupSize == -1) {
       return 0;
     } else {
-      static_assert(kGroupSize == 32 || kGroupSize == 64 ||
-                        kGroupSize == 128,
+      static_assert(kGroupSize == 32 || kGroupSize == 64 || kGroupSize == 128,
                     "SM70 Marlin U8 supports only group sizes "
                     "-1, 32, 64, and 128.");
       return logical_k / kGroupSize;
@@ -166,8 +164,8 @@ class Sm70U8ZpIteratorB {
   CUTLASS_DEVICE
   static int qweight_offset_from_logical(Params const& params, int logical_k,
                                          int logical_n) {
-    return u8_packed_macro_n_qweight_offset_from_logical<kPackedMacroN>(params.size_n, logical_k,
-                                                  logical_n);
+    return u8_packed_macro_n_qweight_offset_from_logical<kPackedMacroN>(
+        params.size_n, logical_k, logical_n);
   }
 
   CUTLASS_DEVICE
@@ -185,8 +183,8 @@ class Sm70U8ZpIteratorB {
     scale_cache[2] = scale_vec[2];
     scale_cache[3] = scale_vec[3];
 
-    half2 const* zp_vec = reinterpret_cast<half2 const*>(
-        zp_ + group * params_.size_n + cache_n);
+    half2 const* zp_vec =
+        reinterpret_cast<half2 const*>(zp_ + group * params_.size_n + cache_n);
     half2* zp_cache = cached_zp_ + c * 4;
     zp_cache[0] = zp_vec[0];
     zp_cache[1] = zp_vec[1];
@@ -205,8 +203,8 @@ class Sm70U8ZpIteratorB {
     scale_cache[2] = scale_vec[2];
     scale_cache[3] = scale_vec[3];
 
-    uint4 const zp_words = *reinterpret_cast<uint4 const*>(
-        zp_ + group * params_.size_n + cache_n);
+    uint4 const zp_words =
+        *reinterpret_cast<uint4 const*>(zp_ + group * params_.size_n + cache_n);
     half2 const* zp_vec = reinterpret_cast<half2 const*>(&zp_words);
     half2* zp_cache = cached_zp_ + c * 4;
     zp_cache[0] = zp_vec[0];
@@ -219,9 +217,8 @@ class Sm70U8ZpIteratorB {
   void cache_current_group_metadata(int group) const {
     CUTLASS_PRAGMA_UNROLL
     for (int c = 0; c < ThreadMap::Iterations::kContiguous; ++c) {
-      int const cache_n =
-          n_offset_ + thread_offset_.contiguous() +
-          c * ThreadMap::Delta::kContiguous;
+      int const cache_n = n_offset_ + thread_offset_.contiguous() +
+                          c * ThreadMap::Delta::kContiguous;
       if constexpr (kUseMetadataVectorWords) {
         cache_metadata_vector_words(c, group, cache_n);
       } else {
@@ -295,12 +292,12 @@ class Sm70U8ZpIteratorB {
 
         half2 deq[2];
         half2* frag_vec = reinterpret_cast<half2*>(frag.data());
-        marlin::dequant<half2, vllm::kU8.id(), false>(
-            static_cast<int>(qword0), deq);
+        marlin::dequant<half2, vllm::kU8.id(), false>(static_cast<int>(qword0),
+                                                      deq);
         frag_vec[0] = __hfma2(deq[0], scale_vec[0], __hneg2(zp_vec[0]));
         frag_vec[1] = __hfma2(deq[1], scale_vec[1], __hneg2(zp_vec[1]));
-        marlin::dequant<half2, vllm::kU8.id(), false>(
-            static_cast<int>(qword1), deq);
+        marlin::dequant<half2, vllm::kU8.id(), false>(static_cast<int>(qword1),
+                                                      deq);
         frag_vec[2] = __hfma2(deq[0], scale_vec[2], __hneg2(zp_vec[2]));
         frag_vec[3] = __hfma2(deq[1], scale_vec[3], __hneg2(zp_vec[3]));
       }
@@ -308,19 +305,17 @@ class Sm70U8ZpIteratorB {
       int const logical_n_base = n_offset_ + thread_offset_.contiguous();
       CUTLASS_PRAGMA_UNROLL
       for (int s = 0; s < ThreadMap::Iterations::kStrided; ++s) {
-        int const logical_k_s =
-            k_offset_ + thread_offset_.strided() +
-            s * ThreadMap::Delta::kStrided;
+        int const logical_k_s = k_offset_ + thread_offset_.strided() +
+                                s * ThreadMap::Delta::kStrided;
         if constexpr (kGroupSize != -1) {
           cache_current_group_metadata(scale_group(logical_k_s));
         }
         int const qweight_base_s =
             qweight_offset_from_logical(params_, logical_k_s, logical_n_base);
         if constexpr (ThreadMap::Iterations::kContiguous == 4) {
-          uint4 const qwords0 =
-              load_qword_vector<4>(qweight_ + qweight_base_s);
-          uint4 const qwords1 = load_qword_vector<4>(
-              qweight_ + qweight_base_s + kQweightWordStrideWords);
+          uint4 const qwords0 = load_qword_vector<4>(qweight_ + qweight_base_s);
+          uint4 const qwords1 = load_qword_vector<4>(qweight_ + qweight_base_s +
+                                                     kQweightWordStrideWords);
           CUTLASS_PRAGMA_UNROLL
           for (int c = 0; c < ThreadMap::Iterations::kContiguous; ++c) {
             constexpr int kAccess = ThreadMap::kElementsPerAccess;
@@ -335,22 +330,17 @@ class Sm70U8ZpIteratorB {
             half2* frag_vec = reinterpret_cast<half2*>(frag.data() + frag_base);
             marlin::dequant<half2, vllm::kU8.id(), false>(
                 static_cast<int>(qword0), deq);
-            frag_vec[0] =
-                __hfma2(deq[0], scale_vec[0], __hneg2(zp_vec[0]));
-            frag_vec[1] =
-                __hfma2(deq[1], scale_vec[1], __hneg2(zp_vec[1]));
+            frag_vec[0] = __hfma2(deq[0], scale_vec[0], __hneg2(zp_vec[0]));
+            frag_vec[1] = __hfma2(deq[1], scale_vec[1], __hneg2(zp_vec[1]));
             marlin::dequant<half2, vllm::kU8.id(), false>(
                 static_cast<int>(qword1), deq);
-            frag_vec[2] =
-                __hfma2(deq[0], scale_vec[2], __hneg2(zp_vec[2]));
-            frag_vec[3] =
-                __hfma2(deq[1], scale_vec[3], __hneg2(zp_vec[3]));
+            frag_vec[2] = __hfma2(deq[0], scale_vec[2], __hneg2(zp_vec[2]));
+            frag_vec[3] = __hfma2(deq[1], scale_vec[3], __hneg2(zp_vec[3]));
           }
         } else if constexpr (ThreadMap::Iterations::kContiguous == 2) {
-          uint2 const qwords0 =
-              load_qword_vector<2>(qweight_ + qweight_base_s);
-          uint2 const qwords1 = load_qword_vector<2>(
-              qweight_ + qweight_base_s + kQweightWordStrideWords);
+          uint2 const qwords0 = load_qword_vector<2>(qweight_ + qweight_base_s);
+          uint2 const qwords1 = load_qword_vector<2>(qweight_ + qweight_base_s +
+                                                     kQweightWordStrideWords);
           CUTLASS_PRAGMA_UNROLL
           for (int c = 0; c < ThreadMap::Iterations::kContiguous; ++c) {
             constexpr int kAccess = ThreadMap::kElementsPerAccess;
@@ -365,20 +355,17 @@ class Sm70U8ZpIteratorB {
             half2* frag_vec = reinterpret_cast<half2*>(frag.data() + frag_base);
             marlin::dequant<half2, vllm::kU8.id(), false>(
                 static_cast<int>(qword0), deq);
-            frag_vec[0] =
-                __hfma2(deq[0], scale_vec[0], __hneg2(zp_vec[0]));
-            frag_vec[1] =
-                __hfma2(deq[1], scale_vec[1], __hneg2(zp_vec[1]));
+            frag_vec[0] = __hfma2(deq[0], scale_vec[0], __hneg2(zp_vec[0]));
+            frag_vec[1] = __hfma2(deq[1], scale_vec[1], __hneg2(zp_vec[1]));
             marlin::dequant<half2, vllm::kU8.id(), false>(
                 static_cast<int>(qword1), deq);
-            frag_vec[2] =
-                __hfma2(deq[0], scale_vec[2], __hneg2(zp_vec[2]));
-            frag_vec[3] =
-                __hfma2(deq[1], scale_vec[3], __hneg2(zp_vec[3]));
+            frag_vec[2] = __hfma2(deq[0], scale_vec[2], __hneg2(zp_vec[2]));
+            frag_vec[3] = __hfma2(deq[1], scale_vec[3], __hneg2(zp_vec[3]));
           }
         } else {
-          static_assert(ThreadMap::Iterations::kContiguous == 1,
-                        "Unsupported SM70 Marlin U8 contiguous iteration count.");
+          static_assert(
+              ThreadMap::Iterations::kContiguous == 1,
+              "Unsupported SM70 Marlin U8 contiguous iteration count.");
           uint32_t const qword0 =
               load_qword_vector<1>(qweight_ + qweight_base_s);
           uint32_t const qword1 = load_qword_vector<1>(
@@ -409,8 +396,7 @@ class Sm70U8ZpIteratorB {
       return;
     }
 
-    if constexpr (kGroupSize != -1 &&
-                  ThreadMap::Iterations::kStrided == 1) {
+    if constexpr (kGroupSize != -1 && ThreadMap::Iterations::kStrided == 1) {
       int const first_logical_k = k_offset_ + thread_offset_.strided();
       cache_current_group_metadata(scale_group(first_logical_k));
     }
@@ -422,32 +408,30 @@ class Sm70U8ZpIteratorB {
 template <bool UseMetadataVectorWords = true>
 struct Sm70U8ZpGemmSpec {
   template <typename Shape, typename ThreadMap, int GroupSize, int PackedMacroN>
-  using IteratorB =
-      Sm70U8ZpIteratorB<Shape, ThreadMap, GroupSize, PackedMacroN,
-                        UseMetadataVectorWords>;
+  using IteratorB = Sm70U8ZpIteratorB<Shape, ThreadMap, GroupSize, PackedMacroN,
+                                      UseMetadataVectorWords>;
 };
 
-template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM,
-          int WarpN, int WarpK, int GroupSize, int PackedMacroN,
+template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM, int WarpN,
+          int WarpK, int GroupSize, int PackedMacroN,
           bool UseMetadataVectorWords = true>
 using Sm70U8ZpGemmTraits =
-    Sm70MarlinGemmTraits<Sm70U8ZpGemmSpec<UseMetadataVectorWords>, CtaM,
-                         CtaN, CtaK, Warps, WarpM, WarpN, WarpK,
-                         GroupSize, PackedMacroN>;
+    Sm70MarlinGemmTraits<Sm70U8ZpGemmSpec<UseMetadataVectorWords>, CtaM, CtaN,
+                         CtaK, Warps, WarpM, WarpN, WarpK, GroupSize,
+                         PackedMacroN>;
 
-template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM,
-          int WarpN, int WarpK, int GroupSize, int PackedMacroN,
+template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM, int WarpN,
+          int WarpK, int GroupSize, int PackedMacroN,
           bool UseMetadataVectorWords = true>
-__global__ __launch_bounds__(Warps * 32, 1)
-void sm70_marlin_u8_gemm_kernel(
+__global__ __launch_bounds__(Warps * 32, 1) void sm70_marlin_u8_gemm_kernel(
     cutlass::half_t const* __restrict__ a,
     uint32_t const* __restrict__ b_q_weight,
     cutlass::half_t const* __restrict__ b_scales,
     cutlass::half_t const* __restrict__ b_zeros,
     cutlass::half_t* __restrict__ c, int m, int n, int k, int lda) {
-  using Traits = Sm70U8ZpGemmTraits<CtaM, CtaN, CtaK, Warps, WarpM,
-                                    WarpN, WarpK, GroupSize, PackedMacroN,
-                                    UseMetadataVectorWords>;
+  using Traits =
+      Sm70U8ZpGemmTraits<CtaM, CtaN, CtaK, Warps, WarpM, WarpN, WarpK,
+                         GroupSize, PackedMacroN, UseMetadataVectorWords>;
   using Mma = typename Traits::Mma;
   using Epilogue = typename Traits::Epilogue;
 
@@ -467,10 +451,10 @@ void sm70_marlin_u8_gemm_kernel(
   typename Traits::LayoutA layout_a(lda);
   typename Traits::LayoutC layout_c(n);
 
-  typename Mma::IteratorA iterator_A(
-      typename Mma::IteratorA::Params(layout_a),
-      const_cast<cutlass::half_t*>(a), cutlass::MatrixCoord(m, k), thread_idx,
-      tb_offset_A);
+  typename Mma::IteratorA iterator_A(typename Mma::IteratorA::Params(layout_a),
+                                     const_cast<cutlass::half_t*>(a),
+                                     cutlass::MatrixCoord(m, k), thread_idx,
+                                     tb_offset_A);
   typename Mma::IteratorB iterator_B(
       typename Mma::IteratorB::Params(k, n),
       reinterpret_cast<uint32_t const*>(b_q_weight),
@@ -496,19 +480,20 @@ void sm70_marlin_u8_gemm_kernel(
   epilogue(output_op, iterator_D, accumulators, iterator_C);
 }
 
-template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM,
-          int WarpN, int WarpK, int GroupSize, int PackedMacroN,
+template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM, int WarpN,
+          int WarpK, int GroupSize, int PackedMacroN,
           bool UseMetadataVectorWords = true>
-__global__ __launch_bounds__(Warps * 32, 1)
-void sm70_marlin_u8_gemm_splitk_kernel(
+__global__
+__launch_bounds__(Warps * 32, 1) void sm70_marlin_u8_gemm_splitk_kernel(
     cutlass::half_t const* __restrict__ a,
     uint32_t const* __restrict__ b_q_weight,
     cutlass::half_t const* __restrict__ b_scales,
     cutlass::half_t const* __restrict__ b_zeros,
-    cutlass::half_t* __restrict__ c, float* __restrict__ c32, int m, int n, int k, int lda, int requested_split_k) {
-  using Traits = Sm70U8ZpGemmTraits<CtaM, CtaN, CtaK, Warps, WarpM,
-                                    WarpN, WarpK, GroupSize, PackedMacroN,
-                                    UseMetadataVectorWords>;
+    cutlass::half_t* __restrict__ c, float* __restrict__ c32, int m, int n,
+    int k, int lda, int requested_split_k) {
+  using Traits =
+      Sm70U8ZpGemmTraits<CtaM, CtaN, CtaK, Warps, WarpM, WarpN, WarpK,
+                         GroupSize, PackedMacroN, UseMetadataVectorWords>;
   using Mma = typename Traits::Mma;
   using AtomicEpilogue = Sm70AtomicFp32Epilogue<Traits>;
 
@@ -519,14 +504,13 @@ void sm70_marlin_u8_gemm_splitk_kernel(
   int const thread_idx = threadIdx.x;
   int const warp_idx = cutlass::canonical_warp_idx_sync();
   int const lane_idx = threadIdx.x % 32;
-  Sm70SplitKPartition const partition =
-      sm70_splitk_partition<GroupSize, CtaK>(k, requested_split_k, int(blockIdx.z));
+  Sm70SplitKPartition const partition = sm70_splitk_partition<GroupSize, CtaK>(
+      k, requested_split_k, int(blockIdx.z));
   if (partition.partition_k == 0) {
     return;
   }
 
-  cutlass::MatrixCoord tb_offset_A{int(blockIdx.x) * CtaM,
-                                   partition.k_begin};
+  cutlass::MatrixCoord tb_offset_A{int(blockIdx.x) * CtaM, partition.k_begin};
   cutlass::MatrixCoord tb_offset_B{partition.k_begin, int(blockIdx.y) * CtaN};
   cutlass::MatrixCoord tb_offset_C{int(blockIdx.x) * CtaM,
                                    int(blockIdx.y) * CtaN};
@@ -534,10 +518,10 @@ void sm70_marlin_u8_gemm_splitk_kernel(
   typename Traits::LayoutA layout_a(lda);
   typename Traits::LayoutC layout_c(n);
 
-  typename Mma::IteratorA iterator_A(
-      typename Mma::IteratorA::Params(layout_a),
-      const_cast<cutlass::half_t*>(a), cutlass::MatrixCoord(m, k), thread_idx,
-      tb_offset_A);
+  typename Mma::IteratorA iterator_A(typename Mma::IteratorA::Params(layout_a),
+                                     const_cast<cutlass::half_t*>(a),
+                                     cutlass::MatrixCoord(m, k), thread_idx,
+                                     tb_offset_A);
   typename Mma::IteratorB iterator_B(
       typename Mma::IteratorB::Params(k, n),
       reinterpret_cast<uint32_t const*>(b_q_weight),
@@ -552,9 +536,8 @@ void sm70_marlin_u8_gemm_splitk_kernel(
   mma(gemm_k_iterations, accumulators, iterator_A, iterator_B, accumulators);
 
   typename AtomicEpilogue::OutputTileIterator iterator_D(
-      typename AtomicEpilogue::OutputTileIterator::Params(layout_c),
-      c, cutlass::MatrixCoord(m, n),
-      thread_idx, tb_offset_C);
+      typename AtomicEpilogue::OutputTileIterator::Params(layout_c), c,
+      cutlass::MatrixCoord(m, n), thread_idx, tb_offset_C);
 
   AtomicEpilogue epilogue(shared_storage.epilogue, thread_idx, warp_idx,
                           lane_idx);
@@ -563,20 +546,23 @@ void sm70_marlin_u8_gemm_splitk_kernel(
 
 }  // namespace
 
-template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM,
-          int WarpN, int WarpK, int GroupSize, int PackedMacroN,
+template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM, int WarpN,
+          int WarpK, int GroupSize, int PackedMacroN,
           bool UseMetadataVectorWords = true>
-torch::Tensor launch_sm70_marlin_u8_gemm(
-    torch::Tensor& a, torch::Tensor& c, torch::Tensor& b_q_weight,
-    torch::Tensor& b_scales, torch::Tensor& b_zeros, int64_t size_m,
-    int64_t size_n, int64_t size_k, int requested_split_k) {
+torch::Tensor launch_sm70_marlin_u8_gemm(torch::Tensor& a, torch::Tensor& c,
+                                         torch::Tensor& b_q_weight,
+                                         torch::Tensor& b_scales,
+                                         torch::Tensor& b_zeros, int64_t size_m,
+                                         int64_t size_n, int64_t size_k,
+                                         int requested_split_k) {
   auto kernel =
       sm70_marlin_u8_gemm_kernel<CtaM, CtaN, CtaK, Warps, WarpM, WarpN, WarpK,
                                  GroupSize, PackedMacroN,
                                  UseMetadataVectorWords>;
-  using SharedStorage = typename Sm70U8ZpGemmTraits<
-      CtaM, CtaN, CtaK, Warps, WarpM, WarpN, WarpK, GroupSize,
-      PackedMacroN, UseMetadataVectorWords>::SharedStorage;
+  using SharedStorage =
+      typename Sm70U8ZpGemmTraits<CtaM, CtaN, CtaK, Warps, WarpM, WarpN, WarpK,
+                                  GroupSize, PackedMacroN,
+                                  UseMetadataVectorWords>::SharedStorage;
   size_t smem_bytes = configure_sm70_dynamic_smem<SharedStorage>(kernel);
 
   dim3 block(Warps * 32);
@@ -597,8 +583,8 @@ torch::Tensor launch_sm70_marlin_u8_gemm(
   }
 
   TORCH_CHECK(size_k % int64_t(CtaK) == 0,
-              "SM70 Marlin uint8 requires K divisible by CTA_K=",
-              CtaK, " for requested_split_k > 1. Got K=", size_k,
+              "SM70 Marlin uint8 requires K divisible by CTA_K=", CtaK,
+              " for requested_split_k > 1. Got K=", size_k,
               ", requested_split_k=", requested_split_k, ".");
 
   auto split_kernel =
@@ -611,8 +597,7 @@ torch::Tensor launch_sm70_marlin_u8_gemm(
   // 0009: fp32 split-K scratch (zeroed for the fp32 atomicAdd), M*N floats.
   // Only allocated on the split_k>1 path, which the auto-selector uses ONLY at
   // low batch (M<128), so the scratch is bounded and small.
-  auto c32 = torch::zeros({size_m, size_n},
-                          a.options().dtype(at::kFloat));
+  auto c32 = torch::zeros({size_m, size_n}, a.options().dtype(at::kFloat));
 
   dim3 grid = sm70_marlin_cta_grid(size_m, size_n, CtaM, CtaN);
   int const active_split_k =
@@ -624,9 +609,9 @@ torch::Tensor launch_sm70_marlin_u8_gemm(
       reinterpret_cast<cutlass::half_t const*>(b_scales.data_ptr<at::Half>()),
       reinterpret_cast<cutlass::half_t const*>(b_zeros.data_ptr<at::Half>()),
       reinterpret_cast<cutlass::half_t*>(c.data_ptr<at::Half>()),
-      c32.data_ptr<float>(),
-      static_cast<int>(size_m), static_cast<int>(size_n),
-      static_cast<int>(size_k), static_cast<int>(a.stride(0)), requested_split_k);
+      c32.data_ptr<float>(), static_cast<int>(size_m), static_cast<int>(size_n),
+      static_cast<int>(size_k), static_cast<int>(a.stride(0)),
+      requested_split_k);
   C10_CUDA_KERNEL_LAUNCH_CHECK();
 
   // 0009: single deterministic-width fp32->fp16 narrow of the scratch.
@@ -634,8 +619,8 @@ torch::Tensor launch_sm70_marlin_u8_gemm(
   int const narrow_grid =
       static_cast<int>((numel + narrow_block - 1) / narrow_block);
   sm70_marlin_narrow_f32_to_f16<256><<<narrow_grid, narrow_block, 0, stream>>>(
-      c32.data_ptr<float>(),
-      reinterpret_cast<half*>(c.data_ptr<at::Half>()), numel);
+      c32.data_ptr<float>(), reinterpret_cast<half*>(c.data_ptr<at::Half>()),
+      numel);
   C10_CUDA_KERNEL_LAUNCH_CHECK();
 
   return c;
@@ -653,13 +638,14 @@ struct Sm70U8Launcher {
   int64_t size_k;
   int requested_split_k;
 
-  template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM,
-            int WarpN, int WarpK, int GroupSize, int PackedMacroN>
+  template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM, int WarpN,
+            int WarpK, int GroupSize, int PackedMacroN>
   torch::Tensor operator()() const {
-    return launch_sm70_marlin_u8_gemm<CtaM, CtaN, CtaK, Warps, WarpM, WarpN, WarpK,
-                                      GroupSize, PackedMacroN,
+    return launch_sm70_marlin_u8_gemm<CtaM, CtaN, CtaK, Warps, WarpM, WarpN,
+                                      WarpK, GroupSize, PackedMacroN,
                                       UseMetadataVectorWords>(
-        a, c, b_q_weight, b_scales, b_zeros, size_m, size_n, size_k, requested_split_k);
+        a, c, b_q_weight, b_scales, b_zeros, size_m, size_n, size_k,
+        requested_split_k);
   }
 };
 
@@ -671,22 +657,25 @@ torch::Tensor sm70_marlin_u8_gemm(torch::Tensor& a, torch::Tensor& c,
                                   int64_t group_size) {
   c10::cuda::CUDAGuard device_guard(a.device());
 
-  auto const params =
-      sm70_marlin_dense_auto_params("uint8", group_size, size_m, size_n,
-                                    size_k);
+  auto const params = sm70_marlin_dense_auto_params("uint8", group_size, size_m,
+                                                    size_n, size_k);
   Sm70CtaGeometry const geometry = params.geometry;
-  validate_sm70_marlin_dense_cta_geometry_supported("SM70 Marlin uint8", geometry);
-  validate_sm70_marlin_dense_cta_n_alignment("SM70 Marlin uint8", geometry, size_n);
+  validate_sm70_marlin_dense_cta_geometry_supported("SM70 Marlin uint8",
+                                                    geometry);
+  validate_sm70_marlin_dense_cta_n_alignment("SM70 Marlin uint8", geometry,
+                                             size_n);
   if (params.use_metadata_vector_words) {
     Sm70U8Launcher<true> const launcher{
-        a, c, b_q_weight, b_scales, b_zeros, size_m, size_n, size_k,
-        params.requested_split_k};
+        a,        c,       b_q_weight,
+        b_scales, b_zeros, size_m,
+        size_n,   size_k,  params.requested_split_k};
     return dispatch_sm70_marlin_geometry_with_group32(
         launcher, geometry, params.packed_macro_n, group_size, "uint8");
   }
   Sm70U8Launcher<false> const launcher{
-      a, c, b_q_weight, b_scales, b_zeros, size_m, size_n, size_k,
-      params.requested_split_k};
+      a,        c,       b_q_weight,
+      b_scales, b_zeros, size_m,
+      size_n,   size_k,  params.requested_split_k};
   return dispatch_sm70_marlin_geometry_with_group32(
       launcher, geometry, params.packed_macro_n, group_size, "uint8");
 }

--- a/csrc/quantization/marlin/sm70_marlin_u8b128_gemm.cu
+++ b/csrc/quantization/marlin/sm70_marlin_u8b128_gemm.cu
@@ -20,26 +20,26 @@
 #include "cutlass/layout/tensor_op_multiplicand_sm70.h"
 #include "cutlass/transform/threadblock/predicated_tile_iterator.h"
 
-using marlin::sm70::Sm70CtaGeometry;
-using marlin::sm70::Sm70AtomicFp16Epilogue;
-using marlin::sm70::Sm70AtomicFp32Epilogue;
-using marlin::sm70::sm70_marlin_narrow_f32_to_f16;
-using marlin::sm70::Sm70MarlinGemmTraits;
-using marlin::sm70::Sm70SplitKPartition;
-using marlin::sm70::validate_sm70_marlin_dense_cta_geometry_supported;
-using marlin::sm70::validate_sm70_marlin_dense_cta_n_alignment;
 using marlin::sm70::configure_sm70_dynamic_smem;
 using marlin::sm70::dispatch_sm70_marlin_geometry_with_group32;
 using marlin::sm70::kQuantTileK;
 using marlin::sm70::kQuantTileN;
-using marlin::sm70::sm70_marlin_dense_auto_params;
 using marlin::sm70::load_qword_vector;
 using marlin::sm70::qword_from_vector;
-using marlin::sm70::sm70_marlin_cta_grid;
 using marlin::sm70::sm70_active_split_k;
+using marlin::sm70::sm70_marlin_cta_grid;
+using marlin::sm70::sm70_marlin_dense_auto_params;
+using marlin::sm70::sm70_marlin_narrow_f32_to_f16;
 using marlin::sm70::sm70_splitk_partition;
+using marlin::sm70::Sm70AtomicFp16Epilogue;
+using marlin::sm70::Sm70AtomicFp32Epilogue;
+using marlin::sm70::Sm70CtaGeometry;
+using marlin::sm70::Sm70MarlinGemmTraits;
+using marlin::sm70::Sm70SplitKPartition;
 using marlin::sm70::u8_packed_macro_n_qweight_offset_from_logical;
 using marlin::sm70::u8_packed_macro_n_qweight_word_stride;
+using marlin::sm70::validate_sm70_marlin_dense_cta_geometry_supported;
+using marlin::sm70::validate_sm70_marlin_dense_cta_n_alignment;
 
 namespace {
 
@@ -55,12 +55,12 @@ class Sm70U8B128IteratorB {
   static int const kPackedMacroN = PackedMacroN_;
   static constexpr bool kUseMetadataVectorWords = UseMetadataVectorWords_;
   using Element = cutlass::half_t;
-  using Fragment = cutlass::Array<
-      Element, ThreadMap::Iterations::kCount * ThreadMap::kElementsPerAccess>;
-  static_assert(Shape::kN == 64 || Shape::kN == 128 || Shape::kN == 256,
-                "SM70 Marlin U8B128 IteratorB expects CTA_N in {64, 128, 256}.");
-  static_assert(ThreadMap::Iterations::kContiguous ==
-                    Shape::kN / kQuantTileN,
+  using Fragment = cutlass::Array<Element, ThreadMap::Iterations::kCount *
+                                               ThreadMap::kElementsPerAccess>;
+  static_assert(
+      Shape::kN == 64 || Shape::kN == 128 || Shape::kN == 256,
+      "SM70 Marlin U8B128 IteratorB expects CTA_N in {64, 128, 256}.");
+  static_assert(ThreadMap::Iterations::kContiguous == Shape::kN / kQuantTileN,
                 "SM70 Marlin U8B128 IteratorB expects one contiguous iteration "
                 "per 64-column quant tile.");
   static_assert(ThreadMap::Delta::kContiguous == kQuantTileN,
@@ -152,8 +152,7 @@ class Sm70U8B128IteratorB {
     if constexpr (kGroupSize == -1) {
       return 0;
     } else {
-      static_assert(kGroupSize == 32 || kGroupSize == 64 ||
-                        kGroupSize == 128,
+      static_assert(kGroupSize == 32 || kGroupSize == 64 || kGroupSize == 128,
                     "SM70 Marlin U8B128 supports only group sizes "
                     "-1, 32, 64, and 128.");
       return logical_k / kGroupSize;
@@ -163,13 +162,12 @@ class Sm70U8B128IteratorB {
   CUTLASS_DEVICE
   static int qweight_offset_from_logical(Params const& params, int logical_k,
                                          int logical_n) {
-    return u8_packed_macro_n_qweight_offset_from_logical<kPackedMacroN>(params.size_n, logical_k,
-                                                     logical_n);
+    return u8_packed_macro_n_qweight_offset_from_logical<kPackedMacroN>(
+        params.size_n, logical_k, logical_n);
   }
 
   CUTLASS_DEVICE
-  static int qweight_word_stride_from_logical(Params const&,
-                                              int logical_n) {
+  static int qweight_word_stride_from_logical(Params const&, int logical_n) {
     return u8_packed_macro_n_qweight_word_stride<kPackedMacroN>();
   }
 
@@ -200,9 +198,8 @@ class Sm70U8B128IteratorB {
   void cache_current_group_metadata(int group) const {
     CUTLASS_PRAGMA_UNROLL
     for (int c = 0; c < ThreadMap::Iterations::kContiguous; ++c) {
-      int const cache_n =
-          n_offset_ + thread_offset_.contiguous() +
-          c * ThreadMap::Delta::kContiguous;
+      int const cache_n = n_offset_ + thread_offset_.contiguous() +
+                          c * ThreadMap::Delta::kContiguous;
       if constexpr (kUseMetadataVectorWords) {
         cache_metadata_vector_words(c, group, cache_n);
       } else {
@@ -263,8 +260,9 @@ class Sm70U8B128IteratorB {
           frag_vec[3] = __hmul2(deq[1], scale_vec[3]);
         }
       } else {
-        static_assert(ThreadMap::Iterations::kContiguous == 1,
-                      "Unsupported SM70 Marlin U8B128 contiguous iteration count.");
+        static_assert(
+            ThreadMap::Iterations::kContiguous == 1,
+            "Unsupported SM70 Marlin U8B128 contiguous iteration count.");
         uint32_t const qword0 =
             load_qword_vector<1>(qweight_ + qweight_base_offset_);
         uint32_t const qword1 = load_qword_vector<1>(
@@ -286,19 +284,17 @@ class Sm70U8B128IteratorB {
       int const logical_n_base = n_offset_ + thread_offset_.contiguous();
       CUTLASS_PRAGMA_UNROLL
       for (int s = 0; s < ThreadMap::Iterations::kStrided; ++s) {
-        int const logical_k_s =
-            k_offset_ + thread_offset_.strided() +
-            s * ThreadMap::Delta::kStrided;
+        int const logical_k_s = k_offset_ + thread_offset_.strided() +
+                                s * ThreadMap::Delta::kStrided;
         if constexpr (kGroupSize != -1) {
           cache_current_group_metadata(scale_group(logical_k_s));
         }
         int const qweight_base_s =
             qweight_offset_from_logical(params_, logical_k_s, logical_n_base);
         if constexpr (ThreadMap::Iterations::kContiguous == 4) {
-          uint4 const qwords0 =
-              load_qword_vector<4>(qweight_ + qweight_base_s);
-          uint4 const qwords1 = load_qword_vector<4>(
-              qweight_ + qweight_base_s + kQweightWordStrideWords);
+          uint4 const qwords0 = load_qword_vector<4>(qweight_ + qweight_base_s);
+          uint4 const qwords1 = load_qword_vector<4>(qweight_ + qweight_base_s +
+                                                     kQweightWordStrideWords);
           CUTLASS_PRAGMA_UNROLL
           for (int c = 0; c < ThreadMap::Iterations::kContiguous; ++c) {
             constexpr int kAccess = ThreadMap::kElementsPerAccess;
@@ -320,10 +316,9 @@ class Sm70U8B128IteratorB {
             frag_vec[3] = __hmul2(deq[1], scale_vec[3]);
           }
         } else if constexpr (ThreadMap::Iterations::kContiguous == 2) {
-          uint2 const qwords0 =
-              load_qword_vector<2>(qweight_ + qweight_base_s);
-          uint2 const qwords1 = load_qword_vector<2>(
-              qweight_ + qweight_base_s + kQweightWordStrideWords);
+          uint2 const qwords0 = load_qword_vector<2>(qweight_ + qweight_base_s);
+          uint2 const qwords1 = load_qword_vector<2>(qweight_ + qweight_base_s +
+                                                     kQweightWordStrideWords);
           CUTLASS_PRAGMA_UNROLL
           for (int c = 0; c < ThreadMap::Iterations::kContiguous; ++c) {
             constexpr int kAccess = ThreadMap::kElementsPerAccess;
@@ -345,8 +340,9 @@ class Sm70U8B128IteratorB {
             frag_vec[3] = __hmul2(deq[1], scale_vec[3]);
           }
         } else {
-          static_assert(ThreadMap::Iterations::kContiguous == 1,
-                        "Unsupported SM70 Marlin U8B128 contiguous iteration count.");
+          static_assert(
+              ThreadMap::Iterations::kContiguous == 1,
+              "Unsupported SM70 Marlin U8B128 contiguous iteration count.");
           uint32_t const qword0 =
               load_qword_vector<1>(qweight_ + qweight_base_s);
           uint32_t const qword1 = load_qword_vector<1>(
@@ -376,8 +372,7 @@ class Sm70U8B128IteratorB {
       return;
     }
 
-    if constexpr (kGroupSize != -1 &&
-                  ThreadMap::Iterations::kStrided == 1) {
+    if constexpr (kGroupSize != -1 && ThreadMap::Iterations::kStrided == 1) {
       int const first_logical_k = k_offset_ + thread_offset_.strided();
       cache_current_group_metadata(scale_group(first_logical_k));
     }
@@ -389,32 +384,29 @@ class Sm70U8B128IteratorB {
 template <bool UseMetadataVectorWords = true>
 struct Sm70U8B128GemmSpec {
   template <typename Shape, typename ThreadMap, int GroupSize, int PackedMacroN>
-  using IteratorB =
-      Sm70U8B128IteratorB<Shape, ThreadMap, GroupSize, PackedMacroN,
-                          UseMetadataVectorWords>;
+  using IteratorB = Sm70U8B128IteratorB<Shape, ThreadMap, GroupSize,
+                                        PackedMacroN, UseMetadataVectorWords>;
 };
 
-template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM,
-          int WarpN, int WarpK, int GroupSize, int PackedMacroN,
+template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM, int WarpN,
+          int WarpK, int GroupSize, int PackedMacroN,
           bool UseMetadataVectorWords = true>
 using Sm70U8B128GemmTraits =
-    Sm70MarlinGemmTraits<Sm70U8B128GemmSpec<UseMetadataVectorWords>, CtaM,
-                         CtaN, CtaK, Warps, WarpM, WarpN, WarpK,
-                         GroupSize, PackedMacroN>;
+    Sm70MarlinGemmTraits<Sm70U8B128GemmSpec<UseMetadataVectorWords>, CtaM, CtaN,
+                         CtaK, Warps, WarpM, WarpN, WarpK, GroupSize,
+                         PackedMacroN>;
 
-template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM,
-          int WarpN, int WarpK, int GroupSize, int PackedMacroN,
+template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM, int WarpN,
+          int WarpK, int GroupSize, int PackedMacroN,
           bool UseMetadataVectorWords = true>
-__global__ __launch_bounds__(Warps * 32, 1)
-void sm70_marlin_u8b128_gemm_kernel(
+__global__ __launch_bounds__(Warps * 32, 1) void sm70_marlin_u8b128_gemm_kernel(
     cutlass::half_t const* __restrict__ a,
     uint32_t const* __restrict__ b_q_weight,
     cutlass::half_t const* __restrict__ b_scales,
     cutlass::half_t* __restrict__ c, int m, int n, int k, int lda) {
   using Traits =
       Sm70U8B128GemmTraits<CtaM, CtaN, CtaK, Warps, WarpM, WarpN, WarpK,
-                           GroupSize, PackedMacroN,
-                           UseMetadataVectorWords>;
+                           GroupSize, PackedMacroN, UseMetadataVectorWords>;
   using Mma = typename Traits::Mma;
   using Epilogue = typename Traits::Epilogue;
 
@@ -434,10 +426,10 @@ void sm70_marlin_u8b128_gemm_kernel(
   typename Traits::LayoutA layout_a(lda);
   typename Traits::LayoutC layout_c(n);
 
-  typename Mma::IteratorA iterator_A(
-      typename Mma::IteratorA::Params(layout_a),
-      const_cast<cutlass::half_t*>(a), cutlass::MatrixCoord(m, k), thread_idx,
-      tb_offset_A);
+  typename Mma::IteratorA iterator_A(typename Mma::IteratorA::Params(layout_a),
+                                     const_cast<cutlass::half_t*>(a),
+                                     cutlass::MatrixCoord(m, k), thread_idx,
+                                     tb_offset_A);
   typename Mma::IteratorB iterator_B(
       typename Mma::IteratorB::Params(k, n),
       reinterpret_cast<uint32_t const*>(b_q_weight),
@@ -462,18 +454,19 @@ void sm70_marlin_u8b128_gemm_kernel(
   epilogue(output_op, iterator_D, accumulators, iterator_C);
 }
 
-template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM,
-          int WarpN, int WarpK, int GroupSize, int PackedMacroN,
+template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM, int WarpN,
+          int WarpK, int GroupSize, int PackedMacroN,
           bool UseMetadataVectorWords = true>
-__global__ __launch_bounds__(Warps * 32, 1)
-void sm70_marlin_u8b128_gemm_splitk_kernel(
+__global__
+__launch_bounds__(Warps * 32, 1) void sm70_marlin_u8b128_gemm_splitk_kernel(
     cutlass::half_t const* __restrict__ a,
     uint32_t const* __restrict__ b_q_weight,
     cutlass::half_t const* __restrict__ b_scales,
-    cutlass::half_t* __restrict__ c, float* __restrict__ c32, int m, int n, int k, int lda, int requested_split_k) {
-  using Traits = Sm70U8B128GemmTraits<CtaM, CtaN, CtaK, Warps, WarpM,
-                                      WarpN, WarpK, GroupSize, PackedMacroN,
-                                      UseMetadataVectorWords>;
+    cutlass::half_t* __restrict__ c, float* __restrict__ c32, int m, int n,
+    int k, int lda, int requested_split_k) {
+  using Traits =
+      Sm70U8B128GemmTraits<CtaM, CtaN, CtaK, Warps, WarpM, WarpN, WarpK,
+                           GroupSize, PackedMacroN, UseMetadataVectorWords>;
   using Mma = typename Traits::Mma;
   using AtomicEpilogue = Sm70AtomicFp32Epilogue<Traits>;
 
@@ -484,14 +477,13 @@ void sm70_marlin_u8b128_gemm_splitk_kernel(
   int const thread_idx = threadIdx.x;
   int const warp_idx = cutlass::canonical_warp_idx_sync();
   int const lane_idx = threadIdx.x % 32;
-  Sm70SplitKPartition const partition =
-      sm70_splitk_partition<GroupSize, CtaK>(k, requested_split_k, int(blockIdx.z));
+  Sm70SplitKPartition const partition = sm70_splitk_partition<GroupSize, CtaK>(
+      k, requested_split_k, int(blockIdx.z));
   if (partition.partition_k == 0) {
     return;
   }
 
-  cutlass::MatrixCoord tb_offset_A{int(blockIdx.x) * CtaM,
-                                   partition.k_begin};
+  cutlass::MatrixCoord tb_offset_A{int(blockIdx.x) * CtaM, partition.k_begin};
   cutlass::MatrixCoord tb_offset_B{partition.k_begin, int(blockIdx.y) * CtaN};
   cutlass::MatrixCoord tb_offset_C{int(blockIdx.x) * CtaM,
                                    int(blockIdx.y) * CtaN};
@@ -499,10 +491,10 @@ void sm70_marlin_u8b128_gemm_splitk_kernel(
   typename Traits::LayoutA layout_a(lda);
   typename Traits::LayoutC layout_c(n);
 
-  typename Mma::IteratorA iterator_A(
-      typename Mma::IteratorA::Params(layout_a),
-      const_cast<cutlass::half_t*>(a), cutlass::MatrixCoord(m, k), thread_idx,
-      tb_offset_A);
+  typename Mma::IteratorA iterator_A(typename Mma::IteratorA::Params(layout_a),
+                                     const_cast<cutlass::half_t*>(a),
+                                     cutlass::MatrixCoord(m, k), thread_idx,
+                                     tb_offset_A);
   typename Mma::IteratorB iterator_B(
       typename Mma::IteratorB::Params(k, n),
       reinterpret_cast<uint32_t const*>(b_q_weight),
@@ -516,9 +508,8 @@ void sm70_marlin_u8b128_gemm_splitk_kernel(
   mma(gemm_k_iterations, accumulators, iterator_A, iterator_B, accumulators);
 
   typename AtomicEpilogue::OutputTileIterator iterator_D(
-      typename AtomicEpilogue::OutputTileIterator::Params(layout_c),
-      c, cutlass::MatrixCoord(m, n),
-      thread_idx, tb_offset_C);
+      typename AtomicEpilogue::OutputTileIterator::Params(layout_c), c,
+      cutlass::MatrixCoord(m, n), thread_idx, tb_offset_C);
 
   AtomicEpilogue epilogue(shared_storage.epilogue, thread_idx, warp_idx,
                           lane_idx);
@@ -527,20 +518,23 @@ void sm70_marlin_u8b128_gemm_splitk_kernel(
 
 }  // namespace
 
-template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM,
-          int WarpN, int WarpK, int GroupSize, int PackedMacroN,
+template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM, int WarpN,
+          int WarpK, int GroupSize, int PackedMacroN,
           bool UseMetadataVectorWords = true>
-torch::Tensor launch_sm70_marlin_u8b128_gemm(
-    torch::Tensor& a, torch::Tensor& c, torch::Tensor& b_q_weight,
-    torch::Tensor& b_scales, int64_t size_m, int64_t size_n, int64_t size_k,
-    int requested_split_k) {
+torch::Tensor launch_sm70_marlin_u8b128_gemm(torch::Tensor& a, torch::Tensor& c,
+                                             torch::Tensor& b_q_weight,
+                                             torch::Tensor& b_scales,
+                                             int64_t size_m, int64_t size_n,
+                                             int64_t size_k,
+                                             int requested_split_k) {
   auto kernel =
       sm70_marlin_u8b128_gemm_kernel<CtaM, CtaN, CtaK, Warps, WarpM, WarpN,
                                      WarpK, GroupSize, PackedMacroN,
                                      UseMetadataVectorWords>;
-  using SharedStorage = typename Sm70U8B128GemmTraits<
-      CtaM, CtaN, CtaK, Warps, WarpM, WarpN, WarpK, GroupSize,
-      PackedMacroN, UseMetadataVectorWords>::SharedStorage;
+  using SharedStorage =
+      typename Sm70U8B128GemmTraits<CtaM, CtaN, CtaK, Warps, WarpM, WarpN,
+                                    WarpK, GroupSize, PackedMacroN,
+                                    UseMetadataVectorWords>::SharedStorage;
   size_t smem_bytes = configure_sm70_dynamic_smem<SharedStorage>(kernel);
 
   dim3 block(Warps * 32);
@@ -560,23 +554,20 @@ torch::Tensor launch_sm70_marlin_u8b128_gemm(
   }
 
   TORCH_CHECK(size_k % int64_t(CtaK) == 0,
-              "SM70 Marlin uint8b128 requires K divisible by CTA_K=",
-              CtaK, " for requested_split_k > 1. Got K=", size_k,
+              "SM70 Marlin uint8b128 requires K divisible by CTA_K=", CtaK,
+              " for requested_split_k > 1. Got K=", size_k,
               ", requested_split_k=", requested_split_k, ".");
 
-  auto split_kernel =
-      sm70_marlin_u8b128_gemm_splitk_kernel<CtaM, CtaN, CtaK, Warps, WarpM,
-                                            WarpN, WarpK, GroupSize,
-                                            PackedMacroN,
-                                            UseMetadataVectorWords>;
+  auto split_kernel = sm70_marlin_u8b128_gemm_splitk_kernel<
+      CtaM, CtaN, CtaK, Warps, WarpM, WarpN, WarpK, GroupSize, PackedMacroN,
+      UseMetadataVectorWords>;
   smem_bytes = configure_sm70_dynamic_smem<SharedStorage>(split_kernel);
 
   int64_t const numel = size_m * size_n;
   // 0009: fp32 split-K scratch (zeroed for the fp32 atomicAdd), M*N floats.
   // Only allocated on the split_k>1 path, which the auto-selector uses ONLY at
   // low batch (M<128), so the scratch is bounded and small.
-  auto c32 = torch::zeros({size_m, size_n},
-                          a.options().dtype(at::kFloat));
+  auto c32 = torch::zeros({size_m, size_n}, a.options().dtype(at::kFloat));
 
   dim3 grid = sm70_marlin_cta_grid(size_m, size_n, CtaM, CtaN);
   int const active_split_k =
@@ -587,9 +578,9 @@ torch::Tensor launch_sm70_marlin_u8b128_gemm(
       reinterpret_cast<uint32_t const*>(b_q_weight.data_ptr<int32_t>()),
       reinterpret_cast<cutlass::half_t const*>(b_scales.data_ptr<at::Half>()),
       reinterpret_cast<cutlass::half_t*>(c.data_ptr<at::Half>()),
-      c32.data_ptr<float>(),
-      static_cast<int>(size_m), static_cast<int>(size_n),
-      static_cast<int>(size_k), static_cast<int>(a.stride(0)), requested_split_k);
+      c32.data_ptr<float>(), static_cast<int>(size_m), static_cast<int>(size_n),
+      static_cast<int>(size_k), static_cast<int>(a.stride(0)),
+      requested_split_k);
   C10_CUDA_KERNEL_LAUNCH_CHECK();
 
   // 0009: single deterministic-width fp32->fp16 narrow of the scratch.
@@ -597,8 +588,8 @@ torch::Tensor launch_sm70_marlin_u8b128_gemm(
   int const narrow_grid =
       static_cast<int>((numel + narrow_block - 1) / narrow_block);
   sm70_marlin_narrow_f32_to_f16<256><<<narrow_grid, narrow_block, 0, stream>>>(
-      c32.data_ptr<float>(),
-      reinterpret_cast<half*>(c.data_ptr<at::Half>()), numel);
+      c32.data_ptr<float>(), reinterpret_cast<half*>(c.data_ptr<at::Half>()),
+      numel);
   C10_CUDA_KERNEL_LAUNCH_CHECK();
 
   return c;
@@ -615,12 +606,11 @@ struct Sm70U8B128Launcher {
   int64_t size_k;
   int requested_split_k;
 
-  template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM,
-            int WarpN, int WarpK, int GroupSize, int PackedMacroN>
+  template <int CtaM, int CtaN, int CtaK, int Warps, int WarpM, int WarpN,
+            int WarpK, int GroupSize, int PackedMacroN>
   torch::Tensor operator()() const {
-    return launch_sm70_marlin_u8b128_gemm<CtaM, CtaN, CtaK, Warps, WarpM,
-                                          WarpN, WarpK, GroupSize,
-                                          PackedMacroN,
+    return launch_sm70_marlin_u8b128_gemm<CtaM, CtaN, CtaK, Warps, WarpM, WarpN,
+                                          WarpK, GroupSize, PackedMacroN,
                                           UseMetadataVectorWords>(
         a, c, b_q_weight, b_scales, size_m, size_n, size_k, requested_split_k);
   }
@@ -633,21 +623,23 @@ torch::Tensor sm70_marlin_u8b128_gemm(torch::Tensor& a, torch::Tensor& c,
                                       int64_t group_size) {
   c10::cuda::CUDAGuard device_guard(a.device());
 
-  auto const params = sm70_marlin_dense_auto_params(
-      "uint8b128", group_size, size_m, size_n, size_k);
+  auto const params = sm70_marlin_dense_auto_params("uint8b128", group_size,
+                                                    size_m, size_n, size_k);
   Sm70CtaGeometry const geometry = params.geometry;
-  validate_sm70_marlin_dense_cta_geometry_supported("SM70 Marlin uint8b128", geometry);
-  validate_sm70_marlin_dense_cta_n_alignment("SM70 Marlin uint8b128", geometry, size_n);
+  validate_sm70_marlin_dense_cta_geometry_supported("SM70 Marlin uint8b128",
+                                                    geometry);
+  validate_sm70_marlin_dense_cta_n_alignment("SM70 Marlin uint8b128", geometry,
+                                             size_n);
   if (params.use_metadata_vector_words) {
     Sm70U8B128Launcher<true> const launcher{
-        a, c, b_q_weight, b_scales, size_m, size_n, size_k,
-        params.requested_split_k};
+        a,      c,      b_q_weight, b_scales,
+        size_m, size_n, size_k,     params.requested_split_k};
     return dispatch_sm70_marlin_geometry_with_group32(
         launcher, geometry, params.packed_macro_n, group_size, "uint8b128");
   }
   Sm70U8B128Launcher<false> const launcher{
-      a, c, b_q_weight, b_scales, size_m, size_n, size_k,
-      params.requested_split_k};
+      a,      c,      b_q_weight, b_scales,
+      size_m, size_n, size_k,     params.requested_split_k};
   return dispatch_sm70_marlin_geometry_with_group32(
       launcher, geometry, params.packed_macro_n, group_size, "uint8b128");
 }

--- a/csrc/sm70_turbomind/ops/tm_registry_sm70.cu
+++ b/csrc/sm70_turbomind/ops/tm_registry_sm70.cu
@@ -6,34 +6,33 @@
 
 namespace turbomind::gemm {
 
-Registry::Registry(std::shared_ptr<cudaDeviceProp> device_prop):
-    device_prop_{std::move(device_prop)}, arch_{device_prop_->major * 100 + device_prop_->minor * 10}
-{
-    // Register the V100 kernels we actually use in this build:
-    // AWQ uint4, FP8/E4M3, and dense fp16 Tensor Core paths.
-    sm70_884_4();
-    sm70_884_8();
-    sm70_884_16();
+Registry::Registry(std::shared_ptr<cudaDeviceProp> device_prop)
+    : device_prop_{std::move(device_prop)},
+      arch_{device_prop_->major * 100 + device_prop_->minor * 10} {
+  // Register the V100 kernels we actually use in this build:
+  // AWQ uint4, FP8/E4M3, and dense fp16 Tensor Core paths.
+  sm70_884_4();
+  sm70_884_8();
+  sm70_884_16();
 }
 
-bool Registry::Add(std::unique_ptr<Kernel> kernel)
-{
-    bool is_valid = true;
+bool Registry::Add(std::unique_ptr<Kernel> kernel) {
+  bool is_valid = true;
 
-    if (!is_arch_compatible(kernel->arch(), arch_)) {
-        is_valid = false;
-    }
+  if (!is_arch_compatible(kernel->arch(), arch_)) {
+    is_valid = false;
+  }
 
-    if ((int)device_prop_->sharedMemPerBlockOptin < kernel->smem_size()) {
-        is_valid = false;
-    }
+  if ((int)device_prop_->sharedMemPerBlockOptin < kernel->smem_size()) {
+    is_valid = false;
+  }
 
-    if (is_valid) {
-        ptrs_.push_back(kernels_.emplace_back(transpose(*kernel)).get());
-        ptrs_.push_back(kernels_.emplace_back(std::move(kernel)).get());
-    }
+  if (is_valid) {
+    ptrs_.push_back(kernels_.emplace_back(transpose(*kernel)).get());
+    ptrs_.push_back(kernels_.emplace_back(std::move(kernel)).get());
+  }
 
-    return true;
+  return true;
 }
 
 }  // namespace turbomind::gemm

--- a/docs/design/qwen36_27b_awq_mtp_target_verifier_fastpaths.md
+++ b/docs/design/qwen36_27b_awq_mtp_target_verifier_fastpaths.md
@@ -351,11 +351,11 @@ Required experiment:
 
 Primary source paths:
 
-- https://github.com/NVIDIA/TensorRT-LLM/blob/main/cpp/tensorrt_llm/kernels/weightOnlyBatchedGemv/kernelDispatcher.h
-- https://github.com/NVIDIA/TensorRT-LLM/blob/main/cpp/tensorrt_llm/kernels/weightOnlyBatchedGemv/kernelLauncher.h
-- https://github.com/NVIDIA/TensorRT-LLM/blob/main/cpp/tensorrt_llm/kernels/weightOnlyBatchedGemv/kernel.h
-- https://github.com/NVIDIA/TensorRT-LLM/blob/main/cpp/tensorrt_llm/kernels/weightOnlyBatchedGemv/utility.h
-- https://github.com/NVIDIA/TensorRT-LLM/blob/main/cpp/tensorrt_llm/plugins/weightOnlyGroupwiseQuantMatmulPlugin/weightOnlyGroupwiseQuantMatmulPlugin.cpp
+- <https://github.com/NVIDIA/TensorRT-LLM/blob/main/cpp/tensorrt_llm/kernels/weightOnlyBatchedGemv/kernelDispatcher.h>
+- <https://github.com/NVIDIA/TensorRT-LLM/blob/main/cpp/tensorrt_llm/kernels/weightOnlyBatchedGemv/kernelLauncher.h>
+- <https://github.com/NVIDIA/TensorRT-LLM/blob/main/cpp/tensorrt_llm/kernels/weightOnlyBatchedGemv/kernel.h>
+- <https://github.com/NVIDIA/TensorRT-LLM/blob/main/cpp/tensorrt_llm/kernels/weightOnlyBatchedGemv/utility.h>
+- <https://github.com/NVIDIA/TensorRT-LLM/blob/main/cpp/tensorrt_llm/plugins/weightOnlyGroupwiseQuantMatmulPlugin/weightOnlyGroupwiseQuantMatmulPlugin.cpp>
 
 ### P1: SM90 Machete-style mixed-input WGMMA
 
@@ -401,7 +401,7 @@ must profile 1-SM, 2-SM, Stream-K, and exact-M GEMV tactics for each of the
 four real shapes.
 
 Source:
-https://github.com/NVIDIA/cutlass/blob/main/examples/86_blackwell_mixed_dtype_gemm/86_blackwell_mixed_dtype.cu
+<https://github.com/NVIDIA/cutlass/blob/main/examples/86_blackwell_mixed_dtype_gemm/86_blackwell_mixed_dtype.cu>
 
 **Native NVFP4/MXFP4.** Blackwell's `tcgen05.mma.blockscaled` consumes native
 block-scaled FP4 and accumulates through TMEM. CUTLASS documents 2x instruction
@@ -415,9 +415,9 @@ valid conversion.
 
 Sources:
 
-- https://github.com/NVIDIA/cutlass/blob/main/examples/72_blackwell_narrow_precision_gemm/72a_blackwell_nvfp4_bf16_gemm.cu
-- https://github.com/NVIDIA/cutlass/blob/main/examples/91_fp4_gemv/91_fp4_gemv.cu
-- https://github.com/NVIDIA/Model-Optimizer/blob/main/examples/llm_ptq/README.md
+- <https://github.com/NVIDIA/cutlass/blob/main/examples/72_blackwell_narrow_precision_gemm/72a_blackwell_nvfp4_bf16_gemm.cu>
+- <https://github.com/NVIDIA/cutlass/blob/main/examples/91_fp4_gemv/91_fp4_gemv.cu>
+- <https://github.com/NVIDIA/Model-Optimizer/blob/main/examples/llm_ptq/README.md>
 
 ### TurboMind SM90 ceiling
 
@@ -429,7 +429,7 @@ mainloop. Therefore, "enable TurboMind SM90" and "exploit Hopper's full mixed
 input path" are separate milestones.
 
 Source:
-https://github.com/InternLM/lmdeploy/blob/main/src/turbomind/kernels/gemm/kernel/sm90_16816_4.cu
+<https://github.com/InternLM/lmdeploy/blob/main/src/turbomind/kernels/gemm/kernel/sm90_16816_4.cu>
 
 ### Ranked benchmark order
 
@@ -538,11 +538,11 @@ or H100 target-forward baseline.
 
 ## Primary References
 
-- NVIDIA Ampere tuning guide: https://docs.nvidia.com/cuda/ampere-tuning-guide/index.html
-- NVIDIA Hopper tuning guide: https://docs.nvidia.com/cuda/archive/12.8.0/hopper-tuning-guide/index.html
-- CUTLASS changelog and mixed-input GEMM support: https://github.com/NVIDIA/cutlass/blob/main/CHANGELOG.md
-- Upstream TurboMind architecture-specific GEMM registry: https://github.com/InternLM/lmdeploy/tree/main/src/turbomind/kernels/gemm/kernel
-- FlashInfer GDN decode/MTP API: https://docs.flashinfer.ai/api/gdn_decode.html
-- FlashInfer GDN SM90 implementation contract: https://github.com/flashinfer-ai/flashinfer/blob/main/flashinfer/gdn_decode.py
-- FlashInfer/TensorRT-LLM MTP attention API: https://docs.flashinfer.ai/generated/flashinfer.decode.trtllm_batch_decode_with_kv_cache.html
-- TensorRT-LLM quantization hardware matrix: https://nvidia.github.io/TensorRT-LLM/latest/features/quantization.html
+- NVIDIA Ampere tuning guide: <https://docs.nvidia.com/cuda/ampere-tuning-guide/index.html>
+- NVIDIA Hopper tuning guide: <https://docs.nvidia.com/cuda/archive/12.8.0/hopper-tuning-guide/index.html>
+- CUTLASS changelog and mixed-input GEMM support: <https://github.com/NVIDIA/cutlass/blob/main/CHANGELOG.md>
+- Upstream TurboMind architecture-specific GEMM registry: <https://github.com/InternLM/lmdeploy/tree/main/src/turbomind/kernels/gemm/kernel>
+- FlashInfer GDN decode/MTP API: <https://docs.flashinfer.ai/api/gdn_decode.html>
+- FlashInfer GDN SM90 implementation contract: <https://github.com/flashinfer-ai/flashinfer/blob/main/flashinfer/gdn_decode.py>
+- FlashInfer/TensorRT-LLM MTP attention API: <https://docs.flashinfer.ai/generated/flashinfer.decode.trtllm_batch_decode_with_kv_cache.html>
+- TensorRT-LLM quantization hardware matrix: <https://nvidia.github.io/TensorRT-LLM/latest/features/quantization.html>

--- a/docs/design/sm70_nvfp4_turbomind_operator_optimization.md
+++ b/docs/design/sm70_nvfp4_turbomind_operator_optimization.md
@@ -640,11 +640,11 @@ Required run shape unless a note says otherwise:
 - CUDA device: one V100/SM70 rank
 - verifier shape: `m=17`, matching `budget=16` plus root
 - weighted verifier suite:
-  - `63` MLP gate/up calls
-  - `63` MLP down calls
-  - `47` linear-attention qkv calls
-  - `47` linear-attention z calls
-  - `16` full-attention o-proj calls
+    - `63` MLP gate/up calls
+    - `63` MLP down calls
+    - `47` linear-attention qkv calls
+    - `47` linear-attention z calls
+    - `16` full-attention o-proj calls
 - time only `awq_gemm_sm70_out` after `awq_sm70_prepare` and warmup
 - record exact env, JSON artifact, selected kernel when tracing is enabled, and
   whether the candidate is default behavior or env-forced only

--- a/docs/design/sm70_tile_runtime_exploration.md
+++ b/docs/design/sm70_tile_runtime_exploration.md
@@ -19,12 +19,12 @@ decode path:
 
 Relevant public references:
 
-- TileRT README: https://github.com/tile-ai/TileRT
-- TileRT execution-model blog: https://www.tilert.ai/blog/speed-as-the-next-scaling-law.html
-- TileRT 1000 TPS blog: https://www.tilert.ai/blog/breaking-1000-tps.html
-- DistFuse tile-wise GEMM/all-reduce paper: https://mcanini.github.io/papers/distfuse.hotinfra24.pdf
-- TokenWeave paper: https://arxiv.org/html/2505.11329v2
-- CUTLASS-native Distributed GEMM write-up: https://blog.shi-labs.com/distributed-gemm-88be6a481e2b
+- TileRT README: <https://github.com/tile-ai/TileRT>
+- TileRT execution-model blog: <https://www.tilert.ai/blog/speed-as-the-next-scaling-law.html>
+- TileRT 1000 TPS blog: <https://www.tilert.ai/blog/breaking-1000-tps.html>
+- DistFuse tile-wise GEMM/all-reduce paper: <https://mcanini.github.io/papers/distfuse.hotinfra24.pdf>
+- TokenWeave paper: <https://arxiv.org/html/2505.11329v2>
+- CUTLASS-native Distributed GEMM write-up: <https://blog.shi-labs.com/distributed-gemm-88be6a481e2b>
 
 The TileRT repository currently ships Python wrappers and binary backends, not
 the core engine source. The actionable implementation detail therefore comes
@@ -314,8 +314,8 @@ Correctness:
   `gated_silu` epilogue produced `max_abs=0`; interleaved normal output
   restored to the original order also produced `max_abs=0`.
 - End-to-end Qwen3.6-27B-AWQ TP2 token hashes matched baseline:
-  - 16-token smoke: `3d326cfe4c2bcd0aae49b11ed684dc2baff445be00e7eff6472cb014eb269cdb`.
-  - 128-token repeat-3: `25acc1257b65019cd7398d36105134378675d9de82bc7d30c6b49d78b1f7b755`.
+    - 16-token smoke: `3d326cfe4c2bcd0aae49b11ed684dc2baff445be00e7eff6472cb014eb269cdb`.
+    - 128-token repeat-3: `25acc1257b65019cd7398d36105134378675d9de82bc7d30c6b49d78b1f7b755`.
 
 Performance, 27B-AWQ TP2 on GPU0/1, `input_len=512`, `output_len=128`,
 `repeat=3`, Flash-V100 compile graph:
@@ -390,9 +390,9 @@ Correctness:
   both repeats produced token hash
   `1ccba72c62311edee3c604b4d41cdeddad72adb96fd6666a1af609c59708fd68`.
 - Tail-worker reduce also matches the normal path:
-  - short smoke, `output_len=4`: token hash
+    - short smoke, `output_len=4`: token hash
     `e3b3ebc930b09ed8921c4e20f0c8dd6fb93f0bd51c382cdc33a485050ef60939`;
-  - stable comparison, `output_len=32`: both repeats produced token hash
+    - stable comparison, `output_len=32`: both repeats produced token hash
     `1ccba72c62311edee3c604b4d41cdeddad72adb96fd6666a1af609c59708fd68`.
 
 Performance, 27B-AWQ TP2 on GPU0/1, `input_len=512`, `output_len=32`,

--- a/flash-attention-v100/include/fused_mma.h
+++ b/flash-attention-v100/include/fused_mma.h
@@ -2,7 +2,7 @@
 #define FUSED_MMA_H
 
 #if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ != 700)
-#error "Volta WMMA: This header is for sm_70 ONLY! Compile with -arch=sm_70"
+  #error "Volta WMMA: This header is for sm_70 ONLY! Compile with -arch=sm_70"
 #endif
 
 #include <cuda_fp16.h>
@@ -15,385 +15,409 @@ struct matrix_a {};
 struct matrix_b {};
 struct accumulator {};
 
-enum layout_t {
-    mem_row_major,
-    mem_col_major
-};
+enum layout_t { mem_row_major, mem_col_major };
 
 template <typename Use, int M, int N, int K, typename T, typename Layout = void>
 struct fragment;
 
-template <> struct fragment<matrix_a, 16, 16, 16, half, row_major> { uint32_t x[8]; static constexpr int num_elements = 16; };
-template <> struct fragment<matrix_a, 16, 16, 16, half, col_major> { uint32_t x[8]; static constexpr int num_elements = 16; };
+template <>
+struct fragment<matrix_a, 16, 16, 16, half, row_major> {
+  uint32_t x[8];
+  static constexpr int num_elements = 16;
+};
+template <>
+struct fragment<matrix_a, 16, 16, 16, half, col_major> {
+  uint32_t x[8];
+  static constexpr int num_elements = 16;
+};
 
-template <> struct fragment<matrix_a, 32, 8, 16, half, row_major>  { uint32_t x[8]; static constexpr int num_elements = 16; };
-template <> struct fragment<matrix_a, 32, 8, 16, half, col_major>  { uint32_t x[8]; static constexpr int num_elements = 16; };
+template <>
+struct fragment<matrix_a, 32, 8, 16, half, row_major> {
+  uint32_t x[8];
+  static constexpr int num_elements = 16;
+};
+template <>
+struct fragment<matrix_a, 32, 8, 16, half, col_major> {
+  uint32_t x[8];
+  static constexpr int num_elements = 16;
+};
 
-template <> struct fragment<matrix_a, 8, 32, 16, half, row_major>  { uint32_t x[8]; static constexpr int num_elements = 16; };
-template <> struct fragment<matrix_a, 8, 32, 16, half, col_major>  { uint32_t x[8]; static constexpr int num_elements = 16; };
+template <>
+struct fragment<matrix_a, 8, 32, 16, half, row_major> {
+  uint32_t x[8];
+  static constexpr int num_elements = 16;
+};
+template <>
+struct fragment<matrix_a, 8, 32, 16, half, col_major> {
+  uint32_t x[8];
+  static constexpr int num_elements = 16;
+};
 
-template <> struct fragment<matrix_b, 16, 16, 16, half, row_major> { uint32_t x[8]; static constexpr int num_elements = 16; };
-template <> struct fragment<matrix_b, 16, 16, 16, half, col_major> { uint32_t x[8]; static constexpr int num_elements = 16; };
+template <>
+struct fragment<matrix_b, 16, 16, 16, half, row_major> {
+  uint32_t x[8];
+  static constexpr int num_elements = 16;
+};
+template <>
+struct fragment<matrix_b, 16, 16, 16, half, col_major> {
+  uint32_t x[8];
+  static constexpr int num_elements = 16;
+};
 
-template <> struct fragment<matrix_b, 32, 8, 16, half, row_major>  { uint32_t x[8]; static constexpr int num_elements = 16; };
-template <> struct fragment<matrix_b, 32, 8, 16, half, col_major>  { uint32_t x[8]; static constexpr int num_elements = 16; };
+template <>
+struct fragment<matrix_b, 32, 8, 16, half, row_major> {
+  uint32_t x[8];
+  static constexpr int num_elements = 16;
+};
+template <>
+struct fragment<matrix_b, 32, 8, 16, half, col_major> {
+  uint32_t x[8];
+  static constexpr int num_elements = 16;
+};
 
-template <> struct fragment<matrix_b, 8, 32, 16, half, row_major>  { uint32_t x[8]; static constexpr int num_elements = 16; };
-template <> struct fragment<matrix_b, 8, 32, 16, half, col_major>  { uint32_t x[8]; static constexpr int num_elements = 16; };
+template <>
+struct fragment<matrix_b, 8, 32, 16, half, row_major> {
+  uint32_t x[8];
+  static constexpr int num_elements = 16;
+};
+template <>
+struct fragment<matrix_b, 8, 32, 16, half, col_major> {
+  uint32_t x[8];
+  static constexpr int num_elements = 16;
+};
 
-template <> struct fragment<accumulator, 16, 16, 16, float> { float x[8]; static constexpr int num_elements = 8; };
-template <> struct fragment<accumulator, 32, 8, 16, float>  { float x[8]; static constexpr int num_elements = 8; };
-template <> struct fragment<accumulator, 8, 32, 16, float>  { float x[8]; static constexpr int num_elements = 8; };
+template <>
+struct fragment<accumulator, 16, 16, 16, float> {
+  float x[8];
+  static constexpr int num_elements = 8;
+};
+template <>
+struct fragment<accumulator, 32, 8, 16, float> {
+  float x[8];
+  static constexpr int num_elements = 8;
+};
+template <>
+struct fragment<accumulator, 8, 32, 16, float> {
+  float x[8];
+  static constexpr int num_elements = 8;
+};
 
 __device__ __forceinline__ unsigned get_lane_id() {
-    unsigned lane_id;
-    asm volatile ("mov.u32 %0, %%laneid;" : "=r"(lane_id));
-    return lane_id;
+  unsigned lane_id;
+  asm volatile("mov.u32 %0, %%laneid;" : "=r"(lane_id));
+  return lane_id;
 }
 
 template <int M, int N, int K>
-__device__ __forceinline__ void fill_fragment(fragment<accumulator, M, N, K, float>& frag, float value) {
-    #pragma unroll
-    for (int i = 0; i < 8; ++i) frag.x[i] = value;
+__device__ __forceinline__ void fill_fragment(
+    fragment<accumulator, M, N, K, float>& frag, float value) {
+#pragma unroll
+  for (int i = 0; i < 8; ++i) frag.x[i] = value;
 }
 
 __device__ __forceinline__ void load_matrix_sync(
-    fragment<matrix_a, 16, 16, 16, half, row_major>& frag,
-    const half* smem_ptr, unsigned ldm) {
+    fragment<matrix_a, 16, 16, 16, half, row_major>& frag, const half* smem_ptr,
+    unsigned ldm) {
+  asm volatile(
+      "wmma.load.a.sync.aligned.row.m16n16k16.f16 "
+      "{%0,%1,%2,%3,%4,%5,%6,%7}, [%8], %9;"
+      : "=r"(frag.x[0]), "=r"(frag.x[1]), "=r"(frag.x[2]), "=r"(frag.x[3]),
+        "=r"(frag.x[4]), "=r"(frag.x[5]), "=r"(frag.x[6]), "=r"(frag.x[7])
+      : "l"(smem_ptr), "r"(ldm)
+      : "memory");
+}
+
+__device__ __forceinline__ void load_matrix_sync(
+    fragment<matrix_a, 16, 16, 16, half, col_major>& frag, const half* smem_ptr,
+    unsigned ldm) {
+  asm volatile(
+      "wmma.load.a.sync.aligned.col.m16n16k16.f16 "
+      "{%0,%1,%2,%3,%4,%5,%6,%7}, [%8], %9;"
+      : "=r"(frag.x[0]), "=r"(frag.x[1]), "=r"(frag.x[2]), "=r"(frag.x[3]),
+        "=r"(frag.x[4]), "=r"(frag.x[5]), "=r"(frag.x[6]), "=r"(frag.x[7])
+      : "l"(smem_ptr), "r"(ldm)
+      : "memory");
+}
+
+__device__ __forceinline__ void load_matrix_sync(
+    fragment<matrix_b, 16, 16, 16, half, row_major>& frag, const half* smem_ptr,
+    unsigned ldm) {
+  asm volatile(
+      "wmma.load.b.sync.aligned.row.m16n16k16.f16 "
+      "{%0,%1,%2,%3,%4,%5,%6,%7}, [%8], %9;"
+      : "=r"(frag.x[0]), "=r"(frag.x[1]), "=r"(frag.x[2]), "=r"(frag.x[3]),
+        "=r"(frag.x[4]), "=r"(frag.x[5]), "=r"(frag.x[6]), "=r"(frag.x[7])
+      : "l"(smem_ptr), "r"(ldm)
+      : "memory");
+}
+
+__device__ __forceinline__ void load_matrix_sync(
+    fragment<matrix_b, 16, 16, 16, half, col_major>& frag, const half* smem_ptr,
+    unsigned ldm) {
+  asm volatile(
+      "wmma.load.b.sync.aligned.col.m16n16k16.f16 "
+      "{%0,%1,%2,%3,%4,%5,%6,%7}, [%8], %9;"
+      : "=r"(frag.x[0]), "=r"(frag.x[1]), "=r"(frag.x[2]), "=r"(frag.x[3]),
+        "=r"(frag.x[4]), "=r"(frag.x[5]), "=r"(frag.x[6]), "=r"(frag.x[7])
+      : "l"(smem_ptr), "r"(ldm)
+      : "memory");
+}
+
+__device__ __forceinline__ void load_matrix_sync(
+    fragment<accumulator, 16, 16, 16, float>& frag, const float* smem_ptr,
+    unsigned ldm, layout_t layout) {
+  if (layout == mem_row_major) {
     asm volatile(
-        "wmma.load.a.sync.aligned.row.m16n16k16.f16 "
+        "wmma.load.c.sync.aligned.row.m16n16k16.f32 "
         "{%0,%1,%2,%3,%4,%5,%6,%7}, [%8], %9;"
-        : "=r"(frag.x[0]), "=r"(frag.x[1]), "=r"(frag.x[2]), "=r"(frag.x[3]),
-          "=r"(frag.x[4]), "=r"(frag.x[5]), "=r"(frag.x[6]), "=r"(frag.x[7])
+        : "=f"(frag.x[0]), "=f"(frag.x[1]), "=f"(frag.x[2]), "=f"(frag.x[3]),
+          "=f"(frag.x[4]), "=f"(frag.x[5]), "=f"(frag.x[6]), "=f"(frag.x[7])
         : "l"(smem_ptr), "r"(ldm)
-        : "memory"
-    );
-}
-
-__device__ __forceinline__ void load_matrix_sync(
-    fragment<matrix_a, 16, 16, 16, half, col_major>& frag,
-    const half* smem_ptr, unsigned ldm) {
+        : "memory");
+  } else {
     asm volatile(
-        "wmma.load.a.sync.aligned.col.m16n16k16.f16 "
+        "wmma.load.c.sync.aligned.col.m16n16k16.f32 "
         "{%0,%1,%2,%3,%4,%5,%6,%7}, [%8], %9;"
-        : "=r"(frag.x[0]), "=r"(frag.x[1]), "=r"(frag.x[2]), "=r"(frag.x[3]),
-          "=r"(frag.x[4]), "=r"(frag.x[5]), "=r"(frag.x[6]), "=r"(frag.x[7])
+        : "=f"(frag.x[0]), "=f"(frag.x[1]), "=f"(frag.x[2]), "=f"(frag.x[3]),
+          "=f"(frag.x[4]), "=f"(frag.x[5]), "=f"(frag.x[6]), "=f"(frag.x[7])
         : "l"(smem_ptr), "r"(ldm)
-        : "memory"
-    );
+        : "memory");
+  }
 }
 
 __device__ __forceinline__ void load_matrix_sync(
-    fragment<matrix_b, 16, 16, 16, half, row_major>& frag,
-    const half* smem_ptr, unsigned ldm) {
+    fragment<matrix_a, 32, 8, 16, half, row_major>& frag, const half* smem_ptr,
+    unsigned ldm) {
+  asm volatile(
+      "wmma.load.a.sync.aligned.row.m32n8k16.f16 "
+      "{%0,%1,%2,%3,%4,%5,%6,%7}, [%8], %9;"
+      : "=r"(frag.x[0]), "=r"(frag.x[1]), "=r"(frag.x[2]), "=r"(frag.x[3]),
+        "=r"(frag.x[4]), "=r"(frag.x[5]), "=r"(frag.x[6]), "=r"(frag.x[7])
+      : "l"(smem_ptr), "r"(ldm)
+      : "memory");
+}
+
+__device__ __forceinline__ void load_matrix_sync(
+    fragment<matrix_a, 32, 8, 16, half, col_major>& frag, const half* smem_ptr,
+    unsigned ldm) {
+  asm volatile(
+      "wmma.load.a.sync.aligned.col.m32n8k16.f16 "
+      "{%0,%1,%2,%3,%4,%5,%6,%7}, [%8], %9;"
+      : "=r"(frag.x[0]), "=r"(frag.x[1]), "=r"(frag.x[2]), "=r"(frag.x[3]),
+        "=r"(frag.x[4]), "=r"(frag.x[5]), "=r"(frag.x[6]), "=r"(frag.x[7])
+      : "l"(smem_ptr), "r"(ldm)
+      : "memory");
+}
+
+__device__ __forceinline__ void load_matrix_sync(
+    fragment<matrix_b, 32, 8, 16, half, row_major>& frag, const half* smem_ptr,
+    unsigned ldm) {
+  asm volatile(
+      "wmma.load.b.sync.aligned.row.m32n8k16.f16 "
+      "{%0,%1,%2,%3,%4,%5,%6,%7}, [%8], %9;"
+      : "=r"(frag.x[0]), "=r"(frag.x[1]), "=r"(frag.x[2]), "=r"(frag.x[3]),
+        "=r"(frag.x[4]), "=r"(frag.x[5]), "=r"(frag.x[6]), "=r"(frag.x[7])
+      : "l"(smem_ptr), "r"(ldm)
+      : "memory");
+}
+
+__device__ __forceinline__ void load_matrix_sync(
+    fragment<matrix_b, 32, 8, 16, half, col_major>& frag, const half* smem_ptr,
+    unsigned ldm) {
+  asm volatile(
+      "wmma.load.b.sync.aligned.col.m32n8k16.f16 "
+      "{%0,%1,%2,%3,%4,%5,%6,%7}, [%8], %9;"
+      : "=r"(frag.x[0]), "=r"(frag.x[1]), "=r"(frag.x[2]), "=r"(frag.x[3]),
+        "=r"(frag.x[4]), "=r"(frag.x[5]), "=r"(frag.x[6]), "=r"(frag.x[7])
+      : "l"(smem_ptr), "r"(ldm)
+      : "memory");
+}
+
+__device__ __forceinline__ void load_matrix_sync(
+    fragment<accumulator, 32, 8, 16, float>& frag, const float* smem_ptr,
+    unsigned ldm, layout_t layout) {
+  if (layout == mem_row_major) {
     asm volatile(
-        "wmma.load.b.sync.aligned.row.m16n16k16.f16 "
+        "wmma.load.c.sync.aligned.row.m32n8k16.f32 "
         "{%0,%1,%2,%3,%4,%5,%6,%7}, [%8], %9;"
-        : "=r"(frag.x[0]), "=r"(frag.x[1]), "=r"(frag.x[2]), "=r"(frag.x[3]),
-          "=r"(frag.x[4]), "=r"(frag.x[5]), "=r"(frag.x[6]), "=r"(frag.x[7])
+        : "=f"(frag.x[0]), "=f"(frag.x[1]), "=f"(frag.x[2]), "=f"(frag.x[3]),
+          "=f"(frag.x[4]), "=f"(frag.x[5]), "=f"(frag.x[6]), "=f"(frag.x[7])
         : "l"(smem_ptr), "r"(ldm)
-        : "memory"
-    );
-}
-
-__device__ __forceinline__ void load_matrix_sync(
-    fragment<matrix_b, 16, 16, 16, half, col_major>& frag,
-    const half* smem_ptr, unsigned ldm) {
+        : "memory");
+  } else {
     asm volatile(
-        "wmma.load.b.sync.aligned.col.m16n16k16.f16 "
+        "wmma.load.c.sync.aligned.col.m32n8k16.f32 "
         "{%0,%1,%2,%3,%4,%5,%6,%7}, [%8], %9;"
-        : "=r"(frag.x[0]), "=r"(frag.x[1]), "=r"(frag.x[2]), "=r"(frag.x[3]),
-          "=r"(frag.x[4]), "=r"(frag.x[5]), "=r"(frag.x[6]), "=r"(frag.x[7])
+        : "=f"(frag.x[0]), "=f"(frag.x[1]), "=f"(frag.x[2]), "=f"(frag.x[3]),
+          "=f"(frag.x[4]), "=f"(frag.x[5]), "=f"(frag.x[6]), "=f"(frag.x[7])
         : "l"(smem_ptr), "r"(ldm)
-        : "memory"
-    );
+        : "memory");
+  }
 }
 
 __device__ __forceinline__ void load_matrix_sync(
-    fragment<accumulator, 16, 16, 16, float>& frag,
-    const float* smem_ptr, unsigned ldm, layout_t layout) {
-    if (layout == mem_row_major) {
-        asm volatile(
-            "wmma.load.c.sync.aligned.row.m16n16k16.f32 "
-            "{%0,%1,%2,%3,%4,%5,%6,%7}, [%8], %9;"
-            : "=f"(frag.x[0]), "=f"(frag.x[1]), "=f"(frag.x[2]), "=f"(frag.x[3]),
-              "=f"(frag.x[4]), "=f"(frag.x[5]), "=f"(frag.x[6]), "=f"(frag.x[7])
-            : "l"(smem_ptr), "r"(ldm)
-            : "memory"
-        );
-    } else {
-        asm volatile(
-            "wmma.load.c.sync.aligned.col.m16n16k16.f32 "
-            "{%0,%1,%2,%3,%4,%5,%6,%7}, [%8], %9;"
-            : "=f"(frag.x[0]), "=f"(frag.x[1]), "=f"(frag.x[2]), "=f"(frag.x[3]),
-              "=f"(frag.x[4]), "=f"(frag.x[5]), "=f"(frag.x[6]), "=f"(frag.x[7])
-            : "l"(smem_ptr), "r"(ldm)
-            : "memory"
-        );
-    }
+    fragment<matrix_a, 8, 32, 16, half, row_major>& frag, const half* smem_ptr,
+    unsigned ldm) {
+  asm volatile(
+      "wmma.load.a.sync.aligned.row.m8n32k16.f16 "
+      "{%0,%1,%2,%3,%4,%5,%6,%7}, [%8], %9;"
+      : "=r"(frag.x[0]), "=r"(frag.x[1]), "=r"(frag.x[2]), "=r"(frag.x[3]),
+        "=r"(frag.x[4]), "=r"(frag.x[5]), "=r"(frag.x[6]), "=r"(frag.x[7])
+      : "l"(smem_ptr), "r"(ldm)
+      : "memory");
 }
 
 __device__ __forceinline__ void load_matrix_sync(
-    fragment<matrix_a, 32, 8, 16, half, row_major>& frag,
-    const half* smem_ptr, unsigned ldm) {
+    fragment<matrix_a, 8, 32, 16, half, col_major>& frag, const half* smem_ptr,
+    unsigned ldm) {
+  asm volatile(
+      "wmma.load.a.sync.aligned.col.m8n32k16.f16 "
+      "{%0,%1,%2,%3,%4,%5,%6,%7}, [%8], %9;"
+      : "=r"(frag.x[0]), "=r"(frag.x[1]), "=r"(frag.x[2]), "=r"(frag.x[3]),
+        "=r"(frag.x[4]), "=r"(frag.x[5]), "=r"(frag.x[6]), "=r"(frag.x[7])
+      : "l"(smem_ptr), "r"(ldm)
+      : "memory");
+}
+
+__device__ __forceinline__ void load_matrix_sync(
+    fragment<matrix_b, 8, 32, 16, half, row_major>& frag, const half* smem_ptr,
+    unsigned ldm) {
+  asm volatile(
+      "wmma.load.b.sync.aligned.row.m8n32k16.f16 "
+      "{%0,%1,%2,%3,%4,%5,%6,%7}, [%8], %9;"
+      : "=r"(frag.x[0]), "=r"(frag.x[1]), "=r"(frag.x[2]), "=r"(frag.x[3]),
+        "=r"(frag.x[4]), "=r"(frag.x[5]), "=r"(frag.x[6]), "=r"(frag.x[7])
+      : "l"(smem_ptr), "r"(ldm)
+      : "memory");
+}
+
+__device__ __forceinline__ void load_matrix_sync(
+    fragment<matrix_b, 8, 32, 16, half, col_major>& frag, const half* smem_ptr,
+    unsigned ldm) {
+  asm volatile(
+      "wmma.load.b.sync.aligned.col.m8n32k16.f16 "
+      "{%0,%1,%2,%3,%4,%5,%6,%7}, [%8], %9;"
+      : "=r"(frag.x[0]), "=r"(frag.x[1]), "=r"(frag.x[2]), "=r"(frag.x[3]),
+        "=r"(frag.x[4]), "=r"(frag.x[5]), "=r"(frag.x[6]), "=r"(frag.x[7])
+      : "l"(smem_ptr), "r"(ldm)
+      : "memory");
+}
+
+__device__ __forceinline__ void load_matrix_sync(
+    fragment<accumulator, 8, 32, 16, float>& frag, const float* smem_ptr,
+    unsigned ldm, layout_t layout) {
+  if (layout == mem_row_major) {
     asm volatile(
-        "wmma.load.a.sync.aligned.row.m32n8k16.f16 "
+        "wmma.load.c.sync.aligned.row.m8n32k16.f32 "
         "{%0,%1,%2,%3,%4,%5,%6,%7}, [%8], %9;"
-        : "=r"(frag.x[0]), "=r"(frag.x[1]), "=r"(frag.x[2]), "=r"(frag.x[3]),
-          "=r"(frag.x[4]), "=r"(frag.x[5]), "=r"(frag.x[6]), "=r"(frag.x[7])
+        : "=f"(frag.x[0]), "=f"(frag.x[1]), "=f"(frag.x[2]), "=f"(frag.x[3]),
+          "=f"(frag.x[4]), "=f"(frag.x[5]), "=f"(frag.x[6]), "=f"(frag.x[7])
         : "l"(smem_ptr), "r"(ldm)
-        : "memory"
-    );
-}
-
-__device__ __forceinline__ void load_matrix_sync(
-    fragment<matrix_a, 32, 8, 16, half, col_major>& frag,
-    const half* smem_ptr, unsigned ldm) {
+        : "memory");
+  } else {
     asm volatile(
-        "wmma.load.a.sync.aligned.col.m32n8k16.f16 "
+        "wmma.load.c.sync.aligned.col.m8n32k16.f32 "
         "{%0,%1,%2,%3,%4,%5,%6,%7}, [%8], %9;"
-        : "=r"(frag.x[0]), "=r"(frag.x[1]), "=r"(frag.x[2]), "=r"(frag.x[3]),
-          "=r"(frag.x[4]), "=r"(frag.x[5]), "=r"(frag.x[6]), "=r"(frag.x[7])
+        : "=f"(frag.x[0]), "=f"(frag.x[1]), "=f"(frag.x[2]), "=f"(frag.x[3]),
+          "=f"(frag.x[4]), "=f"(frag.x[5]), "=f"(frag.x[6]), "=f"(frag.x[7])
         : "l"(smem_ptr), "r"(ldm)
-        : "memory"
-    );
-}
-
-__device__ __forceinline__ void load_matrix_sync(
-    fragment<matrix_b, 32, 8, 16, half, row_major>& frag,
-    const half* smem_ptr, unsigned ldm) {
-    asm volatile(
-        "wmma.load.b.sync.aligned.row.m32n8k16.f16 "
-        "{%0,%1,%2,%3,%4,%5,%6,%7}, [%8], %9;"
-        : "=r"(frag.x[0]), "=r"(frag.x[1]), "=r"(frag.x[2]), "=r"(frag.x[3]),
-          "=r"(frag.x[4]), "=r"(frag.x[5]), "=r"(frag.x[6]), "=r"(frag.x[7])
-        : "l"(smem_ptr), "r"(ldm)
-        : "memory"
-    );
-}
-
-__device__ __forceinline__ void load_matrix_sync(
-    fragment<matrix_b, 32, 8, 16, half, col_major>& frag,
-    const half* smem_ptr, unsigned ldm) {
-    asm volatile(
-        "wmma.load.b.sync.aligned.col.m32n8k16.f16 "
-        "{%0,%1,%2,%3,%4,%5,%6,%7}, [%8], %9;"
-        : "=r"(frag.x[0]), "=r"(frag.x[1]), "=r"(frag.x[2]), "=r"(frag.x[3]),
-          "=r"(frag.x[4]), "=r"(frag.x[5]), "=r"(frag.x[6]), "=r"(frag.x[7])
-        : "l"(smem_ptr), "r"(ldm)
-        : "memory"
-    );
-}
-
-__device__ __forceinline__ void load_matrix_sync(
-    fragment<accumulator, 32, 8, 16, float>& frag,
-    const float* smem_ptr, unsigned ldm, layout_t layout) {
-    if (layout == mem_row_major) {
-        asm volatile(
-            "wmma.load.c.sync.aligned.row.m32n8k16.f32 "
-            "{%0,%1,%2,%3,%4,%5,%6,%7}, [%8], %9;"
-            : "=f"(frag.x[0]), "=f"(frag.x[1]), "=f"(frag.x[2]), "=f"(frag.x[3]),
-              "=f"(frag.x[4]), "=f"(frag.x[5]), "=f"(frag.x[6]), "=f"(frag.x[7])
-            : "l"(smem_ptr), "r"(ldm)
-            : "memory"
-        );
-    } else {
-        asm volatile(
-            "wmma.load.c.sync.aligned.col.m32n8k16.f32 "
-            "{%0,%1,%2,%3,%4,%5,%6,%7}, [%8], %9;"
-            : "=f"(frag.x[0]), "=f"(frag.x[1]), "=f"(frag.x[2]), "=f"(frag.x[3]),
-              "=f"(frag.x[4]), "=f"(frag.x[5]), "=f"(frag.x[6]), "=f"(frag.x[7])
-            : "l"(smem_ptr), "r"(ldm)
-            : "memory"
-        );
-    }
-}
-
-__device__ __forceinline__ void load_matrix_sync(
-    fragment<matrix_a, 8, 32, 16, half, row_major>& frag,
-    const half* smem_ptr, unsigned ldm) {
-    asm volatile(
-        "wmma.load.a.sync.aligned.row.m8n32k16.f16 "
-        "{%0,%1,%2,%3,%4,%5,%6,%7}, [%8], %9;"
-        : "=r"(frag.x[0]), "=r"(frag.x[1]), "=r"(frag.x[2]), "=r"(frag.x[3]),
-          "=r"(frag.x[4]), "=r"(frag.x[5]), "=r"(frag.x[6]), "=r"(frag.x[7])
-        : "l"(smem_ptr), "r"(ldm)
-        : "memory"
-    );
-}
-
-__device__ __forceinline__ void load_matrix_sync(
-    fragment<matrix_a, 8, 32, 16, half, col_major>& frag,
-    const half* smem_ptr, unsigned ldm) {
-    asm volatile(
-        "wmma.load.a.sync.aligned.col.m8n32k16.f16 "
-        "{%0,%1,%2,%3,%4,%5,%6,%7}, [%8], %9;"
-        : "=r"(frag.x[0]), "=r"(frag.x[1]), "=r"(frag.x[2]), "=r"(frag.x[3]),
-          "=r"(frag.x[4]), "=r"(frag.x[5]), "=r"(frag.x[6]), "=r"(frag.x[7])
-        : "l"(smem_ptr), "r"(ldm)
-        : "memory"
-    );
-}
-
-__device__ __forceinline__ void load_matrix_sync(
-    fragment<matrix_b, 8, 32, 16, half, row_major>& frag,
-    const half* smem_ptr, unsigned ldm) {
-    asm volatile(
-        "wmma.load.b.sync.aligned.row.m8n32k16.f16 "
-        "{%0,%1,%2,%3,%4,%5,%6,%7}, [%8], %9;"
-        : "=r"(frag.x[0]), "=r"(frag.x[1]), "=r"(frag.x[2]), "=r"(frag.x[3]),
-          "=r"(frag.x[4]), "=r"(frag.x[5]), "=r"(frag.x[6]), "=r"(frag.x[7])
-        : "l"(smem_ptr), "r"(ldm)
-        : "memory"
-    );
-}
-
-__device__ __forceinline__ void load_matrix_sync(
-    fragment<matrix_b, 8, 32, 16, half, col_major>& frag,
-    const half* smem_ptr, unsigned ldm) {
-    asm volatile(
-        "wmma.load.b.sync.aligned.col.m8n32k16.f16 "
-        "{%0,%1,%2,%3,%4,%5,%6,%7}, [%8], %9;"
-        : "=r"(frag.x[0]), "=r"(frag.x[1]), "=r"(frag.x[2]), "=r"(frag.x[3]),
-          "=r"(frag.x[4]), "=r"(frag.x[5]), "=r"(frag.x[6]), "=r"(frag.x[7])
-        : "l"(smem_ptr), "r"(ldm)
-        : "memory"
-    );
-}
-
-__device__ __forceinline__ void load_matrix_sync(
-    fragment<accumulator, 8, 32, 16, float>& frag,
-    const float* smem_ptr, unsigned ldm, layout_t layout) {
-    if (layout == mem_row_major) {
-        asm volatile(
-            "wmma.load.c.sync.aligned.row.m8n32k16.f32 "
-            "{%0,%1,%2,%3,%4,%5,%6,%7}, [%8], %9;"
-            : "=f"(frag.x[0]), "=f"(frag.x[1]), "=f"(frag.x[2]), "=f"(frag.x[3]),
-              "=f"(frag.x[4]), "=f"(frag.x[5]), "=f"(frag.x[6]), "=f"(frag.x[7])
-            : "l"(smem_ptr), "r"(ldm)
-            : "memory"
-        );
-    } else {
-        asm volatile(
-            "wmma.load.c.sync.aligned.col.m8n32k16.f32 "
-            "{%0,%1,%2,%3,%4,%5,%6,%7}, [%8], %9;"
-            : "=f"(frag.x[0]), "=f"(frag.x[1]), "=f"(frag.x[2]), "=f"(frag.x[3]),
-              "=f"(frag.x[4]), "=f"(frag.x[5]), "=f"(frag.x[6]), "=f"(frag.x[7])
-            : "l"(smem_ptr), "r"(ldm)
-            : "memory"
-        );
-    }
+        : "memory");
+  }
 }
 
 __device__ __forceinline__ void store_matrix_sync(
-    float* smem_ptr,
-    const fragment<accumulator, 16, 16, 16, float>& frag,
+    float* smem_ptr, const fragment<accumulator, 16, 16, 16, float>& frag,
     unsigned ldm, layout_t layout) {
-    if (layout == mem_row_major) {
-        asm volatile(
-            "wmma.store.d.sync.aligned.row.m16n16k16.f32 "
-            "[%0], {%1,%2,%3,%4,%5,%6,%7,%8}, %9;"
-            :
-            : "l"(smem_ptr),
-              "f"(frag.x[0]), "f"(frag.x[1]), "f"(frag.x[2]), "f"(frag.x[3]),
-              "f"(frag.x[4]), "f"(frag.x[5]), "f"(frag.x[6]), "f"(frag.x[7]),
-              "r"(ldm)
-            : "memory"
-        );
-    } else {
-        asm volatile(
-            "wmma.store.d.sync.aligned.col.m16n16k16.f32 "
-            "[%0], {%1,%2,%3,%4,%5,%6,%7,%8}, %9;"
-            :
-            : "l"(smem_ptr),
-              "f"(frag.x[0]), "f"(frag.x[1]), "f"(frag.x[2]), "f"(frag.x[3]),
-              "f"(frag.x[4]), "f"(frag.x[5]), "f"(frag.x[6]), "f"(frag.x[7]),
-              "r"(ldm)
-            : "memory"
-        );
-    }
+  if (layout == mem_row_major) {
+    asm volatile(
+        "wmma.store.d.sync.aligned.row.m16n16k16.f32 "
+        "[%0], {%1,%2,%3,%4,%5,%6,%7,%8}, %9;"
+        :
+        : "l"(smem_ptr), "f"(frag.x[0]), "f"(frag.x[1]), "f"(frag.x[2]),
+          "f"(frag.x[3]), "f"(frag.x[4]), "f"(frag.x[5]), "f"(frag.x[6]),
+          "f"(frag.x[7]), "r"(ldm)
+        : "memory");
+  } else {
+    asm volatile(
+        "wmma.store.d.sync.aligned.col.m16n16k16.f32 "
+        "[%0], {%1,%2,%3,%4,%5,%6,%7,%8}, %9;"
+        :
+        : "l"(smem_ptr), "f"(frag.x[0]), "f"(frag.x[1]), "f"(frag.x[2]),
+          "f"(frag.x[3]), "f"(frag.x[4]), "f"(frag.x[5]), "f"(frag.x[6]),
+          "f"(frag.x[7]), "r"(ldm)
+        : "memory");
+  }
 }
 
 __device__ __forceinline__ void store_matrix_sync(
-    float* smem_ptr,
-    const fragment<accumulator, 32, 8, 16, float>& frag,
+    float* smem_ptr, const fragment<accumulator, 32, 8, 16, float>& frag,
     unsigned ldm, layout_t layout) {
-    if (layout == mem_row_major) {
-        asm volatile(
-            "wmma.store.d.sync.aligned.row.m32n8k16.f32 "
-            "[%0], {%1,%2,%3,%4,%5,%6,%7,%8}, %9;"
-            :
-            : "l"(smem_ptr),
-              "f"(frag.x[0]), "f"(frag.x[1]), "f"(frag.x[2]), "f"(frag.x[3]),
-              "f"(frag.x[4]), "f"(frag.x[5]), "f"(frag.x[6]), "f"(frag.x[7]),
-              "r"(ldm)
-            : "memory"
-        );
-    } else {
-        asm volatile(
-            "wmma.store.d.sync.aligned.col.m32n8k16.f32 "
-            "[%0], {%1,%2,%3,%4,%5,%6,%7,%8}, %9;"
-            :
-            : "l"(smem_ptr),
-              "f"(frag.x[0]), "f"(frag.x[1]), "f"(frag.x[2]), "f"(frag.x[3]),
-              "f"(frag.x[4]), "f"(frag.x[5]), "f"(frag.x[6]), "f"(frag.x[7]),
-              "r"(ldm)
-            : "memory"
-        );
-    }
+  if (layout == mem_row_major) {
+    asm volatile(
+        "wmma.store.d.sync.aligned.row.m32n8k16.f32 "
+        "[%0], {%1,%2,%3,%4,%5,%6,%7,%8}, %9;"
+        :
+        : "l"(smem_ptr), "f"(frag.x[0]), "f"(frag.x[1]), "f"(frag.x[2]),
+          "f"(frag.x[3]), "f"(frag.x[4]), "f"(frag.x[5]), "f"(frag.x[6]),
+          "f"(frag.x[7]), "r"(ldm)
+        : "memory");
+  } else {
+    asm volatile(
+        "wmma.store.d.sync.aligned.col.m32n8k16.f32 "
+        "[%0], {%1,%2,%3,%4,%5,%6,%7,%8}, %9;"
+        :
+        : "l"(smem_ptr), "f"(frag.x[0]), "f"(frag.x[1]), "f"(frag.x[2]),
+          "f"(frag.x[3]), "f"(frag.x[4]), "f"(frag.x[5]), "f"(frag.x[6]),
+          "f"(frag.x[7]), "r"(ldm)
+        : "memory");
+  }
 }
 
 __device__ __forceinline__ void store_matrix_sync(
-    float* smem_ptr,
-    const fragment<accumulator, 8, 32, 16, float>& frag,
+    float* smem_ptr, const fragment<accumulator, 8, 32, 16, float>& frag,
     unsigned ldm, layout_t layout) {
-    if (layout == mem_row_major) {
-        asm volatile(
-            "wmma.store.d.sync.aligned.row.m8n32k16.f32 "
-            "[%0], {%1,%2,%3,%4,%5,%6,%7,%8}, %9;"
-            :
-            : "l"(smem_ptr),
-              "f"(frag.x[0]), "f"(frag.x[1]), "f"(frag.x[2]), "f"(frag.x[3]),
-              "f"(frag.x[4]), "f"(frag.x[5]), "f"(frag.x[6]), "f"(frag.x[7]),
-              "r"(ldm)
-            : "memory"
-        );
-    } else {
-        asm volatile(
-            "wmma.store.d.sync.aligned.col.m8n32k16.f32 "
-            "[%0], {%1,%2,%3,%4,%5,%6,%7,%8}, %9;"
-            :
-            : "l"(smem_ptr),
-              "f"(frag.x[0]), "f"(frag.x[1]), "f"(frag.x[2]), "f"(frag.x[3]),
-              "f"(frag.x[4]), "f"(frag.x[5]), "f"(frag.x[6]), "f"(frag.x[7]),
-              "r"(ldm)
-            : "memory"
-        );
-    }
+  if (layout == mem_row_major) {
+    asm volatile(
+        "wmma.store.d.sync.aligned.row.m8n32k16.f32 "
+        "[%0], {%1,%2,%3,%4,%5,%6,%7,%8}, %9;"
+        :
+        : "l"(smem_ptr), "f"(frag.x[0]), "f"(frag.x[1]), "f"(frag.x[2]),
+          "f"(frag.x[3]), "f"(frag.x[4]), "f"(frag.x[5]), "f"(frag.x[6]),
+          "f"(frag.x[7]), "r"(ldm)
+        : "memory");
+  } else {
+    asm volatile(
+        "wmma.store.d.sync.aligned.col.m8n32k16.f32 "
+        "[%0], {%1,%2,%3,%4,%5,%6,%7,%8}, %9;"
+        :
+        : "l"(smem_ptr), "f"(frag.x[0]), "f"(frag.x[1]), "f"(frag.x[2]),
+          "f"(frag.x[3]), "f"(frag.x[4]), "f"(frag.x[5]), "f"(frag.x[6]),
+          "f"(frag.x[7]), "r"(ldm)
+        : "memory");
+  }
 }
 
-#define VOLTA_WMMA_MMA_F32(M, N, K, ALAY, BLAY) \
-__device__ __forceinline__ void mma_sync( \
-    fragment<accumulator, M, N, K, float>& d, \
-    const fragment<matrix_a, M, N, K, half, ALAY##_major>& a, \
-    const fragment<matrix_b, M, N, K, half, BLAY##_major>& b, \
-    const fragment<accumulator, M, N, K, float>& c) { \
-    asm volatile( \
-        "wmma.mma.sync.aligned." #ALAY "." #BLAY ".m" #M "n" #N "k" #K ".f32.f32 " \
-        "{%0,%1,%2,%3,%4,%5,%6,%7}, " \
-        "{%8,%9,%10,%11,%12,%13,%14,%15}, " \
-        "{%16,%17,%18,%19,%20,%21,%22,%23}, " \
-        "{%24,%25,%26,%27,%28,%29,%30,%31};" \
-        : "=f"(d.x[0]), "=f"(d.x[1]), "=f"(d.x[2]), "=f"(d.x[3]), \
-          "=f"(d.x[4]), "=f"(d.x[5]), "=f"(d.x[6]), "=f"(d.x[7]) \
-        : "r"(a.x[0]), "r"(a.x[1]), "r"(a.x[2]), "r"(a.x[3]), \
-          "r"(a.x[4]), "r"(a.x[5]), "r"(a.x[6]), "r"(a.x[7]), \
-          "r"(b.x[0]), "r"(b.x[1]), "r"(b.x[2]), "r"(b.x[3]), \
-          "r"(b.x[4]), "r"(b.x[5]), "r"(b.x[6]), "r"(b.x[7]), \
-          "f"(c.x[0]), "f"(c.x[1]), "f"(c.x[2]), "f"(c.x[3]), \
-          "f"(c.x[4]), "f"(c.x[5]), "f"(c.x[6]), "f"(c.x[7]) \
-    ); \
-}
+#define VOLTA_WMMA_MMA_F32(M, N, K, ALAY, BLAY)                            \
+  __device__ __forceinline__ void mma_sync(                                \
+      fragment<accumulator, M, N, K, float>& d,                            \
+      const fragment<matrix_a, M, N, K, half, ALAY##_major>& a,            \
+      const fragment<matrix_b, M, N, K, half, BLAY##_major>& b,            \
+      const fragment<accumulator, M, N, K, float>& c) {                    \
+    asm volatile(                                                          \
+        "wmma.mma.sync.aligned." #ALAY "." #BLAY ".m" #M "n" #N "k" #K     \
+        ".f32.f32 "                                                        \
+        "{%0,%1,%2,%3,%4,%5,%6,%7}, "                                      \
+        "{%8,%9,%10,%11,%12,%13,%14,%15}, "                                \
+        "{%16,%17,%18,%19,%20,%21,%22,%23}, "                              \
+        "{%24,%25,%26,%27,%28,%29,%30,%31};"                               \
+        : "=f"(d.x[0]), "=f"(d.x[1]), "=f"(d.x[2]), "=f"(d.x[3]),          \
+          "=f"(d.x[4]), "=f"(d.x[5]), "=f"(d.x[6]), "=f"(d.x[7])           \
+        : "r"(a.x[0]), "r"(a.x[1]), "r"(a.x[2]), "r"(a.x[3]), "r"(a.x[4]), \
+          "r"(a.x[5]), "r"(a.x[6]), "r"(a.x[7]), "r"(b.x[0]), "r"(b.x[1]), \
+          "r"(b.x[2]), "r"(b.x[3]), "r"(b.x[4]), "r"(b.x[5]), "r"(b.x[6]), \
+          "r"(b.x[7]), "f"(c.x[0]), "f"(c.x[1]), "f"(c.x[2]), "f"(c.x[3]), \
+          "f"(c.x[4]), "f"(c.x[5]), "f"(c.x[6]), "f"(c.x[7]));             \
+  }
 
 VOLTA_WMMA_MMA_F32(16, 16, 16, row, col)
 VOLTA_WMMA_MMA_F32(16, 16, 16, row, row)
@@ -412,6 +436,6 @@ VOLTA_WMMA_MMA_F32(8, 32, 16, col, row)
 
 #undef VOLTA_WMMA_MMA_F32
 
-}
+}  // namespace volta
 
 #endif

--- a/flash-attention-v100/kernel/contiguous_to_paged.cu
+++ b/flash-attention-v100/kernel/contiguous_to_paged.cu
@@ -4,89 +4,72 @@
 #include <torch/extension.h>
 
 __global__ void contiguous_to_paged_kernel(
-    const __half* __restrict__ key,
-    const __half* __restrict__ value,
-    const int64_t* __restrict__ slot_mapping,
-          __half* __restrict__ key_cache,
-          __half* __restrict__ value_cache,
-    const int64_t key_stride,
-    const int64_t value_stride,
-    const int64_t block_stride,
-    const int64_t page_stride,
-    const int64_t head_stride,
-    const int block_size,
-    const int num_heads,
-    const int head_dim
-) {
+    const __half* __restrict__ key, const __half* __restrict__ value,
+    const int64_t* __restrict__ slot_mapping, __half* __restrict__ key_cache,
+    __half* __restrict__ value_cache, const int64_t key_stride,
+    const int64_t value_stride, const int64_t block_stride,
+    const int64_t page_stride, const int64_t head_stride, const int block_size,
+    const int num_heads, const int head_dim) {
+  const int token_idx = blockIdx.x;
+  const int64_t slot_idx = slot_mapping[token_idx];
 
-    const int token_idx = blockIdx.x;
-    const int64_t slot_idx = slot_mapping[token_idx];
+  if (slot_idx < 0) {
+    return;
+  }
 
-    if (slot_idx < 0) {
-        return;
+  const int64_t block_idx = slot_idx / block_size;
+  const int64_t block_offset = slot_idx % block_size;
+
+  const int tid = threadIdx.x;
+  const int num_threads = blockDim.x;
+
+  const __half* __restrict__ key_src = key + token_idx * key_stride;
+  const __half* __restrict__ value_src = value + token_idx * value_stride;
+
+  __half* __restrict__ key_dst =
+      key_cache + block_idx * block_stride + block_offset * page_stride;
+  __half* __restrict__ value_dst =
+      value_cache + block_idx * block_stride + block_offset * page_stride;
+
+  for (int head_idx = 0; head_idx < num_heads; head_idx++) {
+    const __half* key_head_src = key_src + head_idx * head_dim;
+    const __half* value_head_src = value_src + head_idx * head_dim;
+    __half* key_head_dst = key_dst + head_idx * head_stride;
+    __half* value_head_dst = value_dst + head_idx * head_stride;
+
+    for (int elem_idx = tid; elem_idx < head_dim; elem_idx += num_threads) {
+      key_head_dst[elem_idx] = key_head_src[elem_idx];
+      value_head_dst[elem_idx] = value_head_src[elem_idx];
     }
-
-    const int64_t block_idx = slot_idx / block_size;
-    const int64_t block_offset = slot_idx % block_size;
-
-    const int tid = threadIdx.x;
-    const int num_threads = blockDim.x;
-
-    const __half* __restrict__ key_src = key + token_idx * key_stride;
-    const __half* __restrict__ value_src = value + token_idx * value_stride;
-
-    __half* __restrict__ key_dst = key_cache + block_idx * block_stride + block_offset * page_stride;
-    __half* __restrict__ value_dst = value_cache + block_idx * block_stride + block_offset * page_stride;
-
-    for (int head_idx = 0; head_idx < num_heads; head_idx++) {
-        const __half* key_head_src = key_src + head_idx * head_dim;
-        const __half* value_head_src = value_src + head_idx * head_dim;
-        __half* key_head_dst = key_dst + head_idx * head_stride;
-        __half* value_head_dst = value_dst + head_idx * head_stride;
-
-        for (int elem_idx = tid; elem_idx < head_dim; elem_idx += num_threads) {
-            key_head_dst[elem_idx] = key_head_src[elem_idx];
-            value_head_dst[elem_idx] = value_head_src[elem_idx];
-        }
-    }
+  }
 }
 
-void contiguous_to_paged(
-    torch::Tensor key,
-    torch::Tensor value,
-    torch::Tensor slot_mapping,
-    torch::Tensor key_cache,
-    torch::Tensor value_cache
-) {
-    const int num_tokens = slot_mapping.size(0);
-    const int num_heads = key.size(1);
-    const int head_dim = key.size(2);
-    const int block_size = key_cache.size(1);
+void contiguous_to_paged(torch::Tensor key, torch::Tensor value,
+                         torch::Tensor slot_mapping, torch::Tensor key_cache,
+                         torch::Tensor value_cache) {
+  const int num_tokens = slot_mapping.size(0);
+  const int num_heads = key.size(1);
+  const int head_dim = key.size(2);
+  const int block_size = key_cache.size(1);
 
-    const int64_t key_stride = key.stride(0);
-    const int64_t value_stride = value.stride(0);
-    const int64_t block_stride = key_cache.stride(0);
-    const int64_t page_stride = key_cache.stride(1);
-    const int64_t head_stride = key_cache.stride(2);
+  const int64_t key_stride = key.stride(0);
+  const int64_t value_stride = value.stride(0);
+  const int64_t block_stride = key_cache.stride(0);
+  const int64_t page_stride = key_cache.stride(1);
+  const int64_t head_stride = key_cache.stride(2);
 
-    const int threads = 256;
-    contiguous_to_paged_kernel<<<num_tokens, threads>>>(
-        reinterpret_cast<const __half*>(key.data_ptr<at::Half>()),
-        reinterpret_cast<const __half*>(value.data_ptr<at::Half>()),
-        slot_mapping.data_ptr<int64_t>(),
-        reinterpret_cast<__half*>(key_cache.data_ptr<at::Half>()),
-        reinterpret_cast<__half*>(value_cache.data_ptr<at::Half>()),
-        key_stride,
-        value_stride,
-        block_stride,
-        page_stride,
-        head_stride,
-        block_size,
-        num_heads,
-        head_dim
-    );
+  const int threads = 256;
+  contiguous_to_paged_kernel<<<num_tokens, threads>>>(
+      reinterpret_cast<const __half*>(key.data_ptr<at::Half>()),
+      reinterpret_cast<const __half*>(value.data_ptr<at::Half>()),
+      slot_mapping.data_ptr<int64_t>(),
+      reinterpret_cast<__half*>(key_cache.data_ptr<at::Half>()),
+      reinterpret_cast<__half*>(value_cache.data_ptr<at::Half>()), key_stride,
+      value_stride, block_stride, page_stride, head_stride, block_size,
+      num_heads, head_dim);
 }
 
 PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
-    m.def("contiguous_to_paged", &contiguous_to_paged, "Contiguous K/V to Paged KV Cache");
+  m.def("contiguous_to_paged", &contiguous_to_paged,
+        "Contiguous K/V to Paged KV Cache");
 }

--- a/flash-attention-v100/kernel/flash_decode_turboquant.cu
+++ b/flash-attention-v100/kernel/flash_decode_turboquant.cu
@@ -14,7 +14,7 @@ constexpr int kThreadsPerBlock = 256;
 constexpr int kWarpsPerBlock = kThreadsPerBlock / kWarpSize;
 
 __device__ __forceinline__ float warp_reduce_sum(float val) {
-  #pragma unroll
+#pragma unroll
   for (int offset = kWarpSize / 2; offset > 0; offset /= 2) {
     val += __shfl_down_sync(0xffffffff, val, offset);
   }
@@ -22,14 +22,14 @@ __device__ __forceinline__ float warp_reduce_sum(float val) {
 }
 
 __device__ __forceinline__ float warp_reduce_max(float val) {
-  #pragma unroll
+#pragma unroll
   for (int offset = kWarpSize / 2; offset > 0; offset /= 2) {
     val = fmaxf(val, __shfl_down_sync(0xffffffff, val, offset));
   }
   return val;
 }
 
-template<int NUM_WARPS>
+template <int NUM_WARPS>
 __device__ __forceinline__ float block_reduce_sum(float val) {
   __shared__ float shared[NUM_WARPS];
   __shared__ float result;
@@ -53,7 +53,7 @@ __device__ __forceinline__ float block_reduce_sum(float val) {
   return result;
 }
 
-template<int NUM_WARPS>
+template <int NUM_WARPS>
 __device__ __forceinline__ float block_reduce_max(float val) {
   __shared__ float shared[NUM_WARPS];
   __shared__ float result;
@@ -77,32 +77,28 @@ __device__ __forceinline__ float block_reduce_max(float val) {
   return result;
 }
 
-__device__ __forceinline__ uint16_t load_u16_le(
-    const uint8_t* __restrict__ data,
-    const int64_t byte_index) {
+__device__ __forceinline__ uint16_t
+load_u16_le(const uint8_t* __restrict__ data, const int64_t byte_index) {
   return static_cast<uint16_t>(data[byte_index]) |
          (static_cast<uint16_t>(data[byte_index + 1]) << 8);
 }
 
 __device__ __forceinline__ float load_f16_le_float(
-    const uint8_t* __restrict__ data,
-    const int64_t byte_index) {
+    const uint8_t* __restrict__ data, const int64_t byte_index) {
   return __half2float(__ushort_as_half(load_u16_le(data, byte_index)));
 }
 
-template<int D, int MSE_BITS, bool NORM_CORRECTION>
+template <int D, int MSE_BITS, bool NORM_CORRECTION>
 __device__ __forceinline__ float dot_qk_turboquant_mse(
-    const float* __restrict__ q_rot,
-    const uint8_t* __restrict__ kv_cache,
-    const int64_t slot_base,
-    const float* __restrict__ centroids,
+    const float* __restrict__ q_rot, const uint8_t* __restrict__ kv_cache,
+    const int64_t slot_base, const float* __restrict__ centroids,
     const int lane) {
   constexpr int kMseBytes = (D * MSE_BITS + 7) / 8;
   constexpr int kMseMask = (1 << MSE_BITS) - 1;
 
   float acc = 0.f;
   float centroid_norm_sq = 0.f;
-  #pragma unroll
+#pragma unroll
   for (int d = lane; d < D; d += kWarpSize) {
     const int bit_offset = d * MSE_BITS;
     const int byte_offset = bit_offset >> 3;
@@ -126,10 +122,9 @@ __device__ __forceinline__ float dot_qk_turboquant_mse(
   return acc * vec_norm;
 }
 
-template<int D, int MSE_BITS, int VQB>
+template <int D, int MSE_BITS, int VQB>
 __device__ __forceinline__ float load_turboquant_value_float(
-    const uint8_t* __restrict__ kv_cache,
-    const int64_t slot_base,
+    const uint8_t* __restrict__ kv_cache, const int64_t slot_base,
     const int d) {
   constexpr int kMseBytes = (D * MSE_BITS + 7) / 8;
   constexpr int kKeyPackedSize = kMseBytes + 2;
@@ -154,32 +149,20 @@ __device__ __forceinline__ float load_turboquant_value_float(
   return static_cast<float>(q_value) * scale + zero;
 }
 
-template<int D, int PARTITION_SIZE, int MSE_BITS, int VQB, bool NORM_CORRECTION>
+template <int D, int PARTITION_SIZE, int MSE_BITS, int VQB,
+          bool NORM_CORRECTION>
 __global__ void flash_attention_turboquant_decode_partition_kernel(
-    const float* __restrict__ q_rot,
-    const uint8_t* __restrict__ kv_cache,
-    float* __restrict__ tmp_out,
-    float* __restrict__ max_logits,
-    float* __restrict__ exp_sums,
-    const int* __restrict__ block_table,
-    const int* __restrict__ seq_lens,
-    const float* __restrict__ centroids,
-    const int batch_size,
-    const int max_num_blocks,
-    const int max_num_partitions,
-    const int num_heads_q,
-    const int num_heads_kv,
-    const int block_size,
-    const int64_t q_stride0,
-    const int64_t q_stride1,
-    const int64_t tmp_out_stride0,
-    const int64_t tmp_out_stride1,
-    const int64_t tmp_out_stride2,
-    const int64_t stats_stride0,
-    const int64_t stats_stride1,
-    const int64_t cache_block_stride,
-    const int64_t cache_token_stride,
-    const int64_t cache_head_stride,
+    const float* __restrict__ q_rot, const uint8_t* __restrict__ kv_cache,
+    float* __restrict__ tmp_out, float* __restrict__ max_logits,
+    float* __restrict__ exp_sums, const int* __restrict__ block_table,
+    const int* __restrict__ seq_lens, const float* __restrict__ centroids,
+    const int batch_size, const int max_num_blocks,
+    const int max_num_partitions, const int num_heads_q, const int num_heads_kv,
+    const int block_size, const int64_t q_stride0, const int64_t q_stride1,
+    const int64_t tmp_out_stride0, const int64_t tmp_out_stride1,
+    const int64_t tmp_out_stride2, const int64_t stats_stride0,
+    const int64_t stats_stride1, const int64_t cache_block_stride,
+    const int64_t cache_token_stride, const int64_t cache_head_stride,
     const float softmax_scale) {
   const int batch_idx = blockIdx.x;
   const int head_idx = blockIdx.y;
@@ -191,8 +174,7 @@ __global__ void flash_attention_turboquant_decode_partition_kernel(
   }
 
   const int seq_len = seq_lens[batch_idx];
-  const int split_len =
-      (seq_len + max_num_partitions - 1) / max_num_partitions;
+  const int split_len = (seq_len + max_num_partitions - 1) / max_num_partitions;
   const int start_token_idx = partition_idx * split_len;
   if (seq_len <= 0 || start_token_idx >= seq_len) {
     return;
@@ -268,8 +250,8 @@ __global__ void flash_attention_turboquant_decode_partition_kernel(
           static_cast<int64_t>(physical_block) * cache_block_stride +
           static_cast<int64_t>(block_offset) * cache_token_stride +
           static_cast<int64_t>(kv_head_idx) * cache_head_stride;
-      const float value = load_turboquant_value_float<D, MSE_BITS, VQB>(
-          kv_cache, slot_base, d);
+      const float value =
+          load_turboquant_value_float<D, MSE_BITS, VQB>(kv_cache, slot_base, d);
       acc = fmaf(scores_shared[i], value, acc);
     }
     tmp_out[tmp_out_base + d] = acc * inv_part_sum;
@@ -284,22 +266,15 @@ __global__ void flash_attention_turboquant_decode_partition_kernel(
   }
 }
 
-template<int D, int PARTITION_SIZE>
+template <int D, int PARTITION_SIZE>
 __global__ void flash_attention_turboquant_decode_reduce_kernel(
-    const float* __restrict__ tmp_out,
-    const float* __restrict__ max_logits,
-    const float* __restrict__ exp_sums,
-    const int* __restrict__ seq_lens,
-    __half* __restrict__ out,
-    const int batch_size,
-    const int max_num_partitions,
-    const int num_heads_q,
-    const int64_t tmp_out_stride0,
-    const int64_t tmp_out_stride1,
-    const int64_t tmp_out_stride2,
-    const int64_t stats_stride0,
-    const int64_t stats_stride1,
-    const int64_t out_stride0,
+    const float* __restrict__ tmp_out, const float* __restrict__ max_logits,
+    const float* __restrict__ exp_sums, const int* __restrict__ seq_lens,
+    __half* __restrict__ out, const int batch_size,
+    const int max_num_partitions, const int num_heads_q,
+    const int64_t tmp_out_stride0, const int64_t tmp_out_stride1,
+    const int64_t tmp_out_stride2, const int64_t stats_stride0,
+    const int64_t stats_stride1, const int64_t out_stride0,
     const int64_t out_stride1) {
   const int batch_idx = blockIdx.x;
   const int head_idx = blockIdx.y;
@@ -313,13 +288,11 @@ __global__ void flash_attention_turboquant_decode_reduce_kernel(
   if (seq_len <= 0) {
     for (int d = threadIdx.x; d < D; d += blockDim.x) {
       out[static_cast<int64_t>(batch_idx) * out_stride0 +
-          static_cast<int64_t>(head_idx) * out_stride1 + d] =
-          __float2half(0.f);
+          static_cast<int64_t>(head_idx) * out_stride1 + d] = __float2half(0.f);
     }
     return;
   }
-  const int split_len =
-      (seq_len + max_num_partitions - 1) / max_num_partitions;
+  const int split_len = (seq_len + max_num_partitions - 1) / max_num_partitions;
   const int num_partitions = (seq_len + split_len - 1) / split_len;
 
   extern __shared__ float shared_mem[];
@@ -342,7 +315,8 @@ __global__ void flash_attention_turboquant_decode_reduce_kernel(
     const int64_t stats_index =
         static_cast<int64_t>(batch_idx) * stats_stride0 +
         static_cast<int64_t>(head_idx) * stats_stride1 + i;
-    const float weight = exp_sums[stats_index] * __expf(max_shared[i] - global_max);
+    const float weight =
+        exp_sums[stats_index] * __expf(max_shared[i] - global_max);
     weight_shared[i] = weight;
     local_sum += weight;
   }
@@ -350,9 +324,8 @@ __global__ void flash_attention_turboquant_decode_reduce_kernel(
   const float inv_global_sum = global_sum > 0.f ? 1.f / global_sum : 0.f;
   __syncthreads();
 
-  const int64_t out_base =
-      static_cast<int64_t>(batch_idx) * out_stride0 +
-      static_cast<int64_t>(head_idx) * out_stride1;
+  const int64_t out_base = static_cast<int64_t>(batch_idx) * out_stride0 +
+                           static_cast<int64_t>(head_idx) * out_stride1;
   const int64_t tmp_out_base =
       static_cast<int64_t>(batch_idx) * tmp_out_stride0 +
       static_cast<int64_t>(head_idx) * tmp_out_stride1;
@@ -369,18 +342,13 @@ __global__ void flash_attention_turboquant_decode_reduce_kernel(
   }
 }
 
-template<int D, int PARTITION_SIZE, int MSE_BITS, int VQB, bool NORM_CORRECTION>
+template <int D, int PARTITION_SIZE, int MSE_BITS, int VQB,
+          bool NORM_CORRECTION>
 void launch_flash_attention_turboquant_decode_paged(
-    const at::Tensor& q_rot,
-    const at::Tensor& kv_cache,
-    at::Tensor& out,
-    const at::Tensor& block_table,
-    const at::Tensor& seq_lens,
-    at::Tensor& tmp_out,
-    at::Tensor& max_logits,
-    at::Tensor& exp_sums,
-    const at::Tensor& centroids,
-    const float softmax_scale,
+    const at::Tensor& q_rot, const at::Tensor& kv_cache, at::Tensor& out,
+    const at::Tensor& block_table, const at::Tensor& seq_lens,
+    at::Tensor& tmp_out, at::Tensor& max_logits, at::Tensor& exp_sums,
+    const at::Tensor& centroids, const float softmax_scale,
     cudaStream_t stream) {
   const int batch_size = q_rot.size(0);
   const int num_heads_q = q_rot.size(1);
@@ -398,68 +366,35 @@ void launch_flash_attention_turboquant_decode_paged(
   flash_attention_turboquant_decode_partition_kernel<
       D, PARTITION_SIZE, MSE_BITS, VQB, NORM_CORRECTION>
       <<<partition_grid, block, 0, stream>>>(
-      q_rot.data_ptr<float>(),
-      kv_cache.data_ptr<uint8_t>(),
-      tmp_out.data_ptr<float>(),
-      max_logits.data_ptr<float>(),
-      exp_sums.data_ptr<float>(),
-      block_table.data_ptr<int>(),
-      seq_lens.data_ptr<int>(),
-      centroids.data_ptr<float>(),
-      batch_size,
-      max_num_blocks,
-      max_num_partitions,
-      num_heads_q,
-      num_heads_kv,
-      block_size,
-      q_rot.stride(0),
-      q_rot.stride(1),
-      tmp_out.stride(0),
-      tmp_out.stride(1),
-      tmp_out.stride(2),
-      max_logits.stride(0),
-      max_logits.stride(1),
-      kv_cache.stride(0),
-      kv_cache.stride(1),
-      kv_cache.stride(2),
-      softmax_scale);
+          q_rot.data_ptr<float>(), kv_cache.data_ptr<uint8_t>(),
+          tmp_out.data_ptr<float>(), max_logits.data_ptr<float>(),
+          exp_sums.data_ptr<float>(), block_table.data_ptr<int>(),
+          seq_lens.data_ptr<int>(), centroids.data_ptr<float>(), batch_size,
+          max_num_blocks, max_num_partitions, num_heads_q, num_heads_kv,
+          block_size, q_rot.stride(0), q_rot.stride(1), tmp_out.stride(0),
+          tmp_out.stride(1), tmp_out.stride(2), max_logits.stride(0),
+          max_logits.stride(1), kv_cache.stride(0), kv_cache.stride(1),
+          kv_cache.stride(2), softmax_scale);
 
   flash_attention_turboquant_decode_reduce_kernel<D, PARTITION_SIZE>
       <<<reduce_grid, block, reduce_shared_mem, stream>>>(
-      tmp_out.data_ptr<float>(),
-      max_logits.data_ptr<float>(),
-      exp_sums.data_ptr<float>(),
-      seq_lens.data_ptr<int>(),
-      reinterpret_cast<__half*>(out.data_ptr<at::Half>()),
-      batch_size,
-      max_num_partitions,
-      num_heads_q,
-      tmp_out.stride(0),
-      tmp_out.stride(1),
-      tmp_out.stride(2),
-      max_logits.stride(0),
-      max_logits.stride(1),
-      out.stride(0),
-      out.stride(1));
+          tmp_out.data_ptr<float>(), max_logits.data_ptr<float>(),
+          exp_sums.data_ptr<float>(), seq_lens.data_ptr<int>(),
+          reinterpret_cast<__half*>(out.data_ptr<at::Half>()), batch_size,
+          max_num_partitions, num_heads_q, tmp_out.stride(0), tmp_out.stride(1),
+          tmp_out.stride(2), max_logits.stride(0), max_logits.stride(1),
+          out.stride(0), out.stride(1));
 }
 
 }  // namespace
 
 at::Tensor flash_attention_turboquant_decode_paged(
-    const at::Tensor& q_rot,
-    const at::Tensor& kv_cache,
-    std::optional<at::Tensor>& out_,
-    const at::Tensor& block_table,
-    const at::Tensor& seq_lens,
-    at::Tensor& tmp_out,
-    at::Tensor& max_logits,
-    at::Tensor& exp_sums,
-    const at::Tensor& centroids,
-    const float softmax_scale,
-    const int partition_size,
-    const int mse_bits,
-    const int value_quant_bits,
-    const bool norm_correction) {
+    const at::Tensor& q_rot, const at::Tensor& kv_cache,
+    std::optional<at::Tensor>& out_, const at::Tensor& block_table,
+    const at::Tensor& seq_lens, at::Tensor& tmp_out, at::Tensor& max_logits,
+    at::Tensor& exp_sums, const at::Tensor& centroids,
+    const float softmax_scale, const int partition_size, const int mse_bits,
+    const int value_quant_bits, const bool norm_correction) {
   TORCH_CHECK(q_rot.is_cuda(), "q_rot must be on CUDA");
   TORCH_CHECK(kv_cache.is_cuda(), "kv_cache must be on CUDA");
   TORCH_CHECK(block_table.is_cuda() && seq_lens.is_cuda(),
@@ -474,7 +409,8 @@ at::Tensor flash_attention_turboquant_decode_paged(
   TORCH_CHECK(tmp_out.dtype() == torch::kFloat32, "tmp_out must be fp32");
   TORCH_CHECK(max_logits.dtype() == torch::kFloat32, "max_logits must be fp32");
   TORCH_CHECK(exp_sums.dtype() == torch::kFloat32, "exp_sums must be fp32");
-  TORCH_CHECK(block_table.dtype() == torch::kInt32, "block_table must be int32");
+  TORCH_CHECK(block_table.dtype() == torch::kInt32,
+              "block_table must be int32");
   TORCH_CHECK(seq_lens.dtype() == torch::kInt32, "seq_lens must be int32");
   TORCH_CHECK(q_rot.dim() == 3, "q_rot must have shape [B, H, D]");
   TORCH_CHECK(kv_cache.dim() == 4,
@@ -483,7 +419,8 @@ at::Tensor flash_attention_turboquant_decode_paged(
               "block_table must have shape [B, max_num_blocks]");
   TORCH_CHECK(seq_lens.dim() == 1, "seq_lens must have shape [B]");
   TORCH_CHECK(tmp_out.dim() == 4, "tmp_out must have shape [B_cap, H, P, D]");
-  TORCH_CHECK(max_logits.dim() == 3, "max_logits must have shape [B_cap, H, P]");
+  TORCH_CHECK(max_logits.dim() == 3,
+              "max_logits must have shape [B_cap, H, P]");
   TORCH_CHECK(exp_sums.dim() == 3, "exp_sums must have shape [B_cap, H, P]");
   TORCH_CHECK(q_rot.stride(-1) == 1, "q_rot last dim must be contiguous");
   TORCH_CHECK(kv_cache.stride(-1) == 1, "kv_cache last dim must be contiguous");
@@ -500,23 +437,26 @@ at::Tensor flash_attention_turboquant_decode_paged(
               "seq_lens batch size must cover q_rot batch size");
   TORCH_CHECK(q_rot.size(0) <= tmp_out.size(0),
               "tmp_out batch size must cover q_rot batch size");
-  TORCH_CHECK(num_heads_q == tmp_out.size(1), "tmp_out head dimension mismatch");
+  TORCH_CHECK(num_heads_q == tmp_out.size(1),
+              "tmp_out head dimension mismatch");
   TORCH_CHECK(head_dim == tmp_out.size(3), "tmp_out head_dim mismatch");
   TORCH_CHECK(max_logits.size(0) == tmp_out.size(0) &&
                   max_logits.size(1) == tmp_out.size(1) &&
                   max_logits.size(2) == tmp_out.size(2),
               "max_logits shape mismatch");
-  TORCH_CHECK(exp_sums.sizes() == max_logits.sizes(), "exp_sums shape mismatch");
+  TORCH_CHECK(exp_sums.sizes() == max_logits.sizes(),
+              "exp_sums shape mismatch");
   TORCH_CHECK(num_heads_q % num_heads_kv == 0,
               "num_heads_q must be divisible by num_heads_kv");
-  TORCH_CHECK(partition_size == 256 || partition_size == 512 ||
-                  partition_size == 1024,
-              "Unsupported decode partition_size: ", partition_size);
   TORCH_CHECK(
-      block_table.size(1) * kv_cache.size(1) <= partition_size * tmp_out.size(2),
-      "TurboQuant decode workspace cannot cover block_table capacity");
-  TORCH_CHECK(mse_bits == 3 || mse_bits == 4,
-              "TurboQuant Flash-V100 decode currently supports 3/4-bit MSE keys");
+      partition_size == 256 || partition_size == 512 || partition_size == 1024,
+      "Unsupported decode partition_size: ", partition_size);
+  TORCH_CHECK(block_table.size(1) * kv_cache.size(1) <=
+                  partition_size * tmp_out.size(2),
+              "TurboQuant decode workspace cannot cover block_table capacity");
+  TORCH_CHECK(
+      mse_bits == 3 || mse_bits == 4,
+      "TurboQuant Flash-V100 decode currently supports 3/4-bit MSE keys");
   TORCH_CHECK(value_quant_bits == 3 || value_quant_bits == 4,
               "TurboQuant Flash-V100 decode currently supports 3/4-bit values");
   TORCH_CHECK(centroids.numel() >= (1 << mse_bits),
@@ -537,65 +477,67 @@ at::Tensor flash_attention_turboquant_decode_paged(
   auto stream = at::cuda::getCurrentCUDAStream().stream();
   c10::cuda::CUDAGuard device_guard(q_rot.device());
 
-  #define LAUNCH_TYPED(HDIM, PARTITION, MSE, VBITS, NC)                       \
-    launch_flash_attention_turboquant_decode_paged<HDIM, PARTITION, MSE,      \
-                                                    VBITS, NC>(               \
-        q_rot, kv_cache, out, block_table, seq_lens, tmp_out, max_logits,      \
-        exp_sums, centroids, softmax_scale, stream)
+#define LAUNCH_TYPED(HDIM, PARTITION, MSE, VBITS, NC)                         \
+  launch_flash_attention_turboquant_decode_paged<HDIM, PARTITION, MSE, VBITS, \
+                                                 NC>(                         \
+      q_rot, kv_cache, out, block_table, seq_lens, tmp_out, max_logits,       \
+      exp_sums, centroids, softmax_scale, stream)
 
-  #define LAUNCH_BY_NORM(HDIM, PARTITION, MSE, VBITS)                         \
-    do {                                                                      \
-      if (norm_correction) {                                                  \
-        LAUNCH_TYPED(HDIM, PARTITION, MSE, VBITS, true);                      \
-      } else {                                                                \
-        LAUNCH_TYPED(HDIM, PARTITION, MSE, VBITS, false);                     \
-      }                                                                       \
-    } while (0)
+#define LAUNCH_BY_NORM(HDIM, PARTITION, MSE, VBITS)     \
+  do {                                                  \
+    if (norm_correction) {                              \
+      LAUNCH_TYPED(HDIM, PARTITION, MSE, VBITS, true);  \
+    } else {                                            \
+      LAUNCH_TYPED(HDIM, PARTITION, MSE, VBITS, false); \
+    }                                                   \
+  } while (0)
 
-  #define LAUNCH_BY_VALUE(HDIM, PARTITION, MSE)                               \
-    do {                                                                      \
-      switch (value_quant_bits) {                                             \
-        case 3:                                                               \
-          LAUNCH_BY_NORM(HDIM, PARTITION, MSE, 3);                            \
-          break;                                                              \
-        case 4:                                                               \
-          LAUNCH_BY_NORM(HDIM, PARTITION, MSE, 4);                            \
-          break;                                                              \
-        default:                                                              \
-          TORCH_CHECK(false, "Unsupported value_quant_bits: ", value_quant_bits); \
-      }                                                                       \
-    } while (0)
+#define LAUNCH_BY_VALUE(HDIM, PARTITION, MSE)                            \
+  do {                                                                   \
+    switch (value_quant_bits) {                                          \
+      case 3:                                                            \
+        LAUNCH_BY_NORM(HDIM, PARTITION, MSE, 3);                         \
+        break;                                                           \
+      case 4:                                                            \
+        LAUNCH_BY_NORM(HDIM, PARTITION, MSE, 4);                         \
+        break;                                                           \
+      default:                                                           \
+        TORCH_CHECK(false,                                               \
+                    "Unsupported value_quant_bits: ", value_quant_bits); \
+    }                                                                    \
+  } while (0)
 
-  #define LAUNCH_BY_MSE(HDIM, PARTITION)                                      \
-    do {                                                                      \
-      switch (mse_bits) {                                                     \
-        case 3:                                                               \
-          LAUNCH_BY_VALUE(HDIM, PARTITION, 3);                                \
-          break;                                                              \
-        case 4:                                                               \
-          LAUNCH_BY_VALUE(HDIM, PARTITION, 4);                                \
-          break;                                                              \
-        default:                                                              \
-          TORCH_CHECK(false, "Unsupported mse_bits: ", mse_bits);            \
-      }                                                                       \
-    } while (0)
+#define LAUNCH_BY_MSE(HDIM, PARTITION)                          \
+  do {                                                          \
+    switch (mse_bits) {                                         \
+      case 3:                                                   \
+        LAUNCH_BY_VALUE(HDIM, PARTITION, 3);                    \
+        break;                                                  \
+      case 4:                                                   \
+        LAUNCH_BY_VALUE(HDIM, PARTITION, 4);                    \
+        break;                                                  \
+      default:                                                  \
+        TORCH_CHECK(false, "Unsupported mse_bits: ", mse_bits); \
+    }                                                           \
+  } while (0)
 
-  #define LAUNCH_BY_PARTITION(HDIM)                                           \
-    do {                                                                      \
-      switch (partition_size) {                                               \
-        case 256:                                                             \
-          LAUNCH_BY_MSE(HDIM, 256);                                           \
-          break;                                                              \
-        case 512:                                                             \
-          LAUNCH_BY_MSE(HDIM, 512);                                           \
-          break;                                                              \
-        case 1024:                                                            \
-          LAUNCH_BY_MSE(HDIM, 1024);                                          \
-          break;                                                              \
-        default:                                                              \
-          TORCH_CHECK(false, "Unsupported decode partition_size: ", partition_size); \
-      }                                                                       \
-    } while (0)
+#define LAUNCH_BY_PARTITION(HDIM)                                           \
+  do {                                                                      \
+    switch (partition_size) {                                               \
+      case 256:                                                             \
+        LAUNCH_BY_MSE(HDIM, 256);                                           \
+        break;                                                              \
+      case 512:                                                             \
+        LAUNCH_BY_MSE(HDIM, 512);                                           \
+        break;                                                              \
+      case 1024:                                                            \
+        LAUNCH_BY_MSE(HDIM, 1024);                                          \
+        break;                                                              \
+      default:                                                              \
+        TORCH_CHECK(false,                                                  \
+                    "Unsupported decode partition_size: ", partition_size); \
+    }                                                                       \
+  } while (0)
 
   switch (head_dim) {
     case 64:
@@ -617,14 +559,15 @@ at::Tensor flash_attention_turboquant_decode_paged(
       LAUNCH_BY_PARTITION(256);
       break;
     default:
-      TORCH_CHECK(false, "Unsupported head_dim for TurboQuant paged decode: ", head_dim);
+      TORCH_CHECK(false, "Unsupported head_dim for TurboQuant paged decode: ",
+                  head_dim);
   }
 
-  #undef LAUNCH_BY_PARTITION
-  #undef LAUNCH_BY_MSE
-  #undef LAUNCH_BY_VALUE
-  #undef LAUNCH_BY_NORM
-  #undef LAUNCH_TYPED
+#undef LAUNCH_BY_PARTITION
+#undef LAUNCH_BY_MSE
+#undef LAUNCH_BY_VALUE
+#undef LAUNCH_BY_NORM
+#undef LAUNCH_TYPED
 
   C10_CUDA_KERNEL_LAUNCH_CHECK();
   return out;

--- a/flash-attention-v100/kernel/flash_v100_traits.cuh
+++ b/flash-attention-v100/kernel/flash_v100_traits.cuh
@@ -3,137 +3,116 @@
 #include <cuda.h>
 #include <cuda_runtime.h>
 
-template<int D>
+template <int D>
 struct FlashV100Traits {
+  static constexpr int BLOCK_M_16 = 16;
+  static constexpr int BLOCK_N_16 = 512;
+  static constexpr int BLOCK_M_32 = 32;
+  static constexpr int BLOCK_N_32 = 256;
+  static constexpr int BLOCK_M_64 = 64;
+  static constexpr int BLOCK_N_64 = 128;
+  static constexpr int BLOCK_M_128 = 32;
+  static constexpr int BLOCK_N_128 = 176;
+  static constexpr int BLOCK_M_256 = 32;
+  static constexpr int BLOCK_N_256 = 64;
+  static constexpr int WARPS_PER_BLOCK = 16;
+  static constexpr int THREADS_PER_WARP = 32;
 
-    static constexpr int BLOCK_M_16  = 16;
-    static constexpr int BLOCK_N_16  = 512;
-    static constexpr int BLOCK_M_32  = 32;
-    static constexpr int BLOCK_N_32  = 256;
-    static constexpr int BLOCK_M_64  = 64;
-    static constexpr int BLOCK_N_64  = 128;
-    static constexpr int BLOCK_M_128 = 32;
-    static constexpr int BLOCK_N_128 = 176;
-    static constexpr int BLOCK_M_256 = 32;
-    static constexpr int BLOCK_N_256 = 64;
-    static constexpr int WARPS_PER_BLOCK = 16;
-    static constexpr int THREADS_PER_WARP = 32;
+  static constexpr int BLOCK_M = (D == 16)    ? BLOCK_M_16
+                                 : (D == 32)  ? BLOCK_M_32
+                                 : (D == 64)  ? BLOCK_M_64
+                                 : (D == 128) ? BLOCK_M_128
+                                              : BLOCK_M_256;
 
-    static constexpr int BLOCK_M = (D == 16) ? BLOCK_M_16 :
-                                   (D == 32) ? BLOCK_M_32 :
-                                   (D == 64) ? BLOCK_M_64 :
-                                   (D == 128) ? BLOCK_M_128 : BLOCK_M_256;
+  static constexpr int BLOCK_N = (D == 16)    ? BLOCK_N_16
+                                 : (D == 32)  ? BLOCK_N_32
+                                 : (D == 64)  ? BLOCK_N_64
+                                 : (D == 128) ? BLOCK_N_128
+                                              : BLOCK_N_256;
 
-    static constexpr int BLOCK_N = (D == 16) ? BLOCK_N_16 :
-                                   (D == 32) ? BLOCK_N_32 :
-                                   (D == 64) ? BLOCK_N_64 :
-                                   (D == 128) ? BLOCK_N_128 : BLOCK_N_256;
+  static constexpr int THREADS_PER_BLOCK = WARPS_PER_BLOCK * THREADS_PER_WARP;
+  static constexpr int THREADS_PER_ROW = THREADS_PER_BLOCK / BLOCK_M;
 
-    static constexpr int THREADS_PER_BLOCK = WARPS_PER_BLOCK * THREADS_PER_WARP;
-    static constexpr int THREADS_PER_ROW = THREADS_PER_BLOCK / BLOCK_M;
+  static constexpr int kBlockM = BLOCK_M;
+  static constexpr int kBlockN = BLOCK_N;
+  static constexpr int kHeadDim = D;
 
-    static constexpr int kBlockM = BLOCK_M;
-    static constexpr int kBlockN = BLOCK_N;
-    static constexpr int kHeadDim = D;
+  static constexpr int kGmemThreadsPerRow = THREADS_PER_ROW;
+  static constexpr int kGmemRowsPerThread = 1;
+  static constexpr int kGmemElemsPerLoad = 8;
 
-    static constexpr int kGmemThreadsPerRow = THREADS_PER_ROW;
-    static constexpr int kGmemRowsPerThread = 1;
-    static constexpr int kGmemElemsPerLoad = 8;
-
-    static constexpr int PER_UINT4 = 8;
-    static constexpr int d_stride_uint4 = (D + PER_UINT4 - 1) / PER_UINT4;
+  static constexpr int PER_UINT4 = 8;
+  static constexpr int d_stride_uint4 = (D + PER_UINT4 - 1) / PER_UINT4;
 };
 
-template<typename Traits>
-__device__ __forceinline__
-int64_t resolve_thread_kv_page_slice_offset(
-    const int tidx,
-    const int n_block,
-    const int page_block_size,
-    const int* __restrict__ block_table,
-    const int page_stride,
-    const int row_stride,
-    const int partial_block_size = -1
-) {
-    constexpr int kGmemThreadsPerRow = Traits::kGmemThreadsPerRow;
-    constexpr int kGmemRowsPerThread = Traits::kGmemRowsPerThread;
-    constexpr int kGmemElemsPerLoad = Traits::kGmemElemsPerLoad;
-    constexpr int kBlockN = Traits::kBlockN;
+template <typename Traits>
+__device__ __forceinline__ int64_t resolve_thread_kv_page_slice_offset(
+    const int tidx, const int n_block, const int page_block_size,
+    const int* __restrict__ block_table, const int page_stride,
+    const int row_stride, const int partial_block_size = -1) {
+  constexpr int kGmemThreadsPerRow = Traits::kGmemThreadsPerRow;
+  constexpr int kGmemRowsPerThread = Traits::kGmemRowsPerThread;
+  constexpr int kGmemElemsPerLoad = Traits::kGmemElemsPerLoad;
+  constexpr int kBlockN = Traits::kBlockN;
 
-    const int64_t col_offset = (tidx % kGmemThreadsPerRow) * kGmemElemsPerLoad;
-    int64_t block_row_offset = (tidx / kGmemThreadsPerRow) * kGmemRowsPerThread;
+  const int64_t col_offset = (tidx % kGmemThreadsPerRow) * kGmemElemsPerLoad;
+  int64_t block_row_offset = (tidx / kGmemThreadsPerRow) * kGmemRowsPerThread;
 
-    if (partial_block_size > 0) {
-        const int final_row_offset = max(partial_block_size - 1, 0);
-        const int final_thread_row_offset =
-            ((final_row_offset + kGmemRowsPerThread - 1) / kGmemRowsPerThread) * kGmemRowsPerThread;
-        block_row_offset = min(block_row_offset, (int64_t)final_thread_row_offset);
-    }
+  if (partial_block_size > 0) {
+    const int final_row_offset = max(partial_block_size - 1, 0);
+    const int final_thread_row_offset =
+        ((final_row_offset + kGmemRowsPerThread - 1) / kGmemRowsPerThread) *
+        kGmemRowsPerThread;
+    block_row_offset = min(block_row_offset, (int64_t)final_thread_row_offset);
+  }
 
-    const int64_t global_row_offset = block_row_offset + n_block * kBlockN;
+  const int64_t global_row_offset = block_row_offset + n_block * kBlockN;
 
-    const int64_t page_offset = global_row_offset % page_block_size;
-    const int64_t virtual_page_idx = global_row_offset / page_block_size;
+  const int64_t page_offset = global_row_offset % page_block_size;
+  const int64_t virtual_page_idx = global_row_offset / page_block_size;
 
-    const int64_t physical_offset =
-        ((int64_t)block_table[virtual_page_idx]) * ((int64_t)page_stride)
-        + page_offset * ((int64_t)row_stride)
-        + col_offset;
+  const int64_t physical_offset =
+      ((int64_t)block_table[virtual_page_idx]) * ((int64_t)page_stride) +
+      page_offset * ((int64_t)row_stride) + col_offset;
 
-    return physical_offset;
+  return physical_offset;
 }
 
-template<typename Traits>
-__device__ __forceinline__
-void load_kv_tile_paged(
-    const __half* __restrict__ kv_cache,
-    const int* __restrict__ block_table,
-    const int start_token_idx,
-    const int num_tokens,
-    const int n_block,
-    const int page_block_size,
-    const int page_stride,
-    const int row_stride,
-    __half* smem_dst,
-    const int smem_stride,
-    const int tid,
-    const int num_threads,
-    const int partial_block_size = -1
-) {
-    constexpr int PER_UINT4 = Traits::PER_UINT4;
-    constexpr int d_stride_uint4 = Traits::d_stride_uint4;
-    constexpr int kBlockN = Traits::kBlockN;
+template <typename Traits>
+__device__ __forceinline__ void load_kv_tile_paged(
+    const __half* __restrict__ kv_cache, const int* __restrict__ block_table,
+    const int start_token_idx, const int num_tokens, const int n_block,
+    const int page_block_size, const int page_stride, const int row_stride,
+    __half* smem_dst, const int smem_stride, const int tid,
+    const int num_threads, const int partial_block_size = -1) {
+  constexpr int PER_UINT4 = Traits::PER_UINT4;
+  constexpr int d_stride_uint4 = Traits::d_stride_uint4;
+  constexpr int kBlockN = Traits::kBlockN;
 
-    const uint4* kv_vec = reinterpret_cast<const uint4*>(kv_cache);
-    uint4* smem_vec = reinterpret_cast<uint4*>(smem_dst);
-    const int smem_stride_uint4 = (smem_stride + PER_UINT4 - 1) / PER_UINT4;
+  const uint4* kv_vec = reinterpret_cast<const uint4*>(kv_cache);
+  uint4* smem_vec = reinterpret_cast<uint4*>(smem_dst);
+  const int smem_stride_uint4 = (smem_stride + PER_UINT4 - 1) / PER_UINT4;
 
-    #pragma unroll 2
-    for (int idx = tid; idx < (num_tokens * d_stride_uint4); idx += num_threads) {
-        const int token_offset = idx / d_stride_uint4;
-        const int vec_col = idx % d_stride_uint4;
+#pragma unroll 2
+  for (int idx = tid; idx < (num_tokens * d_stride_uint4); idx += num_threads) {
+    const int token_offset = idx / d_stride_uint4;
+    const int vec_col = idx % d_stride_uint4;
 
-        uint4 kv_val = make_uint4(0, 0, 0, 0);
+    uint4 kv_val = make_uint4(0, 0, 0, 0);
 
-        if (token_offset < num_tokens && vec_col < d_stride_uint4) {
+    if (token_offset < num_tokens && vec_col < d_stride_uint4) {
+      const int global_token_idx = start_token_idx + token_offset;
 
-            const int global_token_idx = start_token_idx + token_offset;
+      const int64_t physical_offset_halves =
+          resolve_thread_kv_page_slice_offset<Traits>(
+              tid, n_block, page_block_size, block_table, page_stride,
+              row_stride, partial_block_size);
 
-            const int64_t physical_offset_halfs = resolve_thread_kv_page_slice_offset<Traits>(
-                tid,
-                n_block,
-                page_block_size,
-                block_table,
-                page_stride,
-                row_stride,
-                partial_block_size
-            );
+      const int64_t physical_offset_uint4 = physical_offset_halves / PER_UINT4;
 
-            const int64_t physical_offset_uint4 = physical_offset_halfs / PER_UINT4;
-
-            kv_val = __ldg(&kv_vec[physical_offset_uint4 + vec_col]);
-        }
-
-        smem_vec[token_offset * smem_stride_uint4 + vec_col] = kv_val;
+      kv_val = __ldg(&kv_vec[physical_offset_uint4 + vec_col]);
     }
+
+    smem_vec[token_offset * smem_stride_uint4 + vec_col] = kv_val;
+  }
 }

--- a/flash-attention-v100/kernel/fp8_kv_utils.cuh
+++ b/flash-attention-v100/kernel/fp8_kv_utils.cuh
@@ -14,9 +14,7 @@ __device__ __forceinline__ float quiet_nan_f() {
   return __int_as_float(0x7fffffff);
 }
 
-__device__ __forceinline__ float inf_f() {
-  return __int_as_float(0x7f800000);
-}
+__device__ __forceinline__ float inf_f() { return __int_as_float(0x7f800000); }
 
 __device__ __forceinline__ float exp2_int(const int exponent) {
   return __uint_as_float(static_cast<uint32_t>(exponent + 127) << 23);
@@ -38,8 +36,7 @@ __device__ __forceinline__ float fp8_e4m3fn_to_float(uint8_t raw) {
     if (exp == 0x0f && mant == 0x07) {
       return quiet_nan_f();
     }
-    value = (1.0f + static_cast<float>(mant) * 0.125f) *
-            exp2_int(exp - 7);
+    value = (1.0f + static_cast<float>(mant) * 0.125f) * exp2_int(exp - 7);
   }
   return sign ? -value : value;
 }
@@ -52,9 +49,8 @@ __device__ __forceinline__ __half fp8_e5m2_to_half(uint8_t raw) {
 }
 
 __device__ __forceinline__ __half2 fp8_e5m2_pair_to_half2(uint16_t raw_pair) {
-  const uint32_t half2_bits =
-      (static_cast<uint32_t>(raw_pair & 0x00ffu) << 8) |
-      (static_cast<uint32_t>(raw_pair & 0xff00u) << 16);
+  const uint32_t half2_bits = (static_cast<uint32_t>(raw_pair & 0x00ffu) << 8) |
+                              (static_cast<uint32_t>(raw_pair & 0xff00u) << 16);
   union {
     uint32_t u;
     __half2 h2;
@@ -64,8 +60,7 @@ __device__ __forceinline__ __half2 fp8_e5m2_pair_to_half2(uint16_t raw_pair) {
 }
 
 __device__ __forceinline__ __half2 load_fp8_e5m2_half2_unscaled(
-    const void* __restrict__ cache,
-    const int64_t byte_index) {
+    const void* __restrict__ cache, const int64_t byte_index) {
   const uint16_t* cache_u16 = reinterpret_cast<const uint16_t*>(cache);
   return fp8_e5m2_pair_to_half2(cache_u16[byte_index >> 1]);
 }
@@ -74,36 +69,31 @@ __device__ __forceinline__ float fp8_e5m2_to_float(uint8_t raw) {
   return __half2float(fp8_e5m2_to_half(raw));
 }
 
-template<int KV_DTYPE>
+template <int KV_DTYPE>
 __device__ __forceinline__ float load_kv_cache_float_unscaled(
-    const void* __restrict__ cache,
-    const int64_t index) {
+    const void* __restrict__ cache, const int64_t index) {
   if constexpr (KV_DTYPE == KV_CACHE_DTYPE_FP16) {
     const __half* cache_h = reinterpret_cast<const __half*>(cache);
     return __half2float(cache_h[index]);
   } else {
     const uint8_t* cache_u8 = reinterpret_cast<const uint8_t*>(cache);
     const uint8_t raw = cache_u8[index];
-    const float value =
-        KV_DTYPE == KV_CACHE_DTYPE_FP8_E4M3 ? fp8_e4m3fn_to_float(raw)
-                                            : fp8_e5m2_to_float(raw);
+    const float value = KV_DTYPE == KV_CACHE_DTYPE_FP8_E4M3
+                            ? fp8_e4m3fn_to_float(raw)
+                            : fp8_e5m2_to_float(raw);
     return value;
   }
 }
 
-template<int KV_DTYPE>
+template <int KV_DTYPE>
 __device__ __forceinline__ float load_kv_cache_float(
-    const void* __restrict__ cache,
-    const int64_t index,
-    const float scale) {
+    const void* __restrict__ cache, const int64_t index, const float scale) {
   return load_kv_cache_float_unscaled<KV_DTYPE>(cache, index) * scale;
 }
 
-template<int KV_DTYPE>
+template <int KV_DTYPE>
 __device__ __forceinline__ __half load_kv_cache_half(
-    const void* __restrict__ cache,
-    const int64_t index,
-    const float scale) {
+    const void* __restrict__ cache, const int64_t index, const float scale) {
   if constexpr (KV_DTYPE == KV_CACHE_DTYPE_FP8_E5M2) {
     const uint8_t* cache_u8 = reinterpret_cast<const uint8_t*>(cache);
     return __float2half_rn(__half2float(fp8_e5m2_to_half(cache_u8[index])) *

--- a/flash-attention-v100/kernel/fused_mha_backward.cu
+++ b/flash-attention-v100/kernel/fused_mha_backward.cu
@@ -14,1176 +14,1235 @@ using namespace nvcuda::wmma;
 #define WMMA_N 16
 #define WMMA_K 16
 
-#define MAX_THREADS_PER_WARP    32
-#define MAX_THREADS_PER_SM      2048
-#define MAX_THREAD_BLOCK_SIZE   1024
+#define MAX_THREADS_PER_WARP 32
+#define MAX_THREADS_PER_SM 2048
+#define MAX_THREAD_BLOCK_SIZE 1024
 #define MAX_THREAD_BLOCK_PER_SM 32
-#define MAX_WARPS_PER_SM        64
-#define MAX_SM_PER_GPU          80
-#define MAX_SMEM_PER_SM         98304
+#define MAX_WARPS_PER_SM 64
+#define MAX_SM_PER_GPU 80
+#define MAX_SMEM_PER_SM 98304
 
-#define WARP_ALLOC_GROUP        4
+#define WARP_ALLOC_GROUP 4
 
-#define MAX_REG_PER_UNIT        256
-#define MAX_REG_PER_THREAD      255
-#define MAX_REG_PER_BLOCK       65536
-#define MAX_REG_BUFFER          65536
+#define MAX_REG_PER_UNIT 256
+#define MAX_REG_PER_THREAD 255
+#define MAX_REG_PER_BLOCK 65536
+#define MAX_REG_BUFFER 65536
 
-#define BLOCK_M_16  16
-#define BLOCK_N_16  256
-#define WARPS_16    16
+#define BLOCK_M_16 16
+#define BLOCK_N_16 256
+#define WARPS_16 16
 
-#define BLOCK_M_32  32
-#define BLOCK_N_32  128
-#define WARPS_32    16
+#define BLOCK_M_32 32
+#define BLOCK_N_32 128
+#define WARPS_32 16
 
-#define BLOCK_M_64  64
-#define BLOCK_N_64  80
-#define WARPS_64    16
+#define BLOCK_M_64 64
+#define BLOCK_N_64 80
+#define WARPS_64 16
 
 #define BLOCK_M_128 32
 #define BLOCK_N_128 112
-#define WARPS_128   16
+#define WARPS_128 16
 
 #define BLOCK_M_256 32
 #define BLOCK_N_256 32
-#define WARPS_256   16
+#define WARPS_256 16
 
-#define BLOCK_KV_16  32
-#define BLOCK_Q_16   224
+#define BLOCK_KV_16 32
+#define BLOCK_Q_16 224
 #define WARPS_DKV_16 14
 
-#define BLOCK_KV_32  32
-#define BLOCK_Q_32   192
+#define BLOCK_KV_32 32
+#define BLOCK_Q_32 192
 #define WARPS_DKV_32 12
 
-#define BLOCK_KV_64  32
-#define BLOCK_Q_64   128
-#define WARPS_DKV_64  8
+#define BLOCK_KV_64 32
+#define BLOCK_Q_64 128
+#define WARPS_DKV_64 8
 
-#define BLOCK_KV_128  16
-#define BLOCK_Q_128   144
+#define BLOCK_KV_128 16
+#define BLOCK_Q_128 144
 #define WARPS_DKV_128 12
 
-#define BLOCK_KV_256  16
-#define BLOCK_Q_256   64
+#define BLOCK_KV_256 16
+#define BLOCK_Q_256 64
 #define WARPS_DKV_256 16
 
-template<int D>
+template <int D>
 struct dQKernelConfig {
-    static constexpr int BLOCK_M = (D == 16) ? BLOCK_M_16 : (D == 32) ? BLOCK_M_32 : (D == 64)  ? BLOCK_M_64 : (D == 128) ? BLOCK_M_128 : BLOCK_M_256;
-    static constexpr int BLOCK_N = (D == 16) ? BLOCK_N_16 : (D == 32) ? BLOCK_N_32 : (D == 64)  ? BLOCK_N_64 : (D == 128) ? BLOCK_N_128 : BLOCK_N_256;
-    static constexpr int WARPS_PER_BLOCK = (D == 16) ? WARPS_16 : (D == 32) ? WARPS_32 : (D == 64) ? WARPS_64 : (D == 128) ? WARPS_128 : WARPS_256;
+  static constexpr int BLOCK_M = (D == 16)    ? BLOCK_M_16
+                                 : (D == 32)  ? BLOCK_M_32
+                                 : (D == 64)  ? BLOCK_M_64
+                                 : (D == 128) ? BLOCK_M_128
+                                              : BLOCK_M_256;
+  static constexpr int BLOCK_N = (D == 16)    ? BLOCK_N_16
+                                 : (D == 32)  ? BLOCK_N_32
+                                 : (D == 64)  ? BLOCK_N_64
+                                 : (D == 128) ? BLOCK_N_128
+                                              : BLOCK_N_256;
+  static constexpr int WARPS_PER_BLOCK = (D == 16)    ? WARPS_16
+                                         : (D == 32)  ? WARPS_32
+                                         : (D == 64)  ? WARPS_64
+                                         : (D == 128) ? WARPS_128
+                                                      : WARPS_256;
 
-    static constexpr int THREADS_PER_BLOCK  = WARPS_PER_BLOCK * MAX_THREADS_PER_WARP;
-    static constexpr int THREADS_PER_ROW    = THREADS_PER_BLOCK / BLOCK_M;
-    static constexpr int PAD                = (8 - (D % 32) + 32) % 32;
-    static constexpr int Q_STRIDE           = D + PAD;
-    static constexpr int KV_STRIDE          = D + PAD;
-    static constexpr int S_STRIDE           = BLOCK_N + PAD;
-    static constexpr int PER_UINT4          = 8;
-    static constexpr int NUM_UINT4_Q_BLOCK  = BLOCK_M * ((D + PER_UINT4 - 1) / PER_UINT4);
-    static constexpr int NUM_UINT4_KV_BLOCK = BLOCK_N * ((D + PER_UINT4 - 1) / PER_UINT4);
+  static constexpr int THREADS_PER_BLOCK =
+      WARPS_PER_BLOCK * MAX_THREADS_PER_WARP;
+  static constexpr int THREADS_PER_ROW = THREADS_PER_BLOCK / BLOCK_M;
+  static constexpr int PAD = (8 - (D % 32) + 32) % 32;
+  static constexpr int Q_STRIDE = D + PAD;
+  static constexpr int KV_STRIDE = D + PAD;
+  static constexpr int S_STRIDE = BLOCK_N + PAD;
+  static constexpr int PER_UINT4 = 8;
+  static constexpr int NUM_UINT4_Q_BLOCK =
+      BLOCK_M * ((D + PER_UINT4 - 1) / PER_UINT4);
+  static constexpr int NUM_UINT4_KV_BLOCK =
+      BLOCK_N * ((D + PER_UINT4 - 1) / PER_UINT4);
 
-    struct alignas(128) SmemLayout {
-        union {
-            alignas(16) __half k     [BLOCK_N * KV_STRIDE];
-            alignas(16) __half v     [BLOCK_N * KV_STRIDE];
-        } reuse_kv;
-            alignas(16) __half dO    [BLOCK_M * Q_STRIDE];
-            alignas(16) __half q     [BLOCK_M * Q_STRIDE];
-            alignas(16) float  s     [BLOCK_M * S_STRIDE];
-        union {
-            alignas(16) float  dOV   [BLOCK_M * S_STRIDE];
-            alignas(16) __half dS    [BLOCK_M * S_STRIDE];
-        } reuse_sdOVS;
-            alignas(16) float row_dot[BLOCK_M];
-            alignas(16) float lse    [BLOCK_M];
-            alignas(16) float dQ     [BLOCK_M * Q_STRIDE];
-    };
+  struct alignas(128) SmemLayout {
+    union {
+      alignas(16) __half k[BLOCK_N * KV_STRIDE];
+      alignas(16) __half v[BLOCK_N * KV_STRIDE];
+    } reuse_kv;
+    alignas(16) __half dO[BLOCK_M * Q_STRIDE];
+    alignas(16) __half q[BLOCK_M * Q_STRIDE];
+    alignas(16) float s[BLOCK_M * S_STRIDE];
+    union {
+      alignas(16) float dOV[BLOCK_M * S_STRIDE];
+      alignas(16) __half dS[BLOCK_M * S_STRIDE];
+    } reuse_sdOVS;
+    alignas(16) float row_dot[BLOCK_M];
+    alignas(16) float lse[BLOCK_M];
+    alignas(16) float dQ[BLOCK_M * Q_STRIDE];
+  };
 
-    static constexpr size_t TOTAL_SMEM = ((sizeof(SmemLayout) + 127) & ~size_t(127));
+  static constexpr size_t TOTAL_SMEM =
+      ((sizeof(SmemLayout) + 127) & ~size_t(127));
 };
 
-template<typename Config>
+template <typename Config>
 __device__ __forceinline__ void init_smem(char* smem_raw) {
-    constexpr int N_U4 = Config::TOTAL_SMEM / 16;
-    const int lane_id = threadIdx.x & 31;
+  constexpr int N_U4 = Config::TOTAL_SMEM / 16;
+  const int lane_id = threadIdx.x & 31;
 
-    uint32_t addr = static_cast<uint32_t>(__cvta_generic_to_shared(smem_raw));
-    #pragma unroll 1
-    for (int i = lane_id; i < N_U4; i += 32) {
-        asm volatile("st.shared.v4.u32 [%0], {%1,%1,%1,%1};"
-                     :: "r"(addr + (i << 4)), "r"(0) : "memory");
-    }
-    __syncwarp();
+  uint32_t addr = static_cast<uint32_t>(__cvta_generic_to_shared(smem_raw));
+#pragma unroll 1
+  for (int i = lane_id; i < N_U4; i += 32) {
+    asm volatile("st.shared.v4.u32 [%0], {%1,%1,%1,%1};" ::"r"(addr + (i << 4)),
+                 "r"(0)
+                 : "memory");
+  }
+  __syncwarp();
 }
 
-template<int D>
+template <int D>
 struct dKVKernelConfig {
-    static constexpr int BLOCK_M = (D == 16) ? BLOCK_KV_16 : (D == 32) ? BLOCK_KV_32 : (D == 64) ? BLOCK_KV_64 : (D == 128) ? BLOCK_KV_128 : BLOCK_KV_256;
-    static constexpr int BLOCK_N = (D == 16) ? BLOCK_Q_16 : (D == 32) ? BLOCK_Q_32 : (D == 64) ? BLOCK_Q_64 : (D == 128) ? BLOCK_Q_128 : BLOCK_Q_256;
-    static constexpr int WARPS_PER_BLOCK = (D == 16) ? WARPS_DKV_16 : (D == 32) ? WARPS_DKV_32 : (D == 64) ? WARPS_DKV_64 : (D == 128) ? WARPS_DKV_128 : WARPS_DKV_256;
+  static constexpr int BLOCK_M = (D == 16)    ? BLOCK_KV_16
+                                 : (D == 32)  ? BLOCK_KV_32
+                                 : (D == 64)  ? BLOCK_KV_64
+                                 : (D == 128) ? BLOCK_KV_128
+                                              : BLOCK_KV_256;
+  static constexpr int BLOCK_N = (D == 16)    ? BLOCK_Q_16
+                                 : (D == 32)  ? BLOCK_Q_32
+                                 : (D == 64)  ? BLOCK_Q_64
+                                 : (D == 128) ? BLOCK_Q_128
+                                              : BLOCK_Q_256;
+  static constexpr int WARPS_PER_BLOCK = (D == 16)    ? WARPS_DKV_16
+                                         : (D == 32)  ? WARPS_DKV_32
+                                         : (D == 64)  ? WARPS_DKV_64
+                                         : (D == 128) ? WARPS_DKV_128
+                                                      : WARPS_DKV_256;
 
-    static constexpr int THREADS_PER_BLOCK  = WARPS_PER_BLOCK * MAX_THREADS_PER_WARP;
-    static constexpr int THREADS_PER_ROW    = THREADS_PER_BLOCK / BLOCK_N;
-    static constexpr int PAD                = 8;
-    static constexpr int Q_STRIDE           = D + PAD;
-    static constexpr int KV_STRIDE          = D + PAD;
-    static constexpr int S_STRIDE           = BLOCK_M + PAD;
-    static constexpr int PER_UINT4          = 8;
-    static constexpr int NUM_UINT4_Q_BLOCK  = BLOCK_N * ((D + PER_UINT4 - 1) / PER_UINT4);
-    static constexpr int NUM_UINT4_KV_BLOCK = BLOCK_M * ((D + PER_UINT4 - 1) / PER_UINT4);
+  static constexpr int THREADS_PER_BLOCK =
+      WARPS_PER_BLOCK * MAX_THREADS_PER_WARP;
+  static constexpr int THREADS_PER_ROW = THREADS_PER_BLOCK / BLOCK_N;
+  static constexpr int PAD = 8;
+  static constexpr int Q_STRIDE = D + PAD;
+  static constexpr int KV_STRIDE = D + PAD;
+  static constexpr int S_STRIDE = BLOCK_M + PAD;
+  static constexpr int PER_UINT4 = 8;
+  static constexpr int NUM_UINT4_Q_BLOCK =
+      BLOCK_N * ((D + PER_UINT4 - 1) / PER_UINT4);
+  static constexpr int NUM_UINT4_KV_BLOCK =
+      BLOCK_M * ((D + PER_UINT4 - 1) / PER_UINT4);
 
-    struct alignas(128) SmemLayout {
-            alignas(16) __half k     [BLOCK_M * KV_STRIDE];
-            alignas(16) __half v     [BLOCK_M * KV_STRIDE];
-        union {
-            alignas(16) __half dO    [BLOCK_N * Q_STRIDE];
-            alignas(16) __half q     [BLOCK_N * Q_STRIDE];
-        } reuse_qdO;
-        union {
-            alignas(16) float  s     [BLOCK_N * S_STRIDE];
-            alignas(16) __half p     [BLOCK_N * BLOCK_M];
-        } reuse_sp;
-        union {
-            alignas(16) float  dOV   [BLOCK_N * S_STRIDE];
-            alignas(16) __half dS    [BLOCK_N * BLOCK_M];
-        } reuse_dOVS;
-            alignas(16) float row_dot[BLOCK_N];
-            alignas(16) float lse    [BLOCK_N];
-            alignas(16) float dK     [BLOCK_M * KV_STRIDE];
-            alignas(16) float dV     [BLOCK_M * KV_STRIDE];
-    };
+  struct alignas(128) SmemLayout {
+    alignas(16) __half k[BLOCK_M * KV_STRIDE];
+    alignas(16) __half v[BLOCK_M * KV_STRIDE];
+    union {
+      alignas(16) __half dO[BLOCK_N * Q_STRIDE];
+      alignas(16) __half q[BLOCK_N * Q_STRIDE];
+    } reuse_qdO;
+    union {
+      alignas(16) float s[BLOCK_N * S_STRIDE];
+      alignas(16) __half p[BLOCK_N * BLOCK_M];
+    } reuse_sp;
+    union {
+      alignas(16) float dOV[BLOCK_N * S_STRIDE];
+      alignas(16) __half dS[BLOCK_N * BLOCK_M];
+    } reuse_dOVS;
+    alignas(16) float row_dot[BLOCK_N];
+    alignas(16) float lse[BLOCK_N];
+    alignas(16) float dK[BLOCK_M * KV_STRIDE];
+    alignas(16) float dV[BLOCK_M * KV_STRIDE];
+  };
 
-    static constexpr size_t TOTAL_SMEM = ((sizeof(SmemLayout) + 127) & ~size_t(127));
+  static constexpr size_t TOTAL_SMEM =
+      ((sizeof(SmemLayout) + 127) & ~size_t(127));
 };
 
-template<int D, bool IS_CAUSAL>
+template <int D, bool IS_CAUSAL>
 __global__ void __launch_bounds__(dQKernelConfig<D>::THREADS_PER_BLOCK, 2)
-flash_attention_backward_dq_kernel(
-    const __half*  __restrict__ Q,
-    const __half*  __restrict__ K,
-    const __half*  __restrict__ V,
-    const __half*  __restrict__ O,
-    const __half*  __restrict__ dO,
-    const  float*  __restrict__ softmax_lse,
-          __half*  __restrict__ dQ,
-    const int B,
-    const int H,
-    const int M,
-    const int N,
-    const float softmax_scale
-) {
-    using Config = dQKernelConfig<D>;
+    flash_attention_backward_dq_kernel(
+        const __half* __restrict__ Q, const __half* __restrict__ K,
+        const __half* __restrict__ V, const __half* __restrict__ O,
+        const __half* __restrict__ dO, const float* __restrict__ softmax_lse,
+        __half* __restrict__ dQ, const int B, const int H, const int M,
+        const int N, const float softmax_scale) {
+  using Config = dQKernelConfig<D>;
 
-    constexpr int BLOCK_M           = Config::BLOCK_M;
-    constexpr int BLOCK_N           = Config::BLOCK_N;
-    constexpr int THREADS_PER_BLOCK = Config::THREADS_PER_BLOCK;
-    constexpr int THREADS_PER_ROW   = Config::THREADS_PER_ROW;
-    constexpr int WARPS_PER_BLOCK   = Config::WARPS_PER_BLOCK;
-    constexpr int Q_STRIDE          = Config::Q_STRIDE;
-    constexpr int KV_STRIDE         = Config::KV_STRIDE;
-    constexpr int S_STRIDE          = Config::S_STRIDE;
-    constexpr int PER_UINT4         = Config::PER_UINT4;
-    constexpr int NUM_UINT4_Q_BLOCK  = Config::NUM_UINT4_Q_BLOCK;
-    constexpr int NUM_UINT4_KV_BLOCK = Config::NUM_UINT4_KV_BLOCK;
+  constexpr int BLOCK_M = Config::BLOCK_M;
+  constexpr int BLOCK_N = Config::BLOCK_N;
+  constexpr int THREADS_PER_BLOCK = Config::THREADS_PER_BLOCK;
+  constexpr int THREADS_PER_ROW = Config::THREADS_PER_ROW;
+  constexpr int WARPS_PER_BLOCK = Config::WARPS_PER_BLOCK;
+  constexpr int Q_STRIDE = Config::Q_STRIDE;
+  constexpr int KV_STRIDE = Config::KV_STRIDE;
+  constexpr int S_STRIDE = Config::S_STRIDE;
+  constexpr int PER_UINT4 = Config::PER_UINT4;
+  constexpr int NUM_UINT4_Q_BLOCK = Config::NUM_UINT4_Q_BLOCK;
+  constexpr int NUM_UINT4_KV_BLOCK = Config::NUM_UINT4_KV_BLOCK;
 
-    const float NEG_INF = -1e30f;
+  const float NEG_INF = -1e30f;
 
-    const int batch_head_id = blockIdx.z;
-    if (batch_head_id >= B * H) return;
+  const int batch_head_id = blockIdx.z;
+  if (batch_head_id >= B * H) return;
 
-    const int block_m   = blockIdx.x;
-    const int start_row = block_m * BLOCK_M;
-    if (start_row >= M) return;
+  const int block_m = blockIdx.x;
+  const int start_row = block_m * BLOCK_M;
+  if (start_row >= M) return;
 
-    int num_n_tiles = (N + BLOCK_N - 1) / BLOCK_N;
-    const int valid_q_rows = min(BLOCK_M, M - start_row);
+  int num_n_tiles = (N + BLOCK_N - 1) / BLOCK_N;
+  const int valid_q_rows = min(BLOCK_M, M - start_row);
 
-    if constexpr (IS_CAUSAL) {
-        const int max_key_pos = start_row + valid_q_rows - 1;
-        if (max_key_pos < 0) {
-            num_n_tiles = 0;
-        } else {
-            num_n_tiles = min(num_n_tiles, (max_key_pos + BLOCK_N) / BLOCK_N);
-        }
+  if constexpr (IS_CAUSAL) {
+    const int max_key_pos = start_row + valid_q_rows - 1;
+    if (max_key_pos < 0) {
+      num_n_tiles = 0;
+    } else {
+      num_n_tiles = min(num_n_tiles, (max_key_pos + BLOCK_N) / BLOCK_N);
+    }
+  }
+
+  const int tid = threadIdx.x;
+  const int warp_id = tid / MAX_THREADS_PER_WARP;
+  const int lane_id = tid % MAX_THREADS_PER_WARP;
+
+  const __half* q_ptr = Q + (size_t)batch_head_id * M * D + start_row * D;
+  const __half* k_ptr = K + (size_t)batch_head_id * N * D;
+  const __half* v_ptr = V + (size_t)batch_head_id * N * D;
+  const __half* o_ptr = O + (size_t)batch_head_id * M * D + start_row * D;
+  const __half* dO_ptr = dO + (size_t)batch_head_id * M * D + start_row * D;
+  __half* dQ_ptr = dQ + (size_t)batch_head_id * M * D + start_row * D;
+  const float* lse_ptr = softmax_lse + (size_t)batch_head_id * M + start_row;
+
+  extern __shared__ char smem_raw[];
+  init_smem<Config>(smem_raw);
+  auto& smem = *reinterpret_cast<typename Config::SmemLayout*>(smem_raw);
+
+  __half* sK = smem.reuse_kv.k;
+  __half* sV = smem.reuse_kv.v;
+  __half* sdO = smem.dO;
+  __half* sQ = smem.q;
+  float* sS = smem.s;
+  float* sdOV = smem.reuse_sdOVS.dOV;
+  __half* sdS = smem.reuse_sdOVS.dS;
+  float* sRowDot = smem.row_dot;
+  float* sLse = smem.lse;
+  float* sdQ = smem.dQ;
+
+  const int d_stride_uint4 = (D + PER_UINT4 - 1) / PER_UINT4;
+  const int q_stride_uint4 = (Q_STRIDE + PER_UINT4 - 1) / PER_UINT4;
+  const int kv_stride_uint4 = (KV_STRIDE + PER_UINT4 - 1) / PER_UINT4;
+
+  const uint4* q_vec = reinterpret_cast<const uint4*>(q_ptr);
+  const uint4* do_vec = reinterpret_cast<const uint4*>(dO_ptr);
+  uint4* sQ_vec = reinterpret_cast<uint4*>(sQ);
+  uint4* sdO_vec = reinterpret_cast<uint4*>(sdO);
+
+#pragma unroll 2
+  for (int idx = tid; idx < NUM_UINT4_Q_BLOCK; idx += THREADS_PER_BLOCK) {
+    const int row = idx / d_stride_uint4;
+    const int vec_col = idx % d_stride_uint4;
+
+    uint4 q_val = make_uint4(0, 0, 0, 0);
+    uint4 do_val = make_uint4(0, 0, 0, 0);
+
+    if (row < valid_q_rows && vec_col < d_stride_uint4) {
+      q_val = __ldg(&q_vec[row * d_stride_uint4 + vec_col]);
+      do_val = __ldg(&do_vec[row * d_stride_uint4 + vec_col]);
+    }
+    sQ_vec[row * q_stride_uint4 + vec_col] = q_val;
+    sdO_vec[row * q_stride_uint4 + vec_col] = do_val;
+  }
+  __syncthreads();
+
+  if (tid < valid_q_rows * THREADS_PER_ROW) {
+    const int row = tid / THREADS_PER_ROW;
+    const int thread_in_row = tid % THREADS_PER_ROW;
+    const int fp16_x4_per_row = D / 4;
+    const int work_per_thread =
+        (fp16_x4_per_row + THREADS_PER_ROW - 1) / THREADS_PER_ROW;
+    const unsigned mask =
+        (valid_q_rows == BLOCK_M) ? 0xFFFFFFFFU : __activemask();
+
+    float thread_dot = 0.0f;
+
+#pragma unroll
+    for (int j = 0; j < work_per_thread; ++j) {
+      const int chunk_idx = thread_in_row + j * THREADS_PER_ROW;
+      if (chunk_idx >= fp16_x4_per_row) break;
+      const int col = chunk_idx * 4;
+
+      const __half* o_addr = o_ptr + row * D + col;
+      ushort o_h0, o_h1, o_h2, o_h3;
+      asm volatile("ld.global.v4.u16 {%0, %1, %2, %3}, [%4];"
+                   : "=h"(o_h0), "=h"(o_h1), "=h"(o_h2), "=h"(o_h3)
+                   : "l"(o_addr)
+                   : "memory");
+
+      const __half* dO_addr = sdO + row * Q_STRIDE + col;
+      ushort d_h0, d_h1, d_h2, d_h3;
+      const uint32_t ptr_dO = static_cast<uint32_t>(
+          reinterpret_cast<uintptr_t>(__cvta_generic_to_shared(dO_addr)));
+      asm volatile("ld.shared.v4.u16 {%0, %1, %2, %3}, [%4];"
+                   : "=h"(d_h0), "=h"(d_h1), "=h"(d_h2), "=h"(d_h3)
+                   : "r"(ptr_dO)
+                   : "memory");
+
+      const float fo_0 = __half2float(__ushort_as_half(o_h0));
+      const float fo_1 = __half2float(__ushort_as_half(o_h1));
+      const float fo_2 = __half2float(__ushort_as_half(o_h2));
+      const float fo_3 = __half2float(__ushort_as_half(o_h3));
+
+      const float fd_0 = __half2float(__ushort_as_half(d_h0));
+      const float fd_1 = __half2float(__ushort_as_half(d_h1));
+      const float fd_2 = __half2float(__ushort_as_half(d_h2));
+      const float fd_3 = __half2float(__ushort_as_half(d_h3));
+
+      thread_dot = __fmaf_rn(fo_0, fd_0, thread_dot);
+      thread_dot = __fmaf_rn(fo_1, fd_1, thread_dot);
+      thread_dot = __fmaf_rn(fo_2, fd_2, thread_dot);
+      thread_dot = __fmaf_rn(fo_3, fd_3, thread_dot);
     }
 
-    const int tid          = threadIdx.x;
-    const int warp_id      = tid / MAX_THREADS_PER_WARP;
-    const int lane_id      = tid % MAX_THREADS_PER_WARP;
+#pragma unroll
+    for (int o = THREADS_PER_ROW / 2; o > 0; o >>= 1)
+      thread_dot += __shfl_down_sync(mask, thread_dot, o, THREADS_PER_ROW);
 
-    const __half* q_ptr   = Q           + (size_t)batch_head_id * M * D + start_row * D;
-    const __half* k_ptr   = K           + (size_t)batch_head_id * N * D;
-    const __half* v_ptr   = V           + (size_t)batch_head_id * N * D;
-    const __half* o_ptr   = O           + (size_t)batch_head_id * M * D + start_row * D;
-    const __half* dO_ptr  = dO          + (size_t)batch_head_id * M * D + start_row * D;
-          __half* dQ_ptr  = dQ          + (size_t)batch_head_id * M * D + start_row * D;
-    const float*  lse_ptr = softmax_lse + (size_t)batch_head_id * M + start_row;
+    if (thread_in_row == 0) {
+      sRowDot[row] = thread_dot;
+    }
+  }
 
-    extern __shared__ char smem_raw[];
-    init_smem<Config>(smem_raw);
-    auto& smem = *reinterpret_cast<typename Config::SmemLayout*>(smem_raw);
+  if (tid < valid_q_rows) {
+    sLse[tid] = lse_ptr[tid];
+  }
+  __syncthreads();
 
-    __half* sK      = smem.reuse_kv.k;
-    __half* sV      = smem.reuse_kv.v;
-    __half* sdO     = smem.dO;
-    __half* sQ      = smem.q;
-     float* sS      = smem.s;
-     float* sdOV    = smem.reuse_sdOVS.dOV;
-    __half* sdS     = smem.reuse_sdOVS.dS;
-     float* sRowDot = smem.row_dot;
-     float* sLse    = smem.lse;
-     float* sdQ     = smem.dQ;
+  for (int block_n = 0; block_n < num_n_tiles; ++block_n) {
+    const int start_col = block_n * BLOCK_N;
+    if (start_col >= N) break;
+    const int valid_k_rows = min(BLOCK_N, N - start_col);
 
-    const int  d_stride_uint4 = (D + PER_UINT4 - 1) / PER_UINT4;
-    const int  q_stride_uint4 = (Q_STRIDE  + PER_UINT4 - 1) / PER_UINT4;
-    const int kv_stride_uint4 = (KV_STRIDE + PER_UINT4 - 1) / PER_UINT4;
+    if constexpr (IS_CAUSAL) {
+      if (start_col >= start_row + valid_q_rows) {
+        continue;
+      }
+    }
 
-    const uint4* q_vec  = reinterpret_cast<const uint4*>(q_ptr);
-    const uint4* do_vec = reinterpret_cast<const uint4*>(dO_ptr);
-    uint4* sQ_vec  = reinterpret_cast<uint4*>(sQ);
-    uint4* sdO_vec = reinterpret_cast<uint4*>(sdO);
+    const uint4* v_vec = reinterpret_cast<const uint4*>(v_ptr + start_col * D);
+    uint4* sV_vec = reinterpret_cast<uint4*>(sV);
 
-    #pragma unroll 2
-    for (int idx = tid; idx < NUM_UINT4_Q_BLOCK; idx += THREADS_PER_BLOCK) {
-        const int row = idx / d_stride_uint4;
-        const int vec_col = idx % d_stride_uint4;
+#pragma unroll 2
+    for (int idx = tid; idx < NUM_UINT4_KV_BLOCK; idx += THREADS_PER_BLOCK) {
+      const int row = idx / d_stride_uint4;
+      const int vec_col = idx % d_stride_uint4;
+      uint4 v_val = make_uint4(0, 0, 0, 0);
+      if (row < valid_k_rows && vec_col < d_stride_uint4) {
+        v_val = __ldg(&v_vec[row * d_stride_uint4 + vec_col]);
+      }
+      sV_vec[row * kv_stride_uint4 + vec_col] = v_val;
+    }
+    __syncthreads();
 
-        uint4 q_val  = make_uint4(0, 0, 0, 0);
-        uint4 do_val = make_uint4(0, 0, 0, 0);
+    const int num_tiles_m_dov = (BLOCK_M + WMMA_M - 1) / WMMA_M;
+    const int num_tiles_n_dov = (BLOCK_N + WMMA_N - 1) / WMMA_N;
+    const int num_tiles_k_dov = (D + WMMA_K - 1) / WMMA_K;
+    const int total_tiles_dov = num_tiles_m_dov * num_tiles_n_dov;
+    const int tiles_per_warp_dov =
+        (total_tiles_dov + WARPS_PER_BLOCK - 1) / WARPS_PER_BLOCK;
 
-        if (row < valid_q_rows && vec_col < d_stride_uint4) {
-            q_val =  __ldg(&q_vec[row * d_stride_uint4 + vec_col]);
-            do_val = __ldg(&do_vec[row * d_stride_uint4 + vec_col]);
+    for (int tile_idx = 0; tile_idx < tiles_per_warp_dov; ++tile_idx) {
+      const int global_tile_idx = warp_id * tiles_per_warp_dov + tile_idx;
+
+      if (global_tile_idx >= total_tiles_dov) break;
+
+      const int tile_m_idx = global_tile_idx / num_tiles_n_dov;
+      const int tile_n_idx = global_tile_idx % num_tiles_n_dov;
+
+      const int tile_m = tile_m_idx * WMMA_M;
+      const int tile_n = tile_n_idx * WMMA_N;
+
+      if (tile_m >= valid_q_rows || tile_n >= valid_k_rows) continue;
+
+      fragment<matrix_a, WMMA_M, WMMA_N, WMMA_K, __half, row_major> a_frag;
+      fragment<matrix_b, WMMA_M, WMMA_N, WMMA_K, __half, col_major> b_frag;
+      fragment<accumulator, WMMA_M, WMMA_N, WMMA_K, float> acc_frag;
+
+      fill_fragment(acc_frag, 0.0f);
+
+#pragma unroll
+      for (int k_tile = 0; k_tile < num_tiles_k_dov; ++k_tile) {
+        const int k_offset = k_tile * WMMA_K;
+        if (k_offset >= D) break;
+        load_matrix_sync(a_frag, sdO + tile_m * Q_STRIDE + k_offset, Q_STRIDE);
+        load_matrix_sync(b_frag, sV + tile_n * KV_STRIDE + k_offset, KV_STRIDE);
+        mma_sync(acc_frag, a_frag, b_frag, acc_frag);
+      }
+
+      store_matrix_sync(sdOV + tile_m * S_STRIDE + tile_n, acc_frag, S_STRIDE,
+                        mem_row_major);
+    }
+    __syncthreads();
+
+    const uint4* k_vec = reinterpret_cast<const uint4*>(k_ptr + start_col * D);
+    uint4* sK_vec = reinterpret_cast<uint4*>(sK);
+
+#pragma unroll 2
+    for (int idx = tid; idx < NUM_UINT4_KV_BLOCK; idx += THREADS_PER_BLOCK) {
+      const int row = idx / d_stride_uint4;
+      const int vec_col = idx % d_stride_uint4;
+      uint4 k_val = make_uint4(0, 0, 0, 0);
+      if (row < valid_k_rows && vec_col < d_stride_uint4) {
+        k_val = __ldg(&k_vec[row * d_stride_uint4 + vec_col]);
+      }
+      sK_vec[row * kv_stride_uint4 + vec_col] = k_val;
+    }
+    __syncthreads();
+
+    const int num_tiles_m_qk = (BLOCK_M + WMMA_M - 1) / WMMA_M;
+    const int num_tiles_n_qk = (BLOCK_N + WMMA_N - 1) / WMMA_N;
+    const int num_tiles_k_qk = (D + WMMA_K - 1) / WMMA_K;
+    const int total_tiles_qk = num_tiles_m_qk * num_tiles_n_qk;
+    const int tiles_per_warp_qk =
+        (total_tiles_qk + WARPS_PER_BLOCK - 1) / WARPS_PER_BLOCK;
+    const unsigned row_causal = (lane_id & 0b1) + ((lane_id >> 2) & 0b1) * 8 +
+                                ((lane_id >> 4) & 0b1) * 4;
+    const unsigned col_causal =
+        ((lane_id >> 1) & 0b1) * 2 + ((lane_id >> 3) & 0b1) * 8;
+
+    for (int tile_idx = 0; tile_idx < tiles_per_warp_qk; ++tile_idx) {
+      const int global_tile_idx = warp_id * tiles_per_warp_qk + tile_idx;
+
+      if (global_tile_idx >= total_tiles_qk) break;
+
+      const int tile_m_idx = global_tile_idx / num_tiles_n_qk;
+      const int tile_n_idx = global_tile_idx % num_tiles_n_qk;
+
+      const int tile_m = tile_m_idx * WMMA_M;
+      const int tile_n = tile_n_idx * WMMA_N;
+
+      if (tile_m >= valid_q_rows || tile_n >= valid_k_rows) continue;
+
+      fragment<matrix_a, WMMA_M, WMMA_N, WMMA_K, __half, row_major> a_frag;
+      fragment<matrix_b, WMMA_M, WMMA_N, WMMA_K, __half, col_major> b_frag;
+      fragment<accumulator, WMMA_M, WMMA_N, WMMA_K, float> acc_frag;
+
+      fill_fragment(acc_frag, 0.0f);
+
+#pragma unroll
+      for (int k_tile = 0; k_tile < num_tiles_k_qk; ++k_tile) {
+        const int k_offset = k_tile * WMMA_K;
+        if (k_offset >= D) break;
+        load_matrix_sync(a_frag, sQ + tile_m * Q_STRIDE + k_offset, Q_STRIDE);
+        load_matrix_sync(b_frag, sK + tile_n * KV_STRIDE + k_offset, KV_STRIDE);
+        mma_sync(acc_frag, a_frag, b_frag, acc_frag);
+      }
+
+      if constexpr (IS_CAUSAL) {
+#pragma unroll
+        for (int i = 0; i < acc_frag.num_elements; ++i) {
+          const unsigned col = col_causal + (i & 0b1) + ((i >> 2) & 0b1) * 4;
+          const unsigned row = row_causal + ((i >> 1) & 0b1) * 2;
+
+          const int global_m = start_row + tile_m + row;
+          const int global_n = start_col + tile_n + col;
+
+          const bool is_valid = (global_m < start_row + valid_q_rows) &&
+                                (global_n < start_col + valid_k_rows);
+
+          acc_frag.x[i] =
+              is_valid ? ((global_n > global_m) ? NEG_INF
+                                                : acc_frag.x[i] * softmax_scale)
+                       : NEG_INF;
         }
-         sQ_vec[row * q_stride_uint4 + vec_col] = q_val;
-        sdO_vec[row * q_stride_uint4 + vec_col] = do_val;
+      } else {
+#pragma unroll
+        for (int i = 0; i < acc_frag.num_elements; ++i) {
+          acc_frag.x[i] *= softmax_scale;
+        }
+      }
+      store_matrix_sync(sS + tile_m * S_STRIDE + tile_n, acc_frag, S_STRIDE,
+                        mem_row_major);
     }
     __syncthreads();
 
     if (tid < valid_q_rows * THREADS_PER_ROW) {
-        const int row = tid / THREADS_PER_ROW;
-        const int thread_in_row = tid % THREADS_PER_ROW;
-        const int fp16_x4_per_row = D / 4;
-        const int work_per_thread = (fp16_x4_per_row + THREADS_PER_ROW - 1) / THREADS_PER_ROW;
-        const unsigned mask = (valid_q_rows == BLOCK_M) ? 0xFFFFFFFFU : __activemask();
+      const int row = tid / THREADS_PER_ROW;
+      const int thread_in_row = tid % THREADS_PER_ROW;
 
-        float thread_dot = 0.0f;
+      float* sS_row = sS + row * S_STRIDE;
+      float* sdOV_row = sdOV + row * S_STRIDE;
+      __half* sdS_row = sdS + row * S_STRIDE;
 
-        #pragma unroll
-        for (int j = 0; j < work_per_thread; ++j) {
-            const int chunk_idx = thread_in_row + j * THREADS_PER_ROW;
-            if (chunk_idx >= fp16_x4_per_row) break;
-            const int col = chunk_idx * 4;
+      const float lse_val = sLse[row];
+      const float row_dot_val = sRowDot[row];
 
-            const __half* o_addr = o_ptr + row * D + col;
-            ushort o_h0, o_h1, o_h2, o_h3;
-            asm volatile(
-                "ld.global.v4.u16 {%0, %1, %2, %3}, [%4];"
-                : "=h"(o_h0), "=h"(o_h1), "=h"(o_h2), "=h"(o_h3)
-                : "l"(o_addr)
-                : "memory"
-            );
+      const int vec8_cols = valid_k_rows / 8;
+      const int vec8_per_thread =
+          (vec8_cols + THREADS_PER_ROW - 1) / THREADS_PER_ROW;
+      const int tail_start = vec8_cols * 8;
 
-            const __half* dO_addr = sdO + row * Q_STRIDE + col;
-            ushort d_h0, d_h1, d_h2, d_h3;
-            const uint32_t ptr_dO = static_cast<uint32_t>(reinterpret_cast<uintptr_t>(__cvta_generic_to_shared(dO_addr)));
-            asm volatile(
-                "ld.shared.v4.u16 {%0, %1, %2, %3}, [%4];"
-                : "=h"(d_h0), "=h"(d_h1), "=h"(d_h2), "=h"(d_h3)
-                : "r"(ptr_dO)
-                : "memory"
-            );
+      float4* sS_vec4 = reinterpret_cast<float4*>(sS_row);
+      float4* sdOV_vec4 = reinterpret_cast<float4*>(sdOV_row);
+      uint4* sdS_vec_u4 = reinterpret_cast<uint4*>(sdS_row);
 
-            const float fo_0 = __half2float(__ushort_as_half(o_h0));
-            const float fo_1 = __half2float(__ushort_as_half(o_h1));
-            const float fo_2 = __half2float(__ushort_as_half(o_h2));
-            const float fo_3 = __half2float(__ushort_as_half(o_h3));
+      uint4 buf[8];
+      int cnt = 0;
 
-            const float fd_0 = __half2float(__ushort_as_half(d_h0));
-            const float fd_1 = __half2float(__ushort_as_half(d_h1));
-            const float fd_2 = __half2float(__ushort_as_half(d_h2));
-            const float fd_3 = __half2float(__ushort_as_half(d_h3));
+#pragma unroll
+      for (int j = 0; j < vec8_per_thread; ++j) {
+        const int v8 = thread_in_row + j * THREADS_PER_ROW;
+        if (v8 >= vec8_cols) break;
 
-            thread_dot = __fmaf_rn(fo_0, fd_0, thread_dot);
-            thread_dot = __fmaf_rn(fo_1, fd_1, thread_dot);
-            thread_dot = __fmaf_rn(fo_2, fd_2, thread_dot);
-            thread_dot = __fmaf_rn(fo_3, fd_3, thread_dot);
+        float4 s0 = sS_vec4[v8 * 2], s1 = sS_vec4[v8 * 2 + 1];
+        float4 d0 = sdOV_vec4[v8 * 2], d1 = sdOV_vec4[v8 * 2 + 1];
+
+#define COMP(i, sf, df)                                 \
+  float sh##i = (sf) - lse_val;                         \
+  float p##i = (sh##i < -80.0f) ? 0.0f : __expf(sh##i); \
+  float ds##i = p##i * softmax_scale * ((df) - row_dot_val);
+
+        COMP(0, s0.x, d0.x)
+        COMP(1, s0.y, d0.y)
+        COMP(2, s0.z, d0.z)
+        COMP(3, s0.w, d0.w)
+        COMP(4, s1.x, d1.x)
+        COMP(5, s1.y, d1.y)
+        COMP(6, s1.z, d1.z)
+        COMP(7, s1.w, d1.w)
+#undef COMP
+
+        uint4 res;
+        asm volatile(
+            "{ mov.b32 %0, {%4,%5}; mov.b32 %1, {%6,%7}; mov.b32 %2, {%8,%9}; "
+            "mov.b32 %3, {%10,%11}; }\n"
+            : "=r"(res.x), "=r"(res.y), "=r"(res.z), "=r"(res.w)
+            : "h"(__half_as_ushort(__float2half_rn(ds0))),
+              "h"(__half_as_ushort(__float2half_rn(ds1))),
+              "h"(__half_as_ushort(__float2half_rn(ds2))),
+              "h"(__half_as_ushort(__float2half_rn(ds3))),
+              "h"(__half_as_ushort(__float2half_rn(ds4))),
+              "h"(__half_as_ushort(__float2half_rn(ds5))),
+              "h"(__half_as_ushort(__float2half_rn(ds6))),
+              "h"(__half_as_ushort(__float2half_rn(ds7))));
+        buf[cnt++] = res;
+      }
+
+#pragma unroll
+      for (int c = tail_start + thread_in_row; c < BLOCK_N;
+           c += THREADS_PER_ROW) {
+        float s = (c < valid_k_rows) ? sS_row[c] : NEG_INF;
+        float dov = (c < valid_k_rows) ? sdOV_row[c] : 0.0f;
+        float p = (s - lse_val < -80.0f) ? 0.0f : __expf(s - lse_val);
+        float ds = p * softmax_scale *
+                   ((c < valid_k_rows) ? (dov - row_dot_val) : 0.0f);
+        sdS_row[c] = __float2half_rn(ds);
+      }
+
+#pragma unroll
+      for (int i = 0; i < cnt; ++i) {
+        const int v8 = thread_in_row + i * THREADS_PER_ROW;
+        if (v8 < vec8_cols) {
+          sdS_vec_u4[v8] = buf[i];
         }
-
-        #pragma unroll
-        for (int o = THREADS_PER_ROW / 2; o > 0; o >>= 1)
-            thread_dot += __shfl_down_sync(mask, thread_dot, o, THREADS_PER_ROW);
-
-        if (thread_in_row == 0) {
-            sRowDot[row] = thread_dot;
-        }
+      }
     }
-
-    if (tid < valid_q_rows) { sLse[tid] = lse_ptr[tid]; }
     __syncthreads();
 
-    for (int block_n = 0; block_n < num_n_tiles; ++block_n) {
-        const int start_col = block_n * BLOCK_N;
-        if (start_col >= N) break;
-        const int valid_k_rows = min(BLOCK_N, N - start_col);
+    const int num_tiles_m_dq = (BLOCK_M + WMMA_M - 1) / WMMA_M;
+    const int num_tiles_n_dq = (D + WMMA_N - 1) / WMMA_N;
+    const int num_tiles_k_dq = (BLOCK_N + WMMA_K - 1) / WMMA_K;
+    const int total_tiles_dq = num_tiles_m_dq * num_tiles_n_dq;
+    const int tiles_per_warp_dq =
+        (total_tiles_dq + WARPS_PER_BLOCK - 1) / WARPS_PER_BLOCK;
 
-        if constexpr (IS_CAUSAL) {
-            if (start_col >= start_row + valid_q_rows) { continue; }
-        }
+    for (int tile_local = 0; tile_local < tiles_per_warp_dq; ++tile_local) {
+      const int global_tile_idx = warp_id * tiles_per_warp_dq + tile_local;
+      if (global_tile_idx >= total_tiles_dq) break;
 
-        const uint4* v_vec        = reinterpret_cast<const uint4*>(v_ptr + start_col * D);
-        uint4*       sV_vec       = reinterpret_cast<uint4*>(sV);
+      const int tile_m_idx = global_tile_idx / num_tiles_n_dq;
+      const int tile_n_idx = global_tile_idx % num_tiles_n_dq;
 
-        #pragma unroll 2
-        for (int idx = tid; idx < NUM_UINT4_KV_BLOCK; idx += THREADS_PER_BLOCK) {
-            const int row = idx / d_stride_uint4;
-            const int vec_col = idx % d_stride_uint4;
-            uint4 v_val = make_uint4(0, 0, 0, 0);
-            if (row < valid_k_rows && vec_col < d_stride_uint4) {
-                v_val = __ldg(&v_vec[row * d_stride_uint4 + vec_col]);
-            }
-            sV_vec[row * kv_stride_uint4 + vec_col] = v_val;
-        }
-        __syncthreads();
+      const int tile_m = tile_m_idx * WMMA_M;
+      const int tile_n = tile_n_idx * WMMA_N;
 
-        const int num_tiles_m_dov    = (BLOCK_M + WMMA_M - 1) / WMMA_M;
-        const int num_tiles_n_dov    = (BLOCK_N + WMMA_N - 1) / WMMA_N;
-        const int num_tiles_k_dov    = (D + WMMA_K - 1) / WMMA_K;
-        const int total_tiles_dov    = num_tiles_m_dov * num_tiles_n_dov;
-        const int tiles_per_warp_dov = (total_tiles_dov + WARPS_PER_BLOCK - 1) / WARPS_PER_BLOCK;
+      if (tile_m >= valid_q_rows || tile_n >= D) continue;
 
-        for (int tile_idx = 0; tile_idx < tiles_per_warp_dov; ++tile_idx) {
-            const int global_tile_idx = warp_id * tiles_per_warp_dov + tile_idx;
+      fragment<matrix_a, WMMA_M, WMMA_N, WMMA_K, __half, row_major> a_frag;
+      fragment<matrix_b, WMMA_M, WMMA_N, WMMA_K, __half, row_major> b_frag;
+      fragment<accumulator, WMMA_M, WMMA_N, WMMA_K, float> acc_frag;
+      fill_fragment(acc_frag, 0.0f);
 
-            if (global_tile_idx >= total_tiles_dov) break;
+#pragma unroll
+      for (int k_tile = 0; k_tile < num_tiles_k_dq; ++k_tile) {
+        const int k_offset = k_tile * WMMA_K;
+        if (k_offset >= valid_k_rows) break;
 
-            const int tile_m_idx = global_tile_idx / num_tiles_n_dov;
-            const int tile_n_idx = global_tile_idx % num_tiles_n_dov;
+        load_matrix_sync(a_frag, sdS + tile_m * S_STRIDE + k_offset, S_STRIDE);
+        load_matrix_sync(b_frag, sK + k_offset * KV_STRIDE + tile_n, KV_STRIDE);
+        mma_sync(acc_frag, a_frag, b_frag, acc_frag);
+      }
 
-            const int tile_m = tile_m_idx * WMMA_M;
-            const int tile_n = tile_n_idx * WMMA_N;
+      fragment<accumulator, WMMA_M, WMMA_N, WMMA_K, float> curr_frag;
+      load_matrix_sync(curr_frag, sdQ + tile_m * Q_STRIDE + tile_n, Q_STRIDE,
+                       mem_row_major);
 
-            if (tile_m >= valid_q_rows || tile_n >= valid_k_rows) continue;
-
-            fragment<matrix_a, WMMA_M, WMMA_N, WMMA_K, __half, row_major> a_frag;
-            fragment<matrix_b, WMMA_M, WMMA_N, WMMA_K, __half, col_major> b_frag;
-            fragment<accumulator, WMMA_M, WMMA_N, WMMA_K, float> acc_frag;
-
-            fill_fragment(acc_frag, 0.0f);
-
-            #pragma unroll
-            for (int k_tile = 0; k_tile < num_tiles_k_dov; ++k_tile) {
-                const int k_offset = k_tile * WMMA_K;
-                if (k_offset >= D) break;
-                load_matrix_sync(a_frag, sdO + tile_m * Q_STRIDE + k_offset, Q_STRIDE);
-                load_matrix_sync(b_frag, sV + tile_n * KV_STRIDE + k_offset, KV_STRIDE);
-                mma_sync(acc_frag, a_frag, b_frag, acc_frag);
-            }
-
-            store_matrix_sync(sdOV + tile_m * S_STRIDE + tile_n, acc_frag, S_STRIDE, mem_row_major);
-        }
-        __syncthreads();
-
-        const uint4* k_vec     = reinterpret_cast<const uint4*>(k_ptr + start_col * D);
-        uint4*       sK_vec    = reinterpret_cast<uint4*>(sK);
-
-        #pragma unroll 2
-        for (int idx = tid; idx < NUM_UINT4_KV_BLOCK; idx += THREADS_PER_BLOCK) {
-            const int row = idx / d_stride_uint4;
-            const int vec_col = idx % d_stride_uint4;
-            uint4 k_val = make_uint4(0, 0, 0, 0);
-            if (row < valid_k_rows && vec_col < d_stride_uint4) {
-                k_val = __ldg(&k_vec[row * d_stride_uint4 + vec_col]);
-            }
-            sK_vec[row * kv_stride_uint4 + vec_col] = k_val;
-        }
-        __syncthreads();
-
-        const int num_tiles_m_qk    = (BLOCK_M + WMMA_M - 1) / WMMA_M;
-        const int num_tiles_n_qk    = (BLOCK_N + WMMA_N - 1) / WMMA_N;
-        const int num_tiles_k_qk    = (D + WMMA_K - 1) / WMMA_K;
-        const int total_tiles_qk    = num_tiles_m_qk * num_tiles_n_qk;
-        const int tiles_per_warp_qk = (total_tiles_qk + WARPS_PER_BLOCK - 1) / WARPS_PER_BLOCK;
-        const unsigned row_causal   = (lane_id & 0b1) + ((lane_id >> 2) & 0b1) * 8 + ((lane_id >> 4) & 0b1) * 4;
-        const unsigned col_causal   = ((lane_id >> 1) & 0b1) * 2 + ((lane_id >> 3) & 0b1) * 8;
-
-        for (int tile_idx = 0; tile_idx < tiles_per_warp_qk; ++tile_idx) {
-            const int global_tile_idx = warp_id * tiles_per_warp_qk + tile_idx;
-
-            if (global_tile_idx >= total_tiles_qk) break;
-
-            const int tile_m_idx = global_tile_idx / num_tiles_n_qk;
-            const int tile_n_idx = global_tile_idx % num_tiles_n_qk;
-
-            const int tile_m = tile_m_idx * WMMA_M;
-            const int tile_n = tile_n_idx * WMMA_N;
-
-            if (tile_m >= valid_q_rows || tile_n >= valid_k_rows) continue;
-
-            fragment<matrix_a, WMMA_M, WMMA_N, WMMA_K, __half, row_major> a_frag;
-            fragment<matrix_b, WMMA_M, WMMA_N, WMMA_K, __half, col_major> b_frag;
-            fragment<accumulator, WMMA_M, WMMA_N, WMMA_K, float> acc_frag;
-
-            fill_fragment(acc_frag, 0.0f);
-
-            #pragma unroll
-            for (int k_tile = 0; k_tile < num_tiles_k_qk; ++k_tile) {
-                const int k_offset = k_tile * WMMA_K;
-                if (k_offset >= D) break;
-                load_matrix_sync(a_frag, sQ + tile_m * Q_STRIDE + k_offset, Q_STRIDE);
-                load_matrix_sync(b_frag, sK + tile_n * KV_STRIDE + k_offset, KV_STRIDE);
-                mma_sync(acc_frag, a_frag, b_frag, acc_frag);
-            }
-
-            if constexpr (IS_CAUSAL) {
-                #pragma unroll
-                for (int i = 0; i < acc_frag.num_elements; ++i) {
-                    const unsigned col = col_causal + (i & 0b1) + ((i >> 2) & 0b1) * 4;
-                    const unsigned row = row_causal + ((i >> 1) & 0b1) * 2;
-
-                    const int global_m = start_row + tile_m + row;
-                    const int global_n = start_col + tile_n + col;
-
-                    const bool is_valid = (global_m < start_row + valid_q_rows) &&
-                                          (global_n < start_col + valid_k_rows);
-
-                    acc_frag.x[i] = is_valid
-                        ? ((global_n > global_m) ? NEG_INF : acc_frag.x[i] * softmax_scale)
-                        : NEG_INF;
-                }
-            } else {
-                #pragma unroll
-                for (int i = 0; i < acc_frag.num_elements; ++i) {
-                    acc_frag.x[i] *= softmax_scale;
-                }
-            }
-            store_matrix_sync(sS + tile_m * S_STRIDE + tile_n, acc_frag, S_STRIDE, mem_row_major);
-        }
-        __syncthreads();
-
-        if (tid < valid_q_rows * THREADS_PER_ROW) {
-            const int row = tid / THREADS_PER_ROW;
-            const int thread_in_row = tid % THREADS_PER_ROW;
-
-            float*  sS_row   = sS   + row * S_STRIDE;
-            float*  sdOV_row = sdOV + row * S_STRIDE;
-            __half* sdS_row  = sdS  + row * S_STRIDE;
-
-            const float lse_val     = sLse[row];
-            const float row_dot_val = sRowDot[row];
-
-            const int vec8_cols = valid_k_rows / 8;
-            const int vec8_per_thread = (vec8_cols + THREADS_PER_ROW - 1) / THREADS_PER_ROW;
-            const int tail_start = vec8_cols * 8;
-
-            float4* sS_vec4    = reinterpret_cast<float4*>(sS_row);
-            float4* sdOV_vec4  = reinterpret_cast<float4*>(sdOV_row);
-            uint4*  sdS_vec_u4 = reinterpret_cast<uint4*>(sdS_row);
-
-            uint4 buf[8]; int cnt = 0;
-
-            #pragma unroll
-            for (int j = 0; j < vec8_per_thread; ++j) {
-                const int v8 = thread_in_row + j * THREADS_PER_ROW;
-                if (v8 >= vec8_cols) break;
-
-                float4 s0 = sS_vec4[v8 * 2],   s1 = sS_vec4[v8 * 2 + 1];
-                float4 d0 = sdOV_vec4[v8 * 2], d1 = sdOV_vec4[v8 * 2 + 1];
-
-                #define COMP(i, sf, df) \
-                    float sh##i = (sf) - lse_val; \
-                    float p##i = (sh##i < -80.0f) ? 0.0f : __expf(sh##i); \
-                    float ds##i = p##i * softmax_scale * ((df) - row_dot_val);
-
-                COMP(0, s0.x, d0.x) COMP(1, s0.y, d0.y) COMP(2, s0.z, d0.z) COMP(3, s0.w, d0.w)
-                COMP(4, s1.x, d1.x) COMP(5, s1.y, d1.y) COMP(6, s1.z, d1.z) COMP(7, s1.w, d1.w)
-                #undef COMP
-
-                uint4 res;
-                asm volatile(
-                    "{ mov.b32 %0, {%4,%5}; mov.b32 %1, {%6,%7}; mov.b32 %2, {%8,%9}; mov.b32 %3, {%10,%11}; }\n"
-                    : "=r"(res.x), "=r"(res.y), "=r"(res.z), "=r"(res.w)
-                    : "h"(__half_as_ushort(__float2half_rn(ds0))),
-                      "h"(__half_as_ushort(__float2half_rn(ds1))),
-                      "h"(__half_as_ushort(__float2half_rn(ds2))),
-                      "h"(__half_as_ushort(__float2half_rn(ds3))),
-                      "h"(__half_as_ushort(__float2half_rn(ds4))),
-                      "h"(__half_as_ushort(__float2half_rn(ds5))),
-                      "h"(__half_as_ushort(__float2half_rn(ds6))),
-                      "h"(__half_as_ushort(__float2half_rn(ds7)))
-                );
-                buf[cnt++] = res;
-            }
-
-            #pragma unroll
-            for (int c = tail_start + thread_in_row; c < BLOCK_N; c += THREADS_PER_ROW) {
-                float s = (c < valid_k_rows) ? sS_row[c] : NEG_INF;
-                float dov = (c < valid_k_rows) ? sdOV_row[c] : 0.0f;
-                float p = (s - lse_val < -80.0f) ? 0.0f : __expf(s - lse_val);
-                float ds = p * softmax_scale * ((c < valid_k_rows) ? (dov - row_dot_val) : 0.0f);
-                sdS_row[c] = __float2half_rn(ds);
-            }
-
-            #pragma unroll
-            for (int i = 0; i < cnt; ++i) {
-                    const int v8 = thread_in_row + i * THREADS_PER_ROW;
-                    if (v8 < vec8_cols) {
-                        sdS_vec_u4[v8] = buf[i];
-                    }
-            }
-        }
-        __syncthreads();
-
-        const int num_tiles_m_dq    = (BLOCK_M + WMMA_M - 1) / WMMA_M;
-        const int num_tiles_n_dq    = (D + WMMA_N - 1) / WMMA_N;
-        const int num_tiles_k_dq    = (BLOCK_N + WMMA_K - 1) / WMMA_K;
-        const int total_tiles_dq    = num_tiles_m_dq * num_tiles_n_dq;
-        const int tiles_per_warp_dq = (total_tiles_dq + WARPS_PER_BLOCK - 1) / WARPS_PER_BLOCK;
-
-        for (int tile_local = 0; tile_local < tiles_per_warp_dq; ++tile_local) {
-            const int global_tile_idx = warp_id * tiles_per_warp_dq + tile_local;
-            if (global_tile_idx >= total_tiles_dq) break;
-
-            const int tile_m_idx = global_tile_idx / num_tiles_n_dq;
-            const int tile_n_idx = global_tile_idx % num_tiles_n_dq;
-
-            const int tile_m = tile_m_idx * WMMA_M;
-            const int tile_n = tile_n_idx * WMMA_N;
-
-            if (tile_m >= valid_q_rows || tile_n >= D) continue;
-
-            fragment<matrix_a, WMMA_M, WMMA_N, WMMA_K, __half, row_major> a_frag;
-            fragment<matrix_b, WMMA_M, WMMA_N, WMMA_K, __half, row_major> b_frag;
-            fragment<accumulator, WMMA_M, WMMA_N, WMMA_K, float> acc_frag;
-            fill_fragment(acc_frag, 0.0f);
-
-            #pragma unroll
-            for (int k_tile = 0; k_tile < num_tiles_k_dq; ++k_tile) {
-                const int k_offset = k_tile * WMMA_K;
-                if (k_offset >= valid_k_rows) break;
-
-                load_matrix_sync(a_frag, sdS + tile_m * S_STRIDE + k_offset, S_STRIDE);
-                load_matrix_sync(b_frag, sK + k_offset * KV_STRIDE + tile_n, KV_STRIDE);
-                mma_sync(acc_frag, a_frag, b_frag, acc_frag);
-            }
-
-            fragment<accumulator, WMMA_M, WMMA_N, WMMA_K, float> curr_frag;
-            load_matrix_sync(curr_frag, sdQ + tile_m * Q_STRIDE + tile_n, Q_STRIDE, mem_row_major);
-
-            #pragma unroll
-            for (int i = 0; i < curr_frag.num_elements; ++i) {
-                curr_frag.x[i] += acc_frag.x[i];
-            }
-            store_matrix_sync(sdQ + tile_m * Q_STRIDE + tile_n, curr_frag, Q_STRIDE, mem_row_major);
-        }
-        __syncthreads();
+#pragma unroll
+      for (int i = 0; i < curr_frag.num_elements; ++i) {
+        curr_frag.x[i] += acc_frag.x[i];
+      }
+      store_matrix_sync(sdQ + tile_m * Q_STRIDE + tile_n, curr_frag, Q_STRIDE,
+                        mem_row_major);
     }
+    __syncthreads();
+  }
 
-    const int total_fp16_x4 = (valid_q_rows * D) / 4;
-    for (int i = tid; i < total_fp16_x4; i += THREADS_PER_BLOCK) {
-        const int row = i / (D / 4);
-        const int col = (i % (D / 4)) * 4;
+  const int total_fp16_x4 = (valid_q_rows * D) / 4;
+  for (int i = tid; i < total_fp16_x4; i += THREADS_PER_BLOCK) {
+    const int row = i / (D / 4);
+    const int col = (i % (D / 4)) * 4;
 
-        const float* s_dQ_row = sdQ + row * Q_STRIDE;
+    const float* s_dQ_row = sdQ + row * Q_STRIDE;
 
-        const __half h0 = __float2half_rn(s_dQ_row[col + 0]);
-        const __half h1 = __float2half_rn(s_dQ_row[col + 1]);
-        const __half h2 = __float2half_rn(s_dQ_row[col + 2]);
-        const __half h3 = __float2half_rn(s_dQ_row[col + 3]);
+    const __half h0 = __float2half_rn(s_dQ_row[col + 0]);
+    const __half h1 = __float2half_rn(s_dQ_row[col + 1]);
+    const __half h2 = __float2half_rn(s_dQ_row[col + 2]);
+    const __half h3 = __float2half_rn(s_dQ_row[col + 3]);
 
-        asm volatile(
-            "st.global.v4.u16 [%0], {%1, %2, %3, %4};"
-            :
-            : "l"(dQ_ptr + row * D + col),
-              "h"(__half_as_ushort(h0)),
-              "h"(__half_as_ushort(h1)),
-              "h"(__half_as_ushort(h2)),
-              "h"(__half_as_ushort(h3))
-            : "memory"
-        );
-    }
+    asm volatile("st.global.v4.u16 [%0], {%1, %2, %3, %4};"
+                 :
+                 : "l"(dQ_ptr + row * D + col), "h"(__half_as_ushort(h0)),
+                   "h"(__half_as_ushort(h1)), "h"(__half_as_ushort(h2)),
+                   "h"(__half_as_ushort(h3))
+                 : "memory");
+  }
 }
 
-template<int D, bool IS_CAUSAL>
+template <int D, bool IS_CAUSAL>
 __global__ void __launch_bounds__(dKVKernelConfig<D>::THREADS_PER_BLOCK, 2)
-flash_attention_backward_dkv_kernel(
-    const __half* __restrict__ Q,
-    const __half* __restrict__ K,
-    const __half* __restrict__ V,
-    const __half* __restrict__ O,
-    const __half* __restrict__ dO,
-    const  float* __restrict__ softmax_lse,
-          __half* __restrict__ dK,
-          __half* __restrict__ dV,
-    const int B,
-    const int H,
-    const int M,
-    const int N,
-    const float softmax_scale
-) {
-    using Config = dKVKernelConfig<D>;
-    constexpr int BLOCK_M            = Config::BLOCK_M;
-    constexpr int BLOCK_N            = Config::BLOCK_N;
-    constexpr int THREADS_PER_BLOCK  = Config::THREADS_PER_BLOCK;
-    constexpr int THREADS_PER_ROW    = Config::THREADS_PER_ROW;
-    constexpr int WARPS_PER_BLOCK    = Config::WARPS_PER_BLOCK;
-    constexpr int Q_STRIDE           = Config::Q_STRIDE;
-    constexpr int KV_STRIDE          = Config::KV_STRIDE;
-    constexpr int S_STRIDE           = Config::S_STRIDE;
-    constexpr int PER_UINT4          = Config::PER_UINT4;
-    constexpr int NUM_UINT4_Q_BLOCK  = Config::NUM_UINT4_Q_BLOCK;
-    constexpr int NUM_UINT4_KV_BLOCK = Config::NUM_UINT4_KV_BLOCK;
+    flash_attention_backward_dkv_kernel(
+        const __half* __restrict__ Q, const __half* __restrict__ K,
+        const __half* __restrict__ V, const __half* __restrict__ O,
+        const __half* __restrict__ dO, const float* __restrict__ softmax_lse,
+        __half* __restrict__ dK, __half* __restrict__ dV, const int B,
+        const int H, const int M, const int N, const float softmax_scale) {
+  using Config = dKVKernelConfig<D>;
+  constexpr int BLOCK_M = Config::BLOCK_M;
+  constexpr int BLOCK_N = Config::BLOCK_N;
+  constexpr int THREADS_PER_BLOCK = Config::THREADS_PER_BLOCK;
+  constexpr int THREADS_PER_ROW = Config::THREADS_PER_ROW;
+  constexpr int WARPS_PER_BLOCK = Config::WARPS_PER_BLOCK;
+  constexpr int Q_STRIDE = Config::Q_STRIDE;
+  constexpr int KV_STRIDE = Config::KV_STRIDE;
+  constexpr int S_STRIDE = Config::S_STRIDE;
+  constexpr int PER_UINT4 = Config::PER_UINT4;
+  constexpr int NUM_UINT4_Q_BLOCK = Config::NUM_UINT4_Q_BLOCK;
+  constexpr int NUM_UINT4_KV_BLOCK = Config::NUM_UINT4_KV_BLOCK;
 
-    const float NEG_INF = -1e30f;
-    const int batch_head_id = blockIdx.z;
-    if (batch_head_id >= B * H) return;
+  const float NEG_INF = -1e30f;
+  const int batch_head_id = blockIdx.z;
+  if (batch_head_id >= B * H) return;
 
-    const int block_kv = blockIdx.x;
-    const int start_kv = block_kv * BLOCK_M;
-    if (start_kv >= N) return;
+  const int block_kv = blockIdx.x;
+  const int start_kv = block_kv * BLOCK_M;
+  if (start_kv >= N) return;
 
-    int num_q_tiles = (M + BLOCK_N - 1) / BLOCK_N;
-    const int valid_kv_rows = min(BLOCK_M, N - start_kv);
+  int num_q_tiles = (M + BLOCK_N - 1) / BLOCK_N;
+  const int valid_kv_rows = min(BLOCK_M, N - start_kv);
 
-    const int tid     = threadIdx.x;
-    const int warp_id = tid / MAX_THREADS_PER_WARP;
-    const int lane_id = tid % MAX_THREADS_PER_WARP;
+  const int tid = threadIdx.x;
+  const int warp_id = tid / MAX_THREADS_PER_WARP;
+  const int lane_id = tid % MAX_THREADS_PER_WARP;
 
-    const __half*   q_ptr = Q           + (size_t)batch_head_id * M * D;
-    const __half*   k_ptr = K           + (size_t)batch_head_id * N * D + start_kv * D;
-    const __half*   v_ptr = V           + (size_t)batch_head_id * N * D + start_kv * D;
-    const __half*   o_ptr = O           + (size_t)batch_head_id * M * D;
-    const __half*  dO_ptr = dO          + (size_t)batch_head_id * M * D;
-    const  float* lse_ptr = softmax_lse + (size_t)batch_head_id * M;
-          __half*  dK_ptr = dK          + (size_t)batch_head_id * N * D + start_kv * D;
-          __half*  dV_ptr = dV          + (size_t)batch_head_id * N * D + start_kv * D;
+  const __half* q_ptr = Q + (size_t)batch_head_id * M * D;
+  const __half* k_ptr = K + (size_t)batch_head_id * N * D + start_kv * D;
+  const __half* v_ptr = V + (size_t)batch_head_id * N * D + start_kv * D;
+  const __half* o_ptr = O + (size_t)batch_head_id * M * D;
+  const __half* dO_ptr = dO + (size_t)batch_head_id * M * D;
+  const float* lse_ptr = softmax_lse + (size_t)batch_head_id * M;
+  __half* dK_ptr = dK + (size_t)batch_head_id * N * D + start_kv * D;
+  __half* dV_ptr = dV + (size_t)batch_head_id * N * D + start_kv * D;
 
-    extern __shared__ char smem_raw[];
-    init_smem<Config>(smem_raw);
-    auto& smem = *reinterpret_cast<typename Config::SmemLayout*>(smem_raw);
+  extern __shared__ char smem_raw[];
+  init_smem<Config>(smem_raw);
+  auto& smem = *reinterpret_cast<typename Config::SmemLayout*>(smem_raw);
 
-    __half* sK       = smem.k;
-    __half* sV       = smem.v;
-    __half* sdO      = smem.reuse_qdO.dO;
-    __half* sQ       = smem.reuse_qdO.q;
-     float* sS       = smem.reuse_sp.s;
-    __half* sP       = smem.reuse_sp.p;
-     float* sdOV     = smem.reuse_dOVS.dOV;
-    __half* sdS      = smem.reuse_dOVS.dS;
-     float* sRowDot  = smem.row_dot;
-     float* sLse     = smem.lse;
-     float* sdK      = smem.dK;
-     float* sdV      = smem.dV;
+  __half* sK = smem.k;
+  __half* sV = smem.v;
+  __half* sdO = smem.reuse_qdO.dO;
+  __half* sQ = smem.reuse_qdO.q;
+  float* sS = smem.reuse_sp.s;
+  __half* sP = smem.reuse_sp.p;
+  float* sdOV = smem.reuse_dOVS.dOV;
+  __half* sdS = smem.reuse_dOVS.dS;
+  float* sRowDot = smem.row_dot;
+  float* sLse = smem.lse;
+  float* sdK = smem.dK;
+  float* sdV = smem.dV;
 
-    const int  d_stride_uint4 = (D + PER_UINT4 - 1) / PER_UINT4;
-    const int  q_stride_uint4 = (Q_STRIDE  + PER_UINT4 - 1) / PER_UINT4;
-    const int kv_stride_uint4 = (KV_STRIDE + PER_UINT4 - 1) / PER_UINT4;
+  const int d_stride_uint4 = (D + PER_UINT4 - 1) / PER_UINT4;
+  const int q_stride_uint4 = (Q_STRIDE + PER_UINT4 - 1) / PER_UINT4;
+  const int kv_stride_uint4 = (KV_STRIDE + PER_UINT4 - 1) / PER_UINT4;
 
-    const uint4* k_vec = reinterpret_cast<const uint4*>(k_ptr);
-    const uint4* v_vec = reinterpret_cast<const uint4*>(v_ptr);
-    uint4* sK_vec = reinterpret_cast<uint4*>(sK);
-    uint4* sV_vec = reinterpret_cast<uint4*>(sV);
+  const uint4* k_vec = reinterpret_cast<const uint4*>(k_ptr);
+  const uint4* v_vec = reinterpret_cast<const uint4*>(v_ptr);
+  uint4* sK_vec = reinterpret_cast<uint4*>(sK);
+  uint4* sV_vec = reinterpret_cast<uint4*>(sV);
 
-    #pragma unroll 2
-    for (int idx = tid; idx < NUM_UINT4_KV_BLOCK; idx += THREADS_PER_BLOCK) {
-        const int row = idx / d_stride_uint4;
-        const int vec_col = idx % d_stride_uint4;
+#pragma unroll 2
+  for (int idx = tid; idx < NUM_UINT4_KV_BLOCK; idx += THREADS_PER_BLOCK) {
+    const int row = idx / d_stride_uint4;
+    const int vec_col = idx % d_stride_uint4;
 
-        uint4 k_val = make_uint4(0, 0, 0, 0);
-        uint4 v_val = make_uint4(0, 0, 0, 0);
+    uint4 k_val = make_uint4(0, 0, 0, 0);
+    uint4 v_val = make_uint4(0, 0, 0, 0);
 
-        if (row < valid_kv_rows && vec_col < d_stride_uint4) {
-            k_val = __ldg(&k_vec[row * d_stride_uint4 + vec_col]);
-            v_val = __ldg(&v_vec[row * d_stride_uint4 + vec_col]);
-        }
-        sK_vec[row * kv_stride_uint4 + vec_col] = k_val;
-        sV_vec[row * kv_stride_uint4 + vec_col] = v_val;
+    if (row < valid_kv_rows && vec_col < d_stride_uint4) {
+      k_val = __ldg(&k_vec[row * d_stride_uint4 + vec_col]);
+      v_val = __ldg(&v_vec[row * d_stride_uint4 + vec_col]);
+    }
+    sK_vec[row * kv_stride_uint4 + vec_col] = k_val;
+    sV_vec[row * kv_stride_uint4 + vec_col] = v_val;
+  }
+  __syncthreads();
+
+  for (int block_n = 0; block_n < num_q_tiles; ++block_n) {
+    const int start_col = block_n * BLOCK_N;
+    if (start_col >= M) break;
+    const int valid_q_rows = min(BLOCK_N, M - start_col);
+
+    if constexpr (IS_CAUSAL) {
+      if (start_kv >= start_col + valid_q_rows) {
+        continue;
+      }
+    }
+
+    const uint4* q_vec = reinterpret_cast<const uint4*>(q_ptr + start_col * D);
+    uint4* sQ_vec = reinterpret_cast<uint4*>(sdO);
+
+#pragma unroll 2
+    for (int idx = tid; idx < NUM_UINT4_Q_BLOCK; idx += THREADS_PER_BLOCK) {
+      const int row = idx / d_stride_uint4;
+      const int vec_col = idx % d_stride_uint4;
+      uint4 q_val = make_uint4(0, 0, 0, 0);
+      if (row < valid_q_rows && vec_col < d_stride_uint4) {
+        q_val = __ldg(&q_vec[row * d_stride_uint4 + vec_col]);
+      }
+      sQ_vec[row * q_stride_uint4 + vec_col] = q_val;
     }
     __syncthreads();
 
-    for (int block_n = 0; block_n < num_q_tiles; ++block_n) {
-        const int start_col = block_n * BLOCK_N;
-        if (start_col >= M) break;
-        const int valid_q_rows = min(BLOCK_N, M - start_col);
+    const int num_tiles_m_qk = (BLOCK_N + WMMA_M - 1) / WMMA_M;
+    const int num_tiles_n_qk = (BLOCK_M + WMMA_N - 1) / WMMA_N;
+    const int num_tiles_k_qk = (D + WMMA_K - 1) / WMMA_K;
+    const int total_tiles_qk = num_tiles_m_qk * num_tiles_n_qk;
+    const int tiles_per_warp_qk =
+        (total_tiles_qk + WARPS_PER_BLOCK - 1) / WARPS_PER_BLOCK;
+    const unsigned row_causal = (lane_id & 0b1) + ((lane_id >> 2) & 0b1) * 8 +
+                                ((lane_id >> 4) & 0b1) * 4;
+    const unsigned col_causal =
+        ((lane_id >> 1) & 0b1) * 2 + ((lane_id >> 3) & 0b1) * 8;
 
-        if constexpr (IS_CAUSAL) {
-            if (start_kv >= start_col + valid_q_rows) { continue; }
+    for (int tile_local = 0; tile_local < tiles_per_warp_qk; ++tile_local) {
+      const int tile_idx = warp_id * tiles_per_warp_qk + tile_local;
+      if (tile_idx >= total_tiles_qk) break;
+
+      const int tile_m_idx = tile_idx / num_tiles_n_qk;
+      const int tile_n_idx = tile_idx % num_tiles_n_qk;
+
+      const int tile_m = tile_m_idx * WMMA_M;
+      const int tile_n = tile_n_idx * WMMA_N;
+
+      if (tile_m >= valid_q_rows || tile_n >= valid_kv_rows) continue;
+
+      fragment<matrix_a, WMMA_M, WMMA_N, WMMA_K, half, row_major> a_frag;
+      fragment<matrix_b, WMMA_M, WMMA_N, WMMA_K, half, col_major> b_frag;
+      fragment<accumulator, WMMA_M, WMMA_N, WMMA_K, float> acc_frag;
+      fill_fragment(acc_frag, 0.0f);
+
+#pragma unroll
+      for (int k_tile = 0; k_tile < num_tiles_k_qk; ++k_tile) {
+        const int k_offset = k_tile * WMMA_K;
+        if (k_offset >= D) break;
+        load_matrix_sync(a_frag, sQ + tile_m * Q_STRIDE + k_offset, Q_STRIDE);
+        load_matrix_sync(b_frag, sK + tile_n * KV_STRIDE + k_offset, KV_STRIDE);
+        mma_sync(acc_frag, a_frag, b_frag, acc_frag);
+      }
+
+      if constexpr (IS_CAUSAL) {
+#pragma unroll
+        for (int i = 0; i < acc_frag.num_elements; ++i) {
+          const unsigned col = col_causal + (i & 0b1) + ((i >> 2) & 0b1) * 4;
+          const unsigned row = row_causal + ((i >> 1) & 0b1) * 2;
+
+          const int global_m = start_col + tile_m + row;
+          const int global_n = start_kv + tile_n + col;
+
+          const bool is_valid = (global_m < start_col + valid_q_rows) &&
+                                (global_n < start_kv + valid_kv_rows);
+
+          acc_frag.x[i] =
+              is_valid ? ((global_n > global_m) ? NEG_INF
+                                                : acc_frag.x[i] * softmax_scale)
+                       : NEG_INF;
         }
-
-        const uint4* q_vec = reinterpret_cast<const uint4*>(q_ptr + start_col * D);
-        uint4*      sQ_vec = reinterpret_cast<uint4*>(sdO);
-
-        #pragma unroll 2
-        for (int idx = tid; idx < NUM_UINT4_Q_BLOCK; idx += THREADS_PER_BLOCK) {
-            const int row = idx / d_stride_uint4;
-            const int vec_col = idx % d_stride_uint4;
-            uint4 q_val = make_uint4(0, 0, 0, 0);
-            if (row < valid_q_rows && vec_col < d_stride_uint4) {
-                q_val = __ldg(&q_vec[row * d_stride_uint4 + vec_col]);
-            }
-            sQ_vec[row * q_stride_uint4 + vec_col] = q_val;
+      } else {
+#pragma unroll
+        for (int i = 0; i < acc_frag.num_elements; ++i) {
+          acc_frag.x[i] *= softmax_scale;
         }
-        __syncthreads();
+      }
+      store_matrix_sync(sS + tile_m * S_STRIDE + tile_n, acc_frag, S_STRIDE,
+                        mem_row_major);
+    }
+    __syncthreads();
 
-        const int num_tiles_m_qk    = (BLOCK_N + WMMA_M - 1) / WMMA_M;
-        const int num_tiles_n_qk    = (BLOCK_M + WMMA_N - 1) / WMMA_N;
-        const int num_tiles_k_qk    = (D + WMMA_K - 1) / WMMA_K;
-        const int total_tiles_qk    = num_tiles_m_qk * num_tiles_n_qk;
-        const int tiles_per_warp_qk = (total_tiles_qk + WARPS_PER_BLOCK - 1) / WARPS_PER_BLOCK;
-        const unsigned row_causal   = (lane_id & 0b1) + ((lane_id >> 2) & 0b1) * 8 + ((lane_id >> 4) & 0b1) * 4;
-        const unsigned col_causal   = ((lane_id >> 1) & 0b1) * 2 + ((lane_id >> 3) & 0b1) * 8;
+    const uint4* do_vec =
+        reinterpret_cast<const uint4*>(dO_ptr + start_col * D);
+    uint4* sdO_vec = reinterpret_cast<uint4*>(sdO);
 
-        for (int tile_local = 0; tile_local < tiles_per_warp_qk; ++tile_local) {
-            const int tile_idx = warp_id * tiles_per_warp_qk + tile_local;
-            if (tile_idx >= total_tiles_qk) break;
+#pragma unroll 2
+    for (int idx = tid; idx < NUM_UINT4_Q_BLOCK; idx += THREADS_PER_BLOCK) {
+      const int row = idx / d_stride_uint4;
+      const int vec_col = idx % d_stride_uint4;
+      uint4 do_val = make_uint4(0, 0, 0, 0);
+      if (row < valid_q_rows && vec_col < d_stride_uint4) {
+        do_val = __ldg(&do_vec[row * d_stride_uint4 + vec_col]);
+      }
+      sdO_vec[row * q_stride_uint4 + vec_col] = do_val;
+    }
+    __syncthreads();
 
-            const int tile_m_idx = tile_idx / num_tiles_n_qk;
-            const int tile_n_idx = tile_idx % num_tiles_n_qk;
+    const __half* current_o_ptr = o_ptr + start_col * D;
 
-            const int tile_m = tile_m_idx * WMMA_M;
-            const int tile_n = tile_n_idx * WMMA_N;
+    if (tid < valid_q_rows * THREADS_PER_ROW) {
+      const int row = tid / THREADS_PER_ROW;
+      const int thread_in_row = tid % THREADS_PER_ROW;
+      const int fp16_x4_per_row = D / 4;
+      const int work_per_thread =
+          (fp16_x4_per_row + THREADS_PER_ROW - 1) / THREADS_PER_ROW;
+      const unsigned mask =
+          (valid_q_rows == BLOCK_N) ? 0xFFFFFFFFU : __activemask();
 
-            if (tile_m >= valid_q_rows || tile_n >= valid_kv_rows) continue;
+      float thread_dot = 0.0f;
 
-            fragment<matrix_a, WMMA_M, WMMA_N, WMMA_K, half, row_major> a_frag;
-            fragment<matrix_b, WMMA_M, WMMA_N, WMMA_K, half, col_major> b_frag;
-            fragment<accumulator, WMMA_M, WMMA_N, WMMA_K, float> acc_frag;
-            fill_fragment(acc_frag, 0.0f);
+#pragma unroll
+      for (int j = 0; j < work_per_thread; ++j) {
+        const int chunk_idx = thread_in_row + j * THREADS_PER_ROW;
+        if (chunk_idx >= fp16_x4_per_row) break;
+        const int col = chunk_idx * 4;
 
-            #pragma unroll
-            for (int k_tile = 0; k_tile < num_tiles_k_qk; ++k_tile) {
-                const int k_offset = k_tile * WMMA_K;
-                if (k_offset >= D) break;
-                load_matrix_sync(a_frag, sQ + tile_m * Q_STRIDE + k_offset, Q_STRIDE);
-                load_matrix_sync(b_frag, sK + tile_n * KV_STRIDE + k_offset, KV_STRIDE);
-                mma_sync(acc_frag, a_frag, b_frag, acc_frag);
-            }
+        const half* o_addr = current_o_ptr + row * D + col;
+        ushort o_h0, o_h1, o_h2, o_h3;
+        asm volatile("ld.global.v4.u16 {%0, %1, %2, %3}, [%4];"
+                     : "=h"(o_h0), "=h"(o_h1), "=h"(o_h2), "=h"(o_h3)
+                     : "l"(o_addr)
+                     : "memory");
 
-            if constexpr (IS_CAUSAL) {
-                #pragma unroll
-                for (int i = 0; i < acc_frag.num_elements; ++i) {
-                    const unsigned col = col_causal + (i & 0b1) + ((i >> 2) & 0b1) * 4;
-                    const unsigned row = row_causal + ((i >> 1) & 0b1) * 2;
+        const half* dO_addr = sdO + row * Q_STRIDE + col;
+        ushort d_h0, d_h1, d_h2, d_h3;
+        const uint32_t ptr_dO = static_cast<uint32_t>(
+            reinterpret_cast<uintptr_t>(__cvta_generic_to_shared(dO_addr)));
+        asm volatile("ld.shared.v4.u16 {%0, %1, %2, %3}, [%4];"
+                     : "=h"(d_h0), "=h"(d_h1), "=h"(d_h2), "=h"(d_h3)
+                     : "r"(ptr_dO)
+                     : "memory");
 
-                    const int global_m = start_col + tile_m + row;
-                    const int global_n = start_kv  + tile_n + col;
+        const float fo_0 = __half2float(__ushort_as_half(o_h0));
+        const float fo_1 = __half2float(__ushort_as_half(o_h1));
+        const float fo_2 = __half2float(__ushort_as_half(o_h2));
+        const float fo_3 = __half2float(__ushort_as_half(o_h3));
 
-                    const bool is_valid = (global_m < start_col + valid_q_rows) &&
-                                          (global_n < start_kv  + valid_kv_rows);
+        const float fd_0 = __half2float(__ushort_as_half(d_h0));
+        const float fd_1 = __half2float(__ushort_as_half(d_h1));
+        const float fd_2 = __half2float(__ushort_as_half(d_h2));
+        const float fd_3 = __half2float(__ushort_as_half(d_h3));
 
-                    acc_frag.x[i] = is_valid
-                        ? ((global_n > global_m) ? NEG_INF : acc_frag.x[i] * softmax_scale)
-                        : NEG_INF;
-                }
-            } else {
-                #pragma unroll
-                for (int i = 0; i < acc_frag.num_elements; ++i) {
-                    acc_frag.x[i] *= softmax_scale;
-                }
-            }
-            store_matrix_sync(sS + tile_m * S_STRIDE + tile_n, acc_frag, S_STRIDE, mem_row_major);
-        }
-        __syncthreads();
+        thread_dot = __fmaf_rn(fo_0, fd_0, thread_dot);
+        thread_dot = __fmaf_rn(fo_1, fd_1, thread_dot);
+        thread_dot = __fmaf_rn(fo_2, fd_2, thread_dot);
+        thread_dot = __fmaf_rn(fo_3, fd_3, thread_dot);
+      }
 
-        const uint4* do_vec = reinterpret_cast<const uint4*>(dO_ptr + start_col * D);
-        uint4*      sdO_vec = reinterpret_cast<uint4*>(sdO);
+#pragma unroll
+      for (int o = THREADS_PER_ROW / 2; o > 0; o >>= 1)
+        thread_dot += __shfl_down_sync(mask, thread_dot, o, THREADS_PER_ROW);
 
-        #pragma unroll 2
-        for (int idx = tid; idx < NUM_UINT4_Q_BLOCK; idx += THREADS_PER_BLOCK) {
-            const int row = idx / d_stride_uint4;
-            const int vec_col = idx % d_stride_uint4;
-            uint4 do_val = make_uint4(0, 0, 0, 0);
-            if (row < valid_q_rows && vec_col < d_stride_uint4) {
-                do_val = __ldg(&do_vec[row * d_stride_uint4 + vec_col]);
-            }
-            sdO_vec[row * q_stride_uint4 + vec_col] = do_val;
-        }
-        __syncthreads();
-
-        const __half* current_o_ptr = o_ptr + start_col * D;
-
-        if (tid < valid_q_rows * THREADS_PER_ROW) {
-            const int row = tid / THREADS_PER_ROW;
-            const int thread_in_row = tid % THREADS_PER_ROW;
-            const int fp16_x4_per_row = D / 4;
-            const int work_per_thread = (fp16_x4_per_row + THREADS_PER_ROW - 1) / THREADS_PER_ROW;
-            const unsigned mask = (valid_q_rows == BLOCK_N) ? 0xFFFFFFFFU : __activemask();
-
-            float thread_dot = 0.0f;
-
-            #pragma unroll
-            for (int j = 0; j < work_per_thread; ++j) {
-                const int chunk_idx = thread_in_row + j * THREADS_PER_ROW;
-                if (chunk_idx >= fp16_x4_per_row) break;
-                const int col = chunk_idx * 4;
-
-                const half* o_addr = current_o_ptr + row * D + col;
-                ushort o_h0, o_h1, o_h2, o_h3;
-                asm volatile(
-                    "ld.global.v4.u16 {%0, %1, %2, %3}, [%4];"
-                    : "=h"(o_h0), "=h"(o_h1), "=h"(o_h2), "=h"(o_h3)
-                    : "l"(o_addr)
-                    : "memory"
-                );
-
-                const half* dO_addr = sdO + row * Q_STRIDE + col;
-                ushort d_h0, d_h1, d_h2, d_h3;
-                const uint32_t ptr_dO = static_cast<uint32_t>(reinterpret_cast<uintptr_t>(__cvta_generic_to_shared(dO_addr)));
-                asm volatile(
-                    "ld.shared.v4.u16 {%0, %1, %2, %3}, [%4];"
-                    : "=h"(d_h0), "=h"(d_h1), "=h"(d_h2), "=h"(d_h3)
-                    : "r"(ptr_dO)
-                    : "memory"
-                );
-
-                const float fo_0 = __half2float(__ushort_as_half(o_h0));
-                const float fo_1 = __half2float(__ushort_as_half(o_h1));
-                const float fo_2 = __half2float(__ushort_as_half(o_h2));
-                const float fo_3 = __half2float(__ushort_as_half(o_h3));
-
-                const float fd_0 = __half2float(__ushort_as_half(d_h0));
-                const float fd_1 = __half2float(__ushort_as_half(d_h1));
-                const float fd_2 = __half2float(__ushort_as_half(d_h2));
-                const float fd_3 = __half2float(__ushort_as_half(d_h3));
-
-                thread_dot = __fmaf_rn(fo_0, fd_0, thread_dot);
-                thread_dot = __fmaf_rn(fo_1, fd_1, thread_dot);
-                thread_dot = __fmaf_rn(fo_2, fd_2, thread_dot);
-                thread_dot = __fmaf_rn(fo_3, fd_3, thread_dot);
-            }
-
-            #pragma unroll
-            for (int o = THREADS_PER_ROW / 2; o > 0; o >>= 1)
-                thread_dot += __shfl_down_sync(mask, thread_dot, o, THREADS_PER_ROW);
-
-            if (thread_in_row == 0) { sRowDot[row] = thread_dot; }
-        }
-
-        if (tid < valid_q_rows) { sLse[tid] = lse_ptr[start_col + tid]; }
-        __syncthreads();
-
-        const int num_tiles_m_dov    = (BLOCK_N + WMMA_M - 1) / WMMA_M;
-        const int num_tiles_n_dov    = (BLOCK_M + WMMA_N - 1) / WMMA_N;
-        const int num_tiles_k_dov    = (D + WMMA_K - 1) / WMMA_K;
-        const int total_tiles_dov    = num_tiles_m_dov * num_tiles_n_dov;
-        const int tiles_per_warp_dov = (total_tiles_dov + WARPS_PER_BLOCK - 1) / WARPS_PER_BLOCK;
-
-        for (int tile_local = 0; tile_local < tiles_per_warp_dov; ++tile_local) {
-            const int tile_idx = warp_id * tiles_per_warp_dov + tile_local;
-            if (tile_idx >= total_tiles_dov) break;
-
-            const int tile_m_idx = tile_idx / num_tiles_n_dov;
-            const int tile_n_idx = tile_idx % num_tiles_n_dov;
-
-            const int tile_m = tile_m_idx * WMMA_M;
-            const int tile_n = tile_n_idx * WMMA_N;
-
-            if (tile_m >= valid_q_rows || tile_n >= valid_kv_rows) continue;
-
-            fragment<matrix_a, WMMA_M, WMMA_N, WMMA_K, half, row_major> a_frag;
-            fragment<matrix_b, WMMA_M, WMMA_N, WMMA_K, half, col_major> b_frag;
-            fragment<accumulator, WMMA_M, WMMA_N, WMMA_K, float> acc_frag;
-            fill_fragment(acc_frag, 0.0f);
-
-            #pragma unroll
-            for (int k_tile = 0; k_tile < num_tiles_k_dov; ++k_tile) {
-                const int k_offset = k_tile * WMMA_K;
-                if (k_offset >= D) break;
-                load_matrix_sync(a_frag, sdO + tile_m * Q_STRIDE + k_offset, Q_STRIDE);
-                load_matrix_sync(b_frag, sV + tile_n * KV_STRIDE + k_offset, KV_STRIDE);
-                mma_sync(acc_frag, a_frag, b_frag, acc_frag);
-            }
-            store_matrix_sync(sdOV + tile_m * S_STRIDE + tile_n, acc_frag, S_STRIDE, mem_row_major);
-        }
-        __syncthreads();
-
-        const int total_elements = BLOCK_N * BLOCK_M;
-        const int total_pairs = (total_elements + 1) / 2;
-
-        #pragma unroll 2
-        for (int i = tid; i < total_pairs; i += THREADS_PER_BLOCK) {
-            const int linear_idx0 = i * 2;
-            const int linear_idx1 = linear_idx0 + 1;
-
-            const int row0 = linear_idx0 / BLOCK_M;
-            const int col0 = linear_idx0 % BLOCK_M;
-            const bool has_pair = (linear_idx1 < total_elements);
-            const int row1 = has_pair ? linear_idx1 / BLOCK_M : row0;
-            const int col1 = has_pair ? linear_idx1 % BLOCK_M : col0 + 1;
-
-            float s0 = 0.0f, s1 = 0.0f;
-            float dov0 = 0.0f, dov1 = 0.0f;
-
-            const bool in_bounds0 = (row0 < valid_q_rows) && (col0 < valid_kv_rows);
-            const bool causal_ok0 = !IS_CAUSAL || ((start_kv + col0) <= (start_col + row0));
-            const bool valid0 = in_bounds0 && causal_ok0;
-
-            bool valid1 = false;
-            if (has_pair) {
-                const bool in_bounds1 = (row1 < valid_q_rows) && (col1 < valid_kv_rows);
-                const bool causal_ok1 = !IS_CAUSAL || ((start_kv + col1) <= (start_col + row1));
-                valid1 = in_bounds1 && causal_ok1;
-            }
-
-            if (valid0) { s0 = sS[row0 * S_STRIDE + col0]; dov0 = sdOV[row0 * S_STRIDE + col0]; } else { s0 = NEG_INF; }
-            if (valid1) { s1 = sS[row1 * S_STRIDE + col1]; dov1 = sdOV[row1 * S_STRIDE + col1]; } else { s1 = NEG_INF; }
-
-            float lse0 = sLse[row0];
-            float lse1 = (valid1 && row1 != row0) ? sLse[row1] : lse0;
-            float row_dot0 = sRowDot[row0];
-            float row_dot1 = (valid1 && row1 != row0) ? sRowDot[row1] : row_dot0;
-
-            float shifted0 = s0 - lse0;
-            float shifted1 = s1 - lse1;
-
-            float p0 = (shifted0 < -80.0f) ? 0.0f : __expf(shifted0);
-            float p1 = (shifted1 < -80.0f) ? 0.0f : __expf(shifted1);
-
-            float diff0 = dov0 - row_dot0;
-            float diff1 = dov1 - row_dot1;
-            float ds0 = valid0 ? fmaf(p0, softmax_scale * diff0, 0.0f) : 0.0f;
-            float ds1 = valid1 ? fmaf(p1, softmax_scale * diff1, 0.0f) : 0.0f;
-
-            __half2 p_h2 = __float22half2_rn(make_float2(p0, p1));
-            __half2 ds_h2 = __float22half2_rn(make_float2(ds0, ds1));
-
-            if (col1 < BLOCK_M && row1 == row0) {
-                __half* p_dst  = sP  + row0 * BLOCK_M + col0;
-                __half* ds_dst = sdS + row0 * BLOCK_M + col0;
-                p_dst[0]  = p_h2.x;  p_dst[1]  = p_h2.y;
-                ds_dst[0] = ds_h2.x; ds_dst[1] = ds_h2.y;
-            } else {
-                if (valid0) { sP[row0 * BLOCK_M + col0] = p_h2.x; sdS[row0 * BLOCK_M + col0] = ds_h2.x; }
-                if (valid1) { sP[row1 * BLOCK_M + col1] = p_h2.y; sdS[row1 * BLOCK_M + col1] = ds_h2.y; }
-            }
-        }
-        __syncthreads();
-
-        const int num_tiles_m_dv    = (BLOCK_M + WMMA_M - 1) / WMMA_M;
-        const int num_tiles_n_dv    = (D + WMMA_N - 1) / WMMA_N;
-        const int num_tiles_k_dv    = (BLOCK_N + WMMA_K - 1) / WMMA_K;
-        const int total_tiles_dv    = num_tiles_m_dv * num_tiles_n_dv;
-        const int tiles_per_warp_dv = (total_tiles_dv + WARPS_PER_BLOCK - 1) / WARPS_PER_BLOCK;
-
-        for (int tile_local = 0; tile_local < tiles_per_warp_dv; ++tile_local) {
-            const int tile_idx = warp_id * tiles_per_warp_dv + tile_local;
-            if (tile_idx >= total_tiles_dv) break;
-
-            const int tile_m_idx = tile_idx / num_tiles_n_dv;
-            const int tile_n_idx = tile_idx % num_tiles_n_dv;
-
-            const int tile_m = tile_m_idx * WMMA_M;
-            const int tile_n = tile_n_idx * WMMA_N;
-
-            if (tile_m >= valid_kv_rows || tile_n >= D) continue;
-
-            fragment<matrix_a, WMMA_M, WMMA_N, WMMA_K, half, col_major> a_frag;
-            fragment<matrix_b, WMMA_M, WMMA_N, WMMA_K, half, row_major> b_frag;
-            fragment<accumulator, WMMA_M, WMMA_N, WMMA_K, float> acc_frag;
-            load_matrix_sync(acc_frag, sdV + tile_m * KV_STRIDE + tile_n, KV_STRIDE, mem_row_major);
-
-            #pragma unroll
-            for (int k_tile = 0; k_tile < num_tiles_k_dv; ++k_tile) {
-                const int k_offset = k_tile * WMMA_K;
-                if (k_offset >= valid_q_rows) break;
-
-                load_matrix_sync(a_frag, sP + k_offset * BLOCK_M + tile_m, BLOCK_M);
-                load_matrix_sync(b_frag, sdO + k_offset * Q_STRIDE + tile_n, Q_STRIDE);
-                mma_sync(acc_frag, a_frag, b_frag, acc_frag);
-            }
-            store_matrix_sync(sdV + tile_m * KV_STRIDE + tile_n, acc_frag, KV_STRIDE, mem_row_major);
-        }
-        __syncthreads();
-
-        __half* sQ = sdO;
-        #pragma unroll 2
-        for (int idx = tid; idx < NUM_UINT4_Q_BLOCK; idx += THREADS_PER_BLOCK) {
-            const int row = idx / d_stride_uint4;
-            const int vec_col = idx % d_stride_uint4;
-            uint4 q_val = make_uint4(0, 0, 0, 0);
-            if (row < valid_q_rows && vec_col < d_stride_uint4) {
-                q_val = __ldg(&q_vec[row * d_stride_uint4 + vec_col]);
-            }
-            sQ_vec[row * q_stride_uint4 + vec_col] = q_val;
-        }
-        __syncthreads();
-
-        const int num_tiles_m_dk    = (BLOCK_M + WMMA_M - 1) / WMMA_M;
-        const int num_tiles_n_dk    = (D + WMMA_N - 1) / WMMA_N;
-        const int num_tiles_k_dk    = (BLOCK_N + WMMA_K - 1) / WMMA_K;
-        const int total_tiles_dk    = num_tiles_m_dk * num_tiles_n_dk;
-        const int tiles_per_warp_dk = (total_tiles_dk + WARPS_PER_BLOCK - 1) / WARPS_PER_BLOCK;
-
-        for (int tile_local = 0; tile_local < tiles_per_warp_dk; ++tile_local) {
-            const int tile_idx = warp_id * tiles_per_warp_dk + tile_local;
-            if (tile_idx >= total_tiles_dk) break;
-
-            const int tile_m_idx = tile_idx / num_tiles_n_dk;
-            const int tile_n_idx = tile_idx % num_tiles_n_dk;
-
-            const int tile_m = tile_m_idx * WMMA_M;
-            const int tile_n = tile_n_idx * WMMA_N;
-
-            if (tile_m >= valid_kv_rows || tile_n >= D) continue;
-
-            fragment<matrix_a, WMMA_M, WMMA_N, WMMA_K, half, col_major> a_frag;
-            fragment<matrix_b, WMMA_M, WMMA_N, WMMA_K, half, row_major> b_frag;
-            fragment<accumulator, WMMA_M, WMMA_N, WMMA_K, float> acc_frag;
-            load_matrix_sync(acc_frag, sdK + tile_m * KV_STRIDE + tile_n, KV_STRIDE, mem_row_major);
-
-            #pragma unroll
-            for (int k_tile = 0; k_tile < num_tiles_k_dk; ++k_tile) {
-                const int k_offset = k_tile * WMMA_K;
-                if (k_offset >= valid_q_rows) break;
-
-                load_matrix_sync(a_frag, sdS + k_offset * BLOCK_M + tile_m, BLOCK_M);
-                load_matrix_sync(b_frag, sQ + k_offset * Q_STRIDE + tile_n, Q_STRIDE);
-                mma_sync(acc_frag, a_frag, b_frag, acc_frag);
-            }
-            store_matrix_sync(sdK + tile_m * KV_STRIDE + tile_n, acc_frag, KV_STRIDE, mem_row_major);
-        }
-        __syncthreads();
+      if (thread_in_row == 0) {
+        sRowDot[row] = thread_dot;
+      }
     }
 
-    const int total_fp16_x4 = (valid_kv_rows * D) / 4;
-    for (int i = tid; i < total_fp16_x4; i += THREADS_PER_BLOCK) {
-        const int row = i / (D / 4);
-        const int col = (i % (D / 4)) * 4;
-
-        const float* s_dK_row = sdK + row * KV_STRIDE;
-        const float* s_dV_row = sdV + row * KV_STRIDE;
-
-        const __half hk0 = __float2half_rn(s_dK_row[col + 0]);
-        const __half hk1 = __float2half_rn(s_dK_row[col + 1]);
-        const __half hk2 = __float2half_rn(s_dK_row[col + 2]);
-        const __half hk3 = __float2half_rn(s_dK_row[col + 3]);
-
-        const __half hv0 = __float2half_rn(s_dV_row[col + 0]);
-        const __half hv1 = __float2half_rn(s_dV_row[col + 1]);
-        const __half hv2 = __float2half_rn(s_dV_row[col + 2]);
-        const __half hv3 = __float2half_rn(s_dV_row[col + 3]);
-
-        asm volatile(
-            "st.global.v4.u16 [%0], {%1, %2, %3, %4};"
-            :
-            : "l"(dK_ptr + row * D + col),
-              "h"(__half_as_ushort(hk0)),
-              "h"(__half_as_ushort(hk1)),
-              "h"(__half_as_ushort(hk2)),
-              "h"(__half_as_ushort(hk3))
-            : "memory"
-        );
-
-        asm volatile(
-            "st.global.v4.u16 [%0], {%1, %2, %3, %4};"
-            :
-            : "l"(dV_ptr + row * D + col),
-              "h"(__half_as_ushort(hv0)),
-              "h"(__half_as_ushort(hv1)),
-              "h"(__half_as_ushort(hv2)),
-              "h"(__half_as_ushort(hv3))
-            : "memory"
-        );
+    if (tid < valid_q_rows) {
+      sLse[tid] = lse_ptr[start_col + tid];
     }
+    __syncthreads();
+
+    const int num_tiles_m_dov = (BLOCK_N + WMMA_M - 1) / WMMA_M;
+    const int num_tiles_n_dov = (BLOCK_M + WMMA_N - 1) / WMMA_N;
+    const int num_tiles_k_dov = (D + WMMA_K - 1) / WMMA_K;
+    const int total_tiles_dov = num_tiles_m_dov * num_tiles_n_dov;
+    const int tiles_per_warp_dov =
+        (total_tiles_dov + WARPS_PER_BLOCK - 1) / WARPS_PER_BLOCK;
+
+    for (int tile_local = 0; tile_local < tiles_per_warp_dov; ++tile_local) {
+      const int tile_idx = warp_id * tiles_per_warp_dov + tile_local;
+      if (tile_idx >= total_tiles_dov) break;
+
+      const int tile_m_idx = tile_idx / num_tiles_n_dov;
+      const int tile_n_idx = tile_idx % num_tiles_n_dov;
+
+      const int tile_m = tile_m_idx * WMMA_M;
+      const int tile_n = tile_n_idx * WMMA_N;
+
+      if (tile_m >= valid_q_rows || tile_n >= valid_kv_rows) continue;
+
+      fragment<matrix_a, WMMA_M, WMMA_N, WMMA_K, half, row_major> a_frag;
+      fragment<matrix_b, WMMA_M, WMMA_N, WMMA_K, half, col_major> b_frag;
+      fragment<accumulator, WMMA_M, WMMA_N, WMMA_K, float> acc_frag;
+      fill_fragment(acc_frag, 0.0f);
+
+#pragma unroll
+      for (int k_tile = 0; k_tile < num_tiles_k_dov; ++k_tile) {
+        const int k_offset = k_tile * WMMA_K;
+        if (k_offset >= D) break;
+        load_matrix_sync(a_frag, sdO + tile_m * Q_STRIDE + k_offset, Q_STRIDE);
+        load_matrix_sync(b_frag, sV + tile_n * KV_STRIDE + k_offset, KV_STRIDE);
+        mma_sync(acc_frag, a_frag, b_frag, acc_frag);
+      }
+      store_matrix_sync(sdOV + tile_m * S_STRIDE + tile_n, acc_frag, S_STRIDE,
+                        mem_row_major);
+    }
+    __syncthreads();
+
+    const int total_elements = BLOCK_N * BLOCK_M;
+    const int total_pairs = (total_elements + 1) / 2;
+
+#pragma unroll 2
+    for (int i = tid; i < total_pairs; i += THREADS_PER_BLOCK) {
+      const int linear_idx0 = i * 2;
+      const int linear_idx1 = linear_idx0 + 1;
+
+      const int row0 = linear_idx0 / BLOCK_M;
+      const int col0 = linear_idx0 % BLOCK_M;
+      const bool has_pair = (linear_idx1 < total_elements);
+      const int row1 = has_pair ? linear_idx1 / BLOCK_M : row0;
+      const int col1 = has_pair ? linear_idx1 % BLOCK_M : col0 + 1;
+
+      float s0 = 0.0f, s1 = 0.0f;
+      float dov0 = 0.0f, dov1 = 0.0f;
+
+      const bool in_bounds0 = (row0 < valid_q_rows) && (col0 < valid_kv_rows);
+      const bool causal_ok0 =
+          !IS_CAUSAL || ((start_kv + col0) <= (start_col + row0));
+      const bool valid0 = in_bounds0 && causal_ok0;
+
+      bool valid1 = false;
+      if (has_pair) {
+        const bool in_bounds1 = (row1 < valid_q_rows) && (col1 < valid_kv_rows);
+        const bool causal_ok1 =
+            !IS_CAUSAL || ((start_kv + col1) <= (start_col + row1));
+        valid1 = in_bounds1 && causal_ok1;
+      }
+
+      if (valid0) {
+        s0 = sS[row0 * S_STRIDE + col0];
+        dov0 = sdOV[row0 * S_STRIDE + col0];
+      } else {
+        s0 = NEG_INF;
+      }
+      if (valid1) {
+        s1 = sS[row1 * S_STRIDE + col1];
+        dov1 = sdOV[row1 * S_STRIDE + col1];
+      } else {
+        s1 = NEG_INF;
+      }
+
+      float lse0 = sLse[row0];
+      float lse1 = (valid1 && row1 != row0) ? sLse[row1] : lse0;
+      float row_dot0 = sRowDot[row0];
+      float row_dot1 = (valid1 && row1 != row0) ? sRowDot[row1] : row_dot0;
+
+      float shifted0 = s0 - lse0;
+      float shifted1 = s1 - lse1;
+
+      float p0 = (shifted0 < -80.0f) ? 0.0f : __expf(shifted0);
+      float p1 = (shifted1 < -80.0f) ? 0.0f : __expf(shifted1);
+
+      float diff0 = dov0 - row_dot0;
+      float diff1 = dov1 - row_dot1;
+      float ds0 = valid0 ? fmaf(p0, softmax_scale * diff0, 0.0f) : 0.0f;
+      float ds1 = valid1 ? fmaf(p1, softmax_scale * diff1, 0.0f) : 0.0f;
+
+      __half2 p_h2 = __float22half2_rn(make_float2(p0, p1));
+      __half2 ds_h2 = __float22half2_rn(make_float2(ds0, ds1));
+
+      if (col1 < BLOCK_M && row1 == row0) {
+        __half* p_dst = sP + row0 * BLOCK_M + col0;
+        __half* ds_dst = sdS + row0 * BLOCK_M + col0;
+        p_dst[0] = p_h2.x;
+        p_dst[1] = p_h2.y;
+        ds_dst[0] = ds_h2.x;
+        ds_dst[1] = ds_h2.y;
+      } else {
+        if (valid0) {
+          sP[row0 * BLOCK_M + col0] = p_h2.x;
+          sdS[row0 * BLOCK_M + col0] = ds_h2.x;
+        }
+        if (valid1) {
+          sP[row1 * BLOCK_M + col1] = p_h2.y;
+          sdS[row1 * BLOCK_M + col1] = ds_h2.y;
+        }
+      }
+    }
+    __syncthreads();
+
+    const int num_tiles_m_dv = (BLOCK_M + WMMA_M - 1) / WMMA_M;
+    const int num_tiles_n_dv = (D + WMMA_N - 1) / WMMA_N;
+    const int num_tiles_k_dv = (BLOCK_N + WMMA_K - 1) / WMMA_K;
+    const int total_tiles_dv = num_tiles_m_dv * num_tiles_n_dv;
+    const int tiles_per_warp_dv =
+        (total_tiles_dv + WARPS_PER_BLOCK - 1) / WARPS_PER_BLOCK;
+
+    for (int tile_local = 0; tile_local < tiles_per_warp_dv; ++tile_local) {
+      const int tile_idx = warp_id * tiles_per_warp_dv + tile_local;
+      if (tile_idx >= total_tiles_dv) break;
+
+      const int tile_m_idx = tile_idx / num_tiles_n_dv;
+      const int tile_n_idx = tile_idx % num_tiles_n_dv;
+
+      const int tile_m = tile_m_idx * WMMA_M;
+      const int tile_n = tile_n_idx * WMMA_N;
+
+      if (tile_m >= valid_kv_rows || tile_n >= D) continue;
+
+      fragment<matrix_a, WMMA_M, WMMA_N, WMMA_K, half, col_major> a_frag;
+      fragment<matrix_b, WMMA_M, WMMA_N, WMMA_K, half, row_major> b_frag;
+      fragment<accumulator, WMMA_M, WMMA_N, WMMA_K, float> acc_frag;
+      load_matrix_sync(acc_frag, sdV + tile_m * KV_STRIDE + tile_n, KV_STRIDE,
+                       mem_row_major);
+
+#pragma unroll
+      for (int k_tile = 0; k_tile < num_tiles_k_dv; ++k_tile) {
+        const int k_offset = k_tile * WMMA_K;
+        if (k_offset >= valid_q_rows) break;
+
+        load_matrix_sync(a_frag, sP + k_offset * BLOCK_M + tile_m, BLOCK_M);
+        load_matrix_sync(b_frag, sdO + k_offset * Q_STRIDE + tile_n, Q_STRIDE);
+        mma_sync(acc_frag, a_frag, b_frag, acc_frag);
+      }
+      store_matrix_sync(sdV + tile_m * KV_STRIDE + tile_n, acc_frag, KV_STRIDE,
+                        mem_row_major);
+    }
+    __syncthreads();
+
+    __half* sQ = sdO;
+#pragma unroll 2
+    for (int idx = tid; idx < NUM_UINT4_Q_BLOCK; idx += THREADS_PER_BLOCK) {
+      const int row = idx / d_stride_uint4;
+      const int vec_col = idx % d_stride_uint4;
+      uint4 q_val = make_uint4(0, 0, 0, 0);
+      if (row < valid_q_rows && vec_col < d_stride_uint4) {
+        q_val = __ldg(&q_vec[row * d_stride_uint4 + vec_col]);
+      }
+      sQ_vec[row * q_stride_uint4 + vec_col] = q_val;
+    }
+    __syncthreads();
+
+    const int num_tiles_m_dk = (BLOCK_M + WMMA_M - 1) / WMMA_M;
+    const int num_tiles_n_dk = (D + WMMA_N - 1) / WMMA_N;
+    const int num_tiles_k_dk = (BLOCK_N + WMMA_K - 1) / WMMA_K;
+    const int total_tiles_dk = num_tiles_m_dk * num_tiles_n_dk;
+    const int tiles_per_warp_dk =
+        (total_tiles_dk + WARPS_PER_BLOCK - 1) / WARPS_PER_BLOCK;
+
+    for (int tile_local = 0; tile_local < tiles_per_warp_dk; ++tile_local) {
+      const int tile_idx = warp_id * tiles_per_warp_dk + tile_local;
+      if (tile_idx >= total_tiles_dk) break;
+
+      const int tile_m_idx = tile_idx / num_tiles_n_dk;
+      const int tile_n_idx = tile_idx % num_tiles_n_dk;
+
+      const int tile_m = tile_m_idx * WMMA_M;
+      const int tile_n = tile_n_idx * WMMA_N;
+
+      if (tile_m >= valid_kv_rows || tile_n >= D) continue;
+
+      fragment<matrix_a, WMMA_M, WMMA_N, WMMA_K, half, col_major> a_frag;
+      fragment<matrix_b, WMMA_M, WMMA_N, WMMA_K, half, row_major> b_frag;
+      fragment<accumulator, WMMA_M, WMMA_N, WMMA_K, float> acc_frag;
+      load_matrix_sync(acc_frag, sdK + tile_m * KV_STRIDE + tile_n, KV_STRIDE,
+                       mem_row_major);
+
+#pragma unroll
+      for (int k_tile = 0; k_tile < num_tiles_k_dk; ++k_tile) {
+        const int k_offset = k_tile * WMMA_K;
+        if (k_offset >= valid_q_rows) break;
+
+        load_matrix_sync(a_frag, sdS + k_offset * BLOCK_M + tile_m, BLOCK_M);
+        load_matrix_sync(b_frag, sQ + k_offset * Q_STRIDE + tile_n, Q_STRIDE);
+        mma_sync(acc_frag, a_frag, b_frag, acc_frag);
+      }
+      store_matrix_sync(sdK + tile_m * KV_STRIDE + tile_n, acc_frag, KV_STRIDE,
+                        mem_row_major);
+    }
+    __syncthreads();
+  }
+
+  const int total_fp16_x4 = (valid_kv_rows * D) / 4;
+  for (int i = tid; i < total_fp16_x4; i += THREADS_PER_BLOCK) {
+    const int row = i / (D / 4);
+    const int col = (i % (D / 4)) * 4;
+
+    const float* s_dK_row = sdK + row * KV_STRIDE;
+    const float* s_dV_row = sdV + row * KV_STRIDE;
+
+    const __half hk0 = __float2half_rn(s_dK_row[col + 0]);
+    const __half hk1 = __float2half_rn(s_dK_row[col + 1]);
+    const __half hk2 = __float2half_rn(s_dK_row[col + 2]);
+    const __half hk3 = __float2half_rn(s_dK_row[col + 3]);
+
+    const __half hv0 = __float2half_rn(s_dV_row[col + 0]);
+    const __half hv1 = __float2half_rn(s_dV_row[col + 1]);
+    const __half hv2 = __float2half_rn(s_dV_row[col + 2]);
+    const __half hv3 = __float2half_rn(s_dV_row[col + 3]);
+
+    asm volatile("st.global.v4.u16 [%0], {%1, %2, %3, %4};"
+                 :
+                 : "l"(dK_ptr + row * D + col), "h"(__half_as_ushort(hk0)),
+                   "h"(__half_as_ushort(hk1)), "h"(__half_as_ushort(hk2)),
+                   "h"(__half_as_ushort(hk3))
+                 : "memory");
+
+    asm volatile("st.global.v4.u16 [%0], {%1, %2, %3, %4};"
+                 :
+                 : "l"(dV_ptr + row * D + col), "h"(__half_as_ushort(hv0)),
+                   "h"(__half_as_ushort(hv1)), "h"(__half_as_ushort(hv2)),
+                   "h"(__half_as_ushort(hv3))
+                 : "memory");
+  }
 }
 
-template<int D>
+template <int D>
 void launcher_flash_attention_backward_dq(
-    const torch::Tensor& Q,
-    const torch::Tensor& K,
-    const torch::Tensor& V,
-    const torch::Tensor& O,
-    torch::Tensor& dO,
-    const torch::Tensor& softmax_lse,
-    torch::Tensor& dQ,
-    float softmax_scale,
-    bool is_causal,
-    cudaStream_t stream
-) {
-    using Config = dQKernelConfig<D>;
+    const torch::Tensor& Q, const torch::Tensor& K, const torch::Tensor& V,
+    const torch::Tensor& O, torch::Tensor& dO, const torch::Tensor& softmax_lse,
+    torch::Tensor& dQ, float softmax_scale, bool is_causal,
+    cudaStream_t stream) {
+  using Config = dQKernelConfig<D>;
 
-    const int B = Q.size(0);
-    const int H = Q.size(1);
-    const int M = Q.size(2);
-    const int N = K.size(2);
+  const int B = Q.size(0);
+  const int H = Q.size(1);
+  const int M = Q.size(2);
+  const int N = K.size(2);
 
-    const int grid_x = (M + Config::BLOCK_M - 1) / Config::BLOCK_M;
-    const dim3 grid(grid_x, 1, B * H);
-    const dim3 block(Config::THREADS_PER_BLOCK);
-    const size_t smem = Config::TOTAL_SMEM;
+  const int grid_x = (M + Config::BLOCK_M - 1) / Config::BLOCK_M;
+  const dim3 grid(grid_x, 1, B * H);
+  const dim3 block(Config::THREADS_PER_BLOCK);
+  const size_t smem = Config::TOTAL_SMEM;
 
-    TORCH_CHECK(smem <= MAX_SMEM_PER_SM, "Shared memory exceeds 96KB for dQ: ", smem, " bytes");
+  TORCH_CHECK(smem <= MAX_SMEM_PER_SM,
+              "Shared memory exceeds 96KB for dQ: ", smem, " bytes");
 
-    auto kernel = is_causal ?
-        (void*)flash_attention_backward_dq_kernel<D, true> :
-        (void*)flash_attention_backward_dq_kernel<D, false>;
+  auto kernel = is_causal ? (void*)flash_attention_backward_dq_kernel<D, true>
+                          : (void*)flash_attention_backward_dq_kernel<D, false>;
 
-    cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem);
+  cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize,
+                       smem);
 
-    if (is_causal) {
-        flash_attention_backward_dq_kernel<D, true><<<grid, block, smem, stream>>>(
-            reinterpret_cast<const __half*>(Q.data_ptr()),
-            reinterpret_cast<const __half*>(K.data_ptr()),
-            reinterpret_cast<const __half*>(V.data_ptr()),
-            reinterpret_cast<const __half*>(O.data_ptr()),
-            reinterpret_cast<__half*>(dO.data_ptr()),
-            softmax_lse.data_ptr<float>(),
-            reinterpret_cast<__half*>(dQ.data_ptr()),
-            B, H, M, N, softmax_scale
-        );
-    } else {
-        flash_attention_backward_dq_kernel<D, false><<<grid, block, smem, stream>>>(
-            reinterpret_cast<const __half*>(Q.data_ptr()),
-            reinterpret_cast<const __half*>(K.data_ptr()),
-            reinterpret_cast<const __half*>(V.data_ptr()),
-            reinterpret_cast<const __half*>(O.data_ptr()),
-            reinterpret_cast<__half*>(dO.data_ptr()),
-            softmax_lse.data_ptr<float>(),
-            reinterpret_cast<__half*>(dQ.data_ptr()),
-            B, H, M, N, softmax_scale
-        );
-    }
+  if (is_causal) {
+    flash_attention_backward_dq_kernel<D, true><<<grid, block, smem, stream>>>(
+        reinterpret_cast<const __half*>(Q.data_ptr()),
+        reinterpret_cast<const __half*>(K.data_ptr()),
+        reinterpret_cast<const __half*>(V.data_ptr()),
+        reinterpret_cast<const __half*>(O.data_ptr()),
+        reinterpret_cast<__half*>(dO.data_ptr()), softmax_lse.data_ptr<float>(),
+        reinterpret_cast<__half*>(dQ.data_ptr()), B, H, M, N, softmax_scale);
+  } else {
+    flash_attention_backward_dq_kernel<D, false><<<grid, block, smem, stream>>>(
+        reinterpret_cast<const __half*>(Q.data_ptr()),
+        reinterpret_cast<const __half*>(K.data_ptr()),
+        reinterpret_cast<const __half*>(V.data_ptr()),
+        reinterpret_cast<const __half*>(O.data_ptr()),
+        reinterpret_cast<__half*>(dO.data_ptr()), softmax_lse.data_ptr<float>(),
+        reinterpret_cast<__half*>(dQ.data_ptr()), B, H, M, N, softmax_scale);
+  }
 }
 
-template<int D>
+template <int D>
 void launcher_flash_attention_backward_dkv(
-    const torch::Tensor& Q,
-    const torch::Tensor& K,
-    const torch::Tensor& V,
-    const torch::Tensor& O,
-    torch::Tensor& dO,
-    const torch::Tensor& softmax_lse,
-    torch::Tensor& dK,
-    torch::Tensor& dV,
-    float softmax_scale,
-    bool is_causal,
-    cudaStream_t stream
-) {
-    using Config = dKVKernelConfig<D>;
+    const torch::Tensor& Q, const torch::Tensor& K, const torch::Tensor& V,
+    const torch::Tensor& O, torch::Tensor& dO, const torch::Tensor& softmax_lse,
+    torch::Tensor& dK, torch::Tensor& dV, float softmax_scale, bool is_causal,
+    cudaStream_t stream) {
+  using Config = dKVKernelConfig<D>;
 
-    const int B = Q.size(0);
-    const int H = Q.size(1);
-    const int M = Q.size(2);
-    const int N = K.size(2);
+  const int B = Q.size(0);
+  const int H = Q.size(1);
+  const int M = Q.size(2);
+  const int N = K.size(2);
 
-    const int grid_x = (N + Config::BLOCK_M - 1) / Config::BLOCK_M;
-    const dim3 grid(grid_x, 1, B * H);
-    const dim3 block(Config::THREADS_PER_BLOCK);
-    const size_t smem = Config::TOTAL_SMEM;
+  const int grid_x = (N + Config::BLOCK_M - 1) / Config::BLOCK_M;
+  const dim3 grid(grid_x, 1, B * H);
+  const dim3 block(Config::THREADS_PER_BLOCK);
+  const size_t smem = Config::TOTAL_SMEM;
 
-    TORCH_CHECK(smem <= MAX_SMEM_PER_SM, "Shared memory exceeds 96KB for unified dKV: ", smem, " bytes (", smem / 1024, " KB)");
+  TORCH_CHECK(smem <= MAX_SMEM_PER_SM,
+              "Shared memory exceeds 96KB for unified dKV: ", smem, " bytes (",
+              smem / 1024, " KB)");
 
-    auto kernel = is_causal ?
-        (void*)flash_attention_backward_dkv_kernel<D, true> :
-        (void*)flash_attention_backward_dkv_kernel<D, false>;
+  auto kernel = is_causal
+                    ? (void*)flash_attention_backward_dkv_kernel<D, true>
+                    : (void*)flash_attention_backward_dkv_kernel<D, false>;
 
-    cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem);
+  cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize,
+                       smem);
 
-    if (is_causal) {
-        flash_attention_backward_dkv_kernel<D, true><<<grid, block, smem, stream>>>(
+  if (is_causal) {
+    flash_attention_backward_dkv_kernel<D, true><<<grid, block, smem, stream>>>(
+        reinterpret_cast<const __half*>(Q.data_ptr()),
+        reinterpret_cast<const __half*>(K.data_ptr()),
+        reinterpret_cast<const __half*>(V.data_ptr()),
+        reinterpret_cast<const __half*>(O.data_ptr()),
+        reinterpret_cast<__half*>(dO.data_ptr()), softmax_lse.data_ptr<float>(),
+        reinterpret_cast<__half*>(dK.data_ptr()),
+        reinterpret_cast<__half*>(dV.data_ptr()), B, H, M, N, softmax_scale);
+  } else {
+    flash_attention_backward_dkv_kernel<D, false>
+        <<<grid, block, smem, stream>>>(
             reinterpret_cast<const __half*>(Q.data_ptr()),
             reinterpret_cast<const __half*>(K.data_ptr()),
             reinterpret_cast<const __half*>(V.data_ptr()),
@@ -1191,104 +1250,104 @@ void launcher_flash_attention_backward_dkv(
             reinterpret_cast<__half*>(dO.data_ptr()),
             softmax_lse.data_ptr<float>(),
             reinterpret_cast<__half*>(dK.data_ptr()),
-            reinterpret_cast<__half*>(dV.data_ptr()),
-            B, H, M, N, softmax_scale
-        );
-    } else {
-        flash_attention_backward_dkv_kernel<D, false><<<grid, block, smem, stream>>>(
-            reinterpret_cast<const __half*>(Q.data_ptr()),
-            reinterpret_cast<const __half*>(K.data_ptr()),
-            reinterpret_cast<const __half*>(V.data_ptr()),
-            reinterpret_cast<const __half*>(O.data_ptr()),
-            reinterpret_cast<__half*>(dO.data_ptr()),
-            softmax_lse.data_ptr<float>(),
-            reinterpret_cast<__half*>(dK.data_ptr()),
-            reinterpret_cast<__half*>(dV.data_ptr()),
-            B, H, M, N, softmax_scale
-        );
-    }
+            reinterpret_cast<__half*>(dV.data_ptr()), B, H, M, N,
+            softmax_scale);
+  }
 }
 
 std::vector<at::Tensor> flash_attention_backward(
-    const at::Tensor& dout,
-    const at::Tensor& q,
-    const at::Tensor& k,
-    const at::Tensor& v,
-    const at::Tensor& out,
-    const at::Tensor& softmax_lse,
-    std::optional<at::Tensor>& dq_,
-    std::optional<at::Tensor>& dk_,
-    std::optional<at::Tensor>& dv_,
-    std::optional<at::Tensor>& alibi_slopes_,
-    const float p_dropout,
-    const float softmax_scale,
-    const bool is_causal,
-    int window_size_left,
-    int window_size_right,
-    const float softcap,
-    const bool deterministic,
-    std::optional<at::Generator> gen_,
-    std::optional<at::Tensor>& rng_state
-) {
+    const at::Tensor& dout, const at::Tensor& q, const at::Tensor& k,
+    const at::Tensor& v, const at::Tensor& out, const at::Tensor& softmax_lse,
+    std::optional<at::Tensor>& dq_, std::optional<at::Tensor>& dk_,
+    std::optional<at::Tensor>& dv_, std::optional<at::Tensor>& alibi_slopes_,
+    const float p_dropout, const float softmax_scale, const bool is_causal,
+    int window_size_left, int window_size_right, const float softcap,
+    const bool deterministic, std::optional<at::Generator> gen_,
+    std::optional<at::Tensor>& rng_state) {
+  TORCH_CHECK(!alibi_slopes_.has_value(), "alibi_slopes not supported");
+  TORCH_CHECK(p_dropout == 0.f, "dropout not supported");
+  TORCH_CHECK(window_size_left == -1, "window_size_left not supported");
+  TORCH_CHECK(window_size_right == -1 || (is_causal && window_size_right == 0),
+              "window not supported");
+  TORCH_CHECK(softcap == 0.f, "softcap not supported");
+  TORCH_CHECK(!deterministic, "deterministic mode not supported");
+  TORCH_CHECK(!gen_.has_value(), "Generator not supported");
+  TORCH_CHECK(!rng_state.has_value() || rng_state->numel() == 0,
+              "rng_state not supported");
 
-    TORCH_CHECK(!alibi_slopes_.has_value(), "alibi_slopes not supported");
-    TORCH_CHECK(p_dropout == 0.f, "dropout not supported");
-    TORCH_CHECK(window_size_left == -1, "window_size_left not supported");
-    TORCH_CHECK(window_size_right == -1 || (is_causal && window_size_right == 0), "window not supported");
-    TORCH_CHECK(softcap == 0.f, "softcap not supported");
-    TORCH_CHECK(!deterministic, "deterministic mode not supported");
-    TORCH_CHECK(!gen_.has_value(), "Generator not supported");
-    TORCH_CHECK(!rng_state.has_value() || rng_state->numel() == 0, "rng_state not supported");
+  TORCH_CHECK(q.dtype() == torch::kFloat16, "q must be fp16");
+  TORCH_CHECK(k.dtype() == torch::kFloat16, "k must be fp16");
+  TORCH_CHECK(v.dtype() == torch::kFloat16, "v must be fp16");
+  TORCH_CHECK(dout.dtype() == torch::kFloat16, "dout must be fp16");
+  TORCH_CHECK(out.dtype() == torch::kFloat16, "out must be fp16");
+  TORCH_CHECK(softmax_lse.dtype() == torch::kFloat32,
+              "softmax_lse must be fp32");
 
-    TORCH_CHECK(q.dtype() == torch::kFloat16, "q must be fp16");
-    TORCH_CHECK(k.dtype() == torch::kFloat16, "k must be fp16");
-    TORCH_CHECK(v.dtype() == torch::kFloat16, "v must be fp16");
-    TORCH_CHECK(dout.dtype() == torch::kFloat16, "dout must be fp16");
-    TORCH_CHECK(out.dtype() == torch::kFloat16, "out must be fp16");
-    TORCH_CHECK(softmax_lse.dtype() == torch::kFloat32, "softmax_lse must be fp32");
+  const auto sizes = q.sizes();
+  const int B = sizes[0], H = sizes[1], M = sizes[2], D = sizes[3];
+  const int N = k.size(2);
+  TORCH_CHECK(D <= 256 && D % 8 == 0 && D % 2 == 0,
+              "D must be even, <=256, multiple of 8");
 
-    const auto sizes = q.sizes();
-    const int B = sizes[0], H = sizes[1], M = sizes[2], D = sizes[3];
-    const int N = k.size(2);
-    TORCH_CHECK(D <= 256 && D % 8 == 0 && D % 2 == 0, "D must be even, <=256, multiple of 8");
+  at::Tensor dq_fp16 = dq_.has_value() ? dq_.value() : torch::zeros_like(q);
+  at::Tensor dk_fp16 = dk_.has_value() ? dk_.value() : torch::zeros_like(k);
+  at::Tensor dv_fp16 = dv_.has_value() ? dv_.value() : torch::zeros_like(v);
 
-    at::Tensor dq_fp16 = dq_.has_value() ? dq_.value() : torch::zeros_like(q);
-    at::Tensor dk_fp16 = dk_.has_value() ? dk_.value() : torch::zeros_like(k);
-    at::Tensor dv_fp16 = dv_.has_value() ? dv_.value() : torch::zeros_like(v);
+  TORCH_CHECK(dq_fp16.dtype() == torch::kFloat16, "dq must be fp16");
+  TORCH_CHECK(dk_fp16.dtype() == torch::kFloat16, "dk must be fp16");
+  TORCH_CHECK(dv_fp16.dtype() == torch::kFloat16, "dv must be fp16");
 
-    TORCH_CHECK(dq_fp16.dtype() == torch::kFloat16, "dq must be fp16");
-    TORCH_CHECK(dk_fp16.dtype() == torch::kFloat16, "dk must be fp16");
-    TORCH_CHECK(dv_fp16.dtype() == torch::kFloat16, "dv must be fp16");
+  auto dsoftmax_sum =
+      torch::zeros({B, H, M}, torch::dtype(torch::kFloat32).device(q.device()));
 
-    auto dsoftmax_sum = torch::zeros({B, H, M}, torch::dtype(torch::kFloat32).device(q.device()));
+  auto stream = at::cuda::getCurrentCUDAStream().stream();
+  auto props = at::cuda::getCurrentDeviceProperties();
+  bool sm70 = props->major == 7 && props->minor == 0;
+  TORCH_CHECK(sm70, "Kernel supports only Volta GPUs.");
 
-    auto stream = at::cuda::getCurrentCUDAStream().stream();
-    auto props  = at::cuda::getCurrentDeviceProperties();
-    bool sm70   = props->major == 7 && props->minor == 0;
-    TORCH_CHECK(sm70, "Kernel supports only Volta GPUs.");
-
-    switch (D) {
-        case 16:
-            launcher_flash_attention_backward_dq<16>(q, k, v, out, const_cast<at::Tensor&>(dout), softmax_lse, dq_fp16, softmax_scale, is_causal, stream);
-            launcher_flash_attention_backward_dkv<16>(q, k, v, out, const_cast<at::Tensor&>(dout), softmax_lse, dk_fp16, dv_fp16, softmax_scale, is_causal, stream);
-            break;
-        case 32:
-            launcher_flash_attention_backward_dq<32>(q, k, v, out, const_cast<at::Tensor&>(dout), softmax_lse, dq_fp16, softmax_scale, is_causal, stream);
-            launcher_flash_attention_backward_dkv<32>(q, k, v, out, const_cast<at::Tensor&>(dout), softmax_lse, dk_fp16, dv_fp16, softmax_scale, is_causal, stream);
-            break;
-        case 64:
-            launcher_flash_attention_backward_dq<64>(q, k, v, out, const_cast<at::Tensor&>(dout), softmax_lse, dq_fp16, softmax_scale, is_causal, stream);
-            launcher_flash_attention_backward_dkv<64>(q, k, v, out, const_cast<at::Tensor&>(dout), softmax_lse, dk_fp16, dv_fp16, softmax_scale, is_causal, stream);
-            break;
-        case 128:
-            launcher_flash_attention_backward_dq<128>(q, k, v, out, const_cast<at::Tensor&>(dout), softmax_lse, dq_fp16, softmax_scale, is_causal, stream);
-            launcher_flash_attention_backward_dkv<128>(q, k, v, out, const_cast<at::Tensor&>(dout), softmax_lse, dk_fp16, dv_fp16, softmax_scale, is_causal, stream);
-            break;
-        case 256:
-            launcher_flash_attention_backward_dq<256>(q, k, v, out, const_cast<at::Tensor&>(dout), softmax_lse, dq_fp16, softmax_scale, is_causal, stream);
-            launcher_flash_attention_backward_dkv<256>(q, k, v, out, const_cast<at::Tensor&>(dout), softmax_lse, dk_fp16, dv_fp16, softmax_scale, is_causal, stream);
-            break;
-        default: TORCH_CHECK(false, "Unsupported D: ", D);
-    }
-    return {dq_fp16, dk_fp16, dv_fp16, dsoftmax_sum};
+  switch (D) {
+    case 16:
+      launcher_flash_attention_backward_dq<16>(
+          q, k, v, out, const_cast<at::Tensor&>(dout), softmax_lse, dq_fp16,
+          softmax_scale, is_causal, stream);
+      launcher_flash_attention_backward_dkv<16>(
+          q, k, v, out, const_cast<at::Tensor&>(dout), softmax_lse, dk_fp16,
+          dv_fp16, softmax_scale, is_causal, stream);
+      break;
+    case 32:
+      launcher_flash_attention_backward_dq<32>(
+          q, k, v, out, const_cast<at::Tensor&>(dout), softmax_lse, dq_fp16,
+          softmax_scale, is_causal, stream);
+      launcher_flash_attention_backward_dkv<32>(
+          q, k, v, out, const_cast<at::Tensor&>(dout), softmax_lse, dk_fp16,
+          dv_fp16, softmax_scale, is_causal, stream);
+      break;
+    case 64:
+      launcher_flash_attention_backward_dq<64>(
+          q, k, v, out, const_cast<at::Tensor&>(dout), softmax_lse, dq_fp16,
+          softmax_scale, is_causal, stream);
+      launcher_flash_attention_backward_dkv<64>(
+          q, k, v, out, const_cast<at::Tensor&>(dout), softmax_lse, dk_fp16,
+          dv_fp16, softmax_scale, is_causal, stream);
+      break;
+    case 128:
+      launcher_flash_attention_backward_dq<128>(
+          q, k, v, out, const_cast<at::Tensor&>(dout), softmax_lse, dq_fp16,
+          softmax_scale, is_causal, stream);
+      launcher_flash_attention_backward_dkv<128>(
+          q, k, v, out, const_cast<at::Tensor&>(dout), softmax_lse, dk_fp16,
+          dv_fp16, softmax_scale, is_causal, stream);
+      break;
+    case 256:
+      launcher_flash_attention_backward_dq<256>(
+          q, k, v, out, const_cast<at::Tensor&>(dout), softmax_lse, dq_fp16,
+          softmax_scale, is_causal, stream);
+      launcher_flash_attention_backward_dkv<256>(
+          q, k, v, out, const_cast<at::Tensor&>(dout), softmax_lse, dk_fp16,
+          dv_fp16, softmax_scale, is_causal, stream);
+      break;
+    default:
+      TORCH_CHECK(false, "Unsupported D: ", D);
+  }
+  return {dq_fp16, dk_fp16, dv_fp16, dsoftmax_sum};
 }

--- a/flash-attention-v100/kernel/fused_mha_forward.cu
+++ b/flash-attention-v100/kernel/fused_mha_forward.cu
@@ -16,1133 +16,1109 @@ using namespace nvcuda::wmma;
 #define WMMA_N 16
 #define WMMA_K 16
 
-#define MAX_THREADS_PER_WARP    32
-#define MAX_THREADS_PER_SM      2048
-#define MAX_THREAD_BLOCK_SIZE   1024
+#define MAX_THREADS_PER_WARP 32
+#define MAX_THREADS_PER_SM 2048
+#define MAX_THREAD_BLOCK_SIZE 1024
 #define MAX_THREAD_BLOCK_PER_SM 32
-#define MAX_WARPS_PER_SM        64
-#define MAX_SM_PER_GPU          80
-#define MAX_SMEM_PER_SM         98304
+#define MAX_WARPS_PER_SM 64
+#define MAX_SM_PER_GPU 80
+#define MAX_SMEM_PER_SM 98304
 
-#define WARP_ALLOC_GROUP        4
+#define WARP_ALLOC_GROUP 4
 
-#define MAX_REG_PER_UNIT        256
-#define MAX_REG_PER_THREAD      255
-#define MAX_REG_PER_BLOCK       65536
-#define MAX_REG_BUFFER          65536
+#define MAX_REG_PER_UNIT 256
+#define MAX_REG_PER_THREAD 255
+#define MAX_REG_PER_BLOCK 65536
+#define MAX_REG_BUFFER 65536
 
-#define BLOCK_M_16  16
-#define BLOCK_N_16  512
-#define WARPS_16    16
+#define BLOCK_M_16 16
+#define BLOCK_N_16 512
+#define WARPS_16 16
 
-#define BLOCK_M_32  32
-#define BLOCK_N_32  256
-#define WARPS_32    16
+#define BLOCK_M_32 32
+#define BLOCK_N_32 256
+#define WARPS_32 16
 
-#define BLOCK_M_64  64
-#define BLOCK_N_64  128
-#define WARPS_64    16
+#define BLOCK_M_64 64
+#define BLOCK_N_64 128
+#define WARPS_64 16
 
 #define BLOCK_M_128 32
 #define BLOCK_N_128 176
-#define WARPS_128   16
+#define WARPS_128 16
 
 #define BLOCK_M_256 32
 #define BLOCK_N_256 64
-#define WARPS_256   16
+#define WARPS_256 16
 
 #define BLOCK_M_256_LOW_SMEM 16
 #define BLOCK_N_256_LOW_SMEM 32
-#define WARPS_256_LOW_SMEM   16
+#define WARPS_256_LOW_SMEM 16
 
 inline bool env_flag_enabled(const char* name) {
-    const char* raw = std::getenv(name);
-    return raw != nullptr && std::strcmp(raw, "0") != 0;
+  const char* raw = std::getenv(name);
+  return raw != nullptr && std::strcmp(raw, "0") != 0;
 }
 
 inline bool env_flag_enabled_default_on(const char* name) {
-    const char* raw = std::getenv(name);
-    return raw == nullptr || std::strcmp(raw, "0") != 0;
+  const char* raw = std::getenv(name);
+  return raw == nullptr || std::strcmp(raw, "0") != 0;
 }
 
-template<int D, bool LOW_SMEM = false>
+template <int D, bool LOW_SMEM = false>
 struct KernelConfig {
-    static constexpr int BLOCK_M = (D == 16) ? BLOCK_M_16 : (D == 32) ? BLOCK_M_32 : (D == 64) ? BLOCK_M_64 : (D == 128) ? BLOCK_M_128 : (LOW_SMEM ? BLOCK_M_256_LOW_SMEM : BLOCK_M_256);
-    static constexpr int BLOCK_N = (D == 16) ? BLOCK_N_16 : (D == 32) ? BLOCK_N_32 : (D == 64) ? BLOCK_N_64 : (D == 128) ? BLOCK_N_128 : (LOW_SMEM ? BLOCK_N_256_LOW_SMEM : BLOCK_N_256);
-    static constexpr int WARPS_PER_BLOCK = (D == 16) ? WARPS_16 : (D == 32) ? WARPS_32 : (D == 64) ? WARPS_64 : (D == 128) ? WARPS_128 : (LOW_SMEM ? WARPS_256_LOW_SMEM : WARPS_256);
+  static constexpr int BLOCK_M =
+      (D == 16)    ? BLOCK_M_16
+      : (D == 32)  ? BLOCK_M_32
+      : (D == 64)  ? BLOCK_M_64
+      : (D == 128) ? BLOCK_M_128
+                   : (LOW_SMEM ? BLOCK_M_256_LOW_SMEM : BLOCK_M_256);
+  static constexpr int BLOCK_N =
+      (D == 16)    ? BLOCK_N_16
+      : (D == 32)  ? BLOCK_N_32
+      : (D == 64)  ? BLOCK_N_64
+      : (D == 128) ? BLOCK_N_128
+                   : (LOW_SMEM ? BLOCK_N_256_LOW_SMEM : BLOCK_N_256);
+  static constexpr int WARPS_PER_BLOCK =
+      (D == 16)    ? WARPS_16
+      : (D == 32)  ? WARPS_32
+      : (D == 64)  ? WARPS_64
+      : (D == 128) ? WARPS_128
+                   : (LOW_SMEM ? WARPS_256_LOW_SMEM : WARPS_256);
 
-    static constexpr int THREADS_PER_BLOCK = WARPS_PER_BLOCK * MAX_THREADS_PER_WARP;
-    static constexpr int THREADS_PER_ROW   = THREADS_PER_BLOCK / BLOCK_M;
-    static constexpr int PAD               = (8 - (D % 32) + 32) % 32;
-    static constexpr int Q_STRIDE          = D + PAD;
-    static constexpr int KV_STRIDE         = D + PAD;
-    static constexpr int S_STRIDE          = BLOCK_N + PAD;
-    static constexpr int P_SUB_TILE        = 32;
-    static constexpr int P_STRIDE          = P_SUB_TILE + PAD;
-    static constexpr int P_STRICT_ELEMENTS = (D == 256) ? BLOCK_M * P_STRIDE : 1;
-    static constexpr int O_STRIDE          = D + PAD;
-    static constexpr int PER_UINT4         = 8;
+  static constexpr int THREADS_PER_BLOCK =
+      WARPS_PER_BLOCK * MAX_THREADS_PER_WARP;
+  static constexpr int THREADS_PER_ROW = THREADS_PER_BLOCK / BLOCK_M;
+  static constexpr int PAD = (8 - (D % 32) + 32) % 32;
+  static constexpr int Q_STRIDE = D + PAD;
+  static constexpr int KV_STRIDE = D + PAD;
+  static constexpr int S_STRIDE = BLOCK_N + PAD;
+  static constexpr int P_SUB_TILE = 32;
+  static constexpr int P_STRIDE = P_SUB_TILE + PAD;
+  static constexpr int P_STRICT_ELEMENTS = (D == 256) ? BLOCK_M * P_STRIDE : 1;
+  static constexpr int O_STRIDE = D + PAD;
+  static constexpr int PER_UINT4 = 8;
 
-    struct alignas(128) SmemLayout {
-        alignas(16) __half q      [BLOCK_M * Q_STRIDE];
+  struct alignas(128) SmemLayout {
+    alignas(16) __half q[BLOCK_M * Q_STRIDE];
     union {
-        alignas(16) __half k      [BLOCK_N * KV_STRIDE];
-        alignas(16) __half v      [BLOCK_N * KV_STRIDE];
+      alignas(16) __half k[BLOCK_N * KV_STRIDE];
+      alignas(16) __half v[BLOCK_N * KV_STRIDE];
     } reuse_kv;
     union {
-        alignas(16) float  s      [BLOCK_M * S_STRIDE];
-        alignas(16) __half p      [BLOCK_M * S_STRIDE];
+      alignas(16) float s[BLOCK_M * S_STRIDE];
+      alignas(16) __half p[BLOCK_M * S_STRIDE];
     } reuse_sp;
-        alignas(16) __half p_strict[P_STRICT_ELEMENTS];
-        alignas(16) float  o      [BLOCK_M * O_STRIDE];
-        alignas(16) float  row_max[BLOCK_M];
-        alignas(16) float  row_sum[BLOCK_M];
-    };
+    alignas(16) __half p_strict[P_STRICT_ELEMENTS];
+    alignas(16) float o[BLOCK_M * O_STRIDE];
+    alignas(16) float row_max[BLOCK_M];
+    alignas(16) float row_sum[BLOCK_M];
+  };
 
-    static constexpr size_t TOTAL_SMEM = ((sizeof(SmemLayout) + 127) & ~size_t(127));
+  static constexpr size_t TOTAL_SMEM =
+      ((sizeof(SmemLayout) + 127) & ~size_t(127));
 };
 
-template<typename Config>
+template <typename Config>
 __device__ __forceinline__ void init_smem(char* smem_raw) {
-    constexpr int N_U4 = Config::TOTAL_SMEM / 16;
-    constexpr int THREADS_PER_BLOCK = Config::THREADS_PER_BLOCK;
-    const int tid = threadIdx.x;
+  constexpr int N_U4 = Config::TOTAL_SMEM / 16;
+  constexpr int THREADS_PER_BLOCK = Config::THREADS_PER_BLOCK;
+  const int tid = threadIdx.x;
 
-    uint32_t addr = static_cast<uint32_t>(__cvta_generic_to_shared(smem_raw));
-    #pragma unroll 1
-    for (int i = tid; i < N_U4; i += THREADS_PER_BLOCK) {
-        asm volatile("st.shared.v4.u32 [%0], {%1,%1,%1,%1};"
-                     :: "r"(addr + (i << 4)), "r"(0) : "memory");
-    }
-    __syncthreads();
+  uint32_t addr = static_cast<uint32_t>(__cvta_generic_to_shared(smem_raw));
+#pragma unroll 1
+  for (int i = tid; i < N_U4; i += THREADS_PER_BLOCK) {
+    asm volatile("st.shared.v4.u32 [%0], {%1,%1,%1,%1};" ::"r"(addr + (i << 4)),
+                 "r"(0)
+                 : "memory");
+  }
+  __syncthreads();
 }
 
-template<int D, bool LOW_SMEM, bool IS_CAUSAL>
+template <int D, bool LOW_SMEM, bool IS_CAUSAL>
 __device__ __forceinline__ void compute_qk_scores_scalar_fp32(
-    const __half* __restrict__ sQ,
-    const __half* __restrict__ sK,
-    float* __restrict__ sS,
-    const int valid_q_rows,
-    const int valid_k_rows,
-    const int start_row,
-    const int start_col,
-    const int causal_q_offset,
-    const float score_scale,
-    const int window_size_left,
-    const int window_size_right
-) {
-    using Config = KernelConfig<D, LOW_SMEM>;
-    constexpr int THREADS_PER_BLOCK = Config::THREADS_PER_BLOCK;
-    constexpr int Q_STRIDE = Config::Q_STRIDE;
-    constexpr int KV_STRIDE = Config::KV_STRIDE;
-    constexpr int S_STRIDE = Config::S_STRIDE;
-    const float NEG_INF = -1e30f;
-    const int tid = threadIdx.x;
-    const int total_scores = valid_q_rows * valid_k_rows;
+    const __half* __restrict__ sQ, const __half* __restrict__ sK,
+    float* __restrict__ sS, const int valid_q_rows, const int valid_k_rows,
+    const int start_row, const int start_col, const int causal_q_offset,
+    const float score_scale, const int window_size_left,
+    const int window_size_right) {
+  using Config = KernelConfig<D, LOW_SMEM>;
+  constexpr int THREADS_PER_BLOCK = Config::THREADS_PER_BLOCK;
+  constexpr int Q_STRIDE = Config::Q_STRIDE;
+  constexpr int KV_STRIDE = Config::KV_STRIDE;
+  constexpr int S_STRIDE = Config::S_STRIDE;
+  const float NEG_INF = -1e30f;
+  const int tid = threadIdx.x;
+  const int total_scores = valid_q_rows * valid_k_rows;
 
-    for (int idx = tid; idx < total_scores; idx += THREADS_PER_BLOCK) {
-        const int row = idx / valid_k_rows;
-        const int col = idx - row * valid_k_rows;
-        const int global_m = start_row + row;
-        const int global_n = start_col + col;
-        const int global_q_pos = global_m + causal_q_offset;
+  for (int idx = tid; idx < total_scores; idx += THREADS_PER_BLOCK) {
+    const int row = idx / valid_k_rows;
+    const int col = idx - row * valid_k_rows;
+    const int global_m = start_row + row;
+    const int global_n = start_col + col;
+    const int global_q_pos = global_m + causal_q_offset;
 
-        bool is_valid = true;
-        if constexpr (IS_CAUSAL) {
-            is_valid = global_n <= global_q_pos;
-        }
-        if (window_size_left >= 0) {
-            is_valid = is_valid && global_n >= global_q_pos - window_size_left;
-        }
-        if (window_size_right >= 0) {
-            is_valid = is_valid && global_n <= global_q_pos + window_size_right;
-        }
-
-        float acc = 0.0f;
-        if (is_valid) {
-            #pragma unroll 8
-            for (int d = 0; d < D; d += 2) {
-                const __half2 q_h2 = *reinterpret_cast<const __half2*>(
-                    sQ + row * Q_STRIDE + d);
-                const __half2 k_h2 = *reinterpret_cast<const __half2*>(
-                    sK + col * KV_STRIDE + d);
-                const float2 q_f2 = __half22float2(q_h2);
-                const float2 k_f2 = __half22float2(k_h2);
-                acc = fmaf(q_f2.x, k_f2.x, acc);
-                acc = fmaf(q_f2.y, k_f2.y, acc);
-            }
-        }
-        sS[row * S_STRIDE + col] = is_valid ? acc * score_scale : NEG_INF;
-    }
-}
-
-template<int D, bool LOW_SMEM, bool D256_WMMA_QK, bool IS_CAUSAL>
-__global__ void __launch_bounds__(KernelConfig<D, LOW_SMEM>::THREADS_PER_BLOCK, 2)
-flash_attention_forward_kernel(
-    const __half* __restrict__ Q,
-    const __half* __restrict__ K,
-    const __half* __restrict__ V,
-          __half* __restrict__ Out,
-           float* __restrict__ softmax_lse,
-    const int B,
-    const int H,
-    const int H_KV,
-    const int M,
-    const int N,
-    const float softmax_scale,
-    const bool scalar_pv,
-    const int window_size_left,
-    const int window_size_right
-) {
-    using Config = KernelConfig<D, LOW_SMEM>;
-    constexpr int BLOCK_M           = Config::BLOCK_M;
-    constexpr int BLOCK_N           = Config::BLOCK_N;
-    constexpr int THREADS_PER_BLOCK = Config::THREADS_PER_BLOCK;
-    constexpr int THREADS_PER_ROW   = Config::THREADS_PER_ROW;
-    constexpr int WARPS_PER_BLOCK   = Config::WARPS_PER_BLOCK;
-    constexpr int Q_STRIDE          = Config::Q_STRIDE;
-    constexpr int KV_STRIDE         = Config::KV_STRIDE;
-    constexpr int S_STRIDE          = Config::S_STRIDE;
-    constexpr int P_SUB_TILE        = Config::P_SUB_TILE;
-    constexpr int P_STRIDE          = Config::P_STRIDE;
-    constexpr int O_STRIDE          = Config::O_STRIDE;
-    constexpr int PER_UINT4         = Config::PER_UINT4;
-    const float NEG_INF = -1e30f;
-
-    const int batch_head_id = blockIdx.z;
-    if (batch_head_id >= B * H) return;
-    const int batch_id = batch_head_id / H;
-    const int q_head_id = batch_head_id % H;
-    const int kv_group_size = H / H_KV;
-    const int kv_head_id = q_head_id / kv_group_size;
-
-    const int block_m = blockIdx.x;
-    const int start_row = block_m * BLOCK_M;
-    if (start_row >= M) return;
-
-    int num_n_tiles = (N + BLOCK_N - 1) / BLOCK_N;
-    const int valid_q_rows = min(BLOCK_M, M - start_row);
-    const int causal_q_offset = max(N - M, 0);
-
-    int max_key_pos = N - 1;
+    bool is_valid = true;
     if constexpr (IS_CAUSAL) {
-        max_key_pos = min(max_key_pos,
-                          causal_q_offset + start_row + valid_q_rows - 1);
+      is_valid = global_n <= global_q_pos;
+    }
+    if (window_size_left >= 0) {
+      is_valid = is_valid && global_n >= global_q_pos - window_size_left;
     }
     if (window_size_right >= 0) {
-        max_key_pos = min(max_key_pos,
-                          causal_q_offset + start_row + valid_q_rows - 1
-                              + window_size_right);
-    }
-    if (max_key_pos < 0) {
-        num_n_tiles = 0;
-    } else {
-        num_n_tiles = min(num_n_tiles, (max_key_pos + BLOCK_N) / BLOCK_N);
-    }
-    const int min_key_pos = window_size_left >= 0
-                                ? max(0, causal_q_offset + start_row
-                                             - window_size_left)
-                                : 0;
-
-    const int tid = threadIdx.x;
-    const int warp_id = tid / MAX_THREADS_PER_WARP;
-    const int lane_id = tid % MAX_THREADS_PER_WARP;
-
-    const size_t q_head_linear = (size_t)batch_id * H + q_head_id;
-    const size_t kv_head_linear = (size_t)batch_id * H_KV + kv_head_id;
-    const __half* q_ptr = Q + q_head_linear * M * D + start_row * D;
-    const __half* k_ptr = K + kv_head_linear * N * D;
-    const __half* v_ptr = V + kv_head_linear * N * D;
-    __half* out_ptr = Out + q_head_linear * M * D + start_row * D;
-    float* softmax_lse_ptr = softmax_lse + q_head_linear * M + start_row;
-
-    extern __shared__ char smem_raw[];
-    init_smem<Config>(smem_raw);
-    auto& smem = *reinterpret_cast<typename Config::SmemLayout*>(smem_raw);
-
-    __half* sQ      = smem.q;
-    __half* sK      = smem.reuse_kv.k;
-    __half* sV      = smem.reuse_kv.v;
-    float*  sS      = smem.reuse_sp.s;
-    __half* sP      = (D == 256) ? smem.p_strict : smem.reuse_sp.p;
-    const int p_stride = (D == 256) ? P_STRIDE : S_STRIDE;
-    const int p_tile_capacity = (D == 256) ? P_SUB_TILE : BLOCK_N;
-    float*  sO      = smem.o;
-    float*  sRowMax = smem.row_max;
-    float*  sRowSum = smem.row_sum;
-    constexpr float RCP_LN2 = 1.4426950408889634f;
-    constexpr float LN2 = 0.6931471805599453f;
-    constexpr float EXP2_CLAMP = -80.0f * RCP_LN2;
-    const float softmax_scale_log2 = softmax_scale * RCP_LN2;
-
-    const int  d_stride_uint4 = (D + PER_UINT4 - 1) / PER_UINT4;
-    const int  q_stride_uint4 = (Q_STRIDE  + PER_UINT4 - 1) / PER_UINT4;
-    const int kv_stride_uint4 = (KV_STRIDE + PER_UINT4 - 1) / PER_UINT4;
-
-    if (tid < BLOCK_M) {
-        sRowMax[tid] = NEG_INF;
+      is_valid = is_valid && global_n <= global_q_pos + window_size_right;
     }
 
-    const uint4*      q_vec = reinterpret_cast<const uint4*>(q_ptr);
-    uint4*           sQ_vec = reinterpret_cast<uint4*>(sQ);
-
-    #pragma unroll 4
-    for (int idx = tid; idx < (valid_q_rows * d_stride_uint4); idx += THREADS_PER_BLOCK) {
-        const int row = idx / d_stride_uint4;
-        const int vec_col = idx % d_stride_uint4;
-        uint4 q_val = make_uint4(0, 0, 0, 0);
-        if (row < valid_q_rows && vec_col < d_stride_uint4) {
-            q_val = __ldg(&q_vec[row * d_stride_uint4 + vec_col]);
-        }
-        sQ_vec[row * q_stride_uint4 + vec_col] = q_val;
+    float acc = 0.0f;
+    if (is_valid) {
+#pragma unroll 8
+      for (int d = 0; d < D; d += 2) {
+        const __half2 q_h2 =
+            *reinterpret_cast<const __half2*>(sQ + row * Q_STRIDE + d);
+        const __half2 k_h2 =
+            *reinterpret_cast<const __half2*>(sK + col * KV_STRIDE + d);
+        const float2 q_f2 = __half22float2(q_h2);
+        const float2 k_f2 = __half22float2(k_h2);
+        acc = fmaf(q_f2.x, k_f2.x, acc);
+        acc = fmaf(q_f2.y, k_f2.y, acc);
+      }
     }
-    __syncthreads();
-
-    for (int block_n = 0; block_n < num_n_tiles; ++block_n) {
-        const int start_col = block_n * BLOCK_N;
-        if (start_col >= N) break;
-        const int valid_k_rows = min(BLOCK_N, N - start_col);
-
-        if (start_col + valid_k_rows <= min_key_pos) {
-            continue;
-        }
-
-        const uint4* k_vec     = reinterpret_cast<const uint4*>(k_ptr + start_col * D);
-        uint4*       sK_vec    = reinterpret_cast<uint4*>(sK);
-
-        #pragma unroll 2
-        for (int idx = tid; idx < (valid_k_rows * d_stride_uint4); idx += THREADS_PER_BLOCK) {
-            const int row = idx / d_stride_uint4;
-            const int vec_col = idx % d_stride_uint4;
-
-            uint4 k_val = make_uint4(0, 0, 0, 0);
-            if (row < valid_k_rows && vec_col < d_stride_uint4) {
-                k_val = __ldg(&k_vec[row * d_stride_uint4 + vec_col]);
-            }
-            sK_vec[row * kv_stride_uint4 + vec_col] = k_val;
-        }
-        __syncthreads();
-
-        if constexpr (D == 256 && !D256_WMMA_QK) {
-            compute_qk_scores_scalar_fp32<D, LOW_SMEM, IS_CAUSAL>(
-                sQ, sK, sS, valid_q_rows, valid_k_rows, start_row, start_col,
-                causal_q_offset, softmax_scale, window_size_left,
-                window_size_right);
-        } else {
-            const int num_tiles_m_qk    = (BLOCK_M + WMMA_M - 1) / WMMA_M;
-            const int num_tiles_n_qk    = (BLOCK_N + WMMA_N - 1) / WMMA_N;
-            const int num_tiles_k_qk    = (D + WMMA_K - 1) / WMMA_K;
-            const int total_tiles_qk    = num_tiles_m_qk * num_tiles_n_qk;
-            const int tiles_per_warp_qk = (total_tiles_qk + WARPS_PER_BLOCK - 1) / WARPS_PER_BLOCK;
-            const unsigned row_causal   = (lane_id & 0b1) + ((lane_id >> 2) & 0b1) * 8 + ((lane_id >> 4) & 0b1) * 4;
-            const unsigned col_causal   = ((lane_id >> 1) & 0b1) * 2 + ((lane_id >> 3) & 0b1) * 8;
-
-            for (int tile_idx = 0; tile_idx < tiles_per_warp_qk; ++tile_idx) {
-                const int global_tile_idx = warp_id * tiles_per_warp_qk + tile_idx;
-                if (global_tile_idx >= total_tiles_qk) break;
-
-                const int tile_m_idx = global_tile_idx / num_tiles_n_qk;
-                const int tile_n_idx = global_tile_idx % num_tiles_n_qk;
-
-                const int tile_m = tile_m_idx * WMMA_M;
-                const int tile_n = tile_n_idx * WMMA_N;
-
-                if (tile_m >= valid_q_rows || tile_n >= valid_k_rows) continue;
-
-                fragment<matrix_a, WMMA_M, WMMA_N, WMMA_K, half, row_major> a_frag;
-                fragment<matrix_b, WMMA_M, WMMA_N, WMMA_K, half, col_major> b_frag;
-                fragment<accumulator, WMMA_M, WMMA_N, WMMA_K, float> acc_frag;
-                fill_fragment(acc_frag, 0.0f);
-
-                #pragma unroll
-                for (int k_tile = 0; k_tile < num_tiles_k_qk; ++k_tile) {
-                    const int k_offset = k_tile * WMMA_K;
-                    if (k_offset >= D) break;
-
-                    load_matrix_sync(a_frag, sQ + tile_m * Q_STRIDE + k_offset, Q_STRIDE);
-                    load_matrix_sync(b_frag, sK + tile_n * KV_STRIDE + k_offset, KV_STRIDE);
-                    mma_sync(acc_frag, a_frag, b_frag, acc_frag);
-                }
-
-                #pragma unroll
-                for (int i = 0; i < acc_frag.num_elements; ++i) {
-                    const unsigned col = col_causal + (i & 0b1) + ((i >> 2) & 0b1) * 4;
-                    const unsigned row = row_causal + ((i >> 1) & 0b1) * 2;
-
-                    const int global_m = start_row + tile_m + row;
-                    const int global_n = start_col + tile_n + col;
-                    const int global_q_pos = global_m + causal_q_offset;
-
-                    const bool is_valid = (global_m < start_row + valid_q_rows) &&
-                                          (global_n < start_col + valid_k_rows);
-                    bool is_causal_valid = true;
-                    if constexpr (IS_CAUSAL) {
-                        is_causal_valid = global_n <= global_q_pos;
-                    }
-                    bool is_window_valid = true;
-                    if (window_size_left >= 0) {
-                        is_window_valid = is_window_valid &&
-                                          global_n >= global_q_pos - window_size_left;
-                    }
-                    if (window_size_right >= 0) {
-                        is_window_valid = is_window_valid &&
-                                          global_n <= global_q_pos + window_size_right;
-                    }
-
-                    const float qk_scale =
-                        (D == 256) ? softmax_scale : softmax_scale_log2;
-                    acc_frag.x[i] =
-                        (is_valid && is_causal_valid && is_window_valid)
-                            ? acc_frag.x[i] * qk_scale
-                            : NEG_INF;
-                }
-                store_matrix_sync(sS + tile_m * S_STRIDE + tile_n, acc_frag, S_STRIDE, mem_row_major);
-            }
-        }
-        __syncthreads();
-
-        const uint4* v_vec     = reinterpret_cast<const uint4*>(v_ptr + start_col * D);
-        uint4*       sV_vec    = reinterpret_cast<uint4*>(sV);
-
-        #pragma unroll 2
-        for (int idx = tid; idx < (valid_k_rows * d_stride_uint4); idx += THREADS_PER_BLOCK) {
-            const int row = idx / d_stride_uint4;
-            const int vec_col = idx % d_stride_uint4;
-
-            uint4 v_val = make_uint4(0, 0, 0, 0);
-            if (row < valid_k_rows && vec_col < d_stride_uint4) {
-                v_val = __ldg(&v_vec[row * d_stride_uint4 + vec_col]);
-            }
-            sV_vec[row * kv_stride_uint4 + vec_col] = v_val;
-        }
-        __syncthreads();
-
-        const int num_tiles_m_pv    = (BLOCK_M + WMMA_M - 1) / WMMA_M;
-        const int num_tiles_n_pv    = (D + WMMA_N - 1) / WMMA_N;
-        const int total_tiles_pv    = num_tiles_m_pv * num_tiles_n_pv;
-        const int tiles_per_warp_pv = (total_tiles_pv + WARPS_PER_BLOCK - 1) / WARPS_PER_BLOCK;
-        const int softmax_sub_tile = (D == 256) ? P_SUB_TILE : p_tile_capacity;
-
-        for (int sub_start = 0; sub_start < valid_k_rows;
-             sub_start += softmax_sub_tile) {
-            const int sub_valid_k_rows = min(softmax_sub_tile,
-                                             valid_k_rows - sub_start);
-
-            if (tid < valid_q_rows * THREADS_PER_ROW) {
-                const int row = tid / THREADS_PER_ROW;
-                const int thread_in_row = tid % THREADS_PER_ROW;
-                const unsigned mask = (valid_q_rows == BLOCK_M)
-                                          ? 0xFFFFFFFFU
-                                          : __activemask();
-                const int row_leader = __ffs(mask) - 1;
-
-                float*  sS_row_f = sS + row * S_STRIDE + sub_start;
-                __half* sP_row_h = sP + row * p_stride;
-
-                const int vec_cols = sub_valid_k_rows >> 2;
-                const int vecs_per_thread =
-                    (vec_cols + THREADS_PER_ROW - 1) / THREADS_PER_ROW;
-                const int tail_start = vec_cols << 2;
-
-                float thread_max = NEG_INF;
-                float4* sS_vec4 = reinterpret_cast<float4*>(sS_row_f);
-
-                #pragma unroll 4
-                for (int j = 0; j < vecs_per_thread; ++j) {
-                    int vc = thread_in_row + j * THREADS_PER_ROW;
-                    if (vc < vec_cols) {
-                        float4 v4 = sS_vec4[vc];
-                        thread_max = fmaxf(
-                            thread_max,
-                            fmaxf(fmaxf(v4.x, v4.y), fmaxf(v4.z, v4.w)));
-                    }
-                }
-
-                #pragma unroll 4
-                for (int c = tail_start + thread_in_row; c < sub_valid_k_rows;
-                     c += THREADS_PER_ROW) {
-                    thread_max = fmaxf(thread_max, sS_row_f[c]);
-                }
-
-                #pragma unroll
-                for (int o = THREADS_PER_ROW / 2; o > 0; o >>= 1) {
-                    thread_max = fmaxf(
-                        thread_max,
-                        __shfl_down_sync(mask, thread_max, o, THREADS_PER_ROW));
-                }
-
-                const float row_max =
-                    __shfl_sync(mask, thread_max, row_leader, THREADS_PER_ROW);
-                const float old_max = sRowMax[row];
-                const float new_max = fmaxf(old_max, row_max);
-                const float exp_diff = (D == 256)
-                    ? expf(fmaxf(old_max - new_max, -80.0f))
-                    : exp2f(old_max - new_max);
-
-                float thread_sum = 0.0f;
-                __half2 half_buffer[20];
-                int vc_base = thread_in_row;
-                int h2_idx = 0;
-                int tail_col = -1;
-                __half tail_value = __float2half(0.f);
-
-                #pragma unroll 4
-                for (int j = 0; j < vecs_per_thread; ++j,
-                         vc_base += THREADS_PER_ROW) {
-                    if (vc_base < vec_cols) {
-                        float4 v4 = sS_vec4[vc_base];
-
-                        float e0 = (D == 256)
-                            ? expf(fmaxf(v4.x - new_max, -80.0f))
-                            : exp2f(fmaxf(v4.x - new_max, EXP2_CLAMP));
-                        float e1 = (D == 256)
-                            ? expf(fmaxf(v4.y - new_max, -80.0f))
-                            : exp2f(fmaxf(v4.y - new_max, EXP2_CLAMP));
-                        float e2 = (D == 256)
-                            ? expf(fmaxf(v4.z - new_max, -80.0f))
-                            : exp2f(fmaxf(v4.z - new_max, EXP2_CLAMP));
-                        float e3 = (D == 256)
-                            ? expf(fmaxf(v4.w - new_max, -80.0f))
-                            : exp2f(fmaxf(v4.w - new_max, EXP2_CLAMP));
-
-                        thread_sum += (e0 + e1) + (e2 + e3);
-
-                        half_buffer[h2_idx++] =
-                            __float22half2_rn(make_float2(e0, e1));
-                        half_buffer[h2_idx++] =
-                            __float22half2_rn(make_float2(e2, e3));
-                    }
-                }
-
-                #pragma unroll 4
-                for (int c = tail_start + thread_in_row; c < sub_valid_k_rows;
-                     c += THREADS_PER_ROW) {
-                    float v = sS_row_f[c];
-                    float e = (D == 256)
-                        ? expf(fmaxf(v - new_max, -80.0f))
-                        : exp2f(fmaxf(v - new_max, EXP2_CLAMP));
-                    thread_sum += e;
-                    tail_col = c;
-                    tail_value = __float2half_rn(e);
-                }
-
-                #pragma unroll
-                for (int o = THREADS_PER_ROW / 2; o > 0; o >>= 1) {
-                    thread_sum +=
-                        __shfl_down_sync(mask, thread_sum, o, THREADS_PER_ROW);
-                }
-
-                float row_sum =
-                    __shfl_sync(mask, thread_sum, row_leader, THREADS_PER_ROW);
-
-                if (thread_in_row == 0) {
-                    sRowSum[row] = exp_diff * sRowSum[row] + row_sum;
-                    sRowMax[row] = new_max;
-                }
-
-                h2_idx = 0;
-                vc_base = thread_in_row;
-                __half2* sP_half2 = reinterpret_cast<__half2*>(sP_row_h);
-
-                #pragma unroll 4
-                for (int j = 0; j < vecs_per_thread; ++j,
-                         vc_base += THREADS_PER_ROW) {
-                    if (vc_base < vec_cols) {
-                        int base_offset = vc_base * 2;
-                        sP_half2[base_offset] = half_buffer[h2_idx++];
-                        sP_half2[base_offset + 1] = half_buffer[h2_idx++];
-                    }
-                }
-
-                if (tail_col >= 0) {
-                    sP_row_h[tail_col] = tail_value;
-                }
-
-                #pragma unroll 4
-                for (int c = tail_start + thread_in_row; c < p_tile_capacity;
-                     c += THREADS_PER_ROW) {
-                    if (c >= sub_valid_k_rows) {
-                        sP_row_h[c] = __float2half(0.f);
-                    }
-                }
-
-                if (block_n > 0 || sub_start > 0) {
-                    float*  sO_row = sO + row * O_STRIDE;
-                    float4* sO_vec = reinterpret_cast<float4*>(sO_row);
-                    const int o_vec_count = (O_STRIDE + 3) >> 2;
-                    float scale = exp_diff;
-
-                    #pragma unroll 4
-                    for (int ov = thread_in_row; ov < o_vec_count;
-                         ov += THREADS_PER_ROW) {
-                        float4 v = sO_vec[ov];
-                        v.x *= scale;
-                        v.y *= scale;
-                        v.z *= scale;
-                        v.w *= scale;
-                        sO_vec[ov] = v;
-                    }
-                }
-            }
-            __syncthreads();
-
-            if (scalar_pv) {
-                const int total_row_cols = valid_q_rows * D;
-                for (int idx = tid; idx < total_row_cols;
-                     idx += THREADS_PER_BLOCK) {
-                    const int row = idx / D;
-                    const int d_col = idx - row * D;
-                    const __half* sP_row_h = sP + row * p_stride;
-                    float acc = 0.0f;
-
-                    #pragma unroll 1
-                    for (int k_idx = 0; k_idx < sub_valid_k_rows; ++k_idx) {
-                        const float p_val = __half2float(sP_row_h[k_idx]);
-                        const float v_val = __half2float(
-                            sV[(sub_start + k_idx) * KV_STRIDE + d_col]);
-                        acc += p_val * v_val;
-                    }
-                    sO[row * O_STRIDE + d_col] += acc;
-                }
-                __syncthreads();
-                continue;
-            }
-
-            const int num_tiles_k_pv =
-                (p_tile_capacity + WMMA_K - 1) / WMMA_K;
-
-            for (int tile_idx = 0; tile_idx < tiles_per_warp_pv; ++tile_idx) {
-                const int global_tile_idx = warp_id * tiles_per_warp_pv + tile_idx;
-                if (global_tile_idx >= total_tiles_pv) break;
-
-                const int tile_m_idx = global_tile_idx / num_tiles_n_pv;
-                const int tile_d_idx = global_tile_idx % num_tiles_n_pv;
-
-                const int tile_m = tile_m_idx * WMMA_M;
-                const int tile_d = tile_d_idx * WMMA_N;
-
-                if (tile_m >= valid_q_rows) continue;
-
-                fragment<matrix_a, WMMA_M, WMMA_N, WMMA_K, half, row_major> a_frag;
-                fragment<matrix_b, WMMA_M, WMMA_N, WMMA_K, half, row_major> b_frag;
-                fragment<accumulator, WMMA_M, WMMA_N, WMMA_K, float> acc_frag;
-
-                load_matrix_sync(
-                    acc_frag,
-                    sO + tile_m * O_STRIDE + tile_d,
-                    O_STRIDE,
-                    mem_row_major);
-
-                #pragma unroll
-                for (int tile_k = 0; tile_k < num_tiles_k_pv; ++tile_k) {
-                    const int k_offset = tile_k * WMMA_K;
-                    if (k_offset >= sub_valid_k_rows) break;
-
-                    load_matrix_sync(
-                        a_frag,
-                        sP + tile_m * p_stride + k_offset,
-                        p_stride);
-                    load_matrix_sync(
-                        b_frag,
-                        sV + (sub_start + k_offset) * KV_STRIDE + tile_d,
-                        KV_STRIDE);
-                    mma_sync(acc_frag, a_frag, b_frag, acc_frag);
-                }
-                store_matrix_sync(
-                    sO + tile_m * O_STRIDE + tile_d,
-                    acc_frag,
-                    O_STRIDE,
-                    mem_row_major);
-            }
-            __syncthreads();
-        }
-    }
-
-    const int total_fp16_x4 = (valid_q_rows * D) / 4;
-
-    for (int i = tid; i < total_fp16_x4; i += THREADS_PER_BLOCK) {
-        const int row = i / (D / 4);
-        const int col = (i % (D / 4)) * 4;
-
-        const float sum_clamped = fmaxf(sRowSum[row], 1e-24f);
-        const float inv_sum = 1.0f / sum_clamped;
-        const float* sO_row = sO + row * O_STRIDE;
-
-        const __half h0 = __float2half_rn(sO_row[col + 0] * inv_sum);
-        const __half h1 = __float2half_rn(sO_row[col + 1] * inv_sum);
-        const __half h2 = __float2half_rn(sO_row[col + 2] * inv_sum);
-        const __half h3 = __float2half_rn(sO_row[col + 3] * inv_sum);
-
-        asm volatile(
-            "st.global.v4.u16 [%0], {%1, %2, %3, %4};"
-            :
-            : "l"(out_ptr + row * D + col),
-              "h"(__half_as_ushort(h0)),
-              "h"(__half_as_ushort(h1)),
-              "h"(__half_as_ushort(h2)),
-              "h"(__half_as_ushort(h3))
-            : "memory"
-        );
-    }
-
-    if (tid < valid_q_rows) {
-        const float sum = fmaxf(sRowSum[tid], 1e-24f);
-        softmax_lse_ptr[tid] = (D == 256)
-            ? sRowMax[tid] + logf(sum)
-            : (sRowMax[tid] + log2f(sum)) * LN2;
-    }
+    sS[row * S_STRIDE + col] = is_valid ? acc * score_scale : NEG_INF;
+  }
 }
 
-template<int D, bool IS_CAUSAL>
-__global__ void __launch_bounds__(KernelConfig<D>::THREADS_PER_BLOCK, 2)
-flash_attention_qk_scores_kernel(
-    const __half* __restrict__ Q,
-    const __half* __restrict__ K,
-          float* __restrict__ Scores,
-    const int B,
-    const int H,
-    const int H_KV,
-    const int M,
-    const int N,
-    const float softmax_scale
-) {
-    using Config = KernelConfig<D>;
-    constexpr int BLOCK_M           = Config::BLOCK_M;
-    constexpr int BLOCK_N           = Config::BLOCK_N;
-    constexpr int THREADS_PER_BLOCK = Config::THREADS_PER_BLOCK;
-    constexpr int WARPS_PER_BLOCK   = Config::WARPS_PER_BLOCK;
-    constexpr int Q_STRIDE          = Config::Q_STRIDE;
-    constexpr int KV_STRIDE         = Config::KV_STRIDE;
-    constexpr int S_STRIDE          = Config::S_STRIDE;
-    constexpr int PER_UINT4         = Config::PER_UINT4;
-    const float NEG_INF = -1e30f;
+template <int D, bool LOW_SMEM, bool D256_WMMA_QK, bool IS_CAUSAL>
+__global__ void __launch_bounds__(KernelConfig<D, LOW_SMEM>::THREADS_PER_BLOCK,
+                                  2)
+    flash_attention_forward_kernel(
+        const __half* __restrict__ Q, const __half* __restrict__ K,
+        const __half* __restrict__ V, __half* __restrict__ Out,
+        float* __restrict__ softmax_lse, const int B, const int H,
+        const int H_KV, const int M, const int N, const float softmax_scale,
+        const bool scalar_pv, const int window_size_left,
+        const int window_size_right) {
+  using Config = KernelConfig<D, LOW_SMEM>;
+  constexpr int BLOCK_M = Config::BLOCK_M;
+  constexpr int BLOCK_N = Config::BLOCK_N;
+  constexpr int THREADS_PER_BLOCK = Config::THREADS_PER_BLOCK;
+  constexpr int THREADS_PER_ROW = Config::THREADS_PER_ROW;
+  constexpr int WARPS_PER_BLOCK = Config::WARPS_PER_BLOCK;
+  constexpr int Q_STRIDE = Config::Q_STRIDE;
+  constexpr int KV_STRIDE = Config::KV_STRIDE;
+  constexpr int S_STRIDE = Config::S_STRIDE;
+  constexpr int P_SUB_TILE = Config::P_SUB_TILE;
+  constexpr int P_STRIDE = Config::P_STRIDE;
+  constexpr int O_STRIDE = Config::O_STRIDE;
+  constexpr int PER_UINT4 = Config::PER_UINT4;
+  const float NEG_INF = -1e30f;
 
-    const int batch_head_id = blockIdx.z;
-    if (batch_head_id >= B * H) return;
-    const int batch_id = batch_head_id / H;
-    const int q_head_id = batch_head_id % H;
-    const int kv_group_size = H / H_KV;
-    const int kv_head_id = q_head_id / kv_group_size;
+  const int batch_head_id = blockIdx.z;
+  if (batch_head_id >= B * H) return;
+  const int batch_id = batch_head_id / H;
+  const int q_head_id = batch_head_id % H;
+  const int kv_group_size = H / H_KV;
+  const int kv_head_id = q_head_id / kv_group_size;
 
-    const int block_m = blockIdx.x;
-    const int block_n = blockIdx.y;
-    const int start_row = block_m * BLOCK_M;
+  const int block_m = blockIdx.x;
+  const int start_row = block_m * BLOCK_M;
+  if (start_row >= M) return;
+
+  int num_n_tiles = (N + BLOCK_N - 1) / BLOCK_N;
+  const int valid_q_rows = min(BLOCK_M, M - start_row);
+  const int causal_q_offset = max(N - M, 0);
+
+  int max_key_pos = N - 1;
+  if constexpr (IS_CAUSAL) {
+    max_key_pos =
+        min(max_key_pos, causal_q_offset + start_row + valid_q_rows - 1);
+  }
+  if (window_size_right >= 0) {
+    max_key_pos = min(max_key_pos, causal_q_offset + start_row + valid_q_rows -
+                                       1 + window_size_right);
+  }
+  if (max_key_pos < 0) {
+    num_n_tiles = 0;
+  } else {
+    num_n_tiles = min(num_n_tiles, (max_key_pos + BLOCK_N) / BLOCK_N);
+  }
+  const int min_key_pos =
+      window_size_left >= 0
+          ? max(0, causal_q_offset + start_row - window_size_left)
+          : 0;
+
+  const int tid = threadIdx.x;
+  const int warp_id = tid / MAX_THREADS_PER_WARP;
+  const int lane_id = tid % MAX_THREADS_PER_WARP;
+
+  const size_t q_head_linear = (size_t)batch_id * H + q_head_id;
+  const size_t kv_head_linear = (size_t)batch_id * H_KV + kv_head_id;
+  const __half* q_ptr = Q + q_head_linear * M * D + start_row * D;
+  const __half* k_ptr = K + kv_head_linear * N * D;
+  const __half* v_ptr = V + kv_head_linear * N * D;
+  __half* out_ptr = Out + q_head_linear * M * D + start_row * D;
+  float* softmax_lse_ptr = softmax_lse + q_head_linear * M + start_row;
+
+  extern __shared__ char smem_raw[];
+  init_smem<Config>(smem_raw);
+  auto& smem = *reinterpret_cast<typename Config::SmemLayout*>(smem_raw);
+
+  __half* sQ = smem.q;
+  __half* sK = smem.reuse_kv.k;
+  __half* sV = smem.reuse_kv.v;
+  float* sS = smem.reuse_sp.s;
+  __half* sP = (D == 256) ? smem.p_strict : smem.reuse_sp.p;
+  const int p_stride = (D == 256) ? P_STRIDE : S_STRIDE;
+  const int p_tile_capacity = (D == 256) ? P_SUB_TILE : BLOCK_N;
+  float* sO = smem.o;
+  float* sRowMax = smem.row_max;
+  float* sRowSum = smem.row_sum;
+  constexpr float RCP_LN2 = 1.4426950408889634f;
+  constexpr float LN2 = 0.6931471805599453f;
+  constexpr float EXP2_CLAMP = -80.0f * RCP_LN2;
+  const float softmax_scale_log2 = softmax_scale * RCP_LN2;
+
+  const int d_stride_uint4 = (D + PER_UINT4 - 1) / PER_UINT4;
+  const int q_stride_uint4 = (Q_STRIDE + PER_UINT4 - 1) / PER_UINT4;
+  const int kv_stride_uint4 = (KV_STRIDE + PER_UINT4 - 1) / PER_UINT4;
+
+  if (tid < BLOCK_M) {
+    sRowMax[tid] = NEG_INF;
+  }
+
+  const uint4* q_vec = reinterpret_cast<const uint4*>(q_ptr);
+  uint4* sQ_vec = reinterpret_cast<uint4*>(sQ);
+
+#pragma unroll 4
+  for (int idx = tid; idx < (valid_q_rows * d_stride_uint4);
+       idx += THREADS_PER_BLOCK) {
+    const int row = idx / d_stride_uint4;
+    const int vec_col = idx % d_stride_uint4;
+    uint4 q_val = make_uint4(0, 0, 0, 0);
+    if (row < valid_q_rows && vec_col < d_stride_uint4) {
+      q_val = __ldg(&q_vec[row * d_stride_uint4 + vec_col]);
+    }
+    sQ_vec[row * q_stride_uint4 + vec_col] = q_val;
+  }
+  __syncthreads();
+
+  for (int block_n = 0; block_n < num_n_tiles; ++block_n) {
     const int start_col = block_n * BLOCK_N;
-    if (start_row >= M || start_col >= N) return;
-
-    const int valid_q_rows = min(BLOCK_M, M - start_row);
+    if (start_col >= N) break;
     const int valid_k_rows = min(BLOCK_N, N - start_col);
-    const int causal_q_offset = max(N - M, 0);
 
-    if constexpr (IS_CAUSAL) {
-        if (start_col >= causal_q_offset + start_row + valid_q_rows) {
-            return;
-        }
+    if (start_col + valid_k_rows <= min_key_pos) {
+      continue;
     }
 
-    const int tid = threadIdx.x;
-    const int warp_id = tid / MAX_THREADS_PER_WARP;
-    const int lane_id = tid % MAX_THREADS_PER_WARP;
-
-    const size_t q_head_linear = (size_t)batch_id * H + q_head_id;
-    const size_t kv_head_linear = (size_t)batch_id * H_KV + kv_head_id;
-    const __half* q_ptr = Q + q_head_linear * M * D + start_row * D;
-    const __half* k_ptr = K + kv_head_linear * N * D + start_col * D;
-    float* score_ptr = Scores + q_head_linear * M * N + start_row * N + start_col;
-
-    extern __shared__ char smem_raw[];
-    init_smem<Config>(smem_raw);
-    auto& smem = *reinterpret_cast<typename Config::SmemLayout*>(smem_raw);
-
-    __half* sQ = smem.q;
-    __half* sK = smem.reuse_kv.k;
-    float*  sS = smem.reuse_sp.s;
-
-    const int d_stride_uint4  = (D + PER_UINT4 - 1) / PER_UINT4;
-    const int q_stride_uint4  = (Q_STRIDE + PER_UINT4 - 1) / PER_UINT4;
-    const int kv_stride_uint4 = (KV_STRIDE + PER_UINT4 - 1) / PER_UINT4;
-
-    const uint4* q_vec = reinterpret_cast<const uint4*>(q_ptr);
-    uint4* sQ_vec = reinterpret_cast<uint4*>(sQ);
-
-    #pragma unroll 4
-    for (int idx = tid; idx < (valid_q_rows * d_stride_uint4);
-         idx += THREADS_PER_BLOCK) {
-        const int row = idx / d_stride_uint4;
-        const int vec_col = idx % d_stride_uint4;
-        uint4 q_val = make_uint4(0, 0, 0, 0);
-        if (row < valid_q_rows && vec_col < d_stride_uint4) {
-            q_val = __ldg(&q_vec[row * d_stride_uint4 + vec_col]);
-        }
-        sQ_vec[row * q_stride_uint4 + vec_col] = q_val;
-    }
-
-    const uint4* k_vec = reinterpret_cast<const uint4*>(k_ptr);
+    const uint4* k_vec = reinterpret_cast<const uint4*>(k_ptr + start_col * D);
     uint4* sK_vec = reinterpret_cast<uint4*>(sK);
 
-    #pragma unroll 2
+#pragma unroll 2
     for (int idx = tid; idx < (valid_k_rows * d_stride_uint4);
          idx += THREADS_PER_BLOCK) {
-        const int row = idx / d_stride_uint4;
-        const int vec_col = idx % d_stride_uint4;
-        uint4 k_val = make_uint4(0, 0, 0, 0);
-        if (row < valid_k_rows && vec_col < d_stride_uint4) {
-            k_val = __ldg(&k_vec[row * d_stride_uint4 + vec_col]);
-        }
-        sK_vec[row * kv_stride_uint4 + vec_col] = k_val;
+      const int row = idx / d_stride_uint4;
+      const int vec_col = idx % d_stride_uint4;
+
+      uint4 k_val = make_uint4(0, 0, 0, 0);
+      if (row < valid_k_rows && vec_col < d_stride_uint4) {
+        k_val = __ldg(&k_vec[row * d_stride_uint4 + vec_col]);
+      }
+      sK_vec[row * kv_stride_uint4 + vec_col] = k_val;
     }
     __syncthreads();
 
-    if constexpr (D == 256) {
-        compute_qk_scores_scalar_fp32<D, false, IS_CAUSAL>(
-            sQ, sK, sS, valid_q_rows, valid_k_rows, start_row, start_col,
-            causal_q_offset, softmax_scale, -1, -1);
+    if constexpr (D == 256 && !D256_WMMA_QK) {
+      compute_qk_scores_scalar_fp32<D, LOW_SMEM, IS_CAUSAL>(
+          sQ, sK, sS, valid_q_rows, valid_k_rows, start_row, start_col,
+          causal_q_offset, softmax_scale, window_size_left, window_size_right);
     } else {
-        const int num_tiles_m_qk = (BLOCK_M + WMMA_M - 1) / WMMA_M;
-        const int num_tiles_n_qk = (BLOCK_N + WMMA_N - 1) / WMMA_N;
-        const int num_tiles_k_qk = (D + WMMA_K - 1) / WMMA_K;
-        const int total_tiles_qk = num_tiles_m_qk * num_tiles_n_qk;
-        const int tiles_per_warp_qk =
-            (total_tiles_qk + WARPS_PER_BLOCK - 1) / WARPS_PER_BLOCK;
-        const unsigned row_causal =
-            (lane_id & 0b1) + ((lane_id >> 2) & 0b1) * 8
-            + ((lane_id >> 4) & 0b1) * 4;
-        const unsigned col_causal =
-            ((lane_id >> 1) & 0b1) * 2 + ((lane_id >> 3) & 0b1) * 8;
+      const int num_tiles_m_qk = (BLOCK_M + WMMA_M - 1) / WMMA_M;
+      const int num_tiles_n_qk = (BLOCK_N + WMMA_N - 1) / WMMA_N;
+      const int num_tiles_k_qk = (D + WMMA_K - 1) / WMMA_K;
+      const int total_tiles_qk = num_tiles_m_qk * num_tiles_n_qk;
+      const int tiles_per_warp_qk =
+          (total_tiles_qk + WARPS_PER_BLOCK - 1) / WARPS_PER_BLOCK;
+      const unsigned row_causal = (lane_id & 0b1) + ((lane_id >> 2) & 0b1) * 8 +
+                                  ((lane_id >> 4) & 0b1) * 4;
+      const unsigned col_causal =
+          ((lane_id >> 1) & 0b1) * 2 + ((lane_id >> 3) & 0b1) * 8;
 
-        for (int tile_idx = 0; tile_idx < tiles_per_warp_qk; ++tile_idx) {
-            const int global_tile_idx = warp_id * tiles_per_warp_qk + tile_idx;
-            if (global_tile_idx >= total_tiles_qk) break;
+      for (int tile_idx = 0; tile_idx < tiles_per_warp_qk; ++tile_idx) {
+        const int global_tile_idx = warp_id * tiles_per_warp_qk + tile_idx;
+        if (global_tile_idx >= total_tiles_qk) break;
 
-            const int tile_m_idx = global_tile_idx / num_tiles_n_qk;
-            const int tile_n_idx = global_tile_idx % num_tiles_n_qk;
+        const int tile_m_idx = global_tile_idx / num_tiles_n_qk;
+        const int tile_n_idx = global_tile_idx % num_tiles_n_qk;
 
-            const int tile_m = tile_m_idx * WMMA_M;
-            const int tile_n = tile_n_idx * WMMA_N;
+        const int tile_m = tile_m_idx * WMMA_M;
+        const int tile_n = tile_n_idx * WMMA_N;
 
-            if (tile_m >= valid_q_rows || tile_n >= valid_k_rows) continue;
+        if (tile_m >= valid_q_rows || tile_n >= valid_k_rows) continue;
 
-            fragment<matrix_a, WMMA_M, WMMA_N, WMMA_K, half, row_major> a_frag;
-            fragment<matrix_b, WMMA_M, WMMA_N, WMMA_K, half, col_major> b_frag;
-            fragment<accumulator, WMMA_M, WMMA_N, WMMA_K, float> acc_frag;
-            fill_fragment(acc_frag, 0.0f);
+        fragment<matrix_a, WMMA_M, WMMA_N, WMMA_K, half, row_major> a_frag;
+        fragment<matrix_b, WMMA_M, WMMA_N, WMMA_K, half, col_major> b_frag;
+        fragment<accumulator, WMMA_M, WMMA_N, WMMA_K, float> acc_frag;
+        fill_fragment(acc_frag, 0.0f);
 
-            #pragma unroll
-            for (int k_tile = 0; k_tile < num_tiles_k_qk; ++k_tile) {
-                const int k_offset = k_tile * WMMA_K;
-                if (k_offset >= D) break;
+#pragma unroll
+        for (int k_tile = 0; k_tile < num_tiles_k_qk; ++k_tile) {
+          const int k_offset = k_tile * WMMA_K;
+          if (k_offset >= D) break;
 
-                load_matrix_sync(a_frag, sQ + tile_m * Q_STRIDE + k_offset,
-                                 Q_STRIDE);
-                load_matrix_sync(b_frag, sK + tile_n * KV_STRIDE + k_offset,
-                                 KV_STRIDE);
-                mma_sync(acc_frag, a_frag, b_frag, acc_frag);
-            }
-
-            if constexpr (IS_CAUSAL) {
-                #pragma unroll
-                for (int i = 0; i < acc_frag.num_elements; ++i) {
-                    const unsigned col =
-                        col_causal + (i & 0b1) + ((i >> 2) & 0b1) * 4;
-                    const unsigned row = row_causal + ((i >> 1) & 0b1) * 2;
-
-                    const int global_m = start_row + tile_m + row;
-                    const int global_n = start_col + tile_n + col;
-                    const int global_q_pos = global_m + causal_q_offset;
-
-                    const bool is_valid =
-                        (global_m < start_row + valid_q_rows) &&
-                        (global_n < start_col + valid_k_rows);
-
-                    acc_frag.x[i] = is_valid
-                        ? ((global_n > global_q_pos)
-                               ? NEG_INF
-                               : acc_frag.x[i] * softmax_scale)
-                        : NEG_INF;
-                }
-            } else {
-                #pragma unroll
-                for (int i = 0; i < acc_frag.num_elements; ++i) {
-                    acc_frag.x[i] *= softmax_scale;
-                }
-            }
-            store_matrix_sync(sS + tile_m * S_STRIDE + tile_n, acc_frag,
-                              S_STRIDE, mem_row_major);
+          load_matrix_sync(a_frag, sQ + tile_m * Q_STRIDE + k_offset, Q_STRIDE);
+          load_matrix_sync(b_frag, sK + tile_n * KV_STRIDE + k_offset,
+                           KV_STRIDE);
+          mma_sync(acc_frag, a_frag, b_frag, acc_frag);
         }
+
+#pragma unroll
+        for (int i = 0; i < acc_frag.num_elements; ++i) {
+          const unsigned col = col_causal + (i & 0b1) + ((i >> 2) & 0b1) * 4;
+          const unsigned row = row_causal + ((i >> 1) & 0b1) * 2;
+
+          const int global_m = start_row + tile_m + row;
+          const int global_n = start_col + tile_n + col;
+          const int global_q_pos = global_m + causal_q_offset;
+
+          const bool is_valid = (global_m < start_row + valid_q_rows) &&
+                                (global_n < start_col + valid_k_rows);
+          bool is_causal_valid = true;
+          if constexpr (IS_CAUSAL) {
+            is_causal_valid = global_n <= global_q_pos;
+          }
+          bool is_window_valid = true;
+          if (window_size_left >= 0) {
+            is_window_valid =
+                is_window_valid && global_n >= global_q_pos - window_size_left;
+          }
+          if (window_size_right >= 0) {
+            is_window_valid =
+                is_window_valid && global_n <= global_q_pos + window_size_right;
+          }
+
+          const float qk_scale =
+              (D == 256) ? softmax_scale : softmax_scale_log2;
+          acc_frag.x[i] = (is_valid && is_causal_valid && is_window_valid)
+                              ? acc_frag.x[i] * qk_scale
+                              : NEG_INF;
+        }
+        store_matrix_sync(sS + tile_m * S_STRIDE + tile_n, acc_frag, S_STRIDE,
+                          mem_row_major);
+      }
     }
     __syncthreads();
 
-    for (int idx = tid; idx < valid_q_rows * valid_k_rows;
+    const uint4* v_vec = reinterpret_cast<const uint4*>(v_ptr + start_col * D);
+    uint4* sV_vec = reinterpret_cast<uint4*>(sV);
+
+#pragma unroll 2
+    for (int idx = tid; idx < (valid_k_rows * d_stride_uint4);
          idx += THREADS_PER_BLOCK) {
-        const int row = idx / valid_k_rows;
-        const int col = idx % valid_k_rows;
-        score_ptr[row * N + col] = sS[row * S_STRIDE + col];
+      const int row = idx / d_stride_uint4;
+      const int vec_col = idx % d_stride_uint4;
+
+      uint4 v_val = make_uint4(0, 0, 0, 0);
+      if (row < valid_k_rows && vec_col < d_stride_uint4) {
+        v_val = __ldg(&v_vec[row * d_stride_uint4 + vec_col]);
+      }
+      sV_vec[row * kv_stride_uint4 + vec_col] = v_val;
     }
+    __syncthreads();
+
+    const int num_tiles_m_pv = (BLOCK_M + WMMA_M - 1) / WMMA_M;
+    const int num_tiles_n_pv = (D + WMMA_N - 1) / WMMA_N;
+    const int total_tiles_pv = num_tiles_m_pv * num_tiles_n_pv;
+    const int tiles_per_warp_pv =
+        (total_tiles_pv + WARPS_PER_BLOCK - 1) / WARPS_PER_BLOCK;
+    const int softmax_sub_tile = (D == 256) ? P_SUB_TILE : p_tile_capacity;
+
+    for (int sub_start = 0; sub_start < valid_k_rows;
+         sub_start += softmax_sub_tile) {
+      const int sub_valid_k_rows =
+          min(softmax_sub_tile, valid_k_rows - sub_start);
+
+      if (tid < valid_q_rows * THREADS_PER_ROW) {
+        const int row = tid / THREADS_PER_ROW;
+        const int thread_in_row = tid % THREADS_PER_ROW;
+        const unsigned mask =
+            (valid_q_rows == BLOCK_M) ? 0xFFFFFFFFU : __activemask();
+        const int row_leader = __ffs(mask) - 1;
+
+        float* sS_row_f = sS + row * S_STRIDE + sub_start;
+        __half* sP_row_h = sP + row * p_stride;
+
+        const int vec_cols = sub_valid_k_rows >> 2;
+        const int vecs_per_thread =
+            (vec_cols + THREADS_PER_ROW - 1) / THREADS_PER_ROW;
+        const int tail_start = vec_cols << 2;
+
+        float thread_max = NEG_INF;
+        float4* sS_vec4 = reinterpret_cast<float4*>(sS_row_f);
+
+#pragma unroll 4
+        for (int j = 0; j < vecs_per_thread; ++j) {
+          int vc = thread_in_row + j * THREADS_PER_ROW;
+          if (vc < vec_cols) {
+            float4 v4 = sS_vec4[vc];
+            thread_max =
+                fmaxf(thread_max, fmaxf(fmaxf(v4.x, v4.y), fmaxf(v4.z, v4.w)));
+          }
+        }
+
+#pragma unroll 4
+        for (int c = tail_start + thread_in_row; c < sub_valid_k_rows;
+             c += THREADS_PER_ROW) {
+          thread_max = fmaxf(thread_max, sS_row_f[c]);
+        }
+
+#pragma unroll
+        for (int o = THREADS_PER_ROW / 2; o > 0; o >>= 1) {
+          thread_max = fmaxf(thread_max, __shfl_down_sync(mask, thread_max, o,
+                                                          THREADS_PER_ROW));
+        }
+
+        const float row_max =
+            __shfl_sync(mask, thread_max, row_leader, THREADS_PER_ROW);
+        const float old_max = sRowMax[row];
+        const float new_max = fmaxf(old_max, row_max);
+        const float exp_diff = (D == 256)
+                                   ? expf(fmaxf(old_max - new_max, -80.0f))
+                                   : exp2f(old_max - new_max);
+
+        float thread_sum = 0.0f;
+        __half2 half_buffer[20];
+        int vc_base = thread_in_row;
+        int h2_idx = 0;
+        int tail_col = -1;
+        __half tail_value = __float2half(0.f);
+
+#pragma unroll 4
+        for (int j = 0; j < vecs_per_thread; ++j, vc_base += THREADS_PER_ROW) {
+          if (vc_base < vec_cols) {
+            float4 v4 = sS_vec4[vc_base];
+
+            float e0 = (D == 256) ? expf(fmaxf(v4.x - new_max, -80.0f))
+                                  : exp2f(fmaxf(v4.x - new_max, EXP2_CLAMP));
+            float e1 = (D == 256) ? expf(fmaxf(v4.y - new_max, -80.0f))
+                                  : exp2f(fmaxf(v4.y - new_max, EXP2_CLAMP));
+            float e2 = (D == 256) ? expf(fmaxf(v4.z - new_max, -80.0f))
+                                  : exp2f(fmaxf(v4.z - new_max, EXP2_CLAMP));
+            float e3 = (D == 256) ? expf(fmaxf(v4.w - new_max, -80.0f))
+                                  : exp2f(fmaxf(v4.w - new_max, EXP2_CLAMP));
+
+            thread_sum += (e0 + e1) + (e2 + e3);
+
+            half_buffer[h2_idx++] = __float22half2_rn(make_float2(e0, e1));
+            half_buffer[h2_idx++] = __float22half2_rn(make_float2(e2, e3));
+          }
+        }
+
+#pragma unroll 4
+        for (int c = tail_start + thread_in_row; c < sub_valid_k_rows;
+             c += THREADS_PER_ROW) {
+          float v = sS_row_f[c];
+          float e = (D == 256) ? expf(fmaxf(v - new_max, -80.0f))
+                               : exp2f(fmaxf(v - new_max, EXP2_CLAMP));
+          thread_sum += e;
+          tail_col = c;
+          tail_value = __float2half_rn(e);
+        }
+
+#pragma unroll
+        for (int o = THREADS_PER_ROW / 2; o > 0; o >>= 1) {
+          thread_sum += __shfl_down_sync(mask, thread_sum, o, THREADS_PER_ROW);
+        }
+
+        float row_sum =
+            __shfl_sync(mask, thread_sum, row_leader, THREADS_PER_ROW);
+
+        if (thread_in_row == 0) {
+          sRowSum[row] = exp_diff * sRowSum[row] + row_sum;
+          sRowMax[row] = new_max;
+        }
+
+        h2_idx = 0;
+        vc_base = thread_in_row;
+        __half2* sP_half2 = reinterpret_cast<__half2*>(sP_row_h);
+
+#pragma unroll 4
+        for (int j = 0; j < vecs_per_thread; ++j, vc_base += THREADS_PER_ROW) {
+          if (vc_base < vec_cols) {
+            int base_offset = vc_base * 2;
+            sP_half2[base_offset] = half_buffer[h2_idx++];
+            sP_half2[base_offset + 1] = half_buffer[h2_idx++];
+          }
+        }
+
+        if (tail_col >= 0) {
+          sP_row_h[tail_col] = tail_value;
+        }
+
+#pragma unroll 4
+        for (int c = tail_start + thread_in_row; c < p_tile_capacity;
+             c += THREADS_PER_ROW) {
+          if (c >= sub_valid_k_rows) {
+            sP_row_h[c] = __float2half(0.f);
+          }
+        }
+
+        if (block_n > 0 || sub_start > 0) {
+          float* sO_row = sO + row * O_STRIDE;
+          float4* sO_vec = reinterpret_cast<float4*>(sO_row);
+          const int o_vec_count = (O_STRIDE + 3) >> 2;
+          float scale = exp_diff;
+
+#pragma unroll 4
+          for (int ov = thread_in_row; ov < o_vec_count;
+               ov += THREADS_PER_ROW) {
+            float4 v = sO_vec[ov];
+            v.x *= scale;
+            v.y *= scale;
+            v.z *= scale;
+            v.w *= scale;
+            sO_vec[ov] = v;
+          }
+        }
+      }
+      __syncthreads();
+
+      if (scalar_pv) {
+        const int total_row_cols = valid_q_rows * D;
+        for (int idx = tid; idx < total_row_cols; idx += THREADS_PER_BLOCK) {
+          const int row = idx / D;
+          const int d_col = idx - row * D;
+          const __half* sP_row_h = sP + row * p_stride;
+          float acc = 0.0f;
+
+#pragma unroll 1
+          for (int k_idx = 0; k_idx < sub_valid_k_rows; ++k_idx) {
+            const float p_val = __half2float(sP_row_h[k_idx]);
+            const float v_val =
+                __half2float(sV[(sub_start + k_idx) * KV_STRIDE + d_col]);
+            acc += p_val * v_val;
+          }
+          sO[row * O_STRIDE + d_col] += acc;
+        }
+        __syncthreads();
+        continue;
+      }
+
+      const int num_tiles_k_pv = (p_tile_capacity + WMMA_K - 1) / WMMA_K;
+
+      for (int tile_idx = 0; tile_idx < tiles_per_warp_pv; ++tile_idx) {
+        const int global_tile_idx = warp_id * tiles_per_warp_pv + tile_idx;
+        if (global_tile_idx >= total_tiles_pv) break;
+
+        const int tile_m_idx = global_tile_idx / num_tiles_n_pv;
+        const int tile_d_idx = global_tile_idx % num_tiles_n_pv;
+
+        const int tile_m = tile_m_idx * WMMA_M;
+        const int tile_d = tile_d_idx * WMMA_N;
+
+        if (tile_m >= valid_q_rows) continue;
+
+        fragment<matrix_a, WMMA_M, WMMA_N, WMMA_K, half, row_major> a_frag;
+        fragment<matrix_b, WMMA_M, WMMA_N, WMMA_K, half, row_major> b_frag;
+        fragment<accumulator, WMMA_M, WMMA_N, WMMA_K, float> acc_frag;
+
+        load_matrix_sync(acc_frag, sO + tile_m * O_STRIDE + tile_d, O_STRIDE,
+                         mem_row_major);
+
+#pragma unroll
+        for (int tile_k = 0; tile_k < num_tiles_k_pv; ++tile_k) {
+          const int k_offset = tile_k * WMMA_K;
+          if (k_offset >= sub_valid_k_rows) break;
+
+          load_matrix_sync(a_frag, sP + tile_m * p_stride + k_offset, p_stride);
+          load_matrix_sync(b_frag,
+                           sV + (sub_start + k_offset) * KV_STRIDE + tile_d,
+                           KV_STRIDE);
+          mma_sync(acc_frag, a_frag, b_frag, acc_frag);
+        }
+        store_matrix_sync(sO + tile_m * O_STRIDE + tile_d, acc_frag, O_STRIDE,
+                          mem_row_major);
+      }
+      __syncthreads();
+    }
+  }
+
+  const int total_fp16_x4 = (valid_q_rows * D) / 4;
+
+  for (int i = tid; i < total_fp16_x4; i += THREADS_PER_BLOCK) {
+    const int row = i / (D / 4);
+    const int col = (i % (D / 4)) * 4;
+
+    const float sum_clamped = fmaxf(sRowSum[row], 1e-24f);
+    const float inv_sum = 1.0f / sum_clamped;
+    const float* sO_row = sO + row * O_STRIDE;
+
+    const __half h0 = __float2half_rn(sO_row[col + 0] * inv_sum);
+    const __half h1 = __float2half_rn(sO_row[col + 1] * inv_sum);
+    const __half h2 = __float2half_rn(sO_row[col + 2] * inv_sum);
+    const __half h3 = __float2half_rn(sO_row[col + 3] * inv_sum);
+
+    asm volatile("st.global.v4.u16 [%0], {%1, %2, %3, %4};"
+                 :
+                 : "l"(out_ptr + row * D + col), "h"(__half_as_ushort(h0)),
+                   "h"(__half_as_ushort(h1)), "h"(__half_as_ushort(h2)),
+                   "h"(__half_as_ushort(h3))
+                 : "memory");
+  }
+
+  if (tid < valid_q_rows) {
+    const float sum = fmaxf(sRowSum[tid], 1e-24f);
+    softmax_lse_ptr[tid] = (D == 256) ? sRowMax[tid] + logf(sum)
+                                      : (sRowMax[tid] + log2f(sum)) * LN2;
+  }
 }
 
-template<int D, bool LOW_SMEM, bool D256_WMMA_QK>
+template <int D, bool IS_CAUSAL>
+__global__ void __launch_bounds__(KernelConfig<D>::THREADS_PER_BLOCK, 2)
+    flash_attention_qk_scores_kernel(const __half* __restrict__ Q,
+                                     const __half* __restrict__ K,
+                                     float* __restrict__ Scores, const int B,
+                                     const int H, const int H_KV, const int M,
+                                     const int N, const float softmax_scale) {
+  using Config = KernelConfig<D>;
+  constexpr int BLOCK_M = Config::BLOCK_M;
+  constexpr int BLOCK_N = Config::BLOCK_N;
+  constexpr int THREADS_PER_BLOCK = Config::THREADS_PER_BLOCK;
+  constexpr int WARPS_PER_BLOCK = Config::WARPS_PER_BLOCK;
+  constexpr int Q_STRIDE = Config::Q_STRIDE;
+  constexpr int KV_STRIDE = Config::KV_STRIDE;
+  constexpr int S_STRIDE = Config::S_STRIDE;
+  constexpr int PER_UINT4 = Config::PER_UINT4;
+  const float NEG_INF = -1e30f;
+
+  const int batch_head_id = blockIdx.z;
+  if (batch_head_id >= B * H) return;
+  const int batch_id = batch_head_id / H;
+  const int q_head_id = batch_head_id % H;
+  const int kv_group_size = H / H_KV;
+  const int kv_head_id = q_head_id / kv_group_size;
+
+  const int block_m = blockIdx.x;
+  const int block_n = blockIdx.y;
+  const int start_row = block_m * BLOCK_M;
+  const int start_col = block_n * BLOCK_N;
+  if (start_row >= M || start_col >= N) return;
+
+  const int valid_q_rows = min(BLOCK_M, M - start_row);
+  const int valid_k_rows = min(BLOCK_N, N - start_col);
+  const int causal_q_offset = max(N - M, 0);
+
+  if constexpr (IS_CAUSAL) {
+    if (start_col >= causal_q_offset + start_row + valid_q_rows) {
+      return;
+    }
+  }
+
+  const int tid = threadIdx.x;
+  const int warp_id = tid / MAX_THREADS_PER_WARP;
+  const int lane_id = tid % MAX_THREADS_PER_WARP;
+
+  const size_t q_head_linear = (size_t)batch_id * H + q_head_id;
+  const size_t kv_head_linear = (size_t)batch_id * H_KV + kv_head_id;
+  const __half* q_ptr = Q + q_head_linear * M * D + start_row * D;
+  const __half* k_ptr = K + kv_head_linear * N * D + start_col * D;
+  float* score_ptr = Scores + q_head_linear * M * N + start_row * N + start_col;
+
+  extern __shared__ char smem_raw[];
+  init_smem<Config>(smem_raw);
+  auto& smem = *reinterpret_cast<typename Config::SmemLayout*>(smem_raw);
+
+  __half* sQ = smem.q;
+  __half* sK = smem.reuse_kv.k;
+  float* sS = smem.reuse_sp.s;
+
+  const int d_stride_uint4 = (D + PER_UINT4 - 1) / PER_UINT4;
+  const int q_stride_uint4 = (Q_STRIDE + PER_UINT4 - 1) / PER_UINT4;
+  const int kv_stride_uint4 = (KV_STRIDE + PER_UINT4 - 1) / PER_UINT4;
+
+  const uint4* q_vec = reinterpret_cast<const uint4*>(q_ptr);
+  uint4* sQ_vec = reinterpret_cast<uint4*>(sQ);
+
+#pragma unroll 4
+  for (int idx = tid; idx < (valid_q_rows * d_stride_uint4);
+       idx += THREADS_PER_BLOCK) {
+    const int row = idx / d_stride_uint4;
+    const int vec_col = idx % d_stride_uint4;
+    uint4 q_val = make_uint4(0, 0, 0, 0);
+    if (row < valid_q_rows && vec_col < d_stride_uint4) {
+      q_val = __ldg(&q_vec[row * d_stride_uint4 + vec_col]);
+    }
+    sQ_vec[row * q_stride_uint4 + vec_col] = q_val;
+  }
+
+  const uint4* k_vec = reinterpret_cast<const uint4*>(k_ptr);
+  uint4* sK_vec = reinterpret_cast<uint4*>(sK);
+
+#pragma unroll 2
+  for (int idx = tid; idx < (valid_k_rows * d_stride_uint4);
+       idx += THREADS_PER_BLOCK) {
+    const int row = idx / d_stride_uint4;
+    const int vec_col = idx % d_stride_uint4;
+    uint4 k_val = make_uint4(0, 0, 0, 0);
+    if (row < valid_k_rows && vec_col < d_stride_uint4) {
+      k_val = __ldg(&k_vec[row * d_stride_uint4 + vec_col]);
+    }
+    sK_vec[row * kv_stride_uint4 + vec_col] = k_val;
+  }
+  __syncthreads();
+
+  if constexpr (D == 256) {
+    compute_qk_scores_scalar_fp32<D, false, IS_CAUSAL>(
+        sQ, sK, sS, valid_q_rows, valid_k_rows, start_row, start_col,
+        causal_q_offset, softmax_scale, -1, -1);
+  } else {
+    const int num_tiles_m_qk = (BLOCK_M + WMMA_M - 1) / WMMA_M;
+    const int num_tiles_n_qk = (BLOCK_N + WMMA_N - 1) / WMMA_N;
+    const int num_tiles_k_qk = (D + WMMA_K - 1) / WMMA_K;
+    const int total_tiles_qk = num_tiles_m_qk * num_tiles_n_qk;
+    const int tiles_per_warp_qk =
+        (total_tiles_qk + WARPS_PER_BLOCK - 1) / WARPS_PER_BLOCK;
+    const unsigned row_causal = (lane_id & 0b1) + ((lane_id >> 2) & 0b1) * 8 +
+                                ((lane_id >> 4) & 0b1) * 4;
+    const unsigned col_causal =
+        ((lane_id >> 1) & 0b1) * 2 + ((lane_id >> 3) & 0b1) * 8;
+
+    for (int tile_idx = 0; tile_idx < tiles_per_warp_qk; ++tile_idx) {
+      const int global_tile_idx = warp_id * tiles_per_warp_qk + tile_idx;
+      if (global_tile_idx >= total_tiles_qk) break;
+
+      const int tile_m_idx = global_tile_idx / num_tiles_n_qk;
+      const int tile_n_idx = global_tile_idx % num_tiles_n_qk;
+
+      const int tile_m = tile_m_idx * WMMA_M;
+      const int tile_n = tile_n_idx * WMMA_N;
+
+      if (tile_m >= valid_q_rows || tile_n >= valid_k_rows) continue;
+
+      fragment<matrix_a, WMMA_M, WMMA_N, WMMA_K, half, row_major> a_frag;
+      fragment<matrix_b, WMMA_M, WMMA_N, WMMA_K, half, col_major> b_frag;
+      fragment<accumulator, WMMA_M, WMMA_N, WMMA_K, float> acc_frag;
+      fill_fragment(acc_frag, 0.0f);
+
+#pragma unroll
+      for (int k_tile = 0; k_tile < num_tiles_k_qk; ++k_tile) {
+        const int k_offset = k_tile * WMMA_K;
+        if (k_offset >= D) break;
+
+        load_matrix_sync(a_frag, sQ + tile_m * Q_STRIDE + k_offset, Q_STRIDE);
+        load_matrix_sync(b_frag, sK + tile_n * KV_STRIDE + k_offset, KV_STRIDE);
+        mma_sync(acc_frag, a_frag, b_frag, acc_frag);
+      }
+
+      if constexpr (IS_CAUSAL) {
+#pragma unroll
+        for (int i = 0; i < acc_frag.num_elements; ++i) {
+          const unsigned col = col_causal + (i & 0b1) + ((i >> 2) & 0b1) * 4;
+          const unsigned row = row_causal + ((i >> 1) & 0b1) * 2;
+
+          const int global_m = start_row + tile_m + row;
+          const int global_n = start_col + tile_n + col;
+          const int global_q_pos = global_m + causal_q_offset;
+
+          const bool is_valid = (global_m < start_row + valid_q_rows) &&
+                                (global_n < start_col + valid_k_rows);
+
+          acc_frag.x[i] = is_valid ? ((global_n > global_q_pos)
+                                          ? NEG_INF
+                                          : acc_frag.x[i] * softmax_scale)
+                                   : NEG_INF;
+        }
+      } else {
+#pragma unroll
+        for (int i = 0; i < acc_frag.num_elements; ++i) {
+          acc_frag.x[i] *= softmax_scale;
+        }
+      }
+      store_matrix_sync(sS + tile_m * S_STRIDE + tile_n, acc_frag, S_STRIDE,
+                        mem_row_major);
+    }
+  }
+  __syncthreads();
+
+  for (int idx = tid; idx < valid_q_rows * valid_k_rows;
+       idx += THREADS_PER_BLOCK) {
+    const int row = idx / valid_k_rows;
+    const int col = idx % valid_k_rows;
+    score_ptr[row * N + col] = sS[row * S_STRIDE + col];
+  }
+}
+
+template <int D, bool LOW_SMEM, bool D256_WMMA_QK>
 void launcher_flash_attention_forward_impl(
-    const torch::Tensor& Q,
-    const torch::Tensor& K,
-    const torch::Tensor& V,
-    torch::Tensor& Out,
-    torch::Tensor& softmax_lse,
-    float softmax_scale,
-    bool is_causal,
-    bool scalar_pv,
-    int window_size_left,
-    int window_size_right,
-    cudaStream_t stream
-) {
-    using Config = KernelConfig<D, LOW_SMEM>;
+    const torch::Tensor& Q, const torch::Tensor& K, const torch::Tensor& V,
+    torch::Tensor& Out, torch::Tensor& softmax_lse, float softmax_scale,
+    bool is_causal, bool scalar_pv, int window_size_left, int window_size_right,
+    cudaStream_t stream) {
+  using Config = KernelConfig<D, LOW_SMEM>;
 
-    const int B = Q.size(0);
-    const int H = Q.size(1);
-    const int H_KV = K.size(1);
-    const int M = Q.size(2);
-    const int N = K.size(2);
+  const int B = Q.size(0);
+  const int H = Q.size(1);
+  const int H_KV = K.size(1);
+  const int M = Q.size(2);
+  const int N = K.size(2);
 
-    const int grid_x = (M + Config::BLOCK_M - 1) / Config::BLOCK_M;
-    const dim3 grid(grid_x, 1, B * H);
-    const dim3 block(Config::THREADS_PER_BLOCK);
-    const size_t smem = Config::TOTAL_SMEM;
+  const int grid_x = (M + Config::BLOCK_M - 1) / Config::BLOCK_M;
+  const dim3 grid(grid_x, 1, B * H);
+  const dim3 block(Config::THREADS_PER_BLOCK);
+  const size_t smem = Config::TOTAL_SMEM;
 
-    TORCH_CHECK(smem <= MAX_SMEM_PER_SM, "Shared memory exceeds 96KB: ", smem, " bytes");
+  TORCH_CHECK(smem <= MAX_SMEM_PER_SM, "Shared memory exceeds 96KB: ", smem,
+              " bytes");
 
-    auto kernel = is_causal ?
-        (void*)flash_attention_forward_kernel<D, LOW_SMEM, D256_WMMA_QK, true> :
-        (void*)flash_attention_forward_kernel<D, LOW_SMEM, D256_WMMA_QK, false>;
+  auto kernel =
+      is_causal
+          ? (void*)
+                flash_attention_forward_kernel<D, LOW_SMEM, D256_WMMA_QK, true>
+          : (void*)flash_attention_forward_kernel<D, LOW_SMEM, D256_WMMA_QK,
+                                                  false>;
 
-    cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem);
+  cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize,
+                       smem);
 
-    if (is_causal) {
-        flash_attention_forward_kernel<D, LOW_SMEM, D256_WMMA_QK, true>
+  if (is_causal) {
+    flash_attention_forward_kernel<D, LOW_SMEM, D256_WMMA_QK, true>
         <<<grid, block, smem, stream>>>(
             reinterpret_cast<const __half*>(Q.data_ptr()),
             reinterpret_cast<const __half*>(K.data_ptr()),
             reinterpret_cast<const __half*>(V.data_ptr()),
             reinterpret_cast<__half*>(Out.data_ptr()),
-            softmax_lse.data_ptr<float>(),
-            B, H, H_KV, M, N, softmax_scale, scalar_pv,
-            window_size_left, window_size_right
-        );
-    } else {
-        flash_attention_forward_kernel<D, LOW_SMEM, D256_WMMA_QK, false>
+            softmax_lse.data_ptr<float>(), B, H, H_KV, M, N, softmax_scale,
+            scalar_pv, window_size_left, window_size_right);
+  } else {
+    flash_attention_forward_kernel<D, LOW_SMEM, D256_WMMA_QK, false>
         <<<grid, block, smem, stream>>>(
             reinterpret_cast<const __half*>(Q.data_ptr()),
             reinterpret_cast<const __half*>(K.data_ptr()),
             reinterpret_cast<const __half*>(V.data_ptr()),
             reinterpret_cast<__half*>(Out.data_ptr()),
-            softmax_lse.data_ptr<float>(),
-            B, H, H_KV, M, N, softmax_scale, scalar_pv,
-            window_size_left, window_size_right
-        );
-    }
+            softmax_lse.data_ptr<float>(), B, H, H_KV, M, N, softmax_scale,
+            scalar_pv, window_size_left, window_size_right);
+  }
 }
 
-template<int D>
+template <int D>
 void launcher_flash_attention_forward(
-    const torch::Tensor& Q,
-    const torch::Tensor& K,
-    const torch::Tensor& V,
-    torch::Tensor& Out,
-    torch::Tensor& softmax_lse,
-    float softmax_scale,
-    bool is_causal,
-    bool scalar_pv,
-    int window_size_left,
-    int window_size_right,
-    cudaStream_t stream
-) {
-    if constexpr (D == 256) {
-        const bool use_wmma_qk =
-            env_flag_enabled_default_on("VLLM_FLASH_V100_DENSE_D256_WMMA_QK");
-        if (env_flag_enabled("VLLM_FLASH_V100_DENSE_D256_LOW_SMEM")) {
-            if (use_wmma_qk) {
-                launcher_flash_attention_forward_impl<D, true, true>(
-                    Q, K, V, Out, softmax_lse, softmax_scale, is_causal,
-                    scalar_pv, window_size_left, window_size_right, stream);
-            } else {
-                launcher_flash_attention_forward_impl<D, true, false>(
-                    Q, K, V, Out, softmax_lse, softmax_scale, is_causal,
-                    scalar_pv, window_size_left, window_size_right, stream);
-            }
-            return;
-        }
-        if (use_wmma_qk) {
-            launcher_flash_attention_forward_impl<D, false, true>(
-                Q, K, V, Out, softmax_lse, softmax_scale, is_causal,
-                scalar_pv, window_size_left, window_size_right, stream);
-            return;
-        }
+    const torch::Tensor& Q, const torch::Tensor& K, const torch::Tensor& V,
+    torch::Tensor& Out, torch::Tensor& softmax_lse, float softmax_scale,
+    bool is_causal, bool scalar_pv, int window_size_left, int window_size_right,
+    cudaStream_t stream) {
+  if constexpr (D == 256) {
+    const bool use_wmma_qk =
+        env_flag_enabled_default_on("VLLM_FLASH_V100_DENSE_D256_WMMA_QK");
+    if (env_flag_enabled("VLLM_FLASH_V100_DENSE_D256_LOW_SMEM")) {
+      if (use_wmma_qk) {
+        launcher_flash_attention_forward_impl<D, true, true>(
+            Q, K, V, Out, softmax_lse, softmax_scale, is_causal, scalar_pv,
+            window_size_left, window_size_right, stream);
+      } else {
+        launcher_flash_attention_forward_impl<D, true, false>(
+            Q, K, V, Out, softmax_lse, softmax_scale, is_causal, scalar_pv,
+            window_size_left, window_size_right, stream);
+      }
+      return;
     }
-    launcher_flash_attention_forward_impl<D, false, false>(
-        Q, K, V, Out, softmax_lse, softmax_scale, is_causal, scalar_pv,
-        window_size_left, window_size_right, stream);
+    if (use_wmma_qk) {
+      launcher_flash_attention_forward_impl<D, false, true>(
+          Q, K, V, Out, softmax_lse, softmax_scale, is_causal, scalar_pv,
+          window_size_left, window_size_right, stream);
+      return;
+    }
+  }
+  launcher_flash_attention_forward_impl<D, false, false>(
+      Q, K, V, Out, softmax_lse, softmax_scale, is_causal, scalar_pv,
+      window_size_left, window_size_right, stream);
 }
 
-template<int D>
-void launcher_flash_attention_qk_scores(
-    const torch::Tensor& Q,
-    const torch::Tensor& K,
-    torch::Tensor& Scores,
-    float softmax_scale,
-    bool is_causal,
-    cudaStream_t stream
-) {
-    using Config = KernelConfig<D>;
+template <int D>
+void launcher_flash_attention_qk_scores(const torch::Tensor& Q,
+                                        const torch::Tensor& K,
+                                        torch::Tensor& Scores,
+                                        float softmax_scale, bool is_causal,
+                                        cudaStream_t stream) {
+  using Config = KernelConfig<D>;
 
-    const int B = Q.size(0);
-    const int H = Q.size(1);
-    const int M = Q.size(2);
-    const int H_KV = K.size(1);
-    const int N = K.size(2);
+  const int B = Q.size(0);
+  const int H = Q.size(1);
+  const int M = Q.size(2);
+  const int H_KV = K.size(1);
+  const int N = K.size(2);
 
-    const int grid_x = (M + Config::BLOCK_M - 1) / Config::BLOCK_M;
-    const int grid_y = (N + Config::BLOCK_N - 1) / Config::BLOCK_N;
-    const dim3 grid(grid_x, grid_y, B * H);
-    const dim3 block(Config::THREADS_PER_BLOCK);
-    const size_t smem = Config::TOTAL_SMEM;
+  const int grid_x = (M + Config::BLOCK_M - 1) / Config::BLOCK_M;
+  const int grid_y = (N + Config::BLOCK_N - 1) / Config::BLOCK_N;
+  const dim3 grid(grid_x, grid_y, B * H);
+  const dim3 block(Config::THREADS_PER_BLOCK);
+  const size_t smem = Config::TOTAL_SMEM;
 
-    TORCH_CHECK(smem <= MAX_SMEM_PER_SM, "Shared memory exceeds 96KB: ", smem, " bytes");
+  TORCH_CHECK(smem <= MAX_SMEM_PER_SM, "Shared memory exceeds 96KB: ", smem,
+              " bytes");
 
-    auto kernel = is_causal ?
-        (void*)flash_attention_qk_scores_kernel<D, true> :
-        (void*)flash_attention_qk_scores_kernel<D, false>;
+  auto kernel = is_causal ? (void*)flash_attention_qk_scores_kernel<D, true>
+                          : (void*)flash_attention_qk_scores_kernel<D, false>;
 
-    cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem);
+  cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize,
+                       smem);
 
-    if (is_causal) {
-        flash_attention_qk_scores_kernel<D, true><<<grid, block, smem, stream>>>(
-            reinterpret_cast<const __half*>(Q.data_ptr()),
-            reinterpret_cast<const __half*>(K.data_ptr()),
-            Scores.data_ptr<float>(),
-            B, H, H_KV, M, N, softmax_scale
-        );
-    } else {
-        flash_attention_qk_scores_kernel<D, false><<<grid, block, smem, stream>>>(
-            reinterpret_cast<const __half*>(Q.data_ptr()),
-            reinterpret_cast<const __half*>(K.data_ptr()),
-            Scores.data_ptr<float>(),
-            B, H, H_KV, M, N, softmax_scale
-        );
-    }
+  if (is_causal) {
+    flash_attention_qk_scores_kernel<D, true><<<grid, block, smem, stream>>>(
+        reinterpret_cast<const __half*>(Q.data_ptr()),
+        reinterpret_cast<const __half*>(K.data_ptr()), Scores.data_ptr<float>(),
+        B, H, H_KV, M, N, softmax_scale);
+  } else {
+    flash_attention_qk_scores_kernel<D, false><<<grid, block, smem, stream>>>(
+        reinterpret_cast<const __half*>(Q.data_ptr()),
+        reinterpret_cast<const __half*>(K.data_ptr()), Scores.data_ptr<float>(),
+        B, H, H_KV, M, N, softmax_scale);
+  }
 }
 
-at::Tensor flash_attention_qk_scores(
-    const at::Tensor& q,
-    const at::Tensor& k,
-    const float softmax_scale,
-    const bool is_causal
-) {
-    TORCH_CHECK(q.dtype() == torch::kFloat16, "q must be fp16");
-    TORCH_CHECK(k.dtype() == torch::kFloat16, "k must be fp16");
-    TORCH_CHECK(q.is_cuda() && k.is_cuda(), "Tensors must be on CUDA");
-    TORCH_CHECK(q.stride(-1) == 1 && k.stride(-1) == 1,
-                "Last dim must be contiguous");
-    TORCH_CHECK(q.dim() == 4 && k.dim() == 4,
-                "q/k must have shape [B, H, T, D]");
+at::Tensor flash_attention_qk_scores(const at::Tensor& q, const at::Tensor& k,
+                                     const float softmax_scale,
+                                     const bool is_causal) {
+  TORCH_CHECK(q.dtype() == torch::kFloat16, "q must be fp16");
+  TORCH_CHECK(k.dtype() == torch::kFloat16, "k must be fp16");
+  TORCH_CHECK(q.is_cuda() && k.is_cuda(), "Tensors must be on CUDA");
+  TORCH_CHECK(q.stride(-1) == 1 && k.stride(-1) == 1,
+              "Last dim must be contiguous");
+  TORCH_CHECK(q.dim() == 4 && k.dim() == 4, "q/k must have shape [B, H, T, D]");
 
-    const int B = q.size(0);
-    const int H = q.size(1);
-    const int M = q.size(2);
-    const int D = q.size(3);
-    const int H_KV = k.size(1);
-    const int N = k.size(2);
+  const int B = q.size(0);
+  const int H = q.size(1);
+  const int M = q.size(2);
+  const int D = q.size(3);
+  const int H_KV = k.size(1);
+  const int N = k.size(2);
 
-    TORCH_CHECK(k.size(0) == B, "K batch size must match Q");
-    TORCH_CHECK(k.size(3) == D, "K head_dim must match Q");
-    TORCH_CHECK(D <= 256 && D % 8 == 0 && D % 2 == 0,
-                "D must be even, <=256, multiple of 8");
-    TORCH_CHECK(H_KV > 0, "num_kv_heads must be positive");
-    TORCH_CHECK(H % H_KV == 0,
-                "num_attention_heads must be divisible by num_kv_heads");
+  TORCH_CHECK(k.size(0) == B, "K batch size must match Q");
+  TORCH_CHECK(k.size(3) == D, "K head_dim must match Q");
+  TORCH_CHECK(D <= 256 && D % 8 == 0 && D % 2 == 0,
+              "D must be even, <=256, multiple of 8");
+  TORCH_CHECK(H_KV > 0, "num_kv_heads must be positive");
+  TORCH_CHECK(H % H_KV == 0,
+              "num_attention_heads must be divisible by num_kv_heads");
 
-    auto props = at::cuda::getCurrentDeviceProperties();
-    bool sm70 = props->major == 7 && props->minor == 0;
-    TORCH_CHECK(sm70, "Kernel supports only Volta GPUs.");
+  auto props = at::cuda::getCurrentDeviceProperties();
+  bool sm70 = props->major == 7 && props->minor == 0;
+  TORCH_CHECK(sm70, "Kernel supports only Volta GPUs.");
 
-    auto scores = torch::full({B, H, M, N}, -1e30f,
-                              torch::dtype(torch::kFloat32).device(q.device()));
-    auto stream = at::cuda::getCurrentCUDAStream().stream();
+  auto scores = torch::full({B, H, M, N}, -1e30f,
+                            torch::dtype(torch::kFloat32).device(q.device()));
+  auto stream = at::cuda::getCurrentCUDAStream().stream();
 
-    switch (D) {
-        case 16:  launcher_flash_attention_qk_scores<16>(q, k, scores, softmax_scale, is_causal, stream); break;
-        case 32:  launcher_flash_attention_qk_scores<32>(q, k, scores, softmax_scale, is_causal, stream); break;
-        case 64:  launcher_flash_attention_qk_scores<64>(q, k, scores, softmax_scale, is_causal, stream); break;
-        case 128: launcher_flash_attention_qk_scores<128>(q, k, scores, softmax_scale, is_causal, stream); break;
-        case 256: launcher_flash_attention_qk_scores<256>(q, k, scores, softmax_scale, is_causal, stream); break;
-        default: TORCH_CHECK(false, "Unsupported D: ", D);
-    }
+  switch (D) {
+    case 16:
+      launcher_flash_attention_qk_scores<16>(q, k, scores, softmax_scale,
+                                             is_causal, stream);
+      break;
+    case 32:
+      launcher_flash_attention_qk_scores<32>(q, k, scores, softmax_scale,
+                                             is_causal, stream);
+      break;
+    case 64:
+      launcher_flash_attention_qk_scores<64>(q, k, scores, softmax_scale,
+                                             is_causal, stream);
+      break;
+    case 128:
+      launcher_flash_attention_qk_scores<128>(q, k, scores, softmax_scale,
+                                              is_causal, stream);
+      break;
+    case 256:
+      launcher_flash_attention_qk_scores<256>(q, k, scores, softmax_scale,
+                                              is_causal, stream);
+      break;
+    default:
+      TORCH_CHECK(false, "Unsupported D: ", D);
+  }
 
-    return scores;
+  return scores;
 }
 
 std::vector<at::Tensor> flash_attention_forward(
-    at::Tensor& q,
-    const at::Tensor& k,
-    const at::Tensor& v,
-    std::optional<at::Tensor>& out_,
-    std::optional<at::Tensor>& alibi_slopes_,
-    const float p_dropout,
-    const float softmax_scale,
-    bool is_causal,
-    int window_size_left,
-    int window_size_right,
-    const float softcap,
-    const bool return_softmax,
-    std::optional<at::Generator> gen_
-) {
+    at::Tensor& q, const at::Tensor& k, const at::Tensor& v,
+    std::optional<at::Tensor>& out_, std::optional<at::Tensor>& alibi_slopes_,
+    const float p_dropout, const float softmax_scale, bool is_causal,
+    int window_size_left, int window_size_right, const float softcap,
+    const bool return_softmax, std::optional<at::Generator> gen_) {
+  TORCH_CHECK(!alibi_slopes_.has_value(), "alibi_slopes not supported");
+  TORCH_CHECK(p_dropout == 0.f, "dropout not supported");
+  TORCH_CHECK(window_size_left >= -1 && window_size_right >= -1,
+              "window sizes must be >= -1");
+  TORCH_CHECK(softcap == 0.f, "softcap not supported");
+  TORCH_CHECK(!return_softmax, "return_softmax not supported");
+  TORCH_CHECK(!gen_.has_value(), "Generator not supported");
 
-    TORCH_CHECK(!alibi_slopes_.has_value(), "alibi_slopes not supported");
-    TORCH_CHECK(p_dropout == 0.f, "dropout not supported");
-    TORCH_CHECK(window_size_left >= -1 && window_size_right >= -1,
-                "window sizes must be >= -1");
-    TORCH_CHECK(softcap == 0.f, "softcap not supported");
-    TORCH_CHECK(!return_softmax, "return_softmax not supported");
-    TORCH_CHECK(!gen_.has_value(), "Generator not supported");
+  TORCH_CHECK(q.dtype() == torch::kFloat16, "q must be fp16");
+  TORCH_CHECK(k.dtype() == torch::kFloat16, "k must be fp16");
+  TORCH_CHECK(v.dtype() == torch::kFloat16, "v must be fp16");
+  TORCH_CHECK(q.is_cuda() && k.is_cuda() && v.is_cuda(),
+              "Tensors must be on CUDA");
+  TORCH_CHECK(q.stride(-1) == 1 && k.stride(-1) == 1 && v.stride(-1) == 1,
+              "Last dim must be contiguous");
 
-    TORCH_CHECK(q.dtype() == torch::kFloat16, "q must be fp16");
-    TORCH_CHECK(k.dtype() == torch::kFloat16, "k must be fp16");
-    TORCH_CHECK(v.dtype() == torch::kFloat16, "v must be fp16");
-    TORCH_CHECK(q.is_cuda() && k.is_cuda() && v.is_cuda(), "Tensors must be on CUDA");
-    TORCH_CHECK(q.stride(-1) == 1 && k.stride(-1) == 1 && v.stride(-1) == 1, "Last dim must be contiguous");
+  const auto sizes = q.sizes();
+  const int B = sizes[0], H = sizes[1], M = sizes[2], D = sizes[3];
+  const int H_KV = k.size(1);
+  const int N = k.size(2);
+  TORCH_CHECK(D <= 256 && D % 8 == 0 && D % 2 == 0,
+              "D must be even, <=256, multiple of 8");
+  TORCH_CHECK(H_KV > 0, "num_kv_heads must be positive");
+  TORCH_CHECK(H % H_KV == 0,
+              "num_attention_heads must be divisible by num_kv_heads");
+  TORCH_CHECK(k.size(0) == B && v.size(0) == B, "K/V batch size must match Q");
+  TORCH_CHECK(v.size(1) == H_KV, "K/V num_heads must match");
+  TORCH_CHECK(v.size(2) == N, "K/V sequence length must match");
+  TORCH_CHECK(k.size(3) == D && v.size(3) == D, "K/V head_dim must match Q");
 
-    const auto sizes = q.sizes();
-    const int B = sizes[0], H = sizes[1], M = sizes[2], D = sizes[3];
-    const int H_KV = k.size(1);
-    const int N = k.size(2);
-    TORCH_CHECK(D <= 256 && D % 8 == 0 && D % 2 == 0, "D must be even, <=256, multiple of 8");
-    TORCH_CHECK(H_KV > 0, "num_kv_heads must be positive");
-    TORCH_CHECK(H % H_KV == 0, "num_attention_heads must be divisible by num_kv_heads");
-    TORCH_CHECK(k.size(0) == B && v.size(0) == B, "K/V batch size must match Q");
-    TORCH_CHECK(v.size(1) == H_KV, "K/V num_heads must match");
-    TORCH_CHECK(v.size(2) == N, "K/V sequence length must match");
-    TORCH_CHECK(k.size(3) == D && v.size(3) == D, "K/V head_dim must match Q");
+  at::Tensor out_fp16 = out_.has_value() ? out_.value() : torch::zeros_like(q);
+  TORCH_CHECK(out_fp16.dtype() == torch::kFloat16, "out must be fp16");
+  auto softmax_lse =
+      torch::zeros({B, H, M}, torch::dtype(torch::kFloat32).device(q.device()));
+  TORCH_CHECK(softmax_lse.dtype() == torch::kFloat32,
+              "softmax_lse must be fp32");
 
-    at::Tensor out_fp16 = out_.has_value() ? out_.value() : torch::zeros_like(q);
-    TORCH_CHECK(out_fp16.dtype() == torch::kFloat16, "out must be fp16");
-    auto softmax_lse = torch::zeros({B, H, M}, torch::dtype(torch::kFloat32).device(q.device()));
-    TORCH_CHECK(softmax_lse.dtype() == torch::kFloat32, "softmax_lse must be fp32");
+  auto stream = at::cuda::getCurrentCUDAStream().stream();
+  auto props = at::cuda::getCurrentDeviceProperties();
+  bool sm70 = props->major == 7 && props->minor == 0;
+  TORCH_CHECK(sm70, "Kernel supports only Volta GPUs.");
+  const char* scalar_pv_env = std::getenv("VLLM_FLASH_V100_PREFILL_SCALAR_PV");
+  const bool scalar_pv = scalar_pv_env != nullptr && scalar_pv_env[0] != '\0' &&
+                         scalar_pv_env[0] != '0';
 
-    auto stream = at::cuda::getCurrentCUDAStream().stream();
-    auto props  = at::cuda::getCurrentDeviceProperties();
-    bool sm70   = props->major == 7 && props->minor == 0;
-    TORCH_CHECK(sm70, "Kernel supports only Volta GPUs.");
-    const char* scalar_pv_env = std::getenv("VLLM_FLASH_V100_PREFILL_SCALAR_PV");
-    const bool scalar_pv = scalar_pv_env != nullptr && scalar_pv_env[0] != '\0' &&
-                           scalar_pv_env[0] != '0';
+  switch (D) {
+    case 16:
+      launcher_flash_attention_forward<16>(
+          q, k, v, out_fp16, softmax_lse, softmax_scale, is_causal, scalar_pv,
+          window_size_left, window_size_right, stream);
+      break;
+    case 32:
+      launcher_flash_attention_forward<32>(
+          q, k, v, out_fp16, softmax_lse, softmax_scale, is_causal, scalar_pv,
+          window_size_left, window_size_right, stream);
+      break;
+    case 64:
+      launcher_flash_attention_forward<64>(
+          q, k, v, out_fp16, softmax_lse, softmax_scale, is_causal, scalar_pv,
+          window_size_left, window_size_right, stream);
+      break;
+    case 128:
+      launcher_flash_attention_forward<128>(
+          q, k, v, out_fp16, softmax_lse, softmax_scale, is_causal, scalar_pv,
+          window_size_left, window_size_right, stream);
+      break;
+    case 256:
+      launcher_flash_attention_forward<256>(
+          q, k, v, out_fp16, softmax_lse, softmax_scale, is_causal, scalar_pv,
+          window_size_left, window_size_right, stream);
+      break;
+    default:
+      TORCH_CHECK(false, "Unsupported D: ", D);
+  }
 
-    switch (D) {
-        case 16:  launcher_flash_attention_forward<16>(q, k, v, out_fp16, softmax_lse, softmax_scale, is_causal, scalar_pv, window_size_left, window_size_right, stream); break;
-        case 32:  launcher_flash_attention_forward<32>(q, k, v, out_fp16, softmax_lse, softmax_scale, is_causal, scalar_pv, window_size_left, window_size_right, stream); break;
-        case 64:  launcher_flash_attention_forward<64>(q, k, v, out_fp16, softmax_lse, softmax_scale, is_causal, scalar_pv, window_size_left, window_size_right, stream); break;
-        case 128: launcher_flash_attention_forward<128>(q, k, v, out_fp16, softmax_lse, softmax_scale, is_causal, scalar_pv, window_size_left, window_size_right, stream); break;
-        case 256: launcher_flash_attention_forward<256>(q, k, v, out_fp16, softmax_lse, softmax_scale, is_causal, scalar_pv, window_size_left, window_size_right, stream); break;
-        default: TORCH_CHECK(false, "Unsupported D: ", D);
-    }
-
-    auto p = torch::zeros({0}, q.options());
-    auto rng_state = torch::zeros({2}, torch::dtype(torch::kInt64).device(q.device()));
-    return {out_fp16, softmax_lse, p, rng_state};
+  auto p = torch::zeros({0}, q.options());
+  auto rng_state =
+      torch::zeros({2}, torch::dtype(torch::kInt64).device(q.device()));
+  return {out_fp16, softmax_lse, p, rng_state};
 }

--- a/flash-attention-v100/kernel/fused_mha_forward_paged_full.cu
+++ b/flash-attention-v100/kernel/fused_mha_forward_paged_full.cu
@@ -16,589 +16,621 @@ using namespace nvcuda::wmma;
 #define WMMA_N 16
 #define WMMA_K 16
 
-#define MAX_THREADS_PER_WARP    32
-#define MAX_THREADS_PER_SM      2048
-#define MAX_THREAD_BLOCK_SIZE   1024
+#define MAX_THREADS_PER_WARP 32
+#define MAX_THREADS_PER_SM 2048
+#define MAX_THREAD_BLOCK_SIZE 1024
 #define MAX_THREAD_BLOCK_PER_SM 32
-#define MAX_WARPS_PER_SM        64
-#define MAX_SM_PER_GPU          80
-#define MAX_SMEM_PER_SM         98304
+#define MAX_WARPS_PER_SM 64
+#define MAX_SM_PER_GPU 80
+#define MAX_SMEM_PER_SM 98304
 
-#define WARP_ALLOC_GROUP        4
+#define WARP_ALLOC_GROUP 4
 
-#define MAX_REG_PER_UNIT        256
-#define MAX_REG_PER_THREAD      255
-#define MAX_REG_PER_BLOCK       65536
-#define MAX_REG_BUFFER          65536
+#define MAX_REG_PER_UNIT 256
+#define MAX_REG_PER_THREAD 255
+#define MAX_REG_PER_BLOCK 65536
+#define MAX_REG_BUFFER 65536
 
-#define BLOCK_M_16  16
-#define BLOCK_N_16  512
-#define WARPS_16    16
+#define BLOCK_M_16 16
+#define BLOCK_N_16 512
+#define WARPS_16 16
 
-#define BLOCK_M_32  32
-#define BLOCK_N_32  256
-#define WARPS_32    16
+#define BLOCK_M_32 32
+#define BLOCK_N_32 256
+#define WARPS_32 16
 
-#define BLOCK_M_64  64
-#define BLOCK_N_64  128
-#define WARPS_64    16
+#define BLOCK_M_64 64
+#define BLOCK_N_64 128
+#define WARPS_64 16
 
 #define BLOCK_M_128 32
 #define BLOCK_N_128 176
-#define WARPS_128   16
+#define WARPS_128 16
 
 #define BLOCK_M_256 32
 #define BLOCK_N_256 64
-#define WARPS_256   16
+#define WARPS_256 16
 
-template<int D>
+template <int D>
 struct KernelConfig {
-    static constexpr int BLOCK_M = (D == 16) ? BLOCK_M_16 : (D == 32) ? BLOCK_M_32 : (D == 64) ? BLOCK_M_64 : (D == 128) ? BLOCK_M_128 : BLOCK_M_256;
-    static constexpr int BLOCK_N = (D == 16) ? BLOCK_N_16 : (D == 32) ? BLOCK_N_32 : (D == 64) ? BLOCK_N_64 : (D == 128) ? BLOCK_N_128 : BLOCK_N_256;
-    static constexpr int WARPS_PER_BLOCK = (D == 16) ? WARPS_16 : (D == 32) ? WARPS_32 : (D == 64) ? WARPS_64 : (D == 128) ? WARPS_128 : WARPS_256;
+  static constexpr int BLOCK_M = (D == 16)    ? BLOCK_M_16
+                                 : (D == 32)  ? BLOCK_M_32
+                                 : (D == 64)  ? BLOCK_M_64
+                                 : (D == 128) ? BLOCK_M_128
+                                              : BLOCK_M_256;
+  static constexpr int BLOCK_N = (D == 16)    ? BLOCK_N_16
+                                 : (D == 32)  ? BLOCK_N_32
+                                 : (D == 64)  ? BLOCK_N_64
+                                 : (D == 128) ? BLOCK_N_128
+                                              : BLOCK_N_256;
+  static constexpr int WARPS_PER_BLOCK = (D == 16)    ? WARPS_16
+                                         : (D == 32)  ? WARPS_32
+                                         : (D == 64)  ? WARPS_64
+                                         : (D == 128) ? WARPS_128
+                                                      : WARPS_256;
 
-    static constexpr int THREADS_PER_BLOCK = WARPS_PER_BLOCK * MAX_THREADS_PER_WARP;
-    static constexpr int THREADS_PER_ROW   = THREADS_PER_BLOCK / BLOCK_M;
-    static constexpr int PAD               = (8 - (D % 32) + 32) % 32;
-    static constexpr int Q_STRIDE          = D + PAD;
-    static constexpr int KV_STRIDE         = D + PAD;
-    static constexpr int S_STRIDE          = BLOCK_N + PAD;
-    static constexpr int O_STRIDE          = D + PAD;
-    static constexpr int PER_UINT4         = 8;
+  static constexpr int THREADS_PER_BLOCK =
+      WARPS_PER_BLOCK * MAX_THREADS_PER_WARP;
+  static constexpr int THREADS_PER_ROW = THREADS_PER_BLOCK / BLOCK_M;
+  static constexpr int PAD = (8 - (D % 32) + 32) % 32;
+  static constexpr int Q_STRIDE = D + PAD;
+  static constexpr int KV_STRIDE = D + PAD;
+  static constexpr int S_STRIDE = BLOCK_N + PAD;
+  static constexpr int O_STRIDE = D + PAD;
+  static constexpr int PER_UINT4 = 8;
 
-    struct alignas(128) SmemLayout {
-        alignas(16) __half q      [BLOCK_M * Q_STRIDE];
+  struct alignas(128) SmemLayout {
+    alignas(16) __half q[BLOCK_M * Q_STRIDE];
     union {
-        alignas(16) __half k      [BLOCK_N * KV_STRIDE];
-        alignas(16) __half v      [BLOCK_N * KV_STRIDE];
+      alignas(16) __half k[BLOCK_N * KV_STRIDE];
+      alignas(16) __half v[BLOCK_N * KV_STRIDE];
     } reuse_kv;
     union {
-        alignas(16) float  s      [BLOCK_M * S_STRIDE];
-        alignas(16) __half p      [BLOCK_M * S_STRIDE];
+      alignas(16) float s[BLOCK_M * S_STRIDE];
+      alignas(16) __half p[BLOCK_M * S_STRIDE];
     } reuse_sp;
-        alignas(16) float  o      [BLOCK_M * O_STRIDE];
-        alignas(16) float  row_max[BLOCK_M];
-        alignas(16) float  row_sum[BLOCK_M];
-    };
+    alignas(16) float o[BLOCK_M * O_STRIDE];
+    alignas(16) float row_max[BLOCK_M];
+    alignas(16) float row_sum[BLOCK_M];
+  };
 
-    static constexpr size_t TOTAL_SMEM = ((sizeof(SmemLayout) + 127) & ~size_t(127));
+  static constexpr size_t TOTAL_SMEM =
+      ((sizeof(SmemLayout) + 127) & ~size_t(127));
 };
 
-template<typename Config>
+template <typename Config>
 __device__ __forceinline__ void init_smem(char* smem_raw) {
-    constexpr int N_U4 = Config::TOTAL_SMEM / 16;
-    constexpr int THREADS_PER_BLOCK = Config::THREADS_PER_BLOCK;
-    const int tid = threadIdx.x;
+  constexpr int N_U4 = Config::TOTAL_SMEM / 16;
+  constexpr int THREADS_PER_BLOCK = Config::THREADS_PER_BLOCK;
+  const int tid = threadIdx.x;
 
-    uint32_t addr = static_cast<uint32_t>(__cvta_generic_to_shared(smem_raw));
-    #pragma unroll 1
-    for (int i = tid; i < N_U4; i += THREADS_PER_BLOCK) {
-        asm volatile("st.shared.v4.u32 [%0], {%1,%1,%1,%1};"
-                     :: "r"(addr + (i << 4)), "r"(0) : "memory");
-    }
-    __syncthreads();
+  uint32_t addr = static_cast<uint32_t>(__cvta_generic_to_shared(smem_raw));
+#pragma unroll 1
+  for (int i = tid; i < N_U4; i += THREADS_PER_BLOCK) {
+    asm volatile("st.shared.v4.u32 [%0], {%1,%1,%1,%1};" ::"r"(addr + (i << 4)),
+                 "r"(0)
+                 : "memory");
+  }
+  __syncthreads();
 }
 
-template<int D, bool IS_CAUSAL>
+template <int D, bool IS_CAUSAL>
 __global__ void __launch_bounds__(KernelConfig<D>::THREADS_PER_BLOCK, 2)
-flash_attention_forward_kernel(
-    const __half* __restrict__ Q,
-    const __half* __restrict__ K,
-    const __half* __restrict__ V,
-          __half* __restrict__ Out,
-           float* __restrict__ softmax_lse,
-    const int B,
-    const int H,
-    const int M,
-    const int N,
-    const float softmax_scale
-) {
-    using Config = KernelConfig<D>;
-    constexpr int BLOCK_M           = Config::BLOCK_M;
-    constexpr int BLOCK_N           = Config::BLOCK_N;
-    constexpr int THREADS_PER_BLOCK = Config::THREADS_PER_BLOCK;
-    constexpr int THREADS_PER_ROW   = Config::THREADS_PER_ROW;
-    constexpr int WARPS_PER_BLOCK   = Config::WARPS_PER_BLOCK;
-    constexpr int Q_STRIDE          = Config::Q_STRIDE;
-    constexpr int KV_STRIDE         = Config::KV_STRIDE;
-    constexpr int S_STRIDE          = Config::S_STRIDE;
-    constexpr int O_STRIDE          = Config::O_STRIDE;
-    constexpr int PER_UINT4         = Config::PER_UINT4;
-    const float NEG_INF = -1e30f;
+    flash_attention_forward_kernel(const __half* __restrict__ Q,
+                                   const __half* __restrict__ K,
+                                   const __half* __restrict__ V,
+                                   __half* __restrict__ Out,
+                                   float* __restrict__ softmax_lse, const int B,
+                                   const int H, const int M, const int N,
+                                   const float softmax_scale) {
+  using Config = KernelConfig<D>;
+  constexpr int BLOCK_M = Config::BLOCK_M;
+  constexpr int BLOCK_N = Config::BLOCK_N;
+  constexpr int THREADS_PER_BLOCK = Config::THREADS_PER_BLOCK;
+  constexpr int THREADS_PER_ROW = Config::THREADS_PER_ROW;
+  constexpr int WARPS_PER_BLOCK = Config::WARPS_PER_BLOCK;
+  constexpr int Q_STRIDE = Config::Q_STRIDE;
+  constexpr int KV_STRIDE = Config::KV_STRIDE;
+  constexpr int S_STRIDE = Config::S_STRIDE;
+  constexpr int O_STRIDE = Config::O_STRIDE;
+  constexpr int PER_UINT4 = Config::PER_UINT4;
+  const float NEG_INF = -1e30f;
 
-    const int batch_head_id = blockIdx.z;
-    if (batch_head_id >= B * H) return;
+  const int batch_head_id = blockIdx.z;
+  if (batch_head_id >= B * H) return;
 
-    const int block_m = blockIdx.x;
-    const int start_row = block_m * BLOCK_M;
-    if (start_row >= M) return;
+  const int block_m = blockIdx.x;
+  const int start_row = block_m * BLOCK_M;
+  if (start_row >= M) return;
 
-    int num_n_tiles = (N + BLOCK_N - 1) / BLOCK_N;
-    const int valid_q_rows = min(BLOCK_M, M - start_row);
+  int num_n_tiles = (N + BLOCK_N - 1) / BLOCK_N;
+  const int valid_q_rows = min(BLOCK_M, M - start_row);
+
+  if constexpr (IS_CAUSAL) {
+    const int max_key_pos = start_row + valid_q_rows - 1;
+    if (max_key_pos < 0) {
+      num_n_tiles = 0;
+    } else {
+      num_n_tiles = min(num_n_tiles, (max_key_pos + BLOCK_N + 0) / BLOCK_N);
+    }
+  }
+
+  const int tid = threadIdx.x;
+  const int warp_id = tid / MAX_THREADS_PER_WARP;
+  const int lane_id = tid % MAX_THREADS_PER_WARP;
+
+  const __half* q_ptr = Q + (size_t)batch_head_id * M * D + start_row * D;
+  const __half* k_ptr = K + (size_t)batch_head_id * N * D;
+  const __half* v_ptr = V + (size_t)batch_head_id * N * D;
+  __half* out_ptr = Out + (size_t)batch_head_id * M * D + start_row * D;
+  float* softmax_lse_ptr = softmax_lse + (size_t)batch_head_id * M + start_row;
+
+  extern __shared__ char smem_raw[];
+  init_smem<Config>(smem_raw);
+  auto& smem = *reinterpret_cast<typename Config::SmemLayout*>(smem_raw);
+
+  __half* sQ = smem.q;
+  __half* sK = smem.reuse_kv.k;
+  __half* sV = smem.reuse_kv.v;
+  float* sS = smem.reuse_sp.s;
+  __half* sP = smem.reuse_sp.p;
+  float* sO = smem.o;
+  float* sRowMax = smem.row_max;
+  float* sRowSum = smem.row_sum;
+
+  const int d_stride_uint4 = (D + PER_UINT4 - 1) / PER_UINT4;
+  const int q_stride_uint4 = (Q_STRIDE + PER_UINT4 - 1) / PER_UINT4;
+  const int kv_stride_uint4 = (KV_STRIDE + PER_UINT4 - 1) / PER_UINT4;
+
+  if (tid < BLOCK_M) {
+    sRowMax[tid] = NEG_INF;
+  }
+
+  const uint4* q_vec = reinterpret_cast<const uint4*>(q_ptr);
+  uint4* sQ_vec = reinterpret_cast<uint4*>(sQ);
+
+#pragma unroll 4
+  for (int idx = tid; idx < (valid_q_rows * d_stride_uint4);
+       idx += THREADS_PER_BLOCK) {
+    const int row = idx / d_stride_uint4;
+    const int vec_col = idx % d_stride_uint4;
+    uint4 q_val = make_uint4(0, 0, 0, 0);
+    if (row < valid_q_rows && vec_col < d_stride_uint4) {
+      q_val = __ldg(&q_vec[row * d_stride_uint4 + vec_col]);
+    }
+    sQ_vec[row * q_stride_uint4 + vec_col] = q_val;
+  }
+  __syncthreads();
+
+  for (int block_n = 0; block_n < num_n_tiles; ++block_n) {
+    const int start_col = block_n * BLOCK_N;
+    if (start_col >= N) break;
+    const int valid_k_rows = min(BLOCK_N, N - start_col);
 
     if constexpr (IS_CAUSAL) {
-        const int max_key_pos = start_row + valid_q_rows - 1;
-        if (max_key_pos < 0) {
-            num_n_tiles = 0;
-        } else {
-            num_n_tiles = min(num_n_tiles, (max_key_pos + BLOCK_N + 0) / BLOCK_N);
-        }
+      if (start_col >= start_row + valid_q_rows) {
+        continue;
+      }
     }
 
-    const int tid = threadIdx.x;
-    const int warp_id = tid / MAX_THREADS_PER_WARP;
-    const int lane_id = tid % MAX_THREADS_PER_WARP;
+    const uint4* k_vec = reinterpret_cast<const uint4*>(k_ptr + start_col * D);
+    uint4* sK_vec = reinterpret_cast<uint4*>(sK);
 
-    const __half* q_ptr    = Q +           (size_t)batch_head_id * M * D + start_row * D;
-    const __half* k_ptr    = K +           (size_t)batch_head_id * N * D;
-    const __half* v_ptr    = V +           (size_t)batch_head_id * N * D;
-          __half* out_ptr  = Out +         (size_t)batch_head_id * M * D + start_row * D;
-    float* softmax_lse_ptr = softmax_lse + (size_t)batch_head_id * M + start_row;
+#pragma unroll 2
+    for (int idx = tid; idx < (valid_k_rows * d_stride_uint4);
+         idx += THREADS_PER_BLOCK) {
+      const int row = idx / d_stride_uint4;
+      const int vec_col = idx % d_stride_uint4;
 
-    extern __shared__ char smem_raw[];
-    init_smem<Config>(smem_raw);
-    auto& smem = *reinterpret_cast<typename Config::SmemLayout*>(smem_raw);
-
-    __half* sQ      = smem.q;
-    __half* sK      = smem.reuse_kv.k;
-    __half* sV      = smem.reuse_kv.v;
-    float*  sS      = smem.reuse_sp.s;
-    __half* sP      = smem.reuse_sp.p;
-    float*  sO      = smem.o;
-    float*  sRowMax = smem.row_max;
-    float*  sRowSum = smem.row_sum;
-
-    const int  d_stride_uint4 = (D + PER_UINT4 - 1) / PER_UINT4;
-    const int  q_stride_uint4 = (Q_STRIDE  + PER_UINT4 - 1) / PER_UINT4;
-    const int kv_stride_uint4 = (KV_STRIDE + PER_UINT4 - 1) / PER_UINT4;
-
-    if (tid < BLOCK_M) {
-        sRowMax[tid] = NEG_INF;
-    }
-
-    const uint4*      q_vec = reinterpret_cast<const uint4*>(q_ptr);
-    uint4*           sQ_vec = reinterpret_cast<uint4*>(sQ);
-
-    #pragma unroll 4
-    for (int idx = tid; idx < (valid_q_rows * d_stride_uint4); idx += THREADS_PER_BLOCK) {
-        const int row = idx / d_stride_uint4;
-        const int vec_col = idx % d_stride_uint4;
-        uint4 q_val = make_uint4(0, 0, 0, 0);
-        if (row < valid_q_rows && vec_col < d_stride_uint4) {
-            q_val = __ldg(&q_vec[row * d_stride_uint4 + vec_col]);
-        }
-        sQ_vec[row * q_stride_uint4 + vec_col] = q_val;
+      uint4 k_val = make_uint4(0, 0, 0, 0);
+      if (row < valid_k_rows && vec_col < d_stride_uint4) {
+        k_val = __ldg(&k_vec[row * d_stride_uint4 + vec_col]);
+      }
+      sK_vec[row * kv_stride_uint4 + vec_col] = k_val;
     }
     __syncthreads();
 
-    for (int block_n = 0; block_n < num_n_tiles; ++block_n) {
-        const int start_col = block_n * BLOCK_N;
-        if (start_col >= N) break;
-        const int valid_k_rows = min(BLOCK_N, N - start_col);
+    const int num_tiles_m_qk = (BLOCK_M + WMMA_M - 1) / WMMA_M;
+    const int num_tiles_n_qk = (BLOCK_N + WMMA_N - 1) / WMMA_N;
+    const int num_tiles_k_qk = (D + WMMA_K - 1) / WMMA_K;
+    const int total_tiles_qk = num_tiles_m_qk * num_tiles_n_qk;
+    const int tiles_per_warp_qk =
+        (total_tiles_qk + WARPS_PER_BLOCK - 1) / WARPS_PER_BLOCK;
+    const unsigned row_causal = (lane_id & 0b1) + ((lane_id >> 2) & 0b1) * 8 +
+                                ((lane_id >> 4) & 0b1) * 4;
+    const unsigned col_causal =
+        ((lane_id >> 1) & 0b1) * 2 + ((lane_id >> 3) & 0b1) * 8;
 
-        if constexpr (IS_CAUSAL) {
-            if (start_col >= start_row + valid_q_rows) { continue; }
+    for (int tile_idx = 0; tile_idx < tiles_per_warp_qk; ++tile_idx) {
+      const int global_tile_idx = warp_id * tiles_per_warp_qk + tile_idx;
+      if (global_tile_idx >= total_tiles_qk) break;
+
+      const int tile_m_idx = global_tile_idx / num_tiles_n_qk;
+      const int tile_n_idx = global_tile_idx % num_tiles_n_qk;
+
+      const int tile_m = tile_m_idx * WMMA_M;
+      const int tile_n = tile_n_idx * WMMA_N;
+
+      if (tile_m >= valid_q_rows || tile_n >= valid_k_rows) continue;
+
+      fragment<matrix_a, WMMA_M, WMMA_N, WMMA_K, half, row_major> a_frag;
+      fragment<matrix_b, WMMA_M, WMMA_N, WMMA_K, half, col_major> b_frag;
+      fragment<accumulator, WMMA_M, WMMA_N, WMMA_K, float> acc_frag;
+      fill_fragment(acc_frag, 0.0f);
+
+#pragma unroll
+      for (int k_tile = 0; k_tile < num_tiles_k_qk; ++k_tile) {
+        const int k_offset = k_tile * WMMA_K;
+        if (k_offset >= D) break;
+
+        load_matrix_sync(a_frag, sQ + tile_m * Q_STRIDE + k_offset, Q_STRIDE);
+        load_matrix_sync(b_frag, sK + tile_n * KV_STRIDE + k_offset, KV_STRIDE);
+        mma_sync(acc_frag, a_frag, b_frag, acc_frag);
+      }
+
+      if constexpr (IS_CAUSAL) {
+#pragma unroll
+        for (int i = 0; i < acc_frag.num_elements; ++i) {
+          const unsigned col = col_causal + (i & 0b1) + ((i >> 2) & 0b1) * 4;
+          const unsigned row = row_causal + ((i >> 1) & 0b1) * 2;
+
+          const int global_m = start_row + tile_m + row;
+          const int global_n = start_col + tile_n + col;
+
+          const bool is_valid = (global_m < start_row + valid_q_rows) &&
+                                (global_n < start_col + valid_k_rows);
+
+          acc_frag.x[i] =
+              is_valid ? ((global_n > global_m) ? NEG_INF
+                                                : acc_frag.x[i] * softmax_scale)
+                       : NEG_INF;
         }
-
-        const uint4* k_vec     = reinterpret_cast<const uint4*>(k_ptr + start_col * D);
-        uint4*       sK_vec    = reinterpret_cast<uint4*>(sK);
-
-        #pragma unroll 2
-        for (int idx = tid; idx < (valid_k_rows * d_stride_uint4); idx += THREADS_PER_BLOCK) {
-            const int row = idx / d_stride_uint4;
-            const int vec_col = idx % d_stride_uint4;
-
-            uint4 k_val = make_uint4(0, 0, 0, 0);
-            if (row < valid_k_rows && vec_col < d_stride_uint4) {
-                k_val = __ldg(&k_vec[row * d_stride_uint4 + vec_col]);
-            }
-            sK_vec[row * kv_stride_uint4 + vec_col] = k_val;
+      } else {
+#pragma unroll
+        for (int i = 0; i < acc_frag.num_elements; ++i) {
+          acc_frag.x[i] *= softmax_scale;
         }
-        __syncthreads();
-
-        const int num_tiles_m_qk    = (BLOCK_M + WMMA_M - 1) / WMMA_M;
-        const int num_tiles_n_qk    = (BLOCK_N + WMMA_N - 1) / WMMA_N;
-        const int num_tiles_k_qk    = (D + WMMA_K - 1) / WMMA_K;
-        const int total_tiles_qk    = num_tiles_m_qk * num_tiles_n_qk;
-        const int tiles_per_warp_qk = (total_tiles_qk + WARPS_PER_BLOCK - 1) / WARPS_PER_BLOCK;
-        const unsigned row_causal   = (lane_id & 0b1) + ((lane_id >> 2) & 0b1) * 8 + ((lane_id >> 4) & 0b1) * 4;
-        const unsigned col_causal   = ((lane_id >> 1) & 0b1) * 2 + ((lane_id >> 3) & 0b1) * 8;
-
-        for (int tile_idx = 0; tile_idx < tiles_per_warp_qk; ++tile_idx) {
-            const int global_tile_idx = warp_id * tiles_per_warp_qk + tile_idx;
-            if (global_tile_idx >= total_tiles_qk) break;
-
-            const int tile_m_idx = global_tile_idx / num_tiles_n_qk;
-            const int tile_n_idx = global_tile_idx % num_tiles_n_qk;
-
-            const int tile_m = tile_m_idx * WMMA_M;
-            const int tile_n = tile_n_idx * WMMA_N;
-
-            if (tile_m >= valid_q_rows || tile_n >= valid_k_rows) continue;
-
-            fragment<matrix_a, WMMA_M, WMMA_N, WMMA_K, half, row_major> a_frag;
-            fragment<matrix_b, WMMA_M, WMMA_N, WMMA_K, half, col_major> b_frag;
-            fragment<accumulator, WMMA_M, WMMA_N, WMMA_K, float> acc_frag;
-            fill_fragment(acc_frag, 0.0f);
-
-            #pragma unroll
-            for (int k_tile = 0; k_tile < num_tiles_k_qk; ++k_tile) {
-                const int k_offset = k_tile * WMMA_K;
-                if (k_offset >= D) break;
-
-                load_matrix_sync(a_frag, sQ + tile_m * Q_STRIDE + k_offset, Q_STRIDE);
-                load_matrix_sync(b_frag, sK + tile_n * KV_STRIDE + k_offset, KV_STRIDE);
-                mma_sync(acc_frag, a_frag, b_frag, acc_frag);
-            }
-
-            if constexpr (IS_CAUSAL) {
-                #pragma unroll
-                for (int i = 0; i < acc_frag.num_elements; ++i) {
-                    const unsigned col = col_causal + (i & 0b1) + ((i >> 2) & 0b1) * 4;
-                    const unsigned row = row_causal + ((i >> 1) & 0b1) * 2;
-
-                    const int global_m = start_row + tile_m + row;
-                    const int global_n = start_col + tile_n + col;
-
-                    const bool is_valid = (global_m < start_row + valid_q_rows) &&
-                                          (global_n < start_col + valid_k_rows);
-
-                    acc_frag.x[i] = is_valid
-                        ? ((global_n > global_m) ? NEG_INF : acc_frag.x[i] * softmax_scale)
-                        : NEG_INF;
-                }
-            } else {
-                #pragma unroll
-                for (int i = 0; i < acc_frag.num_elements; ++i) {
-                    acc_frag.x[i] *= softmax_scale;
-                }
-            }
-            store_matrix_sync(sS + tile_m * S_STRIDE + tile_n, acc_frag, S_STRIDE, mem_row_major);
-        }
-        __syncthreads();
-
-        if (tid < valid_q_rows * THREADS_PER_ROW) {
-            const int row = tid / THREADS_PER_ROW;
-            const int thread_in_row = tid % THREADS_PER_ROW;
-            const unsigned mask = (valid_q_rows == BLOCK_M) ? 0xFFFFFFFFU : __activemask();
-            const int row_leader = __ffs(mask) - 1;
-
-            float*  sS_row_f = sS + row * S_STRIDE;
-            __half* sP_row_h = sP + row * S_STRIDE;
-
-            const int vec_cols = valid_k_rows >> 2;
-            const int vecs_per_thread = (vec_cols + THREADS_PER_ROW - 1) / THREADS_PER_ROW;
-            const int tail_start = vec_cols << 2;
-
-            float thread_max = NEG_INF;
-            float4* sS_vec4 = reinterpret_cast<float4*>(sS_row_f);
-
-            #pragma unroll 4
-            for (int j = 0; j < vecs_per_thread; ++j) {
-                int vc = thread_in_row + j * THREADS_PER_ROW;
-                if (vc < vec_cols) {
-                    float4 v4 = sS_vec4[vc];
-                    thread_max = fmaxf(thread_max, fmaxf(fmaxf(v4.x, v4.y), fmaxf(v4.z, v4.w)));
-                }
-            }
-
-            #pragma unroll 4
-            for (int c = tail_start + thread_in_row; c < valid_k_rows; c += THREADS_PER_ROW) {
-                thread_max = fmaxf(thread_max, sS_row_f[c]);
-            }
-
-            #pragma unroll
-            for (int o = THREADS_PER_ROW / 2; o > 0; o >>= 1)
-                thread_max = fmaxf(thread_max, __shfl_down_sync(mask, thread_max, o, THREADS_PER_ROW));
-
-            const float row_max  = __shfl_sync(mask, thread_max, row_leader, THREADS_PER_ROW);
-            const float old_max  = sRowMax[row];
-            const float new_max  = fmaxf(old_max, row_max);
-            const float exp_diff = __expf(old_max - new_max);
-
-            float thread_sum = 0.0f;
-            __half2 half_buffer[20];
-            int vc_base = thread_in_row;
-            int h2_idx = 0;
-            int tail_col = -1;
-            __half tail_value = __float2half(0.f);
-
-            #pragma unroll 4
-            for (int j = 0; j < vecs_per_thread; ++j, vc_base += THREADS_PER_ROW) {
-                if (vc_base < vec_cols) {
-                    float4 v4 = sS_vec4[vc_base];
-
-                    float e0 = __expf(fmaxf(v4.x - new_max, -80.0f));
-                    float e1 = __expf(fmaxf(v4.y - new_max, -80.0f));
-                    float e2 = __expf(fmaxf(v4.z - new_max, -80.0f));
-                    float e3 = __expf(fmaxf(v4.w - new_max, -80.0f));
-
-                    thread_sum += (e0 + e1) + (e2 + e3);
-
-                    half_buffer[h2_idx++] = __float22half2_rn(make_float2(e0, e1));
-                    half_buffer[h2_idx++] = __float22half2_rn(make_float2(e2, e3));
-                }
-            }
-
-            #pragma unroll 4
-            for (int c = tail_start + thread_in_row; c < valid_k_rows; c += THREADS_PER_ROW) {
-                float v = sS_row_f[c];
-                float e = __expf(fmaxf(v - new_max, -80.0f));
-                thread_sum += e;
-                tail_col = c;
-                tail_value = __float2half_rn(e);
-            }
-
-            #pragma unroll
-            for (int o = THREADS_PER_ROW / 2; o > 0; o >>= 1)
-                thread_sum += __shfl_down_sync(mask, thread_sum, o, THREADS_PER_ROW);
-
-            float row_sum = __shfl_sync(mask, thread_sum, row_leader, THREADS_PER_ROW);
-
-            if (thread_in_row == 0) {
-                sRowSum[row] = exp_diff * sRowSum[row] + row_sum;
-                sRowMax[row] = new_max;
-            }
-
-            h2_idx = 0;
-            vc_base = thread_in_row;
-            __half2* sP_half2 = reinterpret_cast<__half2*>(sP_row_h);
-
-            #pragma unroll 4
-            for (int j = 0; j < vecs_per_thread; ++j, vc_base += THREADS_PER_ROW) {
-                if (vc_base < vec_cols) {
-                    int base_offset = vc_base * 2;
-
-                    sP_half2[base_offset]     = half_buffer[h2_idx++];
-                    sP_half2[base_offset + 1] = half_buffer[h2_idx++];
-                }
-            }
-
-            if (tail_col >= 0) {
-                sP_row_h[tail_col] = tail_value;
-            }
-
-            #pragma unroll 4
-            for (int c = tail_start + thread_in_row; c < BLOCK_N; c += THREADS_PER_ROW) {
-                if (c >= valid_k_rows) {
-                    sP_row_h[c] = __float2half(0.f);
-                }
-            }
-
-            if (block_n > 0) {
-                float*  sO_row = sO + row * O_STRIDE;
-                float4* sO_vec = reinterpret_cast<float4*>(sO_row);
-                const int o_vec_count = (O_STRIDE + 3) >> 2;
-                float scale = exp_diff;
-
-                #pragma unroll 4
-                for (int ov = thread_in_row; ov < o_vec_count; ov += THREADS_PER_ROW) {
-                    float4 v = sO_vec[ov];
-                    v.x *= scale;
-                    v.y *= scale;
-                    v.z *= scale;
-                    v.w *= scale;
-
-                    sO_vec[ov] = v;
-                }
-            }
-        }
-        __syncthreads();
-
-        const uint4* v_vec     = reinterpret_cast<const uint4*>(v_ptr + start_col * D);
-        uint4*       sV_vec    = reinterpret_cast<uint4*>(sV);
-
-        #pragma unroll 2
-        for (int idx = tid; idx < (valid_k_rows * d_stride_uint4); idx += THREADS_PER_BLOCK) {
-            const int row = idx / d_stride_uint4;
-            const int vec_col = idx % d_stride_uint4;
-
-            uint4 v_val = make_uint4(0, 0, 0, 0);
-            if (row < valid_k_rows && vec_col < d_stride_uint4) {
-                v_val = __ldg(&v_vec[row * d_stride_uint4 + vec_col]);
-            }
-            sV_vec[row * kv_stride_uint4 + vec_col] = v_val;
-        }
-        __syncthreads();
-
-        const int num_tiles_m_pv    = (BLOCK_M + WMMA_M - 1) / WMMA_M;
-        const int num_tiles_n_pv    = (D + WMMA_N - 1) / WMMA_N;
-        const int num_tiles_k_pv    = (BLOCK_N + WMMA_K - 1) / WMMA_K;
-        const int total_tiles_pv    = num_tiles_m_pv * num_tiles_n_pv;
-        const int tiles_per_warp_pv = (total_tiles_pv + WARPS_PER_BLOCK - 1) / WARPS_PER_BLOCK;
-
-        for (int tile_idx = 0; tile_idx < tiles_per_warp_pv; ++tile_idx) {
-            const int global_tile_idx = warp_id * tiles_per_warp_pv + tile_idx;
-            if (global_tile_idx >= total_tiles_pv) break;
-
-            const int tile_m_idx = global_tile_idx / num_tiles_n_pv;
-            const int tile_d_idx = global_tile_idx % num_tiles_n_pv;
-
-            const int tile_m = tile_m_idx * WMMA_M;
-            const int tile_d = tile_d_idx * WMMA_N;
-
-            if (tile_m >= valid_q_rows) continue;
-
-            fragment<matrix_a, WMMA_M, WMMA_N, WMMA_K, half, row_major> a_frag;
-            fragment<matrix_b, WMMA_M, WMMA_N, WMMA_K, half, row_major> b_frag;
-            fragment<accumulator, WMMA_M, WMMA_N, WMMA_K, float> acc_frag;
-
-            load_matrix_sync(acc_frag, sO + tile_m * O_STRIDE + tile_d, O_STRIDE, mem_row_major);
-
-            #pragma unroll
-            for (int tile_k = 0; tile_k < num_tiles_k_pv; ++tile_k) {
-                const int k_offset = tile_k * WMMA_K;
-                if (k_offset >= valid_k_rows) break;
-
-                load_matrix_sync(a_frag, sP + tile_m * S_STRIDE + k_offset, S_STRIDE);
-                load_matrix_sync(b_frag, sV + k_offset * KV_STRIDE + tile_d, KV_STRIDE);
-                mma_sync(acc_frag, a_frag, b_frag, acc_frag);
-            }
-            store_matrix_sync(sO + tile_m * O_STRIDE + tile_d, acc_frag, O_STRIDE, mem_row_major);
-        }
-        __syncthreads();
+      }
+      store_matrix_sync(sS + tile_m * S_STRIDE + tile_n, acc_frag, S_STRIDE,
+                        mem_row_major);
     }
+    __syncthreads();
 
-    const int total_fp16_x4 = (valid_q_rows * D) / 4;
+    if (tid < valid_q_rows * THREADS_PER_ROW) {
+      const int row = tid / THREADS_PER_ROW;
+      const int thread_in_row = tid % THREADS_PER_ROW;
+      const unsigned mask =
+          (valid_q_rows == BLOCK_M) ? 0xFFFFFFFFU : __activemask();
+      const int row_leader = __ffs(mask) - 1;
 
-    for (int i = tid; i < total_fp16_x4; i += THREADS_PER_BLOCK) {
-        const int row = i / (D / 4);
-        const int col = (i % (D / 4)) * 4;
+      float* sS_row_f = sS + row * S_STRIDE;
+      __half* sP_row_h = sP + row * S_STRIDE;
 
-        const float sum_clamped = fmaxf(sRowSum[row], 1e-24f);
-        const float inv_sum = 1.0f / sum_clamped;
-        const float* sO_row = sO + row * O_STRIDE;
+      const int vec_cols = valid_k_rows >> 2;
+      const int vecs_per_thread =
+          (vec_cols + THREADS_PER_ROW - 1) / THREADS_PER_ROW;
+      const int tail_start = vec_cols << 2;
 
-        const __half h0 = __float2half_rn(sO_row[col + 0] * inv_sum);
-        const __half h1 = __float2half_rn(sO_row[col + 1] * inv_sum);
-        const __half h2 = __float2half_rn(sO_row[col + 2] * inv_sum);
-        const __half h3 = __float2half_rn(sO_row[col + 3] * inv_sum);
+      float thread_max = NEG_INF;
+      float4* sS_vec4 = reinterpret_cast<float4*>(sS_row_f);
 
-        asm volatile(
-            "st.global.v4.u16 [%0], {%1, %2, %3, %4};"
-            :
-            : "l"(out_ptr + row * D + col),
-              "h"(__half_as_ushort(h0)),
-              "h"(__half_as_ushort(h1)),
-              "h"(__half_as_ushort(h2)),
-              "h"(__half_as_ushort(h3))
-            : "memory"
-        );
+#pragma unroll 4
+      for (int j = 0; j < vecs_per_thread; ++j) {
+        int vc = thread_in_row + j * THREADS_PER_ROW;
+        if (vc < vec_cols) {
+          float4 v4 = sS_vec4[vc];
+          thread_max =
+              fmaxf(thread_max, fmaxf(fmaxf(v4.x, v4.y), fmaxf(v4.z, v4.w)));
+        }
+      }
+
+#pragma unroll 4
+      for (int c = tail_start + thread_in_row; c < valid_k_rows;
+           c += THREADS_PER_ROW) {
+        thread_max = fmaxf(thread_max, sS_row_f[c]);
+      }
+
+#pragma unroll
+      for (int o = THREADS_PER_ROW / 2; o > 0; o >>= 1)
+        thread_max = fmaxf(
+            thread_max, __shfl_down_sync(mask, thread_max, o, THREADS_PER_ROW));
+
+      const float row_max =
+          __shfl_sync(mask, thread_max, row_leader, THREADS_PER_ROW);
+      const float old_max = sRowMax[row];
+      const float new_max = fmaxf(old_max, row_max);
+      const float exp_diff = __expf(old_max - new_max);
+
+      float thread_sum = 0.0f;
+      __half2 half_buffer[20];
+      int vc_base = thread_in_row;
+      int h2_idx = 0;
+      int tail_col = -1;
+      __half tail_value = __float2half(0.f);
+
+#pragma unroll 4
+      for (int j = 0; j < vecs_per_thread; ++j, vc_base += THREADS_PER_ROW) {
+        if (vc_base < vec_cols) {
+          float4 v4 = sS_vec4[vc_base];
+
+          float e0 = __expf(fmaxf(v4.x - new_max, -80.0f));
+          float e1 = __expf(fmaxf(v4.y - new_max, -80.0f));
+          float e2 = __expf(fmaxf(v4.z - new_max, -80.0f));
+          float e3 = __expf(fmaxf(v4.w - new_max, -80.0f));
+
+          thread_sum += (e0 + e1) + (e2 + e3);
+
+          half_buffer[h2_idx++] = __float22half2_rn(make_float2(e0, e1));
+          half_buffer[h2_idx++] = __float22half2_rn(make_float2(e2, e3));
+        }
+      }
+
+#pragma unroll 4
+      for (int c = tail_start + thread_in_row; c < valid_k_rows;
+           c += THREADS_PER_ROW) {
+        float v = sS_row_f[c];
+        float e = __expf(fmaxf(v - new_max, -80.0f));
+        thread_sum += e;
+        tail_col = c;
+        tail_value = __float2half_rn(e);
+      }
+
+#pragma unroll
+      for (int o = THREADS_PER_ROW / 2; o > 0; o >>= 1)
+        thread_sum += __shfl_down_sync(mask, thread_sum, o, THREADS_PER_ROW);
+
+      float row_sum =
+          __shfl_sync(mask, thread_sum, row_leader, THREADS_PER_ROW);
+
+      if (thread_in_row == 0) {
+        sRowSum[row] = exp_diff * sRowSum[row] + row_sum;
+        sRowMax[row] = new_max;
+      }
+
+      h2_idx = 0;
+      vc_base = thread_in_row;
+      __half2* sP_half2 = reinterpret_cast<__half2*>(sP_row_h);
+
+#pragma unroll 4
+      for (int j = 0; j < vecs_per_thread; ++j, vc_base += THREADS_PER_ROW) {
+        if (vc_base < vec_cols) {
+          int base_offset = vc_base * 2;
+
+          sP_half2[base_offset] = half_buffer[h2_idx++];
+          sP_half2[base_offset + 1] = half_buffer[h2_idx++];
+        }
+      }
+
+      if (tail_col >= 0) {
+        sP_row_h[tail_col] = tail_value;
+      }
+
+#pragma unroll 4
+      for (int c = tail_start + thread_in_row; c < BLOCK_N;
+           c += THREADS_PER_ROW) {
+        if (c >= valid_k_rows) {
+          sP_row_h[c] = __float2half(0.f);
+        }
+      }
+
+      if (block_n > 0) {
+        float* sO_row = sO + row * O_STRIDE;
+        float4* sO_vec = reinterpret_cast<float4*>(sO_row);
+        const int o_vec_count = (O_STRIDE + 3) >> 2;
+        float scale = exp_diff;
+
+#pragma unroll 4
+        for (int ov = thread_in_row; ov < o_vec_count; ov += THREADS_PER_ROW) {
+          float4 v = sO_vec[ov];
+          v.x *= scale;
+          v.y *= scale;
+          v.z *= scale;
+          v.w *= scale;
+
+          sO_vec[ov] = v;
+        }
+      }
     }
+    __syncthreads();
 
-    if (tid < valid_q_rows) {
-        const float sum = fmaxf(sRowSum[tid], 1e-24f);
-        softmax_lse_ptr[tid] = sRowMax[tid] + logf(sum);
+    const uint4* v_vec = reinterpret_cast<const uint4*>(v_ptr + start_col * D);
+    uint4* sV_vec = reinterpret_cast<uint4*>(sV);
+
+#pragma unroll 2
+    for (int idx = tid; idx < (valid_k_rows * d_stride_uint4);
+         idx += THREADS_PER_BLOCK) {
+      const int row = idx / d_stride_uint4;
+      const int vec_col = idx % d_stride_uint4;
+
+      uint4 v_val = make_uint4(0, 0, 0, 0);
+      if (row < valid_k_rows && vec_col < d_stride_uint4) {
+        v_val = __ldg(&v_vec[row * d_stride_uint4 + vec_col]);
+      }
+      sV_vec[row * kv_stride_uint4 + vec_col] = v_val;
     }
+    __syncthreads();
+
+    const int num_tiles_m_pv = (BLOCK_M + WMMA_M - 1) / WMMA_M;
+    const int num_tiles_n_pv = (D + WMMA_N - 1) / WMMA_N;
+    const int num_tiles_k_pv = (BLOCK_N + WMMA_K - 1) / WMMA_K;
+    const int total_tiles_pv = num_tiles_m_pv * num_tiles_n_pv;
+    const int tiles_per_warp_pv =
+        (total_tiles_pv + WARPS_PER_BLOCK - 1) / WARPS_PER_BLOCK;
+
+    for (int tile_idx = 0; tile_idx < tiles_per_warp_pv; ++tile_idx) {
+      const int global_tile_idx = warp_id * tiles_per_warp_pv + tile_idx;
+      if (global_tile_idx >= total_tiles_pv) break;
+
+      const int tile_m_idx = global_tile_idx / num_tiles_n_pv;
+      const int tile_d_idx = global_tile_idx % num_tiles_n_pv;
+
+      const int tile_m = tile_m_idx * WMMA_M;
+      const int tile_d = tile_d_idx * WMMA_N;
+
+      if (tile_m >= valid_q_rows) continue;
+
+      fragment<matrix_a, WMMA_M, WMMA_N, WMMA_K, half, row_major> a_frag;
+      fragment<matrix_b, WMMA_M, WMMA_N, WMMA_K, half, row_major> b_frag;
+      fragment<accumulator, WMMA_M, WMMA_N, WMMA_K, float> acc_frag;
+
+      load_matrix_sync(acc_frag, sO + tile_m * O_STRIDE + tile_d, O_STRIDE,
+                       mem_row_major);
+
+#pragma unroll
+      for (int tile_k = 0; tile_k < num_tiles_k_pv; ++tile_k) {
+        const int k_offset = tile_k * WMMA_K;
+        if (k_offset >= valid_k_rows) break;
+
+        load_matrix_sync(a_frag, sP + tile_m * S_STRIDE + k_offset, S_STRIDE);
+        load_matrix_sync(b_frag, sV + k_offset * KV_STRIDE + tile_d, KV_STRIDE);
+        mma_sync(acc_frag, a_frag, b_frag, acc_frag);
+      }
+      store_matrix_sync(sO + tile_m * O_STRIDE + tile_d, acc_frag, O_STRIDE,
+                        mem_row_major);
+    }
+    __syncthreads();
+  }
+
+  const int total_fp16_x4 = (valid_q_rows * D) / 4;
+
+  for (int i = tid; i < total_fp16_x4; i += THREADS_PER_BLOCK) {
+    const int row = i / (D / 4);
+    const int col = (i % (D / 4)) * 4;
+
+    const float sum_clamped = fmaxf(sRowSum[row], 1e-24f);
+    const float inv_sum = 1.0f / sum_clamped;
+    const float* sO_row = sO + row * O_STRIDE;
+
+    const __half h0 = __float2half_rn(sO_row[col + 0] * inv_sum);
+    const __half h1 = __float2half_rn(sO_row[col + 1] * inv_sum);
+    const __half h2 = __float2half_rn(sO_row[col + 2] * inv_sum);
+    const __half h3 = __float2half_rn(sO_row[col + 3] * inv_sum);
+
+    asm volatile("st.global.v4.u16 [%0], {%1, %2, %3, %4};"
+                 :
+                 : "l"(out_ptr + row * D + col), "h"(__half_as_ushort(h0)),
+                   "h"(__half_as_ushort(h1)), "h"(__half_as_ushort(h2)),
+                   "h"(__half_as_ushort(h3))
+                 : "memory");
+  }
+
+  if (tid < valid_q_rows) {
+    const float sum = fmaxf(sRowSum[tid], 1e-24f);
+    softmax_lse_ptr[tid] = sRowMax[tid] + logf(sum);
+  }
 }
 
-template<int D>
+template <int D>
 void launcher_flash_attention_forward(
-    const torch::Tensor& Q,
-    const torch::Tensor& K,
-    const torch::Tensor& V,
-    torch::Tensor& Out,
-    torch::Tensor& softmax_lse,
-    float softmax_scale,
-    bool is_causal,
-    cudaStream_t stream
-) {
-    using Config = KernelConfig<D>;
+    const torch::Tensor& Q, const torch::Tensor& K, const torch::Tensor& V,
+    torch::Tensor& Out, torch::Tensor& softmax_lse, float softmax_scale,
+    bool is_causal, cudaStream_t stream) {
+  using Config = KernelConfig<D>;
 
-    const int B = Q.size(0);
-    const int H = Q.size(1);
-    const int M = Q.size(2);
-    const int N = K.size(2);
+  const int B = Q.size(0);
+  const int H = Q.size(1);
+  const int M = Q.size(2);
+  const int N = K.size(2);
 
-    const int grid_x = (M + Config::BLOCK_M - 1) / Config::BLOCK_M;
-    const dim3 grid(grid_x, 1, B * H);
-    const dim3 block(Config::THREADS_PER_BLOCK);
-    const size_t smem = Config::TOTAL_SMEM;
+  const int grid_x = (M + Config::BLOCK_M - 1) / Config::BLOCK_M;
+  const dim3 grid(grid_x, 1, B * H);
+  const dim3 block(Config::THREADS_PER_BLOCK);
+  const size_t smem = Config::TOTAL_SMEM;
 
-    TORCH_CHECK(smem <= MAX_SMEM_PER_SM, "Shared memory exceeds 96KB: ", smem, " bytes");
+  TORCH_CHECK(smem <= MAX_SMEM_PER_SM, "Shared memory exceeds 96KB: ", smem,
+              " bytes");
 
-    auto kernel = is_causal ?
-        (void*)flash_attention_forward_kernel<D, true> :
-        (void*)flash_attention_forward_kernel<D, false>;
+  auto kernel = is_causal ? (void*)flash_attention_forward_kernel<D, true>
+                          : (void*)flash_attention_forward_kernel<D, false>;
 
-    cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem);
+  cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize,
+                       smem);
 
-    if (is_causal) {
-        flash_attention_forward_kernel<D, true><<<grid, block, smem, stream>>>(
-            reinterpret_cast<const __half*>(Q.data_ptr()),
-            reinterpret_cast<const __half*>(K.data_ptr()),
-            reinterpret_cast<const __half*>(V.data_ptr()),
-            reinterpret_cast<__half*>(Out.data_ptr()),
-            softmax_lse.data_ptr<float>(),
-            B, H, M, N, softmax_scale
-        );
-    } else {
-        flash_attention_forward_kernel<D, false><<<grid, block, smem, stream>>>(
-            reinterpret_cast<const __half*>(Q.data_ptr()),
-            reinterpret_cast<const __half*>(K.data_ptr()),
-            reinterpret_cast<const __half*>(V.data_ptr()),
-            reinterpret_cast<__half*>(Out.data_ptr()),
-            softmax_lse.data_ptr<float>(),
-            B, H, M, N, softmax_scale
-        );
-    }
+  if (is_causal) {
+    flash_attention_forward_kernel<D, true><<<grid, block, smem, stream>>>(
+        reinterpret_cast<const __half*>(Q.data_ptr()),
+        reinterpret_cast<const __half*>(K.data_ptr()),
+        reinterpret_cast<const __half*>(V.data_ptr()),
+        reinterpret_cast<__half*>(Out.data_ptr()),
+        softmax_lse.data_ptr<float>(), B, H, M, N, softmax_scale);
+  } else {
+    flash_attention_forward_kernel<D, false><<<grid, block, smem, stream>>>(
+        reinterpret_cast<const __half*>(Q.data_ptr()),
+        reinterpret_cast<const __half*>(K.data_ptr()),
+        reinterpret_cast<const __half*>(V.data_ptr()),
+        reinterpret_cast<__half*>(Out.data_ptr()),
+        softmax_lse.data_ptr<float>(), B, H, M, N, softmax_scale);
+  }
 }
 
 std::vector<at::Tensor> flash_attention_forward(
-    at::Tensor& q,
-    const at::Tensor& k,
-    const at::Tensor& v,
-    std::optional<at::Tensor>& out_,
-    std::optional<at::Tensor>& alibi_slopes_,
-    const float p_dropout,
-    const float softmax_scale,
-    bool is_causal,
-    int window_size_left,
-    int window_size_right,
-    const float softcap,
-    const bool return_softmax,
-    std::optional<at::Generator> gen_
-) {
+    at::Tensor& q, const at::Tensor& k, const at::Tensor& v,
+    std::optional<at::Tensor>& out_, std::optional<at::Tensor>& alibi_slopes_,
+    const float p_dropout, const float softmax_scale, bool is_causal,
+    int window_size_left, int window_size_right, const float softcap,
+    const bool return_softmax, std::optional<at::Generator> gen_) {
+  TORCH_CHECK(!alibi_slopes_.has_value(), "alibi_slopes not supported");
+  TORCH_CHECK(p_dropout == 0.f, "dropout not supported");
+  TORCH_CHECK(window_size_left == -1, "window_size_left not supported");
+  TORCH_CHECK(window_size_right == -1 || (is_causal && window_size_right == 0),
+              "window not supported");
+  TORCH_CHECK(softcap == 0.f, "softcap not supported");
+  TORCH_CHECK(!return_softmax, "return_softmax not supported");
+  TORCH_CHECK(!gen_.has_value(), "Generator not supported");
 
-    TORCH_CHECK(!alibi_slopes_.has_value(), "alibi_slopes not supported");
-    TORCH_CHECK(p_dropout == 0.f, "dropout not supported");
-    TORCH_CHECK(window_size_left == -1, "window_size_left not supported");
-    TORCH_CHECK(window_size_right == -1 || (is_causal && window_size_right == 0), "window not supported");
-    TORCH_CHECK(softcap == 0.f, "softcap not supported");
-    TORCH_CHECK(!return_softmax, "return_softmax not supported");
-    TORCH_CHECK(!gen_.has_value(), "Generator not supported");
+  TORCH_CHECK(q.dtype() == torch::kFloat16, "q must be fp16");
+  TORCH_CHECK(k.dtype() == torch::kFloat16, "k must be fp16");
+  TORCH_CHECK(v.dtype() == torch::kFloat16, "v must be fp16");
+  TORCH_CHECK(q.is_cuda() && k.is_cuda() && v.is_cuda(),
+              "Tensors must be on CUDA");
+  TORCH_CHECK(q.stride(-1) == 1 && k.stride(-1) == 1 && v.stride(-1) == 1,
+              "Last dim must be contiguous");
 
-    TORCH_CHECK(q.dtype() == torch::kFloat16, "q must be fp16");
-    TORCH_CHECK(k.dtype() == torch::kFloat16, "k must be fp16");
-    TORCH_CHECK(v.dtype() == torch::kFloat16, "v must be fp16");
-    TORCH_CHECK(q.is_cuda() && k.is_cuda() && v.is_cuda(), "Tensors must be on CUDA");
-    TORCH_CHECK(q.stride(-1) == 1 && k.stride(-1) == 1 && v.stride(-1) == 1, "Last dim must be contiguous");
+  const auto sizes = q.sizes();
+  const int B = sizes[0], H = sizes[1], M = sizes[2], D = sizes[3];
+  const int N = k.size(2);
+  TORCH_CHECK(D <= 256 && D % 8 == 0 && D % 2 == 0,
+              "D must be even, <=256, multiple of 8");
 
-    const auto sizes = q.sizes();
-    const int B = sizes[0], H = sizes[1], M = sizes[2], D = sizes[3];
-    const int N = k.size(2);
-    TORCH_CHECK(D <= 256 && D % 8 == 0 && D % 2 == 0, "D must be even, <=256, multiple of 8");
+  at::Tensor out_fp16 = out_.has_value() ? out_.value() : torch::zeros_like(q);
+  TORCH_CHECK(out_fp16.dtype() == torch::kFloat16, "out must be fp16");
+  auto softmax_lse =
+      torch::zeros({B, H, M}, torch::dtype(torch::kFloat32).device(q.device()));
+  TORCH_CHECK(softmax_lse.dtype() == torch::kFloat32,
+              "softmax_lse must be fp32");
 
-    at::Tensor out_fp16 = out_.has_value() ? out_.value() : torch::zeros_like(q);
-    TORCH_CHECK(out_fp16.dtype() == torch::kFloat16, "out must be fp16");
-    auto softmax_lse = torch::zeros({B, H, M}, torch::dtype(torch::kFloat32).device(q.device()));
-    TORCH_CHECK(softmax_lse.dtype() == torch::kFloat32, "softmax_lse must be fp32");
+  auto stream = at::cuda::getCurrentCUDAStream().stream();
+  auto props = at::cuda::getCurrentDeviceProperties();
+  bool sm70 = props->major == 7 && props->minor == 0;
+  TORCH_CHECK(sm70, "Kernel supports only Volta GPUs.");
 
-    auto stream = at::cuda::getCurrentCUDAStream().stream();
-    auto props  = at::cuda::getCurrentDeviceProperties();
-    bool sm70   = props->major == 7 && props->minor == 0;
-    TORCH_CHECK(sm70, "Kernel supports only Volta GPUs.");
+  switch (D) {
+    case 16:
+      launcher_flash_attention_forward<16>(q, k, v, out_fp16, softmax_lse,
+                                           softmax_scale, is_causal, stream);
+      break;
+    case 32:
+      launcher_flash_attention_forward<32>(q, k, v, out_fp16, softmax_lse,
+                                           softmax_scale, is_causal, stream);
+      break;
+    case 64:
+      launcher_flash_attention_forward<64>(q, k, v, out_fp16, softmax_lse,
+                                           softmax_scale, is_causal, stream);
+      break;
+    case 128:
+      launcher_flash_attention_forward<128>(q, k, v, out_fp16, softmax_lse,
+                                            softmax_scale, is_causal, stream);
+      break;
+    case 256:
+      launcher_flash_attention_forward<256>(q, k, v, out_fp16, softmax_lse,
+                                            softmax_scale, is_causal, stream);
+      break;
+    default:
+      TORCH_CHECK(false, "Unsupported D: ", D);
+  }
 
-    switch (D) {
-        case 16:  launcher_flash_attention_forward<16>(q, k, v, out_fp16, softmax_lse, softmax_scale, is_causal, stream); break;
-        case 32:  launcher_flash_attention_forward<32>(q, k, v, out_fp16, softmax_lse, softmax_scale, is_causal, stream); break;
-        case 64:  launcher_flash_attention_forward<64>(q, k, v, out_fp16, softmax_lse, softmax_scale, is_causal, stream); break;
-        case 128: launcher_flash_attention_forward<128>(q, k, v, out_fp16, softmax_lse, softmax_scale, is_causal, stream); break;
-        case 256: launcher_flash_attention_forward<256>(q, k, v, out_fp16, softmax_lse, softmax_scale, is_causal, stream); break;
-        default: TORCH_CHECK(false, "Unsupported D: ", D);
-    }
-
-    auto p = torch::zeros({0}, q.options());
-    auto rng_state = torch::zeros({2}, torch::dtype(torch::kInt64).device(q.device()));
-    return {out_fp16, softmax_lse, p, rng_state};
+  auto p = torch::zeros({0}, q.options());
+  auto rng_state =
+      torch::zeros({2}, torch::dtype(torch::kInt64).device(q.device()));
+  return {out_fp16, softmax_lse, p, rng_state};
 }

--- a/flash-attention-v100/kernel/paged_kv_utils.cuh
+++ b/flash-attention-v100/kernel/paged_kv_utils.cuh
@@ -4,78 +4,58 @@
 #include <cuda_runtime.h>
 #include <cuda_fp16.h>
 
-__device__ __forceinline__
-size_t resolve_paged_kv_offset(
-    const int token_idx,
-    const int page_block_size,
-    const int* __restrict__ block_table,
-    const int kv_head_offset,
-    const int num_kv_heads,
-    const int head_dim
-) {
+__device__ __forceinline__ size_t resolve_paged_kv_offset(
+    const int token_idx, const int page_block_size,
+    const int* __restrict__ block_table, const int kv_head_offset,
+    const int num_kv_heads, const int head_dim) {
+  const int virtual_page_idx = token_idx / page_block_size;
+  const int page_offset = token_idx % page_block_size;
 
-    const int virtual_page_idx = token_idx / page_block_size;
-    const int page_offset = token_idx % page_block_size;
+  const int physical_block_idx = block_table[virtual_page_idx];
 
-    const int physical_block_idx = block_table[virtual_page_idx];
+  const size_t physical_offset =
+      (size_t)physical_block_idx * page_block_size * num_kv_heads * head_dim +
+      (size_t)page_offset * num_kv_heads * head_dim + (size_t)kv_head_offset;
 
-    const size_t physical_offset =
-        (size_t)physical_block_idx * page_block_size * num_kv_heads * head_dim
-        + (size_t)page_offset * num_kv_heads * head_dim
-        + (size_t)kv_head_offset;
-
-    return physical_offset;
+  return physical_offset;
 }
 
-template<int D>
-__device__ __forceinline__
-void load_kv_tile_paged(
-    const __half* __restrict__ kv_cache,
-    const int* __restrict__ block_table,
-    const int start_token_idx,
-    const int num_tokens,
-    const int kv_head_idx,
-    const int num_kv_heads,
-    const int head_dim,
-    const int page_block_size,
-    __half* smem_dst,
-    const int smem_stride,
-    const int tid,
-    const int num_threads
-) {
-    constexpr int PER_UINT4 = 8;
-    const int d_stride_uint4 = (D + PER_UINT4 - 1) / PER_UINT4;
-    const int smem_stride_uint4 = (smem_stride + PER_UINT4 - 1) / PER_UINT4;
+template <int D>
+__device__ __forceinline__ void load_kv_tile_paged(
+    const __half* __restrict__ kv_cache, const int* __restrict__ block_table,
+    const int start_token_idx, const int num_tokens, const int kv_head_idx,
+    const int num_kv_heads, const int head_dim, const int page_block_size,
+    __half* smem_dst, const int smem_stride, const int tid,
+    const int num_threads) {
+  constexpr int PER_UINT4 = 8;
+  const int d_stride_uint4 = (D + PER_UINT4 - 1) / PER_UINT4;
+  const int smem_stride_uint4 = (smem_stride + PER_UINT4 - 1) / PER_UINT4;
 
-    const int kv_head_offset = kv_head_idx * head_dim;
+  const int kv_head_offset = kv_head_idx * head_dim;
 
-    uint4* smem_vec = reinterpret_cast<uint4*>(smem_dst);
+  uint4* smem_vec = reinterpret_cast<uint4*>(smem_dst);
 
-    #pragma unroll 2
-    for (int idx = tid; idx < (num_tokens * d_stride_uint4); idx += num_threads) {
-        const int token_offset = idx / d_stride_uint4;
-        const int vec_col = idx % d_stride_uint4;
+#pragma unroll 2
+  for (int idx = tid; idx < (num_tokens * d_stride_uint4); idx += num_threads) {
+    const int token_offset = idx / d_stride_uint4;
+    const int vec_col = idx % d_stride_uint4;
 
-        uint4 kv_val = make_uint4(0, 0, 0, 0);
+    uint4 kv_val = make_uint4(0, 0, 0, 0);
 
-        if (token_offset < num_tokens && vec_col < d_stride_uint4) {
-            const int global_token_idx = start_token_idx + token_offset;
+    if (token_offset < num_tokens && vec_col < d_stride_uint4) {
+      const int global_token_idx = start_token_idx + token_offset;
 
-            const size_t base_offset = resolve_paged_kv_offset(
-                global_token_idx,
-                page_block_size,
-                block_table,
-                kv_head_offset,
-                num_kv_heads,
-                head_dim
-            );
+      const size_t base_offset = resolve_paged_kv_offset(
+          global_token_idx, page_block_size, block_table, kv_head_offset,
+          num_kv_heads, head_dim);
 
-            const uint4* kv_vec = reinterpret_cast<const uint4*>(kv_cache + base_offset);
-            kv_val = __ldg(&kv_vec[vec_col]);
-        }
-
-        smem_vec[token_offset * smem_stride_uint4 + vec_col] = kv_val;
+      const uint4* kv_vec =
+          reinterpret_cast<const uint4*>(kv_cache + base_offset);
+      kv_val = __ldg(&kv_vec[vec_col]);
     }
+
+    smem_vec[token_offset * smem_stride_uint4 + vec_col] = kv_val;
+  }
 }
 
 #endif

--- a/flash-attention-v100/kernel/paged_to_contiguous.cu
+++ b/flash-attention-v100/kernel/paged_to_contiguous.cu
@@ -4,215 +4,178 @@
 #include <torch/extension.h>
 
 __global__ void paged_to_contiguous_stride_aware_kernel(
-    const __half* __restrict__ paged_cache,
-    const int* __restrict__ block_table,
-    const int* __restrict__ seq_lens,
-          __half* __restrict__ contiguous,
-    const int64_t block_stride,
-    const int64_t page_stride,
-    const int64_t head_stride,
-    const int block_size,
-    const int num_heads,
-    const int head_dim,
-    const int max_num_blocks
-) {
+    const __half* __restrict__ paged_cache, const int* __restrict__ block_table,
+    const int* __restrict__ seq_lens, __half* __restrict__ contiguous,
+    const int64_t block_stride, const int64_t page_stride,
+    const int64_t head_stride, const int block_size, const int num_heads,
+    const int head_dim, const int max_num_blocks) {
+  const int batch_idx = blockIdx.x;
+  const int seq_len = seq_lens[batch_idx];
+  if (seq_len == 0) return;
 
-    const int batch_idx = blockIdx.x;
-    const int seq_len = seq_lens[batch_idx];
-    if (seq_len == 0) return;
+  int output_offset = 0;
+  for (int i = 0; i < batch_idx; ++i) {
+    output_offset += seq_lens[i];
+  }
 
-    int output_offset = 0;
-    for (int i = 0; i < batch_idx; ++i) {
-        output_offset += seq_lens[i];
+  const int* block_table_seq = block_table + batch_idx * max_num_blocks;
+
+  const int tid = threadIdx.x;
+  const int num_threads = blockDim.x;
+  const int elements_per_token = num_heads * head_dim;
+
+  for (int token_idx = 0; token_idx < seq_len; ++token_idx) {
+    const int virtual_block_idx = token_idx / block_size;
+    const int block_offset = token_idx % block_size;
+    const int physical_block_idx = block_table_seq[virtual_block_idx];
+
+    const __half* token_base = paged_cache + physical_block_idx * block_stride +
+                               block_offset * page_stride;
+
+    __half* output_token =
+        contiguous + (output_offset + token_idx) * elements_per_token;
+
+    for (int head_idx = 0; head_idx < num_heads; ++head_idx) {
+      const __half* head_src = token_base + head_idx * head_stride;
+      __half* head_dst = output_token + head_idx * head_dim;
+
+      for (int elem_idx = tid; elem_idx < head_dim; elem_idx += num_threads) {
+        head_dst[elem_idx] = head_src[elem_idx];
+      }
     }
-
-    const int* block_table_seq = block_table + batch_idx * max_num_blocks;
-
-    const int tid = threadIdx.x;
-    const int num_threads = blockDim.x;
-    const int elements_per_token = num_heads * head_dim;
-
-    for (int token_idx = 0; token_idx < seq_len; ++token_idx) {
-
-        const int virtual_block_idx = token_idx / block_size;
-        const int block_offset = token_idx % block_size;
-        const int physical_block_idx = block_table_seq[virtual_block_idx];
-
-        const __half* token_base = paged_cache
-            + physical_block_idx * block_stride
-            + block_offset * page_stride;
-
-        __half* output_token = contiguous + (output_offset + token_idx) * elements_per_token;
-
-        for (int head_idx = 0; head_idx < num_heads; ++head_idx) {
-            const __half* head_src = token_base + head_idx * head_stride;
-            __half* head_dst = output_token + head_idx * head_dim;
-
-            for (int elem_idx = tid; elem_idx < head_dim; elem_idx += num_threads) {
-                head_dst[elem_idx] = head_src[elem_idx];
-            }
-        }
-    }
+  }
 }
 
 __global__ void paged_kv_to_contiguous_stride_aware_kernel(
     const __half* __restrict__ paged_key_cache,
     const __half* __restrict__ paged_value_cache,
-    const int* __restrict__ block_table,
-    const int* __restrict__ seq_lens,
-          __half* __restrict__ contiguous_key,
-          __half* __restrict__ contiguous_value,
-    const int64_t key_block_stride,
-    const int64_t key_page_stride,
-    const int64_t key_head_stride,
-    const int64_t value_block_stride,
-    const int64_t value_page_stride,
-    const int64_t value_head_stride,
-    const int block_size,
-    const int num_heads,
-    const int head_dim,
-    const int max_num_blocks
-) {
-    const int batch_idx = blockIdx.x;
-    const int seq_len = seq_lens[batch_idx];
-    if (seq_len == 0) return;
+    const int* __restrict__ block_table, const int* __restrict__ seq_lens,
+    __half* __restrict__ contiguous_key, __half* __restrict__ contiguous_value,
+    const int64_t key_block_stride, const int64_t key_page_stride,
+    const int64_t key_head_stride, const int64_t value_block_stride,
+    const int64_t value_page_stride, const int64_t value_head_stride,
+    const int block_size, const int num_heads, const int head_dim,
+    const int max_num_blocks) {
+  const int batch_idx = blockIdx.x;
+  const int seq_len = seq_lens[batch_idx];
+  if (seq_len == 0) return;
 
-    int output_offset = 0;
-    for (int i = 0; i < batch_idx; ++i) {
-        output_offset += seq_lens[i];
+  int output_offset = 0;
+  for (int i = 0; i < batch_idx; ++i) {
+    output_offset += seq_lens[i];
+  }
+
+  const int* block_table_seq = block_table + batch_idx * max_num_blocks;
+  const int tid = threadIdx.x;
+  const int num_threads = blockDim.x;
+  const int elements_per_token = num_heads * head_dim;
+
+  for (int token_idx = 0; token_idx < seq_len; ++token_idx) {
+    const int virtual_block_idx = token_idx / block_size;
+    const int block_offset = token_idx % block_size;
+    const int physical_block_idx = block_table_seq[virtual_block_idx];
+
+    const __half* key_token_base = paged_key_cache +
+                                   physical_block_idx * key_block_stride +
+                                   block_offset * key_page_stride;
+    const __half* value_token_base = paged_value_cache +
+                                     physical_block_idx * value_block_stride +
+                                     block_offset * value_page_stride;
+
+    __half* key_output_token =
+        contiguous_key + (output_offset + token_idx) * elements_per_token;
+    __half* value_output_token =
+        contiguous_value + (output_offset + token_idx) * elements_per_token;
+
+    for (int head_idx = 0; head_idx < num_heads; ++head_idx) {
+      const __half* key_head_src = key_token_base + head_idx * key_head_stride;
+      const __half* value_head_src =
+          value_token_base + head_idx * value_head_stride;
+      __half* key_head_dst = key_output_token + head_idx * head_dim;
+      __half* value_head_dst = value_output_token + head_idx * head_dim;
+
+      for (int elem_idx = tid; elem_idx < head_dim; elem_idx += num_threads) {
+        key_head_dst[elem_idx] = key_head_src[elem_idx];
+        value_head_dst[elem_idx] = value_head_src[elem_idx];
+      }
     }
-
-    const int* block_table_seq = block_table + batch_idx * max_num_blocks;
-    const int tid = threadIdx.x;
-    const int num_threads = blockDim.x;
-    const int elements_per_token = num_heads * head_dim;
-
-    for (int token_idx = 0; token_idx < seq_len; ++token_idx) {
-        const int virtual_block_idx = token_idx / block_size;
-        const int block_offset = token_idx % block_size;
-        const int physical_block_idx = block_table_seq[virtual_block_idx];
-
-        const __half* key_token_base = paged_key_cache
-            + physical_block_idx * key_block_stride
-            + block_offset * key_page_stride;
-        const __half* value_token_base = paged_value_cache
-            + physical_block_idx * value_block_stride
-            + block_offset * value_page_stride;
-
-        __half* key_output_token =
-            contiguous_key + (output_offset + token_idx) * elements_per_token;
-        __half* value_output_token =
-            contiguous_value + (output_offset + token_idx) * elements_per_token;
-
-        for (int head_idx = 0; head_idx < num_heads; ++head_idx) {
-            const __half* key_head_src = key_token_base + head_idx * key_head_stride;
-            const __half* value_head_src =
-                value_token_base + head_idx * value_head_stride;
-            __half* key_head_dst = key_output_token + head_idx * head_dim;
-            __half* value_head_dst = value_output_token + head_idx * head_dim;
-
-            for (int elem_idx = tid; elem_idx < head_dim; elem_idx += num_threads) {
-                key_head_dst[elem_idx] = key_head_src[elem_idx];
-                value_head_dst[elem_idx] = value_head_src[elem_idx];
-            }
-        }
-    }
+  }
 }
 
-torch::Tensor paged_to_contiguous(
-    torch::Tensor paged_cache,
-    torch::Tensor block_table,
-    torch::Tensor seq_lens
-) {
-    const int batch_size = block_table.size(0);
-    const int max_num_blocks = block_table.size(1);
-    const int num_blocks = paged_cache.size(0);
-    const int block_size = paged_cache.size(1);
-    const int num_heads = paged_cache.size(2);
-    const int head_dim = paged_cache.size(3);
+torch::Tensor paged_to_contiguous(torch::Tensor paged_cache,
+                                  torch::Tensor block_table,
+                                  torch::Tensor seq_lens) {
+  const int batch_size = block_table.size(0);
+  const int max_num_blocks = block_table.size(1);
+  const int num_blocks = paged_cache.size(0);
+  const int block_size = paged_cache.size(1);
+  const int num_heads = paged_cache.size(2);
+  const int head_dim = paged_cache.size(3);
 
-    const int64_t block_stride = paged_cache.stride(0);
-    const int64_t page_stride = paged_cache.stride(1);
-    const int64_t head_stride = paged_cache.stride(2);
+  const int64_t block_stride = paged_cache.stride(0);
+  const int64_t page_stride = paged_cache.stride(1);
+  const int64_t head_stride = paged_cache.stride(2);
 
-    const int total_tokens = batch_size * max_num_blocks * block_size;
+  const int total_tokens = batch_size * max_num_blocks * block_size;
 
-    auto contiguous = torch::zeros(
-        {total_tokens, num_heads, head_dim},
-        torch::TensorOptions().dtype(paged_cache.dtype()).device(paged_cache.device())
-    );
+  auto contiguous = torch::zeros({total_tokens, num_heads, head_dim},
+                                 torch::TensorOptions()
+                                     .dtype(paged_cache.dtype())
+                                     .device(paged_cache.device()));
 
-    const int threads = 256;
-    paged_to_contiguous_stride_aware_kernel<<<batch_size, threads>>>(
-        reinterpret_cast<const __half*>(paged_cache.data_ptr<at::Half>()),
-        block_table.data_ptr<int>(),
-        seq_lens.data_ptr<int>(),
-        reinterpret_cast<__half*>(contiguous.data_ptr<at::Half>()),
-        block_stride,
-        page_stride,
-        head_stride,
-        block_size,
-        num_heads,
-        head_dim,
-        max_num_blocks
-    );
+  const int threads = 256;
+  paged_to_contiguous_stride_aware_kernel<<<batch_size, threads>>>(
+      reinterpret_cast<const __half*>(paged_cache.data_ptr<at::Half>()),
+      block_table.data_ptr<int>(), seq_lens.data_ptr<int>(),
+      reinterpret_cast<__half*>(contiguous.data_ptr<at::Half>()), block_stride,
+      page_stride, head_stride, block_size, num_heads, head_dim,
+      max_num_blocks);
 
-    return contiguous;
+  return contiguous;
 }
 
 std::vector<torch::Tensor> paged_kv_to_contiguous(
-    torch::Tensor paged_key_cache,
-    torch::Tensor paged_value_cache,
-    torch::Tensor block_table,
-    torch::Tensor seq_lens
-) {
-    const int batch_size = block_table.size(0);
-    const int max_num_blocks = block_table.size(1);
-    const int block_size = paged_key_cache.size(1);
-    const int num_heads = paged_key_cache.size(2);
-    const int head_dim = paged_key_cache.size(3);
+    torch::Tensor paged_key_cache, torch::Tensor paged_value_cache,
+    torch::Tensor block_table, torch::Tensor seq_lens) {
+  const int batch_size = block_table.size(0);
+  const int max_num_blocks = block_table.size(1);
+  const int block_size = paged_key_cache.size(1);
+  const int num_heads = paged_key_cache.size(2);
+  const int head_dim = paged_key_cache.size(3);
 
-    const int64_t key_block_stride = paged_key_cache.stride(0);
-    const int64_t key_page_stride = paged_key_cache.stride(1);
-    const int64_t key_head_stride = paged_key_cache.stride(2);
-    const int64_t value_block_stride = paged_value_cache.stride(0);
-    const int64_t value_page_stride = paged_value_cache.stride(1);
-    const int64_t value_head_stride = paged_value_cache.stride(2);
+  const int64_t key_block_stride = paged_key_cache.stride(0);
+  const int64_t key_page_stride = paged_key_cache.stride(1);
+  const int64_t key_head_stride = paged_key_cache.stride(2);
+  const int64_t value_block_stride = paged_value_cache.stride(0);
+  const int64_t value_page_stride = paged_value_cache.stride(1);
+  const int64_t value_head_stride = paged_value_cache.stride(2);
 
-    const int total_tokens = batch_size * max_num_blocks * block_size;
+  const int total_tokens = batch_size * max_num_blocks * block_size;
 
-    auto opts = torch::TensorOptions()
-                    .dtype(paged_key_cache.dtype())
-                    .device(paged_key_cache.device());
-    auto contiguous_key = torch::zeros({total_tokens, num_heads, head_dim}, opts);
-    auto contiguous_value = torch::zeros({total_tokens, num_heads, head_dim}, opts);
+  auto opts = torch::TensorOptions()
+                  .dtype(paged_key_cache.dtype())
+                  .device(paged_key_cache.device());
+  auto contiguous_key = torch::zeros({total_tokens, num_heads, head_dim}, opts);
+  auto contiguous_value =
+      torch::zeros({total_tokens, num_heads, head_dim}, opts);
 
-    const int threads = 256;
-    paged_kv_to_contiguous_stride_aware_kernel<<<batch_size, threads>>>(
-        reinterpret_cast<const __half*>(paged_key_cache.data_ptr<at::Half>()),
-        reinterpret_cast<const __half*>(paged_value_cache.data_ptr<at::Half>()),
-        block_table.data_ptr<int>(),
-        seq_lens.data_ptr<int>(),
-        reinterpret_cast<__half*>(contiguous_key.data_ptr<at::Half>()),
-        reinterpret_cast<__half*>(contiguous_value.data_ptr<at::Half>()),
-        key_block_stride,
-        key_page_stride,
-        key_head_stride,
-        value_block_stride,
-        value_page_stride,
-        value_head_stride,
-        block_size,
-        num_heads,
-        head_dim,
-        max_num_blocks
-    );
+  const int threads = 256;
+  paged_kv_to_contiguous_stride_aware_kernel<<<batch_size, threads>>>(
+      reinterpret_cast<const __half*>(paged_key_cache.data_ptr<at::Half>()),
+      reinterpret_cast<const __half*>(paged_value_cache.data_ptr<at::Half>()),
+      block_table.data_ptr<int>(), seq_lens.data_ptr<int>(),
+      reinterpret_cast<__half*>(contiguous_key.data_ptr<at::Half>()),
+      reinterpret_cast<__half*>(contiguous_value.data_ptr<at::Half>()),
+      key_block_stride, key_page_stride, key_head_stride, value_block_stride,
+      value_page_stride, value_head_stride, block_size, num_heads, head_dim,
+      max_num_blocks);
 
-    return {contiguous_key, contiguous_value};
+  return {contiguous_key, contiguous_value};
 }
 
 PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
-    m.def("paged_to_contiguous", &paged_to_contiguous, "Paged KV Cache to Contiguous (Stride-Aware)");
-    m.def("paged_kv_to_contiguous",
-          &paged_kv_to_contiguous,
-          "Paged KV Cache to Contiguous K/V Pair (Stride-Aware)");
+  m.def("paged_to_contiguous", &paged_to_contiguous,
+        "Paged KV Cache to Contiguous (Stride-Aware)");
+  m.def("paged_kv_to_contiguous", &paged_kv_to_contiguous,
+        "Paged KV Cache to Contiguous K/V Pair (Stride-Aware)");
 }

--- a/flash-attention-v100/kernel/paged_to_contiguous_fixed.cu
+++ b/flash-attention-v100/kernel/paged_to_contiguous_fixed.cu
@@ -4,102 +4,85 @@
 #include <torch/extension.h>
 
 __global__ void paged_to_contiguous_stride_aware_kernel(
-    const __half* __restrict__ paged_cache,
-    const int* __restrict__ block_table,
-    const int* __restrict__ seq_lens,
-          __half* __restrict__ contiguous,
-    const int64_t block_stride,
-    const int64_t page_stride,
-    const int64_t head_stride,
-    const int block_size,
-    const int num_heads,
-    const int head_dim,
-    const int max_num_blocks
-) {
+    const __half* __restrict__ paged_cache, const int* __restrict__ block_table,
+    const int* __restrict__ seq_lens, __half* __restrict__ contiguous,
+    const int64_t block_stride, const int64_t page_stride,
+    const int64_t head_stride, const int block_size, const int num_heads,
+    const int head_dim, const int max_num_blocks) {
+  const int batch_idx = blockIdx.x;
+  const int seq_len = seq_lens[batch_idx];
+  if (seq_len == 0) return;
 
-    const int batch_idx = blockIdx.x;
-    const int seq_len = seq_lens[batch_idx];
-    if (seq_len == 0) return;
+  int output_offset = 0;
+  for (int i = 0; i < batch_idx; ++i) {
+    output_offset += seq_lens[i];
+  }
 
-    int output_offset = 0;
-    for (int i = 0; i < batch_idx; ++i) {
-        output_offset += seq_lens[i];
+  const int* block_table_seq = block_table + batch_idx * max_num_blocks;
+
+  const int tid = threadIdx.x;
+  const int num_threads = blockDim.x;
+  const int elements_per_token = num_heads * head_dim;
+
+  for (int token_idx = 0; token_idx < seq_len; ++token_idx) {
+    const int virtual_block_idx = token_idx / block_size;
+    const int block_offset = token_idx % block_size;
+    const int physical_block_idx = block_table_seq[virtual_block_idx];
+
+    const __half* token_base = paged_cache + physical_block_idx * block_stride +
+                               block_offset * page_stride;
+
+    __half* output_token =
+        contiguous + (output_offset + token_idx) * elements_per_token;
+
+    for (int head_idx = 0; head_idx < num_heads; ++head_idx) {
+      const __half* head_src = token_base + head_idx * head_stride;
+      __half* head_dst = output_token + head_idx * head_dim;
+
+      for (int elem_idx = tid; elem_idx < head_dim; elem_idx += num_threads) {
+        head_dst[elem_idx] = head_src[elem_idx];
+      }
     }
-
-    const int* block_table_seq = block_table + batch_idx * max_num_blocks;
-
-    const int tid = threadIdx.x;
-    const int num_threads = blockDim.x;
-    const int elements_per_token = num_heads * head_dim;
-
-    for (int token_idx = 0; token_idx < seq_len; ++token_idx) {
-
-        const int virtual_block_idx = token_idx / block_size;
-        const int block_offset = token_idx % block_size;
-        const int physical_block_idx = block_table_seq[virtual_block_idx];
-
-        const __half* token_base = paged_cache
-            + physical_block_idx * block_stride
-            + block_offset * page_stride;
-
-        __half* output_token = contiguous + (output_offset + token_idx) * elements_per_token;
-
-        for (int head_idx = 0; head_idx < num_heads; ++head_idx) {
-            const __half* head_src = token_base + head_idx * head_stride;
-            __half* head_dst = output_token + head_idx * head_dim;
-
-            for (int elem_idx = tid; elem_idx < head_dim; elem_idx += num_threads) {
-                head_dst[elem_idx] = head_src[elem_idx];
-            }
-        }
-    }
+  }
 }
 
-torch::Tensor paged_to_contiguous(
-    torch::Tensor paged_cache,
-    torch::Tensor block_table,
-    torch::Tensor seq_lens
-) {
-    const int batch_size = block_table.size(0);
-    const int max_num_blocks = block_table.size(1);
-    const int num_blocks = paged_cache.size(0);
-    const int block_size = paged_cache.size(1);
-    const int num_heads = paged_cache.size(2);
-    const int head_dim = paged_cache.size(3);
+torch::Tensor paged_to_contiguous(torch::Tensor paged_cache,
+                                  torch::Tensor block_table,
+                                  torch::Tensor seq_lens) {
+  const int batch_size = block_table.size(0);
+  const int max_num_blocks = block_table.size(1);
+  const int num_blocks = paged_cache.size(0);
+  const int block_size = paged_cache.size(1);
+  const int num_heads = paged_cache.size(2);
+  const int head_dim = paged_cache.size(3);
 
-    const int64_t block_stride = paged_cache.stride(0);
-    const int64_t page_stride = paged_cache.stride(1);
-    const int64_t head_stride = paged_cache.stride(2);
+  const int64_t block_stride = paged_cache.stride(0);
+  const int64_t page_stride = paged_cache.stride(1);
+  const int64_t head_stride = paged_cache.stride(2);
 
-    int total_tokens = 0;
-    auto seq_lens_cpu = seq_lens.cpu();
-    for (int i = 0; i < batch_size; ++i) {
-        total_tokens += seq_lens_cpu[i].item<int>();
-    }
+  int total_tokens = 0;
+  auto seq_lens_cpu = seq_lens.cpu();
+  for (int i = 0; i < batch_size; ++i) {
+    total_tokens += seq_lens_cpu[i].item<int>();
+  }
 
-    auto contiguous = torch::zeros(
-        {total_tokens, num_heads, head_dim},
-        torch::TensorOptions().dtype(paged_cache.dtype()).device(paged_cache.device())
-    );
+  auto contiguous = torch::zeros({total_tokens, num_heads, head_dim},
+                                 torch::TensorOptions()
+                                     .dtype(paged_cache.dtype())
+                                     .device(paged_cache.device()));
 
-    const int threads = 256;
-    paged_to_contiguous_stride_aware_kernel<<<batch_size, threads>>>(
-        reinterpret_cast<const __half*>(paged_cache.data_ptr<at::Half>()),
-        block_table.data_ptr<int>(),
-        seq_lens.data_ptr<int>(),
-        reinterpret_cast<__half*>(contiguous.data_ptr<at::Half>()),
-        block_stride,
-        page_stride,
-        head_stride,
-        block_size,
-        num_heads,
-        head_dim,
-        max_num_blocks
-    );
+  const int threads = 256;
+  paged_to_contiguous_stride_aware_kernel<<<batch_size, threads>>>(
+      reinterpret_cast<const __half*>(paged_cache.data_ptr<at::Half>()),
+      block_table.data_ptr<int>(), seq_lens.data_ptr<int>(),
+      reinterpret_cast<__half*>(contiguous.data_ptr<at::Half>()), block_stride,
+      page_stride, head_stride, block_size, num_heads, head_dim,
+      max_num_blocks);
 
-    return contiguous;
+  return contiguous;
 }
 
 PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
-    m.def("paged_to_contiguous", &paged_to_contiguous, "Paged KV Cache to Contiguous (Stride-Aware)");
+  m.def("paged_to_contiguous", &paged_to_contiguous,
+        "Paged KV Cache to Contiguous (Stride-Aware)");
 }

--- a/flash-attention-v100/kernel/paged_to_contiguous_old.cu
+++ b/flash-attention-v100/kernel/paged_to_contiguous_old.cu
@@ -4,85 +4,75 @@
 #include <torch/extension.h>
 
 __global__ void paged_to_contiguous_kernel(
-    const __half* __restrict__ paged_cache,
-    const int* __restrict__ block_table,
-    const int* __restrict__ seq_lens,
-          __half* __restrict__ contiguous,
-    const int block_size,
-    const int num_heads,
-    const int head_dim,
-    const int max_num_blocks
-) {
+    const __half* __restrict__ paged_cache, const int* __restrict__ block_table,
+    const int* __restrict__ seq_lens, __half* __restrict__ contiguous,
+    const int block_size, const int num_heads, const int head_dim,
+    const int max_num_blocks) {
+  const int batch_idx = blockIdx.x;
+  const int seq_len = seq_lens[batch_idx];
+  if (seq_len == 0) return;
 
-    const int batch_idx = blockIdx.x;
-    const int seq_len = seq_lens[batch_idx];
-    if (seq_len == 0) return;
+  int output_offset = 0;
+  for (int i = 0; i < batch_idx; ++i) {
+    output_offset += seq_lens[i];
+  }
 
-    int output_offset = 0;
-    for (int i = 0; i < batch_idx; ++i) {
-        output_offset += seq_lens[i];
+  const int* block_table_seq = block_table + batch_idx * max_num_blocks;
+
+  const int tid = threadIdx.x;
+  const int num_threads = blockDim.x;
+  const int elements_per_token = num_heads * head_dim;
+
+  for (int token_idx = 0; token_idx < seq_len; ++token_idx) {
+    const int virtual_block_idx = token_idx / block_size;
+    const int block_offset = token_idx % block_size;
+    const int physical_block_idx = block_table_seq[virtual_block_idx];
+
+    const size_t paged_offset =
+        (size_t)physical_block_idx * block_size * elements_per_token +
+        (size_t)block_offset * elements_per_token;
+
+    const size_t cont_offset =
+        (size_t)(output_offset + token_idx) * elements_per_token;
+
+    for (int elem_idx = tid; elem_idx < elements_per_token;
+         elem_idx += num_threads) {
+      contiguous[cont_offset + elem_idx] = paged_cache[paged_offset + elem_idx];
     }
-
-    const int* block_table_seq = block_table + batch_idx * max_num_blocks;
-
-    const int tid = threadIdx.x;
-    const int num_threads = blockDim.x;
-    const int elements_per_token = num_heads * head_dim;
-
-    for (int token_idx = 0; token_idx < seq_len; ++token_idx) {
-
-        const int virtual_block_idx = token_idx / block_size;
-        const int block_offset = token_idx % block_size;
-        const int physical_block_idx = block_table_seq[virtual_block_idx];
-
-        const size_t paged_offset = (size_t)physical_block_idx * block_size * elements_per_token
-                                  + (size_t)block_offset * elements_per_token;
-
-        const size_t cont_offset = (size_t)(output_offset + token_idx) * elements_per_token;
-
-        for (int elem_idx = tid; elem_idx < elements_per_token; elem_idx += num_threads) {
-            contiguous[cont_offset + elem_idx] = paged_cache[paged_offset + elem_idx];
-        }
-    }
+  }
 }
 
-torch::Tensor paged_to_contiguous(
-    torch::Tensor paged_cache,
-    torch::Tensor block_table,
-    torch::Tensor seq_lens
-) {
-    const int batch_size = block_table.size(0);
-    const int max_num_blocks = block_table.size(1);
-    const int block_size = paged_cache.size(1);
-    const int num_heads = paged_cache.size(2);
-    const int head_dim = paged_cache.size(3);
+torch::Tensor paged_to_contiguous(torch::Tensor paged_cache,
+                                  torch::Tensor block_table,
+                                  torch::Tensor seq_lens) {
+  const int batch_size = block_table.size(0);
+  const int max_num_blocks = block_table.size(1);
+  const int block_size = paged_cache.size(1);
+  const int num_heads = paged_cache.size(2);
+  const int head_dim = paged_cache.size(3);
 
-    int total_tokens = 0;
-    auto seq_lens_cpu = seq_lens.cpu();
-    for (int i = 0; i < batch_size; ++i) {
-        total_tokens += seq_lens_cpu[i].item<int>();
-    }
+  int total_tokens = 0;
+  auto seq_lens_cpu = seq_lens.cpu();
+  for (int i = 0; i < batch_size; ++i) {
+    total_tokens += seq_lens_cpu[i].item<int>();
+  }
 
-    auto contiguous = torch::zeros(
-        {total_tokens, num_heads, head_dim},
-        torch::TensorOptions().dtype(paged_cache.dtype()).device(paged_cache.device())
-    );
+  auto contiguous = torch::zeros({total_tokens, num_heads, head_dim},
+                                 torch::TensorOptions()
+                                     .dtype(paged_cache.dtype())
+                                     .device(paged_cache.device()));
 
-    const int threads = 256;
-    paged_to_contiguous_kernel<<<batch_size, threads>>>(
-        reinterpret_cast<const __half*>(paged_cache.data_ptr<at::Half>()),
-        block_table.data_ptr<int>(),
-        seq_lens.data_ptr<int>(),
-        reinterpret_cast<__half*>(contiguous.data_ptr<at::Half>()),
-        block_size,
-        num_heads,
-        head_dim,
-        max_num_blocks
-    );
+  const int threads = 256;
+  paged_to_contiguous_kernel<<<batch_size, threads>>>(
+      reinterpret_cast<const __half*>(paged_cache.data_ptr<at::Half>()),
+      block_table.data_ptr<int>(), seq_lens.data_ptr<int>(),
+      reinterpret_cast<__half*>(contiguous.data_ptr<at::Half>()), block_size,
+      num_heads, head_dim, max_num_blocks);
 
-    return contiguous;
+  return contiguous;
 }
 
 PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
-    m.def("paged_to_contiguous", &paged_to_contiguous, "Paged KV Cache to Contiguous");
+  m.def("paged_to_contiguous", &paged_to_contiguous,
+        "Paged KV Cache to Contiguous");
 }

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -167,7 +167,6 @@ smmap==5.0.3
     # via gitdb
 typing-extensions==4.15.0
     # via
-    #   mkdocstrings-python
     #   pydantic
     #   pydantic-core
     #   typing-inspection

--- a/tests/kernels/attention/test_sm70_flash_v100_splitkv3.py
+++ b/tests/kernels/attention/test_sm70_flash_v100_splitkv3.py
@@ -37,18 +37,14 @@ def _run_case(
         dtype=torch.float16,
     )
     value_cache = torch.randn_like(key_cache)
-    block_table = torch.tensor(
-        [page_ids], device="cuda", dtype=torch.int32
-    )
+    block_table = torch.tensor([page_ids], device="cuda", dtype=torch.int32)
     sequence_lengths = torch.full(
         (batch_size,), sequence_len, device="cuda", dtype=torch.int32
     )
     softmax_scale = head_dim**-0.5
 
     unsplit_out = torch.empty_like(query)
-    unsplit_lse = torch.empty(
-        query.shape[:-1], device="cuda", dtype=torch.float32
-    )
+    unsplit_lse = torch.empty(query.shape[:-1], device="cuda", dtype=torch.float32)
     split_out = torch.empty_like(query)
     split_lse = torch.empty_like(unsplit_lse)
     split_tmp_out = torch.empty(
@@ -202,6 +198,4 @@ def test_splitkv3_python_wrapper_reuses_stream_workspace() -> None:
         rtol=0.0,
         atol=0.001953125,
     )
-    torch.testing.assert_close(
-        second_lse, result["unsplit_lse"], rtol=0.0, atol=0.001
-    )
+    torch.testing.assert_close(second_lse, result["unsplit_lse"], rtol=0.0, atol=0.001)

--- a/tests/kernels/moe/test_moe_permute_unpermute.py
+++ b/tests/kernels/moe/test_moe_permute_unpermute.py
@@ -473,9 +473,7 @@ def test_sm70_single_token_weighted_reduce_matches_moe_unpermute():
         )
         topk_weights = torch.randn((1, topk), device=device, dtype=torch.float32)
         dummy_hidden = torch.randn((1, hidden), device=device, dtype=torch.float16)
-        _, _, offsets, inv, _ = moe_permute(
-            dummy_hidden, None, topk_ids, n_expert
-        )
+        _, _, offsets, inv, _ = moe_permute(dummy_hidden, None, topk_ids, n_expert)
         sorted_output_storage = torch.randn(
             (topk, hidden + pad), device=device, dtype=torch.float16
         )
@@ -483,12 +481,8 @@ def test_sm70_single_token_weighted_reduce_matches_moe_unpermute():
 
         expected = torch.empty((1, hidden), device=device, dtype=torch.float16)
         actual = torch.empty_like(expected)
-        reference_sorted_output = (
-            sorted_output.contiguous() if pad else sorted_output
-        )
-        moe_unpermute(
-            expected, reference_sorted_output, topk_weights, inv, offsets
-        )
+        reference_sorted_output = sorted_output.contiguous() if pad else sorted_output
+        moe_unpermute(expected, reference_sorted_output, topk_weights, inv, offsets)
         torch.ops._C.awq_moe_single_token_weighted_reduce_out(
             sorted_output,
             topk_weights,

--- a/tests/kernels/test_deepseek_v4_sm70_qnorm_rope_kv_insert.py
+++ b/tests/kernels/test_deepseek_v4_sm70_qnorm_rope_kv_insert.py
@@ -25,10 +25,7 @@ pytestmark = pytest.mark.skipif(
 def _make_cos_sin_cache(max_position: int, device: str) -> torch.Tensor:
     inv_freq = 1.0 / (
         10000.0
-        ** (
-            torch.arange(0, ROPE_DIM, 2, dtype=torch.float32, device=device)
-            / ROPE_DIM
-        )
+        ** (torch.arange(0, ROPE_DIM, 2, dtype=torch.float32, device=device) / ROPE_DIM)
     )
     positions = torch.arange(max_position, dtype=torch.float32, device=device)
     frequencies = torch.outer(positions, inv_freq)

--- a/tests/kernels/test_fused_recurrent_packed_decode.py
+++ b/tests/kernels/test_fused_recurrent_packed_decode.py
@@ -151,9 +151,7 @@ def test_fused_recurrent_packed_decode_cuda_graph_replay_uses_runtime_indices():
     mixed_qkv_static = torch.empty((B, qkv_dim), device=device, dtype=dtype)
     a_static = torch.empty((B, HV), device=device, dtype=dtype)
     b_static = torch.empty((B, HV), device=device, dtype=dtype)
-    state_static = torch.empty(
-        (num_state_slots, HV, V, K), device=device, dtype=dtype
-    )
+    state_static = torch.empty((num_state_slots, HV, V, K), device=device, dtype=dtype)
     indices_static = torch.empty((B,), device=device, dtype=torch.int32)
     out_static = torch.empty((B, 1, HV, V), device=device, dtype=dtype)
 
@@ -161,9 +159,7 @@ def test_fused_recurrent_packed_decode_cuda_graph_replay_uses_runtime_indices():
     warm_mixed_qkv = torch.randn((B, qkv_dim), device=device, dtype=dtype)
     warm_a = torch.randn((B, HV), device=device, dtype=dtype)
     warm_b = torch.randn((B, HV), device=device, dtype=dtype)
-    warm_state = torch.randn(
-        (num_state_slots, HV, V, K), device=device, dtype=dtype
-    )
+    warm_state = torch.randn((num_state_slots, HV, V, K), device=device, dtype=dtype)
     warm_indices = torch.tensor([0, 1, -1, -1], device=device, dtype=torch.int32)
     warm_out = torch.empty_like(out_static)
     fused_recurrent_gated_delta_rule_packed_decode(
@@ -183,9 +179,7 @@ def test_fused_recurrent_packed_decode_cuda_graph_replay_uses_runtime_indices():
     capture_mixed_qkv = torch.randn((B, qkv_dim), device=device, dtype=dtype)
     capture_a = torch.randn((B, HV), device=device, dtype=dtype)
     capture_b = torch.randn((B, HV), device=device, dtype=dtype)
-    capture_state = torch.randn(
-        (num_state_slots, HV, V, K), device=device, dtype=dtype
-    )
+    capture_state = torch.randn((num_state_slots, HV, V, K), device=device, dtype=dtype)
     capture_indices = torch.tensor([6, -1, 7, -1], device=device, dtype=torch.int32)
     mixed_qkv_static.copy_(capture_mixed_qkv)
     a_static.copy_(capture_a)

--- a/tests/tool_parsers/test_qwen3coder_tool_parser.py
+++ b/tests/tool_parsers/test_qwen3coder_tool_parser.py
@@ -1384,7 +1384,7 @@ def test_streaming_multi_param_single_chunk(qwen3_tool_parser, qwen3_tokenizer):
 @pytest.mark.parametrize(
     "deltas, expected_content",
     [
-        (["<", "meta charset=\"UTF-8\">"], '<meta charset="UTF-8">'),
+        (["<", 'meta charset="UTF-8">'], '<meta charset="UTF-8">'),
         (["<t", "itle>macOS</title>"], "<title>macOS</title>"),
         (["<", "<", "span>text</span>"], "<<span>text</span>"),
     ],

--- a/tests/v1/spec_decode/test_ddtree_flex_attention.py
+++ b/tests/v1/spec_decode/test_ddtree_flex_attention.py
@@ -29,11 +29,11 @@ def test_ddtree_logical_mask_hides_siblings() -> None:
     )
 
     assert mask.tolist() == [
-        True,   # history
-        True,   # history
-        True,   # root
-        True,   # parent node 1
-        True,   # self node 2
+        True,  # history
+        True,  # history
+        True,  # root
+        True,  # parent node 1
+        True,  # self node 2
         False,  # sibling node 3
         False,  # beyond tree
     ]

--- a/tests/v1/spec_decode/test_ddtree_gpu_runner_positions.py
+++ b/tests/v1/spec_decode/test_ddtree_gpu_runner_positions.py
@@ -304,9 +304,7 @@ def test_mamba_postprocess_ddtree_state_slot_bias_uses_compact_node_index(
         forward_context=forward_context,
         mamba_state_copy_funcs=(copy_func,),
         copy_bufs=copy_bufs,
-        ddtree_accepted_node_indices=torch.tensor(
-            [[0, 2, 5, 9]], dtype=torch.int32
-        ),
+        ddtree_accepted_node_indices=torch.tensor([[0, 2, 5, 9]], dtype=torch.int32),
     )
 
     assert calls == [(9, 1)]
@@ -317,9 +315,7 @@ def test_update_states_after_model_execute_keeps_compact_state_selector() -> Non
     runner.speculative_config = object()
     runner.model_config = SimpleNamespace(is_hybrid=True)
     runner.cache_config = SimpleNamespace(mamba_cache_mode="none")
-    runner.num_accepted_tokens = SimpleNamespace(
-        gpu=torch.ones(1, dtype=torch.int32)
-    )
+    runner.num_accepted_tokens = SimpleNamespace(gpu=torch.ones(1, dtype=torch.int32))
     runner.spec_state_slot_selectors = SimpleNamespace(
         gpu=torch.ones(1, dtype=torch.int32)
     )
@@ -389,9 +385,7 @@ def test_compact_ddtree_drafter_context_moves_branch_to_prefix() -> None:
     scheduler_output = _scheduler_output(payload)
     scheduler_output.num_scheduled_tokens = {"r0": 6}
     scheduler_output.total_num_scheduled_tokens = 6
-    scheduler_output.scheduled_spec_decode_tokens = {
-        "r0": list(payload.tree_token_ids)
-    }
+    scheduler_output.scheduled_spec_decode_tokens = {"r0": list(payload.tree_token_ids)}
 
     runner._compact_ddtree_drafter_context(
         hidden_states,

--- a/tests/v1/spec_decode/test_ddtree_metadata.py
+++ b/tests/v1/spec_decode/test_ddtree_metadata.py
@@ -34,7 +34,8 @@ def test_single_request_metadata_indices() -> None:
     assert metadata.compact_logits_indices[0] == 6
     assert metadata.compact_logits_indices[1] == 7
     assert metadata.node_compact_indices == tuple(
-        range(1, tree.non_root_nodes[-1].index + 1))
+        range(1, tree.non_root_nodes[-1].index + 1)
+    )
     assert metadata.edge_parent_compact_indices[0] == 0
     assert metadata.edge_parent_compact_indices[1] == 1
     assert metadata.tree_position_ids[:3] == (7, 8, 9)

--- a/tools/pre_commit/check_forbidden_imports.py
+++ b/tools/pre_commit/check_forbidden_imports.py
@@ -80,7 +80,12 @@ CHECK_IMPORTS = {
         allowed_pattern=re.compile(
             "from vllm.triton_utils import (triton|tl|tl, triton)"
         ),
-        allowed_files={"vllm/triton_utils/importing.py"},
+        allowed_files={
+            "vllm/triton_utils/importing.py",
+            # AOT inspection needs compiler/backend modules that the vLLM
+            # runtime shim deliberately does not export.
+            "benchmarks/kernels/deepseek_v4_sm70_aot_check.py",
+        },
     ),
 }
 

--- a/tools/pre_commit/check_torch_cuda.py
+++ b/tools/pre_commit/check_torch_cuda.py
@@ -19,7 +19,17 @@ ALLOWED_FILES = {
     "vllm/platforms/",
     "vllm/device_allocator/",
     "vllm/distributed/weight_transfer/ipc_engine.py",
+    # Standalone SM70/DSpark probes intentionally exercise CUDA-only APIs.
+    # Keep the runtime package on torch.accelerator while admitting these
+    # hardware-specific benchmark and operator-test namespaces as baseline.
+    "benchmarks/benchmark_sm70_",
+    "benchmarks/kernels/benchmark_flash_v100_",
+    "benchmarks/kernels/benchmark_sm70_",
+    "benchmarks/kernels/benchmark_dspark_",
+    "benchmarks/kernels/benchmark_deepseek_v4_sm70_",
     "tests/distributed/test_packed_tensor.py",
+    "tests/kernels/test_sm70_",
+    "tests/kernels/quantization/test_sm70_",
 }
 
 

--- a/vllm/compilation/passes/fusion/matcher_utils.py
+++ b/vllm/compilation/passes/fusion/matcher_utils.py
@@ -44,8 +44,7 @@ def get_op_overload(
 
 
 ROTARY_OP = get_op_overload(torch.ops._C, "rotary_embedding")
-FLASHINFER_ROTARY_OP = get_op_overload(torch.ops.vllm,
-                                       "flashinfer_rotary_embedding")
+FLASHINFER_ROTARY_OP = get_op_overload(torch.ops.vllm, "flashinfer_rotary_embedding")
 
 QUANT_OPS: dict[QuantKey, OpOverload] = {}
 

--- a/vllm/compilation/passes/fusion/qk_norm_rope_fusion.py
+++ b/vllm/compilation/passes/fusion/qk_norm_rope_fusion.py
@@ -198,8 +198,7 @@ class QKNormRoPEFusionPass(VllmPatternMatcherPass):
         dtype = config.model_config.dtype
         if FUSED_QK_ROPE_OP is None:
             logger.warning_once(
-                "QK Norm+RoPE fusion not enabled: fused_qk_norm_rope is "
-                "unavailable."
+                "QK Norm+RoPE fusion not enabled: fused_qk_norm_rope is unavailable."
             )
             return
 

--- a/vllm/compilation/passes/fusion/rms_quant_fusion.py
+++ b/vllm/compilation/passes/fusion/rms_quant_fusion.py
@@ -124,12 +124,9 @@ def _register_fused_op(
 
 
 _register_fused_op(kFp8StaticTensorSym, False, "rms_norm_static_fp8_quant")
-_register_fused_op(kFp8StaticTensorSym, True,
-                   "fused_add_rms_norm_static_fp8_quant")
-_register_fused_op(kFp8DynamicTokenSym, False,
-                   "rms_norm_dynamic_per_token_quant")
-_register_fused_op(kFp8DynamicTokenSym, True,
-                   "rms_norm_dynamic_per_token_quant")
+_register_fused_op(kFp8StaticTensorSym, True, "fused_add_rms_norm_static_fp8_quant")
+_register_fused_op(kFp8DynamicTokenSym, False, "rms_norm_dynamic_per_token_quant")
+_register_fused_op(kFp8DynamicTokenSym, True, "rms_norm_dynamic_per_token_quant")
 _register_fused_op(kFp8Dynamic128Sym, False, "rms_norm_per_block_quant")
 _register_fused_op(kFp8Dynamic128Sym, True, "rms_norm_per_block_quant")
 _register_fused_op(kFp8Dynamic64Sym, False, "rms_norm_per_block_quant")

--- a/vllm/compilation/passes/utility/fix_functionalization.py
+++ b/vllm/compilation/passes/utility/fix_functionalization.py
@@ -78,9 +78,7 @@ class FixFunctionalizationPass(VllmInductorPass):
         fused_add_rms_norm_static_fp8_quant = _get_c_op(
             "fused_add_rms_norm_static_fp8_quant"
         )
-        rms_norm_dynamic_per_token_quant = _get_c_op(
-            "rms_norm_dynamic_per_token_quant"
-        )
+        rms_norm_dynamic_per_token_quant = _get_c_op("rms_norm_dynamic_per_token_quant")
         rms_norm_targets = [
             op
             for op in (

--- a/vllm/model_executor/layers/fla/ops/chunk_scaled_dot_kkt.py
+++ b/vllm/model_executor/layers/fla/ops/chunk_scaled_dot_kkt.py
@@ -45,7 +45,9 @@ def _parse_int_list(env_name: str, default_vals: list[int]) -> list[int]:
     return out or default_vals
 
 
-_use_sm70_kkt_schedule = os.getenv("VLLM_SM70_GDN_KKT_SCHEDULE", "1") == "1" and _is_sm70()
+_use_sm70_kkt_schedule = (
+    os.getenv("VLLM_SM70_GDN_KKT_SCHEDULE", "1") == "1" and _is_sm70()
+)
 _kkt_configs = (
     [
         triton.Config({"BK": BK}, num_warps=num_warps, num_stages=num_stages)

--- a/vllm/model_executor/layers/fla/ops/fused_gdn_prefill_post_conv.py
+++ b/vllm/model_executor/layers/fla/ops/fused_gdn_prefill_post_conv.py
@@ -76,8 +76,7 @@ def _fused_post_conv_kernel(
 
         # Load Q features: mixed_qkv[t, i_h*K + k]
         q_offsets = (
-            offs_t[:, None] * stride_x_tok
-            + (i_h * K + offs_k[None, :]) * stride_x_feat
+            offs_t[:, None] * stride_x_tok + (i_h * K + offs_k[None, :]) * stride_x_feat
         )
         q_f32 = tl.load(mixed_qkv_ptr + q_offsets, mask=qk_mask_2d, other=0).to(
             tl.float32

--- a/vllm/model_executor/layers/fla/ops/fused_recurrent.py
+++ b/vllm/model_executor/layers/fla/ops/fused_recurrent.py
@@ -56,9 +56,7 @@ def _round_num_warps(value: int) -> int:
     return 8
 
 
-_SM70_FLA_RECURRENT_SCHEDULE = (
-    os.getenv("VLLM_SM70_FLA_RECURRENT_SCHEDULE", "1") == "1"
-)
+_SM70_FLA_RECURRENT_SCHEDULE = os.getenv("VLLM_SM70_FLA_RECURRENT_SCHEDULE", "1") == "1"
 _SM70_FLA_BV_OVERRIDE = _parse_positive_int_env("VLLM_SM70_FLA_BV")
 _SM70_FLA_WARPS_OVERRIDE = _parse_positive_int_env("VLLM_SM70_FLA_WARPS")
 _SM70_FLA_STAGES_OVERRIDE = _parse_positive_int_env("VLLM_SM70_FLA_STAGES")

--- a/vllm/model_executor/layers/quantization/auto_gptq.py
+++ b/vllm/model_executor/layers/quantization/auto_gptq.py
@@ -480,15 +480,11 @@ class AutoGPTQLinearMethod(LinearMethodBase):
                     group_size=self.quant_config.group_size,
                 )
                 layer.qweight = torch.nn.Parameter(
-                    torch.empty(
-                        0, dtype=torch.int32, device=layer.qweight.device
-                    ),
+                    torch.empty(0, dtype=torch.int32, device=layer.qweight.device),
                     requires_grad=False,
                 )
                 layer.qzeros = torch.nn.Parameter(
-                    torch.empty(
-                        0, dtype=torch.int32, device=layer.scales.device
-                    ),
+                    torch.empty(0, dtype=torch.int32, device=layer.scales.device),
                     requires_grad=False,
                 )
                 layer.scales = torch.nn.Parameter(
@@ -498,9 +494,7 @@ class AutoGPTQLinearMethod(LinearMethodBase):
                     requires_grad=False,
                 )
                 layer.g_idx = torch.nn.Parameter(
-                    torch.empty(
-                        0, dtype=torch.int32, device=layer.scales.device
-                    ),
+                    torch.empty(0, dtype=torch.int32, device=layer.scales.device),
                     requires_grad=False,
                 )
                 logger.info_once("SM70 GPTQ TurboMind dense path enabled.")

--- a/vllm/model_executor/layers/quantization/awq_marlin.py
+++ b/vllm/model_executor/layers/quantization/awq_marlin.py
@@ -610,9 +610,7 @@ class AWQMarlinLinearMethod(LinearMethodBase):
                 torch.empty(0, dtype=tm_scales.dtype, device=tm_weight.device),
                 requires_grad=False,
             )
-            logger.info_once(
-                "SM70 AWQ TurboMind dense path enabled under AWQ Marlin."
-            )
+            logger.info_once("SM70 AWQ TurboMind dense path enabled under AWQ Marlin.")
             return
 
         # AWQ checkpoints use a non-standard packing order and pack qweight

--- a/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_w4a16_nvfp4.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_w4a16_nvfp4.py
@@ -97,8 +97,7 @@ class CompressedTensorsW4A16Fp4(CompressedTensorsScheme):
             layer.weight, envs.VLLM_SM70_NVFP4_TURBOMIND
         ):
             logger.info_once(
-                "SM70 compressed-tensors NVFP4 TurboMind W4A16 dense path "
-                "enabled."
+                "SM70 compressed-tensors NVFP4 TurboMind W4A16 dense path enabled."
             )
             sm70_tm.prepare_nvfp4_linear(layer)
             layer.weight = Parameter(

--- a/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_w4a4_mxfp4.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_w4a4_mxfp4.py
@@ -108,15 +108,11 @@ class CompressedTensorsW4A4Mxfp4(CompressedTensorsScheme):
             )
             sm70_tm.prepare_mxfp4_linear(layer)
             layer.weight_packed = Parameter(
-                torch.empty(
-                    0, dtype=torch.uint8, device=layer.weight_packed.device
-                ),
+                torch.empty(0, dtype=torch.uint8, device=layer.weight_packed.device),
                 requires_grad=False,
             )
             layer.weight_scale = Parameter(
-                torch.empty(
-                    0, dtype=torch.uint8, device=layer.weight_scale.device
-                ),
+                torch.empty(0, dtype=torch.uint8, device=layer.weight_scale.device),
                 requires_grad=False,
             )
             return

--- a/vllm/model_executor/layers/quantization/input_quant_fp8.py
+++ b/vllm/model_executor/layers/quantization/input_quant_fp8.py
@@ -227,9 +227,7 @@ class QuantFP8(CustomOp):
             else:
                 x_max = x.abs().max().unsqueeze(-1).to(torch.float32)
 
-            scale = (x_max / self.fp8_max).clamp(
-                min=self.fp8_min_scaling_factor
-            )
+            scale = (x_max / self.fp8_max).clamp(min=self.fp8_min_scaling_factor)
         else:
             scale = prep_scale_for_group_broadcast(scale, x, self.group_shape)
 

--- a/vllm/model_executor/layers/quantization/utils/marlin_utils_fp4.py
+++ b/vllm/model_executor/layers/quantization/utils/marlin_utils_fp4.py
@@ -28,10 +28,7 @@ def is_fp4_marlin_supported():
         return False
     if current_platform.has_device_capability(75):
         return True
-    return (
-        current_platform.is_device_capability((7, 0))
-        and ops.sm70_marlin_available()
-    )
+    return current_platform.is_device_capability((7, 0)) and ops.sm70_marlin_available()
 
 
 def _nvfp4_compute_scale_factor(

--- a/vllm/model_executor/layers/quantization/utils/w8a8_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/w8a8_utils.py
@@ -22,8 +22,7 @@ def cutlass_fp8_supported() -> bool:
     capability_tuple = current_platform.get_device_capability()
     capability = -1 if capability_tuple is None else capability_tuple.to_int()
 
-    return _cutlass_capability_probe("cutlass_scaled_mm_supports_fp8",
-                                     capability)
+    return _cutlass_capability_probe("cutlass_scaled_mm_supports_fp8", capability)
 
 
 def cutlass_block_fp8_supported() -> bool:
@@ -33,8 +32,7 @@ def cutlass_block_fp8_supported() -> bool:
     capability_tuple = current_platform.get_device_capability()
     capability = -1 if capability_tuple is None else capability_tuple.to_int()
 
-    return _cutlass_capability_probe("cutlass_scaled_mm_supports_block_fp8",
-                                     capability)
+    return _cutlass_capability_probe("cutlass_scaled_mm_supports_block_fp8", capability)
 
 
 def cutlass_group_gemm_supported() -> bool:
@@ -44,8 +42,7 @@ def cutlass_group_gemm_supported() -> bool:
     capability_tuple = current_platform.get_device_capability()
     capability = -1 if capability_tuple is None else capability_tuple.to_int()
 
-    return _cutlass_capability_probe("cutlass_group_gemm_supported",
-                                     capability)
+    return _cutlass_capability_probe("cutlass_group_gemm_supported", capability)
 
 
 CUTLASS_FP8_SUPPORTED = cutlass_fp8_supported()

--- a/vllm/model_executor/models/config.py
+++ b/vllm/model_executor/models/config.py
@@ -361,9 +361,7 @@ class MambaModelConfig(VerifyAndUpdateConfig):
                     )
                 else:
                     cache_config.mamba_cache_mode = (
-                        "all"
-                        if model_config.supports_mamba_prefix_caching
-                        else "align"
+                        "all" if model_config.supports_mamba_prefix_caching else "align"
                     )
                     logger.warning(
                         "Mamba cache mode is set to '%s' for %s by default "

--- a/vllm/model_executor/models/qwen2_moe.py
+++ b/vllm/model_executor/models/qwen2_moe.py
@@ -149,9 +149,7 @@ class Qwen2MoeMLP(nn.Module):
         out = fused_act(x) if fused_act is not None else None
         if out is None:
             gate_up, _ = self.gate_up_proj(x)
-            gate_up = _sm70_dump_qwen_mlp_tensor(
-                "mlp_gate_up", self.layer_idx, gate_up
-            )
+            gate_up = _sm70_dump_qwen_mlp_tensor("mlp_gate_up", self.layer_idx, gate_up)
             out = self.act_fn(gate_up)
         out = _sm70_dump_qwen_mlp_tensor("mlp_silu_out", self.layer_idx, out)
         out, _ = self.down_proj(out)

--- a/vllm/model_executor/models/qwen3_5_mtp.py
+++ b/vllm/model_executor/models/qwen3_5_mtp.py
@@ -462,8 +462,7 @@ class Qwen3_5MTP(nn.Module, SupportsMultiModal):
                 )
 
             if modules_to_not_convert and any(
-                str(module) in ("mtp", "model.mtp")
-                for module in modules_to_not_convert
+                str(module) in ("mtp", "model.mtp") for module in modules_to_not_convert
             ):
                 return True
 

--- a/vllm/tool_parsers/qwen3coder_tool_parser.py
+++ b/vllm/tool_parsers/qwen3coder_tool_parser.py
@@ -358,10 +358,7 @@ class Qwen3CoderToolParser(ToolParser):
                 if pos != -1
             ]
             tool_start = min(tool_start_candidates) if tool_start_candidates else -1
-            if (
-                self.tool_call_start_token_id in delta_token_ids
-                or tool_start != -1
-            ):
+            if self.tool_call_start_token_id in delta_token_ids or tool_start != -1:
                 self.is_tool_call_started = True
                 # Return any content before the tool call
                 if tool_start > len(previous_text):

--- a/vllm/v1/attention/backends/ddtree_branch_triton.py
+++ b/vllm/v1/attention/backends/ddtree_branch_triton.py
@@ -77,10 +77,7 @@ def _ddtree_paged_attention_kernel(
     offs_d = tl.arange(0, BLOCK_D)
     d_mask = offs_d < head_size
     q_ptrs = (
-        query
-        + (q_start + row) * q_stride_t
-        + q_head * q_stride_h
-        + offs_d * q_stride_d
+        query + (q_start + row) * q_stride_t + q_head * q_stride_h + offs_d * q_stride_d
     )
     q_vec = tl.load(q_ptrs, mask=d_mask & active, other=0.0).to(tl.float32)
 
@@ -101,18 +98,10 @@ def _ddtree_paged_attention_kernel(
         for _ in range(max_q_len):
             cur_valid = active & (cur >= 0) & (cur < max_q_len) & (cur < q_len)
             visible = visible | (
-                (local == cur)
-                & (local >= 0)
-                & (local < q_len)
-                & n_mask
-                & cur_valid
+                (local == cur) & (local >= 0) & (local < q_len) & n_mask & cur_valid
             )
             safe_cur = tl.maximum(tl.minimum(cur, max_q_len - 1), 0)
-            parent_ptr = (
-                parent_ids
-                + req_i * parent_stride0
-                + safe_cur * parent_stride1
-            )
+            parent_ptr = parent_ids + req_i * parent_stride0 + safe_cur * parent_stride1
             parent = tl.load(parent_ptr, mask=cur_valid, other=0).to(tl.int32)
             # In vLLM DDTree metadata, -1 means "root child". The verifier has
             # a synthetic prefix/root row at local slot 0, so root children must
@@ -126,9 +115,7 @@ def _ddtree_paged_attention_kernel(
 
         block_offsets = offs_n - (offs_n // block_size) * block_size
         block_ptrs = (
-            block_table
-            + req_i * block_stride0
-            + (offs_n // block_size) * block_stride1
+            block_table + req_i * block_stride0 + (offs_n // block_size) * block_stride1
         )
         block_ids = tl.load(block_ptrs, mask=n_mask, other=0).to(tl.int64)
 

--- a/vllm/v1/attention/backends/fa_utils.py
+++ b/vllm/v1/attention/backends/fa_utils.py
@@ -17,6 +17,7 @@ _ROCM_FLASH_ATTN_AVAILABLE = False
 
 if current_platform.is_cuda():
     from vllm._custom_ops import reshape_and_cache_flash
+
     try:
         from vllm.vllm_flash_attn import (  # type: ignore[attr-defined]
             flash_attn_varlen_func,

--- a/vllm/v1/attention/backends/registry.py
+++ b/vllm/v1/attention/backends/registry.py
@@ -42,12 +42,8 @@ class AttentionBackendEnum(Enum, metaclass=_AttentionBackendEnumMeta):
     """
 
     FLASH_ATTN = "vllm.v1.attention.backends.flash_attn.FlashAttentionBackend"
-    FLASH_ATTN_V100 = (
-        "vllm.v1.attention.backends.flash_attn_v100.FlashAttnV100Backend"
-    )
-    FLASHINFER_SM70 = (
-        "vllm.v1.attention.backends.flashinfer_sm70.FlashInferSM70Backend"
-    )
+    FLASH_ATTN_V100 = "vllm.v1.attention.backends.flash_attn_v100.FlashAttnV100Backend"
+    FLASHINFER_SM70 = "vllm.v1.attention.backends.flashinfer_sm70.FlashInferSM70Backend"
     FLASH_ATTN_DIFFKV = (
         "vllm.v1.attention.backends.flash_attn_diffkv.FlashAttentionDiffKVBackend"
     )

--- a/vllm/v1/attention/ops/triton_prefill_attention.py
+++ b/vllm/v1/attention/ops/triton_prefill_attention.py
@@ -184,11 +184,7 @@ def get_block_size(dtype: torch.dtype, head_dim: int | None = None) -> int:
         80
     ):
         return 128
-    elif (
-        current_platform.is_cuda_alike()
-        and head_dim is not None
-        and head_dim >= 256
-    ):
+    elif current_platform.is_cuda_alike() and head_dim is not None and head_dim >= 256:
         # SM70/SM75 only expose 96KB shared memory per block. With head_dim=256,
         # BLOCK=64 requires 128KB in this Triton kernel.
         return 32

--- a/vllm/v1/attention/ops/triton_unified_attention.py
+++ b/vllm/v1/attention/ops/triton_unified_attention.py
@@ -558,9 +558,7 @@ def kernel_unified_attention(
             if PV_INPUT_PRECISION == "":
                 acc += tl.dot(P.to(V.dtype), V)
             else:
-                acc += tl.dot(
-                    P.to(V.dtype), V, input_precision=PV_INPUT_PRECISION
-                )
+                acc += tl.dot(P.to(V.dtype), V, input_precision=PV_INPUT_PRECISION)
 
     # ---- Epilogue ---------------------------------------------------------
     if IS_3D:
@@ -920,12 +918,8 @@ def unified_attention(
         sm70_prefill_tile_size = envs.VLLM_SM70_TRITON_ATTN_PREFILL_TILE_SIZE
         sm70_decode_tile_size = envs.VLLM_SM70_TRITON_ATTN_DECODE_TILE_SIZE
         sm70_num_warps = envs.VLLM_SM70_TRITON_ATTN_NUM_WARPS
-        sm70_prefill_num_warps = (
-            envs.VLLM_SM70_TRITON_ATTN_PREFILL_NUM_WARPS
-        )
-        sm70_decode_num_warps = (
-            envs.VLLM_SM70_TRITON_ATTN_DECODE_NUM_WARPS
-        )
+        sm70_prefill_num_warps = envs.VLLM_SM70_TRITON_ATTN_PREFILL_NUM_WARPS
+        sm70_decode_num_warps = envs.VLLM_SM70_TRITON_ATTN_DECODE_NUM_WARPS
         sm70_safe_defaults = envs.VLLM_SM70_TRITON_ATTN_SAFE_DEFAULTS
         sm70_qk_input_precision = _validate_sm70_triton_attn_input_precision(
             envs.VLLM_SM70_TRITON_ATTN_QK_INPUT_PRECISION,

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -461,9 +461,7 @@ class EngineCore:
         profile_sample_ms = 0.0
         profile_update_ms = 0.0
         if profile_ddtree_engine:
-            profile_step = getattr(
-                self, "_dflash_ddtree_engine_profile_step", 0
-            ) + 1
+            profile_step = getattr(self, "_dflash_ddtree_engine_profile_step", 0) + 1
             self._dflash_ddtree_engine_profile_step = profile_step
             profile_t0 = time.perf_counter()
 
@@ -478,9 +476,7 @@ class EngineCore:
             profile_part_t0 = time.perf_counter()
         future = self.model_executor.execute_model(scheduler_output, non_block=True)
         if profile_ddtree_engine:
-            profile_execute_submit_ms = (
-                time.perf_counter() - profile_part_t0
-            ) * 1000.0
+            profile_execute_submit_ms = (time.perf_counter() - profile_part_t0) * 1000.0
             profile_part_t0 = time.perf_counter()
         grammar_output = self.scheduler.get_grammar_bitmask(scheduler_output)
         if profile_ddtree_engine:
@@ -497,9 +493,7 @@ class EngineCore:
                 profile_part_t0 = time.perf_counter() if profile_ddtree_engine else 0.0
                 model_output = self.model_executor.sample_tokens(grammar_output)
                 if profile_ddtree_engine:
-                    profile_sample_ms = (
-                        time.perf_counter() - profile_part_t0
-                    ) * 1000.0
+                    profile_sample_ms = (time.perf_counter() - profile_part_t0) * 1000.0
 
         # Before processing the model output, process any aborts that happened
         # during the model execution.
@@ -611,9 +605,7 @@ class EngineCore:
             trace_schedule_t0 = time.perf_counter() if trace_log else 0.0
             scheduler_output = self.scheduler.schedule()
             if trace_log:
-                trace_schedule_ms = (
-                    time.perf_counter() - trace_schedule_t0
-                ) * 1000.0
+                trace_schedule_ms = (time.perf_counter() - trace_schedule_t0) * 1000.0
                 trace_scheduled_tokens = scheduler_output.total_num_scheduled_tokens
             with self.log_error_detail(scheduler_output):
                 trace_execute_t0 = time.perf_counter() if trace_log else 0.0

--- a/vllm/v1/sample/thinking_budget_state.py
+++ b/vllm/v1/sample/thinking_budget_state.py
@@ -153,9 +153,7 @@ class ThinkingBudgetStateHolder:
                 # the suffix that is present; stripping the full spec length in
                 # the repeated layout drops one real output token.
                 spec_suffix_len = (
-                    max(0, spec_len - 1)
-                    if last_row_for_req is not None
-                    else spec_len
+                    max(0, spec_len - 1) if last_row_for_req is not None else spec_len
                 )
                 # Only strip draft suffix when there are spec tokens; ``[:-0]`` would
                 # clear the whole list (Python treats stop index 0 as "up to empty").
@@ -163,9 +161,7 @@ class ThinkingBudgetStateHolder:
                     spec_suffix_len > 0
                     and len(state["output_tok_ids"]) >= spec_suffix_len
                 ):
-                    state["output_tok_ids"] = state["output_tok_ids"][
-                        :-spec_suffix_len
-                    ]
+                    state["output_tok_ids"] = state["output_tok_ids"][:-spec_suffix_len]
             self._update_think_state(state)
 
     def apply_to_logits(

--- a/vllm/v1/spec_decode/ddtree_metadata.py
+++ b/vllm/v1/spec_decode/ddtree_metadata.py
@@ -52,10 +52,10 @@ class DDTreeVerifierMetadata:
         tree_token_ids = tree.token_ids_for_verifier()
         parent_indices = tree.parent_indices_for_verifier()
         node_depths = tree.node_depths_for_verifier()
-        tree_position_ids = tuple(prompt_len + depth - 1
-                                  for depth in node_depths)
+        tree_position_ids = tuple(prompt_len + depth - 1 for depth in node_depths)
         compact_logits_indices = (prompt_len - 1,) + tuple(
-            prompt_len + offset for offset in range(len(tree_token_ids)))
+            prompt_len + offset for offset in range(len(tree_token_ids))
+        )
 
         edge_parent_compact_indices: list[int] = []
         node_compact_indices: list[int] = []
@@ -98,8 +98,7 @@ def _offset_parent_indices(
     parent_indices: tuple[int, ...],
     tree_start: int,
 ) -> list[int]:
-    return [parent if parent < 0 else parent + tree_start
-            for parent in parent_indices]
+    return [parent if parent < 0 else parent + tree_start for parent in parent_indices]
 
 
 def make_prefill_tree_attention_mask(
@@ -115,7 +114,7 @@ def make_prefill_tree_attention_mask(
     visible = torch.zeros((total_len, total_len), device=device, dtype=torch.bool)
 
     for row in range(prompt_len):
-        visible[row, :row + 1] = True
+        visible[row, : row + 1] = True
 
     for node in tree.non_root_nodes:
         row = prompt_len + node.index - 1
@@ -126,10 +125,9 @@ def make_prefill_tree_attention_mask(
             col = prompt_len + ancestor_index - 1
             visible[row, col] = True
 
-    mask = torch.full((total_len, total_len),
-                      torch.finfo(dtype).min,
-                      device=device,
-                      dtype=dtype)
+    mask = torch.full(
+        (total_len, total_len), torch.finfo(dtype).min, device=device, dtype=dtype
+    )
     mask.masked_fill_(visible, 0)
     return mask.unsqueeze(0).unsqueeze(0)
 
@@ -157,7 +155,8 @@ def make_batched_metadata(
 
     max_total_len = max(
         prompt_len + len(tree.non_root_nodes)
-        for prompt_len, tree in zip(prompt_lens, trees, strict=True))
+        for prompt_len, tree in zip(prompt_lens, trees, strict=True)
+    )
     tree_token_ids: list[int] = []
     parent_indices: list[int] = []
     node_depths: list[int] = []
@@ -172,15 +171,18 @@ def make_batched_metadata(
     for metadata in per_request:
         tree_token_ids.extend(metadata.tree_token_ids)
         parent_indices.extend(
-            _offset_parent_indices(metadata.parent_indices, tree_start))
+            _offset_parent_indices(metadata.parent_indices, tree_start)
+        )
         node_depths.extend(metadata.node_depths)
         compact_logits_indices.extend(
-            seq_start + index for index in metadata.compact_logits_indices)
+            seq_start + index for index in metadata.compact_logits_indices
+        )
         edge_parent_compact_indices.extend(
-            compact_start + index
-            for index in metadata.edge_parent_compact_indices)
+            compact_start + index for index in metadata.edge_parent_compact_indices
+        )
         node_compact_indices.extend(
-            compact_start + index for index in metadata.node_compact_indices)
+            compact_start + index for index in metadata.node_compact_indices
+        )
 
         row = list(metadata.all_position_ids())
         row.extend([0] * (max_total_len - len(row)))
@@ -192,24 +194,20 @@ def make_batched_metadata(
 
     return BatchedDDTreeVerifierMetadata(
         prompt_lens=tuple(prompt_lens),
-        tree_token_ids=torch.tensor(tree_token_ids, device=device,
-                                    dtype=torch.int32),
-        parent_indices=torch.tensor(parent_indices, device=device,
-                                    dtype=torch.int32),
+        tree_token_ids=torch.tensor(tree_token_ids, device=device, dtype=torch.int32),
+        parent_indices=torch.tensor(parent_indices, device=device, dtype=torch.int32),
         node_depths=torch.tensor(node_depths, device=device, dtype=torch.int32),
-        position_ids=torch.tensor(position_rows, device=device,
-                                  dtype=torch.long),
-        cu_num_tree_nodes=torch.tensor(cu_nodes, device=device,
-                                       dtype=torch.int32),
-        compact_logits_indices=torch.tensor(compact_logits_indices,
-                                            device=device,
-                                            dtype=torch.int32),
-        edge_parent_compact_indices=torch.tensor(edge_parent_compact_indices,
-                                                 device=device,
-                                                 dtype=torch.int32),
-        node_compact_indices=torch.tensor(node_compact_indices,
-                                          device=device,
-                                          dtype=torch.int32),
+        position_ids=torch.tensor(position_rows, device=device, dtype=torch.long),
+        cu_num_tree_nodes=torch.tensor(cu_nodes, device=device, dtype=torch.int32),
+        compact_logits_indices=torch.tensor(
+            compact_logits_indices, device=device, dtype=torch.int32
+        ),
+        edge_parent_compact_indices=torch.tensor(
+            edge_parent_compact_indices, device=device, dtype=torch.int32
+        ),
+        node_compact_indices=torch.tensor(
+            node_compact_indices, device=device, dtype=torch.int32
+        ),
     )
 
 
@@ -226,7 +224,8 @@ def greedy_sample_from_compact_logits(
     if compact_logits.shape[0] != expected_rows:
         raise ValueError(
             f"compact_logits row mismatch: expected {expected_rows}, "
-            f"got {compact_logits.shape[0]}")
+            f"got {compact_logits.shape[0]}"
+        )
 
     target_argmax = compact_logits.argmax(dim=-1)
     path_to_compact_index: dict[tuple[int, ...], int] = {(): 0}
@@ -252,7 +251,8 @@ def greedy_sample_from_compact_top_tokens(
     if compact_top_tokens.shape[0] != expected_rows:
         raise ValueError(
             f"compact_top_tokens row mismatch: expected {expected_rows}, "
-            f"got {compact_top_tokens.shape[0]}")
+            f"got {compact_top_tokens.shape[0]}"
+        )
 
     target_tokens = compact_top_tokens.detach().cpu().tolist()
     path_to_compact_index: dict[tuple[int, ...], int] = {(): 0}

--- a/vllm/v1/worker/block_table.py
+++ b/vllm/v1/worker/block_table.py
@@ -104,9 +104,7 @@ class BlockTable:
         self.cp_kv_cache_interleave_size = cp_kv_cache_interleave_size
 
     def _mark_dirty(self, row_idx: int) -> None:
-        self._block_table_dirty_until = max(
-            self._block_table_dirty_until, row_idx + 1
-        )
+        self._block_table_dirty_until = max(self._block_table_dirty_until, row_idx + 1)
 
     def append_row(
         self,


### PR DESCRIPTION
## Purpose

Restore a deterministic whole-repository pre-commit baseline on the latest main, so feature PRs are judged on their own diffs instead of inherited repository failures.

- format accumulated Python, CUDA/C++, tests, and Markdown violations
- exclude only the bundled TurboMind upstream snapshot from repository-owned linting
- replace the racy local shellcheck downloader with pinned shellcheck-py
- keep shellcheck errors blocking while leaving legacy warning cleanup out of this baseline
- admit explicit standalone SM70/DSpark CUDA benchmark and operator-test namespaces
- admit the DeepSeek-V4 AOT inspection benchmark to use Triton compiler/backend APIs
- refresh the docs lock annotation and fix one local variable spelling

## Source audit

- Python AST comparison is identical for every auto-formatted Python file.
- The only intended Python AST changes are the two project-required regex-as-re imports and the two pre-commit policy files.
- CUDA/C++ token comparison, after normalizing comments, macro continuations, sorted namespace using declarations, and adjacent string literals, is identical for every formatted file.
- The only CUDA/C++ token change is the local rename physical_offset_halfs to physical_offset_halves, with both references updated.
- git diff --check passes.

## Test plan and result

- pre-commit run -a: passed all hooks
- includes ruff, clang-format, markdownlint, shellcheck, dependency locks, Python 3.10 mypy, SPDX, forbidden imports, torch CUDA API policy, config validation, Rust format, and repository-specific checks
- targeted clang-format check for csrc/sm70_turbomind/ops/tm_registry_sm70.cu passed after normalizing the pre-existing CRLF file
- no end-to-end model run: this PR changes static policy and formatting, not inference behavior
