### PR TITLE
[Core][Performance] Avoid singleton hybrid KV cache group sizing

### DIFF
--- a/tests/v1/core/test_kv_cache_utils.py
+++ b/tests/v1/core/test_kv_cache_utils.py
@@ -214,6 +214,26 @@ def test_resolve_kv_cache_block_sizes_for_aligned_mamba_group():
     ) == (1648, 16)
 
 
+@pytest.mark.parametrize(
+    ("layer_counts", "expected_group_size"),
+    [
+        ([1, 12, 12, 12, 36], 12),
+        ([1, 20, 30], 10),
+        ([1, 64, 64], 16),
+        ([1, 5, 7], 1),
+        ([3, 7], 3),
+        ([5, 6], 6),
+    ],
+)
+def test_select_hybrid_kv_cache_group_size(
+    layer_counts: list[int], expected_group_size: int
+):
+    assert (
+        kv_cache_utils._select_hybrid_kv_cache_group_size(layer_counts)
+        == expected_group_size
+    )
+
+
 @pytest.mark.parametrize("hash_fn", [sha256, sha256_cbor])
 def test_none_hash(monkeypatch, hash_fn):
     import vllm.v1.core.kv_cache_utils

--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -1069,6 +1069,42 @@ def is_kv_cache_type_attention_free(kv_cache_spec: dict[str, KVCacheSpec]) -> bo
     return not kv_cache_spec
 
 
+def _select_hybrid_kv_cache_group_size(layer_counts: Sequence[int]) -> int:
+    """Select a group size without letting a singleton dominate the layout."""
+    min_num_layers = min(layer_counts)
+    max_num_layers = max(layer_counts)
+    if max_num_layers < min_num_layers * 1.5:
+        # If the number of layers is not much larger than the minimum number of
+        # layers, use the maximum number of layers as the group size to avoid
+        # too many padding layers. A typical example is gpt-oss-20b + eagle,
+        # with 12 sw + 13 full. We pad it to (13 sw, 13 full) instead of
+        # (12 sw, 24 full). 1.5 is a heuristic to avoid too many padding
+        # layers while accommodating speculative decoding drafters that add
+        # extra layers to one attention type.
+        return max_num_layers
+
+    # A singleton auxiliary state cache can otherwise force group_size=1 and
+    # multiply metadata preparation for every repeated cache type. Find the
+    # largest divisor shared by the repeated types that keeps total padding at
+    # or below 20%. Restrict this optimization to singleton outliers so existing
+    # hybrid layouts retain their current behavior.
+    if min_num_layers == 1:
+        repeated_counts = [count for count in layer_counts if count > 1]
+        if repeated_counts:
+            common_divisor = math.gcd(*repeated_counts)
+            total_layers = sum(layer_counts)
+            for candidate in range(common_divisor, 1, -1):
+                if common_divisor % candidate != 0:
+                    continue
+                padded_layers = candidate * sum(
+                    cdiv(count, candidate) for count in layer_counts
+                )
+                if (padded_layers - total_layers) * 5 <= total_layers:
+                    return candidate
+
+    return min_num_layers
+
+
 def _get_kv_cache_groups_uniform_page_size(
     kv_cache_spec: dict[str, KVCacheSpec],
 ) -> list[KVCacheGroupSpec]:
@@ -1153,18 +1189,14 @@ def _get_kv_cache_groups_uniform_page_size(
     # is the minimum number of layers among all attention types. Need a better
     # strategy if we want to support more complex patterns (e.g., 20 full + 30
     # sw, where the group size should be 10).
-    min_num_layers = min([len(layers) for layers in same_type_layers.values()])
-    group_size = min_num_layers
-    max_num_layers = max([len(layers) for layers in same_type_layers.values()])
-    if max_num_layers < min_num_layers * 1.5:
-        # If the number of layers is not much larger than the minimum number of
-        # layers, use the maximum number of layers as the group size to avoid
-        # too many padding layers. A typical example is gpt-oss-20b + eagle,
-        # with 12 sw + 13 full. We pad it to (13 sw, 13 full) instead of
-        # (12 sw, 24 full). 1.5 is a heuristic to avoid too many padding
-        # layers while accommodating speculative decoding drafters that add
-        # extra layers to one attention type.
-        group_size = max_num_layers
+    layer_counts = [len(layers) for layers in same_type_layers.values()]
+    group_size = _select_hybrid_kv_cache_group_size(layer_counts)
+    if group_size != min(layer_counts):
+        logger.info(
+            "Using hybrid KV cache group size %d for layer counts %s",
+            group_size,
+            sorted(layer_counts),
+        )
     grouped_layers = []
     for layers in same_type_layers.values():
         num_padding_layers = group_size - len(layers) % group_size


### PR DESCRIPTION
## Summary

- Extract hybrid KV cache group-size selection into a focused helper.
- Prevent a singleton auxiliary state cache from forcing every repeated cache type into groups of one.
- Select the largest shared divisor whose total padding stays within 20%.
- Preserve the existing layout heuristic for all non-singleton configurations.

## Problem

While validating Qwen3.8 Flash Next with PLE offload, the hybrid cache layer counts were `[1, 12, 12, 12, 36]`. The current minimum-count rule selected `group_size=1`, producing 73 cache groups and repeating slot-mapping and QSA metadata work on every decode step.

The singleton is an auxiliary PLE state cache, not the repeating pattern that should define the main hybrid layout.

## Solution

When the minimum layer count is exactly one, compute the greatest common divisor of the repeated cache types and choose the largest divisor that keeps aggregate padding at or below 20%. If no safe divisor exists, retain `group_size=1`.

This is intentionally narrow: configurations without a singleton keep the current behavior.

## Validation

- Added six selector cases covering the Flash Next layout, common divisors, the padding cap, no-common-divisor fallback, and unchanged existing heuristics.
- Targeted selector tests: `6 passed`.
- All pre-commit hooks for both changed files pass, including Ruff, mypy, SPDX, forbidden imports, and configuration checks.
- TP4 on 4x Tesla V100 32 GB, 64-token prompt and 64 measured decode intervals, W4A16 Marlin over ModelOpt packed weights, PLE CPU offload, FULL decode graph:
  - cache groups: `73 -> 7`
  - slot-mapping kernels per token: `73 -> 7`
  - QSA metadata builds per step: `24 -> 2`
  - decode mean: `25.809 -> 34.411 tok/s` (`+33.33%`)
  - deterministic output token IDs remained identical across all measured runs

Observed during the Flash Next work in #338, but this change is generic and does not depend on that model implementation.

## CI note

The remote pre-commit workflow runs with `--all-files` and currently fails on unchanged repository-wide Ruff format, typos, clang-format, markdownlint, SPDX, forbidden-import, and `torch.cuda` baselines. Neither file changed by this PR appears in the failure diff. Both changed files pass the full local pre-commit suite, and the remote Python 3.10, 3.11, 3.12, and 3.13 mypy hooks all pass.