### PR TITLE
[Kernel][SM70] Fold DeepSeek V4 MXFP4 decode exponents

### DIFF
--- a/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/attention/quantization.h
+++ b/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/attention/quantization.h
@@ -723,6 +723,7 @@ struct ConvertKvCache<fp4_e2m1_t, T> {
     return (Array<bfloat16_t, 8>&)vo;
   }
 
+  template <bool ApplyExponentBias = true>
   __device__ static Array<half, 8> cvt_f16x8_e2m1(
       const Array<fp4_e2m1_t, 8>& vi) {
     const uint32_t& x = (const uint32_t&)vi;
@@ -739,12 +740,16 @@ struct ConvertKvCache<fp4_e2m1_t, T> {
         vo[3] = (x <<  0 & S) | (x >> 3 & EM);
     // clang-format on
 
-    constexpr uint32_t e = (15U - 1U + 15U) << 10U;
-    constexpr uint32_t ee = e << 16U | e;
+    if constexpr (ApplyExponentBias) {
+      constexpr uint32_t e = (15U - 1U + 15U) << 10U;
+      constexpr uint32_t ee = e << 16U | e;
 
-    PRAGMA_UNROLL
-    for (int i = 0; i < 4; ++i) {
-      asm volatile("mul.f16x2 %0, %1, %2;" : "=r"(vo[i]) : "r"(vo[i]), "r"(ee));
+      PRAGMA_UNROLL
+      for (int i = 0; i < 4; ++i) {
+        asm volatile("mul.f16x2 %0, %1, %2;"
+                     : "=r"(vo[i])
+                     : "r"(vo[i]), "r"(ee));
+      }
     }
 
     return (Array<half, 8>&)vo;
@@ -759,7 +764,7 @@ struct ConvertKvCache<fp4_e2m1_t, T> {
       if constexpr (std::is_same_v<T, bfloat16_t>) {
         v = cvt_bf16x8_e2m1((Array<fp4_e2m1_t, 8>&)vi[i]);
       } else if constexpr (std::is_same_v<T, half_t>) {
-        v = cvt_f16x8_e2m1((Array<fp4_e2m1_t, 8>&)vi[i]);
+        v = cvt_f16x8_e2m1<true>((Array<fp4_e2m1_t, 8>&)vi[i]);
       } else {
         static_assert(N != N, "not implemented");
       }

--- a/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/arch/config_sm70_s884.h
+++ b/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/arch/config_sm70_s884.h
@@ -120,6 +120,18 @@ using Config_MXF4 = Sm70_s884<Operand_A<half>,             // A
                               raster_order, group_axis>;
 
 template <Order raster_order, int group_axis = -1>
+using Config_MXF4_ExponentFolded =
+    Sm70_s884<Operand_A<half>,             // A
+              Transform_Default,           // transform A
+              VoidOperand,                 // U
+              Operand_B_Pack<fp4_e2m1_t>,  // B
+              Transform_HMMA_SIMT_B_ExponentFoldedE2M1,
+              Operand_V_Pack<uint8_t>,  // adjusted UE8M0 V
+              kRowMajor,                // order_C
+              half,                     // Tc
+              raster_order, group_axis>;
+
+template <Order raster_order, int group_axis = -1>
 using Config_NVF4 = Sm70_s884<Operand_A<half>,             // A
                               Transform_Default,           // tarnsform A
                               VoidOperand,                 // U

--- a/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/gemm.cu
+++ b/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/gemm.cu
@@ -366,13 +366,15 @@ const char* ToString(DispatchPolicy policy) {
   if ((policy & DispatchPolicy::kPreserveDefaultSplits) ||
       (policy & DispatchPolicy::kPreserveDefaultSplitCount) ||
       (policy & DispatchPolicy::kMxfp4MoeGroupedM8Fast) ||
-      (policy & DispatchPolicy::kSm70Fp8PrefillPrescaled)) {
+      (policy & DispatchPolicy::kSm70Fp8PrefillPrescaled) ||
+      (policy & DispatchPolicy::kSm70Mxfp4ExponentFolded)) {
     static thread_local std::string text;
     auto base = static_cast<DispatchPolicy>(
         (int)policy & ~(int)DispatchPolicy::kPreserveDefaultSplits &
         ~(int)DispatchPolicy::kPreserveDefaultSplitCount &
         ~(int)DispatchPolicy::kMxfp4MoeGroupedM8Fast &
-        ~(int)DispatchPolicy::kSm70Fp8PrefillPrescaled);
+        ~(int)DispatchPolicy::kSm70Fp8PrefillPrescaled &
+        ~(int)DispatchPolicy::kSm70Mxfp4ExponentFolded);
     text = std::string(ToString(base));
     if (policy & DispatchPolicy::kPreserveDefaultSplits) {
       text += "|preserve_default_splits";
@@ -385,6 +387,9 @@ const char* ToString(DispatchPolicy policy) {
     }
     if (policy & DispatchPolicy::kSm70Fp8PrefillPrescaled) {
       text += "|sm70_fp8_prefill_prescaled";
+    }
+    if (policy & DispatchPolicy::kSm70Mxfp4ExponentFolded) {
+      text += "|sm70_mxfp4_exponent_folded";
     }
     return text.c_str();
   }
@@ -444,7 +449,8 @@ struct Gemm::Impl {
         arch_{props_->major * 100 + props_->minor * 10},
         registry_{props_},
         cache_{registry_.kernels()},
-        sm70_fp8_prefill_cache_{registry_.kernels()} {
+        sm70_fp8_prefill_cache_{registry_.kernels()},
+        sm70_mxfp4_exponent_folded_cache_{registry_.kernels()} {
     if (arch_ == 700) {
       // V100 decode is dominated by many tiny GEMM/GEMV problems. A
       // broader search space consistently finds better launch specs than
@@ -478,13 +484,19 @@ struct Gemm::Impl {
   LaunchSpec Dispatch(Context& ctx, DispatchPolicy policy, size_t barriers_size,
                       size_t partials_size) {
     const auto& desc = ctx.desc();
-    const bool allow_prescaled =
+    const bool allow_fp8_prescaled =
         policy & DispatchPolicy::kSm70Fp8PrefillPrescaled;
+    const bool allow_mxfp4_exponent_folded =
+        policy & DispatchPolicy::kSm70Mxfp4ExponentFolded;
     const auto is_feasible = [&](const LaunchSpec& spec) {
-      return spec.kernel &&
-             (allow_prescaled ||
-              spec.kernel->name().find("_sm70_fp8_pscale") ==
-                  std::string::npos) &&
+      if (!spec.kernel) {
+        return false;
+      }
+      const auto& name = spec.kernel->name();
+      return (allow_fp8_prescaled ||
+              name.find("_sm70_fp8_pscale") == std::string::npos) &&
+             (allow_mxfp4_exponent_folded ||
+              name.find("_sm70_mxfp4_efold") == std::string::npos) &&
              spec.kernel->is_feasible(ctx.get_desc(*spec.kernel));
     };
     if (policy & DispatchPolicy::kSm70Fp8PrefillPrescaled) {
@@ -498,6 +510,34 @@ struct Gemm::Impl {
                 ctx, specs, *fast_target, barriers_size, partials_size)) {
           sm70_fp8_prefill_cache_.Insert(desc, *fast_spec);
           return *fast_spec;
+        }
+      }
+      return {};
+    }
+    if (policy & DispatchPolicy::kSm70Mxfp4ExponentFolded) {
+      if (auto spec = sm70_mxfp4_exponent_folded_cache_.Find(desc);
+          spec && is_feasible(*spec)) {
+        return *spec;
+      }
+      // The exponent fold is bitwise exact only when the reduction order is
+      // unchanged. Reuse the already measured ordinary launch geometry and
+      // replace only its input transform; do not independently retune splits,
+      // swizzle, or CTA shape.
+      if (auto baseline = cache_.Find(desc); baseline && baseline->kernel) {
+        const std::string folded_name =
+            baseline->kernel->name() + "_sm70_mxfp4_efold_dsv4_m6";
+        auto kernels = ctx.Filter(registry_.kernels());
+        auto match = std::find_if(
+            kernels.begin(), kernels.end(), [&](const Kernel* kernel) {
+              return kernel->name() == folded_name;
+            });
+        if (match != kernels.end()) {
+          auto folded = *baseline;
+          folded.kernel = *match;
+          if (is_feasible(folded)) {
+            sm70_mxfp4_exponent_folded_cache_.Insert(desc, folded);
+            return folded;
+          }
         }
       }
       return {};
@@ -546,15 +586,20 @@ struct Gemm::Impl {
 
   std::vector<LaunchSpec> Find(Context& ctx, size_t barrier_size,
                                size_t partials_size, int top_k,
-                               bool include_prescaled) {
+                               bool include_fp8_prescaled) {
     std::vector<Kernel*> feasible = ctx.Filter(registry_.kernels());
-    if (!include_prescaled) {
+    if (!include_fp8_prescaled) {
       feasible.erase(
           std::remove_if(feasible.begin(), feasible.end(), [](const Kernel* k) {
             return k->name().find("_sm70_fp8_pscale") != std::string::npos;
           }),
           feasible.end());
     }
+    feasible.erase(
+        std::remove_if(feasible.begin(), feasible.end(), [](const Kernel* k) {
+          return k->name().find("_sm70_mxfp4_efold") != std::string::npos;
+        }),
+        feasible.end());
 
     std::vector<std::vector<LaunchSpec>> clusters;
     {
@@ -704,6 +749,8 @@ struct Gemm::Impl {
 
   DispatchCache sm70_fp8_prefill_cache_;
 
+  DispatchCache sm70_mxfp4_exponent_folded_cache_;
+
   std::mutex dispatch_mutex_;
 };
 
@@ -761,7 +808,8 @@ int Gemm::Run(const Operation& operation, float alpha, const void* A,
 
 #if 0
     if (operation.reserved) {
-        auto specs = impl_->Find(context, workspace.barriers_size, workspace.partials_size, 0);
+        auto specs = impl_->Find(context, workspace.barriers_size,
+                                 workspace.partials_size, 0, false);
         auto cases = (std::vector<std::function<LaunchSpec()>>*)operation.reserved;
         for (const auto& spec : specs) {
             cases->push_back([=] {
@@ -779,6 +827,8 @@ int Gemm::Run(const Operation& operation, float alpha, const void* A,
   {
     std::lock_guard<std::mutex> lock(impl_->dispatch_mutex_);
     if (measured) {
+      // Measure the accepted ordinary MXFP4 tactic even for exponent-folded
+      // execution. Dispatch then swaps only the transform implementation.
       impl_->Measure(*dispatch_context, workspace.barriers_size,
                      workspace.partials_size, 1, launch, stream);
     }

--- a/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/kernel/sm70_884_4.cu
+++ b/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/kernel/sm70_884_4.cu
@@ -32,6 +32,22 @@ class ExactMnkKernelImpl final : public KernelImpl<Gemm> {
   }
 };
 
+template <class Gemm>
+class Dsv4ExponentFoldedM6KernelImpl final : public KernelImpl<Gemm> {
+ public:
+  Dsv4ExponentFoldedM6KernelImpl() {
+    this->info_.name += "_sm70_mxfp4_efold_dsv4_m6";
+  }
+
+  bool is_feasible(const GemmDesc& desc) const noexcept override {
+    const bool accepted_shape =
+        (desc.n == 1024 && desc.k == 4096) ||
+        (desc.n == 4096 && desc.k == 512);
+    return desc.m == 6 && desc.num == 1 && accepted_shape &&
+           KernelImpl<Gemm>::is_feasible(desc);
+  }
+};
+
 }  // namespace
 
 void Registry::sm70_884_4() {
@@ -107,6 +123,25 @@ void Registry::sm70_884_4() {
         Add<C::Type< 32, 128,  32, 1, 4, 1, D, S, 2, true, 1, 32>>();
         Add<C::Type< 16, 128,  32, 1, 4, 1, D, S, 2, true, 1, 32>>();
         Add<C::Type<  8, 128,  64, 1, 4, 1, D, S, 2, true, 1, 32>>();
+    // clang-format on
+  }
+
+  if constexpr (1) {
+    // Preserve the complete M=6 tactic search space. Dispatch maps the
+    // measured ordinary tactic to its exact folded counterpart and stores it
+    // separately, so this route cannot poison ordinary MXFP4 selection.
+    // clang-format off
+        using C = Config_MXF4_ExponentFolded<kColMajor, 0>;
+        using C128 = C::Type<128, 128, 16, 2, 2, 1, D, D, 2, true, 1, 32, 64, 128>;
+        using C64  = C::Type< 64, 128, 32, 1, 4, 1, D, S, 2, true, 1, 32, 32, 128>;
+        using C32  = C::Type< 32, 128, 32, 1, 4, 1, D, S, 2, true, 1, 32>;
+        using C16  = C::Type< 16, 128, 32, 1, 4, 1, D, S, 2, true, 1, 32>;
+        using C8   = C::Type<  8, 128, 64, 1, 4, 1, D, S, 2, true, 1, 32>;
+        Add(std::make_unique<Dsv4ExponentFoldedM6KernelImpl<typename C128::Kernel>>());
+        Add(std::make_unique<Dsv4ExponentFoldedM6KernelImpl<typename C64::Kernel>>());
+        Add(std::make_unique<Dsv4ExponentFoldedM6KernelImpl<typename C32::Kernel>>());
+        Add(std::make_unique<Dsv4ExponentFoldedM6KernelImpl<typename C16::Kernel>>());
+        Add(std::make_unique<Dsv4ExponentFoldedM6KernelImpl<typename C8::Kernel>>());
     // clang-format on
   }
 

--- a/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/transform.h
+++ b/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/transform.h
@@ -190,4 +190,47 @@ struct Transform_HMMA_SIMT_B_PrescaledE4M3 {
   }
 };
 
+// DeepSeek V4's adjusted UE8M0 scale exponents are in [2, 14]. Folding the
+// E2M1 conversion factor (2^14) into that exponent removes the fragment-wide
+// half2 multiply while preserving every FP16 bit. The exact decode route
+// validates the scale range once during model loading.
+struct Transform_HMMA_SIMT_B_ExponentFoldedE2M1 {
+  template <class F, int Nf, int Mf, int K, class D, int Nd, int Md, class S,
+            int Ns, int Ms, int Ks>
+  __device__ static void apply(Array<F, Nf> (&frag)[K][Mf], int k,
+                               Array<D, Nd> (&data)[K][Md],
+                               Array<S, Ns> (&stat)[Ks][Ms], int div) {
+    static_assert(std::is_same_v<D, fp4_e2m1_t>);
+    static_assert(std::is_same_v<F, half>);
+    static_assert(std::is_same_v<S, uint8_t>);
+    static_assert(Nf * Mf == Nd * Md);
+    static_assert(Nd % Nf == 0 && Mf % Md == 0);
+    static_assert(Nd % 8 == 0);
+
+    auto& frag_k = reinterpret_cast<Array<F, Nd>(&)[Md]>(frag[k]);
+    auto& stat_k = reinterpret_cast<Array<S, 1>(&)[Ns * Ms]>(stat[k / div]);
+    auto& data_k = data[k];
+
+    PRAGMA_UNROLL
+    for (int m = 0; m < Md; ++m) {
+      Array<F, Nd> tmp;
+      PRAGMA_UNROLL
+      for (int i = 0; i < Nd; i += 8) {
+        auto& src = reinterpret_cast<Array<fp4_e2m1_t, 8>&>(data_k[m][i]);
+        reinterpret_cast<Array<half, 8>&>(tmp[i]) =
+            ConvertKvCache<fp4_e2m1_t, half>::cvt_f16x8_e2m1<false>(src);
+      }
+      PRAGMA_UNROLL
+      for (int i = 0; i < Nd; i += 2) {
+        const uint16_t exponent =
+            static_cast<uint16_t>(stat_k[(m * Nd + i) / Nf][0]) + 14U;
+        const auto scale = __ushort_as_half(exponent << 10U);
+        tmp[i] = __hmul(tmp[i], scale);
+        tmp[i + 1] = __hmul(tmp[i + 1], scale);
+      }
+      frag_k[m] = tmp;
+    }
+  }
+};
+
 }  // namespace turbomind::gemm

--- a/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/types.h
+++ b/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/types.h
@@ -139,6 +139,7 @@ enum class DispatchPolicy : int {
   kPreserveDefaultSplitCount = 8,
   kMxfp4MoeGroupedM8Fast = 16,
   kSm70Fp8PrefillPrescaled = 32,
+  kSm70Mxfp4ExponentFolded = 64,
 };
 
 constexpr bool operator&(const DispatchPolicy& a, const DispatchPolicy& b) {

--- a/csrc/sm70_turbomind/ops/awq_sm70_gemm.cu
+++ b/csrc/sm70_turbomind/ops/awq_sm70_gemm.cu
@@ -1082,6 +1082,12 @@ bool mxfp4_moe_broadcast_input_decode_enabled() {
   return raw == nullptr || std::atoi(raw) != 0;
 }
 
+bool mxfp4_moe_exponent_folded_decode_enabled() {
+  const char* raw =
+      std::getenv("VLLM_SM70_DSV4_MXFP4_EXPONENT_FOLD_DECODE");
+  return raw != nullptr && std::atoi(raw) != 0;
+}
+
 bool mxfp4_moe_grouped_m8_enabled() {
   const char* raw = std::getenv("VLLM_SM70_MXFP4_MOE_GROUPED_M8");
   return raw != nullptr && std::atoi(raw) != 0;
@@ -8248,6 +8254,21 @@ void mxfp4_moe_gemm_sm70_out_impl(
       device, static_cast<int>(total_tokens), static_cast<int>(n),
       static_cast<int>(k), static_cast<int>(num_experts),
       static_cast<int>(group_size), stream);
+  const bool exact_dsv4_exponent_fold_decode =
+      compact_grouped_rows && total_tokens == 6 && num_experts == 6 &&
+      group_size == 32 &&
+      ((n == 1024 && k == 4096) || (n == 4096 && k == 512)) &&
+      vllm::awq_sm70::mxfp4_moe_exponent_folded_decode_enabled();
+  if (exact_dsv4_exponent_fold_decode) {
+    op.dispatch =
+        op.dispatch |
+        turbomind::gemm::DispatchPolicy::kSm70Mxfp4ExponentFolded;
+    static std::atomic<unsigned> logged_mxfp4_exponent_folded{0u};
+    maybe_log_sm70_moe_route_once(
+        logged_mxfp4_exponent_folded,
+        "Exact SM70 DeepSeek V4 MXFP4 exponent-folded decode path enabled",
+        sorted_input, total_tokens, num_experts);
+  }
   op.epilogue = turbomind::gemm::Epilogue::kNone;
   op.quant_a = {turbomind::gemm::QuantType::kNone, 0};
   op.quant_b = {turbomind::gemm::QuantType::kK, static_cast<int>(group_size)};

--- a/docs/design/sm70_v100_migration_control.md
+++ b/docs/design/sm70_v100_migration_control.md
@@ -43624,3 +43624,41 @@ Interpretation:
   original TurboMind transform. The route is opt-in through
   `VLLM_SM70_DSV4_FP8_PRESCALED_DECODE=1` until matched full-model speed and
   pinned dataset gates complete.
+
+## 2026-08-26 DeepSeek V4 exact MXFP4 exponent-fold decode screen
+
+- The E2M1 SM70 transform constructs an exact FP16 value scaled by `2^-14`,
+  multiplies by `2^14`, then applies the adjusted UE8M0 group scale. The new
+  transform adds 14 to the scale exponent and omits the first half2 multiply.
+  A full checkpoint mmap audit covers all 35,718 scale tensors and
+  9,261,408,000 E8M0 bytes: raw exponents are 114--126, their existing
+  adjusted FP16 exponents are 2--14, and folded exponents are 16--28. No
+  value reaches zero, INF, or the clamping boundary. All 16 signed E2M1 codes
+  across the 13 observed exponent values pass 208/208 CPU FP16 bit-pattern
+  comparisons.
+- Independently retuning the folded kernel is rejected even though the local
+  decode is numerically close: its different split-K choices alter FP32
+  reduction order. The accepted dispatcher first measures the ordinary
+  TurboMind tactic, finds the folded kernel with the identical base name, and
+  copies its CTA, split count, and swizzle verbatim. Only the input transform
+  changes; the ordinary and folded launch caches remain separate.
+- The fair pipeline-first CUDA Graph screen uses real layer-0 TP4-rank-0
+  weights for six routed experts. Across 64 changing inputs at scales
+  0.01/0.1/1/4, W13, SwiGLU activation, and W2 are bitwise equal on every
+  replay. A/B/B/A medians move the complete W13+activation+W2 graph from
+  95.141 to 53.163 microseconds, saving 41.978 microseconds per layer or a
+  1.805 ms/token 43-layer service projection. The final extension SHA256 is
+  `5b8cd4cd5796b8180b6e209c5737df753fd08c4118cbc3363741dce65785e2e6`;
+  evidence is under
+  `/data/models/v100-dsv4-0731-pp2tp4-mxfp4-exponent-fold-screen-20260826-r4/`.
+  Screens that capture isolated W13 graphs before the pipeline are not used;
+  that capture order changes the later graph state and hides the endpoint-like
+  delta.
+- Admission is opt-in through
+  `VLLM_SM70_DSV4_MXFP4_EXPONENT_FOLD_DECODE=1` and requires the exact SM70
+  DeepSeek V4 PP2 x TP4, no-speculation, max-one-sequence direct-top6 and
+  direct-order M=6 shapes `(K4096,N1024)` and `(K512,N4096)`. Model loading
+  validates every prepared scale exponent in `[1,16]` and fails closed on any
+  unsupported checkpoint. Prefill, verifier rows, other shapes, and ordinary
+  MXFP4 dispatch remain unchanged. Matched full-model speed and GSM8K-64 gates
+  are still required before acceptance.

--- a/tests/quantization/test_sm70_mxfp4_moe.py
+++ b/tests/quantization/test_sm70_mxfp4_moe.py
@@ -23,9 +23,48 @@ from vllm.model_executor.layers.quantization.mxfp4_sm70_moe import (
     Mxfp4SM70MoEMethod,
     _compact_mxfp4_active_experts,
     _select_mxfp4_stage_dispatch,
+    _validate_mxfp4_exponent_fold_scales,
     validate_mxfp4_sm70_moe_contract,
     validate_mxfp4_sm70_moe_weight_layout,
 )
+
+
+def test_mxfp4_exponent_fold_accepts_finite_adjusted_scale_range():
+    _validate_mxfp4_exponent_fold_scales(
+        scales=torch.tensor([1, 2, 14, 16], dtype=torch.uint8)
+    )
+
+
+@pytest.mark.parametrize("bad_exponent", [0, 17, 30])
+def test_mxfp4_exponent_fold_rejects_unsafe_adjusted_scale_range(
+    bad_exponent: int,
+):
+    with pytest.raises(RuntimeError, match=r"requires adjusted UE8M0.*\[1, 16\]"):
+        _validate_mxfp4_exponent_fold_scales(
+            scales=torch.tensor([bad_exponent], dtype=torch.uint8)
+        )
+
+
+def test_mxfp4_exponent_fold_is_bitwise_exact_for_all_e2m1_codes():
+    # The checkpoint-wide audit constrains the adjusted exponents to [2, 14].
+    # Cover both signs and all eight E2M1 exponent/mantissa bit patterns.
+    for code in range(16):
+        raw_bits = ((code >> 3) << 15) | ((code & 7) << 9)
+        raw = torch.tensor([raw_bits], dtype=torch.uint16).view(torch.float16)
+        bias = torch.tensor([29 << 10], dtype=torch.uint16).view(torch.float16)
+        decoded = raw * bias
+        for exponent in range(2, 15):
+            scale = torch.tensor(
+                [exponent << 10], dtype=torch.uint16
+            ).view(torch.float16)
+            folded_scale = torch.tensor(
+                [(exponent + 14) << 10], dtype=torch.uint16
+            ).view(torch.float16)
+            reference = decoded * scale
+            folded = raw * folded_scale
+            assert torch.equal(
+                reference.view(torch.uint16), folded.view(torch.uint16)
+            )
 
 
 def _v4_flash_moe_config() -> FusedMoEConfig:

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -254,6 +254,7 @@ if TYPE_CHECKING:
     VLLM_SM70_MXFP4_MOE_GROUPED_M8_FAST_SELECTOR: bool = True
     VLLM_SM70_MXFP4_MOE_DIRECT_TOP6_DECODE: bool = False
     VLLM_SM70_MXFP4_MOE_DIRECT_ORDER_DECODE: bool = False
+    VLLM_SM70_DSV4_MXFP4_EXPONENT_FOLD_DECODE: bool = False
     VLLM_SM70_MXFP4_MOE_BROADCAST_INPUT_DECODE: bool = True
     VLLM_SM70_DSV4_SPARSE_MLA_SPLITK_SWA: bool = False
     VLLM_SM70_DSV4_SPARSE_MLA_SPLITK_C4: bool = False
@@ -2215,6 +2216,9 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # quality acceptance are complete.
     "VLLM_SM70_MXFP4_MOE_DIRECT_ORDER_DECODE": lambda: bool(
         int(os.getenv("VLLM_SM70_MXFP4_MOE_DIRECT_ORDER_DECODE", "0"))
+    ),
+    "VLLM_SM70_DSV4_MXFP4_EXPONENT_FOLD_DECODE": lambda: bool(
+        int(os.getenv("VLLM_SM70_DSV4_MXFP4_EXPONENT_FOLD_DECODE", "0"))
     ),
     "VLLM_SM70_MXFP4_MOE_BROADCAST_INPUT_DECODE": lambda: bool(
         int(os.getenv("VLLM_SM70_MXFP4_MOE_BROADCAST_INPUT_DECODE", "1"))

--- a/vllm/model_executor/layers/quantization/mxfp4_sm70_moe.py
+++ b/vllm/model_executor/layers/quantization/mxfp4_sm70_moe.py
@@ -16,6 +16,7 @@ from torch.nn import Parameter
 
 from vllm import _sm70_ops as sm70_ops
 from vllm import envs
+from vllm.config import get_current_vllm_config
 from vllm.logger import init_logger
 from vllm.model_executor.layers.fused_moe import (
     FusedMoEConfig,
@@ -83,6 +84,41 @@ def _mxfp4_grouped_m8_expert_rows_enabled() -> bool:
         (_mxfp4_grouped_m8_enabled() or _mxfp4_grouped_verifier_enabled())
         and envs.VLLM_SM70_MXFP4_MOE_GROUPED_M8_EXPERT_ROWS
     )
+
+
+def _mxfp4_exponent_fold_decode_runtime_contract() -> bool:
+    """Admit only the measured PP2 x TP4 no-spec B1 direct-order lane."""
+    vllm_config = get_current_vllm_config()
+    parallel_config = vllm_config.parallel_config
+    scheduler_config = vllm_config.scheduler_config
+    return bool(
+        envs.VLLM_SM70_MXFP4_MOE_DIRECT_TOP6_DECODE
+        and envs.VLLM_SM70_MXFP4_MOE_DIRECT_ORDER_DECODE
+        and parallel_config.pipeline_parallel_size == 2
+        and parallel_config.tensor_parallel_size == 4
+        and scheduler_config.max_num_seqs == 1
+        and not getattr(parallel_config, "enable_dbo", False)
+        and int(getattr(parallel_config, "ubatch_size", 0)) <= 1
+        and getattr(vllm_config, "speculative_config", None) is None
+    )
+
+
+def _validate_mxfp4_exponent_fold_scales(
+    **named_scales: torch.Tensor,
+) -> None:
+    """Prove that adding 14 keeps every adjusted UE8M0 exponent finite."""
+    for name, scales in named_scales.items():
+        if scales.dtype != torch.uint8:
+            raise TypeError(f"{name} must contain adjusted UE8M0 bytes")
+        minimum, maximum = torch.aminmax(scales)
+        min_exponent = int(minimum.item())
+        max_exponent = int(maximum.item())
+        if min_exponent < 1 or max_exponent > 16:
+            raise RuntimeError(
+                "Exact SM70 MXFP4 exponent folding requires adjusted UE8M0 "
+                f"exponents in [1, 16]; {name} has "
+                f"[{min_exponent}, {max_exponent}]."
+            )
 
 
 @triton.jit
@@ -336,6 +372,18 @@ class Mxfp4SM70MoEMethod(Mxfp4MoEMethod):
         return hidden_size, intermediate_size_per_partition
 
     def process_weights_after_loading(self, layer: RoutedExperts) -> None:
+        use_exponent_fold_decode = bool(
+            envs.VLLM_SM70_DSV4_MXFP4_EXPONENT_FOLD_DECODE
+        )
+        if (
+            use_exponent_fold_decode
+            and not _mxfp4_exponent_fold_decode_runtime_contract()
+        ):
+            raise RuntimeError(
+                "VLLM_SM70_DSV4_MXFP4_EXPONENT_FOLD_DECODE=1 requires "
+                "DeepSeek V4 PP2 x TP4, max_num_seqs=1, no speculation, "
+                "and the direct-top6/direct-order decode route."
+            )
         required_ops: tuple[str, ...] = (
             "mxfp4_sm70_prepare",
             "mxfp4_moe_dense_stage_sm70_out",
@@ -425,6 +473,16 @@ class Mxfp4SM70MoEMethod(Mxfp4MoEMethod):
         layer.w2_tm_weight = Parameter(torch.stack(w2_tm_weights), requires_grad=False)
         layer.w2_tm_scales = Parameter(torch.stack(w2_tm_scales), requires_grad=False)
         layer.w2_tm_meta = Parameter(torch.stack(w2_meta), requires_grad=False)
+
+        if use_exponent_fold_decode:
+            _validate_mxfp4_exponent_fold_scales(
+                w13_tm_scales=layer.w13_tm_scales,
+                w2_tm_scales=layer.w2_tm_scales,
+            )
+            logger.info_once(
+                "Exact SM70 DeepSeek V4 MXFP4 exponent-folded decode "
+                "validated for adjusted UE8M0 exponents in [1, 16]."
+            )
 
         w13_k_ld = int(w13_meta[0][0].item())
         w13_q_ld = int(w13_meta[0][1].item())


### PR DESCRIPTION
## Purpose

Stacked on #309. Fold the exact E2M1 conversion factor into adjusted UE8M0 exponents for the DeepSeek V4 PP2 x TP4 M=6 direct-order decode shapes. Preserve the ordinary measured CTA, split-K, and swizzle so the reduction order and output bits stay unchanged.

## Test Plan

- Audit every MXFP4 scale byte in the V4-Flash checkpoint.
- Enumerate every signed E2M1 code across the observed exponent interval.
- Compile the affected SM70 CUDA translation units and link the stacked extension.
- Run real-weight, changing-input CUDA Graph A/B/B/A operator checks.
- Run the focused CPU unit tests and Ruff.
- Run matched PP2 x TP4 full-model speed and GSM8K-64 before promoting from Draft.

## Test Result

- Checkpoint audit: 35,718 scale tensors, 9,261,408,000 bytes; raw E8M0 114--126, adjusted half exponents 2--14, folded exponents 16--28.
- Exhaustive arithmetic proof: 208/208 FP16 bit patterns equal.
- Final extension SHA256: 5b8cd4cd5796b8180b6e209c5737df753fd08c4118cbc3363741dce65785e2e6.
- Real layer-0 TP4-rank-0 weights: 64/64 dynamic CUDA Graph cases bitwise equal at W13, SwiGLU, and W2.
- Pipeline-first A/B/B/A median: 95.141 -> 53.163 us/layer, projecting 1.805 ms/token across 43 layers.
- pytest focused exponent-fold cases: 5 passed.
- Ruff and git diff --check: passed.
- Full-model and GSM8K-64: pending GPU availability; keep Draft.