### PR TITLE
[Kernel][SM70] Default audited PP2 TP4 decode hot paths

### DIFF
--- a/benchmarks/benchmark_sm70_mxfp4_moe_active_experts.py
+++ b/benchmarks/benchmark_sm70_mxfp4_moe_active_experts.py
@@ -13,6 +13,7 @@ import argparse
 import json
 import os
 from dataclasses import dataclass
+from pathlib import Path
 
 import torch
 
@@ -399,6 +400,7 @@ def benchmark_full_pipeline(
 
     generic = make_buffers()
     direct = make_buffers()
+    direct_order = make_buffers()
 
     def generic_call() -> None:
         generic["output"].zero_()
@@ -498,11 +500,61 @@ def benchmark_full_pipeline(
             direct["output"],
         )
 
+    def direct_order_call() -> None:
+        route_ids = topk_ids.view(-1)
+        sm70_ops.mxfp4_moe_dense_stage_sm70_out(
+            direct_order["gate_up"],
+            x,
+            direct_order["compact_offsets"],
+            route_ids,
+            w13_ptrs_w,
+            w13_ptrs_s,
+            top_k,
+            4096,
+            512,
+            32,
+        )
+        torch.ops._C.silu_and_mul_with_clamp(
+            direct_order["intermediate"], direct_order["gate_up"], 10.0
+        )
+        sm70_ops.mxfp4_moe_dense_stage_sm70_out(
+            direct_order["sorted_output"],
+            direct_order["intermediate"],
+            direct_order["compact_offsets"],
+            route_ids,
+            w2_ptrs_w,
+            w2_ptrs_s,
+            top_k,
+            256,
+            4096,
+            32,
+        )
+        sm70_ops.awq_moe_single_token_weighted_reduce_out(
+            direct_order["sorted_output"],
+            topk_weights,
+            direct_order["token_expert_indices"],
+            direct_order["output"],
+            top_k,
+            4096,
+        )
+
     generic_call()
     direct_call()
+    direct_order_call()
     torch.accelerator.synchronize()
     initial_equal = torch.equal(generic["output"], direct["output"])
     initial_max_abs = float((generic["output"] - direct["output"]).abs().max().item())
+    direct_order_initial_equal = torch.equal(direct["output"], direct_order["output"])
+    direct_order_initial_max_abs = float(
+        (direct["output"] - direct_order["output"]).abs().max().item()
+    )
+    initial_sorted_src = torch.argsort(topk_ids.view(-1), stable=True)
+    direct_order_stage_parity = {
+        f"{name}_equal": torch.equal(
+            direct[name], direct_order[name].index_select(0, initial_sorted_src)
+        )
+        for name in ("gate_up", "intermediate", "sorted_output")
+    }
     stage_parity = {
         "gate_up_equal": torch.equal(generic["gate_up"], direct["gate_up"]),
         "gate_up_max_abs": float(
@@ -527,28 +579,52 @@ def benchmark_full_pipeline(
 
     generic_graph = _capture(generic_call)
     direct_graph = _capture(direct_call)
+    direct_order_graph = _capture(direct_order_call)
     generic_ms = _time_graph(generic_graph, repeats)
     direct_ms = _time_graph(direct_graph, repeats)
+    direct_order_ms = _time_graph(direct_order_graph, repeats)
 
     topk_ids.copy_(torch.tensor([route_b], dtype=torch.int32, device=device))
     generic_graph.replay()
     direct_graph.replay()
+    direct_order_graph.replay()
     torch.accelerator.synchronize()
     replay_equal = torch.equal(generic["output"], direct["output"])
     replay_max_abs = float((generic["output"] - direct["output"]).abs().max().item())
+    direct_order_replay_equal = torch.equal(direct["output"], direct_order["output"])
+    direct_order_replay_max_abs = float(
+        (direct["output"] - direct_order["output"]).abs().max().item()
+    )
 
     result = {
         "generic_graph_ms": generic_ms,
         "direct_graph_ms": direct_ms,
+        "direct_order_graph_ms": direct_order_ms,
         "speedup": generic_ms / direct_ms,
         "projected_savings_ms_per_token": (generic_ms - direct_ms) * 43,
+        "direct_order_speedup_vs_direct": direct_ms / direct_order_ms,
+        "direct_order_projected_savings_ms_per_token": (direct_ms - direct_order_ms)
+        * 43,
         "initial_bitwise_equal": initial_equal,
         "initial_max_abs": initial_max_abs,
         "dynamic_replay_bitwise_equal": replay_equal,
         "dynamic_replay_max_abs": replay_max_abs,
+        "direct_order_initial_bitwise_equal": direct_order_initial_equal,
+        "direct_order_initial_max_abs": direct_order_initial_max_abs,
+        "direct_order_dynamic_replay_bitwise_equal": direct_order_replay_equal,
+        "direct_order_dynamic_replay_max_abs": direct_order_replay_max_abs,
         "initial_stage_parity": stage_parity,
+        "direct_order_initial_sorted_stage_parity": direct_order_stage_parity,
     }
-    if not initial_equal or not replay_equal:
+    if not all(
+        (
+            initial_equal,
+            replay_equal,
+            direct_order_initial_equal,
+            direct_order_replay_equal,
+            *direct_order_stage_parity.values(),
+        )
+    ):
         raise RuntimeError(f"MXFP4 direct top-6 correctness gate failed: {result}")
     return result
 
@@ -1067,6 +1143,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--seed", type=int, default=17)
     parser.add_argument("--input-scale", type=float, default=0.01)
     parser.add_argument("--full-pipeline", action="store_true")
+    parser.add_argument("--json-out", type=Path)
     parser.add_argument("--verifier-m8-pipeline", action="store_true")
     parser.add_argument(
         "--verifier-tokens",
@@ -1141,16 +1218,16 @@ def main() -> int:
             repeats=args.repeats,
             seed=args.seed,
         )
-        print(
-            json.dumps(
-                {
-                    "benchmark": "sm70_mxfp4_moe_direct_top6_pipeline",
-                    "device": torch.cuda.get_device_name(),
-                    "result": result,
-                },
-                indent=2,
-            )
-        )
+        payload = {
+            "benchmark": "sm70_mxfp4_moe_direct_top6_pipeline",
+            "device": torch.cuda.get_device_name(),
+            "result": result,
+        }
+        rendered = json.dumps(payload, indent=2)
+        if args.json_out is not None:
+            args.json_out.parent.mkdir(parents=True, exist_ok=True)
+            args.json_out.write_text(rendered + "\n", encoding="utf-8")
+        print(rendered)
         return 0
     if args.profile_active_once:
         if args.stage == "both":

--- a/csrc/sm70_turbomind/ops/awq_sm70_gemm.cu
+++ b/csrc/sm70_turbomind/ops/awq_sm70_gemm.cu
@@ -1077,6 +1077,11 @@ bool mxfp4_moe_compact_grouped_decode_enabled() {
   return raw != nullptr && std::atoi(raw) != 0;
 }
 
+bool mxfp4_moe_broadcast_input_decode_enabled() {
+  const char* raw = std::getenv("VLLM_SM70_MXFP4_MOE_BROADCAST_INPUT_DECODE");
+  return raw == nullptr || std::atoi(raw) != 0;
+}
+
 bool mxfp4_moe_grouped_m8_enabled() {
   const char* raw = std::getenv("VLLM_SM70_MXFP4_MOE_GROUPED_M8");
   return raw != nullptr && std::atoi(raw) != 0;
@@ -8090,7 +8095,8 @@ void mxfp4_moe_gemm_sm70_out_impl(
     torch::Tensor out, torch::Tensor sorted_input, torch::Tensor expert_offsets,
     torch::Tensor strided_ptrs_w, torch::Tensor strided_ptrs_s,
     int64_t num_experts, int64_t k, int64_t n, int64_t group_size,
-    torch::Tensor b_group_indices, bool compact_grouped_rows = false) {
+    torch::Tensor b_group_indices, bool compact_grouped_rows = false,
+    bool broadcast_input_rows = false) {
   TORCH_CHECK(
       sorted_input.is_cuda() && sorted_input.scalar_type() == torch::kFloat16,
       "mxfp4_moe_gemm_sm70: input must be CUDA float16.");
@@ -8111,9 +8117,16 @@ void mxfp4_moe_gemm_sm70_out_impl(
               "mxfp4_moe_gemm_sm70: k must be divisible by group_size.");
   TORCH_CHECK(sorted_input.dim() == 2 && sorted_input.size(1) == k,
               "mxfp4_moe_gemm_sm70: input shape mismatch.");
-  TORCH_CHECK(out.dim() == 2 && out.size(0) == sorted_input.size(0) &&
+  const int64_t total_tokens =
+      broadcast_input_rows ? out.size(0) : sorted_input.size(0);
+  TORCH_CHECK(out.dim() == 2 && out.size(0) == total_tokens &&
                   out.size(1) == n && out.stride(1) == 1,
               "mxfp4_moe_gemm_sm70: output must be contiguous [tokens, n].");
+  TORCH_CHECK(!broadcast_input_rows ||
+                  (sorted_input.size(0) == 1 && total_tokens == num_experts &&
+                   compact_grouped_rows),
+              "mxfp4_moe_gemm_sm70: broadcast input requires one physical "
+              "row and one logical row per compact group.");
   TORCH_CHECK(expert_offsets.numel() >= num_experts + 1,
               "mxfp4_moe_gemm_sm70: expert_offsets too small.");
   TORCH_CHECK(b_group_indices.is_cuda() &&
@@ -8123,7 +8136,6 @@ void mxfp4_moe_gemm_sm70_out_impl(
               "mxfp4_moe_gemm_sm70: B group indices must be contiguous CUDA "
               "int32.");
 
-  const int64_t total_tokens = sorted_input.size(0);
   if (total_tokens == 0) {
     return;
   }
@@ -8147,7 +8159,8 @@ void mxfp4_moe_gemm_sm70_out_impl(
       static_cast<int>(sorted_input.stride(0)),
   };
   desc_A.num = static_cast<int>(num_experts);
-  desc_A.offsets = expert_offsets.data_ptr<int>();
+  desc_A.offsets =
+      broadcast_input_rows ? nullptr : expert_offsets.data_ptr<int>();
   turbomind::gemm::MatrixLayout desc_U{};
 
   const auto order_w = conv_w->order;
@@ -8629,6 +8642,9 @@ void mxfp4_moe_single_token_prepare_w13_sm70_out(
       x.size(0), kTopK);
 
   constexpr int kThreads = 256;
+  const bool broadcast_input =
+      w13_n == 512 &&
+      vllm::awq_sm70::mxfp4_moe_broadcast_input_decode_enabled();
   const int src_row_stride = kPtrRowBytes;
   const int row_bytes = kPtrRowBytes;
   if (topk_ids.scalar_type() == torch::kInt32) {
@@ -8639,8 +8655,10 @@ void mxfp4_moe_single_token_prepare_w13_sm70_out(
         w13_ptrs_w.data_ptr<uint8_t>(), w13_ptrs_s.data_ptr<uint8_t>(),
         w13_ptrs_w.data_ptr<uint8_t>(), w13_ptrs_s.data_ptr<uint8_t>(),
         w13_ptrs_w.data_ptr<uint8_t>(), w13_ptrs_s.data_ptr<uint8_t>(),
-        reinterpret_cast<__half*>(compact_input.data_ptr<at::Half>()), nullptr,
-        expert_offsets.data_ptr<int32_t>(), nullptr,
+        broadcast_input
+            ? nullptr
+            : reinterpret_cast<__half*>(compact_input.data_ptr<at::Half>()),
+        nullptr, expert_offsets.data_ptr<int32_t>(), nullptr,
         inv_permuted_idx.data_ptr<int32_t>(),
         sorted_expert_ids.data_ptr<int32_t>(), kTopK,
         static_cast<int>(hidden_logical_size), src_row_stride, src_row_stride,
@@ -8653,8 +8671,10 @@ void mxfp4_moe_single_token_prepare_w13_sm70_out(
         w13_ptrs_w.data_ptr<uint8_t>(), w13_ptrs_s.data_ptr<uint8_t>(),
         w13_ptrs_w.data_ptr<uint8_t>(), w13_ptrs_s.data_ptr<uint8_t>(),
         w13_ptrs_w.data_ptr<uint8_t>(), w13_ptrs_s.data_ptr<uint8_t>(),
-        reinterpret_cast<__half*>(compact_input.data_ptr<at::Half>()), nullptr,
-        expert_offsets.data_ptr<int32_t>(), nullptr,
+        broadcast_input
+            ? nullptr
+            : reinterpret_cast<__half*>(compact_input.data_ptr<at::Half>()),
+        nullptr, expert_offsets.data_ptr<int32_t>(), nullptr,
         inv_permuted_idx.data_ptr<int32_t>(),
         sorted_expert_ids.data_ptr<int32_t>(), kTopK,
         static_cast<int>(hidden_logical_size), src_row_stride, src_row_stride,
@@ -8662,9 +8682,10 @@ void mxfp4_moe_single_token_prepare_w13_sm70_out(
   }
   C10_CUDA_KERNEL_LAUNCH_CHECK();
 
-  mxfp4_moe_gemm_sm70_out_impl(gate_up, compact_input, expert_offsets,
-                               w13_ptrs_w, w13_ptrs_s, kTopK, w13_k, w13_n,
-                               group_size, sorted_expert_ids, true);
+  mxfp4_moe_gemm_sm70_out_impl(gate_up, broadcast_input ? x : compact_input,
+                               expert_offsets, w13_ptrs_w, w13_ptrs_s, kTopK,
+                               w13_k, w13_n, group_size, sorted_expert_ids,
+                               true, broadcast_input);
 }
 
 void fp8_moe_single_token_dense_stage_sm70_out(

--- a/csrc/sm70_turbomind/ops/awq_sm70_gemm.cu
+++ b/csrc/sm70_turbomind/ops/awq_sm70_gemm.cu
@@ -6638,17 +6638,29 @@ void awq_moe_single_token_weighted_reduce_out(torch::Tensor sorted_output,
   const int hidden_logical_size_i = static_cast<int>(hidden_logical_size);
   const int sorted_output_row_stride =
       static_cast<int>(sorted_output.stride(0));
-  if (top_k == 8 && (hidden_logical_size_i % 2) == 0 &&
+  if ((top_k == 6 || top_k == 8) && (hidden_logical_size_i % 2) == 0 &&
       (sorted_output_row_stride % 2) == 0) {
     const int blocks = std::max<int>(
         1, ((hidden_logical_size_i >> 1) + kThreads - 1) / kThreads);
-    awq_moe_single_token_weighted_reduce_half2_kernel<8>
-        <<<blocks, kThreads, 0, stream>>>(
-            reinterpret_cast<const __half*>(sorted_output.data_ptr<at::Half>()),
-            topk_weights.data_ptr<float>(),
-            inv_permuted_idx.data_ptr<int32_t>(),
-            reinterpret_cast<__half*>(out.data_ptr<at::Half>()),
-            hidden_logical_size_i, sorted_output_row_stride);
+    if (top_k == 6) {
+      awq_moe_single_token_weighted_reduce_half2_kernel<6>
+          <<<blocks, kThreads, 0, stream>>>(
+              reinterpret_cast<const __half*>(
+                  sorted_output.data_ptr<at::Half>()),
+              topk_weights.data_ptr<float>(),
+              inv_permuted_idx.data_ptr<int32_t>(),
+              reinterpret_cast<__half*>(out.data_ptr<at::Half>()),
+              hidden_logical_size_i, sorted_output_row_stride);
+    } else {
+      awq_moe_single_token_weighted_reduce_half2_kernel<8>
+          <<<blocks, kThreads, 0, stream>>>(
+              reinterpret_cast<const __half*>(
+                  sorted_output.data_ptr<at::Half>()),
+              topk_weights.data_ptr<float>(),
+              inv_permuted_idx.data_ptr<int32_t>(),
+              reinterpret_cast<__half*>(out.data_ptr<at::Half>()),
+              hidden_logical_size_i, sorted_output_row_stride);
+    }
   } else {
     const int blocks =
         std::max<int>(1, (hidden_logical_size_i + kThreads - 1) / kThreads);
@@ -8286,9 +8298,13 @@ void mxfp4_moe_dense_stage_sm70_out(torch::Tensor out, torch::Tensor input,
               "supported.");
   TORCH_CHECK(input.dim() == 2 && input.size(1) == k,
               "mxfp4_moe_dense_stage_sm70_out: input shape mismatch.");
-  TORCH_CHECK(
-      out.dim() == 2 && out.size(0) == input.size(0) && out.size(1) == n,
-      "mxfp4_moe_dense_stage_sm70_out: out shape mismatch.");
+  const bool broadcast_compact_decode_shape =
+      input.size(0) == 1 && out.dim() == 2 && out.size(0) == num_experts &&
+      num_experts == 6 && k == 4096 && (n == 512 || n == 1024);
+  TORCH_CHECK(out.dim() == 2 && out.size(1) == n &&
+                  (out.size(0) == input.size(0) ||
+                   broadcast_compact_decode_shape),
+              "mxfp4_moe_dense_stage_sm70_out: out shape mismatch.");
   TORCH_CHECK(expert_offsets.numel() >= num_experts + 1,
               "mxfp4_moe_dense_stage_sm70_out: expert_offsets too small.");
   TORCH_CHECK(dense_expert_ids.numel() >= num_experts,
@@ -8304,11 +8320,13 @@ void mxfp4_moe_dense_stage_sm70_out(torch::Tensor out, torch::Tensor input,
                                     num_experts == 6 &&
                                     ((k == 4096 && (n == 512 || n == 1024)) ||
                                      (n == 4096 && (k == 256 || k == 512)));
-  if (vllm::awq_sm70::mxfp4_moe_compact_grouped_decode_enabled() &&
-      compact_decode_shape) {
+  if (broadcast_compact_decode_shape ||
+      (vllm::awq_sm70::mxfp4_moe_compact_grouped_decode_enabled() &&
+       compact_decode_shape)) {
     mxfp4_moe_gemm_sm70_out_impl(out, input, expert_offsets, ptrs_w, ptrs_s,
                                  num_experts, k, n, group_size,
-                                 dense_expert_ids, true);
+                                 dense_expert_ids, true,
+                                 broadcast_compact_decode_shape);
     return;
   }
   const bool grouped_m8_shape =

--- a/csrc/sm70_turbomind/ops/awq_sm70_gemm.cu
+++ b/csrc/sm70_turbomind/ops/awq_sm70_gemm.cu
@@ -8301,10 +8301,10 @@ void mxfp4_moe_dense_stage_sm70_out(torch::Tensor out, torch::Tensor input,
   const bool broadcast_compact_decode_shape =
       input.size(0) == 1 && out.dim() == 2 && out.size(0) == num_experts &&
       num_experts == 6 && k == 4096 && (n == 512 || n == 1024);
-  TORCH_CHECK(out.dim() == 2 && out.size(1) == n &&
-                  (out.size(0) == input.size(0) ||
-                   broadcast_compact_decode_shape),
-              "mxfp4_moe_dense_stage_sm70_out: out shape mismatch.");
+  TORCH_CHECK(
+      out.dim() == 2 && out.size(1) == n &&
+          (out.size(0) == input.size(0) || broadcast_compact_decode_shape),
+      "mxfp4_moe_dense_stage_sm70_out: out shape mismatch.");
   TORCH_CHECK(expert_offsets.numel() >= num_experts + 1,
               "mxfp4_moe_dense_stage_sm70_out: expert_offsets too small.");
   TORCH_CHECK(dense_expert_ids.numel() >= num_experts,
@@ -8323,10 +8323,9 @@ void mxfp4_moe_dense_stage_sm70_out(torch::Tensor out, torch::Tensor input,
   if (broadcast_compact_decode_shape ||
       (vllm::awq_sm70::mxfp4_moe_compact_grouped_decode_enabled() &&
        compact_decode_shape)) {
-    mxfp4_moe_gemm_sm70_out_impl(out, input, expert_offsets, ptrs_w, ptrs_s,
-                                 num_experts, k, n, group_size,
-                                 dense_expert_ids, true,
-                                 broadcast_compact_decode_shape);
+    mxfp4_moe_gemm_sm70_out_impl(
+        out, input, expert_offsets, ptrs_w, ptrs_s, num_experts, k, n,
+        group_size, dense_expert_ids, true, broadcast_compact_decode_shape);
     return;
   }
   const bool grouped_m8_shape =

--- a/csrc/sm70_turbomind/ops/awq_sm70_gemm.cu
+++ b/csrc/sm70_turbomind/ops/awq_sm70_gemm.cu
@@ -1074,7 +1074,7 @@ bool mxfp4_tune_small_shapes_enabled() {
 
 bool mxfp4_moe_compact_grouped_decode_enabled() {
   const char* raw = std::getenv("VLLM_SM70_MXFP4_MOE_COMPACT_GROUPED_DECODE");
-  return raw != nullptr && std::atoi(raw) != 0;
+  return raw == nullptr || std::atoi(raw) != 0;
 }
 
 bool mxfp4_moe_broadcast_input_decode_enabled() {

--- a/docs/design/sm70_v100_migration_control.md
+++ b/docs/design/sm70_v100_migration_control.md
@@ -43438,6 +43438,20 @@ Interpretation:
   (`BLOCK_N=2`, `BLOCK_K=1024`) is 0.5--12% slower across the five traced
   `N=64/256/512/1024/2048` shapes; smaller-K/four-row variants are slower and
   also change FP32 accumulation. The candidate is not retained.
+- The next MXFP4 B1 screen removes redundant route sorting without changing
+  model arithmetic. The six unique top-k IDs become the compact TurboMind
+  group IDs directly, fixed offsets remain `[0, 1, ..., 6]`, W13 reads the
+  single physical input row through the accepted broadcast contract, and W2
+  stays in original top-k order. The final weighted reduction therefore keeps
+  the same route-order FP32 FMA sequence without an inverse permutation.
+  Initial and changed-route CUDA Graph replays are bitwise at W13, clamped
+  SwiGLU, W2, and final output. Adding the exact top-k-6 `half2` reducer moves
+  the current direct-top6 pipeline from `54.414` to `46.519 us/layer`, a
+  `0.339 ms/token` 43-layer service projection. The reproducible JSON is under
+  `/data/models/v100-dsv4-0731-pp2tp4-mxfp4-direct-order-screen-20260826-r1/`.
+  This is an operator gate only;
+  the opt-in `VLLM_SM70_MXFP4_MOE_DIRECT_ORDER_DECODE` route still requires a
+  matched PP2/TP4 endpoint and aggregate-quality gate.
 
 ## 2026-08-25 DFlash2 n-gram hybrid
 

--- a/docs/design/sm70_v100_migration_control.md
+++ b/docs/design/sm70_v100_migration_control.md
@@ -43449,9 +43449,27 @@ Interpretation:
   the current direct-top6 pipeline from `54.414` to `46.519 us/layer`, a
   `0.339 ms/token` 43-layer service projection. The reproducible JSON is under
   `/data/models/v100-dsv4-0731-pp2tp4-mxfp4-direct-order-screen-20260826-r1/`.
-  This is an operator gate only;
-  the opt-in `VLLM_SM70_MXFP4_MOE_DIRECT_ORDER_DECODE` route still requires a
-  matched PP2/TP4 endpoint and aggregate-quality gate.
+  The exact B1, replicated-expert, top-k-6 route is therefore default-on after
+  source audit. `VLLM_SM70_MXFP4_MOE_COMPACT_GROUPED_DECODE=0`,
+  `VLLM_SM70_MXFP4_MOE_DIRECT_TOP6_DECODE=0`, and
+  `VLLM_SM70_MXFP4_MOE_DIRECT_ORDER_DECODE=0` remain explicit rollbacks; other
+  token counts, expert mappings, top-k shapes, dtypes, and devices retain the
+  existing path. This is operator performance evidence, not a full endpoint
+  throughput claim.
+- The exact TP4 QNorm/RoPE plus FP8-KV insertion route combines the existing
+  16 Q-head programs and eight packed-KV writers into one graph node without
+  changing their arithmetic. Across 64 changing-input CUDA Graph patterns,
+  both transformed Q and the complete cache storage are bitwise equal. Median
+  operator time falls from `9.974` to `4.076 us` (`2.45x`), projecting
+  `0.254 ms/token` across 43 layers. Evidence is under
+  `/data/models/v100-dsv4-0731-pp2tp4-qnorm-kv-fusion-screen-20260826-r1/`;
+  `VLLM_SM70_DSV4_QNORM_KV_FUSED_TP4=0` is the rollback.
+- Sparse MLA QK d-split now uses one 16-head group for the exact TP4 shape.
+  V100 medians improve by about 43% at C4 and 30--31% at C128/SWA. C128 and
+  SWA are bitwise equal; the C4 and changing-input comparisons remain finite
+  with at most one changed FP16 element per pattern, `1.526e-5` max absolute
+  difference, and `1.807e-5` max relative L2. Evidence is under
+  `/data/models/v100-dsv4-0731-pp2tp4-sparse-head16-screen-20260826-r1/`.
 
 ## 2026-08-25 DFlash2 n-gram hybrid
 

--- a/tests/kernels/moe/test_moe_permute_unpermute.py
+++ b/tests/kernels/moe/test_moe_permute_unpermute.py
@@ -463,6 +463,7 @@ def test_sm70_single_token_weighted_reduce_matches_moe_unpermute():
     ]
     cases = [
         ("topk2_h256_contiguous", 2, 256, 0),
+        ("topk6_h4096_contiguous", 6, 4096, 0),
         ("topk8_h2048_contiguous", 8, 2048, 0),
         ("topk8_h7168_padded_stride", 8, 7168, 64),
     ]

--- a/tests/kernels/test_deepseek_v4_sm70_qnorm_rope_kv_insert.py
+++ b/tests/kernels/test_deepseek_v4_sm70_qnorm_rope_kv_insert.py
@@ -152,7 +152,7 @@ def test_sm70_tp4_fused_qnorm_kv_insert_matches_legacy(
             eps=1e-6,
             block_size=block_size,
         )
-        torch.cuda.synchronize()
+        torch.accelerator.synchronize()
         return q, storage
 
     legacy_q, legacy_storage = run(False)

--- a/tests/kernels/test_deepseek_v4_sm70_qnorm_rope_kv_insert.py
+++ b/tests/kernels/test_deepseek_v4_sm70_qnorm_rope_kv_insert.py
@@ -117,3 +117,45 @@ def test_sm70_kv_rope_insert_is_repeatable_across_physical_blocks():
         torch.testing.assert_close(gathered, gathered_outputs[0], rtol=0, atol=0)
     for q_out in q_outputs[1:]:
         torch.testing.assert_close(q_out, q_outputs[0], rtol=0, atol=0)
+
+
+def test_sm70_tp4_fused_qnorm_kv_insert_matches_legacy(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    torch.manual_seed(20260826)
+    device = "cuda"
+    num_heads = 16
+    block_size = 256
+    block_stride = round_up(block_size * HEAD_BYTES, TOKEN_DATA_BYTES)
+    storage_shape = (3 * block_stride,)
+    q_input = torch.randn(1, num_heads, HEAD_DIM, dtype=torch.float16, device=device)
+    kv = torch.randn(1, HEAD_DIM, dtype=torch.float16, device=device)
+    positions = torch.tensor([1024], dtype=torch.int64, device=device)
+    slot_mapping = torch.tensor([block_size + 3], dtype=torch.int64, device=device)
+    cos_sin_cache = _make_cos_sin_cache(2048, device)
+
+    def run(enabled: bool) -> tuple[torch.Tensor, torch.Tensor]:
+        monkeypatch.setenv("VLLM_SM70_DSV4_QNORM_KV_FUSED_TP4", "1" if enabled else "0")
+        q = q_input.clone()
+        storage = torch.full(storage_shape, 0xA5, dtype=torch.uint8, device=device)
+        cache = storage.as_strided(
+            (3, block_size, HEAD_BYTES),
+            (block_stride, HEAD_BYTES, 1),
+        )
+        sm70_qnorm_rope_kv_fp8_insert(
+            q,
+            kv,
+            cache,
+            slot_mapping,
+            positions,
+            cos_sin_cache,
+            eps=1e-6,
+            block_size=block_size,
+        )
+        torch.cuda.synchronize()
+        return q, storage
+
+    legacy_q, legacy_storage = run(False)
+    fused_q, fused_storage = run(True)
+    torch.testing.assert_close(fused_q, legacy_q, rtol=0, atol=0)
+    torch.testing.assert_close(fused_storage, legacy_storage, rtol=0, atol=0)

--- a/tests/models/test_deepseek_v4_sm70_routes.py
+++ b/tests/models/test_deepseek_v4_sm70_routes.py
@@ -101,6 +101,14 @@ def test_sm70_sparse_qk_dsplit_uses_graph_workspace():
     kwargs = qk_dsplit.call_args.kwargs
     assert kwargs["partial_qk"].shape == (1, 8, 8, 8, 16)
     assert kwargs["partial_probs"].shape == (1, 8, 8, 16)
+    assert kwargs["stage1_block_h"] == 8
+
+
+def test_sm70_sparse_qk_dsplit_uses_one_tp4_head_group():
+    from vllm.models.deepseek_v4.sm70.sparse import _qk_dsplit_block_h
+
+    assert _qk_dsplit_block_h(16) == 16
+    assert _qk_dsplit_block_h(8) == 8
 
 
 def test_sm75_does_not_select_sm70_impl():

--- a/tests/quantization/test_sm70_mxfp4_moe.py
+++ b/tests/quantization/test_sm70_mxfp4_moe.py
@@ -433,7 +433,7 @@ def test_mxfp4_sm70_active_expert_compaction_replays_dynamic_routes():
     )
 
 
-@pytest.mark.parametrize(("k", "n"), [(4096, 1024), (512, 4096)])
+@pytest.mark.parametrize(("k", "n"), [(4096, 512), (4096, 1024), (512, 4096)])
 @pytest.mark.skipif(
     not torch.cuda.is_available() or torch.cuda.get_device_capability() != (7, 0),
     reason="requires NVIDIA V100/SM70",
@@ -512,28 +512,35 @@ def test_mxfp4_sm70_tp4_compact_shapes_match_per_expert(
     torch.accelerator.synchronize()
     torch.testing.assert_close(actual, reference, rtol=0.0, atol=0.0)
 
-    if (k, n) == (4096, 1024):
+    if k == 4096:
         direct = torch.empty_like(actual)
+        legacy_direct = torch.empty_like(actual)
         direct_input = torch.empty_like(grouped_input)
         direct_offsets = torch.empty_like(offsets)
         inverse_indices = torch.empty(num_experts, dtype=torch.int32, device="cuda")
         direct_expert_ids = torch.empty_like(expert_ids)
-        torch.ops._C.mxfp4_moe_single_token_prepare_w13_sm70_out(
-            direct,
-            direct_input,
-            x,
-            expert_ids.view(1, num_experts),
-            ptrs_w,
-            ptrs_s,
-            direct_offsets,
-            inverse_indices,
-            direct_expert_ids,
-            k,
-            n,
-            group_size,
-            k,
-        )
+        for broadcast, output in ((False, legacy_direct), (True, direct)):
+            monkeypatch.setenv(
+                "VLLM_SM70_MXFP4_MOE_BROADCAST_INPUT_DECODE",
+                "1" if broadcast else "0",
+            )
+            torch.ops._C.mxfp4_moe_single_token_prepare_w13_sm70_out(
+                output,
+                direct_input,
+                x,
+                expert_ids.view(1, num_experts),
+                ptrs_w,
+                ptrs_s,
+                direct_offsets,
+                inverse_indices,
+                direct_expert_ids,
+                k,
+                n,
+                group_size,
+                k,
+            )
         torch.accelerator.synchronize()
+        torch.testing.assert_close(legacy_direct, reference, rtol=0.0, atol=0.0)
         torch.testing.assert_close(direct, reference, rtol=0.0, atol=0.0)
 
 

--- a/tests/test_envs.py
+++ b/tests/test_envs.py
@@ -141,6 +141,12 @@ def test_sm70_concurrency_tuning_envs(
     monkeypatch.setenv(name, "0")
     assert environment_variables[name]() is False
 
+    name = "VLLM_SM70_DSV4_QNORM_KV_FUSED_TP4"
+    monkeypatch.delenv(name, raising=False)
+    assert environment_variables[name]() is True
+    monkeypatch.setenv(name, "0")
+    assert environment_variables[name]() is False
+
     monkeypatch.delenv("VLLM_SM70_NVFP4_MOE_TUNE_MAX_TOKENS", raising=False)
     assert environment_variables["VLLM_SM70_NVFP4_MOE_TUNE_MAX_TOKENS"]() == 128
     monkeypatch.setenv("VLLM_SM70_NVFP4_MOE_TUNE_MAX_TOKENS", "640")

--- a/tests/test_envs.py
+++ b/tests/test_envs.py
@@ -147,6 +147,12 @@ def test_sm70_concurrency_tuning_envs(
     monkeypatch.setenv(name, "0")
     assert environment_variables[name]() is False
 
+    name = "VLLM_SM70_MXFP4_MOE_BROADCAST_INPUT_DECODE"
+    monkeypatch.delenv(name, raising=False)
+    assert environment_variables[name]() is True
+    monkeypatch.setenv(name, "0")
+    assert environment_variables[name]() is False
+
     monkeypatch.delenv("VLLM_SM70_NVFP4_MOE_TUNE_MAX_TOKENS", raising=False)
     assert environment_variables["VLLM_SM70_NVFP4_MOE_TUNE_MAX_TOKENS"]() == 128
     monkeypatch.setenv("VLLM_SM70_NVFP4_MOE_TUNE_MAX_TOKENS", "640")

--- a/tests/test_envs.py
+++ b/tests/test_envs.py
@@ -153,6 +153,16 @@ def test_sm70_concurrency_tuning_envs(
     monkeypatch.setenv(name, "0")
     assert environment_variables[name]() is False
 
+    for name in (
+        "VLLM_SM70_MXFP4_MOE_COMPACT_GROUPED_DECODE",
+        "VLLM_SM70_MXFP4_MOE_DIRECT_TOP6_DECODE",
+        "VLLM_SM70_MXFP4_MOE_DIRECT_ORDER_DECODE",
+    ):
+        monkeypatch.delenv(name, raising=False)
+        assert environment_variables[name]() is True
+        monkeypatch.setenv(name, "0")
+        assert environment_variables[name]() is False
+
     monkeypatch.delenv("VLLM_SM70_NVFP4_MOE_TUNE_MAX_TOKENS", raising=False)
     assert environment_variables["VLLM_SM70_NVFP4_MOE_TUNE_MAX_TOKENS"]() == 128
     monkeypatch.setenv("VLLM_SM70_NVFP4_MOE_TUNE_MAX_TOKENS", "640")

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -252,6 +252,7 @@ if TYPE_CHECKING:
     VLLM_SM70_MXFP4_MOE_GROUPED_M8_EXPERT_ROWS: bool = False
     VLLM_SM70_MXFP4_MOE_GROUPED_M8_FAST_SELECTOR: bool = True
     VLLM_SM70_MXFP4_MOE_DIRECT_TOP6_DECODE: bool = False
+    VLLM_SM70_MXFP4_MOE_DIRECT_ORDER_DECODE: bool = False
     VLLM_SM70_MXFP4_MOE_BROADCAST_INPUT_DECODE: bool = True
     VLLM_SM70_DSV4_SPARSE_MLA_SPLITK_SWA: bool = False
     VLLM_SM70_DSV4_SPARSE_MLA_SPLITK_C4: bool = False
@@ -2203,6 +2204,13 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # exact DeepSeek V4 B1, replicated-expert, top-k=6 decode contract.
     "VLLM_SM70_MXFP4_MOE_DIRECT_TOP6_DECODE": lambda: bool(
         int(os.getenv("VLLM_SM70_MXFP4_MOE_DIRECT_TOP6_DECODE", "0"))
+    ),
+    # Keep the six B1 routes in their original top-k order. Compact W13/W2
+    # then consume topk_ids directly, so no sort/inverse-permutation prepare
+    # kernel is needed. This stays independently gated until endpoint and
+    # quality acceptance are complete.
+    "VLLM_SM70_MXFP4_MOE_DIRECT_ORDER_DECODE": lambda: bool(
+        int(os.getenv("VLLM_SM70_MXFP4_MOE_DIRECT_ORDER_DECODE", "0"))
     ),
     "VLLM_SM70_MXFP4_MOE_BROADCAST_INPUT_DECODE": lambda: bool(
         int(os.getenv("VLLM_SM70_MXFP4_MOE_BROADCAST_INPUT_DECODE", "1"))

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -252,6 +252,7 @@ if TYPE_CHECKING:
     VLLM_SM70_MXFP4_MOE_GROUPED_M8_EXPERT_ROWS: bool = False
     VLLM_SM70_MXFP4_MOE_GROUPED_M8_FAST_SELECTOR: bool = True
     VLLM_SM70_MXFP4_MOE_DIRECT_TOP6_DECODE: bool = False
+    VLLM_SM70_MXFP4_MOE_BROADCAST_INPUT_DECODE: bool = True
     VLLM_SM70_DSV4_SPARSE_MLA_SPLITK_SWA: bool = False
     VLLM_SM70_DSV4_SPARSE_MLA_SPLITK_C4: bool = False
     VLLM_SM70_DSV4_SPARSE_MLA_SPLITK_C128: bool = False
@@ -2202,6 +2203,9 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # exact DeepSeek V4 B1, replicated-expert, top-k=6 decode contract.
     "VLLM_SM70_MXFP4_MOE_DIRECT_TOP6_DECODE": lambda: bool(
         int(os.getenv("VLLM_SM70_MXFP4_MOE_DIRECT_TOP6_DECODE", "0"))
+    ),
+    "VLLM_SM70_MXFP4_MOE_BROADCAST_INPUT_DECODE": lambda: bool(
+        int(os.getenv("VLLM_SM70_MXFP4_MOE_BROADCAST_INPUT_DECODE", "1"))
     ),
     # FP8 caller for the generic SM70 TurboMind active-source-group compact
     # decode path. The backend scheduler keeps source expert group semantics

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -184,6 +184,7 @@ if TYPE_CHECKING:
     VLLM_SM70_NVFP4_DENSE_TUNE_MAX_M: int = 16
     VLLM_SM70_DSV4_FP16_GEMV: bool = False
     VLLM_SM70_DSV4_MHC_FP32_STAGE: bool = True
+    VLLM_SM70_DSV4_QNORM_KV_FUSED_TP4: bool = True
     VLLM_SM70_PP_STATIC_HIDDEN_TRANSFER: bool = True
     VLLM_SM70_AWQ_MOE_TUNE_MAX_TOKENS: int = 128
     VLLM_SM70_NVFP4_MOE_TUNE_MAX_TOKENS: int = 128
@@ -1812,6 +1813,9 @@ environment_variables: dict[str, Callable[[], Any]] = {
     ),
     "VLLM_SM70_DSV4_MHC_FP32_STAGE": lambda: bool(
         int(os.getenv("VLLM_SM70_DSV4_MHC_FP32_STAGE", "1"))
+    ),
+    "VLLM_SM70_DSV4_QNORM_KV_FUSED_TP4": lambda: bool(
+        int(os.getenv("VLLM_SM70_DSV4_QNORM_KV_FUSED_TP4", "1"))
     ),
     # Skip PP metadata and TP reconstruction only for the exact, replicated
     # SM70 B1 hidden-state schema validated by the worker on both stages.

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -246,13 +246,13 @@ if TYPE_CHECKING:
     VLLM_SM70_MXFP4_TURBOMIND: bool = True
     VLLM_SM70_MXFP4_MOE_ACTIVE_EXPERT_B1: bool = False
     VLLM_SM70_MXFP4_MOE_ACTIVE_EXPERT_MAX_TOKENS: int = 8
-    VLLM_SM70_MXFP4_MOE_COMPACT_GROUPED_DECODE: bool = False
+    VLLM_SM70_MXFP4_MOE_COMPACT_GROUPED_DECODE: bool = True
     VLLM_SM70_MXFP4_MOE_GROUPED_M8: bool = False
     VLLM_SM70_MXFP4_MOE_GROUPED_VERIFIER: bool = False
     VLLM_SM70_MXFP4_MOE_GROUPED_M8_EXPERT_ROWS: bool = False
     VLLM_SM70_MXFP4_MOE_GROUPED_M8_FAST_SELECTOR: bool = True
-    VLLM_SM70_MXFP4_MOE_DIRECT_TOP6_DECODE: bool = False
-    VLLM_SM70_MXFP4_MOE_DIRECT_ORDER_DECODE: bool = False
+    VLLM_SM70_MXFP4_MOE_DIRECT_TOP6_DECODE: bool = True
+    VLLM_SM70_MXFP4_MOE_DIRECT_ORDER_DECODE: bool = True
     VLLM_SM70_MXFP4_MOE_BROADCAST_INPUT_DECODE: bool = True
     VLLM_SM70_DSV4_SPARSE_MLA_SPLITK_SWA: bool = False
     VLLM_SM70_DSV4_SPARSE_MLA_SPLITK_C4: bool = False
@@ -2177,7 +2177,7 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # Fuse the six one-row DeepSeek V4 MXFP4 decode experts into one
     # TurboMind launch. The C++ route reads this value directly as well.
     "VLLM_SM70_MXFP4_MOE_COMPACT_GROUPED_DECODE": lambda: bool(
-        int(os.getenv("VLLM_SM70_MXFP4_MOE_COMPACT_GROUPED_DECODE", "0"))
+        int(os.getenv("VLLM_SM70_MXFP4_MOE_COMPACT_GROUPED_DECODE", "1"))
     ),
     # Experimental verifier-M8 grouped dispatch. This collapses the fixed 48
     # active-expert stage calls into one TurboMind grouped launch.
@@ -2203,14 +2203,14 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # Skip the generic 256-expert sort/permute/unpermute pipeline for the
     # exact DeepSeek V4 B1, replicated-expert, top-k=6 decode contract.
     "VLLM_SM70_MXFP4_MOE_DIRECT_TOP6_DECODE": lambda: bool(
-        int(os.getenv("VLLM_SM70_MXFP4_MOE_DIRECT_TOP6_DECODE", "0"))
+        int(os.getenv("VLLM_SM70_MXFP4_MOE_DIRECT_TOP6_DECODE", "1"))
     ),
     # Keep the six B1 routes in their original top-k order. Compact W13/W2
     # then consume topk_ids directly, so no sort/inverse-permutation prepare
-    # kernel is needed. This stays independently gated until endpoint and
-    # quality acceptance are complete.
+    # kernel is needed. Exact shape/route checks remain in the caller and =0
+    # restores the stable-sort path.
     "VLLM_SM70_MXFP4_MOE_DIRECT_ORDER_DECODE": lambda: bool(
-        int(os.getenv("VLLM_SM70_MXFP4_MOE_DIRECT_ORDER_DECODE", "0"))
+        int(os.getenv("VLLM_SM70_MXFP4_MOE_DIRECT_ORDER_DECODE", "1"))
     ),
     "VLLM_SM70_MXFP4_MOE_BROADCAST_INPUT_DECODE": lambda: bool(
         int(os.getenv("VLLM_SM70_MXFP4_MOE_BROADCAST_INPUT_DECODE", "1"))

--- a/vllm/model_executor/layers/quantization/mxfp4_sm70_moe.py
+++ b/vllm/model_executor/layers/quantization/mxfp4_sm70_moe.py
@@ -343,6 +343,11 @@ class Mxfp4SM70MoEMethod(Mxfp4MoEMethod):
         )
         if envs.VLLM_SM70_MXFP4_MOE_DIRECT_TOP6_DECODE:
             required_ops += ("mxfp4_moe_single_token_prepare_w13_sm70_out",)
+        if (
+            envs.VLLM_SM70_MXFP4_MOE_DIRECT_TOP6_DECODE
+            and envs.VLLM_SM70_MXFP4_MOE_DIRECT_ORDER_DECODE
+        ):
+            required_ops += ("awq_moe_single_token_weighted_reduce_out",)
         missing_ops = [name for name in required_ops if not hasattr(torch.ops._C, name)]
         if missing_ops:
             raise RuntimeError(
@@ -726,6 +731,49 @@ class Mxfp4SM70MoEMethod(Mxfp4MoEMethod):
             and layer.expert_map is None
             and layer.local_num_experts == layer.global_num_experts
         )
+        direct_order = (
+            direct_top6
+            and envs.VLLM_SM70_MXFP4_MOE_DIRECT_ORDER_DECODE
+            and topk_ids.dtype == torch.int32
+            and topk_ids.is_contiguous()
+        )
+        if direct_order:
+            route_ids = topk_ids.view(-1)
+            route_offsets = buffers["compact_expert_offsets"]
+            sm70_ops.mxfp4_moe_dense_stage_sm70_out(
+                buffers["gate_up"],
+                x,
+                route_offsets,
+                route_ids,
+                layer.w13_strided_ptrs_w,
+                layer.w13_strided_ptrs_s,
+                _DEEPSEEK_V4_FLASH_TOP_K,
+                layer.sm70_mxfp4_w13_k_dim,
+                layer.sm70_mxfp4_w13_n_dim,
+                layer.sm70_mxfp4_group_size,
+            )
+            self._apply_swiglu(layer, buffers["intermediate"], buffers["gate_up"])
+            sm70_ops.mxfp4_moe_dense_stage_sm70_out(
+                buffers["sorted_output"],
+                buffers["intermediate"],
+                route_offsets,
+                route_ids,
+                layer.w2_strided_ptrs_w,
+                layer.w2_strided_ptrs_s,
+                _DEEPSEEK_V4_FLASH_TOP_K,
+                layer.sm70_mxfp4_w2_k_dim,
+                layer.sm70_mxfp4_w2_n_dim,
+                layer.sm70_mxfp4_group_size,
+            )
+            sm70_ops.awq_moe_single_token_weighted_reduce_out(
+                buffers["sorted_output"],
+                topk_weights,
+                buffers["token_expert_indices"],
+                output,
+                _DEEPSEEK_V4_FLASH_TOP_K,
+                layer.sm70_mxfp4_hidden_size,
+            )
+            return output
         if direct_top6:
             sm70_ops.mxfp4_moe_single_token_prepare_w13_sm70_out(
                 buffers["gate_up"],

--- a/vllm/models/deepseek_v4/sm70/qnorm_rope_kv_fp8_insert.py
+++ b/vllm/models/deepseek_v4/sm70/qnorm_rope_kv_fp8_insert.py
@@ -5,8 +5,12 @@
 
 import torch
 
+import vllm.envs as envs
 from vllm.models.deepseek_v4.common.ops.cache_utils import (
     quantize_and_insert_k_cache,
+)
+from vllm.models.deepseek_v4.common.ops.fp8_software import (
+    fp32_to_fp8_e4m3fn_bits,
 )
 from vllm.triton_utils import tl, triton
 
@@ -93,6 +97,111 @@ def _sm70_qnorm_rope_kernel(
         )
 
 
+@triton.jit
+def _sm70_qnorm_rope_parallel_kv_insert_kernel(
+    q_ptr,
+    kv_ptr,
+    cache_ptr,
+    slot_mapping_ptr,
+    positions_ptr,
+    cos_sin_cache_ptr,
+    cache_stride0,
+    eps: tl.constexpr,
+    num_tokens,
+    num_heads: tl.constexpr,
+    cache_block_size: tl.constexpr,
+    HEAD_DIM: tl.constexpr,
+    ROPE_DIM: tl.constexpr,
+    NOPE_DIM: tl.constexpr,
+    HALF_ROPE: tl.constexpr,
+    TOKEN_DATA_SIZE: tl.constexpr,
+):
+    """Fuse TP4 Q transform with eight exact packed-KV writer CTAs."""
+    token_idx = tl.program_id(0)
+    worker_idx = tl.program_id(1)
+    if token_idx >= num_tokens:
+        return
+
+    if worker_idx < num_heads:
+        q_position = tl.load(positions_ptr + token_idx).to(tl.int64)
+        q_pair_idx = tl.arange(0, HALF_ROPE)
+        q_cos = tl.load(cos_sin_cache_ptr + q_position * ROPE_DIM + q_pair_idx).to(
+            tl.float32
+        )
+        q_sin = tl.load(
+            cos_sin_cache_ptr + q_position * ROPE_DIM + HALF_ROPE + q_pair_idx
+        ).to(tl.float32)
+        q_base = q_ptr + token_idx * num_heads * HEAD_DIM + worker_idx * HEAD_DIM
+        q_offsets = tl.arange(0, HEAD_DIM)
+        q_values = tl.load(q_base + q_offsets).to(tl.float32)
+        q_rrms = tl.rsqrt(tl.sum(q_values * q_values, axis=0) / HEAD_DIM + eps)
+        q_values *= q_rrms
+        tl.store(
+            q_base + q_offsets,
+            q_values.to(q_ptr.type.element_ty),
+            mask=q_offsets < NOPE_DIM,
+        )
+
+        q_even_offsets = NOPE_DIM + q_pair_idx * 2
+        q_odd_offsets = q_even_offsets + 1
+        q_even = tl.load(q_base + q_even_offsets).to(tl.float32) * q_rrms
+        q_odd = tl.load(q_base + q_odd_offsets).to(tl.float32) * q_rrms
+        tl.store(
+            q_base + q_even_offsets,
+            (q_even * q_cos - q_odd * q_sin).to(q_ptr.type.element_ty),
+        )
+        tl.store(
+            q_base + q_odd_offsets,
+            (q_even * q_sin + q_odd * q_cos).to(q_ptr.type.element_ty),
+        )
+    else:
+        part_idx = worker_idx - num_heads
+        slot_idx = tl.load(slot_mapping_ptr + token_idx)
+        if slot_idx < 0:
+            return
+
+        block_idx = slot_idx // cache_block_size
+        pos_in_block = slot_idx % cache_block_size
+        cache_block = cache_ptr + block_idx.to(tl.int64) * cache_stride0
+        token_data = cache_block + pos_in_block * TOKEN_DATA_SIZE
+        token_scales = (
+            cache_block + cache_block_size * TOKEN_DATA_SIZE + pos_in_block * 8
+        )
+        kv_row = kv_ptr + token_idx * HEAD_DIM
+        kv_offsets = tl.arange(0, 64)
+        if part_idx < 7:
+            input_offsets = part_idx * 64 + kv_offsets
+            kv_values = tl.load(kv_row + input_offsets)
+            block_max = tl.maximum(tl.max(tl.abs(kv_values), axis=0), 1.0e-4)
+            exponent = tl.ceil(tl.log2(block_max / 448.0))
+            scale = tl.exp2(exponent)
+            scaled = tl.clamp(kv_values / scale, -448.0, 448.0)
+            packed = fp32_to_fp8_e4m3fn_bits(scaled.to(tl.float32))
+            tl.store(token_data + input_offsets, packed)
+            encoded = tl.maximum(tl.minimum(exponent + 127.0, 255.0), 0.0)
+            tl.store(token_scales + part_idx, encoded.to(tl.uint8))
+        else:
+            tl.store(token_scales + 7, tl.zeros((), dtype=tl.uint8))
+            kv_position = tl.load(positions_ptr + token_idx).to(tl.int64)
+            kv_pair_idx = tl.arange(0, HALF_ROPE)
+            kv_cos = tl.load(
+                cos_sin_cache_ptr + kv_position * ROPE_DIM + kv_pair_idx
+            ).to(tl.float32)
+            kv_sin = tl.load(
+                cos_sin_cache_ptr + kv_position * ROPE_DIM + HALF_ROPE + kv_pair_idx
+            ).to(tl.float32)
+            kv_even = tl.load(kv_row + NOPE_DIM + kv_pair_idx * 2).to(tl.float32)
+            kv_odd = tl.load(kv_row + NOPE_DIM + kv_pair_idx * 2 + 1).to(tl.float32)
+            rotated_even = (kv_even * kv_cos - kv_odd * kv_sin).to(tl.float16)
+            rotated_odd = (kv_even * kv_sin + kv_odd * kv_cos).to(tl.float16)
+            bf16_out = (token_data + NOPE_DIM).to(tl.pointer_type(tl.bfloat16))
+            tl.store(bf16_out + kv_pair_idx * 2, rotated_even.to(tl.bfloat16))
+            tl.store(
+                bf16_out + kv_pair_idx * 2 + 1,
+                rotated_odd.to(tl.bfloat16),
+            )
+
+
 def sm70_qnorm_rope_kv_fp8_insert(
     q: torch.Tensor,
     kv: torch.Tensor,
@@ -112,6 +221,29 @@ def sm70_qnorm_rope_kv_fp8_insert(
     assert q.is_contiguous() and kv.is_contiguous()
 
     num_tokens, num_heads, _ = q.shape
+    if envs.VLLM_SM70_DSV4_QNORM_KV_FUSED_TP4 and num_tokens == 1 and num_heads == 16:
+        cache_2d = swa_kv_cache.view(swa_kv_cache.shape[0], -1)
+        _sm70_qnorm_rope_parallel_kv_insert_kernel[(num_tokens, num_heads + 8)](
+            q,
+            kv,
+            cache_2d,
+            slot_mapping,
+            positions,
+            cos_sin_cache,
+            cache_2d.stride(0),
+            eps,
+            slot_mapping.shape[0],
+            num_heads=num_heads,
+            cache_block_size=block_size,
+            HEAD_DIM=_HEAD_DIM,
+            ROPE_DIM=_ROPE_DIM,
+            NOPE_DIM=_NOPE_DIM,
+            HALF_ROPE=_HALF_ROPE,
+            TOKEN_DATA_SIZE=576,
+            num_warps=4,
+        )
+        return q
+
     kv_roped = torch.empty_like(kv)
     _sm70_qnorm_rope_kernel[(num_tokens, num_heads + 1)](
         q,

--- a/vllm/models/deepseek_v4/sm70/qnorm_rope_kv_fp8_insert.py
+++ b/vllm/models/deepseek_v4/sm70/qnorm_rope_kv_fp8_insert.py
@@ -232,7 +232,7 @@ def sm70_qnorm_rope_kv_fp8_insert(
             cos_sin_cache,
             cache_2d.stride(0),
             eps,
-            slot_mapping.shape[0],
+            num_tokens,
             num_heads=num_heads,
             cache_block_size=block_size,
             HEAD_DIM=_HEAD_DIM,

--- a/vllm/models/deepseek_v4/sm70/sparse.py
+++ b/vllm/models/deepseek_v4/sm70/sparse.py
@@ -40,6 +40,11 @@ if TYPE_CHECKING:
 logger = init_logger(__name__)
 
 
+def _qk_dsplit_block_h(num_heads: int) -> int:
+    """Use one CTA head group for the exact TP4 decode shape."""
+    return 16 if num_heads == 16 else 8
+
+
 class DeepseekV4SM70SparseBackend(DeepseekV4FlashMLASparseBackend):
     supported_dtypes: ClassVar[list[torch.dtype]] = [torch.float16]
 
@@ -258,6 +263,7 @@ class DeepseekV4SM70SparseImpl(DeepseekV4SparseMLAAttentionImpl):
                 sm70_sparse_attention_paged_fp8_splitk_qk_dsplit(
                     partial_qk=partial_qk,
                     partial_probs=partial_probs,
+                    stage1_block_h=_qk_dsplit_block_h(q.shape[1]),
                     **common_kwargs,
                 )
             else:


### PR DESCRIPTION
## Purpose

Rebuild and repair PR #308 on the latest main at f5fc157c49716c3cb9cbe269d607f38d669be479.

This PR carries four independently audited SM70 PP2 x TP4 decode optimizations:

- use one 16-head sparse-MLA QK d-split group for the exact TP4 shape;
- fuse the existing Q normalization/RoPE programs and eight packed FP8-KV writers into one graph node;
- broadcast the physical B1 MXFP4 W13 input instead of copying it six times;
- retain top-k-6 route order and use the exact half2 reducer, removing sort and inverse-permutation work.

The validated compact-grouped, direct-top6, direct-order, broadcast-input, and fused-QNorm paths are default-on, each with an explicit environment rollback. Runtime admission remains exact hardware, dtype, tensor shape, token-count, topology, and expert-layout checks. No new model-name, checkpoint, model_type, or architecture-identity gate is added.

This PR supersedes #308 rather than modifying the agent-owned stack.

## Numerical and performance evidence

Sparse MLA head grouping:

- C4 median: 32.317 to 18.412 us, about 43% lower;
- C128 median: 15.278 to 10.609 us, about 31% lower;
- SWA median: 15.135 to 10.424 us, about 31% lower;
- C128/SWA bitwise equal;
- changing-input gate finite with max absolute 1.526e-5 and max relative L2 1.807e-5.

Artifact:
/data/models/v100-dsv4-0731-pp2tp4-sparse-head16-screen-20260826-r1/

QNorm/RoPE plus KV insertion:

- 64/64 changing-input CUDA Graph patterns bitwise equal for transformed Q and complete cache storage;
- median: 9.974 to 4.076 us, 2.45x;
- projected 43-layer saving: 0.254 ms/token.

Artifact:
/data/models/v100-dsv4-0731-pp2tp4-qnorm-kv-fusion-screen-20260826-r1/

MXFP4 direct pipeline:

- generic: 108.397 us/layer;
- current direct-top6: 54.414 us/layer;
- direct-order: 46.519 us/layer;
- direct-order saving versus direct-top6 projects to 0.339 ms/token across 43 layers;
- W13, clamped SwiGLU, W2, and final output are bitwise equal initially and after route IDs change under CUDA Graph;
- top-k-6, H=4096 weighted reduction matches the existing unpermute oracle exactly.

Artifact:
/data/models/v100-dsv4-0731-pp2tp4-mxfp4-direct-order-screen-20260826-r1/results/full_pipeline.json

## Audit repairs

- default the proven compact-grouped, direct-top6, and direct-order paths while retaining =0 rollbacks;
- use q.shape[0] as the fused kernel token bound instead of deriving it from slot-mapping storage;
- replace a direct torch.cuda synchronize call in the test with torch.accelerator;
- reformat the transplanted CUDA hunk against the current main and verify token equivalence.

## Test plan and result

- 3 latest-main CPU route/default tests: passed under Python 3.12 and Torch 2.10 with the matching source-built extension.
- CUDA 12.8 SM70 source build from the original stack: passed; SM70 cubins only.
- focused V100 operator/graph gates listed above: passed.
- pre-commit run -a on latest main: all hooks passed.
- C++ pre/post-format normalized token stream: identical.
- git diff --check: passed.

All eight V100s are currently occupied by existing user services/tasks, so no redundant GPU rerun or end-to-end serving run was started. The existing operator artifacts are the acceptance evidence.
