### PR TITLE
[CI][SM70] Fix #346 benchmark regex imports

### DIFF
--- a/benchmarks/benchmark_sm70_tool_datasets.py
+++ b/benchmarks/benchmark_sm70_tool_datasets.py
@@ -14,12 +14,12 @@ import argparse
 import ast
 import hashlib
 import json
-import re
 import time
 from pathlib import Path
 from typing import Any
 
 import pandas as pd
+import regex as re
 import requests
 
 TOOLACE_MARKER = "Here is a list of functions in JSON format that you can invoke:"

--- a/benchmarks/benchmark_sm70_tool_protocol.py
+++ b/benchmarks/benchmark_sm70_tool_protocol.py
@@ -13,12 +13,12 @@ from __future__ import annotations
 import argparse
 import copy
 import json
-import re
 import time
 from pathlib import Path
 from typing import Any
 
 import jsonschema
+import regex as re
 import requests
 
 TOOLS: list[dict[str, Any]] = [


### PR DESCRIPTION
## Purpose

Repair the changed-file static gate found while auditing #346. The two new SM70 benchmark modules used the forbidden stdlib `re` import; repository policy requires `regex as re`.

## Test Plan

- Run pre-commit on both changed benchmark files.
- Re-run all changed-file pre-commit hooks on the #346 integration audit tree.
- Parse all three new benchmark CLIs with `--help`.

## Test Result

- Two-file pre-commit: passed, including ruff, mypy, SPDX, forbidden-import and configuration gates.
- Full #346 changed-file pre-commit after this patch: passed.
- `benchmark_sm70_tool_datasets.py --help`: passed.
- `benchmark_sm70_tool_protocol.py --help`: passed.
- `compare_sm70_dflash2_quality_matrix.py --help`: passed.

Base head audited: `f5a93e2de2f1940de0e498afb01db85b77982948`.
Repair head: `be44103c65928d574701fdee452ed9fac084e07c`.