### PR TITLE
[Kernel][SM70] Default guarded packed FP13 GEMV

### DIFF
--- a/docs/design/sm70_v100_migration_control.md
+++ b/docs/design/sm70_v100_migration_control.md
@@ -43705,3 +43705,40 @@ Interpretation:
   is the rollback. An explicit `=1` fails closed when its contract cannot be
   honored. Admission never reads model name, checkpoint, `model_type`, or
   architecture identity.
+
+## 2026-08-26 DeepSeek V4 packed-FP13 GEMV screen
+
+- The fixed batch-one SM70 auxiliary/router GEMV reads FP16 parameters that
+  originate from BF16 checkpoint weights. Packing the upper 13 FP16 bits
+  stores 32 values in 13 uint32 words and reduces weight traffic by 18.75%.
+  A full checkpoint scan covered all 188 eligible tensors and 354,680,832
+  values. All 409,653 nonzero discarded tails were FP16 subnormals; no normal
+  value had a discarded bit and no nonfinite value was present. The worst
+  tensor-relative weight L2 is `3.19e-6`, with maximum absolute error
+  `4.18e-7`.
+- Offline SM70 compilation of the single-reduction kernel reports 29 registers,
+  17 global loads, 32 FFMA, eight shuffles, two barriers, and 227 static SASS
+  instructions. The exact source-BF13 variant uses 30 registers and 334
+  instructions; rounded BF12 uses 31 registers and 327 instructions. FP13 is
+  therefore the only retained packed-GEMV candidate for production screening.
+- The existing Nsight trace shows why the full 2.554-ms stage-sum GEMV service
+  must not be projected as endpoint savings. At a representative C4 layer the
+  default-stream FP8 projection takes 43.008 us while concurrent N2048/N512/N64
+  GEMVs take 37.600/25.120/22.496 us. The auxiliaries complete before the
+  downstream dependency. Any wall benefit comes from lower concurrent HBM
+  contention plus the default-stream router GEMV, so an exclusive-V100 overlap
+  screen and then a matched endpoint are required.
+- The production FP13 operator screen on real weights saves a call-count-weighted
+  `0.2074 ms/token` warm and `0.1998 ms/token` cold versus the FP16 operator.
+  An archived four-stream CUDA Graph screen at the source head was stable under
+  A/B/B/A ordering and saved `0.0550 ms` warm and `0.0310 ms` cold per C4 layer,
+  with 64/64 bitwise main-path results and maximum auxiliary relative L2
+  `4.03e-7`. That overlap result is directional after the mainline FP8 M=1 API
+  split and is not relabeled as a current-main endpoint result.
+- Production defaults on through `VLLM_SM70_DSV4_FP13_GEMV=1`; explicit `=0`
+  is the rollback. Admission checks SM70, CUDA device equality, dtype, shape,
+  layout, output contract, and the actual weight bits. It never reads a model
+  name or checkpoint identity, and an incompatible tensor retains FP16. Packing
+  occurs once after loading; capture and per-token execution perform no packing.
+  The retained buffers add 549.66 MiB without pipeline parallelism, or at most
+  282.34 MiB per rank for the audited PP2 partition.

--- a/tests/kernels/test_sm70_deepseek_v4_fp16_gemv.py
+++ b/tests/kernels/test_sm70_deepseek_v4_fp16_gemv.py
@@ -8,6 +8,9 @@ import torch
 
 import vllm.envs as envs
 from vllm.models.deepseek_v4.sm70.gemv import (
+    _has_sm70_dsv4_fp13_weight_contract,
+    _pack_sm70_dsv4_fp13_weight,
+    can_use_sm70_dsv4_fp13_gemv,
     can_use_sm70_dsv4_fp16_gemv,
     maybe_sm70_dsv4_fp16_gemv,
 )
@@ -20,11 +23,77 @@ def reset_env_cache() -> Iterator[None]:
     envs.disable_envs_cache()
 
 
-def test_sm70_dsv4_fp16_gemv_is_default_off(monkeypatch) -> None:
+def test_sm70_dsv4_fp13_gemv_is_default_on_with_rollback(monkeypatch) -> None:
     monkeypatch.delenv("VLLM_SM70_DSV4_FP16_GEMV", raising=False)
+    monkeypatch.delenv("VLLM_SM70_DSV4_FP13_GEMV", raising=False)
+    assert not envs.VLLM_SM70_DSV4_FP16_GEMV
+    assert envs.VLLM_SM70_DSV4_FP13_GEMV
+
+    monkeypatch.setenv("VLLM_SM70_DSV4_FP13_GEMV", "0")
+    envs.disable_envs_cache()
+    assert not envs.VLLM_SM70_DSV4_FP13_GEMV
+
+
+def test_sm70_dsv4_fp13_enables_fp16_fallback(monkeypatch) -> None:
+    monkeypatch.setenv("VLLM_SM70_DSV4_FP16_GEMV", "0")
+    monkeypatch.setenv("VLLM_SM70_DSV4_FP13_GEMV", "1")
+    monkeypatch.setattr(
+        "vllm.models.deepseek_v4.sm70.gemv._has_sm70_dsv4_gemv_contract",
+        lambda *args: True,
+    )
+    x = torch.empty((1, 4096), dtype=torch.float16)
+    weight = torch.empty((256, 4096), dtype=torch.float16)
+    assert can_use_sm70_dsv4_fp16_gemv(x, weight, torch.float32)
+
+
+def test_sm70_dsv4_gemv_rejects_cpu_tensors(monkeypatch) -> None:
+    monkeypatch.setenv("VLLM_SM70_DSV4_FP13_GEMV", "1")
+    monkeypatch.setattr(
+        "vllm.models.deepseek_v4.sm70.gemv.current_platform.is_cuda",
+        lambda: True,
+    )
+    monkeypatch.setattr(
+        "vllm.models.deepseek_v4.sm70.gemv.current_platform.is_device_capability",
+        lambda capability: capability == (7, 0),
+    )
     x = torch.empty((1, 4096), dtype=torch.float16)
     weight = torch.empty((256, 4096), dtype=torch.float16)
     assert not can_use_sm70_dsv4_fp16_gemv(x, weight, torch.float32)
+
+
+def test_sm70_dsv4_fp13_weight_contract_is_tensor_based() -> None:
+    compatible_bits = torch.tensor([0x0000, 0x0007, 0x3C00, -0x4400], dtype=torch.int16)
+    assert _has_sm70_dsv4_fp13_weight_contract(compatible_bits.view(torch.float16))
+
+    normal_with_discarded_bit = torch.tensor([0x3C01], dtype=torch.int16)
+    assert not _has_sm70_dsv4_fp13_weight_contract(
+        normal_with_discarded_bit.view(torch.float16)
+    )
+    nonfinite = torch.tensor([0x7C00], dtype=torch.int16)
+    assert not _has_sm70_dsv4_fp13_weight_contract(nonfinite.view(torch.float16))
+
+
+def test_sm70_dsv4_fp13_pack_preserves_upper_13_bits() -> None:
+    raw = (torch.arange(64 * 4096, dtype=torch.int32).mul(40503).add(17) & 0xFFFF).to(
+        torch.uint16
+    )
+    weight = raw.view(torch.float16).reshape(64, 4096)
+    packed = _pack_sm70_dsv4_fp13_weight(weight)
+    assert packed.shape == (64, 128, 13)
+
+    words = packed.to(torch.int64) & 0xFFFFFFFF
+    unpacked = []
+    for value_index in range(32):
+        bit_offset = value_index * 13
+        word_index = bit_offset // 32
+        shift = bit_offset % 32
+        code = words[..., word_index] >> shift
+        if shift > 19:
+            code |= words[..., word_index + 1] << (32 - shift)
+        unpacked.append(code & 0x1FFF)
+    codes = torch.stack(unpacked, dim=-1).reshape(64, 4096)
+    expected = (raw.to(torch.int32) >> 3).reshape(64, 4096)
+    assert torch.equal(codes.to(torch.int32), expected)
 
 
 @pytest.mark.skipif(
@@ -70,3 +139,54 @@ def test_sm70_dsv4_fp16_gemv_graph(
     else:
         reference = torch.mm(x, weight.T, out_dtype=torch.float32)
         torch.testing.assert_close(captured, reference, rtol=2e-4, atol=5e-5)
+
+
+@pytest.mark.skipif(
+    not torch.cuda.is_available() or torch.cuda.get_device_capability() != (7, 0),
+    reason="requires NVIDIA V100/SM70",
+)
+@pytest.mark.parametrize(
+    ("n", "output_dtype"),
+    [
+        (64, torch.float16),
+        (256, torch.float32),
+        (512, torch.float32),
+        (1024, torch.float32),
+        (2048, torch.float32),
+    ],
+)
+def test_sm70_dsv4_fp13_gemv_graph(
+    monkeypatch, n: int, output_dtype: torch.dtype
+) -> None:
+    monkeypatch.setenv("VLLM_SM70_DSV4_FP16_GEMV", "0")
+    monkeypatch.setenv("VLLM_SM70_DSV4_FP13_GEMV", "1")
+    torch.manual_seed(20260826 + n)
+    x = torch.randn((1, 4096), device="cuda", dtype=torch.float16)
+    source = torch.randn((n, 4096), device="cuda", dtype=torch.bfloat16) * 0.01
+    weight = source.to(torch.float16)
+    packed = _pack_sm70_dsv4_fp13_weight(weight)
+    assert can_use_sm70_dsv4_fp13_gemv(x, weight, packed, output_dtype)
+
+    stream = torch.cuda.Stream()
+    with torch.cuda.stream(stream):
+        candidate = maybe_sm70_dsv4_fp16_gemv(
+            x, weight, output_dtype, packed_weight=packed
+        )
+    torch.cuda.current_stream().wait_stream(stream)
+    torch.cuda.synchronize()
+    assert candidate is not None
+
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph, stream=stream):
+        captured = maybe_sm70_dsv4_fp16_gemv(
+            x, weight, output_dtype, packed_weight=packed
+        )
+    assert captured is not None
+
+    x.copy_(torch.randn_like(x))
+    graph.replay()
+    torch.cuda.synchronize()
+    reference = torch.mm(x, weight.T, out_dtype=torch.float32)
+    if output_dtype == torch.float16:
+        reference = reference.to(torch.float16)
+    torch.testing.assert_close(captured, reference, rtol=3e-4, atol=5e-5)

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -184,6 +184,7 @@ if TYPE_CHECKING:
     VLLM_SM70_MXFP4_DENSE_TUNE_MAX_M: int = 16
     VLLM_SM70_NVFP4_DENSE_TUNE_MAX_M: int = 16
     VLLM_SM70_DSV4_FP16_GEMV: bool = False
+    VLLM_SM70_DSV4_FP13_GEMV: bool = True
     VLLM_SM70_DSV4_MHC_FP32_STAGE: bool = True
     VLLM_SM70_DSV4_QNORM_KV_FUSED_TP4: bool = True
     VLLM_SM70_PP_STATIC_HIDDEN_TRANSFER: bool = True
@@ -1816,6 +1817,9 @@ environment_variables: dict[str, Callable[[], Any]] = {
     ),
     "VLLM_SM70_DSV4_FP16_GEMV": lambda: bool(
         int(os.getenv("VLLM_SM70_DSV4_FP16_GEMV", "0"))
+    ),
+    "VLLM_SM70_DSV4_FP13_GEMV": lambda: bool(
+        int(os.getenv("VLLM_SM70_DSV4_FP13_GEMV", "1"))
     ),
     "VLLM_SM70_DSV4_MHC_FP32_STAGE": lambda: bool(
         int(os.getenv("VLLM_SM70_DSV4_MHC_FP32_STAGE", "1"))

--- a/vllm/model_executor/layers/fused_moe/router/gate_linear.py
+++ b/vllm/model_executor/layers/fused_moe/router/gate_linear.py
@@ -57,6 +57,7 @@ class GateLinear(ReplicatedLinear):
             prefix=prefix,
         )
         self.out_dtype = out_dtype
+        self._sm70_dsv4_fp13_gemv = True
 
         # DSV3 specialized kernel eligibility (SM90+, exact dims)
         self.allow_specialized_router_gemm = can_use_specialized_kernels
@@ -95,12 +96,19 @@ class GateLinear(ReplicatedLinear):
     ) -> torch.Tensor | tuple[torch.Tensor, Parameter | None]:
         import vllm._custom_ops as ops
 
-        if envs.VLLM_SM70_DSV4_FP16_GEMV and self.out_dtype is not None:
+        if (
+            envs.VLLM_SM70_DSV4_FP16_GEMV or envs.VLLM_SM70_DSV4_FP13_GEMV
+        ) and self.out_dtype is not None:
             from vllm.models.deepseek_v4.sm70.gemv import (
                 maybe_sm70_dsv4_fp16_gemv,
             )
 
-            output = maybe_sm70_dsv4_fp16_gemv(x, self.weight, self.out_dtype)
+            output = maybe_sm70_dsv4_fp16_gemv(
+                x,
+                self.weight,
+                self.out_dtype,
+                getattr(self, "_sm70_dsv4_fp13_weight", None),
+            )
             if output is not None:
                 return output, None
 

--- a/vllm/model_executor/layers/linear.py
+++ b/vllm/model_executor/layers/linear.py
@@ -369,6 +369,15 @@ class UnquantizedLinearMethod(LinearMethodBase):
         if not current_platform.is_cuda_alike():
             return
 
+        if envs.VLLM_SM70_DSV4_FP13_GEMV and getattr(
+            layer, "_sm70_dsv4_fp13_gemv", False
+        ):
+            from vllm.models.deepseek_v4.sm70.gemv import (
+                prepare_sm70_dsv4_fp13_gemv,
+            )
+
+            prepare_sm70_dsv4_fp13_gemv(layer)
+
         force_enable = getattr(layer, "_sm70_f16_force_enable", False)
         if not envs.VLLM_SM70_ENABLE_DENSE_F16_FASTPATH and not force_enable:
             return

--- a/vllm/models/deepseek_v4/attention.py
+++ b/vllm/models/deepseek_v4/attention.py
@@ -416,6 +416,11 @@ class DeepseekV4MultiHeadLatentAttentionWrapper(PluggableLayer):
                     hidden_states,
                     compressor.fused_wkv_wgate.weight,
                     torch.float32,
+                    getattr(
+                        compressor.fused_wkv_wgate,
+                        "_sm70_dsv4_fp13_weight",
+                        None,
+                    ),
                 )
                 if output is not None:
                     return output
@@ -435,6 +440,11 @@ class DeepseekV4MultiHeadLatentAttentionWrapper(PluggableLayer):
                     hidden_states,
                     indexer.weights_proj.weight,
                     hidden_states.dtype,
+                    getattr(
+                        indexer.weights_proj,
+                        "_sm70_dsv4_fp13_weight",
+                        None,
+                    ),
                 )
                 if output is not None:
                     return output
@@ -447,6 +457,11 @@ class DeepseekV4MultiHeadLatentAttentionWrapper(PluggableLayer):
                     hidden_states,
                     indexer.compressor.fused_wkv_wgate.weight,
                     torch.float32,
+                    getattr(
+                        indexer.compressor.fused_wkv_wgate,
+                        "_sm70_dsv4_fp13_weight",
+                        None,
+                    ),
                 )
                 if output is not None:
                     return output
@@ -851,6 +866,7 @@ class DeepseekV4Indexer(nn.Module):
             quant_config=None,
             prefix=f"{prefix}.weights_proj",
         )
+        self.weights_proj._sm70_dsv4_fp13_gemv = True
         self.softmax_scale = self.head_dim**-0.5
 
         self.scale_fmt = "ue8m0"

--- a/vllm/models/deepseek_v4/compressor.py
+++ b/vllm/models/deepseek_v4/compressor.py
@@ -304,6 +304,7 @@ class DeepseekCompressor(nn.Module):
             disable_tp=True,
             prefix=f"{prefix}.fused_wkv_wgate",
         )
+        self.fused_wkv_wgate._sm70_dsv4_fp13_gemv = True
         self.norm = RMSNorm(self.head_dim, self.rms_norm_eps)
 
         self.state_cache = CompressorStateCache(

--- a/vllm/models/deepseek_v4/sm70/gemv.py
+++ b/vllm/models/deepseek_v4/sm70/gemv.py
@@ -16,6 +16,11 @@ _SUPPORTED_N = frozenset((64, 256, 512, 1024, 2048))
 _K = 4096
 _BLOCK_K = 1024
 _NUM_WARPS = 4
+_FP13_GROUP_VALUES = 32
+_FP13_GROUP_WORDS = 13
+_FP13_GROUPS_PER_ROW = _K // _FP13_GROUP_VALUES
+_FP13_WORDS_PER_ROW = _FP13_GROUPS_PER_ROW * _FP13_GROUP_WORDS
+_FP13_BUFFER = "_sm70_dsv4_fp13_weight"
 
 
 @triton.jit
@@ -36,15 +41,240 @@ def _sm70_dsv4_fp16_gemv_kernel(
     tl.store(out_ptr + row, acc)
 
 
-def can_use_sm70_dsv4_fp16_gemv(
+@triton.jit
+def _load_fp16x8(ptr):
+    word0, word1, word2, word3 = tl.inline_asm_elementwise(
+        "ld.global.v4.u32 {$0, $1, $2, $3}, [$4];",
+        constraints="=r,=r,=r,=r,l,~{memory}",
+        args=[ptr],
+        dtype=(tl.uint32, tl.uint32, tl.uint32, tl.uint32),
+        is_pure=False,
+        pack=1,
+    )
+    return (
+        (word0 & 0xFFFF).to(tl.uint16).to(tl.float16, bitcast=True).to(tl.float32),
+        (word0 >> 16).to(tl.uint16).to(tl.float16, bitcast=True).to(tl.float32),
+        (word1 & 0xFFFF).to(tl.uint16).to(tl.float16, bitcast=True).to(tl.float32),
+        (word1 >> 16).to(tl.uint16).to(tl.float16, bitcast=True).to(tl.float32),
+        (word2 & 0xFFFF).to(tl.uint16).to(tl.float16, bitcast=True).to(tl.float32),
+        (word2 >> 16).to(tl.uint16).to(tl.float16, bitcast=True).to(tl.float32),
+        (word3 & 0xFFFF).to(tl.uint16).to(tl.float16, bitcast=True).to(tl.float32),
+        (word3 >> 16).to(tl.uint16).to(tl.float16, bitcast=True).to(tl.float32),
+    )
+
+
+@triton.jit
+def _select_fp13_word(
+    word0,
+    word1,
+    word2,
+    word3,
+    word4,
+    word5,
+    word6,
+    word7,
+    word8,
+    word9,
+    word10,
+    word11,
+    word12,
+    INDEX: tl.constexpr,
+):
+    if INDEX == 0:  # noqa: SIM116 - Triton constexpr dispatch needs static branches.
+        return word0
+    elif INDEX == 1:
+        return word1
+    elif INDEX == 2:
+        return word2
+    elif INDEX == 3:
+        return word3
+    elif INDEX == 4:
+        return word4
+    elif INDEX == 5:
+        return word5
+    elif INDEX == 6:
+        return word6
+    elif INDEX == 7:
+        return word7
+    elif INDEX == 8:
+        return word8
+    elif INDEX == 9:
+        return word9
+    elif INDEX == 10:
+        return word10
+    elif INDEX == 11:
+        return word11
+    else:
+        return word12
+
+
+@triton.jit
+def _sm70_dsv4_fp13_gemv_kernel(
+    x_ptr,
+    packed_ptr,
+    out_ptr,
+    GROUP_VALUES: tl.constexpr,
+    GROUP_WORDS: tl.constexpr,
+    GROUPS_PER_ROW: tl.constexpr,
+    WORDS_PER_ROW: tl.constexpr,
+):
+    row = tl.program_id(0)
+    groups = tl.arange(0, GROUPS_PER_ROW)
+    word_base = row * WORDS_PER_ROW + groups * GROUP_WORDS
+    word0 = tl.load(packed_ptr + word_base).to(tl.uint32, bitcast=True)
+    word1 = tl.load(packed_ptr + word_base + 1).to(tl.uint32, bitcast=True)
+    word2 = tl.load(packed_ptr + word_base + 2).to(tl.uint32, bitcast=True)
+    word3 = tl.load(packed_ptr + word_base + 3).to(tl.uint32, bitcast=True)
+    word4 = tl.load(packed_ptr + word_base + 4).to(tl.uint32, bitcast=True)
+    word5 = tl.load(packed_ptr + word_base + 5).to(tl.uint32, bitcast=True)
+    word6 = tl.load(packed_ptr + word_base + 6).to(tl.uint32, bitcast=True)
+    word7 = tl.load(packed_ptr + word_base + 7).to(tl.uint32, bitcast=True)
+    word8 = tl.load(packed_ptr + word_base + 8).to(tl.uint32, bitcast=True)
+    word9 = tl.load(packed_ptr + word_base + 9).to(tl.uint32, bitcast=True)
+    word10 = tl.load(packed_ptr + word_base + 10).to(tl.uint32, bitcast=True)
+    word11 = tl.load(packed_ptr + word_base + 11).to(tl.uint32, bitcast=True)
+    word12 = tl.load(packed_ptr + word_base + 12).to(tl.uint32, bitcast=True)
+    x_values_0 = _load_fp16x8(x_ptr + groups * GROUP_VALUES)
+    x_values_1 = _load_fp16x8(x_ptr + groups * GROUP_VALUES + 8)
+    x_values_2 = _load_fp16x8(x_ptr + groups * GROUP_VALUES + 16)
+    x_values_3 = _load_fp16x8(x_ptr + groups * GROUP_VALUES + 24)
+    partial = tl.zeros((GROUPS_PER_ROW,), tl.float32)
+    for value_index in tl.static_range(0, GROUP_VALUES):
+        bit_offset = value_index * 13
+        word_index = bit_offset // 32
+        shift = bit_offset % 32
+        code = (
+            _select_fp13_word(
+                word0,
+                word1,
+                word2,
+                word3,
+                word4,
+                word5,
+                word6,
+                word7,
+                word8,
+                word9,
+                word10,
+                word11,
+                word12,
+                INDEX=word_index,
+            )
+            >> shift
+        )
+        if shift > 19:
+            code |= _select_fp13_word(
+                word0,
+                word1,
+                word2,
+                word3,
+                word4,
+                word5,
+                word6,
+                word7,
+                word8,
+                word9,
+                word10,
+                word11,
+                word12,
+                INDEX=word_index + 1,
+            ) << (32 - shift)
+        code &= 0x1FFF
+        bits = (code << 3).to(tl.uint16)
+        weight = bits.to(tl.float16, bitcast=True).to(tl.float32)
+        if value_index < 8:
+            x = x_values_0[value_index]
+        elif value_index < 16:
+            x = x_values_1[value_index - 8]
+        elif value_index < 24:
+            x = x_values_2[value_index - 16]
+        else:
+            x = x_values_3[value_index - 24]
+        partial += x * weight
+    result = tl.sum(partial, axis=0)
+    tl.store(out_ptr + row, result)
+
+
+@torch.no_grad()
+def _pack_sm70_dsv4_fp13_weight(weight: torch.Tensor) -> torch.Tensor:
+    if weight.dtype != torch.float16 or weight.ndim != 2 or weight.shape[1] != _K:
+        raise ValueError(
+            f"unsupported FP13 weight contract: {weight.dtype=} {weight.shape=}"
+        )
+    raw = weight.view(torch.int16).to(torch.int32) & 0xFFFF
+    codes = (raw >> 3).reshape(
+        weight.shape[0], _FP13_GROUPS_PER_ROW, _FP13_GROUP_VALUES
+    )
+    words = torch.zeros(
+        (weight.shape[0], _FP13_GROUPS_PER_ROW, _FP13_GROUP_WORDS),
+        dtype=torch.int32,
+        device=weight.device,
+    )
+    for value_index in range(_FP13_GROUP_VALUES):
+        bit_offset = value_index * 13
+        word_index = bit_offset // 32
+        shift = bit_offset % 32
+        value = codes[..., value_index]
+        words[..., word_index].bitwise_or_(value << shift)
+        if shift > 19:
+            words[..., word_index + 1].bitwise_or_(value >> (32 - shift))
+    return words.contiguous()
+
+
+@torch.no_grad()
+def _has_sm70_dsv4_fp13_weight_contract(weight: torch.Tensor) -> bool:
+    """Accept exact BF16-derived normals and bounded FP16 subnormal tails."""
+    bits = weight.view(torch.int16).to(torch.int32) & 0xFFFF
+    exponent = (bits >> 10) & 0x1F
+    discarded = bits & 0x7
+    incompatible = (exponent == 0x1F) | ((discarded != 0) & (exponent != 0))
+    return not bool(torch.any(incompatible).item())
+
+
+def prepare_sm70_dsv4_fp13_gemv(layer: torch.nn.Module) -> torch.Tensor | None:
+    if not envs.VLLM_SM70_DSV4_FP13_GEMV or not getattr(
+        layer, "_sm70_dsv4_fp13_gemv", False
+    ):
+        return None
+    weight = getattr(layer, "weight", None)
+    if not isinstance(weight, torch.Tensor):
+        return None
+    if (
+        not current_platform.is_cuda()
+        or not current_platform.is_device_capability((7, 0))
+        or not weight.is_cuda
+        or weight.dtype != torch.float16
+        or weight.ndim != 2
+        or weight.shape[0] not in _SUPPORTED_N
+        or weight.shape[1] != _K
+        or not weight.is_contiguous()
+    ):
+        return None
+    if not _has_sm70_dsv4_fp13_weight_contract(weight):
+        logger.warning_once(
+            "SM70 packed-FP13 GEMV rejected a weight outside its tensor-value "
+            "contract; retaining the FP16 GEMV fallback."
+        )
+        return None
+    packed = _pack_sm70_dsv4_fp13_weight(weight)
+    if _FP13_BUFFER in layer._buffers:
+        layer._buffers[_FP13_BUFFER] = packed
+    else:
+        layer.register_buffer(_FP13_BUFFER, packed, persistent=False)
+    return packed
+
+
+def _has_sm70_dsv4_gemv_contract(
     x: torch.Tensor,
     weight: torch.Tensor,
     output_dtype: torch.dtype,
 ) -> bool:
     return (
-        envs.VLLM_SM70_DSV4_FP16_GEMV
-        and current_platform.is_cuda()
+        current_platform.is_cuda()
         and current_platform.is_device_capability((7, 0))
+        and x.is_cuda
+        and weight.is_cuda
+        and x.device == weight.device
         and x.dtype == torch.float16
         and weight.dtype == torch.float16
         and output_dtype in (torch.float16, torch.float32)
@@ -59,11 +289,57 @@ def can_use_sm70_dsv4_fp16_gemv(
     )
 
 
+def can_use_sm70_dsv4_fp16_gemv(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    output_dtype: torch.dtype,
+) -> bool:
+    enabled = envs.VLLM_SM70_DSV4_FP16_GEMV or envs.VLLM_SM70_DSV4_FP13_GEMV
+    return enabled and _has_sm70_dsv4_gemv_contract(x, weight, output_dtype)
+
+
+def can_use_sm70_dsv4_fp13_gemv(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    packed_weight: torch.Tensor | None,
+    output_dtype: torch.dtype,
+) -> bool:
+    return (
+        envs.VLLM_SM70_DSV4_FP13_GEMV
+        and _has_sm70_dsv4_gemv_contract(x, weight, output_dtype)
+        and packed_weight is not None
+        and packed_weight.dtype == torch.int32
+        and packed_weight.device == weight.device
+        and packed_weight.shape
+        == (weight.shape[0], _FP13_GROUPS_PER_ROW, _FP13_GROUP_WORDS)
+        and packed_weight.is_contiguous()
+    )
+
+
 def maybe_sm70_dsv4_fp16_gemv(
     x: torch.Tensor,
     weight: torch.Tensor,
     output_dtype: torch.dtype,
+    packed_weight: torch.Tensor | None = None,
 ) -> torch.Tensor | None:
+    if can_use_sm70_dsv4_fp13_gemv(x, weight, packed_weight, output_dtype):
+        assert packed_weight is not None
+        logger.info_once(
+            "DeepSeek V4 SM70 packed-FP13 GEMV enabled for batch-one decode."
+        )
+        out = torch.empty((1, weight.shape[0]), device=x.device, dtype=output_dtype)
+        _sm70_dsv4_fp13_gemv_kernel[(weight.shape[0],)](
+            x,
+            packed_weight,
+            out,
+            GROUP_VALUES=_FP13_GROUP_VALUES,
+            GROUP_WORDS=_FP13_GROUP_WORDS,
+            GROUPS_PER_ROW=_FP13_GROUPS_PER_ROW,
+            WORDS_PER_ROW=_FP13_WORDS_PER_ROW,
+            num_warps=_NUM_WARPS,
+        )
+        return out
+
     if not can_use_sm70_dsv4_fp16_gemv(x, weight, output_dtype):
         return None
 


### PR DESCRIPTION
## Purpose

Repair #322 on the latest `main` and make the measured packed-FP13 SM70 GEMV the safe default. Only the final FP13 change was replayed; the eight stale stacked optimization commits from the original branch are intentionally excluded.

## Source contract

- Integration base: `6a424f2aca9d89db1fb132a6870ef6e2f9ce0383`
- Head: `b32354c7729dff57b3561ac88e1b73fef8fd0dc7`
- Original audited source: `165ec09fa9f9b16f416ee586534d342d6c3f479a`
- The FP16/FP13 Triton kernel region is byte-identical to the original GPU-screened source.

## Implementation and admission

- Packs 32 upper-13-bit FP16 values into 13 `uint32` words once after weight loading.
- Defaults `VLLM_SM70_DSV4_FP13_GEMV=1`; explicit `=0` is the rollback.
- Requires SM70, CUDA tensors on the same device, batch-one `1 x 4096` input, contiguous FP16 weights, supported `N`, and the existing output-dtype contract.
- Adds a tensor-value gate: normal FP16 values must have zero discarded bits, subnormal tails are allowed, and nonfinite weights fall back.
- Admission does not inspect model name, checkpoint, `model_type`, or architecture identity.
- An incompatible tensor retains the existing FP16 GEMV path.

## Numeric quality

A complete CPU scan covered all 188 eligible tensors / 354,680,832 values in `/data/models/DeepSeek-V4-Flash-0731`:

- 409,653 values have nonzero discarded tails; all are FP16 subnormals.
- Normal-value violations: 0; nonfinite values: 0.
- Worst tensor-relative weight L2: `3.1842e-6`.
- Maximum absolute weight error: `4.1724e-7`.
- The retained 64-pattern GPU overlap artifact has maximum auxiliary relative L2 `4.0202e-7`, minimum cosine `0.99999976`, and 64/64 bitwise main-path outputs.

## Performance and memory

The real-weight production-kernel screen reports call-count-weighted savings versus FP16 of:

- warm: `0.2074 ms/token`
- cold: `0.1998 ms/token`

The archived four-stream CUDA Graph screen was stable under A/B/B/A ordering and reported `0.0550 ms` warm / `0.0310 ms` cold saving per C4 layer. It predates the mainline FP8 M=1 schema split, so it is retained as directional overlap evidence rather than relabeled as a current-main endpoint result.

Packed buffers add `549.66 MiB` without PP, or at most `282.34 MiB` per rank for the audited PP2 partition. No packing occurs during capture or token execution.

## Test plan and result

- `pre-commit run --from-ref origin/main --to-ref HEAD`: passed, including Ruff, Markdown, mypy, SPDX, env-default validation, and forbidden-API checks.
- `pytest -q tests/kernels/test_sm70_deepseek_v4_fp16_gemv.py` with CUDA hidden: `5 passed, 10 skipped` (V100 graph cases skipped because all GPUs are owned by the active service).
- CPU pack/unpack covers arbitrary 16-bit patterns.
- New tests cover default-on/explicit rollback, FP16 fallback, CPU-device rejection, compatible subnormal tails, incompatible normal tails, and nonfinite rejection.
- Original offline SM70 compile: 29 registers, 227 static instructions, 17 global loads, 32 FFMA, 8 shuffles, 2 barriers.

Per project direction, no end-to-end service rerun was performed.

## Artifacts

- Full weight contract: `/data/models/v100-dsv4-0731-pp2tp4-fp13-audit-20260826-r2/results/full_weight_contract.json`
- Real-weight operator screen: `/data/models/v100-dsv4-0731-pp2tp4-post-endpoint-screens-20260826-r1/results/bf13_gemv.json`
- Four-stream overlap screen: `/data/models/v100-dsv4-0731-pp2tp4-post-endpoint-screens-20260826-r1/results/fp13_overlap.json`

Supersedes #322 after merge.
