### PR TITLE
[Bugfix][SM70] Keep bounded FP13 path enabled

### DIFF
--- a/docs/design/sm70_v100_migration_control.md
+++ b/docs/design/sm70_v100_migration_control.md
@@ -43740,14 +43740,16 @@ Interpretation:
   with 64/64 bitwise main-path results and maximum auxiliary relative L2
   `4.03e-7`. That overlap result is directional after the mainline FP8 M=1 API
   split and is not relabeled as a current-main endpoint result.
-- FP13 now defaults off because these operator and overlap screens do not
-  constitute a matched model-level dataset gate. Explicit
-  `VLLM_SM70_DSV4_FP13_GEMV=1` remains available for an isolated future A/B.
+- FP13 remains default-on under its narrow tensor/runtime contract because the
+  real-weight operator and graph screens show a bounded numerical delta and a
+  repeatable latency reduction, with no recorded task-quality regression.
+  `VLLM_SM70_DSV4_FP13_GEMV=0` is the explicit rollback. The route is not
+  reported as an endpoint gain until a matched model-level dataset A/B closes.
   Admission still checks SM70, CUDA device equality, dtype, shape, layout,
   output contract, and the actual weight bits; incompatible tensors retain
-  FP16. Packing occurs once after loading. The retained buffers would add
-  549.66 MiB without pipeline parallelism, or at most 282.34 MiB per rank for
-  the audited PP2 partition.
+  FP16. Packing occurs once after loading. The retained buffers add 549.66 MiB
+  without pipeline parallelism, or at most 282.34 MiB per rank for the audited
+  PP2 partition.
 
 ## 2026-08-26 DeepSeek V4 PP2 x TP4 100-token/s continuation
 
@@ -43760,10 +43762,12 @@ Interpretation:
   operator may default on after graph, numerical and source gates pass, with
   an explicit rollback; it is not reported as an endpoint gain until a matched
   full-model benchmark exists.
-- The current quality-safe source-`59adf8d89a` control explicitly disables all
-  FP8 QPN8 routes and packed FP13 while retaining the exact fused-WQA prescale,
-  exact MXFP4 QPN M1, static PP transfer, TP4 push all-reduce, fused Q/KV
-  normalization, direct-order MoE, and exponent fold. It scores GSM8K-64
+- The source-`59adf8d89a` measurement control explicitly disables all FP8 QPN8
+  routes and packed FP13 to isolate the remaining stack; that measurement
+  choice does not change the guarded FP13 runtime default. The control retains
+  the exact fused-WQA prescale, exact MXFP4 QPN M1, static PP transfer, TP4 push
+  all-reduce, fused Q/KV normalization, direct-order MoE, and exponent fold. It
+  scores GSM8K-64
   `64/64` with zero invalid answers, HumanEval `29/32`, and LongBench `44.740`.
   Three matched 1024+256 pure-decode runs measure `73.534`, `73.542`, and
   `73.539 token/s` (median `73.539`, `13.598 ms/token`). This is the accepted

--- a/tests/kernels/test_sm70_deepseek_v4_fp16_gemv.py
+++ b/tests/kernels/test_sm70_deepseek_v4_fp16_gemv.py
@@ -23,15 +23,15 @@ def reset_env_cache() -> Iterator[None]:
     envs.disable_envs_cache()
 
 
-def test_sm70_dsv4_fp13_gemv_is_default_off_with_opt_in(monkeypatch) -> None:
+def test_sm70_dsv4_fp13_gemv_is_default_on_with_rollback(monkeypatch) -> None:
     monkeypatch.delenv("VLLM_SM70_DSV4_FP16_GEMV", raising=False)
     monkeypatch.delenv("VLLM_SM70_DSV4_FP13_GEMV", raising=False)
     assert not envs.VLLM_SM70_DSV4_FP16_GEMV
-    assert not envs.VLLM_SM70_DSV4_FP13_GEMV
-
-    monkeypatch.setenv("VLLM_SM70_DSV4_FP13_GEMV", "1")
-    envs.disable_envs_cache()
     assert envs.VLLM_SM70_DSV4_FP13_GEMV
+
+    monkeypatch.setenv("VLLM_SM70_DSV4_FP13_GEMV", "0")
+    envs.disable_envs_cache()
+    assert not envs.VLLM_SM70_DSV4_FP13_GEMV
 
 
 def test_sm70_dsv4_fp13_enables_fp16_fallback(monkeypatch) -> None:

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -185,7 +185,7 @@ if TYPE_CHECKING:
     VLLM_SM70_MXFP4_DENSE_TUNE_MAX_M: int = 16
     VLLM_SM70_NVFP4_DENSE_TUNE_MAX_M: int = 16
     VLLM_SM70_DSV4_FP16_GEMV: bool = False
-    VLLM_SM70_DSV4_FP13_GEMV: bool = False
+    VLLM_SM70_DSV4_FP13_GEMV: bool = True
     VLLM_SM70_DSV4_MHC_FP32_STAGE: bool = True
     VLLM_SM70_DSV4_QNORM_KV_FUSED_TP4: bool = True
     VLLM_SM70_PP_STATIC_HIDDEN_TRANSFER: bool = True
@@ -1829,7 +1829,7 @@ environment_variables: dict[str, Callable[[], Any]] = {
         int(os.getenv("VLLM_SM70_DSV4_FP16_GEMV", "0"))
     ),
     "VLLM_SM70_DSV4_FP13_GEMV": lambda: bool(
-        int(os.getenv("VLLM_SM70_DSV4_FP13_GEMV", "0"))
+        int(os.getenv("VLLM_SM70_DSV4_FP13_GEMV", "1"))
     ),
     "VLLM_SM70_DSV4_MHC_FP32_STAGE": lambda: bool(
         int(os.getenv("VLLM_SM70_DSV4_MHC_FP32_STAGE", "1"))


### PR DESCRIPTION
## Purpose

Repair the policy portion of #344 before it reaches `main`. Keep the objectively quality-regressing QPN8 routes disabled and retain the MXFP4 post-load crash fix, while preserving packed FP13 as default-on under its exact tensor/runtime gate.

FP13 has a real-weight numerical bound, graph stability, and a repeatable ~0.20 ms/token operator saving with no recorded task-quality regression. The project policy does not require greedy identity and keeps evidenced speedups enabled unless an actual quality regression is demonstrated. `VLLM_SM70_DSV4_FP13_GEMV=0` remains the explicit rollback.

## Base

- Repair base / #344 head: `22a25e877fff7db150543f020a46c9f74ad634f6`

## Test result

- Changed-file pre-commit: passed (Ruff, format, typos, Markdown, mypy, SPDX, config defaults, forbidden imports and policy hooks).
- `git diff --check`: passed.
- Existing FP13 numerical and performance evidence remains unchanged; no broad E2E was repeated for this policy-only repair.
