### PR TITLE
[CI/Build] Repair CUDA test dependency updates

### DIFF
--- a/requirements/test/cuda.txt
+++ b/requirements/test/cuda.txt
@@ -91,7 +91,7 @@ cffi==2.0.0
     # via
     #   cryptography
     #   soundfile
-chardet==5.2.0
+chardet==7.6.0
     # via mbstrdecoder
 charset-normalizer==3.4.0
     # via requests

--- a/requirements/test/cuda.txt
+++ b/requirements/test/cuda.txt
@@ -62,7 +62,7 @@ backoff==2.2.1
     #   schemathesis
 bitsandbytes==0.49.2
     # via -r requirements/test/cuda.in
-black==24.10.0
+black==26.5.1
     # via datamodel-code-generator
 blobfile==3.0.0
     # via -r requirements/test/cuda.in

--- a/requirements/test/cuda.txt
+++ b/requirements/test/cuda.txt
@@ -890,7 +890,7 @@ scipy==1.13.1
     #   vocos
 segmentation-models-pytorch==0.5.0
     # via -r requirements/test/cuda.in
-sentence-transformers==5.2.0
+sentence-transformers==6.0.0
     # via
     #   -r requirements/test/cuda.in
     #   mteb

--- a/requirements/test/cuda.txt
+++ b/requirements/test/cuda.txt
@@ -616,7 +616,7 @@ perceptron==0.1.4
     # via -r requirements/test/cuda.in
 perf-analyzer==0.1.0
     # via genai-perf
-pillow==10.4.0
+pillow==12.3.0
     # via
     #   genai-perf
     #   imagehash

--- a/requirements/test/cuda.txt
+++ b/requirements/test/cuda.txt
@@ -91,7 +91,7 @@ cffi==2.0.0
     # via
     #   cryptography
     #   soundfile
-chardet==7.6.0
+chardet==5.2.0
     # via mbstrdecoder
 charset-normalizer==3.4.0
     # via requests
@@ -488,6 +488,7 @@ numpy==2.2.6
     #   scikit-learn
     #   scipy
     #   segmentation-models-pytorch
+    #   sentence-transformers
     #   soxr
     #   statsmodels
     #   tensorizer
@@ -762,6 +763,8 @@ python-dateutil==2.9.0.post0
     #   typepy
 python-rapidjson==1.20
     # via tritonclient
+pytokens==0.4.1
+    # via black
 pytrec-eval-terrier==0.5.7
     # via mteb
 pytz==2024.2
@@ -986,6 +989,7 @@ tokenizers==0.22.2
     # via
     #   -c requirements/common.txt
     #   -r requirements/test/cuda.in
+    #   sentence-transformers
     #   transformers
 tomli==2.2.1
     # via schemathesis

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -468,7 +468,7 @@ class HfRunner:
                 model_name,
                 revision=revision,
                 device=self.device,
-                automodel_args=model_kwargs,
+                model_kwargs=model_kwargs,
                 trust_remote_code=trust_remote_code,
             )
         else:


### PR DESCRIPTION
## Purpose

Audit and safely land the useful dependency updates from #304, #305, and #306 on the latest `main` without importing the incompatible chardet update from #307.

- Upgrade `sentence-transformers` 5.2.0 -> 6.0.0.
- Upgrade Pillow 10.4.0 -> 12.3.0.
- Upgrade Black 24.10.0 -> 26.5.1 and lock its new required `pytokens` dependency.
- Repair the shared `CrossEncoder` test runner to use the supported `model_kwargs` parameter (valid in both SentenceTransformers 5.2 and 6.0).
- Keep chardet at 5.2.0 because `mbstrdecoder==1.1.3` requires `chardet>=3.0.4,<6`.

## Audit notes

The original Dependabot PRs changed only one lock line each. Re-resolving the CUDA test lock showed:

- #306 omitted Black 26's required `pytokens~=0.4.0` package.
- #307 is unsatisfiable with the current `mbstrdecoder` dependency and was automatically resolved back to chardet 5.2.0.
- The existing test runner passed removed `automodel_args` to `CrossEncoder`; both SentenceTransformers 5.2 and 6.0 expose `model_kwargs` instead.

## Test Plan / Result

- `uv pip compile requirements/test/cuda.in -c requirements/cuda.txt -o requirements/test/cuda.txt --index-strategy unsafe-best-match --torch-backend cu130 --python-platform x86_64-manylinux_2_28 --python-version 3.12` — passed, 316 packages resolved.
- Import/signature smoke with SentenceTransformers 6.0.0 + Transformers 5.5.3 — passed.
- CrossEncoder signature smoke with SentenceTransformers 5.2.0 — passed.
- Pillow 12.3 image composition/drawing smoke — passed.
- Black 26.5.1 formatting smoke with `pytokens==0.4.1` — passed.
- `pre-commit run --files requirements/test/cuda.txt tests/conftest.py` — all applicable hooks passed.

No GPU or end-to-end model test was run.

Supersedes the effective changes of #304, #305, and #306 after merge. #307 should remain open until its parent dependency permits chardet 6+.
