### PR TITLE
[Kernel][SM70] Extend unswizzled NVFP4 weight dequantization

### DIFF
--- a/tests/kernels/quantization/test_nvfp4_emulation.py
+++ b/tests/kernels/quantization/test_nvfp4_emulation.py
@@ -64,6 +64,74 @@ def test_nvfp4_sm70_e4m3_scale_fallback_matches_torch_float8(monkeypatch) -> Non
 
 
 @pytest.mark.skipif(
+    not (current_platform.is_cuda() and current_platform.has_device_capability(70)),
+    reason="Integer-decoded NVFP4 weight dequantization requires CUDA SM70+.",
+)
+@pytest.mark.parametrize("output_dtype", [torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("use_3d", [False, True])
+def test_integer_e4m3_weight_dequantization_matches_reference(
+    monkeypatch, output_dtype: torch.dtype, use_3d: bool
+) -> None:
+    """The integer E4M3 decoder must bit-match the PyTorch fallback."""
+    block_size = 16
+    raw_scales = torch.arange(256, dtype=torch.uint8)
+    rows = raw_scales.numel()
+    tensor_sf = raw_scales.reshape(rows, 1).view(torch.float8_e4m3fn).cuda()
+    tensor_fp4 = (
+        torch.arange(rows * (block_size // 2), dtype=torch.int32)
+        .remainder(256)
+        .to(torch.uint8)
+        .reshape(rows, block_size // 2)
+        .cuda()
+    )
+    global_scale = torch.tensor(0.75, dtype=torch.float32, device="cuda")
+    finite_rows = (raw_scales & 0x7F) != 0x7F
+    if use_3d:
+        tensor_sf = tensor_sf.reshape(2, rows // 2, 1)
+        tensor_fp4 = tensor_fp4.reshape(2, rows // 2, block_size // 2)
+        global_scale = torch.tensor([0.5, 1.25], device="cuda")
+        finite_rows = finite_rows.reshape(2, rows // 2)
+
+    monkeypatch.setattr(
+        nvfp4_emulation_utils, "_TRITON_NVFP4_EMULATION_SUPPORTED", False
+    )
+    monkeypatch.setattr(
+        nvfp4_emulation_utils,
+        "_TRITON_NVFP4_DEQUANTIZATION_SUPPORTED",
+        True,
+    )
+    actual = dequantize_to_dtype(
+        tensor_fp4,
+        tensor_sf,
+        global_scale,
+        output_dtype,
+        block_size,
+        swizzle=False,
+    )
+
+    with monkeypatch.context() as reference_patch:
+        reference_patch.setattr(
+            nvfp4_emulation_utils,
+            "_TRITON_NVFP4_DEQUANTIZATION_SUPPORTED",
+            False,
+        )
+        expected = dequantize_to_dtype(
+            tensor_fp4,
+            tensor_sf,
+            global_scale,
+            output_dtype,
+            block_size,
+            swizzle=False,
+        )
+
+    torch.testing.assert_close(actual, expected, atol=0, rtol=0, equal_nan=True)
+    assert torch.equal(
+        actual[finite_rows].view(torch.int16),
+        expected[finite_rows].view(torch.int16),
+    )
+
+
+@pytest.mark.skipif(
     not current_platform.is_cuda_alike(),
     reason="Triton NVFP4 kernel requires CUDA.",
 )

--- a/vllm/model_executor/layers/quantization/utils/nvfp4_emulation_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/nvfp4_emulation_utils.py
@@ -21,6 +21,7 @@ kE2M1ToFloat_handle = SimpleNamespace(
     val=torch.tensor([0.0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0], dtype=torch.float32)
 )
 _TRITON_NVFP4_EMULATION_SUPPORTED: bool | None = None
+_TRITON_NVFP4_DEQUANTIZATION_SUPPORTED: bool | None = None
 
 
 def _supports_triton_nvfp4_emulation(device: torch.device | None = None) -> bool:
@@ -34,6 +35,27 @@ def _supports_triton_nvfp4_emulation(device: torch.device | None = None) -> bool
             and current_platform.has_device_capability(89)
         )
     return _TRITON_NVFP4_EMULATION_SUPPORTED
+
+
+def _supports_triton_nvfp4_dequantization(
+    device: torch.device | None = None,
+) -> bool:
+    """Return whether the weight-only Triton dequantizer can run.
+
+    The full quantize-dequantize emulation kernel needs the native
+    ``tl.float8e4nv`` type and therefore remains gated to SM89+.  Weight
+    dequantization can also run on older CUDA GPUs because its E4M3 scale
+    bytes are decoded with regular integer and float32 operations.
+    """
+    if device is not None and device.type != "cuda":
+        return False
+
+    global _TRITON_NVFP4_DEQUANTIZATION_SUPPORTED
+    if _TRITON_NVFP4_DEQUANTIZATION_SUPPORTED is None:
+        _TRITON_NVFP4_DEQUANTIZATION_SUPPORTED = _supports_triton_nvfp4_emulation(
+            device
+        ) or (current_platform.is_cuda() and current_platform.has_device_capability(70))
+    return _TRITON_NVFP4_DEQUANTIZATION_SUPPORTED
 
 
 def _quantize_e4m3fn_scale(scale: torch.Tensor) -> torch.Tensor:
@@ -78,6 +100,31 @@ def _e2m1_inline(magnitude):
 
 
 @triton.jit
+def _apply_float32_sign_bit(value, sign_bit):
+    """Apply a sign bit without canonicalizing negative zero."""
+    value_bits = tl.cast(value, tl.uint32, bitcast=True)
+    signed_bits = value_bits | (sign_bit.to(tl.uint32) << 31)
+    return tl.cast(signed_bits, tl.float32, bitcast=True)
+
+
+@triton.jit
+def _e4m3fn_byte_to_float(raw):
+    """Decode E4M3FN bytes without using a native FP8 Triton type."""
+    raw_i32 = raw.to(tl.int32)
+    sign_bit = (raw_i32 >> 7) & 1
+    exponent = (raw_i32 >> 3) & 0x0F
+    mantissa = raw_i32 & 0x07
+    mantissa_f32 = mantissa.to(tl.float32)
+    normal = (1.0 + mantissa_f32 * 0.125) * tl.exp2(exponent.to(tl.float32) - 7.0)
+    subnormal = mantissa_f32 * 0.001953125  # 2**-9
+    value = _apply_float32_sign_bit(
+        tl.where(exponent == 0, subnormal, normal), sign_bit
+    )
+    is_nan = (exponent == 0x0F) & (mantissa == 0x07)
+    return tl.where(is_nan, float("nan"), value)
+
+
+@triton.jit
 def _dequantize_nvfp4_kernel(
     fp4_ptr,
     scale_ptr,
@@ -88,6 +135,7 @@ def _dequantize_nvfp4_kernel(
     BLOCK_SIZE: tl.constexpr,
     has_batch_global_scale: tl.constexpr,
     TILE_BLOCKS: tl.constexpr,
+    NATIVE_FP8_SCALE_DECODE: tl.constexpr,
 ):
     """Triton kernel for NVFP4 dequantization (swizzle=False).
 
@@ -119,7 +167,10 @@ def _dequantize_nvfp4_kernel(
         mask=block_mask,
         other=0,
     )
-    scale_f32 = tl.cast(raw_scales, tl.float8e4nv, bitcast=True).to(tl.float32)
+    if NATIVE_FP8_SCALE_DECODE:
+        scale_f32 = tl.cast(raw_scales, tl.float8e4nv, bitcast=True).to(tl.float32)
+    else:
+        scale_f32 = _e4m3fn_byte_to_float(raw_scales)
     scale_values = (scale_f32 * global_scale)[:, None]
 
     # Load [TILE_BLOCKS, BLOCK_PACKED] packed bytes
@@ -139,12 +190,20 @@ def _dequantize_nvfp4_kernel(
     low_mag = low_nibble & 0x07
     low_val = _e2m1_inline(low_mag)
     low_sign = (low_nibble >> 3) & 1
-    low_result = tl.where(low_sign == 1, -low_val, low_val) * scale_values
+    if NATIVE_FP8_SCALE_DECODE:
+        low_signed = tl.where(low_sign == 1, -low_val, low_val)
+    else:
+        low_signed = _apply_float32_sign_bit(low_val, low_sign)
+    low_result = low_signed * scale_values
 
     high_mag = high_nibble & 0x07
     high_val = _e2m1_inline(high_mag)
     high_sign = (high_nibble >> 3) & 1
-    high_result = tl.where(high_sign == 1, -high_val, high_val) * scale_values
+    if NATIVE_FP8_SCALE_DECODE:
+        high_signed = tl.where(high_sign == 1, -high_val, high_val)
+    else:
+        high_signed = _apply_float32_sign_bit(high_val, high_sign)
+    high_result = high_signed * scale_values
 
     # Interleave for coalesced contiguous store
     result = tl.interleave(low_result, high_result)
@@ -345,6 +404,7 @@ def _triton_dequantize_nvfp4(
         block_size,
         is_3d,
         tile_blocks,
+        _supports_triton_nvfp4_emulation(tensor_fp4.device),
         num_warps=nw,
         num_stages=ns,
     )
@@ -406,7 +466,7 @@ def dequantize_to_dtype(
     # Two fp4 values are packed into one uint8.
     assert tensor_fp4.dtype == torch.uint8
 
-    if not swizzle and _supports_triton_nvfp4_emulation(tensor_fp4.device):
+    if not swizzle and _supports_triton_nvfp4_dequantization(tensor_fp4.device):
         return _triton_dequantize_nvfp4(
             tensor_fp4, tensor_sf, global_scale, dtype, block_size
         )


### PR DESCRIPTION
## Purpose

Use the existing unswizzled Triton NVFP4 weight dequantizer on CUDA SM70-SM88
without requiring Triton's native FP8 type.

The full NVFP4 quantize-dequantize emulation kernel uses `tl.float8e4nv` and
must remain gated to SM89+. Weight-only dequantization does not need native FP8
math: its E4M3FN scale bytes can be decoded with integer and float32 Triton
operations. Splitting those two capability gates prevents pre-SM89 CUDA GPUs
from falling back to the allocation-heavy PyTorch nibble expansion.

The manual decoder preserves the E4M3FN and E2M1 sign bits explicitly, including
negative zero. The existing native FP8 branch on SM89+ is compile-time unchanged.

This is a narrow dequantizer change. It does not add a model, PLE offload, or a
native/direct NVFP4 MoE backend, and it does not claim production-usable model
throughput for software FP4 emulation.

This is the clean replacement for the closed draft #339.

## Test Plan

- `ruff check` and `ruff format --check` on both changed files.
- `git diff --check` against current `main`.
- Run the new CUDA test for all 256 E4M3FN byte encodings, FP16/BF16 output,
  and 2D/3D tensor layouts.
- On a physical V100, compare the Triton path with the existing PyTorch
  reference using raw output bit patterns for finite encodings and NaN masks.
- Benchmark both paths in separate processes with a 512-expert TP4 per-rank
  layer pair:
  - w13 output: `[512, 320, 2560]` FP16
  - w2 output: `[512, 2560, 160]` FP16
- Run a four-V100 software-emulation smoke after weight loading and warmup.

## Test Result

- Ruff check: passed.
- Ruff format check: passed.
- `git diff --check`: passed.
- Tesla V100 PCIe 32 GB bitwise gate: passed all four combinations
  (FP16/BF16 x 2D/3D). All 254 finite E4M3FN encodings were bitwise equal to
  the reference; both NaN encodings produced matching NaN masks.
- Exact TP4 layer-pair microbenchmark:

| Path | Incremental allocated | Peak allocated | Median dequant time |
|---|---:|---:|---:|
| PyTorch fallback | 9,200 MiB | 9,538.5 MiB | 58.3045 ms |
| Triton integer E4M3 decode | 1,200 MiB | 1,538.5 MiB | 4.6408 ms |

The required output tensors themselves total 1,200 MiB. The Triton path now
allocates that output without the extra 8,000 MiB of PyTorch intermediates.

- Four-V100 software-emulation smoke: passed with exit code 0 after loading
  206 checkpoint shards, binding CPU-offloaded PLE, and completing warmup plus
  a 32-token prompt / 4-token decode request. Model loading used 19.69 GiB per
  GPU worker; the run used a fixed 256 MiB/GPU KV cache. The observed
  4.13 tok/s decode is recorded only to make clear that software emulation is
  not a production-performance backend.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] Purpose and non-goals are explicit.
- [x] Test commands and physical-device plan are listed.
- [x] Four-V100 end-to-end smoke result recorded.
- [x] No documentation update is required for this internal kernel change.
</details>

