### PR TITLE
[Bugfix][SM70] Repair #345 Qwen4Exp integration gates

### DIFF
--- a/tests/models/qwen4_exp/test_ple.py
+++ b/tests/models/qwen4_exp/test_ple.py
@@ -101,7 +101,7 @@ def test_pinned_host_ple_fp8_rows_are_gatherable_on_sm70(
     layer.prepare_accelerator_weight()
 
     output = layer(torch.tensor([0, 7], dtype=torch.int64, device="cuda"))
-    torch.cuda.synchronize()
+    torch.accelerator.synchronize()
 
     assert output.dtype == torch.float16
     expected = raw.view(torch.float8_e4m3fn).float() * 0.25

--- a/tests/models/qwen4_exp/test_qsa_cache.py
+++ b/tests/models/qwen4_exp/test_qsa_cache.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 from types import SimpleNamespace
+from typing import Any
 
 import torch
 
@@ -12,7 +13,7 @@ from vllm.v1.worker.utils import bind_kv_cache
 
 def test_bind_qsa_key_cache_builds_key_and_mrope_views() -> None:
     prefix = "model.layers.0.self_attn.raw_key_cache"
-    static_forward_context = {}
+    static_forward_context: dict[str, Any] = {}
     layer = QSAKeyStateCache(
         head_size=128,
         dtype=torch.float16,
@@ -27,7 +28,7 @@ def test_bind_qsa_key_cache_builds_key_and_mrope_views() -> None:
         ),
     )
     cache = torch.empty(2, 8, 1, layer.head_size, dtype=torch.float16)
-    runner_kv_caches = []
+    runner_kv_caches: list[torch.Tensor] = []
 
     bind_kv_cache({prefix: cache}, static_forward_context, runner_kv_caches)
 

--- a/tests/quantization/test_sm70_modelopt_mixed_nvfp4.py
+++ b/tests/quantization/test_sm70_modelopt_mixed_nvfp4.py
@@ -222,7 +222,7 @@ def test_nvfp4_single_token_direct_routing_is_exact_and_graph_dynamic():
     torch.ops._moe_C.moe_unpermute(
         expert_output, weights, identity, None, top_k, reference
     )
-    torch.cuda.synchronize()
+    torch.accelerator.synchronize()
     assert torch.equal(expanded, x.expand(top_k, -1))
     assert torch.equal(active_ids, topk_ids[0].int())
     assert torch.equal(output, reference)
@@ -240,7 +240,7 @@ def test_nvfp4_single_token_direct_routing_is_exact_and_graph_dynamic():
     torch.ops._moe_C.moe_unpermute(
         expert_output, weights, identity, None, top_k, reference
     )
-    torch.cuda.synchronize()
+    torch.accelerator.synchronize()
     assert torch.equal(expanded, x.expand(top_k, -1))
     assert torch.equal(active_ids, topk_ids[0].int())
     assert torch.equal(output, reference)

--- a/tests/v1/worker/test_model_state_init.py
+++ b/tests/v1/worker/test_model_state_init.py
@@ -10,7 +10,7 @@ from vllm.v1.worker.gpu.model_states import init_model_state
 
 
 def test_model_can_select_custom_model_state() -> None:
-    captured = {}
+    captured: dict[str, object] = {}
 
     class CustomModelState:
         def __init__(self, vllm_config, model, encoder_cache, device) -> None:

--- a/tests/v1/worker/test_qwen4_exp_ngram.py
+++ b/tests/v1/worker/test_qwen4_exp_ngram.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 from types import SimpleNamespace
+from typing import Any
 
 import numpy as np
 import torch
@@ -58,7 +59,7 @@ def test_v1_runner_prepares_committed_ngram_context() -> None:
 
 def test_v1_runner_uses_stable_dummy_ngram_buffers() -> None:
     runner = _runner()
-    model_kwargs = {}
+    model_kwargs: dict[str, Any] = {}
 
     runner._maybe_add_ngram_kwargs(
         model_kwargs,

--- a/tests/v1/worker/test_qwen4_exp_v2.py
+++ b/tests/v1/worker/test_qwen4_exp_v2.py
@@ -219,7 +219,7 @@ def test_qsa_circular_group_emits_no_generic_slots_on_sm70() -> None:
         positions=torch.tensor([153797, 165757], dtype=torch.int64, device=device),
         num_tokens_padded=2,
     )
-    torch.cuda.synchronize()
+    torch.accelerator.synchronize()
 
     assert slot_mappings[0].tolist() == [-1, -1]
     assert slot_mappings[1].tolist() == [

--- a/vllm/model_executor/layers/linear.py
+++ b/vllm/model_executor/layers/linear.py
@@ -1224,11 +1224,13 @@ class MergedColumnParallelLinear(ColumnParallelLinear):
             self.validate_shard_id(shard_id)
             if "." in name:
                 submodule, _, attr = name.rpartition(".")
-                param = getattr(self.get_submodule(submodule), attr, self)
+                param = getattr(self.get_submodule(submodule), attr, None)
             else:
-                param = getattr(self, name, self)
+                param = getattr(self, name, None)
             if param is None and name == "bias":
                 continue
+            if param is None:
+                raise ValueError(f"Unknown parameter {name!r} for {self.prefix}")
             param.weight_loader(param, loaded_weight, shard_id)
             logger.debug(
                 "Loaded shard %s with shape %s into %s.%s",
@@ -1346,11 +1348,13 @@ class QKVParallelLinear(ColumnParallelLinear):
             self.validate_shard_id(shard_id)
             if "." in name:
                 submodule, _, attr = name.rpartition(".")
-                param = getattr(self.get_submodule(submodule), attr, self)
+                param = getattr(self.get_submodule(submodule), attr, None)
             else:
-                param = getattr(self, name, self)
+                param = getattr(self, name, None)
             if param is None and name == "bias":
                 continue
+            if param is None:
+                raise ValueError(f"Unknown parameter {name!r} for {self.prefix}")
             param.weight_loader(param, loaded_weight, shard_id)
             logger.debug(
                 "Loaded shard %s with shape %s into %s.%s",

--- a/vllm/models/qwen4_exp/nvidia/model.py
+++ b/vllm/models/qwen4_exp/nvidia/model.py
@@ -375,6 +375,7 @@ class Qwen4ExpDecoderLayer(nn.Module):
             attn_out = self.self_attn(
                 hidden_states=block_input,
                 positions=positions,
+                output=None,
             )
         else:
             raise ValueError("Invalid layer_type")
@@ -691,7 +692,7 @@ class Qwen4ExpForCausalLM(
             prefix=maybe_prefix(prefix, "lm_head"),
         )
         self.logits_processor = LogitsProcessor(config.vocab_size)
-        self.make_empty_intermediate_tensors = (
+        self.make_empty_intermediate_tensors = (  # type: ignore[method-assign]
             self.model.make_empty_intermediate_tensors
         )
         self.set_moe_parameters(self.model.layers)
@@ -769,7 +770,7 @@ class Qwen4ExpForCausalLM(
     @classmethod
     def get_gdn_mamba_state_shape_from_config(
         cls, vllm_config: VllmConfig
-    ) -> tuple[tuple[int, int], tuple[int, int]]:
+    ) -> tuple[tuple[int, int], tuple[int, int, int]]:
         parallel_config = vllm_config.parallel_config
         hf_config = vllm_config.model_config.hf_text_config
         tp_size = parallel_config.tensor_parallel_size
@@ -798,7 +799,7 @@ class Qwen4ExpForCausalLM(
     @classmethod
     def get_mamba_state_shape_from_config(
         cls, vllm_config: VllmConfig
-    ) -> tuple[tuple[int, int], tuple[int, int]]:
+    ) -> tuple[tuple[int, int], tuple[int, int, int]]:
         return cls.get_gdn_mamba_state_shape_from_config(vllm_config)
 
     @classmethod
@@ -967,7 +968,7 @@ class Qwen4ExpForConditionalGeneration(
                 prefix=maybe_prefix(prefix, "language_model"),
             )
 
-        self.make_empty_intermediate_tensors = (
+        self.make_empty_intermediate_tensors = (  # type: ignore[method-assign]
             self.language_model.make_empty_intermediate_tensors
         )
         if not get_pp_group().is_first_rank and self.use_deepstack:
@@ -1069,10 +1070,10 @@ class Qwen4ExpForConditionalGeneration(
         return Qwen4ExpForCausalLM.get_mamba_state_dtype_from_config(vllm_config)
 
     @classmethod
-    def get_mamba_state_shape_from_config(
+    def get_mamba_state_shape_from_config(  # type: ignore[override]
         cls,
         vllm_config: VllmConfig,
-    ) -> tuple[tuple[int, int], tuple[int, int]]:
+    ) -> tuple[tuple[int, int], tuple[int, int, int]]:
         return Qwen4ExpForCausalLM.get_mamba_state_shape_from_config(vllm_config)
 
     @classmethod

--- a/vllm/models/qwen4_exp/nvidia/mtp.py
+++ b/vllm/models/qwen4_exp/nvidia/mtp.py
@@ -432,7 +432,7 @@ class Qwen4ExpMTP(nn.Module, SupportsPP, Qwen4ExpMixtureOfExperts):
             self.lm_head = PPMissingLayer()
 
         self.logits_processor = LogitsProcessor(config.vocab_size)
-        self.make_empty_intermediate_tensors = (
+        self.make_empty_intermediate_tensors = (  # type: ignore[method-assign]
             self.model.make_empty_intermediate_tensors
         )
         self.set_moe_parameters(self.model.layers)
@@ -441,7 +441,7 @@ class Qwen4ExpMTP(nn.Module, SupportsPP, Qwen4ExpMixtureOfExperts):
     def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
         return self.model.embed_input_ids(input_ids)
 
-    def forward(
+    def forward(  # type: ignore[override]
         self,
         input_ids: torch.Tensor | None,
         positions: torch.Tensor,

--- a/vllm/models/qwen4_exp/nvidia/ple_layer.py
+++ b/vllm/models/qwen4_exp/nvidia/ple_layer.py
@@ -334,10 +334,13 @@ class Qwen4ExpPinnedHostEmbedding(VocabParallelEmbedding):
                 quant_method=quant_method,
             )
 
+        meta_weight = self._parameters.get("weight")
+        if not isinstance(meta_weight, torch.Tensor):
+            raise RuntimeError("Qwen4Exp PLE meta weight was not initialized")
         host_weight = ModelWeightParameter(
             data=torch.empty(
-                tuple(self.weight.shape),
-                dtype=self.weight.dtype,
+                tuple(meta_weight.shape),
+                dtype=meta_weight.dtype,
                 device="cpu",
                 pin_memory=True,
             ),
@@ -369,7 +372,9 @@ class Qwen4ExpPinnedHostEmbedding(VocabParallelEmbedding):
                 f"Qwen4Exp pinned-host PLE requires a CUDA input, got {device}"
             )
         device_index = (
-            torch.cuda.current_device() if device.index is None else device.index
+            torch.accelerator.current_device_index()
+            if device.index is None
+            else device.index
         )
         view = self._accelerator_weight_views.get(device_index)
         if view is None:
@@ -377,20 +382,22 @@ class Qwen4ExpPinnedHostEmbedding(VocabParallelEmbedding):
                 raise RuntimeError(
                     "Qwen4Exp PLE UVA view must be prepared before CUDA graph capture"
                 )
-            with torch.cuda.device(device_index):
+            with torch.accelerator.device_index(device_index):
                 view = get_accelerator_view_from_cpu_tensor(self.weight)
             self._accelerator_weight_views[device_index] = view
             self._accelerator_weight_ptrs[device_index] = view.data_ptr()
         return view
 
     def prepare_accelerator_weight(self) -> None:
-        self.get_accelerator_weight(torch.device("cuda", torch.cuda.current_device()))
+        self.get_accelerator_weight(
+            torch.device("cuda", torch.accelerator.current_device_index())
+        )
 
     def embedding_lookup(self, input_: torch.Tensor) -> torch.Tensor:
         """Gather FP8 UVA rows and emit scaled model-dtype values."""
 
         device_index = (
-            torch.cuda.current_device()
+            torch.accelerator.current_device_index()
             if input_.device.index is None
             else input_.device.index
         )

--- a/vllm/models/qwen4_exp/nvidia/qsa.py
+++ b/vllm/models/qwen4_exp/nvidia/qsa.py
@@ -429,6 +429,7 @@ class Qwen4ExpQSAAttention(Qwen3NextAttention, AttentionLayerBase):
     def forward(
         self,
         positions: torch.Tensor,
+        output: torch.Tensor | None,
         hidden_states: torch.Tensor,
     ) -> torch.Tensor:
         qkv, _ = self.qkv_proj(hidden_states)
@@ -462,8 +463,10 @@ class Qwen4ExpQSAAttention(Qwen3NextAttention, AttentionLayerBase):
         flat_output = attn_output.view(num_tokens, -1)
         if gate is not None:
             flat_output = flat_output * torch.sigmoid(gate)
-        output, _ = self.o_proj(flat_output)
-        return output
+        projected_output, _ = self.o_proj(flat_output)
+        if output is not None:
+            output.copy_(projected_output)
+        return projected_output
 
 
 def qwen4_exp_qsa_with_output(

--- a/vllm/v1/kv_cache_interface.py
+++ b/vllm/v1/kv_cache_interface.py
@@ -634,7 +634,7 @@ class SlidingWindowMLASpec(SlidingWindowSpec):
 @dataclass(frozen=True)
 class MambaSpec(KVCacheSpec):
     shapes: tuple[tuple[int, ...], ...]
-    dtypes: tuple[torch.dtype]
+    dtypes: tuple[torch.dtype, ...]
     page_size_padded: int | None = None
     mamba_type: MambaAttentionBackendEnum = MambaAttentionBackendEnum.MAMBA2
     mamba_cache_mode: str = "none"

--- a/vllm/v1/worker/gpu/spec_decode/eagle/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/eagle/speculator.py
@@ -6,7 +6,7 @@ import numpy as np
 import torch
 import torch.nn as nn
 
-from vllm.config import VllmConfig, get_layers_from_vllm_config
+from vllm.config import SpeculativeConfig, VllmConfig, get_layers_from_vllm_config
 from vllm.config.compilation import CUDAGraphMode
 from vllm.forward_context import BatchDescriptor, set_forward_context
 from vllm.logger import init_logger
@@ -43,8 +43,9 @@ class EagleSpeculator:
         self.vllm_config = vllm_config
         self.device = device
 
-        self.speculative_config = vllm_config.speculative_config
-        assert self.speculative_config is not None
+        speculative_config = vllm_config.speculative_config
+        assert speculative_config is not None
+        self.speculative_config: SpeculativeConfig = speculative_config
         self.method = self.speculative_config.method
         self.num_speculative_steps = self.speculative_config.num_speculative_tokens
         self.draft_model_config = self.speculative_config.draft_model_config

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -1557,9 +1557,7 @@ class GPUModelRunner(
             elif self.speculative_config.use_step3p5_mtp():
                 self.drafter = Step3p5MTPProposer(self.vllm_config, self.device, self)
             elif self.speculative_config.use_qwen4_exp_mtp():
-                self.drafter = Qwen4ExpMTPProposer(
-                    self.vllm_config, self.device, self
-                )
+                self.drafter = Qwen4ExpMTPProposer(self.vllm_config, self.device, self)
             elif self.speculative_config.use_dspark():
                 self.drafter = DSparkProposer(self.vllm_config, self.device, self)
                 self.use_aux_hidden_state_outputs = True


### PR DESCRIPTION
## Purpose

Repair the latest-main source and static-gate issues found while auditing #345 without changing its model policy or performance defaults.

- Preserve stacked QKV/merged-column loader metadata while failing clearly on unknown parameters.
- Restore the inherited Qwen attention `output` contract so both QSA and ordinary full-attention paths are callable.
- Correct heterogeneous Mamba state shape/dtype annotations.
- Narrow the speculative config type and align Qwen4Exp PLE device management with `torch.accelerator`.
- Fix changed-test type annotations and forbidden `torch.cuda` synchronization calls.

## Test Plan

- Run every changed-file pre-commit hook.
- Compile all #345 Python files.
- Run the focused Qwen4Exp config/model/PLE/QSA/weight-loading, stacked-loader, custom-AR, KV-cache, spec-decode, and V2 worker CPU contracts.

## Test Result

- All changed-file pre-commit hooks passed, including ruff, mypy, forbidden-import and accelerator API gates.
- Python compile passed for all #345 Python files.
- Focused source/CPU contracts: 74 passed, 3 CUDA-only skipped.
- The two locally attempted CUDA-only cases were not used as acceptance evidence: all eight V100s are occupied by an unrelated PP2/TP4 service and this audit worktree has no matching `_C` binary. No process was stopped or preempted.
- Existing #345 recorded V100/model evidence remains unchanged.

Audited #345 head: `ceb543c05573c9bcbf1cc9563bab0c2e8c746ae3`.
Repair head: `95fdf660b325ef1627a01b414518d1c45f7e67d0`.