### PR TITLE
[Bugfix][SM70] Audit DFlash2 output quality

### DIFF
--- a/benchmarks/benchmark_sm70_dflash2_gsm8k.py
+++ b/benchmarks/benchmark_sm70_dflash2_gsm8k.py
@@ -66,6 +66,12 @@ def _parse_args() -> argparse.Namespace:
     parser.add_argument("--max-num-batched-tokens", type=int, default=512)
     parser.add_argument("--max-num-seqs", type=int, default=4)
     parser.add_argument("--sequential", action="store_true")
+    parser.add_argument("--enable-prefix-caching", action="store_true")
+    parser.add_argument(
+        "--mamba-cache-mode",
+        choices=("all", "align", "none"),
+        help="Override the engine Mamba cache mode for practical-contract runs.",
+    )
     parser.add_argument("--gpu-memory-utilization", type=float, default=0.8)
     parser.add_argument(
         "--target-kv-cache-dtype",
@@ -85,11 +91,25 @@ def _parse_args() -> argparse.Namespace:
         help="Draft-only attention backend; the target remains on FLASH_ATTN_V100.",
     )
     parser.add_argument("--seed", type=int, default=0)
-    parser.add_argument(
+    seed_group = parser.add_mutually_exclusive_group()
+    seed_group.add_argument(
         "--request-seed",
         type=int,
         default=0,
         help="Sampling seed for every request; use -1 for server-style random seeds.",
+    )
+    seed_group.add_argument(
+        "--request-seeds",
+        help=(
+            "Comma-separated non-negative sampling seeds. Each seed replays the "
+            "selected prompt set without reloading the model."
+        ),
+    )
+    parser.add_argument(
+        "--request-seed-mode",
+        choices=("fixed", "index"),
+        default="fixed",
+        help="Use each seed as-is or add the original dataset index per request.",
     )
     parser.add_argument(
         "--cuda-profiler-capture",
@@ -105,6 +125,23 @@ def _sha256_file(path: Path) -> str:
         for chunk in iter(lambda: file.read(1024 * 1024), b""):
             digest.update(chunk)
     return digest.hexdigest()
+
+
+def _request_seeds(args: argparse.Namespace) -> list[int | None]:
+    if args.request_seeds is None:
+        if args.request_seed < -1:
+            raise ValueError("--request-seed must be -1 or a non-negative integer")
+        return [None if args.request_seed == -1 else args.request_seed]
+
+    try:
+        seeds = [int(value.strip()) for value in args.request_seeds.split(",")]
+    except ValueError as exc:
+        raise ValueError("--request-seeds must be comma-separated integers") from exc
+    if not seeds or any(seed < 0 for seed in seeds):
+        raise ValueError("--request-seeds must contain non-negative integers")
+    if len(set(seeds)) != len(seeds):
+        raise ValueError("--request-seeds must not contain duplicates")
+    return seeds
 
 
 def _model_weight_files(model: Path) -> dict[str, str]:
@@ -219,10 +256,11 @@ def main() -> int:
     args = _parse_args()
     if args.num_questions <= 0:
         raise ValueError("--num-questions must be positive")
-    if args.request_seed < -1:
-        raise ValueError("--request-seed must be -1 or a non-negative integer")
     if args.mode == "dflash" and args.draft_model is None:
         raise ValueError("--draft-model is required for --mode dflash")
+    if args.request_seed_mode == "index" and not args.sequential:
+        raise ValueError("--request-seed-mode index requires --sequential")
+    request_seeds = _request_seeds(args)
 
     import torch
     import vllm._C as vllm_c
@@ -275,12 +313,14 @@ def main() -> int:
         "max_num_batched_tokens": args.max_num_batched_tokens,
         "max_num_seqs": args.max_num_seqs,
         "gpu_memory_utilization": args.gpu_memory_utilization,
-        "enable_prefix_caching": False,
+        "enable_prefix_caching": args.enable_prefix_caching,
         "disable_log_stats": False,
         "enforce_eager": args.enforce_eager,
         "seed": args.seed,
         "speculative_config": speculative_config,
     }
+    if args.mamba_cache_mode is not None:
+        engine_kwargs["mamba_cache_mode"] = args.mamba_cache_mode
     if args.cuda_profiler_capture:
         engine_kwargs["profiler_config"] = {"profiler": "cuda"}
 
@@ -288,42 +328,84 @@ def main() -> int:
     llm = LLM(**engine_kwargs)
     load_seconds = time.perf_counter() - load_started
 
-    request_seed = None if args.request_seed == -1 else args.request_seed
+    warmup_seed = request_seeds[0]
+    if warmup_seed is not None and args.request_seed_mode == "index":
+        warmup_seed += rows[0][0]
     warmup_sampling = SamplingParams(
         temperature=args.temperature,
         top_p=0.95,
         top_k=20,
         max_tokens=args.warmup_tokens,
-        seed=request_seed,
+        seed=warmup_seed,
         skip_special_tokens=False,
     )
     llm.generate([prompts[0]], warmup_sampling, use_tqdm=False)
 
-    sampling = SamplingParams(
-        temperature=args.temperature,
-        top_p=0.95,
-        top_k=20,
-        max_tokens=args.max_tokens,
-        seed=request_seed,
-        skip_special_tokens=False,
-    )
     spec_before = _spec_metrics_snapshot(llm)
     if args.cuda_profiler_capture:
         llm.start_profile()
     started = time.perf_counter()
-    if args.sequential:
-        outputs = []
-        request_spec_metrics = []
-        for prompt in prompts:
-            request_spec_before = _spec_metrics_snapshot(llm)
-            outputs.append(llm.generate([prompt], sampling, use_tqdm=False)[0])
-            request_spec_after = _spec_metrics_snapshot(llm)
-            request_spec_metrics.append(
-                _diff_spec_metrics(request_spec_before, request_spec_after)
+    outputs = []
+    request_spec_metrics = []
+    case_inputs = []
+    for seed_base in request_seeds:
+        if args.sequential:
+            seed_outputs = []
+            seed_spec_metrics = []
+            actual_seeds = []
+            for (dataset_index, _row), prompt in zip(rows, prompts, strict=True):
+                request_seed = seed_base
+                if request_seed is not None and args.request_seed_mode == "index":
+                    request_seed += dataset_index
+                sampling = SamplingParams(
+                    temperature=args.temperature,
+                    top_p=0.95,
+                    top_k=20,
+                    max_tokens=args.max_tokens,
+                    seed=request_seed,
+                    skip_special_tokens=False,
+                )
+                request_spec_before = _spec_metrics_snapshot(llm)
+                seed_outputs.append(llm.generate([prompt], sampling, use_tqdm=False)[0])
+                request_spec_after = _spec_metrics_snapshot(llm)
+                seed_spec_metrics.append(
+                    _diff_spec_metrics(request_spec_before, request_spec_after)
+                )
+                actual_seeds.append(request_seed)
+        else:
+            sampling = SamplingParams(
+                temperature=args.temperature,
+                top_p=0.95,
+                top_k=20,
+                max_tokens=args.max_tokens,
+                seed=seed_base,
+                skip_special_tokens=False,
             )
-    else:
-        outputs = llm.generate(prompts, sampling, use_tqdm=False)
-        request_spec_metrics = [None] * len(outputs)
+            seed_outputs = llm.generate(prompts, sampling, use_tqdm=False)
+            seed_spec_metrics = [None] * len(seed_outputs)
+            actual_seeds = [seed_base] * len(seed_outputs)
+        outputs.extend(seed_outputs)
+        request_spec_metrics.extend(seed_spec_metrics)
+        case_inputs.extend(
+            (
+                seed_base,
+                request_seed,
+                dataset_index,
+                row,
+                prompt_content,
+                prompt_tokens,
+            )
+            for request_seed, (
+                dataset_index,
+                row,
+            ), prompt_content, prompt_tokens in zip(
+                actual_seeds,
+                rows,
+                prompt_contents,
+                prompt_token_counts,
+                strict=True,
+            )
+        )
     elapsed_seconds = time.perf_counter() - started
     if args.cuda_profiler_capture:
         llm.stop_profile()
@@ -331,10 +413,17 @@ def main() -> int:
 
     cases = []
     for (
+        request_seed_base,
+        request_seed,
         dataset_index,
         row,
-    ), prompt_content, prompt_tokens, output, request_spec in zip(
-        rows, prompt_contents, prompt_token_counts, outputs, request_spec_metrics
+        prompt_content,
+        prompt_tokens,
+    ), output, request_spec in zip(
+        case_inputs,
+        outputs,
+        request_spec_metrics,
+        strict=True,
     ):
         result = output.outputs[0]
         token_ids = list(result.token_ids)
@@ -348,7 +437,11 @@ def main() -> int:
             correct = None
         cases.append(
             {
+                "request_seed_base": request_seed_base,
+                "request_seed": request_seed,
                 "dataset_index": dataset_index,
+                "suite": row.get("_suite"),
+                "suite_index": row.get("_suite_index"),
                 "question": row.get("question"),
                 "prompt_content": prompt_content,
                 "expected_answer": expected,
@@ -400,6 +493,7 @@ def main() -> int:
             "dataset_format": args.dataset_format,
             "start_index": args.start_index,
             "num_questions": args.num_questions,
+            "num_samples": len(cases),
             "dataset_order": args.dataset_order,
             "model": str(args.model),
             "model_config_sha256": _sha256_file(args.model / "config.json"),
@@ -418,7 +512,14 @@ def main() -> int:
                 "top_p": 0.95,
                 "top_k": 20,
                 "max_tokens": args.max_tokens,
-                "seed": request_seed,
+                "seed": (
+                    request_seeds[0]
+                    if len(request_seeds) == 1 and args.request_seed_mode == "fixed"
+                    else None
+                ),
+                "seeds": (request_seeds if args.request_seed_mode == "fixed" else None),
+                "seed_bases": request_seeds,
+                "seed_mode": args.request_seed_mode,
                 "ignore_eos": False,
                 "thinking": True,
                 "reasoning_effort": "xhigh",

--- a/benchmarks/benchmark_sm70_tool_datasets.py
+++ b/benchmarks/benchmark_sm70_tool_datasets.py
@@ -14,12 +14,12 @@ import argparse
 import ast
 import hashlib
 import json
-import re
 import time
 from pathlib import Path
 from typing import Any
 
 import pandas as pd
+import regex as re
 import requests
 
 TOOLACE_MARKER = "Here is a list of functions in JSON format that you can invoke:"

--- a/benchmarks/benchmark_sm70_tool_datasets.py
+++ b/benchmarks/benchmark_sm70_tool_datasets.py
@@ -1,0 +1,546 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Run fixed ToolACE and NexusRaven function-calling samples via an API.
+
+These are deterministic dataset subsets for matched route comparisons, not
+full official leaderboard submissions. ToolACE function names are sanitized
+to the OpenAI-compatible namespace while retaining their original names in
+the descriptions and ground truth.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import hashlib
+import json
+import re
+import time
+from pathlib import Path
+from typing import Any
+
+import pandas as pd
+import requests
+
+TOOLACE_MARKER = "Here is a list of functions in JSON format that you can invoke:"
+SAFE_TOOL_NAME = re.compile(r"[^A-Za-z0-9_]")
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as file:
+        for chunk in iter(lambda: file.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _post_chat(base_url: str, payload: dict[str, Any]) -> dict[str, Any]:
+    started = time.perf_counter()
+    response = requests.post(
+        f"{base_url.rstrip('/')}/v1/chat/completions",
+        json=payload,
+        timeout=600,
+    )
+    if response.status_code != 200:
+        return {
+            "ok": False,
+            "status_code": response.status_code,
+            "body": response.text,
+            "elapsed_seconds": time.perf_counter() - started,
+        }
+    try:
+        body = response.json()
+    except requests.JSONDecodeError as exc:
+        return {
+            "ok": False,
+            "status_code": response.status_code,
+            "body": response.text,
+            "error": str(exc),
+            "elapsed_seconds": time.perf_counter() - started,
+        }
+    choice = body.get("choices", [{}])[0]
+    message = choice.get("message") or {}
+    return {
+        "ok": True,
+        "status_code": response.status_code,
+        "elapsed_seconds": time.perf_counter() - started,
+        "finish_reason": choice.get("finish_reason"),
+        "content": message.get("content") or "",
+        "reasoning_content": message.get("reasoning_content") or "",
+        "prompt_token_ids": body.get("prompt_token_ids") or [],
+        "output_token_ids": choice.get("token_ids") or [],
+        "tool_calls": message.get("tool_calls") or [],
+        "raw_response": body,
+    }
+
+
+def _canonical_calls(result: dict[str, Any]) -> tuple[list[dict[str, Any]], list[str]]:
+    calls: list[dict[str, Any]] = []
+    errors: list[str] = []
+    for call in result.get("tool_calls") or []:
+        function = call.get("function") or {}
+        try:
+            arguments = json.loads(function.get("arguments") or "")
+        except (TypeError, json.JSONDecodeError) as exc:
+            errors.append(f"invalid arguments JSON: {exc}")
+            continue
+        calls.append({"name": function.get("name") or "", "arguments": arguments})
+    return calls, errors
+
+
+def _normalize_schema(value: Any) -> Any:
+    if isinstance(value, list):
+        return [_normalize_schema(item) for item in value]
+    if not isinstance(value, dict):
+        return value
+    normalized = {key: _normalize_schema(item) for key, item in value.items()}
+    type_map = {
+        "dict": "object",
+        "float": "number",
+        "tuple": "array",
+        "any": None,
+        "None": None,
+    }
+    schema_type = normalized.get("type")
+    if isinstance(schema_type, str) and schema_type in type_map:
+        mapped = type_map[schema_type]
+        if mapped is None:
+            normalized.pop("type")
+        else:
+            normalized["type"] = mapped
+    return normalized
+
+
+def _stratified(items: list[Any], count: int, *, key) -> list[Any]:
+    items = sorted(items, key=key)
+    if len(items) <= count:
+        return items
+    if count == 1:
+        return [items[len(items) // 2]]
+    return [
+        items[round(index * (len(items) - 1) / (count - 1))] for index in range(count)
+    ]
+
+
+def _split_top_level(text: str) -> list[str]:
+    pieces: list[str] = []
+    start = 0
+    depth = 0
+    quote: str | None = None
+    escaped = False
+    for index, character in enumerate(text):
+        if quote is not None:
+            if escaped:
+                escaped = False
+            elif character == "\\":
+                escaped = True
+            elif character == quote:
+                quote = None
+        elif character in {'"', "'"}:
+            quote = character
+        elif character in "([{":
+            depth += 1
+        elif character in ")]}" and depth:
+            depth -= 1
+        elif character == "," and depth == 0:
+            pieces.append(text[start:index].strip())
+            start = index + 1
+    pieces.append(text[start:].strip())
+    return [piece for piece in pieces if piece]
+
+
+def _toolace_functions(record: dict[str, Any]) -> list[dict[str, Any]] | None:
+    system = record.get("system") or ""
+    marker = system.find(TOOLACE_MARKER)
+    if marker == -1:
+        return None
+    start = system.find("[", marker + len(TOOLACE_MARKER))
+    if start == -1:
+        return None
+    try:
+        functions = json.JSONDecoder().raw_decode(system[start:])[0]
+    except (TypeError, json.JSONDecodeError):
+        return None
+    if not isinstance(functions, list) or not all(
+        isinstance(function, dict)
+        and isinstance(function.get("name"), str)
+        and isinstance(function.get("parameters"), dict)
+        for function in functions
+    ):
+        return None
+    return functions
+
+
+def _parse_toolace_calls(
+    answer: str, function_names: list[str]
+) -> list[dict[str, Any]] | None:
+    answer = answer.strip()
+    if not answer.startswith("[") or not answer.endswith("]"):
+        return None
+    body = answer[1:-1].strip()
+    if not body:
+        return []
+    calls: list[dict[str, Any]] = []
+    for piece in _split_top_level(body):
+        names = [
+            name
+            for name in function_names
+            if piece.startswith(f"{name}(") and piece.endswith(")")
+        ]
+        if not names:
+            return None
+        name = max(names, key=len)
+        argument_text = piece[len(name) + 1 : -1]
+        try:
+            call = ast.parse(f"f({argument_text})", mode="eval").body
+            if not isinstance(call, ast.Call) or call.args:
+                return None
+            arguments = {
+                keyword.arg: ast.literal_eval(keyword.value)
+                for keyword in call.keywords
+                if keyword.arg is not None
+            }
+        except (SyntaxError, ValueError):
+            return None
+        calls.append({"name": name, "arguments": arguments})
+    return calls
+
+
+def _clear_no_tool_answer(answer: str, functions: list[dict[str, Any]]) -> bool:
+    if not functions:
+        return True
+    lowered = answer.lower()
+    signatures = (
+        "no available function",
+        "no available functions",
+        "lacks the required",
+        "lacks the parameter",
+        "please provide",
+        "provide further",
+        "additional information",
+        "not enough information",
+    )
+    return any(signature in lowered for signature in signatures)
+
+
+def _safe_tool_names(
+    functions: list[dict[str, Any]],
+) -> tuple[list[dict[str, Any]], dict[str, str]]:
+    tools: list[dict[str, Any]] = []
+    name_map: dict[str, str] = {}
+    used: set[str] = set()
+    for index, function in enumerate(functions):
+        slug = SAFE_TOOL_NAME.sub("_", function["name"]).strip("_") or "function"
+        safe_name = f"tool_{index}_{slug}"[:64]
+        while safe_name in used:
+            safe_name = f"tool_{index}_{slug}_{len(used)}"[:64]
+        used.add(safe_name)
+        name_map[function["name"]] = safe_name
+        tools.append(
+            {
+                "type": "function",
+                "function": {
+                    "name": safe_name,
+                    "description": (
+                        f"Original tool name: {function['name']}. "
+                        f"{function.get('description') or ''}"
+                    ),
+                    "parameters": _normalize_schema(function["parameters"]),
+                },
+            }
+        )
+    return tools, name_map
+
+
+def _run_toolace(
+    base_url: str,
+    model: str,
+    seed: int,
+    path: Path,
+    per_bucket: int,
+) -> dict[str, Any]:
+    records = json.loads(path.read_text())
+    buckets: dict[str, list[dict[str, Any]]] = {
+        "single": [],
+        "parallel": [],
+        "no_tool": [],
+    }
+    for index, record in enumerate(records):
+        conversations = record.get("conversations") or []
+        if len(conversations) != 2 or conversations[0].get("from") != "user":
+            continue
+        functions = _toolace_functions(record)
+        if functions is None:
+            continue
+        answer = conversations[1].get("value") or ""
+        calls = _parse_toolace_calls(answer, [item["name"] for item in functions])
+        if calls is not None and calls:
+            bucket = "parallel" if len(calls) > 1 else "single"
+        elif _clear_no_tool_answer(answer, functions):
+            bucket = "no_tool"
+            calls = []
+        else:
+            continue
+        buckets[bucket].append(
+            {
+                "index": index,
+                "prompt": conversations[0]["value"],
+                "functions": functions,
+                "expected": calls,
+                "system_length": len(record.get("system") or ""),
+            }
+        )
+
+    results_by_bucket: dict[str, Any] = {}
+    for bucket, candidates in buckets.items():
+        selected = _stratified(
+            candidates,
+            per_bucket,
+            key=lambda item: (item["system_length"], item["index"]),
+        )
+        results: list[dict[str, Any]] = []
+        for case in selected:
+            tools, name_map = _safe_tool_names(case["functions"])
+            expected = [
+                {"name": name_map[call["name"]], "arguments": call["arguments"]}
+                for call in case["expected"]
+            ]
+            payload = {
+                "model": model,
+                "messages": [{"role": "user", "content": case["prompt"]}],
+                "temperature": 0.0,
+                "seed": seed,
+                "max_tokens": 1024,
+                "return_token_ids": True,
+                "chat_template_kwargs": {"enable_thinking": False},
+            }
+            if tools:
+                payload.update(
+                    {
+                        "tools": tools,
+                        "tool_choice": "auto",
+                        "parallel_tool_calls": True,
+                    }
+                )
+            result = _post_chat(base_url, payload)
+            actual, errors = _canonical_calls(result)
+            if result.get("ok") and actual != expected:
+                errors.append(f"calls {actual!r} != {expected!r}")
+            elif not result.get("ok"):
+                errors.append("request failed")
+            result.update(
+                {
+                    "index": case["index"],
+                    "expected": expected,
+                    "actual": actual,
+                    "errors": errors,
+                }
+            )
+            results.append(result)
+        results_by_bucket[bucket] = {
+            "score": sum(not result["errors"] for result in results),
+            "total": len(results),
+            "cases": results,
+        }
+    score = sum(item["score"] for item in results_by_bucket.values())
+    total = sum(item["total"] for item in results_by_bucket.values())
+    return {
+        "score": score,
+        "total": total,
+        "protocol_passed": all(
+            case.get("ok")
+            for bucket in results_by_bucket.values()
+            for case in bucket["cases"]
+        ),
+        "per_bucket": results_by_bucket,
+        "note": "Fixed ToolACE subset with OpenAI-safe function-name mapping.",
+    }
+
+
+def _nexus_tool(function: dict[str, Any]) -> dict[str, Any]:
+    json_types = {
+        "str": "string",
+        "int": "integer",
+        "list": "array",
+        "dict": "object",
+    }
+    properties: dict[str, Any] = {}
+    required: list[str] = []
+    for argument in function["args_dicts"]:
+        properties[argument["name"]] = {
+            "description": argument.get("description") or ""
+        }
+        if json_type := json_types.get(str(argument.get("type"))):
+            properties[argument["name"]]["type"] = json_type
+        if argument.get("required"):
+            required.append(argument["name"])
+    return {
+        "type": "function",
+        "function": {
+            "name": function["name"],
+            "description": function.get("description") or "",
+            "parameters": {
+                "type": "object",
+                "properties": properties,
+                "required": required,
+                "additionalProperties": False,
+            },
+        },
+    }
+
+
+def _run_nexus(
+    base_url: str,
+    model: str,
+    seed: int,
+    queries_path: Path,
+    api_path: Path,
+    per_domain: int,
+) -> dict[str, Any]:
+    queries = pd.read_parquet(queries_path)
+    functions = pd.read_parquet(api_path)
+    function_map = {
+        (row["dataset"], row["name"]): row for row in functions.to_dict("records")
+    }
+    domain_results: dict[str, Any] = {}
+    for domain in sorted(queries["dataset"].unique()):
+        records = queries[queries["dataset"] == domain].to_dict("records")
+        selected = _stratified(
+            list(enumerate(records)),
+            per_domain,
+            key=lambda item: (len(item[1]["prompt"]), item[0]),
+        )
+        results: list[dict[str, Any]] = []
+        for dataset_index, record in selected:
+            tools = [
+                _nexus_tool(function_map[(domain, name)])
+                for name in record["context_functions"]
+            ]
+            expected = [
+                {
+                    "name": record["python_function_name"],
+                    "arguments": json.loads(record["python_args_dict"]),
+                }
+            ]
+            result = _post_chat(
+                base_url,
+                {
+                    "model": model,
+                    "messages": [{"role": "user", "content": record["prompt"]}],
+                    "tools": tools,
+                    "tool_choice": "auto",
+                    "parallel_tool_calls": False,
+                    "temperature": 0.0,
+                    "seed": seed,
+                    "max_tokens": 1024,
+                    "return_token_ids": True,
+                    "chat_template_kwargs": {"enable_thinking": False},
+                },
+            )
+            actual, errors = _canonical_calls(result)
+            if result.get("ok") and actual != expected:
+                errors.append(f"calls {actual!r} != {expected!r}")
+            elif not result.get("ok"):
+                errors.append("request failed")
+            result.update(
+                {
+                    "dataset_index": dataset_index,
+                    "prompt": record["prompt"],
+                    "expected": expected,
+                    "actual": actual,
+                    "errors": errors,
+                }
+            )
+            results.append(result)
+        domain_results[domain] = {
+            "score": sum(not result["errors"] for result in results),
+            "total": len(results),
+            "cases": results,
+        }
+    score = sum(item["score"] for item in domain_results.values())
+    total = sum(item["total"] for item in domain_results.values())
+    return {
+        "score": score,
+        "total": total,
+        "protocol_passed": all(
+            case.get("ok")
+            for domain in domain_results.values()
+            for case in domain["cases"]
+        ),
+        "per_domain": domain_results,
+        "note": "Fixed NexusRaven API evaluation subset; exact call/argument match.",
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--base-url", required=True)
+    parser.add_argument("--model", default="quality-audit-dflash2")
+    parser.add_argument("--seed", type=int, default=20260827)
+    parser.add_argument("--out", type=Path, required=True)
+    parser.add_argument("--toolace-data", type=Path, required=True)
+    parser.add_argument("--toolace-per-bucket", type=int, default=4)
+    parser.add_argument("--nexus-queries", type=Path, required=True)
+    parser.add_argument("--nexus-api-list", type=Path, required=True)
+    parser.add_argument("--nexus-per-domain", type=int, default=4)
+    args = parser.parse_args()
+
+    artifact = {
+        "base_url": args.base_url,
+        "model": args.model,
+        "seed": args.seed,
+        "sources": {
+            "toolace": {
+                "path": str(args.toolace_data),
+                "sha256": _sha256(args.toolace_data),
+            },
+            "nexus_queries": {
+                "path": str(args.nexus_queries),
+                "sha256": _sha256(args.nexus_queries),
+            },
+            "nexus_api_list": {
+                "path": str(args.nexus_api_list),
+                "sha256": _sha256(args.nexus_api_list),
+            },
+        },
+        "toolace": _run_toolace(
+            args.base_url,
+            args.model,
+            args.seed,
+            args.toolace_data,
+            args.toolace_per_bucket,
+        ),
+        "nexus_raven": _run_nexus(
+            args.base_url,
+            args.model,
+            args.seed,
+            args.nexus_queries,
+            args.nexus_api_list,
+            args.nexus_per_domain,
+        ),
+    }
+    artifact["protocol_passed"] = bool(
+        artifact["toolace"]["protocol_passed"]
+        and artifact["nexus_raven"]["protocol_passed"]
+    )
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    args.out.write_text(json.dumps(artifact, ensure_ascii=False, indent=2) + "\n")
+    print(
+        json.dumps(
+            {
+                "protocol_passed": artifact["protocol_passed"],
+                "toolace": [artifact["toolace"]["score"], artifact["toolace"]["total"]],
+                "nexus_raven": [
+                    artifact["nexus_raven"]["score"],
+                    artifact["nexus_raven"]["total"],
+                ],
+                "out": str(args.out),
+            }
+        )
+    )
+    if not artifact["protocol_passed"]:
+        raise SystemExit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/benchmark_sm70_tool_protocol.py
+++ b/benchmarks/benchmark_sm70_tool_protocol.py
@@ -1,0 +1,1291 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Exercise long, streamed tool calls and structured output through an API.
+
+This is a deterministic protocol gate, not a substitute for BFCL task scores.
+It catches malformed streamed arguments, invalid tool names, history replay
+failures, and JSON-schema violations while retaining the raw SSE events needed
+to localize a first divergence between two server configurations.
+"""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import json
+import re
+import time
+from pathlib import Path
+from typing import Any
+
+import jsonschema
+import requests
+
+TOOLS: list[dict[str, Any]] = [
+    {
+        "type": "function",
+        "function": {
+            "name": "Read",
+            "description": "Read a UTF-8 file.",
+            "parameters": {
+                "type": "object",
+                "properties": {"file_path": {"type": "string"}},
+                "required": ["file_path"],
+                "additionalProperties": False,
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "Grep",
+            "description": "Search files for a literal pattern.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "pattern": {"type": "string"},
+                    "path": {"type": "string"},
+                    "output_mode": {
+                        "type": "string",
+                        "enum": ["content", "files_with_matches", "count"],
+                    },
+                },
+                "required": ["pattern", "path", "output_mode"],
+                "additionalProperties": False,
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "Glob",
+            "description": "Find files matching a glob pattern.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "pattern": {"type": "string"},
+                    "path": {"type": "string"},
+                },
+                "required": ["pattern", "path"],
+                "additionalProperties": False,
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "Bash",
+            "description": "Run one shell command.",
+            "parameters": {
+                "type": "object",
+                "properties": {"command": {"type": "string"}},
+                "required": ["command"],
+                "additionalProperties": False,
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "Edit",
+            "description": "Replace an exact string in a file.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "file_path": {"type": "string"},
+                    "old_string": {"type": "string"},
+                    "new_string": {"type": "string"},
+                    "replace_all": {"type": "boolean"},
+                },
+                "required": [
+                    "file_path",
+                    "old_string",
+                    "new_string",
+                    "replace_all",
+                ],
+                "additionalProperties": False,
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "Write",
+            "description": "Write complete UTF-8 content to a file.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "file_path": {"type": "string"},
+                    "content": {"type": "string"},
+                },
+                "required": ["file_path", "content"],
+                "additionalProperties": False,
+            },
+        },
+    },
+]
+
+
+STEPS: list[dict[str, Any]] = [
+    {
+        "name": "Read",
+        "prompt": "Call Read for /tmp/project/src/app.py. Do not call another tool.",
+        "arguments": {"file_path": "/tmp/project/src/app.py"},
+        "result": "def run():\n    return 1\n",
+    },
+    {
+        "name": "Grep",
+        "prompt": (
+            "Call Grep for literal pattern run in /tmp/project/src with "
+            "output_mode=count. Do not call another tool."
+        ),
+        "arguments": {
+            "pattern": "run",
+            "path": "/tmp/project/src",
+            "output_mode": "count",
+        },
+        "result": "/tmp/project/src/app.py:1",
+    },
+    {
+        "name": "Glob",
+        "prompt": (
+            "Call Glob with pattern **/*.py under /tmp/project. "
+            "Do not call another tool."
+        ),
+        "arguments": {"pattern": "**/*.py", "path": "/tmp/project"},
+        "result": "/tmp/project/src/app.py",
+    },
+    {
+        "name": "Bash",
+        "prompt": (
+            "Call Bash with exactly: python -m pytest -q. Do not call another tool."
+        ),
+        "arguments": {"command": "python -m pytest -q"},
+        "result": "8 passed in 1.20s",
+    },
+    {
+        "name": "Edit",
+        "prompt": (
+            "Call Edit on /tmp/project/src/app.py. Replace exactly the string "
+            "`    return 1\\n` with `    return 2\\n`, and set replace_all=false. "
+            "Preserve all indentation and newlines."
+        ),
+        "arguments": {
+            "file_path": "/tmp/project/src/app.py",
+            "old_string": "    return 1\n",
+            "new_string": "    return 2\n",
+            "replace_all": False,
+        },
+        "result": "updated /tmp/project/src/app.py",
+    },
+    {
+        "name": "Write",
+        "prompt": (
+            "Call Write for /tmp/project/result.json with exactly this content: "
+            '{"ok":true,"lines":["a\\nb","<parameter=x>literal"]}.'
+        ),
+        "arguments": {
+            "file_path": "/tmp/project/result.json",
+            "content": '{"ok":true,"lines":["a\\nb","<parameter=x>literal"]}',
+        },
+        "result": "wrote 55 bytes",
+    },
+]
+
+
+STRUCTURED_CASES: list[dict[str, Any]] = [
+    {
+        "name": "nested",
+        "prompt": (
+            "Return the build record for project alpha, successful, with stages "
+            "compile=12 and test=8."
+        ),
+        "schema": {
+            "type": "object",
+            "properties": {
+                "project": {"type": "string", "const": "alpha"},
+                "success": {"type": "boolean", "const": True},
+                "stages": {
+                    "type": "array",
+                    "prefixItems": [
+                        {
+                            "type": "object",
+                            "properties": {
+                                "name": {"const": "compile"},
+                                "seconds": {"type": "integer", "const": 12},
+                            },
+                            "required": ["name", "seconds"],
+                            "additionalProperties": False,
+                        },
+                        {
+                            "type": "object",
+                            "properties": {
+                                "name": {"const": "test"},
+                                "seconds": {"type": "integer", "const": 8},
+                            },
+                            "required": ["name", "seconds"],
+                            "additionalProperties": False,
+                        },
+                    ],
+                    "minItems": 2,
+                    "maxItems": 2,
+                },
+            },
+            "required": ["project", "success", "stages"],
+            "additionalProperties": False,
+        },
+    },
+    {
+        "name": "escaped_text",
+        "prompt": "Return path /tmp/a, the two-line text `a\\nb`, and count 2.",
+        "schema": {
+            "type": "object",
+            "properties": {
+                "path": {"type": "string", "const": "/tmp/a"},
+                "text": {"type": "string", "const": "a\nb"},
+                "count": {"type": "integer", "const": 2},
+            },
+            "required": ["path", "text", "count"],
+            "additionalProperties": False,
+        },
+    },
+]
+
+
+STREAM_PARITY_CASES: list[dict[str, str]] = [
+    {
+        "name": "quoted_ascii",
+        "expected": 'The "implied" volatility is a "forward-looking" measure.',
+    },
+    {
+        "name": "json_utf8",
+        "expected": '{"path":"/tmp/中.txt","text":"a\\nb","emoji":"🌶️"}',
+    },
+]
+
+
+def _schema_by_tool_name() -> dict[str, dict[str, Any]]:
+    return {item["function"]["name"]: item["function"]["parameters"] for item in TOOLS}
+
+
+def _stream_chat(base_url: str, payload: dict[str, Any]) -> dict[str, Any]:
+    started = time.perf_counter()
+    response = requests.post(
+        f"{base_url.rstrip('/')}/v1/chat/completions",
+        json=payload,
+        stream=True,
+        timeout=600,
+    )
+    if response.status_code != 200:
+        return {
+            "ok": False,
+            "status_code": response.status_code,
+            "body": response.text,
+            "elapsed_seconds": time.perf_counter() - started,
+        }
+
+    raw_events: list[dict[str, Any]] = []
+    prompt_token_ids: list[int] = []
+    output_token_ids: list[int] = []
+    output_token_chunks: list[list[int]] = []
+    content = ""
+    reasoning = ""
+    finish_reason = None
+    calls: dict[int, dict[str, Any]] = {}
+    malformed_sse: list[str] = []
+    for raw_line in response.iter_lines(decode_unicode=True):
+        if not raw_line or not raw_line.startswith("data:"):
+            continue
+        data = raw_line[5:].strip()
+        if data == "[DONE]":
+            break
+        try:
+            event = json.loads(data)
+        except json.JSONDecodeError:
+            malformed_sse.append(data)
+            continue
+        raw_events.append(event)
+        choice = event.get("choices", [{}])[0]
+        if event.get("prompt_token_ids"):
+            prompt_token_ids.extend(event["prompt_token_ids"])
+        token_ids = choice.get("token_ids") or []
+        if token_ids:
+            output_token_chunks.append(token_ids)
+            output_token_ids.extend(token_ids)
+        finish_reason = choice.get("finish_reason") or finish_reason
+        delta = choice.get("delta") or {}
+        content += delta.get("content") or ""
+        reasoning += delta.get("reasoning_content") or ""
+        for call_delta in delta.get("tool_calls") or []:
+            index = int(call_delta.get("index", 0))
+            call = calls.setdefault(
+                index,
+                {
+                    "id": "",
+                    "type": "function",
+                    "function": {"name": "", "arguments": ""},
+                },
+            )
+            call["id"] += call_delta.get("id") or ""
+            function = call_delta.get("function") or {}
+            call["function"]["name"] += function.get("name") or ""
+            call["function"]["arguments"] += function.get("arguments") or ""
+
+    return {
+        "ok": not malformed_sse,
+        "status_code": response.status_code,
+        "elapsed_seconds": time.perf_counter() - started,
+        "finish_reason": finish_reason,
+        "content": content,
+        "reasoning_content": reasoning,
+        "prompt_token_ids": prompt_token_ids,
+        "output_token_ids": output_token_ids,
+        "output_token_chunks": output_token_chunks,
+        "tool_calls": [calls[index] for index in sorted(calls)],
+        "malformed_sse": malformed_sse,
+        "raw_events": raw_events,
+    }
+
+
+def _nonstream_chat(base_url: str, payload: dict[str, Any]) -> dict[str, Any]:
+    started = time.perf_counter()
+    response = requests.post(
+        f"{base_url.rstrip('/')}/v1/chat/completions",
+        json=payload,
+        timeout=600,
+    )
+    if response.status_code != 200:
+        return {
+            "ok": False,
+            "status_code": response.status_code,
+            "body": response.text,
+            "elapsed_seconds": time.perf_counter() - started,
+        }
+    try:
+        body = response.json()
+    except requests.JSONDecodeError as exc:
+        return {
+            "ok": False,
+            "status_code": response.status_code,
+            "body": response.text,
+            "error": str(exc),
+            "elapsed_seconds": time.perf_counter() - started,
+        }
+    choice = body.get("choices", [{}])[0]
+    message = choice.get("message") or {}
+    return {
+        "ok": True,
+        "status_code": response.status_code,
+        "elapsed_seconds": time.perf_counter() - started,
+        "finish_reason": choice.get("finish_reason"),
+        "content": message.get("content") or "",
+        "reasoning_content": message.get("reasoning_content") or "",
+        "prompt_token_ids": body.get("prompt_token_ids") or [],
+        "output_token_ids": choice.get("token_ids") or [],
+        "tool_calls": message.get("tool_calls") or [],
+        "raw_response": body,
+    }
+
+
+def _responses_tools() -> list[dict[str, Any]]:
+    tools: list[dict[str, Any]] = []
+    for tool in TOOLS:
+        function = tool["function"]
+        tools.append(
+            {
+                "type": "function",
+                "name": function["name"],
+                "description": function["description"],
+                "parameters": function["parameters"],
+                "strict": True,
+            }
+        )
+    return tools
+
+
+def _stream_responses(base_url: str, payload: dict[str, Any]) -> dict[str, Any]:
+    """Collect Responses SSE without relying on a particular SDK version."""
+    started = time.perf_counter()
+    response = requests.post(
+        f"{base_url.rstrip('/')}/v1/responses",
+        json=payload,
+        stream=True,
+        timeout=600,
+    )
+    if response.status_code != 200:
+        return {
+            "ok": False,
+            "status_code": response.status_code,
+            "body": response.text,
+            "elapsed_seconds": time.perf_counter() - started,
+        }
+
+    raw_events: list[dict[str, Any]] = []
+    malformed_sse: list[str] = []
+    response_id = ""
+    response_status = ""
+    output_text_chunks: list[str] = []
+    protocol_errors: list[str] = []
+    calls: dict[int, dict[str, Any]] = {}
+
+    for raw_line in response.iter_lines(decode_unicode=True):
+        if not raw_line or not raw_line.startswith("data:"):
+            continue
+        data = raw_line[5:].strip()
+        if data == "[DONE]":
+            break
+        try:
+            event = json.loads(data)
+        except json.JSONDecodeError:
+            malformed_sse.append(data)
+            continue
+        raw_events.append(event)
+        event_type = event.get("type") or ""
+        event_response = event.get("response") or {}
+        response_id = event_response.get("id") or response_id
+        response_status = event_response.get("status") or response_status
+
+        if event_type == "response.output_text.delta":
+            output_text_chunks.append(event.get("delta") or "")
+        elif event_type == "response.output_item.added":
+            item = event.get("item") or {}
+            if item.get("type") == "function_call":
+                output_index = int(event.get("output_index", 0))
+                calls[output_index] = {
+                    "output_index": output_index,
+                    "added_item": item,
+                    "argument_chunks": [],
+                    "done_arguments": None,
+                    "done_item": None,
+                }
+        elif event_type == "response.function_call_arguments.delta":
+            output_index = int(event.get("output_index", 0))
+            call = calls.get(output_index)
+            if call is None:
+                protocol_errors.append(
+                    f"arguments delta before item at output {output_index}"
+                )
+            else:
+                call["argument_chunks"].append(event.get("delta") or "")
+        elif event_type == "response.function_call_arguments.done":
+            output_index = int(event.get("output_index", 0))
+            call = calls.get(output_index)
+            if call is None:
+                protocol_errors.append(
+                    f"arguments done before item at output {output_index}"
+                )
+            else:
+                call["done_arguments"] = event.get("arguments") or ""
+        elif event_type == "response.output_item.done":
+            item = event.get("item") or {}
+            if item.get("type") == "function_call":
+                output_index = int(event.get("output_index", 0))
+                call = calls.get(output_index)
+                if call is None:
+                    protocol_errors.append(
+                        f"item done before item added at output {output_index}"
+                    )
+                else:
+                    call["done_item"] = item
+        elif event_type in {"response.failed", "error"}:
+            protocol_errors.append(json.dumps(event, ensure_ascii=False))
+
+    function_calls: list[dict[str, Any]] = []
+    for output_index in sorted(calls):
+        record = calls[output_index]
+        added = record["added_item"]
+        done = record["done_item"] or {}
+        delta_arguments = "".join(record["argument_chunks"])
+        done_arguments = record["done_arguments"]
+        final_arguments = done.get("arguments")
+        if final_arguments is None:
+            final_arguments = done_arguments
+        if final_arguments is None:
+            final_arguments = delta_arguments or added.get("arguments") or ""
+
+        if done_arguments is not None and done_arguments != delta_arguments:
+            protocol_errors.append(
+                f"arguments delta/done mismatch at output {output_index}"
+            )
+        if done and done.get("arguments") != final_arguments:
+            protocol_errors.append(
+                f"arguments done/item mismatch at output {output_index}"
+            )
+        if done and done.get("name") != added.get("name"):
+            protocol_errors.append(f"tool name changed at output {output_index}")
+
+        function_calls.append(
+            {
+                "output_index": output_index,
+                "id": done.get("id") or added.get("id") or "",
+                "call_id": done.get("call_id") or added.get("call_id") or "",
+                "name": done.get("name") or added.get("name") or "",
+                "arguments": final_arguments,
+                "argument_chunks": record["argument_chunks"],
+                "done_arguments": done_arguments,
+                "added_item": added,
+                "done_item": record["done_item"],
+            }
+        )
+
+    completed = any(event.get("type") == "response.completed" for event in raw_events)
+    if not completed:
+        protocol_errors.append("response.completed event missing")
+    return {
+        "ok": not malformed_sse and not protocol_errors,
+        "status_code": response.status_code,
+        "elapsed_seconds": time.perf_counter() - started,
+        "response_id": response_id,
+        "response_status": response_status,
+        "output_text": "".join(output_text_chunks),
+        "function_calls": function_calls,
+        "malformed_sse": malformed_sse,
+        "protocol_errors": protocol_errors,
+        "raw_events": raw_events,
+    }
+
+
+def _validate_responses_tool_step(
+    result: dict[str, Any], expected: dict[str, Any]
+) -> list[str]:
+    if not result.get("ok"):
+        return ["request failed"]
+    calls = result.get("function_calls") or []
+    if len(calls) != 1:
+        return [f"expected one function call, got {len(calls)}"]
+    call = calls[0]
+    errors: list[str] = []
+    if call["name"] != expected["name"]:
+        errors.append(f"tool name {call['name']!r} != {expected['name']!r}")
+    if not call.get("call_id"):
+        errors.append("call_id missing")
+    try:
+        arguments = json.loads(call["arguments"])
+    except json.JSONDecodeError as exc:
+        return errors + [f"invalid arguments JSON: {exc}"]
+    schema = _schema_by_tool_name().get(call["name"])
+    if schema is None:
+        errors.append(f"unknown tool {call['name']!r}")
+    else:
+        try:
+            jsonschema.validate(arguments, schema)
+        except jsonschema.ValidationError as exc:
+            errors.append(f"schema violation: {exc.message}")
+    if arguments != expected["arguments"]:
+        errors.append(f"arguments {arguments!r} != {expected['arguments']!r}")
+    return errors
+
+
+def _responses_payload(
+    model: str,
+    seed: int,
+    input_items: str | list[dict[str, Any]],
+    tool_name: str,
+    *,
+    previous_response_id: str | None = None,
+) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "model": model,
+        "input": input_items,
+        "instructions": (
+            "Follow the user literally, call exactly the requested listed tool, "
+            "and preserve every string byte including whitespace and XML-like text."
+        ),
+        "tools": _responses_tools(),
+        "tool_choice": {"type": "function", "name": tool_name},
+        "parallel_tool_calls": False,
+        "stream": True,
+        "store": True,
+        "temperature": 0.0,
+        "seed": seed,
+        "max_output_tokens": 2048,
+        "chat_template_kwargs": {"enable_thinking": False},
+    }
+    if previous_response_id is not None:
+        payload["previous_response_id"] = previous_response_id
+    return payload
+
+
+def _run_responses_chain(base_url: str, model: str, seed: int) -> dict[str, Any]:
+    """Cover stateful and explicit-history Responses tool protocols."""
+    stateful_steps = [*STEPS, STEPS[0]]
+    stateful_results: list[dict[str, Any]] = []
+    previous_response_id: str | None = None
+    previous_call_id = ""
+    previous_result = ""
+    for step_index, step in enumerate(stateful_steps):
+        if previous_response_id is None:
+            input_items: str | list[dict[str, Any]] = step["prompt"]
+        else:
+            input_items = [
+                {
+                    "type": "function_call_output",
+                    "call_id": previous_call_id,
+                    "output": previous_result,
+                },
+                {"role": "user", "content": step["prompt"]},
+            ]
+        payload = _responses_payload(
+            model,
+            seed,
+            input_items,
+            step["name"],
+            previous_response_id=previous_response_id,
+        )
+        result = _stream_responses(base_url, payload)
+        errors = _validate_responses_tool_step(result, step)
+        result["step"] = step_index
+        result["expected_name"] = step["name"]
+        result["errors"] = errors
+        stateful_results.append(result)
+        if errors:
+            break
+        previous_response_id = result["response_id"]
+        previous_call_id = result["function_calls"][0]["call_id"]
+        previous_result = step["result"]
+
+    explicit_input: list[dict[str, Any]] = []
+    for step_index, step in enumerate(STEPS):
+        call_id = f"call_explicit_history_{step_index}"
+        explicit_input.extend(
+            [
+                {"role": "user", "content": step["prompt"]},
+                {
+                    "type": "function_call",
+                    "call_id": call_id,
+                    "name": step["name"],
+                    "arguments": json.dumps(
+                        step["arguments"], ensure_ascii=False, separators=(",", ":")
+                    ),
+                },
+                {
+                    "type": "function_call_output",
+                    "call_id": call_id,
+                    "output": step["result"],
+                },
+            ]
+        )
+    replay_step = STEPS[0]
+    explicit_input.append({"role": "user", "content": replay_step["prompt"]})
+    explicit_result = _stream_responses(
+        base_url,
+        _responses_payload(
+            model,
+            seed,
+            explicit_input,
+            replay_step["name"],
+        ),
+    )
+    explicit_errors = _validate_responses_tool_step(explicit_result, replay_step)
+    explicit_result["errors"] = explicit_errors
+
+    return {
+        "passed": (
+            len(stateful_results) == len(stateful_steps)
+            and all(not item["errors"] for item in stateful_results)
+            and not explicit_errors
+        ),
+        "stateful_steps": stateful_results,
+        "explicit_history_replay": explicit_result,
+    }
+
+
+def _read_jsonl(path: Path) -> list[dict[str, Any]]:
+    return [json.loads(line) for line in path.read_text().splitlines() if line]
+
+
+def _normalize_bfcl_schema(value: Any) -> Any:
+    if isinstance(value, list):
+        return [_normalize_bfcl_schema(item) for item in value]
+    if not isinstance(value, dict):
+        return value
+    normalized = {key: _normalize_bfcl_schema(item) for key, item in value.items()}
+    type_map = {"dict": "object", "float": "number", "tuple": "array"}
+    if isinstance(normalized.get("type"), str):
+        normalized["type"] = type_map.get(normalized["type"], normalized["type"])
+    return normalized
+
+
+def _bfcl_tools(functions: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    return [
+        {
+            "type": "function",
+            "function": {
+                "name": function["name"],
+                "description": function.get("description") or "",
+                "parameters": _normalize_bfcl_schema(function["parameters"]),
+            },
+        }
+        for function in functions
+    ]
+
+
+def _bfcl_normalized_value(value: Any) -> Any:
+    if isinstance(value, str):
+        return re.sub(r"[ ,./\-_*^]", "", value).lower().replace("'", '"')
+    if isinstance(value, list):
+        return [_bfcl_normalized_value(item) for item in value]
+    if isinstance(value, dict):
+        return {
+            key: _bfcl_normalized_value(item) for key, item in sorted(value.items())
+        }
+    return value
+
+
+def _bfcl_call_matches(
+    actual: dict[str, Any],
+    expected: dict[str, Any],
+    functions: dict[str, dict[str, Any]],
+) -> tuple[bool, str]:
+    expected_name, expected_arguments = next(iter(expected.items()))
+    if actual.get("name") != expected_name:
+        return False, f"tool name {actual.get('name')!r} != {expected_name!r}"
+    arguments = actual.get("arguments")
+    if not isinstance(arguments, dict):
+        return False, "arguments are not a JSON object"
+    function = functions.get(expected_name)
+    if function is None:
+        return False, f"function description missing for {expected_name!r}"
+    properties = function["parameters"].get("properties") or {}
+    required = function["parameters"].get("required") or []
+    for name in required:
+        if name not in arguments:
+            return False, f"required argument {name!r} missing"
+    for name, value in arguments.items():
+        if name not in properties or name not in expected_arguments:
+            return False, f"unexpected argument {name!r}"
+        allowed = expected_arguments[name]
+        if not any(
+            _bfcl_normalized_value(value) == _bfcl_normalized_value(candidate)
+            for candidate in allowed
+        ):
+            return False, f"argument {name!r} value {value!r} not in {allowed!r}"
+    for name, allowed in expected_arguments.items():
+        if name not in arguments and "" not in allowed:
+            return False, f"expected argument {name!r} missing"
+    return True, ""
+
+
+def _validate_bfcl_calls(
+    result: dict[str, Any],
+    entry: dict[str, Any],
+    ground_truth: list[dict[str, Any]] | None,
+    *,
+    irrelevance: bool,
+) -> list[str]:
+    if not result.get("ok"):
+        return ["request failed"]
+    canonical = _canonical_tool_calls(result.get("tool_calls") or [])
+    if irrelevance:
+        return [] if not canonical else [f"irrelevant request called {canonical!r}"]
+    assert ground_truth is not None
+    if len(canonical) != len(ground_truth):
+        return [
+            f"wrong number of calls: got {len(canonical)}, expected {len(ground_truth)}"
+        ]
+    functions = {function["name"]: function for function in entry["function"]}
+    unmatched = set(range(len(canonical)))
+    errors: list[str] = []
+    for expected in ground_truth:
+        candidate_errors: list[str] = []
+        for index in list(unmatched):
+            matched, error = _bfcl_call_matches(canonical[index], expected, functions)
+            if matched:
+                unmatched.remove(index)
+                break
+            candidate_errors.append(error)
+        else:
+            errors.append(f"no call matched {expected!r}: {candidate_errors!r}")
+    return errors
+
+
+def _run_bfcl_sample(
+    base_url: str,
+    model: str,
+    seed: int,
+    data_dir: Path,
+    per_category: int,
+) -> dict[str, Any]:
+    categories = {
+        "simple_python": False,
+        "parallel": False,
+        "multiple": False,
+        "irrelevance": True,
+    }
+    category_results: dict[str, Any] = {}
+    for category, irrelevance in categories.items():
+        filename = f"BFCL_v4_{category}.json"
+        entries = _read_jsonl(data_dir / filename)[:per_category]
+        ground_truth_by_id: dict[str, list[dict[str, Any]]] = {}
+        if not irrelevance:
+            ground_truth_by_id = {
+                item["id"]: item["ground_truth"]
+                for item in _read_jsonl(data_dir / "possible_answer" / filename)
+            }
+        results: list[dict[str, Any]] = []
+        for entry in entries:
+            payload = {
+                "model": model,
+                "messages": entry["question"][0],
+                "tools": _bfcl_tools(entry["function"]),
+                "tool_choice": "auto",
+                "parallel_tool_calls": True,
+                "stream": True,
+                "return_token_ids": True,
+                "temperature": 0.0,
+                "seed": seed,
+                "max_tokens": 1024,
+                "chat_template_kwargs": {"enable_thinking": False},
+            }
+            result = _stream_chat(base_url, payload)
+            errors = _validate_bfcl_calls(
+                result,
+                entry,
+                ground_truth_by_id.get(entry["id"]),
+                irrelevance=irrelevance,
+            )
+            result["id"] = entry["id"]
+            result["errors"] = errors
+            results.append(result)
+        category_results[category] = {
+            "passed": sum(not item["errors"] for item in results),
+            "total": len(results),
+            "cases": results,
+        }
+    passed = sum(item["passed"] for item in category_results.values())
+    total = sum(item["total"] for item in category_results.values())
+    return {
+        "passed": passed == total,
+        "score": passed,
+        "total": total,
+        "per_category": category_results,
+        "note": "Fixed BFCL v4 subset; not a full leaderboard submission.",
+    }
+
+
+def _adapt_openai_json_schema(schema: dict[str, Any]) -> dict[str, Any]:
+    adapted = copy.deepcopy(schema)
+    if "type" not in adapted:
+        adapted["type"] = "object"
+
+    def visit(value: Any) -> None:
+        if isinstance(value, list):
+            for item in value:
+                visit(item)
+            return
+        if not isinstance(value, dict):
+            return
+        properties = value.get("properties")
+        if isinstance(properties, dict):
+            if value.get("additionalProperties", True):
+                value["additionalProperties"] = False
+            value["required"] = list(properties)
+        for item in value.values():
+            visit(item)
+
+    visit(adapted)
+    return adapted
+
+
+def _run_json_schema_bench_sample(
+    base_url: str,
+    model: str,
+    seed: int,
+    schema_dir: Path,
+    limit: int,
+    max_schema_bytes: int,
+) -> dict[str, Any]:
+    results: list[dict[str, Any]] = []
+    candidates = sorted(
+        (
+            path
+            for path in schema_dir.glob("*.json")
+            if path.stat().st_size <= max_schema_bytes
+        ),
+        key=lambda path: (path.stat().st_size, path.name),
+    )
+    if len(candidates) > limit:
+        if limit == 1:
+            candidates = [candidates[len(candidates) // 2]]
+        else:
+            candidates = [
+                candidates[round(index * (len(candidates) - 1) / (limit - 1))]
+                for index in range(limit)
+            ]
+    for path in candidates:
+        schema = _adapt_openai_json_schema(json.loads(path.read_text()))
+        payload = {
+            "model": model,
+            "messages": [
+                {
+                    "role": "system",
+                    "content": (
+                        "You need to generate a JSON object that matches the "
+                        "schema below."
+                    ),
+                },
+                {
+                    "role": "user",
+                    "content": json.dumps(schema, ensure_ascii=False),
+                },
+            ],
+            "stream": True,
+            "return_token_ids": True,
+            "temperature": 0.0,
+            "seed": seed,
+            "max_tokens": 2048,
+            "response_format": {
+                "type": "json_schema",
+                "json_schema": {
+                    "name": path.stem,
+                    "strict": True,
+                    "schema": schema,
+                },
+            },
+        }
+        result = _stream_chat(base_url, payload)
+        errors: list[str] = []
+        if not result.get("ok"):
+            errors.append("request failed")
+        else:
+            try:
+                value = json.loads(result["content"])
+                jsonschema.validate(value, schema)
+            except (json.JSONDecodeError, jsonschema.ValidationError) as exc:
+                errors.append(str(exc))
+        result["schema"] = path.name
+        result["errors"] = errors
+        results.append(result)
+    passed = sum(not item["errors"] for item in results)
+    return {
+        "passed": passed == len(results),
+        "score": passed,
+        "total": len(results),
+        "cases": results,
+        "note": (
+            "Deterministic zero-shot WashingtonPost JSONSchemaBench subset; "
+            f"schemas are size-stratified up to {max_schema_bytes} bytes; not a "
+            "full benchmark score."
+        ),
+    }
+
+
+def _canonical_tool_calls(calls: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    canonical: list[dict[str, Any]] = []
+    for call in calls:
+        function = call.get("function") or {}
+        arguments = function.get("arguments") or ""
+        try:
+            parsed_arguments: Any = json.loads(arguments)
+        except (TypeError, json.JSONDecodeError):
+            parsed_arguments = arguments
+        canonical.append(
+            {
+                "name": function.get("name") or "",
+                "arguments": parsed_arguments,
+            }
+        )
+    return canonical
+
+
+def _compare_stream_pair(
+    nonstream: dict[str, Any],
+    stream: dict[str, Any],
+    *,
+    compare_content: bool,
+    compare_tools: bool,
+) -> list[str]:
+    errors: list[str] = []
+    if not nonstream.get("ok") or not stream.get("ok"):
+        return ["stream or non-stream request failed"]
+    if compare_content and nonstream["content"] != stream["content"]:
+        errors.append("stream/non-stream content mismatch")
+    if nonstream["reasoning_content"] != stream["reasoning_content"]:
+        errors.append("stream/non-stream reasoning mismatch")
+    if compare_tools and _canonical_tool_calls(
+        nonstream["tool_calls"]
+    ) != _canonical_tool_calls(stream["tool_calls"]):
+        errors.append("stream/non-stream tool-call mismatch")
+    nonstream_ids = nonstream.get("output_token_ids") or []
+    stream_ids = stream.get("output_token_ids") or []
+    if not nonstream_ids or not stream_ids:
+        errors.append("output token IDs unavailable for parity check")
+    elif nonstream_ids != stream_ids:
+        errors.append("stream/non-stream output token IDs differ")
+    return errors
+
+
+def _run_stream_parity(base_url: str, model: str, seed: int) -> dict[str, Any]:
+    results: list[dict[str, Any]] = []
+    for case in STREAM_PARITY_CASES:
+        expected = case["expected"]
+        payload = {
+            "model": model,
+            "messages": [
+                {
+                    "role": "user",
+                    "content": (
+                        "Reply with exactly the text after TEXT, without quotes, "
+                        f"commentary, or a code fence.\nTEXT: {expected}"
+                    ),
+                }
+            ],
+            "return_token_ids": True,
+            "temperature": 0.0,
+            "seed": seed,
+            "max_tokens": 256,
+            "chat_template_kwargs": {"enable_thinking": False},
+        }
+        nonstream = _nonstream_chat(base_url, {**payload, "stream": False})
+        stream = _stream_chat(base_url, {**payload, "stream": True})
+        errors = _compare_stream_pair(
+            nonstream,
+            stream,
+            compare_content=True,
+            compare_tools=False,
+        )
+        if nonstream.get("ok") and nonstream["content"] != expected:
+            errors.append("non-stream exact-copy output mismatch")
+        if stream.get("ok") and stream["content"] != expected:
+            errors.append("stream exact-copy output mismatch")
+        results.append(
+            {
+                "case": case["name"],
+                "expected": expected,
+                "nonstream": nonstream,
+                "stream": stream,
+                "errors": errors,
+            }
+        )
+
+    step = STEPS[0]
+    tool_payload = {
+        "model": model,
+        "messages": [{"role": "user", "content": step["prompt"]}],
+        "tools": TOOLS,
+        "tool_choice": "auto",
+        "return_token_ids": True,
+        "temperature": 0.0,
+        "seed": seed,
+        "max_tokens": 512,
+        "chat_template_kwargs": {"enable_thinking": False},
+    }
+    nonstream = _nonstream_chat(base_url, {**tool_payload, "stream": False})
+    stream = _stream_chat(base_url, {**tool_payload, "stream": True})
+    errors = _compare_stream_pair(
+        nonstream,
+        stream,
+        compare_content=True,
+        compare_tools=True,
+    )
+    if nonstream.get("ok"):
+        errors.extend(_validate_tool_step(nonstream, step))
+    if stream.get("ok"):
+        errors.extend(_validate_tool_step(stream, step))
+    results.append(
+        {
+            "case": "tool_read",
+            "nonstream": nonstream,
+            "stream": stream,
+            "errors": errors,
+        }
+    )
+    return {"passed": all(not item["errors"] for item in results), "cases": results}
+
+
+def _validate_tool_step(result: dict[str, Any], expected: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+    calls = result.get("tool_calls") or []
+    if len(calls) != 1:
+        return [f"expected one tool call, got {len(calls)}"]
+    call = calls[0]
+    name = call["function"]["name"]
+    if name != expected["name"]:
+        errors.append(f"tool name {name!r} != {expected['name']!r}")
+    try:
+        arguments = json.loads(call["function"]["arguments"])
+    except json.JSONDecodeError as exc:
+        return errors + [f"invalid arguments JSON: {exc}"]
+    schema = _schema_by_tool_name().get(name)
+    if schema is None:
+        errors.append(f"unknown tool {name!r}")
+    else:
+        try:
+            jsonschema.validate(arguments, schema)
+        except jsonschema.ValidationError as exc:
+            errors.append(f"schema violation: {exc.message}")
+    if arguments != expected["arguments"]:
+        errors.append(f"arguments {arguments!r} != {expected['arguments']!r}")
+    return errors
+
+
+def _run_tool_chain(base_url: str, model: str, seed: int) -> dict[str, Any]:
+    messages: list[dict[str, Any]] = [
+        {
+            "role": "system",
+            "content": (
+                "You are a tool protocol validation agent. Follow each user request "
+                "literally, call only a listed tool, and preserve string whitespace."
+            ),
+        }
+    ]
+    results: list[dict[str, Any]] = []
+    for step_index, step in enumerate(STEPS):
+        messages.append({"role": "user", "content": step["prompt"]})
+        payload = {
+            "model": model,
+            "messages": messages,
+            "tools": TOOLS,
+            "tool_choice": "auto",
+            "stream": True,
+            "return_token_ids": True,
+            "temperature": 0.0,
+            "seed": seed,
+            "max_tokens": 2048,
+        }
+        result = _stream_chat(base_url, payload)
+        errors = (
+            _validate_tool_step(result, step)
+            if result.get("ok")
+            else ["request failed"]
+        )
+        result["step"] = step_index
+        result["expected_name"] = step["name"]
+        result["errors"] = errors
+        results.append(result)
+        if errors:
+            break
+
+        tool_call = result["tool_calls"][0]
+        history_tool_call = copy.deepcopy(tool_call)
+        history_tool_call["id"] = f"call_protocol_step_{step_index}"
+        messages.append(
+            {
+                "role": "assistant",
+                "content": result.get("content") or None,
+                "tool_calls": [history_tool_call],
+            }
+        )
+        messages.append(
+            {
+                "role": "tool",
+                "tool_call_id": history_tool_call["id"],
+                "content": step["result"],
+            }
+        )
+    return {
+        "passed": len(results) == len(STEPS)
+        and all(not item["errors"] for item in results),
+        "steps": results,
+    }
+
+
+def _run_structured(base_url: str, model: str, seed: int) -> dict[str, Any]:
+    results: list[dict[str, Any]] = []
+    for case in STRUCTURED_CASES:
+        payload = {
+            "model": model,
+            "messages": [{"role": "user", "content": case["prompt"]}],
+            "stream": True,
+            "return_token_ids": True,
+            "temperature": 0.0,
+            "seed": seed,
+            "max_tokens": 512,
+            "response_format": {
+                "type": "json_schema",
+                "json_schema": {
+                    "name": case["name"],
+                    "strict": True,
+                    "schema": case["schema"],
+                },
+            },
+        }
+        result = _stream_chat(base_url, payload)
+        errors: list[str] = []
+        if not result.get("ok"):
+            errors.append("request failed")
+        else:
+            try:
+                value = json.loads(result["content"])
+                jsonschema.validate(value, case["schema"])
+            except (json.JSONDecodeError, jsonschema.ValidationError) as exc:
+                errors.append(str(exc))
+        result["case"] = case["name"]
+        result["errors"] = errors
+        results.append(result)
+    return {"passed": all(not item["errors"] for item in results), "cases": results}
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--base-url", required=True)
+    parser.add_argument("--model", default="quality-audit-dflash2")
+    parser.add_argument("--out", type=Path, required=True)
+    parser.add_argument("--seed", type=int, default=20260827)
+    parser.add_argument("--bfcl-data-dir", type=Path)
+    parser.add_argument("--bfcl-per-category", type=int, default=0)
+    parser.add_argument("--json-schema-dir", type=Path)
+    parser.add_argument("--json-schema-limit", type=int, default=0)
+    parser.add_argument("--json-schema-max-bytes", type=int, default=16384)
+    parser.add_argument(
+        "--only-datasets",
+        action="store_true",
+        help="Skip synthetic protocol and Responses gates for matched dataset arms.",
+    )
+    args = parser.parse_args()
+
+    artifact: dict[str, Any] = {
+        "base_url": args.base_url,
+        "model": args.model,
+        "seed": args.seed,
+        "only_datasets": args.only_datasets,
+    }
+    if not args.only_datasets:
+        artifact.update(
+            {
+                "tool_chain": _run_tool_chain(args.base_url, args.model, args.seed),
+                "structured": _run_structured(args.base_url, args.model, args.seed),
+                "stream_parity": _run_stream_parity(
+                    args.base_url, args.model, args.seed
+                ),
+                "responses": _run_responses_chain(args.base_url, args.model, args.seed),
+            }
+        )
+    if args.bfcl_data_dir is not None and args.bfcl_per_category > 0:
+        artifact["bfcl_fixed_sample"] = _run_bfcl_sample(
+            args.base_url,
+            args.model,
+            args.seed,
+            args.bfcl_data_dir,
+            args.bfcl_per_category,
+        )
+    if args.json_schema_dir is not None and args.json_schema_limit > 0:
+        artifact["json_schema_bench_fixed_sample"] = _run_json_schema_bench_sample(
+            args.base_url,
+            args.model,
+            args.seed,
+            args.json_schema_dir,
+            args.json_schema_limit,
+            args.json_schema_max_bytes,
+        )
+    result_keys = {
+        "tool_chain",
+        "structured",
+        "stream_parity",
+        "responses",
+        "bfcl_fixed_sample",
+        "json_schema_bench_fixed_sample",
+    }
+    required_results = [value for key, value in artifact.items() if key in result_keys]
+    artifact["passed"] = bool(
+        required_results and all(value["passed"] for value in required_results)
+    )
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    args.out.write_text(json.dumps(artifact, ensure_ascii=False, indent=2) + "\n")
+    print(json.dumps({"passed": artifact["passed"], "out": str(args.out)}))
+    if not artifact["passed"]:
+        raise SystemExit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/benchmark_sm70_tool_protocol.py
+++ b/benchmarks/benchmark_sm70_tool_protocol.py
@@ -13,12 +13,12 @@ from __future__ import annotations
 import argparse
 import copy
 import json
-import re
 import time
 from pathlib import Path
 from typing import Any
 
 import jsonschema
+import regex as re
 import requests
 
 TOOLS: list[dict[str, Any]] = [

--- a/benchmarks/compare_sm70_dflash2_quality_matrix.py
+++ b/benchmarks/compare_sm70_dflash2_quality_matrix.py
@@ -1,0 +1,280 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Compare paired multi-seed rows from the bounded DFlash2 quality matrix."""
+
+from __future__ import annotations
+
+import argparse
+import itertools
+import json
+import math
+import random
+from collections import Counter, defaultdict
+from pathlib import Path
+from typing import Any
+
+import regex as re
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--scores", type=Path, required=True)
+    parser.add_argument("--out", type=Path, required=True)
+    parser.add_argument("--bootstrap-samples", type=int, default=20_000)
+    parser.add_argument("--bootstrap-seed", type=int, default=20260826)
+    return parser.parse_args()
+
+
+def _arm_name(path: Path) -> str:
+    match = re.search(r"-(t0|d[0-9]+)$", path.stem)
+    if match is None:
+        raise ValueError(f"cannot infer matrix arm from {path}")
+    return match.group(1)
+
+
+def _ordered_arm_names(arms: dict[str, Any]) -> list[str]:
+    """Order the target control before progressively accelerated DFlash arms."""
+
+    def key(name: str) -> tuple[int, int]:
+        if name == "t0":
+            return (0, 0)
+        return (1, int(name[1:]))
+
+    return sorted(arms, key=key)
+
+
+def _percentile(values: list[float], quantile: float) -> float | None:
+    if not values:
+        return None
+    ordered = sorted(values)
+    position = (len(ordered) - 1) * quantile
+    lower = math.floor(position)
+    upper = math.ceil(position)
+    if lower == upper:
+        return ordered[lower]
+    weight = position - lower
+    return ordered[lower] + (ordered[upper] - ordered[lower]) * weight
+
+
+def _paired_bootstrap_delta(
+    pairs: list[tuple[float, float]],
+    *,
+    samples: int,
+    seed: int,
+) -> dict[str, float | int | None]:
+    if not pairs:
+        return {"count": 0, "mean_delta": None, "ci95": None}
+    deltas = [right - left for left, right in pairs]
+    rng = random.Random(seed)
+    means = []
+    for _ in range(samples):
+        means.append(sum(rng.choice(deltas) for _ in deltas) / len(deltas))
+    return {
+        "count": len(deltas),
+        "mean_delta": sum(deltas) / len(deltas),
+        "ci95": [_percentile(means, 0.025), _percentile(means, 0.975)],
+    }
+
+
+def _mcnemar_exact(left: list[bool], right: list[bool]) -> dict[str, float | int]:
+    left_only = sum(a and not b for a, b in zip(left, right, strict=True))
+    right_only = sum(b and not a for a, b in zip(left, right, strict=True))
+    discordant = left_only + right_only
+    if discordant == 0:
+        p_value = 1.0
+    else:
+        tail = sum(
+            math.comb(discordant, index)
+            for index in range(min(left_only, right_only) + 1)
+        ) / (2**discordant)
+        p_value = min(1.0, 2.0 * tail)
+    return {
+        "left_only": left_only,
+        "right_only": right_only,
+        "discordant": discordant,
+        "p_value": p_value,
+    }
+
+
+def _summarize(records: list[dict[str, Any]]) -> dict[str, Any]:
+    passed = sum(record["passed"] for record in records)
+    acceptance = [
+        float(record["acceptance_length"])
+        for record in records
+        if record["acceptance_length"] is not None
+    ]
+    steady_decode = [
+        float(record["steady_decode_tps"])
+        for record in records
+        if record["steady_decode_tps"] is not None
+    ]
+    return {
+        "num_cases": len(records),
+        "passed": passed,
+        "score": passed / len(records) if records else None,
+        "finish_reasons": dict(Counter(record["finish_reason"] for record in records)),
+        "failure_reasons": dict(
+            Counter(record["reason"] for record in records if not record["passed"])
+        ),
+        "mean_acceptance_length": (
+            sum(acceptance) / len(acceptance) if acceptance else None
+        ),
+        "mean_steady_decode_tps": (
+            sum(steady_decode) / len(steady_decode) if steady_decode else None
+        ),
+    }
+
+
+def _load_arms(scores_path: Path) -> dict[str, dict[str, Any]]:
+    scores = json.loads(scores_path.read_text(encoding="utf-8"))
+    arms = {}
+    for scored_run in scores["runs"]:
+        raw_path = Path(scored_run["result"])
+        raw = json.loads(raw_path.read_text(encoding="utf-8"))
+        if len(raw["cases"]) != len(scored_run["cases"]):
+            raise ValueError(f"raw/scored case count differs for {raw_path}")
+
+        records = []
+        for raw_case, scored_case in zip(
+            raw["cases"], scored_run["cases"], strict=True
+        ):
+            if raw_case["dataset_index"] != scored_case["dataset_index"]:
+                raise ValueError(f"raw/scored case order differs for {raw_path}")
+            request_metrics = raw_case.get("request_metrics") or {}
+            spec_metrics = raw_case.get("spec_decode_metrics") or {}
+            records.append(
+                {
+                    "key": [raw_case.get("request_seed"), raw_case["dataset_index"]],
+                    "request_seed": raw_case.get("request_seed"),
+                    "dataset_index": raw_case["dataset_index"],
+                    "suite": scored_case["suite"],
+                    "suite_index": scored_case["suite_index"],
+                    "passed": bool(scored_case["passed"]),
+                    "reason": scored_case["reason"],
+                    "finish_reason": raw_case["finish_reason"],
+                    "token_hash": raw_case["token_hash"],
+                    "output_tokens": raw_case["output_tokens"],
+                    "acceptance_length": spec_metrics.get("acceptance_length"),
+                    "steady_decode_tps": request_metrics.get("steady_decode_tps"),
+                }
+            )
+        arm = _arm_name(raw_path)
+        if arm in arms:
+            raise ValueError(f"duplicate matrix arm {arm}")
+        arms[arm] = {
+            "result": str(raw_path),
+            "contract": raw["contract"],
+            "runtime": raw["runtime"],
+            "records": records,
+        }
+    return arms
+
+
+def _record_map(arm: dict[str, Any]) -> dict[tuple[int | None, int], dict[str, Any]]:
+    result = {}
+    for record in arm["records"]:
+        key = tuple(record["key"])
+        if key in result:
+            raise ValueError(f"duplicate paired key {key}")
+        result[key] = record
+    return result
+
+
+def _compare(
+    left_name: str,
+    left_arm: dict[str, Any],
+    right_name: str,
+    right_arm: dict[str, Any],
+    *,
+    bootstrap_samples: int,
+    bootstrap_seed: int,
+) -> dict[str, Any]:
+    left = _record_map(left_arm)
+    right = _record_map(right_arm)
+    if set(left) != set(right):
+        raise ValueError(f"paired keys differ for {left_name}/{right_name}")
+    keys = sorted(left)
+    left_pass = [left[key]["passed"] for key in keys]
+    right_pass = [right[key]["passed"] for key in keys]
+    score_pairs = [(float(a), float(b)) for a, b in zip(left_pass, right_pass)]
+    acceptance_pairs = [
+        (float(left[key]["acceptance_length"]), float(right[key]["acceptance_length"]))
+        for key in keys
+        if left[key]["acceptance_length"] is not None
+        and right[key]["acceptance_length"] is not None
+    ]
+    return {
+        "left": left_name,
+        "right": right_name,
+        "num_cases": len(keys),
+        "token_hash_equal_cases": sum(
+            left[key]["token_hash"] == right[key]["token_hash"] for key in keys
+        ),
+        "score": _paired_bootstrap_delta(
+            score_pairs,
+            samples=bootstrap_samples,
+            seed=bootstrap_seed,
+        ),
+        "acceptance_length": _paired_bootstrap_delta(
+            acceptance_pairs,
+            samples=bootstrap_samples,
+            seed=bootstrap_seed + 1,
+        ),
+        "mcnemar_exact": _mcnemar_exact(left_pass, right_pass),
+    }
+
+
+def main() -> int:
+    args = _parse_args()
+    if args.bootstrap_samples <= 0:
+        raise ValueError("--bootstrap-samples must be positive")
+    arms = _load_arms(args.scores)
+
+    summaries = {}
+    for arm_name, arm in sorted(arms.items()):
+        by_suite: dict[str, list[dict[str, Any]]] = defaultdict(list)
+        by_seed: dict[str, list[dict[str, Any]]] = defaultdict(list)
+        for record in arm["records"]:
+            by_suite[record["suite"]].append(record)
+            by_seed[str(record["request_seed"])].append(record)
+        summaries[arm_name] = {
+            "result": arm["result"],
+            "aggregate": _summarize(arm["records"]),
+            "by_suite": {
+                name: _summarize(records) for name, records in sorted(by_suite.items())
+            },
+            "by_seed": {
+                name: _summarize(records) for name, records in sorted(by_seed.items())
+            },
+        }
+
+    comparisons = [
+        _compare(
+            left,
+            arms[left],
+            right,
+            arms[right],
+            bootstrap_samples=args.bootstrap_samples,
+            bootstrap_seed=args.bootstrap_seed,
+        )
+        for left, right in itertools.combinations(_ordered_arm_names(arms), 2)
+    ]
+
+    payload = {
+        "format": "sm70_dflash2_quality_matrix_v1",
+        "scores": str(args.scores),
+        "bootstrap": {
+            "samples": args.bootstrap_samples,
+            "seed": args.bootstrap_seed,
+        },
+        "arms": summaries,
+        "comparisons": comparisons,
+    }
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    args.out.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+    print(json.dumps(payload, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/design/sm70_dflash2_quality_audit.md
+++ b/docs/design/sm70_dflash2_quality_audit.md
@@ -1,0 +1,316 @@
+# SM70 NVFP4 DFlash2 output-quality audit
+
+## Scope and provenance
+
+This audit starts from private integration commit
+`d63e9490f65f9e01f6649053c1ab72922034b931` on branch
+`codex/v100-dflash2-quality-audit-20260826-124851`. It covers the practical
+Qwen3.8-27B NVFP4 target plus official BF16 DFlash2 drafter on TP4 V100. Remote
+deployment and packaging are out of scope.
+
+The production contract remains temperature 1.0, top-p 0.95, top-k 20,
+`xhigh` reasoning, seven probabilistic draft tokens, FP8 E5M2 target KV, FP16
+draft KV, FULL target/draft CUDA Graphs, prefix caching, Mamba align, 256K
+maximum context, 4096 maximum batched tokens, and the Qwen tool/reasoning
+parsers. Quality is judged by scored distributions rather than greedy or
+bitwise identity.
+
+Upstream was checked once on 2026-08-26. vLLM PR
+[`#52816`](https://github.com/vllm-project/vllm/pull/52816) is now merged. Its
+following draft-logit cache-stride fix, vLLM PR `#53017`, does not apply to
+this DFlash2 path: DFlash2 uses its own sparse top-16 cache kernel and passes
+both request and step strides explicitly. Open quantized-drafter fixes are
+also outside this contract because the retained drafter is the official BF16
+checkpoint.
+
+The structured-output audit found a separate relevant upstream chain after
+the local May 29 fork point: vLLM PRs
+[`#44297`](https://github.com/vllm-project/vllm/pull/44297),
+[`#44993`](https://github.com/vllm-project/vllm/pull/44993),
+[`#52805`](https://github.com/vllm-project/vllm/pull/52805), and
+[`#53046`](https://github.com/vllm-project/vllm/pull/53046). They constrain
+draft rows after a reasoning boundary, advance only the post-boundary suffix,
+stop XGrammar at termination, and avoid logging expected invalid pre-mask
+drafts as FSM errors. This is directly relevant to the still-open upstream
+DFlash2 `json_object` report
+[`#53777`](https://github.com/vllm-project/vllm/issues/53777); only this minimal
+behavioral closure is backported here.
+
+## Existing evidence
+
+- The repaired stable RMSNorm extension SHA `7689e5...d449` passes its 13-case
+  batched-weight suite. The stale SHA `fe986a...9ba8c` reproduced the historical
+  row-zero context-K normalization bug and is not valid quality evidence.
+- Draft-MLP QPN8 was removed after request-mean acceptance changed by
+  `-0.06397`, beyond the fixed `-0.05` gate. It remains disabled.
+- The corrected MBPP-32 16K pair scores target-only/DFlash2 `31/32` versus
+  `32/32`; EvalPlus base `30/31` versus `31/31`; and EvalPlus plus `27/31`
+  versus `30/31`. HumanEval-32 EvalPlus is `32/32` for both. This is useful but
+  is only one sampling realization.
+- The practical selector-QPN8 run on 64 GSM8K rows changed request-mean
+  acceptance `5.39851 -> 5.43951`, but its speed comparison used different
+  physical GPU groups. The design record explicitly kept the route opt-in.
+- The packaged practical launch nevertheless forced
+  `VLLM_SM70_DFLASH2_QPN8_RERANK=1` and
+  `VLLM_SM70_DFLASH2_QPN8_DENSE_ORDER=0`. This bypasses the source defaults
+  (`rerank=0`, `dense_order=1`) and must not be treated as a promoted quality
+  contract.
+- Historical real-hidden candidate-order shadows contain no missing dense
+  top-20 token from the QPN8 top-64 support in the measured sample, and their
+  returned FP16 values match. They still change the local top-20 token set on
+  69/4640 top-20 rows (1.49%) and top-1 on 6/4640 rows because equal-valued
+  cutoff tokens are resolved in candidate order.
+- An offline scan of 2,048 retained selector-alignment dumps covers 16,384
+  target rows. The 19th and 20th returned FP16 logits are equal on 544 rows
+  (3.3203%); four rows expose three equal cutoff entries within the returned
+  support. Visible cutoff probability mass averages about `0.000445`. This is
+  small per step but can accumulate in multi-thousand-token coding outputs.
+- The retained 32K eager LongBench pair has four Qasper/NarrativeQA records.
+  Target-only and DFlash2 have identical token hashes on all four records and
+  the same average score, `36.6667`. This is useful long-prompt parity evidence,
+  but it does not replace Graph, prefix-cache, or 128K/256K validation.
+- The retained grouped verifier is lower risk: its dedicated operator and
+  graph-replay tests are bitwise equal to the accepted fallback under the
+  admitted SM70 shape. Fixed interleaved page addressing and staged page IDs
+  still require the paired state-pollution checks below.
+
+## Hypotheses, in test order
+
+1. **Experimental selector launch configuration.** Candidate-order QPN8 may
+   alter low-probability target support at FP16 ties or very rarely miss the
+   dense top-20 support. Dense-order QPN8 should retain most of the speed while
+   restoring the local dense-vocabulary tie contract.
+2. **Compact TP top-k boundary.** Sparse target rejection merges per-rank
+   candidates rather than materializing the full vocabulary. Non-tied rows are
+   exact; tied cutoff rows need a real-hidden global shadow before the path is
+   called distribution-equivalent to target-only.
+3. **Graph/prefix/request-slot state.** Same-seed requests must be checked cold,
+   warm, after mixed-length contamination, and after prefix-cache reuse. A
+   target-only repeat is required before attributing cross-process stochastic
+   variation to DFlash2.
+4. **Sparse rejection arithmetic.** Temperature application, target top-k then
+   top-p masking, conditional selector scores, token-keyed acceptance uniforms,
+   and `log1p` residual sampling are statically consistent. Dense versus sparse
+   same-source scoring remains the decisive dynamic check.
+
+## Minimal isolation matrix
+
+Every arm uses the same source, extension hashes, physical GPU group, model,
+prompt order, request seeds, natural EOS, and practical engine parameters.
+
+| Arm | DFlash2 | Sparse target rejection | Selector QPN8 | Dense order | Purpose |
+| --- | --- | --- | --- | --- | --- |
+| `T0` | no | n/a | n/a | n/a | target-only score and repeat variance |
+| `D0` | yes | off | off | n/a | dense DFlash2 reference |
+| `D1` | yes | on | off | n/a | isolate compact rejection |
+| `D2` | yes | on | on | on | quality-first accelerated selector |
+| `D3` | yes | on | on | off | reproduce current packaged launch |
+
+The first screen uses a small fixed coding/reasoning subset and at least three
+predeclared seeds. It records token/text hashes as diagnostics but promotes by
+paired scores, natural-stop/invalid rates, acceptance, and confidence
+intervals. Eager real-hidden shadows are run only long enough to measure QPN8
+support coverage and compact-global top-k boundary behavior. Graph runs then
+check immediate repeats, mixed-length contamination, cold/warm prefix cache,
+and request-slot reuse.
+
+The full gate uses HumanEval and MBPP with EvalPlus, stratified LiveCodeBench,
+GSM8K, MATH-500, WikiText prompt PPL, tool-call validity, and long-output coding
+health. At least three predeclared sampling seeds are required for executable
+coding scores. No suite may show a statistically supported regression versus
+the same NVFP4 target-only route. DFlash2 request-mean acceptance may not fall
+more than `0.05` from the accepted dense DFlash2 reference.
+
+## Performance gate
+
+Quality fixes are measured on the same practical 256K/4096/prefix/tool contract.
+The accepted short baseline is approximately 18 ms per complete speculative
+round; high-acceptance prompts can exceed 220 output token/s. A safe change
+must preserve the retained grouped long-context verifier and should keep the
+complete-round regression below 1%. Candidate-order QPN8 is not retained merely
+to save tens of microseconds if dense-order or dense-selector scoring is more
+stable.
+
+## 2026-08-26 bounded multi-seed isolation result
+
+The same physical V100 group 4--7 ran all five arms sequentially. The bounded
+screen replays two GSM8K, two MATH-500, two HumanEval, and two embedded MBPP
+rows at three predeclared request seeds, for 24 outputs per arm. Sampling is
+temperature 1.0/top-p 0.95/top-k 20 with `xhigh` reasoning, natural EOS, and a
+2,048-token cap. The embedded MBPP rows are useful only for relative trajectory
+health: both target-only and every DFlash arm score 0/6 because this cap ends
+reasoning before valid code or because the embedded prompt lacks the corrected
+independent-test contract. They are not an absolute coding score.
+
+| Arm | Valid score pattern | Total | Natural stop | Request acceptance | Mean steady decode |
+| --- | --- | ---: | ---: | ---: | ---: |
+| `T0` | GSM 5/6, MATH 3/6, HumanEval 6/6 | 14/24 | 15/24 | n/a | 75.246 tok/s |
+| `D0` | GSM 6/6, MATH 3/6, HumanEval 6/6 | 15/24 | 16/24 | 4.64385 | 237.849 tok/s |
+| `D1` | GSM 5/6, MATH 3/6, HumanEval 6/6 | 14/24 | 16/24 | 4.64085 | 244.086 tok/s |
+| `D2` | GSM 5/6, MATH 3/6, HumanEval 6/6 | 14/24 | 16/24 | 4.62132 | 253.552 tok/s |
+| `D3` | GSM 4/6, MATH 3/6, HumanEval 6/6 | 13/24 | 15/24 | 4.67840 | 259.833 tok/s |
+
+`T0` and `D1` have exactly the same 24-row pass/fail set despite zero equal
+token hashes. This is direct evidence that random trajectory divergence alone
+is not a quality regression. `D0 -> D1` changes request-mean acceptance by only
+`-0.002999` while improving mean steady decode by 2.62%; compact rejection is
+retained. `D1 -> D2` exchanges one win in each direction, keeps aggregate score
+unchanged, changes acceptance by `-0.019532`, and improves mean steady decode
+by 3.88%; dense-order selector QPN8 remains the quality-first accelerated
+candidate.
+
+`D2 -> D3` yields one D2-only pass and no D3-only pass in this small screen,
+reducing 14/24 to 13/24 for a 2.48% mean-decode gain. McNemar `p=1.0` and the
+wide bootstrap interval do not prove a population regression, but they also do
+not authorize the packaged candidate-order override. Combined with retained
+real-hidden evidence, the quality/risk trade is unfavorable. The source now
+ignores `VLLM_SM70_DFLASH2_QPN8_DENSE_ORDER=0` unless the separate explicit
+benchmark-only `VLLM_SM70_DFLASH2_QPN8_ALLOW_CANDIDATE_ORDER=1` is present.
+This converts stale production launch files to the D2 path while preserving
+the main QPN8 speedup and leaves D3 available only for controlled research.
+
+This screen loaded stale stable-ABI RMSNorm SHA `fe986a...9ba8c`; the runtime
+capability guard correctly selected the bitwise per-layer fallback. Therefore
+its score evidence is valid and all arms are comparable, but its throughput is
+directional rather than a practical-endpoint claim. The formal API and speed
+gates force repaired SHA `7689e5...d449`.
+
+## Structured-output safety backport
+
+The local scheduler previously derived the new reasoning window from stale
+async placeholders, fed the whole boundary step to the grammar, advanced FSM
+state through drafts produced before their masks existed, and allowed
+XGrammar to consume tokens after termination. Those are state-machine bugs,
+not model-sampling variation. The targeted backport now:
+
+- uses the exact `new_token_ids` appended by the scheduler step;
+- records the reasoning-end token and advances only the suffix after it;
+- grammar-validates post-marker drafts before temporary bitmask-state advance;
+- keeps the bonus row constrained after invalid `-1` draft padding;
+- stops XGrammar acceptance/validation at termination and resets termination
+  state explicitly.
+
+The combined DFlash2, reasoning-structured-output, XGrammar termination, and
+quality-comparator gate first passed `110` tests. The final CPU-only rerun,
+which deliberately hides GPUs while another process owns them, passes `106`
+and skips 12 explicit CUDA cases. The separate V100 compact-rejection gate
+passes all eight temperature 0.6/1.0 cases. The two exact failure shapes
+reported upstream pass without `Failed to advance FSM`.
+
+The repaired-extension TP4 Graph API gate then ran with prefix caching, Mamba
+align, `qwen3` reasoning, and `qwen3_coder` tools. At B1 and B4 it repeated
+`json_object`, strict JSON schema, and required `get_weather` tool calls four
+times each: both lanes pass `12/12`, all 24 requests finish successfully, and
+the server log contains no FSM-advance, traceback, EngineCore error, HTTP 500,
+or `FINISHED_ERROR` signature. The launch intentionally supplied the stale
+`DENSE_ORDER=0` value; the runtime logged that it ignored it and enabled
+`dense_order=True`, proving the production safety admission works. These short
+prompts did not produce a prefix-cache hit. A second gate therefore uses the
+actual 256K/current-Flash contract and alternates two long ALPHA/BETA prefixes.
+All five requests return the exact per-request sentinel and checksum. Prefix
+metrics record 59,396 queried tokens and 32,960 hit tokens, far above the
+1,024-token admission threshold. The server log remains free of FSM, HTTP 500,
+EngineCore, traceback, and `FINISHED_ERROR` signatures.
+
+The official Qwen model card also distinguishes general thinking sampling from
+precise coding: the latter recommends temperature 0.6 with top-p 0.95/top-k 20
+and no presence penalty. Temperature 1.0 remains the general-thinking and
+distribution-equivalence contract. Temperature 0.6 is evaluated below as a
+separate client-visible precise-coding profile; sampling profiles must not mask
+a verifier or grammar defect.
+
+## Practical 16K coding gate
+
+The quality-first D2 route completed MBPP-32, HumanEval-32, and stratified
+LiveCodeBench-16 at three predeclared seed bases. Each request uses the
+practical 256K/4096/prefix/Mamba-align/Graph engine contract, temperature
+1.0/top-p 0.95/top-k 20, `xhigh` reasoning, and a 16K natural-EOS cap. MBPP
+excludes the one upstream EvalPlus row without a valid independent-test
+contract, leaving 31 scored rows per seed.
+
+| Suite | Samples | Base/score | Plus | Natural stop | Aggregate output | Mean steady decode | Pooled/request acceptance |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| MBPP | 96 (93 scored) | 89/93 | 80/93 | 95/96 | 213.539 tok/s | 236.902 tok/s | 4.061/4.318 |
+| HumanEval | 96 | 94/96 | 92/96 | 91/96 | 208.978 tok/s | 245.645 tok/s | 3.972/4.476 |
+| LiveCodeBench | 48 | 33/48 | n/a | 32/48 | 170.283 tok/s | 196.541 tok/s | 3.277/3.694 |
+
+MBPP Base/Plus by seed are `31/29`, `27/24`, and `31/27` out of 31.
+HumanEval Base/Plus are `31/30`, `31/31`, and `32/31` out of 32. The middle
+MBPP seed demonstrates substantial sampling variance even though its
+acceptance and speed are not worse; this is why a single output or acceptance
+mean is not an intelligence metric.
+
+The first seed exactly matches the historical no-DFlash request-seed contract.
+Across MBPP plus HumanEval, both routes score Base `62/63` and Plus `59/63`.
+The accelerated route gains one Base and two Plus rows on MBPP, while losing
+one Base and two Plus rows on HumanEval. Thus the matched aggregate shows no
+net score regression, although the changed sampled trajectory moves individual
+failures. MBPP/HumanEval expose six 16K cases among 192 outputs, with three
+still extractable and correct. LiveCodeBench adds 16 length cases among 48
+outputs. The temperature-0.6 follow-up below improves executable score but not
+natural-stop behavior, so it is retained as an optional precise-coding profile
+rather than a forced API default.
+
+LiveCodeBench scores `11/16` for every seed. Aggregated difficulty scores are
+easy `18/18`, medium `12/18`, and hard `3/12`. The historical no-DFlash and
+old-DFlash first-seed controls also score `11/16`; the current route exchanges
+one passing task with each but adds one natural stop (`11/16` versus `10/16`).
+Across all three current seeds, the first two have 11 stops and the third has
+10. Every failure is a 16K length case; all stopped cases in the first two
+seeds pass. This isolates excessive thinking as the remaining coding-product
+risk, rather than verifier corruption or a score regression.
+
+## Precise-coding sampling and PPL distribution gate
+
+The same practical D2 engine contract was repeated at temperature 0.6 for the
+predeclared middle seed, which was the weakest temperature-1.0 MBPP
+realization. All other engine, dataset, prompt, seed, reasoning, and 16K
+natural-EOS settings were unchanged.
+
+| Suite | Temperature 1.0 | Temperature 0.6 | Natural stop, 1.0 -> 0.6 |
+| --- | --- | --- | ---: |
+| MBPP | Base 27/31, Plus 24/31 | Base 29/31, Plus 27/31 | 31/32 -> 30/32 |
+| HumanEval | Base 31/32, Plus 31/32 | Base 31/32, Plus 31/32 | 30/32 -> 30/32 |
+| LiveCodeBench | 11/16 | 11/16 | 11/16 -> 10/16 |
+
+Across the 80 requests, temperature 0.6 changes request-mean acceptance
+`4.27345 -> 4.51356`, pooled acceptance `3.70902 -> 3.84470`, mean steady
+decode `233.187 -> 244.520 token/s`, and output-token/decode-time throughput
+`195.817 -> 201.852 token/s`. It improves MBPP executable scores and lowers no
+suite's aggregate score, but natural stops fall from `72/80` to `70/80`.
+LiveCodeBench exchanges one pass in each direction: one temperature-1.0 stop
+becomes a temperature-0.6 length failure while a different 16K length output
+becomes executable and passes. This is sampling variation, not evidence that
+temperature 0.6 fixes long-thinking termination. Therefore temperature 0.6 is
+accepted as an optional precise-coding profile, not as a forced global API
+default; the general-thinking profile remains temperature 1.0.
+
+A separate current-source Graph PPL pair compares target-only and DFlash2 on
+eight fixed 2,048-token WikiText segments. Both arms use the NVFP4 target,
+E5M2 target KV, TP4 V100, 256K maximum context, 4096 chunking, prefix caching,
+Mamba align, and the repaired extension set. The 16,376 scored prompt tokens
+produce weighted target-only/DFlash2 PPL `5.4993116/5.4993622`, an absolute
+change of `+0.0000506` (`+0.00092%`). Maximum per-segment PPL difference is
+`0.0062143`; prompt-logprob mean/max absolute differences are
+`0.0048521/0.481627`. The predeclared `0.01` maximum segment-PPL gate passes
+with no failed evidence. The generic comparator labels the artifact
+`B-pending` only because this prompt-PPL experiment intentionally does not
+collect output-logprob or sampler-logit tensors; the scored generation,
+compact-rejection equivalence, and API state gates cover those separate
+behaviors. The aggregate PPL result rejects a distribution-level degradation
+of the target model from enabling DFlash2.
+
+## Current status
+
+The source worktree is isolated. The five-arm screen, safe selector admission,
+minimal structured-output backport, comparator, focused CPU/GPU tests, actual
+structured API gate, three-seed practical coding gate, 256K long-prefix state
+gate, temperature-0.6 repeat, and current Graph PPL pair are complete. The
+benchmark supports index-derived request seeds so its first lane exactly
+matches the historical target-only seed contract, and it records suite
+metadata for official EvalPlus/LiveCodeBench scoring. Compact rejection
+matches dense rejection at both temperature `1.0` and precise-coding
+temperature `0.6`. The same-card bounded D1/D2 screen already attributes a
+3.88% steady-decode gain to quality-safe dense-order selector QPN8; a larger
+practical D1/D2 performance pair is optional follow-up rather than a quality
+blocker. Development and Draft PR #18 are private; no public branch is used.

--- a/docs/design/sm70_v100_migration_control.md
+++ b/docs/design/sm70_v100_migration_control.md
@@ -43878,3 +43878,65 @@ Interpretation:
   PR for this continuation use the private remote and the isolated branch
   `agent/private-v100-dsv4-pp2tp4-100tps-20260826`; public upstream is
   fetch-only for this work.
+
+## 2026-08-27 NVFP4 DFlash2 output-quality audit
+
+- This audit starts from private main
+  `d63e9490f65f9e01f6649053c1ab72922034b931` in isolated worktree
+  `v100-dflash2-quality-audit-20260826-124851`. Source changes are in private
+  Draft PR #18; no public branch is used. Remote deployment and packaging are
+  explicitly out of scope.
+- The packaged launch forced selector QPN8 candidate-order tie resolution even
+  though source defaults retained dense-vocabulary order. Real-hidden evidence
+  shows a 1.49% top-20 set change and rare top-1 changes at equal-valued
+  cutoffs. Candidate order now requires a separate benchmark-only opt-in;
+  stale `DENSE_ORDER=0` launch files are ignored and log `dense_order=True`.
+  The five-arm three-seed screen keeps D1 and D2 at `14/24`; D2 improves mean
+  steady decode by 3.88% and changes request acceptance by `-0.0195`. The
+  unsafe D3 arm scores `13/24` and is not promoted.
+- The local fork predated upstream structured-output fixes. The minimal
+  backport uses the scheduler's exact accepted tokens, trims reasoning before
+  grammar advance, constrains bonus/post-marker rows, avoids expected FSM
+  errors for drafts produced before their masks, and stops/resets XGrammar at
+  termination. It does not change Eagle, MTP, DDTree, or their routing.
+- The practical temperature-1.0 coding gate uses NVFP4 target, official BF16
+  DFlash2 draft, TP4 V100, target E5M2 KV, draft FP16 KV, 256K max context,
+  4096 chunking, prefix cache, Mamba align, probabilistic block-8, and full
+  Graphs. Three seed bases produce:
+    - MBPP EvalPlus Base `89/93`, Plus `80/93`, natural stop `95/96`;
+    - HumanEval Base `94/96`, Plus `92/96`, natural stop `91/96`;
+    - LiveCodeBench `33/48`, exactly `11/16` for each seed, natural stop `32/48`.
+  The first-seed MBPP+HumanEval aggregate exactly matches historical
+  no-DFlash at Base `62/63`, Plus `59/63`. LiveCodeBench also matches both
+  historical no-DFlash and old DFlash at `11/16`, exchanging one passing task
+  rather than changing the total score.
+- LiveCodeBench's aggregate output rate is `170.283 token/s`, mean per-request
+  steady decode is `196.541 token/s`, pooled acceptance is `3.277`, and mean
+  per-request acceptance is `3.694`. All failures in the first two seeds are
+  16K length cases, while all naturally stopped cases pass. Excessive thinking
+  at temperature 1.0, not verifier corruption, is the remaining coding-product
+  risk.
+- The same weak middle seed at the official precise-coding temperature 0.6
+  improves MBPP Base/Plus from `27/24` to `29/27` out of 31, keeps HumanEval
+  Base/Plus at `31/31` out of 32, and keeps LiveCodeBench at `11/16`. Across all
+  80 requests, request-mean acceptance moves `4.273 -> 4.514` and mean steady
+  decode `233.187 -> 244.520 token/s`, but natural stops fall from `72/80` to
+  `70/80`. Temperature 0.6 is therefore an optional precise-coding profile,
+  not a global API-default replacement for temperature 1.0.
+- The current 256K/4096/prefix/Mamba-align Graph PPL pair scores 16,376 fixed
+  WikiText tokens. Target-only/DFlash2 weighted PPL is
+  `5.4993116/5.4993622`, a `+0.0000506` (`+0.00092%`) change; maximum per-segment
+  difference is `0.0062143`. This passes the fixed 0.01 segment-PPL bound and
+  provides distribution-level evidence against DFlash2-induced target-model
+  degradation.
+- The actual 256K Graph API gate enables prefix cache, Mamba align, `qwen3`
+  reasoning and `qwen3_coder` tools. B1 and B4 each pass 12/12 across
+  `json_object`, strict schema, and required tool calls. Alternating long
+  ALPHA/BETA prefixes pass 5/5 with exact sentinels and checksums; metrics show
+  59,396 queried and 32,960 cached tokens. The error-signature scan is empty.
+- Evidence is rooted at
+  `/data/minimax-h3/task-cache/v100-dflash2-quality-audit-20260826/`.
+  Detailed rationale and per-arm results are in
+  `docs/design/sm70_dflash2_quality_audit.md`. Do not cite acceptance length as
+  intelligence: it explains throughput, while official executable scores and
+  natural termination are the quality gates.

--- a/tests/benchmarks/test_benchmark_sm70_dflash2_gsm8k.py
+++ b/tests/benchmarks/test_benchmark_sm70_dflash2_gsm8k.py
@@ -1,0 +1,51 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import importlib
+from argparse import Namespace
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture
+def request_seeds_parser(monkeypatch):
+    benchmark_dir = Path(__file__).resolve().parents[2] / "benchmarks"
+    monkeypatch.syspath_prepend(str(benchmark_dir))
+    module = importlib.import_module("benchmark_sm70_dflash2_gsm8k")
+    return module._request_seeds
+
+
+@pytest.mark.parametrize(
+    ("request_seed", "request_seeds", "expected"),
+    [
+        (0, None, [0]),
+        (-1, None, [None]),
+        (0, "11, 22,33", [11, 22, 33]),
+    ],
+)
+def test_request_seeds_parsing(
+    request_seeds_parser, request_seed, request_seeds, expected
+):
+    args = Namespace(request_seed=request_seed, request_seeds=request_seeds)
+
+    assert request_seeds_parser(args) == expected
+
+
+@pytest.mark.parametrize(
+    ("request_seed", "request_seeds"),
+    [
+        (-2, None),
+        (0, ""),
+        (0, "1,-2"),
+        (0, "7,7"),
+        (0, "1,invalid"),
+    ],
+)
+def test_request_seeds_rejects_ambiguous_contracts(
+    request_seeds_parser, request_seed, request_seeds
+):
+    args = Namespace(request_seed=request_seed, request_seeds=request_seeds)
+
+    with pytest.raises(ValueError):
+        request_seeds_parser(args)

--- a/tests/benchmarks/test_compare_sm70_dflash2_quality_matrix.py
+++ b/tests/benchmarks/test_compare_sm70_dflash2_quality_matrix.py
@@ -1,0 +1,45 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from benchmarks.compare_sm70_dflash2_quality_matrix import (
+    _mcnemar_exact,
+    _ordered_arm_names,
+    _paired_bootstrap_delta,
+)
+
+
+def test_mcnemar_exact_counts_discordant_pairs():
+    result = _mcnemar_exact(
+        [True, True, False, False],
+        [False, True, True, False],
+    )
+
+    assert result == {
+        "left_only": 1,
+        "right_only": 1,
+        "discordant": 2,
+        "p_value": 1.0,
+    }
+
+
+def test_paired_bootstrap_delta_is_reproducible():
+    pairs = [(1.0, 2.0), (3.0, 3.0), (4.0, 3.0)]
+
+    left = _paired_bootstrap_delta(pairs, samples=1000, seed=7)
+    right = _paired_bootstrap_delta(pairs, samples=1000, seed=7)
+
+    assert left == right
+    assert left["count"] == 3
+    assert left["mean_delta"] == 0.0
+
+
+def test_matrix_arm_order_tracks_acceleration_layers():
+    arms: dict[str, object] = {
+        "d3": {},
+        "d1": {},
+        "t0": {},
+        "d0": {},
+        "d2": {},
+    }
+
+    assert _ordered_arm_names(arms) == ["t0", "d0", "d1", "d2", "d3"]

--- a/tests/tool_parsers/test_qwen3coder_tool_parser.py
+++ b/tests/tool_parsers/test_qwen3coder_tool_parser.py
@@ -482,6 +482,162 @@ TX
     assert extracted_tool_calls.tool_calls[0].function.name == "get_current_weather"
 
 
+def test_extract_json_body_tool_call(qwen3_tool_parser):
+    """Accept the alternate JSON body emitted by Qwen/OpenCode prompts."""
+    model_output = (
+        "I will check it."
+        "<tool_call>\n"
+        '{"name":"get_current_weather","arguments":'
+        '{"city":"Dallas","state":"TX"}}\n'
+        "</tool_call>"
+    )
+    request = ChatCompletionRequest(model=MODEL, messages=[])
+
+    extracted = qwen3_tool_parser.extract_tool_calls(model_output, request=request)
+
+    assert extracted.tools_called
+    assert extracted.content == "I will check it."
+    assert len(extracted.tool_calls) == 1
+    assert extracted.tool_calls[0].function.name == "get_current_weather"
+    assert json.loads(extracted.tool_calls[0].function.arguments) == {
+        "city": "Dallas",
+        "state": "TX",
+    }
+
+
+def test_streaming_json_body_tool_call(qwen3_tool_parser):
+    """Buffer split JSON arguments and emit one valid atomic tool delta."""
+    request = ChatCompletionRequest(model=MODEL, messages=[])
+    deltas = [
+        "I will check it.<tool_call>\n{",
+        '"name":"get_current_weather",',
+        '"arguments":{"city":"Dallas",',
+        '"state":"TX"}}\n</tool_call>',
+    ]
+
+    from tests.tool_parsers.utils import (
+        run_tool_extraction_streaming,
+    )
+
+    reconstructor = run_tool_extraction_streaming(
+        qwen3_tool_parser,
+        deltas,
+        request,
+        assert_one_tool_per_delta=False,
+    )
+
+    assert reconstructor.other_content == "I will check it."
+    assert len(reconstructor.tool_calls) == 1
+    assert reconstructor.tool_calls[0].function.name == "get_current_weather"
+    assert json.loads(reconstructor.tool_calls[0].function.arguments) == {
+        "city": "Dallas",
+        "state": "TX",
+    }
+
+
+def test_malformed_json_body_remains_content(qwen3_tool_parser):
+    model_output = '<tool_call>{"name":"get_current_weather","arguments":{</tool_call>'
+    request = ChatCompletionRequest(model=MODEL, messages=[])
+
+    extracted = qwen3_tool_parser.extract_tool_calls(model_output, request=request)
+
+    assert not extracted.tools_called
+    assert extracted.content == model_output
+
+
+def test_parameter_markers_inside_string_value(qwen3_tokenizer):
+    """Write/Edit payloads may contain XML-like text without adding fields."""
+    tools = [
+        ChatCompletionToolsParam(
+            type="function",
+            function={
+                "name": "Write",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "file_path": {"type": "string"},
+                        "content": {"type": "string"},
+                    },
+                    "required": ["file_path", "content"],
+                    "additionalProperties": False,
+                },
+            },
+        )
+    ]
+    content = '{"open":"<parameter=x>literal","close":"before</parameter>after"}'
+    model_output = (
+        "<tool_call>\n"
+        "<function=Write>\n"
+        "<parameter=file_path>\n/tmp/result.json\n</parameter>\n"
+        f"<parameter=content>\n{content}\n</parameter>\n"
+        "</function>\n"
+        "</tool_call>"
+    )
+    request = ChatCompletionRequest(model=MODEL, messages=[], tools=tools)
+
+    parser = Qwen3CoderToolParser(qwen3_tokenizer, tools=tools)
+    extracted = parser.extract_tool_calls(model_output, request=request)
+
+    assert extracted.tools_called
+    assert len(extracted.tool_calls) == 1
+    assert json.loads(extracted.tool_calls[0].function.arguments) == {
+        "file_path": "/tmp/result.json",
+        "content": content,
+    }
+
+
+def test_streaming_parameter_markers_inside_string_value(qwen3_tokenizer):
+    """Wait for structural lookahead when a chunk ends on a literal close tag."""
+    tools = [
+        ChatCompletionToolsParam(
+            type="function",
+            function={
+                "name": "Write",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "file_path": {"type": "string"},
+                        "content": {"type": "string"},
+                    },
+                    "required": ["file_path", "content"],
+                    "additionalProperties": False,
+                },
+            },
+        )
+    ]
+    content = '{"open":"<parameter=x>literal","close":"before</parameter>after"}'
+    deltas = [
+        "<tool_call>",
+        "\n<function=Write>",
+        "\n",
+        "<parameter=file_path>\n/tmp/result.json\n</parameter>\n",
+        (
+            "<parameter=content>\n"
+            '{"open":"<parameter=x>literal","close":"before</parameter>'
+        ),
+        'after"}\n</parameter>\n</function>\n</tool_call>',
+    ]
+    request = ChatCompletionRequest(model=MODEL, messages=[], tools=tools)
+
+    from tests.tool_parsers.utils import (
+        run_tool_extraction_streaming,
+    )
+
+    parser = Qwen3CoderToolParser(qwen3_tokenizer, tools=tools)
+    reconstructor = run_tool_extraction_streaming(
+        parser,
+        deltas,
+        request,
+        assert_one_tool_per_delta=False,
+    )
+
+    assert len(reconstructor.tool_calls) == 1
+    assert json.loads(reconstructor.tool_calls[0].function.arguments) == {
+        "file_path": "/tmp/result.json",
+        "content": content,
+    }
+
+
 def test_extract_tool_calls_type_conversion(qwen3_tokenizer):
     """Test parameter type conversion based on tool schema"""
     tools = [
@@ -1379,6 +1535,40 @@ def test_streaming_multi_param_single_chunk(qwen3_tool_parser, qwen3_tokenizer):
     assert args["city"] == "Dallas"
     assert args["state"] == "TX"
     assert args["unit"] == "fahrenheit"
+
+
+def test_streaming_final_param_and_function_close_single_chunk(
+    qwen3_tool_parser,
+):
+    """A speculative burst must not omit the final JSON closing brace."""
+    request = ChatCompletionRequest(model=MODEL, messages=[])
+    deltas = [
+        "<tool_call>",
+        "\n<function=get_current_weather>",
+        "\n",
+        (
+            "<parameter=city>\nDallas\n</parameter>\n"
+            "<parameter=state>\nTX\n</parameter>\n"
+            "</function>\n</tool_call>"
+        ),
+    ]
+
+    from tests.tool_parsers.utils import (
+        run_tool_extraction_streaming,
+    )
+
+    reconstructor = run_tool_extraction_streaming(
+        qwen3_tool_parser,
+        deltas,
+        request,
+        assert_one_tool_per_delta=False,
+    )
+
+    assert len(reconstructor.tool_calls) == 1
+    assert json.loads(reconstructor.tool_calls[0].function.arguments) == {
+        "city": "Dallas",
+        "state": "TX",
+    }
 
 
 @pytest.mark.parametrize(

--- a/tests/v1/spec_decode/test_dflash2.py
+++ b/tests/v1/spec_decode/test_dflash2.py
@@ -25,6 +25,7 @@ from vllm.model_executor.layers.vocab_parallel_embedding import (
     VocabParallelEmbedding,
     _sm70_dflash2_dense_order_topk,
     _sm70_dflash2_rerank_output_buffers,
+    _sm70_dflash2_use_dense_order,
 )
 from vllm.model_executor.models.dflash_sm70 import (
     DFLASH_SM70_GATE_UP_INPUT_SCALE,
@@ -64,6 +65,7 @@ from vllm.v1.worker.gpu.spec_decode.dflash2.speculator import (
 def test_dflash2_gdn_fastpaths_are_default_off(monkeypatch):
     names = (
         "VLLM_SM70_DFLASH2_QPN8_RERANK",
+        "VLLM_SM70_DFLASH2_QPN8_ALLOW_CANDIDATE_ORDER",
         "VLLM_SM70_DFLASH2_VERIFY_FASTPATH",
         "VLLM_SM70_DFLASH2_FUSED_GDN_METADATA",
         "VLLM_SM70_DFLASH2_GDN_METADATA_SHADOW",
@@ -937,6 +939,23 @@ def test_qpn8_rerank_restores_dense_vocab_tie_order():
     expected_values, expected_ids = torch.topk(reference, 4, dim=-1, sorted=True)
     assert torch.equal(actual_values, expected_values)
     assert torch.equal(actual_ids, expected_ids + vocab_start)
+
+
+def test_qpn8_candidate_order_requires_explicit_experimental_opt_in(monkeypatch):
+    monkeypatch.setattr(envs, "VLLM_SM70_DFLASH2_QPN8_DENSE_ORDER", False)
+    monkeypatch.setattr(
+        envs,
+        "VLLM_SM70_DFLASH2_QPN8_ALLOW_CANDIDATE_ORDER",
+        False,
+    )
+    assert _sm70_dflash2_use_dense_order()
+
+    monkeypatch.setattr(
+        envs,
+        "VLLM_SM70_DFLASH2_QPN8_ALLOW_CANDIDATE_ORDER",
+        True,
+    )
+    assert not _sm70_dflash2_use_dense_order()
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")

--- a/tests/v1/spec_decode/test_dflash2_structured_output.py
+++ b/tests/v1/spec_decode/test_dflash2_structured_output.py
@@ -1,0 +1,148 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Structured-output state safety for DFlash2/speculative draft windows."""
+
+from transformers import AutoTokenizer
+
+from vllm.config import StructuredOutputsConfig, VllmConfig
+from vllm.config.model import ModelConfig
+from vllm.config.speculative import SpeculativeConfig
+from vllm.sampling_params import SamplingParams, StructuredOutputsParams
+from vllm.v1.request import Request
+from vllm.v1.structured_output import StructuredOutputManager
+
+TOKENIZER = "gpt2"
+NUM_SPEC_TOKENS = 4
+
+
+def _make_manager_and_request(prompt_str: str = '{"a": "b"}'):
+    tokenizer = AutoTokenizer.from_pretrained(TOKENIZER)
+    prompt = tokenizer.encode(prompt_str)
+    config = VllmConfig(
+        model_config=ModelConfig(tokenizer=TOKENIZER),
+        structured_outputs_config=StructuredOutputsConfig(backend="xgrammar"),
+        speculative_config=SpeculativeConfig(
+            model="[ngram]",
+            num_speculative_tokens=NUM_SPEC_TOKENS,
+        ),
+    )
+    manager = StructuredOutputManager(config)
+    sampling_params = SamplingParams(
+        structured_outputs=StructuredOutputsParams(json='{"type": "object"}'),
+    )
+    assert sampling_params.structured_outputs is not None
+    sampling_params.structured_outputs._backend = "xgrammar"
+    sampling_params.update_from_generation_config({}, tokenizer.eos_token_id)
+    request = Request(
+        "dflash2-structured-output",
+        prompt_token_ids=prompt,
+        sampling_params=sampling_params,
+        pooling_params=None,
+    )
+    manager.grammar_init(request)
+    assert request.structured_output_request is not None
+    while not request.structured_output_request._check_grammar_completion():
+        pass
+    return tokenizer, manager, request, prompt
+
+
+def _grammar(request: Request):
+    assert request.structured_output_request is not None
+    grammar = request.structured_output_request.grammar
+    assert grammar is not None
+    return grammar
+
+
+def test_dflash2_bonus_row_remains_constrained_after_invalid_draft_padding():
+    tokenizer, manager, request, prompt = _make_manager_and_request('{"a"')
+    grammar = _grammar(request)
+    assert grammar.accept_tokens(request.request_id, prompt)
+
+    drafts = [tokenizer.encode(":")[0], -1, -1, -1]
+    bitmask = manager.grammar_bitmask(
+        requests={request.request_id: request},
+        structured_output_request_ids=[request.request_id],
+        scheduled_spec_decode_tokens={request.request_id: drafts},
+    )
+
+    assert bitmask is not None
+    assert bitmask.shape[0] == NUM_SPEC_TOKENS + 1
+    assert not (bitmask[-1] == -1).all()
+    assert not grammar.is_terminated()
+
+
+def test_dflash2_post_reasoning_invalid_draft_does_not_advance_fsm(caplog):
+    tokenizer, manager, request, prompt = _make_manager_and_request("{")
+    grammar = _grammar(request)
+    assert grammar.accept_tokens(request.request_id, prompt)
+
+    marker = tokenizer.encode("\n")[0]
+
+    class MarkerReasoner:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def is_reasoning_end(self, input_ids):
+            return marker in list(input_ids)
+
+        def is_reasoning_end_streaming(self, input_ids, delta_ids):
+            return marker in list(delta_ids)
+
+    manager.reasoner_cls = MarkerReasoner
+    assert request.structured_output_request is not None
+    request.structured_output_request.reasoner = MarkerReasoner()
+    request.structured_output_request.reasoning_ended = False
+
+    drafts = [tokenizer.encode(" ")[0], marker, tokenizer.encode("z")[0]]
+    bitmask = manager.grammar_bitmask(
+        requests={request.request_id: request},
+        structured_output_request_ids=[request.request_id],
+        scheduled_spec_decode_tokens={request.request_id: drafts},
+    )
+
+    assert bitmask is not None
+    assert (bitmask[0] == -1).all()
+    assert (bitmask[1] == -1).all()
+    assert not (bitmask[2] == -1).all()
+    assert not (bitmask[-1] == -1).all()
+    assert not grammar.is_terminated()
+    assert "Failed to advance FSM" not in caplog.text
+
+
+def test_xgrammar_stops_accepting_at_termination(capfd):
+    tokenizer, _, request, prompt = _make_manager_and_request()
+    grammar = _grammar(request)
+    assert grammar.accept_tokens(request.request_id, prompt)
+
+    eos = tokenizer.eos_token_id
+    trailing = tokenizer.encode("\n")[0]
+    processed_before = grammar.num_processed_tokens
+
+    assert grammar.accept_tokens(request.request_id, [eos, trailing])
+    assert grammar.is_terminated()
+    assert grammar.num_processed_tokens == processed_before + 1
+    assert "trying to accept new token" not in capfd.readouterr().err
+
+    processed_after = grammar.num_processed_tokens
+    assert grammar.accept_tokens(request.request_id, [trailing])
+    assert grammar.num_processed_tokens == processed_after
+
+    grammar.reset()
+    assert not grammar.is_terminated()
+    assert grammar.num_processed_tokens == 0
+
+
+def test_xgrammar_validation_rolls_back_at_termination(capfd):
+    tokenizer, _, request, prompt = _make_manager_and_request()
+    grammar = _grammar(request)
+    assert grammar.accept_tokens(request.request_id, prompt)
+
+    eos = tokenizer.eos_token_id
+    trailing = tokenizer.encode("\n")[0]
+    assert grammar.validate_tokens([eos, trailing]) == [eos]
+    assert "trying to accept new token" not in capfd.readouterr().err
+    assert not grammar.matcher.is_terminated()
+
+    assert grammar.accept_tokens(request.request_id, [eos])
+    assert grammar.is_terminated()
+    assert grammar.validate_tokens([trailing]) == []

--- a/tests/v1/spec_decode/test_rejection_sampler_utils.py
+++ b/tests/v1/spec_decode/test_rejection_sampler_utils.py
@@ -132,9 +132,11 @@ def _assert_distribution_match(
 
 @pytest.mark.parametrize("num_speculative_steps", [3, 7])
 @pytest.mark.parametrize("top_p", [1.0, 0.95])
+@pytest.mark.parametrize("temperature", [0.6, 1.0])
 def test_dflash2_sparse_topk_matches_dense_rejection(
     num_speculative_steps: int,
     top_p: float,
+    temperature: float,
 ):
     """Compact p/q support must preserve the dense DFlash2 decision path."""
     torch.manual_seed(20260823)
@@ -174,7 +176,11 @@ def test_dflash2_sparse_topk_matches_dense_rejection(
     top_p_rows = torch.full((num_logits,), top_p, dtype=torch.float32, device=device)
     from vllm.v1.sample.ops.topk_topp_sampler import apply_top_k_top_p
 
-    processed_target = apply_top_k_top_p(target_dense.clone(), top_k_tensor, top_p_rows)
+    processed_target = apply_top_k_top_p(
+        target_dense.clone() / temperature,
+        top_k_tensor,
+        top_p_rows,
+    )
 
     draft_topk_ids = torch.stack(
         [
@@ -187,12 +193,15 @@ def test_dflash2_sparse_topk_matches_dense_rejection(
             for _ in range(num_reqs)
         ]
     )
-    draft_topk_logits = torch.randn(
-        num_reqs,
-        num_speculative_steps,
-        draft_top_k,
-        dtype=torch.float32,
-        device=device,
+    draft_topk_logits = (
+        torch.randn(
+            num_reqs,
+            num_speculative_steps,
+            draft_top_k,
+            dtype=torch.float32,
+            device=device,
+        )
+        / temperature
     )
     draft_dense = torch.full(
         (num_reqs, num_speculative_steps, VOCAB_SIZE),
@@ -216,7 +225,9 @@ def test_dflash2_sparse_topk_matches_dense_rejection(
         rows_per_req, dtype=torch.int32, device=device
     ).repeat(num_reqs)
     pos = torch.arange(num_logits, dtype=torch.int64, device=device) + 8192
-    temperature = torch.ones(num_reqs, dtype=torch.float32, device=device)
+    temperature_per_req = torch.full(
+        (num_reqs,), temperature, dtype=torch.float32, device=device
+    )
     top_p_per_req = torch.full((num_reqs,), top_p, dtype=torch.float32, device=device)
     seeds = torch.arange(101, 101 + num_reqs, dtype=torch.int64, device=device)
 
@@ -229,7 +240,7 @@ def test_dflash2_sparse_topk_matches_dense_rejection(
         idx_mapping,
         expanded_idx_mapping,
         expanded_local_pos,
-        temperature,
+        temperature_per_req,
         seeds,
         num_speculative_steps,
     )
@@ -242,7 +253,7 @@ def test_dflash2_sparse_topk_matches_dense_rejection(
         cu_num_logits,
         pos,
         idx_mapping,
-        temperature,
+        temperature_per_req,
         top_p_per_req,
         seeds,
         num_speculative_steps,

--- a/tests/v1/structured_output/test_reasoning_structured_output.py
+++ b/tests/v1/structured_output/test_reasoning_structured_output.py
@@ -189,7 +189,7 @@ class TestReasoningStructuredOutput:
         # Should return False since reasoning hasn't ended
         assert result is False
 
-    def test_should_advance_reasoning_just_ended(
+    def test_should_advance_reasoning_just_ended_records_boundary(
         self,
         manager_with_reasoner,
         mock_request_with_structured_output,
@@ -204,16 +204,23 @@ class TestReasoningStructuredOutput:
         structured_req = mock_request_with_structured_output.structured_output_request
         structured_req.reasoner = reasoner
 
+        new_token_ids = [6, 7, 8]
         result = manager_with_reasoner.should_advance(
-            mock_request_with_structured_output
+            mock_request_with_structured_output,
+            new_token_ids=new_token_ids,
         )
 
-        # Should set reasoning_ended to True but return False for this step
+        # The scheduler must advance only the suffix after the marker in the
+        # same step; deferring loses that suffix under speculative decoding.
         assert (
             mock_request_with_structured_output.structured_output_request.reasoning_ended
             is True
         )
-        assert result is False
+        assert result is True
+        assert (
+            mock_request_with_structured_output.structured_output_request.reasoning_end_token_index
+            == 5
+        )
 
     def test_should_advance_reasoning_just_ended_with_spec_decode_structural_tag(
         self,
@@ -240,6 +247,46 @@ class TestReasoningStructuredOutput:
 
         assert structured_req.reasoning_ended is True
         assert result is True
+
+    def test_should_advance_uses_appended_tokens_not_stale_placeholders(
+        self,
+        manager_with_reasoner,
+        mock_request_with_structured_output,
+    ):
+        structured_req = mock_request_with_structured_output.structured_output_request
+        structured_req.reasoning_ended = False
+        mock_request_with_structured_output.num_output_placeholders = 99
+
+        reasoner = MockReasoner(tokenizer=Mock())
+        reasoner.is_reasoning_end_streaming.side_effect = (
+            lambda _all_ids, delta_ids: 8 in list(delta_ids)
+        )
+        structured_req.reasoner = reasoner
+
+        assert manager_with_reasoner.should_advance(
+            mock_request_with_structured_output,
+            new_token_ids=[7, 8],
+        )
+        assert structured_req.reasoning_end_token_index == 7
+
+    def test_trim_reasoning_for_advance_keeps_only_post_marker_suffix(
+        self,
+        manager_with_reasoner,
+        mock_request_with_structured_output,
+    ):
+        structured_req = mock_request_with_structured_output.structured_output_request
+        structured_req.reasoning_end_token_index = 6
+
+        assert manager_with_reasoner.trim_reasoning_for_advance(
+            mock_request_with_structured_output,
+            [6, 7, 8],
+        ) == [8]
+
+        mock_request_with_structured_output.all_token_ids.extend([9, 10])
+        assert manager_with_reasoner.trim_reasoning_for_advance(
+            mock_request_with_structured_output,
+            [9, 10],
+        ) == [9, 10]
 
     def test_should_advance_reasoning_already_ended(
         self,

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -198,6 +198,7 @@ if TYPE_CHECKING:
     VLLM_SM70_DFLASH2_QPN8_RERANK: bool = False
     VLLM_SM70_DFLASH2_QPN8_RERANK_SHADOW: bool = False
     VLLM_SM70_DFLASH2_QPN8_DENSE_ORDER: bool = True
+    VLLM_SM70_DFLASH2_QPN8_ALLOW_CANDIDATE_ORDER: bool = False
     VLLM_SM70_DFLASH2_VERIFY_FASTPATH: bool = False
     VLLM_SM70_DFLASH2_FUSED_GDN_METADATA: bool = False
     VLLM_SM70_DFLASH2_GDN_METADATA_SHADOW: bool = False
@@ -1901,6 +1902,12 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # multi-block top-k, but may be enabled only for paired quality tests.
     "VLLM_SM70_DFLASH2_QPN8_DENSE_ORDER": lambda: bool(
         int(os.getenv("VLLM_SM70_DFLASH2_QPN8_DENSE_ORDER", "1"))
+    ),
+    # Candidate-order tie handling is a benchmark-only experiment. Requiring
+    # a second opt-in prevents stale deployment scripts from silently trading
+    # scored quality for a small selector win.
+    "VLLM_SM70_DFLASH2_QPN8_ALLOW_CANDIDATE_ORDER": lambda: bool(
+        int(os.getenv("VLLM_SM70_DFLASH2_QPN8_ALLOW_CANDIDATE_ORDER", "0"))
     ),
     # Umbrella gate for selector-based DFlash verification optimizations. Keep
     # this default-off while each stage is checked against the unchanged path.

--- a/vllm/model_executor/layers/vocab_parallel_embedding.py
+++ b/vllm/model_executor/layers/vocab_parallel_embedding.py
@@ -65,6 +65,24 @@ def _sm70_dflash2_qpn8_rerank_requested() -> bool:
     )
 
 
+def _sm70_dflash2_use_dense_order() -> bool:
+    """Keep production on the scored full-vocabulary tie-order contract."""
+    if envs.VLLM_SM70_DFLASH2_QPN8_DENSE_ORDER:
+        return True
+    if envs.VLLM_SM70_DFLASH2_QPN8_ALLOW_CANDIDATE_ORDER:
+        logger.warning_once(
+            "Using experimental SM70 DFlash2 QPN8 candidate-order top-k. "
+            "This path is not authorized for quality-sensitive serving."
+        )
+        return False
+    logger.warning_once(
+        "Ignoring VLLM_SM70_DFLASH2_QPN8_DENSE_ORDER=0 without the explicit "
+        "benchmark-only VLLM_SM70_DFLASH2_QPN8_ALLOW_CANDIDATE_ORDER=1; "
+        "using the scored dense-order path."
+    )
+    return True
+
+
 def _trace_sm70_lm_head_skip(reason: str) -> None:
     if envs.VLLM_SM70_GREEDY_TOKEN_FASTPATH_TRACE or envs.VLLM_SM70_PROFILE_TRACE:
         logger.warning_once("SM70 LM head fast path not prepared: %s", reason)
@@ -537,7 +555,8 @@ def _maybe_sm70_dflash2_qpn8_rerank(
     values, _positions, ids = _sm70_dflash2_rerank_output_buffers(
         layer, num_rows, selector_k
     )
-    if envs.VLLM_SM70_DFLASH2_QPN8_DENSE_ORDER:
+    use_dense_order = _sm70_dflash2_use_dense_order()
+    if use_dense_order:
         _sm70_dflash2_dense_order_topk(
             layer._sm70_dflash2_rerank_dense_logits[:num_rows],
             qpn8_ids,
@@ -595,7 +614,7 @@ def _maybe_sm70_dflash2_qpn8_rerank(
     logger.info_once(
         "SM70 DFlash2 QPN8 top-64 plus exact packed TurboMind FP16 rerank "
         "path enabled (dense_order=%s).",
-        envs.VLLM_SM70_DFLASH2_QPN8_DENSE_ORDER,
+        use_dense_order,
     )
     output_shape = (*x.shape[:-1], selector_k)
     return values.reshape(output_shape), ids.reshape(output_shape)

--- a/vllm/tool_parsers/qwen3coder_tool_parser.py
+++ b/vllm/tool_parsers/qwen3coder_tool_parser.py
@@ -119,6 +119,7 @@ class Qwen3CoderToolParser(ToolParser):
         # Store accumulated parameters for type conversion
         self.accumulated_params = {}
         self.streaming_request = None
+        self.json_tool_calls_streamed = 0
 
     def _convert_param_value(
         self, param_value: str, param_name: str, param_config: dict, func_name: str
@@ -130,6 +131,103 @@ class Qwen3CoderToolParser(ToolParser):
         param_types = extract_types_from_schema(param_schema)
         return coerce_to_schema_type(param_value, param_types)
 
+    def _parameter_start_positions(
+        self,
+        text: str,
+        param_config: dict,
+    ) -> list[int]:
+        """Find parameter tags without treating inline code as markup.
+
+        Qwen's wire format puts parameter tags on structural boundaries. Tool
+        values, especially code and JSON passed to Write/Edit, may themselves
+        contain strings such as ``<parameter=x>``. A raw substring scan treats
+        those literals as new arguments and corrupts the tool call.
+
+        Unknown names at a bare line boundary are ignored when a schema is
+        available, but remain accepted after a real closing tag. This preserves
+        malformed-output recovery without interpreting an inline literal as a
+        schema field.
+        """
+        positions: list[int] = []
+        search_idx = 0
+        while True:
+            position = text.find(self.parameter_prefix, search_idx)
+            if position == -1:
+                break
+            search_idx = position + len(self.parameter_prefix)
+
+            name_end = text.find(">", search_idx)
+            if name_end == -1:
+                break
+            name = text[search_idx:name_end]
+
+            line_start = text.rfind("\n", 0, position) + 1
+            at_line_boundary = not text[line_start:position].strip()
+            after_close = text[:position].rstrip().endswith(self.parameter_end_token)
+            after_function_header = False
+            if not positions:
+                function_start = text.rfind(self.tool_call_prefix, 0, position)
+                if function_start != -1:
+                    function_header_end = text.find(">", function_start)
+                    after_function_header = (
+                        function_header_end != -1
+                        and not text[function_header_end + 1 : position].strip()
+                    )
+                elif not text[:position].strip():
+                    after_function_header = True
+
+            is_structural = at_line_boundary or after_close or after_function_header
+            if not is_structural:
+                continue
+            if (
+                param_config
+                and name not in param_config
+                and not after_close
+                and not after_function_header
+            ):
+                continue
+            positions.append(position)
+        return positions
+
+    def _find_structural_parameter_end(
+        self,
+        text: str,
+        *,
+        value_start: int,
+        next_parameter_start: int | None,
+        container_end: int | None,
+        allow_text_end: bool,
+    ) -> int | None:
+        """Return a closing tag only when its suffix is structural.
+
+        Literal ``</parameter>`` text is common in generated XML and source
+        files. It closes the current value only when followed by the next real
+        parameter, the function/tool boundary, or (for a complete non-streamed
+        body) the end of the text. Streaming deliberately waits for that one-
+        token lookahead instead of publishing a value that may later truncate.
+        """
+        search_idx = value_start
+        limit = next_parameter_start
+        if limit is None:
+            limit = container_end
+        if limit is None:
+            limit = len(text)
+
+        while True:
+            position = text.find(self.parameter_end_token, search_idx)
+            if position == -1 or position >= limit:
+                return None
+            suffix = position + len(self.parameter_end_token)
+            while suffix < len(text) and text[suffix].isspace():
+                suffix += 1
+            if next_parameter_start is not None and suffix == next_parameter_start:
+                return position
+            if container_end is not None and suffix == container_end:
+                return position
+            if allow_text_end and suffix == len(text):
+                return position
+            search_idx = position + len(self.parameter_end_token)
+
     def _parse_xml_function_call(self, function_call_str: str) -> ToolCall | None:
         # Extract function name
         end_index = function_call_str.find(">")
@@ -140,10 +238,29 @@ class Qwen3CoderToolParser(ToolParser):
         param_config = find_tool_properties(self.tools, function_name)
         parameters = function_call_str[end_index + 1 :]
         param_dict = {}
-        for match_text in self.tool_call_parameter_regex.findall(parameters):
-            idx = match_text.index(">")
-            param_name = match_text[:idx]
-            param_value = str(match_text[idx + 1 :])
+        param_starts = self._parameter_start_positions(parameters, param_config)
+        for param_index, position in enumerate(param_starts):
+            name_start = position + len(self.parameter_prefix)
+            name_end = parameters.find(">", name_start)
+            if name_end == -1:
+                continue
+            param_name = parameters[name_start:name_end]
+            value_start = name_end + 1
+            next_start = (
+                param_starts[param_index + 1]
+                if param_index + 1 < len(param_starts)
+                else None
+            )
+            value_end = self._find_structural_parameter_end(
+                parameters,
+                value_start=value_start,
+                next_parameter_start=next_start,
+                container_end=len(parameters),
+                allow_text_end=True,
+            )
+            if value_end is None:
+                value_end = next_start if next_start is not None else len(parameters)
+            param_value = parameters[value_start:value_end]
             # Remove prefix and trailing \n
             if param_value.startswith("\n"):
                 param_value = param_value[1:]
@@ -159,6 +276,51 @@ class Qwen3CoderToolParser(ToolParser):
                 name=function_name, arguments=json.dumps(param_dict, ensure_ascii=False)
             ),
         )
+
+    @staticmethod
+    def _parse_json_function_call(payload: str) -> ToolCall | None:
+        """Parse the alternate Qwen/OpenCode JSON body inside ``<tool_call>``.
+
+        Some Qwen coding prompts teach ``{"name": ..., "arguments": ...}``
+        while the native model template teaches XML ``<function=...>``.  The
+        wrapper token is unambiguous, so accepting the JSON body keeps both
+        clients interoperable without treating arbitrary assistant JSON as a
+        tool call.
+        """
+        try:
+            raw_call = json.loads(payload.strip())
+        except (TypeError, json.JSONDecodeError):
+            return None
+        if not isinstance(raw_call, dict):
+            return None
+
+        name = raw_call.get("name")
+        arguments = raw_call.get("arguments", {})
+        if not isinstance(name, str) or not name:
+            return None
+        if isinstance(arguments, str):
+            try:
+                arguments = json.loads(arguments)
+            except json.JSONDecodeError:
+                return None
+        if not isinstance(arguments, dict):
+            return None
+
+        return ToolCall(
+            type="function",
+            function=FunctionCall(
+                name=name,
+                arguments=json.dumps(arguments, ensure_ascii=False),
+            ),
+        )
+
+    def _get_json_function_calls(self, model_output: str) -> list[ToolCall]:
+        calls: list[ToolCall] = []
+        for match in self.tool_call_complete_regex.finditer(model_output):
+            parsed = self._parse_json_function_call(match.group(1))
+            if parsed is not None:
+                calls.append(parsed)
+        return calls
 
     def _get_function_calls(self, model_output: str) -> list[str]:
         # Find all tool calls
@@ -230,6 +392,106 @@ class Qwen3CoderToolParser(ToolParser):
             return pending_and_delta[: -len(current_prefix)]
         return pending_and_delta
 
+    def _finish_streaming_function(self, tool_text: str) -> None:
+        """Finalize one streamed XML function and its JSON argument state."""
+        self.json_closed = True
+
+        func_start = tool_text.find(self.tool_call_prefix) + len(self.tool_call_prefix)
+        func_content_end = tool_text.find(self.function_end_token, func_start)
+        if func_content_end != -1:
+            func_content = tool_text[func_start:func_content_end]
+            try:
+                parsed_tool = self._parse_xml_function_call(func_content)
+                if parsed_tool and self.current_tool_index < len(
+                    self.prev_tool_call_arr
+                ):
+                    self.prev_tool_call_arr[self.current_tool_index]["arguments"] = (
+                        parsed_tool.function.arguments
+                    )
+            except Exception:
+                logger.debug(
+                    "Failed to parse tool call during streaming: %s",
+                    tool_text,
+                    exc_info=True,
+                )
+
+        if self.current_tool_index < len(self.streamed_args_for_tool):
+            self.streamed_args_for_tool[self.current_tool_index] += "}"
+        else:
+            logger.warning(
+                "streamed_args_for_tool out of sync: index=%d len=%d",
+                self.current_tool_index,
+                len(self.streamed_args_for_tool),
+            )
+
+        self.in_function = False
+        self.accumulated_params = {}
+
+    def _extract_json_tool_calls_streaming(
+        self,
+        previous_text: str,
+        current_text: str,
+    ) -> DeltaMessage | None:
+        """Emit complete alternate-format JSON calls as atomic deltas.
+
+        Buffering until ``</tool_call>`` deliberately favors correctness over
+        partial display: downstream agents must never observe malformed JSON
+        arguments and then persist that broken call into the next turn.
+        """
+        matches = list(self.tool_call_complete_regex.finditer(current_text))
+        if self.json_tool_calls_streamed >= len(matches):
+            return None
+
+        deltas: list[DeltaToolCall] = []
+        first_new_match = None
+        for match_index in range(self.json_tool_calls_streamed, len(matches)):
+            match = matches[match_index]
+            parsed = self._parse_json_function_call(match.group(1))
+            if parsed is None:
+                continue
+            if first_new_match is None:
+                first_new_match = match
+
+            call_index = len(self.prev_tool_call_arr)
+            call_id = self._generate_tool_call_id()
+            arguments = parsed.function.arguments
+            self.prev_tool_call_arr.append(
+                {
+                    "name": parsed.function.name,
+                    "arguments": arguments,
+                }
+            )
+            self.streamed_args_for_tool.append(arguments)
+            deltas.append(
+                DeltaToolCall(
+                    index=call_index,
+                    id=call_id,
+                    function=DeltaFunctionCall(
+                        name=parsed.function.name,
+                        arguments=arguments,
+                    ),
+                    type="function",
+                )
+            )
+
+        # Complete wrappers, including malformed ones, are consumed once.
+        self.json_tool_calls_streamed = len(matches)
+        if not deltas:
+            return None
+
+        self.is_tool_call_started = False
+        self.header_sent = False
+        self.in_function = False
+        self.json_started = True
+        self.json_closed = True
+
+        content = None
+        if first_new_match is not None and first_new_match.start() > len(previous_text):
+            content = current_text[len(previous_text) : first_new_match.start()]
+            if not content:
+                content = None
+        return DeltaMessage(content=content, tool_calls=deltas)
+
     def extract_tool_calls(
         self,
         model_output: str,
@@ -237,6 +499,22 @@ class Qwen3CoderToolParser(ToolParser):
     ) -> ExtractedToolCallInformation:
         # Quick check to avoid unnecessary processing
         if self.tool_call_prefix not in model_output:
+            json_tool_calls = self._get_json_function_calls(model_output)
+            if json_tool_calls:
+                self.prev_tool_call_arr = [
+                    {
+                        "name": call.function.name,
+                        "arguments": call.function.arguments,
+                    }
+                    for call in json_tool_calls
+                ]
+                content_index = model_output.find(self.tool_call_start_token)
+                content = model_output[:content_index]
+                return ExtractedToolCallInformation(
+                    tools_called=True,
+                    tool_calls=json_tool_calls,
+                    content=content if content else None,
+                )
             return ExtractedToolCallInformation(
                 tools_called=False, tool_calls=[], content=model_output
             )
@@ -324,6 +602,17 @@ class Qwen3CoderToolParser(ToolParser):
 
         # Update accumulated text
         self.accumulated_text = current_text
+
+        # Qwen/OpenCode may emit a JSON body inside the same unambiguous
+        # <tool_call> wrapper used by the XML format. Handle a complete JSON
+        # call before the XML state machine consumes the wrapper and waits for
+        # a <function= header that will never arrive.
+        json_delta = self._extract_json_tool_calls_streaming(
+            previous_text,
+            current_text,
+        )
+        if json_delta is not None:
+            return json_delta
 
         # Check if we need to advance to next tool
         if self.json_closed and not self.in_function:
@@ -473,15 +762,10 @@ class Qwen3CoderToolParser(ToolParser):
                     ]
                 )
 
-            # Find all parameter start positions in current tool_text
-            param_starts = []
-            search_idx = 0
-            while True:
-                search_idx = tool_text.find(self.parameter_prefix, search_idx)
-                if search_idx == -1:
-                    break
-                param_starts.append(search_idx)
-                search_idx += len(self.parameter_prefix)
+            param_config = find_tool_properties(
+                self.tools, self.current_function_name or ""
+            )
+            param_starts = self._parameter_start_positions(tool_text, param_config)
 
             # Process ALL complete params in a loop (spec decode fix).
             # With speculative decoding a single delta can deliver
@@ -503,48 +787,46 @@ class Qwen3CoderToolParser(ToolParser):
                 current_param_name = remaining[:name_end]
 
                 value_start = param_start + name_end + 1
-                value_text = tool_text[value_start:]
-                if value_text.startswith("\n"):
-                    value_text = value_text[1:]
-
-                param_end_idx = value_text.find(self.parameter_end_token)
-                if param_end_idx == -1:
-                    next_param_idx = value_text.find(self.parameter_prefix)
-                    func_end_idx = value_text.find(self.function_end_token)
-
-                    if next_param_idx != -1 and (
-                        func_end_idx == -1 or next_param_idx < func_end_idx
-                    ):
-                        param_end_idx = next_param_idx
-                    elif func_end_idx != -1:
-                        param_end_idx = func_end_idx
+                next_param_idx = (
+                    param_starts[self.param_count + 1]
+                    if self.param_count + 1 < len(param_starts)
+                    else None
+                )
+                function_end_idx = tool_text.find(self.function_end_token, value_start)
+                tool_end_idx = tool_text.find(self.tool_call_end_token, value_start)
+                boundaries = [
+                    boundary
+                    for boundary in (function_end_idx, tool_end_idx)
+                    if boundary != -1
+                ]
+                container_end = min(boundaries) if boundaries else None
+                value_end = self._find_structural_parameter_end(
+                    tool_text,
+                    value_start=value_start,
+                    next_parameter_start=next_param_idx,
+                    container_end=container_end,
+                    allow_text_end=False,
+                )
+                if value_end is None:
+                    if next_param_idx is not None:
+                        # Recover a missing </parameter> before a real next tag.
+                        value_end = next_param_idx
+                    elif container_end is not None:
+                        # Recover a missing final close before function/tool end.
+                        value_end = container_end
                     else:
-                        # Fallback for malformed XML where </function>
-                        # is missing. Use </tool_call> as a delimiter
-                        # if present in the value so we don't include
-                        # the closing tag as part of the param value.
-                        tool_end_in_value = value_text.find(self.tool_call_end_token)
-                        if tool_end_in_value != -1:
-                            param_end_idx = tool_end_in_value
-                        else:
-                            # Parameter incomplete — break so we still
-                            # emit any fragments accumulated by earlier
-                            # loop iterations.
-                            break
+                        # Wait for structural lookahead. The current suffix may
+                        # be literal </parameter> text inside a long value.
+                        break
 
-                if param_end_idx == -1:
-                    break
-
-                param_value = value_text[:param_end_idx]
+                param_value = tool_text[value_start:value_end]
+                if param_value.startswith("\n"):
+                    param_value = param_value[1:]
                 if param_value.endswith("\n"):
                     param_value = param_value[:-1]
 
                 self.current_param_name = current_param_name
                 self.accumulated_params[current_param_name] = param_value
-
-                param_config = find_tool_properties(
-                    self.tools, self.current_function_name or ""
-                )
 
                 converted_value = self._convert_param_value(
                     param_value,
@@ -575,6 +857,14 @@ class Qwen3CoderToolParser(ToolParser):
                         len(self.streamed_args_for_tool),
                     )
 
+                # A speculative burst (or stream_interval > 1) can complete
+                # the final parameter and close the function in one parser
+                # call. Returning only the parameter fragment loses the final
+                # JSON brace because the next delta may be EOS/empty.
+                if not self.json_closed and self.function_end_token in tool_text:
+                    self._finish_streaming_function(tool_text)
+                    combined += "}"
+
                 return DeltaMessage(
                     tool_calls=[
                         DeltaToolCall(
@@ -591,39 +881,7 @@ class Qwen3CoderToolParser(ToolParser):
             # "}" and set in_function=False before the parameter loop
             # ever ran, causing the parameter to be silently dropped.
             if not self.json_closed and self.function_end_token in tool_text:
-                self.json_closed = True
-
-                func_start = tool_text.find(self.tool_call_prefix) + len(
-                    self.tool_call_prefix
-                )
-                func_content_end = tool_text.find(self.function_end_token, func_start)
-                if func_content_end != -1:
-                    func_content = tool_text[func_start:func_content_end]
-                    try:
-                        parsed_tool = self._parse_xml_function_call(
-                            func_content,
-                        )
-                        if parsed_tool and self.current_tool_index < len(
-                            self.prev_tool_call_arr
-                        ):
-                            self.prev_tool_call_arr[self.current_tool_index][
-                                "arguments"
-                            ] = parsed_tool.function.arguments
-                    except Exception:
-                        logger.debug(
-                            "Failed to parse tool call during streaming: %s",
-                            tool_text,
-                            exc_info=True,
-                        )
-
-                if self.current_tool_index < len(self.streamed_args_for_tool):
-                    self.streamed_args_for_tool[self.current_tool_index] += "}"
-                else:
-                    logger.warning(
-                        "streamed_args_for_tool out of sync: index=%d len=%d",
-                        self.current_tool_index,
-                        len(self.streamed_args_for_tool),
-                    )
+                self._finish_streaming_function(tool_text)
 
                 result = DeltaMessage(
                     tool_calls=[
@@ -633,10 +891,6 @@ class Qwen3CoderToolParser(ToolParser):
                         )
                     ]
                 )
-
-                self.in_function = False
-                self.json_closed = True
-                self.accumulated_params = {}
 
                 return result
 

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -1646,17 +1646,25 @@ class Scheduler(SchedulerInterface):
                 request.status = RequestStatus.FINISHED_STOPPED
                 stopped = True
 
-            if new_token_ids and self.structured_output_manager.should_advance(request):
+            if new_token_ids and self.structured_output_manager.should_advance(
+                request, new_token_ids=new_token_ids
+            ):
                 struct_output_request = request.structured_output_request
                 assert struct_output_request is not None
-                assert struct_output_request.grammar is not None
-                if not struct_output_request.grammar.accept_tokens(  # type: ignore[union-attr]
-                    req_id, new_token_ids
+                grammar = struct_output_request.grammar
+                assert grammar is not None
+                advance_token_ids = (
+                    self.structured_output_manager.trim_reasoning_for_advance(
+                        request, new_token_ids
+                    )
+                )
+                if advance_token_ids and not grammar.accept_tokens(
+                    req_id, advance_token_ids
                 ):
                     logger.error(
                         "Unexpected: grammar rejected tokens %s for request %s. "
                         "Terminating request.",
-                        new_token_ids,
+                        advance_token_ids,
                         req_id,
                     )
                     request.status = RequestStatus.FINISHED_ERROR

--- a/vllm/v1/structured_output/__init__.py
+++ b/vllm/v1/structured_output/__init__.py
@@ -2,12 +2,11 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 import itertools
 import multiprocessing
-from collections.abc import Iterable
+from collections.abc import Iterable, Sequence
 from concurrent.futures import Future, ThreadPoolExecutor
 from typing import TYPE_CHECKING
 
 from vllm.config import VllmConfig
-from vllm.logger import init_logger
 from vllm.reasoning import ReasoningParserManager
 from vllm.tokenizers import cached_tokenizer_from_config
 from vllm.utils.import_utils import LazyLoader
@@ -15,7 +14,6 @@ from vllm.v1.structured_output.backend_guidance import GuidanceBackend
 from vllm.v1.structured_output.backend_types import (
     StructuredOutputBackend,
     StructuredOutputGrammar,
-    StructuredOutputOptions,
 )
 from vllm.v1.structured_output.backend_xgrammar import XgrammarBackend
 
@@ -28,9 +26,6 @@ if TYPE_CHECKING:
     from vllm.v1.request import Request
 else:
     torch = LazyLoader("torch", globals(), "torch")
-
-
-logger = init_logger(__name__)
 
 
 class StructuredOutputManager:
@@ -275,17 +270,63 @@ class StructuredOutputManager:
                 grammar = structured_output_request.grammar
                 apply_bitmask = self.should_fill_bitmask(request)
 
+                reasoner = None if apply_bitmask else self._get_reasoner(request)
+                detect_reasoning_end = reasoner is not None
+                simulated_buf: list[int] | None = None
+                history_len = 0
+
                 state_advancements = 0
+                post_reasoning_end_in_window = False
                 req_tokens = scheduled_spec_decode_tokens.get(req_id, ())
-                for token in itertools.chain(req_tokens, (-1,)):
+                for i, token in enumerate(req_tokens):
                     self._fill_bitmasks(((grammar, cumulative_index, apply_bitmask),))
+                    advance_grammar = apply_bitmask
                     if token == -1:
-                        # Stop advancing the grammar once we hit a padding token.
                         apply_bitmask = False
-                    if apply_bitmask and not grammar.is_terminated():
-                        accepted = grammar.accept_tokens(req_id, [token])
-                        assert accepted, (token, req_id, scheduled_spec_decode_tokens)
-                        state_advancements += 1
+                        advance_grammar = False
+                    elif (
+                        detect_reasoning_end
+                        and reasoner is not None
+                        and not apply_bitmask
+                    ):
+                        if simulated_buf is None:
+                            history = list(request.all_token_ids)
+                            history_len = len(history)
+                            simulated_buf = history + list(req_tokens)
+                        simulated = simulated_buf[: history_len + i + 1]
+                        if reasoner.is_reasoning_end_streaming(simulated, [token]):
+                            # The marker belongs to reasoning. Constrain the
+                            # following draft rows, but do not advance the
+                            # grammar through this token.
+                            apply_bitmask = True
+                            advance_grammar = False
+                            post_reasoning_end_in_window = True
+                    if advance_grammar and not grammar.is_terminated():
+                        if post_reasoning_end_in_window:
+                            # These drafts were produced before their grammar
+                            # masks existed. Validate them without logging an
+                            # expected FSM error, then advance only valid rows.
+                            accepted = bool(grammar.validate_tokens([token]))
+                            if accepted:
+                                accepted = grammar.accept_tokens(req_id, [token])
+                        else:
+                            accepted = grammar.accept_tokens(req_id, [token])
+                        if accepted:
+                            state_advancements += 1
+                        elif not post_reasoning_end_in_window:
+                            raise AssertionError(
+                                (token, req_id, scheduled_spec_decode_tokens)
+                            )
+                    cumulative_index += 1
+
+                # Diffusion models do not sample a bonus position after their
+                # scheduled block. Autoregressive speculative decoding does.
+                is_diffusion = bool(
+                    getattr(self.vllm_config.model_config, "is_diffusion", False)
+                )
+                if not (is_diffusion and req_tokens):
+                    bonus_apply = self.should_fill_bitmask(request) or apply_bitmask
+                    self._fill_bitmasks(((grammar, cumulative_index, bonus_apply),))
                     cumulative_index += 1
                 if state_advancements > 0:
                     grammar.rollback(state_advancements)
@@ -303,23 +344,31 @@ class StructuredOutputManager:
         # NOTE (Hanchen) if enable_in_reasoning is True, it means that
         # the model needs to be constrained in reasoning. So we should always
         # enable the bitmask filling.
+        structured_req = request.structured_output_request
+        if self.enable_in_reasoning or (
+            structured_req is not None and structured_req.reasoning_ended is True
+        ):
+            return True
+
         reasoner = self._get_reasoner(request)
         if reasoner is not None:
-            if self.enable_in_reasoning:
-                return True
-            assert request.structured_output_request is not None
-            if request.structured_output_request.reasoning_ended is None:
+            assert structured_req is not None
+            if structured_req.reasoning_ended is None:
                 # This should be removed here, but since `openai_gptoss`
                 # is an independent code path, it is kept for now.
                 # After unifying the `openai_gptoss` and non-`openai_gptoss` styles,
                 # it can be removed.
-                request.structured_output_request.reasoning_ended = (
-                    reasoner.is_reasoning_end(request.prompt_token_ids or [])
+                structured_req.reasoning_ended = reasoner.is_reasoning_end(
+                    request.prompt_token_ids or []
                 )
-            return request.structured_output_request.reasoning_ended
+            return structured_req.reasoning_ended
         return True
 
-    def should_advance(self, request: "Request") -> bool:
+    def should_advance(
+        self,
+        request: "Request",
+        new_token_ids: list[int] | None = None,
+    ) -> bool:
         if not request.use_structured_output:
             return False
 
@@ -328,46 +377,73 @@ class StructuredOutputManager:
         if TYPE_CHECKING:
             assert request.structured_output_request is not None
             assert request.structured_output_request.grammar is not None
-        # by default, we should always advance
-        # for cases that don't use thinking mode.
+        structured_req = request.structured_output_request
+        if self.enable_in_reasoning or (
+            structured_req is not None and structured_req.reasoning_ended is True
+        ):
+            return True
+
+        # By default, always advance requests that have no reasoning parser.
         reasoner = self._get_reasoner(request)
         if reasoner is None:
             return True
 
-        # if the model needs structured in reasoning, we should advance
-        if self.enable_in_reasoning:
-            return True
+        assert structured_req is not None
 
-        structured_req = request.structured_output_request
-        if structured_req.reasoning_ended:
-            return True
-
-        # Check if reasoning ends in *this* step
-        delta_from = request.num_computed_tokens - request.num_output_placeholders
+        # Use the tokens appended in this scheduler step when available. The
+        # placeholder-derived fallback is not reliable after partial draft
+        # rejection under async scheduling.
         all_token_ids = request.all_token_ids
-        start = (
-            delta_from if delta_from >= 0 else max(len(all_token_ids) + delta_from, 0)
-        )
-        if reasoner.is_reasoning_end_streaming(
-            all_token_ids, itertools.islice(all_token_ids, start, None)
-        ):
+        if new_token_ids:
+            start = len(all_token_ids) - len(new_token_ids)
+            delta_ids: Iterable[int] = new_token_ids
+        else:
+            delta_from = request.num_computed_tokens - request.num_output_placeholders
+            start = (
+                delta_from
+                if delta_from >= 0
+                else max(len(all_token_ids) + delta_from, 0)
+            )
+            delta_ids = itertools.islice(all_token_ids, start, None)
+        if reasoner.is_reasoning_end_streaming(all_token_ids, delta_ids):
             structured_req.reasoning_ended = True
-
-            # Reasoning just ended this step. Defer FSM advance until the next
-            # pass (see reasoning_ended check above) for JSON/regex/choice/grammar:
-            # advancing on the closing boundary token can accept tokens that still
-            # belong to the reasoning stream. Structural tags are the only safe
-            # same-step exception: they model phased output (e.g. thinking tag ->
-            # answer tag), and speculative decoding must run grammar.validate_tokens
-            # on draft tokens produced immediately after that transition.
-            if (
-                self.vllm_config.speculative_config is not None
-                and structured_req.structured_output_key[0]
-                == StructuredOutputOptions.STRUCTURAL_TAG
-            ):
-                return True
+            structured_req.reasoning_end_token_index = self._find_reasoning_end_index(
+                reasoner, all_token_ids, start
+            )
+            return True
 
         return False
+
+    @staticmethod
+    def _find_reasoning_end_index(
+        reasoner: "ReasoningParser", all_token_ids: Sequence[int], start: int
+    ) -> int:
+        """Return the absolute index of the final reasoning-marker token."""
+        prefix = list(itertools.islice(all_token_ids, start))
+        for idx in range(start, len(all_token_ids)):
+            token = all_token_ids[idx]
+            prefix.append(token)
+            if reasoner.is_reasoning_end_streaming(prefix, [token]):
+                return idx
+        # Multi-token markers may only be recognized from the complete delta.
+        # Conservatively keep the whole step out of the grammar in that case.
+        return len(all_token_ids) - 1
+
+    def trim_reasoning_for_advance(
+        self, request: "Request", new_token_ids: list[int]
+    ) -> list[int]:
+        """Drop reasoning content before advancing the structured grammar."""
+        structured_req = request.structured_output_request
+        if structured_req is None:
+            return new_token_ids
+        end_idx = structured_req.reasoning_end_token_index
+        if end_idx is None:
+            return new_token_ids
+        first_idx = len(request.all_token_ids) - len(new_token_ids)
+        num_reasoning = end_idx + 1 - first_idx
+        if num_reasoning <= 0:
+            return new_token_ids
+        return new_token_ids[num_reasoning:]
 
     def clear_backend(self) -> None:
         if self.backend is not None:

--- a/vllm/v1/structured_output/backend_xgrammar.py
+++ b/vllm/v1/structured_output/backend_xgrammar.py
@@ -148,11 +148,11 @@ class XgrammarGrammar(StructuredOutputGrammar):
     def accept_tokens(self, request_id: str, tokens: list[int]) -> bool:
         """Accepts a list of tokens and advances the FSM.
 
-        Returns True if the FSM was advanced successfully.
-        Returns False if the FSM failed to advance.
+        Returns True if every constrained token was accepted. Tokens after
+        grammar termination are ignored. Returns False on rejection.
         """
         if self._is_terminated:
-            return False
+            return True
         for token in tokens:
             if not self.matcher.accept_token(token):
                 logger.error(
@@ -163,7 +163,9 @@ class XgrammarGrammar(StructuredOutputGrammar):
                 )
                 return False
             self.num_processed_tokens += 1
-        self._is_terminated = self.matcher.is_terminated()
+            self._is_terminated = self.matcher.is_terminated()
+            if self._is_terminated:
+                break
         return True
 
     def validate_tokens(self, tokens: list[int]) -> list[int]:
@@ -172,10 +174,15 @@ class XgrammarGrammar(StructuredOutputGrammar):
 
         Returns the prefix list of tokens that are accepted by the FSM.
         """
+        if self._is_terminated:
+            return []
+
         accepted_tokens = []
         for token in tokens:
             if self.matcher.accept_token(token):
                 accepted_tokens.append(token)
+                if self.matcher.is_terminated():
+                    break
             else:
                 break
         if len(accepted_tokens) > 0:
@@ -195,8 +202,9 @@ class XgrammarGrammar(StructuredOutputGrammar):
         return self._is_terminated
 
     def reset(self):
-        self.num_processed_tokens = 0
         self.matcher.reset()
+        self.num_processed_tokens = 0
+        self._is_terminated = False
 
 
 # cf https://github.com/mlc-ai/xgrammar/blob/a32ac892676d2eedc0327416105b9b06edfb94b2/cpp/json_schema_converter.cc

--- a/vllm/v1/structured_output/request.py
+++ b/vllm/v1/structured_output/request.py
@@ -23,6 +23,9 @@ class StructuredOutputRequest:
     params: StructuredOutputsParams
     _grammar: Future[StructuredOutputGrammar] | StructuredOutputGrammar | None = None
     reasoning_ended: bool | None = None
+    # Absolute index in all_token_ids of the last reasoning-marker token.
+    # Only the suffix after this boundary may advance the structured grammar.
+    reasoning_end_token_index: int | None = None
     reasoning_parser_kwargs: dict[str, Any] | None = None
     # Cached per request; do not share reasoning parsers across requests because
     # their behavior can depend on reasoning_parser_kwargs.


### PR DESCRIPTION
> Public migration note (2026-08-27): this Draft is the public continuation of private PR #18, mirrored at exact head f5a93e2de2f1940de0e498afb01db85b77982948 after public main resumed through #342. The original implementation notes and evidence are preserved below.

## Purpose

- Keep stale selector-QPN8 deployment overrides on the scored dense-order contract unless a separate research-only opt-in is present.
- Backport the minimal structured-output/spec-decode state fixes needed for DFlash2 reasoning, JSON schema, and tool calls.
- Add reproducible multi-seed quality evidence without replacing Eagle, MTP, DDTree, or the retained DFlash2 acceleration stack.

## Test Plan

- Focused DFlash2, structured-output, XGrammar, comparator, and benchmark tests.
- TP4 V100 Graph API tests at B1/B4 with reasoning, tools, JSON schema, prefix cache, FP8 KV, and current Flash-V100.
- Three-seed 16K natural-EOS MBPP, HumanEval, and LiveCodeBench scoring.
- Long repeated-prefix state isolation, same-seed temperature 0.6 coding follow-up, and current-source target-only/DFlash2 Graph PPL pair.

## Test Result

- Pre-commit: passed.
- CPU-focused gate: 106 passed, 12 CUDA-only skipped; separate V100 compact-rejection temperature 0.6/1.0 equivalence: 8 passed.
- Structured API: B1/B4 24/24; long alternating-prefix state 5/5; 32,960 prefix-cache hit tokens; no FSM, HTTP 500, traceback, or engine-error signature.
- MBPP three-seed EvalPlus: Base 89/93, Plus 80/93.
- HumanEval three-seed EvalPlus: Base 94/96, Plus 92/96.
- LiveCodeBench three-seed: 33/48, exactly 11/16 per seed.
- Same-seed historical no-DFlash comparison: MBPP+HumanEval both Base 62/63 and Plus 59/63; LiveCodeBench both 11/16.
- Temperature 0.6 weak-seed follow-up: MBPP Base/Plus 29/27 versus 27/24 at temperature 1.0; HumanEval 31/31 unchanged; LiveCodeBench 11/16 unchanged. It is an optional precise-coding profile because natural stops move 72/80 to 70/80.
- Current 256K/4096/prefix/Mamba-align Graph PPL: target-only 5.4993116, DFlash2 5.4993622 across 16,376 WikiText tokens; maximum segment difference 0.0062143.
- Quality-safe D2 dense-order selector keeps the bounded aggregate score and improves same-card mean steady decode 3.88% versus D1.

Full evidence and decisions are recorded in `docs/design/sm70_dflash2_quality_audit.md`.

This PR remains private and Draft; no public branch was updated.