### PR TITLE
[Model][SM70] Exclude unsafe PP2 TP4 QPN8 gate/up

### DIFF
--- a/docs/design/sm70_v100_migration_control.md
+++ b/docs/design/sm70_v100_migration_control.md
@@ -43519,6 +43519,28 @@ Interpretation:
   contract, validate artifact self-consistency, and gate aggregate HumanEval,
   LongBench, GSM8K, and needle-retrieval quality. They report directional
   sample flips but do not treat greedy identity as task quality.
+- A post-merge real-weight accuracy audit replaces the PP2 x TP4 route's
+  fastest single-pattern schedules with four-pattern accuracy-first schedules.
+  Fused WQA/WKV, attention WQ-B/WO-B, grouped WO-A, and shared-expert down
+  retain at least `99.707%` exact FP16 elements and at most `1.444e-5`
+  relative L2 error against same-process TurboMind. Shared-expert gate/up
+  retains only `53.516%` exact elements with its fused activation and is
+  removed from the default QPN8 tensor contract; the replicated indexer WQ-B
+  remains excluded.
+- The latest-main production source gate covers M=1 and M=9, changing-input
+  CUDA Graph replay, FP32 and TurboMind references, grouped WO-A layout, and
+  both excluded roles. All five admitted projections pass, both excluded roles
+  remain on TurboMind, and the route reuses one 16-MiB workspace. Evidence is
+  under `/data/models/v100-dsv4-0731-pp2tp4-qpn8-accuracy-source-gate-20260826-r2-main/`.
+  The isolated weighted projection is `6.067 -> 3.321 ms/token` of stage-sum
+  FP8 service; it is not an endpoint TPOT claim.
+- Withdraw the earlier causal attribution of a `63/64 -> 2/64` GSM8K result to
+  fused-WQA QPN8 alone. That recorded endpoint also pinned five static FP8
+  tactics and enabled grouped WO-A; the static-FP8-only endpoint reproduces
+  the same class of incoherent output. Those artifacts prove that the bundled
+  configuration fails, not which operator caused it. Keep the accuracy-first
+  schedule change unmerged until a clean matched pure-decode run and pinned
+  dataset gates close.
 
 ## 2026-08-26 generic multimodal-tower UVA offload
 

--- a/docs/design/sm70_v100_migration_control.md
+++ b/docs/design/sm70_v100_migration_control.md
@@ -43519,28 +43519,48 @@ Interpretation:
   contract, validate artifact self-consistency, and gate aggregate HumanEval,
   LongBench, GSM8K, and needle-retrieval quality. They report directional
   sample flips but do not treat greedy identity as task quality.
-- A post-merge real-weight accuracy audit replaces the PP2 x TP4 route's
-  fastest single-pattern schedules with four-pattern accuracy-first schedules.
-  Fused WQA/WKV, attention WQ-B/WO-B, grouped WO-A, and shared-expert down
-  retain at least `99.707%` exact FP16 elements and at most `1.444e-5`
-  relative L2 error against same-process TurboMind. Shared-expert gate/up
-  retains only `53.516%` exact elements with its fused activation and is
-  removed from the default QPN8 tensor contract; the replicated indexer WQ-B
-  remains excluded.
-- The latest-main production source gate covers M=1 and M=9, changing-input
-  CUDA Graph replay, FP32 and TurboMind references, grouped WO-A layout, and
-  both excluded roles. All five admitted projections pass, both excluded roles
-  remain on TurboMind, and the route reuses one 16-MiB workspace. Evidence is
-  under `/data/models/v100-dsv4-0731-pp2tp4-qpn8-accuracy-source-gate-20260826-r2-main/`.
-  The isolated weighted projection is `6.067 -> 3.321 ms/token` of stage-sum
-  FP8 service; it is not an endpoint TPOT claim.
+- A post-merge four-pattern, real-weight matrix separates a single numerical
+  outlier from five already-bounded fast schedules. Fused WQA/WKV, attention
+  WQ-B/WO-B, grouped WO-A, and shared-expert down retain at least `99.707%`
+  exact FP16 elements and at most `1.641e-5` relative L2 against same-process
+  TurboMind with their existing speed winners. Their accuracy-first schedules
+  are about 15--36% slower at the isolated operator while only reducing errors
+  that are already in the `1e-5` range, so the production route keeps the
+  speed winners. The matrix is under
+  `/data/models/v100-dsv4-0731-pp2tp4-qpn8-accuracy-matrix-20260826-r1/`.
+- Shared-expert gate/up is the material outlier: its fused activation retains
+  only `53.516%` exact elements and reaches `5.989e-4` relative L2. It is the
+  only role removed from the default QPN8 tensor contract and now falls back
+  to TurboMind. The replicated indexer WQ-B remains excluded. This narrows an
+  existing hardware/topology/tensor route; it does not add a model-identity
+  admission rule or disable QPN8 globally.
+- The conservative all-accuracy source gate covers M=1 and M=9,
+  changing-input CUDA Graph replay, FP32 and TurboMind references, grouped
+  WO-A layout, both excluded roles, and one reused 16-MiB workspace. All five
+  admitted projections pass and both excluded roles remain on TurboMind.
+  Evidence is under
+  `/data/models/v100-dsv4-0731-pp2tp4-qpn8-accuracy-source-gate-20260826-r2-main/`.
+  Its isolated weighted projection is `6.067 -> 3.321 ms/token` of stage-sum
+  FP8 service; this is a conservative lower-speed variant, not an endpoint
+  TPOT claim for the retained speed-winner schedules.
 - Withdraw the earlier causal attribution of a `63/64 -> 2/64` GSM8K result to
   fused-WQA QPN8 alone. That recorded endpoint also pinned five static FP8
   tactics and enabled grouped WO-A; the static-FP8-only endpoint reproduces
   the same class of incoherent output. Those artifacts prove that the bundled
-  configuration fails, not which operator caused it. Keep the accuracy-first
-  schedule change unmerged until a clean matched pure-decode run and pinned
-  dataset gates close.
+  configuration fails, not which operator caused it.
+- Clean matched PP2 x TP4, B1, no-spec runs now close the conservative
+  all-accuracy variant. QPN8-off records a median `63.6434 tok/s` and
+  `15.71254 ms/token`; the all-accuracy candidate records `63.9120 tok/s` and
+  `15.64652 ms/token`, about `+0.42%` and `-0.066 ms/token`. The paired pinned
+  GSM8K64 run is `62/64` versus `61/64`, with zero invalid outputs and one
+  directional difference at item 37. That single sample remains visible, but
+  it is not a greedy-identity gate and does not show that choosing the lowest
+  operator error improves aggregate task quality. The accepted repair
+  therefore preserves every numerically bounded speed winner and falls back
+  only the demonstrated gate/up outlier. Full artifacts are under
+  `/data/models/v100-dsv4-0731-pp2tp4-qpn8-accuracy-fullmodel-control-20260826-r1/`
+  and
+  `/data/models/v100-dsv4-0731-pp2tp4-qpn8-accuracy-fullmodel-candidate-20260826-r2/`.
 
 ## 2026-08-26 generic multimodal-tower UVA offload
 

--- a/tests/model_executor/test_sm70_fp8_qpn8_pp2_tp4.py
+++ b/tests/model_executor/test_sm70_fp8_qpn8_pp2_tp4.py
@@ -52,32 +52,10 @@ def test_pp2_tp4_qpn8_is_default_on_with_explicit_rollback(monkeypatch) -> None:
 @pytest.mark.parametrize(
     ("layer", "gated_silu", "expected"),
     [
-        (_layer("fused_wqa_wkv", 1, 4096, 1536), False, (32, 2, False)),
-        (_layer("wq_b", 4, 1024, 8192), False, (8, 2, False)),
-        (_layer("wo_b", 4, 2048, 4096), False, (16, 2, False)),
-        (
-            _layer(
-                "gate_up_proj",
-                4,
-                4096,
-                1024,
-                output_partition_sizes=[512, 512],
-            ),
-            False,
-            (32, 2, False),
-        ),
-        (
-            _layer(
-                "gate_up_proj",
-                4,
-                4096,
-                1024,
-                output_partition_sizes=[512, 512],
-            ),
-            True,
-            (16, 2, False),
-        ),
-        (_layer("down_proj", 4, 512, 4096), False, (16, 2, False)),
+        (_layer("fused_wqa_wkv", 1, 4096, 1536), False, (16, 1, True)),
+        (_layer("wq_b", 4, 1024, 8192), False, (4, 1, False)),
+        (_layer("wo_b", 4, 2048, 4096), False, (8, 2, False)),
+        (_layer("down_proj", 4, 512, 4096), False, (4, 1, False)),
     ],
 )
 def test_pp2_tp4_qpn8_exact_operator_contracts(
@@ -97,14 +75,15 @@ def test_pp2_tp4_qpn8_rejects_wrong_tensor_and_concurrency_roles() -> None:
         fp8._sm70_fp8_qpn8_pp2_tp4_config(concurrent_indexer, gated_silu=False) is None
     )
 
-    wrong_gate = _layer(
+    excluded_gate = _layer(
         "gate_up_proj",
         4,
         4096,
         1024,
-        output_partition_sizes=[256, 768],
+        output_partition_sizes=[512, 512],
     )
-    assert fp8._sm70_fp8_qpn8_pp2_tp4_config(wrong_gate, gated_silu=True) is None
+    assert fp8._sm70_fp8_qpn8_pp2_tp4_config(excluded_gate, gated_silu=False) is None
+    assert fp8._sm70_fp8_qpn8_pp2_tp4_config(excluded_gate, gated_silu=True) is None
 
     wrong_layout = _layer("wo_b", 4, 2048, 4096)
     wrong_layout.weight_block_size = [64, 128]
@@ -146,16 +125,16 @@ def test_pp2_tp4_qpn8_grouped_dispatches_caller_groups() -> None:
     layer = _layer("wo_a", 4, 4096, 2048)
     layer.is_bmm = True
     layer.bmm_batch_size = 2
-    assert fp8._sm70_fp8_qpn8_pp2_tp4_bmm_config(layer) == (32, 2, False)
+    assert fp8._sm70_fp8_qpn8_pp2_tp4_bmm_config(layer) == (16, 1, True)
 
     layer.sm70_fp8_turbomind = True
     layer.sm70_fp8_qpn8 = True
     layer.sm70_fp8_qpn8_bmm = True
     layer.sm70_fp8_bmm_groups = 2
     layer.sm70_fp8_bmm_output_size = 1024
-    layer.sm70_fp8_qpn8_split_k = 32
-    layer.sm70_fp8_qpn8_nacc = 2
-    layer.sm70_fp8_qpn8_prefetch = False
+    layer.sm70_fp8_qpn8_split_k = 16
+    layer.sm70_fp8_qpn8_nacc = 1
+    layer.sm70_fp8_qpn8_prefetch = True
     layer.sm70_fp8_prefill_exact_dense_workspace_ptr = 123
     layer.weight = torch.empty((2, 4096, 1024), device="meta")
     layer.weight_scale_inv = torch.empty((2, 256, 32), device="meta")
@@ -178,15 +157,15 @@ def test_pp2_tp4_qpn8_grouped_dispatches_caller_groups() -> None:
             (tuple(input_.shape), workspace_ptr, split_k, prefetch, gated_silu)
         )
         out.fill_(len(calls))
-        assert nacc == 2
+        assert nacc == 1
 
     x = torch.zeros((1, 2, 4096), dtype=torch.float16)
     with patch.object(fp8.sm70_ops, "fp8_qpn8_dispatch_sm70_out", fake_dispatch):
         out = fp8.Fp8LinearMethod.apply(None, layer, x)
 
     assert calls == [
-        ((1, 4096), 123, 32, False, False),
-        ((1, 4096), 123, 32, False, False),
+        ((1, 4096), 123, 16, True, False),
+        ((1, 4096), 123, 16, True, False),
     ]
     assert out.shape == (1, 2, 1024)
     torch.testing.assert_close(out[:, 0], torch.ones_like(out[:, 0]))
@@ -245,6 +224,6 @@ def test_pp2_tp4_qpn8_default_prepares_matching_layer(monkeypatch) -> None:
         envs.disable_envs_cache()
 
     assert layer.sm70_fp8_qpn8
-    assert layer.sm70_fp8_qpn8_split_k == 32
-    assert layer.sm70_fp8_qpn8_nacc == 2
-    assert not layer.sm70_fp8_qpn8_prefetch
+    assert layer.sm70_fp8_qpn8_split_k == 16
+    assert layer.sm70_fp8_qpn8_nacc == 1
+    assert layer.sm70_fp8_qpn8_prefetch

--- a/tests/model_executor/test_sm70_fp8_qpn8_pp2_tp4.py
+++ b/tests/model_executor/test_sm70_fp8_qpn8_pp2_tp4.py
@@ -52,10 +52,10 @@ def test_pp2_tp4_qpn8_is_default_on_with_explicit_rollback(monkeypatch) -> None:
 @pytest.mark.parametrize(
     ("layer", "gated_silu", "expected"),
     [
-        (_layer("fused_wqa_wkv", 1, 4096, 1536), False, (16, 1, True)),
-        (_layer("wq_b", 4, 1024, 8192), False, (4, 1, False)),
-        (_layer("wo_b", 4, 2048, 4096), False, (8, 2, False)),
-        (_layer("down_proj", 4, 512, 4096), False, (4, 1, False)),
+        (_layer("fused_wqa_wkv", 1, 4096, 1536), False, (32, 2, False)),
+        (_layer("wq_b", 4, 1024, 8192), False, (8, 2, False)),
+        (_layer("wo_b", 4, 2048, 4096), False, (16, 2, False)),
+        (_layer("down_proj", 4, 512, 4096), False, (16, 2, False)),
     ],
 )
 def test_pp2_tp4_qpn8_exact_operator_contracts(
@@ -125,16 +125,16 @@ def test_pp2_tp4_qpn8_grouped_dispatches_caller_groups() -> None:
     layer = _layer("wo_a", 4, 4096, 2048)
     layer.is_bmm = True
     layer.bmm_batch_size = 2
-    assert fp8._sm70_fp8_qpn8_pp2_tp4_bmm_config(layer) == (16, 1, True)
+    assert fp8._sm70_fp8_qpn8_pp2_tp4_bmm_config(layer) == (32, 2, False)
 
     layer.sm70_fp8_turbomind = True
     layer.sm70_fp8_qpn8 = True
     layer.sm70_fp8_qpn8_bmm = True
     layer.sm70_fp8_bmm_groups = 2
     layer.sm70_fp8_bmm_output_size = 1024
-    layer.sm70_fp8_qpn8_split_k = 16
-    layer.sm70_fp8_qpn8_nacc = 1
-    layer.sm70_fp8_qpn8_prefetch = True
+    layer.sm70_fp8_qpn8_split_k = 32
+    layer.sm70_fp8_qpn8_nacc = 2
+    layer.sm70_fp8_qpn8_prefetch = False
     layer.sm70_fp8_prefill_exact_dense_workspace_ptr = 123
     layer.weight = torch.empty((2, 4096, 1024), device="meta")
     layer.weight_scale_inv = torch.empty((2, 256, 32), device="meta")
@@ -157,15 +157,15 @@ def test_pp2_tp4_qpn8_grouped_dispatches_caller_groups() -> None:
             (tuple(input_.shape), workspace_ptr, split_k, prefetch, gated_silu)
         )
         out.fill_(len(calls))
-        assert nacc == 1
+        assert nacc == 2
 
     x = torch.zeros((1, 2, 4096), dtype=torch.float16)
     with patch.object(fp8.sm70_ops, "fp8_qpn8_dispatch_sm70_out", fake_dispatch):
         out = fp8.Fp8LinearMethod.apply(None, layer, x)
 
     assert calls == [
-        ((1, 4096), 123, 16, True, False),
-        ((1, 4096), 123, 16, True, False),
+        ((1, 4096), 123, 32, False, False),
+        ((1, 4096), 123, 32, False, False),
     ]
     assert out.shape == (1, 2, 1024)
     torch.testing.assert_close(out[:, 0], torch.ones_like(out[:, 0]))
@@ -224,6 +224,6 @@ def test_pp2_tp4_qpn8_default_prepares_matching_layer(monkeypatch) -> None:
         envs.disable_envs_cache()
 
     assert layer.sm70_fp8_qpn8
-    assert layer.sm70_fp8_qpn8_split_k == 16
-    assert layer.sm70_fp8_qpn8_nacc == 1
-    assert layer.sm70_fp8_qpn8_prefetch
+    assert layer.sm70_fp8_qpn8_split_k == 32
+    assert layer.sm70_fp8_qpn8_nacc == 2
+    assert not layer.sm70_fp8_qpn8_prefetch

--- a/vllm/model_executor/layers/quantization/fp8.py
+++ b/vllm/model_executor/layers/quantization/fp8.py
@@ -132,23 +132,24 @@ _SM70_FP8_QPN8_EXTRA_SHAPES = {
     "qkv_proj": (5120, 3584),
 }
 _SM70_FP8_QPN8_PP2_TP4_CONFIGS = {
-    # Measured B1 winners: (K, N, fused gated-SiLU) maps to
-    # (split-K, accumulator chains, prefetch codes).
-    (4096, 1536, False): (32, 2, False),
-    (1024, 8192, False): (8, 2, False),
-    (2048, 4096, False): (16, 2, False),
-    (4096, 1024, False): (32, 2, False),
-    (4096, 1024, True): (16, 2, False),
-    (512, 4096, False): (16, 2, False),
+    # Accuracy-first real-weight schedules: (K, N, fused gated-SiLU) maps to
+    # (split-K, accumulator chains, prefetch codes). The shared-expert gate/up
+    # projection is deliberately absent after its four-pattern comparison
+    # matched only 53.5--60.9% of TurboMind FP16 elements.
+    (4096, 1536, False): (16, 1, True),
+    (1024, 8192, False): (4, 1, False),
+    (2048, 4096, False): (8, 2, False),
+    (4096, 1024, False): (16, 1, True),
+    (512, 4096, False): (4, 1, False),
 }
 _SM70_FP8_QPN8_PP2_TP4_SHAPES = {
-    # Operator role: accepted (layer TP size, K, N) tuples. The replicated
-    # indexer wq_b is deliberately excluded by TP size: its long-prefill work
-    # may overlap the main wq_b and cannot share one dense fallback workspace.
+    # Operator role: accepted (layer TP size, K, N) tuples. The shared-expert
+    # gate/up projection is excluded by numerical evidence. The replicated
+    # indexer wq_b is excluded by TP size: its long-prefill work may overlap
+    # the main wq_b and cannot share one dense fallback workspace.
     "fused_wqa_wkv": {(1, 4096, 1536)},
     "wq_b": {(4, 1024, 8192)},
     "wo_b": {(4, 2048, 4096)},
-    "gate_up_proj": {(4, 4096, 1024)},
     "down_proj": {(4, 512, 4096)},
 }
 _SM70_FP8_QPN8_PP2_TP4_WORKSPACE_ELEMENTS = max(

--- a/vllm/model_executor/layers/quantization/fp8.py
+++ b/vllm/model_executor/layers/quantization/fp8.py
@@ -132,15 +132,14 @@ _SM70_FP8_QPN8_EXTRA_SHAPES = {
     "qkv_proj": (5120, 3584),
 }
 _SM70_FP8_QPN8_PP2_TP4_CONFIGS = {
-    # Accuracy-first real-weight schedules: (K, N, fused gated-SiLU) maps to
-    # (split-K, accumulator chains, prefetch codes). The shared-expert gate/up
-    # projection is deliberately absent after its four-pattern comparison
-    # matched only 53.5--60.9% of TurboMind FP16 elements.
-    (4096, 1536, False): (16, 1, True),
-    (1024, 8192, False): (4, 1, False),
-    (2048, 4096, False): (8, 2, False),
-    (4096, 1024, False): (16, 1, True),
-    (512, 4096, False): (4, 1, False),
+    # Real-weight speed winners remain numerically bounded for every admitted
+    # projection. The shared-expert gate/up role is deliberately absent below
+    # after its fused activation matched only 53.5% of TurboMind FP16 elements.
+    (4096, 1536, False): (32, 2, False),
+    (1024, 8192, False): (8, 2, False),
+    (2048, 4096, False): (16, 2, False),
+    (4096, 1024, False): (32, 2, False),
+    (512, 4096, False): (16, 2, False),
 }
 _SM70_FP8_QPN8_PP2_TP4_SHAPES = {
     # Operator role: accepted (layer TP size, K, N) tuples. The shared-expert


### PR DESCRIPTION
## Purpose

Rebuild and repair PR #302 on the latest main at 1d64f84dce6a42c1496c42e0e4c021ac9f979591.

The original PR changed every admitted PP2 x TP4 QPN8 projection to its lowest-error schedule. Source audit shows that this pays a 15--36% isolated operator slowdown for errors that are already bounded around 1e-5. The actual numerical outlier is only fused shared-expert gate/up.

This repair therefore:

- removes shared-expert gate/up from the default QPN8 operator contract so it falls back to TurboMind;
- retains the existing measured speed-winner schedules for WQA/WKV, WQ-B, WO-B, grouped WO-A, and shared down;
- keeps the replicated indexer excluded;
- preserves the existing PP2 x TP4 B1 no-spec hardware/topology/tensor admission and rollback controls;
- never reads model name, checkpoint path, model_type, or architecture identity.

This PR supersedes #302 rather than pushing into the agent-owned branch.

## Numerical and performance audit

Four-pattern real-weight comparison against same-process TurboMind:

- retained fast schedules: exact FP16 fraction at least 99.707%, relative L2 at most 1.641e-5;
- fused shared gate/up: exact fraction 53.516%, relative L2 5.989e-4;
- accuracy-first alternatives for the retained roles are about 15--36% slower in the isolated operator matrix.

Matrix artifact:
/data/models/v100-dsv4-0731-pp2tp4-qpn8-accuracy-matrix-20260826-r1/

The conservative all-accuracy source gate passes M=1/M=9, changing-input CUDA Graph replay, FP32/TurboMind references, grouped WO-A layout, both excluded roles, and one reused 16 MiB workspace:
/data/models/v100-dsv4-0731-pp2tp4-qpn8-accuracy-source-gate-20260826-r2-main/

Matched PP2 x TP4 B1 no-spec evidence for that slower all-accuracy variant:

- QPN8 off median: 63.6434 tok/s, 15.71254 ms/token;
- all-accuracy QPN8 median: 63.9120 tok/s, 15.64652 ms/token;
- difference: about +0.42%, -0.066 ms/token;
- pinned GSM8K64: 62/64 versus 61/64, zero invalid outputs, one directional difference at item 37.

The single GSM8K difference is recorded rather than treated as a greedy-identity failure. It also provides no evidence that selecting the lowest already-small operator error improves aggregate task quality. The accepted source repair is consequently the speed-preserving hybrid: retain every bounded speed winner and fall back only the demonstrated outlier.

Full artifacts:
/data/models/v100-dsv4-0731-pp2tp4-qpn8-accuracy-fullmodel-control-20260826-r1/
/data/models/v100-dsv4-0731-pp2tp4-qpn8-accuracy-fullmodel-candidate-20260826-r2/

## Test plan and result

- 9 focused PP2 x TP4 QPN8 route, rollback, workspace, and grouped-dispatch tests: passed under Python 3.12, Torch 2.10, and the matching source-built extension.
- pre-commit run -a on latest main: all hooks passed.
- git diff --check: passed.
- no new end-to-end run: the user-requested audit is source/operator focused, and the matched artifacts above already close the conservative variant.
