### PR TITLE
[Kernel][SM70] Revisit exact fused V4 auxiliary GEMVs

### DIFF
--- a/docs/design/sm70_v100_migration_control.md
+++ b/docs/design/sm70_v100_migration_control.md
@@ -43935,8 +43935,10 @@ Interpretation:
 - The source-`22a25e877f` quality-safe stack now has a fresh 28-step steady
   Nsight trace. Its output-token prefix is exactly equal to the pinned
   uninstrumented request. Nsight injection expands the replay interval to
-  `15.410 ms`; the matched uninstrumented baseline remains `13.598 ms/token`
-  and `73.539 token/s`. Excluding PP dependency residency, stage-sum service
+  `15.410 ms`; the corresponding historical uninstrumented endpoint was
+  `13.598 ms/token` and `73.539 token/s`. A later same-effective-route startup
+  changed dataset rows, so this speed point is no longer a reproducible
+  quality baseline. Excluding PP dependency residency, stage-sum service
   is led by FP8 dense `6.133 ms`, FP16 GEMV/compressor `2.328 ms`, MXFP4 MoE
   `2.208 ms`, mHC `1.750 ms`, Q/KV work `1.122 ms`, sparse MLA `1.119 ms`,
   routing/activation `1.003 ms`, and TP all-reduce `0.852 ms`. Evidence is
@@ -43947,8 +43949,10 @@ Interpretation:
   candidate rejoins the real `N=2048/512/64`, `K=4096` FP16 weights and uses
   the unchanged block-K-1024 FP32 FMA/reduction kernel in one `N=2624` launch.
   It is mutually exclusive with FP13 and remains default-off. Prior real-V100
-  evidence has 64/64 bitwise main and auxiliary patterns and changes warm
-  overlap from `103.809` to `51.639 us/C4 layer`, and cold overlap from
-  `99.104` to `73.856 us/C4 layer`. Current-source operator, endpoint, and
-  per-sample dataset gates are pending, so none of that projected saving is
-  admitted into the `73.539 token/s` baseline yet.
+  evidence has 64/64 bitwise main and auxiliary patterns. The current-source
+  real-weight screen confirms 64/64 bitwise main and auxiliary outputs with
+  stable CUDA Graph replay. A/B/B/A timing changes warm overlap from
+  `105.894` to `51.884 us/C4 layer`, and cold overlap from `99.080` to
+  `74.040 us/C4 layer`. The repeated endpoint and per-sample dataset gates are
+  pending behind FP8 tactic stabilization, so none of that projected saving is
+  admitted yet.

--- a/docs/design/sm70_v100_migration_control.md
+++ b/docs/design/sm70_v100_migration_control.md
@@ -43932,3 +43932,23 @@ Interpretation:
   PR for this continuation use the private remote and the isolated branch
   `agent/private-v100-dsv4-pp2tp4-followup-20260826`; public upstream is
   fetch-only for this work.
+- The source-`22a25e877f` quality-safe stack now has a fresh 28-step steady
+  Nsight trace. Its output-token prefix is exactly equal to the pinned
+  uninstrumented request. Nsight injection expands the replay interval to
+  `15.410 ms`; the matched uninstrumented baseline remains `13.598 ms/token`
+  and `73.539 token/s`. Excluding PP dependency residency, stage-sum service
+  is led by FP8 dense `6.133 ms`, FP16 GEMV/compressor `2.328 ms`, MXFP4 MoE
+  `2.208 ms`, mHC `1.750 ms`, Q/KV work `1.122 ms`, sparse MLA `1.119 ms`,
+  routing/activation `1.003 ms`, and TP all-reduce `0.852 ms`. Evidence is
+  under
+  `/data/models/v100-dsv4-0731-pp2tp4-quality-safe-nsys-20260827-r2/`.
+- Packed FP13 is now quality-gated off by default, so the earlier reason for
+  shelving the exact C4 auxiliary fusion no longer applies. The private
+  candidate rejoins the real `N=2048/512/64`, `K=4096` FP16 weights and uses
+  the unchanged block-K-1024 FP32 FMA/reduction kernel in one `N=2624` launch.
+  It is mutually exclusive with FP13 and remains default-off. Prior real-V100
+  evidence has 64/64 bitwise main and auxiliary patterns and changes warm
+  overlap from `103.809` to `51.639 us/C4 layer`, and cold overlap from
+  `99.104` to `73.856 us/C4 layer`. Current-source operator, endpoint, and
+  per-sample dataset gates are pending, so none of that projected saving is
+  admitted into the `73.539 token/s` baseline yet.

--- a/tests/kernels/test_sm70_deepseek_v4_fp16_gemv.py
+++ b/tests/kernels/test_sm70_deepseek_v4_fp16_gemv.py
@@ -12,7 +12,11 @@ from vllm.models.deepseek_v4.sm70.gemv import (
     _pack_sm70_dsv4_fp13_weight,
     can_use_sm70_dsv4_fp13_gemv,
     can_use_sm70_dsv4_fp16_gemv,
+    can_use_sm70_dsv4_fused_fp16_aux_gemv,
+    has_sm70_dsv4_fused_fp16_aux_weight_contract,
     maybe_sm70_dsv4_fp16_gemv,
+    maybe_sm70_dsv4_fused_fp16_aux_gemv,
+    prepare_sm70_dsv4_fused_fp16_aux_weight,
 )
 
 
@@ -44,6 +48,34 @@ def test_sm70_dsv4_fp13_enables_fp16_fallback(monkeypatch) -> None:
     x = torch.empty((1, 4096), dtype=torch.float16)
     weight = torch.empty((256, 4096), dtype=torch.float16)
     assert can_use_sm70_dsv4_fp16_gemv(x, weight, torch.float32)
+
+
+def test_sm70_dsv4_fused_fp16_aux_contract_is_exact_and_default_off(
+    monkeypatch,
+) -> None:
+    monkeypatch.delenv("VLLM_SM70_DSV4_FUSED_FP16_AUX_GEMV", raising=False)
+    weights = tuple(
+        torch.empty((rows, 4096), dtype=torch.float16, device="meta")
+        for rows in (2048, 512, 64)
+    )
+
+    assert has_sm70_dsv4_fused_fp16_aux_weight_contract(weights)
+    assert prepare_sm70_dsv4_fused_fp16_aux_weight(weights) is None
+    assert not has_sm70_dsv4_fused_fp16_aux_weight_contract(
+        (weights[1], weights[0], weights[2])
+    )
+    malformed = (weights[0], torch.empty((), device="meta"), weights[2])
+    assert not has_sm70_dsv4_fused_fp16_aux_weight_contract(malformed)
+
+
+def test_sm70_dsv4_fused_fp16_aux_rejects_fp13(monkeypatch) -> None:
+    monkeypatch.setenv("VLLM_SM70_DSV4_FP16_GEMV", "1")
+    monkeypatch.setenv("VLLM_SM70_DSV4_FUSED_FP16_AUX_GEMV", "1")
+    monkeypatch.setenv("VLLM_SM70_DSV4_FP13_GEMV", "1")
+    envs.disable_envs_cache()
+    x = torch.empty((1, 4096), dtype=torch.float16, device="meta")
+    fused_weight = torch.empty((2624, 4096), dtype=torch.float16, device="meta")
+    assert not can_use_sm70_dsv4_fused_fp16_aux_gemv(x, fused_weight)
 
 
 def test_sm70_dsv4_gemv_rejects_cpu_tensors(monkeypatch) -> None:
@@ -139,6 +171,58 @@ def test_sm70_dsv4_fp16_gemv_graph(
     else:
         reference = torch.mm(x, weight.T, out_dtype=torch.float32)
         torch.testing.assert_close(captured, reference, rtol=2e-4, atol=5e-5)
+
+
+@pytest.mark.skipif(
+    not torch.cuda.is_available() or torch.cuda.get_device_capability() != (7, 0),
+    reason="requires NVIDIA V100/SM70",
+)
+def test_sm70_dsv4_fused_fp16_aux_graph_is_bitwise(monkeypatch) -> None:
+    monkeypatch.setenv("VLLM_SM70_DSV4_FP16_GEMV", "1")
+    monkeypatch.setenv("VLLM_SM70_DSV4_FUSED_FP16_AUX_GEMV", "1")
+    monkeypatch.setenv("VLLM_SM70_DSV4_FP13_GEMV", "0")
+    envs.disable_envs_cache()
+    torch.manual_seed(20260826)
+    x = torch.randn((1, 4096), device="cuda", dtype=torch.float16)
+    weights = tuple(
+        torch.randn((rows, 4096), device="cuda", dtype=torch.float16) * 0.01
+        for rows in (2048, 512, 64)
+    )
+    fused_weight = prepare_sm70_dsv4_fused_fp16_aux_weight(weights)
+    assert fused_weight is not None
+
+    output_dtypes = (torch.float32, torch.float32, torch.float16)
+    reference = tuple(
+        maybe_sm70_dsv4_fp16_gemv(x, weight, output_dtype)
+        for weight, output_dtype in zip(weights, output_dtypes)
+    )
+    candidate = maybe_sm70_dsv4_fused_fp16_aux_gemv(x, fused_weight)
+    assert all(output is not None for output in reference)
+    assert candidate is not None
+    torch.cuda.synchronize()
+    assert all(
+        torch.equal(actual, expected)
+        for actual, expected in zip(candidate, reference)
+        if expected is not None
+    )
+
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        captured_reference = tuple(
+            maybe_sm70_dsv4_fp16_gemv(x, weight, output_dtype)
+            for weight, output_dtype in zip(weights, output_dtypes)
+        )
+        captured_candidate = maybe_sm70_dsv4_fused_fp16_aux_gemv(x, fused_weight)
+    assert all(output is not None for output in captured_reference)
+    assert captured_candidate is not None
+    x.copy_(torch.randn_like(x))
+    graph.replay()
+    torch.cuda.synchronize()
+    assert all(
+        torch.equal(actual, expected)
+        for actual, expected in zip(captured_candidate, captured_reference)
+        if expected is not None
+    )
 
 
 @pytest.mark.skipif(

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -186,6 +186,7 @@ if TYPE_CHECKING:
     VLLM_SM70_NVFP4_DENSE_TUNE_MAX_M: int = 16
     VLLM_SM70_DSV4_FP16_GEMV: bool = False
     VLLM_SM70_DSV4_FP13_GEMV: bool = False
+    VLLM_SM70_DSV4_FUSED_FP16_AUX_GEMV: bool = False
     VLLM_SM70_DSV4_MHC_FP32_STAGE: bool = True
     VLLM_SM70_DSV4_QNORM_KV_FUSED_TP4: bool = True
     VLLM_SM70_PP_STATIC_HIDDEN_TRANSFER: bool = True
@@ -1830,6 +1831,9 @@ environment_variables: dict[str, Callable[[], Any]] = {
     ),
     "VLLM_SM70_DSV4_FP13_GEMV": lambda: bool(
         int(os.getenv("VLLM_SM70_DSV4_FP13_GEMV", "0"))
+    ),
+    "VLLM_SM70_DSV4_FUSED_FP16_AUX_GEMV": lambda: bool(
+        int(os.getenv("VLLM_SM70_DSV4_FUSED_FP16_AUX_GEMV", "0"))
     ),
     "VLLM_SM70_DSV4_MHC_FP32_STAGE": lambda: bool(
         int(os.getenv("VLLM_SM70_DSV4_MHC_FP32_STAGE", "1"))

--- a/vllm/models/deepseek_v4/attention.py
+++ b/vllm/models/deepseek_v4/attention.py
@@ -51,7 +51,12 @@ from vllm.model_executor.layers.quantization.utils.quant_utils import (
     GroupShape,
 )
 from vllm.models.deepseek_v4.compressor import DeepseekCompressor
-from vllm.models.deepseek_v4.sm70.gemv import maybe_sm70_dsv4_fp16_gemv
+from vllm.models.deepseek_v4.sm70.gemv import (
+    can_use_sm70_dsv4_fused_fp16_aux_gemv,
+    maybe_sm70_dsv4_fp16_gemv,
+    maybe_sm70_dsv4_fused_fp16_aux_gemv,
+    prepare_sm70_dsv4_fused_fp16_aux_weight,
+)
 from vllm.platforms import current_platform
 from vllm.triton_utils import tl, triton
 from vllm.utils.multi_stream_utils import (
@@ -310,6 +315,7 @@ class DeepseekV4MultiHeadLatentAttentionWrapper(PluggableLayer):
                 k_cache_prefix=self.mla_attn.prefix,
                 validity_cache_prefix=self.swa_cache_layer.prefix,
             )
+        self.register_buffer("_sm70_dsv4_fused_fp16_aux_weight", None, persistent=False)
 
     def forward(
         self,
@@ -395,6 +401,20 @@ class DeepseekV4MultiHeadLatentAttentionWrapper(PluggableLayer):
 
         return self.wo_b(z.flatten(1))
 
+    def prepare_sm70_fused_fp16_aux_weight(self) -> None:
+        """Join the three exact C4 weights once, after checkpoint loading."""
+        if self.compressor is None or self.indexer is None:
+            return
+        fused_weight = prepare_sm70_dsv4_fused_fp16_aux_weight(
+            (
+                self.compressor.fused_wkv_wgate.weight,
+                self.indexer.compressor.fused_wkv_wgate.weight,
+                self.indexer.weights_proj.weight,
+            )
+        )
+        if fused_weight is not None:
+            self._buffers["_sm70_dsv4_fused_fp16_aux_weight"] = fused_weight
+
     def attn_gemm_parallel_execute(self, hidden_states) -> tuple[Any, ...]:
         aux_streams = self.aux_stream_list
         if aux_streams is not None:
@@ -478,6 +498,31 @@ class DeepseekV4MultiHeadLatentAttentionWrapper(PluggableLayer):
             # MergedColumnParallelLinear returns (output, bias); bias is None.
             qr_kv, _ = self.fused_wqa_wkv(hidden_states)
             return qr_kv
+
+        fused_aux_weight = self._sm70_dsv4_fused_fp16_aux_weight
+        if aux_streams is not None and can_use_sm70_dsv4_fused_fp16_aux_gemv(
+            hidden_states, fused_aux_weight
+        ):
+
+            def fused_fp16_aux() -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+                result = maybe_sm70_dsv4_fused_fp16_aux_gemv(
+                    hidden_states, fused_aux_weight
+                )
+                assert result is not None
+                return result
+
+            qr_kv, fused_results = execute_in_parallel(
+                fused_wqa_wkv,
+                [fused_fp16_aux],
+                self.ln_events[0],
+                [self.ln_events[1]],
+                [aux_streams[0]],
+                enable=True,
+            )
+            fused_result = fused_results[0]
+            assert fused_result is not None
+            kv_score, indexer_kv_score, indexer_weights = fused_result
+            return qr_kv, kv_score, indexer_kv_score, indexer_weights
 
         qr_kv, (kv_score, indexer_weights, indexer_kv_score) = execute_in_parallel(
             fused_wqa_wkv,

--- a/vllm/models/deepseek_v4/nvidia/model.py
+++ b/vllm/models/deepseek_v4/nvidia/model.py
@@ -1292,6 +1292,11 @@ class DeepseekV4Model(nn.Module, EagleModelMixin):
                 .sum(dim=1)
             )
 
+    def finalize_sm70_fused_aux_weights(self) -> None:
+        for layer in islice(self.layers, self.start_layer, self.end_layer):
+            if isinstance(layer, DeepseekV4DecoderLayer):
+                layer.attn.mla_attn.prepare_sm70_fused_fp16_aux_weight()
+
 
 def _make_deepseek_v4_weights_mapper(expert_dtype: str) -> WeightsMapper:
     if expert_dtype == "fp4":
@@ -1406,6 +1411,7 @@ class DeepseekV4ForCausalLM(nn.Module, SupportsPP, SupportsEagle3):
         loaded_params = loader.load_weights(weights, mapper=self.hf_to_vllm_mapper)
         self.model.finalize_mega_moe_weights()
         self.model.finalize_mhc_broadcast_weights()
+        self.model.finalize_sm70_fused_aux_weights()
         return loaded_params
 
     def get_expert_mapping(self) -> list[tuple[str, str, int, str]]:

--- a/vllm/models/deepseek_v4/sm70/gemv.py
+++ b/vllm/models/deepseek_v4/sm70/gemv.py
@@ -16,6 +16,8 @@ _SUPPORTED_N = frozenset((64, 256, 512, 1024, 2048))
 _K = 4096
 _BLOCK_K = 1024
 _NUM_WARPS = 4
+_FUSED_AUX_ROWS = (2048, 512, 64)
+_FUSED_AUX_N = sum(_FUSED_AUX_ROWS)
 _FP13_GROUP_VALUES = 32
 _FP13_GROUP_WORDS = 13
 _FP13_GROUPS_PER_ROW = _K // _FP13_GROUP_VALUES
@@ -39,6 +41,39 @@ def _sm70_dsv4_fp16_gemv_kernel(
         weight = tl.load(weight_ptr + row * K + block_start + offsets).to(tl.float32)
         acc += tl.sum(x * weight, axis=0)
     tl.store(out_ptr + row, acc)
+
+
+@triton.jit
+def _sm70_dsv4_fused_fp16_aux_gemv_kernel(
+    x_ptr,
+    weight_ptr,
+    compressor_out_ptr,
+    indexer_compressor_out_ptr,
+    indexer_weights_out_ptr,
+    K: tl.constexpr,
+    BLOCK_K: tl.constexpr,
+    COMPRESSOR_N: tl.constexpr,
+    INDEXER_COMPRESSOR_N: tl.constexpr,
+):
+    """Compute the three C4 auxiliary GEMVs in one exact-FP16 launch."""
+    row = tl.program_id(0)
+    offsets = tl.arange(0, BLOCK_K)
+    acc = 0.0
+    for block_start in tl.static_range(0, K, BLOCK_K):
+        x = tl.load(x_ptr + block_start + offsets).to(tl.float32)
+        weight = tl.load(weight_ptr + row * K + block_start + offsets).to(tl.float32)
+        acc += tl.sum(x * weight, axis=0)
+    tl.store(compressor_out_ptr + row, acc, mask=row < COMPRESSOR_N)
+    tl.store(
+        indexer_compressor_out_ptr + row - COMPRESSOR_N,
+        acc,
+        mask=(row >= COMPRESSOR_N) & (row < COMPRESSOR_N + INDEXER_COMPRESSOR_N),
+    )
+    tl.store(
+        indexer_weights_out_ptr + row - COMPRESSOR_N - INDEXER_COMPRESSOR_N,
+        acc,
+        mask=row >= COMPRESSOR_N + INDEXER_COMPRESSOR_N,
+    )
 
 
 @triton.jit
@@ -262,6 +297,99 @@ def prepare_sm70_dsv4_fp13_gemv(layer: torch.nn.Module) -> torch.Tensor | None:
     else:
         layer.register_buffer(_FP13_BUFFER, packed, persistent=False)
     return packed
+
+
+def has_sm70_dsv4_fused_fp16_aux_weight_contract(
+    weights: tuple[torch.Tensor, torch.Tensor, torch.Tensor],
+) -> bool:
+    """Check the exact C4 auxiliary row order used by the fused kernel."""
+    if tuple(tuple(weight.shape) for weight in weights) != tuple(
+        (rows, _K) for rows in _FUSED_AUX_ROWS
+    ):
+        return False
+    device = weights[0].device
+    return all(
+        weight.dtype == torch.float16
+        and weight.ndim == 2
+        and weight.shape[1] == _K
+        and weight.device == device
+        and weight.is_contiguous()
+        for weight in weights
+    )
+
+
+@torch.no_grad()
+def prepare_sm70_dsv4_fused_fp16_aux_weight(
+    weights: tuple[torch.Tensor, torch.Tensor, torch.Tensor],
+) -> torch.Tensor | None:
+    """Join exact FP16 weights only when the approximate FP13 route is off."""
+    if (
+        not envs.VLLM_SM70_DSV4_FP16_GEMV
+        or not envs.VLLM_SM70_DSV4_FUSED_FP16_AUX_GEMV
+        or envs.VLLM_SM70_DSV4_FP13_GEMV
+        or not current_platform.is_cuda()
+        or not current_platform.is_device_capability((7, 0))
+        or not weights[0].is_cuda
+        or not has_sm70_dsv4_fused_fp16_aux_weight_contract(weights)
+    ):
+        return None
+    return torch.cat(weights, dim=0).contiguous()
+
+
+def can_use_sm70_dsv4_fused_fp16_aux_gemv(
+    x: torch.Tensor,
+    fused_weight: torch.Tensor | None,
+) -> bool:
+    return (
+        envs.VLLM_SM70_DSV4_FP16_GEMV
+        and envs.VLLM_SM70_DSV4_FUSED_FP16_AUX_GEMV
+        and not envs.VLLM_SM70_DSV4_FP13_GEMV
+        and current_platform.is_cuda()
+        and current_platform.is_device_capability((7, 0))
+        and x.is_cuda
+        and x.dtype == torch.float16
+        and x.ndim == 2
+        and x.shape == (1, _K)
+        and x.is_contiguous()
+        and fused_weight is not None
+        and fused_weight.is_cuda
+        and fused_weight.dtype == torch.float16
+        and fused_weight.device == x.device
+        and fused_weight.shape == (_FUSED_AUX_N, _K)
+        and fused_weight.is_contiguous()
+    )
+
+
+def maybe_sm70_dsv4_fused_fp16_aux_gemv(
+    x: torch.Tensor,
+    fused_weight: torch.Tensor | None,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor] | None:
+    if not can_use_sm70_dsv4_fused_fp16_aux_gemv(x, fused_weight):
+        return None
+    assert fused_weight is not None
+    compressor_out = torch.empty(
+        (1, _FUSED_AUX_ROWS[0]), device=x.device, dtype=torch.float32
+    )
+    indexer_compressor_out = torch.empty(
+        (1, _FUSED_AUX_ROWS[1]), device=x.device, dtype=torch.float32
+    )
+    indexer_weights_out = torch.empty(
+        (1, _FUSED_AUX_ROWS[2]), device=x.device, dtype=torch.float16
+    )
+    _sm70_dsv4_fused_fp16_aux_gemv_kernel[(_FUSED_AUX_N,)](
+        x,
+        fused_weight,
+        compressor_out,
+        indexer_compressor_out,
+        indexer_weights_out,
+        K=_K,
+        BLOCK_K=_BLOCK_K,
+        COMPRESSOR_N=_FUSED_AUX_ROWS[0],
+        INDEXER_COMPRESSOR_N=_FUSED_AUX_ROWS[1],
+        num_warps=_NUM_WARPS,
+    )
+    logger.info_once("DeepSeek V4 SM70 exact fused-FP16 C4 auxiliary GEMV enabled.")
+    return compressor_out, indexer_compressor_out, indexer_weights_out
 
 
 def _has_sm70_dsv4_gemv_contract(


### PR DESCRIPTION
> Public migration note (2026-08-27): this Draft is the public continuation of private PR #20, mirrored at exact head efd6f1f7adce23f4f0b2303684bad2c4d6f9d8b6 after public main resumed through #342. The original implementation notes and evidence are preserved below.
>
> This is the active follow-up to archived public #327; #327 will remain a historical Draft and must not be merged ahead of this newer evidence.

Purpose

- Fuse the three exact FP16 C4 auxiliary projections into one launch while
  preserving the existing FP32 FMA and reduction order.
- Keep the route default-off and mutually exclusive with FP13 until the strict
  endpoint quality gate passes.
- This private exact-FP16 route is distinct from the older approximate FP13
  experiment and does not duplicate another open private PR.

Test Plan

- Exercise real weights and 64 changing inputs under CUDA Graph replay.
- Compare all main and auxiliary outputs bitwise.
- Run the stabilized repeated GSM8K, HumanEval and LongBench gate before
  endpoint admission.

Test Result

- Focused host tests: 7 passed, 11 CUDA-skipped; related route tests: 24 passed.
- Changed-file pre-commit: passed.
- Current-source V100 operator screen: main 64/64 bitwise, auxiliaries 64/64
  bitwise, graph stable.
- Warm overlap: `105.894 -> 51.884 us/C4 layer`; cold overlap:
  `99.080 -> 74.040 us/C4 layer`.
- Full-model admission is intentionally pending while the FP8 tactic quality
  baseline is stabilized; this PR remains Draft.

AI assistance was used. Every changed line and final benchmark must be reviewed
by the human submitter.
