### PR TITLE
[Bench][SM70] Record prefix architecture environment

### DIFF
--- a/benchmarks/benchmark_sm70_decode.py
+++ b/benchmarks/benchmark_sm70_decode.py
@@ -169,6 +169,7 @@ def _tracked_env() -> dict[str, str]:
         "VLLM_FLASH_",
         "FLASH_ATTN",
         "FLA_",
+        "PREFIX_",
         "CUDA_MODULE_LOADING",
         "TORCH_CUDA_ARCH_LIST",
         "TORCHINDUCTOR_",


### PR DESCRIPTION
## Purpose

Split the safe benchmark-observability change from Draft #315 and land it independently on the latest `main`.

Track environment variables with the `PREFIX_` prefix in `benchmark_sm70_decode.py`, including the serialized-tail and other SM70 prefill architecture controls. This prevents benchmark artifacts from omitting configuration that can change memory use, scheduling, latency, and numerical behavior.

## Test Plan / Result

- `pre-commit run --files benchmarks/benchmark_sm70_decode.py` — all applicable hooks passed.
- `git diff --check origin/main...HEAD` — passed.

No GPU or end-to-end test is needed for this metadata-only benchmark change.

Source: safe third commit from #315. The CUDA kernel portion of #315 remains Draft/Open under separate audit gates.
