### PR TITLE
[Kernel][SM70] Default safe FP8 prescaled M1 decode

### DIFF
--- a/csrc/ops.h
+++ b/csrc/ops.h
@@ -220,6 +220,12 @@ void fp8_gemm_sm70_prefill_prescaled_out(torch::Tensor out,
                                          int64_t group_size, int64_t k_ld,
                                          int64_t q_ld);
 
+void fp8_gemm_sm70_prescaled_m1_out(torch::Tensor out, torch::Tensor _in_feats,
+                                    torch::Tensor _kernel,
+                                    torch::Tensor _prescaled_factors,
+                                    int64_t group_size, int64_t k_ld,
+                                    int64_t q_ld);
+
 std::vector<torch::Tensor> nvfp4_qpn2_prepare_sm70(torch::Tensor weight_packed,
                                                    torch::Tensor weight_scale);
 

--- a/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/gemm.cu
+++ b/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/gemm.cu
@@ -280,6 +280,23 @@ std::optional<Sm70AwqTp2FastTarget> GetSm70Fp8BlockPrefillPrescaledTarget(
     return Sm70AwqTp2FastTarget{
         desc.n, desc.k, 64, 256, 16, 1, 3, true, "sm70_fp8_pscale_full"};
   }
+  if (desc_str == "sm70_f16_e4m3k128_f16_tnt_fff_1x1536x4096_1") {
+    return Sm70AwqTp2FastTarget{desc.n, desc.k, 8, 128, 64, 5, 1, true,
+                                "sm70_fp8_pscale_dsv4_m1"};
+  }
+  if (desc_str == "sm70_f16_e4m3k128_f16_tnt_fff_1x8192x1024_1" ||
+      desc_str == "sm70_f16_e4m3k128_f16_tnt_fff_1x4096x2048_1") {
+    return Sm70AwqTp2FastTarget{desc.n, desc.k, 8, 128, 64, 2, 3, true,
+                                "sm70_fp8_pscale_dsv4_m1"};
+  }
+  if (desc_str == "sm70_f16_e4m3k128_f16_tnt_fff_1x1024x4096_1") {
+    return Sm70AwqTp2FastTarget{desc.n, desc.k, 8, 128, 64, 7, 1, true,
+                                "sm70_fp8_pscale_dsv4_m1"};
+  }
+  if (desc_str == "sm70_f16_e4m3k128_f16_tnt_fff_1x4096x512_1") {
+    return Sm70AwqTp2FastTarget{desc.n, desc.k, 8, 128, 64, 2, 1, true,
+                                "sm70_fp8_pscale_dsv4_m1"};
+  }
   return std::nullopt;
 }
 
@@ -461,8 +478,13 @@ struct Gemm::Impl {
   LaunchSpec Dispatch(Context& ctx, DispatchPolicy policy, size_t barriers_size,
                       size_t partials_size) {
     const auto& desc = ctx.desc();
+    const bool allow_prescaled =
+        policy & DispatchPolicy::kSm70Fp8PrefillPrescaled;
     const auto is_feasible = [&](const LaunchSpec& spec) {
       return spec.kernel &&
+             (allow_prescaled ||
+              spec.kernel->name().find("_sm70_fp8_pscale") ==
+                  std::string::npos) &&
              spec.kernel->is_feasible(ctx.get_desc(*spec.kernel));
     };
     if (policy & DispatchPolicy::kSm70Fp8PrefillPrescaled) {
@@ -471,7 +493,7 @@ struct Gemm::Impl {
         return *spec;
       }
       if (auto fast_target = GetSm70Fp8BlockPrefillPrescaledTarget(desc)) {
-        auto specs = Find(ctx, barriers_size, partials_size, 0);
+        auto specs = Find(ctx, barriers_size, partials_size, 0, true);
         if (auto fast_spec = SelectSm70AwqTp2FastSpec(
                 ctx, specs, *fast_target, barriers_size, partials_size)) {
           sm70_fp8_prefill_cache_.Insert(desc, *fast_spec);
@@ -482,7 +504,7 @@ struct Gemm::Impl {
     }
     if (policy & DispatchPolicy::kMxfp4MoeGroupedM8Fast) {
       if (auto fast_target = GetSm70Mxfp4MoeGroupedM8FastTarget(desc)) {
-        auto specs = Find(ctx, barriers_size, partials_size, 0);
+        auto specs = Find(ctx, barriers_size, partials_size, 0, false);
         if (auto fast_spec = SelectSm70AwqTp2FastSpec(
                 ctx, specs, *fast_target, barriers_size, partials_size)) {
           return *fast_spec;
@@ -506,7 +528,8 @@ struct Gemm::Impl {
     }
 
     const auto fast_target = GetSm70AwqTp2FastTarget(desc);
-    auto specs = Find(ctx, barriers_size, partials_size, fast_target ? 0 : 1);
+    auto specs =
+        Find(ctx, barriers_size, partials_size, fast_target ? 0 : 1, false);
     if (!specs.empty()) {
       auto selected = specs.front();
       if (fast_target) {
@@ -522,8 +545,16 @@ struct Gemm::Impl {
   }
 
   std::vector<LaunchSpec> Find(Context& ctx, size_t barrier_size,
-                               size_t partials_size, int top_k) {
+                               size_t partials_size, int top_k,
+                               bool include_prescaled) {
     std::vector<Kernel*> feasible = ctx.Filter(registry_.kernels());
+    if (!include_prescaled) {
+      feasible.erase(
+          std::remove_if(feasible.begin(), feasible.end(), [](const Kernel* k) {
+            return k->name().find("_sm70_fp8_pscale") != std::string::npos;
+          }),
+          feasible.end());
+    }
 
     std::vector<std::vector<LaunchSpec>> clusters;
     {
@@ -618,7 +649,8 @@ struct Gemm::Impl {
     // std::cerr << "GEMM: " << desc.m << "x" << desc.n << "x" << desc.k <<
     // "\n";
 
-    const auto tmp = Find(ctx, barriers_size, partials_size, tuning_.top_k);
+    const auto tmp =
+        Find(ctx, barriers_size, partials_size, tuning_.top_k, false);
 
     std::vector<LaunchSpec> specs;
     for (const auto& spec : tmp) {
@@ -761,7 +793,7 @@ int Gemm::Run(const Operation& operation, float alpha, const void* A,
         (preserve_default_kernel || preserve_default_split_count)) {
       auto default_specs =
           impl_->Find(*dispatch_context, workspace.barriers_size,
-                      workspace.partials_size, 1);
+                      workspace.partials_size, 1, false);
       if (!default_specs.empty()) {
         const auto default_spec = default_specs.front();
         if (preserve_default_kernel) {

--- a/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/gemm.cu
+++ b/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/gemm.cu
@@ -282,20 +282,20 @@ std::optional<Sm70AwqTp2FastTarget> GetSm70Fp8BlockPrefillPrescaledTarget(
   }
   if (desc_str == "sm70_f16_e4m3k128_f16_tnt_fff_1x1536x4096_1") {
     return Sm70AwqTp2FastTarget{desc.n, desc.k, 8, 128, 64, 5, 1, true,
-                                "sm70_fp8_pscale_dsv4_m1"};
+                                "sm70_fp8_pscale_m1"};
   }
   if (desc_str == "sm70_f16_e4m3k128_f16_tnt_fff_1x8192x1024_1" ||
       desc_str == "sm70_f16_e4m3k128_f16_tnt_fff_1x4096x2048_1") {
     return Sm70AwqTp2FastTarget{desc.n, desc.k, 8, 128, 64, 2, 3, true,
-                                "sm70_fp8_pscale_dsv4_m1"};
+                                "sm70_fp8_pscale_m1"};
   }
   if (desc_str == "sm70_f16_e4m3k128_f16_tnt_fff_1x1024x4096_1") {
     return Sm70AwqTp2FastTarget{desc.n, desc.k, 8, 128, 64, 7, 1, true,
-                                "sm70_fp8_pscale_dsv4_m1"};
+                                "sm70_fp8_pscale_m1"};
   }
   if (desc_str == "sm70_f16_e4m3k128_f16_tnt_fff_1x4096x512_1") {
     return Sm70AwqTp2FastTarget{desc.n, desc.k, 8, 128, 64, 2, 1, true,
-                                "sm70_fp8_pscale_dsv4_m1"};
+                                "sm70_fp8_pscale_m1"};
   }
   return std::nullopt;
 }

--- a/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/kernel/sm70_884_8.cu
+++ b/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/kernel/sm70_884_8.cu
@@ -28,10 +28,10 @@ class Qwen38PrescaledFullTileKernelImpl final : public KernelImpl<Gemm> {
 };
 
 template <class Gemm>
-class Dsv4PrescaledM1KernelImpl final : public KernelImpl<Gemm> {
+class Fp8PrescaledM1KernelImpl final : public KernelImpl<Gemm> {
  public:
-  Dsv4PrescaledM1KernelImpl() {
-    this->info_.name += "_sm70_fp8_pscale_dsv4_m1";
+  Fp8PrescaledM1KernelImpl() {
+    this->info_.name += "_sm70_fp8_pscale_m1";
   }
 
   bool is_feasible(const GemmDesc& desc) const noexcept override {
@@ -72,8 +72,8 @@ void Registry::sm70_884_8() {
         using Q38PrescaledFull = CP::Type<64, 256, 16, 1, 4, 1, D, S, 2, true, 1, 128, 64, 128, 1, true>;
         Add(std::make_unique<Qwen38PrescaledFullTileKernelImpl<typename Q38PrescaledFull::Kernel>>());
 
-        using Dsv4PrescaledM1 = CP::Type<8, 128, 64, 1, 4, 1, D, S, 2, true, 1, 128>;
-        Add(std::make_unique<Dsv4PrescaledM1KernelImpl<typename Dsv4PrescaledM1::Kernel>>());
+        using Fp8PrescaledM1 = CP::Type<8, 128, 64, 1, 4, 1, D, S, 2, true, 1, 128>;
+        Add(std::make_unique<Fp8PrescaledM1KernelImpl<typename Fp8PrescaledM1::Kernel>>());
     // clang-format on
   }
 }

--- a/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/kernel/sm70_884_8.cu
+++ b/csrc/sm70_turbomind/lmdeploy/src/turbomind/kernels/gemm/kernel/sm70_884_8.cu
@@ -27,6 +27,27 @@ class Qwen38PrescaledFullTileKernelImpl final : public KernelImpl<Gemm> {
   }
 };
 
+template <class Gemm>
+class Dsv4PrescaledM1KernelImpl final : public KernelImpl<Gemm> {
+ public:
+  Dsv4PrescaledM1KernelImpl() {
+    this->info_.name += "_sm70_fp8_pscale_dsv4_m1";
+  }
+
+  bool is_feasible(const GemmDesc& desc) const noexcept override {
+    if (desc.m != 1 || desc.num != 1) {
+      return false;
+    }
+    const bool accepted_shape =
+        (desc.n == 1536 && desc.k == 4096) ||
+        (desc.n == 8192 && desc.k == 1024) ||
+        (desc.n == 4096 && desc.k == 2048) ||
+        (desc.n == 1024 && desc.k == 4096) ||
+        (desc.n == 4096 && desc.k == 512);
+    return accepted_shape && KernelImpl<Gemm>::is_feasible(desc);
+  }
+};
+
 }  // namespace
 
 void Registry::sm70_884_8() {
@@ -50,6 +71,9 @@ void Registry::sm70_884_8() {
         using CP = Config_E4M3_Prescaled<kColMajor, 0>;
         using Q38PrescaledFull = CP::Type<64, 256, 16, 1, 4, 1, D, S, 2, true, 1, 128, 64, 128, 1, true>;
         Add(std::make_unique<Qwen38PrescaledFullTileKernelImpl<typename Q38PrescaledFull::Kernel>>());
+
+        using Dsv4PrescaledM1 = CP::Type<8, 128, 64, 1, 4, 1, D, S, 2, true, 1, 128>;
+        Add(std::make_unique<Dsv4PrescaledM1KernelImpl<typename Dsv4PrescaledM1::Kernel>>());
     // clang-format on
   }
 }

--- a/csrc/sm70_turbomind/ops/awq_sm70_gemm.cu
+++ b/csrc/sm70_turbomind/ops/awq_sm70_gemm.cu
@@ -3510,10 +3510,19 @@ void fp8_gemm_sm70_out(torch::Tensor out, torch::Tensor in_feats,
   TORCH_CHECK(out.stride(1) == 1,
               "fp8_gemm_sm70: output must be row-major contiguous.");
   if (exact_8k_prefill_prescaled) {
-    TORCH_CHECK(
-        m == 8000 && k == 5120 && (n == 4096 || n == 3584) && !gated_silu,
-        "fp8_gemm_sm70: pre-scaled block-FP8 prefill requires "
-        "M=8000, K=5120, N=4096/3584, and no fused epilogue.");
+    const bool qwen38_prefill =
+        m == 8000 && k == 5120 && (n == 4096 || n == 3584);
+    const bool dsv4_m1 =
+        m == 1 && ((n == 1536 && k == 4096) ||
+                   (n == 8192 && k == 1024) ||
+                   (n == 4096 && k == 2048) ||
+                   (n == 1024 && k == 4096) ||
+                   (n == 4096 && k == 512));
+    TORCH_CHECK(qwen38_prefill || dsv4_m1,
+                "fp8_gemm_sm70: pre-scaled block-FP8 requires an accepted "
+                "Qwen3.8 prefill or DeepSeek V4 M=1 shape.");
+    TORCH_CHECK(!gated_silu,
+                "fp8_gemm_sm70: pre-scaled path does not fuse gated SILU.");
   }
   if (gated_silu) {
     TORCH_CHECK((n % 2) == 0,

--- a/csrc/sm70_turbomind/ops/awq_sm70_gemm.cu
+++ b/csrc/sm70_turbomind/ops/awq_sm70_gemm.cu
@@ -3512,15 +3512,13 @@ void fp8_gemm_sm70_out(torch::Tensor out, torch::Tensor in_feats,
   if (exact_8k_prefill_prescaled) {
     const bool qwen38_prefill =
         m == 8000 && k == 5120 && (n == 4096 || n == 3584);
-    const bool dsv4_m1 =
-        m == 1 && ((n == 1536 && k == 4096) ||
-                   (n == 8192 && k == 1024) ||
-                   (n == 4096 && k == 2048) ||
-                   (n == 1024 && k == 4096) ||
+    const bool prescaled_m1 =
+        m == 1 && ((n == 1536 && k == 4096) || (n == 8192 && k == 1024) ||
+                   (n == 4096 && k == 2048) || (n == 1024 && k == 4096) ||
                    (n == 4096 && k == 512));
-    TORCH_CHECK(qwen38_prefill || dsv4_m1,
+    TORCH_CHECK(qwen38_prefill || prescaled_m1,
                 "fp8_gemm_sm70: pre-scaled block-FP8 requires an accepted "
-                "Qwen3.8 prefill or DeepSeek V4 M=1 shape.");
+                "8K prefill or M=1 tensor shape.");
     TORCH_CHECK(!gated_silu,
                 "fp8_gemm_sm70: pre-scaled path does not fuse gated SILU.");
   }
@@ -5575,6 +5573,17 @@ void fp8_gemm_sm70_prefill_prescaled_out(torch::Tensor out,
                                          torch::Tensor _prescaled_factors,
                                          int64_t group_size, int64_t k_ld,
                                          int64_t q_ld) {
+  vllm::awq_sm70::fp8_gemm_sm70_out(out, _in_feats, _kernel, _prescaled_factors,
+                                    group_size, k_ld, q_ld, false, true);
+}
+
+void fp8_gemm_sm70_prescaled_m1_out(torch::Tensor out, torch::Tensor _in_feats,
+                                    torch::Tensor _kernel,
+                                    torch::Tensor _prescaled_factors,
+                                    int64_t group_size, int64_t k_ld,
+                                    int64_t q_ld) {
+  TORCH_CHECK(_in_feats.dim() == 2 && _in_feats.size(0) == 1,
+              "fp8_gemm_sm70_prescaled_m1_out requires a rank-2 M=1 input.");
   vllm::awq_sm70::fp8_gemm_sm70_out(out, _in_feats, _kernel, _prescaled_factors,
                                     group_size, k_ld, q_ld, false, true);
 }

--- a/csrc/torch_bindings.cpp
+++ b/csrc/torch_bindings.cpp
@@ -323,6 +323,15 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, ops) {
   ops.impl("fp8_gemm_sm70_prefill_prescaled_out", torch::kCUDA,
            &fp8_gemm_sm70_prefill_prescaled_out);
 
+  // A distinct schema is also a capability marker: older extensions expose
+  // only the 8K-prefill contract and must not receive the new M=1 shapes.
+  ops.def(
+      "fp8_gemm_sm70_prescaled_m1_out(Tensor(a!) out, Tensor _in_feats, "
+      "Tensor _kernel, Tensor _prescaled_factors, int group_size, int k_ld, "
+      "int q_ld) -> ()");
+  ops.impl("fp8_gemm_sm70_prescaled_m1_out", torch::kCUDA,
+           &fp8_gemm_sm70_prescaled_m1_out);
+
   ops.def(
       "nvfp4_qpn2_prepare_sm70(Tensor weight_packed, Tensor weight_scale) -> "
       "Tensor[]");

--- a/docs/design/sm70_v100_migration_control.md
+++ b/docs/design/sm70_v100_migration_control.md
@@ -43679,7 +43679,7 @@ Interpretation:
   `mistral_common` (`NamedToolChoice` import); no service or end-to-end run is
   claimed.
 
-## 2026-08-26 DeepSeek V4 exact FP8 prescaled-decode screen
+## 2026-08-26 exact SM70 FP8 prescaled-M1 decode screen
 
 - The SM70 E4M3 transform normally applies the exact exponent-bias factor and
   the checkpoint block scale as two FP16 multiplies. DeepSeek V4 UE8M0 block
@@ -43697,7 +43697,11 @@ Interpretation:
 - Production admission is initially narrower than the operator screen: SM70,
   UE8M0 128x128 block scales, PP2 x TP4, one sequence, no DBO/ubatching or
   speculation, M=1, and the exact replicated K4096/N1536 fused-WQA/WKV role.
-  Prefill, gated activation, other shapes, and other scale formats retain the
-  original TurboMind transform. The route is opt-in through
-  `VLLM_SM70_DSV4_FP8_PRESCALED_DECODE=1` until matched full-model speed and
-  pinned dataset gates complete.
+  Model loading also requires the actual FP16 scales to remain finite and
+  bitwise reversible after the 256x exponent shift. Prefill, gated activation,
+  other shapes, other scale formats, missing operators, and unsupported scale
+  ranges retain the original TurboMind transform. The route is default-on for
+  the exact tensor/runtime contract; `VLLM_SM70_FP8_PRESCALED_M1_DECODE=0`
+  is the rollback. An explicit `=1` fails closed when its contract cannot be
+  honored. Admission never reads model name, checkpoint, `model_type`, or
+  architecture identity.

--- a/docs/design/sm70_v100_migration_control.md
+++ b/docs/design/sm70_v100_migration_control.md
@@ -43678,3 +43678,26 @@ Interpretation:
   blocked before collection by the environment's unrelated stale
   `mistral_common` (`NamedToolChoice` import); no service or end-to-end run is
   claimed.
+
+## 2026-08-26 DeepSeek V4 exact FP8 prescaled-decode screen
+
+- The SM70 E4M3 transform normally applies the exact exponent-bias factor and
+  the checkpoint block scale as two FP16 multiplies. DeepSeek V4 UE8M0 block
+  scales are powers of two, so multiplying each prepared scale by 256 once at
+  load time removes the per-fragment exponent-bias multiply without changing
+  the MMA layout, split count, swizzle, FP32 accumulation order, or FP16
+  epilogue.
+- A same-process CUDA Graph A/B/B/A screen uses real layer-0 TP4-rank-0
+  weights and the five non-gated M=1 decode shapes. All 320 changing-input
+  comparisons are bitwise equal. The fused WQA/WKV projection improves from
+  63.330 to 20.577 microseconds (`3.078x`); the weighted five-shape projection
+  saves 1.867 ms/token warm and 1.821 ms/token after a 256-MiB cache scrub.
+  Evidence is under
+  `/data/models/v100-dsv4-0731-pp2tp4-fp8-prescaled-decode-screen-20260826-r1/`.
+- Production admission is initially narrower than the operator screen: SM70,
+  UE8M0 128x128 block scales, PP2 x TP4, one sequence, no DBO/ubatching or
+  speculation, M=1, and the exact replicated K4096/N1536 fused-WQA/WKV role.
+  Prefill, gated activation, other shapes, and other scale formats retain the
+  original TurboMind transform. The route is opt-in through
+  `VLLM_SM70_DSV4_FP8_PRESCALED_DECODE=1` until matched full-model speed and
+  pinned dataset gates complete.

--- a/tests/quantization/test_sm70_fp8_prefill_exact_dense.py
+++ b/tests/quantization/test_sm70_fp8_prefill_exact_dense.py
@@ -25,6 +25,7 @@ from vllm.model_executor.layers.quantization.fp8 import (
     _SM70_FP8_PREFILL_DENSE_WORKSPACE_BYTES,
     Fp8LinearMethod,
     _get_sm70_fp8_prefill_exact_dense_workspace,
+    _is_sm70_dsv4_fp8_prescaled_decode_layer,
     _is_sm70_fp8_exact_8k_prefill_layer,
     _is_sm70_fp8_prefill_exact_dense_layer,
     _is_sm70_fp8_qpn8_layer,
@@ -673,6 +674,81 @@ def test_fp8_prefill_prescaled_scales_only_reach_exact_8k_route(monkeypatch):
     ]
     assert calls[0][2] is normal_scales
     assert calls[1][2] is prescaled_scales
+    assert calls[2][2] is normal_scales
+
+
+def test_dsv4_fp8_prescaled_decode_admission_is_exact():
+    layer = SimpleNamespace(
+        prefix="model.layers.2.attn.fused_wqa_wkv",
+        tp_size=1,
+        weight_block_size=[128, 128],
+        input_size_per_partition=4096,
+        output_size_per_partition=1536,
+        weight=torch.empty((1536, 4096), device="meta"),
+    )
+    assert _is_sm70_dsv4_fp8_prescaled_decode_layer(layer)
+
+    layer.tp_size = 4
+    assert not _is_sm70_dsv4_fp8_prescaled_decode_layer(layer)
+    layer.tp_size = 1
+    layer.prefix = "model.layers.2.attn.indexer.fused_wqa_wkv"
+    assert _is_sm70_dsv4_fp8_prescaled_decode_layer(layer)
+    layer.prefix = "model.layers.2.attn.wq_b"
+    assert not _is_sm70_dsv4_fp8_prescaled_decode_layer(layer)
+
+
+def test_dsv4_fp8_prescaled_decode_only_handles_m1(monkeypatch):
+    calls = []
+
+    def fake_default(out, input, qweight, scales, *args):
+        calls.append(("default", input.shape[0], scales))
+        out.zero_()
+
+    def fake_prescaled(out, input, qweight, scales, *args):
+        calls.append(("prescaled", input.shape[0], scales))
+        out.zero_()
+
+    monkeypatch.setattr(
+        "vllm.model_executor.layers.quantization.fp8.sm70_ops.fp8_gemm_sm70_out",
+        fake_default,
+    )
+    monkeypatch.setattr(
+        "vllm.model_executor.layers.quantization.fp8.sm70_ops."
+        "fp8_gemm_sm70_prefill_prescaled_out",
+        fake_prescaled,
+    )
+    normal_scales = torch.empty((1, 6), dtype=torch.float16)
+    prescaled_scales = torch.empty((1, 6), dtype=torch.float16)
+    layer = SimpleNamespace(
+        sm70_fp8_turbomind=True,
+        sm70_fp8_bmm=False,
+        output_size_per_partition=6,
+        weight=torch.empty((4, 6), dtype=torch.uint8),
+        weight_scale_inv=normal_scales,
+        sm70_fp8_decode_prescaled_scales=prescaled_scales,
+        sm70_fp8_k_ld=4,
+        sm70_fp8_q_ld=6,
+    )
+    method = SimpleNamespace()
+
+    monkeypatch.setenv("VLLM_SM70_DSV4_FP8_PRESCALED_DECODE", "1")
+    envs.disable_envs_cache()
+    try:
+        Fp8LinearMethod.apply(method, layer, torch.empty((1, 4), dtype=torch.float16))
+        Fp8LinearMethod.apply(method, layer, torch.empty((2, 4), dtype=torch.float16))
+        monkeypatch.setenv("VLLM_SM70_DSV4_FP8_PRESCALED_DECODE", "0")
+        envs.disable_envs_cache()
+        Fp8LinearMethod.apply(method, layer, torch.empty((1, 4), dtype=torch.float16))
+    finally:
+        envs.disable_envs_cache()
+
+    assert [(route, m) for route, m, _ in calls] == [
+        ("prescaled", 1),
+        ("default", 2),
+        ("default", 1),
+    ]
+    assert calls[0][2] is prescaled_scales
+    assert calls[1][2] is normal_scales
     assert calls[2][2] is normal_scales
 
 

--- a/tests/quantization/test_sm70_fp8_prefill_exact_dense.py
+++ b/tests/quantization/test_sm70_fp8_prefill_exact_dense.py
@@ -25,13 +25,14 @@ from vllm.model_executor.layers.quantization.fp8 import (
     _SM70_FP8_PREFILL_DENSE_WORKSPACE_BYTES,
     Fp8LinearMethod,
     _get_sm70_fp8_prefill_exact_dense_workspace,
-    _is_sm70_dsv4_fp8_prescaled_decode_layer,
     _is_sm70_fp8_exact_8k_prefill_layer,
     _is_sm70_fp8_prefill_exact_dense_layer,
+    _is_sm70_fp8_prescaled_m1_decode_layer,
     _is_sm70_fp8_qpn8_layer,
     _is_sm70_fp8_qpn8_runtime_contract,
     _sm70_fp8_prefill_dense_workspaces,
     _sm70_fp8_prefill_visible_dense_mm,
+    _try_sm70_fp8_prescaled_decode_scales,
 )
 
 
@@ -677,7 +678,7 @@ def test_fp8_prefill_prescaled_scales_only_reach_exact_8k_route(monkeypatch):
     assert calls[2][2] is normal_scales
 
 
-def test_dsv4_fp8_prescaled_decode_admission_is_exact():
+def test_fp8_prescaled_m1_decode_admission_is_exact():
     layer = SimpleNamespace(
         prefix="model.layers.2.attn.fused_wqa_wkv",
         tp_size=1,
@@ -686,18 +687,38 @@ def test_dsv4_fp8_prescaled_decode_admission_is_exact():
         output_size_per_partition=1536,
         weight=torch.empty((1536, 4096), device="meta"),
     )
-    assert _is_sm70_dsv4_fp8_prescaled_decode_layer(layer)
+    assert _is_sm70_fp8_prescaled_m1_decode_layer(layer)
 
     layer.tp_size = 4
-    assert not _is_sm70_dsv4_fp8_prescaled_decode_layer(layer)
+    assert not _is_sm70_fp8_prescaled_m1_decode_layer(layer)
     layer.tp_size = 1
     layer.prefix = "model.layers.2.attn.indexer.fused_wqa_wkv"
-    assert _is_sm70_dsv4_fp8_prescaled_decode_layer(layer)
+    assert _is_sm70_fp8_prescaled_m1_decode_layer(layer)
     layer.prefix = "model.layers.2.attn.wq_b"
-    assert not _is_sm70_dsv4_fp8_prescaled_decode_layer(layer)
+    assert not _is_sm70_fp8_prescaled_m1_decode_layer(layer)
 
 
-def test_dsv4_fp8_prescaled_decode_only_handles_m1(monkeypatch):
+def test_fp8_prescaled_m1_decode_scale_gate_is_reversible():
+    scales = torch.tensor([2**-12, 2**-11, 0.0], dtype=torch.float16)
+    prescaled = _try_sm70_fp8_prescaled_decode_scales(scales)
+    assert prescaled is not None
+    torch.testing.assert_close(prescaled, scales * 256, rtol=0, atol=0)
+
+    assert (
+        _try_sm70_fp8_prescaled_decode_scales(
+            torch.tensor([512.0], dtype=torch.float16)
+        )
+        is None
+    )
+    assert (
+        _try_sm70_fp8_prescaled_decode_scales(
+            torch.tensor([-(2**-12)], dtype=torch.float16)
+        )
+        is None
+    )
+
+
+def test_fp8_prescaled_m1_decode_only_handles_m1(monkeypatch):
     calls = []
 
     def fake_default(out, input, qweight, scales, *args):
@@ -714,7 +735,7 @@ def test_dsv4_fp8_prescaled_decode_only_handles_m1(monkeypatch):
     )
     monkeypatch.setattr(
         "vllm.model_executor.layers.quantization.fp8.sm70_ops."
-        "fp8_gemm_sm70_prefill_prescaled_out",
+        "fp8_gemm_sm70_prescaled_m1_out",
         fake_prescaled,
     )
     normal_scales = torch.empty((1, 6), dtype=torch.float16)
@@ -731,12 +752,12 @@ def test_dsv4_fp8_prescaled_decode_only_handles_m1(monkeypatch):
     )
     method = SimpleNamespace()
 
-    monkeypatch.setenv("VLLM_SM70_DSV4_FP8_PRESCALED_DECODE", "1")
+    monkeypatch.setenv("VLLM_SM70_FP8_PRESCALED_M1_DECODE", "1")
     envs.disable_envs_cache()
     try:
         Fp8LinearMethod.apply(method, layer, torch.empty((1, 4), dtype=torch.float16))
         Fp8LinearMethod.apply(method, layer, torch.empty((2, 4), dtype=torch.float16))
-        monkeypatch.setenv("VLLM_SM70_DSV4_FP8_PRESCALED_DECODE", "0")
+        monkeypatch.setenv("VLLM_SM70_FP8_PRESCALED_M1_DECODE", "0")
         envs.disable_envs_cache()
         Fp8LinearMethod.apply(method, layer, torch.empty((1, 4), dtype=torch.float16))
     finally:

--- a/tests/test_envs.py
+++ b/tests/test_envs.py
@@ -147,6 +147,12 @@ def test_sm70_concurrency_tuning_envs(
     monkeypatch.setenv(name, "0")
     assert environment_variables[name]() is False
 
+    name = "VLLM_SM70_FP8_PRESCALED_M1_DECODE"
+    monkeypatch.delenv(name, raising=False)
+    assert environment_variables[name]() is True
+    monkeypatch.setenv(name, "0")
+    assert environment_variables[name]() is False
+
     name = "VLLM_SM70_MXFP4_MOE_BROADCAST_INPUT_DECODE"
     monkeypatch.delenv(name, raising=False)
     assert environment_variables[name]() is True

--- a/vllm/_sm70_ops.py
+++ b/vllm/_sm70_ops.py
@@ -490,6 +490,35 @@ if hasattr(torch.ops._C, "fp8_gemm_sm70_prefill_prescaled_out"):
         return None
 
 
+def fp8_gemm_sm70_prescaled_m1_out(
+    out: torch.Tensor,
+    input: torch.Tensor,
+    qweight: torch.Tensor,
+    prescaled_factors: torch.Tensor,
+    group_size: int,
+    k_ld: int,
+    q_ld: int,
+) -> None:
+    _op("fp8_gemm_sm70_prescaled_m1_out")(
+        out, input, qweight, prescaled_factors, group_size, k_ld, q_ld
+    )
+
+
+if hasattr(torch.ops._C, "fp8_gemm_sm70_prescaled_m1_out"):
+
+    @register_fake("_C::fp8_gemm_sm70_prescaled_m1_out")
+    def _fp8_gemm_sm70_prescaled_m1_out_fake(
+        out: torch.Tensor,
+        input: torch.Tensor,
+        qweight: torch.Tensor,
+        prescaled_factors: torch.Tensor,
+        group_size: int,
+        k_ld: int,
+        q_ld: int,
+    ) -> None:
+        return None
+
+
 def fp8_qpn8_prepare_sm70(
     qweight: torch.Tensor,
     scales: torch.Tensor,

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -159,6 +159,7 @@ if TYPE_CHECKING:
     VLLM_SM70_FP8_GROUPED_BMM_DECODE: bool = True
     VLLM_SM70_FP8_PREFILL_FAST_SELECTOR: bool = True
     VLLM_SM70_FP8_PREFILL_PRESCALED: bool = True
+    VLLM_SM70_DSV4_FP8_PRESCALED_DECODE: bool = False
     VLLM_SM70_FP8_PREFILL_CUTLASS: bool = True
     VLLM_SM70_FP8_PRESERVE_DEFAULT_SPLITS: bool = True
     VLLM_SM70_FP8_PRESERVE_DEFAULT_SPLITS_ONLY: bool = False
@@ -1765,6 +1766,9 @@ environment_variables: dict[str, Callable[[], Any]] = {
     ),
     "VLLM_SM70_FP8_PREFILL_PRESCALED": lambda: bool(
         int(os.getenv("VLLM_SM70_FP8_PREFILL_PRESCALED", "1"))
+    ),
+    "VLLM_SM70_DSV4_FP8_PRESCALED_DECODE": lambda: bool(
+        int(os.getenv("VLLM_SM70_DSV4_FP8_PRESCALED_DECODE", "0"))
     ),
     "VLLM_SM70_FP8_PRESERVE_DEFAULT_SPLITS": lambda: bool(
         int(os.getenv("VLLM_SM70_FP8_PRESERVE_DEFAULT_SPLITS", "1"))

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -159,7 +159,7 @@ if TYPE_CHECKING:
     VLLM_SM70_FP8_GROUPED_BMM_DECODE: bool = True
     VLLM_SM70_FP8_PREFILL_FAST_SELECTOR: bool = True
     VLLM_SM70_FP8_PREFILL_PRESCALED: bool = True
-    VLLM_SM70_DSV4_FP8_PRESCALED_DECODE: bool = False
+    VLLM_SM70_FP8_PRESCALED_M1_DECODE: bool = True
     VLLM_SM70_FP8_PREFILL_CUTLASS: bool = True
     VLLM_SM70_FP8_PRESERVE_DEFAULT_SPLITS: bool = True
     VLLM_SM70_FP8_PRESERVE_DEFAULT_SPLITS_ONLY: bool = False
@@ -1767,8 +1767,8 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "VLLM_SM70_FP8_PREFILL_PRESCALED": lambda: bool(
         int(os.getenv("VLLM_SM70_FP8_PREFILL_PRESCALED", "1"))
     ),
-    "VLLM_SM70_DSV4_FP8_PRESCALED_DECODE": lambda: bool(
-        int(os.getenv("VLLM_SM70_DSV4_FP8_PRESCALED_DECODE", "0"))
+    "VLLM_SM70_FP8_PRESCALED_M1_DECODE": lambda: bool(
+        int(os.getenv("VLLM_SM70_FP8_PRESCALED_M1_DECODE", "1"))
     ),
     "VLLM_SM70_FP8_PRESERVE_DEFAULT_SPLITS": lambda: bool(
         int(os.getenv("VLLM_SM70_FP8_PRESERVE_DEFAULT_SPLITS", "1"))

--- a/vllm/model_executor/layers/quantization/fp8.py
+++ b/vllm/model_executor/layers/quantization/fp8.py
@@ -168,6 +168,33 @@ _sm70_fp8_prefill_dense_workspaces: dict[tuple[int, torch.dtype], torch.Tensor] 
 _sm70_fp8_qpn8_pp2_tp4_workspaces: dict[tuple[int, torch.dtype], torch.Tensor] = {}
 
 
+def _is_sm70_dsv4_fp8_prescaled_decode_layer(layer: torch.nn.Module) -> bool:
+    """Admit only the replicated V4 fused WQA/WKV block-FP8 projection."""
+    return bool(
+        getattr(layer, "prefix", "").rsplit(".", 1)[-1] == "fused_wqa_wkv"
+        and int(getattr(layer, "tp_size", 1)) == 1
+        and getattr(layer, "weight_block_size", None) == [128, 128]
+        and int(getattr(layer, "input_size_per_partition", 0)) == 4096
+        and int(getattr(layer, "output_size_per_partition", 0)) == 1536
+        and tuple(layer.weight.shape) == (1536, 4096)
+    )
+
+
+def _is_sm70_dsv4_fp8_prescaled_decode_runtime_contract() -> bool:
+    """Require the measured PP2 x TP4 no-spec single-request decode lane."""
+    vllm_config = get_current_vllm_config()
+    parallel_config = vllm_config.parallel_config
+    scheduler_config = vllm_config.scheduler_config
+    return bool(
+        parallel_config.pipeline_parallel_size == 2
+        and parallel_config.tensor_parallel_size == 4
+        and scheduler_config.max_num_seqs == 1
+        and not getattr(parallel_config, "enable_dbo", False)
+        and int(getattr(parallel_config, "ubatch_size", 0)) <= 1
+        and getattr(vllm_config, "speculative_config", None) is None
+    )
+
+
 def _is_sm70_fp8_exact_8k_prefill_layer(layer: torch.nn.Module) -> bool:
     if getattr(layer, "tp_size", 1) != 4:
         return False
@@ -1079,6 +1106,12 @@ class Fp8LinearMethod(LinearMethodBase):
                         "workspace; retaining the TurboMind layout."
                     )
 
+            use_dsv4_prescaled_decode = bool(
+                envs.VLLM_SM70_DSV4_FP8_PRESCALED_DECODE
+                and self.is_scale_e8m0
+                and _is_sm70_dsv4_fp8_prescaled_decode_layer(layer)
+                and _is_sm70_dsv4_fp8_prescaled_decode_runtime_contract()
+            )
             tm_weight, tm_scales, meta = sm70_ops.fp8_sm70_prepare(
                 weight,
                 weight_scale_inv,
@@ -1106,6 +1139,23 @@ class Fp8LinearMethod(LinearMethodBase):
             layer.register_buffer("sm70_fp8_meta", meta, persistent=False)
             layer.sm70_fp8_k_ld = int(meta[0].item())
             layer.sm70_fp8_q_ld = int(meta[1].item())
+            if use_dsv4_prescaled_decode:
+                if not hasattr(
+                    torch.ops._C, "fp8_gemm_sm70_prefill_prescaled_out"
+                ):
+                    raise RuntimeError(
+                        "VLLM_SM70_DSV4_FP8_PRESCALED_DECODE=1 requires the "
+                        "source-built SM70 prescaled FP8 operator."
+                    )
+                layer.register_buffer(
+                    "sm70_fp8_decode_prescaled_scales",
+                    tm_scales.mul(256),
+                    persistent=False,
+                )
+                logger.info_once(
+                    "Exact SM70 DeepSeek V4 fused-WQA/WKV prescaled decode "
+                    "path enabled."
+                )
             if (
                 envs.VLLM_SM70_FP8_PREFILL_FAST_SELECTOR
                 and envs.VLLM_SM70_FP8_PREFILL_PRESCALED
@@ -1391,6 +1441,9 @@ class Fp8LinearMethod(LinearMethodBase):
             prefill_prescaled_scales = getattr(
                 layer, "sm70_fp8_prefill_prescaled_scales", None
             )
+            decode_prescaled_scales = getattr(
+                layer, "sm70_fp8_decode_prescaled_scales", None
+            )
             prefill_min_m = getattr(
                 layer,
                 "sm70_fp8_prefill_exact_dense_min_m",
@@ -1404,7 +1457,21 @@ class Fp8LinearMethod(LinearMethodBase):
                 gated_silu=False,
                 min_prefill_m=prefill_min_m,
             )
-            if visible_dense_out is not None:
+            if (
+                decode_prescaled_scales is not None
+                and envs.VLLM_SM70_DSV4_FP8_PRESCALED_DECODE
+                and x_2d.shape[0] == 1
+            ):
+                sm70_ops.fp8_gemm_sm70_prefill_prescaled_out(
+                    out_2d,
+                    x_2d,
+                    layer.weight,
+                    decode_prescaled_scales,
+                    128,
+                    layer.sm70_fp8_k_ld,
+                    layer.sm70_fp8_q_ld,
+                )
+            elif visible_dense_out is not None:
                 out_2d = visible_dense_out
             elif prefill_workspace_ptr is not None and x_2d.dtype == torch.float16:
                 sm70_ops.fp8_gemm_sm70_prefill_dispatch_out(

--- a/vllm/model_executor/layers/quantization/fp8.py
+++ b/vllm/model_executor/layers/quantization/fp8.py
@@ -168,8 +168,8 @@ _sm70_fp8_prefill_dense_workspaces: dict[tuple[int, torch.dtype], torch.Tensor] 
 _sm70_fp8_qpn8_pp2_tp4_workspaces: dict[tuple[int, torch.dtype], torch.Tensor] = {}
 
 
-def _is_sm70_dsv4_fp8_prescaled_decode_layer(layer: torch.nn.Module) -> bool:
-    """Admit only the replicated V4 fused WQA/WKV block-FP8 projection."""
+def _is_sm70_fp8_prescaled_m1_decode_layer(layer: torch.nn.Module) -> bool:
+    """Admit only the measured replicated fused WQA/WKV tensor contract."""
     return bool(
         getattr(layer, "prefix", "").rsplit(".", 1)[-1] == "fused_wqa_wkv"
         and int(getattr(layer, "tp_size", 1)) == 1
@@ -180,7 +180,7 @@ def _is_sm70_dsv4_fp8_prescaled_decode_layer(layer: torch.nn.Module) -> bool:
     )
 
 
-def _is_sm70_dsv4_fp8_prescaled_decode_runtime_contract() -> bool:
+def _is_sm70_fp8_prescaled_m1_decode_runtime_contract() -> bool:
     """Require the measured PP2 x TP4 no-spec single-request decode lane."""
     vllm_config = get_current_vllm_config()
     parallel_config = vllm_config.parallel_config
@@ -193,6 +193,20 @@ def _is_sm70_dsv4_fp8_prescaled_decode_runtime_contract() -> bool:
         and int(getattr(parallel_config, "ubatch_size", 0)) <= 1
         and getattr(vllm_config, "speculative_config", None) is None
     )
+
+
+def _try_sm70_fp8_prescaled_decode_scales(
+    scales: torch.Tensor,
+) -> torch.Tensor | None:
+    """Prescale only when the FP16 exponent shift is finite and reversible."""
+    if scales.dtype != torch.float16 or not bool(torch.all(scales >= 0).item()):
+        return None
+    prescaled = scales.mul(256)
+    if not bool(torch.isfinite(prescaled).all().item()):
+        return None
+    if not torch.equal(prescaled.mul(1.0 / 256.0), scales):
+        return None
+    return prescaled
 
 
 def _is_sm70_fp8_exact_8k_prefill_layer(layer: torch.nn.Module) -> bool:
@@ -1106,11 +1120,28 @@ class Fp8LinearMethod(LinearMethodBase):
                         "workspace; retaining the TurboMind layout."
                     )
 
-            use_dsv4_prescaled_decode = bool(
-                envs.VLLM_SM70_DSV4_FP8_PRESCALED_DECODE
+            prescaled_decode_requested = envs.VLLM_SM70_FP8_PRESCALED_M1_DECODE
+            prescaled_decode_explicit = (
+                os.getenv("VLLM_SM70_FP8_PRESCALED_M1_DECODE") == "1"
+            )
+            prescaled_decode_layer = _is_sm70_fp8_prescaled_m1_decode_layer(layer)
+            prescaled_decode_runtime = bool(
+                prescaled_decode_layer
+                and _is_sm70_fp8_prescaled_m1_decode_runtime_contract()
+            )
+            if (
+                prescaled_decode_explicit
+                and prescaled_decode_layer
+                and not (self.is_scale_e8m0 and prescaled_decode_runtime)
+            ):
+                raise RuntimeError(
+                    "Explicit SM70 FP8 prescaled decode requires UE8M0 128x128 "
+                    "scales and the PP2 x TP4 no-spec single-request contract."
+                )
+            use_prescaled_m1_decode = bool(
+                prescaled_decode_requested
                 and self.is_scale_e8m0
-                and _is_sm70_dsv4_fp8_prescaled_decode_layer(layer)
-                and _is_sm70_dsv4_fp8_prescaled_decode_runtime_contract()
+                and prescaled_decode_runtime
             )
             tm_weight, tm_scales, meta = sm70_ops.fp8_sm70_prepare(
                 weight,
@@ -1139,23 +1170,36 @@ class Fp8LinearMethod(LinearMethodBase):
             layer.register_buffer("sm70_fp8_meta", meta, persistent=False)
             layer.sm70_fp8_k_ld = int(meta[0].item())
             layer.sm70_fp8_q_ld = int(meta[1].item())
-            if use_dsv4_prescaled_decode:
-                if not hasattr(
-                    torch.ops._C, "fp8_gemm_sm70_prefill_prescaled_out"
-                ):
+            if use_prescaled_m1_decode:
+                has_prescaled_op = hasattr(
+                    torch.ops._C, "fp8_gemm_sm70_prescaled_m1_out"
+                )
+                prescaled_scales = (
+                    _try_sm70_fp8_prescaled_decode_scales(tm_scales)
+                    if has_prescaled_op
+                    else None
+                )
+                if prescaled_scales is None and prescaled_decode_explicit:
                     raise RuntimeError(
-                        "VLLM_SM70_DSV4_FP8_PRESCALED_DECODE=1 requires the "
-                        "source-built SM70 prescaled FP8 operator."
+                        "Explicit SM70 FP8 prescaled decode requires the "
+                        "source-built operator and finite, reversible FP16 "
+                        "scales after the 256x exponent shift."
                     )
-                layer.register_buffer(
-                    "sm70_fp8_decode_prescaled_scales",
-                    tm_scales.mul(256),
-                    persistent=False,
-                )
-                logger.info_once(
-                    "Exact SM70 DeepSeek V4 fused-WQA/WKV prescaled decode "
-                    "path enabled."
-                )
+                if prescaled_scales is None:
+                    logger.warning_once(
+                        "SM70 FP8 prescaled decode is unavailable for the "
+                        "loaded extension or scale range; retaining the "
+                        "ordinary TurboMind transform."
+                    )
+                else:
+                    layer.register_buffer(
+                        "sm70_fp8_decode_prescaled_scales",
+                        prescaled_scales,
+                        persistent=False,
+                    )
+                    logger.info_once(
+                        "Exact SM70 fused-WQA/WKV prescaled decode path enabled."
+                    )
             if (
                 envs.VLLM_SM70_FP8_PREFILL_FAST_SELECTOR
                 and envs.VLLM_SM70_FP8_PREFILL_PRESCALED
@@ -1459,10 +1503,10 @@ class Fp8LinearMethod(LinearMethodBase):
             )
             if (
                 decode_prescaled_scales is not None
-                and envs.VLLM_SM70_DSV4_FP8_PRESCALED_DECODE
+                and envs.VLLM_SM70_FP8_PRESCALED_M1_DECODE
                 and x_2d.shape[0] == 1
             ):
-                sm70_ops.fp8_gemm_sm70_prefill_prescaled_out(
+                sm70_ops.fp8_gemm_sm70_prescaled_m1_out(
                     out_2d,
                     x_2d,
                     layer.weight,


### PR DESCRIPTION
## Purpose

Supersede #309 with a latest-main rebuild based on `1b1c9faeb82c30bf3d81158279404cd884bbfb19`.

Absorb the exact E4M3 power-of-two exponent factor into reversible FP16 UE8M0 scales at load time for the measured SM70 M=1 tensor/runtime contract. Admission uses hardware, block layout, operator role, tensor shape, TP/PP topology, scheduler state, and actual scale values; it never reads model/checkpoint/type/architecture identity.

The route is default-on when its exact contract is available and remains behind the faster accepted QPN8 route. Missing old-extension capability or unsafe scale values fall back to ordinary TurboMind; explicit `VLLM_SM70_FP8_PRESCALED_M1_DECODE=1` fails closed, and `=0` is the rollback. A distinct M=1 operator schema prevents old 8K-prefill-only extensions from receiving the new shapes.

## Test Plan

- Reuse the recorded real-weight same-process CUDA Graph A/B/B/A operator screen.
- Run focused admission, scale-reversibility, M=1 dispatch, and environment-default tests.
- Run the complete repository pre-commit suite.
- No end-to-end rerun, per current audit scope and because all V100s are occupied.

## Test Result

- Recorded real layer-0 TP4-rank0 screen: 320/320 changing-input comparisons bitwise equal across five M=1 shapes.
- Fused WQA/WKV: 63.330 us to 20.577 us, 3.078x.
- Five-shape weighted projection: -1.867 ms/token warm and -1.821 ms/token after cache scrub; production admission is intentionally narrower and does not claim endpoint TPOT.
- `pytest -q tests/quantization/test_sm70_fp8_prefill_exact_dense.py -k prescaled`: 4 passed.
- `pytest -q tests/test_envs.py -k sm70_concurrency_tuning_envs`: 1 passed.
- `pre-commit run -a`: passed.
- `git diff --check origin/main`: passed.

Evidence: `/data/models/v100-dsv4-0731-pp2tp4-fp8-prescaled-decode-screen-20260826-r1/`.