### PR TITLE
[Perf][SM70] Optimize Qwen3.8 Flash Next prefill

### DIFF
--- a/csrc/sm70_turbomind/ops/awq_sm70_gemm.cu
+++ b/csrc/sm70_turbomind/ops/awq_sm70_gemm.cu
@@ -8583,8 +8583,11 @@ void nvfp4_moe_dense_stage_sm70_out(torch::Tensor out, torch::Tensor input,
       input.size(0) > kNvfp4LegacyCompactGroups && num_experts == 256 &&
       ((k == 2048 && (n == 1024 || n == 512 || n == 256)) ||
        (n == 2048 && (k == 512 || k == 256 || k == 128)));
+  const bool exact_qwen4_exp_prefill_shape =
+      input.size(0) > kNvfp4LegacyCompactGroups && num_experts == 512 &&
+      ((k == 2560 && n == 320) || (k == 160 && n == 2560));
   if (vllm::awq_sm70::nvfp4_moe_grouped_prefill_enabled() &&
-      exact_qwen36_prefill_shape) {
+      (exact_qwen36_prefill_shape || exact_qwen4_exp_prefill_shape)) {
     static std::atomic<unsigned> logged_nvfp4_grouped_prefill{0u};
     maybe_log_sm70_moe_route_once(
         logged_nvfp4_grouped_prefill,

--- a/docs/design/sm70_v100_migration_control.md
+++ b/docs/design/sm70_v100_migration_control.md
@@ -68,6 +68,40 @@ Goal:
   and no non-finite values. A 128-column tile is rejected before execution
   because its `139264`-byte shared-memory requirement exceeds V100's
   `98304`-byte limit.
+- The next hotspot audit inspected the cached SM70 PTX instead of screening
+  more launch shapes blindly. Both QSA scoring kernels contain no `mma`/`wmma`
+  instructions: selected attention compiles to roughly 1026 static FP32 FMA
+  instructions, and the four-head D128 index scorer compiles to roughly 2048.
+  The latter grows with all visible compressed blocks and explains most of the
+  additional 131K decay.
+- A D256 selected-attention WMMA prototype is rejected. It has real SM70 HMMA,
+  no local-memory spill, and passes the resource gate, but measures only
+  `51.808ms` versus `55.682ms` at 8192 rows (`1.0748x`) and its output relative
+  L2 is `0.5627`. At 512 rows it is only `1.2532x`. It is neither correct nor
+  fast enough to justify a production integration or model restart.
+- The retained long-indexer candidate gathers one request's paged FP16 MQA
+  keys once, applies a cuBLAS FP16-input/FP32-output Tensor Core GEMM in a
+  bounded workspace, and fuses per-head ReLU, head sum, visibility and scale
+  into one Triton epilogue. At 1024 rows and 131K context, scoring including
+  paged gather moves from `35.767ms` to `2.108ms` (`16.964x`), with maximum
+  absolute error `8.11e-6` and relative L2 `2.90e-7`. The complete
+  score/top-k/expand path moves from `38.792ms` to `3.118ms` (`12.441x`).
+  Random stress selection sets are exact for 1023/1024 rows; the sole mismatch
+  is a boundary near-tie, and final sparse-attention cosine is `0.9999992`.
+  Production admission is limited to exact SM70, FP16 `[rows,4,128]`, FP16
+  `[pages,page,1,128]`, one request, at least 512 rows, and at least 1,048,576
+  row-column score elements; decode, short work and generic batches retain the
+  paged Triton route. The measured crossover is `0.733x` at 1K context,
+  `2.164x` at 2K, `4.900x` at 8K, `8.064x` at 16K and `11.102x` at 32K. A real
+  TP4 token-hash and quality gate remains required before this candidate is
+  accepted or reported as an endpoint improvement.
+- Raising the NVFP4 MoE tuning limit is rejected independently of the model
+  gate. Real layer-0 weights and the exact 8192-token/top-10 routing shape
+  measure default W13/W2 at `4.320/2.382ms` (`31.07/28.18 TFLOP/s`) and the
+  measured policy at `4.343/2.381ms`; combined tuning is `0.9966x`. The real
+  router distribution is highly skewed (0/58/160/2150 minimum/median/mean/
+  maximum rows per expert), but TurboMind's measured dispatch does not improve
+  it. Do not spend another startup autotuning this same shape.
 - No new GDN candidate is claimed by this follow-up. A cold standalone 8192
   token original-TileLang probe under `/usr` CUDA attempted to rebuild the
   TileLang cumsum kernel and failed in the installed TileLang BF16 fallback

--- a/docs/design/sm70_v100_migration_control.md
+++ b/docs/design/sm70_v100_migration_control.md
@@ -24,6 +24,55 @@ Goal:
   sampling, and normal MoE architecture wherever possible.
 - Do not carry unsafe quality-regressing routes into the main path.
 
+## Qwen3.8 Flash Next NVFP4 prefill acceptance, 2026-08-27
+
+- Review scope: Draft PR #23 on
+  `codex/v100-qwen38-flash-next-prefill-20260827-000848`, stacked on the
+  Qwen3.8 Flash Next bring-up branch. This scope is prefill-only; decode and
+  MTP acceptance remain separate work.
+- Frozen route: four V100-SXM2-32GB GPUs, TP4/PP1, V2 engine, ModelOpt NVFP4,
+  FP16 activations and KV cache, MTP off, `FLASH_ATTN_V100`, FlashQLA-SM70 GDN
+  prefill, pinned-host PLE, prefix caching off, chunked prefill on, and
+  `VLLM_COMPILE` with PIECEWISE CUDA graphs.
+- The matched 8192-token candidate has mean pure prefill time `2.315786s`, or
+  `3537.46 tok/s`, and mean TTFT `2.322317s`. The earlier same-route baseline
+  has mean pure prefill time `21.339760s`, or `383.88 tok/s`: a `9.2149x`
+  speedup and `89.15%` latency reduction. The baseline generated 512 tokens
+  and used FULL_AND_PIECEWISE while the candidate generated 16 tokens and used
+  PIECEWISE; only request-metric prefill time is compared, and prefill uses the
+  PIECEWISE dispatch in both runs.
+- The accepted change admits the two real 512-expert Flash Next prefill GEMM
+  contracts to grouped TurboMind NVFP4 execution, uses four QSA sparse-kernel
+  warps for exact SM70 prefill shapes, and permits an absolute prebuilt
+  FlashQLA-SM70 extension path so all TP ranks avoid redundant JIT builds.
+  Focused validation is `15 passed, 5 skipped`; exact QSA probes are bitwise
+  equal and improve the 8192-token kernel profile from `1320.204ms` to
+  `85.261ms`.
+- Long-context pure-prefill results from one guarded model startup are:
+  32768 tokens `10.740389s` / `3050.91 tok/s`, 65536 tokens `25.020538s` /
+  `2619.29 tok/s`, and 131000 tokens `63.960919s` / `2048.13 tok/s`. The 32K
+  and 64K repeat token hashes are stable, and the arithmetic and Chinese
+  quality outputs match the accepted 8K run exactly.
+- At `gpu_memory_utilization=0.85` and `max_model_len=140000`, vLLM reports
+  `3.09 GiB` available KV cache, `250028` token capacity, and `1.79x` 140K
+  concurrency. Measured peak device use is `29090 MiB` (`28.408 GiB`) per
+  rank; minimum host `MemAvailable` is `47.912 GiB`, with `247.921 GiB` swap
+  still free.
+- Do not repeat the rejected `gpu_memory_utilization=0.82` 140K startup. It
+  fails cleanly before requests because `1.08 GiB` KV cache is below the
+  required `1.73 GiB`, with an estimated maximum length of 86800 tokens. The
+  single `0.85` retry passed the capacity gate and all planned 32K/64K/131K
+  cases, so no third startup is needed.
+- Retained local evidence is under
+  `.artifacts/qwen38_flash_next_prefill_20260827/results/`, notably
+  `grouped-v1-piecewise-8192x16.json` and
+  `grouped-v1-piecewise-longctx-u085.json`. The corresponding PR evidence is
+  recorded in the
+  [8K result](https://github.com/yangzhuxinyzx/1Cat-vLLM-private/pull/23#issuecomment-5436515073)
+  and
+  [long-context result](https://github.com/yangzhuxinyzx/1Cat-vLLM-private/pull/23#issuecomment-5437096030)
+  comments.
+
 ## Active MRV2 DFlash2 campaign, 2026-08-20
 
 - Integration base: `onecat/main@7aede2cf010d92815c9d7bff25867b4fa009b6cb`.

--- a/docs/design/sm70_v100_migration_control.md
+++ b/docs/design/sm70_v100_migration_control.md
@@ -53,6 +53,21 @@ Goal:
   `2619.29 tok/s`, and 131000 tokens `63.960919s` / `2048.13 tok/s`. The 32K
   and 64K repeat token hashes are stable, and the arithmetic and Chinese
   quality outputs match the accepted 8K run exactly.
+- A follow-up SM70-only QSA tile reduction from 64 to 32 columns passed the
+  matched long-context gate. Pure-prefill time is `9.044346s` at 32K,
+  `21.517608s` at 64K, and `56.609353s` at 131K, corresponding to
+  `3623.04`, `3045.69`, and `2314.11 tok/s`. Relative to the preceding
+  candidate this is a `1.1875x`, `1.1628x`, and `1.1299x` speedup, with
+  latency reductions of `15.79%`, `14.00%`, and `11.49%` respectively. All
+  five quality/performance case token hashes remain exactly equal to the
+  matched baseline.
+- Exact-shape QSA microbenchmarks explain the end-to-end change. At 8192 rows,
+  the 32-column tile measures `56.723ms` versus `92.730ms` for 64 columns
+  (`1.6348x`); at 512 rows with four splits it measures `4.397ms` versus
+  `6.385ms` (`1.4520x`). Both have maximum FP16 difference `0.0001220703125`
+  and no non-finite values. A 128-column tile is rejected before execution
+  because its `139264`-byte shared-memory requirement exceeds V100's
+  `98304`-byte limit.
 - At `gpu_memory_utilization=0.85` and `max_model_len=140000`, vLLM reports
   `3.09 GiB` available KV cache, `250028` token capacity, and `1.79x` 140K
   concurrency. Measured peak device use is `29090 MiB` (`28.408 GiB`) per
@@ -66,7 +81,9 @@ Goal:
 - Retained local evidence is under
   `.artifacts/qwen38_flash_next_prefill_20260827/results/`, notably
   `grouped-v1-piecewise-8192x16.json` and
-  `grouped-v1-piecewise-longctx-u085.json`. The corresponding PR evidence is
+  `grouped-v1-piecewise-longctx-u085.json`. The QSA follow-up is retained as
+  `grouped-v2-qsa-bn32-longctx-u085.json`, with microbenchmarks in
+  `qsa-blockn-sweep-{8192,512-split4}.json`. The corresponding PR evidence is
   recorded in the
   [8K result](https://github.com/yangzhuxinyzx/1Cat-vLLM-private/pull/23#issuecomment-5436515073)
   and

--- a/docs/design/sm70_v100_migration_control.md
+++ b/docs/design/sm70_v100_migration_control.md
@@ -68,6 +68,12 @@ Goal:
   and no non-finite values. A 128-column tile is rejected before execution
   because its `139264`-byte shared-memory requirement exceeds V100's
   `98304`-byte limit.
+- No new GDN candidate is claimed by this follow-up. A cold standalone 8192
+  token original-TileLang probe under `/usr` CUDA attempted to rebuild the
+  TileLang cumsum kernel and failed in the installed TileLang BF16 fallback
+  headers. The guarded full-model run reused the accepted production cache and
+  route successfully. Do not treat the standalone failure as a GDN runtime
+  regression or repeat it without the source-matched TileLang toolchain/cache.
 - At `gpu_memory_utilization=0.85` and `max_model_len=140000`, vLLM reports
   `3.09 GiB` available KV cache, `250028` token capacity, and `1.79x` 140K
   concurrency. Measured peak device use is `29090 MiB` (`28.408 GiB`) per

--- a/flash_qla/ops/gated_delta_rule/chunk/sm70/fused_fwd.py
+++ b/flash_qla/ops/gated_delta_rule/chunk/sm70/fused_fwd.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import importlib
+import importlib.util
 import os
 from pathlib import Path
 
@@ -15,6 +16,7 @@ _EXT_LOAD_ERROR: Exception | None = None
 _PREBUILT_EXTENSION = (
     "flash_qla.ops.gated_delta_rule.chunk.sm70.flash_qla_sm70_gdn_strided"
 )
+_PREBUILT_EXTENSION_PATH_ENV = "FLASH_QLA_SM70_PREBUILT_EXTENSION_PATH"
 
 # Avoid CUDA-device auto-detection while distributed workers are initializing.
 # The fallback JIT supports both architectures implemented by this source file.
@@ -35,6 +37,25 @@ def _load_ext():
         ) from _EXT_LOAD_ERROR
     if not torch.cuda.is_available():
         raise RuntimeError("SM70 FlashQLA backend requires CUDA.")
+
+    prebuilt_path = os.environ.get(_PREBUILT_EXTENSION_PATH_ENV)
+    if prebuilt_path:
+        path = Path(prebuilt_path).expanduser()
+        try:
+            if not path.is_file():
+                raise FileNotFoundError(path)
+            spec = importlib.util.spec_from_file_location(_PREBUILT_EXTENSION, path)
+            if spec is None or spec.loader is None:
+                raise ImportError(f"Cannot load extension spec from {path}")
+            module = importlib.util.module_from_spec(spec)
+            spec.loader.exec_module(module)
+            _EXT = module
+            return _EXT
+        except Exception as exc:
+            _EXT_LOAD_ERROR = exc
+            raise RuntimeError(
+                f"Failed to load {_PREBUILT_EXTENSION_PATH_ENV}={path}."
+            ) from exc
 
     try:
         _EXT = importlib.import_module(_PREBUILT_EXTENSION)

--- a/tests/models/qwen4_exp/test_qsa_ops.py
+++ b/tests/models/qwen4_exp/test_qsa_ops.py
@@ -1,7 +1,11 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import torch
+
+from vllm.models.qwen4_exp.nvidia.ops import qsa as qsa_ops
 from vllm.models.qwen4_exp.nvidia.ops.qsa import (
+    _qsa_indexer_cublas_shape_supported,
     _qsa_sparse_launch_profile,
 )
 
@@ -15,3 +19,48 @@ def test_sm70_qsa_prefill_uses_narrow_tiles_and_four_warps():
 def test_non_sm70_qsa_prefill_keeps_gb300_profile():
     assert _qsa_sparse_launch_profile(512, 8, False) == (64, 4, 2)
     assert _qsa_sparse_launch_profile(8192, 8, False) == (64, 1, 2)
+
+
+def test_qsa_indexer_cublas_accepts_only_exact_single_request_shape():
+    query = torch.empty(8, 4, 128, dtype=torch.float16)
+    cache = torch.empty(2, 400, 1, 128, dtype=torch.float16)
+    page_table = torch.empty(1, 2, dtype=torch.int32)
+
+    assert _qsa_indexer_cublas_shape_supported(query, cache, page_table)
+    assert not _qsa_indexer_cublas_shape_supported(
+        query.to(torch.bfloat16), cache, page_table
+    )
+    assert not _qsa_indexer_cublas_shape_supported(
+        query, cache, page_table.expand(2, -1)
+    )
+    assert not _qsa_indexer_cublas_shape_supported(query[:, :3], cache, page_table)
+
+
+def test_qsa_indexer_cublas_does_not_capture_decode_rows(monkeypatch):
+    cache = torch.empty(2, 400, 1, 128, dtype=torch.float16)
+    page_table = torch.empty(1, 2, dtype=torch.int32)
+    monkeypatch.setattr(qsa_ops, "_SM70_INDEXER_CUBLAS", True)
+    monkeypatch.setattr(qsa_ops, "_SM70_INDEXER_CUBLAS_MIN_ROWS", 256)
+    monkeypatch.setattr(
+        qsa_ops.current_platform,
+        "is_device_capability",
+        lambda capability: capability == 70,
+    )
+
+    assert qsa_ops._use_sm70_qsa_indexer_cublas(
+        torch.empty(256, 4, 128, dtype=torch.float16), cache, page_table
+    )
+    assert not qsa_ops._use_sm70_qsa_indexer_cublas(
+        torch.empty(255, 4, 128, dtype=torch.float16), cache, page_table
+    )
+
+
+def test_qsa_indexer_cublas_requires_enough_score_work(monkeypatch):
+    monkeypatch.setattr(
+        qsa_ops,
+        "_SM70_INDEXER_CUBLAS_MIN_SCORE_ELEMENTS",
+        1024**2,
+    )
+
+    assert not qsa_ops._qsa_indexer_cublas_work_supported(1024, 512)
+    assert qsa_ops._qsa_indexer_cublas_work_supported(2048, 512)

--- a/tests/models/qwen4_exp/test_qsa_ops.py
+++ b/tests/models/qwen4_exp/test_qsa_ops.py
@@ -1,0 +1,16 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from vllm.models.qwen4_exp.nvidia.ops.qsa import (
+    _qsa_sparse_launch_profile,
+)
+
+
+def test_sm70_qsa_prefill_uses_four_warps():
+    assert _qsa_sparse_launch_profile(512, 8, True) == (64, 4, 4)
+    assert _qsa_sparse_launch_profile(8192, 8, True) == (64, 1, 4)
+
+
+def test_non_sm70_qsa_prefill_keeps_gb300_profile():
+    assert _qsa_sparse_launch_profile(512, 8, False) == (64, 4, 2)
+    assert _qsa_sparse_launch_profile(8192, 8, False) == (64, 1, 2)

--- a/tests/models/qwen4_exp/test_qsa_ops.py
+++ b/tests/models/qwen4_exp/test_qsa_ops.py
@@ -6,9 +6,10 @@ from vllm.models.qwen4_exp.nvidia.ops.qsa import (
 )
 
 
-def test_sm70_qsa_prefill_uses_four_warps():
-    assert _qsa_sparse_launch_profile(512, 8, True) == (64, 4, 4)
-    assert _qsa_sparse_launch_profile(8192, 8, True) == (64, 1, 4)
+def test_sm70_qsa_prefill_uses_narrow_tiles_and_four_warps():
+    assert _qsa_sparse_launch_profile(511, 8, True) == (64, 4, 4)
+    assert _qsa_sparse_launch_profile(512, 8, True) == (32, 4, 4)
+    assert _qsa_sparse_launch_profile(8192, 8, True) == (32, 1, 4)
 
 
 def test_non_sm70_qsa_prefill_keeps_gb300_profile():

--- a/vllm/models/qwen4_exp/nvidia/ops/qsa.py
+++ b/vllm/models/qwen4_exp/nvidia/ops/qsa.py
@@ -5,14 +5,28 @@
 from __future__ import annotations
 
 import math
+import os
 
 import torch
 
+from vllm.logger import init_logger
 from vllm.platforms import current_platform
 from vllm.triton_utils import HAS_TRITON, tl, triton
 
+logger = init_logger(__name__)
+
 _LOGITS_WORKSPACE_BYTES = 128 * 1024 * 1024
 _TOPK_WORKSPACE_BYTES = 1024 * 1024
+_SM70_INDEXER_CUBLAS = os.getenv("VLLM_SM70_QSA_INDEXER_CUBLAS", "1") == "1"
+_SM70_INDEXER_SCORE_TILE_BYTES = (
+    int(os.getenv("VLLM_SM70_QSA_INDEXER_SCORE_TILE_MB", "64")) * 1024 * 1024
+)
+_SM70_INDEXER_CUBLAS_MIN_ROWS = int(
+    os.getenv("VLLM_SM70_QSA_INDEXER_CUBLAS_MIN_ROWS", "512")
+)
+_SM70_INDEXER_CUBLAS_MIN_SCORE_ELEMENTS = int(
+    os.getenv("VLLM_SM70_QSA_INDEXER_CUBLAS_MIN_SCORE_ELEMENTS", str(1024**2))
+)
 
 
 @triton.jit
@@ -116,6 +130,124 @@ def _qsa_mqa_paged_kernel(
             tl.where(page_valid, score, -float("inf")),
             mask=live & (columns < num_columns),
         )
+
+
+@triton.jit
+def _qsa_visible_blocks_kernel(
+    token_to_req_ptr,
+    query_positions_ptr,
+    sequence_lengths_ptr,
+    visible_blocks_ptr,
+    rows,
+    num_requests,
+    COMPRESS_RATIO: tl.constexpr,
+) -> None:
+    row = tl.program_id(0)
+    request = tl.load(token_to_req_ptr + row, mask=row < rows, other=-1)
+    valid_request = (request >= 0) & (request < num_requests)
+    safe_request = tl.minimum(tl.maximum(request, 0), num_requests - 1)
+    query_position = tl.load(query_positions_ptr + row, mask=row < rows, other=-1)
+    sequence_length = tl.load(
+        sequence_lengths_ptr + safe_request,
+        mask=(row < rows) & valid_request,
+        other=0,
+    )
+    visible = tl.minimum(
+        (query_position + 1) // COMPRESS_RATIO,
+        sequence_length // COMPRESS_RATIO,
+    )
+    tl.store(
+        visible_blocks_ptr + row,
+        tl.where(valid_request, tl.maximum(visible, 0), 0),
+        mask=row < rows,
+    )
+
+
+@triton.jit
+def _qsa_gather_single_request_keys_kernel(
+    cache_ptr,
+    page_table_ptr,
+    keys_ptr,
+    valid_ptr,
+    stride_cache_page,
+    stride_cache_token,
+    stride_cache_dim,
+    stride_table_page,
+    stride_keys_row,
+    columns,
+    num_pages,
+    PAGE_SIZE: tl.constexpr,
+    PAGE_TABLE_WIDTH: tl.constexpr,
+    HEAD_DIM: tl.constexpr,
+    BLOCK_D: tl.constexpr,
+) -> None:
+    column = tl.program_id(0)
+    dims = tl.arange(0, BLOCK_D)
+    logical_page = column // PAGE_SIZE
+    page_offset = column % PAGE_SIZE
+    physical_page = tl.load(
+        page_table_ptr + logical_page * stride_table_page,
+        mask=(column < columns) & (logical_page < PAGE_TABLE_WIDTH),
+        other=-1,
+    )
+    valid = (column < columns) & (physical_page >= 0) & (physical_page < num_pages)
+    safe_page = tl.maximum(physical_page, 0).to(tl.int64)
+    key = tl.load(
+        cache_ptr
+        + safe_page * stride_cache_page
+        + page_offset * stride_cache_token
+        + dims * stride_cache_dim,
+        mask=valid & (dims < HEAD_DIM),
+        other=0.0,
+    )
+    tl.store(
+        keys_ptr + column * stride_keys_row + dims,
+        key,
+        mask=(column < columns) & (dims < HEAD_DIM),
+    )
+    tl.store(valid_ptr + column, valid, mask=column < columns)
+
+
+@triton.jit
+def _qsa_relu_headsum_visible_kernel(
+    score_ptr,
+    visible_ptr,
+    key_valid_ptr,
+    logits_ptr,
+    stride_score_row,
+    stride_score_column,
+    stride_logits_row,
+    width,
+    column_start,
+    score_divisor,
+    NUM_HEADS: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+) -> None:
+    row = tl.program_id(0)
+    columns = tl.program_id(1) * BLOCK_N + tl.arange(0, BLOCK_N)
+    absolute_columns = column_start + columns
+    visible = tl.load(visible_ptr + row)
+    key_valid = tl.load(
+        key_valid_ptr + absolute_columns,
+        mask=columns < width,
+        other=0,
+    ).to(tl.int1)
+    live = (columns < width) & (absolute_columns < visible) & key_valid
+    score = tl.zeros((BLOCK_N,), dtype=tl.float32)
+    for head in range(NUM_HEADS):
+        values = tl.load(
+            score_ptr
+            + (row * NUM_HEADS + head) * stride_score_row
+            + columns * stride_score_column,
+            mask=columns < width,
+            other=0.0,
+        ).to(tl.float32)
+        score += tl.maximum(values, 0.0)
+    tl.store(
+        logits_ptr + row * stride_logits_row + absolute_columns,
+        tl.where(live, score / score_divisor, -float("inf")),
+        mask=columns < width,
+    )
 
 
 @triton.jit
@@ -682,6 +814,144 @@ def qsa_mqa_paged(
     return logits, visible_blocks
 
 
+def _qsa_indexer_cublas_shape_supported(
+    q: torch.Tensor,
+    k_cache: torch.Tensor,
+    page_table: torch.Tensor,
+) -> bool:
+    """Whether the exact Qwen3.8 single-request index shape can use cuBLAS."""
+
+    return (
+        q.dtype == torch.float16
+        and k_cache.dtype == torch.float16
+        and q.ndim == 3
+        and q.shape[1:] == (4, 128)
+        and k_cache.ndim == 4
+        and k_cache.shape[2:] == (1, 128)
+        and page_table.ndim == 2
+        and page_table.shape[0] == 1
+    )
+
+
+def _use_sm70_qsa_indexer_cublas(
+    q: torch.Tensor,
+    k_cache: torch.Tensor,
+    page_table: torch.Tensor,
+) -> bool:
+    return (
+        _SM70_INDEXER_CUBLAS
+        and current_platform.is_device_capability(70)
+        and q.shape[0] >= _SM70_INDEXER_CUBLAS_MIN_ROWS
+        and _qsa_indexer_cublas_shape_supported(q, k_cache, page_table)
+    )
+
+
+def _qsa_indexer_cublas_work_supported(rows: int, columns: int) -> bool:
+    return rows * columns >= _SM70_INDEXER_CUBLAS_MIN_SCORE_ELEMENTS
+
+
+def _qsa_visible_blocks(
+    token_to_req: torch.Tensor,
+    query_positions: torch.Tensor,
+    sequence_lengths: torch.Tensor,
+    compress_ratio: int,
+) -> torch.Tensor:
+    rows = query_positions.shape[0]
+    visible = torch.empty(rows, dtype=torch.int32, device=query_positions.device)
+    if rows:
+        _qsa_visible_blocks_kernel[(rows,)](
+            token_to_req,
+            query_positions,
+            sequence_lengths,
+            visible,
+            rows,
+            sequence_lengths.shape[0],
+            COMPRESS_RATIO=compress_ratio,
+            num_warps=1,
+        )
+    return visible
+
+
+def _qsa_gather_single_request_keys(
+    k_cache: torch.Tensor,
+    page_table: torch.Tensor,
+    columns: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    keys = torch.empty(
+        (columns, k_cache.shape[3]), dtype=k_cache.dtype, device=k_cache.device
+    )
+    valid = torch.empty(columns, dtype=torch.uint8, device=k_cache.device)
+    if columns:
+        _qsa_gather_single_request_keys_kernel[(columns,)](
+            k_cache,
+            page_table[0],
+            keys,
+            valid,
+            k_cache.stride(0),
+            k_cache.stride(1),
+            k_cache.stride(3),
+            page_table.stride(1),
+            keys.stride(0),
+            columns,
+            k_cache.shape[0],
+            PAGE_SIZE=k_cache.shape[1],
+            PAGE_TABLE_WIDTH=page_table.shape[1],
+            HEAD_DIM=k_cache.shape[3],
+            BLOCK_D=triton.next_power_of_2(k_cache.shape[3]),
+            num_warps=4,
+        )
+    return keys, valid
+
+
+def _qsa_mqa_cublas(
+    q: torch.Tensor,
+    keys: torch.Tensor,
+    key_valid: torch.Tensor,
+    visible: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Score one request with Volta Tensor Cores and a fused QSA epilogue."""
+
+    rows, num_heads, head_dim = q.shape
+    columns = keys.shape[0]
+    logits = torch.empty((rows, columns), dtype=torch.float32, device=q.device)
+    if not rows or not columns:
+        return logits, visible
+
+    q2 = q.reshape(rows * num_heads, head_dim)
+    bytes_per_column = max(1, q2.shape[0] * torch.float32.itemsize)
+    tile_columns = max(
+        256,
+        min(columns, _SM70_INDEXER_SCORE_TILE_BYTES // bytes_per_column),
+    )
+    tile_columns = max(256, tile_columns // 256 * 256)
+    for column_start in range(0, columns, tile_columns):
+        column_stop = min(column_start + tile_columns, columns)
+        width = column_stop - column_start
+        # FP16 inputs, FP32 accumulation/output. This still selects Volta HMMA
+        # through cuBLAS while avoiding an FP16 round trip before top-k.
+        scores = torch.mm(
+            q2,
+            keys[column_start:column_stop].t(),
+            out_dtype=torch.float32,
+        )
+        _qsa_relu_headsum_visible_kernel[(rows, triton.cdiv(width, 256))](
+            scores,
+            visible,
+            key_valid,
+            logits,
+            scores.stride(0),
+            scores.stride(1),
+            logits.stride(0),
+            width,
+            column_start,
+            math.sqrt(head_dim),
+            NUM_HEADS=num_heads,
+            BLOCK_N=256,
+            num_warps=4,
+        )
+    return logits, visible
+
+
 def expand_qsa_block_indices_cuda(
     block_indices: torch.Tensor,
     query_positions: torch.Tensor,
@@ -762,9 +1032,44 @@ def qsa_select_paged_tokens(
     if not rows:
         return out
 
-    columns = page_table.shape[1] * k_cache.shape[1]
+    capacity_columns = page_table.shape[1] * k_cache.shape[1]
+    score_columns = capacity_columns
     block_topk = token_topk // compress_ratio
-    rows_per_chunk = max(1, _LOGITS_WORKSPACE_BYTES // max(columns * 4, 1))
+    contiguous_keys: torch.Tensor | None = None
+    key_valid: torch.Tensor | None = None
+    all_visible: torch.Tensor | None = None
+    if _use_sm70_qsa_indexer_cublas(q, k_cache, page_table):
+        all_visible = _qsa_visible_blocks(
+            token_to_req,
+            query_positions,
+            sequence_lengths,
+            compress_ratio,
+        )
+        # cuBLAS has a rectangular host-side launch shape, unlike the paged
+        # Triton kernel's device-side early exit. Bound it to this chunk's live
+        # prefix so early-context prefill does not multiply the unused 140K
+        # model-capacity tail. This is one scalar sync per QSA layer.
+        score_columns = min(
+            capacity_columns,
+            max(block_topk, int(all_visible.max().item())),
+        )
+        if _qsa_indexer_cublas_work_supported(rows, score_columns):
+            logger.info_once(
+                "Using SM70 QSA indexer prefill cuBLAS path "
+                "(single-request FP16, rows=%d, score_tile_mib=%d).",
+                rows,
+                _SM70_INDEXER_SCORE_TILE_BYTES // (1024 * 1024),
+            )
+            # Gather this request's paged MQA keys once, then reuse them across
+            # every bounded logits chunk below. Generic, short-work and
+            # multi-request batches keep the paged Triton fallback.
+            contiguous_keys, key_valid = _qsa_gather_single_request_keys(
+                k_cache, page_table, score_columns
+            )
+        else:
+            score_columns = capacity_columns
+            all_visible = None
+    rows_per_chunk = max(1, _LOGITS_WORKSPACE_BYTES // max(score_columns * 4, 1))
     chunk_rows = min(rows, rows_per_chunk)
     blocks_buffer = torch.empty(
         (chunk_rows, block_topk), dtype=torch.int32, device=q.device
@@ -775,15 +1080,24 @@ def qsa_select_paged_tokens(
     for row_start in range(0, rows, rows_per_chunk):
         row_end = min(row_start + rows_per_chunk, rows)
         row_slice = slice(row_start, row_end)
-        logits, visible_blocks = qsa_mqa_paged(
-            q[row_slice],
-            k_cache,
-            page_table,
-            token_to_req[row_slice],
-            query_positions[row_slice],
-            sequence_lengths,
-            compress_ratio,
-        )
+        if contiguous_keys is not None and key_valid is not None:
+            assert all_visible is not None
+            logits, visible_blocks = _qsa_mqa_cublas(
+                q[row_slice],
+                contiguous_keys,
+                key_valid,
+                all_visible[row_slice],
+            )
+        else:
+            logits, visible_blocks = qsa_mqa_paged(
+                q[row_slice],
+                k_cache,
+                page_table,
+                token_to_req[row_slice],
+                query_positions[row_slice],
+                sequence_lengths,
+                compress_ratio,
+            )
         blocks = blocks_buffer[: row_end - row_start]
         use_cooperative_topk = (
             blocks.shape[0] <= 32
@@ -796,7 +1110,14 @@ def qsa_select_paged_tokens(
             if use_cooperative_topk
             else torch.ops._C.persistent_topk
         )
-        topk_op(logits, visible_blocks, blocks, topk_workspace, block_topk, columns)
+        topk_op(
+            logits,
+            visible_blocks,
+            blocks,
+            topk_workspace,
+            block_topk,
+            score_columns,
+        )
         expand_qsa_block_indices_cuda(
             blocks,
             query_positions[row_slice],

--- a/vllm/models/qwen4_exp/nvidia/ops/qsa.py
+++ b/vllm/models/qwen4_exp/nvidia/ops/qsa.py
@@ -966,9 +966,12 @@ def _qsa_sparse_launch_profile(
         block_n, target_splits, partial_warps = 64, 1, 2
     if is_sm70 and block_n == 64:
         # Two warps serialize the D=256 tensor-core work on V100. Four warps
-        # preserve the exact reduction order while restoring warp-level
-        # parallelism for both split and non-split prefill profiles.
+        # restore warp-level parallelism for split and non-split prefill.
         partial_warps = 4
+        if base_programs >= 512:
+            # A 32-column tile improves the exact 512-row and 8192-row Qwen4Exp
+            # prefill shapes without changing small-batch or non-SM70 routes.
+            block_n = 32
     return block_n, target_splits, partial_warps
 
 

--- a/vllm/models/qwen4_exp/nvidia/ops/qsa.py
+++ b/vllm/models/qwen4_exp/nvidia/ops/qsa.py
@@ -858,20 +858,11 @@ def qsa_sparse_paged_attention(
     group_size = q.shape[1] // k_cache.shape[2]
     block_m = triton.next_power_of_2(group_size)
     base_programs = q.shape[0] * k_cache.shape[2]
-    small_profile_limit = 8 if block_m <= 8 else 4
-
-    # Tuned on GB300 for the Qwen-Air TP1, TP2, and TP4 attention shapes.
-    # Narrow tiles favor decode; wide tiles improve throughput for prefill.
-    if base_programs <= small_profile_limit:
-        block_n, target_splits, partial_warps = 16, 64, 4
-    elif base_programs < 32:
-        block_n, target_splits, partial_warps = 16, 32, 4
-    elif base_programs <= 256:
-        block_n, target_splits, partial_warps = 64, 8, 2
-    elif base_programs <= 512:
-        block_n, target_splits, partial_warps = 64, 4, 2
-    else:
-        block_n, target_splits, partial_warps = 64, 1, 2
+    block_n, target_splits, partial_warps = _qsa_sparse_launch_profile(
+        base_programs,
+        block_m,
+        current_platform.is_device_capability(70),
+    )
 
     num_tiles = triton.cdiv(logical_indices.shape[1], block_n)
     # Avoid empty splits when the selection width is smaller than the profile.
@@ -951,6 +942,34 @@ def qsa_sparse_paged_attention(
         num_stages=1,
     )
     return out
+
+
+def _qsa_sparse_launch_profile(
+    base_programs: int,
+    block_m: int,
+    is_sm70: bool,
+) -> tuple[int, int, int]:
+    """Return BLOCK_N, target splits, and warps for sparse QSA."""
+    small_profile_limit = 8 if block_m <= 8 else 4
+
+    # Tuned on GB300 for the Qwen-Air TP1, TP2, and TP4 attention shapes.
+    # Narrow tiles favor decode; wide tiles improve throughput for prefill.
+    if base_programs <= small_profile_limit:
+        block_n, target_splits, partial_warps = 16, 64, 4
+    elif base_programs < 32:
+        block_n, target_splits, partial_warps = 16, 32, 4
+    elif base_programs <= 256:
+        block_n, target_splits, partial_warps = 64, 8, 2
+    elif base_programs <= 512:
+        block_n, target_splits, partial_warps = 64, 4, 2
+    else:
+        block_n, target_splits, partial_warps = 64, 1, 2
+    if is_sm70 and block_n == 64:
+        # Two warps serialize the D=256 tensor-core work on V100. Four warps
+        # preserve the exact reduction order while restoring warp-level
+        # parallelism for both split and non-split prefill profiles.
+        partial_warps = 4
+    return block_n, target_splits, partial_warps
 
 
 def qsa_store_cache_rows(


### PR DESCRIPTION
> Public migration note (2026-08-27): this Draft is the public continuation of private PR #23, mirrored at exact head a271361cac0b225c453800784dec728f16a8594a after public main resumed through #342. The original implementation notes and evidence are preserved below.
>
> This is stacked on the migrated Qwen3.8 Flash Next adaptation and inherits its consolidation dependency on public #338.

## Objective
Improve and validate Qwen3.8 Flash Next NVFP4 TP4 prefill performance on four V100-SXM2-32GB GPUs. Decode/MTP optimization is explicitly out of scope.

## Base
- Integration branch: `codex/v100-qwen38-flash-next-nvfp4-20260826-140311`
- BASE_SHA: `383ff458dbc8af1dda79a1a29bf700019030f054`

## Planned gates
- Exact TP4/FP16/Flash-V100 route audit
- 8K correctness, TTFT, and pure prefill baseline
- Profile-driven exact-shape microbench before source changes
- Focused CPU/GPU numerical tests
- Same-contract 8K/32K/128K trend validation

## Status
Draft campaign boundary created; no prefill source change yet.