### PR TITLE
[CI][SM70] Repair adaptive DFlash2 gates

### DIFF
--- a/benchmarks/kernels/benchmark_dflash2_lookup.py
+++ b/benchmarks/kernels/benchmark_dflash2_lookup.py
@@ -15,7 +15,7 @@ from vllm.v1.worker.gpu.spec_decode.dflash2.lookup import fuse_draft, suffix_loo
 def _time_ms(fn: Callable[[], None], repeats: int, warmup: int) -> float:
     for _ in range(warmup):
         fn()
-    torch.cuda.synchronize()
+    torch.accelerator.synchronize()
     start = torch.cuda.Event(enable_timing=True)
     end = torch.cuda.Event(enable_timing=True)
     start.record()
@@ -114,7 +114,7 @@ def _benchmark_case(
         for _ in range(3):
             lookup_and_fuse()
     torch.cuda.current_stream().wait_stream(capture_stream)
-    torch.cuda.synchronize()
+    torch.accelerator.synchronize()
     with torch.cuda.graph(graph):
         lookup_and_fuse()
     graph_ms = _time_ms(graph.replay, repeats, warmup)

--- a/vllm/v1/worker/gpu/cudagraph_utils.py
+++ b/vllm/v1/worker/gpu/cudagraph_utils.py
@@ -150,7 +150,7 @@ class CudaGraphManager:
         assert self.compilation_config is not None
         self.cudagraph_mode = cudagraph_mode
         self.decode_query_len = decode_query_len
-        self.decode_query_lens = (decode_query_len,)
+        self.decode_query_lens: tuple[int, ...] = (decode_query_len,)
         speculative_config = vllm_config.speculative_config
         if speculative_config is not None and uses_adaptive_dflash_lookup(
             speculative_config

--- a/vllm/v1/worker/gpu/spec_decode/dflash2/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/dflash2/speculator.py
@@ -402,7 +402,11 @@ class DFlash2Speculator(DFlashSpeculator):
             speculative_config is not None
             and getattr(speculative_config, "ngram_assist", False)
         )
-        if ngram_assist and self.draft_block == self.num_speculative_steps:
+        if (
+            speculative_config is not None
+            and ngram_assist
+            and self.draft_block == self.num_speculative_steps
+        ):
             min_ngram = speculative_config.prompt_lookup_min
             max_ngram = speculative_config.prompt_lookup_max
             assert min_ngram is not None and max_ngram is not None


### PR DESCRIPTION
## Purpose

Repair the static gates found while auditing #366 without changing the adaptive lookup algorithm or its performance defaults.

- Keep CUDA graph decode widths typed as a variable-length tuple.
- Prove the speculative configuration is present before reading lookup bounds.
- Use the portable accelerator synchronization API in the CUDA-only benchmark.

## Test Plan

- Run focused lookup/ngram, config, CUDA graph, GDN warmup, parser, and grouped-verifier tests.
- Run a V100 lookup CUDA-graph microbenchmark.
- Run changed-file and remote pre-commit gates.

## Test Result

- Changed-file pre-commit: passed (Ruff, Mypy, config validation, CUDA API gate).
- DFlash2 lookup/ngram: 33 passed.
- Config/CUDA graph/GDN focused cases: 9 passed.
- Qwen3 tool-call burst parsing: 3 passed.
- New grouped verifier 1728/3456 page cases: 4 passed on V100.
- V100 lookup/fuse graph benchmark: passed at 1K, 32K, and 128K context.
- Full extension build was attempted but the local CUDA 12.0 toolchain failed in pre-existing cumem_allocator.cpp and activation_kernels.cu; neither file is changed by #366. The affected Triton/LABD paths were executed with a compatible same-repository SM70 extension artifact.
- Remote full pre-commit: passed.