### PR TITLE
[Bugfix][SM70] Harden #361 default fast paths

### DIFF
--- a/tests/quantization/test_sm70_online_qpn8.py
+++ b/tests/quantization/test_sm70_online_qpn8.py
@@ -10,16 +10,42 @@ import vllm.envs as envs
 from vllm.model_executor.layers.quantization import sm70_online_qpn8 as online_qpn8
 
 
-def test_qwen4_exp_online_qpn8_is_opt_in(monkeypatch):
+def test_qwen4_exp_online_qpn8_defaults_on_and_can_be_disabled(monkeypatch):
     monkeypatch.delenv("VLLM_SM70_QWEN4_EXP_ONLINE_QPN8", raising=False)
     envs.disable_envs_cache()
     try:
-        assert not envs.VLLM_SM70_QWEN4_EXP_ONLINE_QPN8
-        monkeypatch.setenv("VLLM_SM70_QWEN4_EXP_ONLINE_QPN8", "1")
-        envs.disable_envs_cache()
         assert envs.VLLM_SM70_QWEN4_EXP_ONLINE_QPN8
+        monkeypatch.setenv("VLLM_SM70_QWEN4_EXP_ONLINE_QPN8", "0")
+        envs.disable_envs_cache()
+        assert not envs.VLLM_SM70_QWEN4_EXP_ONLINE_QPN8
     finally:
         envs.disable_envs_cache()
+
+
+def test_qwen3next_shared_gate_fusion_defaults_on_and_can_be_disabled(monkeypatch):
+    monkeypatch.delenv("VLLM_SM70_QWEN3NEXT_SHARED_GATE_FUSION", raising=False)
+    envs.disable_envs_cache()
+    try:
+        assert envs.VLLM_SM70_QWEN3NEXT_SHARED_GATE_FUSION
+        monkeypatch.setenv("VLLM_SM70_QWEN3NEXT_SHARED_GATE_FUSION", "0")
+        envs.disable_envs_cache()
+        assert not envs.VLLM_SM70_QWEN3NEXT_SHARED_GATE_FUSION
+    finally:
+        envs.disable_envs_cache()
+
+
+def test_default_on_qpn_sidecars_load_without_enable_overrides(monkeypatch):
+    calls: list[str] = []
+    monkeypatch.setenv("VLLM_SM70_FP8_QPN8_LIBRARY", "/tmp/qpn8.so")
+    monkeypatch.setenv("VLLM_SM70_NVFP4_QPN_M1_LIBRARY", "/tmp/qpn-m1.so")
+    monkeypatch.delenv("VLLM_SM70_QWEN4_EXP_ONLINE_QPN8", raising=False)
+    monkeypatch.delenv("VLLM_SM70_NVFP4_QWEN38_MOE_QPN_M1_DECODE", raising=False)
+    monkeypatch.setattr(torch.ops, "load_library", calls.append)
+
+    online_qpn8.sm70_ops._maybe_load_fp8_qpn8_library()
+    online_qpn8.sm70_ops._maybe_load_nvfp4_qpn_m1_library()
+
+    assert calls == ["/tmp/qpn8.so", "/tmp/qpn-m1.so"]
 
 
 @pytest.mark.parametrize(
@@ -50,10 +76,19 @@ def test_online_qpn8_shape_gate(prefix, k, n, expected):
 
 def test_online_qpn8_runtime_contract_is_tp4_no_mtp(monkeypatch):
     text_config = SimpleNamespace(
-        model_type="qwen4_exp_text",
+        model_type="generic_hybrid_moe",
         hidden_size=2560,
         num_hidden_layers=48,
         num_experts=512,
+        num_experts_per_tok=10,
+        moe_intermediate_size=640,
+        hc_count=4,
+        hc_lowrank=320,
+        num_attention_heads=24,
+        num_key_value_heads=2,
+        indexer_head_dim=128,
+        indexer_budget=2048,
+        indexer_compress_ratio=4,
     )
     config = SimpleNamespace(
         model_config=SimpleNamespace(hf_text_config=text_config),
@@ -67,6 +102,9 @@ def test_online_qpn8_runtime_contract_is_tp4_no_mtp(monkeypatch):
     assert not online_qpn8._exact_runtime_contract()
     config.speculative_config = None
     monkeypatch.setattr(online_qpn8, "get_tensor_model_parallel_world_size", lambda: 2)
+    assert not online_qpn8._exact_runtime_contract()
+    monkeypatch.setattr(online_qpn8, "get_tensor_model_parallel_world_size", lambda: 4)
+    text_config.hc_count = 2
     assert not online_qpn8._exact_runtime_contract()
 
 

--- a/tests/v1/worker/test_gpu_model_runner_v2_greedy.py
+++ b/tests/v1/worker/test_gpu_model_runner_v2_greedy.py
@@ -54,6 +54,7 @@ def test_sm70_v2_decode_uses_model_top_tokens(
 
     runner = object.__new__(GPUModelRunner)
     runner.model = Model()
+    runner.lora_config = None
     runner.sampler = SimpleNamespace(
         can_use_sm70_greedy_token_fastpath=lambda _input_batch: True
     )
@@ -90,6 +91,10 @@ def test_sm70_v2_decode_uses_model_top_tokens(
     assert output.sampled_token_ids.tolist() == [[42]]
     assert num_sampled.tolist() == [1]
     assert num_rejected.tolist() == [0]
+
+    runner.lora_config = object()
+    with pytest.raises(AssertionError, match="full logits must not run"):
+        GPUModelRunner.sample(runner, torch.zeros(1, 4), input_batch, None)
 
 
 @pytest.mark.parametrize(

--- a/vllm/_sm70_ops.py
+++ b/vllm/_sm70_ops.py
@@ -24,9 +24,11 @@ def _maybe_load_fp8_qpn8_library() -> None:
         return
     generic_override = os.getenv("VLLM_SM70_FP8_QPN8")
     specific_override = os.getenv("VLLM_SM70_FP8_QPN8_PP2_TP4")
+    online_override = os.getenv("VLLM_SM70_QWEN4_EXP_ONLINE_QPN8")
     generic_enabled = generic_override == "1"
     specific_enabled = generic_override != "0" and specific_override == "1"
-    if generic_enabled or specific_enabled:
+    online_enabled = online_override != "0"
+    if generic_enabled or specific_enabled or online_enabled:
         torch.ops.load_library(library_path)
 
 
@@ -36,7 +38,7 @@ _maybe_load_fp8_qpn8_library()
 def _maybe_load_nvfp4_qpn_m1_library() -> None:
     """Load the narrow Qwen3.8 NVFP4 experiment in spawned TP workers."""
     library_path = os.getenv("VLLM_SM70_NVFP4_QPN_M1_LIBRARY")
-    route_enabled = os.getenv("VLLM_SM70_NVFP4_QWEN38_MOE_QPN_M1_DECODE") == "1"
+    route_enabled = os.getenv("VLLM_SM70_NVFP4_QWEN38_MOE_QPN_M1_DECODE", "1") != "0"
     if library_path is not None and route_enabled:
         torch.ops.load_library(library_path)
 

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -165,8 +165,8 @@ if TYPE_CHECKING:
     VLLM_SM70_FP8_PRESERVE_DEFAULT_SPLITS_ONLY: bool = False
     VLLM_SM70_FP8_PREFILL_EXACT_DENSE: bool = True
     VLLM_SM70_FP8_QPN8: bool = False
-    VLLM_SM70_QWEN4_EXP_ONLINE_QPN8: bool = False
-    VLLM_SM70_QWEN3NEXT_SHARED_GATE_FUSION: bool = False
+    VLLM_SM70_QWEN4_EXP_ONLINE_QPN8: bool = True
+    VLLM_SM70_QWEN3NEXT_SHARED_GATE_FUSION: bool = True
     VLLM_SM70_FP8_QPN8_PP2_TP4: bool = False
     VLLM_SM70_FP8_QPN8_PP2_TP4_SHARED_GATE: bool = False
     VLLM_SM70_FP8_QPN8_LIBRARY: str | None = None
@@ -1703,13 +1703,13 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # the compressed-tensors scheme. Explicit 0 disables both routes.
     "VLLM_SM70_FP8_QPN8": lambda: bool(int(os.getenv("VLLM_SM70_FP8_QPN8", "0"))),
     "VLLM_SM70_QWEN4_EXP_ONLINE_QPN8": lambda: bool(
-        int(os.getenv("VLLM_SM70_QWEN4_EXP_ONLINE_QPN8", "0"))
+        int(os.getenv("VLLM_SM70_QWEN4_EXP_ONLINE_QPN8", "1"))
     ),
     # Exact M=1 Qwen3Next/Qwen4Exp shared-expert output gate. This replaces
     # the scalar GEMV, sigmoid, and output multiply with one SM70 kernel while
     # retaining the checkpoint's FP16 accumulation and output rounding.
     "VLLM_SM70_QWEN3NEXT_SHARED_GATE_FUSION": lambda: bool(
-        int(os.getenv("VLLM_SM70_QWEN3NEXT_SHARED_GATE_FUSION", "0"))
+        int(os.getenv("VLLM_SM70_QWEN3NEXT_SHARED_GATE_FUSION", "1"))
     ),
     # Experimental QPN8 route for the serialized PP2 x TP4 contract. It is
     # default-off after matched model-level quality regressions. An explicit

--- a/vllm/model_executor/layers/quantization/sm70_online_qpn8.py
+++ b/vllm/model_executor/layers/quantization/sm70_online_qpn8.py
@@ -70,10 +70,18 @@ def _exact_runtime_contract() -> bool:
     return bool(
         tp_size == 4
         and config.speculative_config is None
-        and getattr(text_config, "model_type", None) == "qwen4_exp_text"
         and int(getattr(text_config, "hidden_size", 0)) == 2560
         and int(getattr(text_config, "num_hidden_layers", 0)) == 48
         and int(getattr(text_config, "num_experts", 0)) == 512
+        and int(getattr(text_config, "num_experts_per_tok", 0)) == 10
+        and int(getattr(text_config, "moe_intermediate_size", 0)) == 640
+        and int(getattr(text_config, "hc_count", 0)) == 4
+        and int(getattr(text_config, "hc_lowrank", 0)) == 320
+        and int(getattr(text_config, "num_attention_heads", 0)) == 24
+        and int(getattr(text_config, "num_key_value_heads", 0)) == 2
+        and int(getattr(text_config, "indexer_head_dim", 0)) == 128
+        and int(getattr(text_config, "indexer_budget", 0)) == 2048
+        and int(getattr(text_config, "indexer_compress_ratio", 0)) == 4
     )
 
 

--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -1054,6 +1054,7 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             and grammar_output is None
             and self.device.type == "cuda"
             and current_platform.is_device_capability(70)
+            and getattr(self, "lora_config", None) is None
             and hasattr(self.model, "get_top_tokens")
             and self.sampler is not None
             and self.sampler.can_use_sm70_greedy_token_fastpath(input_batch)


### PR DESCRIPTION
## Purpose

Audit and repair #361 before it reaches `main`.

## Planned fixes

- Make the measured exact-shape online QPN8/shared-gate gains default-on with explicit rollback.
- Replace the QPN8 model identity check with exact structural capability gates.
- Keep V2 TP-local greedy sampling off when LoRA is configured.
- Align optional sidecar loading with default-on route semantics.

## Test plan

Run the complete changed-file pre-commit set and focused policy/contract tests, then revalidate the final tree after #341 updates `main`.