### PR TITLE
[Kernel][SM70] Fuse DeepSeek V4 FP16 auxiliary GEMVs

### DIFF
--- a/docs/design/sm70_v100_migration_control.md
+++ b/docs/design/sm70_v100_migration_control.md
@@ -43459,6 +43459,25 @@ Interpretation:
   capture. The corrected branch uses the immutable `slot_expert_offsets`
   buffer. Keep the route opt-in until a post-fix full-model and GSM8K-64 gate
   pass; the failed endpoint is rejection evidence, not a speed baseline.
+- A follow-up C4 scheduling screen joins the `N=2048` main compressor,
+  `N=512` indexer compressor, and `N=64` indexer-weight FP16 row GEMVs into
+  one `N=2624` launch on one auxiliary stream. It preserves the original
+  `K=4096`, block-K=1024 FP32 FMA and reduction order; all three outputs and
+  the concurrently executed prescaled WQA/WKV output are bitwise equal across
+  64 changing inputs. The exact FP16 arm improves the four-stream overlap from
+  `103.809` to `51.639 us/C4 layer` warm and from `99.104` to
+  `73.856 us/C4 layer` after cache scrub. This is preferred over the slightly
+  faster packed-FP13 arm because it introduces no weight approximation. The
+  joined non-persistent buffer costs 20.5 MiB per C4 layer. Evidence is under
+  `/data/models/v100-dsv4-0731-pp2tp4-fp13-fused-overlap-screen-20260826-r2/`.
+  The production kernel also passes a driver-free SM70 compile gate at 32
+  registers with zero stack, local, or static shared memory, plus a real-V100
+  CUDA Graph bitwise test under
+  `/data/models/v100-dsv4-0731-pp2tp4-fused-fp16-aux-gpu-test-20260826-r1/`.
+  Admission additionally requires the existing exact FP16 GEMV route through
+  `VLLM_SM70_DSV4_FP16_GEMV=1`; keep
+  `VLLM_SM70_DSV4_FUSED_FP16_AUX_GEMV` opt-in until an endpoint trace and
+  aggregate dataset gate pass.
 
 ## 2026-08-25 DFlash2 n-gram hybrid
 

--- a/docs/design/sm70_v100_migration_control.md
+++ b/docs/design/sm70_v100_migration_control.md
@@ -43498,6 +43498,17 @@ Interpretation:
   is warranted and the source change is not retained. The isolated candidate
   failure is under
   `/data/models/v100-dsv4-0731-pp2tp4-fp8-exponent-fold-screen-20260826-r6/`.
+- MXFP4 gated-SwiGLU epilogues remain rejected as endpoint priorities. The
+  real layer-0 TP4-rank-0 screen is bitwise at the activated intermediate and
+  W2 output for 64 changing inputs across scales `0.01/0.1/1/4`, but the full
+  W13-to-W2 pipeline saves only `0.978 us/layer`, or `0.042 ms/token` across
+  43 layers. The much larger isolated W13-plus-activation delta is contradicted
+  by the complete pipeline and is not used. A same-address paired variant
+  independently projects only `0.143 ms/token`. Neither source candidate is
+  retained. Evidence is under
+  `/data/models/v100-dsv4-0731-pp2tp4-mxfp4-gated-silu-screen-20260826-r1/`
+  and
+  `/data/models/v100-dsv4-0731-pp2tp4-mxfp4-gated-epilogue-screen-20260826-r2/`.
 
 ## 2026-08-25 DFlash2 n-gram hybrid
 

--- a/docs/design/sm70_v100_migration_control.md
+++ b/docs/design/sm70_v100_migration_control.md
@@ -43478,6 +43478,17 @@ Interpretation:
   `VLLM_SM70_DSV4_FP16_GEMV=1`; keep
   `VLLM_SM70_DSV4_FUSED_FP16_AUX_GEMV` opt-in until an endpoint trace and
   aggregate dataset gate pass.
+- Two smaller launch-shape candidates are rejected and their source changes
+  are not retained. Changing the M=1 mHC FP32 dot tile from N=2 to N=4 is
+  bitwise across 64 changing inputs, but a 43-layer, 64.5-MiB weight-streaming
+  graph moves only `0.162908` to `0.158266 ms/stage`, saving `0.004642 ms`.
+  Evidence is under
+  `/data/models/v100-dsv4-0731-pp2tp4-mhc-tile4-screen-20260826-r1/`.
+  Likewise, reducing the M=1/E=256 sqrt-softplus router block from four warps
+  to one preserves initial, 64-pattern, and M=33 fallback hashes, but moves 40
+  layer calls only `0.274614` to `0.274186 ms/token`, saving `0.000428 ms`.
+  Evidence is
+  `/data/models/v100-dsv4-0731-pp2tp4-post-endpoint-screens-20260826-r1/results/topk_warp1.json`.
 
 ## 2026-08-25 DFlash2 n-gram hybrid
 

--- a/docs/design/sm70_v100_migration_control.md
+++ b/docs/design/sm70_v100_migration_control.md
@@ -43489,6 +43489,15 @@ Interpretation:
   layer calls only `0.274614` to `0.274186 ms/token`, saving `0.000428 ms`.
   Evidence is
   `/data/models/v100-dsv4-0731-pp2tp4-post-endpoint-screens-20260826-r1/results/topk_warp1.json`.
+- A separate FP8-E4M3 prescaled exponent-fold transform is also rejected; it
+  is unrelated to the accepted MXFP4-E2M1 fold. The rebuilt candidate has no
+  feasible kernel for the exact fused-WQA `M=1, N=1536, K=4096` descriptor,
+  both with ordinary selection and with the baseline
+  `8x128x64:5:1:1` tactic locked. Choosing a different tactic would abandon
+  the required reduction-order contract, so no further timing or dataset gate
+  is warranted and the source change is not retained. The isolated candidate
+  failure is under
+  `/data/models/v100-dsv4-0731-pp2tp4-fp8-exponent-fold-screen-20260826-r6/`.
 
 ## 2026-08-25 DFlash2 n-gram hybrid
 

--- a/tests/kernels/test_sm70_deepseek_v4_fp16_gemv.py
+++ b/tests/kernels/test_sm70_deepseek_v4_fp16_gemv.py
@@ -9,7 +9,10 @@ import torch
 import vllm.envs as envs
 from vllm.models.deepseek_v4.sm70.gemv import (
     can_use_sm70_dsv4_fp16_gemv,
+    has_sm70_dsv4_fused_fp16_aux_weight_contract,
     maybe_sm70_dsv4_fp16_gemv,
+    maybe_sm70_dsv4_fused_fp16_aux_gemv,
+    prepare_sm70_dsv4_fused_fp16_aux_weight,
 )
 
 
@@ -25,6 +28,24 @@ def test_sm70_dsv4_fp16_gemv_is_default_off(monkeypatch) -> None:
     x = torch.empty((1, 4096), dtype=torch.float16)
     weight = torch.empty((256, 4096), dtype=torch.float16)
     assert not can_use_sm70_dsv4_fp16_gemv(x, weight, torch.float32)
+
+
+def test_sm70_dsv4_fused_fp16_aux_contract_is_exact_and_default_off(
+    monkeypatch,
+) -> None:
+    monkeypatch.delenv("VLLM_SM70_DSV4_FUSED_FP16_AUX_GEMV", raising=False)
+    weights = tuple(
+        torch.empty((rows, 4096), dtype=torch.float16, device="meta")
+        for rows in (2048, 512, 64)
+    )
+
+    assert has_sm70_dsv4_fused_fp16_aux_weight_contract(weights)
+    assert prepare_sm70_dsv4_fused_fp16_aux_weight(weights) is None
+    assert not has_sm70_dsv4_fused_fp16_aux_weight_contract(
+        (weights[1], weights[0], weights[2])
+    )
+    malformed_weights = (weights[0], torch.empty((), device="meta"), weights[2])
+    assert not has_sm70_dsv4_fused_fp16_aux_weight_contract(malformed_weights)
 
 
 @pytest.mark.skipif(
@@ -70,3 +91,53 @@ def test_sm70_dsv4_fp16_gemv_graph(
     else:
         reference = torch.mm(x, weight.T, out_dtype=torch.float32)
         torch.testing.assert_close(captured, reference, rtol=2e-4, atol=5e-5)
+
+
+@pytest.mark.skipif(
+    not torch.cuda.is_available() or torch.cuda.get_device_capability() != (7, 0),
+    reason="requires NVIDIA V100/SM70",
+)
+def test_sm70_dsv4_fused_fp16_aux_graph_is_bitwise(monkeypatch) -> None:
+    monkeypatch.setenv("VLLM_SM70_DSV4_FP16_GEMV", "1")
+    monkeypatch.setenv("VLLM_SM70_DSV4_FUSED_FP16_AUX_GEMV", "1")
+    torch.manual_seed(20260826)
+    x = torch.randn((1, 4096), device="cuda", dtype=torch.float16)
+    weights = tuple(
+        torch.randn((rows, 4096), device="cuda", dtype=torch.float16) * 0.01
+        for rows in (2048, 512, 64)
+    )
+    fused_weight = prepare_sm70_dsv4_fused_fp16_aux_weight(weights)
+    assert fused_weight is not None
+
+    output_dtypes = (torch.float32, torch.float32, torch.float16)
+    reference = tuple(
+        maybe_sm70_dsv4_fp16_gemv(x, weight, output_dtype)
+        for weight, output_dtype in zip(weights, output_dtypes)
+    )
+    candidate = maybe_sm70_dsv4_fused_fp16_aux_gemv(x, fused_weight)
+    assert all(output is not None for output in reference)
+    assert candidate is not None
+    torch.cuda.synchronize()
+    assert all(
+        torch.equal(actual, expected)
+        for actual, expected in zip(candidate, reference)
+        if expected is not None
+    )
+
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        captured_reference = tuple(
+            maybe_sm70_dsv4_fp16_gemv(x, weight, output_dtype)
+            for weight, output_dtype in zip(weights, output_dtypes)
+        )
+        captured_candidate = maybe_sm70_dsv4_fused_fp16_aux_gemv(x, fused_weight)
+    assert all(output is not None for output in captured_reference)
+    assert captured_candidate is not None
+    x.copy_(torch.randn_like(x))
+    graph.replay()
+    torch.cuda.synchronize()
+    assert all(
+        torch.equal(actual, expected)
+        for actual, expected in zip(captured_candidate, captured_reference)
+        if expected is not None
+    )

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -183,6 +183,7 @@ if TYPE_CHECKING:
     VLLM_SM70_MXFP4_DENSE_TUNE_MAX_M: int = 16
     VLLM_SM70_NVFP4_DENSE_TUNE_MAX_M: int = 16
     VLLM_SM70_DSV4_FP16_GEMV: bool = False
+    VLLM_SM70_DSV4_FUSED_FP16_AUX_GEMV: bool = False
     VLLM_SM70_DSV4_MHC_FP32_STAGE: bool = True
     VLLM_SM70_DSV4_QNORM_KV_FUSED_TP4: bool = True
     VLLM_SM70_PP_STATIC_HIDDEN_TRANSFER: bool = True
@@ -1812,6 +1813,9 @@ environment_variables: dict[str, Callable[[], Any]] = {
     ),
     "VLLM_SM70_DSV4_FP16_GEMV": lambda: bool(
         int(os.getenv("VLLM_SM70_DSV4_FP16_GEMV", "0"))
+    ),
+    "VLLM_SM70_DSV4_FUSED_FP16_AUX_GEMV": lambda: bool(
+        int(os.getenv("VLLM_SM70_DSV4_FUSED_FP16_AUX_GEMV", "0"))
     ),
     "VLLM_SM70_DSV4_MHC_FP32_STAGE": lambda: bool(
         int(os.getenv("VLLM_SM70_DSV4_MHC_FP32_STAGE", "1"))

--- a/vllm/models/deepseek_v4/attention.py
+++ b/vllm/models/deepseek_v4/attention.py
@@ -51,7 +51,12 @@ from vllm.model_executor.layers.quantization.utils.quant_utils import (
     GroupShape,
 )
 from vllm.models.deepseek_v4.compressor import DeepseekCompressor
-from vllm.models.deepseek_v4.sm70.gemv import maybe_sm70_dsv4_fp16_gemv
+from vllm.models.deepseek_v4.sm70.gemv import (
+    can_use_sm70_dsv4_fused_fp16_aux_gemv,
+    maybe_sm70_dsv4_fp16_gemv,
+    maybe_sm70_dsv4_fused_fp16_aux_gemv,
+    prepare_sm70_dsv4_fused_fp16_aux_weight,
+)
 from vllm.platforms import current_platform
 from vllm.triton_utils import tl, triton
 from vllm.utils.multi_stream_utils import (
@@ -310,6 +315,9 @@ class DeepseekV4MultiHeadLatentAttentionWrapper(PluggableLayer):
                 k_cache_prefix=self.mla_attn.prefix,
                 validity_cache_prefix=self.swa_cache_layer.prefix,
             )
+        self.register_buffer(
+            "_sm70_dsv4_fused_fp16_aux_weight", None, persistent=False
+        )
 
     def forward(
         self,
@@ -395,6 +403,20 @@ class DeepseekV4MultiHeadLatentAttentionWrapper(PluggableLayer):
 
         return self.wo_b(z.flatten(1))
 
+    def prepare_sm70_fused_fp16_aux_weight(self) -> None:
+        """Join the three exact C4 weights once, after checkpoint loading."""
+        if self.compressor is None or self.indexer is None:
+            return
+        fused_weight = prepare_sm70_dsv4_fused_fp16_aux_weight(
+            (
+                self.compressor.fused_wkv_wgate.weight,
+                self.indexer.compressor.fused_wkv_wgate.weight,
+                self.indexer.weights_proj.weight,
+            )
+        )
+        if fused_weight is not None:
+            self._buffers["_sm70_dsv4_fused_fp16_aux_weight"] = fused_weight
+
     def attn_gemm_parallel_execute(self, hidden_states) -> tuple[Any, ...]:
         aux_streams = self.aux_stream_list
         if aux_streams is not None:
@@ -463,6 +485,31 @@ class DeepseekV4MultiHeadLatentAttentionWrapper(PluggableLayer):
             # MergedColumnParallelLinear returns (output, bias); bias is None.
             qr_kv, _ = self.fused_wqa_wkv(hidden_states)
             return qr_kv
+
+        fused_aux_weight = self._sm70_dsv4_fused_fp16_aux_weight
+        if aux_streams is not None and can_use_sm70_dsv4_fused_fp16_aux_gemv(
+            hidden_states, fused_aux_weight
+        ):
+
+            def fused_fp16_aux() -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+                result = maybe_sm70_dsv4_fused_fp16_aux_gemv(
+                    hidden_states, fused_aux_weight
+                )
+                assert result is not None
+                return result
+
+            qr_kv, fused_results = execute_in_parallel(
+                fused_wqa_wkv,
+                [fused_fp16_aux],
+                self.ln_events[0],
+                [self.ln_events[1]],
+                [aux_streams[0]],
+                enable=True,
+            )
+            fused_result = fused_results[0]
+            assert fused_result is not None
+            kv_score, indexer_kv_score, indexer_weights = fused_result
+            return qr_kv, kv_score, indexer_kv_score, indexer_weights
 
         qr_kv, (kv_score, indexer_weights, indexer_kv_score) = execute_in_parallel(
             fused_wqa_wkv,

--- a/vllm/models/deepseek_v4/nvidia/model.py
+++ b/vllm/models/deepseek_v4/nvidia/model.py
@@ -1292,6 +1292,11 @@ class DeepseekV4Model(nn.Module, EagleModelMixin):
                 .sum(dim=1)
             )
 
+    def finalize_sm70_fused_aux_weights(self) -> None:
+        for layer in islice(self.layers, self.start_layer, self.end_layer):
+            if isinstance(layer, DeepseekV4DecoderLayer):
+                layer.attn.mla_attn.prepare_sm70_fused_fp16_aux_weight()
+
 
 def _make_deepseek_v4_weights_mapper(expert_dtype: str) -> WeightsMapper:
     if expert_dtype == "fp4":
@@ -1406,6 +1411,7 @@ class DeepseekV4ForCausalLM(nn.Module, SupportsPP, SupportsEagle3):
         loaded_params = loader.load_weights(weights, mapper=self.hf_to_vllm_mapper)
         self.model.finalize_mega_moe_weights()
         self.model.finalize_mhc_broadcast_weights()
+        self.model.finalize_sm70_fused_aux_weights()
         return loaded_params
 
     def get_expert_mapping(self) -> list[tuple[str, str, int, str]]:

--- a/vllm/models/deepseek_v4/sm70/gemv.py
+++ b/vllm/models/deepseek_v4/sm70/gemv.py
@@ -16,6 +16,8 @@ _SUPPORTED_N = frozenset((64, 256, 512, 1024, 2048))
 _K = 4096
 _BLOCK_K = 1024
 _NUM_WARPS = 4
+_FUSED_AUX_ROWS = (2048, 512, 64)
+_FUSED_AUX_N = sum(_FUSED_AUX_ROWS)
 
 
 @triton.jit
@@ -34,6 +36,132 @@ def _sm70_dsv4_fp16_gemv_kernel(
         weight = tl.load(weight_ptr + row * K + block_start + offsets).to(tl.float32)
         acc += tl.sum(x * weight, axis=0)
     tl.store(out_ptr + row, acc)
+
+
+@triton.jit
+def _sm70_dsv4_fused_fp16_aux_gemv_kernel(
+    x_ptr,
+    weight_ptr,
+    compressor_out_ptr,
+    indexer_compressor_out_ptr,
+    indexer_weights_out_ptr,
+    K: tl.constexpr,
+    BLOCK_K: tl.constexpr,
+    COMPRESSOR_N: tl.constexpr,
+    INDEXER_COMPRESSOR_N: tl.constexpr,
+):
+    """Compute the three C4 auxiliary GEMVs in one exact-FP16 launch."""
+    row = tl.program_id(0)
+    offsets = tl.arange(0, BLOCK_K)
+    acc = 0.0
+    for block_start in tl.static_range(0, K, BLOCK_K):
+        x = tl.load(x_ptr + block_start + offsets).to(tl.float32)
+        weight = tl.load(
+            weight_ptr + row * K + block_start + offsets
+        ).to(tl.float32)
+        acc += tl.sum(x * weight, axis=0)
+    tl.store(compressor_out_ptr + row, acc, mask=row < COMPRESSOR_N)
+    tl.store(
+        indexer_compressor_out_ptr + row - COMPRESSOR_N,
+        acc,
+        mask=(row >= COMPRESSOR_N)
+        & (row < COMPRESSOR_N + INDEXER_COMPRESSOR_N),
+    )
+    tl.store(
+        indexer_weights_out_ptr + row - COMPRESSOR_N - INDEXER_COMPRESSOR_N,
+        acc,
+        mask=row >= COMPRESSOR_N + INDEXER_COMPRESSOR_N,
+    )
+
+
+def has_sm70_dsv4_fused_fp16_aux_weight_contract(
+    weights: tuple[torch.Tensor, torch.Tensor, torch.Tensor],
+) -> bool:
+    """Check the exact C4 auxiliary row order used by the fused kernel."""
+    if tuple(tuple(weight.shape) for weight in weights) != tuple(
+        (rows, _K) for rows in _FUSED_AUX_ROWS
+    ):
+        return False
+    device = weights[0].device
+    return all(
+        weight.dtype == torch.float16
+        and weight.ndim == 2
+        and weight.shape[1] == _K
+        and weight.device == device
+        and weight.is_contiguous()
+        for weight in weights
+    )
+
+
+@torch.no_grad()
+def prepare_sm70_dsv4_fused_fp16_aux_weight(
+    weights: tuple[torch.Tensor, torch.Tensor, torch.Tensor],
+) -> torch.Tensor | None:
+    if (
+        not envs.VLLM_SM70_DSV4_FP16_GEMV
+        or not envs.VLLM_SM70_DSV4_FUSED_FP16_AUX_GEMV
+        or not current_platform.is_cuda()
+        or not current_platform.is_device_capability((7, 0))
+        or not weights[0].is_cuda
+        or not has_sm70_dsv4_fused_fp16_aux_weight_contract(weights)
+    ):
+        return None
+    return torch.cat(weights, dim=0).contiguous()
+
+
+def can_use_sm70_dsv4_fused_fp16_aux_gemv(
+    x: torch.Tensor,
+    fused_weight: torch.Tensor | None,
+) -> bool:
+    return (
+        envs.VLLM_SM70_DSV4_FP16_GEMV
+        and envs.VLLM_SM70_DSV4_FUSED_FP16_AUX_GEMV
+        and current_platform.is_cuda()
+        and current_platform.is_device_capability((7, 0))
+        and x.dtype == torch.float16
+        and x.ndim == 2
+        and x.shape == (1, _K)
+        and x.is_contiguous()
+        and fused_weight is not None
+        and fused_weight.dtype == torch.float16
+        and fused_weight.device == x.device
+        and fused_weight.shape == (_FUSED_AUX_N, _K)
+        and fused_weight.is_contiguous()
+    )
+
+
+def maybe_sm70_dsv4_fused_fp16_aux_gemv(
+    x: torch.Tensor,
+    fused_weight: torch.Tensor | None,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor] | None:
+    if not can_use_sm70_dsv4_fused_fp16_aux_gemv(x, fused_weight):
+        return None
+    assert fused_weight is not None
+    compressor_out = torch.empty(
+        (1, _FUSED_AUX_ROWS[0]), device=x.device, dtype=torch.float32
+    )
+    indexer_compressor_out = torch.empty(
+        (1, _FUSED_AUX_ROWS[1]), device=x.device, dtype=torch.float32
+    )
+    indexer_weights_out = torch.empty(
+        (1, _FUSED_AUX_ROWS[2]), device=x.device, dtype=torch.float16
+    )
+    _sm70_dsv4_fused_fp16_aux_gemv_kernel[(_FUSED_AUX_N,)](
+        x,
+        fused_weight,
+        compressor_out,
+        indexer_compressor_out,
+        indexer_weights_out,
+        K=_K,
+        BLOCK_K=_BLOCK_K,
+        COMPRESSOR_N=_FUSED_AUX_ROWS[0],
+        INDEXER_COMPRESSOR_N=_FUSED_AUX_ROWS[1],
+        num_warps=_NUM_WARPS,
+    )
+    logger.info_once(
+        "DeepSeek V4 SM70 exact fused-FP16 C4 auxiliary GEMV enabled."
+    )
+    return compressor_out, indexer_compressor_out, indexer_weights_out
 
 
 def can_use_sm70_dsv4_fp16_gemv(


### PR DESCRIPTION
## Purpose

- Fuse the DeepSeek V4 C4 `N=2048`, `N=512`, and `N=64` exact FP16 auxiliary GEMVs into one `N=2624` launch on one auxiliary stream.
- Preserve the existing block-K=1024 FP32 FMA/reduction order and output dtypes.
- Keep admission default-off and restricted to SM70 M=1 exact shapes; the new flag also requires `VLLM_SM70_DSV4_FP16_GEMV=1`.
- Prepare one non-persistent joined buffer after checkpoint loading (20.5 MiB per C4 layer).

This is stacked on the direct-order offset repair in draft PR #308.

## Test Plan

- CPU contract/default-off tests.
- Driver-free Triton SM70 compile and resource audit.
- Real V100 CUDA Graph bitwise test of the production kernel.
- Four-stream C4 overlap A/B screen with changing inputs.
- Pending before acceptance: matched PP2 x TP4 full-model endpoint, Nsight trace, GSM8K-64 and broader aggregate quality gates.

## Test Result

- CPU: 2 passed.
- V100 production CUDA Graph gate: 1 passed; three outputs are bitwise equal to the existing exact kernels.
- Overlap screen: 64/64 changing inputs bitwise for all auxiliary outputs and concurrent WQA/WKV output. Warm C4 overlap moves 103.809 us to 51.639 us; cache-scrubbed moves 99.104 us to 73.856 us.
- AOT: SM70 PTX/cubin generated; 32 registers, zero stack/local/static shared memory.
- Ruff and `git diff --check`: passed.

Evidence:
- `/data/models/v100-dsv4-0731-pp2tp4-fp13-fused-overlap-screen-20260826-r2/`
- `/data/models/v100-dsv4-0731-pp2tp4-fused-fp16-aux-gpu-test-20260826-r1/`

The route remains opt-in pending endpoint and dataset evidence.