### PR TITLE
[Bugfix][SM70] Stabilize PP2 TP4 FP8 tactics

### DIFF
--- a/csrc/sm70_turbomind/ops/awq_sm70_gemm.cu
+++ b/csrc/sm70_turbomind/ops/awq_sm70_gemm.cu
@@ -1130,7 +1130,9 @@ bool fp8_0dot3_dense_selector_enabled() {
 
 bool fp8_safe_fast_selector_enabled() {
   const char* raw = std::getenv("VLLM_SM70_FP8_SAFE_FAST_SELECTOR");
-  return raw != nullptr && std::atoi(raw) != 0;
+  // Keep the default kernel and split-K accumulation tree while allowing the
+  // measured lane to select scheduling-only parameters such as swizzle.
+  return raw == nullptr || std::atoi(raw) != 0;
 }
 
 bool fp8_grouped_bmm_decode_enabled() {

--- a/csrc/sm70_turbomind/ops/awq_sm70_gemm.cu
+++ b/csrc/sm70_turbomind/ops/awq_sm70_gemm.cu
@@ -1082,6 +1082,11 @@ bool mxfp4_moe_broadcast_input_decode_enabled() {
   return raw == nullptr || std::atoi(raw) != 0;
 }
 
+bool mxfp4_moe_b1_safe_selector_enabled() {
+  const char* raw = std::getenv("VLLM_SM70_MXFP4_MOE_B1_SAFE_SELECTOR");
+  return raw == nullptr || std::atoi(raw) != 0;
+}
+
 bool mxfp4_moe_grouped_m8_enabled() {
   const char* raw = std::getenv("VLLM_SM70_MXFP4_MOE_GROUPED_M8");
   return raw != nullptr && std::atoi(raw) != 0;
@@ -1427,9 +1432,20 @@ turbomind::gemm::DispatchPolicy select_mxfp4_moe_dispatch_policy(
       mxfp4_moe_grouped_m8_fast_selector_enabled() && exact_grouped_m8) {
     return turbomind::gemm::DispatchPolicy::kMxfp4MoeGroupedM8Fast;
   }
-  return select_moe_dispatch_policy_impl(
+  auto policy = select_moe_dispatch_policy_impl(
       device, total_tokens, n, k, num_experts, group_size, stream,
       TuneKeyKind::kMxfp4Moe, mxfp4_tune_small_shapes_enabled());
+  const bool exact_dsv4_b1 =
+      total_tokens == 6 && num_experts == 6 && group_size == 32 &&
+      ((n == 1024 && k == 4096) || (n == 4096 && k == 512));
+  if (mxfp4_moe_b1_safe_selector_enabled() && exact_dsv4_b1 &&
+      (policy == turbomind::gemm::DispatchPolicy::kMeasure ||
+       policy == turbomind::gemm::DispatchPolicy::kReuse)) {
+    // Preserve the heuristic kernel and split-K accumulation tree. Dynamic
+    // measurement may still choose a scheduling-only swizzle.
+    return policy | turbomind::gemm::DispatchPolicy::kPreserveDefaultSplits;
+  }
+  return policy;
 }
 
 turbomind::gemm::DispatchPolicy select_nvfp4_moe_dispatch_policy(

--- a/docs/design/sm70_v100_migration_control.md
+++ b/docs/design/sm70_v100_migration_control.md
@@ -43978,6 +43978,14 @@ Interpretation:
   default kernel and split-K accumulation tree are retained. Explicit `=0`
   remains the unsafe diagnostic rollback. Host tests pass (`56` environment
   tests and `17` SM70 warmup tests), and changed-file pre-commit passes.
+- MXFP4 TurboMind B1 had the same unguarded dynamic-tuning problem. PR 21 adds
+  `VLLM_SM70_MXFP4_MOE_B1_SAFE_SELECTOR=1` for only the exact six-route
+  W13 `M6/N1024/K4096` and W2 `M6/N4096/K512` descriptors. It preserves the
+  heuristic kernel and split-K tree while allowing measured swizzle. The first
+  queued matrix disables MXFP4 tuning entirely to establish the deterministic
+  arithmetic oracle with the already-built extension; the new safe selector
+  requires a rebuilt extension and a second exact-output/performance pair
+  before it can replace that oracle.
 - Two matched unsafe-dynamic startup traces are queued to record the exact
   kernel/split/swizzle chosen on all eight ranks. A subsequent strict matrix
   compares fixed FP8, safe FP8, safe FP8 plus the MXFP4-QPN diagnostic, and a

--- a/docs/design/sm70_v100_migration_control.md
+++ b/docs/design/sm70_v100_migration_control.md
@@ -43932,3 +43932,59 @@ Interpretation:
   PR for this continuation use the private remote and the isolated branch
   `agent/private-v100-dsv4-pp2tp4-followup-20260826`; public upstream is
   fetch-only for this work.
+
+## 2026-08-27 DeepSeek V4 FP8 tactic quality stabilization
+
+- The latest quality-safe PP2 x TP4 CUDA-graph trace is under
+  `/data/models/v100-dsv4-0731-pp2tp4-quality-safe-nsys-20260827-r2/`.
+  Output/reference prefixes are exact. Nsight-instrumented replay averages
+  `15.410 ms/token`; this is profiler evidence, not a replacement for the
+  uninstrumented endpoint. Excluding pipeline dependency residency, the
+  two-stage service sums are FP8 dense `6.133 ms`, FP16 GEMV `2.328 ms`,
+  MXFP4 MoE `2.208 ms`, mHC `1.750 ms`, Q/KV `1.122 ms`, sparse MLA
+  `1.119 ms`, routing `1.003 ms`, TP all-reduce `0.852 ms`, and LM/sample
+  `0.481 ms`. The push all-reduce kernel itself averages about `8.18 us` per
+  call and is not the primary bottleneck.
+- A strict three-arm rerun on source `22a25e877f` invalidates the earlier
+  assumption that `73.539 token/s` plus GSM8K `64/64` was a reproducible
+  quality baseline. With WQA prescale disabled and MXFP4-QPN enabled, results
+  are GSM8K `61/64`, HumanEval `28/32`, LongBench `40.404`, and median
+  `74.628 token/s`. With WQA prescale enabled and MXFP4-QPN disabled, they are
+  `63/64`, `28/32`, `44.425`, and `70.729 token/s`. With both enabled, they
+  are `62/64`, `29/32`, `52.169`, and `73.560 token/s`. Both isolated
+  comparisons fail row-level quality and exact-output checks. None is an
+  admitted baseline or optimization.
+- The last arm has the same effective runtime routes as the previous
+  quality-safe endpoint, but the earlier run produced GSM8K `64/64`,
+  HumanEval `29/32`, and LongBench `44.740`. Server logs show that startup
+  performs process-local TurboMind measurement before caching launch specs;
+  TP coordination only copies each pipeline stage's TP-leader cache. Kernel,
+  split-K, or swizzle winners can therefore vary with startup timing. Different
+  split-K trees alter FP16 rounding and can change greedy token trajectories.
+- This is consistent with the older control rule in this document: bare
+  `VLLM_SM70_FP8_TUNE_SMALL_SHAPES=1` is diagnostic-only because full-model
+  output hashes can drift. The source nevertheless defaulted dynamic FP8
+  tuning on while defaulting `VLLM_SM70_FP8_SAFE_FAST_SELECTOR` off. Private
+  Draft PR 21 changes the safe selector default to on in both Python and C++.
+  Dynamic measurement may still select scheduling-only swizzle, but the
+  default kernel and split-K accumulation tree are retained. Explicit `=0`
+  remains the unsafe diagnostic rollback. Host tests pass (`56` environment
+  tests and `17` SM70 warmup tests), and changed-file pre-commit passes.
+- Two matched unsafe-dynamic startup traces are queued to record the exact
+  kernel/split/swizzle chosen on all eight ranks. A subsequent strict matrix
+  compares fixed FP8, safe FP8, safe FP8 plus exact MXFP4-QPN, and a second
+  identical candidate startup. Admission requires exact GSM8K rows,
+  HumanEval responses, LongBench rows, chat output and performance-output
+  hashes, plus zero correct-to-wrong transitions versus the pinned GSM8K
+  baseline. Until that matrix passes, PR 21 remains Draft and no speed result
+  from these routes is accepted.
+- Two exact operator candidates remain outside the endpoint. The current-source
+  joined FP16 C4 auxiliary route is bitwise for main and auxiliary outputs over
+  `64` changing inputs and moves warm overlap from `105.894` to
+  `51.884 us/layer` and cold overlap from `99.080` to `74.040 us/layer`.
+  The shared-gate prescale route, after matching the ordinary kernel,
+  split-K-7, and swizzle, is bitwise over `64` inputs and moves `62.229` to
+  `20.793 us/layer`. Its source matching is now limited to the exact
+  `M1/N1024/K4096` shared-gate shape so fused WQA retains existing semantics.
+  Both candidates still require the stabilized repeated dataset gate before
+  endpoint admission.

--- a/docs/design/sm70_v100_migration_control.md
+++ b/docs/design/sm70_v100_migration_control.md
@@ -43954,6 +43954,14 @@ Interpretation:
   are `62/64`, `29/32`, `52.169`, and `73.560 token/s`. Both isolated
   comparisons fail row-level quality and exact-output checks. None is an
   admitted baseline or optimization.
+- WQA prescale also slows the current matched endpoint by `1.068 token/s`, so
+  retaining it does not preserve speed. The MXFP4-QPN operator gate is a
+  bounded-error rather than bitwise result: `93/136` comparisons differ, with
+  minimum exact fraction `98.816%`, maximum absolute difference `0.001953125`,
+  and maximum relative L2 `4.69e-5`. Combined with the model-level
+  correct-to-wrong transition, this is insufficient for a default route.
+  Private Draft PR 21 therefore defaults both WQA prescale and MXFP4-QPN off;
+  explicit opt-ins remain available only for the strict diagnostic matrix.
 - The last arm has the same effective runtime routes as the previous
   quality-safe endpoint, but the earlier run produced GSM8K `64/64`,
   HumanEval `29/32`, and LongBench `44.740`. Server logs show that startup
@@ -43972,8 +43980,8 @@ Interpretation:
   tests and `17` SM70 warmup tests), and changed-file pre-commit passes.
 - Two matched unsafe-dynamic startup traces are queued to record the exact
   kernel/split/swizzle chosen on all eight ranks. A subsequent strict matrix
-  compares fixed FP8, safe FP8, safe FP8 plus exact MXFP4-QPN, and a second
-  identical candidate startup. Admission requires exact GSM8K rows,
+  compares fixed FP8, safe FP8, safe FP8 plus the MXFP4-QPN diagnostic, and a
+  second identical candidate startup. Admission requires exact GSM8K rows,
   HumanEval responses, LongBench rows, chat output and performance-output
   hashes, plus zero correct-to-wrong transitions versus the pinned GSM8K
   baseline. Until that matrix passes, PR 21 remains Draft and no speed result

--- a/tests/quantization/test_sm70_mxfp4_moe.py
+++ b/tests/quantization/test_sm70_mxfp4_moe.py
@@ -227,15 +227,15 @@ def test_mxfp4_sm70_direct_order_ignores_compacted_offsets():
     torch.testing.assert_close(offsets, torch.arange(7, dtype=torch.int32))
 
 
-def test_mxfp4_sm70_qpn_m1_is_default_with_rollback(monkeypatch):
+def test_mxfp4_sm70_qpn_m1_is_default_off_with_opt_in(monkeypatch):
     monkeypatch.delenv("VLLM_SM70_MXFP4_MOE_QPN_M1_DECODE", raising=False)
     envs.disable_envs_cache()
     try:
-        assert envs.VLLM_SM70_MXFP4_MOE_QPN_M1_DECODE
-
-        monkeypatch.setenv("VLLM_SM70_MXFP4_MOE_QPN_M1_DECODE", "0")
-        envs.disable_envs_cache()
         assert not envs.VLLM_SM70_MXFP4_MOE_QPN_M1_DECODE
+
+        monkeypatch.setenv("VLLM_SM70_MXFP4_MOE_QPN_M1_DECODE", "1")
+        envs.disable_envs_cache()
+        assert envs.VLLM_SM70_MXFP4_MOE_QPN_M1_DECODE
     finally:
         envs.disable_envs_cache()
 

--- a/tests/test_envs.py
+++ b/tests/test_envs.py
@@ -159,6 +159,12 @@ def test_sm70_concurrency_tuning_envs(
     monkeypatch.setenv(name, "0")
     assert environment_variables[name]() is False
 
+    name = "VLLM_SM70_MXFP4_MOE_B1_SAFE_SELECTOR"
+    monkeypatch.delenv(name, raising=False)
+    assert environment_variables[name]() is True
+    monkeypatch.setenv(name, "0")
+    assert environment_variables[name]() is False
+
     name = "VLLM_SM70_MXFP4_MOE_BROADCAST_INPUT_DECODE"
     monkeypatch.delenv(name, raising=False)
     assert environment_variables[name]() is True

--- a/tests/test_envs.py
+++ b/tests/test_envs.py
@@ -153,6 +153,12 @@ def test_sm70_concurrency_tuning_envs(
     monkeypatch.setenv(name, "0")
     assert environment_variables[name]() is False
 
+    name = "VLLM_SM70_FP8_SAFE_FAST_SELECTOR"
+    monkeypatch.delenv(name, raising=False)
+    assert environment_variables[name]() is True
+    monkeypatch.setenv(name, "0")
+    assert environment_variables[name]() is False
+
     name = "VLLM_SM70_MXFP4_MOE_BROADCAST_INPUT_DECODE"
     monkeypatch.delenv(name, raising=False)
     assert environment_variables[name]() is True

--- a/tests/test_envs.py
+++ b/tests/test_envs.py
@@ -149,9 +149,9 @@ def test_sm70_concurrency_tuning_envs(
 
     name = "VLLM_SM70_FP8_PRESCALED_M1_DECODE"
     monkeypatch.delenv(name, raising=False)
-    assert environment_variables[name]() is True
-    monkeypatch.setenv(name, "0")
     assert environment_variables[name]() is False
+    monkeypatch.setenv(name, "1")
+    assert environment_variables[name]() is True
 
     name = "VLLM_SM70_FP8_SAFE_FAST_SELECTOR"
     monkeypatch.delenv(name, raising=False)

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -256,6 +256,7 @@ if TYPE_CHECKING:
     VLLM_SM70_MXFP4_MOE_GROUPED_M8_FAST_SELECTOR: bool = True
     VLLM_SM70_MXFP4_MOE_DIRECT_TOP6_DECODE: bool = True
     VLLM_SM70_MXFP4_MOE_DIRECT_ORDER_DECODE: bool = True
+    VLLM_SM70_MXFP4_MOE_B1_SAFE_SELECTOR: bool = True
     VLLM_SM70_MXFP4_MOE_QPN_M1_DECODE: bool = False
     VLLM_SM70_MXFP4_MOE_BROADCAST_INPUT_DECODE: bool = True
     VLLM_SM70_DSV4_SPARSE_MLA_SPLITK_SWA: bool = False
@@ -2229,6 +2230,11 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # restores the stable-sort path.
     "VLLM_SM70_MXFP4_MOE_DIRECT_ORDER_DECODE": lambda: bool(
         int(os.getenv("VLLM_SM70_MXFP4_MOE_DIRECT_ORDER_DECODE", "1"))
+    ),
+    # Preserve the default kernel and split-K tree for the exact DSV4 B1
+    # TurboMind route while retaining dynamic swizzle selection.
+    "VLLM_SM70_MXFP4_MOE_B1_SAFE_SELECTOR": lambda: bool(
+        int(os.getenv("VLLM_SM70_MXFP4_MOE_B1_SAFE_SELECTOR", "1"))
     ),
     # Diagnostic route over the existing TurboMind E2M1/UE8M0 pack. It remains
     # default-off after the strict model-level quality comparison regressed.

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -155,7 +155,7 @@ if TYPE_CHECKING:
     VLLM_SM70_FP8_TUNE_SMALL_SHAPES: bool = True
     VLLM_SM70_FP8_COORDINATED_TUNING: bool = True
     VLLM_SM70_FP8_REUSE_IMPORTED_CACHE: bool = False
-    VLLM_SM70_FP8_SAFE_FAST_SELECTOR: bool = False
+    VLLM_SM70_FP8_SAFE_FAST_SELECTOR: bool = True
     VLLM_SM70_FP8_GROUPED_BMM_DECODE: bool = True
     VLLM_SM70_FP8_PREFILL_FAST_SELECTOR: bool = True
     VLLM_SM70_FP8_PREFILL_PRESCALED: bool = True
@@ -1767,7 +1767,7 @@ environment_variables: dict[str, Callable[[], Any]] = {
         int(os.getenv("VLLM_SM70_FP8_REUSE_IMPORTED_CACHE", "0"))
     ),
     "VLLM_SM70_FP8_SAFE_FAST_SELECTOR": lambda: bool(
-        int(os.getenv("VLLM_SM70_FP8_SAFE_FAST_SELECTOR", "0"))
+        int(os.getenv("VLLM_SM70_FP8_SAFE_FAST_SELECTOR", "1"))
     ),
     "VLLM_SM70_FP8_GROUPED_BMM_DECODE": lambda: bool(
         int(os.getenv("VLLM_SM70_FP8_GROUPED_BMM_DECODE", "1"))

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -159,7 +159,7 @@ if TYPE_CHECKING:
     VLLM_SM70_FP8_GROUPED_BMM_DECODE: bool = True
     VLLM_SM70_FP8_PREFILL_FAST_SELECTOR: bool = True
     VLLM_SM70_FP8_PREFILL_PRESCALED: bool = True
-    VLLM_SM70_FP8_PRESCALED_M1_DECODE: bool = True
+    VLLM_SM70_FP8_PRESCALED_M1_DECODE: bool = False
     VLLM_SM70_FP8_PREFILL_CUTLASS: bool = True
     VLLM_SM70_FP8_PRESERVE_DEFAULT_SPLITS: bool = True
     VLLM_SM70_FP8_PRESERVE_DEFAULT_SPLITS_ONLY: bool = False
@@ -256,7 +256,7 @@ if TYPE_CHECKING:
     VLLM_SM70_MXFP4_MOE_GROUPED_M8_FAST_SELECTOR: bool = True
     VLLM_SM70_MXFP4_MOE_DIRECT_TOP6_DECODE: bool = True
     VLLM_SM70_MXFP4_MOE_DIRECT_ORDER_DECODE: bool = True
-    VLLM_SM70_MXFP4_MOE_QPN_M1_DECODE: bool = True
+    VLLM_SM70_MXFP4_MOE_QPN_M1_DECODE: bool = False
     VLLM_SM70_MXFP4_MOE_BROADCAST_INPUT_DECODE: bool = True
     VLLM_SM70_DSV4_SPARSE_MLA_SPLITK_SWA: bool = False
     VLLM_SM70_DSV4_SPARSE_MLA_SPLITK_C4: bool = False
@@ -1779,7 +1779,7 @@ environment_variables: dict[str, Callable[[], Any]] = {
         int(os.getenv("VLLM_SM70_FP8_PREFILL_PRESCALED", "1"))
     ),
     "VLLM_SM70_FP8_PRESCALED_M1_DECODE": lambda: bool(
-        int(os.getenv("VLLM_SM70_FP8_PRESCALED_M1_DECODE", "1"))
+        int(os.getenv("VLLM_SM70_FP8_PRESCALED_M1_DECODE", "0"))
     ),
     "VLLM_SM70_FP8_PRESERVE_DEFAULT_SPLITS": lambda: bool(
         int(os.getenv("VLLM_SM70_FP8_PRESERVE_DEFAULT_SPLITS", "1"))
@@ -2230,10 +2230,10 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "VLLM_SM70_MXFP4_MOE_DIRECT_ORDER_DECODE": lambda: bool(
         int(os.getenv("VLLM_SM70_MXFP4_MOE_DIRECT_ORDER_DECODE", "1"))
     ),
-    # Consume the existing TurboMind E2M1/UE8M0 pack directly for the exact
-    # six-route B1 W13/W2 tensors. Set to 0 to retain the dense-stage path.
+    # Diagnostic route over the existing TurboMind E2M1/UE8M0 pack. It remains
+    # default-off after the strict model-level quality comparison regressed.
     "VLLM_SM70_MXFP4_MOE_QPN_M1_DECODE": lambda: bool(
-        int(os.getenv("VLLM_SM70_MXFP4_MOE_QPN_M1_DECODE", "1"))
+        int(os.getenv("VLLM_SM70_MXFP4_MOE_QPN_M1_DECODE", "0"))
     ),
     "VLLM_SM70_MXFP4_MOE_BROADCAST_INPUT_DECODE": lambda: bool(
         int(os.getenv("VLLM_SM70_MXFP4_MOE_BROADCAST_INPUT_DECODE", "1"))

--- a/vllm/model_executor/layers/quantization/fp8.py
+++ b/vllm/model_executor/layers/quantization/fp8.py
@@ -1239,7 +1239,7 @@ class Fp8LinearMethod(LinearMethodBase):
                         persistent=False,
                     )
                     logger.info_once(
-                        "Exact SM70 fused-WQA/WKV prescaled decode path enabled."
+                        "Diagnostic SM70 fused-WQA/WKV prescaled decode path enabled."
                     )
             if (
                 envs.VLLM_SM70_FP8_PREFILL_FAST_SELECTOR

--- a/vllm/model_executor/layers/quantization/mxfp4_sm70_moe.py
+++ b/vllm/model_executor/layers/quantization/mxfp4_sm70_moe.py
@@ -9,7 +9,6 @@ UE8M0 scales. It never materializes an FP16/BF16 expert-weight copy.
 
 from __future__ import annotations
 
-import os
 from typing import Final
 
 import torch
@@ -51,21 +50,15 @@ def _mxfp4_qpn_m1_op_available() -> bool:
 
 
 def _mxfp4_qpn_m1_extension_enabled() -> bool:
-    """Resolve the default-on route without breaking an older extension."""
+    """Resolve the diagnostic route and fail closed without its extension."""
     if not envs.VLLM_SM70_MXFP4_MOE_QPN_M1_DECODE:
         return False
     if _mxfp4_qpn_m1_op_available():
         return True
-    if os.getenv(_MXFP4_QPN_M1_ENV) is not None:
-        raise RuntimeError(
-            "The explicitly enabled SM70 MXFP4 QPN M1 route requires the "
-            f"source-built {_MXFP4_QPN_M1_OP} operator."
-        )
-    logger.warning_once(
-        "The default SM70 MXFP4 QPN M1 route is unavailable in the loaded "
-        "vllm._C; retaining the TurboMind dense-stage path."
+    raise RuntimeError(
+        "The explicitly enabled SM70 MXFP4 QPN M1 route requires the "
+        f"source-built {_MXFP4_QPN_M1_OP} operator."
     )
-    return False
 
 
 def _mxfp4_active_expert_b1_enabled() -> bool:

--- a/vllm/model_executor/layers/quantization/mxfp4_sm70_moe.py
+++ b/vllm/model_executor/layers/quantization/mxfp4_sm70_moe.py
@@ -826,7 +826,7 @@ class Mxfp4SM70MoEMethod(Mxfp4MoEMethod):
                 layer.sm70_mxfp4_hidden_size,
             )
             logger.info_once(
-                "Default SM70 MXFP4 QPN M1 route enabled for the exact "
+                "Diagnostic SM70 MXFP4 QPN M1 route enabled for the exact "
                 "TP4 six-route W13/W2 tensor contract."
             )
             return output


### PR DESCRIPTION
> Public migration note (2026-08-27): this Draft is the public continuation of private PR #21, mirrored at exact head c015a5695c61bd87f3cc39a97ec8bcedac45645e after public main resumed through #342. The original implementation notes and evidence are preserved below.

Purpose

- Make DeepSeek V4 PP2 x TP4 FP8 launch arithmetic reproducible across
  pipeline stages and process restarts.
- Keep dynamic scheduling search while preserving the default kernel and
  split-K accumulation tree by default.
- Treat any output-quality regression as a hard admission failure.
- This is private V100-specific follow-up work and does not duplicate another
  open private PR.

Test Plan

- Compare two matched unsafe-dynamic restarts and retain exact M=1 launch
  evidence only when the trace filter reaches decode descriptors.
- Compare fixed FP8, safe FP8, diagnostic MXFP4-QPN, and an identical candidate
  restart.
- Require exact output hashes and row-level GSM8K/HumanEval/LongBench equality
  before admission.
- Build the SM70 extension, audit every embedded cubin, and run focused
  warmup/cache and fresh-import tests.

Test Result

- `tests/test_envs.py`: 56 passed.
- `tests/quantization/test_sm70_warmup.py`: 17 passed.
- The expanded FP8/MXFP4/default-policy set: 107 passed, 4 CUDA-skipped.
- The scoped MXFP4 B1 safe-selector set: 84 passed, 4 CUDA-skipped; its changed
  CUDA translation unit compiles for SM70.
- The full `_C` target built successfully (`50/50`). Extension SHA256 is
  `139aaf8e2d28d497c53bbd6ea4473523ebaf0802a978294135e8e1f15745debb`;
  all 38 embedded cubins are `sm_70` and none targets another architecture.
- A fresh interpreter binds this branch to that task-owned extension and sees
  the intended absent-environment defaults: FP8 safe selector on, WQA
  prescaled-M1 off, MXFP4 B1 safe selector on, and MXFP4-QPN off.
- Changed-file pre-commit: passed.
- The implementation currently defaults WQA prescale and MXFP4-QPN off. The
  latter remains rejected after 93/136 non-bitwise operator comparisons plus
  a model-level correct-to-wrong transition. The completed deterministic arm
  now also rejects the WQA-default-off change; it must be reverted or its
  quality root repaired before this Draft can merge.
- The exact DSV4 MXFP4 B1 TurboMind descriptors now preserve their heuristic
  kernel/split-K tree while retaining measured swizzle. Its planned
  64-pattern, fresh-process operator/restart gate was cancelled before launch
  when testing was stopped; it is not admitted.
- Two matched current-source unsafe-dynamic restarts measured `73.662` and
  `73.592 token/s`; within each restart all three performance outputs match,
  but the hashes differ across restarts, as do the chat outputs. The first
  diagnostic filter spent its trace quota on prefill, so it is explicitly not
  claimed as M=1 trace evidence. An older exact M=1 trace of the same selector
  mechanism records multiple split-K trees on three of five dense descriptors
  (`5/6`, `2/4`, and `1/2`).
- Testing was stopped on request after the fixed-arithmetic arm completed.
  That arm records GSM8K `62/64` with zero invalid answers, HumanEval `29/32`,
  LongBench `40.320`, and median `64.132 token/s`. Pinned-correct GSM item 37
  regresses from `2` to `0` with no compensating fix, so the hard quality gate
  fails. The safe arm was interrupted before datasets/performance; diagnostic,
  restart, and one-GPU follow-ups did not run. All owned GPU processes and
  queues were cleaned. This PR remains Draft and non-admitted.

AI assistance was used. Every changed line and the final evidence must be
reviewed by the human submitter.
