### PR TITLE
[CI/Build] Use latest compatible charset stack

### DIFF
--- a/requirements/test/cuda.txt
+++ b/requirements/test/cuda.txt
@@ -91,7 +91,7 @@ cffi==2.0.0
     # via
     #   cryptography
     #   soundfile
-chardet==5.2.0
+chardet==6.0.0.post1
     # via mbstrdecoder
 charset-normalizer==3.4.0
     # via requests
@@ -400,7 +400,7 @@ markupsafe==3.0.1
     #   werkzeug
 matplotlib==3.9.2
     # via -r requirements/test/cuda.in
-mbstrdecoder==1.1.3
+mbstrdecoder==1.1.5
     # via
     #   dataproperty
     #   pytablewriter


### PR DESCRIPTION
## Purpose

Repair the useful portion of #307 on top of current `main` without replaying its stale generated lock. Upgrade `mbstrdecoder` from 1.1.3 to 1.1.5 and `chardet` from 5.2.0 to the highest release allowed by current upstream metadata, 6.0.0.post1.

`chardet==7.6.0` cannot currently be installed with even the latest `mbstrdecoder==1.1.5`, which declares `chardet>=3.0.4,<7`.

## Test Plan

- Re-resolve the CUDA/Python 3.12 lock with uv.
- Verify installed metadata consistency in an isolated Python 3.12 environment.
- Exercise multibyte UTF-8 decoding and the downstream `pytablewriter` path.
- Run targeted repository pre-commit hooks.

## Test Result

- `uv pip compile ... --upgrade-package chardet --upgrade-package mbstrdecoder`: 316 packages resolved; only the intended two pins changed.
- `uv pip check`: all 13 isolated smoke-environment packages compatible.
- `MultiByteStrDecoder` UTF-8 smoke: passed.
- `MarkdownTableWriter.dumps()` smoke: passed.
- `pre-commit run --files requirements/test/cuda.txt`: passed.

Reported-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
Signed-off-by: yangzhuxinyzx <153831768+yangzhuxinyzx@users.noreply.github.com>