### PR TITLE
[Draft][Kernel][SM70] Reduce NVFP4 emulation dequant memory

### DIFF
--- a/tests/kernels/quantization/test_nvfp4_emulation.py
+++ b/tests/kernels/quantization/test_nvfp4_emulation.py
@@ -64,6 +64,65 @@ def test_nvfp4_sm70_e4m3_scale_fallback_matches_torch_float8(monkeypatch) -> Non
 
 
 @pytest.mark.skipif(
+    not (current_platform.is_cuda() and current_platform.has_device_capability(70)),
+    reason="SM70 NVFP4 weight dequantization requires CUDA SM70+.",
+)
+@pytest.mark.parametrize("output_dtype", [torch.float16, torch.bfloat16])
+def test_sm70_triton_weight_dequantization_matches_reference(
+    monkeypatch, output_dtype: torch.dtype
+) -> None:
+    """The integer E4M3 decoder must exactly match the PyTorch fallback."""
+    block_size = 16
+    raw_scales = torch.arange(256, dtype=torch.uint8)
+    rows = raw_scales.numel()
+    tensor_sf = raw_scales.reshape(rows, 1).view(torch.float8_e4m3fn).cuda()
+    tensor_fp4 = (
+        torch.arange(rows * (block_size // 2), dtype=torch.int32)
+        .remainder(256)
+        .to(torch.uint8)
+        .reshape(rows, block_size // 2)
+        .cuda()
+    )
+    global_scale = torch.tensor(0.75, dtype=torch.float32, device="cuda")
+
+    monkeypatch.setattr(
+        nvfp4_emulation_utils, "_TRITON_NVFP4_EMULATION_SUPPORTED", False
+    )
+    monkeypatch.setattr(
+        nvfp4_emulation_utils,
+        "_TRITON_NVFP4_DEQUANTIZATION_SUPPORTED",
+        True,
+    )
+    actual = dequantize_to_dtype(
+        tensor_fp4,
+        tensor_sf,
+        global_scale,
+        output_dtype,
+        block_size,
+        swizzle=False,
+    )
+
+    with monkeypatch.context() as reference_patch:
+        reference_patch.setattr(
+            nvfp4_emulation_utils,
+            "_TRITON_NVFP4_DEQUANTIZATION_SUPPORTED",
+            False,
+        )
+        expected = dequantize_to_dtype(
+            tensor_fp4,
+            tensor_sf,
+            global_scale,
+            output_dtype,
+            block_size,
+            swizzle=False,
+        )
+
+    torch.testing.assert_close(actual, expected, atol=0, rtol=0, equal_nan=True)
+    finite_rows = (raw_scales & 0x7F) != 0x7F
+    assert torch.equal(actual[finite_rows], expected[finite_rows])
+
+
+@pytest.mark.skipif(
     not current_platform.is_cuda_alike(),
     reason="Triton NVFP4 kernel requires CUDA.",
 )

--- a/vllm/model_executor/layers/quantization/utils/nvfp4_emulation_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/nvfp4_emulation_utils.py
@@ -21,6 +21,7 @@ kE2M1ToFloat_handle = SimpleNamespace(
     val=torch.tensor([0.0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0], dtype=torch.float32)
 )
 _TRITON_NVFP4_EMULATION_SUPPORTED: bool | None = None
+_TRITON_NVFP4_DEQUANTIZATION_SUPPORTED: bool | None = None
 
 
 def _supports_triton_nvfp4_emulation(device: torch.device | None = None) -> bool:
@@ -34,6 +35,27 @@ def _supports_triton_nvfp4_emulation(device: torch.device | None = None) -> bool
             and current_platform.has_device_capability(89)
         )
     return _TRITON_NVFP4_EMULATION_SUPPORTED
+
+
+def _supports_triton_nvfp4_dequantization(
+    device: torch.device | None = None,
+) -> bool:
+    """Return whether the weight-only Triton dequantizer can run.
+
+    The full quantize-dequantize emulation kernel needs the native
+    ``tl.float8e4nv`` type and therefore remains gated to SM89+.  Weight
+    dequantization can also run on older CUDA GPUs because its E4M3 scale
+    bytes are decoded with regular integer and float32 operations.
+    """
+    if device is not None and device.type != "cuda":
+        return False
+
+    global _TRITON_NVFP4_DEQUANTIZATION_SUPPORTED
+    if _TRITON_NVFP4_DEQUANTIZATION_SUPPORTED is None:
+        _TRITON_NVFP4_DEQUANTIZATION_SUPPORTED = _supports_triton_nvfp4_emulation(
+            device
+        ) or (current_platform.is_cuda() and current_platform.has_device_capability(70))
+    return _TRITON_NVFP4_DEQUANTIZATION_SUPPORTED
 
 
 def _quantize_e4m3fn_scale(scale: torch.Tensor) -> torch.Tensor:
@@ -78,6 +100,21 @@ def _e2m1_inline(magnitude):
 
 
 @triton.jit
+def _e4m3fn_byte_to_float(raw):
+    """Decode E4M3FN bytes without using a native FP8 Triton type."""
+    raw_i32 = raw.to(tl.int32)
+    sign = tl.where((raw_i32 & 0x80) == 0, 1.0, -1.0)
+    exponent = (raw_i32 >> 3) & 0x0F
+    mantissa = raw_i32 & 0x07
+    mantissa_f32 = mantissa.to(tl.float32)
+    normal = (1.0 + mantissa_f32 * 0.125) * tl.exp2(exponent.to(tl.float32) - 7.0)
+    subnormal = mantissa_f32 * 0.001953125  # 2**-9
+    value = sign * tl.where(exponent == 0, subnormal, normal)
+    is_nan = (exponent == 0x0F) & (mantissa == 0x07)
+    return tl.where(is_nan, float("nan"), value)
+
+
+@triton.jit
 def _dequantize_nvfp4_kernel(
     fp4_ptr,
     scale_ptr,
@@ -88,6 +125,7 @@ def _dequantize_nvfp4_kernel(
     BLOCK_SIZE: tl.constexpr,
     has_batch_global_scale: tl.constexpr,
     TILE_BLOCKS: tl.constexpr,
+    NATIVE_FP8_SCALE_DECODE: tl.constexpr,
 ):
     """Triton kernel for NVFP4 dequantization (swizzle=False).
 
@@ -119,7 +157,10 @@ def _dequantize_nvfp4_kernel(
         mask=block_mask,
         other=0,
     )
-    scale_f32 = tl.cast(raw_scales, tl.float8e4nv, bitcast=True).to(tl.float32)
+    if NATIVE_FP8_SCALE_DECODE:
+        scale_f32 = tl.cast(raw_scales, tl.float8e4nv, bitcast=True).to(tl.float32)
+    else:
+        scale_f32 = _e4m3fn_byte_to_float(raw_scales)
     scale_values = (scale_f32 * global_scale)[:, None]
 
     # Load [TILE_BLOCKS, BLOCK_PACKED] packed bytes
@@ -345,6 +386,7 @@ def _triton_dequantize_nvfp4(
         block_size,
         is_3d,
         tile_blocks,
+        _supports_triton_nvfp4_emulation(tensor_fp4.device),
         num_warps=nw,
         num_stages=ns,
     )
@@ -406,7 +448,7 @@ def dequantize_to_dtype(
     # Two fp4 values are packed into one uint8.
     assert tensor_fp4.dtype == torch.uint8
 
-    if not swizzle and _supports_triton_nvfp4_emulation(tensor_fp4.device):
+    if not swizzle and _supports_triton_nvfp4_dequantization(tensor_fp4.device):
         return _triton_dequantize_nvfp4(
             tensor_fp4, tensor_sf, global_scale, dtype, block_size
         )


### PR DESCRIPTION
## Draft scope warning

This PR only reduces temporary allocations inside the existing software NVFP4
emulation dequantizer. It does **not** make ModelOpt NVFP4 W4A4 inference on
Volta a production-usable compressed execution path.

On four V100 32 GB GPUs, the full Qwen3.8 Flash Next integration now fits, but
single-stream decode remains about 4.13 tok/s because every routed-expert
forward still materializes FP16 expert weights. Treating this PR as Flash Next
or general SM70 NVFP4 enablement would therefore be misleading. It remains a
Draft until the maintainers decide whether this bounded fallback is useful on
its own; direct compressed MoE execution is a separate prerequisite for useful
model performance.

## Narrow purpose

Avoid the multi-gigabyte PyTorch nibble-expansion fallback when an already
selected ModelOpt NVFP4 emulation path dequantizes unswizzled expert weights on
CUDA SM70-SM88.

This is deliberately separate from Qwen3.8 Flash Next, PLE offload, model
registration, and any direct Marlin/TurboMind backend work. There is no
model-name admission in this change.

## Root cause

The existing Triton weight dequantizer used `tl.float8e4nv` to decode E4M3FN
scale bytes, so its support gate was tied to SM89+. On V100, emulation therefore
fell back to `break_fp4_bytes`, materializing uint8, bool, int64, float32, and
final half tensors for the entire 3D expert layer.

An exact TP4 Flash Next per-rank layer has these final dequantized tensors:

- w13: `[512, 320, 2560]` = 800 MiB FP16
- w2: `[512, 2560, 160]` = 400 MiB FP16

The required FP16 outputs total 1,200 MiB, while the legacy implementation
allocated 9,200 MiB incrementally because of its intermediates.

## Implementation

- Separate weight-only Triton dequantization support from the full activation
  quantize-dequantize gate.
- Decode raw E4M3FN scale bytes with Triton integer/FP32 operations on CUDA
  SM70-SM88.
- Preserve native `tl.float8e4nv` scale decoding on SM89+.
- Leave swizzled tensors and full activation QDQ on their existing paths.
- Test all 256 E4M3FN byte encodings and FP16/BF16 output.

## V100 kernel evidence

Physical Tesla V100 PCIe 32 GB, exact TP4 per-rank expert shapes, measured in
separate processes:

| Path | Incremental allocated | Peak allocated | Layer-pair dequant time |
|---|---:|---:|---:|
| Legacy PyTorch fallback | 9,200 MiB | 9,538.5 MiB | 58.3045 ms |
| Triton SM70 weight dequant | 1,200 MiB | 1,538.5 MiB | 5.3463 ms |

The finite-scale device oracle covered 254 E4M3FN encodings across FP16/BF16
and 2D/3D layouts with exact equality and `max_abs_error=0`.

## Integration evidence and hard limit

With ModelOpt NVFP4 W4A4, FP16 model dtype, TP4, PLE CPU offload, eager mode,
MTP off, and 256 MiB/GPU KV cache:

- Before: OOM during warmup at 32,488 MiB on GPU0.
- After: smoke test passes at 22,908 MiB on GPU0 with the same token IDs.
- Decode is still only about 4.13 tok/s, so this fallback is not a useful final
  execution path for this model.

## Validation

- Ruff check and format check on both changed files: passed locally.
- Python compileall and `git diff --check`: passed.
- Physical V100 finite-scale oracle: exact, max absolute error 0.
- Full four-V100 smoke: passed, with the performance limitation above.

The repository-wide `pre-commit --all-files` job currently also reformats and
flags numerous files outside this two-file PR. That baseline-wide CI failure is
being kept visible; it is not being presented as a passing gate.
