### PR TITLE
[Bugfix][SM70] Isolate MXFP4 direct-order offsets

### DIFF
--- a/docs/design/sm70_v100_migration_control.md
+++ b/docs/design/sm70_v100_migration_control.md
@@ -43456,6 +43456,14 @@ Interpretation:
   token counts, expert mappings, top-k shapes, dtypes, and devices retain the
   existing path. This is operator performance evidence, not a full endpoint
   throughput claim.
+- The first matched endpoint reached `69.949 token/s`, but its quality gate
+  failed with incoherent output and is rejected as a speed baseline. M2--M8
+  warmup and verifier compaction can overwrite `compact_expert_offsets` before
+  the B1 graph is captured, while direct-order incorrectly assumed that buffer
+  still contained `[0, 1, ..., 6]`. Direct-order now reads the immutable
+  `slot_expert_offsets` buffer. This restores the proven one-row-per-route
+  contract without changing the kernel, route order, or default-on/rollback
+  policy; a poisoned-workspace regression covers the failure mode.
 - The exact TP4 QNorm/RoPE plus FP8-KV insertion route combines the existing
   16 Q-head programs and eight packed-KV writers into one graph node without
   changing their arithmetic. Across 64 changing-input CUDA Graph patterns,

--- a/tests/quantization/test_sm70_mxfp4_moe.py
+++ b/tests/quantization/test_sm70_mxfp4_moe.py
@@ -22,6 +22,7 @@ from vllm.model_executor.layers.quantization.mxfp4 import (
 from vllm.model_executor.layers.quantization.mxfp4_sm70_moe import (
     Mxfp4SM70MoEMethod,
     _compact_mxfp4_active_experts,
+    _select_mxfp4_direct_order_offsets,
     _select_mxfp4_stage_dispatch,
     validate_mxfp4_sm70_moe_contract,
     validate_mxfp4_sm70_moe_weight_layout,
@@ -208,6 +209,21 @@ def test_mxfp4_sm70_b1_dispatch_selects_six_runtime_experts(monkeypatch):
     assert offsets is buffers["compact_expert_offsets"]
     assert expert_ids is buffers["permuted_experts_id"]
     assert count == 6
+
+
+def test_mxfp4_sm70_direct_order_ignores_compacted_offsets():
+    buffers = {
+        # Reproduce M8 compaction state left before the B1 graph is captured.
+        "compact_expert_offsets": torch.tensor(
+            [0, 8, 9, 16, 24, 32, 48], dtype=torch.int32
+        ),
+        "slot_expert_offsets": torch.arange(7, dtype=torch.int32),
+    }
+
+    offsets = _select_mxfp4_direct_order_offsets(buffers)
+
+    assert offsets is buffers["slot_expert_offsets"]
+    torch.testing.assert_close(offsets, torch.arange(7, dtype=torch.int32))
 
 
 def test_mxfp4_sm70_b1_dispatch_rejects_incompatible_permute_fastpath(

--- a/vllm/model_executor/layers/quantization/mxfp4_sm70_moe.py
+++ b/vllm/model_executor/layers/quantization/mxfp4_sm70_moe.py
@@ -185,6 +185,18 @@ def _select_mxfp4_stage_dispatch(
     return buffers["expert_offsets"], buffers["dense_expert_ids"], num_experts
 
 
+def _select_mxfp4_direct_order_offsets(
+    buffers: dict[str, torch.Tensor],
+) -> torch.Tensor:
+    """Return immutable one-row offsets for B1 direct-order decode.
+
+    Active-expert compaction overwrites ``compact_expert_offsets`` during
+    M2--M8 warmup and verifier calls. Direct-order B1 has one row per route,
+    so it must use the separately maintained slot offsets instead.
+    """
+    return buffers["slot_expert_offsets"]
+
+
 def validate_mxfp4_sm70_moe_contract(
     *,
     global_num_experts: int,
@@ -739,7 +751,7 @@ class Mxfp4SM70MoEMethod(Mxfp4MoEMethod):
         )
         if direct_order:
             route_ids = topk_ids.view(-1)
-            route_offsets = buffers["compact_expert_offsets"]
+            route_offsets = _select_mxfp4_direct_order_offsets(buffers)
             sm70_ops.mxfp4_moe_dense_stage_sm70_out(
                 buffers["gate_up"],
                 x,


### PR DESCRIPTION
## Purpose

Repair the new quality bug reported on #308 without replaying its stale optimization stack. Current main already contains the accepted direct-order optimization from #314, but B1 graph capture can observe offsets overwritten by M2--M8 warmup or verifier compaction.

## Source contract

- Base: `9bbc554e1d9f63a628d1bc66ecb45ee4632267a2`
- Head: `f096a85bf43f3d00df3b25a34299c748ad747b2a`
- Original report/fix commit: `052312c66f89bb144cf68f5776d83552c7b9e3d1`

## Fix

- B1 direct-order decode now uses the immutable `slot_expert_offsets` buffer (`[0, 1, ..., 6]`).
- It no longer reuses `compact_expert_offsets`, which M2--M8 compaction mutates before a B1 graph may be captured.
- CUDA kernels, route IDs/order, FP32 weighted-reduction order, environment defaults, and rollback switches are unchanged.
- A CPU regression poisons the compact workspace with representative M8 offsets and proves direct-order still selects the immutable one-row slots.

The first pre-fix matched endpoint reached `69.949 token/s` but produced incoherent output. It is recorded as rejected quality evidence, not a speed baseline. This repair preserves the already measured optimization while removing the identified cross-shape state leak.

## Test result

- `pytest -q tests/quantization/test_sm70_mxfp4_moe.py` with CUDA hidden: `25 passed, 4 skipped`.
- `pre-commit run --from-ref onecat/main --to-ref HEAD`: passed, including Ruff, Markdown, mypy, SPDX, configuration, and forbidden-API checks.
- No GPU or end-to-end rerun: this change only selects an existing immutable buffer before the unchanged CUDA calls, and all V100s remain owned by the active service.

Supersedes the post-#314 bugfix portion of #308 after merge.
